### PR TITLE
Use TrustedRandomAccess for loop desugaring

### DIFF
--- a/compiler/rustc_hir/src/lang_items.rs
+++ b/compiler/rustc_hir/src/lang_items.rs
@@ -314,8 +314,10 @@ language_item_table! {
     ControlFlowBreak,        sym::Break,               cf_break_variant,           Target::Variant,        GenericRequirement::None;
 
     IntoFutureIntoFuture,    sym::into_future,         into_future_fn,             Target::Method(MethodKind::Trait { body: false }), GenericRequirement::None;
-    IntoIterIntoIter,        sym::into_iter,           into_iter_fn,               Target::Method(MethodKind::Trait { body: false }), GenericRequirement::None;
-    IteratorNext,            sym::next,                next_fn,                    Target::Method(MethodKind::Trait { body: false}), GenericRequirement::None;
+
+    IntoIterIntoIter,        sym::into_iter,           into_iter_fn,               Target::Method(MethodKind::Inherent), GenericRequirement::None;
+    IteratorNext,            sym::next,                next_fn,                    Target::Method(MethodKind::Inherent), GenericRequirement::None;
+
 
     PinNewUnchecked,         sym::new_unchecked,       new_unchecked_fn,           Target::Method(MethodKind::Inherent), GenericRequirement::None;
 

--- a/library/alloc/src/collections/vec_deque/iter.rs
+++ b/library/alloc/src/collections/vec_deque/iter.rs
@@ -206,8 +206,6 @@ unsafe impl<T> TrustedLen for Iter<'_, T> {}
 #[doc(hidden)]
 #[unstable(feature = "trusted_random_access", issue = "none")]
 unsafe impl<T> TrustedRandomAccess for Iter<'_, T> {
-    const NEEDS_CLEANUP: bool = false;
-
     fn cleanup(&mut self, num: usize, forward: bool) {
         if forward {
             let _ = self.advance_by(num);

--- a/library/alloc/src/collections/vec_deque/iter.rs
+++ b/library/alloc/src/collections/vec_deque/iter.rs
@@ -206,11 +206,11 @@ unsafe impl<T> TrustedLen for Iter<'_, T> {}
 #[doc(hidden)]
 #[unstable(feature = "trusted_random_access", issue = "none")]
 unsafe impl<T> TrustedRandomAccess for Iter<'_, T> {
-    fn cleanup(&mut self, num: usize, forward: bool) {
-        if forward {
-            let _ = self.advance_by(num);
-        } else {
-            let _ = self.advance_back_by(num);
-        }
+    fn cleanup_front(&mut self, num: usize) {
+        let _ = self.advance_by(num);
+    }
+
+    fn cleanup_back(&mut self, num: usize) {
+        let _ = self.advance_back_by(num);
     }
 }

--- a/library/alloc/src/collections/vec_deque/iter.rs
+++ b/library/alloc/src/collections/vec_deque/iter.rs
@@ -210,7 +210,6 @@ unsafe impl<T> TrustedRandomAccess for Iter<'_, T> {}
 #[doc(hidden)]
 #[unstable(feature = "trusted_random_access", issue = "none")]
 unsafe impl<T> TrustedRandomAccessNoCoerce for Iter<'_, T> {
-    const MAY_HAVE_SIDE_EFFECT: bool = false;
     const NEEDS_CLEANUP: bool = false;
 
     fn cleanup(&mut self, num: usize, forward: bool) {

--- a/library/alloc/src/collections/vec_deque/iter.rs
+++ b/library/alloc/src/collections/vec_deque/iter.rs
@@ -211,4 +211,13 @@ unsafe impl<T> TrustedRandomAccess for Iter<'_, T> {}
 #[unstable(feature = "trusted_random_access", issue = "none")]
 unsafe impl<T> TrustedRandomAccessNoCoerce for Iter<'_, T> {
     const MAY_HAVE_SIDE_EFFECT: bool = false;
+    const NEEDS_CLEANUP: bool = false;
+
+    fn cleanup(&mut self, num: usize, forward: bool) {
+        if forward {
+            let _ = self.advance_by(num);
+        } else {
+            let _ = self.advance_back_by(num);
+        }
+    }
 }

--- a/library/alloc/src/collections/vec_deque/iter.rs
+++ b/library/alloc/src/collections/vec_deque/iter.rs
@@ -1,5 +1,5 @@
 use core::fmt;
-use core::iter::{FusedIterator, TrustedLen, TrustedRandomAccess, TrustedRandomAccessNoCoerce};
+use core::iter::{FusedIterator, TrustedLen, TrustedRandomAccess};
 use core::mem::MaybeUninit;
 use core::ops::Try;
 
@@ -205,11 +205,7 @@ unsafe impl<T> TrustedLen for Iter<'_, T> {}
 
 #[doc(hidden)]
 #[unstable(feature = "trusted_random_access", issue = "none")]
-unsafe impl<T> TrustedRandomAccess for Iter<'_, T> {}
-
-#[doc(hidden)]
-#[unstable(feature = "trusted_random_access", issue = "none")]
-unsafe impl<T> TrustedRandomAccessNoCoerce for Iter<'_, T> {
+unsafe impl<T> TrustedRandomAccess for Iter<'_, T> {
     const NEEDS_CLEANUP: bool = false;
 
     fn cleanup(&mut self, num: usize, forward: bool) {

--- a/library/alloc/src/collections/vec_deque/iter_mut.rs
+++ b/library/alloc/src/collections/vec_deque/iter_mut.rs
@@ -155,8 +155,6 @@ unsafe impl<T> TrustedLen for IterMut<'_, T> {}
 #[doc(hidden)]
 #[unstable(feature = "trusted_random_access", issue = "none")]
 unsafe impl<T> TrustedRandomAccess for IterMut<'_, T> {
-    const NEEDS_CLEANUP: bool = false;
-
     fn cleanup(&mut self, num: usize, forward: bool) {
         if forward {
             let _ = self.advance_by(num);

--- a/library/alloc/src/collections/vec_deque/iter_mut.rs
+++ b/library/alloc/src/collections/vec_deque/iter_mut.rs
@@ -1,5 +1,5 @@
 use core::fmt;
-use core::iter::{FusedIterator, TrustedLen, TrustedRandomAccess, TrustedRandomAccessNoCoerce};
+use core::iter::{FusedIterator, TrustedLen, TrustedRandomAccess};
 use core::marker::PhantomData;
 
 use super::{count, wrap_index, RingSlices};
@@ -154,11 +154,7 @@ unsafe impl<T> TrustedLen for IterMut<'_, T> {}
 
 #[doc(hidden)]
 #[unstable(feature = "trusted_random_access", issue = "none")]
-unsafe impl<T> TrustedRandomAccess for IterMut<'_, T> {}
-
-#[doc(hidden)]
-#[unstable(feature = "trusted_random_access", issue = "none")]
-unsafe impl<T> TrustedRandomAccessNoCoerce for IterMut<'_, T> {
+unsafe impl<T> TrustedRandomAccess for IterMut<'_, T> {
     const NEEDS_CLEANUP: bool = false;
 
     fn cleanup(&mut self, num: usize, forward: bool) {

--- a/library/alloc/src/collections/vec_deque/iter_mut.rs
+++ b/library/alloc/src/collections/vec_deque/iter_mut.rs
@@ -160,4 +160,13 @@ unsafe impl<T> TrustedRandomAccess for IterMut<'_, T> {}
 #[unstable(feature = "trusted_random_access", issue = "none")]
 unsafe impl<T> TrustedRandomAccessNoCoerce for IterMut<'_, T> {
     const MAY_HAVE_SIDE_EFFECT: bool = false;
+    const NEEDS_CLEANUP: bool = false;
+
+    fn cleanup(&mut self, num: usize, forward: bool) {
+        if forward {
+            let _ = self.advance_by(num);
+        } else {
+            let _ = self.advance_back_by(num);
+        }
+    }
 }

--- a/library/alloc/src/collections/vec_deque/iter_mut.rs
+++ b/library/alloc/src/collections/vec_deque/iter_mut.rs
@@ -159,7 +159,6 @@ unsafe impl<T> TrustedRandomAccess for IterMut<'_, T> {}
 #[doc(hidden)]
 #[unstable(feature = "trusted_random_access", issue = "none")]
 unsafe impl<T> TrustedRandomAccessNoCoerce for IterMut<'_, T> {
-    const MAY_HAVE_SIDE_EFFECT: bool = false;
     const NEEDS_CLEANUP: bool = false;
 
     fn cleanup(&mut self, num: usize, forward: bool) {

--- a/library/alloc/src/collections/vec_deque/iter_mut.rs
+++ b/library/alloc/src/collections/vec_deque/iter_mut.rs
@@ -155,11 +155,11 @@ unsafe impl<T> TrustedLen for IterMut<'_, T> {}
 #[doc(hidden)]
 #[unstable(feature = "trusted_random_access", issue = "none")]
 unsafe impl<T> TrustedRandomAccess for IterMut<'_, T> {
-    fn cleanup(&mut self, num: usize, forward: bool) {
-        if forward {
-            let _ = self.advance_by(num);
-        } else {
-            let _ = self.advance_back_by(num);
-        }
+    fn cleanup_front(&mut self, num: usize) {
+        let _ = self.advance_by(num);
+    }
+
+    fn cleanup_back(&mut self, num: usize) {
+        let _ = self.advance_back_by(num);
     }
 }

--- a/library/alloc/src/vec/in_place_collect.rs
+++ b/library/alloc/src/vec/in_place_collect.rs
@@ -275,6 +275,9 @@ where
                 drop_guard.dst = dst.add(1);
             }
         }
+        // FIXME: this should run the TrustedRandomAccess cleanup code.
+        //  currently not running it is ok because IntoIter only implements TRA for Copy types
+        //  but if we relax that the cleanup will be needed
         mem::forget(drop_guard);
         len
     }

--- a/library/alloc/src/vec/into_iter.rs
+++ b/library/alloc/src/vec/into_iter.rs
@@ -4,7 +4,10 @@ use crate::alloc::{Allocator, Global};
 use crate::raw_vec::RawVec;
 use core::fmt;
 use core::intrinsics::arith_offset;
-use core::iter::{FusedIterator, InPlaceIterable, SourceIter, TrustedLen, TrustedRandomAccess};
+use core::iter::{
+    FusedIterator, InPlaceIterable, SourceIter, TrustedLen, TrustedRandomAccess,
+    TrustedRandomAccessNeedsCleanup,
+};
 use core::marker::PhantomData;
 use core::mem::{self, ManuallyDrop};
 use core::ops::Deref;
@@ -286,8 +289,6 @@ unsafe impl<T, A: Allocator> TrustedRandomAccess for IntoIter<T, A>
 where
     T: NonDrop,
 {
-    const NEEDS_CLEANUP: bool = true;
-
     fn cleanup(&mut self, num: usize, forward: bool) {
         if forward {
             if mem::size_of::<T>() == 0 {
@@ -312,6 +313,10 @@ where
         }
     }
 }
+
+#[doc(hidden)]
+#[unstable(issue = "none", feature = "std_internals")]
+unsafe impl<T, A: Allocator> TrustedRandomAccessNeedsCleanup for IntoIter<T, A> where T: NonDrop {}
 
 #[cfg(not(no_global_oom_handling))]
 #[stable(feature = "vec_into_iter_clone", since = "1.8.0")]

--- a/library/alloc/src/vec/into_iter.rs
+++ b/library/alloc/src/vec/into_iter.rs
@@ -4,9 +4,7 @@ use crate::alloc::{Allocator, Global};
 use crate::raw_vec::RawVec;
 use core::fmt;
 use core::intrinsics::arith_offset;
-use core::iter::{
-    FusedIterator, InPlaceIterable, SourceIter, TrustedLen, TrustedRandomAccessNoCoerce,
-};
+use core::iter::{FusedIterator, InPlaceIterable, SourceIter, TrustedLen, TrustedRandomAccess};
 use core::marker::PhantomData;
 use core::mem::{self, ManuallyDrop};
 use core::ops::Deref;
@@ -200,7 +198,7 @@ impl<T, A: Allocator> Iterator for IntoIter<T, A> {
     #[doc(hidden)]
     unsafe fn __iterator_get_unchecked(&mut self, i: usize) -> Self::Item
     where
-        Self: TrustedRandomAccessNoCoerce,
+        Self: TrustedRandomAccess,
     {
         // SAFETY: the caller must guarantee that `i` is in bounds of the
         // `Vec<T>`, so `i` cannot overflow an `isize`, and the `self.ptr.add(i)`
@@ -284,9 +282,7 @@ impl<T: Copy> NonDrop for T {}
 
 #[doc(hidden)]
 #[unstable(issue = "none", feature = "std_internals")]
-// TrustedRandomAccess (without NoCoerce) must not be implemented because
-// subtypes/supertypes of `T` might not be `NonDrop`
-unsafe impl<T, A: Allocator> TrustedRandomAccessNoCoerce for IntoIter<T, A>
+unsafe impl<T, A: Allocator> TrustedRandomAccess for IntoIter<T, A>
 where
     T: NonDrop,
 {

--- a/library/alloc/src/vec/into_iter.rs
+++ b/library/alloc/src/vec/into_iter.rs
@@ -290,7 +290,6 @@ unsafe impl<T, A: Allocator> TrustedRandomAccessNoCoerce for IntoIter<T, A>
 where
     T: NonDrop,
 {
-    const MAY_HAVE_SIDE_EFFECT: bool = false;
     const NEEDS_CLEANUP: bool = true;
 
     fn cleanup(&mut self, num: usize, forward: bool) {

--- a/library/core/benches/iter.rs
+++ b/library/core/benches/iter.rs
@@ -367,3 +367,27 @@ fn bench_partial_cmp(b: &mut Bencher) {
 fn bench_lt(b: &mut Bencher) {
     b.iter(|| (0..100000).map(black_box).lt((0..100000).map(black_box)))
 }
+
+#[bench]
+fn bench_trusted_random_access_adapters(b: &mut Bencher) {
+    let vec1: Vec<_> = (0usize..100000).collect();
+    let vec2 = black_box(vec1.clone());
+    b.iter(|| {
+        let mut iter = vec1
+            .iter()
+            .copied()
+            .enumerate()
+            .map(|(idx, e)| idx.wrapping_add(e))
+            .zip(vec2.iter().copied())
+            .map(|(a, b)| a.wrapping_add(b))
+            .fuse();
+        let mut acc = 0;
+        let size = iter.size();
+        for i in 0..size {
+            // SAFETY: TRA requirements are satisfied by 0..size iteration and then dropping the
+            // iterator.
+            acc += unsafe { iter.__iterator_get_unchecked(i) };
+        }
+        acc
+    })
+}

--- a/library/core/benches/lib.rs
+++ b/library/core/benches/lib.rs
@@ -3,6 +3,7 @@
 #![feature(flt2dec)]
 #![feature(int_log)]
 #![feature(test)]
+#![feature(trusted_random_access)]
 
 extern crate test;
 

--- a/library/core/src/iter/adapters/cloned.rs
+++ b/library/core/src/iter/adapters/cloned.rs
@@ -1,5 +1,8 @@
 use crate::iter::traits::trusted_random_access::try_get_unchecked;
-use crate::iter::traits::TrustedRandomAccess;
+use crate::iter::traits::{
+    TrustedRandomAccess, TrustedRandomAccessNeedsCleanup, TrustedRandomAccessNeedsForwardSetup,
+    TrustedRandomAccessNeedsReverseSetup,
+};
 use crate::iter::{FusedIterator, TrustedLen};
 use crate::ops::Try;
 
@@ -126,12 +129,29 @@ unsafe impl<I> TrustedRandomAccess for Cloned<I>
 where
     I: TrustedRandomAccess,
 {
-    const NEEDS_CLEANUP: bool = I::NEEDS_CLEANUP;
-
     #[inline]
     fn cleanup(&mut self, num: usize, forward: bool) {
         self.it.cleanup(num, forward);
     }
+}
+
+#[doc(hidden)]
+#[unstable(feature = "trusted_random_access", issue = "none")]
+unsafe impl<I> TrustedRandomAccessNeedsCleanup for Cloned<I> where I: TrustedRandomAccessNeedsCleanup
+{}
+
+#[doc(hidden)]
+#[unstable(feature = "trusted_random_access", issue = "none")]
+unsafe impl<I> TrustedRandomAccessNeedsForwardSetup for Cloned<I> where
+    I: TrustedRandomAccessNeedsForwardSetup
+{
+}
+
+#[doc(hidden)]
+#[unstable(feature = "trusted_random_access", issue = "none")]
+unsafe impl<I> TrustedRandomAccessNeedsReverseSetup for Cloned<I> where
+    I: TrustedRandomAccessNeedsReverseSetup
+{
 }
 
 #[unstable(feature = "trusted_len", issue = "37572")]

--- a/library/core/src/iter/adapters/cloned.rs
+++ b/library/core/src/iter/adapters/cloned.rs
@@ -132,6 +132,13 @@ where
     I: TrustedRandomAccessNoCoerce,
 {
     const MAY_HAVE_SIDE_EFFECT: bool = true;
+
+    const NEEDS_CLEANUP: bool = I::NEEDS_CLEANUP;
+
+    #[inline]
+    fn cleanup(&mut self, num: usize, forward: bool) {
+        self.it.cleanup(num, forward);
+    }
 }
 
 #[unstable(feature = "trusted_len", issue = "37572")]

--- a/library/core/src/iter/adapters/cloned.rs
+++ b/library/core/src/iter/adapters/cloned.rs
@@ -130,8 +130,13 @@ where
     I: TrustedRandomAccess,
 {
     #[inline]
-    fn cleanup(&mut self, num: usize, forward: bool) {
-        self.it.cleanup(num, forward);
+    fn cleanup_front(&mut self, num: usize) {
+        self.it.cleanup_front(num);
+    }
+
+    #[inline]
+    fn cleanup_back(&mut self, num: usize) {
+        self.it.cleanup_back(num);
     }
 }
 

--- a/library/core/src/iter/adapters/cloned.rs
+++ b/library/core/src/iter/adapters/cloned.rs
@@ -1,6 +1,4 @@
-use crate::iter::adapters::{
-    zip::try_get_unchecked, TrustedRandomAccess, TrustedRandomAccessNoCoerce,
-};
+use crate::iter::adapters::{zip::try_get_unchecked, TrustedRandomAccess};
 use crate::iter::{FusedIterator, TrustedLen};
 use crate::ops::Try;
 
@@ -63,7 +61,7 @@ where
     #[doc(hidden)]
     unsafe fn __iterator_get_unchecked(&mut self, idx: usize) -> T
     where
-        Self: TrustedRandomAccessNoCoerce,
+        Self: TrustedRandomAccess,
     {
         // SAFETY: the caller must uphold the contract for
         // `Iterator::__iterator_get_unchecked`.
@@ -123,13 +121,9 @@ where
 
 #[doc(hidden)]
 #[unstable(feature = "trusted_random_access", issue = "none")]
-unsafe impl<I> TrustedRandomAccess for Cloned<I> where I: TrustedRandomAccess {}
-
-#[doc(hidden)]
-#[unstable(feature = "trusted_random_access", issue = "none")]
-unsafe impl<I> TrustedRandomAccessNoCoerce for Cloned<I>
+unsafe impl<I> TrustedRandomAccess for Cloned<I>
 where
-    I: TrustedRandomAccessNoCoerce,
+    I: TrustedRandomAccess,
 {
     const NEEDS_CLEANUP: bool = I::NEEDS_CLEANUP;
 

--- a/library/core/src/iter/adapters/cloned.rs
+++ b/library/core/src/iter/adapters/cloned.rs
@@ -131,8 +131,6 @@ unsafe impl<I> TrustedRandomAccessNoCoerce for Cloned<I>
 where
     I: TrustedRandomAccessNoCoerce,
 {
-    const MAY_HAVE_SIDE_EFFECT: bool = true;
-
     const NEEDS_CLEANUP: bool = I::NEEDS_CLEANUP;
 
     #[inline]

--- a/library/core/src/iter/adapters/cloned.rs
+++ b/library/core/src/iter/adapters/cloned.rs
@@ -1,4 +1,5 @@
-use crate::iter::adapters::{zip::try_get_unchecked, TrustedRandomAccess};
+use crate::iter::traits::trusted_random_access::try_get_unchecked;
+use crate::iter::traits::TrustedRandomAccess;
 use crate::iter::{FusedIterator, TrustedLen};
 use crate::ops::Try;
 

--- a/library/core/src/iter/adapters/copied.rs
+++ b/library/core/src/iter/adapters/copied.rs
@@ -1,5 +1,8 @@
 use crate::iter::traits::trusted_random_access::try_get_unchecked;
-use crate::iter::traits::TrustedRandomAccess;
+use crate::iter::traits::{
+    TrustedRandomAccess, TrustedRandomAccessNeedsCleanup, TrustedRandomAccessNeedsForwardSetup,
+    TrustedRandomAccessNeedsReverseSetup,
+};
 use crate::iter::{FusedIterator, TrustedLen};
 use crate::ops::Try;
 
@@ -152,12 +155,29 @@ unsafe impl<I> TrustedRandomAccess for Copied<I>
 where
     I: TrustedRandomAccess,
 {
-    const NEEDS_CLEANUP: bool = I::NEEDS_CLEANUP;
-
     #[inline]
     fn cleanup(&mut self, num: usize, forward: bool) {
         self.it.cleanup(num, forward);
     }
+}
+
+#[doc(hidden)]
+#[unstable(feature = "trusted_random_access", issue = "none")]
+unsafe impl<I> TrustedRandomAccessNeedsCleanup for Copied<I> where I: TrustedRandomAccessNeedsCleanup
+{}
+
+#[doc(hidden)]
+#[unstable(feature = "trusted_random_access", issue = "none")]
+unsafe impl<I> TrustedRandomAccessNeedsForwardSetup for Copied<I> where
+    I: TrustedRandomAccessNeedsForwardSetup
+{
+}
+
+#[doc(hidden)]
+#[unstable(feature = "trusted_random_access", issue = "none")]
+unsafe impl<I> TrustedRandomAccessNeedsReverseSetup for Copied<I> where
+    I: TrustedRandomAccessNeedsReverseSetup
+{
 }
 
 #[stable(feature = "iter_copied", since = "1.36.0")]

--- a/library/core/src/iter/adapters/copied.rs
+++ b/library/core/src/iter/adapters/copied.rs
@@ -157,8 +157,6 @@ unsafe impl<I> TrustedRandomAccessNoCoerce for Copied<I>
 where
     I: TrustedRandomAccessNoCoerce,
 {
-    const MAY_HAVE_SIDE_EFFECT: bool = I::MAY_HAVE_SIDE_EFFECT;
-
     const NEEDS_CLEANUP: bool = I::NEEDS_CLEANUP;
 
     #[inline]

--- a/library/core/src/iter/adapters/copied.rs
+++ b/library/core/src/iter/adapters/copied.rs
@@ -1,6 +1,4 @@
-use crate::iter::adapters::{
-    zip::try_get_unchecked, TrustedRandomAccess, TrustedRandomAccessNoCoerce,
-};
+use crate::iter::adapters::{zip::try_get_unchecked, TrustedRandomAccess};
 use crate::iter::{FusedIterator, TrustedLen};
 use crate::ops::Try;
 
@@ -84,7 +82,7 @@ where
     #[doc(hidden)]
     unsafe fn __iterator_get_unchecked(&mut self, idx: usize) -> T
     where
-        Self: TrustedRandomAccessNoCoerce,
+        Self: TrustedRandomAccess,
     {
         // SAFETY: the caller must uphold the contract for
         // `Iterator::__iterator_get_unchecked`.
@@ -149,13 +147,9 @@ where
 
 #[doc(hidden)]
 #[unstable(feature = "trusted_random_access", issue = "none")]
-unsafe impl<I> TrustedRandomAccess for Copied<I> where I: TrustedRandomAccess {}
-
-#[doc(hidden)]
-#[unstable(feature = "trusted_random_access", issue = "none")]
-unsafe impl<I> TrustedRandomAccessNoCoerce for Copied<I>
+unsafe impl<I> TrustedRandomAccess for Copied<I>
 where
-    I: TrustedRandomAccessNoCoerce,
+    I: TrustedRandomAccess,
 {
     const NEEDS_CLEANUP: bool = I::NEEDS_CLEANUP;
 

--- a/library/core/src/iter/adapters/copied.rs
+++ b/library/core/src/iter/adapters/copied.rs
@@ -158,6 +158,13 @@ where
     I: TrustedRandomAccessNoCoerce,
 {
     const MAY_HAVE_SIDE_EFFECT: bool = I::MAY_HAVE_SIDE_EFFECT;
+
+    const NEEDS_CLEANUP: bool = I::NEEDS_CLEANUP;
+
+    #[inline]
+    fn cleanup(&mut self, num: usize, forward: bool) {
+        self.it.cleanup(num, forward);
+    }
 }
 
 #[stable(feature = "iter_copied", since = "1.36.0")]

--- a/library/core/src/iter/adapters/copied.rs
+++ b/library/core/src/iter/adapters/copied.rs
@@ -156,8 +156,13 @@ where
     I: TrustedRandomAccess,
 {
     #[inline]
-    fn cleanup(&mut self, num: usize, forward: bool) {
-        self.it.cleanup(num, forward);
+    fn cleanup_front(&mut self, num: usize) {
+        self.it.cleanup_front(num);
+    }
+
+    #[inline]
+    fn cleanup_back(&mut self, num: usize) {
+        self.it.cleanup_back(num);
     }
 }
 

--- a/library/core/src/iter/adapters/copied.rs
+++ b/library/core/src/iter/adapters/copied.rs
@@ -1,4 +1,5 @@
-use crate::iter::adapters::{zip::try_get_unchecked, TrustedRandomAccess};
+use crate::iter::traits::trusted_random_access::try_get_unchecked;
+use crate::iter::traits::TrustedRandomAccess;
 use crate::iter::{FusedIterator, TrustedLen};
 use crate::ops::Try;
 

--- a/library/core/src/iter/adapters/enumerate.rs
+++ b/library/core/src/iter/adapters/enumerate.rs
@@ -129,6 +129,7 @@ where
 
     #[rustc_inherit_overflow_checks]
     #[doc(hidden)]
+    #[inline]
     unsafe fn __iterator_get_unchecked(&mut self, idx: usize) -> <Self as Iterator>::Item
     where
         Self: TrustedRandomAccessNoCoerce,

--- a/library/core/src/iter/adapters/enumerate.rs
+++ b/library/core/src/iter/adapters/enumerate.rs
@@ -1,6 +1,9 @@
 use crate::iter::adapters::SourceIter;
 use crate::iter::traits::trusted_random_access::try_get_unchecked;
-use crate::iter::traits::TrustedRandomAccess;
+use crate::iter::traits::{
+    TrustedRandomAccess, TrustedRandomAccessNeedsCleanup, TrustedRandomAccessNeedsForwardSetup,
+    TrustedRandomAccessNeedsReverseSetup,
+};
 use crate::iter::{FusedIterator, InPlaceIterable, TrustedLen};
 use crate::ops::Try;
 
@@ -236,12 +239,31 @@ unsafe impl<I> TrustedRandomAccess for Enumerate<I>
 where
     I: TrustedRandomAccess,
 {
-    const NEEDS_CLEANUP: bool = I::NEEDS_CLEANUP;
-
     #[inline]
     fn cleanup(&mut self, num: usize, forward: bool) {
         self.iter.cleanup(num, forward);
     }
+}
+
+#[doc(hidden)]
+#[unstable(feature = "trusted_random_access", issue = "none")]
+unsafe impl<I> TrustedRandomAccessNeedsCleanup for Enumerate<I> where
+    I: TrustedRandomAccessNeedsCleanup
+{
+}
+
+#[doc(hidden)]
+#[unstable(feature = "trusted_random_access", issue = "none")]
+unsafe impl<I> TrustedRandomAccessNeedsForwardSetup for Enumerate<I> where
+    I: TrustedRandomAccessNeedsForwardSetup
+{
+}
+
+#[doc(hidden)]
+#[unstable(feature = "trusted_random_access", issue = "none")]
+unsafe impl<I> TrustedRandomAccessNeedsReverseSetup for Enumerate<I> where
+    I: TrustedRandomAccessNeedsReverseSetup
+{
 }
 
 #[stable(feature = "fused", since = "1.26.0")]

--- a/library/core/src/iter/adapters/enumerate.rs
+++ b/library/core/src/iter/adapters/enumerate.rs
@@ -1,4 +1,6 @@
-use crate::iter::adapters::{zip::try_get_unchecked, SourceIter, TrustedRandomAccess};
+use crate::iter::adapters::SourceIter;
+use crate::iter::traits::trusted_random_access::try_get_unchecked;
+use crate::iter::traits::TrustedRandomAccess;
 use crate::iter::{FusedIterator, InPlaceIterable, TrustedLen};
 use crate::ops::Try;
 

--- a/library/core/src/iter/adapters/enumerate.rs
+++ b/library/core/src/iter/adapters/enumerate.rs
@@ -240,8 +240,6 @@ unsafe impl<I> TrustedRandomAccessNoCoerce for Enumerate<I>
 where
     I: TrustedRandomAccessNoCoerce,
 {
-    const MAY_HAVE_SIDE_EFFECT: bool = I::MAY_HAVE_SIDE_EFFECT;
-
     const NEEDS_CLEANUP: bool = I::NEEDS_CLEANUP;
 
     #[inline]

--- a/library/core/src/iter/adapters/enumerate.rs
+++ b/library/core/src/iter/adapters/enumerate.rs
@@ -241,6 +241,13 @@ where
     I: TrustedRandomAccessNoCoerce,
 {
     const MAY_HAVE_SIDE_EFFECT: bool = I::MAY_HAVE_SIDE_EFFECT;
+
+    const NEEDS_CLEANUP: bool = I::NEEDS_CLEANUP;
+
+    #[inline]
+    fn cleanup(&mut self, num: usize, forward: bool) {
+        self.iter.cleanup(num, forward);
+    }
 }
 
 #[stable(feature = "fused", since = "1.26.0")]

--- a/library/core/src/iter/adapters/enumerate.rs
+++ b/library/core/src/iter/adapters/enumerate.rs
@@ -240,8 +240,13 @@ where
     I: TrustedRandomAccess,
 {
     #[inline]
-    fn cleanup(&mut self, num: usize, forward: bool) {
-        self.iter.cleanup(num, forward);
+    fn cleanup_front(&mut self, num: usize) {
+        self.iter.cleanup_front(num);
+    }
+
+    #[inline]
+    fn cleanup_back(&mut self, num: usize) {
+        self.iter.cleanup_back(num);
     }
 }
 

--- a/library/core/src/iter/adapters/enumerate.rs
+++ b/library/core/src/iter/adapters/enumerate.rs
@@ -1,6 +1,4 @@
-use crate::iter::adapters::{
-    zip::try_get_unchecked, SourceIter, TrustedRandomAccess, TrustedRandomAccessNoCoerce,
-};
+use crate::iter::adapters::{zip::try_get_unchecked, SourceIter, TrustedRandomAccess};
 use crate::iter::{FusedIterator, InPlaceIterable, TrustedLen};
 use crate::ops::Try;
 
@@ -132,7 +130,7 @@ where
     #[inline]
     unsafe fn __iterator_get_unchecked(&mut self, idx: usize) -> <Self as Iterator>::Item
     where
-        Self: TrustedRandomAccessNoCoerce,
+        Self: TrustedRandomAccess,
     {
         // SAFETY: the caller must uphold the contract for
         // `Iterator::__iterator_get_unchecked`.
@@ -232,13 +230,9 @@ where
 
 #[doc(hidden)]
 #[unstable(feature = "trusted_random_access", issue = "none")]
-unsafe impl<I> TrustedRandomAccess for Enumerate<I> where I: TrustedRandomAccess {}
-
-#[doc(hidden)]
-#[unstable(feature = "trusted_random_access", issue = "none")]
-unsafe impl<I> TrustedRandomAccessNoCoerce for Enumerate<I>
+unsafe impl<I> TrustedRandomAccess for Enumerate<I>
 where
-    I: TrustedRandomAccessNoCoerce,
+    I: TrustedRandomAccess,
 {
     const NEEDS_CLEANUP: bool = I::NEEDS_CLEANUP;
 

--- a/library/core/src/iter/adapters/fuse.rs
+++ b/library/core/src/iter/adapters/fuse.rs
@@ -2,6 +2,8 @@ use crate::intrinsics;
 use crate::iter::traits::trusted_random_access::try_get_unchecked;
 use crate::iter::{
     DoubleEndedIterator, ExactSizeIterator, FusedIterator, TrustedLen, TrustedRandomAccess,
+    TrustedRandomAccessNeedsCleanup, TrustedRandomAccessNeedsForwardSetup,
+    TrustedRandomAccessNeedsReverseSetup,
 };
 use crate::ops::Try;
 
@@ -225,14 +227,30 @@ unsafe impl<I> TrustedRandomAccess for Fuse<I>
 where
     I: TrustedRandomAccess,
 {
-    const NEEDS_CLEANUP: bool = I::NEEDS_CLEANUP;
-
     #[inline]
     fn cleanup(&mut self, num: usize, forward: bool) {
         if let Some(iter) = self.iter.as_mut() {
             iter.cleanup(num, forward);
         }
     }
+}
+
+#[doc(hidden)]
+#[unstable(feature = "trusted_random_access", issue = "none")]
+unsafe impl<I> TrustedRandomAccessNeedsCleanup for Fuse<I> where I: TrustedRandomAccessNeedsCleanup {}
+
+#[doc(hidden)]
+#[unstable(feature = "trusted_random_access", issue = "none")]
+unsafe impl<I> TrustedRandomAccessNeedsForwardSetup for Fuse<I> where
+    I: TrustedRandomAccessNeedsForwardSetup
+{
+}
+
+#[doc(hidden)]
+#[unstable(feature = "trusted_random_access", issue = "none")]
+unsafe impl<I> TrustedRandomAccessNeedsReverseSetup for Fuse<I> where
+    I: TrustedRandomAccessNeedsReverseSetup
+{
 }
 
 /// Fuse specialization trait

--- a/library/core/src/iter/adapters/fuse.rs
+++ b/library/core/src/iter/adapters/fuse.rs
@@ -2,7 +2,6 @@ use crate::intrinsics;
 use crate::iter::adapters::zip::try_get_unchecked;
 use crate::iter::{
     DoubleEndedIterator, ExactSizeIterator, FusedIterator, TrustedLen, TrustedRandomAccess,
-    TrustedRandomAccessNoCoerce,
 };
 use crate::ops::Try;
 
@@ -132,7 +131,7 @@ where
     #[doc(hidden)]
     unsafe fn __iterator_get_unchecked(&mut self, idx: usize) -> Self::Item
     where
-        Self: TrustedRandomAccessNoCoerce,
+        Self: TrustedRandomAccess,
     {
         match self.iter {
             // SAFETY: the caller must uphold the contract for
@@ -222,13 +221,9 @@ unsafe impl<I> TrustedLen for Fuse<I> where I: TrustedLen {}
 //
 // This is safe to implement as `Fuse` is just forwarding these to the wrapped iterator `I`, which
 // preserves these properties.
-unsafe impl<I> TrustedRandomAccess for Fuse<I> where I: TrustedRandomAccess {}
-
-#[doc(hidden)]
-#[unstable(feature = "trusted_random_access", issue = "none")]
-unsafe impl<I> TrustedRandomAccessNoCoerce for Fuse<I>
+unsafe impl<I> TrustedRandomAccess for Fuse<I>
 where
-    I: TrustedRandomAccessNoCoerce,
+    I: TrustedRandomAccess,
 {
     const NEEDS_CLEANUP: bool = I::NEEDS_CLEANUP;
 

--- a/library/core/src/iter/adapters/fuse.rs
+++ b/library/core/src/iter/adapters/fuse.rs
@@ -230,8 +230,6 @@ unsafe impl<I> TrustedRandomAccessNoCoerce for Fuse<I>
 where
     I: TrustedRandomAccessNoCoerce,
 {
-    const MAY_HAVE_SIDE_EFFECT: bool = I::MAY_HAVE_SIDE_EFFECT;
-
     const NEEDS_CLEANUP: bool = I::NEEDS_CLEANUP;
 
     #[inline]

--- a/library/core/src/iter/adapters/fuse.rs
+++ b/library/core/src/iter/adapters/fuse.rs
@@ -228,9 +228,16 @@ where
     I: TrustedRandomAccess,
 {
     #[inline]
-    fn cleanup(&mut self, num: usize, forward: bool) {
+    fn cleanup_front(&mut self, num: usize) {
         if let Some(iter) = self.iter.as_mut() {
-            iter.cleanup(num, forward);
+            iter.cleanup_front(num);
+        }
+    }
+
+    #[inline]
+    fn cleanup_back(&mut self, num: usize) {
+        if let Some(iter) = self.iter.as_mut() {
+            iter.cleanup_back(num);
         }
     }
 }

--- a/library/core/src/iter/adapters/fuse.rs
+++ b/library/core/src/iter/adapters/fuse.rs
@@ -231,6 +231,15 @@ where
     I: TrustedRandomAccessNoCoerce,
 {
     const MAY_HAVE_SIDE_EFFECT: bool = I::MAY_HAVE_SIDE_EFFECT;
+
+    const NEEDS_CLEANUP: bool = I::NEEDS_CLEANUP;
+
+    #[inline]
+    fn cleanup(&mut self, num: usize, forward: bool) {
+        if let Some(iter) = self.iter.as_mut() {
+            iter.cleanup(num, forward);
+        }
+    }
 }
 
 /// Fuse specialization trait

--- a/library/core/src/iter/adapters/fuse.rs
+++ b/library/core/src/iter/adapters/fuse.rs
@@ -1,5 +1,5 @@
 use crate::intrinsics;
-use crate::iter::adapters::zip::try_get_unchecked;
+use crate::iter::traits::trusted_random_access::try_get_unchecked;
 use crate::iter::{
     DoubleEndedIterator, ExactSizeIterator, FusedIterator, TrustedLen, TrustedRandomAccess,
 };

--- a/library/core/src/iter/adapters/map.rs
+++ b/library/core/src/iter/adapters/map.rs
@@ -125,6 +125,7 @@ where
     }
 
     #[doc(hidden)]
+    #[inline]
     unsafe fn __iterator_get_unchecked(&mut self, idx: usize) -> B
     where
         Self: TrustedRandomAccessNoCoerce,

--- a/library/core/src/iter/adapters/map.rs
+++ b/library/core/src/iter/adapters/map.rs
@@ -1,7 +1,10 @@
 use crate::fmt;
 use crate::iter::adapters::SourceIter;
 use crate::iter::traits::trusted_random_access::try_get_unchecked;
-use crate::iter::traits::TrustedRandomAccess;
+use crate::iter::traits::{
+    TrustedRandomAccess, TrustedRandomAccessNeedsCleanup, TrustedRandomAccessNeedsForwardSetup,
+    TrustedRandomAccessNeedsReverseSetup,
+};
 use crate::iter::{FusedIterator, InPlaceIterable, TrustedLen};
 use crate::ops::Try;
 
@@ -194,12 +197,31 @@ unsafe impl<I, F> TrustedRandomAccess for Map<I, F>
 where
     I: TrustedRandomAccess,
 {
-    const NEEDS_CLEANUP: bool = I::NEEDS_CLEANUP;
-
     #[inline]
     fn cleanup(&mut self, num: usize, forward: bool) {
         self.iter.cleanup(num, forward);
     }
+}
+
+#[doc(hidden)]
+#[unstable(feature = "trusted_random_access", issue = "none")]
+unsafe impl<I, F> TrustedRandomAccessNeedsCleanup for Map<I, F> where
+    I: TrustedRandomAccessNeedsCleanup
+{
+}
+
+#[doc(hidden)]
+#[unstable(feature = "trusted_random_access", issue = "none")]
+unsafe impl<I, F> TrustedRandomAccessNeedsForwardSetup for Map<I, F> where
+    I: TrustedRandomAccessNeedsForwardSetup
+{
+}
+
+#[doc(hidden)]
+#[unstable(feature = "trusted_random_access", issue = "none")]
+unsafe impl<I, F> TrustedRandomAccessNeedsReverseSetup for Map<I, F> where
+    I: TrustedRandomAccessNeedsReverseSetup
+{
 }
 
 #[unstable(issue = "none", feature = "inplace_iteration")]

--- a/library/core/src/iter/adapters/map.rs
+++ b/library/core/src/iter/adapters/map.rs
@@ -198,8 +198,6 @@ unsafe impl<I, F> TrustedRandomAccessNoCoerce for Map<I, F>
 where
     I: TrustedRandomAccessNoCoerce,
 {
-    const MAY_HAVE_SIDE_EFFECT: bool = true;
-
     const NEEDS_CLEANUP: bool = I::NEEDS_CLEANUP;
 
     #[inline]

--- a/library/core/src/iter/adapters/map.rs
+++ b/library/core/src/iter/adapters/map.rs
@@ -199,6 +199,13 @@ where
     I: TrustedRandomAccessNoCoerce,
 {
     const MAY_HAVE_SIDE_EFFECT: bool = true;
+
+    const NEEDS_CLEANUP: bool = I::NEEDS_CLEANUP;
+
+    #[inline]
+    fn cleanup(&mut self, num: usize, forward: bool) {
+        self.iter.cleanup(num, forward);
+    }
 }
 
 #[unstable(issue = "none", feature = "inplace_iteration")]

--- a/library/core/src/iter/adapters/map.rs
+++ b/library/core/src/iter/adapters/map.rs
@@ -1,5 +1,7 @@
 use crate::fmt;
-use crate::iter::adapters::{zip::try_get_unchecked, SourceIter, TrustedRandomAccess};
+use crate::iter::adapters::SourceIter;
+use crate::iter::traits::trusted_random_access::try_get_unchecked;
+use crate::iter::traits::TrustedRandomAccess;
 use crate::iter::{FusedIterator, InPlaceIterable, TrustedLen};
 use crate::ops::Try;
 

--- a/library/core/src/iter/adapters/map.rs
+++ b/library/core/src/iter/adapters/map.rs
@@ -198,8 +198,13 @@ where
     I: TrustedRandomAccess,
 {
     #[inline]
-    fn cleanup(&mut self, num: usize, forward: bool) {
-        self.iter.cleanup(num, forward);
+    fn cleanup_front(&mut self, num: usize) {
+        self.iter.cleanup_front(num);
+    }
+
+    #[inline]
+    fn cleanup_back(&mut self, num: usize) {
+        self.iter.cleanup_back(num);
     }
 }
 

--- a/library/core/src/iter/adapters/map.rs
+++ b/library/core/src/iter/adapters/map.rs
@@ -1,7 +1,5 @@
 use crate::fmt;
-use crate::iter::adapters::{
-    zip::try_get_unchecked, SourceIter, TrustedRandomAccess, TrustedRandomAccessNoCoerce,
-};
+use crate::iter::adapters::{zip::try_get_unchecked, SourceIter, TrustedRandomAccess};
 use crate::iter::{FusedIterator, InPlaceIterable, TrustedLen};
 use crate::ops::Try;
 
@@ -128,7 +126,7 @@ where
     #[inline]
     unsafe fn __iterator_get_unchecked(&mut self, idx: usize) -> B
     where
-        Self: TrustedRandomAccessNoCoerce,
+        Self: TrustedRandomAccess,
     {
         // SAFETY: the caller must uphold the contract for
         // `Iterator::__iterator_get_unchecked`.
@@ -190,13 +188,9 @@ where
 
 #[doc(hidden)]
 #[unstable(feature = "trusted_random_access", issue = "none")]
-unsafe impl<I, F> TrustedRandomAccess for Map<I, F> where I: TrustedRandomAccess {}
-
-#[doc(hidden)]
-#[unstable(feature = "trusted_random_access", issue = "none")]
-unsafe impl<I, F> TrustedRandomAccessNoCoerce for Map<I, F>
+unsafe impl<I, F> TrustedRandomAccess for Map<I, F>
 where
-    I: TrustedRandomAccessNoCoerce,
+    I: TrustedRandomAccess,
 {
     const NEEDS_CLEANUP: bool = I::NEEDS_CLEANUP;
 

--- a/library/core/src/iter/adapters/mod.rs
+++ b/library/core/src/iter/adapters/mod.rs
@@ -52,9 +52,6 @@ pub use self::intersperse::{Intersperse, IntersperseWith};
 #[stable(feature = "iter_map_while", since = "1.57.0")]
 pub use self::map_while::MapWhile;
 
-#[unstable(feature = "trusted_random_access", issue = "none")]
-pub use self::zip::TrustedRandomAccess;
-
 #[stable(feature = "iter_zip", since = "1.59.0")]
 pub use self::zip::zip;
 

--- a/library/core/src/iter/adapters/mod.rs
+++ b/library/core/src/iter/adapters/mod.rs
@@ -55,9 +55,6 @@ pub use self::map_while::MapWhile;
 #[unstable(feature = "trusted_random_access", issue = "none")]
 pub use self::zip::TrustedRandomAccess;
 
-#[unstable(feature = "trusted_random_access", issue = "none")]
-pub use self::zip::TrustedRandomAccessNoCoerce;
-
 #[stable(feature = "iter_zip", since = "1.59.0")]
 pub use self::zip::zip;
 

--- a/library/core/src/iter/adapters/zip.rs
+++ b/library/core/src/iter/adapters/zip.rs
@@ -554,6 +554,7 @@ pub unsafe trait TrustedRandomAccessNoCoerce: Sized {
 ///
 /// Same requirements calling `get_unchecked` directly.
 #[doc(hidden)]
+#[inline]
 pub(in crate::iter::adapters) unsafe fn try_get_unchecked<I>(it: &mut I, idx: usize) -> I::Item
 where
     I: Iterator,
@@ -576,6 +577,7 @@ unsafe impl<I: Iterator> SpecTrustedRandomAccess for I {
 }
 
 unsafe impl<I: Iterator + TrustedRandomAccessNoCoerce> SpecTrustedRandomAccess for I {
+    #[inline]
     unsafe fn try_get_unchecked(&mut self, index: usize) -> Self::Item {
         // SAFETY: the caller must uphold the contract for
         // `Iterator::__iterator_get_unchecked`.

--- a/library/core/src/iter/adapters/zip.rs
+++ b/library/core/src/iter/adapters/zip.rs
@@ -2,7 +2,10 @@ use crate::cmp;
 use crate::fmt::{self, Debug};
 use crate::iter::traits::trusted_random_access::try_get_unchecked;
 use crate::iter::{DoubleEndedIterator, ExactSizeIterator, FusedIterator, Iterator};
-use crate::iter::{InPlaceIterable, SourceIter, TrustedLen, TrustedRandomAccess};
+use crate::iter::{
+    InPlaceIterable, SourceIter, TrustedLen, TrustedRandomAccess, TrustedRandomAccessNeedsCleanup,
+    TrustedRandomAccessNeedsForwardSetup, TrustedRandomAccessNeedsReverseSetup,
+};
 use crate::ops::Try;
 
 /// An iterator that iterates two other iterators simultaneously.
@@ -259,13 +262,62 @@ where
     A: TrustedRandomAccess,
     B: TrustedRandomAccess,
 {
-    const NEEDS_CLEANUP: bool = A::NEEDS_CLEANUP || B::NEEDS_CLEANUP;
-
     fn cleanup(&mut self, num: usize, forward: bool) {
         self.a.cleanup(num, forward);
         self.b.cleanup(num, forward);
     }
 }
+
+#[doc(hidden)]
+#[unstable(feature = "trusted_random_access", issue = "none")]
+unsafe impl<A, B> TrustedRandomAccessNeedsCleanup for Zip<A, B> where
+    A: TrustedRandomAccessNeedsCleanup
+{
+}
+
+#[doc(hidden)]
+#[unstable(feature = "trusted_random_access", issue = "none")]
+unsafe impl<A, B> TrustedRandomAccessNeedsCleanup for Zip<A, B> where
+    B: TrustedRandomAccessNeedsCleanup
+{
+}
+
+#[doc(hidden)]
+#[unstable(feature = "trusted_random_access", issue = "none")]
+unsafe impl<A, B> TrustedRandomAccessNeedsCleanup for Zip<A, B>
+where
+    A: TrustedRandomAccessNeedsCleanup,
+    B: TrustedRandomAccessNeedsCleanup,
+{
+}
+
+#[doc(hidden)]
+#[unstable(feature = "trusted_random_access", issue = "none")]
+unsafe impl<A, B> TrustedRandomAccessNeedsForwardSetup for Zip<A, B> where
+    A: TrustedRandomAccessNeedsForwardSetup
+{
+}
+
+#[doc(hidden)]
+#[unstable(feature = "trusted_random_access", issue = "none")]
+unsafe impl<A, B> TrustedRandomAccessNeedsForwardSetup for Zip<A, B> where
+    B: TrustedRandomAccessNeedsForwardSetup
+{
+}
+
+#[doc(hidden)]
+#[unstable(feature = "trusted_random_access", issue = "none")]
+unsafe impl<A, B> TrustedRandomAccessNeedsForwardSetup for Zip<A, B>
+where
+    A: TrustedRandomAccessNeedsForwardSetup,
+    B: TrustedRandomAccessNeedsForwardSetup,
+{
+}
+
+
+#[doc(hidden)]
+#[unstable(feature = "trusted_random_access", issue = "none")]
+unsafe impl<A, B> TrustedRandomAccessNeedsReverseSetup for Zip<A, B> where Self: TrustedRandomAccess {}
 
 #[stable(feature = "fused", since = "1.26.0")]
 impl<A, B> FusedIterator for Zip<A, B>

--- a/library/core/src/iter/adapters/zip.rs
+++ b/library/core/src/iter/adapters/zip.rs
@@ -217,7 +217,7 @@ where
             accum = f(accum, x);
         }
         // FIXME drop-guard or use ForLoopDesugar
-        self.cleanup(len, true);
+        self.cleanup_front(len);
         accum
     }
 
@@ -236,7 +236,7 @@ where
             accum = f(accum, x)?;
         }
         // FIXME drop-guard or use ForLoopDesugar
-        self.cleanup(len, true);
+        self.cleanup_front(len);
         try { accum }
     }
 
@@ -262,9 +262,14 @@ where
     A: TrustedRandomAccess,
     B: TrustedRandomAccess,
 {
-    fn cleanup(&mut self, num: usize, forward: bool) {
-        self.a.cleanup(num, forward);
-        self.b.cleanup(num, forward);
+    fn cleanup_front(&mut self, num: usize) {
+        self.a.cleanup_front(num);
+        self.b.cleanup_front(num);
+    }
+
+    fn cleanup_back(&mut self, num: usize) {
+        self.a.cleanup_back(num);
+        self.b.cleanup_back(num);
     }
 }
 
@@ -313,7 +318,6 @@ where
     B: TrustedRandomAccessNeedsForwardSetup,
 {
 }
-
 
 #[doc(hidden)]
 #[unstable(feature = "trusted_random_access", issue = "none")]

--- a/library/core/src/iter/adapters/zip.rs
+++ b/library/core/src/iter/adapters/zip.rs
@@ -1,7 +1,8 @@
 use crate::cmp;
 use crate::fmt::{self, Debug};
+use crate::iter::traits::trusted_random_access::try_get_unchecked;
 use crate::iter::{DoubleEndedIterator, ExactSizeIterator, FusedIterator, Iterator};
-use crate::iter::{InPlaceIterable, SourceIter, TrustedLen};
+use crate::iter::{InPlaceIterable, SourceIter, TrustedLen, TrustedRandomAccess};
 use crate::ops::Try;
 
 /// An iterator that iterates two other iterators simultaneously.
@@ -324,105 +325,5 @@ impl<A: Debug + TrustedRandomAccess, B: Debug + TrustedRandomAccess> ZipFmt<A, B
         // It's *not safe* to call fmt on the contained iterators, since once
         // we start iterating they're in strange, potentially unsafe, states.
         f.debug_struct("Zip").finish()
-    }
-}
-
-/// An iterator whose items are random-accessible efficiently
-///
-/// # Safety
-///
-/// The iterator's `size_hint` must be exact and cheap to call.
-///
-/// `TrustedRandomAccess::size` may not be overridden.
-///
-/// All subtypes and all supertypes of `Self` must also implement `TrustedRandomAccess`.
-/// In particular, this means that types with non-invariant parameters usually can not have
-/// an impl for `TrustedRandomAccess` that depends on any trait bounds on such parameters, except
-/// for bounds that come from the respective struct/enum definition itself, or bounds involving
-/// traits that themselves come with a guarantee similar to this one.
-///
-/// If `Self: ExactSizeIterator` then `self.len()` must always produce results consistent
-/// with `self.size()`.
-///
-/// If `Self: Iterator`, then `<Self as Iterator>::__iterator_get_unchecked(&mut self, idx)`
-/// must be safe to call provided the following conditions are met.
-///
-/// 1. `0 <= idx` and `idx < self.size()`.
-/// 2. If `Self: !Clone`, then `self.__iterator_get_unchecked(idx)` is never called with the same
-///    index on `self` more than once.
-/// 3. After `self.__iterator_get_unchecked(idx)` has been called, then `self.next_back()` will
-///    only be called at most `self.size() - idx - 1` times. If `Self: Clone` and `self` is cloned,
-///    then this number is calculated for `self` and its clone individually,
-///    but `self.next_back()` calls that happened before the cloning count for both `self` and the clone.
-/// 4. After `self.__iterator_get_unchecked(idx)` has been called, then only the following methods
-///    will be called on `self` or on any new clones of `self`:
-///     * `std::clone::Clone::clone`
-///     * `std::iter::Iterator::size_hint`
-///     * `std::iter::DoubleEndedIterator::next_back`
-///     * `std::iter::ExactSizeIterator::len`
-///     * `std::iter::Iterator::__iterator_get_unchecked`
-///     * `std::iter::TrustedRandomAccess::size`
-///
-/// Further, given that these conditions are met, it must guarantee that:
-///
-/// * It does not change the value returned from `size_hint`
-/// * It must be safe to call the methods listed above on `self` after calling
-///   `self.__iterator_get_unchecked(idx)`, assuming that the required traits are implemented.
-/// * It must also be safe to drop `self` after calling `self.__iterator_get_unchecked(idx)`.
-//
-// FIXME: Clarify interaction with SourceIter/InPlaceIterable. Calling `SourceIter::as_inner`
-// after `__iterator_get_unchecked` is supposed to be allowed.
-#[doc(hidden)]
-#[unstable(feature = "trusted_random_access", issue = "none")]
-#[rustc_specialization_trait]
-pub unsafe trait TrustedRandomAccess: Sized {
-    // Convenience method.
-    fn size(&self) -> usize
-    where
-        Self: Iterator,
-    {
-        self.size_hint().0
-    }
-
-    const NEEDS_CLEANUP: bool;
-
-    fn cleanup(&mut self, num: usize, forward: bool);
-}
-
-/// Like `Iterator::__iterator_get_unchecked`, but doesn't require the compiler to
-/// know that `U: TrustedRandomAccess`.
-///
-/// ## Safety
-///
-/// Same requirements calling `get_unchecked` directly.
-#[doc(hidden)]
-#[inline]
-pub(in crate::iter::adapters) unsafe fn try_get_unchecked<I>(it: &mut I, idx: usize) -> I::Item
-where
-    I: Iterator,
-{
-    // SAFETY: the caller must uphold the contract for
-    // `Iterator::__iterator_get_unchecked`.
-    unsafe { it.try_get_unchecked(idx) }
-}
-
-unsafe trait SpecTrustedRandomAccess: Iterator {
-    /// If `Self: TrustedRandomAccess`, it must be safe to call
-    /// `Iterator::__iterator_get_unchecked(self, index)`.
-    unsafe fn try_get_unchecked(&mut self, index: usize) -> Self::Item;
-}
-
-unsafe impl<I: Iterator> SpecTrustedRandomAccess for I {
-    default unsafe fn try_get_unchecked(&mut self, _: usize) -> Self::Item {
-        panic!("Should only be called on TrustedRandomAccess iterators");
-    }
-}
-
-unsafe impl<I: Iterator + TrustedRandomAccess> SpecTrustedRandomAccess for I {
-    #[inline]
-    unsafe fn try_get_unchecked(&mut self, index: usize) -> Self::Item {
-        // SAFETY: the caller must uphold the contract for
-        // `Iterator::__iterator_get_unchecked`.
-        unsafe { self.__iterator_get_unchecked(index) }
     }
 }

--- a/library/core/src/iter/adapters/zip.rs
+++ b/library/core/src/iter/adapters/zip.rs
@@ -400,6 +400,13 @@ where
     B: TrustedRandomAccessNoCoerce,
 {
     const MAY_HAVE_SIDE_EFFECT: bool = A::MAY_HAVE_SIDE_EFFECT || B::MAY_HAVE_SIDE_EFFECT;
+
+    const NEEDS_CLEANUP: bool = A::NEEDS_CLEANUP || B::NEEDS_CLEANUP;
+
+    fn cleanup(&mut self, num: usize, forward: bool) {
+        self.a.cleanup(num, forward);
+        self.b.cleanup(num, forward);
+    }
 }
 
 #[stable(feature = "fused", since = "1.26.0")]
@@ -542,9 +549,14 @@ pub unsafe trait TrustedRandomAccessNoCoerce: Sized {
     {
         self.size_hint().0
     }
+
     /// `true` if getting an iterator element may have side effects.
     /// Remember to take inner iterators into account.
     const MAY_HAVE_SIDE_EFFECT: bool;
+
+    const NEEDS_CLEANUP: bool;
+
+    fn cleanup(&mut self, num: usize, forward: bool);
 }
 
 /// Like `Iterator::__iterator_get_unchecked`, but doesn't require the compiler to

--- a/library/core/src/iter/loop_desugar.rs
+++ b/library/core/src/iter/loop_desugar.rs
@@ -1,5 +1,5 @@
 use crate::iter::IntoIterator;
-use crate::iter::TrustedRandomAccessNoCoerce;
+use crate::iter::TrustedRandomAccess;
 
 #[derive(Debug)]
 #[doc(hidden)]
@@ -60,7 +60,7 @@ where
 
 impl<I, T> DesugarSpec<T> for ForLoopDesugar<I>
 where
-    I: TrustedRandomAccessNoCoerce + Iterator<Item = T>,
+    I: TrustedRandomAccess + Iterator<Item = T>,
 {
     #[inline]
     fn setup(&mut self) {

--- a/library/core/src/iter/loop_desugar.rs
+++ b/library/core/src/iter/loop_desugar.rs
@@ -1,0 +1,76 @@
+use crate::iter::IntoIterator as RealIntoIterator;
+use crate::iter::TrustedRandomAccessNoCoerce;
+
+#[unstable(feature = "trusted_random_access", issue = "none")]
+#[doc(hidden)]
+
+pub trait IntoIterator {
+    type IntoIter: Iterator;
+
+    #[unstable(feature = "trusted_random_access", issue = "none")]
+    // #[cfg_attr(not(bootstrap), lang = "loop_desugar")]
+    #[cfg_attr(not(bootstrap), lang = "into_iter")]
+    fn into_iter(self) -> Self::IntoIter;
+}
+
+impl<C: RealIntoIterator> IntoIterator for C {
+    type IntoIter = ForLoopDesugar<C::IntoIter>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        ForLoopDesugar { iter: <Self as RealIntoIterator>::into_iter(self), idx: 0 }
+    }
+}
+
+#[derive(Debug)]
+#[doc(hidden)]
+#[unstable(feature = "trusted_random_access", issue = "none")]
+pub struct ForLoopDesugar<I> {
+    iter: I,
+    idx: usize,
+}
+
+#[unstable(feature = "trusted_random_access", issue = "none")]
+impl<I: Iterator> Iterator for ForLoopDesugar<I> {
+    type Item = I::Item;
+
+    #[inline]
+    fn next(&mut self) -> Option<I::Item> {
+        // self.iter.next_spec(&mut self.idx)
+        self.next_spec()
+    }
+}
+
+trait DesugarSpec<T> {
+    fn next_spec(&mut self) -> Option<T>;
+}
+
+impl<I, T> DesugarSpec<T> for ForLoopDesugar<I>
+where
+    I: Iterator<Item = T>,
+{
+    #[inline]
+    default fn next_spec(&mut self) -> Option<I::Item> {
+        self.iter.next()
+    }
+}
+
+impl<I, T> DesugarSpec<T> for ForLoopDesugar<I>
+where
+    I: TrustedRandomAccessNoCoerce + Iterator<Item = T>,
+{
+    #[inline]
+    fn next_spec(&mut self) -> Option<I::Item> {
+        let idx = self.idx;
+        if idx < self.iter.size() {
+            // SAFETY: idx can't overflow since size is a usize. idx is always
+            // less than size, so the index is always valid.
+            unsafe {
+                self.idx = idx.unchecked_add(1);
+                Some(self.iter.__iterator_get_unchecked(idx))
+            }
+        } else {
+            None
+        }
+    }
+}

--- a/library/core/src/iter/loop_desugar.rs
+++ b/library/core/src/iter/loop_desugar.rs
@@ -110,6 +110,6 @@ where
 {
     #[inline]
     fn cleanup(&mut self) {
-        self.iter.cleanup(self.idx, true);
+        self.iter.cleanup_front(self.idx);
     }
 }

--- a/library/core/src/iter/mod.rs
+++ b/library/core/src/iter/mod.rs
@@ -383,13 +383,16 @@ pub use self::traits::FusedIterator;
 pub use self::traits::InPlaceIterable;
 #[unstable(feature = "trusted_len", issue = "37572")]
 pub use self::traits::TrustedLen;
-#[unstable(feature = "trusted_random_access", issue = "none")]
-pub use self::traits::TrustedRandomAccess;
 #[unstable(feature = "trusted_step", issue = "85731")]
 pub use self::traits::TrustedStep;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use self::traits::{
     DoubleEndedIterator, ExactSizeIterator, Extend, FromIterator, IntoIterator, Product, Sum,
+};
+#[unstable(feature = "trusted_random_access", issue = "none")]
+pub use self::traits::{
+    TrustedRandomAccess, TrustedRandomAccessNeedsCleanup, TrustedRandomAccessNeedsForwardSetup,
+    TrustedRandomAccessNeedsReverseSetup,
 };
 
 #[stable(feature = "iter_zip", since = "1.59.0")]

--- a/library/core/src/iter/mod.rs
+++ b/library/core/src/iter/mod.rs
@@ -383,6 +383,8 @@ pub use self::traits::FusedIterator;
 pub use self::traits::InPlaceIterable;
 #[unstable(feature = "trusted_len", issue = "37572")]
 pub use self::traits::TrustedLen;
+#[unstable(feature = "trusted_random_access", issue = "none")]
+pub use self::traits::TrustedRandomAccess;
 #[unstable(feature = "trusted_step", issue = "85731")]
 pub use self::traits::TrustedStep;
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -404,8 +406,6 @@ pub use self::adapters::MapWhile;
 pub use self::adapters::SourceIter;
 #[stable(feature = "iterator_step_by", since = "1.28.0")]
 pub use self::adapters::StepBy;
-#[unstable(feature = "trusted_random_access", issue = "none")]
-pub use self::adapters::TrustedRandomAccess;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use self::adapters::{
     Chain, Cycle, Enumerate, Filter, FilterMap, FlatMap, Fuse, Inspect, Map, Peekable, Rev, Scan,

--- a/library/core/src/iter/mod.rs
+++ b/library/core/src/iter/mod.rs
@@ -406,8 +406,6 @@ pub use self::adapters::SourceIter;
 pub use self::adapters::StepBy;
 #[unstable(feature = "trusted_random_access", issue = "none")]
 pub use self::adapters::TrustedRandomAccess;
-#[unstable(feature = "trusted_random_access", issue = "none")]
-pub use self::adapters::TrustedRandomAccessNoCoerce;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use self::adapters::{
     Chain, Cycle, Enumerate, Filter, FilterMap, FlatMap, Fuse, Inspect, Map, Peekable, Rev, Scan,

--- a/library/core/src/iter/mod.rs
+++ b/library/core/src/iter/mod.rs
@@ -419,6 +419,7 @@ pub use self::adapters::{Intersperse, IntersperseWith};
 pub(crate) use self::adapters::{try_process, ByRefSized};
 
 mod adapters;
+mod loop_desugar;
 mod range;
 mod sources;
 mod traits;

--- a/library/core/src/iter/range.rs
+++ b/library/core/src/iter/range.rs
@@ -504,8 +504,6 @@ macro_rules! unsafe_range_trusted_random_access_impl {
                     let _ = self.advance_back_by(num);
                 }
             }
-
-            const NEEDS_CLEANUP: bool = false;
         }
     )*)
 }

--- a/library/core/src/iter/range.rs
+++ b/library/core/src/iter/range.rs
@@ -497,13 +497,14 @@ macro_rules! unsafe_range_trusted_random_access_impl {
         #[unstable(feature = "trusted_random_access", issue = "none")]
         unsafe impl TrustedRandomAccess for ops::Range<$t> {
 
-            fn cleanup(&mut self, num: usize, forward: bool) {
-                if forward {
-                    let _ = self.advance_by(num);
-                } else {
-                    let _ = self.advance_back_by(num);
-                }
+            fn cleanup_front(&mut self, num: usize) {
+                let _ = self.advance_by(num);
             }
+
+            fn cleanup_back(&mut self, num: usize) {
+                let _ = self.advance_back_by(num);
+            }
+
         }
     )*)
 }

--- a/library/core/src/iter/range.rs
+++ b/library/core/src/iter/range.rs
@@ -3,9 +3,7 @@ use crate::convert::TryFrom;
 use crate::mem;
 use crate::ops::{self, Try};
 
-use super::{
-    FusedIterator, TrustedLen, TrustedRandomAccess, TrustedRandomAccessNoCoerce, TrustedStep,
-};
+use super::{FusedIterator, TrustedLen, TrustedRandomAccess, TrustedStep};
 
 // Safety: All invariants are upheld.
 macro_rules! unsafe_impl_trusted_step {
@@ -497,11 +495,7 @@ macro_rules! unsafe_range_trusted_random_access_impl {
     ($($t:ty)*) => ($(
         #[doc(hidden)]
         #[unstable(feature = "trusted_random_access", issue = "none")]
-        unsafe impl TrustedRandomAccess for ops::Range<$t> {}
-
-        #[doc(hidden)]
-        #[unstable(feature = "trusted_random_access", issue = "none")]
-        unsafe impl TrustedRandomAccessNoCoerce for ops::Range<$t> {
+        unsafe impl TrustedRandomAccess for ops::Range<$t> {
 
             fn cleanup(&mut self, num: usize, forward: bool) {
                 if forward {
@@ -764,7 +758,7 @@ impl<A: Step> Iterator for ops::Range<A> {
     #[doc(hidden)]
     unsafe fn __iterator_get_unchecked(&mut self, idx: usize) -> Self::Item
     where
-        Self: TrustedRandomAccessNoCoerce,
+        Self: TrustedRandomAccess,
     {
         // SAFETY: The TrustedRandomAccess contract requires that callers only  pass an index
         // that is in bounds.

--- a/library/core/src/iter/range.rs
+++ b/library/core/src/iter/range.rs
@@ -502,7 +502,18 @@ macro_rules! unsafe_range_trusted_random_access_impl {
         #[doc(hidden)]
         #[unstable(feature = "trusted_random_access", issue = "none")]
         unsafe impl TrustedRandomAccessNoCoerce for ops::Range<$t> {
+
+            fn cleanup(&mut self, num: usize, forward: bool) {
+                if forward {
+                    let _ = self.advance_by(num);
+                } else {
+                    let _ = self.advance_back_by(num);
+                }
+            }
+
             const MAY_HAVE_SIDE_EFFECT: bool = false;
+
+            const NEEDS_CLEANUP: bool = false;
         }
     )*)
 }

--- a/library/core/src/iter/range.rs
+++ b/library/core/src/iter/range.rs
@@ -511,8 +511,6 @@ macro_rules! unsafe_range_trusted_random_access_impl {
                 }
             }
 
-            const MAY_HAVE_SIDE_EFFECT: bool = false;
-
             const NEEDS_CLEANUP: bool = false;
         }
     )*)

--- a/library/core/src/iter/traits/collect.rs
+++ b/library/core/src/iter/traits/collect.rs
@@ -262,7 +262,7 @@ pub trait IntoIterator {
     /// assert_eq!(Some(3), iter.next());
     /// assert_eq!(None, iter.next());
     /// ```
-    #[lang = "into_iter"]
+    #[cfg_attr(bootstrap, lang = "into_iter")]
     #[stable(feature = "rust1", since = "1.0.0")]
     fn into_iter(self) -> Self::IntoIter;
 }

--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -94,8 +94,8 @@ pub trait Iterator {
     /// assert_eq!(None, iter.next());
     /// assert_eq!(None, iter.next());
     /// ```
-    #[lang = "next"]
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[cfg_attr(bootstrap, lang = "next")]
     fn next(&mut self) -> Option<Self::Item>;
 
     /// Returns the bounds on the remaining length of the iterator.

--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -3,7 +3,7 @@ use crate::ops::{ChangeOutputType, ControlFlow, FromResidual, Residual, Try};
 
 use super::super::try_process;
 use super::super::ByRefSized;
-use super::super::TrustedRandomAccessNoCoerce;
+use super::super::TrustedRandomAccess;
 use super::super::{Chain, Cloned, Copied, Cycle, Enumerate, Filter, FilterMap, Fuse};
 use super::super::{FlatMap, Flatten};
 use super::super::{FromIterator, Intersperse, IntersperseWith, Product, Sum, Zip};
@@ -3763,7 +3763,7 @@ pub trait Iterator {
     #[unstable(feature = "trusted_random_access", issue = "none")]
     unsafe fn __iterator_get_unchecked(&mut self, _idx: usize) -> Self::Item
     where
-        Self: TrustedRandomAccessNoCoerce,
+        Self: TrustedRandomAccess,
     {
         unreachable!("Always specialized");
     }

--- a/library/core/src/iter/traits/mod.rs
+++ b/library/core/src/iter/traits/mod.rs
@@ -21,4 +21,7 @@ pub use self::marker::InPlaceIterable;
 #[unstable(feature = "trusted_step", issue = "85731")]
 pub use self::marker::TrustedStep;
 #[unstable(feature = "trusted_random_access", issue = "none")]
-pub use self::trusted_random_access::TrustedRandomAccess;
+pub use self::trusted_random_access::{
+    TrustedRandomAccess, TrustedRandomAccessNeedsCleanup, TrustedRandomAccessNeedsForwardSetup,
+    TrustedRandomAccessNeedsReverseSetup,
+};

--- a/library/core/src/iter/traits/mod.rs
+++ b/library/core/src/iter/traits/mod.rs
@@ -4,6 +4,7 @@ mod double_ended;
 mod exact_size;
 mod iterator;
 mod marker;
+pub(crate) mod trusted_random_access;
 
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use self::{
@@ -19,3 +20,5 @@ pub use self::{
 pub use self::marker::InPlaceIterable;
 #[unstable(feature = "trusted_step", issue = "85731")]
 pub use self::marker::TrustedStep;
+#[unstable(feature = "trusted_random_access", issue = "none")]
+pub use self::trusted_random_access::TrustedRandomAccess;

--- a/library/core/src/iter/traits/trusted_random_access.rs
+++ b/library/core/src/iter/traits/trusted_random_access.rs
@@ -55,7 +55,9 @@ pub unsafe trait TrustedRandomAccess: Sized {
         self.size_hint().0
     }
 
-    fn cleanup(&mut self, num: usize, forward: bool);
+    fn cleanup_front(&mut self, num: usize);
+
+    fn cleanup_back(&mut self, num: usize);
 }
 
 // The following marker traits exist because specializing on them currently is the only way to avoid

--- a/library/core/src/iter/traits/trusted_random_access.rs
+++ b/library/core/src/iter/traits/trusted_random_access.rs
@@ -1,0 +1,99 @@
+/// An iterator whose items are random-accessible efficiently
+///
+/// # Safety
+///
+/// The iterator's `size_hint` must be exact and cheap to call.
+///
+/// `TrustedRandomAccess::size` may not be overridden.
+///
+/// All subtypes and all supertypes of `Self` must also implement `TrustedRandomAccess`.
+/// In particular, this means that types with non-invariant parameters usually can not have
+/// an impl for `TrustedRandomAccess` that depends on any trait bounds on such parameters, except
+/// for bounds that come from the respective struct/enum definition itself, or bounds involving
+/// traits that themselves come with a guarantee similar to this one.
+///
+/// If `Self: ExactSizeIterator` then `self.len()` must always produce results consistent
+/// with `self.size()`.
+///
+/// If `Self: Iterator`, then `<Self as Iterator>::__iterator_get_unchecked(&mut self, idx)`
+/// must be safe to call provided the following conditions are met.
+///
+/// 1. `0 <= idx` and `idx < self.size()`.
+/// 2. If `Self: !Clone`, then `self.__iterator_get_unchecked(idx)` is never called with the same
+///    index on `self` more than once.
+/// 3. After `self.__iterator_get_unchecked(idx)` has been called, then `self.next_back()` will
+///    only be called at most `self.size() - idx - 1` times. If `Self: Clone` and `self` is cloned,
+///    then this number is calculated for `self` and its clone individually,
+///    but `self.next_back()` calls that happened before the cloning count for both `self` and the clone.
+/// 4. After `self.__iterator_get_unchecked(idx)` has been called, then only the following methods
+///    will be called on `self` or on any new clones of `self`:
+///     * `std::clone::Clone::clone`
+///     * `std::iter::Iterator::size_hint`
+///     * `std::iter::DoubleEndedIterator::next_back`
+///     * `std::iter::ExactSizeIterator::len`
+///     * `std::iter::Iterator::__iterator_get_unchecked`
+///     * `std::iter::TrustedRandomAccess::size`
+///
+/// Further, given that these conditions are met, it must guarantee that:
+///
+/// * It does not change the value returned from `size_hint`
+/// * It must be safe to call the methods listed above on `self` after calling
+///   `self.__iterator_get_unchecked(idx)`, assuming that the required traits are implemented.
+/// * It must also be safe to drop `self` after calling `self.__iterator_get_unchecked(idx)`.
+//
+// FIXME: Clarify interaction with SourceIter/InPlaceIterable. Calling `SourceIter::as_inner`
+// after `__iterator_get_unchecked` is supposed to be allowed.
+#[doc(hidden)]
+#[unstable(feature = "trusted_random_access", issue = "none")]
+#[rustc_specialization_trait]
+pub unsafe trait TrustedRandomAccess: Sized {
+    // Convenience method.
+    fn size(&self) -> usize
+    where
+        Self: Iterator,
+    {
+        self.size_hint().0
+    }
+
+    const NEEDS_CLEANUP: bool;
+
+    fn cleanup(&mut self, num: usize, forward: bool);
+}
+
+/// Like `Iterator::__iterator_get_unchecked`, but doesn't require the compiler to
+/// know that `U: TrustedRandomAccess`.
+///
+/// ## Safety
+///
+/// Same requirements calling `get_unchecked` directly.
+#[doc(hidden)]
+#[inline]
+pub(in crate::iter) unsafe fn try_get_unchecked<I>(it: &mut I, idx: usize) -> I::Item
+where
+    I: Iterator,
+{
+    // SAFETY: the caller must uphold the contract for
+    // `Iterator::__iterator_get_unchecked`.
+    unsafe { it.try_get_unchecked(idx) }
+}
+
+unsafe trait SpecTrustedRandomAccess: Iterator {
+    /// If `Self: TrustedRandomAccess`, it must be safe to call
+    /// `Iterator::__iterator_get_unchecked(self, index)`.
+    unsafe fn try_get_unchecked(&mut self, index: usize) -> Self::Item;
+}
+
+unsafe impl<I: Iterator> SpecTrustedRandomAccess for I {
+    default unsafe fn try_get_unchecked(&mut self, _: usize) -> Self::Item {
+        panic!("Should only be called on TrustedRandomAccess iterators");
+    }
+}
+
+unsafe impl<I: Iterator + TrustedRandomAccess> SpecTrustedRandomAccess for I {
+    #[inline]
+    unsafe fn try_get_unchecked(&mut self, index: usize) -> Self::Item {
+        // SAFETY: the caller must uphold the contract for
+        // `Iterator::__iterator_get_unchecked`.
+        unsafe { self.__iterator_get_unchecked(index) }
+    }
+}

--- a/library/core/src/iter/traits/trusted_random_access.rs
+++ b/library/core/src/iter/traits/trusted_random_access.rs
@@ -55,10 +55,33 @@ pub unsafe trait TrustedRandomAccess: Sized {
         self.size_hint().0
     }
 
-    const NEEDS_CLEANUP: bool;
-
     fn cleanup(&mut self, num: usize, forward: bool);
 }
+
+// The following marker traits exist because specializing on them currently is the only way to avoid
+// emitting dead IR. Associated constants do not work because we currently don't have post-monomorphization
+// DCE.
+//
+// Pulling in the setup and cleanup methods on every specialized `for _ in` loop leads to 10% IR bloat
+// and LLVM won't eliminate it in debug mode.
+
+#[doc(hidden)]
+#[unstable(feature = "trusted_random_access", issue = "none")]
+#[rustc_specialization_trait]
+#[marker]
+pub unsafe trait TrustedRandomAccessNeedsCleanup {}
+
+#[doc(hidden)]
+#[unstable(feature = "trusted_random_access", issue = "none")]
+#[rustc_specialization_trait]
+#[marker]
+pub unsafe trait TrustedRandomAccessNeedsForwardSetup {}
+
+#[doc(hidden)]
+#[unstable(feature = "trusted_random_access", issue = "none")]
+#[rustc_specialization_trait]
+#[marker]
+pub unsafe trait TrustedRandomAccessNeedsReverseSetup {}
 
 /// Like `Iterator::__iterator_get_unchecked`, but doesn't require the compiler to
 /// know that `U: TrustedRandomAccess`.

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -186,6 +186,7 @@
 #![feature(lang_items)]
 #![feature(link_llvm_intrinsics)]
 #![feature(macro_metavar_expr)]
+#![feature(marker_trait_attr)]
 #![feature(min_specialization)]
 #![feature(mixed_integer_ops)]
 #![feature(must_not_suspend)]

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -174,6 +174,7 @@
 #![feature(deprecated_suggestion)]
 #![feature(doc_cfg)]
 #![feature(doc_notable_trait)]
+#![feature(dropck_eyepatch)]
 #![feature(rustdoc_internals)]
 #![feature(exhaustive_patterns)]
 #![feature(doc_cfg_hide)]

--- a/library/core/src/slice/iter.rs
+++ b/library/core/src/slice/iter.rs
@@ -1371,8 +1371,6 @@ impl<T> FusedIterator for Windows<'_, T> {}
 #[doc(hidden)]
 #[unstable(feature = "trusted_random_access", issue = "none")]
 unsafe impl<'a, T> TrustedRandomAccess for Windows<'a, T> {
-    const NEEDS_CLEANUP: bool = false;
-
     fn cleanup(&mut self, num: usize, forward: bool) {
         if forward {
             self.v = &self.v[num..];
@@ -1559,8 +1557,6 @@ impl<T> FusedIterator for Chunks<'_, T> {}
 #[doc(hidden)]
 #[unstable(feature = "trusted_random_access", issue = "none")]
 unsafe impl<'a, T> TrustedRandomAccess for Chunks<'a, T> {
-    const NEEDS_CLEANUP: bool = false;
-
     fn cleanup(&mut self, num: usize, forward: bool) {
         if forward {
             let len = self.v.len();
@@ -1735,8 +1731,6 @@ impl<T> FusedIterator for ChunksMut<'_, T> {}
 #[doc(hidden)]
 #[unstable(feature = "trusted_random_access", issue = "none")]
 unsafe impl<'a, T> TrustedRandomAccess for ChunksMut<'a, T> {
-    const NEEDS_CLEANUP: bool = false;
-
     fn cleanup(&mut self, num: usize, forward: bool) {
         let len = self.len();
         let v = mem::replace(&mut self.v, &mut []);
@@ -1904,8 +1898,6 @@ impl<T> FusedIterator for ChunksExact<'_, T> {}
 #[doc(hidden)]
 #[unstable(feature = "trusted_random_access", issue = "none")]
 unsafe impl<'a, T> TrustedRandomAccess for ChunksExact<'a, T> {
-    const NEEDS_CLEANUP: bool = false;
-
     fn cleanup(&mut self, num: usize, forward: bool) {
         if forward {
             let start = self.chunk_size * num;
@@ -2067,8 +2059,6 @@ impl<T> FusedIterator for ChunksExactMut<'_, T> {}
 #[doc(hidden)]
 #[unstable(feature = "trusted_random_access", issue = "none")]
 unsafe impl<'a, T> TrustedRandomAccess for ChunksExactMut<'a, T> {
-    const NEEDS_CLEANUP: bool = false;
-
     fn cleanup(&mut self, num: usize, forward: bool) {
         let v = mem::replace(&mut self.v, &mut []);
         if forward {
@@ -2319,8 +2309,6 @@ impl<T, const N: usize> FusedIterator for ArrayChunks<'_, T, N> {}
 #[doc(hidden)]
 #[unstable(feature = "array_chunks", issue = "74985")]
 unsafe impl<'a, T, const N: usize> TrustedRandomAccess for ArrayChunks<'a, T, N> {
-    const NEEDS_CLEANUP: bool = false;
-
     fn cleanup(&mut self, num: usize, forward: bool) {
         self.iter.cleanup(num, forward);
     }
@@ -2438,8 +2426,6 @@ impl<T, const N: usize> FusedIterator for ArrayChunksMut<'_, T, N> {}
 #[doc(hidden)]
 #[unstable(feature = "array_chunks", issue = "74985")]
 unsafe impl<'a, T, const N: usize> TrustedRandomAccess for ArrayChunksMut<'a, T, N> {
-    const NEEDS_CLEANUP: bool = false;
-
     fn cleanup(&mut self, num: usize, forward: bool) {
         self.iter.cleanup(num, forward);
     }
@@ -2612,8 +2598,6 @@ impl<T> FusedIterator for RChunks<'_, T> {}
 #[doc(hidden)]
 #[unstable(feature = "trusted_random_access", issue = "none")]
 unsafe impl<'a, T> TrustedRandomAccess for RChunks<'a, T> {
-    const NEEDS_CLEANUP: bool = false;
-
     fn cleanup(&mut self, num: usize, forward: bool) {
         if forward {
             let end = self.v.len().saturating_sub(self.chunk_size * num);
@@ -2791,8 +2775,6 @@ impl<T> FusedIterator for RChunksMut<'_, T> {}
 #[doc(hidden)]
 #[unstable(feature = "trusted_random_access", issue = "none")]
 unsafe impl<'a, T> TrustedRandomAccess for RChunksMut<'a, T> {
-    const NEEDS_CLEANUP: bool = false;
-
     fn cleanup(&mut self, num: usize, forward: bool) {
         let len = self.len();
         let v = mem::replace(&mut self.v, &mut []);
@@ -2964,8 +2946,6 @@ impl<T> FusedIterator for RChunksExact<'_, T> {}
 #[doc(hidden)]
 #[unstable(feature = "trusted_random_access", issue = "none")]
 unsafe impl<'a, T> TrustedRandomAccess for RChunksExact<'a, T> {
-    const NEEDS_CLEANUP: bool = false;
-
     fn cleanup(&mut self, num: usize, forward: bool) {
         if forward {
             let end = self.v.len() - (self.chunk_size * num);
@@ -3131,8 +3111,6 @@ impl<T> FusedIterator for RChunksExactMut<'_, T> {}
 #[doc(hidden)]
 #[unstable(feature = "trusted_random_access", issue = "none")]
 unsafe impl<'a, T> TrustedRandomAccess for RChunksExactMut<'a, T> {
-    const NEEDS_CLEANUP: bool = false;
-
     fn cleanup(&mut self, num: usize, forward: bool) {
         let v = mem::replace(&mut self.v, &mut []);
         if forward {
@@ -3148,8 +3126,6 @@ unsafe impl<'a, T> TrustedRandomAccess for RChunksExactMut<'a, T> {
 #[doc(hidden)]
 #[unstable(feature = "trusted_random_access", issue = "none")]
 unsafe impl<'a, T> TrustedRandomAccess for Iter<'a, T> {
-    const NEEDS_CLEANUP: bool = false;
-
     #[inline]
     fn cleanup(&mut self, num: usize, forward: bool) {
         if forward {
@@ -3163,8 +3139,6 @@ unsafe impl<'a, T> TrustedRandomAccess for Iter<'a, T> {
 #[doc(hidden)]
 #[unstable(feature = "trusted_random_access", issue = "none")]
 unsafe impl<'a, T> TrustedRandomAccess for IterMut<'a, T> {
-    const NEEDS_CLEANUP: bool = false;
-
     #[inline]
     fn cleanup(&mut self, num: usize, forward: bool) {
         if forward {

--- a/library/core/src/slice/iter.rs
+++ b/library/core/src/slice/iter.rs
@@ -7,7 +7,7 @@ use crate::cmp;
 use crate::cmp::Ordering;
 use crate::fmt;
 use crate::intrinsics::{assume, exact_div, unchecked_sub};
-use crate::iter::{FusedIterator, TrustedLen, TrustedRandomAccess, TrustedRandomAccessNoCoerce};
+use crate::iter::{FusedIterator, TrustedLen, TrustedRandomAccess};
 use crate::marker::{PhantomData, Send, Sized, Sync};
 use crate::mem;
 use crate::num::NonZeroUsize;
@@ -1370,11 +1370,7 @@ impl<T> FusedIterator for Windows<'_, T> {}
 
 #[doc(hidden)]
 #[unstable(feature = "trusted_random_access", issue = "none")]
-unsafe impl<'a, T> TrustedRandomAccess for Windows<'a, T> {}
-
-#[doc(hidden)]
-#[unstable(feature = "trusted_random_access", issue = "none")]
-unsafe impl<'a, T> TrustedRandomAccessNoCoerce for Windows<'a, T> {
+unsafe impl<'a, T> TrustedRandomAccess for Windows<'a, T> {
     const NEEDS_CLEANUP: bool = false;
 
     fn cleanup(&mut self, num: usize, forward: bool) {
@@ -1562,11 +1558,7 @@ impl<T> FusedIterator for Chunks<'_, T> {}
 
 #[doc(hidden)]
 #[unstable(feature = "trusted_random_access", issue = "none")]
-unsafe impl<'a, T> TrustedRandomAccess for Chunks<'a, T> {}
-
-#[doc(hidden)]
-#[unstable(feature = "trusted_random_access", issue = "none")]
-unsafe impl<'a, T> TrustedRandomAccessNoCoerce for Chunks<'a, T> {
+unsafe impl<'a, T> TrustedRandomAccess for Chunks<'a, T> {
     const NEEDS_CLEANUP: bool = false;
 
     fn cleanup(&mut self, num: usize, forward: bool) {
@@ -1742,11 +1734,7 @@ impl<T> FusedIterator for ChunksMut<'_, T> {}
 
 #[doc(hidden)]
 #[unstable(feature = "trusted_random_access", issue = "none")]
-unsafe impl<'a, T> TrustedRandomAccess for ChunksMut<'a, T> {}
-
-#[doc(hidden)]
-#[unstable(feature = "trusted_random_access", issue = "none")]
-unsafe impl<'a, T> TrustedRandomAccessNoCoerce for ChunksMut<'a, T> {
+unsafe impl<'a, T> TrustedRandomAccess for ChunksMut<'a, T> {
     const NEEDS_CLEANUP: bool = false;
 
     fn cleanup(&mut self, num: usize, forward: bool) {
@@ -1915,11 +1903,7 @@ impl<T> FusedIterator for ChunksExact<'_, T> {}
 
 #[doc(hidden)]
 #[unstable(feature = "trusted_random_access", issue = "none")]
-unsafe impl<'a, T> TrustedRandomAccess for ChunksExact<'a, T> {}
-
-#[doc(hidden)]
-#[unstable(feature = "trusted_random_access", issue = "none")]
-unsafe impl<'a, T> TrustedRandomAccessNoCoerce for ChunksExact<'a, T> {
+unsafe impl<'a, T> TrustedRandomAccess for ChunksExact<'a, T> {
     const NEEDS_CLEANUP: bool = false;
 
     fn cleanup(&mut self, num: usize, forward: bool) {
@@ -2082,11 +2066,7 @@ impl<T> FusedIterator for ChunksExactMut<'_, T> {}
 
 #[doc(hidden)]
 #[unstable(feature = "trusted_random_access", issue = "none")]
-unsafe impl<'a, T> TrustedRandomAccess for ChunksExactMut<'a, T> {}
-
-#[doc(hidden)]
-#[unstable(feature = "trusted_random_access", issue = "none")]
-unsafe impl<'a, T> TrustedRandomAccessNoCoerce for ChunksExactMut<'a, T> {
+unsafe impl<'a, T> TrustedRandomAccess for ChunksExactMut<'a, T> {
     const NEEDS_CLEANUP: bool = false;
 
     fn cleanup(&mut self, num: usize, forward: bool) {
@@ -2338,11 +2318,7 @@ impl<T, const N: usize> FusedIterator for ArrayChunks<'_, T, N> {}
 
 #[doc(hidden)]
 #[unstable(feature = "array_chunks", issue = "74985")]
-unsafe impl<'a, T, const N: usize> TrustedRandomAccess for ArrayChunks<'a, T, N> {}
-
-#[doc(hidden)]
-#[unstable(feature = "array_chunks", issue = "74985")]
-unsafe impl<'a, T, const N: usize> TrustedRandomAccessNoCoerce for ArrayChunks<'a, T, N> {
+unsafe impl<'a, T, const N: usize> TrustedRandomAccess for ArrayChunks<'a, T, N> {
     const NEEDS_CLEANUP: bool = false;
 
     fn cleanup(&mut self, num: usize, forward: bool) {
@@ -2461,11 +2437,7 @@ impl<T, const N: usize> FusedIterator for ArrayChunksMut<'_, T, N> {}
 
 #[doc(hidden)]
 #[unstable(feature = "array_chunks", issue = "74985")]
-unsafe impl<'a, T, const N: usize> TrustedRandomAccess for ArrayChunksMut<'a, T, N> {}
-
-#[doc(hidden)]
-#[unstable(feature = "array_chunks", issue = "74985")]
-unsafe impl<'a, T, const N: usize> TrustedRandomAccessNoCoerce for ArrayChunksMut<'a, T, N> {
+unsafe impl<'a, T, const N: usize> TrustedRandomAccess for ArrayChunksMut<'a, T, N> {
     const NEEDS_CLEANUP: bool = false;
 
     fn cleanup(&mut self, num: usize, forward: bool) {
@@ -2639,11 +2611,7 @@ impl<T> FusedIterator for RChunks<'_, T> {}
 
 #[doc(hidden)]
 #[unstable(feature = "trusted_random_access", issue = "none")]
-unsafe impl<'a, T> TrustedRandomAccess for RChunks<'a, T> {}
-
-#[doc(hidden)]
-#[unstable(feature = "trusted_random_access", issue = "none")]
-unsafe impl<'a, T> TrustedRandomAccessNoCoerce for RChunks<'a, T> {
+unsafe impl<'a, T> TrustedRandomAccess for RChunks<'a, T> {
     const NEEDS_CLEANUP: bool = false;
 
     fn cleanup(&mut self, num: usize, forward: bool) {
@@ -2822,11 +2790,7 @@ impl<T> FusedIterator for RChunksMut<'_, T> {}
 
 #[doc(hidden)]
 #[unstable(feature = "trusted_random_access", issue = "none")]
-unsafe impl<'a, T> TrustedRandomAccess for RChunksMut<'a, T> {}
-
-#[doc(hidden)]
-#[unstable(feature = "trusted_random_access", issue = "none")]
-unsafe impl<'a, T> TrustedRandomAccessNoCoerce for RChunksMut<'a, T> {
+unsafe impl<'a, T> TrustedRandomAccess for RChunksMut<'a, T> {
     const NEEDS_CLEANUP: bool = false;
 
     fn cleanup(&mut self, num: usize, forward: bool) {
@@ -2999,11 +2963,7 @@ impl<T> FusedIterator for RChunksExact<'_, T> {}
 
 #[doc(hidden)]
 #[unstable(feature = "trusted_random_access", issue = "none")]
-unsafe impl<'a, T> TrustedRandomAccess for RChunksExact<'a, T> {}
-
-#[doc(hidden)]
-#[unstable(feature = "trusted_random_access", issue = "none")]
-unsafe impl<'a, T> TrustedRandomAccessNoCoerce for RChunksExact<'a, T> {
+unsafe impl<'a, T> TrustedRandomAccess for RChunksExact<'a, T> {
     const NEEDS_CLEANUP: bool = false;
 
     fn cleanup(&mut self, num: usize, forward: bool) {
@@ -3170,11 +3130,7 @@ impl<T> FusedIterator for RChunksExactMut<'_, T> {}
 
 #[doc(hidden)]
 #[unstable(feature = "trusted_random_access", issue = "none")]
-unsafe impl<'a, T> TrustedRandomAccess for RChunksExactMut<'a, T> {}
-
-#[doc(hidden)]
-#[unstable(feature = "trusted_random_access", issue = "none")]
-unsafe impl<'a, T> TrustedRandomAccessNoCoerce for RChunksExactMut<'a, T> {
+unsafe impl<'a, T> TrustedRandomAccess for RChunksExactMut<'a, T> {
     const NEEDS_CLEANUP: bool = false;
 
     fn cleanup(&mut self, num: usize, forward: bool) {
@@ -3191,11 +3147,7 @@ unsafe impl<'a, T> TrustedRandomAccessNoCoerce for RChunksExactMut<'a, T> {
 
 #[doc(hidden)]
 #[unstable(feature = "trusted_random_access", issue = "none")]
-unsafe impl<'a, T> TrustedRandomAccess for Iter<'a, T> {}
-
-#[doc(hidden)]
-#[unstable(feature = "trusted_random_access", issue = "none")]
-unsafe impl<'a, T> TrustedRandomAccessNoCoerce for Iter<'a, T> {
+unsafe impl<'a, T> TrustedRandomAccess for Iter<'a, T> {
     const NEEDS_CLEANUP: bool = false;
 
     #[inline]
@@ -3210,11 +3162,7 @@ unsafe impl<'a, T> TrustedRandomAccessNoCoerce for Iter<'a, T> {
 
 #[doc(hidden)]
 #[unstable(feature = "trusted_random_access", issue = "none")]
-unsafe impl<'a, T> TrustedRandomAccess for IterMut<'a, T> {}
-
-#[doc(hidden)]
-#[unstable(feature = "trusted_random_access", issue = "none")]
-unsafe impl<'a, T> TrustedRandomAccessNoCoerce for IterMut<'a, T> {
+unsafe impl<'a, T> TrustedRandomAccess for IterMut<'a, T> {
     const NEEDS_CLEANUP: bool = false;
 
     #[inline]

--- a/library/core/src/slice/iter.rs
+++ b/library/core/src/slice/iter.rs
@@ -1375,7 +1375,6 @@ unsafe impl<'a, T> TrustedRandomAccess for Windows<'a, T> {}
 #[doc(hidden)]
 #[unstable(feature = "trusted_random_access", issue = "none")]
 unsafe impl<'a, T> TrustedRandomAccessNoCoerce for Windows<'a, T> {
-    const MAY_HAVE_SIDE_EFFECT: bool = false;
     const NEEDS_CLEANUP: bool = false;
 
     fn cleanup(&mut self, num: usize, forward: bool) {
@@ -1568,7 +1567,6 @@ unsafe impl<'a, T> TrustedRandomAccess for Chunks<'a, T> {}
 #[doc(hidden)]
 #[unstable(feature = "trusted_random_access", issue = "none")]
 unsafe impl<'a, T> TrustedRandomAccessNoCoerce for Chunks<'a, T> {
-    const MAY_HAVE_SIDE_EFFECT: bool = false;
     const NEEDS_CLEANUP: bool = false;
 
     fn cleanup(&mut self, num: usize, forward: bool) {
@@ -1749,7 +1747,6 @@ unsafe impl<'a, T> TrustedRandomAccess for ChunksMut<'a, T> {}
 #[doc(hidden)]
 #[unstable(feature = "trusted_random_access", issue = "none")]
 unsafe impl<'a, T> TrustedRandomAccessNoCoerce for ChunksMut<'a, T> {
-    const MAY_HAVE_SIDE_EFFECT: bool = false;
     const NEEDS_CLEANUP: bool = false;
 
     fn cleanup(&mut self, num: usize, forward: bool) {
@@ -1923,7 +1920,6 @@ unsafe impl<'a, T> TrustedRandomAccess for ChunksExact<'a, T> {}
 #[doc(hidden)]
 #[unstable(feature = "trusted_random_access", issue = "none")]
 unsafe impl<'a, T> TrustedRandomAccessNoCoerce for ChunksExact<'a, T> {
-    const MAY_HAVE_SIDE_EFFECT: bool = false;
     const NEEDS_CLEANUP: bool = false;
 
     fn cleanup(&mut self, num: usize, forward: bool) {
@@ -2091,7 +2087,6 @@ unsafe impl<'a, T> TrustedRandomAccess for ChunksExactMut<'a, T> {}
 #[doc(hidden)]
 #[unstable(feature = "trusted_random_access", issue = "none")]
 unsafe impl<'a, T> TrustedRandomAccessNoCoerce for ChunksExactMut<'a, T> {
-    const MAY_HAVE_SIDE_EFFECT: bool = false;
     const NEEDS_CLEANUP: bool = false;
 
     fn cleanup(&mut self, num: usize, forward: bool) {
@@ -2348,7 +2343,6 @@ unsafe impl<'a, T, const N: usize> TrustedRandomAccess for ArrayChunks<'a, T, N>
 #[doc(hidden)]
 #[unstable(feature = "array_chunks", issue = "74985")]
 unsafe impl<'a, T, const N: usize> TrustedRandomAccessNoCoerce for ArrayChunks<'a, T, N> {
-    const MAY_HAVE_SIDE_EFFECT: bool = false;
     const NEEDS_CLEANUP: bool = false;
 
     fn cleanup(&mut self, num: usize, forward: bool) {
@@ -2472,7 +2466,6 @@ unsafe impl<'a, T, const N: usize> TrustedRandomAccess for ArrayChunksMut<'a, T,
 #[doc(hidden)]
 #[unstable(feature = "array_chunks", issue = "74985")]
 unsafe impl<'a, T, const N: usize> TrustedRandomAccessNoCoerce for ArrayChunksMut<'a, T, N> {
-    const MAY_HAVE_SIDE_EFFECT: bool = false;
     const NEEDS_CLEANUP: bool = false;
 
     fn cleanup(&mut self, num: usize, forward: bool) {
@@ -2651,7 +2644,6 @@ unsafe impl<'a, T> TrustedRandomAccess for RChunks<'a, T> {}
 #[doc(hidden)]
 #[unstable(feature = "trusted_random_access", issue = "none")]
 unsafe impl<'a, T> TrustedRandomAccessNoCoerce for RChunks<'a, T> {
-    const MAY_HAVE_SIDE_EFFECT: bool = false;
     const NEEDS_CLEANUP: bool = false;
 
     fn cleanup(&mut self, num: usize, forward: bool) {
@@ -2835,7 +2827,6 @@ unsafe impl<'a, T> TrustedRandomAccess for RChunksMut<'a, T> {}
 #[doc(hidden)]
 #[unstable(feature = "trusted_random_access", issue = "none")]
 unsafe impl<'a, T> TrustedRandomAccessNoCoerce for RChunksMut<'a, T> {
-    const MAY_HAVE_SIDE_EFFECT: bool = false;
     const NEEDS_CLEANUP: bool = false;
 
     fn cleanup(&mut self, num: usize, forward: bool) {
@@ -3013,7 +3004,6 @@ unsafe impl<'a, T> TrustedRandomAccess for RChunksExact<'a, T> {}
 #[doc(hidden)]
 #[unstable(feature = "trusted_random_access", issue = "none")]
 unsafe impl<'a, T> TrustedRandomAccessNoCoerce for RChunksExact<'a, T> {
-    const MAY_HAVE_SIDE_EFFECT: bool = false;
     const NEEDS_CLEANUP: bool = false;
 
     fn cleanup(&mut self, num: usize, forward: bool) {
@@ -3185,7 +3175,6 @@ unsafe impl<'a, T> TrustedRandomAccess for RChunksExactMut<'a, T> {}
 #[doc(hidden)]
 #[unstable(feature = "trusted_random_access", issue = "none")]
 unsafe impl<'a, T> TrustedRandomAccessNoCoerce for RChunksExactMut<'a, T> {
-    const MAY_HAVE_SIDE_EFFECT: bool = false;
     const NEEDS_CLEANUP: bool = false;
 
     fn cleanup(&mut self, num: usize, forward: bool) {
@@ -3207,7 +3196,6 @@ unsafe impl<'a, T> TrustedRandomAccess for Iter<'a, T> {}
 #[doc(hidden)]
 #[unstable(feature = "trusted_random_access", issue = "none")]
 unsafe impl<'a, T> TrustedRandomAccessNoCoerce for Iter<'a, T> {
-    const MAY_HAVE_SIDE_EFFECT: bool = false;
     const NEEDS_CLEANUP: bool = false;
 
     #[inline]
@@ -3227,7 +3215,6 @@ unsafe impl<'a, T> TrustedRandomAccess for IterMut<'a, T> {}
 #[doc(hidden)]
 #[unstable(feature = "trusted_random_access", issue = "none")]
 unsafe impl<'a, T> TrustedRandomAccessNoCoerce for IterMut<'a, T> {
-    const MAY_HAVE_SIDE_EFFECT: bool = false;
     const NEEDS_CLEANUP: bool = false;
 
     #[inline]

--- a/library/core/src/slice/iter/macros.rs
+++ b/library/core/src/slice/iter/macros.rs
@@ -326,6 +326,7 @@ macro_rules! iterator {
             }
 
             #[doc(hidden)]
+            #[inline]
             unsafe fn __iterator_get_unchecked(&mut self, idx: usize) -> Self::Item {
                 // SAFETY: the caller must guarantee that `i` is in bounds of
                 // the underlying slice, so `i` cannot overflow an `isize`, and

--- a/library/core/src/str/iter.rs
+++ b/library/core/src/str/iter.rs
@@ -348,8 +348,6 @@ unsafe impl TrustedLen for Bytes<'_> {}
 #[doc(hidden)]
 #[unstable(feature = "trusted_random_access", issue = "none")]
 unsafe impl TrustedRandomAccess for Bytes<'_> {
-    const NEEDS_CLEANUP: bool = false;
-
     #[inline]
     fn cleanup(&mut self, num: usize, forward: bool) {
         self.0.cleanup(num, forward);

--- a/library/core/src/str/iter.rs
+++ b/library/core/src/str/iter.rs
@@ -349,8 +349,13 @@ unsafe impl TrustedLen for Bytes<'_> {}
 #[unstable(feature = "trusted_random_access", issue = "none")]
 unsafe impl TrustedRandomAccess for Bytes<'_> {
     #[inline]
-    fn cleanup(&mut self, num: usize, forward: bool) {
-        self.0.cleanup(num, forward);
+    fn cleanup_front(&mut self, num: usize) {
+        self.0.cleanup_front(num);
+    }
+
+    #[inline]
+    fn cleanup_back(&mut self, num: usize) {
+        self.0.cleanup_back(num);
     }
 }
 

--- a/library/core/src/str/iter.rs
+++ b/library/core/src/str/iter.rs
@@ -3,8 +3,7 @@
 use crate::char;
 use crate::fmt::{self, Write};
 use crate::iter::{Chain, FlatMap, Flatten};
-use crate::iter::{Copied, Filter, FusedIterator, Map, TrustedLen};
-use crate::iter::{TrustedRandomAccess, TrustedRandomAccessNoCoerce};
+use crate::iter::{Copied, Filter, FusedIterator, Map, TrustedLen, TrustedRandomAccess};
 use crate::ops::Try;
 use crate::option;
 use crate::slice::{self, Split as SliceSplit};
@@ -348,11 +347,7 @@ unsafe impl TrustedLen for Bytes<'_> {}
 
 #[doc(hidden)]
 #[unstable(feature = "trusted_random_access", issue = "none")]
-unsafe impl TrustedRandomAccess for Bytes<'_> {}
-
-#[doc(hidden)]
-#[unstable(feature = "trusted_random_access", issue = "none")]
-unsafe impl TrustedRandomAccessNoCoerce for Bytes<'_> {
+unsafe impl TrustedRandomAccess for Bytes<'_> {
     const NEEDS_CLEANUP: bool = false;
 
     #[inline]

--- a/library/core/src/str/iter.rs
+++ b/library/core/src/str/iter.rs
@@ -354,6 +354,12 @@ unsafe impl TrustedRandomAccess for Bytes<'_> {}
 #[unstable(feature = "trusted_random_access", issue = "none")]
 unsafe impl TrustedRandomAccessNoCoerce for Bytes<'_> {
     const MAY_HAVE_SIDE_EFFECT: bool = false;
+    const NEEDS_CLEANUP: bool = false;
+
+    #[inline]
+    fn cleanup(&mut self, num: usize, forward: bool) {
+        self.0.cleanup(num, forward);
+    }
 }
 
 /// This macro generates a Clone impl for string pattern API

--- a/library/core/src/str/iter.rs
+++ b/library/core/src/str/iter.rs
@@ -353,7 +353,6 @@ unsafe impl TrustedRandomAccess for Bytes<'_> {}
 #[doc(hidden)]
 #[unstable(feature = "trusted_random_access", issue = "none")]
 unsafe impl TrustedRandomAccessNoCoerce for Bytes<'_> {
-    const MAY_HAVE_SIDE_EFFECT: bool = false;
     const NEEDS_CLEANUP: bool = false;
 
     #[inline]

--- a/library/core/tests/iter/adapters/cloned.rs
+++ b/library/core/tests/iter/adapters/cloned.rs
@@ -31,7 +31,7 @@ fn test_cloned_side_effects() {
             .zip(&[1]);
         for _ in iter {}
     }
-    assert_eq!(count, 2);
+    assert_eq!(count, 1);
 }
 
 #[test]

--- a/library/core/tests/iter/adapters/zip.rs
+++ b/library/core/tests/iter/adapters/zip.rs
@@ -175,19 +175,6 @@ fn test_zip_map_rev_sideffectful() {
 }
 
 #[test]
-fn test_zip_nested_sideffectful() {
-    let mut xs = [0; 6];
-    let ys = [0; 4];
-
-    {
-        // test that it has the side effect nested inside enumerate
-        let it = xs.iter_mut().map(|x| *x = 1).enumerate().zip(&ys);
-        it.count();
-    }
-    assert_eq!(&xs, &[1, 1, 1, 1, 1, 0]);
-}
-
-#[test]
 fn test_zip_nth_back_side_effects_exhausted() {
     let mut a = Vec::new();
     let mut b = Vec::new();

--- a/library/core/tests/iter/adapters/zip.rs
+++ b/library/core/tests/iter/adapters/zip.rs
@@ -119,7 +119,7 @@ fn test_zip_cloned_sideffectful() {
 
     for _ in xs.iter().cloned().zip(ys.iter().cloned()) {}
 
-    assert_eq!(&xs, &[1, 1, 1, 0][..]);
+    assert_eq!(&xs, &[1, 1, 0, 0][..]);
     assert_eq!(&ys, &[1, 1][..]);
 
     let xs = [CountClone::new(), CountClone::new()];
@@ -138,7 +138,7 @@ fn test_zip_map_sideffectful() {
 
     for _ in xs.iter_mut().map(|x| *x += 1).zip(ys.iter_mut().map(|y| *y += 1)) {}
 
-    assert_eq!(&xs, &[1, 1, 1, 1, 1, 0]);
+    assert_eq!(&xs, &[1, 1, 1, 1, 0, 0]);
     assert_eq!(&ys, &[1, 1, 1, 1]);
 
     let mut xs = [0; 4];

--- a/src/test/mir-opt/remove_storage_markers.main.RemoveStorageMarkers.diff
+++ b/src/test/mir-opt/remove_storage_markers.main.RemoveStorageMarkers.diff
@@ -4,32 +4,37 @@
   fn main() -> () {
       let mut _0: ();                      // return place in scope 0 at $DIR/remove_storage_markers.rs:6:11: 6:11
       let mut _1: i32;                     // in scope 0 at $DIR/remove_storage_markers.rs:7:9: 7:16
-      let mut _2: std::ops::Range<i32>;    // in scope 0 at $DIR/remove_storage_markers.rs:8:14: 8:19
+      let mut _2: std::iter::loop_desugar::ForLoopDesugar<std::ops::Range<i32>>; // in scope 0 at $DIR/remove_storage_markers.rs:8:14: 8:19
       let mut _3: std::ops::Range<i32>;    // in scope 0 at $DIR/remove_storage_markers.rs:8:14: 8:19
       let mut _5: ();                      // in scope 0 at $DIR/remove_storage_markers.rs:6:1: 11:2
       let _6: ();                          // in scope 0 at $DIR/remove_storage_markers.rs:8:14: 8:19
       let mut _7: std::option::Option<i32>; // in scope 0 at $DIR/remove_storage_markers.rs:8:14: 8:19
-      let mut _8: &mut std::ops::Range<i32>; // in scope 0 at $DIR/remove_storage_markers.rs:8:14: 8:19
-      let mut _9: &mut std::ops::Range<i32>; // in scope 0 at $DIR/remove_storage_markers.rs:8:14: 8:19
+      let mut _8: &mut std::iter::loop_desugar::ForLoopDesugar<std::ops::Range<i32>>; // in scope 0 at $DIR/remove_storage_markers.rs:8:14: 8:19
+      let mut _9: &mut std::iter::loop_desugar::ForLoopDesugar<std::ops::Range<i32>>; // in scope 0 at $DIR/remove_storage_markers.rs:8:14: 8:19
       let mut _10: isize;                  // in scope 0 at $DIR/remove_storage_markers.rs:8:5: 10:6
       let mut _11: !;                      // in scope 0 at $DIR/remove_storage_markers.rs:8:5: 10:6
       let mut _13: i32;                    // in scope 0 at $DIR/remove_storage_markers.rs:9:16: 9:17
       scope 1 {
           debug sum => _1;                 // in scope 1 at $DIR/remove_storage_markers.rs:7:9: 7:16
-          let mut _4: std::ops::Range<i32>; // in scope 1 at $DIR/remove_storage_markers.rs:8:14: 8:19
+          let mut _4: std::iter::loop_desugar::ForLoopDesugar<std::ops::Range<i32>>; // in scope 1 at $DIR/remove_storage_markers.rs:8:14: 8:19
           scope 2 {
               debug iter => _4;            // in scope 2 at $DIR/remove_storage_markers.rs:8:14: 8:19
               let _12: i32;                // in scope 2 at $DIR/remove_storage_markers.rs:8:9: 8:10
               scope 3 {
                   debug i => _12;          // in scope 3 at $DIR/remove_storage_markers.rs:8:9: 8:10
               }
-              scope 5 (inlined iter::range::<impl Iterator for std::ops::Range<i32>>::next) { // at $DIR/remove_storage_markers.rs:8:14: 8:19
-                  debug self => _8;        // in scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
-                  let mut _14: &mut std::ops::Range<i32>; // in scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+              scope 6 (inlined <iter::loop_desugar::ForLoopDesugar<std::ops::Range<i32>> as Iterator>::next) { // at $DIR/remove_storage_markers.rs:8:14: 8:19
+                  debug self => _8;        // in scope 6 at $SRC_DIR/core/src/iter/loop_desugar.rs:LL:COL
+                  let mut _16: &mut std::iter::loop_desugar::ForLoopDesugar<std::ops::Range<i32>>; // in scope 6 at $SRC_DIR/core/src/iter/loop_desugar.rs:LL:COL
               }
           }
-          scope 4 (inlined <std::ops::Range<i32> as IntoIterator>::into_iter) { // at $DIR/remove_storage_markers.rs:8:14: 8:19
-              debug self => _3;            // in scope 4 at $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
+          scope 4 (inlined <std::ops::Range<i32> as iter::loop_desugar::IntoIterator>::into_iter) { // at $DIR/remove_storage_markers.rs:8:14: 8:19
+              debug self => _3;            // in scope 4 at $SRC_DIR/core/src/iter/loop_desugar.rs:LL:COL
+              let mut _14: std::ops::Range<i32>; // in scope 4 at $SRC_DIR/core/src/iter/loop_desugar.rs:LL:COL
+              let mut _15: std::ops::Range<i32>; // in scope 4 at $SRC_DIR/core/src/iter/loop_desugar.rs:LL:COL
+              scope 5 (inlined <std::ops::Range<i32> as IntoIterator>::into_iter) { // at $SRC_DIR/core/src/iter/loop_desugar.rs:LL:COL
+                  debug self => _15;       // in scope 5 at $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
+              }
           }
       }
   
@@ -41,7 +46,14 @@
           Deinit(_3);                      // scope 1 at $DIR/remove_storage_markers.rs:8:14: 8:19
           (_3.0: i32) = const 0_i32;       // scope 1 at $DIR/remove_storage_markers.rs:8:14: 8:19
           (_3.1: i32) = const 10_i32;      // scope 1 at $DIR/remove_storage_markers.rs:8:14: 8:19
-          _2 = move _3;                    // scope 4 at $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
+-         StorageLive(_14);                // scope 4 at $SRC_DIR/core/src/iter/loop_desugar.rs:LL:COL
+-         StorageLive(_15);                // scope 4 at $SRC_DIR/core/src/iter/loop_desugar.rs:LL:COL
+          _15 = move _3;                   // scope 4 at $SRC_DIR/core/src/iter/loop_desugar.rs:LL:COL
+          _14 = move _15;                  // scope 5 at $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
+-         StorageDead(_15);                // scope 4 at $SRC_DIR/core/src/iter/loop_desugar.rs:LL:COL
+          (_2.0: std::ops::Range<i32>) = move _14; // scope 4 at $SRC_DIR/core/src/iter/loop_desugar.rs:LL:COL
+          (_2.1: usize) = const 0_usize;   // scope 4 at $SRC_DIR/core/src/iter/loop_desugar.rs:LL:COL
+-         StorageDead(_14);                // scope 4 at $SRC_DIR/core/src/iter/loop_desugar.rs:LL:COL
 -         StorageDead(_3);                 // scope 1 at $DIR/remove_storage_markers.rs:8:18: 8:19
 -         StorageLive(_4);                 // scope 1 at $DIR/remove_storage_markers.rs:8:14: 8:19
           _4 = move _2;                    // scope 1 at $DIR/remove_storage_markers.rs:8:14: 8:19
@@ -55,12 +67,12 @@
 -         StorageLive(_9);                 // scope 2 at $DIR/remove_storage_markers.rs:8:14: 8:19
           _9 = &mut _4;                    // scope 2 at $DIR/remove_storage_markers.rs:8:14: 8:19
           _8 = &mut (*_9);                 // scope 2 at $DIR/remove_storage_markers.rs:8:14: 8:19
--         StorageLive(_14);                // scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
-          _14 = &mut (*_8);                // scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
-          _7 = <std::ops::Range<i32> as iter::range::RangeIteratorImpl>::spec_next(move _14) -> bb4; // scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+-         StorageLive(_16);                // scope 6 at $SRC_DIR/core/src/iter/loop_desugar.rs:LL:COL
+          _16 = &mut (*_8);                // scope 6 at $SRC_DIR/core/src/iter/loop_desugar.rs:LL:COL
+          _7 = <iter::loop_desugar::ForLoopDesugar<std::ops::Range<i32>> as iter::loop_desugar::DesugarSpec<i32>>::next_spec(move _16) -> bb4; // scope 6 at $SRC_DIR/core/src/iter/loop_desugar.rs:LL:COL
                                            // mir::Constant
-                                           // + span: $SRC_DIR/core/src/iter/range.rs:LL:COL
-                                           // + literal: Const { ty: for<'r> fn(&'r mut std::ops::Range<i32>) -> Option<<std::ops::Range<i32> as iter::range::RangeIteratorImpl>::Item> {<std::ops::Range<i32> as iter::range::RangeIteratorImpl>::spec_next}, val: Value(Scalar(<ZST>)) }
+                                           // + span: $SRC_DIR/core/src/iter/loop_desugar.rs:LL:COL
+                                           // + literal: Const { ty: for<'r> fn(&'r mut iter::loop_desugar::ForLoopDesugar<std::ops::Range<i32>>) -> Option<i32> {<iter::loop_desugar::ForLoopDesugar<std::ops::Range<i32>> as iter::loop_desugar::DesugarSpec<i32>>::next_spec}, val: Value(Scalar(<ZST>)) }
       }
   
       bb2: {
@@ -91,7 +103,7 @@
       }
   
       bb4: {
--         StorageDead(_14);                // scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+-         StorageDead(_16);                // scope 6 at $SRC_DIR/core/src/iter/loop_desugar.rs:LL:COL
 -         StorageDead(_8);                 // scope 2 at $DIR/remove_storage_markers.rs:8:18: 8:19
           _10 = discriminant(_7);          // scope 2 at $DIR/remove_storage_markers.rs:8:14: 8:19
           switchInt(move _10) -> [0_isize: bb3, otherwise: bb2]; // scope 2 at $DIR/remove_storage_markers.rs:8:14: 8:19

--- a/src/test/ui/consts/const-fn-error.stderr
+++ b/src/test/ui/consts/const-fn-error.stderr
@@ -35,7 +35,7 @@ LL |     for i in 0..x {
    = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
 
-error[E0015]: cannot call non-const fn `<std::ops::Range<usize> as Iterator>::next` in constant functions
+error[E0015]: cannot call non-const fn `<iter::loop_desugar::ForLoopDesugar<std::ops::Range<usize>> as Iterator>::next` in constant functions
   --> $DIR/const-fn-error.rs:5:14
    |
 LL |     for i in 0..x {

--- a/src/test/ui/consts/const-for.stderr
+++ b/src/test/ui/consts/const-for.stderr
@@ -11,7 +11,7 @@ LL | impl<I: Iterator> IntoIterator for I {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: calls in constants are limited to constant functions, tuple structs and tuple variants
 
-error[E0015]: cannot call non-const fn `<std::ops::Range<i32> as Iterator>::next` in constants
+error[E0015]: cannot call non-const fn `<iter::loop_desugar::ForLoopDesugar<std::ops::Range<i32>> as Iterator>::next` in constants
   --> $DIR/const-for.rs:5:14
    |
 LL |     for _ in 0..5 {}

--- a/src/test/ui/issues/issue-20605.stderr
+++ b/src/test/ui/issues/issue-20605.stderr
@@ -2,10 +2,10 @@ error[E0277]: the size for values of type `dyn Iterator<Item = &'a mut u8>` cann
   --> $DIR/issue-20605.rs:2:17
    |
 LL |     for item in *things { *item = 0 }
-   |                 ^^^^^^^ expected an implementor of trait `IntoIterator`
+   |                 ^^^^^^^ expected an implementor of trait `iter::loop_desugar::IntoIterator`
    |
-   = note: the trait bound `dyn Iterator<Item = &'a mut u8>: IntoIterator` is not satisfied
-   = note: required because of the requirements on the impl of `IntoIterator` for `dyn Iterator<Item = &'a mut u8>`
+   = note: the trait bound `dyn Iterator<Item = &'a mut u8>: iter::loop_desugar::IntoIterator` is not satisfied
+   = note: required because of the requirements on the impl of `iter::loop_desugar::IntoIterator` for `dyn Iterator<Item = &'a mut u8>`
 help: consider mutably borrowing here
    |
 LL |     for item in &mut *things { *item = 0 }

--- a/src/test/ui/issues/issue-33941.rs
+++ b/src/test/ui/issues/issue-33941.rs
@@ -6,4 +6,5 @@ fn main() {
     for _ in HashMap::new().iter().cloned() {} //~ ERROR type mismatch
     //~^ ERROR type mismatch
     //~| ERROR type mismatch
+    //~| ERROR type mismatch
 }

--- a/src/test/ui/issues/issue-33941.stderr
+++ b/src/test/ui/issues/issue-33941.stderr
@@ -33,6 +33,18 @@ LL |     for _ in HashMap::new().iter().cloned() {}
            found reference `&_`
    = note: required because of the requirements on the impl of `Iterator` for `Cloned<std::collections::hash_map::Iter<'_, _, _>>`
 
-error: aborting due to 3 previous errors
+error[E0271]: type mismatch resolving `<std::collections::hash_map::Iter<'_, _, _> as Iterator>::Item == &_`
+  --> $DIR/issue-33941.rs:6:14
+   |
+LL |     for _ in HashMap::new().iter().cloned() {}
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected tuple, found reference
+   |
+   = note:  expected tuple `(&_, &_)`
+           found reference `&_`
+   = note: required because of the requirements on the impl of `Iterator` for `Cloned<std::collections::hash_map::Iter<'_, _, _>>`
+   = note: 1 redundant requirement hidden
+   = note: required because of the requirements on the impl of `Iterator` for `iter::loop_desugar::ForLoopDesugar<Cloned<std::collections::hash_map::Iter<'_, _, _>>>`
+
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0271`.

--- a/src/test/ui/issues/issue-61108.stderr
+++ b/src/test/ui/issues/issue-61108.stderr
@@ -10,7 +10,7 @@ LL |     bad_letters.push('s');
    |     ^^^^^^^^^^^^^^^^^^^^^ value borrowed here after move
    |
 note: this function takes ownership of the receiver `self`, which moves `bad_letters`
-  --> $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
+  --> $SRC_DIR/core/src/iter/loop_desugar.rs:LL:COL
    |
 LL |     fn into_iter(self) -> Self::IntoIter;
    |                  ^^^^

--- a/src/test/ui/issues/issue-64559.stderr
+++ b/src/test/ui/issues/issue-64559.stderr
@@ -11,7 +11,7 @@ LL |     let _closure = || orig;
    |                    value used here after move
    |
 note: this function takes ownership of the receiver `self`, which moves `orig`
-  --> $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
+  --> $SRC_DIR/core/src/iter/loop_desugar.rs:LL:COL
    |
 LL |     fn into_iter(self) -> Self::IntoIter;
    |                  ^^^^

--- a/src/test/ui/issues/issue-83924.stderr
+++ b/src/test/ui/issues/issue-83924.stderr
@@ -11,7 +11,7 @@ LL |     for n in v {
    |              ^ value used here after move
    |
 note: this function takes ownership of the receiver `self`, which moves `v`
-  --> $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
+  --> $SRC_DIR/core/src/iter/loop_desugar.rs:LL:COL
    |
 LL |     fn into_iter(self) -> Self::IntoIter;
    |                  ^^^^

--- a/src/test/ui/loops/issue-82916.stderr
+++ b/src/test/ui/loops/issue-82916.stderr
@@ -10,7 +10,7 @@ LL |     let z = x;
    |             ^ value used here after move
    |
 note: this function takes ownership of the receiver `self`, which moves `x`
-  --> $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
+  --> $SRC_DIR/core/src/iter/loop_desugar.rs:LL:COL
    |
 LL |     fn into_iter(self) -> Self::IntoIter;
    |                  ^^^^

--- a/src/test/ui/moves/move-fn-self-receiver.stderr
+++ b/src/test/ui/moves/move-fn-self-receiver.stderr
@@ -123,6 +123,11 @@ LL |     for _val in implicit_into_iter {}
 LL |     implicit_into_iter;
    |     ^^^^^^^^^^^^^^^^^^ value used here after move
    |
+note: this function takes ownership of the receiver `self`, which moves `implicit_into_iter`
+  --> $SRC_DIR/core/src/iter/loop_desugar.rs:LL:COL
+   |
+LL |     fn into_iter(self) -> Self::IntoIter;
+   |                  ^^^^
 help: consider iterating over a slice of the `Vec<bool>`'s content to avoid moving into the `for` loop
    |
 LL |     for _val in &implicit_into_iter {}

--- a/src/test/ui/never_type/issue-52443.stderr
+++ b/src/test/ui/never_type/issue-52443.stderr
@@ -60,7 +60,7 @@ LL |     [(); { for _ in 0usize.. {}; 0}];
    = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
 
-error[E0015]: cannot call non-const fn `<RangeFrom<usize> as Iterator>::next` in constants
+error[E0015]: cannot call non-const fn `<iter::loop_desugar::ForLoopDesugar<RangeFrom<usize>> as Iterator>::next` in constants
   --> $DIR/issue-52443.rs:9:21
    |
 LL |     [(); { for _ in 0usize.. {}; 0}];

--- a/src/test/ui/suggestions/borrow-for-loop-head.stderr
+++ b/src/test/ui/suggestions/borrow-for-loop-head.stderr
@@ -16,7 +16,7 @@ LL |         for j in a {
    |                  ^ `a` moved due to this implicit call to `.into_iter()`, in previous iteration of loop
    |
 note: this function takes ownership of the receiver `self`, which moves `a`
-  --> $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
+  --> $SRC_DIR/core/src/iter/loop_desugar.rs:LL:COL
    |
 LL |     fn into_iter(self) -> Self::IntoIter;
    |                  ^^^^

--- a/src/test/ui/suggestions/for-i-in-vec.stderr
+++ b/src/test/ui/suggestions/for-i-in-vec.stderr
@@ -8,7 +8,7 @@ LL |         for _ in self.v {
    |                  move occurs because `self.v` has type `Vec<u32>`, which does not implement the `Copy` trait
    |
 note: this function takes ownership of the receiver `self`, which moves `self.v`
-  --> $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
+  --> $SRC_DIR/core/src/iter/loop_desugar.rs:LL:COL
    |
 LL |     fn into_iter(self) -> Self::IntoIter;
    |                  ^^^^
@@ -41,7 +41,7 @@ LL |     for loader in *LOADERS {
    |                   move occurs because value has type `Vec<&u8>`, which does not implement the `Copy` trait
    |
 note: this function takes ownership of the receiver `self`, which moves value
-  --> $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
+  --> $SRC_DIR/core/src/iter/loop_desugar.rs:LL:COL
    |
 LL |     fn into_iter(self) -> Self::IntoIter;
    |                  ^^^^

--- a/src/test/ui/suggestions/slice-issue-87994.stderr
+++ b/src/test/ui/suggestions/slice-issue-87994.stderr
@@ -2,10 +2,10 @@ error[E0277]: the size for values of type `[i32]` cannot be known at compilation
   --> $DIR/slice-issue-87994.rs:3:12
    |
 LL |   for _ in v[1..] {
-   |            ^^^^^^ expected an implementor of trait `IntoIterator`
+   |            ^^^^^^ expected an implementor of trait `iter::loop_desugar::IntoIterator`
    |
-   = note: the trait bound `[i32]: IntoIterator` is not satisfied
-   = note: required because of the requirements on the impl of `IntoIterator` for `[i32]`
+   = note: the trait bound `[i32]: iter::loop_desugar::IntoIterator` is not satisfied
+   = note: required because of the requirements on the impl of `iter::loop_desugar::IntoIterator` for `[i32]`
 help: consider borrowing here
    |
 LL |   for _ in &v[1..] {
@@ -32,10 +32,10 @@ error[E0277]: the size for values of type `[K]` cannot be known at compilation t
   --> $DIR/slice-issue-87994.rs:11:13
    |
 LL |   for i2 in v2[1..] {
-   |             ^^^^^^^ expected an implementor of trait `IntoIterator`
+   |             ^^^^^^^ expected an implementor of trait `iter::loop_desugar::IntoIterator`
    |
-   = note: the trait bound `[K]: IntoIterator` is not satisfied
-   = note: required because of the requirements on the impl of `IntoIterator` for `[K]`
+   = note: the trait bound `[K]: iter::loop_desugar::IntoIterator` is not satisfied
+   = note: required because of the requirements on the impl of `iter::loop_desugar::IntoIterator` for `[K]`
 help: consider borrowing here
    |
 LL |   for i2 in &v2[1..] {


### PR DESCRIPTION
The idea behind this PR is to change `for _ in` to use TrustedRandomAccessNoCoerce (TRANC) which means the optimizer immediately sees see that they're counted loops instead of only having the possibility of seeing that after inlining. This mostly alleviates the need to have single-step methods such as `Zip::next` use TRA but may also enable some other external iterations to optimize more like internal iteration.

The possible steps after this change:

* rip out the Zip specialization
* replace it with a more narrow `Zip::fold` specialization
* remove the TRANC/TRA distinction since that's only used in Zip
* add a post-loop-cleanup function to TRA and implement TRA for `try_fold`, `by_ref` and `vec::IntoIter` for Drop types. These were previously blocked on the cleanup method not being feasible with single-step methods, which this change would eliminate

So the primary goal of this PR is to open up the path to complexity reduction in Zip and potential performance gains by bringing counted loops to more iterators. This PR on its own is not expected to improve performance significantly due to the extra indirection in the loop desugaring.

Prior [Zulip discussion](https://rust-lang.zulipchat.com/#narrow/stream/219381-t-libs/topic/Improving.20TrustedRandomAccess.20and.20its.20Zip.20specialization/near/266205596) outlining the idea.

Some of the diagnostics may need fixes.

Since this uses TRA in more places this also contains the commits from #92566 for perf testing (the first two commits), but I can remove them again if we want them to land separately.