### PR TITLE
Fix whitespace in pretty printed PatKind::Range

### DIFF
--- a/compiler/rustc_ast_pretty/src/pprust/state.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state.rs
@@ -2515,7 +2515,6 @@ impl<'a> State<'a> {
             PatKind::Range(ref begin, ref end, Spanned { node: ref end_kind, .. }) => {
                 if let Some(e) = begin {
                     self.print_expr(e);
-                    self.space();
                 }
                 match *end_kind {
                     RangeEnd::Included(RangeSyntax::DotDotDot) => self.word("..."),

--- a/compiler/rustc_hir_pretty/src/lib.rs
+++ b/compiler/rustc_hir_pretty/src/lib.rs
@@ -1948,7 +1948,6 @@ impl<'a> State<'a> {
             PatKind::Range(ref begin, ref end, ref end_kind) => {
                 if let Some(expr) = begin {
                     self.print_expr(expr);
-                    self.space();
                 }
                 match *end_kind {
                     RangeEnd::Included => self.word("..."),

--- a/src/test/ui/half-open-range-patterns/half-open-range-pats-ref-ambiguous-interp.stderr
+++ b/src/test/ui/half-open-range-patterns/half-open-range-pats-ref-ambiguous-interp.stderr
@@ -2,7 +2,7 @@ error: the range pattern here has ambiguous interpretation
   --> $DIR/half-open-range-pats-ref-ambiguous-interp.rs:8:10
    |
 LL |         &0.. | _ => {}
-   |          ^^^ help: add parentheses to clarify the precedence: `(0 ..)`
+   |          ^^^ help: add parentheses to clarify the precedence: `(0..)`
 
 error[E0586]: inclusive range with no end
   --> $DIR/half-open-range-pats-ref-ambiguous-interp.rs:10:11
@@ -16,7 +16,7 @@ error: the range pattern here has ambiguous interpretation
   --> $DIR/half-open-range-pats-ref-ambiguous-interp.rs:10:10
    |
 LL |         &0..= | _ => {}
-   |          ^^^^ help: add parentheses to clarify the precedence: `(0 ..=)`
+   |          ^^^^ help: add parentheses to clarify the precedence: `(0..=)`
 
 error[E0586]: inclusive range with no end
   --> $DIR/half-open-range-pats-ref-ambiguous-interp.rs:13:11

--- a/src/test/ui/macros/stringify.rs
+++ b/src/test/ui/macros/stringify.rs
@@ -712,10 +712,10 @@ fn test_pat() {
 
     // PatKind::Range
     assert_eq!(stringify_pat!(..1), "..1");
-    assert_eq!(stringify_pat!(0..), "0 .."); // FIXME
-    assert_eq!(stringify_pat!(0..1), "0 ..1");
-    assert_eq!(stringify_pat!(0..=1), "0 ..=1");
-    assert_eq!(stringify_pat!(-2..=-1), "-2 ..=-1");
+    assert_eq!(stringify_pat!(0..), "0..");
+    assert_eq!(stringify_pat!(0..1), "0..1");
+    assert_eq!(stringify_pat!(0..=1), "0..=1");
+    assert_eq!(stringify_pat!(-2..=-1), "-2..=-1");
 
     // PatKind::Slice
     assert_eq!(stringify_pat!([]), "[]");

--- a/src/test/ui/parser/intersection-patterns.rs
+++ b/src/test/ui/parser/intersection-patterns.rs
@@ -34,7 +34,7 @@ fn main() {
         //~| pattern on the left, should be on the right
         //~| binding on the right, should be on the left
         //~| HELP switch the order
-        //~| SUGGESTION e @ 1 ..=5
+        //~| SUGGESTION e @ 1..=5
         _ => {}
     }
 }

--- a/src/test/ui/parser/intersection-patterns.stderr
+++ b/src/test/ui/parser/intersection-patterns.stderr
@@ -27,7 +27,7 @@ LL |         1 ..= 5 @ e => {}
    |         |         |
    |         |         binding on the right, should be on the left
    |         pattern on the left, should be on the right
-   |         help: switch the order: `e @ 1 ..=5`
+   |         help: switch the order: `e @ 1..=5`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/range/range-inclusive-pattern-precedence.fixed
+++ b/src/test/ui/range/range-inclusive-pattern-precedence.fixed
@@ -12,7 +12,7 @@ pub fn main() {
         //~^ WARN `...` range patterns are deprecated
         //~| WARN this is accepted in the current edition
         //~| HELP use `..=` for an inclusive range
-        &(10 ..=15) => {}
+        &(10..=15) => {}
         //~^ ERROR the range pattern here has ambiguous interpretation
         //~| HELP add parentheses to clarify the precedence
         &(16..=20) => {}

--- a/src/test/ui/range/range-inclusive-pattern-precedence.stderr
+++ b/src/test/ui/range/range-inclusive-pattern-precedence.stderr
@@ -2,7 +2,7 @@ error: the range pattern here has ambiguous interpretation
   --> $DIR/range-inclusive-pattern-precedence.rs:15:10
    |
 LL |         &10..=15 => {}
-   |          ^^^^^^^ help: add parentheses to clarify the precedence: `(10 ..=15)`
+   |          ^^^^^^^ help: add parentheses to clarify the precedence: `(10..=15)`
 
 warning: `...` range patterns are deprecated
   --> $DIR/range-inclusive-pattern-precedence.rs:11:9

--- a/src/test/ui/range/range-inclusive-pattern-precedence2.stderr
+++ b/src/test/ui/range/range-inclusive-pattern-precedence2.stderr
@@ -2,7 +2,7 @@ error: the range pattern here has ambiguous interpretation
   --> $DIR/range-inclusive-pattern-precedence2.rs:14:13
    |
 LL |         box 10..=15 => {}
-   |             ^^^^^^^ help: add parentheses to clarify the precedence: `(10 ..=15)`
+   |             ^^^^^^^ help: add parentheses to clarify the precedence: `(10..=15)`
 
 warning: `...` range patterns are deprecated
   --> $DIR/range-inclusive-pattern-precedence2.rs:10:14

--- a/src/test/ui/unpretty-expr-fn-arg.stdout
+++ b/src/test/ui/unpretty-expr-fn-arg.stdout
@@ -14,4 +14,4 @@ extern crate std;
 
 fn main() ({ } as ())
 
-fn foo((-(128 as i8) as i8) ...(127 as i8): i8) ({ } as ())
+fn foo((-(128 as i8) as i8)...(127 as i8): i8) ({ } as ())


### PR DESCRIPTION
Follow-up to #92238 fixing one of the FIXMEs.

```rust
macro_rules! repro {
    ($pat:pat) => {
        stringify!($pat)
    };
}

fn main() {
    println!("{}", repro!(0..=1));
}
```

Before:&ensp;`0 ..=1`
After:&ensp;`0..=1`

The canonical spacing applied by rustfmt has no space after the lower expr. Rustc's parser diagnostics also do not put a space there:

https://github.com/rust-lang/rust/blob/df96fb166f59431e3de443835e50d5b8a7a4adb0/compiler/rustc_parse/src/parser/pat.rs#L754