### PR TITLE
Make `unused_lifetimes` lint warn-by-default

### DIFF
--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -1540,7 +1540,7 @@ declare_lint! {
     /// Unused lifetime parameters may signal a mistake or unfinished code.
     /// Consider removing the parameter.
     pub UNUSED_LIFETIMES,
-    Allow,
+    Warn,
     "detects lifetime parameters that are never used"
 }
 


### PR DESCRIPTION
There are no open issues related to this lint, and
it would be useful to have turned on.