### PR TITLE
rustbot: Add autolabeling for `T-compiler`

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -114,6 +114,15 @@ trigger_files = [
     "src/tools/rustdoc-themes",
 ]
 
+[autolabel."T-compiler"]
+trigger_files = [
+    # Source code
+    "compiler",
+
+    # Tests
+    "src/test/ui",
+]
+
 [notify-zulip."I-prioritize"]
 zulip_stream = 245100 # #t-compiler/wg-prioritization/alerts
 topic = "#{number} {title}"


### PR DESCRIPTION
This commit adds autolabeling for the `T-compiler` label, for PRs that
modify rustc's source code or tests (currently only `src/test/ui`).

This is possible now that rust-lang/triagebot#1321 has landed.