### PR TITLE
Fix a missing dot in the main item heading

### DIFF
--- a/src/librustdoc/templates/print_item.html
+++ b/src/librustdoc/templates/print_item.html
@@ -16,12 +16,12 @@
     </h1> {#- -#}
     <span class="out-of-band"> {#- -#}
         {% if !stability_since_raw.is_empty() %}
-        {{- stability_since_raw|safe -}} ·
+        {{- stability_since_raw|safe -}} · {# -#}
         {% endif %}
         {%- match src_href -%}
             {%- when Some with (href) -%}
-                <a class="srclink" href="{{href|safe}}" title="goto source code">source</a>
-            {%- else -%} ·
+                <a class="srclink" href="{{href|safe}}" title="goto source code">source</a> · {# -#}
+            {%- else -%}
         {%- endmatch -%}
         <a id="toggle-all-docs" href="javascript:void(0)" title="collapse all docs"> {#- -#}
             [<span class="inner">&#x2212;</span>] {#- -#}


### PR DESCRIPTION
This pull-request fix a missing `·` in the item header ~~and also make use of `&nbsp;` to explicit that the spaces are mandatory~~.

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/3616612/149393966-7cca6dc5-9a62-47fa-8c9c-18f936d43aa9.png) | ![image](https://user-images.githubusercontent.com/3616612/149393869-5ffd6e44-d91c-4ece-b69e-d103304f6626.png) |

PS: This was introduce yesterday by https://github.com/rust-lang/rust/pull/92526 (the migration from Tera to Askama) and is not currently observable in the nightly doc.