### PR TITLE
Change Backtrace::enabled atomic from SeqCst to Relaxed

### DIFF
--- a/library/std/src/backtrace.rs
+++ b/library/std/src/backtrace.rs
@@ -99,7 +99,7 @@ use crate::cell::UnsafeCell;
 use crate::env;
 use crate::ffi::c_void;
 use crate::fmt;
-use crate::sync::atomic::{AtomicUsize, Ordering::SeqCst};
+use crate::sync::atomic::{AtomicUsize, Ordering::Relaxed};
 use crate::sync::Once;
 use crate::sys_common::backtrace::{lock, output_filename};
 use crate::vec::Vec;
@@ -256,7 +256,7 @@ impl Backtrace {
         // backtrace captures speedy, because otherwise reading environment
         // variables every time can be somewhat slow.
         static ENABLED: AtomicUsize = AtomicUsize::new(0);
-        match ENABLED.load(SeqCst) {
+        match ENABLED.load(Relaxed) {
             0 => {}
             1 => return false,
             _ => return true,
@@ -268,7 +268,7 @@ impl Backtrace {
                 Err(_) => false,
             },
         };
-        ENABLED.store(enabled as usize + 1, SeqCst);
+        ENABLED.store(enabled as usize + 1, Relaxed);
         enabled
     }
 


### PR DESCRIPTION
This atomic is not synchronizing anything outside of its own value, so we don't need the `Acquire`/`Release` guarantee that all memory operations prior to the store are visible after the subsequent load, nor the `SeqCst` guarantee of all threads seeing all of the sequentially consistent operations in the same order.

Using `Relaxed` reduces the overhead of `Backtrace::capture()` in the case that backtraces are not enabled.

## Benchmark

```rust
#![feature(backtrace)]

use std::backtrace::Backtrace;
use std::sync::atomic::{AtomicUsize, Ordering};
use std::thread;
use std::time::Instant;

fn main() {
    let begin = Instant::now();
    let mut threads = Vec::new();
    for _ in 0..64 {
        threads.push(thread::spawn(|| {
            for _ in 0..10_000_000 {
                let _ = Backtrace::capture();
                static LOL: AtomicUsize = AtomicUsize::new(0);
                LOL.store(1, Ordering::Release);
            }
        }));
    }
    for thread in threads {
        let _ = thread.join();
    }
    println!("{:?}", begin.elapsed());
}
```

**Before:**&ensp;6.73 seconds
**After:**&ensp;5.18 seconds