### PR TITLE
rustdoc: Fix inconsistency of local blanket impls

### DIFF
--- a/src/librustdoc/json/mod.rs
+++ b/src/librustdoc/json/mod.rs
@@ -172,21 +172,8 @@ impl<'tcx> FormatRenderer<'tcx> for JsonRenderer<'tcx> {
     /// the hashmap because certain items (traits and types) need to have their mappings for trait
     /// implementations filled out before they're inserted.
     fn item(&mut self, item: clean::Item) -> Result<(), Error> {
-        let local_blanket_impl = match item.def_id {
-            clean::ItemId::Blanket { impl_id, .. } => impl_id.is_local(),
-            clean::ItemId::Auto { .. }
-            | clean::ItemId::DefId(_)
-            | clean::ItemId::Primitive(_, _) => false,
-        };
-
         // Flatten items that recursively store other items
-        // FIXME(CraftSpider): We skip children of local blanket implementations, as we'll have
-        //     already seen the actual generic impl, and the generated ones don't need documenting.
-        //     This is necessary due to the visibility, return type, and self arg of the generated
-        //     impls not quite matching, and will no longer be necessary when the mismatch is fixed.
-        if !local_blanket_impl {
-            item.kind.inner_items().for_each(|i| self.item(i.clone()).unwrap());
-        }
+        item.kind.inner_items().for_each(|i| self.item(i.clone()).unwrap());
 
         let id = item.def_id;
         if let Some(mut new_item) = self.convert_item(item) {

--- a/src/test/rustdoc-json/impls/blanket_with_local.rs
+++ b/src/test/rustdoc-json/impls/blanket_with_local.rs
@@ -4,10 +4,12 @@
 // @has blanket_with_local.json "$.index[*][?(@.name=='Load')]"
 pub trait Load {
     fn load() {}
+    fn write(self) {}
 }
 
 impl<P> Load for P {
     fn load() {}
+    fn write(self) {}
 }
 
 // @has - "$.index[*][?(@.name=='Wrapper')]"

--- a/src/test/rustdoc-json/impls/blanket_with_local.rs
+++ b/src/test/rustdoc-json/impls/blanket_with_local.rs
@@ -3,7 +3,9 @@
 
 // @has blanket_with_local.json "$.index[*][?(@.name=='Load')]"
 pub trait Load {
+    // @has - "$.index[*][?(@.name=='load')]"
     fn load() {}
+    // @has - "$.index[*][?(@.name=='write')]"
     fn write(self) {}
 }
 


### PR DESCRIPTION
When a blanket impl is local, go through HIR instead of middle. This fixes inconsistencies with data detected during JSON generation.

Expected this change to take longer. I also tried doing the whole item through existing clean architecture, but it didn't work out trivially, and felt like it would have added more complexity than it removed.

Properly fixes #83718