### PR TITLE
Do not ICE when inlining a function with un-satisfiable bounds

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/codegen.rs
+++ b/compiler/rustc_trait_selection/src/traits/codegen.rs
@@ -65,6 +65,8 @@ pub fn codegen_fulfill_obligation<'tcx>(
             Err(Unimplemented) => {
                 // This can trigger when we probe for the source of a `'static` lifetime requirement
                 // on a trait object: `impl Foo for dyn Trait {}` has an implicit `'static` bound.
+                // This can also trigger when we have a global bound that is not actually satisfied,
+                // but was included during typeck due to the trivial_bounds feature.
                 infcx.tcx.sess.delay_span_bug(
                     rustc_span::DUMMY_SP,
                     &format!(

--- a/src/test/ui/trait-bounds/issue-93008.rs
+++ b/src/test/ui/trait-bounds/issue-93008.rs
@@ -1,0 +1,10 @@
+// compile-flags: -Zmir-opt-level=4
+
+pub fn bar<T>(s: &'static mut ())
+where
+    &'static mut (): Clone, //~ ERROR the trait bound
+{
+    <&'static mut () as Clone>::clone(&s);
+}
+
+fn main() {}

--- a/src/test/ui/trait-bounds/issue-93008.stderr
+++ b/src/test/ui/trait-bounds/issue-93008.stderr
@@ -1,0 +1,12 @@
+error[E0277]: the trait bound `&'static mut (): Clone` is not satisfied
+  --> $DIR/issue-93008.rs:5:5
+   |
+LL |     &'static mut (): Clone,
+   |     ^^^^^^^^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `&'static mut ()`
+   |
+   = help: see issue #48214
+   = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
Fixes #93008
This is kinda a hack... but it's the fix I thought had the least blast-radius.

We use `normalize_param_env_or_error` to verify that the predicates in the param env are self-consistent, since with RevealAll, a bad predicate like `<&'static () as Clone>` will be evaluated with an empty ParamEnv (since it references no generics), and we'll raise an error for it.