### PR TITLE
Add feature "strict-align" for RustHermit

### DIFF
--- a/compiler/rustc_target/src/spec/aarch64_unknown_hermit.rs
+++ b/compiler/rustc_target/src/spec/aarch64_unknown_hermit.rs
@@ -3,6 +3,7 @@ use crate::spec::Target;
 pub fn target() -> Target {
     let mut base = super::hermit_base::opts();
     base.max_atomic_width = Some(128);
+    base.features: "+strict-align,+neon,+fp-armv8".to_string();
 
     Target {
         llvm_target: "aarch64-unknown-hermit".to_string(),

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -1082,9 +1082,6 @@ impl Attributes {
         let mut out = String::new();
         add_doc_fragment(&mut out, ori);
         for new_frag in iter {
-            if new_frag.kind != ori.kind || new_frag.parent_module != ori.parent_module {
-                break;
-            }
             add_doc_fragment(&mut out, new_frag);
         }
         out.pop();


### PR DESCRIPTION
Like the target `aarch64-unknown-none` our kernel depends on the feature `strict-align`. Consequently, we want to define it per default in the target specification.