### PR TITLE
Move `PatKind::Lit` checking from ast_validation to ast lowering

### DIFF
--- a/src/test/ui/match/expr_before_ident_pat.stderr
+++ b/src/test/ui/match/expr_before_ident_pat.stderr
@@ -1,14 +1,14 @@
-error: arbitrary expressions aren't allowed in patterns
-  --> $DIR/expr_before_ident_pat.rs:12:12
-   |
-LL |     funny!(a, a);
-   |            ^
-
 error[E0425]: cannot find value `a` in this scope
   --> $DIR/expr_before_ident_pat.rs:12:12
    |
 LL |     funny!(a, a);
    |            ^ not found in this scope
+
+error: arbitrary expressions aren't allowed in patterns
+  --> $DIR/expr_before_ident_pat.rs:12:12
+   |
+LL |     funny!(a, a);
+   |            ^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/pattern/issue-92074-macro-ice.rs
+++ b/src/test/ui/pattern/issue-92074-macro-ice.rs
@@ -1,0 +1,36 @@
+pub enum En {
+    A(Vec<u8>)
+}
+
+fn get_usize() -> usize {
+    0
+}
+
+macro_rules! force_expr {
+    ($e:expr) => { $e }
+}
+
+macro_rules! force_pat {
+    ($a:expr, $b:expr) => { $a..=$b }
+}
+
+macro_rules! make_vec {
+    () => { force_expr!(Vec::new()) } //~ ERROR arbitrary expressions aren't allowed
+}
+
+macro_rules! make_pat {
+    () => { force_pat!(get_usize(), get_usize()) }
+    //~^ ERROR arbitrary expressions aren't allowed
+    //~| ERROR arbitrary expressions aren't allowed
+}
+
+#[allow(unreachable_code)]
+fn f() -> Result<(), impl core::fmt::Debug> {
+    let x: En = loop {};
+
+    assert!(matches!(x, En::A(make_vec!())));
+    assert!(matches!(5, make_pat!()));
+    Ok::<(), &'static str>(())
+}
+
+fn main() {}

--- a/src/test/ui/pattern/issue-92074-macro-ice.stderr
+++ b/src/test/ui/pattern/issue-92074-macro-ice.stderr
@@ -1,0 +1,35 @@
+error: arbitrary expressions aren't allowed in patterns
+  --> $DIR/issue-92074-macro-ice.rs:18:25
+   |
+LL |     () => { force_expr!(Vec::new()) }
+   |                         ^^^^^^^^^^
+...
+LL |     assert!(matches!(x, En::A(make_vec!())));
+   |                               ----------- in this macro invocation
+   |
+   = note: this error originates in the macro `make_vec` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: arbitrary expressions aren't allowed in patterns
+  --> $DIR/issue-92074-macro-ice.rs:22:24
+   |
+LL |     () => { force_pat!(get_usize(), get_usize()) }
+   |                        ^^^^^^^^^^^
+...
+LL |     assert!(matches!(5, make_pat!()));
+   |                         ----------- in this macro invocation
+   |
+   = note: this error originates in the macro `make_pat` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: arbitrary expressions aren't allowed in patterns
+  --> $DIR/issue-92074-macro-ice.rs:22:37
+   |
+LL |     () => { force_pat!(get_usize(), get_usize()) }
+   |                                     ^^^^^^^^^^^
+...
+LL |     assert!(matches!(5, make_pat!()));
+   |                         ----------- in this macro invocation
+   |
+   = note: this error originates in the macro `make_pat` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 3 previous errors
+


### PR DESCRIPTION
Fixes #92074

This allows us to insert an `ExprKind::Err` when an invalid expression
is used in a literal pattern, preventing later stages of compilation
from seeing an unexpected literal pattern.