### PR TITLE
Fix doc formatting for time.rs

### DIFF
--- a/library/std/src/time.rs
+++ b/library/std/src/time.rs
@@ -54,7 +54,7 @@ pub use core::time::FromSecsError;
 /// instant when created, and are often useful for tasks such as measuring
 /// benchmarks or timing how long an operation takes.
 ///
-/// Note, however, that instants are not guaranteed to be **steady**. In other
+/// Note, however, that instants are **not** guaranteed to be **steady**. In other
 /// words, each tick of the underlying clock might not be the same length (e.g.
 /// some seconds may be longer than others). An instant may jump forwards or
 /// experience time dilation (slow down or speed up), but it will never go


### PR DESCRIPTION
The doc states that instants are not steady, but the word "not" wasn't highlighted in bold.