### PR TITLE
Remove "up here" arrow on item-infos

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -175,11 +175,13 @@ h3.code-header {
 h4.code-header {
 	font-size: 1rem;
 }
-h3.code-header, h4.code-header {
+.code-header {
 	font-weight: 600;
 	border-bottom-style: none;
-	padding: 0;
 	margin: 0;
+	padding: 0;
+	margin-top: 0.6em;
+	margin-bottom: 0.4em;
 }
 .impl,
 .impl-items .method,
@@ -192,8 +194,6 @@ h3.code-header, h4.code-header {
 .methods .associatedtype {
 	flex-basis: 100%;
 	font-weight: 600;
-	margin-top: 16px;
-	margin-bottom: 10px;
 	position: relative;
 }
 
@@ -744,19 +744,11 @@ nav.sub {
 
 .content .item-info {
 	position: relative;
-	margin-left: 33px;
+	margin-left: 24px;
 }
 
 .sub-variant > div > .item-info {
 	margin-top: initial;
-}
-
-.content .item-info::before {
-	content: '⬑';
-	font-size: 1.5625rem;
-	position: absolute;
-	top: -6px;
-	left: -19px;
 }
 
 .content .impl-items .docblock, .content .impl-items .item-info {
@@ -777,6 +769,7 @@ nav.sub {
 
 #main-content > .item-info {
 	margin-top: 0;
+	margin-left: 0;
 }
 
 nav.sub {
@@ -1123,13 +1116,6 @@ body.blur > :not(#help) {
 
 .rightside {
 	float: right;
-}
-
-.has-srclink {
-	font-size: 1rem;
-	margin-bottom: 12px;
-	/* Push the src link out to the right edge consistently */
-	justify-content: space-between;
 }
 
 .variants_table {
@@ -2065,6 +2051,24 @@ details.rustdoc-toggle[open] > summary.hideme::after {
 	}
 }
 
+.method-toggle summary,
+.implementors-toggle summary {
+	margin-bottom: 0.75em;
+}
+
+.method-toggle[open] {
+	margin-bottom: 2em;
+}
+
+.implementors-toggle[open]  {
+	margin-bottom: 2em;
+}
+
+#trait-implementations-list .method-toggle,
+#synthetic-implementations-list .method-toggle,
+#blanket-implementations-list .method-toggle {
+	margin-bottom: 1em;
+}
 
 /* Begin: styles for --scrape-examples feature */
 

--- a/src/test/rustdoc-gui/hash-item-expansion.goml
+++ b/src/test/rustdoc-gui/hash-item-expansion.goml
@@ -4,10 +4,6 @@ goto: file://|DOC_PATH|/test_docs/struct.Foo.html#method.borrow
 assert-attribute: ("#blanket-implementations-list > details:nth-child(2)", {"open": ""})
 // We first check that the impl block is open by default.
 assert-attribute: ("#implementations + details", {"open": ""})
-// We collapse it.
-click: "#implementations + details > summary"
-// We check that it was collapsed as expected.
-assert-attribute-false: ("#implementations + details", {"open": ""})
 // To ensure that we will click on the currently hidden method.
 assert-text: (".sidebar-links > a", "must_use")
 click: ".sidebar-links > a"

--- a/src/test/rustdoc-gui/item-info-width.goml
+++ b/src/test/rustdoc-gui/item-info-width.goml
@@ -3,5 +3,6 @@ goto: file://|DOC_PATH|/lib2/struct.Foo.html
 // We set a fixed size so there is no chance of "random" resize.
 size: (1100, 800)
 // We check that ".item-info" is bigger than its content.
-assert-css: (".item-info", {"width": "757px"})
+assert-css: (".item-info", {"width": "790px"})
 assert-css: (".item-info .stab", {"width": "341px"})
+assert-position: (".item-info .stab", {"x": 295})


### PR DESCRIPTION
Use spacing to distinguish what is related to a given heading.

This was originally introduced in #53043, in response to #51387. The arrow is a little distracting, and leads the item-info to not be aligned properly with the text below it.

Demo: https://rustdoc.crud.net/jsha/impl-spacing/std/string/struct.String.html

r? @GuillaumeGomez