### PR TITLE
Suggest to specify a target triple when lang item is missing

### DIFF
--- a/compiler/rustc_passes/src/weak_lang_items.rs
+++ b/compiler/rustc_passes/src/weak_lang_items.rs
@@ -67,10 +67,16 @@ fn verify<'tcx>(tcx: TyCtxt<'tcx>, items: &lang_items::LanguageItems) {
             } else if item == LangItem::Oom {
                 if !tcx.features().default_alloc_error_handler {
                     tcx.sess.err("`#[alloc_error_handler]` function required, but not found");
-                    tcx.sess.note_without_error("Use `#![feature(default_alloc_error_handler)]` for a default error handler");
+                    tcx.sess.note_without_error("use `#![feature(default_alloc_error_handler)]` for a default error handler");
                 }
             } else {
-                tcx.sess.err(&format!("language item required, but not found: `{}`", name));
+                tcx
+                    .sess
+                    .diagnostic()
+                    .struct_err(&format!("language item required, but not found: `{}`", name))
+                    .note(&format!("this can occur when a binary crate with `#![no_std]` is compiled for a target where `{}` is defined in the standard library", name))
+                    .help(&format!("you may be able to compile for a target that doesn't need `{}`, specify a target with `--target` or in `.cargo/config`", name))
+                    .emit();
             }
         }
     }

--- a/src/test/ui/extern-flag/empty-extern-arg.stderr
+++ b/src/test/ui/extern-flag/empty-extern-arg.stderr
@@ -1,6 +1,9 @@
 error: extern location for std does not exist: 
 
 error: language item required, but not found: `eh_personality`
+   |
+   = note: this can occur when a binary crate with `#![no_std]` is compiled for a target where `eh_personality` is defined in the standard library
+   = help: you may be able to compile for a target that doesn't need `eh_personality`, specify a target with `--target` or in `.cargo/config`
 
 error: `#[panic_handler]` function required, but not found
 

--- a/src/test/ui/missing/missing-alloc_error_handler.stderr
+++ b/src/test/ui/missing/missing-alloc_error_handler.stderr
@@ -1,6 +1,6 @@
 error: `#[alloc_error_handler]` function required, but not found
 
-note: Use `#![feature(default_alloc_error_handler)]` for a default error handler
+note: use `#![feature(default_alloc_error_handler)]` for a default error handler
 
 error: aborting due to previous error
 

--- a/src/test/ui/panic-handler/weak-lang-item.stderr
+++ b/src/test/ui/panic-handler/weak-lang-item.stderr
@@ -11,6 +11,9 @@ LL | extern crate core as other_core;
    |
 
 error: language item required, but not found: `eh_personality`
+   |
+   = note: this can occur when a binary crate with `#![no_std]` is compiled for a target where `eh_personality` is defined in the standard library
+   = help: you may be able to compile for a target that doesn't need `eh_personality`, specify a target with `--target` or in `.cargo/config`
 
 error: `#[panic_handler]` function required, but not found
 


### PR DESCRIPTION
It is very common for newbies to embedded to hit this confusing error when forgetting to specify the target.
Source: me googling this error many times.

## Possible changes
* We could possibly restrict the note+help to only be included on eh_personality lang item if that helped reduce false positives, but its also possible doing so would just increase false negatives
* Open to any suggestions on rewriting the messages
* We could possibly remove the `.cargo/config` alternative to avoid the message getting too noisy but I think its valuable to have as its the correct approach for most embedded projects so that `cargo build` just works.

r? rust-lang/diagnostics