### PR TITLE
Hide mobile sidebar on some clicks

### DIFF
--- a/src/librustdoc/html/static/js/main.js
+++ b/src/librustdoc/html/static/js/main.js
@@ -897,6 +897,9 @@ function hideThemeButtonState() {
     handleClick("help-button", function(ev) {
         displayHelp(true, ev);
     });
+    handleClick(MAIN_ID, function() {
+        hideSidebar();
+    });
 
     onEachLazy(document.getElementsByTagName("a"), function(el) {
         // For clicks on internal links (<A> tags with a hash property), we expand the section we're
@@ -905,6 +908,7 @@ function hideThemeButtonState() {
         if (el.hash) {
             el.addEventListener("click", function() {
                 expandSection(el.hash.slice(1));
+                hideSidebar();
             });
         }
     });

--- a/src/test/rustdoc-gui/sidebar-mobile.goml
+++ b/src/test/rustdoc-gui/sidebar-mobile.goml
@@ -18,3 +18,11 @@ assert-css: (".sidebar-elems", {"display": "block", "left": "0px"})
 // When we tab out of the sidebar, close it.
 focus: ".search-input"
 assert-css: (".sidebar-elems", {"display": "block", "left": "-246px"})
+
+// Open the sidebar menu.
+click: ".sidebar-menu"
+assert-css: (".sidebar-elems", {"left": "0px"})
+
+// Click elsewhere.
+click: "body"
+assert-css: (".sidebar-elems", {"left": "-246px"})


### PR DESCRIPTION
When the user clicks outside the sidebar, the sidebar should close. Also, when the user clicks an internal link in the sidebar, it should close.

Fixes #92682

Demo: https://rustdoc.crud.net/jsha/hide-sidebar/std/string/struct.String.html