### PR TITLE
Implement namespacing for doc comments IDs

### DIFF
--- a/src/librustdoc/externalfiles.rs
+++ b/src/librustdoc/externalfiles.rs
@@ -1,4 +1,4 @@
-use crate::html::markdown::{ErrorCodes, HeadingOffset, IdMap, Markdown, Playground};
+use crate::html::markdown::{ErrorCodes, HeadingOffset, IdMap, IdPrefix, Markdown, Playground};
 use crate::rustc_span::edition::Edition;
 use std::fs;
 use std::path::Path;
@@ -47,6 +47,7 @@ impl ExternalHtml {
                 edition,
                 playground,
                 heading_offset: HeadingOffset::H2,
+                id_prefix: IdPrefix::without_parent(),
             }
             .into_string()
         );
@@ -63,6 +64,7 @@ impl ExternalHtml {
                 edition,
                 playground,
                 heading_offset: HeadingOffset::H2,
+                id_prefix: IdPrefix::without_parent(),
             }
             .into_string()
         );

--- a/src/librustdoc/html/markdown/tests.rs
+++ b/src/librustdoc/html/markdown/tests.rs
@@ -1,5 +1,7 @@
 use super::{find_testable_code, plain_text_summary, short_markdown_summary};
-use super::{ErrorCodes, HeadingOffset, IdMap, Ignore, LangString, Markdown, MarkdownHtml};
+use super::{
+    ErrorCodes, HeadingOffset, IdMap, IdPrefix, Ignore, LangString, Markdown, MarkdownHtml,
+};
 use rustc_span::edition::{Edition, DEFAULT_EDITION};
 
 #[test]
@@ -28,8 +30,8 @@ fn test_unique_id() {
         "examples-2",
         "method.into_iter-1",
         "foo-1",
-        "main-content-1",
-        "search-1",
+        "main-content",
+        "search",
         "methods",
         "examples-3",
         "method.into_iter-2",
@@ -38,7 +40,8 @@ fn test_unique_id() {
     ];
 
     let mut map = IdMap::new();
-    let actual: Vec<String> = input.iter().map(|s| map.derive(s.to_string())).collect();
+    let actual: Vec<String> =
+        input.iter().map(|s| map.derive(s.to_string(), IdPrefix::none())).collect();
     assert_eq!(&actual[..], expected);
 }
 
@@ -155,6 +158,7 @@ fn test_header() {
             edition: DEFAULT_EDITION,
             playground: &None,
             heading_offset: HeadingOffset::H2,
+            id_prefix: IdPrefix::none(),
         }
         .into_string();
         assert_eq!(output, expect, "original: {}", input);
@@ -197,6 +201,7 @@ fn test_header_ids_multiple_blocks() {
             edition: DEFAULT_EDITION,
             playground: &None,
             heading_offset: HeadingOffset::H2,
+            id_prefix: IdPrefix::none(),
         }
         .into_string();
         assert_eq!(output, expect, "original: {}", input);
