### PR TITLE
mips64-openwrt-linux-musl: Add Tier 3 target

### DIFF
--- a/compiler/rustc_target/src/spec/mips64_openwrt_linux_musl.rs
+++ b/compiler/rustc_target/src/spec/mips64_openwrt_linux_musl.rs
@@ -1,0 +1,26 @@
+/// A target tuple for OpenWrt MIPS64 targets
+///
+use crate::abi::Endian;
+use crate::spec::{Target, TargetOptions};
+
+pub fn target() -> Target {
+    let mut base = super::linux_musl_base::opts();
+    base.cpu = "mips64r2".to_string();
+    base.features = "+mips64r2".to_string();
+    base.max_atomic_width = Some(64);
+    base.crt_static_default = false;
+
+    Target {
+        // LLVM doesn't recognize "muslabi64" yet.
+        llvm_target: "mips64-unknown-linux-musl".to_string(),
+        pointer_width: 64,
+        data_layout: "E-m:e-i8:8:32-i16:16:32-i64:64-n32:64-S128".to_string(),
+        arch: "mips64".to_string(),
+        options: TargetOptions {
+            abi: "abi64".to_string(),
+            endian: Endian::Big,
+            mcount: "_mcount".to_string(),
+            ..base
+        },
+    }
+}

--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -1016,6 +1016,8 @@ supported_targets! {
     ("armv7-unknown-linux-uclibceabihf", armv7_unknown_linux_uclibceabihf),
 
     ("x86_64-unknown-none", x86_64_unknown_none),
+
+    ("mips64-openwrt-linux-musl", mips64_openwrt_linux_musl),
 }
 
 /// Warnings encountered when parsing the target `json`.

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -244,6 +244,7 @@ target | std | host | notes
 `i686-wrs-vxworks` | ? |  |
 `m68k-unknown-linux-gnu` | ? |  | Motorola 680x0 Linux
 `mips-unknown-linux-uclibc` | ✓ |  | MIPS Linux with uClibc
+`mips64-openwrt-linux-musl` | ? |  | MIPS64 for OpenWrt Linux MUSL
 `mipsel-sony-psp` | * |  | MIPS (LE) Sony PlayStation Portable (PSP)
 `mipsel-unknown-linux-uclibc` | ✓ |  | MIPS (LE) Linux with uClibc
 `mipsel-unknown-none` | * |  | Bare MIPS (LE) softfloat

--- a/src/doc/rustc/src/platform-support/mips64-openwrt-linux-musl.md
+++ b/src/doc/rustc/src/platform-support/mips64-openwrt-linux-musl.md
@@ -1,0 +1,28 @@
+# `mips64-openwrt-linux-musl`
+**Tier: 3**
+
+## Target maintainers
+- Donald Hoskins `grommish@gmail.com`, https://github.com/Itus-Shield
+
+## Requirements
+This target is cross-compiled. There is no support for `std`. There is no
+default allocator, but it's possible to use `alloc` by supplying an allocator.
+
+By default, Rust code generated for this target uses `-msoft-float` and is
+dynamically linked.
+
+This target generated binaries in the ELF format.
+
+## Building the target
+This target is built exclusively within the `OpenWrt` build system via
+the `rust-lang` HOST package
+
+## Building Rust programs
+Rust does not yet ship pre-compiled artifacts for this target. To compile for
+this target, you will either need to build Rust with the target enabled (see
+"Building the target" above).
+
+## Testing
+As `mips64-openwrt-linux-musl` supports a variety of different environments and does
+not support `std`, this target does not support running the Rust testsuite at this
+time.


### PR DESCRIPTION
Tier 3 tuple for Mips64 OpenWrt toolchain.

This add first-time support for OpenWrt.  Future Tier3 targets will be added as I test them.

Signed-off-by: Donald Hoskins <grommish@gmail.com>