### PR TITLE
Update tracking issue numbers for inline assembly sub-features

### DIFF
--- a/compiler/rustc_feature/src/active.rs
+++ b/compiler/rustc_feature/src/active.rs
@@ -281,13 +281,13 @@ declare_features! (
     /// Allows trait methods with arbitrary self types.
     (active, arbitrary_self_types, "1.23.0", Some(44874), None),
     /// Allows using `const` operands in inline assembly.
-    (active, asm_const, "1.58.0", Some(72016), None),
+    (active, asm_const, "1.58.0", Some(93332), None),
     /// Enables experimental inline assembly support for additional architectures.
-    (active, asm_experimental_arch, "1.58.0", Some(72016), None),
+    (active, asm_experimental_arch, "1.58.0", Some(93335), None),
     /// Allows using `sym` operands in inline assembly.
-    (active, asm_sym, "1.58.0", Some(72016), None),
+    (active, asm_sym, "1.58.0", Some(93333), None),
     /// Allows the `may_unwind` option in inline assembly.
-    (active, asm_unwind, "1.58.0", Some(72016), None),
+    (active, asm_unwind, "1.58.0", Some(93334), None),
     /// Allows users to enforce equality of associated constants `TraitImpl<AssocConst=3>`.
     (active, associated_const_equality, "1.58.0", Some(92827), None),
     /// Allows the user of associated type bounds.

--- a/src/doc/unstable-book/src/language-features/asm-const.md
+++ b/src/doc/unstable-book/src/language-features/asm-const.md
@@ -1,8 +1,8 @@
 # `asm_const`
 
-The tracking issue for this feature is: [#72016]
+The tracking issue for this feature is: [#93332]
 
-[#72016]: https://github.com/rust-lang/rust/issues/72016
+[#93332]: https://github.com/rust-lang/rust/issues/93332
 
 ------------------------
 

--- a/src/doc/unstable-book/src/language-features/asm-experimental-arch.md
+++ b/src/doc/unstable-book/src/language-features/asm-experimental-arch.md
@@ -1,8 +1,8 @@
 # `asm_experimental_arch`
 
-The tracking issue for this feature is: [#72016]
+The tracking issue for this feature is: [#93335]
 
-[#72016]: https://github.com/rust-lang/rust/issues/72016
+[#93335]: https://github.com/rust-lang/rust/issues/93335
 
 ------------------------
 

--- a/src/doc/unstable-book/src/language-features/asm-sym.md
+++ b/src/doc/unstable-book/src/language-features/asm-sym.md
@@ -1,8 +1,8 @@
 # `asm_sym`
 
-The tracking issue for this feature is: [#72016]
+The tracking issue for this feature is: [#93333]
 
-[#72016]: https://github.com/rust-lang/rust/issues/72016
+[#93333]: https://github.com/rust-lang/rust/issues/93333
 
 ------------------------
 

--- a/src/doc/unstable-book/src/language-features/asm-unwind.md
+++ b/src/doc/unstable-book/src/language-features/asm-unwind.md
@@ -1,8 +1,8 @@
 # `asm_unwind`
 
-The tracking issue for this feature is: [#72016]
+The tracking issue for this feature is: [#93334]
 
-[#72016]: https://github.com/rust-lang/rust/issues/72016
+[#93334]: https://github.com/rust-lang/rust/issues/93334
 
 ------------------------
 

--- a/src/test/ui/feature-gates/feature-gate-asm_const.stderr
+++ b/src/test/ui/feature-gates/feature-gate-asm_const.stderr
@@ -4,7 +4,7 @@ error[E0658]: const operands for inline assembly are unstable
 LL |         asm!("mov eax, {}", const 123);
    |                             ^^^^^^^^^
    |
-   = note: see issue #72016 <https://github.com/rust-lang/rust/issues/72016> for more information
+   = note: see issue #93332 <https://github.com/rust-lang/rust/issues/93332> for more information
    = help: add `#![feature(asm_const)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/feature-gates/feature-gate-asm_experimental_arch.stderr
+++ b/src/test/ui/feature-gates/feature-gate-asm_experimental_arch.stderr
@@ -4,7 +4,7 @@ error[E0658]: inline assembly is not stable yet on this architecture
 LL |     asm!("");
    |     ^^^^^^^^
    |
-   = note: see issue #72016 <https://github.com/rust-lang/rust/issues/72016> for more information
+   = note: see issue #93335 <https://github.com/rust-lang/rust/issues/93335> for more information
    = help: add `#![feature(asm_experimental_arch)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/feature-gates/feature-gate-asm_sym.stderr
+++ b/src/test/ui/feature-gates/feature-gate-asm_sym.stderr
@@ -4,7 +4,7 @@ error[E0658]: sym operands for inline assembly are unstable
 LL |         asm!("mov eax, {}", sym main);
    |                             ^^^^^^^^
    |
-   = note: see issue #72016 <https://github.com/rust-lang/rust/issues/72016> for more information
+   = note: see issue #93333 <https://github.com/rust-lang/rust/issues/93333> for more information
    = help: add `#![feature(asm_sym)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/feature-gates/feature-gate-asm_unwind.stderr
+++ b/src/test/ui/feature-gates/feature-gate-asm_unwind.stderr
@@ -4,7 +4,7 @@ error[E0658]: the `may_unwind` option is unstable
 LL |         asm!("", options(may_unwind));
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: see issue #72016 <https://github.com/rust-lang/rust/issues/72016> for more information
+   = note: see issue #93334 <https://github.com/rust-lang/rust/issues/93334> for more information
    = help: add `#![feature(asm_unwind)]` to the crate attributes to enable
 
 error: aborting due to previous error


### PR DESCRIPTION
The main tracking issue for inline assembly is [closed](https://github.com/rust-lang/rust/issues/72016#issuecomment-1022332954), further tracking of the remaining sub-features has been moved to separate tracking issues.