### PR TITLE
pass -Wl,-z,origin to set DF_ORIGIN when using rpath

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/rpath.rs
+++ b/compiler/rustc_codegen_ssa/src/back/rpath.rs
@@ -23,9 +23,12 @@ pub fn get_rpath_flags(config: &mut RPathConfig<'_>) -> Vec<String> {
     let rpaths = get_rpaths(config);
     let mut flags = rpaths_to_flags(&rpaths);
 
-    // Use DT_RUNPATH instead of DT_RPATH if available
     if config.linker_is_gnu {
+        // Use DT_RUNPATH instead of DT_RPATH if available
         flags.push("-Wl,--enable-new-dtags".to_owned());
+
+        // Set DF_ORIGIN for substitute $ORIGIN
+        flags.push("-Wl,-z,origin".to_owned());
     }
 
     flags

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -1176,6 +1176,7 @@ impl<'a> Builder<'a> {
                 rustflags.arg("-Zosx-rpath-install-name");
                 Some("-Wl,-rpath,@loader_path/../lib")
             } else if !target.contains("windows") {
+                rustflags.arg("-Clink-args=-Wl,-z,origin");
                 Some("-Wl,-rpath,$ORIGIN/../lib")
             } else {
                 None


### PR DESCRIPTION
DF_ORIGIN flag signifies that the object being loaded may make reference to the $ORIGIN substitution string.

Some implementations are just ignoring [DF_ORIGIN](http://www.sco.com/developers/gabi/latest/ch5.dynamic.html#df_flags) and do [substitution](http://www.sco.com/developers/gabi/latest/ch5.dynamic.html#substitution) for $ORIGIN if present (whatever DF_ORIGIN presence or not) like glibc. But some others mandate the present of DF_ORIGIN for the substitution (like OpenBSD).

Set the flag inconditionally if rpath is wanted.

One possible fallout is if the linker rejects `-z origin` option.