### PR TITLE
Drop guards in slice sorting derive src pointers from &mut T, which is invalidated by interior mutation in comparison

### DIFF
--- a/library/alloc/src/slice.rs
+++ b/library/alloc/src/slice.rs
@@ -892,7 +892,7 @@ where
             //    performance than with the 2nd method.
             //
             // All methods were benchmarked, and the 3rd showed best results. So we chose that one.
-            let mut tmp = mem::ManuallyDrop::new(ptr::read(&v[0]));
+            let tmp = mem::ManuallyDrop::new(ptr::read(&v[0]));
 
             // Intermediate state of the insertion process is always tracked by `hole`, which
             // serves two purposes:
@@ -904,7 +904,7 @@ where
             // If `is_less` panics at any point during the process, `hole` will get dropped and
             // fill the hole in `v` with `tmp`, thus ensuring that `v` still holds every object it
             // initially held exactly once.
-            let mut hole = InsertionHole { src: &mut *tmp, dest: &mut v[1] };
+            let mut hole = InsertionHole { src: &*tmp, dest: &mut v[1] };
             ptr::copy_nonoverlapping(&v[1], &mut v[0], 1);
 
             for i in 2..v.len() {
@@ -920,7 +920,7 @@ where
 
     // When dropped, copies from `src` into `dest`.
     struct InsertionHole<T> {
-        src: *mut T,
+        src: *const T,
         dest: *mut T,
     }
 


### PR DESCRIPTION
I tried to run https://github.com/rust-lang/miri-test-libstd on `alloc` with `-Zmiri-track-raw-pointers`, and got a failure on the test `slice::panic_safe`. The test failure has nothing to do with panic safety, it's from how the test tests for panic safety.

I minimized the test failure into this very silly program:
```rust
use std::cell::Cell;
use std::cmp::Ordering;

#[derive(Clone)]
struct Evil(Cell<usize>);

fn main() {
    let mut input = vec![Evil(Cell::new(0)); 3];

    // Hits the bug pattern via CopyOnDrop in core
    input.sort_unstable_by(|a, _b| {
        a.0.set(0);
        Ordering::Less
    });

    // Hits the bug pattern via InsertionHole in alloc
    input.sort_by(|_a, b| {
        b.0.set(0);
        Ordering::Less
    });
}
```

To fix this, I'm just removing the mutability/uniqueness where it wasn't required.