### PR TITLE
Abstract the pretty printer's ringbuffer to be infinitely sized

### DIFF
--- a/compiler/rustc_ast_pretty/src/pp/ring.rs
+++ b/compiler/rustc_ast_pretty/src/pp/ring.rs
@@ -1,0 +1,53 @@
+use std::collections::VecDeque;
+use std::ops::{Index, IndexMut};
+
+/// A view onto a finite range of an infinitely long sequence of T.
+///
+/// The Ts are indexed 0..infinity. A RingBuffer begins as a view of elements
+/// 0..0 (i.e. nothing). The user of the RingBuffer advances its left and right
+/// position independently, although only in the positive direction, and only
+/// with left <= right at all times.
+///
+/// Holding a RingBuffer whose view is elements left..right gives the ability to
+/// use Index and IndexMut to access elements i in the infinitely long queue for
+/// which left <= i < right.
+pub struct RingBuffer<T> {
+    data: VecDeque<T>,
+    // Abstract index of data[0] in the infinitely sized queue.
+    offset: usize,
+}
+
+impl<T> RingBuffer<T> {
+    pub fn new() -> Self {
+        RingBuffer { data: VecDeque::new(), offset: 0 }
+    }
+
+    pub fn advance_right(&mut self)
+    where
+        T: Default,
+    {
+        self.data.push_back(T::default());
+    }
+
+    pub fn advance_left(&mut self) {
+        self.data.pop_front().unwrap();
+        self.offset += 1;
+    }
+
+    pub fn truncate(&mut self, len: usize) {
+        self.data.truncate(len);
+    }
+}
+
+impl<T> Index<usize> for RingBuffer<T> {
+    type Output = T;
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.data[index.checked_sub(self.offset).unwrap()]
+    }
+}
+
+impl<T> IndexMut<usize> for RingBuffer<T> {
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        &mut self.data[index.checked_sub(self.offset).unwrap()]
+    }
+}


### PR DESCRIPTION
This PR backports https://github.com/dtolnay/prettyplease/commit/8e5e83c3ff7faaa272115a81b76f07a1d4a91969 from the `prettyplease` crate into `rustc_ast_pretty`.

Using a dedicated RingBuffer type with non-wrapping indices, instead of manually `%`-ing indices into a capped sized buffer, unlocks a number of simplifications to the pretty printing algorithm implementation in followup commits such as https://github.com/dtolnay/prettyplease/commit/fcb5968b1e1357497c7d7e205d22bb4e8c1dbd38 and https://github.com/dtolnay/prettyplease/commit/4427cedcb80294e89b823f923fdb16544c737bd9.

This change also greatly reduces memory overhead of the pretty printer. The old implementation always grows its buffer to 205920 bytes even for files without deeply nested code, because it only wraps its indices when they hit the maximum tolerable size of the ring buffer (the size after which the pretty printer will crash if there are that many tokens buffered). In contrast, the new implementation uses memory proportional to the peak number of simultaneously buffered tokens only, not the number of tokens that have ever been in the buffer.

Speaking of crashing the pretty printer and "maximum tolerable size", the constant used for that in the old implementation is a lie:

https://github.com/rust-lang/rust/blob/de9b573eedaaa6d6e7c00c986cccbee802f9287b/compiler/rustc_ast_pretty/src/pp.rs#L227-L228

It was raised from 3 to 55 in https://github.com/rust-lang/rust/pull/33934 because that was empirically the size that avoided crashing on one particular test crate, but according to https://github.com/rust-lang/rust/pull/33934#issuecomment-226700470 other syntax trees still crash at that size. There is no reason to believe that any particular size is good enough for arbitrary code, and using a large number like 55 adds overhead to inputs that never need close to that much of a buffer. The new implementation eliminates this tradeoff.