### PR TITLE
Improve opaque type higher-ranked region error message under NLL

### DIFF
--- a/compiler/rustc_borrowck/src/lib.rs
+++ b/compiler/rustc_borrowck/src/lib.rs
@@ -5,6 +5,7 @@
 #![feature(crate_visibility_modifier)]
 #![feature(let_else)]
 #![feature(min_specialization)]
+#![feature(never_type)]
 #![feature(stmt_expr_attributes)]
 #![feature(trusted_step)]
 #![feature(try_blocks)]

--- a/compiler/rustc_borrowck/src/region_infer/mod.rs
+++ b/compiler/rustc_borrowck/src/region_infer/mod.rs
@@ -44,6 +44,7 @@ mod reverse_sccs;
 pub mod values;
 
 pub struct RegionInferenceContext<'tcx> {
+    pub var_infos: VarInfos,
     /// Contains the definition for every region variable. Region
     /// variables are identified by their index (`RegionVid`). The
     /// definition contains information about where the region came
@@ -266,7 +267,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
     ) -> Self {
         // Create a RegionDefinition for each inference variable.
         let definitions: IndexVec<_, _> = var_infos
-            .into_iter()
+            .iter()
             .map(|info| RegionDefinition::new(info.universe, info.origin))
             .collect();
 
@@ -291,6 +292,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
             Rc::new(member_constraints_in.into_mapped(|r| constraint_sccs.scc(r)));
 
         let mut result = Self {
+            var_infos,
             definitions,
             liveness_constraints,
             constraints,

--- a/compiler/rustc_borrowck/src/type_check/free_region_relations.rs
+++ b/compiler/rustc_borrowck/src/type_check/free_region_relations.rs
@@ -268,7 +268,7 @@ impl<'tcx> UniversalRegionRelationsBuilder<'_, 'tcx> {
                         TypeOpOutput {
                             output: self.infcx.tcx.ty_error(),
                             constraints: None,
-                            canonicalized_query: None,
+                            error_info: None,
                         }
                     });
                 // Note: we need this in examples like

--- a/compiler/rustc_infer/src/lib.rs
+++ b/compiler/rustc_infer/src/lib.rs
@@ -22,6 +22,7 @@
 #![feature(control_flow_enum)]
 #![feature(min_specialization)]
 #![feature(label_break_value)]
+#![feature(backtrace)]
 #![recursion_limit = "512"] // For rustdoc
 #![cfg_attr(not(bootstrap), allow(rustc::potential_query_instability))]
 

--- a/compiler/rustc_trait_selection/src/traits/query/type_op/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/query/type_op/mod.rs
@@ -28,6 +28,7 @@ pub use rustc_middle::traits::query::type_op::*;
 /// cannot be completed).
 pub trait TypeOp<'tcx>: Sized + fmt::Debug {
     type Output;
+    type ErrorInfo;
 
     /// Processes the operation and all resulting obligations,
     /// returning the final result along with any region constraints
@@ -41,9 +42,8 @@ pub struct TypeOpOutput<'tcx, Op: TypeOp<'tcx>> {
     pub output: Op::Output,
     /// Any region constraints from performing the type op.
     pub constraints: Option<Rc<QueryRegionConstraints<'tcx>>>,
-    /// The canonicalized form of the query.
-    /// This for error reporting to be able to rerun the query.
-    pub canonicalized_query: Option<Canonical<'tcx, Op>>,
+    /// Used for error reporting to be able to rerun the query
+    pub error_info: Option<Op::ErrorInfo>,
 }
 
 /// "Query type ops" are type ops that are implemented using a
