### PR TITLE
Add try_reserve and  try_reserve_exact for OsString

### DIFF
--- a/library/std/src/ffi/os_str.rs
+++ b/library/std/src/ffi/os_str.rs
@@ -284,7 +284,7 @@ impl OsString {
     /// use std::ffi::OsString;
     /// use std::collections::TryReserveError;
     ///
-    /// fn find_max_slow(data: &str) -> Result<OsString, TryReserveError> {
+    /// fn process_data(data: &str) -> Result<OsString, TryReserveError> {
     ///     let mut s = OsString::new();
     ///
     ///     // Pre-reserve the memory, exiting if we can't
@@ -295,7 +295,7 @@ impl OsString {
     ///
     ///     Ok(s)
     /// }
-    /// # find_max_slow("123").expect("why is the test harness OOMing on 12 bytes?");
+    /// # process_data("123").expect("why is the test harness OOMing on 3 bytes?");
     /// ```
     #[unstable(feature = "try_reserve_2", issue = "91789")]
     #[inline]
@@ -352,7 +352,7 @@ impl OsString {
     /// use std::ffi::OsString;
     /// use std::collections::TryReserveError;
     ///
-    /// fn find_max_slow(data: &str) -> Result<OsString, TryReserveError> {
+    /// fn process_data(data: &str) -> Result<OsString, TryReserveError> {
     ///     let mut s = OsString::new();
     ///
     ///     // Pre-reserve the memory, exiting if we can't
@@ -363,7 +363,7 @@ impl OsString {
     ///
     ///     Ok(s)
     /// }
-    /// # find_max_slow("123").expect("why is the test harness OOMing on 12 bytes?");
+    /// # process_data("123").expect("why is the test harness OOMing on 3 bytes?");
     /// ```
     #[unstable(feature = "try_reserve_2", issue = "91789")]
     #[inline]

--- a/library/std/src/ffi/os_str.rs
+++ b/library/std/src/ffi/os_str.rs
@@ -267,7 +267,7 @@ impl OsString {
     }
 
     /// Tries to reserve capacity for at least `additional` more elements to be inserted
-    /// in the given `OsString`. The collection may reserve more space to avoid
+    /// in the given `OsString`. The string may reserve more space to avoid
     /// frequent reallocations. After calling `try_reserve`, capacity will be
     /// greater than or equal to `self.len() + additional`. Does nothing if
     /// capacity is already sufficient.

--- a/library/std/src/ffi/os_str.rs
+++ b/library/std/src/ffi/os_str.rs
@@ -266,7 +266,7 @@ impl OsString {
         self.inner.reserve(additional)
     }
 
-    /// Tries to reserve capacity for at least `additional` more elements to be inserted
+    /// Tries to reserve capacity for at least `additional` more length units
     /// in the given `OsString`. The string may reserve more space to avoid
     /// frequent reallocations. After calling `try_reserve`, capacity will be
     /// greater than or equal to `self.len() + additional`. Does nothing if
@@ -288,7 +288,7 @@ impl OsString {
     ///     let mut s = OsString::new();
     ///
     ///     // Pre-reserve the memory, exiting if we can't
-    ///     s.try_reserve(data.len())?;
+    ///     s.try_reserve(OsString::from(data).len())?;
     ///
     ///     // Now we know this can't OOM in the middle of our complex work
     ///     s.push(data);
@@ -329,12 +329,12 @@ impl OsString {
     }
 
     /// Tries to reserve the minimum capacity for exactly `additional`
-    /// elements to be inserted in the given `OsString`. After calling
+    /// more length units in the given `OsString`. After calling
     /// `try_reserve_exact`, capacity will be greater than or equal to
     /// `self.len() + additional` if it returns `Ok(())`.
     /// Does nothing if the capacity is already sufficient.
     ///
-    /// Note that the allocator may give the collection more space than it
+    /// Note that the allocator may give the `OsString` more space than it
     /// requests. Therefore, capacity can not be relied upon to be precisely
     /// minimal. Prefer [`try_reserve`] if future insertions are expected.
     ///
@@ -353,10 +353,10 @@ impl OsString {
     /// use std::collections::TryReserveError;
     ///
     /// fn find_max_slow(data: &str) -> Result<OsString, TryReserveError> {
-    ///     let mut s = OsString::from(data);
+    ///     let mut s = OsString::new();
     ///
     ///     // Pre-reserve the memory, exiting if we can't
-    ///     s.try_reserve_exact(data.len())?;
+    ///     s.try_reserve_exact(OsString::from(data).len())?;
     ///
     ///     // Now we know this can't OOM in the middle of our complex work
     ///     s.push(data);

--- a/library/std/src/ffi/os_str.rs
+++ b/library/std/src/ffi/os_str.rs
@@ -281,14 +281,14 @@ impl OsString {
     ///
     /// ```
     /// #![feature(try_reserve_2)]
-    /// use std::ffi::OsString;
+    /// use std::ffi::{OsStr, OsString};
     /// use std::collections::TryReserveError;
     ///
     /// fn process_data(data: &str) -> Result<OsString, TryReserveError> {
     ///     let mut s = OsString::new();
     ///
     ///     // Pre-reserve the memory, exiting if we can't
-    ///     s.try_reserve(OsString::from(data).len())?;
+    ///     s.try_reserve(OsStr::new(data).len())?;
     ///
     ///     // Now we know this can't OOM in the middle of our complex work
     ///     s.push(data);
@@ -349,14 +349,14 @@ impl OsString {
     ///
     /// ```
     /// #![feature(try_reserve_2)]
-    /// use std::ffi::OsString;
+    /// use std::ffi::{OsStr, OsString};
     /// use std::collections::TryReserveError;
     ///
     /// fn process_data(data: &str) -> Result<OsString, TryReserveError> {
     ///     let mut s = OsString::new();
     ///
     ///     // Pre-reserve the memory, exiting if we can't
-    ///     s.try_reserve_exact(OsString::from(data).len())?;
+    ///     s.try_reserve_exact(OsStr::new(data).len())?;
     ///
     ///     // Now we know this can't OOM in the middle of our complex work
     ///     s.push(data);

--- a/library/std/src/ffi/os_str.rs
+++ b/library/std/src/ffi/os_str.rs
@@ -3,6 +3,7 @@ mod tests;
 
 use crate::borrow::{Borrow, Cow};
 use crate::cmp;
+use crate::collections::TryReserveError;
 use crate::fmt;
 use crate::hash::{Hash, Hasher};
 use crate::iter::{Extend, FromIterator};
@@ -265,6 +266,43 @@ impl OsString {
         self.inner.reserve(additional)
     }
 
+    /// Tries to reserve capacity for at least `additional` more elements to be inserted
+    /// in the given `OsString`. The collection may reserve more space to avoid
+    /// frequent reallocations. After calling `try_reserve`, capacity will be
+    /// greater than or equal to `self.len() + additional`. Does nothing if
+    /// capacity is already sufficient.
+    ///
+    /// # Errors
+    ///
+    /// If the capacity overflows, or the allocator reports a failure, then an error
+    /// is returned.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(try_reserve_2)]
+    /// use std::ffi::OsString;
+    /// use std::collections::TryReserveError;
+    ///
+    /// fn find_max_slow(data: &str) -> Result<OsString, TryReserveError> {
+    ///     let mut s = OsString::new();
+    ///
+    ///     // Pre-reserve the memory, exiting if we can't
+    ///     s.try_reserve(data.len())?;
+    ///
+    ///     // Now we know this can't OOM in the middle of our complex work
+    ///     s.push(data);
+    ///
+    ///     Ok(s)
+    /// }
+    /// # find_max_slow("123").expect("why is the test harness OOMing on 12 bytes?");
+    /// ```
+    #[unstable(feature = "try_reserve_2", issue = "91789")]
+    #[inline]
+    pub fn try_reserve(&mut self, additional: usize) -> Result<(), TryReserveError> {
+        self.inner.try_reserve(additional)
+    }
+
     /// Reserves the minimum capacity for exactly `additional` more capacity to
     /// be inserted in the given `OsString`. Does nothing if the capacity is
     /// already sufficient.
@@ -288,6 +326,49 @@ impl OsString {
     #[inline]
     pub fn reserve_exact(&mut self, additional: usize) {
         self.inner.reserve_exact(additional)
+    }
+
+    /// Tries to reserve the minimum capacity for exactly `additional`
+    /// elements to be inserted in the given `OsString`. After calling
+    /// `try_reserve_exact`, capacity will be greater than or equal to
+    /// `self.len() + additional` if it returns `Ok(())`.
+    /// Does nothing if the capacity is already sufficient.
+    ///
+    /// Note that the allocator may give the collection more space than it
+    /// requests. Therefore, capacity can not be relied upon to be precisely
+    /// minimal. Prefer [`try_reserve`] if future insertions are expected.
+    ///
+    /// [`try_reserve`]: OsString::try_reserve
+    ///
+    /// # Errors
+    ///
+    /// If the capacity overflows, or the allocator reports a failure, then an error
+    /// is returned.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(try_reserve_2)]
+    /// use std::ffi::OsString;
+    /// use std::collections::TryReserveError;
+    ///
+    /// fn find_max_slow(data: &str) -> Result<OsString, TryReserveError> {
+    ///     let mut s = OsString::from(data);
+    ///
+    ///     // Pre-reserve the memory, exiting if we can't
+    ///     s.try_reserve_exact(data.len())?;
+    ///
+    ///     // Now we know this can't OOM in the middle of our complex work
+    ///     s.push(data);
+    ///
+    ///     Ok(s)
+    /// }
+    /// # find_max_slow("123").expect("why is the test harness OOMing on 12 bytes?");
+    /// ```
+    #[unstable(feature = "try_reserve_2", issue = "91789")]
+    #[inline]
+    pub fn try_reserve_exact(&mut self, additional: usize) -> Result<(), TryReserveError> {
+        self.inner.try_reserve_exact(additional)
     }
 
     /// Shrinks the capacity of the `OsString` to match its length.

--- a/library/std/src/sys/unix/os_str.rs
+++ b/library/std/src/sys/unix/os_str.rs
@@ -2,6 +2,7 @@
 //! systems: just a `Vec<u8>`/`[u8]`.
 
 use crate::borrow::Cow;
+use crate::collections::TryReserveError;
 use crate::fmt;
 use crate::fmt::Write;
 use crate::mem;
@@ -113,8 +114,18 @@ impl Buf {
     }
 
     #[inline]
+    pub fn try_reserve(&mut self, additional: usize) -> Result<(), TryReserveError> {
+        self.inner.try_reserve(additional)
+    }
+
+    #[inline]
     pub fn reserve_exact(&mut self, additional: usize) {
         self.inner.reserve_exact(additional)
+    }
+
+    #[inline]
+    pub fn try_reserve_exact(&mut self, additional: usize) -> Result<(), TryReserveError> {
+        self.inner.try_reserve_exact(additional)
     }
 
     #[inline]

--- a/library/std/src/sys/windows/os_str.rs
+++ b/library/std/src/sys/windows/os_str.rs
@@ -1,6 +1,7 @@
 /// The underlying OsString/OsStr implementation on Windows is a
 /// wrapper around the "WTF-8" encoding; see the `wtf8` module for more.
 use crate::borrow::Cow;
+use crate::collections::TryReserveError;
 use crate::fmt;
 use crate::mem;
 use crate::rc::Rc;
@@ -104,8 +105,16 @@ impl Buf {
         self.inner.reserve(additional)
     }
 
+    pub fn try_reserve(&mut self, additional: usize) -> Result<(), TryReserveError> {
+        self.inner.try_reserve(additional)
+    }
+
     pub fn reserve_exact(&mut self, additional: usize) {
         self.inner.reserve_exact(additional)
+    }
+
+    pub fn try_reserve_exact(&mut self, additional: usize) -> Result<(), TryReserveError> {
+        self.inner.try_reserve_exact(additional)
     }
 
     pub fn shrink_to_fit(&mut self) {

--- a/library/std/src/sys_common/wtf8.rs
+++ b/library/std/src/sys_common/wtf8.rs
@@ -22,6 +22,7 @@ use core::str::next_code_point;
 
 use crate::borrow::Cow;
 use crate::char;
+use crate::collections::TryReserveError;
 use crate::fmt;
 use crate::hash::{Hash, Hasher};
 use crate::iter::FromIterator;
@@ -231,9 +232,45 @@ impl Wtf8Buf {
         self.bytes.reserve(additional)
     }
 
+    /// Tries to reserve capacity for at least `additional` more elements to be inserted
+    /// in the given `Wtf8Buf`. The collection may reserve more space to avoid
+    /// frequent reallocations. After calling `try_reserve`, capacity will be
+    /// greater than or equal to `self.len() + additional`. Does nothing if
+    /// capacity is already sufficient.
+    ///
+    /// # Errors
+    ///
+    /// If the capacity overflows, or the allocator reports a failure, then an error
+    /// is returned.
+    #[inline]
+    pub fn try_reserve(&mut self, additional: usize) -> Result<(), TryReserveError> {
+        self.bytes.try_reserve(additional)
+    }
+
     #[inline]
     pub fn reserve_exact(&mut self, additional: usize) {
         self.bytes.reserve_exact(additional)
+    }
+
+    /// Tries to reserve the minimum capacity for exactly `additional`
+    /// elements to be inserted in the given `Wtf8Buf`. After calling
+    /// `try_reserve_exact`, capacity will be greater than or equal to
+    /// `self.len() + additional` if it returns `Ok(())`.
+    /// Does nothing if the capacity is already sufficient.
+    ///
+    /// Note that the allocator may give the collection more space than it
+    /// requests. Therefore, capacity can not be relied upon to be precisely
+    /// minimal. Prefer [`try_reserve`] if future insertions are expected.
+    ///
+    /// [`try_reserve`]: Wtf8Buf::try_reserve
+    ///
+    /// # Errors
+    ///
+    /// If the capacity overflows, or the allocator reports a failure, then an error
+    /// is returned.
+    #[inline]
+    pub fn try_reserve_exact(&mut self, additional: usize) -> Result<(), TryReserveError> {
+        self.bytes.try_reserve_exact(additional)
     }
 
     #[inline]

--- a/library/std/src/sys_common/wtf8.rs
+++ b/library/std/src/sys_common/wtf8.rs
@@ -232,8 +232,8 @@ impl Wtf8Buf {
         self.bytes.reserve(additional)
     }
 
-    /// Tries to reserve capacity for at least `additional` more elements to be inserted
-    /// in the given `Wtf8Buf`. The collection may reserve more space to avoid
+    /// Tries to reserve capacity for at least `additional` more length units
+    /// in the given `Wtf8Buf`. The `Wtf8Buf` may reserve more space to avoid
     /// frequent reallocations. After calling `try_reserve`, capacity will be
     /// greater than or equal to `self.len() + additional`. Does nothing if
     /// capacity is already sufficient.
@@ -253,12 +253,12 @@ impl Wtf8Buf {
     }
 
     /// Tries to reserve the minimum capacity for exactly `additional`
-    /// elements to be inserted in the given `Wtf8Buf`. After calling
+    /// length units in the given `Wtf8Buf`. After calling
     /// `try_reserve_exact`, capacity will be greater than or equal to
     /// `self.len() + additional` if it returns `Ok(())`.
     /// Does nothing if the capacity is already sufficient.
     ///
-    /// Note that the allocator may give the collection more space than it
+    /// Note that the allocator may give the `Wtf8Buf` more space than it
     /// requests. Therefore, capacity can not be relied upon to be precisely
     /// minimal. Prefer [`try_reserve`] if future insertions are expected.
     ///


### PR DESCRIPTION
Add `try_reserve` and `try_reserve_exact` for OsString.

Part of https://github.com/rust-lang/rust/issues/91789

I will squash the commits after PR is ready to merge.

Signed-off-by: Xuanwo <github@xuanwo.io>