### PR TITLE
Don't resolve blocks in foreign functions

### DIFF
--- a/src/test/ui/foreign/issue-91370-foreign-fn-block-impl.rs
+++ b/src/test/ui/foreign/issue-91370-foreign-fn-block-impl.rs
@@ -1,0 +1,12 @@
+// Regression test for issue #91370.
+
+extern {
+    //~^ `extern` blocks define existing foreign functions
+    fn f() {
+        //~^ incorrect function inside `extern` block
+        //~| cannot have a body
+        impl Copy for u8 {}
+    }
+}
+
+fn main() {}

--- a/src/test/ui/foreign/issue-91370-foreign-fn-block-impl.stderr
+++ b/src/test/ui/foreign/issue-91370-foreign-fn-block-impl.stderr
@@ -1,0 +1,21 @@
+error: incorrect function inside `extern` block
+  --> $DIR/issue-91370-foreign-fn-block-impl.rs:5:8
+   |
+LL |   extern {
+   |   ------ `extern` blocks define existing foreign functions and functions inside of them cannot have a body
+LL |
+LL |       fn f() {
+   |  ________^___-
+   | |        |
+   | |        cannot have a body
+LL | |
+LL | |
+LL | |         impl Copy for u8 {}
+LL | |     }
+   | |_____- help: remove the invalid body: `;`
+   |
+   = help: you might have meant to write a function accessible through FFI, which can be done by writing `extern fn` outside of the `extern` block
+   = note: for more information, visit https://doc.rust-lang.org/std/keyword.extern.html
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Although it is an error for a foreign function to have a block, it is still possible at the level of the AST. #74204 made AST lowering skip over blocks belonging to foreign functions, since they're invalid. However, resolve still treated these blocks normally, resulting in a mismatch between the HIR and resolve, which could cause an ICE under certain circumstances. This PR changes resolve to skip over blocks belonging to foreign functions, as AST lowering does.

Fixes #91370.

r? @cjgillot