### PR TITLE
Update cargo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -379,7 +379,7 @@ dependencies = [
  "tar",
  "tempfile",
  "termcolor",
- "toml",
+ "toml_edit",
  "unicode-width",
  "unicode-xid",
  "url 2.2.2",
@@ -465,7 +465,7 @@ dependencies = [
  "serde_json",
  "tar",
  "termcolor",
- "toml",
+ "toml_edit",
  "url 2.2.2",
 ]
 
@@ -729,6 +729,16 @@ dependencies = [
  "atty",
  "lazy_static",
  "winapi",
+]
+
+[[package]]
+name = "combine"
+version = "4.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50b727aacc797f9fc28e355d21f34709ac4fc9adecfe470ad07b8f4464f53062"
+dependencies = [
+ "bytes",
+ "memchr",
 ]
 
 [[package]]
@@ -1951,6 +1961,15 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "unicase",
+]
+
+[[package]]
+name = "kstring"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b310ccceade8121d7d77fee406160e457c2f4e7c7982d589da3499bc7ea4526"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -5220,6 +5239,19 @@ version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75cf45bb0bef80604d001caaec0d09da99611b3c0fd39d3080468875cdb65645"
 dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b80ac5e1b91e3378c63dab121962472b5ca20cf9ab1975e3d588548717807a8"
+dependencies = [
+ "combine",
+ "indexmap",
+ "itertools 0.10.1",
+ "kstring",
  "serde",
 ]
 


### PR DESCRIPTION
9 commits in 95bb3c92bf516017e812e7f1c14c2dea3845b30e..1c034752de0df744fcd7788fcbca158830b8bf85
2022-01-18 17:39:35 +0000 to 2022-01-25 22:36:53 +0000
- Sync toml_edit versions (rust-lang/cargo#10329)
- Check --config for dotted keys only (rust-lang/cargo#10176)
- Remove deprecated --host arg for search and publish cmds (rust-lang/cargo#10327)
- doc: it's valid to use OUT_DIR for intermediate artifacts (rust-lang/cargo#10326)
- Use local git info for version. (rust-lang/cargo#10323)
- Fix documenting with undocumented dependencies. (rust-lang/cargo#10324)
- do not compile test for bins flagged as `test = false` (rust-lang/cargo#10305)
- Port cargo from toml-rs to toml_edit (rust-lang/cargo#10086)
- Fix new::git_default_branch with different default (rust-lang/cargo#10306)