### PR TITLE
Do not fail evaluation in const blocks

### DIFF
--- a/compiler/rustc_typeck/src/check/expr.rs
+++ b/compiler/rustc_typeck/src/check/expr.rs
@@ -1226,7 +1226,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let body = self.tcx.hir().body(anon_const.body);
 
         // Create a new function context.
-        let fcx = FnCtxt::new(self, self.param_env, body.value.hir_id);
+        let fcx = FnCtxt::new(self, self.param_env.with_const(), body.value.hir_id);
         crate::check::GatherLocalsVisitor::new(&fcx).visit_body(body);
 
         let ty = fcx.check_expr_with_expectation(&body.value, expected);

--- a/src/test/ui/consts/const-block-const-bound.rs
+++ b/src/test/ui/consts/const-block-const-bound.rs
@@ -1,0 +1,17 @@
+#![allow(unused)]
+#![feature(const_fn_trait_bound, const_trait_impl, inline_const)]
+
+const fn f<T: ~const Drop>(x: T) {}
+
+struct UnconstDrop;
+
+impl Drop for UnconstDrop {
+    fn drop(&mut self) {}
+}
+
+fn main() {
+    const {
+        f(UnconstDrop);
+        //~^ ERROR the trait bound `UnconstDrop: Drop` is not satisfied
+    }
+}

--- a/src/test/ui/consts/const-block-const-bound.stderr
+++ b/src/test/ui/consts/const-block-const-bound.stderr
@@ -1,0 +1,21 @@
+error[E0277]: the trait bound `UnconstDrop: Drop` is not satisfied
+  --> $DIR/const-block-const-bound.rs:14:11
+   |
+LL |         f(UnconstDrop);
+   |         - ^^^^^^^^^^^ the trait `Drop` is not implemented for `UnconstDrop`
+   |         |
+   |         required by a bound introduced by this call
+   |
+note: required by a bound in `f`
+  --> $DIR/const-block-const-bound.rs:4:15
+   |
+LL | const fn f<T: ~const Drop>(x: T) {}
+   |               ^^^^^^^^^^^ required by this bound in `f`
+help: consider introducing a `where` bound, but there might be an alternative better way to express this requirement
+   |
+LL | fn main() where UnconstDrop: Drop {
+   |           +++++++++++++++++++++++
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
Evaluate const blocks with a const param-env, so we properly check `~const` trait bounds. 

Fixes #92713
(I will fix the poor diagnostics in #92713 and #92712 in a separate PR) 

cc @nbdd0121 who wrote the code this PR touches in #89561