### PR TITLE
Add forwarding impls for Read, Write, Seek to Arc, Rc

### DIFF
--- a/library/std/src/io/impls.rs
+++ b/library/std/src/io/impls.rs
@@ -1,6 +1,9 @@
 #[cfg(test)]
 mod tests;
 
+mod arc;
+mod rc;
+
 use crate::alloc::Allocator;
 use crate::cmp;
 use crate::fmt;

--- a/library/std/src/io/impls/arc.rs
+++ b/library/std/src/io/impls/arc.rs
@@ -1,9 +1,15 @@
-//! Forwarding implementations for Rc
+//! Forwarding implementations for Arc
 
 use crate::fmt;
 use crate::io::{self, IoSlice, IoSliceMut, Read, ReadBuf, Seek, SeekFrom, Write};
 use alloc::sync::Arc;
 
+/// Enables forwarding `Read` through an `Arc<T>`
+///
+/// This only applies for types such as `File` or `TcpStream` that implement Read
+/// on `&T`. The reason is that `Read` normally requires `&mut self`, but mutation
+/// through an `Arc` is not generally allowed because the value in the `Arc` may be
+/// shared.
 #[stable(feature = "io_delegation_rc", since = "1.60.0")]
 impl<T> Read for Arc<T>
 where
@@ -44,6 +50,12 @@ where
         (self as &T).read_exact(buf)
     }
 }
+/// Enables forwarding `Write` through an `Arc<T>`
+///
+/// This only applies for types such as `File` or `TcpStream` that implement Write
+/// on `&T`. The reason is that `Write` normally requires `&mut self`, but mutation
+/// through an `Arc` is not generally allowed because the value in the `Arc` may be
+/// shared.
 #[stable(feature = "io_delegation_rc", since = "1.60.0")]
 impl<T> Write for Arc<T>
 where
@@ -79,6 +91,12 @@ where
         (self as &T).write_fmt(fmt)
     }
 }
+/// Enables forwarding `Seek` through an `Arc<T>`
+///
+/// This only applies for types such as `File` or `TcpStream` that implement Seek
+/// on `&T`. The reason is that `Seek` normally requires `&mut self`, but mutation
+/// through an `Arc` is not generally allowed because the value in the `Arc` may be
+/// shared.
 #[stable(feature = "io_delegation_rc", since = "1.60.0")]
 impl<T> Seek for Arc<T>
 where

--- a/library/std/src/io/impls/arc.rs
+++ b/library/std/src/io/impls/arc.rs
@@ -1,0 +1,96 @@
+//! Forwarding implementations for Rc
+
+use crate::fmt;
+use crate::io::{self, IoSlice, IoSliceMut, Read, ReadBuf, Seek, SeekFrom, Write};
+use alloc::sync::Arc;
+
+#[stable(feature = "io_delegation_rc", since = "1.60.0")]
+impl<T> Read for Arc<T>
+where
+    for<'a> &'a T: Read,
+{
+    #[inline]
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        (self as &T).read(buf)
+    }
+
+    #[inline]
+    fn read_buf(&mut self, buf: &mut ReadBuf<'_>) -> io::Result<()> {
+        (self as &T).read_buf(buf)
+    }
+
+    #[inline]
+    fn read_vectored(&mut self, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
+        (self as &T).read_vectored(bufs)
+    }
+
+    #[inline]
+    fn is_read_vectored(&self) -> bool {
+        (self as &T).is_read_vectored()
+    }
+
+    #[inline]
+    fn read_to_end(&mut self, buf: &mut Vec<u8>) -> io::Result<usize> {
+        (self as &T).read_to_end(buf)
+    }
+
+    #[inline]
+    fn read_to_string(&mut self, buf: &mut String) -> io::Result<usize> {
+        (self as &T).read_to_string(buf)
+    }
+
+    #[inline]
+    fn read_exact(&mut self, buf: &mut [u8]) -> io::Result<()> {
+        (self as &T).read_exact(buf)
+    }
+}
+#[stable(feature = "io_delegation_rc", since = "1.60.0")]
+impl<T> Write for Arc<T>
+where
+    for<'a> &'a T: Write,
+{
+    #[inline]
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        (self as &T).write(buf)
+    }
+
+    #[inline]
+    fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
+        (self as &T).write_vectored(bufs)
+    }
+
+    #[inline]
+    fn is_write_vectored(&self) -> bool {
+        (self as &T).is_write_vectored()
+    }
+
+    #[inline]
+    fn flush(&mut self) -> io::Result<()> {
+        (self as &T).flush()
+    }
+
+    #[inline]
+    fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
+        (self as &T).write_all(buf)
+    }
+
+    #[inline]
+    fn write_fmt(&mut self, fmt: fmt::Arguments<'_>) -> io::Result<()> {
+        (self as &T).write_fmt(fmt)
+    }
+}
+#[stable(feature = "io_delegation_rc", since = "1.60.0")]
+impl<T> Seek for Arc<T>
+where
+    for<'a> &'a T: Seek,
+{
+    #[inline]
+    fn seek(&mut self, pos: SeekFrom) -> io::Result<u64> {
+        (self as &T).seek(pos)
+    }
+
+    #[inline]
+    fn stream_position(&mut self) -> io::Result<u64> {
+        (self as &T).stream_position()
+    }
+}