@@ -119,10 +119,11 @@ where
     Q: QueryTypeOp<'tcx>,
 {
     type Output = Q::QueryResponse;
+    type ErrorInfo = Canonical<'tcx, ParamEnvAnd<'tcx, Q>>;
 
     fn fully_perform(self, infcx: &InferCtxt<'_, 'tcx>) -> Fallible<TypeOpOutput<'tcx, Self>> {
         let mut region_constraints = QueryRegionConstraints::default();
-        let (output, canonicalized_query, mut obligations, _) =
+        let (output, error_info, mut obligations, _) =
             Q::fully_perform_into(self, infcx, &mut region_constraints)?;
 
         // Typically, instantiating NLL query results does not
@@ -160,6 +161,6 @@ where
         let region_constraints =
             if region_constraints.is_empty() { None } else { Some(Rc::new(region_constraints)) };
 
-        Ok(TypeOpOutput { output, constraints: region_constraints, canonicalized_query })
+        Ok(TypeOpOutput { output, constraints: region_constraints, error_info })
     }
 }

--- a/src/test/ui/impl-trait/issues/issue-88236-2.nll.stderr
+++ b/src/test/ui/impl-trait/issues/issue-88236-2.nll.stderr
@@ -1,14 +1,20 @@
-error: higher-ranked subtype error
+error: implementation of `Hrtb` is not general enough
   --> $DIR/issue-88236-2.rs:17:5
    |
 LL |     &()
-   |     ^^^
+   |     ^^^ implementation of `Hrtb` is not general enough
+   |
+   = note: `Hrtb<'0>` would have to be implemented for the type `&()`, for any lifetime `'0`...
+   = note: ...but `Hrtb<'1>` is actually implemented for the type `&'1 ()`, for some specific lifetime `'1`
 
-error: higher-ranked subtype error
+error: implementation of `Hrtb` is not general enough
   --> $DIR/issue-88236-2.rs:17:5
    |
 LL |     &()
-   |     ^^^
+   |     ^^^ implementation of `Hrtb` is not general enough
+   |
+   = note: `Hrtb<'0>` would have to be implemented for the type `&()`, for any lifetime `'0`...
+   = note: ...but `Hrtb<'1>` is actually implemented for the type `&'1 ()`, for some specific lifetime `'1`
 
 error: lifetime may not live long enough
   --> $DIR/issue-88236-2.rs:20:5
