### PR TITLE
Ignore flaky `panic-short-backtrace-windows-x86_64.rs` test for now

### DIFF
--- a/src/test/ui/panics/panic-short-backtrace-windows-x86_64.rs
+++ b/src/test/ui/panics/panic-short-backtrace-windows-x86_64.rs
@@ -1,3 +1,7 @@
+// This test has been spuriously failing a lot recently (#92000).
+// Ignore it until the underlying issue is fixed.
+// ignore-test
+
 // Regression test for #87481: short backtrace formatting cut off the entire stack trace.
 
 // Codegen-units is specified here so that we can replicate a typical rustc invocation which


### PR DESCRIPTION
Mitigates (but does not fix) #92000.

It has been causing a lot of spurious test failures recently that slow
down the bors queue.