### PR TITLE
Fix query cycle in needs drop code.

### DIFF
--- a/src/test/ui/closures/2229_closure_analysis/issue-92724-needsdrop-query-cycle.rs
+++ b/src/test/ui/closures/2229_closure_analysis/issue-92724-needsdrop-query-cycle.rs
@@ -1,0 +1,13 @@
+// ICEs if checking if there is a significant destructor causes a query cycle
+// check-pass
+
+#![warn(rust_2021_incompatible_closure_captures)]
+pub struct Foo(Bar);
+pub struct Bar(Vec<Foo>);
+
+impl Foo {
+    pub fn bar(self, v: Bar) -> Bar {
+        (|| v)()
+    }
+}
+fn main() {}


### PR DESCRIPTION
Closes #92725 .

In #90845, an optimization was introduced in the needs drop code to ensure that we recurse through the query system, thereby improving caching and not duplicating work. However, this optimization did not correctly check for possible cycles in doing this. This change introduces that check.

(the diff looks much bigger than it actually is thanks to indentation)