### PR TITLE
Fix stack overflows when compiling high-`recursion_limit` programs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3818,6 +3818,7 @@ version = "0.0.0"
 dependencies = [
  "rustc_ast",
  "rustc_ast_pretty",
+ "rustc_data_structures",
  "rustc_hir",
  "rustc_span",
  "rustc_target",

--- a/compiler/rustc_ast_passes/src/ast_validation.rs
+++ b/compiler/rustc_ast_passes/src/ast_validation.rs
@@ -13,6 +13,7 @@ use rustc_ast::walk_list;
 use rustc_ast::*;
 use rustc_ast_pretty::pprust::{self, State};
 use rustc_data_structures::fx::FxHashMap;
+use rustc_data_structures::stack::ensure_sufficient_stack;
 use rustc_errors::{error_code, pluralize, struct_span_err, Applicability};
 use rustc_parse::validate_attr;
 use rustc_session::lint::builtin::{
@@ -215,7 +216,7 @@ impl<'a> AstValidator<'a> {
 
     // Mirrors `visit::walk_ty`, but tracks relevant state.
     fn walk_ty(&mut self, t: &'a Ty) {
-        match t.kind {
+        ensure_sufficient_stack(|| match t.kind {
             TyKind::ImplTrait(..) => {
                 self.with_impl_trait(Some(t.span), |this| visit::walk_ty(this, t))
             }
@@ -254,7 +255,7 @@ impl<'a> AstValidator<'a> {
                 }
             }
             _ => visit::walk_ty(self, t),
-        }
+        })
     }
 
     fn visit_struct_field_def(&mut self, field: &'a FieldDef) {

--- a/compiler/rustc_codegen_llvm/src/debuginfo/create_scope_map.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/create_scope_map.rs
@@ -1,5 +1,5 @@
 use super::metadata::file_metadata;
-use super::utils::DIB;
+use super::utils::{self, DIB};
 use rustc_codegen_ssa::mir::debuginfo::{DebugScope, FunctionDebugContext};
 use rustc_codegen_ssa::traits::*;
 
@@ -97,15 +97,19 @@ fn make_mir_scope<'ll, 'tcx>(
             let callee_fn_abi = cx.fn_abi_of_instance(callee, ty::List::empty());
             cx.dbg_scope_fn(callee, callee_fn_abi, None)
         }
-        None => unsafe {
-            llvm::LLVMRustDIBuilderCreateLexicalBlock(
-                DIB(cx),
-                parent_scope.dbg_scope.unwrap(),
-                file_metadata,
-                loc.line,
-                loc.col,
-            )
-        },
+        None => {
+            let dbg_scope = unsafe {
+                llvm::LLVMRustDIBuilderCreateLexicalBlock(
+                    DIB(cx),
+                    parent_scope.dbg_scope.unwrap(),
+                    file_metadata,
+                    loc.line,
+                    loc.col,
+                )
+            };
+            utils::debug_context(cx).add_di_node(dbg_scope);
+            dbg_scope
+        }
     };
 
     let inlined_at = scope_data.inlined.map(|(_, callsite_span)| {

--- a/compiler/rustc_codegen_llvm/src/debuginfo/metadata/enums/cpp_like.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/metadata/enums/cpp_like.rs
@@ -27,7 +27,7 @@ use crate::{
             unknown_file_metadata, DINodeCreationResult, SmallVec, NO_GENERICS, NO_SCOPE_METADATA,
             UNKNOWN_LINE_NUMBER,
         },
-        utils::DIB,
+        utils::{debug_context, DIB},
     },
     llvm::{
         self,
@@ -441,7 +441,7 @@ fn build_union_fields_for_direct_tag_enum_or_generator<'ll, 'tcx>(
         // We use LLVMRustDIBuilderCreateMemberType() member type directly because
         // the build_field_di_node() function does not support specifying a source location,
         // which is something that we don't do anywhere else.
-        unsafe {
+        let member_type_di_node = unsafe {
             llvm::LLVMRustDIBuilderCreateMemberType(
                 DIB(cx),
                 enum_type_di_node,
@@ -458,7 +458,9 @@ fn build_union_fields_for_direct_tag_enum_or_generator<'ll, 'tcx>(
                 DIFlags::FlagZero,
                 variant_member_info.variant_struct_type_di_node,
             )
-        }
+        };
+        debug_context(cx).add_di_node(member_type_di_node);
+        member_type_di_node
     }));
 
     debug_assert_eq!(

--- a/compiler/rustc_codegen_llvm/src/debuginfo/metadata/type_map.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/metadata/type_map.rs
@@ -175,7 +175,7 @@ pub(super) fn stub<'ll, 'tcx>(
     containing_scope: Option<&'ll DIScope>,
     flags: DIFlags,
 ) -> StubInfo<'ll, 'tcx> {
-    let empty_array = create_DIArray(DIB(cx), &[]);
+    let empty_array = create_DIArray(cx, &[]);
     let unique_type_id_str = unique_type_id.generate_unique_id_string(cx.tcx);
 
     let metadata = match kind {
@@ -222,6 +222,7 @@ pub(super) fn stub<'ll, 'tcx>(
             )
         },
     };
+    debug_context(cx).add_di_node(metadata);
     StubInfo { metadata, unique_type_id }
 }
 
@@ -251,8 +252,8 @@ pub(super) fn build_type_with_children<'ll, 'tcx>(
 
     if !(members.is_empty() && generics.is_empty()) {
         unsafe {
-            let members_array = create_DIArray(DIB(cx), &members[..]);
-            let generics_array = create_DIArray(DIB(cx), &generics[..]);
+            let members_array = create_DIArray(cx, &members[..]);
+            let generics_array = create_DIArray(cx, &generics[..]);
             llvm::LLVMRustDICompositeTypeReplaceArrays(
                 DIB(cx),
                 stub_info.metadata,
@@ -260,6 +261,7 @@ pub(super) fn build_type_with_children<'ll, 'tcx>(
                 Some(generics_array),
             );
         }
+        debug_context(cx).add_di_node(stub_info.metadata);
     }
 
     DINodeCreationResult { di_node: stub_info.metadata, already_stored_in_typemap: true }

--- a/compiler/rustc_codegen_llvm/src/debuginfo/namespace.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/namespace.rs
@@ -42,6 +42,7 @@ pub fn item_namespace<'ll>(cx: &CodegenCx<'ll, '_>, def_id: DefId) -> &'ll DISco
             false, // ExportSymbols (only relevant for C++ anonymous namespaces)
         )
     };
+    debug_context(cx).add_di_node(scope);
 
     debug_context(cx).namespace_map.borrow_mut().insert(def_id, scope);
     scope

--- a/compiler/rustc_codegen_llvm/src/debuginfo/utils.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/utils.rs
@@ -26,10 +26,13 @@ pub fn is_node_local_to_unit(cx: &CodegenCx<'_, '_>, def_id: DefId) -> bool {
 
 #[allow(non_snake_case)]
 pub fn create_DIArray<'ll>(
-    builder: &DIBuilder<'ll>,
+    cx: &CodegenCx<'ll, '_>,
     arr: &[Option<&'ll DIDescriptor>],
 ) -> &'ll DIArray {
-    unsafe { llvm::LLVMRustDIBuilderGetOrCreateArray(builder, arr.as_ptr(), arr.len() as u32) }
+    let di_array =
+        unsafe { llvm::LLVMRustDIBuilderGetOrCreateArray(DIB(cx), arr.as_ptr(), arr.len() as u32) };
+    debug_context(cx).add_di_node(di_array);
+    di_array
 }
 
 #[inline]

--- a/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
@@ -1075,6 +1075,7 @@ extern "C" {
     pub fn LLVMGetUndef(Ty: &Type) -> &Value;
 
     // Operations on metadata
+    pub fn LLVMIsAMDNode(Val: &Value) -> Option<&Value>;
     pub fn LLVMMDStringInContext(C: &Context, Str: *const c_char, SLen: c_uint) -> &Value;
     pub fn LLVMMDNodeInContext<'a>(
         C: &'a Context,
@@ -1082,6 +1083,8 @@ extern "C" {
         Count: c_uint,
     ) -> &'a Value;
     pub fn LLVMAddNamedMetadataOperand<'a>(M: &'a Module, Name: *const c_char, Val: &'a Value);
+    pub fn LLVMGetMDNodeNumOperands(V: &Value) -> c_uint;
+    pub fn LLVMGetMDNodeOperands<'a>(V: &'a Value, Dest: *mut Option<&'a Value>);
 
     // Operations on scalar constants
     pub fn LLVMConstInt(IntTy: &Type, N: c_ulonglong, SignExtend: Bool) -> &Value;

--- a/compiler/rustc_codegen_ssa/src/debuginfo/type_names.rs
+++ b/compiler/rustc_codegen_ssa/src/debuginfo/type_names.rs
@@ -13,6 +13,7 @@
 
 use rustc_data_structures::fx::FxHashSet;
 use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
+use rustc_data_structures::stack::ensure_sufficient_stack;
 use rustc_hir::def_id::DefId;
 use rustc_hir::definitions::{DefPathData, DefPathDataName, DisambiguatedDefPathData};
 use rustc_hir::{AsyncGeneratorKind, GeneratorKind, Mutability};
@@ -57,7 +58,7 @@ fn push_debuginfo_type_name<'tcx>(
     // .natvis visualizers (and perhaps other existing native debuggers?)
     let cpp_like_debuginfo = cpp_like_debuginfo(tcx);
 
-    match *t.kind() {
+    ensure_sufficient_stack(|| match *t.kind() {
         ty::Bool => output.push_str("bool"),
         ty::Char => output.push_str("char"),
         ty::Str => output.push_str("str"),
@@ -424,7 +425,7 @@ fn push_debuginfo_type_name<'tcx>(
                 t
             );
         }
-    }
+    });
 
     /// MSVC names enums differently than other platforms so that the debugging visualization
     // format (natvis) is able to understand enums and render the active variant correctly in the

--- a/compiler/rustc_const_eval/src/transform/promote_consts.rs
+++ b/compiler/rustc_const_eval/src/transform/promote_consts.rs
@@ -12,6 +12,7 @@
 //! initialization and can otherwise silence errors, if
 //! move analysis runs after promotion on broken MIR.
 
+use rustc_data_structures::stack::ensure_sufficient_stack;
 use rustc_hir as hir;
 use rustc_middle::mir::traversal::ReversePostorder;
 use rustc_middle::mir::visit::{MutVisitor, MutatingUseContext, PlaceContext, Visitor};
@@ -926,7 +927,7 @@ impl<'a, 'tcx> MutVisitor<'tcx> for Promoter<'a, 'tcx> {
 
     fn visit_local(&mut self, local: &mut Local, _: PlaceContext, _: Location) {
         if self.is_temp_kind(*local) {
-            *local = self.promote_temp(*local);
+            *local = ensure_sufficient_stack(|| self.promote_temp(*local));
         }
     }
 }

--- a/compiler/rustc_data_structures/src/stack.rs
+++ b/compiler/rustc_data_structures/src/stack.rs
@@ -16,3 +16,8 @@ const STACK_PER_RECURSION: usize = 1 * 1024 * 1024; // 1MB
 pub fn ensure_sufficient_stack<R>(f: impl FnOnce() -> R) -> R {
     stacker::maybe_grow(RED_ZONE, STACK_PER_RECURSION, f)
 }
+
+pub fn ensure_recursive_stack<R>(stack_size: usize, f: impl FnOnce() -> R) -> R {
+    let full_size = stack_size + RED_ZONE;
+    stacker::maybe_grow(full_size, full_size, f)
+}

--- a/compiler/rustc_hir/src/stable_hash_impls.rs
+++ b/compiler/rustc_hir/src/stable_hash_impls.rs
@@ -1,10 +1,11 @@
-use rustc_data_structures::stable_hasher::{HashStable, StableHasher, ToStableHashKey};
-
 use crate::hir::{
     AttributeMap, BodyId, Crate, Expr, ForeignItemId, ImplItemId, ItemId, OwnerNodes, TraitItemId,
     Ty,
 };
 use crate::hir_id::{HirId, ItemLocalId};
+
+use rustc_data_structures::stable_hasher::{HashStable, StableHasher, ToStableHashKey};
+use rustc_data_structures::stack::ensure_sufficient_stack;
 use rustc_span::def_id::DefPathHash;
 
 /// Requirements for a `StableHashingContext` to be used in this crate.
@@ -98,7 +99,7 @@ impl<HirCtx: crate::HashStableContext> HashStable<HirCtx> for BodyId {
 
 impl<HirCtx: crate::HashStableContext> HashStable<HirCtx> for Expr<'_> {
     fn hash_stable(&self, hcx: &mut HirCtx, hasher: &mut StableHasher) {
-        hcx.hash_hir_expr(self, hasher)
+        ensure_sufficient_stack(|| hcx.hash_hir_expr(self, hasher))
     }
 }
 

--- a/compiler/rustc_hir_pretty/Cargo.toml
+++ b/compiler/rustc_hir_pretty/Cargo.toml
@@ -8,6 +8,7 @@ doctest = false
 
 [dependencies]
 rustc_ast_pretty = { path = "../rustc_ast_pretty" }
+rustc_data_structures = { path = "../rustc_data_structures" }
 rustc_hir = { path = "../rustc_hir" }
 rustc_target = { path = "../rustc_target" }
 rustc_span = { path = "../rustc_span" }

--- a/compiler/rustc_hir_pretty/src/lib.rs
+++ b/compiler/rustc_hir_pretty/src/lib.rs
@@ -5,6 +5,7 @@ use rustc_ast::util::parser::{self, AssocOp, Fixity};
 use rustc_ast_pretty::pp::Breaks::{Consistent, Inconsistent};
 use rustc_ast_pretty::pp::{self, Breaks};
 use rustc_ast_pretty::pprust::{Comments, PrintState};
+use rustc_data_structures::stack::ensure_sufficient_stack;
 use rustc_hir as hir;
 use rustc_hir::{GenericArg, GenericParam, GenericParamKind, Node, Term};
 use rustc_hir::{GenericBound, PatKind, RangeEnd, TraitBoundModifier};
@@ -1359,7 +1360,7 @@ impl<'a> State<'a> {
         self.print_outer_attributes(self.attrs(expr.hir_id));
         self.ibox(INDENT_UNIT);
         self.ann.pre(self, AnnNode::Expr(expr));
-        match expr.kind {
+        ensure_sufficient_stack(|| match expr.kind {
             hir::ExprKind::Box(ref expr) => {
                 self.word_space("box");
                 self.print_expr_maybe_paren(expr, parser::PREC_PREFIX);
@@ -1545,7 +1546,7 @@ impl<'a> State<'a> {
                 self.word("/*ERROR*/");
                 self.pclose();
             }
-        }
+        });
         self.ann.post(self, AnnNode::Expr(expr));
         self.end()
     }

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -33,6 +33,7 @@ use rustc_attr as attr;
 use rustc_data_structures::fx::{FxHashMap, FxHashSet, FxIndexMap};
 use rustc_data_structures::intern::{Interned, WithStableHash};
 use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
+use rustc_data_structures::stack::ensure_sufficient_stack;
 use rustc_data_structures::tagged_ptr::CopyTaggedPtr;
 use rustc_hir as hir;
 use rustc_hir::def::{CtorKind, CtorOf, DefKind, Res};
@@ -466,7 +467,7 @@ impl<'a, 'tcx> HashStable<StableHashingContext<'a>> for TyS<'tcx> {
             outer_exclusive_binder: _,
         } = self;
 
-        kind.hash_stable(hcx, hasher)
+        ensure_sufficient_stack(|| kind.hash_stable(hcx, hasher))
     }
 }
 

