### PR TITLE
Ensure that early-bound function lifetimes are always 'local'

### DIFF
--- a/src/test/mir-opt/nll/named_lifetimes_basic.use_x.nll.0.mir
+++ b/src/test/mir-opt/nll/named_lifetimes_basic.use_x.nll.0.mir
@@ -2,8 +2,8 @@
 
 | Free Region Mapping
 | '_#0r | Global | ['_#2r, '_#1r, '_#0r, '_#4r, '_#3r]
-| '_#1r | External | ['_#1r, '_#4r]
-| '_#2r | External | ['_#2r, '_#1r, '_#4r]
+| '_#1r | Local | ['_#1r, '_#4r]
+| '_#2r | Local | ['_#2r, '_#1r, '_#4r]
 | '_#3r | Local | ['_#4r, '_#3r]
 | '_#4r | Local | ['_#4r]
 |

--- a/src/test/ui/c-variadic/variadic-ffi-4.stderr
+++ b/src/test/ui/c-variadic/variadic-ffi-4.stderr
@@ -20,7 +20,7 @@ LL | pub unsafe extern "C" fn no_escape0<'f>(_: usize, ap: ...) -> VaListImpl<'f
    |                                     |
    |                                     lifetime `'f` defined here
 LL |     ap
-   |     ^^ returning this value requires that `'1` must outlive `'f`
+   |     ^^ function was supposed to return data with lifetime `'f` but it is returning data with lifetime `'1`
    |
    = note: requirement occurs because of the type VaListImpl<'_>, which makes the generic argument '_ invariant
    = note: the struct VaListImpl<'f> is invariant over the parameter 'f

