### PR TITLE
Enforce that UNTRACKED options are not accessed by queries

### DIFF
--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -809,7 +809,7 @@ impl Default for Options {
 impl Options {
     /// Returns `true` if there is a reason to build the dep graph.
     pub fn build_dep_graph(&self) -> bool {
-        self.incremental.is_some()
+        self.get_incremental().is_some()
             || self.debugging_opts.dump_dep_graph
             || self.debugging_opts.query_dep_graph
     }

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -121,6 +121,10 @@ impl Options {
         self.cg.instrument_coverage.unwrap_or(InstrumentCoverage::Off)
             == InstrumentCoverage::ExceptUnusedFunctions
     }
+
+    pub fn get_incremental(&self) -> Option<PathBuf> {
+        self.incremental
+    }
 }
 
 top_level_options!(

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -68,7 +68,7 @@ macro_rules! top_level_options {
         pub struct Options {
             $(
                 $( #[$attr] )*
-                pub $opt: $t
+                $opt: $t
             ),*
         }
 

--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -865,7 +865,7 @@ impl Session {
     }
 
     pub fn incr_comp_session_dir_opt(&self) -> Option<cell::Ref<'_, PathBuf>> {
-        self.opts.incremental.as_ref().map(|_| self.incr_comp_session_dir())
+        self.opts.get_incremental().as_ref().map(|_| self.incr_comp_session_dir())
     }
 
     pub fn print_perf_stats(&self) {
@@ -937,7 +937,7 @@ impl Session {
         // If incremental compilation is turned on, we default to a high number
         // codegen units in order to reduce the "collateral damage" small
         // changes cause.
-        if self.opts.incremental.is_some() {
+        if self.opts.get_incremental().is_some() {
             return 256;
         }
 


### PR DESCRIPTION
Part of https://github.com/rust-lang/rust/issues/90317.

See https://github.com/rust-lang/rust/issues/90317#issuecomment-975950940.