### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -7,7 +7,7 @@ Version 1.58.1 (2022-01-19)
 * [Fix wrong error message displayed when some imports are missing][91254]
 * [Fix rustfmt not formatting generated files from stdin][92912]
 
-[CVE-2022-21658]: https://www.cve.org/CVERecord?id=CVE-2022-21658]
+[CVE-2022-21658]: https://www.cve.org/CVERecord?id=CVE-2022-21658
 [91254]: https://github.com/rust-lang/rust/pull/91254
 [92912]: https://github.com/rust-lang/rust/pull/92912
 [clippy/8075]: https://github.com/rust-lang/rust-clippy/pull/8075

--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -72,6 +72,7 @@ mod tests;
 
 use crate::borrow::{Borrow, Cow};
 use crate::cmp;
+use crate::collections::TryReserveError;
 use crate::error::Error;
 use crate::fmt;
 use crate::fs;
@@ -1512,6 +1513,15 @@ impl PathBuf {
         self.inner.reserve(additional)
     }
 
+    /// Invokes [`try_reserve`] on the underlying instance of [`OsString`].
+    ///
+    /// [`try_reserve`]: OsString::try_reserve
+    #[unstable(feature = "try_reserve_2", issue = "91789")]
+    #[inline]
+    pub fn try_reserve(&mut self, additional: usize) -> Result<(), TryReserveError> {
+        self.inner.try_reserve(additional)
+    }
+
     /// Invokes [`reserve_exact`] on the underlying instance of [`OsString`].
     ///
     /// [`reserve_exact`]: OsString::reserve_exact
