### PR TITLE
[perf experiment] Increase the Rust ABI by-value arg/return size limit from 2*usize to 3*usize.

### DIFF
--- a/src/test/codegen/arg-return-value-in-reg.rs
+++ b/src/test/codegen/arg-return-value-in-reg.rs
@@ -19,7 +19,7 @@ pub fn modify(s: S) -> S {
 
 #[repr(packed)]
 pub struct TooBig {
-    a: u64,
+    a: u128,
     b: u32,
     c: u32,
     d: u8,

--- a/src/test/codegen/array-equality.rs
+++ b/src/test/codegen/array-equality.rs
@@ -25,11 +25,11 @@ pub fn array_eq_ref(a: &[u16; 6], b: &[u16; 6]) -> bool {
 
 // CHECK-LABEL: @array_eq_value_still_passed_by_pointer
 #[no_mangle]
-pub fn array_eq_value_still_passed_by_pointer(a: [u16; 9], b: [u16; 9]) -> bool {
+pub fn array_eq_value_still_passed_by_pointer(a: [u16; 13], b: [u16; 13]) -> bool {
     // CHECK-NEXT: start:
     // CHECK-NEXT: bitcast
     // CHECK-NEXT: bitcast
-    // CHECK-NEXT: %[[CMP:.+]] = tail call i32 @{{bcmp|memcmp}}(i8* {{.*}} dereferenceable(18) %{{.+}}, i8* {{.*}} dereferenceable(18) %{{.+}}, i64 18)
+    // CHECK-NEXT: %[[CMP:.+]] = tail call i32 @{{bcmp|memcmp}}(i8* {{.*}} dereferenceable(26) %{{.+}}, i8* {{.*}} dereferenceable(26) %{{.+}}, i64 26)
     // CHECK-NEXT: %[[EQ:.+]] = icmp eq i32 %[[CMP]], 0
     // CHECK-NEXT: ret i1 %[[EQ]]
     a == b

--- a/src/test/codegen/issue-15953.rs
+++ b/src/test/codegen/issue-15953.rs
@@ -1,14 +1,17 @@
 // Test that llvm generates `memcpy` for moving a value
 // inside a function and moving an argument.
 
+// NOTE(eddyb) this has to be large enough to never be passed in registers.
+type BigWithDrop = [String; 2];
+
 struct Foo {
-    x: Vec<i32>,
+    x: BigWithDrop,
 }
 
 #[inline(never)]
 #[no_mangle]
 // CHECK: memcpy
-fn interior(x: Vec<i32>) -> Vec<i32> {
+fn interior(x: BigWithDrop) -> BigWithDrop {
     let Foo { x } = Foo { x: x };
     x
 }
@@ -16,14 +19,14 @@ fn interior(x: Vec<i32>) -> Vec<i32> {
 #[inline(never)]
 #[no_mangle]
 // CHECK: memcpy
-fn exterior(x: Vec<i32>) -> Vec<i32> {
+fn exterior(x: BigWithDrop) -> BigWithDrop {
     x
 }
 
 fn main() {
-    let x = interior(Vec::new());
+    let x = interior(BigWithDrop::default());
     println!("{:?}", x);
 
-    let x = exterior(Vec::new());
+    let x = exterior(BigWithDrop::default());
     println!("{:?}", x);
 }


### PR DESCRIPTION
(I had planned to try this as a regression fix for #93259, before the perf run for that came out neutral - but I've thought of it before, and this is one of those things I can never figure out if it's been tried and rejected)

In the interest of not changing the optimization behavior, I've left in the existing behavior of turning `<= 2*usize` aggregates into a single `iN`, even when it might not be ideal.

Not sure how to test this outside of using the compiler as a benchmark, but I suppose that's at least a start.