### PR TITLE
Implement `Deref<Target = [T]>` for `[T; N]`, and fix const infer variable canonicalization (fix `Deref<Target=[T; N]>` ICEs)

### DIFF
--- a/compiler/rustc_infer/src/infer/canonical/canonicalizer.rs
+++ b/compiler/rustc_infer/src/infer/canonical/canonicalizer.rs
@@ -425,7 +425,7 @@ impl<'cx, 'tcx> TypeFolder<'tcx> for Canonicalizer<'cx, 'tcx> {
                         // FIXME: perf problem described in #55921.
                         ui = ty::UniverseIndex::ROOT;
                         return self.canonicalize_const_var(
-                            CanonicalVarInfo { kind: CanonicalVarKind::Const(ui) },
+                            CanonicalVarInfo { kind: CanonicalVarKind::Const(ui, ct.ty) },
                             ct,
                         );
                     }

--- a/compiler/rustc_infer/src/infer/canonical/mod.rs
+++ b/compiler/rustc_infer/src/infer/canonical/mod.rs
@@ -137,12 +137,9 @@ impl<'cx, 'tcx> InferCtxt<'cx, 'tcx> {
                 self.tcx.mk_region(ty::RePlaceholder(placeholder_mapped)).into()
             }
 
-            CanonicalVarKind::Const(ui) => self
+            CanonicalVarKind::Const(ui, ty) => self
                 .next_const_var_in_universe(
-                    self.next_ty_var_in_universe(
-                        TypeVariableOrigin { kind: TypeVariableOriginKind::MiscVariable, span },
-                        universe_map(ui),
-                    ),
+                    ty,
                     ConstVariableOrigin { kind: ConstVariableOriginKind::MiscVariable, span },
                     universe_map(ui),
                 )

--- a/compiler/rustc_middle/src/infer/canonical.rs
+++ b/compiler/rustc_middle/src/infer/canonical.rs
@@ -23,7 +23,7 @@
 
 use crate::infer::MemberConstraint;
 use crate::ty::subst::GenericArg;
-use crate::ty::{self, BoundVar, List, Region, TyCtxt};
+use crate::ty::{self, BoundVar, List, Region, Ty, TyCtxt};
 use rustc_index::vec::IndexVec;
 use rustc_macros::HashStable;
 use smallvec::SmallVec;
@@ -104,7 +104,7 @@ impl<'tcx> CanonicalVarInfo<'tcx> {
             CanonicalVarKind::PlaceholderTy(_) => false,
             CanonicalVarKind::Region(_) => true,
             CanonicalVarKind::PlaceholderRegion(..) => false,
-            CanonicalVarKind::Const(_) => true,
+            CanonicalVarKind::Const(..) => true,
             CanonicalVarKind::PlaceholderConst(_) => false,
         }
     }
@@ -130,7 +130,7 @@ pub enum CanonicalVarKind<'tcx> {
     PlaceholderRegion(ty::PlaceholderRegion),
 
     /// Some kind of const inference variable.
-    Const(ty::UniverseIndex),
+    Const(ty::UniverseIndex, Ty<'tcx>),
 
     /// A "placeholder" that represents "any const".
     PlaceholderConst(ty::PlaceholderConst<'tcx>),
@@ -147,7 +147,7 @@ impl<'tcx> CanonicalVarKind<'tcx> {
             CanonicalVarKind::PlaceholderTy(placeholder) => placeholder.universe,
             CanonicalVarKind::Region(ui) => ui,
             CanonicalVarKind::PlaceholderRegion(placeholder) => placeholder.universe,
-            CanonicalVarKind::Const(ui) => ui,
+            CanonicalVarKind::Const(ui, _) => ui,
             CanonicalVarKind::PlaceholderConst(placeholder) => placeholder.universe,
         }
     }

--- a/compiler/rustc_middle/src/traits/query.rs
+++ b/compiler/rustc_middle/src/traits/query.rs
@@ -188,7 +188,6 @@ pub struct CandidateStep<'tcx> {
     /// `fn by_raw_ptr(self: *const Self)` and `fn by_ref(&self)`, then
     /// `foo.by_raw_ptr()` will work and `foo.by_ref()` won't.
     pub from_unsafe_deref: bool,
-    pub unsize: bool,
 }
 
 #[derive(Clone, Debug, HashStable)]

--- a/compiler/rustc_traits/src/chalk/mod.rs
+++ b/compiler/rustc_traits/src/chalk/mod.rs
@@ -85,7 +85,7 @@ crate fn evaluate_goal<'tcx>(
                         chalk_ir::VariableKind::Lifetime,
                         chalk_ir::UniverseIndex { counter: ui.index() },
                     ),
-                    CanonicalVarKind::Const(_ui) => unimplemented!(),
+                    CanonicalVarKind::Const(_ui, _ty) => unimplemented!(),
                     CanonicalVarKind::PlaceholderConst(_pc) => unimplemented!(),
                 }),
             ),
@@ -127,9 +127,9 @@ crate fn evaluate_goal<'tcx>(
                     chalk_ir::VariableKind::Lifetime => CanonicalVarKind::Region(
                         ty::UniverseIndex::from_usize(var.skip_kind().counter),
                     ),
-                    chalk_ir::VariableKind::Const(_) => CanonicalVarKind::Const(
-                        ty::UniverseIndex::from_usize(var.skip_kind().counter),
-                    ),
+                    // FIXME(compiler-errors): We don't currently have a way of turning
+                    // a Chalk ty back into a rustc ty, right?
+                    chalk_ir::VariableKind::Const(_) => todo!(),
                 };
                 CanonicalVarInfo { kind }
             })