--- a/src/test/ui/fn/implied-bounds-unnorm-associated-type.nll.stderr
+++ b/src/test/ui/fn/implied-bounds-unnorm-associated-type.nll.stderr
@@ -6,7 +6,7 @@ LL | fn f<'a, 'b>(s: &'b str, _: <&'a &'b () as Trait>::Type) -> &'a str {
    |      |
    |      lifetime `'a` defined here
 LL |     s
-   |     ^ returning this value requires that `'b` must outlive `'a`
+   |     ^ function was supposed to return data with lifetime `'a` but it is returning data with lifetime `'b`
    |
    = help: consider adding the following bound: `'b: 'a`
 

--- a/src/test/ui/issues/issue-16683.nll.stderr
+++ b/src/test/ui/issues/issue-16683.nll.stderr
@@ -1,20 +1,13 @@
-error[E0521]: borrowed data escapes outside of associated function
+error: lifetime may not live long enough
   --> $DIR/issue-16683.rs:4:9
    |
 LL | trait T<'a> {
    |         -- lifetime `'a` defined here
 LL |     fn a(&'a self) -> &'a bool;
 LL |     fn b(&self) {
-   |          -----
-   |          |
-   |          `self` is a reference that is only valid in the associated function body
-   |          let's call the lifetime of this reference `'1`
+   |          - let's call the lifetime of this reference `'1`
 LL |         self.a();
-   |         ^^^^^^^^
-   |         |
-   |         `self` escapes the associated function body here
-   |         argument requires that `'1` must outlive `'a`
+   |         ^^^^^^^^ argument requires that `'1` must outlive `'a`
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0521`.

--- a/src/test/ui/issues/issue-17758.nll.stderr
+++ b/src/test/ui/issues/issue-17758.nll.stderr
@@ -1,20 +1,13 @@
-error[E0521]: borrowed data escapes outside of associated function
+error: lifetime may not live long enough
   --> $DIR/issue-17758.rs:7:9
    |
 LL | trait Foo<'a> {
    |           -- lifetime `'a` defined here
 LL |     fn foo(&'a self);
 LL |     fn bar(&self) {
-   |            -----
-   |            |
-   |            `self` is a reference that is only valid in the associated function body
-   |            let's call the lifetime of this reference `'1`
+   |            - let's call the lifetime of this reference `'1`
 LL |         self.foo();
-   |         ^^^^^^^^^^
-   |         |
-   |         `self` escapes the associated function body here
-   |         argument requires that `'1` must outlive `'a`
+   |         ^^^^^^^^^^ argument requires that `'1` must outlive `'a`
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0521`.

--- a/src/test/ui/issues/issue-52213.nll.stderr
+++ b/src/test/ui/issues/issue-52213.nll.stderr
@@ -7,7 +7,7 @@ LL | fn transmute_lifetime<'a, 'b, T>(t: &'a (T,)) -> &'b T {
    |                       lifetime `'a` defined here
 LL |     match (&t,) {
 LL |         ((u,),) => u,
-   |                    ^ returning this value requires that `'a` must outlive `'b`
+   |                    ^ function was supposed to return data with lifetime `'b` but it is returning data with lifetime `'a`
    |
    = help: consider adding the following bound: `'a: 'b`
 

--- a/src/test/ui/match/match-ref-mut-invariance.nll.stderr
+++ b/src/test/ui/match/match-ref-mut-invariance.nll.stderr
@@ -6,7 +6,7 @@ LL | impl<'b> S<'b> {
 LL |     fn bar<'a>(&'a mut self) -> &'a mut &'a i32 {
    |            -- lifetime `'a` defined here
 LL |         match self.0 { ref mut x => x }
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ returning this value requires that `'a` must outlive `'b`
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ associated function was supposed to return data with lifetime `'b` but it is returning data with lifetime `'a`
    |
    = help: consider adding the following bound: `'a: 'b`
    = note: requirement occurs because of a mutable reference to &i32

--- a/src/test/ui/match/match-ref-mut-let-invariance.nll.stderr
+++ b/src/test/ui/match/match-ref-mut-let-invariance.nll.stderr
@@ -7,7 +7,7 @@ LL |     fn bar<'a>(&'a mut self) -> &'a mut &'a i32 {
    |            -- lifetime `'a` defined here
 LL |         let ref mut x = self.0;
 LL |         x
-   |         ^ returning this value requires that `'a` must outlive `'b`
+   |         ^ associated function was supposed to return data with lifetime `'b` but it is returning data with lifetime `'a`
    |
    = help: consider adding the following bound: `'a: 'b`
    = note: requirement occurs because of a mutable reference to &i32

--- a/src/test/ui/nll/issue-52113.stderr
+++ b/src/test/ui/nll/issue-52113.stderr
@@ -7,7 +7,7 @@ LL | fn produce_err<'a, 'b: 'a>(data: &'b mut Vec<&'b u32>, value: &'a u32) -> i
    |                lifetime `'a` defined here
 ...
 LL |     x
-   |     ^ returning this value requires that `'a` must outlive `'b`
+   |     ^ function was supposed to return data with lifetime `'b` but it is returning data with lifetime `'a`
    |
    = help: consider adding the following bound: `'a: 'b`
 

--- a/src/test/ui/nll/issue-55394.nll.stderr
+++ b/src/test/ui/nll/issue-55394.nll.stderr
@@ -6,7 +6,7 @@ LL |     fn new(bar: &mut Bar) -> Self {
    |                 |
    |                 let's call the lifetime of this reference `'1`
 LL |         Foo { bar }
-   |         ^^^^^^^^^^^ returning this value requires that `'1` must outlive `'2`
+   |         ^^^^^^^^^^^ associated function was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/issue-67007-escaping-data.rs
+++ b/src/test/ui/nll/issue-67007-escaping-data.rs
@@ -14,7 +14,7 @@ struct Consumer<'tcx>(&'tcx ());
 
 impl<'tcx> Consumer<'tcx> {
     fn bad_method<'a>(&self, fcx: &FnCtxt<'a, 'tcx>) {
-        let other = self.use_fcx(fcx); //~ ERROR borrowed data
+        let other = self.use_fcx(fcx); //~ ERROR lifetime may not live long enough
         fcx.use_it(other);
     }
 

--- a/src/test/ui/nll/issue-67007-escaping-data.stderr
+++ b/src/test/ui/nll/issue-67007-escaping-data.stderr
@@ -1,21 +1,14 @@
-error[E0521]: borrowed data escapes outside of associated function
+error: lifetime may not live long enough
   --> $DIR/issue-67007-escaping-data.rs:17:21
    |
 LL | impl<'tcx> Consumer<'tcx> {
    |      ---- lifetime `'tcx` defined here
 LL |     fn bad_method<'a>(&self, fcx: &FnCtxt<'a, 'tcx>) {
-   |                   --  -----  --- `fcx` is a reference that is only valid in the associated function body
-   |                   |   |
-   |                   |   `self` declared here, outside of the associated function body
-   |                   lifetime `'a` defined here
+   |                   -- lifetime `'a` defined here
 LL |         let other = self.use_fcx(fcx);
-   |                     ^^^^^^^^^^^^^^^^^
-   |                     |
-   |                     `fcx` escapes the associated function body here
-   |                     argument requires that `'a` must outlive `'tcx`
+   |                     ^^^^^^^^^^^^^^^^^ argument requires that `'a` must outlive `'tcx`
    |
    = help: consider adding the following bound: `'a: 'tcx`
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0521`.

--- a/src/test/ui/nll/mir_check_cast_closure.stderr
+++ b/src/test/ui/nll/mir_check_cast_closure.stderr
@@ -7,7 +7,7 @@ LL | fn bar<'a, 'b>() -> fn(&'a u32, &'b u32) -> &'a u32 {
    |        lifetime `'a` defined here
 LL |     let g: fn(_, _) -> _ = |_x, y| y;
 LL |     g
-   |     ^ returning this value requires that `'b` must outlive `'a`
+   |     ^ function was supposed to return data with lifetime `'a` but it is returning data with lifetime `'b`
    |
    = help: consider adding the following bound: `'b: 'a`
 

--- a/src/test/ui/nll/outlives-suggestion-more.stderr
+++ b/src/test/ui/nll/outlives-suggestion-more.stderr
@@ -6,7 +6,7 @@ LL | fn foo1<'a, 'b, 'c, 'd>(x: &'a usize, y: &'b usize) -> (&'c usize, &'d usiz
    |         |
    |         lifetime `'a` defined here
 LL |     (x, y)
-   |     ^^^^^^ returning this value requires that `'a` must outlive `'c`
+   |     ^^^^^^ function was supposed to return data with lifetime `'c` but it is returning data with lifetime `'a`
    |
    = help: consider adding the following bound: `'a: 'c`
 
@@ -18,7 +18,7 @@ LL | fn foo1<'a, 'b, 'c, 'd>(x: &'a usize, y: &'b usize) -> (&'c usize, &'d usiz
    |             |
    |             lifetime `'b` defined here
 LL |     (x, y)
-   |     ^^^^^^ returning this value requires that `'b` must outlive `'d`
+   |     ^^^^^^ function was supposed to return data with lifetime `'d` but it is returning data with lifetime `'b`
    |
    = help: consider adding the following bound: `'b: 'd`
 
@@ -35,7 +35,7 @@ LL | fn foo2<'a, 'b, 'c>(x: &'a usize, y: &'b usize) -> (&'c usize, &'static usi
    |         |
    |         lifetime `'a` defined here
 LL |     (x, y)
-   |     ^^^^^^ returning this value requires that `'a` must outlive `'c`
+   |     ^^^^^^ function was supposed to return data with lifetime `'c` but it is returning data with lifetime `'a`
    |
    = help: consider adding the following bound: `'a: 'c`
 

--- a/src/test/ui/nll/outlives-suggestion-simple.rs
+++ b/src/test/ui/nll/outlives-suggestion-simple.rs
@@ -70,7 +70,7 @@ pub struct Foo2<'a> {
 impl<'a> Foo2<'a> {
     // should not produce outlives suggestions to name 'self
     fn get_bar(&self) -> Bar2 {
-        Bar2::new(&self) //~ERROR borrowed data escapes outside of associated function
+        Bar2::new(&self) //~ERROR lifetime may not live long enough
     }
 }
 

--- a/src/test/ui/nll/outlives-suggestion-simple.stderr
+++ b/src/test/ui/nll/outlives-suggestion-simple.stderr
@@ -6,7 +6,7 @@ LL | fn foo1<'a, 'b>(x: &'a usize) -> &'b usize {
    |         |
    |         lifetime `'a` defined here
 LL |     x
-   |     ^ returning this value requires that `'a` must outlive `'b`
+   |     ^ function was supposed to return data with lifetime `'b` but it is returning data with lifetime `'a`
    |
    = help: consider adding the following bound: `'a: 'b`
 
@@ -53,7 +53,7 @@ LL | fn foo4<'a, 'b, 'c>(x: &'a usize) -> (&'b usize, &'c usize) {
    |         lifetime `'a` defined here
 ...
 LL |     (x, x)
-   |     ^^^^^^ returning this value requires that `'a` must outlive `'b`
+   |     ^^^^^^ function was supposed to return data with lifetime `'b` but it is returning data with lifetime `'a`
    |
    = help: consider adding the following bound: `'a: 'b`
 
@@ -73,7 +73,7 @@ LL | impl<'a> Bar<'a> {
 LL |     pub fn get<'b>(&self) -> &'b usize {
    |                -- lifetime `'b` defined here
 LL |         self.x
-   |         ^^^^^^ returning this value requires that `'a` must outlive `'b`
+   |         ^^^^^^ associated function was supposed to return data with lifetime `'b` but it is returning data with lifetime `'a`
    |
    = help: consider adding the following bound: `'a: 'b`
 
@@ -85,28 +85,20 @@ LL | impl<'a> Baz<'a> {
 LL |     fn get<'b>(&'b self) -> &'a i32 {
    |            -- lifetime `'b` defined here
 LL |         self.x
-   |         ^^^^^^ returning this value requires that `'b` must outlive `'a`
+   |         ^^^^^^ associated function was supposed to return data with lifetime `'a` but it is returning data with lifetime `'b`
    |
    = help: consider adding the following bound: `'b: 'a`
 
-error[E0521]: borrowed data escapes outside of associated function
+error: lifetime may not live long enough
   --> $DIR/outlives-suggestion-simple.rs:73:9
    |
 LL | impl<'a> Foo2<'a> {
    |      -- lifetime `'a` defined here
 LL |     // should not produce outlives suggestions to name 'self
 LL |     fn get_bar(&self) -> Bar2 {
-   |                -----
-   |                |
-   |                `self` declared here, outside of the associated function body
-   |                `self` is a reference that is only valid in the associated function body
-   |                let's call the lifetime of this reference `'1`
+   |                - let's call the lifetime of this reference `'1`
 LL |         Bar2::new(&self)
-   |         ^^^^^^^^^^^^^^^^
-   |         |
-   |         `self` escapes the associated function body here
-   |         argument requires that `'1` must outlive `'a`
+   |         ^^^^^^^^^^^^^^^^ argument requires that `'1` must outlive `'a`
 
 error: aborting due to 9 previous errors
 
-For more information about this error, try `rustc --explain E0521`.

--- a/src/test/ui/nll/type-alias-free-regions.nll.stderr
+++ b/src/test/ui/nll/type-alias-free-regions.nll.stderr
@@ -6,7 +6,7 @@ LL | impl<'a> FromBox<'a> for C<'a> {
 LL |     fn from_box(b: Box<B>) -> Self {
    |                 - has type `Box<Box<&'1 isize>>`
 LL |         C { f: b }
-   |         ^^^^^^^^^^ returning this value requires that `'1` must outlive `'a`
+   |         ^^^^^^^^^^ associated function was supposed to return data with lifetime `'a` but it is returning data with lifetime `'1`
 
 error: lifetime may not live long enough
   --> $DIR/type-alias-free-regions.rs:27:9
@@ -16,7 +16,7 @@ LL | impl<'a> FromTuple<'a> for C<'a> {
 LL |     fn from_tuple(b: (B,)) -> Self {
    |                   - has type `(Box<&'1 isize>,)`
 LL |         C { f: Box::new(b.0) }
-   |         ^^^^^^^^^^^^^^^^^^^^^^ returning this value requires that `'1` must outlive `'a`
+   |         ^^^^^^^^^^^^^^^^^^^^^^ associated function was supposed to return data with lifetime `'a` but it is returning data with lifetime `'1`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/nll/type-check-pointer-coercions.stderr
+++ b/src/test/ui/nll/type-check-pointer-coercions.stderr
@@ -6,7 +6,7 @@ LL | fn shared_to_const<'a, 'b>(x: &&'a i32) -> *const &'b i32 {
    |                    |
    |                    lifetime `'a` defined here
 LL |     x
-   |     ^ returning this value requires that `'a` must outlive `'b`
+   |     ^ function was supposed to return data with lifetime `'b` but it is returning data with lifetime `'a`
    |
    = help: consider adding the following bound: `'a: 'b`
 
@@ -18,7 +18,7 @@ LL | fn unique_to_const<'a, 'b>(x: &mut &'a i32) -> *const &'b i32 {
    |                    |
    |                    lifetime `'a` defined here
 LL |     x
-   |     ^ returning this value requires that `'a` must outlive `'b`
+   |     ^ function was supposed to return data with lifetime `'b` but it is returning data with lifetime `'a`
    |
    = help: consider adding the following bound: `'a: 'b`
 
@@ -47,7 +47,7 @@ LL | fn unique_to_mut<'a, 'b>(x: &mut &'a i32) -> *mut &'b i32 {
    |                  lifetime `'a` defined here
 LL |     // Two errors because *mut is invariant
 LL |     x
-   |     ^ returning this value requires that `'a` must outlive `'b`
+   |     ^ function was supposed to return data with lifetime `'b` but it is returning data with lifetime `'a`
    |
    = help: consider adding the following bound: `'a: 'b`
    = note: requirement occurs because of a mutable pointer to &i32
@@ -64,7 +64,7 @@ LL | fn mut_to_const<'a, 'b>(x: *mut &'a i32) -> *const &'b i32 {
    |                 |
    |                 lifetime `'a` defined here
 LL |     x
-   |     ^ returning this value requires that `'a` must outlive `'b`
+   |     ^ function was supposed to return data with lifetime `'b` but it is returning data with lifetime `'a`
    |
    = help: consider adding the following bound: `'a: 'b`
 
@@ -77,7 +77,7 @@ LL | fn array_elem<'a, 'b>(x: &'a i32) -> *const &'b i32 {
    |               lifetime `'a` defined here
 ...
 LL |     y
-   |     ^ returning this value requires that `'a` must outlive `'b`
+   |     ^ function was supposed to return data with lifetime `'b` but it is returning data with lifetime `'a`
    |
    = help: consider adding the following bound: `'a: 'b`
 
@@ -90,7 +90,7 @@ LL | fn array_coerce<'a, 'b>(x: &'a i32) -> *const [&'b i32; 3] {
    |                 lifetime `'a` defined here
 ...
 LL |     y
-   |     ^ returning this value requires that `'a` must outlive `'b`
+   |     ^ function was supposed to return data with lifetime `'b` but it is returning data with lifetime `'a`
    |
    = help: consider adding the following bound: `'a: 'b`
 
@@ -103,7 +103,7 @@ LL | fn nested_array<'a, 'b>(x: &'a i32) -> *const [&'b i32; 2] {
    |                 lifetime `'a` defined here
 ...
 LL |     y
-   |     ^ returning this value requires that `'a` must outlive `'b`
+   |     ^ function was supposed to return data with lifetime `'b` but it is returning data with lifetime `'a`
    |
    = help: consider adding the following bound: `'a: 'b`
 

--- a/src/test/ui/nll/user-annotations/wf-self-type.stderr
+++ b/src/test/ui/nll/user-annotations/wf-self-type.stderr
@@ -6,7 +6,7 @@ LL | pub fn foo<'a, 'b>(u: &'b ()) -> &'a () {
    |            |
    |            lifetime `'a` defined here
 LL |     Foo::xmute(u)
-   |     ^^^^^^^^^^^^^ returning this value requires that `'b` must outlive `'a`
+   |     ^^^^^^^^^^^^^ function was supposed to return data with lifetime `'a` but it is returning data with lifetime `'b`
    |
    = help: consider adding the following bound: `'b: 'a`
 

--- a/src/test/ui/object-lifetime/object-lifetime-default-elision.nll.stderr
+++ b/src/test/ui/object-lifetime/object-lifetime-default-elision.nll.stderr
@@ -7,7 +7,7 @@ LL | fn load3<'a,'b>(ss: &'a dyn SomeTrait) -> &'b dyn SomeTrait {
    |          lifetime `'a` defined here
 ...
 LL |     ss
-   |     ^^ returning this value requires that `'a` must outlive `'b`
+   |     ^^ function was supposed to return data with lifetime `'b` but it is returning data with lifetime `'a`
    |
    = help: consider adding the following bound: `'a: 'b`
 

--- a/src/test/ui/regions/region-object-lifetime-2.nll.stderr
+++ b/src/test/ui/regions/region-object-lifetime-2.nll.stderr
@@ -6,7 +6,7 @@ LL | fn borrowed_receiver_different_lifetimes<'a,'b>(x: &'a dyn Foo) -> &'b () {
    |                                          |
    |                                          lifetime `'a` defined here
 LL |     x.borrowed()
-   |     ^^^^^^^^^^^^ returning this value requires that `'a` must outlive `'b`
+   |     ^^^^^^^^^^^^ function was supposed to return data with lifetime `'b` but it is returning data with lifetime `'a`
    |
    = help: consider adding the following bound: `'a: 'b`
 

--- a/src/test/ui/regions/region-object-lifetime-in-coercion.nll.stderr
+++ b/src/test/ui/regions/region-object-lifetime-in-coercion.nll.stderr
@@ -31,7 +31,7 @@ LL | fn d<'a,'b>(v: &'a [u8]) -> Box<dyn Foo+'b> {
    |      |
    |      lifetime `'a` defined here
 LL |     Box::new(v)
-   |     ^^^^^^^^^^^ returning this value requires that `'a` must outlive `'b`
+   |     ^^^^^^^^^^^ function was supposed to return data with lifetime `'b` but it is returning data with lifetime `'a`
    |
    = help: consider adding the following bound: `'a: 'b`
 

--- a/src/test/ui/regions/regions-bounded-method-type-parameters-trait-bound.nll.stderr
+++ b/src/test/ui/regions/regions-bounded-method-type-parameters-trait-bound.nll.stderr
@@ -1,18 +1,13 @@
-error[E0521]: borrowed data escapes outside of function
+error: lifetime may not live long enough
   --> $DIR/regions-bounded-method-type-parameters-trait-bound.rs:20:5
    |
 LL | fn caller2<'a,'b,F:Foo<'a>>(a: Inv<'a>, b: Inv<'b>, f: F) {
-   |            -- --            -           - `b` is a reference that is only valid in the function body
-   |            |  |             |
-   |            |  |             `a` declared here, outside of the function body
-   |            |  lifetime `'b` defined here
+   |            -- -- lifetime `'b` defined here
+   |            |
    |            lifetime `'a` defined here
 LL |     // Here the value provided for 'y is 'b, and hence 'b:'a does not hold.
 LL |     f.method(b);
-   |     ^^^^^^^^^^^
-   |     |
-   |     `b` escapes the function body here
-   |     argument requires that `'b` must outlive `'a`
+   |     ^^^^^^^^^^^ argument requires that `'b` must outlive `'a`
    |
    = help: consider adding the following bound: `'b: 'a`
    = note: requirement occurs because of the type Inv<'_>, which makes the generic argument '_ invariant
@@ -21,4 +16,3 @@ LL |     f.method(b);
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0521`.

--- a/src/test/ui/regions/regions-bounds.nll.stderr
+++ b/src/test/ui/regions/regions-bounds.nll.stderr
@@ -6,7 +6,7 @@ LL | fn a_fn1<'a,'b>(e: TupleStruct<'a>) -> TupleStruct<'b> {
    |          |
    |          lifetime `'a` defined here
 LL |     return e;
-   |            ^ returning this value requires that `'a` must outlive `'b`
+   |            ^ function was supposed to return data with lifetime `'b` but it is returning data with lifetime `'a`
    |
    = help: consider adding the following bound: `'a: 'b`
 
@@ -18,7 +18,7 @@ LL | fn a_fn3<'a,'b>(e: Struct<'a>) -> Struct<'b> {
    |          |
    |          lifetime `'a` defined here
 LL |     return e;
-   |            ^ returning this value requires that `'a` must outlive `'b`
+   |            ^ function was supposed to return data with lifetime `'b` but it is returning data with lifetime `'a`
    |
    = help: consider adding the following bound: `'a: 'b`
 

--- a/src/test/ui/regions/regions-close-over-type-parameter-multiple.nll.stderr
+++ b/src/test/ui/regions/regions-close-over-type-parameter-multiple.nll.stderr
@@ -7,7 +7,7 @@ LL | fn make_object_bad<'a,'b,'c,A:SomeTrait+'a+'b>(v: A) -> Box<dyn SomeTrait +
    |                    lifetime `'a` defined here
 LL |     // A outlives 'a AND 'b...but not 'c.
 LL |     Box::new(v) as Box<dyn SomeTrait + 'a>
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ returning this value requires that `'a` must outlive `'c`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function was supposed to return data with lifetime `'c` but it is returning data with lifetime `'a`
    |
    = help: consider adding the following bound: `'a: 'c`
 

--- a/src/test/ui/regions/regions-creating-enums4.nll.stderr
+++ b/src/test/ui/regions/regions-creating-enums4.nll.stderr
@@ -6,7 +6,7 @@ LL | fn mk_add_bad2<'a,'b>(x: &'a Ast<'a>, y: &'a Ast<'a>, z: &Ast) -> Ast<'b> {
    |                |
    |                lifetime `'a` defined here
 LL |     Ast::Add(x, y)
-   |     ^^^^^^^^^^^^^^ returning this value requires that `'a` must outlive `'b`
+   |     ^^^^^^^^^^^^^^ function was supposed to return data with lifetime `'b` but it is returning data with lifetime `'a`
    |
    = help: consider adding the following bound: `'a: 'b`
 

--- a/src/test/ui/regions/regions-early-bound-error-method.nll.stderr
+++ b/src/test/ui/regions/regions-early-bound-error-method.nll.stderr
@@ -6,7 +6,7 @@ LL | impl<'a> Box<'a> {
 LL |     fn or<'b,G:GetRef<'b>>(&self, g2: G) -> &'a isize {
    |           -- lifetime `'b` defined here
 LL |         g2.get()
-   |         ^^^^^^^^ returning this value requires that `'b` must outlive `'a`
+   |         ^^^^^^^^ associated function was supposed to return data with lifetime `'a` but it is returning data with lifetime `'b`
    |
    = help: consider adding the following bound: `'b: 'a`
 

--- a/src/test/ui/regions/regions-free-region-ordering-incorrect.nll.stderr
+++ b/src/test/ui/regions/regions-free-region-ordering-incorrect.nll.stderr
@@ -9,7 +9,7 @@ LL | /         match self.next {
 LL | |             Some(ref next) => next.get(),
 LL | |             None => &self.val
 LL | |         }
-   | |_________^ returning this value requires that `'a` must outlive `'b`
+   | |_________^ associated function was supposed to return data with lifetime `'b` but it is returning data with lifetime `'a`
    |
    = help: consider adding the following bound: `'a: 'b`
 

--- a/src/test/ui/regions/regions-infer-not-param.nll.stderr
+++ b/src/test/ui/regions/regions-infer-not-param.nll.stderr
@@ -2,7 +2,7 @@ error: lifetime may not live long enough
   --> $DIR/regions-infer-not-param.rs:15:54
    |
 LL | fn take_direct<'a,'b>(p: Direct<'a>) -> Direct<'b> { p }
-   |                -- -- lifetime `'b` defined here      ^ returning this value requires that `'a` must outlive `'b`
+   |                -- -- lifetime `'b` defined here      ^ function was supposed to return data with lifetime `'b` but it is returning data with lifetime `'a`
    |                |
    |                lifetime `'a` defined here
    |
@@ -25,7 +25,7 @@ error: lifetime may not live long enough
   --> $DIR/regions-infer-not-param.rs:19:63
    |
 LL | fn take_indirect2<'a,'b>(p: Indirect2<'a>) -> Indirect2<'b> { p }
-   |                   -- -- lifetime `'b` defined here            ^ returning this value requires that `'a` must outlive `'b`
+   |                   -- -- lifetime `'b` defined here            ^ function was supposed to return data with lifetime `'b` but it is returning data with lifetime `'a`
    |                   |
    |                   lifetime `'a` defined here
    |

--- a/src/test/ui/regions/regions-trait-object-subtyping.nll.stderr
+++ b/src/test/ui/regions/regions-trait-object-subtyping.nll.stderr
@@ -7,7 +7,7 @@ LL | fn foo3<'a,'b>(x: &'a mut dyn Dummy) -> &'b mut dyn Dummy {
    |         lifetime `'a` defined here
 LL |     // Without knowing 'a:'b, we can't coerce
 LL |     x
-   |     ^ returning this value requires that `'a` must outlive `'b`
+   |     ^ function was supposed to return data with lifetime `'b` but it is returning data with lifetime `'a`
    |
    = help: consider adding the following bound: `'a: 'b`
    = note: requirement occurs because of a mutable reference to dyn Dummy
@@ -23,7 +23,7 @@ LL | fn foo4<'a:'b,'b>(x: Wrapper<&'a mut dyn Dummy>) -> Wrapper<&'b mut dyn Dum
    |         lifetime `'a` defined here
 LL |     // We can't coerce because it is packed in `Wrapper`
 LL |     x
-   |     ^ returning this value requires that `'b` must outlive `'a`
+   |     ^ function was supposed to return data with lifetime `'a` but it is returning data with lifetime `'b`
    |
    = help: consider adding the following bound: `'b: 'a`
    = note: requirement occurs because of a mutable reference to dyn Dummy

--- a/src/test/ui/variance/variance-contravariant-arg-object.nll.stderr
+++ b/src/test/ui/variance/variance-contravariant-arg-object.nll.stderr
@@ -7,7 +7,7 @@ LL | fn get_min_from_max<'min, 'max>(v: Box<dyn Get<&'max i32>>)
    |                     lifetime `'min` defined here
 ...
 LL |     v
-   |     ^ returning this value requires that `'min` must outlive `'max`
+   |     ^ function was supposed to return data with lifetime `'max` but it is returning data with lifetime `'min`
    |
    = help: consider adding the following bound: `'min: 'max`
 
@@ -20,7 +20,7 @@ LL | fn get_max_from_min<'min, 'max, G>(v: Box<dyn Get<&'min i32>>)
    |                     lifetime `'min` defined here
 ...
 LL |     v
-   |     ^ returning this value requires that `'min` must outlive `'max`
+   |     ^ function was supposed to return data with lifetime `'max` but it is returning data with lifetime `'min`
    |
    = help: consider adding the following bound: `'min: 'max`
 

--- a/src/test/ui/variance/variance-covariant-arg-object.nll.stderr
+++ b/src/test/ui/variance/variance-covariant-arg-object.nll.stderr
@@ -7,7 +7,7 @@ LL | fn get_min_from_max<'min, 'max>(v: Box<dyn Get<&'max i32>>)
    |                     lifetime `'min` defined here
 ...
 LL |     v
-   |     ^ returning this value requires that `'min` must outlive `'max`
+   |     ^ function was supposed to return data with lifetime `'max` but it is returning data with lifetime `'min`
    |
    = help: consider adding the following bound: `'min: 'max`
 
@@ -20,7 +20,7 @@ LL | fn get_max_from_min<'min, 'max, G>(v: Box<dyn Get<&'min i32>>)
    |                     lifetime `'min` defined here
 ...
 LL |     v
-   |     ^ returning this value requires that `'min` must outlive `'max`
+   |     ^ function was supposed to return data with lifetime `'max` but it is returning data with lifetime `'min`
    |
    = help: consider adding the following bound: `'min: 'max`
 

--- a/src/test/ui/variance/variance-invariant-arg-object.nll.stderr
+++ b/src/test/ui/variance/variance-invariant-arg-object.nll.stderr
@@ -7,7 +7,7 @@ LL | fn get_min_from_max<'min, 'max>(v: Box<dyn Get<&'max i32>>)
    |                     lifetime `'min` defined here
 ...
 LL |     v
-   |     ^ returning this value requires that `'min` must outlive `'max`
+   |     ^ function was supposed to return data with lifetime `'max` but it is returning data with lifetime `'min`
    |
    = help: consider adding the following bound: `'min: 'max`
 
@@ -20,7 +20,7 @@ LL | fn get_max_from_min<'min, 'max, G>(v: Box<dyn Get<&'min i32>>)
    |                     lifetime `'min` defined here
 ...
 LL |     v
-   |     ^ returning this value requires that `'min` must outlive `'max`
+   |     ^ function was supposed to return data with lifetime `'max` but it is returning data with lifetime `'min`
    |
    = help: consider adding the following bound: `'min: 'max`
 

--- a/src/test/ui/variance/variance-use-contravariant-struct-1.nll.stderr
+++ b/src/test/ui/variance/variance-use-contravariant-struct-1.nll.stderr
@@ -7,7 +7,7 @@ LL | fn foo<'min,'max>(v: SomeStruct<&'max ()>)
    |        lifetime `'min` defined here
 ...
 LL |     v
-   |     ^ returning this value requires that `'min` must outlive `'max`
+   |     ^ function was supposed to return data with lifetime `'max` but it is returning data with lifetime `'min`
    |
    = help: consider adding the following bound: `'min: 'max`
 

--- a/src/test/ui/variance/variance-use-covariant-struct-1.nll.stderr
+++ b/src/test/ui/variance/variance-use-covariant-struct-1.nll.stderr
@@ -7,7 +7,7 @@ LL | fn foo<'min,'max>(v: SomeStruct<&'min ()>)
    |        lifetime `'min` defined here
 ...
 LL |     v
-   |     ^ returning this value requires that `'min` must outlive `'max`
+   |     ^ function was supposed to return data with lifetime `'max` but it is returning data with lifetime `'min`
    |
    = help: consider adding the following bound: `'min: 'max`
 

--- a/src/test/ui/variance/variance-use-invariant-struct-1.nll.stderr
+++ b/src/test/ui/variance/variance-use-invariant-struct-1.nll.stderr
@@ -7,7 +7,7 @@ LL | fn foo<'min,'max>(v: SomeStruct<&'max ()>)
    |        lifetime `'min` defined here
 ...
 LL |     v
-   |     ^ returning this value requires that `'min` must outlive `'max`
+   |     ^ function was supposed to return data with lifetime `'max` but it is returning data with lifetime `'min`
    |
    = help: consider adding the following bound: `'min: 'max`
    = note: requirement occurs because of the type SomeStruct<&()>, which makes the generic argument &() invariant
@@ -23,7 +23,7 @@ LL | fn bar<'min,'max>(v: SomeStruct<&'min ()>)
    |        lifetime `'min` defined here
 ...
 LL |     v
-   |     ^ returning this value requires that `'min` must outlive `'max`
+   |     ^ function was supposed to return data with lifetime `'max` but it is returning data with lifetime `'min`
    |
    = help: consider adding the following bound: `'min: 'max`
    = note: requirement occurs because of the type SomeStruct<&()>, which makes the generic argument &() invariant

--- a/src/test/ui/wf/wf-static-method.nll.stderr
+++ b/src/test/ui/wf/wf-static-method.nll.stderr
@@ -7,7 +7,7 @@ LL | impl<'a, 'b> Foo<'a, 'b, Evil<'a, 'b>> for () {
    |      lifetime `'a` defined here
 ...
 LL |         u
-   |         ^ returning this value requires that `'b` must outlive `'a`
+   |         ^ associated function was supposed to return data with lifetime `'a` but it is returning data with lifetime `'b`
    |
    = help: consider adding the following bound: `'b: 'a`
 
@@ -33,7 +33,7 @@ LL | impl<'a, 'b> Evil<'a, 'b> {
    |      lifetime `'a` defined here
 LL |     fn inherent_evil(u: &'b u32) -> &'a u32 {
 LL |         u
-   |         ^ returning this value requires that `'b` must outlive `'a`
+   |         ^ associated function was supposed to return data with lifetime `'a` but it is returning data with lifetime `'b`
    |
    = help: consider adding the following bound: `'b: 'a`
 
@@ -45,7 +45,7 @@ LL | fn evil<'a, 'b>(b: &'b u32) -> &'a u32 {
    |         |
    |         lifetime `'a` defined here
 LL |     <()>::static_evil(b)
-   |     ^^^^^^^^^^^^^^^^^^^^ returning this value requires that `'b` must outlive `'a`
+   |     ^^^^^^^^^^^^^^^^^^^^ function was supposed to return data with lifetime `'a` but it is returning data with lifetime `'b`
    |
    = help: consider adding the following bound: `'b: 'a`
 
@@ -57,7 +57,7 @@ LL | fn indirect_evil<'a, 'b>(b: &'b u32) -> &'a u32 {
    |                  |
    |                  lifetime `'a` defined here
 LL |     <IndirectEvil>::static_evil(b)
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ returning this value requires that `'b` must outlive `'a`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function was supposed to return data with lifetime `'a` but it is returning data with lifetime `'b`
    |
    = help: consider adding the following bound: `'b: 'a`
 
@@ -69,7 +69,7 @@ LL | fn inherent_evil<'a, 'b>(b: &'b u32) -> &'a u32 {
    |                  |
    |                  lifetime `'a` defined here
 LL |     <Evil>::inherent_evil(b)
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^ returning this value requires that `'b` must outlive `'a`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^ function was supposed to return data with lifetime `'a` but it is returning data with lifetime `'b`
    |
    = help: consider adding the following bound: `'b: 'a`
 


### PR DESCRIPTION
During borrowchecking, we treat any free (early-bound) regions on
the 'defining type' as `RegionClassification::External`. According
to the doc comments, we should only have 'external' regions when
checking a closure/generator.

However, a plain function can also have some if its regions
be considered 'early bound' - this occurs when the region is
constrained by an argument, appears in a `where` clause, or
in an opaque type. This was causing us to incorrectly mark these
regions as 'external', which caused some diagnostic code
to act as if we were referring to a 'parent' region from inside
a closure.

This PR marks all instantiated region variables as 'local'
when we're borrow-checking something other than a
closure/generator/inline-const.