### PR TITLE
Specialize len in ExactSizeIterator implementations

### DIFF
--- a/library/alloc/src/collections/binary_heap.rs
+++ b/library/alloc/src/collections/binary_heap.rs
@@ -1342,6 +1342,10 @@ impl<'a, T> DoubleEndedIterator for Iter<'a, T> {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T> ExactSizeIterator for Iter<'_, T> {
+    fn len(&self) -> usize {
+        self.iter.len()
+    }
+
     fn is_empty(&self) -> bool {
         self.iter.is_empty()
     }
@@ -1395,6 +1399,10 @@ impl<T> DoubleEndedIterator for IntoIter<T> {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T> ExactSizeIterator for IntoIter<T> {
+    fn len(&self) -> usize {
+        self.iter.len()
+    }
+
     fn is_empty(&self) -> bool {
         self.iter.is_empty()
     }
@@ -1452,7 +1460,11 @@ impl<T: Ord> Iterator for IntoIterSorted<T> {
 }
 
 #[unstable(feature = "binary_heap_into_iter_sorted", issue = "59278")]
-impl<T: Ord> ExactSizeIterator for IntoIterSorted<T> {}
+impl<T: Ord> ExactSizeIterator for IntoIterSorted<T> {
+    fn len(&self) -> usize {
+        self.inner.len()
+    }
+}
 
 #[unstable(feature = "binary_heap_into_iter_sorted", issue = "59278")]
 impl<T: Ord> FusedIterator for IntoIterSorted<T> {}
@@ -1497,6 +1509,10 @@ impl<T> DoubleEndedIterator for Drain<'_, T> {
 
 #[stable(feature = "drain", since = "1.6.0")]
 impl<T> ExactSizeIterator for Drain<'_, T> {
+    fn len(&self) -> usize {
+        self.iter.len()
+    }
+
     fn is_empty(&self) -> bool {
         self.iter.is_empty()
     }
@@ -1554,7 +1570,11 @@ impl<T: Ord> Iterator for DrainSorted<'_, T> {
 }
 
 #[unstable(feature = "binary_heap_drain_sorted", issue = "59278")]
-impl<T: Ord> ExactSizeIterator for DrainSorted<'_, T> {}
+impl<T: Ord> ExactSizeIterator for DrainSorted<'_, T> {
+    fn len(&self) -> usize {
+        self.inner.len()
+    }
+}
 
 #[unstable(feature = "binary_heap_drain_sorted", issue = "59278")]
 impl<T: Ord> FusedIterator for DrainSorted<'_, T> {}

--- a/library/alloc/src/collections/linked_list.rs
+++ b/library/alloc/src/collections/linked_list.rs
@@ -1070,7 +1070,12 @@ impl<'a, T> DoubleEndedIterator for Iter<'a, T> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T> ExactSizeIterator for Iter<'_, T> {}
+impl<T> ExactSizeIterator for Iter<'_, T> {
+    #[inline]
+    fn len(&self) -> usize {
+        self.len
+    }
+}
 
 #[stable(feature = "fused", since = "1.26.0")]
 impl<T> FusedIterator for Iter<'_, T> {}
@@ -1124,7 +1129,11 @@ impl<'a, T> DoubleEndedIterator for IterMut<'a, T> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T> ExactSizeIterator for IterMut<'_, T> {}
+impl<T> ExactSizeIterator for IterMut<'_, T> {
+    fn len(&self) -> usize {
+        self.len
+    }
+}
 
 #[stable(feature = "fused", since = "1.26.0")]
 impl<T> FusedIterator for IterMut<'_, T> {}
@@ -1803,7 +1812,11 @@ impl<T> DoubleEndedIterator for IntoIter<T> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T> ExactSizeIterator for IntoIter<T> {}
+impl<T> ExactSizeIterator for IntoIter<T> {
+    fn len(&self) -> usize {
+        self.list.len
+    }
+}
 
 #[stable(feature = "fused", since = "1.26.0")]
 impl<T> FusedIterator for IntoIter<T> {}

