### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/compiler/rustc_data_structures/src/functor.rs
+++ b/compiler/rustc_data_structures/src/functor.rs
@@ -34,38 +34,43 @@ impl<T> IdFunctor for Vec<T> {
     type Inner = T;
 
     #[inline]
-    fn try_map_id<F, E>(mut self, mut f: F) -> Result<Self, E>
+    fn try_map_id<F, E>(self, mut f: F) -> Result<Self, E>
     where
         F: FnMut(Self::Inner) -> Result<Self::Inner, E>,
     {
-        // FIXME: We don't really care about panics here and leak
-        // far more than we should, but that should be fine for now.
-        let len = self.len();
-        unsafe {
-            self.set_len(0);
-            let start = self.as_mut_ptr();
-            for i in 0..len {
-                let p = start.add(i);
-                match f(p.read()) {
-                    Ok(val) => p.write(val),
-                    Err(err) => {
-                        // drop all other elements in self
-                        // (current element was "moved" into the call to f)
-                        for j in (0..i).chain(i + 1..len) {
-                            start.add(j).drop_in_place();
-                        }
+        struct HoleVec<T> {
+            vec: Vec<mem::ManuallyDrop<T>>,
+            hole: Option<usize>,
+        }
 
-                        // returning will drop self, releasing the allocation
-                        // (len is 0 so elements will not be re-dropped)
-                        return Err(err);
+        impl<T> Drop for HoleVec<T> {
+            fn drop(&mut self) {
+                unsafe {
+                    for (index, slot) in self.vec.iter_mut().enumerate() {
+                        if self.hole != Some(index) {
+                            mem::ManuallyDrop::drop(slot);
+                        }
                     }
                 }
             }
-            // Even if we encountered an error, set the len back
-            // so we don't leak memory.
-            self.set_len(len);
         }
-        Ok(self)
+
+        unsafe {
+            let (ptr, length, capacity) = self.into_raw_parts();
+            let vec = Vec::from_raw_parts(ptr.cast(), length, capacity);
+            let mut hole_vec = HoleVec { vec, hole: None };
+
+            for (index, slot) in hole_vec.vec.iter_mut().enumerate() {
+                hole_vec.hole = Some(index);
+                let original = mem::ManuallyDrop::take(slot);
+                let mapped = f(original)?;
+                *slot = mem::ManuallyDrop::new(mapped);
+                hole_vec.hole = None;
+            }
+
+            mem::forget(hole_vec);
+            Ok(Vec::from_raw_parts(ptr, length, capacity))
+        }
     }
 }
 

--- a/compiler/rustc_data_structures/src/lib.rs
+++ b/compiler/rustc_data_structures/src/lib.rs
@@ -23,6 +23,7 @@
 #![feature(once_cell)]
 #![feature(test)]
 #![feature(thread_id_value)]
+#![feature(vec_into_raw_parts)]
 #![allow(rustc::default_hash_types)]
 #![deny(unaligned_references)]
 

--- a/compiler/rustc_mir_transform/src/check_packed_ref.rs
+++ b/compiler/rustc_mir_transform/src/check_packed_ref.rs
@@ -105,6 +105,11 @@ impl<'tcx> Visitor<'tcx> for PackedRefChecker<'_, 'tcx> {
                                     a misaligned reference is undefined behavior (even if that \
                                     reference is never dereferenced)",
                                 )
+                                .help(
+                                    "copy the field contents to a local variable, or replace the \
+                                    reference with a raw pointer and use `read_unaligned`/`write_unaligned` \
+                                    (loads and stores via `*p` must be properly aligned even when using raw pointers)"
+                                )
                                 .emit()
                         },
                     );

--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -327,6 +327,19 @@ impl Options {
             return Err(0);
         }
 
+        let color = config::parse_color(matches);
+        let config::JsonConfig { json_rendered, json_unused_externs, .. } =
+            config::parse_json(matches);
+        let error_format = config::parse_error_format(matches, color, json_rendered);
+
+        let codegen_options = CodegenOptions::build(matches, error_format);
+        let debugging_opts = DebuggingOptions::build(matches, error_format);
+
+        let diag = new_handler(error_format, None, &debugging_opts);
+
+        // check for deprecated options
+        check_deprecated_options(matches, &diag);
+
         if matches.opt_strs("passes") == ["list"] {
             println!("Available passes for running rustdoc:");
             for pass in passes::PASSES {
@@ -358,19 +371,6 @@ impl Options {
 
             return Err(0);
         }
-
-        let color = config::parse_color(matches);
-        let config::JsonConfig { json_rendered, json_unused_externs, .. } =
-            config::parse_json(matches);
-        let error_format = config::parse_error_format(matches, color, json_rendered);
-
-        let codegen_options = CodegenOptions::build(matches, error_format);
-        let debugging_opts = DebuggingOptions::build(matches, error_format);
-
-        let diag = new_handler(error_format, None, &debugging_opts);
-
-        // check for deprecated options
-        check_deprecated_options(matches, &diag);
 
         let mut emit = Vec::new();
         for list in matches.opt_strs("emit") {

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -976,6 +976,7 @@ fn item_typedef(
     // associated items from the aliased type (see discussion in #32077), but
     // we need #14072 to make sense of the generics.
     render_assoc_items(w, cx, it, def_id, AssocItemRender::All);
+    document_type_layout(w, cx, def_id);
 }
 
 fn item_union(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, s: &clean::Union) {

--- a/src/test/rustdoc-ui/issue-91713.rs
+++ b/src/test/rustdoc-ui/issue-91713.rs
@@ -1,0 +1,2 @@
+// check-pass
+// compile-flags: --passes list

--- a/src/test/rustdoc-ui/issue-91713.rs
+++ b/src/test/rustdoc-ui/issue-91713.rs
@@ -1,2 +1,3 @@
 // check-pass
 // compile-flags: --passes list
+// error-pattern: the `passes` flag is deprecated

--- a/src/test/rustdoc-ui/issue-91713.stderr
+++ b/src/test/rustdoc-ui/issue-91713.stderr
@@ -1,0 +1,4 @@
+warning: the `passes` flag is deprecated
+   |
+   = note: see issue #44136 <https://github.com/rust-lang/rust/issues/44136> for more information
+

--- a/src/test/rustdoc-ui/issue-91713.stdout
+++ b/src/test/rustdoc-ui/issue-91713.stdout
@@ -1,0 +1,31 @@
+Available passes for running rustdoc:
+check_doc_test_visibility - run various visibility-related lints on doctests
+        strip-hidden - strips all `#[doc(hidden)]` items from the output
+   unindent-comments - removes excess indentation on comments in order for markdown to like it
+       strip-private - strips all private items from a crate which cannot be seen externally, implies strip-priv-imports
+  strip-priv-imports - strips all private import statements (`use`, `extern crate`) from a crate
+   propagate-doc-cfg - propagates `#[doc(cfg(...))]` to child items
+collect-intra-doc-links - resolves intra-doc links
+check-code-block-syntax - validates syntax inside Rust code blocks
+ collect-trait-impls - retrieves trait impls for items in the crate
+calculate-doc-coverage - counts the number of items with and without documentation
+check-invalid-html-tags - detects invalid HTML tags in doc comments
+     check-bare-urls - detects URLs that are not hyperlinks
+
+Default passes for rustdoc:
+ collect-trait-impls
+   unindent-comments
+check_doc_test_visibility
+        strip-hidden  (when not --document-hidden-items)
+       strip-private  (when not --document-private-items)
+  strip-priv-imports  (when --document-private-items)
+collect-intra-doc-links
+check-code-block-syntax
+check-invalid-html-tags
+   propagate-doc-cfg
+     check-bare-urls
+
+Passes run with `--show-coverage`:
+        strip-hidden  (when not --document-hidden-items)
+       strip-private  (when not --document-private-items)
+calculate-doc-coverage

--- a/src/test/rustdoc/type-layout.rs
+++ b/src/test/rustdoc/type-layout.rs
@@ -50,6 +50,18 @@ pub struct GenericLifetimes<'a>(&'a str);
 // @has - '(unsized)'
 pub struct Unsized([u8]);
 
+// @has type_layout/type.TypeAlias.html 'Size: '
+// @has - ' bytes'
+pub type TypeAlias = X;
+
+// @has type_layout/type.GenericTypeAlias.html 'Size: '
+// @has - '8 bytes'
+pub type GenericTypeAlias = (Generic<(u32, ())>, Generic<u32>);
+
+// Regression test for the rustdoc equivalent of #85103.
+// @has type_layout/type.Edges.html 'Encountered an error during type layout; the type failed to be normalized.'
+pub type Edges<'a, E> = std::borrow::Cow<'a, [E]>;
+
 // @!has type_layout/trait.MyTrait.html 'Size: '
 pub trait MyTrait {}
 

--- a/src/test/ui/array-slice-vec/box-of-array-of-drop-1.rs
+++ b/src/test/ui/array-slice-vec/box-of-array-of-drop-1.rs
@@ -1,4 +1,5 @@
 // run-pass
+// needs-unwind
 #![allow(overflowing_literals)]
 
 // Test that we cleanup a fixed size Box<[D; k]> properly when D has a

--- a/src/test/ui/array-slice-vec/box-of-array-of-drop-2.rs
+++ b/src/test/ui/array-slice-vec/box-of-array-of-drop-2.rs
@@ -1,4 +1,5 @@
 // run-pass
+// needs-unwind
 #![allow(overflowing_literals)]
 
 // Test that we cleanup dynamic sized Box<[D]> properly when D has a

--- a/src/test/ui/array-slice-vec/nested-vec-3.rs
+++ b/src/test/ui/array-slice-vec/nested-vec-3.rs
@@ -1,4 +1,5 @@
 // run-pass
+// needs-unwind
 #![allow(overflowing_literals)]
 
 // ignore-emscripten no threads support

--- a/src/test/ui/array-slice-vec/slice-panic-1.rs
+++ b/src/test/ui/array-slice-vec/slice-panic-1.rs
@@ -1,4 +1,5 @@
 // run-pass
+// needs-unwind
 
 // ignore-emscripten no threads support
 

--- a/src/test/ui/array-slice-vec/slice-panic-2.rs
+++ b/src/test/ui/array-slice-vec/slice-panic-2.rs
@@ -1,4 +1,5 @@
 // run-pass
+// needs-unwind
 
 // ignore-emscripten no threads support
 

--- a/src/test/ui/async-await/issues/issue-65419/issue-65419-async-fn-resume-after-panic.rs
+++ b/src/test/ui/async-await/issues/issue-65419/issue-65419-async-fn-resume-after-panic.rs
@@ -2,6 +2,7 @@
 // be talking about `async fn`s instead. Should also test what happens when it panics.
 
 // run-fail
+// needs-unwind
 // error-pattern: thread 'main' panicked at '`async fn` resumed after panicking'
 // edition:2018
 // ignore-wasm no panic or subprocess support

--- a/src/test/ui/binding/fn-arg-incomplete-pattern-drop-order.rs
+++ b/src/test/ui/binding/fn-arg-incomplete-pattern-drop-order.rs
@@ -1,4 +1,5 @@
 // run-pass
+// needs-unwind
 // Check that partially moved from function parameters are dropped after the
 // named bindings that move from them.
 

--- a/src/test/ui/binding/issue-53114-safety-checks.stderr
+++ b/src/test/ui/binding/issue-53114-safety-checks.stderr
@@ -8,6 +8,7 @@ LL |     let _ = &p.b;
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #82523 <https://github.com/rust-lang/rust/issues/82523>
    = note: fields of packed structs are not properly aligned, and creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
+   = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
 
 warning: reference to packed field is unaligned
   --> $DIR/issue-53114-safety-checks.rs:29:17
@@ -18,6 +19,7 @@ LL |     let (_,) = (&p.b,);
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #82523 <https://github.com/rust-lang/rust/issues/82523>
    = note: fields of packed structs are not properly aligned, and creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
+   = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
 
 warning: reference to packed field is unaligned
   --> $DIR/issue-53114-safety-checks.rs:39:11
@@ -28,6 +30,7 @@ LL |     match &p.b  { _ => { } }
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #82523 <https://github.com/rust-lang/rust/issues/82523>
    = note: fields of packed structs are not properly aligned, and creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
+   = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
 
 warning: reference to packed field is unaligned
   --> $DIR/issue-53114-safety-checks.rs:45:12
@@ -38,6 +41,7 @@ LL |     match (&p.b,)  { (_,) => { } }
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #82523 <https://github.com/rust-lang/rust/issues/82523>
    = note: fields of packed structs are not properly aligned, and creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
+   = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
 
 error[E0133]: access to union field is unsafe and requires unsafe function or block
   --> $DIR/issue-53114-safety-checks.rs:26:13

--- a/src/test/ui/builtin-clone-unwind.rs
+++ b/src/test/ui/builtin-clone-unwind.rs
@@ -1,4 +1,5 @@
 // run-pass
+// needs-unwind
 
 #![allow(unused_variables)]
 #![allow(unused_imports)]

--- a/src/test/ui/catch-unwind-bang.rs
+++ b/src/test/ui/catch-unwind-bang.rs
@@ -1,4 +1,5 @@
 // run-pass
+// needs-unwind
 // ignore-wasm32-bare compiled with panic=abort by default
 
 fn worker() -> ! {

--- a/src/test/ui/cleanup-rvalue-temp-during-incomplete-alloc.rs
+++ b/src/test/ui/cleanup-rvalue-temp-during-incomplete-alloc.rs
@@ -1,4 +1,5 @@
 // run-pass
+// needs-unwind
 
 #![allow(unused_must_use)]
 #![allow(dead_code)]

--- a/src/test/ui/closures/2229_closure_analysis/diagnostics/repr_packed.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/diagnostics/repr_packed.stderr
@@ -8,6 +8,7 @@ LL |         println!("{}", foo.x);
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #82523 <https://github.com/rust-lang/rust/issues/82523>
    = note: fields of packed structs are not properly aligned, and creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
+   = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
    = note: this warning originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: 1 warning emitted

--- a/src/test/ui/closures/2229_closure_analysis/migrations/mir_calls_to_shims.fixed
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/mir_calls_to_shims.fixed
@@ -1,4 +1,5 @@
 // run-rustfix
+// needs-unwind
 
 #![deny(rust_2021_incompatible_closure_captures)]
 //~^ NOTE: the lint level is defined here

--- a/src/test/ui/closures/2229_closure_analysis/migrations/mir_calls_to_shims.rs
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/mir_calls_to_shims.rs
@@ -1,4 +1,5 @@
 // run-rustfix
+// needs-unwind
 
 #![deny(rust_2021_incompatible_closure_captures)]
 //~^ NOTE: the lint level is defined here

--- a/src/test/ui/closures/2229_closure_analysis/migrations/mir_calls_to_shims.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/mir_calls_to_shims.stderr
@@ -1,5 +1,5 @@
 error: changes to closure capture in Rust 2021 will affect which traits the closure implements
-  --> $DIR/mir_calls_to_shims.rs:20:38
+  --> $DIR/mir_calls_to_shims.rs:21:38
    |
 LL |     let result = panic::catch_unwind(move || {
    |                                      ^^^^^^^
@@ -11,7 +11,7 @@ LL |         f.0()
    |         --- in Rust 2018, this closure captures all of `f`, but in Rust 2021, it will only capture `f.0`
    |
 note: the lint level is defined here
-  --> $DIR/mir_calls_to_shims.rs:3:9
+  --> $DIR/mir_calls_to_shims.rs:4:9
    |
 LL | #![deny(rust_2021_incompatible_closure_captures)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/drop/drop-trait-enum.rs
+++ b/src/test/ui/drop/drop-trait-enum.rs
@@ -3,6 +3,7 @@
 #![allow(unused_assignments)]
 #![allow(unused_variables)]
 // ignore-emscripten no threads support
+// needs-unwind
 
 use std::thread;
 use std::sync::mpsc::{channel, Sender};

--- a/src/test/ui/drop/dynamic-drop-async.rs
+++ b/src/test/ui/drop/dynamic-drop-async.rs
@@ -4,6 +4,7 @@
 // * Dropping one of the values panics while dropping the future.
 
 // run-pass
+// needs-unwind
 // edition:2018
 // ignore-wasm32-bare compiled with panic=abort by default
 

--- a/src/test/ui/drop/dynamic-drop.rs
+++ b/src/test/ui/drop/dynamic-drop.rs
@@ -1,4 +1,5 @@
 // run-pass
+// needs-unwind
 // ignore-wasm32-bare compiled with panic=abort by default
 
 #![feature(generators, generator_trait)]

--- a/src/test/ui/drop/terminate-in-initializer.rs
+++ b/src/test/ui/drop/terminate-in-initializer.rs
@@ -1,4 +1,5 @@
 // run-pass
+// needs-unwind
 // ignore-emscripten no threads support
 
 // Issue #787

--- a/src/test/ui/extern/issue-64655-allow-unwind-when-calling-panic-directly.rs
+++ b/src/test/ui/extern/issue-64655-allow-unwind-when-calling-panic-directly.rs
@@ -1,4 +1,5 @@
 // run-pass
+// needs-unwind
 // ignore-wasm32-bare compiled with panic=abort by default
 // ignore-emscripten no threads support
 

--- a/src/test/ui/extern/issue-64655-extern-rust-must-allow-unwind.rs
+++ b/src/test/ui/extern/issue-64655-extern-rust-must-allow-unwind.rs
@@ -1,4 +1,5 @@
 // run-pass
+// needs-unwind
 // ignore-wasm32-bare compiled with panic=abort by default
 // ignore-emscripten no threads support
 

--- a/src/test/ui/generator/generator-resume-after-panic.rs
+++ b/src/test/ui/generator/generator-resume-after-panic.rs
@@ -1,4 +1,5 @@
 // run-fail
+// needs-unwind
 // error-pattern:generator resumed after panicking
 // ignore-emscripten no processes
 

--- a/src/test/ui/generator/panic-drops-resume.rs
+++ b/src/test/ui/generator/panic-drops-resume.rs
@@ -1,6 +1,7 @@
 //! Tests that panics inside a generator will correctly drop the initial resume argument.
 
 // run-pass
+// needs-unwind
 // ignore-wasm       no unwind support
 // ignore-emscripten no unwind support
 

--- a/src/test/ui/generator/panic-drops.rs
+++ b/src/test/ui/generator/panic-drops.rs
@@ -1,4 +1,5 @@
 // run-pass
+// needs-unwind
 
 // ignore-wasm32-bare compiled with panic=abort by default
 

--- a/src/test/ui/generator/panic-safe.rs
+++ b/src/test/ui/generator/panic-safe.rs
@@ -1,4 +1,5 @@
 // run-pass
+// needs-unwind
 
 // ignore-wasm32-bare compiled with panic=abort by default
 

--- a/src/test/ui/generator/resume-after-return.rs
+++ b/src/test/ui/generator/resume-after-return.rs
@@ -1,4 +1,5 @@
 // run-pass
+// needs-unwind
 
 // ignore-wasm32-bare compiled with panic=abort by default
 

--- a/src/test/ui/intrinsics/panic-uninitialized-zeroed.rs
+++ b/src/test/ui/intrinsics/panic-uninitialized-zeroed.rs
@@ -1,4 +1,5 @@
 // run-pass
+// needs-unwind
 // ignore-wasm32-bare compiled with panic=abort by default
 // revisions: mir thir
 // [thir]compile-flags: -Zthir-unsafeck

--- a/src/test/ui/issues/issue-14875.rs
+++ b/src/test/ui/issues/issue-14875.rs
@@ -1,4 +1,5 @@
 // run-pass
+// needs-unwind
 // ignore-wasm32-bare compiled with panic=abort by default
 
 // Check that values are not leaked when a dtor panics (#14875)

--- a/src/test/ui/issues/issue-25089.rs
+++ b/src/test/ui/issues/issue-25089.rs
@@ -1,4 +1,5 @@
 // run-pass
+// needs-unwind
 // ignore-emscripten no threads support
 
 use std::thread;

--- a/src/test/ui/issues/issue-26655.rs
+++ b/src/test/ui/issues/issue-26655.rs
@@ -1,4 +1,5 @@
 // run-pass
+// needs-unwind
 // ignore-emscripten no threads support
 
 // Check that the destructors of simple enums are run on unwinding

--- a/src/test/ui/issues/issue-29485.rs
+++ b/src/test/ui/issues/issue-29485.rs
@@ -1,6 +1,7 @@
 // run-pass
 #![allow(unused_attributes)]
 // aux-build:issue-29485.rs
+// needs-unwind
 // ignore-emscripten no threads
 
 #[feature(recover)]

--- a/src/test/ui/issues/issue-29948.rs
+++ b/src/test/ui/issues/issue-29948.rs
@@ -1,4 +1,5 @@
 // run-pass
+// needs-unwind
 // ignore-wasm32-bare compiled with panic=abort by default
 
 use std::panic;

--- a/src/test/ui/issues/issue-30018-panic.rs
+++ b/src/test/ui/issues/issue-30018-panic.rs
@@ -4,6 +4,7 @@
 // spawned thread to isolate the expected error result from the
 // SIGTRAP injected by the drop-flag consistency checking.
 
+// needs-unwind
 // ignore-emscripten no threads support
 
 struct Foo;

--- a/src/test/ui/issues/issue-43853.rs
+++ b/src/test/ui/issues/issue-43853.rs
@@ -1,4 +1,5 @@
 // run-pass
+// needs-unwind
 // ignore-wasm32-bare compiled with panic=abort by default
 
 use std::panic;

--- a/src/test/ui/issues/issue-46519.rs
+++ b/src/test/ui/issues/issue-46519.rs
@@ -1,6 +1,7 @@
 // run-pass
 // compile-flags:--test -O
 
+// needs-unwind
 // ignore-wasm32-bare compiled with panic=abort by default
 
 #[test]

--- a/src/test/ui/iterators/iter-count-overflow-debug.rs
+++ b/src/test/ui/iterators/iter-count-overflow-debug.rs
@@ -1,5 +1,6 @@
 // run-pass
 // only-32bit too impatient for 2⁶⁴ items
+// needs-unwind
 // ignore-wasm32-bare compiled with panic=abort by default
 // compile-flags: -C debug_assertions=yes -C opt-level=3
 

--- a/src/test/ui/iterators/iter-position-overflow-debug.rs
+++ b/src/test/ui/iterators/iter-position-overflow-debug.rs
@@ -1,5 +1,6 @@
 // run-pass
 // only-32bit too impatient for 2⁶⁴ items
+// needs-unwind
 // ignore-wasm32-bare compiled with panic=abort by default
 // compile-flags: -C debug_assertions=yes -C opt-level=3
 

--- a/src/test/ui/iterators/iter-step-overflow-debug.rs
+++ b/src/test/ui/iterators/iter-step-overflow-debug.rs
@@ -1,4 +1,5 @@
 // run-pass
+// needs-unwind
 // ignore-wasm32-bare compiled with panic=abort by default
 // compile-flags: -C debug_assertions=yes
 

--- a/src/test/ui/iterators/iter-sum-overflow-debug.rs
+++ b/src/test/ui/iterators/iter-sum-overflow-debug.rs
@@ -1,4 +1,5 @@
 // run-pass
+// needs-unwind
 // ignore-wasm32-bare compiled with panic=abort by default
 // compile-flags: -C debug_assertions=yes
 

--- a/src/test/ui/iterators/iter-sum-overflow-overflow-checks.rs
+++ b/src/test/ui/iterators/iter-sum-overflow-overflow-checks.rs
@@ -1,4 +1,5 @@
 // run-pass
+// needs-unwind
 // ignore-wasm32-bare compiled with panic=abort by default
 // compile-flags: -C overflow-checks
 

--- a/src/test/ui/lint/unaligned_references.stderr
+++ b/src/test/ui/lint/unaligned_references.stderr
@@ -12,6 +12,7 @@ LL | #![deny(unaligned_references)]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #82523 <https://github.com/rust-lang/rust/issues/82523>
    = note: fields of packed structs are not properly aligned, and creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
+   = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
 
 error: reference to packed field is unaligned
   --> $DIR/unaligned_references.rs:24:17
@@ -22,6 +23,7 @@ LL |         let _ = &good.data;
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #82523 <https://github.com/rust-lang/rust/issues/82523>
    = note: fields of packed structs are not properly aligned, and creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
+   = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
 
 error: reference to packed field is unaligned
   --> $DIR/unaligned_references.rs:27:17
@@ -32,6 +34,7 @@ LL |         let _ = &good.data as *const _;
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #82523 <https://github.com/rust-lang/rust/issues/82523>
    = note: fields of packed structs are not properly aligned, and creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
+   = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
 
 error: reference to packed field is unaligned
   --> $DIR/unaligned_references.rs:29:27
@@ -42,6 +45,7 @@ LL |         let _: *const _ = &good.data;
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #82523 <https://github.com/rust-lang/rust/issues/82523>
    = note: fields of packed structs are not properly aligned, and creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
+   = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
 
 error: reference to packed field is unaligned
   --> $DIR/unaligned_references.rs:32:17
@@ -52,6 +56,7 @@ LL |         let _ = good.data.clone();
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #82523 <https://github.com/rust-lang/rust/issues/82523>
    = note: fields of packed structs are not properly aligned, and creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
+   = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
 
 error: reference to packed field is unaligned
   --> $DIR/unaligned_references.rs:35:17
@@ -62,6 +67,7 @@ LL |         let _ = &good.data2[0];
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #82523 <https://github.com/rust-lang/rust/issues/82523>
    = note: fields of packed structs are not properly aligned, and creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
+   = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
 
 error: reference to packed field is unaligned
   --> $DIR/unaligned_references.rs:45:17
@@ -72,6 +78,7 @@ LL |         let _ = &packed2.x;
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #82523 <https://github.com/rust-lang/rust/issues/82523>
    = note: fields of packed structs are not properly aligned, and creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
+   = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
 
 error: aborting due to 7 previous errors
 

--- a/src/test/ui/lint/unaligned_references_external_macro.stderr
+++ b/src/test/ui/lint/unaligned_references_external_macro.stderr
@@ -24,6 +24,7 @@ LL | | }
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #82523 <https://github.com/rust-lang/rust/issues/82523>
    = note: fields of packed structs are not properly aligned, and creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
+   = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
    = note: this error originates in the macro `unaligned_references_external_crate::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error

--- a/src/test/ui/macros/macro-comma-behavior-rpass.rs
+++ b/src/test/ui/macros/macro-comma-behavior-rpass.rs
@@ -1,4 +1,5 @@
 // run-pass
+// needs-unwind
 #![allow(unused_imports)]
 // Ideally, any macro call with a trailing comma should behave
 // identically to a call without the comma.

--- a/src/test/ui/mir/mir_calls_to_shims.rs
+++ b/src/test/ui/mir/mir_calls_to_shims.rs
@@ -1,4 +1,5 @@
 // run-pass
+// needs-unwind
 // ignore-wasm32-bare compiled with panic=abort by default
 
 #![feature(fn_traits)]

--- a/src/test/ui/mir/mir_drop_order.rs
+++ b/src/test/ui/mir/mir_drop_order.rs
@@ -1,4 +1,5 @@
 // run-pass
+// needs-unwind
 // ignore-wasm32-bare compiled with panic=abort by default
 
 use std::cell::RefCell;

--- a/src/test/ui/mir/mir_drop_panics.rs
+++ b/src/test/ui/mir/mir_drop_panics.rs
@@ -1,4 +1,5 @@
 // run-fail
+// needs-unwind
 // error-pattern:panic 1
 // error-pattern:drop 2
 // ignore-emscripten no processes

--- a/src/test/ui/mir/mir_dynamic_drops_3.rs
+++ b/src/test/ui/mir/mir_dynamic_drops_3.rs
@@ -1,4 +1,5 @@
 // run-fail
+// needs-unwind
 // error-pattern:unwind happens
 // error-pattern:drop 3
 // error-pattern:drop 2

--- a/src/test/ui/numbers-arithmetic/int-abs-overflow.rs
+++ b/src/test/ui/numbers-arithmetic/int-abs-overflow.rs
@@ -1,6 +1,7 @@
 // run-pass
 // compile-flags: -C overflow-checks=on
 // ignore-emscripten no threads support
+// needs-unwind
 
 use std::thread;
 

--- a/src/test/ui/numbers-arithmetic/next-power-of-two-overflow-debug.rs
+++ b/src/test/ui/numbers-arithmetic/next-power-of-two-overflow-debug.rs
@@ -1,5 +1,6 @@
 // run-pass
 // compile-flags: -C debug_assertions=yes
+// needs-unwind
 // ignore-wasm32-bare compiled with panic=abort by default
 // ignore-emscripten dies with an LLVM error
 

--- a/src/test/ui/packed/issue-27060.stderr
+++ b/src/test/ui/packed/issue-27060.stderr
@@ -12,6 +12,7 @@ LL | #[deny(unaligned_references)]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #82523 <https://github.com/rust-lang/rust/issues/82523>
    = note: fields of packed structs are not properly aligned, and creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
+   = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
 
 error: reference to packed field is unaligned
   --> $DIR/issue-27060.rs:18:13
@@ -22,6 +23,7 @@ LL |     let _ = &good.data2[0];
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #82523 <https://github.com/rust-lang/rust/issues/82523>
    = note: fields of packed structs are not properly aligned, and creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
+   = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
 
 error: reference to packed field is unaligned
   --> $DIR/issue-27060.rs:21:13
@@ -32,6 +34,7 @@ LL |     let _ = &good.data;
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #82523 <https://github.com/rust-lang/rust/issues/82523>
    = note: fields of packed structs are not properly aligned, and creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
+   = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
 
 error: reference to packed field is unaligned
   --> $DIR/issue-27060.rs:23:13
@@ -42,6 +45,7 @@ LL |     let _ = &good.data2[0];
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #82523 <https://github.com/rust-lang/rust/issues/82523>
    = note: fields of packed structs are not properly aligned, and creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
+   = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/packed/packed-struct-borrow-element-64bit.stderr
+++ b/src/test/ui/packed/packed-struct-borrow-element-64bit.stderr
@@ -8,6 +8,7 @@ LL |     let brw = &foo.baz;
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #82523 <https://github.com/rust-lang/rust/issues/82523>
    = note: fields of packed structs are not properly aligned, and creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
+   = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
 
 warning: 1 warning emitted
 

--- a/src/test/ui/packed/packed-struct-borrow-element.stderr
+++ b/src/test/ui/packed/packed-struct-borrow-element.stderr
@@ -8,6 +8,7 @@ LL |     let brw = &foo.baz;
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #82523 <https://github.com/rust-lang/rust/issues/82523>
    = note: fields of packed structs are not properly aligned, and creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
+   = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
 
 warning: reference to packed field is unaligned
   --> $DIR/packed-struct-borrow-element.rs:30:15
@@ -18,6 +19,7 @@ LL |     let brw = &foo.baz;
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #82523 <https://github.com/rust-lang/rust/issues/82523>
    = note: fields of packed structs are not properly aligned, and creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
+   = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
 
 warning: 2 warnings emitted
 

--- a/src/test/ui/panics/panic-handler-chain.rs
+++ b/src/test/ui/panics/panic-handler-chain.rs
@@ -1,4 +1,5 @@
 // run-pass
+// needs-unwind
 #![allow(stable_features)]
 
 // ignore-emscripten no threads support

--- a/src/test/ui/panics/panic-handler-flail-wildly.rs
+++ b/src/test/ui/panics/panic-handler-flail-wildly.rs
@@ -1,4 +1,5 @@
 // run-pass
+// needs-unwind
 
 #![allow(stable_features)]
 #![allow(unused_must_use)]

--- a/src/test/ui/panics/panic-handler-set-twice.rs
+++ b/src/test/ui/panics/panic-handler-set-twice.rs
@@ -1,4 +1,5 @@
 // run-pass
+// needs-unwind
 #![allow(unused_variables)]
 #![allow(stable_features)]
 

--- a/src/test/ui/panics/panic-in-dtor-drops-fields.rs
+++ b/src/test/ui/panics/panic-in-dtor-drops-fields.rs
@@ -1,4 +1,5 @@
 // run-pass
+// needs-unwind
 #![allow(dead_code)]
 #![allow(non_upper_case_globals)]
 

--- a/src/test/ui/panics/panic-recover-propagate.rs
+++ b/src/test/ui/panics/panic-recover-propagate.rs
@@ -1,4 +1,5 @@
 // run-pass
+// needs-unwind
 // ignore-emscripten no threads support
 
 use std::sync::atomic::{AtomicUsize, Ordering};

--- a/src/test/ui/privacy/reachable-unnameable-items.rs
+++ b/src/test/ui/privacy/reachable-unnameable-items.rs
@@ -1,5 +1,6 @@
 // run-pass
 // ignore-wasm32-bare compiled with panic=abort by default
+// needs-unwind
 // aux-build:reachable-unnameable-items.rs
 
 extern crate reachable_unnameable_items;

--- a/src/test/ui/proc-macro/expand-with-a-macro.rs
+++ b/src/test/ui/proc-macro/expand-with-a-macro.rs
@@ -1,4 +1,5 @@
 // run-pass
+// needs-unwind
 // aux-build:expand-with-a-macro.rs
 
 // ignore-wasm32-bare compiled with panic=abort by default

--- a/src/test/ui/rfc-1937-termination-trait/termination-trait-in-test.rs
+++ b/src/test/ui/rfc-1937-termination-trait/termination-trait-in-test.rs
@@ -1,5 +1,6 @@
 // compile-flags: --test
 // run-pass
+// needs-unwind
 
 // ignore-wasm32-bare compiled with panic=abort by default
 

--- a/src/test/ui/rfc-2091-track-caller/std-panic-locations.rs
+++ b/src/test/ui/rfc-2091-track-caller/std-panic-locations.rs
@@ -1,4 +1,5 @@
 // run-pass
+// needs-unwind
 // ignore-wasm32-bare compiled with panic=abort by default
 // revisions: default mir-opt
 //[mir-opt] compile-flags: -Zmir-opt-level=4

--- a/src/test/ui/rfcs/rfc1857-drop-order.rs
+++ b/src/test/ui/rfcs/rfc1857-drop-order.rs
@@ -1,4 +1,5 @@
 // run-pass
+// needs-unwind
 // ignore-wasm32-bare compiled with panic=abort by default
 
 #![allow(dead_code, unreachable_code)]

--- a/src/test/ui/runtime/rt-explody-panic-payloads.rs
+++ b/src/test/ui/runtime/rt-explody-panic-payloads.rs
@@ -1,4 +1,5 @@
 // run-pass
+// needs-unwind
 // ignore-emscripten no processes
 // ignore-sgx no processes
 // ignore-wasm32-bare no unwinding panic

--- a/src/test/ui/sepcomp/sepcomp-unwind.rs
+++ b/src/test/ui/sepcomp/sepcomp-unwind.rs
@@ -1,4 +1,5 @@
 // run-pass
+// needs-unwind
 #![allow(dead_code)]
 // compile-flags: -C codegen-units=3
 // ignore-emscripten no threads support

--- a/src/test/ui/structs-enums/unit-like-struct-drop-run.rs
+++ b/src/test/ui/structs-enums/unit-like-struct-drop-run.rs
@@ -1,4 +1,5 @@
 // run-pass
+// needs-unwind
 // ignore-emscripten no threads support
 
 // Make sure the destructor is run for unit-like structs.

--- a/src/test/ui/test-attrs/test-should-fail-good-message.rs
+++ b/src/test/ui/test-attrs/test-should-fail-good-message.rs
@@ -1,4 +1,5 @@
 // run-pass
+// needs-unwind
 // ignore-wasm32-bare compiled with panic=abort by default
 // compile-flags: --test
 #[test]

--- a/src/test/ui/threads-sendsync/task-stderr.rs
+++ b/src/test/ui/threads-sendsync/task-stderr.rs
@@ -1,5 +1,6 @@
 // run-pass
 // ignore-emscripten no threads support
+// needs-unwind
 
 #![feature(internal_output_capture)]
 

--- a/src/test/ui/threads-sendsync/unwind-resource.rs
+++ b/src/test/ui/threads-sendsync/unwind-resource.rs
@@ -1,4 +1,5 @@
 // run-pass
+// needs-unwind
 
 #![allow(non_camel_case_types)]
 // ignore-emscripten no threads support

--- a/src/test/ui/unwind-unique.rs
+++ b/src/test/ui/unwind-unique.rs
@@ -1,4 +1,5 @@
 // run-pass
+// needs-unwind
 // ignore-emscripten no threads support
 
 use std::thread;


### PR DESCRIPTION
Successful merges:

 - #91373 (Add needs-unwind to tests that depend on panicking)
 - #91426 (Make IdFunctor::try_map_id panic-safe)
 - #91617 (Improve the readability of `List<T>`.)
 - #91682 (rustdoc: Show type layout for type aliases)
 - #91711 (Improve `std::iter::zip` example)
 - #91717 (Add deprecation warning for --passes)
 - #91718 (give more help in the unaligned_references lint)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=91373,91426,91617,91682,91711,91717,91718)
<!-- homu-ignore:end -->