--- a/compiler/rustc_typeck/src/check/method/confirm.rs
+++ b/compiler/rustc_typeck/src/check/method/confirm.rs
@@ -166,7 +166,7 @@ impl<'a, 'tcx> ConfirmContext<'a, 'tcx> {
             self.structurally_resolved_type(autoderef.span(), autoderef.final_ty(false));
 
         match &pick.autoref_or_ptr_adjustment {
-            Some(probe::AutorefOrPtrAdjustment::Autoref { mutbl, unsize }) => {
+            Some(probe::AutorefOrPtrAdjustment::Autoref { mutbl }) => {
                 let region = self.next_region_var(infer::Autoref(self.span));
                 target = self.tcx.mk_ref(region, ty::TypeAndMut { mutbl: *mutbl, ty: target });
                 let mutbl = match mutbl {
@@ -181,14 +181,6 @@ impl<'a, 'tcx> ConfirmContext<'a, 'tcx> {
                     kind: Adjust::Borrow(AutoBorrow::Ref(region, mutbl)),
                     target,
                 });
-
-                if let Some(unsize_target) = unsize {
-                    target = self
-                        .tcx
-                        .mk_ref(region, ty::TypeAndMut { mutbl: mutbl.into(), ty: unsize_target });
-                    adjustments
-                        .push(Adjustment { kind: Adjust::Pointer(PointerCast::Unsize), target });
-                }
             }
             Some(probe::AutorefOrPtrAdjustment::ToConstPtr) => {
                 target = match target.kind() {

--- a/library/core/src/array/mod.rs
+++ b/library/core/src/array/mod.rs
@@ -14,6 +14,8 @@ use crate::mem::{self, MaybeUninit};
 use crate::ops::{
     ChangeOutputType, ControlFlow, FromResidual, Index, IndexMut, NeverShortCircuit, Residual, Try,
 };
+#[cfg(not(bootstrap))]
+use crate::ops::{Deref, DerefMut};
 use crate::slice::{Iter, IterMut};
 
 mod equality;
@@ -298,6 +300,28 @@ where
     #[inline]
     fn index_mut(&mut self, index: I) -> &mut Self::Output {
         IndexMut::index_mut(self as &mut [T], index)
+    }
+}
+
+#[stable(feature = "deref_on_arrays", since = "1.60.0")]
+#[rustc_const_unstable(feature = "const_deref_on_arrays", issue = "none")]
+#[cfg(not(bootstrap))]
+impl<T, const N: usize> const Deref for [T; N] {
+    type Target = [T];
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        self as &[T]
+    }
+}
+
+#[stable(feature = "deref_on_arrays", since = "1.60.0")]
+#[rustc_const_unstable(feature = "const_deref_on_arrays", issue = "none")]
+#[cfg(not(bootstrap))]
+impl<T, const N: usize> const DerefMut for [T; N] {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self as &mut [T]
     }
 }
 

--- a/src/test/mir-opt/const_promotion_extern_static.BAR.PromoteTemps.diff
+++ b/src/test/mir-opt/const_promotion_extern_static.BAR.PromoteTemps.diff
@@ -4,20 +4,22 @@
   static mut BAR: *const &i32 = {
       let mut _0: *const &i32;             // return place in scope 0 at $DIR/const-promotion-extern-static.rs:9:17: 9:28
       let mut _1: &[&i32];                 // in scope 0 at $DIR/const-promotion-extern-static.rs:9:31: 9:44
-      let mut _2: &[&i32; 1];              // in scope 0 at $DIR/const-promotion-extern-static.rs:9:31: 9:44
-      let _3: [&i32; 1];                   // in scope 0 at $DIR/const-promotion-extern-static.rs:9:31: 9:35
-      let mut _4: &i32;                    // in scope 0 at $DIR/const-promotion-extern-static.rs:9:32: 9:34
-      let _5: &i32;                        // in scope 0 at $DIR/const-promotion-extern-static.rs:9:33: 9:34
-+     let mut _6: &[&i32; 1];              // in scope 0 at $DIR/const-promotion-extern-static.rs:9:31: 9:44
+      let _2: &[&i32];                     // in scope 0 at $DIR/const-promotion-extern-static.rs:9:31: 9:44
+      let mut _3: &[&i32; 1];              // in scope 0 at $DIR/const-promotion-extern-static.rs:9:31: 9:44
+      let _4: [&i32; 1];                   // in scope 0 at $DIR/const-promotion-extern-static.rs:9:31: 9:35
+      let mut _5: &i32;                    // in scope 0 at $DIR/const-promotion-extern-static.rs:9:32: 9:34
+      let _6: &i32;                        // in scope 0 at $DIR/const-promotion-extern-static.rs:9:33: 9:34
++     let mut _7: &[&i32; 1];              // in scope 0 at $DIR/const-promotion-extern-static.rs:9:31: 9:44
   
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/const-promotion-extern-static.rs:9:31: 9:44
           StorageLive(_2);                 // scope 0 at $DIR/const-promotion-extern-static.rs:9:31: 9:44
--         StorageLive(_3);                 // scope 0 at $DIR/const-promotion-extern-static.rs:9:31: 9:35
--         StorageLive(_4);                 // scope 0 at $DIR/const-promotion-extern-static.rs:9:32: 9:34
--         StorageLive(_5);                 // scope 0 at $DIR/const-promotion-extern-static.rs:9:33: 9:34
--         _5 = const {alloc1: &i32};       // scope 0 at $DIR/const-promotion-extern-static.rs:9:33: 9:34
-+         _6 = const BAR::promoted[0];     // scope 0 at $DIR/const-promotion-extern-static.rs:9:31: 9:44
+          StorageLive(_3);                 // scope 0 at $DIR/const-promotion-extern-static.rs:9:31: 9:44
+-         StorageLive(_4);                 // scope 0 at $DIR/const-promotion-extern-static.rs:9:31: 9:35
+-         StorageLive(_5);                 // scope 0 at $DIR/const-promotion-extern-static.rs:9:32: 9:34
+-         StorageLive(_6);                 // scope 0 at $DIR/const-promotion-extern-static.rs:9:33: 9:34
+-         _6 = const {alloc1: &i32};       // scope 0 at $DIR/const-promotion-extern-static.rs:9:33: 9:34
++         _7 = const BAR::promoted[0];     // scope 0 at $DIR/const-promotion-extern-static.rs:9:31: 9:44
                                            // ty::Const
 -                                          // + ty: &i32
 -                                          // + val: Value(Scalar(alloc1))
@@ -26,15 +28,16 @@
                                            // mir::Constant
 -                                          // + span: $DIR/const-promotion-extern-static.rs:9:33: 9:34
 -                                          // + literal: Const { ty: &i32, val: Value(Scalar(alloc1)) }
--         _4 = &(*_5);                     // scope 0 at $DIR/const-promotion-extern-static.rs:9:32: 9:34
--         _3 = [move _4];                  // scope 0 at $DIR/const-promotion-extern-static.rs:9:31: 9:35
--         _2 = &_3;                        // scope 0 at $DIR/const-promotion-extern-static.rs:9:31: 9:44
+-         _5 = &(*_6);                     // scope 0 at $DIR/const-promotion-extern-static.rs:9:32: 9:34
+-         _4 = [move _5];                  // scope 0 at $DIR/const-promotion-extern-static.rs:9:31: 9:35
+-         _3 = &_4;                        // scope 0 at $DIR/const-promotion-extern-static.rs:9:31: 9:44
 +                                          // + span: $DIR/const-promotion-extern-static.rs:9:31: 9:44
 +                                          // + literal: Const { ty: &[&i32; 1], val: Unevaluated(Unevaluated { def: WithOptConstParam { did: DefId(0:6 ~ const_promotion_extern_static[HASH]::BAR), const_param_did: None }, substs_: Some([]), promoted: Some(promoted[0]) }) }
-+         _2 = &(*_6);                     // scope 0 at $DIR/const-promotion-extern-static.rs:9:31: 9:44
-          _1 = move _2 as &[&i32] (Pointer(Unsize)); // scope 0 at $DIR/const-promotion-extern-static.rs:9:31: 9:44
--         StorageDead(_4);                 // scope 0 at $DIR/const-promotion-extern-static.rs:9:34: 9:35
-          StorageDead(_2);                 // scope 0 at $DIR/const-promotion-extern-static.rs:9:34: 9:35
++         _3 = &(*_7);                     // scope 0 at $DIR/const-promotion-extern-static.rs:9:31: 9:44
+          _2 = move _3 as &[&i32] (Pointer(Unsize)); // scope 0 at $DIR/const-promotion-extern-static.rs:9:31: 9:44
+          _1 = &(*_2);                     // scope 0 at $DIR/const-promotion-extern-static.rs:9:31: 9:44
+-         StorageDead(_5);                 // scope 0 at $DIR/const-promotion-extern-static.rs:9:34: 9:35
+          StorageDead(_3);                 // scope 0 at $DIR/const-promotion-extern-static.rs:9:34: 9:35
           _0 = core::slice::<impl [&i32]>::as_ptr(move _1) -> [return: bb1, unwind: bb2]; // scope 0 at $DIR/const-promotion-extern-static.rs:9:31: 9:44
                                            // mir::Constant
                                            // + span: $DIR/const-promotion-extern-static.rs:9:36: 9:42
@@ -42,8 +45,9 @@
       }
   
       bb1: {
--         StorageDead(_5);                 // scope 0 at $DIR/const-promotion-extern-static.rs:9:43: 9:44
--         StorageDead(_3);                 // scope 0 at $DIR/const-promotion-extern-static.rs:9:43: 9:44
+-         StorageDead(_6);                 // scope 0 at $DIR/const-promotion-extern-static.rs:9:43: 9:44
+-         StorageDead(_4);                 // scope 0 at $DIR/const-promotion-extern-static.rs:9:43: 9:44
+          StorageDead(_2);                 // scope 0 at $DIR/const-promotion-extern-static.rs:9:43: 9:44
           StorageDead(_1);                 // scope 0 at $DIR/const-promotion-extern-static.rs:9:43: 9:44
           return;                          // scope 0 at $DIR/const-promotion-extern-static.rs:9:1: 9:45
       }

--- a/src/test/mir-opt/const_promotion_extern_static.FOO.PromoteTemps.diff
+++ b/src/test/mir-opt/const_promotion_extern_static.FOO.PromoteTemps.diff
@@ -4,22 +4,24 @@
   static mut FOO: *const &i32 = {
       let mut _0: *const &i32;             // return place in scope 0 at $DIR/const-promotion-extern-static.rs:13:17: 13:28
       let mut _1: &[&i32];                 // in scope 0 at $DIR/const-promotion-extern-static.rs:13:31: 13:55
-      let mut _2: &[&i32; 1];              // in scope 0 at $DIR/const-promotion-extern-static.rs:13:31: 13:55
-      let _3: [&i32; 1];                   // in scope 0 at $DIR/const-promotion-extern-static.rs:13:31: 13:46
-      let mut _4: &i32;                    // in scope 0 at $DIR/const-promotion-extern-static.rs:13:32: 13:45
-      let _5: *const i32;                  // in scope 0 at $DIR/const-promotion-extern-static.rs:13:42: 13:43
-+     let mut _6: &[&i32; 1];              // in scope 0 at $DIR/const-promotion-extern-static.rs:13:31: 13:55
+      let _2: &[&i32];                     // in scope 0 at $DIR/const-promotion-extern-static.rs:13:31: 13:55
+      let mut _3: &[&i32; 1];              // in scope 0 at $DIR/const-promotion-extern-static.rs:13:31: 13:55
+      let _4: [&i32; 1];                   // in scope 0 at $DIR/const-promotion-extern-static.rs:13:31: 13:46
+      let mut _5: &i32;                    // in scope 0 at $DIR/const-promotion-extern-static.rs:13:32: 13:45
+      let _6: *const i32;                  // in scope 0 at $DIR/const-promotion-extern-static.rs:13:42: 13:43
++     let mut _7: &[&i32; 1];              // in scope 0 at $DIR/const-promotion-extern-static.rs:13:31: 13:55
       scope 1 {
       }
   
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/const-promotion-extern-static.rs:13:31: 13:55
           StorageLive(_2);                 // scope 0 at $DIR/const-promotion-extern-static.rs:13:31: 13:55
--         StorageLive(_3);                 // scope 0 at $DIR/const-promotion-extern-static.rs:13:31: 13:46
--         StorageLive(_4);                 // scope 0 at $DIR/const-promotion-extern-static.rs:13:32: 13:45
--         StorageLive(_5);                 // scope 1 at $DIR/const-promotion-extern-static.rs:13:42: 13:43
--         _5 = const {alloc3: *const i32}; // scope 1 at $DIR/const-promotion-extern-static.rs:13:42: 13:43
-+         _6 = const FOO::promoted[0];     // scope 0 at $DIR/const-promotion-extern-static.rs:13:31: 13:55
+          StorageLive(_3);                 // scope 0 at $DIR/const-promotion-extern-static.rs:13:31: 13:55
+-         StorageLive(_4);                 // scope 0 at $DIR/const-promotion-extern-static.rs:13:31: 13:46
+-         StorageLive(_5);                 // scope 0 at $DIR/const-promotion-extern-static.rs:13:32: 13:45
+-         StorageLive(_6);                 // scope 1 at $DIR/const-promotion-extern-static.rs:13:42: 13:43
+-         _6 = const {alloc3: *const i32}; // scope 1 at $DIR/const-promotion-extern-static.rs:13:42: 13:43
++         _7 = const FOO::promoted[0];     // scope 0 at $DIR/const-promotion-extern-static.rs:13:31: 13:55
                                            // ty::Const
 -                                          // + ty: *const i32
 -                                          // + val: Value(Scalar(alloc3))
@@ -28,15 +30,16 @@
                                            // mir::Constant
 -                                          // + span: $DIR/const-promotion-extern-static.rs:13:42: 13:43
 -                                          // + literal: Const { ty: *const i32, val: Value(Scalar(alloc3)) }
--         _4 = &(*_5);                     // scope 1 at $DIR/const-promotion-extern-static.rs:13:41: 13:43
--         _3 = [move _4];                  // scope 0 at $DIR/const-promotion-extern-static.rs:13:31: 13:46
--         _2 = &_3;                        // scope 0 at $DIR/const-promotion-extern-static.rs:13:31: 13:55
+-         _5 = &(*_6);                     // scope 1 at $DIR/const-promotion-extern-static.rs:13:41: 13:43
+-         _4 = [move _5];                  // scope 0 at $DIR/const-promotion-extern-static.rs:13:31: 13:46
+-         _3 = &_4;                        // scope 0 at $DIR/const-promotion-extern-static.rs:13:31: 13:55
 +                                          // + span: $DIR/const-promotion-extern-static.rs:13:31: 13:55
 +                                          // + literal: Const { ty: &[&i32; 1], val: Unevaluated(Unevaluated { def: WithOptConstParam { did: DefId(0:7 ~ const_promotion_extern_static[HASH]::FOO), const_param_did: None }, substs_: Some([]), promoted: Some(promoted[0]) }) }
-+         _2 = &(*_6);                     // scope 0 at $DIR/const-promotion-extern-static.rs:13:31: 13:55
-          _1 = move _2 as &[&i32] (Pointer(Unsize)); // scope 0 at $DIR/const-promotion-extern-static.rs:13:31: 13:55
--         StorageDead(_4);                 // scope 0 at $DIR/const-promotion-extern-static.rs:13:45: 13:46
-          StorageDead(_2);                 // scope 0 at $DIR/const-promotion-extern-static.rs:13:45: 13:46
++         _3 = &(*_7);                     // scope 0 at $DIR/const-promotion-extern-static.rs:13:31: 13:55
+          _2 = move _3 as &[&i32] (Pointer(Unsize)); // scope 0 at $DIR/const-promotion-extern-static.rs:13:31: 13:55
+          _1 = &(*_2);                     // scope 0 at $DIR/const-promotion-extern-static.rs:13:31: 13:55
+-         StorageDead(_5);                 // scope 0 at $DIR/const-promotion-extern-static.rs:13:45: 13:46
+          StorageDead(_3);                 // scope 0 at $DIR/const-promotion-extern-static.rs:13:45: 13:46
           _0 = core::slice::<impl [&i32]>::as_ptr(move _1) -> [return: bb1, unwind: bb2]; // scope 0 at $DIR/const-promotion-extern-static.rs:13:31: 13:55
                                            // mir::Constant
                                            // + span: $DIR/const-promotion-extern-static.rs:13:47: 13:53
@@ -44,8 +47,9 @@
       }
   
       bb1: {
--         StorageDead(_5);                 // scope 0 at $DIR/const-promotion-extern-static.rs:13:54: 13:55
--         StorageDead(_3);                 // scope 0 at $DIR/const-promotion-extern-static.rs:13:54: 13:55
+-         StorageDead(_6);                 // scope 0 at $DIR/const-promotion-extern-static.rs:13:54: 13:55
+-         StorageDead(_4);                 // scope 0 at $DIR/const-promotion-extern-static.rs:13:54: 13:55
+          StorageDead(_2);                 // scope 0 at $DIR/const-promotion-extern-static.rs:13:54: 13:55
           StorageDead(_1);                 // scope 0 at $DIR/const-promotion-extern-static.rs:13:54: 13:55
           return;                          // scope 0 at $DIR/const-promotion-extern-static.rs:13:1: 13:56
       }

--- a/src/test/mir-opt/lower_array_len.array_bound.InstCombine.diff
+++ b/src/test/mir-opt/lower_array_len.array_bound.InstCombine.diff
@@ -9,11 +9,11 @@
       let mut _4: usize;                   // in scope 0 at $DIR/lower_array_len.rs:7:8: 7:13
       let mut _5: usize;                   // in scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
       let mut _6: &[u8];                   // in scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
-      let mut _7: &[u8; N];                // in scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
-      let _8: usize;                       // in scope 0 at $DIR/lower_array_len.rs:8:15: 8:20
-      let mut _9: usize;                   // in scope 0 at $DIR/lower_array_len.rs:8:9: 8:21
-      let mut _10: bool;                   // in scope 0 at $DIR/lower_array_len.rs:8:9: 8:21
-      let mut _11: &[u8; N];               // in scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
+      let _7: &[u8];                       // in scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
+      let mut _8: &[u8; N];                // in scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
+      let _9: usize;                       // in scope 0 at $DIR/lower_array_len.rs:8:15: 8:20
+      let mut _10: usize;                  // in scope 0 at $DIR/lower_array_len.rs:8:9: 8:21
+      let mut _11: bool;                   // in scope 0 at $DIR/lower_array_len.rs:8:9: 8:21
   
       bb0: {
           StorageLive(_3);                 // scope 0 at $DIR/lower_array_len.rs:7:8: 7:27
@@ -22,34 +22,34 @@
           StorageLive(_5);                 // scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
           StorageLive(_6);                 // scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
           StorageLive(_7);                 // scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
--         _7 = &(*_2);                     // scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
-+         _7 = _2;                         // scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
-          StorageLive(_11);                // scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
-          _11 = _7;                        // scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
-          _6 = move _7 as &[u8] (Pointer(Unsize)); // scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
-          StorageDead(_7);                 // scope 0 at $DIR/lower_array_len.rs:7:20: 7:21
--         _5 = Len((*_11));                // scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
-+         _5 = const N;                    // scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
-          StorageDead(_11);                // scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
+          StorageLive(_8);                 // scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
+-         _8 = &(*_2);                     // scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
++         _8 = _2;                         // scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
+          _7 = move _8 as &[u8] (Pointer(Unsize)); // scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
+-         _6 = &(*_7);                     // scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
++         _6 = _7;                         // scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
+          StorageDead(_8);                 // scope 0 at $DIR/lower_array_len.rs:7:20: 7:21
+          _5 = Len((*_6));                 // scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
           StorageDead(_6);                 // scope 0 at $DIR/lower_array_len.rs:7:26: 7:27
           _3 = Lt(move _4, move _5);       // scope 0 at $DIR/lower_array_len.rs:7:8: 7:27
+          StorageDead(_7);                 // scope 0 at $DIR/lower_array_len.rs:7:26: 7:27
           StorageDead(_5);                 // scope 0 at $DIR/lower_array_len.rs:7:26: 7:27
           StorageDead(_4);                 // scope 0 at $DIR/lower_array_len.rs:7:26: 7:27
           switchInt(move _3) -> [false: bb3, otherwise: bb1]; // scope 0 at $DIR/lower_array_len.rs:7:8: 7:27
       }
   
       bb1: {
-          StorageLive(_8);                 // scope 0 at $DIR/lower_array_len.rs:8:15: 8:20
-          _8 = _1;                         // scope 0 at $DIR/lower_array_len.rs:8:15: 8:20
--         _9 = Len((*_2));                 // scope 0 at $DIR/lower_array_len.rs:8:9: 8:21
-+         _9 = const N;                    // scope 0 at $DIR/lower_array_len.rs:8:9: 8:21
-          _10 = Lt(_8, _9);                // scope 0 at $DIR/lower_array_len.rs:8:9: 8:21
-          assert(move _10, "index out of bounds: the length is {} but the index is {}", move _9, _8) -> bb2; // scope 0 at $DIR/lower_array_len.rs:8:9: 8:21
+          StorageLive(_9);                 // scope 0 at $DIR/lower_array_len.rs:8:15: 8:20
+          _9 = _1;                         // scope 0 at $DIR/lower_array_len.rs:8:15: 8:20
+-         _10 = Len((*_2));                // scope 0 at $DIR/lower_array_len.rs:8:9: 8:21
++         _10 = const N;                   // scope 0 at $DIR/lower_array_len.rs:8:9: 8:21
+          _11 = Lt(_9, _10);               // scope 0 at $DIR/lower_array_len.rs:8:9: 8:21
+          assert(move _11, "index out of bounds: the length is {} but the index is {}", move _10, _9) -> bb2; // scope 0 at $DIR/lower_array_len.rs:8:9: 8:21
       }
   
       bb2: {
-          _0 = (*_2)[_8];                  // scope 0 at $DIR/lower_array_len.rs:8:9: 8:21
-          StorageDead(_8);                 // scope 0 at $DIR/lower_array_len.rs:9:5: 9:6
+          _0 = (*_2)[_9];                  // scope 0 at $DIR/lower_array_len.rs:8:9: 8:21
+          StorageDead(_9);                 // scope 0 at $DIR/lower_array_len.rs:9:5: 9:6
           goto -> bb4;                     // scope 0 at $DIR/lower_array_len.rs:7:5: 11:6
       }
   

--- a/src/test/mir-opt/lower_array_len.array_bound.NormalizeArrayLen.diff
+++ b/src/test/mir-opt/lower_array_len.array_bound.NormalizeArrayLen.diff
@@ -9,11 +9,11 @@
       let mut _4: usize;                   // in scope 0 at $DIR/lower_array_len.rs:7:8: 7:13
       let mut _5: usize;                   // in scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
       let mut _6: &[u8];                   // in scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
-      let mut _7: &[u8; N];                // in scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
-      let _8: usize;                       // in scope 0 at $DIR/lower_array_len.rs:8:15: 8:20
-      let mut _9: usize;                   // in scope 0 at $DIR/lower_array_len.rs:8:9: 8:21
-      let mut _10: bool;                   // in scope 0 at $DIR/lower_array_len.rs:8:9: 8:21
-+     let mut _11: &[u8; N];               // in scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
+      let _7: &[u8];                       // in scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
+      let mut _8: &[u8; N];                // in scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
+      let _9: usize;                       // in scope 0 at $DIR/lower_array_len.rs:8:15: 8:20
+      let mut _10: usize;                  // in scope 0 at $DIR/lower_array_len.rs:8:9: 8:21
+      let mut _11: bool;                   // in scope 0 at $DIR/lower_array_len.rs:8:9: 8:21
   
       bb0: {
           StorageLive(_3);                 // scope 0 at $DIR/lower_array_len.rs:7:8: 7:27
@@ -22,36 +22,35 @@
           StorageLive(_5);                 // scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
           StorageLive(_6);                 // scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
           StorageLive(_7);                 // scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
-          _7 = &(*_2);                     // scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
-+         StorageLive(_11);                // scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
-+         _11 = _7;                        // scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
-          _6 = move _7 as &[u8] (Pointer(Unsize)); // scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
-          StorageDead(_7);                 // scope 0 at $DIR/lower_array_len.rs:7:20: 7:21
--         _5 = Len((*_6));                 // scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
-+         _5 = Len((*_11));                // scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
-+         StorageDead(_11);                // scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
+          StorageLive(_8);                 // scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
+          _8 = &(*_2);                     // scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
+          _7 = move _8 as &[u8] (Pointer(Unsize)); // scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
+          _6 = &(*_7);                     // scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
+          StorageDead(_8);                 // scope 0 at $DIR/lower_array_len.rs:7:20: 7:21
+          _5 = Len((*_6));                 // scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
           goto -> bb1;                     // scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
       }
   
       bb1: {
           StorageDead(_6);                 // scope 0 at $DIR/lower_array_len.rs:7:26: 7:27
           _3 = Lt(move _4, move _5);       // scope 0 at $DIR/lower_array_len.rs:7:8: 7:27
+          StorageDead(_7);                 // scope 0 at $DIR/lower_array_len.rs:7:26: 7:27
           StorageDead(_5);                 // scope 0 at $DIR/lower_array_len.rs:7:26: 7:27
           StorageDead(_4);                 // scope 0 at $DIR/lower_array_len.rs:7:26: 7:27
           switchInt(move _3) -> [false: bb4, otherwise: bb2]; // scope 0 at $DIR/lower_array_len.rs:7:8: 7:27
       }
   
       bb2: {
-          StorageLive(_8);                 // scope 0 at $DIR/lower_array_len.rs:8:15: 8:20
-          _8 = _1;                         // scope 0 at $DIR/lower_array_len.rs:8:15: 8:20
-          _9 = Len((*_2));                 // scope 0 at $DIR/lower_array_len.rs:8:9: 8:21
-          _10 = Lt(_8, _9);                // scope 0 at $DIR/lower_array_len.rs:8:9: 8:21
-          assert(move _10, "index out of bounds: the length is {} but the index is {}", move _9, _8) -> bb3; // scope 0 at $DIR/lower_array_len.rs:8:9: 8:21
+          StorageLive(_9);                 // scope 0 at $DIR/lower_array_len.rs:8:15: 8:20
+          _9 = _1;                         // scope 0 at $DIR/lower_array_len.rs:8:15: 8:20
+          _10 = Len((*_2));                // scope 0 at $DIR/lower_array_len.rs:8:9: 8:21
+          _11 = Lt(_9, _10);               // scope 0 at $DIR/lower_array_len.rs:8:9: 8:21
+          assert(move _11, "index out of bounds: the length is {} but the index is {}", move _10, _9) -> bb3; // scope 0 at $DIR/lower_array_len.rs:8:9: 8:21
       }
   
       bb3: {
-          _0 = (*_2)[_8];                  // scope 0 at $DIR/lower_array_len.rs:8:9: 8:21
-          StorageDead(_8);                 // scope 0 at $DIR/lower_array_len.rs:9:5: 9:6
+          _0 = (*_2)[_9];                  // scope 0 at $DIR/lower_array_len.rs:8:9: 8:21
+          StorageDead(_9);                 // scope 0 at $DIR/lower_array_len.rs:9:5: 9:6
           goto -> bb5;                     // scope 0 at $DIR/lower_array_len.rs:7:5: 11:6
       }
   

--- a/src/test/mir-opt/lower_array_len.array_bound.SimplifyLocals.diff
+++ b/src/test/mir-opt/lower_array_len.array_bound.SimplifyLocals.diff
@@ -8,55 +8,45 @@
       let mut _3: bool;                    // in scope 0 at $DIR/lower_array_len.rs:7:8: 7:27
       let mut _4: usize;                   // in scope 0 at $DIR/lower_array_len.rs:7:8: 7:13
       let mut _5: usize;                   // in scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
--     let mut _6: &[u8];                   // in scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
--     let mut _7: &[u8; N];                // in scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
--     let _8: usize;                       // in scope 0 at $DIR/lower_array_len.rs:8:15: 8:20
--     let mut _9: usize;                   // in scope 0 at $DIR/lower_array_len.rs:8:9: 8:21
--     let mut _10: bool;                   // in scope 0 at $DIR/lower_array_len.rs:8:9: 8:21
--     let mut _11: &[u8; N];               // in scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
-+     let _6: usize;                       // in scope 0 at $DIR/lower_array_len.rs:8:15: 8:20
-+     let mut _7: usize;                   // in scope 0 at $DIR/lower_array_len.rs:8:9: 8:21
-+     let mut _8: bool;                    // in scope 0 at $DIR/lower_array_len.rs:8:9: 8:21
+      let mut _6: &[u8];                   // in scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
+      let _7: &[u8];                       // in scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
+      let mut _8: &[u8; N];                // in scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
+      let _9: usize;                       // in scope 0 at $DIR/lower_array_len.rs:8:15: 8:20
+      let mut _10: usize;                  // in scope 0 at $DIR/lower_array_len.rs:8:9: 8:21
+      let mut _11: bool;                   // in scope 0 at $DIR/lower_array_len.rs:8:9: 8:21
   
       bb0: {
           StorageLive(_3);                 // scope 0 at $DIR/lower_array_len.rs:7:8: 7:27
           StorageLive(_4);                 // scope 0 at $DIR/lower_array_len.rs:7:8: 7:13
           _4 = _1;                         // scope 0 at $DIR/lower_array_len.rs:7:8: 7:13
           StorageLive(_5);                 // scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
--         StorageLive(_6);                 // scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
--         StorageLive(_7);                 // scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
--         _7 = _2;                         // scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
--         StorageLive(_11);                // scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
--         _11 = _7;                        // scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
--         _6 = move _7 as &[u8] (Pointer(Unsize)); // scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
--         StorageDead(_7);                 // scope 0 at $DIR/lower_array_len.rs:7:20: 7:21
-          _5 = const N;                    // scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
--         StorageDead(_11);                // scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
--         StorageDead(_6);                 // scope 0 at $DIR/lower_array_len.rs:7:26: 7:27
+          StorageLive(_6);                 // scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
+          StorageLive(_7);                 // scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
+          StorageLive(_8);                 // scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
+          _8 = _2;                         // scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
+          _7 = move _8 as &[u8] (Pointer(Unsize)); // scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
+          _6 = _7;                         // scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
+          StorageDead(_8);                 // scope 0 at $DIR/lower_array_len.rs:7:20: 7:21
+          _5 = Len((*_6));                 // scope 0 at $DIR/lower_array_len.rs:7:16: 7:27
+          StorageDead(_6);                 // scope 0 at $DIR/lower_array_len.rs:7:26: 7:27
           _3 = Lt(move _4, move _5);       // scope 0 at $DIR/lower_array_len.rs:7:8: 7:27
+          StorageDead(_7);                 // scope 0 at $DIR/lower_array_len.rs:7:26: 7:27
           StorageDead(_5);                 // scope 0 at $DIR/lower_array_len.rs:7:26: 7:27
           StorageDead(_4);                 // scope 0 at $DIR/lower_array_len.rs:7:26: 7:27
           switchInt(move _3) -> [false: bb3, otherwise: bb1]; // scope 0 at $DIR/lower_array_len.rs:7:8: 7:27
       }
   
       bb1: {
--         StorageLive(_8);                 // scope 0 at $DIR/lower_array_len.rs:8:15: 8:20
--         _8 = _1;                         // scope 0 at $DIR/lower_array_len.rs:8:15: 8:20
--         _9 = const N;                    // scope 0 at $DIR/lower_array_len.rs:8:9: 8:21
--         _10 = Lt(_8, _9);                // scope 0 at $DIR/lower_array_len.rs:8:9: 8:21
--         assert(move _10, "index out of bounds: the length is {} but the index is {}", move _9, _8) -> bb2; // scope 0 at $DIR/lower_array_len.rs:8:9: 8:21
-+         StorageLive(_6);                 // scope 0 at $DIR/lower_array_len.rs:8:15: 8:20
-+         _6 = _1;                         // scope 0 at $DIR/lower_array_len.rs:8:15: 8:20
-+         _7 = const N;                    // scope 0 at $DIR/lower_array_len.rs:8:9: 8:21
-+         _8 = Lt(_6, _7);                 // scope 0 at $DIR/lower_array_len.rs:8:9: 8:21
-+         assert(move _8, "index out of bounds: the length is {} but the index is {}", move _7, _6) -> bb2; // scope 0 at $DIR/lower_array_len.rs:8:9: 8:21
+          StorageLive(_9);                 // scope 0 at $DIR/lower_array_len.rs:8:15: 8:20
+          _9 = _1;                         // scope 0 at $DIR/lower_array_len.rs:8:15: 8:20
+          _10 = const N;                   // scope 0 at $DIR/lower_array_len.rs:8:9: 8:21
+          _11 = Lt(_9, _10);               // scope 0 at $DIR/lower_array_len.rs:8:9: 8:21
+          assert(move _11, "index out of bounds: the length is {} but the index is {}", move _10, _9) -> bb2; // scope 0 at $DIR/lower_array_len.rs:8:9: 8:21
       }
   
       bb2: {
--         _0 = (*_2)[_8];                  // scope 0 at $DIR/lower_array_len.rs:8:9: 8:21
--         StorageDead(_8);                 // scope 0 at $DIR/lower_array_len.rs:9:5: 9:6
-+         _0 = (*_2)[_6];                  // scope 0 at $DIR/lower_array_len.rs:8:9: 8:21
-+         StorageDead(_6);                 // scope 0 at $DIR/lower_array_len.rs:9:5: 9:6
+          _0 = (*_2)[_9];                  // scope 0 at $DIR/lower_array_len.rs:8:9: 8:21
+          StorageDead(_9);                 // scope 0 at $DIR/lower_array_len.rs:9:5: 9:6
           goto -> bb4;                     // scope 0 at $DIR/lower_array_len.rs:7:5: 11:6
       }
   

--- a/src/test/mir-opt/lower_array_len.array_bound_mut.InstCombine.diff
+++ b/src/test/mir-opt/lower_array_len.array_bound_mut.InstCombine.diff
@@ -9,14 +9,14 @@
       let mut _4: usize;                   // in scope 0 at $DIR/lower_array_len.rs:18:8: 18:13
       let mut _5: usize;                   // in scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
       let mut _6: &[u8];                   // in scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
-      let mut _7: &[u8; N];                // in scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
-      let _8: usize;                       // in scope 0 at $DIR/lower_array_len.rs:19:15: 19:20
-      let mut _9: usize;                   // in scope 0 at $DIR/lower_array_len.rs:19:9: 19:21
-      let mut _10: bool;                   // in scope 0 at $DIR/lower_array_len.rs:19:9: 19:21
-      let _11: usize;                      // in scope 0 at $DIR/lower_array_len.rs:21:15: 21:16
-      let mut _12: usize;                  // in scope 0 at $DIR/lower_array_len.rs:21:9: 21:17
-      let mut _13: bool;                   // in scope 0 at $DIR/lower_array_len.rs:21:9: 21:17
-      let mut _14: &[u8; N];               // in scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
+      let _7: &[u8];                       // in scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
+      let mut _8: &[u8; N];                // in scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
+      let _9: usize;                       // in scope 0 at $DIR/lower_array_len.rs:19:15: 19:20
+      let mut _10: usize;                  // in scope 0 at $DIR/lower_array_len.rs:19:9: 19:21
+      let mut _11: bool;                   // in scope 0 at $DIR/lower_array_len.rs:19:9: 19:21
+      let _12: usize;                      // in scope 0 at $DIR/lower_array_len.rs:21:15: 21:16
+      let mut _13: usize;                  // in scope 0 at $DIR/lower_array_len.rs:21:9: 21:17
+      let mut _14: bool;                   // in scope 0 at $DIR/lower_array_len.rs:21:9: 21:17
   
       bb0: {
           StorageLive(_3);                 // scope 0 at $DIR/lower_array_len.rs:18:8: 18:27
@@ -25,48 +25,48 @@
           StorageLive(_5);                 // scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
           StorageLive(_6);                 // scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
           StorageLive(_7);                 // scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
-          _7 = &(*_2);                     // scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
-          StorageLive(_14);                // scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
-          _14 = _7;                        // scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
-          _6 = move _7 as &[u8] (Pointer(Unsize)); // scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
-          StorageDead(_7);                 // scope 0 at $DIR/lower_array_len.rs:18:20: 18:21
--         _5 = Len((*_14));                // scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
-+         _5 = const N;                    // scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
-          StorageDead(_14);                // scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
+          StorageLive(_8);                 // scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
+          _8 = &(*_2);                     // scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
+          _7 = move _8 as &[u8] (Pointer(Unsize)); // scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
+-         _6 = &(*_7);                     // scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
++         _6 = _7;                         // scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
+          StorageDead(_8);                 // scope 0 at $DIR/lower_array_len.rs:18:20: 18:21
+          _5 = Len((*_6));                 // scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
           StorageDead(_6);                 // scope 0 at $DIR/lower_array_len.rs:18:26: 18:27
           _3 = Lt(move _4, move _5);       // scope 0 at $DIR/lower_array_len.rs:18:8: 18:27
+          StorageDead(_7);                 // scope 0 at $DIR/lower_array_len.rs:18:26: 18:27
           StorageDead(_5);                 // scope 0 at $DIR/lower_array_len.rs:18:26: 18:27
           StorageDead(_4);                 // scope 0 at $DIR/lower_array_len.rs:18:26: 18:27
           switchInt(move _3) -> [false: bb3, otherwise: bb1]; // scope 0 at $DIR/lower_array_len.rs:18:8: 18:27
       }
   
       bb1: {
-          StorageLive(_8);                 // scope 0 at $DIR/lower_array_len.rs:19:15: 19:20
-          _8 = _1;                         // scope 0 at $DIR/lower_array_len.rs:19:15: 19:20
--         _9 = Len((*_2));                 // scope 0 at $DIR/lower_array_len.rs:19:9: 19:21
-+         _9 = const N;                    // scope 0 at $DIR/lower_array_len.rs:19:9: 19:21
-          _10 = Lt(_8, _9);                // scope 0 at $DIR/lower_array_len.rs:19:9: 19:21
-          assert(move _10, "index out of bounds: the length is {} but the index is {}", move _9, _8) -> bb2; // scope 0 at $DIR/lower_array_len.rs:19:9: 19:21
+          StorageLive(_9);                 // scope 0 at $DIR/lower_array_len.rs:19:15: 19:20
+          _9 = _1;                         // scope 0 at $DIR/lower_array_len.rs:19:15: 19:20
+-         _10 = Len((*_2));                // scope 0 at $DIR/lower_array_len.rs:19:9: 19:21
++         _10 = const N;                   // scope 0 at $DIR/lower_array_len.rs:19:9: 19:21
+          _11 = Lt(_9, _10);               // scope 0 at $DIR/lower_array_len.rs:19:9: 19:21
+          assert(move _11, "index out of bounds: the length is {} but the index is {}", move _10, _9) -> bb2; // scope 0 at $DIR/lower_array_len.rs:19:9: 19:21
       }
   
       bb2: {
-          _0 = (*_2)[_8];                  // scope 0 at $DIR/lower_array_len.rs:19:9: 19:21
-          StorageDead(_8);                 // scope 0 at $DIR/lower_array_len.rs:20:5: 20:6
+          _0 = (*_2)[_9];                  // scope 0 at $DIR/lower_array_len.rs:19:9: 19:21
+          StorageDead(_9);                 // scope 0 at $DIR/lower_array_len.rs:20:5: 20:6
           goto -> bb5;                     // scope 0 at $DIR/lower_array_len.rs:18:5: 24:6
       }
   
       bb3: {
-          StorageLive(_11);                // scope 0 at $DIR/lower_array_len.rs:21:15: 21:16
-          _11 = const 0_usize;             // scope 0 at $DIR/lower_array_len.rs:21:15: 21:16
--         _12 = Len((*_2));                // scope 0 at $DIR/lower_array_len.rs:21:9: 21:17
-+         _12 = const N;                   // scope 0 at $DIR/lower_array_len.rs:21:9: 21:17
-          _13 = Lt(_11, _12);              // scope 0 at $DIR/lower_array_len.rs:21:9: 21:17
-          assert(move _13, "index out of bounds: the length is {} but the index is {}", move _12, _11) -> bb4; // scope 0 at $DIR/lower_array_len.rs:21:9: 21:17
+          StorageLive(_12);                // scope 0 at $DIR/lower_array_len.rs:21:15: 21:16
+          _12 = const 0_usize;             // scope 0 at $DIR/lower_array_len.rs:21:15: 21:16
+-         _13 = Len((*_2));                // scope 0 at $DIR/lower_array_len.rs:21:9: 21:17
++         _13 = const N;                   // scope 0 at $DIR/lower_array_len.rs:21:9: 21:17
+          _14 = Lt(_12, _13);              // scope 0 at $DIR/lower_array_len.rs:21:9: 21:17
+          assert(move _14, "index out of bounds: the length is {} but the index is {}", move _13, _12) -> bb4; // scope 0 at $DIR/lower_array_len.rs:21:9: 21:17
       }
   
       bb4: {
-          (*_2)[_11] = const 42_u8;        // scope 0 at $DIR/lower_array_len.rs:21:9: 21:22
-          StorageDead(_11);                // scope 0 at $DIR/lower_array_len.rs:21:22: 21:23
+          (*_2)[_12] = const 42_u8;        // scope 0 at $DIR/lower_array_len.rs:21:9: 21:22
+          StorageDead(_12);                // scope 0 at $DIR/lower_array_len.rs:21:22: 21:23
           _0 = const 42_u8;                // scope 0 at $DIR/lower_array_len.rs:23:9: 23:11
           goto -> bb5;                     // scope 0 at $DIR/lower_array_len.rs:18:5: 24:6
       }

--- a/src/test/mir-opt/lower_array_len.array_bound_mut.NormalizeArrayLen.diff
+++ b/src/test/mir-opt/lower_array_len.array_bound_mut.NormalizeArrayLen.diff
@@ -9,14 +9,14 @@
       let mut _4: usize;                   // in scope 0 at $DIR/lower_array_len.rs:18:8: 18:13
       let mut _5: usize;                   // in scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
       let mut _6: &[u8];                   // in scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
-      let mut _7: &[u8; N];                // in scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
-      let _8: usize;                       // in scope 0 at $DIR/lower_array_len.rs:19:15: 19:20
-      let mut _9: usize;                   // in scope 0 at $DIR/lower_array_len.rs:19:9: 19:21
-      let mut _10: bool;                   // in scope 0 at $DIR/lower_array_len.rs:19:9: 19:21
-      let _11: usize;                      // in scope 0 at $DIR/lower_array_len.rs:21:15: 21:16
-      let mut _12: usize;                  // in scope 0 at $DIR/lower_array_len.rs:21:9: 21:17
-      let mut _13: bool;                   // in scope 0 at $DIR/lower_array_len.rs:21:9: 21:17
-+     let mut _14: &[u8; N];               // in scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
+      let _7: &[u8];                       // in scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
+      let mut _8: &[u8; N];                // in scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
+      let _9: usize;                       // in scope 0 at $DIR/lower_array_len.rs:19:15: 19:20
+      let mut _10: usize;                  // in scope 0 at $DIR/lower_array_len.rs:19:9: 19:21
+      let mut _11: bool;                   // in scope 0 at $DIR/lower_array_len.rs:19:9: 19:21
+      let _12: usize;                      // in scope 0 at $DIR/lower_array_len.rs:21:15: 21:16
+      let mut _13: usize;                  // in scope 0 at $DIR/lower_array_len.rs:21:9: 21:17
+      let mut _14: bool;                   // in scope 0 at $DIR/lower_array_len.rs:21:9: 21:17
   
       bb0: {
           StorageLive(_3);                 // scope 0 at $DIR/lower_array_len.rs:18:8: 18:27
@@ -25,50 +25,49 @@
           StorageLive(_5);                 // scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
           StorageLive(_6);                 // scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
           StorageLive(_7);                 // scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
-          _7 = &(*_2);                     // scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
-+         StorageLive(_14);                // scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
-+         _14 = _7;                        // scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
-          _6 = move _7 as &[u8] (Pointer(Unsize)); // scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
-          StorageDead(_7);                 // scope 0 at $DIR/lower_array_len.rs:18:20: 18:21
--         _5 = Len((*_6));                 // scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
-+         _5 = Len((*_14));                // scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
-+         StorageDead(_14);                // scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
+          StorageLive(_8);                 // scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
+          _8 = &(*_2);                     // scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
+          _7 = move _8 as &[u8] (Pointer(Unsize)); // scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
+          _6 = &(*_7);                     // scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
+          StorageDead(_8);                 // scope 0 at $DIR/lower_array_len.rs:18:20: 18:21
+          _5 = Len((*_6));                 // scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
           goto -> bb1;                     // scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
       }
   
       bb1: {
           StorageDead(_6);                 // scope 0 at $DIR/lower_array_len.rs:18:26: 18:27
           _3 = Lt(move _4, move _5);       // scope 0 at $DIR/lower_array_len.rs:18:8: 18:27
+          StorageDead(_7);                 // scope 0 at $DIR/lower_array_len.rs:18:26: 18:27
           StorageDead(_5);                 // scope 0 at $DIR/lower_array_len.rs:18:26: 18:27
           StorageDead(_4);                 // scope 0 at $DIR/lower_array_len.rs:18:26: 18:27
           switchInt(move _3) -> [false: bb4, otherwise: bb2]; // scope 0 at $DIR/lower_array_len.rs:18:8: 18:27
       }
   
       bb2: {
-          StorageLive(_8);                 // scope 0 at $DIR/lower_array_len.rs:19:15: 19:20
-          _8 = _1;                         // scope 0 at $DIR/lower_array_len.rs:19:15: 19:20
-          _9 = Len((*_2));                 // scope 0 at $DIR/lower_array_len.rs:19:9: 19:21
-          _10 = Lt(_8, _9);                // scope 0 at $DIR/lower_array_len.rs:19:9: 19:21
-          assert(move _10, "index out of bounds: the length is {} but the index is {}", move _9, _8) -> bb3; // scope 0 at $DIR/lower_array_len.rs:19:9: 19:21
+          StorageLive(_9);                 // scope 0 at $DIR/lower_array_len.rs:19:15: 19:20
+          _9 = _1;                         // scope 0 at $DIR/lower_array_len.rs:19:15: 19:20
+          _10 = Len((*_2));                // scope 0 at $DIR/lower_array_len.rs:19:9: 19:21
+          _11 = Lt(_9, _10);               // scope 0 at $DIR/lower_array_len.rs:19:9: 19:21
+          assert(move _11, "index out of bounds: the length is {} but the index is {}", move _10, _9) -> bb3; // scope 0 at $DIR/lower_array_len.rs:19:9: 19:21
       }
   
       bb3: {
-          _0 = (*_2)[_8];                  // scope 0 at $DIR/lower_array_len.rs:19:9: 19:21
-          StorageDead(_8);                 // scope 0 at $DIR/lower_array_len.rs:20:5: 20:6
+          _0 = (*_2)[_9];                  // scope 0 at $DIR/lower_array_len.rs:19:9: 19:21
+          StorageDead(_9);                 // scope 0 at $DIR/lower_array_len.rs:20:5: 20:6
           goto -> bb6;                     // scope 0 at $DIR/lower_array_len.rs:18:5: 24:6
       }
   
       bb4: {
-          StorageLive(_11);                // scope 0 at $DIR/lower_array_len.rs:21:15: 21:16
-          _11 = const 0_usize;             // scope 0 at $DIR/lower_array_len.rs:21:15: 21:16
-          _12 = Len((*_2));                // scope 0 at $DIR/lower_array_len.rs:21:9: 21:17
-          _13 = Lt(_11, _12);              // scope 0 at $DIR/lower_array_len.rs:21:9: 21:17
-          assert(move _13, "index out of bounds: the length is {} but the index is {}", move _12, _11) -> bb5; // scope 0 at $DIR/lower_array_len.rs:21:9: 21:17
+          StorageLive(_12);                // scope 0 at $DIR/lower_array_len.rs:21:15: 21:16
+          _12 = const 0_usize;             // scope 0 at $DIR/lower_array_len.rs:21:15: 21:16
+          _13 = Len((*_2));                // scope 0 at $DIR/lower_array_len.rs:21:9: 21:17
+          _14 = Lt(_12, _13);              // scope 0 at $DIR/lower_array_len.rs:21:9: 21:17
+          assert(move _14, "index out of bounds: the length is {} but the index is {}", move _13, _12) -> bb5; // scope 0 at $DIR/lower_array_len.rs:21:9: 21:17
       }
   
       bb5: {
-          (*_2)[_11] = const 42_u8;        // scope 0 at $DIR/lower_array_len.rs:21:9: 21:22
-          StorageDead(_11);                // scope 0 at $DIR/lower_array_len.rs:21:22: 21:23
+          (*_2)[_12] = const 42_u8;        // scope 0 at $DIR/lower_array_len.rs:21:9: 21:22
+          StorageDead(_12);                // scope 0 at $DIR/lower_array_len.rs:21:22: 21:23
           _0 = const 42_u8;                // scope 0 at $DIR/lower_array_len.rs:23:9: 23:11
           goto -> bb6;                     // scope 0 at $DIR/lower_array_len.rs:18:5: 24:6
       }

--- a/src/test/mir-opt/lower_array_len.array_bound_mut.SimplifyLocals.diff
+++ b/src/test/mir-opt/lower_array_len.array_bound_mut.SimplifyLocals.diff
@@ -8,82 +8,62 @@
       let mut _3: bool;                    // in scope 0 at $DIR/lower_array_len.rs:18:8: 18:27
       let mut _4: usize;                   // in scope 0 at $DIR/lower_array_len.rs:18:8: 18:13
       let mut _5: usize;                   // in scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
--     let mut _6: &[u8];                   // in scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
--     let mut _7: &[u8; N];                // in scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
--     let _8: usize;                       // in scope 0 at $DIR/lower_array_len.rs:19:15: 19:20
--     let mut _9: usize;                   // in scope 0 at $DIR/lower_array_len.rs:19:9: 19:21
--     let mut _10: bool;                   // in scope 0 at $DIR/lower_array_len.rs:19:9: 19:21
--     let _11: usize;                      // in scope 0 at $DIR/lower_array_len.rs:21:15: 21:16
--     let mut _12: usize;                  // in scope 0 at $DIR/lower_array_len.rs:21:9: 21:17
--     let mut _13: bool;                   // in scope 0 at $DIR/lower_array_len.rs:21:9: 21:17
--     let mut _14: &[u8; N];               // in scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
-+     let _6: usize;                       // in scope 0 at $DIR/lower_array_len.rs:19:15: 19:20
-+     let mut _7: usize;                   // in scope 0 at $DIR/lower_array_len.rs:19:9: 19:21
-+     let mut _8: bool;                    // in scope 0 at $DIR/lower_array_len.rs:19:9: 19:21
-+     let _9: usize;                       // in scope 0 at $DIR/lower_array_len.rs:21:15: 21:16
-+     let mut _10: usize;                  // in scope 0 at $DIR/lower_array_len.rs:21:9: 21:17
-+     let mut _11: bool;                   // in scope 0 at $DIR/lower_array_len.rs:21:9: 21:17
+      let mut _6: &[u8];                   // in scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
+      let _7: &[u8];                       // in scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
+      let mut _8: &[u8; N];                // in scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
+      let _9: usize;                       // in scope 0 at $DIR/lower_array_len.rs:19:15: 19:20
+      let mut _10: usize;                  // in scope 0 at $DIR/lower_array_len.rs:19:9: 19:21
+      let mut _11: bool;                   // in scope 0 at $DIR/lower_array_len.rs:19:9: 19:21
+      let _12: usize;                      // in scope 0 at $DIR/lower_array_len.rs:21:15: 21:16
+      let mut _13: usize;                  // in scope 0 at $DIR/lower_array_len.rs:21:9: 21:17
+      let mut _14: bool;                   // in scope 0 at $DIR/lower_array_len.rs:21:9: 21:17
   
       bb0: {
           StorageLive(_3);                 // scope 0 at $DIR/lower_array_len.rs:18:8: 18:27
           StorageLive(_4);                 // scope 0 at $DIR/lower_array_len.rs:18:8: 18:13
           _4 = _1;                         // scope 0 at $DIR/lower_array_len.rs:18:8: 18:13
           StorageLive(_5);                 // scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
--         StorageLive(_6);                 // scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
--         StorageLive(_7);                 // scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
--         _7 = &(*_2);                     // scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
--         StorageLive(_14);                // scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
--         _14 = _7;                        // scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
--         _6 = move _7 as &[u8] (Pointer(Unsize)); // scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
--         StorageDead(_7);                 // scope 0 at $DIR/lower_array_len.rs:18:20: 18:21
-          _5 = const N;                    // scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
--         StorageDead(_14);                // scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
--         StorageDead(_6);                 // scope 0 at $DIR/lower_array_len.rs:18:26: 18:27
+          StorageLive(_6);                 // scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
+          StorageLive(_7);                 // scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
+          StorageLive(_8);                 // scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
+          _8 = &(*_2);                     // scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
+          _7 = move _8 as &[u8] (Pointer(Unsize)); // scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
+          _6 = _7;                         // scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
+          StorageDead(_8);                 // scope 0 at $DIR/lower_array_len.rs:18:20: 18:21
+          _5 = Len((*_6));                 // scope 0 at $DIR/lower_array_len.rs:18:16: 18:27
+          StorageDead(_6);                 // scope 0 at $DIR/lower_array_len.rs:18:26: 18:27
           _3 = Lt(move _4, move _5);       // scope 0 at $DIR/lower_array_len.rs:18:8: 18:27
+          StorageDead(_7);                 // scope 0 at $DIR/lower_array_len.rs:18:26: 18:27
           StorageDead(_5);                 // scope 0 at $DIR/lower_array_len.rs:18:26: 18:27
           StorageDead(_4);                 // scope 0 at $DIR/lower_array_len.rs:18:26: 18:27
           switchInt(move _3) -> [false: bb3, otherwise: bb1]; // scope 0 at $DIR/lower_array_len.rs:18:8: 18:27
       }
   
       bb1: {
--         StorageLive(_8);                 // scope 0 at $DIR/lower_array_len.rs:19:15: 19:20
--         _8 = _1;                         // scope 0 at $DIR/lower_array_len.rs:19:15: 19:20
--         _9 = const N;                    // scope 0 at $DIR/lower_array_len.rs:19:9: 19:21
--         _10 = Lt(_8, _9);                // scope 0 at $DIR/lower_array_len.rs:19:9: 19:21
--         assert(move _10, "index out of bounds: the length is {} but the index is {}", move _9, _8) -> bb2; // scope 0 at $DIR/lower_array_len.rs:19:9: 19:21
-+         StorageLive(_6);                 // scope 0 at $DIR/lower_array_len.rs:19:15: 19:20
-+         _6 = _1;                         // scope 0 at $DIR/lower_array_len.rs:19:15: 19:20
-+         _7 = const N;                    // scope 0 at $DIR/lower_array_len.rs:19:9: 19:21
-+         _8 = Lt(_6, _7);                 // scope 0 at $DIR/lower_array_len.rs:19:9: 19:21
-+         assert(move _8, "index out of bounds: the length is {} but the index is {}", move _7, _6) -> bb2; // scope 0 at $DIR/lower_array_len.rs:19:9: 19:21
+          StorageLive(_9);                 // scope 0 at $DIR/lower_array_len.rs:19:15: 19:20
+          _9 = _1;                         // scope 0 at $DIR/lower_array_len.rs:19:15: 19:20
+          _10 = const N;                   // scope 0 at $DIR/lower_array_len.rs:19:9: 19:21
+          _11 = Lt(_9, _10);               // scope 0 at $DIR/lower_array_len.rs:19:9: 19:21
+          assert(move _11, "index out of bounds: the length is {} but the index is {}", move _10, _9) -> bb2; // scope 0 at $DIR/lower_array_len.rs:19:9: 19:21
       }
   
       bb2: {
--         _0 = (*_2)[_8];                  // scope 0 at $DIR/lower_array_len.rs:19:9: 19:21
--         StorageDead(_8);                 // scope 0 at $DIR/lower_array_len.rs:20:5: 20:6
-+         _0 = (*_2)[_6];                  // scope 0 at $DIR/lower_array_len.rs:19:9: 19:21
-+         StorageDead(_6);                 // scope 0 at $DIR/lower_array_len.rs:20:5: 20:6
+          _0 = (*_2)[_9];                  // scope 0 at $DIR/lower_array_len.rs:19:9: 19:21
+          StorageDead(_9);                 // scope 0 at $DIR/lower_array_len.rs:20:5: 20:6
           goto -> bb5;                     // scope 0 at $DIR/lower_array_len.rs:18:5: 24:6
       }
   
       bb3: {
--         StorageLive(_11);                // scope 0 at $DIR/lower_array_len.rs:21:15: 21:16
--         _11 = const 0_usize;             // scope 0 at $DIR/lower_array_len.rs:21:15: 21:16
--         _12 = const N;                   // scope 0 at $DIR/lower_array_len.rs:21:9: 21:17
--         _13 = Lt(const 0_usize, _12);    // scope 0 at $DIR/lower_array_len.rs:21:9: 21:17
--         assert(move _13, "index out of bounds: the length is {} but the index is {}", move _12, const 0_usize) -> bb4; // scope 0 at $DIR/lower_array_len.rs:21:9: 21:17
-+         StorageLive(_9);                 // scope 0 at $DIR/lower_array_len.rs:21:15: 21:16
-+         _9 = const 0_usize;              // scope 0 at $DIR/lower_array_len.rs:21:15: 21:16
-+         _10 = const N;                   // scope 0 at $DIR/lower_array_len.rs:21:9: 21:17
-+         _11 = Lt(const 0_usize, _10);    // scope 0 at $DIR/lower_array_len.rs:21:9: 21:17
-+         assert(move _11, "index out of bounds: the length is {} but the index is {}", move _10, const 0_usize) -> bb4; // scope 0 at $DIR/lower_array_len.rs:21:9: 21:17
+          StorageLive(_12);                // scope 0 at $DIR/lower_array_len.rs:21:15: 21:16
+          _12 = const 0_usize;             // scope 0 at $DIR/lower_array_len.rs:21:15: 21:16
+          _13 = const N;                   // scope 0 at $DIR/lower_array_len.rs:21:9: 21:17
+          _14 = Lt(const 0_usize, _13);    // scope 0 at $DIR/lower_array_len.rs:21:9: 21:17
+          assert(move _14, "index out of bounds: the length is {} but the index is {}", move _13, const 0_usize) -> bb4; // scope 0 at $DIR/lower_array_len.rs:21:9: 21:17
       }
   
       bb4: {
--         (*_2)[_11] = const 42_u8;        // scope 0 at $DIR/lower_array_len.rs:21:9: 21:22
--         StorageDead(_11);                // scope 0 at $DIR/lower_array_len.rs:21:22: 21:23
-+         (*_2)[_9] = const 42_u8;         // scope 0 at $DIR/lower_array_len.rs:21:9: 21:22
-+         StorageDead(_9);                 // scope 0 at $DIR/lower_array_len.rs:21:22: 21:23
+          (*_2)[_12] = const 42_u8;        // scope 0 at $DIR/lower_array_len.rs:21:9: 21:22
+          StorageDead(_12);                // scope 0 at $DIR/lower_array_len.rs:21:22: 21:23
           _0 = const 42_u8;                // scope 0 at $DIR/lower_array_len.rs:23:9: 23:11
           goto -> bb5;                     // scope 0 at $DIR/lower_array_len.rs:18:5: 24:6
       }

--- a/src/test/mir-opt/lower_array_len.array_len.InstCombine.diff
+++ b/src/test/mir-opt/lower_array_len.array_len.InstCombine.diff
@@ -5,22 +5,22 @@
       debug arr => _1;                     // in scope 0 at $DIR/lower_array_len.rs:30:34: 30:37
       let mut _0: usize;                   // return place in scope 0 at $DIR/lower_array_len.rs:30:52: 30:57
       let mut _2: &[u8];                   // in scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
-      let mut _3: &[u8; N];                // in scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
+      let _3: &[u8];                       // in scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
       let mut _4: &[u8; N];                // in scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
   
       bb0: {
           StorageLive(_2);                 // scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
           StorageLive(_3);                 // scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
--         _3 = &(*_1);                     // scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
-+         _3 = _1;                         // scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
           StorageLive(_4);                 // scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
-          _4 = _3;                         // scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
-          _2 = move _3 as &[u8] (Pointer(Unsize)); // scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
-          StorageDead(_3);                 // scope 0 at $DIR/lower_array_len.rs:31:7: 31:8
--         _0 = Len((*_4));                 // scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
-+         _0 = const N;                    // scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
-          StorageDead(_4);                 // scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
+-         _4 = &(*_1);                     // scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
++         _4 = _1;                         // scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
+          _3 = move _4 as &[u8] (Pointer(Unsize)); // scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
+-         _2 = &(*_3);                     // scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
++         _2 = _3;                         // scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
+          StorageDead(_4);                 // scope 0 at $DIR/lower_array_len.rs:31:7: 31:8
+          _0 = Len((*_2));                 // scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
           StorageDead(_2);                 // scope 0 at $DIR/lower_array_len.rs:31:13: 31:14
+          StorageDead(_3);                 // scope 0 at $DIR/lower_array_len.rs:32:1: 32:2
           return;                          // scope 0 at $DIR/lower_array_len.rs:32:2: 32:2
       }
   }

--- a/src/test/mir-opt/lower_array_len.array_len.NormalizeArrayLen.diff
+++ b/src/test/mir-opt/lower_array_len.array_len.NormalizeArrayLen.diff
@@ -5,25 +5,24 @@
       debug arr => _1;                     // in scope 0 at $DIR/lower_array_len.rs:30:34: 30:37
       let mut _0: usize;                   // return place in scope 0 at $DIR/lower_array_len.rs:30:52: 30:57
       let mut _2: &[u8];                   // in scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
-      let mut _3: &[u8; N];                // in scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
-+     let mut _4: &[u8; N];                // in scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
+      let _3: &[u8];                       // in scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
+      let mut _4: &[u8; N];                // in scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
   
       bb0: {
           StorageLive(_2);                 // scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
           StorageLive(_3);                 // scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
-          _3 = &(*_1);                     // scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
-+         StorageLive(_4);                 // scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
-+         _4 = _3;                         // scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
-          _2 = move _3 as &[u8] (Pointer(Unsize)); // scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
-          StorageDead(_3);                 // scope 0 at $DIR/lower_array_len.rs:31:7: 31:8
--         _0 = Len((*_2));                 // scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
-+         _0 = Len((*_4));                 // scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
-+         StorageDead(_4);                 // scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
+          StorageLive(_4);                 // scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
+          _4 = &(*_1);                     // scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
+          _3 = move _4 as &[u8] (Pointer(Unsize)); // scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
+          _2 = &(*_3);                     // scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
+          StorageDead(_4);                 // scope 0 at $DIR/lower_array_len.rs:31:7: 31:8
+          _0 = Len((*_2));                 // scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
           goto -> bb1;                     // scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
       }
   
       bb1: {
           StorageDead(_2);                 // scope 0 at $DIR/lower_array_len.rs:31:13: 31:14
+          StorageDead(_3);                 // scope 0 at $DIR/lower_array_len.rs:32:1: 32:2
           return;                          // scope 0 at $DIR/lower_array_len.rs:32:2: 32:2
       }
   }

