### PR TITLE
Warn when casting an enum that is fieldless but not C-like

### DIFF
--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -3067,6 +3067,7 @@ declare_lint_pass! {
         DEREF_INTO_DYN_SUPERTRAIT,
         DEPRECATED_CFG_ATTR_CRATE_TYPE_NAME,
         DUPLICATE_MACRO_ATTRIBUTES,
+        NOT_CENUM_CAST,
     ]
 }
 
@@ -3632,4 +3633,44 @@ declare_lint! {
     pub DUPLICATE_MACRO_ATTRIBUTES,
     Warn,
     "duplicated attribute"
+}
+
+declare_lint! {
+    /// The `not_cenum_cast` lint detects an `as` cast of a field-less
+    /// `enum` that is not C-like.
+    ///
+    /// ### Example
+    ///
+    /// ```rust
+    /// # #![allow(unused)]
+    /// enum E {
+    ///     A(),
+    ///     B{},
+    ///     C,
+    /// }
+    ///
+    /// fn main() {
+    ///     let i = E::A() as u32;
+    /// }
+    /// ```
+    ///
+    /// {{produces}}
+    ///
+    /// ### Explanation
+    ///
+    /// Historically we permit casting of enums if none of the variants have
+    /// fields. The intended behaviour is that only C-like (all variants are
+    /// unit variants) enums can be casted this way.
+    ///
+    /// This is a [future-incompatible] lint to transition this to a hard error
+    /// in the future. See [issue #88621] for more details.
+    ///
+    /// [future-incompatible]: ../index.md#future-incompatible-lints
+    /// [issue #88621]: https://github.com/rust-lang/rust/issues/88621
+    pub NOT_CENUM_CAST,
+    Warn,
+    "an enum that is not C-like is cast",
+    @future_incompatible = FutureIncompatibleInfo {
+        reference: "issue #88611 <https://github.com/rust-lang/rust/issues/88621>",
+    };
 }

--- a/compiler/rustc_middle/src/ty/adt.rs
+++ b/compiler/rustc_middle/src/ty/adt.rs
@@ -354,6 +354,20 @@ impl<'tcx> AdtDef {
         self.variants.iter().all(|v| v.fields.is_empty())
     }
 
+    /// Whether all variants have only constant constructors
+    /// (i.e. there are no tuple or struct variants).
+    /// This is distinct from `is_payloadfree` specifically for the case of
+    /// empty tuple constructors, e.g. for:
+    /// ```
+    /// enum Number {
+    ///   Zero(),
+    /// }
+    /// ```
+    /// this function returns false, where `is_payloadfree` returns true.
+    pub fn is_c_like_enum(&self) -> bool {
+        self.is_enum() && self.variants.iter().all(|v| v.ctor_kind == CtorKind::Const)
+    }
+
     /// Return a `VariantDef` given a variant id.
     pub fn variant_with_id(&self, vid: DefId) -> &VariantDef {
         self.variants.iter().find(|v| v.def_id == vid).expect("variant_with_id: unknown variant")

--- a/src/test/ui/cast/not_cenum_cast.rs
+++ b/src/test/ui/cast/not_cenum_cast.rs
@@ -1,0 +1,13 @@
+#![deny(not_cenum_cast)]
+
+enum E {
+    A(),
+    B{},
+    C,
+}
+
+fn main() {
+    let i = E::A() as u32;
+    //~^ ERROR cannot cast enum `E` into integer `u32` because it is not C-like
+    //~| WARN this was previously accepted
+}

--- a/src/test/ui/cast/not_cenum_cast.stderr
+++ b/src/test/ui/cast/not_cenum_cast.stderr
@@ -1,0 +1,16 @@
+error: cannot cast enum `E` into integer `u32` because it is not C-like
+  --> $DIR/not_cenum_cast.rs:10:13
+   |
+LL |     let i = E::A() as u32;
+   |             ^^^^^^^^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/not_cenum_cast.rs:1:9
+   |
+LL | #![deny(not_cenum_cast)]
+   |         ^^^^^^^^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #88611 <https://github.com/rust-lang/rust/issues/88621>
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Implementation of the second option as mentioned in https://github.com/rust-lang/rust/issues/60553#issuecomment-985007785.

Marked as draft as this needs a lang team decision.

r? @ghost
@rustbot label: +T-lang