### PR TITLE
rustdoc: Remove unnecessary `need_backline` function

### DIFF
--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -1033,12 +1033,6 @@ impl Attributes {
     ) -> Attributes {
         let mut doc_strings: Vec<DocFragment> = vec![];
 
-        fn update_need_backline(doc_strings: &mut Vec<DocFragment>) {
-            if let Some(prev) = doc_strings.last_mut() {
-                prev.need_backline = true;
-            }
-        }
-
         let clean_attr = |(attr, parent_module): (&ast::Attribute, Option<DefId>)| {
             if let Some(value) = attr.doc_str() {
                 trace!("got doc_str={:?}", value);
@@ -1058,7 +1052,9 @@ impl Attributes {
                     indent: 0,
                 };
 
-                update_need_backline(&mut doc_strings);
+                if let Some(prev) = doc_strings.last_mut() {
+                    prev.need_backline = true;
+                }
 
                 doc_strings.push(frag);
 


### PR DESCRIPTION
r? @GuillaumeGomez 