### PR TITLE
Don't over-constrain projections in generic method signatures

### DIFF
--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -2101,8 +2101,9 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
 
                         let ty_fn_ptr_from = tcx.mk_fn_ptr(fn_sig);
 
+                        let ty = self.normalize(*ty, location);
                         if let Err(terr) = self.eq_types(
-                            *ty,
+                            ty,
                             ty_fn_ptr_from,
                             location.to_locations(),
                             ConstraintCategory::Cast,
@@ -2124,9 +2125,11 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
                             _ => bug!(),
                         };
                         let ty_fn_ptr_from = tcx.mk_fn_ptr(tcx.signature_unclosure(sig, *unsafety));
+                        let ty_fn_ptr_from = self.normalize(ty_fn_ptr_from, location);
 
+                        let ty = self.normalize(*ty, location);
                         if let Err(terr) = self.eq_types(
-                            *ty,
+                            ty,
                             ty_fn_ptr_from,
                             location.to_locations(),
                             ConstraintCategory::Cast,
@@ -2154,8 +2157,9 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
 
                         let ty_fn_ptr_from = tcx.safe_to_unsafe_fn_ty(fn_sig);
 
+                        let ty = self.normalize(*ty, location);
                         if let Err(terr) = self.eq_types(
-                            *ty,
+                            ty,
                             ty_fn_ptr_from,
                             location.to_locations(),
                             ConstraintCategory::Cast,

--- a/compiler/rustc_infer/src/infer/mod.rs
+++ b/compiler/rustc_infer/src/infer/mod.rs
@@ -920,6 +920,10 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
             .region_constraints_added_in_snapshot(&snapshot.undo_snapshot)
     }
 
+    pub fn any_instantiations(&self, snapshot: &CombinedSnapshot<'a, 'tcx>) -> bool {
+        self.inner.borrow_mut().any_instantiations(&snapshot.undo_snapshot)
+    }
+
     pub fn add_given(&self, sub: ty::Region<'tcx>, sup: ty::RegionVid) {
         self.inner.borrow_mut().unwrap_region_constraints().add_given(sub, sup);
     }

--- a/compiler/rustc_trait_selection/src/traits/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/mod.rs
@@ -55,7 +55,10 @@ pub use self::object_safety::is_vtable_safe_method;
 pub use self::object_safety::MethodViolationCode;
 pub use self::object_safety::ObjectSafetyViolation;
 pub use self::on_unimplemented::{OnUnimplementedDirective, OnUnimplementedNote};
-pub use self::project::{normalize, normalize_projection_type, normalize_to};
+pub use self::project::{
+    normalize, normalize_projection_type, normalize_to, normalize_with_depth_to,
+    project_and_unify_type,
+};
 pub use self::select::{EvaluationCache, SelectionCache, SelectionContext};
 pub use self::select::{EvaluationResult, IntercrateAmbiguityCause, OverflowError};
 pub use self::specialize::specialization_graph::FutureCompatOverlapError;

--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -1523,18 +1523,12 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         })
     }
 
