### PR TITLE
Increase the format version of rustdoc-json-types

### DIFF
--- a/src/rustdoc-json-types/lib.rs
+++ b/src/rustdoc-json-types/lib.rs
@@ -8,6 +8,9 @@ use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 
+/// rustdoc format-version.
+pub const FORMAT_VERSION: u32 = 10;
+
 /// A `Crate` is the root of the emitted JSON blob. It contains all type/documentation information
 /// about the language items in the local crate, as well as info about external items to allow
 /// tools to find or link to them.
@@ -516,9 +519,6 @@ pub struct Static {
     pub mutable: bool,
     pub expr: String,
 }
-
-/// rustdoc format-version.
-pub const FORMAT_VERSION: u32 = 9;
 
 #[cfg(test)]
 mod tests;


### PR DESCRIPTION
PR https://github.com/rust-lang/rust/pull/87648 changed `rustdoc-json-types` without increasing the format version.
https://github.com/rust-lang/rust/commit/e7529d6a3867ed1692818702b40814ee992eba2d#diff-ede26372490522288745c5b3df2b6b2a1cc913dcd09b29af3a49935afe00c7e6

This PR increase the format version by +1 and move the `FORMAT_VERSION` constant to the start of the file to hopefully make it more clear that `rustdoc-json-types` is versioned.