### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/compiler/rustc_lint_defs/src/lib.rs
+++ b/compiler/rustc_lint_defs/src/lib.rs
@@ -282,7 +282,7 @@ pub enum ExternDepSpec {
 
 // This could be a closure, but then implementing derive trait
 // becomes hacky (and it gets allocated).
-#[derive(PartialEq, Debug)]
+#[derive(Debug)]
 pub enum BuiltinLintDiagnostics {
     Normal,
     AbsPathWithModule(Span),
@@ -309,7 +309,6 @@ pub enum BuiltinLintDiagnostics {
 
 /// Lints that are buffered up early on in the `Session` before the
 /// `LintLevels` is calculated.
-#[derive(PartialEq)]
 pub struct BufferedEarlyLint {
     /// The span of code that we are linting on.
     pub span: MultiSpan,
@@ -336,9 +335,7 @@ pub struct LintBuffer {
 impl LintBuffer {
     pub fn add_early_lint(&mut self, early_lint: BufferedEarlyLint) {
         let arr = self.map.entry(early_lint.node_id).or_default();
-        if !arr.contains(&early_lint) {
-            arr.push(early_lint);
-        }
+        arr.push(early_lint);
     }
 
     pub fn add_lint(

--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -731,28 +731,22 @@ impl<'a> Parser<'a> {
                     match x {
                         Ok((_, _, false)) => {
                             if self.eat(&token::Gt) {
-                                let turbo_err = e.span_suggestion_verbose(
+                                e.span_suggestion_verbose(
                                     binop.span.shrink_to_lo(),
                                     TURBOFISH_SUGGESTION_STR,
                                     "::".to_string(),
                                     Applicability::MaybeIncorrect,
-                                );
-                                if matches!(self.token.kind, token::Semi | token::CloseDelim(_)) {
-                                    turbo_err.emit();
-                                    *expr = self.mk_expr_err(expr.span);
-                                    return Ok(());
-                                } else {
-                                    match self.parse_expr() {
-                                        Ok(_) => {
-                                            turbo_err.emit();
-                                            *expr = self
-                                                .mk_expr_err(expr.span.to(self.prev_token.span));
-                                            return Ok(());
-                                        }
-                                        Err(mut err) => {
-                                            turbo_err.cancel();
-                                            err.cancel();
-                                        }
+                                )
+                                .emit();
+                                match self.parse_expr() {
+                                    Ok(_) => {
+                                        *expr =
+                                            self.mk_expr_err(expr.span.to(self.prev_token.span));
+                                        return Ok(());
+                                    }
+                                    Err(mut err) => {
+                                        *expr = self.mk_expr_err(expr.span);
+                                        err.cancel();
                                     }
                                 }
                             }

--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -737,7 +737,7 @@ impl<'a> Parser<'a> {
                                     "::".to_string(),
                                     Applicability::MaybeIncorrect,
                                 );
-                                if self.check(&TokenKind::Semi) {
+                                if matches!(self.token.kind, token::Semi | token::CloseDelim(_)) {
                                     turbo_err.emit();
                                     *expr = self.mk_expr_err(expr.span);
                                     return Ok(());

--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -1448,6 +1448,8 @@ impl<'a> Parser<'a> {
         let lo = label.ident.span;
         let label = Some(label);
         let ate_colon = self.eat(&token::Colon);
+        let msg = "expected `while`, `for`, `loop` or `{` after a label";
+
         let expr = if self.eat_keyword(kw::While) {
             self.parse_while_expr(label, lo, attrs)
         } else if self.eat_keyword(kw::For) {
@@ -1457,13 +1459,12 @@ impl<'a> Parser<'a> {
         } else if self.check(&token::OpenDelim(token::Brace)) || self.token.is_whole_block() {
             self.parse_block_expr(label, lo, BlockCheckMode::Default, attrs)
         } else if !ate_colon && (self.check(&TokenKind::Comma) || self.check(&TokenKind::Gt)) {
+            self.struct_span_err(self.token.span, msg).span_label(self.token.span, msg).emit();
             // We're probably inside of a `Path<'a>` that needs a turbofish, so suppress the
             // "must be followed by a colon" error.
-            self.diagnostic().delay_span_bug(lo, "this label wasn't parsed correctly");
             consume_colon = false;
             Ok(self.mk_expr_err(lo))
         } else {
-            let msg = "expected `while`, `for`, `loop` or `{` after a label";
             self.struct_span_err(self.token.span, msg).span_label(self.token.span, msg).emit();
             // Continue as an expression in an effort to recover on `'label: non_block_expr`.
             self.parse_expr()

--- a/library/std/src/sys/windows/mod.rs
+++ b/library/std/src/sys/windows/mod.rs
@@ -285,6 +285,7 @@ pub fn dur2timeout(dur: Duration) -> c::DWORD {
 #[allow(unreachable_code)]
 pub fn abort_internal() -> ! {
     const FAST_FAIL_FATAL_APP_EXIT: usize = 7;
+    #[cfg(not(miri))] // inline assembly does not work in Miri
     unsafe {
         cfg_if::cfg_if! {
             if #[cfg(any(target_arch = "x86", target_arch = "x86_64"))] {

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -484,6 +484,10 @@ nav.sub {
 	overflow: hidden;
 }
 
+.sidebar-links a {
+	white-space: nowrap;
+}
+
 .sidebar h2 {
 	border-bottom: none;
 	font-weight: 500;

--- a/src/librustdoc/html/static/css/themes/light.css
+++ b/src/librustdoc/html/static/css/themes/light.css
@@ -167,7 +167,7 @@ a.result-keyword:focus { background-color: #afc6e4; }
 .sidebar a.current.traitalias { color: #4b349e; }
 .sidebar a.current.fn,
 .sidebar a.current.method,
-.sidebar a.current.tymethod { color: #32d479; }
+.sidebar a.current.tymethod { color: #a67736; }
 .sidebar a.current.keyword { color: #356da4; }
 
 nav.main .current {

--- a/src/test/rustdoc-gui/sidebar.goml
+++ b/src/test/rustdoc-gui/sidebar.goml
@@ -74,3 +74,7 @@ assert-text: (".sidebar > .location", "Module sub_sub_module")
 assert-false: ".sidebar-elems .crate"
 assert-text: (".sidebar-elems .items > ul > li:nth-child(1)", "Functions")
 assert-text: ("#functions + .item-table .item-left > a", "foo")
+
+// Links to trait implementations in the sidebar should not wrap even if they are long.
+goto: file://|DOC_PATH|/lib2/struct.HasALongTraitWithParams.html
+assert-property: (".sidebar-links a", {"offsetHeight": 29})

--- a/src/test/rustdoc-gui/src/lib2/lib.rs
+++ b/src/test/rustdoc-gui/src/lib2/lib.rs
@@ -114,3 +114,9 @@ pub mod too_long {
         pub fn foo(&self) {}
     }
 }
+
+pub struct HasALongTraitWithParams {}
+
+pub trait LongTraitWithParamsBananaBananaBanana<T> {}
+
+impl LongTraitWithParamsBananaBananaBanana<usize> for HasALongTraitWithParams {}

--- a/src/test/ui/cfg/future-compat-crate-attributes-using-cfg_attr.rs
+++ b/src/test/ui/cfg/future-compat-crate-attributes-using-cfg_attr.rs
@@ -5,8 +5,12 @@
 #![cfg_attr(foo, crate_type="bin")]
 //~^ERROR `crate_type` within
 //~| WARN this was previously accepted
+//~|ERROR `crate_type` within
+//~| WARN this was previously accepted
 #![cfg_attr(foo, crate_name="bar")]
 //~^ERROR `crate_name` within
+//~| WARN this was previously accepted
+//~|ERROR `crate_name` within
 //~| WARN this was previously accepted
 
 fn main() {}

--- a/src/test/ui/cfg/future-compat-crate-attributes-using-cfg_attr.stderr
+++ b/src/test/ui/cfg/future-compat-crate-attributes-using-cfg_attr.stderr
@@ -14,7 +14,7 @@ LL | #![deny(warnings)]
    = note: for more information, see issue #91632 <https://github.com/rust-lang/rust/issues/91632>
 
 error: `crate_name` within an `#![cfg_attr] attribute is deprecated`
-  --> $DIR/future-compat-crate-attributes-using-cfg_attr.rs:8:18
+  --> $DIR/future-compat-crate-attributes-using-cfg_attr.rs:10:18
    |
 LL | #![cfg_attr(foo, crate_name="bar")]
    |                  ^^^^^^^^^^^^^^^^
@@ -22,5 +22,23 @@ LL | #![cfg_attr(foo, crate_name="bar")]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #91632 <https://github.com/rust-lang/rust/issues/91632>
 
-error: aborting due to 2 previous errors
+error: `crate_type` within an `#![cfg_attr] attribute is deprecated`
+  --> $DIR/future-compat-crate-attributes-using-cfg_attr.rs:5:18
+   |
+LL | #![cfg_attr(foo, crate_type="bin")]
+   |                  ^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #91632 <https://github.com/rust-lang/rust/issues/91632>
+
+error: `crate_name` within an `#![cfg_attr] attribute is deprecated`
+  --> $DIR/future-compat-crate-attributes-using-cfg_attr.rs:10:18
+   |
+LL | #![cfg_attr(foo, crate_name="bar")]
+   |                  ^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #91632 <https://github.com/rust-lang/rust/issues/91632>
+
+error: aborting due to 4 previous errors
 

--- a/src/test/ui/parser/issues/issue-93282.rs
+++ b/src/test/ui/parser/issues/issue-93282.rs
@@ -1,5 +1,4 @@
 fn main() {
     f<'a,>
     //~^ ERROR expected
-    //~| ERROR expected
 }

--- a/src/test/ui/parser/issues/issue-93282.rs
+++ b/src/test/ui/parser/issues/issue-93282.rs
@@ -1,0 +1,5 @@
+fn main() {
+    f<'a,>
+    //~^ ERROR expected
+    //~| ERROR expected
+}

--- a/src/test/ui/parser/issues/issue-93282.stderr
+++ b/src/test/ui/parser/issues/issue-93282.stderr
@@ -1,0 +1,19 @@
+error: expected `while`, `for`, `loop` or `{` after a label
+  --> $DIR/issue-93282.rs:2:9
+   |
+LL |     f<'a,>
+   |         ^ expected `while`, `for`, `loop` or `{` after a label
+
+error: expected one of `.`, `:`, `;`, `?`, `for`, `loop`, `while`, `{`, `}`, or an operator, found `,`
+  --> $DIR/issue-93282.rs:2:9
+   |
+LL |     f<'a,>
+   |         ^ expected one of 10 possible tokens
+   |
+help: use `::<...>` instead of `<...>` to specify lifetime, type, or const arguments
+   |
+LL |     f::<'a,>
+   |      ++
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/parser/issues/issue-93282.stderr
+++ b/src/test/ui/parser/issues/issue-93282.stderr
@@ -1,9 +1,3 @@
-error: expected `while`, `for`, `loop` or `{` after a label
-  --> $DIR/issue-93282.rs:2:9
-   |
-LL |     f<'a,>
-   |         ^ expected `while`, `for`, `loop` or `{` after a label
-
 error: expected one of `.`, `:`, `;`, `?`, `for`, `loop`, `while`, `{`, `}`, or an operator, found `,`
   --> $DIR/issue-93282.rs:2:9
    |
@@ -15,5 +9,5 @@ help: use `::<...>` instead of `<...>` to specify lifetime, type, or const argum
 LL |     f::<'a,>
    |      ++
 
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 

--- a/src/test/ui/parser/require-parens-for-chained-comparison.rs
+++ b/src/test/ui/parser/require-parens-for-chained-comparison.rs
@@ -21,12 +21,10 @@ fn main() {
 
     let _ = f<'_, i8>();
     //~^ ERROR expected one of
-    //~| ERROR expected
     //~| HELP use `::<...>` instead of `<...>` to specify lifetime, type, or const arguments
 
     f<'_>();
     //~^ comparison operators cannot be chained
-    //~| ERROR expected
     //~| HELP use `::<...>` instead of `<...>` to specify lifetime, type, or const arguments
 
     let _ = f<u8>;

--- a/src/test/ui/parser/require-parens-for-chained-comparison.rs
+++ b/src/test/ui/parser/require-parens-for-chained-comparison.rs
@@ -21,10 +21,12 @@ fn main() {
 
     let _ = f<'_, i8>();
     //~^ ERROR expected one of
+    //~| ERROR expected
     //~| HELP use `::<...>` instead of `<...>` to specify lifetime, type, or const arguments
 
     f<'_>();
     //~^ comparison operators cannot be chained
+    //~| ERROR expected
     //~| HELP use `::<...>` instead of `<...>` to specify lifetime, type, or const arguments
 
     let _ = f<u8>;

--- a/src/test/ui/parser/require-parens-for-chained-comparison.stderr
+++ b/src/test/ui/parser/require-parens-for-chained-comparison.stderr
@@ -53,6 +53,12 @@ help: use `::<...>` instead of `<...>` to specify lifetime, type, or const argum
 LL |     let _ = f::<u8, i8>();
    |              ++
 
+error: expected `while`, `for`, `loop` or `{` after a label
+  --> $DIR/require-parens-for-chained-comparison.rs:22:17
+   |
+LL |     let _ = f<'_, i8>();
+   |                 ^ expected `while`, `for`, `loop` or `{` after a label
+
 error: expected one of `.`, `:`, `;`, `?`, `else`, `for`, `loop`, `while`, `{`, or an operator, found `,`
   --> $DIR/require-parens-for-chained-comparison.rs:22:17
    |
@@ -64,8 +70,14 @@ help: use `::<...>` instead of `<...>` to specify lifetime, type, or const argum
 LL |     let _ = f::<'_, i8>();
    |              ++
 
+error: expected `while`, `for`, `loop` or `{` after a label
+  --> $DIR/require-parens-for-chained-comparison.rs:27:9
+   |
+LL |     f<'_>();
+   |         ^ expected `while`, `for`, `loop` or `{` after a label
+
 error: comparison operators cannot be chained
-  --> $DIR/require-parens-for-chained-comparison.rs:26:6
+  --> $DIR/require-parens-for-chained-comparison.rs:27:6
    |
 LL |     f<'_>();
    |      ^  ^
@@ -76,7 +88,7 @@ LL |     f::<'_>();
    |      ++
 
 error: comparison operators cannot be chained
-  --> $DIR/require-parens-for-chained-comparison.rs:30:14
+  --> $DIR/require-parens-for-chained-comparison.rs:32:14
    |
 LL |     let _ = f<u8>;
    |              ^  ^
@@ -84,5 +96,5 @@ LL |     let _ = f<u8>;
    = help: use `::<...>` instead of `<...>` to specify lifetime, type, or const arguments
    = help: or use `(...)` if you meant to specify fn arguments
 
-error: aborting due to 8 previous errors
+error: aborting due to 10 previous errors
 

--- a/src/test/ui/parser/require-parens-for-chained-comparison.stderr
+++ b/src/test/ui/parser/require-parens-for-chained-comparison.stderr
@@ -53,12 +53,6 @@ help: use `::<...>` instead of `<...>` to specify lifetime, type, or const argum
 LL |     let _ = f::<u8, i8>();
    |              ++
 
-error: expected `while`, `for`, `loop` or `{` after a label
-  --> $DIR/require-parens-for-chained-comparison.rs:22:17
-   |
-LL |     let _ = f<'_, i8>();
-   |                 ^ expected `while`, `for`, `loop` or `{` after a label
-
 error: expected one of `.`, `:`, `;`, `?`, `else`, `for`, `loop`, `while`, `{`, or an operator, found `,`
   --> $DIR/require-parens-for-chained-comparison.rs:22:17
    |
@@ -70,14 +64,8 @@ help: use `::<...>` instead of `<...>` to specify lifetime, type, or const argum
 LL |     let _ = f::<'_, i8>();
    |              ++
 
-error: expected `while`, `for`, `loop` or `{` after a label
-  --> $DIR/require-parens-for-chained-comparison.rs:27:9
-   |
-LL |     f<'_>();
-   |         ^ expected `while`, `for`, `loop` or `{` after a label
-
 error: comparison operators cannot be chained
-  --> $DIR/require-parens-for-chained-comparison.rs:27:6
+  --> $DIR/require-parens-for-chained-comparison.rs:26:6
    |
 LL |     f<'_>();
    |      ^  ^
@@ -88,7 +76,7 @@ LL |     f::<'_>();
    |      ++
 
 error: comparison operators cannot be chained
-  --> $DIR/require-parens-for-chained-comparison.rs:32:14
+  --> $DIR/require-parens-for-chained-comparison.rs:30:14
    |
 LL |     let _ = f<u8>;
    |              ^  ^
@@ -96,5 +84,5 @@ LL |     let _ = f<u8>;
    = help: use `::<...>` instead of `<...>` to specify lifetime, type, or const arguments
    = help: or use `(...)` if you meant to specify fn arguments
 
-error: aborting due to 10 previous errors
+error: aborting due to 8 previous errors
 

--- a/src/test/ui/proc-macro/issue-73933-procedural-masquerade.rs
+++ b/src/test/ui/proc-macro/issue-73933-procedural-masquerade.rs
@@ -4,7 +4,14 @@
 extern crate test_macros;
 
 #[derive(Print)]
-enum ProceduralMasqueradeDummyType { //~ ERROR using
+enum ProceduralMasqueradeDummyType {
+//~^ ERROR using
+//~| WARN this was previously
+//~| ERROR using
+//~| WARN this was previously
+//~| ERROR using
+//~| WARN this was previously
+//~| ERROR using
 //~| WARN this was previously
     Input
 }

--- a/src/test/ui/proc-macro/issue-73933-procedural-masquerade.stderr
+++ b/src/test/ui/proc-macro/issue-73933-procedural-masquerade.stderr
@@ -9,7 +9,37 @@ LL | enum ProceduralMasqueradeDummyType {
    = note: for more information, see issue #83125 <https://github.com/rust-lang/rust/issues/83125>
    = note: The `procedural-masquerade` crate has been unnecessary since Rust 1.30.0. Versions of this crate below 0.1.7 will eventually stop compiling.
 
-error: aborting due to previous error
+error: using `procedural-masquerade` crate
+  --> $DIR/issue-73933-procedural-masquerade.rs:7:6
+   |
+LL | enum ProceduralMasqueradeDummyType {
+   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #83125 <https://github.com/rust-lang/rust/issues/83125>
+   = note: The `procedural-masquerade` crate has been unnecessary since Rust 1.30.0. Versions of this crate below 0.1.7 will eventually stop compiling.
+
+error: using `procedural-masquerade` crate
+  --> $DIR/issue-73933-procedural-masquerade.rs:7:6
+   |
+LL | enum ProceduralMasqueradeDummyType {
+   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #83125 <https://github.com/rust-lang/rust/issues/83125>
+   = note: The `procedural-masquerade` crate has been unnecessary since Rust 1.30.0. Versions of this crate below 0.1.7 will eventually stop compiling.
+
+error: using `procedural-masquerade` crate
+  --> $DIR/issue-73933-procedural-masquerade.rs:7:6
+   |
+LL | enum ProceduralMasqueradeDummyType {
+   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #83125 <https://github.com/rust-lang/rust/issues/83125>
+   = note: The `procedural-masquerade` crate has been unnecessary since Rust 1.30.0. Versions of this crate below 0.1.7 will eventually stop compiling.
+
+error: aborting due to 4 previous errors
 
 Future incompatibility report: Future breakage diagnostic:
 error: using `procedural-masquerade` crate
@@ -19,6 +49,39 @@ LL | enum ProceduralMasqueradeDummyType {
    |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `#[deny(proc_macro_back_compat)]` on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #83125 <https://github.com/rust-lang/rust/issues/83125>
+   = note: The `procedural-masquerade` crate has been unnecessary since Rust 1.30.0. Versions of this crate below 0.1.7 will eventually stop compiling.
+
+Future breakage diagnostic:
+error: using `procedural-masquerade` crate
+  --> $DIR/issue-73933-procedural-masquerade.rs:7:6
+   |
+LL | enum ProceduralMasqueradeDummyType {
+   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #83125 <https://github.com/rust-lang/rust/issues/83125>
+   = note: The `procedural-masquerade` crate has been unnecessary since Rust 1.30.0. Versions of this crate below 0.1.7 will eventually stop compiling.
+
+Future breakage diagnostic:
+error: using `procedural-masquerade` crate
+  --> $DIR/issue-73933-procedural-masquerade.rs:7:6
+   |
+LL | enum ProceduralMasqueradeDummyType {
+   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #83125 <https://github.com/rust-lang/rust/issues/83125>
+   = note: The `procedural-masquerade` crate has been unnecessary since Rust 1.30.0. Versions of this crate below 0.1.7 will eventually stop compiling.
+
+Future breakage diagnostic:
+error: using `procedural-masquerade` crate
+  --> $DIR/issue-73933-procedural-masquerade.rs:7:6
+   |
+LL | enum ProceduralMasqueradeDummyType {
+   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #83125 <https://github.com/rust-lang/rust/issues/83125>
    = note: The `procedural-masquerade` crate has been unnecessary since Rust 1.30.0. Versions of this crate below 0.1.7 will eventually stop compiling.

--- a/src/test/ui/proc-macro/issue-73933-procedural-masquerade.stdout
+++ b/src/test/ui/proc-macro/issue-73933-procedural-masquerade.stdout
@@ -14,9 +14,9 @@ PRINT-DERIVE INPUT (DEBUG): TokenStream [
         stream: TokenStream [
             Ident {
                 ident: "Input",
-                span: #0 bytes(173..178),
+                span: #0 bytes(315..320),
             },
         ],
-        span: #0 bytes(121..180),
+        span: #0 bytes(121..322),
     },
 ]

--- a/src/test/ui/proc-macro/issue-75930-derive-cfg.stderr
+++ b/src/test/ui/proc-macro/issue-75930-derive-cfg.stderr
@@ -11,5 +11,17 @@ LL | #[derive(Print)]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #79202 <https://github.com/rust-lang/rust/issues/79202>
 
-warning: 1 warning emitted
+warning: derive helper attribute is used before it is introduced
+  --> $DIR/issue-75930-derive-cfg.rs:19:3
+   |
+LL | #[print_helper(a)]
+   |   ^^^^^^^^^^^^
+...
+LL | #[derive(Print)]
+   |          ----- the attribute is introduced here
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #79202 <https://github.com/rust-lang/rust/issues/79202>
+
+warning: 2 warnings emitted
 

--- a/src/test/ui/rust-2018/edition-lint-nested-empty-paths.fixed
+++ b/src/test/ui/rust-2018/edition-lint-nested-empty-paths.fixed
@@ -17,13 +17,27 @@ crate mod foo {
 use crate::foo::{bar::{baz::{}}};
 //~^ ERROR absolute paths must start with
 //~| WARN this is accepted in the current edition
+//~| ERROR absolute paths must start with
+//~| WARN this is accepted in the current edition
 
 use crate::foo::{bar::{XX, baz::{}}};
 //~^ ERROR absolute paths must start with
 //~| WARN this is accepted in the current edition
+//~| ERROR absolute paths must start with
+//~| WARN this is accepted in the current edition
+//~| ERROR absolute paths must start with
+//~| WARN this is accepted in the current edition
+//~| ERROR absolute paths must start with
+//~| WARN this is accepted in the current edition
 
 use crate::foo::{bar::{baz::{}, baz1::{}}};
 //~^ ERROR absolute paths must start with
+//~| WARN this is accepted in the current edition
+//~| ERROR absolute paths must start with
+//~| WARN this is accepted in the current edition
+//~| ERROR absolute paths must start with
+//~| WARN this is accepted in the current edition
+//~| ERROR absolute paths must start with
 //~| WARN this is accepted in the current edition
 
 fn main() {

--- a/src/test/ui/rust-2018/edition-lint-nested-empty-paths.rs
+++ b/src/test/ui/rust-2018/edition-lint-nested-empty-paths.rs
@@ -17,13 +17,27 @@ crate mod foo {
 use foo::{bar::{baz::{}}};
 //~^ ERROR absolute paths must start with
 //~| WARN this is accepted in the current edition
+//~| ERROR absolute paths must start with
+//~| WARN this is accepted in the current edition
 
 use foo::{bar::{XX, baz::{}}};
 //~^ ERROR absolute paths must start with
 //~| WARN this is accepted in the current edition
+//~| ERROR absolute paths must start with
+//~| WARN this is accepted in the current edition
+//~| ERROR absolute paths must start with
+//~| WARN this is accepted in the current edition
+//~| ERROR absolute paths must start with
+//~| WARN this is accepted in the current edition
 
 use foo::{bar::{baz::{}, baz1::{}}};
 //~^ ERROR absolute paths must start with
+//~| WARN this is accepted in the current edition
+//~| ERROR absolute paths must start with
+//~| WARN this is accepted in the current edition
+//~| ERROR absolute paths must start with
+//~| WARN this is accepted in the current edition
+//~| ERROR absolute paths must start with
 //~| WARN this is accepted in the current edition
 
 fn main() {

--- a/src/test/ui/rust-2018/edition-lint-nested-empty-paths.stderr
+++ b/src/test/ui/rust-2018/edition-lint-nested-empty-paths.stderr
@@ -13,7 +13,16 @@ LL | #![deny(absolute_paths_not_starting_with_crate)]
    = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
 
 error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
-  --> $DIR/edition-lint-nested-empty-paths.rs:21:5
+  --> $DIR/edition-lint-nested-empty-paths.rs:17:5
+   |
+LL | use foo::{bar::{baz::{}}};
+   |     ^^^^^^^^^^^^^^^^^^^^^ help: use `crate`: `crate::foo::{bar::{baz::{}}}`
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2018!
+   = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
+
+error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
+  --> $DIR/edition-lint-nested-empty-paths.rs:23:5
    |
 LL | use foo::{bar::{XX, baz::{}}};
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `crate`: `crate::foo::{bar::{XX, baz::{}}}`
@@ -22,7 +31,34 @@ LL | use foo::{bar::{XX, baz::{}}};
    = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
 
 error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
-  --> $DIR/edition-lint-nested-empty-paths.rs:25:5
+  --> $DIR/edition-lint-nested-empty-paths.rs:23:5
+   |
+LL | use foo::{bar::{XX, baz::{}}};
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `crate`: `crate::foo::{bar::{XX, baz::{}}}`
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2018!
+   = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
+
+error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
+  --> $DIR/edition-lint-nested-empty-paths.rs:23:5
+   |
+LL | use foo::{bar::{XX, baz::{}}};
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `crate`: `crate::foo::{bar::{XX, baz::{}}}`
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2018!
+   = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
+
+error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
+  --> $DIR/edition-lint-nested-empty-paths.rs:23:5
+   |
+LL | use foo::{bar::{XX, baz::{}}};
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `crate`: `crate::foo::{bar::{XX, baz::{}}}`
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2018!
+   = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
+
+error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
+  --> $DIR/edition-lint-nested-empty-paths.rs:33:5
    |
 LL | use foo::{bar::{baz::{}, baz1::{}}};
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `crate`: `crate::foo::{bar::{baz::{}, baz1::{}}}`
@@ -30,5 +66,32 @@ LL | use foo::{bar::{baz::{}, baz1::{}}};
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2018!
    = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
 
-error: aborting due to 3 previous errors
+error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
+  --> $DIR/edition-lint-nested-empty-paths.rs:33:5
+   |
+LL | use foo::{bar::{baz::{}, baz1::{}}};
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `crate`: `crate::foo::{bar::{baz::{}, baz1::{}}}`
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2018!
+   = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
+
+error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
+  --> $DIR/edition-lint-nested-empty-paths.rs:33:5
+   |
+LL | use foo::{bar::{baz::{}, baz1::{}}};
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `crate`: `crate::foo::{bar::{baz::{}, baz1::{}}}`
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2018!
+   = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
+
+error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
+  --> $DIR/edition-lint-nested-empty-paths.rs:33:5
+   |
+LL | use foo::{bar::{baz::{}, baz1::{}}};
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `crate`: `crate::foo::{bar::{baz::{}, baz1::{}}}`
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2018!
+   = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
+
+error: aborting due to 10 previous errors
 

--- a/src/test/ui/rust-2018/edition-lint-nested-paths.fixed
+++ b/src/test/ui/rust-2018/edition-lint-nested-paths.fixed
@@ -6,6 +6,12 @@
 use crate::foo::{a, b};
 //~^ ERROR absolute paths must start with
 //~| this is accepted in the current edition
+//~| ERROR absolute paths must start with
+//~| this is accepted in the current edition
+//~| ERROR absolute paths must start with
+//~| this is accepted in the current edition
+//~| ERROR absolute paths must start with
+//~| this is accepted in the current edition
 
 mod foo {
     crate fn a() {}
@@ -20,6 +26,10 @@ fn main() {
     {
         use crate::foo::{self as x, c};
         //~^ ERROR absolute paths must start with
+        //~| this is accepted in the current edition
+        //~| ERROR absolute paths must start with
+        //~| this is accepted in the current edition
+        //~| ERROR absolute paths must start with
         //~| this is accepted in the current edition
         x::a();
         c();

--- a/src/test/ui/rust-2018/edition-lint-nested-paths.rs
+++ b/src/test/ui/rust-2018/edition-lint-nested-paths.rs
@@ -6,6 +6,12 @@
 use foo::{a, b};
 //~^ ERROR absolute paths must start with
 //~| this is accepted in the current edition
+//~| ERROR absolute paths must start with
+//~| this is accepted in the current edition
+//~| ERROR absolute paths must start with
+//~| this is accepted in the current edition
+//~| ERROR absolute paths must start with
+//~| this is accepted in the current edition
 
 mod foo {
     crate fn a() {}
@@ -20,6 +26,10 @@ fn main() {
     {
         use foo::{self as x, c};
         //~^ ERROR absolute paths must start with
+        //~| this is accepted in the current edition
+        //~| ERROR absolute paths must start with
+        //~| this is accepted in the current edition
+        //~| ERROR absolute paths must start with
         //~| this is accepted in the current edition
         x::a();
         c();

--- a/src/test/ui/rust-2018/edition-lint-nested-paths.stderr
+++ b/src/test/ui/rust-2018/edition-lint-nested-paths.stderr
@@ -13,7 +13,34 @@ LL | #![deny(absolute_paths_not_starting_with_crate)]
    = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
 
 error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
-  --> $DIR/edition-lint-nested-paths.rs:21:13
+  --> $DIR/edition-lint-nested-paths.rs:6:5
+   |
+LL | use foo::{a, b};
+   |     ^^^^^^^^^^^ help: use `crate`: `crate::foo::{a, b}`
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2018!
+   = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
+
+error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
+  --> $DIR/edition-lint-nested-paths.rs:6:5
+   |
+LL | use foo::{a, b};
+   |     ^^^^^^^^^^^ help: use `crate`: `crate::foo::{a, b}`
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2018!
+   = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
+
+error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
+  --> $DIR/edition-lint-nested-paths.rs:6:5
+   |
+LL | use foo::{a, b};
+   |     ^^^^^^^^^^^ help: use `crate`: `crate::foo::{a, b}`
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2018!
+   = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
+
+error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
+  --> $DIR/edition-lint-nested-paths.rs:27:13
    |
 LL |         use foo::{self as x, c};
    |             ^^^^^^^^^^^^^^^^^^^ help: use `crate`: `crate::foo::{self as x, c}`
@@ -21,5 +48,23 @@ LL |         use foo::{self as x, c};
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2018!
    = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
 
-error: aborting due to 2 previous errors
+error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
+  --> $DIR/edition-lint-nested-paths.rs:27:13
+   |
+LL |         use foo::{self as x, c};
+   |             ^^^^^^^^^^^^^^^^^^^ help: use `crate`: `crate::foo::{self as x, c}`
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2018!
+   = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
+
+error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
+  --> $DIR/edition-lint-nested-paths.rs:27:13
+   |
+LL |         use foo::{self as x, c};
+   |             ^^^^^^^^^^^^^^^^^^^ help: use `crate`: `crate::foo::{self as x, c}`
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2018!
+   = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
+
+error: aborting due to 7 previous errors
 

--- a/src/test/ui/rust-2018/edition-lint-paths.fixed
+++ b/src/test/ui/rust-2018/edition-lint-paths.fixed
@@ -12,16 +12,24 @@ pub mod foo {
     use crate::bar::Bar;
     //~^ ERROR absolute
     //~| WARN this is accepted in the current edition
+    //~| ERROR absolute
+    //~| WARN this is accepted in the current edition
+
     use super::bar::Bar2;
     use crate::bar::Bar3;
 
     use crate::bar;
     //~^ ERROR absolute
     //~| WARN this is accepted in the current edition
+
     use crate::bar as something_else;
 
     use crate::{main, Bar as SomethingElse};
     //~^ ERROR absolute
+    //~| WARN this is accepted in the current edition
+    //~| ERROR absolute
+    //~| WARN this is accepted in the current edition
+    //~| ERROR absolute
     //~| WARN this is accepted in the current edition
 
     use crate::{main as another_main, Bar as SomethingElse2};
@@ -33,6 +41,8 @@ pub mod foo {
 
 use crate::bar::Bar;
 //~^ ERROR absolute
+//~| WARN this is accepted in the current edition
+//~| ERROR absolute
 //~| WARN this is accepted in the current edition
 
 pub mod bar {
@@ -51,11 +61,14 @@ mod baz {
 impl crate::foo::SomeTrait for u32 {}
 //~^ ERROR absolute
 //~| WARN this is accepted in the current edition
+//~| ERROR absolute
+//~| WARN this is accepted in the current edition
 
 fn main() {
     let x = crate::bar::Bar;
     //~^ ERROR absolute
     //~| WARN this is accepted in the current edition
+
     let x = bar::Bar;
     let x = crate::bar::Bar;
     let x = self::bar::Bar;

--- a/src/test/ui/rust-2018/edition-lint-paths.rs
+++ b/src/test/ui/rust-2018/edition-lint-paths.rs
@@ -12,16 +12,24 @@ pub mod foo {
     use bar::Bar;
     //~^ ERROR absolute
     //~| WARN this is accepted in the current edition
+    //~| ERROR absolute
+    //~| WARN this is accepted in the current edition
+
     use super::bar::Bar2;
     use crate::bar::Bar3;
 
     use bar;
     //~^ ERROR absolute
     //~| WARN this is accepted in the current edition
+
     use crate::bar as something_else;
 
     use {main, Bar as SomethingElse};
     //~^ ERROR absolute
+    //~| WARN this is accepted in the current edition
+    //~| ERROR absolute
+    //~| WARN this is accepted in the current edition
+    //~| ERROR absolute
     //~| WARN this is accepted in the current edition
 
     use crate::{main as another_main, Bar as SomethingElse2};
@@ -33,6 +41,8 @@ pub mod foo {
 
 use bar::Bar;
 //~^ ERROR absolute
+//~| WARN this is accepted in the current edition
+//~| ERROR absolute
 //~| WARN this is accepted in the current edition
 
 pub mod bar {
@@ -51,11 +61,14 @@ mod baz {
 impl ::foo::SomeTrait for u32 {}
 //~^ ERROR absolute
 //~| WARN this is accepted in the current edition
+//~| ERROR absolute
+//~| WARN this is accepted in the current edition
 
 fn main() {
     let x = ::bar::Bar;
     //~^ ERROR absolute
     //~| WARN this is accepted in the current edition
+
     let x = bar::Bar;
     let x = crate::bar::Bar;
     let x = self::bar::Bar;

--- a/src/test/ui/rust-2018/edition-lint-paths.stderr
+++ b/src/test/ui/rust-2018/edition-lint-paths.stderr
@@ -13,7 +13,16 @@ LL | #![deny(absolute_paths_not_starting_with_crate)]
    = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
 
 error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
-  --> $DIR/edition-lint-paths.rs:18:9
+  --> $DIR/edition-lint-paths.rs:12:9
+   |
+LL |     use bar::Bar;
+   |         ^^^^^^^^ help: use `crate`: `crate::bar::Bar`
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2018!
+   = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
+
+error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
+  --> $DIR/edition-lint-paths.rs:21:9
    |
 LL |     use bar;
    |         ^^^ help: use `crate`: `crate::bar`
@@ -22,7 +31,7 @@ LL |     use bar;
    = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
 
 error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
-  --> $DIR/edition-lint-paths.rs:23:9
+  --> $DIR/edition-lint-paths.rs:27:9
    |
 LL |     use {main, Bar as SomethingElse};
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `crate`: `crate::{main, Bar as SomethingElse}`
@@ -31,7 +40,25 @@ LL |     use {main, Bar as SomethingElse};
    = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
 
 error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
-  --> $DIR/edition-lint-paths.rs:34:5
+  --> $DIR/edition-lint-paths.rs:27:9
+   |
+LL |     use {main, Bar as SomethingElse};
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `crate`: `crate::{main, Bar as SomethingElse}`
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2018!
+   = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
+
+error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
+  --> $DIR/edition-lint-paths.rs:27:9
+   |
+LL |     use {main, Bar as SomethingElse};
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `crate`: `crate::{main, Bar as SomethingElse}`
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2018!
+   = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
+
+error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
+  --> $DIR/edition-lint-paths.rs:42:5
    |
 LL | use bar::Bar;
    |     ^^^^^^^^ help: use `crate`: `crate::bar::Bar`
@@ -40,7 +67,16 @@ LL | use bar::Bar;
    = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
 
 error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
-  --> $DIR/edition-lint-paths.rs:46:9
+  --> $DIR/edition-lint-paths.rs:42:5
+   |
+LL | use bar::Bar;
+   |     ^^^^^^^^ help: use `crate`: `crate::bar::Bar`
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2018!
+   = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
+
+error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
+  --> $DIR/edition-lint-paths.rs:56:9
    |
 LL |     use *;
    |         ^ help: use `crate`: `crate::*`
@@ -49,7 +85,7 @@ LL |     use *;
    = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
 
 error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
-  --> $DIR/edition-lint-paths.rs:51:6
+  --> $DIR/edition-lint-paths.rs:61:6
    |
 LL | impl ::foo::SomeTrait for u32 {}
    |      ^^^^^^^^^^^^^^^^ help: use `crate`: `crate::foo::SomeTrait`
@@ -58,7 +94,16 @@ LL | impl ::foo::SomeTrait for u32 {}
    = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
 
 error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
-  --> $DIR/edition-lint-paths.rs:56:13
+  --> $DIR/edition-lint-paths.rs:61:6
+   |
+LL | impl ::foo::SomeTrait for u32 {}
+   |      ^^^^^^^^^^^^^^^^ help: use `crate`: `crate::foo::SomeTrait`
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2018!
+   = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
+
+error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
+  --> $DIR/edition-lint-paths.rs:68:13
    |
 LL |     let x = ::bar::Bar;
    |             ^^^^^^^^^^ help: use `crate`: `crate::bar::Bar`
@@ -66,5 +111,5 @@ LL |     let x = ::bar::Bar;
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2018!
    = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
 
-error: aborting due to 7 previous errors
+error: aborting due to 12 previous errors
 

--- a/src/test/ui/rust-2018/extern-crate-rename.fixed
+++ b/src/test/ui/rust-2018/extern-crate-rename.fixed
@@ -12,6 +12,8 @@ extern crate edition_lint_paths as my_crate;
 use crate::my_crate::foo;
 //~^ ERROR absolute paths must start
 //~| WARNING this is accepted in the current edition
+//~| ERROR absolute paths must start
+//~| WARNING this is accepted in the current edition
 
 fn main() {
     foo();

--- a/src/test/ui/rust-2018/extern-crate-rename.rs
+++ b/src/test/ui/rust-2018/extern-crate-rename.rs
@@ -12,6 +12,8 @@ extern crate edition_lint_paths as my_crate;
 use my_crate::foo;
 //~^ ERROR absolute paths must start
 //~| WARNING this is accepted in the current edition
+//~| ERROR absolute paths must start
+//~| WARNING this is accepted in the current edition
 
 fn main() {
     foo();

--- a/src/test/ui/rust-2018/extern-crate-rename.stderr
+++ b/src/test/ui/rust-2018/extern-crate-rename.stderr
@@ -12,5 +12,14 @@ LL | #![deny(absolute_paths_not_starting_with_crate)]
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2018!
    = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
 
-error: aborting due to previous error
+error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
+  --> $DIR/extern-crate-rename.rs:12:5
+   |
+LL | use my_crate::foo;
+   |     ^^^^^^^^^^^^^ help: use `crate`: `crate::my_crate::foo`
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2018!
+   = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
+
+error: aborting due to 2 previous errors
 

--- a/src/test/ui/rust-2018/extern-crate-submod.fixed
+++ b/src/test/ui/rust-2018/extern-crate-submod.fixed
@@ -19,6 +19,9 @@ mod m {
 use crate::m::edition_lint_paths::foo;
 //~^ ERROR absolute paths must start
 //~| WARNING this is accepted in the current edition
+//~| ERROR absolute paths must start
+//~| WARNING this is accepted in the current edition
+
 
 fn main() {
     foo();

--- a/src/test/ui/rust-2018/extern-crate-submod.rs
+++ b/src/test/ui/rust-2018/extern-crate-submod.rs
@@ -19,6 +19,9 @@ mod m {
 use m::edition_lint_paths::foo;
 //~^ ERROR absolute paths must start
 //~| WARNING this is accepted in the current edition
+//~| ERROR absolute paths must start
+//~| WARNING this is accepted in the current edition
+
 
 fn main() {
     foo();

--- a/src/test/ui/rust-2018/extern-crate-submod.stderr
+++ b/src/test/ui/rust-2018/extern-crate-submod.stderr
@@ -12,5 +12,14 @@ LL | #![deny(absolute_paths_not_starting_with_crate)]
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2018!
    = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
 
-error: aborting due to previous error
+error: absolute paths must start with `self`, `super`, `crate`, or an external crate name in the 2018 edition
+  --> $DIR/extern-crate-submod.rs:19:5
+   |
+LL | use m::edition_lint_paths::foo;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `crate`: `crate::m::edition_lint_paths::foo`
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2018!
+   = note: for more information, see issue #53130 <https://github.com/rust-lang/rust/issues/53130>
+
+error: aborting due to 2 previous errors
 


### PR DESCRIPTION
Successful merges:

 - #93250 (Remove deduplication of early lints)
 - #93286 (Add white-space: nowrap to links in the sidebar)
 - #93291 (minor fix for #93231)
 - #93300 (make Windows abort_internal Miri-compatible)
 - #93303 (Fix ICE when parsing bad turbofish with lifetime argument)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=93250,93286,93291,93300,93303)
<!-- homu-ignore:end -->