### PR TITLE
Change advance(_back)_by to return the remainder instead of the number of processed elements

### DIFF
--- a/library/alloc/src/collections/vec_deque/into_iter.rs
+++ b/library/alloc/src/collections/vec_deque/into_iter.rs
@@ -54,14 +54,14 @@ impl<T, A: Allocator> Iterator for IntoIter<T, A> {
     }
 
     #[inline]
-    fn advance_by(&mut self, n: usize) -> Result<(), usize> {
+    fn advance_by(&mut self, n: usize) -> usize {
         if self.inner.len < n {
             let len = self.inner.len;
             self.inner.clear();
-            Err(len)
+            len - n
         } else {
             self.inner.drain(..n);
-            Ok(())
+            0
         }
     }
 
@@ -182,14 +182,14 @@ impl<T, A: Allocator> DoubleEndedIterator for IntoIter<T, A> {
     }
 
     #[inline]
-    fn advance_back_by(&mut self, n: usize) -> Result<(), usize> {
+    fn advance_back_by(&mut self, n: usize) -> usize {
         let len = self.inner.len;
         if len >= n {
             self.inner.truncate(len - n);
-            Ok(())
+            0
         } else {
             self.inner.clear();
-            Err(len)
+            n - len
         }
     }
 

--- a/library/alloc/src/collections/vec_deque/into_iter.rs
+++ b/library/alloc/src/collections/vec_deque/into_iter.rs
@@ -56,10 +56,10 @@ impl<T, A: Allocator> Iterator for IntoIter<T, A> {
 
     #[inline]
     fn advance_by(&mut self, n: usize) -> Result<(), NonZeroUsize> {
-        let rem = if self.inner.len < n {
-            let len = self.inner.len;
+        let len = self.inner.len;
+        let rem = if len < n {
             self.inner.clear();
-            len - n
+            n - len
         } else {
             self.inner.drain(..n);
             0
@@ -186,12 +186,12 @@ impl<T, A: Allocator> DoubleEndedIterator for IntoIter<T, A> {
     #[inline]
     fn advance_back_by(&mut self, n: usize) -> Result<(), NonZeroUsize> {
         let len = self.inner.len;
-        let rem = if len >= n {
-            self.inner.truncate(len - n);
-            0
-        } else {
+        let rem = if len < n {
             self.inner.clear();
             n - len
+        } else {
+            self.inner.truncate(len - n);
+            0
         };
         NonZeroUsize::new(rem).map_or(Ok(()), Err)
     }

--- a/library/alloc/src/collections/vec_deque/iter.rs
+++ b/library/alloc/src/collections/vec_deque/iter.rs
@@ -1,4 +1,5 @@
 use core::iter::{FusedIterator, TrustedLen, TrustedRandomAccess, TrustedRandomAccessNoCoerce};
+use core::num::NonZeroUsize;
 use core::ops::Try;
 use core::{fmt, mem, slice};
 
@@ -55,13 +56,15 @@ impl<'a, T> Iterator for Iter<'a, T> {
         }
     }
 
-    fn advance_by(&mut self, n: usize) -> usize {
+    fn advance_by(&mut self, n: usize) -> Result<(), NonZeroUsize> {
         let remaining = self.i1.advance_by(n);
-        if remaining == 0 {
-            return 0;
+        match remaining {
+            Ok(()) => return Ok(()),
+            Err(n) => {
+                mem::swap(&mut self.i1, &mut self.i2);
+                self.i1.advance_by(n.get())
+            }
         }
-        mem::swap(&mut self.i1, &mut self.i2);
-        self.i1.advance_by(remaining)
     }
 
     #[inline]
@@ -125,13 +128,14 @@ impl<'a, T> DoubleEndedIterator for Iter<'a, T> {
         }
     }
 
-    fn advance_back_by(&mut self, n: usize) -> usize {
-        let remaining = self.i2.advance_back_by(n);
-        if remaining == 0 {
-            return 0;
+    fn advance_back_by(&mut self, n: usize) -> Result<(), NonZeroUsize> {
+        match self.i2.advance_back_by(n) {
+            Ok(()) => return Ok(()),
+            Err(n) => {
+                mem::swap(&mut self.i1, &mut self.i2);
+                self.i2.advance_back_by(n.get())
+            }
         }
-        mem::swap(&mut self.i1, &mut self.i2);
-        self.i2.advance_back_by(remaining)
     }
 
     fn rfold<Acc, F>(self, accum: Acc, mut f: F) -> Acc

--- a/library/alloc/src/collections/vec_deque/iter.rs
+++ b/library/alloc/src/collections/vec_deque/iter.rs
@@ -55,13 +55,13 @@ impl<'a, T> Iterator for Iter<'a, T> {
         }
     }
 
-    fn advance_by(&mut self, n: usize) -> Result<(), usize> {
-        let m = match self.i1.advance_by(n) {
-            Ok(_) => return Ok(()),
-            Err(m) => m,
-        };
+    fn advance_by(&mut self, n: usize) -> usize {
+        let remaining = self.i1.advance_by(n);
+        if remaining == 0 {
+            return 0;
+        }
         mem::swap(&mut self.i1, &mut self.i2);
-        self.i1.advance_by(n - m).map_err(|o| o + m)
+        self.i1.advance_by(remaining)
     }
 
     #[inline]
@@ -125,14 +125,13 @@ impl<'a, T> DoubleEndedIterator for Iter<'a, T> {
         }
     }
 
-    fn advance_back_by(&mut self, n: usize) -> Result<(), usize> {
-        let m = match self.i2.advance_back_by(n) {
-            Ok(_) => return Ok(()),
-            Err(m) => m,
-        };
-
+    fn advance_back_by(&mut self, n: usize) -> usize {
+        let remaining = self.i2.advance_back_by(n);
+        if remaining == 0 {
+            return 0;
+        }
         mem::swap(&mut self.i1, &mut self.i2);
-        self.i2.advance_back_by(n - m).map_err(|o| m + o)
+        self.i2.advance_back_by(remaining)
     }
 
     fn rfold<Acc, F>(self, accum: Acc, mut f: F) -> Acc

--- a/library/alloc/src/collections/vec_deque/iter_mut.rs
+++ b/library/alloc/src/collections/vec_deque/iter_mut.rs
@@ -47,13 +47,13 @@ impl<'a, T> Iterator for IterMut<'a, T> {
         }
     }
 
-    fn advance_by(&mut self, n: usize) -> Result<(), usize> {
-        let m = match self.i1.advance_by(n) {
-            Ok(_) => return Ok(()),
-            Err(m) => m,
-        };
+    fn advance_by(&mut self, n: usize) -> usize {
+        let remaining = self.i1.advance_by(n);
+        if remaining == 0 {
+            return 0;
+        }
         mem::swap(&mut self.i1, &mut self.i2);
-        self.i1.advance_by(n - m).map_err(|o| o + m)
+        self.i1.advance_by(remaining)
     }
 
     #[inline]
@@ -117,14 +117,13 @@ impl<'a, T> DoubleEndedIterator for IterMut<'a, T> {
         }
     }
 
-    fn advance_back_by(&mut self, n: usize) -> Result<(), usize> {
-        let m = match self.i2.advance_back_by(n) {
-            Ok(_) => return Ok(()),
-            Err(m) => m,
-        };
-
+    fn advance_back_by(&mut self, n: usize) -> usize {
+        let remaining = self.i2.advance_back_by(n);
+        if remaining == 0 {
+            return 0;
+        }
         mem::swap(&mut self.i1, &mut self.i2);
-        self.i2.advance_back_by(n - m).map_err(|o| m + o)
+        self.i2.advance_back_by(remaining)
     }
 
     fn rfold<Acc, F>(self, accum: Acc, mut f: F) -> Acc

--- a/library/alloc/src/vec/into_iter.rs
+++ b/library/alloc/src/vec/into_iter.rs
@@ -213,7 +213,7 @@ impl<T, A: Allocator> Iterator for IntoIter<T, A> {
     }
 
     #[inline]
-    fn advance_by(&mut self, n: usize) -> Result<(), usize> {
+    fn advance_by(&mut self, n: usize) -> usize {
         let step_size = self.len().min(n);
         let to_drop = ptr::slice_from_raw_parts_mut(self.ptr as *mut T, step_size);
         if T::IS_ZST {
@@ -227,10 +227,7 @@ impl<T, A: Allocator> Iterator for IntoIter<T, A> {
         unsafe {
             ptr::drop_in_place(to_drop);
         }
-        if step_size < n {
-            return Err(step_size);
-        }
-        Ok(())
+        n - step_size
     }
 
     #[inline]
@@ -313,7 +310,7 @@ impl<T, A: Allocator> DoubleEndedIterator for IntoIter<T, A> {
     }
 
     #[inline]
-    fn advance_back_by(&mut self, n: usize) -> Result<(), usize> {
+    fn advance_back_by(&mut self, n: usize) -> usize {
         let step_size = self.len().min(n);
         if T::IS_ZST {
             // SAFETY: same as for advance_by()
@@ -327,10 +324,7 @@ impl<T, A: Allocator> DoubleEndedIterator for IntoIter<T, A> {
         unsafe {
             ptr::drop_in_place(to_drop);
         }
-        if step_size < n {
-            return Err(step_size);
-        }
-        Ok(())
+        n - step_size
     }
 }
 

--- a/library/alloc/tests/vec.rs
+++ b/library/alloc/tests/vec.rs
@@ -1,6 +1,7 @@
 use core::alloc::{Allocator, Layout};
 use core::assert_eq;
 use core::iter::IntoIterator;
+use core::num::NonZeroUsize;
 use core::ptr::NonNull;
 use std::alloc::System;
 use std::assert_matches::assert_matches;
@@ -1064,20 +1065,20 @@ fn test_into_iter_leak() {
 #[test]
 fn test_into_iter_advance_by() {
     let mut i = vec![1, 2, 3, 4, 5].into_iter();
-    assert_eq!(i.advance_by(0), 0);
-    assert_eq!(i.advance_back_by(0), 0);
+    assert_eq!(i.advance_by(0), Ok(()));
+    assert_eq!(i.advance_back_by(0), Ok(()));
     assert_eq!(i.as_slice(), [1, 2, 3, 4, 5]);
 
-    assert_eq!(i.advance_by(1), 0);
-    assert_eq!(i.advance_back_by(1), 0);
+    assert_eq!(i.advance_by(1), Ok(()));
+    assert_eq!(i.advance_back_by(1), Ok(()));
     assert_eq!(i.as_slice(), [2, 3, 4]);
 
-    assert_eq!(i.advance_back_by(usize::MAX), usize::MAX - 3);
+    assert_eq!(i.advance_back_by(usize::MAX), Err(NonZeroUsize::new(usize::MAX - 3).unwrap()));
 
-    assert_eq!(i.advance_by(usize::MAX), usize::MAX);
+    assert_eq!(i.advance_by(usize::MAX), Err(NonZeroUsize::new(usize::MAX).unwrap()));
 
-    assert_eq!(i.advance_by(0), 0);
-    assert_eq!(i.advance_back_by(0), 0);
+    assert_eq!(i.advance_by(0), Ok(()));
+    assert_eq!(i.advance_back_by(0), Ok(()));
 
     assert_eq!(i.len(), 0);
 }
@@ -1125,7 +1126,7 @@ fn test_into_iter_zst() {
     for _ in vec![C; 5].into_iter().rev() {}
 
     let mut it = vec![C, C].into_iter();
-    assert_eq!(it.advance_by(1), 0);
+    assert_eq!(it.advance_by(1), Ok(()));
     drop(it);
 
     let mut it = vec![C, C].into_iter();

--- a/library/alloc/tests/vec.rs
+++ b/library/alloc/tests/vec.rs
@@ -1,4 +1,5 @@
 use core::alloc::{Allocator, Layout};
+use core::assert_eq;
 use core::iter::IntoIterator;
 use core::ptr::NonNull;
 use std::alloc::System;
@@ -1062,21 +1063,21 @@ fn test_into_iter_leak() {
 
 #[test]
 fn test_into_iter_advance_by() {
-    let mut i = [1, 2, 3, 4, 5].into_iter();
-    i.advance_by(0).unwrap();
-    i.advance_back_by(0).unwrap();
+    let mut i = vec![1, 2, 3, 4, 5].into_iter();
+    assert_eq!(i.advance_by(0), 0);
+    assert_eq!(i.advance_back_by(0), 0);
     assert_eq!(i.as_slice(), [1, 2, 3, 4, 5]);
 
-    i.advance_by(1).unwrap();
-    i.advance_back_by(1).unwrap();
+    assert_eq!(i.advance_by(1), 0);
+    assert_eq!(i.advance_back_by(1), 0);
     assert_eq!(i.as_slice(), [2, 3, 4]);
 
-    assert_eq!(i.advance_back_by(usize::MAX), Err(3));
+    assert_eq!(i.advance_back_by(usize::MAX), usize::MAX - 3);
 
-    assert_eq!(i.advance_by(usize::MAX), Err(0));
+    assert_eq!(i.advance_by(usize::MAX), usize::MAX);
 
-    i.advance_by(0).unwrap();
-    i.advance_back_by(0).unwrap();
+    assert_eq!(i.advance_by(0), 0);
+    assert_eq!(i.advance_back_by(0), 0);
 
     assert_eq!(i.len(), 0);
 }
@@ -1124,7 +1125,7 @@ fn test_into_iter_zst() {
     for _ in vec![C; 5].into_iter().rev() {}
 
     let mut it = vec![C, C].into_iter();
-    it.advance_by(1).unwrap();
+    assert_eq!(it.advance_by(1), 0);
     drop(it);
 
     let mut it = vec![C, C].into_iter();

--- a/library/alloc/tests/vec_deque.rs
+++ b/library/alloc/tests/vec_deque.rs
@@ -1,3 +1,4 @@
+use core::num::NonZeroUsize;
 use std::assert_matches::assert_matches;
 use std::collections::TryReserveErrorKind::*;
 use std::collections::{vec_deque::Drain, VecDeque};
@@ -425,6 +426,28 @@ fn test_into_iter() {
         assert_eq!(it.size_hint(), (6, Some(6)));
         assert_eq!(it.next(), Some(7));
         assert_eq!(it.size_hint(), (5, Some(5)));
+    }
+
+    // advance_by
+    {
+        let mut d = VecDeque::new();
+        for i in 0..=4 {
+            d.push_back(i);
+        }
+        for i in 6..=8 {
+            d.push_front(i);
+        }
+
+        let mut it = d.into_iter();
+        assert_eq!(it.advance_by(1), Ok(()));
+        assert_eq!(it.next(), Some(7));
+        assert_eq!(it.advance_back_by(1), Ok(()));
+        assert_eq!(it.next_back(), Some(3));
+
+        let mut it = VecDeque::from(vec![1, 2, 3, 4, 5]).into_iter();
+        assert_eq!(it.advance_by(10), Err(NonZeroUsize::new(5).unwrap()));
+        let mut it = VecDeque::from(vec![1, 2, 3, 4, 5]).into_iter();
+        assert_eq!(it.advance_back_by(10), Err(NonZeroUsize::new(5).unwrap()));
     }
 }
 

--- a/library/core/src/iter/adapters/by_ref_sized.rs
+++ b/library/core/src/iter/adapters/by_ref_sized.rs
@@ -26,7 +26,7 @@ impl<I: Iterator> Iterator for ByRefSized<'_, I> {
     }
 
     #[inline]
-    fn advance_by(&mut self, n: usize) -> Result<(), usize> {
+    fn advance_by(&mut self, n: usize) -> usize {
         I::advance_by(self.0, n)
     }
 
@@ -62,7 +62,7 @@ impl<I: DoubleEndedIterator> DoubleEndedIterator for ByRefSized<'_, I> {
     }
 
     #[inline]
-    fn advance_back_by(&mut self, n: usize) -> Result<(), usize> {
+    fn advance_back_by(&mut self, n: usize) -> usize {
         I::advance_back_by(self.0, n)
     }
 

--- a/library/core/src/iter/adapters/by_ref_sized.rs
+++ b/library/core/src/iter/adapters/by_ref_sized.rs
@@ -1,3 +1,4 @@
+use crate::num::NonZeroUsize;
 use crate::ops::{NeverShortCircuit, Try};
 
 /// Like `Iterator::by_ref`, but requiring `Sized` so it can forward generics.
@@ -26,7 +27,7 @@ impl<I: Iterator> Iterator for ByRefSized<'_, I> {
     }
 
     #[inline]
-    fn advance_by(&mut self, n: usize) -> usize {
+    fn advance_by(&mut self, n: usize) -> Result<(), NonZeroUsize> {
         I::advance_by(self.0, n)
     }
 
@@ -62,7 +63,7 @@ impl<I: DoubleEndedIterator> DoubleEndedIterator for ByRefSized<'_, I> {
     }
 
     #[inline]
-    fn advance_back_by(&mut self, n: usize) -> usize {
+    fn advance_back_by(&mut self, n: usize) -> Result<(), NonZeroUsize> {
         I::advance_back_by(self.0, n)
     }
 

--- a/library/core/src/iter/adapters/chain.rs
+++ b/library/core/src/iter/adapters/chain.rs
@@ -95,38 +95,33 @@ where
     }
 
     #[inline]
-    fn advance_by(&mut self, n: usize) -> Result<(), usize> {
-        let mut rem = n;
-
+    fn advance_by(&mut self, mut n: usize) -> usize {
         if let Some(ref mut a) = self.a {
-            match a.advance_by(rem) {
-                Ok(()) => return Ok(()),
-                Err(k) => rem -= k,
+            n = a.advance_by(n);
+            if n == 0 {
+                return n;
             }
             self.a = None;
         }
 
         if let Some(ref mut b) = self.b {
-            match b.advance_by(rem) {
-                Ok(()) => return Ok(()),
-                Err(k) => rem -= k,
-            }
+            n = b.advance_by(n);
             // we don't fuse the second iterator
         }
 
-        if rem == 0 { Ok(()) } else { Err(n - rem) }
+        n
     }
 
     #[inline]
     fn nth(&mut self, mut n: usize) -> Option<Self::Item> {
         if let Some(ref mut a) = self.a {
-            match a.advance_by(n) {
-                Ok(()) => match a.next() {
-                    None => n = 0,
+            n = match a.advance_by(n) {
+                0 => match a.next() {
+                    None => 0,
                     x => return x,
                 },
-                Err(k) => n -= k,
-            }
+                k => k,
+            };
 
             self.a = None;
         }
@@ -186,38 +181,33 @@ where
     }
 
     #[inline]
-    fn advance_back_by(&mut self, n: usize) -> Result<(), usize> {
-        let mut rem = n;
-
+    fn advance_back_by(&mut self, mut n: usize) -> usize {
         if let Some(ref mut b) = self.b {
-            match b.advance_back_by(rem) {
-                Ok(()) => return Ok(()),
-                Err(k) => rem -= k,
+            n = b.advance_back_by(n);
+            if n == 0 {
+                return n;
             }
             self.b = None;
         }
 
         if let Some(ref mut a) = self.a {
-            match a.advance_back_by(rem) {
-                Ok(()) => return Ok(()),
-                Err(k) => rem -= k,
-            }
+            n = a.advance_back_by(n);
             // we don't fuse the second iterator
         }
 
-        if rem == 0 { Ok(()) } else { Err(n - rem) }
+        n
     }
 
     #[inline]
     fn nth_back(&mut self, mut n: usize) -> Option<Self::Item> {
         if let Some(ref mut b) = self.b {
-            match b.advance_back_by(n) {
-                Ok(()) => match b.next_back() {
-                    None => n = 0,
+            n = match b.advance_back_by(n) {
+                0 => match b.next_back() {
+                    None => 0,
                     x => return x,
                 },
-                Err(k) => n -= k,
-            }
+                k => k,
+            };
 
             self.b = None;
         }

--- a/library/core/src/iter/adapters/copied.rs
+++ b/library/core/src/iter/adapters/copied.rs
@@ -89,7 +89,7 @@ where
     }
 
     #[inline]
-    fn advance_by(&mut self, n: usize) -> Result<(), usize> {
+    fn advance_by(&mut self, n: usize) -> usize {
         self.it.advance_by(n)
     }
 
@@ -130,7 +130,7 @@ where
     }
 
     #[inline]
-    fn advance_back_by(&mut self, n: usize) -> Result<(), usize> {
+    fn advance_back_by(&mut self, n: usize) -> usize {
         self.it.advance_back_by(n)
     }
 }

--- a/library/core/src/iter/adapters/copied.rs
+++ b/library/core/src/iter/adapters/copied.rs
@@ -4,6 +4,7 @@ use crate::iter::adapters::{
 use crate::iter::{FusedIterator, TrustedLen};
 use crate::mem::MaybeUninit;
 use crate::mem::SizedTypeProperties;
+use crate::num::NonZeroUsize;
 use crate::ops::Try;
 use crate::{array, ptr};
 
@@ -89,7 +90,7 @@ where
     }
 
     #[inline]
-    fn advance_by(&mut self, n: usize) -> usize {
+    fn advance_by(&mut self, n: usize) -> Result<(), NonZeroUsize> {
         self.it.advance_by(n)
     }
 
@@ -130,7 +131,7 @@ where
     }
 
     #[inline]
-    fn advance_back_by(&mut self, n: usize) -> usize {
+    fn advance_back_by(&mut self, n: usize) -> Result<(), NonZeroUsize> {
         self.it.advance_back_by(n)
     }
 }

--- a/library/core/src/iter/adapters/cycle.rs
+++ b/library/core/src/iter/adapters/cycle.rs
@@ -81,23 +81,22 @@ where
 
     #[inline]
     #[rustc_inherit_overflow_checks]
-    fn advance_by(&mut self, n: usize) -> Result<(), usize> {
-        let mut rem = n;
-        match self.iter.advance_by(rem) {
-            ret @ Ok(_) => return ret,
-            Err(advanced) => rem -= advanced,
+    fn advance_by(&mut self, n: usize) -> usize {
+        let mut n = self.iter.advance_by(n);
+        if n == 0 {
+            return n;
         }
 
-        while rem > 0 {
+        while n > 0 {
             self.iter = self.orig.clone();
-            match self.iter.advance_by(rem) {
-                ret @ Ok(_) => return ret,
-                Err(0) => return Err(n - rem),
-                Err(advanced) => rem -= advanced,
+            let rem = self.iter.advance_by(n);
+            if rem == n {
+                return n;
             }
+            n = rem;
         }
 
-        Ok(())
+        0
     }
 
     // No `fold` override, because `fold` doesn't make much sense for `Cycle`,

--- a/library/core/src/iter/adapters/enumerate.rs
+++ b/library/core/src/iter/adapters/enumerate.rs
@@ -114,17 +114,10 @@ where
 
     #[inline]
     #[rustc_inherit_overflow_checks]
-    fn advance_by(&mut self, n: usize) -> Result<(), usize> {
-        match self.iter.advance_by(n) {
-            ret @ Ok(_) => {
-                self.count += n;
-                ret
-            }
-            ret @ Err(advanced) => {
-                self.count += advanced;
-                ret
-            }
-        }
+    fn advance_by(&mut self, n: usize) -> usize {
+        let n = self.iter.advance_by(n);
+        self.count += n;
+        n
     }
 
     #[rustc_inherit_overflow_checks]
@@ -208,7 +201,7 @@ where
     }
 
     #[inline]
-    fn advance_back_by(&mut self, n: usize) -> Result<(), usize> {
+    fn advance_back_by(&mut self, n: usize) -> usize {
         // we do not need to update the count since that only tallies the number of items
         // consumed from the front. consuming items from the back can never reduce that.
         self.iter.advance_back_by(n)

--- a/library/core/src/iter/adapters/flatten.rs
+++ b/library/core/src/iter/adapters/flatten.rs
@@ -75,7 +75,7 @@ where
     }
 
     #[inline]
-    fn advance_by(&mut self, n: usize) -> Result<(), usize> {
+    fn advance_by(&mut self, n: usize) -> usize {
         self.inner.advance_by(n)
     }
 
@@ -120,7 +120,7 @@ where
     }
 
     #[inline]
-    fn advance_back_by(&mut self, n: usize) -> Result<(), usize> {
+    fn advance_back_by(&mut self, n: usize) -> usize {
         self.inner.advance_back_by(n)
     }
 }
@@ -236,7 +236,7 @@ where
     }
 
     #[inline]
-    fn advance_by(&mut self, n: usize) -> Result<(), usize> {
+    fn advance_by(&mut self, n: usize) -> usize {
         self.inner.advance_by(n)
     }
 
@@ -281,7 +281,7 @@ where
     }
 
     #[inline]
-    fn advance_back_by(&mut self, n: usize) -> Result<(), usize> {
+    fn advance_back_by(&mut self, n: usize) -> usize {
         self.inner.advance_back_by(n)
     }
 }
@@ -552,19 +552,19 @@ where
 
     #[inline]
     #[rustc_inherit_overflow_checks]
-    fn advance_by(&mut self, n: usize) -> Result<(), usize> {
+    fn advance_by(&mut self, n: usize) -> usize {
         #[inline]
         #[rustc_inherit_overflow_checks]
         fn advance<U: Iterator>(n: usize, iter: &mut U) -> ControlFlow<(), usize> {
             match iter.advance_by(n) {
-                Ok(()) => ControlFlow::Break(()),
-                Err(advanced) => ControlFlow::Continue(n - advanced),
+                0 => ControlFlow::Break(()),
+                remaining => ControlFlow::Continue(remaining),
             }
         }
 
         match self.iter_try_fold(n, advance) {
-            ControlFlow::Continue(remaining) if remaining > 0 => Err(n - remaining),
-            _ => Ok(()),
+            ControlFlow::Continue(remaining) => remaining,
+            _ => 0,
         }
     }
 
@@ -642,19 +642,19 @@ where
 
     #[inline]
     #[rustc_inherit_overflow_checks]
-    fn advance_back_by(&mut self, n: usize) -> Result<(), usize> {
+    fn advance_back_by(&mut self, n: usize) -> usize {
         #[inline]
         #[rustc_inherit_overflow_checks]
         fn advance<U: DoubleEndedIterator>(n: usize, iter: &mut U) -> ControlFlow<(), usize> {
             match iter.advance_back_by(n) {
-                Ok(()) => ControlFlow::Break(()),
-                Err(advanced) => ControlFlow::Continue(n - advanced),
+                0 => ControlFlow::Break(()),
+                remaining => ControlFlow::Continue(remaining),
             }
         }
 
         match self.iter_try_rfold(n, advance) {
-            ControlFlow::Continue(remaining) if remaining > 0 => Err(n - remaining),
-            _ => Ok(()),
+            ControlFlow::Continue(remaining) => remaining,
+            _ => 0,
         }
     }
 }

--- a/library/core/src/iter/adapters/rev.rs
+++ b/library/core/src/iter/adapters/rev.rs
@@ -1,4 +1,5 @@
 use crate::iter::{FusedIterator, TrustedLen};
+use crate::num::NonZeroUsize;
 use crate::ops::Try;
 
 /// A double-ended iterator with the direction inverted.
@@ -38,7 +39,7 @@ where
     }
 
     #[inline]
-    fn advance_by(&mut self, n: usize) -> usize {
+    fn advance_by(&mut self, n: usize) -> Result<(), NonZeroUsize> {
         self.iter.advance_back_by(n)
     }
 
@@ -83,7 +84,7 @@ where
     }
 
     #[inline]
-    fn advance_back_by(&mut self, n: usize) -> usize {
+    fn advance_back_by(&mut self, n: usize) -> Result<(), NonZeroUsize> {
         self.iter.advance_by(n)
     }
 

--- a/library/core/src/iter/adapters/rev.rs
+++ b/library/core/src/iter/adapters/rev.rs
@@ -38,7 +38,7 @@ where
     }
 
     #[inline]
-    fn advance_by(&mut self, n: usize) -> Result<(), usize> {
+    fn advance_by(&mut self, n: usize) -> usize {
         self.iter.advance_back_by(n)
     }
 
@@ -83,7 +83,7 @@ where
     }
 
     #[inline]
-    fn advance_back_by(&mut self, n: usize) -> Result<(), usize> {
+    fn advance_back_by(&mut self, n: usize) -> usize {
         self.iter.advance_by(n)
     }
 

--- a/library/core/src/iter/range.rs
+++ b/library/core/src/iter/range.rs
@@ -1,6 +1,7 @@
 use crate::convert::TryFrom;
 use crate::marker::Destruct;
 use crate::mem;
+use crate::num::NonZeroUsize;
 use crate::ops::{self, Try};
 
 use super::{
@@ -530,12 +531,12 @@ trait RangeIteratorImpl {
     // Iterator
     fn spec_next(&mut self) -> Option<Self::Item>;
     fn spec_nth(&mut self, n: usize) -> Option<Self::Item>;
-    fn spec_advance_by(&mut self, n: usize) -> usize;
+    fn spec_advance_by(&mut self, n: usize) -> Result<(), NonZeroUsize>;
 
     // DoubleEndedIterator
     fn spec_next_back(&mut self) -> Option<Self::Item>;
     fn spec_nth_back(&mut self, n: usize) -> Option<Self::Item>;
-    fn spec_advance_back_by(&mut self, n: usize) -> usize;
+    fn spec_advance_back_by(&mut self, n: usize) -> Result<(), NonZeroUsize>;
 }
 
 impl<A: ~const Step + ~const Destruct> const RangeIteratorImpl for ops::Range<A> {
@@ -567,7 +568,7 @@ impl<A: ~const Step + ~const Destruct> const RangeIteratorImpl for ops::Range<A>
     }
 
     #[inline]
-    default fn spec_advance_by(&mut self, n: usize) -> usize {
+    default fn spec_advance_by(&mut self, n: usize) -> Result<(), NonZeroUsize> {
         let available = if self.start <= self.end {
             Step::steps_between(&self.start, &self.end).unwrap_or(usize::MAX)
         } else {
@@ -579,7 +580,7 @@ impl<A: ~const Step + ~const Destruct> const RangeIteratorImpl for ops::Range<A>
         self.start =
             Step::forward_checked(self.start.clone(), taken).expect("`Step` invariants not upheld");
 
-        n - taken
+        NonZeroUsize::new(n - taken).map_or(Ok(()), Err)
     }
 
     #[inline]
@@ -608,7 +609,7 @@ impl<A: ~const Step + ~const Destruct> const RangeIteratorImpl for ops::Range<A>
     }
 
     #[inline]
-    default fn spec_advance_back_by(&mut self, n: usize) -> usize {
+    default fn spec_advance_back_by(&mut self, n: usize) -> Result<(), NonZeroUsize> {
         let available = if self.start <= self.end {
             Step::steps_between(&self.start, &self.end).unwrap_or(usize::MAX)
         } else {
@@ -620,7 +621,7 @@ impl<A: ~const Step + ~const Destruct> const RangeIteratorImpl for ops::Range<A>
         self.end =
             Step::backward_checked(self.end.clone(), taken).expect("`Step` invariants not upheld");
 
-        n - taken
+        NonZeroUsize::new(n - taken).map_or(Ok(()), Err)
     }
 }
 
@@ -651,7 +652,7 @@ impl<T: ~const TrustedStep + ~const Destruct> const RangeIteratorImpl for ops::R
     }
 
     #[inline]
-    fn spec_advance_by(&mut self, n: usize) -> usize {
+    fn spec_advance_by(&mut self, n: usize) -> Result<(), NonZeroUsize> {
         let available = if self.start <= self.end {
             Step::steps_between(&self.start, &self.end).unwrap_or(usize::MAX)
         } else {
@@ -666,7 +667,7 @@ impl<T: ~const TrustedStep + ~const Destruct> const RangeIteratorImpl for ops::R
         // Otherwise 0 is returned which always safe to use.
         self.start = unsafe { Step::forward_unchecked(self.start.clone(), taken) };
 
-        n - taken
+        NonZeroUsize::new(n - taken).map_or(Ok(()), Err)
     }
 
     #[inline]
@@ -695,7 +696,7 @@ impl<T: ~const TrustedStep + ~const Destruct> const RangeIteratorImpl for ops::R
     }
 
     #[inline]
-    fn spec_advance_back_by(&mut self, n: usize) -> usize {
+    fn spec_advance_back_by(&mut self, n: usize) -> Result<(), NonZeroUsize> {
         let available = if self.start <= self.end {
             Step::steps_between(&self.start, &self.end).unwrap_or(usize::MAX)
         } else {
@@ -707,7 +708,7 @@ impl<T: ~const TrustedStep + ~const Destruct> const RangeIteratorImpl for ops::R
         // SAFETY: same as the spec_advance_by() implementation
         self.end = unsafe { Step::backward_unchecked(self.end.clone(), taken) };
 
-        n - taken
+        NonZeroUsize::new(n - taken).map_or(Ok(()), Err)
     }
 }
 
@@ -757,7 +758,7 @@ impl<A: ~const Step + ~const Destruct> const Iterator for ops::Range<A> {
     }
 
     #[inline]
-    fn advance_by(&mut self, n: usize) -> usize {
+    fn advance_by(&mut self, n: usize) -> Result<(), NonZeroUsize> {
         self.spec_advance_by(n)
     }
 
@@ -836,7 +837,7 @@ impl<A: ~const Step + ~const Destruct> const DoubleEndedIterator for ops::Range<
     }
 
     #[inline]
-    fn advance_back_by(&mut self, n: usize) -> usize {
+    fn advance_back_by(&mut self, n: usize) -> Result<(), NonZeroUsize> {
         self.spec_advance_back_by(n)
     }
 }

--- a/library/core/src/iter/sources/repeat.rs
+++ b/library/core/src/iter/sources/repeat.rs
@@ -80,10 +80,10 @@ impl<A: Clone> Iterator for Repeat<A> {
     }
 
     #[inline]
-    fn advance_by(&mut self, n: usize) -> Result<(), usize> {
+    fn advance_by(&mut self, n: usize) -> usize {
         // Advancing an infinite iterator of a single element is a no-op.
         let _ = n;
-        Ok(())
+        0
     }
 
     #[inline]
@@ -109,10 +109,10 @@ impl<A: Clone> DoubleEndedIterator for Repeat<A> {
     }
 
     #[inline]
-    fn advance_back_by(&mut self, n: usize) -> Result<(), usize> {
+    fn advance_back_by(&mut self, n: usize) -> usize {
         // Advancing an infinite iterator of a single element is a no-op.
         let _ = n;
-        Ok(())
+        0
     }
 
     #[inline]

--- a/library/core/src/iter/sources/repeat.rs
+++ b/library/core/src/iter/sources/repeat.rs
@@ -1,4 +1,5 @@
 use crate::iter::{FusedIterator, TrustedLen};
+use crate::num::NonZeroUsize;
 
 /// Creates a new iterator that endlessly repeats a single element.
 ///
@@ -80,10 +81,10 @@ impl<A: Clone> Iterator for Repeat<A> {
     }
 
     #[inline]
-    fn advance_by(&mut self, n: usize) -> usize {
+    fn advance_by(&mut self, n: usize) -> Result<(), NonZeroUsize> {
         // Advancing an infinite iterator of a single element is a no-op.
         let _ = n;
-        0
+        Ok(())
     }
 
     #[inline]
@@ -109,10 +110,10 @@ impl<A: Clone> DoubleEndedIterator for Repeat<A> {
     }
 
     #[inline]
-    fn advance_back_by(&mut self, n: usize) -> usize {
+    fn advance_back_by(&mut self, n: usize) -> Result<(), NonZeroUsize> {
         // Advancing an infinite iterator of a single element is a no-op.
         let _ = n;
-        0
+        Ok(())
     }
 
     #[inline]

--- a/library/core/src/iter/sources/repeat_n.rs
+++ b/library/core/src/iter/sources/repeat_n.rs
@@ -1,5 +1,6 @@
 use crate::iter::{FusedIterator, TrustedLen};
 use crate::mem::ManuallyDrop;
+use crate::num::NonZeroUsize;
 
 /// Creates a new iterator that repeats a single element a given number of times.
 ///
@@ -137,7 +138,7 @@ impl<A: Clone> Iterator for RepeatN<A> {
     }
 
     #[inline]
-    fn advance_by(&mut self, skip: usize) -> usize {
+    fn advance_by(&mut self, skip: usize) -> Result<(), NonZeroUsize> {
         let len = self.count;
 
         if skip >= len {
@@ -145,10 +146,11 @@ impl<A: Clone> Iterator for RepeatN<A> {
         }
 
         if skip > len {
-            skip - len
+            // SAFETY: we just checked that the difference is positive
+            Err(unsafe { NonZeroUsize::new_unchecked(skip - len) })
         } else {
             self.count = len - skip;
-            0
+            Ok(())
         }
     }
 
@@ -178,7 +180,7 @@ impl<A: Clone> DoubleEndedIterator for RepeatN<A> {
     }
 
     #[inline]
-    fn advance_back_by(&mut self, n: usize) -> usize {
+    fn advance_back_by(&mut self, n: usize) -> Result<(), NonZeroUsize> {
         self.advance_by(n)
     }
 

--- a/library/core/src/iter/sources/repeat_n.rs
+++ b/library/core/src/iter/sources/repeat_n.rs
@@ -137,7 +137,7 @@ impl<A: Clone> Iterator for RepeatN<A> {
     }
 
     #[inline]
-    fn advance_by(&mut self, skip: usize) -> Result<(), usize> {
+    fn advance_by(&mut self, skip: usize) -> usize {
         let len = self.count;
 
         if skip >= len {
@@ -145,10 +145,10 @@ impl<A: Clone> Iterator for RepeatN<A> {
         }
 
         if skip > len {
-            Err(len)
+            skip - len
         } else {
             self.count = len - skip;
-            Ok(())
+            0
         }
     }
 
@@ -178,7 +178,7 @@ impl<A: Clone> DoubleEndedIterator for RepeatN<A> {
     }
 
     #[inline]
-    fn advance_back_by(&mut self, n: usize) -> Result<(), usize> {
+    fn advance_back_by(&mut self, n: usize) -> usize {
         self.advance_by(n)
     }
 

--- a/library/core/src/iter/traits/double_ended.rs
+++ b/library/core/src/iter/traits/double_ended.rs
@@ -1,4 +1,5 @@
 use crate::marker::Destruct;
+use crate::num::NonZeroUsize;
 use crate::ops::{ControlFlow, Try};
 
 /// An iterator able to yield elements from both ends.
@@ -120,29 +121,31 @@ pub trait DoubleEndedIterator: Iterator {
     /// ```
     /// #![feature(iter_advance_by)]
     ///
+    /// use std::num::NonZeroUsize;
     /// let a = [3, 4, 5, 6];
     /// let mut iter = a.iter();
     ///
-    /// assert_eq!(iter.advance_back_by(2), 0);
+    /// assert_eq!(iter.advance_back_by(2), Ok(()));
     /// assert_eq!(iter.next_back(), Some(&4));
-    /// assert_eq!(iter.advance_back_by(0), 0);
-    /// assert_eq!(iter.advance_back_by(100), 99); // only `&3` was skipped
+    /// assert_eq!(iter.advance_back_by(0), Ok(()));
+    /// assert_eq!(iter.advance_back_by(100), Err(NonZeroUsize::new(99).unwrap())); // only `&3` was skipped
     /// ```
     ///
     /// [`Ok(())`]: Ok
     /// [`Err(k)`]: Err
     #[inline]
     #[unstable(feature = "iter_advance_by", reason = "recently added", issue = "77404")]
-    fn advance_back_by(&mut self, n: usize) -> usize
+    fn advance_back_by(&mut self, n: usize) -> Result<(), NonZeroUsize>
     where
         Self::Item: ~const Destruct,
     {
         for i in 0..n {
             if self.next_back().is_none() {
-                return n - i;
+                // SAFETY: `i` is always less than `n`.
+                return Err(unsafe { NonZeroUsize::new_unchecked(n - i) });
             }
         }
-        0
+        Ok(())
     }
 
     /// Returns the `n`th element from the end of the iterator.
@@ -190,7 +193,7 @@ pub trait DoubleEndedIterator: Iterator {
     #[stable(feature = "iter_nth_back", since = "1.37.0")]
     #[rustc_do_not_const_check]
     fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
-        if self.advance_back_by(n) > 0 {
+        if self.advance_back_by(n).is_err() {
             return None;
         }
         self.next_back()
@@ -378,7 +381,7 @@ impl<'a, I: DoubleEndedIterator + ?Sized> DoubleEndedIterator for &'a mut I {
     fn next_back(&mut self) -> Option<I::Item> {
         (**self).next_back()
     }
-    fn advance_back_by(&mut self, n: usize) -> usize {
+    fn advance_back_by(&mut self, n: usize) -> Result<(), NonZeroUsize> {
         (**self).advance_back_by(n)
     }
     fn nth_back(&mut self, n: usize) -> Option<I::Item> {

--- a/library/core/src/iter/traits/double_ended.rs
+++ b/library/core/src/iter/traits/double_ended.rs
@@ -100,10 +100,10 @@ pub trait DoubleEndedIterator: Iterator {
     /// eagerly skip `n` elements starting from the back by calling [`next_back`] up
     /// to `n` times until [`None`] is encountered.
     ///
-    /// `advance_back_by(n)` will return [`Ok(())`] if the iterator successfully advances by
-    /// `n` elements, or [`Err(k)`] if [`None`] is encountered, where `k` is the number of
-    /// elements the iterator is advanced by before running out of elements (i.e. the length
-    /// of the iterator). Note that `k` is always less than `n`.
+    /// `advance_back_by(n)` will return `0` if the iterator successfully advances by
+    /// `n` elements, or an usize `k` if [`None`] is encountered, where `k` is remaining number
+    /// of steps that could not be advanced because the iterator ran out.
+    /// Note that `k` is always less than `n`.
     ///
     /// Calling `advance_back_by(0)` can do meaningful work, for example [`Flatten`] can advance its
     /// outer iterator until it finds an inner iterator that is not empty, which then often
@@ -123,24 +123,26 @@ pub trait DoubleEndedIterator: Iterator {
     /// let a = [3, 4, 5, 6];
     /// let mut iter = a.iter();
     ///
-    /// assert_eq!(iter.advance_back_by(2), Ok(()));
+    /// assert_eq!(iter.advance_back_by(2), 0);
     /// assert_eq!(iter.next_back(), Some(&4));
-    /// assert_eq!(iter.advance_back_by(0), Ok(()));
-    /// assert_eq!(iter.advance_back_by(100), Err(1)); // only `&3` was skipped
+    /// assert_eq!(iter.advance_back_by(0), 0);
+    /// assert_eq!(iter.advance_back_by(100), 99); // only `&3` was skipped
     /// ```
     ///
     /// [`Ok(())`]: Ok
     /// [`Err(k)`]: Err
     #[inline]
     #[unstable(feature = "iter_advance_by", reason = "recently added", issue = "77404")]
-    fn advance_back_by(&mut self, n: usize) -> Result<(), usize>
+    fn advance_back_by(&mut self, n: usize) -> usize
     where
         Self::Item: ~const Destruct,
     {
         for i in 0..n {
-            self.next_back().ok_or(i)?;
+            if self.next_back().is_none() {
+                return n - i;
+            }
         }
-        Ok(())
+        0
     }
 
     /// Returns the `n`th element from the end of the iterator.
@@ -188,7 +190,9 @@ pub trait DoubleEndedIterator: Iterator {
     #[stable(feature = "iter_nth_back", since = "1.37.0")]
     #[rustc_do_not_const_check]
     fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
-        self.advance_back_by(n).ok()?;
+        if self.advance_back_by(n) > 0 {
+            return None;
+        }
         self.next_back()
     }
 
@@ -374,7 +378,7 @@ impl<'a, I: DoubleEndedIterator + ?Sized> DoubleEndedIterator for &'a mut I {
     fn next_back(&mut self) -> Option<I::Item> {
         (**self).next_back()
     }
-    fn advance_back_by(&mut self, n: usize) -> Result<(), usize> {
+    fn advance_back_by(&mut self, n: usize) -> usize {
         (**self).advance_back_by(n)
     }
     fn nth_back(&mut self, n: usize) -> Option<I::Item> {

--- a/library/core/src/iter/traits/double_ended.rs
+++ b/library/core/src/iter/traits/double_ended.rs
@@ -101,10 +101,11 @@ pub trait DoubleEndedIterator: Iterator {
     /// eagerly skip `n` elements starting from the back by calling [`next_back`] up
     /// to `n` times until [`None`] is encountered.
     ///
-    /// `advance_back_by(n)` will return `0` if the iterator successfully advances by
-    /// `n` elements, or an usize `k` if [`None`] is encountered, where `k` is remaining number
-    /// of steps that could not be advanced because the iterator ran out.
-    /// Note that `k` is always less than `n`.
+    /// `advance_back_by(n)` will return `Ok(())` if the iterator successfully advances by
+    /// `n` elements, or a `Err(NonZeroUsize)` with value `k` if [`None`] is encountered, where `k`
+    /// is remaining number of steps that could not be advanced because the iterator ran out.
+    /// If `self` is empty and `n` is non-zero, then this returns `Err(n)`.
+    /// Otherwise, `k` is always less than `n`.
     ///
     /// Calling `advance_back_by(0)` can do meaningful work, for example [`Flatten`] can advance its
     /// outer iterator until it finds an inner iterator that is not empty, which then often

--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -309,10 +309,11 @@ pub trait Iterator {
     /// This method will eagerly skip `n` elements by calling [`next`] up to `n`
     /// times until [`None`] is encountered.
     ///
-    /// `advance_by(n)` will return `0` if the iterator successfully advances by
-    /// `n` elements, or an usize `k` if [`None`] is encountered, where `k` is remaining number
-    /// of steps that could not be advanced because the iterator ran out.
-    /// Note that `k` is always less than `n`.
+    /// `advance_by(n)` will return `Ok(())` if the iterator successfully advances by
+    /// `n` elements, or a `Err(NonZeroUsize)` with value `k` if [`None`] is encountered,
+    /// where `k` is remaining number of steps that could not be advanced because the iterator ran out.
+    /// If `self` is empty and `n` is non-zero, then this returns `Err(n)`.
+    /// Otherwise, `k` is always less than `n`.
     ///
     /// Calling `advance_by(0)` can do meaningful work, for example [`Flatten`]
     /// can advance its outer iterator until it finds an inner iterator that is not empty, which

--- a/library/core/src/ops/index_range.rs
+++ b/library/core/src/ops/index_range.rs
@@ -1,5 +1,6 @@
 use crate::intrinsics::{assert_unsafe_precondition, unchecked_add, unchecked_sub};
 use crate::iter::{FusedIterator, TrustedLen};
+use crate::num::NonZeroUsize;
 
 /// Like a `Range<usize>`, but with a safety invariant that `start <= end`.
 ///
@@ -132,9 +133,9 @@ impl Iterator for IndexRange {
     }
 
     #[inline]
-    fn advance_by(&mut self, n: usize) -> usize {
+    fn advance_by(&mut self, n: usize) -> Result<(), NonZeroUsize> {
         let taken = self.take_prefix(n);
-        n - taken.len()
+        NonZeroUsize::new(n - taken.len()).map_or(Ok(()), Err)
     }
 }
 
@@ -150,9 +151,9 @@ impl DoubleEndedIterator for IndexRange {
     }
 
     #[inline]
-    fn advance_back_by(&mut self, n: usize) -> usize {
+    fn advance_back_by(&mut self, n: usize) -> Result<(), NonZeroUsize> {
         let taken = self.take_suffix(n);
-        n - taken.len()
+        NonZeroUsize::new(n - taken.len()).map_or(Ok(()), Err)
     }
 }
 

--- a/library/core/src/ops/index_range.rs
+++ b/library/core/src/ops/index_range.rs
@@ -132,10 +132,9 @@ impl Iterator for IndexRange {
     }
 
     #[inline]
-    fn advance_by(&mut self, n: usize) -> Result<(), usize> {
-        let original_len = self.len();
-        self.take_prefix(n);
-        if n > original_len { Err(original_len) } else { Ok(()) }
+    fn advance_by(&mut self, n: usize) -> usize {
+        let taken = self.take_prefix(n);
+        n - taken.len()
     }
 }
 
@@ -151,10 +150,9 @@ impl DoubleEndedIterator for IndexRange {
     }
 
     #[inline]
-    fn advance_back_by(&mut self, n: usize) -> Result<(), usize> {
-        let original_len = self.len();
-        self.take_suffix(n);
-        if n > original_len { Err(original_len) } else { Ok(()) }
+    fn advance_back_by(&mut self, n: usize) -> usize {
+        let taken = self.take_suffix(n);
+        n - taken.len()
     }
 }
 

--- a/library/core/src/slice/iter/macros.rs
+++ b/library/core/src/slice/iter/macros.rs
@@ -176,11 +176,11 @@ macro_rules! iterator {
             }
 
             #[inline]
-            fn advance_by(&mut self, n: usize) -> Result<(), usize> {
+            fn advance_by(&mut self, n: usize) -> usize {
                 let advance = cmp::min(len!(self), n);
                 // SAFETY: By construction, `advance` does not exceed `self.len()`.
                 unsafe { self.post_inc_start(advance) };
-                if advance == n { Ok(()) } else { Err(advance) }
+                n - advance
             }
 
             #[inline]
@@ -371,11 +371,11 @@ macro_rules! iterator {
             }
 
             #[inline]
-            fn advance_back_by(&mut self, n: usize) -> Result<(), usize> {
+            fn advance_back_by(&mut self, n: usize) -> usize {
                 let advance = cmp::min(len!(self), n);
                 // SAFETY: By construction, `advance` does not exceed `self.len()`.
                 unsafe { self.pre_dec_end(advance) };
-                if advance == n { Ok(()) } else { Err(advance) }
+                n - advance
             }
         }
 

--- a/library/core/src/slice/iter/macros.rs
+++ b/library/core/src/slice/iter/macros.rs
@@ -176,11 +176,11 @@ macro_rules! iterator {
             }
 
             #[inline]
-            fn advance_by(&mut self, n: usize) -> usize {
+            fn advance_by(&mut self, n: usize) -> Result<(), NonZeroUsize> {
                 let advance = cmp::min(len!(self), n);
                 // SAFETY: By construction, `advance` does not exceed `self.len()`.
                 unsafe { self.post_inc_start(advance) };
-                n - advance
+                NonZeroUsize::new(n - advance).map_or(Ok(()), Err)
             }
 
             #[inline]
@@ -371,11 +371,11 @@ macro_rules! iterator {
             }
 
             #[inline]
-            fn advance_back_by(&mut self, n: usize) -> usize {
+            fn advance_back_by(&mut self, n: usize) -> Result<(), NonZeroUsize> {
                 let advance = cmp::min(len!(self), n);
                 // SAFETY: By construction, `advance` does not exceed `self.len()`.
                 unsafe { self.pre_dec_end(advance) };
-                n - advance
+                NonZeroUsize::new(n - advance).map_or(Ok(()), Err)
             }
         }
 

--- a/library/core/tests/array.rs
+++ b/library/core/tests/array.rs
@@ -1,4 +1,4 @@
-use core::array;
+use core::{array, assert_eq};
 use core::convert::TryFrom;
 use core::sync::atomic::{AtomicUsize, Ordering};
 
@@ -535,17 +535,17 @@ fn array_intoiter_advance_by() {
     let mut it = IntoIterator::into_iter(a);
 
     let r = it.advance_by(1);
-    assert_eq!(r, Ok(()));
+    assert_eq!(r, 0);
     assert_eq!(it.len(), 99);
     assert_eq!(counter.get(), 1);
 
     let r = it.advance_by(0);
-    assert_eq!(r, Ok(()));
+    assert_eq!(r, 0);
     assert_eq!(it.len(), 99);
     assert_eq!(counter.get(), 1);
 
     let r = it.advance_by(11);
-    assert_eq!(r, Ok(()));
+    assert_eq!(r, 0);
     assert_eq!(it.len(), 88);
     assert_eq!(counter.get(), 12);
 
@@ -557,17 +557,17 @@ fn array_intoiter_advance_by() {
     assert_eq!(counter.get(), 13);
 
     let r = it.advance_by(123456);
-    assert_eq!(r, Err(87));
+    assert_eq!(r, 123456 - 87);
     assert_eq!(it.len(), 0);
     assert_eq!(counter.get(), 100);
 
     let r = it.advance_by(0);
-    assert_eq!(r, Ok(()));
+    assert_eq!(r, 0);
     assert_eq!(it.len(), 0);
     assert_eq!(counter.get(), 100);
 
     let r = it.advance_by(10);
-    assert_eq!(r, Err(0));
+    assert_eq!(r, 10);
     assert_eq!(it.len(), 0);
     assert_eq!(counter.get(), 100);
 }
@@ -588,17 +588,17 @@ fn array_intoiter_advance_back_by() {
     let mut it = IntoIterator::into_iter(a);
 
     let r = it.advance_back_by(1);
-    assert_eq!(r, Ok(()));
+    assert_eq!(r, 0);
     assert_eq!(it.len(), 99);
     assert_eq!(counter.get(), 1);
 
     let r = it.advance_back_by(0);
-    assert_eq!(r, Ok(()));
+    assert_eq!(r, 0);
     assert_eq!(it.len(), 99);
     assert_eq!(counter.get(), 1);
 
     let r = it.advance_back_by(11);
-    assert_eq!(r, Ok(()));
+    assert_eq!(r, 0);
     assert_eq!(it.len(), 88);
     assert_eq!(counter.get(), 12);
 
@@ -610,17 +610,17 @@ fn array_intoiter_advance_back_by() {
     assert_eq!(counter.get(), 13);
 
     let r = it.advance_back_by(123456);
-    assert_eq!(r, Err(87));
+    assert_eq!(r, 123456 - 87);
     assert_eq!(it.len(), 0);
     assert_eq!(counter.get(), 100);
 
     let r = it.advance_back_by(0);
-    assert_eq!(r, Ok(()));
+    assert_eq!(r, 0);
     assert_eq!(it.len(), 0);
     assert_eq!(counter.get(), 100);
 
     let r = it.advance_back_by(10);
-    assert_eq!(r, Err(0));
+    assert_eq!(r, 10);
     assert_eq!(it.len(), 0);
     assert_eq!(counter.get(), 100);
 }
@@ -679,8 +679,8 @@ fn array_into_iter_fold() {
 
     let a = [1, 2, 3, 4, 5, 6];
     let mut it = a.into_iter();
-    it.advance_by(1).unwrap();
-    it.advance_back_by(2).unwrap();
+    assert_eq!(it.advance_by(1), 0);
+    assert_eq!(it.advance_back_by(2), 0);
     let s = it.fold(10, |a, b| 10 * a + b);
     assert_eq!(s, 10234);
 }
@@ -695,8 +695,8 @@ fn array_into_iter_rfold() {
 
     let a = [1, 2, 3, 4, 5, 6];
     let mut it = a.into_iter();
-    it.advance_by(1).unwrap();
-    it.advance_back_by(2).unwrap();
+    assert_eq!(it.advance_by(1), 0);
+    assert_eq!(it.advance_back_by(2), 0);
     let s = it.rfold(10, |a, b| 10 * a + b);
     assert_eq!(s, 10432);
 }

--- a/library/core/tests/array.rs
+++ b/library/core/tests/array.rs
@@ -1,5 +1,6 @@
 use core::{array, assert_eq};
 use core::convert::TryFrom;
+use core::num::NonZeroUsize;
 use core::sync::atomic::{AtomicUsize, Ordering};
 
 #[test]
@@ -535,17 +536,17 @@ fn array_intoiter_advance_by() {
     let mut it = IntoIterator::into_iter(a);
 
     let r = it.advance_by(1);
-    assert_eq!(r, 0);
+    assert_eq!(r, Ok(()));
     assert_eq!(it.len(), 99);
     assert_eq!(counter.get(), 1);
 
     let r = it.advance_by(0);
-    assert_eq!(r, 0);
+    assert_eq!(r, Ok(()));
     assert_eq!(it.len(), 99);
     assert_eq!(counter.get(), 1);
 
     let r = it.advance_by(11);
-    assert_eq!(r, 0);
+    assert_eq!(r, Ok(()));
     assert_eq!(it.len(), 88);
     assert_eq!(counter.get(), 12);
 
@@ -557,17 +558,17 @@ fn array_intoiter_advance_by() {
     assert_eq!(counter.get(), 13);
 
     let r = it.advance_by(123456);
-    assert_eq!(r, 123456 - 87);
+    assert_eq!(r, Err(NonZeroUsize::new(123456 - 87).unwrap()));
     assert_eq!(it.len(), 0);
     assert_eq!(counter.get(), 100);
 
     let r = it.advance_by(0);
-    assert_eq!(r, 0);
+    assert_eq!(r, Ok(()));
     assert_eq!(it.len(), 0);
     assert_eq!(counter.get(), 100);
 
     let r = it.advance_by(10);
-    assert_eq!(r, 10);
+    assert_eq!(r, Err(NonZeroUsize::new(10).unwrap()));
     assert_eq!(it.len(), 0);
     assert_eq!(counter.get(), 100);
 }
@@ -588,17 +589,17 @@ fn array_intoiter_advance_back_by() {
     let mut it = IntoIterator::into_iter(a);
 
     let r = it.advance_back_by(1);
-    assert_eq!(r, 0);
+    assert_eq!(r, Ok(()));
     assert_eq!(it.len(), 99);
     assert_eq!(counter.get(), 1);
 
     let r = it.advance_back_by(0);
-    assert_eq!(r, 0);
+    assert_eq!(r, Ok(()));
     assert_eq!(it.len(), 99);
     assert_eq!(counter.get(), 1);
 
     let r = it.advance_back_by(11);
-    assert_eq!(r, 0);
+    assert_eq!(r, Ok(()));
     assert_eq!(it.len(), 88);
     assert_eq!(counter.get(), 12);
 
@@ -610,17 +611,17 @@ fn array_intoiter_advance_back_by() {
     assert_eq!(counter.get(), 13);
 
     let r = it.advance_back_by(123456);
-    assert_eq!(r, 123456 - 87);
+    assert_eq!(r, Err(NonZeroUsize::new(123456 - 87).unwrap()));
     assert_eq!(it.len(), 0);
     assert_eq!(counter.get(), 100);
 
     let r = it.advance_back_by(0);
-    assert_eq!(r, 0);
+    assert_eq!(r, Ok(()));
     assert_eq!(it.len(), 0);
     assert_eq!(counter.get(), 100);
 
     let r = it.advance_back_by(10);
-    assert_eq!(r, 10);
+    assert_eq!(r, Err(NonZeroUsize::new(10).unwrap()));
     assert_eq!(it.len(), 0);
     assert_eq!(counter.get(), 100);
 }
@@ -679,8 +680,8 @@ fn array_into_iter_fold() {
 
     let a = [1, 2, 3, 4, 5, 6];
     let mut it = a.into_iter();
-    assert_eq!(it.advance_by(1), 0);
-    assert_eq!(it.advance_back_by(2), 0);
+    assert_eq!(it.advance_by(1), Ok(()));
+    assert_eq!(it.advance_back_by(2), Ok(()));
     let s = it.fold(10, |a, b| 10 * a + b);
     assert_eq!(s, 10234);
 }
@@ -695,8 +696,8 @@ fn array_into_iter_rfold() {
 
     let a = [1, 2, 3, 4, 5, 6];
     let mut it = a.into_iter();
-    assert_eq!(it.advance_by(1), 0);
-    assert_eq!(it.advance_back_by(2), 0);
+    assert_eq!(it.advance_by(1), Ok(()));
+    assert_eq!(it.advance_back_by(2), Ok(()));
     let s = it.rfold(10, |a, b| 10 * a + b);
     assert_eq!(s, 10432);
 }

--- a/library/core/tests/iter/adapters/chain.rs
+++ b/library/core/tests/iter/adapters/chain.rs
@@ -31,28 +31,28 @@ fn test_iterator_chain_advance_by() {
 
         for i in 0..xs.len() {
             let mut iter = Unfuse::new(xs).chain(Unfuse::new(ys));
-            iter.advance_by(i).unwrap();
+            assert_eq!(0, iter.advance_by(i));
             assert_eq!(iter.next(), Some(&xs[i]));
-            assert_eq!(iter.advance_by(100), Err(len - i - 1));
-            iter.advance_by(0).unwrap();
+            assert_eq!(iter.advance_by(100), 100 - (len - i - 1));
+            assert_eq!(0, iter.advance_by(0));
         }
 
         for i in 0..ys.len() {
             let mut iter = Unfuse::new(xs).chain(Unfuse::new(ys));
-            iter.advance_by(xs.len() + i).unwrap();
+            assert_eq!(iter.advance_by(xs.len() + i), 0);
             assert_eq!(iter.next(), Some(&ys[i]));
-            assert_eq!(iter.advance_by(100), Err(ys.len() - i - 1));
-            iter.advance_by(0).unwrap();
+            assert_eq!(iter.advance_by(100), 100 - (ys.len() - i - 1));
+            assert_eq!(iter.advance_by(0), 0);
         }
 
         let mut iter = xs.iter().chain(ys);
-        iter.advance_by(len).unwrap();
+        assert_eq!(iter.advance_by(len), 0);
         assert_eq!(iter.next(), None);
-        iter.advance_by(0).unwrap();
+        assert_eq!(iter.advance_by(0), 0);
 
         let mut iter = xs.iter().chain(ys);
-        assert_eq!(iter.advance_by(len + 1), Err(len));
-        iter.advance_by(0).unwrap();
+        assert_eq!(iter.advance_by(len + 1), 1);
+        assert_eq!(iter.advance_by(0), 0);
     }
 
     test_chain(&[], &[]);
@@ -68,28 +68,28 @@ fn test_iterator_chain_advance_back_by() {
 
         for i in 0..ys.len() {
             let mut iter = Unfuse::new(xs).chain(Unfuse::new(ys));
-            iter.advance_back_by(i).unwrap();
+            assert_eq!(iter.advance_back_by(i), 0);
             assert_eq!(iter.next_back(), Some(&ys[ys.len() - i - 1]));
-            assert_eq!(iter.advance_back_by(100), Err(len - i - 1));
-            iter.advance_back_by(0).unwrap();
+            assert_eq!(iter.advance_back_by(100), 100 - (len - i - 1));
+            assert_eq!(iter.advance_back_by(0), 0);
         }
 
         for i in 0..xs.len() {
             let mut iter = Unfuse::new(xs).chain(Unfuse::new(ys));
-            iter.advance_back_by(ys.len() + i).unwrap();
+            assert_eq!(iter.advance_back_by(ys.len() + i), 0);
             assert_eq!(iter.next_back(), Some(&xs[xs.len() - i - 1]));
-            assert_eq!(iter.advance_back_by(100), Err(xs.len() - i - 1));
-            iter.advance_back_by(0).unwrap();
+            assert_eq!(iter.advance_back_by(100), 100 - (xs.len() - i - 1));
+            assert_eq!(iter.advance_back_by(0), 0);
         }
 
         let mut iter = xs.iter().chain(ys);
-        iter.advance_back_by(len).unwrap();
+        assert_eq!(iter.advance_back_by(len), 0);
         assert_eq!(iter.next_back(), None);
-        iter.advance_back_by(0).unwrap();
+        assert_eq!(iter.advance_back_by(0), 0);
 
         let mut iter = xs.iter().chain(ys);
-        assert_eq!(iter.advance_back_by(len + 1), Err(len));
-        iter.advance_back_by(0).unwrap();
+        assert_eq!(iter.advance_back_by(len + 1), 1);
+        assert_eq!(iter.advance_back_by(0), 0);
     }
 
     test_chain(&[], &[]);

--- a/library/core/tests/iter/adapters/chain.rs
+++ b/library/core/tests/iter/adapters/chain.rs
@@ -1,5 +1,6 @@
 use super::*;
 use core::iter::*;
+use core::num::NonZeroUsize;
 
 #[test]
 fn test_iterator_chain() {
@@ -31,28 +32,28 @@ fn test_iterator_chain_advance_by() {
 
         for i in 0..xs.len() {
             let mut iter = Unfuse::new(xs).chain(Unfuse::new(ys));
-            assert_eq!(0, iter.advance_by(i));
+            assert_eq!(iter.advance_by(i), Ok(()));
             assert_eq!(iter.next(), Some(&xs[i]));
-            assert_eq!(iter.advance_by(100), 100 - (len - i - 1));
-            assert_eq!(0, iter.advance_by(0));
+            assert_eq!(iter.advance_by(100), Err(NonZeroUsize::new(100 - (len - i - 1)).unwrap()));
+            assert_eq!(iter.advance_by(0), Ok(()));
         }
 
         for i in 0..ys.len() {
             let mut iter = Unfuse::new(xs).chain(Unfuse::new(ys));
-            assert_eq!(iter.advance_by(xs.len() + i), 0);
+            assert_eq!(iter.advance_by(xs.len() + i), Ok(()));
             assert_eq!(iter.next(), Some(&ys[i]));
-            assert_eq!(iter.advance_by(100), 100 - (ys.len() - i - 1));
-            assert_eq!(iter.advance_by(0), 0);
+            assert_eq!(iter.advance_by(100), Err(NonZeroUsize::new(100 - (ys.len() - i - 1)).unwrap()));
+            assert_eq!(iter.advance_by(0), Ok(()));
         }
 
         let mut iter = xs.iter().chain(ys);
-        assert_eq!(iter.advance_by(len), 0);
+        assert_eq!(iter.advance_by(len), Ok(()));
         assert_eq!(iter.next(), None);
-        assert_eq!(iter.advance_by(0), 0);
+        assert_eq!(iter.advance_by(0), Ok(()));
 
         let mut iter = xs.iter().chain(ys);
-        assert_eq!(iter.advance_by(len + 1), 1);
-        assert_eq!(iter.advance_by(0), 0);
+        assert_eq!(iter.advance_by(len + 1), Err(NonZeroUsize::new(1).unwrap()));
+        assert_eq!(iter.advance_by(0), Ok(()));
     }
 
     test_chain(&[], &[]);
@@ -68,28 +69,28 @@ fn test_iterator_chain_advance_back_by() {
 
         for i in 0..ys.len() {
             let mut iter = Unfuse::new(xs).chain(Unfuse::new(ys));
-            assert_eq!(iter.advance_back_by(i), 0);
+            assert_eq!(iter.advance_back_by(i), Ok(()));
             assert_eq!(iter.next_back(), Some(&ys[ys.len() - i - 1]));
-            assert_eq!(iter.advance_back_by(100), 100 - (len - i - 1));
-            assert_eq!(iter.advance_back_by(0), 0);
+            assert_eq!(iter.advance_back_by(100), Err(NonZeroUsize::new(100 - (len - i - 1)).unwrap()));
+            assert_eq!(iter.advance_back_by(0), Ok(()));
         }
 
         for i in 0..xs.len() {
             let mut iter = Unfuse::new(xs).chain(Unfuse::new(ys));
-            assert_eq!(iter.advance_back_by(ys.len() + i), 0);
+            assert_eq!(iter.advance_back_by(ys.len() + i), Ok(()));
             assert_eq!(iter.next_back(), Some(&xs[xs.len() - i - 1]));
-            assert_eq!(iter.advance_back_by(100), 100 - (xs.len() - i - 1));
-            assert_eq!(iter.advance_back_by(0), 0);
+            assert_eq!(iter.advance_back_by(100), Err(NonZeroUsize::new(100 - (xs.len() - i - 1)).unwrap()));
+            assert_eq!(iter.advance_back_by(0), Ok(()));
         }
 
         let mut iter = xs.iter().chain(ys);
-        assert_eq!(iter.advance_back_by(len), 0);
+        assert_eq!(iter.advance_back_by(len), Ok(()));
         assert_eq!(iter.next_back(), None);
-        assert_eq!(iter.advance_back_by(0), 0);
+        assert_eq!(iter.advance_back_by(0), Ok(()));
 
         let mut iter = xs.iter().chain(ys);
-        assert_eq!(iter.advance_back_by(len + 1), 1);
-        assert_eq!(iter.advance_back_by(0), 0);
+        assert_eq!(iter.advance_back_by(len + 1), Err(NonZeroUsize::new(1).unwrap()));
+        assert_eq!(iter.advance_back_by(0), Ok(()));
     }
 
     test_chain(&[], &[]);

--- a/library/core/tests/iter/adapters/enumerate.rs
+++ b/library/core/tests/iter/adapters/enumerate.rs
@@ -1,4 +1,5 @@
 use core::iter::*;
+use core::num::NonZeroUsize;
 
 #[test]
 fn test_iterator_enumerate() {
@@ -53,6 +54,20 @@ fn test_iterator_enumerate_nth_back() {
 fn test_iterator_enumerate_count() {
     let xs = [0, 1, 2, 3, 4, 5];
     assert_eq!(xs.iter().enumerate().count(), 6);
+}
+
+#[test]
+fn test_iterator_enumerate_advance_by() {
+    let xs = [0, 1, 2, 3, 4, 5];
+    let mut it = xs.iter().enumerate();
+    assert_eq!(it.advance_by(0), Ok(()));
+    assert_eq!(it.next(), Some((0, &0)));
+    assert_eq!(it.advance_by(1), Ok(()));
+    assert_eq!(it.next(), Some((2, &2)));
+    assert_eq!(it.advance_by(2), Ok(()));
+    assert_eq!(it.next(), Some((5, &5)));
+    assert_eq!(it.advance_by(1), Err(NonZeroUsize::new(1).unwrap()));
+    assert_eq!(it.next(), None);
 }
 
 #[test]

--- a/library/core/tests/iter/adapters/flatten.rs
+++ b/library/core/tests/iter/adapters/flatten.rs
@@ -1,3 +1,4 @@
+use core::assert_eq;
 use super::*;
 use core::iter::*;
 
@@ -61,19 +62,19 @@ fn test_flatten_try_folds() {
 fn test_flatten_advance_by() {
     let mut it = once(0..10).chain(once(10..30)).chain(once(30..40)).flatten();
 
-    it.advance_by(5).unwrap();
+    assert_eq!(it.advance_by(5), 0);
     assert_eq!(it.next(), Some(5));
-    it.advance_by(9).unwrap();
+    assert_eq!(it.advance_by(9), 0);
     assert_eq!(it.next(), Some(15));
-    it.advance_back_by(4).unwrap();
+    assert_eq!(it.advance_back_by(4), 0);
     assert_eq!(it.next_back(), Some(35));
-    it.advance_back_by(9).unwrap();
+    assert_eq!(it.advance_back_by(9), 0);
     assert_eq!(it.next_back(), Some(25));
 
-    assert_eq!(it.advance_by(usize::MAX), Err(9));
-    assert_eq!(it.advance_back_by(usize::MAX), Err(0));
-    it.advance_by(0).unwrap();
-    it.advance_back_by(0).unwrap();
+    assert_eq!(it.advance_by(usize::MAX), usize::MAX - 9);
+    assert_eq!(it.advance_back_by(usize::MAX), usize::MAX);
+    assert_eq!(it.advance_by(0), 0);
+    assert_eq!(it.advance_back_by(0), 0);
     assert_eq!(it.size_hint(), (0, Some(0)));
 }
 
@@ -174,19 +175,19 @@ fn test_flatten_count() {
     let mut it = once(0..10).chain(once(10..30)).chain(once(30..40)).flatten();
 
     assert_eq!(it.clone().count(), 40);
-    it.advance_by(5).unwrap();
+    assert_eq!(it.advance_by(5), 0);
     assert_eq!(it.clone().count(), 35);
-    it.advance_back_by(5).unwrap();
+    assert_eq!(it.advance_back_by(5), 0);
     assert_eq!(it.clone().count(), 30);
-    it.advance_by(10).unwrap();
+    assert_eq!(it.advance_by(10), 0);
     assert_eq!(it.clone().count(), 20);
-    it.advance_back_by(8).unwrap();
+    assert_eq!(it.advance_back_by(8), 0);
     assert_eq!(it.clone().count(), 12);
-    it.advance_by(4).unwrap();
+    assert_eq!(it.advance_by(4), 0);
     assert_eq!(it.clone().count(), 8);
-    it.advance_back_by(5).unwrap();
+    assert_eq!(it.advance_back_by(5), 0);
     assert_eq!(it.clone().count(), 3);
-    it.advance_by(3).unwrap();
+    assert_eq!(it.advance_by(3), 0);
     assert_eq!(it.clone().count(), 0);
 }
 
@@ -195,18 +196,18 @@ fn test_flatten_last() {
     let mut it = once(0..10).chain(once(10..30)).chain(once(30..40)).flatten();
 
     assert_eq!(it.clone().last(), Some(39));
-    it.advance_by(5).unwrap(); // 5..40
+    assert_eq!(it.advance_by(5), 0); // 5..40
     assert_eq!(it.clone().last(), Some(39));
-    it.advance_back_by(5).unwrap(); // 5..35
+    assert_eq!(it.advance_back_by(5), 0); // 5..35
     assert_eq!(it.clone().last(), Some(34));
-    it.advance_by(10).unwrap(); // 15..35
+    assert_eq!(it.advance_by(10), 0); // 15..35
     assert_eq!(it.clone().last(), Some(34));
-    it.advance_back_by(8).unwrap(); // 15..27
+    assert_eq!(it.advance_back_by(8), 0); // 15..27
     assert_eq!(it.clone().last(), Some(26));
-    it.advance_by(4).unwrap(); // 19..27
+    assert_eq!(it.advance_by(4), 0); // 19..27
     assert_eq!(it.clone().last(), Some(26));
-    it.advance_back_by(5).unwrap(); // 19..22
+    assert_eq!(it.advance_back_by(5), 0); // 19..22
     assert_eq!(it.clone().last(), Some(21));
-    it.advance_by(3).unwrap(); // 22..22
+    assert_eq!(it.advance_by(3), 0); // 22..22
     assert_eq!(it.clone().last(), None);
 }

--- a/library/core/tests/iter/adapters/flatten.rs
+++ b/library/core/tests/iter/adapters/flatten.rs
@@ -1,6 +1,7 @@
 use core::assert_eq;
 use super::*;
 use core::iter::*;
+use core::num::NonZeroUsize;
 
 #[test]
 fn test_iterator_flatten() {
@@ -62,19 +63,19 @@ fn test_flatten_try_folds() {
 fn test_flatten_advance_by() {
     let mut it = once(0..10).chain(once(10..30)).chain(once(30..40)).flatten();
 
-    assert_eq!(it.advance_by(5), 0);
+    assert_eq!(it.advance_by(5), Ok(()));
     assert_eq!(it.next(), Some(5));
-    assert_eq!(it.advance_by(9), 0);
+    assert_eq!(it.advance_by(9), Ok(()));
     assert_eq!(it.next(), Some(15));
-    assert_eq!(it.advance_back_by(4), 0);
+    assert_eq!(it.advance_back_by(4), Ok(()));
     assert_eq!(it.next_back(), Some(35));
-    assert_eq!(it.advance_back_by(9), 0);
+    assert_eq!(it.advance_back_by(9), Ok(()));
     assert_eq!(it.next_back(), Some(25));
 
-    assert_eq!(it.advance_by(usize::MAX), usize::MAX - 9);
-    assert_eq!(it.advance_back_by(usize::MAX), usize::MAX);
-    assert_eq!(it.advance_by(0), 0);
-    assert_eq!(it.advance_back_by(0), 0);
+    assert_eq!(it.advance_by(usize::MAX), Err(NonZeroUsize::new(usize::MAX - 9).unwrap()));
+    assert_eq!(it.advance_back_by(usize::MAX), Err(NonZeroUsize::new(usize::MAX).unwrap()));
+    assert_eq!(it.advance_by(0), Ok(()));
+    assert_eq!(it.advance_back_by(0), Ok(()));
     assert_eq!(it.size_hint(), (0, Some(0)));
 }
 
@@ -175,19 +176,19 @@ fn test_flatten_count() {
     let mut it = once(0..10).chain(once(10..30)).chain(once(30..40)).flatten();
 
     assert_eq!(it.clone().count(), 40);
-    assert_eq!(it.advance_by(5), 0);
+    assert_eq!(it.advance_by(5), Ok(()));
     assert_eq!(it.clone().count(), 35);
-    assert_eq!(it.advance_back_by(5), 0);
+    assert_eq!(it.advance_back_by(5), Ok(()));
     assert_eq!(it.clone().count(), 30);
-    assert_eq!(it.advance_by(10), 0);
+    assert_eq!(it.advance_by(10), Ok(()));
     assert_eq!(it.clone().count(), 20);
-    assert_eq!(it.advance_back_by(8), 0);
+    assert_eq!(it.advance_back_by(8), Ok(()));
     assert_eq!(it.clone().count(), 12);
-    assert_eq!(it.advance_by(4), 0);
+    assert_eq!(it.advance_by(4), Ok(()));
     assert_eq!(it.clone().count(), 8);
-    assert_eq!(it.advance_back_by(5), 0);
+    assert_eq!(it.advance_back_by(5), Ok(()));
     assert_eq!(it.clone().count(), 3);
-    assert_eq!(it.advance_by(3), 0);
+    assert_eq!(it.advance_by(3), Ok(()));
     assert_eq!(it.clone().count(), 0);
 }
 
@@ -196,18 +197,18 @@ fn test_flatten_last() {
     let mut it = once(0..10).chain(once(10..30)).chain(once(30..40)).flatten();
 
     assert_eq!(it.clone().last(), Some(39));
-    assert_eq!(it.advance_by(5), 0); // 5..40
+    assert_eq!(it.advance_by(5), Ok(())); // 5..40
     assert_eq!(it.clone().last(), Some(39));
-    assert_eq!(it.advance_back_by(5), 0); // 5..35
+    assert_eq!(it.advance_back_by(5), Ok(())); // 5..35
     assert_eq!(it.clone().last(), Some(34));
-    assert_eq!(it.advance_by(10), 0); // 15..35
+    assert_eq!(it.advance_by(10), Ok(())); // 15..35
     assert_eq!(it.clone().last(), Some(34));
-    assert_eq!(it.advance_back_by(8), 0); // 15..27
+    assert_eq!(it.advance_back_by(8), Ok(())); // 15..27
     assert_eq!(it.clone().last(), Some(26));
-    assert_eq!(it.advance_by(4), 0); // 19..27
+    assert_eq!(it.advance_by(4), Ok(())); // 19..27
     assert_eq!(it.clone().last(), Some(26));
-    assert_eq!(it.advance_back_by(5), 0); // 19..22
+    assert_eq!(it.advance_back_by(5), Ok(())); // 19..22
     assert_eq!(it.clone().last(), Some(21));
-    assert_eq!(it.advance_by(3), 0); // 22..22
+    assert_eq!(it.advance_by(3), Ok(())); // 22..22
     assert_eq!(it.clone().last(), None);
 }

--- a/library/core/tests/iter/adapters/skip.rs
+++ b/library/core/tests/iter/adapters/skip.rs
@@ -73,13 +73,16 @@ fn test_iterator_skip_nth() {
 
 #[test]
 fn test_skip_advance_by() {
-    assert_eq!((0..0).skip(10).advance_by(0), Ok(()));
-    assert_eq!((0..0).skip(10).advance_by(1), Err(0));
-    assert_eq!((0u128..(usize::MAX as u128) + 1).skip(usize::MAX).advance_by(usize::MAX), Err(1));
-    assert_eq!((0u128..u128::MAX).skip(usize::MAX).advance_by(1), Ok(()));
+    assert_eq!((0..0).skip(10).advance_by(0), 0);
+    assert_eq!((0..0).skip(10).advance_by(1), 1);
+    assert_eq!(
+        (0u128..(usize::MAX as u128) + 1).skip(usize::MAX - 10).advance_by(usize::MAX - 5),
+        usize::MAX - 16
+    );
+    assert_eq!((0u128..u128::MAX).skip(usize::MAX - 10).advance_by(20), 0);
 
-    assert_eq!((0..2).skip(1).advance_back_by(10), Err(1));
-    assert_eq!((0..0).skip(1).advance_back_by(0), Ok(()));
+    assert_eq!((0..2).skip(1).advance_back_by(10), 9);
+    assert_eq!((0..0).skip(1).advance_back_by(0), 0);
 }
 
 #[test]

--- a/library/core/tests/iter/adapters/skip.rs
+++ b/library/core/tests/iter/adapters/skip.rs
@@ -1,4 +1,5 @@
 use core::iter::*;
+use core::num::NonZeroUsize;
 
 use super::Unfuse;
 
@@ -73,16 +74,16 @@ fn test_iterator_skip_nth() {
 
 #[test]
 fn test_skip_advance_by() {
-    assert_eq!((0..0).skip(10).advance_by(0), 0);
-    assert_eq!((0..0).skip(10).advance_by(1), 1);
+    assert_eq!((0..0).skip(10).advance_by(0), Ok(()));
+    assert_eq!((0..0).skip(10).advance_by(1), Err(NonZeroUsize::new(1).unwrap()));
     assert_eq!(
         (0u128..(usize::MAX as u128) + 1).skip(usize::MAX - 10).advance_by(usize::MAX - 5),
-        usize::MAX - 16
+        Err(NonZeroUsize::new(usize::MAX - 16).unwrap())
     );
-    assert_eq!((0u128..u128::MAX).skip(usize::MAX - 10).advance_by(20), 0);
+    assert_eq!((0u128..u128::MAX).skip(usize::MAX - 10).advance_by(20), Ok(()));
 
-    assert_eq!((0..2).skip(1).advance_back_by(10), 9);
-    assert_eq!((0..0).skip(1).advance_back_by(0), 0);
+    assert_eq!((0..2).skip(1).advance_back_by(10), Err(NonZeroUsize::new(9).unwrap()));
+    assert_eq!((0..0).skip(1).advance_back_by(0), Ok(()));
 }
 
 #[test]

--- a/library/core/tests/iter/adapters/take.rs
+++ b/library/core/tests/iter/adapters/take.rs
@@ -76,23 +76,23 @@ fn test_iterator_take_nth_back() {
 #[test]
 fn test_take_advance_by() {
     let mut take = (0..10).take(3);
-    assert_eq!(take.advance_by(2), Ok(()));
+    assert_eq!(take.advance_by(2), 0);
     assert_eq!(take.next(), Some(2));
-    assert_eq!(take.advance_by(1), Err(0));
+    assert_eq!(take.advance_by(1), 1);
 
-    assert_eq!((0..0).take(10).advance_by(0), Ok(()));
-    assert_eq!((0..0).take(10).advance_by(1), Err(0));
-    assert_eq!((0..10).take(4).advance_by(5), Err(4));
+    assert_eq!((0..0).take(10).advance_by(0), 0);
+    assert_eq!((0..0).take(10).advance_by(1), 1);
+    assert_eq!((0..10).take(4).advance_by(5), 1);
 
     let mut take = (0..10).take(3);
-    assert_eq!(take.advance_back_by(2), Ok(()));
+    assert_eq!(take.advance_back_by(2), 0);
     assert_eq!(take.next(), Some(0));
-    assert_eq!(take.advance_back_by(1), Err(0));
+    assert_eq!(take.advance_back_by(1), 1);
 
-    assert_eq!((0..2).take(1).advance_back_by(10), Err(1));
-    assert_eq!((0..0).take(1).advance_back_by(1), Err(0));
-    assert_eq!((0..0).take(1).advance_back_by(0), Ok(()));
-    assert_eq!((0..usize::MAX).take(100).advance_back_by(usize::MAX), Err(100));
+    assert_eq!((0..2).take(1).advance_back_by(10), 9);
+    assert_eq!((0..0).take(1).advance_back_by(1), 1);
+    assert_eq!((0..0).take(1).advance_back_by(0), 0);
+    assert_eq!((0..usize::MAX).take(100).advance_back_by(usize::MAX), usize::MAX - 100);
 }
 
 #[test]

--- a/library/core/tests/iter/adapters/take.rs
+++ b/library/core/tests/iter/adapters/take.rs
@@ -1,4 +1,5 @@
 use core::iter::*;
+use core::num::NonZeroUsize;
 
 #[test]
 fn test_iterator_take() {
@@ -76,23 +77,23 @@ fn test_iterator_take_nth_back() {
 #[test]
 fn test_take_advance_by() {
     let mut take = (0..10).take(3);
-    assert_eq!(take.advance_by(2), 0);
+    assert_eq!(take.advance_by(2), Ok(()));
     assert_eq!(take.next(), Some(2));
-    assert_eq!(take.advance_by(1), 1);
+    assert_eq!(take.advance_by(1), Err(NonZeroUsize::new(1).unwrap()));
 
-    assert_eq!((0..0).take(10).advance_by(0), 0);
-    assert_eq!((0..0).take(10).advance_by(1), 1);
-    assert_eq!((0..10).take(4).advance_by(5), 1);
+    assert_eq!((0..0).take(10).advance_by(0), Ok(()));
+    assert_eq!((0..0).take(10).advance_by(1), Err(NonZeroUsize::new(1).unwrap()));
+    assert_eq!((0..10).take(4).advance_by(5), Err(NonZeroUsize::new(1).unwrap()));
 
     let mut take = (0..10).take(3);
-    assert_eq!(take.advance_back_by(2), 0);
+    assert_eq!(take.advance_back_by(2), Ok(()));
     assert_eq!(take.next(), Some(0));
-    assert_eq!(take.advance_back_by(1), 1);
+    assert_eq!(take.advance_back_by(1), Err(NonZeroUsize::new(1).unwrap()));
 
-    assert_eq!((0..2).take(1).advance_back_by(10), 9);
-    assert_eq!((0..0).take(1).advance_back_by(1), 1);
-    assert_eq!((0..0).take(1).advance_back_by(0), 0);
-    assert_eq!((0..usize::MAX).take(100).advance_back_by(usize::MAX), usize::MAX - 100);
+    assert_eq!((0..2).take(1).advance_back_by(10), Err(NonZeroUsize::new(9).unwrap()));
+    assert_eq!((0..0).take(1).advance_back_by(1), Err(NonZeroUsize::new(1).unwrap()));
+    assert_eq!((0..0).take(1).advance_back_by(0), Ok(()));
+    assert_eq!((0..usize::MAX).take(100).advance_back_by(usize::MAX), Err(NonZeroUsize::new(usize::MAX - 100).unwrap()));
 }
 
 #[test]

--- a/library/core/tests/iter/range.rs
+++ b/library/core/tests/iter/range.rs
@@ -1,3 +1,4 @@
+use core::num::NonZeroUsize;
 use super::*;
 
 #[test]
@@ -287,25 +288,25 @@ fn test_range_step() {
 #[test]
 fn test_range_advance_by() {
     let mut r = 0..usize::MAX;
-    assert_eq!(0, r.advance_by(0));
-    assert_eq!(0, r.advance_back_by(0));
+    assert_eq!(Ok(()), r.advance_by(0));
+    assert_eq!(Ok(()), r.advance_back_by(0));
 
     assert_eq!(r.len(), usize::MAX);
 
-    assert_eq!(0, r.advance_by(1));
-    assert_eq!(0, r.advance_back_by(1));
+    assert_eq!(Ok(()), r.advance_by(1));
+    assert_eq!(Ok(()), r.advance_back_by(1));
 
     assert_eq!((r.start, r.end), (1, usize::MAX - 1));
 
-    assert_eq!(2, r.advance_by(usize::MAX));
+    assert_eq!(Err(NonZeroUsize::new(2).unwrap()), r.advance_by(usize::MAX));
 
-    assert_eq!(0, r.advance_by(0));
-    assert_eq!(0, r.advance_back_by(0));
+    assert_eq!(Ok(()), r.advance_by(0));
+    assert_eq!(Ok(()), r.advance_back_by(0));
 
     let mut r = 0u128..u128::MAX;
 
-    assert_eq!(0, r.advance_by(usize::MAX));
-    assert_eq!(0, r.advance_back_by(usize::MAX));
+    assert_eq!(Ok(()), r.advance_by(usize::MAX));
+    assert_eq!(Ok(()), r.advance_back_by(usize::MAX));
 
     assert_eq!((r.start, r.end), (0u128 + usize::MAX as u128, u128::MAX - usize::MAX as u128));
 }

--- a/library/core/tests/iter/range.rs
+++ b/library/core/tests/iter/range.rs
@@ -287,25 +287,25 @@ fn test_range_step() {
 #[test]
 fn test_range_advance_by() {
     let mut r = 0..usize::MAX;
-    r.advance_by(0).unwrap();
-    r.advance_back_by(0).unwrap();
+    assert_eq!(0, r.advance_by(0));
+    assert_eq!(0, r.advance_back_by(0));
 
     assert_eq!(r.len(), usize::MAX);
 
-    r.advance_by(1).unwrap();
-    r.advance_back_by(1).unwrap();
+    assert_eq!(0, r.advance_by(1));
+    assert_eq!(0, r.advance_back_by(1));
 
     assert_eq!((r.start, r.end), (1, usize::MAX - 1));
 
-    assert_eq!(r.advance_by(usize::MAX), Err(usize::MAX - 2));
+    assert_eq!(2, r.advance_by(usize::MAX));
 
-    r.advance_by(0).unwrap();
-    r.advance_back_by(0).unwrap();
+    assert_eq!(0, r.advance_by(0));
+    assert_eq!(0, r.advance_back_by(0));
 
     let mut r = 0u128..u128::MAX;
 
-    r.advance_by(usize::MAX).unwrap();
-    r.advance_back_by(usize::MAX).unwrap();
+    assert_eq!(0, r.advance_by(usize::MAX));
+    assert_eq!(0, r.advance_back_by(usize::MAX));
 
     assert_eq!((r.start, r.end), (0u128 + usize::MAX as u128, u128::MAX - usize::MAX as u128));
 }

--- a/library/core/tests/iter/traits/iterator.rs
+++ b/library/core/tests/iter/traits/iterator.rs
@@ -1,3 +1,5 @@
+use core::num::NonZeroUsize;
+
 /// A wrapper struct that implements `Eq` and `Ord` based on the wrapped
 /// integer modulo 3. Used to test that `Iterator::max` and `Iterator::min`
 /// return the correct element if some of them are equal.
@@ -148,13 +150,13 @@ fn test_iterator_advance_by() {
 
     for i in 0..v.len() {
         let mut iter = v.iter();
-        assert_eq!(iter.advance_by(i), 0);
+        assert_eq!(iter.advance_by(i), Ok(()));
         assert_eq!(iter.next().unwrap(), &v[i]);
-        assert_eq!(iter.advance_by(100), 100 - (v.len() - 1 - i));
+        assert_eq!(iter.advance_by(100), Err(NonZeroUsize::new(100 - (v.len() - 1 - i)).unwrap()));
     }
 
-    assert_eq!(v.iter().advance_by(v.len()), 0);
-    assert_eq!(v.iter().advance_by(100), 100 - v.len());
+    assert_eq!(v.iter().advance_by(v.len()), Ok(()));
+    assert_eq!(v.iter().advance_by(100), Err(NonZeroUsize::new(100 - v.len()).unwrap()));
 }
 
 #[test]
@@ -163,13 +165,13 @@ fn test_iterator_advance_back_by() {
 
     for i in 0..v.len() {
         let mut iter = v.iter();
-        assert_eq!(iter.advance_back_by(i), 0);
+        assert_eq!(iter.advance_back_by(i), Ok(()));
         assert_eq!(iter.next_back().unwrap(), &v[v.len() - 1 - i]);
-        assert_eq!(iter.advance_back_by(100), 100 - (v.len() - 1 - i));
+        assert_eq!(iter.advance_back_by(100), Err(NonZeroUsize::new(100 - (v.len() - 1 - i)).unwrap()));
     }
 
-    assert_eq!(v.iter().advance_back_by(v.len()), 0);
-    assert_eq!(v.iter().advance_back_by(100), 100 - v.len());
+    assert_eq!(v.iter().advance_back_by(v.len()), Ok(()));
+    assert_eq!(v.iter().advance_back_by(100), Err(NonZeroUsize::new(100 - v.len()).unwrap()));
 }
 
 #[test]
@@ -178,13 +180,13 @@ fn test_iterator_rev_advance_back_by() {
 
     for i in 0..v.len() {
         let mut iter = v.iter().rev();
-        assert_eq!(iter.advance_back_by(i), 0);
+        assert_eq!(iter.advance_back_by(i), Ok(()));
         assert_eq!(iter.next_back().unwrap(), &v[i]);
-        assert_eq!(iter.advance_back_by(100), 100 - (v.len() - 1 - i));
+        assert_eq!(iter.advance_back_by(100), Err(NonZeroUsize::new(100 - (v.len() - 1 - i)).unwrap()));
     }
 
-    assert_eq!(v.iter().rev().advance_back_by(v.len()), 0);
-    assert_eq!(v.iter().rev().advance_back_by(100), 100 - v.len());
+    assert_eq!(v.iter().rev().advance_back_by(v.len()), Ok(()));
+    assert_eq!(v.iter().rev().advance_back_by(100), Err(NonZeroUsize::new(100 - v.len()).unwrap()));
 }
 
 #[test]
@@ -422,13 +424,13 @@ fn test_iterator_rev_advance_by() {
 
     for i in 0..v.len() {
         let mut iter = v.iter().rev();
-        assert_eq!(iter.advance_by(i), 0);
+        assert_eq!(iter.advance_by(i), Ok(()));
         assert_eq!(iter.next().unwrap(), &v[v.len() - 1 - i]);
-        assert_eq!(iter.advance_by(100), 100 - (v.len() - 1 - i));
+        assert_eq!(iter.advance_by(100), Err(NonZeroUsize::new(100 - (v.len() - 1 - i)).unwrap()));
     }
 
-    assert_eq!(v.iter().rev().advance_by(v.len()), 0);
-    assert_eq!(v.iter().rev().advance_by(100), 100 - v.len());
+    assert_eq!(v.iter().rev().advance_by(v.len()), Ok(()));
+    assert_eq!(v.iter().rev().advance_by(100), Err(NonZeroUsize::new(100 - v.len()).unwrap()));
 }
 
 #[test]

--- a/library/core/tests/iter/traits/iterator.rs
+++ b/library/core/tests/iter/traits/iterator.rs
@@ -148,13 +148,13 @@ fn test_iterator_advance_by() {
 
     for i in 0..v.len() {
         let mut iter = v.iter();
-        assert_eq!(iter.advance_by(i), Ok(()));
+        assert_eq!(iter.advance_by(i), 0);
         assert_eq!(iter.next().unwrap(), &v[i]);
-        assert_eq!(iter.advance_by(100), Err(v.len() - 1 - i));
+        assert_eq!(iter.advance_by(100), 100 - (v.len() - 1 - i));
     }
 
-    assert_eq!(v.iter().advance_by(v.len()), Ok(()));
-    assert_eq!(v.iter().advance_by(100), Err(v.len()));
+    assert_eq!(v.iter().advance_by(v.len()), 0);
+    assert_eq!(v.iter().advance_by(100), 100 - v.len());
 }
 
 #[test]
@@ -163,13 +163,13 @@ fn test_iterator_advance_back_by() {
 
     for i in 0..v.len() {
         let mut iter = v.iter();
-        assert_eq!(iter.advance_back_by(i), Ok(()));
+        assert_eq!(iter.advance_back_by(i), 0);
         assert_eq!(iter.next_back().unwrap(), &v[v.len() - 1 - i]);
-        assert_eq!(iter.advance_back_by(100), Err(v.len() - 1 - i));
+        assert_eq!(iter.advance_back_by(100), 100 - (v.len() - 1 - i));
     }
 
-    assert_eq!(v.iter().advance_back_by(v.len()), Ok(()));
-    assert_eq!(v.iter().advance_back_by(100), Err(v.len()));
+    assert_eq!(v.iter().advance_back_by(v.len()), 0);
+    assert_eq!(v.iter().advance_back_by(100), 100 - v.len());
 }
 
 #[test]
@@ -178,13 +178,13 @@ fn test_iterator_rev_advance_back_by() {
 
     for i in 0..v.len() {
         let mut iter = v.iter().rev();
-        assert_eq!(iter.advance_back_by(i), Ok(()));
+        assert_eq!(iter.advance_back_by(i), 0);
         assert_eq!(iter.next_back().unwrap(), &v[i]);
-        assert_eq!(iter.advance_back_by(100), Err(v.len() - 1 - i));
+        assert_eq!(iter.advance_back_by(100), 100 - (v.len() - 1 - i));
     }
 
-    assert_eq!(v.iter().rev().advance_back_by(v.len()), Ok(()));
-    assert_eq!(v.iter().rev().advance_back_by(100), Err(v.len()));
+    assert_eq!(v.iter().rev().advance_back_by(v.len()), 0);
+    assert_eq!(v.iter().rev().advance_back_by(100), 100 - v.len());
 }
 
 #[test]
@@ -422,13 +422,13 @@ fn test_iterator_rev_advance_by() {
 
     for i in 0..v.len() {
         let mut iter = v.iter().rev();
-        assert_eq!(iter.advance_by(i), Ok(()));
+        assert_eq!(iter.advance_by(i), 0);
         assert_eq!(iter.next().unwrap(), &v[v.len() - 1 - i]);
-        assert_eq!(iter.advance_by(100), Err(v.len() - 1 - i));
+        assert_eq!(iter.advance_by(100), 100 - (v.len() - 1 - i));
     }
 
-    assert_eq!(v.iter().rev().advance_by(v.len()), Ok(()));
-    assert_eq!(v.iter().rev().advance_by(100), Err(v.len()));
+    assert_eq!(v.iter().rev().advance_by(v.len()), 0);
+    assert_eq!(v.iter().rev().advance_by(100), 100 - v.len());
 }
 
 #[test]

--- a/library/core/tests/slice.rs
+++ b/library/core/tests/slice.rs
@@ -142,20 +142,20 @@ fn test_iterator_advance_by() {
 
     for i in 0..=v.len() {
         let mut iter = v.iter();
-        iter.advance_by(i).unwrap();
+        assert_eq!(iter.advance_by(i), 0);
         assert_eq!(iter.as_slice(), &v[i..]);
     }
 
     let mut iter = v.iter();
-    assert_eq!(iter.advance_by(v.len() + 1), Err(v.len()));
+    assert_eq!(iter.advance_by(v.len() + 1), 1);
     assert_eq!(iter.as_slice(), &[]);
 
     let mut iter = v.iter();
-    iter.advance_by(3).unwrap();
+    assert_eq!(iter.advance_by(3), 0);
     assert_eq!(iter.as_slice(), &v[3..]);
-    iter.advance_by(2).unwrap();
+    assert_eq!(iter.advance_by(2), 0);
     assert_eq!(iter.as_slice(), &[]);
-    iter.advance_by(0).unwrap();
+    assert_eq!(iter.advance_by(0), 0);
 }
 
 #[test]
@@ -164,20 +164,20 @@ fn test_iterator_advance_back_by() {
 
     for i in 0..=v.len() {
         let mut iter = v.iter();
-        iter.advance_back_by(i).unwrap();
+        assert_eq!(iter.advance_back_by(i), 0);
         assert_eq!(iter.as_slice(), &v[..v.len() - i]);
     }
 
     let mut iter = v.iter();
-    assert_eq!(iter.advance_back_by(v.len() + 1), Err(v.len()));
+    assert_eq!(iter.advance_back_by(v.len() + 1), 1);
     assert_eq!(iter.as_slice(), &[]);
 
     let mut iter = v.iter();
-    iter.advance_back_by(3).unwrap();
+    assert_eq!(iter.advance_back_by(3), 0);
     assert_eq!(iter.as_slice(), &v[..v.len() - 3]);
-    iter.advance_back_by(2).unwrap();
+    assert_eq!(iter.advance_back_by(2), 0);
     assert_eq!(iter.as_slice(), &[]);
-    iter.advance_back_by(0).unwrap();
+    assert_eq!(iter.advance_back_by(0), 0);
 }
 
 #[test]

--- a/library/core/tests/slice.rs
+++ b/library/core/tests/slice.rs
@@ -1,6 +1,7 @@
 use core::cell::Cell;
 use core::cmp::Ordering;
 use core::mem::MaybeUninit;
+use core::num::NonZeroUsize;
 use core::result::Result::{Err, Ok};
 use core::slice;
 
@@ -142,20 +143,20 @@ fn test_iterator_advance_by() {
 
     for i in 0..=v.len() {
         let mut iter = v.iter();
-        assert_eq!(iter.advance_by(i), 0);
+        assert_eq!(iter.advance_by(i), Ok(()));
         assert_eq!(iter.as_slice(), &v[i..]);
     }
 
     let mut iter = v.iter();
-    assert_eq!(iter.advance_by(v.len() + 1), 1);
+    assert_eq!(iter.advance_by(v.len() + 1), Err(NonZeroUsize::new(1).unwrap()));
     assert_eq!(iter.as_slice(), &[]);
 
     let mut iter = v.iter();
-    assert_eq!(iter.advance_by(3), 0);
+    assert_eq!(iter.advance_by(3), Ok(()));
     assert_eq!(iter.as_slice(), &v[3..]);
-    assert_eq!(iter.advance_by(2), 0);
+    assert_eq!(iter.advance_by(2), Ok(()));
     assert_eq!(iter.as_slice(), &[]);
-    assert_eq!(iter.advance_by(0), 0);
+    assert_eq!(iter.advance_by(0), Ok(()));
 }
 
 #[test]
@@ -164,20 +165,20 @@ fn test_iterator_advance_back_by() {
 
     for i in 0..=v.len() {
         let mut iter = v.iter();
-        assert_eq!(iter.advance_back_by(i), 0);
+        assert_eq!(iter.advance_back_by(i), Ok(()));
         assert_eq!(iter.as_slice(), &v[..v.len() - i]);
     }
 
     let mut iter = v.iter();
-    assert_eq!(iter.advance_back_by(v.len() + 1), 1);
+    assert_eq!(iter.advance_back_by(v.len() + 1), Err(NonZeroUsize::new(1).unwrap()));
     assert_eq!(iter.as_slice(), &[]);
 
     let mut iter = v.iter();
-    assert_eq!(iter.advance_back_by(3), 0);
+    assert_eq!(iter.advance_back_by(3), Ok(()));
     assert_eq!(iter.as_slice(), &v[..v.len() - 3]);
-    assert_eq!(iter.advance_back_by(2), 0);
+    assert_eq!(iter.advance_back_by(2), Ok(()));
     assert_eq!(iter.as_slice(), &[]);
-    assert_eq!(iter.advance_back_by(0), 0);
+    assert_eq!(iter.advance_back_by(0), Ok(()));
 }
 
 #[test]


### PR DESCRIPTION
When advance_by can't advance the iterator by the number of requested elements it now returns the amount by which it couldn't be advanced instead of the amount by which it did.

This simplifies adapters like chain, flatten or cycle because the remainder doesn't have to be calculated as the difference between requested steps and completed steps anymore.

Additionally switching from `Result<(), usize>` to `Result<(), NonZeroUsize>` reduces the size of the result and makes converting from/to a usize representing the number of remaining steps cheap.