### PR TITLE
Fix drop shadow on Rust logo in docs

### DIFF
--- a/src/librustdoc/html/static/css/themes/ayu.css
+++ b/src/librustdoc/html/static/css/themes/ayu.css
@@ -61,7 +61,7 @@ pre, .rustdoc.source .example-wrap {
 	background-color: #14191f;
 }
 
-.rust-logo > img {
+.rust-logo {
 	filter: drop-shadow(1px 0 0px #fff)
 		drop-shadow(0 1px 0 #fff)
 		drop-shadow(-1px 0 0 #fff)

--- a/src/librustdoc/html/static/css/themes/dark.css
+++ b/src/librustdoc/html/static/css/themes/dark.css
@@ -32,7 +32,7 @@ pre, .rustdoc.source .example-wrap {
 	background-color: #505050;
 }
 
-.rust-logo > img {
+.rust-logo {
 	filter: drop-shadow(1px 0 0px #fff)
 		drop-shadow(0 1px 0 #fff)
 		drop-shadow(-1px 0 0 #fff)

--- a/src/librustdoc/html/static/css/themes/light.css
+++ b/src/librustdoc/html/static/css/themes/light.css
@@ -43,7 +43,7 @@ pre, .rustdoc.source .example-wrap {
 	scrollbar-color: rgba(36, 37, 39, 0.6) #d9d9d9;
 }
 
-.rust-logo > img {
+.rust-logo {
 	/* No need for a border in here! */
 }
 


### PR DESCRIPTION
In https://github.com/rust-lang/rust/pull/91958/files I fixed the logo so it only gets the `rust-logo` class when it really is the default logo. However, as part of that I also moved the class from a parent div to the img itself, and forgot to update the corresponding CSS rules.

r? @GuillaumeGomez

Demo: https://rustdoc.crud.net/jsha/logo-tracing/std/io/trait.Read.html