### PR TITLE
Impl {Add,Sub,Mul,Div,Rem,BitXor,BitOr,BitAnd}Assign<$t> for Wrapping<$t> for rust 1.60.0

### DIFF
--- a/library/core/src/num/wrapping.rs
+++ b/library/core/src/num/wrapping.rs
@@ -239,7 +239,7 @@ macro_rules! wrapping_impl {
         }
         forward_ref_op_assign! { impl const AddAssign, add_assign for Wrapping<$t>, Wrapping<$t> }
 
-        #[stable(feature = "wrapping_int_assign_impl", since = "1.61.0")]
+        #[stable(feature = "wrapping_int_assign_impl", since = "1.60.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "90080")]
         impl const AddAssign<$t> for Wrapping<$t> {
             #[inline]
@@ -272,7 +272,7 @@ macro_rules! wrapping_impl {
         }
         forward_ref_op_assign! { impl const SubAssign, sub_assign for Wrapping<$t>, Wrapping<$t> }
 
-        #[stable(feature = "wrapping_int_assign_impl", since = "1.61.0")]
+        #[stable(feature = "wrapping_int_assign_impl", since = "1.60.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "90080")]
         impl const SubAssign<$t> for Wrapping<$t> {
             #[inline]
@@ -305,7 +305,7 @@ macro_rules! wrapping_impl {
         }
         forward_ref_op_assign! { impl const MulAssign, mul_assign for Wrapping<$t>, Wrapping<$t> }
 
-        #[stable(feature = "wrapping_int_assign_impl", since = "1.61.0")]
+        #[stable(feature = "wrapping_int_assign_impl", since = "1.60.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "90080")]
         impl const MulAssign<$t> for Wrapping<$t> {
             #[inline]
@@ -338,7 +338,7 @@ macro_rules! wrapping_impl {
         }
         forward_ref_op_assign! { impl const DivAssign, div_assign for Wrapping<$t>, Wrapping<$t> }
 
-        #[stable(feature = "wrapping_int_assign_impl", since = "1.61.0")]
+        #[stable(feature = "wrapping_int_assign_impl", since = "1.60.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "90080")]
         impl const DivAssign<$t> for Wrapping<$t> {
             #[inline]
@@ -371,7 +371,7 @@ macro_rules! wrapping_impl {
         }
         forward_ref_op_assign! { impl const RemAssign, rem_assign for Wrapping<$t>, Wrapping<$t> }
 
-        #[stable(feature = "wrapping_int_assign_impl", since = "1.61.0")]
+        #[stable(feature = "wrapping_int_assign_impl", since = "1.60.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "90080")]
         impl const RemAssign<$t> for Wrapping<$t> {
             #[inline]
@@ -417,7 +417,7 @@ macro_rules! wrapping_impl {
         }
         forward_ref_op_assign! { impl const BitXorAssign, bitxor_assign for Wrapping<$t>, Wrapping<$t> }
 
-        #[stable(feature = "wrapping_int_assign_impl", since = "1.61.0")]
+        #[stable(feature = "wrapping_int_assign_impl", since = "1.60.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "90080")]
         impl const BitXorAssign<$t> for Wrapping<$t> {
             #[inline]
@@ -450,7 +450,7 @@ macro_rules! wrapping_impl {
         }
         forward_ref_op_assign! { impl const BitOrAssign, bitor_assign for Wrapping<$t>, Wrapping<$t> }
 
-        #[stable(feature = "wrapping_int_assign_impl", since = "1.61.0")]
+        #[stable(feature = "wrapping_int_assign_impl", since = "1.60.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "90080")]
         impl const BitOrAssign<$t> for Wrapping<$t> {
             #[inline]
@@ -483,7 +483,7 @@ macro_rules! wrapping_impl {
         }
         forward_ref_op_assign! { impl const BitAndAssign, bitand_assign for Wrapping<$t>, Wrapping<$t> }
 
-        #[stable(feature = "wrapping_int_assign_impl", since = "1.61.0")]
+        #[stable(feature = "wrapping_int_assign_impl", since = "1.60.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "90080")]
         impl const BitAndAssign<$t> for Wrapping<$t> {
             #[inline]

--- a/library/core/src/num/wrapping.rs
+++ b/library/core/src/num/wrapping.rs
@@ -239,6 +239,16 @@ macro_rules! wrapping_impl {
         }
         forward_ref_op_assign! { impl const AddAssign, add_assign for Wrapping<$t>, Wrapping<$t> }
 
+        #[stable(feature = "wrapping_int_assign_impl", since = "1.61.0")]
+        #[rustc_const_unstable(feature = "const_ops", issue = "90080")]
+        impl const AddAssign<$t> for Wrapping<$t> {
+            #[inline]
+            fn add_assign(&mut self, other: $t) {
+                *self = *self + Wrapping(other);
+            }
+        }
+        forward_ref_op_assign! { impl const AddAssign, add_assign for Wrapping<$t>, $t }
+
         #[stable(feature = "rust1", since = "1.0.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "90080")]
         impl const Sub for Wrapping<$t> {
@@ -261,6 +271,16 @@ macro_rules! wrapping_impl {
             }
         }
         forward_ref_op_assign! { impl const SubAssign, sub_assign for Wrapping<$t>, Wrapping<$t> }
+
+        #[stable(feature = "wrapping_int_assign_impl", since = "1.61.0")]
+        #[rustc_const_unstable(feature = "const_ops", issue = "90080")]
+        impl const SubAssign<$t> for Wrapping<$t> {
+            #[inline]
+            fn sub_assign(&mut self, other: $t) {
+                *self = *self - Wrapping(other);
+            }
+        }
+        forward_ref_op_assign! { impl const SubAssign, sub_assign for Wrapping<$t>, $t }
 
         #[stable(feature = "rust1", since = "1.0.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "90080")]
@@ -285,6 +305,16 @@ macro_rules! wrapping_impl {
         }
         forward_ref_op_assign! { impl const MulAssign, mul_assign for Wrapping<$t>, Wrapping<$t> }
 
+        #[stable(feature = "wrapping_int_assign_impl", since = "1.61.0")]
+        #[rustc_const_unstable(feature = "const_ops", issue = "90080")]
+        impl const MulAssign<$t> for Wrapping<$t> {
+            #[inline]
+            fn mul_assign(&mut self, other: $t) {
+                *self = *self * Wrapping(other);
+            }
+        }
+        forward_ref_op_assign! { impl const MulAssign, mul_assign for Wrapping<$t>, $t }
+
         #[stable(feature = "wrapping_div", since = "1.3.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "90080")]
         impl const Div for Wrapping<$t> {
@@ -308,6 +338,16 @@ macro_rules! wrapping_impl {
         }
         forward_ref_op_assign! { impl const DivAssign, div_assign for Wrapping<$t>, Wrapping<$t> }
 
+        #[stable(feature = "wrapping_int_assign_impl", since = "1.61.0")]
+        #[rustc_const_unstable(feature = "const_ops", issue = "90080")]
+        impl const DivAssign<$t> for Wrapping<$t> {
+            #[inline]
+            fn div_assign(&mut self, other: $t) {
+                *self = *self / Wrapping(other);
+            }
+        }
+        forward_ref_op_assign! { impl const DivAssign, div_assign for Wrapping<$t>, $t }
+
         #[stable(feature = "wrapping_impls", since = "1.7.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "90080")]
         impl const Rem for Wrapping<$t> {
@@ -330,6 +370,16 @@ macro_rules! wrapping_impl {
             }
         }
         forward_ref_op_assign! { impl const RemAssign, rem_assign for Wrapping<$t>, Wrapping<$t> }
+
+        #[stable(feature = "wrapping_int_assign_impl", since = "1.61.0")]
+        #[rustc_const_unstable(feature = "const_ops", issue = "90080")]
+        impl const RemAssign<$t> for Wrapping<$t> {
+            #[inline]
+            fn rem_assign(&mut self, other: $t) {
+                *self = *self % Wrapping(other);
+            }
+        }
+        forward_ref_op_assign! { impl const RemAssign, rem_assign for Wrapping<$t>, $t }
 
         #[stable(feature = "rust1", since = "1.0.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "90080")]
@@ -367,6 +417,16 @@ macro_rules! wrapping_impl {
         }
         forward_ref_op_assign! { impl const BitXorAssign, bitxor_assign for Wrapping<$t>, Wrapping<$t> }
 
+        #[stable(feature = "wrapping_int_assign_impl", since = "1.61.0")]
+        #[rustc_const_unstable(feature = "const_ops", issue = "90080")]
+        impl const BitXorAssign<$t> for Wrapping<$t> {
+            #[inline]
+            fn bitxor_assign(&mut self, other: $t) {
+                *self = *self ^ Wrapping(other);
+            }
+        }
+        forward_ref_op_assign! { impl const BitXorAssign, bitxor_assign for Wrapping<$t>, $t }
+
         #[stable(feature = "rust1", since = "1.0.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "90080")]
         impl const BitOr for Wrapping<$t> {
@@ -390,6 +450,16 @@ macro_rules! wrapping_impl {
         }
         forward_ref_op_assign! { impl const BitOrAssign, bitor_assign for Wrapping<$t>, Wrapping<$t> }
 
+        #[stable(feature = "wrapping_int_assign_impl", since = "1.61.0")]
+        #[rustc_const_unstable(feature = "const_ops", issue = "90080")]
+        impl const BitOrAssign<$t> for Wrapping<$t> {
+            #[inline]
+            fn bitor_assign(&mut self, other: $t) {
+                *self = *self | Wrapping(other);
+            }
+        }
+        forward_ref_op_assign! { impl const BitOrAssign, bitor_assign for Wrapping<$t>, $t }
+
         #[stable(feature = "rust1", since = "1.0.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "90080")]
         impl const BitAnd for Wrapping<$t> {
@@ -412,6 +482,16 @@ macro_rules! wrapping_impl {
             }
         }
         forward_ref_op_assign! { impl const BitAndAssign, bitand_assign for Wrapping<$t>, Wrapping<$t> }
+
+        #[stable(feature = "wrapping_int_assign_impl", since = "1.61.0")]
+        #[rustc_const_unstable(feature = "const_ops", issue = "90080")]
+        impl const BitAndAssign<$t> for Wrapping<$t> {
+            #[inline]
+            fn bitand_assign(&mut self, other: $t) {
+                *self = *self & Wrapping(other);
+            }
+        }
+        forward_ref_op_assign! { impl const BitAndAssign, bitand_assign for Wrapping<$t>, $t }
 
         #[stable(feature = "wrapping_neg", since = "1.10.0")]
         #[rustc_const_unstable(feature = "const_ops", issue = "90080")]


### PR DESCRIPTION
Tracking issue #93204

This is about adding basic integer operations to the `Wrapping` type:

```rust
let mut value = Wrapping(2u8);
value += 3u8;
value -= 1u8;
value *= 2u8;
value /= 2u8;
value %= 2u8;
value ^= 255u8;
value |= 123u8;
value &= 2u8;
```

Because this adds stable impls on a stable type, it runs into the following issue if an `#[unstable(...)]` attribute is used: 

```
an `#[unstable]` annotation here has no effect
note: see issue #55436 <https://github.com/rust-lang/rust/issues/55436> for more information
```

This means - if I understood this correctly - the new impls have to be stabilized instantly.
Which in turn means, this PR has to kick of an FCP on the tracking issue as well?


This impl is analog to 1c0dc1810d778bb6fea16aac02cafc5aa2e84b11 #92356 for the `Saturating` type @dtolnay  @Mark-Simulacrum 