### PR TITLE
Include Projections when elaborating TypeOutlives

### DIFF
--- a/compiler/rustc_infer/src/infer/outlives/obligations.rs
+++ b/compiler/rustc_infer/src/infer/outlives/obligations.rs
@@ -164,7 +164,7 @@ impl<'cx, 'tcx> InferCtxt<'cx, 'tcx> {
             "cannot process registered region obligations in a snapshot"
         );
 
-        debug!("process_registered_region_obligations()");
+        debug!(?param_env, "process_registered_region_obligations()");
 
         let my_region_obligations = self.take_registered_region_obligations();
 
@@ -355,6 +355,8 @@ where
         // results.
         let trait_bounds: Vec<_> =
             self.verify_bound.projection_declared_bounds_from_trait(projection_ty).collect();
+
+        debug!(?trait_bounds);
 
         // Compute the bounds we can derive from the environment. This
         // is an "approximate" match -- in some cases, these bounds

--- a/compiler/rustc_infer/src/traits/util.rs
+++ b/compiler/rustc_infer/src/traits/util.rs
@@ -241,10 +241,19 @@ impl<'tcx> Elaborator<'tcx> {
 
                             Component::UnresolvedInferenceVariable(_) => None,
 
-                            Component::Projection(_) | Component::EscapingProjection(_) => {
-                                // We can probably do more here. This
-                                // corresponds to a case like `<T as
-                                // Foo<'a>>::U: 'b`.
+                            Component::Projection(projection) => {
+                                // We might end up here if we have `Foo<<Bar as Baz>::Assoc>: 'a`.
+                                // With this, we can deduce that `<Bar as Baz>::Assoc: 'a`.
+                                let ty =
+                                    tcx.mk_projection(projection.item_def_id, projection.substs);
+                                Some(ty::PredicateKind::TypeOutlives(ty::OutlivesPredicate(
+                                    ty, r_min,
+                                )))
+                            }
+
+                            Component::EscapingProjection(_) => {
+                                // We might be able to do more here, but we don't
+                                // want to deal with escaping vars right now.
                                 None
                             }
                         })

