### PR TITLE
rustdoc: Return String from doc_value, not Option

### DIFF
--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -414,7 +414,7 @@ impl Item {
 
     /// Finds the `doc` attribute as a NameValue and returns the corresponding
     /// value found.
-    crate fn doc_value(&self) -> Option<String> {
+    crate fn doc_value(&self) -> String {
         self.attrs.doc_value()
     }
 
@@ -1081,10 +1081,13 @@ impl Attributes {
 
     /// Finds the `doc` attribute as a NameValue and returns the corresponding
     /// value found.
-    crate fn doc_value(&self) -> Option<String> {
+    crate fn doc_value(&self) -> String {
         let mut iter = self.doc_strings.iter();
 
-        let ori = iter.next()?;
+        let ori = match iter.next() {
+            Some(s) => s,
+            None => return String::new(),
+        };
         let mut out = String::new();
         add_doc_fragment(&mut out, ori);
         for new_frag in iter {
@@ -1093,7 +1096,7 @@ impl Attributes {
             }
             add_doc_fragment(&mut out, new_frag);
         }
-        if out.is_empty() { None } else { Some(out) }
+        out
     }
 
     /// Return the doc-comments on this item, grouped by the module they came from.

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -123,12 +123,11 @@ crate struct Crate {
     crate primitives: ThinVec<(DefId, PrimitiveType)>,
     /// Only here so that they can be filtered through the rustdoc passes.
     crate external_traits: Rc<RefCell<FxHashMap<DefId, TraitWithExtraInfo>>>,
-    crate collapsed: bool,
 }
 
 // `Crate` is frequently moved by-value. Make sure it doesn't unintentionally get bigger.
 #[cfg(all(target_arch = "x86_64", target_pointer_width = "64"))]
-rustc_data_structures::static_assert_size!(Crate, 80);
+rustc_data_structures::static_assert_size!(Crate, 72);
 
 impl Crate {
     crate fn name(&self, tcx: TyCtxt<'_>) -> Symbol {

--- a/src/librustdoc/clean/utils.rs
+++ b/src/librustdoc/clean/utils.rs
@@ -72,7 +72,7 @@ crate fn krate(cx: &mut DocContext<'_>) -> Crate {
         }));
     }
 
-    Crate { module, primitives, external_traits: cx.external_traits.clone(), collapsed: false }
+    Crate { module, primitives, external_traits: cx.external_traits.clone() }
 }
 
 fn external_generic_args(

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -510,9 +510,6 @@ crate fn run_global_ctxt(
 
     krate = tcx.sess.time("create_format_cache", || Cache::populate(&mut ctxt, krate));
 
-    // The main crate doc comments are always collapsed.
-    krate.collapsed = true;
-
     (krate, ctxt.render_options, ctxt.cache)
 }
 

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -397,7 +397,7 @@ crate fn run_global_ctxt(
 
     let mut krate = tcx.sess.time("clean_crate", || clean::krate(&mut ctxt));
 
-    if krate.module.doc_value().map(|d| d.is_empty()).unwrap_or(true) {
+    if krate.module.doc_value().is_empty() {
         let help = format!(
             "The following guide may be of use:\n\
             {}/rustdoc/how-to-write-documentation.html",

--- a/src/librustdoc/formats/cache.rs
+++ b/src/librustdoc/formats/cache.rs
@@ -294,9 +294,8 @@ impl<'a, 'tcx> DocFolder for CacheBuilder<'a, 'tcx> {
                     // which should not be indexed. The crate-item itself is
                     // inserted later on when serializing the search-index.
                     if item.def_id.index().map_or(false, |idx| idx != CRATE_DEF_INDEX) {
-                        let desc = item.doc_value().map_or_else(String::new, |x| {
-                            short_markdown_summary(x.as_str(), &item.link_names(self.cache))
-                        });
+                        let desc =
+                            short_markdown_summary(&item.doc_value(), &item.link_names(self.cache));
                         self.cache.search_index.push(IndexItem {
                             ty: item.type_(),
                             name: s.to_string(),

--- a/src/librustdoc/html/render/cache.rs
+++ b/src/librustdoc/html/render/cache.rs
@@ -32,9 +32,7 @@ crate fn build_index<'tcx>(krate: &clean::Crate, cache: &mut Cache, tcx: TyCtxt<
     // has since been learned.
     for &(did, ref item) in &cache.orphan_impl_items {
         if let Some(&(ref fqp, _)) = cache.paths.get(&did) {
-            let desc = item
-                .doc_value()
-                .map_or_else(String::new, |s| short_markdown_summary(&s, &item.link_names(cache)));
+            let desc = short_markdown_summary(&item.doc_value(), &item.link_names(cache));
             cache.search_index.push(IndexItem {
                 ty: item.type_(),
                 name: item.name.unwrap().to_string(),
@@ -48,10 +46,8 @@ crate fn build_index<'tcx>(krate: &clean::Crate, cache: &mut Cache, tcx: TyCtxt<
         }
     }
 
-    let crate_doc = krate
-        .module
-        .doc_value()
-        .map_or_else(String::new, |s| short_markdown_summary(&s, &krate.module.link_names(cache)));
+    let crate_doc =
+        short_markdown_summary(&krate.module.doc_value(), &krate.module.link_names(cache));
 
     let Cache { ref mut search_index, ref paths, .. } = *cache;
 

--- a/src/librustdoc/html/render/context.rs
+++ b/src/librustdoc/html/render/context.rs
@@ -88,8 +88,6 @@ crate struct SharedContext<'tcx> {
     crate local_sources: FxHashMap<PathBuf, String>,
     /// Show the memory layout of types in the docs.
     pub(super) show_type_layout: bool,
-    /// Whether the collapsed pass ran
-    collapsed: bool,
     /// The base-URL of the issue tracker for when an item has been tagged with
     /// an issue number.
     pub(super) issue_tracker_base_url: Option<String>,
@@ -140,12 +138,6 @@ impl SharedContext<'_> {
         }
 
         Ok(())
-    }
-
-    /// Returns the `collapsed_doc_value` of the given item if this is the main crate, otherwise
-    /// returns the `doc_value`.
-    crate fn maybe_collapsed_doc_value<'a>(&self, item: &'a clean::Item) -> Option<String> {
-        if self.collapsed { item.collapsed_doc_value() } else { item.doc_value() }
     }
 
     crate fn edition(&self) -> Edition {
@@ -472,7 +464,6 @@ impl<'tcx> FormatRenderer<'tcx> for Context<'tcx> {
         let (sender, receiver) = channel();
         let mut scx = SharedContext {
             tcx,
-            collapsed: krate.collapsed,
             src_root,
             local_sources,
             issue_tracker_base_url,

--- a/src/librustdoc/html/render/context.rs
+++ b/src/librustdoc/html/render/context.rs
@@ -183,8 +183,8 @@ impl<'tcx> Context<'tcx> {
         };
         title.push_str(" - Rust");
         let tyname = it.type_();
-        let desc = it.doc_value().as_ref().map(|doc| plain_text_summary(doc));
-        let desc = if let Some(desc) = desc {
+        let desc = plain_text_summary(&it.doc_value());
+        let desc = if !desc.is_empty() {
             desc
         } else if it.is_crate() {
             format!("API documentation for the Rust `{}` crate.", self.shared.layout.krate)
@@ -265,10 +265,9 @@ impl<'tcx> Context<'tcx> {
                 Some(ref s) => s.to_string(),
             };
             let short = short.to_string();
-            map.entry(short).or_default().push((
-                myname,
-                Some(item.doc_value().map_or_else(String::new, |s| plain_text_summary(&s))),
-            ));
+            map.entry(short)
+                .or_default()
+                .push((myname, Some(plain_text_summary(&item.doc_value()))));
         }
 
         if self.shared.sort_modules_alphabetically {

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -567,7 +567,7 @@ fn document_full_inner(
     is_collapsible: bool,
     heading_offset: HeadingOffset,
 ) {
-    if let Some(s) = cx.shared.maybe_collapsed_doc_value(item) {
+    if let Some(s) = item.collapsed_doc_value() {
         debug!("Doc block: =====\n{}\n=====", s);
         if is_collapsible {
             w.write_str(
@@ -1612,7 +1612,7 @@ fn render_impl(
             write!(w, "</summary>")
         }
 
-        if let Some(ref dox) = cx.shared.maybe_collapsed_doc_value(&i.impl_item) {
+        if let Some(ref dox) = i.impl_item.collapsed_doc_value() {
             let mut ids = cx.id_map.borrow_mut();
             write!(
                 w,

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -525,10 +525,11 @@ fn document_short(
     if !show_def_docs {
         return;
     }
-    if let Some(s) = item.doc_value() {
-        let mut summary_html = MarkdownSummaryLine(&s, &item.links(cx)).into_string();
+    let dox = &item.doc_value();
+    if !dox.is_empty() {
+        let mut summary_html = MarkdownSummaryLine(dox, &item.links(cx)).into_string();
 
-        if s.contains('\n') {
+        if dox.contains('\n') {
             let link = format!(r#" <a href="{}">Read more</a>"#, naive_assoc_href(item, link, cx));
 
             if let Some(idx) = summary_html.rfind("</p>") {
@@ -1363,7 +1364,7 @@ fn render_impl(
                     if let Some(it) = t.items.iter().find(|i| i.name == item.name) {
                         // We need the stability of the item from the trait
                         // because impls can't have a stability.
-                        if item.doc_value().is_some() {
+                        if !item.doc_value().is_empty() {
                             document_item_info(&mut info_buffer, cx, it, Some(parent));
                             document_full(&mut doc_buffer, item, cx, HeadingOffset::H5);
                             short_documented = false;

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -388,7 +388,7 @@ fn item_module(w: &mut Buffer, cx: &Context<'_>, item: &clean::Item, items: &[cl
                 let stab = myitem.stability_class(cx.tcx());
                 let add = if stab.is_some() { " " } else { "" };
 
-                let doc_value = myitem.doc_value().unwrap_or_default();
+                let doc_value = myitem.doc_value();
                 w.write_str(ITEM_TABLE_ROW_OPEN);
                 write!(
                     w,


### PR DESCRIPTION
Very few places actually need to special case this, and those that do can use `.is_empty()` instead.

Note that both `plain_text_summary` and `short_markdown_summary()` already special case empty
strings, so this is still taking the fast path for those docs.

This is similar to https://github.com/rust-lang/rust/pull/92078, but for `doc_value` instead of `collapsed_doc_value`. Builds on https://github.com/rust-lang/rust/pull/92077.

r? @camelid cc @GuillaumeGomez https://github.com/rust-lang/rust/pull/91072#discussion_r771843923