### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/compiler/rustc_ast/src/mut_visit.rs
+++ b/compiler/rustc_ast/src/mut_visit.rs
@@ -1,5 +1,5 @@
 //! A `MutVisitor` represents an AST modification; it accepts an AST piece and
-//! and mutates it in place. So, for instance, macro expansion is a `MutVisitor`
+//! mutates it in place. So, for instance, macro expansion is a `MutVisitor`
 //! that walks over an AST and modifies it.
 //!
 //! Note: using a `MutVisitor` (other than the `MacroExpander` `MutVisitor`) on

--- a/compiler/rustc_const_eval/src/interpret/operator.rs
+++ b/compiler/rustc_const_eval/src/interpret/operator.rs
@@ -328,7 +328,8 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 self.binary_int_op(bin_op, l, left.layout, r, right.layout)
             }
             _ if left.layout.ty.is_any_ptr() => {
-                // The RHS type must be the same *or an integer type* (for `Offset`).
+                // The RHS type must be a `pointer` *or an integer type* (for `Offset`).
+                // (This is workaround for the issue #91636)
                 assert!(
                     right.layout.ty.is_any_ptr() || right.layout.ty.is_integral(),
                     "Unexpected types for BinOp: {:?} {:?} {:?}",

--- a/compiler/rustc_const_eval/src/interpret/operator.rs
+++ b/compiler/rustc_const_eval/src/interpret/operator.rs
@@ -329,7 +329,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             }
             _ if left.layout.ty.is_any_ptr() => {
                 // The RHS type must be a `pointer` *or an integer type* (for `Offset`).
-                // (This is workaround for the issue #91636)
+                // (Even when both sides are pointers, their type might differ, see issue #91636)
                 assert!(
                     right.layout.ty.is_any_ptr() || right.layout.ty.is_integral(),
                     "Unexpected types for BinOp: {:?} {:?} {:?}",

--- a/compiler/rustc_const_eval/src/interpret/operator.rs
+++ b/compiler/rustc_const_eval/src/interpret/operator.rs
@@ -330,7 +330,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             _ if left.layout.ty.is_any_ptr() => {
                 // The RHS type must be the same *or an integer type* (for `Offset`).
                 assert!(
-                    right.layout.ty == left.layout.ty || right.layout.ty.is_integral(),
+                    right.layout.ty.is_any_ptr()|| right.layout.ty.is_integral(),
                     "Unexpected types for BinOp: {:?} {:?} {:?}",
                     left.layout.ty,
                     bin_op,

--- a/compiler/rustc_const_eval/src/interpret/operator.rs
+++ b/compiler/rustc_const_eval/src/interpret/operator.rs
@@ -330,7 +330,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             _ if left.layout.ty.is_any_ptr() => {
                 // The RHS type must be the same *or an integer type* (for `Offset`).
                 assert!(
-                    right.layout.ty.is_any_ptr()|| right.layout.ty.is_integral(),
+                    right.layout.ty.is_any_ptr() || right.layout.ty.is_integral(),
                     "Unexpected types for BinOp: {:?} {:?} {:?}",
                     left.layout.ty,
                     bin_op,

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -298,11 +298,16 @@ impl<'a: 'ast, 'ast> LateResolutionVisitor<'a, '_, 'ast> {
                             .get(0)
                             .map(|p| (p.span.shrink_to_lo(), "&self, "))
                             .unwrap_or_else(|| {
+                                // Try to look for the "(" after the function name, if possible.
+                                // This avoids placing the suggestion into the visibility specifier.
+                                let span = fn_kind
+                                    .ident()
+                                    .map_or(*span, |ident| span.with_lo(ident.span.hi()));
                                 (
                                     self.r
                                         .session
                                         .source_map()
-                                        .span_through_char(*span, '(')
+                                        .span_through_char(span, '(')
                                         .shrink_to_hi(),
                                     "&self",
                                 )

--- a/library/alloc/tests/slice.rs
+++ b/library/alloc/tests/slice.rs
@@ -863,7 +863,7 @@ fn test_splitator_inclusive() {
     assert_eq!(xs.split_inclusive(|_| true).collect::<Vec<&[i32]>>(), splits);
 
     let xs: &[i32] = &[];
-    let splits: &[&[i32]] = &[&[]];
+    let splits: &[&[i32]] = &[];
     assert_eq!(xs.split_inclusive(|x| *x == 5).collect::<Vec<&[i32]>>(), splits);
 }
 
@@ -883,7 +883,7 @@ fn test_splitator_inclusive_reverse() {
     assert_eq!(xs.split_inclusive(|_| true).rev().collect::<Vec<_>>(), splits);
 
     let xs: &[i32] = &[];
-    let splits: &[&[i32]] = &[&[]];
+    let splits: &[&[i32]] = &[];
     assert_eq!(xs.split_inclusive(|x| *x == 5).rev().collect::<Vec<_>>(), splits);
 }
 
@@ -903,7 +903,7 @@ fn test_splitator_mut_inclusive() {
     assert_eq!(xs.split_inclusive_mut(|_| true).collect::<Vec<_>>(), splits);
 
     let xs: &mut [i32] = &mut [];
-    let splits: &[&[i32]] = &[&[]];
+    let splits: &[&[i32]] = &[];
     assert_eq!(xs.split_inclusive_mut(|x| *x == 5).collect::<Vec<_>>(), splits);
 }
 
@@ -923,7 +923,7 @@ fn test_splitator_mut_inclusive_reverse() {
     assert_eq!(xs.split_inclusive_mut(|_| true).rev().collect::<Vec<_>>(), splits);
 
     let xs: &mut [i32] = &mut [];
-    let splits: &[&[i32]] = &[&[]];
+    let splits: &[&[i32]] = &[];
     assert_eq!(xs.split_inclusive_mut(|x| *x == 5).rev().collect::<Vec<_>>(), splits);
 }
 

--- a/library/core/src/slice/iter.rs
+++ b/library/core/src/slice/iter.rs
@@ -479,7 +479,8 @@ where
 impl<'a, T: 'a, P: FnMut(&T) -> bool> SplitInclusive<'a, T, P> {
     #[inline]
     pub(super) fn new(slice: &'a [T], pred: P) -> Self {
-        Self { v: slice, pred, finished: false }
+        let finished = slice.is_empty();
+        Self { v: slice, pred, finished }
     }
 }
 
@@ -727,7 +728,8 @@ where
 impl<'a, T: 'a, P: FnMut(&T) -> bool> SplitInclusiveMut<'a, T, P> {
     #[inline]
     pub(super) fn new(slice: &'a mut [T], pred: P) -> Self {
-        Self { v: slice, pred, finished: false }
+        let finished = slice.is_empty();
+        Self { v: slice, pred, finished }
     }
 }
 

--- a/src/test/ui/binop/binary-op-on-fn-ptr-eq.rs
+++ b/src/test/ui/binop/binary-op-on-fn-ptr-eq.rs
@@ -1,0 +1,8 @@
+// Tests equality between supertype and subtype of a function
+// See the issue #91636
+fn foo(_a: &str) {}
+
+fn main() {
+    let x = foo as fn(&'static str);
+    let _ = x == foo;
+}

--- a/src/test/ui/binop/binary-op-on-fn-ptr-eq.rs
+++ b/src/test/ui/binop/binary-op-on-fn-ptr-eq.rs
@@ -1,3 +1,4 @@
+// run-pass
 // Tests equality between supertype and subtype of a function
 // See the issue #91636
 fn foo(_a: &str) {}

--- a/src/test/ui/issues/issue-87490.rs
+++ b/src/test/ui/issues/issue-87490.rs
@@ -1,0 +1,10 @@
+fn main() {}
+trait StreamOnce {
+    type Position;
+}
+impl StreamOnce for &str {
+    type Position = usize;
+}
+fn follow(_: &str) -> <&str as StreamOnce>::Position {
+    String::new  //~ ERROR mismatched types
+}

--- a/src/test/ui/issues/issue-87490.stderr
+++ b/src/test/ui/issues/issue-87490.stderr
@@ -1,0 +1,14 @@
+error[E0308]: mismatched types
+  --> $DIR/issue-87490.rs:9:5
+   |
+LL | fn follow(_: &str) -> <&str as StreamOnce>::Position {
+   |                       ------------------------------ expected `usize` because of return type
+LL |     String::new
+   |     ^^^^^^^^^^^ expected `usize`, found fn item
+   |
+   = note: expected type `usize`
+           found fn item `fn() -> String {String::new}`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/mir/mir_const_prop_identity.rs
+++ b/src/test/ui/mir/mir_const_prop_identity.rs
@@ -1,0 +1,12 @@
+// Regression test for issue #91725.
+//
+// run-pass
+// compile-flags: -Zmir-opt-level=4
+
+fn main() {
+    let a = true;
+    let _ = &a;
+    let mut b = false;
+    b |= a;
+    assert!(b);
+}

--- a/src/test/ui/operator-recovery/less-than-greater-than.rs
+++ b/src/test/ui/operator-recovery/less-than-greater-than.rs
@@ -1,0 +1,4 @@
+fn main() {
+    println!("{}", 1 <> 2);
+    //~^ERROR invalid comparison operator `<>`
+}

--- a/src/test/ui/operator-recovery/less-than-greater-than.stderr
+++ b/src/test/ui/operator-recovery/less-than-greater-than.stderr
@@ -1,0 +1,8 @@
+error: invalid comparison operator `<>`
+  --> $DIR/less-than-greater-than.rs:2:22
+   |
+LL |     println!("{}", 1 <> 2);
+   |                      ^^ help: `<>` is not a valid comparison operator, use `!=`
+
+error: aborting due to previous error
+

--- a/src/test/ui/operator-recovery/spaceship.rs
+++ b/src/test/ui/operator-recovery/spaceship.rs
@@ -1,0 +1,4 @@
+fn main() {
+    println!("{}", 1 <=> 2);
+    //~^ERROR invalid comparison operator `<=>`
+}

--- a/src/test/ui/operator-recovery/spaceship.stderr
+++ b/src/test/ui/operator-recovery/spaceship.stderr
@@ -1,0 +1,8 @@
+error: invalid comparison operator `<=>`
+  --> $DIR/spaceship.rs:2:22
+   |
+LL |     println!("{}", 1 <=> 2);
+   |                      ^^^ `<=>` is not a valid comparison operator, use `std::cmp::Ordering`
+
+error: aborting due to previous error
+

--- a/src/test/ui/suggestions/suggest-add-self.rs
+++ b/src/test/ui/suggestions/suggest-add-self.rs
@@ -1,0 +1,15 @@
+struct X(i32);
+
+impl X {
+    pub(crate) fn f() {
+        self.0
+        //~^ ERROR expected value, found module `self`
+    }
+
+    pub fn g() {
+        self.0
+        //~^ ERROR expected value, found module `self`
+    }
+}
+
+fn main() {}

--- a/src/test/ui/suggestions/suggest-add-self.stderr
+++ b/src/test/ui/suggestions/suggest-add-self.stderr
@@ -1,0 +1,29 @@
+error[E0424]: expected value, found module `self`
+  --> $DIR/suggest-add-self.rs:5:9
+   |
+LL |     pub(crate) fn f() {
+   |                   - this function doesn't have a `self` parameter
+LL |         self.0
+   |         ^^^^ `self` value is a keyword only available in methods with a `self` parameter
+   |
+help: add a `self` receiver parameter to make the associated `fn` a method
+   |
+LL |     pub(crate) fn f(&self) {
+   |                     +++++
+
+error[E0424]: expected value, found module `self`
+  --> $DIR/suggest-add-self.rs:10:9
+   |
+LL |     pub fn g() {
+   |            - this function doesn't have a `self` parameter
+LL |         self.0
+   |         ^^^^ `self` value is a keyword only available in methods with a `self` parameter
+   |
+help: add a `self` receiver parameter to make the associated `fn` a method
+   |
+LL |     pub fn g(&self) {
+   |              +++++
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0424`.


### PR DESCRIPTION
Successful merges:

 - #89825 (Make split_inclusive() on an empty slice yield an empty output)
 - #91239 (regression test for issue 87490)
 - #91597 (Recover on invalid operators `<>` and `<=>`)
 - #91774 (Fix typo for MutVisitor)
 - #91786 (Return an error when `eval_rvalue_with_identities` fails)
 - #91798 (Avoid suggest adding `self` in visibility spec)
 - #91856 (Looser check for overflowing_binary_op)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=89825,91239,91597,91774,91786,91798,91856)
<!-- homu-ignore:end -->