### PR TITLE
Show the unused type for `unused_results` lint

### DIFF
--- a/compiler/rustc_lint/src/unused.rs
+++ b/compiler/rustc_lint/src/unused.rs
@@ -169,7 +169,9 @@ impl<'tcx> LateLintPass<'tcx> for UnusedResults {
         }
 
         if !(type_permits_lack_of_use || fn_warned || op_warned) {
-            cx.struct_span_lint(UNUSED_RESULTS, s.span, |lint| lint.build("unused result").emit());
+            cx.struct_span_lint(UNUSED_RESULTS, s.span, |lint| {
+                lint.build(&format!("unused result of type `{}`", ty)).emit()
+            });
         }
 
         // Returns whether an error has been emitted (and thus another does not need to be later).

--- a/src/test/ui/lint/unused/unused-result.rs
+++ b/src/test/ui/lint/unused/unused-result.rs
@@ -31,7 +31,7 @@ fn test2() {
 }
 
 fn main() {
-    foo::<isize>(); //~ ERROR: unused result
+    foo::<isize>(); //~ ERROR: unused result of type `isize`
     foo::<MustUse>(); //~ ERROR: unused `MustUse` that must be used
     foo::<MustUseMsg>(); //~ ERROR: unused `MustUseMsg` that must be used
     //~^ NOTE: some message

--- a/src/test/ui/lint/unused/unused-result.stderr
+++ b/src/test/ui/lint/unused/unused-result.stderr
@@ -18,7 +18,7 @@ LL |     foo::<MustUseMsg>();
    |
    = note: some message
 
-error: unused result
+error: unused result of type `isize`
   --> $DIR/unused-result.rs:34:5
    |
 LL |     foo::<isize>();


### PR DESCRIPTION
I think it's helpful to know what type was unused when looking at these
warnings. The type will likely determine whether the result *should* be
used, or whether it should just be ignored.

Including the type also matches the behavior of the `must_use` lint:
unused `SomeType` that must be used.
