### PR TITLE
make Windows abort_internal Miri-compatible

### DIFF
--- a/library/std/src/sys/windows/mod.rs
+++ b/library/std/src/sys/windows/mod.rs
@@ -285,6 +285,7 @@ pub fn dur2timeout(dur: Duration) -> c::DWORD {
 #[allow(unreachable_code)]
 pub fn abort_internal() -> ! {
     const FAST_FAIL_FATAL_APP_EXIT: usize = 7;
+    #[cfg(not(miri))] // inline assembly does not work in Miri
     unsafe {
         cfg_if::cfg_if! {
             if #[cfg(any(target_arch = "x86", target_arch = "x86_64"))] {


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/92828 started calling `abort_internal` on double-panics, uncovering that on Windows this function does not work in Miri because of its use of inline assembly.

Cc @Amanieu 