### PR TITLE
Pretty printer algorithm revamp step 2

### DIFF
--- a/compiler/rustc_ast_pretty/src/pp.rs
+++ b/compiler/rustc_ast_pretty/src/pp.rs
@@ -336,9 +336,9 @@ impl Printer {
 
     fn check_stream(&mut self) {
         if self.right_total - self.left_total > self.space {
-            if Some(&self.left) == self.scan_stack.back() {
-                let scanned = self.scan_stack.pop_back().unwrap();
-                self.buf[scanned].size = SIZE_INFINITY;
+            if self.scan_stack.back() == Some(&self.left) {
+                self.scan_stack.pop_back().unwrap();
+                self.buf[self.left].size = SIZE_INFINITY;
             }
             self.advance_left();
             if self.left != self.right {

--- a/compiler/rustc_ast_pretty/src/pp.rs
+++ b/compiler/rustc_ast_pretty/src/pp.rs
@@ -347,10 +347,6 @@ impl Printer {
         }
     }
 
-    fn scan_pop(&mut self) -> usize {
-        self.scan_stack.pop_front().unwrap()
-    }
-
     fn scan_top(&self) -> usize {
         *self.scan_stack.front().unwrap()
     }
@@ -396,19 +392,19 @@ impl Printer {
             match self.buf[x].token {
                 Token::Begin(_) => {
                     if k > 0 {
-                        self.scan_pop();
+                        self.scan_stack.pop_front().unwrap();
                         self.buf[x].size += self.right_total;
                         self.check_stack(k - 1);
                     }
                 }
                 Token::End => {
                     // paper says + not =, but that makes no sense.
-                    self.scan_pop();
+                    self.scan_stack.pop_front().unwrap();
                     self.buf[x].size = 1;
                     self.check_stack(k + 1);
                 }
                 _ => {
-                    self.scan_pop();
+                    self.scan_stack.pop_front().unwrap();
                     self.buf[x].size += self.right_total;
                     if k > 0 {
                         self.check_stack(k);

--- a/compiler/rustc_ast_pretty/src/pp.rs
+++ b/compiler/rustc_ast_pretty/src/pp.rs
@@ -288,12 +288,11 @@ impl Printer {
             self.left_total = 1;
             self.right_total = 1;
             self.right = self.left;
-            self.buf.truncate(1);
+            self.buf.clear();
         } else {
             self.right += 1;
-            self.buf.advance_right();
         }
-        self.buf[self.right] = BufEntry { token: Token::Begin(b), size: -self.right_total };
+        self.buf.push(BufEntry { token: Token::Begin(b), size: -self.right_total });
         self.scan_stack.push_front(self.right);
     }
 
@@ -302,8 +301,7 @@ impl Printer {
             self.print_end();
         } else {
             self.right += 1;
-            self.buf.advance_right();
-            self.buf[self.right] = BufEntry { token: Token::End, size: -1 };
+            self.buf.push(BufEntry { token: Token::End, size: -1 });
             self.scan_stack.push_front(self.right);
         }
     }
@@ -329,9 +327,8 @@ impl Printer {
             self.print_string(s);
         } else {
             self.right += 1;
-            self.buf.advance_right();
             let len = s.len() as isize;
-            self.buf[self.right] = BufEntry { token: Token::String(s), size: len };
+            self.buf.push(BufEntry { token: Token::String(s), size: len });
             self.right_total += len;
             self.check_stream();
         }

--- a/compiler/rustc_ast_pretty/src/pp.rs
+++ b/compiler/rustc_ast_pretty/src/pp.rs
@@ -290,7 +290,8 @@ impl Printer {
             self.right = self.left;
             self.buf.truncate(1);
         } else {
-            self.advance_right();
+            self.right += 1;
+            self.buf.advance_right();
         }
         self.scan_push(BufEntry { token: Token::Begin(b), size: -self.right_total });
     }
@@ -299,7 +300,8 @@ impl Printer {
         if self.scan_stack.is_empty() {
             self.print_end();
         } else {
-            self.advance_right();
+            self.right += 1;
+            self.buf.advance_right();
             self.scan_push(BufEntry { token: Token::End, size: -1 });
         }
     }
@@ -311,7 +313,8 @@ impl Printer {
             self.right = self.left;
             self.buf.truncate(1);
         } else {
-            self.advance_right();
+            self.right += 1;
+            self.buf.advance_right();
         }
         self.check_stack(0);
         self.scan_push(BufEntry { token: Token::Break(b), size: -self.right_total });
@@ -322,7 +325,8 @@ impl Printer {
         if self.scan_stack.is_empty() {
             self.print_string(s);
         } else {
-            self.advance_right();
+            self.right += 1;
+            self.buf.advance_right();
             let len = s.len() as isize;
             self.buf[self.right] = BufEntry { token: Token::String(s), size: len };
             self.right_total += len;
@@ -358,11 +362,6 @@ impl Printer {
 
     fn scan_pop_bottom(&mut self) -> usize {
         self.scan_stack.pop_back().unwrap()
-    }
-
-    fn advance_right(&mut self) {
-        self.right += 1;
-        self.buf.advance_right();
     }
 
     fn advance_left(&mut self) {

--- a/compiler/rustc_ast_pretty/src/pp.rs
+++ b/compiler/rustc_ast_pretty/src/pp.rs
@@ -311,13 +311,12 @@ impl Printer {
             self.left_total = 1;
             self.right_total = 1;
             self.right = self.left;
-            self.buf.truncate(1);
+            self.buf.clear();
         } else {
-            self.right += 1;
-            self.buf.advance_right();
             self.check_stack(0);
+            self.right += 1;
         }
-        self.buf[self.right] = BufEntry { token: Token::Break(b), size: -self.right_total };
+        self.buf.push(BufEntry { token: Token::Break(b), size: -self.right_total });
         self.scan_stack.push_front(self.right);
         self.right_total += b.blank_space;
     }

--- a/compiler/rustc_ast_pretty/src/pp.rs
+++ b/compiler/rustc_ast_pretty/src/pp.rs
@@ -335,14 +335,14 @@ impl Printer {
     }
 
     fn check_stream(&mut self) {
-        if self.right_total - self.left_total > self.space {
+        while self.right_total - self.left_total > self.space {
             if self.scan_stack.back() == Some(&self.left) {
                 self.scan_stack.pop_back().unwrap();
                 self.buf[self.left].size = SIZE_INFINITY;
             }
             self.advance_left();
-            if self.left != self.right {
-                self.check_stream();
+            if self.left == self.right {
+                break;
             }
         }
     }

--- a/compiler/rustc_ast_pretty/src/pp.rs
+++ b/compiler/rustc_ast_pretty/src/pp.rs
@@ -380,24 +380,25 @@ impl Printer {
 
     fn check_stack(&mut self, mut k: usize) {
         while let Some(&x) = self.scan_stack.front() {
-            match self.buf[x].token {
+            let mut entry = &mut self.buf[x];
+            match entry.token {
                 Token::Begin(_) => {
                     if k == 0 {
                         break;
                     }
                     self.scan_stack.pop_front().unwrap();
-                    self.buf[x].size += self.right_total;
+                    entry.size += self.right_total;
                     k -= 1;
                 }
                 Token::End => {
                     // paper says + not =, but that makes no sense.
                     self.scan_stack.pop_front().unwrap();
-                    self.buf[x].size = 1;
+                    entry.size = 1;
                     k += 1;
                 }
                 _ => {
                     self.scan_stack.pop_front().unwrap();
-                    self.buf[x].size += self.right_total;
+                    entry.size += self.right_total;
                     if k == 0 {
                         break;
                     }

--- a/compiler/rustc_ast_pretty/src/pp.rs
+++ b/compiler/rustc_ast_pretty/src/pp.rs
@@ -315,8 +315,8 @@ impl Printer {
         } else {
             self.right += 1;
             self.buf.advance_right();
+            self.check_stack(0);
         }
-        self.check_stack(0);
         self.buf[self.right] = BufEntry { token: Token::Break(b), size: -self.right_total };
         self.scan_stack.push_front(self.right);
         self.right_total += b.blank_space;

--- a/compiler/rustc_ast_pretty/src/pp.rs
+++ b/compiler/rustc_ast_pretty/src/pp.rs
@@ -378,27 +378,28 @@ impl Printer {
         }
     }
 
-    fn check_stack(&mut self, k: usize) {
-        if let Some(&x) = self.scan_stack.front() {
+    fn check_stack(&mut self, mut k: usize) {
+        while let Some(&x) = self.scan_stack.front() {
             match self.buf[x].token {
                 Token::Begin(_) => {
-                    if k > 0 {
-                        self.scan_stack.pop_front().unwrap();
-                        self.buf[x].size += self.right_total;
-                        self.check_stack(k - 1);
+                    if k == 0 {
+                        break;
                     }
+                    self.scan_stack.pop_front().unwrap();
+                    self.buf[x].size += self.right_total;
+                    k -= 1;
                 }
                 Token::End => {
                     // paper says + not =, but that makes no sense.
                     self.scan_stack.pop_front().unwrap();
                     self.buf[x].size = 1;
-                    self.check_stack(k + 1);
+                    k += 1;
                 }
                 _ => {
                     self.scan_stack.pop_front().unwrap();
                     self.buf[x].size += self.right_total;
-                    if k > 0 {
-                        self.check_stack(k);
+                    if k == 0 {
+                        break;
                     }
                 }
             }

--- a/compiler/rustc_ast_pretty/src/pp.rs
+++ b/compiler/rustc_ast_pretty/src/pp.rs
@@ -379,8 +379,7 @@ impl Printer {
     }
 
     fn check_stack(&mut self, k: usize) {
-        if !self.scan_stack.is_empty() {
-            let x = *self.scan_stack.front().unwrap();
+        if let Some(&x) = self.scan_stack.front() {
             match self.buf[x].token {
                 Token::Begin(_) => {
                     if k > 0 {

--- a/compiler/rustc_ast_pretty/src/pp.rs
+++ b/compiler/rustc_ast_pretty/src/pp.rs
@@ -337,7 +337,7 @@ impl Printer {
     fn check_stream(&mut self) {
         if self.right_total - self.left_total > self.space {
             if Some(&self.left) == self.scan_stack.back() {
-                let scanned = self.scan_pop_bottom();
+                let scanned = self.scan_stack.pop_back().unwrap();
                 self.buf[scanned].size = SIZE_INFINITY;
             }
             self.advance_left();
@@ -345,10 +345,6 @@ impl Printer {
                 self.check_stream();
             }
         }
-    }
-
-    fn scan_pop_bottom(&mut self) -> usize {
-        self.scan_stack.pop_back().unwrap()
     }
 
     fn advance_left(&mut self) {

--- a/compiler/rustc_ast_pretty/src/pp.rs
+++ b/compiler/rustc_ast_pretty/src/pp.rs
@@ -347,10 +347,6 @@ impl Printer {
         }
     }
 
-    fn scan_top(&self) -> usize {
-        *self.scan_stack.front().unwrap()
-    }
-
     fn scan_pop_bottom(&mut self) -> usize {
         self.scan_stack.pop_back().unwrap()
     }
@@ -388,7 +384,7 @@ impl Printer {
 
     fn check_stack(&mut self, k: usize) {
         if !self.scan_stack.is_empty() {
-            let x = self.scan_top();
+            let x = *self.scan_stack.front().unwrap();
             match self.buf[x].token {
                 Token::Begin(_) => {
                     if k > 0 {

--- a/compiler/rustc_ast_pretty/src/pp.rs
+++ b/compiler/rustc_ast_pretty/src/pp.rs
@@ -293,7 +293,8 @@ impl Printer {
             self.right += 1;
             self.buf.advance_right();
         }
-        self.scan_push(BufEntry { token: Token::Begin(b), size: -self.right_total });
+        self.buf[self.right] = BufEntry { token: Token::Begin(b), size: -self.right_total };
+        self.scan_stack.push_front(self.right);
     }
 
     fn scan_end(&mut self) {
@@ -302,7 +303,8 @@ impl Printer {
         } else {
             self.right += 1;
             self.buf.advance_right();
-            self.scan_push(BufEntry { token: Token::End, size: -1 });
+            self.buf[self.right] = BufEntry { token: Token::End, size: -1 };
+            self.scan_stack.push_front(self.right);
         }
     }
 
@@ -317,7 +319,8 @@ impl Printer {
             self.buf.advance_right();
         }
         self.check_stack(0);
-        self.scan_push(BufEntry { token: Token::Break(b), size: -self.right_total });
+        self.buf[self.right] = BufEntry { token: Token::Break(b), size: -self.right_total };
+        self.scan_stack.push_front(self.right);
         self.right_total += b.blank_space;
     }
 
@@ -345,11 +348,6 @@ impl Printer {
                 self.check_stream();
             }
         }
-    }
-
-    fn scan_push(&mut self, entry: BufEntry) {
-        self.buf[self.right] = entry;
-        self.scan_stack.push_front(self.right);
     }
 
     fn scan_pop(&mut self) -> usize {

--- a/compiler/rustc_ast_pretty/src/pp/ring.rs
+++ b/compiler/rustc_ast_pretty/src/pp/ring.rs
@@ -22,8 +22,14 @@ impl<T> RingBuffer<T> {
         RingBuffer { data: VecDeque::new(), offset: 0 }
     }
 
-    pub fn push(&mut self, value: T) {
+    pub fn is_empty(&self) -> bool {
+        self.data.is_empty()
+    }
+
+    pub fn push(&mut self, value: T) -> usize {
+        let index = self.offset + self.data.len();
         self.data.push_back(value);
+        index
     }
 
     pub fn advance_left(&mut self) {
@@ -33,6 +39,18 @@ impl<T> RingBuffer<T> {
 
     pub fn clear(&mut self) {
         self.data.clear();
+    }
+
+    pub fn index_of_first(&self) -> usize {
+        self.offset
+    }
+
+    pub fn first(&self) -> Option<&T> {
+        self.data.front()
+    }
+
+    pub fn first_mut(&mut self) -> Option<&mut T> {
+        self.data.front_mut()
     }
 
     pub fn last(&self) -> Option<&T> {

--- a/compiler/rustc_ast_pretty/src/pp/ring.rs
+++ b/compiler/rustc_ast_pretty/src/pp/ring.rs
@@ -41,10 +41,6 @@ impl<T> RingBuffer<T> {
     pub fn clear(&mut self) {
         self.data.clear();
     }
-
-    pub fn truncate(&mut self, len: usize) {
-        self.data.truncate(len);
-    }
 }
 
 impl<T> Index<usize> for RingBuffer<T> {

--- a/compiler/rustc_ast_pretty/src/pp/ring.rs
+++ b/compiler/rustc_ast_pretty/src/pp/ring.rs
@@ -22,6 +22,10 @@ impl<T> RingBuffer<T> {
         RingBuffer { data: VecDeque::new(), offset: 0 }
     }
 
+    pub fn push(&mut self, value: T) {
+        self.data.push_back(value);
+    }
+
     pub fn advance_right(&mut self)
     where
         T: Default,
@@ -32,6 +36,10 @@ impl<T> RingBuffer<T> {
     pub fn advance_left(&mut self) {
         self.data.pop_front().unwrap();
         self.offset += 1;
+    }
+
+    pub fn clear(&mut self) {
+        self.data.clear();
     }
 
     pub fn truncate(&mut self, len: usize) {

--- a/compiler/rustc_ast_pretty/src/pp/ring.rs
+++ b/compiler/rustc_ast_pretty/src/pp/ring.rs
@@ -26,13 +26,6 @@ impl<T> RingBuffer<T> {
         self.data.push_back(value);
     }
 
-    pub fn advance_right(&mut self)
-    where
-        T: Default,
-    {
-        self.data.push_back(T::default());
-    }
-
     pub fn advance_left(&mut self) {
         self.data.pop_front().unwrap();
         self.offset += 1;
@@ -40,6 +33,14 @@ impl<T> RingBuffer<T> {
 
     pub fn clear(&mut self) {
         self.data.clear();
+    }
+
+    pub fn last(&self) -> Option<&T> {
+        self.data.back()
+    }
+
+    pub fn last_mut(&mut self) -> Option<&mut T> {
+        self.data.back_mut()
     }
 }
 

--- a/compiler/rustc_ast_pretty/src/pprust/state.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state.rs
@@ -329,9 +329,9 @@ pub trait PrintState<'a>: std::ops::Deref<Target = pp::Printer> + std::ops::Dere
             CommentStyle::BlankLine => {
                 // We need to do at least one, possibly two hardbreaks.
                 let twice = match self.last_token() {
-                    pp::Token::String(s) => ";" == s,
-                    pp::Token::Begin(_) => true,
-                    pp::Token::End => true,
+                    Some(pp::Token::String(s)) => ";" == s,
+                    Some(pp::Token::Begin(_)) => true,
+                    Some(pp::Token::End) => true,
                     _ => false,
                 };
                 if twice {
@@ -687,11 +687,15 @@ pub trait PrintState<'a>: std::ops::Deref<Target = pp::Printer> + std::ops::Dere
     fn break_offset_if_not_bol(&mut self, n: usize, off: isize) {
         if !self.is_beginning_of_line() {
             self.break_offset(n, off)
-        } else if off != 0 && self.last_token().is_hardbreak_tok() {
-            // We do something pretty sketchy here: tuck the nonzero
-            // offset-adjustment we were going to deposit along with the
-            // break into the previous hardbreak.
-            self.replace_last_token(pp::Printer::hardbreak_tok_offset(off));
+        } else if off != 0 {
+            if let Some(last_token) = self.last_token_still_buffered() {
+                if last_token.is_hardbreak_tok() {
+                    // We do something pretty sketchy here: tuck the nonzero
+                    // offset-adjustment we were going to deposit along with the
+                    // break into the previous hardbreak.
+                    self.replace_last_token_still_buffered(pp::Printer::hardbreak_tok_offset(off));
+                }
+            }
         }
     }
 


### PR DESCRIPTION
This PR follows #92923 as a second chunk of modernizations backported from https://github.com/dtolnay/prettyplease into rustc_ast_pretty.

I've broken this up into atomic commits that hopefully are sensible in isolation. At every commit, the pretty printer is compilable and has runtime behavior that is identical to before and after the PR. None of the refactoring so far changes behavior.

The general theme of this chunk of commits is: the logic in the old pretty printer is doing some very basic things (pushing and popping tokens on a ring buffer) but expressed in a too-low-level way that I found makes it quite complicated/subtle to reason about. There are a number of obvious invariants that are "almost true" -- things like `self.left == self.buf.offset` and `self.right == self.buf.offset + self.buf.data.len()` and `self.right_total == self.left_total + self.buf.data.sum()`. The reason these things are "almost true" is the implementation tends to put updating one side of the invariant unreasonably far apart from updating the other side, leaving the invariant broken while unrelated stuff happens in between. The following code from master is an example of this:

https://github.com/rust-lang/rust/blob/e5e2b0be26ea177527b60d355bd8f56cd473bd00/compiler/rustc_ast_pretty/src/pp.rs#L314-L317

In this code the `advance_right` is reserving an entry into which to write a next token on the right side of the ring buffer, the `check_stack` is doing something totally unrelated to the right boundary of the ring buffer, and the `scan_push` is actually writing the token we previously reserved space for. Much of what this PR is doing is rearranging code to shrink the amount of stuff in between when an invariant is broken to when it is restored, until the whole thing can be factored out into one indivisible method call on the RingBuffer type.

The end state of the PR is that we can entirely eliminate `self.left` (because it's now just equal to `self.buf.offset` always) and `self.right` (because it's equal to `self.buf.offset + self.buf.data.len()` always) and the whole `Token::Eof` state which used to be the value of tokens that have been reserved space for but not yet written.

I found without these changes the pretty printer implementation to be hard to reason about and I wasn't able to confidently introduce improvements like trailing commas in `prettyplease` until after this refactor. The logic here is 43 years old at this point (Graydon translated it as directly as possible from the 1979 pretty printing paper) and while there are advantages to following the paper as closely as possible, in `prettyplease` I decided if we're going to adapt the algorithm to work better for Rust syntax, it was worthwhile making it easier to follow than the original.