### PR TITLE
Apply rust-logo class only on default logo

### DIFF
--- a/src/librustdoc/html/templates/page.html
+++ b/src/librustdoc/html/templates/page.html
@@ -74,30 +74,26 @@
     {{- layout.external_html.before_content | safe -}}
     <nav class="sidebar"> {#- -#}
         <div class="sidebar-menu" role="button">&#9776;</div> {#- -#}
-        <a class="sidebar-logo" href='{{page.root_path | safe}}{{krate_with_trailing_slash | safe}}index.html'> {#- -#}
-            <div class='logo-container rust-logo'> {#- -#}
-                <img src='
-                    {%- if layout.logo -%}
-                    {{layout.logo}}
-                    {%- else -%}
-                    {{static_root_path | safe}}rust-logo{{page.resource_suffix}}.png
-                    {%- endif -%}
-                    ' alt='logo'> {#- -#}
-            </div> {#- -#}
+        <a class="sidebar-logo" href="{{page.root_path | safe}}{{krate_with_trailing_slash | safe}}index.html"> {#- -#}
+            <div class="logo-container"> {#- -#}
+            {%- if layout.logo -%}
+                <img src="{{layout.logo}}" alt="logo"> {#- -#}
+            {%- else -%}
+                <img class="rust-logo" src="{{static_root_path | safe}}rust-logo{{page.resource_suffix}}.png" alt="logo"> {#- -#}
+            {%- endif -%}
+            </div>
         </a> {#- -#}
         {{- sidebar | safe -}}
     </nav> {#- -#}
     <main> {#- -#}
         <div class="width-limiter"> {#- -#}
             <div class="sub-container"> {#- -#}
-                <a class="sub-logo-container rust-logo" href='{{page.root_path | safe}}{{krate_with_trailing_slash | safe}}index.html'> {#- -#}
-                    <img src='
-                        {%- if layout.logo -%}
-                        {{layout.logo}}
-                        {%- else -%}
-                        {{static_root_path | safe}}rust-logo{{page.resource_suffix}}.png
-                        {%- endif -%}
-                        ' alt='logo'> {#- -#}
+                <a class="sub-logo-container" href="{{page.root_path | safe}}{{krate_with_trailing_slash | safe}}index.html"> {#- -#}
+                    {%- if layout.logo -%}
+                    <img src="{{layout.logo}}" alt="logo">
+                    {%- else -%}
+                    <img class="rust-logo" src="{{static_root_path | safe}}rust-logo{{page.resource_suffix}}.png" alt="logo">
+                    {%- endif -%}
                 </a> {#- -#}
                 <nav class="sub"> {#- -#}
                     <div class="theme-picker"> {#- -#}

--- a/src/test/rustdoc/logo-class-default.rs
+++ b/src/test/rustdoc/logo-class-default.rs
@@ -1,0 +1,4 @@
+// Note: this test is paired with logo-class.rs.
+// @has logo_class_default/struct.SomeStruct.html '//*[@class="logo-container"]/img[@class="rust-logo"]' ''
+// @has logo_class_default/struct.SomeStruct.html '//*[@class="sub-logo-container"]/img[@class="rust-logo"]' ''
+pub struct SomeStruct;

--- a/src/test/rustdoc/logo-class.rs
+++ b/src/test/rustdoc/logo-class.rs
@@ -1,0 +1,10 @@
+#![doc(html_logo_url =
+    "https://raw.githubusercontent.com/sagebind/isahc/master/media/isahc.svg.png")]
+// Note: this test is paired with logo-class-default.rs.
+
+// @has logo_class/struct.SomeStruct.html '//*[@class="logo-container"]/img[@src="https://raw.githubusercontent.com/sagebind/isahc/master/media/isahc.svg.png"]' ''
+// @!has logo_class/struct.SomeStruct.html '//*[@class="logo-container"]/img[@class="rust-logo"]' ''
+//
+// @has logo_class/struct.SomeStruct.html '//*[@class="sub-logo-container"]/img[@src="https://raw.githubusercontent.com/sagebind/isahc/master/media/isahc.svg.png"]' ''
+// @!has logo_class/struct.SomeStruct.html '//*[@class="sub-logo-container"]/img[@class="rust-logo"]' ''
+pub struct SomeStruct;


### PR DESCRIPTION
Fixes #91653.

![image](https://user-images.githubusercontent.com/220205/146138145-a7a62ea6-3205-4bc7-8460-e985284d93ea.png)

Demo: https://rustdoc.crud.net/jsha/hashes/sha2/

r? @GuillaumeGomez 