### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/compiler/rustc_incremental/src/assert_dep_graph.rs
+++ b/compiler/rustc_incremental/src/assert_dep_graph.rs
@@ -103,7 +103,7 @@ struct IfThisChanged<'tcx> {
     then_this_would_need: Targets,
 }
 
-impl IfThisChanged<'tcx> {
+impl<'tcx> IfThisChanged<'tcx> {
     fn argument(&self, attr: &ast::Attribute) -> Option<Symbol> {
         let mut value = None;
         for list_item in attr.meta_item_list().unwrap_or_default() {
@@ -172,7 +172,7 @@ impl IfThisChanged<'tcx> {
     }
 }
 
-impl Visitor<'tcx> for IfThisChanged<'tcx> {
+impl<'tcx> Visitor<'tcx> for IfThisChanged<'tcx> {
     type Map = Map<'tcx>;
 
     fn nested_visit_map(&mut self) -> NestedVisitorMap<Self::Map> {

--- a/compiler/rustc_incremental/src/assert_module_sources.rs
+++ b/compiler/rustc_incremental/src/assert_module_sources.rs
@@ -56,7 +56,7 @@ struct AssertModuleSource<'tcx> {
     available_cgus: BTreeSet<String>,
 }
 
-impl AssertModuleSource<'tcx> {
+impl<'tcx> AssertModuleSource<'tcx> {
     fn check_attr(&self, attr: &ast::Attribute) {
         let (expected_reuse, comp_kind) = if attr.has_name(sym::rustc_partition_reused) {
             (CguReuse::PreLto, ComparisonKind::AtLeast)

--- a/compiler/rustc_incremental/src/lib.rs
+++ b/compiler/rustc_incremental/src/lib.rs
@@ -2,7 +2,6 @@
 
 #![deny(missing_docs)]
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
-#![feature(in_band_lifetimes)]
 #![feature(let_else)]
 #![feature(nll)]
 #![recursion_limit = "256"]

--- a/compiler/rustc_incremental/src/persist/dirty_clean.rs
+++ b/compiler/rustc_incremental/src/persist/dirty_clean.rs
@@ -155,7 +155,7 @@ pub struct DirtyCleanVisitor<'tcx> {
     checked_attrs: FxHashSet<ast::AttrId>,
 }
 
-impl DirtyCleanVisitor<'tcx> {
+impl<'tcx> DirtyCleanVisitor<'tcx> {
     /// Possibly "deserialize" the attribute into a clean/dirty assertion
     fn assertion_maybe(&mut self, item_id: LocalDefId, attr: &Attribute) -> Option<Assertion> {
         if !attr.has_name(sym::rustc_clean) {
@@ -352,7 +352,7 @@ impl DirtyCleanVisitor<'tcx> {
     }
 }
 
-impl ItemLikeVisitor<'tcx> for DirtyCleanVisitor<'tcx> {
+impl<'tcx> ItemLikeVisitor<'tcx> for DirtyCleanVisitor<'tcx> {
     fn visit_item(&mut self, item: &'tcx hir::Item<'tcx>) {
         self.check_item(item.def_id, item.span);
     }
@@ -415,7 +415,7 @@ pub struct FindAllAttrs<'tcx> {
     found_attrs: Vec<&'tcx Attribute>,
 }
 
-impl FindAllAttrs<'tcx> {
+impl<'tcx> FindAllAttrs<'tcx> {
     fn is_active_attr(&mut self, attr: &Attribute) -> bool {
         if attr.has_name(sym::rustc_clean) && check_config(self.tcx, attr) {
             return true;
@@ -434,7 +434,7 @@ impl FindAllAttrs<'tcx> {
     }
 }
 
-impl intravisit::Visitor<'tcx> for FindAllAttrs<'tcx> {
+impl<'tcx> intravisit::Visitor<'tcx> for FindAllAttrs<'tcx> {
     type Map = Map<'tcx>;
 
     fn nested_visit_map(&mut self) -> intravisit::NestedVisitorMap<Self::Map> {

--- a/compiler/rustc_lint/src/unused.rs
+++ b/compiler/rustc_lint/src/unused.rs
@@ -479,7 +479,7 @@ trait UnusedDelimLint {
                 && match &inner.kind {
                     ExprKind::Ret(_) | ExprKind::Break(..) | ExprKind::Yield(..) => true,
                     ExprKind::Range(_lhs, Some(rhs), _limits) => {
-                        !classify::expr_requires_semi_to_be_stmt(&rhs)
+                        matches!(rhs.kind, ExprKind::Block(..))
                     }
                     _ => parser::contains_exterior_struct_lit(&inner),
                 })

--- a/compiler/rustc_lint/src/unused.rs
+++ b/compiler/rustc_lint/src/unused.rs
@@ -476,8 +476,11 @@ trait UnusedDelimLint {
 
         lhs_needs_parens
             || (followed_by_block
-                && match inner.kind {
+                && match &inner.kind {
                     ExprKind::Ret(_) | ExprKind::Break(..) | ExprKind::Yield(..) => true,
+                    ExprKind::Range(_lhs, Some(rhs), _limits) => {
+                        !classify::expr_requires_semi_to_be_stmt(&rhs)
+                    }
                     _ => parser::contains_exterior_struct_lit(&inner),
                 })
     }

--- a/compiler/rustc_middle/src/ty/layout.rs
+++ b/compiler/rustc_middle/src/ty/layout.rs
@@ -347,10 +347,6 @@ impl<'tcx> LayoutCx<'tcx, TyCtxt<'tcx>> {
 
         let mut inverse_memory_index: Vec<u32> = (0..fields.len() as u32).collect();
 
-        // `ReprOptions.layout_seed` is a deterministic seed that we can use to
-        // randomize field ordering with
-        let mut rng = Xoshiro128StarStar::seed_from_u64(repr.field_shuffle_seed);
-
         let optimize = !repr.inhibit_struct_field_reordering_opt();
         if optimize {
             let end =
@@ -364,6 +360,10 @@ impl<'tcx> LayoutCx<'tcx, TyCtxt<'tcx>> {
             // the field ordering to try and catch some code making assumptions about layouts
             // we don't guarantee
             if repr.can_randomize_type_layout() {
+                // `ReprOptions.layout_seed` is a deterministic seed that we can use to
+                // randomize field ordering with
+                let mut rng = Xoshiro128StarStar::seed_from_u64(repr.field_shuffle_seed);
+
                 // Shuffle the ordering of the fields
                 optimizing.shuffle(&mut rng);
 

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -1608,9 +1608,9 @@ bitflags! {
         // the seed stored in `ReprOptions.layout_seed`
         const RANDOMIZE_LAYOUT   = 1 << 5;
         // Any of these flags being set prevent field reordering optimisation.
-        const IS_UNOPTIMISABLE   = ReprFlags::IS_C.bits |
-                                   ReprFlags::IS_SIMD.bits |
-                                   ReprFlags::IS_LINEAR.bits;
+        const IS_UNOPTIMISABLE   = ReprFlags::IS_C.bits
+                                 | ReprFlags::IS_SIMD.bits
+                                 | ReprFlags::IS_LINEAR.bits;
     }
 }
 

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -1321,6 +1321,8 @@ options! {
         "print some statistics about the query system (default: no)"),
     randomize_layout: bool = (false, parse_bool, [TRACKED],
         "randomize the layout of types (default: no)"),
+    layout_seed: Option<u64> = (None, parse_opt_number, [TRACKED],
+        "seed layout randomization"),
     relax_elf_relocations: Option<bool> = (None, parse_opt_bool, [TRACKED],
         "whether ELF relocations can be relaxed"),
     relro_level: Option<RelroLevel> = (None, parse_relro_level, [TRACKED],

--- a/library/alloc/src/borrow.rs
+++ b/library/alloc/src/borrow.rs
@@ -170,7 +170,7 @@ where
 /// clone_on_write.values.to_mut().push(3);
 /// println!("clone_on_write = {:?}", clone_on_write.values);
 ///
-/// // The data was mutated. Let check it out.
+/// // The data was mutated. Let's check it out.
 /// match clone_on_write {
 ///     Items { values: Cow::Owned(_) } => println!("clone_on_write contains owned data"),
 ///     _ => panic!("expect owned data"),

--- a/library/core/src/stream/stream.rs
+++ b/library/core/src/stream/stream.rs
@@ -95,13 +95,13 @@ impl<S: ?Sized + Stream + Unpin> Stream for &mut S {
 #[unstable(feature = "async_stream", issue = "79024")]
 impl<P> Stream for Pin<P>
 where
-    P: DerefMut + Unpin,
+    P: DerefMut,
     P::Target: Stream,
 {
     type Item = <P::Target as Stream>::Item;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        self.get_mut().as_mut().poll_next(cx)
+        <P::Target as Stream>::poll_next(self.as_deref_mut(), cx)
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {

--- a/src/ci/docker/host-x86_64/x86_64-gnu-tools/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-tools/Dockerfile
@@ -72,7 +72,7 @@ ENV PATH="/node-v14.4.0-linux-x64/bin:${PATH}"
 # https://github.com/puppeteer/puppeteer/issues/375
 #
 # We also specify the version in case we need to update it to go around cache limitations.
-RUN npm install -g browser-ui-test@0.5.0 --unsafe-perm=true
+RUN npm install -g browser-ui-test@0.5.1 --unsafe-perm=true
 
 ENV RUST_CONFIGURE_ARGS \
   --build=x86_64-unknown-linux-gnu \

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -1,7 +1,6 @@
 use std::cell::RefCell;
 use std::default::Default;
 use std::hash::{Hash, Hasher};
-use std::iter::FromIterator;
 use std::lazy::SyncOnceCell as OnceCell;
 use std::path::PathBuf;
 use std::rc::Rc;
@@ -958,16 +957,14 @@ fn add_doc_fragment(out: &mut String, frag: &DocFragment) {
     }
 }
 
-impl<'a> FromIterator<&'a DocFragment> for String {
-    fn from_iter<T>(iter: T) -> Self
-    where
-        T: IntoIterator<Item = &'a DocFragment>,
-    {
-        iter.into_iter().fold(String::new(), |mut acc, frag| {
-            add_doc_fragment(&mut acc, frag);
-            acc
-        })
+/// Collapse a collection of [`DocFragment`]s into one string,
+/// handling indentation and newlines as needed.
+crate fn collapse_doc_fragments(doc_strings: &[DocFragment]) -> String {
+    let mut acc = String::new();
+    for frag in doc_strings {
+        add_doc_fragment(&mut acc, frag);
     }
+    acc
 }
 
 /// A link that has not yet been rendered.
@@ -1113,7 +1110,11 @@ impl Attributes {
     /// Finds all `doc` attributes as NameValues and returns their corresponding values, joined
     /// with newlines.
     crate fn collapsed_doc_value(&self) -> Option<String> {
-        if self.doc_strings.is_empty() { None } else { Some(self.doc_strings.iter().collect()) }
+        if self.doc_strings.is_empty() {
+            None
+        } else {
+            Some(collapse_doc_fragments(&self.doc_strings))
+        }
     }
 
     crate fn get_doc_aliases(&self) -> Box<[Symbol]> {

--- a/src/librustdoc/passes/unindent_comments/tests.rs
+++ b/src/librustdoc/passes/unindent_comments/tests.rs
@@ -1,4 +1,7 @@
 use super::*;
+
+use crate::clean::collapse_doc_fragments;
+
 use rustc_span::create_default_session_globals_then;
 use rustc_span::source_map::DUMMY_SP;
 use rustc_span::symbol::Symbol;
@@ -19,7 +22,7 @@ fn run_test(input: &str, expected: &str) {
     create_default_session_globals_then(|| {
         let mut s = create_doc_fragment(input);
         unindent_fragments(&mut s);
-        assert_eq!(&s.iter().collect::<String>(), expected);
+        assert_eq!(collapse_doc_fragments(&s), expected);
     });
 }
 

--- a/src/test/rustdoc-gui/anchors.goml
+++ b/src/test/rustdoc-gui/anchors.goml
@@ -34,7 +34,7 @@ assert-css: ("#impl a.anchor", {"color": "rgb(0, 0, 0)"})
 move-cursor-to: ".top-doc .docblock .section-header:first-child"
 assert-css: (
     ".top-doc .docblock .section-header:first-child > a::before",
-    {"left": "-10px", "padding-right": "10px"}
+    {"left": "-10px", "padding-right": "10px"},
 )
 // We also check that the heading itself has a different indent.
 assert-css: (".top-doc .docblock .section-header:first-child", {"margin-left": "15px"})
@@ -42,7 +42,7 @@ assert-css: (".top-doc .docblock .section-header:first-child", {"margin-left": "
 move-cursor-to: ".top-doc .docblock .section-header:not(:first-child)"
 assert-css: (
     ".top-doc .docblock .section-header:not(:first-child) > a::before",
-    {"left": "-25px", "padding-right": "10px"}
+    {"left": "-25px", "padding-right": "10px"},
 )
 assert-css: (".top-doc .docblock .section-header:not(:first-child)", {"margin-left": "0px"})
 
@@ -51,14 +51,14 @@ assert-css: (".top-doc .docblock .section-header:not(:first-child)", {"margin-le
 move-cursor-to: "#title-for-struct-impl-doc"
 assert-css: (
     "#title-for-struct-impl-doc > a::before",
-    {"left": "-25px", "padding-right": "10px"}
+    {"left": "-25px", "padding-right": "10px"},
 )
 assert-css: ("#title-for-struct-impl-doc", {"margin-left": "0px"})
 // Now a method docs.
 move-cursor-to: "#title-for-struct-impl-item-doc"
 assert-css: (
     "#title-for-struct-impl-item-doc > a::before",
-    {"left": "-25px", "padding-right": "10px"}
+    {"left": "-25px", "padding-right": "10px"},
 )
 assert-css: ("#title-for-struct-impl-item-doc", {"margin-left": "0px"})
 
@@ -69,6 +69,6 @@ goto: file://|DOC_PATH|/test_docs/enum.WhoLetTheDogOut.html
 move-cursor-to: ".top-doc .docblock .section-header"
 assert-css: (
     ".top-doc .docblock .section-header > a::before",
-    {"left": "-25px", "padding-right": "10px"}
+    {"left": "-25px", "padding-right": "10px"},
 )
 assert-css: (".top-doc .docblock .section-header", {"margin-left": "0px"})

--- a/src/test/rustdoc-gui/docblock-code-block-line-number.goml
+++ b/src/test/rustdoc-gui/docblock-code-block-line-number.goml
@@ -16,7 +16,7 @@ wait-for: "pre.line-number"
 assert-css: ("pre.line-number", {
     "margin": "0px",
     "padding": "13px 8px",
-    "text-align": "right"
+    "text-align": "right",
 })
 // The first code block has two lines so let's check its `<pre>` elements lists both of them.
 assert-text: ("pre.line-number", "1\n2")

--- a/src/test/rustdoc-gui/docblock-table-overflow.goml
+++ b/src/test/rustdoc-gui/docblock-table-overflow.goml
@@ -11,7 +11,11 @@ assert-property: (".top-doc .docblock table", {"scrollWidth": "1573"})
 // Checking it works on other doc blocks as well...
 
 // Logically, the ".docblock" and the "<p>" should have the same scroll width.
-compare-elements-property: ("#implementations + details .docblock", "#implementations + details .docblock > p", ["scrollWidth"])
+compare-elements-property: (
+    "#implementations + details .docblock",
+    "#implementations + details .docblock > p",
+    ["scrollWidth"],
+)
 assert-property: ("#implementations + details .docblock", {"scrollWidth": "816"})
 // However, since there is overflow in the <table>, its scroll width is bigger.
 assert-property: ("#implementations + details .docblock table", {"scrollWidth": "1573"})

--- a/src/test/rustdoc-gui/font-weight.goml
+++ b/src/test/rustdoc-gui/font-weight.goml
@@ -1,7 +1,10 @@
 goto: file://|DOC_PATH|/lib2/struct.Foo.html
 // This test checks that the font weight is correctly applied.
 assert-css: ("//*[@class='docblock item-decl']//a[text()='Alias']", {"font-weight": "400"})
-assert-css: ("//*[@class='structfield small-section-header']//a[text()='Alias']", {"font-weight": "400"})
+assert-css: (
+    "//*[@class='structfield small-section-header']//a[text()='Alias']",
+    {"font-weight": "400"},
+)
 assert-css: ("#method\.a_method > .code-header", {"font-weight": "600"})
 assert-css: ("#associatedtype\.X > .code-header", {"font-weight": "600"})
 assert-css: ("#associatedconstant\.Y > .code-header", {"font-weight": "600"})
@@ -25,8 +28,14 @@ goto: file://|DOC_PATH|/lib2/trait.Trait.html
 //
 // This uses '/parent::*' as a proxy for the style of the text node.
 // We can't just select the '<a>' because intermediate tags could be added.
-assert-count: ("//*[@class='docblock item-decl']/pre[@class='rust trait']/code/a[@class='constant']//text()/parent::*", 1)
-assert-css: ("//*[@class='docblock item-decl']/pre[@class='rust trait']/code/a[@class='constant']//text()/parent::*", {"font-weight": "400"})
+assert-count: (
+    "//*[@class='docblock item-decl']/pre[@class='rust trait']/code/a[@class='constant']//text()/parent::*",
+    1,
+)
+assert-css: (
+    "//*[@class='docblock item-decl']/pre[@class='rust trait']/code/a[@class='constant']//text()/parent::*",
+    {"font-weight": "400"},
+)
 
 assert-count: (".methods .type", 1)
 assert-css: (".methods .type", {"font-weight": "600"})

--- a/src/test/rustdoc-gui/headers-color.goml
+++ b/src/test/rustdoc-gui/headers-color.goml
@@ -5,33 +5,71 @@ goto: file://|DOC_PATH|/test_docs/struct.Foo.html
 show-text: true
 
 // Ayu theme
-local-storage: {"rustdoc-theme": "ayu", "rustdoc-preferred-dark-theme": "ayu", "rustdoc-use-system-theme": "false"}
+local-storage: {
+    "rustdoc-theme": "ayu",
+    "rustdoc-preferred-dark-theme": "ayu",
+    "rustdoc-use-system-theme": "false",
+}
 reload:
 
-assert-css: (".impl", {"color": "rgb(197, 197, 197)", "background-color": "rgba(0, 0, 0, 0)"}, ALL)
-assert-css: (".impl .code-header", {"color": "rgb(230, 225, 207)", "background-color": "rgb(15, 20, 25)"}, ALL)
+assert-css: (
+    ".impl",
+    {"color": "rgb(197, 197, 197)", "background-color": "rgba(0, 0, 0, 0)"},
+    ALL,
+)
+assert-css: (
+    ".impl .code-header",
+    {"color": "rgb(230, 225, 207)", "background-color": "rgb(15, 20, 25)"},
+    ALL,
+)
 
 goto: file://|DOC_PATH|/test_docs/struct.Foo.html#impl
-assert-css: ("#impl", {"color": "rgb(197, 197, 197)", "background-color": "rgba(255, 236, 164, 0.06)"})
+assert-css: (
+    "#impl",
+    {"color": "rgb(197, 197, 197)", "background-color": "rgba(255, 236, 164, 0.06)"},
+)
 
 goto: file://|DOC_PATH|/test_docs/struct.Foo.html#method.must_use
-assert-css: ("#method\.must_use", {"color": "rgb(197, 197, 197)", "background-color": "rgba(255, 236, 164, 0.06)"}, ALL)
+assert-css: (
+    "#method\.must_use",
+    {"color": "rgb(197, 197, 197)", "background-color": "rgba(255, 236, 164, 0.06)"},
+    ALL,
+)
 
 goto: file://|DOC_PATH|/test_docs/index.html
 assert-css: (".section-header a", {"color": "rgb(197, 197, 197)"}, ALL)
 
 // Dark theme
-local-storage: {"rustdoc-theme": "dark", "rustdoc-preferred-dark-theme": "dark", "rustdoc-use-system-theme": "false"}
+local-storage: {
+    "rustdoc-theme": "dark",
+    "rustdoc-preferred-dark-theme": "dark",
+    "rustdoc-use-system-theme": "false",
+}
 goto: file://|DOC_PATH|/test_docs/struct.Foo.html
 
-assert-css: (".impl", {"color": "rgb(221, 221, 221)", "background-color": "rgba(0, 0, 0, 0)"}, ALL)
-assert-css: (".impl .code-header", {"color": "rgb(221, 221, 221)", "background-color": "rgb(53, 53, 53)"}, ALL)
+assert-css: (
+    ".impl",
+    {"color": "rgb(221, 221, 221)", "background-color": "rgba(0, 0, 0, 0)"},
+    ALL,
+)
+assert-css: (
+    ".impl .code-header",
+    {"color": "rgb(221, 221, 221)", "background-color": "rgb(53, 53, 53)"},
+    ALL,
+)
 
 goto: file://|DOC_PATH|/test_docs/struct.Foo.html#impl
-assert-css: ("#impl", {"color": "rgb(221, 221, 221)", "background-color": "rgb(73, 74, 61)"})
+assert-css: (
+    "#impl",
+    {"color": "rgb(221, 221, 221)", "background-color": "rgb(73, 74, 61)"},
+)
 
 goto: file://|DOC_PATH|/test_docs/struct.Foo.html#method.must_use
-assert-css: ("#method\.must_use", {"color": "rgb(221, 221, 221)", "background-color": "rgb(73, 74, 61)"}, ALL)
+assert-css: (
+    "#method\.must_use",
+    {"color": "rgb(221, 221, 221)", "background-color": "rgb(73, 74, 61)"},
+    ALL,
+)
 
 goto: file://|DOC_PATH|/test_docs/index.html
 assert-css: (".section-header a", {"color": "rgb(221, 221, 221)"}, ALL)
@@ -42,14 +80,26 @@ reload:
 
 goto: file://|DOC_PATH|/test_docs/struct.Foo.html
 
-assert-css: (".impl", {"color": "rgb(0, 0, 0)", "background-color": "rgba(0, 0, 0, 0)"}, ALL)
-assert-css: (".impl .code-header", {"color": "rgb(0, 0, 0)", "background-color": "rgb(255, 255, 255)"}, ALL)
+assert-css: (
+    ".impl",
+    {"color": "rgb(0, 0, 0)", "background-color": "rgba(0, 0, 0, 0)"},
+    ALL,
+)
+assert-css: (
+    ".impl .code-header",
+    {"color": "rgb(0, 0, 0)", "background-color": "rgb(255, 255, 255)"},
+    ALL,
+)
 
 goto: file://|DOC_PATH|/test_docs/struct.Foo.html#impl
 assert-css: ("#impl", {"color": "rgb(0, 0, 0)", "background-color": "rgb(253, 255, 211)"})
 
 goto: file://|DOC_PATH|/test_docs/struct.Foo.html#method.must_use
-assert-css: ("#method\.must_use", {"color": "rgb(0, 0, 0)", "background-color": "rgb(253, 255, 211)"}, ALL)
+assert-css: (
+    "#method\.must_use",
+    {"color": "rgb(0, 0, 0)", "background-color": "rgb(253, 255, 211)"},
+    ALL,
+)
 
 goto: file://|DOC_PATH|/test_docs/index.html
 assert-css: (".section-header a", {"color": "rgb(0, 0, 0)"}, ALL)

--- a/src/test/rustdoc-gui/huge-collection-of-constants.goml
+++ b/src/test/rustdoc-gui/huge-collection-of-constants.goml
@@ -2,4 +2,8 @@ goto: file://|DOC_PATH|/test_docs/huge_amount_of_consts/index.html
 
 // Make sure that the last two entries are more than 12 pixels apart and not stacked on each other.
 
-compare-elements-position-near-false: ("//*[@class='item-table']//div[last()-1]", "//*[@class='item-table']//div[last()-3]", {"y": 12})
+compare-elements-position-near-false: (
+    "//*[@class='item-table']//div[last()-1]",
+    "//*[@class='item-table']//div[last()-3]",
+    {"y": 12},
+)

--- a/src/test/rustdoc-gui/jump-to-def-background.goml
+++ b/src/test/rustdoc-gui/jump-to-def-background.goml
@@ -2,22 +2,42 @@
 goto: file://|DOC_PATH|/src/link_to_definition/lib.rs.html
 
 // Set the theme to dark.
-local-storage: {"rustdoc-theme": "dark", "rustdoc-preferred-dark-theme": "dark", "rustdoc-use-system-theme": "false"}
+local-storage: {
+    "rustdoc-theme": "dark",
+    "rustdoc-preferred-dark-theme": "dark",
+    "rustdoc-use-system-theme": "false",
+}
 // We reload the page so the local storage settings are being used.
 reload:
 
-assert-css: ("body.source .example-wrap pre.rust a", {"background-color": "rgb(51, 51, 51)"}, ALL)
+assert-css: (
+    "body.source .example-wrap pre.rust a",
+    {"background-color": "rgb(51, 51, 51)"},
+    ALL,
+)
 
 // Set the theme to ayu.
-local-storage: {"rustdoc-theme": "ayu", "rustdoc-preferred-dark-theme": "ayu", "rustdoc-use-system-theme": "false"}
+local-storage: {
+    "rustdoc-theme": "ayu",
+    "rustdoc-preferred-dark-theme": "ayu",
+    "rustdoc-use-system-theme": "false",
+}
 // We reload the page so the local storage settings are being used.
 reload:
 
-assert-css: ("body.source .example-wrap pre.rust a", {"background-color": "rgb(51, 51, 51)"}, ALL)
+assert-css: (
+    "body.source .example-wrap pre.rust a",
+    {"background-color": "rgb(51, 51, 51)"},
+    ALL,
+)
 
 // Set the theme to light.
 local-storage: {"rustdoc-theme": "light", "rustdoc-use-system-theme": "false"}
 // We reload the page so the local storage settings are being used.
 reload:
 
-assert-css: ("body.source .example-wrap pre.rust a", {"background-color": "rgb(238, 238, 238)"}, ALL)
+assert-css: (
+    "body.source .example-wrap pre.rust a",
+    {"background-color": "rgb(238, 238, 238)"},
+    ALL,
+)

--- a/src/test/rustdoc-gui/label-next-to-symbol.goml
+++ b/src/test/rustdoc-gui/label-next-to-symbol.goml
@@ -8,29 +8,71 @@ assert: (".stab.deprecated")
 assert: (".stab.portability")
 
 // make sure that deprecated and portability are different colours
-assert-css: (".item-table .item-left .stab.deprecated", { "background-color": "rgb(255, 196, 196)" })
-assert-css: (".item-table .item-left .stab.portability", { "background-color": "rgb(243, 223, 255)" })
+assert-css: (
+    ".item-table .item-left .stab.deprecated",
+    { "background-color": "rgb(255, 196, 196)" },
+)
+assert-css: (
+    ".item-table .item-left .stab.portability",
+    { "background-color": "rgb(243, 223, 255)" },
+)
 
 // table like view
 assert-css: (".item-right.docblock-short", { "padding-left": "0px" })
-compare-elements-position-near: ("//*[@class='item-left module-item']//a[text()='replaced_function']", ".item-left .stab.deprecated", {"y": 2})
-compare-elements-position: (".item-left .stab.deprecated", ".item-left .stab.portability", ("y"))
+compare-elements-position-near: (
+    "//*[@class='item-left module-item']//a[text()='replaced_function']",
+    ".item-left .stab.deprecated",
+    {"y": 2},
+)
+compare-elements-position: (
+    ".item-left .stab.deprecated",
+    ".item-left .stab.portability",
+    ("y"),
+)
 
 // Ensure no wrap
-compare-elements-position-near: ("//*[@class='item-left module-item']//a[text()='replaced_function']", "//*[@class='item-right docblock-short']//p[text()='a thing with a label']", {"y": 2})
+compare-elements-position-near: (
+    "//*[@class='item-left module-item']//a[text()='replaced_function']",
+    "//*[@class='item-right docblock-short']//p[text()='a thing with a label']",
+    {"y": 2},
+)
 // compare parent elements
-compare-elements-position: ("//*[@class='item-left module-item']//a[text()='replaced_function']/..", "//*[@class='item-right docblock-short']//p[text()='a thing with a label']/..", ("y"))
+compare-elements-position: (
+    "//*[@class='item-left module-item']//a[text()='replaced_function']/..",
+    "//*[@class='item-right docblock-short']//p[text()='a thing with a label']/..",
+    ("y"),
+)
 
 
 // Mobile view
 size: (600, 600)
 // staggered layout with 2em spacing
 assert-css: (".item-right.docblock-short", { "padding-left": "32px" })
-compare-elements-position-near: ("//*[@class='item-left module-item']//a[text()='replaced_function']", ".item-left .stab.deprecated", {"y": 1})
-compare-elements-position: (".item-left .stab.deprecated", ".item-left .stab.portability", ("y"))
+compare-elements-position-near: (
+    "//*[@class='item-left module-item']//a[text()='replaced_function']",
+    ".item-left .stab.deprecated",
+    {"y": 1},
+)
+compare-elements-position: (
+    ".item-left .stab.deprecated",
+    ".item-left .stab.portability",
+    ("y"),
+)
 
 // Ensure wrap
-compare-elements-position-near-false: ("//*[@class='item-left module-item']//a[text()='replaced_function']", "//*[@class='item-right docblock-short']//p[text()='a thing with a label']", {"y": 12})
+compare-elements-position-near-false: (
+    "//*[@class='item-left module-item']//a[text()='replaced_function']",
+    "//*[@class='item-right docblock-short']//p[text()='a thing with a label']",
+    {"y": 12},
+)
 // compare parent elements
-compare-elements-position-false: ("//*[@class='item-left module-item']//a[text()='replaced_function']/..", "//*[@class='item-right docblock-short']//p[text()='a thing with a label']/..", ("y"))
-compare-elements-position-false: (".item-left .stab.deprecated", "//*[@class='item-right docblock-short']//p[text()='a thing with a label']", ("y"))
+compare-elements-position-false: (
+    "//*[@class='item-left module-item']//a[text()='replaced_function']/..",
+    "//*[@class='item-right docblock-short']//p[text()='a thing with a label']/..",
+    ("y"),
+)
+compare-elements-position-false: (
+    ".item-left .stab.deprecated",
+    "//*[@class='item-right docblock-short']//p[text()='a thing with a label']",
+    ("y"),
+)

--- a/src/test/rustdoc-gui/module-items-font.goml
+++ b/src/test/rustdoc-gui/module-items-font.goml
@@ -1,23 +1,67 @@
 // This test checks that the correct font is used on module items (in index.html pages).
 goto: file://|DOC_PATH|/test_docs/index.html
-assert-css: (".item-table .module-item a", {"font-family": '"Fira Sans", Arial, NanumBarunGothic, sans-serif'}, ALL)
-assert-css: (".item-table .docblock-short", {"font-family": '"Source Serif 4", NanumBarunGothic, serif'}, ALL)
+assert-css: (
+    ".item-table .module-item a",
+    {"font-family": '"Fira Sans", Arial, NanumBarunGothic, sans-serif'},
+    ALL,
+)
+assert-css: (
+    ".item-table .docblock-short",
+    {"font-family": '"Source Serif 4", NanumBarunGothic, serif'},
+    ALL,
+)
 
 // modules
-assert-css: ("#modules + .item-table .item-left a", {"font-family": '"Fira Sans", Arial, NanumBarunGothic, sans-serif'})
-assert-css: ("#modules + .item-table .item-right.docblock-short", {"font-family": '"Source Serif 4", NanumBarunGothic, serif'})
+assert-css: (
+    "#modules + .item-table .item-left a",
+    {"font-family": '"Fira Sans", Arial, NanumBarunGothic, sans-serif'},
+)
+assert-css: (
+    "#modules + .item-table .item-right.docblock-short",
+    {"font-family": '"Source Serif 4", NanumBarunGothic, serif'},
+)
 // structs
-assert-css: ("#structs + .item-table .item-left a", {"font-family": '"Fira Sans", Arial, NanumBarunGothic, sans-serif'})
-assert-css: ("#structs + .item-table .item-right.docblock-short", {"font-family": '"Source Serif 4", NanumBarunGothic, serif'})
+assert-css: (
+    "#structs + .item-table .item-left a",
+    {"font-family": '"Fira Sans", Arial, NanumBarunGothic, sans-serif'},
+)
+assert-css: (
+    "#structs + .item-table .item-right.docblock-short",
+    {"font-family": '"Source Serif 4", NanumBarunGothic, serif'},
+)
 // enums
-assert-css: ("#enums + .item-table .item-left a", {"font-family": '"Fira Sans", Arial, NanumBarunGothic, sans-serif'})
-assert-css: ("#enums + .item-table .item-right.docblock-short", {"font-family": '"Source Serif 4", NanumBarunGothic, serif'})
+assert-css: (
+    "#enums + .item-table .item-left a",
+    {"font-family": '"Fira Sans", Arial, NanumBarunGothic, sans-serif'},
+)
+assert-css: (
+    "#enums + .item-table .item-right.docblock-short",
+    {"font-family": '"Source Serif 4", NanumBarunGothic, serif'},
+)
 // traits
-assert-css: ("#traits + .item-table .item-left a", {"font-family": '"Fira Sans", Arial, NanumBarunGothic, sans-serif'})
-assert-css: ("#traits + .item-table .item-right.docblock-short", {"font-family": '"Source Serif 4", NanumBarunGothic, serif'})
+assert-css: (
+    "#traits + .item-table .item-left a",
+    {"font-family": '"Fira Sans", Arial, NanumBarunGothic, sans-serif'},
+)
+assert-css: (
+    "#traits + .item-table .item-right.docblock-short",
+    {"font-family": '"Source Serif 4", NanumBarunGothic, serif'},
+)
 // functions
-assert-css: ("#functions + .item-table .item-left a", {"font-family": '"Fira Sans", Arial, NanumBarunGothic, sans-serif'})
-assert-css: ("#functions + .item-table .item-right.docblock-short", {"font-family": '"Source Serif 4", NanumBarunGothic, serif'})
+assert-css: (
+    "#functions + .item-table .item-left a",
+    {"font-family": '"Fira Sans", Arial, NanumBarunGothic, sans-serif'},
+)
+assert-css: (
+    "#functions + .item-table .item-right.docblock-short",
+    {"font-family": '"Source Serif 4", NanumBarunGothic, serif'},
+)
 // keywords
-assert-css: ("#keywords + .item-table .item-left a", {"font-family": '"Fira Sans", Arial, NanumBarunGothic, sans-serif'})
-assert-css: ("#keywords + .item-table .item-right.docblock-short", {"font-family": '"Source Serif 4", NanumBarunGothic, serif'})
+assert-css: (
+    "#keywords + .item-table .item-left a",
+    {"font-family": '"Fira Sans", Arial, NanumBarunGothic, sans-serif'},
+)
+assert-css: (
+    "#keywords + .item-table .item-right.docblock-short",
+    {"font-family": '"Source Serif 4", NanumBarunGothic, serif'},
+)

--- a/src/test/rustdoc-gui/search-result-color.goml
+++ b/src/test/rustdoc-gui/search-result-color.goml
@@ -5,28 +5,54 @@ goto: file://|DOC_PATH|/test_docs/index.html?search=coo
 show-text: true
 
 // Ayu theme
-local-storage: {"rustdoc-theme": "ayu", "rustdoc-preferred-dark-theme": "ayu", "rustdoc-use-system-theme": "false"}
+local-storage: {
+    "rustdoc-theme": "ayu",
+    "rustdoc-preferred-dark-theme": "ayu",
+    "rustdoc-use-system-theme": "false",
+}
 reload:
 
 // Waiting for the search results to appear...
 wait-for: "#titles"
-assert-css: ("//*[@class='desc']//*[text()='Just a normal struct.']", {"color": "rgb(197, 197, 197)"})
-assert-css: ("//*[@class='result-name']/*[text()='test_docs::']", {"color": "rgb(0, 150, 207)"})
+assert-css: (
+    "//*[@class='desc']//*[text()='Just a normal struct.']",
+    {"color": "rgb(197, 197, 197)"},
+)
+assert-css: (
+    "//*[@class='result-name']/*[text()='test_docs::']",
+    {"color": "rgb(0, 150, 207)"},
+)
 
 // Checking the color for "keyword".
-assert-css: ("//*[@class='result-name']//*[text()='(keyword)']", {"color": "rgb(120, 135, 151)"})
+assert-css: (
+    "//*[@class='result-name']//*[text()='(keyword)']",
+    {"color": "rgb(120, 135, 151)"},
+)
 
 // Dark theme
-local-storage: {"rustdoc-theme": "dark", "rustdoc-preferred-dark-theme": "dark", "rustdoc-use-system-theme": "false"}
+local-storage: {
+    "rustdoc-theme": "dark",
+    "rustdoc-preferred-dark-theme": "dark",
+    "rustdoc-use-system-theme": "false",
+}
 reload:
 
 // Waiting for the search results to appear...
 wait-for: "#titles"
-assert-css: ("//*[@class='desc']//*[text()='Just a normal struct.']", {"color": "rgb(221, 221, 221)"})
-assert-css: ("//*[@class='result-name']/*[text()='test_docs::']", {"color": "rgb(221, 221, 221)"})
+assert-css: (
+    "//*[@class='desc']//*[text()='Just a normal struct.']",
+    {"color": "rgb(221, 221, 221)"},
+)
+assert-css: (
+    "//*[@class='result-name']/*[text()='test_docs::']",
+    {"color": "rgb(221, 221, 221)"},
+)
 
 // Checking the color for "keyword".
-assert-css: ("//*[@class='result-name']//*[text()='(keyword)']", {"color": "rgb(221, 221, 221)"})
+assert-css: (
+    "//*[@class='result-name']//*[text()='(keyword)']",
+    {"color": "rgb(221, 221, 221)"},
+)
 
 // Light theme
 local-storage: {"rustdoc-theme": "light", "rustdoc-use-system-theme": "false"}
@@ -34,8 +60,17 @@ reload:
 
 // Waiting for the search results to appear...
 wait-for: "#titles"
-assert-css: ("//*[@class='desc']//*[text()='Just a normal struct.']", {"color": "rgb(0, 0, 0)"})
-assert-css: ("//*[@class='result-name']/*[text()='test_docs::']", {"color": "rgb(0, 0, 0)"})
+assert-css: (
+    "//*[@class='desc']//*[text()='Just a normal struct.']",
+    {"color": "rgb(0, 0, 0)"},
+)
+assert-css: (
+    "//*[@class='result-name']/*[text()='test_docs::']",
+    {"color": "rgb(0, 0, 0)"},
+)
 
 // Checking the color for "keyword".
-assert-css: ("//*[@class='result-name']//*[text()='(keyword)']", {"color": "rgb(0, 0, 0)"})
+assert-css: (
+    "//*[@class='result-name']//*[text()='(keyword)']",
+    {"color": "rgb(0, 0, 0)"},
+)

--- a/src/test/rustdoc-gui/search-result-colors.goml
+++ b/src/test/rustdoc-gui/search-result-colors.goml
@@ -1,7 +1,11 @@
 goto: file://|DOC_PATH|/test_docs/index.html
 // We set the theme so we're sure that the correct values will be used, whatever the computer
 // this test is running on.
-local-storage: {"rustdoc-theme": "dark", "rustdoc-preferred-dark-theme": "dark", "rustdoc-use-system-theme": "false"}
+local-storage: {
+    "rustdoc-theme": "dark",
+    "rustdoc-preferred-dark-theme": "dark",
+    "rustdoc-use-system-theme": "false",
+}
 // If the text isn't displayed, the browser doesn't compute color style correctly...
 show-text: true
 // We reload the page so the local storage settings are being used.

--- a/src/test/ui/lint/unused/issue-90807-unused-paren-error.rs
+++ b/src/test/ui/lint/unused/issue-90807-unused-paren-error.rs
@@ -1,0 +1,9 @@
+// Make sure unused parens lint emit is emitted for loop and match.
+// See https://github.com/rust-lang/rust/issues/90807
+// and https://github.com/rust-lang/rust/pull/91956#discussion_r771647953
+#![deny(unused_parens)]
+
+fn main() {
+    for _ in (1..loop { break 2 }) {} //~ERROR
+    for _ in (1..match () { () => 2 }) {} //~ERROR
+}

--- a/src/test/ui/lint/unused/issue-90807-unused-paren-error.stderr
+++ b/src/test/ui/lint/unused/issue-90807-unused-paren-error.stderr
@@ -1,0 +1,31 @@
+error: unnecessary parentheses around `for` iterator expression
+  --> $DIR/issue-90807-unused-paren-error.rs:7:14
+   |
+LL |     for _ in (1..loop { break 2 }) {}
+   |              ^                   ^
+   |
+note: the lint level is defined here
+  --> $DIR/issue-90807-unused-paren-error.rs:4:9
+   |
+LL | #![deny(unused_parens)]
+   |         ^^^^^^^^^^^^^
+help: remove these parentheses
+   |
+LL -     for _ in (1..loop { break 2 }) {}
+LL +     for _ in 1..loop { break 2 } {}
+   | 
+
+error: unnecessary parentheses around `for` iterator expression
+  --> $DIR/issue-90807-unused-paren-error.rs:8:14
+   |
+LL |     for _ in (1..match () { () => 2 }) {}
+   |              ^                       ^
+   |
+help: remove these parentheses
+   |
+LL -     for _ in (1..match () { () => 2 }) {}
+LL +     for _ in 1..match () { () => 2 } {}
+   | 
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/lint/unused/issue-90807-unused-paren.rs
+++ b/src/test/ui/lint/unused/issue-90807-unused-paren.rs
@@ -1,0 +1,8 @@
+// check-pass
+// Make sure unused parens lint doesn't emit a false positive.
+// See https://github.com/rust-lang/rust/issues/90807
+#![deny(unused_parens)]
+
+fn main() {
+    for _ in (1..{ 2 }) {}
+}


### PR DESCRIPTION
Successful merges:

 - #91834 (Update browser-ui-test version and improve rustdoc-gui tests readability)
 - #91894 (Remove `in_band_lifetimes` from `rustc_incremental`)
 - #91932 (Add user seed to `-Z randomize-layout`)
 - #91956 (fix(rustc_lint): better detect when parens are necessary)
 - #92020 (Remove P: Unpin bound on impl Stream for Pin)
 - #92063 (docs: fix typo)
 - #92082 (rustdoc: Write doc-comments directly instead of using FromIterator)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=91834,91894,91932,91956,92020,92063,92082)
<!-- homu-ignore:end -->