### PR TITLE
Do not point at whole file missing `fn main`

### DIFF
--- a/compiler/rustc_passes/src/entry.rs
+++ b/compiler/rustc_passes/src/entry.rs
@@ -218,9 +218,9 @@ fn no_main_err(tcx: TyCtxt<'_>, visitor: &EntryContext<'_, '_>) {
     // The file may be empty, which leads to the diagnostic machinery not emitting this
     // note. This is a relatively simple way to detect that case and emit a span-less
     // note instead.
-    if tcx.sess.source_map().lookup_line(sp.lo()).is_ok() {
-        err.set_span(sp);
-        err.span_label(sp, &note);
+    if tcx.sess.source_map().lookup_line(sp.hi()).is_ok() {
+        err.set_span(sp.shrink_to_hi());
+        err.span_label(sp.shrink_to_hi(), &note);
     } else {
         err.note(&note);
     }

--- a/src/test/ui/attributes/issue-90873.rs
+++ b/src/test/ui/attributes/issue-90873.rs
@@ -1,9 +1,9 @@
 #![u=||{static d=||1;}]
 //~^ unexpected token
 //~| cannot find attribute `u` in this scope
-//~| `main` function not found in crate `issue_90873`
 //~| missing type for `static` item
 
 #![a={impl std::ops::Neg for i8 {}}]
 //~^ ERROR unexpected token
 //~| ERROR cannot find attribute `a` in this scope
+//~| ERROR `main` function not found in crate `issue_90873`

--- a/src/test/ui/attributes/issue-90873.stderr
+++ b/src/test/ui/attributes/issue-90873.stderr
@@ -10,7 +10,7 @@ LL | #![u=||{static d=||1;}]
 error: unexpected token: `{
            impl std::ops::Neg for i8 {}
        }`
-  --> $DIR/issue-90873.rs:7:6
+  --> $DIR/issue-90873.rs:6:6
    |
 LL | #![a={impl std::ops::Neg for i8 {}}]
    |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -22,22 +22,16 @@ LL | #![u=||{static d=||1;}]
    |    ^
 
 error: cannot find attribute `a` in this scope
-  --> $DIR/issue-90873.rs:7:4
+  --> $DIR/issue-90873.rs:6:4
    |
 LL | #![a={impl std::ops::Neg for i8 {}}]
    |    ^
 
 error[E0601]: `main` function not found in crate `issue_90873`
-  --> $DIR/issue-90873.rs:1:1
+  --> $DIR/issue-90873.rs:6:37
    |
-LL | / #![u=||{static d=||1;}]
-LL | |
-LL | |
-LL | |
-LL | |
-LL | |
-LL | | #![a={impl std::ops::Neg for i8 {}}]
-   | |____________________________________^ consider adding a `main` function to `$DIR/issue-90873.rs`
+LL | #![a={impl std::ops::Neg for i8 {}}]
+   |                                     ^ consider adding a `main` function to `$DIR/issue-90873.rs`
 
 error: missing type for `static` item
   --> $DIR/issue-90873.rs:1:16

--- a/src/test/ui/conditional-compilation/cfg-attr-cfg-2.stderr
+++ b/src/test/ui/conditional-compilation/cfg-attr-cfg-2.stderr
@@ -1,9 +1,8 @@
 error[E0601]: `main` function not found in crate `cfg_attr_cfg_2`
-  --> $DIR/cfg-attr-cfg-2.rs:8:1
+  --> $DIR/cfg-attr-cfg-2.rs:9:14
    |
-LL | / #[cfg_attr(foo, cfg(bar))]
-LL | | fn main() { }
-   | |_____________^ consider adding a `main` function to `$DIR/cfg-attr-cfg-2.rs`
+LL | fn main() { }
+   |              ^ consider adding a `main` function to `$DIR/cfg-attr-cfg-2.rs`
 
 error: aborting due to previous error
 

--- a/src/test/ui/conditional-compilation/cfg-in-crate-1.stderr
+++ b/src/test/ui/conditional-compilation/cfg-in-crate-1.stderr
@@ -1,8 +1,8 @@
 error[E0601]: `main` function not found in crate `cfg_in_crate_1`
-  --> $DIR/cfg-in-crate-1.rs:3:1
+  --> $DIR/cfg-in-crate-1.rs:3:13
    |
 LL | #![cfg(bar)]
-   | ^^^^^^^^^^^^ consider adding a `main` function to `$DIR/cfg-in-crate-1.rs`
+   |             ^ consider adding a `main` function to `$DIR/cfg-in-crate-1.rs`
 
 error: aborting due to previous error
 

--- a/src/test/ui/continue-after-missing-main.nll.stderr
+++ b/src/test/ui/continue-after-missing-main.nll.stderr
@@ -1,14 +1,8 @@
 error[E0601]: `main` function not found in crate `continue_after_missing_main`
-  --> $DIR/continue-after-missing-main.rs:1:1
+  --> $DIR/continue-after-missing-main.rs:30:2
    |
-LL | / #![allow(dead_code)]
-LL | |
-LL | | struct Tableau<'a, MP> {
-LL | |     provider: &'a MP,
-...  |
-LL | |
-LL | | }
-   | |_^ consider adding a `main` function to `$DIR/continue-after-missing-main.rs`
+LL | }
+   |  ^ consider adding a `main` function to `$DIR/continue-after-missing-main.rs`
 
 error: aborting due to previous error
 

