### PR TITLE
Update chalk to 0.75.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -492,9 +492,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chalk-derive"
-version = "0.55.0"
+version = "0.75.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3983193cacd81f0f924acb666b7fe5e1a0d81db9f113fa69203eda7ea8ce8b6c"
+checksum = "d54e3b5f9e3425e6b119ff07568d8d006bfa5a8d6f78a9cbc3530b1e962e316c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -504,9 +504,9 @@ dependencies = [
 
 [[package]]
 name = "chalk-engine"
-version = "0.55.0"
+version = "0.75.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05a171ce5abbf0fbd06f221ab80ab182c7ef78603d23b858bc44e7ce8a86a396"
+checksum = "bdc891073396b167163db77123b0a3c00088edc00466cecc5531f33e3e989523"
 dependencies = [
  "chalk-derive",
  "chalk-ir",
@@ -517,9 +517,9 @@ dependencies = [
 
 [[package]]
 name = "chalk-ir"
-version = "0.55.0"
+version = "0.75.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a522f53af971e7678f472d687e053120157b3ae26e2ebd5ecbc0f5ab124f2cb6"
+checksum = "2b79e5a1d04b79311e90c69356a2c62027853906a7e33b3e070b93c055fc3e8a"
 dependencies = [
  "bitflags",
  "chalk-derive",
@@ -528,18 +528,18 @@ dependencies = [
 
 [[package]]
 name = "chalk-solve"
-version = "0.55.0"
+version = "0.75.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdf79fb77a567e456a170f7ec84ea6584163d4ba3f13660cd182013d34ca667c"
+checksum = "a5d2a1db6605aba70a58820bd80ac422b218913a510f1a40beef9efc5371ea1d"
 dependencies = [
  "chalk-derive",
  "chalk-ir",
  "ena",
- "itertools 0.9.0",
+ "itertools 0.10.1",
  "petgraph",
  "rustc-hash",
  "tracing",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.3",
  "tracing-tree",
 ]
 
@@ -680,9 +680,9 @@ dependencies = [
 
 [[package]]
 name = "compiler_builtins"
-version = "0.1.65"
+version = "0.1.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed37ea958309f2451e1cea7fd2b37aa56b1894c9a9fbdbbe6a194f7b78f0362d"
+checksum = "191424db7756bbed2c4996959a0fbda94388abcf4f5a2728a8af17481ad9c4f7"
 dependencies = [
  "cc",
  "rustc-std-workspace-core",
@@ -704,7 +704,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tracing",
- "tracing-subscriber",
+ "tracing-subscriber 0.2.16",
  "unified-diff",
  "walkdir",
  "winapi",
@@ -2110,6 +2110,15 @@ name = "matchers"
 version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
  "regex-automata",
 ]
@@ -3845,7 +3854,7 @@ dependencies = [
  "rustc_target",
  "rustc_typeck",
  "tracing",
- "tracing-subscriber",
+ "tracing-subscriber 0.2.16",
  "tracing-tree",
  "winapi",
 ]
@@ -4624,7 +4633,7 @@ dependencies = [
  "tempfile",
  "tera",
  "tracing",
- "tracing-subscriber",
+ "tracing-subscriber 0.2.16",
  "tracing-tree",
 ]
 
@@ -5121,9 +5130,9 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.12.4"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
+checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5447,50 +5456,52 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-serde"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb65ea441fbb84f9f6748fd496cf7f63ec9af5bca94dd86456978d055e8eb28b"
-dependencies = [
- "serde",
- "tracing-core",
-]
-
-[[package]]
 name = "tracing-subscriber"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ab8966ac3ca27126141f7999361cc97dd6fb4b71da04c02044fa9045d98bb96"
 dependencies = [
  "ansi_term 0.12.1",
- "chrono",
  "lazy_static",
- "matchers",
+ "matchers 0.0.1",
  "parking_lot",
  "regex",
- "serde",
- "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245da694cc7fc4729f3f418b304cb57789f1bed2a78c575407ab8a23f53cb4d3"
+dependencies = [
+ "ansi_term 0.12.1",
+ "lazy_static",
+ "matchers 0.1.0",
+ "regex",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
- "tracing-serde",
 ]
 
 [[package]]
 name = "tracing-tree"
-version = "0.1.9"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1712b40907f8d9bc2bc66763ab61dec914b7123d7149e59feb0d4e2a95fc4967"
+checksum = "3ce989c9962c7f61fe084dd4a230eec784649dfc2392467c790007c3a6e134e7"
 dependencies = [
  "ansi_term 0.12.1",
  "atty",
- "termcolor",
- "tracing",
+ "tracing-core",
  "tracing-log",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.3",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -539,7 +539,7 @@ dependencies = [
  "petgraph",
  "rustc-hash",
  "tracing",
- "tracing-subscriber 0.3.3",
+ "tracing-subscriber",
  "tracing-tree",
 ]
 
@@ -704,7 +704,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tracing",
- "tracing-subscriber 0.2.16",
+ "tracing-subscriber",
  "unified-diff",
  "walkdir",
  "winapi",
@@ -2103,15 +2103,6 @@ dependencies = [
  "markup5ever",
  "tendril",
  "xml5ever",
-]
-
-[[package]]
-name = "matchers"
-version = "0.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
-dependencies = [
- "regex-automata",
 ]
 
 [[package]]
@@ -3854,7 +3845,7 @@ dependencies = [
  "rustc_target",
  "rustc_typeck",
  "tracing",
- "tracing-subscriber 0.2.16",
+ "tracing-subscriber",
  "tracing-tree",
  "winapi",
 ]
@@ -4633,7 +4624,7 @@ dependencies = [
  "tempfile",
  "tera",
  "tracing",
- "tracing-subscriber 0.2.16",
+ "tracing-subscriber",
  "tracing-tree",
 ]
 
@@ -5457,31 +5448,14 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ab8966ac3ca27126141f7999361cc97dd6fb4b71da04c02044fa9045d98bb96"
-dependencies = [
- "ansi_term 0.12.1",
- "lazy_static",
- "matchers 0.0.1",
- "parking_lot",
- "regex",
- "sharded-slab",
- "smallvec",
- "thread_local",
- "tracing",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-subscriber"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "245da694cc7fc4729f3f418b304cb57789f1bed2a78c575407ab8a23f53cb4d3"
 dependencies = [
  "ansi_term 0.12.1",
  "lazy_static",
- "matchers 0.1.0",
+ "matchers",
+ "parking_lot",
  "regex",
  "sharded-slab",
  "smallvec",
@@ -5501,7 +5475,7 @@ dependencies = [
  "atty",
  "tracing-core",
  "tracing-log",
- "tracing-subscriber 0.3.3",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/compiler/rustc_driver/Cargo.toml
+++ b/compiler/rustc_driver/Cargo.toml
@@ -11,7 +11,7 @@ libc = "0.2"
 atty = "0.2"
 tracing = { version = "0.1.28" }
 tracing-subscriber = { version = "0.2.16", default-features = false, features = ["fmt", "env-filter", "smallvec", "parking_lot", "ansi"] }
-tracing-tree = "0.1.9"
+tracing-tree = "0.2.0"
 rustc_middle = { path = "../rustc_middle" }
 rustc_ast_pretty = { path = "../rustc_ast_pretty" }
 rustc_target = { path = "../rustc_target" }

--- a/compiler/rustc_driver/Cargo.toml
+++ b/compiler/rustc_driver/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["dylib"]
 libc = "0.2"
 atty = "0.2"
 tracing = { version = "0.1.28" }
-tracing-subscriber = { version = "0.2.16", default-features = false, features = ["fmt", "env-filter", "smallvec", "parking_lot", "ansi"] }
+tracing-subscriber = { version = "0.3.3", default-features = false, features = ["fmt", "env-filter", "smallvec", "parking_lot", "ansi"] }
 tracing-tree = "0.2.0"
 rustc_middle = { path = "../rustc_middle" }
 rustc_ast_pretty = { path = "../rustc_ast_pretty" }

--- a/compiler/rustc_middle/Cargo.toml
+++ b/compiler/rustc_middle/Cargo.toml
@@ -29,7 +29,7 @@ rustc_index = { path = "../rustc_index" }
 rustc_serialize = { path = "../rustc_serialize" }
 rustc_ast = { path = "../rustc_ast" }
 rustc_span = { path = "../rustc_span" }
-chalk-ir = "0.55.0"
+chalk-ir = "0.75.0"
 smallvec = { version = "1.6.1", features = ["union", "may_dangle"] }
 rustc_session = { path = "../rustc_session" }
 rustc_type_ir = { path = "../rustc_type_ir" }

--- a/compiler/rustc_middle/src/traits/chalk.rs
+++ b/compiler/rustc_middle/src/traits/chalk.rs
@@ -206,35 +206,36 @@ impl<'tcx> chalk_ir::interner::Interner for RustInterner<'tcx> {
         Some(write!(fmt, "{:?}", opaque_ty.opaque_ty_id))
     }
 
-    fn intern_ty(&self, ty: chalk_ir::TyData<Self>) -> Self::InternedType {
-        Box::new(ty)
+    fn intern_ty(self, ty: chalk_ir::TyKind<Self>) -> Self::InternedType {
+        let flags = ty.compute_flags(self);
+        Box::new(chalk_ir::TyData { kind: ty, flags: flags })
     }
 
-    fn ty_data<'a>(&self, ty: &'a Self::InternedType) -> &'a chalk_ir::TyData<Self> {
+    fn ty_data<'a>(self, ty: &'a Self::InternedType) -> &'a chalk_ir::TyData<Self> {
         ty
     }
 
-    fn intern_lifetime(&self, lifetime: chalk_ir::LifetimeData<Self>) -> Self::InternedLifetime {
+    fn intern_lifetime(self, lifetime: chalk_ir::LifetimeData<Self>) -> Self::InternedLifetime {
         Box::new(lifetime)
     }
 
     fn lifetime_data<'a>(
-        &self,
+        self,
         lifetime: &'a Self::InternedLifetime,
     ) -> &'a chalk_ir::LifetimeData<Self> {
         &lifetime
     }
 
-    fn intern_const(&self, constant: chalk_ir::ConstData<Self>) -> Self::InternedConst {
+    fn intern_const(self, constant: chalk_ir::ConstData<Self>) -> Self::InternedConst {
         Box::new(constant)
     }
 
-    fn const_data<'a>(&self, constant: &'a Self::InternedConst) -> &'a chalk_ir::ConstData<Self> {
+    fn const_data<'a>(self, constant: &'a Self::InternedConst) -> &'a chalk_ir::ConstData<Self> {
         &constant
     }
 
     fn const_eq(
-        &self,
+        self,
         _ty: &Self::InternedType,
         c1: &Self::InternedConcreteConst,
         c2: &Self::InternedConcreteConst,
@@ -242,143 +243,143 @@ impl<'tcx> chalk_ir::interner::Interner for RustInterner<'tcx> {
         c1 == c2
     }
 
-    fn intern_generic_arg(&self, data: chalk_ir::GenericArgData<Self>) -> Self::InternedGenericArg {
+    fn intern_generic_arg(self, data: chalk_ir::GenericArgData<Self>) -> Self::InternedGenericArg {
         Box::new(data)
     }
 
     fn generic_arg_data<'a>(
-        &self,
+        self,
         data: &'a Self::InternedGenericArg,
     ) -> &'a chalk_ir::GenericArgData<Self> {
         &data
     }
 
-    fn intern_goal(&self, goal: chalk_ir::GoalData<Self>) -> Self::InternedGoal {
+    fn intern_goal(self, goal: chalk_ir::GoalData<Self>) -> Self::InternedGoal {
         Box::new(goal)
     }
 
-    fn goal_data<'a>(&self, goal: &'a Self::InternedGoal) -> &'a chalk_ir::GoalData<Self> {
+    fn goal_data<'a>(self, goal: &'a Self::InternedGoal) -> &'a chalk_ir::GoalData<Self> {
         &goal
     }
 
     fn intern_goals<E>(
-        &self,
+        self,
         data: impl IntoIterator<Item = Result<chalk_ir::Goal<Self>, E>>,
     ) -> Result<Self::InternedGoals, E> {
         data.into_iter().collect::<Result<Vec<_>, _>>()
     }
 
-    fn goals_data<'a>(&self, goals: &'a Self::InternedGoals) -> &'a [chalk_ir::Goal<Self>] {
+    fn goals_data<'a>(self, goals: &'a Self::InternedGoals) -> &'a [chalk_ir::Goal<Self>] {
         goals
     }
 
     fn intern_substitution<E>(
-        &self,
+        self,
         data: impl IntoIterator<Item = Result<chalk_ir::GenericArg<Self>, E>>,
     ) -> Result<Self::InternedSubstitution, E> {
         data.into_iter().collect::<Result<Vec<_>, _>>()
     }
 
     fn substitution_data<'a>(
