### PR TITLE
Add an implicit `Self: ~const Trait` bound on `default_method_body_is_const` methods

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/object_safety.rs
+++ b/compiler/rustc_trait_selection/src/traits/object_safety.rs
@@ -433,7 +433,7 @@ fn virtual_call_violation_for_method<'tcx>(
     }
 
     if tcx
-        .predicates_of(method.def_id)
+        .predicates_defined_on(method.def_id)
         .predicates
         .iter()
         // A trait object can't claim to live more than the concrete type,

--- a/library/core/src/cmp.rs
+++ b/library/core/src/cmp.rs
@@ -1243,7 +1243,8 @@ mod impls {
     macro_rules! partial_eq_impl {
         ($($t:ty)*) => ($(
             #[stable(feature = "rust1", since = "1.0.0")]
-            impl PartialEq for $t {
+            #[rustc_const_unstable(feature = "const_cmp", issue = "none")]
+            impl const PartialEq for $t {
                 #[inline]
                 fn eq(&self, other: &$t) -> bool { (*self) == (*other) }
                 #[inline]
@@ -1280,10 +1281,11 @@ mod impls {
     macro_rules! partial_ord_impl {
         ($($t:ty)*) => ($(
             #[stable(feature = "rust1", since = "1.0.0")]
-            impl PartialOrd for $t {
+            #[rustc_const_unstable(feature = "const_cmp", issue = "none")]
+            impl const PartialOrd for $t {
                 #[inline]
                 fn partial_cmp(&self, other: &$t) -> Option<Ordering> {
-                    match (self <= other, self >= other) {
+                    match (*self <= *other, *self >= *other) {
                         (false, false) => None,
                         (false, true) => Some(Greater),
                         (true, false) => Some(Less),
@@ -1323,10 +1325,13 @@ mod impls {
     macro_rules! ord_impl {
         ($($t:ty)*) => ($(
             #[stable(feature = "rust1", since = "1.0.0")]
-            impl PartialOrd for $t {
+            #[rustc_const_unstable(feature = "const_cmp", issue = "none")]
+            impl const PartialOrd for $t {
                 #[inline]
                 fn partial_cmp(&self, other: &$t) -> Option<Ordering> {
-                    Some(self.cmp(other))
+                    Some(if *self < *other { Less }
+                        else if *self == *other { Equal }
+                        else { Greater })
                 }
                 #[inline]
                 fn lt(&self, other: &$t) -> bool { (*self) < (*other) }

--- a/src/test/ui/const-generics/issues/issue-90318.rs
+++ b/src/test/ui/const-generics/issues/issue-90318.rs
@@ -12,16 +12,14 @@ impl True for If<true> {}
 fn consume<T: 'static>(_val: T)
 where
     If<{ TypeId::of::<T>() != TypeId::of::<()>() }>: True,
-    //~^ ERROR: overly complex generic constant
-    //~| ERROR: calls in constants are limited to constant functions
+    //~^ ERROR: can't compare
 {
 }
 
 fn test<T: 'static>()
 where
     If<{ TypeId::of::<T>() != TypeId::of::<()>() }>: True,
-    //~^ ERROR: overly complex generic constant
-    //~| ERROR: calls in constants are limited to constant functions
+    //~^ ERROR: can't compare
 {
 }
 

--- a/src/test/ui/const-generics/issues/issue-90318.stderr
+++ b/src/test/ui/const-generics/issues/issue-90318.stderr
@@ -1,37 +1,27 @@
-error: overly complex generic constant
-  --> $DIR/issue-90318.rs:14:8
+error[E0277]: can't compare `TypeId` with `TypeId`
+  --> $DIR/issue-90318.rs:14:28
    |
 LL |     If<{ TypeId::of::<T>() != TypeId::of::<()>() }>: True,
-   |        ^^-----------------^^^^^^^^^^^^^^^^^^^^^^^^
-   |          |
-   |          borrowing is not supported in generic constants
+   |                            ^^ no implementation for `TypeId == TypeId`
    |
-   = help: consider moving this anonymous constant into a `const` function
-   = note: this operation may be supported in the future
-
-error[E0015]: calls in constants are limited to constant functions, tuple structs and tuple variants
-  --> $DIR/issue-90318.rs:14:10
+   = help: the trait `PartialEq` is not implemented for `TypeId`
+help: consider extending the `where` bound, but there might be an alternative better way to express this requirement
    |
-LL |     If<{ TypeId::of::<T>() != TypeId::of::<()>() }>: True,
-   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     If<{ TypeId::of::<T>() != TypeId::of::<()>() }>: True, TypeId: PartialEq
+   |                                                          ~~~~~~~~~~~~~~~~~~~
 
-error: overly complex generic constant
-  --> $DIR/issue-90318.rs:22:8
+error[E0277]: can't compare `TypeId` with `TypeId`
+  --> $DIR/issue-90318.rs:21:28
    |
 LL |     If<{ TypeId::of::<T>() != TypeId::of::<()>() }>: True,
-   |        ^^-----------------^^^^^^^^^^^^^^^^^^^^^^^^
-   |          |
-   |          borrowing is not supported in generic constants
+   |                            ^^ no implementation for `TypeId == TypeId`
    |
-   = help: consider moving this anonymous constant into a `const` function
-   = note: this operation may be supported in the future
-
-error[E0015]: calls in constants are limited to constant functions, tuple structs and tuple variants
-  --> $DIR/issue-90318.rs:22:10
+   = help: the trait `PartialEq` is not implemented for `TypeId`
+help: consider extending the `where` bound, but there might be an alternative better way to express this requirement
    |
-LL |     If<{ TypeId::of::<T>() != TypeId::of::<()>() }>: True,
-   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     If<{ TypeId::of::<T>() != TypeId::of::<()>() }>: True, TypeId: PartialEq
+   |                                                          ~~~~~~~~~~~~~~~~~~~
 
-error: aborting due to 4 previous errors
+error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0015`.
+For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/consts/issue-25826.rs
+++ b/src/test/ui/consts/issue-25826.rs
@@ -1,6 +1,6 @@
 fn id<T>(t: T) -> T { t }
 fn main() {
     const A: bool = unsafe { id::<u8> as *const () < id::<u16> as *const () };
-    //~^ ERROR pointers cannot be reliably compared during const eval
+    //~^ ERROR can't compare
     println!("{}", A);
 }

--- a/src/test/ui/consts/issue-25826.stderr
+++ b/src/test/ui/consts/issue-25826.stderr
@@ -1,10 +1,15 @@
-error: pointers cannot be reliably compared during const eval
-  --> $DIR/issue-25826.rs:3:30
+error[E0277]: can't compare `*const ()` with `*const ()`
+  --> $DIR/issue-25826.rs:3:52
    |
 LL |     const A: bool = unsafe { id::<u8> as *const () < id::<u16> as *const () };
-   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                                    ^ no implementation for `*const () < *const ()` and `*const () > *const ()`
    |
-   = note: see issue #53020 <https://github.com/rust-lang/rust/issues/53020> for more information
+   = help: the trait `PartialOrd` is not implemented for `*const ()`
+help: consider introducing a `where` bound, but there might be an alternative better way to express this requirement
+   |
+LL | fn main() where *const (): PartialOrd {
+   |           +++++++++++++++++++++++++++
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/rfc-2632-const-trait-impl/const-default-method-bodies.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/const-default-method-bodies.rs
@@ -23,7 +23,7 @@ impl const ConstDefaultFn for ConstImpl {
 
 const fn test() {
     NonConstImpl.a();
-    //~^ ERROR calls in constant functions are limited to constant functions, tuple structs and tuple variants
+    //~^ ERROR the trait bound `NonConstImpl: ConstDefaultFn` is not satisfied
     ConstImpl.a();
 }
 

--- a/src/test/ui/rfc-2632-const-trait-impl/const-default-method-bodies.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/const-default-method-bodies.stderr
@@ -1,9 +1,14 @@
-error[E0015]: calls in constant functions are limited to constant functions, tuple structs and tuple variants
-  --> $DIR/const-default-method-bodies.rs:25:5
+error[E0277]: the trait bound `NonConstImpl: ConstDefaultFn` is not satisfied
+  --> $DIR/const-default-method-bodies.rs:25:18
    |
 LL |     NonConstImpl.a();
-   |     ^^^^^^^^^^^^^^^^
+   |                  ^ the trait `ConstDefaultFn` is not implemented for `NonConstImpl`
+   |
+help: consider introducing a `where` bound, but there might be an alternative better way to express this requirement
+   |
+LL | const fn test() where NonConstImpl: ConstDefaultFn {
+   |                 ++++++++++++++++++++++++++++++++++
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0015`.
+For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/rfc-2632-const-trait-impl/default-method-body-is-const-implied-bounds-on-self.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/default-method-body-is-const-implied-bounds-on-self.rs
@@ -1,0 +1,17 @@
+// check-pass
+
+#![feature(const_trait_impl)]
+#![feature(const_fn_trait_bound)]
+
+pub trait Foo {
+    #[default_method_body_is_const]
+    fn do_stuff(self) where Self: Sized {
+        do_stuff_as_foo(self);
+    }
+}
+
+const fn do_stuff_as_foo<T: ~const Foo>(foo: T) {
+    std::mem::forget(foo);
+}
+
+fn main() {}


### PR DESCRIPTION
Closes #92158

r? @oli-obk

Do not r+ before I prepare a `const_cmp` PR.