### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/compiler/rustc_codegen_llvm/src/lib.rs
+++ b/compiler/rustc_codegen_llvm/src/lib.rs
@@ -6,7 +6,6 @@
 
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
 #![feature(bool_to_option)]
-#![feature(const_cstr_unchecked)]
 #![feature(crate_visibility_modifier)]
 #![feature(extern_types)]
 #![feature(in_band_lifetimes)]

--- a/compiler/rustc_infer/src/infer/free_regions.rs
+++ b/compiler/rustc_infer/src/infer/free_regions.rs
@@ -11,7 +11,7 @@ use rustc_middle::ty::{self, Lift, Region, TyCtxt};
 ///
 /// This stuff is a bit convoluted and should be refactored, but as we
 /// transition to NLL, it'll all go away anyhow.
-pub struct RegionRelations<'a, 'tcx> {
+pub(crate) struct RegionRelations<'a, 'tcx> {
     pub tcx: TyCtxt<'tcx>,
 
     /// The context used for debug messages

--- a/compiler/rustc_infer/src/infer/lexical_region_resolve/mod.rs
+++ b/compiler/rustc_infer/src/infer/lexical_region_resolve/mod.rs
@@ -28,7 +28,7 @@ use std::fmt;
 /// assuming such values can be found. It returns the final values of
 /// all the variables as well as a set of errors that must be reported.
 #[instrument(level = "debug", skip(region_rels, var_infos, data))]
-pub fn resolve<'tcx>(
+pub(crate) fn resolve<'tcx>(
     region_rels: &RegionRelations<'_, 'tcx>,
     var_infos: VarInfos,
     data: RegionConstraintData<'tcx>,

--- a/compiler/rustc_target/src/spec/wasm32_unknown_emscripten.rs
+++ b/compiler/rustc_target/src/spec/wasm32_unknown_emscripten.rs
@@ -35,7 +35,7 @@ pub fn target() -> Target {
         exe_suffix: ".js".to_string(),
         linker: None,
         is_like_emscripten: true,
-        panic_strategy: PanicStrategy::Unwind,
+        panic_strategy: PanicStrategy::Abort,
         post_link_args,
         families: vec!["unix".to_string()],
         ..options

--- a/compiler/rustc_typeck/src/astconv/mod.rs
+++ b/compiler/rustc_typeck/src/astconv/mod.rs
@@ -414,34 +414,40 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                 arg: &GenericArg<'_>,
             ) -> subst::GenericArg<'tcx> {
                 let tcx = self.astconv.tcx();
+
+                let mut handle_ty_args = |has_default, ty: &hir::Ty<'_>| {
+                    if has_default {
+                        tcx.check_optional_stability(
+                            param.def_id,
+                            Some(arg.id()),
+                            arg.span(),
+                            None,
+                            |_, _| {
+                                // Default generic parameters may not be marked
+                                // with stability attributes, i.e. when the
+                                // default parameter was defined at the same time
+                                // as the rest of the type. As such, we ignore missing
+                                // stability attributes.
+                            },
+                        )
+                    }
+                    if let (hir::TyKind::Infer, false) = (&ty.kind, self.astconv.allow_ty_infer()) {
+                        self.inferred_params.push(ty.span);
+                        tcx.ty_error().into()
+                    } else {
+                        self.astconv.ast_ty_to_ty(ty).into()
+                    }
+                };
+
                 match (&param.kind, arg) {
                     (GenericParamDefKind::Lifetime, GenericArg::Lifetime(lt)) => {
                         self.astconv.ast_region_to_region(lt, Some(param)).into()
                     }
                     (&GenericParamDefKind::Type { has_default, .. }, GenericArg::Type(ty)) => {
-                        if has_default {
-                            tcx.check_optional_stability(
-                                param.def_id,
-                                Some(arg.id()),
-                                arg.span(),
-                                None,
-                                |_, _| {
-                                    // Default generic parameters may not be marked
-                                    // with stability attributes, i.e. when the
-                                    // default parameter was defined at the same time
-                                    // as the rest of the type. As such, we ignore missing
-                                    // stability attributes.
-                                },
-                            )
-                        }
-                        if let (hir::TyKind::Infer, false) =
-                            (&ty.kind, self.astconv.allow_ty_infer())
-                        {
-                            self.inferred_params.push(ty.span);
-                            tcx.ty_error().into()
-                        } else {
-                            self.astconv.ast_ty_to_ty(ty).into()
-                        }
+                        handle_ty_args(has_default, ty)
+                    }
+                    (&GenericParamDefKind::Type { has_default, .. }, GenericArg::Infer(inf)) => {
+                        handle_ty_args(has_default, &inf.to_ty())
                     }
                     (GenericParamDefKind::Const { .. }, GenericArg::Const(ct)) => {
                         ty::Const::from_opt_const_arg_anon_const(
@@ -453,41 +459,13 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                         )
                         .into()
                     }
-                    (&GenericParamDefKind::Const { has_default }, hir::GenericArg::Infer(inf)) => {
-                        if has_default {
-                            tcx.const_param_default(param.def_id).into()
-                        } else if self.astconv.allow_ty_infer() {
-                            // FIXME(const_generics): Actually infer parameter here?
-                            todo!()
-                        } else {
-                            self.inferred_params.push(inf.span);
-                            tcx.ty_error().into()
-                        }
-                    }
-                    (
-                        &GenericParamDefKind::Type { has_default, .. },
-                        hir::GenericArg::Infer(inf),
-                    ) => {
-                        if has_default {
-                            tcx.check_optional_stability(
-                                param.def_id,
-                                Some(arg.id()),
-                                arg.span(),
-                                None,
-                                |_, _| {
-                                    // Default generic parameters may not be marked
-                                    // with stability attributes, i.e. when the
-                                    // default parameter was defined at the same time
-                                    // as the rest of the type. As such, we ignore missing
-                                    // stability attributes.
-                                },
-                            );
-                        }
+                    (&GenericParamDefKind::Const { .. }, hir::GenericArg::Infer(inf)) => {
+                        let ty = tcx.at(self.span).type_of(param.def_id);
                         if self.astconv.allow_ty_infer() {
-                            self.astconv.ast_ty_to_ty(&inf.to_ty()).into()
+                            self.astconv.ct_infer(ty, Some(param), inf.span).into()
                         } else {
                             self.inferred_params.push(inf.span);
-                            tcx.ty_error().into()
+                            tcx.const_error(ty).into()
                         }
                     }
                     _ => unreachable!(),

--- a/compiler/rustc_typeck/src/check/wfcheck.rs
+++ b/compiler/rustc_typeck/src/check/wfcheck.rs
@@ -487,9 +487,12 @@ fn check_gat_where_clauses(
             );
 
             let bound = if clauses.len() > 1 { "these bounds are" } else { "this bound is" };
-            err.note(&format!("{} required to ensure that impls have maximum flexibility", bound));
+            err.note(&format!(
+                "{} currently required to ensure that impls have maximum flexibility",
+                bound
+            ));
             err.note(
-                "see issue #87479 \
+                "we are soliciting feedback, see issue #87479 \
                  <https://github.com/rust-lang/rust/issues/87479> \
                  for more information",
             );

--- a/compiler/rustc_typeck/src/check/wfcheck.rs
+++ b/compiler/rustc_typeck/src/check/wfcheck.rs
@@ -14,8 +14,9 @@ use rustc_hir::lang_items::LangItem;
 use rustc_hir::ItemKind;
 use rustc_infer::infer::outlives::env::OutlivesEnvironment;
 use rustc_infer::infer::outlives::obligations::TypeOutlives;
-use rustc_infer::infer::TyCtxtInferExt;
 use rustc_infer::infer::{self, RegionckMode, SubregionOrigin};
+use rustc_infer::infer::{RegionResolutionError, TyCtxtInferExt};
+use rustc_infer::traits::TraitEngine;
 use rustc_middle::hir::map as hir_map;
 use rustc_middle::ty::subst::{GenericArgKind, InternalSubsts, Subst};
 use rustc_middle::ty::trait_def::TraitSpecializationKind;
@@ -26,7 +27,9 @@ use rustc_session::parse::feature_err;
 use rustc_span::symbol::{sym, Ident, Symbol};
 use rustc_span::{Span, DUMMY_SP};
 use rustc_trait_selection::traits::query::evaluate_obligation::InferCtxtExt as _;
-use rustc_trait_selection::traits::{self, ObligationCause, ObligationCauseCode, WellFormedLoc};
+use rustc_trait_selection::traits::{
+    self, ObligationCause, ObligationCauseCode, TraitEngineExt, WellFormedLoc,
+};
 
 use std::convert::TryInto;
 use std::iter;
@@ -426,42 +429,105 @@ fn check_gat_where_clauses(
         }
     }
 
-    // If there are any missing clauses, emit an error
-    let mut clauses = clauses.unwrap_or_default();
+    // If there are any clauses that aren't provable, emit an error
+    let clauses = clauses.unwrap_or_default();
     debug!(?clauses);
     if !clauses.is_empty() {
-        let written_predicates: ty::GenericPredicates<'_> =
-            tcx.explicit_predicates_of(trait_item.def_id);
-        let mut clauses: Vec<_> = clauses
-            .drain_filter(|clause| !written_predicates.predicates.iter().any(|p| &p.0 == clause))
-            .map(|clause| format!("{}", clause))
-            .collect();
-        // We sort so that order is predictable
-        clauses.sort();
-        if !clauses.is_empty() {
-            let mut err = tcx.sess.struct_span_err(
-                trait_item.span,
-                &format!("Missing required bounds on {}", trait_item.ident),
-            );
+        let param_env = tcx.param_env(trait_item.def_id);
 
-            let suggestion = format!(
-                "{} {}",
-                if !trait_item.generics.where_clause.predicates.is_empty() {
-                    ","
-                } else {
-                    " where"
-                },
-                clauses.join(", "),
-            );
-            err.span_suggestion(
-                trait_item.generics.where_clause.tail_span_for_suggestion(),
-                "add the required where clauses",
-                suggestion,
-                Applicability::MachineApplicable,
-            );
+        // This shouldn't really matter, but we need it
+        let cause = traits::ObligationCause::new(
+            trait_item.span,
+            trait_item.hir_id(),
+            ObligationCauseCode::MiscObligation,
+        );
+        // Create an `InferCtxt` to try to prove the clauses we require
+        tcx.infer_ctxt().enter(|infcx| {
+            let mut fulfillment_cx = <dyn TraitEngine<'_>>::new(tcx);
 
-            err.emit()
-        }
+            // Register all the clauses as obligations
+            clauses
+                .clone()
+                .into_iter()
+                .map(|predicate| {
+                    traits::Obligation::new(
+                        cause.clone(),
+                        param_env,
+                        predicate,
+                    )
+                })
+                .for_each(|obligation| {
+                    fulfillment_cx.register_predicate_obligation(&infcx, obligation)
+                });
+
+            // Convert these obligations into constraints by selecting
+            let errors = fulfillment_cx.select_all_or_error(&infcx);
+            if !errors.is_empty() {
+                bug!("should have only registered region obligations, which get registerd as constraints");
+            }
+
+            // FIXME(jackh726): some of this code is shared with `regionctxt`, but in a different
+            // flow; we could probably better extract the shared logic
+
+            // Process the region obligations
+            let body_id_map = infcx
+                .inner
+                .borrow()
+                .region_obligations()
+                .iter()
+                .map(|&(id, _)| (id, vec![]))
+                .collect();
+
+            infcx.process_registered_region_obligations(&body_id_map, None, param_env);
+
+            // Resolve the region constraints to find any constraints that we're provable
+            let outlives_env = OutlivesEnvironment::new(param_env);
+            let errors = infcx.resolve_regions(trait_item.def_id.to_def_id(), &outlives_env, RegionckMode::default());
+
+            // Emit an error if there are non-provable constriants
+            if !errors.is_empty() {
+                let mut clauses: Vec<_> = errors.into_iter().map(|error| match error {
+                    RegionResolutionError::ConcreteFailure(_, sup, sub) => format!("{}: {}", sub, sup),
+                    RegionResolutionError::GenericBoundFailure(_, sub, sup) => format!("{}: {}", sub, sup),
+                    _ => bug!("Unexpected region resolution error when resolving outlives lint"),
+                }).collect();
+                clauses.sort();
+
+                let plural = if clauses.len() > 1 { "s" } else { "" };
+                let mut err = tcx.sess.struct_span_err(
+                    trait_item.span,
+                    &format!("missing required bound{} on `{}`", plural, trait_item.ident),
+                );
+
+                let suggestion = format!(
+                    "{} {}",
+                    if !trait_item.generics.where_clause.predicates.is_empty() {
+                        ","
+                    } else {
+                        " where"
+                    },
+                    clauses.join(", "),
+                );
+                err.span_suggestion(
+                    trait_item.generics.where_clause.tail_span_for_suggestion(),
+                    &format!("add the required where clause{}", plural),
+                    suggestion,
+                    Applicability::MachineApplicable,
+                );
+
+                let bound = if clauses.len() > 1 { "these bounds are" } else { "this bound is" };
+                err.note(
+                    &format!("{} required to ensure that impls have maximum flexibility", bound)
+                );
+                err.note(
+                    "see issue #87479 \
+                     <https://github.com/rust-lang/rust/issues/87479> \
+                     for more information",
+                );
+
+                err.emit()
+            }
+        });
     }
 }
 
@@ -541,7 +607,8 @@ fn region_known_to_outlive<'tcx>(
         });
 
         use rustc_infer::infer::outlives::obligations::TypeOutlivesDelegate;
