### PR TITLE
rustdoc: fix overflow-wrap for table layouts

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -675,7 +675,6 @@ nav.sub {
 	margin: .5em 0;
 	width: calc(100% - 2px);
 	overflow-x: auto;
-	overflow-wrap: normal;
 	display: block;
 }
 
@@ -861,6 +860,31 @@ h2.small-section-header > .anchor {
 }
 
 .block a.current.crate { font-weight: 500; }
+
+/*  In most contexts we use `overflow-wrap: anywhere` to ensure that we can wrap
+	as much as needed on mobile (see
+	src/test/rustdoc-gui/type-declaration-overflow.goml for an example of why
+	this matters). The `anywhere` value means:
+
+	"Soft wrap opportunities introduced by the word break are considered when
+	 calculating min-content intrinsic sizes."
+
+	https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-wrap#values
+
+	For table layouts, that becomes a problem: the browser tries to make each
+	column as narrow as possible, and `overflow-wrap: anywhere` means it can do
+	so by breaking words - even if some other column could be shrunk without
+	breaking words! This shows up, for instance, in the `Structs` / `Modules` /
+	`Functions` (etcetera) sections of a module page, and when a docblock
+	contains a table.
+
+	So, for table layouts, override the default with break-word, which does
+	_not_ affect min-content intrinsic sizes.
+*/
+table,
+.item-table {
+	overflow-wrap: break-word;
+}
 
 .item-table {
 	display: table;
@@ -2038,10 +2062,6 @@ details.rustdoc-toggle[open] > summary.hideme::after {
 	.docblock code {
 		overflow-wrap: break-word;
 		overflow-wrap: anywhere;
-	}
-
-	.docblock table code {
-		overflow-wrap: normal;
 	}
 
 	.sub-container {

--- a/src/test/rustdoc-gui/src/lib2/lib.rs
+++ b/src/test/rustdoc-gui/src/lib2/lib.rs
@@ -39,7 +39,6 @@ impl Trait for Foo {
     const Y: u32 = 0;
 }
 
-
 impl implementors::Whatever for Foo {
     type Foo = u32;
 }
@@ -58,8 +57,10 @@ pub mod sub_mod {
 pub mod long_trait {
     use std::ops::DerefMut;
 
-    pub trait ALongNameBecauseItHelpsTestingTheCurrentProblem: DerefMut<Target = u32>
-        + From<u128> + Send + Sync + AsRef<str> + 'static {}
+    pub trait ALongNameBecauseItHelpsTestingTheCurrentProblem:
+        DerefMut<Target = u32> + From<u128> + Send + Sync + AsRef<str> + 'static
+    {
+    }
 }
 
 pub mod long_table {
@@ -88,18 +89,28 @@ pub mod summary_table {
 }
 
 pub mod too_long {
-pub type ReallyLongTypeNameLongLongLong = Option<unsafe extern "C" fn(a: *const u8, b: *const u8) -> *const u8>;
+    pub type ReallyLongTypeNameLongLongLong =
+        Option<unsafe extern "C" fn(a: *const u8, b: *const u8) -> *const u8>;
 
-pub const ReallyLongTypeNameLongLongLongConstBecauseWhyNotAConstRightGigaGigaSupraLong: u32 = 0;
+    pub const ReallyLongTypeNameLongLongLongConstBecauseWhyNotAConstRightGigaGigaSupraLong: u32 = 0;
 
-pub struct SuperIncrediblyLongLongLongLongLongLongLongGigaGigaGigaMegaLongLongLongStructName {
-    pub a: u32,
-}
+    /// This also has a really long doccomment. Lorem ipsum dolor sit amet,
+    /// consectetur adipiscing elit. Suspendisse id nibh malesuada, hendrerit
+    /// massa vel, tincidunt est. Nulla interdum, sem ac efficitur ornare, arcu
+    /// nunc dignissim nibh, at rutrum diam augue ac mauris. Fusce tincidunt et
+    /// ligula sed viverra. Aenean sed facilisis dui, non volutpat felis. In
+    /// vitae est dui. Donec felis nibh, blandit at nibh eu, tempor suscipit
+    /// nisl. Vestibulum ornare porta libero, eu faucibus purus iaculis ut. Ut
+    /// quis tincidunt nunc, in mollis purus. Nulla sed interdum quam. Nunc
+    /// vitae cursus ex.
+    pub struct SuperIncrediblyLongLongLongLongLongLongLongGigaGigaGigaMegaLongLongLongStructName {
+        pub a: u32,
+    }
 
-impl SuperIncrediblyLongLongLongLongLongLongLongGigaGigaGigaMegaLongLongLongStructName {
-    /// ```
-    /// let x = SuperIncrediblyLongLongLongLongLongLongLongGigaGigaGigaMegaLongLongLongStructName { a: 0 };
-    /// ```
+    impl SuperIncrediblyLongLongLongLongLongLongLongGigaGigaGigaMegaLongLongLongStructName {
+        /// ```
+        /// let x = SuperIncrediblyLongLongLongLongLongLongLongGigaGigaGigaMegaLongLongLongStructName { a: 0 };
+        /// ```
         pub fn foo(&self) {}
     }
 }

--- a/src/test/rustdoc-gui/type-declation-overflow.goml
+++ b/src/test/rustdoc-gui/type-declation-overflow.goml
@@ -7,6 +7,10 @@ assert-property: ("body", {"scrollWidth": "1100"})
 // However, since there is overflow in the type declaration, its scroll width is bigger.
 assert-property: (".item-decl pre", {"scrollWidth": "1324"})
 
+// In the table-ish view on the module index, the name should not be wrapped more than necessary.
+goto: file://|DOC_PATH|/lib2/too_long/index.html
+assert-property: (".item-table .struct", {"offsetWidth": "684"})
+
 // We now make the same check on type declaration...
 goto: file://|DOC_PATH|/lib2/too_long/type.ReallyLongTypeNameLongLongLong.html
 assert-property: ("body", {"scrollWidth": "1100"})


### PR DESCRIPTION
For all table layouts, set overflow-wrap: break-word.

Fixes #93135

Demo: https://rustdoc.crud.net/jsha/fix-wrapped-names/std/intrinsics/index.html#functions

(Compare vs https://doc.rust-lang.org/nightly/std/intrinsics/index.html - you may have to make your browser narrower to see the effect)

r? @Nemo157 