### PR TITLE
Fix some lints documentation

### DIFF
--- a/compiler/rustc_lint/src/builtin.rs
+++ b/compiler/rustc_lint/src/builtin.rs
@@ -3147,6 +3147,7 @@ declare_lint! {
     /// ### Example
     ///
     /// ```rust,compile_fail
+    /// # #![feature(asm)]
     /// use std::arch::asm;
     ///
     /// fn main() {

--- a/compiler/rustc_lint/src/builtin.rs
+++ b/compiler/rustc_lint/src/builtin.rs
@@ -3147,7 +3147,6 @@ declare_lint! {
     /// ### Example
     ///
     /// ```rust,compile_fail
-    /// # #![feature(asm)]
     /// use std::arch::asm;
     ///
     /// fn main() {

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -1805,7 +1805,7 @@ declare_lint! {
     ///
     /// ### Example
     ///
-    /// ```
+    /// ```rust
     /// if let _ = 123 {
     ///     println!("always runs!");
     /// }
@@ -2431,7 +2431,19 @@ declare_lint! {
     /// }
     /// ```
     ///
-    /// {{produces}}
+    /// This will produce:
+    ///
+    /// ```text
+    /// warning: formatting may not be suitable for sub-register argument
+    ///  --> src/main.rs:7:19
+    ///   |
+    /// 7 |         asm!("mov {0}, {0}", in(reg) 0i16);
+    ///   |                   ^^^  ^^^           ---- for this argument
+    ///   |
+    ///   = note: `#[warn(asm_sub_register)]` on by default
+    ///   = help: use the `x` modifier to have the register formatted as `ax`
+    ///   = help: or use the `r` modifier to keep the default formatting of `rax`
+    /// ```
     ///
     /// ### Explanation
     ///
@@ -2470,7 +2482,17 @@ declare_lint! {
     /// }
     /// ```
     ///
-    /// {{produces}}
+    /// This will produce:
+    ///
+    /// ```text
+    /// warning: avoid using `.att_syntax`, prefer using `options(att_syntax)` instead
+    ///  --> src/main.rs:8:14
+    ///   |
+    /// 8 |             ".att_syntax",
+    ///   |              ^^^^^^^^^^^
+    ///   |
+    ///   = note: `#[warn(bad_asm_style)]` on by default
+    /// ```
     ///
     /// ### Explanation
     ///
@@ -2788,7 +2810,7 @@ declare_lint! {
     ///
     /// ### Example
     ///
-    /// ```compile_fail
+    /// ```rust,compile_fail
     /// #![feature(staged_api)]
     ///
     /// #[derive(Clone)]
@@ -3618,7 +3640,17 @@ declare_lint! {
     /// fn foo() {}
     /// ```
     ///
-    /// {{produces}}
+    /// This will produce:
+    ///
+    /// ```text
+    /// warning: duplicated attribute
+    ///  --> src/lib.rs:2:1
+    ///   |
+    /// 2 | #[test]
+    ///   | ^^^^^^^
+    ///   |
+    ///   = note: `#[warn(duplicate_macro_attributes)]` on by default
+    /// ```
     ///
     /// ### Explanation
     ///


### PR DESCRIPTION
Several lints documentation failed to show the output of the example (mostly due to `ignore` attribute):

- [irrefutable_let_patterns](https://doc.rust-lang.org/rustc/lints/listing/warn-by-default.html#irrefutable-let-patterns)
- [asm_sub_register](https://doc.rust-lang.org/rustc/lints/listing/warn-by-default.html#asm-sub-register)
- [bad_asm_style](https://doc.rust-lang.org/rustc/lints/listing/warn-by-default.html#bad-asm-style)
- [ineffective_unstable_trait_impl](https://doc.rust-lang.org/rustc/lints/listing/deny-by-default.html#ineffective-unstable-trait-impl)
- duplicate_macro_attributes

This pull request fixes these lints output so that they can be displayed properly.