### PR TITLE
Store NtLiteral without generalizing to Expr

### DIFF
--- a/compiler/rustc_ast/src/ast_like.rs
+++ b/compiler/rustc_ast/src/ast_like.rs
@@ -44,7 +44,7 @@ impl AstLike for crate::token::Nonterminal {
         match self {
             Nonterminal::NtItem(item) => item.attrs(),
             Nonterminal::NtStmt(stmt) => stmt.attrs(),
-            Nonterminal::NtExpr(expr) | Nonterminal::NtLiteral(expr) => expr.attrs(),
+            Nonterminal::NtExpr(expr) => expr.attrs(),
             Nonterminal::NtPat(_)
             | Nonterminal::NtTy(_)
             | Nonterminal::NtMeta(_)
@@ -53,14 +53,15 @@ impl AstLike for crate::token::Nonterminal {
             | Nonterminal::NtTT(_)
             | Nonterminal::NtBlock(_)
             | Nonterminal::NtIdent(..)
-            | Nonterminal::NtLifetime(_) => &[],
+            | Nonterminal::NtLifetime(_)
+            | Nonterminal::NtLiteral(_) => &[],
         }
     }
     fn visit_attrs(&mut self, f: impl FnOnce(&mut Vec<Attribute>)) {
         match self {
             Nonterminal::NtItem(item) => item.visit_attrs(f),
             Nonterminal::NtStmt(stmt) => stmt.visit_attrs(f),
-            Nonterminal::NtExpr(expr) | Nonterminal::NtLiteral(expr) => expr.visit_attrs(f),
+            Nonterminal::NtExpr(expr) => expr.visit_attrs(f),
             Nonterminal::NtPat(_)
             | Nonterminal::NtTy(_)
             | Nonterminal::NtMeta(_)
@@ -69,21 +70,25 @@ impl AstLike for crate::token::Nonterminal {
             | Nonterminal::NtTT(_)
             | Nonterminal::NtBlock(_)
             | Nonterminal::NtIdent(..)
-            | Nonterminal::NtLifetime(_) => {}
+            | Nonterminal::NtLifetime(_)
+            | Nonterminal::NtLiteral(_) => {}
         }
     }
     fn tokens_mut(&mut self) -> Option<&mut Option<LazyTokenStream>> {
         match self {
             Nonterminal::NtItem(item) => item.tokens_mut(),
             Nonterminal::NtStmt(stmt) => stmt.tokens_mut(),
-            Nonterminal::NtExpr(expr) | Nonterminal::NtLiteral(expr) => expr.tokens_mut(),
+            Nonterminal::NtExpr(expr) => expr.tokens_mut(),
             Nonterminal::NtPat(pat) => pat.tokens_mut(),
             Nonterminal::NtTy(ty) => ty.tokens_mut(),
             Nonterminal::NtMeta(attr_item) => attr_item.tokens_mut(),
             Nonterminal::NtPath(path) => path.tokens_mut(),
             Nonterminal::NtVis(vis) => vis.tokens_mut(),
             Nonterminal::NtBlock(block) => block.tokens_mut(),
-            Nonterminal::NtIdent(..) | Nonterminal::NtLifetime(..) | Nonterminal::NtTT(..) => None,
+            Nonterminal::NtIdent(..)
+            | Nonterminal::NtLifetime(..)
+            | Nonterminal::NtLiteral(_)
+            | Nonterminal::NtTT(..) => None,
         }
     }
 }

--- a/compiler/rustc_ast/src/mut_visit.rs
+++ b/compiler/rustc_ast/src/mut_visit.rs
@@ -781,7 +781,13 @@ pub fn visit_interpolated<T: MutVisitor>(nt: &mut token::Nonterminal, vis: &mut 
         token::NtTy(ty) => vis.visit_ty(ty),
         token::NtIdent(ident, _is_raw) => vis.visit_ident(ident),
         token::NtLifetime(ident) => vis.visit_ident(ident),
-        token::NtLiteral(expr) => vis.visit_expr(expr),
+        token::NtLiteral(signed) => {
+            if let Some(neg_span) = &mut signed.neg {
+                vis.visit_span(neg_span);
+            }
+            vis.visit_span(&mut signed.lit.span);
+            vis.visit_span(&mut signed.span);
+        }
         token::NtMeta(item) => {
             let AttrItem { path, args, tokens } = item.deref_mut();
             vis.visit_path(path);

--- a/compiler/rustc_ast/src/token.rs
+++ b/compiler/rustc_ast/src/token.rs
@@ -679,12 +679,21 @@ pub enum Nonterminal {
     NtTy(P<ast::Ty>),
     NtIdent(Ident, /* is_raw */ bool),
     NtLifetime(Ident),
-    NtLiteral(P<ast::Expr>),
+    NtLiteral(SignedLiteral),
     /// Stuff inside brackets for attributes
     NtMeta(P<ast::AttrItem>),
     NtPath(ast::Path),
     NtVis(ast::Visibility),
     NtTT(TokenTree),
+}
+
+#[derive(Clone, Encodable, Decodable)]
+pub struct SignedLiteral {
+    pub neg: Option<Span>,
+    pub lit: P<ast::Lit>,
+    // If neg is None, then identical to lit.span.
+    // If neg is Some, then neg.to(lit.span).
+    pub span: Span,
 }
 
 // `Nonterminal` is used a lot. Make sure it doesn't unintentionally get bigger.
@@ -776,9 +785,10 @@ impl Nonterminal {
             NtBlock(block) => block.span,
             NtStmt(stmt) => stmt.span,
             NtPat(pat) => pat.span,
-            NtExpr(expr) | NtLiteral(expr) => expr.span,
+            NtExpr(expr) => expr.span,
             NtTy(ty) => ty.span,
             NtIdent(ident, _) | NtLifetime(ident) => ident.span,
+            NtLiteral(lit) => lit.span,
             NtMeta(attr_item) => attr_item.span(),
             NtPath(path) => path.span,
             NtVis(vis) => vis.span,

--- a/compiler/rustc_ast/src/util/literal.rs
+++ b/compiler/rustc_ast/src/util/literal.rs
@@ -217,9 +217,13 @@ impl Lit {
             }
             token::Literal(lit) => lit,
             token::Interpolated(ref nt) => {
-                if let token::NtExpr(expr) | token::NtLiteral(expr) = &**nt {
+                if let token::NtExpr(expr) = &**nt {
                     if let ast::ExprKind::Lit(lit) = &expr.kind {
                         return Ok(lit.clone());
+                    }
+                } else if let token::NtLiteral(signed) = &**nt {
+                    if signed.neg.is_none() {
+                        return Ok((*signed.lit).clone());
                     }
                 }
                 return Err(LitError::NotLiteral);

--- a/compiler/rustc_ast_pretty/src/pprust/state.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state.rs
@@ -706,7 +706,13 @@ pub trait PrintState<'a>: std::ops::Deref<Target = pp::Printer> + std::ops::Dere
             token::NtPat(ref e) => self.pat_to_string(e),
             token::NtIdent(e, is_raw) => IdentPrinter::for_ast_ident(e, is_raw).to_string(),
             token::NtLifetime(e) => e.to_string(),
-            token::NtLiteral(ref e) => self.expr_to_string(e),
+            token::NtLiteral(ref e) => {
+                let mut string = literal_to_string(e.lit.token);
+                if e.neg.is_some() {
+                    string.insert(0, '-');
+                }
+                string
+            }
             token::NtTT(ref tree) => self.tt_to_string(tree),
             token::NtVis(ref e) => self.vis_to_string(e),
         }


### PR DESCRIPTION
The discussion under #91166 raised the question of whether a NtLiteral (the value of a `$:literal` matcher in macro_rules) can be conceptualized as a single token, the way that `$:ident` is. Today it isn't &mdash; a negative literal is passed to procedural macros as a pair of proc macro tokens:

```rust
// main.rs

macro_rules! fwd {
    ($literal:literal) => {
        repro!($literal);
    };
}

fwd!(-1);
```

```rust
// lib.rs

#[proc_macro]
pub fn repro(input: TokenStream) -> TokenStream {
    println!("{:#?}", input);
    TokenStream::new()
}
```

```console
TokenStream [
    Group {
        delimiter: None,
        stream: TokenStream [
            Punct {
                ch: '-',
                spacing: Alone,
            },
            Literal {
                kind: Integer,
                symbol: "1",
                suffix: None,
            },
        ],
    },
]
```

However proc macro literals *already* support negative literals in a single token, and it's easy to construct one: `proc_macro::Literal::i32_unsuffixed(-1)`. As such, given that macro_rules's `$:literal` and proc_macro::Literal are both already capable of representing negative literals in one piece, I think having those literals fall apart on entry into the proc macro is not a great behavior. My expectation would be that the proc macro call in the snippet above would pass a single token which is equivalent to `proc_macro::Literal::i32_unsuffixed(-1)`, and I'd like to start making changes in that direction.

This PR does not make any intentional observable behavior change, but it replaces the way that `$:literal` is represented internally from `P<Expr>` (which happens to be always either `ExprKind::Lit` or `ExprKind::Unary(UnOp::Neg, ExprKind::Lit)` if rustc is correctly implemented) to a dedicated `SignedLiteral` type. This makes illegal states unrepresentable and will make it more straightforward to map `$:literal` one-to-one to proc_macro::Literal whenever that comes up.