-    /// Return `Yes` if the obligation's predicate type applies to the env_predicate, and
-    /// `No` if it does not. Return `Ambiguous` in the case that the projection type is a GAT,
-    /// and applying this env_predicate constrains any of the obligation's GAT substitutions.
-    ///
-    /// This behavior is a somewhat of a hack to prevent overconstraining inference variables
-    /// in cases like #91762.
     pub(super) fn match_projection_projections(
         &mut self,
         obligation: &ProjectionTyObligation<'tcx>,
         env_predicate: PolyProjectionPredicate<'tcx>,
         potentially_unnormalized_candidates: bool,
-    ) -> ProjectionMatchesProjection {
+    ) -> bool {
         let mut nested_obligations = Vec::new();
         let (infer_predicate, _) = self.infcx.replace_bound_vars_with_fresh_vars(
             obligation.cause.span,
@@ -1556,8 +1550,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             infer_predicate.projection_ty
         };
 
-        let is_match = self
-            .infcx
+        self.infcx
             .at(&obligation.cause, obligation.param_env)
             .sup(obligation.predicate, infer_projection)
             .map_or(false, |InferOk { obligations, value: () }| {
@@ -1566,26 +1559,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                     nested_obligations.into_iter().chain(obligations),
                 )
                 .map_or(false, |res| res.may_apply())
-            });
-
-        if is_match {
-            let generics = self.tcx().generics_of(obligation.predicate.item_def_id);
-            // FIXME(generic-associated-types): Addresses aggressive inference in #92917.
-            // If this type is a GAT, and of the GAT substs resolve to something new,
-            // that means that we must have newly inferred something about the GAT.
-            // We should give up in that case.
-            if !generics.params.is_empty()
-                && obligation.predicate.substs[generics.parent_count..]
-                    .iter()
-                    .any(|&p| p.has_infer_types_or_consts() && self.infcx.shallow_resolve(p) != p)
-            {
-                ProjectionMatchesProjection::Ambiguous
-            } else {
-                ProjectionMatchesProjection::Yes
-            }
-        } else {
-            ProjectionMatchesProjection::No
-        }
+            })
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -2742,10 +2716,4 @@ impl<'o, 'tcx> fmt::Debug for TraitObligationStack<'o, 'tcx> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "TraitObligationStack({:?})", self.obligation)
     }
-}
-
-pub enum ProjectionMatchesProjection {
-    Yes,
-    Ambiguous,
-    No,
 }

--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -132,6 +132,17 @@ pub struct SelectionContext<'cx, 'tcx> {
     /// policy. In essence, canonicalized queries need their errors propagated
     /// rather than immediately reported because we do not have accurate spans.
     query_mode: TraitQueryMode,
+
+    pub normalization_mode: NormalizationMode,
+}
+
+#[derive(Copy, Clone)]
+pub struct NormalizationMode {
+    pub allow_infer_constraint_during_projection: bool,
+    /// If true, when a projection is unable to be completed, an inference
+    /// variable will be created and an obligation registered to project to that
+    /// inference variable. Also, constants will be eagerly evaluated.
+    pub eager_inference_replacement: bool,
 }
 
 // A stack that walks back up the stack frame.
@@ -221,6 +232,10 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             intercrate_ambiguity_causes: None,
             allow_negative_impls: false,
             query_mode: TraitQueryMode::Standard,
+            normalization_mode: NormalizationMode {
+                allow_infer_constraint_during_projection: true,
+                eager_inference_replacement: true,
+            },
         }
     }
 
@@ -232,6 +247,10 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             intercrate_ambiguity_causes: None,
             allow_negative_impls: false,
             query_mode: TraitQueryMode::Standard,
+            normalization_mode: NormalizationMode {
+                allow_infer_constraint_during_projection: true,
+                eager_inference_replacement: true,
+            },
         }
     }
 
@@ -247,6 +266,10 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             intercrate_ambiguity_causes: None,
             allow_negative_impls,
             query_mode: TraitQueryMode::Standard,
+            normalization_mode: NormalizationMode {
+                allow_infer_constraint_during_projection: true,
+                eager_inference_replacement: true,
+            },
         }
     }
 
@@ -262,6 +285,10 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             intercrate_ambiguity_causes: None,
             allow_negative_impls: false,
             query_mode,
+            normalization_mode: NormalizationMode {
+                allow_infer_constraint_during_projection: true,
+                eager_inference_replacement: true,
+            },
         }
     }
 
@@ -295,6 +322,10 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
 
     pub fn is_intercrate(&self) -> bool {
         self.intercrate
+    }
+
+    pub fn normalization_mode(&self) -> NormalizationMode {
+        self.normalization_mode
     }
 
     ///////////////////////////////////////////////////////////////////////////

--- a/compiler/rustc_typeck/src/check/expr.rs
+++ b/compiler/rustc_typeck/src/check/expr.rs
@@ -159,7 +159,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     /// Note that inspecting a type's structure *directly* may expose the fact
     /// that there are actually multiple representations for `Error`, so avoid
     /// that when err needs to be handled differently.
