### PR TITLE
Fix rustdoc::private_doc_tests lint for public re-exported items

### DIFF
--- a/src/librustdoc/passes/check_doc_test_visibility.rs
+++ b/src/librustdoc/passes/check_doc_test_visibility.rs
@@ -131,7 +131,7 @@ crate fn look_for_tests<'tcx>(cx: &DocContext<'tcx>, dox: &str, item: &Item) {
             );
         }
     } else if tests.found_tests > 0
-        && !cx.cache.access_levels.is_public(item.def_id.expect_def_id())
+        && !cx.cache.access_levels.is_exported(item.def_id.expect_def_id())
     {
         cx.tcx.struct_span_lint_hir(
             crate::lint::PRIVATE_DOC_TESTS,

--- a/src/test/rustdoc-ui/private-public-item-doc-test.rs
+++ b/src/test/rustdoc-ui/private-public-item-doc-test.rs
@@ -1,0 +1,11 @@
+#![deny(rustdoc::private_doc_tests)]
+
+mod foo {
+    /// private doc test
+    ///
+    /// ```
+    /// assert!(false);
+    /// ```
+    //~^^^^^ ERROR documentation test in private item
+    pub fn bar() {}
+}

--- a/src/test/rustdoc-ui/private-public-item-doc-test.stderr
+++ b/src/test/rustdoc-ui/private-public-item-doc-test.stderr
@@ -1,0 +1,18 @@
+error: documentation test in private item
+  --> $DIR/private-public-item-doc-test.rs:4:5
+   |
+LL | /     /// private doc test
+LL | |     ///
+LL | |     /// ```
+LL | |     /// assert!(false);
+LL | |     /// ```
+   | |___________^
+   |
+note: the lint level is defined here
+  --> $DIR/private-public-item-doc-test.rs:1:9
+   |
+LL | #![deny(rustdoc::private_doc_tests)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+

--- a/src/test/rustdoc-ui/public-reexported-item-doc-test.rs
+++ b/src/test/rustdoc-ui/public-reexported-item-doc-test.rs
@@ -1,0 +1,14 @@
+// check-pass
+
+#![deny(rustdoc::private_doc_tests)]
+
+mod foo {
+    /// re-exported doc test
+    ///
+    /// ```
+    /// assert!(true);
+    /// ```
+    pub fn bar() {}
+}
+
+pub use foo::bar;

--- a/src/test/rustdoc-ui/public-reexported-item-doc-test.rs
+++ b/src/test/rustdoc-ui/public-reexported-item-doc-test.rs
@@ -2,7 +2,9 @@
 
 #![deny(rustdoc::private_doc_tests)]
 
-mod foo {
+pub fn foo() {}
+
+mod private {
     /// re-exported doc test
     ///
     /// ```
@@ -11,4 +13,4 @@ mod foo {
     pub fn bar() {}
 }
 
-pub use foo::bar;
+pub use private::bar;


### PR DESCRIPTION
Closes #72081

This involves changing the lint to check the access level is exported, rather than public.
The [exported access level](https://github.com/rust-lang/rust/blob/e91ad5fc62bdee4a29c18baa5fad2ca42fc91bf4/compiler/rustc_middle/src/middle/privacy.rs#L24) accounts for public items and items accessible to other crates with the help of `pub use` re-exports. 
The pattern of re-exporting public items from a private module is usage seen in a number of popular crates.