### PR TITLE
Add `std::error::Report` type

### DIFF
--- a/library/std/src/error.rs
+++ b/library/std/src/error.rs
@@ -811,6 +811,8 @@ impl dyn Error + Send + Sync {
 /// An error reporter that exposes the entire error chain for printing.
 /// It also exposes options for formatting the error chain, either entirely on a single line,
 /// or in multi-line format with each cause in the error chain on a new line.
+/// `Report` only requires that the wrapped error implements `Error`. It doesn't require that the
+/// wrapped error be `Send`, `Sync`, or `'static`.
 ///
 /// # Examples
 ///
@@ -822,68 +824,31 @@ impl dyn Error + Send + Sync {
 /// use std::fmt;
 ///
 /// #[derive(Debug)]
-/// struct SuperError {
-///     side: SuperErrorSideKick,
+/// struct SuperError<'a> {
+///     side: &'a str,
 /// }
 ///
-/// impl fmt::Display for SuperError {
+/// impl<'a> fmt::Display for SuperError<'a> {
 ///     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-///         write!(f, "SuperError is here!")
+///         write!(f, "SuperError is here: {}", self.side)
 ///     }
 /// }
 ///
-/// impl Error for SuperError {
-///     fn source(&self) -> Option<&(dyn Error + 'static)> {
-///         Some(&self.side)
-///     }
-/// }
-///
-/// #[derive(Debug)]
-/// struct SuperErrorSideKick;
-///
-/// impl fmt::Display for SuperErrorSideKick {
-///     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-///         write!(f, "SuperErrorSideKick is here!")
-///     }
-/// }
-///
-/// impl Error for SuperErrorSideKick {}
+/// impl<'a> Error for SuperError<'a> {}
 ///
 /// // Note that the error doesn't need to be `Send` or `Sync`.
 /// impl !Send for SuperError {}
 /// impl !Sync for SuperError {}
 ///
 /// fn main() {
-///     let error = SuperError { side: SuperErrorSideKick };
+///     let msg = String::from("Huzzah!");
+///     let error = SuperError { side: &msg };
 ///     let report = Report::new(&error).pretty(true);
 ///
 ///     println!("{}", report);
 /// }
 /// ```
-///
-/// `Report` only requires that the wrapped error implements `Error`. It doesn't require that the
-/// wrapped error be `Send`, `Sync`, or `'static`.
-///
-/// ```rust
-/// # #![feature(error_reporter)]
-/// # use std::fmt;
-/// # use std::error::{Error, Report};
-/// #[derive(Debug)]
-/// struct SuperError<'a> {
-///     side: &'a str,
-/// }
-/// impl<'a> fmt::Display for SuperError<'a> {
-///     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-///         write!(f, "SuperError is here: {}", self.side)
-///     }
-/// }
-/// impl<'a> Error for SuperError<'a> {}
-/// fn main() {
-///     let msg = String::from("Huzzah!");
-///     let report = Report::new(SuperError { side: &msg });
-///     println!("{}", report);
-/// }
-/// ```
+
 #[unstable(feature = "error_reporter", issue = "90172")]
 pub struct Report<E> {
     /// The error being reported.

--- a/library/std/src/error.rs
+++ b/library/std/src/error.rs
@@ -850,7 +850,7 @@ impl dyn Error + Send + Sync {
 ///
 /// fn main() {
 ///     let error = SuperError { side: SuperErrorSideKick };
-///     let report = Report::new(&error).pretty();
+///     let report = Report::new(&error).pretty(true);
 ///
 ///     println!("{}", report);
 /// }
@@ -874,15 +874,15 @@ where
 
     /// Enable pretty-printing the report.
     #[unstable(feature = "error_reporter", issue = "90172")]
-    pub fn pretty(mut self) -> Self {
-        self.pretty = true;
+    pub fn pretty(mut self, pretty: bool) -> Self {
+        self.pretty = pretty;
         self
     }
 
     /// Enable showing a backtrace for the report.
     #[unstable(feature = "error_reporter", issue = "90172")]
-    pub fn show_backtrace(mut self) -> Self {
-        self.show_backtrace = true;
+    pub fn show_backtrace(mut self, show_backtrace: bool) -> Self {
+        self.show_backtrace = show_backtrace;
         self
     }
 

--- a/library/std/src/error.rs
+++ b/library/std/src/error.rs
@@ -857,7 +857,7 @@ impl dyn Error + Send + Sync {
 /// ```
 #[unstable(feature = "error_reporter", issue = "90172")]
 pub struct Report<E> {
-    source: E,
+    error: E,
     show_backtrace: bool,
     pretty: bool,
 }
@@ -868,8 +868,8 @@ where
 {
     /// Create a new `Report` from an input error.
     #[unstable(feature = "error_reporter", issue = "90172")]
-    pub fn new(source: E) -> Report<E> {
-        Report { source, show_backtrace: false, pretty: false }
+    pub fn new(error: E) -> Report<E> {
+        Report { error, show_backtrace: false, pretty: false }
     }
 
     /// Enable pretty-printing the report.
@@ -889,9 +889,9 @@ where
     /// Format the report as a single line.
     #[unstable(feature = "error_reporter", issue = "90172")]
     fn fmt_singleline(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.source)?;
+        write!(f, "{}", self.error)?;
 
-        let sources = self.source.source().into_iter().flat_map(<dyn Error>::chain);
+        let sources = self.error.source().into_iter().flat_map(<dyn Error>::chain);
 
         for cause in sources {
             write!(f, ": {}", cause)?;
@@ -903,7 +903,7 @@ where
     /// Format the report as multiple lines, with each error cause on its own line.
     #[unstable(feature = "error_reporter", issue = "90172")]
     fn fmt_multiline(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let error = &self.source;
+        let error = &self.error;
 
         write!(f, "{}", error)?;
 
@@ -950,8 +950,8 @@ impl<E> From<E> for Report<E>
 where
     E: Error,
 {
-    fn from(source: E) -> Self {
-        Report::new(source)
+    fn from(error: E) -> Self {
+        Report::new(error)
     }
 }
 

--- a/library/std/src/error.rs
+++ b/library/std/src/error.rs
@@ -837,8 +837,8 @@ impl dyn Error + Send + Sync {
 /// impl<'a> Error for SuperError<'a> {}
 ///
 /// // Note that the error doesn't need to be `Send` or `Sync`.
-/// impl !Send for SuperError {}
-/// impl !Sync for SuperError {}
+/// impl<'a> !Send for SuperError<'a> {}
+/// impl<'a> !Sync for SuperError<'a> {}
 ///
 /// fn main() {
 ///     let msg = String::from("Huzzah!");

--- a/library/std/src/error.rs
+++ b/library/std/src/error.rs
@@ -814,7 +814,7 @@ impl dyn Error + Send + Sync {
 ///
 /// # Examples
 ///
-/// ```
+/// ```rust
 /// #![feature(error_reporter)]
 /// #![feature(negative_impls)]
 ///

--- a/library/std/src/error.rs
+++ b/library/std/src/error.rs
@@ -914,106 +914,109 @@ impl dyn Error + Send + Sync {
 /// thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: SuperError is here!: SuperErrorSideKick is here!', src/error.rs:34:40
 /// note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 /// ```
-// /// TODO: Report doesn't yet support return from `main` gracefully, fix in followup (yaahc)
-// /// ## Return from `main`
-// ///
-// /// `Report` also implements `From` for all types that implement [`Error`], this when combined with
-// /// the `Debug` output means `Report` is an ideal starting place for formatting errors returned
-// /// from `main`.
-// ///
-// /// ```
-// /// #![feature(error_reporter)]
-// /// use std::error::Report;
-// /// # use std::error::Error;
-// /// # use std::fmt;
-// /// # #[derive(Debug)]
-// /// # struct SuperError {
-// /// #     source: SuperErrorSideKick,
-// /// # }
-// /// # impl fmt::Display for SuperError {
-// /// #     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-// /// #         write!(f, "SuperError is here!")
-// /// #     }
-// /// # }
-// /// # impl Error for SuperError {
-// /// #     fn source(&self) -> Option<&(dyn Error + 'static)> {
-// /// #         Some(&self.source)
-// /// #     }
-// /// # }
-// /// # #[derive(Debug)]
-// /// # struct SuperErrorSideKick;
-// /// # impl fmt::Display for SuperErrorSideKick {
-// /// #     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-// /// #         write!(f, "SuperErrorSideKick is here!")
-// /// #     }
-// /// # }
-// /// # impl Error for SuperErrorSideKick {}
-// /// # fn get_super_error() -> Result<(), SuperError> {
-// /// #     Err(SuperError { source: SuperErrorSideKick })
-// /// # }
-// ///
-// /// fn main() -> Result<(), Report> {
-// ///     get_super_error()?;
-// /// }
-// /// ```
-// ///
-// /// This example produces the following output:
-// ///
-// /// ```console
-// /// thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: SuperError is here!: SuperErrorSideKick is here!', src/error.rs:34:40
-// /// note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
-// /// ```
-// ///
-// /// **Note**: `Report`s constructed via `?` and `From` will be configured to use the single line
-// /// output format, if you want to make sure your `Report`s are pretty printed and include backtrace
-// /// you will need to manually convert and enable those flags.
-// ///
-// /// ```
-// /// #![feature(error_reporter)]
-// /// use std::error::Report;
-// /// # use std::error::Error;
-// /// # use std::fmt;
-// /// # #[derive(Debug)]
-// /// # struct SuperError {
-// /// #     source: SuperErrorSideKick,
-// /// # }
-// /// # impl fmt::Display for SuperError {
-// /// #     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-// /// #         write!(f, "SuperError is here!")
-// /// #     }
-// /// # }
-// /// # impl Error for SuperError {
-// /// #     fn source(&self) -> Option<&(dyn Error + 'static)> {
-// /// #         Some(&self.source)
-// /// #     }
-// /// # }
-// /// # #[derive(Debug)]
-// /// # struct SuperErrorSideKick;
-// /// # impl fmt::Display for SuperErrorSideKick {
-// /// #     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-// /// #         write!(f, "SuperErrorSideKick is here!")
-// /// #     }
-// /// # }
-// /// # impl Error for SuperErrorSideKick {}
-// /// # fn get_super_error() -> Result<(), SuperError> {
-// /// #     Err(SuperError { source: SuperErrorSideKick })
-// /// # }
-// ///
-// /// fn main() -> Result<(), Report> {
-// ///     get_super_error()
-// ///         .map_err(Report::new)
-// ///         .map_err(|r| r.pretty(true).show_backtrace(true))?;
-// /// }
-// /// ```
-// ///
-// /// This example produces the following output:
-// ///
-// /// ```console
-// /// thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: SuperError is here!: SuperErrorSideKick is here!', src/error.rs:34:40
-// /// note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
-// /// ```
+///
+/// ## Return from `main`
+///
+/// `Report` also implements `From` for all types that implement [`Error`], this when combined with
+/// the `Debug` output means `Report` is an ideal starting place for formatting errors returned
+/// from `main`.
+///
+/// ```should_panic
+/// #![feature(error_reporter)]
+/// use std::error::Report;
+/// # use std::error::Error;
+/// # use std::fmt;
+/// # #[derive(Debug)]
+/// # struct SuperError {
+/// #     source: SuperErrorSideKick,
+/// # }
+/// # impl fmt::Display for SuperError {
+/// #     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+/// #         write!(f, "SuperError is here!")
+/// #     }
+/// # }
+/// # impl Error for SuperError {
+/// #     fn source(&self) -> Option<&(dyn Error + 'static)> {
+/// #         Some(&self.source)
+/// #     }
+/// # }
+/// # #[derive(Debug)]
+/// # struct SuperErrorSideKick;
+/// # impl fmt::Display for SuperErrorSideKick {
+/// #     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+/// #         write!(f, "SuperErrorSideKick is here!")
+/// #     }
+/// # }
+/// # impl Error for SuperErrorSideKick {}
+/// # fn get_super_error() -> Result<(), SuperError> {
+/// #     Err(SuperError { source: SuperErrorSideKick })
+/// # }
+///
+/// fn main() -> Result<(), Report> {
+///     get_super_error()?;
+///     Ok(())
+/// }
+/// ```
+///
+/// This example produces the following output:
+///
+/// ```console
+/// Error: SuperError is here!: SuperErrorSideKick is here!
+/// ```
+///
+/// **Note**: `Report`s constructed via `?` and `From` will be configured to use the single line
+/// output format, if you want to make sure your `Report`s are pretty printed and include backtrace
+/// you will need to manually convert and enable those flags.
+///
+/// ```should_panic
+/// #![feature(error_reporter)]
+/// use std::error::Report;
+/// # use std::error::Error;
+/// # use std::fmt;
+/// # #[derive(Debug)]
+/// # struct SuperError {
+/// #     source: SuperErrorSideKick,
+/// # }
+/// # impl fmt::Display for SuperError {
+/// #     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+/// #         write!(f, "SuperError is here!")
+/// #     }
+/// # }
+/// # impl Error for SuperError {
+/// #     fn source(&self) -> Option<&(dyn Error + 'static)> {
+/// #         Some(&self.source)
+/// #     }
+/// # }
+/// # #[derive(Debug)]
+/// # struct SuperErrorSideKick;
+/// # impl fmt::Display for SuperErrorSideKick {
+/// #     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+/// #         write!(f, "SuperErrorSideKick is here!")
+/// #     }
+/// # }
+/// # impl Error for SuperErrorSideKick {}
+/// # fn get_super_error() -> Result<(), SuperError> {
+/// #     Err(SuperError { source: SuperErrorSideKick })
+/// # }
+///
+/// fn main() -> Result<(), Report> {
+///     get_super_error()
+///         .map_err(Report::from)
+///         .map_err(|r| r.pretty(true).show_backtrace(true))?;
+///     Ok(())
+/// }
+/// ```
+///
+/// This example produces the following output:
+///
+/// ```console
+/// Error: SuperError is here!
+///
+/// Caused by:
+///       SuperErrorSideKick is here!
+/// ```
 #[unstable(feature = "error_reporter", issue = "90172")]
-pub struct Report<E> {
+pub struct Report<E = Box<dyn Error>> {
     /// The error being reported.
     error: E,
     /// Whether a backtrace should be included as part of the report.
@@ -1024,14 +1027,16 @@ pub struct Report<E> {
 
 impl<E> Report<E>
 where
-    E: Error,
+    Report<E>: From<E>,
 {
     /// Create a new `Report` from an input error.
     #[unstable(feature = "error_reporter", issue = "90172")]
     pub fn new(error: E) -> Report<E> {
-        Report { error, show_backtrace: false, pretty: false }
+        Self::from(error)
     }
+}
 
+impl<E> Report<E> {
     /// Enable pretty-printing the report across multiple lines.
     ///
     /// # Examples
@@ -1232,7 +1237,81 @@ where
         self.show_backtrace = show_backtrace;
         self
     }
+}
 
+impl<E> Report<E>
+where
+    E: Error,
+{
+    fn backtrace(&self) -> Option<&Backtrace> {
+        // have to grab the backtrace on the first error directly since that error may not be
+        // 'static
+        let backtrace = self.error.backtrace();
+        let backtrace = backtrace.or_else(|| {
+            self.error
+                .source()
+                .map(|source| source.chain().find_map(|source| source.backtrace()))
+                .flatten()
+        });
+        backtrace
+    }
+
+    /// Format the report as a single line.
+    #[unstable(feature = "error_reporter", issue = "90172")]
+    fn fmt_singleline(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.error)?;
+
+        let sources = self.error.source().into_iter().flat_map(<dyn Error>::chain);
+
+        for cause in sources {
+            write!(f, ": {}", cause)?;
+        }
+
+        Ok(())
+    }
+
+    /// Format the report as multiple lines, with each error cause on its own line.
+    #[unstable(feature = "error_reporter", issue = "90172")]
+    fn fmt_multiline(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let error = &self.error;
+
+        write!(f, "{}", error)?;
+
+        if let Some(cause) = error.source() {
+            write!(f, "\n\nCaused by:")?;
+
+            let multiple = cause.source().is_some();
+
+            for (ind, error) in cause.chain().enumerate() {
+                writeln!(f)?;
+                let mut indented = Indented {
+                    inner: f,
+                };
+                if multiple {
+                    write!(indented, "{: >4}: {}", ind, error)?;
+                } else {
+                    write!(indented, "      {}", error)?;
+                }
+            }
+        }
+
+        if self.show_backtrace {
+            let backtrace = self.backtrace();
+
+            if let Some(backtrace) = backtrace {
+                let backtrace = backtrace.to_string();
+
+                f.write_str("\n\nStack backtrace:\n")?;
+                f.write_str(backtrace.trim_end())?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl Report<Box<dyn Error>>
+{
     fn backtrace(&self) -> Option<&Backtrace> {
         // have to grab the backtrace on the first error directly since that error may not be
         // 'static
@@ -1306,7 +1385,18 @@ where
     E: Error,
 {
     fn from(error: E) -> Self {
-        Report::new(error)
+        Report { error, show_backtrace: false, pretty: false }
+    }
+}
+
+#[unstable(feature = "error_reporter", issue = "90172")]
+impl<'a, E> From<E> for Report<Box<dyn Error + 'a>>
+where
+    E: Error + 'a,
+{
+    fn from(error: E) -> Self {
+        let error = box error;
+        Report { error, show_backtrace: false, pretty: false }
     }
 }
 
@@ -1320,12 +1410,20 @@ where
     }
 }
 
+#[unstable(feature = "error_reporter", issue = "90172")]
+impl fmt::Display for Report<Box<dyn Error>>
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.pretty { self.fmt_multiline(f) } else { self.fmt_singleline(f) }
+    }
+}
+
 // This type intentionally outputs the same format for `Display` and `Debug`for
 // situations where you unwrap a `Report` or return it from main.
 #[unstable(feature = "error_reporter", issue = "90172")]
 impl<E> fmt::Debug for Report<E>
 where
-    E: Error,
+    Report<E>: fmt::Display,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(self, f)

--- a/library/std/src/error.rs
+++ b/library/std/src/error.rs
@@ -1284,9 +1284,7 @@ where
 
             for (ind, error) in cause.chain().enumerate() {
                 writeln!(f)?;
-                let mut indented = Indented {
-                    inner: f,
-                };
+                let mut indented = Indented { inner: f };
                 if multiple {
                     write!(indented, "{: >4}: {}", ind, error)?;
                 } else {
@@ -1310,8 +1308,7 @@ where
     }
 }
 
-impl Report<Box<dyn Error>>
-{
+impl Report<Box<dyn Error>> {
     fn backtrace(&self) -> Option<&Backtrace> {
         // have to grab the backtrace on the first error directly since that error may not be
         // 'static
@@ -1353,9 +1350,7 @@ impl Report<Box<dyn Error>>
 
             for (ind, error) in cause.chain().enumerate() {
                 writeln!(f)?;
-                let mut indented = Indented {
-                    inner: f,
-                };
+                let mut indented = Indented { inner: f };
                 if multiple {
                     write!(indented, "{: >4}: {}", ind, error)?;
                 } else {
@@ -1411,8 +1406,7 @@ where
 }
 
 #[unstable(feature = "error_reporter", issue = "90172")]
-impl fmt::Display for Report<Box<dyn Error>>
-{
+impl fmt::Display for Report<Box<dyn Error>> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if self.pretty { self.fmt_multiline(f) } else { self.fmt_singleline(f) }
     }

--- a/library/std/src/error/tests.rs
+++ b/library/std/src/error/tests.rs
@@ -35,3 +35,294 @@ fn downcasting() {
         Err(e) => assert_eq!(*e.downcast::<A>().unwrap(), A),
     }
 }
+
+use crate::backtrace;
+use crate::env;
+use crate::error::Report;
+
+#[derive(Debug)]
+struct SuperError {
+    side: SuperErrorSideKick,
+}
+
+impl fmt::Display for SuperError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "SuperError is here!")
+    }
+}
+
+impl Error for SuperError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        Some(&self.side)
+    }
+}
+
+#[derive(Debug)]
+struct SuperErrorSideKick;
+
+impl fmt::Display for SuperErrorSideKick {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "SuperErrorSideKick is here!")
+    }
+}
+
+impl Error for SuperErrorSideKick {}
+
+#[test]
+fn single_line_formatting() {
+    let error = SuperError { side: SuperErrorSideKick };
+    let report = Report::new(&error);
+    let actual = report.to_string();
+    let expected = String::from("SuperError is here!: SuperErrorSideKick is here!");
+
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn multi_line_formatting() {
+    let error = SuperError { side: SuperErrorSideKick };
+    let report = Report::new(&error).pretty(true);
+    let actual = report.to_string();
+    let expected =
+        String::from("SuperError is here!\n\nCaused by:\n    SuperErrorSideKick is here!");
+
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn error_with_no_sources_formats_single_line_correctly() {
+    let report = Report::new(SuperErrorSideKick);
+    let actual = report.to_string();
+    let expected = String::from("SuperErrorSideKick is here!");
+
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn error_with_no_sources_formats_multi_line_correctly() {
+    let report = Report::new(SuperErrorSideKick).pretty(true);
+    let actual = report.to_string();
+    let expected = String::from("SuperErrorSideKick is here!");
+
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn error_with_backtrace_outputs_correctly() {
+    use backtrace::Backtrace;
+
+    env::remove_var("RUST_BACKTRACE");
+
+    #[derive(Debug)]
+    struct ErrorWithBacktrace<'a> {
+        msg: &'a str,
+        trace: Backtrace,
+    }
+
+    impl<'a> fmt::Display for ErrorWithBacktrace<'a> {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(f, "Error with backtrace: {}", self.msg)
+        }
+    }
+
+    impl<'a> Error for ErrorWithBacktrace<'a> {
+        fn backtrace(&self) -> Option<&Backtrace> {
+            Some(&self.trace)
+        }
+    }
+
+    let msg = String::from("The source of the error");
+    let report = Report::new(ErrorWithBacktrace { msg: &msg, trace: Backtrace::capture() })
+        .pretty(true)
+        .show_backtrace(true);
+
+    let expected = String::from(
+        "Error with backtrace: The source of the error\n\nStack backtrace:\ndisabled backtrace",
+    );
+
+    assert_eq!(expected, report.to_string());
+}
+
+#[derive(Debug)]
+struct GenericError<D> {
+    message: D,
+    source: Option<Box<dyn Error + 'static>>,
+}
+
+impl<D> GenericError<D> {
+    fn new(message: D) -> GenericError<D> {
+        Self { message, source: None }
+    }
+
+    fn new_with_source<E>(message: D, source: E) -> GenericError<D>
+    where
+        E: Error + 'static,
+    {
+        let source: Box<dyn Error + 'static> = Box::new(source);
+        let source = Some(source);
+        GenericError { message, source }
+    }
+}
+
+impl<D> fmt::Display for GenericError<D>
+where
+    D: fmt::Display,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.message, f)
+    }
+}
+
+impl<D> Error for GenericError<D>
+where
+    D: fmt::Debug + fmt::Display,
+{
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        self.source.as_deref()
+    }
+}
+
+#[test]
+fn error_formats_single_line_with_rude_display_impl() {
+    #[derive(Debug)]
+    struct MyMessage;
+
+    impl fmt::Display for MyMessage {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.write_str("line 1\nline 2")?;
+            f.write_str("\nline 3\nline 4\n")?;
+            f.write_str("line 5\nline 6")?;
+            Ok(())
+        }
+    }
+
+    let error = GenericError::new(MyMessage);
+    let error = GenericError::new_with_source(MyMessage, error);
+    let error = GenericError::new_with_source(MyMessage, error);
+    let error = GenericError::new_with_source(MyMessage, error);
+    let report = Report::new(error);
+    let expected = r#"line 1
+line 2
+line 3
+line 4
+line 5
+line 6: line 1
+line 2
+line 3
+line 4
+line 5
+line 6: line 1
+line 2
+line 3
+line 4
+line 5
+line 6: line 1
+line 2
+line 3
+line 4
+line 5
+line 6"#;
+
+    let actual = report.to_string();
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn error_formats_multi_line_with_rude_display_impl() {
+    #[derive(Debug)]
+    struct MyMessage;
+
+    impl fmt::Display for MyMessage {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.write_str("line 1\nline 2")?;
+            f.write_str("\nline 3\nline 4\n")?;
+            f.write_str("line 5\nline 6")?;
+            Ok(())
+        }
+    }
+
+    let error = GenericError::new(MyMessage);
+    let error = GenericError::new_with_source(MyMessage, error);
+    let error = GenericError::new_with_source(MyMessage, error);
+    let error = GenericError::new_with_source(MyMessage, error);
+    let report = Report::new(error).pretty(true);
+    let expected = r#"line 1
+line 2
+line 3
+line 4
+line 5
+line 6
+
+Caused by:
+   0: line 1
+      line 2
+      line 3
+      line 4
+      line 5
+      line 6
+   1: line 1
+      line 2
+      line 3
+      line 4
+      line 5
+      line 6
+   2: line 1
+      line 2
+      line 3
+      line 4
+      line 5
+      line 6"#;
+
+    let actual = report.to_string();
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn errors_that_start_with_newline_formats_correctly() {
+    #[derive(Debug)]
+    struct MyMessage;
+
+    impl fmt::Display for MyMessage {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.write_str("\nThe message\n")
+        }
+    }
+
+    let error = GenericError::new(MyMessage);
+    let error = GenericError::new_with_source(MyMessage, error);
+    let error = GenericError::new_with_source(MyMessage, error);
+    let report = Report::new(error).pretty(true);
+    let expected = r#"
+The message
+
+
+Caused by:
+   0: The message
+   1: The message"#;
+
+    let actual = report.to_string();
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn errors_with_string_interpolation_formats_correctly() {
+    #[derive(Debug)]
+    struct MyMessage(usize);
+
+    impl fmt::Display for MyMessage {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(f, "Got an error code: ({}). ", self.0)?;
+            write!(f, "What would you like to do in response?")
+        }
+    }
+
+    let error = GenericError::new(MyMessage(10));
+    let error = GenericError::new_with_source(MyMessage(20), error);
+    let report = Report::new(error).pretty(true);
+    let expected = r#"Got an error code: (20). What would you like to do in response?
+
+Caused by:
+    Got an error code: (10). What would you like to do in response?"#;
+    let actual = report.to_string();
+    assert_eq!(expected, actual);
+}

--- a/library/std/src/error/tests.rs
+++ b/library/std/src/error/tests.rs
@@ -82,11 +82,13 @@ fn multi_line_formatting() {
     let error = SuperError { source: SuperErrorSideKick };
     let report = Report::new(&error).pretty(true);
     let actual = report.to_string();
-    let expected = String::from("\
+    let expected = String::from(
+        "\
 SuperError is here!
 
 Caused by:
-      SuperErrorSideKick is here!");
+      SuperErrorSideKick is here!",
+    );
 
     assert_eq!(expected, actual);
 }
@@ -112,19 +114,21 @@ fn error_with_no_sources_formats_multi_line_correctly() {
 #[test]
 fn error_with_backtrace_outputs_correctly_with_one_source() {
     let trace = Backtrace::force_capture();
-    let expected = format!("\
+    let expected = format!(
+        "\
 The source of the error
 
 Caused by:
       Error with backtrace
 
 Stack backtrace:
-{}", trace);
+{}",
+        trace
+    );
     let error = GenericError::new("Error with backtrace");
     let mut error = GenericError::new_with_source("The source of the error", error);
     error.backtrace = Some(trace);
     let report = Report::new(error).pretty(true).show_backtrace(true);
-
 
     println!("Error: {}", report);
     assert_eq!(expected.trim_end(), report.to_string());
@@ -133,7 +137,8 @@ Stack backtrace:
 #[test]
 fn error_with_backtrace_outputs_correctly_with_two_sources() {
     let trace = Backtrace::force_capture();
-    let expected = format!("\
+    let expected = format!(
+        "\
 Error with two sources
 
 Caused by:
@@ -141,13 +146,14 @@ Caused by:
    1: Error with backtrace
 
 Stack backtrace:
-{}", trace);
+{}",
+        trace
+    );
     let mut error = GenericError::new("Error with backtrace");
     error.backtrace = Some(trace);
     let error = GenericError::new_with_source("The source of the error", error);
     let error = GenericError::new_with_source("Error with two sources", error);
     let report = Report::new(error).pretty(true).show_backtrace(true);
-
 
     println!("Error: {}", report);
     assert_eq!(expected.trim_end(), report.to_string());
@@ -313,11 +319,11 @@ The message
 
 
 Caused by:
-   0: 
-      The message
-      
-   1: 
-      The message
+   0: \
+\n      The message
+      \
+\n   1: \
+\n      The message
       ";
 
     let actual = report.to_string();
@@ -399,11 +405,11 @@ line 2
 
 Caused by:
    0: line 1
-      
-      line 2
+      \
+\n      line 2
    1: line 1
-      
-      line 2";
+      \
+\n      line 2";
 
     let actual = report.to_string();
     assert_eq!(expected, actual);


### PR DESCRIPTION
This is a continuation of https://github.com/rust-lang/rust/pull/90174, split into a separate PR since I cannot push to @seanchen1991 's fork