### PR TITLE
Deduplicate bounds on associated types when deriving

### DIFF
--- a/compiler/rustc_builtin_macros/src/deriving/generic/mod.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/generic/mod.rs
@@ -636,6 +636,10 @@ impl<'a> TraitDef<'a> {
             }
         }));
 
+        // If this type declaration has type parameters, look for any mention of types *derived* from
+        // those parameters in the declaration (e.g. `T::Item`). Those derived types need bounds as
+        // well.
+
         let mut ty_params = params
             .iter()
             .filter(|param| matches!(param.kind, ast::GenericParamKind::Type { .. }))

--- a/compiler/rustc_builtin_macros/src/lib.rs
+++ b/compiler/rustc_builtin_macros/src/lib.rs
@@ -6,6 +6,7 @@
 #![feature(bool_to_option)]
 #![feature(crate_visibility_modifier)]
 #![feature(decl_macro)]
+#![feature(let_else)]
 #![feature(nll)]
 #![feature(proc_macro_internals)]
 #![feature(proc_macro_quote)]


### PR DESCRIPTION
`polonius` uses a trait [with a few associated types](https://docs.rs/polonius-engine/latest/polonius_engine/trait.FactTypes.html) to define which newtyped indexes represent CFG points, loans, etc. `rustc` makes no effort to deduplicate bounds when deriving common traits on structures whose fields mention associated types, resulting in very large, redundant `where` clauses like [this one](https://docs.rs/polonius-engine/latest/polonius_engine/struct.Output.html#impl-Debug). I find this mildly annoying when reading documentation.

This PR adds deduplication of simple paths (no generic arguments or qualified self types) to the `derive` machinery. As a result, the derived impl I linked above has only a single bound for each associated type, as one might expect.