--- a/src/test/mir-opt/lower_array_len.array_len.SimplifyLocals.diff
+++ b/src/test/mir-opt/lower_array_len.array_len.SimplifyLocals.diff
@@ -4,21 +4,21 @@
   fn array_len(_1: &[u8; N]) -> usize {
       debug arr => _1;                     // in scope 0 at $DIR/lower_array_len.rs:30:34: 30:37
       let mut _0: usize;                   // return place in scope 0 at $DIR/lower_array_len.rs:30:52: 30:57
--     let mut _2: &[u8];                   // in scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
--     let mut _3: &[u8; N];                // in scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
--     let mut _4: &[u8; N];                // in scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
+      let mut _2: &[u8];                   // in scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
+      let _3: &[u8];                       // in scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
+      let mut _4: &[u8; N];                // in scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
   
       bb0: {
--         StorageLive(_2);                 // scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
--         StorageLive(_3);                 // scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
--         _3 = _1;                         // scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
--         StorageLive(_4);                 // scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
--         _4 = _3;                         // scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
--         _2 = move _3 as &[u8] (Pointer(Unsize)); // scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
--         StorageDead(_3);                 // scope 0 at $DIR/lower_array_len.rs:31:7: 31:8
-          _0 = const N;                    // scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
--         StorageDead(_4);                 // scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
--         StorageDead(_2);                 // scope 0 at $DIR/lower_array_len.rs:31:13: 31:14
+          StorageLive(_2);                 // scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
+          StorageLive(_3);                 // scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
+          StorageLive(_4);                 // scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
+          _4 = _1;                         // scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
+          _3 = move _4 as &[u8] (Pointer(Unsize)); // scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
+          _2 = _3;                         // scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
+          StorageDead(_4);                 // scope 0 at $DIR/lower_array_len.rs:31:7: 31:8
+          _0 = Len((*_2));                 // scope 0 at $DIR/lower_array_len.rs:31:5: 31:14
+          StorageDead(_2);                 // scope 0 at $DIR/lower_array_len.rs:31:13: 31:14
+          StorageDead(_3);                 // scope 0 at $DIR/lower_array_len.rs:32:1: 32:2
           return;                          // scope 0 at $DIR/lower_array_len.rs:32:2: 32:2
       }
   }

