### PR TITLE
Use argument name consistent with documentation

### DIFF
--- a/library/std/src/io/stdio.rs
+++ b/library/std/src/io/stdio.rs
@@ -539,7 +539,7 @@ impl BufRead for StdinLock<'_> {
         self.inner.fill_buf()
     }
 
-    fn consume(&mut self, n: usize) {
+    fn consume(&mut self, amt: usize) {
         self.inner.consume(n)
     }
 


### PR DESCRIPTION
Rustdoc shows the first line of the documentation of `consume` in the std/io/mod.rs file, where the argument is called `amt` not `n`.