### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/compiler/rustc_builtin_macros/src/asm.rs
+++ b/compiler/rustc_builtin_macros/src/asm.rs
@@ -809,7 +809,7 @@ fn expand_preparsed_asm(ecx: &mut ExtCtxt<'_>, args: AsmArgs) -> Option<ast::Inl
     })
 }
 
-pub fn expand_asm<'cx>(
+pub(super) fn expand_asm<'cx>(
     ecx: &'cx mut ExtCtxt<'_>,
     sp: Span,
     tts: TokenStream,
@@ -836,7 +836,7 @@ pub fn expand_asm<'cx>(
     }
 }
 
-pub fn expand_global_asm<'cx>(
+pub(super) fn expand_global_asm<'cx>(
     ecx: &'cx mut ExtCtxt<'_>,
     sp: Span,
     tts: TokenStream,

--- a/compiler/rustc_builtin_macros/src/lib.rs
+++ b/compiler/rustc_builtin_macros/src/lib.rs
@@ -19,7 +19,6 @@ use rustc_expand::base::{MacroExpanderFn, ResolverExpand, SyntaxExtensionKind};
 use rustc_expand::proc_macro::BangProcMacro;
 use rustc_span::symbol::sym;
 
-mod asm;
 mod assert;
 mod cfg;
 mod cfg_accessible;
@@ -42,6 +41,7 @@ mod test;
 mod trace_macros;
 mod util;
 
+pub mod asm;
 pub mod cmdline_attrs;
 pub mod proc_macro_harness;
 pub mod standard_library_imports;

