### PR TITLE
BTree{Map,Set}::range{,_mut} could take a reference

### DIFF
--- a/library/alloc/src/collections/btree/map.rs
+++ b/library/alloc/src/collections/btree/map.rs
@@ -1050,7 +1050,7 @@ impl<K, V> BTreeMap<K, V> {
     /// assert_eq!(Some((&5, &"b")), map.range(4..).next());
     /// ```
     #[stable(feature = "btree_range", since = "1.17.0")]
-    pub fn range<T: ?Sized, R>(&self, range: R) -> Range<'_, K, V>
+    pub fn range<T: ?Sized, R>(&self, range: &R) -> Range<'_, K, V>
     where
         T: Ord,
         K: Borrow<T> + Ord,
@@ -1094,7 +1094,7 @@ impl<K, V> BTreeMap<K, V> {
     /// }
     /// ```
     #[stable(feature = "btree_range", since = "1.17.0")]
-    pub fn range_mut<T: ?Sized, R>(&mut self, range: R) -> RangeMut<'_, K, V>
+    pub fn range_mut<T: ?Sized, R>(&mut self, range: &R) -> RangeMut<'_, K, V>
     where
         T: Ord,
         K: Borrow<T> + Ord,

--- a/library/alloc/src/collections/btree/navigate.rs
+++ b/library/alloc/src/collections/btree/navigate.rs
@@ -248,14 +248,14 @@ impl<BorrowType: marker::BorrowType, K, V> NodeRef<BorrowType, K, V, marker::Lea
     /// KV twice.
     unsafe fn find_leaf_edges_spanning_range<Q: ?Sized, R>(
         self,
-        range: R,
+        range: &R,
     ) -> LeafRange<BorrowType, K, V>
     where
         Q: Ord,
         K: Borrow<Q>,
         R: RangeBounds<Q>,
     {
-        match self.search_tree_for_bifurcation(&range) {
+        match self.search_tree_for_bifurcation(range) {
             Err(_) => LeafRange::none(),
             Ok((
                 node,
@@ -298,7 +298,7 @@ impl<'a, K: 'a, V: 'a> NodeRef<marker::Immut<'a>, K, V, marker::LeafOrInternal> 
     ///
     /// The result is meaningful only if the tree is ordered by key, like the tree
     /// in a `BTreeMap` is.
-    pub fn range_search<Q, R>(self, range: R) -> LeafRange<marker::Immut<'a>, K, V>
+    pub fn range_search<Q, R>(self, range: &R) -> LeafRange<marker::Immut<'a>, K, V>
     where
         Q: ?Sized + Ord,
         K: Borrow<Q>,
@@ -324,7 +324,7 @@ impl<'a, K: 'a, V: 'a> NodeRef<marker::ValMut<'a>, K, V, marker::LeafOrInternal>
     ///
     /// # Safety
     /// Do not use the duplicate handles to visit the same KV twice.
-    pub fn range_search<Q, R>(self, range: R) -> LeafRange<marker::ValMut<'a>, K, V>
+    pub fn range_search<Q, R>(self, range: &R) -> LeafRange<marker::ValMut<'a>, K, V>
     where
         Q: ?Sized + Ord,
         K: Borrow<Q>,

--- a/library/alloc/src/collections/btree/set.rs
+++ b/library/alloc/src/collections/btree/set.rs
@@ -276,7 +276,7 @@ impl<T> BTreeSet<T> {
     /// assert_eq!(Some(&5), set.range(4..).next());
     /// ```
     #[stable(feature = "btree_range", since = "1.17.0")]
-    pub fn range<K: ?Sized, R>(&self, range: R) -> Range<'_, T>
+    pub fn range<K: ?Sized, R>(&self, range: &R) -> Range<'_, T>
     where
         K: Ord,
         T: Borrow<K> + Ord,


### PR DESCRIPTION
Currently, `BTreeMap::range`, `BTreeMap::range_mut`, and `BTreeSet::range` take the `RangeBounds` argument by-move, but there's nothing requiring that to be the case - they only ever use the range argument by-reference. This is reasonable for the "doctest" style examples where a range is being constructed inline with the call, or for the case where the key type for the BTreeMap is `Copy`, but imposes a pretty high performance cost when using non-copy keys (in my case, my key is a `Vec` containing some pretty large strings).

This PR exists really mostly to demonstrate that std *could* update the signatures of these methods to take `range` as a reference - obviously it *shouldn't*, at least not without an edition bump, as that'd be backwards compatible - so mainly this is here as a strawman to get in the requisite bikeshedding prior to putting more work into implementation. Some thoughts:

* Introduce `BTreeMap::range_ref` etc. This would work, but feels ugly / I can't think of a good name
* Make this change at an edition boundary. This feels like a bad idea to me, in part because `map.range(&(1..2))` looks ugly.
* `impl<T, A> RangeBounds<A> for &T where T: RangeBounds<A>` using some special compiler magic to fix the incoherence
* something I'm not thinking of?

Also, if this should be an RFC or even pre-RFC, let me know