### PR TITLE
Fix HashStable implementation on InferTy

### DIFF
--- a/compiler/rustc_type_ir/src/lib.rs
+++ b/compiler/rustc_type_ir/src/lib.rs
@@ -559,6 +559,7 @@ impl<CTX> HashStable<CTX> for FloatTy {
 impl<CTX> HashStable<CTX> for InferTy {
     fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
         use InferTy::*;
+        discriminant(self).hash_stable(ctx, hasher);
         match self {
             TyVar(v) => v.as_u32().hash_stable(ctx, hasher),
             IntVar(v) => v.index.hash_stable(ctx, hasher),

--- a/src/test/ui/traits/vtable/issue-91807.rs
+++ b/src/test/ui/traits/vtable/issue-91807.rs
@@ -1,0 +1,17 @@
+// check-pass
+// incremental
+
+struct Struct<T>(T);
+
+impl<T> std::ops::Deref for Struct<T> {
+    type Target = dyn Fn(T);
+    fn deref(&self) -> &Self::Target {
+        unimplemented!()
+    }
+}
+
+fn main() {
+    let f = Struct(Default::default());
+    f(0);
+    f(0);
+}


### PR DESCRIPTION
HashStable impl forgot to hash the discriminant.

Fixes #91807