### PR TITLE
Fix spacing for `·` between stability and source

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1176,7 +1176,6 @@ a.test-arrow:hover{
 .out-of-band > span.since {
 	position: initial;
 	font-size: 1.25rem;
-	margin-right: 5px;
 }
 
 h3.variant {

--- a/src/librustdoc/html/templates/print_item.html
+++ b/src/librustdoc/html/templates/print_item.html
@@ -16,7 +16,7 @@
     </h1> {#- -#}
     <span class="out-of-band"> {#- -#}
         {% if !stability_since_raw.is_empty() %}
-        {{- stability_since_raw|safe -}} · {# -#}
+        {{- stability_since_raw|safe }} · {# -#}
         {% endif %}
         {%- match src_href -%}
             {%- when Some with (href) -%}

--- a/src/test/rustdoc/source-version-separator.rs
+++ b/src/test/rustdoc/source-version-separator.rs
@@ -1,10 +1,9 @@
 #![stable(feature = "bar", since = "1.0")]
 #![crate_name = "foo"]
-
 #![feature(staged_api)]
 
 // @has foo/trait.Bar.html
-// @has - '//div[@class="main-heading"]/*[@class="out-of-band"]' '1.0· source · '
+// @has - '//div[@class="main-heading"]/*[@class="out-of-band"]' '1.0 · source · '
 #[stable(feature = "bar", since = "1.0")]
 pub trait Bar {
     // @has - '//div[@id="tymethod.foo"]/*[@class="rightside"]' '3.0 · source'
@@ -15,7 +14,7 @@ pub trait Bar {
 // @has - '//div[@id="implementors-list"]//*[@class="rightside"]' '4.0 · source'
 
 // @has foo/struct.Foo.html
-// @has - '//div[@class="main-heading"]/*[@class="out-of-band"]' '1.0· source · '
+// @has - '//div[@class="main-heading"]/*[@class="out-of-band"]' '1.0 · source · '
 #[stable(feature = "baz", since = "1.0")]
 pub struct Foo;
 


### PR DESCRIPTION
This puts in an actual space (by adjusting the space-eating operators in our templates), updates the test, and remove the now-unnecessary CSS rule.

r? @GuillaumeGomez