### PR TITLE
Suggest single quotes when char expected, str provided

### DIFF
--- a/src/test/ui/inference/char-as-str-multi.rs
+++ b/src/test/ui/inference/char-as-str-multi.rs
@@ -1,0 +1,6 @@
+// When a MULTI-character string literal is used where a char should be,
+// DO NOT suggest changing to single quotes.
+
+fn main() {
+    let _: char = "foo"; //~ ERROR mismatched types
+}

--- a/src/test/ui/inference/char-as-str-multi.stderr
+++ b/src/test/ui/inference/char-as-str-multi.stderr
@@ -1,0 +1,11 @@
+error[E0308]: mismatched types
+  --> $DIR/char-as-str-multi.rs:5:19
+   |
+LL |     let _: char = "foo";
+   |            ----   ^^^^^ expected `char`, found `&str`
+   |            |
+   |            expected due to this
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/inference/char-as-str-single.fixed
+++ b/src/test/ui/inference/char-as-str-single.fixed
@@ -1,0 +1,11 @@
+// When a SINGLE-character string literal is used where a char should be,
+// suggest changing to single quotes.
+
+// Testing both single-byte and multi-byte characters, as we should handle both.
+
+// run-rustfix
+
+fn main() {
+    let _: char = 'a'; //~ ERROR mismatched types
+    let _: char = '人'; //~ ERROR mismatched types
+}

--- a/src/test/ui/inference/char-as-str-single.rs
+++ b/src/test/ui/inference/char-as-str-single.rs
@@ -1,0 +1,11 @@
+// When a SINGLE-character string literal is used where a char should be,
+// suggest changing to single quotes.
+
+// Testing both single-byte and multi-byte characters, as we should handle both.
+
+// run-rustfix
+
+fn main() {
+    let _: char = "a"; //~ ERROR mismatched types
+    let _: char = "人"; //~ ERROR mismatched types
+}

--- a/src/test/ui/inference/char-as-str-single.stderr
+++ b/src/test/ui/inference/char-as-str-single.stderr
@@ -1,0 +1,29 @@
+error[E0308]: mismatched types
+  --> $DIR/char-as-str-single.rs:9:19
+   |
+LL |     let _: char = "a";
+   |            ----   ^^^ expected `char`, found `&str`
+   |            |
+   |            expected due to this
+   |
+help: if you meant to write a `char` literal, use single quotes
+   |
+LL |     let _: char = 'a';
+   |                   ~~~
+
+error[E0308]: mismatched types
+  --> $DIR/char-as-str-single.rs:10:19
+   |
+LL |     let _: char = "人";
+   |            ----   ^^^^ expected `char`, found `&str`
+   |            |
+   |            expected due to this
+   |
+help: if you meant to write a `char` literal, use single quotes
+   |
+LL |     let _: char = '人';
+   |                   ~~~~
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/inference/str-as-char.fixed
+++ b/src/test/ui/inference/str-as-char.fixed
@@ -1,0 +1,8 @@
+// When a char literal is used where a str should be,
+// suggest changing to double quotes.
+
+// run-rustfix
+
+fn main() {
+    let _: &str = "a"; //~ ERROR mismatched types
+}

--- a/src/test/ui/inference/str-as-char.rs
+++ b/src/test/ui/inference/str-as-char.rs
@@ -1,0 +1,8 @@
+// When a char literal is used where a str should be,
+// suggest changing to double quotes.
+
+// run-rustfix
+
+fn main() {
+    let _: &str = 'a'; //~ ERROR mismatched types
+}

--- a/src/test/ui/inference/str-as-char.stderr
+++ b/src/test/ui/inference/str-as-char.stderr
@@ -1,0 +1,16 @@
+error[E0308]: mismatched types
+  --> $DIR/str-as-char.rs:7:19
+   |
+LL |     let _: &str = 'a';
+   |            ----   ^^^ expected `&str`, found `char`
+   |            |
+   |            expected due to this
+   |
+help: if you meant to write a `str` literal, use double quotes
+   |
+LL |     let _: &str = "a";
+   |                   ~~~
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/issues/issue-23589.stderr
+++ b/src/test/ui/issues/issue-23589.stderr
@@ -12,6 +12,11 @@ error[E0308]: mismatched types
    |
 LL |     let v: Vec(&str) = vec!['1', '2'];
    |                             ^^^ expected `&str`, found `char`
+   |
+help: if you meant to write a `str` literal, use double quotes
+   |
+LL |     let v: Vec(&str) = vec!["1", '2'];
+   |                             ~~~
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION
If a type mismatch occurs where a char is expected and a string literal is provided, suggest changing the double quotes to single quotes.

We already provide this suggestion in the other direction ( ' -> " ).

Especially useful for new rust devs used to a language in which single/double quotes are interchangeable.

Fixes #92479.