### PR TITLE
Rustdoc: reduce size of `Clean` types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3800,6 +3800,7 @@ dependencies = [
  "stable_deref_trait",
  "stacker",
  "tempfile",
+ "thin-slice",
  "tracing",
  "winapi",
 ]
@@ -5246,6 +5247,12 @@ checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
 ]
+
+[[package]]
+name = "thin-slice"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eaa81235c7058867fa8c0e7314f33dcce9c215f535d1913822a2b3f5e289f3c"
 
 [[package]]
 name = "thiserror"

--- a/compiler/rustc_data_structures/Cargo.toml
+++ b/compiler/rustc_data_structures/Cargo.toml
@@ -27,6 +27,7 @@ measureme = "10.0.0"
 libc = "0.2"
 stacker = "0.1.14"
 tempfile = "3.2"
+thin-slice = "0.1.1"
 
 [dependencies.parking_lot]
 version = "0.11"

--- a/compiler/rustc_data_structures/src/lib.rs
+++ b/compiler/rustc_data_structures/src/lib.rs
@@ -103,6 +103,7 @@ pub mod steal;
 pub mod tagged_ptr;
 pub mod temp_dir;
 pub mod unhash;
+pub mod thin_slice;
 
 pub use ena::undo_log;
 pub use ena::unify;

--- a/compiler/rustc_data_structures/src/thin_slice.rs
+++ b/compiler/rustc_data_structures/src/thin_slice.rs
@@ -1,0 +1,51 @@
+use std::ops::{Deref, DerefMut};
+
+#[derive(Clone, Debug, Hash, Eq, PartialEq)]
+pub struct ThinSlice<T> {
+    slice: Box<[T]>,
+}
+
+impl<T> ThinSlice<T> {
+    pub fn into_vec(self) -> Vec<T> {
+        self.into()
+    }
+}
+
+impl<T> Default for ThinSlice<T> {
+    fn default() -> Self {
+        Self { slice: Default::default() }
+    }
+}
+
+impl<T> From<Vec<T>> for ThinSlice<T> {
+    fn from(vec: Vec<T>) -> Self {
+        Self { slice: vec.into_boxed_slice() }
+    }
+}
+
+impl<T> From<ThinSlice<T>> for Vec<T> {
+    fn from(slice: ThinSlice<T>) -> Self {
+        slice.slice.into_vec()
+    }
+}
+
+impl<T> FromIterator<T> for ThinSlice<T> {
+    fn from_iter<I: IntoIterator<Item=T>>(iter: I) -> Self {
+        let vec: Vec<T> = iter.into_iter().collect();
+        vec.into()
+    }
+}
+
+impl<T> Deref for ThinSlice<T> {
+    type Target = [T];
+
+    fn deref(&self) -> &Self::Target {
+        self.slice.deref()
+    }
+}
+
+impl<T> DerefMut for ThinSlice<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.slice.deref_mut()
+    }
+}