@@ -1519,6 +1529,15 @@ impl PathBuf {
     #[inline]
     pub fn reserve_exact(&mut self, additional: usize) {
         self.inner.reserve_exact(additional)
+    }
+
+    /// Invokes [`try_reserve_exact`] on the underlying instance of [`OsString`].
+    ///
+    /// [`try_reserve_exact`]: OsString::try_reserve_exact
+    #[unstable(feature = "try_reserve_2", issue = "91789")]
+    #[inline]
+    pub fn try_reserve_exact(&mut self, additional: usize) -> Result<(), TryReserveError> {
+        self.inner.try_reserve_exact(additional)
     }
 
     /// Invokes [`shrink_to_fit`] on the underlying instance of [`OsString`].

--- a/library/std/src/sys/unix/fs.rs
+++ b/library/std/src/sys/unix/fs.rs
@@ -1448,8 +1448,8 @@ pub fn chroot(dir: &Path) -> io::Result<()> {
 
 pub use remove_dir_impl::remove_dir_all;
 
-// Fallback for REDOX
-#[cfg(target_os = "redox")]
+// Fallback for REDOX and ESP-IDF
+#[cfg(any(target_os = "redox", target_os = "espidf"))]
 mod remove_dir_impl {
     pub use crate::sys_common::fs::remove_dir_all;
 }
@@ -1573,7 +1573,11 @@ mod remove_dir_impl {
 }
 
 // Modern implementation using openat(), unlinkat() and fdopendir()
-#[cfg(not(any(all(target_os = "macos", target_arch = "x86_64"), target_os = "redox")))]
+#[cfg(not(any(
+    all(target_os = "macos", target_arch = "x86_64"),
+    target_os = "redox",
+    target_os = "espidf"
+)))]
 mod remove_dir_impl {
     use super::{cstr, lstat, Dir, DirEntry, InnerReadDir, ReadDir};
     use crate::ffi::CStr;

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -398,7 +398,7 @@ nav.sub {
 }
 
 .source .sidebar > *:not(:first-child) {
-	transition: opacity 0.5s, visibility 0.2s;
+	transition: opacity 0.5s;
 	opacity: 0;
 	visibility: hidden;
 }

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1868,7 +1868,6 @@ details.rustdoc-toggle[open] > summary.hideme::after {
 		position: sticky;
 		z-index: 10;
 		font-size: 2rem;
-		cursor: pointer;
 		height: 45px;
 		width: 100%;
 		left: 0;

--- a/src/librustdoc/html/static/css/themes/ayu.css
+++ b/src/librustdoc/html/static/css/themes/ayu.css
@@ -221,6 +221,9 @@ pre.rust a,
 body.source .example-wrap pre.rust a {
 	background: #333;
 }
+.sidebar a {
+	color: #53b1db;
+}
 
 details.rustdoc-toggle > summary.hideme > span,
 details.rustdoc-toggle > summary::before,

--- a/src/librustdoc/html/static/css/themes/ayu.css
+++ b/src/librustdoc/html/static/css/themes/ayu.css
@@ -191,6 +191,10 @@ pre, .rustdoc.source .example-wrap {
 	color: #a37acc;
 }
 
+.sidebar a { color: #53b1db; }
+.sidebar a.current.type { color: #53b1db; }
+.sidebar a.current.associatedtype { color: #53b1db; }
+
 pre.rust .comment { color: #788797; }
 pre.rust .doccomment { color: #a1ac88; }
 
@@ -495,6 +499,25 @@ a.result-constant:focus,
 a.result-static:focus {}
 a.result-primitive:focus {}
 a.result-keyword:focus {}
+
+.sidebar a.current.enum {}
+.sidebar a.current.struct {}
+.sidebar a.current.foreigntype {}
+.sidebar a.current.attr,
+.sidebar a.current.derive,
+.sidebar a.current.macro {}
+.sidebar a.current.union {}
+.sidebar a.current.constant
+.sidebar a.current.static {}
+.sidebar a.current.primitive {}
+.sidebar a.current.externcrate
+.sidebar a.current.mod {}
+.sidebar a.current.trait {}
+.sidebar a.current.traitalias {}
+.sidebar a.current.fn,
+.sidebar a.current.method,
+.sidebar a.current.tymethod {}
+.sidebar a.current.keyword {}
 
 @media (max-width: 700px) {
 	.sidebar-menu {

--- a/src/librustdoc/html/static/css/themes/ayu.css
+++ b/src/librustdoc/html/static/css/themes/ayu.css
@@ -225,9 +225,6 @@ pre.rust a,
 body.source .example-wrap pre.rust a {
 	background: #333;
 }
-.sidebar a {
-	color: #53b1db;
-}
 
 details.rustdoc-toggle > summary.hideme > span,
 details.rustdoc-toggle > summary::before,

--- a/src/librustdoc/html/static/css/themes/dark.css
+++ b/src/librustdoc/html/static/css/themes/dark.css
@@ -148,6 +148,28 @@ a.result-keyword:focus { background-color: #884719; }
 .content .fnname{ color: #2BAB63; }
 .content span.keyword, .content a.keyword, .block a.current.keyword { color: #D2991D; }
 
+.sidebar a { color: #fdbf35; }
+.sidebar a.current.enum { color: #12ece2; }
+.sidebar a.current.struct { color: #12ece2; }
+.sidebar a.current.type { color: #12ece2; }
+.sidebar a.current.associatedtype { color: #fdbf35; }
+.sidebar a.current.foreigntype { color: #12ece2; }
+.sidebar a.current.attr,
+.sidebar a.current.derive,
+.sidebar a.current.macro { color: #0be900; }
+.sidebar a.current.union { color: #12ece2; }
+.sidebar a.current.constant
+.sidebar a.current.static { color: #fdbf35; }
+.sidebar a.current.primitive { color: #12ece2; }
+.sidebar a.current.externcrate
+.sidebar a.current.mod { color: #fdbf35; }
+.sidebar a.current.trait { color: #cca7ff; }
+.sidebar a.current.traitalias { color: #cca7ff; }
+.sidebar a.current.fn,
+.sidebar a.current.method,
+.sidebar a.current.tymethod { color: #32d479; }
+.sidebar a.current.keyword { color: #fdbf35; }
+
 pre.rust .comment { color: #8d8d8b; }
 pre.rust .doccomment { color: #8ca375; }
 
@@ -181,9 +203,6 @@ a.test-arrow {
 }
 body.source .example-wrap pre.rust a {
 	background: #333;
-}
-.sidebar a {
-	color: #fdbf35;
 }
 
 details.rustdoc-toggle > summary.hideme > span,

--- a/src/librustdoc/html/static/css/themes/dark.css
+++ b/src/librustdoc/html/static/css/themes/dark.css
@@ -182,6 +182,9 @@ a.test-arrow {
 body.source .example-wrap pre.rust a {
 	background: #333;
 }
+.sidebar a {
+	color: #fdbf35;
+}
 
 details.rustdoc-toggle > summary.hideme > span,
 details.rustdoc-toggle > summary::before,

--- a/src/librustdoc/html/static/css/themes/light.css
+++ b/src/librustdoc/html/static/css/themes/light.css
@@ -148,6 +148,28 @@ a.result-keyword:focus { background-color: #afc6e4; }
 .content .fnname { color: #AD7C37; }
 .content span.keyword, .content a.keyword, .block a.current.keyword { color: #3873AD; }
 
+.sidebar a { color: #356da4; }
+.sidebar a.current.enum { color: #a63283; }
+.sidebar a.current.struct { color: #a63283; }
+.sidebar a.current.type { color: #a63283; }
+.sidebar a.current.associatedtype { color: #356da4; }
+.sidebar a.current.foreigntype { color: #356da4; }
+.sidebar a.current.attr,
+.sidebar a.current.derive,
+.sidebar a.current.macro { color: #067901; }
+.sidebar a.current.union { color: #a63283; }
+.sidebar a.current.constant
+.sidebar a.current.static { color: #356da4; }
+.sidebar a.current.primitive { color: #a63283; }
+.sidebar a.current.externcrate
+.sidebar a.current.mod { color: #356da4; }
+.sidebar a.current.trait { color: #6849c3; }
+.sidebar a.current.traitalias { color: #4b349e; }
+.sidebar a.current.fn,
+.sidebar a.current.method,
+.sidebar a.current.tymethod { color: #32d479; }
+.sidebar a.current.keyword { color: #356da4; }
+
 nav.main .current {
 	border-top-color: #000;
 	border-bottom-color: #000;

--- a/src/librustdoc/html/static/css/themes/light.css
+++ b/src/librustdoc/html/static/css/themes/light.css
@@ -201,9 +201,6 @@ a.test-arrow {
 body.source .example-wrap pre.rust a {
 	background: #eee;
 }
-.sidebar a {
-	color: #356da4;
-}
 
 details.rustdoc-toggle > summary.hideme > span,
 details.rustdoc-toggle > summary::before,

--- a/src/librustdoc/html/static/css/themes/light.css
+++ b/src/librustdoc/html/static/css/themes/light.css
@@ -179,6 +179,9 @@ a.test-arrow {
 body.source .example-wrap pre.rust a {
 	background: #eee;
 }
+.sidebar a {
+	color: #356da4;
+}
 
 details.rustdoc-toggle > summary.hideme > span,
 details.rustdoc-toggle > summary::before,

--- a/src/librustdoc/html/templates/page.html
+++ b/src/librustdoc/html/templates/page.html
@@ -117,6 +117,7 @@
                     </div> {#- -#}
                     <form class="search-form"> {#- -#}
                         <div class="search-container"> {#- -#}
+                            <span></span> {#- This empty span is a hacky fix for Safari - See #93184 -#}
                             <input {# -#}
                                 class="search-input" {# -#}
                                 name="search" {# -#}

--- a/src/test/rustdoc-gui/anchors.goml
+++ b/src/test/rustdoc-gui/anchors.goml
@@ -20,7 +20,7 @@ assert-css: (".srclink", {"text-decoration": "underline solid rgb(56, 115, 173)"
 
 assert-css: ("#top-doc-prose-title", {"color": "rgb(0, 0, 0)"})
 
-assert-css: (".sidebar a", {"color": "rgb(56, 115, 173)"})
+assert-css: (".sidebar a", {"color": "rgb(53, 109, 164)"})
 assert-css: (".in-band a", {"color": "rgb(0, 0, 0)"})
 
 // We move the cursor over the "Implementations" title so the anchor is displayed.

--- a/src/test/rustdoc-gui/sidebar.goml
+++ b/src/test/rustdoc-gui/sidebar.goml
@@ -9,7 +9,7 @@ assert-text: (".sidebar > .location", "Crate test_docs")
 // In modules, we only have one "location" element.
 assert-count: (".sidebar .location", 1)
 assert-text: ("#all-types", "All Items")
-assert-css: ("#all-types", {"color": "rgb(56, 115, 173)"})
+assert-css: ("#all-types", {"color": "rgb(53, 109, 164)"})
 // We check that we have the crates list and that the "current" on is "test_docs".
 assert-text: (".sidebar-elems .crate > ul > li > a.current", "test_docs")
 // And we're also supposed to have the list of items in the current module.
@@ -38,7 +38,7 @@ assert-property: ("html", {"scrollTop": "0"})
 
 // We now go back to the crate page to click on the "lib2" crate link.
 goto: file://|DOC_PATH|/test_docs/index.html
-assert-css: (".sidebar-elems .crate > ul > li:first-child > a", {"color": "rgb(56, 115, 173)"})
+assert-css: (".sidebar-elems .crate > ul > li:first-child > a", {"color": "rgb(53, 109, 164)"})
 click: ".sidebar-elems .crate > ul > li:first-child > a"
 
 // PAGE: lib2/index.html


### PR DESCRIPTION
Successful merges:

 - #92513 (std: Implement try_reserve and try_reserve_exact on PathBuf)
 - #93152 (Fix STD compilation for the ESP-IDF target (regression from CVE-2022-21658))
 - #93186 (Fix link to CVE-2022-21658)
 - #93188 (rustdoc: fix bump down typing search on Safari)
 - #93212 (Remove unneeded cursor pointer rule on mobile sidebar)
 - #93231 (adjust sidebar link brightness)
 - #93241 (Fix brief appearance of rust logo in the sidebar)
 - #93253 (Update theme on pageshow event)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=92513,93152,93186,93188,93212,93231,93241,93253)
<!-- homu-ignore:end -->