### PR TITLE
debuginfo: Don't emit DW_AT_address_class attribute for pointer type debuginfo.

### DIFF
--- a/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
@@ -2021,7 +2021,7 @@ extern "C" {
         PointeeTy: &'a DIType,
         SizeInBits: u64,
         AlignInBits: u32,
-        AddressSpace: c_uint,
+        AddressSpace: Option<&c_uint>,
         Name: *const c_char,
         NameLen: size_t,
     ) -> &'a DIDerivedType;

--- a/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
@@ -763,11 +763,14 @@ extern "C" LLVMMetadataRef LLVMRustDIBuilderCreateTypedef(
 
 extern "C" LLVMMetadataRef LLVMRustDIBuilderCreatePointerType(
     LLVMRustDIBuilderRef Builder, LLVMMetadataRef PointeeTy,
-    uint64_t SizeInBits, uint32_t AlignInBits, unsigned AddressSpace,
+    uint64_t SizeInBits, uint32_t AlignInBits, const unsigned* AddressSpace,
     const char *Name, size_t NameLen) {
+
+  auto OptAddressSpace = AddressSpace ? Optional<unsigned>(*AddressSpace) : None;
+
   return wrap(Builder->createPointerType(unwrapDI<DIType>(PointeeTy),
                                          SizeInBits, AlignInBits,
-                                         AddressSpace,
+                                         OptAddressSpace,
                                          StringRef(Name, NameLen)));
 }
 

--- a/src/test/codegen/debug-no-dwarf-address-space.rs
+++ b/src/test/codegen/debug-no-dwarf-address-space.rs
@@ -1,0 +1,31 @@
+// compile-flags: -Cdebuginfo=2
+#![crate_type = "lib"]
+
+// The program below results in debuginfo being generated for at least
+// five different pointer types. Check that they don't have a
+// dwarfAddressSpace attribute.
+
+// CHECK: !DIDerivedType(tag: DW_TAG_pointer_type
+// CHECK-NOT: dwarfAddressSpace
+
+// CHECK: !DIDerivedType(tag: DW_TAG_pointer_type
+// CHECK-NOT: dwarfAddressSpace
+
+// CHECK: !DIDerivedType(tag: DW_TAG_pointer_type
+// CHECK-NOT: dwarfAddressSpace
+
+// CHECK: !DIDerivedType(tag: DW_TAG_pointer_type
+// CHECK-NOT: dwarfAddressSpace
+
+// CHECK: !DIDerivedType(tag: DW_TAG_pointer_type
+// CHECK-NOT: dwarfAddressSpace
+
+pub fn foo(
+    shared_ref: &usize,
+    mut_ref: &mut usize,
+    const_ptr: *const usize,
+    mut_ptr: *mut usize,
+    boxed: Box<usize>,
+) -> usize {
+    *shared_ref + *mut_ref + const_ptr as usize + mut_ptr as usize + *boxed
+}


### PR DESCRIPTION
Currently the compiler adds the `DW_AT_address_class` attribute to pointer type debuginfo. This seems to be accidental, mostly due to our LLVM bindings not allowing to omit the attribute. This PR changes this and brings the actual behavior in line with the intended behavior (as expressed in the pre-existing comments in metadata.rs).

For reference, Clang does not emit the attribute.

Only the final commit is relevant for this PR. The other two commits are from https://github.com/rust-lang/rust/pull/93006, which should be merged first.