### PR TITLE
Set `RUST_BACKTRACE=0` when running location-detail tests

### DIFF
--- a/src/test/ui/panics/location-detail-panic-no-column.rs
+++ b/src/test/ui/panics/location-detail-panic-no-column.rs
@@ -1,6 +1,7 @@
 // run-fail
 // check-run-results
 // compile-flags: -Zlocation-detail=line,file
+// exec-env:RUST_BACKTRACE=0
 
 fn main() {
     panic!("column-redacted");

--- a/src/test/ui/panics/location-detail-panic-no-column.run.stderr
+++ b/src/test/ui/panics/location-detail-panic-no-column.run.stderr
@@ -1,2 +1,2 @@
-thread 'main' panicked at 'column-redacted', $DIR/location-detail-panic-no-column.rs:6:0
+thread 'main' panicked at 'column-redacted', $DIR/location-detail-panic-no-column.rs:7:0
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

--- a/src/test/ui/panics/location-detail-panic-no-file.rs
+++ b/src/test/ui/panics/location-detail-panic-no-file.rs
@@ -1,6 +1,7 @@
 // run-fail
 // check-run-results
 // compile-flags: -Zlocation-detail=line,column
+// exec-env:RUST_BACKTRACE=0
 
 fn main() {
     panic!("file-redacted");

--- a/src/test/ui/panics/location-detail-panic-no-file.run.stderr
+++ b/src/test/ui/panics/location-detail-panic-no-file.run.stderr
@@ -1,2 +1,2 @@
-thread 'main' panicked at 'file-redacted', <redacted>:6:5
+thread 'main' panicked at 'file-redacted', <redacted>:7:5
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

--- a/src/test/ui/panics/location-detail-panic-no-line.rs
+++ b/src/test/ui/panics/location-detail-panic-no-line.rs
@@ -1,6 +1,7 @@
 // run-fail
 // check-run-results
 // compile-flags: -Zlocation-detail=file,column
+// exec-env:RUST_BACKTRACE=0
 
 fn main() {
     panic!("line-redacted");

--- a/src/test/ui/panics/location-detail-unwrap-no-file.rs
+++ b/src/test/ui/panics/location-detail-unwrap-no-file.rs
@@ -1,6 +1,7 @@
 // run-fail
 // check-run-results
 // compile-flags: -Zlocation-detail=line,column
+// exec-env:RUST_BACKTRACE=0
 
 fn main() {
     let opt: Option<u32> = None;

--- a/src/test/ui/panics/location-detail-unwrap-no-file.run.stderr
+++ b/src/test/ui/panics/location-detail-unwrap-no-file.run.stderr
@@ -1,2 +1,2 @@
-thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', <redacted>:7:9
+thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', <redacted>:8:9
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


### PR DESCRIPTION
This ensures that the output does not depend on environment variables
set in the shell.