### PR TITLE
src/test/rustdoc-json: Check for `struct_field`s in `variant_tuple_struct.rs`

### DIFF
--- a/src/test/rustdoc-json/enums/variant_struct.rs
+++ b/src/test/rustdoc-json/enums/variant_struct.rs
@@ -2,8 +2,8 @@
 // @has - "$.index[*][?(@.name=='EnumStruct')].kind" \"enum\"
 pub enum EnumStruct {
     // @has - "$.index[*][?(@.name=='VariantS')].inner.variant_kind" \"struct\"
-    // @has - "$.index[*][?(@.name=='x')]"
-    // @has - "$.index[*][?(@.name=='y')]"
+    // @has - "$.index[*][?(@.name=='x')].kind" \"struct_field\"
+    // @has - "$.index[*][?(@.name=='y')].kind" \"struct_field\"
     VariantS {
         x: u32,
         y: String,

--- a/src/test/rustdoc-json/enums/variant_tuple_struct.rs
+++ b/src/test/rustdoc-json/enums/variant_tuple_struct.rs
@@ -2,5 +2,7 @@
 // @has - "$.index[*][?(@.name=='EnumTupleStruct')].kind" \"enum\"
 pub enum EnumTupleStruct {
     // @has - "$.index[*][?(@.name=='VariantA')].inner.variant_kind" \"tuple\"
+    // @has - "$.index[*][?(@.name=='0')].kind" \"struct_field\"
+    // @has - "$.index[*][?(@.name=='1')].kind" \"struct_field\"
     VariantA(u32, String),
 }


### PR DESCRIPTION
The presence of `struct_field`s is being checked for already in
`variant_struct.rs`. We should also check for them in `variant_tuple_struct.rs`.

This PR is one small step towards resolving #92945.