### PR TITLE
Tweak assoc type obligation spans

### DIFF
--- a/compiler/rustc_infer/src/infer/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/mod.rs
@@ -1429,6 +1429,15 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
         }
     }
 
+    /// Extend a type error with extra labels pointing at "non-trivial" types, like closures and
+    /// the return type of `async fn`s.
+    ///
+    /// `secondary_span` gives the caller the opportunity to expand `diag` with a `span_label`.
+    ///
+    /// `swap_secondary_and_primary` is used to make projection errors in particular nicer by using
+    /// the message in `secondary_span` as the primary label, and apply the message that would
+    /// otherwise be used for the primary label on the `secondary_span` `Span`. This applies on
+    /// E0271, like `src/test/ui/issues/issue-39970.stderr`.
     pub fn note_type_err(
         &self,
         diag: &mut DiagnosticBuilder<'tcx>,
@@ -1436,6 +1445,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
         secondary_span: Option<(Span, String)>,
         mut values: Option<ValuePairs<'tcx>>,
         terr: &TypeError<'tcx>,
+        swap_secondary_and_primary: bool,
     ) {
         let span = cause.span(self.tcx);
         debug!("note_type_err cause={:?} values={:?}, terr={:?}", cause, values, terr);
@@ -1612,9 +1622,32 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
         match terr {
             TypeError::ObjectUnsafeCoercion(_) => {}
             _ => {
-                diag.span_label(span, terr.to_string());
+                let mut label_or_note = |span: Span, msg: &str| {
+                    if &[span] == diag.span.primary_spans() {
+                        diag.span_label(span, msg);
+                    } else {
+                        diag.span_note(span, msg);
+                    }
+                };
                 if let Some((sp, msg)) = secondary_span {
-                    diag.span_label(sp, msg);
+                    if swap_secondary_and_primary {
+                        let terr = if let Some(infer::ValuePairs::Types(infer::ExpectedFound {
+                            expected,
+                            ..
+                        })) = values
+                        {
+                            format!("expected this to be `{}`", expected)
+                        } else {
+                            terr.to_string()
+                        };
+                        label_or_note(sp, &terr);
+                        label_or_note(span, &msg);
+                    } else {
+                        label_or_note(span, &terr.to_string());
+                        label_or_note(sp, &msg);
+                    }
+                } else {
+                    label_or_note(span, &terr.to_string());
                 }
             }
         };
@@ -2048,7 +2081,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 struct_span_err!(self.tcx.sess, span, E0644, "{}", failure_str)
             }
         };
-        self.note_type_err(&mut diag, &trace.cause, None, Some(trace.values), terr);
+        self.note_type_err(&mut diag, &trace.cause, None, Some(trace.values), terr, false);
         diag
     }
 

--- a/compiler/rustc_middle/src/ty/error.rs
+++ b/compiler/rustc_middle/src/ty/error.rs
@@ -118,8 +118,7 @@ impl<'tcx> fmt::Display for TypeError<'tcx> {
             ArgumentMutability(_) | Mutability => write!(f, "types differ in mutability"),
             TupleSize(values) => write!(
                 f,
-                "expected a tuple with {} element{}, \
-                           found one with {} element{}",
+                "expected a tuple with {} element{}, found one with {} element{}",
                 values.expected,
                 pluralize!(values.expected),
                 values.found,
@@ -127,8 +126,7 @@ impl<'tcx> fmt::Display for TypeError<'tcx> {
             ),
             FixedArraySize(values) => write!(
                 f,
-                "expected an array with a fixed size of {} element{}, \
-                           found one with {} element{}",
+                "expected an array with a fixed size of {} element{}, found one with {} element{}",
                 values.expected,
                 pluralize!(values.expected),
                 values.found,

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
@@ -1338,7 +1338,46 @@ impl<'a, 'tcx> InferCtxtPrivExt<'tcx> for InferCtxt<'a, 'tcx> {
                     "type mismatch resolving `{}`",
                     predicate
                 );
-                self.note_type_err(&mut diag, &obligation.cause, None, values, err);
+                let secondary_span = match predicate.kind().skip_binder() {
+                    ty::PredicateKind::Projection(proj) => self
+                        .tcx
+                        .opt_associated_item(proj.projection_ty.item_def_id)
+                        .and_then(|trait_assoc_item| {
+                            self.tcx
+                                .trait_of_item(proj.projection_ty.item_def_id)
+                                .map(|id| (trait_assoc_item, id))
+                        })
+                        .and_then(|(trait_assoc_item, id)| {
+                            self.tcx.find_map_relevant_impl(
+                                id,
+                                proj.projection_ty.self_ty(),
+                                |did| {
+                                    self.tcx
+                                        .associated_items(did)
+                                        .in_definition_order()
+                                        .filter(|assoc| assoc.ident == trait_assoc_item.ident)
+                                        .next()
+                                },
+                            )
+                        })
+                        .and_then(|item| match self.tcx.hir().get_if_local(item.def_id) {
+                            Some(
+                                hir::Node::TraitItem(hir::TraitItem {
+                                    kind: hir::TraitItemKind::Type(_, Some(ty)),
+                                    ..
+                                })
+                                | hir::Node::ImplItem(hir::ImplItem {
+                                    kind: hir::ImplItemKind::TyAlias(ty),
+                                    ..
+                                }),
+                            ) => {
+                                Some((ty.span, format!("type mismatch resolving `{}`", predicate)))
+                            }
+                            _ => None,
+                        }),
+                    _ => None,
+                };
+                self.note_type_err(&mut diag, &obligation.cause, secondary_span, values, err, true);
                 self.note_obligation_cause(&mut diag, obligation);
                 diag.emit();
             }
@@ -2095,9 +2134,20 @@ impl<'a, 'tcx> InferCtxtPrivExt<'tcx> for InferCtxt<'a, 'tcx> {
     ) -> bool {
         if let ObligationCauseCode::BuiltinDerivedObligation(ref data) = cause_code {
             let parent_trait_ref = self.resolve_vars_if_possible(data.parent_trait_ref);
-
-            if obligated_types.iter().any(|ot| ot == &parent_trait_ref.skip_binder().self_ty()) {
+            let self_ty = parent_trait_ref.skip_binder().self_ty();
+            if obligated_types.iter().any(|ot| ot == &self_ty) {
                 return true;
+            }
+            if let ty::Adt(def, substs) = self_ty.kind() {
+                if let [arg] = &substs[..] {
+                    if let ty::subst::GenericArgKind::Type(ty) = arg.unpack() {
+                        if let ty::Adt(inner_def, _) = ty.kind() {
+                            if inner_def == def {
+                                return true;
+                            }
+                        }
+                    }
+                }
             }
         }
         false

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -2186,6 +2186,16 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                             seen_requirements,
                         )
                     });
+                } else {
+                    ensure_sufficient_stack(|| {
+                        self.note_obligation_cause_code(
+                            err,
+                            &parent_predicate,
+                            &cause_code.peel_derives(),
+                            obligated_types,
+                            seen_requirements,
+                        )
+                    });
                 }
             }
             ObligationCauseCode::ImplDerivedObligation(ref data) => {

--- a/compiler/rustc_typeck/src/check/cast.rs
+++ b/compiler/rustc_typeck/src/check/cast.rs
@@ -638,7 +638,11 @@ impl<'a, 'tcx> CastCheck<'tcx> {
         self.expr_ty = fcx.structurally_resolved_type(self.expr.span, self.expr_ty);
         self.cast_ty = fcx.structurally_resolved_type(self.cast_span, self.cast_ty);
 
-        if !fcx.type_is_known_to_be_sized_modulo_regions(self.cast_ty, self.span) {
+        debug!("check_cast({}, {:?} as {:?})", self.expr.hir_id, self.expr_ty, self.cast_ty);
+
+        if !fcx.type_is_known_to_be_sized_modulo_regions(self.cast_ty, self.span)
+            && !self.cast_ty.has_infer_types()
+        {
             self.report_cast_to_unsized_type(fcx);
         } else if self.expr_ty.references_error() || self.cast_ty.references_error() {
             // No sense in giving duplicate error messages

--- a/compiler/rustc_typeck/src/check/check.rs
+++ b/compiler/rustc_typeck/src/check/check.rs
@@ -730,7 +730,7 @@ pub fn check_item_type<'tcx>(tcx: TyCtxt<'tcx>, it: &'tcx hir::Item<'tcx>) {
                         let abi = sig.header.abi;
                         fn_maybe_err(tcx, item.ident.span, abi);
                     }
-                    hir::TraitItemKind::Type(.., Some(_default)) => {
+                    hir::TraitItemKind::Type(.., Some(default)) => {
                         let assoc_item = tcx.associated_item(item.def_id);
                         let trait_substs =
                             InternalSubsts::identity_for_item(tcx, it.def_id.to_def_id());
@@ -738,7 +738,7 @@ pub fn check_item_type<'tcx>(tcx: TyCtxt<'tcx>, it: &'tcx hir::Item<'tcx>) {
                             tcx,
                             assoc_item,
                             assoc_item,
-                            item.span,
+                            default.span,
                             ty::TraitRef { def_id: it.def_id.to_def_id(), substs: trait_substs },
                         );
                     }
@@ -987,12 +987,12 @@ pub(super) fn check_impl_items_against_trait<'tcx>(
                         opt_trait_span,
                     );
                 }
-                hir::ImplItemKind::TyAlias(_) => {
+                hir::ImplItemKind::TyAlias(impl_ty) => {
                     let opt_trait_span = tcx.hir().span_if_local(ty_trait_item.def_id);
                     compare_ty_impl(
                         tcx,
                         &ty_impl_item,
-                        impl_item.span,
+                        impl_ty.span,
                         &ty_trait_item,
                         impl_trait_ref,
                         opt_trait_span,

--- a/compiler/rustc_typeck/src/check/compare_method.rs
+++ b/compiler/rustc_typeck/src/check/compare_method.rs
@@ -379,6 +379,7 @@ fn compare_predicate_entailment<'tcx>(
                     found: impl_fty,
                 })),
                 &terr,
+                false,
             );
             diag.emit();
             return Err(ErrorReported);
@@ -734,8 +735,7 @@ fn compare_number_of_method_arguments<'tcx>(
             tcx.sess,
             impl_span,
             E0050,
-            "method `{}` has {} but the declaration in \
-                                        trait `{}` has {}",
+            "method `{}` has {} but the declaration in trait `{}` has {}",
             trait_m.ident,
             potentially_plural_count(impl_number_args, "parameter"),
             tcx.def_path_str(trait_m.def_id),
@@ -1069,6 +1069,7 @@ crate fn compare_const_impl<'tcx>(
                     found: impl_ty,
                 })),
                 &terr,
+                false,
             );
             diag.emit();
         }
@@ -1099,7 +1100,8 @@ crate fn compare_ty_impl<'tcx>(
     let _: Result<(), ErrorReported> = (|| {
         compare_number_of_generics(tcx, impl_ty, impl_ty_span, trait_ty, trait_item_span)?;
 
-        compare_type_predicate_entailment(tcx, impl_ty, impl_ty_span, trait_ty, impl_trait_ref)?;
+        let sp = tcx.def_span(impl_ty.def_id);
+        compare_type_predicate_entailment(tcx, impl_ty, sp, trait_ty, impl_trait_ref)?;
 
         check_type_bounds(tcx, trait_ty, impl_ty, impl_ty_span, impl_trait_ref)
     })();

