### PR TITLE
Update some rustc dependencies to deduplicate them

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1601,9 +1601,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.11.0"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "362385356d610bd1e5a408ddf8d022041774b683f345a1d2cfcb4f60f8ae2db5"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 dependencies = [
  "ahash",
  "compiler_builtins",
@@ -2430,23 +2430,12 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.27.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ac1d3f9a1d3616fd9a60c8d74296f22406a238b6a72f5cc1e6f314df4ffbf9"
-dependencies = [
- "crc32fast",
- "flate2",
- "indexmap",
- "memchr",
-]
-
-[[package]]
-name = "object"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ce8b38d41f9f3618fc23f908faae61510f8d8ce2d99cbe910641e8f1971f084"
 dependencies = [
  "crc32fast",
+ "flate2",
  "hashbrown",
  "indexmap",
  "memchr",
@@ -5390,13 +5379,13 @@ dependencies = [
 
 [[package]]
 name = "thorin-dwp"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "039d1fc0bfdb73910c2702893515580e38c192f47a987bc98ddd38a36f2d953a"
+checksum = "dd95b4559c196987c8451b4e14d08a4c796c2844f9adf4d2a2dbc9b3142843be"
 dependencies = [
  "gimli 0.26.1",
- "indexmap",
- "object 0.27.1",
+ "hashbrown",
+ "object 0.28.1",
  "tracing",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3719,7 +3719,7 @@ dependencies = [
 name = "rustc_ast_passes"
 version = "0.0.0"
 dependencies = [
- "itertools 0.9.0",
+ "itertools 0.10.1",
  "rustc_ast",
  "rustc_ast_pretty",
  "rustc_attr",
@@ -3763,7 +3763,7 @@ name = "rustc_borrowck"
 version = "0.0.0"
 dependencies = [
  "either",
- "itertools 0.9.0",
+ "itertools 0.10.1",
  "polonius-engine",
  "rustc_const_eval",
  "rustc_data_structures",
@@ -3844,7 +3844,7 @@ version = "0.0.0"
 dependencies = [
  "bitflags",
  "cc",
- "itertools 0.9.0",
+ "itertools 0.10.1",
  "jobserver",
  "libc",
  "object 0.28.1",
@@ -4328,7 +4328,7 @@ name = "rustc_mir_transform"
 version = "0.0.0"
 dependencies = [
  "coverage_test_macros",
- "itertools 0.9.0",
+ "itertools 0.10.1",
  "rustc_ast",
  "rustc_attr",
  "rustc_const_eval",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4052,7 +4052,7 @@ dependencies = [
 name = "rustc_incremental"
 version = "0.0.0"
 dependencies = [
- "rand 0.7.3",
+ "rand 0.8.4",
  "rustc_ast",
  "rustc_data_structures",
  "rustc_errors",

--- a/compiler/rustc_ast_passes/Cargo.toml
+++ b/compiler/rustc_ast_passes/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 edition = "2021"
 
 [dependencies]
-itertools = "0.9"
+itertools = "0.10"
 tracing = "0.1"
 rustc_ast_pretty = { path = "../rustc_ast_pretty" }
 rustc_attr = { path = "../rustc_attr" }

--- a/compiler/rustc_borrowck/Cargo.toml
+++ b/compiler/rustc_borrowck/Cargo.toml
@@ -8,7 +8,7 @@ doctest = false
 
 [dependencies]
 either = "1.5.0"
-itertools = "0.9"
+itertools = "0.10"
 tracing = "0.1"
 polonius-engine = "0.13.0"
 smallvec = { version = "1.6.1", features = ["union", "may_dangle"] }

--- a/compiler/rustc_codegen_ssa/Cargo.toml
+++ b/compiler/rustc_codegen_ssa/Cargo.toml
@@ -14,7 +14,7 @@ tracing = "0.1"
 libc = "0.2.50"
 jobserver = "0.1.22"
 tempfile = "3.2"
-thorin-dwp = "0.1.1"
+thorin-dwp = "0.2"
 pathdiff = "0.2.0"
 snap = "1"
 smallvec = { version = "1.6.1", features = ["union", "may_dangle"] }

--- a/compiler/rustc_codegen_ssa/Cargo.toml
+++ b/compiler/rustc_codegen_ssa/Cargo.toml
@@ -9,7 +9,7 @@ test = false
 [dependencies]
 bitflags = "1.2.1"
 cc = "1.0.69"
-itertools = "0.9"
+itertools = "0.10"
 tracing = "0.1"
 libc = "0.2.50"
 jobserver = "0.1.22"

--- a/compiler/rustc_incremental/Cargo.toml
+++ b/compiler/rustc_incremental/Cargo.toml
@@ -9,7 +9,7 @@ doctest = false
 [dependencies]
 rustc_graphviz = { path = "../rustc_graphviz" }
 tracing = "0.1"
-rand = "0.7"
+rand = "0.8.4"
 rustc_middle = { path = "../rustc_middle" }
 rustc_data_structures = { path = "../rustc_data_structures" }
 rustc_hir = { path = "../rustc_hir" }

--- a/compiler/rustc_mir_transform/Cargo.toml
+++ b/compiler/rustc_mir_transform/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 doctest = false
 
 [dependencies]
-itertools = "0.9"
+itertools = "0.10"
 smallvec = { version = "1.6.1", features = ["union", "may_dangle"] }
 tracing = "0.1"
 rustc_ast = { path = "../rustc_ast" }


### PR DESCRIPTION
This PR updates `rand` and `itertools` in rustc (not the whole workspace) in order to deduplicate them (and hopefully slightly improve compile times).

~~Currently, `object` is still duplicated, but https://github.com/rust-lang/thorin/pull/15 and updating `thorin` in the future will remove the use of version 0.27.~~  Update: Thorin 0.2 has now been released, and this PR updates `rustc_codegen_ssa` to use it and deduplicate the `object` crate.

There's a final tiny rustc dependency, `cfg-if`, which will be left: as both versions 0.1.x and 1.0 looked to be heavily depended on, they will require a few cascading updates to be removed.