### PR TITLE
Bump `gsgdt` to 0.1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1507,9 +1507,9 @@ dependencies = [
 
 [[package]]
 name = "gsgdt"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0d876ce7262df96262a2a19531da6ff9a86048224d49580a585fc5c04617825"
+checksum = "cb958139bb971f37d2f5423436f137768f88b9c616b4c21d4f634dd129508d60"
 dependencies = [
  "serde",
 ]

--- a/compiler/rustc_middle/Cargo.toml
+++ b/compiler/rustc_middle/Cargo.toml
@@ -10,7 +10,7 @@ doctest = false
 rustc_arena = { path = "../rustc_arena" }
 bitflags = "1.2.1"
 either = "1.5.0"
-gsgdt = "0.1.2"
+gsgdt = "0.1.3"
 tracing = "0.1"
 rustc-rayon = "0.3.1"
 rustc-rayon-core = "0.3.1"

--- a/compiler/rustc_middle/src/mir/generic_graph.rs
+++ b/compiler/rustc_middle/src/mir/generic_graph.rs
@@ -55,7 +55,7 @@ fn bb_to_graph_node(block: BasicBlock, body: &Body<'_>, dark_mode: bool) -> Node
     data.terminator().kind.fmt_head(&mut terminator_head).unwrap();
     stmts.push(terminator_head);
 
-    Node::new(stmts, label, title, style)
+    Node::from_list(stmts, label, title, style)
 }
 
 // Must match `[0-9A-Za-z_]*`. This does not appear in the rendered graph, so


### PR DESCRIPTION
No functional changes intended.

The 0.1.2 -> 0.1.3 commit https://github.com/vn-ki/gsgdt-rs/commit/3e1dcec5398d281e1b33afb41e43dfb248321a1d renames `Node::new` to `Node::from_list`.