### PR TITLE
Update browser-ui-test version and improve rustdoc-gui tests readability

### DIFF
--- a/src/ci/docker/host-x86_64/x86_64-gnu-tools/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-tools/Dockerfile
@@ -72,7 +72,7 @@ ENV PATH="/node-v14.4.0-linux-x64/bin:${PATH}"
 # https://github.com/puppeteer/puppeteer/issues/375
 #
 # We also specify the version in case we need to update it to go around cache limitations.
-RUN npm install -g browser-ui-test@0.5.0 --unsafe-perm=true
+RUN npm install -g browser-ui-test@0.5.1 --unsafe-perm=true
 
 ENV RUST_CONFIGURE_ARGS \
   --build=x86_64-unknown-linux-gnu \

--- a/src/test/rustdoc-gui/anchors.goml
+++ b/src/test/rustdoc-gui/anchors.goml
@@ -34,7 +34,7 @@ assert-css: ("#impl a.anchor", {"color": "rgb(0, 0, 0)"})
 move-cursor-to: ".top-doc .docblock .section-header:first-child"
 assert-css: (
     ".top-doc .docblock .section-header:first-child > a::before",
-    {"left": "-10px", "padding-right": "10px"}
+    {"left": "-10px", "padding-right": "10px"},
 )
 // We also check that the heading itself has a different indent.
 assert-css: (".top-doc .docblock .section-header:first-child", {"margin-left": "15px"})
