### PR TITLE
Fix spacing and ordering of words in pretty printed Impl

### DIFF
--- a/compiler/rustc_ast_pretty/src/pprust/state.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state.rs
@@ -1285,13 +1285,16 @@ impl<'a> State<'a> {
                 self.print_visibility(&item.vis);
                 self.print_defaultness(defaultness);
                 self.print_unsafety(unsafety);
-                self.word_nbsp("impl");
-                self.print_constness(constness);
+                self.word("impl");
 
-                if !generics.params.is_empty() {
+                if generics.params.is_empty() {
+                    self.nbsp();
+                } else {
                     self.print_generic_params(&generics.params);
                     self.space();
                 }
+
+                self.print_constness(constness);
 
                 if let ast::ImplPolarity::Negative(_) = polarity {
                     self.word("!");

--- a/src/test/ui/macros/stringify.rs
+++ b/src/test/ui/macros/stringify.rs
@@ -613,6 +613,12 @@ fn test_item() {
     );
     assert_eq!(
         stringify_item!(
+            impl<T> const Trait for T {}
+        ),
+        "impl const <T> Trait for T {}", // FIXME
+    );
+    assert_eq!(
+        stringify_item!(
             impl ~const Struct {}
         ),
         "impl Struct {}", // FIXME

--- a/src/test/ui/macros/stringify.rs
+++ b/src/test/ui/macros/stringify.rs
@@ -603,7 +603,7 @@ fn test_item() {
         stringify_item!(
             impl<T> Struct<T> {}
         ),
-        "impl <T> Struct<T> {}", // FIXME
+        "impl<T> Struct<T> {}",
     );
     assert_eq!(
         stringify_item!(
@@ -615,7 +615,7 @@ fn test_item() {
         stringify_item!(
             impl<T> const Trait for T {}
         ),
-        "impl const <T> Trait for T {}", // FIXME
+        "impl<T> const Trait for T {}",
     );
     assert_eq!(
         stringify_item!(


### PR DESCRIPTION
Follow-up to #92238 fixing one of the FIXMEs.

```rust
macro_rules! repro {
    ($item:item) => {
        stringify!($item)
    };
}

fn main() {
    println!("{}", repro!(impl<T> Struct<T> {}));
    println!("{}", repro!(impl<T> const Trait for T {}));
}
```

Before:&ensp;`impl <T> Struct<T> {}`
After:&ensp;`impl<T> Struct<T> {}`

Before:&ensp;`impl const <T> Trait for T {}` :crying_cat_face: 
After:&ensp;`impl<T> const Trait for T {}`