### PR TITLE
Do not use deprecated -Zsymbol-mangling-version in bootstrap

### DIFF
--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -988,10 +988,20 @@ impl<'a> Builder<'a> {
             }
         };
 
-        if use_new_symbol_mangling {
-            rustflags.arg("-Zsymbol-mangling-version=v0");
+        // cfg(bootstrap) -- drop the compiler.stage == 0 branch.
+        if compiler.stage == 0 {
+            if use_new_symbol_mangling {
+                rustflags.arg("-Zsymbol-mangling-version=v0");
+            } else {
+                rustflags.arg("-Zsymbol-mangling-version=legacy");
+            }
         } else {
-            rustflags.arg("-Zsymbol-mangling-version=legacy");
+            if use_new_symbol_mangling {
+                rustflags.arg("-Csymbol-mangling-version=v0");
+            } else {
+                rustflags.arg("-Csymbol-mangling-version=legacy");
+                rustflags.arg("-Zunstable-options");
+            }
         }
 
         // FIXME: It might be better to use the same value for both `RUSTFLAGS` and `RUSTDOCFLAGS`,


### PR DESCRIPTION
`-Zsymbol-mangling-version` now produces warnings unconditionally. So if you want to use legacy mangling for the compiler (`new-symbol-mangling = false` in `config.toml`), the build is now littered with warnings.

However, with this change, stage 1 `std` doesn't compile:
```
error: `-C symbol-mangling-version=legacy` requires `-Z unstable-options`
```
Even after the bootstrap compiler is updated and it will support `-Csymbol-mangling-version`, the bootstrap code would either need to use `-Z` for the legacy mangling or use `-C` in combination with `-Z unstable-options` (because `-C` + legacy is not allowed without the unstable options). Should we just add `-Z unstable-options` to `std` compilation to resolve this?

Btw I use legacy mangling because the new mangling is not supported by [Hotspot](https://github.com/KDAB/hotspot).