### PR TITLE
link to pref_align_of tracking issue

### DIFF
--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -811,7 +811,8 @@ extern "rust-intrinsic" {
     /// The preferred alignment of a type.
     ///
     /// This intrinsic does not have a stable counterpart.
-    #[rustc_const_unstable(feature = "const_pref_align_of", issue = "none")]
+    /// It's "tracking issue" is [#91971](https://github.com/rust-lang/rust/issues/91971).
+    #[rustc_const_unstable(feature = "const_pref_align_of", issue = "91971")]
     pub fn pref_align_of<T>() -> usize;
 
     /// The size of the referenced value in bytes.


### PR DESCRIPTION
If we are not going to remove this intrinsic (https://github.com/rust-lang/rust/pull/90877), I think we should at least have a place to centralize discussion around it, so here we go. Intrinsics don't have their own separate features and usually we instead use the public method for tracking it, but this one does not have such a method... so the tracking issue is just a regular link. (And then we sue it for the const part as well.)