### PR TITLE
Allow remap-path-prefix in rustdoc

### DIFF
--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -92,6 +92,8 @@ pub(crate) struct Options {
     pub(crate) debugging_opts: DebuggingOptions,
     /// Debugging (`-Z`) options strings to pass to the compiler.
     pub(crate) debugging_opts_strs: Vec<String>,
+    /// Path remapping (`--remap-path-prefix`) directives to hand to the compiler.
+    pub(crate) remap_path_prefix_strs: Vec<String>,
     /// The target used to compile the crate against.
     pub(crate) target: TargetTriple,
     /// Edition used when reading the crate. Defaults to "2015". Also used by default when
@@ -179,6 +181,7 @@ impl fmt::Debug for Options {
             .field("check-cfgs", &self.check_cfgs)
             .field("codegen_options", &"...")
             .field("debugging_options", &"...")
+            .field("remap_path_prefixes", &"...")
             .field("target", &self.target)
             .field("edition", &self.edition)
             .field("maybe_sysroot", &self.maybe_sysroot)
@@ -644,6 +647,7 @@ impl Options {
         let test_builder = matches.opt_str("test-builder").map(PathBuf::from);
         let codegen_options_strs = matches.opt_strs("C");
         let debugging_opts_strs = matches.opt_strs("Z");
+        let remap_path_prefix_strs = matches.opt_strs("remap-path-prefix");
         let lib_strs = matches.opt_strs("L");
         let extern_strs = matches.opt_strs("extern");
         let runtool = matches.opt_str("runtool");
@@ -687,6 +691,7 @@ impl Options {
             codegen_options_strs,
             debugging_opts,
             debugging_opts_strs,
+            remap_path_prefix_strs,
             target,
             edition,
             maybe_sysroot,

--- a/src/librustdoc/doctest.rs
+++ b/src/librustdoc/doctest.rs
@@ -360,6 +360,9 @@ fn run_test(
     for debugging_option_str in &rustdoc_options.debugging_opts_strs {
         compiler.arg("-Z").arg(&debugging_option_str);
     }
+    for remap_path_prefix_str in &rustdoc_options.remap_path_prefix_strs {
+        compiler.arg("--remap-path-prefix").arg(&remap_path_prefix_str);
+    }
     if no_run && !lang_string.compile_fail && rustdoc_options.persist_doctests.is_none() {
         compiler.arg("--emit=metadata");
     }

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -278,6 +278,14 @@ fn opts() -> Vec<RustcOptGroup> {
         stable("C", |o| {
             o.optmulti("C", "codegen", "pass a codegen option to rustc", "OPT[=VALUE]")
         }),
+        unstable("remap-path-prefix", |o| {
+            o.optmulti(
+                "",
+                "remap-path-prefix",
+                "Remap source names in all output (compiler messages and output files)",
+                "FROM=TO",
+            )
+        }),
         stable("document-private-items", |o| {
             o.optflagmulti("", "document-private-items", "document private items")
         }),

--- a/src/test/run-make-fulldeps/coverage-reports/Makefile
+++ b/src/test/run-make-fulldeps/coverage-reports/Makefile
@@ -35,7 +35,7 @@ endif
 # workaround for two problems causing tests to fail on Windows:
 #
 # 1. When multiple files appear in the `llvm-cov show` results, each file's coverage results can
-#    appear in different a different order. Whether this is random or, somehow, platform-specific,
+#    appear in a different order. Whether this is random or, somehow, platform-specific,
 #    the Windows output flips the order of the files, compared to Linux. In the `uses_crate.rs`
 #    test, the only test-unique (interesting) results we care about are the results for only one
 #    of the two files, `mod/uses_crate.rs`, so the workaround is to ignore all but this one file.

--- a/src/test/run-make-fulldeps/remap-path-prefix/Makefile
+++ b/src/test/run-make-fulldeps/remap-path-prefix/Makefile
@@ -7,3 +7,6 @@ all:
 	$(RUSTC) --remap-path-prefix $$PWD/auxiliary=/the/aux --crate-type=lib --emit=metadata auxiliary/lib.rs
 	grep "/the/aux/lib.rs" $(TMPDIR)/liblib.rmeta || exit 1
 	! grep "$$PWD/auxiliary" $(TMPDIR)/liblib.rmeta || exit 1
+	$(RUSTDOC) --test --no-run -C debuginfo=1 -C split-debuginfo=off -Zunstable-options --remap-path-prefix $$PWD/auxiliary=/the/aux --remap-path-prefix $$PWD=/the/pwd --persist-doctests=$(TMPDIR)/rustdoc-remap auxiliary/lib.rs
+	grep "/the/pwd" $(TMPDIR)/rustdoc-remap/auxiliary_lib_rs_1_0/rust_out || exit 1
+	! grep "$$PWD" $(TMPDIR)/rustdoc-remap/auxiliary_lib_rs_1_0/rust_out || exit 1

--- a/src/test/run-make-fulldeps/remap-path-prefix/auxiliary/lib.rs
+++ b/src/test/run-make-fulldeps/remap-path-prefix/auxiliary/lib.rs
@@ -1,3 +1,6 @@
+/// ```
+/// assert_eq!(1, 1);
+/// ```
 pub fn lib() {
     panic!("calm");
 }


### PR DESCRIPTION
This adds the `--remap-path-prefix` (as an unstable option) to `rustdoc`
as well, and passes it down to the rust compiler when compiling doctests.

Combined with `--persist-doctests`, the generated executables should
have the same resulting paths as the crate artifact itself.

This is the rustdoc change needed for https://github.com/taiki-e/cargo-llvm-cov/pull/122.

CC @richkadel I tried putting a `--remap-path-prefix` into all the rustc/rustdoc invocations for the coverage tests (and adjusting the `llvm-cov --compilation-dir` param), but that resulted in `llvm-cov` generating two different sections for the same path (probably because it is treated as different paths internally for whatever reason).
However it has the intended effect for the above linked `cargo-llvm-cov` PR.

I wonder how I could better test this. Maybe a rustdoc maintainer can help me out here.

r? @jyn514 