### PR TITLE
Introduce `enhanced_binary_op` feature

### DIFF
--- a/compiler/rustc_feature/src/active.rs
+++ b/compiler/rustc_feature/src/active.rs
@@ -142,6 +142,8 @@ declare_features! (
     (active, allow_internal_unstable, "1.0.0", None, None),
     /// Allows identifying the `compiler_builtins` crate.
     (active, compiler_builtins, "1.13.0", None, None),
+    /// Allows more code to compile within a binary operation context
+    (active, enhanced_binary_op, "1.60.0", None, None),
     /// Allows using the `rust-intrinsic`'s "ABI".
     (active, intrinsics, "1.0.0", None, None),
     /// Allows using `#[lang = ".."]` attribute for linking items to special compiler logic.

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -611,6 +611,7 @@ symbols! {
         enclosing_scope,
         encode,
         end,
+        enhanced_binary_op,
         env,
         env_macro,
         eprint_macro,

--- a/src/test/ui/rfc-2497-if-let-chains/feature-gate-enhanced_binary_op.rs
+++ b/src/test/ui/rfc-2497-if-let-chains/feature-gate-enhanced_binary_op.rs
@@ -1,0 +1,20 @@
+#![feature(enhanced_binary_op)]
+
+fn and_chain() {
+    let z;
+    if true && { z = 3; true } && z == 3 {}
+}
+
+fn and_chain_2() {
+    let z;
+    true && { z = 3; true } && z == 3;
+}
+
+fn or_chain() {
+    let z;
+    if false || { z = 3; false } || z == 3 {}
+    //~^ ERROR use of possibly-uninitialized
+}
+
+fn main() {
+}

--- a/src/test/ui/rfc-2497-if-let-chains/feature-gate-enhanced_binary_op.stderr
+++ b/src/test/ui/rfc-2497-if-let-chains/feature-gate-enhanced_binary_op.stderr
@@ -1,0 +1,9 @@
+error[E0381]: use of possibly-uninitialized variable: `z`
+  --> $DIR/feature-gate-enhanced_binary_op.rs:15:37
+   |
+LL |     if false || { z = 3; false } || z == 3 {}
+   |                                     ^ use of possibly-uninitialized `z`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0381`.


### PR DESCRIPTION
Addresses the requests of @rust-lang/lang in https://github.com/rust-lang/rust/pull/88642#issuecomment-1015731744.
Direct usage could be applied through a FCP but everything was extracted into a feature flag as inferred by previous comments.

r? @matthewjasper
cc #53667