### PR TITLE
rustdoc: fix bump down typing search on Safari

### DIFF
--- a/src/librustdoc/html/templates/page.html
+++ b/src/librustdoc/html/templates/page.html
@@ -117,6 +117,7 @@
                     </div> {#- -#}
                     <form class="search-form"> {#- -#}
                         <div class="search-container"> {#- -#}
+                            <span></span> {#- This empty span is a hacky fix for Safari - See #93184 -#}
                             <input {# -#}
                                 class="search-input" {# -#}
                                 name="search" {# -#}


### PR DESCRIPTION
Fixes #93184.

For some reason, if the search input doesn't have a previous sibling, typing in the search box increases the search-container's size by about 5px on the bottom. Putting in a dummy sibling fixes it.

https://rustdoc.crud.net/jsha/fix-safari-bumpy-search/std/string/struct.String.html

r? @camelid 