### PR TITLE
Visit expressions in-order when resolving pattern bindings

### DIFF
--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -1603,10 +1603,13 @@ impl<'a: 'ast, 'b, 'ast> LateResolutionVisitor<'a, 'b, 'ast> {
         pat_src: PatternSource,
         bindings: &mut SmallVec<[(PatBoundCtx, FxHashSet<Ident>); 1]>,
     ) {
+        // We walk the pattern before declaring the pattern's inner bindings,
+        // so that we avoid resolving a literal expression to a binding defined
+        // by the pattern.
+        visit::walk_pat(self, pat);
         self.resolve_pattern_inner(pat, pat_src, bindings);
         // This has to happen *after* we determine which pat_idents are variants:
         self.check_consistent_bindings_top(pat);
-        visit::walk_pat(self, pat);
     }
 
     /// Resolve bindings in a pattern. This is a helper to `resolve_pattern`.

--- a/src/test/ui/match/expr_before_ident_pat.rs
+++ b/src/test/ui/match/expr_before_ident_pat.rs
@@ -1,0 +1,15 @@
+#![feature(half_open_range_patterns)]
+
+macro_rules! funny {
+    ($a:expr, $b:ident) => {
+        match [1, 2] {
+            [$a, $b] => {}
+        }
+    };
+}
+
+fn main() {
+    funny!(a, a);
+    //~^ ERROR cannot find value `a` in this scope
+    //~| ERROR arbitrary expressions aren't allowed in patterns
+}

--- a/src/test/ui/match/expr_before_ident_pat.stderr
+++ b/src/test/ui/match/expr_before_ident_pat.stderr
@@ -1,0 +1,15 @@
+error: arbitrary expressions aren't allowed in patterns
+  --> $DIR/expr_before_ident_pat.rs:12:12
+   |
+LL |     funny!(a, a);
+   |            ^
+
+error[E0425]: cannot find value `a` in this scope
+  --> $DIR/expr_before_ident_pat.rs:12:12
+   |
+LL |     funny!(a, a);
+   |            ^ not found in this scope
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0425`.

--- a/src/test/ui/match/issue-92100.rs
+++ b/src/test/ui/match/issue-92100.rs
@@ -1,0 +1,7 @@
+#![feature(half_open_range_patterns)]
+
+fn main() {
+    match [1, 2] {
+        [a.., a] => {} //~ ERROR cannot find value `a` in this scope
+    }
+}

--- a/src/test/ui/match/issue-92100.stderr
+++ b/src/test/ui/match/issue-92100.stderr
@@ -1,0 +1,9 @@
+error[E0425]: cannot find value `a` in this scope
+  --> $DIR/issue-92100.rs:5:10
+   |
+LL |         [a.., a] => {}
+   |          ^ not found in this scope
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0425`.


### PR DESCRIPTION
[edited:] Visit the pattern's sub-expressions before defining any bindings.

Otherwise, we might get into a case where a Lit/Range expression in a pattern has a qpath pointing to a Ident pattern that is defined after it, causing an ICE when lowering to HIR. I have a more detailed explanation in the issue linked.

Fixes #92100 