--- a/compiler/rustc_data_structures/src/thin_slice.rs
+++ b/compiler/rustc_data_structures/src/thin_slice.rs
@@ -19,7 +19,7 @@ impl<T> Default for ThinSlice<T> {
 
 impl<T> From<Vec<T>> for ThinSlice<T> {
     fn from(vec: Vec<T>) -> Self {
-        Self { slice: vec.into_boxed_slice() }
+        Self { slice: vec.into_boxed_slice2() }
     }
 }
 

--- a/compiler/rustc_data_structures/src/thin_slice.rs
+++ b/compiler/rustc_data_structures/src/thin_slice.rs
@@ -1,8 +1,9 @@
 use std::ops::{Deref, DerefMut};
+use thin_slice::ThinBoxedSlice;
 
 #[derive(Clone, Debug, Hash, Eq, PartialEq)]
 pub struct ThinSlice<T> {
-    slice: Box<[T]>,
+    slice: ThinBoxedSlice<T>,
 }
 
 impl<T> ThinSlice<T> {
@@ -19,13 +20,14 @@ impl<T> Default for ThinSlice<T> {
 
 impl<T> From<Vec<T>> for ThinSlice<T> {
     fn from(vec: Vec<T>) -> Self {
-        Self { slice: vec.into_boxed_slice2() }
+        Self { slice: vec.into_boxed_slice2().into() }
     }
 }
 
 impl<T> From<ThinSlice<T>> for Vec<T> {
     fn from(slice: ThinSlice<T>) -> Self {
-        slice.slice.into_vec()
+        let boxed: Box<[T]> = slice.slice.into();
+        boxed.into_vec()
     }
 }
 

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -1002,6 +1002,18 @@ impl<T, A: Allocator> Vec<T, A> {
         }
     }
 
+    /// WIP
+    #[cfg(not(no_global_oom_handling))]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub fn into_boxed_slice2(self) -> Box<[T], A> {
+        unsafe {
+            let me = ManuallyDrop::new(self);
+            let buf = ptr::read(&me.buf);
+            let len = me.len();
+            buf.into_box(len).assume_init()
+        }
+    }
+
     /// Shortens the vector, keeping the first `len` elements and dropping
     /// the rest.
     ///

--- a/src/librustdoc/clean/blanket_impl.rs
+++ b/src/librustdoc/clean/blanket_impl.rs
@@ -123,7 +123,7 @@ impl<'a, 'tcx> BlanketImplFinder<'a, 'tcx> {
                             .associated_items(impl_def_id)
                             .in_definition_order()
                             .map(|x| x.clean(self.cx))
-                            .collect::<Vec<_>>(),
+                            .collect(),
                         polarity: ty::ImplPolarity::Positive,
                         kind: ImplKind::Blanket(box trait_ref.self_ty().clean(self.cx)),
                     }),

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -216,7 +216,7 @@ crate fn build_external_trait(cx: &mut DocContext<'_>, did: DefId) -> clean::Tra
         unsafety: cx.tcx.trait_def(did).unsafety,
         generics,
         items: trait_items,
-        bounds: supertrait_bounds,
+        bounds: supertrait_bounds.into(),
         is_auto,
     }
 }
@@ -496,7 +496,7 @@ crate fn build_impl(
             generics,
             trait_,
             for_,
-            items: trait_items,
+            items: trait_items.into(),
             polarity,
             kind: ImplKind::Normal,
         }),
@@ -540,10 +540,10 @@ fn build_module(
                                 segments: vec![clean::PathSegment {
                                     name: prim_ty.as_sym(),
                                     args: clean::GenericArgs::AngleBracketed {
-                                        args: Vec::new(),
+                                        args: Default::default(),
                                         bindings: ThinVec::new(),
                                     },
-                                }],
+                                }].into(),
                             },
                             did: None,
                         },
@@ -604,7 +604,7 @@ fn build_macro(
         }
         LoadedMacro::ProcMacro(ext) => clean::ProcMacroItem(clean::ProcMacro {
             kind: ext.macro_kind(),
-            helpers: ext.helper_attrs,
+            helpers: ext.helper_attrs.into(),
         }),
     }
 }

--- a/src/librustdoc/clean/simplify.rs
+++ b/src/librustdoc/clean/simplify.rs
@@ -37,7 +37,7 @@ crate fn where_clauses(cx: &DocContext<'_>, clauses: Vec<WP>) -> Vec<WP> {
                 clean::Generic(s) => {
                     let (b, p) = params.entry(s).or_default();
                     b.extend(bounds);
-                    p.extend(bound_params);
+                    p.extend(bound_params.into_vec());
                 }
                 t => tybounds.push((t, (bounds, bound_params))),
             },
