### PR TITLE
Introduce `RUSTC_STATIC_CLANG_RT_PATH` and `RUSTC_STATIC_UNWIND_PATH` envs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4995,6 +4995,7 @@ version = "0.0.0"
 dependencies = [
  "addr2line",
  "alloc",
+ "build_helper",
  "cfg-if 0.1.10",
  "compiler_builtins",
  "core",
@@ -5662,6 +5663,7 @@ dependencies = [
 name = "unwind"
 version = "0.0.0"
 dependencies = [
+ "build_helper",
  "cc",
  "cfg-if 0.1.10",
  "compiler_builtins",

--- a/compiler/rustc_llvm/build.rs
+++ b/compiler/rustc_llvm/build.rs
@@ -2,7 +2,7 @@ use std::env;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use build_helper::{output, tracked_env_var_os};
+use build_helper::{maybe_static_library, output, tracked_env_var_os};
 
 fn detect_llvm_link() -> (&'static str, &'static str) {
     // Force the link mode we want, preferring static by default, but
@@ -307,4 +307,6 @@ fn main() {
     if target.contains("windows-gnu") {
         println!("cargo:rustc-link-lib=static:-bundle=pthread");
     }
+
+    maybe_static_library("RUSTC_STATIC_CLANG_RT_PATH", "clang_rt");
 }

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -84,3 +84,6 @@ heap_size = 0x8000000
 name = "stdbenches"
 path = "benches/lib.rs"
 test = true
+
+[build-dependencies]
+build_helper = { path = "../../src/build_helper" }

--- a/library/std/build.rs
+++ b/library/std/build.rs
@@ -1,5 +1,7 @@
 use std::env;
 
+use build_helper::maybe_static_library;
+
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
     let target = env::var("TARGET").expect("TARGET was not set");
@@ -47,4 +49,6 @@ fn main() {
     }
     println!("cargo:rustc-env=STD_ENV_ARCH={}", env::var("CARGO_CFG_TARGET_ARCH").unwrap());
     println!("cargo:rustc-cfg=backtrace_in_libstd");
+
+    maybe_static_library("RUSTC_STATIC_CLANG_RT_PATH", "clang_rt");
 }

--- a/library/unwind/Cargo.toml
+++ b/library/unwind/Cargo.toml
@@ -20,6 +20,7 @@ compiler_builtins = "0.1.0"
 cfg-if = "0.1.8"
 
 [build-dependencies]
+build_helper = { path = "../../src/build_helper" }
 cc = "1.0.69"
 
 [features]

--- a/library/unwind/build.rs
+++ b/library/unwind/build.rs
@@ -1,8 +1,14 @@
 use std::env;
 
+use build_helper::maybe_static_library;
+
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
     let target = env::var("TARGET").expect("TARGET was not set");
+
+    if maybe_static_library("RUSTC_STATIC_UNWIND_PATH", "unwind") {
+        return;
+    }
 
     if target.contains("android") {
         let build = cc::Build::new();


### PR DESCRIPTION
The goal of this envirements variable is easy statically link `libclang_rt` or `libunwind` into rust.

It also introduces a way to easy extend rust build in a way which allows to inject more static builds for some rare system if it required.

It haven't been documented because it seems as very deep hack and the user who needs it will discover this hack by reading sources ;)

Closes: https://github.com/rust-lang/rust/issues/59164