### PR TITLE
fs: Use readdir() instead of readdir_r() on Linux and Android

### DIFF
--- a/library/std/src/sys/unix/fs.rs
+++ b/library/std/src/sys/unix/fs.rs
@@ -35,6 +35,7 @@ use libc::dirfd;
 #[cfg(any(target_os = "linux", target_os = "emscripten"))]
 use libc::fstatat64;
 #[cfg(any(
+    target_os = "android",
     target_os = "solaris",
     target_os = "fuchsia",
     target_os = "redox",
@@ -46,6 +47,7 @@ use libc::readdir64;
 #[cfg(any(target_os = "emscripten", target_os = "l4re"))]
 use libc::readdir64_r;
 #[cfg(not(any(
+    target_os = "android",
     target_os = "linux",
     target_os = "emscripten",
     target_os = "solaris",
@@ -211,6 +213,7 @@ struct InnerReadDir {
 pub struct ReadDir {
     inner: Arc<InnerReadDir>,
     #[cfg(not(any(
+        target_os = "android",
         target_os = "linux",
         target_os = "solaris",
         target_os = "illumos",
@@ -232,6 +235,7 @@ pub struct DirEntry {
     // readdir() (not readdir_r()), because a) struct dirent may use a flexible
     // array to store the name, b) it lives only until the next readdir() call.
     #[cfg(any(
+        target_os = "android",
         target_os = "linux",
         target_os = "solaris",
         target_os = "illumos",
@@ -459,6 +463,7 @@ impl Iterator for ReadDir {
     type Item = io::Result<DirEntry>;
 
     #[cfg(any(
+        target_os = "android",
         target_os = "linux",
         target_os = "solaris",
         target_os = "fuchsia",
@@ -498,6 +503,7 @@ impl Iterator for ReadDir {
     }
 
     #[cfg(not(any(
+        target_os = "android",
         target_os = "linux",
         target_os = "solaris",
         target_os = "fuchsia",
@@ -665,6 +671,7 @@ impl DirEntry {
     }
 
     #[cfg(not(any(
+        target_os = "android",
         target_os = "linux",
         target_os = "solaris",
         target_os = "illumos",
@@ -675,6 +682,7 @@ impl DirEntry {
         unsafe { CStr::from_ptr(self.entry.d_name.as_ptr()) }
     }
     #[cfg(any(
+        target_os = "android",
         target_os = "linux",
         target_os = "solaris",
         target_os = "illumos",
@@ -1086,6 +1094,7 @@ pub fn readdir(p: &Path) -> io::Result<ReadDir> {
             Ok(ReadDir {
                 inner: Arc::new(inner),
                 #[cfg(not(any(
+                    target_os = "android",
                     target_os = "linux",
                     target_os = "solaris",
                     target_os = "illumos",
@@ -1622,6 +1631,7 @@ mod remove_dir_impl {
             ReadDir {
                 inner: Arc::new(InnerReadDir { dirp, root: dummy_root }),
                 #[cfg(not(any(
+                    target_os = "android",
                     target_os = "linux",
                     target_os = "solaris",
                     target_os = "illumos",

--- a/library/std/src/sys/unix/os.rs
+++ b/library/std/src/sys/unix/os.rs
@@ -75,7 +75,7 @@ pub fn errno() -> i32 {
 }
 
 /// Sets the platform-specific value of errno
-#[cfg(all(not(target_os = "linux"), not(target_os = "dragonfly"), not(target_os = "vxworks")))] // needed for readdir and syscall!
+#[cfg(all(not(target_os = "dragonfly"), not(target_os = "vxworks")))] // needed for readdir and syscall!
 #[allow(dead_code)] // but not all target cfgs actually end up using it
 pub fn set_errno(e: i32) {
     unsafe { *errno_location() = e as c_int }


### PR DESCRIPTION
See #40021 for more details.  Fixes #86649.  Fixes #34668.
