### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/metadata.rs
+++ b/compiler/rustc_codegen_ssa/src/back/metadata.rs
@@ -259,8 +259,15 @@ pub fn create_compressed_metadata_file(
     let section = file.add_section(
         file.segment_name(StandardSegment::Data).to_vec(),
         b".rustc".to_vec(),
-        SectionKind::Data,
+        SectionKind::ReadOnlyData,
     );
+    match file.format() {
+        BinaryFormat::Elf => {
+            // Explicitly set no flags to avoid SHF_ALLOC default for data section.
+            file.section_mut(section).flags = SectionFlags::Elf { sh_flags: 0 };
+        }
+        _ => {}
+    };
     let offset = file.append_section_data(section, &compressed, 1);
 
     // For MachO and probably PE this is necessary to prevent the linker from throwing away the

--- a/compiler/rustc_infer/src/infer/canonical/canonicalizer.rs
+++ b/compiler/rustc_infer/src/infer/canonical/canonicalizer.rs
@@ -134,7 +134,7 @@ impl<'cx, 'tcx> InferCtxt<'cx, 'tcx> {
 /// response*, then we don't typically replace free regions, as they
 /// must have been introduced from other parts of the system.
 trait CanonicalizeRegionMode {
-    fn canonicalize_free_region(
+    fn canonicalize_free_region<'tcx>(
         &self,
         canonicalizer: &mut Canonicalizer<'_, 'tcx>,
         r: ty::Region<'tcx>,
@@ -146,7 +146,7 @@ trait CanonicalizeRegionMode {
 struct CanonicalizeQueryResponse;
 
 impl CanonicalizeRegionMode for CanonicalizeQueryResponse {
-    fn canonicalize_free_region(
+    fn canonicalize_free_region<'tcx>(
         &self,
         canonicalizer: &mut Canonicalizer<'_, 'tcx>,
         r: ty::Region<'tcx>,
@@ -203,7 +203,7 @@ impl CanonicalizeRegionMode for CanonicalizeQueryResponse {
 struct CanonicalizeUserTypeAnnotation;
 
 impl CanonicalizeRegionMode for CanonicalizeUserTypeAnnotation {
-    fn canonicalize_free_region(
+    fn canonicalize_free_region<'tcx>(
         &self,
         canonicalizer: &mut Canonicalizer<'_, 'tcx>,
         r: ty::Region<'tcx>,
@@ -226,7 +226,7 @@ impl CanonicalizeRegionMode for CanonicalizeUserTypeAnnotation {
 struct CanonicalizeAllFreeRegions;
 
 impl CanonicalizeRegionMode for CanonicalizeAllFreeRegions {
-    fn canonicalize_free_region(
+    fn canonicalize_free_region<'tcx>(
         &self,
         canonicalizer: &mut Canonicalizer<'_, 'tcx>,
         r: ty::Region<'tcx>,
@@ -242,7 +242,7 @@ impl CanonicalizeRegionMode for CanonicalizeAllFreeRegions {
 struct CanonicalizeFreeRegionsOtherThanStatic;
 
 impl CanonicalizeRegionMode for CanonicalizeFreeRegionsOtherThanStatic {
-    fn canonicalize_free_region(
+    fn canonicalize_free_region<'tcx>(
         &self,
         canonicalizer: &mut Canonicalizer<'_, 'tcx>,
         r: ty::Region<'tcx>,

--- a/compiler/rustc_infer/src/infer/combine.rs
+++ b/compiler/rustc_infer/src/infer/combine.rs
@@ -533,7 +533,7 @@ struct Generalization<'tcx> {
     needs_wf: bool,
 }
 
-impl TypeRelation<'tcx> for Generalizer<'_, 'tcx> {
+impl<'tcx> TypeRelation<'tcx> for Generalizer<'_, 'tcx> {
     fn tcx(&self) -> TyCtxt<'tcx> {
         self.infcx.tcx
     }
@@ -827,7 +827,7 @@ struct ConstInferUnifier<'cx, 'tcx> {
 // We use `TypeRelation` here to propagate `RelateResult` upwards.
 //
 // Both inputs are expected to be the same.
-impl TypeRelation<'tcx> for ConstInferUnifier<'_, 'tcx> {
+impl<'tcx> TypeRelation<'tcx> for ConstInferUnifier<'_, 'tcx> {
     fn tcx(&self) -> TyCtxt<'tcx> {
         self.infcx.tcx
     }

--- a/compiler/rustc_infer/src/infer/equate.rs
+++ b/compiler/rustc_infer/src/infer/equate.rs
@@ -23,7 +23,7 @@ impl<'combine, 'infcx, 'tcx> Equate<'combine, 'infcx, 'tcx> {
     }
 }
 
-impl TypeRelation<'tcx> for Equate<'combine, 'infcx, 'tcx> {
+impl<'tcx> TypeRelation<'tcx> for Equate<'_, '_, 'tcx> {
     fn tag(&self) -> &'static str {
         "Equate"
     }

--- a/compiler/rustc_infer/src/infer/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/mod.rs
@@ -83,7 +83,7 @@ pub use need_type_info::TypeAnnotationNeeded;
 
 pub mod nice_region_error;
 
-pub(super) fn note_and_explain_region(
+pub(super) fn note_and_explain_region<'tcx>(
     tcx: TyCtxt<'tcx>,
     err: &mut DiagnosticBuilder<'_>,
     prefix: &str,
@@ -116,7 +116,7 @@ pub(super) fn note_and_explain_region(
     emit_msg_span(err, prefix, description, span, suffix);
 }
 
-fn explain_free_region(
+fn explain_free_region<'tcx>(
     tcx: TyCtxt<'tcx>,
     err: &mut DiagnosticBuilder<'_>,
     prefix: &str,
@@ -128,7 +128,7 @@ fn explain_free_region(
     label_msg_span(err, prefix, description, span, suffix);
 }
 
-fn msg_span_from_free_region(
+fn msg_span_from_free_region<'tcx>(
     tcx: TyCtxt<'tcx>,
     region: ty::Region<'tcx>,
     alt_span: Option<Span>,
@@ -145,7 +145,7 @@ fn msg_span_from_free_region(
     }
 }
 
-fn msg_span_from_early_bound_and_free_regions(
+fn msg_span_from_early_bound_and_free_regions<'tcx>(
     tcx: TyCtxt<'tcx>,
     region: ty::Region<'tcx>,
 ) -> (String, Span) {
@@ -226,7 +226,7 @@ fn label_msg_span(
     }
 }
 
-pub fn unexpected_hidden_region_diagnostic(
+pub fn unexpected_hidden_region_diagnostic<'tcx>(
     tcx: TyCtxt<'tcx>,
     span: Span,
     hidden_ty: Ty<'tcx>,
@@ -316,7 +316,7 @@ pub fn unexpected_hidden_region_diagnostic(
 /// with the other type. A TyVar inference type is compatible with any type, and an IntVar or
 /// FloatVar inference type are compatible with themselves or their concrete types (Int and
 /// Float types, respectively). When comparing two ADTs, these rules apply recursively.
-pub fn same_type_modulo_infer(a: Ty<'tcx>, b: Ty<'ctx>) -> bool {
+pub fn same_type_modulo_infer<'tcx>(a: Ty<'tcx>, b: Ty<'tcx>) -> bool {
     match (&a.kind(), &b.kind()) {
         (&ty::Adt(did_a, substs_a), &ty::Adt(did_b, substs_b)) => {
             if did_a != did_b {

--- a/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/find_anon_type.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/find_anon_type.rs
@@ -20,7 +20,7 @@ use rustc_middle::ty::{self, Region, TyCtxt};
 /// ```
 /// The function returns the nested type corresponding to the anonymous region
 /// for e.g., `&u8` and `Vec<&u8>`.
-pub(crate) fn find_anon_type(
+pub(crate) fn find_anon_type<'tcx>(
     tcx: TyCtxt<'tcx>,
     region: Region<'tcx>,
     br: &ty::BoundRegionKind,
@@ -50,7 +50,7 @@ pub(crate) fn find_anon_type(
 
 // This method creates a FindNestedTypeVisitor which returns the type corresponding
 // to the anonymous region.
-fn find_component_for_bound_region(
+fn find_component_for_bound_region<'tcx>(
     tcx: TyCtxt<'tcx>,
     arg: &'tcx hir::Ty<'tcx>,
     br: &ty::BoundRegionKind,
@@ -83,7 +83,7 @@ struct FindNestedTypeVisitor<'tcx> {
     current_index: ty::DebruijnIndex,
 }
 
-impl Visitor<'tcx> for FindNestedTypeVisitor<'tcx> {
+impl<'tcx> Visitor<'tcx> for FindNestedTypeVisitor<'tcx> {
     type Map = Map<'tcx>;
 
     fn nested_visit_map(&mut self) -> NestedVisitorMap<Self::Map> {
@@ -207,7 +207,7 @@ struct TyPathVisitor<'tcx> {
     current_index: ty::DebruijnIndex,
 }
 
-impl Visitor<'tcx> for TyPathVisitor<'tcx> {
+impl<'tcx> Visitor<'tcx> for TyPathVisitor<'tcx> {
     type Map = Map<'tcx>;
 
     fn nested_visit_map(&mut self) -> NestedVisitorMap<Map<'tcx>> {

--- a/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/placeholder_error.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/placeholder_error.rs
@@ -13,7 +13,7 @@ use rustc_middle::ty::{self, TyCtxt};
 
 use std::fmt::{self, Write};
 
-impl NiceRegionError<'me, 'tcx> {
+impl<'tcx> NiceRegionError<'_, 'tcx> {
     /// When given a `ConcreteFailure` for a function with arguments containing a named region and
     /// an anonymous region, emit a descriptive diagnostic error.
     pub(super) fn try_report_placeholder_conflict(&self) -> Option<DiagnosticBuilder<'tcx>> {

--- a/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/static_impl_trait.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/static_impl_trait.rs
@@ -287,7 +287,7 @@ impl<'a, 'tcx> NiceRegionError<'a, 'tcx> {
 }
 
 pub fn suggest_new_region_bound(
-    tcx: TyCtxt<'tcx>,
+    tcx: TyCtxt<'_>,
     err: &mut DiagnosticBuilder<'_>,
     fn_returns: Vec<&rustc_hir::Ty<'_>>,
     lifetime_name: String,

--- a/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/trait_impl_difference.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/trait_impl_difference.rs
@@ -86,7 +86,7 @@ impl<'a, 'tcx> NiceRegionError<'a, 'tcx> {
             counter: usize,
         }
 
-        impl HighlightBuilder<'tcx> {
+        impl<'tcx> HighlightBuilder<'tcx> {
             fn build(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>) -> RegionHighlightMode {
                 let mut builder =
                     HighlightBuilder { highlight: RegionHighlightMode::default(), counter: 1, tcx };
@@ -186,7 +186,7 @@ struct TypeParamSpanVisitor<'tcx> {
     types: Vec<Span>,
 }
 
-impl Visitor<'tcx> for TypeParamSpanVisitor<'tcx> {
+impl<'tcx> Visitor<'tcx> for TypeParamSpanVisitor<'tcx> {
     type Map = rustc_middle::hir::map::Map<'tcx>;
 
     fn nested_visit_map(&mut self) -> hir::intravisit::NestedVisitorMap<Self::Map> {

--- a/compiler/rustc_infer/src/infer/glb.rs
+++ b/compiler/rustc_infer/src/infer/glb.rs
@@ -23,7 +23,7 @@ impl<'combine, 'infcx, 'tcx> Glb<'combine, 'infcx, 'tcx> {
     }
 }
 
-impl TypeRelation<'tcx> for Glb<'combine, 'infcx, 'tcx> {
+impl<'tcx> TypeRelation<'tcx> for Glb<'_, '_, 'tcx> {
     fn tag(&self) -> &'static str {
         "Glb"
     }

--- a/compiler/rustc_infer/src/infer/lub.rs
+++ b/compiler/rustc_infer/src/infer/lub.rs
@@ -23,7 +23,7 @@ impl<'combine, 'infcx, 'tcx> Lub<'combine, 'infcx, 'tcx> {
     }
 }
 
-impl TypeRelation<'tcx> for Lub<'combine, 'infcx, 'tcx> {
+impl<'tcx> TypeRelation<'tcx> for Lub<'_, '_, 'tcx> {
     fn tag(&self) -> &'static str {
         "Lub"
     }

--- a/compiler/rustc_infer/src/infer/mod.rs
+++ b/compiler/rustc_infer/src/infer/mod.rs
@@ -554,7 +554,7 @@ pub trait TyCtxtInferExt<'tcx> {
     fn infer_ctxt(self) -> InferCtxtBuilder<'tcx>;
 }
 
-impl TyCtxtInferExt<'tcx> for TyCtxt<'tcx> {
+impl<'tcx> TyCtxtInferExt<'tcx> for TyCtxt<'tcx> {
     fn infer_ctxt(self) -> InferCtxtBuilder<'tcx> {
         InferCtxtBuilder {
             tcx: self,
@@ -1718,7 +1718,7 @@ pub enum TyOrConstInferVar<'tcx> {
     Const(ConstVid<'tcx>),
 }
 
-impl TyOrConstInferVar<'tcx> {
+impl<'tcx> TyOrConstInferVar<'tcx> {
     /// Tries to extract an inference variable from a type or a constant, returns `None`
     /// for types other than `ty::Infer(_)` (or `InferTy::Fresh*`) and
     /// for constants other than `ty::ConstKind::Infer(_)` (or `InferConst::Fresh`).

--- a/compiler/rustc_infer/src/infer/nll_relate/mod.rs
+++ b/compiler/rustc_infer/src/infer/nll_relate/mod.rs
@@ -407,7 +407,7 @@ trait VidValuePair<'tcx>: Debug {
     /// Extract the scopes that apply to whichever side of the tuple
     /// the vid was found on.  See the comment where this is called
     /// for more details on why we want them.
-    fn vid_scopes<D: TypeRelatingDelegate<'tcx>>(
+    fn vid_scopes<'r, D: TypeRelatingDelegate<'tcx>>(
         &self,
         relate: &'r mut TypeRelating<'_, 'tcx, D>,
     ) -> &'r mut Vec<BoundRegionScope<'tcx>>;
@@ -424,7 +424,7 @@ trait VidValuePair<'tcx>: Debug {
         D: TypeRelatingDelegate<'tcx>;
 }
 
-impl VidValuePair<'tcx> for (ty::TyVid, Ty<'tcx>) {
+impl<'tcx> VidValuePair<'tcx> for (ty::TyVid, Ty<'tcx>) {
     fn vid(&self) -> ty::TyVid {
         self.0
     }
@@ -433,7 +433,7 @@ impl VidValuePair<'tcx> for (ty::TyVid, Ty<'tcx>) {
         self.1
     }
 
-    fn vid_scopes<D>(
+    fn vid_scopes<'r, D>(
         &self,
         relate: &'r mut TypeRelating<'_, 'tcx, D>,
     ) -> &'r mut Vec<BoundRegionScope<'tcx>>
@@ -456,7 +456,7 @@ impl VidValuePair<'tcx> for (ty::TyVid, Ty<'tcx>) {
 }
 
 // In this case, the "vid" is the "b" type.
-impl VidValuePair<'tcx> for (Ty<'tcx>, ty::TyVid) {
+impl<'tcx> VidValuePair<'tcx> for (Ty<'tcx>, ty::TyVid) {
     fn vid(&self) -> ty::TyVid {
         self.1
     }
@@ -465,7 +465,7 @@ impl VidValuePair<'tcx> for (Ty<'tcx>, ty::TyVid) {
         self.0
     }
 
-    fn vid_scopes<D>(
+    fn vid_scopes<'r, D>(
         &self,
         relate: &'r mut TypeRelating<'_, 'tcx, D>,
     ) -> &'r mut Vec<BoundRegionScope<'tcx>>
@@ -487,7 +487,7 @@ impl VidValuePair<'tcx> for (Ty<'tcx>, ty::TyVid) {
     }
 }
 
-impl<D> TypeRelation<'tcx> for TypeRelating<'me, 'tcx, D>
+impl<'tcx, D> TypeRelation<'tcx> for TypeRelating<'_, 'tcx, D>
 where
     D: TypeRelatingDelegate<'tcx>,
 {
@@ -841,7 +841,7 @@ where
     universe: ty::UniverseIndex,
 }
 
-impl<D> TypeRelation<'tcx> for TypeGeneralizer<'me, 'tcx, D>
+impl<'tcx, D> TypeRelation<'tcx> for TypeGeneralizer<'_, 'tcx, D>
 where
     D: TypeRelatingDelegate<'tcx>,
 {

--- a/compiler/rustc_infer/src/infer/outlives/components.rs
+++ b/compiler/rustc_infer/src/infer/outlives/components.rs
@@ -49,7 +49,7 @@ pub enum Component<'tcx> {
 
 /// Push onto `out` all the things that must outlive `'a` for the condition
 /// `ty0: 'a` to hold. Note that `ty0` must be a **fully resolved type**.
-pub fn push_outlives_components(
+pub fn push_outlives_components<'tcx>(
     tcx: TyCtxt<'tcx>,
     ty0: Ty<'tcx>,
     out: &mut SmallVec<[Component<'tcx>; 4]>,
@@ -59,7 +59,7 @@ pub fn push_outlives_components(
     debug!("components({:?}) = {:?}", ty0, out);
 }
 
-fn compute_components(
+fn compute_components<'tcx>(
     tcx: TyCtxt<'tcx>,
     ty: Ty<'tcx>,
     out: &mut SmallVec<[Component<'tcx>; 4]>,
@@ -190,7 +190,7 @@ fn compute_components(
         }
 }
 
-fn compute_components_recursive(
+fn compute_components_recursive<'tcx>(
     tcx: TyCtxt<'tcx>,
     parent: GenericArg<'tcx>,
     out: &mut SmallVec<[Component<'tcx>; 4]>,

--- a/compiler/rustc_infer/src/infer/region_constraints/mod.rs
+++ b/compiler/rustc_infer/src/infer/region_constraints/mod.rs
@@ -65,7 +65,7 @@ pub struct RegionConstraintCollector<'a, 'tcx> {
     undo_log: &'a mut InferCtxtUndoLogs<'tcx>,
 }
 
-impl std::ops::Deref for RegionConstraintCollector<'_, 'tcx> {
+impl<'tcx> std::ops::Deref for RegionConstraintCollector<'_, 'tcx> {
     type Target = RegionConstraintStorage<'tcx>;
     #[inline]
     fn deref(&self) -> &RegionConstraintStorage<'tcx> {
@@ -73,7 +73,7 @@ impl std::ops::Deref for RegionConstraintCollector<'_, 'tcx> {
     }
 }
 
-impl std::ops::DerefMut for RegionConstraintCollector<'_, 'tcx> {
+impl<'tcx> std::ops::DerefMut for RegionConstraintCollector<'_, 'tcx> {
     #[inline]
     fn deref_mut(&mut self) -> &mut RegionConstraintStorage<'tcx> {
         self.storage

--- a/compiler/rustc_infer/src/infer/sub.rs
+++ b/compiler/rustc_infer/src/infer/sub.rs
@@ -31,7 +31,7 @@ impl<'combine, 'infcx, 'tcx> Sub<'combine, 'infcx, 'tcx> {
     }
 }
 
-impl TypeRelation<'tcx> for Sub<'combine, 'infcx, 'tcx> {
+impl<'tcx> TypeRelation<'tcx> for Sub<'_, '_, 'tcx> {
     fn tag(&self) -> &'static str {
         "Sub"
     }

--- a/compiler/rustc_infer/src/lib.rs
+++ b/compiler/rustc_infer/src/lib.rs
@@ -20,7 +20,6 @@
 #![feature(iter_zip)]
 #![feature(let_else)]
 #![feature(never_type)]
-#![feature(in_band_lifetimes)]
 #![feature(control_flow_enum)]
 #![feature(min_specialization)]
 #![feature(label_break_value)]

--- a/compiler/rustc_infer/src/traits/engine.rs
+++ b/compiler/rustc_infer/src/traits/engine.rs
@@ -63,7 +63,7 @@ pub trait TraitEngineExt<'tcx> {
     );
 }
 
-impl<T: ?Sized + TraitEngine<'tcx>> TraitEngineExt<'tcx> for T {
+impl<'tcx, T: ?Sized + TraitEngine<'tcx>> TraitEngineExt<'tcx> for T {
     fn register_predicate_obligations(
         &mut self,
         infcx: &InferCtxt<'_, 'tcx>,

--- a/compiler/rustc_infer/src/traits/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/traits/error_reporting/mod.rs
@@ -35,7 +35,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
     }
 }
 
-pub fn report_object_safety_error(
+pub fn report_object_safety_error<'tcx>(
     tcx: TyCtxt<'tcx>,
     span: Span,
     trait_def_id: DefId,

--- a/compiler/rustc_infer/src/traits/mod.rs
+++ b/compiler/rustc_infer/src/traits/mod.rs
@@ -55,7 +55,7 @@ pub struct Obligation<'tcx, T> {
 pub type PredicateObligation<'tcx> = Obligation<'tcx, ty::Predicate<'tcx>>;
 pub type TraitObligation<'tcx> = Obligation<'tcx, ty::PolyTraitPredicate<'tcx>>;
 
-impl PredicateObligation<'tcx> {
+impl<'tcx> PredicateObligation<'tcx> {
     /// Flips the polarity of the inner predicate.
     ///
     /// Given `T: Trait` predicate it returns `T: !Trait` and given `T: !Trait` returns `T: Trait`.
@@ -69,7 +69,7 @@ impl PredicateObligation<'tcx> {
     }
 }
 
-impl TraitObligation<'tcx> {
+impl TraitObligation<'_> {
     /// Returns `true` if the trait predicate is considered `const` in its ParamEnv.
     pub fn is_const(&self) -> bool {
         match (self.predicate.skip_binder().constness, self.param_env.constness()) {

--- a/compiler/rustc_infer/src/traits/project.rs
+++ b/compiler/rustc_infer/src/traits/project.rs
@@ -80,7 +80,7 @@ pub struct ProjectionCacheKey<'tcx> {
     ty: ty::ProjectionTy<'tcx>,
 }
 
-impl ProjectionCacheKey<'tcx> {
+impl<'tcx> ProjectionCacheKey<'tcx> {
     pub fn new(ty: ty::ProjectionTy<'tcx>) -> Self {
         Self { ty }
     }

--- a/compiler/rustc_infer/src/traits/util.rs
+++ b/compiler/rustc_infer/src/traits/util.rs
@@ -20,7 +20,7 @@ pub struct PredicateSet<'tcx> {
     set: FxHashSet<ty::Predicate<'tcx>>,
 }
 
-impl PredicateSet<'tcx> {
+impl<'tcx> PredicateSet<'tcx> {
     pub fn new(tcx: TyCtxt<'tcx>) -> Self {
         Self { tcx, set: Default::default() }
     }
@@ -40,7 +40,7 @@ impl PredicateSet<'tcx> {
     }
 }
 
-impl Extend<ty::Predicate<'tcx>> for PredicateSet<'tcx> {
+impl<'tcx> Extend<ty::Predicate<'tcx>> for PredicateSet<'tcx> {
     fn extend<I: IntoIterator<Item = ty::Predicate<'tcx>>>(&mut self, iter: I) {
         for pred in iter {
             self.insert(pred);
@@ -131,7 +131,7 @@ fn predicate_obligation<'tcx>(
     Obligation { cause, param_env, recursion_depth: 0, predicate }
 }
 
-impl Elaborator<'tcx> {
+impl<'tcx> Elaborator<'tcx> {
     pub fn filter_to_traits(self) -> FilterToTraits<Self> {
         FilterToTraits::new(self)
     }
@@ -267,7 +267,7 @@ impl Elaborator<'tcx> {
     }
 }
 
-impl Iterator for Elaborator<'tcx> {
+impl<'tcx> Iterator for Elaborator<'tcx> {
     type Item = PredicateObligation<'tcx>;
 
     fn size_hint(&self) -> (usize, Option<usize>) {

--- a/compiler/rustc_monomorphize/src/collector.rs
+++ b/compiler/rustc_monomorphize/src/collector.rs
@@ -498,7 +498,7 @@ fn record_accesses<'a, 'tcx: 'a>(
 /// the user's terminal with thousands of lines of type-name.
 ///
 /// If the type name is longer than before+after, it will be written to a file.
-fn shrunk_instance_name(
+fn shrunk_instance_name<'tcx>(
     tcx: TyCtxt<'tcx>,
     instance: &Instance<'tcx>,
     before: usize,
@@ -1145,7 +1145,7 @@ struct RootCollector<'a, 'tcx> {
     entry_fn: Option<(DefId, EntryFnType)>,
 }
 
-impl ItemLikeVisitor<'v> for RootCollector<'_, 'v> {
+impl<'v> ItemLikeVisitor<'v> for RootCollector<'_, 'v> {
     fn visit_item(&mut self, item: &'v hir::Item<'v>) {
         match item.kind {
             hir::ItemKind::ExternCrate(..)
@@ -1225,7 +1225,7 @@ impl ItemLikeVisitor<'v> for RootCollector<'_, 'v> {
     fn visit_foreign_item(&mut self, _foreign_item: &'v hir::ForeignItem<'v>) {}
 }
 
-impl RootCollector<'_, 'v> {
+impl<'v> RootCollector<'_, 'v> {
     fn is_root(&self, def_id: LocalDefId) -> bool {
         !item_requires_monomorphization(self.tcx, def_id)
             && match self.mode {

--- a/compiler/rustc_monomorphize/src/lib.rs
+++ b/compiler/rustc_monomorphize/src/lib.rs
@@ -3,7 +3,6 @@
 #![feature(crate_visibility_modifier)]
 #![feature(control_flow_enum)]
 #![feature(let_else)]
-#![feature(in_band_lifetimes)]
 #![recursion_limit = "256"]
 
 #[macro_use]

--- a/compiler/rustc_monomorphize/src/partitioning/default.rs
+++ b/compiler/rustc_monomorphize/src/partitioning/default.rs
@@ -378,7 +378,7 @@ fn fallback_cgu_name(name_builder: &mut CodegenUnitNameBuilder<'_>) -> Symbol {
     name_builder.build_cgu_name(LOCAL_CRATE, &["fallback"], Some("cgu"))
 }
 
-fn mono_item_linkage_and_visibility(
+fn mono_item_linkage_and_visibility<'tcx>(
     tcx: TyCtxt<'tcx>,
     mono_item: &MonoItem<'tcx>,
     can_be_internalized: &mut bool,
@@ -393,7 +393,7 @@ fn mono_item_linkage_and_visibility(
 
 type CguNameCache = FxHashMap<(DefId, bool), Symbol>;
 
-fn mono_item_visibility(
+fn mono_item_visibility<'tcx>(
     tcx: TyCtxt<'tcx>,
     mono_item: &MonoItem<'tcx>,
     can_be_internalized: &mut bool,

--- a/compiler/rustc_monomorphize/src/util.rs
+++ b/compiler/rustc_monomorphize/src/util.rs
@@ -7,7 +7,7 @@ use std::io::prelude::*;
 ///
 /// During the same compile all closures dump the information in the same file
 /// "closure_profile_XXXXX.csv", which is created in the directory where the compiler is invoked.
-crate fn dump_closure_profile(tcx: TyCtxt<'tcx>, closure_instance: Instance<'tcx>) {
+crate fn dump_closure_profile<'tcx>(tcx: TyCtxt<'tcx>, closure_instance: Instance<'tcx>) {
     let mut file = if let Ok(file) = OpenOptions::new()
         .create(true)
         .append(true)

--- a/src/test/ui/consts/issue-91434.rs
+++ b/src/test/ui/consts/issue-91434.rs
@@ -1,0 +1,6 @@
+fn main() {
+    [9; [[9E; h]]];
+    //~^ ERROR: expected at least one digit in exponent
+    //~| ERROR: cannot find value `h` in this scope [E0425]
+    //~| ERROR: constant expression depends on a generic parameter
+}

--- a/src/test/ui/consts/issue-91434.stderr
+++ b/src/test/ui/consts/issue-91434.stderr
@@ -1,0 +1,23 @@
+error: expected at least one digit in exponent
+  --> $DIR/issue-91434.rs:2:11
+   |
+LL |     [9; [[9E; h]]];
+   |           ^^
+
+error[E0425]: cannot find value `h` in this scope
+  --> $DIR/issue-91434.rs:2:15
+   |
+LL |     [9; [[9E; h]]];
+   |               ^ not found in this scope
+
+error: constant expression depends on a generic parameter
+  --> $DIR/issue-91434.rs:2:9
+   |
+LL |     [9; [[9E; h]]];
+   |         ^^^^^^^^^
+   |
+   = note: this may fail depending on what value the parameter takes
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0425`.


### PR DESCRIPTION
Successful merges:

 - #91791 (Fix an ICE when lowering a float with missing exponent magnitude)
 - #91878 (Remove `in_band_lifetimes` from `rustc_infer`)
 - #91895 (Remove `in_band_lifetimes` for `rustc_monomorphize`)
 - #92029 (Explicitly set no ELF flags for .rustc section)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=91791,91878,91895,92029)
<!-- homu-ignore:end -->