--- a/library/alloc/src/collections/vec_deque/drain.rs
+++ b/library/alloc/src/collections/vec_deque/drain.rs
@@ -136,7 +136,14 @@ impl<T, A: Allocator> DoubleEndedIterator for Drain<'_, T, A> {
 }
 
 #[stable(feature = "drain", since = "1.6.0")]
-impl<T, A: Allocator> ExactSizeIterator for Drain<'_, T, A> {}
+impl<T, A: Allocator> ExactSizeIterator for Drain<'_, T, A> {
+    #[inline]
+    fn len(&self) -> usize {
+        let n = self.iter.len();
+        debug_assert_eq!(self.size_hint(), (n, Some(n)));
+        n
+    }
+}
 
 #[stable(feature = "fused", since = "1.26.0")]
 impl<T, A: Allocator> FusedIterator for Drain<'_, T, A> {}

--- a/library/alloc/src/collections/vec_deque/into_iter.rs
+++ b/library/alloc/src/collections/vec_deque/into_iter.rs
@@ -60,6 +60,11 @@ impl<T, A: Allocator> DoubleEndedIterator for IntoIter<T, A> {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T, A: Allocator> ExactSizeIterator for IntoIter<T, A> {
+    #[inline]
+    fn len(&self) -> usize {
+        self.inner.len()
+    }
+
     fn is_empty(&self) -> bool {
         self.inner.is_empty()
     }

--- a/library/alloc/src/collections/vec_deque/iter.rs
+++ b/library/alloc/src/collections/vec_deque/iter.rs
@@ -67,7 +67,7 @@ impl<'a, T> Iterator for Iter<'a, T> {
 
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let len = count(self.tail, self.head, self.ring.len());
+        let len = self.len();
         (len, Some(len))
     }
 
@@ -113,7 +113,7 @@ impl<'a, T> Iterator for Iter<'a, T> {
     }
 
     fn nth(&mut self, n: usize) -> Option<Self::Item> {
-        if n >= count(self.tail, self.head, self.ring.len()) {
+        if n >= self.len() {
             self.tail = self.head;
             None
         } else {
@@ -197,6 +197,11 @@ impl<'a, T> DoubleEndedIterator for Iter<'a, T> {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T> ExactSizeIterator for Iter<'_, T> {
+    #[inline]
+    fn len(&self) -> usize {
+        count(self.tail, self.head, self.ring.len())
+    }
+
     fn is_empty(&self) -> bool {
         self.head == self.tail
     }

--- a/library/alloc/src/collections/vec_deque/iter_mut.rs
+++ b/library/alloc/src/collections/vec_deque/iter_mut.rs
@@ -68,7 +68,7 @@ impl<'a, T> Iterator for IterMut<'a, T> {
 
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let len = count(self.tail, self.head, self.ring.len());
+        let len = self.len();
         (len, Some(len))
     }
 
@@ -85,7 +85,7 @@ impl<'a, T> Iterator for IterMut<'a, T> {
     }
 
     fn nth(&mut self, n: usize) -> Option<Self::Item> {
-        if n >= count(self.tail, self.head, self.ring.len()) {
+        if n >= self.len() {
             self.tail = self.head;
             None
         } else {
@@ -140,6 +140,11 @@ impl<'a, T> DoubleEndedIterator for IterMut<'a, T> {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T> ExactSizeIterator for IterMut<'_, T> {
+    #[inline]
+    fn len(&self) -> usize {
+        count(self.tail, self.head, self.ring.len())
+    }
+
     fn is_empty(&self) -> bool {
         self.head == self.tail
     }

--- a/library/alloc/src/vec/drain.rs
+++ b/library/alloc/src/vec/drain.rs
@@ -172,6 +172,10 @@ impl<T, A: Allocator> Drop for Drain<'_, T, A> {
 
 #[stable(feature = "drain", since = "1.6.0")]
 impl<T, A: Allocator> ExactSizeIterator for Drain<'_, T, A> {
+    fn len(&self) -> usize {
+        self.iter.len()
+    }
+
     fn is_empty(&self) -> bool {
         self.iter.is_empty()
     }

--- a/library/alloc/src/vec/into_iter.rs
+++ b/library/alloc/src/vec/into_iter.rs
@@ -166,11 +166,7 @@ impl<T, A: Allocator> Iterator for IntoIter<T, A> {
 
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let exact = if mem::size_of::<T>() == 0 {
-            self.end.addr().wrapping_sub(self.ptr.addr())
-        } else {
-            unsafe { self.end.sub_ptr(self.ptr) }
-        };
+        let exact = self.len();
         (exact, Some(exact))
     }
 
@@ -265,6 +261,15 @@ impl<T, A: Allocator> DoubleEndedIterator for IntoIter<T, A> {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T, A: Allocator> ExactSizeIterator for IntoIter<T, A> {
+    #[inline]
+    fn len(&self) -> usize {
+        if mem::size_of::<T>() == 0 {
+            self.end.addr().wrapping_sub(self.ptr.addr())
+        } else {
+            unsafe { self.end.sub_ptr(self.ptr) }
+        }
+    }
+
     fn is_empty(&self) -> bool {
         self.ptr == self.end
     }

--- a/library/alloc/src/vec/splice.rs
+++ b/library/alloc/src/vec/splice.rs
@@ -48,7 +48,13 @@ impl<I: Iterator, A: Allocator> DoubleEndedIterator for Splice<'_, I, A> {
 }
 
 #[stable(feature = "vec_splice", since = "1.21.0")]
-impl<I: Iterator, A: Allocator> ExactSizeIterator for Splice<'_, I, A> {}
+impl<I: Iterator, A: Allocator> ExactSizeIterator for Splice<'_, I, A> {
+    fn len(&self) -> usize {
+        let n = self.drain.len();
+        debug_assert_eq!(self.size_hint(), (n, Some(n)));
+        n
+    }
+}
 
 #[stable(feature = "vec_splice", since = "1.21.0")]
 impl<I: Iterator, A: Allocator> Drop for Splice<'_, I, A> {

--- a/library/core/src/ascii.rs
+++ b/library/core/src/ascii.rs
@@ -129,7 +129,11 @@ impl DoubleEndedIterator for EscapeDefault {
     }
 }
 #[stable(feature = "rust1", since = "1.0.0")]
-impl ExactSizeIterator for EscapeDefault {}
+impl ExactSizeIterator for EscapeDefault {
+    fn len(&self) -> usize {
+        self.range.len()
+    }
+}
 #[stable(feature = "fused", since = "1.26.0")]
 impl FusedIterator for EscapeDefault {}
 

--- a/library/core/src/char/mod.rs
+++ b/library/core/src/char/mod.rs
@@ -386,7 +386,13 @@ impl Iterator for EscapeDebug {
 }
 
 #[stable(feature = "char_escape_debug", since = "1.20.0")]
-impl ExactSizeIterator for EscapeDebug {}
+impl ExactSizeIterator for EscapeDebug {
+    fn len(&self) -> usize {
+        let n = self.0.len();
+        debug_assert_eq!(self.size_hint(), (n, Some(n)));
+        n
+    }
+}
 
 #[stable(feature = "fused", since = "1.26.0")]
 impl FusedIterator for EscapeDebug {}
@@ -430,7 +436,13 @@ impl DoubleEndedIterator for ToLowercase {
 impl FusedIterator for ToLowercase {}
 
 #[stable(feature = "exact_size_case_mapping_iter", since = "1.35.0")]
-impl ExactSizeIterator for ToLowercase {}
+impl ExactSizeIterator for ToLowercase {
+    fn len(&self) -> usize {
+        let n = self.0.len();
+        debug_assert_eq!(self.size_hint(), (n, Some(n)));
+        n
+    }
+}
 
 /// Returns an iterator that yields the uppercase equivalent of a `char`.
 ///
@@ -464,7 +476,13 @@ impl DoubleEndedIterator for ToUppercase {
 impl FusedIterator for ToUppercase {}
 
 #[stable(feature = "exact_size_case_mapping_iter", since = "1.35.0")]
-impl ExactSizeIterator for ToUppercase {}
+impl ExactSizeIterator for ToUppercase {
+    fn len(&self) -> usize {
+        let n = self.0.len();
+        debug_assert_eq!(self.size_hint(), (n, Some(n)));
+        n
+    }
+}
 
 #[derive(Debug, Clone)]
 enum CaseMappingIter {
@@ -509,13 +527,19 @@ impl Iterator for CaseMappingIter {
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let size = match self {
+        let size = self.len();
+        (size, Some(size))
+    }
+}
+
+impl CaseMappingIter {
+    fn len(&self) -> usize {
+        match self {
             CaseMappingIter::Three(..) => 3,
             CaseMappingIter::Two(..) => 2,
             CaseMappingIter::One(_) => 1,
             CaseMappingIter::Zero => 0,
-        };
-        (size, Some(size))
+        }
     }
 }
 

--- a/library/core/src/iter/traits/exact_size.rs
+++ b/library/core/src/iter/traits/exact_size.rs
@@ -102,9 +102,9 @@ pub trait ExactSizeIterator: Iterator {
     fn len(&self) -> usize {
         let (lower, upper) = self.size_hint();
         // Note: This assertion is overly defensive, but it checks the invariant
-        // guaranteed by the trait. If this trait were rust-internal,
-        // we could use debug_assert!; assert_eq! will check all Rust user
-        // implementations too.
+        // guaranteed by the trait in all Rust user implementations too.
+        // If this trait were rust-internal, we could use debug_assert!, but
+        // any implementation for which it matters can override `len`.
         assert_eq!(upper, Some(lower));
         lower
     }

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -2049,10 +2049,8 @@ impl<A> Iterator for Item<A> {
 
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
-        match self.opt {
-            Some(_) => (1, Some(1)),
-            None => (0, Some(0)),
-        }
+        let exact = self.len();
+        (exact, Some(exact))
     }
 }
 
@@ -2063,7 +2061,16 @@ impl<A> DoubleEndedIterator for Item<A> {
     }
 }
 
-impl<A> ExactSizeIterator for Item<A> {}
+impl<A> ExactSizeIterator for Item<A> {
+    #[inline]
+    fn len(&self) -> usize {
+        match self.opt {
+            Some(_) => 1,
+            None => 0,
+        }
+    }
+}
+
 impl<A> FusedIterator for Item<A> {}
 unsafe impl<A> TrustedLen for Item<A> {}
 
@@ -2101,7 +2108,14 @@ impl<'a, A> DoubleEndedIterator for Iter<'a, A> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<A> ExactSizeIterator for Iter<'_, A> {}
+impl<A> ExactSizeIterator for Iter<'_, A> {
+    #[inline]
+    fn len(&self) -> usize {
+        let n = self.inner.len();
+        debug_assert_eq!(self.size_hint(), (n, Some(n)));
+        n
+    }
+}
 
 #[stable(feature = "fused", since = "1.26.0")]
 impl<A> FusedIterator for Iter<'_, A> {}
@@ -2151,7 +2165,14 @@ impl<'a, A> DoubleEndedIterator for IterMut<'a, A> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<A> ExactSizeIterator for IterMut<'_, A> {}
+impl<A> ExactSizeIterator for IterMut<'_, A> {
+    #[inline]
+    fn len(&self) -> usize {
+        let n = self.inner.len();
+        debug_assert_eq!(self.size_hint(), (n, Some(n)));
+        n
+    }
+}
 
 #[stable(feature = "fused", since = "1.26.0")]
 impl<A> FusedIterator for IterMut<'_, A> {}
@@ -2192,7 +2213,14 @@ impl<A> DoubleEndedIterator for IntoIter<A> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<A> ExactSizeIterator for IntoIter<A> {}
+impl<A> ExactSizeIterator for IntoIter<A> {
+    #[inline]
+    fn len(&self) -> usize {
+        let n = self.inner.len();
+        debug_assert_eq!(self.size_hint(), (n, Some(n)));
+        n
+    }
+}
 
 #[stable(feature = "fused", since = "1.26.0")]
 impl<A> FusedIterator for IntoIter<A> {}

--- a/library/core/src/result.rs
+++ b/library/core/src/result.rs
@@ -1919,7 +1919,7 @@ impl<'a, T> Iterator for Iter<'a, T> {
     }
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let n = if self.inner.is_some() { 1 } else { 0 };
+        let n = self.len();
         (n, Some(n))
     }
 }
@@ -1933,7 +1933,12 @@ impl<'a, T> DoubleEndedIterator for Iter<'a, T> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T> ExactSizeIterator for Iter<'_, T> {}
+impl<T> ExactSizeIterator for Iter<'_, T> {
+    #[inline]
+    fn len(&self) -> usize {
+        if self.inner.is_some() { 1 } else { 0 }
+    }
+}
 
 #[stable(feature = "fused", since = "1.26.0")]
 impl<T> FusedIterator for Iter<'_, T> {}
@@ -1968,7 +1973,7 @@ impl<'a, T> Iterator for IterMut<'a, T> {
     }
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let n = if self.inner.is_some() { 1 } else { 0 };
+        let n = self.len();
         (n, Some(n))
     }
 }
@@ -1982,7 +1987,12 @@ impl<'a, T> DoubleEndedIterator for IterMut<'a, T> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T> ExactSizeIterator for IterMut<'_, T> {}
+impl<T> ExactSizeIterator for IterMut<'_, T> {
+    #[inline]
+    fn len(&self) -> usize {
+        if self.inner.is_some() { 1 } else { 0 }
+    }
+}
 
 #[stable(feature = "fused", since = "1.26.0")]
 impl<T> FusedIterator for IterMut<'_, T> {}
@@ -2014,7 +2024,7 @@ impl<T> Iterator for IntoIter<T> {
     }
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let n = if self.inner.is_some() { 1 } else { 0 };
+        let n = self.len();
         (n, Some(n))
     }
 }