-        (&infcx).push_sub_region_constraint(origin, region_a, region_b);
+        // `region_a: region_b` -> `region_b <= region_a`
+        (&infcx).push_sub_region_constraint(origin, region_b, region_a);
 
         let errors = infcx.resolve_regions(
             id.expect_owner().to_def_id(),

--- a/library/std/src/ffi/c_str.rs
+++ b/library/std/src/ffi/c_str.rs
@@ -1259,7 +1259,7 @@ impl CStr {
     #[inline]
     #[must_use]
     #[stable(feature = "cstr_from_bytes", since = "1.10.0")]
-    #[rustc_const_unstable(feature = "const_cstr_unchecked", issue = "90343")]
+    #[rustc_const_stable(feature = "const_cstr_unchecked", since = "1.59.0")]
     pub const unsafe fn from_bytes_with_nul_unchecked(bytes: &[u8]) -> &CStr {
         // SAFETY: Casting to CStr is safe because its internal representation
         // is a [u8] too (safe only inside std).

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -252,7 +252,6 @@
 #![feature(char_internals)]
 #![cfg_attr(not(bootstrap), feature(concat_bytes))]
 #![feature(concat_idents)]
-#![feature(const_cstr_unchecked)]
 #![feature(const_fn_floating_point_arithmetic)]
 #![feature(const_fn_fn_ptr_basics)]
 #![feature(const_fn_trait_bound)]

--- a/src/librustdoc/doctest.rs
+++ b/src/librustdoc/doctest.rs
@@ -34,8 +34,9 @@ use crate::html::markdown::{self, ErrorCodes, Ignore, LangString};
 use crate::lint::init_lints;
 use crate::passes::span_of_attrs;
 
+/// Options that apply to all doctests in a crate or Markdown file (for `rustdoc foo.md`).
 #[derive(Clone, Default)]
-crate struct TestOptions {
+crate struct GlobalTestOptions {
     /// Whether to disable the default `extern crate my_crate;` when creating doctests.
     crate no_crate_inject: bool,
     /// Additional crate-level attributes to add to doctests.
@@ -214,10 +215,10 @@ crate fn run_tests(mut test_args: Vec<String>, nocapture: bool, tests: Vec<test:
 }
 
 // Look for `#![doc(test(no_crate_inject))]`, used by crates in the std facade.
-fn scrape_test_config(attrs: &[ast::Attribute]) -> TestOptions {
+fn scrape_test_config(attrs: &[ast::Attribute]) -> GlobalTestOptions {
     use rustc_ast_pretty::pprust;
 
-    let mut opts = TestOptions { no_crate_inject: false, attrs: Vec::new() };
+    let mut opts = GlobalTestOptions { no_crate_inject: false, attrs: Vec::new() };
 
     let test_attrs: Vec<_> = attrs
         .iter()
@@ -298,7 +299,7 @@ fn run_test(
     runtool: Option<String>,
     runtool_args: Vec<String>,
     target: TargetTriple,
-    opts: &TestOptions,
+    opts: &GlobalTestOptions,
     edition: Edition,
     outdir: DirState,
     path: PathBuf,
@@ -484,7 +485,7 @@ crate fn make_test(
     s: &str,
     crate_name: Option<&str>,
     dont_insert_main: bool,
-    opts: &TestOptions,
+    opts: &GlobalTestOptions,
     edition: Edition,
     test_id: Option<&str>,
 ) -> (String, usize, bool) {
@@ -805,7 +806,7 @@ crate struct Collector {
     use_headers: bool,
     enable_per_target_ignores: bool,
     crate_name: Symbol,
-    opts: TestOptions,
+    opts: GlobalTestOptions,
     position: Span,
     source_map: Option<Lrc<SourceMap>>,
     filename: Option<PathBuf>,
@@ -819,7 +820,7 @@ impl Collector {
         crate_name: Symbol,
         options: Options,
         use_headers: bool,
-        opts: TestOptions,
+        opts: GlobalTestOptions,
         source_map: Option<Lrc<SourceMap>>,
         filename: Option<PathBuf>,
         enable_per_target_ignores: bool,

--- a/src/librustdoc/doctest/tests.rs
+++ b/src/librustdoc/doctest/tests.rs
@@ -1,10 +1,10 @@
-use super::{make_test, TestOptions};
+use super::{make_test, GlobalTestOptions};
 use rustc_span::edition::DEFAULT_EDITION;
 
 #[test]
 fn make_test_basic() {
     //basic use: wraps with `fn main`, adds `#![allow(unused)]`
-    let opts = TestOptions::default();
+    let opts = GlobalTestOptions::default();
     let input = "assert_eq!(2+2, 4);";
     let expected = "#![allow(unused)]
 fn main() {
@@ -19,7 +19,7 @@ assert_eq!(2+2, 4);
 fn make_test_crate_name_no_use() {
     // If you give a crate name but *don't* use it within the test, it won't bother inserting
     // the `extern crate` statement.
-    let opts = TestOptions::default();
+    let opts = GlobalTestOptions::default();
     let input = "assert_eq!(2+2, 4);";
     let expected = "#![allow(unused)]
 fn main() {
@@ -34,7 +34,7 @@ assert_eq!(2+2, 4);
 fn make_test_crate_name() {
     // If you give a crate name and use it within the test, it will insert an `extern crate`
     // statement before `fn main`.
-    let opts = TestOptions::default();
+    let opts = GlobalTestOptions::default();
     let input = "use asdf::qwop;
 assert_eq!(2+2, 4);";
     let expected = "#![allow(unused)]
@@ -52,7 +52,7 @@ assert_eq!(2+2, 4);
 fn make_test_no_crate_inject() {
     // Even if you do use the crate within the test, setting `opts.no_crate_inject` will skip
     // adding it anyway.
-    let opts = TestOptions { no_crate_inject: true, attrs: vec![] };
+    let opts = GlobalTestOptions { no_crate_inject: true, attrs: vec![] };
     let input = "use asdf::qwop;
 assert_eq!(2+2, 4);";
     let expected = "#![allow(unused)]
@@ -70,7 +70,7 @@ fn make_test_ignore_std() {
     // Even if you include a crate name, and use it in the doctest, we still won't include an
     // `extern crate` statement if the crate is "std" -- that's included already by the
     // compiler!
-    let opts = TestOptions::default();
+    let opts = GlobalTestOptions::default();
     let input = "use std::*;
 assert_eq!(2+2, 4);";
     let expected = "#![allow(unused)]
@@ -87,7 +87,7 @@ assert_eq!(2+2, 4);
 fn make_test_manual_extern_crate() {
     // When you manually include an `extern crate` statement in your doctest, `make_test`
     // assumes you've included one for your own crate too.
-    let opts = TestOptions::default();
+    let opts = GlobalTestOptions::default();
     let input = "extern crate asdf;
 use asdf::qwop;
 assert_eq!(2+2, 4);";
@@ -104,7 +104,7 @@ assert_eq!(2+2, 4);
 
 #[test]
 fn make_test_manual_extern_crate_with_macro_use() {
-    let opts = TestOptions::default();
+    let opts = GlobalTestOptions::default();
     let input = "#[macro_use] extern crate asdf;
 use asdf::qwop;
 assert_eq!(2+2, 4);";
@@ -123,7 +123,7 @@ assert_eq!(2+2, 4);
 fn make_test_opts_attrs() {
     // If you supplied some doctest attributes with `#![doc(test(attr(...)))]`, it will use
     // those instead of the stock `#![allow(unused)]`.
-    let mut opts = TestOptions::default();
+    let mut opts = GlobalTestOptions::default();
     opts.attrs.push("feature(sick_rad)".to_string());
     let input = "use asdf::qwop;
 assert_eq!(2+2, 4);";
@@ -155,7 +155,7 @@ assert_eq!(2+2, 4);
 fn make_test_crate_attrs() {
     // Including inner attributes in your doctest will apply them to the whole "crate", pasting
     // them outside the generated main function.
-    let opts = TestOptions::default();
+    let opts = GlobalTestOptions::default();
     let input = "#![feature(sick_rad)]
 assert_eq!(2+2, 4);";
     let expected = "#![allow(unused)]
@@ -171,7 +171,7 @@ assert_eq!(2+2, 4);
 #[test]
 fn make_test_with_main() {
     // Including your own `fn main` wrapper lets the test use it verbatim.
-    let opts = TestOptions::default();
+    let opts = GlobalTestOptions::default();
     let input = "fn main() {
     assert_eq!(2+2, 4);
 }";
@@ -187,7 +187,7 @@ fn main() {
 #[test]
 fn make_test_fake_main() {
     // ... but putting it in a comment will still provide a wrapper.
-    let opts = TestOptions::default();
+    let opts = GlobalTestOptions::default();
     let input = "//Ceci n'est pas une `fn main`
 assert_eq!(2+2, 4);";
     let expected = "#![allow(unused)]
@@ -203,7 +203,7 @@ assert_eq!(2+2, 4);
 #[test]
 fn make_test_dont_insert_main() {
     // Even with that, if you set `dont_insert_main`, it won't create the `fn main` wrapper.
-    let opts = TestOptions::default();
+    let opts = GlobalTestOptions::default();
     let input = "//Ceci n'est pas une `fn main`
 assert_eq!(2+2, 4);";
     let expected = "#![allow(unused)]
@@ -216,7 +216,7 @@ assert_eq!(2+2, 4);"
 
 #[test]
 fn make_test_issues_21299_33731() {
-    let opts = TestOptions::default();
+    let opts = GlobalTestOptions::default();
 
     let input = "// fn main
 assert_eq!(2+2, 4);";
@@ -248,7 +248,7 @@ assert_eq!(asdf::foo, 4);
 
 #[test]
 fn make_test_main_in_macro() {
-    let opts = TestOptions::default();
+    let opts = GlobalTestOptions::default();
     let input = "#[macro_use] extern crate my_crate;
 test_wrapper! {
     fn main() {}
@@ -267,7 +267,7 @@ test_wrapper! {
 #[test]
 fn make_test_returns_result() {
     // creates an inner function and unwraps it
-    let opts = TestOptions::default();
+    let opts = GlobalTestOptions::default();
     let input = "use std::io;
 let mut input = String::new();
 io::stdin().read_line(&mut input)?;
@@ -287,7 +287,7 @@ Ok::<(), io:Error>(())
 #[test]
 fn make_test_named_wrapper() {
     // creates an inner function with a specific name
-    let opts = TestOptions::default();
+    let opts = GlobalTestOptions::default();
     let input = "assert_eq!(2+2, 4);";
     let expected = "#![allow(unused)]
 fn main() { #[allow(non_snake_case)] fn _doctest_main__some_unique_name() {

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -836,6 +836,10 @@ h2.small-section-header > .anchor {
 	top: 10px;
 }
 .search-input {
+	/* Override Normalize.css: it has a rule that sets
+	   -webkit-appearance: textfield for search inputs. That
+	   causes rounded corners and no border on iOS Safari. */
+	-webkit-appearance: none;
 	/* Override Normalize.css: we have margins and do
 	 not want to overflow - the `moz` attribute is necessary
 	 until Firefox 29, too early to drop at this point */

--- a/src/librustdoc/markdown.rs
+++ b/src/librustdoc/markdown.rs
@@ -7,7 +7,7 @@ use rustc_span::source_map::DUMMY_SP;
 use rustc_span::Symbol;
 
 use crate::config::{Options, RenderOptions};
-use crate::doctest::{Collector, TestOptions};
+use crate::doctest::{Collector, GlobalTestOptions};
 use crate::html::escape::Escape;
 use crate::html::markdown;
 use crate::html::markdown::{
@@ -129,7 +129,7 @@ crate fn render<P: AsRef<Path>>(
 crate fn test(options: Options) -> Result<(), String> {
     let input_str = read_to_string(&options.input)
         .map_err(|err| format!("{}: {}", options.input.display(), err))?;
-    let mut opts = TestOptions::default();
+    let mut opts = GlobalTestOptions::default();
     opts.no_crate_inject = true;
     let mut collector = Collector::new(
         Symbol::intern(&options.input.display().to_string()),

--- a/src/test/ui/const-generics/generic_arg_infer/dont-use-defaults.rs
+++ b/src/test/ui/const-generics/generic_arg_infer/dont-use-defaults.rs
@@ -1,0 +1,15 @@
+// run-pass
+#![feature(generic_arg_infer)]
+
+// test that we dont use defaults to aide in type inference
+
+struct Foo<const N: usize = 2>;
+impl<const N: usize> Foo<N> {
+    fn make_arr() -> [(); N] {
+        [(); N]
+    }
+}
+
+fn main() {
+    let [(), (), ()] = Foo::<_>::make_arr();
+}

--- a/src/test/ui/const-generics/generic_arg_infer/issue-91614.rs
+++ b/src/test/ui/const-generics/generic_arg_infer/issue-91614.rs
@@ -1,0 +1,8 @@
+#![feature(portable_simd)]
+#![feature(generic_arg_infer)]
+use std::simd::Mask;
+
+fn main() {
+    let y = Mask::<_, _>::splat(false);
+    //~^ error: type annotations needed for `Mask<_, {_: usize}>`
+}

--- a/src/test/ui/const-generics/generic_arg_infer/issue-91614.stderr
+++ b/src/test/ui/const-generics/generic_arg_infer/issue-91614.stderr
@@ -1,0 +1,18 @@
+error[E0283]: type annotations needed for `Mask<_, {_: usize}>`
+  --> $DIR/issue-91614.rs:6:13
+   |
+LL |     let y = Mask::<_, _>::splat(false);
+   |         -   ^^^^^^^^^^^^^^^^^^^ cannot infer type for type parameter `T`
+   |         |
+   |         consider giving `y` the explicit type `Mask<_, LANES>`, where the type parameter `T` is specified
+   |
+   = note: cannot satisfy `_: MaskElement`
+note: required by a bound in `Mask::<T, LANES>::splat`
+  --> $SRC_DIR/core/src/../../portable-simd/crates/core_simd/src/masks.rs:LL:COL
+   |
+LL |     T: MaskElement,
+   |        ^^^^^^^^^^^ required by this bound in `Mask::<T, LANES>::splat`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0283`.

--- a/src/test/ui/generic-associated-types/issue-86787.rs
+++ b/src/test/ui/generic-associated-types/issue-86787.rs
@@ -9,7 +9,7 @@ enum Either<L, R> {
 pub trait HasChildrenOf {
     type T;
     type TRef<'a>;
-    //~^ Missing required bounds
+    //~^ missing required
 
     fn ref_children<'a>(&'a self) -> Vec<Self::TRef<'a>>;
     fn take_children(self) -> Vec<Self::T>;

--- a/src/test/ui/generic-associated-types/issue-86787.stderr
+++ b/src/test/ui/generic-associated-types/issue-86787.stderr
@@ -6,8 +6,8 @@ LL |     type TRef<'a>;
    |                  |
    |                  help: add the required where clause: `where Self: 'a`
    |
-   = note: this bound is required to ensure that impls have maximum flexibility
-   = note: see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
+   = note: this bound is currently required to ensure that impls have maximum flexibility
+   = note: we are soliciting feedback, see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
 
 error: aborting due to previous error
 

--- a/src/test/ui/generic-associated-types/issue-86787.stderr
+++ b/src/test/ui/generic-associated-types/issue-86787.stderr
@@ -1,10 +1,13 @@
-error: Missing required bounds on TRef
+error: missing required bound on `TRef`
   --> $DIR/issue-86787.rs:11:5
    |
 LL |     type TRef<'a>;
    |     ^^^^^^^^^^^^^-
    |                  |
-   |                  help: add the required where clauses: `where Self: 'a`
+   |                  help: add the required where clause: `where Self: 'a`
+   |
+   = note: this bound is required to ensure that impls have maximum flexibility
+   = note: see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
 
 error: aborting due to previous error
 

--- a/src/test/ui/generic-associated-types/self-outlives-lint.stderr
+++ b/src/test/ui/generic-associated-types/self-outlives-lint.stderr
@@ -1,98 +1,145 @@
-error: Missing required bounds on Item
+error: missing required bound on `Item`
   --> $DIR/self-outlives-lint.rs:9:5
    |
 LL |     type Item<'x>;
    |     ^^^^^^^^^^^^^-
    |                  |
-   |                  help: add the required where clauses: `where Self: 'x`
+   |                  help: add the required where clause: `where Self: 'x`
+   |
+   = note: this bound is required to ensure that impls have maximum flexibility
+   = note: see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
 
-error: Missing required bounds on Out
+error: missing required bound on `Out`
   --> $DIR/self-outlives-lint.rs:25:5
    |
 LL |     type Out<'x>;
    |     ^^^^^^^^^^^^-
    |                 |
-   |                 help: add the required where clauses: `where T: 'x`
+   |                 help: add the required where clause: `where T: 'x`
+   |
+   = note: this bound is required to ensure that impls have maximum flexibility
+   = note: see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
 
-error: Missing required bounds on Out
+error: missing required bound on `Out`
   --> $DIR/self-outlives-lint.rs:39:5
    |
 LL |     type Out<'x>;
    |     ^^^^^^^^^^^^-
    |                 |
-   |                 help: add the required where clauses: `where T: 'x`
+   |                 help: add the required where clause: `where T: 'x`
+   |
+   = note: this bound is required to ensure that impls have maximum flexibility
+   = note: see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
 
-error: Missing required bounds on Out
+error: missing required bounds on `Out`
   --> $DIR/self-outlives-lint.rs:46:5
    |
 LL |     type Out<'x, 'y>;
    |     ^^^^^^^^^^^^^^^^-
    |                     |
    |                     help: add the required where clauses: `where T: 'x, U: 'y`
+   |
+   = note: these bounds are required to ensure that impls have maximum flexibility
+   = note: see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
 
-error: Missing required bounds on Out
+error: missing required bound on `Out`
   --> $DIR/self-outlives-lint.rs:61:5
    |
 LL |     type Out<'x, D>;
    |     ^^^^^^^^^^^^^^^-
    |                    |
-   |                    help: add the required where clauses: `where D: 'x`
+   |                    help: add the required where clause: `where D: 'x`
+   |
+   = note: this bound is required to ensure that impls have maximum flexibility
+   = note: see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
 
-error: Missing required bounds on Out
+error: missing required bound on `Out`
   --> $DIR/self-outlives-lint.rs:77:5
    |
 LL |     type Out<'x, D>;
    |     ^^^^^^^^^^^^^^^-
    |                    |
-   |                    help: add the required where clauses: `where D: 'x`
+   |                    help: add the required where clause: `where D: 'x`
+   |
+   = note: this bound is required to ensure that impls have maximum flexibility
+   = note: see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
 
-error: Missing required bounds on Out
+error: missing required bound on `Out`
   --> $DIR/self-outlives-lint.rs:92:5
    |
 LL |     type Out<'x, D>;
    |     ^^^^^^^^^^^^^^^-
    |                    |
-   |                    help: add the required where clauses: `where D: 'x`
+   |                    help: add the required where clause: `where D: 'x`
+   |
+   = note: this bound is required to ensure that impls have maximum flexibility
+   = note: see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
 
-error: Missing required bounds on Bar
+error: missing required bounds on `Bar`
   --> $DIR/self-outlives-lint.rs:114:5
    |
 LL |     type Bar<'b>;
    |     ^^^^^^^^^^^^-
    |                 |
    |                 help: add the required where clauses: `where Self: 'a, Self: 'b`
+   |
+   = note: these bounds are required to ensure that impls have maximum flexibility
+   = note: see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
 
-error: Missing required bounds on Bar
+error: missing required bound on `Bar`
   --> $DIR/self-outlives-lint.rs:122:5
    |
 LL |     type Bar<'b>;
    |     ^^^^^^^^^^^^-
    |                 |
-   |                 help: add the required where clauses: `where Self: 'a, Self: 'b`
+   |                 help: add the required where clause: `where Self: 'b`
+   |
+   = note: this bound is required to ensure that impls have maximum flexibility
+   = note: see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
 
-error: Missing required bounds on Bar
+error: missing required bound on `Bar`
   --> $DIR/self-outlives-lint.rs:129:5
    |
 LL |     type Bar<'b>;
    |     ^^^^^^^^^^^^-
    |                 |
-   |                 help: add the required where clauses: `where Self: 'b`
+   |                 help: add the required where clause: `where Self: 'b`
+   |
+   = note: this bound is required to ensure that impls have maximum flexibility
+   = note: see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
 
-error: Missing required bounds on Iterator
+error: missing required bound on `Iterator`
   --> $DIR/self-outlives-lint.rs:143:5
    |
 LL |     type Iterator<'a>: Iterator<Item = Self::Item<'a>>;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
    |                                                       |
-   |                                                       help: add the required where clauses: `where Self: 'a`
+   |                                                       help: add the required where clause: `where Self: 'a`
+   |
+   = note: this bound is required to ensure that impls have maximum flexibility
+   = note: see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
 
-error: Missing required bounds on Bar
-  --> $DIR/self-outlives-lint.rs:150:5
+error: missing required bound on `Bar`
+  --> $DIR/self-outlives-lint.rs:151:5
    |
 LL |     type Bar<'a, 'b>;
    |     ^^^^^^^^^^^^^^^^-
    |                     |
-   |                     help: add the required where clauses: `where 'a: 'b`
+   |                     help: add the required where clause: `where 'b: 'a`
+   |
+   = note: this bound is required to ensure that impls have maximum flexibility
+   = note: see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
 
-error: aborting due to 12 previous errors
+error: missing required bound on `Fut`
+  --> $DIR/self-outlives-lint.rs:167:5
+   |
+LL |     type Fut<'out>;
+   |     ^^^^^^^^^^^^^^-
+   |                   |
+   |                   help: add the required where clause: `where 'ctx: 'out`
+   |
+   = note: this bound is required to ensure that impls have maximum flexibility
+   = note: see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
+
+error: aborting due to 13 previous errors
 

--- a/src/test/ui/generic-associated-types/self-outlives-lint.stderr
+++ b/src/test/ui/generic-associated-types/self-outlives-lint.stderr
@@ -6,8 +6,8 @@ LL |     type Item<'x>;
    |                  |
    |                  help: add the required where clause: `where Self: 'x`
    |
-   = note: this bound is required to ensure that impls have maximum flexibility
-   = note: see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
+   = note: this bound is currently required to ensure that impls have maximum flexibility
+   = note: we are soliciting feedback, see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
 
 error: missing required bound on `Out`
   --> $DIR/self-outlives-lint.rs:25:5
@@ -17,8 +17,8 @@ LL |     type Out<'x>;
    |                 |
    |                 help: add the required where clause: `where T: 'x`
    |
-   = note: this bound is required to ensure that impls have maximum flexibility
-   = note: see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
+   = note: this bound is currently required to ensure that impls have maximum flexibility
+   = note: we are soliciting feedback, see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
 
 error: missing required bound on `Out`
   --> $DIR/self-outlives-lint.rs:39:5
@@ -28,8 +28,8 @@ LL |     type Out<'x>;
    |                 |
    |                 help: add the required where clause: `where T: 'x`
    |
-   = note: this bound is required to ensure that impls have maximum flexibility
-   = note: see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
+   = note: this bound is currently required to ensure that impls have maximum flexibility
+   = note: we are soliciting feedback, see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
 
 error: missing required bounds on `Out`
   --> $DIR/self-outlives-lint.rs:46:5
@@ -39,8 +39,8 @@ LL |     type Out<'x, 'y>;
    |                     |
    |                     help: add the required where clauses: `where T: 'x, U: 'y`
    |
-   = note: these bounds are required to ensure that impls have maximum flexibility
-   = note: see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
+   = note: these bounds are currently required to ensure that impls have maximum flexibility
+   = note: we are soliciting feedback, see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
 
 error: missing required bound on `Out`
   --> $DIR/self-outlives-lint.rs:61:5
@@ -50,8 +50,8 @@ LL |     type Out<'x, D>;
    |                    |
    |                    help: add the required where clause: `where D: 'x`
    |
-   = note: this bound is required to ensure that impls have maximum flexibility
-   = note: see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
+   = note: this bound is currently required to ensure that impls have maximum flexibility
+   = note: we are soliciting feedback, see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
 
 error: missing required bound on `Out`
   --> $DIR/self-outlives-lint.rs:77:5
@@ -61,8 +61,8 @@ LL |     type Out<'x, D>;
    |                    |
    |                    help: add the required where clause: `where D: 'x`
    |
-   = note: this bound is required to ensure that impls have maximum flexibility
-   = note: see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
+   = note: this bound is currently required to ensure that impls have maximum flexibility
+   = note: we are soliciting feedback, see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
 
 error: missing required bound on `Out`
   --> $DIR/self-outlives-lint.rs:92:5
@@ -72,8 +72,8 @@ LL |     type Out<'x, D>;
    |                    |
    |                    help: add the required where clause: `where D: 'x`
    |
-   = note: this bound is required to ensure that impls have maximum flexibility
-   = note: see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
+   = note: this bound is currently required to ensure that impls have maximum flexibility
+   = note: we are soliciting feedback, see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
 
 error: missing required bounds on `Bar`
   --> $DIR/self-outlives-lint.rs:114:5
@@ -83,8 +83,8 @@ LL |     type Bar<'b>;
    |                 |
    |                 help: add the required where clauses: `where Self: 'a, Self: 'b`
    |
-   = note: these bounds are required to ensure that impls have maximum flexibility
-   = note: see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
+   = note: these bounds are currently required to ensure that impls have maximum flexibility
+   = note: we are soliciting feedback, see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
 
 error: missing required bound on `Bar`
   --> $DIR/self-outlives-lint.rs:122:5
@@ -94,8 +94,8 @@ LL |     type Bar<'b>;
    |                 |
    |                 help: add the required where clause: `where Self: 'b`
    |
-   = note: this bound is required to ensure that impls have maximum flexibility
-   = note: see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
+   = note: this bound is currently required to ensure that impls have maximum flexibility
+   = note: we are soliciting feedback, see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
 
 error: missing required bound on `Bar`
   --> $DIR/self-outlives-lint.rs:129:5
@@ -105,8 +105,8 @@ LL |     type Bar<'b>;
    |                 |
    |                 help: add the required where clause: `where Self: 'b`
    |
-   = note: this bound is required to ensure that impls have maximum flexibility
-   = note: see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
+   = note: this bound is currently required to ensure that impls have maximum flexibility
+   = note: we are soliciting feedback, see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
 
 error: missing required bound on `Iterator`
   --> $DIR/self-outlives-lint.rs:143:5
@@ -116,8 +116,8 @@ LL |     type Iterator<'a>: Iterator<Item = Self::Item<'a>>;
    |                                                       |
    |                                                       help: add the required where clause: `where Self: 'a`
    |
-   = note: this bound is required to ensure that impls have maximum flexibility
-   = note: see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
+   = note: this bound is currently required to ensure that impls have maximum flexibility
+   = note: we are soliciting feedback, see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
 
 error: missing required bound on `Bar`
   --> $DIR/self-outlives-lint.rs:151:5
@@ -127,8 +127,8 @@ LL |     type Bar<'a, 'b>;
    |                     |
    |                     help: add the required where clause: `where 'b: 'a`
    |
-   = note: this bound is required to ensure that impls have maximum flexibility
-   = note: see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
+   = note: this bound is currently required to ensure that impls have maximum flexibility
+   = note: we are soliciting feedback, see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
 
 error: missing required bound on `Fut`
   --> $DIR/self-outlives-lint.rs:167:5
@@ -138,8 +138,8 @@ LL |     type Fut<'out>;
    |                   |
    |                   help: add the required where clause: `where 'ctx: 'out`
    |
-   = note: this bound is required to ensure that impls have maximum flexibility
-   = note: see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
+   = note: this bound is currently required to ensure that impls have maximum flexibility
+   = note: we are soliciting feedback, see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
 
 error: aborting due to 13 previous errors
 


### PR DESCRIPTION
Successful merges:

 - #89762 (Change default panic strategy to abort for wasm32-unknown-emscripten)
 - #91699 (Add `-webkit-appearance: none` to search input)
 - #91846 (rustdoc: Reduce number of arguments for `run_test` a bit)
 - #91847 (Fix FIXME for `generic_arg_infer` in `create_substs_for_ast_path`)
 - #91849 (GATs outlives lint: Try to prove bounds)
 - #91855 (Stabilize const_cstr_unchecked)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=89762,91699,91846,91847,91849,91855)
<!-- homu-ignore:end -->