### PR TITLE
bootstrap: add comment for people trying to figure out what "fabricate" is (NFC)

### DIFF
--- a/src/bootstrap/tool.rs
+++ b/src/bootstrap/tool.rs
@@ -365,6 +365,7 @@ bootstrap_tool!(
     Compiletest, "src/tools/compiletest", "compiletest", is_unstable_tool = true;
     BuildManifest, "src/tools/build-manifest", "build-manifest";
     RemoteTestClient, "src/tools/remote-test-client", "remote-test-client";
+    // the tool lives in the "rust-installer" submodule but the binary is named "fabricate"
     RustInstaller, "src/tools/rust-installer", "fabricate", is_external_tool = true;
     RustdocTheme, "src/tools/rustdoc-themes", "rustdoc-themes";
     ExpandYamlAnchors, "src/tools/expand-yaml-anchors", "expand-yaml-anchors";


### PR DESCRIPTION
Spent some time trying to figure out where the "fabricate" executable comes from, turns out the tool is actually named "rust-installer"