### PR TITLE
disable test with self-referential generator on Miri

### DIFF
--- a/library/core/tests/future.rs
+++ b/library/core/tests/future.rs
@@ -30,6 +30,7 @@ fn poll_n(val: usize, num: usize) -> PollN {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)] // self-referential generators do not work with Miri's aliasing checks
 fn test_join() {
     block_on(async move {
         let x = join!(async { 0 }).await;


### PR DESCRIPTION
Running the libcore test suite in Miri currently fails due to the known incompatibility of self-referential generators with Miri's aliasing checks (https://github.com/rust-lang/unsafe-code-guidelines/issues/148). So let's disable that test in Miri for now.