### PR TITLE
Avoid accidentally enabling unstable features in compilers

### DIFF
--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -1246,7 +1246,6 @@ def bootstrap(help_triggered):
     env["BOOTSTRAP_PARENT_ID"] = str(os.getpid())
     env["BOOTSTRAP_PYTHON"] = sys.executable
     env["BUILD_DIR"] = build.build_dir
-    env["RUSTC_BOOTSTRAP"] = '1'
     if toml_path:
         env["BOOTSTRAP_CONFIG"] = toml_path
     if build.rustc_commit is not None:


### PR DESCRIPTION
This allows rustbuild to control whether crates can use nightly features or not.
In practice, it has no effect because `builder.rs` already sets RUSTC_BOOTSTRAP unconditionally.