### PR TITLE
[DO NOT MERGE] Windows: use directory locking for remove_dir_all

### DIFF
--- a/library/std/src/sys/windows/c.rs
+++ b/library/std/src/sys/windows/c.rs
@@ -3,7 +3,7 @@
 #![allow(nonstandard_style)]
 #![cfg_attr(test, allow(dead_code))]
 #![unstable(issue = "none", feature = "windows_c")]
-
+#![allow(unused)]
 use crate::mem;
 use crate::os::raw::NonZero_c_ulong;
 use crate::os::raw::{c_char, c_int, c_long, c_longlong, c_uint, c_ulong, c_ushort};

--- a/library/std/src/sys/windows/c.rs
+++ b/library/std/src/sys/windows/c.rs
@@ -244,6 +244,7 @@ pub struct ipv6_mreq {
 }
 
 pub const VOLUME_NAME_DOS: DWORD = 0x0;
+pub const VOLUME_NAME_NT: DWORD = 0x2;
 pub const MOVEFILE_REPLACE_EXISTING: DWORD = 1;
 
 pub const FILE_BEGIN: DWORD = 0;


### PR DESCRIPTION
Note that the first commit is #93264 but that's just for convenience so only the second commit is particularly interesting here.

This is an attempt to use directory locking instead of using relative paths when deleting entire directory trees. It prevents other processes from being able to delete, rename or write link metadata to the directories being accessed. The lock also prevents parent directories from being renamed.

### Advantages 

* Does not use the `Nt*` APIs.

### Disadvantages

* Directory locking is an added point of failure.
* The `ERROR_DELETE_PENDING` is mapped to `ERROR_ACCESS_DENIED` which is annoying. Not the end of the world though.

I'm still not 100% confident that this is totally safe from exploits but I'm an optimist. My main worry atm is things I haven't thought of.

I'm pushing this now to show my working, it isn't yet ready for a proper review so...

r? @ghost