@@ -42,7 +42,7 @@ assert-css: (".top-doc .docblock .section-header:first-child", {"margin-left": "
 move-cursor-to: ".top-doc .docblock .section-header:not(:first-child)"
 assert-css: (
     ".top-doc .docblock .section-header:not(:first-child) > a::before",
-    {"left": "-25px", "padding-right": "10px"}
+    {"left": "-25px", "padding-right": "10px"},
 )
 assert-css: (".top-doc .docblock .section-header:not(:first-child)", {"margin-left": "0px"})
 
@@ -51,14 +51,14 @@ assert-css: (".top-doc .docblock .section-header:not(:first-child)", {"margin-le
 move-cursor-to: "#title-for-struct-impl-doc"
 assert-css: (
     "#title-for-struct-impl-doc > a::before",
-    {"left": "-25px", "padding-right": "10px"}
+    {"left": "-25px", "padding-right": "10px"},
 )
 assert-css: ("#title-for-struct-impl-doc", {"margin-left": "0px"})
 // Now a method docs.
 move-cursor-to: "#title-for-struct-impl-item-doc"
 assert-css: (
     "#title-for-struct-impl-item-doc > a::before",
-    {"left": "-25px", "padding-right": "10px"}
+    {"left": "-25px", "padding-right": "10px"},
 )
 assert-css: ("#title-for-struct-impl-item-doc", {"margin-left": "0px"})
 
@@ -69,6 +69,6 @@ goto: file://|DOC_PATH|/test_docs/enum.WhoLetTheDogOut.html
 move-cursor-to: ".top-doc .docblock .section-header"
 assert-css: (
     ".top-doc .docblock .section-header > a::before",
-    {"left": "-25px", "padding-right": "10px"}
+    {"left": "-25px", "padding-right": "10px"},
 )
 assert-css: (".top-doc .docblock .section-header", {"margin-left": "0px"})

--- a/src/test/rustdoc-gui/docblock-code-block-line-number.goml
+++ b/src/test/rustdoc-gui/docblock-code-block-line-number.goml
@@ -16,7 +16,7 @@ wait-for: "pre.line-number"
 assert-css: ("pre.line-number", {
     "margin": "0px",
     "padding": "13px 8px",
-    "text-align": "right"
+    "text-align": "right",
 })
 // The first code block has two lines so let's check its `<pre>` elements lists both of them.
 assert-text: ("pre.line-number", "1\n2")

--- a/src/test/rustdoc-gui/docblock-table-overflow.goml
+++ b/src/test/rustdoc-gui/docblock-table-overflow.goml
@@ -11,7 +11,11 @@ assert-property: (".top-doc .docblock table", {"scrollWidth": "1573"})
 // Checking it works on other doc blocks as well...
 
 // Logically, the ".docblock" and the "<p>" should have the same scroll width.
-compare-elements-property: ("#implementations + details .docblock", "#implementations + details .docblock > p", ["scrollWidth"])
+compare-elements-property: (
+    "#implementations + details .docblock",
+    "#implementations + details .docblock > p",
+    ["scrollWidth"],
+)
 assert-property: ("#implementations + details .docblock", {"scrollWidth": "816"})
 // However, since there is overflow in the <table>, its scroll width is bigger.
 assert-property: ("#implementations + details .docblock table", {"scrollWidth": "1573"})

--- a/src/test/rustdoc-gui/font-weight.goml
+++ b/src/test/rustdoc-gui/font-weight.goml
@@ -1,7 +1,10 @@
 goto: file://|DOC_PATH|/lib2/struct.Foo.html
 // This test checks that the font weight is correctly applied.
 assert-css: ("//*[@class='docblock item-decl']//a[text()='Alias']", {"font-weight": "400"})
-assert-css: ("//*[@class='structfield small-section-header']//a[text()='Alias']", {"font-weight": "400"})
+assert-css: (
+    "//*[@class='structfield small-section-header']//a[text()='Alias']",
+    {"font-weight": "400"},
+)
 assert-css: ("#method\.a_method > .code-header", {"font-weight": "600"})
 assert-css: ("#associatedtype\.X > .code-header", {"font-weight": "600"})
 assert-css: ("#associatedconstant\.Y > .code-header", {"font-weight": "600"})
@@ -25,8 +28,14 @@ goto: file://|DOC_PATH|/lib2/trait.Trait.html
 //
 // This uses '/parent::*' as a proxy for the style of the text node.
 // We can't just select the '<a>' because intermediate tags could be added.
-assert-count: ("//*[@class='docblock item-decl']/pre[@class='rust trait']/code/a[@class='constant']//text()/parent::*", 1)
-assert-css: ("//*[@class='docblock item-decl']/pre[@class='rust trait']/code/a[@class='constant']//text()/parent::*", {"font-weight": "400"})
+assert-count: (
+    "//*[@class='docblock item-decl']/pre[@class='rust trait']/code/a[@class='constant']//text()/parent::*",
+    1,
+)
+assert-css: (
+    "//*[@class='docblock item-decl']/pre[@class='rust trait']/code/a[@class='constant']//text()/parent::*",
+    {"font-weight": "400"},
+)
 
 assert-count: (".methods .type", 1)
 assert-css: (".methods .type", {"font-weight": "600"})

--- a/src/test/rustdoc-gui/headers-color.goml
+++ b/src/test/rustdoc-gui/headers-color.goml
@@ -5,33 +5,71 @@ goto: file://|DOC_PATH|/test_docs/struct.Foo.html
 show-text: true
 
 // Ayu theme
-local-storage: {"rustdoc-theme": "ayu", "rustdoc-preferred-dark-theme": "ayu", "rustdoc-use-system-theme": "false"}
+local-storage: {
+    "rustdoc-theme": "ayu",
+    "rustdoc-preferred-dark-theme": "ayu",
+    "rustdoc-use-system-theme": "false",
+}
 reload:
 
-assert-css: (".impl", {"color": "rgb(197, 197, 197)", "background-color": "rgba(0, 0, 0, 0)"}, ALL)
-assert-css: (".impl .code-header", {"color": "rgb(230, 225, 207)", "background-color": "rgb(15, 20, 25)"}, ALL)
+assert-css: (
+    ".impl",
+    {"color": "rgb(197, 197, 197)", "background-color": "rgba(0, 0, 0, 0)"},
+    ALL,
+)
+assert-css: (
+    ".impl .code-header",
+    {"color": "rgb(230, 225, 207)", "background-color": "rgb(15, 20, 25)"},
+    ALL,
+)
 
 goto: file://|DOC_PATH|/test_docs/struct.Foo.html#impl
-assert-css: ("#impl", {"color": "rgb(197, 197, 197)", "background-color": "rgba(255, 236, 164, 0.06)"})
+assert-css: (
+    "#impl",
+    {"color": "rgb(197, 197, 197)", "background-color": "rgba(255, 236, 164, 0.06)"},
+)
 
 goto: file://|DOC_PATH|/test_docs/struct.Foo.html#method.must_use
-assert-css: ("#method\.must_use", {"color": "rgb(197, 197, 197)", "background-color": "rgba(255, 236, 164, 0.06)"}, ALL)
+assert-css: (
+    "#method\.must_use",
+    {"color": "rgb(197, 197, 197)", "background-color": "rgba(255, 236, 164, 0.06)"},
+    ALL,
+)
 
 goto: file://|DOC_PATH|/test_docs/index.html
 assert-css: (".section-header a", {"color": "rgb(197, 197, 197)"}, ALL)
 
 // Dark theme
-local-storage: {"rustdoc-theme": "dark", "rustdoc-preferred-dark-theme": "dark", "rustdoc-use-system-theme": "false"}
+local-storage: {
+    "rustdoc-theme": "dark",
+    "rustdoc-preferred-dark-theme": "dark",
+    "rustdoc-use-system-theme": "false",
+}
 goto: file://|DOC_PATH|/test_docs/struct.Foo.html
 
-assert-css: (".impl", {"color": "rgb(221, 221, 221)", "background-color": "rgba(0, 0, 0, 0)"}, ALL)
-assert-css: (".impl .code-header", {"color": "rgb(221, 221, 221)", "background-color": "rgb(53, 53, 53)"}, ALL)
+assert-css: (
+    ".impl",
+    {"color": "rgb(221, 221, 221)", "background-color": "rgba(0, 0, 0, 0)"},
+    ALL,
+)
+assert-css: (
+    ".impl .code-header",
+    {"color": "rgb(221, 221, 221)", "background-color": "rgb(53, 53, 53)"},
+    ALL,
+)
 
 goto: file://|DOC_PATH|/test_docs/struct.Foo.html#impl
-assert-css: ("#impl", {"color": "rgb(221, 221, 221)", "background-color": "rgb(73, 74, 61)"})
+assert-css: (
+    "#impl",
+    {"color": "rgb(221, 221, 221)", "background-color": "rgb(73, 74, 61)"},
+)
 
 goto: file://|DOC_PATH|/test_docs/struct.Foo.html#method.must_use
-assert-css: ("#method\.must_use", {"color": "rgb(221, 221, 221)", "background-color": "rgb(73, 74, 61)"}, ALL)
+assert-css: (
+    "#method\.must_use",
+    {"color": "rgb(221, 221, 221)", "background-color": "rgb(73, 74, 61)"},
+    ALL,
+)
 
 goto: file://|DOC_PATH|/test_docs/index.html
 assert-css: (".section-header a", {"color": "rgb(221, 221, 221)"}, ALL)
@@ -42,14 +80,26 @@ reload:
 
 goto: file://|DOC_PATH|/test_docs/struct.Foo.html
 
-assert-css: (".impl", {"color": "rgb(0, 0, 0)", "background-color": "rgba(0, 0, 0, 0)"}, ALL)
-assert-css: (".impl .code-header", {"color": "rgb(0, 0, 0)", "background-color": "rgb(255, 255, 255)"}, ALL)
+assert-css: (
+    ".impl",
+    {"color": "rgb(0, 0, 0)", "background-color": "rgba(0, 0, 0, 0)"},
+    ALL,
+)
+assert-css: (
+    ".impl .code-header",
+    {"color": "rgb(0, 0, 0)", "background-color": "rgb(255, 255, 255)"},
+    ALL,
+)
 
 goto: file://|DOC_PATH|/test_docs/struct.Foo.html#impl
 assert-css: ("#impl", {"color": "rgb(0, 0, 0)", "background-color": "rgb(253, 255, 211)"})
 
 goto: file://|DOC_PATH|/test_docs/struct.Foo.html#method.must_use
-assert-css: ("#method\.must_use", {"color": "rgb(0, 0, 0)", "background-color": "rgb(253, 255, 211)"}, ALL)
+assert-css: (
+    "#method\.must_use",
+    {"color": "rgb(0, 0, 0)", "background-color": "rgb(253, 255, 211)"},
+    ALL,
+)
 
 goto: file://|DOC_PATH|/test_docs/index.html
 assert-css: (".section-header a", {"color": "rgb(0, 0, 0)"}, ALL)

--- a/src/test/rustdoc-gui/huge-collection-of-constants.goml
+++ b/src/test/rustdoc-gui/huge-collection-of-constants.goml
@@ -2,4 +2,8 @@ goto: file://|DOC_PATH|/test_docs/huge_amount_of_consts/index.html
 
 // Make sure that the last two entries are more than 12 pixels apart and not stacked on each other.
 
-compare-elements-position-near-false: ("//*[@class='item-table']//div[last()-1]", "//*[@class='item-table']//div[last()-3]", {"y": 12})
+compare-elements-position-near-false: (
+    "//*[@class='item-table']//div[last()-1]",
+    "//*[@class='item-table']//div[last()-3]",
+    {"y": 12},
+)

--- a/src/test/rustdoc-gui/jump-to-def-background.goml
+++ b/src/test/rustdoc-gui/jump-to-def-background.goml
@@ -2,22 +2,42 @@
 goto: file://|DOC_PATH|/src/link_to_definition/lib.rs.html
 
 // Set the theme to dark.
-local-storage: {"rustdoc-theme": "dark", "rustdoc-preferred-dark-theme": "dark", "rustdoc-use-system-theme": "false"}
+local-storage: {
+    "rustdoc-theme": "dark",
+    "rustdoc-preferred-dark-theme": "dark",
+    "rustdoc-use-system-theme": "false",
+}
 // We reload the page so the local storage settings are being used.
 reload:
 
-assert-css: ("body.source .example-wrap pre.rust a", {"background-color": "rgb(51, 51, 51)"}, ALL)
+assert-css: (
+    "body.source .example-wrap pre.rust a",
+    {"background-color": "rgb(51, 51, 51)"},
+    ALL,
+)
 
 // Set the theme to ayu.
-local-storage: {"rustdoc-theme": "ayu", "rustdoc-preferred-dark-theme": "ayu", "rustdoc-use-system-theme": "false"}
+local-storage: {
+    "rustdoc-theme": "ayu",
+    "rustdoc-preferred-dark-theme": "ayu",
+    "rustdoc-use-system-theme": "false",
+}
 // We reload the page so the local storage settings are being used.
 reload:
 
-assert-css: ("body.source .example-wrap pre.rust a", {"background-color": "rgb(51, 51, 51)"}, ALL)
+assert-css: (
+    "body.source .example-wrap pre.rust a",
+    {"background-color": "rgb(51, 51, 51)"},
+    ALL,
+)
 
 // Set the theme to light.
 local-storage: {"rustdoc-theme": "light", "rustdoc-use-system-theme": "false"}
 // We reload the page so the local storage settings are being used.
 reload:
 
-assert-css: ("body.source .example-wrap pre.rust a", {"background-color": "rgb(238, 238, 238)"}, ALL)
+assert-css: (
+    "body.source .example-wrap pre.rust a",
+    {"background-color": "rgb(238, 238, 238)"},
+    ALL,
+)

--- a/src/test/rustdoc-gui/label-next-to-symbol.goml
+++ b/src/test/rustdoc-gui/label-next-to-symbol.goml
@@ -8,29 +8,71 @@ assert: (".stab.deprecated")
 assert: (".stab.portability")
 
 // make sure that deprecated and portability are different colours
-assert-css: (".item-table .item-left .stab.deprecated", { "background-color": "rgb(255, 196, 196)" })
-assert-css: (".item-table .item-left .stab.portability", { "background-color": "rgb(243, 223, 255)" })
+assert-css: (
+    ".item-table .item-left .stab.deprecated",
+    { "background-color": "rgb(255, 196, 196)" },
+)
+assert-css: (
+    ".item-table .item-left .stab.portability",
+    { "background-color": "rgb(243, 223, 255)" },
+)
 
 // table like view
 assert-css: (".item-right.docblock-short", { "padding-left": "0px" })
-compare-elements-position-near: ("//*[@class='item-left module-item']//a[text()='replaced_function']", ".item-left .stab.deprecated", {"y": 2})
-compare-elements-position: (".item-left .stab.deprecated", ".item-left .stab.portability", ("y"))
+compare-elements-position-near: (
+    "//*[@class='item-left module-item']//a[text()='replaced_function']",
+    ".item-left .stab.deprecated",
+    {"y": 2},
+)
+compare-elements-position: (
+    ".item-left .stab.deprecated",
+    ".item-left .stab.portability",
+    ("y"),
+)
 
 // Ensure no wrap
-compare-elements-position-near: ("//*[@class='item-left module-item']//a[text()='replaced_function']", "//*[@class='item-right docblock-short']//p[text()='a thing with a label']", {"y": 2})
+compare-elements-position-near: (
+    "//*[@class='item-left module-item']//a[text()='replaced_function']",
+    "//*[@class='item-right docblock-short']//p[text()='a thing with a label']",
+    {"y": 2},
+)
 // compare parent elements
-compare-elements-position: ("//*[@class='item-left module-item']//a[text()='replaced_function']/..", "//*[@class='item-right docblock-short']//p[text()='a thing with a label']/..", ("y"))
+compare-elements-position: (
+    "//*[@class='item-left module-item']//a[text()='replaced_function']/..",
+    "//*[@class='item-right docblock-short']//p[text()='a thing with a label']/..",
+    ("y"),
+)
 
 
 // Mobile view
 size: (600, 600)
 // staggered layout with 2em spacing
 assert-css: (".item-right.docblock-short", { "padding-left": "32px" })
-compare-elements-position-near: ("//*[@class='item-left module-item']//a[text()='replaced_function']", ".item-left .stab.deprecated", {"y": 1})
-compare-elements-position: (".item-left .stab.deprecated", ".item-left .stab.portability", ("y"))
+compare-elements-position-near: (
+    "//*[@class='item-left module-item']//a[text()='replaced_function']",
+    ".item-left .stab.deprecated",
+    {"y": 1},
+)
+compare-elements-position: (
+    ".item-left .stab.deprecated",
+    ".item-left .stab.portability",
+    ("y"),
+)
 
 // Ensure wrap
-compare-elements-position-near-false: ("//*[@class='item-left module-item']//a[text()='replaced_function']", "//*[@class='item-right docblock-short']//p[text()='a thing with a label']", {"y": 12})
+compare-elements-position-near-false: (
+    "//*[@class='item-left module-item']//a[text()='replaced_function']",
+    "//*[@class='item-right docblock-short']//p[text()='a thing with a label']",
+    {"y": 12},
+)
 // compare parent elements
-compare-elements-position-false: ("//*[@class='item-left module-item']//a[text()='replaced_function']/..", "//*[@class='item-right docblock-short']//p[text()='a thing with a label']/..", ("y"))
-compare-elements-position-false: (".item-left .stab.deprecated", "//*[@class='item-right docblock-short']//p[text()='a thing with a label']", ("y"))
+compare-elements-position-false: (
+    "//*[@class='item-left module-item']//a[text()='replaced_function']/..",
+    "//*[@class='item-right docblock-short']//p[text()='a thing with a label']/..",
+    ("y"),
+)
+compare-elements-position-false: (
+    ".item-left .stab.deprecated",
+    "//*[@class='item-right docblock-short']//p[text()='a thing with a label']",
+    ("y"),
+)

--- a/src/test/rustdoc-gui/module-items-font.goml
+++ b/src/test/rustdoc-gui/module-items-font.goml
@@ -1,23 +1,67 @@
 // This test checks that the correct font is used on module items (in index.html pages).
 goto: file://|DOC_PATH|/test_docs/index.html
-assert-css: (".item-table .module-item a", {"font-family": '"Fira Sans", Arial, NanumBarunGothic, sans-serif'}, ALL)
-assert-css: (".item-table .docblock-short", {"font-family": '"Source Serif 4", NanumBarunGothic, serif'}, ALL)
+assert-css: (
+    ".item-table .module-item a",
+    {"font-family": '"Fira Sans", Arial, NanumBarunGothic, sans-serif'},
+    ALL,
+)
+assert-css: (
+    ".item-table .docblock-short",
+    {"font-family": '"Source Serif 4", NanumBarunGothic, serif'},
+    ALL,
+)
 
 // modules
-assert-css: ("#modules + .item-table .item-left a", {"font-family": '"Fira Sans", Arial, NanumBarunGothic, sans-serif'})
-assert-css: ("#modules + .item-table .item-right.docblock-short", {"font-family": '"Source Serif 4", NanumBarunGothic, serif'})
+assert-css: (
+    "#modules + .item-table .item-left a",
+    {"font-family": '"Fira Sans", Arial, NanumBarunGothic, sans-serif'},
+)
+assert-css: (
+    "#modules + .item-table .item-right.docblock-short",
+    {"font-family": '"Source Serif 4", NanumBarunGothic, serif'},
+)
 // structs
-assert-css: ("#structs + .item-table .item-left a", {"font-family": '"Fira Sans", Arial, NanumBarunGothic, sans-serif'})
-assert-css: ("#structs + .item-table .item-right.docblock-short", {"font-family": '"Source Serif 4", NanumBarunGothic, serif'})
+assert-css: (
+    "#structs + .item-table .item-left a",
+    {"font-family": '"Fira Sans", Arial, NanumBarunGothic, sans-serif'},
+)
+assert-css: (
+    "#structs + .item-table .item-right.docblock-short",
+    {"font-family": '"Source Serif 4", NanumBarunGothic, serif'},
+)
 // enums
-assert-css: ("#enums + .item-table .item-left a", {"font-family": '"Fira Sans", Arial, NanumBarunGothic, sans-serif'})
-assert-css: ("#enums + .item-table .item-right.docblock-short", {"font-family": '"Source Serif 4", NanumBarunGothic, serif'})
+assert-css: (
+    "#enums + .item-table .item-left a",
+    {"font-family": '"Fira Sans", Arial, NanumBarunGothic, sans-serif'},
+)
+assert-css: (
+    "#enums + .item-table .item-right.docblock-short",
+    {"font-family": '"Source Serif 4", NanumBarunGothic, serif'},
+)
 // traits
-assert-css: ("#traits + .item-table .item-left a", {"font-family": '"Fira Sans", Arial, NanumBarunGothic, sans-serif'})
-assert-css: ("#traits + .item-table .item-right.docblock-short", {"font-family": '"Source Serif 4", NanumBarunGothic, serif'})
+assert-css: (
+    "#traits + .item-table .item-left a",
+    {"font-family": '"Fira Sans", Arial, NanumBarunGothic, sans-serif'},
+)
+assert-css: (
+    "#traits + .item-table .item-right.docblock-short",
+    {"font-family": '"Source Serif 4", NanumBarunGothic, serif'},
+)
 // functions
-assert-css: ("#functions + .item-table .item-left a", {"font-family": '"Fira Sans", Arial, NanumBarunGothic, sans-serif'})
-assert-css: ("#functions + .item-table .item-right.docblock-short", {"font-family": '"Source Serif 4", NanumBarunGothic, serif'})
+assert-css: (
+    "#functions + .item-table .item-left a",
+    {"font-family": '"Fira Sans", Arial, NanumBarunGothic, sans-serif'},
+)
+assert-css: (
+    "#functions + .item-table .item-right.docblock-short",
+    {"font-family": '"Source Serif 4", NanumBarunGothic, serif'},
+)
 // keywords
-assert-css: ("#keywords + .item-table .item-left a", {"font-family": '"Fira Sans", Arial, NanumBarunGothic, sans-serif'})
-assert-css: ("#keywords + .item-table .item-right.docblock-short", {"font-family": '"Source Serif 4", NanumBarunGothic, serif'})
+assert-css: (
+    "#keywords + .item-table .item-left a",
+    {"font-family": '"Fira Sans", Arial, NanumBarunGothic, sans-serif'},
+)
+assert-css: (
+    "#keywords + .item-table .item-right.docblock-short",
+    {"font-family": '"Source Serif 4", NanumBarunGothic, serif'},
+)

--- a/src/test/rustdoc-gui/search-result-color.goml
+++ b/src/test/rustdoc-gui/search-result-color.goml
@@ -5,28 +5,54 @@ goto: file://|DOC_PATH|/test_docs/index.html?search=coo
 show-text: true
 
 // Ayu theme
-local-storage: {"rustdoc-theme": "ayu", "rustdoc-preferred-dark-theme": "ayu", "rustdoc-use-system-theme": "false"}
+local-storage: {
+    "rustdoc-theme": "ayu",
+    "rustdoc-preferred-dark-theme": "ayu",
+    "rustdoc-use-system-theme": "false",
+}
 reload:
 
 // Waiting for the search results to appear...
 wait-for: "#titles"
-assert-css: ("//*[@class='desc']//*[text()='Just a normal struct.']", {"color": "rgb(197, 197, 197)"})
-assert-css: ("//*[@class='result-name']/*[text()='test_docs::']", {"color": "rgb(0, 150, 207)"})
+assert-css: (
+    "//*[@class='desc']//*[text()='Just a normal struct.']",
+    {"color": "rgb(197, 197, 197)"},
+)
+assert-css: (
+    "//*[@class='result-name']/*[text()='test_docs::']",
+    {"color": "rgb(0, 150, 207)"},
+)
 
 // Checking the color for "keyword".
-assert-css: ("//*[@class='result-name']//*[text()='(keyword)']", {"color": "rgb(120, 135, 151)"})
+assert-css: (
+    "//*[@class='result-name']//*[text()='(keyword)']",
+    {"color": "rgb(120, 135, 151)"},
+)
 
 // Dark theme
-local-storage: {"rustdoc-theme": "dark", "rustdoc-preferred-dark-theme": "dark", "rustdoc-use-system-theme": "false"}
+local-storage: {
+    "rustdoc-theme": "dark",
+    "rustdoc-preferred-dark-theme": "dark",
+    "rustdoc-use-system-theme": "false",
+}
 reload:
 
 // Waiting for the search results to appear...
 wait-for: "#titles"
-assert-css: ("//*[@class='desc']//*[text()='Just a normal struct.']", {"color": "rgb(221, 221, 221)"})
-assert-css: ("//*[@class='result-name']/*[text()='test_docs::']", {"color": "rgb(221, 221, 221)"})
+assert-css: (
+    "//*[@class='desc']//*[text()='Just a normal struct.']",
+    {"color": "rgb(221, 221, 221)"},
+)
+assert-css: (
+    "//*[@class='result-name']/*[text()='test_docs::']",
+    {"color": "rgb(221, 221, 221)"},
+)
 
 // Checking the color for "keyword".
-assert-css: ("//*[@class='result-name']//*[text()='(keyword)']", {"color": "rgb(221, 221, 221)"})
+assert-css: (
+    "//*[@class='result-name']//*[text()='(keyword)']",
+    {"color": "rgb(221, 221, 221)"},
+)
 
 // Light theme
 local-storage: {"rustdoc-theme": "light", "rustdoc-use-system-theme": "false"}
@@ -34,8 +60,17 @@ reload:
 
 // Waiting for the search results to appear...
 wait-for: "#titles"
-assert-css: ("//*[@class='desc']//*[text()='Just a normal struct.']", {"color": "rgb(0, 0, 0)"})
-assert-css: ("//*[@class='result-name']/*[text()='test_docs::']", {"color": "rgb(0, 0, 0)"})
+assert-css: (
+    "//*[@class='desc']//*[text()='Just a normal struct.']",
+    {"color": "rgb(0, 0, 0)"},
+)
+assert-css: (
+    "//*[@class='result-name']/*[text()='test_docs::']",
+    {"color": "rgb(0, 0, 0)"},
+)
 
 // Checking the color for "keyword".
-assert-css: ("//*[@class='result-name']//*[text()='(keyword)']", {"color": "rgb(0, 0, 0)"})
+assert-css: (
+    "//*[@class='result-name']//*[text()='(keyword)']",
+    {"color": "rgb(0, 0, 0)"},
+)

--- a/src/test/rustdoc-gui/search-result-colors.goml
+++ b/src/test/rustdoc-gui/search-result-colors.goml
@@ -1,7 +1,11 @@
 goto: file://|DOC_PATH|/test_docs/index.html
 // We set the theme so we're sure that the correct values will be used, whatever the computer
 // this test is running on.
-local-storage: {"rustdoc-theme": "dark", "rustdoc-preferred-dark-theme": "dark", "rustdoc-use-system-theme": "false"}
+local-storage: {
+    "rustdoc-theme": "dark",
+    "rustdoc-preferred-dark-theme": "dark",
+    "rustdoc-use-system-theme": "false",
+}
 // If the text isn't displayed, the browser doesn't compute color style correctly...
 show-text: true
 // We reload the page so the local storage settings are being used.


### PR DESCRIPTION
Since the `0.5.1`, we can use trailing commas. I also used the opportunity to clean up the existing tests.

r? @notriddle