### PR TITLE
Sort MonoItems by span instead of DefIndex.

### DIFF
--- a/src/test/assembly/asm/avr-types.rs
+++ b/src/test/assembly/asm/avr-types.rs
@@ -30,50 +30,6 @@ impl Copy for i32 {}
 impl Copy for i64 {}
 impl Copy for ptr {}
 
-macro_rules! check {
-    ($func:ident $ty:ident $class:ident) => {
-        #[no_mangle]
-        pub unsafe fn $func(x: $ty) -> $ty {
-            let y;
-            asm!("mov {}, {}", lateout($class) y, in($class) x);
-            y
-        }
-    };
-}
-
-macro_rules! checkw {
-    ($func:ident $ty:ident $class:ident) => {
-        #[no_mangle]
-        pub unsafe fn $func(x: $ty) -> $ty {
-            let y;
-            asm!("movw {}, {}", lateout($class) y, in($class) x);
-            y
-        }
-    };
-}
-
-macro_rules! check_reg {
-    ($func:ident $ty:ident $reg:tt) => {
-        #[no_mangle]
-        pub unsafe fn $func(x: $ty) -> $ty {
-            let y;
-            asm!(concat!("mov ", $reg, ", ", $reg), lateout($reg) y, in($reg) x);
-            y
-        }
-    };
-}
-
-macro_rules! check_regw {
-    ($func:ident $ty:ident $reg:tt $reg_lit:tt) => {
-        #[no_mangle]
-        pub unsafe fn $func(x: $ty) -> $ty {
-            let y;
-            asm!(concat!("movw ", $reg_lit, ", ", $reg_lit), lateout($reg) y, in($reg) x);
-            y
-        }
-    };
-}
-
 extern "C" {
     fn extern_func();
     static extern_static: i8;
@@ -161,6 +117,17 @@ pub unsafe fn muls_clobber(x: i8, y: i8) -> i16 {
     z
 }
 
+macro_rules! check {
+    ($func:ident $ty:ident $class:ident) => {
+        #[no_mangle]
+        pub unsafe fn $func(x: $ty) -> $ty {
+            let y;
+            asm!("mov {}, {}", lateout($class) y, in($class) x);
+            y
+        }
+    };
+}
+
 // CHECK-LABEL: reg_i8:
 // CHECK: ;APP
 // CHECK: mov r{{[0-9]+}}, r{{[0-9]+}}
@@ -172,6 +139,17 @@ check!(reg_i8 i8 reg);
 // CHECK: mov r{{[1-3][0-9]}}, r{{[1-3][0-9]}}
 // CHECK: ;NO_APP
 check!(reg_upper_i8 i8 reg_upper);
+
+macro_rules! checkw {
+    ($func:ident $ty:ident $class:ident) => {
+        #[no_mangle]
+        pub unsafe fn $func(x: $ty) -> $ty {
+            let y;
+            asm!("movw {}, {}", lateout($class) y, in($class) x);
+            y
+        }
+    };
+}
 
 // CHECK-LABEL: reg_pair_i16:
 // CHECK: ;APP
@@ -191,6 +169,17 @@ checkw!(reg_iw_i16 i16 reg_iw);
 // CHECK: ;NO_APP
 checkw!(reg_ptr_i16 i16 reg_ptr);
 
+macro_rules! check_reg {
+    ($func:ident $ty:ident $reg:tt) => {
+        #[no_mangle]
+        pub unsafe fn $func(x: $ty) -> $ty {
+            let y;
+            asm!(concat!("mov ", $reg, ", ", $reg), lateout($reg) y, in($reg) x);
+            y
+        }
+    };
+}
+
 // CHECK-LABEL: r2_i8:
 // CHECK: ;APP
 // CHECK: mov r2, r2
@@ -208,6 +197,17 @@ check_reg!(xl_i8 i8 "XL");
 // CHECK: mov r27, r27
 // CHECK: ;NO_APP
 check_reg!(xh_i8 i8 "XH");
+
+macro_rules! check_regw {
+    ($func:ident $ty:ident $reg:tt $reg_lit:tt) => {
+        #[no_mangle]
+        pub unsafe fn $func(x: $ty) -> $ty {
+            let y;
+            asm!(concat!("movw ", $reg_lit, ", ", $reg_lit), lateout($reg) y, in($reg) x);
+            y
+        }
+    };
+}
 
 // CHECK-LABEL: x_i16:
 // CHECK: ;APP

--- a/src/test/assembly/asm/bpf-types.rs
+++ b/src/test/assembly/asm/bpf-types.rs
@@ -34,28 +34,6 @@ impl Copy for i32 {}
 impl Copy for i64 {}
 impl Copy for ptr {}
 
-macro_rules! check {
-    ($func:ident $ty:ident $class:ident) => {
-        #[no_mangle]
-        pub unsafe fn $func(x: $ty) -> $ty {
-            let y;
-            asm!("{} = {}", out($class) y, in($class) x);
-            y
-        }
-    };
-}
-
-macro_rules! check_reg {
-    ($func:ident $ty:ident $reg:tt) => {
-        #[no_mangle]
-        pub unsafe fn $func(x: $ty) -> $ty {
-            let y;
-            asm!(concat!($reg, " = ", $reg), lateout($reg) y, in($reg) x);
-            y
-        }
-    };
-}
-
 extern "C" {
     fn extern_func();
 }
@@ -67,6 +45,17 @@ extern "C" {
 #[no_mangle]
 pub unsafe fn sym_fn() {
     asm!("call {}", sym extern_func);
+}
+
+macro_rules! check {
+    ($func:ident $ty:ident $class:ident) => {
+        #[no_mangle]
+        pub unsafe fn $func(x: $ty) -> $ty {
+            let y;
+            asm!("{} = {}", out($class) y, in($class) x);
+            y
+        }
+    };
 }
 
 // CHECK-LABEL: reg_i8:
@@ -110,6 +99,17 @@ check!(wreg_i16 i16 wreg);
 // CHECK: w{{[0-9]+}} = w{{[0-9]+}}
 // CHECK: #NO_APP
 check!(wreg_i32 i32 wreg);
+
+macro_rules! check_reg {
+    ($func:ident $ty:ident $reg:tt) => {
+        #[no_mangle]
+        pub unsafe fn $func(x: $ty) -> $ty {
+            let y;
+            asm!(concat!($reg, " = ", $reg), lateout($reg) y, in($reg) x);
+            y
+        }
+    };
+}
 
 // CHECK-LABEL: r0_i8:
 // CHECK: #APP

--- a/src/test/assembly/asm/hexagon-types.rs
+++ b/src/test/assembly/asm/hexagon-types.rs
@@ -37,40 +37,6 @@ extern "C" {
     static extern_static: u8;
 }
 
-macro_rules! check {
-    ($func:ident $ty:ident $class:ident) => {
-        #[no_mangle]
-        pub unsafe fn $func(x: $ty) -> $ty {
-            // Hack to avoid function merging
-            extern "Rust" {
-                fn dont_merge(s: &str);
-            }
-            dont_merge(stringify!($func));
-
-            let y;
-            asm!("{} = {}", out($class) y, in($class) x);
-            y
-        }
-    };
-}
-
-macro_rules! check_reg {
-    ($func:ident $ty:ident $reg:tt) => {
-        #[no_mangle]
-        pub unsafe fn $func(x: $ty) -> $ty {
-            // Hack to avoid function merging
-            extern "Rust" {
-                fn dont_merge(s: &str);
-            }
-            dont_merge(stringify!($func));
-
-            let y;
-            asm!(concat!($reg, " = ", $reg), lateout($reg) y, in($reg) x);
-            y
-        }
-    };
-}
-
 // CHECK-LABEL: sym_static:
 // CHECK: InlineAsm Start
 // CHECK: r0 = {{#+}}extern_static
@@ -120,6 +86,23 @@ pub unsafe fn packet() {
     }}", out(reg) _, in(reg) &val);
 }
 
