### PR TITLE
Add `Future::poll_once`

### DIFF
--- a/library/core/src/future/future.rs
+++ b/library/core/src/future/future.rs
@@ -1,5 +1,6 @@
 #![stable(feature = "futures_api", since = "1.36.0")]
 
+use crate::future::PollOnce;
 use crate::marker::Unpin;
 use crate::ops;
 use crate::pin::Pin;
@@ -101,6 +102,32 @@ pub trait Future {
     #[lang = "poll"]
     #[stable(feature = "futures_api", since = "1.36.0")]
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output>;
+
+    /// Poll a future once.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// #![feature(future_poll_once)]
+    ///
+    /// use std::future::{self, Future};
+    /// use std::task::Poll;
+    ///
+    /// # let _ = async {
+    /// let f = future::ready(1);
+    /// assert_eq!(f.poll_once().await, Poll::Ready(1));
+    ///
+    /// let mut f = future::pending::<()>();
+    /// assert_eq!(f.poll_once().await, Poll::Pending);
+    /// # };
+    /// ```
+    #[unstable(feature = "future_poll_once", issue = "92115")]
+    fn poll_once(self) -> PollOnce<Self>
+    where
+        Self: Sized,
+    {
+        PollOnce { future: self }
+    }
 }
 
 #[stable(feature = "futures_api", since = "1.36.0")]

--- a/library/core/src/future/mod.rs
+++ b/library/core/src/future/mod.rs
@@ -13,6 +13,7 @@ mod future;
 mod into_future;
 mod pending;
 mod poll_fn;
+mod poll_once;
 mod ready;
 
 #[stable(feature = "futures_api", since = "1.36.0")]
@@ -28,6 +29,9 @@ pub use ready::{ready, Ready};
 
 #[unstable(feature = "future_poll_fn", issue = "72302")]
 pub use poll_fn::{poll_fn, PollFn};
+
+#[unstable(feature = "future_poll_once", issue = "92115")]
+pub use poll_once::PollOnce;
 
 /// This type is needed because:
 ///

--- a/library/core/src/future/poll_once.rs
+++ b/library/core/src/future/poll_once.rs
@@ -1,0 +1,32 @@
+use crate::fmt;
+use crate::future::Future;
+use crate::pin::Pin;
+use crate::task::{Context, Poll};
+
+/// Resolves to the output of polling a future once.
+///
+/// This `struct` is created by [`poll_once()`]. See its
+/// documentation for more.
+#[unstable(feature = "future_poll_once", issue = "92115")]
+pub struct PollOnce<F> {
+    pub(crate) future: F,
+}
+
+#[unstable(feature = "future_poll_once", issue = "92115")]
+impl<F> fmt::Debug for PollOnce<F> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("PollOnce").finish()
+    }
+}
+
+#[unstable(feature = "future_poll_once", issue = "92115")]
+impl<F> Future for PollOnce<F>
+where
+    F: Future + Unpin,
+{
+    type Output = Poll<F::Output>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        Poll::Ready(Pin::new(&mut self.future).poll(cx))
+    }
+}


### PR DESCRIPTION
This PR adds `Future::poll_once`, which returns the output of polling a future once.

```rust
let f = ready(1);
assert_eq!(f.poll_once().await, Poll::Ready(1));

let mut f = pending();
assert_eq!(f.poll_once().await, Poll::Pending);
```

I'm not sure what a good name for this would be (try_await?). It isn't polling *once* any more than `Future::poll` is. Maybe keeping it as a macro/free-standing function is the best way to resolve the ambiguity?

Prior Art: https://docs.rs/futures/latest/futures/macro.poll.html

(Can someone on the team cc/ @rust-lang/wg-async-foundations?)