### PR TITLE
Parse and suggest moving where clauses after equals for type aliases

### DIFF
--- a/compiler/rustc_ast_pretty/src/pprust/state.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state.rs
@@ -2780,34 +2780,34 @@ impl<'a> State<'a> {
                 self.word_space(",");
             }
 
-            match *predicate {
-                ast::WherePredicate::BoundPredicate(ast::WhereBoundPredicate {
-                    ref bound_generic_params,
-                    ref bounded_ty,
-                    ref bounds,
-                    ..
-                }) => {
-                    self.print_formal_generic_params(bound_generic_params);
-                    self.print_type(bounded_ty);
-                    self.print_type_bounds(":", bounds);
-                }
-                ast::WherePredicate::RegionPredicate(ast::WhereRegionPredicate {
-                    ref lifetime,
-                    ref bounds,
-                    ..
-                }) => {
-                    self.print_lifetime_bounds(*lifetime, bounds);
-                }
-                ast::WherePredicate::EqPredicate(ast::WhereEqPredicate {
-                    ref lhs_ty,
-                    ref rhs_ty,
-                    ..
-                }) => {
-                    self.print_type(lhs_ty);
-                    self.space();
-                    self.word_space("=");
-                    self.print_type(rhs_ty);
-                }
+            self.print_where_predicate(predicate);
+        }
+    }
+
+    pub fn print_where_predicate(&mut self, predicate: &ast::WherePredicate) {
+        match predicate {
+            ast::WherePredicate::BoundPredicate(ast::WhereBoundPredicate {
+                bound_generic_params,
+                bounded_ty,
+                bounds,
+                ..
+            }) => {
+                self.print_formal_generic_params(bound_generic_params);
+                self.print_type(bounded_ty);
+                self.print_type_bounds(":", bounds);
+            }
+            ast::WherePredicate::RegionPredicate(ast::WhereRegionPredicate {
+                lifetime,
+                bounds,
+                ..
+            }) => {
+                self.print_lifetime_bounds(*lifetime, bounds);
+            }
+            ast::WherePredicate::EqPredicate(ast::WhereEqPredicate { lhs_ty, rhs_ty, .. }) => {
+                self.print_type(lhs_ty);
+                self.space();
+                self.word_space("=");
+                self.print_type(rhs_ty);
             }
         }
     }

--- a/src/test/ui/parser/type-alias-where.rs
+++ b/src/test/ui/parser/type-alias-where.rs
@@ -1,0 +1,37 @@
+// check-fail
+
+#![feature(generic_associated_types)]
+
+// Fine, but lints as unused
+type Foo where u32: Copy = ();
+// Not fine.
+type Bar = () where u32: Copy;
+//~^ ERROR where clause not allowed here
+type Baz = () where;
+//~^ ERROR where clause not allowed here
+
+trait Trait {
+    // Fine.
+    type Assoc where u32: Copy;
+    // Fine.
+    type Assoc2 where u32: Copy, i32: Copy;
+}
+
+impl Trait for u32 {
+    // Fine.
+    type Assoc where u32: Copy = ();
+    // Not fine, suggests moving `i32: Copy`
+    type Assoc2 where u32: Copy = () where i32: Copy;
+    //~^ ERROR where clause not allowed here
+}
+
+impl Trait for i32 {
+    // Not fine, suggests moving `u32: Copy`
+    type Assoc = () where u32: Copy;
+    //~^ ERROR where clause not allowed here
+    // Not fine, suggests moving both.
+    type Assoc2 = () where u32: Copy, i32: Copy;
+    //~^ ERROR where clause not allowed here
+}
+
+fn main() {}

--- a/src/test/ui/parser/type-alias-where.stderr
+++ b/src/test/ui/parser/type-alias-where.stderr
@@ -1,0 +1,40 @@
+error: where clause not allowed here
+  --> $DIR/type-alias-where.rs:8:15
+   |
+LL | type Bar = () where u32: Copy;
+   |         -     ^^^^^^^^^^^^^^^
+   |         |
+   |         help: move it here: `where u32: Copy`
+
+error: where clause not allowed here
+  --> $DIR/type-alias-where.rs:10:15
+   |
+LL | type Baz = () where;
+   |               ^^^^^
+
+error: where clause not allowed here
+  --> $DIR/type-alias-where.rs:24:38
+   |
+LL |     type Assoc2 where u32: Copy = () where i32: Copy;
+   |                                -     ^^^^^^^^^^^^^^^
+   |                                |
+   |                                help: move it here: `, i32: Copy`
+
+error: where clause not allowed here
+  --> $DIR/type-alias-where.rs:30:21
+   |
+LL |     type Assoc = () where u32: Copy;
+   |               -     ^^^^^^^^^^^^^^^
+   |               |
+   |               help: move it here: `where u32: Copy`
+
+error: where clause not allowed here
+  --> $DIR/type-alias-where.rs:33:22
+   |
+LL |     type Assoc2 = () where u32: Copy, i32: Copy;
+   |                -     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                |
+   |                help: move it here: `where u32: Copy, i32: Copy`
+
+error: aborting due to 5 previous errors
+


### PR DESCRIPTION
~Mostly the same as #90076, but doesn't make any syntax changes.~ Whether or not we want to land the syntax changes, we should  parse the invalid where clause position and suggest moving.

r? @nikomatsakis 
cc @petrochenkov you might have thoughts on implementation