### PR TITLE
Destabilize RustcEncodable and RustcDecodable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,9 +253,9 @@ checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 
 [[package]]
 name = "bytes"
-version = "1.1.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
+checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
 
 [[package]]
 name = "bytesize"
@@ -2242,9 +2242,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.7.14"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8067b404fe97c70829f082dec8bcf4f71225d7eaea1d8645349cb76fa06205cc"
+checksum = "8c2bdb6314ec10835cd3293dd268473a835c02b7b352e788be788b3c6ca6bb16"
 dependencies = [
  "libc",
  "log",
@@ -2427,9 +2427,9 @@ checksum = "dd20eec3dbe4376829cb7d80ae6ac45e0a766831dca50202ff2d40db46a8a024"
 
 [[package]]
 name = "os_info"
-version = "3.0.9"
+version = "3.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b89dd55b8d8d97dabd0d1adc625d188378fcf87632825bfe9c956acc9a11a72a"
+checksum = "6ac91020bfed8cc3f8aa450d4c3b5fa1d3373fc091c8a92009f3b27749d5a227"
 dependencies = [
  "log",
  "serde",
@@ -5330,10 +5330,11 @@ checksum = "238ce071d267c5710f9d31451efec16c5ee22de34df17cc05e56cbc92e967117"
 
 [[package]]
 name = "tokio"
-version = "1.15.0"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbbf1c778ec206785635ce8ad57fe52b3009ae9e0c9f574a728f3049d3e55838"
+checksum = "c2602b8af3767c285202012822834005f596c811042315fa7e9f5b12b2a43207"
 dependencies = [
+ "autocfg",
  "bytes",
  "libc",
  "memchr",
@@ -5347,9 +5348,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.8"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50145484efff8818b5ccd256697f36863f587da82cf8b409c53adf1e840798e3"
+checksum = "7b2f3f698253f03119ac0102beaa64f67a67e08074d03a22d18784104543727f"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -5358,9 +5359,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.6.9"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e99e1983e5d376cd8eb4b66604d2e99e79f5bd988c3055891dcd8c9e2604cc0"
+checksum = "1caa0b0c8d94a049db56b5acf8cba99dc0623aab1b26d5b5f5e2d945846b3592"
 dependencies = [
  "bytes",
  "futures-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,9 +253,9 @@ checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 
 [[package]]
 name = "bytes"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
+checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
 name = "bytesize"
@@ -2242,9 +2242,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.7.13"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c2bdb6314ec10835cd3293dd268473a835c02b7b352e788be788b3c6ca6bb16"
+checksum = "8067b404fe97c70829f082dec8bcf4f71225d7eaea1d8645349cb76fa06205cc"
 dependencies = [
  "libc",
  "log",
@@ -2427,9 +2427,9 @@ checksum = "dd20eec3dbe4376829cb7d80ae6ac45e0a766831dca50202ff2d40db46a8a024"
 
 [[package]]
 name = "os_info"
-version = "3.0.7"
+version = "3.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ac91020bfed8cc3f8aa450d4c3b5fa1d3373fc091c8a92009f3b27749d5a227"
+checksum = "b89dd55b8d8d97dabd0d1adc625d188378fcf87632825bfe9c956acc9a11a72a"
 dependencies = [
  "log",
  "serde",
@@ -5330,11 +5330,10 @@ checksum = "238ce071d267c5710f9d31451efec16c5ee22de34df17cc05e56cbc92e967117"
 
 [[package]]
 name = "tokio"
-version = "1.8.2"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2602b8af3767c285202012822834005f596c811042315fa7e9f5b12b2a43207"
+checksum = "fbbf1c778ec206785635ce8ad57fe52b3009ae9e0c9f574a728f3049d3e55838"
 dependencies = [
- "autocfg",
  "bytes",
  "libc",
  "memchr",
@@ -5348,9 +5347,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b2f3f698253f03119ac0102beaa64f67a67e08074d03a22d18784104543727f"
+checksum = "50145484efff8818b5ccd256697f36863f587da82cf8b409c53adf1e840798e3"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -5359,9 +5358,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.6.7"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1caa0b0c8d94a049db56b5acf8cba99dc0623aab1b26d5b5f5e2d945846b3592"
+checksum = "9e99e1983e5d376cd8eb4b66604d2e99e79f5bd988c3055891dcd8c9e2604cc0"
 dependencies = [
  "bytes",
  "futures-core",

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -151,6 +151,7 @@
 #![feature(variant_count)]
 #![feature(const_array_from_ref)]
 #![feature(const_slice_from_ref)]
+#![feature(rustc_encodable_decodable)]
 //
 // Language features:
 #![feature(abi_unadjusted)]

--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -1517,7 +1517,8 @@ pub(crate) mod builtin {
     #[unstable(
         feature = "rustc_encodable_decodable",
         issue = "none",
-        reason = "RustcDecodable cannot be used stably"
+        soft,
+        reason = "unstable implementation detail of the `rustc` compiler, do not use"
     )]
     pub macro RustcDecodable($item:item) {
         /* compiler built-in */
@@ -1534,7 +1535,8 @@ pub(crate) mod builtin {
     #[unstable(
         feature = "rustc_encodable_decodable",
         issue = "none",
-        reason = "RustcDecodable cannot be used stably"
+        soft,
+        reason = "unstable implementation detail of the `rustc` compiler, do not use"
     )]
     pub macro RustcEncodable($item:item) {
         /* compiler built-in */

--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -1508,26 +1508,34 @@ pub(crate) mod builtin {
 
     /// Unstable implementation detail of the `rustc` compiler, do not use.
     #[rustc_builtin_macro]
-    #[stable(feature = "rust1", since = "1.0.0")]
     #[allow_internal_unstable(core_intrinsics, libstd_sys_internals)]
     #[rustc_deprecated(
         since = "1.52.0",
         reason = "rustc-serialize is deprecated and no longer supported"
     )]
     #[doc(hidden)] // While technically stable, using it is unstable, and deprecated. Hide it.
+    #[unstable(
+        feature = "rustc_encodable_decodable",
+        issue = "none",
+        reason = "RustcDecodable cannot be used stably"
+    )]
     pub macro RustcDecodable($item:item) {
         /* compiler built-in */
     }
 
     /// Unstable implementation detail of the `rustc` compiler, do not use.
     #[rustc_builtin_macro]
-    #[stable(feature = "rust1", since = "1.0.0")]
     #[allow_internal_unstable(core_intrinsics)]
     #[rustc_deprecated(
         since = "1.52.0",
         reason = "rustc-serialize is deprecated and no longer supported"
     )]
     #[doc(hidden)] // While technically stable, using it is unstable, and deprecated. Hide it.
+    #[unstable(
+        feature = "rustc_encodable_decodable",
+        issue = "none",
+        reason = "RustcDecodable cannot be used stably"
+    )]
     pub macro RustcEncodable($item:item) {
         /* compiler built-in */
     }

--- a/library/core/src/prelude/v1.rs
+++ b/library/core/src/prelude/v1.rs
@@ -70,7 +70,12 @@ pub use crate::{
 pub use crate::concat_bytes;
 
 // Do not `doc(inline)` these `doc(hidden)` items.
-#[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
+#[unstable(
+    feature = "rustc_encodable_decodable",
+    issue = "none",
+    soft,
+    reason = "unstable implementation detail of the `rustc` compiler, do not use"
+)]
 #[allow(deprecated)]
 pub use crate::macros::builtin::{RustcDecodable, RustcEncodable};
 

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -321,6 +321,7 @@
 #![feature(ptr_internals)]
 #![feature(rustc_attrs)]
 #![feature(rustc_private)]
