### PR TITLE
rustbot: Add autolabeling for `T-rustdoc`

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -91,6 +91,29 @@ exclude_labels = [
     "requires-nightly",
 ]
 
+[autolabel."T-rustdoc"]
+trigger_files = [
+    # Source code
+    "src/librustdoc",
+    "src/tools/rustdoc",
+    "src/rustdoc-json-types",
+
+    # Tests
+    "src/test/rustdoc",
+    "src/test/rustdoc-ui",
+    "src/test/rustdoc-gui",
+    "src/test/rustdoc-js",
+    "src/test/rustdoc-js-std",
+    "src/test/rustdoc-json",
+
+    # Internal tooling
+    "src/etc/htmldocck.py",
+    "src/tools/jsondocck",
+    "src/tools/rustdoc-gui",
+    "src/tools/rustdoc-js",
+    "src/tools/rustdoc-themes",
+]
+
 [notify-zulip."I-prioritize"]
 zulip_stream = 245100 # #t-compiler/wg-prioritization/alerts
 topic = "#{number} {title}"


### PR DESCRIPTION
This commit adds autolabeling for the `T-rustdoc` label, for PRs that
modify rustdoc's source code, tests, or internal tooling.

This is possible now that rust-lang/triagebot#1321 has landed.