### PR TITLE
Specialize Enumerate::fold for TrustedRandomAccess iterators

### DIFF
--- a/library/core/benches/iter.rs
+++ b/library/core/benches/iter.rs
@@ -367,3 +367,28 @@ fn bench_partial_cmp(b: &mut Bencher) {
 fn bench_lt(b: &mut Bencher) {
     b.iter(|| (0..100000).map(black_box).lt((0..100000).map(black_box)))
 }
+
+// Ideally the compiler should be able to optimize away the range checks here and turn those
+// benchmarks into nops
+#[bench]
+fn bench_iter_enumerate_ext(b: &mut Bencher) {
+    let v = vec![0; 8000];
+
+    b.iter(|| {
+        let v = black_box(v.as_slice());
+        for (i, _) in v.iter().enumerate() {
+            assert!(i <= v.len());
+        }
+    })
+}
+
+#[bench]
+fn bench_iter_enumerate_int(b: &mut Bencher) {
+    let v = vec![0; 8000];
+    b.iter(|| {
+        let v = black_box(v.as_slice());
+        v.iter().enumerate().for_each(|(i, _)| {
+            assert!(i <= v.len());
+        })
+    })
+}


### PR DESCRIPTION
Using a single loop induction makes it easier for the optimizer to see the value range of the enumerated
indexes are in bounds of of the iterated slice.

Helps with #92174 but doesn't solve it.