--- a/src/test/ui/continue-after-missing-main.rs
+++ b/src/test/ui/continue-after-missing-main.rs
@@ -1,4 +1,4 @@
-#![allow(dead_code)] //~ ERROR `main` function not found in crate
+#![allow(dead_code)]
 
 struct Tableau<'a, MP> {
     provider: &'a MP,
@@ -27,4 +27,4 @@ fn create_and_solve_subproblems<'data_provider, 'original_data, MP>(
 ) {
     let _: AdaptedMatrixProvider<'original_data, MP> = tableau.provider().clone_with_extra_bound();
     //~^ ERROR lifetime mismatch
-}
+} //~ ERROR `main` function not found in crate

--- a/src/test/ui/continue-after-missing-main.stderr
+++ b/src/test/ui/continue-after-missing-main.stderr
@@ -1,14 +1,8 @@
 error[E0601]: `main` function not found in crate `continue_after_missing_main`
-  --> $DIR/continue-after-missing-main.rs:1:1
+  --> $DIR/continue-after-missing-main.rs:30:2
    |
-LL | / #![allow(dead_code)]
-LL | |
-LL | | struct Tableau<'a, MP> {
-LL | |     provider: &'a MP,
-...  |
-LL | |
-LL | | }
-   | |_^ consider adding a `main` function to `$DIR/continue-after-missing-main.rs`
+LL | }
+   |  ^ consider adding a `main` function to `$DIR/continue-after-missing-main.rs`
 
 error[E0623]: lifetime mismatch
   --> $DIR/continue-after-missing-main.rs:28:56

--- a/src/test/ui/elided-test.stderr
+++ b/src/test/ui/elided-test.stderr
@@ -1,10 +1,8 @@
 error[E0601]: `main` function not found in crate `elided_test`
-  --> $DIR/elided-test.rs:5:1
+  --> $DIR/elided-test.rs:7:2
    |
-LL | / #[test]
-LL | | fn main() {
-LL | | }
-   | |_^ consider adding a `main` function to `$DIR/elided-test.rs`
+LL | }
+   |  ^ consider adding a `main` function to `$DIR/elided-test.rs`
 
 error: aborting due to previous error
 

--- a/src/test/ui/entry-point/imported_main_const_fn_item_type_forbidden.rs
+++ b/src/test/ui/entry-point/imported_main_const_fn_item_type_forbidden.rs
@@ -1,7 +1,6 @@
 #![feature(imported_main)]
 #![feature(type_alias_impl_trait)]
 #![allow(incomplete_features)]