-        &self,
+        self,
         substitution: &'a Self::InternedSubstitution,
     ) -> &'a [chalk_ir::GenericArg<Self>] {
         substitution
     }
 
     fn intern_program_clause(
-        &self,
+        self,
         data: chalk_ir::ProgramClauseData<Self>,
     ) -> Self::InternedProgramClause {
         Box::new(data)
     }
 
     fn program_clause_data<'a>(
-        &self,
+        self,
         clause: &'a Self::InternedProgramClause,
     ) -> &'a chalk_ir::ProgramClauseData<Self> {
         &clause
     }
 
     fn intern_program_clauses<E>(
-        &self,
+        self,
         data: impl IntoIterator<Item = Result<chalk_ir::ProgramClause<Self>, E>>,
     ) -> Result<Self::InternedProgramClauses, E> {
         data.into_iter().collect::<Result<Vec<_>, _>>()
     }
 
     fn program_clauses_data<'a>(
-        &self,
+        self,
         clauses: &'a Self::InternedProgramClauses,
     ) -> &'a [chalk_ir::ProgramClause<Self>] {
         clauses
     }
 
     fn intern_quantified_where_clauses<E>(
-        &self,
+        self,
         data: impl IntoIterator<Item = Result<chalk_ir::QuantifiedWhereClause<Self>, E>>,
     ) -> Result<Self::InternedQuantifiedWhereClauses, E> {
         data.into_iter().collect::<Result<Vec<_>, _>>()
     }
 
     fn quantified_where_clauses_data<'a>(
