### PR TITLE
Future deprecation of `env::{set, remove}_var`

### DIFF
--- a/library/std/src/env.rs
+++ b/library/std/src/env.rs
@@ -327,6 +327,7 @@ impl Error for VarError {
 /// assert_eq!(env::var(key), Ok("VALUE".to_string()));
 /// ```
 #[stable(feature = "env", since = "1.0.0")]
+#[rustc_deprecated(since = "TBD", reason = "method is unsound")]
 pub fn set_var<K: AsRef<OsStr>, V: AsRef<OsStr>>(key: K, value: V) {
     _set_var(key.as_ref(), value.as_ref())
 }
@@ -369,6 +370,7 @@ fn _set_var(key: &OsStr, value: &OsStr) {
 /// assert!(env::var(key).is_err());
 /// ```
 #[stable(feature = "env", since = "1.0.0")]
+#[rustc_deprecated(since = "TBD", reason = "method is unsound")]
 pub fn remove_var<K: AsRef<OsStr>>(key: K) {
     _remove_var(key.as_ref())
 }


### PR DESCRIPTION
At some point in the future it is quite likely that `std::env::set_var` and `std::env::remove_var` will be deprecated. There appears to be consensus that this should happen per [a poll on IRLO](https://internals.rust-lang.org/t/synchronized-ffi-access-to-posix-environment-variable-functions/15475/155?u=jhpratt). The only blocker to actually deprecating these methods is agreement on what should replace them. This PR serves two purposes: indicate they will be deprecated in documentation and trigger the `deprecated_in_future` lint.

@rustbot label +S-waiting-on-review +T-libs-api 