### PR TITLE
rustdoc: Remove `String` allocation in iteration in `print_generic_bounds`

### DIFF
--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -141,9 +141,7 @@ crate fn print_generic_bounds<'a, 'tcx: 'a>(
     display_fn(move |f| {
         let mut bounds_dup = FxHashSet::default();
 
-        for (i, bound) in
-            bounds.iter().filter(|b| bounds_dup.insert(b.print(cx).to_string())).enumerate()
-        {
+        for (i, bound) in bounds.iter().filter(|b| bounds_dup.insert(b.clone())).enumerate() {
             if i > 0 {
                 f.write_str(" + ")?;
             }


### PR DESCRIPTION
(I realized only after making the commit that maybe I shouldn't refer to iteration as looping, but it's close enough)

The string representation of a `clean::GenericBound` instance (evaluated [here](https://github.com/rust-lang/rust/blob/master/src/librustdoc/html/format.rs#L397)) is deterministic for a given `self` (the instance), `cx` and `f`, and since `cx` and `f` are constant (as far as I can tell) for a given invocation of `print_generic_bounds`, `self` is the determining factor. Therefore, using the data in `self` shouldn't differ in effect from using its string representation.

Given the totality of the function calls needed to evaluate the string representation as well as the actual allocation, at the very least, this shouldn't negatively affect performance.