### PR TITLE
Don't constrain projection predicates with inference vars in GAT substs

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -2470,7 +2470,7 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                 let projection_ty = ty::ProjectionTy {
                     // `T`
                     substs: self.tcx.mk_substs_trait(
-                        trait_ref.self_ty().skip_binder(),
+                        trait_pred.self_ty().skip_binder(),
                         &self.fresh_substs_for_item(span, item_def_id)[1..],
                     ),
                     // `Future::Output`

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -2470,8 +2470,8 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                 let projection_ty = ty::ProjectionTy {
                     // `T`
                     substs: self.tcx.mk_substs_trait(
-                        trait_pred.self_ty().skip_binder(),
-                        self.fresh_substs_for_item(span, item_def_id),
+                        trait_ref.self_ty().skip_binder(),
+                        &self.fresh_substs_for_item(span, item_def_id)[1..],
                     ),
                     // `Future::Output`
                     item_def_id,

--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -1521,16 +1521,6 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             infer_predicate.projection_ty
         };
 
-        // If the obligation contains any inference types or consts in associated
-        // type substs, then we don't match any projection candidates against it.
-        // This isn't really correct, but otherwise we can end up in a case where
-        // we constrain inference variables by selecting a single predicate, when
-        // we need to stay general. See issue #91762.
-        let (_, predicate_own_substs) =
-            obligation.predicate.trait_ref_and_own_substs(self.infcx.tcx);
-        if predicate_own_substs.iter().any(|g| g.has_infer_types_or_consts()) {
-            return false;
-        }
         self.infcx
             .at(&obligation.cause, obligation.param_env)
             .sup(obligation.predicate, infer_projection)

--- a/src/test/ui/generic-associated-types/issue-74824.rs
+++ b/src/test/ui/generic-associated-types/issue-74824.rs
@@ -17,6 +17,7 @@ impl<T> UnsafeCopy for T {}
 fn main() {
     let b = Box::new(42usize);
     let copy = <()>::copy(&b);
+    //~^ type annotations needed
 
     let raw_b = Box::deref(&b) as *const _;
     let raw_copy = Box::deref(&copy) as *const _;

--- a/src/test/ui/generic-associated-types/issue-74824.stderr
+++ b/src/test/ui/generic-associated-types/issue-74824.stderr
@@ -27,6 +27,13 @@ help: consider restricting type parameter `T`
 LL |     type Copy<T: std::clone::Clone>: Copy = Box<T>;
    |                +++++++++++++++++++
 
-error: aborting due to 2 previous errors
+error[E0282]: type annotations needed
+  --> $DIR/issue-74824.rs:19:16
+   |
+LL |     let copy = <()>::copy(&b);
+   |                ^^^^^^^^^^ cannot infer type for type parameter `T` declared on the associated function `copy`
 
-For more information about this error, try `rustc --explain E0277`.
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0277, E0282.
+For more information about an error, try `rustc --explain E0277`.

--- a/src/test/ui/generic-associated-types/issue-91762.rs
+++ b/src/test/ui/generic-associated-types/issue-91762.rs
@@ -23,7 +23,7 @@ pub trait FunctorExt<T>: Sized {
 
         arg = self;
         ret = <Self::Base as Functor>::fmap(arg);
-        //~^ mismatched types
+        //~^ type annotations needed
     }
 }
 

--- a/src/test/ui/generic-associated-types/issue-91762.rs
+++ b/src/test/ui/generic-associated-types/issue-91762.rs
@@ -1,0 +1,30 @@
+// check-fail
+
+// FIXME(generic_associated_types): We almost certaintly want this to pass, but
+// it's particularly difficult currently, because we need a way of specifying
+// that `<Self::Base as Functor>::With<T> = Self` without using that when we have
+// a `U`. See `https://github.com/rust-lang/rust/pull/92728` for a (hacky)
+// solution. This might be better to just wait for Chalk.
+
+#![feature(generic_associated_types)]
+
+pub trait Functor {
+    type With<T>;
+
+    fn fmap<T, U>(this: Self::With<T>) -> Self::With<U>;
+}
+
+pub trait FunctorExt<T>: Sized {
+    type Base: Functor<With<T> = Self>;
+
+    fn fmap<U>(self) {
+        let arg: <Self::Base as Functor>::With<T>;
+        let ret: <Self::Base as Functor>::With<U>;
+
+        arg = self;
+        ret = <Self::Base as Functor>::fmap(arg);
+        //~^ mismatched types
+    }
+}
+
+fn main() {}

--- a/src/test/ui/generic-associated-types/issue-91762.stderr
+++ b/src/test/ui/generic-associated-types/issue-91762.stderr
@@ -1,0 +1,22 @@
+error[E0308]: mismatched types
+  --> $DIR/issue-91762.rs:25:45
+   |
+LL | / pub trait FunctorExt<T>: Sized {
+LL | |     type Base: Functor<With<T> = Self>;
+LL | |
+LL | |     fn fmap<U>(self) {
+...  |
+LL | |         ret = <Self::Base as Functor>::fmap(arg);
+   | |                                             ^^^ expected associated type, found type parameter `Self`
+LL | |
+LL | |     }
+LL | | }
+   | |_- this type parameter
+   |
+   = note: expected associated type `<<Self as FunctorExt<T>>::Base as Functor>::With<_>`
+               found type parameter `Self`
+   = note: you might be missing a type parameter or trait bound
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/generic-associated-types/issue-91762.stderr
+++ b/src/test/ui/generic-associated-types/issue-91762.stderr
@@ -1,22 +1,9 @@
-error[E0308]: mismatched types
-  --> $DIR/issue-91762.rs:25:45
+error[E0282]: type annotations needed
+  --> $DIR/issue-91762.rs:25:15
    |
-LL | / pub trait FunctorExt<T>: Sized {
-LL | |     type Base: Functor<With<T> = Self>;
-LL | |
-LL | |     fn fmap<U>(self) {
-...  |
-LL | |         ret = <Self::Base as Functor>::fmap(arg);
-   | |                                             ^^^ expected associated type, found type parameter `Self`
-LL | |
-LL | |     }
-LL | | }
-   | |_- this type parameter
-   |
-   = note: expected associated type `<<Self as FunctorExt<T>>::Base as Functor>::With<_>`
-               found type parameter `Self`
-   = note: you might be missing a type parameter or trait bound
+LL |         ret = <Self::Base as Functor>::fmap(arg);
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type for type parameter `T` declared on the associated function `fmap`
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0308`.
+For more information about this error, try `rustc --explain E0282`.


### PR DESCRIPTION
cc #91762 

Not a fix, but a mitigation to prevent a backwards-compatible hazard where we normalize using a predicate only because it's the only one available, but shouldn't. This would constrain an inference variable which didn't really want. We already do this when selecting a projection candidate, which isn't always correct. But changing that is a problem for a different day.

Also found out that a suggestion for `await`ing a future was using the wrong substs.

r? @nikomatsakis 