### PR TITLE
Add white-space: nowrap to links in the sidebar

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -484,6 +484,10 @@ nav.sub {
 	overflow: hidden;
 }
 
+.sidebar-links a {
+	white-space: nowrap;
+}
+
 .sidebar h2 {
 	border-bottom: none;
 	font-weight: 500;

--- a/src/test/rustdoc-gui/sidebar.goml
+++ b/src/test/rustdoc-gui/sidebar.goml
@@ -74,3 +74,7 @@ assert-text: (".sidebar > .location", "Module sub_sub_module")
 assert-false: ".sidebar-elems .crate"
 assert-text: (".sidebar-elems .items > ul > li:nth-child(1)", "Functions")
 assert-text: ("#functions + .item-table .item-left > a", "foo")
+
+// Links to trait implementations in the sidebar should not wrap even if they are long.
+goto: file://|DOC_PATH|/lib2/struct.HasALongTraitWithParams.html
+assert-property: (".sidebar-links a", {"offsetHeight": 29})

--- a/src/test/rustdoc-gui/src/lib2/lib.rs
+++ b/src/test/rustdoc-gui/src/lib2/lib.rs
@@ -114,3 +114,9 @@ pub mod too_long {
         pub fn foo(&self) {}
     }
 }
+
+pub struct HasALongTraitWithParams {}
+
+pub trait LongTraitWithParamsBananaBananaBanana<T> {}
+
+impl LongTraitWithParamsBananaBananaBanana<usize> for HasALongTraitWithParams {}


### PR DESCRIPTION
We already have overflow: hidden on these links, but if there is a possibility to wrap, they will wrap. This happens in particular for trait implementations because the punctuation (`<>, `) introduces opportunities for breaks. That produces inconsistent UI. Fix it by forcing them not to wrap.

Demo: https://rustdoc.crud.net/jsha/sidebar-nowrap/std/string/struct.String.html

To see the effect, scroll down to the "Trait Implementations" portion of the sidebar and look at IndexMut. Compare vs:

https://doc.rust-lang.org/std/string/struct.String.html
https://doc.rust-lang.org/nightly/std/string/struct.String.html

r? @camelid