### PR TITLE
Looser check for overflowing_binary_op

### DIFF
--- a/compiler/rustc_const_eval/src/interpret/operator.rs
+++ b/compiler/rustc_const_eval/src/interpret/operator.rs
@@ -328,7 +328,8 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 self.binary_int_op(bin_op, l, left.layout, r, right.layout)
             }
             _ if left.layout.ty.is_any_ptr() => {
-                // The RHS type must be the same *or an integer type* (for `Offset`).
+                // The RHS type must be a `pointer` *or an integer type* (for `Offset`).
+                // (This is workaround for the issue #91636)
                 assert!(
                     right.layout.ty.is_any_ptr() || right.layout.ty.is_integral(),
                     "Unexpected types for BinOp: {:?} {:?} {:?}",

--- a/compiler/rustc_const_eval/src/interpret/operator.rs
+++ b/compiler/rustc_const_eval/src/interpret/operator.rs
@@ -329,7 +329,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             }
             _ if left.layout.ty.is_any_ptr() => {
                 // The RHS type must be a `pointer` *or an integer type* (for `Offset`).
-                // (This is workaround for the issue #91636)
+                // (Even when both sides are pointers, their type might differ, see issue #91636)
                 assert!(
                     right.layout.ty.is_any_ptr() || right.layout.ty.is_integral(),
                     "Unexpected types for BinOp: {:?} {:?} {:?}",

--- a/compiler/rustc_const_eval/src/interpret/operator.rs
+++ b/compiler/rustc_const_eval/src/interpret/operator.rs
@@ -330,7 +330,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             _ if left.layout.ty.is_any_ptr() => {
                 // The RHS type must be the same *or an integer type* (for `Offset`).
                 assert!(
-                    right.layout.ty == left.layout.ty || right.layout.ty.is_integral(),
+                    right.layout.ty.is_any_ptr()|| right.layout.ty.is_integral(),
                     "Unexpected types for BinOp: {:?} {:?} {:?}",
                     left.layout.ty,
                     bin_op,

--- a/compiler/rustc_const_eval/src/interpret/operator.rs
+++ b/compiler/rustc_const_eval/src/interpret/operator.rs
@@ -330,7 +330,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             _ if left.layout.ty.is_any_ptr() => {
                 // The RHS type must be the same *or an integer type* (for `Offset`).
                 assert!(
-                    right.layout.ty.is_any_ptr()|| right.layout.ty.is_integral(),
+                    right.layout.ty.is_any_ptr() || right.layout.ty.is_integral(),
                     "Unexpected types for BinOp: {:?} {:?} {:?}",
                     left.layout.ty,
                     bin_op,

--- a/src/test/ui/binop/binary-op-on-fn-ptr-eq.rs
+++ b/src/test/ui/binop/binary-op-on-fn-ptr-eq.rs
@@ -1,0 +1,8 @@
+// Tests equality between supertype and subtype of a function
+// See the issue #91636
+fn foo(_a: &str) {}
+
+fn main() {
+    let x = foo as fn(&'static str);
+    let _ = x == foo;
+}

--- a/src/test/ui/binop/binary-op-on-fn-ptr-eq.rs
+++ b/src/test/ui/binop/binary-op-on-fn-ptr-eq.rs
@@ -1,3 +1,4 @@
+// run-pass
 // Tests equality between supertype and subtype of a function
 // See the issue #91636
 fn foo(_a: &str) {}


### PR DESCRIPTION
Fix for issue #91636 tight check resulted in ICE, this makes the check a little looser. It seems `eq` allows comparing of `supertype` and `subtype` if `lhs = supertype` and `rhs = subtype` but not vice versa, is this intended behavior ?