### PR TITLE
Rustdoc: allocate less when working with fully qualified paths

### DIFF
--- a/src/librustdoc/html/render/cache.rs
+++ b/src/librustdoc/html/render/cache.rs
@@ -38,7 +38,7 @@ crate fn build_index<'tcx>(krate: &clean::Crate, cache: &mut Cache, tcx: TyCtxt<
             cache.search_index.push(IndexItem {
                 ty: item.type_(),
                 name: item.name.unwrap().to_string(),
-                path: fqp[..fqp.len() - 1].join("::"),
+                path: String::from(fqp.parent().as_str()),
                 desc,
                 parent: Some(did),
                 parent_idx: None,
@@ -90,7 +90,7 @@ crate fn build_index<'tcx>(krate: &clean::Crate, cache: &mut Cache, tcx: TyCtxt<
                     lastpathid += 1;
 
                     if let Some(&(ref fqp, short)) = paths.get(&defid) {
-                        crate_paths.push((short, fqp.last().unwrap().clone()));
+                        crate_paths.push((short, String::from(fqp.iter().last())));
                         Some(pathid)
                     } else {
                         None

--- a/src/librustdoc/html/render/context.rs
+++ b/src/librustdoc/html/render/context.rs
@@ -228,11 +228,11 @@ impl<'tcx> Context<'tcx> {
         } else {
             if let Some(&(ref names, ty)) = self.cache().paths.get(&it.def_id.expect_def_id()) {
                 let mut path = String::new();
-                for name in &names[..names.len() - 1] {
+                for name in names.parent().iter_paths() {
                     path.push_str(name);
                     path.push('/');
                 }
-                path.push_str(&item_path(ty, names.last().unwrap()));
+                path.push_str(&item_path(ty, names.iter().last()));
                 match self.shared.redirections {
                     Some(ref redirections) => {
                         let mut current_path = String::new();
@@ -240,7 +240,7 @@ impl<'tcx> Context<'tcx> {
                             current_path.push_str(name);
                             current_path.push('/');
                         }
-                        current_path.push_str(&item_path(ty, names.last().unwrap()));
+                        current_path.push_str(&item_path(ty, names.iter().last()));
                         redirections.borrow_mut().insert(current_path, path);
                     }
                     None => return layout::redirect(&format!("{}{}", self.root_path(), path)),

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -2512,11 +2512,11 @@ fn collect_paths_for_type(first_ty: clean::Type, cache: &Cache) -> Vec<String> {
     let mut work = VecDeque::new();
 
     let mut process_path = |did: DefId| {
-        let get_extern = || cache.external_paths.get(&did).map(|s| s.0.clone());
-        let fqp = cache.exact_paths.get(&did).cloned().or_else(get_extern);
+        let get_extern = || cache.external_paths.get(&did).map(|s| &s.0);
+        let fqp = cache.exact_paths.get(&did).or_else(get_extern);
 
-        if let Some(path) = fqp {
-            out.push(path.join("::"));
+        if let Some(fqp) = fqp {
+            out.push(String::from(fqp.as_str()));
         }
     };
 

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -32,6 +32,7 @@ use crate::html::highlight;
 use crate::html::layout::Page;
 use crate::html::markdown::{HeadingOffset, MarkdownSummaryLine};
 
+use crate::clean::inline::join_paths;
 use serde::Serialize;
 
 const ITEM_TABLE_OPEN: &str = "<div class=\"item-table\">";
@@ -874,7 +875,7 @@ fn item_trait(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, t: &clean::Tra
             cx.current.join("/")
         } else {
             let (ref path, _) = cache.external_paths[&it.def_id.expect_def_id()];
-            path[..path.len() - 1].join("/")
+            join_paths(path.parent().iter_paths(), "/")
         },
         ty = it.type_(),
         name = *it.name.as_ref().unwrap()

--- a/src/librustdoc/html/render/write_shared.rs
+++ b/src/librustdoc/html/render/write_shared.rs
@@ -568,11 +568,11 @@ pub(super) fn write_shared(
         );
 
         let mut mydst = dst.clone();
-        for part in &remote_path[..remote_path.len() - 1] {
+        for part in remote_path.parent().iter_paths() {
             mydst.push(part);
         }
         cx.shared.ensure_dir(&mydst)?;
-        mydst.push(&format!("{}.{}.js", remote_item_type, remote_path[remote_path.len() - 1]));
+        mydst.push(&format!("{}.{}.js", remote_item_type, remote_path.iter().last()));
 
         let (mut all_implementors, _) =
             try_err!(collect(&mydst, krate.name(cx.tcx()).as_str(), "implementors"), &mydst);

--- a/src/librustdoc/html/tests.rs
+++ b/src/librustdoc/html/tests.rs
@@ -1,9 +1,12 @@
+use crate::clean::inline::FullyQualifiedName;
 use crate::html::format::href_relative_parts;
 
 fn assert_relative_path(expected: &str, relative_to_fqp: &[&str], fqp: &[&str]) {
     let relative_to_fqp: Vec<String> = relative_to_fqp.iter().copied().map(String::from).collect();
     let fqp: Vec<String> = fqp.iter().copied().map(String::from).collect();
-    assert_eq!(expected, href_relative_parts(&fqp, &relative_to_fqp).finish());
+
+    let fqp = FullyQualifiedName::from_paths(&fqp);
+    assert_eq!(expected, href_relative_parts(fqp.iter(), &relative_to_fqp).finish());
 }
 
 #[test]

--- a/src/librustdoc/json/mod.rs
+++ b/src/librustdoc/json/mod.rs
@@ -109,19 +109,20 @@ impl JsonRenderer<'tcx> {
                         types::Item {
                             id: from_item_id(id.into()),
                             crate_id: id.krate.as_u32(),
-                            name: self
-                                .cache
-                                .paths
-                                .get(&id)
-                                .unwrap_or_else(|| {
-                                    self.cache
-                                        .external_paths
-                                        .get(&id)
-                                        .expect("Trait should either be in local or external paths")
-                                })
-                                .0
-                                .last()
-                                .map(Clone::clone),
+                            name: Some(
+                                self.cache
+                                    .paths
+                                    .get(&id)
+                                    .unwrap_or_else(|| {
+                                        self.cache.external_paths.get(&id).expect(
+                                            "Trait should either be in local or external paths",
+                                        )
+                                    })
+                                    .0
+                                    .iter()
+                                    .last()
+                                    .to_string(),
+                            ),
                             visibility: types::Visibility::Public,
                             inner: types::ItemEnum::Trait(trait_item.clone().into_tcx(self.tcx)),
                             span: None,
@@ -231,7 +232,7 @@ impl<'tcx> FormatRenderer<'tcx> for JsonRenderer<'tcx> {
                         from_item_id(k.into()),
                         types::ItemSummary {
                             crate_id: k.krate.as_u32(),
-                            path,
+                            path: path.to_parts(),
                             kind: kind.into_tcx(self.tcx),
                         },
                     )


### PR DESCRIPTION
I noticed that `rustdoc` allocates quite a lot when working with fully qualified paths, since it represents them as `Vec<String>`. I tried to reduce the amount of allocations by changing the representation to a `String` where the individual parts are separated with `::`.

The results have been a bit disappointing locally, but since I already implemented it, I also wanted to check perf on CI.

r? rust-lang/rustdoc