### PR TITLE
Make `TyS::is_suggestable` check for non-suggestable types structually

### DIFF
--- a/src/test/ui/associated-types/defaults-in-other-trait-items.rs
+++ b/src/test/ui/associated-types/defaults-in-other-trait-items.rs
@@ -10,6 +10,7 @@ trait Tr {
         //~^ ERROR mismatched types
         //~| NOTE expected associated type, found `()`
         //~| NOTE expected associated type `<Self as Tr>::A`
+        //~| NOTE this expression has type `<Self as Tr>::A`
     }
 }
 

--- a/src/test/ui/associated-types/defaults-in-other-trait-items.stderr
+++ b/src/test/ui/associated-types/defaults-in-other-trait-items.stderr
@@ -5,13 +5,15 @@ LL |     type A = ();
    |     ------------ associated type defaults can't be assumed inside the trait defining them
 ...
 LL |         let () = p;
-   |             ^^ expected associated type, found `()`
+   |             ^^   - this expression has type `<Self as Tr>::A`
+   |             |
+   |             expected associated type, found `()`
    |
    = note: expected associated type `<Self as Tr>::A`
                     found unit type `()`
 
 error[E0308]: mismatched types
-  --> $DIR/defaults-in-other-trait-items.rs:35:25
+  --> $DIR/defaults-in-other-trait-items.rs:36:25
    |
 LL |     type Ty = u8;
    |     ------------- associated type defaults can't be assumed inside the trait defining them

--- a/src/test/ui/destructuring-assignment/default-match-bindings-forbidden.stderr
+++ b/src/test/ui/destructuring-assignment/default-match-bindings-forbidden.stderr
@@ -2,9 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/default-match-bindings-forbidden.rs:6:5
    |
 LL |     (x, y) = &(1, 2);
-   |     ^^^^^^   ------- this expression has type `&({integer}, {integer})`
-   |     |
-   |     expected reference, found tuple
+   |     ^^^^^^ expected reference, found tuple
    |
    = note: expected type `&({integer}, {integer})`
              found tuple `(_, _)`

--- a/src/test/ui/destructuring-assignment/tuple_destructure_fail.stderr
+++ b/src/test/ui/destructuring-assignment/tuple_destructure_fail.stderr
@@ -10,9 +10,7 @@ error[E0308]: mismatched types
   --> $DIR/tuple_destructure_fail.rs:8:5
    |
 LL |     (a, a, b) = (1, 2);
-   |     ^^^^^^^^^   ------ this expression has type `({integer}, {integer})`
-   |     |
-   |     expected a tuple with 2 elements, found one with 3 elements
+   |     ^^^^^^^^^ expected a tuple with 2 elements, found one with 3 elements
    |
    = note: expected type `({integer}, {integer})`
              found tuple `(_, _, _)`
@@ -29,9 +27,7 @@ error[E0308]: mismatched types
   --> $DIR/tuple_destructure_fail.rs:10:5
    |
 LL |     (_,) = (1, 2);
-   |     ^^^^   ------ this expression has type `({integer}, {integer})`
-   |     |
-   |     expected a tuple with 2 elements, found one with 1 element
+   |     ^^^^ expected a tuple with 2 elements, found one with 1 element
    |
    = note: expected type `({integer}, {integer})`
              found tuple `(_,)`

--- a/src/test/ui/half-open-range-patterns/exclusive_range_pattern_syntax_collision.stderr
+++ b/src/test/ui/half-open-range-patterns/exclusive_range_pattern_syntax_collision.stderr
@@ -1,8 +1,6 @@
 error[E0308]: mismatched types
   --> $DIR/exclusive_range_pattern_syntax_collision.rs:6:13
    |
