### PR TITLE
Edit docs introduction for `std::cmp::PartialOrd`

### DIFF
--- a/library/core/src/cmp.rs
+++ b/library/core/src/cmp.rs
@@ -880,7 +880,7 @@ impl PartialOrd for Ordering {
     }
 }
 
-/// Trait for values that can be compared for a sort-order.
+/// Trait for types that form a [partial order](https://en.wikipedia.org/wiki/Partial_order).
 ///
 /// The `lt`, `le`, `gt`, and `ge` methods of this trait can be called using
 /// the `<`, `<=`, `>`, and `>=` operators, respectively.


### PR DESCRIPTION
This makes `PartialOrd` consistent with the other three traits in this module, which all include links to their corresponding mathematical concepts on Wikipedia.

<img width="500" alt="Screen Shot 2022-01-26 at 10 24 23 PM" src="https://user-images.githubusercontent.com/19642016/151291720-decd85ed-cd6e-4be0-84a9-619b98ceb386.png">