### PR TITLE
Fix FIXME for `generic_arg_infer` in `create_substs_for_ast_path`

### DIFF
--- a/compiler/rustc_typeck/src/astconv/mod.rs
+++ b/compiler/rustc_typeck/src/astconv/mod.rs
@@ -414,34 +414,40 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                 arg: &GenericArg<'_>,
             ) -> subst::GenericArg<'tcx> {
                 let tcx = self.astconv.tcx();
+
+                let mut handle_ty_args = |has_default, ty: &hir::Ty<'_>| {
+                    if has_default {
+                        tcx.check_optional_stability(
+                            param.def_id,
+                            Some(arg.id()),
+                            arg.span(),
+                            None,
+                            |_, _| {
+                                // Default generic parameters may not be marked
+                                // with stability attributes, i.e. when the
+                                // default parameter was defined at the same time
+                                // as the rest of the type. As such, we ignore missing
+                                // stability attributes.
+                            },
+                        )
+                    }
+                    if let (hir::TyKind::Infer, false) = (&ty.kind, self.astconv.allow_ty_infer()) {
+                        self.inferred_params.push(ty.span);
+                        tcx.ty_error().into()
+                    } else {
+                        self.astconv.ast_ty_to_ty(ty).into()
+                    }
+                };
+
                 match (&param.kind, arg) {
                     (GenericParamDefKind::Lifetime, GenericArg::Lifetime(lt)) => {
                         self.astconv.ast_region_to_region(lt, Some(param)).into()
                     }
                     (&GenericParamDefKind::Type { has_default, .. }, GenericArg::Type(ty)) => {
-                        if has_default {
-                            tcx.check_optional_stability(
-                                param.def_id,
-                                Some(arg.id()),
-                                arg.span(),
-                                None,
-                                |_, _| {
-                                    // Default generic parameters may not be marked
-                                    // with stability attributes, i.e. when the
-                                    // default parameter was defined at the same time
-                                    // as the rest of the type. As such, we ignore missing
-                                    // stability attributes.
-                                },
-                            )
-                        }
-                        if let (hir::TyKind::Infer, false) =
-                            (&ty.kind, self.astconv.allow_ty_infer())
-                        {
-                            self.inferred_params.push(ty.span);
-                            tcx.ty_error().into()
-                        } else {
-                            self.astconv.ast_ty_to_ty(ty).into()
-                        }
+                        handle_ty_args(has_default, ty)
+                    }
+                    (&GenericParamDefKind::Type { has_default, .. }, GenericArg::Infer(inf)) => {
+                        handle_ty_args(has_default, &inf.to_ty())
                     }
                     (GenericParamDefKind::Const { .. }, GenericArg::Const(ct)) => {
                         ty::Const::from_opt_const_arg_anon_const(
@@ -453,41 +459,13 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                         )
                         .into()
                     }
-                    (&GenericParamDefKind::Const { has_default }, hir::GenericArg::Infer(inf)) => {
-                        if has_default {
-                            tcx.const_param_default(param.def_id).into()
-                        } else if self.astconv.allow_ty_infer() {
-                            // FIXME(const_generics): Actually infer parameter here?
-                            todo!()
-                        } else {
-                            self.inferred_params.push(inf.span);
-                            tcx.ty_error().into()
-                        }
-                    }
-                    (
-                        &GenericParamDefKind::Type { has_default, .. },
-                        hir::GenericArg::Infer(inf),
-                    ) => {
-                        if has_default {
-                            tcx.check_optional_stability(
-                                param.def_id,
-                                Some(arg.id()),
-                                arg.span(),
-                                None,
-                                |_, _| {
-                                    // Default generic parameters may not be marked
-                                    // with stability attributes, i.e. when the
-                                    // default parameter was defined at the same time
-                                    // as the rest of the type. As such, we ignore missing
-                                    // stability attributes.
-                                },
-                            );
-                        }
+                    (&GenericParamDefKind::Const { .. }, hir::GenericArg::Infer(inf)) => {
+                        let ty = tcx.at(self.span).type_of(param.def_id);
                         if self.astconv.allow_ty_infer() {
-                            self.astconv.ast_ty_to_ty(&inf.to_ty()).into()
+                            self.astconv.ct_infer(ty, Some(param), inf.span).into()
                         } else {
                             self.inferred_params.push(inf.span);
-                            tcx.ty_error().into()
+                            tcx.const_error(ty).into()
                         }
                     }
                     _ => unreachable!(),

--- a/src/test/ui/const-generics/generic_arg_infer/dont-use-defaults.rs
+++ b/src/test/ui/const-generics/generic_arg_infer/dont-use-defaults.rs
@@ -1,0 +1,15 @@
+// run-pass
+#![feature(generic_arg_infer)]
+
+// test that we dont use defaults to aide in type inference
+
+struct Foo<const N: usize = 2>;
+impl<const N: usize> Foo<N> {
+    fn make_arr() -> [(); N] {
+        [(); N]
+    }
+}
+
+fn main() {
+    let [(), (), ()] = Foo::<_>::make_arr();
+}

--- a/src/test/ui/const-generics/generic_arg_infer/issue-91614.rs
+++ b/src/test/ui/const-generics/generic_arg_infer/issue-91614.rs
@@ -1,0 +1,8 @@
+#![feature(portable_simd)]
+#![feature(generic_arg_infer)]
+use std::simd::Mask;
+
+fn main() {
+    let y = Mask::<_, _>::splat(false);
+    //~^ error: type annotations needed for `Mask<_, {_: usize}>`
+}

--- a/src/test/ui/const-generics/generic_arg_infer/issue-91614.stderr
+++ b/src/test/ui/const-generics/generic_arg_infer/issue-91614.stderr
@@ -1,0 +1,18 @@
+error[E0283]: type annotations needed for `Mask<_, {_: usize}>`
+  --> $DIR/issue-91614.rs:6:13
+   |
+LL |     let y = Mask::<_, _>::splat(false);
+   |         -   ^^^^^^^^^^^^^^^^^^^ cannot infer type for type parameter `T`
+   |         |
+   |         consider giving `y` the explicit type `Mask<_, LANES>`, where the type parameter `T` is specified
+   |
+   = note: cannot satisfy `_: MaskElement`
+note: required by a bound in `Mask::<T, LANES>::splat`
+  --> $SRC_DIR/core/src/../../portable-simd/crates/core_simd/src/masks.rs:LL:COL
+   |
+LL |     T: MaskElement,
+   |        ^^^^^^^^^^^ required by this bound in `Mask::<T, LANES>::splat`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0283`.


### PR DESCRIPTION
Fixes a FIXME, does some general refactoring of this fn, and also fixes a bug where we would use a const params defaults instead of an inference var ([playground](https://play.rust-lang.org/?version=nightly&mode=debug&edition=2021&gist=19456f65ea5dc3fcaa9b696f842ab380))
(lot of stuff in one PR but it was all so close together...)

r? @lcnr 
 
Fixes #91614