--- a/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
@@ -206,7 +206,9 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             })?);
 
             if let ty::Projection(..) = placeholder_self_ty.kind() {
-                for predicate in tcx.predicates_of(def_id).instantiate_own(tcx, substs).predicates {
+                let predicates = tcx.predicates_of(def_id).instantiate_own(tcx, substs).predicates;
+                debug!(?predicates, "projection predicates");
+                for predicate in predicates {
                     let normalized = normalize_with_depth_to(
                         self,
                         obligation.param_env,

--- a/src/test/ui/generic-associated-types/issue-92096.migrate.stderr
+++ b/src/test/ui/generic-associated-types/issue-92096.migrate.stderr
@@ -1,5 +1,5 @@
 error[E0311]: the parameter type `C` may not live long enough
-  --> $DIR/issue-92096.rs:18:33
+  --> $DIR/issue-92096.rs:20:33
    |
 LL | fn call_connect<C>(c: &'_ C) -> impl '_ + Future + Send
    |                 -               ^^^^^^^^^^^^^^^^^^^^^^^ ...so that the type `C` will meet its required lifetime bounds
@@ -7,7 +7,7 @@ LL | fn call_connect<C>(c: &'_ C) -> impl '_ + Future + Send
    |                 help: consider adding an explicit lifetime bound...: `C: 'a`
 
 error[E0311]: the parameter type `C` may not live long enough
-  --> $DIR/issue-92096.rs:18:33
+  --> $DIR/issue-92096.rs:20:33
    |
 LL | fn call_connect<C>(c: &'_ C) -> impl '_ + Future + Send
    |                 -               ^^^^^^^^^^^^^^^^^^^^^^^ ...so that the type `C` will meet its required lifetime bounds

--- a/src/test/ui/generic-associated-types/issue-92096.rs
+++ b/src/test/ui/generic-associated-types/issue-92096.rs
@@ -1,8 +1,10 @@
 // edition:2018
-// check-fail
-// FIXME(generic_associated_types): this should pass, but we end up
-// essentially requiring that `for<'s> C: 's`
+// [nll] check-pass
+// revisions: migrate nll
+// Explicitly testing nll with revision, so ignore compare-mode=nll
+// ignore-compare-mode-nll
 
+#![cfg_attr(nll, feature(nll))]
 #![feature(generic_associated_types)]
 
 use std::future::Future;
@@ -16,8 +18,8 @@ trait Client {
 }
 
 fn call_connect<C>(c: &'_ C) -> impl '_ + Future + Send
-//~^ ERROR the parameter
-//~| ERROR the parameter
+//[migrate]~^ ERROR the parameter
+//[migrate]~| ERROR the parameter
 where
     C: Client + Send + Sync,
 {

--- a/src/test/ui/generic-associated-types/issue-92096.rs
+++ b/src/test/ui/generic-associated-types/issue-92096.rs
@@ -1,0 +1,27 @@
+// edition:2018
+// check-fail
+// FIXME(generic_associated_types): this should pass, but we end up
+// essentially requiring that `for<'s> C: 's`
+
+#![feature(generic_associated_types)]
+
+use std::future::Future;
+
+trait Client {
+    type Connecting<'a>: Future + Send
+    where
+        Self: 'a;
+
+    fn connect(&'_ self) -> Self::Connecting<'_>;
+}
+
+fn call_connect<C>(c: &'_ C) -> impl '_ + Future + Send
+//~^ ERROR the parameter
+//~| ERROR the parameter
+where
+    C: Client + Send + Sync,
+{
+    async move { c.connect().await }
+}
+
+fn main() {}

--- a/src/test/ui/generic-associated-types/issue-92096.stderr
+++ b/src/test/ui/generic-associated-types/issue-92096.stderr
@@ -1,0 +1,18 @@
+error[E0311]: the parameter type `C` may not live long enough
+  --> $DIR/issue-92096.rs:18:33
+   |
+LL | fn call_connect<C>(c: &'_ C) -> impl '_ + Future + Send
+   |                 -               ^^^^^^^^^^^^^^^^^^^^^^^ ...so that the type `C` will meet its required lifetime bounds
+   |                 |
+   |                 help: consider adding an explicit lifetime bound...: `C: 'a`
+
+error[E0311]: the parameter type `C` may not live long enough
+  --> $DIR/issue-92096.rs:18:33
+   |
+LL | fn call_connect<C>(c: &'_ C) -> impl '_ + Future + Send
+   |                 -               ^^^^^^^^^^^^^^^^^^^^^^^ ...so that the type `C` will meet its required lifetime bounds
+   |                 |
+   |                 help: consider adding an explicit lifetime bound...: `C: 'a`
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/generic-associated-types/issue-92280.rs
+++ b/src/test/ui/generic-associated-types/issue-92280.rs
@@ -1,0 +1,26 @@
+// check-pass
+
+#![feature(generic_associated_types)]
+#![allow(non_camel_case_types)]
+
+trait HasAssoc {
+    type Assoc;
+}
+
+trait Iterate<S: HasAssoc> {
+    type Iter<'a>
+    where
+        Self: 'a;
+}
+
+struct KeySegment_Broken<T> {
+    key: T,
+}
+impl<S: HasAssoc> Iterate<S> for KeySegment_Broken<S::Assoc> {
+    type Iter<'a>
+    where
+        Self: 'a,
+    = ();
+}
+
+fn main() {}


### PR DESCRIPTION
Fixes #92280

In `Elaborator`, we elaborate that `Foo<<Bar as Baz>::Assoc>: 'a` -> `<Bar as Baz>::Assoc: 'a`. This is the same rule that would be applied to any other `Param`. If there are escaping vars, we continue to do nothing.

r? @nikomatsakis 