### PR TITLE
Add a couple needs-asm-support headers to tests

### DIFF
--- a/src/test/incremental/hashes/inline_asm.rs
+++ b/src/test/incremental/hashes/inline_asm.rs
@@ -8,6 +8,7 @@
 // build-pass (FIXME(62277): could be check-pass?)
 // revisions: cfail1 cfail2 cfail3 cfail4 cfail5 cfail6
 // compile-flags: -Z query-dep-graph
+// needs-asm-support
 // [cfail1]compile-flags: -Zincremental-ignore-spans
 // [cfail2]compile-flags: -Zincremental-ignore-spans
 // [cfail3]compile-flags: -Zincremental-ignore-spans

--- a/src/test/incremental/issue-72386.rs
+++ b/src/test/incremental/issue-72386.rs
@@ -1,4 +1,5 @@
 // revisions: rpass1 cfail1 rpass3
+// needs-asm-support
 // only-x86_64
 // Regression test for issue #72386
 // Checks that we don't ICE when switching to an invalid register


### PR DESCRIPTION
This will allow them to be ignored by codegen backends that don't support inline asm.