### PR TITLE
Add missing GUI test explanations

### DIFF
--- a/src/test/rustdoc-gui/check_info_sign_position.goml
+++ b/src/test/rustdoc-gui/check_info_sign_position.goml
@@ -1,3 +1,5 @@
+// This test checks the position of the information on the code blocks (like
+// `compile_fail` or `ignore`).
 goto: file://|DOC_PATH|/test_docs/index.html
 goto: ./fn.check_list_code_block.html
 // If the codeblock is the first element of the docblock, the information tooltip must have

--- a/src/test/rustdoc-gui/code-sidebar-toggle.goml
+++ b/src/test/rustdoc-gui/code-sidebar-toggle.goml
@@ -1,3 +1,4 @@
+// This test checks that the source code pages sidebar toggle is working as expected.
 goto: file://|DOC_PATH|/test_docs/index.html
 click: ".srclink"
 wait-for: "#sidebar-toggle"

--- a/src/test/rustdoc-gui/escape-key.goml
+++ b/src/test/rustdoc-gui/escape-key.goml
@@ -1,3 +1,5 @@
+// This test ensures that the "Escape" shortcut is handled correctly based on the
+// current content displayed.
 goto: file://|DOC_PATH|/test_docs/index.html
 // First, we check that the search results are hidden when the Escape key is pressed.
 write: (".search-input", "test")

--- a/src/test/rustdoc-gui/font-weight.goml
+++ b/src/test/rustdoc-gui/font-weight.goml
@@ -1,5 +1,5 @@
-goto: file://|DOC_PATH|/lib2/struct.Foo.html
 // This test checks that the font weight is correctly applied.
+goto: file://|DOC_PATH|/lib2/struct.Foo.html
 assert-css: ("//*[@class='docblock item-decl']//a[text()='Alias']", {"font-weight": "400"})
 assert-css: (
     "//*[@class='structfield small-section-header']//a[text()='Alias']",

--- a/src/test/rustdoc-gui/huge-collection-of-constants.goml
+++ b/src/test/rustdoc-gui/huge-collection-of-constants.goml
@@ -1,6 +1,6 @@
-goto: file://|DOC_PATH|/test_docs/huge_amount_of_consts/index.html
-
 // Make sure that the last two entries are more than 12 pixels apart and not stacked on each other.
+
+goto: file://|DOC_PATH|/test_docs/huge_amount_of_consts/index.html
 
 compare-elements-position-near-false: (
     "//*[@class='item-table']//div[last()-1]",

--- a/src/test/rustdoc-gui/list_code_block.goml
+++ b/src/test/rustdoc-gui/list_code_block.goml
@@ -1,3 +1,4 @@
+// This test checks that code blocks in list are supported.
 goto: file://|DOC_PATH|/test_docs/index.html
 goto: ./fn.check_list_code_block.html
 assert: ("pre.rust.fn")

--- a/src/test/rustdoc-gui/search-filter.goml
+++ b/src/test/rustdoc-gui/search-filter.goml
@@ -1,3 +1,4 @@
+// Checks that the crate search filtering is handled correctly and changes the results.
 goto: file://|DOC_PATH|/test_docs/index.html
 show-text: true
 write: (".search-input", "test")

--- a/src/test/rustdoc-gui/search-result-colors.goml
+++ b/src/test/rustdoc-gui/search-result-colors.goml
@@ -1,3 +1,4 @@
+// Checks that the result colors are as expected.
 goto: file://|DOC_PATH|/test_docs/index.html
 // We set the theme so we're sure that the correct values will be used, whatever the computer
 // this test is running on.

--- a/src/test/rustdoc-gui/search-result-display.goml
+++ b/src/test/rustdoc-gui/search-result-display.goml
@@ -1,3 +1,4 @@
+// Checks that the search results have the expected width.
 goto: file://|DOC_PATH|/test_docs/index.html
 size: (900, 1000)
 write: (".search-input", "test")

--- a/src/test/rustdoc-gui/search-result-keyword.goml
+++ b/src/test/rustdoc-gui/search-result-keyword.goml
@@ -1,3 +1,4 @@
+// Checks that the "keyword" results have the expected text alongside them.
 goto: file://|DOC_PATH|/test_docs/index.html
 write: (".search-input", "CookieMonster")
 // Waiting for the search results to appear...

--- a/src/test/rustdoc-gui/search-tab-selection-if-current-is-empty.goml
+++ b/src/test/rustdoc-gui/search-tab-selection-if-current-is-empty.goml
@@ -1,3 +1,5 @@
+// Checks that the first non-empty search result tab is selected if the default/currently selected
+// one is empty.
 goto: file://|DOC_PATH|/test_docs/index.html
 write: (".search-input", "Foo")
 // Waiting for the search results to appear...

--- a/src/test/rustdoc-gui/sidebar.goml
+++ b/src/test/rustdoc-gui/sidebar.goml
@@ -1,3 +1,4 @@
+// Checks multiple things on the sidebar display (width of its elements, colors, etc).
 goto: file://|DOC_PATH|/test_docs/index.html
 show-text: true
 local-storage: {"rustdoc-theme": "light"}

--- a/src/test/rustdoc-gui/source-code-page.goml
+++ b/src/test/rustdoc-gui/source-code-page.goml
@@ -1,3 +1,4 @@
+// Checks that the interactions with the source code pages are workined as expected.
 goto: file://|DOC_PATH|/src/test_docs/lib.rs.html
 // Check that we can click on the line number.
 click: ".line-numbers > span:nth-child(4)" // This is the span for line 4.

--- a/src/test/rustdoc-gui/theme-change.goml
+++ b/src/test/rustdoc-gui/theme-change.goml
@@ -1,3 +1,4 @@
+// Ensures that the theme change is working as expected.
 goto: file://|DOC_PATH|/test_docs/index.html
 click: "#theme-picker"
 click: "#theme-choices > button:first-child"

--- a/src/test/rustdoc-gui/toggle-docs-mobile.goml
+++ b/src/test/rustdoc-gui/toggle-docs-mobile.goml
@@ -1,3 +1,5 @@
+// Checks that the documentation toggles on mobile have the correct position, style and work
+// as expected.
 goto: file://|DOC_PATH|/test_docs/struct.Foo.html
 size: (433, 600)
 assert-attribute: (".top-doc", {"open": ""})

--- a/src/test/rustdoc-gui/toggle-docs.goml
+++ b/src/test/rustdoc-gui/toggle-docs.goml
@@ -1,3 +1,4 @@
+// Checks that the documentation toggles have the correct position, style and work as expected.
 goto: file://|DOC_PATH|/test_docs/index.html
 assert-attribute: ("#main-content > details.top-doc", {"open": ""})
 assert-text: ("#toggle-all-docs", "[−]")

--- a/src/test/rustdoc-gui/trait-sidebar-item-order.goml
+++ b/src/test/rustdoc-gui/trait-sidebar-item-order.goml
@@ -1,3 +1,4 @@
+// Checks that the elements in the sidebar are alphabetically sorted.
 goto: file://|DOC_PATH|/test_docs/trait.AnotherOne.html
 assert-text: (".sidebar-links a:nth-of-type(1)", "another")
 assert-text: (".sidebar-links a:nth-of-type(2)", "func1")


### PR DESCRIPTION
Some GUI tests didn't have a global explanation about what they were testing. This fixes it.

r? @jsha 