### PR TITLE
Error if submodule fetch fails.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,9 @@ jobs:
       - name: disable git crlf conversion
         run: src/ci/scripts/disable-git-crlf-conversion.sh
         if: success() && !env.SKIP_JOB
+      - name: checkout submodules
+        run: src/ci/scripts/checkout-submodules.sh
+        if: success() && !env.SKIP_JOB
       - name: install MSYS2
         run: src/ci/scripts/install-msys2.sh
         if: success() && !env.SKIP_JOB
@@ -118,9 +121,6 @@ jobs:
         if: success() && !env.SKIP_JOB
       - name: disable git crlf conversion
         run: src/ci/scripts/disable-git-crlf-conversion.sh
-        if: success() && !env.SKIP_JOB
-      - name: checkout submodules
-        run: src/ci/scripts/checkout-submodules.sh
         if: success() && !env.SKIP_JOB
       - name: ensure line endings are correct
         run: src/ci/scripts/verify-line-endings.sh
@@ -502,6 +502,9 @@ jobs:
       - name: disable git crlf conversion
         run: src/ci/scripts/disable-git-crlf-conversion.sh
         if: success() && !env.SKIP_JOB
+      - name: checkout submodules
+        run: src/ci/scripts/checkout-submodules.sh
+        if: success() && !env.SKIP_JOB
       - name: install MSYS2
         run: src/ci/scripts/install-msys2.sh
         if: success() && !env.SKIP_JOB
@@ -516,9 +519,6 @@ jobs:
         if: success() && !env.SKIP_JOB
       - name: disable git crlf conversion
         run: src/ci/scripts/disable-git-crlf-conversion.sh
-        if: success() && !env.SKIP_JOB
-      - name: checkout submodules
-        run: src/ci/scripts/checkout-submodules.sh
         if: success() && !env.SKIP_JOB
       - name: ensure line endings are correct
         run: src/ci/scripts/verify-line-endings.sh
@@ -615,6 +615,9 @@ jobs:
       - name: disable git crlf conversion
         run: src/ci/scripts/disable-git-crlf-conversion.sh
         if: success() && !env.SKIP_JOB
+      - name: checkout submodules
+        run: src/ci/scripts/checkout-submodules.sh
+        if: success() && !env.SKIP_JOB
       - name: install MSYS2
         run: src/ci/scripts/install-msys2.sh
         if: success() && !env.SKIP_JOB
@@ -629,9 +632,6 @@ jobs:
         if: success() && !env.SKIP_JOB
       - name: disable git crlf conversion
         run: src/ci/scripts/disable-git-crlf-conversion.sh
-        if: success() && !env.SKIP_JOB
-      - name: checkout submodules
-        run: src/ci/scripts/checkout-submodules.sh
         if: success() && !env.SKIP_JOB
       - name: ensure line endings are correct
         run: src/ci/scripts/verify-line-endings.sh

--- a/src/ci/github-actions/ci.yml
+++ b/src/ci/github-actions/ci.yml
@@ -169,6 +169,10 @@ x--expand-yaml-anchors--remove:
         run: src/ci/scripts/disable-git-crlf-conversion.sh
         <<: *step
 
+      - name: checkout submodules
+        run: src/ci/scripts/checkout-submodules.sh
+        <<: *step
+
       - name: install MSYS2
         run: src/ci/scripts/install-msys2.sh
         <<: *step
@@ -192,10 +196,6 @@ x--expand-yaml-anchors--remove:
       # appropriate line endings.
       - name: disable git crlf conversion
         run: src/ci/scripts/disable-git-crlf-conversion.sh
-        <<: *step
-
-      - name: checkout submodules
-        run: src/ci/scripts/checkout-submodules.sh
         <<: *step
 
       - name: ensure line endings are correct

--- a/src/ci/init_repo.sh
+++ b/src/ci/init_repo.sh
@@ -62,6 +62,7 @@ for i in ${!modules[@]}; do
         url=${urls[$i]}
         url=${url/\.git/}
         fetch_github_commit_archive $module "$url/archive/$commit.tar.gz" &
+        bg_pids[${i}]=$!
         continue
     else
         use_git="$use_git $module"
@@ -70,4 +71,9 @@ done
 retry sh -c "git submodule deinit -f $use_git && \
     git submodule sync && \
     git submodule update -j 16 --init --recursive $use_git"
-wait
+STATUS=0
+for pid in ${bg_pids[*]}
+do
+    wait $pid || STATUS=1
+done
+exit ${STATUS}

--- a/src/ci/init_repo.sh
+++ b/src/ci/init_repo.sh
@@ -43,6 +43,11 @@ function fetch_github_commit_archive {
         curl -f -sSL -o $cached $2"
     mkdir $module
     touch "$module/.git"
+    # On Windows, the default behavior is to emulate symlinks by copying
+    # files. However, that ends up being order-dependent while extracting,
+    # which can cause a failure if the symlink comes first. This env var
+    # causes tar to use real symlinks instead, which are allowed to dangle.
+    export MSYS=winsymlinks:nativestrict
     tar -C $module --strip-components=1 -xf $cached
     rm $cached
 }


### PR DESCRIPTION
In CI, if fetching a submodule fails, the script would exit successfully. Later parts of the build will fail due to the missing files, but it is a bit confusing, and I think it would be better to error out earlier.

The reason is that in bash, `wait` without arguments will exit 0 even if a background job exits with an error. The solution here is to wait on each individual job, which will return the exit code of the job.

This was encountered in #92177.
