### PR TITLE
Switch `pc-windows-gnu` targets from GCC to Clang

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -366,25 +366,25 @@ jobs:
             env:
               RUST_CONFIGURE_ARGS: "--build=i686-pc-windows-gnu"
               SCRIPT: make ci-mingw-subset-1
-              CUSTOM_MINGW: 1
+              CUSTOM_MINGW: 0
             os: windows-latest-xl
           - name: i686-mingw-2
             env:
               RUST_CONFIGURE_ARGS: "--build=i686-pc-windows-gnu"
               SCRIPT: make ci-mingw-subset-2
-              CUSTOM_MINGW: 1
+              CUSTOM_MINGW: 0
             os: windows-latest-xl
           - name: x86_64-mingw-1
             env:
               SCRIPT: make ci-mingw-subset-1
               RUST_CONFIGURE_ARGS: "--build=x86_64-pc-windows-gnu --enable-profiler"
-              CUSTOM_MINGW: 1
+              CUSTOM_MINGW: 0
             os: windows-latest-xl
           - name: x86_64-mingw-2
             env:
               SCRIPT: make ci-mingw-subset-2
               RUST_CONFIGURE_ARGS: "--build=x86_64-pc-windows-gnu --enable-profiler"
-              CUSTOM_MINGW: 1
+              CUSTOM_MINGW: 0
             os: windows-latest-xl
           - name: dist-x86_64-msvc
             env:
@@ -409,14 +409,14 @@ jobs:
             env:
               RUST_CONFIGURE_ARGS: "--build=i686-pc-windows-gnu --enable-full-tools --enable-profiler"
               SCRIPT: python x.py dist
-              CUSTOM_MINGW: 1
+              CUSTOM_MINGW: 0
               DIST_REQUIRE_ALL_TOOLS: 1
             os: windows-latest-xl
           - name: dist-x86_64-mingw
             env:
               SCRIPT: python x.py dist
               RUST_CONFIGURE_ARGS: "--build=x86_64-pc-windows-gnu --enable-full-tools --enable-profiler"
-              CUSTOM_MINGW: 1
+              CUSTOM_MINGW: 0
               DIST_REQUIRE_ALL_TOOLS: 1
             os: windows-latest-xl
           - name: dist-x86_64-msvc-alt

