### PR TITLE
Update hashbrown to 0.12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1587,6 +1587,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 dependencies = [
  "ahash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c21d40587b92fa6a6c6e3c1bdbf87d75511db5672f9c93175574b3a00df1758"
+dependencies = [
  "compiler_builtins",
  "rustc-std-workspace-alloc",
  "rustc-std-workspace-core",
@@ -1736,7 +1744,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.11.2",
  "serde",
 ]
 
@@ -2411,7 +2419,7 @@ checksum = "7ce8b38d41f9f3618fc23f908faae61510f8d8ce2d99cbe910641e8f1971f084"
 dependencies = [
  "crc32fast",
  "flate2",
- "hashbrown",
+ "hashbrown 0.11.2",
  "indexmap",
  "memchr",
 ]
@@ -4825,7 +4833,7 @@ dependencies = [
  "core",
  "dlmalloc",
  "fortanix-sgx-abi",
- "hashbrown",
+ "hashbrown 0.12.0",
  "hermit-abi",
  "libc",
  "miniz_oxide",
@@ -5107,7 +5115,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd95b4559c196987c8451b4e14d08a4c796c2844f9adf4d2a2dbc9b3142843be"
 dependencies = [
  "gimli 0.26.1",
- "hashbrown",
+ "hashbrown 0.11.2",
  "object 0.28.1",
  "tracing",
 ]

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -19,7 +19,7 @@ libc = { version = "0.2.108", default-features = false, features = ['rustc-dep-o
 compiler_builtins = { version = "0.1.66" }
 profiler_builtins = { path = "../profiler_builtins", optional = true }
 unwind = { path = "../unwind" }
-hashbrown = { version = "0.11", default-features = false, features = ['rustc-dep-of-std'] }
+hashbrown = { version = "0.12", default-features = false, features = ['rustc-dep-of-std'] }
 std_detect = { path = "../stdarch/crates/std_detect", default-features = false, features = ['rustc-dep-of-std'] }
 
 # Dependencies of the `backtrace` crate

--- a/library/std/src/collections/hash/map/tests.rs
+++ b/library/std/src/collections/hash/map/tests.rs
@@ -828,11 +828,21 @@ fn test_try_reserve() {
         "usize::MAX should trigger an overflow!"
     );
 
-    assert_matches!(
-        empty_bytes.try_reserve(MAX_USIZE / 8).map_err(|e| e.kind()),
-        Err(AllocError { .. }),
-        "usize::MAX / 8 should trigger an OOM!"
-    );
+    if let Err(AllocError { .. }) = empty_bytes.try_reserve(MAX_USIZE / 16).map_err(|e| e.kind()) {
+    } else {
+        // This may succeed if there is enough free memory. Attempt to
+        // allocate a few more hashmaps to ensure the allocation will fail.
+        let mut empty_bytes2: HashMap<u8, u8> = HashMap::new();
+        let _ = empty_bytes2.try_reserve(MAX_USIZE / 16);
+        let mut empty_bytes3: HashMap<u8, u8> = HashMap::new();
+        let _ = empty_bytes3.try_reserve(MAX_USIZE / 16);
+        let mut empty_bytes4: HashMap<u8, u8> = HashMap::new();
+        assert_matches!(
+            empty_bytes4.try_reserve(MAX_USIZE / 16).map_err(|e| e.kind()),
+            Err(AllocError { .. }),
+            "usize::MAX / 16 should trigger an OOM!"
+        );
+    }
 }
 
 #[test]

--- a/library/std/src/collections/hash/map/tests.rs
+++ b/library/std/src/collections/hash/map/tests.rs
@@ -817,6 +817,7 @@ fn test_retain() {
 }
 
 #[test]
+#[cfg_attr(target_os = "android", ignore)] // Android used in CI has a broken dlmalloc
 fn test_try_reserve() {
     let mut empty_bytes: HashMap<u8, u8> = HashMap::new();
 


### PR DESCRIPTION
[Changelog](https://github.com/rust-lang/hashbrown/blob/master/CHANGELOG.md#v0120---2022-01-17)