### PR TITLE
Remove deduplication of early lints

### DIFF
--- a/compiler/rustc_lint_defs/src/lib.rs
+++ b/compiler/rustc_lint_defs/src/lib.rs
@@ -282,7 +282,7 @@ pub enum ExternDepSpec {
 
 // This could be a closure, but then implementing derive trait
 // becomes hacky (and it gets allocated).
-#[derive(PartialEq, Debug)]
+#[derive(Debug)]
 pub enum BuiltinLintDiagnostics {
     Normal,
     AbsPathWithModule(Span),
@@ -309,7 +309,6 @@ pub enum BuiltinLintDiagnostics {
 
 /// Lints that are buffered up early on in the `Session` before the
 /// `LintLevels` is calculated.
-#[derive(PartialEq)]
 pub struct BufferedEarlyLint {
     /// The span of code that we are linting on.
     pub span: MultiSpan,
@@ -336,9 +335,7 @@ pub struct LintBuffer {
 impl LintBuffer {
     pub fn add_early_lint(&mut self, early_lint: BufferedEarlyLint) {
         let arr = self.map.entry(early_lint.node_id).or_default();
-        if !arr.contains(&early_lint) {
-            arr.push(early_lint);
-        }
+        arr.push(early_lint);
     }
 
     pub fn add_lint(

--- a/src/test/ui/cfg/future-compat-crate-attributes-using-cfg_attr.rs
+++ b/src/test/ui/cfg/future-compat-crate-attributes-using-cfg_attr.rs
@@ -5,8 +5,12 @@
 #![cfg_attr(foo, crate_type="bin")]
 //~^ERROR `crate_type` within
 //~| WARN this was previously accepted
+//~|ERROR `crate_type` within
+//~| WARN this was previously accepted
 #![cfg_attr(foo, crate_name="bar")]
 //~^ERROR `crate_name` within
+//~| WARN this was previously accepted
+//~|ERROR `crate_name` within
 //~| WARN this was previously accepted
 
 fn main() {}

--- a/src/test/ui/cfg/future-compat-crate-attributes-using-cfg_attr.stderr
+++ b/src/test/ui/cfg/future-compat-crate-attributes-using-cfg_attr.stderr
@@ -14,7 +14,7 @@ LL | #![deny(warnings)]
    = note: for more information, see issue #91632 <https://github.com/rust-lang/rust/issues/91632>
 
 error: `crate_name` within an `#![cfg_attr] attribute is deprecated`
-  --> $DIR/future-compat-crate-attributes-using-cfg_attr.rs:8:18
+  --> $DIR/future-compat-crate-attributes-using-cfg_attr.rs:10:18
    |
 LL | #![cfg_attr(foo, crate_name="bar")]
    |                  ^^^^^^^^^^^^^^^^
@@ -22,5 +22,23 @@ LL | #![cfg_attr(foo, crate_name="bar")]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #91632 <https://github.com/rust-lang/rust/issues/91632>
 
-error: aborting due to 2 previous errors
+error: `crate_type` within an `#![cfg_attr] attribute is deprecated`
+  --> $DIR/future-compat-crate-attributes-using-cfg_attr.rs:5:18
+   |
+LL | #![cfg_attr(foo, crate_type="bin")]
+   |                  ^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #91632 <https://github.com/rust-lang/rust/issues/91632>
+
+error: `crate_name` within an `#![cfg_attr] attribute is deprecated`
+  --> $DIR/future-compat-crate-attributes-using-cfg_attr.rs:10:18
+   |
+LL | #![cfg_attr(foo, crate_name="bar")]
+   |                  ^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #91632 <https://github.com/rust-lang/rust/issues/91632>
+
+error: aborting due to 4 previous errors
 

--- a/src/test/ui/proc-macro/issue-73933-procedural-masquerade.rs
+++ b/src/test/ui/proc-macro/issue-73933-procedural-masquerade.rs
@@ -4,7 +4,14 @@
 extern crate test_macros;
 
 #[derive(Print)]
-enum ProceduralMasqueradeDummyType { //~ ERROR using
+enum ProceduralMasqueradeDummyType {
+//~^ ERROR using
+//~| WARN this was previously
+//~| ERROR using
+//~| WARN this was previously
+//~| ERROR using
+//~| WARN this was previously
+//~| ERROR using
 //~| WARN this was previously
     Input
 }

--- a/src/test/ui/proc-macro/issue-73933-procedural-masquerade.stderr
+++ b/src/test/ui/proc-macro/issue-73933-procedural-masquerade.stderr
@@ -9,7 +9,37 @@ LL | enum ProceduralMasqueradeDummyType {
    = note: for more information, see issue #83125 <https://github.com/rust-lang/rust/issues/83125>
    = note: The `procedural-masquerade` crate has been unnecessary since Rust 1.30.0. Versions of this crate below 0.1.7 will eventually stop compiling.
 
-error: aborting due to previous error
+error: using `procedural-masquerade` crate
+  --> $DIR/issue-73933-procedural-masquerade.rs:7:6
+   |
+LL | enum ProceduralMasqueradeDummyType {
+   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #83125 <https://github.com/rust-lang/rust/issues/83125>
+   = note: The `procedural-masquerade` crate has been unnecessary since Rust 1.30.0. Versions of this crate below 0.1.7 will eventually stop compiling.
+
+error: using `procedural-masquerade` crate
+  --> $DIR/issue-73933-procedural-masquerade.rs:7:6
+   |
+LL | enum ProceduralMasqueradeDummyType {
+   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #83125 <https://github.com/rust-lang/rust/issues/83125>
+   = note: The `procedural-masquerade` crate has been unnecessary since Rust 1.30.0. Versions of this crate below 0.1.7 will eventually stop compiling.
+
+error: using `procedural-masquerade` crate
+  --> $DIR/issue-73933-procedural-masquerade.rs:7:6
+   |
+LL | enum ProceduralMasqueradeDummyType {
+   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #83125 <https://github.com/rust-lang/rust/issues/83125>
+   = note: The `procedural-masquerade` crate has been unnecessary since Rust 1.30.0. Versions of this crate below 0.1.7 will eventually stop compiling.
+
+error: aborting due to 4 previous errors
 
 Future incompatibility report: Future breakage diagnostic:
 error: using `procedural-masquerade` crate
@@ -19,6 +49,39 @@ LL | enum ProceduralMasqueradeDummyType {
    |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `#[deny(proc_macro_back_compat)]` on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #83125 <https://github.com/rust-lang/rust/issues/83125>
+   = note: The `procedural-masquerade` crate has been unnecessary since Rust 1.30.0. Versions of this crate below 0.1.7 will eventually stop compiling.
+
+Future breakage diagnostic:
+error: using `procedural-masquerade` crate
+  --> $DIR/issue-73933-procedural-masquerade.rs:7:6
+   |
+LL | enum ProceduralMasqueradeDummyType {
+   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #83125 <https://github.com/rust-lang/rust/issues/83125>
+   = note: The `procedural-masquerade` crate has been unnecessary since Rust 1.30.0. Versions of this crate below 0.1.7 will eventually stop compiling.
+
+Future breakage diagnostic:
+error: using `procedural-masquerade` crate
+  --> $DIR/issue-73933-procedural-masquerade.rs:7:6
+   |
+LL | enum ProceduralMasqueradeDummyType {
+   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #83125 <https://github.com/rust-lang/rust/issues/83125>
+   = note: The `procedural-masquerade` crate has been unnecessary since Rust 1.30.0. Versions of this crate below 0.1.7 will eventually stop compiling.
+
+Future breakage diagnostic:
+error: using `procedural-masquerade` crate
+  --> $DIR/issue-73933-procedural-masquerade.rs:7:6
+   |
+LL | enum ProceduralMasqueradeDummyType {
+   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #83125 <https://github.com/rust-lang/rust/issues/83125>
    = note: The `procedural-masquerade` crate has been unnecessary since Rust 1.30.0. Versions of this crate below 0.1.7 will eventually stop compiling.

--- a/src/test/ui/proc-macro/issue-73933-procedural-masquerade.stdout
+++ b/src/test/ui/proc-macro/issue-73933-procedural-masquerade.stdout
@@ -14,9 +14,9 @@ PRINT-DERIVE INPUT (DEBUG): TokenStream [
         stream: TokenStream [
             Ident {
                 ident: "Input",
-                span: #0 bytes(173..178),
+                span: #0 bytes(315..320),
             },
         ],
-        span: #0 bytes(121..180),
+        span: #0 bytes(121..322),
     },
 ]

--- a/src/test/ui/proc-macro/issue-75930-derive-cfg.stderr
+++ b/src/test/ui/proc-macro/issue-75930-derive-cfg.stderr
@@ -11,5 +11,17 @@ LL | #[derive(Print)]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #79202 <https://github.com/rust-lang/rust/issues/79202>
 
-warning: 1 warning emitted
+warning: derive helper attribute is used before it is introduced
+  --> $DIR/issue-75930-derive-cfg.rs:19:3
+   |
+LL | #[print_helper(a)]
+   |   ^^^^^^^^^^^^
+...
+LL | #[derive(Print)]
+   |          ----- the attribute is introduced here
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #79202 <https://github.com/rust-lang/rust/issues/79202>
+
+warning: 2 warnings emitted
 

--- a/src/test/ui/rust-2018/edition-lint-nested-empty-paths.fixed
+++ b/src/test/ui/rust-2018/edition-lint-nested-empty-paths.fixed
@@ -17,13 +17,27 @@ crate mod foo {
 use crate::foo::{bar::{baz::{}}};
 //~^ ERROR absolute paths must start with
 //~| WARN this is accepted in the current edition
+//~| ERROR absolute paths must start with
+//~| WARN this is accepted in the current edition
 
 use crate::foo::{bar::{XX, baz::{}}};
 //~^ ERROR absolute paths must start with
 //~| WARN this is accepted in the current edition
+//~| ERROR absolute paths must start with
+//~| WARN this is accepted in the current edition
+//~| ERROR absolute paths must start with
+//~| WARN this is accepted in the current edition
+//~| ERROR absolute paths must start with
+//~| WARN this is accepted in the current edition
 
 use crate::foo::{bar::{baz::{}, baz1::{}}};
 //~^ ERROR absolute paths must start with
+//~| WARN this is accepted in the current edition
+//~| ERROR absolute paths must start with
+//~| WARN this is accepted in the current edition
+//~| ERROR absolute paths must start with
+//~| WARN this is accepted in the current edition
+//~| ERROR absolute paths must start with
 //~| WARN this is accepted in the current edition
 
 fn main() {

--- a/src/test/ui/rust-2018/edition-lint-nested-empty-paths.rs
+++ b/src/test/ui/rust-2018/edition-lint-nested-empty-paths.rs
@@ -17,13 +17,27 @@ crate mod foo {
 use foo::{bar::{baz::{}}};
 //~^ ERROR absolute paths must start with
 //~| WARN this is accepted in the current edition
+//~| ERROR absolute paths must start with
+//~| WARN this is accepted in the current edition
 
 use foo::{bar::{XX, baz::{}}};
 //~^ ERROR absolute paths must start with
 //~| WARN this is accepted in the current edition
+//~| ERROR absolute paths must start with
+//~| WARN this is accepted in the current edition
+//~| ERROR absolute paths must start with
+//~| WARN this is accepted in the current edition
+//~| ERROR absolute paths must start with
+//~| WARN this is accepted in the current edition
 
 use foo::{bar::{baz::{}, baz1::{}}};
 //~^ ERROR absolute paths must start with
+//~| WARN this is accepted in the current edition
+//~| ERROR absolute paths must start with
+//~| WARN this is accepted in the current edition
+//~| ERROR absolute paths must start with
+//~| WARN this is accepted in the current edition
+//~| ERROR absolute paths must start with
 //~| WARN this is accepted in the current edition
 
 fn main() {

--- a/src/test/ui/rust-2018/edition-lint-nested-empty-paths.stderr
+++ b/src/test/ui/rust-2018/edition-lint-nested-empty-paths.stderr
@@ -13,7 +13,16 @@ LL | #![deny(absolute_paths_not_starting_with_crate)]
    = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
 
 error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
-  --> $DIR/edition-lint-nested-empty-paths.rs:21:5
+  --> $DIR/edition-lint-nested-empty-paths.rs:17:5
+   |
+LL | use foo::{bar::{baz::{}}};
+   |     ^^^^^^^^^^^^^^^^^^^^^ help: use `crate`: `crate::foo::{bar::{baz::{}}}`
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2018!
+   = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
+
+error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
+  --> $DIR/edition-lint-nested-empty-paths.rs:23:5
    |
 LL | use foo::{bar::{XX, baz::{}}};
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `crate`: `crate::foo::{bar::{XX, baz::{}}}`
@@ -22,7 +31,34 @@ LL | use foo::{bar::{XX, baz::{}}};
    = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
 
 error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
-  --> $DIR/edition-lint-nested-empty-paths.rs:25:5
+  --> $DIR/edition-lint-nested-empty-paths.rs:23:5
+   |
+LL | use foo::{bar::{XX, baz::{}}};
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `crate`: `crate::foo::{bar::{XX, baz::{}}}`
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2018!
+   = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
+
+error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
+  --> $DIR/edition-lint-nested-empty-paths.rs:23:5
+   |
+LL | use foo::{bar::{XX, baz::{}}};
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `crate`: `crate::foo::{bar::{XX, baz::{}}}`
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2018!
+   = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
+
+error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
+  --> $DIR/edition-lint-nested-empty-paths.rs:23:5
+   |
+LL | use foo::{bar::{XX, baz::{}}};
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `crate`: `crate::foo::{bar::{XX, baz::{}}}`
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2018!
+   = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
+
+error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
+  --> $DIR/edition-lint-nested-empty-paths.rs:33:5
    |
 LL | use foo::{bar::{baz::{}, baz1::{}}};
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `crate`: `crate::foo::{bar::{baz::{}, baz1::{}}}`
@@ -30,5 +66,32 @@ LL | use foo::{bar::{baz::{}, baz1::{}}};
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2018!
    = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
 
-error: aborting due to 3 previous errors
+error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
+  --> $DIR/edition-lint-nested-empty-paths.rs:33:5
+   |
+LL | use foo::{bar::{baz::{}, baz1::{}}};
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `crate`: `crate::foo::{bar::{baz::{}, baz1::{}}}`
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2018!
+   = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
+
+error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
+  --> $DIR/edition-lint-nested-empty-paths.rs:33:5
+   |
+LL | use foo::{bar::{baz::{}, baz1::{}}};
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `crate`: `crate::foo::{bar::{baz::{}, baz1::{}}}`
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2018!
+   = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
+
+error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
+  --> $DIR/edition-lint-nested-empty-paths.rs:33:5
+   |
+LL | use foo::{bar::{baz::{}, baz1::{}}};
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `crate`: `crate::foo::{bar::{baz::{}, baz1::{}}}`
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2018!
+   = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
+
+error: aborting due to 10 previous errors
 

--- a/src/test/ui/rust-2018/edition-lint-nested-paths.fixed
+++ b/src/test/ui/rust-2018/edition-lint-nested-paths.fixed
@@ -6,6 +6,12 @@
 use crate::foo::{a, b};
 //~^ ERROR absolute paths must start with
 //~| this is accepted in the current edition
+//~| ERROR absolute paths must start with
+//~| this is accepted in the current edition
+//~| ERROR absolute paths must start with
+//~| this is accepted in the current edition
+//~| ERROR absolute paths must start with
+//~| this is accepted in the current edition
 
 mod foo {
     crate fn a() {}
@@ -20,6 +26,10 @@ fn main() {
     {
         use crate::foo::{self as x, c};
         //~^ ERROR absolute paths must start with
+        //~| this is accepted in the current edition
+        //~| ERROR absolute paths must start with
+        //~| this is accepted in the current edition
+        //~| ERROR absolute paths must start with
         //~| this is accepted in the current edition
         x::a();
         c();

--- a/src/test/ui/rust-2018/edition-lint-nested-paths.rs
+++ b/src/test/ui/rust-2018/edition-lint-nested-paths.rs
@@ -6,6 +6,12 @@
 use foo::{a, b};
 //~^ ERROR absolute paths must start with
 //~| this is accepted in the current edition
+//~| ERROR absolute paths must start with
+//~| this is accepted in the current edition
+//~| ERROR absolute paths must start with
+//~| this is accepted in the current edition
+//~| ERROR absolute paths must start with
+//~| this is accepted in the current edition
 
 mod foo {
     crate fn a() {}
@@ -20,6 +26,10 @@ fn main() {
     {
         use foo::{self as x, c};
         //~^ ERROR absolute paths must start with
+        //~| this is accepted in the current edition
+        //~| ERROR absolute paths must start with
+        //~| this is accepted in the current edition
+        //~| ERROR absolute paths must start with
         //~| this is accepted in the current edition
         x::a();
         c();

--- a/src/test/ui/rust-2018/edition-lint-nested-paths.stderr
+++ b/src/test/ui/rust-2018/edition-lint-nested-paths.stderr
@@ -13,7 +13,34 @@ LL | #![deny(absolute_paths_not_starting_with_crate)]
    = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
 
 error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
-  --> $DIR/edition-lint-nested-paths.rs:21:13
+  --> $DIR/edition-lint-nested-paths.rs:6:5
+   |
+LL | use foo::{a, b};
+   |     ^^^^^^^^^^^ help: use `crate`: `crate::foo::{a, b}`
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2018!
+   = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
+
+error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
+  --> $DIR/edition-lint-nested-paths.rs:6:5
+   |
+LL | use foo::{a, b};
+   |     ^^^^^^^^^^^ help: use `crate`: `crate::foo::{a, b}`
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2018!
+   = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
+
+error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
+  --> $DIR/edition-lint-nested-paths.rs:6:5
+   |
+LL | use foo::{a, b};
+   |     ^^^^^^^^^^^ help: use `crate`: `crate::foo::{a, b}`
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2018!
+   = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
+
+error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
+  --> $DIR/edition-lint-nested-paths.rs:27:13
    |
 LL |         use foo::{self as x, c};
    |             ^^^^^^^^^^^^^^^^^^^ help: use `crate`: `crate::foo::{self as x, c}`
@@ -21,5 +48,23 @@ LL |         use foo::{self as x, c};
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2018!
    = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
 
-error: aborting due to 2 previous errors
+error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
+  --> $DIR/edition-lint-nested-paths.rs:27:13
+   |
+LL |         use foo::{self as x, c};
+   |             ^^^^^^^^^^^^^^^^^^^ help: use `crate`: `crate::foo::{self as x, c}`
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2018!
+   = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
+
+error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
+  --> $DIR/edition-lint-nested-paths.rs:27:13
+   |
+LL |         use foo::{self as x, c};
+   |             ^^^^^^^^^^^^^^^^^^^ help: use `crate`: `crate::foo::{self as x, c}`
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2018!
+   = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
+
+error: aborting due to 7 previous errors
 

--- a/src/test/ui/rust-2018/edition-lint-paths.fixed
+++ b/src/test/ui/rust-2018/edition-lint-paths.fixed
@@ -12,16 +12,24 @@ pub mod foo {
     use crate::bar::Bar;
     //~^ ERROR absolute
     //~| WARN this is accepted in the current edition
+    //~| ERROR absolute
+    //~| WARN this is accepted in the current edition
+
     use super::bar::Bar2;
     use crate::bar::Bar3;
 
     use crate::bar;
     //~^ ERROR absolute
     //~| WARN this is accepted in the current edition
+
     use crate::bar as something_else;
 
     use crate::{main, Bar as SomethingElse};
     //~^ ERROR absolute
+    //~| WARN this is accepted in the current edition
+    //~| ERROR absolute
+    //~| WARN this is accepted in the current edition
+    //~| ERROR absolute
     //~| WARN this is accepted in the current edition
 
     use crate::{main as another_main, Bar as SomethingElse2};
@@ -33,6 +41,8 @@ pub mod foo {
 
 use crate::bar::Bar;
 //~^ ERROR absolute
+//~| WARN this is accepted in the current edition
+//~| ERROR absolute
 //~| WARN this is accepted in the current edition
 
 pub mod bar {
@@ -51,11 +61,14 @@ mod baz {
 impl crate::foo::SomeTrait for u32 {}
 //~^ ERROR absolute
 //~| WARN this is accepted in the current edition
+//~| ERROR absolute
+//~| WARN this is accepted in the current edition
 
 fn main() {
     let x = crate::bar::Bar;
     //~^ ERROR absolute
     //~| WARN this is accepted in the current edition
+
     let x = bar::Bar;
     let x = crate::bar::Bar;
     let x = self::bar::Bar;

--- a/src/test/ui/rust-2018/edition-lint-paths.rs
+++ b/src/test/ui/rust-2018/edition-lint-paths.rs
@@ -12,16 +12,24 @@ pub mod foo {
     use bar::Bar;
     //~^ ERROR absolute
     //~| WARN this is accepted in the current edition
+    //~| ERROR absolute
+    //~| WARN this is accepted in the current edition
+
     use super::bar::Bar2;
     use crate::bar::Bar3;
 
     use bar;
     //~^ ERROR absolute
     //~| WARN this is accepted in the current edition
+
     use crate::bar as something_else;
 
     use {main, Bar as SomethingElse};
     //~^ ERROR absolute
+    //~| WARN this is accepted in the current edition
+    //~| ERROR absolute
+    //~| WARN this is accepted in the current edition
+    //~| ERROR absolute
     //~| WARN this is accepted in the current edition
 
     use crate::{main as another_main, Bar as SomethingElse2};
@@ -33,6 +41,8 @@ pub mod foo {
 
 use bar::Bar;
 //~^ ERROR absolute
+//~| WARN this is accepted in the current edition
+//~| ERROR absolute
 //~| WARN this is accepted in the current edition
 
 pub mod bar {
@@ -51,11 +61,14 @@ mod baz {
 impl ::foo::SomeTrait for u32 {}
 //~^ ERROR absolute
 //~| WARN this is accepted in the current edition
+//~| ERROR absolute
+//~| WARN this is accepted in the current edition
 
 fn main() {
     let x = ::bar::Bar;
     //~^ ERROR absolute
     //~| WARN this is accepted in the current edition
+
     let x = bar::Bar;
     let x = crate::bar::Bar;
     let x = self::bar::Bar;

--- a/src/test/ui/rust-2018/edition-lint-paths.stderr
+++ b/src/test/ui/rust-2018/edition-lint-paths.stderr
@@ -13,7 +13,16 @@ LL | #![deny(absolute_paths_not_starting_with_crate)]
    = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
 
 error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
-  --> $DIR/edition-lint-paths.rs:18:9
+  --> $DIR/edition-lint-paths.rs:12:9
+   |
+LL |     use bar::Bar;
+   |         ^^^^^^^^ help: use `crate`: `crate::bar::Bar`
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2018!
+   = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
+
+error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
+  --> $DIR/edition-lint-paths.rs:21:9
    |
 LL |     use bar;
    |         ^^^ help: use `crate`: `crate::bar`
@@ -22,7 +31,7 @@ LL |     use bar;
    = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
 
 error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
-  --> $DIR/edition-lint-paths.rs:23:9
+  --> $DIR/edition-lint-paths.rs:27:9
    |
 LL |     use {main, Bar as SomethingElse};
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `crate`: `crate::{main, Bar as SomethingElse}`
@@ -31,7 +40,25 @@ LL |     use {main, Bar as SomethingElse};
    = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
 
 error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
-  --> $DIR/edition-lint-paths.rs:34:5
+  --> $DIR/edition-lint-paths.rs:27:9
+   |
+LL |     use {main, Bar as SomethingElse};
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `crate`: `crate::{main, Bar as SomethingElse}`
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2018!
+   = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
+
+error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
+  --> $DIR/edition-lint-paths.rs:27:9
+   |
+LL |     use {main, Bar as SomethingElse};
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `crate`: `crate::{main, Bar as SomethingElse}`
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2018!
+   = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
+
+error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
+  --> $DIR/edition-lint-paths.rs:42:5
    |
 LL | use bar::Bar;
    |     ^^^^^^^^ help: use `crate`: `crate::bar::Bar`
@@ -40,7 +67,16 @@ LL | use bar::Bar;
    = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
 
 error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
-  --> $DIR/edition-lint-paths.rs:46:9
+  --> $DIR/edition-lint-paths.rs:42:5
+   |
+LL | use bar::Bar;
+   |     ^^^^^^^^ help: use `crate`: `crate::bar::Bar`
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2018!
+   = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
+
+error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
+  --> $DIR/edition-lint-paths.rs:56:9
    |
 LL |     use *;
    |         ^ help: use `crate`: `crate::*`
@@ -49,7 +85,7 @@ LL |     use *;
    = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
 
 error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
-  --> $DIR/edition-lint-paths.rs:51:6
+  --> $DIR/edition-lint-paths.rs:61:6
    |
 LL | impl ::foo::SomeTrait for u32 {}
    |      ^^^^^^^^^^^^^^^^ help: use `crate`: `crate::foo::SomeTrait`
@@ -58,7 +94,16 @@ LL | impl ::foo::SomeTrait for u32 {}
    = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
 
 error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
-  --> $DIR/edition-lint-paths.rs:56:13
+  --> $DIR/edition-lint-paths.rs:61:6
+   |
+LL | impl ::foo::SomeTrait for u32 {}
+   |      ^^^^^^^^^^^^^^^^ help: use `crate`: `crate::foo::SomeTrait`
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2018!
+   = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
+
+error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
+  --> $DIR/edition-lint-paths.rs:68:13
    |
 LL |     let x = ::bar::Bar;
    |             ^^^^^^^^^^ help: use `crate`: `crate::bar::Bar`
@@ -66,5 +111,5 @@ LL |     let x = ::bar::Bar;
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2018!
    = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
 
-error: aborting due to 7 previous errors
+error: aborting due to 12 previous errors
 

--- a/src/test/ui/rust-2018/extern-crate-rename.fixed
+++ b/src/test/ui/rust-2018/extern-crate-rename.fixed
@@ -12,6 +12,8 @@ extern crate edition_lint_paths as my_crate;
 use crate::my_crate::foo;
 //~^ ERROR absolute paths must start
 //~| WARNING this is accepted in the current edition
+//~| ERROR absolute paths must start
+//~| WARNING this is accepted in the current edition
 
 fn main() {
     foo();

--- a/src/test/ui/rust-2018/extern-crate-rename.rs
+++ b/src/test/ui/rust-2018/extern-crate-rename.rs
@@ -12,6 +12,8 @@ extern crate edition_lint_paths as my_crate;
 use my_crate::foo;
 //~^ ERROR absolute paths must start
 //~| WARNING this is accepted in the current edition
+//~| ERROR absolute paths must start
+//~| WARNING this is accepted in the current edition
 
 fn main() {
     foo();

--- a/src/test/ui/rust-2018/extern-crate-rename.stderr
+++ b/src/test/ui/rust-2018/extern-crate-rename.stderr
@@ -12,5 +12,14 @@ LL | #![deny(absolute_paths_not_starting_with_crate)]
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2018!
    = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
 
-error: aborting due to previous error
+error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
+  --> $DIR/extern-crate-rename.rs:12:5
+   |
+LL | use my_crate::foo;
+   |     ^^^^^^^^^^^^^ help: use `crate`: `crate::my_crate::foo`
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2018!
+   = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
+
+error: aborting due to 2 previous errors
 

--- a/src/test/ui/rust-2018/extern-crate-submod.fixed
+++ b/src/test/ui/rust-2018/extern-crate-submod.fixed
@@ -19,6 +19,9 @@ mod m {
 use crate::m::edition_lint_paths::foo;
 //~^ ERROR absolute paths must start
 //~| WARNING this is accepted in the current edition
+//~| ERROR absolute paths must start
+//~| WARNING this is accepted in the current edition
+
 
 fn main() {
     foo();

--- a/src/test/ui/rust-2018/extern-crate-submod.rs
+++ b/src/test/ui/rust-2018/extern-crate-submod.rs
@@ -19,6 +19,9 @@ mod m {
 use m::edition_lint_paths::foo;
 //~^ ERROR absolute paths must start
 //~| WARNING this is accepted in the current edition
+//~| ERROR absolute paths must start
+//~| WARNING this is accepted in the current edition
+
 
 fn main() {
     foo();

--- a/src/test/ui/rust-2018/extern-crate-submod.stderr
+++ b/src/test/ui/rust-2018/extern-crate-submod.stderr
@@ -12,5 +12,14 @@ LL | #![deny(absolute_paths_not_starting_with_crate)]
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2018!
    = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
 
-error: aborting due to previous error
+error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
+  --> $DIR/extern-crate-submod.rs:19:5
+   |
+LL | use m::edition_lint_paths::foo;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `crate`: `crate::m::edition_lint_paths::foo`
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2018!
+   = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
+
+error: aborting due to 2 previous errors
 


### PR DESCRIPTION
We already have a general mechanism for deduplicating reported
lints, so there's no need to have an additional one for early lints
specifically. This allows us to remove some `PartialEq` impls.