### PR TITLE
Normalize field access types during borrowck

### DIFF
--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -758,6 +758,7 @@ impl<'a, 'b, 'tcx> TypeVerifier<'a, 'b, 'tcx> {
             },
             ProjectionElem::Field(field, fty) => {
                 let fty = self.sanitize_type(place, fty);
+                let fty = self.cx.normalize(fty, location);
                 match self.field_ty(place, base, field, location) {
                     Ok(ty) => {
                         let ty = self.cx.normalize(ty, location);

--- a/src/test/ui/generic-associated-types/issue-93141.rs
+++ b/src/test/ui/generic-associated-types/issue-93141.rs
@@ -1,0 +1,25 @@
+// check-pass
+
+#![feature(generic_associated_types)]
+
+pub trait Fooey: Sized {
+    type Context<'c> where Self: 'c;
+}
+
+pub struct Handle<E: Fooey>(Option<Box<dyn for<'c> Fn(&mut E::Context<'c>)>>);
+
+fn tuple<T>() -> (Option<T>,) { (Option::None,) }
+
+pub struct FooImpl {}
+impl Fooey for FooImpl {
+    type Context<'c> = &'c ();
+}
+
+impl FooImpl {
+    pub fn fail1() -> Handle<Self> {
+        let (tx,) = tuple();
+        Handle(tx)
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
I think a normalize was just left out here, since we normalize analogously throughout this file.

Fixes #93141 