### PR TITLE
Liberate late bound regions when collecting GAT substs in wfcheck

### DIFF
--- a/src/test/ui/generic-associated-types/issue-92954.rs
+++ b/src/test/ui/generic-associated-types/issue-92954.rs
@@ -1,0 +1,10 @@
+// check-pass
+
+#![feature(generic_associated_types)]
+
+pub trait Foo {
+    type Assoc<'c>;
+    fn function() -> for<'x> fn(Self::Assoc<'x>);
+}
+
+fn main() {}


### PR DESCRIPTION
The issue here is that the [`GATSubstCollector`](https://github.com/rust-lang/rust/blob/master/compiler/rustc_typeck/src/check/wfcheck.rs#L604) does not currently do anything wrt `Binder`s, so the GAT substs it copies out have escaping late bound regions when it walks through types like `for<'x> fn() -> Self::Gat<'x>`. 

I made that visitor call `liberate_late_bound_regions`, not sure if that's the right thing here or we need to do something else to replace these bound vars with placeholders. I'm not familiar with other code doing anything similar.. But the issue is indeed no longer ICEing.

Fixes #92954

r? @jackh726 
since you last touched this code, feel free to reassign