### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/compiler/rustc_typeck/src/check/method/suggest.rs
+++ b/compiler/rustc_typeck/src/check/method/suggest.rs
@@ -1175,11 +1175,11 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     fn suggest_derive(
         &self,
         err: &mut DiagnosticBuilder<'_>,
-        unsatisfied_predicates: &Vec<(
+        unsatisfied_predicates: &[(
             ty::Predicate<'tcx>,
             Option<ty::Predicate<'tcx>>,
             Option<ObligationCause<'tcx>>,
-        )>,
+        )],
     ) {
         let mut derives = Vec::<(String, Span, String)>::new();
         let mut traits = Vec::<Span>::new();
@@ -1216,22 +1216,23 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 traits.push(self.tcx.def_span(trait_pred.def_id()));
             }
         }
-        derives.sort();
-        let derives_grouped = derives.into_iter().fold(
-            Vec::<(String, Span, String)>::new(),
-            |mut acc, (self_name, self_span, trait_name)| {
-                if let Some((acc_self_name, _, ref mut traits)) = acc.last_mut() {
-                    if acc_self_name == &self_name {
-                        traits.push_str(format!(", {}", trait_name).as_str());
-                        return acc;
-                    }
-                }
-                acc.push((self_name, self_span, trait_name));
-                acc
-            },
-        );
         traits.sort();
         traits.dedup();
+
+        derives.sort();
+        derives.dedup();
+
+        let mut derives_grouped = Vec::<(String, Span, String)>::new();
+        for (self_name, self_span, trait_name) in derives.into_iter() {
+            if let Some((last_self_name, _, ref mut last_trait_names)) = derives_grouped.last_mut()
+            {
+                if last_self_name == &self_name {
+                    last_trait_names.push_str(format!(", {}", trait_name).as_str());
+                    continue;
+                }
+            }
+            derives_grouped.push((self_name, self_span, trait_name));
+        }
 
         let len = traits.len();
         if len > 0 {

--- a/library/alloc/tests/str.rs
+++ b/library/alloc/tests/str.rs
@@ -1126,6 +1126,37 @@ fn test_rev_iterator() {
 }
 
 #[test]
+fn test_to_lowercase_rev_iterator() {
+    let s = "AÖßÜ💩ΣΤΙΓΜΑΣǅﬁİ";
+    let v = ['\u{307}', 'i', 'ﬁ', 'ǆ', 'σ', 'α', 'μ', 'γ', 'ι', 'τ', 'σ', '💩', 'ü', 'ß', 'ö', 'a'];
+
+    let mut pos = 0;
+    let it = s.chars().flat_map(|c| c.to_lowercase()).rev();
+
+    for c in it {
+        assert_eq!(c, v[pos]);
+        pos += 1;
+    }
+    assert_eq!(pos, v.len());
+}
+
+#[test]
+fn test_to_uppercase_rev_iterator() {
+    let s = "aößü💩στιγμαςǅﬁᾀ";
+    let v =
+        ['Ι', 'Ἀ', 'I', 'F', 'Ǆ', 'Σ', 'Α', 'Μ', 'Γ', 'Ι', 'Τ', 'Σ', '💩', 'Ü', 'S', 'S', 'Ö', 'A'];
+
+    let mut pos = 0;
+    let it = s.chars().flat_map(|c| c.to_uppercase()).rev();
+
+    for c in it {
+        assert_eq!(c, v[pos]);
+        pos += 1;
+    }
+    assert_eq!(pos, v.len());
+}
+
+#[test]
 #[cfg_attr(miri, ignore)] // Miri is too slow
 fn test_chars_decoding() {
     let mut bytes = [0; 4];

--- a/library/core/src/char/mod.rs
+++ b/library/core/src/char/mod.rs
@@ -393,6 +393,13 @@ impl Iterator for ToLowercase {
     }
 }
 
+#[stable(feature = "rust1", since = "1.0.0")]
+impl DoubleEndedIterator for ToLowercase {
+    fn next_back(&mut self) -> Option<char> {
+        self.0.next_back()
+    }
+}
+
 #[stable(feature = "fused", since = "1.26.0")]
 impl FusedIterator for ToLowercase {}
 
@@ -417,6 +424,13 @@ impl Iterator for ToUppercase {
     }
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.0.size_hint()
+    }
+}
+
+#[stable(feature = "rust1", since = "1.0.0")]
+impl DoubleEndedIterator for ToUppercase {
+    fn next_back(&mut self) -> Option<char> {
+        self.0.next_back()
     }
 }
 
