### PR TITLE
Remove LazyMeta::min_size

### DIFF
--- a/compiler/rustc_metadata/src/rmeta/mod.rs
+++ b/compiler/rustc_metadata/src/rmeta/mod.rs
@@ -62,27 +62,14 @@ pub const METADATA_HEADER: &[u8] = &[b'r', b'u', b's', b't', 0, 0, 0, METADATA_V
 /// e.g. for `Lazy<[T]>`, this is the length (count of `T` values).
 trait LazyMeta {
     type Meta: Copy + 'static;
-
-    /// Returns the minimum encoded size.
-    // FIXME(eddyb) Give better estimates for certain types.
-    fn min_size(meta: Self::Meta) -> usize;
 }
 
 impl<T> LazyMeta for T {
     type Meta = ();
-
-    fn min_size(_: ()) -> usize {
-        assert_ne!(std::mem::size_of::<T>(), 0);
-        1
-    }
 }
 
 impl<T> LazyMeta for [T] {
     type Meta = usize;
-
-    fn min_size(len: usize) -> usize {
-        len * T::min_size(())
-    }
 }
 
 /// A value of type T referred to by its absolute position
@@ -160,8 +147,7 @@ enum LazyState {
     NodeStart(NonZeroUsize),
 
     /// Inside a metadata node, with a previous `Lazy`.
-    /// The position is a conservative estimate of where that
-    /// previous `Lazy` would end (see their comments).
+    /// The position is where that previous `Lazy` would start.
     Previous(NonZeroUsize),
 }
 

--- a/compiler/rustc_metadata/src/rmeta/table.rs
+++ b/compiler/rustc_metadata/src/rmeta/table.rs
@@ -183,10 +183,6 @@ where
     Option<T>: FixedSizeEncoding,
 {
     type Meta = usize;
-
-    fn min_size(len: usize) -> usize {
-        len
-    }
 }
 
 impl<I: Idx, T> Lazy<Table<I, T>>


### PR DESCRIPTION
It is extremely conservative and as such barely reduces the size of encoded Lazy distances, but does increase complexity.