### PR TITLE
Link sidebar "location" heading to top of page

### DIFF
--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -1737,7 +1737,7 @@ fn print_sidebar(cx: &Context<'_>, it: &clean::Item, buffer: &mut Buffer) {
     {
         write!(
             buffer,
-            "<h2 class=\"location\">{}{}</h2>",
+            "<h2 class=\"location\"><a href=\"#\">{}{}</a></h2>",
             match *it.kind {
                 clean::StructItem(..) => "Struct ",
                 clean::TraitItem(..) => "Trait ",

--- a/src/test/rustdoc-gui/sidebar.goml
+++ b/src/test/rustdoc-gui/sidebar.goml
@@ -22,6 +22,13 @@ click: "#structs + .item-table .item-left > a"
 assert-count: (".sidebar .location", 2)
 // We check that there is no crate listed outside of the top level.
 assert-false: ".sidebar-elems > .crate"
+
+click: ".sidebar-links a"
+assert-property: ("html", {"scrollTop": "389"})
+
+click: ".sidebar h2.location"
+assert-property: ("html", {"scrollTop": "0"})
+
 // We now go back to the crate page to click on the "lib2" crate link.
 goto: file://|DOC_PATH|/test_docs/index.html
 click: ".sidebar-elems .crate > ul > li:first-child > a"


### PR DESCRIPTION
This makes it easy, when you are scrolled far down in a page, to jump back to the top.

Demo: https://rustdoc.crud.net/jsha/link-to-top/std/string/struct.String.html

r? @GuillaumeGomez