### PR TITLE
rustdoc: Replace String with Symbol in `Cache.paths` et al.

### DIFF
--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -162,13 +162,11 @@ crate fn load_attrs<'hir>(cx: &DocContext<'hir>, did: DefId) -> Attrs<'hir> {
 /// These names are used later on by HTML rendering to generate things like
 /// source links back to the original item.
 crate fn record_extern_fqn(cx: &mut DocContext<'_>, did: DefId, kind: ItemType) {
-    let crate_name = cx.tcx.crate_name(did.krate).to_string();
+    let crate_name = cx.tcx.crate_name(did.krate);
 
-    let relative = cx.tcx.def_path(did).data.into_iter().filter_map(|elem| {
-        // extern blocks have an empty name
-        let s = elem.data.to_string();
-        if !s.is_empty() { Some(s) } else { None }
-    });
+    // FIXME: use def_id_to_path instead
+    let relative =
+        cx.tcx.def_path(did).data.into_iter().filter_map(|elem| elem.data.get_opt_name());
     let fqn = if let ItemType::Macro = kind {
         // Check to see if it is a macro 2.0 or built-in macro
         if matches!(

--- a/src/librustdoc/clean/utils.rs
+++ b/src/librustdoc/clean/utils.rs
@@ -536,3 +536,20 @@ pub(super) fn display_macro_source(
         }
     }
 }
+
+crate fn join_path_segments(segments: &[Symbol]) -> String {
+    join_path_segments_with_sep(segments, "::")
+}
+
+crate fn join_path_segments_with_sep(segments: &[Symbol], sep: &str) -> String {
+    let mut out = String::new();
+    // This can't use an iterator intersperse because then it would be borrowing from
+    // temporary SymbolStrs due to the lifetimes on SymbolStr's Deref impl.
+    for (i, s) in segments.iter().enumerate() {
+        if i > 0 {
+            out.push_str(sep);
+        }
+        out.push_str(&s.as_str())
+    }
+    out
+}

--- a/src/librustdoc/html/mod.rs
+++ b/src/librustdoc/html/mod.rs
@@ -9,6 +9,7 @@ crate mod render;
 crate mod sources;
 crate mod static_files;
 crate mod toc;
+mod url_parts_builder;
 
 #[cfg(test)]
 mod tests;

--- a/src/librustdoc/html/render/cache.rs
+++ b/src/librustdoc/html/render/cache.rs
@@ -8,6 +8,7 @@ use serde::ser::{Serialize, SerializeStruct, Serializer};
 
 use crate::clean;
 use crate::clean::types::{FnDecl, FnRetTy, GenericBound, Generics, Type, WherePredicate};
+use crate::clean::utils::join_path_segments;
 use crate::formats::cache::Cache;
 use crate::formats::item_type::ItemType;
 use crate::html::markdown::short_markdown_summary;
@@ -38,7 +39,7 @@ crate fn build_index<'tcx>(krate: &clean::Crate, cache: &mut Cache, tcx: TyCtxt<
             cache.search_index.push(IndexItem {
                 ty: item.type_(),
                 name: item.name.unwrap().to_string(),
-                path: fqp[..fqp.len() - 1].join("::"),
+                path: join_path_segments(&fqp[..fqp.len() - 1]),
                 desc,
                 parent: Some(did),
                 parent_idx: None,
@@ -90,7 +91,7 @@ crate fn build_index<'tcx>(krate: &clean::Crate, cache: &mut Cache, tcx: TyCtxt<
                     lastpathid += 1;
 
                     if let Some(&(ref fqp, short)) = paths.get(&defid) {
-                        crate_paths.push((short, fqp.last().unwrap().clone()));
+                        crate_paths.push((short, fqp.last().unwrap().to_string()));
                         Some(pathid)
                     } else {
                         None

--- a/src/librustdoc/html/render/context.rs
+++ b/src/librustdoc/html/render/context.rs
@@ -237,10 +237,10 @@ impl<'tcx> Context<'tcx> {
             if let Some(&(ref names, ty)) = self.cache().paths.get(&it.def_id.expect_def_id()) {
                 let mut path = String::new();
                 for name in &names[..names.len() - 1] {
-                    path.push_str(name);
+                    path.push_str(&name.as_str());
                     path.push('/');
                 }
-                path.push_str(&item_path(ty, names.last().unwrap()));
+                path.push_str(&item_path(ty, &names.last().unwrap().as_str()));
                 match self.shared.redirections {
                     Some(ref redirections) => {
                         let mut current_path = String::new();
@@ -248,7 +248,7 @@ impl<'tcx> Context<'tcx> {
                             current_path.push_str(name);
                             current_path.push('/');
                         }
-                        current_path.push_str(&item_path(ty, names.last().unwrap()));
+                        current_path.push_str(&item_path(ty, &names.last().unwrap().as_str()));
                         redirections.borrow_mut().insert(current_path, path);
                     }
                     None => return layout::redirect(&format!("{}{}", self.root_path(), path)),

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -63,6 +63,7 @@ use rustc_span::{
 use serde::ser::SerializeSeq;
 use serde::{Serialize, Serializer};
 
+use crate::clean::utils::join_path_segments;
 use crate::clean::{self, ItemId, RenderedLink, SelfTy};
 use crate::error::Error;
 use crate::formats::cache::Cache;
@@ -2524,7 +2525,7 @@ fn collect_paths_for_type(first_ty: clean::Type, cache: &Cache) -> Vec<String> {
         let fqp = cache.exact_paths.get(&did).cloned().or_else(get_extern);
 
         if let Some(path) = fqp {
-            out.push(path.join("::"));
+            out.push(join_path_segments(&path));
         }
     };
 

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -22,6 +22,7 @@ use super::{
     ImplRenderingParameters,
 };
 use crate::clean;
+use crate::clean::utils::join_path_segments_with_sep;
 use crate::formats::item_type::ItemType;
 use crate::formats::{AssocItemRender, Impl, RenderMode};
 use crate::html::escape::Escape;
@@ -874,7 +875,7 @@ fn item_trait(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, t: &clean::Tra
             cx.current.join("/")
         } else {
             let (ref path, _) = cache.external_paths[&it.def_id.expect_def_id()];
-            path[..path.len() - 1].join("/")
+            join_path_segments_with_sep(&path[..path.len() - 1], "/")
         },
         ty = it.type_(),
         name = *it.name.as_ref().unwrap()

--- a/src/librustdoc/html/render/write_shared.rs
+++ b/src/librustdoc/html/render/write_shared.rs
@@ -569,7 +569,7 @@ pub(super) fn write_shared(
 
         let mut mydst = dst.clone();
         for part in &remote_path[..remote_path.len() - 1] {
-            mydst.push(part);
+            mydst.push(&*part.as_str());
         }
         cx.shared.ensure_dir(&mydst)?;
         mydst.push(&format!("{}.{}.js", remote_item_type, remote_path[remote_path.len() - 1]));

--- a/src/librustdoc/html/tests.rs
+++ b/src/librustdoc/html/tests.rs
@@ -1,44 +1,44 @@
 use crate::html::format::href_relative_parts;
 
-fn assert_relative_path(expected: &[&str], relative_to_fqp: &[&str], fqp: &[&str]) {
+fn assert_relative_path(expected: &str, relative_to_fqp: &[&str], fqp: &[&str]) {
     let relative_to_fqp: Vec<String> = relative_to_fqp.iter().copied().map(String::from).collect();
     let fqp: Vec<String> = fqp.iter().copied().map(String::from).collect();
-    assert_eq!(expected, href_relative_parts(&fqp, &relative_to_fqp));
+    assert_eq!(expected, href_relative_parts(&fqp, &relative_to_fqp).finish());
 }
 
 #[test]
 fn href_relative_parts_basic() {
     let relative_to_fqp = &["std", "vec"];
     let fqp = &["std", "iter"];
-    assert_relative_path(&["..", "iter"], relative_to_fqp, fqp);
+    assert_relative_path("../iter", relative_to_fqp, fqp);
 }
 #[test]
 fn href_relative_parts_parent_module() {
     let relative_to_fqp = &["std", "vec"];
     let fqp = &["std"];
-    assert_relative_path(&[".."], relative_to_fqp, fqp);
+    assert_relative_path("..", relative_to_fqp, fqp);
 }
 #[test]
 fn href_relative_parts_different_crate() {
     let relative_to_fqp = &["std", "vec"];
     let fqp = &["core", "iter"];
-    assert_relative_path(&["..", "..", "core", "iter"], relative_to_fqp, fqp);
+    assert_relative_path("../../core/iter", relative_to_fqp, fqp);
 }
 #[test]
 fn href_relative_parts_same_module() {
     let relative_to_fqp = &["std", "vec"];
     let fqp = &["std", "vec"];
-    assert_relative_path(&[], relative_to_fqp, fqp);
+    assert_relative_path("", relative_to_fqp, fqp);
 }
 #[test]
 fn href_relative_parts_child_module() {
     let relative_to_fqp = &["std"];
     let fqp = &["std", "vec"];
-    assert_relative_path(&["vec"], relative_to_fqp, fqp);
+    assert_relative_path("vec", relative_to_fqp, fqp);
 }
 #[test]
 fn href_relative_parts_root() {
     let relative_to_fqp = &[];
     let fqp = &["std"];
-    assert_relative_path(&["std"], relative_to_fqp, fqp);
+    assert_relative_path("std", relative_to_fqp, fqp);
 }

--- a/src/librustdoc/html/url_parts_builder.rs
+++ b/src/librustdoc/html/url_parts_builder.rs
@@ -1,0 +1,119 @@
+/// A builder that allows efficiently and easily constructing the part of a URL
+/// after the domain: `nightly/core/str/struct.Bytes.html`.
+///
+/// This type is a wrapper around the final `String` buffer,
+/// but its API is like that of a `Vec` of URL components.
+#[derive(Debug)]
+crate struct UrlPartsBuilder {
+    buf: String,
+}
+
+impl UrlPartsBuilder {
+    /// Create an empty buffer.
+    crate fn new() -> Self {
+        Self { buf: String::new() }
+    }
+
+    /// Create an empty buffer with capacity for the specified number of bytes.
+    fn with_capacity_bytes(count: usize) -> Self {
+        Self { buf: String::with_capacity(count) }
+    }
+
+    /// Create a buffer with one URL component.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```ignore (private-type)
+    /// let builder = UrlPartsBuilder::singleton("core");
+    /// assert_eq!(builder.finish(), "core");
+    /// ```
+    ///
+    /// Adding more components afterward.
+    ///
+    /// ```ignore (private-type)
+    /// let mut builder = UrlPartsBuilder::singleton("core");
+    /// builder.push("str");
+    /// builder.push_front("nightly");
+    /// assert_eq!(builder.finish(), "nightly/core/str");
+    /// ```
+    crate fn singleton(part: &str) -> Self {
+        Self { buf: part.to_owned() }
+    }
+
+    /// Push a component onto the buffer.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```ignore (private-type)
+    /// let mut builder = UrlPartsBuilder::new();
+    /// builder.push("core");
+    /// builder.push("str");
+    /// builder.push("struct.Bytes.html");
+    /// assert_eq!(builder.finish(), "core/str/struct.Bytes.html");
+    /// ```
+    crate fn push(&mut self, part: &str) {
+        if !self.buf.is_empty() {
+            self.buf.push('/');
+        }
+        self.buf.push_str(part);
+    }
+
+    /// Push a component onto the front of the buffer.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```ignore (private-type)
+    /// let mut builder = UrlPartsBuilder::new();
+    /// builder.push("core");
+    /// builder.push("str");
+    /// builder.push_front("nightly");
+    /// builder.push("struct.Bytes.html");
+    /// assert_eq!(builder.finish(), "nightly/core/str/struct.Bytes.html");
+    /// ```
+    crate fn push_front(&mut self, part: &str) {
+        let is_empty = self.buf.is_empty();
+        self.buf.reserve(part.len() + if !is_empty { 1 } else { 0 });
+        self.buf.insert_str(0, part);
+        if !is_empty {
+            self.buf.insert(part.len(), '/');
+        }
+    }
+
+    /// Get the final `String` buffer.
+    crate fn finish(self) -> String {
+        self.buf
+    }
+}
+
+/// This is just a guess at the average length of a URL part,
+/// used for [`String::with_capacity`] calls in the [`FromIterator`]
+/// and [`Extend`] impls.
+///
+/// This is intentionally on the lower end to avoid overallocating.
+const AVG_PART_LENGTH: usize = 5;
+
+impl<'a> FromIterator<&'a str> for UrlPartsBuilder {
+    fn from_iter<T: IntoIterator<Item = &'a str>>(iter: T) -> Self {
+        let iter = iter.into_iter();
+        let mut builder = Self::with_capacity_bytes(AVG_PART_LENGTH * iter.size_hint().0);
+        iter.for_each(|part| builder.push(part));
+        builder
+    }
+}
+
+impl<'a> Extend<&'a str> for UrlPartsBuilder {
+    fn extend<T: IntoIterator<Item = &'a str>>(&mut self, iter: T) {
+        let iter = iter.into_iter();
+        self.buf.reserve(AVG_PART_LENGTH * iter.size_hint().0);
+        iter.for_each(|part| self.push(part));
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/librustdoc/html/url_parts_builder.rs
+++ b/src/librustdoc/html/url_parts_builder.rs
@@ -1,3 +1,5 @@
+use rustc_span::Symbol;
+
 /// A builder that allows efficiently and easily constructing the part of a URL
 /// after the domain: `nightly/core/str/struct.Bytes.html`.
 ///
@@ -112,6 +114,23 @@ impl<'a> Extend<&'a str> for UrlPartsBuilder {
         let iter = iter.into_iter();
         self.buf.reserve(AVG_PART_LENGTH * iter.size_hint().0);
         iter.for_each(|part| self.push(part));
+    }
+}
+
+impl FromIterator<Symbol> for UrlPartsBuilder {
+    fn from_iter<T: IntoIterator<Item = Symbol>>(iter: T) -> Self {
+        let iter = iter.into_iter();
+        let mut builder = Self::with_capacity_bytes(AVG_PART_LENGTH * iter.size_hint().0);
+        iter.for_each(|part| builder.push(&part.as_str()));
+        builder
+    }
+}
+
+impl Extend<Symbol> for UrlPartsBuilder {
+    fn extend<T: IntoIterator<Item = Symbol>>(&mut self, iter: T) {
+        let iter = iter.into_iter();
+        self.buf.reserve(AVG_PART_LENGTH * iter.size_hint().0);
+        iter.for_each(|part| self.push(&part.as_str()));
     }
 }
 

--- a/src/librustdoc/html/url_parts_builder/tests.rs
+++ b/src/librustdoc/html/url_parts_builder/tests.rs
@@ -1,0 +1,54 @@
+use super::*;
+
+fn t(builder: UrlPartsBuilder, expect: &str) {
+    assert_eq!(builder.finish(), expect);
+}
+
+#[test]
+fn empty() {
+    t(UrlPartsBuilder::new(), "");
+}
+
+#[test]
+fn singleton() {
+    t(UrlPartsBuilder::singleton("index.html"), "index.html");
+}
+
+#[test]
+fn push_several() {
+    let mut builder = UrlPartsBuilder::new();
+    builder.push("core");
+    builder.push("str");
+    builder.push("struct.Bytes.html");
+    t(builder, "core/str/struct.Bytes.html");
+}
+
+#[test]
+fn push_front_empty() {
+    let mut builder = UrlPartsBuilder::new();
+    builder.push_front("page.html");
+    t(builder, "page.html");
+}
+
+#[test]
+fn push_front_non_empty() {
+    let mut builder = UrlPartsBuilder::new();
+    builder.push("core");
+    builder.push("str");
+    builder.push("struct.Bytes.html");
+    builder.push_front("nightly");
+    t(builder, "nightly/core/str/struct.Bytes.html");
+}
+
+#[test]
+fn collect() {
+    t(["core", "str"].into_iter().collect(), "core/str");
+    t(["core", "str", "struct.Bytes.html"].into_iter().collect(), "core/str/struct.Bytes.html");
+}
+
+#[test]
+fn extend() {
+    let mut builder = UrlPartsBuilder::singleton("core");
+    builder.extend(["str", "struct.Bytes.html"]);
+    t(builder, "core/str/struct.Bytes.html");
+}

--- a/src/librustdoc/json/mod.rs
+++ b/src/librustdoc/json/mod.rs
@@ -121,7 +121,7 @@ impl JsonRenderer<'tcx> {
                                 })
                                 .0
                                 .last()
-                                .map(Clone::clone),
+                                .map(|s| s.to_string()),
                             visibility: types::Visibility::Public,
                             inner: types::ItemEnum::Trait(trait_item.clone().into_tcx(self.tcx)),
                             span: None,
@@ -231,7 +231,7 @@ impl<'tcx> FormatRenderer<'tcx> for JsonRenderer<'tcx> {
                         from_item_id(k.into()),
                         types::ItemSummary {
                             crate_id: k.krate.as_u32(),
-                            path,
+                            path: path.iter().map(|s| s.to_string()).collect(),
                             kind: kind.into_tcx(self.tcx),
                         },
                     )

--- a/src/librustdoc/visit_ast.rs
+++ b/src/librustdoc/visit_ast.rs
@@ -42,13 +42,9 @@ impl Module<'hir> {
 }
 
 // FIXME: Should this be replaced with tcx.def_path_str?
-fn def_id_to_path(tcx: TyCtxt<'_>, did: DefId) -> Vec<String> {
-    let crate_name = tcx.crate_name(did.krate).to_string();
-    let relative = tcx.def_path(did).data.into_iter().filter_map(|elem| {
-        // extern blocks have an empty name
-        let s = elem.data.to_string();
-        if !s.is_empty() { Some(s) } else { None }
-    });
+fn def_id_to_path(tcx: TyCtxt<'_>, did: DefId) -> Vec<Symbol> {
+    let crate_name = tcx.crate_name(did.krate);
+    let relative = tcx.def_path(did).data.into_iter().filter_map(|elem| elem.data.get_opt_name());
     std::iter::once(crate_name).chain(relative).collect()
 }
 
@@ -71,7 +67,7 @@ crate struct RustdocVisitor<'a, 'tcx> {
     inlining: bool,
     /// Are the current module and all of its parents public?
     inside_public_path: bool,
-    exact_paths: FxHashMap<DefId, Vec<String>>,
+    exact_paths: FxHashMap<DefId, Vec<Symbol>>,
 }
 
 impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {


### PR DESCRIPTION
**Blocked on #91871.**

This should hopefully improve memory usage and rustdoc run time.
It's also more consistent with the rest of rustc and rustdoc.

r? @jyn514
