### PR TITLE
Pretty printer algorithm revamp step 3

### DIFF
--- a/compiler/rustc_ast_pretty/src/pp.rs
+++ b/compiler/rustc_ast_pretty/src/pp.rs
@@ -364,11 +364,6 @@ impl Printer {
         }
     }
 
-    fn print_newline(&mut self, amount: isize) {
-        self.out.push('\n');
-        self.pending_indentation = amount;
-    }
-
     fn get_top(&self) -> PrintFrame {
         *self
             .print_stack
@@ -396,12 +391,14 @@ impl Printer {
                 self.space -= token.blank_space;
             }
             PrintFrame::Broken { offset, breaks: Breaks::Consistent } => {
-                self.print_newline(offset + token.offset);
+                self.out.push('\n');
+                self.pending_indentation = offset + token.offset;
                 self.space = self.margin - (offset + token.offset);
             }
             PrintFrame::Broken { offset, breaks: Breaks::Inconsistent } => {
                 if size > self.space {
-                    self.print_newline(offset + token.offset);
+                    self.out.push('\n');
+                    self.pending_indentation = offset + token.offset;
                     self.space = self.margin - (offset + token.offset);
                 } else {
                     self.pending_indentation += token.blank_space;

--- a/compiler/rustc_ast_pretty/src/pp.rs
+++ b/compiler/rustc_ast_pretty/src/pp.rs
@@ -137,7 +137,6 @@ mod ring;
 use ring::RingBuffer;
 use std::borrow::Cow;
 use std::collections::VecDeque;
-use std::fmt;
 
 /// How to break. Described in more detail in the module docs.
 #[derive(Clone, Copy, PartialEq)]
@@ -172,17 +171,6 @@ pub enum Token {
 impl Token {
     pub fn is_hardbreak_tok(&self) -> bool {
         matches!(self, Token::Break(BreakToken { offset: 0, blank_space: SIZE_INFINITY }))
-    }
-}
-
-impl fmt::Display for Token {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match *self {
-            Token::String(ref s) => write!(f, "STR({},{})", s, s.len()),
-            Token::Break(_) => f.write_str("BREAK"),
-            Token::Begin(_) => f.write_str("BEGIN"),
-            Token::End => f.write_str("END"),
-        }
     }
 }
 

--- a/compiler/rustc_ast_pretty/src/pp.rs
+++ b/compiler/rustc_ast_pretty/src/pp.rs
@@ -137,6 +137,7 @@ mod ring;
 use ring::RingBuffer;
 use std::borrow::Cow;
 use std::collections::VecDeque;
+use std::iter;
 
 /// How to break. Described in more detail in the module docs.
 #[derive(Clone, Copy, PartialEq)]
@@ -425,10 +426,6 @@ impl Printer {
     }
 
     fn print_string(&mut self, string: &str) {
-        let len = string.len() as isize;
-        // assert!(len <= space);
-        self.space -= len;
-
         // Write the pending indent. A more concise way of doing this would be:
         //
         //   write!(self.out, "{: >n$}", "", n = self.pending_indentation as usize)?;
@@ -436,9 +433,11 @@ impl Printer {
         // But that is significantly slower. This code is sufficiently hot, and indents can get
         // sufficiently large, that the difference is significant on some workloads.
         self.out.reserve(self.pending_indentation as usize);
-        self.out.extend(std::iter::repeat(' ').take(self.pending_indentation as usize));
+        self.out.extend(iter::repeat(' ').take(self.pending_indentation as usize));
         self.pending_indentation = 0;
+
         self.out.push_str(string);
+        self.space -= string.len() as isize;
     }
 
     // Convenience functions to talk to the printer.

--- a/compiler/rustc_ast_pretty/src/pp.rs
+++ b/compiler/rustc_ast_pretty/src/pp.rs
@@ -366,12 +366,7 @@ impl Printer {
 
     fn print_newline(&mut self, amount: isize) {
         self.out.push('\n');
-        self.pending_indentation = 0;
-        self.indent(amount);
-    }
-
-    fn indent(&mut self, amount: isize) {
-        self.pending_indentation += amount;
+        self.pending_indentation = amount;
     }
 
     fn get_top(&self) -> PrintFrame {
@@ -397,7 +392,7 @@ impl Printer {
     fn print_break(&mut self, token: BreakToken, size: isize) {
         match self.get_top() {
             PrintFrame::Fits => {
-                self.indent(token.blank_space);
+                self.pending_indentation += token.blank_space;
                 self.space -= token.blank_space;
             }
             PrintFrame::Broken { offset, breaks: Breaks::Consistent } => {
@@ -409,7 +404,7 @@ impl Printer {
                     self.print_newline(offset + token.offset);
                     self.space = self.margin - (offset + token.offset);
                 } else {
-                    self.indent(token.blank_space);
+                    self.pending_indentation += token.blank_space;
                     self.space -= token.blank_space;
                 }
             }

--- a/compiler/rustc_ast_pretty/src/pp.rs
+++ b/compiler/rustc_ast_pretty/src/pp.rs
@@ -319,7 +319,7 @@ impl Printer {
         let mut left_size = self.buf.first().unwrap().size;
 
         while left_size >= 0 {
-            let left = self.buf.first().unwrap().token.clone();
+            let left = self.buf.pop_first().unwrap().token;
 
             let len = match left {
                 Token::Break(b) => b.blank_space,
@@ -335,7 +335,6 @@ impl Printer {
 
             self.left_total += len;
 
-            self.buf.advance_left();
             if self.buf.is_empty() {
                 break;
             }

--- a/compiler/rustc_ast_pretty/src/pp.rs
+++ b/compiler/rustc_ast_pretty/src/pp.rs
@@ -320,16 +320,16 @@ impl Printer {
             let left = self.buf.pop_first().unwrap();
 
             match &left.token {
-                Token::Break(b) => self.left_total += b.blank_space,
-                Token::String(s) => self.left_total += s.len() as isize,
-                _ => {}
-            }
-
-            match &left.token {
+                Token::String(s) => {
+                    self.left_total += s.len() as isize;
+                    self.print_string(s);
+                }
+                Token::Break(b) => {
+                    self.left_total += b.blank_space;
+                    self.print_break(*b, left.size);
+                }
                 Token::Begin(b) => self.print_begin(*b, left.size),
                 Token::End => self.print_end(),
-                Token::Break(b) => self.print_break(*b, left.size),
-                Token::String(s) => self.print_string(s),
             }
 
             self.last_printed = Some(left.token);

--- a/compiler/rustc_ast_pretty/src/pp.rs
+++ b/compiler/rustc_ast_pretty/src/pp.rs
@@ -385,26 +385,21 @@ impl Printer {
     }
 
     fn print_break(&mut self, token: BreakToken, size: isize) {
-        match self.get_top() {
-            PrintFrame::Fits => {
-                self.pending_indentation += token.blank_space;
-                self.space -= token.blank_space;
-            }
-            PrintFrame::Broken { offset, breaks: Breaks::Consistent } => {
-                self.out.push('\n');
-                self.pending_indentation = offset + token.offset;
-                self.space = self.margin - (offset + token.offset);
-            }
-            PrintFrame::Broken { offset, breaks: Breaks::Inconsistent } => {
-                if size > self.space {
-                    self.out.push('\n');
-                    self.pending_indentation = offset + token.offset;
-                    self.space = self.margin - (offset + token.offset);
-                } else {
-                    self.pending_indentation += token.blank_space;
-                    self.space -= token.blank_space;
+        let break_offset =
+            match self.get_top() {
+                PrintFrame::Fits => None,
+                PrintFrame::Broken { offset, breaks: Breaks::Consistent } => Some(offset),
+                PrintFrame::Broken { offset, breaks: Breaks::Inconsistent } => {
+                    if size > self.space { Some(offset) } else { None }
                 }
-            }
+            };
+        if let Some(offset) = break_offset {
+            self.out.push('\n');
+            self.pending_indentation = offset + token.offset;
+            self.space = self.margin - (offset + token.offset);
+        } else {
+            self.pending_indentation += token.blank_space;
+            self.space -= token.blank_space;
         }
     }
 

--- a/compiler/rustc_ast_pretty/src/pp.rs
+++ b/compiler/rustc_ast_pretty/src/pp.rs
@@ -321,19 +321,13 @@ impl Printer {
         while left_size >= 0 {
             let left = self.buf.pop_first().unwrap().token;
 
-            let len = match left {
-                Token::Break(b) => b.blank_space,
-                Token::String(ref s) => {
-                    let len = s.len() as isize;
-                    assert_eq!(len, left_size);
-                    len
-                }
-                _ => 0,
-            };
+            match &left {
+                Token::Break(b) => self.left_total += b.blank_space,
+                Token::String(s) => self.left_total += s.len() as isize,
+                _ => {}
+            }
 
             self.print(left, left_size);
-
-            self.left_total += len;
 
             if self.buf.is_empty() {
                 break;
@@ -447,11 +441,7 @@ impl Printer {
             Token::Begin(b) => self.print_begin(*b, l),
             Token::End => self.print_end(),
             Token::Break(b) => self.print_break(*b, l),
-            Token::String(s) => {
-                let len = s.len() as isize;
-                assert_eq!(len, l);
-                self.print_string(s);
-            }
+            Token::String(s) => self.print_string(s),
         }
         self.last_printed = Some(token);
     }

--- a/compiler/rustc_ast_pretty/src/pp.rs
+++ b/compiler/rustc_ast_pretty/src/pp.rs
@@ -316,24 +316,20 @@ impl Printer {
     }
 
     fn advance_left(&mut self) {
-        let mut left_size = self.buf.first().unwrap().size;
+        while self.buf.first().unwrap().size >= 0 {
+            let left = self.buf.pop_first().unwrap();
 
-        while left_size >= 0 {
-            let left = self.buf.pop_first().unwrap().token;
-
-            match &left {
+            match &left.token {
                 Token::Break(b) => self.left_total += b.blank_space,
                 Token::String(s) => self.left_total += s.len() as isize,
                 _ => {}
             }
 
-            self.print(left, left_size);
+            self.print(left.token, left.size);
 
             if self.buf.is_empty() {
                 break;
             }
-
-            left_size = self.buf.first().unwrap().size;
         }
     }
 

--- a/compiler/rustc_ast_pretty/src/pp.rs
+++ b/compiler/rustc_ast_pretty/src/pp.rs
@@ -325,7 +325,14 @@ impl Printer {
                 _ => {}
             }
 
-            self.print(left.token, left.size);
+            match &left.token {
+                Token::Begin(b) => self.print_begin(*b, left.size),
+                Token::End => self.print_end(),
+                Token::Break(b) => self.print_break(*b, left.size),
+                Token::String(s) => self.print_string(s),
+            }
+
+            self.last_printed = Some(left.token);
 
             if self.buf.is_empty() {
                 break;
@@ -430,16 +437,6 @@ impl Printer {
         self.out.extend(std::iter::repeat(' ').take(self.pending_indentation as usize));
         self.pending_indentation = 0;
         self.out.push_str(s);
-    }
-
-    fn print(&mut self, token: Token, l: isize) {
-        match &token {
-            Token::Begin(b) => self.print_begin(*b, l),
-            Token::End => self.print_end(),
-            Token::Break(b) => self.print_break(*b, l),
-            Token::String(s) => self.print_string(s),
-        }
-        self.last_printed = Some(token);
     }
 
     // Convenience functions to talk to the printer.

--- a/compiler/rustc_ast_pretty/src/pp/ring.rs
+++ b/compiler/rustc_ast_pretty/src/pp/ring.rs
@@ -32,11 +32,6 @@ impl<T> RingBuffer<T> {
         index
     }
 
-    pub fn advance_left(&mut self) {
-        self.data.pop_front().unwrap();
-        self.offset += 1;
-    }
-
     pub fn clear(&mut self) {
         self.data.clear();
     }
@@ -51,6 +46,12 @@ impl<T> RingBuffer<T> {
 
     pub fn first_mut(&mut self) -> Option<&mut T> {
         self.data.front_mut()
+    }
+
+    pub fn pop_first(&mut self) -> Option<T> {
+        let first = self.data.pop_front()?;
+        self.offset += 1;
+        Some(first)
     }
 
     pub fn last(&self) -> Option<&T> {


### PR DESCRIPTION
This PR follows #93065 as a third chunk of minor modernizations backported from https://github.com/dtolnay/prettyplease into rustc_ast_pretty.

I've broken this up into atomic commits that hopefully are sensible in isolation. At every commit, the pretty printer is compilable and has runtime behavior that is identical to before and after the PR. None of the refactoring so far changes behavior.

This PR is the last chunk of non-behavior-changing cleanup. After this the **next PR** will begin backporting behavior changes from `prettyplease`, starting with block indentation:

```rust
macro_rules! print_expr {
    ($expr:expr) => {
        println!("{}", stringify!($expr));
    };
}

fn main() {
    print_expr!(Struct { x: 0, y: 0 });
    print_expr!(Structtttttttttttttttttttttttttttttttttttttttttttttttttt { xxxxxxxxx: 0, yyyyyyyyy: 0 });
}
```

Output currently on master (nowhere near modern Rust style):

```console
Struct{x: 0, y: 0,}
Structtttttttttttttttttttttttttttttttttttttttttttttttttt{xxxxxxxxx: 0,
                                                         yyyyyyyyy: 0,}
```

After the upcoming PR for block indentation (based on https://github.com/dtolnay/prettyplease/commit/401d60c04213e6c66565e0e69a95b4588db5fdba):

```console
Struct { x: 0, y: 0, }
Structtttttttttttttttttttttttttttttttttttttttttttttttttt {
    xxxxxxxxx: 0,
    yyyyyyyyy: 0,
}
```

And the PR after that, for intelligent trailing commas (based on https://github.com/dtolnay/prettyplease/commit/e2a0297f1781b787b90bca5aba1bdb4966661882):

```console
Struct { x: 0, y: 0 }
Structtttttttttttttttttttttttttttttttttttttttttttttttttt {
    xxxxxxxxx: 0,
    yyyyyyyyy: 0,
}
```