--- a/src/test/mir-opt/lower_array_len.array_len_by_value.InstCombine.diff
+++ b/src/test/mir-opt/lower_array_len.array_len_by_value.InstCombine.diff
@@ -5,21 +5,21 @@
       debug arr => _1;                     // in scope 0 at $DIR/lower_array_len.rs:37:43: 37:46
       let mut _0: usize;                   // return place in scope 0 at $DIR/lower_array_len.rs:37:60: 37:65
       let mut _2: &[u8];                   // in scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
-      let mut _3: &[u8; N];                // in scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
+      let _3: &[u8];                       // in scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
       let mut _4: &[u8; N];                // in scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
   
       bb0: {
           StorageLive(_2);                 // scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
           StorageLive(_3);                 // scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
-          _3 = &_1;                        // scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
           StorageLive(_4);                 // scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
-          _4 = _3;                         // scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
-          _2 = move _3 as &[u8] (Pointer(Unsize)); // scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
-          StorageDead(_3);                 // scope 0 at $DIR/lower_array_len.rs:38:7: 38:8
--         _0 = Len((*_4));                 // scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
-+         _0 = const N;                    // scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
-          StorageDead(_4);                 // scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
+          _4 = &_1;                        // scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
+          _3 = move _4 as &[u8] (Pointer(Unsize)); // scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
+-         _2 = &(*_3);                     // scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
++         _2 = _3;                         // scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
+          StorageDead(_4);                 // scope 0 at $DIR/lower_array_len.rs:38:7: 38:8
+          _0 = Len((*_2));                 // scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
           StorageDead(_2);                 // scope 0 at $DIR/lower_array_len.rs:38:13: 38:14
+          StorageDead(_3);                 // scope 0 at $DIR/lower_array_len.rs:39:1: 39:2
           return;                          // scope 0 at $DIR/lower_array_len.rs:39:2: 39:2
       }
   }

