### PR TITLE
[WIP] make error more helpful if box is used as identifier

### DIFF
--- a/compiler/rustc_parse/src/parser/pat.rs
+++ b/compiler/rustc_parse/src/parser/pat.rs
@@ -337,9 +337,13 @@ impl<'a> Parser<'a> {
             self.parse_pat_ident(BindingMode::ByRef(mutbl))?
         } else if self.eat_keyword(kw::Box) {
             // Parse `box pat`
-            let pat = self.parse_pat_with_range_pat(false, None)?;
-            self.sess.gated_spans.gate(sym::box_patterns, lo.to(self.prev_token.span));
-            PatKind::Box(pat)
+            if self.can_be_ident_pat() {
+                self.parse_pat_ident(BindingMode::ByValue(Mutability::Not))?
+            } else {
+                let pat = self.parse_pat_with_range_pat(false, None)?;
+                self.sess.gated_spans.gate(sym::box_patterns, lo.to(self.prev_token.span));
+                PatKind::Box(pat)
+            }
         } else if self.check_inline_const(0) {
             // Parse `const pat`
             let const_expr = self.parse_const_block(lo.to(self.token.span), true)?;

--- a/src/test/ui/parser/keyword-box-as-identifier.rs
+++ b/src/test/ui/parser/keyword-box-as-identifier.rs
@@ -1,3 +1,3 @@
 fn main() {
-    let box = "foo"; //~ error: expected pattern, found `=`
+    let box = "foo"; //~ error: expected identifier, found reserved keyword `box`
 }

--- a/src/test/ui/parser/keyword-box-as-identifier.stderr
+++ b/src/test/ui/parser/keyword-box-as-identifier.stderr
@@ -1,8 +1,13 @@
-error: expected pattern, found `=`
-  --> $DIR/keyword-box-as-identifier.rs:2:13
+error: expected identifier, found reserved keyword `box`
+  --> $DIR/keyword-box-as-identifier.rs:4:9
    |
 LL |     let box = "foo";
-   |             ^ expected pattern
+   |         ^^^ expected identifier, found reserved keyword
+   |
+help: you can escape reserved keywords to use them as identifiers
+   |
+LL |     let r#box = "foo";
+   |         ~~~~~
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Fixes #93088 

there was already a test for the box keyword, so I changed the error to match the new, ideally more helpful, one