### PR TITLE
Deduplicate box deref and regular deref suggestions

### DIFF
--- a/compiler/rustc_typeck/src/check/demand.rs
+++ b/compiler/rustc_typeck/src/check/demand.rs
@@ -31,7 +31,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         error: TypeError<'tcx>,
     ) {
         self.annotate_expected_due_to_let_ty(err, expr, error);
-        self.suggest_box_deref(err, expr, expected, expr_ty);
         self.suggest_compatible_variants(err, expr, expected, expr_ty);
         self.suggest_deref_ref_or_into(err, expr, expected, expr_ty, expected_ty_expr);
         if self.suggest_calling_boxed_future_when_appropriate(err, expr, expected, expr_ty) {
@@ -256,23 +255,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 }
             }
             _ => {}
-        }
-    }
-
-    fn suggest_box_deref(
-        &self,
-        err: &mut DiagnosticBuilder<'_>,
-        expr: &hir::Expr<'_>,
-        expected: Ty<'tcx>,
-        expr_ty: Ty<'tcx>,
-    ) {
-        if expr_ty.is_box() && expr_ty.boxed_ty() == expected {
-            err.span_suggestion_verbose(
-                expr.span.shrink_to_lo(),
-                "try dereferencing the `Box`",
-                "*".to_string(),
-                Applicability::MachineApplicable,
-            );
         }
     }
 
@@ -857,14 +839,17 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                                 Applicability::MachineApplicable,
                                 false,
                             ));
