### PR TITLE
Avoid sorting in hash map stable hashing

### DIFF
--- a/compiler/rustc_data_structures/src/stable_hasher.rs
+++ b/compiler/rustc_data_structures/src/stable_hasher.rs
@@ -503,13 +503,17 @@ impl_stable_hash_via_hash!(::std::path::PathBuf);
 
 impl<K, V, R, HCX> HashStable<HCX> for ::std::collections::HashMap<K, V, R>
 where
-    K: HashStable<HCX> + ToStableHashKey<HCX> + Eq,
+    K: ToStableHashKey<HCX> + Eq,
     V: HashStable<HCX>,
     R: BuildHasher,
 {
     #[inline]
     fn hash_stable(&self, hcx: &mut HCX, hasher: &mut StableHasher) {
-        hash_stable_hashmap(hcx, hasher, self, ToStableHashKey::to_stable_hash_key);
+        stable_hash_reduce(hcx, hasher, self.iter(), self.len(), |hasher, hcx, (key, value)| {
+            let key = key.to_stable_hash_key(hcx);
+            key.hash_stable(hcx, hasher);
+            value.hash_stable(hcx, hasher);
+        });
     }
 }
 
@@ -519,9 +523,10 @@ where
     R: BuildHasher,
 {
     fn hash_stable(&self, hcx: &mut HCX, hasher: &mut StableHasher) {
-        let mut keys: Vec<_> = self.iter().map(|k| k.to_stable_hash_key(hcx)).collect();
-        keys.sort_unstable();
-        keys.hash_stable(hcx, hasher);
+        stable_hash_reduce(hcx, hasher, self.iter(), self.len(), |hasher, hcx, key| {
+            let key = key.to_stable_hash_key(hcx);
+            key.hash_stable(hcx, hasher);
+        });
     }
 }
 
@@ -531,10 +536,11 @@ where
     V: HashStable<HCX>,
 {
     fn hash_stable(&self, hcx: &mut HCX, hasher: &mut StableHasher) {
-        let mut entries: Vec<_> =
-            self.iter().map(|(k, v)| (k.to_stable_hash_key(hcx), v)).collect();
-        entries.sort_unstable_by(|&(ref sk1, _), &(ref sk2, _)| sk1.cmp(sk2));
-        entries.hash_stable(hcx, hasher);
+        stable_hash_reduce(hcx, hasher, self.iter(), self.len(), |hasher, hcx, (key, value)| {
+            let key = key.to_stable_hash_key(hcx);
+            key.hash_stable(hcx, hasher);
+            value.hash_stable(hcx, hasher);
+        });
     }
 }
 
@@ -543,34 +549,30 @@ where
     K: ToStableHashKey<HCX>,
 {
     fn hash_stable(&self, hcx: &mut HCX, hasher: &mut StableHasher) {
-        let mut keys: Vec<_> = self.iter().map(|k| k.to_stable_hash_key(hcx)).collect();
-        keys.sort_unstable();
-        keys.hash_stable(hcx, hasher);
+        stable_hash_reduce(hcx, hasher, self.iter(), self.len(), |hasher, hcx, key| {
+            let key = key.to_stable_hash_key(hcx);
+            key.hash_stable(hcx, hasher);
+        });
     }
 }
 
-pub fn hash_stable_hashmap<HCX, K, V, R, SK, F>(
+fn stable_hash_reduce<HCX, I, C, F>(
     hcx: &mut HCX,
     hasher: &mut StableHasher,
-    map: &::std::collections::HashMap<K, V, R>,
-    to_stable_hash_key: F,
+    collection: C,
+    length: usize,
+    hash_function: F,
 ) where
-    K: Eq + HashStable<HCX>,
-    V: HashStable<HCX>,
-    R: BuildHasher,
-    SK: HashStable<HCX> + Ord,
-    F: Fn(&K, &HCX) -> SK,
+    C: Iterator<Item = I>,
+    F: Fn(&mut StableHasher, &mut HCX, I),
 {
-    let hash = map
-        .iter()
-        .map(|(key, value)| {
-            let key = to_stable_hash_key(key, hcx);
+    let hash = collection
+        .map(|value| {
             let mut hasher = StableHasher::new();
-            key.hash_stable(hcx, &mut hasher);
-            value.hash_stable(hcx, &mut hasher);
+            hash_function(&mut hasher, hcx, value);
             hasher.finish::<u128>()
         })
         .reduce(|accum, value| accum.wrapping_add(value));
-    map.len().hash_stable(hcx, hasher);
+    length.hash_stable(hcx, hasher);
     hash.hash_stable(hcx, hasher);
 }

--- a/compiler/rustc_data_structures/src/stable_hasher.rs
+++ b/compiler/rustc_data_structures/src/stable_hasher.rs
@@ -503,7 +503,7 @@ impl_stable_hash_via_hash!(::std::path::PathBuf);
 
 impl<K, V, R, HCX> HashStable<HCX> for ::std::collections::HashMap<K, V, R>
 where
-    K: ToStableHashKey<HCX> + Eq,
+    K: HashStable<HCX> + ToStableHashKey<HCX> + Eq,
     V: HashStable<HCX>,
     R: BuildHasher,
 {
@@ -555,7 +555,7 @@ pub fn hash_stable_hashmap<HCX, K, V, R, SK, F>(
     map: &::std::collections::HashMap<K, V, R>,
     to_stable_hash_key: F,
 ) where
-    K: Eq,
+    K: Eq + HashStable<HCX>,
     V: HashStable<HCX>,
     R: BuildHasher,
     SK: HashStable<HCX> + Ord,
@@ -570,7 +570,7 @@ pub fn hash_stable_hashmap<HCX, K, V, R, SK, F>(
             value.hash_stable(hcx, &mut hasher);
             hasher.finish::<u128>()
         })
-        .reduce(|accum, value| accum.wrapping_mul(value));
+        .reduce(|accum, value| accum.wrapping_add(value));
     map.len().hash_stable(hcx, hasher);
     hash.hash_stable(hcx, hasher);
 }


### PR DESCRIPTION
Suggested by @the8472 [here](https://github.com/rust-lang/rust/pull/89404#issuecomment-991813333). I hope that I understood it right, I replaced the sort with modular multiplication, which should be commutative.

Can I ask for a perf. run? However, locally it didn't help at all. Creating the `StableHasher` all over again is probably slowing it down quite a lot. And using `FxHasher` is not straightforward, because the keys and values only implement `HashStable` (and probably they shouldn't be just hashed via `Hash` anyway for it to actually be stable).

Maybe the `StableHash` interface could be changed somehow to better suppor these scenarios where the hasher is short-lived. Or the `StableHasher` implementation could have variants with e.g. a shorter buffer for these scenarios.