### PR TITLE
Return an error when `eval_rvalue_with_identities` fails

### DIFF
--- a/src/test/ui/mir/mir_const_prop_identity.rs
+++ b/src/test/ui/mir/mir_const_prop_identity.rs
@@ -1,0 +1,12 @@
+// Regression test for issue #91725.
+//
+// run-pass
+// compile-flags: -Zmir-opt-level=4
+
+fn main() {
+    let a = true;
+    let _ = &a;
+    let mut b = false;
+    b |= a;
+    assert!(b);
+}


### PR DESCRIPTION
Previously some code paths would fail to evaluate the rvalue, while
incorrectly indicating success with `Ok`. As a result the previous value
of lhs could have been incorrectly const propagated.

Fixes #91725.

r? @oli-obk 