### PR TITLE
Readd track_caller to Result::from_residual

### DIFF
--- a/library/core/src/result.rs
+++ b/library/core/src/result.rs
@@ -1953,6 +1953,7 @@ impl<T, E> ops::Try for Result<T, E> {
 #[unstable(feature = "try_trait_v2", issue = "84277")]
 impl<T, E, F: From<E>> ops::FromResidual<Result<convert::Infallible, E>> for Result<T, F> {
     #[inline]
+    #[track_caller]
     fn from_residual(residual: Result<convert::Infallible, E>) -> Self {
         match residual {
             Err(e) => Err(From::from(e)),

--- a/src/test/mir-opt/separate_const_switch.identity.ConstProp.diff
+++ b/src/test/mir-opt/separate_const_switch.identity.ConstProp.diff
@@ -15,7 +15,7 @@
       scope 1 {
           debug residual => _6;            // in scope 1 at $DIR/separate_const_switch.rs:29:9: 29:10
           scope 2 {
-              scope 8 (inlined <Result<i32, i32> as FromResidual<Result<Infallible, i32>>>::from_residual) { // at $DIR/separate_const_switch.rs:29:8: 29:10
+              scope 8 (inlined #[track_caller] <Result<i32, i32> as FromResidual<Result<Infallible, i32>>>::from_residual) { // at $DIR/separate_const_switch.rs:29:8: 29:10
                   debug residual => _8;    // in scope 8 at $DIR/separate_const_switch.rs:29:8: 29:10
                   let _16: i32;            // in scope 8 at $DIR/separate_const_switch.rs:29:8: 29:10
                   let mut _17: i32;        // in scope 8 at $DIR/separate_const_switch.rs:29:8: 29:10

--- a/src/test/mir-opt/separate_const_switch.identity.PreCodegen.after.mir
+++ b/src/test/mir-opt/separate_const_switch.identity.PreCodegen.after.mir
@@ -12,7 +12,7 @@ fn identity(_1: Result<i32, i32>) -> Result<i32, i32> {
     scope 1 {
         debug residual => _5;            // in scope 1 at $DIR/separate_const_switch.rs:29:9: 29:10
         scope 2 {
-            scope 8 (inlined <Result<i32, i32> as FromResidual<Result<Infallible, i32>>>::from_residual) { // at $DIR/separate_const_switch.rs:29:8: 29:10
+            scope 8 (inlined #[track_caller] <Result<i32, i32> as FromResidual<Result<Infallible, i32>>>::from_residual) { // at $DIR/separate_const_switch.rs:29:8: 29:10
                 debug residual => _6;    // in scope 8 at $DIR/separate_const_switch.rs:29:8: 29:10
                 let _14: i32;            // in scope 8 at $DIR/separate_const_switch.rs:29:8: 29:10
                 let mut _15: i32;        // in scope 8 at $DIR/separate_const_switch.rs:29:8: 29:10

--- a/src/test/mir-opt/separate_const_switch.identity.SeparateConstSwitch.diff
+++ b/src/test/mir-opt/separate_const_switch.identity.SeparateConstSwitch.diff
@@ -15,7 +15,7 @@
       scope 1 {
           debug residual => _6;            // in scope 1 at $DIR/separate_const_switch.rs:29:9: 29:10
           scope 2 {
-              scope 8 (inlined <Result<i32, i32> as FromResidual<Result<Infallible, i32>>>::from_residual) { // at $DIR/separate_const_switch.rs:29:8: 29:10
+              scope 8 (inlined #[track_caller] <Result<i32, i32> as FromResidual<Result<Infallible, i32>>>::from_residual) { // at $DIR/separate_const_switch.rs:29:8: 29:10
                   debug residual => _8;    // in scope 8 at $DIR/separate_const_switch.rs:29:8: 29:10
                   let _16: i32;            // in scope 8 at $DIR/separate_const_switch.rs:29:8: 29:10
                   let mut _17: i32;        // in scope 8 at $DIR/separate_const_switch.rs:29:8: 29:10


### PR DESCRIPTION
This is a followup on https://github.com/rust-lang/rust/issues/87401 in and an attempt to move the issue towards resolution.

As part of the overhaul of the Try trait we removed the ability for errors to grab location information during propagation via `?` with the builtin `std::result::Result`. The previously linked issue has a fair bit of discussion into the reasons for and against the usage of `#[track_caller]` on the `FromResidual` impl on `Result` that I will do my best to summarize.

---
### For

- https://github.com/rust-lang/rust/issues/87401#issuecomment-915053533: Difficulties with using non `std::result::Result` like types
- https://github.com/rust-lang/rust/issues/87401#issuecomment-978355102: Inconsistency with functionality provided for recoverable (Result) and non-recoverable errors (panic), where panic provides a location and Result does not, pushing some users towards using panic

### Against

- https://github.com/rust-lang/rust/issues/84277#issuecomment-885322833: concern that this will bloat callers that never use this data

---

Personally, I want to quantify the performance / bloat impact of re-adding this attribute, and fully evaluate the pros and cons before deciding if I need to switch `eyre` to have a custom `Result` type, which would also mean I need `try_trait_v2` to be stabilized, cc @scottmcm. If the performance impact is minor enough in the general case I think I would prefer that the default `Result` type has the ability to track location information for consistency with `panic` error reporting, and leave it to applications that need particularly high performance to handle the micro optimizations of introducing their own efficient custom Result type or matching manually.

Alternatively, I wonder if the performance penalty on code that doesn't use the location information on `FromResidual` could be mitigated via new optimizations.