### PR TITLE
Refine scopes around temporaries generated in local accesses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4134,6 +4134,7 @@ dependencies = [
  "rustc_session",
  "rustc_span",
  "rustc_target",
+ "smallvec",
  "tracing",
 ]
 

--- a/compiler/rustc_middle/src/middle/region.rs
+++ b/compiler/rustc_middle/src/middle/region.rs
@@ -368,7 +368,10 @@ impl ScopeTree {
     }
 
     pub fn record_local_access_scope(&mut self, var: hir::ItemLocalId, proposed_lifetime: Scope) {
-        debug!("record_local_access_scope(sub={:?}, sup={:?})", var, proposed_lifetime);
+        debug!(
+            "record_local_access_scope(var={:?}, proposed_lifetime={:?})",
+            var, proposed_lifetime
+        );
         let mut id = Scope { id: var, data: ScopeData::Node };
 
         while let Some(&(p, _)) = self.parent_map.get(&id) {
@@ -385,6 +388,7 @@ impl ScopeTree {
     }
 
     pub fn record_eager_scope(&mut self, var: hir::ItemLocalId, proposed_lifetime: Scope) {
+        debug!("record_eager_scope(var={:?}, proposed_lifetime={:?})", var, proposed_lifetime);
         if let Some(destruction) = self.temporary_scope(var) {
             if self.is_subscope_of(destruction, proposed_lifetime) {
                 // If the current temporary scope is already a subset of the proposed region,

--- a/compiler/rustc_passes/Cargo.toml
+++ b/compiler/rustc_passes/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 tracing = "0.1"
+smallvec = { version = "1.6.1", features = ["union", "may_dangle"] }
 rustc_middle = { path = "../rustc_middle" }
 rustc_attr = { path = "../rustc_attr" }
 rustc_data_structures = { path = "../rustc_data_structures" }

--- a/compiler/rustc_passes/src/region.rs
+++ b/compiler/rustc_passes/src/region.rs
@@ -278,10 +278,6 @@ fn mark_local_terminating_scopes<'tcx>(expr: &'tcx hir::Expr<'tcx>) -> FxHashSet
         }
     }
     impl<'a, 'b> Visitor<'a> for LocalAccessResolutionVisitor<'b> {
-        type Map = intravisit::ErasedMap<'a>;
-        fn nested_visit_map(&mut self) -> NestedVisitorMap<Self::Map> {
-            NestedVisitorMap::None
-        }
         fn visit_expr(&mut self, expr: &'a Expr<'a>) {
             match expr.kind {
                 hir::ExprKind::AddrOf(..)
@@ -290,7 +286,8 @@ fn mark_local_terminating_scopes<'tcx>(expr: &'tcx hir::Expr<'tcx>) -> FxHashSet
                 | hir::ExprKind::Index(..)
                 | hir::ExprKind::Path(..) => self.probe(expr),
 
-                // We do not probe into other function bodies or blocks.
+                // We do not probe into other function bodies or blocks,
+                // neither `if`s and `match`es because they will be covered in deeper visits
                 hir::ExprKind::If(..)
                 | hir::ExprKind::Match(..)
                 | hir::ExprKind::Block(..)

--- a/compiler/rustc_passes/src/region.rs
+++ b/compiler/rustc_passes/src/region.rs
@@ -244,14 +244,9 @@ fn mark_local_terminating_scopes<'tcx>(expr: &'tcx hir::Expr<'tcx>) -> FxHashSet
                         ops.push((nested_expr, OpTy::Deref));
                         nested_expr = subexpr;
                     }
-                    hir::ExprKind::Field(subexpr, _) => {
+                    hir::ExprKind::Field(subexpr, _) | hir::ExprKind::Index(subexpr, _) => {
                         ops.push((nested_expr, OpTy::Project));
                         nested_expr = subexpr;
-                    }
-                    hir::ExprKind::Index(subexpr, idxexpr) => {
-                        ops.push((nested_expr, OpTy::Project));
-                        nested_expr = subexpr;
-                        intravisit::walk_expr(self, idxexpr);
                     }
                     _ => {
                         drop(ops);
@@ -296,7 +291,9 @@ fn mark_local_terminating_scopes<'tcx>(expr: &'tcx hir::Expr<'tcx>) -> FxHashSet
                 | hir::ExprKind::Path(..) => self.probe(expr),
 
                 // We do not probe into other function bodies or blocks.
-                hir::ExprKind::Block(..)
+                hir::ExprKind::If(..)
+                | hir::ExprKind::Match(..)
+                | hir::ExprKind::Block(..)
                 | hir::ExprKind::Closure(..)
                 | hir::ExprKind::ConstBlock(..) => {}
                 _ => intravisit::walk_expr(self, expr),

--- a/src/test/mir-opt/remove_storage_markers.main.RemoveStorageMarkers.diff
+++ b/src/test/mir-opt/remove_storage_markers.main.RemoveStorageMarkers.diff
@@ -71,7 +71,6 @@
 -         StorageDead(_13);                // scope 3 at $DIR/remove_storage_markers.rs:9:16: 9:17
           _6 = const ();                   // scope 3 at $DIR/remove_storage_markers.rs:8:20: 10:6
 -         StorageDead(_12);                // scope 2 at $DIR/remove_storage_markers.rs:10:5: 10:6
--         StorageDead(_9);                 // scope 2 at $DIR/remove_storage_markers.rs:10:5: 10:6
 -         StorageDead(_7);                 // scope 2 at $DIR/remove_storage_markers.rs:10:5: 10:6
 -         StorageDead(_6);                 // scope 2 at $DIR/remove_storage_markers.rs:10:5: 10:6
           _5 = const ();                   // scope 2 at $DIR/remove_storage_markers.rs:8:5: 10:6
@@ -80,7 +79,6 @@
   
       bb3: {
           _0 = const ();                   // scope 2 at $DIR/remove_storage_markers.rs:8:5: 10:6
--         StorageDead(_9);                 // scope 2 at $DIR/remove_storage_markers.rs:10:5: 10:6
 -         StorageDead(_7);                 // scope 2 at $DIR/remove_storage_markers.rs:10:5: 10:6
 -         StorageDead(_6);                 // scope 2 at $DIR/remove_storage_markers.rs:10:5: 10:6
 -         StorageDead(_4);                 // scope 1 at $DIR/remove_storage_markers.rs:10:5: 10:6
@@ -91,6 +89,7 @@
   
       bb4: {
 -         StorageDead(_14);                // scope 5 at $DIR/remove_storage_markers.rs:8:14: 8:19
+-         StorageDead(_9);                 // scope 2 at $DIR/remove_storage_markers.rs:8:18: 8:19
 -         StorageDead(_8);                 // scope 2 at $DIR/remove_storage_markers.rs:8:18: 8:19
           _10 = discriminant(_7);          // scope 2 at $DIR/remove_storage_markers.rs:8:14: 8:19
           switchInt(move _10) -> [0_isize: bb3, otherwise: bb2]; // scope 2 at $DIR/remove_storage_markers.rs:8:14: 8:19

--- a/src/test/ui/async-await/issue-64130-4-async-move.rs
+++ b/src/test/ui/async-await/issue-64130-4-async-move.rs
@@ -13,8 +13,8 @@ impl Client {
 async fn get() {}
 
 pub fn foo() -> impl Future + Send {
+    //~^ ERROR future cannot be sent between threads safely
     async {
-        //~^ ERROR future cannot be sent between threads safely
         match Client(Box::new(true)).status() {
             200 => {
                 let _x = get().await;

--- a/src/test/ui/async-await/issue-64130-4-async-move.rs
+++ b/src/test/ui/async-await/issue-64130-4-async-move.rs
@@ -10,16 +10,15 @@ impl Client {
     }
 }
 
-async fn get() { }
+async fn get() {}
 
 pub fn foo() -> impl Future + Send {
-    //~^ ERROR future cannot be sent between threads safely
-    let client = Client(Box::new(true));
-    async move {
-        match client.status() {
+    async {
+        //~^ ERROR future cannot be sent between threads safely
+        match Client(Box::new(true)).status() {
             200 => {
                 let _x = get().await;
-            },
+            }
             _ => (),
         }
     }

--- a/src/test/ui/async-await/issue-64130-4-async-move.stderr
+++ b/src/test/ui/async-await/issue-64130-4-async-move.stderr
@@ -6,21 +6,21 @@ LL | pub fn foo() -> impl Future + Send {
    |
    = help: the trait `Sync` is not implemented for `(dyn Any + Send + 'static)`
 note: future is not `Send` as this value is used across an await
-  --> $DIR/issue-64130-4-async-move.rs:21:31
+  --> $DIR/issue-64130-4-async-move.rs:20:31
    |
-LL |         match client.status() {
-   |               ------ has type `&Client` which is not `Send`
+LL |         match Client(Box::new(true)).status() {
+   |               ---------------------- has type `&Client` which is not `Send`
 LL |             200 => {
 LL |                 let _x = get().await;
-   |                               ^^^^^^ await occurs here, with `client` maybe used later
+   |                               ^^^^^^ await occurs here, with `Client(Box::new(true))` maybe used later
 ...
 LL |     }
-   |     - `client` is later dropped here
+   |     - `Client(Box::new(true))` is later dropped here
 help: consider moving this into a `let` binding to create a shorter lived borrow
-  --> $DIR/issue-64130-4-async-move.rs:19:15
+  --> $DIR/issue-64130-4-async-move.rs:18:15
    |
-LL |         match client.status() {
-   |               ^^^^^^^^^^^^^^^
+LL |         match Client(Box::new(true)).status() {
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/async-await/issue-69663-lingering-local-borrows.rs
+++ b/src/test/ui/async-await/issue-69663-lingering-local-borrows.rs
@@ -1,0 +1,51 @@
+// edition:2018
+// run-pass
+
+use std::ops::Index;
+
+/// A `Send + !Sync` for demonstration purposes.
+struct Banana(*mut ());
+unsafe impl Send for Banana {}
+
+impl Banana {
+    /// Make a static mutable reference to Banana for convenience purposes.
+    ///
+    /// Any potential unsoundness here is not super relevant to the issue at hand.
+    fn new() -> &'static mut Banana {
+        static mut BANANA: Banana = Banana(std::ptr::null_mut());
+        unsafe { &mut BANANA }
+    }
+}
+
+// Peach is still Send (because `impl Send for &mut T where T: Send`)
+struct Peach<'a>(&'a mut Banana);
+
+impl<'a> std::ops::Index<usize> for Peach<'a> {
+    type Output = ();
+    fn index(&self, _: usize) -> &() {
+        &()
+    }
+}
+
+async fn baz(_: &()) {}
+
+async fn bar() {
+    let peach = Peach(Banana::new());
+    let r = &*peach.index(0);
+    baz(r).await;
+    peach.index(0); // make sure peach is retained across yield point
+}
+
+async fn bat() {
+    let peach = Peach(Banana::new());
+    let r = &peach[0];
+    baz(r).await;
+    peach[0]; // make sure peach is retained across yield point
+}
+
+fn assert_send<T: Send>(_: T) {}
+
+pub fn main() {
+    assert_send(bar());
+    assert_send(bat());
+}

--- a/src/test/ui/async-await/issue-69663-lingering-local-borrows.rs
+++ b/src/test/ui/async-await/issue-69663-lingering-local-borrows.rs
@@ -1,5 +1,5 @@
 // edition:2018
-// run-pass
+// build-pass
 
 use std::ops::Index;
 

--- a/src/test/ui/generator/refined-region-for-local-accesses.rs
+++ b/src/test/ui/generator/refined-region-for-local-accesses.rs
@@ -7,6 +7,10 @@ fn assert_send<T: Send>(_: T) {}
 struct Client;
 
 impl Client {
+    fn zero(&self) -> usize {
+        0
+    }
+
     fn status(&self) -> i16 {
         200
     }
@@ -25,6 +29,10 @@ fn main() {
             _ => yield,
         }
         match (&*&x).status() {
+            _ => yield,
+        }
+        let a = [0];
+        match a[Client.zero()] {
             _ => yield,
         }
     };

--- a/src/test/ui/generator/refined-region-for-local-accesses.rs
+++ b/src/test/ui/generator/refined-region-for-local-accesses.rs
@@ -1,5 +1,5 @@
 // edition:2018
-// run-pass
+// build-pass
 #![feature(generators, generator_trait, negative_impls)]
 
 fn assert_send<T: Send>(_: T) {}

--- a/src/test/ui/generator/refined-region-for-local-accesses.rs
+++ b/src/test/ui/generator/refined-region-for-local-accesses.rs
@@ -1,0 +1,32 @@
+// edition:2018
+// run-pass
+#![feature(generators, generator_trait, negative_impls)]
+
+fn assert_send<T: Send>(_: T) {}
+
+struct Client;
+
+impl Client {
+    fn status(&self) -> i16 {
+        200
+    }
+}
+
+impl !Sync for Client {}
+
+fn status(_: &Client) -> i16 {
+    200
+}
+
+fn main() {
+    let g = || {
+        let x = Client;
+        match status(&x) {
+            _ => yield,
+        }
+        match (&*&x).status() {
+            _ => yield,
+        }
+    };
+    assert_send(g);
+}


### PR DESCRIPTION
Fix #57017
Fix #72956

Related to #69663

Sorry for the long sabbatical. This PR takes inspiration from the [comments](https://github.com/rust-lang/rust/issues/72956#issuecomment-948271239) by @pnkfelix and further extends the idea to at least allow refined scopes for temporaries generated while evaluating expressions like `x.status()`.  In details, expressions like `x.status()` generates temporaries for place or place references to a local variable `x`, but they could be discarded at an earlier opportunity. What is left to improve the region analysis in a generator body is to identify regions where we can restrict those temporaries. They are tentatively set to `if` and `match` sub-expressions.

I have come to a rather late realization that #91032 could be solving the related problems in a more comprehensive setting. However, I would like to gather some feedback and join the relevant discussion with this opportunity.