### PR TITLE
Eliminate duplicate code for using jemalloc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3471,8 +3471,6 @@ version = "0.0.0"
 dependencies = [
  "rustc_codegen_ssa",
  "rustc_driver",
- "tikv-jemalloc-sys",
- "tikv-jemallocator",
 ]
 
 [[package]]
@@ -3833,6 +3831,8 @@ dependencies = [
  "rustc_span",
  "rustc_target",
  "rustc_typeck",
+ "tikv-jemalloc-sys",
+ "tikv-jemallocator",
  "tracing",
  "tracing-subscriber",
  "tracing-tree",

--- a/compiler/rustc/Cargo.toml
+++ b/compiler/rustc/Cargo.toml
@@ -10,16 +10,7 @@ rustc_driver = { path = "../rustc_driver" }
 # crate is intended to be used by codegen backends, which may not be in-tree.
 rustc_codegen_ssa = { path = "../rustc_codegen_ssa" }
 
-[dependencies.tikv-jemalloc-sys]
-version = '0.4.0'
-optional = true
-features = ['unprefixed_malloc_on_supported_platforms']
-
-[dependencies.tikv-jemallocator]
-version = '0.4.0'
-optional = true
-
 [features]
-jemalloc = ['tikv-jemalloc-sys', 'tikv-jemallocator']
+jemalloc = ['rustc_driver/jemalloc']
 llvm = ['rustc_driver/llvm']
 max_level_info = ['rustc_driver/max_level_info']

--- a/compiler/rustc/src/main.rs
+++ b/compiler/rustc/src/main.rs
@@ -1,57 +1,7 @@
-// Configure jemalloc as the `global_allocator` when configured. This is
-// so that we use the sized deallocation apis jemalloc provides
-// (namely `sdallocx`).
-//
-// The symbol overrides documented below are also performed so that we can
-// ensure that we use a consistent allocator across the rustc <-> llvm boundary
-#[cfg(feature = "jemalloc")]
-#[global_allocator]
-static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
-
-#[cfg(feature = "tikv-jemalloc-sys")]
-use tikv_jemalloc_sys as jemalloc_sys;
-
 fn main() {
     // Pull in jemalloc when enabled.
-    //
-    // Note that we're pulling in a static copy of jemalloc which means that to
-    // pull it in we need to actually reference its symbols for it to get
-    // linked. The two crates we link to here, std and rustc_driver, are both
-    // dynamic libraries. That means to pull in jemalloc we actually need to
-    // reference allocation symbols one way or another (as this file is the only
-    // object code in the rustc executable).
-    #[cfg(feature = "tikv-jemalloc-sys")]
-    {
-        use std::os::raw::{c_int, c_void};
-
-        #[used]
-        static _F1: unsafe extern "C" fn(usize, usize) -> *mut c_void = jemalloc_sys::calloc;
-        #[used]
-        static _F2: unsafe extern "C" fn(*mut *mut c_void, usize, usize) -> c_int =
-            jemalloc_sys::posix_memalign;
-        #[used]
-        static _F3: unsafe extern "C" fn(usize, usize) -> *mut c_void = jemalloc_sys::aligned_alloc;
-        #[used]
-        static _F4: unsafe extern "C" fn(usize) -> *mut c_void = jemalloc_sys::malloc;
-        #[used]
-        static _F5: unsafe extern "C" fn(*mut c_void, usize) -> *mut c_void = jemalloc_sys::realloc;
-        #[used]
-        static _F6: unsafe extern "C" fn(*mut c_void) = jemalloc_sys::free;
-
-        // On OSX, jemalloc doesn't directly override malloc/free, but instead
-        // registers itself with the allocator's zone APIs in a ctor. However,
-        // the linker doesn't seem to consider ctors as "used" when statically
-        // linking, so we need to explicitly depend on the function.
-        #[cfg(target_os = "macos")]
-        {
-            extern "C" {
-                fn _rjem_je_zone_register();
-            }
-
-            #[used]
-            static _F7: unsafe extern "C" fn() = _rjem_je_zone_register;
-        }
-    }
+    #[cfg(feature = "jemalloc")]
+    rustc_driver::set_jemalloc();
 
     rustc_driver::set_sigpipe_handler();
     rustc_driver::main()

--- a/compiler/rustc_driver/Cargo.toml
+++ b/compiler/rustc_driver/Cargo.toml
@@ -34,10 +34,13 @@ rustc_serialize = { path = "../rustc_serialize" }
 rustc_ast = { path = "../rustc_ast" }
 rustc_span = { path = "../rustc_span" }
 rustc_typeck = { path = "../rustc_typeck" }
+tikv-jemalloc-sys = { version = '0.4.0', optional = true, features = ['unprefixed_malloc_on_supported_platforms'] }
+tikv-jemallocator = { version = '0.4.0', optional = true }
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["consoleapi", "debugapi", "processenv"] }
 
 [features]
+jemalloc = ['tikv-jemalloc-sys', 'tikv-jemallocator']
 llvm = ['rustc_interface/llvm']
 max_level_info = ['tracing/max_level_info']

--- a/compiler/rustc_driver/src/lib.rs
+++ b/compiler/rustc_driver/src/lib.rs
@@ -1382,3 +1382,56 @@ pub fn main() -> ! {
 
     process::exit(exit_code)
 }
+
+// Configure jemalloc as the `global_allocator` when configured. This is
+// so that we use the sized deallocation apis jemalloc provides
+// (namely `sdallocx`).
+//
+// The symbol overrides documented below are also performed so that we can
+// ensure that we use a consistent allocator across the rustc <-> llvm boundary
+#[cfg(feature = "jemalloc")]
+#[global_allocator]
+static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
+// Pull in jemalloc when enabled.
+//
+// Note that we're pulling in a static copy of jemalloc which means that to
+// pull it in we need to actually reference its symbols for it to get
+// linked. The two crates we link to here, std and rustc_driver, are both
+// dynamic libraries. That means to pull in jemalloc we actually need to
+// reference allocation symbols one way or another (as this file is the only
+// object code in the rustc executable).
+#[cfg(feature = "jemalloc")]
+pub fn set_jemalloc() {
+    use std::os::raw::{c_int, c_void};
+
+    #[used]
+    static _F1: unsafe extern "C" fn(usize, usize) -> *mut c_void = tikv_jemalloc_sys::calloc;
+    #[used]
+    static _F2: unsafe extern "C" fn(*mut *mut c_void, usize, usize) -> c_int =
+        tikv_jemalloc_sys::posix_memalign;
+    #[used]
+    static _F3: unsafe extern "C" fn(usize, usize) -> *mut c_void =
+        tikv_jemalloc_sys::aligned_alloc;
+    #[used]
+    static _F4: unsafe extern "C" fn(usize) -> *mut c_void = tikv_jemalloc_sys::malloc;
+    #[used]
+    static _F5: unsafe extern "C" fn(*mut c_void, usize) -> *mut c_void =
+        tikv_jemalloc_sys::realloc;
+    #[used]
+    static _F6: unsafe extern "C" fn(*mut c_void) = tikv_jemalloc_sys::free;
+
+    // On OSX, jemalloc doesn't directly override malloc/free, but instead
+    // registers itself with the allocator's zone APIs in a ctor. However,
+    // the linker doesn't seem to consider ctors as "used" when statically
+    // linking, so we need to explicitly depend on the function.
+    #[cfg(target_os = "macos")]
+    {
+        extern "C" {
+            fn _rjem_je_zone_register();
+        }
+
+        #[used]
+        static _F7: unsafe extern "C" fn() = _rjem_je_zone_register;
+    }
+}

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -63,15 +63,6 @@ extern crate rustc_trait_selection;
 extern crate rustc_typeck;
 extern crate test;
 
-#[cfg(feature = "jemalloc")]
-extern crate tikv_jemalloc_sys;
-#[cfg(feature = "jemalloc")]
-use tikv_jemalloc_sys as jemalloc_sys;
-#[cfg(feature = "jemalloc")]
-extern crate tikv_jemallocator;
-#[cfg(feature = "jemalloc")]
-use tikv_jemallocator as jemallocator;
-
 use std::default::Default;
 use std::env;
 use std::process;
@@ -124,49 +115,9 @@ mod theme;
 mod visit;
 mod visit_ast;
 mod visit_lib;
-
-// See docs in https://github.com/rust-lang/rust/blob/master/compiler/rustc/src/main.rs
-// about jemallocator
-#[cfg(feature = "jemalloc")]
-#[global_allocator]
-static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
-
 pub fn main() {
-    // See docs in https://github.com/rust-lang/rust/blob/master/compiler/rustc/src/main.rs
-    // about jemalloc-sys
     #[cfg(feature = "jemalloc")]
-    {
-        use std::os::raw::{c_int, c_void};
-
-        #[used]
-        static _F1: unsafe extern "C" fn(usize, usize) -> *mut c_void = jemalloc_sys::calloc;
-        #[used]
-        static _F2: unsafe extern "C" fn(*mut *mut c_void, usize, usize) -> c_int =
-            jemalloc_sys::posix_memalign;
-        #[used]
-        static _F3: unsafe extern "C" fn(usize, usize) -> *mut c_void = jemalloc_sys::aligned_alloc;
-        #[used]
-        static _F4: unsafe extern "C" fn(usize) -> *mut c_void = jemalloc_sys::malloc;
-        #[used]
-        static _F5: unsafe extern "C" fn(*mut c_void, usize) -> *mut c_void = jemalloc_sys::realloc;
-        #[used]
-        static _F6: unsafe extern "C" fn(*mut c_void) = jemalloc_sys::free;
-
-        // On OSX, jemalloc doesn't directly override malloc/free, but instead
-        // registers itself with the allocator's zone APIs in a ctor. However,
-        // the linker doesn't seem to consider ctors as "used" when statically
-        // linking, so we need to explicitly depend on the function.
-        #[cfg(target_os = "macos")]
-        {
-            extern "C" {
-                fn _rjem_je_zone_register();
-            }
-
-            #[used]
-            static _F7: unsafe extern "C" fn() = _rjem_je_zone_register;
-        }
-    }
-
+    rustc_driver::set_jemalloc();
     rustc_driver::set_sigpipe_handler();
     rustc_driver::install_ice_hook();
 

--- a/src/tools/tidy/src/deps.rs
+++ b/src/tools/tidy/src/deps.rs
@@ -230,6 +230,9 @@ const PERMITTED_DEPENDENCIES: &[&str] = &[
     "winapi-x86_64-pc-windows-gnu",
     // this is a false-positive: it's only used by rustfmt, but because it's enabled through a feature, tidy thinks it's used by rustc as well.
     "yansi-term",
+    "tikv-jemalloc-sys",
+    "tikv-jemallocator",
+    "fs_extra",
 ];
 
 const PERMITTED_CRANELIFT_DEPENDENCIES: &[&str] = &[


### PR DESCRIPTION
Eliminate duplicate code.
There are duplicate jemalloc codes in rustc and librustdoc. Merge these codes