### PR TITLE
Remove some unnecessary uses of `FieldDef::ident`

### DIFF
--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -398,8 +398,7 @@ impl<'a, 'tcx> LinkCollector<'a, 'tcx> {
                 }
                 match tcx.type_of(did).kind() {
                     ty::Adt(def, _) if def.is_enum() => {
-                        if let Some(field) =
-                            def.all_fields().find(|f| f.ident(tcx).name == variant_field_name)
+                        if let Some(field) = def.all_fields().find(|f| f.name == variant_field_name)
                         {
                             Ok((ty_res, Some(ItemFragment(FragmentKind::VariantField, field.did))))
                         } else {
@@ -770,11 +769,8 @@ impl<'a, 'tcx> LinkCollector<'a, 'tcx> {
                     ty::Adt(def, _) if !def.is_enum() => def,
                     _ => return None,
                 };
-                let field = def
-                    .non_enum_variant()
-                    .fields
-                    .iter()
-                    .find(|item| item.ident(tcx).name == item_name)?;
+                let field =
+                    def.non_enum_variant().fields.iter().find(|item| item.name == item_name)?;
                 Some((root_res, ItemFragment(FragmentKind::StructField, field.did)))
             }
             Res::Def(DefKind::Trait, did) => tcx


### PR DESCRIPTION
Followup from #92533.

cc @Aaron1011 @petrochenkov 