### PR TITLE
Optimize `impl_read_unsigned_leb128`

### DIFF
--- a/compiler/rustc_serialize/src/leb128.rs
+++ b/compiler/rustc_serialize/src/leb128.rs
@@ -53,16 +53,15 @@ impl_write_unsigned_leb128!(write_usize_leb128, usize);
 macro_rules! impl_read_unsigned_leb128 {
     ($fn_name:ident, $int_ty:ty) => {
         #[inline]
-        pub fn $fn_name(slice: &[u8]) -> ($int_ty, usize) {
+        pub fn $fn_name(slice: &[u8], position: &mut usize) -> $int_ty {
             let mut result = 0;
             let mut shift = 0;
-            let mut position = 0;
             loop {
-                let byte = slice[position];
-                position += 1;
+                let byte = slice[*position];
+                *position += 1;
                 if (byte & 0x80) == 0 {
                     result |= (byte as $int_ty) << shift;
-                    return (result, position);
+                    return result;
                 } else {
                     result |= ((byte & 0x7F) as $int_ty) << shift;
                 }
@@ -122,15 +121,14 @@ impl_write_signed_leb128!(write_isize_leb128, isize);
 macro_rules! impl_read_signed_leb128 {
     ($fn_name:ident, $int_ty:ty) => {
         #[inline]
-        pub fn $fn_name(slice: &[u8]) -> ($int_ty, usize) {
+        pub fn $fn_name(slice: &[u8], position: &mut usize) -> $int_ty {
             let mut result = 0;
             let mut shift = 0;
-            let mut position = 0;
             let mut byte;
 
             loop {
-                byte = slice[position];
-                position += 1;
+                byte = slice[*position];
+                *position += 1;
                 result |= <$int_ty>::from(byte & 0x7F) << shift;
                 shift += 7;
 
@@ -144,7 +142,7 @@ macro_rules! impl_read_signed_leb128 {
                 result |= (!0 << shift);
             }
 
-            (result, position)
+            result
         }
     };
 }

--- a/compiler/rustc_serialize/src/opaque.rs
+++ b/compiler/rustc_serialize/src/opaque.rs
@@ -559,11 +559,7 @@ impl<'a> Decoder<'a> {
 }
 
 macro_rules! read_leb128 {
-    ($dec:expr, $fun:ident) => {{
-        let (value, bytes_read) = leb128::$fun(&$dec.data[$dec.position..]);
-        $dec.position += bytes_read;
-        Ok(value)
-    }};
+    ($dec:expr, $fun:ident) => {{ Ok(leb128::$fun($dec.data, &mut $dec.position)) }};
 }
 
 impl<'a> serialize::Decoder for Decoder<'a> {

--- a/compiler/rustc_serialize/tests/leb128.rs
+++ b/compiler/rustc_serialize/tests/leb128.rs
@@ -30,9 +30,8 @@ macro_rules! impl_test_unsigned_leb128 {
 
             let mut position = 0;
             for &expected in &values {
-                let (actual, bytes_read) = $read_fn_name(&stream[position..]);
+                let actual = $read_fn_name(&stream, &mut position);
                 assert_eq!(expected, actual);
-                position += bytes_read;
             }
             assert_eq!(stream.len(), position);
         }
@@ -77,9 +76,8 @@ macro_rules! impl_test_signed_leb128 {
 
             let mut position = 0;
             for &expected in &values {
-                let (actual, bytes_read) = $read_fn_name(&stream[position..]);
+                let actual = $read_fn_name(&stream, &mut position);
                 assert_eq!(expected, actual);
-                position += bytes_read;
             }
             assert_eq!(stream.len(), position);
         }


### PR DESCRIPTION
I see instruction count improvements of up to 3.5% locally with these changes, mostly on the smaller benchmarks.

r? @michaelwoerister 