### PR TITLE
resolve rustfmt issue with generated files

### DIFF
--- a/src/tools/rustfmt/Configurations.md
+++ b/src/tools/rustfmt/Configurations.md
@@ -929,9 +929,9 @@ fn add_one(x: i32) -> i32 {
 ## `format_generated_files`
 
 Format generated files. A file is considered generated
-if any of the first five lines contains `@generated` marker.
+if any of the first five lines contain a `@generated` comment marker.
 
-- **Default value**: `false`
+- **Default value**: `true`
 - **Possible values**: `true`, `false`
 - **Stable**: No (tracking issue: [#5080](https://github.com/rust-lang/rustfmt/issues/5080))
 

--- a/src/tools/rustfmt/src/config/mod.rs
+++ b/src/tools/rustfmt/src/config/mod.rs
@@ -138,7 +138,7 @@ create_config! {
     inline_attribute_width: usize, 0, false,
         "Write an item and its attribute on the same line \
         if their combined width is below a threshold";
-    format_generated_files: bool, false, false, "Format generated files";
+    format_generated_files: bool, true, false, "Format generated files";
 
     // Options that can change the source code beyond whitespace/blocks (somewhat linty things)
     merge_derives: bool, true, true, "Merge multiple `#[derive(...)]` into a single one";
@@ -606,7 +606,7 @@ blank_lines_lower_bound = 0
 edition = "2015"
 version = "One"
 inline_attribute_width = 0
-format_generated_files = false
+format_generated_files = true
 merge_derives = true
 use_try_shorthand = false
 use_field_init_shorthand = false

--- a/src/tools/rustfmt/src/formatting.rs
+++ b/src/tools/rustfmt/src/formatting.rs
@@ -80,7 +80,9 @@ fn should_skip_module<T: FormatHandler>(
         return true;
     }
 
-    if !config.format_generated_files() {
+    // FIXME(calebcartwright) - we need to determine how we'll handle the
+    // `format_generated_files` option with stdin based input.
+    if !input_is_stdin && !config.format_generated_files() {
         let source_file = context.parse_session.span_to_file_contents(module.span);
         let src = source_file.src.as_ref().expect("SourceFile without src");
 

--- a/src/tools/rustfmt/src/test/mod.rs
+++ b/src/tools/rustfmt/src/test/mod.rs
@@ -488,6 +488,24 @@ fn stdin_disable_all_formatting_test() {
 }
 
 #[test]
+fn stdin_generated_files_issue_5172() {
+    init_log();
+    let input = Input::Text("//@generated\nfn   main() {}".to_owned());
+    let mut config = Config::default();
+    config.set().emit_mode(EmitMode::Stdout);
+    config.set().format_generated_files(false);
+    config.set().newline_style(NewlineStyle::Unix);
+    let mut buf: Vec<u8> = vec![];
+    {
+        let mut session = Session::new(config, Some(&mut buf));
+        session.format(input).unwrap();
+        assert!(session.has_no_errors());
+    }
+    // N.B. this should be changed once `format_generated_files` is supported with stdin
+    assert_eq!(buf, "stdin:\n\n//@generated\nfn main() {}\n".as_bytes());
+}
+
+#[test]
 fn format_lines_errors_are_reported() {
     init_log();
     let long_identifier = String::from_utf8(vec![b'a'; 239]).unwrap();


### PR DESCRIPTION
Discussed in https://rust-lang.zulipchat.com/#narrow/stream/241545-t-release/topic/1.2E58.20patch.20release

refs https://github.com/rust-lang/rustfmt/issues/5080#issuecomment-1013303455 and https://github.com/rust-lang/rustfmt/issues/5172

updating in-tree vs. subtree sync to make backporting easier, would like to nominate backporting to both beta/1.59 as well as the 1.58.1 patch release