### PR TITLE
Include aarch64-apple-darwin docs in manifest.

### DIFF
--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -156,6 +156,7 @@ static TARGETS: &[&str] = &[
 ];
 
 static DOCS_TARGETS: &[&str] = &[
+    "aarch64-apple-darwin",
     "aarch64-unknown-linux-gnu",
     "i686-apple-darwin",
     "i686-pc-windows-gnu",


### PR DESCRIPTION
The docs are being built on the dist-aarch64-apple builder, but they are not included in the manifest so people can't download them with rustup.  This adds them to the manifest.