+macro_rules! check {
+    ($func:ident $ty:ident $class:ident) => {
+        #[no_mangle]
+        pub unsafe fn $func(x: $ty) -> $ty {
+            // Hack to avoid function merging
+            extern "Rust" {
+                fn dont_merge(s: &str);
+            }
+            dont_merge(stringify!($func));
+
+            let y;
+            asm!("{} = {}", out($class) y, in($class) x);
+            y
+        }
+    };
+}
+
 // CHECK-LABEL: reg_ptr:
 // CHECK: InlineAsm Start
 // CHECK: r{{[0-9]+}} = r{{[0-9]+}}
@@ -149,6 +132,23 @@ check!(reg_i8 i8 reg);
 // CHECK: r{{[0-9]+}} = r{{[0-9]+}}
 // CHECK: InlineAsm End
 check!(reg_i16 i16 reg);
+
+macro_rules! check_reg {
+    ($func:ident $ty:ident $reg:tt) => {
+        #[no_mangle]
+        pub unsafe fn $func(x: $ty) -> $ty {
+            // Hack to avoid function merging
+            extern "Rust" {
+                fn dont_merge(s: &str);
+            }
+            dont_merge(stringify!($func));
+
+            let y;
+            asm!(concat!($reg, " = ", $reg), lateout($reg) y, in($reg) x);
+            y
+        }
+    };
+}
 
 // CHECK-LABEL: r0_ptr:
 // CHECK: InlineAsm Start

