### PR TITLE
Recover when attempting to force a query with unknown DefPathHash.

### DIFF
--- a/compiler/rustc_hir/src/definitions.rs
+++ b/compiler/rustc_hir/src/definitions.rs
@@ -442,14 +442,14 @@ impl Definitions {
         self.def_id_to_hir_id.iter_enumerated().map(|(k, _)| k)
     }
 
+    // FIXME(cjgillot) Stop returning an Option.
     #[inline(always)]
-    pub fn local_def_path_hash_to_def_id(&self, hash: DefPathHash) -> LocalDefId {
-        debug_assert!(hash.stable_crate_id() == self.stable_crate_id);
+    pub fn local_def_path_hash_to_def_id(&self, hash: DefPathHash) -> Option<LocalDefId> {
+        debug_assert_eq!(hash.stable_crate_id(), self.stable_crate_id);
         self.table
             .def_path_hash_to_index
             .get(&hash)
             .map(|local_def_index| LocalDefId { local_def_index })
-            .unwrap()
     }
 
     pub fn def_path_hash_to_def_index_map(&self) -> &DefPathHashMap {

--- a/compiler/rustc_metadata/src/rmeta/decoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder.rs
@@ -1627,7 +1627,7 @@ impl<'a, 'tcx> CrateMetadataRef<'a> {
     }
 
     #[inline]
-    fn def_path_hash_to_def_index(&self, hash: DefPathHash) -> DefIndex {
+    fn def_path_hash_to_def_index(&self, hash: DefPathHash) -> Option<DefIndex> {
         self.def_path_hash_map.def_path_hash_to_def_index(&hash)
     }
 

--- a/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
@@ -507,9 +507,11 @@ impl CrateStore for CStore {
         self.get_crate_data(def.krate).def_path_hash(def.index)
     }
 
-    fn def_path_hash_to_def_id(&self, cnum: CrateNum, hash: DefPathHash) -> DefId {
-        let def_index = self.get_crate_data(cnum).def_path_hash_to_def_index(hash);
-        DefId { krate: cnum, index: def_index }
+    // FIXME(cjgillot) Stop returning an Option.
+    fn def_path_hash_to_def_id(&self, hash: DefPathHash) -> Option<DefId> {
+        let cnum = self.stable_crate_id_to_crate_num(hash.stable_crate_id());
+        let def_index = self.get_crate_data(cnum).def_path_hash_to_def_index(hash)?;
+        Some(DefId { krate: cnum, index: def_index })
     }
 
     fn expn_hash_to_expn_id(

--- a/compiler/rustc_metadata/src/rmeta/def_path_hash_map.rs
+++ b/compiler/rustc_metadata/src/rmeta/def_path_hash_map.rs
@@ -12,10 +12,11 @@ crate enum DefPathHashMapRef<'tcx> {
 }
 
 impl DefPathHashMapRef<'tcx> {
+    // FIXME(cjgillot) Stop returning an Option.
     #[inline]
-    pub fn def_path_hash_to_def_index(&self, def_path_hash: &DefPathHash) -> DefIndex {
+    pub fn def_path_hash_to_def_index(&self, def_path_hash: &DefPathHash) -> Option<DefIndex> {
         match *self {
-            DefPathHashMapRef::OwnedFromMetadata(ref map) => map.get(def_path_hash).unwrap(),
+            DefPathHashMapRef::OwnedFromMetadata(ref map) => map.get(def_path_hash),
             DefPathHashMapRef::BorrowedFromTcx(_) => {
                 panic!("DefPathHashMap::BorrowedFromTcx variant only exists for serialization")
             }

--- a/compiler/rustc_middle/src/dep_graph/dep_node.rs
+++ b/compiler/rustc_middle/src/dep_graph/dep_node.rs
@@ -266,7 +266,7 @@ impl DepNodeExt for DepNode {
     /// has been removed.
     fn extract_def_id(&self, tcx: TyCtxt<'tcx>) -> Option<DefId> {
         if self.kind.fingerprint_style(tcx) == FingerprintStyle::DefPathHash {
-            Some(tcx.def_path_hash_to_def_id(DefPathHash(self.hash.into())))
+            tcx.def_path_hash_to_def_id(DefPathHash(self.hash.into()))
         } else {
             None
         }

--- a/compiler/rustc_query_impl/src/on_disk_cache.rs
+++ b/compiler/rustc_query_impl/src/on_disk_cache.rs
@@ -747,7 +747,7 @@ impl<'a, 'tcx> Decodable<CacheDecoder<'a, 'tcx>> for DefId {
         // If we get to this point, then all of the query inputs were green,
         // which means that the definition with this hash is guaranteed to
         // still exist in the current compilation session.
-        Ok(d.tcx().def_path_hash_to_def_id(def_path_hash))
+        Ok(d.tcx().def_path_hash_to_def_id(def_path_hash).unwrap())
     }
 }
 

--- a/compiler/rustc_session/src/cstore.rs
+++ b/compiler/rustc_session/src/cstore.rs
@@ -193,7 +193,7 @@ pub trait CrateStore: std::fmt::Debug {
     fn stable_crate_id_to_crate_num(&self, stable_crate_id: StableCrateId) -> CrateNum;
 
     /// Fetch a DefId from a DefPathHash for a foreign crate.
-    fn def_path_hash_to_def_id(&self, cnum: CrateNum, hash: DefPathHash) -> DefId;
+    fn def_path_hash_to_def_id(&self, hash: DefPathHash) -> Option<DefId>;
     fn expn_hash_to_expn_id(
         &self,
         sess: &Session,


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/90682
Fixes https://github.com/rust-lang/rust/issues/90697
Fixes https://github.com/rust-lang/rust/issues/90715
Fixes https://github.com/rust-lang/rust/issues/90739
Fixes https://github.com/rust-lang/rust/issues/91401

In the bugs above, the dep-graph attempts to force a dep-node whose DefPathHash is not known to the compiler. This causes an ICE because the query that refers to this DefPathHash should have been marked red.

This PR **hides** the bug by gracefully failing to force the query when this happens. I think this is the *wrong solution* to the problem. However, this has the merit of avoiding user-visible ICEs.

The right solution would be to find where the alien DefPathHash come from and to plug the information leak. I believe https://github.com/rust-lang/rust/issues/85914 it responsible for a part.

r? @michaelwoerister 