### PR TITLE
Better diagnostic for using struct fields in consts

### DIFF
--- a/compiler/rustc_parse/src/parser/stmt.rs
+++ b/compiler/rustc_parse/src/parser/stmt.rs
@@ -254,6 +254,9 @@ impl<'a> Parser<'a> {
                         err.emit();
                         None
                     } else {
+                        if self.check(&token::Dot) {
+                            err.help("if this was intended as a const argument, wrap it in curly braces: `{ ... }`");
+                        }
                         // Rewind to before attempting to parse the type and continue parsing.
                         let parser_snapshot_after_type =
                             mem::replace(self, parser_snapshot_before_type);

--- a/src/test/ui/issues/issue-92776.rs
+++ b/src/test/ui/issues/issue-92776.rs
@@ -1,0 +1,23 @@
+struct Example {
+    foo: usize
+}
+
+struct Example2(u32);
+
+const EXAMPLE: Example = Example { foo: 42 };
+const EXAMPLE_2: Example2 = Example2(42);
+
+struct Wow<const N: usize> {
+    field: [u8; N]
+}
+
+
+fn a() {
+    let _a: Wow<EXAMPLE.foo> = Wow::new();
+    //~^ ERROR expected one of
+}
+
+fn main() {
+    let _b: Wow<EXAMPLE_2.0> = Wow::new();
+    //~^ ERROR expected one of
+}

--- a/src/test/ui/issues/issue-92776.stderr
+++ b/src/test/ui/issues/issue-92776.stderr
@@ -1,0 +1,22 @@
+error: expected one of `!`, `(`, `+`, `,`, `::`, `:`, `<`, `=`, or `>`, found `.`
+  --> $DIR/issue-92776.rs:16:24
+   |
+LL |     let _a: Wow<EXAMPLE.foo> = Wow::new();
+   |         --             ^ expected one of 9 possible tokens
+   |         |
+   |         while parsing the type for `_a`
+   |
+   = help: if this was intended as a const argument, wrap it in curly braces: `{ ... }`
+
+error: expected one of `!`, `(`, `+`, `,`, `::`, `:`, `<`, `=`, or `>`, found `.`
+  --> $DIR/issue-92776.rs:21:26
+   |
+LL |     let _b: Wow<EXAMPLE_2.0> = Wow::new();
+   |         --               ^ expected one of 9 possible tokens
+   |         |
+   |         while parsing the type for `_b`
+   |
+   = help: if this was intended as a const argument, wrap it in curly braces: `{ ... }`
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Addresses #92776, by printing out a help message if an error was raised when a `.` was encountered in a type.
cc @estebank since it's diagnostics related