--- a/compiler/rustc_target/src/spec/i686_pc_windows_gnu.rs
+++ b/compiler/rustc_target/src/spec/i686_pc_windows_gnu.rs
@@ -7,7 +7,7 @@ pub fn target() -> Target {
         .insert(LinkerFlavor::Lld(LldFlavor::Ld), vec!["-m".to_string(), "i386pe".to_string()]);
     base.max_atomic_width = Some(64);
     base.frame_pointer = FramePointer::Always; // Required for backtraces
-    base.linker = Some("i686-w64-mingw32-gcc".to_string());
+    base.linker = Some("i686-w64-mingw32-clang".to_string());
 
     // Mark all dynamic libraries and executables as compatible with the larger 4GiB address
     // space available to x86 Windows binaries on x86_64.

--- a/compiler/rustc_target/src/spec/x86_64_pc_windows_gnu.rs
+++ b/compiler/rustc_target/src/spec/x86_64_pc_windows_gnu.rs
@@ -10,7 +10,7 @@ pub fn target() -> Target {
     base.pre_link_args
         .insert(LinkerFlavor::Lld(LldFlavor::Ld), vec!["-m".to_string(), "i386pep".to_string()]);
     base.max_atomic_width = Some(64);
-    base.linker = Some("x86_64-w64-mingw32-gcc".to_string());
+    base.linker = Some("x86_64-w64-mingw32-clang".to_string());
 
     Target {
         llvm_target: "x86_64-pc-windows-gnu".to_string(),

--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -470,6 +470,15 @@ class RustBuild(object):
             with output(self.rustc_stamp(stage0)) as rust_stamp:
                 rust_stamp.write(key)
 
+            # FIXME remove this when the Clang Windows GNU toolchain has been published
+            if (os.environ.get('GCC_LIBS_HACK')):
+                gcc_libs_hack = os.environ.get('GCC_LIBS_HACK')
+                gcc_libs_hack_dest = '{}/rustlib/{}/lib'.format(lib_dir, self.build)
+                shutil.copy(gcc_libs_hack + '/libgcc.a', gcc_libs_hack_dest)
+                shutil.copy(gcc_libs_hack + '/libgcc_eh.a', gcc_libs_hack_dest)
+                shutil.copy(gcc_libs_hack + '/libgcc_s.a', gcc_libs_hack_dest)
+                shutil.copy(gcc_libs_hack + '/libstdc++.a', gcc_libs_hack_dest)
+
         if self.rustfmt() and self.rustfmt().startswith(bin_root) and (
             not os.path.exists(self.rustfmt())
             or self.program_out_of_date(

--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -160,31 +160,29 @@ fn make_win_dist(
     }
 
     let compiler = if target == "i686-pc-windows-gnu" {
-        "i686-w64-mingw32-gcc.exe"
+        "i686-w64-mingw32-clang.exe"
     } else if target == "x86_64-pc-windows-gnu" {
-        "x86_64-w64-mingw32-gcc.exe"
+        "x86_64-w64-mingw32-clang.exe"
+    } else if target == "aarch64-pc-windows-gnu" {
+        "aarch64-w64-mingw32-clang.exe"
     } else {
-        "gcc.exe"
+        "clang.exe"
     };
     let target_tools = [compiler, "ld.exe", "dlltool.exe", "libwinpthread-1.dll"];
     let mut rustc_dlls = vec!["libwinpthread-1.dll"];
-    if target.starts_with("i686-") {
-        rustc_dlls.push("libgcc_s_dw2-1.dll");
-    } else {
-        rustc_dlls.push("libgcc_s_seh-1.dll");
-    }
+
+    rustc_dlls.push("libunwind.dll");
+    rustc_dlls.push("libc++.dll");
 
     let target_libs = [
         //MinGW libs
-        "libgcc.a",
-        "libgcc_eh.a",
-        "libgcc_s.a",
+        "libunwind.a",
+        "libunwind.dll.a",
         "libm.a",
         "libmingw32.a",
         "libmingwex.a",
-        "libstdc++.a",
+        "libc++.a",
         "libiconv.a",
-        "libmoldname.a",
         "libpthread.a",
         //Windows import libs
         "libadvapi32.a",

--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -163,10 +163,10 @@ impl Step for Llvm {
             }
         };
 
-        let llvm_exp_targets = match builder.config.llvm_experimental_targets {
-            Some(ref s) => s,
-            None => "AVR;M68k",
-        };
+        //let llvm_exp_targets = match builder.config.llvm_experimental_targets {
+        //    Some(ref s) => s,
+        //    None => "AVR;M68k",
+        //};
 
         let assertions = if builder.config.llvm_assertions { "ON" } else { "OFF" };
         let plugins = if builder.config.llvm_plugins { "ON" } else { "OFF" };
@@ -177,7 +177,7 @@ impl Step for Llvm {
             .define("LLVM_ENABLE_ASSERTIONS", assertions)
             .define("LLVM_ENABLE_PLUGINS", plugins)
             .define("LLVM_TARGETS_TO_BUILD", llvm_targets)
-            .define("LLVM_EXPERIMENTAL_TARGETS_TO_BUILD", llvm_exp_targets)
+            // .define("LLVM_EXPERIMENTAL_TARGETS_TO_BUILD", llvm_exp_targets)
             .define("LLVM_INCLUDE_EXAMPLES", "OFF")
             .define("LLVM_INCLUDE_DOCS", "OFF")
             .define("LLVM_INCLUDE_BENCHMARKS", "OFF")

--- a/src/ci/github-actions/ci.yml
+++ b/src/ci/github-actions/ci.yml
@@ -577,28 +577,28 @@ jobs:
             env:
               RUST_CONFIGURE_ARGS: --build=i686-pc-windows-gnu
               SCRIPT: make ci-mingw-subset-1
-              CUSTOM_MINGW: 1
+              CUSTOM_MINGW: 0
             <<: *job-windows-xl
 
           - name: i686-mingw-2
             env:
               RUST_CONFIGURE_ARGS: --build=i686-pc-windows-gnu
               SCRIPT: make ci-mingw-subset-2
-              CUSTOM_MINGW: 1
+              CUSTOM_MINGW: 0
             <<: *job-windows-xl
 
           - name: x86_64-mingw-1
             env:
               SCRIPT: make ci-mingw-subset-1
               RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-gnu --enable-profiler
-              CUSTOM_MINGW: 1
+              CUSTOM_MINGW: 0
             <<: *job-windows-xl
 
           - name: x86_64-mingw-2
             env:
               SCRIPT: make ci-mingw-subset-2
               RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-gnu --enable-profiler
-              CUSTOM_MINGW: 1
+              CUSTOM_MINGW: 0
             <<: *job-windows-xl
 
           - name: dist-x86_64-msvc
@@ -644,7 +644,7 @@ jobs:
             env:
               RUST_CONFIGURE_ARGS: --build=i686-pc-windows-gnu --enable-full-tools --enable-profiler
               SCRIPT: python x.py dist
-              CUSTOM_MINGW: 1
+              CUSTOM_MINGW: 0
               DIST_REQUIRE_ALL_TOOLS: 1
             <<: *job-windows-xl
 
@@ -652,7 +652,7 @@ jobs:
             env:
               SCRIPT: python x.py dist
               RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-gnu --enable-full-tools --enable-profiler
-              CUSTOM_MINGW: 1
+              CUSTOM_MINGW: 0
               DIST_REQUIRE_ALL_TOOLS: 1
             <<: *job-windows-xl
 


### PR DESCRIPTION
My main goal is to add a new target for `aarch64-pc-windows-gnu`. However, [GCC doesn't support Windows arm64](https://www.msys2.org/docs/environments/#gcc-vs-llvmclang) so we'll first need to switch to Clang. Luckily, the MSYS2 team [has been providing `clang64` builds of Rust since a few months](https://packages.msys2.org/package/mingw-w64-clang-x86_64-rust?repo=clang64).

This PR changes the toolchain for `*-pc-windows-gnu` from GCC to Clang. This uses [the great work](https://github.com/msys2/MINGW-packages/blob/911622ebc606e15ae6a73dbecff93ea5b61bcd28/mingw-w64-rust/0007-clang-subsystem.patch) that the MSYS2 team has done to get Rust to build on Clang for Windows GNU targets.

The challenge is that the bootstrap compiler still uses GCC to build the target, so if I understand things correctly, we'll need to have a temporary situation in which things like `libgcc_eh.a` and `libgcc_s.a` are available until a new version of the `x86_64-pc-windows-gnu` toolchain has been published. Since those dependencies are not available in Clang, I applied [the same hacks that the MSYS2 team did](https://github.com/msys2/MINGW-packages/blob/911622ebc606e15ae6a73dbecff93ea5b61bcd28/mingw-w64-rust/0007-clang-subsystem.patch) to get things to work. I'll be more than happy to create a follow-up PR to get rid of those hacks once a new version of the CI/bootstrap compiler has been published.

I was able to build a full distribution locally with MSYS2 `clang64` - artifacts can be found here: https://github.com/dennisameling/rust/releases/tag/windows-gnu-clang