--- a/src/test/assembly/asm/msp430-types.rs
+++ b/src/test/assembly/asm/msp430-types.rs
@@ -30,50 +30,6 @@ impl Copy for i32 {}
 impl Copy for i64 {}
 impl Copy for ptr {}
 
-macro_rules! check {
-    ($func:ident $ty:ident $class:ident) => {
-        #[no_mangle]
-        pub unsafe fn $func(x: $ty) -> $ty {
-            let y;
-            asm!("mov {}, {}", lateout($class) y, in($class) x);
-            y
-        }
-    };
-}
-
-macro_rules! checkb {
-    ($func:ident $ty:ident $class:ident) => {
-        #[no_mangle]
-        pub unsafe fn $func(x: $ty) -> $ty {
-            let y;
-            asm!("mov.b {}, {}", lateout($class) y, in($class) x);
-            y
-        }
-    };
-}
-
-macro_rules! check_reg {
-    ($func:ident $ty:ident $reg:tt) => {
-        #[no_mangle]
-        pub unsafe fn $func(x: $ty) -> $ty {
-            let y;
-            asm!(concat!("mov ", $reg, ", ", $reg), lateout($reg) y, in($reg) x);
-            y
-        }
-    };
-}
-
-macro_rules! check_regb {
-    ($func:ident $ty:ident $reg:tt) => {
-        #[no_mangle]
-        pub unsafe fn $func(x: $ty) -> $ty {
-            let y;
-            asm!(concat!("mov.b ", $reg, ", ", $reg), lateout($reg) y, in($reg) x);
-            y
-        }
-    };
-}
-
 extern "C" {
     fn extern_func();
     static extern_static: i8;
@@ -121,6 +77,17 @@ pub unsafe fn mov_postincrement(mut x: *const i16) -> (i16, *const i16) {
     (y, x)
 }
 
+macro_rules! check {
+    ($func:ident $ty:ident $class:ident) => {
+        #[no_mangle]
+        pub unsafe fn $func(x: $ty) -> $ty {
+            let y;
+            asm!("mov {}, {}", lateout($class) y, in($class) x);
+            y
+        }
+    };
+}
+
 // CHECK-LABEL: reg_i8:
 // CHECK: ;APP
 // CHECK: mov r{{[0-9]+}}, r{{[0-9]+}}
@@ -133,11 +100,33 @@ check!(reg_i8 i8 reg);
 // CHECK: ;NO_APP
 check!(reg_i16 i16 reg);
 
+macro_rules! checkb {
+    ($func:ident $ty:ident $class:ident) => {
+        #[no_mangle]
+        pub unsafe fn $func(x: $ty) -> $ty {
+            let y;
+            asm!("mov.b {}, {}", lateout($class) y, in($class) x);
+            y
+        }
+    };
+}
+
 // CHECK-LABEL: reg_i8b:
 // CHECK: ;APP
 // CHECK: mov.b r{{[0-9]+}}, r{{[0-9]+}}
 // CHECK: ;NO_APP
 checkb!(reg_i8b i8 reg);
+
+macro_rules! check_reg {
+    ($func:ident $ty:ident $reg:tt) => {
+        #[no_mangle]
+        pub unsafe fn $func(x: $ty) -> $ty {
+            let y;
+            asm!(concat!("mov ", $reg, ", ", $reg), lateout($reg) y, in($reg) x);
+            y
+        }
+    };
+}
 
 // CHECK-LABEL: r5_i8:
 // CHECK: ;APP
@@ -150,6 +139,17 @@ check_reg!(r5_i8 i8 "r5");
 // CHECK: mov r5, r5
 // CHECK: ;NO_APP
 check_reg!(r5_i16 i16 "r5");
+
+macro_rules! check_regb {
+    ($func:ident $ty:ident $reg:tt) => {
+        #[no_mangle]
+        pub unsafe fn $func(x: $ty) -> $ty {
+            let y;
+            asm!(concat!("mov.b ", $reg, ", ", $reg), lateout($reg) y, in($reg) x);
+            y
+        }
+    };
+}
 
 // CHECK-LABEL: r5_i8b:
 // CHECK: ;APP

--- a/src/test/assembly/asm/s390x-types.rs
+++ b/src/test/assembly/asm/s390x-types.rs
@@ -47,28 +47,6 @@ extern "Rust" {
     fn dont_merge(s: &str);
 }
 
-macro_rules! check { ($func:ident, $ty:ty, $class:ident, $mov:literal) => {
-    #[no_mangle]
-    pub unsafe fn $func(x: $ty) -> $ty {
-        dont_merge(stringify!($func));
-
-        let y;
-        asm!(concat!($mov," {}, {}"), out($class) y, in($class) x);
-        y
-    }
-};}
-
-macro_rules! check_reg { ($func:ident, $ty:ty, $reg:tt, $mov:literal) => {
-    #[no_mangle]
-    pub unsafe fn $func(x: $ty) -> $ty {
-        dont_merge(stringify!($func));
-
-        let y;
-        asm!(concat!($mov, " %", $reg, ", %", $reg), lateout($reg) y, in($reg) x);
-        y
-    }
-};}
-
 // CHECK-LABEL: sym_fn_32:
 // CHECK: #APP
 // CHECK: brasl %r14, extern_func
@@ -87,6 +65,17 @@ pub unsafe fn sym_fn_32() {
 pub unsafe fn sym_static() {
     asm!("brasl %r14, {}", sym extern_static);
 }
+
+macro_rules! check { ($func:ident, $ty:ty, $class:ident, $mov:literal) => {
+    #[no_mangle]
+    pub unsafe fn $func(x: $ty) -> $ty {
+        dont_merge(stringify!($func));
+
+        let y;
+        asm!(concat!($mov," {}, {}"), out($class) y, in($class) x);
+        y
+    }
+};}
 
 // CHECK-LABEL: reg_i8:
 // CHECK: #APP
@@ -129,6 +118,17 @@ check!(reg_f64, f64, freg, "ldr");
 // CHECK: lgr %r{{[0-9]+}}, %r{{[0-9]+}}
 // CHECK: #NO_APP
 check!(reg_ptr, ptr, reg, "lgr");
+
+macro_rules! check_reg { ($func:ident, $ty:ty, $reg:tt, $mov:literal) => {
+    #[no_mangle]
+    pub unsafe fn $func(x: $ty) -> $ty {
+        dont_merge(stringify!($func));
+
+        let y;
+        asm!(concat!($mov, " %", $reg, ", %", $reg), lateout($reg) y, in($reg) x);
+        y
+    }
+};}
 
 // CHECK-LABEL: r0_i8:
 // CHECK: #APP


### PR DESCRIPTION
The codegen tests rely on items being process in the same order as they appear in the file.

Instead of sorting them by `DefIndex`, we should just sort them by `def_span`.

cc #90317.