### PR TITLE
Mention intent of `From` trait in its docs

### DIFF
--- a/library/core/src/convert/mod.rs
+++ b/library/core/src/convert/mod.rs
@@ -300,7 +300,8 @@ pub trait Into<T>: Sized {
 /// that encapsulate multiple error types. See the "Examples" section and [the book][book] for more
 /// details.
 ///
-/// **Note: This trait must not fail**. If the conversion can fail, use [`TryFrom`].
+/// **Note: This trait must not fail**. The `From` trait is intended for perfect conversions.
+/// If the conversion can fail or is not perfect, use [`TryFrom`].
 ///
 /// # Generic Implementations
 ///


### PR DESCRIPTION
This pr is a docs modification to add to the documentation of the `From` trait a note about its intent as a perfect conversion.  This is already stated in the `TryFrom` docs so this is simply adding that information in a more visible way.