### PR TITLE
Remove CommandEnv::apply

### DIFF
--- a/library/std/src/sys_common/process.rs
+++ b/library/std/src/sys_common/process.rs
@@ -39,22 +39,6 @@ impl CommandEnv {
         result
     }
 
-    // Apply these changes directly to the current environment
-    pub fn apply(&self) {
-        if self.clear {
-            for (k, _) in env::vars_os() {
-                env::remove_var(k);
-            }
-        }
-        for (key, maybe_val) in self.vars.iter() {
-            if let Some(ref val) = maybe_val {
-                env::set_var(key, val);
-            } else {
-                env::remove_var(key);
-            }
-        }
-    }
-
     pub fn is_unchanged(&self) -> bool {
         !self.clear && self.vars.is_empty()
     }


### PR DESCRIPTION
It's not being used and uses unsound set_var and remove_var functions. This is an internal function that isn't exported (even with `process_internals` feature), so this shouldn't break anything.

Also see #92365. Note that this isn't the only use of those methods in standard library, so that particular pull request will need more changes than just this to work (in particular, `test_capture_env_at_spawn` is using `set_var` and `remove_var`).