--- a/src/test/mir-opt/lower_array_len.array_len_by_value.NormalizeArrayLen.diff
+++ b/src/test/mir-opt/lower_array_len.array_len_by_value.NormalizeArrayLen.diff
@@ -5,25 +5,24 @@
       debug arr => _1;                     // in scope 0 at $DIR/lower_array_len.rs:37:43: 37:46
       let mut _0: usize;                   // return place in scope 0 at $DIR/lower_array_len.rs:37:60: 37:65
       let mut _2: &[u8];                   // in scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
-      let mut _3: &[u8; N];                // in scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
-+     let mut _4: &[u8; N];                // in scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
+      let _3: &[u8];                       // in scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
+      let mut _4: &[u8; N];                // in scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
   
       bb0: {
           StorageLive(_2);                 // scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
           StorageLive(_3);                 // scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
-          _3 = &_1;                        // scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
-+         StorageLive(_4);                 // scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
-+         _4 = _3;                         // scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
-          _2 = move _3 as &[u8] (Pointer(Unsize)); // scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
-          StorageDead(_3);                 // scope 0 at $DIR/lower_array_len.rs:38:7: 38:8
--         _0 = Len((*_2));                 // scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
-+         _0 = Len((*_4));                 // scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
-+         StorageDead(_4);                 // scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
+          StorageLive(_4);                 // scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
+          _4 = &_1;                        // scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
+          _3 = move _4 as &[u8] (Pointer(Unsize)); // scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
+          _2 = &(*_3);                     // scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
+          StorageDead(_4);                 // scope 0 at $DIR/lower_array_len.rs:38:7: 38:8
+          _0 = Len((*_2));                 // scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
           goto -> bb1;                     // scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
       }
   
       bb1: {
           StorageDead(_2);                 // scope 0 at $DIR/lower_array_len.rs:38:13: 38:14
+          StorageDead(_3);                 // scope 0 at $DIR/lower_array_len.rs:39:1: 39:2
           return;                          // scope 0 at $DIR/lower_array_len.rs:39:2: 39:2
       }
   }

