### PR TITLE
Update stdlib to the 2021 edition

### DIFF
--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/rust.git"
 description = "The Rust Standard Library"
-edition = "2018"
+edition = "2021"
 
 [lib]
 crate-type = ["dylib", "rlib"]

--- a/library/std/src/fs/tests.rs
+++ b/library/std/src/fs/tests.rs
@@ -38,10 +38,9 @@ macro_rules! error {
     ($e:expr, $s:expr) => {
         match $e {
             Ok(_) => panic!("Unexpected success. Should've been: {:?}", $s),
-            Err(ref err) => assert!(
-                err.raw_os_error() == Some($s),
-                format!("`{}` did not have a code of `{}`", err, $s)
-            ),
+            Err(ref err) => {
+                assert!(err.raw_os_error() == Some($s), "`{}` did not have a code of `{}`", err, $s)
+            }
         }
     };
 }
@@ -58,7 +57,7 @@ macro_rules! error_contains {
         match $e {
             Ok(_) => panic!("Unexpected success. Should've been: {:?}", $s),
             Err(ref err) => {
-                assert!(err.to_string().contains($s), format!("`{}` did not contain `{}`", err, $s))
+                assert!(err.to_string().contains($s), "`{}` did not contain `{}`", err, $s)
             }
         }
     };

--- a/library/std/src/process.rs
+++ b/library/std/src/process.rs
@@ -1600,7 +1600,6 @@ impl ExitStatusError {
     /// ```
     /// #![feature(exit_status_error)]
     /// # if cfg!(unix) {
-    /// use std::convert::TryFrom;
     /// use std::num::NonZeroI32;
     /// use std::process::Command;
     ///

--- a/library/std/src/thread/tests.rs
+++ b/library/std/src/thread/tests.rs
@@ -1,6 +1,7 @@
 use super::Builder;
 use crate::any::Any;
 use crate::mem;
+use crate::panic::panic_any;
 use crate::result;
 use crate::sync::{
     mpsc::{channel, Sender},
@@ -183,7 +184,7 @@ fn test_simple_newsched_spawn() {
 }
 
 #[test]
-fn test_try_panic_message_static_str() {
+fn test_try_panic_message_string_literal() {
     match thread::spawn(move || {
         panic!("static string");
     })
@@ -199,9 +200,9 @@ fn test_try_panic_message_static_str() {
 }
 
 #[test]
-fn test_try_panic_message_owned_str() {
+fn test_try_panic_any_message_owned_str() {
     match thread::spawn(move || {
-        panic!("owned string".to_string());
+        panic_any("owned string".to_string());
     })
     .join()
     {
@@ -215,9 +216,9 @@ fn test_try_panic_message_owned_str() {
 }
 
 #[test]
-fn test_try_panic_message_any() {
+fn test_try_panic_any_message_any() {
     match thread::spawn(move || {
-        panic!(box 413u16 as Box<dyn Any + Send>);
+        panic_any(box 413u16 as Box<dyn Any + Send>);
     })
     .join()
     {
@@ -233,10 +234,10 @@ fn test_try_panic_message_any() {
 }
 
 #[test]
-fn test_try_panic_message_unit_struct() {
+fn test_try_panic_any_message_unit_struct() {
     struct Juju;
 
-    match thread::spawn(move || panic!(Juju)).join() {
+    match thread::spawn(move || panic_any(Juju)).join() {
         Err(ref e) if e.is::<Juju>() => {}
         Err(_) | Ok(()) => panic!(),
     }

--- a/src/tools/tidy/src/edition.rs
+++ b/src/tools/tidy/src/edition.rs
@@ -23,8 +23,10 @@ pub fn check(path: &Path, bad: &mut bool) {
                 return;
             }
 
-            // Library crates are not yet ready to migrate to 2021.
-            if path.components().any(|c| c.as_os_str() == "library") {
+            // Not all library crates are ready to migrate to 2021.
+            if file.components().any(|c| c.as_os_str() == "library")
+                && file.components().all(|c| c.as_os_str() != "std")
+            {
                 let has = contents.lines().any(is_edition_2018);
                 if !has {
                     tidy_error!(


### PR DESCRIPTION
progress towards https://github.com/rust-lang/rust/issues/88638

I couldnt find a way to run the 2018 style panic tests against 2018 so I just deleted them, maybe theres a way to do it that I missed though?