### PR TITLE
Add the Provider api to core::any

### DIFF
--- a/library/core/src/any.rs
+++ b/library/core/src/any.rs
@@ -1,5 +1,9 @@
-//! This module implements the `Any` trait, which enables dynamic typing
-//! of any `'static` type through runtime reflection.
+//! This module contains the `Any` trait, which enables dynamic typing
+//! of any `'static` type through runtime reflection. It also contains the
+//! `Provider` trait and accompanying API, which enable trait objects to provide
+//! data based on typed requests, an alternate form of runtime reflection.
+//!
+//! # `Any` and `TypeId`
 //!
 //! `Any` itself can be used to get a `TypeId`, and has more features when used
 //! as a trait object. As `&dyn Any` (a borrowed trait object), it has the `is`
@@ -37,7 +41,7 @@
 //! assert_eq!(boxed_id, TypeId::of::<Box<dyn Any>>());
 //! ```
 //!
-//! # Examples
+//! ## Examples
 //!
 //! Consider a situation where we want to log out a value passed to a function.
 //! We know the value we're working on implements Debug, but we don't know its
@@ -81,11 +85,76 @@
 //!     do_work(&my_i8);
 //! }
 //! ```
+//!
+//! # `Provider` and `Demand`
+//!
+//! `Provider` and the associated APIs support generic, type-driven access to data, and a mechanism
+//! for implementers to provide such data. The key parts of the interface are the `Provider`
+//! trait for objects which can provide data, and the [`request_value`] and [`request_ref`]
+//! functions for requesting data from an object which implements `Provider`. Note that end users
+//! should not call `request_*` directly, they are helper functions for intermediate implementers
+//! to use to implement a user-facing interface.
+//!
+//! Typically, a data provider is a trait object of a trait which extends `Provider`. A user will
+//! request data from the trait object by specifying the type.
+//!
+//! ## Data flow
+//!
+//! * A user requests an object, which is delegated to `request_value` or `request_ref`
+//! * `request_*` creates a `Demand` object and passes it to `Provider::provide`
+//! * The object provider's implementation of `Provider::provide` tries providing values of
+//!   different types using `Demand::provide_*`. If the type matches the type requested by
+//!   the user, it will be stored in the `Demand` object.
+//! * `request_*` unpacks the `Demand` object and returns any stored value to the user.
+//!
+//! ## Examples
+//!
+//! ```
+//! # #![allow(incomplete_features)]
+//! # #![feature(provide_any)]
+//! # #![feature(trait_upcasting)]
+//! use std::any::{Provider, Demand, request_ref};
+//!
+//! // Definition of MyTrait
+//! trait MyTrait: Provider {
+//!     // ...
+//! }
+//!
+//! // Methods on `MyTrait` trait objects.
+//! impl dyn MyTrait + '_ {
+//!     /// Common case: get a reference to a field of the error.
+//!     pub fn get_context_ref<T: ?Sized + 'static>(&self) -> Option<&T> {
+//!         request_ref::<T>(self)
+//!     }
+//! }
+//!
+//! // Downstream implementation of `MyTrait` and `Provider`.
+//! # struct SomeConcreteType { some_string: String }
+//! impl MyTrait for SomeConcreteType {
+//!     // ...
+//! }
+//!
+//! impl Provider for SomeConcreteType {
+//!     fn provide<'a>(&'a self, req: &mut Demand<'a>) {
+//!         req.provide_ref::<String>(&self.some_string);
+//!     }
+//! }
+//!
+//! // Downstream usage of `MyTrait`.
+//! fn use_my_trait(obj: &dyn MyTrait) {
+//!     // Request a &String from obj.
+//!     let _ = obj.get_context_ref::<String>().unwrap();
+//! }
+//! ```
+//!
+//! In this example, if the concrete type of `obj` in `use_my_trait` is `SomeConcreteType`, then
+//! the `get_context_ref` call will return a reference to `obj.some_string`.
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
 use crate::fmt;
 use crate::intrinsics;
+use crate::mem::transmute;
 
 ///////////////////////////////////////////////////////////////////////////////
 // Any trait
