### PR TITLE
adjust sidebar link brightness

### DIFF
--- a/src/librustdoc/html/static/css/themes/ayu.css
+++ b/src/librustdoc/html/static/css/themes/ayu.css
@@ -221,6 +221,9 @@ pre.rust a,
 body.source .example-wrap pre.rust a {
 	background: #333;
 }
+.sidebar a {
+	color: #53b1db;
+}
 
 details.rustdoc-toggle > summary.hideme > span,
 details.rustdoc-toggle > summary::before,

--- a/src/librustdoc/html/static/css/themes/ayu.css
+++ b/src/librustdoc/html/static/css/themes/ayu.css
@@ -191,6 +191,10 @@ pre, .rustdoc.source .example-wrap {
 	color: #a37acc;
 }
 
+.sidebar a { color: #53b1db; }
+.sidebar a.current.type { color: #53b1db; }
+.sidebar a.current.associatedtype { color: #53b1db; }
+
 pre.rust .comment { color: #788797; }
 pre.rust .doccomment { color: #a1ac88; }
 
@@ -495,6 +499,25 @@ a.result-constant:focus,
 a.result-static:focus {}
 a.result-primitive:focus {}
 a.result-keyword:focus {}
+
+.sidebar a.current.enum {}
+.sidebar a.current.struct {}
+.sidebar a.current.foreigntype {}
+.sidebar a.current.attr,
+.sidebar a.current.derive,
+.sidebar a.current.macro {}
+.sidebar a.current.union {}
+.sidebar a.current.constant
+.sidebar a.current.static {}
+.sidebar a.current.primitive {}
+.sidebar a.current.externcrate
+.sidebar a.current.mod {}
+.sidebar a.current.trait {}
+.sidebar a.current.traitalias {}
+.sidebar a.current.fn,
+.sidebar a.current.method,
+.sidebar a.current.tymethod {}
+.sidebar a.current.keyword {}
 
 @media (max-width: 700px) {
 	.sidebar-menu {

--- a/src/librustdoc/html/static/css/themes/ayu.css
+++ b/src/librustdoc/html/static/css/themes/ayu.css
@@ -225,9 +225,6 @@ pre.rust a,
 body.source .example-wrap pre.rust a {
 	background: #333;
 }
-.sidebar a {
-	color: #53b1db;
-}
 
 details.rustdoc-toggle > summary.hideme > span,
 details.rustdoc-toggle > summary::before,

--- a/src/librustdoc/html/static/css/themes/dark.css
+++ b/src/librustdoc/html/static/css/themes/dark.css
@@ -148,6 +148,28 @@ a.result-keyword:focus { background-color: #884719; }
 .content .fnname{ color: #2BAB63; }
 .content span.keyword, .content a.keyword, .block a.current.keyword { color: #D2991D; }
 
+.sidebar a { color: #fdbf35; }
+.sidebar a.current.enum { color: #12ece2; }
+.sidebar a.current.struct { color: #12ece2; }
+.sidebar a.current.type { color: #12ece2; }
+.sidebar a.current.associatedtype { color: #fdbf35; }
+.sidebar a.current.foreigntype { color: #12ece2; }
+.sidebar a.current.attr,
+.sidebar a.current.derive,
+.sidebar a.current.macro { color: #0be900; }
+.sidebar a.current.union { color: #12ece2; }
+.sidebar a.current.constant
+.sidebar a.current.static { color: #fdbf35; }
+.sidebar a.current.primitive { color: #12ece2; }
+.sidebar a.current.externcrate
+.sidebar a.current.mod { color: #fdbf35; }
+.sidebar a.current.trait { color: #cca7ff; }
+.sidebar a.current.traitalias { color: #cca7ff; }
+.sidebar a.current.fn,
+.sidebar a.current.method,
+.sidebar a.current.tymethod { color: #32d479; }
+.sidebar a.current.keyword { color: #fdbf35; }
+
 pre.rust .comment { color: #8d8d8b; }
 pre.rust .doccomment { color: #8ca375; }
 
@@ -181,9 +203,6 @@ a.test-arrow {
 }
 body.source .example-wrap pre.rust a {
 	background: #333;
-}
-.sidebar a {
-	color: #fdbf35;
 }
 
 details.rustdoc-toggle > summary.hideme > span,

--- a/src/librustdoc/html/static/css/themes/dark.css
+++ b/src/librustdoc/html/static/css/themes/dark.css
@@ -182,6 +182,9 @@ a.test-arrow {
 body.source .example-wrap pre.rust a {
 	background: #333;
 }
+.sidebar a {
+	color: #fdbf35;
+}
 
 details.rustdoc-toggle > summary.hideme > span,
 details.rustdoc-toggle > summary::before,

--- a/src/librustdoc/html/static/css/themes/light.css
+++ b/src/librustdoc/html/static/css/themes/light.css
@@ -148,6 +148,28 @@ a.result-keyword:focus { background-color: #afc6e4; }
 .content .fnname { color: #AD7C37; }
 .content span.keyword, .content a.keyword, .block a.current.keyword { color: #3873AD; }
 
+.sidebar a { color: #356da4; }
+.sidebar a.current.enum { color: #a63283; }
+.sidebar a.current.struct { color: #a63283; }
+.sidebar a.current.type { color: #a63283; }
+.sidebar a.current.associatedtype { color: #356da4; }
+.sidebar a.current.foreigntype { color: #356da4; }
+.sidebar a.current.attr,
+.sidebar a.current.derive,
+.sidebar a.current.macro { color: #067901; }
+.sidebar a.current.union { color: #a63283; }
+.sidebar a.current.constant
+.sidebar a.current.static { color: #356da4; }
+.sidebar a.current.primitive { color: #a63283; }
+.sidebar a.current.externcrate
+.sidebar a.current.mod { color: #356da4; }
+.sidebar a.current.trait { color: #6849c3; }
+.sidebar a.current.traitalias { color: #4b349e; }
+.sidebar a.current.fn,
+.sidebar a.current.method,
+.sidebar a.current.tymethod { color: #32d479; }
+.sidebar a.current.keyword { color: #356da4; }
+
 nav.main .current {
 	border-top-color: #000;
 	border-bottom-color: #000;

--- a/src/librustdoc/html/static/css/themes/light.css
+++ b/src/librustdoc/html/static/css/themes/light.css
@@ -201,9 +201,6 @@ a.test-arrow {
 body.source .example-wrap pre.rust a {
 	background: #eee;
 }
-.sidebar a {
-	color: #356da4;
-}
 
 details.rustdoc-toggle > summary.hideme > span,
 details.rustdoc-toggle > summary::before,

--- a/src/librustdoc/html/static/css/themes/light.css
+++ b/src/librustdoc/html/static/css/themes/light.css
@@ -179,6 +179,9 @@ a.test-arrow {
 body.source .example-wrap pre.rust a {
 	background: #eee;
 }
+.sidebar a {
+	color: #356da4;
+}
 
 details.rustdoc-toggle > summary.hideme > span,
 details.rustdoc-toggle > summary::before,

--- a/src/test/rustdoc-gui/anchors.goml
+++ b/src/test/rustdoc-gui/anchors.goml
@@ -20,7 +20,7 @@ assert-css: (".srclink", {"text-decoration": "underline solid rgb(56, 115, 173)"
 
 assert-css: ("#top-doc-prose-title", {"color": "rgb(0, 0, 0)"})
 
-assert-css: (".sidebar a", {"color": "rgb(56, 115, 173)"})
+assert-css: (".sidebar a", {"color": "rgb(53, 109, 164)"})
 assert-css: (".in-band a", {"color": "rgb(0, 0, 0)"})
 
 // We move the cursor over the "Implementations" title so the anchor is displayed.

--- a/src/test/rustdoc-gui/sidebar.goml
+++ b/src/test/rustdoc-gui/sidebar.goml
@@ -9,7 +9,7 @@ assert-text: (".sidebar > .location", "Crate test_docs")
 // In modules, we only have one "location" element.
 assert-count: (".sidebar .location", 1)
 assert-text: ("#all-types", "All Items")
-assert-css: ("#all-types", {"color": "rgb(56, 115, 173)"})
+assert-css: ("#all-types", {"color": "rgb(53, 109, 164)"})
 // We check that we have the crates list and that the "current" on is "test_docs".
 assert-text: (".sidebar-elems .crate > ul > li > a.current", "test_docs")
 // And we're also supposed to have the list of items in the current module.
@@ -38,7 +38,7 @@ assert-property: ("html", {"scrollTop": "0"})
 
 // We now go back to the crate page to click on the "lib2" crate link.
 goto: file://|DOC_PATH|/test_docs/index.html
-assert-css: (".sidebar-elems .crate > ul > li:first-child > a", {"color": "rgb(56, 115, 173)"})
+assert-css: (".sidebar-elems .crate > ul > li:first-child > a", {"color": "rgb(53, 109, 164)"})
 click: ".sidebar-elems .crate > ul > li:first-child > a"
 
 // PAGE: lib2/index.html


### PR DESCRIPTION
Fairly simple change. I've taken the existing link colour and main body background colours, and made sure that the sidebar+link contrast is the same.

ayu:
- [main content contrast](https://colourcontrast.cc/0f1419/39afd7) - 7.31
- [current sidebar contrast](https://colourcontrast.cc/14191f/39afd7) - 6.97
- [new sidebar contrast](https://colourcontrast.cc/14191f/56b1d9) - 7.30

dark:
- [main content contrast](https://colourcontrast.cc/353535/d2991d) - 4.86
- [current sidebar contrast](https://colourcontrast.cc/14191f/d2991d) - 3.19
- [new sidebar contrast](https://colourcontrast.cc/14191f/fdbf35) - 4.87

light:
- [main content contrast](https://colourcontrast.cc/ffffff/3873ad) - 4.97
- [current sidebar contrast](https://colourcontrast.cc/f5f5f5/3873ad) - 4.56
- [new sidebar contrast](https://colourcontrast.cc/f5f5f5/356da4) - 4.97