--- a/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
@@ -417,16 +417,12 @@ impl CStore {
 
         let span = data.get_span(id.index, sess);
 
-        let attrs = data.get_item_attrs(id.index, sess).collect();
-
-        let ident = data.item_ident(id.index, sess);
-
         LoadedMacro::MacroDef(
             ast::Item {
-                ident,
+                ident: data.item_ident(id.index, sess),
                 id: ast::DUMMY_NODE_ID,
                 span,
-                attrs,
+                attrs: data.get_item_attrs(id.index, sess).collect(),
                 kind: ast::ItemKind::MacroDef(data.get_macro(id.index, sess)),
                 vis: ast::Visibility {
                     span: span.shrink_to_lo(),

--- a/compiler/rustc_privacy/src/lib.rs
+++ b/compiler/rustc_privacy/src/lib.rs
@@ -2069,7 +2069,11 @@ impl<'tcx> Visitor<'tcx> for PrivateItemsInPublicInterfacesVisitor<'tcx> {
             // Subitems of trait impls have inherited publicity.
             hir::ItemKind::Impl(ref impl_) => {
                 let impl_vis = ty::Visibility::of_impl(item.def_id, tcx, &Default::default());
-                self.check(item.def_id, impl_vis).generics().predicates();
+                // check that private components do not appear in the generics or predicates of inherent impls
+                // this check is intentionally NOT performed for impls of traits, per #90586
+                if impl_.of_trait.is_none() {
+                    self.check(item.def_id, impl_vis).generics().predicates();
+                }
                 for impl_item_ref in impl_.items {
                     let impl_item_vis = if impl_.of_trait.is_none() {
                         min(tcx.visibility(impl_item_ref.id.def_id), impl_vis, tcx)

--- a/compiler/rustc_typeck/src/check/expr.rs
+++ b/compiler/rustc_typeck/src/check/expr.rs
@@ -1508,7 +1508,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 }
             } else {
                 self.check_expr_has_type_or_error(base_expr, adt_ty, |_| {
-                    let base_ty = self.check_expr(base_expr);
+                    let base_ty = self.typeck_results.borrow().node_type(base_expr.hir_id);
                     let same_adt = match (adt_ty.kind(), base_ty.kind()) {
                         (ty::Adt(adt, _), ty::Adt(base_adt, _)) if adt == base_adt => true,
                         _ => false,

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -2043,7 +2043,7 @@ impl<T, A: Allocator> Vec<T, A> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(vec_spare_capacity, maybe_uninit_extra)]
+    /// #![feature(vec_spare_capacity)]
     ///
     /// // Allocate vector big enough for 10 elements.
     /// let mut v = Vec::with_capacity(10);
@@ -2102,7 +2102,7 @@ impl<T, A: Allocator> Vec<T, A> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(vec_split_at_spare, maybe_uninit_extra)]
+    /// #![feature(vec_split_at_spare)]
     ///
     /// let mut v = vec![1, 1, 2];
     ///

--- a/library/std/src/io/readbuf.rs
+++ b/library/std/src/io/readbuf.rs
@@ -52,7 +52,7 @@ impl<'a> ReadBuf<'a> {
 
     /// Creates a new `ReadBuf` from a fully uninitialized buffer.
     ///
-    /// Use `assume_init` if part of the buffer is known to be already inintialized.
+    /// Use `assume_init` if part of the buffer is known to be already initialized.
     #[inline]
     pub fn uninit(buf: &'a mut [MaybeUninit<u8>]) -> ReadBuf<'a> {
         ReadBuf { buf, filled: 0, initialized: 0 }
@@ -145,7 +145,7 @@ impl<'a> ReadBuf<'a> {
                 byte.write(0);
             }
 
-            // SAFETY: we just inintialized uninit bytes, and the previous bytes were already init
+            // SAFETY: we just initialized uninit bytes, and the previous bytes were already init
             unsafe {
                 self.assume_init(n);
             }

--- a/library/std/src/net/ip.rs
+++ b/library/std/src/net/ip.rs
@@ -1826,7 +1826,7 @@ impl fmt::Display for Ipv6Addr {
                 }
             }
         } else {
-            // Slow path: write the address to a local buffer, the use f.pad.
+            // Slow path: write the address to a local buffer, then use f.pad.
             // Defined recursively by using the fast path to write to the
             // buffer.
 

--- a/src/test/ui/closures/2229_closure_analysis/wild_patterns.rs
+++ b/src/test/ui/closures/2229_closure_analysis/wild_patterns.rs
@@ -3,7 +3,7 @@
 #![feature(rustc_attrs)]
 
 // Test to ensure that we can handle cases where
-// let statements create no bindings are intialized
+// let statements create no bindings are initialized
 // using a Place expression
 //
 // Note: Currently when feature `capture_disjoint_fields` is enabled

--- a/src/test/ui/const-generics/generic_const_exprs/eval-privacy.rs
+++ b/src/test/ui/const-generics/generic_const_exprs/eval-privacy.rs
@@ -9,12 +9,7 @@ pub trait Trait {
     fn assoc_fn() -> Self::AssocTy;
 }
 
-impl<const U: u8> Trait for Const<U>
-//~^ WARN private type
-//~| WARN this was previously
-//~| WARN private type
-//~| WARN this was previously
-
+impl<const U: u8> Trait for Const<U> // OK, trait impl predicates
 where
     Const<{ my_const_fn(U) }>: ,
 {

--- a/src/test/ui/const-generics/generic_const_exprs/eval-privacy.stderr
+++ b/src/test/ui/const-generics/generic_const_exprs/eval-privacy.stderr
@@ -1,36 +1,5 @@
-warning: private type `fn(u8) -> u8 {my_const_fn}` in public interface (error E0446)
-  --> $DIR/eval-privacy.rs:12:1
-   |
-LL | / impl<const U: u8> Trait for Const<U>
-LL | |
-LL | |
-LL | |
-...  |
-LL | |     }
-LL | | }
-   | |_^
-   |
-   = note: `#[warn(private_in_public)]` on by default
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
-
-warning: private type `fn(u8) -> u8 {my_const_fn}` in public interface (error E0446)
-  --> $DIR/eval-privacy.rs:12:1
-   |
-LL | / impl<const U: u8> Trait for Const<U>
-LL | |
-LL | |
-LL | |
-...  |
-LL | |     }
-LL | | }
-   | |_^
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
-
 error[E0446]: private type `fn(u8) -> u8 {my_const_fn}` in public interface
-  --> $DIR/eval-privacy.rs:21:5
+  --> $DIR/eval-privacy.rs:16:5
    |
 LL |     type AssocTy = Const<{ my_const_fn(U) }>;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't leak private type
@@ -38,6 +7,6 @@ LL |     type AssocTy = Const<{ my_const_fn(U) }>;
 LL | const fn my_const_fn(val: u8) -> u8 {
    | ----------------------------------- `fn(u8) -> u8 {my_const_fn}` declared as private
 
-error: aborting due to previous error; 2 warnings emitted
+error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0446`.

--- a/src/test/ui/issues/issue-26186.rs
+++ b/src/test/ui/issues/issue-26186.rs
@@ -1,0 +1,62 @@
+// check-pass
+use std::sync::Mutex;
+use std::cell::RefCell;
+use std::rc::Rc;
+use std::ops::*;
+
+//eefriedman example
+struct S<'a, T:FnMut() + 'static + ?Sized>(&'a mut T);
+impl<'a, T:?Sized + FnMut() + 'static> DerefMut for S<'a, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target { &mut self.0 }
+}
+impl<'a, T:?Sized + FnMut() + 'static> Deref for S<'a, T> {
+    type Target = dyn FnMut() + 'a;
+    fn deref(&self) -> &Self::Target { &self.0 }
+}
+
+//Ossipal example
+struct FunctionIcon {
+    get_icon: Mutex<Box<dyn FnMut() -> u32>>,
+}
+
+impl FunctionIcon {
+    fn get_icon(&self) -> impl '_ + std::ops::DerefMut<Target=Box<dyn FnMut() -> u32>> {
+        self.get_icon.lock().unwrap()
+    }
+
+    fn load_icon(&self)  {
+        let mut get_icon = self.get_icon();
+        let _rgba_icon = (*get_icon)();
+    }
+}
+
+//shepmaster example
+struct Foo;
+
+impl Deref for Foo {
+    type Target = dyn FnMut() + 'static;
+    fn deref(&self) -> &Self::Target {
+        unimplemented!()
+    }
+}
+
+impl DerefMut for Foo {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        unimplemented!()
+    }
+}
+
+fn main() {
+    //eefriedman example
+    let mut f = ||{};
+    let mut s = S(&mut f);
+    s();
+
+    //Diggsey/Mark-Simulacrum example
+    let a: Rc<RefCell<dyn FnMut()>> = Rc::new(RefCell::new(||{}));
+    a.borrow_mut()();
+
+    //shepmaster example
+    let mut t = Foo;
+    t();
+}

--- a/src/test/ui/privacy/private-in-public-warn.rs
+++ b/src/test/ui/privacy/private-in-public-warn.rs
@@ -63,8 +63,7 @@ mod traits {
     }
     impl<T: PrivTr> Pub<T> {} //~ ERROR private trait `traits::PrivTr` in public interface
         //~^ WARNING hard error
-    impl<T: PrivTr> PubTr for Pub<T> {} //~ ERROR private trait `traits::PrivTr` in public interface
-        //~^ WARNING hard error
+    impl<T: PrivTr> PubTr for Pub<T> {} // OK, trait impl predicates
 }
 
 mod traits_where {
@@ -87,9 +86,7 @@ mod traits_where {
     impl<T> Pub<T> where T: PrivTr {}
         //~^ ERROR private trait `traits_where::PrivTr` in public interface
         //~| WARNING hard error
-    impl<T> PubTr for Pub<T> where T: PrivTr {}
-        //~^ ERROR private trait `traits_where::PrivTr` in public interface
-        //~| WARNING hard error
+    impl<T> PubTr for Pub<T> where T: PrivTr {} // OK, trait impl predicates
 }
 
 mod generics {

--- a/src/test/ui/privacy/private-in-public-warn.stderr
+++ b/src/test/ui/privacy/private-in-public-warn.stderr
@@ -156,17 +156,8 @@ LL |     impl<T: PrivTr> Pub<T> {}
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
 
-error: private trait `traits::PrivTr` in public interface (error E0445)
-  --> $DIR/private-in-public-warn.rs:66:5
-   |
-LL |     impl<T: PrivTr> PubTr for Pub<T> {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
-
 error: private trait `traits_where::PrivTr` in public interface (error E0445)
-  --> $DIR/private-in-public-warn.rs:75:5
+  --> $DIR/private-in-public-warn.rs:74:5
    |
 LL |     pub type Alias<T> where T: PrivTr = T;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -175,7 +166,7 @@ LL |     pub type Alias<T> where T: PrivTr = T;
    = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
 
 error: private trait `traits_where::PrivTr` in public interface (error E0445)
-  --> $DIR/private-in-public-warn.rs:79:5
+  --> $DIR/private-in-public-warn.rs:78:5
    |
 LL |     pub trait Tr2<T> where T: PrivTr {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -184,7 +175,7 @@ LL |     pub trait Tr2<T> where T: PrivTr {}
    = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
 
 error: private trait `traits_where::PrivTr` in public interface (error E0445)
-  --> $DIR/private-in-public-warn.rs:83:9
+  --> $DIR/private-in-public-warn.rs:82:9
    |
 LL |         fn f<T>(arg: T) where T: PrivTr {}
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -193,7 +184,7 @@ LL |         fn f<T>(arg: T) where T: PrivTr {}
    = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
 
 error: private trait `traits_where::PrivTr` in public interface (error E0445)
-  --> $DIR/private-in-public-warn.rs:87:5
+  --> $DIR/private-in-public-warn.rs:86:5
    |
 LL |     impl<T> Pub<T> where T: PrivTr {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -201,17 +192,8 @@ LL |     impl<T> Pub<T> where T: PrivTr {}
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
 
-error: private trait `traits_where::PrivTr` in public interface (error E0445)
-  --> $DIR/private-in-public-warn.rs:90:5
-   |
-LL |     impl<T> PubTr for Pub<T> where T: PrivTr {}
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
-
 error: private trait `generics::PrivTr<generics::Pub>` in public interface (error E0445)
-  --> $DIR/private-in-public-warn.rs:101:5
+  --> $DIR/private-in-public-warn.rs:98:5
    |
 LL |     pub trait Tr1: PrivTr<Pub> {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -220,7 +202,7 @@ LL |     pub trait Tr1: PrivTr<Pub> {}
    = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
 
 error: private type `generics::Priv` in public interface (error E0446)
-  --> $DIR/private-in-public-warn.rs:104:5
+  --> $DIR/private-in-public-warn.rs:101:5
    |
 LL |     pub trait Tr2: PubTr<Priv> {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -229,7 +211,7 @@ LL |     pub trait Tr2: PubTr<Priv> {}
    = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
 
 error: private type `generics::Priv` in public interface (error E0446)
-  --> $DIR/private-in-public-warn.rs:106:5
+  --> $DIR/private-in-public-warn.rs:103:5
    |
 LL |     pub trait Tr3: PubTr<[Priv; 1]> {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -238,7 +220,7 @@ LL |     pub trait Tr3: PubTr<[Priv; 1]> {}
    = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
 
 error: private type `generics::Priv` in public interface (error E0446)
-  --> $DIR/private-in-public-warn.rs:108:5
+  --> $DIR/private-in-public-warn.rs:105:5
    |
 LL |     pub trait Tr4: PubTr<Pub<Priv>> {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -247,7 +229,7 @@ LL |     pub trait Tr4: PubTr<Pub<Priv>> {}
    = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
 
 error[E0446]: private type `impls::Priv` in public interface
-  --> $DIR/private-in-public-warn.rs:135:9
+  --> $DIR/private-in-public-warn.rs:132:9
    |
 LL |     struct Priv;
    |     ------------ `impls::Priv` declared as private
@@ -256,13 +238,22 @@ LL |         type Alias = Priv;
    |         ^^^^^^^^^^^^^^^^^^ can't leak private type
 
 error: private type `aliases_pub::Priv` in public interface (error E0446)
-  --> $DIR/private-in-public-warn.rs:206:9
+  --> $DIR/private-in-public-warn.rs:203:9
    |
 LL |         pub fn f(arg: Priv) {}
    |         ^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
+
+error[E0446]: private type `aliases_pub::Priv` in public interface
+  --> $DIR/private-in-public-warn.rs:207:9
+   |
+LL |     struct Priv;
+   |     ------------ `aliases_pub::Priv` declared as private
+...
+LL |         type Check = Priv;
+   |         ^^^^^^^^^^^^^^^^^^ can't leak private type
 
 error[E0446]: private type `aliases_pub::Priv` in public interface
   --> $DIR/private-in-public-warn.rs:210:9
@@ -291,17 +282,8 @@ LL |     struct Priv;
 LL |         type Check = Priv;
    |         ^^^^^^^^^^^^^^^^^^ can't leak private type
 
-error[E0446]: private type `aliases_pub::Priv` in public interface
-  --> $DIR/private-in-public-warn.rs:219:9
-   |
-LL |     struct Priv;
-   |     ------------ `aliases_pub::Priv` declared as private
-...
-LL |         type Check = Priv;
-   |         ^^^^^^^^^^^^^^^^^^ can't leak private type
-
 error: private trait `PrivTr1` in public interface (error E0445)
-  --> $DIR/private-in-public-warn.rs:249:5
+  --> $DIR/private-in-public-warn.rs:246:5
    |
 LL |     pub trait Tr1: PrivUseAliasTr {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -310,7 +292,7 @@ LL |     pub trait Tr1: PrivUseAliasTr {}
    = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
 
 error: private trait `PrivTr1<Priv2>` in public interface (error E0445)
-  --> $DIR/private-in-public-warn.rs:252:5
+  --> $DIR/private-in-public-warn.rs:249:5
    |
 LL |     pub trait Tr2: PrivUseAliasTr<PrivAlias> {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -319,7 +301,7 @@ LL |     pub trait Tr2: PrivUseAliasTr<PrivAlias> {}
    = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
 
 error: private type `Priv2` in public interface (error E0446)
-  --> $DIR/private-in-public-warn.rs:252:5
+  --> $DIR/private-in-public-warn.rs:249:5
    |
 LL |     pub trait Tr2: PrivUseAliasTr<PrivAlias> {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -341,7 +323,7 @@ LL +     pub type Alias<T> = T;
    | 
 
 warning: where clauses are not enforced in type aliases
-  --> $DIR/private-in-public-warn.rs:75:29
+  --> $DIR/private-in-public-warn.rs:74:29
    |
 LL |     pub type Alias<T> where T: PrivTr = T;
    |                             ^^^^^^^^^
@@ -352,6 +334,6 @@ LL -     pub type Alias<T> where T: PrivTr = T;
 LL +     pub type Alias<T>  = T;
    | 
 
-error: aborting due to 36 previous errors; 2 warnings emitted
+error: aborting due to 34 previous errors; 2 warnings emitted
 
 For more information about this error, try `rustc --explain E0446`.

--- a/src/test/ui/privacy/where-priv-type.rs
+++ b/src/test/ui/privacy/where-priv-type.rs
@@ -1,0 +1,90 @@
+// priv-in-pub lint tests where the private type appears in the
+// `where` clause of a public item
+
+#![crate_type = "lib"]
+#![feature(generic_const_exprs)]
+#![allow(incomplete_features)]
+
+
+struct PrivTy;
+trait PrivTr {}
+pub struct PubTy;
+pub struct PubTyGeneric<T>(T);
+pub trait PubTr {}
+impl PubTr for PrivTy {}
+pub trait PubTrWithAssocTy { type AssocTy; }
+impl PubTrWithAssocTy for PrivTy { type AssocTy = PrivTy; }
+
+
+pub struct S
+//~^ WARNING private type `PrivTy` in public interface
+//~| WARNING hard error
+where
+    PrivTy:
+{}
+
+
+pub enum E
+//~^ WARNING private type `PrivTy` in public interface
+//~| WARNING hard error
+where
+    PrivTy:
+{}
+
+
+pub fn f()
+//~^ WARNING private type `PrivTy` in public interface
+//~| WARNING hard error
+where
+    PrivTy:
+{}
+
+
+impl S
+//~^ ERROR private type `PrivTy` in public interface
+where
+    PrivTy:
+{
+    pub fn f()
+    //~^ WARNING private type `PrivTy` in public interface
+    //~| WARNING hard error
+    where
+        PrivTy:
+    {}
+}
+
+
+impl PubTr for PubTy
+where
+    PrivTy:
+{}
+
+
+impl<T> PubTr for PubTyGeneric<T>
+where
+    T: PubTrWithAssocTy<AssocTy=PrivTy>
+{}
+
+
+pub struct Const<const U: u8>;
+
+pub trait Trait {
+    type AssocTy;
+    fn assoc_fn() -> Self::AssocTy;
+}
+
+impl<const U: u8> Trait for Const<U>
+where
+    Const<{ my_const_fn(U) }>: ,
+{
+    type AssocTy = Const<{ my_const_fn(U) }>;
+    //~^ ERROR private type
+    fn assoc_fn() -> Self::AssocTy {
+        Const
+    }
+}
+
+const fn my_const_fn(val: u8) -> u8 {
+    // body of this function doesn't matter
+    val
+}

--- a/src/test/ui/privacy/where-priv-type.stderr
+++ b/src/test/ui/privacy/where-priv-type.stderr
@@ -1,0 +1,82 @@
+warning: private type `PrivTy` in public interface (error E0446)
+  --> $DIR/where-priv-type.rs:19:1
+   |
+LL | / pub struct S
+LL | |
+LL | |
+LL | | where
+LL | |     PrivTy:
+LL | | {}
+   | |__^
+   |
+   = note: `#[warn(private_in_public)]` on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
+
+warning: private type `PrivTy` in public interface (error E0446)
+  --> $DIR/where-priv-type.rs:27:1
+   |
+LL | / pub enum E
+LL | |
+LL | |
+LL | | where
+LL | |     PrivTy:
+LL | | {}
+   | |__^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
+
+warning: private type `PrivTy` in public interface (error E0446)
+  --> $DIR/where-priv-type.rs:35:1
+   |
+LL | / pub fn f()
+LL | |
+LL | |
+LL | | where
+LL | |     PrivTy:
+   | |___________^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
+
+error[E0446]: private type `PrivTy` in public interface
+  --> $DIR/where-priv-type.rs:43:1
+   |
+LL |   struct PrivTy;
+   |   -------------- `PrivTy` declared as private
+...
+LL | / impl S
+LL | |
+LL | | where
+LL | |     PrivTy:
+...  |
+LL | |     {}
+LL | | }
+   | |_^ can't leak private type
+
+warning: private type `PrivTy` in public interface (error E0446)
+  --> $DIR/where-priv-type.rs:48:5
+   |
+LL | /     pub fn f()
+LL | |
+LL | |
+LL | |     where
+LL | |         PrivTy:
+   | |_______________^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #34537 <https://github.com/rust-lang/rust/issues/34537>
+
+error[E0446]: private type `fn(u8) -> u8 {my_const_fn}` in public interface
+  --> $DIR/where-priv-type.rs:80:5
+   |
+LL |     type AssocTy = Const<{ my_const_fn(U) }>;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't leak private type
+...
+LL | const fn my_const_fn(val: u8) -> u8 {
+   | ----------------------------------- `fn(u8) -> u8 {my_const_fn}` declared as private
+
+error: aborting due to 2 previous errors; 4 warnings emitted
+
+For more information about this error, try `rustc --explain E0446`.

--- a/src/test/ui/privacy/where-pub-type-impls-priv-trait.rs
+++ b/src/test/ui/privacy/where-pub-type-impls-priv-trait.rs
@@ -1,0 +1,56 @@
+// priv-in-pub lint tests where the private trait bounds a public type
+
+#![crate_type = "lib"]
+#![feature(generic_const_exprs)]
+#![allow(incomplete_features)]
+
+
+struct PrivTy;
+trait PrivTr {}
+pub struct PubTy;
+pub struct PubTyGeneric<T>(T);
+pub trait PubTr {}
+impl PubTr for PrivTy {}
+impl PrivTr for PubTy {}
+pub trait PubTrWithAssocTy { type AssocTy; }
+impl PubTrWithAssocTy for PrivTy { type AssocTy = PrivTy; }
+
+
+pub struct S
+//~^ ERROR private trait `PrivTr` in public interface
+where
+    PubTy: PrivTr
+{}
+
+
+pub enum E
+//~^ ERROR private trait `PrivTr` in public interface
+where
+    PubTy: PrivTr
+{}
+
+
+pub fn f()
+//~^ ERROR private trait `PrivTr` in public interface
+where
+    PubTy: PrivTr
+{}
+
+
+impl S
+//~^ ERROR private trait `PrivTr` in public interface
+where
+    PubTy: PrivTr
+{
+    pub fn f()
+    //~^ ERROR private trait `PrivTr` in public interface
+    where
+        PubTy: PrivTr
+    {}
+}
+
+
+impl PubTr for PubTy
+where
+    PubTy: PrivTr
+{}

--- a/src/test/ui/privacy/where-pub-type-impls-priv-trait.stderr
+++ b/src/test/ui/privacy/where-pub-type-impls-priv-trait.stderr
@@ -1,0 +1,68 @@
+error[E0445]: private trait `PrivTr` in public interface
+  --> $DIR/where-pub-type-impls-priv-trait.rs:19:1
+   |
+LL |   trait PrivTr {}
+   |   ------------ `PrivTr` declared as private
+...
+LL | / pub struct S
+LL | |
+LL | | where
+LL | |     PubTy: PrivTr
+LL | | {}
+   | |__^ can't leak private trait
+
+error[E0445]: private trait `PrivTr` in public interface
+  --> $DIR/where-pub-type-impls-priv-trait.rs:26:1
+   |
+LL |   trait PrivTr {}
+   |   ------------ `PrivTr` declared as private
+...
+LL | / pub enum E
+LL | |
+LL | | where
+LL | |     PubTy: PrivTr
+LL | | {}
+   | |__^ can't leak private trait
+
+error[E0445]: private trait `PrivTr` in public interface
+  --> $DIR/where-pub-type-impls-priv-trait.rs:33:1
+   |
+LL |   trait PrivTr {}
+   |   ------------ `PrivTr` declared as private
+...
+LL | / pub fn f()
+LL | |
+LL | | where
+LL | |     PubTy: PrivTr
+   | |_________________^ can't leak private trait
+
+error[E0445]: private trait `PrivTr` in public interface
+  --> $DIR/where-pub-type-impls-priv-trait.rs:40:1
+   |
+LL |   trait PrivTr {}
+   |   ------------ `PrivTr` declared as private
+...
+LL | / impl S
+LL | |
+LL | | where
+LL | |     PubTy: PrivTr
+...  |
+LL | |     {}
+LL | | }
+   | |_^ can't leak private trait
+
+error[E0445]: private trait `PrivTr` in public interface
+  --> $DIR/where-pub-type-impls-priv-trait.rs:45:5
+   |
+LL |   trait PrivTr {}
+   |   ------------ `PrivTr` declared as private
+...
+LL | /     pub fn f()
+LL | |
+LL | |     where
+LL | |         PubTy: PrivTr
+   | |_____________________^ can't leak private trait
+
+error: aborting due to 5 previous errors
+
+For more information about this error, try `rustc --explain E0445`.

--- a/src/test/ui/rfcs/rfc-2528-type-changing-struct-update/issue-92010-trait-bound-not-satisfied.rs
+++ b/src/test/ui/rfcs/rfc-2528-type-changing-struct-update/issue-92010-trait-bound-not-satisfied.rs
@@ -1,0 +1,12 @@
+#[derive(Clone)]
+struct P<T> {
+    x: T,
+    y: f64,
+}
+
+impl<T> P<T> {
+    fn y(&self, y: f64) -> Self { P{y, .. self.clone() } }
+                                       //~^ mismatched types [E0308]
+}
+
+fn main() {}

--- a/src/test/ui/rfcs/rfc-2528-type-changing-struct-update/issue-92010-trait-bound-not-satisfied.stderr
+++ b/src/test/ui/rfcs/rfc-2528-type-changing-struct-update/issue-92010-trait-bound-not-satisfied.stderr
@@ -1,0 +1,12 @@
+error[E0308]: mismatched types
+  --> $DIR/issue-92010-trait-bound-not-satisfied.rs:8:43
+   |
+LL |     fn y(&self, y: f64) -> Self { P{y, .. self.clone() } }
+   |                                           ^^^^^^^^^^^^ expected struct `P`, found `&P<T>`
+   |
+   = note: expected struct `P<T>`
+           found reference `&P<T>`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Successful merges:

 - #90586 (Relax priv-in-pub lint on generic bounds and where clauses of trait impls.)
 - #92112 (Fix the error of checking `base_expr` twice in type_changing_struct_update)
 - #92147 (rustc_builtin_macros: make asm mod public for rustfmt)
 - #92161 (resolve: Minor miscellaneous cleanups from #89059)
 - #92264 (Remove `maybe_uninit_extra` feature from Vec docs)
 - #92303 (Add test cases for issue #26186)
 - #92307 (Fix minor typos)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=90586,92112,92147,92161,92264,92303,92307)
<!-- homu-ignore:end -->