### PR TITLE
Make Run button visible on hover

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1117,6 +1117,7 @@ pre.rust .question-mark {
 
 a.test-arrow {
 	display: inline-block;
+	visibility: hidden;
 	position: absolute;
 	padding: 5px 10px 5px 10px;
 	border-radius: 5px;
@@ -1125,10 +1126,12 @@ a.test-arrow {
 	right: 5px;
 	z-index: 1;
 }
+.example-wrap:hover .test-arrow {
+	visibility: visible;
+}
 a.test-arrow:hover{
 	text-decoration: none;
 }
-
 .section-header:hover a:before {
 	position: absolute;
 	left: -25px;

--- a/src/test/rustdoc-gui/run-on-hover.goml
+++ b/src/test/rustdoc-gui/run-on-hover.goml
@@ -1,0 +1,7 @@
+// Example code blocks sometimes have a "Run" button to run them on the
+// Playground. That button is hidden until the user hovers over the code block.
+// This test checks that it is hidden, and that it shows on hover.
+goto: file://|DOC_PATH|/test_docs/fn.foo.html
+assert-css: (".test-arrow", {"visibility": "hidden"})
+move-cursor-to: ".example-wrap"
+assert-css: (".test-arrow", {"visibility": "visible"})

--- a/src/test/rustdoc-gui/src/test_docs/lib.rs
+++ b/src/test/rustdoc-gui/src/test_docs/lib.rs
@@ -1,5 +1,6 @@
 //! The point of this crate is to be able to have enough different "kinds" of
 //! documentation generated so we can test each different features.
+#![doc(html_playground_url="https://play.rust-lang.org/")]
 
 #![crate_name = "test_docs"]
 #![feature(rustdoc_internals)]


### PR DESCRIPTION
This slightly reduces the noisiness of doc pages, making them easier to read.

Demo: https://rustdoc.crud.net/jsha/run-on-hover/std/string/struct.String.html

[Discussed on Zulip](https://rust-lang.zulipchat.com/#narrow/stream/266220-rustdoc/topic/.22Run.22.20button.20visible.20on.20hover).

Part of #59845