### PR TITLE
Implement RFC 3184 - thread local cell methods

### DIFF
--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -249,6 +249,7 @@
 #![feature(const_ip)]
 #![feature(const_ipv4)]
 #![feature(const_ipv6)]
+#![feature(const_mut_refs)]
 #![feature(const_option)]
 #![feature(const_socketaddr)]
 #![feature(const_trait_impl)]

--- a/library/std/src/thread/local.rs
+++ b/library/std/src/thread/local.rs
@@ -482,7 +482,7 @@ impl<T: 'static> LocalKey<Cell<T>> {
     ///
     /// assert_eq!(X.get(), 123);
     /// ```
-    #[unstable(feature = "local_key_cell_methods", issue = "none")]
+    #[unstable(feature = "local_key_cell_methods", issue = "92122")]
     pub fn set(&'static self, value: T) {
         self.initialize_with(Cell::new(value), |init, cell| {
             if let Some(init) = init {
@@ -513,7 +513,7 @@ impl<T: 'static> LocalKey<Cell<T>> {
     ///
     /// assert_eq!(X.get(), 1);
     /// ```
-    #[unstable(feature = "local_key_cell_methods", issue = "none")]
+    #[unstable(feature = "local_key_cell_methods", issue = "92122")]
     pub fn get(&'static self) -> T
     where
         T: Copy,
@@ -544,7 +544,7 @@ impl<T: 'static> LocalKey<Cell<T>> {
     /// assert_eq!(X.take(), Some(1));
     /// assert_eq!(X.take(), None);
     /// ```
-    #[unstable(feature = "local_key_cell_methods", issue = "none")]
+    #[unstable(feature = "local_key_cell_methods", issue = "92122")]
     pub fn take(&'static self) -> T
     where
         T: Default,
@@ -575,7 +575,7 @@ impl<T: 'static> LocalKey<Cell<T>> {
     /// assert_eq!(X.replace(2), 1);
     /// assert_eq!(X.replace(3), 2);
     /// ```
-    #[unstable(feature = "local_key_cell_methods", issue = "none")]
+    #[unstable(feature = "local_key_cell_methods", issue = "92122")]
     pub fn replace(&'static self, value: T) -> T {
         self.with(|cell| cell.replace(value))
     }
@@ -606,7 +606,7 @@ impl<T: 'static> LocalKey<RefCell<T>> {
     ///
     /// X.with_borrow(|v| assert!(v.is_empty()));
     /// ```
-    #[unstable(feature = "local_key_cell_methods", issue = "none")]
+    #[unstable(feature = "local_key_cell_methods", issue = "92122")]
     pub fn with_borrow<F, R>(&'static self, f: F) -> R
     where
         F: FnOnce(&T) -> R,
@@ -640,7 +640,7 @@ impl<T: 'static> LocalKey<RefCell<T>> {
     ///
     /// X.with_borrow(|v| assert_eq!(*v, vec![1]));
     /// ```
-    #[unstable(feature = "local_key_cell_methods", issue = "none")]
+    #[unstable(feature = "local_key_cell_methods", issue = "92122")]
     pub fn with_borrow_mut<F, R>(&'static self, f: F) -> R
     where
         F: FnOnce(&mut T) -> R,
@@ -675,7 +675,7 @@ impl<T: 'static> LocalKey<RefCell<T>> {
     ///
     /// X.with_borrow(|v| assert_eq!(*v, vec![1, 2, 3]));
     /// ```
-    #[unstable(feature = "local_key_cell_methods", issue = "none")]
+    #[unstable(feature = "local_key_cell_methods", issue = "92122")]
     pub fn set(&'static self, value: T) {
         self.initialize_with(RefCell::new(value), |init, cell| {
             if let Some(init) = init {
@@ -714,7 +714,7 @@ impl<T: 'static> LocalKey<RefCell<T>> {
     ///
     /// X.with_borrow(|v| assert!(v.is_empty()));
     /// ```
-    #[unstable(feature = "local_key_cell_methods", issue = "none")]
+    #[unstable(feature = "local_key_cell_methods", issue = "92122")]
     pub fn take(&'static self) -> T
     where
         T: Default,
@@ -746,7 +746,7 @@ impl<T: 'static> LocalKey<RefCell<T>> {
     ///
     /// X.with_borrow(|v| assert_eq!(*v, vec![1, 2, 3]));
     /// ```
-    #[unstable(feature = "local_key_cell_methods", issue = "none")]
+    #[unstable(feature = "local_key_cell_methods", issue = "92122")]
     pub fn replace(&'static self, value: T) -> T {
         self.with(|cell| cell.replace(value))
     }

--- a/library/std/src/thread/local.rs
+++ b/library/std/src/thread/local.rs
@@ -268,6 +268,8 @@ macro_rules! __thread_local_inner {
                         if let $crate::option::Option::Some(init) = _init {
                             if let $crate::option::Option::Some(value) = init.take() {
                                 return value;
+                            } else if $crate::cfg!(debug_assertions) {
+                                unreachable!("missing initial value");
                             }
                         }
                         __init()
@@ -341,6 +343,8 @@ macro_rules! __thread_local_inner {
                         if let $crate::option::Option::Some(init) = init {
                             if let $crate::option::Option::Some(value) = init.take() {
                                 return value;
+                            } else if $crate::cfg!(debug_assertions) {
+                                unreachable!("missing default value");
                             }
                         }
                         __init()

--- a/library/std/src/thread/local.rs
+++ b/library/std/src/thread/local.rs
@@ -630,7 +630,7 @@ impl<T: 'static> LocalKey<RefCell<T>> {
     where
         F: FnOnce(&T) -> R,
     {
-        self.with(|cell| f(&mut cell.borrow()))
+        self.with(|cell| f(&cell.borrow()))
     }
 
     /// Acquires a mutable reference to the contained value.
@@ -703,7 +703,7 @@ impl<T: 'static> LocalKey<RefCell<T>> {
                 // The cell was already initialized, so `value` wasn't used to
                 // initialize it. So we overwrite the current value with the
                 // new one instead.
-                cell.replace(init.into_inner());
+                *cell.borrow_mut() = value.into_inner();
             }
         });
     }

--- a/library/std/src/thread/local.rs
+++ b/library/std/src/thread/local.rs
@@ -604,10 +604,10 @@ impl<T: 'static> LocalKey<RefCell<T>> {
     ///     static X: RefCell<Vec<i32>> = RefCell::new(Vec::new());
     /// }
     ///
-    /// X.with_ref(|v| assert!(v.is_empty()));
+    /// X.with_borrow(|v| assert!(v.is_empty()));
     /// ```
     #[unstable(feature = "local_key_cell_methods", issue = "none")]
-    pub fn with_ref<F, R>(&'static self, f: F) -> R
+    pub fn with_borrow<F, R>(&'static self, f: F) -> R
     where
         F: FnOnce(&T) -> R,
     {
@@ -636,12 +636,12 @@ impl<T: 'static> LocalKey<RefCell<T>> {
     ///     static X: RefCell<Vec<i32>> = RefCell::new(Vec::new());
     /// }
     ///
-    /// X.with_mut(|v| v.push(1));
+    /// X.with_borrow_mut(|v| v.push(1));
     ///
-    /// X.with_ref(|v| assert_eq!(*v, vec![1]));
+    /// X.with_borrow(|v| assert_eq!(*v, vec![1]));
     /// ```
     #[unstable(feature = "local_key_cell_methods", issue = "none")]
-    pub fn with_mut<F, R>(&'static self, f: F) -> R
+    pub fn with_borrow_mut<F, R>(&'static self, f: F) -> R
     where
         F: FnOnce(&mut T) -> R,
     {
@@ -673,7 +673,7 @@ impl<T: 'static> LocalKey<RefCell<T>> {
     ///
     /// X.set(vec![1, 2, 3]); // But X.set() is fine, as it skips the initializer above.
     ///
-    /// X.with_ref(|v| assert_eq!(*v, vec![1, 2, 3]));
+    /// X.with_borrow(|v| assert_eq!(*v, vec![1, 2, 3]));
     /// ```
     #[unstable(feature = "local_key_cell_methods", issue = "none")]
     pub fn set(&'static self, value: T) {
@@ -706,13 +706,13 @@ impl<T: 'static> LocalKey<RefCell<T>> {
     ///     static X: RefCell<Vec<i32>> = RefCell::new(Vec::new());
     /// }
     ///
-    /// X.with_mut(|v| v.push(1));
+    /// X.with_borrow_mut(|v| v.push(1));
     ///
     /// let a = X.take();
     ///
     /// assert_eq!(a, vec![1]);
     ///
-    /// X.with_ref(|v| assert!(v.is_empty()));
+    /// X.with_borrow(|v| assert!(v.is_empty()));
     /// ```
     #[unstable(feature = "local_key_cell_methods", issue = "none")]
     pub fn take(&'static self) -> T
@@ -744,7 +744,7 @@ impl<T: 'static> LocalKey<RefCell<T>> {
     /// let prev = X.replace(vec![1, 2, 3]);
     /// assert!(prev.is_empty());
     ///
-    /// X.with_ref(|v| assert_eq!(*v, vec![1, 2, 3]));
+    /// X.with_borrow(|v| assert_eq!(*v, vec![1, 2, 3]));
     /// ```
     #[unstable(feature = "local_key_cell_methods", issue = "none")]
     pub fn replace(&'static self, value: T) -> T {

--- a/src/test/ui/suggestions/missing-lifetime-specifier.rs
+++ b/src/test/ui/suggestions/missing-lifetime-specifier.rs
@@ -45,10 +45,12 @@ thread_local! {
     //~| ERROR this union takes 2 lifetime arguments but 1 lifetime argument was supplied
     //~| ERROR this union takes 2 lifetime arguments but 1 lifetime argument was supplied
     //~| ERROR this union takes 2 lifetime arguments but 1 lifetime argument was supplied
+    //~| ERROR this union takes 2 lifetime arguments but 1 lifetime argument was supplied
 }
 thread_local! {
     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, i32>>>>> = RefCell::new(HashMap::new());
     //~^ ERROR this trait takes 2 lifetime arguments but 1 lifetime argument was supplied
+    //~| ERROR this trait takes 2 lifetime arguments but 1 lifetime argument was supplied
     //~| ERROR this trait takes 2 lifetime arguments but 1 lifetime argument was supplied
     //~| ERROR this trait takes 2 lifetime arguments but 1 lifetime argument was supplied
     //~| ERROR this trait takes 2 lifetime arguments but 1 lifetime argument was supplied

--- a/src/test/ui/suggestions/missing-lifetime-specifier.stderr
+++ b/src/test/ui/suggestions/missing-lifetime-specifier.stderr
@@ -13,14 +13,15 @@ LL |     static a: RefCell<HashMap<i32, Vec<Vec<Foo<'static, 'static>>>>> = RefC
 error[E0106]: missing lifetime specifiers
   --> $DIR/missing-lifetime-specifier.rs:18:44
    |
-LL |     static a: RefCell<HashMap<i32, Vec<Vec<Foo>>>> = RefCell::new(HashMap::new());
-   |                                            ^^^ expected 2 lifetime parameters
+LL | / thread_local! {
+LL | |     static a: RefCell<HashMap<i32, Vec<Vec<Foo>>>> = RefCell::new(HashMap::new());
+   | |                                            ^^^ expected 2 lifetime parameters
+LL | |
+LL | |
+LL | | }
+   | |_-
    |
-   = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
-help: consider using the `'static` lifetime
-   |
-LL |     static a: RefCell<HashMap<i32, Vec<Vec<Foo<'static, 'static>>>>> = RefCell::new(HashMap::new());
-   |                                            ~~~~~~~~~~~~~~~~~~~~~
+   = help: this function's return type contains a borrowed value, but the signature does not say which one of `init`'s 3 lifetimes it is borrowed from
 
 error[E0106]: missing lifetime specifier
   --> $DIR/missing-lifetime-specifier.rs:23:44
@@ -49,26 +50,32 @@ LL |     static b: RefCell<HashMap<i32, Vec<Vec<&Bar<'static, 'static>>>>> = Ref
 error[E0106]: missing lifetime specifier
   --> $DIR/missing-lifetime-specifier.rs:23:44
    |
-LL |     static b: RefCell<HashMap<i32, Vec<Vec<&Bar>>>> = RefCell::new(HashMap::new());
-   |                                            ^ expected named lifetime parameter
+LL | / thread_local! {
+LL | |     static b: RefCell<HashMap<i32, Vec<Vec<&Bar>>>> = RefCell::new(HashMap::new());
+   | |                                            ^ expected named lifetime parameter
+LL | |
+LL | |
+LL | |
+LL | |
+LL | | }
+   | |_-
    |
-   = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
-help: consider using the `'static` lifetime
-   |
-LL |     static b: RefCell<HashMap<i32, Vec<Vec<&'static Bar>>>> = RefCell::new(HashMap::new());
-   |                                            ~~~~~~~~
+   = help: this function's return type contains a borrowed value, but the signature does not say which one of `init`'s 4 lifetimes it is borrowed from
 
 error[E0106]: missing lifetime specifiers
   --> $DIR/missing-lifetime-specifier.rs:23:45
    |
-LL |     static b: RefCell<HashMap<i32, Vec<Vec<&Bar>>>> = RefCell::new(HashMap::new());
-   |                                             ^^^ expected 2 lifetime parameters
+LL | / thread_local! {
+LL | |     static b: RefCell<HashMap<i32, Vec<Vec<&Bar>>>> = RefCell::new(HashMap::new());
+   | |                                             ^^^ expected 2 lifetime parameters
+LL | |
+LL | |
+LL | |
+LL | |
+LL | | }
+   | |_-
    |
-   = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
-help: consider using the `'static` lifetime
-   |
-LL |     static b: RefCell<HashMap<i32, Vec<Vec<&Bar<'static, 'static>>>>> = RefCell::new(HashMap::new());
-   |                                             ~~~~~~~~~~~~~~~~~~~~~
+   = help: this function's return type contains a borrowed value, but the signature does not say which one of `init`'s 4 lifetimes it is borrowed from
 
 error[E0106]: missing lifetime specifiers
   --> $DIR/missing-lifetime-specifier.rs:30:48
@@ -85,14 +92,15 @@ LL |     static c: RefCell<HashMap<i32, Vec<Vec<Qux<'static, 'static, i32>>>>> =
 error[E0106]: missing lifetime specifiers
   --> $DIR/missing-lifetime-specifier.rs:30:48
    |
-LL |     static c: RefCell<HashMap<i32, Vec<Vec<Qux<i32>>>>> = RefCell::new(HashMap::new());
-   |                                                ^ expected 2 lifetime parameters
+LL | / thread_local! {
+LL | |     static c: RefCell<HashMap<i32, Vec<Vec<Qux<i32>>>>> = RefCell::new(HashMap::new());
+   | |                                                ^ expected 2 lifetime parameters
+LL | |
+LL | |
+LL | | }
+   | |_-
    |
-   = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
-help: consider using the `'static` lifetime
-   |
-LL |     static c: RefCell<HashMap<i32, Vec<Vec<Qux<'static, 'static, i32>>>>> = RefCell::new(HashMap::new());
-   |                                                +++++++++++++++++
+   = help: this function's return type contains a borrowed value, but the signature does not say which one of `init`'s 3 lifetimes it is borrowed from
 
 error[E0106]: missing lifetime specifier
   --> $DIR/missing-lifetime-specifier.rs:35:44
@@ -121,26 +129,32 @@ LL |     static d: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, 'static, i32>>>>> 
 error[E0106]: missing lifetime specifier
   --> $DIR/missing-lifetime-specifier.rs:35:44
    |
-LL |     static d: RefCell<HashMap<i32, Vec<Vec<&Tar<i32>>>>> = RefCell::new(HashMap::new());
-   |                                            ^ expected named lifetime parameter
+LL | / thread_local! {
+LL | |     static d: RefCell<HashMap<i32, Vec<Vec<&Tar<i32>>>>> = RefCell::new(HashMap::new());
+   | |                                            ^ expected named lifetime parameter
+LL | |
+LL | |
+LL | |
+LL | |
+LL | | }
+   | |_-
    |
-   = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
-help: consider using the `'static` lifetime
-   |
-LL |     static d: RefCell<HashMap<i32, Vec<Vec<&'static Tar<i32>>>>> = RefCell::new(HashMap::new());
-   |                                            ~~~~~~~~
+   = help: this function's return type contains a borrowed value, but the signature does not say which one of `init`'s 4 lifetimes it is borrowed from
 
 error[E0106]: missing lifetime specifiers
   --> $DIR/missing-lifetime-specifier.rs:35:49
    |
-LL |     static d: RefCell<HashMap<i32, Vec<Vec<&Tar<i32>>>>> = RefCell::new(HashMap::new());
-   |                                                 ^ expected 2 lifetime parameters
+LL | / thread_local! {
+LL | |     static d: RefCell<HashMap<i32, Vec<Vec<&Tar<i32>>>>> = RefCell::new(HashMap::new());
+   | |                                                 ^ expected 2 lifetime parameters
+LL | |
+LL | |
+LL | |
+LL | |
+LL | | }
+   | |_-
    |
-   = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
-help: consider using the `'static` lifetime
-   |
-LL |     static d: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, 'static, i32>>>>> = RefCell::new(HashMap::new());
-   |                                                 +++++++++++++++++
+   = help: this function's return type contains a borrowed value, but the signature does not say which one of `init`'s 4 lifetimes it is borrowed from
 
 error[E0107]: this union takes 2 lifetime arguments but 1 lifetime argument was supplied
   --> $DIR/missing-lifetime-specifier.rs:43:44
@@ -211,11 +225,29 @@ LL | pub union Qux<'t, 'k, I> {
    |           ^^^ --  --
 help: add missing lifetime argument
    |
+LL |     static e: RefCell<HashMap<i32, Vec<Vec<Qux<'static, 'k, i32>>>>> = RefCell::new(HashMap::new());
+   |                                                       ++++
+
+error[E0107]: this union takes 2 lifetime arguments but 1 lifetime argument was supplied
+  --> $DIR/missing-lifetime-specifier.rs:43:44
+   |
+LL |     static e: RefCell<HashMap<i32, Vec<Vec<Qux<'static, i32>>>>> = RefCell::new(HashMap::new());
+   |                                            ^^^ ------- supplied 1 lifetime argument
+   |                                            |
+   |                                            expected 2 lifetime arguments
+   |
+note: union defined here, with 2 lifetime parameters: `'t`, `'k`
+  --> $DIR/missing-lifetime-specifier.rs:11:11
+   |
+LL | pub union Qux<'t, 'k, I> {
+   |           ^^^ --  --
+help: add missing lifetime argument
+   |
 LL |     static e: RefCell<HashMap<i32, Vec<Vec<Qux<'static, '_, i32>>>>> = RefCell::new(HashMap::new());
    |                                                       ++++
 
 error[E0107]: this trait takes 2 lifetime arguments but 1 lifetime argument was supplied
-  --> $DIR/missing-lifetime-specifier.rs:50:45
+  --> $DIR/missing-lifetime-specifier.rs:51:45
    |
 LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, i32>>>>> = RefCell::new(HashMap::new());
    |                                             ^^^ ------- supplied 1 lifetime argument
@@ -233,7 +265,7 @@ LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, '_, i32>>>>> = Ref
    |                                                        ++++
 
 error[E0106]: missing lifetime specifier
-  --> $DIR/missing-lifetime-specifier.rs:50:44
+  --> $DIR/missing-lifetime-specifier.rs:51:44
    |
 LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, i32>>>>> = RefCell::new(HashMap::new());
    |                                            ^ expected named lifetime parameter
@@ -245,7 +277,7 @@ LL |     static f: RefCell<HashMap<i32, Vec<Vec<&'static Tar<'static, i32>>>>> =
    |                                            ~~~~~~~~
 
 error[E0107]: this trait takes 2 lifetime arguments but 1 lifetime argument was supplied
-  --> $DIR/missing-lifetime-specifier.rs:50:45
+  --> $DIR/missing-lifetime-specifier.rs:51:45
    |
 LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, i32>>>>> = RefCell::new(HashMap::new());
    |                                             ^^^ ------- supplied 1 lifetime argument
@@ -263,19 +295,22 @@ LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, 'k, i32>>>>> = Ref
    |                                                        ++++
 
 error[E0106]: missing lifetime specifier
-  --> $DIR/missing-lifetime-specifier.rs:50:44
+  --> $DIR/missing-lifetime-specifier.rs:51:44
    |
-LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, i32>>>>> = RefCell::new(HashMap::new());
-   |                                            ^ expected named lifetime parameter
+LL | / thread_local! {
+LL | |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, i32>>>>> = RefCell::new(HashMap::new());
+   | |                                            ^ expected named lifetime parameter
+LL | |
+LL | |
+...  |
+LL | |
+LL | | }
+   | |_-
    |
-   = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
-help: consider using the `'static` lifetime
-   |
-LL |     static f: RefCell<HashMap<i32, Vec<Vec<&'static Tar<'static, i32>>>>> = RefCell::new(HashMap::new());
-   |                                            ~~~~~~~~
+   = help: this function's return type contains a borrowed value, but the signature does not say which one of `init`'s 3 lifetimes it is borrowed from
 
 error[E0107]: this trait takes 2 lifetime arguments but 1 lifetime argument was supplied
-  --> $DIR/missing-lifetime-specifier.rs:50:45
+  --> $DIR/missing-lifetime-specifier.rs:51:45
    |
 LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, i32>>>>> = RefCell::new(HashMap::new());
    |                                             ^^^ ------- supplied 1 lifetime argument
@@ -293,7 +328,25 @@ LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, 'k, i32>>>>> = Ref
    |                                                        ++++
 
 error[E0107]: this trait takes 2 lifetime arguments but 1 lifetime argument was supplied
-  --> $DIR/missing-lifetime-specifier.rs:50:45
+  --> $DIR/missing-lifetime-specifier.rs:51:45
+   |
+LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, i32>>>>> = RefCell::new(HashMap::new());
+   |                                             ^^^ ------- supplied 1 lifetime argument
+   |                                             |
+   |                                             expected 2 lifetime arguments
+   |
+note: trait defined here, with 2 lifetime parameters: `'t`, `'k`
+  --> $DIR/missing-lifetime-specifier.rs:15:7
+   |
+LL | trait Tar<'t, 'k, I> {}
+   |       ^^^ --  --
+help: add missing lifetime argument
+   |
+LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, 'k, i32>>>>> = RefCell::new(HashMap::new());
+   |                                                        ++++
+
+error[E0107]: this trait takes 2 lifetime arguments but 1 lifetime argument was supplied
+  --> $DIR/missing-lifetime-specifier.rs:51:45
    |
 LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, i32>>>>> = RefCell::new(HashMap::new());
    |                                             ^^^ ------- supplied 1 lifetime argument
@@ -310,7 +363,7 @@ help: add missing lifetime argument
 LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, '_, i32>>>>> = RefCell::new(HashMap::new());
    |                                                        ++++
 
-error: aborting due to 22 previous errors
+error: aborting due to 24 previous errors
 
 Some errors have detailed explanations: E0106, E0107.
 For more information about an error, try `rustc --explain E0106`.

--- a/src/test/ui/threads-sendsync/issue-43733.mir.stderr
+++ b/src/test/ui/threads-sendsync/issue-43733.mir.stderr
@@ -1,5 +1,5 @@
 error[E0133]: call to unsafe function is unsafe and requires unsafe function or block
-  --> $DIR/issue-43733.rs:17:5
+  --> $DIR/issue-43733.rs:19:5
    |
 LL |     __KEY.get(Default::default)
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function
@@ -7,7 +7,7 @@ LL |     __KEY.get(Default::default)
    = note: consult the function's documentation for information on how to avoid undefined behavior
 
 error[E0133]: call to unsafe function is unsafe and requires unsafe function or block
-  --> $DIR/issue-43733.rs:20:42
+  --> $DIR/issue-43733.rs:22:42
    |
 LL | static FOO: std::thread::LocalKey<Foo> = std::thread::LocalKey::new(__getit);
    |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function

--- a/src/test/ui/threads-sendsync/issue-43733.rs
+++ b/src/test/ui/threads-sendsync/issue-43733.rs
@@ -4,6 +4,8 @@
 #![feature(thread_local)]
 #![feature(cfg_target_thread_local, thread_local_internals)]
 
+use std::cell::RefCell;
+
 type Foo = std::cell::RefCell<String>;
 
 #[cfg(target_thread_local)]
@@ -13,7 +15,7 @@ static __KEY: std::thread::__FastLocalKeyInner<Foo> = std::thread::__FastLocalKe
 #[cfg(not(target_thread_local))]
 static __KEY: std::thread::__OsLocalKeyInner<Foo> = std::thread::__OsLocalKeyInner::new();
 
-fn __getit() -> std::option::Option<&'static Foo> {
+fn __getit(_: Option<&mut Option<RefCell<String>>>) -> std::option::Option<&'static Foo> {
     __KEY.get(Default::default) //~ ERROR call to unsafe function is unsafe
 }
 

--- a/src/test/ui/threads-sendsync/issue-43733.thir.stderr
+++ b/src/test/ui/threads-sendsync/issue-43733.thir.stderr
@@ -1,5 +1,5 @@
 error[E0133]: call to unsafe function is unsafe and requires unsafe function or block
-  --> $DIR/issue-43733.rs:17:5
+  --> $DIR/issue-43733.rs:19:5
    |
 LL |     __KEY.get(Default::default)
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function
@@ -7,7 +7,7 @@ LL |     __KEY.get(Default::default)
    = note: consult the function's documentation for information on how to avoid undefined behavior
 
 error[E0133]: call to unsafe function is unsafe and requires unsafe function or block
-  --> $DIR/issue-43733.rs:20:42
+  --> $DIR/issue-43733.rs:22:42
    |
 LL | static FOO: std::thread::LocalKey<Foo> = std::thread::LocalKey::new(__getit);
    |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function


### PR DESCRIPTION
This implements [RFC 3184](https://github.com/rust-lang/rfcs/pull/3184), with @danielhenrymantilla's [suggestion](https://github.com/rust-lang/rfcs/pull/3184#issuecomment-965773616) for the `with_` method names.

Tracking issue: https://github.com/rust-lang/rust/issues/92122