--- a/src/test/mir-opt/lower_array_len.array_len_by_value.SimplifyLocals.diff
+++ b/src/test/mir-opt/lower_array_len.array_len_by_value.SimplifyLocals.diff
@@ -4,21 +4,21 @@
   fn array_len_by_value(_1: [u8; N]) -> usize {
       debug arr => _1;                     // in scope 0 at $DIR/lower_array_len.rs:37:43: 37:46
       let mut _0: usize;                   // return place in scope 0 at $DIR/lower_array_len.rs:37:60: 37:65
--     let mut _2: &[u8];                   // in scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
--     let mut _3: &[u8; N];                // in scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
--     let mut _4: &[u8; N];                // in scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
+      let mut _2: &[u8];                   // in scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
+      let _3: &[u8];                       // in scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
+      let mut _4: &[u8; N];                // in scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
   
       bb0: {
--         StorageLive(_2);                 // scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
--         StorageLive(_3);                 // scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
--         _3 = &_1;                        // scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
--         StorageLive(_4);                 // scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
--         _4 = _3;                         // scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
--         _2 = move _3 as &[u8] (Pointer(Unsize)); // scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
--         StorageDead(_3);                 // scope 0 at $DIR/lower_array_len.rs:38:7: 38:8
-          _0 = const N;                    // scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
--         StorageDead(_4);                 // scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
--         StorageDead(_2);                 // scope 0 at $DIR/lower_array_len.rs:38:13: 38:14
+          StorageLive(_2);                 // scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
+          StorageLive(_3);                 // scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
+          StorageLive(_4);                 // scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
+          _4 = &_1;                        // scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
+          _3 = move _4 as &[u8] (Pointer(Unsize)); // scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
+          _2 = _3;                         // scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
+          StorageDead(_4);                 // scope 0 at $DIR/lower_array_len.rs:38:7: 38:8
+          _0 = Len((*_2));                 // scope 0 at $DIR/lower_array_len.rs:38:5: 38:14
+          StorageDead(_2);                 // scope 0 at $DIR/lower_array_len.rs:38:13: 38:14
+          StorageDead(_3);                 // scope 0 at $DIR/lower_array_len.rs:39:1: 39:2
           return;                          // scope 0 at $DIR/lower_array_len.rs:39:2: 39:2
       }
   }

