### PR TITLE
Help optimize out backtraces when disabled

### DIFF
--- a/library/std/src/panicking.rs
+++ b/library/std/src/panicking.rs
@@ -263,7 +263,7 @@ fn default_hook(info: &PanicInfo<'_>) {
     // If this is a double panic, make sure that we print a backtrace
     // for this panic. Otherwise only print it if logging is enabled.
     let backtrace_env = if panic_count::get_count() >= 2 {
-        RustBacktrace::Print(crate::backtrace_rs::PrintFmt::Full)
+        backtrace::rust_backtrace_print_full()
     } else {
         backtrace::rust_backtrace_env()
     };


### PR DESCRIPTION
The comment in `rust_backtrace_env` says:

>    // If the `backtrace` feature of this crate isn't enabled quickly return
>   // `None` so this can be constant propagated all over the place to turn
>  // optimize away callers.

but this optimization has regressed, because the only caller of this function had an alternative path that unconditionally (and pointlessly) asked for a full backtrace, so the disabled state couldn't propagate.

I've added a getter for the full format that respects the feature flag, so that the caller will now be able to really optimize out the disabled backtrace path. I've also made `rust_backtrace_env` trivially inlineable when backtraces are disabled.