-        &self,
+        self,
         clauses: &'a Self::InternedQuantifiedWhereClauses,
     ) -> &'a [chalk_ir::QuantifiedWhereClause<Self>] {
         clauses
     }
 
     fn intern_generic_arg_kinds<E>(
-        &self,
+        self,
         data: impl IntoIterator<Item = Result<chalk_ir::VariableKind<Self>, E>>,
     ) -> Result<Self::InternedVariableKinds, E> {
         data.into_iter().collect::<Result<Vec<_>, _>>()
     }
 
     fn variable_kinds_data<'a>(
-        &self,
+        self,
         parameter_kinds: &'a Self::InternedVariableKinds,
     ) -> &'a [chalk_ir::VariableKind<Self>] {
         parameter_kinds
     }
 
     fn intern_canonical_var_kinds<E>(
-        &self,
+        self,
         data: impl IntoIterator<Item = Result<chalk_ir::CanonicalVarKind<Self>, E>>,
     ) -> Result<Self::InternedCanonicalVarKinds, E> {
         data.into_iter().collect::<Result<Vec<_>, _>>()
     }
 
     fn canonical_var_kinds_data<'a>(
-        &self,
+        self,
         canonical_var_kinds: &'a Self::InternedCanonicalVarKinds,
     ) -> &'a [chalk_ir::CanonicalVarKind<Self>] {
         canonical_var_kinds
     }
 
     fn intern_constraints<E>(
-        &self,
+        self,
         data: impl IntoIterator<Item = Result<chalk_ir::InEnvironment<chalk_ir::Constraint<Self>>, E>>,
     ) -> Result<Self::InternedConstraints, E> {
         data.into_iter().collect::<Result<Vec<_>, _>>()
     }
 
     fn constraints_data<'a>(
