### PR TITLE
Add Iterator::collect_into and Iterator::collect_with

### DIFF
--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -1766,12 +1766,12 @@ pub trait Iterator {
     /// #![feature(iter_more_collects)]
     ///
     /// let a = [1, 2, 3];
-    /// let mut vec: Vec::<i32> = Vec::new();
+    /// let mut vec: Vec::<i32> = vec![0, 1];
     ///
     /// a.iter().map(|&x| x * 2).collect_into(&mut vec);
     /// a.iter().map(|&x| x * 10).collect_into(&mut vec);
     ///
-    /// assert_eq!(vec![2, 4, 6, 10, 20, 30], vec);
+    /// assert_eq!(vec![0, 1, 2, 4, 6, 10, 20, 30], vec);
     /// ```
     ///
     /// `Vec` can have a manual set capacity to avoid reallocating it:

--- a/library/core/tests/iter/traits/iterator.rs
+++ b/library/core/tests/iter/traits/iterator.rs
@@ -496,3 +496,18 @@ fn test_collect() {
     let b: Vec<isize> = a.iter().cloned().collect();
     assert!(a == b);
 }
+
+#[test]
+fn test_collect_into() {
+    let a = vec![1, 2, 3, 4, 5];
+    let mut b = Vec::new();
+    a.iter().cloned().collect_into(&mut b);
+    assert!(a == b);
+}
+
+#[test]
+fn test_collect_with() {
+    let a = vec![1, 2, 3, 4, 5];
+    let b = a.iter().cloned().collect_with(Vec::with_capacity(5));
+    assert!(a == b);
+}

--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -60,6 +60,7 @@
 #![feature(slice_partition_dedup)]
 #![feature(int_log)]
 #![feature(iter_advance_by)]
+#![feature(iter_more_collects)]
 #![feature(iter_partition_in_place)]
 #![feature(iter_intersperse)]
 #![feature(iter_is_partitioned)]


### PR DESCRIPTION
This is a PR for adding `Iterator::collect_into` and `Iterator::collect_with` as proposed by @cormacrelf in #48597 (see https://github.com/rust-lang/rust/pull/48597#issuecomment-842083688).

This adds the following methods to the Iterator trait:
```rust
fn collect_into<E: Extend<Self::Item>>(self, collection: &mut E) -> &mut E;

fn collect_with<E: Extend<Self::Item>>(self, mut collection: E) -> E;
```