### PR TITLE
Fix the error of checking `base_expr` twice in type_changing_struct_update

### DIFF
--- a/compiler/rustc_typeck/src/check/expr.rs
+++ b/compiler/rustc_typeck/src/check/expr.rs
@@ -1508,7 +1508,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 }
             } else {
                 self.check_expr_has_type_or_error(base_expr, adt_ty, |_| {
-                    let base_ty = self.check_expr(base_expr);
+                    let base_ty = self.typeck_results.borrow().node_type(base_expr.hir_id);
                     let same_adt = match (adt_ty.kind(), base_ty.kind()) {
                         (ty::Adt(adt, _), ty::Adt(base_adt, _)) if adt == base_adt => true,
                         _ => false,

--- a/src/test/ui/rfcs/rfc-2528-type-changing-struct-update/issue-92010-trait-bound-not-satisfied.rs
+++ b/src/test/ui/rfcs/rfc-2528-type-changing-struct-update/issue-92010-trait-bound-not-satisfied.rs
@@ -1,0 +1,12 @@
+#[derive(Clone)]
+struct P<T> {
+    x: T,
+    y: f64,
+}
+
+impl<T> P<T> {
+    fn y(&self, y: f64) -> Self { P{y, .. self.clone() } }
+                                       //~^ mismatched types [E0308]
+}
+
+fn main() {}

--- a/src/test/ui/rfcs/rfc-2528-type-changing-struct-update/issue-92010-trait-bound-not-satisfied.stderr
+++ b/src/test/ui/rfcs/rfc-2528-type-changing-struct-update/issue-92010-trait-bound-not-satisfied.stderr
@@ -1,0 +1,12 @@
+error[E0308]: mismatched types
+  --> $DIR/issue-92010-trait-bound-not-satisfied.rs:8:43
+   |
+LL |     fn y(&self, y: f64) -> Self { P{y, .. self.clone() } }
+   |                                           ^^^^^^^^^^^^ expected struct `P`, found `&P<T>`
+   |
+   = note: expected struct `P<T>`
+           found reference `&P<T>`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Fixes #92010 