-        &self,
+        self,
         constraints: &'a Self::InternedConstraints,
     ) -> &'a [chalk_ir::InEnvironment<chalk_ir::Constraint<Self>>] {
         constraints
     }
 
     fn intern_variances<E>(
-        &self,
+        self,
         data: impl IntoIterator<Item = Result<chalk_ir::Variance, E>>,
     ) -> Result<Self::InternedVariances, E> {
         data.into_iter().collect::<Result<Vec<_>, _>>()
     }
 
     fn variances_data<'a>(
-        &self,
+        self,
         variances: &'a Self::InternedVariances,
     ) -> &'a [chalk_ir::Variance] {
         variances

--- a/compiler/rustc_traits/Cargo.toml
+++ b/compiler/rustc_traits/Cargo.toml
@@ -12,9 +12,9 @@ rustc_hir = { path = "../rustc_hir" }
 rustc_index = { path = "../rustc_index" }
 rustc_ast = { path = "../rustc_ast" }
 rustc_span = { path = "../rustc_span" }
-chalk-ir = "0.55.0"
-chalk-solve = "0.55.0"
-chalk-engine = "0.55.0"
+chalk-ir = "0.75.0"
+chalk-engine = "0.75.0"
+chalk-solve = "0.75.0"
 smallvec = { version = "1.6.1", features = ["union", "may_dangle"] }
 rustc_infer = { path = "../rustc_infer" }
 rustc_trait_selection = { path = "../rustc_trait_selection" }

