### PR TITLE
rustdoc: Write doc-comments directly instead of using FromIterator

### DIFF
--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -1,7 +1,6 @@
 use std::cell::RefCell;
 use std::default::Default;
 use std::hash::{Hash, Hasher};
-use std::iter::FromIterator;
 use std::lazy::SyncOnceCell as OnceCell;
 use std::path::PathBuf;
 use std::rc::Rc;
@@ -958,16 +957,14 @@ fn add_doc_fragment(out: &mut String, frag: &DocFragment) {
     }
 }
 
-impl<'a> FromIterator<&'a DocFragment> for String {
-    fn from_iter<T>(iter: T) -> Self
-    where
-        T: IntoIterator<Item = &'a DocFragment>,
-    {
-        iter.into_iter().fold(String::new(), |mut acc, frag| {
-            add_doc_fragment(&mut acc, frag);
-            acc
-        })
+/// Collapse a collection of [`DocFragment`]s into one string,
+/// handling indentation and newlines as needed.
+crate fn collapse_doc_fragments(doc_strings: &[DocFragment]) -> String {
+    let mut acc = String::new();
+    for frag in doc_strings {
+        add_doc_fragment(&mut acc, frag);
     }
+    acc
 }
 
 /// A link that has not yet been rendered.
@@ -1113,7 +1110,11 @@ impl Attributes {
     /// Finds all `doc` attributes as NameValues and returns their corresponding values, joined
     /// with newlines.
     crate fn collapsed_doc_value(&self) -> Option<String> {
-        if self.doc_strings.is_empty() { None } else { Some(self.doc_strings.iter().collect()) }
+        if self.doc_strings.is_empty() {
+            None
+        } else {
+            Some(collapse_doc_fragments(&self.doc_strings))
+        }
     }
 
     crate fn get_doc_aliases(&self) -> Box<[Symbol]> {

--- a/src/librustdoc/passes/unindent_comments/tests.rs
+++ b/src/librustdoc/passes/unindent_comments/tests.rs
@@ -1,4 +1,7 @@
 use super::*;
+
+use crate::clean::collapse_doc_fragments;
+
 use rustc_span::create_default_session_globals_then;
 use rustc_span::source_map::DUMMY_SP;
 use rustc_span::symbol::Symbol;
@@ -19,7 +22,7 @@ fn run_test(input: &str, expected: &str) {
     create_default_session_globals_then(|| {
         let mut s = create_doc_fragment(input);
         unindent_fragments(&mut s);
-        assert_eq!(&s.iter().collect::<String>(), expected);
+        assert_eq!(collapse_doc_fragments(&s), expected);
     });
 }
 


### PR DESCRIPTION
The FromIterator impl made the code much harder to understand. The types
don't make sense until you realize there's a custom FromIterator impl.

This is the first commit from https://github.com/rust-lang/rust/pull/91305; since @camelid wrote it originally I don't feel bad unilaterally approving it.

r? @ghost
@bors r+

Note that this will conflict with https://github.com/rust-lang/rust/pull/92078.