@@ -476,6 +490,26 @@ impl Iterator for CaseMappingIter {
             CaseMappingIter::Zero => 0,
         };
         (size, Some(size))
+    }
+}
+
+impl DoubleEndedIterator for CaseMappingIter {
+    fn next_back(&mut self) -> Option<char> {
+        match *self {
+            CaseMappingIter::Three(a, b, c) => {
+                *self = CaseMappingIter::Two(a, b);
+                Some(c)
+            }
+            CaseMappingIter::Two(b, c) => {
+                *self = CaseMappingIter::One(b);
+                Some(c)
+            }
+            CaseMappingIter::One(c) => {
+                *self = CaseMappingIter::Zero;
+                Some(c)
+            }
+            CaseMappingIter::Zero => None,
+        }
     }
 }
 

--- a/library/core/src/char/mod.rs
+++ b/library/core/src/char/mod.rs
@@ -393,7 +393,7 @@ impl Iterator for ToLowercase {
     }
 }
 
-#[stable(feature = "rust1", since = "1.0.0")]
+#[stable(feature = "case_mapping_double_ended", since = "1.59.0")]
 impl DoubleEndedIterator for ToLowercase {
     fn next_back(&mut self) -> Option<char> {
         self.0.next_back()
@@ -427,7 +427,7 @@ impl Iterator for ToUppercase {
     }
 }
 
-#[stable(feature = "rust1", since = "1.0.0")]
+#[stable(feature = "case_mapping_double_ended", since = "1.59.0")]
 impl DoubleEndedIterator for ToUppercase {
     fn next_back(&mut self) -> Option<char> {
         self.0.next_back()

--- a/library/core/tests/char.rs
+++ b/library/core/tests/char.rs
@@ -91,6 +91,9 @@ fn test_to_lowercase() {
         let iter: String = c.to_lowercase().collect();
         let disp: String = c.to_lowercase().to_string();
         assert_eq!(iter, disp);
+        let iter_rev: String = c.to_lowercase().rev().collect();
+        let disp_rev: String = disp.chars().rev().collect();
+        assert_eq!(iter_rev, disp_rev);
         iter
     }
     assert_eq!(lower('A'), "a");
@@ -118,6 +121,9 @@ fn test_to_uppercase() {
         let iter: String = c.to_uppercase().collect();
         let disp: String = c.to_uppercase().to_string();
         assert_eq!(iter, disp);
+        let iter_rev: String = c.to_uppercase().rev().collect();
+        let disp_rev: String = disp.chars().rev().collect();
+        assert_eq!(iter_rev, disp_rev);
         iter
     }
     assert_eq!(upper('a'), "A");

--- a/library/std/src/backtrace.rs
+++ b/library/std/src/backtrace.rs
@@ -99,7 +99,7 @@ use crate::cell::UnsafeCell;
 use crate::env;
 use crate::ffi::c_void;
 use crate::fmt;
-use crate::sync::atomic::{AtomicUsize, Ordering::SeqCst};
+use crate::sync::atomic::{AtomicUsize, Ordering::Relaxed};
 use crate::sync::Once;
 use crate::sys_common::backtrace::{lock, output_filename};
 use crate::vec::Vec;
@@ -256,7 +256,7 @@ impl Backtrace {
         // backtrace captures speedy, because otherwise reading environment
         // variables every time can be somewhat slow.
         static ENABLED: AtomicUsize = AtomicUsize::new(0);
-        match ENABLED.load(SeqCst) {
+        match ENABLED.load(Relaxed) {
             0 => {}
             1 => return false,
             _ => return true,
@@ -268,7 +268,7 @@ impl Backtrace {
                 Err(_) => false,
             },
         };
-        ENABLED.store(enabled as usize + 1, SeqCst);
+        ENABLED.store(enabled as usize + 1, Relaxed);
         enabled
     }
 

--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -282,7 +282,10 @@ crate struct RenderOptions {
     crate emit: Vec<EmitType>,
     /// If `true`, HTML source pages will generate links for items to their definition.
     crate generate_link_to_definition: bool,
+    /// Set of function-call locations to include as examples
     crate call_locations: AllCallLocations,
+    /// If `true`, Context::init will not emit shared files.
+    crate no_emit_shared: bool,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -753,6 +756,7 @@ impl Options {
                 emit,
                 generate_link_to_definition,
                 call_locations,
+                no_emit_shared: false,
             },
             crate_name,
             output_format,

--- a/src/librustdoc/html/render/context.rs
+++ b/src/librustdoc/html/render/context.rs
@@ -405,6 +405,7 @@ impl<'tcx> FormatRenderer<'tcx> for Context<'tcx> {
             show_type_layout,
             generate_link_to_definition,
             call_locations,
+            no_emit_shared,
             ..
         } = options;
 
@@ -525,13 +526,16 @@ impl<'tcx> FormatRenderer<'tcx> for Context<'tcx> {
             sources::render(&mut cx, &krate)?;
         }
 
-        // Build our search index
-        let index = build_index(&krate, &mut Rc::get_mut(&mut cx.shared).unwrap().cache, tcx);
+        if !no_emit_shared {
+            // Build our search index
+            let index = build_index(&krate, &mut Rc::get_mut(&mut cx.shared).unwrap().cache, tcx);
 
-        // Write shared runs within a flock; disable thread dispatching of IO temporarily.
-        Rc::get_mut(&mut cx.shared).unwrap().fs.set_sync_only(true);
-        write_shared(&cx, &krate, index, &md_opts)?;
-        Rc::get_mut(&mut cx.shared).unwrap().fs.set_sync_only(false);
+            // Write shared runs within a flock; disable thread dispatching of IO temporarily.
+            Rc::get_mut(&mut cx.shared).unwrap().fs.set_sync_only(true);
+            write_shared(&cx, &krate, index, &md_opts)?;
+            Rc::get_mut(&mut cx.shared).unwrap().fs.set_sync_only(false);
+        }
+
         Ok((cx, krate))
     }
 

--- a/src/librustdoc/html/static/js/README.md
+++ b/src/librustdoc/html/static/js/README.md
@@ -1,0 +1,15 @@
+# Rustdoc JS
+
+These JavaScript files are incorporated into the rustdoc binary at build time,
+and are minified and written to the filesystem as part of the doc build process.
+
+We use the [Closure Compiler](https://github.com/google/closure-compiler/wiki/Annotating-JavaScript-for-the-Closure-Compiler)
+dialect of JSDoc to comment our code and annotate params and return types.
+To run a check:
+
+    ./x.py doc library/std
+    npm i -g google-closure-compiler
+    google-closure-compiler -W VERBOSE \
+      build/<YOUR PLATFORM>/doc/{search-index*.js,crates*.js} \
+      src/librustdoc/html/static/js/{search.js,main.js,storage.js} \
+      --externs src/librustdoc/html/static/js/externs.js >/dev/null

--- a/src/librustdoc/html/static/js/externs.js
+++ b/src/librustdoc/html/static/js/externs.js
@@ -1,0 +1,32 @@
+// This file contains type definitions that are processed by the Closure Compiler but are
+// not put into the JavaScript we include as part of the documentation. It is used for
+// type checking. See README.md in this directory for more info.
+
+/* eslint-disable */
+var searchState;
+function initSearch(searchIndex){}
+
+/**
+ * @typedef {{
+ *   raw: string,
+ *   query: string,
+ *   type: string,
+ *   id: string,
+ * }}
+ */
+var ParsedQuery;
+
+/**
+ * @typedef {{
+ *    crate: string,
+ *    desc: string,
+ *    id: number,
+ *    name: string,
+ *    normalizedName: string,
+ *    parent: (Object|null|undefined),
+ *    path: string,
+ *    ty: (Number|null|number),
+ *    type: (Array<?>|null)
+ * }}
+ */
+var Row;

--- a/src/librustdoc/html/static/js/main.js
+++ b/src/librustdoc/html/static/js/main.js
@@ -420,6 +420,13 @@ function hideThemeButtonState() {
         return document.getElementById("help");
     }
 
+    /**
+     * Show the help popup.
+     *
+     * @param {boolean} display    - Whether to show or hide the popup
+     * @param {Event}   ev         - The event that triggered this call
+     * @param {Element} [help]     - The help element if it already exists
+     */
     function displayHelp(display, ev, help) {
         if (display) {
             help = help ? help : getHelpElement(true);

--- a/src/librustdoc/html/static/js/storage.js
+++ b/src/librustdoc/html/static/js/storage.js
@@ -55,6 +55,12 @@ function removeClass(elem, className) {
     elem.classList.remove(className);
 }
 
+/**
+ * Run a callback for every element of an Array.
+ * @param {Array<?>}    arr        - The array to iterate over
+ * @param {function(?)} func       - The callback
+ * @param {boolean}     [reversed] - Whether to iterate in reverse
+ */
 function onEach(arr, func, reversed) {
     if (arr && arr.length > 0 && func) {
         var length = arr.length;
@@ -76,6 +82,16 @@ function onEach(arr, func, reversed) {
     return false;
 }
 
+/**
+ * Turn an HTMLCollection or a NodeList into an Array, then run a callback
+ * for every element. This is useful because iterating over an HTMLCollection
+ * or a "live" NodeList while modifying it can be very slow.
+ * https://developer.mozilla.org/en-US/docs/Web/API/HTMLCollection
+ * https://developer.mozilla.org/en-US/docs/Web/API/NodeList
+ * @param {NodeList<?>|HTMLCollection<?>} lazyArray  - An array to iterate over
+ * @param {function(?)}                   func       - The callback
+ * @param {boolean}                       [reversed] - Whether to iterate in reverse
+ */
 function onEachLazy(lazyArray, func, reversed) {
     return onEach(
         Array.prototype.slice.call(lazyArray),

--- a/src/librustdoc/scrape_examples.rs
+++ b/src/librustdoc/scrape_examples.rs
@@ -223,13 +223,14 @@ where
 
 crate fn run(
     krate: clean::Crate,
-    renderopts: config::RenderOptions,
+    mut renderopts: config::RenderOptions,
     cache: formats::cache::Cache,
     tcx: TyCtxt<'_>,
     options: ScrapeExamplesOptions,
 ) -> interface::Result<()> {
     let inner = move || -> Result<(), String> {
         // Generates source files for examples
+        renderopts.no_emit_shared = true;
         let (cx, _) = Context::init(krate, renderopts, cache, tcx).map_err(|e| e.to_string())?;
 
         // Collect CrateIds corresponding to provided target crates

--- a/src/test/ui/derives/issue-91492.rs
+++ b/src/test/ui/derives/issue-91492.rs
@@ -1,0 +1,25 @@
+// Reproduce the issue with vec
+pub struct NoDerives;
+fn fun1(foo: &mut Vec<NoDerives>, bar: &[NoDerives]) {
+    foo.extend_from_slice(bar); //~ ERROR
+}
+
+// Reproduce the issue with vec
+// and demonstrate that other derives are ignored in the suggested output
+#[derive(Default, PartialEq)]
+pub struct SomeDerives;
+fn fun2(foo: &mut Vec<SomeDerives>, bar: &[SomeDerives]) {
+    foo.extend_from_slice(bar); //~ ERROR
+}
+
+// Try and fail to reproduce the issue without vec.
+// No idea why it doesnt reproduce the issue but its still a useful test case.
+struct Object<T, A>(T, A);
+impl<T: Clone, A: Default> Object<T, A> {
+    fn use_clone(&self) {}
+}
+fn fun3(foo: Object<NoDerives, SomeDerives>) {
+    foo.use_clone(); //~ ERROR
+}
+
+fn main() {}

--- a/src/test/ui/derives/issue-91492.stderr
+++ b/src/test/ui/derives/issue-91492.stderr
@@ -1,0 +1,54 @@
+error[E0599]: the method `extend_from_slice` exists for mutable reference `&mut Vec<NoDerives>`, but its trait bounds were not satisfied
+  --> $DIR/issue-91492.rs:4:9
+   |
+LL | pub struct NoDerives;
+   | --------------------- doesn't satisfy `NoDerives: Clone`
+LL | fn fun1(foo: &mut Vec<NoDerives>, bar: &[NoDerives]) {
+LL |     foo.extend_from_slice(bar);
+   |         ^^^^^^^^^^^^^^^^^
+   |
+   = note: the following trait bounds were not satisfied:
+           `NoDerives: Clone`
+help: consider annotating `NoDerives` with `#[derive(Clone)]`
+   |
+LL | #[derive(Clone)]
+   |
+
+error[E0599]: the method `extend_from_slice` exists for mutable reference `&mut Vec<SomeDerives>`, but its trait bounds were not satisfied
+  --> $DIR/issue-91492.rs:12:9
+   |
+LL | pub struct SomeDerives;
+   | ----------------------- doesn't satisfy `SomeDerives: Clone`
+LL | fn fun2(foo: &mut Vec<SomeDerives>, bar: &[SomeDerives]) {
+LL |     foo.extend_from_slice(bar);
+   |         ^^^^^^^^^^^^^^^^^
+   |
+   = note: the following trait bounds were not satisfied:
+           `SomeDerives: Clone`
+help: consider annotating `SomeDerives` with `#[derive(Clone)]`
+   |
+LL | #[derive(Clone)]
+   |
+
+error[E0599]: the method `use_clone` exists for struct `Object<NoDerives, SomeDerives>`, but its trait bounds were not satisfied
+  --> $DIR/issue-91492.rs:22:9
+   |
+LL | pub struct NoDerives;
+   | --------------------- doesn't satisfy `NoDerives: Clone`
+...
+LL | struct Object<T, A>(T, A);
+   | -------------------------- method `use_clone` not found for this
+...
+LL |     foo.use_clone();
+   |         ^^^^^^^^^ method cannot be called on `Object<NoDerives, SomeDerives>` due to unsatisfied trait bounds
+   |
+   = note: the following trait bounds were not satisfied:
+           `NoDerives: Clone`
+help: consider annotating `NoDerives` with `#[derive(Clone)]`
+   |
+LL | #[derive(Clone)]
+   |
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0599`.


### PR DESCRIPTION
Successful merges:

 - #88858 (Allow reverse iteration of lowercase'd/uppercase'd chars)
 - #91544 (Fix duplicate derive clone suggestion)
 - #92026 (Add some JSDoc comments to rustdoc JS)
 - #92117 (kmc-solid: Add `std::sys::solid::fs::File::read_buf`)
 - #92139 (Change Backtrace::enabled atomic from SeqCst to Relaxed)
 - #92146 (Don't emit shared files when scraping examples from dependencies in Rustdoc)
 - #92208 (Quote bat script command line)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=88858,91544,92026,92117,92139,92146,92208)
<!-- homu-ignore:end -->