### PR TITLE
rustdoc: Display "private fields" instead of "fields omitted"

### DIFF
--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -1557,7 +1557,7 @@ fn render_union(
     }
 
     if it.has_stripped_fields().unwrap() {
-        write!(w, "    // some fields omitted\n{}", tab);
+        write!(w, "    /* private fields */\n{}", tab);
     }
     if toggle {
         toggle_close(w);
@@ -1613,13 +1613,11 @@ fn render_struct(
 
             if has_visible_fields {
                 if it.has_stripped_fields().unwrap() {
-                    write!(w, "\n{}    // some fields omitted", tab);
+                    write!(w, "\n{}    /* private fields */", tab);
                 }
                 write!(w, "\n{}", tab);
             } else if it.has_stripped_fields().unwrap() {
-                // If there are no visible fields we can just display
-                // `{ /* fields omitted */ }` to save space.
-                write!(w, " /* fields omitted */ ");
+                write!(w, " /* private fields */ ");
             }
             if toggle {
                 toggle_close(w);

--- a/src/test/rustdoc/structfields.rs
+++ b/src/test/rustdoc/structfields.rs
@@ -2,7 +2,7 @@
 pub struct Foo {
     // @has - //pre "pub a: ()"
     pub a: (),
-    // @has - //pre "// some fields omitted"
+    // @has - //pre "/* private fields */"
     // @!has - //pre "b: ()"
     b: (),
     // @!has - //pre "c: usize"
@@ -16,7 +16,7 @@ pub struct Foo {
 pub struct Bar {
     // @has - //pre "pub a: ()"
     pub a: (),
-    // @!has - //pre "// some fields omitted"
+    // @!has - //pre "/* private fields */"
 }
 
 // @has structfields/enum.Qux.html
@@ -29,11 +29,11 @@ pub enum Qux {
         b: (),
         // @has - //pre "c: usize"
         c: usize,
-        // @has - //pre "// some fields omitted"
+        // @has - //pre "/* private fields */"
     },
 }
 
-// @has structfields/struct.Baz.html //pre "pub struct Baz { /* fields omitted */ }"
+// @has structfields/struct.Baz.html //pre "pub struct Baz { /* private fields */ }"
 pub struct Baz {
     x: u8,
     #[doc(hidden)]

--- a/src/test/rustdoc/toggle-item-contents.rs
+++ b/src/test/rustdoc/toggle-item-contents.rs
@@ -55,7 +55,7 @@ pub union Union {
 
 // @has 'toggle_item_contents/struct.PrivStruct.html'
 // @count - '//details[@class="rustdoc-toggle type-contents-toggle"]' 0
-// @has - '//div[@class="docblock item-decl"]' 'fields omitted'
+// @has - '//div[@class="docblock item-decl"]' '/* private fields */'
 pub struct PrivStruct {
     a: usize,
     b: usize,

--- a/src/test/rustdoc/union.rs
+++ b/src/test/rustdoc/union.rs
@@ -2,7 +2,7 @@
 pub union U {
     // @has - //pre "pub a: u8"
     pub a: u8,
-    // @has - //pre "// some fields omitted"
+    // @has - //pre "/* private fields */"
     // @!has - //pre "b: u16"
     b: u16,
 }


### PR DESCRIPTION
Also:

  * Always use `/* */` block comments
  * Use the same message everywhere, rather than sometimes prefixing
    with "some"

When I first read rustdoc docs, I was confused why the fields were being
omitted. It was only later that I realized it was because they were
private. It's also always bothered me that rustdoc sometimes uses `//`
and sometimes uses `/*` comments for these messages, so this change
makes them all use `/*`.

Technically, I think fields can be omitted if they are public but
`doc(hidden)` too, but `doc(hidden)` is analogous to privacy. It's
really just used to emulate "doc privacy" when -- because of technical
limitations -- an item has to be public. So I think it's fine to include
this under the category of "private fields".

r? @jsha 