### PR TITLE
Delay remaining `span_bug`s in drop elaboration

### DIFF
--- a/compiler/rustc_mir_transform/src/elaborate_drops.rs
+++ b/compiler/rustc_mir_transform/src/elaborate_drops.rs
@@ -316,12 +316,12 @@ impl<'b, 'tcx> ElaborateDropsCtxt<'b, 'tcx> {
                 LookupResult::Parent(Some(parent)) => {
                     let (_maybe_live, maybe_dead) = self.init_data.maybe_live_dead(parent);
                     if maybe_dead {
-                        span_bug!(
+                        self.tcx.sess.delay_span_bug(
                             terminator.source_info.span,
-                            "drop of untracked, uninitialized value {:?}, place {:?} ({:?})",
-                            bb,
-                            place,
-                            path
+                            &format!(
+                                "drop of untracked, uninitialized value {:?}, place {:?} ({:?})",
+                                bb, place, path,
+                            ),
                         );
                     }
                     continue;
@@ -368,10 +368,9 @@ impl<'b, 'tcx> ElaborateDropsCtxt<'b, 'tcx> {
                             bb,
                         ),
                         LookupResult::Parent(..) => {
-                            span_bug!(
+                            self.tcx.sess.delay_span_bug(
                                 terminator.source_info.span,
-                                "drop of untracked value {:?}",
-                                bb
+                                &format!("drop of untracked value {:?}", bb),
                             );
                         }
                     }

--- a/src/test/ui/mir/drop-elaboration-after-borrowck-error.rs
+++ b/src/test/ui/mir/drop-elaboration-after-borrowck-error.rs
@@ -1,0 +1,25 @@
+// Regression test for issue 81708 and issue 91816 where running a drop
+// elaboration on a MIR which failed borrowck lead to an ICE.
+
+static A: () = {
+    let a: [String; 1];
+    //~^ ERROR destructors cannot be evaluated at compile-time
+    a[0] = String::new();
+    //~^ ERROR destructors cannot be evaluated at compile-time
+    //~| ERROR use of possibly-uninitialized variable
+};
+
+struct B<T>([T; 1]);
+
+impl<T> B<T> {
+    pub const fn f(mut self, other: T) -> Self {
+        let _this = self;
+        //~^ ERROR destructors cannot be evaluated at compile-time
+        self.0[0] = other;
+        //~^ ERROR destructors cannot be evaluated at compile-time
+        //~| ERROR use of moved value
+        self
+    }
+}
+
+fn main() {}

--- a/src/test/ui/mir/drop-elaboration-after-borrowck-error.stderr
+++ b/src/test/ui/mir/drop-elaboration-after-borrowck-error.stderr
@@ -1,0 +1,57 @@
+error[E0493]: destructors cannot be evaluated at compile-time
+  --> $DIR/drop-elaboration-after-borrowck-error.rs:7:5
+   |
+LL |     a[0] = String::new();
+   |     ^^^^
+   |     |
+   |     statics cannot evaluate destructors
+   |     value is dropped here
+
+error[E0493]: destructors cannot be evaluated at compile-time
+  --> $DIR/drop-elaboration-after-borrowck-error.rs:5:9
+   |
+LL |     let a: [String; 1];
+   |         ^ statics cannot evaluate destructors
+...
+LL | };
+   | - value is dropped here
+
+error[E0381]: use of possibly-uninitialized variable: `a`
+  --> $DIR/drop-elaboration-after-borrowck-error.rs:7:5
+   |
+LL |     a[0] = String::new();
+   |     ^^^^ use of possibly-uninitialized `a`
+
+error[E0493]: destructors cannot be evaluated at compile-time
+  --> $DIR/drop-elaboration-after-borrowck-error.rs:18:9
+   |
+LL |         self.0[0] = other;
+   |         ^^^^^^^^^
+   |         |
+   |         constant functions cannot evaluate destructors
+   |         value is dropped here
+
+error[E0493]: destructors cannot be evaluated at compile-time
+  --> $DIR/drop-elaboration-after-borrowck-error.rs:16:13
+   |
+LL |         let _this = self;
+   |             ^^^^^ constant functions cannot evaluate destructors
+...
+LL |     }
+   |     - value is dropped here
+
+error[E0382]: use of moved value: `self.0`
+  --> $DIR/drop-elaboration-after-borrowck-error.rs:18:9
+   |
+LL |     pub const fn f(mut self, other: T) -> Self {
+   |                    -------- move occurs because `self` has type `B<T>`, which does not implement the `Copy` trait
+LL |         let _this = self;
+   |                     ---- value moved here
+LL |
+LL |         self.0[0] = other;
+   |         ^^^^^^^^^ value used here after move
+
+error: aborting due to 6 previous errors
+
+Some errors have detailed explanations: E0381, E0382, E0493.
+For more information about an error, try `rustc --explain E0381`.


### PR DESCRIPTION
This follows changes from #67967 and converts remaining `span_bug`s into
delayed bugs, since for const items drop elaboration might be executed
on a MIR which failed borrowck.

Fixes #81708.
Fixes #91816.