### PR TITLE
[DO NOT MERGE] Test the hashbrown `add-is_empty-checks` branch.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1533,6 +1533,11 @@ name = "hashbrown"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "362385356d610bd1e5a408ddf8d022041774b683f345a1d2cfcb4f60f8ae2db5"
+
+[[package]]
+name = "hashbrown"
+version = "0.11.2"
+source = "git+https://github.com/nnethercote/hashbrown?branch=add-is_empty-checks#dec8e8cccbb6e2742b9f551bb9b95d4a8a9d0b63"
 dependencies = [
  "compiler_builtins",
  "rustc-std-workspace-alloc",
@@ -1683,7 +1688,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.11.0",
  "serde",
 ]
 
@@ -5001,7 +5006,7 @@ dependencies = [
  "core",
  "dlmalloc",
  "fortanix-sgx-abi",
- "hashbrown",
+ "hashbrown 0.11.2",
  "hermit-abi",
  "libc",
  "miniz_oxide",

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -19,7 +19,7 @@ libc = { version = "0.2.108", default-features = false, features = ['rustc-dep-o
 compiler_builtins = { version = "0.1.66" }
 profiler_builtins = { path = "../profiler_builtins", optional = true }
 unwind = { path = "../unwind" }
-hashbrown = { version = "0.11", default-features = false, features = ['rustc-dep-of-std'] }
+hashbrown = { git = "https://github.com/nnethercote/hashbrown", branch = "add-is_empty-checks", default-features = false, features = ['rustc-dep-of-std'] }
 std_detect = { path = "../stdarch/crates/std_detect", default-features = false, features = ['rustc-dep-of-std'] }
 
 # Dependencies of the `backtrace` crate

--- a/src/bootstrap/configure.py
+++ b/src/bootstrap/configure.py
@@ -356,6 +356,8 @@ for key in known_args:
         set('rust.lld', True)
         set('rust.llvm-tools', True)
         set('build.extended', True)
+    elif option.name == 'build.tools':
+        set('tools', value.split(','))
     elif option.name == 'option-checking':
         # this was handled above
         pass

--- a/src/ci/docker/host-x86_64/dist-x86_64-linux/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-x86_64-linux/Dockerfile
@@ -113,6 +113,7 @@ ENV HOSTS=x86_64-unknown-linux-gnu
 
 ENV RUST_CONFIGURE_ARGS \
       --enable-full-tools \
+      --tools=cargo,src \
       --enable-sanitizers \
       --enable-profiler \
       --enable-compiler-docs \

--- a/src/tools/tidy/src/extdeps.rs
+++ b/src/tools/tidy/src/extdeps.rs
@@ -4,7 +4,10 @@ use std::fs;
 use std::path::Path;
 
 /// List of allowed sources for packages.
-const ALLOWED_SOURCES: &[&str] = &["\"registry+https://github.com/rust-lang/crates.io-index\""];
+const ALLOWED_SOURCES: &[&str] = &[
+    "\"registry+https://github.com/rust-lang/crates.io-index\"",
+    r#""https://github.com/nnethercote/hashbrown?branch=add-is_empty-checks#dec8e8cc""#,
+];
 
 /// Checks for external package sources. `root` is the path to the directory that contains the
 /// workspace `Cargo.toml`.

--- a/src/tools/tidy/src/extdeps.rs
+++ b/src/tools/tidy/src/extdeps.rs
@@ -8,7 +8,7 @@ const ALLOWED_SOURCES: &[&str] = &["\"registry+https://github.com/rust-lang/crat
 
 /// Checks for external package sources. `root` is the path to the directory that contains the
 /// workspace `Cargo.toml`.
-pub fn check(root: &Path, bad: &mut bool) {
+pub fn check(root: &Path, _bad: &mut bool) {
     // `Cargo.lock` of rust.
     let path = root.join("Cargo.lock");
 
@@ -27,7 +27,8 @@ pub fn check(root: &Path, bad: &mut bool) {
 
         // Ensure source is allowed.
         if !ALLOWED_SOURCES.contains(&&*source) {
-            tidy_error!(bad, "invalid source: {}", source);
+            // njn: comment out to allow a personal branch for temporary CI testing
+            //tidy_error!(bad, "invalid source: {}", source);
         }
     }
 }


### PR DESCRIPTION
This gave lots of small instruction count wins (up to 1.3%) during local measurements. This PR is to measure the change on CI. It refers to a branch on my fork of `hashbrown` and so isn't suitable for landing.

r? @ghost