### PR TITLE
Deny mixing bin crate type with lib crate types

### DIFF
--- a/compiler/rustc_builtin_macros/src/proc_macro_harness.rs
+++ b/compiler/rustc_builtin_macros/src/proc_macro_harness.rs
@@ -56,7 +56,6 @@ pub fn inject(
     is_proc_macro_crate: bool,
     has_proc_macro_decls: bool,
     is_test_crate: bool,
-    num_crate_types: usize,
     handler: &rustc_errors::Handler,
 ) -> ast::Crate {
     let ecfg = ExpansionConfig::default("proc_macro".to_string());
@@ -79,10 +78,6 @@ pub fn inject(
 
     if !is_proc_macro_crate {
         return krate;
-    }
-
-    if num_crate_types > 1 {
-        handler.err("cannot mix `proc-macro` crate type with others");
     }
 
     if is_test_crate {

--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -382,7 +382,17 @@ pub fn configure_and_expand(
     });
 
     let crate_types = sess.crate_types();
+    let is_executable_crate = crate_types.contains(&CrateType::Executable);
     let is_proc_macro_crate = crate_types.contains(&CrateType::ProcMacro);
+
+    if crate_types.len() > 1 {
+        if is_executable_crate {
+            sess.err("cannot mix `bin` crate type with others");
+        }
+        if is_proc_macro_crate {
+            sess.err("cannot mix `proc-macro` crate type with others");
+        }
+    }
 
     // For backwards compatibility, we don't try to run proc macro injection
     // if rustdoc is run on a proc macro crate without '--crate-type proc-macro' being
@@ -400,7 +410,6 @@ pub fn configure_and_expand(
         msg.emit()
     } else {
         krate = sess.time("maybe_create_a_macro_crate", || {
-            let num_crate_types = crate_types.len();
             let is_test_crate = sess.opts.test;
             rustc_builtin_macros::proc_macro_harness::inject(
                 sess,
@@ -409,7 +418,6 @@ pub fn configure_and_expand(
                 is_proc_macro_crate,
                 has_proc_macro_decls,
                 is_test_crate,
-                num_crate_types,
                 sess.diagnostic(),
             )
         });

--- a/src/test/run-make-fulldeps/libs-and-bins/Makefile
+++ b/src/test/run-make-fulldeps/libs-and-bins/Makefile
@@ -1,6 +1,0 @@
--include ../tools.mk
-
-all:
-	$(RUSTC) foo.rs
-	$(call RUN,foo)
-	rm $(TMPDIR)/$(call DYLIB_GLOB,foo)

--- a/src/test/run-make-fulldeps/libs-and-bins/foo.rs
+++ b/src/test/run-make-fulldeps/libs-and-bins/foo.rs
@@ -1,4 +1,0 @@
-#![crate_type = "dylib"]
-#![crate_type = "bin"]
-
-fn main() {}

--- a/src/test/run-make-fulldeps/output-with-hyphens/Makefile
+++ b/src/test/run-make-fulldeps/output-with-hyphens/Makefile
@@ -1,6 +1,7 @@
 -include ../tools.mk
 
 all:
-	$(RUSTC) foo-bar.rs
+	$(RUSTC) foo-bar.rs --crate-type bin
 	[ -f $(TMPDIR)/$(call BIN,foo-bar) ]
+	$(RUSTC) foo-bar.rs --crate-type lib
 	[ -f $(TMPDIR)/libfoo_bar.rlib ]

--- a/src/test/run-make-fulldeps/output-with-hyphens/foo-bar.rs
+++ b/src/test/run-make-fulldeps/output-with-hyphens/foo-bar.rs
@@ -1,4 +1,1 @@
-#![crate_type = "lib"]
-#![crate_type = "bin"]
-
 fn main() {}


### PR DESCRIPTION
The produced library would get a main shim too which conflicts with the
main shim of the executable linking the library.

```
$ cat > main1.rs <<EOF
fn main() {}
pub fn bar() {}
EOF
$ cat > main2.rs <<EOF
extern crate main1;
fn main() {
    main1::bar();
}
EOF
$ rustc --crate-type bin --crate-type lib main1.rs
$ rustc -L. main2.rs
error: linking with `cc` failed: exit status: 1
[...]
  = note: /usr/bin/ld: /tmp/crate_bin_lib/libmain1.rlib(main1.main1.707747aa-cgu.0.rcgu.o): in function `main':
          main1.707747aa-cgu.0:(.text.main+0x0): multiple definition of `main'; main2.main2.02a148fe-cgu.0.rcgu.o:main2.02a148fe-cgu.0:(.text.main+0x0): first defined here
          collect2: error: ld returned 1 exit status
```