### PR TITLE
Link impl items to corresponding trait items in late resolver.

### DIFF
--- a/compiler/rustc_ast_lowering/src/index.rs
+++ b/compiler/rustc_ast_lowering/src/index.rs
@@ -335,7 +335,8 @@ impl<'a, 'hir> Visitor<'hir> for NodeCollector<'a, 'hir> {
     fn visit_impl_item_ref(&mut self, ii: &'hir ImplItemRef) {
         // Do not visit the duplicate information in ImplItemRef. We want to
         // map the actual nodes, not the duplicate ones in the *Ref.
-        let ImplItemRef { id, ident: _, kind: _, span: _, defaultness: _ } = *ii;
+        let ImplItemRef { id, ident: _, kind: _, span: _, defaultness: _, trait_item_def_id: _ } =
+            *ii;
 
         self.visit_nested_impl_item(id);
     }

--- a/compiler/rustc_ast_lowering/src/item.rs
+++ b/compiler/rustc_ast_lowering/src/item.rs
@@ -925,6 +925,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 }
                 AssocItemKind::MacCall(..) => unimplemented!(),
             },
+            trait_item_def_id: self.resolver.get_partial_res(i.id).map(|r| r.base_res().def_id()),
         }
     }
 

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -2885,6 +2885,8 @@ pub struct ImplItemRef {
     pub kind: AssocItemKind,
     pub span: Span,
     pub defaultness: Defaultness,
+    /// When we are in a trait impl, link to the trait-item's id.
+    pub trait_item_def_id: Option<DefId>,
 }
 
 #[derive(Copy, Clone, PartialEq, Encodable, Debug, HashStable_Generic)]

--- a/compiler/rustc_hir/src/intravisit.rs
+++ b/compiler/rustc_hir/src/intravisit.rs
@@ -1088,7 +1088,8 @@ pub fn walk_foreign_item_ref<'v, V: Visitor<'v>>(
 
 pub fn walk_impl_item_ref<'v, V: Visitor<'v>>(visitor: &mut V, impl_item_ref: &'v ImplItemRef) {
     // N.B., deliberately force a compilation error if/when new fields are added.
-    let ImplItemRef { id, ident, ref kind, span: _, ref defaultness } = *impl_item_ref;
+    let ImplItemRef { id, ident, ref kind, span: _, ref defaultness, trait_item_def_id: _ } =
+        *impl_item_ref;
     visitor.visit_nested_impl_item(id);
     visitor.visit_ident(ident);
     visitor.visit_associated_item_kind(kind);

--- a/compiler/rustc_middle/src/ty/assoc.rs
+++ b/compiler/rustc_middle/src/ty/assoc.rs
@@ -139,21 +139,6 @@ impl<'tcx> AssocItems<'tcx> {
         self.items.get_by_key(name).copied()
     }
 
-    /// Returns an iterator over all associated items with the given name.
-    ///
-    /// Multiple items may have the same name if they are in different `Namespace`s. For example,
-    /// an associated type can have the same name as a method. Use one of the `find_by_name_and_*`
-    /// methods below if you know which item you are looking for.
-    pub fn filter_by_name<'a>(
-        &'a self,
-        tcx: TyCtxt<'a>,
-        ident: Ident,
-        parent_def_id: DefId,
-    ) -> impl 'a + Iterator<Item = &'a ty::AssocItem> {
-        self.filter_by_name_unhygienic(ident.name)
-            .filter(move |item| tcx.hygienic_eq(ident, item.ident, parent_def_id))
-    }
-
     /// Returns the associated item with the given name and `AssocKind`, if one exists.
     pub fn find_by_name_and_kind(
         &self,

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -602,6 +602,25 @@ impl<'a> Resolver<'a> {
 
                 err
             }
+            ResolutionError::TraitImplMismatch {
+                name,
+                kind,
+                code,
+                trait_item_span,
+                trait_path,
+            } => {
+                let mut err = self.session.struct_span_err_with_code(
+                    span,
+                    &format!(
+                        "item `{}` is an associated {}, which doesn't match its trait `{}`",
+                        name, kind, trait_path,
+                    ),
+                    code,
+                );
+                err.span_label(span, "does not match trait");
+                err.span_label(trait_item_span, "item in trait");
+                err
+            }
         }
     }
 

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -258,6 +258,14 @@ enum ResolutionError<'a> {
     SelfInGenericParamDefault,
     /// Error E0767: use of unreachable label
     UnreachableLabel { name: Symbol, definition_span: Span, suggestion: Option<LabelSuggestion> },
+    /// Error E0323, E0324, E0325: mismatch between trait item and impl item.
+    TraitImplMismatch {
+        name: Symbol,
+        kind: &'static str,
+        trait_path: String,
+        trait_item_span: Span,
+        code: rustc_errors::DiagnosticId,
+    },
 }
 
 enum VisResolutionError<'a> {

--- a/compiler/rustc_ty_utils/src/assoc.rs
+++ b/compiler/rustc_ty_utils/src/assoc.rs
@@ -1,8 +1,7 @@
 use rustc_data_structures::fx::FxHashMap;
-use rustc_errors::struct_span_err;
 use rustc_hir as hir;
 use rustc_hir::def_id::{DefId, LocalDefId};
-use rustc_middle::ty::{self, TyCtxt, TypeFoldable};
+use rustc_middle::ty::{self, TyCtxt};
 
 pub fn provide(providers: &mut ty::query::Providers) {
     *providers = ty::query::Providers {
@@ -125,115 +124,14 @@ fn associated_item_from_impl_item_ref(
         hir::AssocItemKind::Type => (ty::AssocKind::Type, false),
     };
 
-    let trait_item_def_id = impl_item_base_id(tcx, parent_def_id, impl_item_ref);
-
     ty::AssocItem {
         ident: impl_item_ref.ident,
         kind,
         vis: tcx.visibility(def_id),
         defaultness: impl_item_ref.defaultness,
         def_id: def_id.to_def_id(),
-        trait_item_def_id,
+        trait_item_def_id: impl_item_ref.trait_item_def_id,
         container: ty::ImplContainer(parent_def_id.to_def_id()),
         fn_has_self_parameter: has_self,
     }
-}
-
-fn impl_item_base_id<'tcx>(
-    tcx: TyCtxt<'tcx>,
-    parent_def_id: LocalDefId,
-    impl_item: &hir::ImplItemRef,
-) -> Option<DefId> {
-    let impl_trait_ref = tcx.impl_trait_ref(parent_def_id)?;
-
-    // If the trait reference itself is erroneous (so the compilation is going
-    // to fail), skip checking the items here -- the `impl_item` table in `tcx`
-    // isn't populated for such impls.
-    if impl_trait_ref.references_error() {
-        return None;
-    }
-
-    // Locate trait items
-    let associated_items = tcx.associated_items(impl_trait_ref.def_id);
-
-    // Match item against trait
-    let mut items = associated_items.filter_by_name(tcx, impl_item.ident, impl_trait_ref.def_id);
-
-    let mut trait_item = items.next()?;
-
-    let is_compatible = |ty: &&ty::AssocItem| match (ty.kind, &impl_item.kind) {
-        (ty::AssocKind::Const, hir::AssocItemKind::Const) => true,
-        (ty::AssocKind::Fn, hir::AssocItemKind::Fn { .. }) => true,
-        (ty::AssocKind::Type, hir::AssocItemKind::Type) => true,
-        _ => false,
-    };
-
-    // If we don't have a compatible item, we'll use the first one whose name matches
-    // to report an error.
-    let mut compatible_kind = is_compatible(&trait_item);
-
-    if !compatible_kind {
-        if let Some(ty_trait_item) = items.find(is_compatible) {
-            compatible_kind = true;
-            trait_item = ty_trait_item;
-        }
-    }
-
-    if compatible_kind {
-        Some(trait_item.def_id)
-    } else {
-        report_mismatch_error(tcx, trait_item.def_id, impl_trait_ref, impl_item);
-        None
-    }
-}
-
-#[inline(never)]
-#[cold]
-fn report_mismatch_error<'tcx>(
-    tcx: TyCtxt<'tcx>,
-    trait_item_def_id: DefId,
-    impl_trait_ref: ty::TraitRef<'tcx>,
-    impl_item: &hir::ImplItemRef,
-) {
-    let mut err = match impl_item.kind {
-        hir::AssocItemKind::Const => {
-            // Find associated const definition.
-            struct_span_err!(
-                tcx.sess,
-                impl_item.span,
-                E0323,
-                "item `{}` is an associated const, which doesn't match its trait `{}`",
-                impl_item.ident,
-                impl_trait_ref.print_only_trait_path()
-            )
-        }
-
-        hir::AssocItemKind::Fn { .. } => {
-            struct_span_err!(
-                tcx.sess,
-                impl_item.span,
-                E0324,
-                "item `{}` is an associated method, which doesn't match its trait `{}`",
-                impl_item.ident,
-                impl_trait_ref.print_only_trait_path()
-            )
-        }
-
-        hir::AssocItemKind::Type => {
-            struct_span_err!(
-                tcx.sess,
-                impl_item.span,
-                E0325,
-                "item `{}` is an associated type, which doesn't match its trait `{}`",
-                impl_item.ident,
-                impl_trait_ref.print_only_trait_path()
-            )
-        }
-    };
-
-    err.span_label(impl_item.span, "does not match trait");
-    if let Some(trait_span) = tcx.hir().span_if_local(trait_item_def_id) {
-        err.span_label(trait_span, "item in trait");
-    }
-    err.emit();
 }

