### PR TITLE
Remove unneeded cursor pointer rule on mobile sidebar

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1868,7 +1868,6 @@ details.rustdoc-toggle[open] > summary.hideme::after {
 		position: sticky;
 		z-index: 10;
 		font-size: 2rem;
-		cursor: pointer;
 		height: 45px;
 		width: 100%;
 		left: 0;


### PR DESCRIPTION
Since it's on mobile, there isn't much point in this rule...

r? @jsha