-                        } else if self.infcx.type_is_copy_modulo_regions(
-                            self.param_env,
-                            expected,
-                            sp,
-                        ) {
-                            // For this suggestion to make sense, the type would need to be `Copy`.
+                        }
+
+                        // For this suggestion to make sense, the type would need to be `Copy`,
+                        // or we have to be moving out of a `Box<T>`
+                        if self.infcx.type_is_copy_modulo_regions(self.param_env, expected, sp)
+                            || checked_ty.is_box()
+                        {
                             if let Ok(code) = sm.span_to_snippet(expr.span) {
-                                let message = if checked_ty.is_region_ptr() {
+                                let message = if checked_ty.is_box() {
+                                    "consider unboxing the value"
+                                } else if checked_ty.is_region_ptr() {
                                     "consider dereferencing the borrow"
                                 } else {
                                     "consider dereferencing the type"

--- a/compiler/rustc_typeck/src/check/demand.rs
+++ b/compiler/rustc_typeck/src/check/demand.rs
@@ -31,8 +31,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         error: TypeError<'tcx>,
     ) {
         self.annotate_expected_due_to_let_ty(err, expr, error);
-        self.suggest_compatible_variants(err, expr, expected, expr_ty);
         self.suggest_deref_ref_or_into(err, expr, expected, expr_ty, expected_ty_expr);
+        self.suggest_compatible_variants(err, expr, expected, expr_ty);
         if self.suggest_calling_boxed_future_when_appropriate(err, expr, expected, expr_ty) {
             return;
         }

--- a/src/test/ui/infinite/infinite-autoderef.stderr
+++ b/src/test/ui/infinite/infinite-autoderef.stderr
@@ -2,9 +2,12 @@ error[E0308]: mismatched types
   --> $DIR/infinite-autoderef.rs:20:13
    |
 LL |         x = Box::new(x);
-   |             ^^^^^^^^^^^- help: try using a conversion method: `.to_string()`
-   |             |
-   |             cyclic type of infinite size
+   |             ^^^^^^^^^^^ cyclic type of infinite size
+   |
+help: consider unboxing the value
+   |
+LL |         x = *Box::new(x);
+   |             +
 
 error[E0055]: reached the recursion limit while auto-dereferencing `Foo`
   --> $DIR/infinite-autoderef.rs:25:5

--- a/src/test/ui/occurs-check-2.stderr
+++ b/src/test/ui/occurs-check-2.stderr
@@ -2,9 +2,12 @@ error[E0308]: mismatched types
   --> $DIR/occurs-check-2.rs:7:9
    |
 LL |     f = Box::new(g);
-   |         ^^^^^^^^^^^- help: try using a conversion method: `.to_string()`
-   |         |
-   |         cyclic type of infinite size
+   |         ^^^^^^^^^^^ cyclic type of infinite size
+   |
+help: consider unboxing the value
+   |
+LL |     f = *Box::new(g);
+   |         +
 
 error: aborting due to previous error
 

--- a/src/test/ui/occurs-check.stderr
+++ b/src/test/ui/occurs-check.stderr
@@ -2,9 +2,12 @@ error[E0308]: mismatched types
   --> $DIR/occurs-check.rs:5:9
    |
 LL |     f = Box::new(f);
-   |         ^^^^^^^^^^^- help: try using a conversion method: `.to_string()`
-   |         |
-   |         cyclic type of infinite size
+   |         ^^^^^^^^^^^ cyclic type of infinite size
+   |
+help: consider unboxing the value
+   |
+LL |     f = *Box::new(f);
+   |         +
 
 error: aborting due to previous error
 

--- a/src/test/ui/span/coerce-suggestions.stderr
+++ b/src/test/ui/span/coerce-suggestions.stderr
@@ -38,9 +38,12 @@ error[E0308]: mismatched types
   --> $DIR/coerce-suggestions.rs:17:9
    |
 LL |     f = Box::new(f);
-   |         ^^^^^^^^^^^- help: try using a conversion method: `.to_string()`
-   |         |
-   |         cyclic type of infinite size
+   |         ^^^^^^^^^^^ cyclic type of infinite size
+   |
+help: consider unboxing the value
+   |
+LL |     f = *Box::new(f);
+   |         +
 
 error[E0308]: mismatched types
   --> $DIR/coerce-suggestions.rs:21:9

--- a/src/test/ui/suggestions/boxed-variant-field.rs
+++ b/src/test/ui/suggestions/boxed-variant-field.rs
@@ -8,7 +8,7 @@ fn foo(x: Ty) -> Ty {
         Ty::Unit => Ty::Unit,
         Ty::List(elem) => foo(elem),
         //~^ ERROR mismatched types
-        //~| HELP try dereferencing the `Box`
+        //~| HELP consider unboxing the value
         //~| HELP try wrapping
     }
 }

--- a/src/test/ui/suggestions/boxed-variant-field.stderr
+++ b/src/test/ui/suggestions/boxed-variant-field.stderr
@@ -6,14 +6,14 @@ LL |         Ty::List(elem) => foo(elem),
    |
    = note: expected enum `Ty`
             found struct `Box<Ty>`
-help: try wrapping the expression in `Ty::List`
-   |
-LL |         Ty::List(elem) => foo(Ty::List(elem)),
-   |                               +++++++++    +
 help: consider unboxing the value
    |
 LL |         Ty::List(elem) => foo(*elem),
    |                               +
+help: try wrapping the expression in `Ty::List`
+   |
+LL |         Ty::List(elem) => foo(Ty::List(elem)),
+   |                               +++++++++    +
 
 error: aborting due to previous error
 

--- a/src/test/ui/suggestions/boxed-variant-field.stderr
+++ b/src/test/ui/suggestions/boxed-variant-field.stderr
@@ -6,14 +6,14 @@ LL |         Ty::List(elem) => foo(elem),
    |
    = note: expected enum `Ty`
             found struct `Box<Ty>`
-help: try dereferencing the `Box`
-   |
-LL |         Ty::List(elem) => foo(*elem),
-   |                               +
 help: try wrapping the expression in `Ty::List`
    |
 LL |         Ty::List(elem) => foo(Ty::List(elem)),
    |                               +++++++++    +
+help: consider unboxing the value
+   |
+LL |         Ty::List(elem) => foo(*elem),
+   |                               +
 
 error: aborting due to previous error
 

--- a/src/test/ui/terr-sorts.stderr
+++ b/src/test/ui/terr-sorts.stderr
@@ -6,7 +6,7 @@ LL |     want_foo(b);
    |
    = note: expected struct `Foo`
               found struct `Box<Foo>`
-help: try dereferencing the `Box`
+help: consider unboxing the value
    |
 LL |     want_foo(*b);
    |              +


### PR DESCRIPTION
Remove the suggestion code special-cased for Box deref.

r? @camelid 
since you introduced the code in #90627