### PR TITLE
Remove useless collapse toggle on "all items" page

### DIFF
--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -312,14 +312,6 @@ impl AllTypes {
         f.write_str(
             "<h1 class=\"fqn\">\
                  <span class=\"in-band\">List of all items</span>\
-                 <span class=\"out-of-band\">\
-                     <span id=\"render-detail\">\
-                         <a id=\"toggle-all-docs\" href=\"javascript:void(0)\" \
-                            title=\"collapse all docs\">\
-                             [<span class=\"inner\">&#x2212;</span>]\
-                         </a>\
-                     </span>
-                 </span>
              </h1>",
         );
         // Note: print_entries does not escape the title, because we know the current set of titles


### PR DESCRIPTION
When clicking on this toggle, nothing happens because there is nothing to collapse. Instead of keeping it around, let's just remove it.

Before:

![Screenshot from 2022-01-08 16-02-38](https://user-images.githubusercontent.com/3050060/148649149-821a1e77-8c34-4975-b50a-984ca8865518.png)

After:

![Screenshot from 2022-01-08 16-02-32](https://user-images.githubusercontent.com/3050060/148649154-b5912a97-9229-46bd-be3c-df3c3fa3ac8f.png)

r? @jsha 