### PR TITLE
Enable `TargetConditionals.h` on Apple platforms

### DIFF
--- a/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
@@ -1,3 +1,6 @@
+#ifdef __APPLE__
+#include <TargetConditionals.h>
+#endif
 #include <stdio.h>
 
 #include <vector>


### PR DESCRIPTION
Here a trivial but tricky fix which allows to build `llvm-wrapper` on Apple platform againsts custom LLVM.

For example MacOS' 11 SDK requires `TARGET_OS_IPHONE` to be defined when anyone is used `stdio.h`: https://github.com/phracker/MacOSX-SDKs/blob/master/MacOSX11.0.sdk/usr/include/stdio.h#L220

Without this include an attempt to compile `llvm-wrapper` fails with an error:

```
warning: /Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk/usr/include/stdio.h:220:5: error: 'TARGET_OS_EMBEDDED' is not defined, evaluates to 0 [-Werror,-Wundef-prefix=TARGET_OS_]
warning: #if TARGET_OS_EMBEDDED
warning:     ^
```

`TargetConditionals.h` exists since macOS 10.1: https://github.com/phracker/MacOSX-SDKs/blob/master/MacOSX10.1.5.sdk/usr/include/TargetConditionals.h

=> it is safe to implement on this way.