### PR TITLE
Update cargo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -276,7 +276,7 @@ dependencies = [
 
 [[package]]
 name = "cargo"
-version = "0.59.0"
+version = "0.60.0"
 dependencies = [
  "anyhow",
  "atty",
@@ -419,7 +419,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-util"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "core-foundation",
@@ -768,7 +768,7 @@ checksum = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
 
 [[package]]
 name = "crates-io"
-version = "0.33.0"
+version = "0.33.1"
 dependencies = [
  "anyhow",
  "curl",


### PR DESCRIPTION
14 commits in 40dc281755137ee804bc9b3b08e782773b726e44..a359ce16073401f28b84840da85b268aa3d37c88
2021-12-06 21:54:44 +0000 to 2021-12-14 18:40:22 +0000
- Support `term.quiet` configuration (rust-lang/cargo#10152)
- Display alias target on 'cargo help &lt;alias&gt;` (rust-lang/cargo#10193)
- delete --host command and message (rust-lang/cargo#10145)
- Improve I/O error message for fingerprint of build script (rust-lang/cargo#10191)
- Explicitly mark aliases in `cargo list`. (rust-lang/cargo#10177)
- Don't emit "executable" JSON field for non-executables. (rust-lang/cargo#10171)
- Move scrape-examples docs to correct section. (rust-lang/cargo#10166)
- Do not suggest source config if nothing to vendor (rust-lang/cargo#10161)
- Bump versions of local deps. (rust-lang/cargo#10155)
- Bump to 0.60.0, update changelog (rust-lang/cargo#10154)
- Fix some profile documentation. (rust-lang/cargo#10153)
- Document lib before bin. (rust-lang/cargo#10172)
- Sync cargo-the-cli version with rustc. (rust-lang/cargo#10178)
- Remove `-Z future-incompat-report` from message displayed to user (rust-lang/cargo#10185)