--- a/src/test/ui/autoref-autoderef/deref-into-array.rs
+++ b/src/test/ui/autoref-autoderef/deref-into-array.rs
@@ -1,0 +1,17 @@
+// check-pass
+
+struct Test<T>([T; 1]);
+
+impl<T> std::ops::Deref for Test<T> {
+    type Target = [T; 1];
+
+    fn deref(&self) -> &[T; 1] {
+        &self.0
+    }
+}
+
+fn main() {
+    let out = Test([(); 1]);
+    let blah = out.len();
+    println!("{}", blah);
+}

--- a/src/test/ui/coercion/issue-73886.rs
+++ b/src/test/ui/coercion/issue-73886.rs
@@ -1,6 +1,4 @@
 fn main() {
-    let _ = &&[0] as &[_];
-    //~^ ERROR non-primitive cast: `&&[i32; 1]` as `&[_]`
     let _ = 7u32 as Option<_>;
     //~^ ERROR non-primitive cast: `u32` as `Option<_>`
 }

--- a/src/test/ui/coercion/issue-73886.stderr
+++ b/src/test/ui/coercion/issue-73886.stderr
@@ -1,17 +1,11 @@
-error[E0605]: non-primitive cast: `&&[i32; 1]` as `&[_]`
-  --> $DIR/issue-73886.rs:2:13
-   |
-LL |     let _ = &&[0] as &[_];
-   |             ^^^^^^^^^^^^^ an `as` expression can only be used to convert between primitive types or to coerce to a specific trait object
-
 error[E0605]: non-primitive cast: `u32` as `Option<_>`
