### PR TITLE
Inline DefId hash implementation

### DIFF
--- a/compiler/rustc_span/src/def_id.rs
+++ b/compiler/rustc_span/src/def_id.rs
@@ -247,6 +247,7 @@ pub struct DefId {
 // faster than another `FxHash` round.
 #[cfg(target_pointer_width = "64")]
 impl Hash for DefId {
+    #[inline]
     fn hash<H: Hasher>(&self, h: &mut H) {
         (((self.krate.as_u32() as u64) << 32) | (self.index.as_u32() as u64)).hash(h)
     }


### PR DESCRIPTION
`DefId` recently got a new `Hash` implementation (https://github.com/rust-lang/rust/pull/91660). I noticed in profiles that the function was not being inlined. Locally it produced some small gains when I inlined it.