### PR TITLE
Delete pretty printer tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3433,7 +3433,6 @@ version = "0.0.0"
 dependencies = [
  "rustc_ast",
  "rustc_span",
- "tracing",
 ]
 
 [[package]]

--- a/compiler/rustc_ast_pretty/Cargo.toml
+++ b/compiler/rustc_ast_pretty/Cargo.toml
@@ -7,6 +7,5 @@ edition = "2021"
 doctest = false
 
 [dependencies]
-tracing = "0.1"
 rustc_span = { path = "../rustc_span" }
 rustc_ast = { path = "../rustc_ast" }


### PR DESCRIPTION
These are left over from 2011. I did not find these helpful at all in my work on https://github.com/dtolnay/prettyplease despite doing significant refactors to this code. Learning what these messages all refer to is harder than putting in your own messages to log exactly what is relevant to specifically the thing that you are working on debugging.