### PR TITLE
Enable `#[thread_local]` for all windows-msvc targets

### DIFF
--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -880,7 +880,7 @@ fn default_configuration(sess: &Session) -> CrateConfig {
     ret.insert((sym::target_env, Some(Symbol::intern(env))));
     ret.insert((sym::target_abi, Some(Symbol::intern(abi))));
     ret.insert((sym::target_vendor, Some(Symbol::intern(vendor))));
-    if sess.target.has_elf_tls {
+    if sess.target.has_thread_local {
         ret.insert((sym::target_thread_local, None));
     }
     for (i, align) in [

--- a/compiler/rustc_target/src/spec/aarch64_pc_windows_msvc.rs
+++ b/compiler/rustc_target/src/spec/aarch64_pc_windows_msvc.rs
@@ -3,7 +3,6 @@ use crate::spec::Target;
 pub fn target() -> Target {
     let mut base = super::windows_msvc_base::opts();
     base.max_atomic_width = Some(64);
-    base.has_elf_tls = true;
     base.features = "+neon,+fp-armv8".to_string();
 
     Target {

--- a/compiler/rustc_target/src/spec/aarch64_uwp_windows_msvc.rs
+++ b/compiler/rustc_target/src/spec/aarch64_uwp_windows_msvc.rs
@@ -3,7 +3,6 @@ use crate::spec::Target;
 pub fn target() -> Target {
     let mut base = super::windows_uwp_msvc_base::opts();
     base.max_atomic_width = Some(64);
-    base.has_elf_tls = true;
 
     Target {
         llvm_target: "aarch64-pc-windows-msvc".to_string(),

--- a/compiler/rustc_target/src/spec/android_base.rs
+++ b/compiler/rustc_target/src/spec/android_base.rs
@@ -11,7 +11,7 @@ pub fn opts() -> TargetOptions {
         .push("-Wl,--allow-multiple-definition".to_string());
     base.dwarf_version = Some(2);
     base.position_independent_executables = true;
-    base.has_elf_tls = false;
+    base.has_thread_local = false;
     // This is for backward compatibility, see https://github.com/rust-lang/rust/issues/49867
     // for context. (At that time, there was no `-C force-unwind-tables`, so the only solution
     // was to always emit `uwtable`).

--- a/compiler/rustc_target/src/spec/apple_base.rs
+++ b/compiler/rustc_target/src/spec/apple_base.rs
@@ -16,7 +16,7 @@ pub fn opts(os: &str) -> TargetOptions {
     // TLS is flagged as enabled if it looks to be supported. The architecture
     // only matters for default deployment target which is 11.0 for ARM64 and
     // 10.7 for everything else.
-    let has_elf_tls = macos_deployment_target("x86_64") >= (10, 7);
+    let has_thread_local = macos_deployment_target("x86_64") >= (10, 7);
 
     TargetOptions {
         os: os.to_string(),
@@ -33,7 +33,7 @@ pub fn opts(os: &str) -> TargetOptions {
         has_rpath: true,
         dll_suffix: ".dylib".to_string(),
         archive_format: "darwin".to_string(),
-        has_elf_tls,
+        has_thread_local,
         abi_return_struct_as_int: true,
         emit_debug_gdb_scripts: false,
         eh_frame_header: false,

--- a/compiler/rustc_target/src/spec/apple_sdk_base.rs
+++ b/compiler/rustc_target/src/spec/apple_sdk_base.rs
@@ -53,7 +53,7 @@ pub fn opts(os: &str, arch: Arch) -> TargetOptions {
         dynamic_linking: false,
         executables: true,
         link_env_remove: link_env_remove(arch),
-        has_elf_tls: false,
+        has_thread_local: false,
         ..super::apple_base::opts(os)
     }
 }

--- a/compiler/rustc_target/src/spec/fuchsia_base.rs
+++ b/compiler/rustc_target/src/spec/fuchsia_base.rs
@@ -35,7 +35,7 @@ pub fn opts() -> TargetOptions {
             (LinkOutputKind::StaticPicExe, &["Scrt1.o"]),
         ]),
         position_independent_executables: true,
-        has_elf_tls: true,
+        has_thread_local: true,
         ..Default::default()
     }
 }

--- a/compiler/rustc_target/src/spec/hermit_base.rs
+++ b/compiler/rustc_target/src/spec/hermit_base.rs
@@ -12,7 +12,7 @@ pub fn opts() -> TargetOptions {
         linker_flavor: LinkerFlavor::Lld(LldFlavor::Ld),
         linker: Some("rust-lld".to_owned()),
         executables: true,
-        has_elf_tls: true,
+        has_thread_local: true,
         pre_link_args,
         panic_strategy: PanicStrategy::Abort,
         position_independent_executables: true,

--- a/compiler/rustc_target/src/spec/i686_uwp_windows_msvc.rs
+++ b/compiler/rustc_target/src/spec/i686_uwp_windows_msvc.rs
@@ -4,7 +4,6 @@ pub fn target() -> Target {
     let mut base = super::windows_uwp_msvc_base::opts();
     base.cpu = "pentium4".to_string();
     base.max_atomic_width = Some(64);
-    base.has_elf_tls = true;
 
     Target {
         llvm_target: "i686-pc-windows-msvc".to_string(),

--- a/compiler/rustc_target/src/spec/illumos_base.rs
+++ b/compiler/rustc_target/src/spec/illumos_base.rs
@@ -45,7 +45,7 @@ pub fn opts() -> TargetOptions {
         // (see src/libstd/sys/unix/fast_thread_local.rs) that is currently
         // missing in illumos.  For now at least, we must fallback to using
         // pthread_{get,set}specific.
-        //has_elf_tls: true,
+        //has_thread_local: true,
 
         // FIXME: Currently, rust is invoking cc to link, which ends up
         // causing these to get included twice.  We should eventually transition

--- a/compiler/rustc_target/src/spec/linux_base.rs
+++ b/compiler/rustc_target/src/spec/linux_base.rs
@@ -9,7 +9,7 @@ pub fn opts() -> TargetOptions {
         has_rpath: true,
         position_independent_executables: true,
         relro_level: RelroLevel::Full,
-        has_elf_tls: true,
+        has_thread_local: true,
         crt_static_respected: true,
         ..Default::default()
     }

--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -1279,9 +1279,8 @@ pub struct TargetOptions {
     /// `argc` and `argv` values.
     pub main_needs_argc_argv: bool,
 
-    /// Flag indicating whether ELF TLS (e.g., #[thread_local]) is available for
-    /// this target.
-    pub has_elf_tls: bool,
+    /// Flag indicating whether #[thread_local] is available for this target.
+    pub has_thread_local: bool,
     // This is mainly for easy compatibility with emscripten.
     // If we give emcc .o files that are actually .bc files it
     // will 'just work'.
@@ -1487,7 +1486,7 @@ impl Default for TargetOptions {
             archive_format: "gnu".to_string(),
             main_needs_argc_argv: true,
             allow_asm: true,
-            has_elf_tls: false,
+            has_thread_local: false,
             obj_is_bitcode: false,
             forces_embed_bitcode: false,
             bitcode_llvm_cmdline: String::new(),
@@ -2074,7 +2073,7 @@ impl Target {
         key!(archive_format);
         key!(allow_asm, bool);
         key!(main_needs_argc_argv, bool);
-        key!(has_elf_tls, bool);
+        key!(has_thread_local, bool);
         key!(obj_is_bitcode, bool);
         key!(forces_embed_bitcode, bool);
         key!(bitcode_llvm_cmdline);
@@ -2315,7 +2314,7 @@ impl ToJson for Target {
         target_option_val!(archive_format);
         target_option_val!(allow_asm);
         target_option_val!(main_needs_argc_argv);
-        target_option_val!(has_elf_tls);
+        target_option_val!(has_thread_local);
         target_option_val!(obj_is_bitcode);
         target_option_val!(forces_embed_bitcode);
         target_option_val!(bitcode_llvm_cmdline);

--- a/compiler/rustc_target/src/spec/redox_base.rs
+++ b/compiler/rustc_target/src/spec/redox_base.rs
@@ -10,7 +10,7 @@ pub fn opts() -> TargetOptions {
         has_rpath: true,
         position_independent_executables: true,
         relro_level: RelroLevel::Full,
-        has_elf_tls: true,
+        has_thread_local: true,
         crt_static_default: true,
         crt_static_respected: true,
         ..Default::default()

--- a/compiler/rustc_target/src/spec/solid_base.rs
+++ b/compiler/rustc_target/src/spec/solid_base.rs
@@ -6,7 +6,7 @@ pub fn opts(kernel: &str) -> TargetOptions {
         os: format!("solid_{}", kernel),
         vendor: "kmc".to_string(),
         frame_pointer: FramePointer::NonLeaf,
-        has_elf_tls: true,
+        has_thread_local: true,
         ..Default::default()
     }
 }

--- a/compiler/rustc_target/src/spec/thumbv7a_uwp_windows_msvc.rs
+++ b/compiler/rustc_target/src/spec/thumbv7a_uwp_windows_msvc.rs
@@ -9,7 +9,6 @@ pub fn target() -> Target {
         options: TargetOptions {
             features: "+vfp3,+neon".to_string(),
             max_atomic_width: Some(64),
-            has_elf_tls: true,
             // FIXME(jordanrh): use PanicStrategy::Unwind when SEH is
             // implemented for windows/arm in LLVM
             panic_strategy: PanicStrategy::Abort,

--- a/compiler/rustc_target/src/spec/vxworks_base.rs
+++ b/compiler/rustc_target/src/spec/vxworks_base.rs
@@ -11,7 +11,7 @@ pub fn opts() -> TargetOptions {
         executables: true,
         families: vec!["unix".to_string()],
         has_rpath: true,
-        has_elf_tls: true,
+        has_thread_local: true,
         crt_static_default: true,
         crt_static_respected: true,
         crt_static_allows_dylibs: true,

--- a/compiler/rustc_target/src/spec/wasm_base.rs
+++ b/compiler/rustc_target/src/spec/wasm_base.rs
@@ -120,9 +120,9 @@ pub fn options() -> TargetOptions {
         // When the atomics feature is activated then these two keys matter,
         // otherwise they're basically ignored by the standard library. In this
         // mode, however, the `#[thread_local]` attribute works (i.e.
-        // `has_elf_tls`) and we need to get it to work by specifying
+        // `has_thread_local`) and we need to get it to work by specifying
         // `local-exec` as that's all that's implemented in LLVM today for wasm.
-        has_elf_tls: true,
+        has_thread_local: true,
         tls_model: TlsModel::LocalExec,
 
         // gdb scripts don't work on wasm blobs

--- a/compiler/rustc_target/src/spec/windows_msvc_base.rs
+++ b/compiler/rustc_target/src/spec/windows_msvc_base.rs
@@ -27,6 +27,7 @@ pub fn opts() -> TargetOptions {
         // linking some libraries which require a specific agreement, so it may
         // not ever be possible for us to pass this flag.
         no_default_libraries: false,
+        has_elf_tls: true,
 
         ..base
     }

--- a/compiler/rustc_target/src/spec/windows_msvc_base.rs
+++ b/compiler/rustc_target/src/spec/windows_msvc_base.rs
@@ -27,7 +27,7 @@ pub fn opts() -> TargetOptions {
         // linking some libraries which require a specific agreement, so it may
         // not ever be possible for us to pass this flag.
         no_default_libraries: false,
-        has_elf_tls: true,
+        has_thread_local: true,
 
         ..base
     }

--- a/compiler/rustc_target/src/spec/x86_64_pc_windows_msvc.rs
+++ b/compiler/rustc_target/src/spec/x86_64_pc_windows_msvc.rs
@@ -4,7 +4,6 @@ pub fn target() -> Target {
     let mut base = super::windows_msvc_base::opts();
     base.cpu = "x86-64".to_string();
     base.max_atomic_width = Some(64);
-    base.has_elf_tls = true;
 
     Target {
         llvm_target: "x86_64-pc-windows-msvc".to_string(),

--- a/compiler/rustc_target/src/spec/x86_64_unknown_linux_gnux32.rs
+++ b/compiler/rustc_target/src/spec/x86_64_unknown_linux_gnux32.rs
@@ -8,7 +8,7 @@ pub fn target() -> Target {
     base.pre_link_args.entry(LinkerFlavor::Gcc).or_default().push("-mx32".to_string());
     // don't use probe-stack=inline-asm until rust#83139 and rust#84667 are resolved
     base.stack_probes = StackProbeType::Call;
-    base.has_elf_tls = false;
+    base.has_thread_local = false;
     // BUG(GabrielMajeri): disabling the PLT on x86_64 Linux with x32 ABI
     // breaks code gen. See LLVM bug 36743
     base.needs_plt = true;

--- a/compiler/rustc_target/src/spec/x86_64_uwp_windows_msvc.rs
+++ b/compiler/rustc_target/src/spec/x86_64_uwp_windows_msvc.rs
@@ -4,7 +4,6 @@ pub fn target() -> Target {
     let mut base = super::windows_uwp_msvc_base::opts();
     base.cpu = "x86-64".to_string();
     base.max_atomic_width = Some(64);
-    base.has_elf_tls = true;
 
     Target {
         llvm_target: "x86_64-pc-windows-msvc".to_string(),


### PR DESCRIPTION
As it stands, `#[thread_local]` is enabled haphazardly for msvc. It seems all 64-bit targets have it enabled, but not 32-bit targets unless they're also UWP targets (perhaps because UWP was added more recently?). So this PR simply enables it for 32-bit targets as well. I can't think of a reason not to and I've confirmed by running tests locally which pass.

See also #91659