### PR TITLE
Make `Atomic*::from_mut` return `&mut Atomic*`

### DIFF
--- a/library/core/src/sync/atomic.rs
+++ b/library/core/src/sync/atomic.rs
@@ -333,10 +333,10 @@ impl AtomicBool {
     #[inline]
     #[cfg(target_has_atomic_equal_alignment = "8")]
     #[unstable(feature = "atomic_from_mut", issue = "76314")]
-    pub fn from_mut(v: &mut bool) -> &Self {
+    pub fn from_mut(v: &mut bool) -> &mut Self {
         // SAFETY: the mutable reference guarantees unique ownership, and
         // alignment of both `bool` and `Self` is 1.
-        unsafe { &*(v as *mut bool as *mut Self) }
+        unsafe { &mut *(v as *mut bool as *mut Self) }
     }
 
     /// Consumes the atomic and returns the contained value.
@@ -934,14 +934,14 @@ impl<T> AtomicPtr<T> {
     #[inline]
     #[cfg(target_has_atomic_equal_alignment = "ptr")]
     #[unstable(feature = "atomic_from_mut", issue = "76314")]
-    pub fn from_mut(v: &mut *mut T) -> &Self {
+    pub fn from_mut(v: &mut *mut T) -> &mut Self {
         use crate::mem::align_of;
         let [] = [(); align_of::<AtomicPtr<()>>() - align_of::<*mut ()>()];
         // SAFETY:
         //  - the mutable reference guarantees unique ownership.
         //  - the alignment of `*mut T` and `Self` is the same on all platforms
         //    supported by rust, as verified above.
-        unsafe { &*(v as *mut *mut T as *mut Self) }
+        unsafe { &mut *(v as *mut *mut T as *mut Self) }
     }
 
     /// Consumes the atomic and returns the contained value.
@@ -1447,14 +1447,14 @@ macro_rules! atomic_int {
             #[inline]
             #[$cfg_align]
             #[unstable(feature = "atomic_from_mut", issue = "76314")]
-            pub fn from_mut(v: &mut $int_type) -> &Self {
+            pub fn from_mut(v: &mut $int_type) -> &mut Self {
                 use crate::mem::align_of;
                 let [] = [(); align_of::<Self>() - align_of::<$int_type>()];
                 // SAFETY:
                 //  - the mutable reference guarantees unique ownership.
                 //  - the alignment of `$int_type` and `Self` is the
                 //    same, as promised by $cfg_align and verified above.
-                unsafe { &*(v as *mut $int_type as *mut Self) }
+                unsafe { &mut *(v as *mut $int_type as *mut Self) }
             }
 
             /// Consumes the atomic and returns the contained value.


### PR DESCRIPTION
```rust
impl Atomic* {
    pub fn from_mut(v: &mut bool) -> &mut Self;
    //                               ^^^^---- previously was just a &
}
```

This PR makes `from_mut` atomic methods tracked in #76314 return unique references to atomic types, instead of shared ones. This makes `from_mut` and `get_mut` inverses of each other, allowing to undo either of them by the other.

r? @RalfJung 
(as Ralf was [concerned](https://github.com/rust-lang/rust/issues/76314#issuecomment-955062593) about this)