-  --> $DIR/issue-73886.rs:4:13
+  --> $DIR/issue-73886.rs:2:13
    |
 LL |     let _ = 7u32 as Option<_>;
    |             ^^^^^^^^^^^^^^^^^ help: consider using the `From` trait instead: `Option<_>::from(7u32)`
    |
    = note: an `as` expression can only be used to convert between primitive types or to coerce to a specific trait object
 
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0605`.

--- a/src/test/ui/const-generics/deref-into-array-generic.rs
+++ b/src/test/ui/const-generics/deref-into-array-generic.rs
@@ -1,0 +1,27 @@
+// check-pass
+
+struct Test<T, const N: usize>([T; N]);
+
+impl<T: Copy + Default, const N: usize> Default for Test<T, N> {
+    fn default() -> Self {
+        Self([T::default(); N])
+    }
+}
+
+impl<T, const N: usize> std::ops::Deref for Test<T, N> {
+    type Target = [T; N];
+
+    fn deref(&self) -> &[T; N] {
+        &self.0
+    }
+}
+
+fn test() -> Test<u64, 16> {
+    let test = Test::default();
+    println!("{}", test.len());
+    test
+}
+
+fn main() {
+    test();
+}


### PR DESCRIPTION
1. Stash a const infer's type into the canonical var during canonicalization, so we can recreate the fresh const infer with that same type. 
    For example, given `[T; _]` we know `_` is a `usize`. If we go from infer => canonical => infer, we shouldn't forget that variable is a usize.
Fixes #92626
Fixes #83704

2. Implement `Deref` for `[T; N]` which allows us to remove some custom array unsizing logic that was leaking an inference variable during method selection.
Fixes #92637

r? @lcnr 