### PR TITLE
Make `Vec::push` as non-generic as possible

### DIFF
--- a/library/alloc/src/raw_vec/tests.rs
+++ b/library/alloc/src/raw_vec/tests.rs
@@ -135,11 +135,11 @@ fn zst() {
     assert_eq!(v.try_reserve_exact(101, usize::MAX - 100), cap_err);
     zst_sanity(&v);
 
-    assert_eq!(v.grow_amortized(100, usize::MAX - 100), cap_err);
+    //v.grow_amortized(100, usize::MAX - 100); // panics, in `zst_grow_amortized_panic` below
     assert_eq!(v.grow_amortized(101, usize::MAX - 100), cap_err);
     zst_sanity(&v);
 
-    assert_eq!(v.grow_exact(100, usize::MAX - 100), cap_err);
+    //v.grow_exact(100, usize::MAX - 100); // panics, in `zst_grow_exact_panic` below
     assert_eq!(v.grow_exact(101, usize::MAX - 100), cap_err);
     zst_sanity(&v);
 }
@@ -160,4 +160,26 @@ fn zst_reserve_exact_panic() {
     zst_sanity(&v);
 
     v.reserve_exact(101, usize::MAX - 100);
+}
+
+#[test]
+#[should_panic(expected = "divide by zero")]
+fn zst_grow_amortized_panic() {
+    let mut v: RawVec<ZST> = RawVec::new();
+    zst_sanity(&v);
+
+    // This shows the divide by zero that occurs when `grow_amortized()` is
+    // called when `needs_to_grow()` would have returned `false`.
+    let _ = v.grow_amortized(100, usize::MAX - 100);
+}
+
+#[test]
+#[should_panic(expected = "divide by zero")]
+fn zst_grow_exact_panic() {
+    let mut v: RawVec<ZST> = RawVec::new();
+    zst_sanity(&v);
+
+    // This shows the divide by zero that occurs when `grow_amortized()` is
+    // called when `needs_to_grow()` would have returned `false`.
+    let _ = v.grow_exact(100, usize::MAX - 100);
 }


### PR DESCRIPTION
`Vec::push` is a frequently instantiated generic function, and reducing the amount of generic code in functions it calls (e.g. `RawVec::grow_amortized` has been a performance win in the past, e.g. #72013, #91246. But some additional attempts also failed, e.g. #72189, #73912, #75093, #75129.

This PR goes deeper than those old failed attemps. It makes `RawVec::grow_amortized()` about as non-generic as possible. Everything remaining in it involves `self`, or a `T`-dependent operation, or is passing stuff to the non-generic `finish_grow_amortized()`.

r? @ghost