### PR TITLE
Add #[must_use] to {HashMap,HashSet,BTreeMap,BTreeSet}::insert

### DIFF
--- a/library/alloc/src/collections/btree/map.rs
+++ b/library/alloc/src/collections/btree/map.rs
@@ -853,6 +853,7 @@ impl<K, V> BTreeMap<K, V> {
     /// assert_eq!(map[&37], "c");
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[must_use]
     pub fn insert(&mut self, key: K, value: V) -> Option<V>
     where
         K: Ord,

--- a/library/alloc/src/collections/btree/set.rs
+++ b/library/alloc/src/collections/btree/set.rs
@@ -789,6 +789,7 @@ impl<T> BTreeSet<T> {
     /// assert_eq!(set.len(), 1);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[must_use]
     pub fn insert(&mut self, value: T) -> bool
     where
         T: Ord,

--- a/library/std/src/collections/hash/map.rs
+++ b/library/std/src/collections/hash/map.rs
@@ -924,6 +924,7 @@ where
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[must_use]
     pub fn insert(&mut self, k: K, v: V) -> Option<V> {
         self.base.insert(k, v)
     }

--- a/library/std/src/collections/hash/set.rs
+++ b/library/std/src/collections/hash/set.rs
@@ -851,6 +851,7 @@ where
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[must_use]
     pub fn insert(&mut self, value: T) -> bool {
         self.base.insert(value)
     }


### PR DESCRIPTION
I propose adding `#[must_use]` to methods `insert` of `HashMap`, `HashSet`, `BTreeMap`, `BTreeSet`.

Because in my code I always want to check whether such key existed before. And it is easy to forget such check. My current workaround is so: I forbid direct calls to `HashMap::insert` and similar functions using `clippy::disallowed_methods` and wrap this functions using wrappers with `#[must_use]`. I propose simply to add `#[must_use]` to std.

Yes, I am aware about `try_insert` ( https://github.com/rust-lang/rust/issues/82766 ). But this functions is misnamed: prefix `try_` is usually used for functions, which can report allocation error, such as `HashMap::try_reserve`. Also, this doesn't fix the problem for `HashSet`