### PR TITLE
Add RISC-V detection macro and more architecture instructions

### DIFF
--- a/library/core/src/hint.rs
+++ b/library/core/src/hint.rs
@@ -123,6 +123,21 @@ pub fn spin_loop() {
         }
     }
 
+    // RISC-V platform spin loop hint implementation
+    {
+        // RISC-V RV32 and RV64 share the same PAUSE instruction, but they are located in different
+        // modules in `core::arch`.
+        // In this case, here we call `pause` function in each core arch module.
+        #[cfg(target_arch = "riscv32")]
+        {
+            crate::arch::riscv32::pause();
+        }
+        #[cfg(target_arch = "riscv64")]
+        {
+            crate::arch::riscv64::pause();
+        }
+    }
+
     #[cfg(any(target_arch = "aarch64", all(target_arch = "arm", target_feature = "v6")))]
     {
         #[cfg(target_arch = "aarch64")]
@@ -136,11 +151,6 @@ pub fn spin_loop() {
             // with support for the v6 feature.
             unsafe { crate::arch::arm::__yield() };
         }
-    }
-
-    #[cfg(any(target_arch = "riscv32", target_arch = "riscv64"))]
-    {
-        crate::arch::riscv::pause();
     }
 }
 

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -556,6 +556,7 @@ pub use std_detect::*;
 pub use std_detect::{
     is_aarch64_feature_detected, is_arm_feature_detected, is_mips64_feature_detected,
     is_mips_feature_detected, is_powerpc64_feature_detected, is_powerpc_feature_detected,
+    is_riscv_feature_detected,
 };
 
 // Re-export macros defined in libcore.


### PR DESCRIPTION
This pull request includes:

- Update `stdarch` dependency to include ratified RISC-V supervisor and hypervisor instruction intrinsics which is useful in Rust kernel development
- Add macro `is_riscv_feature_detected!`
- Modify impl of `core::hint::spin_loop` to comply with latest version of `core::arch`

After this update, users may now develop RISC-V kernels and user applications more freely.

r? @Amanieu