### PR TITLE
Experiment: mark derived Clone impls as const

### DIFF
--- a/compiler/rustc_builtin_macros/src/deriving/bounds.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/bounds.rs
@@ -20,6 +20,7 @@ pub fn expand_deriving_copy(
         additional_bounds: Vec::new(),
         generics: Bounds::empty(),
         is_unsafe: false,
+        is_const: false,
         supports_unions: true,
         methods: Vec::new(),
         associated_types: Vec::new(),

--- a/compiler/rustc_builtin_macros/src/deriving/cmp/eq.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/cmp/eq.rs
@@ -28,6 +28,7 @@ pub fn expand_deriving_eq(
         additional_bounds: Vec::new(),
         generics: Bounds::empty(),
         is_unsafe: false,
+        is_const: false,
         supports_unions: true,
         methods: vec![MethodDef {
             name: sym::assert_receiver_is_total_eq,

--- a/compiler/rustc_builtin_macros/src/deriving/cmp/ord.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/cmp/ord.rs
@@ -24,6 +24,7 @@ pub fn expand_deriving_ord(
         additional_bounds: Vec::new(),
         generics: Bounds::empty(),
         is_unsafe: false,
+        is_const: false,
         supports_unions: false,
         methods: vec![MethodDef {
             name: sym::cmp,

--- a/compiler/rustc_builtin_macros/src/deriving/cmp/partial_eq.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/cmp/partial_eq.rs
@@ -104,6 +104,7 @@ pub fn expand_deriving_partial_eq(
         additional_bounds: Vec::new(),
         generics: Bounds::empty(),
         is_unsafe: false,
+        is_const: false,
         supports_unions: false,
         methods,
         associated_types: Vec::new(),

--- a/compiler/rustc_builtin_macros/src/deriving/cmp/partial_ord.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/cmp/partial_ord.rs
@@ -47,6 +47,7 @@ pub fn expand_deriving_partial_ord(
         additional_bounds: vec![],
         generics: Bounds::empty(),
         is_unsafe: false,
+        is_const: false,
         supports_unions: false,
         methods: vec![partial_cmp_def],
         associated_types: Vec::new(),

--- a/compiler/rustc_builtin_macros/src/deriving/debug.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/debug.rs
@@ -30,6 +30,7 @@ pub fn expand_deriving_debug(
         additional_bounds: Vec::new(),
         generics: Bounds::empty(),
         is_unsafe: false,
+        is_const: false,
         supports_unions: false,
         methods: vec![MethodDef {
             name: sym::fmt,

--- a/compiler/rustc_builtin_macros/src/deriving/decodable.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/decodable.rs
@@ -27,6 +27,7 @@ pub fn expand_deriving_rustc_decodable(
         additional_bounds: Vec::new(),
         generics: Bounds::empty(),
         is_unsafe: false,
+        is_const: false,
         supports_unions: false,
         methods: vec![MethodDef {
             name: sym::decode,

--- a/compiler/rustc_builtin_macros/src/deriving/default.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/default.rs
@@ -31,6 +31,7 @@ pub fn expand_deriving_default(
         additional_bounds: Vec::new(),
         generics: Bounds::empty(),
         is_unsafe: false,
+        is_const: false,
         supports_unions: false,
         methods: vec![MethodDef {
             name: kw::Default,

--- a/compiler/rustc_builtin_macros/src/deriving/encodable.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/encodable.rs
@@ -112,6 +112,7 @@ pub fn expand_deriving_rustc_encodable(
         additional_bounds: Vec::new(),
         generics: Bounds::empty(),
         is_unsafe: false,
+        is_const: false,
         supports_unions: false,
         methods: vec![MethodDef {
             name: sym::encode,

--- a/compiler/rustc_builtin_macros/src/deriving/hash.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/hash.rs
@@ -27,6 +27,7 @@ pub fn expand_deriving_hash(
         additional_bounds: Vec::new(),
         generics: Bounds::empty(),
         is_unsafe: false,
+        is_const: false,
         supports_unions: false,
         methods: vec![MethodDef {
             name: sym::hash,

--- a/compiler/rustc_expand/src/build.rs
+++ b/compiler/rustc_expand/src/build.rs
@@ -128,11 +128,12 @@ impl<'a> ExtCtxt<'a> {
         }
     }
 
-    pub fn trait_bound(&self, path: ast::Path) -> ast::GenericBound {
-        ast::GenericBound::Trait(
-            self.poly_trait_ref(path.span, path),
-            ast::TraitBoundModifier::None,
-        )
+    pub fn trait_bound(
+        &self,
+        path: ast::Path,
+        modif: ast::TraitBoundModifier,
+    ) -> ast::GenericBound {
+        ast::GenericBound::Trait(self.poly_trait_ref(path.span, path), modif)
     }
 
     pub fn lifetime(&self, span: Span, ident: Ident) -> ast::Lifetime {
@@ -566,5 +567,13 @@ impl<'a> ExtCtxt<'a> {
 
     pub fn meta_word(&self, sp: Span, w: Symbol) -> ast::MetaItem {
         attr::mk_word_item(Ident::new(w, sp))
+    }
+
+    pub fn meta_name_value(&self, sp: Span, n: Symbol, v: Symbol) -> ast::NestedMetaItem {
+        ast::NestedMetaItem::MetaItem(attr::mk_name_value_item_str(Ident::new(n, sp), v, sp))
+    }
+
+    pub fn meta_list(&self, sp: Span, w: Symbol, items: Vec<ast::NestedMetaItem>) -> ast::MetaItem {
+        attr::mk_list_item(Ident::new(w, sp), items)
     }
 }

--- a/library/core/src/clone.rs
+++ b/library/core/src/clone.rs
@@ -127,7 +127,11 @@ pub trait Clone: Sized {
     /// allocations.
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
-    fn clone_from(&mut self, source: &Self) {
+    #[default_method_body_is_const]
+    fn clone_from(&mut self, source: &Self)
+    where
+        Self: ~const Clone + ~const Drop,
+    {
         *self = source.clone()
     }
 }
@@ -178,7 +182,8 @@ mod impls {
         ($($t:ty)*) => {
             $(
                 #[stable(feature = "rust1", since = "1.0.0")]
-                impl Clone for $t {
+                #[rustc_const_unstable(feature = "const_clone", issue = "none")]
+                impl const Clone for $t {
                     #[inline]
                     fn clone(&self) -> Self {
                         *self
@@ -196,7 +201,8 @@ mod impls {
     }
 
     #[unstable(feature = "never_type", issue = "35121")]
-    impl Clone for ! {
+    #[rustc_const_unstable(feature = "const_clone", issue = "none")]
+    impl const Clone for ! {
         #[inline]
         fn clone(&self) -> Self {
             *self
@@ -204,7 +210,8 @@ mod impls {
     }
 
     #[stable(feature = "rust1", since = "1.0.0")]
-    impl<T: ?Sized> Clone for *const T {
+    #[rustc_const_unstable(feature = "const_clone", issue = "none")]
+    impl<T: ?Sized> const Clone for *const T {
         #[inline]
         fn clone(&self) -> Self {
             *self
@@ -212,7 +219,8 @@ mod impls {
     }
 
     #[stable(feature = "rust1", since = "1.0.0")]
-    impl<T: ?Sized> Clone for *mut T {
+    #[rustc_const_unstable(feature = "const_clone", issue = "none")]
+    impl<T: ?Sized> const Clone for *mut T {
         #[inline]
         fn clone(&self) -> Self {
             *self
@@ -221,7 +229,8 @@ mod impls {
 
     /// Shared references can be cloned, but mutable references *cannot*!
     #[stable(feature = "rust1", since = "1.0.0")]
-    impl<T: ?Sized> Clone for &T {
+    #[rustc_const_unstable(feature = "const_clone", issue = "none")]
+    impl<T: ?Sized> const Clone for &T {
         #[inline]
         #[rustc_diagnostic_item = "noop_method_clone"]
         fn clone(&self) -> Self {

--- a/src/test/ui/derives/deriving-copyclone.rs
+++ b/src/test/ui/derives/deriving-copyclone.rs
@@ -1,22 +1,34 @@
+#![feature(const_trait_impl)]
+
 // this will get a no-op Clone impl
 #[derive(Copy, Clone)]
 struct A {
     a: i32,
-    b: i64
+    b: i64,
 }
 
 // this will get a deep Clone impl
 #[derive(Copy, Clone)]
 struct B<T> {
     a: i32,
-    b: T
+    b: T,
 }
 
 struct C; // not Copy or Clone
-#[derive(Clone)] struct D; // Clone but not Copy
+#[derive(Clone)]
+struct D; // Clone but not Copy
+
+// not const Clone or Copy
+struct E(A);
+impl Clone for E {
+    fn clone(&self) -> E {
+        *self
+    }
+}
+impl Copy for E {}
 
 fn is_copy<T: Copy>(_: T) {}
-fn is_clone<T: Clone>(_: T) {}
+const fn is_clone<T: ~const Clone>(_: T) {}
 
 fn main() {
     // A can be copied and cloned
@@ -35,3 +47,9 @@ fn main() {
     is_copy(B { a: 1, b: D }); //~ ERROR Copy
     is_clone(B { a: 1, b: D });
 }
+
+// A can be cloned in a const context
+const _: () = is_clone(A { a: 1, b: 2 });
+
+// E can't be cloned in a const context
+const _: () = is_clone(E(A { a: 1, b: 2 })); //~ ERROR Clone

--- a/src/test/ui/derives/deriving-copyclone.stderr
+++ b/src/test/ui/derives/deriving-copyclone.stderr
@@ -1,5 +1,19 @@
+error[E0277]: the trait bound `E: ~const Clone` is not satisfied
+  --> $DIR/deriving-copyclone.rs:55:24
+   |
+LL | const _: () = is_clone(E(A { a: 1, b: 2 }));
+   |               -------- ^^^^^^^^^^^^^^^^^^^ the trait `~const Clone` is not implemented for `E`
+   |               |
+   |               required by a bound introduced by this call
+   |
+note: required by a bound in `is_clone`
+  --> $DIR/deriving-copyclone.rs:31:22
+   |
+LL | const fn is_clone<T: ~const Clone>(_: T) {}
+   |                      ^^^^^^^^^^^^ required by this bound in `is_clone`
+
 error[E0277]: the trait bound `B<C>: Copy` is not satisfied
-  --> $DIR/deriving-copyclone.rs:31:13
+  --> $DIR/deriving-copyclone.rs:43:13
    |
 LL |     is_copy(B { a: 1, b: C });
    |     ------- ^^^^^^^^^^^^^^^^ expected an implementor of trait `Copy`
@@ -7,12 +21,12 @@ LL |     is_copy(B { a: 1, b: C });
    |     required by a bound introduced by this call
    |
 note: required because of the requirements on the impl of `Copy` for `B<C>`
-  --> $DIR/deriving-copyclone.rs:9:10
+  --> $DIR/deriving-copyclone.rs:11:10
    |
 LL | #[derive(Copy, Clone)]
    |          ^^^^
 note: required by a bound in `is_copy`
-  --> $DIR/deriving-copyclone.rs:18:15
+  --> $DIR/deriving-copyclone.rs:30:15
    |
 LL | fn is_copy<T: Copy>(_: T) {}
    |               ^^^^ required by this bound in `is_copy`
@@ -22,24 +36,24 @@ help: consider borrowing here
 LL |     is_copy(&B { a: 1, b: C });
    |             +
 
-error[E0277]: the trait bound `B<C>: Clone` is not satisfied
-  --> $DIR/deriving-copyclone.rs:32:14
+error[E0277]: the trait bound `B<C>: ~const Clone` is not satisfied
+  --> $DIR/deriving-copyclone.rs:44:14
    |
 LL |     is_clone(B { a: 1, b: C });
-   |     -------- ^^^^^^^^^^^^^^^^ expected an implementor of trait `Clone`
+   |     -------- ^^^^^^^^^^^^^^^^ expected an implementor of trait `~const Clone`
    |     |
    |     required by a bound introduced by this call
    |
 note: required because of the requirements on the impl of `Clone` for `B<C>`
-  --> $DIR/deriving-copyclone.rs:9:16
+  --> $DIR/deriving-copyclone.rs:11:16
    |
 LL | #[derive(Copy, Clone)]
    |                ^^^^^
 note: required by a bound in `is_clone`
-  --> $DIR/deriving-copyclone.rs:19:16
+  --> $DIR/deriving-copyclone.rs:31:22
    |
-LL | fn is_clone<T: Clone>(_: T) {}
-   |                ^^^^^ required by this bound in `is_clone`
+LL | const fn is_clone<T: ~const Clone>(_: T) {}
+   |                      ^^^^^^^^^^^^ required by this bound in `is_clone`
    = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider borrowing here
    |
@@ -47,7 +61,7 @@ LL |     is_clone(&B { a: 1, b: C });
    |              +
 
 error[E0277]: the trait bound `B<D>: Copy` is not satisfied
-  --> $DIR/deriving-copyclone.rs:35:13
+  --> $DIR/deriving-copyclone.rs:47:13
    |
 LL |     is_copy(B { a: 1, b: D });
    |     ------- ^^^^^^^^^^^^^^^^ expected an implementor of trait `Copy`
@@ -55,12 +69,12 @@ LL |     is_copy(B { a: 1, b: D });
    |     required by a bound introduced by this call
    |
 note: required because of the requirements on the impl of `Copy` for `B<D>`
-  --> $DIR/deriving-copyclone.rs:9:10
+  --> $DIR/deriving-copyclone.rs:11:10
    |
 LL | #[derive(Copy, Clone)]
    |          ^^^^
 note: required by a bound in `is_copy`
-  --> $DIR/deriving-copyclone.rs:18:15
+  --> $DIR/deriving-copyclone.rs:30:15
    |
 LL | fn is_copy<T: Copy>(_: T) {}
    |               ^^^^ required by this bound in `is_copy`
@@ -70,6 +84,6 @@ help: consider borrowing here
 LL |     is_copy(&B { a: 1, b: D });
    |             +
 
-error: aborting due to 3 previous errors
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
This is an attempt to lay the foundation for marking `#[derive]`d trait impls as const. Right now, only trivial `Clone` impls (`*self`) are marked as const, but in the future, more complicated impls like `PartialEq` and `PartialOrd` could be marked as `const` as well.

This mostly just modifies the `TraitDef` struct in `rustc_builtin_macros` to allow marking traits as const. For now, only the `Clone` implementations are marked as const since they're the simplest, to prove that the feature works.

This also augments the existing `Clone` derive test to check that the generated impls can be const.