### PR TITLE
Fix a minor mistake in `String::try_reserve_exact` examples

### DIFF
--- a/library/alloc/src/string.rs
+++ b/library/alloc/src/string.rs
@@ -1062,7 +1062,7 @@ impl String {
     ///     let mut output = String::new();
     ///
     ///     // Pre-reserve the memory, exiting if we can't
-    ///     output.try_reserve(data.len())?;
+    ///     output.try_reserve_exact(data.len())?;
     ///
     ///     // Now we know this can't OOM in the middle of our complex work
     ///     output.push_str(data);


### PR DESCRIPTION
The examples of `String::try_reserve_exact` didn't actually use `try_reserve_exact`, which was probably a minor mistake, and this PR fixed it.