### PR TITLE
Give types to some bool function arguments in pretty printer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4694,6 +4694,7 @@ version = "0.0.0"
 dependencies = [
  "rustc_arena",
  "rustc_ast",
+ "rustc_ast_pretty",
  "rustc_attr",
  "rustc_data_structures",
  "rustc_errors",

--- a/compiler/rustc_driver/src/pretty.rs
+++ b/compiler/rustc_driver/src/pretty.rs
@@ -2,6 +2,7 @@
 
 use rustc_ast as ast;
 use rustc_ast_pretty::pprust;
+use rustc_ast_pretty::pprust::state::IsExpanded;
 use rustc_errors::ErrorReported;
 use rustc_hir as hir;
 use rustc_hir_pretty as pprust_hir;
@@ -390,7 +391,7 @@ pub fn print_after_parsing(
                     src_name,
                     src,
                     annotation.pp_ann(),
-                    false,
+                    IsExpanded(false),
                     parse.edition,
                 )
             })
@@ -432,7 +433,7 @@ pub fn print_after_hir_lowering<'tcx>(
                     src_name,
                     src,
                     annotation.pp_ann(),
-                    true,
+                    IsExpanded(true),
                     parse.edition,
                 )
             })

--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -15,6 +15,7 @@ use rustc_ast::{
     PatKind, Path, PathSegment, QSelf, Ty, TyKind,
 };
 use rustc_ast_pretty::pprust;
+use rustc_ast_pretty::pprust::state::PrintConst;
 use rustc_data_structures::fx::FxHashSet;
 use rustc_errors::{pluralize, struct_span_err};
 use rustc_errors::{Applicability, DiagnosticBuilder, Handler, PResult};
