### PR TITLE
Suggest while let x = y when encountering while x = y

### DIFF
--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -2376,7 +2376,9 @@ impl<'a: 'ast, 'b, 'ast> LateResolutionVisitor<'a, 'b, 'ast> {
             ExprKind::While(ref cond, ref block, label) => {
                 self.with_resolved_label(label, expr.id, |this| {
                     this.with_rib(ValueNS, NormalRibKind, |this| {
+                        let old = this.diagnostic_metadata.in_if_condition.replace(cond);
                         this.visit_expr(cond);
+                        this.diagnostic_metadata.in_if_condition = old;
                         this.visit_block(block);
                     })
                 });

--- a/src/test/ui/suggestions/while-let-typo.rs
+++ b/src/test/ui/suggestions/while-let-typo.rs
@@ -1,0 +1,9 @@
+fn main() {
+    let foo = Some(0);
+    let bar = None;
+    while Some(x) = foo {} //~ ERROR cannot find value `x` in this scope
+    while Some(foo) = bar {}
+    while 3 = foo {} //~ ERROR mismatched types
+    while Some(3) = foo {} //~ ERROR invalid left-hand side of assignment
+    while x = 5 {} //~ ERROR cannot find value `x` in this scope
+}

--- a/src/test/ui/suggestions/while-let-typo.stderr
+++ b/src/test/ui/suggestions/while-let-typo.stderr
@@ -1,0 +1,45 @@
+error[E0425]: cannot find value `x` in this scope
+  --> $DIR/while-let-typo.rs:4:16
+   |
+LL |     while Some(x) = foo {}
+   |                ^ not found in this scope
+   |
+help: you might have meant to use pattern matching
+   |
+LL |     while let Some(x) = foo {}
+   |           +++
+
+error[E0425]: cannot find value `x` in this scope
+  --> $DIR/while-let-typo.rs:8:11
+   |
+LL |     while x = 5 {}
+   |           ^ not found in this scope
+   |
+help: you might have meant to use pattern matching
+   |
+LL |     while let x = 5 {}
+   |           +++
+
+error[E0308]: mismatched types
+  --> $DIR/while-let-typo.rs:6:11
+   |
+LL |     while 3 = foo {}
+   |           ^^^^^^^ expected `bool`, found `()`
+
+error[E0070]: invalid left-hand side of assignment
+  --> $DIR/while-let-typo.rs:7:19
+   |
+LL |     while Some(3) = foo {}
+   |                -  ^
+   |                |
+   |                cannot assign to this expression
+   |
+help: you might have meant to use pattern destructuring
+   |
+LL |     while let Some(3) = foo {}
+   |           +++
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0070, E0308, E0425.
+For more information about an error, try `rustc --explain E0070`.


### PR DESCRIPTION
Extends #75931 to also detect where the `let` might be missing from `while let` expressions.