### PR TITLE
Emit an error for `--cfg=)`

### DIFF
--- a/src/test/ui/conditional-compilation/cfg-arg-invalid-8.rs
+++ b/src/test/ui/conditional-compilation/cfg-arg-invalid-8.rs
@@ -1,0 +1,3 @@
+// compile-flags: --cfg )
+// error-pattern: invalid `--cfg` argument: `)` (expected `key` or `key="value"`)
+fn main() {}

--- a/src/test/ui/conditional-compilation/cfg-arg-invalid-8.stderr
+++ b/src/test/ui/conditional-compilation/cfg-arg-invalid-8.stderr
@@ -1,0 +1,2 @@
+error: invalid `--cfg` argument: `)` (expected `key` or `key="value"`)
+


### PR DESCRIPTION
Fixes #73026

See also: #64467, #89468

The issue stems from a `FatalError` being silently raised in
`panictry_buffer`. Normally this is not a problem, because
`panictry_buffer` emits the causes of the error, but they are not
themselves fatal, so they get filtered out by the silent emitter.

To fix this, we use a parser entrypoint which doesn't use
`panictry_buffer`, and we handle the error ourselves.