@@ -23,17 +29,23 @@ help: to allow this `impl Trait` to capture borrowed data with lifetime `'b`, ad
 LL | fn make_bad_impl<'b>(x: &'b ()) -> impl for<'a> Hrtb<'a, Assoc = impl Send + 'a> + 'b {
    |                                                                                  ++++
 
-error: higher-ranked subtype error
+error: implementation of `Hrtb` is not general enough
   --> $DIR/issue-88236-2.rs:20:5
    |
 LL |     x
-   |     ^
+   |     ^ implementation of `Hrtb` is not general enough
+   |
+   = note: `Hrtb<'0>` would have to be implemented for the type `&()`, for any lifetime `'0`...
+   = note: ...but `Hrtb<'1>` is actually implemented for the type `&'1 ()`, for some specific lifetime `'1`
 
-error: higher-ranked subtype error
+error: implementation of `Hrtb` is not general enough
   --> $DIR/issue-88236-2.rs:20:5
    |
 LL |     x
-   |     ^
+   |     ^ implementation of `Hrtb` is not general enough
+   |
+   = note: `Hrtb<'0>` would have to be implemented for the type `&()`, for any lifetime `'0`...
+   = note: ...but `Hrtb<'1>` is actually implemented for the type `&'1 ()`, for some specific lifetime `'1`
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/nll/relate_tys/opaque-hrtb.rs
+++ b/src/test/ui/nll/relate_tys/opaque-hrtb.rs
@@ -1,0 +1,16 @@
+#![feature(nll)]
+
+trait MyTrait<T> {}
+
+struct Foo;
+impl<T> MyTrait<T> for Foo {}
+
+fn bar<Input>() -> impl MyTrait<Input> {
+    Foo
+}
+
+fn foo() -> impl for<'a> MyTrait<&'a str> {
+    bar() //~ ERROR implementation of `MyTrait` is not general enough
+}
+
+fn main() {}

--- a/src/test/ui/nll/relate_tys/opaque-hrtb.stderr
+++ b/src/test/ui/nll/relate_tys/opaque-hrtb.stderr
@@ -1,0 +1,11 @@
+error: implementation of `MyTrait` is not general enough
+  --> $DIR/opaque-hrtb.rs:13:5
+   |
+LL |     bar()
+   |     ^^^^^ implementation of `MyTrait` is not general enough
+   |
+   = note: `impl MyTrait<&'2 str>` must implement `MyTrait<&'1 str>`, for any lifetime `'1`...
+   = note: ...but it actually implements `MyTrait<&'2 str>`, for some specific lifetime `'2`
+
+error: aborting due to previous error
+

--- a/src/test/ui/type-alias-impl-trait/issue-57611-trait-alias.nll.stderr
+++ b/src/test/ui/type-alias-impl-trait/issue-57611-trait-alias.nll.stderr
@@ -1,14 +1,26 @@
-error: higher-ranked subtype error
+error[E0308]: mismatched types
+  --> $DIR/issue-57611-trait-alias.rs:20:9
+   |
+LL |         |x| x
+   |         ^^^^^ one type is more general than the other
+   |
+   = note: expected type `for<'r> Fn<(&'r X,)>`
+              found type `Fn<(&X,)>`
+note: this closure does not fulfill the lifetime requirements
   --> $DIR/issue-57611-trait-alias.rs:20:9
    |
 LL |         |x| x
    |         ^^^^^
 
-error: higher-ranked subtype error
+error: implementation of `FnOnce` is not general enough
   --> $DIR/issue-57611-trait-alias.rs:20:9
    |
 LL |         |x| x
-   |         ^^^^^
+   |         ^^^^^ implementation of `FnOnce` is not general enough
+   |
+   = note: closure with signature `fn(&'2 X) -> &X` must implement `FnOnce<(&'1 X,)>`, for any lifetime `'1`...
+   = note: ...but it actually implements `FnOnce<(&'2 X,)>`, for some specific lifetime `'2`
 
 error: aborting due to 2 previous errors
 
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Currently, any higher-ranked region errors involving opaque types
fall back to a generic "higher-ranked subtype error" message when
run under NLL. This PR adds better error message handling for this
case, giving us the same kinds of error messages that we currently
get without NLL:

```
error: implementation of `MyTrait` is not general enough
  --> $DIR/opaque-hrtb.rs:12:13
   |
LL | fn foo() -> impl for<'a> MyTrait<&'a str> {
   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ implementation of `MyTrait` is not general enough
   |
   = note: `impl MyTrait<&'2 str>` must implement `MyTrait<&'1 str>`, for any lifetime `'1`...
   = note: ...but it actually implements `MyTrait<&'2 str>`, for some specific lifetime `'2`

error: aborting due to previous error
```

To accomplish this, several different refactoring needed to be made:

* We now have a dedicated `InstantiateOpaqueType` struct which
implements `TypeOp`. This is used to invoke `instantiate_opaque_types`
during MIR type checking.
* `TypeOp` is refactored to pass around a `MirBorrowckCtxt`, which is
needed to report opaque type region errors.
* We no longer assume that all `TypeOp`s correspond to canonicalized
queries. This allows us to properly handle opaque type instantiation
(which does not occur in a query) as a `TypeOp`.
A new `ErrorInfo` associated type is used to determine what
additional information is used during higher-ranked region error
handling.
* The body of `try_extract_error_from_fulfill_cx`
has been moved out to a new function `try_extract_error_from_region_constraints`.
This allows us to re-use the same error reporting code between
canonicalized queries (which can extract region constraints directly
from a fresh `InferCtxt`) and opaque type handling (which needs to take
region constraints from the pre-existing `InferCtxt` that we use
throughout MIR borrow checking).