@@ -220,7 +225,7 @@ fn test_header_ids_multiple_blocks() {
     t(
         &mut map,
         "# Search",
-        "<h2 id=\"search-1\" class=\"section-header\"><a href=\"#search-1\">Search</a></h2>",
+        "<h2 id=\"search\" class=\"section-header\"><a href=\"#search\">Search</a></h2>",
     );
     t(
         &mut map,
@@ -307,8 +312,15 @@ fn test_plain_text_summary() {
 fn test_markdown_html_escape() {
     fn t(input: &str, expect: &str) {
         let mut idmap = IdMap::new();
-        let output =
-            MarkdownHtml(input, &mut idmap, ErrorCodes::Yes, DEFAULT_EDITION, &None).into_string();
+        let output = MarkdownHtml(
+            input,
+            &mut idmap,
+            ErrorCodes::Yes,
+            DEFAULT_EDITION,
+            &None,
+            IdPrefix::none(),
+        )
+        .into_string();
         assert_eq!(output, expect, "original: {}", input);
     }
 

--- a/src/librustdoc/html/render/context.rs
+++ b/src/librustdoc/html/render/context.rs
@@ -31,7 +31,7 @@ use crate::formats::item_type::ItemType;
 use crate::formats::FormatRenderer;
 use crate::html::escape::Escape;
 use crate::html::format::Buffer;
-use crate::html::markdown::{self, plain_text_summary, ErrorCodes, IdMap};
+use crate::html::markdown::{self, plain_text_summary, ErrorCodes, IdMap, IdPrefix};
 use crate::html::{layout, sources};
 use crate::scrape_examples::AllCallLocations;
 use crate::try_err;
@@ -168,7 +168,7 @@ impl<'tcx> Context<'tcx> {
 
     pub(super) fn derive_id(&self, id: String) -> String {
         let mut map = self.id_map.borrow_mut();
-        map.derive(id)
+        map.derive(id, IdPrefix::none())
     }
 
     /// String representation of how to get back to the root path of the 'doc/'

--- a/src/librustdoc/markdown.rs
+++ b/src/librustdoc/markdown.rs
@@ -11,7 +11,7 @@ use crate::doctest::{Collector, GlobalTestOptions};
 use crate::html::escape::Escape;
 use crate::html::markdown;
 use crate::html::markdown::{
-    find_testable_code, ErrorCodes, HeadingOffset, IdMap, Markdown, MarkdownWithToc,
+    find_testable_code, ErrorCodes, HeadingOffset, IdMap, IdPrefix, Markdown, MarkdownWithToc,
 };
 
 /// Separate any lines at the start of the file that begin with `# ` or `%`.
@@ -70,7 +70,8 @@ crate fn render<P: AsRef<Path>>(
     let mut ids = IdMap::new();
     let error_codes = ErrorCodes::from(options.unstable_features.is_nightly_build());
     let text = if !options.markdown_no_toc {
-        MarkdownWithToc(text, &mut ids, error_codes, edition, &playground).into_string()
+        MarkdownWithToc(text, &mut ids, error_codes, edition, &playground, IdPrefix::none())
+            .into_string()
     } else {
         Markdown {
             content: text,
@@ -80,6 +81,7 @@ crate fn render<P: AsRef<Path>>(
             edition,
             playground: &playground,
             heading_offset: HeadingOffset::H1,
+            id_prefix: IdPrefix::none(),
         }
         .into_string()
     };

--- a/src/test/rustdoc-gui/anchors.goml
+++ b/src/test/rustdoc-gui/anchors.goml
@@ -16,7 +16,7 @@ assert-css: (".fqn .in-band a:nth-of-type(2)", {"color": "rgb(173, 68, 142)"})
 assert-css: (".srclink", {"color": "rgb(0, 0, 0)"})
 assert-css: (".srclink", {"color": "rgb(0, 0, 0)"})
 
-assert-css: ("#top-doc-prose-title", {"color": "rgb(0, 0, 0)"})
+assert-css: ("#struct\.HeavilyDocumentedStruct\.top-doc-prose-title", {"color": "rgb(0, 0, 0)"})
 
 assert-css: (".sidebar a", {"color": "rgb(0, 0, 0)"})
 assert-css: (".in-band a", {"color": "rgb(0, 0, 0)"})
@@ -48,19 +48,19 @@ assert-css: (".top-doc .docblock .section-header:not(:first-child)", {"margin-le
 
 // Now let's check some other docblock headings...
 // First the impl block docs.
-move-cursor-to: "#title-for-struct-impl-doc"
+move-cursor-to: "#impl\.unknown\.title-for-struct-impl-doc"
 assert-css: (
-    "#title-for-struct-impl-doc > a::before",
+    "#impl\.unknown\.title-for-struct-impl-doc > a::before",
     {"left": "-25px", "padding-right": "10px"},
 )
-assert-css: ("#title-for-struct-impl-doc", {"margin-left": "0px"})
+assert-css: ("#impl\.unknown\.title-for-struct-impl-doc", {"margin-left": "0px"})
 // Now a method docs.
-move-cursor-to: "#title-for-struct-impl-item-doc"
+move-cursor-to: "#method\.do_nothing\.title-for-struct-impl-item-doc"
 assert-css: (
-    "#title-for-struct-impl-item-doc > a::before",
+    "#method\.do_nothing\.title-for-struct-impl-item-doc > a::before",
     {"left": "-25px", "padding-right": "10px"},
 )
-assert-css: ("#title-for-struct-impl-item-doc", {"margin-left": "0px"})
+assert-css: ("#method\.do_nothing\.title-for-struct-impl-item-doc", {"margin-left": "0px"})
 
 // Finally, we want to ensure that if the first element of the doc block isn't a heading,
 // if there is a heading afterwards, it won't have the indent.

--- a/src/test/rustdoc-gui/headings.goml
+++ b/src/test/rustdoc-gui/headings.goml
@@ -17,19 +17,37 @@ goto: file://|DOC_PATH|/test_docs/struct.HeavilyDocumentedStruct.html
 assert-css: ("h1.fqn", {"font-size": "24px"})
 assert-css: ("h1.fqn", {"border-bottom-width": "1px"})
 
-assert-css: ("h2#top-doc-prose-title", {"font-size": "20.8px"})
-assert-css: ("h2#top-doc-prose-title", {"border-bottom-width": "1px"})
-assert-css: ("h3#top-doc-prose-sub-heading", {"font-size": "18.4px"})
-assert-css: ("h3#top-doc-prose-sub-heading", {"border-bottom-width": "1px"})
-assert-css: ("h4#top-doc-prose-sub-sub-heading", {"font-size": "17.6px"})
-assert-css: ("h4#top-doc-prose-sub-sub-heading", {"border-bottom-width": "1px"})
+assert-css: (
+    "h2#struct\.HeavilyDocumentedStruct\.top-doc-prose-title",
+    {"font-size": "20.8px"},
+)
+assert-css: (
+    "h2#struct\.HeavilyDocumentedStruct\.top-doc-prose-title",
+    {"border-bottom-width": "1px"},
+)
+assert-css: (
+    "h3#struct\.HeavilyDocumentedStruct\.top-doc-prose-sub-heading",
+    {"font-size": "18.4px"},
+)
+assert-css: (
+    "h3#struct\.HeavilyDocumentedStruct\.top-doc-prose-sub-heading",
+    {"border-bottom-width": "1px"},
+)
+assert-css: (
+    "h4#struct\.HeavilyDocumentedStruct\.top-doc-prose-sub-sub-heading",
+    {"font-size": "17.6px"},
+)
+assert-css: (
+    "h4#struct\.HeavilyDocumentedStruct\.top-doc-prose-sub-sub-heading",
+    {"border-bottom-width": "1px"},
+)
 
 assert-css: ("h2#fields", {"font-size": "22.4px"})
 assert-css: ("h2#fields", {"border-bottom-width": "1px"})
-assert-css: ("h3#title-for-field", {"font-size": "20.8px"})
-assert-css: ("h3#title-for-field", {"border-bottom-width": "0px"})
-assert-css: ("h4#sub-heading-for-field", {"font-size": "16px"})
-assert-css: ("h4#sub-heading-for-field", {"border-bottom-width": "0px"})
+assert-css: ("h3#structfield\.nothing\.title-for-field", {"font-size": "20.8px"})
+assert-css: ("h3#structfield\.nothing\.title-for-field", {"border-bottom-width": "0px"})
+assert-css: ("h4#structfield\.nothing\.sub-heading-for-field", {"font-size": "16px"})
+assert-css: ("h4#structfield\.nothing\.sub-heading-for-field", {"border-bottom-width": "0px"})
 
 assert-css: ("h2#implementations", {"font-size": "22.4px"})
 assert-css: ("h2#implementations", {"border-bottom-width": "1px"})
@@ -39,53 +57,104 @@ assert-css: ("#impl > h3.code-header", {"border-bottom-width": "0px"})
 assert-css: ("#method\.do_nothing > h4.code-header", {"font-size": "16px"})
 assert-css: ("#method\.do_nothing > h4.code-header", {"border-bottom-width": "0px"})
 
-assert-css: ("h4#title-for-struct-impl-doc", {"font-size": "16px"})
-assert-css: ("h4#title-for-struct-impl-doc", {"border-bottom-width": "0px"})
-assert-css: ("h5#sub-heading-for-struct-impl-doc", {"font-size": "16px"})
-assert-css: ("h5#sub-heading-for-struct-impl-doc", {"border-bottom-width": "0px"})
-assert-css: ("h6#sub-sub-heading-for-struct-impl-doc", {"font-size": "15.2px"})
-assert-css: ("h6#sub-sub-heading-for-struct-impl-doc", {"border-bottom-width": "0px"})
+assert-css: (
+    "h4#impl\.unknown\.title-for-struct-impl-doc",
+    {"font-size": "16px"},
+)
+assert-css: (
+    "h4#impl\.unknown\.title-for-struct-impl-doc",
+    {"border-bottom-width": "0px"},
+)
+assert-css: (
+    "h5#impl\.unknown\.sub-heading-for-struct-impl-doc",
+    {"font-size": "16px"},
+)
+assert-css: (
+    "h5#impl\.unknown\.sub-heading-for-struct-impl-doc",
+    {"border-bottom-width": "0px"},
+)
+assert-css: (
+    "h6#impl\.unknown\.sub-sub-heading-for-struct-impl-doc",
+    {"font-size": "15.2px"},
+)
+assert-css: (
+    "h6#impl\.unknown\.sub-sub-heading-for-struct-impl-doc",
+    {"border-bottom-width": "0px"},
+)
 
-assert-css: ("h5#title-for-struct-impl-item-doc", {"font-size": "16px"})
-assert-css: ("h5#title-for-struct-impl-item-doc", {"border-bottom-width": "0px"})
-assert-css: ("h6#sub-heading-for-struct-impl-item-doc", {"font-size": "15.2px"})
-assert-css: ("h6#sub-heading-for-struct-impl-item-doc", {"border-bottom-width": "0px"})
-assert-css: ("h6#sub-sub-heading-for-struct-impl-item-doc", {"font-size": "15.2px"})
+assert-css: (
+    "h5#method\.do_nothing\.title-for-struct-impl-item-doc",
+    {"font-size": "16px"},
+)
+assert-css: (
+    "h5#method\.do_nothing\.title-for-struct-impl-item-doc",
+    {"border-bottom-width": "0px"},
+)
+assert-css: (
+    "h6#method\.do_nothing\.sub-heading-for-struct-impl-item-doc",
+    {"font-size": "15.2px"},
+)
+assert-css: (
+    "h6#method\.do_nothing\.sub-heading-for-struct-impl-item-doc",
+    {"border-bottom-width": "0px"},
+)
+assert-css: (
+    "h6#method\.do_nothing\.sub-sub-heading-for-struct-impl-item-doc",
+    {"font-size": "15.2px"},
+)
 
 goto: file://|DOC_PATH|/test_docs/enum.HeavilyDocumentedEnum.html
 
 assert-css: ("h1.fqn", {"font-size": "24px"})
 assert-css: ("h1.fqn", {"border-bottom-width": "1px"})
 
-assert-css: ("h2#top-doc-prose-title", {"font-size": "20.8px"})
-assert-css: ("h2#top-doc-prose-title", {"border-bottom-width": "1px"})
-assert-css: ("h3#top-doc-prose-sub-heading", {"font-size": "18.4px"})
-assert-css: ("h3#top-doc-prose-sub-heading", {"border-bottom-width": "1px"})
-assert-css: ("h4#top-doc-prose-sub-sub-heading", {"font-size": "17.6px"})
-assert-css: ("h4#top-doc-prose-sub-sub-heading", {"border-bottom-width": "1px"})
+assert-css: (
+    "h2#enum\.HeavilyDocumentedEnum\.top-doc-prose-title",
+    {"font-size": "20.8px"},
+)
+assert-css: (
+    "h2#enum\.HeavilyDocumentedEnum\.top-doc-prose-title",
+    {"border-bottom-width": "1px"},
+)
+assert-css: (
+    "h3#enum\.HeavilyDocumentedEnum\.top-doc-prose-sub-heading",
+    {"font-size": "18.4px"},
+)
+assert-css: (
+    "h3#enum\.HeavilyDocumentedEnum\.top-doc-prose-sub-heading",
+    {"border-bottom-width": "1px"},
+)
+assert-css: (
+    "h4#enum\.HeavilyDocumentedEnum\.top-doc-prose-sub-sub-heading",
+    {"font-size": "17.6px"},
+)
+assert-css: (
+    "h4#enum\.HeavilyDocumentedEnum\.top-doc-prose-sub-sub-heading",
+    {"border-bottom-width": "1px"},
+)
 
 assert-css: ("h2#variants", {"font-size": "22.4px"})
 assert-css: ("h2#variants", {"border-bottom-width": "1px"})
 
-assert-css: ("h4#none-prose-title", {"font-size": "16px"})
-assert-css: ("h4#none-prose-title", {"border-bottom-width": "0px"})
-assert-css: ("h5#none-prose-sub-heading", {"font-size": "16px"})
-assert-css: ("h5#none-prose-sub-heading", {"border-bottom-width": "0px"})
+assert-css: ("h4#variant\.None\.none-prose-title", {"font-size": "16px"})
+assert-css: ("h4#variant\.None\.none-prose-title", {"border-bottom-width": "0px"})
+assert-css: ("h5#variant\.None\.none-prose-sub-heading", {"font-size": "16px"})
+assert-css: ("h5#variant\.None\.none-prose-sub-heading", {"border-bottom-width": "0px"})
 
-assert-css: ("h4#wrapped-prose-title", {"font-size": "16px"})
-assert-css: ("h4#wrapped-prose-title", {"border-bottom-width": "0px"})
-assert-css: ("h5#wrapped-prose-sub-heading", {"font-size": "16px"})
-assert-css: ("h5#wrapped-prose-sub-heading", {"border-bottom-width": "0px"})
+assert-css: ("h4#variant\.Wrapped\.wrapped-prose-title", {"font-size": "16px"})
+assert-css: ("h4#variant\.Wrapped\.wrapped-prose-title", {"border-bottom-width": "0px"})
+assert-css: ("h5#variant\.Wrapped\.wrapped-prose-sub-heading", {"font-size": "16px"})
+assert-css: ("h5#variant\.Wrapped\.wrapped-prose-sub-heading", {"border-bottom-width": "0px"})
 
-assert-css: ("h5#wrapped0-prose-title", {"font-size": "16px"})
-assert-css: ("h5#wrapped0-prose-title", {"border-bottom-width": "0px"})
-assert-css: ("h6#wrapped0-prose-sub-heading", {"font-size": "15.2px"})
-assert-css: ("h6#wrapped0-prose-sub-heading", {"border-bottom-width": "0px"})
+assert-css: ("h5#structfield\.0\.wrapped0-prose-title", {"font-size": "16px"})
+assert-css: ("h5#structfield\.0\.wrapped0-prose-title", {"border-bottom-width": "0px"})
+assert-css: ("h6#structfield\.0\.wrapped0-prose-sub-heading", {"font-size": "15.2px"})
+assert-css: ("h6#structfield\.0\.wrapped0-prose-sub-heading", {"border-bottom-width": "0px"})
 
-assert-css: ("h5#structy-prose-title", {"font-size": "16px"})
-assert-css: ("h5#structy-prose-title", {"border-bottom-width": "0px"})
-assert-css: ("h6#structy-prose-sub-heading", {"font-size": "15.2px"})
-assert-css: ("h6#structy-prose-sub-heading", {"border-bottom-width": "0px"})
+assert-css: ("h5#structfield\.alpha\.structy-prose-title", {"font-size": "16px"})
+assert-css: ("h5#structfield\.alpha\.structy-prose-title", {"border-bottom-width": "0px"})
+assert-css: ("h6#structfield\.alpha\.structy-prose-sub-heading", {"font-size": "15.2px"})
+assert-css: ("h6#structfield\.alpha\.structy-prose-sub-heading", {"border-bottom-width": "0px"})
 
 assert-css: ("h2#implementations", {"font-size": "22.4px"})
 assert-css: ("h2#implementations", {"border-bottom-width": "1px"})
@@ -95,19 +164,37 @@ assert-css: ("#impl > h3.code-header", {"border-bottom-width": "0px"})
 assert-css: ("#method\.do_nothing > h4.code-header", {"font-size": "16px"})
 assert-css: ("#method\.do_nothing > h4.code-header", {"border-bottom-width": "0px"})
 
-assert-css: ("h4#title-for-enum-impl-doc", {"font-size": "16px"})
-assert-css: ("h4#title-for-enum-impl-doc", {"border-bottom-width": "0px"})
-assert-css: ("h5#sub-heading-for-enum-impl-doc", {"font-size": "16px"})
-assert-css: ("h5#sub-heading-for-enum-impl-doc", {"border-bottom-width": "0px"})
-assert-css: ("h6#sub-sub-heading-for-enum-impl-doc", {"font-size": "15.2px"})
-assert-css: ("h6#sub-sub-heading-for-enum-impl-doc", {"border-bottom-width": "0px"})
+assert-css: ("h4#impl\.unknown\.title-for-enum-impl-doc", {"font-size": "16px"})
+assert-css: ("h4#impl\.unknown\.title-for-enum-impl-doc", {"border-bottom-width": "0px"})
+assert-css: ("h5#impl\.unknown\.sub-heading-for-enum-impl-doc", {"font-size": "16px"})
+assert-css: ("h5#impl\.unknown\.sub-heading-for-enum-impl-doc", {"border-bottom-width": "0px"})
+assert-css: ("h6#impl\.unknown\.sub-sub-heading-for-enum-impl-doc", {"font-size": "15.2px"})
+assert-css: ("h6#impl\.unknown\.sub-sub-heading-for-enum-impl-doc", {"border-bottom-width": "0px"})
 
-assert-css: ("h5#title-for-enum-impl-item-doc", {"font-size": "16px"})
-assert-css: ("h5#title-for-enum-impl-item-doc", {"border-bottom-width": "0px"})
-assert-css: ("h6#sub-heading-for-enum-impl-item-doc", {"font-size": "15.2px"})
-assert-css: ("h6#sub-heading-for-enum-impl-item-doc", {"border-bottom-width": "0px"})
-assert-css: ("h6#sub-sub-heading-for-enum-impl-item-doc", {"font-size": "15.2px"})
-assert-css: ("h6#sub-sub-heading-for-enum-impl-item-doc", {"border-bottom-width": "0px"})
+assert-css: (
+    "h5#method\.do_nothing\.title-for-enum-impl-item-doc",
+    {"font-size": "16px"},
+)
+assert-css: (
+    "h5#method\.do_nothing\.title-for-enum-impl-item-doc",
+    {"border-bottom-width": "0px"},
+)
+assert-css: (
+    "h6#method\.do_nothing\.sub-heading-for-enum-impl-item-doc",
+    {"font-size": "15.2px"},
+)
+assert-css: (
+    "h6#method\.do_nothing\.sub-heading-for-enum-impl-item-doc",
+    {"border-bottom-width": "0px"},
+)
+assert-css: (
+    "h6#method\.do_nothing\.sub-sub-heading-for-enum-impl-item-doc",
+    {"font-size": "15.2px"},
+)
+assert-css: (
+    "h6#method\.do_nothing\.sub-sub-heading-for-enum-impl-item-doc",
+    {"border-bottom-width": "0px"},
+)
 
 assert-text: (".sidebar .others h3", "Modules")
 assert-css: (".sidebar .others h3", {"border-bottom-width": "1px"}, ALL)
@@ -117,40 +204,88 @@ goto: file://|DOC_PATH|/test_docs/union.HeavilyDocumentedUnion.html
 assert-css: ("h1.fqn", {"font-size": "24px"})
 assert-css: ("h1.fqn", {"border-bottom-width": "1px"})
 
-assert-css: ("h2#top-doc-prose-title", {"font-size": "20.8px"})
-assert-css: ("h2#top-doc-prose-title", {"border-bottom-width": "1px"})
-assert-css: ("h3#top-doc-prose-sub-heading", {"font-size": "18.4px"})
-assert-css: ("h3#top-doc-prose-sub-heading", {"border-bottom-width": "1px"})
+assert-css: (
+    "h2#union\.HeavilyDocumentedUnion\.top-doc-prose-title",
+    {"font-size": "20.8px"},
+)
+assert-css: (
+    "h2#union\.HeavilyDocumentedUnion\.top-doc-prose-title",
+    {"border-bottom-width": "1px"},
+)
+assert-css: (
+    "h3#union\.HeavilyDocumentedUnion\.top-doc-prose-sub-heading",
+    {"font-size": "18.4px"},
+)
+assert-css: (
+    "h3#union\.HeavilyDocumentedUnion\.top-doc-prose-sub-heading",
+    {"border-bottom-width": "1px"},
+)
 
 assert-css: ("h2#fields", {"font-size": "22.4px"})
 assert-css: ("h2#fields", {"border-bottom-width": "1px"})
 
-assert-css: ("h3#title-for-union-variant", {"font-size": "20.8px"})
-assert-css: ("h3#title-for-union-variant", {"border-bottom-width": "0px"})
-assert-css: ("h4#sub-heading-for-union-variant", {"font-size": "16px"})
-assert-css: ("h4#sub-heading-for-union-variant", {"border-bottom-width": "0px"})
+assert-css: (
+    "h3#structfield\.nothing\.title-for-union-variant",
+    {"font-size": "20.8px"},
+)
+assert-css: (
+    "h3#structfield\.nothing\.title-for-union-variant",
+    {"border-bottom-width": "0px"},
+)
+assert-css: (
+    "h4#structfield\.nothing\.sub-heading-for-union-variant",
+    {"font-size": "16px"},
+)
+assert-css: (
+    "h4#structfield\.nothing\.sub-heading-for-union-variant",
+    {"border-bottom-width": "0px"},
+)
 
 assert-css: ("h2#implementations", {"font-size": "22.4px"})
 assert-css: ("h2#implementations", {"border-bottom-width": "1px"})
 
 assert-css: ("#impl > h3.code-header", {"font-size": "17.6px"})
 assert-css: ("#impl > h3.code-header", {"border-bottom-width": "0px"})
-assert-css: ("h4#title-for-union-impl-doc", {"font-size": "16px"})
-assert-css: ("h4#title-for-union-impl-doc", {"border-bottom-width": "0px"})
-assert-css: ("h5#sub-heading-for-union-impl-doc", {"font-size": "16px"})
-assert-css: ("h5#sub-heading-for-union-impl-doc", {"border-bottom-width": "0px"})
+assert-css: ("h4#impl\.unknown\.title-for-union-impl-doc", {"font-size": "16px"})
+assert-css: ("h4#impl\.unknown\.title-for-union-impl-doc", {"border-bottom-width": "0px"})
+assert-css: ("h5#impl\.unknown\.sub-heading-for-union-impl-doc", {"font-size": "16px"})
+assert-css: ("h5#impl\.unknown\.sub-heading-for-union-impl-doc", {"border-bottom-width": "0px"})
 
-assert-css: ("h5#title-for-union-impl-item-doc", {"font-size": "16px"})
-assert-css: ("h5#title-for-union-impl-item-doc", {"border-bottom-width": "0px"})
-assert-css: ("h6#sub-heading-for-union-impl-item-doc", {"font-size": "15.2px"})
-assert-css: ("h6#sub-heading-for-union-impl-item-doc", {"border-bottom-width": "0px"})
+assert-css: (
+    "h5#method\.do_nothing\.title-for-union-impl-item-doc",
+    {"font-size": "16px"},
+)
+assert-css: (
+    "h5#method\.do_nothing\.title-for-union-impl-item-doc",
+    {"border-bottom-width": "0px"},
+)
+assert-css: (
+    "h6#method\.do_nothing\.sub-heading-for-union-impl-item-doc",
+    {"font-size": "15.2px"},
+)
+assert-css: (
+    "h6#method\.do_nothing\.sub-heading-for-union-impl-item-doc",
+    {"border-bottom-width": "0px"},
+)
 
 goto: file://|DOC_PATH|/test_docs/macro.heavily_documented_macro.html
 
 assert-css: ("h1.fqn", {"font-size": "24px"})
 assert-css: ("h1.fqn", {"border-bottom-width": "1px"})
 
-assert-css: ("h2#top-doc-prose-title", {"font-size": "20.8px"})
-assert-css: ("h2#top-doc-prose-title", {"border-bottom-width": "1px"})
-assert-css: ("h3#top-doc-prose-sub-heading", {"font-size": "18.4px"})
-assert-css: ("h3#top-doc-prose-sub-heading", {"border-bottom-width": "1px"})
+assert-css: (
+    "h2#macro\.heavily_documented_macro\.top-doc-prose-title",
+    {"font-size": "20.8px"},
+)
+assert-css: (
+    "h2#macro\.heavily_documented_macro\.top-doc-prose-title",
+    {"border-bottom-width": "1px"},
+)
+assert-css: (
+    "h3#macro\.heavily_documented_macro\.top-doc-prose-sub-heading",
+    {"font-size": "18.4px"},
+)
+assert-css: (
+    "h3#macro\.heavily_documented_macro\.top-doc-prose-sub-heading",
+    {"border-bottom-width": "1px"},
+)

--- a/src/test/rustdoc/enum-headings.rs
+++ b/src/test/rustdoc/enum-headings.rs
@@ -3,23 +3,23 @@
 /// A token!
 /// # First
 /// Some following text...
-// @has - '//h2[@id="first"]' "First"
+// @has - '//h2[@id="enum.Token.first"]' "First"
 pub enum Token {
     /// A declaration!
     /// # Variant-First
     /// Some following text...
-    // @has - '//h4[@id="variant-first"]' "Variant-First"
+    // @has - '//h4[@id="variant.Declaration.variant-first"]' "Variant-First"
     Declaration {
         /// A version!
         /// # Variant-Field-First
         /// Some following text...
-        // @has - '//h5[@id="variant-field-first"]' "Variant-Field-First"
+        // @has - '//h5[@id="structfield.version.variant-field-first"]' "Variant-Field-First"
         version: String,
     },
     /// A Zoople!
     /// # Variant-First
     Zoople(
-        // @has - '//h5[@id="variant-tuple-field-first"]' "Variant-Tuple-Field-First"
+        // @has - '//h5[@id="structfield.0.variant-tuple-field-first"]' "Variant-Tuple-Field-First"
         /// Zoople's first variant!
         /// # Variant-Tuple-Field-First
         /// Some following text...
@@ -28,13 +28,13 @@ pub enum Token {
     /// Unfinished business!
     /// # Non-Exhaustive-First
     /// Some following text...
-    // @has - '//h4[@id="non-exhaustive-first"]' "Non-Exhaustive-First"
+    // @has - '//h4[@id="variant.Unfinished.non-exhaustive-first"]' "Non-Exhaustive-First"
     #[non_exhaustive]
     Unfinished {
         /// This is x.
         /// # X-First
         /// Some following text...
-        // @has - '//h5[@id="x-first"]' "X-First"
+        // @has - '//h5[@id="structfield.x.x-first"]' "X-First"
         x: usize,
     },
 }

--- a/src/test/rustdoc/issue-29449.rs
+++ b/src/test/rustdoc/issue-29449.rs
@@ -2,18 +2,20 @@
 pub struct Foo;
 
 impl Foo {
-    // @has - '//*[@id="examples"]//a' 'Examples'
-    // @has - '//*[@id="panics"]//a' 'Panics'
+    // @has - '//*[@id="method.bar.examples"]//a' 'Examples'
+    // @has - '//*[@id="method.bar.panics"]//a' 'Panics'
     /// # Examples
     /// # Panics
     pub fn bar() {}
 
-    // @has - '//*[@id="examples-1"]//a' 'Examples'
+    // @has - '//*[@id="method.bar_1.examples"]//a' 'Examples'
+    // @has - '//*[@id="method.bar_1.examples-1"]//a' 'Examples'
+    /// # Examples
     /// # Examples
     pub fn bar_1() {}
 
-    // @has - '//*[@id="examples-2"]//a' 'Examples'
-    // @has - '//*[@id="panics-1"]//a' 'Panics'
+    // @has - '//*[@id="method.bar_2.examples"]//a' 'Examples'
+    // @has - '//*[@id="method.bar_2.panics"]//a' 'Panics'
     /// # Examples
     /// # Panics
     pub fn bar_2() {}

--- a/src/test/rustdoc/remove-url-from-headings.rs
+++ b/src/test/rustdoc/remove-url-from-headings.rs
@@ -2,8 +2,8 @@
 
 // @has foo/fn.foo.html
 // @!has - '//a[@href="http://a.a"]'
-// @has - '//a[@href="#implementing-stuff-somewhere"]' 'Implementing stuff somewhere'
-// @has - '//a[@href="#another-one-urg"]' 'Another one urg'
+// @has - '//a[@href="#fn.foo.implementing-stuff-somewhere"]' 'Implementing stuff somewhere'
+// @has - '//a[@href="#fn.foo.another-one-urg"]' 'Another one urg'
 
 /// fooo
 ///

--- a/src/test/rustdoc/short-docblock.rs
+++ b/src/test/rustdoc/short-docblock.rs
@@ -2,7 +2,7 @@
 
 // @has foo/index.html '//*[@class="item-right docblock-short"]/p' 'fooo'
 // @!has foo/index.html '//*[@class="item-right docblock-short"]/p/h1' 'fooo'
-// @has foo/fn.foo.html '//h2[@id="fooo"]/a[@href="#fooo"]' 'fooo'
+// @has foo/fn.foo.html '//h2[@id="fn.foo.fooo"]/a[@href="#fn.foo.fooo"]' 'fooo'
 
 /// # fooo
 ///
@@ -11,7 +11,7 @@ pub fn foo() {}
 
 // @has foo/index.html '//*[@class="item-right docblock-short"]/p' 'mooood'
 // @!has foo/index.html '//*[@class="item-right docblock-short"]/p/h2' 'mooood'
-// @has foo/foo/index.html '//h3[@id="mooood"]/a[@href="#mooood"]' 'mooood'
+// @has foo/foo/index.html '//h3[@id="mod.foo.mooood"]/a[@href="#mod.foo.mooood"]' 'mooood'
 
 /// ## mooood
 ///

--- a/src/tools/error_index_generator/main.rs
+++ b/src/tools/error_index_generator/main.rs
@@ -14,7 +14,7 @@ use std::path::PathBuf;
 
 use rustc_span::edition::DEFAULT_EDITION;
 
-use rustdoc::html::markdown::{ErrorCodes, HeadingOffset, IdMap, Markdown, Playground};
+use rustdoc::html::markdown::{ErrorCodes, HeadingOffset, IdMap, IdPrefix, Markdown, Playground};
 
 pub struct ErrorMetadata {
     pub description: Option<String>,
@@ -127,6 +127,7 @@ impl Formatter for HTMLFormatter {
                         edition: DEFAULT_EDITION,
                         playground: &Some(playground),
                         heading_offset: HeadingOffset::H1,
+                        id_prefix: IdPrefix::none(),
                     }
                     .into_string()
                 )?


### PR DESCRIPTION
Fixes #91759.

I think it also completely removes the need for #86178 (yeay!).

Thanks to the namespacing, we can stop worrying about declaring the IDs used by rustdoc for its layout.

You can check it online [here](https://rustdoc.crud.net/imperio/doc-comment-id-namespace/std/index.html).

cc @jsha (since the idea comes from you :) )
r? @camelid 