### PR TITLE
RustWrapper: adapt to new AttributeMask API

### DIFF
--- a/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
@@ -341,16 +341,12 @@ extern "C" void LLVMRustRemoveFunctionAttributes(LLVMValueRef Fn,
                                                  unsigned Index,
                                                  LLVMRustAttribute RustAttr) {
   Function *F = unwrap<Function>(Fn);
-  Attribute Attr = Attribute::get(F->getContext(), fromRust(RustAttr));
-  auto PAL = F->getAttributes();
+  AttributeList PAL = F->getAttributes();
   AttributeList PALNew;
 #if LLVM_VERSION_LT(14, 0)
-  AttrBuilder B(Attr);
-  PALNew = PAL.removeAttributes(F->getContext(), Index, B);
+  PALNew = PAL.removeAttribute(F->getContext(), Index, fromRust(RustAttr));
 #else
-  AttributeMask M;
-  M.addAttribute(Attr);
-  PALNew = PAL.removeAttributesAtIndex(F->getContext(), Index, M);
+  PALNew = PAL.removeAttributeAtIndex(F->getContext(), Index, fromRust(RustAttr));
 #endif
   F->setAttributes(PALNew);
 }

--- a/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
@@ -342,13 +342,15 @@ extern "C" void LLVMRustRemoveFunctionAttributes(LLVMValueRef Fn,
                                                  LLVMRustAttribute RustAttr) {
   Function *F = unwrap<Function>(Fn);
   Attribute Attr = Attribute::get(F->getContext(), fromRust(RustAttr));
-  AttrBuilder B(Attr);
   auto PAL = F->getAttributes();
   AttributeList PALNew;
 #if LLVM_VERSION_LT(14, 0)
+  AttrBuilder B(Attr);
   PALNew = PAL.removeAttributes(F->getContext(), Index, B);
 #else
-  PALNew = PAL.removeAttributesAtIndex(F->getContext(), Index, B);
+  AttributeMask M;
+  M.addAttribute(Attr);
+  PALNew = PAL.removeAttributesAtIndex(F->getContext(), Index, M);
 #endif
   F->setAttributes(PALNew);
 }


### PR DESCRIPTION
Upstream LLVM change 9290ccc3c1a1 migrated attribute removal to use
AttributeMask instead of AttrBuilder, so we need to follow suit here.

r? @nagisa cc @nikic