### PR TITLE
`impl PartialEq<ErrorKind> for io::Error`

### DIFF
--- a/library/std/src/io/error.rs
+++ b/library/std/src/io/error.rs
@@ -742,6 +742,12 @@ impl Error {
         }
     }
 }
+#[stable(feature = "io_error_eq_errorkind", since = "1.60.0")]
+impl PartialEq<ErrorKind> for Error {
+    fn eq(&self, other: &ErrorKind) -> bool {
+        self.kind() == *other
+    }
+}
 
 impl fmt::Debug for Repr {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/library/std/src/io/error/tests.rs
+++ b/library/std/src/io/error/tests.rs
@@ -67,3 +67,9 @@ fn test_const() {
     assert!(format!("{:?}", E).contains("\"hello\""));
     assert!(format!("{:?}", E).contains("NotFound"));
 }
+
+#[test]
+fn test_eq_errorkind() {
+    let error = Error::new(ErrorKind::NotFound, "hello");
+    assert_eq!(error, ErrorKind::NotFound);
+}


### PR DESCRIPTION
This is an ergonomic improvement that allows directly testing `io::Error` against `io::ErrorKind` instead of needing to call `kind()`. Inspired by #93090.

r? @joshtriplett 