@@ -2028,7 +2038,12 @@ impl<T> DoubleEndedIterator for IntoIter<T> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T> ExactSizeIterator for IntoIter<T> {}
+impl<T> ExactSizeIterator for IntoIter<T> {
+    #[inline]
+    fn len(&self) -> usize {
+        if self.inner.is_some() { 1 } else { 0 }
+    }
+}
 
 #[stable(feature = "fused", since = "1.26.0")]
 impl<T> FusedIterator for IntoIter<T> {}


### PR DESCRIPTION
~~Two commits (tell me if you prefer separate PRs):~~

1. ~~Override the default implementation of `Iterator::count` in `ExactSizeIterator` iterators without side effects, much like #62316, making them O(1) instead of O(n). Though I doubt `count` is used often or at all.~~
   - Most of these `count` simply delegate to an inner implementation, which means the ones in HashMap/HashSet don't actually shortcut until hashbrown's would do so.
   - library/alloc/src/boxed.rs: is only conditionally `ExactSizeIterator`.

2. Override the default implementation of `ExactSizeIterator::len`, where `size_hint` clearly returns equal lower and upper limits. This contradicts [ExactSizeIterator's advice](https://doc.rust-lang.org/core/iter/trait.ExactSizeIterator.html) "The len method has a default implementation, so you usually shouldn’t implement it", but I think it makes code easier to understand, might improve performance, and most of the library iterators already do it: I counted 50 iterators that do, plus an unexplored number of slice iterators through [a macro](https://github.com/rust-lang/rust/blob/master/library/core/src/slice/iter/macros.rs), against 31 iterators that didn't and are in this PR, and these that can't easily be:
   - library/core/src/iter/adapters/peekable.rs: is only conditionally `ExactSizeIterator`
   - library/core/src/iter/adapters/skip.rs: ditto
   - library/core/src/iter/adapters/step_by.rs: ditto
   - library/core/src/iter/adapters/take.rs: ditto
   - library/core/src/iter/adapters/zip.rs: ditto
   - library/core/src/iter/range.rs: not touching that without a radiation suit
   - library/core/src/slice/ascii.rs: `FlatMap` is only conditionally `TrustedLen` and not even `ExactSizeIterator`
