### PR TITLE
Disable drop range analysis

### DIFF
--- a/src/test/ui/async-await/issue-93197.rs
+++ b/src/test/ui/async-await/issue-93197.rs
@@ -1,0 +1,15 @@
+// Regression test for #93197
+// build-pass
+// edition:2021
+
+#![feature(try_blocks)]
+
+use std::sync::{mpsc, mpsc::SendError};
+
+pub async fn foo() {
+    let (tx, _) = mpsc::channel();
+
+    let _: Result<(), SendError<&str>> = try { tx.send("hello")?; };
+}
+
+fn main() {}

--- a/src/test/ui/async-await/issue-93197.rs
+++ b/src/test/ui/async-await/issue-93197.rs
@@ -1,5 +1,5 @@
 // Regression test for #93197
-// build-pass
+// check-pass
 // edition:2021
 
 #![feature(try_blocks)]


### PR DESCRIPTION
The previous PR, #93165, still performed the drop range analysis despite ignoring the results. Unfortunately, there were ICEs in the analysis as well, so some packages failed to build (see the issue #93197 for an example). This change further disables the analysis and just provides dummy results in that case.