### PR TITLE
Fix double space in pretty printed TryBlock

### DIFF
--- a/compiler/rustc_ast_pretty/src/pprust/state.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state.rs
@@ -2239,7 +2239,6 @@ impl<'a> State<'a> {
             }
             ast::ExprKind::TryBlock(ref blk) => {
                 self.head("try");
-                self.space();
                 self.print_block_with_attrs(blk, attrs)
             }
             ast::ExprKind::Err => {

--- a/src/test/ui/macros/stringify.rs
+++ b/src/test/ui/macros/stringify.rs
@@ -256,7 +256,7 @@ fn test_expr() {
     assert_eq!(stringify_expr!(expr.await), "expr.await");
 
     // ExprKind::TryBlock
-    assert_eq!(stringify_expr!(try {}), "try  {}"); // FIXME
+    assert_eq!(stringify_expr!(try {}), "try {}");
 
     // ExprKind::Assign
     assert_eq!(stringify_expr!(expr = true), "expr = true");


### PR DESCRIPTION
Follow-up to #92238 fixing one of the FIXMEs.

```rust
macro_rules! repro {
    ($expr:expr) => {
        stringify!($expr)
    };
}

fn main() {
    println!("{}", repro!(try {}));
}
```

Before:&ensp;<code>try&nbsp;&nbsp;{}</code>
After:&ensp;<code>try&nbsp;{}</code>

The `head` helper already appends a space:

https://github.com/rust-lang/rust/blob/2b67c30bfece00357d5fc09d99b49f21066f04ba/compiler/rustc_ast_pretty/src/pprust/state.rs#L654-L664

so doing `head` followed by `space` resulted in a double space:

https://github.com/rust-lang/rust/blob/2b67c30bfece00357d5fc09d99b49f21066f04ba/compiler/rustc_ast_pretty/src/pprust/state.rs#L2241-L2242