### PR TITLE
Improve string concatenation suggestion

### DIFF
--- a/compiler/rustc_typeck/src/check/op.rs
+++ b/compiler/rustc_typeck/src/check/op.rs
@@ -549,11 +549,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         is_assign: IsAssign,
         op: hir::BinOp,
     ) -> bool {
-        let str_concat_note = "String concatenation appends the string on the right to the
-string on the left and may require reallocation.
-This requires ownership of the string on the left.";
+        let str_concat_note = "string concatenation requires an owned `String` on the left";
         let rm_borrow_msg = "remove the borrow to obtain an owned `String`";
-        let to_owned_msg = "use `to_owned()` to create an owned `String` from a string reference";
+        let to_owned_msg = "create an owned `String` from a string reference";
 
         let string_type = self.tcx.get_diagnostic_item(sym::String);
         let is_std_string = |ty: Ty<'tcx>| match ty.ty_adt_def() {
@@ -603,7 +601,7 @@ This requires ownership of the string on the left.";
                             sugg_msg = "remove the borrow on the left and add one on the right";
                             (lhs_expr.span.until(lhs_inner_expr.span), "".to_owned())
                         } else {
-                            sugg_msg = "call `.to_owned()` on the left and add a borrow on the right";
+                            sugg_msg = "create an owned `String` on the left and add a borrow on the right";
                             (lhs_expr.span.shrink_to_hi(), ".to_owned()".to_owned())
                         };
                         let suggestions = vec![

--- a/compiler/rustc_typeck/src/check/op.rs
+++ b/compiler/rustc_typeck/src/check/op.rs
@@ -549,9 +549,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         is_assign: IsAssign,
         op: hir::BinOp,
     ) -> bool {
-        let str_concat_note = "String concatenation appends the string on the right to the \
-                                    string on the left and may require reallocation. This \
-                                    requires ownership of the string on the left.";
+        let str_concat_note = "String concatenation appends the string on the right to the
+string on the left and may require reallocation.
+This requires ownership of the string on the left.";
         let rm_borrow_msg = "remove the borrow to obtain an owned `String`";
         let to_owned_msg = "use `to_owned()` to create an owned `String` from a string reference";
 

--- a/compiler/rustc_typeck/src/check/op.rs
+++ b/compiler/rustc_typeck/src/check/op.rs
@@ -570,14 +570,14 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     err.span_label(op.span, "`+` cannot be used to concatenate two `&str` strings");
                     err.note(str_concat_note);
                     if let hir::ExprKind::AddrOf(_, _, lhs_inner_expr) = lhs_expr.kind {
-                        err.span_suggestion(
+                        err.span_suggestion_verbose(
                             lhs_expr.span.until(lhs_inner_expr.span),
                             rm_borrow_msg,
                             "".to_owned(),
                             Applicability::MachineApplicable
                         );
                     } else {
-                        err.span_suggestion(
+                        err.span_suggestion_verbose(
                             lhs_expr.span.shrink_to_hi(),
                             to_owned_msg,
                             ".to_owned()".to_owned(),
@@ -608,7 +608,11 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             lhs_sugg,
                             (rhs_expr.span.shrink_to_lo(), "&".to_owned()),
                         ];
-                        err.multipart_suggestion(sugg_msg, suggestions, Applicability::MachineApplicable);
+                        err.multipart_suggestion_verbose(
+                            sugg_msg,
+                            suggestions,
+                            Applicability::MachineApplicable,
+                        );
                     }
                     IsAssign::Yes => {
                         err.note(str_concat_note);

--- a/compiler/rustc_typeck/src/check/op.rs
+++ b/compiler/rustc_typeck/src/check/op.rs
@@ -571,7 +571,7 @@ This requires ownership of the string on the left.";
                 if let IsAssign::No = is_assign { // Do not supply this message if `&str += &str`
                     err.span_label(op.span, "`+` cannot be used to concatenate two `&str` strings");
                     err.note(str_concat_note);
-                    if let hir::ExprKind::AddrOf(_,_,lhs_inner_expr) = lhs_expr.kind {
+                    if let hir::ExprKind::AddrOf(_, _, lhs_inner_expr) = lhs_expr.kind {
                         err.span_suggestion(
                             lhs_expr.span.until(lhs_inner_expr.span),
                             rm_borrow_msg,

--- a/src/test/ui/issues/issue-47377.stderr
+++ b/src/test/ui/issues/issue-47377.stderr
@@ -2,13 +2,16 @@ error[E0369]: cannot add `&str` to `&str`
   --> $DIR/issue-47377.rs:4:14
    |
 LL |      let _a = b + ", World!";
-   |               --^ ---------- &str
-   |               |||
-   |               ||`+` cannot be used to concatenate two `&str` strings
-   |               |help: create an owned `String` from a string reference: `.to_owned()`
+   |               - ^ ---------- &str
+   |               | |
+   |               | `+` cannot be used to concatenate two `&str` strings
    |               &str
    |
    = note: string concatenation requires an owned `String` on the left
+help: create an owned `String` from a string reference
+   |
+LL |      let _a = b.to_owned() + ", World!";
+   |                +++++++++++
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-47377.stderr
+++ b/src/test/ui/issues/issue-47377.stderr
@@ -10,7 +10,7 @@ LL |      let _a = b + ", World!";
 help: `to_owned()` can be used to create an owned `String` from a string reference. String concatenation appends the string on the right to the string on the left and may require reallocation. This requires ownership of the string on the left
    |
 LL |      let _a = b.to_owned() + ", World!";
-   |               ~~~~~~~~~~~~
+   |                +++++++++++
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-47377.stderr
+++ b/src/test/ui/issues/issue-47377.stderr
@@ -2,18 +2,13 @@ error[E0369]: cannot add `&str` to `&str`
   --> $DIR/issue-47377.rs:4:14
    |
 LL |      let _a = b + ", World!";
-   |               - ^ ---------- &str
-   |               | |
-   |               | `+` cannot be used to concatenate two `&str` strings
+   |               --^ ---------- &str
+   |               |||
+   |               ||`+` cannot be used to concatenate two `&str` strings
+   |               |help: create an owned `String` from a string reference: `.to_owned()`
    |               &str
    |
-   = note: String concatenation appends the string on the right to the
-           string on the left and may require reallocation.
-           This requires ownership of the string on the left.
-help: use `to_owned()` to create an owned `String` from a string reference
-   |
-LL |      let _a = b.to_owned() + ", World!";
-   |                +++++++++++
+   = note: string concatenation requires an owned `String` on the left
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-47377.stderr
+++ b/src/test/ui/issues/issue-47377.stderr
@@ -7,7 +7,8 @@ LL |      let _a = b + ", World!";
    |               | `+` cannot be used to concatenate two `&str` strings
    |               &str
    |
-help: `to_owned()` can be used to create an owned `String` from a string reference. String concatenation appends the string on the right to the string on the left and may require reallocation. This requires ownership of the string on the left
+   = note: String concatenation appends the string on the right to the string on the left and may require reallocation. This requires ownership of the string on the left.
+help: use `to_owned()` to create an owned `String` from a string reference
    |
 LL |      let _a = b.to_owned() + ", World!";
    |                +++++++++++

--- a/src/test/ui/issues/issue-47377.stderr
+++ b/src/test/ui/issues/issue-47377.stderr
@@ -7,7 +7,9 @@ LL |      let _a = b + ", World!";
    |               | `+` cannot be used to concatenate two `&str` strings
    |               &str
    |
-   = note: String concatenation appends the string on the right to the string on the left and may require reallocation. This requires ownership of the string on the left.
+   = note: String concatenation appends the string on the right to the
+           string on the left and may require reallocation.
+           This requires ownership of the string on the left.
 help: use `to_owned()` to create an owned `String` from a string reference
    |
 LL |      let _a = b.to_owned() + ", World!";

--- a/src/test/ui/issues/issue-47380.stderr
+++ b/src/test/ui/issues/issue-47380.stderr
@@ -7,7 +7,8 @@ LL |     println!("🦀🦀🦀🦀🦀"); let _a = b + ", World!";
    |                                      | `+` cannot be used to concatenate two `&str` strings
    |                                      &str
    |
-help: `to_owned()` can be used to create an owned `String` from a string reference. String concatenation appends the string on the right to the string on the left and may require reallocation. This requires ownership of the string on the left
+   = note: String concatenation appends the string on the right to the string on the left and may require reallocation. This requires ownership of the string on the left.
+help: use `to_owned()` to create an owned `String` from a string reference
    |
 LL |     println!("🦀🦀🦀🦀🦀"); let _a = b.to_owned() + ", World!";
    |                                       +++++++++++

--- a/src/test/ui/issues/issue-47380.stderr
+++ b/src/test/ui/issues/issue-47380.stderr
@@ -2,18 +2,13 @@ error[E0369]: cannot add `&str` to `&str`
   --> $DIR/issue-47380.rs:3:35
    |
 LL |     println!("🦀🦀🦀🦀🦀"); let _a = b + ", World!";
-   |                                      - ^ ---------- &str
-   |                                      | |
-   |                                      | `+` cannot be used to concatenate two `&str` strings
+   |                                      --^ ---------- &str
+   |                                      |||
+   |                                      ||`+` cannot be used to concatenate two `&str` strings
+   |                                      |help: create an owned `String` from a string reference: `.to_owned()`
    |                                      &str
    |
-   = note: String concatenation appends the string on the right to the
-           string on the left and may require reallocation.
-           This requires ownership of the string on the left.
-help: use `to_owned()` to create an owned `String` from a string reference
-   |
-LL |     println!("🦀🦀🦀🦀🦀"); let _a = b.to_owned() + ", World!";
-   |                                       +++++++++++
+   = note: string concatenation requires an owned `String` on the left
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-47380.stderr
+++ b/src/test/ui/issues/issue-47380.stderr
@@ -10,7 +10,7 @@ LL |     println!("🦀🦀🦀🦀🦀"); let _a = b + ", World!";
 help: `to_owned()` can be used to create an owned `String` from a string reference. String concatenation appends the string on the right to the string on the left and may require reallocation. This requires ownership of the string on the left
    |
 LL |     println!("🦀🦀🦀🦀🦀"); let _a = b.to_owned() + ", World!";
-   |                                      ~~~~~~~~~~~~
+   |                                       +++++++++++
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-47380.stderr
+++ b/src/test/ui/issues/issue-47380.stderr
@@ -7,7 +7,9 @@ LL |     println!("🦀🦀🦀🦀🦀"); let _a = b + ", World!";
    |                                      | `+` cannot be used to concatenate two `&str` strings
    |                                      &str
    |
-   = note: String concatenation appends the string on the right to the string on the left and may require reallocation. This requires ownership of the string on the left.
+   = note: String concatenation appends the string on the right to the
+           string on the left and may require reallocation.
+           This requires ownership of the string on the left.
 help: use `to_owned()` to create an owned `String` from a string reference
    |
 LL |     println!("🦀🦀🦀🦀🦀"); let _a = b.to_owned() + ", World!";

--- a/src/test/ui/issues/issue-47380.stderr
+++ b/src/test/ui/issues/issue-47380.stderr
@@ -2,13 +2,16 @@ error[E0369]: cannot add `&str` to `&str`
   --> $DIR/issue-47380.rs:3:35
    |
 LL |     println!("🦀🦀🦀🦀🦀"); let _a = b + ", World!";
-   |                                      --^ ---------- &str
-   |                                      |||
-   |                                      ||`+` cannot be used to concatenate two `&str` strings
-   |                                      |help: create an owned `String` from a string reference: `.to_owned()`
+   |                                      - ^ ---------- &str
+   |                                      | |
+   |                                      | `+` cannot be used to concatenate two `&str` strings
    |                                      &str
    |
    = note: string concatenation requires an owned `String` on the left
+help: create an owned `String` from a string reference
+   |
+LL |     println!("🦀🦀🦀🦀🦀"); let _a = b.to_owned() + ", World!";
+   |                                       +++++++++++
 
 error: aborting due to previous error
 

--- a/src/test/ui/span/issue-39018.stderr
+++ b/src/test/ui/span/issue-39018.stderr
@@ -2,13 +2,16 @@ error[E0369]: cannot add `&str` to `&str`
   --> $DIR/issue-39018.rs:2:22
    |
 LL |     let x = "Hello " + "World!";
-   |             ---------^ -------- &str
-   |             |       ||
-   |             |       |`+` cannot be used to concatenate two `&str` strings
-   |             |       help: create an owned `String` from a string reference: `.to_owned()`
+   |             -------- ^ -------- &str
+   |             |        |
+   |             |        `+` cannot be used to concatenate two `&str` strings
    |             &str
    |
    = note: string concatenation requires an owned `String` on the left
+help: create an owned `String` from a string reference
+   |
+LL |     let x = "Hello ".to_owned() + "World!";
+   |                     +++++++++++
 
 error[E0369]: cannot add `World` to `World`
   --> $DIR/issue-39018.rs:8:26
@@ -57,9 +60,13 @@ LL |     let _ = &a + &b;
    |             |  |
    |             |  `+` cannot be used to concatenate two `&str` strings
    |             &String
-   |             help: remove the borrow to obtain an owned `String`
    |
    = note: string concatenation requires an owned `String` on the left
+help: remove the borrow to obtain an owned `String`
+   |
+LL -     let _ = &a + &b;
+LL +     let _ = a + &b;
+   | 
 
 error[E0369]: cannot add `String` to `&String`
   --> $DIR/issue-39018.rs:27:16
@@ -103,37 +110,46 @@ error[E0369]: cannot add `&String` to `&String`
   --> $DIR/issue-39018.rs:31:15
    |
 LL |     let _ = e + &b;
-   |             --^ -- &String
-   |             |||
-   |             ||`+` cannot be used to concatenate two `&str` strings
-   |             |help: create an owned `String` from a string reference: `.to_owned()`
+   |             - ^ -- &String
+   |             | |
+   |             | `+` cannot be used to concatenate two `&str` strings
    |             &String
    |
    = note: string concatenation requires an owned `String` on the left
+help: create an owned `String` from a string reference
+   |
+LL |     let _ = e.to_owned() + &b;
+   |              +++++++++++
 
 error[E0369]: cannot add `&str` to `&String`
   --> $DIR/issue-39018.rs:32:15
    |
 LL |     let _ = e + d;
-   |             --^ - &str
-   |             |||
-   |             ||`+` cannot be used to concatenate two `&str` strings
-   |             |help: create an owned `String` from a string reference: `.to_owned()`
+   |             - ^ - &str
+   |             | |
+   |             | `+` cannot be used to concatenate two `&str` strings
    |             &String
    |
    = note: string concatenation requires an owned `String` on the left
+help: create an owned `String` from a string reference
+   |
+LL |     let _ = e.to_owned() + d;
+   |              +++++++++++
 
 error[E0369]: cannot add `&&str` to `&String`
   --> $DIR/issue-39018.rs:33:15
    |
 LL |     let _ = e + &d;
-   |             --^ -- &&str
-   |             |||
-   |             ||`+` cannot be used to concatenate two `&str` strings
-   |             |help: create an owned `String` from a string reference: `.to_owned()`
+   |             - ^ -- &&str
+   |             | |
+   |             | `+` cannot be used to concatenate two `&str` strings
    |             &String
    |
    = note: string concatenation requires an owned `String` on the left
+help: create an owned `String` from a string reference
+   |
+LL |     let _ = e.to_owned() + &d;
+   |              +++++++++++
 
 error[E0369]: cannot add `&&str` to `&&str`
   --> $DIR/issue-39018.rs:34:16
@@ -155,25 +171,31 @@ error[E0369]: cannot add `&&str` to `&str`
   --> $DIR/issue-39018.rs:36:15
    |
 LL |     let _ = c + &d;
-   |             --^ -- &&str
-   |             |||
-   |             ||`+` cannot be used to concatenate two `&str` strings
-   |             |help: create an owned `String` from a string reference: `.to_owned()`
+   |             - ^ -- &&str
+   |             | |
+   |             | `+` cannot be used to concatenate two `&str` strings
    |             &str
    |
    = note: string concatenation requires an owned `String` on the left
+help: create an owned `String` from a string reference
+   |
+LL |     let _ = c.to_owned() + &d;
+   |              +++++++++++
 
 error[E0369]: cannot add `&str` to `&str`
   --> $DIR/issue-39018.rs:37:15
    |
 LL |     let _ = c + d;
-   |             --^ - &str
-   |             |||
-   |             ||`+` cannot be used to concatenate two `&str` strings
-   |             |help: create an owned `String` from a string reference: `.to_owned()`
+   |             - ^ - &str
+   |             | |
+   |             | `+` cannot be used to concatenate two `&str` strings
    |             &str
    |
    = note: string concatenation requires an owned `String` on the left
+help: create an owned `String` from a string reference
+   |
+LL |     let _ = c.to_owned() + d;
+   |              +++++++++++
 
 error: aborting due to 14 previous errors
 

--- a/src/test/ui/span/issue-39018.stderr
+++ b/src/test/ui/span/issue-39018.stderr
@@ -7,7 +7,9 @@ LL |     let x = "Hello " + "World!";
    |             |        `+` cannot be used to concatenate two `&str` strings
    |             &str
    |
-   = note: String concatenation appends the string on the right to the string on the left and may require reallocation. This requires ownership of the string on the left.
+   = note: String concatenation appends the string on the right to the
+           string on the left and may require reallocation.
+           This requires ownership of the string on the left.
 help: use `to_owned()` to create an owned `String` from a string reference
    |
 LL |     let x = "Hello ".to_owned() + "World!";
@@ -62,7 +64,9 @@ LL |     let _ = &a + &b;
    |             &String
    |             help: remove the borrow to obtain an owned `String`
    |
-   = note: String concatenation appends the string on the right to the string on the left and may require reallocation. This requires ownership of the string on the left.
+   = note: String concatenation appends the string on the right to the
+           string on the left and may require reallocation.
+           This requires ownership of the string on the left.
 
 error[E0369]: cannot add `String` to `&String`
   --> $DIR/issue-39018.rs:27:16
@@ -111,7 +115,9 @@ LL |     let _ = e + &b;
    |             | `+` cannot be used to concatenate two `&str` strings
    |             &String
    |
-   = note: String concatenation appends the string on the right to the string on the left and may require reallocation. This requires ownership of the string on the left.
+   = note: String concatenation appends the string on the right to the
+           string on the left and may require reallocation.
+           This requires ownership of the string on the left.
 help: use `to_owned()` to create an owned `String` from a string reference
    |
 LL |     let _ = e.to_owned() + &b;
@@ -126,7 +132,9 @@ LL |     let _ = e + d;
    |             | `+` cannot be used to concatenate two `&str` strings
    |             &String
    |
-   = note: String concatenation appends the string on the right to the string on the left and may require reallocation. This requires ownership of the string on the left.
+   = note: String concatenation appends the string on the right to the
+           string on the left and may require reallocation.
+           This requires ownership of the string on the left.
 help: use `to_owned()` to create an owned `String` from a string reference
    |
 LL |     let _ = e.to_owned() + d;
@@ -141,7 +149,9 @@ LL |     let _ = e + &d;
    |             | `+` cannot be used to concatenate two `&str` strings
    |             &String
    |
-   = note: String concatenation appends the string on the right to the string on the left and may require reallocation. This requires ownership of the string on the left.
+   = note: String concatenation appends the string on the right to the
+           string on the left and may require reallocation.
+           This requires ownership of the string on the left.
 help: use `to_owned()` to create an owned `String` from a string reference
    |
 LL |     let _ = e.to_owned() + &d;
@@ -172,7 +182,9 @@ LL |     let _ = c + &d;
    |             | `+` cannot be used to concatenate two `&str` strings
    |             &str
    |
-   = note: String concatenation appends the string on the right to the string on the left and may require reallocation. This requires ownership of the string on the left.
+   = note: String concatenation appends the string on the right to the
+           string on the left and may require reallocation.
+           This requires ownership of the string on the left.
 help: use `to_owned()` to create an owned `String` from a string reference
    |
 LL |     let _ = c.to_owned() + &d;
@@ -187,7 +199,9 @@ LL |     let _ = c + d;
    |             | `+` cannot be used to concatenate two `&str` strings
    |             &str
    |
-   = note: String concatenation appends the string on the right to the string on the left and may require reallocation. This requires ownership of the string on the left.
+   = note: String concatenation appends the string on the right to the
+           string on the left and may require reallocation.
+           This requires ownership of the string on the left.
 help: use `to_owned()` to create an owned `String` from a string reference
    |
 LL |     let _ = c.to_owned() + d;

--- a/src/test/ui/span/issue-39018.stderr
+++ b/src/test/ui/span/issue-39018.stderr
@@ -7,7 +7,8 @@ LL |     let x = "Hello " + "World!";
    |             |        `+` cannot be used to concatenate two `&str` strings
    |             &str
    |
-help: `to_owned()` can be used to create an owned `String` from a string reference. String concatenation appends the string on the right to the string on the left and may require reallocation. This requires ownership of the string on the left
+   = note: String concatenation appends the string on the right to the string on the left and may require reallocation. This requires ownership of the string on the left.
+help: use `to_owned()` to create an owned `String` from a string reference
    |
 LL |     let x = "Hello ".to_owned() + "World!";
    |                     +++++++++++
@@ -46,7 +47,7 @@ LL |     let x = "Hello " + "World!".to_owned();
    |             |        `+` cannot be used to concatenate a `&str` with a `String`
    |             &str
    |
-help: `to_owned()` can be used to create an owned `String` from a string reference. String concatenation appends the string on the right to the string on the left and may require reallocation. This requires ownership of the string on the left
+help: call `.to_owned()` on the left and add a borrow on the right
    |
 LL |     let x = "Hello ".to_owned() + &"World!".to_owned();
    |                     +++++++++++   +
@@ -59,12 +60,9 @@ LL |     let _ = &a + &b;
    |             |  |
    |             |  `+` cannot be used to concatenate two `&str` strings
    |             &String
+   |             help: remove the borrow to obtain an owned `String`
    |
-help: String concatenation appends the string on the right to the string on the left and may require reallocation. This requires ownership of the string on the left
-   |
-LL -     let _ = &a + &b;
-LL +     let _ = a + &b;
-   | 
+   = note: String concatenation appends the string on the right to the string on the left and may require reallocation. This requires ownership of the string on the left.
 
 error[E0369]: cannot add `String` to `&String`
   --> $DIR/issue-39018.rs:27:16
@@ -75,7 +73,7 @@ LL |     let _ = &a + b;
    |             |  `+` cannot be used to concatenate a `&str` with a `String`
    |             &String
    |
-help: `to_owned()` can be used to create an owned `String` from a string reference. String concatenation appends the string on the right to the string on the left and may require reallocation. This requires ownership of the string on the left
+help: remove the borrow on the left and add one on the right
    |
 LL -     let _ = &a + b;
 LL +     let _ = a + &b;
@@ -99,7 +97,7 @@ LL |     let _ = e + b;
    |             | `+` cannot be used to concatenate a `&str` with a `String`
    |             &String
    |
-help: `to_owned()` can be used to create an owned `String` from a string reference. String concatenation appends the string on the right to the string on the left and may require reallocation. This requires ownership of the string on the left
+help: call `.to_owned()` on the left and add a borrow on the right
    |
 LL |     let _ = e.to_owned() + &b;
    |              +++++++++++   +
@@ -113,7 +111,8 @@ LL |     let _ = e + &b;
    |             | `+` cannot be used to concatenate two `&str` strings
    |             &String
    |
-help: `to_owned()` can be used to create an owned `String` from a string reference. String concatenation appends the string on the right to the string on the left and may require reallocation. This requires ownership of the string on the left
+   = note: String concatenation appends the string on the right to the string on the left and may require reallocation. This requires ownership of the string on the left.
+help: use `to_owned()` to create an owned `String` from a string reference
    |
 LL |     let _ = e.to_owned() + &b;
    |              +++++++++++
@@ -127,7 +126,8 @@ LL |     let _ = e + d;
    |             | `+` cannot be used to concatenate two `&str` strings
    |             &String
    |
-help: `to_owned()` can be used to create an owned `String` from a string reference. String concatenation appends the string on the right to the string on the left and may require reallocation. This requires ownership of the string on the left
+   = note: String concatenation appends the string on the right to the string on the left and may require reallocation. This requires ownership of the string on the left.
+help: use `to_owned()` to create an owned `String` from a string reference
    |
 LL |     let _ = e.to_owned() + d;
    |              +++++++++++
@@ -141,7 +141,8 @@ LL |     let _ = e + &d;
    |             | `+` cannot be used to concatenate two `&str` strings
    |             &String
    |
-help: `to_owned()` can be used to create an owned `String` from a string reference. String concatenation appends the string on the right to the string on the left and may require reallocation. This requires ownership of the string on the left
+   = note: String concatenation appends the string on the right to the string on the left and may require reallocation. This requires ownership of the string on the left.
+help: use `to_owned()` to create an owned `String` from a string reference
    |
 LL |     let _ = e.to_owned() + &d;
    |              +++++++++++
@@ -171,7 +172,8 @@ LL |     let _ = c + &d;
    |             | `+` cannot be used to concatenate two `&str` strings
    |             &str
    |
-help: `to_owned()` can be used to create an owned `String` from a string reference. String concatenation appends the string on the right to the string on the left and may require reallocation. This requires ownership of the string on the left
+   = note: String concatenation appends the string on the right to the string on the left and may require reallocation. This requires ownership of the string on the left.
+help: use `to_owned()` to create an owned `String` from a string reference
    |
 LL |     let _ = c.to_owned() + &d;
    |              +++++++++++
@@ -185,7 +187,8 @@ LL |     let _ = c + d;
    |             | `+` cannot be used to concatenate two `&str` strings
    |             &str
    |
-help: `to_owned()` can be used to create an owned `String` from a string reference. String concatenation appends the string on the right to the string on the left and may require reallocation. This requires ownership of the string on the left
+   = note: String concatenation appends the string on the right to the string on the left and may require reallocation. This requires ownership of the string on the left.
+help: use `to_owned()` to create an owned `String` from a string reference
    |
 LL |     let _ = c.to_owned() + d;
    |              +++++++++++

--- a/src/test/ui/span/issue-39018.stderr
+++ b/src/test/ui/span/issue-39018.stderr
@@ -10,7 +10,7 @@ LL |     let x = "Hello " + "World!";
 help: `to_owned()` can be used to create an owned `String` from a string reference. String concatenation appends the string on the right to the string on the left and may require reallocation. This requires ownership of the string on the left
    |
 LL |     let x = "Hello ".to_owned() + "World!";
-   |             ~~~~~~~~~~~~~~~~~~~
+   |                     +++++++++++
 
 error[E0369]: cannot add `World` to `World`
   --> $DIR/issue-39018.rs:8:26
@@ -49,7 +49,7 @@ LL |     let x = "Hello " + "World!".to_owned();
 help: `to_owned()` can be used to create an owned `String` from a string reference. String concatenation appends the string on the right to the string on the left and may require reallocation. This requires ownership of the string on the left
    |
 LL |     let x = "Hello ".to_owned() + &"World!".to_owned();
-   |             ~~~~~~~~~~~~~~~~~~~   ~~~~~~~~~~~~~~~~~~~~
+   |                     +++++++++++   +
 
 error[E0369]: cannot add `&String` to `&String`
   --> $DIR/issue-39018.rs:26:16
@@ -62,8 +62,9 @@ LL |     let _ = &a + &b;
    |
 help: String concatenation appends the string on the right to the string on the left and may require reallocation. This requires ownership of the string on the left
    |
-LL |     let _ = a + &b;
-   |             ~
+LL -     let _ = &a + &b;
+LL +     let _ = a + &b;
+   | 
 
 error[E0369]: cannot add `String` to `&String`
   --> $DIR/issue-39018.rs:27:16
@@ -76,8 +77,9 @@ LL |     let _ = &a + b;
    |
 help: `to_owned()` can be used to create an owned `String` from a string reference. String concatenation appends the string on the right to the string on the left and may require reallocation. This requires ownership of the string on the left
    |
-LL |     let _ = a + &b;
-   |             ~   ~~
+LL -     let _ = &a + b;
+LL +     let _ = a + &b;
+   | 
 
 error[E0308]: mismatched types
   --> $DIR/issue-39018.rs:29:17
@@ -100,7 +102,7 @@ LL |     let _ = e + b;
 help: `to_owned()` can be used to create an owned `String` from a string reference. String concatenation appends the string on the right to the string on the left and may require reallocation. This requires ownership of the string on the left
    |
 LL |     let _ = e.to_owned() + &b;
-   |             ~~~~~~~~~~~~   ~~
+   |              +++++++++++   +
 
 error[E0369]: cannot add `&String` to `&String`
   --> $DIR/issue-39018.rs:31:15
@@ -114,7 +116,7 @@ LL |     let _ = e + &b;
 help: `to_owned()` can be used to create an owned `String` from a string reference. String concatenation appends the string on the right to the string on the left and may require reallocation. This requires ownership of the string on the left
    |
 LL |     let _ = e.to_owned() + &b;
-   |             ~~~~~~~~~~~~
+   |              +++++++++++
 
 error[E0369]: cannot add `&str` to `&String`
   --> $DIR/issue-39018.rs:32:15
@@ -128,7 +130,7 @@ LL |     let _ = e + d;
 help: `to_owned()` can be used to create an owned `String` from a string reference. String concatenation appends the string on the right to the string on the left and may require reallocation. This requires ownership of the string on the left
    |
 LL |     let _ = e.to_owned() + d;
-   |             ~~~~~~~~~~~~
+   |              +++++++++++
 
 error[E0369]: cannot add `&&str` to `&String`
   --> $DIR/issue-39018.rs:33:15
@@ -142,7 +144,7 @@ LL |     let _ = e + &d;
 help: `to_owned()` can be used to create an owned `String` from a string reference. String concatenation appends the string on the right to the string on the left and may require reallocation. This requires ownership of the string on the left
    |
 LL |     let _ = e.to_owned() + &d;
-   |             ~~~~~~~~~~~~
+   |              +++++++++++
 
 error[E0369]: cannot add `&&str` to `&&str`
   --> $DIR/issue-39018.rs:34:16
@@ -172,7 +174,7 @@ LL |     let _ = c + &d;
 help: `to_owned()` can be used to create an owned `String` from a string reference. String concatenation appends the string on the right to the string on the left and may require reallocation. This requires ownership of the string on the left
    |
 LL |     let _ = c.to_owned() + &d;
-   |             ~~~~~~~~~~~~
+   |              +++++++++++
 
 error[E0369]: cannot add `&str` to `&str`
   --> $DIR/issue-39018.rs:37:15
@@ -186,7 +188,7 @@ LL |     let _ = c + d;
 help: `to_owned()` can be used to create an owned `String` from a string reference. String concatenation appends the string on the right to the string on the left and may require reallocation. This requires ownership of the string on the left
    |
 LL |     let _ = c.to_owned() + d;
-   |             ~~~~~~~~~~~~
+   |              +++++++++++
 
 error: aborting due to 14 previous errors
 

--- a/src/test/ui/span/issue-39018.stderr
+++ b/src/test/ui/span/issue-39018.stderr
@@ -2,18 +2,13 @@ error[E0369]: cannot add `&str` to `&str`
   --> $DIR/issue-39018.rs:2:22
    |
 LL |     let x = "Hello " + "World!";
-   |             -------- ^ -------- &str
-   |             |        |
-   |             |        `+` cannot be used to concatenate two `&str` strings
+   |             ---------^ -------- &str
+   |             |       ||
+   |             |       |`+` cannot be used to concatenate two `&str` strings
+   |             |       help: create an owned `String` from a string reference: `.to_owned()`
    |             &str
    |
-   = note: String concatenation appends the string on the right to the
-           string on the left and may require reallocation.
-           This requires ownership of the string on the left.
-help: use `to_owned()` to create an owned `String` from a string reference
-   |
-LL |     let x = "Hello ".to_owned() + "World!";
-   |                     +++++++++++
+   = note: string concatenation requires an owned `String` on the left
 
 error[E0369]: cannot add `World` to `World`
   --> $DIR/issue-39018.rs:8:26
@@ -49,7 +44,7 @@ LL |     let x = "Hello " + "World!".to_owned();
    |             |        `+` cannot be used to concatenate a `&str` with a `String`
    |             &str
    |
-help: call `.to_owned()` on the left and add a borrow on the right
+help: create an owned `String` on the left and add a borrow on the right
    |
 LL |     let x = "Hello ".to_owned() + &"World!".to_owned();
    |                     +++++++++++   +
@@ -64,9 +59,7 @@ LL |     let _ = &a + &b;
    |             &String
    |             help: remove the borrow to obtain an owned `String`
    |
-   = note: String concatenation appends the string on the right to the
-           string on the left and may require reallocation.
-           This requires ownership of the string on the left.
+   = note: string concatenation requires an owned `String` on the left
 
 error[E0369]: cannot add `String` to `&String`
   --> $DIR/issue-39018.rs:27:16
@@ -101,7 +94,7 @@ LL |     let _ = e + b;
    |             | `+` cannot be used to concatenate a `&str` with a `String`
    |             &String
    |
-help: call `.to_owned()` on the left and add a borrow on the right
+help: create an owned `String` on the left and add a borrow on the right
    |
 LL |     let _ = e.to_owned() + &b;
    |              +++++++++++   +
@@ -110,52 +103,37 @@ error[E0369]: cannot add `&String` to `&String`
   --> $DIR/issue-39018.rs:31:15
    |
 LL |     let _ = e + &b;
-   |             - ^ -- &String
-   |             | |
-   |             | `+` cannot be used to concatenate two `&str` strings
+   |             --^ -- &String
+   |             |||
+   |             ||`+` cannot be used to concatenate two `&str` strings
+   |             |help: create an owned `String` from a string reference: `.to_owned()`
    |             &String
    |
-   = note: String concatenation appends the string on the right to the
-           string on the left and may require reallocation.
-           This requires ownership of the string on the left.
-help: use `to_owned()` to create an owned `String` from a string reference
-   |
-LL |     let _ = e.to_owned() + &b;
-   |              +++++++++++
+   = note: string concatenation requires an owned `String` on the left
 
 error[E0369]: cannot add `&str` to `&String`
   --> $DIR/issue-39018.rs:32:15
    |
 LL |     let _ = e + d;
-   |             - ^ - &str
-   |             | |
-   |             | `+` cannot be used to concatenate two `&str` strings
+   |             --^ - &str
+   |             |||
+   |             ||`+` cannot be used to concatenate two `&str` strings
+   |             |help: create an owned `String` from a string reference: `.to_owned()`
    |             &String
    |
-   = note: String concatenation appends the string on the right to the
-           string on the left and may require reallocation.
-           This requires ownership of the string on the left.
-help: use `to_owned()` to create an owned `String` from a string reference
-   |
-LL |     let _ = e.to_owned() + d;
-   |              +++++++++++
+   = note: string concatenation requires an owned `String` on the left
 
 error[E0369]: cannot add `&&str` to `&String`
   --> $DIR/issue-39018.rs:33:15
    |
 LL |     let _ = e + &d;
-   |             - ^ -- &&str
-   |             | |
-   |             | `+` cannot be used to concatenate two `&str` strings
+   |             --^ -- &&str
+   |             |||
+   |             ||`+` cannot be used to concatenate two `&str` strings
+   |             |help: create an owned `String` from a string reference: `.to_owned()`
    |             &String
    |
-   = note: String concatenation appends the string on the right to the
-           string on the left and may require reallocation.
-           This requires ownership of the string on the left.
-help: use `to_owned()` to create an owned `String` from a string reference
-   |
-LL |     let _ = e.to_owned() + &d;
-   |              +++++++++++
+   = note: string concatenation requires an owned `String` on the left
 
 error[E0369]: cannot add `&&str` to `&&str`
   --> $DIR/issue-39018.rs:34:16
@@ -177,35 +155,25 @@ error[E0369]: cannot add `&&str` to `&str`
   --> $DIR/issue-39018.rs:36:15
    |
 LL |     let _ = c + &d;
-   |             - ^ -- &&str
-   |             | |
-   |             | `+` cannot be used to concatenate two `&str` strings
+   |             --^ -- &&str
+   |             |||
+   |             ||`+` cannot be used to concatenate two `&str` strings
+   |             |help: create an owned `String` from a string reference: `.to_owned()`
    |             &str
    |
-   = note: String concatenation appends the string on the right to the
-           string on the left and may require reallocation.
-           This requires ownership of the string on the left.
-help: use `to_owned()` to create an owned `String` from a string reference
-   |
-LL |     let _ = c.to_owned() + &d;
-   |              +++++++++++
+   = note: string concatenation requires an owned `String` on the left
 
 error[E0369]: cannot add `&str` to `&str`
   --> $DIR/issue-39018.rs:37:15
    |
 LL |     let _ = c + d;
-   |             - ^ - &str
-   |             | |
-   |             | `+` cannot be used to concatenate two `&str` strings
+   |             --^ - &str
+   |             |||
+   |             ||`+` cannot be used to concatenate two `&str` strings
+   |             |help: create an owned `String` from a string reference: `.to_owned()`
    |             &str
    |
-   = note: String concatenation appends the string on the right to the
-           string on the left and may require reallocation.
-           This requires ownership of the string on the left.
-help: use `to_owned()` to create an owned `String` from a string reference
-   |
-LL |     let _ = c.to_owned() + d;
-   |              +++++++++++
+   = note: string concatenation requires an owned `String` on the left
 
 error: aborting due to 14 previous errors
 

--- a/src/test/ui/str/str-concat-on-double-ref.stderr
+++ b/src/test/ui/str/str-concat-on-double-ref.stderr
@@ -7,7 +7,8 @@ LL |     let c = a + b;
    |             | `+` cannot be used to concatenate two `&str` strings
    |             &String
    |
-help: `to_owned()` can be used to create an owned `String` from a string reference. String concatenation appends the string on the right to the string on the left and may require reallocation. This requires ownership of the string on the left
+   = note: String concatenation appends the string on the right to the string on the left and may require reallocation. This requires ownership of the string on the left.
+help: use `to_owned()` to create an owned `String` from a string reference
    |
 LL |     let c = a.to_owned() + b;
    |              +++++++++++

--- a/src/test/ui/str/str-concat-on-double-ref.stderr
+++ b/src/test/ui/str/str-concat-on-double-ref.stderr
@@ -2,18 +2,13 @@ error[E0369]: cannot add `&str` to `&String`
   --> $DIR/str-concat-on-double-ref.rs:4:15
    |
 LL |     let c = a + b;
-   |             - ^ - &str
-   |             | |
-   |             | `+` cannot be used to concatenate two `&str` strings
+   |             --^ - &str
+   |             |||
+   |             ||`+` cannot be used to concatenate two `&str` strings
+   |             |help: create an owned `String` from a string reference: `.to_owned()`
    |             &String
    |
-   = note: String concatenation appends the string on the right to the
-           string on the left and may require reallocation.
-           This requires ownership of the string on the left.
-help: use `to_owned()` to create an owned `String` from a string reference
-   |
-LL |     let c = a.to_owned() + b;
-   |              +++++++++++
+   = note: string concatenation requires an owned `String` on the left
 
 error: aborting due to previous error
 

--- a/src/test/ui/str/str-concat-on-double-ref.stderr
+++ b/src/test/ui/str/str-concat-on-double-ref.stderr
@@ -2,13 +2,16 @@ error[E0369]: cannot add `&str` to `&String`
   --> $DIR/str-concat-on-double-ref.rs:4:15
    |
 LL |     let c = a + b;
-   |             --^ - &str
-   |             |||
-   |             ||`+` cannot be used to concatenate two `&str` strings
-   |             |help: create an owned `String` from a string reference: `.to_owned()`
+   |             - ^ - &str
+   |             | |
+   |             | `+` cannot be used to concatenate two `&str` strings
    |             &String
    |
    = note: string concatenation requires an owned `String` on the left
+help: create an owned `String` from a string reference
+   |
+LL |     let c = a.to_owned() + b;
+   |              +++++++++++
 
 error: aborting due to previous error
 

--- a/src/test/ui/str/str-concat-on-double-ref.stderr
+++ b/src/test/ui/str/str-concat-on-double-ref.stderr
@@ -10,7 +10,7 @@ LL |     let c = a + b;
 help: `to_owned()` can be used to create an owned `String` from a string reference. String concatenation appends the string on the right to the string on the left and may require reallocation. This requires ownership of the string on the left
    |
 LL |     let c = a.to_owned() + b;
-   |             ~~~~~~~~~~~~
+   |              +++++++++++
 
 error: aborting due to previous error
 

--- a/src/test/ui/str/str-concat-on-double-ref.stderr
+++ b/src/test/ui/str/str-concat-on-double-ref.stderr
@@ -7,7 +7,9 @@ LL |     let c = a + b;
    |             | `+` cannot be used to concatenate two `&str` strings
    |             &String
    |
-   = note: String concatenation appends the string on the right to the string on the left and may require reallocation. This requires ownership of the string on the left.
+   = note: String concatenation appends the string on the right to the
+           string on the left and may require reallocation.
+           This requires ownership of the string on the left.
 help: use `to_owned()` to create an owned `String` from a string reference
    |
 LL |     let c = a.to_owned() + b;

--- a/src/test/ui/terminal-width/non-1-width-unicode-multiline-label.stderr
+++ b/src/test/ui/terminal-width/non-1-width-unicode-multiline-label.stderr
@@ -7,7 +7,8 @@ LL | ...ཽཾཿ྄ཱྀྀྂྃ྅྆྇ྈྉྊྋྌྍྎྏྐྑྒྒྷྔ
    |                                                  |              `+` cannot be used to concatenate two `&str` strings
    |                                                  &str
    |
-help: `to_owned()` can be used to create an owned `String` from a string reference. String concatenation appends the string on the right to the string on the left and may require reallocation. This requires ownership of the string on the left
+   = note: String concatenation appends the string on the right to the string on the left and may require reallocation. This requires ownership of the string on the left.
+help: use `to_owned()` to create an owned `String` from a string reference
    |
 LL |     let _ = "ༀ༁༂༃༄༅༆༇༈༉༊་༌།༎༏༐༑༒༓༔༕༖༗༘༙༚༛༜༝༞༟༠༡༢༣༤༥༦༧༨༩༪༫༬༭༮༯༰༱༲༳༴༵༶༷༸༹༺༻༼༽༾༿ཀཁགགྷངཅཆཇ཈ཉཊཋཌཌྷཎཏཐདདྷནཔཕབབྷམཙཚཛཛྷཝཞཟའཡརལཤཥསཧཨཀྵཪཫཬ཭཮཯཰ཱཱཱིིུུྲྀཷླྀཹེཻོཽཾཿ྄ཱྀྀྂྃ྅྆྇ྈྉྊྋྌྍྎྏྐྑྒྒྷྔྕྖྗ྘ྙྚྛྜྜྷྞྟྠྡྡྷྣྤྥྦྦྷྨྩྪྫྫྷྭྮྯྰྱྲླྴྵྶྷྸྐྵྺྻྼ྽྾྿࿀࿁࿂࿃࿄࿅࿆࿇࿈࿉࿊࿋࿌࿍࿎࿏࿐࿑࿒࿓࿔࿕࿖࿗࿘࿙࿚"; let _a = unicode_is_fun.to_owned() + " really fun!";
    |                                                                                                                                                                                         +++++++++++

--- a/src/test/ui/terminal-width/non-1-width-unicode-multiline-label.stderr
+++ b/src/test/ui/terminal-width/non-1-width-unicode-multiline-label.stderr
@@ -1,14 +1,17 @@
 error[E0369]: cannot add `&str` to `&str`
   --> $DIR/non-1-width-unicode-multiline-label.rs:5:260
    |
-LL | ...྅྆྇ྈྉྊྋྌྍྎྏྐྑྒྒྷྔྕྖྗ྘ྙྚྛྜྜྷྞྟྠྡྡྷྣྤྥྦྦྷྨྩྪྫྫྷྭྮྯྰྱྲླྴྵྶྷྸྐྵྺྻྼ྽྾྿࿀࿁࿂࿃࿄࿅࿆࿇࿈࿉࿊࿋࿌࿍࿎...࿒࿓࿔࿕࿖࿗࿘࿙࿚"; let _a = unicode_is_fun + " really fun!";
-   |                                                 ---------------^ -------------- &str
-   |                                                 |             ||
-   |                                                 |             |`+` cannot be used to concatenate two `&str` strings
-   |                                                 |             help: create an owned `String` from a string reference: `.to_owned()`
-   |                                                 &str
+LL | ...ཽཾཿ྄ཱྀྀྂྃ྅྆྇ྈྉྊྋྌྍྎྏྐྑྒྒྷྔྕྖྗ྘ྙྚྛྜྜྷྞྟྠྡྡྷྣྤྥྦྦྷྨྩྪྫྫྷྭྮྯྰྱྲླྴྵྶྷྸྐྵྺྻྼ྽྾྿࿀࿁࿂࿃࿄࿅࿆࿇...࿋࿌࿍࿎࿏࿐࿑࿒࿓࿔࿕࿖࿗࿘࿙࿚"; let _a = unicode_is_fun + " really fun!";
+   |                                                  -------------- ^ -------------- &str
+   |                                                  |              |
+   |                                                  |              `+` cannot be used to concatenate two `&str` strings
+   |                                                  &str
    |
    = note: string concatenation requires an owned `String` on the left
+help: create an owned `String` from a string reference
+   |
+LL |     let _ = "ༀ༁༂༃༄༅༆༇༈༉༊་༌།༎༏༐༑༒༓༔༕༖༗༘༙༚༛༜༝༞༟༠༡༢༣༤༥༦༧༨༩༪༫༬༭༮༯༰༱༲༳༴༵༶༷༸༹༺༻༼༽༾༿ཀཁགགྷངཅཆཇ཈ཉཊཋཌཌྷཎཏཐདདྷནཔཕབབྷམཙཚཛཛྷཝཞཟའཡརལཤཥསཧཨཀྵཪཫཬ཭཮཯཰ཱཱཱིིུུྲྀཷླྀཹེཻོཽཾཿ྄ཱྀྀྂྃ྅྆྇ྈྉྊྋྌྍྎྏྐྑྒྒྷྔྕྖྗ྘ྙྚྛྜྜྷྞྟྠྡྡྷྣྤྥྦྦྷྨྩྪྫྫྷྭྮྯྰྱྲླྴྵྶྷྸྐྵྺྻྼ྽྾྿࿀࿁࿂࿃࿄࿅࿆࿇࿈࿉࿊࿋࿌࿍࿎࿏࿐࿑࿒࿓࿔࿕࿖࿗࿘࿙࿚"; let _a = unicode_is_fun.to_owned() + " really fun!";
+   |                                                                                                                                                                                         +++++++++++
 
 error: aborting due to previous error
 

--- a/src/test/ui/terminal-width/non-1-width-unicode-multiline-label.stderr
+++ b/src/test/ui/terminal-width/non-1-width-unicode-multiline-label.stderr
@@ -10,7 +10,7 @@ LL | ...ཽཾཿ྄ཱྀྀྂྃ྅྆྇ྈྉྊྋྌྍྎྏྐྑྒྒྷྔ
 help: `to_owned()` can be used to create an owned `String` from a string reference. String concatenation appends the string on the right to the string on the left and may require reallocation. This requires ownership of the string on the left
    |
 LL |     let _ = "ༀ༁༂༃༄༅༆༇༈༉༊་༌།༎༏༐༑༒༓༔༕༖༗༘༙༚༛༜༝༞༟༠༡༢༣༤༥༦༧༨༩༪༫༬༭༮༯༰༱༲༳༴༵༶༷༸༹༺༻༼༽༾༿ཀཁགགྷངཅཆཇ཈ཉཊཋཌཌྷཎཏཐདདྷནཔཕབབྷམཙཚཛཛྷཝཞཟའཡརལཤཥསཧཨཀྵཪཫཬ཭཮཯཰ཱཱཱིིུུྲྀཷླྀཹེཻོཽཾཿ྄ཱྀྀྂྃ྅྆྇ྈྉྊྋྌྍྎྏྐྑྒྒྷྔྕྖྗ྘ྙྚྛྜྜྷྞྟྠྡྡྷྣྤྥྦྦྷྨྩྪྫྫྷྭྮྯྰྱྲླྴྵྶྷྸྐྵྺྻྼ྽྾྿࿀࿁࿂࿃࿄࿅࿆࿇࿈࿉࿊࿋࿌࿍࿎࿏࿐࿑࿒࿓࿔࿕࿖࿗࿘࿙࿚"; let _a = unicode_is_fun.to_owned() + " really fun!";
-   |                                                                                                                                                                           ~~~~~~~~~~~~~~~~~~~~~~~~~
+   |                                                                                                                                                                                         +++++++++++
 
 error: aborting due to previous error
 

--- a/src/test/ui/terminal-width/non-1-width-unicode-multiline-label.stderr
+++ b/src/test/ui/terminal-width/non-1-width-unicode-multiline-label.stderr
@@ -7,7 +7,9 @@ LL | ...ཽཾཿ྄ཱྀྀྂྃ྅྆྇ྈྉྊྋྌྍྎྏྐྑྒྒྷྔ
    |                                                  |              `+` cannot be used to concatenate two `&str` strings
    |                                                  &str
    |
-   = note: String concatenation appends the string on the right to the string on the left and may require reallocation. This requires ownership of the string on the left.
+   = note: String concatenation appends the string on the right to the
+           string on the left and may require reallocation.
+           This requires ownership of the string on the left.
 help: use `to_owned()` to create an owned `String` from a string reference
    |
 LL |     let _ = "ༀ༁༂༃༄༅༆༇༈༉༊་༌།༎༏༐༑༒༓༔༕༖༗༘༙༚༛༜༝༞༟༠༡༢༣༤༥༦༧༨༩༪༫༬༭༮༯༰༱༲༳༴༵༶༷༸༹༺༻༼༽༾༿ཀཁགགྷངཅཆཇ཈ཉཊཋཌཌྷཎཏཐདདྷནཔཕབབྷམཙཚཛཛྷཝཞཟའཡརལཤཥསཧཨཀྵཪཫཬ཭཮཯཰ཱཱཱིིུུྲྀཷླྀཹེཻོཽཾཿ྄ཱྀྀྂྃ྅྆྇ྈྉྊྋྌྍྎྏྐྑྒྒྷྔྕྖྗ྘ྙྚྛྜྜྷྞྟྠྡྡྷྣྤྥྦྦྷྨྩྪྫྫྷྭྮྯྰྱྲླྴྵྶྷྸྐྵྺྻྼ྽྾྿࿀࿁࿂࿃࿄࿅࿆࿇࿈࿉࿊࿋࿌࿍࿎࿏࿐࿑࿒࿓࿔࿕࿖࿗࿘࿙࿚"; let _a = unicode_is_fun.to_owned() + " really fun!";

--- a/src/test/ui/terminal-width/non-1-width-unicode-multiline-label.stderr
+++ b/src/test/ui/terminal-width/non-1-width-unicode-multiline-label.stderr
@@ -1,19 +1,14 @@
 error[E0369]: cannot add `&str` to `&str`
   --> $DIR/non-1-width-unicode-multiline-label.rs:5:260
    |
-LL | ...ཽཾཿ྄ཱྀྀྂྃ྅྆྇ྈྉྊྋྌྍྎྏྐྑྒྒྷྔྕྖྗ྘ྙྚྛྜྜྷྞྟྠྡྡྷྣྤྥྦྦྷྨྩྪྫྫྷྭྮྯྰྱྲླྴྵྶྷྸྐྵྺྻྼ྽྾྿࿀࿁࿂࿃࿄࿅࿆࿇...࿋࿌࿍࿎࿏࿐࿑࿒࿓࿔࿕࿖࿗࿘࿙࿚"; let _a = unicode_is_fun + " really fun!";
-   |                                                  -------------- ^ -------------- &str
-   |                                                  |              |
-   |                                                  |              `+` cannot be used to concatenate two `&str` strings
-   |                                                  &str
+LL | ...྅྆྇ྈྉྊྋྌྍྎྏྐྑྒྒྷྔྕྖྗ྘ྙྚྛྜྜྷྞྟྠྡྡྷྣྤྥྦྦྷྨྩྪྫྫྷྭྮྯྰྱྲླྴྵྶྷྸྐྵྺྻྼ྽྾྿࿀࿁࿂࿃࿄࿅࿆࿇࿈࿉࿊࿋࿌࿍࿎...࿒࿓࿔࿕࿖࿗࿘࿙࿚"; let _a = unicode_is_fun + " really fun!";
+   |                                                 ---------------^ -------------- &str
+   |                                                 |             ||
+   |                                                 |             |`+` cannot be used to concatenate two `&str` strings
+   |                                                 |             help: create an owned `String` from a string reference: `.to_owned()`
+   |                                                 &str
    |
-   = note: String concatenation appends the string on the right to the
-           string on the left and may require reallocation.
-           This requires ownership of the string on the left.
-help: use `to_owned()` to create an owned `String` from a string reference
-   |
-LL |     let _ = "ༀ༁༂༃༄༅༆༇༈༉༊་༌།༎༏༐༑༒༓༔༕༖༗༘༙༚༛༜༝༞༟༠༡༢༣༤༥༦༧༨༩༪༫༬༭༮༯༰༱༲༳༴༵༶༷༸༹༺༻༼༽༾༿ཀཁགགྷངཅཆཇ཈ཉཊཋཌཌྷཎཏཐདདྷནཔཕབབྷམཙཚཛཛྷཝཞཟའཡརལཤཥསཧཨཀྵཪཫཬ཭཮཯཰ཱཱཱིིུུྲྀཷླྀཹེཻོཽཾཿ྄ཱྀྀྂྃ྅྆྇ྈྉྊྋྌྍྎྏྐྑྒྒྷྔྕྖྗ྘ྙྚྛྜྜྷྞྟྠྡྡྷྣྤྥྦྦྷྨྩྪྫྫྷྭྮྯྰྱྲླྴྵྶྷྸྐྵྺྻྼ྽྾྿࿀࿁࿂࿃࿄࿅࿆࿇࿈࿉࿊࿋࿌࿍࿎࿏࿐࿑࿒࿓࿔࿕࿖࿗࿘࿙࿚"; let _a = unicode_is_fun.to_owned() + " really fun!";
-   |                                                                                                                                                                                         +++++++++++
+   = note: string concatenation requires an owned `String` on the left
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Before:

    error[E0369]: cannot add `&str` to `&str`
     --> file.rs:2:22
      |
    2 |     let _x = "hello" + " world";
      |              ------- ^ -------- &str
      |              |       |
      |              |       `+` cannot be used to concatenate two `&str` strings
      |              &str
      |
    help: `to_owned()` can be used to create an owned `String` from a string reference. String concatenation appends the string on the right to the string on the left and may require reallocation. This requires ownership of the string on the left
      |
    2 |     let _x = "hello".to_owned() + " world";
      |              ~~~~~~~~~~~~~~~~~~

After:

    error[E0369]: cannot add `&str` to `&str`
     --> file.rs:2:22
      |
    2 |     let _x = "hello" + " world";
      |              ------- ^ -------- &str
      |              |       |
      |              |       `+` cannot be used to concatenate two `&str` strings
      |              &str
      |
      = note: string concatenation requires an owned `String` on the left
    help: create an owned `String` from a string reference
      |
    2 |     let _x = "hello".to_owned() + " world";
      |                     +++++++++++
