### PR TITLE
Warn for outlives lint when gats are enabled for non-gats

### DIFF
--- a/compiler/rustc_typeck/src/check/wfcheck.rs
+++ b/compiler/rustc_typeck/src/check/wfcheck.rs
@@ -285,11 +285,6 @@ fn check_gat_where_clauses(
         return;
     }
     let generics: &ty::Generics = tcx.generics_of(trait_item.def_id);
-    // If the current associated type doesn't have any (own) params, it's not a GAT
-    // FIXME(jackh726): we can also warn in the more general case
-    if generics.params.len() == 0 && !tcx.features().generic_associated_types {
-        return;
-    }
     let associated_items: &ty::AssocItems<'_> = tcx.associated_items(encl_trait_def_id);
     let mut clauses: Option<FxHashSet<ty::Predicate<'_>>> = None;
     // For every function in this trait...
@@ -466,17 +461,11 @@ fn check_gat_where_clauses(
         if !clauses.is_empty() {
             let plural = if clauses.len() > 1 { "s" } else { "" };
             let severity = if generics.params.len() == 0 { "recommended" } else { "required" };
-            let mut err = if generics.params.len() == 0 {
-                tcx.sess.struct_span_warn(
-                    trait_item.span,
-                    &format!("missing {} bound{} on `{}`", severity, plural, trait_item.ident),
-                )
-            } else {
+            let mut err = 
                 tcx.sess.struct_span_err(
                     trait_item.span,
                     &format!("missing {} bound{} on `{}`", severity, plural, trait_item.ident),
-                )
-            };
+                );
 
             let suggestion = format!(
                 "{} {}",

--- a/src/test/ui/generic-associated-types/self-outlives-lint.rs
+++ b/src/test/ui/generic-associated-types/self-outlives-lint.rs
@@ -102,10 +102,20 @@ impl Des3 for () {
 }
 */
 
-// Similar case to before, except with GAT.
+// Similar case to before, except without GAT.
 trait NoGat<'a> {
     type Bar;
+    //~^ missing recommended
     fn method(&'a self) -> Self::Bar;
+}
+
+
+// Same as above, except explicit
+trait NoGatWarning<'a> {
+    type Output;
+    //~^ missing recommended
+
+    fn method(&'a self) -> <Self as NoGatWarning<'a>>::Output;
 }
 
 // Lifetime is not on function; except `Self: 'a`
@@ -184,7 +194,7 @@ trait MultipleMethods {
 
 // We would normally require `Self: 'a`, but we can prove that `Self: 'static`
 // because of the the bounds on the trait, so the bound is proven
-trait Trait: 'static {
+trait StaticTrait: 'static {
     type Assoc<'a>;
     fn make_assoc(_: &u32) -> Self::Assoc<'_>;
 }

--- a/src/test/ui/generic-associated-types/self-outlives-lint.stderr
+++ b/src/test/ui/generic-associated-types/self-outlives-lint.stderr
@@ -75,8 +75,30 @@ LL |     type Out<'x, D>;
    = note: this bound is currently required to ensure that impls have maximum flexibility
    = note: we are soliciting feedback, see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
 
+warning: missing recommended bound on `Bar`
+  --> $DIR/self-outlives-lint.rs:107:5
+   |
+LL |     type Bar;
+   |     ^^^^^^^^-
+   |             |
+   |             help: add the recommended where clause: `where Self: 'a`
+   |
+   = note: this bound is currently recommended to ensure that impls have maximum flexibility
+   = note: we are soliciting feedback, see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
+
+warning: missing recommended bound on `Output`
+  --> $DIR/self-outlives-lint.rs:115:5
+   |
+LL |     type Output;
+   |     ^^^^^^^^^^^-
+   |                |
+   |                help: add the recommended where clause: `where Self: 'a`
+   |
+   = note: this bound is currently recommended to ensure that impls have maximum flexibility
+   = note: we are soliciting feedback, see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
+
 error: missing required bounds on `Bar`
-  --> $DIR/self-outlives-lint.rs:114:5
+  --> $DIR/self-outlives-lint.rs:124:5
    |
 LL |     type Bar<'b>;
    |     ^^^^^^^^^^^^-
@@ -87,7 +109,7 @@ LL |     type Bar<'b>;
    = note: we are soliciting feedback, see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
 
 error: missing required bound on `Bar`
-  --> $DIR/self-outlives-lint.rs:122:5
+  --> $DIR/self-outlives-lint.rs:132:5
    |
 LL |     type Bar<'b>;
    |     ^^^^^^^^^^^^-
@@ -98,7 +120,7 @@ LL |     type Bar<'b>;
    = note: we are soliciting feedback, see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
 
 error: missing required bound on `Bar`
-  --> $DIR/self-outlives-lint.rs:129:5
+  --> $DIR/self-outlives-lint.rs:139:5
    |
 LL |     type Bar<'b>;
    |     ^^^^^^^^^^^^-
@@ -109,7 +131,7 @@ LL |     type Bar<'b>;
    = note: we are soliciting feedback, see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
 
 error: missing required bound on `Iterator`
-  --> $DIR/self-outlives-lint.rs:143:5
+  --> $DIR/self-outlives-lint.rs:153:5
    |
 LL |     type Iterator<'a>: Iterator<Item = Self::Item<'a>>;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
@@ -120,7 +142,7 @@ LL |     type Iterator<'a>: Iterator<Item = Self::Item<'a>>;
    = note: we are soliciting feedback, see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
 
 error: missing required bound on `Bar`
-  --> $DIR/self-outlives-lint.rs:151:5
+  --> $DIR/self-outlives-lint.rs:161:5
    |
 LL |     type Bar<'a, 'b>;
    |     ^^^^^^^^^^^^^^^^-
@@ -131,7 +153,7 @@ LL |     type Bar<'a, 'b>;
    = note: we are soliciting feedback, see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
 
 error: missing required bound on `Fut`
-  --> $DIR/self-outlives-lint.rs:167:5
+  --> $DIR/self-outlives-lint.rs:177:5
    |
 LL |     type Fut<'out>;
    |     ^^^^^^^^^^^^^^-
@@ -141,5 +163,5 @@ LL |     type Fut<'out>;
    = note: this bound is currently required to ensure that impls have maximum flexibility
    = note: we are soliciting feedback, see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
 
-error: aborting due to 13 previous errors
+error: aborting due to 13 previous errors; 2 warnings emitted
 


### PR DESCRIPTION
Based on #91849

The basic idea is that having a where clause allows more flexibility, as with GATs. We can't error, because of backwards compatibility.

I think this needs further discussion before merge, but opening this for that discussion.

r? @nikomatsakis 