### PR TITLE
Fix errors on blanket impls by ignoring the children of generated impls

### DIFF
--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -76,6 +76,14 @@ impl ItemId {
     }
 
     #[inline]
+    crate fn is_local_impl(self) -> bool {
+        match self {
+            ItemId::Blanket { impl_id, .. } => impl_id.is_local(),
+            ItemId::Auto { .. } | ItemId::DefId(_) | ItemId::Primitive(_, _) => false,
+        }
+    }
+
+    #[inline]
     #[track_caller]
     crate fn expect_def_id(self) -> DefId {
         self.as_def_id()

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -76,14 +76,6 @@ impl ItemId {
     }
 
     #[inline]
-    crate fn is_local_impl(self) -> bool {
-        match self {
-            ItemId::Blanket { impl_id, .. } => impl_id.is_local(),
-            ItemId::Auto { .. } | ItemId::DefId(_) | ItemId::Primitive(_, _) => false,
-        }
-    }
-
-    #[inline]
     #[track_caller]
     crate fn expect_def_id(self) -> DefId {
         self.as_def_id()

--- a/src/librustdoc/json/mod.rs
+++ b/src/librustdoc/json/mod.rs
@@ -171,8 +171,10 @@ impl<'tcx> FormatRenderer<'tcx> for JsonRenderer<'tcx> {
     /// the hashmap because certain items (traits and types) need to have their mappings for trait
     /// implementations filled out before they're inserted.
     fn item(&mut self, item: clean::Item) -> Result<(), Error> {
-        // We skip children of local blanket implementations, as we'll have already seen the actual
-        // generic impl, and the generated ones don't need documenting.
+        // FIXME(CraftSpider): We skip children of local blanket implementations, as we'll have
+        //     already seen the actual generic impl, and the generated ones don't need documenting.
+        //     This is necessary due to the visibility, return type, and self arg of the generated
+        //     impls not quite matching, and will no longer be necessary when the mismatch is fixed.
         let local_blanket_impl = match item.def_id {
             clean::ItemId::Blanket { impl_id, .. } => impl_id.is_local(),
             clean::ItemId::Auto { .. }

--- a/src/librustdoc/json/mod.rs
+++ b/src/librustdoc/json/mod.rs
@@ -171,10 +171,17 @@ impl<'tcx> FormatRenderer<'tcx> for JsonRenderer<'tcx> {
     /// the hashmap because certain items (traits and types) need to have their mappings for trait
     /// implementations filled out before they're inserted.
     fn item(&mut self, item: clean::Item) -> Result<(), Error> {
+        // We skip children of local blanket implementations, as we'll have already seen the actual
+        // generic impl, and the generated ones don't need documenting.
+        let local_blanket_impl = match item.def_id {
+            clean::ItemId::Blanket { impl_id, .. } => impl_id.is_local(),
+            clean::ItemId::Auto { .. }
+            | clean::ItemId::DefId(_)
+            | clean::ItemId::Primitive(_, _) => false,
+        };
+
         // Flatten items that recursively store other items
-        // We skip local blanket implementations, as we'll have already seen the actual generic
-        // impl, and the generated ones don't need documenting.
-        if !item.def_id.is_local_impl() {
+        if !local_blanket_impl {
             item.kind.inner_items().for_each(|i| self.item(i.clone()).unwrap());
         }
 

--- a/src/librustdoc/json/mod.rs
+++ b/src/librustdoc/json/mod.rs
@@ -172,7 +172,11 @@ impl<'tcx> FormatRenderer<'tcx> for JsonRenderer<'tcx> {
     /// implementations filled out before they're inserted.
     fn item(&mut self, item: clean::Item) -> Result<(), Error> {
         // Flatten items that recursively store other items
-        item.kind.inner_items().for_each(|i| self.item(i.clone()).unwrap());
+        // We skip local blanket implementations, as we'll have already seen the actual generic
+        // impl, and the generated ones don't need documenting.
+        if !item.def_id.is_local_impl() {
+            item.kind.inner_items().for_each(|i| self.item(i.clone()).unwrap());
+        }
 
         let id = item.def_id;
         if let Some(mut new_item) = self.convert_item(item) {

--- a/src/librustdoc/json/mod.rs
+++ b/src/librustdoc/json/mod.rs
@@ -171,10 +171,6 @@ impl<'tcx> FormatRenderer<'tcx> for JsonRenderer<'tcx> {
     /// the hashmap because certain items (traits and types) need to have their mappings for trait
     /// implementations filled out before they're inserted.
     fn item(&mut self, item: clean::Item) -> Result<(), Error> {
-        // FIXME(CraftSpider): We skip children of local blanket implementations, as we'll have
-        //     already seen the actual generic impl, and the generated ones don't need documenting.
-        //     This is necessary due to the visibility, return type, and self arg of the generated
-        //     impls not quite matching, and will no longer be necessary when the mismatch is fixed.
         let local_blanket_impl = match item.def_id {
             clean::ItemId::Blanket { impl_id, .. } => impl_id.is_local(),
             clean::ItemId::Auto { .. }
@@ -183,6 +179,10 @@ impl<'tcx> FormatRenderer<'tcx> for JsonRenderer<'tcx> {
         };
 
         // Flatten items that recursively store other items
+        // FIXME(CraftSpider): We skip children of local blanket implementations, as we'll have
+        //     already seen the actual generic impl, and the generated ones don't need documenting.
+        //     This is necessary due to the visibility, return type, and self arg of the generated
+        //     impls not quite matching, and will no longer be necessary when the mismatch is fixed.
         if !local_blanket_impl {
             item.kind.inner_items().for_each(|i| self.item(i.clone()).unwrap());
         }

--- a/src/test/rustdoc-json/impls/blanket_with_local.rs
+++ b/src/test/rustdoc-json/impls/blanket_with_local.rs
@@ -1,7 +1,7 @@
 // Test for the ICE in rust/83718
 // A blanket impl plus a local type together shouldn't result in mismatched ID issues
 
-// @has method_abi.json "$.index[*][?(@.name=='Load')]"
+// @has blanket_with_local.json "$.index[*][?(@.name=='Load')]"
 pub trait Load {
     fn load() {}
 }

--- a/src/test/rustdoc-json/impls/blanket_with_local.rs
+++ b/src/test/rustdoc-json/impls/blanket_with_local.rs
@@ -1,0 +1,14 @@
+// Test for the ICE in rust/83718
+// A blanket impl plus a local type together shouldn't result in mismatched ID issues
+
+// @has method_abi.json "$.index[*][?(@.name=='Load')]"
+pub trait Load {
+    fn load() {}
+}
+
+impl<P> Load for P {
+    fn load() {}
+}
+
+// @has - "$.index[*][?(@.name=='Wrapper')]"
+pub struct Wrapper {}


### PR DESCRIPTION
Related to #83718

We can safely skip the children, as they don't contain any new info, and may be subtly different for reasons hard to track down, in ways that are consistently worse than the actual generic impl.