### PR TITLE
Fix invalid removal of newlines from doc comments

### DIFF
--- a/compiler/rustc_ast/src/util/comments.rs
+++ b/compiler/rustc_ast/src/util/comments.rs
@@ -34,15 +34,8 @@ pub fn beautify_doc_string(data: Symbol) -> Symbol {
             i += 1;
         }
 
-        while i < j && lines[i].trim().is_empty() {
-            i += 1;
-        }
         // like the first, a last line of all stars should be omitted
         if j > i && !lines[j - 1].is_empty() && lines[j - 1].chars().all(|c| c == '*') {
-            j -= 1;
-        }
-
-        while j > i && lines[j - 1].trim().is_empty() {
             j -= 1;
         }
 

--- a/src/test/rustdoc/mixing-doc-comments-and-attrs.S1_top-doc.html
+++ b/src/test/rustdoc/mixing-doc-comments-and-attrs.S1_top-doc.html
@@ -1,4 +1,4 @@
-<div class="docblock"><p>Hello world!
-Goodbye!
+<div class="docblock"><p>Hello world!</p>
+<p>Goodbye!
 Hello again!</p>
 </div>

--- a/src/test/rustdoc/mixing-doc-comments-and-attrs.S3_top-doc.html
+++ b/src/test/rustdoc/mixing-doc-comments-and-attrs.S3_top-doc.html
@@ -1,0 +1,3 @@
+<div class="docblock"><p>Par 1</p>
+<p>Par 2</p>
+</div>

--- a/src/test/rustdoc/mixing-doc-comments-and-attrs.rs
+++ b/src/test/rustdoc/mixing-doc-comments-and-attrs.rs
@@ -16,3 +16,10 @@ pub struct S1;
 #[doc = "Goodbye!"]
 /// Hello again!
 pub struct S2;
+
+// @has 'foo/struct.S3.html'
+// @snapshot S3_top-doc - '//details[@class="rustdoc-toggle top-doc"]/div[@class="docblock"]'
+/** Par 1
+*/ ///
+/// Par 2
+pub struct S3;


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/91201.

Before:

![Screenshot from 2021-12-28 17-02-11](https://user-images.githubusercontent.com/3050060/147585187-c8e67531-c1b4-457d-9d30-d5b44bf91fea.png)

After:

![Screenshot from 2021-12-28 17-02-25](https://user-images.githubusercontent.com/3050060/147585190-30aa0398-1fc7-4fe7-9e8b-5c475d4f9613.png)

r? @camelid 