### PR TITLE
Implement a hashed SourceFile lookup for decoding spans in rmeta

### DIFF
--- a/compiler/rustc_span/src/lib.rs
+++ b/compiler/rustc_span/src/lib.rs
@@ -1203,15 +1203,19 @@ pub struct NormalizedPos {
     pub diff: u32,
 }
 
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Encodable, Decodable)]
+pub struct SourceFileIndex(pub u32);
+
 #[derive(PartialEq, Eq, Clone, Debug)]
 pub enum ExternalSource {
     /// No external source has to be loaded, since the `SourceFile` represents a local crate.
     Unneeded,
     Foreign {
         kind: ExternalSourceKind,
+        /// This SourceFile's index in the files list of the source_map of its original crate.
+        original_source_index: SourceFileIndex,
         /// This SourceFile's byte-offset within the source_map of its original crate.
         original_start_pos: BytePos,
-        /// The end of this SourceFile within the source_map of its original crate.
         original_end_pos: BytePos,
     },
 }

--- a/compiler/rustc_span/src/source_map.rs
+++ b/compiler/rustc_span/src/source_map.rs
@@ -335,6 +335,7 @@ impl SourceMap {
         mut file_local_multibyte_chars: Vec<MultiByteChar>,
         mut file_local_non_narrow_chars: Vec<NonNarrowChar>,
         mut file_local_normalized_pos: Vec<NormalizedPos>,
+        original_source_index: SourceFileIndex,
         original_start_pos: BytePos,
         original_end_pos: BytePos,
     ) -> Lrc<SourceFile> {
@@ -367,6 +368,7 @@ impl SourceMap {
             src_hash,
             external_src: Lock::new(ExternalSource::Foreign {
                 kind: ExternalSourceKind::AbsentOk,
+                original_source_index,
                 original_start_pos,
                 original_end_pos,
             }),

--- a/compiler/rustc_span/src/source_map/tests.rs
+++ b/compiler/rustc_span/src/source_map/tests.rs
@@ -250,6 +250,7 @@ fn t10() {
         multibyte_chars,
         non_narrow_chars,
         normalized_pos,
+        SourceFileIndex(0),
         start_pos,
         end_pos,
     );


### PR DESCRIPTION
Took a first pass at the suggestion in #92176. Decoding got much simpler, at the expense of a more complicated encoding. Not sure how this plays out.. 

The main complication with encoding is that we don't encode all the files in the SourceMap, just the ones that we have Spans pointing to... so we have to manually keep track and increment a SourceFileIndex when we see a new file that we know we need to emit. This makes us have to maintain a HashMap (SourceFile -> index) and an ordered list of SourceFiles to emit as our SourceMap.

r? @Aaron1011 

Fixes #92176