### PR TITLE
Remove VCVARS_BAT

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -355,7 +355,6 @@ jobs:
             env:
               SCRIPT: python x.py --stage 2 test src/tools/cargotest src/tools/cargo
               RUST_CONFIGURE_ARGS: "--build=x86_64-pc-windows-msvc --enable-lld"
-              VCVARS_BAT: vcvars64.bat
             os: windows-latest-xl
           - name: x86_64-msvc-tools
             env:

--- a/src/ci/github-actions/ci.yml
+++ b/src/ci/github-actions/ci.yml
@@ -548,7 +548,6 @@ jobs:
             env:
               SCRIPT: python x.py --stage 2 test src/tools/cargotest src/tools/cargo
               RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-msvc --enable-lld
-              VCVARS_BAT: vcvars64.bat
             <<: *job-windows-xl
 
           - name: x86_64-msvc-tools


### PR DESCRIPTION
This environment variable is no longer used.  It was used in the original Azure Pipelines configuration (#60777). When GitHub Actions were added (#70190), it was no longer used, and I suspect it was just an oversight while transitioning the configuration.
