### PR TITLE
`Iterator::cloned`: document side effect behavior

### DIFF
--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -2998,6 +2998,11 @@ pub trait Iterator {
     /// This is useful when you have an iterator over `&T`, but you need an
     /// iterator over `T`.
     ///
+    /// Note that unlike copying, cloning is regarded as a side effect, because
+    /// `Clone` implementations may contain observable behavior. For example,
+    /// `iter.cloned().last()` will clone all elements even if only the last
+    /// one is actually returned.
+    ///
     /// [`clone`]: Clone::clone
     ///
     /// # Examples


### PR DESCRIPTION
During discussing work on clippy's upcoming `iter_overeager_cloned` lint, I found that the fact that the `cloned` implementation never optimizes any `clone` call away because the clone implementation could contain an observable side effect is underdocumented in the `Iterator::cloned` method.

This PR adds a note to rectify this omission.