+#![feature(rustc_encodable_decodable)]
 #![feature(saturating_int_impl)]
 #![feature(slice_concat_ext)]
 #![feature(slice_internals)]

--- a/library/std/src/prelude/v1.rs
+++ b/library/std/src/prelude/v1.rs
@@ -55,7 +55,12 @@ pub use core::prelude::v1::{
 pub use core::prelude::v1::concat_bytes;
 
 // Do not `doc(inline)` these `doc(hidden)` items.
-#[unstable(feature = "rustc_encodable_decodable", issue = "none")]
+#[unstable(
+    feature = "rustc_encodable_decodable",
+    issue = "none",
+    soft,
+    reason = "unstable implementation detail of the `rustc` compiler, do not use"
+)]
 #[allow(deprecated)]
 pub use core::prelude::v1::{RustcDecodable, RustcEncodable};
 

--- a/library/std/src/prelude/v1.rs
+++ b/library/std/src/prelude/v1.rs
@@ -55,7 +55,7 @@ pub use core::prelude::v1::{
 pub use core::prelude::v1::concat_bytes;
 
 // Do not `doc(inline)` these `doc(hidden)` items.
-#[stable(feature = "builtin_macro_prelude", since = "1.38.0")]
+#[unstable(feature = "rustc_encodable_decodable", issue = "none")]
 #[allow(deprecated)]
 pub use core::prelude::v1::{RustcDecodable, RustcEncodable};
 

--- a/src/test/run-make-fulldeps/pretty-expanded/input.rs
+++ b/src/test/run-make-fulldeps/pretty-expanded/input.rs
@@ -1,5 +1,7 @@
 #[crate_type="lib"]
 
+// FIXME: Maybe this should be replaced with some other derive macro
+#![feature(rustc_encodable_decodable)]
 // #13544
 
 extern crate rustc_serialize;

--- a/src/test/run-make-fulldeps/pretty-expanded/input.rs
+++ b/src/test/run-make-fulldeps/pretty-expanded/input.rs
@@ -1,8 +1,6 @@
-#[crate_type="lib"]
-
-// FIXME: Maybe this should be replaced with some other derive macro
+// FIXME: This should be replaced with some other derive macro
 #![feature(rustc_encodable_decodable)]
-// #13544
+#[crate_type="lib"] // Why is this an outer attribute?
 
 extern crate rustc_serialize;
 


### PR DESCRIPTION
This adds the feature `rustc_encodable_decodable` and gates the previously stable `RustcDecodable` and `RustcEncodable` (though deprecated, hidden, and unusable) macros behind them.

These macros have always been a mystery. They have no documentation (and are notably now hidden), cannot be used on stable (except to refer to them, which this PR changes) as their expansion references the `rustc_serialize` crate (which itself is only exposed as `rustc_private`), and cannot reasonably be implemented outside of rustc (except as a compile error). 
They were deprecated in https://github.com/rust-lang/rust/pull/83160, but as they cannot be expanded on stable, I see no reason why they cannot be made unstable (or alternatively, removed; I had no issues in rustc itself, from destabilizing the macros, and the only error was in libstd where the macro is reexported in the prelude), however, I would recommend a crater run to be sure (I highly doubt many crates have `use core::prelude::v1::RustcDecodable;`, though).  
See also: <https://internals.rust-lang.org/t/what-is-rustc-decodable-encodable-and-why-is-it-stable/13744>.