--- a/library/std/src/io/impls/rc.rs
+++ b/library/std/src/io/impls/rc.rs
@@ -1,0 +1,96 @@
+//! Forwarding implementations for Rc
+
+use crate::fmt;
+use crate::io::{self, IoSlice, IoSliceMut, Read, ReadBuf, Seek, SeekFrom, Write};
+use alloc::rc::Rc;
+
+#[stable(feature = "io_delegation_rc", since = "1.60.0")]
+impl<T> Read for Rc<T>
+where
+    for<'a> &'a T: Read,
+{
+    #[inline]
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        (self as &T).read(buf)
+    }
+
+    #[inline]
+    fn read_buf(&mut self, buf: &mut ReadBuf<'_>) -> io::Result<()> {
+        (self as &T).read_buf(buf)
+    }
+
+    #[inline]
+    fn read_vectored(&mut self, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
+        (self as &T).read_vectored(bufs)
+    }
+
+    #[inline]
+    fn is_read_vectored(&self) -> bool {
+        (self as &T).is_read_vectored()
+    }
+
+    #[inline]
+    fn read_to_end(&mut self, buf: &mut Vec<u8>) -> io::Result<usize> {
+        (self as &T).read_to_end(buf)
+    }
+
+    #[inline]
+    fn read_to_string(&mut self, buf: &mut String) -> io::Result<usize> {
+        (self as &T).read_to_string(buf)
+    }
+
+    #[inline]
+    fn read_exact(&mut self, buf: &mut [u8]) -> io::Result<()> {
+        (self as &T).read_exact(buf)
+    }
+}
+#[stable(feature = "io_delegation_rc", since = "1.60.0")]
+impl<T> Write for Rc<T>
+where
+    for<'a> &'a T: Write,
+{
+    #[inline]
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        (self as &T).write(buf)
+    }
+
+    #[inline]
+    fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
+        (self as &T).write_vectored(bufs)
+    }
+
+    #[inline]
+    fn is_write_vectored(&self) -> bool {
+        (self as &T).is_write_vectored()
+    }
+
+    #[inline]
+    fn flush(&mut self) -> io::Result<()> {
+        (self as &T).flush()
+    }
+
+    #[inline]
+    fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
+        (self as &T).write_all(buf)
+    }
+
+    #[inline]
+    fn write_fmt(&mut self, fmt: fmt::Arguments<'_>) -> io::Result<()> {
+        (self as &T).write_fmt(fmt)
+    }
+}
+#[stable(feature = "io_delegation_rc", since = "1.60.0")]
+impl<T> Seek for Rc<T>
+where
+    for<'a> &'a T: Seek,
+{
+    #[inline]
+    fn seek(&mut self, pos: SeekFrom) -> io::Result<u64> {
+        (self as &T).seek(pos)
+    }
+
+    #[inline]
+    fn stream_position(&mut self) -> io::Result<u64> {
+        (self as &T).stream_position()
+    }
+}

