### PR TITLE
rustdoc: remove dashed underline under main heading

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -150,7 +150,6 @@ h1.fqn {
 	display: flex;
 	flex-wrap: wrap;
 	justify-content: space-between;
-	border-bottom: 1px dashed #DDDDDD;
 	padding-bottom: 6px;
 	margin-bottom: 15px;
 }


### PR DESCRIPTION
This was removed in #92797 but accidentally re-introduced by a bad merge in #92861.

r? @camelid 