@@ -1059,7 +1060,7 @@ impl<'a> Parser<'a> {
                 let sum_with_parens = pprust::to_string(|s| {
                     s.s.word("&");
                     s.print_opt_lifetime(lifetime);
-                    s.print_mutability(mut_ty.mutbl, false);
+                    s.print_mutability(mut_ty.mutbl, PrintConst(false));
                     s.popen();
                     s.print_type(&mut_ty.ty);
                     s.print_type_bounds(" +", &bounds);

--- a/compiler/rustc_typeck/Cargo.toml
+++ b/compiler/rustc_typeck/Cargo.toml
@@ -21,6 +21,7 @@ rustc_target = { path = "../rustc_target" }
 rustc_session = { path = "../rustc_session" }
 smallvec = { version = "1.6.1", features = ["union", "may_dangle"] }
 rustc_ast = { path = "../rustc_ast" }
+rustc_ast_pretty = { path = "../rustc_ast_pretty" }
 rustc_span = { path = "../rustc_span" }
 rustc_index = { path = "../rustc_index" }
 rustc_infer = { path = "../rustc_infer" }

--- a/compiler/rustc_typeck/src/check/pat.rs
+++ b/compiler/rustc_typeck/src/check/pat.rs
@@ -1,6 +1,7 @@
 use crate::check::FnCtxt;
 use rustc_ast as ast;
 
+use rustc_ast_pretty::pprust::state::ColonsBeforeParams;
 use rustc_data_structures::fx::FxHashMap;
 use rustc_errors::{pluralize, struct_span_err, Applicability, DiagnosticBuilder};
 use rustc_hir as hir;
@@ -1381,7 +1382,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             let has_shorthand_field_name = field_patterns.iter().any(|field| field.is_shorthand);
             if has_shorthand_field_name {
                 let path = rustc_hir_pretty::to_string(rustc_hir_pretty::NO_ANN, |s| {
-                    s.print_qpath(qpath, false)
+                    s.print_qpath(qpath, ColonsBeforeParams(false))
                 });
                 let mut err = struct_span_err!(
                     self.tcx.sess,
@@ -1543,7 +1544,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     ) -> Option<DiagnosticBuilder<'tcx>> {
         if let (CtorKind::Fn, PatKind::Struct(qpath, ..)) = (variant.ctor_kind, &pat.kind) {
             let path = rustc_hir_pretty::to_string(rustc_hir_pretty::NO_ANN, |s| {
-                s.print_qpath(qpath, false)
+                s.print_qpath(qpath, ColonsBeforeParams(false))
             });
             let mut err = struct_span_err!(
                 self.tcx.sess,

--- a/src/tools/clippy/clippy_lints/src/match_result_ok.rs
+++ b/src/tools/clippy/clippy_lints/src/match_result_ok.rs
@@ -4,6 +4,7 @@ use clippy_utils::method_chain_args;
 use clippy_utils::source::snippet_with_applicability;
 use clippy_utils::ty::is_type_diagnostic_item;
 use if_chain::if_chain;
+use rustc_ast_pretty::pprust::state::ColonsBeforeParams;
 use rustc_errors::Applicability;
 use rustc_hir::{Expr, ExprKind, PatKind, QPath};
 use rustc_lint::{LateContext, LateLintPass};
@@ -62,7 +63,7 @@ impl<'tcx> LateLintPass<'tcx> for MatchResultOk {
             if let PatKind::TupleStruct(QPath::Resolved(_, x), y, _)  = let_pat.kind; //get operation
             if method_chain_args(let_expr, &["ok"]).is_some(); //test to see if using ok() methoduse std::marker::Sized;
             if is_type_diagnostic_item(cx, cx.typeck_results().expr_ty(result_types_0), sym::Result);
-            if rustc_hir_pretty::to_string(rustc_hir_pretty::NO_ANN, |s| s.print_path(x, false)) == "Some";
+            if rustc_hir_pretty::to_string(rustc_hir_pretty::NO_ANN, |s| s.print_path(x, ColonsBeforeParams(false))) == "Some";
 
             then {
 

--- a/src/tools/clippy/clippy_lints/src/mut_reference.rs
+++ b/src/tools/clippy/clippy_lints/src/mut_reference.rs
@@ -1,4 +1,5 @@
 use clippy_utils::diagnostics::span_lint;
+use rustc_ast_pretty::pprust::state::ColonsBeforeParams;
 use rustc_hir::{BorrowKind, Expr, ExprKind, Mutability};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_middle::ty::subst::Subst;
@@ -40,7 +41,9 @@ impl<'tcx> LateLintPass<'tcx> for UnnecessaryMutPassed {
                         cx,
                         arguments,
                         cx.typeck_results().expr_ty(fn_expr),
-                        &rustc_hir_pretty::to_string(rustc_hir_pretty::NO_ANN, |s| s.print_qpath(path, false)),
+                        &rustc_hir_pretty::to_string(rustc_hir_pretty::NO_ANN, |s| {
+                            s.print_qpath(path, ColonsBeforeParams(false))
+                        }),
                         "function",
                     );
                 }

--- a/src/tools/clippy/clippy_lints/src/utils/inspector.rs
+++ b/src/tools/clippy/clippy_lints/src/utils/inspector.rs
@@ -2,6 +2,7 @@
 
 use clippy_utils::get_attr;
 use rustc_ast::ast::{Attribute, InlineAsmTemplatePiece};
+use rustc_ast_pretty::pprust::state::ColonsBeforeParams;
 use rustc_hir as hir;
 use rustc_lint::{LateContext, LateLintPass, LintContext};
 use rustc_session::Session;
@@ -50,7 +51,9 @@ impl<'tcx> LateLintPass<'tcx> for DeepCodeInspector {
             hir::VisibilityKind::Crate(_) => println!("visible crate wide"),
             hir::VisibilityKind::Restricted { path, .. } => println!(
                 "visible in module `{}`",
-                rustc_hir_pretty::to_string(rustc_hir_pretty::NO_ANN, |s| s.print_path(path, false))
+                rustc_hir_pretty::to_string(rustc_hir_pretty::NO_ANN, |s| {
+                    s.print_path(path, ColonsBeforeParams(false))
+                }),
             ),
             hir::VisibilityKind::Inherited => println!("visibility inherited from outer item"),
         }
@@ -364,7 +367,9 @@ fn print_item(cx: &LateContext<'_>, item: &hir::Item<'_>) {
         hir::VisibilityKind::Crate(_) => println!("visible crate wide"),
         hir::VisibilityKind::Restricted { path, .. } => println!(
             "visible in module `{}`",
-            rustc_hir_pretty::to_string(rustc_hir_pretty::NO_ANN, |s| s.print_path(path, false))
+            rustc_hir_pretty::to_string(rustc_hir_pretty::NO_ANN, |s| {
+                s.print_path(path, ColonsBeforeParams(false))
+            }),
         ),
         hir::VisibilityKind::Inherited => println!("visibility inherited from outer item"),
     }
@@ -464,7 +469,9 @@ fn print_pat(cx: &LateContext<'_>, pat: &hir::Pat<'_>, indent: usize) {
             println!(
                 "{}name: {}",
                 ind,
-                rustc_hir_pretty::to_string(rustc_hir_pretty::NO_ANN, |s| s.print_qpath(path, false))
+                rustc_hir_pretty::to_string(rustc_hir_pretty::NO_ANN, |s| {
+                    s.print_qpath(path, ColonsBeforeParams(false))
+                }),
             );
             println!("{}ignore leftover fields: {}", ind, ignore);
             println!("{}fields:", ind);
@@ -481,7 +488,9 @@ fn print_pat(cx: &LateContext<'_>, pat: &hir::Pat<'_>, indent: usize) {
             println!(
                 "{}path: {}",
                 ind,
-                rustc_hir_pretty::to_string(rustc_hir_pretty::NO_ANN, |s| s.print_qpath(path, false))
+                rustc_hir_pretty::to_string(rustc_hir_pretty::NO_ANN, |s| {
+                    s.print_qpath(path, ColonsBeforeParams(false))
+                }),
             );
             if let Some(dot_position) = opt_dots_position {
                 println!("{}dot position: {}", ind, dot_position);


### PR DESCRIPTION
I found that the pervasive use of random anonymous bools in the pretty printer made code changes hard to review. Like in the following, it's easy for a reviewer to be inclined to just assume that `false` and `true` are correct without tracking down the signature to find out what they mean.

https://github.com/rust-lang/rust/blob/d6d12b6a5d2c2906ef4e85ce1d50a8684cf43626/compiler/rustc_ast_pretty/src/pprust/state.rs#L460-L468

This PR replaces all the `bool` in function signatures in the pretty printer with appropriately named newtype wrappers around `bool`.

Illustrative example from the code that deals with printing `&T` / `&mut T` / `&raw const T` / `&raw mut T`:

### Before

https://github.com/rust-lang/rust/blob/d6d12b6a5d2c2906ef4e85ce1d50a8684cf43626/compiler/rustc_ast_pretty/src/pprust/state.rs#L1915-L1922

### After

https://github.com/rust-lang/rust/blob/fa65008f2fa822c100c10d73ba220f4e4e5352f3/compiler/rustc_ast_pretty/src/pprust/state.rs#L2005-L2012