### PR TITLE
Fix dot separator when there is no source link

### DIFF
--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -1676,11 +1676,12 @@ fn render_rightside(
         containing_item.stable_since(tcx),
         const_stable_since,
     );
-    if has_stability {
+    let mut tmp_buf = Buffer::empty_from(w);
+    write_srclink(cx, item, &mut tmp_buf);
+    if has_stability && !tmp_buf.is_empty() {
         w.write_str(" · ");
     }
-
-    write_srclink(cx, item, w);
+    w.push_buffer(tmp_buf);
     w.write_str("</div>");
 }
 

--- a/src/test/rustdoc/version-separator-without-source.rs
+++ b/src/test/rustdoc/version-separator-without-source.rs
@@ -1,0 +1,23 @@
+#![doc(html_no_source)]
+#![feature(staged_api)]
+#![stable(feature = "bar", since = "1.0")]
+#![crate_name = "foo"]
+
+// @has foo/fn.foo.html
+// @has - '//div[@class="main-heading"]/*[@class="out-of-band"]' '1.0 · '
+// @!has - '//div[@class="main-heading"]/*[@class="out-of-band"]' '1.0 · source · '
+#[stable(feature = "bar", since = "1.0")]
+pub fn foo() {}
+
+// @has foo/struct.Bar.html
+// @has - '//div[@class="main-heading"]/*[@class="out-of-band"]' '1.0 · '
+// @!has - '//div[@class="main-heading"]/*[@class="out-of-band"]' '1.0 · source · '
+#[stable(feature = "bar", since = "1.0")]
+pub struct Bar;
+
+impl Bar {
+    // @has - '//div[@id="method.bar"]/*[@class="rightside"]' '2.0'
+    // @!has - '//div[@id="method.bar"]/*[@class="rightside"]' '2.0 ·'
+    #[stable(feature = "foobar", since = "2.0")]
+    pub fn bar() {}
+}


### PR DESCRIPTION
Fixes #92973.

We did well adding this test since there was a bug:

![Screenshot from 2022-01-25 17-05-48](https://user-images.githubusercontent.com/3050060/151016535-39b45f52-e1e0-4963-ad19-532e24ec4c9b.png)

r? @jsha 