### PR TITLE
libunwind: readd link attrs to _Unwind_Backtrace

### DIFF
--- a/library/unwind/src/libunwind.rs
+++ b/library/unwind/src/libunwind.rs
@@ -246,6 +246,10 @@ if #[cfg(not(all(target_os = "ios", target_arch = "arm")))] {
     extern "C-unwind" {
         pub fn _Unwind_RaiseException(exception: *mut _Unwind_Exception) -> _Unwind_Reason_Code;
     }
+    #[cfg_attr(
+        all(feature = "llvm-libunwind", any(target_os = "fuchsia", target_os = "linux")),
+        link(name = "unwind", kind = "static", modifiers = "-bundle")
+    )]
     extern "C" {
         pub fn _Unwind_Backtrace(trace: _Unwind_Trace_Fn,
                                  trace_argument: *mut c_void)


### PR DESCRIPTION
It seems the removal of these in 1c07096a45a15de64216f12ec726333870e372b1 was unintended; readding them fixes the build.

fixes rust-lang/rust#93349

r? @alexcrichton 