--- a/library/std/src/io/impls/rc.rs
+++ b/library/std/src/io/impls/rc.rs
@@ -4,6 +4,12 @@ use crate::fmt;
 use crate::io::{self, IoSlice, IoSliceMut, Read, ReadBuf, Seek, SeekFrom, Write};
 use alloc::rc::Rc;
 
+/// Enables forwarding `Read` through an `Rc<T>`
+///
+/// This only applies for types such as `File` or `TcpStream` that implement Read
+/// on `&T`. The reason is that `Read` normally requires `&mut self`, but mutation
+/// through an `Rc` is not generally allowed because the value in the `Rc` may be
+/// shared.
 #[stable(feature = "io_delegation_rc", since = "1.60.0")]
 impl<T> Read for Rc<T>
 where
@@ -44,6 +50,12 @@ where
         (self as &T).read_exact(buf)
     }
 }
+/// Enables forwarding `Write` through an `Rc<T>`
+///
+/// This only applies for types such as `File` or `TcpStream` that implement Write
+/// on `&T`. The reason is that `Write` normally requires `&mut self`, but mutation
+/// through an `Rc` is not generally allowed because the value in the `Rc` may be
+/// shared.
 #[stable(feature = "io_delegation_rc", since = "1.60.0")]
 impl<T> Write for Rc<T>
 where
@@ -79,6 +91,12 @@ where
         (self as &T).write_fmt(fmt)
     }
 }
+/// Enables forwarding `Seek` through an `Rc<T>`
+///
+/// This only applies for types such as `File` or `TcpStream` that implement Seek
+/// on `&T`. The reason is that `Seek` normally requires `&mut self`, but mutation
+/// through an `Rc` is not generally allowed because the value in the `Rc` may be
+/// shared.
 #[stable(feature = "io_delegation_rc", since = "1.60.0")]
 impl<T> Seek for Rc<T>
 where

--- a/library/std/src/io/tests.rs
+++ b/library/std/src/io/tests.rs
@@ -604,9 +604,13 @@ fn bench_take_read_buf(b: &mut test::Bencher) {
 }
 
 #[test]
-fn read_arc() {
+fn forward_arc() {
+    // Tests forwarding of Read, Write, and Seek through an Arc<T> when &T implements the trait.
+
     use crate::net::TcpStream;
+    use crate::fs::File;
     use crate::sync::Arc;
+    use crate::io::SeekFrom;
 
     // This test is wrapped in a closure to make sure it typechecks
     // but we do not run it.
@@ -615,5 +619,38 @@ fn read_arc() {
         let mut stream = Arc::new(stream);
         let mut buffer = [0; 4];
         stream.read(&mut buffer).unwrap();
+        stream.write(&buffer).unwrap();
+    };
+
+    let _ = || {
+        let file = File::open("foo").unwrap();
+        let mut file = Arc::new(file);
+        file.seek(SeekFrom::Start(10)).unwrap();
+    };
+}
+
+#[test]
+fn forward_rc() {
+    // Tests forwarding of Read, Write, and Seek through an Arc<T> when &T implements the trait.
+
+    use crate::net::TcpStream;
+    use crate::fs::File;
+    use crate::rc::Rc;
+    use crate::io::SeekFrom;
+
+    // This test is wrapped in a closure to make sure it typechecks
+    // but we do not run it.
+    let _ = || {
+        let stream = TcpStream::connect("localhost:8080").unwrap();
+        let mut stream = Rc::new(stream);
+        let mut buffer = [0; 4];
+        stream.read(&mut buffer).unwrap();
+        stream.write(&buffer).unwrap();
+    };
+
+    let _ = || {
+        let file = File::open("foo").unwrap();
+        let mut file = Rc::new(file);
+        file.seek(SeekFrom::Start(10)).unwrap();
     };
 }

--- a/library/std/src/io/tests.rs
+++ b/library/std/src/io/tests.rs
@@ -602,3 +602,18 @@ fn bench_take_read_buf(b: &mut test::Bencher) {
         [255; 128].take(64).read_buf(&mut rbuf).unwrap();
     });
 }
