### PR TITLE
Normalize generator-local types with unevaluated constants

### DIFF
--- a/compiler/rustc_mir_transform/src/generator.rs
+++ b/compiler/rustc_mir_transform/src/generator.rs
@@ -726,9 +726,13 @@ fn sanitize_witness<'tcx>(
     saved_locals: &GeneratorSavedLocals,
 ) {
     let did = body.source.def_id();
-    let allowed_upvars = tcx.erase_regions(upvars);
+    let param_env = tcx.param_env(did);
+
+    let allowed_upvars = tcx.normalize_erasing_regions(param_env, upvars);
     let allowed = match witness.kind() {
-        &ty::GeneratorWitness(s) => tcx.erase_late_bound_regions(s),
+        &ty::GeneratorWitness(interior_tys) => {
+            tcx.normalize_erasing_late_bound_regions(param_env, interior_tys)
+        }
         _ => {
             tcx.sess.delay_span_bug(
                 body.span,
@@ -737,8 +741,6 @@ fn sanitize_witness<'tcx>(
             return;
         }
     };
-
-    let param_env = tcx.param_env(did);
 
     for (local, decl) in body.local_decls.iter_enumerated() {
         // Ignore locals which are internal or not saved between yields.

--- a/src/test/ui/async-await/interior-with-const-generic-expr.rs
+++ b/src/test/ui/async-await/interior-with-const-generic-expr.rs
@@ -1,0 +1,26 @@
+// edition:2018
+// run-pass
+
+#![allow(incomplete_features)]
+#![feature(generic_const_exprs)]
+#![allow(unused)]
+
+fn main() {
+    let x = test();
+}
+
+fn concat<const A: usize, const B: usize>(a: [f32; A], b: [f32; B]) -> [f32; A + B] {
+    todo!()
+}
+
+async fn reverse<const A: usize>(x: [f32; A]) -> [f32; A] {
+    todo!()
+}
+
+async fn test() {
+    let a = [0.0];
+    let b = [1.0, 2.0];
+    let ab = concat(a,b);
+    let ba = reverse(ab).await;
+    println!("{:?}", ba);
+}


### PR DESCRIPTION
Normalize generator-interior types in addition to (i.e. instead of just) erasing regions, since sometimes we collect types with unevaluated const exprs.

Fixes #84737 
Fixes #88171 
Fixes #92091 
Fixes #92634
Probably also fixes #73114, but that one has no code I could test. It looks like it's the same issue, though.