@@ -76,7 +76,7 @@ crate fn where_clauses(cx: &DocContext<'_>, clauses: Vec<WP>) -> Vec<WP> {
     clauses.extend(params.into_iter().map(|(k, (bounds, params))| WP::BoundPredicate {
         ty: clean::Generic(k),
         bounds,
-        bound_params: params,
+        bound_params: params.into(),
     }));
     clauses.extend(tybounds.into_iter().map(|(ty, (bounds, bound_params))| WP::BoundPredicate {
         ty,

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -1226,7 +1226,7 @@ impl WherePredicate {
 }
 
 #[cfg(all(target_arch = "x86_64", target_pointer_width = "64"))]
-rustc_data_structures::static_assert_size!(WherePredicate, 136);
+rustc_data_structures::static_assert_size!(WherePredicate, 120);
 
 #[derive(Clone, PartialEq, Eq, Debug, Hash)]
 crate enum GenericParamDefKind {
@@ -1383,7 +1383,7 @@ crate struct Trait {
 }
 
 #[cfg(all(target_arch = "x86_64", target_pointer_width = "64"))]
-rustc_data_structures::static_assert_size!(Trait, 88);
+rustc_data_structures::static_assert_size!(Trait, 72);
 
 #[derive(Clone, Debug)]
 crate struct TraitAlias {
@@ -1392,7 +1392,7 @@ crate struct TraitAlias {
 }
 
 #[cfg(all(target_arch = "x86_64", target_pointer_width = "64"))]
-rustc_data_structures::static_assert_size!(TraitAlias, 64);
+rustc_data_structures::static_assert_size!(TraitAlias, 56);
 
 /// A trait reference, which may have higher ranked lifetimes.
 #[derive(Clone, PartialEq, Eq, Debug, Hash)]
@@ -1402,7 +1402,7 @@ crate struct PolyTrait {
 }
 
 #[cfg(all(target_arch = "x86_64", target_pointer_width = "64"))]
-rustc_data_structures::static_assert_size!(PolyTrait, 56);
+rustc_data_structures::static_assert_size!(PolyTrait, 40);
 
 /// Rustdoc's representation of types, mostly based on the [`hir::Ty`].
 #[derive(Clone, PartialEq, Eq, Debug, Hash)]
@@ -1453,7 +1453,7 @@ crate enum Type {
 
 // `Type` is used a lot. Make sure it doesn't unintentionally get bigger.
 #[cfg(all(target_arch = "x86_64", target_pointer_width = "64"))]
-rustc_data_structures::static_assert_size!(Type, 64);
+rustc_data_structures::static_assert_size!(Type, 56);
 
 impl Type {
     /// When comparing types for equality, it can help to ignore `&` wrapping.
@@ -1923,7 +1923,7 @@ crate struct Struct {
 }
 
 #[cfg(all(target_arch = "x86_64", target_pointer_width = "64"))]
-rustc_data_structures::static_assert_size!(Struct, 72);
+rustc_data_structures::static_assert_size!(Struct, 64);
 
 #[derive(Clone, Debug)]
 crate struct Union {
@@ -1933,7 +1933,7 @@ crate struct Union {
 }
 
 #[cfg(all(target_arch = "x86_64", target_pointer_width = "64"))]
-rustc_data_structures::static_assert_size!(Union, 72);
+rustc_data_structures::static_assert_size!(Union, 64);
 
 /// This is a more limited form of the standard Struct, different in that
 /// it lacks the things most items have (name, id, parameterization). Found
@@ -1946,7 +1946,7 @@ crate struct VariantStruct {
 }
 
 #[cfg(all(target_arch = "x86_64", target_pointer_width = "64"))]
-rustc_data_structures::static_assert_size!(VariantStruct, 24);
+rustc_data_structures::static_assert_size!(VariantStruct, 16);
 
 #[derive(Clone, Debug)]
 crate struct Enum {
@@ -1963,7 +1963,7 @@ crate enum Variant {
 }
 
 #[cfg(all(target_arch = "x86_64", target_pointer_width = "64"))]
-rustc_data_structures::static_assert_size!(Variant, 32);
+rustc_data_structures::static_assert_size!(Variant, 24);
 
 /// Small wrapper around [`rustc_span::Span`] that adds helper methods
 /// and enforces calling [`rustc_span::Span::source_callsite()`].
@@ -2081,7 +2081,7 @@ crate enum GenericArg {
 // `GenericArg` can occur many times in a single `Path`, so make sure it
 // doesn't increase in size unexpectedly.
 #[cfg(all(target_arch = "x86_64", target_pointer_width = "64"))]
-rustc_data_structures::static_assert_size!(GenericArg, 72);
+rustc_data_structures::static_assert_size!(GenericArg, 64);
 
 #[derive(Clone, PartialEq, Eq, Debug, Hash)]
 crate enum GenericArgs {
@@ -2092,7 +2092,7 @@ crate enum GenericArgs {
 // `GenericArgs` is in every `PathSegment`, so its size can significantly
 // affect rustdoc's memory usage.
 #[cfg(all(target_arch = "x86_64", target_pointer_width = "64"))]
-rustc_data_structures::static_assert_size!(GenericArgs, 32);
+rustc_data_structures::static_assert_size!(GenericArgs, 24);
 
 #[derive(Clone, PartialEq, Eq, Debug, Hash)]
 crate struct PathSegment {
@@ -2103,7 +2103,7 @@ crate struct PathSegment {
 // `PathSegment` usually occurs multiple times in every `Path`, so its size can
 // significantly affect rustdoc's memory usage.
 #[cfg(all(target_arch = "x86_64", target_pointer_width = "64"))]
-rustc_data_structures::static_assert_size!(PathSegment, 40);
+rustc_data_structures::static_assert_size!(PathSegment, 32);
 
 #[derive(Clone, Debug)]
 crate struct Typedef {

--- a/src/librustdoc/clean/utils.rs
+++ b/src/librustdoc/clean/utils.rs
@@ -109,7 +109,7 @@ fn external_generic_args(
     if cx.tcx.fn_trait_kind_from_lang_item(did).is_some() {
         let inputs = match ty_kind.unwrap() {
             ty::Tuple(tys) => tys.iter().map(|t| t.expect_ty().clean(cx)).collect(),
-            _ => return GenericArgs::AngleBracketed { args, bindings: bindings.into() },
+            _ => return GenericArgs::AngleBracketed { args: args.into(), bindings: bindings.into() },
         };
         let output = None;
         // FIXME(#20299) return type comes from a projection now
@@ -119,7 +119,7 @@ fn external_generic_args(
         // };
         GenericArgs::Parenthesized { inputs, output }
     } else {
-        GenericArgs::AngleBracketed { args, bindings: bindings.into() }
+        GenericArgs::AngleBracketed { args: args.into(), bindings: bindings.into() }
     }
 }
 
@@ -137,14 +137,14 @@ pub(super) fn external_path(
         segments: vec![PathSegment {
             name,
             args: external_generic_args(cx, did, has_self, bindings, substs),
-        }],
+        }].into(),
     }
 }
 
 /// Remove the generic arguments from a path.
 crate fn strip_path_generics(mut path: Path) -> Path {
     for ps in path.segments.iter_mut() {
-        ps.args = GenericArgs::AngleBracketed { args: vec![], bindings: ThinVec::new() }
+        ps.args = GenericArgs::AngleBracketed { args: Default::default(), bindings: ThinVec::new() }
     }
 
     path

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -432,7 +432,7 @@ impl clean::GenericArgs {
                             f.write_str("&lt;")?;
                         }
                         let mut comma = false;
-                        for arg in args {
+                        for arg in args.iter() {
                             if comma {
                                 f.write_str(", ")?;
                             }
@@ -464,7 +464,7 @@ impl clean::GenericArgs {
                 clean::GenericArgs::Parenthesized { inputs, output } => {
                     f.write_str("(")?;
                     let mut comma = false;
-                    for ty in inputs {
+                    for ty in inputs.iter() {
                         if comma {
                             f.write_str(", ")?;
                         }

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -1266,7 +1266,7 @@ fn notable_traits_decl(decl: &clean::FnDecl, cx: &Context<'_>) -> String {
                             "<span class=\"where fmt-newline\">{}</span>",
                             impl_.print(false, cx)
                         );
-                        for it in &impl_.items {
+                        for it in impl_.items.iter() {
                             if let clean::TypedefItem(ref tydef, _) = *it.kind {
                                 out.push_str("<span class=\"where fmt-newline\">    ");
                                 let empty_set = FxHashSet::default();
@@ -1515,7 +1515,7 @@ fn render_impl(
     let mut impl_items = Buffer::empty_from(w);
     let mut default_impl_items = Buffer::empty_from(w);
 
-    for trait_item in &i.inner_impl().items {
+    for trait_item in i.inner_impl().items.iter() {
         doc_impl_item(
             &mut default_impl_items,
             &mut impl_items,
@@ -1542,7 +1542,7 @@ fn render_impl(
         render_mode: RenderMode,
         rendering_params: ImplRenderingParameters,
     ) {
-        for trait_item in &t.items {
+        for trait_item in t.items.iter() {
             let n = trait_item.name;
             if i.items.iter().any(|m| m.name == n) {
                 continue;
@@ -1706,7 +1706,7 @@ pub(crate) fn render_impl_summary(
     if let Some(use_absolute) = use_absolute {
         write!(w, "{}", i.inner_impl().print(use_absolute, cx));
         if show_def_docs {
-            for it in &i.inner_impl().items {
+            for it in i.inner_impl().items.iter() {
                 if let clean::TypedefItem(ref tydef, _) = *it.kind {
                     w.write_str("<span class=\"where fmt-newline\">  ");
                     assoc_type(w, it, &[], Some(&tydef.type_), AssocItemLink::Anchor(None), "", cx);

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -1146,7 +1146,7 @@ fn item_enum(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, e: &clean::Enum
                 write!(w, "<div class=\"sub-variant\" id=\"{id}\">", id = variant_id);
                 write!(w, "<h4>{extra}Fields</h4>", extra = extra,);
                 document_non_exhaustive(w, variant);
-                for field in fields {
+                for field in fields.iter() {
                     match *field.kind {
                         clean::StrippedItem(box clean::StructFieldItem(_)) => {}
                         clean::StructFieldItem(ref ty) => {
@@ -1220,7 +1220,7 @@ fn item_proc_macro(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, m: &clean
                     if !m.helpers.is_empty() {
                         w.push_str("\n{\n");
                         w.push_str("    // Attributes available to this derive:\n");
-                        for attr in &m.helpers {
+                        for attr in m.helpers.iter() {
                             writeln!(w, "    #[{}]", attr);
                         }
                         w.push_str("}\n");

--- a/src/librustdoc/json/mod.rs
+++ b/src/librustdoc/json/mod.rs
@@ -102,7 +102,7 @@ impl<'tcx> JsonRenderer<'tcx> {
                 // only need to synthesize items for external traits
                 if !id.is_local() {
                     let trait_item = &trait_item.trait_;
-                    trait_item.items.clone().into_iter().for_each(|i| self.item(i).unwrap());
+                    trait_item.items.clone().into_vec().into_iter().for_each(|i| self.item(i).unwrap());
                     Some((
                         from_item_id(id.into()),
                         types::Item {


### PR DESCRIPTION
This is an experiment to see how much we could reduce the size of various `clean` types and if it's even worth it. Most of the clean types that contain a `Vec` do not actually need any `Vec` functionality, since the `Vec` is essentially read only. It could thus be replaced with a boxed slice to reduce its size.

The PR is split into three commits:
1) The first simply replaces most `Vec<T>`s with `Box<[T]>`. This reduces the size from `24` to `16` bytes. Conversion from `Box<[T]>` into a `Vec` is mostly free, however in the other direction it can be a bit more complex (see next commit).
2) When converting from a vec to a boxed slice, the `into_boxed_slice` method first shrinks the `Vec` to reduce any excess capacity. I hoped that this shrinking would not happen in rustdoc code and that the capacity would equal the length in most cases, since the vecs are usually built out of a `vec!` macro or a `collect` call. Sadly, this was not the case, and the reallocations from the shrinking outweighed any RSS improvements.

    To alleviate this, I introduced the `into_boxed_slice2` method, which avoids this shrinking. It is of course a horrible hack, but I didn't know how to do this from outside the `vec` module, so this was done just to make it work. This would need to be done in a different way of course if we decide to use this approach.
3) The third commit uses the `thin-slice` crate that offers a thin boxed slice, which further reduces the size from `16` to `8` bytes. It can hold slices up to length 65535 without an additional indirection.

I'm not sure if the RSS improvements will be worth it, but I suppose that it's worth a perf. run.
I suspect that there are many other places in the compiler when a `Vec` could be replaced by a (thin) boxed slice to reduce its size.