-//~^^^ ERROR `main` function not found in crate
 pub mod foo {
     type MainFn = impl Fn();
     //~^ ERROR could not find defining uses
@@ -11,4 +10,4 @@ pub mod foo {
     //~^ ERROR mismatched types [E0308]
 }
 
-use foo::BAR as main;
+use foo::BAR as main; //~ ERROR `main` function not found in crate

--- a/src/test/ui/entry-point/imported_main_const_fn_item_type_forbidden.stderr
+++ b/src/test/ui/entry-point/imported_main_const_fn_item_type_forbidden.stderr
@@ -1,19 +1,13 @@
 error[E0601]: `main` function not found in crate `imported_main_const_fn_item_type_forbidden`
-  --> $DIR/imported_main_const_fn_item_type_forbidden.rs:1:1
+  --> $DIR/imported_main_const_fn_item_type_forbidden.rs:13:22
    |
-LL | / #![feature(imported_main)]
-LL | | #![feature(type_alias_impl_trait)]
-LL | | #![allow(incomplete_features)]
-LL | |
-...  |
-LL | |
-LL | | use foo::BAR as main;
-   | |_____----------------^ consider adding a `main` function to `$DIR/imported_main_const_fn_item_type_forbidden.rs`
-   |       |
-   |       non-function item at `crate::main` is found
+LL | use foo::BAR as main;
+   |     ---------------- ^ consider adding a `main` function to `$DIR/imported_main_const_fn_item_type_forbidden.rs`
+   |     |
+   |     non-function item at `crate::main` is found
 
 error[E0308]: mismatched types
-  --> $DIR/imported_main_const_fn_item_type_forbidden.rs:10:29
+  --> $DIR/imported_main_const_fn_item_type_forbidden.rs:9:29
    |
 LL |     type MainFn = impl Fn();
    |                   --------- the expected opaque type
@@ -25,7 +19,7 @@ LL |     pub const BAR: MainFn = bar;
                   found fn item `fn() {bar}`
 
 error: could not find defining uses
-  --> $DIR/imported_main_const_fn_item_type_forbidden.rs:6:19
+  --> $DIR/imported_main_const_fn_item_type_forbidden.rs:5:19
    |
 LL |     type MainFn = impl Fn();
    |                   ^^^^^^^^^

--- a/src/test/ui/entry-point/imported_main_const_forbidden.rs
+++ b/src/test/ui/entry-point/imported_main_const_forbidden.rs
@@ -1,7 +1,6 @@
 #![feature(imported_main)]
-//~^ ERROR `main` function not found in crate
 pub mod foo {
     pub const BAR: usize = 42;
 }
 
-use foo::BAR as main;
+use foo::BAR as main; //~ ERROR `main` function not found in crate

--- a/src/test/ui/entry-point/imported_main_const_forbidden.stderr
+++ b/src/test/ui/entry-point/imported_main_const_forbidden.stderr
@@ -1,16 +1,10 @@
 error[E0601]: `main` function not found in crate `imported_main_const_forbidden`
-  --> $DIR/imported_main_const_forbidden.rs:1:1
+  --> $DIR/imported_main_const_forbidden.rs:6:22
    |
-LL | / #![feature(imported_main)]
-LL | |
-LL | | pub mod foo {
-LL | |     pub const BAR: usize = 42;
-LL | | }
-LL | |
-LL | | use foo::BAR as main;
-   | |_____----------------^ consider adding a `main` function to `$DIR/imported_main_const_forbidden.rs`
-   |       |
-   |       non-function item at `crate::main` is found
+LL | use foo::BAR as main;
+   |     ---------------- ^ consider adding a `main` function to `$DIR/imported_main_const_forbidden.rs`
+   |     |
+   |     non-function item at `crate::main` is found
 
 error: aborting due to previous error
 

--- a/src/test/ui/main-wrong-location.rs
+++ b/src/test/ui/main-wrong-location.rs
@@ -1,6 +1,5 @@
 mod m {
-//~^ ERROR `main` function not found
     // An inferred main entry point
     // must appear at the top of the crate
     fn main() { }
-}
+} //~ ERROR `main` function not found