-    #[instrument(skip(self, expr), level = "debug")]
     pub(super) fn check_expr_with_expectation(
         &self,
         expr: &'tcx hir::Expr<'tcx>,
@@ -170,6 +169,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
     /// Same as `check_expr_with_expectation`, but allows us to pass in the arguments of a
     /// `ExprKind::Call` when evaluating its callee when it is an `ExprKind::Path`.
+    #[instrument(skip(self, expr), level = "debug")]
     pub(super) fn check_expr_with_expectation_and_args(
         &self,
         expr: &'tcx hir::Expr<'tcx>,

--- a/compiler/rustc_typeck/src/check/method/probe.rs
+++ b/compiler/rustc_typeck/src/check/method/probe.rs
@@ -468,12 +468,11 @@ pub fn provide(providers: &mut ty::query::Providers) {
     providers.method_autoderef_steps = method_autoderef_steps;
 }
 
+#[tracing::instrument(level = "debug", skip(tcx))]
 fn method_autoderef_steps<'tcx>(
     tcx: TyCtxt<'tcx>,
     goal: CanonicalTyGoal<'tcx>,
 ) -> MethodAutoderefStepsResult<'tcx> {
-    debug!("method_autoderef_steps({:?})", goal);
-
     tcx.infer_ctxt().enter_with_canonical(DUMMY_SP, &goal, |ref infcx, goal, inference_vars| {
         let ParamEnvAnd { param_env, value: self_ty } = goal;
 
@@ -529,7 +528,7 @@ fn method_autoderef_steps<'tcx>(
             _ => None,
         };
 
-        debug!("method_autoderef_steps: steps={:?} opt_bad_ty={:?}", steps, opt_bad_ty);
+        debug!(?steps, ?opt_bad_ty);
 
         MethodAutoderefStepsResult {
             steps: tcx.arena.alloc_from_iter(steps),

--- a/src/test/ui/generic-associated-types/issue-91139.migrate.stderr
+++ b/src/test/ui/generic-associated-types/issue-91139.migrate.stderr
@@ -6,5 +6,21 @@ LL | fn foo<T>() {
 LL |     let _: for<'a> fn(<() as Foo<T>>::Type<'a>, &'a T) = |_, _| ();
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ...so that the type `T` will meet its required lifetime bounds
 
-error: aborting due to previous error
+error[E0311]: the parameter type `T` may not live long enough
+  --> $DIR/issue-91139.rs:27:58
+   |
+LL | fn foo<T>() {
+   |        - help: consider adding an explicit lifetime bound...: `T: 'a`
+LL |     let _: for<'a> fn(<() as Foo<T>>::Type<'a>, &'a T) = |_, _| ();
+   |                                                          ^^^^^^^^^ ...so that the type `T` will meet its required lifetime bounds
+
+error[E0311]: the parameter type `T` may not live long enough
+  --> $DIR/issue-91139.rs:27:58
+   |
+LL | fn foo<T>() {
+   |        - help: consider adding an explicit lifetime bound...: `T: 'a`
+LL |     let _: for<'a> fn(<() as Foo<T>>::Type<'a>, &'a T) = |_, _| ();
+   |                                                          ^^^^^^^^^ ...so that the type `T` will meet its required lifetime bounds
+
+error: aborting due to 3 previous errors
 

--- a/src/test/ui/generic-associated-types/issue-91139.rs
+++ b/src/test/ui/generic-associated-types/issue-91139.rs
@@ -25,7 +25,9 @@ impl<T> Foo<T> for () {
 
 fn foo<T>() {
     let _: for<'a> fn(<() as Foo<T>>::Type<'a>, &'a T) = |_, _| ();
-    //[migrate]~^ the parameter type `T` may not live long enough
+    //[migrate]~^ the parameter type
+    //[migrate]~| the parameter type
+    //[migrate]~| the parameter type
 }
 
 pub fn main() {}

--- a/src/test/ui/generic-associated-types/issue-91395.rs
+++ b/src/test/ui/generic-associated-types/issue-91395.rs
@@ -1,0 +1,33 @@
+// check-fail
+// FIXME(generic_associated_types): This *should* pass, but fails
+// because we pick some region `'_#1r` instead of `'a`
+
+#![feature(generic_associated_types)]
+
+trait Foo {
+    type Item;
+    fn item(&self) -> Self::Item;
+}
+
+trait Table {
+    type Blocks<'a>: Foo
+    where
+        Self: 'a;
+
+    fn blocks(&self) -> Self::Blocks<'_>;
+}
+
+fn box_static_block<U: 'static>(_block: U) {}
+
+fn clone_static_table<'a, T>(table: &'a T)
+where
+    T: Table,
+    <<T as Table>::Blocks<'a> as Foo>::Item: 'static,
+    //for<'x> <<T as Table>::Blocks<'x> as Foo>::Item: 'static, // This also doesn't work
+{
+    let block = table.blocks().item();
+    box_static_block(block);
+    //~^ the associated type
+}
+
+fn main() {}

--- a/src/test/ui/generic-associated-types/issue-91395.stderr
+++ b/src/test/ui/generic-associated-types/issue-91395.stderr
@@ -1,0 +1,17 @@
+error[E0310]: the associated type `<<T as Table>::Blocks<'_> as Foo>::Item` may not live long enough
+  --> $DIR/issue-91395.rs:29:5
+   |
+LL |     box_static_block(block);
+   |     ^^^^^^^^^^^^^^^^
+   |
+   = help: consider adding an explicit lifetime bound `<<T as Table>::Blocks<'_> as Foo>::Item: 'static`...
+   = note: ...so that the type `<<T as Table>::Blocks<'_> as Foo>::Item` will meet its required lifetime bounds...
+note: ...that is required by this bound
+  --> $DIR/issue-91395.rs:20:24
+   |
+LL | fn box_static_block<U: 'static>(_block: U) {}
+   |                        ^^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0310`.

--- a/src/test/ui/generic-associated-types/issue-91693.rs
+++ b/src/test/ui/generic-associated-types/issue-91693.rs
@@ -1,0 +1,41 @@
+// check-fail
+// FIXME(generic_associated_types): This *should* pass, but fails likely due to
+// leak check/universe related things
+
+#![feature(generic_associated_types)]
+
+pub trait LendingIterator {
+    type Item<'a>
+    where
+        Self: 'a;
+    fn next(&mut self) -> Option<Self::Item<'_>>;
+
+    fn for_each<F>(mut self, mut f: F)
+    where
+        Self: Sized,
+        F: FnMut(Self::Item<'_>),
+    {
+        while let Some(item) = self.next() {
+            f(item)
+        }
+    }
+}
+
+pub struct Mutator<T>(T);
+
+impl<T> LendingIterator for Mutator<T> {
+    type Item<'a> = &'a mut T
+    where
+        Self: 'a;
+    fn next(&mut self) -> Option<Self::Item<'_>> {
+        Some(&mut self.0)
+    }
+}
+
+pub fn bar<T>(m: Mutator<T>) {
+    m.for_each(|_: &mut T| {});
+    //~^ ERROR the parameter type
+    //~| ERROR the parameter type
+}
+
+fn main() {}

--- a/src/test/ui/generic-associated-types/issue-91693.stderr
+++ b/src/test/ui/generic-associated-types/issue-91693.stderr
@@ -1,0 +1,18 @@
+error[E0311]: the parameter type `T` may not live long enough
+  --> $DIR/issue-91693.rs:36:7
+   |
+LL | pub fn bar<T>(m: Mutator<T>) {
+   |            - help: consider adding an explicit lifetime bound...: `T: 'a`
+LL |     m.for_each(|_: &mut T| {});
+   |       ^^^^^^^^ ...so that the type `Mutator<T>` will meet its required lifetime bounds
+
+error[E0311]: the parameter type `T` may not live long enough
+  --> $DIR/issue-91693.rs:36:7
+   |
+LL | pub fn bar<T>(m: Mutator<T>) {
+   |            - help: consider adding an explicit lifetime bound...: `T: 'a`
+LL |     m.for_each(|_: &mut T| {});
+   |       ^^^^^^^^ ...so that the type `Mutator<T>` will meet its required lifetime bounds
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/generic-associated-types/issue-91762.rs
+++ b/src/test/ui/generic-associated-types/issue-91762.rs
@@ -1,12 +1,17 @@
 // check-fail
-
-// FIXME(generic_associated_types): We almost certaintly want this to pass, but
-// it's particularly difficult currently, because we need a way of specifying
-// that `<Self::Base as Functor>::With<T> = Self` without using that when we have
-// a `U`. See `https://github.com/rust-lang/rust/pull/92728` for a (hacky)
-// solution. This might be better to just wait for Chalk.
+// compile-flags: -Zverbose
 
 #![feature(generic_associated_types)]
+#![feature(lang_items)]
+#![feature(no_core)]
+#![no_core]
+#![crate_type = "rlib"]
+
+#[lang = "sized"]
+pub trait Sized {}
+
+#[lang = "copy"]
+pub trait Copy {}
 
 pub trait Functor {
     type With<T>;
@@ -23,8 +28,7 @@ pub trait FunctorExt<T>: Sized {
 
         arg = self;
         ret = <Self::Base as Functor>::fmap(arg);
-        //~^ type annotations needed
+        //~^ cannot infer type
+        //~| type annotations needed
     }
 }
-
-fn main() {}

--- a/src/test/ui/generic-associated-types/issue-91762.rs
+++ b/src/test/ui/generic-associated-types/issue-91762.rs
@@ -28,7 +28,6 @@ pub trait FunctorExt<T>: Sized {
 
         arg = self;
         ret = <Self::Base as Functor>::fmap(arg);
-        //~^ cannot infer type
-        //~| type annotations needed
+        //~^ mismatched types
     }
 }

--- a/src/test/ui/generic-associated-types/issue-91762.stderr
+++ b/src/test/ui/generic-associated-types/issue-91762.stderr
@@ -1,9 +1,23 @@
-error[E0282]: type annotations needed
+error[E0308]: mismatched types
   --> $DIR/issue-91762.rs:30:15
    |
+LL | pub trait FunctorExt<T>: Sized {
+   |                      - found type parameter
+...
+LL |     fn fmap<U>(self) {
+   |             - expected type parameter
+LL |         let arg: <Self::Base as Functor>::With<T>;
+LL |         let ret: <Self::Base as Functor>::With<U>;
+   |                  -------------------------------- expected due to this type
+...
 LL |         ret = <Self::Base as Functor>::fmap(arg);
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type for type parameter `T` declared on the associated function `fmap`
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected type parameter `U`, found type parameter `T`
+   |
+   = note: expected associated type `<<Self as FunctorExt<T>>::Base as Functor>::With<U>`
+              found associated type `<<Self as FunctorExt<T>>::Base as Functor>::With<T>`
+   = note: a type parameter was expected, but a different one was found; you might be missing a type parameter or trait bound
+   = note: for more information, visit https://doc.rust-lang.org/book/ch10-02-traits.html#traits-as-parameters
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0282`.
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/generic-associated-types/issue-91762.stderr
+++ b/src/test/ui/generic-associated-types/issue-91762.stderr
@@ -1,5 +1,5 @@
 error[E0282]: type annotations needed
-  --> $DIR/issue-91762.rs:25:15
+  --> $DIR/issue-91762.rs:30:15
    |
 LL |         ret = <Self::Base as Functor>::fmap(arg);
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type for type parameter `T` declared on the associated function `fmap`


### PR DESCRIPTION
Fixes #91762

This is likely not the "right" way to do this. Just opening for thoughts

r? @nikomatsakis 