### PR TITLE
Exit nonzero on rustc -Wall

### DIFF
--- a/compiler/rustc_driver/src/lib.rs
+++ b/compiler/rustc_driver/src/lib.rs
@@ -1047,7 +1047,7 @@ pub fn handle_options(args: &[String]) -> Option<getopts::Matches> {
     let wall = matches.opt_strs("W");
     if wall.iter().any(|x| *x == "all") {
         print_wall_help();
-        return None;
+        rustc_errors::FatalError.raise();
     }
 
     // Don't handle -W help here, because we might first load plugins.


### PR DESCRIPTION
Previously `rustc -Wall /dev/null` would print a paragraph explaining that `-Wall` is not a thing in Rust, but would then exit 0. I believe exiting 0 is not the right behavior. For something like `rustc --version` or `rustc --help` or `rustc -C help` the user is requesting rustc to print some information; rustc prints that information and exits 0 because what the user requested has been accomplished. In the case of `rustc -Wall path/to/main.rs`, I don't find it correct to conceptualize this as "the user requested rustc to print information about the fact that Wall doesn't exist". The user requested a particular thing, and despite rustc knowing what they probably meant and informing them about that, the thing they requested has *not* been accomplished. Thus a nonzero exit code is needed.