### PR TITLE
rustdoc: Add regression test for Iterator as notable trait on &T

### DIFF
--- a/src/test/rustdoc/doc-notable_trait-mut_t_is_not_ref_t.rs
+++ b/src/test/rustdoc/doc-notable_trait-mut_t_is_not_ref_t.rs
@@ -1,0 +1,21 @@
+//! Test case for [#78160].
+//!
+//! A SomeTrait that is implemented for `&mut T` should not be marked as
+//! "notable" for return values that are `&T`.
+//!
+//! [#78160]: https://github.com/rust-lang/rust/issues/78160
+
+#![feature(rustdoc_internals)]
+
+#[doc(primitive = "reference")]
+/// Some useless docs, wouhou!
+///
+/// We need to put this in here, because notable traits
+/// that are implemented on foreign types don't show up.
+mod reference {}
+
+// @has doc_notable_trait_mut_t_is_not_ref_t/fn.fn_no_matches.html
+// @!has - '//code[@class="content"]' "impl<'_, I> Iterator for &'_ mut I"
+pub fn fn_no_matches<'a, T: Iterator + 'a>() -> &'a T {
+    loop {}
+}


### PR DESCRIPTION
Closes #78160

This regression test is different from the one in #91748, because while neither of these function should have Iterator marked as a notable trait, the reasons are different.

* In this PR, it returns `&T where T: Iterator`. The `mut` is what's missing.
* In #91748, it returns `&mut T`. The trait bounds are what's missing.