### PR TITLE
Resolve concern of `derive_default_enum`

### DIFF
--- a/compiler/rustc_builtin_macros/src/deriving/default.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/default.rs
@@ -222,9 +222,6 @@ fn validate_default_attribute(
             "this method must only be called with a variant that has a `#[default]` attribute",
         ),
         [first, rest @ ..] => {
-            // FIXME(jhpratt) Do we want to perform this check? It doesn't exist
-            // for `#[inline]`, `#[non_exhaustive]`, and presumably others.
-
             let suggestion_text =
                 if rest.len() == 1 { "try removing this" } else { "try removing these" };
 


### PR DESCRIPTION
This resolves the concern in favor of prohibiting multiple instances of
the attribute. This is similar to non-helper attributes as introduced in
#88681.

@rustbot label +S-waiting-on-review +T-libs-api