### PR TITLE
Suggest `as_mut` when `Pin<T>` is used after move

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
@@ -295,9 +295,9 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                                     err.span_suggestion_verbose(
                                         fn_call_span.shrink_to_lo(),
                                         &format!(
-                                        "consider calling `.{}()` to borrow the type's contents",
-                                        borrow_method
-                                    ),
+                                            "consider calling `.{}()` to borrow the type's contents",
+                                            borrow_method,
+                                        ),
                                         format!("{}().", borrow_method),
                                         Applicability::MachineApplicable,
                                     );

--- a/library/core/src/pin.rs
+++ b/library/core/src/pin.rs
@@ -402,6 +402,7 @@ use crate::ops::{CoerceUnsized, Deref, DerefMut, DispatchFromDyn, Receiver};
 // See <https://internals.rust-lang.org/t/unsoundness-in-pin/11311> for more details.
 #[stable(feature = "pin", since = "1.33.0")]
 #[lang = "pin"]
+#[rustc_diagnostic_item = "Pin"]
 #[fundamental]
 #[repr(transparent)]
 #[derive(Copy, Clone)]

--- a/src/test/ui/suggestions/pin-content-move.rs
+++ b/src/test/ui/suggestions/pin-content-move.rs
@@ -1,0 +1,23 @@
+use std::pin::Pin;
+
+struct Foo;
+
+impl Foo {
+    fn foo(self: Pin<&mut Self>) {}
+}
+
+fn main() {
+    let mut foo = Foo;
+    let foo = Pin::new(&mut foo);
+    foo.foo();
+    //~^ HELP consider calling `.as_mut()` to borrow the type's contents
+    foo.foo();
+    //~^ ERROR use of moved value
+
+    let mut x = 1;
+    let mut x = Pin::new(&mut x);
+    x.get_mut();
+    //~^ HELP consider calling `.as_mut()` to borrow the type's contents
+    x.get_mut();
+    //~^ ERROR use of moved value
+}

--- a/src/test/ui/suggestions/pin-content-move.stderr
+++ b/src/test/ui/suggestions/pin-content-move.stderr
@@ -1,0 +1,45 @@
+error[E0382]: use of moved value: `foo`
+  --> $DIR/pin-content-move.rs:14:5
+   |
+LL |     let foo = Pin::new(&mut foo);
+   |         --- move occurs because `foo` has type `Pin<&mut Foo>`, which does not implement the `Copy` trait
+LL |     foo.foo();
+   |         ----- `foo` moved due to this method call
+LL |
+LL |     foo.foo();
+   |     ^^^ value used here after move
+   |
+note: this function takes ownership of the receiver `self`, which moves `foo`
+  --> $DIR/pin-content-move.rs:6:12
+   |
+LL |     fn foo(self: Pin<&mut Self>) {}
+   |            ^^^^
+help: consider calling `.as_mut()` to borrow the type's contents
+   |
+LL |     foo.as_mut().foo();
+   |         +++++++++
+
+error[E0382]: use of moved value: `x`
+  --> $DIR/pin-content-move.rs:21:5
+   |
+LL |     let mut x = Pin::new(&mut x);
+   |         ----- move occurs because `x` has type `Pin<&mut i32>`, which does not implement the `Copy` trait
+LL |     x.get_mut();
+   |       --------- `x` moved due to this method call
+LL |
+LL |     x.get_mut();
+   |     ^ value used here after move
+   |
+note: this function takes ownership of the receiver `self`, which moves `x`
+  --> $SRC_DIR/core/src/pin.rs:LL:COL
+   |
+LL |     pub const fn get_mut(self) -> &'a mut T
+   |                          ^^^^
+help: consider calling `.as_mut()` to borrow the type's contents
+   |
+LL |     x.as_mut().get_mut();
+   |       +++++++++
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0382`.


### PR DESCRIPTION
```rust
let foo = Pin::new(&mut foo);
foo.foo();
foo.foo();
```
```
help: consider calling `.as_mut()` to borrow the type's contents
   |
2  |     foo.as_mut().foo();
   |         +++++++++
```

Resolves https://github.com/rust-lang/rust/issues/65409