### PR TITLE
Remove effect of `#[no_link]` attribute on name resolution

### DIFF
--- a/compiler/rustc_metadata/src/rmeta/decoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder.rs
@@ -1099,10 +1099,7 @@ impl<'a, 'tcx> CrateMetadataRef<'a> {
         };
 
         // Iterate over all children.
-        let macros_only = self.dep_kind.lock().macros_only();
-        if !macros_only {
-            let children = self.root.tables.children.get(self, id).unwrap_or_else(Lazy::empty);
-
+        if let Some(children) = self.root.tables.children.get(self, id) {
             for child_index in children.decode((self, sess)) {
                 // Get the item.
                 let child_kind = match self.maybe_kind(child_index) {
@@ -1200,11 +1197,6 @@ impl<'a, 'tcx> CrateMetadataRef<'a> {
 
         if let EntryKind::Mod(exports) = kind {
             for exp in exports.decode((self, sess)) {
-                match exp.res {
-                    Res::Def(DefKind::Macro(..), _) => {}
-                    _ if macros_only => continue,
-                    _ => {}
-                }
                 callback(exp);
             }
         }

--- a/src/test/ui/no-link.rs
+++ b/src/test/ui/no-link.rs
@@ -1,8 +1,9 @@
+// check-pass
 // aux-build:empty-struct.rs
 
 #[no_link]
 extern crate empty_struct;
 
 fn main() {
-    empty_struct::XEmpty1; //~ ERROR cannot find value `XEmpty1` in crate `empty_struct`
+    empty_struct::XEmpty1 {};
 }

--- a/src/test/ui/no-link.stderr
+++ b/src/test/ui/no-link.stderr
@@ -1,9 +1,0 @@
-error[E0425]: cannot find value `XEmpty1` in crate `empty_struct`
-  --> $DIR/no-link.rs:7:19
-   |
-LL |     empty_struct::XEmpty1;
-   |                   ^^^^^^^ not found in `empty_struct`
-
-error: aborting due to previous error
-
-For more information about this error, try `rustc --explain E0425`.


### PR DESCRIPTION
Previously it hid all non-macro names from other crates.
This has no relation to linking and can change name resolution behavior in some cases (e.g. glob conflicts), in addition to just producing the "unresolved name" errors.

I can kind of understand the possible reasoning behind the current behavior - if you can use names from a `no_link` crates then you can use, for example, functions too, but whether it will actually work or produce link-time errors will depend on random factors like inliner behavior.
(^^^ This is not the actual reason why the current behavior exist, I've looked through git history and it's mostly accidental.)

I think this risk is ok for such an obscure attribute, and we don't need to specifically prevent use of non-macro items from such crates.
(I'm not actually sure why would anyone use `#[no_link]` on a crate, even if it's macro only, if you aware of any use cases, please share. IIRC, at some point it was used for crates implementing custom derives - the now removed legacy ones, not the current proc macros.)

Extracted from https://github.com/rust-lang/rust/pull/91795.