### PR TITLE
Remove pretty printer space inside block with only outer attrs

### DIFF
--- a/src/test/pretty/attr-fn-inner.rs
+++ b/src/test/pretty/attr-fn-inner.rs
@@ -9,8 +9,8 @@
 fn main() {
     #![rustc_dummy]
     #[rustc_dummy]
-    fn f() { }
+    fn f() {}
 
     #[rustc_dummy]
-    fn g() { }
+    fn g() {}
 }

--- a/src/test/pretty/attr-literals.rs
+++ b/src/test/pretty/attr-literals.rs
@@ -7,8 +7,8 @@
 fn main() {
     #![rustc_dummy("hi", 1, 2, 1.012, pi = 3.14, bye, name("John"))]
     #[rustc_dummy = 8]
-    fn f() { }
+    fn f() {}
 
     #[rustc_dummy(1, 2, 3)]
-    fn g() { }
+    fn g() {}
 }

--- a/src/test/pretty/attr-tokens-raw-ident.rs
+++ b/src/test/pretty/attr-tokens-raw-ident.rs
@@ -4,4 +4,4 @@
 // pp-exact
 
 #[rustfmt::r#final(final)]
-fn main() { }
+fn main() {}

--- a/src/test/pretty/delimited-token-groups.rs
+++ b/src/test/pretty/delimited-token-groups.rs
@@ -45,4 +45,4 @@ mac! {
   }]
 #[rustc_dummy =
   "aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa aaaaaaaa"]
-fn main() { }
+fn main() {}

--- a/src/test/pretty/doc-comments.rs
+++ b/src/test/pretty/doc-comments.rs
@@ -5,7 +5,7 @@
 // some single-line non-doc comment
 
 /// some single line outer-docs
-fn a() { }
+fn a() {}
 
 fn b() {
     //! some single line inner-docs
@@ -17,7 +17,7 @@ fn b() {
 //////////////////////////////////
 /// some single-line outer-docs preceded by a separator
 /// (and trailing whitespaces)
-fn c() { }
+fn c() {}
 
 /*
  * some multi-line non-doc comment
@@ -26,7 +26,7 @@ fn c() { }
 /**
  * some multi-line outer-docs
  */
-fn d() { }
+fn d() {}
 
 fn e() {
     /*!
@@ -43,10 +43,10 @@ fn e() {
 /**
  * some multi-line outer-docs preceded by a separator
  */
-fn f() { }
+fn f() {}
 
 #[doc = "unsugared outer doc-comments work also"]
-fn g() { }
+fn g() {}
 
 fn h() {
     #![doc = "as do inner ones"]

--- a/src/test/ui/macros/stringify.rs
+++ b/src/test/ui/macros/stringify.rs
@@ -235,7 +235,7 @@ fn test_expr() {
             #[attr]
             {}
         ),
-        "#[attr] { }", // FIXME
+        "#[attr] {}",
     );
     assert_eq!(
         stringify_expr!(


### PR DESCRIPTION
Follow-up to #92238 fixing one of the FIXMEs.

```rust
macro_rules! repro {
    ($expr:expr) => {
        stringify!($expr)
    };
}

fn main() {
    println!("{}", repro!(#[attr] {}));
}
```

Before:&ensp;`#[attr] { }`
After:&ensp;`#[attr] {}`