### PR TITLE
Implement `core::slice::IterMut::as_mut_slice` and `impl<T> AsMut<[T]> for IterMut<'_, T>`

### DIFF
--- a/library/core/src/slice/iter.rs
+++ b/library/core/src/slice/iter.rs
@@ -315,7 +315,7 @@ impl<'a, T> IterMut<'a, T> {
     /// Basic usage:
     ///
     /// ```
-    /// # #![feature(slice_iter_mut_as_mut_slice)]
+    /// #![feature(slice_iter_mut_as_mut_slice)]
     ///
     /// let mut slice: &mut [usize] = &mut [1, 2, 3];
     ///


### PR DESCRIPTION
As per [the zulip discussion](https://rust-lang.zulipchat.com/#narrow/stream/219381-t-libs/topic/.60std.3A.3Aslice.3A.3AIterMut.3A.3Aas_mut_slice.60), the `AsMut` impl has been commented out, with a comment near the `#[unstable(...)]` to uncomment it when `as_mut_slice` gets stabilized.