### PR TITLE
Print space after formal generic params in fn type

### DIFF
--- a/compiler/rustc_ast_pretty/src/pprust/state.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state.rs
@@ -2908,10 +2908,7 @@ impl<'a> State<'a> {
         generic_params: &[ast::GenericParam],
     ) {
         self.ibox(INDENT_UNIT);
-        if !generic_params.is_empty() {
-            self.word("for");
-            self.print_generic_params(generic_params);
-        }
+        self.print_formal_generic_params(generic_params);
         let generics = ast::Generics {
             params: Vec::new(),
             where_clause: ast::WhereClause {

--- a/compiler/rustc_hir_pretty/src/lib.rs
+++ b/compiler/rustc_hir_pretty/src/lib.rs
@@ -2327,10 +2327,7 @@ impl<'a> State<'a> {
         arg_names: &[Ident],
     ) {
         self.ibox(INDENT_UNIT);
-        if !generic_params.is_empty() {
-            self.word("for");
-            self.print_generic_params(generic_params);
-        }
+        self.print_formal_generic_params(generic_params);
         let generics = hir::Generics {
             params: &[],
             where_clause: hir::WhereClause { predicates: &[], span: rustc_span::DUMMY_SP },

--- a/src/test/ui/macros/stringify.rs
+++ b/src/test/ui/macros/stringify.rs
@@ -803,7 +803,7 @@ fn test_ty() {
     assert_eq!(stringify_ty!(fn(x: u8)), "fn(x: u8)");
     #[rustfmt::skip]
     assert_eq!(stringify_ty!(for<> fn()), "fn()");
-    assert_eq!(stringify_ty!(for<'a> fn()), "for<'a>fn()"); // FIXME
+    assert_eq!(stringify_ty!(for<'a> fn()), "for<'a> fn()");
 
     // TyKind::Never
     assert_eq!(stringify_ty!(!), "!");


### PR DESCRIPTION
Follow-up to #92238 fixing one of the FIXMEs.

```rust
macro_rules! repro {
    ($ty:ty) => {
        stringify!($ty)
    };
}

fn main() {
    println!("{}", repro!(for<'a> fn(&'a u8)));
}
```

Before:&ensp;`for<'a>fn(&'a u8)`
After:&ensp;`for<'a> fn(&'a u8)`

The pretty printer's `print_formal_generic_params` already prints formal generic params correctly with a space, we just need to call it when printing BareFn types instead of reimplementing the printing incorrectly without a space.

https://github.com/rust-lang/rust/blob/83b15bfe1c15f325bc186ebfe3691b729ed59f2b/compiler/rustc_ast_pretty/src/pprust/state.rs#L1394-L1400