### PR TITLE
Rustdoc: use `is_doc_hidden` method on more places

### DIFF
--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -17,7 +17,7 @@ use rustc_span::symbol::{kw, sym, Symbol};
 
 use crate::clean::{
     self, clean_fn_decl_from_did_and_sig, clean_ty_generics, utils, Attributes, AttributesExt,
-    Clean, ImplKind, ItemId, NestedAttributesExt, Type, Visibility,
+    Clean, ImplKind, ItemId, Type, Visibility,
 };
 use crate::core::DocContext;
 use crate::formats::item_type::ItemType;
@@ -421,7 +421,7 @@ crate fn build_impl(
                                 associated_trait.def_id,
                             )
                             .unwrap(); // SAFETY: For all impl items there exists trait item that has the same name.
-                        !tcx.get_attrs(trait_item.def_id).lists(sym::doc).has_word(sym::hidden)
+                        !tcx.is_doc_hidden(trait_item.def_id)
                     } else {
                         true
                     }
@@ -456,7 +456,7 @@ crate fn build_impl(
     let mut stack: Vec<&Type> = vec![&for_];
 
     if let Some(did) = trait_.as_ref().map(|t| t.def_id()) {
-        if tcx.get_attrs(did).lists(sym::doc).has_word(sym::hidden) {
+        if tcx.is_doc_hidden(did) {
             return;
         }
     }
@@ -466,7 +466,7 @@ crate fn build_impl(
 
     while let Some(ty) = stack.pop() {
         if let Some(did) = ty.def_id(&cx.cache) {
-            if tcx.get_attrs(did).lists(sym::doc).has_word(sym::hidden) {
+            if tcx.is_doc_hidden(did) {
                 return;
             }
         }

--- a/src/librustdoc/passes/collect_trait_impls.rs
+++ b/src/librustdoc/passes/collect_trait_impls.rs
@@ -47,7 +47,7 @@ crate fn collect_trait_impls(mut krate: Crate, cx: &mut DocContext<'_>) -> Crate
                 inline::build_impl(cx, None, def_id, None, &mut new_items);
 
                 // FIXME(eddyb) is this `doc(hidden)` check needed?
-                if !cx.tcx.get_attrs(def_id).lists(sym::doc).has_word(sym::hidden) {
+                if !cx.tcx.is_doc_hidden(def_id) {
                     let impls = get_auto_trait_and_blanket_impls(cx, def_id);
                     new_items.extend(impls.filter(|i| cx.inlined.insert(i.def_id)));
                 }
@@ -176,13 +176,7 @@ impl<'a, 'tcx> DocVisitor for SyntheticImplCollector<'a, 'tcx> {
     fn visit_item(&mut self, i: &Item) {
         if i.is_struct() || i.is_enum() || i.is_union() {
             // FIXME(eddyb) is this `doc(hidden)` check needed?
-            if !self
-                .cx
-                .tcx
-                .get_attrs(i.def_id.expect_def_id())
-                .lists(sym::doc)
-                .has_word(sym::hidden)
-            {
+            if !self.cx.tcx.is_doc_hidden(i.def_id.expect_def_id()) {
                 self.impls
                     .extend(get_auto_trait_and_blanket_impls(self.cx, i.def_id.expect_def_id()));
             }

--- a/src/librustdoc/visit_lib.rs
+++ b/src/librustdoc/visit_lib.rs
@@ -3,9 +3,6 @@ use rustc_hir::def::{DefKind, Res};
 use rustc_hir::def_id::{CrateNum, DefId, CRATE_DEF_INDEX};
 use rustc_middle::middle::privacy::{AccessLevel, AccessLevels};
 use rustc_middle::ty::TyCtxt;
-use rustc_span::symbol::sym;
-
-use crate::clean::{AttributesExt, NestedAttributesExt};
 
 // FIXME: this may not be exhaustive, but is sufficient for rustdocs current uses
 
@@ -39,7 +36,7 @@ impl<'a, 'tcx> LibEmbargoVisitor<'a, 'tcx> {
 
     // Updates node level and returns the updated level
     fn update(&mut self, did: DefId, level: Option<AccessLevel>) -> Option<AccessLevel> {
-        let is_hidden = self.tcx.get_attrs(did).lists(sym::doc).has_word(sym::hidden);
+        let is_hidden = self.tcx.is_doc_hidden(did);
 
         let old_level = self.access_levels.map.get(&did).cloned();
         // Accessibility levels can only grow


### PR DESCRIPTION
While profiling `rustdoc`, I noticed that finding out if some item is marked with `#[doc(hidden)]` is relatively hot, so I tried to optimize it.

I noticed that there is already a method called `is_doc_hidden` on `TyCtxt`, but it wasn't used much, so I replaced the manual calls to `attrs(...).has_word(...)` with this method. Just by doing that, perf. was improved locally, although I'm not sure if the semantics of the previous calls and this method are the same?

As another step, I tried to querify `is_doc_hidden`, but I didn't include that here until we see the perf. results from the first commit and until I find whether this change is OK at all :)

Can I ask for a perf. run? Thanks.

r? @jyn514