### PR TITLE
Inline two hot dep graph functions.

### DIFF
--- a/compiler/rustc_middle/src/dep_graph/mod.rs
+++ b/compiler/rustc_middle/src/dep_graph/mod.rs
@@ -56,7 +56,8 @@ impl rustc_query_system::dep_graph::DepKind for DepKind {
         })
     }
 
-    fn read_deps<OP>(op: OP)
+    #[inline(always)]
+    fn inlined_read_deps<OP>(op: OP)
     where
         OP: for<'a> FnOnce(Option<&'a Lock<TaskDeps>>),
     {
@@ -64,6 +65,14 @@ impl rustc_query_system::dep_graph::DepKind for DepKind {
             let icx = if let Some(icx) = icx { icx } else { return };
             op(icx.task_deps)
         })
+    }
+
+    #[inline(never)]
+    fn uninlined_read_deps<OP>(op: OP)
+    where
+        OP: for<'a> FnOnce(Option<&'a Lock<TaskDeps>>),
+    {
+        Self::inlined_read_deps(op);
     }
 }
 

--- a/compiler/rustc_query_system/src/cache.rs
+++ b/compiler/rustc_query_system/src/cache.rs
@@ -47,7 +47,7 @@ impl<T: Clone> WithDepNode<T> {
     }
 
     pub fn get<CTX: DepContext>(&self, tcx: CTX) -> T {
-        tcx.dep_graph().read_index(self.dep_node);
+        tcx.dep_graph().uninlined_read_index(self.dep_node);
         self.cached_value.clone()
     }
 }

--- a/compiler/rustc_query_system/src/dep_graph/graph.rs
+++ b/compiler/rustc_query_system/src/dep_graph/graph.rs
@@ -158,7 +158,7 @@ impl<K: DepKind> DepGraph<K> {
 
     pub fn assert_ignored(&self) {
         if let Some(..) = self.data {
-            K::read_deps(|task_deps| {
+            K::uninlined_read_deps(|task_deps| {
                 assert!(task_deps.is_none(), "expected no task dependency tracking");
             })
         }
@@ -355,10 +355,10 @@ impl<K: DepKind> DepGraph<K> {
         }
     }
 
-    #[inline]
-    pub fn read_index(&self, dep_node_index: DepNodeIndex) {
+    #[inline(always)]
+    pub fn inlined_read_index(&self, dep_node_index: DepNodeIndex) {
         if let Some(ref data) = self.data {
-            K::read_deps(|task_deps| {
+            K::inlined_read_deps(|task_deps| {
                 if let Some(task_deps) = task_deps {
                     let mut task_deps = task_deps.lock();
                     let task_deps = &mut *task_deps;
@@ -398,6 +398,11 @@ impl<K: DepKind> DepGraph<K> {
                 }
             })
         }
+    }
+
+    #[inline(never)]
+    pub fn uninlined_read_index(&self, dep_node_index: DepNodeIndex) {
+        self.inlined_read_index(dep_node_index);
     }
 
     #[inline]

--- a/compiler/rustc_query_system/src/dep_graph/mod.rs
+++ b/compiler/rustc_query_system/src/dep_graph/mod.rs
@@ -94,8 +94,15 @@ pub trait DepKind: Copy + fmt::Debug + Eq + Hash + Send + Encodable<FileEncoder>
     where
         OP: FnOnce() -> R;
 
-    /// Access dependencies from current implicit context.
-    fn read_deps<OP>(op: OP)
+    /// Access dependencies from current implicit context (hot call sites).
+    /// Impls should be marked with `#[inline(always)]`.
+    fn inlined_read_deps<OP>(op: OP)
+    where
+        OP: for<'a> FnOnce(Option<&'a Lock<TaskDeps<Self>>>);
+
+    /// Access dependencies from current implicit context (cold call sites).
+    /// Impls should be marked with `#[inline(never)]`.
+    fn uninlined_read_deps<OP>(op: OP)
     where
         OP: for<'a> FnOnce(Option<&'a Lock<TaskDeps<Self>>>);
 }

--- a/compiler/rustc_query_system/src/query/plumbing.rs
+++ b/compiler/rustc_query_system/src/query/plumbing.rs
@@ -369,7 +369,7 @@ where
         if unlikely!(tcx.profiler().enabled()) {
             tcx.profiler().query_cache_hit(index.into());
         }
-        tcx.dep_graph().read_index(index);
+        tcx.dep_graph().inlined_read_index(index);
         on_hit(value)
     })
 }
@@ -717,7 +717,7 @@ where
             (true, Some(dep_node))
         }
         Some((_, dep_node_index)) => {
-            dep_graph.read_index(dep_node_index);
+            dep_graph.uninlined_read_index(dep_node_index);
             tcx.dep_context().profiler().query_cache_hit(dep_node_index.into());
             (false, None)
         }
@@ -764,7 +764,7 @@ where
         &query,
     );
     if let Some(dep_node_index) = dep_node_index {
-        tcx.dep_context().dep_graph().read_index(dep_node_index)
+        tcx.dep_context().dep_graph().uninlined_read_index(dep_node_index)
     }
     Some(result)
 }

--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -1076,7 +1076,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
     {
         let (result, dep_node) =
             self.tcx().dep_graph.with_anon_task(self.tcx(), DepKind::TraitSelect, || op(self));
-        self.tcx().dep_graph.read_index(dep_node);
+        self.tcx().dep_graph.inlined_read_index(dep_node);
         (result, dep_node)
     }
 


### PR DESCRIPTION
But only at the hot call sites. This reduces instructions counts on lots
of benchmarks, mostly by less than 1%, with the best being over 2%.

r? @Mark-Simulacrum 