### PR TITLE
Make `StableHasher` generic over the inner hasher and use FxHasher for hashing unsorted collection items

### DIFF
--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -39,6 +39,7 @@ use rustc_span::{Span, DUMMY_SP};
 use std::cmp::Ordering;
 use std::convert::TryFrom;
 use std::fmt;
+use std::hash::Hasher;
 
 #[cfg(test)]
 mod tests;
@@ -107,7 +108,7 @@ impl PartialEq<Symbol> for Path {
 }
 
 impl<CTX> HashStable<CTX> for Path {
-    fn hash_stable(&self, hcx: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable<H: Hasher>(&self, hcx: &mut CTX, hasher: &mut StableHasher<H>) {
         self.segments.len().hash_stable(hcx, hasher);
         for segment in &self.segments {
             segment.ident.name.hash_stable(hcx, hasher);

--- a/compiler/rustc_ast/src/lib.rs
+++ b/compiler/rustc_ast/src/lib.rs
@@ -42,6 +42,7 @@ pub mod visit;
 
 pub use self::ast::*;
 pub use self::ast_like::AstLike;
+use std::hash::Hasher;
 
 use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
 
@@ -49,11 +50,11 @@ use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
 /// This is a hack to allow using the `HashStable_Generic` derive macro
 /// instead of implementing everything in `rustc_middle`.
 pub trait HashStableContext: rustc_span::HashStableContext {
-    fn hash_attr(&mut self, _: &ast::Attribute, hasher: &mut StableHasher);
+    fn hash_attr<H: Hasher>(&mut self, _: &ast::Attribute, hasher: &mut StableHasher<H>);
 }
 
 impl<AstCtx: crate::HashStableContext> HashStable<AstCtx> for ast::Attribute {
-    fn hash_stable(&self, hcx: &mut AstCtx, hasher: &mut StableHasher) {
+    fn hash_stable<H: Hasher>(&self, hcx: &mut AstCtx, hasher: &mut StableHasher<H>) {
         hcx.hash_attr(self, hasher)
     }
 }

--- a/compiler/rustc_ast/src/ptr.rs
+++ b/compiler/rustc_ast/src/ptr.rs
@@ -22,6 +22,7 @@
 //!   Moreover, a switch to, e.g., `P<'a, T>` would be easy and mostly automated.
 
 use std::fmt::{self, Debug, Display};
+use std::hash::Hasher;
 use std::iter::FromIterator;
 use std::ops::{Deref, DerefMut};
 use std::{slice, vec};
@@ -213,7 +214,7 @@ impl<CTX, T> HashStable<CTX> for P<T>
 where
     T: ?Sized + HashStable<CTX>,
 {
-    fn hash_stable(&self, hcx: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable<H: Hasher>(&self, hcx: &mut CTX, hasher: &mut StableHasher<H>) {
         (**self).hash_stable(hcx, hasher);
     }
 }

--- a/compiler/rustc_ast/src/token.rs
+++ b/compiler/rustc_ast/src/token.rs
@@ -15,6 +15,7 @@ use rustc_span::symbol::{kw, sym};
 use rustc_span::symbol::{Ident, Symbol};
 use rustc_span::{self, edition::Edition, Span, DUMMY_SP};
 use std::borrow::Cow;
+use std::hash::Hasher;
 use std::{fmt, mem};
 
 #[derive(Clone, Copy, PartialEq, Encodable, Decodable, Debug, HashStable_Generic)]
@@ -828,7 +829,7 @@ impl<CTX> HashStable<CTX> for Nonterminal
 where
     CTX: crate::HashStableContext,
 {
-    fn hash_stable(&self, _hcx: &mut CTX, _hasher: &mut StableHasher) {
+    fn hash_stable<H: Hasher>(&self, _hcx: &mut CTX, _hasher: &mut StableHasher<H>) {
         panic!("interpolated tokens should not be present in the HIR")
     }
 }

--- a/compiler/rustc_ast/src/tokenstream.rs
+++ b/compiler/rustc_ast/src/tokenstream.rs
@@ -23,6 +23,7 @@ use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
 use rustc_span::{Span, DUMMY_SP};
 use smallvec::{smallvec, SmallVec};
 
+use std::hash::Hasher;
 use std::{fmt, iter, mem};
 
 /// When the main Rust parser encounters a syntax-extension invocation, it
@@ -116,7 +117,7 @@ impl<CTX> HashStable<CTX> for TokenStream
 where
     CTX: crate::HashStableContext,
 {
-    fn hash_stable(&self, hcx: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable<H: Hasher>(&self, hcx: &mut CTX, hasher: &mut StableHasher<H>) {
         for sub_tt in self.trees() {
             sub_tt.hash_stable(hcx, hasher);
         }
@@ -169,7 +170,7 @@ impl<D: Decoder> Decodable<D> for LazyTokenStream {
 }
 
 impl<CTX> HashStable<CTX> for LazyTokenStream {
-    fn hash_stable(&self, _hcx: &mut CTX, _hasher: &mut StableHasher) {
+    fn hash_stable<H: Hasher>(&self, _hcx: &mut CTX, _hasher: &mut StableHasher<H>) {
         panic!("Attempted to compute stable hash for LazyTokenStream");
     }
 }

--- a/compiler/rustc_codegen_cranelift/src/driver/aot.rs
+++ b/compiler/rustc_codegen_cranelift/src/driver/aot.rs
@@ -21,7 +21,7 @@ use crate::{prelude::*, BackendConfig};
 struct ModuleCodegenResult(CompiledModule, Option<(WorkProductId, WorkProduct)>);
 
 impl<HCX> HashStable<HCX> for ModuleCodegenResult {
-    fn hash_stable(&self, _: &mut HCX, _: &mut StableHasher) {
+    fn hash_stable<H: core::hash::Hasher>(&self, _: &mut HCX, _: &mut StableHasher<H>) {
         // do nothing
     }
 }

--- a/compiler/rustc_codegen_ssa/src/common.rs
+++ b/compiler/rustc_codegen_ssa/src/common.rs
@@ -110,9 +110,10 @@ pub enum TypeKind {
 mod temp_stable_hash_impls {
     use crate::ModuleCodegen;
     use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
+    use std::hash::Hasher;
 
     impl<HCX, M> HashStable<HCX> for ModuleCodegen<M> {
-        fn hash_stable(&self, _: &mut HCX, _: &mut StableHasher) {
+        fn hash_stable<H: Hasher>(&self, _: &mut HCX, _: &mut StableHasher<H>) {
             // do nothing
         }
     }

--- a/compiler/rustc_const_eval/src/interpret/eval_context.rs
+++ b/compiler/rustc_const_eval/src/interpret/eval_context.rs
@@ -1,5 +1,6 @@
 use std::cell::Cell;
 use std::fmt;
+use std::hash::Hasher;
 use std::mem;
 
 use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
@@ -1028,7 +1029,11 @@ where
     Extra: HashStable<StableHashingContext<'ctx>>,
     Tag: HashStable<StableHashingContext<'ctx>>,
 {
-    fn hash_stable(&self, hcx: &mut StableHashingContext<'ctx>, hasher: &mut StableHasher) {
+    fn hash_stable<H: Hasher>(
+        &self,
+        hcx: &mut StableHashingContext<'ctx>,
+        hasher: &mut StableHasher<H>,
+    ) {
         // Exhaustive match on fields to make sure we forget no field.
         let Frame {
             body,

--- a/compiler/rustc_data_structures/src/sip128.rs
+++ b/compiler/rustc_data_structures/src/sip128.rs
@@ -50,6 +50,13 @@ pub struct SipHasher128 {
     processed: usize, // how many bytes we've processed
 }
 
+impl Default for SipHasher128 {
+    #[inline]
+    fn default() -> Self {
+        Self::new_with_keys(0, 0)
+    }
+}
+
 #[derive(Debug, Clone, Copy)]
 #[repr(C)]
 struct State {

--- a/compiler/rustc_data_structures/src/sorted_map.rs
+++ b/compiler/rustc_data_structures/src/sorted_map.rs
@@ -1,6 +1,7 @@
 use crate::stable_hasher::{HashStable, StableHasher};
 use std::borrow::Borrow;
 use std::cmp::Ordering;
+use std::hash::Hasher;
 use std::iter::FromIterator;
 use std::mem;
 use std::ops::{Bound, Index, IndexMut, RangeBounds};
@@ -293,7 +294,7 @@ impl<K: Ord, V> FromIterator<(K, V)> for SortedMap<K, V> {
 
 impl<K: HashStable<CTX>, V: HashStable<CTX>, CTX> HashStable<CTX> for SortedMap<K, V> {
     #[inline]
-    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable<H: Hasher>(&self, ctx: &mut CTX, hasher: &mut StableHasher<H>) {
         self.data.hash_stable(ctx, hasher);
     }
 }

--- a/compiler/rustc_data_structures/src/sorted_map/index_map.rs
+++ b/compiler/rustc_data_structures/src/sorted_map/index_map.rs
@@ -125,7 +125,7 @@ where
     K: HashStable<C>,
     V: HashStable<C>,
 {
-    fn hash_stable(&self, ctx: &mut C, hasher: &mut StableHasher) {
+    fn hash_stable<H: Hasher>(&self, ctx: &mut C, hasher: &mut StableHasher<H>) {
         self.items.hash_stable(ctx, hasher)
     }
 }

--- a/compiler/rustc_data_structures/src/steal.rs
+++ b/compiler/rustc_data_structures/src/steal.rs
@@ -1,5 +1,6 @@
 use crate::stable_hasher::{HashStable, StableHasher};
 use crate::sync::{MappedReadGuard, ReadGuard, RwLock};
+use std::hash::Hasher;
 
 /// The `Steal` struct is intended to used as the value for a query.
 /// Specifically, we sometimes have queries (*cough* MIR *cough*)
@@ -49,7 +50,7 @@ impl<T> Steal<T> {
 }
 
 impl<CTX, T: HashStable<CTX>> HashStable<CTX> for Steal<T> {
-    fn hash_stable(&self, hcx: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable<H: Hasher>(&self, hcx: &mut CTX, hasher: &mut StableHasher<H>) {
         self.borrow().hash_stable(hcx, hasher);
     }
 }

--- a/compiler/rustc_data_structures/src/svh.rs
+++ b/compiler/rustc_data_structures/src/svh.rs
@@ -62,7 +62,7 @@ impl<D: Decoder> Decodable<D> for Svh {
 
 impl<T> stable_hasher::HashStable<T> for Svh {
     #[inline]
-    fn hash_stable(&self, ctx: &mut T, hasher: &mut stable_hasher::StableHasher) {
+    fn hash_stable<H: Hasher>(&self, ctx: &mut T, hasher: &mut stable_hasher::StableHasher<H>) {
         let Svh { hash } = *self;
         hash.hash_stable(ctx, hasher);
     }

--- a/compiler/rustc_data_structures/src/tagged_ptr/copy.rs
+++ b/compiler/rustc_data_structures/src/tagged_ptr/copy.rs
@@ -1,6 +1,7 @@
 use super::{Pointer, Tag};
 use crate::stable_hasher::{HashStable, StableHasher};
 use std::fmt;
+use std::hash::Hasher;
 use std::marker::PhantomData;
 use std::num::NonZeroUsize;
 
@@ -176,7 +177,7 @@ where
     P: Pointer + HashStable<HCX>,
     T: Tag + HashStable<HCX>,
 {
-    fn hash_stable(&self, hcx: &mut HCX, hasher: &mut StableHasher) {
+    fn hash_stable<H: Hasher>(&self, hcx: &mut HCX, hasher: &mut StableHasher<H>) {
         unsafe {
             Pointer::with_ref(self.pointer_raw(), |p: &P| p.hash_stable(hcx, hasher));
         }

--- a/compiler/rustc_data_structures/src/tagged_ptr/drop.rs
+++ b/compiler/rustc_data_structures/src/tagged_ptr/drop.rs
@@ -1,6 +1,7 @@
 use super::{Pointer, Tag};
 use crate::stable_hasher::{HashStable, StableHasher};
 use std::fmt;
+use std::hash::Hasher;
 
 use super::CopyTaggedPtr;
 
@@ -127,7 +128,7 @@ where
     P: Pointer + HashStable<HCX>,
     T: Tag + HashStable<HCX>,
 {
-    fn hash_stable(&self, hcx: &mut HCX, hasher: &mut StableHasher) {
+    fn hash_stable<H: Hasher>(&self, hcx: &mut HCX, hasher: &mut StableHasher<H>) {
         self.raw.hash_stable(hcx, hasher);
     }
 }

--- a/compiler/rustc_data_structures/src/thin_vec.rs
+++ b/compiler/rustc_data_structures/src/thin_vec.rs
@@ -1,4 +1,5 @@
 use crate::stable_hasher::{HashStable, StableHasher};
+use std::hash::Hasher;
 
 use std::iter::FromIterator;
 
@@ -116,7 +117,7 @@ impl<T> Extend<T> for ThinVec<T> {
 }
 
 impl<T: HashStable<CTX>, CTX> HashStable<CTX> for ThinVec<T> {
-    fn hash_stable(&self, hcx: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable<H: Hasher>(&self, hcx: &mut CTX, hasher: &mut StableHasher<H>) {
         (**self).hash_stable(hcx, hasher)
     }
 }

--- a/compiler/rustc_data_structures/src/vec_map.rs
+++ b/compiler/rustc_data_structures/src/vec_map.rs
@@ -1,5 +1,6 @@
 use std::borrow::Borrow;
 use std::fmt::Debug;
+use std::hash::Hasher;
 use std::iter::FromIterator;
 use std::slice::Iter;
 use std::vec::IntoIter;
@@ -171,7 +172,7 @@ where
     K: HashStable<CTX> + Eq,
     V: HashStable<CTX>,
 {
-    fn hash_stable(&self, hcx: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable<H: Hasher>(&self, hcx: &mut CTX, hasher: &mut StableHasher<H>) {
         self.0.hash_stable(hcx, hasher)
     }
 }

--- a/compiler/rustc_hir/src/diagnostic_items.rs
+++ b/compiler/rustc_hir/src/diagnostic_items.rs
@@ -2,6 +2,7 @@ use crate::def_id::DefId;
 use rustc_data_structures::fx::FxHashMap;
 use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
 use rustc_span::Symbol;
+use std::hash::Hasher;
 
 #[derive(Debug, Default)]
 pub struct DiagnosticItems {
@@ -11,7 +12,7 @@ pub struct DiagnosticItems {
 
 impl<CTX: crate::HashStableContext> HashStable<CTX> for DiagnosticItems {
     #[inline]
-    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable<H: Hasher>(&self, ctx: &mut CTX, hasher: &mut StableHasher<H>) {
         self.name_to_id.hash_stable(ctx, hasher);
     }
 }

--- a/compiler/rustc_hir/src/lang_items.rs
+++ b/compiler/rustc_hir/src/lang_items.rs
@@ -9,6 +9,7 @@
 
 use crate::def_id::DefId;
 use crate::{MethodKind, Target};
+use std::hash::Hasher;
 
 use rustc_ast as ast;
 use rustc_data_structures::fx::FxHashMap;
@@ -143,7 +144,7 @@ macro_rules! language_item_table {
 }
 
 impl<CTX> HashStable<CTX> for LangItem {
-    fn hash_stable(&self, _: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable<H: Hasher>(&self, _: &mut CTX, hasher: &mut StableHasher<H>) {
         ::std::hash::Hash::hash(self, hasher);
     }
 }

--- a/compiler/rustc_hir/src/stable_hash_impls.rs
+++ b/compiler/rustc_hir/src/stable_hash_impls.rs
@@ -1,4 +1,5 @@
 use rustc_data_structures::stable_hasher::{HashStable, StableHasher, ToStableHashKey};
+use std::hash::Hasher;
 
 use crate::hir::{
     AttributeMap, BodyId, Crate, Expr, ForeignItem, ForeignItemId, ImplItem, ImplItemId, Item,
@@ -13,15 +14,23 @@ use rustc_span::def_id::DefPathHash;
 pub trait HashStableContext:
     rustc_ast::HashStableContext + rustc_target::HashStableContext
 {
-    fn hash_hir_id(&mut self, _: HirId, hasher: &mut StableHasher);
-    fn hash_body_id(&mut self, _: BodyId, hasher: &mut StableHasher);
-    fn hash_reference_to_item(&mut self, _: HirId, hasher: &mut StableHasher);
-    fn hash_hir_mod(&mut self, _: &Mod<'_>, hasher: &mut StableHasher);
-    fn hash_hir_expr(&mut self, _: &Expr<'_>, hasher: &mut StableHasher);
-    fn hash_hir_ty(&mut self, _: &Ty<'_>, hasher: &mut StableHasher);
-    fn hash_hir_visibility_kind(&mut self, _: &VisibilityKind<'_>, hasher: &mut StableHasher);
+    fn hash_hir_id<H: Hasher>(&mut self, _: HirId, hasher: &mut StableHasher<H>);
+    fn hash_body_id<H: Hasher>(&mut self, _: BodyId, hasher: &mut StableHasher<H>);
+    fn hash_reference_to_item<H: Hasher>(&mut self, _: HirId, hasher: &mut StableHasher<H>);
+    fn hash_hir_mod<H: Hasher>(&mut self, _: &Mod<'_>, hasher: &mut StableHasher<H>);
+    fn hash_hir_expr<H: Hasher>(&mut self, _: &Expr<'_>, hasher: &mut StableHasher<H>);
+    fn hash_hir_ty<H: Hasher>(&mut self, _: &Ty<'_>, hasher: &mut StableHasher<H>);
+    fn hash_hir_visibility_kind<H: Hasher>(
+        &mut self,
+        _: &VisibilityKind<'_>,
+        hasher: &mut StableHasher<H>,
+    );
     fn hash_hir_item_like<F: FnOnce(&mut Self)>(&mut self, f: F);
-    fn hash_hir_trait_candidate(&mut self, _: &TraitCandidate, hasher: &mut StableHasher);
+    fn hash_hir_trait_candidate<H: Hasher>(
+        &mut self,
+        _: &TraitCandidate,
+        hasher: &mut StableHasher<H>,
+    );
 }
 
 impl<HirCtx: crate::HashStableContext> ToStableHashKey<HirCtx> for HirId {
@@ -90,13 +99,13 @@ impl<HirCtx: crate::HashStableContext> ToStableHashKey<HirCtx> for ForeignItemId
 }
 
 impl<HirCtx: crate::HashStableContext> HashStable<HirCtx> for HirId {
-    fn hash_stable(&self, hcx: &mut HirCtx, hasher: &mut StableHasher) {
+    fn hash_stable<H: Hasher>(&self, hcx: &mut HirCtx, hasher: &mut StableHasher<H>) {
         hcx.hash_hir_id(*self, hasher)
     }
 }
 
 impl<HirCtx: crate::HashStableContext> HashStable<HirCtx> for BodyId {
-    fn hash_stable(&self, hcx: &mut HirCtx, hasher: &mut StableHasher) {
+    fn hash_stable<H: Hasher>(&self, hcx: &mut HirCtx, hasher: &mut StableHasher<H>) {
         hcx.hash_body_id(*self, hasher)
     }
 }
@@ -109,55 +118,55 @@ impl<HirCtx: crate::HashStableContext> HashStable<HirCtx> for BodyId {
 // in "DefPath Mode".
 
 impl<HirCtx: crate::HashStableContext> HashStable<HirCtx> for ItemId {
-    fn hash_stable(&self, hcx: &mut HirCtx, hasher: &mut StableHasher) {
+    fn hash_stable<H: Hasher>(&self, hcx: &mut HirCtx, hasher: &mut StableHasher<H>) {
         hcx.hash_reference_to_item(self.hir_id(), hasher)
     }
 }
 
 impl<HirCtx: crate::HashStableContext> HashStable<HirCtx> for ForeignItemId {
-    fn hash_stable(&self, hcx: &mut HirCtx, hasher: &mut StableHasher) {
+    fn hash_stable<H: Hasher>(&self, hcx: &mut HirCtx, hasher: &mut StableHasher<H>) {
         hcx.hash_reference_to_item(self.hir_id(), hasher)
     }
 }
 
 impl<HirCtx: crate::HashStableContext> HashStable<HirCtx> for ImplItemId {
-    fn hash_stable(&self, hcx: &mut HirCtx, hasher: &mut StableHasher) {
+    fn hash_stable<H: Hasher>(&self, hcx: &mut HirCtx, hasher: &mut StableHasher<H>) {
         hcx.hash_reference_to_item(self.hir_id(), hasher)
     }
 }
 
 impl<HirCtx: crate::HashStableContext> HashStable<HirCtx> for TraitItemId {
-    fn hash_stable(&self, hcx: &mut HirCtx, hasher: &mut StableHasher) {
+    fn hash_stable<H: Hasher>(&self, hcx: &mut HirCtx, hasher: &mut StableHasher<H>) {
         hcx.hash_reference_to_item(self.hir_id(), hasher)
     }
 }
 
 impl<HirCtx: crate::HashStableContext> HashStable<HirCtx> for Mod<'_> {
-    fn hash_stable(&self, hcx: &mut HirCtx, hasher: &mut StableHasher) {
+    fn hash_stable<H: Hasher>(&self, hcx: &mut HirCtx, hasher: &mut StableHasher<H>) {
         hcx.hash_hir_mod(self, hasher)
     }
 }
 
 impl<HirCtx: crate::HashStableContext> HashStable<HirCtx> for Expr<'_> {
-    fn hash_stable(&self, hcx: &mut HirCtx, hasher: &mut StableHasher) {
+    fn hash_stable<H: Hasher>(&self, hcx: &mut HirCtx, hasher: &mut StableHasher<H>) {
         hcx.hash_hir_expr(self, hasher)
     }
 }
 
 impl<HirCtx: crate::HashStableContext> HashStable<HirCtx> for Ty<'_> {
-    fn hash_stable(&self, hcx: &mut HirCtx, hasher: &mut StableHasher) {
+    fn hash_stable<H: Hasher>(&self, hcx: &mut HirCtx, hasher: &mut StableHasher<H>) {
         hcx.hash_hir_ty(self, hasher)
     }
 }
 
 impl<HirCtx: crate::HashStableContext> HashStable<HirCtx> for VisibilityKind<'_> {
-    fn hash_stable(&self, hcx: &mut HirCtx, hasher: &mut StableHasher) {
+    fn hash_stable<H: Hasher>(&self, hcx: &mut HirCtx, hasher: &mut StableHasher<H>) {
         hcx.hash_hir_visibility_kind(self, hasher)
     }
 }
 
 impl<HirCtx: crate::HashStableContext> HashStable<HirCtx> for TraitItem<'_> {
-    fn hash_stable(&self, hcx: &mut HirCtx, hasher: &mut StableHasher) {
+    fn hash_stable<H: Hasher>(&self, hcx: &mut HirCtx, hasher: &mut StableHasher<H>) {
         let TraitItem { def_id: _, ident, ref generics, ref kind, span } = *self;
 
         hcx.hash_hir_item_like(|hcx| {
@@ -170,7 +179,7 @@ impl<HirCtx: crate::HashStableContext> HashStable<HirCtx> for TraitItem<'_> {
 }
 
 impl<HirCtx: crate::HashStableContext> HashStable<HirCtx> for ImplItem<'_> {
-    fn hash_stable(&self, hcx: &mut HirCtx, hasher: &mut StableHasher) {
+    fn hash_stable<H: Hasher>(&self, hcx: &mut HirCtx, hasher: &mut StableHasher<H>) {
         let ImplItem { def_id: _, ident, ref vis, defaultness, ref generics, ref kind, span } =
             *self;
 
@@ -186,7 +195,7 @@ impl<HirCtx: crate::HashStableContext> HashStable<HirCtx> for ImplItem<'_> {
 }
 
 impl<HirCtx: crate::HashStableContext> HashStable<HirCtx> for ForeignItem<'_> {
-    fn hash_stable(&self, hcx: &mut HirCtx, hasher: &mut StableHasher) {
+    fn hash_stable<H: Hasher>(&self, hcx: &mut HirCtx, hasher: &mut StableHasher<H>) {
         let ForeignItem { def_id: _, ident, ref kind, span, ref vis } = *self;
 
         hcx.hash_hir_item_like(|hcx| {
@@ -199,7 +208,7 @@ impl<HirCtx: crate::HashStableContext> HashStable<HirCtx> for ForeignItem<'_> {
 }
 
 impl<HirCtx: crate::HashStableContext> HashStable<HirCtx> for Item<'_> {
-    fn hash_stable(&self, hcx: &mut HirCtx, hasher: &mut StableHasher) {
+    fn hash_stable<H: Hasher>(&self, hcx: &mut HirCtx, hasher: &mut StableHasher<H>) {
         let Item { ident, def_id: _, ref kind, ref vis, span } = *self;
 
         hcx.hash_hir_item_like(|hcx| {
@@ -212,7 +221,7 @@ impl<HirCtx: crate::HashStableContext> HashStable<HirCtx> for Item<'_> {
 }
 
 impl<'tcx, HirCtx: crate::HashStableContext> HashStable<HirCtx> for OwnerNodes<'tcx> {
-    fn hash_stable(&self, hcx: &mut HirCtx, hasher: &mut StableHasher) {
+    fn hash_stable<H: Hasher>(&self, hcx: &mut HirCtx, hasher: &mut StableHasher<H>) {
         // We ignore the `nodes` and `bodies` fields since these refer to information included in
         // `hash` which is hashed in the collector and used for the crate hash.
         let OwnerNodes { hash_including_bodies, hash_without_bodies: _, nodes: _, bodies: _ } =
@@ -222,7 +231,7 @@ impl<'tcx, HirCtx: crate::HashStableContext> HashStable<HirCtx> for OwnerNodes<'
 }
 
 impl<'tcx, HirCtx: crate::HashStableContext> HashStable<HirCtx> for AttributeMap<'tcx> {
-    fn hash_stable(&self, hcx: &mut HirCtx, hasher: &mut StableHasher) {
+    fn hash_stable<H: Hasher>(&self, hcx: &mut HirCtx, hasher: &mut StableHasher<H>) {
         // We ignore the `map` since it refers to information included in `hash` which is hashed in
         // the collector and used for the crate hash.
         let AttributeMap { hash, map: _ } = *self;
@@ -231,14 +240,14 @@ impl<'tcx, HirCtx: crate::HashStableContext> HashStable<HirCtx> for AttributeMap
 }
 
 impl<HirCtx: crate::HashStableContext> HashStable<HirCtx> for Crate<'_> {
-    fn hash_stable(&self, hcx: &mut HirCtx, hasher: &mut StableHasher) {
+    fn hash_stable<H: Hasher>(&self, hcx: &mut HirCtx, hasher: &mut StableHasher<H>) {
         let Crate { owners: _, hir_hash } = self;
         hir_hash.hash_stable(hcx, hasher)
     }
 }
 
 impl<HirCtx: crate::HashStableContext> HashStable<HirCtx> for TraitCandidate {
-    fn hash_stable(&self, hcx: &mut HirCtx, hasher: &mut StableHasher) {
+    fn hash_stable<H: Hasher>(&self, hcx: &mut HirCtx, hasher: &mut StableHasher<H>) {
         hcx.hash_hir_trait_candidate(self, hasher)
     }
 }

--- a/compiler/rustc_lint_defs/src/lib.rs
+++ b/compiler/rustc_lint_defs/src/lib.rs
@@ -8,6 +8,7 @@ use rustc_serialize::json::Json;
 use rustc_span::edition::Edition;
 use rustc_span::{sym, symbol::Ident, MultiSpan, Span, Symbol};
 use rustc_target::spec::abi::Abi;
+use std::hash::Hasher;
 
 pub mod builtin;
 
@@ -259,7 +260,7 @@ impl LintId {
 
 impl<HCX> HashStable<HCX> for LintId {
     #[inline]
-    fn hash_stable(&self, hcx: &mut HCX, hasher: &mut StableHasher) {
+    fn hash_stable<H: Hasher>(&self, hcx: &mut HCX, hasher: &mut StableHasher<H>) {
         self.lint_name_raw().hash_stable(hcx, hasher);
     }
 }

--- a/compiler/rustc_macros/src/hash_stable.rs
+++ b/compiler/rustc_macros/src/hash_stable.rs
@@ -73,10 +73,10 @@ pub fn hash_stable_generic_derive(mut s: synstructure::Structure<'_>) -> proc_ma
         quote!(::rustc_data_structures::stable_hasher::HashStable<__CTX>),
         quote! {
             #[inline]
-            fn hash_stable(
+            fn hash_stable<H: ::std::hash::Hasher>(
                 &self,
                 __hcx: &mut __CTX,
-                __hasher: &mut ::rustc_data_structures::stable_hasher::StableHasher) {
+                __hasher: &mut ::rustc_data_structures::stable_hasher::StableHasher<H>) {
                 #discriminant
                 match *self { #body }
             }
@@ -119,10 +119,10 @@ pub fn hash_stable_derive(mut s: synstructure::Structure<'_>) -> proc_macro2::To
         ),
         quote! {
             #[inline]
-            fn hash_stable(
+            fn hash_stable<H: ::std::hash::Hasher>(
                 &self,
                 __hcx: &mut ::rustc_query_system::ich::StableHashingContext<'__ctx>,
-                __hasher: &mut ::rustc_data_structures::stable_hasher::StableHasher) {
+                __hasher: &mut ::rustc_data_structures::stable_hasher::StableHasher<H>) {
                 #discriminant
                 match *self { #body }
             }

--- a/compiler/rustc_middle/src/hir/mod.rs
+++ b/compiler/rustc_middle/src/hir/mod.rs
@@ -14,6 +14,7 @@ use rustc_hir::def_id::LocalDefId;
 use rustc_hir::*;
 use rustc_query_system::ich::StableHashingContext;
 use rustc_span::DUMMY_SP;
+use std::hash::Hasher;
 
 /// Top-level HIR node for current owner. This only contains the node for which
 /// `HirId::local_id == 0`, and excludes bodies.
@@ -28,7 +29,11 @@ pub struct Owner<'tcx> {
 
 impl<'a, 'tcx> HashStable<StableHashingContext<'a>> for Owner<'tcx> {
     #[inline]
-    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
+    fn hash_stable<H: Hasher>(
+        &self,
+        hcx: &mut StableHashingContext<'a>,
+        hasher: &mut StableHasher<H>,
+    ) {
         let Owner { node: _, hash_without_bodies } = self;
         hash_without_bodies.hash_stable(hcx, hasher)
     }

--- a/compiler/rustc_middle/src/lint.rs
+++ b/compiler/rustc_middle/src/lint.rs
@@ -1,4 +1,5 @@
 use std::cmp;
+use std::hash::Hasher;
 
 use rustc_data_structures::fx::FxHashMap;
 use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
@@ -177,7 +178,11 @@ impl LintLevelMap {
 
 impl<'a> HashStable<StableHashingContext<'a>> for LintLevelMap {
     #[inline]
-    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
+    fn hash_stable<H: Hasher>(
+        &self,
+        hcx: &mut StableHashingContext<'a>,
+        hasher: &mut StableHasher<H>,
+    ) {
         let LintLevelMap { ref sets, ref id_to_set } = *self;
 
         id_to_set.hash_stable(hcx, hasher);

--- a/compiler/rustc_middle/src/middle/privacy.rs
+++ b/compiler/rustc_middle/src/middle/privacy.rs
@@ -7,7 +7,7 @@ use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
 use rustc_macros::HashStable;
 use rustc_query_system::ich::{NodeIdHashingMode, StableHashingContext};
 use rustc_span::def_id::LocalDefId;
-use std::hash::Hash;
+use std::hash::{Hash, Hasher};
 
 /// Represents the levels of accessibility an item can have.
 ///
@@ -57,7 +57,11 @@ impl<Id> Default for AccessLevels<Id> {
 }
 
 impl<'a> HashStable<StableHashingContext<'a>> for AccessLevels {
-    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
+    fn hash_stable<H: Hasher>(
+        &self,
+        hcx: &mut StableHashingContext<'a>,
+        hasher: &mut StableHasher<H>,
+    ) {
         hcx.with_node_id_hashing_mode(NodeIdHashingMode::HashDefPath, |hcx| {
             let AccessLevels { ref map } = *self;
             map.hash_stable(hcx, hasher);

--- a/compiler/rustc_middle/src/middle/region.rs
+++ b/compiler/rustc_middle/src/middle/region.rs
@@ -16,6 +16,7 @@ use rustc_query_system::ich::{NodeIdHashingMode, StableHashingContext};
 use rustc_span::{Span, DUMMY_SP};
 
 use std::fmt;
+use std::hash::Hasher;
 
 /// Represents a statically-describable scope that can be used to
 /// bound the lifetime/region for values.
@@ -436,7 +437,11 @@ impl ScopeTree {
 }
 
 impl<'a> HashStable<StableHashingContext<'a>> for ScopeTree {
-    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
+    fn hash_stable<H: Hasher>(
+        &self,
+        hcx: &mut StableHashingContext<'a>,
+        hasher: &mut StableHasher<H>,
+    ) {
         let ScopeTree {
             root_body,
             ref body_expr_count,

--- a/compiler/rustc_middle/src/mir/graph_cyclic_cache.rs
+++ b/compiler/rustc_middle/src/mir/graph_cyclic_cache.rs
@@ -4,6 +4,7 @@ use rustc_data_structures::graph::{
 use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
 use rustc_data_structures::sync::OnceCell;
 use rustc_serialize as serialize;
+use std::hash::Hasher;
 
 /// Helper type to cache the result of `graph::is_cyclic`.
 #[derive(Clone, Debug)]
@@ -52,7 +53,7 @@ impl<D: serialize::Decoder> serialize::Decodable<D> for GraphIsCyclicCache {
 
 impl<CTX> HashStable<CTX> for GraphIsCyclicCache {
     #[inline]
-    fn hash_stable(&self, _: &mut CTX, _: &mut StableHasher) {
+    fn hash_stable<H: Hasher>(&self, _: &mut CTX, _: &mut StableHasher<H>) {
         // do nothing
     }
 }

--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -834,9 +834,14 @@ TrivialTypeFoldableAndLiftImpls! { BindingForm<'tcx>, }
 mod binding_form_impl {
     use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
     use rustc_query_system::ich::StableHashingContext;
+    use std::hash::Hasher;
 
     impl<'a, 'tcx> HashStable<StableHashingContext<'a>> for super::BindingForm<'tcx> {
-        fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
+        fn hash_stable<H: Hasher>(
+            &self,
+            hcx: &mut StableHashingContext<'a>,
+            hasher: &mut StableHasher<H>,
+        ) {
             use super::BindingForm::*;
             std::mem::discriminant(self).hash_stable(hcx, hasher);
 

--- a/compiler/rustc_middle/src/mir/mono.rs
+++ b/compiler/rustc_middle/src/mir/mono.rs
@@ -12,7 +12,7 @@ use rustc_session::config::OptLevel;
 use rustc_span::source_map::Span;
 use rustc_span::symbol::Symbol;
 use std::fmt;
-use std::hash::Hash;
+use std::hash::{Hash, Hasher};
 
 /// Describes how a monomorphization will be instantiated in object files.
 #[derive(PartialEq)]
@@ -206,7 +206,11 @@ impl<'tcx> MonoItem<'tcx> {
 }
 
 impl<'a, 'tcx> HashStable<StableHashingContext<'a>> for MonoItem<'tcx> {
-    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
+    fn hash_stable<H: Hasher>(
+        &self,
+        hcx: &mut StableHashingContext<'a>,
+        hasher: &mut StableHasher<H>,
+    ) {
         ::std::mem::discriminant(self).hash_stable(hcx, hasher);
 
         match *self {
@@ -400,7 +404,11 @@ impl<'tcx> CodegenUnit<'tcx> {
 }
 
 impl<'a, 'tcx> HashStable<StableHashingContext<'a>> for CodegenUnit<'tcx> {
-    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
+    fn hash_stable<H: Hasher>(
+        &self,
+        hcx: &mut StableHashingContext<'a>,
+        hasher: &mut StableHasher<H>,
+    ) {
         let CodegenUnit {
             ref items,
             name,

--- a/compiler/rustc_middle/src/mir/predecessors.rs
+++ b/compiler/rustc_middle/src/mir/predecessors.rs
@@ -5,6 +5,7 @@ use rustc_data_structures::sync::OnceCell;
 use rustc_index::vec::IndexVec;
 use rustc_serialize as serialize;
 use smallvec::SmallVec;
+use std::hash::Hasher;
 
 use crate::mir::{BasicBlock, BasicBlockData};
 
@@ -70,7 +71,7 @@ impl<D: serialize::Decoder> serialize::Decodable<D> for PredecessorCache {
 
 impl<CTX> HashStable<CTX> for PredecessorCache {
     #[inline]
-    fn hash_stable(&self, _: &mut CTX, _: &mut StableHasher) {
+    fn hash_stable<H: Hasher>(&self, _: &mut CTX, _: &mut StableHasher<H>) {
         // do nothing
     }
 }

--- a/compiler/rustc_middle/src/traits/query.rs
+++ b/compiler/rustc_middle/src/traits/query.rs
@@ -9,6 +9,7 @@ use crate::infer::canonical::{Canonical, QueryResponse};
 use crate::ty::error::TypeError;
 use crate::ty::subst::GenericArg;
 use crate::ty::{self, Ty, TyCtxt};
+use std::hash::Hasher;
 
 use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
 use rustc_data_structures::sync::Lrc;
@@ -230,7 +231,11 @@ pub enum OutlivesBound<'tcx> {
 }
 
 impl<'a, 'tcx> HashStable<StableHashingContext<'a>> for OutlivesBound<'tcx> {
-    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
+    fn hash_stable<H: Hasher>(
+        &self,
+        hcx: &mut StableHashingContext<'a>,
+        hasher: &mut StableHasher<H>,
+    ) {
         mem::discriminant(self).hash_stable(hcx, hasher);
         match *self {
             OutlivesBound::RegionSubRegion(ref a, ref b) => {

--- a/compiler/rustc_middle/src/ty/adt.rs
+++ b/compiler/rustc_middle/src/ty/adt.rs
@@ -134,7 +134,11 @@ impl Hash for AdtDef {
 }
 
 impl<'a> HashStable<StableHashingContext<'a>> for AdtDef {
-    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
+    fn hash_stable<H: Hasher>(
+        &self,
+        hcx: &mut StableHashingContext<'a>,
+        hasher: &mut StableHasher<H>,
+    ) {
         thread_local! {
             static CACHE: RefCell<FxHashMap<usize, Fingerprint>> = Default::default();
         }

--- a/compiler/rustc_middle/src/ty/consts/int.rs
+++ b/compiler/rustc_middle/src/ty/consts/int.rs
@@ -4,6 +4,7 @@ use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
 use rustc_target::abi::Size;
 use std::convert::{TryFrom, TryInto};
 use std::fmt;
+use std::hash::Hasher;
 
 use crate::ty::TyCtxt;
 
@@ -129,7 +130,7 @@ pub struct ScalarInt {
 // Cannot derive these, as the derives take references to the fields, and we
 // can't take references to fields of packed structs.
 impl<CTX> crate::ty::HashStable<CTX> for ScalarInt {
-    fn hash_stable(&self, hcx: &mut CTX, hasher: &mut crate::ty::StableHasher) {
+    fn hash_stable<H: Hasher>(&self, hcx: &mut CTX, hasher: &mut crate::ty::StableHasher<H>) {
         // Using a block `{self.data}` here to force a copy instead of using `self.data`
         // directly, because `hash_stable` takes `&self` and would thus borrow `self.data`.
         // Since `Self` is a packed struct, that would create a possibly unaligned reference,

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -749,7 +749,11 @@ impl<'tcx> TypeckResults<'tcx> {
 }
 
 impl<'a, 'tcx> HashStable<StableHashingContext<'a>> for TypeckResults<'tcx> {
-    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
+    fn hash_stable<H: Hasher>(
+        &self,
+        hcx: &mut StableHashingContext<'a>,
+        hasher: &mut StableHasher<H>,
+    ) {
         let ty::TypeckResults {
             hir_owner,
             ref type_dependent_defs,

--- a/compiler/rustc_middle/src/ty/fast_reject.rs
+++ b/compiler/rustc_middle/src/ty/fast_reject.rs
@@ -4,7 +4,7 @@ use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
 use rustc_hir::def_id::DefId;
 use rustc_query_system::ich::StableHashingContext;
 use std::fmt::Debug;
-use std::hash::Hash;
+use std::hash::{Hash, Hasher};
 use std::mem;
 
 use self::SimplifiedTypeGen::*;
@@ -179,7 +179,11 @@ impl<'a, D> HashStable<StableHashingContext<'a>> for SimplifiedTypeGen<D>
 where
     D: Copy + Debug + Ord + Eq + HashStable<StableHashingContext<'a>>,
 {
-    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
+    fn hash_stable<H: Hasher>(
+        &self,
+        hcx: &mut StableHashingContext<'a>,
+        hasher: &mut StableHasher<H>,
+    ) {
         mem::discriminant(self).hash_stable(hcx, hasher);
         match *self {
             BoolSimplifiedType

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -446,7 +446,11 @@ impl<'tcx> Hash for TyS<'tcx> {
 }
 
 impl<'a, 'tcx> HashStable<StableHashingContext<'a>> for TyS<'tcx> {
-    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
+    fn hash_stable<H: Hasher>(
+        &self,
+        hcx: &mut StableHashingContext<'a>,
+        hasher: &mut StableHasher<H>,
+    ) {
         let ty::TyS {
             ref kind,
 
@@ -535,7 +539,11 @@ impl<'tcx> Predicate<'tcx> {
 }
 
 impl<'a, 'tcx> HashStable<StableHashingContext<'a>> for Predicate<'tcx> {
-    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
+    fn hash_stable<H: Hasher>(
+        &self,
+        hcx: &mut StableHashingContext<'a>,
+        hasher: &mut StableHasher<H>,
+    ) {
         let PredicateInner {
             ref kind,
 
@@ -1053,7 +1061,11 @@ impl<'a, T> HashStable<StableHashingContext<'a>> for Placeholder<T>
 where
     T: HashStable<StableHashingContext<'a>>,
 {
-    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
+    fn hash_stable<H: Hasher>(
+        &self,
+        hcx: &mut StableHashingContext<'a>,
+        hasher: &mut StableHasher<H>,
+    ) {
         self.universe.hash_stable(hcx, hasher);
         self.name.hash_stable(hcx, hasher);
     }
@@ -1261,7 +1273,11 @@ impl<'tcx> fmt::Debug for ParamEnv<'tcx> {
 }
 
 impl<'a, 'tcx> HashStable<StableHashingContext<'a>> for ParamEnv<'tcx> {
-    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
+    fn hash_stable<H: Hasher>(
+        &self,
+        hcx: &mut StableHashingContext<'a>,
+        hasher: &mut StableHasher<H>,
+    ) {
         self.caller_bounds().hash_stable(hcx, hasher);
         self.reveal().hash_stable(hcx, hasher);
         self.constness().hash_stable(hcx, hasher);
@@ -1455,7 +1471,11 @@ impl<'a, 'tcx, T> HashStable<StableHashingContext<'a>> for ParamEnvAnd<'tcx, T>
 where
     T: HashStable<StableHashingContext<'a>>,
 {
-    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
+    fn hash_stable<H: Hasher>(
+        &self,
+        hcx: &mut StableHashingContext<'a>,
+        hasher: &mut StableHasher<H>,
+    ) {
         let ParamEnvAnd { ref param_env, ref value } = *self;
 
         param_env.hash_stable(hcx, hasher);

--- a/compiler/rustc_query_system/src/dep_graph/dep_node.rs
+++ b/compiler/rustc_query_system/src/dep_graph/dep_node.rs
@@ -48,7 +48,7 @@ use crate::ich::StableHashingContext;
 use rustc_data_structures::fingerprint::{Fingerprint, PackedFingerprint};
 use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
 use std::fmt;
-use std::hash::Hash;
+use std::hash::{Hash, Hasher};
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Encodable, Decodable)]
 pub struct DepNode<K> {
@@ -172,7 +172,7 @@ impl WorkProductId {
 
 impl<HCX> HashStable<HCX> for WorkProductId {
     #[inline]
-    fn hash_stable(&self, hcx: &mut HCX, hasher: &mut StableHasher) {
+    fn hash_stable<H: Hasher>(&self, hcx: &mut HCX, hasher: &mut StableHasher<H>) {
         self.hash.hash_stable(hcx, hasher)
     }
 }

--- a/compiler/rustc_query_system/src/ich/hcx.rs
+++ b/compiler/rustc_query_system/src/ich/hcx.rs
@@ -12,6 +12,7 @@ use rustc_session::Session;
 use rustc_span::source_map::SourceMap;
 use rustc_span::symbol::Symbol;
 use rustc_span::{BytePos, CachingSourceMapView, SourceFile, Span, SpanData};
+use std::hash::Hasher;
 
 fn compute_ignored_attr_names() -> FxHashSet<Symbol> {
     debug_assert!(!ich::IGNORED_ATTRIBUTES.is_empty());
@@ -187,7 +188,7 @@ impl<'a> StableHashingContext<'a> {
 
 impl<'a> HashStable<StableHashingContext<'a>> for ast::NodeId {
     #[inline]
-    fn hash_stable(&self, _: &mut StableHashingContext<'a>, _: &mut StableHasher) {
+    fn hash_stable<H: Hasher>(&self, _: &mut StableHashingContext<'a>, _: &mut StableHasher<H>) {
         panic!("Node IDs should not appear in incremental state");
     }
 }

--- a/compiler/rustc_span/src/def_id.rs
+++ b/compiler/rustc_span/src/def_id.rs
@@ -374,21 +374,21 @@ rustc_data_structures::define_id_collections!(LocalDefIdMap, LocalDefIdSet, Loca
 
 impl<CTX: HashStableContext> HashStable<CTX> for DefId {
     #[inline]
-    fn hash_stable(&self, hcx: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable<H: Hasher>(&self, hcx: &mut CTX, hasher: &mut StableHasher<H>) {
         self.to_stable_hash_key(hcx).hash_stable(hcx, hasher);
     }
 }
 
 impl<CTX: HashStableContext> HashStable<CTX> for LocalDefId {
     #[inline]
-    fn hash_stable(&self, hcx: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable<H: Hasher>(&self, hcx: &mut CTX, hasher: &mut StableHasher<H>) {
         self.to_stable_hash_key(hcx).hash_stable(hcx, hasher);
     }
 }
 
 impl<CTX: HashStableContext> HashStable<CTX> for CrateNum {
     #[inline]
-    fn hash_stable(&self, hcx: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable<H: Hasher>(&self, hcx: &mut CTX, hasher: &mut StableHasher<H>) {
         self.to_stable_hash_key(hcx).hash_stable(hcx, hasher);
     }
 }

--- a/compiler/rustc_span/src/hygiene.rs
+++ b/compiler/rustc_span/src/hygiene.rs
@@ -39,7 +39,7 @@ use rustc_index::vec::IndexVec;
 use rustc_macros::HashStable_Generic;
 use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
 use std::fmt;
-use std::hash::Hash;
+use std::hash::{Hash, Hasher};
 use tracing::*;
 
 /// A `SyntaxContext` represents a chain of pairs `(ExpnId, Transparency)` named "marks".
@@ -1476,7 +1476,7 @@ fn update_disambiguator(expn_data: &mut ExpnData, mut ctx: impl HashStableContex
 }
 
 impl<CTX: HashStableContext> HashStable<CTX> for SyntaxContext {
-    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable<H: Hasher>(&self, ctx: &mut CTX, hasher: &mut StableHasher<H>) {
         const TAG_EXPANSION: u8 = 0;
         const TAG_NO_EXPANSION: u8 = 1;
 
@@ -1492,7 +1492,7 @@ impl<CTX: HashStableContext> HashStable<CTX> for SyntaxContext {
 }
 
 impl<CTX: HashStableContext> HashStable<CTX> for ExpnId {
-    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable<H: Hasher>(&self, ctx: &mut CTX, hasher: &mut StableHasher<H>) {
         let hash = if *self == ExpnId::root() {
             // Avoid fetching TLS storage for a trivial often-used value.
             Fingerprint::ZERO

--- a/compiler/rustc_span/src/lib.rs
+++ b/compiler/rustc_span/src/lib.rs
@@ -60,7 +60,7 @@ use rustc_data_structures::sync::{Lock, Lrc};
 use std::borrow::Cow;
 use std::cmp::{self, Ordering};
 use std::fmt;
-use std::hash::Hash;
+use std::hash::{Hash, Hasher};
 use std::ops::{Add, Range, Sub};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
@@ -2048,7 +2048,7 @@ where
     /// codepoint offsets. For the purpose of the hash that's sufficient.
     /// Also, hashing filenames is expensive so we avoid doing it twice when the
     /// span starts and ends in the same file, which is almost always the case.
-    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable<H: Hasher>(&self, ctx: &mut CTX, hasher: &mut StableHasher<H>) {
         const TAG_VALID_SPAN: u8 = 0;
         const TAG_INVALID_SPAN: u8 = 1;
         const TAG_RELATIVE_SPAN: u8 = 2;

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1711,7 +1711,7 @@ impl<D: Decoder> Decodable<D> for Symbol {
 
 impl<CTX> HashStable<CTX> for Symbol {
     #[inline]
-    fn hash_stable(&self, hcx: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable<H: Hasher>(&self, hcx: &mut CTX, hasher: &mut StableHasher<H>) {
         self.as_str().hash_stable(hcx, hasher);
     }
 }

--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -42,6 +42,7 @@ use rustc_serialize::json::{Json, ToJson};
 use rustc_span::symbol::{sym, Symbol};
 use std::collections::BTreeMap;
 use std::convert::TryFrom;
+use std::hash::Hasher;
 use std::iter::FromIterator;
 use std::ops::{Deref, DerefMut};
 use std::path::{Path, PathBuf};
@@ -662,7 +663,7 @@ impl IntoIterator for SanitizerSet {
 }
 
 impl<CTX> HashStable<CTX> for SanitizerSet {
-    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable<H: Hasher>(&self, ctx: &mut CTX, hasher: &mut StableHasher<H>) {
         self.bits().hash_stable(ctx, hasher);
     }
 }
@@ -2400,7 +2401,7 @@ impl TargetTriple {
     /// by `triple()`.
     pub fn debug_triple(&self) -> String {
         use std::collections::hash_map::DefaultHasher;
-        use std::hash::{Hash, Hasher};
+        use std::hash::Hash;
 
         let triple = self.triple();
         if let TargetTriple::TargetPath(ref path) = *self {

--- a/compiler/rustc_type_ir/src/lib.rs
+++ b/compiler/rustc_type_ir/src/lib.rs
@@ -8,6 +8,7 @@ extern crate rustc_macros;
 use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
 use rustc_data_structures::unify::{EqUnifyValue, UnifyKey};
 use std::fmt;
+use std::hash::Hasher;
 use std::mem::discriminant;
 
 bitflags! {
@@ -533,31 +534,31 @@ impl Variance {
 }
 
 impl<CTX> HashStable<CTX> for DebruijnIndex {
-    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable<H: Hasher>(&self, ctx: &mut CTX, hasher: &mut StableHasher<H>) {
         self.as_u32().hash_stable(ctx, hasher);
     }
 }
 
 impl<CTX> HashStable<CTX> for IntTy {
-    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable<H: Hasher>(&self, ctx: &mut CTX, hasher: &mut StableHasher<H>) {
         discriminant(self).hash_stable(ctx, hasher);
     }
 }
 
 impl<CTX> HashStable<CTX> for UintTy {
-    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable<H: Hasher>(&self, ctx: &mut CTX, hasher: &mut StableHasher<H>) {
         discriminant(self).hash_stable(ctx, hasher);
     }
 }
 
 impl<CTX> HashStable<CTX> for FloatTy {
-    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable<H: Hasher>(&self, ctx: &mut CTX, hasher: &mut StableHasher<H>) {
         discriminant(self).hash_stable(ctx, hasher);
     }
 }
 
 impl<CTX> HashStable<CTX> for InferTy {
-    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable<H: Hasher>(&self, ctx: &mut CTX, hasher: &mut StableHasher<H>) {
         use InferTy::*;
         discriminant(self).hash_stable(ctx, hasher);
         match self {
@@ -570,7 +571,7 @@ impl<CTX> HashStable<CTX> for InferTy {
 }
 
 impl<CTX> HashStable<CTX> for Variance {
-    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable<H: Hasher>(&self, ctx: &mut CTX, hasher: &mut StableHasher<H>) {
         discriminant(self).hash_stable(ctx, hasher);
     }
 }


### PR DESCRIPTION
This is an experiment to see how bad is it to repeatedly create a `SipHasher128` just for hashing a single `key` or a `(key, value)` pair when stable-hashing unsorted collections (maps, sets, etc.).

The `SipHasher128` is replaced here with the fast `FxHasher`. It is only used to create hashes of unsorted collection items, the rest is still hashed with the SipHasher. Obviously, using `FxHasher` will be faster, but at the cost of more collision probability. I wonder if it's okay to make that tradeoff here.

Anyway, even if not, it might be useful to have the `StableHasher` generic to experiment with e.g. SIP hashers using various buffer sizes or other hasher implementations.

Could you please schedule a perf. run? Thanks.

r? @the8472