### PR TITLE
Use const initializer for LOCAL_PANIC_COUNT

### DIFF
--- a/library/std/src/panicking.rs
+++ b/library/std/src/panicking.rs
@@ -325,7 +325,7 @@ pub mod panic_count {
     pub const ALWAYS_ABORT_FLAG: usize = 1 << (usize::BITS - 1);
 
     // Panic count for the current thread.
-    thread_local! { static LOCAL_PANIC_COUNT: Cell<usize> = Cell::new(0) }
+    thread_local! { static LOCAL_PANIC_COUNT: Cell<usize> = const { Cell::new(0) } }
 
     // Sum of panic counts from all threads. The purpose of this is to have
     // a fast path in `is_zero` (which is used by `panicking`). In any particular


### PR DESCRIPTION
This reduces the size of the __getit function for LOCAL_PANIC_COUNT and should speed up accesses of LOCAL_PANIC_COUNT a bit.