### PR TITLE
minor fix for #93231

### DIFF
--- a/src/librustdoc/html/static/css/themes/light.css
+++ b/src/librustdoc/html/static/css/themes/light.css
@@ -167,7 +167,7 @@ a.result-keyword:focus { background-color: #afc6e4; }
 .sidebar a.current.traitalias { color: #4b349e; }
 .sidebar a.current.fn,
 .sidebar a.current.method,
-.sidebar a.current.tymethod { color: #32d479; }
+.sidebar a.current.tymethod { color: #a67736; }
 .sidebar a.current.keyword { color: #356da4; }
 
 nav.main .current {


### PR DESCRIPTION
In #93231 I introduced the new sidebar colours to make the contrast more balanced and easier to read, but it seems I made a copy-paste error in the light theme, resulting in functions appearing green.

This one line change replaces that colour with it's corrected orange/brown colour.

I have double checked the rest of the colours and they seem ok. Sorry for the inconvenience