### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/compiler/rustc_incremental/src/assert_dep_graph.rs
+++ b/compiler/rustc_incremental/src/assert_dep_graph.rs
@@ -103,7 +103,7 @@ struct IfThisChanged<'tcx> {
     then_this_would_need: Targets,
 }
 
-impl IfThisChanged<'tcx> {
+impl<'tcx> IfThisChanged<'tcx> {
     fn argument(&self, attr: &ast::Attribute) -> Option<Symbol> {
         let mut value = None;
         for list_item in attr.meta_item_list().unwrap_or_default() {
@@ -172,7 +172,7 @@ impl IfThisChanged<'tcx> {
     }
 }
 
-impl Visitor<'tcx> for IfThisChanged<'tcx> {
+impl<'tcx> Visitor<'tcx> for IfThisChanged<'tcx> {
     type Map = Map<'tcx>;
 
     fn nested_visit_map(&mut self) -> NestedVisitorMap<Self::Map> {

--- a/compiler/rustc_incremental/src/assert_module_sources.rs
+++ b/compiler/rustc_incremental/src/assert_module_sources.rs
@@ -56,7 +56,7 @@ struct AssertModuleSource<'tcx> {
     available_cgus: BTreeSet<String>,
 }
 
-impl AssertModuleSource<'tcx> {
+impl<'tcx> AssertModuleSource<'tcx> {
     fn check_attr(&self, attr: &ast::Attribute) {
         let (expected_reuse, comp_kind) = if attr.has_name(sym::rustc_partition_reused) {
             (CguReuse::PreLto, ComparisonKind::AtLeast)

--- a/compiler/rustc_incremental/src/lib.rs
+++ b/compiler/rustc_incremental/src/lib.rs
@@ -2,7 +2,6 @@
 
 #![deny(missing_docs)]
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
-#![feature(in_band_lifetimes)]
 #![feature(let_else)]
 #![feature(nll)]
 #![recursion_limit = "256"]

--- a/compiler/rustc_incremental/src/persist/dirty_clean.rs
+++ b/compiler/rustc_incremental/src/persist/dirty_clean.rs
@@ -155,7 +155,7 @@ pub struct DirtyCleanVisitor<'tcx> {
     checked_attrs: FxHashSet<ast::AttrId>,
 }
 
-impl DirtyCleanVisitor<'tcx> {
+impl<'tcx> DirtyCleanVisitor<'tcx> {
     /// Possibly "deserialize" the attribute into a clean/dirty assertion
     fn assertion_maybe(&mut self, item_id: LocalDefId, attr: &Attribute) -> Option<Assertion> {
         if !attr.has_name(sym::rustc_clean) {
@@ -352,7 +352,7 @@ impl DirtyCleanVisitor<'tcx> {
     }
 }
 
-impl ItemLikeVisitor<'tcx> for DirtyCleanVisitor<'tcx> {
+impl<'tcx> ItemLikeVisitor<'tcx> for DirtyCleanVisitor<'tcx> {
     fn visit_item(&mut self, item: &'tcx hir::Item<'tcx>) {
         self.check_item(item.def_id, item.span);
     }
@@ -415,7 +415,7 @@ pub struct FindAllAttrs<'tcx> {
     found_attrs: Vec<&'tcx Attribute>,
 }
 
-impl FindAllAttrs<'tcx> {
+impl<'tcx> FindAllAttrs<'tcx> {
     fn is_active_attr(&mut self, attr: &Attribute) -> bool {
         if attr.has_name(sym::rustc_clean) && check_config(self.tcx, attr) {
             return true;
@@ -434,7 +434,7 @@ impl FindAllAttrs<'tcx> {
     }
 }
 
-impl intravisit::Visitor<'tcx> for FindAllAttrs<'tcx> {
+impl<'tcx> intravisit::Visitor<'tcx> for FindAllAttrs<'tcx> {
     type Map = Map<'tcx>;
 
     fn nested_visit_map(&mut self) -> intravisit::NestedVisitorMap<Self::Map> {

--- a/crates/core_simd/src/masks/bitmask.rs
+++ b/crates/core_simd/src/masks/bitmask.rs
@@ -105,18 +105,14 @@ where
     #[must_use = "method returns a new vector and does not mutate the original value"]
     pub fn to_int(self) -> Simd<T, LANES> {
         unsafe {
-            crate::intrinsics::simd_select_bitmask(
-                self.0,
-                Simd::splat(T::TRUE),
-                Simd::splat(T::FALSE),
-            )
+            intrinsics::simd_select_bitmask(self.0, Simd::splat(T::TRUE), Simd::splat(T::FALSE))
         }
     }
 
     #[inline]
     #[must_use = "method returns a new mask and does not mutate the original value"]
     pub unsafe fn from_int_unchecked(value: Simd<T, LANES>) -> Self {
-        unsafe { Self(crate::intrinsics::simd_bitmask(value), PhantomData) }
+        unsafe { Self(intrinsics::simd_bitmask(value), PhantomData) }
     }
 
     #[cfg(feature = "generic_const_exprs")]

--- a/crates/core_simd/src/masks/full_masks.rs
+++ b/crates/core_simd/src/masks/full_masks.rs
@@ -115,7 +115,7 @@ where
     pub fn to_bitmask(self) -> [u8; LaneCount::<LANES>::BITMASK_LEN] {
         unsafe {
             let mut bitmask: [u8; LaneCount::<LANES>::BITMASK_LEN] =
-                crate::intrinsics::simd_bitmask(self.0);
+                intrinsics::simd_bitmask(self.0);
 
             // There is a bug where LLVM appears to implement this operation with the wrong
             // bit order.
@@ -144,7 +144,7 @@ where
                 }
             }
 
-            Self::from_int_unchecked(crate::intrinsics::simd_select_bitmask(
+            Self::from_int_unchecked(intrinsics::simd_select_bitmask(
                 bitmask,
                 Self::splat(true).to_int(),
                 Self::splat(false).to_int(),

--- a/crates/core_simd/src/mod.rs
+++ b/crates/core_simd/src/mod.rs
@@ -27,7 +27,6 @@ pub mod simd {
 
     pub use crate::core_simd::lane_count::{LaneCount, SupportedLaneCount};
     pub use crate::core_simd::masks::*;
-    pub use crate::core_simd::select::Select;
     pub use crate::core_simd::swizzle::*;
     pub use crate::core_simd::vector::*;
 }

--- a/library/core/src/mem/maybe_uninit.rs
+++ b/library/core/src/mem/maybe_uninit.rs
@@ -972,8 +972,8 @@ impl<T> MaybeUninit<T> {
     #[rustc_const_unstable(feature = "maybe_uninit_slice", issue = "63569")]
     #[inline(always)]
     pub const unsafe fn slice_assume_init_ref(slice: &[Self]) -> &[T] {
-        // SAFETY: casting slice to a `*const [T]` is safe since the caller guarantees that
-        // `slice` is initialized, and`MaybeUninit` is guaranteed to have the same layout as `T`.
+        // SAFETY: casting `slice` to a `*const [T]` is safe since the caller guarantees that
+        // `slice` is initialized, and `MaybeUninit` is guaranteed to have the same layout as `T`.
         // The pointer obtained is valid since it refers to memory owned by `slice` which is a
         // reference and thus guaranteed to be valid for reads.
         unsafe { &*(slice as *const [Self] as *const [T]) }

--- a/library/core/src/stream/stream.rs
+++ b/library/core/src/stream/stream.rs
@@ -95,13 +95,13 @@ impl<S: ?Sized + Stream + Unpin> Stream for &mut S {
 #[unstable(feature = "async_stream", issue = "79024")]
 impl<P> Stream for Pin<P>
 where
-    P: DerefMut + Unpin,
+    P: DerefMut,
     P::Target: Stream,
 {
     type Item = <P::Target as Stream>::Item;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        self.get_mut().as_mut().poll_next(cx)
+        <P::Target as Stream>::poll_next(self.as_deref_mut(), cx)
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -1,7 +1,6 @@
 use std::cell::RefCell;
 use std::default::Default;
 use std::hash::{Hash, Hasher};
-use std::iter::FromIterator;
 use std::lazy::SyncOnceCell as OnceCell;
 use std::path::PathBuf;
 use std::rc::Rc;
@@ -958,16 +957,14 @@ fn add_doc_fragment(out: &mut String, frag: &DocFragment) {
     }
 }
 
-impl<'a> FromIterator<&'a DocFragment> for String {
-    fn from_iter<T>(iter: T) -> Self
-    where
-        T: IntoIterator<Item = &'a DocFragment>,
-    {
-        iter.into_iter().fold(String::new(), |mut acc, frag| {
-            add_doc_fragment(&mut acc, frag);
-            acc
-        })
+/// Collapse a collection of [`DocFragment`]s into one string,
+/// handling indentation and newlines as needed.
+crate fn collapse_doc_fragments(doc_strings: &[DocFragment]) -> String {
+    let mut acc = String::new();
+    for frag in doc_strings {
+        add_doc_fragment(&mut acc, frag);
     }
+    acc
 }
 
 /// A link that has not yet been rendered.
@@ -1113,7 +1110,11 @@ impl Attributes {
     /// Finds all `doc` attributes as NameValues and returns their corresponding values, joined
     /// with newlines.
     crate fn collapsed_doc_value(&self) -> Option<String> {
-        if self.doc_strings.is_empty() { None } else { Some(self.doc_strings.iter().collect()) }
+        if self.doc_strings.is_empty() {
+            None
+        } else {
+            Some(collapse_doc_fragments(&self.doc_strings))
+        }
     }
 
     crate fn get_doc_aliases(&self) -> Box<[Symbol]> {

--- a/src/librustdoc/passes/unindent_comments/tests.rs
+++ b/src/librustdoc/passes/unindent_comments/tests.rs
@@ -1,4 +1,7 @@
 use super::*;
+
+use crate::clean::collapse_doc_fragments;
+
 use rustc_span::create_default_session_globals_then;
 use rustc_span::source_map::DUMMY_SP;
 use rustc_span::symbol::Symbol;
@@ -19,7 +22,7 @@ fn run_test(input: &str, expected: &str) {
     create_default_session_globals_then(|| {
         let mut s = create_doc_fragment(input);
         unindent_fragments(&mut s);
-        assert_eq!(&s.iter().collect::<String>(), expected);
+        assert_eq!(collapse_doc_fragments(&s), expected);
     });
 }
 

--- a/src/test/ui/panics/location-detail-panic-no-column.rs
+++ b/src/test/ui/panics/location-detail-panic-no-column.rs
@@ -1,6 +1,7 @@
 // run-fail
 // check-run-results
 // compile-flags: -Zlocation-detail=line,file
+// exec-env:RUST_BACKTRACE=0
 
 fn main() {
     panic!("column-redacted");

--- a/src/test/ui/panics/location-detail-panic-no-column.run.stderr
+++ b/src/test/ui/panics/location-detail-panic-no-column.run.stderr
@@ -1,2 +1,2 @@
-thread 'main' panicked at 'column-redacted', $DIR/location-detail-panic-no-column.rs:6:0
+thread 'main' panicked at 'column-redacted', $DIR/location-detail-panic-no-column.rs:7:0
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

--- a/src/test/ui/panics/location-detail-panic-no-file.rs
+++ b/src/test/ui/panics/location-detail-panic-no-file.rs
@@ -1,6 +1,7 @@
 // run-fail
 // check-run-results
 // compile-flags: -Zlocation-detail=line,column
+// exec-env:RUST_BACKTRACE=0
 
 fn main() {
     panic!("file-redacted");

--- a/src/test/ui/panics/location-detail-panic-no-file.run.stderr
+++ b/src/test/ui/panics/location-detail-panic-no-file.run.stderr
@@ -1,2 +1,2 @@
-thread 'main' panicked at 'file-redacted', <redacted>:6:5
+thread 'main' panicked at 'file-redacted', <redacted>:7:5
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

--- a/src/test/ui/panics/location-detail-panic-no-line.rs
+++ b/src/test/ui/panics/location-detail-panic-no-line.rs
@@ -1,6 +1,7 @@
 // run-fail
 // check-run-results
 // compile-flags: -Zlocation-detail=file,column
+// exec-env:RUST_BACKTRACE=0
 
 fn main() {
     panic!("line-redacted");

--- a/src/test/ui/panics/location-detail-unwrap-no-file.rs
+++ b/src/test/ui/panics/location-detail-unwrap-no-file.rs
@@ -1,6 +1,7 @@
 // run-fail
 // check-run-results
 // compile-flags: -Zlocation-detail=line,column
+// exec-env:RUST_BACKTRACE=0
 
 fn main() {
     let opt: Option<u32> = None;

--- a/src/test/ui/panics/location-detail-unwrap-no-file.run.stderr
+++ b/src/test/ui/panics/location-detail-unwrap-no-file.run.stderr
@@ -1,2 +1,2 @@
-thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', <redacted>:7:9
+thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', <redacted>:8:9
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


### PR DESCRIPTION
Successful merges:

 - #91894 (Remove `in_band_lifetimes` from `rustc_incremental`)
 - #92020 (Remove P: Unpin bound on impl Stream for Pin)
 - #92028 (Sync portable-simd to fix libcore build for AVX-512 enabled targets)
 - #92047 (Set `RUST_BACKTRACE=0` when running location-detail tests)
 - #92050 (Add a space and 2 grave accents )
 - #92082 (rustdoc: Write doc-comments directly instead of using FromIterator)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=91894,92020,92028,92047,92050,92082)
<!-- homu-ignore:end -->