--- a/compiler/rustc_typeck/src/check/wfcheck.rs
+++ b/compiler/rustc_typeck/src/check/wfcheck.rs
@@ -683,7 +683,8 @@ pub fn check_impl_item(tcx: TyCtxt<'_>, def_id: LocalDefId) {
 
     let (method_sig, span) = match impl_item.kind {
         hir::ImplItemKind::Fn(ref sig, _) => (Some(sig), impl_item.span),
-        hir::ImplItemKind::TyAlias(ty) => (None, ty.span),
+        // Constrain binding and overflow error spans to `<Ty>` in `type foo = <Ty>`.
+        hir::ImplItemKind::TyAlias(ty) if ty.span != DUMMY_SP => (None, ty.span),
         _ => (None, impl_item.span),
     };
 

--- a/src/test/ui/associated-consts/associated-const-generic-obligations.stderr
+++ b/src/test/ui/associated-consts/associated-const-generic-obligations.stderr
@@ -1,12 +1,14 @@
 error[E0326]: implemented const `FROM` has an incompatible type for trait
   --> $DIR/associated-const-generic-obligations.rs:14:17
    |
-LL |     const FROM: Self::Out;
-   |                 --------- type in trait
-...
 LL |     const FROM: &'static str = "foo";
    |                 ^^^^^^^^^^^^ expected associated type, found `&str`
    |
+note: type in trait
+  --> $DIR/associated-const-generic-obligations.rs:10:17
+   |
+LL |     const FROM: Self::Out;
+   |                 ^^^^^^^^^
    = note: expected associated type `<T as Foo>::Out`
                     found reference `&'static str`
 

--- a/src/test/ui/associated-consts/associated-const-impl-wrong-type.stderr
+++ b/src/test/ui/associated-consts/associated-const-impl-wrong-type.stderr
@@ -1,11 +1,14 @@
 error[E0326]: implemented const `BAR` has an incompatible type for trait
   --> $DIR/associated-const-impl-wrong-type.rs:8:16
    |
-LL |     const BAR: u32;
-   |                --- type in trait
-...
 LL |     const BAR: i32 = -1;
    |                ^^^ expected `u32`, found `i32`
+   |
+note: type in trait
+  --> $DIR/associated-const-impl-wrong-type.rs:2:16
+   |
+LL |     const BAR: u32;
+   |                ^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/associated-types/associated-types-binding-to-type-defined-in-supertrait.stderr
+++ b/src/test/ui/associated-types/associated-types-binding-to-type-defined-in-supertrait.stderr
@@ -2,8 +2,13 @@ error[E0271]: type mismatch resolving `<ModelT as Vehicle>::Color == Blue`
   --> $DIR/associated-types-binding-to-type-defined-in-supertrait.rs:31:10
    |
 LL | fn b() { blue_car(ModelT); }
-   |          ^^^^^^^^ expected struct `Blue`, found struct `Black`
+   |          ^^^^^^^^ type mismatch resolving `<ModelT as Vehicle>::Color == Blue`
    |
+note: expected this to be `Blue`
+  --> $DIR/associated-types-binding-to-type-defined-in-supertrait.rs:16:40
+   |
+LL | impl Vehicle for ModelT { type Color = Black; }
+   |                                        ^^^^^
 note: required by a bound in `blue_car`
   --> $DIR/associated-types-binding-to-type-defined-in-supertrait.rs:27:19
    |
@@ -14,8 +19,13 @@ error[E0271]: type mismatch resolving `<ModelU as Vehicle>::Color == Black`
   --> $DIR/associated-types-binding-to-type-defined-in-supertrait.rs:32:10
    |
 LL | fn c() { black_car(ModelU); }
-   |          ^^^^^^^^^ expected struct `Black`, found struct `Blue`
+   |          ^^^^^^^^^ type mismatch resolving `<ModelU as Vehicle>::Color == Black`
    |
+note: expected this to be `Black`
+  --> $DIR/associated-types-binding-to-type-defined-in-supertrait.rs:21:40
+   |
+LL | impl Vehicle for ModelU { type Color = Blue; }
+   |                                        ^^^^
 note: required by a bound in `black_car`
   --> $DIR/associated-types-binding-to-type-defined-in-supertrait.rs:24:20
    |

--- a/src/test/ui/associated-types/associated-types-eq-3.rs
+++ b/src/test/ui/associated-types/associated-types-eq-3.rs
@@ -37,8 +37,6 @@ pub fn main() {
     let a = 42;
     foo1(a);
     //~^ ERROR type mismatch resolving
-    //~| expected struct `Bar`, found `usize`
     baz(&a);
     //~^ ERROR type mismatch resolving
-    //~| expected struct `Bar`, found `usize`
 }

--- a/src/test/ui/associated-types/associated-types-eq-3.stderr
+++ b/src/test/ui/associated-types/associated-types-eq-3.stderr
@@ -17,8 +17,13 @@ error[E0271]: type mismatch resolving `<isize as Foo>::A == Bar`
   --> $DIR/associated-types-eq-3.rs:38:5
    |
 LL |     foo1(a);
-   |     ^^^^ expected struct `Bar`, found `usize`
+   |     ^^^^ type mismatch resolving `<isize as Foo>::A == Bar`
    |
+note: expected this to be `Bar`
+  --> $DIR/associated-types-eq-3.rs:12:14
+   |
+LL |     type A = usize;
+   |              ^^^^^
 note: required by a bound in `foo1`
   --> $DIR/associated-types-eq-3.rs:18:16
    |
@@ -26,11 +31,16 @@ LL | fn foo1<I: Foo<A=Bar>>(x: I) {
    |                ^^^^^ required by this bound in `foo1`
 
 error[E0271]: type mismatch resolving `<isize as Foo>::A == Bar`
-  --> $DIR/associated-types-eq-3.rs:41:9
+  --> $DIR/associated-types-eq-3.rs:40:9
    |
 LL |     baz(&a);
-   |         ^^ expected struct `Bar`, found `usize`
+   |         ^^ type mismatch resolving `<isize as Foo>::A == Bar`
    |
+note: expected this to be `Bar`
+  --> $DIR/associated-types-eq-3.rs:12:14
+   |
+LL |     type A = usize;
+   |              ^^^^^
    = note: required for the cast to the object type `dyn Foo<A = Bar>`
 
 error: aborting due to 3 previous errors

--- a/src/test/ui/associated-types/associated-types-eq-hr.nll.stderr
+++ b/src/test/ui/associated-types/associated-types-eq-hr.nll.stderr
@@ -2,8 +2,13 @@ error[E0271]: type mismatch resolving `for<'x> <UintStruct as TheTrait<&'x isize
   --> $DIR/associated-types-eq-hr.rs:87:5
    |
 LL |     foo::<UintStruct>();
-   |     ^^^^^^^^^^^^^^^^^ expected `isize`, found `usize`
+   |     ^^^^^^^^^^^^^^^^^ type mismatch resolving `for<'x> <UintStruct as TheTrait<&'x isize>>::A == &'x isize`
    |
+note: expected this to be `&isize`
+  --> $DIR/associated-types-eq-hr.rs:26:14
+   |
+LL |     type A = &'a usize;
+   |              ^^^^^^^^^
    = note: expected reference `&isize`
               found reference `&usize`
 note: required by a bound in `foo`
@@ -19,8 +24,13 @@ error[E0271]: type mismatch resolving `for<'x> <IntStruct as TheTrait<&'x isize>
   --> $DIR/associated-types-eq-hr.rs:91:5
    |
 LL |     bar::<IntStruct>();
-   |     ^^^^^^^^^^^^^^^^ expected `usize`, found `isize`
+   |     ^^^^^^^^^^^^^^^^ type mismatch resolving `for<'x> <IntStruct as TheTrait<&'x isize>>::A == &'x usize`
    |
+note: expected this to be `&usize`
+  --> $DIR/associated-types-eq-hr.rs:14:14
+   |
+LL |     type A = &'a isize;
+   |              ^^^^^^^^^
    = note: expected reference `&usize`
               found reference `&isize`
 note: required by a bound in `bar`

--- a/src/test/ui/associated-types/associated-types-eq-hr.stderr
+++ b/src/test/ui/associated-types/associated-types-eq-hr.stderr
@@ -2,8 +2,13 @@ error[E0271]: type mismatch resolving `for<'x> <UintStruct as TheTrait<&'x isize
   --> $DIR/associated-types-eq-hr.rs:87:5
    |
 LL |     foo::<UintStruct>();
-   |     ^^^^^^^^^^^^^^^^^ expected `isize`, found `usize`
+   |     ^^^^^^^^^^^^^^^^^ type mismatch resolving `for<'x> <UintStruct as TheTrait<&'x isize>>::A == &'x isize`
    |
+note: expected this to be `&isize`
+  --> $DIR/associated-types-eq-hr.rs:26:14
+   |
+LL |     type A = &'a usize;
+   |              ^^^^^^^^^
    = note: expected reference `&isize`
               found reference `&usize`
 note: required by a bound in `foo`
@@ -19,8 +24,13 @@ error[E0271]: type mismatch resolving `for<'x> <IntStruct as TheTrait<&'x isize>
   --> $DIR/associated-types-eq-hr.rs:91:5
    |
 LL |     bar::<IntStruct>();
-   |     ^^^^^^^^^^^^^^^^ expected `usize`, found `isize`
+   |     ^^^^^^^^^^^^^^^^ type mismatch resolving `for<'x> <IntStruct as TheTrait<&'x isize>>::A == &'x usize`
    |
+note: expected this to be `&usize`
+  --> $DIR/associated-types-eq-hr.rs:14:14
+   |
+LL |     type A = &'a isize;
+   |              ^^^^^^^^^
    = note: expected reference `&usize`
               found reference `&isize`
 note: required by a bound in `bar`

--- a/src/test/ui/associated-types/associated-types-issue-20346.stderr
+++ b/src/test/ui/associated-types/associated-types-issue-20346.stderr
@@ -5,8 +5,13 @@ LL | fn test_adapter<T, I: Iterator<Item=Option<T>>>(it: I) {
    |                 - this type parameter
 ...
 LL |     is_iterator_of::<Option<T>, _>(&adapter);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected enum `Option`, found type parameter `T`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type mismatch resolving `<Adapter<I> as Iterator>::Item == Option<T>`
    |
+note: expected this to be `Option<T>`
+  --> $DIR/associated-types-issue-20346.rs:23:17
+   |
+LL |     type Item = T;
+   |                 ^
    = note: expected enum `Option<T>`
               found type `T`
 note: required by a bound in `is_iterator_of`

--- a/src/test/ui/associated-types/defaults-specialization.stderr
+++ b/src/test/ui/associated-types/defaults-specialization.stderr
@@ -11,24 +11,23 @@ LL | #![feature(associated_type_defaults, specialization)]
 error[E0053]: method `make` has an incompatible type for trait
   --> $DIR/defaults-specialization.rs:19:18
    |
-LL |     fn make() -> Self::Ty {
-   |                  -------- type in trait
-...
 LL |     fn make() -> u8 { 0 }
    |                  ^^
    |                  |
    |                  expected associated type, found `u8`
    |                  help: change the output type to match the trait: `<A<T> as Tr>::Ty`
    |
+note: type in trait
+  --> $DIR/defaults-specialization.rs:9:18
+   |
+LL |     fn make() -> Self::Ty {
+   |                  ^^^^^^^^
    = note: expected fn pointer `fn() -> <A<T> as Tr>::Ty`
               found fn pointer `fn() -> u8`
 
 error[E0053]: method `make` has an incompatible type for trait
   --> $DIR/defaults-specialization.rs:35:18
    |
-LL |     fn make() -> Self::Ty {
-   |                  -------- type in trait
-...
 LL |     default type Ty = bool;
    |     ----------------------- expected this associated type
 LL | 
@@ -38,6 +37,11 @@ LL |     fn make() -> bool { true }
    |                  expected associated type, found `bool`
    |                  help: change the output type to match the trait: `<B<T> as Tr>::Ty`
    |
+note: type in trait
+  --> $DIR/defaults-specialization.rs:9:18
+   |
+LL |     fn make() -> Self::Ty {
+   |                  ^^^^^^^^
    = note: expected fn pointer `fn() -> <B<T> as Tr>::Ty`
               found fn pointer `fn() -> bool`
 

--- a/src/test/ui/associated-types/defaults-suitability.stderr
+++ b/src/test/ui/associated-types/defaults-suitability.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the trait bound `NotClone: Clone` is not satisfied
-  --> $DIR/defaults-suitability.rs:13:5
+  --> $DIR/defaults-suitability.rs:13:22
    |
 LL |     type Ty: Clone = NotClone;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `NotClone`
+   |                      ^^^^^^^^ the trait `Clone` is not implemented for `NotClone`
    |
 note: required by a bound in `Tr::Ty`
   --> $DIR/defaults-suitability.rs:13:14
@@ -11,10 +11,10 @@ LL |     type Ty: Clone = NotClone;
    |              ^^^^^ required by this bound in `Tr::Ty`
 
 error[E0277]: the trait bound `NotClone: Clone` is not satisfied
-  --> $DIR/defaults-suitability.rs:22:5
+  --> $DIR/defaults-suitability.rs:22:15
    |
 LL |     type Ty = NotClone;
-   |     ^^^^^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `NotClone`
+   |               ^^^^^^^^ the trait `Clone` is not implemented for `NotClone`
    |
 note: required by a bound in `Tr2::Ty`
   --> $DIR/defaults-suitability.rs:20:15
@@ -26,10 +26,10 @@ LL |     type Ty = NotClone;
    |          -- required by a bound in this
 
 error[E0277]: the trait bound `T: Clone` is not satisfied
-  --> $DIR/defaults-suitability.rs:28:5
+  --> $DIR/defaults-suitability.rs:28:23
    |
 LL |     type Bar: Clone = Vec<T>;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `T`
+   |                       ^^^^^^ the trait `Clone` is not implemented for `T`
    |
    = note: required because of the requirements on the impl of `Clone` for `Vec<T>`
 note: required by a bound in `Foo::Bar`
@@ -43,10 +43,10 @@ LL | trait Foo<T: std::clone::Clone> {
    |            +++++++++++++++++++
 
 error[E0277]: the trait bound `(): Foo<Self>` is not satisfied
-  --> $DIR/defaults-suitability.rs:34:5
+  --> $DIR/defaults-suitability.rs:34:29
    |
 LL |     type Assoc: Foo<Self> = ();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Foo<Self>` is not implemented for `()`
+   |                             ^^ the trait `Foo<Self>` is not implemented for `()`
    |
 note: required by a bound in `Bar::Assoc`
   --> $DIR/defaults-suitability.rs:34:17
@@ -55,10 +55,10 @@ LL |     type Assoc: Foo<Self> = ();
    |                 ^^^^^^^^^ required by this bound in `Bar::Assoc`
 
 error[E0277]: the trait bound `NotClone: IsU8<NotClone>` is not satisfied
-  --> $DIR/defaults-suitability.rs:56:5
+  --> $DIR/defaults-suitability.rs:56:18
    |
 LL |     type Assoc = NotClone;
-   |     ^^^^^^^^^^^^^^^^^^^^^^ the trait `IsU8<NotClone>` is not implemented for `NotClone`
+   |                  ^^^^^^^^ the trait `IsU8<NotClone>` is not implemented for `NotClone`
    |
 note: required by a bound in `D::Assoc`
   --> $DIR/defaults-suitability.rs:53:18
@@ -70,10 +70,10 @@ LL |     type Assoc = NotClone;
    |          ----- required by a bound in this
 
 error[E0277]: the trait bound `<Self as Foo2<T>>::Baz: Clone` is not satisfied
-  --> $DIR/defaults-suitability.rs:65:5
+  --> $DIR/defaults-suitability.rs:65:23
    |
 LL |     type Bar: Clone = Vec<Self::Baz>;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `<Self as Foo2<T>>::Baz`
+   |                       ^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `<Self as Foo2<T>>::Baz`
    |
    = note: required because of the requirements on the impl of `Clone` for `Vec<<Self as Foo2<T>>::Baz>`
 note: required by a bound in `Foo2::Bar`
@@ -87,10 +87,10 @@ LL | trait Foo2<T> where <Self as Foo2<T>>::Baz: Clone {
    |               +++++++++++++++++++++++++++++++++++
 
 error[E0277]: the trait bound `<Self as Foo25<T>>::Baz: Clone` is not satisfied
-  --> $DIR/defaults-suitability.rs:74:5
+  --> $DIR/defaults-suitability.rs:74:23
    |
 LL |     type Bar: Clone = Vec<Self::Baz>;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `<Self as Foo25<T>>::Baz`
+   |                       ^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `<Self as Foo25<T>>::Baz`
    |
    = note: required because of the requirements on the impl of `Clone` for `Vec<<Self as Foo25<T>>::Baz>`
 note: required by a bound in `Foo25::Bar`
@@ -104,10 +104,10 @@ LL | trait Foo25<T: Clone> where <Self as Foo25<T>>::Baz: Clone {
    |                       ++++++++++++++++++++++++++++++++++++
 
 error[E0277]: the trait bound `T: Clone` is not satisfied
-  --> $DIR/defaults-suitability.rs:87:5
+  --> $DIR/defaults-suitability.rs:87:16
    |
 LL |     type Baz = T;
-   |     ^^^^^^^^^^^^^ the trait `Clone` is not implemented for `T`
+   |                ^ the trait `Clone` is not implemented for `T`
    |
 note: required by a bound in `Foo3::Baz`
   --> $DIR/defaults-suitability.rs:84:16

--- a/src/test/ui/associated-types/defaults-unsound-62211-1.stderr
+++ b/src/test/ui/associated-types/defaults-unsound-62211-1.stderr
@@ -1,8 +1,8 @@
 error[E0277]: `Self` doesn't implement `std::fmt::Display`
-  --> $DIR/defaults-unsound-62211-1.rs:20:5
+  --> $DIR/defaults-unsound-62211-1.rs:20:96
    |
 LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Self` cannot be formatted with the default formatter
+   |                                                                                                ^^^^ `Self` cannot be formatted with the default formatter
    |
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
 note: required by a bound in `UncheckedCopy::Output`
@@ -16,10 +16,10 @@ LL | trait UncheckedCopy: Sized + std::fmt::Display {
    |                            +++++++++++++++++++
 
 error[E0277]: cannot add-assign `&'static str` to `Self`
-  --> $DIR/defaults-unsound-62211-1.rs:20:5
+  --> $DIR/defaults-unsound-62211-1.rs:20:96
    |
 LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no implementation for `Self += &'static str`
+   |                                                                                                ^^^^ no implementation for `Self += &'static str`
    |
 note: required by a bound in `UncheckedCopy::Output`
   --> $DIR/defaults-unsound-62211-1.rs:20:47
@@ -32,10 +32,10 @@ LL | trait UncheckedCopy: Sized + AddAssign<&'static str> {
    |                            +++++++++++++++++++++++++
 
 error[E0277]: the trait bound `Self: Deref` is not satisfied
-  --> $DIR/defaults-unsound-62211-1.rs:20:5
+  --> $DIR/defaults-unsound-62211-1.rs:20:96
    |
 LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Deref` is not implemented for `Self`
+   |                                                                                                ^^^^ the trait `Deref` is not implemented for `Self`
    |
 note: required by a bound in `UncheckedCopy::Output`
   --> $DIR/defaults-unsound-62211-1.rs:20:25
@@ -48,10 +48,10 @@ LL | trait UncheckedCopy: Sized + Deref {
    |                            +++++++
 
 error[E0277]: the trait bound `Self: Copy` is not satisfied
-  --> $DIR/defaults-unsound-62211-1.rs:20:5
+  --> $DIR/defaults-unsound-62211-1.rs:20:96
    |
 LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `Self`
+   |                                                                                                ^^^^ the trait `Copy` is not implemented for `Self`
    |
 note: required by a bound in `UncheckedCopy::Output`
   --> $DIR/defaults-unsound-62211-1.rs:20:18

--- a/src/test/ui/associated-types/defaults-unsound-62211-2.stderr
+++ b/src/test/ui/associated-types/defaults-unsound-62211-2.stderr
@@ -1,8 +1,8 @@
 error[E0277]: `Self` doesn't implement `std::fmt::Display`
-  --> $DIR/defaults-unsound-62211-2.rs:20:5
+  --> $DIR/defaults-unsound-62211-2.rs:20:96
    |
 LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Self` cannot be formatted with the default formatter
+   |                                                                                                ^^^^ `Self` cannot be formatted with the default formatter
    |
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
 note: required by a bound in `UncheckedCopy::Output`
@@ -16,10 +16,10 @@ LL | trait UncheckedCopy: Sized + std::fmt::Display {
    |                            +++++++++++++++++++
 
 error[E0277]: cannot add-assign `&'static str` to `Self`
-  --> $DIR/defaults-unsound-62211-2.rs:20:5
+  --> $DIR/defaults-unsound-62211-2.rs:20:96
    |
 LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no implementation for `Self += &'static str`
+   |                                                                                                ^^^^ no implementation for `Self += &'static str`
    |
 note: required by a bound in `UncheckedCopy::Output`
   --> $DIR/defaults-unsound-62211-2.rs:20:47
@@ -32,10 +32,10 @@ LL | trait UncheckedCopy: Sized + AddAssign<&'static str> {
    |                            +++++++++++++++++++++++++
 
 error[E0277]: the trait bound `Self: Deref` is not satisfied
-  --> $DIR/defaults-unsound-62211-2.rs:20:5
+  --> $DIR/defaults-unsound-62211-2.rs:20:96
    |
 LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Deref` is not implemented for `Self`
+   |                                                                                                ^^^^ the trait `Deref` is not implemented for `Self`
    |
 note: required by a bound in `UncheckedCopy::Output`
   --> $DIR/defaults-unsound-62211-2.rs:20:25
@@ -48,10 +48,10 @@ LL | trait UncheckedCopy: Sized + Deref {
    |                            +++++++
 
 error[E0277]: the trait bound `Self: Copy` is not satisfied
-  --> $DIR/defaults-unsound-62211-2.rs:20:5
+  --> $DIR/defaults-unsound-62211-2.rs:20:96
    |
 LL |     type Output: Copy + Deref<Target = str> + AddAssign<&'static str> + From<Self> + Display = Self;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `Self`
+   |                                                                                                ^^^^ the trait `Copy` is not implemented for `Self`
    |
 note: required by a bound in `UncheckedCopy::Output`
   --> $DIR/defaults-unsound-62211-2.rs:20:18

--- a/src/test/ui/associated-types/issue-43784-associated-type.stderr
+++ b/src/test/ui/associated-types/issue-43784-associated-type.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the trait bound `T: Copy` is not satisfied
-  --> $DIR/issue-43784-associated-type.rs:14:5
+  --> $DIR/issue-43784-associated-type.rs:14:18
    |
 LL |     type Assoc = T;
-   |     ^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `T`
+   |                  ^ the trait `Copy` is not implemented for `T`
    |
 note: required by a bound in `Complete::Assoc`
   --> $DIR/issue-43784-associated-type.rs:5:17

--- a/src/test/ui/associated-types/issue-43924.stderr
+++ b/src/test/ui/associated-types/issue-43924.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the trait bound `(dyn ToString + 'static): Default` is not satisfied
-  --> $DIR/issue-43924.rs:7:5
+  --> $DIR/issue-43924.rs:7:45
    |
 LL |     type Out: Default + ToString + ?Sized = dyn ToString;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Default` is not implemented for `(dyn ToString + 'static)`
+   |                                             ^^^^^^^^^^^^ the trait `Default` is not implemented for `(dyn ToString + 'static)`
    |
 note: required by a bound in `Foo::Out`
   --> $DIR/issue-43924.rs:7:15

--- a/src/test/ui/associated-types/issue-44153.stderr
+++ b/src/test/ui/associated-types/issue-44153.stderr
@@ -2,8 +2,13 @@ error[E0271]: type mismatch resolving `<() as Array>::Element == &()`
   --> $DIR/issue-44153.rs:18:5
    |
 LL |     <() as Visit>::visit();
-   |     ^^^^^^^^^^^^^^^^^^^^ expected `&()`, found `()`
+   |     ^^^^^^^^^^^^^^^^^^^^ type mismatch resolving `<() as Array>::Element == &()`
    |
+note: expected this to be `&()`
+  --> $DIR/issue-44153.rs:10:20
+   |
+LL |     type Element = ();
+   |                    ^^
 note: required because of the requirements on the impl of `Visit` for `()`
   --> $DIR/issue-44153.rs:13:10
    |

--- a/src/test/ui/associated-types/issue-54108.stderr
+++ b/src/test/ui/associated-types/issue-54108.stderr
@@ -1,8 +1,8 @@
 error[E0277]: cannot add `<T as SubEncoder>::ActualSize` to `<T as SubEncoder>::ActualSize`
-  --> $DIR/issue-54108.rs:19:5
+  --> $DIR/issue-54108.rs:19:17
    |
 LL |     type Size = <Self as SubEncoder>::ActualSize;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no implementation for `<T as SubEncoder>::ActualSize + <T as SubEncoder>::ActualSize`
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no implementation for `<T as SubEncoder>::ActualSize + <T as SubEncoder>::ActualSize`
    |
    = help: the trait `Add` is not implemented for `<T as SubEncoder>::ActualSize`
 note: required by a bound in `Encoder::Size`

--- a/src/test/ui/associated-types/issue-63593.stderr
+++ b/src/test/ui/associated-types/issue-63593.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the size for values of type `Self` cannot be known at compilation time
-  --> $DIR/issue-63593.rs:9:5
+  --> $DIR/issue-63593.rs:9:17
    |
 LL |     type This = Self;
-   |     ^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |                 ^^^^ doesn't have a size known at compile-time
    |
 note: required by a bound in `MyTrait::This`
   --> $DIR/issue-63593.rs:9:5

--- a/src/test/ui/associated-types/issue-65774-1.stderr
+++ b/src/test/ui/associated-types/issue-65774-1.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the trait bound `T: MyDisplay` is not satisfied
-  --> $DIR/issue-65774-1.rs:10:5
+  --> $DIR/issue-65774-1.rs:10:33
    |
 LL |     type MpuConfig: MyDisplay = T;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `MyDisplay` is not implemented for `T`
+   |                                 ^ the trait `MyDisplay` is not implemented for `T`
    |
 note: required by a bound in `MPU::MpuConfig`
   --> $DIR/issue-65774-1.rs:10:21

--- a/src/test/ui/associated-types/issue-65774-2.stderr
+++ b/src/test/ui/associated-types/issue-65774-2.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the trait bound `T: MyDisplay` is not satisfied
-  --> $DIR/issue-65774-2.rs:10:5
+  --> $DIR/issue-65774-2.rs:10:33
    |
 LL |     type MpuConfig: MyDisplay = T;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `MyDisplay` is not implemented for `T`
+   |                                 ^ the trait `MyDisplay` is not implemented for `T`
    |
 note: required by a bound in `MPU::MpuConfig`
   --> $DIR/issue-65774-2.rs:10:21

--- a/src/test/ui/associated-types/issue-72806.stderr
+++ b/src/test/ui/associated-types/issue-72806.stderr
@@ -1,9 +1,14 @@
 error[E0271]: type mismatch resolving `<Foo2 as Bar2>::Ok == char`
-  --> $DIR/issue-72806.rs:14:5
+  --> $DIR/issue-72806.rs:14:20
    |
 LL |     type Sibling = Foo2;
-   |     ^^^^^^^^^^^^^^^^^^^^ expected `char`, found `u32`
+   |                    ^^^^ type mismatch resolving `<Foo2 as Bar2>::Ok == char`
    |
+note: expected this to be `char`
+  --> $DIR/issue-72806.rs:18:15
+   |
+LL |     type Ok = u32;
+   |               ^^^
 note: required by a bound in `Bar::Sibling`
   --> $DIR/issue-72806.rs:3:24
    |

--- a/src/test/ui/associated-types/point-at-type-on-obligation-failure-2.stderr
+++ b/src/test/ui/associated-types/point-at-type-on-obligation-failure-2.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the trait bound `bool: Bar` is not satisfied
-  --> $DIR/point-at-type-on-obligation-failure-2.rs:8:5
+  --> $DIR/point-at-type-on-obligation-failure-2.rs:8:18
    |
 LL |     type Assoc = bool;
-   |     ^^^^^^^^^^^^^^^^^^ the trait `Bar` is not implemented for `bool`
+   |                  ^^^^ the trait `Bar` is not implemented for `bool`
    |
 note: required by a bound in `Foo::Assoc`
   --> $DIR/point-at-type-on-obligation-failure-2.rs:4:17
@@ -11,10 +11,10 @@ LL |     type Assoc: Bar;
    |                 ^^^ required by this bound in `Foo::Assoc`
 
 error[E0277]: the trait bound `bool: Bar` is not satisfied
-  --> $DIR/point-at-type-on-obligation-failure-2.rs:19:5
+  --> $DIR/point-at-type-on-obligation-failure-2.rs:19:18
    |
 LL |     type Assoc = bool;
-   |     ^^^^^^^^^^^^^^^^^^ the trait `Bar` is not implemented for `bool`
+   |                  ^^^^ the trait `Bar` is not implemented for `bool`
    |
 note: required by a bound in `Baz::Assoc`
   --> $DIR/point-at-type-on-obligation-failure-2.rs:13:18
@@ -26,10 +26,10 @@ LL |     type Assoc;
    |          ----- required by a bound in this
 
 error[E0277]: the trait bound `bool: Bar` is not satisfied
-  --> $DIR/point-at-type-on-obligation-failure-2.rs:30:5
+  --> $DIR/point-at-type-on-obligation-failure-2.rs:30:18
    |
 LL |     type Assoc = bool;
-   |     ^^^^^^^^^^^^^^^^^^ the trait `Bar` is not implemented for `bool`
+   |                  ^^^^ the trait `Bar` is not implemented for `bool`
    |
 note: required by a bound in `Bat::Assoc`
   --> $DIR/point-at-type-on-obligation-failure-2.rs:24:27

--- a/src/test/ui/associated-types/point-at-type-on-obligation-failure.stderr
+++ b/src/test/ui/associated-types/point-at-type-on-obligation-failure.stderr
@@ -1,9 +1,14 @@
 error[E0271]: type mismatch resolving `<Foo2 as Bar2>::Ok == ()`
-  --> $DIR/point-at-type-on-obligation-failure.rs:14:5
+  --> $DIR/point-at-type-on-obligation-failure.rs:14:20
    |
 LL |     type Sibling = Foo2;
-   |     ^^^^^^^^^^^^^^^^^^^^ expected `()`, found `u32`
+   |                    ^^^^ type mismatch resolving `<Foo2 as Bar2>::Ok == ()`
    |
+note: expected this to be `()`
+  --> $DIR/point-at-type-on-obligation-failure.rs:18:15
+   |
+LL |     type Ok = u32;
+   |               ^^^
 note: required by a bound in `Bar::Sibling`
   --> $DIR/point-at-type-on-obligation-failure.rs:3:24
    |

--- a/src/test/ui/chalkify/impl_wf_2.stderr
+++ b/src/test/ui/chalkify/impl_wf_2.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the trait bound `f32: Foo` is not satisfied
-  --> $DIR/impl_wf_2.rs:25:5
+  --> $DIR/impl_wf_2.rs:25:17
    |
 LL |     type Item = f32;
-   |     ^^^^^^^^^^^^^^^^ the trait `Foo` is not implemented for `f32`
+   |                 ^^^ the trait `Foo` is not implemented for `f32`
    |
 note: required by a bound in `Bar::Item`
   --> $DIR/impl_wf_2.rs:8:16

--- a/src/test/ui/compare-method/bad-self-type.stderr
+++ b/src/test/ui/compare-method/bad-self-type.stderr
@@ -13,27 +13,31 @@ LL |     fn poll(self, _: &mut Context<'_>) -> Poll<()> {
 error[E0053]: method `foo` has an incompatible type for trait
   --> $DIR/bad-self-type.rs:22:18
    |
-LL |     fn foo(self);
-   |            ---- type in trait
-...
 LL |     fn foo(self: Box<Self>) {}
    |            ------^^^^^^^^^
    |            |     |
    |            |     expected struct `MyFuture`, found struct `Box`
    |            help: change the self-receiver type to match the trait: `self`
    |
+note: type in trait
+  --> $DIR/bad-self-type.rs:17:12
+   |
+LL |     fn foo(self);
+   |            ^^^^
    = note: expected fn pointer `fn(MyFuture)`
               found fn pointer `fn(Box<MyFuture>)`
 
 error[E0053]: method `bar` has an incompatible type for trait
   --> $DIR/bad-self-type.rs:24:18
    |
-LL |     fn bar(self) -> Option<()>;
-   |                     ---------- type in trait
-...
 LL |     fn bar(self) {}
    |                  ^ expected enum `Option`, found `()`
    |
+note: type in trait
+  --> $DIR/bad-self-type.rs:18:21
+   |
+LL |     fn bar(self) -> Option<()>;
+   |                     ^^^^^^^^^^
    = note: expected fn pointer `fn(MyFuture) -> Option<()>`
               found fn pointer `fn(MyFuture)`
 help: change the output type to match the trait

--- a/src/test/ui/compare-method/reordered-type-param.stderr
+++ b/src/test/ui/compare-method/reordered-type-param.stderr
@@ -1,9 +1,6 @@
 error[E0053]: method `b` has an incompatible type for trait
   --> $DIR/reordered-type-param.rs:16:30
    |
-LL |   fn b<C:Clone,D>(&self, x: C) -> C;
-   |                             - type in trait
-...
 LL |   fn b<F:Clone,G>(&self, _x: G) -> G { panic!() }
    |        -       -             ^
    |        |       |             |
@@ -12,6 +9,11 @@ LL |   fn b<F:Clone,G>(&self, _x: G) -> G { panic!() }
    |        |       found type parameter
    |        expected type parameter
    |
+note: type in trait
+  --> $DIR/reordered-type-param.rs:7:29
+   |
+LL |   fn b<C:Clone,D>(&self, x: C) -> C;
+   |                             ^
    = note: expected fn pointer `fn(&E, F) -> F`
               found fn pointer `fn(&E, G) -> G`
    = note: a type parameter was expected, but a different one was found; you might be missing a type parameter or trait bound

--- a/src/test/ui/const-generics/associated-type-bound-fail.stderr
+++ b/src/test/ui/const-generics/associated-type-bound-fail.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the trait bound `u16: Bar<N>` is not satisfied
-  --> $DIR/associated-type-bound-fail.rs:9:5
+  --> $DIR/associated-type-bound-fail.rs:9:18
    |
 LL |     type Assoc = u16;
-   |     ^^^^^^^^^^^^^^^^^ the trait `Bar<N>` is not implemented for `u16`
+   |                  ^^^ the trait `Bar<N>` is not implemented for `u16`
    |
    = help: the following implementations were found:
              <u16 as Bar<3_usize>>

--- a/src/test/ui/consts/issue-70942-trait-vs-impl-mismatch.stderr
+++ b/src/test/ui/consts/issue-70942-trait-vs-impl-mismatch.stderr
@@ -1,11 +1,14 @@
 error[E0326]: implemented const `VALUE` has an incompatible type for trait
   --> $DIR/issue-70942-trait-vs-impl-mismatch.rs:8:18
    |
-LL |     const VALUE: usize;
-   |                  ----- type in trait
-...
 LL |     const VALUE: i32 = 0;
    |                  ^^^ expected `usize`, found `i32`
+   |
+note: type in trait
+  --> $DIR/issue-70942-trait-vs-impl-mismatch.rs:2:18
+   |
+LL |     const VALUE: usize;
+   |                  ^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/dst/dst-bad-deep.stderr
+++ b/src/test/ui/dst/dst-bad-deep.stderr
@@ -10,11 +10,6 @@ note: required because it appears within the type `Fat<[isize]>`
    |
 LL | struct Fat<T: ?Sized> {
    |        ^^^
-note: required because it appears within the type `Fat<Fat<[isize]>>`
-  --> $DIR/dst-bad-deep.rs:6:8
-   |
-LL | struct Fat<T: ?Sized> {
-   |        ^^^
    = note: structs must have a statically known size to be initialized
 
 error: aborting due to previous error

--- a/src/test/ui/error-codes/E0271.stderr
+++ b/src/test/ui/error-codes/E0271.stderr
@@ -2,8 +2,13 @@ error[E0271]: type mismatch resolving `<i8 as Trait>::AssociatedType == u32`
   --> $DIR/E0271.rs:10:5
    |
 LL |     foo(3_i8);
-   |     ^^^ expected `u32`, found `&str`
+   |     ^^^ type mismatch resolving `<i8 as Trait>::AssociatedType == u32`
    |
+note: expected this to be `u32`
+  --> $DIR/E0271.rs:7:43
+   |
+LL | impl Trait for i8 { type AssociatedType = &'static str; }
+   |                                           ^^^^^^^^^^^^
 note: required by a bound in `foo`
   --> $DIR/E0271.rs:3:32
    |

--- a/src/test/ui/extern/extern-types-unsized.stderr
+++ b/src/test/ui/extern/extern-types-unsized.stderr
@@ -71,11 +71,6 @@ note: required because it appears within the type `Bar<A>`
    |
 LL | struct Bar<T: ?Sized> {
    |        ^^^
-note: required because it appears within the type `Bar<Bar<A>>`
-  --> $DIR/extern-types-unsized.rs:14:8
-   |
-LL | struct Bar<T: ?Sized> {
-   |        ^^^
 note: required by a bound in `assert_sized`
   --> $DIR/extern-types-unsized.rs:19:17
    |

--- a/src/test/ui/feature-gates/feature-gate-generic_associated_types.stderr
+++ b/src/test/ui/feature-gates/feature-gate-generic_associated_types.stderr
@@ -62,10 +62,10 @@ LL |     type Assoc where Self: Sized = Foo;
    = help: add `#![feature(generic_associated_types)]` to the crate attributes to enable
 
 error[E0277]: the trait bound `U32: Clone` is not satisfied
-  --> $DIR/feature-gate-generic_associated_types.rs:16:5
+  --> $DIR/feature-gate-generic_associated_types.rs:16:26
    |
 LL |     type Pointer2<U32> = Box<U32>;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `U32`
+   |                          ^^^^^^^^ the trait `Clone` is not implemented for `U32`
    |
 help: consider restricting type parameter `U32`
    |

--- a/src/test/ui/generic-associated-types/cross-crate-bounds.stderr
+++ b/src/test/ui/generic-associated-types/cross-crate-bounds.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the trait bound `(): AsRef<()>` is not satisfied
-  --> $DIR/cross-crate-bounds.rs:15:5
+  --> $DIR/cross-crate-bounds.rs:15:16
    |
 LL |     type Bar = ();
-   |     ^^^^^^^^^^^^^^ the trait `AsRef<()>` is not implemented for `()`
+   |                ^^ the trait `AsRef<()>` is not implemented for `()`
    |
 note: required by a bound in `foo_defn::Foo::Bar`
   --> $DIR/auxiliary/foo_defn.rs:6:15

--- a/src/test/ui/generic-associated-types/generic-associated-types-where.stderr
+++ b/src/test/ui/generic-associated-types/generic-associated-types-where.stderr
@@ -1,8 +1,8 @@
 error[E0277]: `T` doesn't implement `std::fmt::Display`
-  --> $DIR/generic-associated-types-where.rs:20:5
+  --> $DIR/generic-associated-types-where.rs:20:22
    |
 LL |     type Assoc2<T> = Vec<T>;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^ `T` cannot be formatted with the default formatter
+   |                      ^^^^^^ `T` cannot be formatted with the default formatter
    |
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
 help: consider restricting type parameter `T`

--- a/src/test/ui/generic-associated-types/impl_bounds.stderr
+++ b/src/test/ui/generic-associated-types/impl_bounds.stderr
@@ -17,10 +17,10 @@ LL |     type B<'a, 'b> where 'b: 'a = (&'a(), &'b ());
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ found
 
 error[E0478]: lifetime bound not satisfied
-  --> $DIR/impl_bounds.rs:17:5
+  --> $DIR/impl_bounds.rs:17:35
    |
 LL |     type B<'a, 'b> where 'b: 'a = (&'a(), &'b ());
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                   ^^^^^^^^^^^^^^^
    |
 note: lifetime parameter instantiated with the lifetime `'a` as defined here
   --> $DIR/impl_bounds.rs:17:12

--- a/src/test/ui/generic-associated-types/issue-68641-check-gat-bounds.stderr
+++ b/src/test/ui/generic-associated-types/issue-68641-check-gat-bounds.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the trait bound `T: Copy` is not satisfied
-  --> $DIR/issue-68641-check-gat-bounds.rs:14:5
+  --> $DIR/issue-68641-check-gat-bounds.rs:14:21
    |
 LL |     type Item<'a> = T;
-   |     ^^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `T`
+   |                     ^ the trait `Copy` is not implemented for `T`
    |
 note: required by a bound in `UnsafeCopy::Item`
   --> $DIR/issue-68641-check-gat-bounds.rs:6:20

--- a/src/test/ui/generic-associated-types/issue-68642-broken-llvm-ir.stderr
+++ b/src/test/ui/generic-associated-types/issue-68642-broken-llvm-ir.stderr
@@ -1,8 +1,8 @@
 error[E0277]: expected a `Fn<()>` closure, found `T`
-  --> $DIR/issue-68642-broken-llvm-ir.rs:14:5
+  --> $DIR/issue-68642-broken-llvm-ir.rs:14:18
    |
 LL |     type F<'a> = Self;
-   |     ^^^^^^^^^^^^^^^^^^ expected an `Fn<()>` closure, found `T`
+   |                  ^^^^ expected an `Fn<()>` closure, found `T`
    |
    = note: wrap the `T` in a closure with no arguments: `|| { /* code */ }`
 note: required by a bound in `Fun::F`

--- a/src/test/ui/generic-associated-types/issue-68643-broken-mir.stderr
+++ b/src/test/ui/generic-associated-types/issue-68643-broken-mir.stderr
@@ -1,8 +1,8 @@
 error[E0277]: expected a `Fn<()>` closure, found `T`
-  --> $DIR/issue-68643-broken-mir.rs:14:5
+  --> $DIR/issue-68643-broken-mir.rs:14:18
    |
 LL |     type F<'a> = Self;
-   |     ^^^^^^^^^^^^^^^^^^ expected an `Fn<()>` closure, found `T`
+   |                  ^^^^ expected an `Fn<()>` closure, found `T`
    |
    = note: wrap the `T` in a closure with no arguments: `|| { /* code */ }`
 note: required by a bound in `Fun::F`

--- a/src/test/ui/generic-associated-types/issue-68644-codegen-selection.stderr
+++ b/src/test/ui/generic-associated-types/issue-68644-codegen-selection.stderr
@@ -1,8 +1,8 @@
 error[E0277]: expected a `Fn<()>` closure, found `T`
-  --> $DIR/issue-68644-codegen-selection.rs:14:5
+  --> $DIR/issue-68644-codegen-selection.rs:14:18
    |
 LL |     type F<'a> = Self;
-   |     ^^^^^^^^^^^^^^^^^^ expected an `Fn<()>` closure, found `T`
+   |                  ^^^^ expected an `Fn<()>` closure, found `T`
    |
    = note: wrap the `T` in a closure with no arguments: `|| { /* code */ }`
 note: required by a bound in `Fun::F`

--- a/src/test/ui/generic-associated-types/issue-68645-codegen-fulfillment.stderr
+++ b/src/test/ui/generic-associated-types/issue-68645-codegen-fulfillment.stderr
@@ -1,8 +1,8 @@
 error[E0277]: expected a `Fn<()>` closure, found `T`
-  --> $DIR/issue-68645-codegen-fulfillment.rs:14:5
+  --> $DIR/issue-68645-codegen-fulfillment.rs:14:18
    |
 LL |     type F<'a> = Self;
-   |     ^^^^^^^^^^^^^^^^^^ expected an `Fn<()>` closure, found `T`
+   |                  ^^^^ expected an `Fn<()>` closure, found `T`
    |
    = note: wrap the `T` in a closure with no arguments: `|| { /* code */ }`
 note: required by a bound in `Fun::F`

--- a/src/test/ui/generic-associated-types/issue-68656-unsized-values.stderr
+++ b/src/test/ui/generic-associated-types/issue-68656-unsized-values.stderr
@@ -1,10 +1,10 @@
 error[E0271]: type mismatch resolving `<T as Deref>::Target == T`
-  --> $DIR/issue-68656-unsized-values.rs:15:5
+  --> $DIR/issue-68656-unsized-values.rs:15:21
    |
 LL | impl<T: Copy + std::ops::Deref> UnsafeCopy<T> for T {
    |      - this type parameter
 LL |     type Item<'a> = T;
-   |     ^^^^^^^^^^^^^^^^^^ expected type parameter `T`, found associated type
+   |                     ^ expected type parameter `T`, found associated type
    |
    = note: expected type parameter `T`
              found associated type `<T as Deref>::Target`

--- a/src/test/ui/generic-associated-types/issue-74684-2.stderr
+++ b/src/test/ui/generic-associated-types/issue-74684-2.stderr
@@ -2,8 +2,13 @@ error[E0271]: type mismatch resolving `<{integer} as Fun>::F<'_> == [u8]`
   --> $DIR/issue-74684-2.rs:23:5
    |
 LL |     bug(Box::new(x));
-   |     ^^^ expected slice `[u8]`, found `i32`
+   |     ^^^ type mismatch resolving `<{integer} as Fun>::F<'_> == [u8]`
    |
+note: expected this to be `[u8]`
+  --> $DIR/issue-74684-2.rs:10:18
+   |
+LL |     type F<'a> = i32;
+   |                  ^^^
 note: required by a bound in `bug`
   --> $DIR/issue-74684-2.rs:13:28
    |

--- a/src/test/ui/generic-associated-types/issue-74816.stderr
+++ b/src/test/ui/generic-associated-types/issue-74816.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the trait bound `Self: Trait1` is not satisfied
-  --> $DIR/issue-74816.rs:9:5
+  --> $DIR/issue-74816.rs:9:31
    |
 LL |     type Associated: Trait1 = Self;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Trait1` is not implemented for `Self`
+   |                               ^^^^ the trait `Trait1` is not implemented for `Self`
    |
 note: required by a bound in `Trait2::Associated`
   --> $DIR/issue-74816.rs:9:22
@@ -15,10 +15,10 @@ LL | trait Trait2: Trait1 {
    |             ++++++++
 
 error[E0277]: the size for values of type `Self` cannot be known at compilation time
-  --> $DIR/issue-74816.rs:9:5
+  --> $DIR/issue-74816.rs:9:31
    |
 LL |     type Associated: Trait1 = Self;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |                               ^^^^ doesn't have a size known at compile-time
    |
 note: required by a bound in `Trait2::Associated`
   --> $DIR/issue-74816.rs:9:5

--- a/src/test/ui/generic-associated-types/issue-74824.stderr
+++ b/src/test/ui/generic-associated-types/issue-74824.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the trait bound `Box<T>: Copy` is not satisfied
-  --> $DIR/issue-74824.rs:7:5
+  --> $DIR/issue-74824.rs:7:26
    |
 LL |     type Copy<T>: Copy = Box<T>;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `Box<T>`
+   |                          ^^^^^^ the trait `Copy` is not implemented for `Box<T>`
    |
 note: required by a bound in `UnsafeCopy::Copy`
   --> $DIR/issue-74824.rs:7:19
@@ -11,10 +11,10 @@ LL |     type Copy<T>: Copy = Box<T>;
    |                   ^^^^ required by this bound in `UnsafeCopy::Copy`
 
 error[E0277]: the trait bound `T: Clone` is not satisfied
-  --> $DIR/issue-74824.rs:7:5
+  --> $DIR/issue-74824.rs:7:26
    |
 LL |     type Copy<T>: Copy = Box<T>;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `T`
+   |                          ^^^^^^ the trait `Clone` is not implemented for `T`
    |
    = note: required because of the requirements on the impl of `Clone` for `Box<T>`
 note: required by a bound in `UnsafeCopy::Copy`

--- a/src/test/ui/generic-associated-types/issue-78113-lifetime-mismatch-dyn-trait-box.stderr
+++ b/src/test/ui/generic-associated-types/issue-78113-lifetime-mismatch-dyn-trait-box.stderr
@@ -1,8 +1,8 @@
 error: incompatible lifetime on type
-  --> $DIR/issue-78113-lifetime-mismatch-dyn-trait-box.rs:17:5
+  --> $DIR/issue-78113-lifetime-mismatch-dyn-trait-box.rs:17:18
    |
 LL |     type T<'a> = Box<dyn A + 'a>;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                  ^^^^^^^^^^^^^^^
    |
 note: because this has an unmet lifetime requirement
   --> $DIR/issue-78113-lifetime-mismatch-dyn-trait-box.rs:12:17
@@ -26,10 +26,10 @@ LL | impl A for Box<dyn A + '_> {}
    |                      ++++
 
 error: incompatible lifetime on type
-  --> $DIR/issue-78113-lifetime-mismatch-dyn-trait-box.rs:27:5
+  --> $DIR/issue-78113-lifetime-mismatch-dyn-trait-box.rs:27:18
    |
 LL |     type T<'a> = Box<dyn A + 'a>;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                  ^^^^^^^^^^^^^^^
    |
 note: because this has an unmet lifetime requirement
   --> $DIR/issue-78113-lifetime-mismatch-dyn-trait-box.rs:23:17
@@ -48,10 +48,10 @@ LL | impl C for Box<dyn A + 'static> {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: incompatible lifetime on type
-  --> $DIR/issue-78113-lifetime-mismatch-dyn-trait-box.rs:37:5
+  --> $DIR/issue-78113-lifetime-mismatch-dyn-trait-box.rs:37:18
    |
 LL |     type T<'a> = (Box<dyn A + 'a>, Box<dyn A + 'a>);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: because this has an unmet lifetime requirement
   --> $DIR/issue-78113-lifetime-mismatch-dyn-trait-box.rs:33:17

--- a/src/test/ui/generic-associated-types/issue-87429-associated-type-default.stderr
+++ b/src/test/ui/generic-associated-types/issue-87429-associated-type-default.stderr
@@ -1,8 +1,8 @@
 error[E0277]: can't compare `Foo` with `Foo`
-  --> $DIR/issue-87429-associated-type-default.rs:14:5
+  --> $DIR/issue-87429-associated-type-default.rs:14:60
    |
 LL |     type Member<'a>: for<'b> PartialEq<Self::Member<'b>> = Foo;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no implementation for `Foo == Foo`
+   |                                                            ^^^ no implementation for `Foo == Foo`
    |
    = help: the trait `PartialEq` is not implemented for `Foo`
 note: required by a bound in `Family2::Member`

--- a/src/test/ui/generic-associated-types/issue-87429-specialization.stderr
+++ b/src/test/ui/generic-associated-types/issue-87429-specialization.stderr
@@ -9,10 +9,10 @@ LL | #![feature(specialization)]
    = help: consider using `min_specialization` instead, which is more stable and complete
 
 error[E0277]: can't compare `Foo` with `Foo`
-  --> $DIR/issue-87429-specialization.rs:21:5
+  --> $DIR/issue-87429-specialization.rs:21:31
    |
 LL |     default type Member<'a> = Foo;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no implementation for `Foo == Foo`
+   |                               ^^^ no implementation for `Foo == Foo`
    |
    = help: the trait `PartialEq` is not implemented for `Foo`
 note: required by a bound in `Family::Member`

--- a/src/test/ui/generic-associated-types/issue-88595.stderr
+++ b/src/test/ui/generic-associated-types/issue-88595.stderr
@@ -1,8 +1,8 @@
 error[E0478]: lifetime bound not satisfied
-  --> $DIR/issue-88595.rs:19:5
+  --> $DIR/issue-88595.rs:19:18
    |
 LL |     type B<'b> = impl Clone;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^
+   |                  ^^^^^^^^^^
    |
 note: lifetime parameter instantiated with the lifetime `'a` as defined here
   --> $DIR/issue-88595.rs:18:6

--- a/src/test/ui/generic-associated-types/issue-90014.stderr
+++ b/src/test/ui/generic-associated-types/issue-90014.stderr
@@ -1,8 +1,8 @@
 error[E0477]: the type `&mut ()` does not fulfill the required lifetime
-  --> $DIR/issue-90014.rs:14:5
+  --> $DIR/issue-90014.rs:14:20
    |
 LL |     type Fut<'a> = impl Future<Output = ()>;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: type must outlive the lifetime `'a` as defined here
   --> $DIR/issue-90014.rs:14:14

--- a/src/test/ui/generic-associated-types/unsatisfied-outlives-bound.stderr
+++ b/src/test/ui/generic-associated-types/unsatisfied-outlives-bound.stderr
@@ -1,8 +1,8 @@
 error[E0477]: the type `&'b ()` does not fulfill the required lifetime
-  --> $DIR/unsatisfied-outlives-bound.rs:8:5
+  --> $DIR/unsatisfied-outlives-bound.rs:8:21
    |
 LL |     type Item<'a> = &'b ();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^
+   |                     ^^^^^^
    |
 note: type must outlive the lifetime `'a` as defined here as required by this binding
   --> $DIR/unsatisfied-outlives-bound.rs:8:15
@@ -11,10 +11,10 @@ LL |     type Item<'a> = &'b ();
    |               ^^
 
 error[E0477]: the type `&'a ()` does not fulfill the required lifetime
-  --> $DIR/unsatisfied-outlives-bound.rs:17:5
+  --> $DIR/unsatisfied-outlives-bound.rs:17:21
    |
 LL |     type Item<'a> = &'a ();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^
+   |                     ^^^^^^
    |
 note: type must satisfy the static lifetime as required by this binding
   --> $DIR/unsatisfied-outlives-bound.rs:13:20

--- a/src/test/ui/hrtb/issue-62203-hrtb-ice.stderr
+++ b/src/test/ui/hrtb/issue-62203-hrtb-ice.stderr
@@ -2,8 +2,13 @@ error[E0271]: type mismatch resolving `for<'r> <L<[closure@$DIR/issue-62203-hrtb
   --> $DIR/issue-62203-hrtb-ice.rs:38:19
    |
 LL |     let v = Unit2.m(
-   |                   ^ expected associated type, found struct `Unit4`
+   |                   ^ type mismatch resolving `for<'r> <L<[closure@$DIR/issue-62203-hrtb-ice.rs:42:17: 42:39]> as T0<'r, (&'r u8,)>>::O == <_ as Ty<'r>>::V`
    |
+note: expected this to be `<_ as Ty<'_>>::V`
+  --> $DIR/issue-62203-hrtb-ice.rs:21:14
+   |
+LL |     type O = T::Output;
+   |              ^^^^^^^^^
    = note: expected associated type `<_ as Ty<'_>>::V`
                        found struct `Unit4`
    = help: consider constraining the associated type `<_ as Ty<'_>>::V` to `Unit4` or calling a method that returns `<_ as Ty<'_>>::V`

--- a/src/test/ui/impl-trait/bound-normalization-fail.stderr
+++ b/src/test/ui/impl-trait/bound-normalization-fail.stderr
@@ -2,8 +2,13 @@ error[E0271]: type mismatch resolving `<Foo<()> as FooLike>::Output == <T as imp
   --> $DIR/bound-normalization-fail.rs:25:32
    |
 LL |     fn foo_fail<T: Trait>() -> impl FooLike<Output = T::Assoc> {
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected associated type, found `()`
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type mismatch resolving `<Foo<()> as FooLike>::Output == <T as impl_trait::Trait>::Assoc`
    |
+note: expected this to be `<T as impl_trait::Trait>::Assoc`
+  --> $DIR/bound-normalization-fail.rs:14:19
+   |
+LL |     type Output = T;
+   |                   ^
    = note: expected associated type `<T as impl_trait::Trait>::Assoc`
                     found unit type `()`
 help: consider constraining the associated type `<T as impl_trait::Trait>::Assoc` to `()`
@@ -21,8 +26,13 @@ error[E0271]: type mismatch resolving `<Foo<()> as FooLike>::Output == <T as lif
   --> $DIR/bound-normalization-fail.rs:41:41
    |
 LL |     fn foo2_fail<'a, T: Trait<'a>>() -> impl FooLike<Output = T::Assoc> {
-   |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected associated type, found `()`
+   |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type mismatch resolving `<Foo<()> as FooLike>::Output == <T as lifetimes::Trait<'static>>::Assoc`
    |
+note: expected this to be `<T as lifetimes::Trait<'static>>::Assoc`
+  --> $DIR/bound-normalization-fail.rs:14:19
+   |
+LL |     type Output = T;
+   |                   ^
    = note: expected associated type `<T as lifetimes::Trait<'static>>::Assoc`
                     found unit type `()`
 help: consider constraining the associated type `<T as lifetimes::Trait<'static>>::Assoc` to `()`

--- a/src/test/ui/impl-trait/impl-generic-mismatch-ab.stderr
+++ b/src/test/ui/impl-trait/impl-generic-mismatch-ab.stderr
@@ -1,9 +1,6 @@
 error[E0053]: method `foo` has an incompatible type for trait
   --> $DIR/impl-generic-mismatch-ab.rs:8:32
    |
-LL |     fn foo<A: Debug>(&self, a: &A, b: &impl Debug);
-   |                                -- type in trait
-...
 LL |     fn foo<B: Debug>(&self, a: &impl Debug, b: &B) { }
    |            -                   ^^^^^^^^^^^
    |            |                   |
@@ -11,6 +8,11 @@ LL |     fn foo<B: Debug>(&self, a: &impl Debug, b: &B) { }
    |            |                   help: change the parameter type to match the trait: `&B`
    |            expected type parameter
    |
+note: type in trait
+  --> $DIR/impl-generic-mismatch-ab.rs:4:32
+   |
+LL |     fn foo<A: Debug>(&self, a: &A, b: &impl Debug);
+   |                                ^^
    = note: expected fn pointer `fn(&(), &B, &impl Debug)`
               found fn pointer `fn(&(), &impl Debug, &B)`
    = note: a type parameter was expected, but a different one was found; you might be missing a type parameter or trait bound

--- a/src/test/ui/impl-trait/projection-mismatch-in-impl-where-clause.stderr
+++ b/src/test/ui/impl-trait/projection-mismatch-in-impl-where-clause.stderr
@@ -2,8 +2,13 @@ error[E0271]: type mismatch resolving `<() as Super>::Assoc == ()`
   --> $DIR/projection-mismatch-in-impl-where-clause.rs:13:14
    |
 LL | fn test() -> impl Test {
-   |              ^^^^^^^^^ expected `()`, found `u8`
+   |              ^^^^^^^^^ type mismatch resolving `<() as Super>::Assoc == ()`
    |
+note: expected this to be `()`
+  --> $DIR/projection-mismatch-in-impl-where-clause.rs:6:18
+   |
+LL |     type Assoc = u8;
+   |                  ^^
 note: required because of the requirements on the impl of `Test` for `()`
   --> $DIR/projection-mismatch-in-impl-where-clause.rs:11:9
    |

--- a/src/test/ui/inference/cannot-infer-partial-try-return.rs
+++ b/src/test/ui/inference/cannot-infer-partial-try-return.rs
@@ -16,7 +16,7 @@ fn infallible() -> Result<(), std::convert::Infallible> {
 
 fn main() {
     let x = || -> Result<_, QualifiedError<_>> {
-        infallible()?; //~ERROR type annotations needed
+        infallible()?; //~ ERROR type annotations needed
         Ok(())
     };
 }

--- a/src/test/ui/issues/issue-13033.stderr
+++ b/src/test/ui/issues/issue-13033.stderr
@@ -1,15 +1,17 @@
 error[E0053]: method `bar` has an incompatible type for trait
   --> $DIR/issue-13033.rs:8:30
    |
-LL |     fn bar(&mut self, other: &mut dyn Foo);
-   |                              ------------ type in trait
-...
 LL |     fn bar(&mut self, other: &dyn Foo) {}
    |                              ^^^^^^^^
    |                              |
    |                              types differ in mutability
    |                              help: change the parameter type to match the trait: `&mut dyn Foo`
    |
+note: type in trait
+  --> $DIR/issue-13033.rs:2:30
+   |
+LL |     fn bar(&mut self, other: &mut dyn Foo);
+   |                              ^^^^^^^^^^^^
    = note: expected fn pointer `fn(&mut Baz, &mut dyn Foo)`
               found fn pointer `fn(&mut Baz, &dyn Foo)`
 

--- a/src/test/ui/issues/issue-35869.stderr
+++ b/src/test/ui/issues/issue-35869.stderr
@@ -1,60 +1,68 @@
 error[E0053]: method `foo` has an incompatible type for trait
   --> $DIR/issue-35869.rs:11:15
    |
-LL |     fn foo(_: fn(u8) -> ());
-   |               ------------ type in trait
-...
 LL |     fn foo(_: fn(u16) -> ()) {}
    |               ^^^^^^^^^^^^^
    |               |
    |               expected `u8`, found `u16`
    |               help: change the parameter type to match the trait: `fn(u8)`
    |
+note: type in trait
+  --> $DIR/issue-35869.rs:2:15
+   |
+LL |     fn foo(_: fn(u8) -> ());
+   |               ^^^^^^^^^^^^
    = note: expected fn pointer `fn(fn(u8))`
               found fn pointer `fn(fn(u16))`
 
 error[E0053]: method `bar` has an incompatible type for trait
   --> $DIR/issue-35869.rs:13:15
    |
-LL |     fn bar(_: Option<u8>);
-   |               ---------- type in trait
-...
 LL |     fn bar(_: Option<u16>) {}
    |               ^^^^^^^^^^^
    |               |
    |               expected `u8`, found `u16`
    |               help: change the parameter type to match the trait: `Option<u8>`
    |
+note: type in trait
+  --> $DIR/issue-35869.rs:3:15
+   |
+LL |     fn bar(_: Option<u8>);
+   |               ^^^^^^^^^^
    = note: expected fn pointer `fn(Option<u8>)`
               found fn pointer `fn(Option<u16>)`
 
 error[E0053]: method `baz` has an incompatible type for trait
   --> $DIR/issue-35869.rs:15:15
    |
-LL |     fn baz(_: (u8, u16));
-   |               --------- type in trait
-...
 LL |     fn baz(_: (u16, u16)) {}
    |               ^^^^^^^^^^
    |               |
    |               expected `u8`, found `u16`
    |               help: change the parameter type to match the trait: `(u8, u16)`
    |
+note: type in trait
+  --> $DIR/issue-35869.rs:4:15
+   |
+LL |     fn baz(_: (u8, u16));
+   |               ^^^^^^^^^
    = note: expected fn pointer `fn((u8, _))`
               found fn pointer `fn((u16, _))`
 
 error[E0053]: method `qux` has an incompatible type for trait
   --> $DIR/issue-35869.rs:17:17
    |
-LL |     fn qux() -> u8;
-   |                 -- type in trait
-...
 LL |     fn qux() -> u16 { 5u16 }
    |                 ^^^
    |                 |
    |                 expected `u8`, found `u16`
    |                 help: change the output type to match the trait: `u8`
    |
+note: type in trait
+  --> $DIR/issue-35869.rs:5:17
+   |
+LL |     fn qux() -> u8;
+   |                 ^^
    = note: expected fn pointer `fn() -> u8`
               found fn pointer `fn() -> u16`
 

--- a/src/test/ui/issues/issue-39970.stderr
+++ b/src/test/ui/issues/issue-39970.stderr
@@ -2,8 +2,13 @@ error[E0271]: type mismatch resolving `for<'a> <() as Array<'a>>::Element == ()`
   --> $DIR/issue-39970.rs:19:5
    |
 LL |     <() as Visit>::visit();
-   |     ^^^^^^^^^^^^^^^^^^^^ expected `()`, found `&()`
+   |     ^^^^^^^^^^^^^^^^^^^^ type mismatch resolving `for<'a> <() as Array<'a>>::Element == ()`
    |
+note: expected this to be `()`
+  --> $DIR/issue-39970.rs:10:20
+   |
+LL |     type Element = &'a ();
+   |                    ^^^^^^
 note: required because of the requirements on the impl of `Visit` for `()`
   --> $DIR/issue-39970.rs:13:6
    |

--- a/src/test/ui/mismatched_types/E0053.stderr
+++ b/src/test/ui/mismatched_types/E0053.stderr
@@ -1,30 +1,34 @@
 error[E0053]: method `foo` has an incompatible type for trait
   --> $DIR/E0053.rs:9:15
    |
-LL |     fn foo(x: u16);
-   |               --- type in trait
-...
 LL |     fn foo(x: i16) { }
    |               ^^^
    |               |
    |               expected `u16`, found `i16`
    |               help: change the parameter type to match the trait: `u16`
    |
+note: type in trait
+  --> $DIR/E0053.rs:2:15
+   |
+LL |     fn foo(x: u16);
+   |               ^^^
    = note: expected fn pointer `fn(u16)`
               found fn pointer `fn(i16)`
 
 error[E0053]: method `bar` has an incompatible type for trait
   --> $DIR/E0053.rs:11:12
    |
-LL |     fn bar(&self);
-   |            ----- type in trait
-...
 LL |     fn bar(&mut self) { }
    |            ^^^^^^^^^
    |            |
    |            types differ in mutability
    |            help: change the self-receiver type to match the trait: `self: &Bar`
    |
+note: type in trait
+  --> $DIR/E0053.rs:3:12
+   |
+LL |     fn bar(&self);
+   |            ^^^^^
    = note: expected fn pointer `fn(&Bar)`
               found fn pointer `fn(&mut Bar)`
 

--- a/src/test/ui/mismatched_types/trait-impl-fn-incompatibility.stderr
+++ b/src/test/ui/mismatched_types/trait-impl-fn-incompatibility.stderr
@@ -1,30 +1,34 @@
 error[E0053]: method `foo` has an incompatible type for trait
   --> $DIR/trait-impl-fn-incompatibility.rs:9:15
    |
-LL |     fn foo(x: u16);
-   |               --- type in trait
-...
 LL |     fn foo(x: i16) { }
    |               ^^^
    |               |
    |               expected `u16`, found `i16`
    |               help: change the parameter type to match the trait: `u16`
    |
+note: type in trait
+  --> $DIR/trait-impl-fn-incompatibility.rs:2:15
+   |
+LL |     fn foo(x: u16);
+   |               ^^^
    = note: expected fn pointer `fn(u16)`
               found fn pointer `fn(i16)`
 
 error[E0053]: method `bar` has an incompatible type for trait
   --> $DIR/trait-impl-fn-incompatibility.rs:10:28
    |
-LL |     fn bar(&mut self, bar: &mut Bar);
-   |                            -------- type in trait
-...
 LL |     fn bar(&mut self, bar: &Bar) { }
    |                            ^^^^
    |                            |
    |                            types differ in mutability
    |                            help: change the parameter type to match the trait: `&mut Bar`
    |
+note: type in trait
+  --> $DIR/trait-impl-fn-incompatibility.rs:3:28
+   |
+LL |     fn bar(&mut self, bar: &mut Bar);
+   |                            ^^^^^^^^
    = note: expected fn pointer `fn(&mut Bar, &mut Bar)`
               found fn pointer `fn(&mut Bar, &Bar)`
 

--- a/src/test/ui/never_type/issue-51506.stderr
+++ b/src/test/ui/never_type/issue-51506.stderr
@@ -1,8 +1,8 @@
 error[E0277]: `!` is not an iterator
-  --> $DIR/issue-51506.rs:13:5
+  --> $DIR/issue-51506.rs:13:24
    |
 LL |     default type Out = !;
-   |     ^^^^^^^^^^^^^^^^^^^^^ `!` is not an iterator
+   |                        ^ `!` is not an iterator
    |
    = help: the trait `Iterator` is not implemented for `!`
 note: required by a bound in `Trait::Out`

--- a/src/test/ui/parser/fn-header-semantic-fail.stderr
+++ b/src/test/ui/parser/fn-header-semantic-fail.stderr
@@ -183,9 +183,6 @@ LL |         const async unsafe extern "C" fn fe5();
 error[E0053]: method `ft1` has an incompatible type for trait
   --> $DIR/fn-header-semantic-fail.rs:28:24
    |
-LL |         async fn ft1();
-   |                       - type in trait
-...
 LL |         async fn ft1() {}
    |                        ^
    |                        |
@@ -193,15 +190,17 @@ LL |         async fn ft1() {}
    |                        expected `()`, found opaque type
    |
    = note: while checking the return type of the `async fn`
+note: type in trait
+  --> $DIR/fn-header-semantic-fail.rs:16:23
+   |
+LL |         async fn ft1();
+   |                       ^
    = note: expected fn pointer `fn()`
               found fn pointer `fn() -> impl Future<Output = ()>`
 
 error[E0053]: method `ft5` has an incompatible type for trait
   --> $DIR/fn-header-semantic-fail.rs:33:48
    |
-LL |         const async unsafe extern "C" fn ft5();
-   |                                               - type in trait
-...
 LL |         const async unsafe extern "C" fn ft5() {}
    |                                                ^
    |                                                |
@@ -209,6 +208,11 @@ LL |         const async unsafe extern "C" fn ft5() {}
    |                                                expected `()`, found opaque type
    |
    = note: while checking the return type of the `async fn`
+note: type in trait
+  --> $DIR/fn-header-semantic-fail.rs:20:47
+   |
+LL |         const async unsafe extern "C" fn ft5();
+   |                                               ^
    = note: expected fn pointer `unsafe extern "C" fn()`
               found fn pointer `unsafe extern "C" fn() -> impl Future<Output = ()>`
 

--- a/src/test/ui/regions/regions-assoc-type-region-bound-in-trait-not-met.stderr
+++ b/src/test/ui/regions/regions-assoc-type-region-bound-in-trait-not-met.stderr
@@ -1,8 +1,8 @@
 error[E0477]: the type `&'a i32` does not fulfill the required lifetime
-  --> $DIR/regions-assoc-type-region-bound-in-trait-not-met.rs:15:5
+  --> $DIR/regions-assoc-type-region-bound-in-trait-not-met.rs:15:18
    |
 LL |     type Value = &'a i32;
-   |     ^^^^^^^^^^^^^^^^^^^^^
+   |                  ^^^^^^^
    |
 note: type must satisfy the static lifetime as required by this binding
   --> $DIR/regions-assoc-type-region-bound-in-trait-not-met.rs:5:17
@@ -11,10 +11,10 @@ LL |     type Value: 'a;
    |                 ^^
 
 error[E0477]: the type `&'a i32` does not fulfill the required lifetime
-  --> $DIR/regions-assoc-type-region-bound-in-trait-not-met.rs:20:5
+  --> $DIR/regions-assoc-type-region-bound-in-trait-not-met.rs:20:18
    |
 LL |     type Value = &'a i32;
-   |     ^^^^^^^^^^^^^^^^^^^^^
+   |                  ^^^^^^^
    |
 note: type must outlive the lifetime `'b` as defined here as required by this binding
   --> $DIR/regions-assoc-type-region-bound-in-trait-not-met.rs:19:10

--- a/src/test/ui/regions/regions-assoc-type-static-bound-in-trait-not-met.stderr
+++ b/src/test/ui/regions/regions-assoc-type-static-bound-in-trait-not-met.stderr
@@ -1,8 +1,8 @@
 error[E0477]: the type `&'a i32` does not fulfill the required lifetime
-  --> $DIR/regions-assoc-type-static-bound-in-trait-not-met.rs:10:5
+  --> $DIR/regions-assoc-type-static-bound-in-trait-not-met.rs:10:18
    |
 LL |     type Value = &'a i32;
-   |     ^^^^^^^^^^^^^^^^^^^^^
+   |                  ^^^^^^^
    |
 note: type must satisfy the static lifetime as required by this binding
   --> $DIR/regions-assoc-type-static-bound-in-trait-not-met.rs:5:17

--- a/src/test/ui/resolve/issue-70736-async-fn-no-body-def-collector.stderr
+++ b/src/test/ui/resolve/issue-70736-async-fn-no-body-def-collector.stderr
@@ -48,15 +48,17 @@ error[E0053]: method `associated` has an incompatible type for trait
   --> $DIR/issue-70736-async-fn-no-body-def-collector.rs:15:26
    |
 LL |     async fn associated();
-   |                          - type in trait
-...
-LL |     async fn associated();
    |                          ^
    |                          |
    |                          checked the `Output` of this `async fn`, found opaque type
    |                          expected `()`, found opaque type
    |
    = note: while checking the return type of the `async fn`
+note: type in trait
+  --> $DIR/issue-70736-async-fn-no-body-def-collector.rs:11:26
+   |
+LL |     async fn associated();
+   |                          ^
    = note: expected fn pointer `fn()`
               found fn pointer `fn() -> impl Future<Output = ()>`
 

--- a/src/test/ui/rfc-2632-const-trait-impl/assoc-type.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/assoc-type.stderr
@@ -1,8 +1,8 @@
 error[E0277]: cannot add `NonConstAdd` to `NonConstAdd`
-  --> $DIR/assoc-type.rs:19:5
+  --> $DIR/assoc-type.rs:19:16
    |
 LL |     type Bar = NonConstAdd;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^ no implementation for `NonConstAdd + NonConstAdd`
+   |                ^^^^^^^^^^^ no implementation for `NonConstAdd + NonConstAdd`
    |
    = help: the trait `Add` is not implemented for `NonConstAdd`
 note: required by a bound in `Foo::Bar`

--- a/src/test/ui/specialization/deafult-associated-type-bound-1.stderr
+++ b/src/test/ui/specialization/deafult-associated-type-bound-1.stderr
@@ -9,10 +9,10 @@ LL | #![feature(specialization)]
    = help: consider using `min_specialization` instead, which is more stable and complete
 
 error[E0277]: the trait bound `str: Clone` is not satisfied
-  --> $DIR/deafult-associated-type-bound-1.rs:19:5
+  --> $DIR/deafult-associated-type-bound-1.rs:19:22
    |
 LL |     default type U = str;
-   |     ^^^^^^^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `str`
+   |                      ^^^ the trait `Clone` is not implemented for `str`
    |
 note: required by a bound in `X::U`
   --> $DIR/deafult-associated-type-bound-1.rs:9:13

--- a/src/test/ui/specialization/deafult-associated-type-bound-2.stderr
+++ b/src/test/ui/specialization/deafult-associated-type-bound-2.stderr
@@ -9,10 +9,10 @@ LL | #![feature(specialization)]
    = help: consider using `min_specialization` instead, which is more stable and complete
 
 error[E0277]: can't compare `&'static B` with `B`
-  --> $DIR/deafult-associated-type-bound-2.rs:16:5
+  --> $DIR/deafult-associated-type-bound-2.rs:16:22
    |
 LL |     default type U = &'static B;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no implementation for `&'static B == B`
+   |                      ^^^^^^^^^^ no implementation for `&'static B == B`
    |
    = help: the trait `PartialEq<B>` is not implemented for `&'static B`
 note: required by a bound in `X::U`

--- a/src/test/ui/specialization/deafult-generic-associated-type-bound.stderr
+++ b/src/test/ui/specialization/deafult-generic-associated-type-bound.stderr
@@ -9,10 +9,10 @@ LL | #![feature(specialization)]
    = help: consider using `min_specialization` instead, which is more stable and complete
 
 error[E0277]: can't compare `T` with `T`
-  --> $DIR/deafult-generic-associated-type-bound.rs:18:5
+  --> $DIR/deafult-generic-associated-type-bound.rs:18:26
    |
 LL |     default type U<'a> = &'a T;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ no implementation for `T == T`
+   |                          ^^^^^ no implementation for `T == T`
    |
    = note: required because of the requirements on the impl of `PartialEq` for `&'a T`
 note: required by a bound in `X::U`

--- a/src/test/ui/specialization/issue-33017.stderr
+++ b/src/test/ui/specialization/issue-33017.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the trait bound `T: Copy` is not satisfied
-  --> $DIR/issue-33017.rs:12:5
+  --> $DIR/issue-33017.rs:12:27
    |
 LL |     default type Output = Self;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `T`
+   |                           ^^^^ the trait `Copy` is not implemented for `T`
    |
 note: required by a bound in `UncheckedCopy::Output`
   --> $DIR/issue-33017.rs:8:31

--- a/src/test/ui/specialization/issue-38091.stderr
+++ b/src/test/ui/specialization/issue-38091.stderr
@@ -9,10 +9,10 @@ LL | #![feature(specialization)]
    = help: consider using `min_specialization` instead, which is more stable and complete
 
 error[E0277]: the trait bound `(): Valid` is not satisfied
-  --> $DIR/issue-38091.rs:12:5
+  --> $DIR/issue-38091.rs:12:23
    |
 LL |     default type Ty = ();
-   |     ^^^^^^^^^^^^^^^^^^^^^ the trait `Valid` is not implemented for `()`
+   |                       ^^ the trait `Valid` is not implemented for `()`
    |
 note: required by a bound in `Iterate::Ty`
   --> $DIR/issue-38091.rs:5:14

--- a/src/test/ui/specialization/issue-44861.stderr
+++ b/src/test/ui/specialization/issue-44861.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the trait bound `(): CoerceUnsized<*const [u8]>` is not satisfied
-  --> $DIR/issue-44861.rs:21:5
+  --> $DIR/issue-44861.rs:21:26
    |
 LL |     default type Data2 = ();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `CoerceUnsized<*const [u8]>` is not implemented for `()`
+   |                          ^^ the trait `CoerceUnsized<*const [u8]>` is not implemented for `()`
    |
 note: required by a bound in `Smartass::Data2`
   --> $DIR/issue-44861.rs:12:17

--- a/src/test/ui/specialization/issue-59435.stderr
+++ b/src/test/ui/specialization/issue-59435.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the trait bound `MyStruct: Default` is not satisfied
-  --> $DIR/issue-59435.rs:11:5
+  --> $DIR/issue-59435.rs:11:27
    |
 LL |     default type MyType = MyStruct;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Default` is not implemented for `MyStruct`
+   |                           ^^^^^^^^ the trait `Default` is not implemented for `MyStruct`
    |
 note: required by a bound in `MyTrait::MyType`
   --> $DIR/issue-59435.rs:7:18

--- a/src/test/ui/suggestions/issue-85945-check-where-clause-before-suggesting-unsized.rs
+++ b/src/test/ui/suggestions/issue-85945-check-where-clause-before-suggesting-unsized.rs
@@ -2,7 +2,7 @@
 // `Sized` bound is already in a `where` clause.
 fn foo<T>(_: &T) where T: Sized {}
 fn bar() { foo(""); }
-//~^ERROR the size for values of type
+//~^ ERROR the size for values of type
 
 pub fn main() {
 }

--- a/src/test/ui/traits/associated_type_bound/check-trait-object-bounds-5.stderr
+++ b/src/test/ui/traits/associated_type_bound/check-trait-object-bounds-5.stderr
@@ -2,8 +2,13 @@ error[E0271]: type mismatch resolving `<i32 as Is>::T == i64`
   --> $DIR/check-trait-object-bounds-5.rs:23:5
    |
 LL |     is_obj(x)
-   |     ^^^^^^ expected `i64`, found `i32`
+   |     ^^^^^^ type mismatch resolving `<i32 as Is>::T == i64`
    |
+note: expected this to be `i64`
+  --> $DIR/check-trait-object-bounds-5.rs:9:14
+   |
+LL |     type T = U;
+   |              ^
 note: required by a bound in `is_obj`
   --> $DIR/check-trait-object-bounds-5.rs:20:23
    |

--- a/src/test/ui/traits/associated_type_bound/check-trait-object-bounds-6.stderr
+++ b/src/test/ui/traits/associated_type_bound/check-trait-object-bounds-6.stderr
@@ -2,8 +2,13 @@ error[E0271]: type mismatch resolving `<i32 as Is>::T == i64`
   --> $DIR/check-trait-object-bounds-6.rs:20:5
    |
 LL |     is_obj(x)
-   |     ^^^^^^ expected `i64`, found `i32`
+   |     ^^^^^^ type mismatch resolving `<i32 as Is>::T == i64`
    |
+note: expected this to be `i64`
+  --> $DIR/check-trait-object-bounds-6.rs:9:14
+   |
+LL |     type T = U;
+   |              ^
 note: required by a bound in `is_obj`
   --> $DIR/check-trait-object-bounds-6.rs:17:23
    |

--- a/src/test/ui/traits/impl-method-mismatch.stderr
+++ b/src/test/ui/traits/impl-method-mismatch.stderr
@@ -1,12 +1,14 @@
 error[E0053]: method `jumbo` has an incompatible type for trait
   --> $DIR/impl-method-mismatch.rs:7:5
    |
-LL |     fn jumbo(&self, x: &usize) -> usize;
-   |     ------------------------------------ type in trait
-...
 LL |     unsafe fn jumbo(&self, x: &usize) { *self + *x; }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected normal fn, found unsafe fn
    |
+note: type in trait
+  --> $DIR/impl-method-mismatch.rs:2:5
+   |
+LL |     fn jumbo(&self, x: &usize) -> usize;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: expected fn pointer `fn(&usize, &usize) -> usize`
               found fn pointer `unsafe fn(&usize, &usize)`
 

--- a/src/test/ui/traits/inductive-overflow/lifetime.rs
+++ b/src/test/ui/traits/inductive-overflow/lifetime.rs
@@ -22,6 +22,7 @@ impl<'a> NotAuto for C<'a> {}
 fn is_send<S: NotAuto>() {}
 //~^ NOTE: required
 //~| NOTE: required
+
 fn main() {
     // Should only be a few notes.
     is_send::<X<C<'static>>>();

--- a/src/test/ui/traits/inductive-overflow/lifetime.stderr
+++ b/src/test/ui/traits/inductive-overflow/lifetime.stderr
@@ -1,5 +1,5 @@
 error[E0275]: overflow evaluating the requirement `X<C<'_>>: NotAuto`
-  --> $DIR/lifetime.rs:27:5
+  --> $DIR/lifetime.rs:28:5
    |
 LL |     is_send::<X<C<'static>>>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/traits/inductive-overflow/two-traits.stderr
+++ b/src/test/ui/traits/inductive-overflow/two-traits.stderr
@@ -1,8 +1,8 @@
 error[E0277]: `T` cannot be shared between threads safely
-  --> $DIR/two-traits.rs:11:5
+  --> $DIR/two-traits.rs:11:14
    |
 LL |     type X = Self;
-   |     ^^^^^^^^^^^^^^ `T` cannot be shared between threads safely
+   |              ^^^^ `T` cannot be shared between threads safely
    |
 note: required by a bound in `Magic::X`
   --> $DIR/two-traits.rs:8:13

--- a/src/test/ui/traits/issue-65673.stderr
+++ b/src/test/ui/traits/issue-65673.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the size for values of type `(dyn Trait + 'static)` cannot be known at compilation time
-  --> $DIR/issue-65673.rs:9:5
+  --> $DIR/issue-65673.rs:9:16
    |
 LL |     type Ctx = dyn Alias<T>;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |                ^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `(dyn Trait + 'static)`
 note: required by a bound in `WithType::Ctx`

--- a/src/test/ui/type-alias-impl-trait/issue-63355.stderr
+++ b/src/test/ui/type-alias-impl-trait/issue-63355.stderr
@@ -4,8 +4,13 @@ error[E0271]: type mismatch resolving `<() as Bar>::Foo == ()`
 LL | pub type FooImpl = impl Foo;
    |                    -------- the found opaque type
 LL | pub type BarImpl = impl Bar<Foo = FooImpl>;
-   |                    ^^^^^^^^^^^^^^^^^^^^^^^ expected `()`, found opaque type
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^ type mismatch resolving `<() as Bar>::Foo == ()`
    |
+note: expected this to be `()`
+  --> $DIR/issue-63355.rs:24:16
+   |
+LL |     type Foo = FooImpl;
+   |                ^^^^^^^
    = note: expected unit type `()`
             found opaque type `impl Foo`
 

--- a/src/test/ui/type/type-annotation-needed.rs
+++ b/src/test/ui/type/type-annotation-needed.rs
@@ -1,6 +1,7 @@
 fn foo<T: Into<String>>(x: i32) {}
 //~^ NOTE required by
 //~| NOTE required by
+
 fn main() {
     foo(42);
     //~^ ERROR type annotations needed

--- a/src/test/ui/type/type-annotation-needed.stderr
+++ b/src/test/ui/type/type-annotation-needed.stderr
@@ -1,5 +1,5 @@
 error[E0283]: type annotations needed
-  --> $DIR/type-annotation-needed.rs:5:5
+  --> $DIR/type-annotation-needed.rs:6:5
    |
 LL |     foo(42);
    |     ^^^ cannot infer type for type parameter `T` declared on the function `foo`

--- a/src/test/ui/unsafe/unsafe-trait-impl.stderr
+++ b/src/test/ui/unsafe/unsafe-trait-impl.stderr
@@ -1,12 +1,14 @@
 error[E0053]: method `len` has an incompatible type for trait
   --> $DIR/unsafe-trait-impl.rs:8:5
    |
-LL |     unsafe fn len(&self) -> u32;
-   |     ---------------------------- type in trait
-...
 LL |     fn len(&self) -> u32 { *self }
    |     ^^^^^^^^^^^^^^^^^^^^ expected unsafe fn, found normal fn
    |
+note: type in trait
+  --> $DIR/unsafe-trait-impl.rs:4:5
+   |
+LL |     unsafe fn len(&self) -> u32;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: expected fn pointer `unsafe fn(&u32) -> _`
               found fn pointer `fn(&u32) -> _`
 


### PR DESCRIPTION
* Point at RHS of associated type in obligation span
* Point at `impl` assoc type on projection error
* Reduce verbosity of recursive obligations
* Point at source of binding lifetime obligation
* Tweak "required bound" note
* Tweak "expected... found opaque (return) type" labels
* Point at set type in impl assoc type WF errors

r? @oli-obk 

This is a(n uncontroversial) subset of #85799.