### PR TITLE
CI: Migrate builders from retiring ubuntu-latest-xl to ubuntu-20.04-xl.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,15 +41,15 @@ jobs:
       matrix:
         include:
           - name: mingw-check
-            os: ubuntu-latest-xl
+            os: ubuntu-20.04-xl
             env: {}
           - name: x86_64-gnu-llvm-12
-            os: ubuntu-latest-xl
+            os: ubuntu-20.04-xl
             env: {}
           - name: x86_64-gnu-tools
             env:
               CI_ONLY_WHEN_SUBMODULES_CHANGED: 1
-            os: ubuntu-latest-xl
+            os: ubuntu-20.04-xl
     timeout-minutes: 600
     runs-on: "${{ matrix.os }}"
     steps:
@@ -163,128 +163,128 @@ jobs:
               - ARM64
               - linux
           - name: arm-android
-            os: ubuntu-latest-xl
+            os: ubuntu-20.04-xl
             env: {}
           - name: armhf-gnu
-            os: ubuntu-latest-xl
+            os: ubuntu-20.04-xl
             env: {}
           - name: dist-aarch64-linux
-            os: ubuntu-latest-xl
+            os: ubuntu-20.04-xl
             env: {}
           - name: dist-android
-            os: ubuntu-latest-xl
+            os: ubuntu-20.04-xl
             env: {}
           - name: dist-arm-linux
-            os: ubuntu-latest-xl
+            os: ubuntu-20.04-xl
             env: {}
           - name: dist-armhf-linux
-            os: ubuntu-latest-xl
+            os: ubuntu-20.04-xl
             env: {}
           - name: dist-armv7-linux
-            os: ubuntu-latest-xl
+            os: ubuntu-20.04-xl
             env: {}
           - name: dist-i586-gnu-i586-i686-musl
-            os: ubuntu-latest-xl
+            os: ubuntu-20.04-xl
             env: {}
           - name: dist-i686-linux
-            os: ubuntu-latest-xl
+            os: ubuntu-20.04-xl
             env: {}
           - name: dist-mips-linux
-            os: ubuntu-latest-xl
+            os: ubuntu-20.04-xl
             env: {}
           - name: dist-mips64-linux
-            os: ubuntu-latest-xl
+            os: ubuntu-20.04-xl
             env: {}
           - name: dist-mips64el-linux
-            os: ubuntu-latest-xl
+            os: ubuntu-20.04-xl
             env: {}
           - name: dist-mipsel-linux
-            os: ubuntu-latest-xl
+            os: ubuntu-20.04-xl
             env: {}
           - name: dist-powerpc-linux
-            os: ubuntu-latest-xl
+            os: ubuntu-20.04-xl
             env: {}
           - name: dist-powerpc64-linux
-            os: ubuntu-latest-xl
+            os: ubuntu-20.04-xl
             env: {}
           - name: dist-powerpc64le-linux
-            os: ubuntu-latest-xl
+            os: ubuntu-20.04-xl
             env: {}
           - name: dist-riscv64-linux
-            os: ubuntu-latest-xl
+            os: ubuntu-20.04-xl
             env: {}
           - name: dist-s390x-linux
-            os: ubuntu-latest-xl
+            os: ubuntu-20.04-xl
             env: {}
           - name: dist-various-1
-            os: ubuntu-latest-xl
+            os: ubuntu-20.04-xl
             env: {}
           - name: dist-various-2
-            os: ubuntu-latest-xl
+            os: ubuntu-20.04-xl
             env: {}
           - name: dist-x86_64-freebsd
-            os: ubuntu-latest-xl
+            os: ubuntu-20.04-xl
             env: {}
           - name: dist-x86_64-illumos
-            os: ubuntu-latest-xl
+            os: ubuntu-20.04-xl
             env: {}
           - name: dist-x86_64-linux
-            os: ubuntu-latest-xl
+            os: ubuntu-20.04-xl
             env: {}
           - name: dist-x86_64-linux-alt
             env:
               IMAGE: dist-x86_64-linux
-            os: ubuntu-latest-xl
+            os: ubuntu-20.04-xl
           - name: dist-x86_64-musl
-            os: ubuntu-latest-xl
+            os: ubuntu-20.04-xl
             env: {}
           - name: dist-x86_64-netbsd
-            os: ubuntu-latest-xl
+            os: ubuntu-20.04-xl
             env: {}
           - name: i686-gnu
-            os: ubuntu-latest-xl
+            os: ubuntu-20.04-xl
             env: {}
           - name: i686-gnu-nopt
-            os: ubuntu-latest-xl
+            os: ubuntu-20.04-xl
             env: {}
           - name: mingw-check
-            os: ubuntu-latest-xl
+            os: ubuntu-20.04-xl
             env: {}
           - name: test-various
-            os: ubuntu-latest-xl
+            os: ubuntu-20.04-xl
             env: {}
           - name: wasm32
-            os: ubuntu-latest-xl
+            os: ubuntu-20.04-xl
             env: {}
           - name: x86_64-gnu
-            os: ubuntu-latest-xl
+            os: ubuntu-20.04-xl
             env: {}
           - name: x86_64-gnu-stable
             env:
               IMAGE: x86_64-gnu
               RUST_CI_OVERRIDE_RELEASE_CHANNEL: stable
               CI_ONLY_WHEN_CHANNEL: nightly
-            os: ubuntu-latest-xl
+            os: ubuntu-20.04-xl
           - name: x86_64-gnu-aux
-            os: ubuntu-latest-xl
+            os: ubuntu-20.04-xl
             env: {}
           - name: x86_64-gnu-debug
-            os: ubuntu-latest-xl
+            os: ubuntu-20.04-xl
             env: {}
           - name: x86_64-gnu-distcheck
-            os: ubuntu-latest-xl
+            os: ubuntu-20.04-xl
             env: {}
           - name: x86_64-gnu-llvm-12
             env:
               RUST_BACKTRACE: 1
-            os: ubuntu-latest-xl
+            os: ubuntu-20.04-xl
           - name: x86_64-gnu-nopt
-            os: ubuntu-latest-xl
+            os: ubuntu-20.04-xl
             env: {}
           - name: x86_64-gnu-tools
             env:
               DEPLOY_TOOLSTATES_JSON: toolstates-linux.json
-            os: ubuntu-latest-xl
+            os: ubuntu-20.04-xl
           - name: dist-x86_64-apple
             env:
               SCRIPT: "./x.py dist --exclude rust-docs --exclude extended && ./x.py dist --target=x86_64-apple-darwin rust-docs && ./x.py dist extended"
@@ -532,7 +532,7 @@ jobs:
       matrix:
         include:
           - name: dist-x86_64-linux
-            os: ubuntu-latest-xl
+            os: ubuntu-20.04-xl
             env: {}
     timeout-minutes: 600
     runs-on: "${{ matrix.os }}"

--- a/src/ci/github-actions/ci.yml
+++ b/src/ci/github-actions/ci.yml
@@ -73,7 +73,7 @@ x--expand-yaml-anchors--remove:
     env: {}
 
   - &job-linux-xl
-    os: ubuntu-latest-xl
+    os: ubuntu-20.04-xl
     <<: *base-job
 
   - &job-macos-xl


### PR DESCRIPTION
> ubuntu-20.04-xl runner image is now available. The existing ubuntu-latest-xl runner image (based on Ubuntu 18.04 XL) is deprecated and will retire on January 15, 2022. Migrate to ubuntu-20.04-xl instead.

Fixes #89850.