### PR TITLE
rustdoc: Add missing dot separator

### DIFF
--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -670,7 +670,11 @@ fn item_trait(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, t: &clean::Tra
         }
         write!(w, "<div id=\"{}\" class=\"method has-srclink\">", id);
         write!(w, "<div class=\"rightside\">");
-        render_stability_since(w, m, t, cx.tcx());
+
+        let has_stability = render_stability_since(w, m, t, cx.tcx());
+        if has_stability {
+            w.write_str(" · ");
+        }
         write_srclink(cx, m, w);
         write!(w, "</div>");
         write!(w, "<h4 class=\"code-header\">");
@@ -1457,14 +1461,14 @@ fn render_stability_since(
     item: &clean::Item,
     containing_item: &clean::Item,
     tcx: TyCtxt<'_>,
-) {
+) -> bool {
     render_stability_since_raw(
         w,
         item.stable_since(tcx),
         item.const_stability(tcx),
         containing_item.stable_since(tcx),
         containing_item.const_stable_since(tcx),
-    );
+    )
 }
 
 fn compare_impl<'a, 'b>(lhs: &'a &&Impl, rhs: &'b &&Impl, cx: &Context<'_>) -> Ordering {

--- a/src/test/rustdoc/source-version-separator.rs
+++ b/src/test/rustdoc/source-version-separator.rs
@@ -1,0 +1,31 @@
+#![stable(feature = "bar", since = "1.0")]
+#![crate_name = "foo"]
+
+#![feature(staged_api)]
+
+// @has foo/trait.Bar.html
+// @has - '//div[@class="main-heading"]/*[@class="out-of-band"]' '1.0· source · '
+#[stable(feature = "bar", since = "1.0")]
+pub trait Bar {
+    // @has - '//div[@id="tymethod.foo"]/*[@class="rightside"]' '3.0 · source'
+    #[stable(feature = "foobar", since = "3.0")]
+    fn foo();
+}
+
+// @has - '//div[@id="implementors-list"]//*[@class="rightside"]' '4.0 · source'
+
+// @has foo/struct.Foo.html
+// @has - '//div[@class="main-heading"]/*[@class="out-of-band"]' '1.0· source · '
+#[stable(feature = "baz", since = "1.0")]
+pub struct Foo;
+
+impl Foo {
+    // @has - '//div[@id="method.foofoo"]/*[@class="rightside"]' '3.0 · source'
+    #[stable(feature = "foobar", since = "3.0")]
+    pub fn foofoo() {}
+}
+
+#[stable(feature = "yolo", since = "4.0")]
+impl Bar for Foo {
+    fn foo() {}
+}


### PR DESCRIPTION
Fixes #92901.

![Screenshot from 2022-01-15 17-47-18](https://user-images.githubusercontent.com/3050060/149631249-e2c0c3a4-9ed8-48e2-92cc-79a5bb347b35.png)

r? @jsha