@@ -699,4 +768,202 @@ pub const fn type_name<T: ?Sized>() -> &'static str {
 #[rustc_const_unstable(feature = "const_type_name", issue = "63084")]
 pub const fn type_name_of_val<T: ?Sized>(_val: &T) -> &'static str {
     type_name::<T>()
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Provider trait
+///////////////////////////////////////////////////////////////////////////////
+
+/// Trait implemented by a type which can dynamically provide values based on type.
+#[unstable(feature = "provide_any", issue = "none")]
+pub trait Provider {
+    /// Object providers should implement this method to provide *all* values they are able to
+    /// provide using `req`.
+    #[unstable(feature = "provide_any", issue = "none")]
+    fn provide<'a>(&'a self, req: &mut Demand<'a>);
+}
+
+/// Request a value from the `Provider`.
+#[unstable(feature = "provide_any", issue = "none")]
+pub fn request_value<'a, T: 'static>(provider: &'a dyn Provider) -> Option<T> {
+    request_by_type_tag::<'a, tags::Value<T>>(provider)
+}
+
+/// Request a reference from the `Provider`.
+#[unstable(feature = "provide_any", issue = "none")]
+pub fn request_ref<'a, T: ?Sized + 'static>(provider: &'a dyn Provider) -> Option<&'a T> {
+    request_by_type_tag::<'a, tags::Ref<tags::MaybeSizedValue<T>>>(provider)
+}
+
+/// Request a specific value by tag from the `Provider`.
+fn request_by_type_tag<'a, I>(provider: &'a dyn Provider) -> Option<I::Reified>
+where
+    I: tags::Type<'a>,
+{
+    let mut tagged = TaggedOption::<'a, I>(None);
+    provider.provide(tagged.as_demand());
+    tagged.0
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Demand and its methods
+///////////////////////////////////////////////////////////////////////////////
+
+/// A helper object for providing objects by type.
+///
+/// An object provider provides values by calling this type's provide methods.
+#[allow(missing_debug_implementations)]
+#[unstable(feature = "provide_any", issue = "none")]
+// SAFETY: `TaggedOption::as_demand` relies on this precise definition.
+#[repr(transparent)]
+pub struct Demand<'a>(dyn Erased<'a> + 'a);
+
+impl<'a> Demand<'a> {
+    /// Provide a value or other type with only static lifetimes.
+    #[unstable(feature = "provide_any", issue = "none")]
+    pub fn provide_value<T, F>(&mut self, fulfil: F) -> &mut Self
+    where
+        T: 'static,
+        F: FnOnce() -> T,
+    {
+        self.provide_with::<tags::Value<T>, F>(fulfil)
+    }
+
+    /// Provide a reference, note that the referee type must be bounded by `'static`, but may be unsized.
+    #[unstable(feature = "provide_any", issue = "none")]
+    pub fn provide_ref<T: ?Sized + 'static>(&mut self, value: &'a T) -> &mut Self {
+        self.provide::<tags::Ref<tags::MaybeSizedValue<T>>>(value)
+    }
+
+    /// Provide a value with the given `Type` tag.
+    fn provide<I>(&mut self, value: I::Reified) -> &mut Self
+    where
+        I: tags::Type<'a>,
+    {
+        if let Some(res @ TaggedOption(None)) = self.0.downcast_mut::<I>() {
+            res.0 = Some(value);
+        }
+        self
+    }
+
+    /// Provide a value with the given `Type` tag, using a closure to prevent unnecessary work.
+    fn provide_with<I, F>(&mut self, fulfil: F) -> &mut Self
+    where
+        I: tags::Type<'a>,
+        F: FnOnce() -> I::Reified,
+    {
+        if let Some(res @ TaggedOption(None)) = self.0.downcast_mut::<I>() {
+            res.0 = Some(fulfil());
+        }
+        self
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Type tags
+///////////////////////////////////////////////////////////////////////////////
+
+mod tags {
+    //! Type tags are used to identify a type using a separate value. This module includes type tags
+    //! for some very common types.
+    //!
+    //! Many users of the provider APIs will not need to use type tags at all. But if you want to
+    //! use them with more complex types (typically those including lifetime parameters), you will
+    //! need to write your own tags.
+
+    use crate::marker::PhantomData;
+
+    /// This trait is implemented by specific tag types in order to allow
+    /// describing a type which can be requested for a given lifetime `'a`.
+    ///
+    /// A few example implementations for type-driven tags can be found in this
+    /// module, although crates may also implement their own tags for more
+    /// complex types with internal lifetimes.
+    pub trait Type<'a>: Sized + 'static {
+        /// The type of values which may be tagged by this tag for the given
+        /// lifetime.
+        type Reified: 'a;
+    }
+
+    /// Similar to the [`Type`] trait, but represents a type which may be unsized (i.e., has a
+    /// `'Sized` bound). E.g., `str`.
+    pub trait MaybeSizedType<'a>: Sized + 'static {
+        type Reified: 'a + ?Sized;
+    }
+
+    impl<'a, T: Type<'a>> MaybeSizedType<'a> for T {
+        type Reified = T::Reified;
+    }
+
+    /// Type-based tag for types bounded by `'static`, i.e., with no borrowed element.
+    #[derive(Debug)]
+    pub struct Value<T: 'static>(PhantomData<T>);
+
+    impl<'a, T: 'static> Type<'a> for Value<T> {
+        type Reified = T;
+    }
+
+    /// Type-based tag similar to [`Value`] but which may be unsized (i.e., has a `'Sized` bound).
+    #[derive(Debug)]
+    pub struct MaybeSizedValue<T: ?Sized + 'static>(PhantomData<T>);
+
+    impl<'a, T: ?Sized + 'static> MaybeSizedType<'a> for MaybeSizedValue<T> {
+        type Reified = T;
+    }
+
+    /// Type-based tag for `&'a T` types.
+    #[derive(Debug)]
+    pub struct Ref<I>(PhantomData<I>);
+
+    impl<'a, I: MaybeSizedType<'a>> Type<'a> for Ref<I> {
+        type Reified = &'a I::Reified;
+    }
+}
+
+/// An `Option` with a type tag `I`.
+///
+/// Since this struct implements `Erased`, the type can be erased to make a dynamically typed
+/// option. The type can be checked dynamically using `Erased::tag_id` and since this is statically
+/// checked for the concrete type, there is some degree of type safety.
+#[repr(transparent)]
+struct TaggedOption<'a, I: tags::Type<'a>>(Option<I::Reified>);
+
+impl<'a, I: tags::Type<'a>> TaggedOption<'a, I> {
+    fn as_demand(&mut self) -> &mut Demand<'a> {
+        // SAFETY: transmuting `&mut (dyn Erased<'a> + 'a)` to `&mut Demand<'a>` is safe since
+        // `Demand` is repr(transparent) and holds only a `dyn Erased<'a> + 'a`.
+        unsafe { transmute(self as &mut (dyn Erased<'a> + 'a)) }
+    }
+}
+
+/// Represents a type-erased but identifiable object.
+///
+/// This trait is exclusively implemented by the `TaggedOption` type.
+trait Erased<'a>: 'a {
+    /// The `TypeId` of the erased type.
+    fn tag_id(&self) -> TypeId;
+}
+
+impl<'a, I: tags::Type<'a>> Erased<'a> for TaggedOption<'a, I> {
+    fn tag_id(&self) -> TypeId {
+        TypeId::of::<I>()
+    }
+}
+
+#[unstable(feature = "provide_any", issue = "none")]
+impl<'a> dyn Erased<'a> {
+    /// Returns some reference to the dynamic value if it is tagged with `I`,
+    /// or `None` if it isn't.
+    #[inline]
+    fn downcast_mut<I>(&mut self) -> Option<&mut TaggedOption<'a, I>>
+    where
+        I: tags::Type<'a>,
+    {
+        if self.tag_id() == TypeId::of::<I>() {
+            // SAFETY: Just checked whether we're pointing to an I.
+            Some(unsafe { &mut *(self as *mut Self as *mut TaggedOption<'a, I>) })
+        } else {
+            None
+        }
+    }
 }

--- a/library/core/src/any.rs
+++ b/library/core/src/any.rs
@@ -776,7 +776,7 @@ pub const fn type_name_of_val<T: ?Sized>(_val: &T) -> &'static str {
 ///////////////////////////////////////////////////////////////////////////////
 
 /// Trait implemented by a type which can dynamically provide values based on type.
-#[unstable(feature = "provide_any", issue = "none")]
+#[unstable(feature = "provide_any", issue = "96024")]
 pub trait Provider {
     /// Data providers should implement this method to provide *all* values they are able to
     /// provide by using `demand`.
@@ -796,7 +796,7 @@ pub trait Provider {
     ///     }
     /// }
     /// ```
-    #[unstable(feature = "provide_any", issue = "none")]
+    #[unstable(feature = "provide_any", issue = "96024")]
     fn provide<'a>(&'a self, demand: &mut Demand<'a>);
 }
 
@@ -814,7 +814,7 @@ pub trait Provider {
 ///     request_value::<String, _>(provider).unwrap()
 /// }
 /// ```
-#[unstable(feature = "provide_any", issue = "none")]
+#[unstable(feature = "provide_any", issue = "96024")]
 pub fn request_value<'a, T, P>(provider: &'a P) -> Option<T>
 where
     T: 'static,
@@ -837,7 +837,7 @@ where
 ///     request_ref::<str, _>(provider).unwrap()
 /// }
 /// ```
-#[unstable(feature = "provide_any", issue = "none")]
+#[unstable(feature = "provide_any", issue = "96024")]
 pub fn request_ref<'a, T, P>(provider: &'a P) -> Option<&'a T>
 where
     T: 'static + ?Sized,
@@ -865,7 +865,7 @@ where
 ///
 /// A data provider provides values by calling this type's provide methods.
 #[allow(missing_debug_implementations)]
-#[unstable(feature = "provide_any", issue = "none")]
+#[unstable(feature = "provide_any", issue = "96024")]
 #[repr(transparent)]
 pub struct Demand<'a>(dyn Erased<'a> + 'a);
 
@@ -887,7 +887,7 @@ impl<'a> Demand<'a> {
     ///     }
     /// }
     /// ```
-    #[unstable(feature = "provide_any", issue = "none")]
+    #[unstable(feature = "provide_any", issue = "96024")]
     pub fn provide_value<T, F>(&mut self, fulfil: F) -> &mut Self
     where
         T: 'static,
@@ -914,7 +914,7 @@ impl<'a> Demand<'a> {
     ///     }
     /// }
     /// ```
-    #[unstable(feature = "provide_any", issue = "none")]
+    #[unstable(feature = "provide_any", issue = "96024")]
     pub fn provide_ref<T: ?Sized + 'static>(&mut self, value: &'a T) -> &mut Self {
         self.provide::<tags::Ref<tags::MaybeSizedValue<T>>>(value)
     }
@@ -1034,7 +1034,7 @@ impl<'a, I: tags::Type<'a>> Erased<'a> for TaggedOption<'a, I> {
     }
 }
 
-#[unstable(feature = "provide_any", issue = "none")]
+#[unstable(feature = "provide_any", issue = "96024")]
 impl<'a> dyn Erased<'a> {
     /// Returns some reference to the dynamic value if it is tagged with `I`,
     /// or `None` otherwise.

--- a/library/core/tests/any.rs
+++ b/library/core/tests/any.rs
@@ -148,7 +148,7 @@ impl Provider for SomeConcreteType {
 fn test_provider() {
     let obj: &dyn Provider = &SomeConcreteType { some_string: "hello".to_owned() };
 
-    assert_eq!(&**request_ref::<String>(obj).unwrap(), "hello");
-    assert_eq!(&*request_value::<String>(obj).unwrap(), "bye");
-    assert_eq!(request_value::<u8>(obj), None);
+    assert_eq!(&**request_ref::<String, _>(obj).unwrap(), "hello");
+    assert_eq!(&*request_value::<String, _>(obj).unwrap(), "bye");
+    assert_eq!(request_value::<u8, _>(obj), None);
 }

--- a/library/core/tests/any.rs
+++ b/library/core/tests/any.rs
@@ -130,3 +130,25 @@ fn distinct_type_names() {
 
     assert_ne!(type_name_of_val(Velocity), type_name_of_val(Velocity(0.0, -9.8)),);
 }
+
+// Test the `Provider` API.
+
+struct SomeConcreteType {
+    some_string: String,
+}
+
+impl Provider for SomeConcreteType {
+    fn provide<'a>(&'a self, req: &mut Demand<'a>) {
+        req.provide_ref::<String>(&self.some_string)
+            .provide_value::<String, _>(|| "bye".to_owned());
+    }
+}
+
+#[test]
+fn test_provider() {
+    let obj: &dyn Provider = &SomeConcreteType { some_string: "hello".to_owned() };
+
+    assert_eq!(&**request_ref::<String>(obj).unwrap(), "hello");
+    assert_eq!(&*request_value::<String>(obj).unwrap(), "bye");
+    assert_eq!(request_value::<u8>(obj), None);
+}

--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -97,6 +97,7 @@
 #![feature(const_slice_from_ref)]
 #![feature(waker_getters)]
 #![feature(slice_flatten)]
+#![feature(provide_any)]
 #![deny(unsafe_op_in_unsafe_fn)]
 
 extern crate test;


### PR DESCRIPTION
This is an implementation of [RFC 3192](https://github.com/rust-lang/rfcs/pull/3192) ~~(which is yet to be merged, thus why this is a draft PR)~~. It adds an API for type-driven requests and provision of data from trait objects. A primary use case is for the `Error` trait, though that is not implemented in this PR. The only major difference to the RFC is that the functionality is added to the `any` module, rather than being in a sibling `provide_any` module (as discussed in the RFC thread).

~~Still todo: improve documentation on items, including adding examples.~~

cc @yaahc 