--- a/compiler/rustc_traits/src/chalk/mod.rs
+++ b/compiler/rustc_traits/src/chalk/mod.rs
@@ -63,7 +63,7 @@ crate fn evaluate_goal<'tcx>(
     > = chalk_ir::UCanonical {
         canonical: chalk_ir::Canonical {
             binders: chalk_ir::CanonicalVarKinds::from_iter(
-                &interner,
+                interner,
                 obligation.variables.iter().map(|v| match v.kind {
                     CanonicalVarKind::PlaceholderTy(_ty) => unimplemented!(),
                     CanonicalVarKind::PlaceholderRegion(_ui) => unimplemented!(),
@@ -89,7 +89,7 @@ crate fn evaluate_goal<'tcx>(
                     CanonicalVarKind::PlaceholderConst(_pc) => unimplemented!(),
                 }),
             ),
-            value: obligation.value.lower_into(&interner),
+            value: obligation.value.lower_into(interner),
         },
         universes: max_universe + 1,
     };
@@ -110,11 +110,11 @@ crate fn evaluate_goal<'tcx>(
         use rustc_middle::infer::canonical::CanonicalVarInfo;
 
         let mut var_values: IndexVec<BoundVar, GenericArg<'tcx>> = IndexVec::new();
-        subst.as_slice(&interner).iter().for_each(|p| {
-            var_values.push(p.lower_into(&interner));
+        subst.as_slice(interner).iter().for_each(|p| {
+            var_values.push(p.lower_into(interner));
         });
         let variables: Vec<_> = binders
-            .iter(&interner)
+            .iter(interner)
             .map(|var| {
                 let kind = match var.kind {
                     chalk_ir::VariableKind::Ty(ty_kind) => CanonicalVarKind::Ty(match ty_kind {
@@ -134,8 +134,7 @@ crate fn evaluate_goal<'tcx>(
                 CanonicalVarInfo { kind }
             })
             .collect();
-        let max_universe =
-            binders.iter(&interner).map(|v| v.skip_kind().counter).max().unwrap_or(0);
+        let max_universe = binders.iter(interner).map(|v| v.skip_kind().counter).max().unwrap_or(0);
         let sol = Canonical {
             max_universe: ty::UniverseIndex::from_usize(max_universe),
             variables: tcx.intern_canonical_var_infos(&variables),

--- a/src/librustdoc/Cargo.toml
+++ b/src/librustdoc/Cargo.toml
@@ -23,7 +23,7 @@ tracing-tree = "0.2.0"
 tera = { version = "1.10.0", default-features = false }
 
 [dependencies.tracing-subscriber]
-version = "0.2.13"
+version = "0.3.3"
 default-features = false
 features = ["fmt", "env-filter", "smallvec", "parking_lot", "ansi"]
 

--- a/src/librustdoc/Cargo.toml
+++ b/src/librustdoc/Cargo.toml
@@ -19,7 +19,7 @@ itertools = "0.9"
 regex = "1"
 rustdoc-json-types = { path = "../rustdoc-json-types" }
 tracing = "0.1"
-tracing-tree = "0.1.9"
+tracing-tree = "0.2.0"
 tera = { version = "1.10.0", default-features = false }
 
 [dependencies.tracing-subscriber]

--- a/src/tools/compiletest/Cargo.toml
+++ b/src/tools/compiletest/Cargo.toml
@@ -9,7 +9,7 @@ diff = "0.1.10"
 unified-diff = "0.2.1"
 getopts = "0.2"
 tracing = "0.1"
-tracing-subscriber = { version = "0.2", default-features = false, features = ["fmt", "env-filter", "smallvec", "parking_lot", "ansi"] }
+tracing-subscriber = { version = "0.3.3", default-features = false, features = ["fmt", "env-filter", "smallvec", "parking_lot", "ansi"] }
 regex = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/src/tools/tidy/src/deps.rs
+++ b/src/tools/tidy/src/deps.rs
@@ -208,7 +208,6 @@ const PERMITTED_DEPENDENCIES: &[&str] = &[
     "tracing-attributes",
     "tracing-core",
     "tracing-log",
-    "tracing-serde",
     "tracing-subscriber",
     "tracing-tree",
     "typenum",


### PR DESCRIPTION
- Compute flags in `intern_ty`
- Remove `tracing-serde` from `PERMITTED_DEPENDENCIES`
- Bump `tracing-tree` to 0.2.0
- Bump `tracing-subscriber` to 0.3.3