### PR TITLE
Provide ignore message in the result of test

### DIFF
--- a/compiler/rustc_expand/src/build.rs
+++ b/compiler/rustc_expand/src/build.rs
@@ -329,6 +329,10 @@ impl<'a> ExtCtxt<'a> {
         self.expr_call_global(sp, some, vec![expr])
     }
 
+    pub fn expr_none(&self, sp: Span) -> P<ast::Expr> {
+        let none = self.std_path(&[sym::option, sym::Option, sym::None]);
+        self.expr_path(self.path_global(sp, none))
+    }
     pub fn expr_tuple(&self, sp: Span, exprs: Vec<P<ast::Expr>>) -> P<ast::Expr> {
         self.expr(sp, ast::ExprKind::Tup(exprs))
     }

--- a/library/test/src/tests.rs
+++ b/library/test/src/tests.rs
@@ -61,6 +61,8 @@ fn one_ignored_one_unignored_test() -> Vec<TestDescAndFn> {
             desc: TestDesc {
                 name: StaticTestName("1"),
                 ignore: true,
+                #[cfg(not(bootstrap))]
+                ignore_message: None,
                 should_panic: ShouldPanic::No,
                 compile_fail: false,
                 no_run: false,
@@ -74,6 +76,8 @@ fn one_ignored_one_unignored_test() -> Vec<TestDescAndFn> {
             desc: TestDesc {
                 name: StaticTestName("2"),
                 ignore: false,
+                #[cfg(not(bootstrap))]
+                ignore_message: None,
                 should_panic: ShouldPanic::No,
                 compile_fail: false,
                 no_run: false,
@@ -95,6 +99,8 @@ pub fn do_not_run_ignored_tests() {
         desc: TestDesc {
             name: StaticTestName("whatever"),
             ignore: true,
+            #[cfg(not(bootstrap))]
+            ignore_message: None,
             should_panic: ShouldPanic::No,
             compile_fail: false,
             no_run: false,
@@ -117,6 +123,8 @@ pub fn ignored_tests_result_in_ignored() {
         desc: TestDesc {
             name: StaticTestName("whatever"),
             ignore: true,
+            #[cfg(not(bootstrap))]
+            ignore_message: None,
             should_panic: ShouldPanic::No,
             compile_fail: false,
             no_run: false,
@@ -143,6 +151,8 @@ fn test_should_panic() {
         desc: TestDesc {
             name: StaticTestName("whatever"),
             ignore: false,
+            #[cfg(not(bootstrap))]
+            ignore_message: None,
             should_panic: ShouldPanic::Yes,
             compile_fail: false,
             no_run: false,
@@ -169,6 +179,8 @@ fn test_should_panic_good_message() {
         desc: TestDesc {
             name: StaticTestName("whatever"),
             ignore: false,
+            #[cfg(not(bootstrap))]
+            ignore_message: None,
             should_panic: ShouldPanic::YesWithMessage("error message"),
             compile_fail: false,
             no_run: false,
@@ -200,6 +212,8 @@ fn test_should_panic_bad_message() {
         desc: TestDesc {
             name: StaticTestName("whatever"),
             ignore: false,
+            #[cfg(not(bootstrap))]
+            ignore_message: None,
             should_panic: ShouldPanic::YesWithMessage(expected),
             compile_fail: false,
             no_run: false,
@@ -235,6 +249,8 @@ fn test_should_panic_non_string_message_type() {
         desc: TestDesc {
             name: StaticTestName("whatever"),
             ignore: false,
+            #[cfg(not(bootstrap))]
+            ignore_message: None,
             should_panic: ShouldPanic::YesWithMessage(expected),
             compile_fail: false,
             no_run: false,
@@ -262,6 +278,8 @@ fn test_should_panic_but_succeeds() {
             desc: TestDesc {
                 name: StaticTestName("whatever"),
                 ignore: false,
+                #[cfg(not(bootstrap))]
+                ignore_message: None,
                 should_panic,
                 compile_fail: false,
                 no_run: false,
@@ -297,6 +315,8 @@ fn report_time_test_template(report_time: bool) -> Option<TestExecTime> {
         desc: TestDesc {
             name: StaticTestName("whatever"),
             ignore: false,
+            #[cfg(not(bootstrap))]
+            ignore_message: None,
             should_panic: ShouldPanic::No,
             compile_fail: false,
             no_run: false,
@@ -333,6 +353,8 @@ fn time_test_failure_template(test_type: TestType) -> TestResult {
         desc: TestDesc {
             name: StaticTestName("whatever"),
             ignore: false,
+            #[cfg(not(bootstrap))]
+            ignore_message: None,
             should_panic: ShouldPanic::No,
             compile_fail: false,
             no_run: false,
@@ -373,6 +395,8 @@ fn typed_test_desc(test_type: TestType) -> TestDesc {
     TestDesc {
         name: StaticTestName("whatever"),
         ignore: false,
+        #[cfg(not(bootstrap))]
+        ignore_message: None,
         should_panic: ShouldPanic::No,
         compile_fail: false,
         no_run: false,
@@ -486,6 +510,8 @@ pub fn exclude_should_panic_option() {
         desc: TestDesc {
             name: StaticTestName("3"),
             ignore: false,
+            #[cfg(not(bootstrap))]
+            ignore_message: None,
             should_panic: ShouldPanic::Yes,
             compile_fail: false,
             no_run: false,
@@ -511,6 +537,8 @@ pub fn exact_filter_match() {
                 desc: TestDesc {
                     name: StaticTestName(name),
                     ignore: false,
+                    #[cfg(not(bootstrap))]
+                    ignore_message: None,
                     should_panic: ShouldPanic::No,
                     compile_fail: false,
                     no_run: false,
@@ -601,6 +629,8 @@ fn sample_tests() -> Vec<TestDescAndFn> {
             desc: TestDesc {
                 name: DynTestName((*name).clone()),
                 ignore: false,
+                #[cfg(not(bootstrap))]
+                ignore_message: None,
                 should_panic: ShouldPanic::No,
                 compile_fail: false,
                 no_run: false,
@@ -753,6 +783,8 @@ pub fn test_bench_no_iter() {
     let desc = TestDesc {
         name: StaticTestName("f"),
         ignore: false,
+        #[cfg(not(bootstrap))]
+        ignore_message: None,
         should_panic: ShouldPanic::No,
         compile_fail: false,
         no_run: false,
@@ -776,6 +808,8 @@ pub fn test_bench_iter() {
     let desc = TestDesc {
         name: StaticTestName("f"),
         ignore: false,
+        #[cfg(not(bootstrap))]
+        ignore_message: None,
         should_panic: ShouldPanic::No,
         compile_fail: false,
         no_run: false,
@@ -793,6 +827,8 @@ fn should_sort_failures_before_printing_them() {
     let test_a = TestDesc {
         name: StaticTestName("a"),
         ignore: false,
+        #[cfg(not(bootstrap))]
+        ignore_message: None,
         should_panic: ShouldPanic::No,
         compile_fail: false,
         no_run: false,
@@ -804,6 +840,8 @@ fn should_sort_failures_before_printing_them() {
     let test_b = TestDesc {
         name: StaticTestName("b"),
         ignore: false,
+        #[cfg(not(bootstrap))]
+        ignore_message: None,
         should_panic: ShouldPanic::No,
         compile_fail: false,
         no_run: false,

--- a/library/test/src/types.rs
+++ b/library/test/src/types.rs
@@ -117,6 +117,8 @@ pub struct TestId(pub usize);
 pub struct TestDesc {
     pub name: TestName,
     pub ignore: bool,
+    #[cfg(not(bootstrap))]
+    pub ignore_message: Option<&'static str>,
     pub should_panic: options::ShouldPanic,
     pub compile_fail: bool,
     pub no_run: bool,

--- a/src/librustdoc/doctest.rs
+++ b/src/librustdoc/doctest.rs
@@ -949,6 +949,8 @@ impl Tester for Collector {
                     Ignore::None => false,
                     Ignore::Some(ref ignores) => ignores.iter().any(|s| target_str.contains(s)),
                 },
+                #[cfg(not(bootstrap))]
+                ignore_message: None,
                 // compiler failures are test failures
                 should_panic: test::ShouldPanic::No,
                 compile_fail: config.compile_fail,

--- a/src/tools/compiletest/src/header.rs
+++ b/src/tools/compiletest/src/header.rs
@@ -806,6 +806,8 @@ pub fn make_test_description<R: Read>(
     cfg: Option<&str>,
 ) -> test::TestDesc {
     let mut ignore = false;
+    #[cfg(not(bootstrap))]
+    let ignore_message: Option<String> = None;
     let mut should_fail = false;
 
     let rustc_has_profiler_support = env::var_os("RUSTC_PROFILER_SUPPORT").is_some();
@@ -877,6 +879,8 @@ pub fn make_test_description<R: Read>(
     test::TestDesc {
         name,
         ignore,
+        #[cfg(not(bootstrap))]
+        ignore_message,
         should_panic,
         compile_fail: false,
         no_run: false,


### PR DESCRIPTION
Provide ignore the message in the result of the test.

This PR does not need RFC, because it is about the presentation of the report of `cargo test`.

However, the following document listed here helps you to know about PR.

- [RFC](https://github.com/rust-lang/rfcs/pull/3217)
- [Rendered](https://github.com/yanganto/rfcs/blob/ignore-test-message/text/0000-ignore-test-message.md)
- [Previous discussion on IRLO](https://internals.rust-lang.org/t/pre-rfc-provide-ignore-message-when-the-test-ignored/15904)

If there is something improper, please let me know.
Thanks.