--- a/compiler/rustc_mir_build/src/thir/cx/expr.rs
+++ b/compiler/rustc_mir_build/src/thir/cx/expr.rs
@@ -28,7 +28,7 @@ impl<'tcx> Cx<'tcx> {
     }
 
     crate fn mirror_exprs(&mut self, exprs: &'tcx [hir::Expr<'tcx>]) -> Box<[ExprId]> {
-        exprs.iter().map(|expr| self.mirror_expr_inner(expr)).collect()
+        ensure_sufficient_stack(|| exprs.iter().map(|expr| self.mirror_expr_inner(expr)).collect())
     }
 
     pub(super) fn mirror_expr_inner(&mut self, hir_expr: &'tcx hir::Expr<'tcx>) -> ExprId {

--- a/compiler/rustc_passes/src/liveness.rs
+++ b/compiler/rustc_passes/src/liveness.rs
@@ -86,6 +86,7 @@ use self::VarKind::*;
 
 use rustc_ast::InlineAsmOptions;
 use rustc_data_structures::fx::FxIndexMap;
+use rustc_data_structures::stack::ensure_sufficient_stack;
 use rustc_errors::Applicability;
 use rustc_hir as hir;
 use rustc_hir::def::*;
@@ -825,7 +826,7 @@ impl<'a, 'tcx> Liveness<'a, 'tcx> {
     fn propagate_through_expr(&mut self, expr: &Expr<'_>, succ: LiveNode) -> LiveNode {
         debug!("propagate_through_expr: {:?}", expr);
 
-        match expr.kind {
+        ensure_sufficient_stack(|| match expr.kind {
             // Interesting cases with control flow or which gen/kill
             hir::ExprKind::Path(hir::QPath::Resolved(_, ref path)) => {
                 self.access_path(expr.hir_id, path, succ, ACC_READ | ACC_USE)
@@ -1099,7 +1100,7 @@ impl<'a, 'tcx> Liveness<'a, 'tcx> {
             // Note that labels have been resolved, so we don't need to look
             // at the label ident
             hir::ExprKind::Block(ref blk, _) => self.propagate_through_block(&blk, succ),
-        }
+        })
     }
 
     fn propagate_through_place_components(&mut self, expr: &Expr<'_>, succ: LiveNode) -> LiveNode {

--- a/compiler/rustc_resolve/src/late/lifetimes.rs
+++ b/compiler/rustc_resolve/src/late/lifetimes.rs
@@ -9,6 +9,7 @@
 use crate::late::diagnostics::{ForLifetimeSpanType, MissingLifetimeSpot};
 use rustc_ast::walk_list;
 use rustc_data_structures::fx::{FxHashMap, FxHashSet, FxIndexMap};
+use rustc_data_structures::stack::ensure_sufficient_stack;
 use rustc_errors::{struct_span_err, Applicability, Diagnostic};
 use rustc_hir as hir;
 use rustc_hir::def::{DefKind, Res};
@@ -867,7 +868,7 @@ impl<'a, 'tcx> Visitor<'tcx> for LifetimeContext<'a, 'tcx> {
 
     #[tracing::instrument(level = "debug", skip(self))]
     fn visit_ty(&mut self, ty: &'tcx hir::Ty<'tcx>) {
-        match ty.kind {
+        ensure_sufficient_stack(|| match ty.kind {
             hir::TyKind::BareFn(ref c) => {
                 let next_early_index = self.next_early_index();
                 let lifetime_span: Option<Span> =
@@ -1118,7 +1119,7 @@ impl<'a, 'tcx> Visitor<'tcx> for LifetimeContext<'a, 'tcx> {
                 }
             }
             _ => intravisit::walk_ty(self, ty),
-        }
+        })
     }
 
     fn visit_trait_item(&mut self, trait_item: &'tcx hir::TraitItem<'tcx>) {

--- a/compiler/rustc_typeck/src/astconv/mod.rs
+++ b/compiler/rustc_typeck/src/astconv/mod.rs
@@ -15,6 +15,7 @@ use crate::middle::resolve_lifetime as rl;
 use crate::require_c_abi_if_c_variadic;
 use rustc_ast::TraitObjectSyntax;
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};
+use rustc_data_structures::stack::ensure_sufficient_stack;
 use rustc_errors::{
     struct_span_err, Applicability, DiagnosticBuilder, ErrorGuaranteed, FatalError,
 };
@@ -2368,7 +2369,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
     fn ast_ty_to_ty_inner(&self, ast_ty: &hir::Ty<'_>, borrowed: bool, in_path: bool) -> Ty<'tcx> {
         let tcx = self.tcx();
 
-        let result_ty = match ast_ty.kind {
+        let result_ty = ensure_sufficient_stack(|| match ast_ty.kind {
             hir::TyKind::Slice(ref ty) => tcx.mk_slice(self.ast_ty_to_ty(ty)),
             hir::TyKind::Ptr(ref mt) => {
                 tcx.mk_ptr(ty::TypeAndMut { ty: self.ast_ty_to_ty(mt.ty), mutbl: mt.mutbl })
@@ -2479,7 +2480,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                 self.ty_infer(None, ast_ty.span)
             }
             hir::TyKind::Err => tcx.ty_error(),
-        };
+        });
 
         debug!(?result_ty);
 


### PR DESCRIPTION
This should close #75577; I've added `ensure_sufficient_stack` to all of the recursive paths used by the original dumb program, as well as more I've found while testing trivial variations. (Some of the variations are listed in [my comment](https://github.com/rust-lang/rust/issues/75577#issuecomment-888731966) there.) However, there are a few problems left with these fixes.

1. While I tried to avoid modifying indentation of large blocks, this was not possible for all functions. In its current state, upstream changes are causing frequent merge conflicts with the modified functions. There might be no solution to this. It would be nice to have something like an `#[ensure_sufficient_stack]` attribute on functions that wraps their entire body, but rustc currently only seems to be using proc macros for deriving traits.
2. The final commit is extremely unpolished; I mainly wanted to have it work at all. The `llvm::Verifier` class (defined in `src/llvm-project/llvm/lib/IR/Verifier.cpp`) finds all references to metadata nodes (mostly debuginfo) in the LLVM module, then traverses them in a recursive function. Fixing stack overflows here is necessary for all of the variations involving deeply nested types. Since the function is written in C++, I can't simply insert `ensure_sufficient_stack`; the only option is to allocate the entire additional stack space ahead of time. However, to do that, the compiler must compute the depth of the metadata node graph (which can contain loops), and then pass that down to the backend in the codegen thread for the module. There are several ways to achieve the first:
    - Each time a possibly recursive metadata node is created, calculate its depth from its operands, and store that in a `HashMap` somewhere. This is what my commit does; I added a call to every invocation of a `DIBuilder` method.
    - Instead of passing around raw `llvm::DIWhatever` references, always pass `(llvm::DIWhatever, usize)` pairs with the depth of the node and its operands.
    - Use LLVM's APIs to traverse the entire `llvm::Module` after the fact to compute the depth. This would effectively involve replicating all of `Verifier.cpp`.
    - Determine exactly what kinds of metadata the compiler generates, including which parts are recursive. Use known information about the crate's types and other items to derive the depth of the metadata generated from it.
    - Use some multiple of the `recursion_limit`. This is the simplest possible solution, but it creates lots of memory overhead when the limit is not reached and would likely cause issues in currently existing crates.

    After that, there's the issue of collecting the data and passing it to the backend. In my commit, I add a `RefCell<FxHashMap<&'ll llvm::Metadata, usize>>` to the `CrateDebugContext` (as well as a method to add to it), and a static `Mutex<FxHashMap<usize, usize>>` to associate `llvm::Module` pointers to their maximum depths. I'm not familiar with the compiler, and I simply have no idea how to idiomatically pass anything but the `llvm::Module` itself to the backend. Overall, I could really use some advice on this part of the fix.
3. There are undoubtedly many recursive paths which my limited testing has not revealed. Eliminating all stack overflows would require inspecting the entire call graph of the compiler, including its backends. I recall seeing a couple tools offering call graph generation for regular crates, but I doubt they'd work well with rustc's custom build system.