### PR TITLE
Clarify the `usage-of-qualified-ty` error message.

### DIFF
--- a/compiler/rustc_lint/src/internal.rs
+++ b/compiler/rustc_lint/src/internal.rs
@@ -108,7 +108,7 @@ impl<'tcx> LateLintPass<'tcx> for TyTyKind {
                                     lint.build(&format!("usage of qualified `ty::{}`", t))
                                         .span_suggestion(
                                             path.span,
-                                            "try using it unqualified",
+                                            "try importing it and using it unqualified",
                                             t,
                                             // The import probably needs to be changed
                                             Applicability::MaybeIncorrect,

--- a/src/test/ui-fulldeps/internal-lints/qualified_ty_ty_ctxt.stderr
+++ b/src/test/ui-fulldeps/internal-lints/qualified_ty_ty_ctxt.stderr
@@ -2,7 +2,7 @@ error: usage of qualified `ty::Ty<'_>`
   --> $DIR/qualified_ty_ty_ctxt.rs:25:11
    |
 LL |     ty_q: ty::Ty<'_>,
-   |           ^^^^^^^^^^ help: try using it unqualified: `Ty<'_>`
+   |           ^^^^^^^^^^ help: try importing it and using it unqualified: `Ty<'_>`
    |
 note: the lint level is defined here
   --> $DIR/qualified_ty_ty_ctxt.rs:4:9
@@ -14,7 +14,7 @@ error: usage of qualified `ty::TyCtxt<'_>`
   --> $DIR/qualified_ty_ty_ctxt.rs:27:16
    |
 LL |     ty_ctxt_q: ty::TyCtxt<'_>,
-   |                ^^^^^^^^^^^^^^ help: try using it unqualified: `TyCtxt<'_>`
+   |                ^^^^^^^^^^^^^^ help: try importing it and using it unqualified: `TyCtxt<'_>`
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION
I found this message confusing when I encountered it. This commit makes
it clearer that you have to import the unqualified type yourself.

r? @lcnr 