### PR TITLE
mangling_v0: Skip extern blocks during mangling

### DIFF
--- a/compiler/rustc_symbol_mangling/src/v0.rs
+++ b/compiler/rustc_symbol_mangling/src/v0.rs
@@ -771,9 +771,9 @@ impl<'tcx> Printer<'tcx> for &mut SymbolMangler<'tcx> {
         disambiguated_data: &DisambiguatedDefPathData,
     ) -> Result<Self::Path, Self::Error> {
         let ns = match disambiguated_data.data {
-            // FIXME: It shouldn't be necessary to add anything for extern block segments,
-            // but we add 't' for backward compatibility.
-            DefPathData::ForeignMod => 't',
+            // Extern block segments can be skipped, names from extern blocks
+            // are effectively living in their parent modules.
+            DefPathData::ForeignMod => return print_prefix(self),
 
             // Uppercase categories are more stable than lowercase ones.
             DefPathData::TypeNs(_) => 't',

--- a/src/test/ui/symbol-names/foreign-types.rs
+++ b/src/test/ui/symbol-names/foreign-types.rs
@@ -1,5 +1,5 @@
 // build-fail
-// compile-flags: -Z symbol-mangling-version=v0
+// compile-flags: -C symbol-mangling-version=v0
 
 #![feature(extern_types)]
 #![feature(rustc_attrs)]

--- a/src/test/ui/symbol-names/foreign-types.rs
+++ b/src/test/ui/symbol-names/foreign-types.rs
@@ -1,0 +1,19 @@
+// build-fail
+// compile-flags: -Z symbol-mangling-version=v0
+
+#![feature(extern_types)]
+#![feature(rustc_attrs)]
+
+extern "C" {
+    type ForeignType;
+}
+
+struct Check<T: ?Sized>(T);
+
+#[rustc_symbol_name]
+//~^ ERROR symbol-name(_RMCs
+//~| ERROR demangling(<foreign_types[
+//~| ERROR demangling-alt(<foreign_types::Check<foreign_types::ForeignType>>)
+impl Check<ForeignType> {}
+
+fn main() {}

--- a/src/test/ui/symbol-names/foreign-types.stderr
+++ b/src/test/ui/symbol-names/foreign-types.stderr
@@ -1,0 +1,20 @@
+error: symbol-name(_RMCsCRATE_HASH_13foreign_typesINtB<REF>_5CheckNvNtB<REF>_011ForeignTypeE)
+  --> $DIR/foreign-types.rs:13:1
+   |
+LL | #[rustc_symbol_name]
+   | ^^^^^^^^^^^^^^^^^^^^
+
+error: demangling(<foreign_types[HASH]::Check<foreign_types[HASH]::ForeignType>>)
+  --> $DIR/foreign-types.rs:13:1
+   |
+LL | #[rustc_symbol_name]
+   | ^^^^^^^^^^^^^^^^^^^^
+
+error: demangling-alt(<foreign_types::Check<foreign_types::ForeignType>>)
+  --> $DIR/foreign-types.rs:13:1
+   |
+LL | #[rustc_symbol_name]
+   | ^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 3 previous errors
+

--- a/src/test/ui/symbol-names/foreign-types.stderr
+++ b/src/test/ui/symbol-names/foreign-types.stderr
@@ -1,4 +1,4 @@
-error: symbol-name(_RMCsCRATE_HASH_13foreign_typesINtB<REF>_5CheckNvNtB<REF>_011ForeignTypeE)
+error: symbol-name(_RMCsCRATE_HASH_13foreign_typesINtB<REF>_5CheckNvB<REF>_11ForeignTypeE)
   --> $DIR/foreign-types.rs:13:1
    |
 LL | #[rustc_symbol_name]

--- a/src/tools/rust-demangler/tests/lib.rs
+++ b/src/tools/rust-demangler/tests/lib.rs
@@ -29,14 +29,14 @@ cc[4d6468d6c9fd4bb3]::spawn::{closure#0}::{closure#0}
 <core[846817f741e54dfd]::slice::Iter<u8> as core[846817f741e54dfd]::iter::iterator::Iterator>::rposition::<core[846817f741e54dfd]::slice::memchr::memrchr::{closure#1}>::{closure#0}
 alloc[f15a878b47eb696b]::alloc::box_free::<dyn alloc[f15a878b47eb696b]::boxed::FnBox<(), Output = ()>>
 INtC8arrayvec8ArrayVechKj7b_E
-<const_generic[317d481089b8c8fe]::Unsigned<11: u8>>
-<const_generic[317d481089b8c8fe]::Signed<152: i16>>
-<const_generic[317d481089b8c8fe]::Signed<-11: i8>>
-<const_generic[317d481089b8c8fe]::Bool<false: bool>>
-<const_generic[317d481089b8c8fe]::Bool<true: bool>>
-<const_generic[317d481089b8c8fe]::Char<'v': char>>
-<const_generic[317d481089b8c8fe]::Char<'\n': char>>
-<const_generic[317d481089b8c8fe]::Char<'∂': char>>
+<const_generic[317d481089b8c8fe]::Unsigned<11u8>>
+<const_generic[317d481089b8c8fe]::Signed<152i16>>
+<const_generic[317d481089b8c8fe]::Signed<-11i8>>
+<const_generic[317d481089b8c8fe]::Bool<false>>
+<const_generic[317d481089b8c8fe]::Bool<true>>
+<const_generic[317d481089b8c8fe]::Char<'v'>>
+<const_generic[317d481089b8c8fe]::Char<'\n'>>
+<const_generic[317d481089b8c8fe]::Char<'∂'>>
 <const_generic[317d481089b8c8fe]::Foo<_>>::foo::FOO
 foo[0]
 foo[0]
@@ -51,14 +51,14 @@ cc::spawn::{closure#0}::{closure#0}
 <core::slice::Iter<u8> as core::iter::iterator::Iterator>::rposition::<core::slice::memchr::memrchr::{closure#1}>::{closure#0}
 alloc::alloc::box_free::<dyn alloc::boxed::FnBox<(), Output = ()>>
 INtC8arrayvec8ArrayVechKj7b_E
-<const_generic::Unsigned<11: u8>>
-<const_generic::Signed<152: i16>>
-<const_generic::Signed<-11: i8>>
-<const_generic::Bool<false: bool>>
-<const_generic::Bool<true: bool>>
-<const_generic::Char<'v': char>>
-<const_generic::Char<'\n': char>>
-<const_generic::Char<'∂': char>>
+<const_generic::Unsigned<11u8>>
+<const_generic::Signed<152i16>>
+<const_generic::Signed<-11i8>>
+<const_generic::Bool<false>>
+<const_generic::Bool<true>>
+<const_generic::Char<'v'>>
+<const_generic::Char<'\n'>>
+<const_generic::Char<'∂'>>
 <const_generic::Foo<_>>::foo::FOO
 foo[0]
 foo[0]


### PR DESCRIPTION
There's no need to include the dummy `Nt` into the symbol name, items in extern blocks belong to their parent modules for all purposes except for inheriting the ABI and attributes.

Follow up to https://github.com/rust-lang/rust/pull/92032

(There's also a drive-by fix to the `rust-demangler` tool's tests, which don't run on CI, I initially attempted using them for testing this PR.)