+
+#[test]
+fn read_arc() {
+    use crate::net::TcpStream;
+    use crate::sync::Arc;
+
+    // This test is wrapped in a closure to make sure it typechecks
+    // but we do not run it.
+    let _ = || {
+        let stream = TcpStream::connect("localhost:8080").unwrap();
+        let mut stream = Arc::new(stream);
+        let mut buffer = [0; 4];
+        stream.read(&mut buffer).unwrap();
+    };
+}

--- a/library/std/src/io/tests.rs
+++ b/library/std/src/io/tests.rs
@@ -607,10 +607,10 @@ fn bench_take_read_buf(b: &mut test::Bencher) {
 fn forward_arc() {
     // Tests forwarding of Read, Write, and Seek through an Arc<T> when &T implements the trait.
 
-    use crate::net::TcpStream;
     use crate::fs::File;
-    use crate::sync::Arc;
     use crate::io::SeekFrom;
+    use crate::net::TcpStream;
+    use crate::sync::Arc;
 
     // This test is wrapped in a closure to make sure it typechecks
     // but we do not run it.
@@ -633,10 +633,10 @@ fn forward_arc() {
 fn forward_rc() {
     // Tests forwarding of Read, Write, and Seek through an Arc<T> when &T implements the trait.
 
-    use crate::net::TcpStream;
     use crate::fs::File;
-    use crate::rc::Rc;
     use crate::io::SeekFrom;
+    use crate::net::TcpStream;
+    use crate::rc::Rc;
 
     // This test is wrapped in a closure to make sure it typechecks
     // but we do not run it.


### PR DESCRIPTION
This adds forwarding impls for `std::io::Read`, `std::io::Write`, and `std::io::Seek` to `alloc:sync::Arc` and `alloc::rc::Rc`. This is relevant for types such as `std::fs::File`, `std::net::TcpStream`, and `std::os::unix::UnixStream` which [implement `Read`, `Write`, and `Seek` for `&T`](https://doc.rust-lang.org/stable/std/io/trait.Read.html#impl-Read-12).

It is currently possible to do this manually through wrappers (See the "Implement a forwarding wrapper by hand" section for an example), but providing forwarding impls makes this pattern nicer to use. In some cases this can also be done with an extra reference, as shown below:

```rust
let stream = TcpStream::connect("localhost:8080");
let stream = Arc::new(stream);

&stream1.write(b"hello world")?; // OK: Read is available for &Arc<TcpStream>.
stream1.write(b"hello world")?;  // Error: Read is not available for Arc<TcpStream>.
                                 // (Enabled by this PR)
```

The reason why we want `Arc<T>: Read where &T: Read` is because this enables `Arc<T>` to be passed directly into APIs which expect `T: Read`:

```rust
fn operate<R: Read>(reader: R) {}

let stream = TcpStream::connect("localhost:8080");
let stream = Arc::new(stream);
operate(stream);  // Error: `Arc<TcpStream>` does not implement `Read`
                  // (Enabled by this PR)
```

## Implement a forwarding wrapper by hand

These trait impls do not allow anything which wasn't allowed before. Dereferencing to the inner type to get `Arc<T>: Read` to work is already possible by creating an intermediate type, as shown here:

```rust
/// A variant of `Arc` that delegates IO traits if available on `&T`.
#[derive(Debug)]
pub struct IoArc<T>(Arc<T>);

impl<T> IoArc<T> {
    /// Create a new instance of IoArc.
    pub fn new(data: T) -> Self {
        Self(Arc::new(data))
    }
}

impl<T> Read for IoArc<T>
where
    for<'a> &'a T: Read,
{
    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
        (&mut &*self.0).read(buf)
    }
}

impl<T> Write for IoArc<T>
where
    for<'a> &'a T: Write,
{
    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
        (&mut &*self.0).write(buf)
    }

    fn flush(&mut self) -> io::Result<()> {
        (&mut &*self.0).flush()
    }
}

// forward `Clone`, `Seek` as well here
```

## References

- [IO trait delegation for `Arc` blog post](https://blog.yoshuawuyts.com/io-trait-delegation-for-arc/)
- [`async-dup` crate](https://docs.rs/async-dup/latest/async_dup/)
- [`io-arc` crate](https://docs.rs/io-arc/latest/io_arc/)

Joint work with @yoshuawuyts. 