### PR TITLE
Implement StableHash for BitSet and BitMatrix via Hash

### DIFF
--- a/compiler/rustc_data_structures/src/stable_hasher.rs
+++ b/compiler/rustc_data_structures/src/stable_hasher.rs
@@ -476,14 +476,14 @@ where
 }
 
 impl<I: vec::Idx, CTX> HashStable<CTX> for bit_set::BitSet<I> {
-    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
-        self.words().hash_stable(ctx, hasher);
+    fn hash_stable(&self, _ctx: &mut CTX, hasher: &mut StableHasher) {
+        ::std::hash::Hash::hash(self, hasher);
     }
 }
 
 impl<R: vec::Idx, C: vec::Idx, CTX> HashStable<CTX> for bit_set::BitMatrix<R, C> {
-    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
-        self.words().hash_stable(ctx, hasher);
+    fn hash_stable(&self, _ctx: &mut CTX, hasher: &mut StableHasher) {
+        ::std::hash::Hash::hash(self, hasher);
     }
 }
 

--- a/compiler/rustc_data_structures/src/stable_hasher/tests.rs
+++ b/compiler/rustc_data_structures/src/stable_hasher/tests.rs
@@ -71,3 +71,30 @@ fn test_hash_isize() {
 
     assert_eq!(h.finalize(), expected);
 }
+
+fn hash<T: HashStable<()>>(t: &T) -> u128 {
+    let mut h = StableHasher::new();
+    let ctx = &mut ();
+    t.hash_stable(ctx, &mut h);
+    h.finish()
+}
+
+// Check that bit set hash includes the domain size.
+#[test]
+fn test_hash_bit_set() {
+    use rustc_index::bit_set::BitSet;
+    let a: BitSet<usize> = BitSet::new_empty(1);
+    let b: BitSet<usize> = BitSet::new_empty(2);
+    assert_ne!(a, b);
+    assert_ne!(hash(&a), hash(&b));
+}
+
+// Check that bit matrix hash includes the matrix dimensions.
+#[test]
+fn test_hash_bit_matrix() {
+    use rustc_index::bit_set::BitMatrix;
+    let a: BitMatrix<usize, usize> = BitMatrix::new(1, 1);
+    let b: BitMatrix<usize, usize> = BitMatrix::new(1, 2);
+    assert_ne!(a, b);
+    assert_ne!(hash(&a), hash(&b));
+}

--- a/compiler/rustc_index/src/bit_set.rs
+++ b/compiler/rustc_index/src/bit_set.rs
@@ -87,7 +87,7 @@ macro_rules! bit_relations_inherent_impls {
 /// to or greater than the domain size. All operations that involve two bitsets
 /// will panic if the bitsets have differing domain sizes.
 ///
-#[derive(Eq, PartialEq, Decodable, Encodable)]
+#[derive(Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct BitSet<T> {
     domain_size: usize,
     words: Vec<Word>,
@@ -987,7 +987,7 @@ impl<T: Idx> GrowableBitSet<T> {
 ///
 /// All operations that involve a row and/or column index will panic if the
 /// index exceeds the relevant bound.
-#[derive(Clone, Eq, PartialEq, Decodable, Encodable)]
+#[derive(Clone, Eq, PartialEq, Hash, Decodable, Encodable)]
 pub struct BitMatrix<R: Idx, C: Idx> {
     num_rows: usize,
     num_columns: usize,


### PR DESCRIPTION
This fixes an issue where bit sets / bit matrices the same word
content but a different domain size would receive the same hash.