### PR TITLE
Suggest adding `{ .. }` around more bad const generic exprs

### DIFF
--- a/src/test/ui/const-generics/bad-const-generic-exprs.rs
+++ b/src/test/ui/const-generics/bad-const-generic-exprs.rs
@@ -1,0 +1,22 @@
+struct Wow<const N: usize>;
+
+fn main() {
+    let _: Wow<if true {}>;
+    //~^ ERROR invalid const generic expression
+    //~| HELP expressions must be enclosed in braces to be used as const generic arguments
+    let _: Wow<|| ()>;
+    //~^ ERROR invalid const generic expression
+    //~| HELP expressions must be enclosed in braces to be used as const generic arguments
+    let _: Wow<A.b>;
+    //~^ ERROR expected one of
+    //~| HELP expressions must be enclosed in braces to be used as const generic arguments
+    let _: Wow<A.0>;
+    //~^ ERROR expected one of
+    //~| HELP expressions must be enclosed in braces to be used as const generic arguments
+
+    // FIXME(compiler-errors): This one is still unsatisfying,
+    // and probably a case I could see someone typing by accident..
+    let _: Wow<[12]>;
+    //~^ ERROR expected type, found
+    //~| ERROR type provided when a constant was expected
+}

--- a/src/test/ui/const-generics/bad-const-generic-exprs.stderr
+++ b/src/test/ui/const-generics/bad-const-generic-exprs.stderr
@@ -1,0 +1,59 @@
+error: invalid const generic expression
+  --> $DIR/bad-const-generic-exprs.rs:4:16
+   |
+LL |     let _: Wow<if true {}>;
+   |                ^^^^^^^^^^
+   |
+help: expressions must be enclosed in braces to be used as const generic arguments
+   |
+LL |     let _: Wow<{ if true {} }>;
+   |                +            +
+
+error: invalid const generic expression
+  --> $DIR/bad-const-generic-exprs.rs:7:16
+   |
+LL |     let _: Wow<|| ()>;
+   |                ^^^^^
+   |
+help: expressions must be enclosed in braces to be used as const generic arguments
+   |
+LL |     let _: Wow<{ || () }>;
+   |                +       +
+
+error: expected one of `,` or `>`, found `.`
+  --> $DIR/bad-const-generic-exprs.rs:10:17
+   |
+LL |     let _: Wow<A.b>;
+   |                 ^ expected one of `,` or `>`
+   |
+help: expressions must be enclosed in braces to be used as const generic arguments
+   |
+LL |     let _: Wow<{ A.b }>;
+   |                +     +
+
+error: expected one of `,` or `>`, found `.`
+  --> $DIR/bad-const-generic-exprs.rs:13:17
+   |
+LL |     let _: Wow<A.0>;
+   |                 ^ expected one of `,` or `>`
+   |
+help: expressions must be enclosed in braces to be used as const generic arguments
+   |
+LL |     let _: Wow<{ A.0 }>;
+   |                +     +
+
+error: expected type, found `12`
+  --> $DIR/bad-const-generic-exprs.rs:19:17
+   |
+LL |     let _: Wow<[12]>;
+   |                 ^^ expected type
+
+error[E0747]: type provided when a constant was expected
+  --> $DIR/bad-const-generic-exprs.rs:19:16
+   |
+LL |     let _: Wow<[12]>;
+   |                ^^^^
+
+error: aborting due to 6 previous errors
+
+For more information about this error, try `rustc --explain E0747`.


### PR DESCRIPTION
Fixes #92776 