### PR TITLE
Add `#[inline]` modifier to `TypeId::of`

### DIFF
--- a/library/core/src/any.rs
+++ b/library/core/src/any.rs
@@ -616,6 +616,7 @@ impl TypeId {
     /// assert_eq!(is_string(&0), false);
     /// assert_eq!(is_string(&"cookie monster".to_string()), true);
     /// ```
+    #[inline]
     #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_const_unstable(feature = "const_type_id", issue = "77125")]


### PR DESCRIPTION
It was already inlined but it happened only in 4th InlinerPass on my testcase.
With `#[inline]` modifier it happens on 2nd pass.

Closes #74362