### PR TITLE
accept that box dyn error is not and will never be an error

### DIFF
--- a/library/std/src/error.rs
+++ b/library/std/src/error.rs
@@ -516,6 +516,9 @@ impl<T: Error> Error for Box<T> {
     }
 }
 
+#[stable(feature = "box_error", since = "1.8.0")]
+impl !Error for Box<dyn Error + Send + Sync + 'static> {}
+
 #[stable(feature = "error_by_ref", since = "1.51.0")]
 impl<'a, T: Error + ?Sized> Error for &'a T {
     #[allow(deprecated, deprecated_in_future)]


### PR DESCRIPTION
r? @dtolnay since this is also relevant to you and `anyhow`.

I'm adding this negative impl to make it so I can eventually add the following impl to `eyre`:

```rust
    impl StdError for Box<dyn std::error::Error + Send + Sync + 'static> {
        fn ext_report<D>(self, msg: D) -> Report
        where
            D: Display + Send + Sync + 'static,
        {
            self.wrap_err(msg)
        }
    }
```

Which lets me call `.wrap_err` on `Result<T, Box<dyn Error + Send + Sync + 'static>>`. This is currently impossible because it produces a future incompatibility error:

<pre><font color="#AB4642"><b>error[E0119]</b></font><b>: conflicting implementations of trait `context::ext::StdError` for type `std::boxed::Box&lt;(dyn std::error::Error + std::marker::Send + std::marker::Sync + &apos;static)&gt;`</b>
  <font color="#7CAFC2"><b>--&gt; </b></font>src/context.rs:30:5
   <font color="#7CAFC2"><b>|</b></font>
<font color="#7CAFC2"><b>18</b></font> <font color="#7CAFC2"><b>| /</b></font>     impl&lt;E&gt; StdError for E
<font color="#7CAFC2"><b>19</b></font> <font color="#7CAFC2"><b>| |</b></font>     where
<font color="#7CAFC2"><b>20</b></font> <font color="#7CAFC2"><b>| |</b></font>         E: std::error::Error + Send + Sync + &apos;static,
<font color="#7CAFC2"><b>21</b></font> <font color="#7CAFC2"><b>| |</b></font>     {
<font color="#7CAFC2"><b>...</b></font>  <font color="#7CAFC2"><b>|</b></font>
<font color="#7CAFC2"><b>27</b></font> <font color="#7CAFC2"><b>| |</b></font>         }
<font color="#7CAFC2"><b>28</b></font> <font color="#7CAFC2"><b>| |</b></font>     }
   <font color="#7CAFC2"><b>| |_____-</b></font> <font color="#7CAFC2"><b>first implementation here</b></font>
<font color="#7CAFC2"><b>29</b></font> <font color="#7CAFC2"><b>| </b></font>
<font color="#7CAFC2"><b>30</b></font> <font color="#7CAFC2"><b>| </b></font>      impl StdError for Box&lt;dyn std::error::Error + Send + Sync + &apos;static&gt; {
   <font color="#7CAFC2"><b>| </b></font>      <font color="#AB4642"><b>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^</b></font> <font color="#AB4642"><b>conflicting implementation for `std::boxed::Box&lt;(dyn std::error::Error + std::marker::Send + std::marker::Sync + &apos;static)&gt;`</b></font>
   <font color="#7CAFC2"><b>|</b></font>
   <font color="#7CAFC2"><b>= </b></font><b>note</b>: upstream crates may add a new impl of trait `std::error::Error` for type `std::boxed::Box&lt;(dyn std::error::Error + std::marker::Send + std::marker::Sync + &apos;static)&gt;` in future versions

<b>For more information about this error, try `rustc --explain E0119`.</b>
<font color="#AB4642"><b>error</b></font><b>:</b> could not compile `eyre` due to previous error
</pre>

But this error is incorrect because we cannot add the proper `Error` impl to `Box<dyn Error>` without lattice specialization, which is not happening any time soon, if ever. Adding this negative impl promises to never impl Error for box dyn error in the future, so this will need an FCP.