--- a/compiler/rustc_typeck/src/check/method/mod.rs
+++ b/compiler/rustc_typeck/src/check/method/mod.rs
@@ -369,7 +369,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         // Trait must have a method named `m_name` and it should not have
         // type parameters or early-bound regions.
         let tcx = self.tcx;
-        let method_item = match self.associated_item(trait_def_id, m_name, Namespace::ValueNS) {
+        let method_item = match self.associated_value(trait_def_id, m_name) {
             Some(method_item) => method_item,
             None => {
                 tcx.sess.delay_span_bug(
@@ -538,15 +538,10 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
     /// Finds item with name `item_name` defined in impl/trait `def_id`
     /// and return it, or `None`, if no such item was defined there.
-    pub fn associated_item(
-        &self,
-        def_id: DefId,
-        item_name: Ident,
-        ns: Namespace,
-    ) -> Option<ty::AssocItem> {
+    pub fn associated_value(&self, def_id: DefId, item_name: Ident) -> Option<ty::AssocItem> {
         self.tcx
             .associated_items(def_id)
-            .find_by_name_and_namespace(self.tcx, item_name, ns, def_id)
+            .find_by_name_and_namespace(self.tcx, item_name, Namespace::ValueNS, def_id)
             .copied()
     }
 }

--- a/compiler/rustc_typeck/src/check/method/probe.rs
+++ b/compiler/rustc_typeck/src/check/method/probe.rs
@@ -1915,7 +1915,7 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
                     .collect()
             } else {
                 self.fcx
-                    .associated_item(def_id, name, Namespace::ValueNS)
+                    .associated_value(def_id, name)
                     .map_or_else(SmallVec::new, |x| SmallVec::from_buf([x]))
             }
         } else {

--- a/compiler/rustc_typeck/src/check/method/suggest.rs
+++ b/compiler/rustc_typeck/src/check/method/suggest.rs
@@ -5,7 +5,6 @@ use crate::check::FnCtxt;
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_errors::{pluralize, struct_span_err, Applicability, DiagnosticBuilder};
 use rustc_hir as hir;
-use rustc_hir::def::Namespace;
 use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_hir::lang_items::LangItem;
 use rustc_hir::{ExprKind, Node, QPath};
@@ -99,16 +98,10 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     CandidateSource::ImplSource(impl_did) => {
                         // Provide the best span we can. Use the item, if local to crate, else
                         // the impl, if local to crate (item may be defaulted), else nothing.
-                        let item = match self
-                            .associated_item(impl_did, item_name, Namespace::ValueNS)
-                            .or_else(|| {
-                                let impl_trait_ref = self.tcx.impl_trait_ref(impl_did)?;
-                                self.associated_item(
-                                    impl_trait_ref.def_id,
-                                    item_name,
-                                    Namespace::ValueNS,
-                                )
-                            }) {
+                        let item = match self.associated_value(impl_did, item_name).or_else(|| {
+                            let impl_trait_ref = self.tcx.impl_trait_ref(impl_did)?;
+                            self.associated_value(impl_trait_ref.def_id, item_name)
+                        }) {
                             Some(item) => item,
                             None => continue,
                         };
@@ -187,11 +180,10 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         }
                     }
                     CandidateSource::TraitSource(trait_did) => {
-                        let item =
-                            match self.associated_item(trait_did, item_name, Namespace::ValueNS) {
-                                Some(item) => item,
-                                None => continue,
-                            };
+                        let item = match self.associated_value(trait_did, item_name) {
+                            Some(item) => item,
+                            None => continue,
+                        };
                         let item_span = self
                             .tcx
                             .sess
@@ -271,16 +263,14 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     // Suggest clamping down the type if the method that is being attempted to
                     // be used exists at all, and the type is an ambiguous numeric type
                     // ({integer}/{float}).
-                    let mut candidates = all_traits(self.tcx).into_iter().filter_map(|info| {
-                        self.associated_item(info.def_id, item_name, Namespace::ValueNS)
-                    });
+                    let mut candidates = all_traits(self.tcx)
+                        .into_iter()
+                        .filter_map(|info| self.associated_value(info.def_id, item_name));
                     // There are methods that are defined on the primitive types and won't be
                     // found when exploring `all_traits`, but we also need them to be acurate on
                     // our suggestions (#47759).
                     let fund_assoc = |opt_def_id: Option<DefId>| {
-                        opt_def_id
-                            .and_then(|id| self.associated_item(id, item_name, Namespace::ValueNS))
-                            .is_some()
+                        opt_def_id.and_then(|id| self.associated_value(id, item_name)).is_some()
                     };
                     let lang_items = tcx.lang_items();
                     let found_candidate = candidates.next().is_some()
@@ -398,11 +388,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                                             .inherent_impls(adt_deref.did)
                                             .iter()
                                             .filter_map(|def_id| {
-                                                self.associated_item(
-                                                    *def_id,
-                                                    item_name,
-                                                    Namespace::ValueNS,
-                                                )
+                                                self.associated_value(*def_id, item_name)
                                             })
                                             .count()
                                             >= 1
@@ -515,9 +501,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                                 .iter()
                                 .copied()
                                 .filter(|def_id| {
-                                    if let Some(assoc) =
-                                        self.associated_item(*def_id, item_name, Namespace::ValueNS)
-                                    {
+                                    if let Some(assoc) = self.associated_value(*def_id, item_name) {
                                         // Check for both mode is the same so we avoid suggesting
                                         // incorrect associated item.
                                         match (mode, assoc.fn_has_self_parameter, source) {
@@ -1588,7 +1572,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     }
                 }) && (type_is_local || info.def_id.is_local())
                     && self
-                        .associated_item(info.def_id, item_name, Namespace::ValueNS)
+                        .associated_value(info.def_id, item_name)
                         .filter(|item| {
                             if let ty::AssocKind::Fn = item.kind {
                                 let id = item

--- a/compiler/rustc_typeck/src/coherence/mod.rs
+++ b/compiler/rustc_typeck/src/coherence/mod.rs
@@ -121,28 +121,6 @@ fn enforce_trait_manually_implementable(
             return;
         }
     }
-
-    let trait_name = if did == li.fn_trait() {
-        "Fn"
-    } else if did == li.fn_mut_trait() {
-        "FnMut"
-    } else if did == li.fn_once_trait() {
-        "FnOnce"
-    } else {
-        return; // everything OK
-    };
-
-    let span = impl_header_span(tcx, impl_def_id);
-    struct_span_err!(
-        tcx.sess,
-        span,
-        E0183,
-        "manual implementations of `{}` are experimental",
-        trait_name
-    )
-    .span_label(span, format!("manual implementations of `{}` are experimental", trait_name))
-    .help("add `#![feature(unboxed_closures)]` to the crate attributes to enable")
-    .emit();
 }
 
 /// We allow impls of marker traits to overlap, so they can't override impls

--- a/src/test/ui/feature-gates/feature-gate-in_band_lifetimes.stderr
+++ b/src/test/ui/feature-gates/feature-gate-in_band_lifetimes.stderr
@@ -1,87 +1,3 @@
-error[E0261]: use of undeclared lifetime name `'a`
-  --> $DIR/feature-gate-in_band_lifetimes.rs:50:14
-   |
-LL | impl MyTrait<'a> for Y<&'a u8> {
-   |     -        ^^ undeclared lifetime
-   |     |
-   |     help: consider introducing lifetime `'a` here: `<'a>`
-   |
-   = help: if you want to experiment with in-band lifetime bindings, add `#![feature(in_band_lifetimes)]` to the crate attributes
-
-error[E0261]: use of undeclared lifetime name `'a`
-  --> $DIR/feature-gate-in_band_lifetimes.rs:50:25
-   |
-LL | impl MyTrait<'a> for Y<&'a u8> {
-   |     -                   ^^ undeclared lifetime
-   |     |
-   |     help: consider introducing lifetime `'a` here: `<'a>`
-   |
-   = help: if you want to experiment with in-band lifetime bindings, add `#![feature(in_band_lifetimes)]` to the crate attributes
-
-error[E0261]: use of undeclared lifetime name `'a`
-  --> $DIR/feature-gate-in_band_lifetimes.rs:53:31
-   |
-LL |     fn my_lifetime(&self) -> &'a u8 { self.0 }
-   |                               ^^ undeclared lifetime
-   |
-   = help: if you want to experiment with in-band lifetime bindings, add `#![feature(in_band_lifetimes)]` to the crate attributes
-help: consider introducing lifetime `'a` here
-   |
-LL | impl<'a> MyTrait<'a> for Y<&'a u8> {
-   |     ++++
-help: consider introducing lifetime `'a` here
-   |
-LL |     fn my_lifetime<'a>(&self) -> &'a u8 { self.0 }
-   |                   ++++
-
-error[E0261]: use of undeclared lifetime name `'b`
-  --> $DIR/feature-gate-in_band_lifetimes.rs:55:27
-   |
-LL |     fn any_lifetime() -> &'b u8 { &0 }
-   |                           ^^ undeclared lifetime
-   |
-   = help: if you want to experiment with in-band lifetime bindings, add `#![feature(in_band_lifetimes)]` to the crate attributes
-help: consider introducing lifetime `'b` here
-   |
-LL | impl<'b> MyTrait<'a> for Y<&'a u8> {
-   |     ++++
-help: consider introducing lifetime `'b` here
-   |
-LL |     fn any_lifetime<'b>() -> &'b u8 { &0 }
-   |                    ++++
-
-error[E0261]: use of undeclared lifetime name `'b`
-  --> $DIR/feature-gate-in_band_lifetimes.rs:57:27
-   |
-LL |     fn borrowed_lifetime(&'b self) -> &'b u8 { &*self.0 }
-   |                           ^^ undeclared lifetime
-   |
-   = help: if you want to experiment with in-band lifetime bindings, add `#![feature(in_band_lifetimes)]` to the crate attributes
-help: consider introducing lifetime `'b` here
-   |
-LL | impl<'b> MyTrait<'a> for Y<&'a u8> {
-   |     ++++
-help: consider introducing lifetime `'b` here
-   |
-LL |     fn borrowed_lifetime<'b>(&'b self) -> &'b u8 { &*self.0 }
-   |                         ++++
-
-error[E0261]: use of undeclared lifetime name `'b`
-  --> $DIR/feature-gate-in_band_lifetimes.rs:57:40
-   |
-LL |     fn borrowed_lifetime(&'b self) -> &'b u8 { &*self.0 }
-   |                                        ^^ undeclared lifetime
-   |
-   = help: if you want to experiment with in-band lifetime bindings, add `#![feature(in_band_lifetimes)]` to the crate attributes
-help: consider introducing lifetime `'b` here
-   |
-LL | impl<'b> MyTrait<'a> for Y<&'a u8> {
-   |     ++++
-help: consider introducing lifetime `'b` here
-   |
-LL |     fn borrowed_lifetime<'b>(&'b self) -> &'b u8 { &*self.0 }
-   |                         ++++
-
 error[E0261]: use of undeclared lifetime name `'x`
   --> $DIR/feature-gate-in_band_lifetimes.rs:3:12
    |
@@ -177,6 +93,90 @@ help: consider introducing lifetime `'a` here
    |
 LL |     fn inner<'a>(&self) -> &'a u8 {
    |             ++++
+
+error[E0261]: use of undeclared lifetime name `'a`
+  --> $DIR/feature-gate-in_band_lifetimes.rs:50:14
+   |
+LL | impl MyTrait<'a> for Y<&'a u8> {
+   |     -        ^^ undeclared lifetime
+   |     |
+   |     help: consider introducing lifetime `'a` here: `<'a>`
+   |
+   = help: if you want to experiment with in-band lifetime bindings, add `#![feature(in_band_lifetimes)]` to the crate attributes
+
+error[E0261]: use of undeclared lifetime name `'a`
+  --> $DIR/feature-gate-in_band_lifetimes.rs:50:25
+   |
+LL | impl MyTrait<'a> for Y<&'a u8> {
+   |     -                   ^^ undeclared lifetime
+   |     |
+   |     help: consider introducing lifetime `'a` here: `<'a>`
+   |
+   = help: if you want to experiment with in-band lifetime bindings, add `#![feature(in_band_lifetimes)]` to the crate attributes
+
+error[E0261]: use of undeclared lifetime name `'a`
+  --> $DIR/feature-gate-in_band_lifetimes.rs:53:31
+   |
+LL |     fn my_lifetime(&self) -> &'a u8 { self.0 }
+   |                               ^^ undeclared lifetime
+   |
+   = help: if you want to experiment with in-band lifetime bindings, add `#![feature(in_band_lifetimes)]` to the crate attributes
+help: consider introducing lifetime `'a` here
+   |
+LL | impl<'a> MyTrait<'a> for Y<&'a u8> {
+   |     ++++
+help: consider introducing lifetime `'a` here
+   |
+LL |     fn my_lifetime<'a>(&self) -> &'a u8 { self.0 }
+   |                   ++++
+
+error[E0261]: use of undeclared lifetime name `'b`
+  --> $DIR/feature-gate-in_band_lifetimes.rs:55:27
+   |
+LL |     fn any_lifetime() -> &'b u8 { &0 }
+   |                           ^^ undeclared lifetime
+   |
+   = help: if you want to experiment with in-band lifetime bindings, add `#![feature(in_band_lifetimes)]` to the crate attributes
+help: consider introducing lifetime `'b` here
+   |
+LL | impl<'b> MyTrait<'a> for Y<&'a u8> {
+   |     ++++
+help: consider introducing lifetime `'b` here
+   |
+LL |     fn any_lifetime<'b>() -> &'b u8 { &0 }
+   |                    ++++
+
+error[E0261]: use of undeclared lifetime name `'b`
+  --> $DIR/feature-gate-in_band_lifetimes.rs:57:27
+   |
+LL |     fn borrowed_lifetime(&'b self) -> &'b u8 { &*self.0 }
+   |                           ^^ undeclared lifetime
+   |
+   = help: if you want to experiment with in-band lifetime bindings, add `#![feature(in_band_lifetimes)]` to the crate attributes
+help: consider introducing lifetime `'b` here
+   |
+LL | impl<'b> MyTrait<'a> for Y<&'a u8> {
+   |     ++++
+help: consider introducing lifetime `'b` here
+   |
+LL |     fn borrowed_lifetime<'b>(&'b self) -> &'b u8 { &*self.0 }
+   |                         ++++
+
+error[E0261]: use of undeclared lifetime name `'b`
+  --> $DIR/feature-gate-in_band_lifetimes.rs:57:40
+   |
+LL |     fn borrowed_lifetime(&'b self) -> &'b u8 { &*self.0 }
+   |                                        ^^ undeclared lifetime
+   |
+   = help: if you want to experiment with in-band lifetime bindings, add `#![feature(in_band_lifetimes)]` to the crate attributes
+help: consider introducing lifetime `'b` here
+   |
+LL | impl<'b> MyTrait<'a> for Y<&'a u8> {
+   |     ++++
+help: consider introducing lifetime `'b` here
+   |
+LL |     fn borrowed_lifetime<'b>(&'b self) -> &'b u8 { &*self.0 }
+   |                         ++++
 
 error[E0261]: use of undeclared lifetime name `'b`
   --> $DIR/feature-gate-in_band_lifetimes.rs:43:27

--- a/src/test/ui/feature-gates/feature-gate-unboxed-closures-manual-impls.stderr
+++ b/src/test/ui/feature-gates/feature-gate-unboxed-closures-manual-impls.stderr
@@ -38,9 +38,25 @@ error[E0658]: the precise format of `Fn`-family traits' type parameters is subje
   --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:9:6
    |
 LL | impl Fn<()> for Foo {
-   |      ^^^^^^ help: use parenthetical notation instead: `Fn() -> ()`
+   |      ^^^^^^
    |
    = note: see issue #29625 <https://github.com/rust-lang/rust/issues/29625> for more information
+   = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
+
+error[E0183]: manual implementations of `Fn` are experimental
+  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:9:6
+   |
+LL | impl Fn<()> for Foo {
+   |      ^^^^^^ manual implementations of `Fn` are experimental
+   |
+   = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
+
+error[E0183]: manual implementations of `FnOnce` are experimental
+  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:16:6
+   |
+LL | impl FnOnce() for Foo1 {
+   |      ^^^^^^^^ manual implementations of `FnOnce` are experimental
+   |
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
 error[E0229]: associated type bindings are not allowed here
@@ -53,49 +69,33 @@ error[E0658]: the precise format of `Fn`-family traits' type parameters is subje
   --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:23:6
    |
 LL | impl FnMut<()> for Bar {
-   |      ^^^^^^^^^ help: use parenthetical notation instead: `FnMut() -> ()`
+   |      ^^^^^^^^^
    |
    = note: see issue #29625 <https://github.com/rust-lang/rust/issues/29625> for more information
+   = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
+
+error[E0183]: manual implementations of `FnMut` are experimental
+  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:23:6
+   |
+LL | impl FnMut<()> for Bar {
+   |      ^^^^^^^^^ manual implementations of `FnMut` are experimental
+   |
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
 error[E0658]: the precise format of `Fn`-family traits' type parameters is subject to change
   --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:30:6
    |
 LL | impl FnOnce<()> for Baz {
-   |      ^^^^^^^^^^ help: use parenthetical notation instead: `FnOnce() -> ()`
+   |      ^^^^^^^^^^
    |
    = note: see issue #29625 <https://github.com/rust-lang/rust/issues/29625> for more information
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
-error[E0183]: manual implementations of `Fn` are experimental
-  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:9:1
-   |
-LL | impl Fn<()> for Foo {
-   | ^^^^^^^^^^^^^^^^^^^ manual implementations of `Fn` are experimental
-   |
-   = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
-
-error[E0183]: manual implementations of `FnMut` are experimental
-  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:23:1
-   |
-LL | impl FnMut<()> for Bar {
-   | ^^^^^^^^^^^^^^^^^^^^^^ manual implementations of `FnMut` are experimental
-   |
-   = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
-
 error[E0183]: manual implementations of `FnOnce` are experimental
-  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:16:1
-   |
-LL | impl FnOnce() for Foo1 {
-   | ^^^^^^^^^^^^^^^^^^^^^^ manual implementations of `FnOnce` are experimental
-   |
-   = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
-
-error[E0183]: manual implementations of `FnOnce` are experimental
-  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:30:1
+  --> $DIR/feature-gate-unboxed-closures-manual-impls.rs:30:6
    |
 LL | impl FnOnce<()> for Baz {
-   | ^^^^^^^^^^^^^^^^^^^^^^^ manual implementations of `FnOnce` are experimental
+   |      ^^^^^^^^^^ manual implementations of `FnOnce` are experimental
    |
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 

--- a/src/test/ui/feature-gates/feature-gate-unboxed-closures.stderr
+++ b/src/test/ui/feature-gates/feature-gate-unboxed-closures.stderr
@@ -11,16 +11,16 @@ error[E0658]: the precise format of `Fn`-family traits' type parameters is subje
   --> $DIR/feature-gate-unboxed-closures.rs:5:6
    |
 LL | impl FnOnce<(u32, u32)> for Test {
-   |      ^^^^^^^^^^^^^^^^^^ help: use parenthetical notation instead: `FnOnce(u32, u32) -> ()`
+   |      ^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #29625 <https://github.com/rust-lang/rust/issues/29625> for more information
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 
 error[E0183]: manual implementations of `FnOnce` are experimental
-  --> $DIR/feature-gate-unboxed-closures.rs:5:1
+  --> $DIR/feature-gate-unboxed-closures.rs:5:6
    |
 LL | impl FnOnce<(u32, u32)> for Test {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ manual implementations of `FnOnce` are experimental
+   |      ^^^^^^^^^^^^^^^^^^ manual implementations of `FnOnce` are experimental
    |
    = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
 

--- a/src/test/ui/issues/issue-3214.rs
+++ b/src/test/ui/issues/issue-3214.rs
@@ -5,8 +5,7 @@ fn foo<T>() {
 
     impl<T> Drop for Foo<T> {
         //~^ ERROR this struct takes 0 generic arguments but 1 generic argument
-        //~| ERROR the type parameter `T` is not constrained by the impl trait, self type, or predicates
         fn drop(&mut self) {}
     }
 }
-fn main() { }
+fn main() {}

--- a/src/test/ui/issues/issue-3214.stderr
+++ b/src/test/ui/issues/issue-3214.stderr
@@ -23,13 +23,7 @@ note: struct defined here, with 0 generic parameters
 LL |     struct Foo {
    |            ^^^
 
-error[E0207]: the type parameter `T` is not constrained by the impl trait, self type, or predicates
-  --> $DIR/issue-3214.rs:6:10
-   |
-LL |     impl<T> Drop for Foo<T> {
-   |          ^ unconstrained type parameter
+error: aborting due to 2 previous errors
 
-error: aborting due to 3 previous errors
-
-Some errors have detailed explanations: E0107, E0207, E0401.
+Some errors have detailed explanations: E0107, E0401.
 For more information about an error, try `rustc --explain E0107`.

--- a/src/test/ui/span/impl-wrong-item-for-trait.rs
+++ b/src/test/ui/span/impl-wrong-item-for-trait.rs
@@ -29,12 +29,10 @@ impl Foo for FooTypeForMethod {
     //~^ ERROR E0046
     type bar = u64;
     //~^ ERROR E0325
-    //~| ERROR E0437
     const MY_CONST: u32 = 1;
 }
 
-impl Debug for FooTypeForMethod {
-}
-//~^^ ERROR E0046
+impl Debug for FooTypeForMethod {}
+//~^ ERROR E0046
 
-fn main () {}
+fn main() {}

--- a/src/test/ui/span/impl-wrong-item-for-trait.stderr
+++ b/src/test/ui/span/impl-wrong-item-for-trait.stderr
@@ -1,8 +1,11 @@
-error[E0437]: type `bar` is not a member of trait `Foo`
-  --> $DIR/impl-wrong-item-for-trait.rs:30:5
+error[E0323]: item `bar` is an associated const, which doesn't match its trait `Foo`
+  --> $DIR/impl-wrong-item-for-trait.rs:12:5
    |
-LL |     type bar = u64;
-   |     ^^^^^^^^^^^^^^^ not a member of trait `Foo`
+LL |     fn bar(&self);
+   |     -------------- item in trait
+...
+LL |     const bar: u64 = 1;
+   |     ^^^^^^^^^^^^^^^^^^^ does not match trait
 
 error[E0324]: item `MY_CONST` is an associated method, which doesn't match its trait `Foo`
   --> $DIR/impl-wrong-item-for-trait.rs:22:5
@@ -12,15 +15,6 @@ LL |     const MY_CONST: u32;
 ...
 LL |     fn MY_CONST() {}
    |     ^^^^^^^^^^^^^^^^ does not match trait
-
-error[E0323]: item `bar` is an associated const, which doesn't match its trait `Foo`
-  --> $DIR/impl-wrong-item-for-trait.rs:12:5
-   |
-LL |     fn bar(&self);
-   |     -------------- item in trait
-...
-LL |     const bar: u64 = 1;
-   |     ^^^^^^^^^^^^^^^^^^^ does not match trait
 
 error[E0325]: item `bar` is an associated type, which doesn't match its trait `Foo`
   --> $DIR/impl-wrong-item-for-trait.rs:30:5
@@ -59,14 +53,14 @@ LL | impl Foo for FooTypeForMethod {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `bar` in implementation
 
 error[E0046]: not all trait items implemented, missing: `fmt`
-  --> $DIR/impl-wrong-item-for-trait.rs:36:1
+  --> $DIR/impl-wrong-item-for-trait.rs:35:1
    |
-LL | impl Debug for FooTypeForMethod {
+LL | impl Debug for FooTypeForMethod {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `fmt` in implementation
    |
    = help: implement the missing item: `fn fmt(&self, _: &mut Formatter<'_>) -> Result<(), std::fmt::Error> { todo!() }`
 
-error: aborting due to 8 previous errors
+error: aborting due to 7 previous errors
 
-Some errors have detailed explanations: E0046, E0323, E0324, E0325, E0437.
+Some errors have detailed explanations: E0046, E0323, E0324, E0325.
 For more information about an error, try `rustc --explain E0046`.

--- a/src/test/ui/stability-attribute/generics-default-stability-trait.rs
+++ b/src/test/ui/stability-attribute/generics-default-stability-trait.rs
@@ -1,0 +1,33 @@
+// aux-build:unstable_generic_param.rs
+#![feature(unstable_default6)]
+
+extern crate unstable_generic_param;
+
+use unstable_generic_param::*;
+
+struct R;
+
+impl Trait1 for S {
+    fn foo() -> () { () } // ok
+}
+
+struct S;
+
+impl Trait1<usize> for S { //~ ERROR use of unstable library feature 'unstable_default'
+    fn foo() -> usize { 0 }
+}
+
+impl Trait1<isize> for S { //~ ERROR use of unstable library feature 'unstable_default'
+    fn foo() -> isize { 0 }
+}
+
+impl Trait2<usize> for S { //~ ERROR use of unstable library feature 'unstable_default'
+    fn foo() -> usize { 0 }
+}
+
+impl Trait3<usize> for S {
+    fn foo() -> usize { 0 } // ok
+}
+
+fn main() {
+}

--- a/src/test/ui/stability-attribute/generics-default-stability-trait.stderr
+++ b/src/test/ui/stability-attribute/generics-default-stability-trait.stderr
@@ -1,0 +1,27 @@
+error[E0658]: use of unstable library feature 'unstable_default'
+  --> $DIR/generics-default-stability-trait.rs:16:13
+   |
+LL | impl Trait1<usize> for S {
+   |             ^^^^^
+   |
+   = help: add `#![feature(unstable_default)]` to the crate attributes to enable
+
+error[E0658]: use of unstable library feature 'unstable_default'
+  --> $DIR/generics-default-stability-trait.rs:20:13
+   |
+LL | impl Trait1<isize> for S {
+   |             ^^^^^
+   |
+   = help: add `#![feature(unstable_default)]` to the crate attributes to enable
+
+error[E0658]: use of unstable library feature 'unstable_default'
+  --> $DIR/generics-default-stability-trait.rs:24:13
+   |
+LL | impl Trait2<usize> for S {
+   |             ^^^^^
+   |
+   = help: add `#![feature(unstable_default)]` to the crate attributes to enable
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/stability-attribute/generics-default-stability.rs
+++ b/src/test/ui/stability-attribute/generics-default-stability.rs
@@ -13,18 +13,6 @@ impl Trait1 for S {
 
 struct S;
 
-impl Trait1<usize> for S { //~ ERROR use of unstable library feature 'unstable_default'
-    fn foo() -> usize { 0 }
-}
-
-impl Trait1<isize> for S { //~ ERROR use of unstable library feature 'unstable_default'
-    fn foo() -> isize { 0 }
-}
-
-impl Trait2<usize> for S { //~ ERROR use of unstable library feature 'unstable_default'
-    fn foo() -> usize { 0 }
-}
-
 impl Trait3<usize> for S {
     fn foo() -> usize { 0 } // ok
 }

--- a/src/test/ui/stability-attribute/generics-default-stability.stderr
+++ b/src/test/ui/stability-attribute/generics-default-stability.stderr
@@ -1,29 +1,5 @@
-error[E0658]: use of unstable library feature 'unstable_default'
-  --> $DIR/generics-default-stability.rs:16:13
-   |
-LL | impl Trait1<usize> for S {
-   |             ^^^^^
-   |
-   = help: add `#![feature(unstable_default)]` to the crate attributes to enable
-
-error[E0658]: use of unstable library feature 'unstable_default'
-  --> $DIR/generics-default-stability.rs:20:13
-   |
-LL | impl Trait1<isize> for S {
-   |             ^^^^^
-   |
-   = help: add `#![feature(unstable_default)]` to the crate attributes to enable
-
-error[E0658]: use of unstable library feature 'unstable_default'
-  --> $DIR/generics-default-stability.rs:24:13
-   |
-LL | impl Trait2<usize> for S {
-   |             ^^^^^
-   |
-   = help: add `#![feature(unstable_default)]` to the crate attributes to enable
-
 warning: use of deprecated struct `unstable_generic_param::Struct4`: test
-  --> $DIR/generics-default-stability.rs:83:29
+  --> $DIR/generics-default-stability.rs:71:29
    |
 LL |     let _: Struct4<isize> = Struct4 { field: 1 };
    |                             ^^^^^^^
@@ -31,217 +7,217 @@ LL |     let _: Struct4<isize> = Struct4 { field: 1 };
    = note: `#[warn(deprecated)]` on by default
 
 warning: use of deprecated struct `unstable_generic_param::Struct4`: test
-  --> $DIR/generics-default-stability.rs:83:12
+  --> $DIR/generics-default-stability.rs:71:12
    |
 LL |     let _: Struct4<isize> = Struct4 { field: 1 };
    |            ^^^^^^^
 
 warning: use of deprecated struct `unstable_generic_param::Struct4`: test
-  --> $DIR/generics-default-stability.rs:88:12
+  --> $DIR/generics-default-stability.rs:76:12
    |
 LL |     let _: Struct4 = STRUCT4;
    |            ^^^^^^^
 
 warning: use of deprecated struct `unstable_generic_param::Struct4`: test
-  --> $DIR/generics-default-stability.rs:89:12
+  --> $DIR/generics-default-stability.rs:77:12
    |
 LL |     let _: Struct4<usize> = STRUCT4;
    |            ^^^^^^^
 
 warning: use of deprecated struct `unstable_generic_param::Struct4`: test
-  --> $DIR/generics-default-stability.rs:90:29
+  --> $DIR/generics-default-stability.rs:78:29
    |
 LL |     let _: Struct4<isize> = Struct4 { field: 0 };
    |                             ^^^^^^^
 
 warning: use of deprecated struct `unstable_generic_param::Struct4`: test
-  --> $DIR/generics-default-stability.rs:90:12
+  --> $DIR/generics-default-stability.rs:78:12
    |
 LL |     let _: Struct4<isize> = Struct4 { field: 0 };
    |            ^^^^^^^
 
 warning: use of deprecated struct `unstable_generic_param::Struct5`: test
-  --> $DIR/generics-default-stability.rs:96:29
+  --> $DIR/generics-default-stability.rs:84:29
    |
 LL |     let _: Struct5<isize> = Struct5 { field: 1 };
    |                             ^^^^^^^
 
 warning: use of deprecated struct `unstable_generic_param::Struct5`: test
-  --> $DIR/generics-default-stability.rs:96:12
+  --> $DIR/generics-default-stability.rs:84:12
    |
 LL |     let _: Struct5<isize> = Struct5 { field: 1 };
    |            ^^^^^^^
 
 warning: use of deprecated struct `unstable_generic_param::Struct5`: test
-  --> $DIR/generics-default-stability.rs:101:12
+  --> $DIR/generics-default-stability.rs:89:12
    |
 LL |     let _: Struct5 = STRUCT5;
    |            ^^^^^^^
 
 warning: use of deprecated struct `unstable_generic_param::Struct5`: test
-  --> $DIR/generics-default-stability.rs:102:12
+  --> $DIR/generics-default-stability.rs:90:12
    |
 LL |     let _: Struct5<usize> = STRUCT5;
    |            ^^^^^^^
 
 warning: use of deprecated struct `unstable_generic_param::Struct5`: test
-  --> $DIR/generics-default-stability.rs:104:29
+  --> $DIR/generics-default-stability.rs:92:29
    |
 LL |     let _: Struct5<isize> = Struct5 { field: 0 };
    |                             ^^^^^^^
 
 warning: use of deprecated struct `unstable_generic_param::Struct5`: test
-  --> $DIR/generics-default-stability.rs:104:12
+  --> $DIR/generics-default-stability.rs:92:12
    |
 LL |     let _: Struct5<isize> = Struct5 { field: 0 };
    |            ^^^^^^^
 
 warning: use of deprecated type alias `unstable_generic_param::Alias4`: test
-  --> $DIR/generics-default-stability.rs:159:28
+  --> $DIR/generics-default-stability.rs:147:28
    |
 LL |     let _: Alias4<isize> = Alias4::Some(1);
    |                            ^^^^^^
 
 warning: use of deprecated type alias `unstable_generic_param::Alias4`: test
-  --> $DIR/generics-default-stability.rs:159:12
+  --> $DIR/generics-default-stability.rs:147:12
    |
 LL |     let _: Alias4<isize> = Alias4::Some(1);
    |            ^^^^^^
 
 warning: use of deprecated type alias `unstable_generic_param::Alias4`: test
-  --> $DIR/generics-default-stability.rs:163:12
+  --> $DIR/generics-default-stability.rs:151:12
    |
 LL |     let _: Alias4 = ALIAS4;
    |            ^^^^^^
 
 warning: use of deprecated type alias `unstable_generic_param::Alias4`: test
-  --> $DIR/generics-default-stability.rs:164:12
+  --> $DIR/generics-default-stability.rs:152:12
    |
 LL |     let _: Alias4<usize> = ALIAS4;
    |            ^^^^^^
 
 warning: use of deprecated type alias `unstable_generic_param::Alias4`: test
-  --> $DIR/generics-default-stability.rs:165:28
+  --> $DIR/generics-default-stability.rs:153:28
    |
 LL |     let _: Alias4<isize> = Alias4::Some(0);
    |                            ^^^^^^
 
 warning: use of deprecated type alias `unstable_generic_param::Alias4`: test
-  --> $DIR/generics-default-stability.rs:165:12
+  --> $DIR/generics-default-stability.rs:153:12
    |
 LL |     let _: Alias4<isize> = Alias4::Some(0);
    |            ^^^^^^
 
 warning: use of deprecated type alias `unstable_generic_param::Alias5`: test
-  --> $DIR/generics-default-stability.rs:170:28
+  --> $DIR/generics-default-stability.rs:158:28
    |
 LL |     let _: Alias5<isize> = Alias5::Some(1);
    |                            ^^^^^^
 
 warning: use of deprecated type alias `unstable_generic_param::Alias5`: test
-  --> $DIR/generics-default-stability.rs:170:12
+  --> $DIR/generics-default-stability.rs:158:12
    |
 LL |     let _: Alias5<isize> = Alias5::Some(1);
    |            ^^^^^^
 
 warning: use of deprecated type alias `unstable_generic_param::Alias5`: test
-  --> $DIR/generics-default-stability.rs:174:12
+  --> $DIR/generics-default-stability.rs:162:12
    |
 LL |     let _: Alias5 = ALIAS5;
    |            ^^^^^^
 
 warning: use of deprecated type alias `unstable_generic_param::Alias5`: test
-  --> $DIR/generics-default-stability.rs:175:12
+  --> $DIR/generics-default-stability.rs:163:12
    |
 LL |     let _: Alias5<usize> = ALIAS5;
    |            ^^^^^^
 
 warning: use of deprecated type alias `unstable_generic_param::Alias5`: test
-  --> $DIR/generics-default-stability.rs:177:28
+  --> $DIR/generics-default-stability.rs:165:28
    |
 LL |     let _: Alias5<isize> = Alias5::Some(0);
    |                            ^^^^^^
 
 warning: use of deprecated type alias `unstable_generic_param::Alias5`: test
-  --> $DIR/generics-default-stability.rs:177:12
+  --> $DIR/generics-default-stability.rs:165:12
    |
 LL |     let _: Alias5<isize> = Alias5::Some(0);
    |            ^^^^^^
 
 warning: use of deprecated variant `unstable_generic_param::Enum4::Some`: test
-  --> $DIR/generics-default-stability.rs:231:34
+  --> $DIR/generics-default-stability.rs:219:34
    |
 LL |     let _: Enum4<isize> = Enum4::Some(1);
    |                                  ^^^^
 
 warning: use of deprecated enum `unstable_generic_param::Enum4`: test
-  --> $DIR/generics-default-stability.rs:231:12
+  --> $DIR/generics-default-stability.rs:219:12
    |
 LL |     let _: Enum4<isize> = Enum4::Some(1);
    |            ^^^^^
 
 warning: use of deprecated enum `unstable_generic_param::Enum4`: test
-  --> $DIR/generics-default-stability.rs:235:12
+  --> $DIR/generics-default-stability.rs:223:12
    |
 LL |     let _: Enum4 = ENUM4;
    |            ^^^^^
 
 warning: use of deprecated enum `unstable_generic_param::Enum4`: test
-  --> $DIR/generics-default-stability.rs:236:12
+  --> $DIR/generics-default-stability.rs:224:12
    |
 LL |     let _: Enum4<usize> = ENUM4;
    |            ^^^^^
 
 warning: use of deprecated variant `unstable_generic_param::Enum4::Some`: test
-  --> $DIR/generics-default-stability.rs:237:34
+  --> $DIR/generics-default-stability.rs:225:34
    |
 LL |     let _: Enum4<isize> = Enum4::Some(0);
    |                                  ^^^^
 
 warning: use of deprecated enum `unstable_generic_param::Enum4`: test
-  --> $DIR/generics-default-stability.rs:237:12
+  --> $DIR/generics-default-stability.rs:225:12
    |
 LL |     let _: Enum4<isize> = Enum4::Some(0);
    |            ^^^^^
 
 warning: use of deprecated variant `unstable_generic_param::Enum5::Some`: test
-  --> $DIR/generics-default-stability.rs:242:34
+  --> $DIR/generics-default-stability.rs:230:34
    |
 LL |     let _: Enum5<isize> = Enum5::Some(1);
    |                                  ^^^^
 
 warning: use of deprecated enum `unstable_generic_param::Enum5`: test
-  --> $DIR/generics-default-stability.rs:242:12
+  --> $DIR/generics-default-stability.rs:230:12
    |
 LL |     let _: Enum5<isize> = Enum5::Some(1);
    |            ^^^^^
 
 warning: use of deprecated enum `unstable_generic_param::Enum5`: test
-  --> $DIR/generics-default-stability.rs:246:12
+  --> $DIR/generics-default-stability.rs:234:12
    |
 LL |     let _: Enum5 = ENUM5;
    |            ^^^^^
 
 warning: use of deprecated enum `unstable_generic_param::Enum5`: test
-  --> $DIR/generics-default-stability.rs:247:12
+  --> $DIR/generics-default-stability.rs:235:12
    |
 LL |     let _: Enum5<usize> = ENUM5;
    |            ^^^^^
 
 warning: use of deprecated variant `unstable_generic_param::Enum5::Some`: test
-  --> $DIR/generics-default-stability.rs:249:34
+  --> $DIR/generics-default-stability.rs:237:34
    |
 LL |     let _: Enum5<isize> = Enum5::Some(0);
    |                                  ^^^^
 
 warning: use of deprecated enum `unstable_generic_param::Enum5`: test
-  --> $DIR/generics-default-stability.rs:249:12
+  --> $DIR/generics-default-stability.rs:237:12
    |
 LL |     let _: Enum5<isize> = Enum5::Some(0);
    |            ^^^^^
 
 error[E0658]: use of unstable library feature 'unstable_default'
-  --> $DIR/generics-default-stability.rs:35:20
+  --> $DIR/generics-default-stability.rs:23:20
    |
 LL |     let _: Struct1<isize> = Struct1 { field: 1 };
    |                    ^^^^^
@@ -249,7 +225,7 @@ LL |     let _: Struct1<isize> = Struct1 { field: 1 };
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_default'
-  --> $DIR/generics-default-stability.rs:39:20
+  --> $DIR/generics-default-stability.rs:27:20
    |
 LL |     let _: Struct1<usize> = STRUCT1;
    |                    ^^^^^
@@ -257,7 +233,7 @@ LL |     let _: Struct1<usize> = STRUCT1;
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_default'
-  --> $DIR/generics-default-stability.rs:40:20
+  --> $DIR/generics-default-stability.rs:28:20
    |
 LL |     let _: Struct1<isize> = Struct1 { field: 0 };
    |                    ^^^^^
@@ -265,7 +241,7 @@ LL |     let _: Struct1<isize> = Struct1 { field: 0 };
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_default'
-  --> $DIR/generics-default-stability.rs:69:27
+  --> $DIR/generics-default-stability.rs:57:27
    |
 LL |     let _: Struct3<isize, usize> = STRUCT3;
    |                           ^^^^^
@@ -273,7 +249,7 @@ LL |     let _: Struct3<isize, usize> = STRUCT3;
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_default'
-  --> $DIR/generics-default-stability.rs:71:27
+  --> $DIR/generics-default-stability.rs:59:27
    |
 LL |     let _: Struct3<isize, isize> = Struct3 { field1: 0, field2: 0 };
    |                           ^^^^^
@@ -281,7 +257,7 @@ LL |     let _: Struct3<isize, isize> = Struct3 { field1: 0, field2: 0 };
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_default'
-  --> $DIR/generics-default-stability.rs:72:27
+  --> $DIR/generics-default-stability.rs:60:27
    |
 LL |     let _: Struct3<usize, usize> = Struct3 { field1: 0, field2: 0 };
    |                           ^^^^^
@@ -289,7 +265,7 @@ LL |     let _: Struct3<usize, usize> = Struct3 { field1: 0, field2: 0 };
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_default'
-  --> $DIR/generics-default-stability.rs:96:20
+  --> $DIR/generics-default-stability.rs:84:20
    |
 LL |     let _: Struct5<isize> = Struct5 { field: 1 };
    |                    ^^^^^
@@ -297,7 +273,7 @@ LL |     let _: Struct5<isize> = Struct5 { field: 1 };
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_default'
-  --> $DIR/generics-default-stability.rs:102:20
+  --> $DIR/generics-default-stability.rs:90:20
    |
 LL |     let _: Struct5<usize> = STRUCT5;
    |                    ^^^^^
@@ -305,7 +281,7 @@ LL |     let _: Struct5<usize> = STRUCT5;
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_default'
-  --> $DIR/generics-default-stability.rs:104:20
+  --> $DIR/generics-default-stability.rs:92:20
    |
 LL |     let _: Struct5<isize> = Struct5 { field: 0 };
    |                    ^^^^^
@@ -313,7 +289,7 @@ LL |     let _: Struct5<isize> = Struct5 { field: 0 };
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_default'
-  --> $DIR/generics-default-stability.rs:112:19
+  --> $DIR/generics-default-stability.rs:100:19
    |
 LL |     let _: Alias1<isize> = Alias1::Some(1);
    |                   ^^^^^
@@ -321,7 +297,7 @@ LL |     let _: Alias1<isize> = Alias1::Some(1);
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_default'
-  --> $DIR/generics-default-stability.rs:116:19
+  --> $DIR/generics-default-stability.rs:104:19
    |
 LL |     let _: Alias1<usize> = ALIAS1;
    |                   ^^^^^
@@ -329,7 +305,7 @@ LL |     let _: Alias1<usize> = ALIAS1;
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_default'
-  --> $DIR/generics-default-stability.rs:117:19
+  --> $DIR/generics-default-stability.rs:105:19
    |
 LL |     let _: Alias1<isize> = Alias1::Some(0);
    |                   ^^^^^
@@ -337,7 +313,7 @@ LL |     let _: Alias1<isize> = Alias1::Some(0);
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_default'
-  --> $DIR/generics-default-stability.rs:145:26
+  --> $DIR/generics-default-stability.rs:133:26
    |
 LL |     let _: Alias3<isize, usize> = ALIAS3;
    |                          ^^^^^
@@ -345,7 +321,7 @@ LL |     let _: Alias3<isize, usize> = ALIAS3;
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_default'
-  --> $DIR/generics-default-stability.rs:147:26
+  --> $DIR/generics-default-stability.rs:135:26
    |
 LL |     let _: Alias3<isize, isize> = Alias3::Ok(0);
    |                          ^^^^^
@@ -353,7 +329,7 @@ LL |     let _: Alias3<isize, isize> = Alias3::Ok(0);
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_default'
-  --> $DIR/generics-default-stability.rs:148:26
+  --> $DIR/generics-default-stability.rs:136:26
    |
 LL |     let _: Alias3<usize, usize> = Alias3::Ok(0);
    |                          ^^^^^
@@ -361,7 +337,7 @@ LL |     let _: Alias3<usize, usize> = Alias3::Ok(0);
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_default'
-  --> $DIR/generics-default-stability.rs:170:19
+  --> $DIR/generics-default-stability.rs:158:19
    |
 LL |     let _: Alias5<isize> = Alias5::Some(1);
    |                   ^^^^^
@@ -369,7 +345,7 @@ LL |     let _: Alias5<isize> = Alias5::Some(1);
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_default'
-  --> $DIR/generics-default-stability.rs:175:19
+  --> $DIR/generics-default-stability.rs:163:19
    |
 LL |     let _: Alias5<usize> = ALIAS5;
    |                   ^^^^^
@@ -377,7 +353,7 @@ LL |     let _: Alias5<usize> = ALIAS5;
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_default'
-  --> $DIR/generics-default-stability.rs:177:19
+  --> $DIR/generics-default-stability.rs:165:19
    |
 LL |     let _: Alias5<isize> = Alias5::Some(0);
    |                   ^^^^^
@@ -385,7 +361,7 @@ LL |     let _: Alias5<isize> = Alias5::Some(0);
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_default'
-  --> $DIR/generics-default-stability.rs:184:18
+  --> $DIR/generics-default-stability.rs:172:18
    |
 LL |     let _: Enum1<isize> = Enum1::Some(1);
    |                  ^^^^^
@@ -393,7 +369,7 @@ LL |     let _: Enum1<isize> = Enum1::Some(1);
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_default'
-  --> $DIR/generics-default-stability.rs:188:18
+  --> $DIR/generics-default-stability.rs:176:18
    |
 LL |     let _: Enum1<usize> = ENUM1;
    |                  ^^^^^
@@ -401,7 +377,7 @@ LL |     let _: Enum1<usize> = ENUM1;
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_default'
-  --> $DIR/generics-default-stability.rs:189:18
+  --> $DIR/generics-default-stability.rs:177:18
    |
 LL |     let _: Enum1<isize> = Enum1::Some(0);
    |                  ^^^^^
@@ -409,7 +385,7 @@ LL |     let _: Enum1<isize> = Enum1::Some(0);
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_default'
-  --> $DIR/generics-default-stability.rs:217:25
+  --> $DIR/generics-default-stability.rs:205:25
    |
 LL |     let _: Enum3<isize, usize> = ENUM3;
    |                         ^^^^^
@@ -417,7 +393,7 @@ LL |     let _: Enum3<isize, usize> = ENUM3;
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_default'
-  --> $DIR/generics-default-stability.rs:219:25
+  --> $DIR/generics-default-stability.rs:207:25
    |
 LL |     let _: Enum3<isize, isize> = Enum3::Ok(0);
    |                         ^^^^^
@@ -425,7 +401,7 @@ LL |     let _: Enum3<isize, isize> = Enum3::Ok(0);
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_default'
-  --> $DIR/generics-default-stability.rs:220:25
+  --> $DIR/generics-default-stability.rs:208:25
    |
 LL |     let _: Enum3<usize, usize> = Enum3::Ok(0);
    |                         ^^^^^
@@ -433,7 +409,7 @@ LL |     let _: Enum3<usize, usize> = Enum3::Ok(0);
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_default'
-  --> $DIR/generics-default-stability.rs:242:18
+  --> $DIR/generics-default-stability.rs:230:18
    |
 LL |     let _: Enum5<isize> = Enum5::Some(1);
    |                  ^^^^^
@@ -441,7 +417,7 @@ LL |     let _: Enum5<isize> = Enum5::Some(1);
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_default'
-  --> $DIR/generics-default-stability.rs:247:18
+  --> $DIR/generics-default-stability.rs:235:18
    |
 LL |     let _: Enum5<usize> = ENUM5;
    |                  ^^^^^
@@ -449,7 +425,7 @@ LL |     let _: Enum5<usize> = ENUM5;
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_default'
-  --> $DIR/generics-default-stability.rs:249:18
+  --> $DIR/generics-default-stability.rs:237:18
    |
 LL |     let _: Enum5<isize> = Enum5::Some(0);
    |                  ^^^^^
@@ -457,7 +433,7 @@ LL |     let _: Enum5<isize> = Enum5::Some(0);
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'box_alloc_param'
-  --> $DIR/generics-default-stability.rs:256:24
+  --> $DIR/generics-default-stability.rs:244:24
    |
 LL |     let _: Box1<isize, System> = Box1::new(1);
    |                        ^^^^^^
@@ -465,29 +441,29 @@ LL |     let _: Box1<isize, System> = Box1::new(1);
    = help: add `#![feature(box_alloc_param)]` to the crate attributes to enable
 
 warning: use of deprecated field `unstable_generic_param::Struct4::field`: test
-  --> $DIR/generics-default-stability.rs:83:39
+  --> $DIR/generics-default-stability.rs:71:39
    |
 LL |     let _: Struct4<isize> = Struct4 { field: 1 };
    |                                       ^^^^^^^^
 
 warning: use of deprecated field `unstable_generic_param::Struct4::field`: test
-  --> $DIR/generics-default-stability.rs:90:39
+  --> $DIR/generics-default-stability.rs:78:39
    |
 LL |     let _: Struct4<isize> = Struct4 { field: 0 };
    |                                       ^^^^^^^^
 
 warning: use of deprecated field `unstable_generic_param::Struct5::field`: test
-  --> $DIR/generics-default-stability.rs:96:39
+  --> $DIR/generics-default-stability.rs:84:39
    |
 LL |     let _: Struct5<isize> = Struct5 { field: 1 };
    |                                       ^^^^^^^^
 
 warning: use of deprecated field `unstable_generic_param::Struct5::field`: test
-  --> $DIR/generics-default-stability.rs:104:39
+  --> $DIR/generics-default-stability.rs:92:39
    |
 LL |     let _: Struct5<isize> = Struct5 { field: 0 };
    |                                       ^^^^^^^^
 
-error: aborting due to 31 previous errors; 40 warnings emitted
+error: aborting due to 28 previous errors; 40 warnings emitted
 
 For more information about this error, try `rustc --explain E0658`.


### PR DESCRIPTION
Hygienically linking trait impl items to declarations in the trait can be done directly by the late resolver. In fact, it is already done to diagnose unknown items.

This PR uses this resolution work and stores the `DefId` of the trait item in the HIR. This avoids having to do this resolution manually later.

r? @matthewjasper 
Related to #90639. The added `trait_item_id` field can be moved to `ImplItemRef` to be used directly by your PR.
