### PR TITLE
Regression test for borrowck ICE #92015

### DIFF
--- a/src/test/ui/borrowck/issue-92015.rs
+++ b/src/test/ui/borrowck/issue-92015.rs
@@ -1,0 +1,7 @@
+// Regression test for #92105.
+// ICE when mutating immutable reference from last statement of a block.
+
+fn main() {
+    let foo = Some(&0).unwrap();
+    *foo = 1; //~ ERROR cannot assign
+}

--- a/src/test/ui/borrowck/issue-92015.stderr
+++ b/src/test/ui/borrowck/issue-92015.stderr
@@ -1,0 +1,11 @@
+error[E0594]: cannot assign to `*foo`, which is behind a `&` reference
+  --> $DIR/issue-92015.rs:6:5
+   |
+LL |     let foo = Some(&0).unwrap();
+   |         --- help: consider changing this to be a mutable reference: `&mut i32`
+LL |     *foo = 1;
+   |     ^^^^^^^^ `foo` is a `&` reference, so the data it refers to cannot be written
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0594`.


### PR DESCRIPTION
This issue has come up a few times. Creating a regression test.
Closes #92015. 