### PR TITLE
Fix brief appearance of rust logo in the sidebar

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -398,7 +398,7 @@ nav.sub {
 }
 
 .source .sidebar > *:not(:first-child) {
-	transition: opacity 0.5s, visibility 0.2s;
+	transition: opacity 0.5s;
 	opacity: 0;
 	visibility: hidden;
 }


### PR DESCRIPTION
Part of #91374.

I simply removed the CSS animation on the visibility, which now makes it all appear at once. I didn't change the CSS animation on the width though, which gives:

https://user-images.githubusercontent.com/3050060/150689595-067a6e00-9875-40c8-9d8a-1e3031dbcaba.mp4

cc @camelid 

r? @jsha 