--- a/src/test/ui/main-wrong-location.stderr
+++ b/src/test/ui/main-wrong-location.stderr
@@ -1,16 +1,11 @@
 error[E0601]: `main` function not found in crate `main_wrong_location`
-  --> $DIR/main-wrong-location.rs:1:1
+  --> $DIR/main-wrong-location.rs:5:2
    |
-LL | / mod m {
-LL | |
-LL | |     // An inferred main entry point
-LL | |     // must appear at the top of the crate
-LL | |     fn main() { }
-LL | | }
-   | |_^ the main function must be defined at the crate level (in `$DIR/main-wrong-location.rs`)
+LL | }
+   |  ^ the main function must be defined at the crate level (in `$DIR/main-wrong-location.rs`)
    |
 note: here is a function named `main`
-  --> $DIR/main-wrong-location.rs:5:5
+  --> $DIR/main-wrong-location.rs:4:5
    |
 LL |     fn main() { }
    |     ^^^^^^^^^^^^^

--- a/src/test/ui/missing/missing-main.stderr
+++ b/src/test/ui/missing/missing-main.stderr
@@ -1,8 +1,8 @@
 error[E0601]: `main` function not found in crate `missing_main`
-  --> $DIR/missing-main.rs:2:1
+  --> $DIR/missing-main.rs:2:14
    |
 LL | fn mian() { }
-   | ^^^^^^^^^^^^^ consider adding a `main` function to `$DIR/missing-main.rs`
+   |              ^ consider adding a `main` function to `$DIR/missing-main.rs`
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/issues/issue-49040.stderr
+++ b/src/test/ui/parser/issues/issue-49040.stderr
@@ -5,10 +5,10 @@ LL | #![allow(unused_variables)];
    |                            ^ help: remove this semicolon
 
 error[E0601]: `main` function not found in crate `issue_49040`
-  --> $DIR/issue-49040.rs:1:1
+  --> $DIR/issue-49040.rs:1:29
    |
 LL | #![allow(unused_variables)];
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ consider adding a `main` function to `$DIR/issue-49040.rs`
+   |                             ^ consider adding a `main` function to `$DIR/issue-49040.rs`
 
 error: aborting due to 2 previous errors
 

--- a/src/tools/clippy/tests/ui/crashes/ice-6250.stderr
+++ b/src/tools/clippy/tests/ui/crashes/ice-6250.stderr
@@ -1,14 +1,8 @@
 error[E0601]: `main` function not found in crate `ice_6250`
-  --> $DIR/ice-6250.rs:4:1
+  --> $DIR/ice-6250.rs:16:2
    |
-LL | / pub struct Cache {
-LL | |     data: Vec<i32>,
-LL | | }
-LL | |
-...  |
-LL | |     }
-LL | | }
-   | |_^ consider adding a `main` function to `$DIR/ice-6250.rs`
+LL | }
+   |  ^ consider adding a `main` function to `$DIR/ice-6250.rs`
 
 error[E0308]: mismatched types
   --> $DIR/ice-6250.rs:12:14

--- a/src/tools/clippy/tests/ui/crashes/ice-6251.stderr
+++ b/src/tools/clippy/tests/ui/crashes/ice-6251.stderr
@@ -1,10 +1,8 @@
 error[E0601]: `main` function not found in crate `ice_6251`
-  --> $DIR/ice-6251.rs:4:1
+  --> $DIR/ice-6251.rs:6:2
    |
-LL | / fn bug<T>() -> impl Iterator<Item = [(); { |x: [u8]| x }]> {
-LL | |     std::iter::empty()
-LL | | }
-   | |_^ consider adding a `main` function to `$DIR/ice-6251.rs`
+LL | }
+   |  ^ consider adding a `main` function to `$DIR/ice-6251.rs`
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> $DIR/ice-6251.rs:4:45


### PR DESCRIPTION
Only point at the end of the crate. We could try making it point at the
beginning of the crate, but that is confused with `DUMMY_SP`, causing
the output to be *worse*.

This change will make it so that VSCode will *not* underline the whole
file when `main` is missing, so other errors will be visible.