### PR TITLE
Don't emit shared files when scraping examples from dependencies in Rustdoc

### DIFF
--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -282,7 +282,10 @@ crate struct RenderOptions {
     crate emit: Vec<EmitType>,
     /// If `true`, HTML source pages will generate links for items to their definition.
     crate generate_link_to_definition: bool,
+    /// Set of function-call locations to include as examples
     crate call_locations: AllCallLocations,
+    /// If `true`, Context::init will not emit shared files.
+    crate no_emit_shared: bool,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -753,6 +756,7 @@ impl Options {
                 emit,
                 generate_link_to_definition,
                 call_locations,
+                no_emit_shared: false,
             },
             crate_name,
             output_format,

--- a/src/librustdoc/html/render/context.rs
+++ b/src/librustdoc/html/render/context.rs
@@ -405,6 +405,7 @@ impl<'tcx> FormatRenderer<'tcx> for Context<'tcx> {
             show_type_layout,
             generate_link_to_definition,
             call_locations,
+            no_emit_shared,
             ..
         } = options;
 
@@ -525,13 +526,16 @@ impl<'tcx> FormatRenderer<'tcx> for Context<'tcx> {
             sources::render(&mut cx, &krate)?;
         }
 
-        // Build our search index
-        let index = build_index(&krate, &mut Rc::get_mut(&mut cx.shared).unwrap().cache, tcx);
+        if !no_emit_shared {
+            // Build our search index
+            let index = build_index(&krate, &mut Rc::get_mut(&mut cx.shared).unwrap().cache, tcx);
 
-        // Write shared runs within a flock; disable thread dispatching of IO temporarily.
-        Rc::get_mut(&mut cx.shared).unwrap().fs.set_sync_only(true);
-        write_shared(&cx, &krate, index, &md_opts)?;
-        Rc::get_mut(&mut cx.shared).unwrap().fs.set_sync_only(false);
+            // Write shared runs within a flock; disable thread dispatching of IO temporarily.
+            Rc::get_mut(&mut cx.shared).unwrap().fs.set_sync_only(true);
+            write_shared(&cx, &krate, index, &md_opts)?;
+            Rc::get_mut(&mut cx.shared).unwrap().fs.set_sync_only(false);
+        }
+
         Ok((cx, krate))
     }
 

--- a/src/librustdoc/scrape_examples.rs
+++ b/src/librustdoc/scrape_examples.rs
@@ -223,13 +223,14 @@ where
 
 crate fn run(
     krate: clean::Crate,
-    renderopts: config::RenderOptions,
+    mut renderopts: config::RenderOptions,
     cache: formats::cache::Cache,
     tcx: TyCtxt<'_>,
     options: ScrapeExamplesOptions,
 ) -> interface::Result<()> {
     let inner = move || -> Result<(), String> {
         // Generates source files for examples
+        renderopts.no_emit_shared = true;
         let (cx, _) = Context::init(krate, renderopts, cache, tcx).map_err(|e| e.to_string())?;
 
         // Collect CrateIds corresponding to provided target crates


### PR DESCRIPTION
This PR fixes #91605. The issue is that `Context::init` gets called when scraping dependencies. By default, just calling `init` calls into `write_shared` and `build_index` which register the scraped crate into a list that later gets used for the Rustdoc sidebar. The fix is to ensure that `write_shared` is not called when scraping.

r? @jyn514 