### PR TITLE
rustdoc: Use `intersperse` in a `visit_path` function

### DIFF
--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -492,9 +492,9 @@ impl<'tcx> Visitor<'tcx> for EmitIgnoredResolutionErrors<'tcx> {
                 "could not resolve path `{}`",
                 path.segments
                     .iter()
-                    .map(|segment| segment.ident.as_str().to_string())
-                    .collect::<Vec<_>>()
-                    .join("::")
+                    .map(|segment| segment.ident.as_str())
+                    .intersperse("::")
+                    .collect::<String>()
             );
             let mut err = rustc_errors::struct_span_err!(
                 self.tcx.sess,


### PR DESCRIPTION
(~~Is there a better way to word the title?~~ Eh, this works, I guess.)
I'm surprised that the compiler didn't complain when I left out the `.to_string()`, but hey, if it works then it works.