-LL |     match [5..4, 99..105, 43..44] {
-   |           ----------------------- this expression has type `[std::ops::Range<{integer}>; 3]`
 LL |         [_, 99.., _] => {},
    |             ^^ expected struct `std::ops::Range`, found integer
    |

--- a/src/test/ui/half-open-range-patterns/exclusive_range_pattern_syntax_collision2.stderr
+++ b/src/test/ui/half-open-range-patterns/exclusive_range_pattern_syntax_collision2.stderr
@@ -7,8 +7,6 @@ LL |         [_, 99..] => {},
 error[E0308]: mismatched types
   --> $DIR/exclusive_range_pattern_syntax_collision2.rs:6:13
    |
-LL |     match [5..4, 99..105, 43..44] {
-   |           ----------------------- this expression has type `[std::ops::Range<{integer}>; 3]`
 LL |         [_, 99..] => {},
    |             ^^ expected struct `std::ops::Range`, found integer
    |

--- a/src/test/ui/half-open-range-patterns/exclusive_range_pattern_syntax_collision3.stderr
+++ b/src/test/ui/half-open-range-patterns/exclusive_range_pattern_syntax_collision3.stderr
@@ -1,8 +1,6 @@
 error[E0308]: mismatched types
   --> $DIR/exclusive_range_pattern_syntax_collision3.rs:6:12
    |
-LL |     match [5..4, 99..105, 43..44] {
-   |           ----------------------- this expression has type `[std::ops::Range<{integer}>; 3]`
 LL |         [..9, 99..100, _] => {},
    |            ^ expected struct `std::ops::Range`, found integer
    |
@@ -12,8 +10,6 @@ LL |         [..9, 99..100, _] => {},
 error[E0308]: mismatched types
   --> $DIR/exclusive_range_pattern_syntax_collision3.rs:6:15
    |
-LL |     match [5..4, 99..105, 43..44] {
-   |           ----------------------- this expression has type `[std::ops::Range<{integer}>; 3]`
 LL |         [..9, 99..100, _] => {},
    |               ^^  --- this is of type `{integer}`
    |               |
@@ -25,8 +21,6 @@ LL |         [..9, 99..100, _] => {},
 error[E0308]: mismatched types
   --> $DIR/exclusive_range_pattern_syntax_collision3.rs:6:19
    |
-LL |     match [5..4, 99..105, 43..44] {
-   |           ----------------------- this expression has type `[std::ops::Range<{integer}>; 3]`
 LL |         [..9, 99..100, _] => {},
    |               --  ^^^ expected struct `std::ops::Range`, found integer
    |               |

--- a/src/test/ui/half-open-range-patterns/pat-tuple-5.stderr
+++ b/src/test/ui/half-open-range-patterns/pat-tuple-5.stderr
@@ -1,8 +1,6 @@
 error[E0308]: mismatched types
   --> $DIR/pat-tuple-5.rs:8:10
    |
-LL |     match (0, 1) {
-   |           ------ this expression has type `({integer}, {integer})`
 LL |         (PAT ..) => {}
    |          ^^^ expected tuple, found `u8`
    |

--- a/src/test/ui/issues/issue-11844.stderr
+++ b/src/test/ui/issues/issue-11844.stderr
@@ -1,8 +1,6 @@
 error[E0308]: mismatched types
   --> $DIR/issue-11844.rs:6:9
    |
-LL |     match a {
-   |           - this expression has type `Option<Box<{integer}>>`
 LL |         Ok(a) =>
    |         ^^^^^ expected enum `Option`, found enum `Result`
    |

--- a/src/test/ui/issues/issue-12552.stderr
+++ b/src/test/ui/issues/issue-12552.stderr
@@ -1,8 +1,6 @@
 error[E0308]: mismatched types
   --> $DIR/issue-12552.rs:6:5
    |
-LL |   match t {
-   |         - this expression has type `Result<_, {integer}>`
 LL |     Some(k) => match k {
    |     ^^^^^^^ expected enum `Result`, found enum `Option`
    |
@@ -12,9 +10,6 @@ LL |     Some(k) => match k {
 error[E0308]: mismatched types
   --> $DIR/issue-12552.rs:9:5
    |
-LL |   match t {
-   |         - this expression has type `Result<_, {integer}>`
-...
 LL |     None => ()
    |     ^^^^ expected enum `Result`, found enum `Option`
    |

--- a/src/test/ui/issues/issue-13466.stderr
+++ b/src/test/ui/issues/issue-13466.stderr
@@ -1,8 +1,6 @@
 error[E0308]: mismatched types
   --> $DIR/issue-13466.rs:8:9
    |
-LL |     let _x: usize = match Some(1) {
-   |                           ------- this expression has type `Option<{integer}>`
 LL |         Ok(u) => u,
    |         ^^^^^ expected enum `Option`, found enum `Result`
    |
@@ -12,9 +10,6 @@ LL |         Ok(u) => u,
 error[E0308]: mismatched types
   --> $DIR/issue-13466.rs:14:9
    |
-LL |     let _x: usize = match Some(1) {
-   |                           ------- this expression has type `Option<{integer}>`
-...
 LL |         Err(e) => panic!(e)
    |         ^^^^^^ expected enum `Option`, found enum `Result`
    |

--- a/src/test/ui/issues/issue-3680.stderr
+++ b/src/test/ui/issues/issue-3680.stderr
@@ -1,8 +1,6 @@
 error[E0308]: mismatched types
   --> $DIR/issue-3680.rs:3:9
    |
-LL |     match None {
-   |           ---- this expression has type `Option<_>`
 LL |         Err(_) => ()
    |         ^^^^^^ expected enum `Option`, found enum `Result`
    |

--- a/src/test/ui/issues/issue-66706.stderr
+++ b/src/test/ui/issues/issue-66706.stderr
@@ -36,7 +36,7 @@ error[E0308]: mismatched types
   --> $DIR/issue-66706.rs:2:5
    |
 LL | fn a() {
-   |        - help: try adding a return type: `-> [{integer}; _]`
+   |        - possibly return type missing here?
 LL |     [0; [|_: _ &_| ()].len()]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^ expected `()`, found array `[{integer}; _]`
 
@@ -44,7 +44,7 @@ error[E0308]: mismatched types
   --> $DIR/issue-66706.rs:14:5
    |
 LL | fn c() {
-   |        - help: try adding a return type: `-> [{integer}; _]`
+   |        - possibly return type missing here?
 LL |     [0; [|&_: _ &_| {}; 0 ].len()]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `()`, found array `[{integer}; _]`
 
@@ -52,7 +52,7 @@ error[E0308]: mismatched types
   --> $DIR/issue-66706.rs:20:5
    |
 LL | fn d() {
-   |        - help: try adding a return type: `-> [{integer}; _]`
+   |        - possibly return type missing here?
 LL |     [0; match [|f @ &ref _| () ] {} ]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `()`, found array `[{integer}; _]`
 

--- a/src/test/ui/issues/issue-72574-1.stderr
+++ b/src/test/ui/issues/issue-72574-1.stderr
@@ -21,8 +21,6 @@ LL |         (_a, _x @ ..) => {}
 error[E0308]: mismatched types
   --> $DIR/issue-72574-1.rs:4:9
    |
-LL |     match x {
-   |           - this expression has type `({integer}, {integer}, {integer})`
 LL |         (_a, _x @ ..) => {}
    |         ^^^^^^^^^^^^^ expected a tuple with 3 elements, found one with 2 elements
    |

--- a/src/test/ui/mismatched_types/E0409.stderr
+++ b/src/test/ui/mismatched_types/E0409.stderr
@@ -9,8 +9,6 @@ LL |         (0, ref y) | (y, 0) => {}
 error[E0308]: mismatched types
   --> $DIR/E0409.rs:5:23
    |
-LL |     match x {
-   |           - this expression has type `({integer}, {integer})`
 LL |         (0, ref y) | (y, 0) => {}
    |             -----     ^ expected `&{integer}`, found integer
    |             |

--- a/src/test/ui/mut/mut-pattern-mismatched.stderr
+++ b/src/test/ui/mut/mut-pattern-mismatched.stderr
@@ -3,9 +3,6 @@ error[E0308]: mismatched types
    |
 LL |      let &_
    |          ^^ types differ in mutability
-...
-LL |         = foo;
-   |           --- this expression has type `&mut {integer}`
    |
    = note: expected mutable reference `&mut {integer}`
                       found reference `&_`
@@ -15,9 +12,6 @@ error[E0308]: mismatched types
    |
 LL |     let &mut _
    |         ^^^^^^ types differ in mutability
-...
-LL |          = bar;
-   |            --- this expression has type `&{integer}`
    |
    = note:      expected reference `&{integer}`
            found mutable reference `&mut _`

--- a/src/test/ui/never_type/diverging-tuple-parts-39485.stderr
+++ b/src/test/ui/never_type/diverging-tuple-parts-39485.stderr
@@ -1,15 +1,13 @@
 error[E0308]: mismatched types
   --> $DIR/diverging-tuple-parts-39485.rs:8:5
    |
+LL | fn g() {
+   |        - possibly return type missing here?
 LL |     &panic!()
    |     ^^^^^^^^^ expected `()`, found reference
    |
    = note: expected unit type `()`
               found reference `&_`
-help: try adding a return type
-   |
-LL | fn g() -> &_ {
-   |        +++++
 help: consider removing the borrow
    |
 LL -     &panic!()

--- a/src/test/ui/or-patterns/already-bound-name.stderr
+++ b/src/test/ui/or-patterns/already-bound-name.stderr
@@ -86,9 +86,8 @@ error[E0308]: mismatched types
   --> $DIR/already-bound-name.rs:30:32
    |
 LL |     let (B(A(a, _) | B(a)) | A(a, A(a, _) | B(a))) = B(B(1));
-   |              -                 ^                     ------- this expression has type `E<E<{integer}>>`
-   |              |                 |
-   |              |                 expected integer, found enum `E`
+   |              -                 ^ expected integer, found enum `E`
+   |              |
    |              first introduced with type `{integer}` here
    |
    = note: expected type `{integer}`

--- a/src/test/ui/or-patterns/inconsistent-modes.stderr
+++ b/src/test/ui/or-patterns/inconsistent-modes.stderr
@@ -65,9 +65,8 @@ error[E0308]: mismatched types
   --> $DIR/inconsistent-modes.rs:13:32
    |
 LL |     let (Ok((ref a, b)) | Err((ref mut a, ref b))) = Ok((0, &0));
-   |              -----             ^^^^^^^^^             ----------- this expression has type `Result<({integer}, &{integer}), (_, _)>`
-   |              |                 |
-   |              |                 types differ in mutability
+   |              -----             ^^^^^^^^^ types differ in mutability
+   |              |
    |              first introduced with type `&{integer}` here
    |
    = note: expected type `&{integer}`

--- a/src/test/ui/pattern/issue-74702.stderr
+++ b/src/test/ui/pattern/issue-74702.stderr
@@ -22,9 +22,7 @@ error[E0308]: mismatched types
   --> $DIR/issue-74702.rs:2:9
    |
 LL |     let (foo @ ..,) = (0, 0);
-   |         ^^^^^^^^^^^   ------ this expression has type `({integer}, {integer})`
-   |         |
-   |         expected a tuple with 2 elements, found one with 1 element
+   |         ^^^^^^^^^^^ expected a tuple with 2 elements, found one with 1 element
    |
    = note: expected tuple `({integer}, {integer})`
               found tuple `(_,)`

--- a/src/test/ui/pattern/pat-tuple-overfield.stderr
+++ b/src/test/ui/pattern/pat-tuple-overfield.stderr
@@ -150,8 +150,6 @@ LL |         E1::Z0 => {}
 error[E0308]: mismatched types
   --> $DIR/pat-tuple-overfield.rs:19:9
    |
-LL |     match (1, 2, 3) {
-   |           --------- this expression has type `({integer}, {integer}, {integer})`
 LL |         (1, 2, 3, 4) => {}
    |         ^^^^^^^^^^^^ expected a tuple with 3 elements, found one with 4 elements
    |
@@ -161,9 +159,6 @@ LL |         (1, 2, 3, 4) => {}
 error[E0308]: mismatched types
   --> $DIR/pat-tuple-overfield.rs:20:9
    |
-LL |     match (1, 2, 3) {
-   |           --------- this expression has type `({integer}, {integer}, {integer})`
-LL |         (1, 2, 3, 4) => {}
 LL |         (1, 2, .., 3, 4) => {}
    |         ^^^^^^^^^^^^^^^^ expected a tuple with 3 elements, found one with 4 elements
    |

--- a/src/test/ui/return/return-type.stderr
+++ b/src/test/ui/return/return-type.stderr
@@ -1,19 +1,15 @@
 error[E0308]: mismatched types
   --> $DIR/return-type.rs:10:5
    |
+LL | fn bar() {
+   |          - possibly return type missing here?
 LL |     foo(4 as usize)
-   |     ^^^^^^^^^^^^^^^ expected `()`, found struct `S`
+   |     ^^^^^^^^^^^^^^^- help: consider using a semicolon here: `;`
+   |     |
+   |     expected `()`, found struct `S`
    |
    = note: expected unit type `()`
                  found struct `S<usize>`
-help: consider using a semicolon here
-   |
-LL |     foo(4 as usize);
-   |                    +
-help: try adding a return type
-   |
-LL | fn bar() -> S<usize> {
-   |          +++++++++++
 
 error: aborting due to previous error
 

--- a/src/test/ui/rfc-2497-if-let-chains/disallowed-positions.stderr
+++ b/src/test/ui/rfc-2497-if-let-chains/disallowed-positions.stderr
@@ -644,7 +644,9 @@ error[E0308]: mismatched types
   --> $DIR/disallowed-positions.rs:76:12
    |
 LL |     if let Range { start: F, end } = F..|| true {}
-   |            ^^^^^^^^^^^^^^^^^^^^^^^ expected fn pointer, found struct `std::ops::Range`
+   |            ^^^^^^^^^^^^^^^^^^^^^^^   - this expression has type `fn() -> bool`
+   |            |
+   |            expected fn pointer, found struct `std::ops::Range`
    |
    = note: expected fn pointer `fn() -> bool`
                   found struct `std::ops::Range<_>`
@@ -832,7 +834,9 @@ error[E0308]: mismatched types
   --> $DIR/disallowed-positions.rs:140:15
    |
 LL |     while let Range { start: F, end } = F..|| true {}
-   |               ^^^^^^^^^^^^^^^^^^^^^^^ expected fn pointer, found struct `std::ops::Range`
+   |               ^^^^^^^^^^^^^^^^^^^^^^^   - this expression has type `fn() -> bool`
+   |               |
+   |               expected fn pointer, found struct `std::ops::Range`
    |
    = note: expected fn pointer `fn() -> bool`
                   found struct `std::ops::Range<_>`

--- a/src/test/ui/slightly-nice-generic-literal-messages.stderr
+++ b/src/test/ui/slightly-nice-generic-literal-messages.stderr
@@ -1,8 +1,6 @@
 error[E0308]: mismatched types
   --> $DIR/slightly-nice-generic-literal-messages.rs:7:9
    |
-LL |     match Foo(1.1, marker::PhantomData) {
-   |           ----------------------------- this expression has type `Foo<{float}, _>`
 LL |         1 => {}
    |         ^ expected struct `Foo`, found integer
    |

--- a/src/test/ui/structs/structure-constructor-type-mismatch.stderr
+++ b/src/test/ui/structs/structure-constructor-type-mismatch.stderr
@@ -101,8 +101,6 @@ LL | type PointF = Point<f32>;
 error[E0308]: mismatched types
   --> $DIR/structure-constructor-type-mismatch.rs:54:9
    |
-LL |     match (Point { x: 1, y: 2 }) {
-   |           ---------------------- this expression has type `Point<{integer}>`
 LL |         PointF::<u32> { .. } => {}
    |         ^^^^^^^^^^^^^^^^^^^^ expected integer, found `f32`
    |
@@ -112,8 +110,6 @@ LL |         PointF::<u32> { .. } => {}
 error[E0308]: mismatched types
   --> $DIR/structure-constructor-type-mismatch.rs:59:9
    |
-LL |     match (Point { x: 1, y: 2 }) {
-   |           ---------------------- this expression has type `Point<{integer}>`
 LL |         PointF { .. } => {}
    |         ^^^^^^^^^^^^^ expected integer, found `f32`
    |
@@ -123,8 +119,6 @@ LL |         PointF { .. } => {}
 error[E0308]: mismatched types
   --> $DIR/structure-constructor-type-mismatch.rs:67:9
    |
-LL |     match (Pair { x: 1, y: 2 }) {
-   |           --------------------- this expression has type `Pair<{integer}, {integer}>`
 LL |         PairF::<u32> { .. } => {}
    |         ^^^^^^^^^^^^^^^^^^^ expected integer, found `f32`
    |

--- a/src/test/ui/typeck/issue-57673-ice-on-deref-of-boxed-trait.stderr
+++ b/src/test/ui/typeck/issue-57673-ice-on-deref-of-boxed-trait.stderr
@@ -2,7 +2,7 @@ error[E0308]: mismatched types
   --> $DIR/issue-57673-ice-on-deref-of-boxed-trait.rs:5:5
    |
 LL | fn ice(x: Box<dyn Iterator<Item=()>>) {
-   |                                       - possibly return type missing here?
+   |                                       - help: try adding a return type: `-> (dyn Iterator<Item = ()> + 'static)`
 LL |     *x
    |     ^^ expected `()`, found trait object `dyn Iterator`
    |

--- a/src/test/ui/typeck/issue-91334.stderr
+++ b/src/test/ui/typeck/issue-91334.stderr
@@ -40,7 +40,7 @@ error[E0308]: mismatched types
 LL | fn f(){||yield(((){),
    |       -^^^^^^^^^^^^^^^ expected `()`, found generator
    |       |
-   |       help: try adding a return type: `-> [generator@$DIR/issue-91334.rs:10:8: 10:23]`
+   |       possibly return type missing here?
    |
    = note: expected unit type `()`
               found generator `[generator@$DIR/issue-91334.rs:10:8: 10:23]`

--- a/src/test/ui/typeck/return_type_containing_closure.rs
+++ b/src/test/ui/typeck/return_type_containing_closure.rs
@@ -1,0 +1,10 @@
+#[allow(unused)]
+fn foo() {
+    //~^ NOTE possibly return type missing here?
+    vec!['a'].iter().map(|c| c)
+    //~^ ERROR mismatched types [E0308]
+    //~| NOTE expected `()`, found struct `Map`
+    //~| NOTE expected unit type `()`
+}
+
+fn main() {}

--- a/src/test/ui/typeck/return_type_containing_closure.stderr
+++ b/src/test/ui/typeck/return_type_containing_closure.stderr
@@ -1,0 +1,17 @@
+error[E0308]: mismatched types
+  --> $DIR/return_type_containing_closure.rs:4:5
+   |
+LL | fn foo() {
+   |          - possibly return type missing here?
+LL |
+LL |     vec!['a'].iter().map(|c| c)
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^- help: consider using a semicolon here: `;`
+   |     |
+   |     expected `()`, found struct `Map`
+   |
+   = note: expected unit type `()`
+                 found struct `Map<std::slice::Iter<'_, char>, [closure@$DIR/return_type_containing_closure.rs:4:26: 4:31]>`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Not sure if I went overboard checking substs in dyn types, etc. Let me know if I should simplify this function.

Fixes #91832