### PR TITLE
Add ReadBufRef

### DIFF
--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -13,7 +13,7 @@ mod tests;
 
 use crate::ffi::OsString;
 use crate::fmt;
-use crate::io::{self, IoSlice, IoSliceMut, Read, ReadBuf, Seek, SeekFrom, Write};
+use crate::io::{self, IoSlice, IoSliceMut, Read, ReadBufRef, Seek, SeekFrom, Write};
 use crate::path::{Path, PathBuf};
 use crate::sys::fs as fs_imp;
 use crate::sys_common::{AsInner, AsInnerMut, FromInner, IntoInner};
@@ -624,7 +624,7 @@ impl Read for File {
         self.inner.read_vectored(bufs)
     }
 
-    fn read_buf(&mut self, buf: &mut ReadBuf<'_>) -> io::Result<()> {
+    fn read_buf(&mut self, buf: ReadBufRef<'_, '_>) -> io::Result<()> {
         self.inner.read_buf(buf)
     }
 
@@ -676,7 +676,7 @@ impl Read for &File {
         self.inner.read(buf)
     }
 
-    fn read_buf(&mut self, buf: &mut ReadBuf<'_>) -> io::Result<()> {
+    fn read_buf(&mut self, buf: ReadBufRef<'_, '_>) -> io::Result<()> {
         self.inner.read_buf(buf)
     }
 

--- a/library/std/src/io/buffered/bufreader.rs
+++ b/library/std/src/io/buffered/bufreader.rs
@@ -1,7 +1,8 @@
 use crate::cmp;
 use crate::fmt;
 use crate::io::{
-    self, BufRead, IoSliceMut, Read, ReadBuf, ReadBufRef, Seek, SeekFrom, SizeHint, DEFAULT_BUF_SIZE,
+    self, BufRead, IoSliceMut, Read, ReadBuf, ReadBufRef, Seek, SeekFrom, SizeHint,
+    DEFAULT_BUF_SIZE,
 };
 use crate::mem::MaybeUninit;
 

--- a/library/std/src/io/buffered/tests.rs
+++ b/library/std/src/io/buffered/tests.rs
@@ -64,7 +64,7 @@ fn test_buffered_reader_read_buf() {
     let mut buf = [MaybeUninit::uninit(); 3];
     let mut buf = ReadBuf::uninit(&mut buf);
 
-    reader.read_buf(&mut buf).unwrap();
+    reader.read_buf(buf.borrow()).unwrap();
 
     assert_eq!(buf.filled(), [5, 6, 7]);
     assert_eq!(reader.buffer(), []);
@@ -72,7 +72,7 @@ fn test_buffered_reader_read_buf() {
     let mut buf = [MaybeUninit::uninit(); 2];
     let mut buf = ReadBuf::uninit(&mut buf);
 
-    reader.read_buf(&mut buf).unwrap();
+    reader.read_buf(buf.borrow()).unwrap();
 
     assert_eq!(buf.filled(), [0, 1]);
     assert_eq!(reader.buffer(), []);
@@ -80,7 +80,7 @@ fn test_buffered_reader_read_buf() {
     let mut buf = [MaybeUninit::uninit(); 1];
     let mut buf = ReadBuf::uninit(&mut buf);
 
-    reader.read_buf(&mut buf).unwrap();
+    reader.read_buf(buf.borrow()).unwrap();
 
     assert_eq!(buf.filled(), [2]);
     assert_eq!(reader.buffer(), [3]);
@@ -88,19 +88,19 @@ fn test_buffered_reader_read_buf() {
     let mut buf = [MaybeUninit::uninit(); 3];
     let mut buf = ReadBuf::uninit(&mut buf);
 
-    reader.read_buf(&mut buf).unwrap();
+    reader.read_buf(buf.borrow()).unwrap();
 
     assert_eq!(buf.filled(), [3]);
     assert_eq!(reader.buffer(), []);
 
-    reader.read_buf(&mut buf).unwrap();
+    reader.read_buf(buf.borrow()).unwrap();
 
     assert_eq!(buf.filled(), [3, 4]);
     assert_eq!(reader.buffer(), []);
 
     buf.clear();
 
-    reader.read_buf(&mut buf).unwrap();
+    reader.read_buf(buf.borrow()).unwrap();
 
     assert_eq!(buf.filled_len(), 0);
 }

--- a/library/std/src/io/copy.rs
+++ b/library/std/src/io/copy.rs
@@ -95,7 +95,7 @@ impl<I: Write> BufferedCopySpec for BufWriter<I> {
             }
 
             if read_buf.capacity() >= DEFAULT_BUF_SIZE {
-                match reader.read_buf(&mut read_buf) {
+                match reader.read_buf(read_buf.borrow()) {
                     Ok(()) => {
                         let bytes_read = read_buf.filled_len();
 
@@ -132,7 +132,7 @@ fn stack_buffer_copy<R: Read + ?Sized, W: Write + ?Sized>(
     let mut len = 0;
 
     loop {
-        match reader.read_buf(&mut buf) {
+        match reader.read_buf(buf.borrow()) {
             Ok(()) => {}
             Err(e) if e.kind() == ErrorKind::Interrupted => continue,
             Err(e) => return Err(e),

--- a/library/std/src/io/cursor.rs
+++ b/library/std/src/io/cursor.rs
@@ -4,7 +4,7 @@ mod tests;
 use crate::io::prelude::*;
 
 use crate::cmp;
-use crate::io::{self, ErrorKind, IoSlice, IoSliceMut, ReadBuf, SeekFrom};
+use crate::io::{self, ErrorKind, IoSlice, IoSliceMut, ReadBufRef, SeekFrom};
 
 use core::convert::TryInto;
 
@@ -324,10 +324,10 @@ where
         Ok(n)
     }
 
-    fn read_buf(&mut self, buf: &mut ReadBuf<'_>) -> io::Result<()> {
+    fn read_buf(&mut self, mut buf: ReadBufRef<'_, '_>) -> io::Result<()> {
         let prev_filled = buf.filled_len();
 
-        Read::read_buf(&mut self.fill_buf()?, buf)?;
+        Read::read_buf(&mut self.fill_buf()?, buf.reborrow())?;
 
         self.pos += (buf.filled_len() - prev_filled) as u64;
 

--- a/library/std/src/io/impls.rs
+++ b/library/std/src/io/impls.rs
@@ -5,7 +5,7 @@ use crate::alloc::Allocator;
 use crate::cmp;
 use crate::fmt;
 use crate::io::{
-    self, BufRead, ErrorKind, IoSlice, IoSliceMut, Read, ReadBuf, Seek, SeekFrom, Write,
+    self, BufRead, ErrorKind, IoSlice, IoSliceMut, Read, ReadBufRef, Seek, SeekFrom, Write,
 };
 use crate::mem;
 
@@ -20,7 +20,7 @@ impl<R: Read + ?Sized> Read for &mut R {
     }
 
     #[inline]
-    fn read_buf(&mut self, buf: &mut ReadBuf<'_>) -> io::Result<()> {
+    fn read_buf(&mut self, buf: ReadBufRef<'_, '_>) -> io::Result<()> {
         (**self).read_buf(buf)
     }
 
@@ -124,7 +124,7 @@ impl<R: Read + ?Sized> Read for Box<R> {
     }
 
     #[inline]
-    fn read_buf(&mut self, buf: &mut ReadBuf<'_>) -> io::Result<()> {
+    fn read_buf(&mut self, buf: ReadBufRef<'_, '_>) -> io::Result<()> {
         (**self).read_buf(buf)
     }
 
@@ -248,7 +248,7 @@ impl Read for &[u8] {
     }
 
     #[inline]
-    fn read_buf(&mut self, buf: &mut ReadBuf<'_>) -> io::Result<()> {
+    fn read_buf(&mut self, mut buf: ReadBufRef<'_, '_>) -> io::Result<()> {
         let amt = cmp::min(buf.remaining(), self.len());
         let (a, b) = self.split_at(amt);
 

--- a/library/std/src/io/readbuf.rs
+++ b/library/std/src/io/readbuf.rs
@@ -7,6 +7,8 @@ use crate::cmp;
 use crate::fmt::{self, Debug, Formatter};
 use crate::mem::MaybeUninit;
 
+use core::ops::Deref;
+
 /// A wrapper around a byte buffer that is incrementally filled and initialized.
 ///
 /// This type is a sort of "double cursor". It tracks three regions in the buffer: a region at the beginning of the
@@ -262,30 +264,10 @@ impl<'a, 'b> ReadBufRef<'a, 'b> {
         ReadBufRef { read_buf: self.read_buf }
     }
 
-    /// Returns the total capacity of the buffer.
-    #[inline]
-    pub fn capacity(&self) -> usize {
-        self.read_buf.capacity()
-    }
-
-    /// Returns a shared reference to the filled portion of the buffer.
-    #[inline]
-    pub fn filled(&self) -> &[u8] {
-        self.read_buf.filled()
-    }
-
     /// Returns a mutable reference to the filled portion of the buffer.
     #[inline]
     pub fn filled_mut(&mut self) -> &mut [u8] {
         self.read_buf.filled_mut()
-    }
-
-    /// Returns a shared reference to the initialized portion of the buffer.
-    ///
-    /// This includes the filled portion.
-    #[inline]
-    pub fn initialized(&self) -> &[u8] {
-        self.read_buf.initialized()
     }
 
     /// Returns a mutable reference to the initialized portion of the buffer.
@@ -333,12 +315,6 @@ impl<'a, 'b> ReadBufRef<'a, 'b> {
     #[inline]
     pub fn initialize_unfilled_to(&mut self, n: usize) -> &mut [u8] {
         self.read_buf.initialize_unfilled_to(n)
-    }
-
-    /// Returns the number of bytes at the end of the slice that have not yet been filled.
-    #[inline]
-    pub fn remaining(&self) -> usize {
-        self.read_buf.remaining()
     }
 
     /// Clears the buffer, resetting the filled region to empty.
@@ -398,16 +374,12 @@ impl<'a, 'b> ReadBufRef<'a, 'b> {
     pub fn append(&mut self, buf: &[u8]) {
         self.read_buf.append(buf)
     }
+}
 
-    /// Returns the amount of bytes that have been filled.
-    #[inline]
-    pub fn filled_len(&self) -> usize {
-        self.read_buf.filled_len()
-    }
+impl<'a, 'b> Deref for ReadBufRef<'a, 'b> {
+    type Target = ReadBuf<'b>;
 
-    /// Returns the amount of bytes that have been initialized.
-    #[inline]
-    pub fn initialized_len(&self) -> usize {
-        self.read_buf.initialized_len()
+    fn deref(&self) -> &ReadBuf<'b> {
+        &*self.read_buf
     }
 }

--- a/library/std/src/io/readbuf.rs
+++ b/library/std/src/io/readbuf.rs
@@ -61,7 +61,7 @@ impl<'a> ReadBuf<'a> {
     /// Creates a new [`ReadBufRef`] referencing this `ReadBuf`.
     #[inline]
     pub fn borrow(&mut self) -> ReadBufRef<'_, 'a> {
-        ReadBufRef {read_buf: self}
+        ReadBufRef { read_buf: self }
     }
 
     /// Returns the total capacity of the buffer.
@@ -250,17 +250,16 @@ impl<'a> ReadBuf<'a> {
     }
 }
 
-
 /// A wrapper around [`&mut ReadBuf`](ReadBuf) which prevents the buffer that the `ReadBuf` points to from being replaced.
 #[derive(Debug)]
 pub struct ReadBufRef<'a, 'b> {
-    read_buf: &'a mut ReadBuf<'b>
+    read_buf: &'a mut ReadBuf<'b>,
 }
 
 impl<'a, 'b> ReadBufRef<'a, 'b> {
     /// Creates a new `ReadBufRef` referencing the same `ReadBuf` as this one.
     pub fn reborrow(&mut self) -> ReadBufRef<'_, 'b> {
-        ReadBufRef {read_buf: self.read_buf}
+        ReadBufRef { read_buf: self.read_buf }
     }
 
     /// Returns the total capacity of the buffer.

--- a/library/std/src/io/tests.rs
+++ b/library/std/src/io/tests.rs
@@ -163,20 +163,20 @@ fn read_buf_exact() {
     let mut buf = ReadBuf::new(&mut buf);
 
     let mut c = Cursor::new(&b""[..]);
-    assert_eq!(c.read_buf_exact(&mut buf).unwrap_err().kind(), io::ErrorKind::UnexpectedEof);
+    assert_eq!(c.read_buf_exact(buf.borrow()).unwrap_err().kind(), io::ErrorKind::UnexpectedEof);
 
     let mut c = Cursor::new(&b"123456789"[..]);
-    c.read_buf_exact(&mut buf).unwrap();
+    c.read_buf_exact(buf.borrow()).unwrap();
     assert_eq!(buf.filled(), b"1234");
 
     buf.clear();
 
-    c.read_buf_exact(&mut buf).unwrap();
+    c.read_buf_exact(buf.borrow()).unwrap();
     assert_eq!(buf.filled(), b"5678");
 
     buf.clear();
 
-    assert_eq!(c.read_buf_exact(&mut buf).unwrap_err().kind(), io::ErrorKind::UnexpectedEof);
+    assert_eq!(c.read_buf_exact(buf.borrow()).unwrap_err().kind(), io::ErrorKind::UnexpectedEof);
 }
 
 #[test]
@@ -599,6 +599,6 @@ fn bench_take_read_buf(b: &mut test::Bencher) {
 
         let mut rbuf = ReadBuf::uninit(&mut buf);
 
-        [255; 128].take(64).read_buf(&mut rbuf).unwrap();
+        [255; 128].take(64).read_buf(rbuf.borrow()).unwrap();
     });
 }

--- a/library/std/src/io/util.rs
+++ b/library/std/src/io/util.rs
@@ -5,7 +5,7 @@ mod tests;
 
 use crate::fmt;
 use crate::io::{
-    self, BufRead, IoSlice, IoSliceMut, Read, ReadBuf, Seek, SeekFrom, SizeHint, Write,
+    self, BufRead, IoSlice, IoSliceMut, Read, ReadBufRef, Seek, SeekFrom, SizeHint, Write,
 };
 
 /// A reader which is always at EOF.
@@ -47,7 +47,7 @@ impl Read for Empty {
     }
 
     #[inline]
-    fn read_buf(&mut self, _buf: &mut ReadBuf<'_>) -> io::Result<()> {
+    fn read_buf(&mut self, _buf: ReadBufRef<'_, '_>) -> io::Result<()> {
         Ok(())
     }
 }
@@ -130,7 +130,7 @@ impl Read for Repeat {
         Ok(buf.len())
     }
 
-    fn read_buf(&mut self, buf: &mut ReadBuf<'_>) -> io::Result<()> {
+    fn read_buf(&mut self, mut buf: ReadBufRef<'_, '_>) -> io::Result<()> {
         // SAFETY: No uninit bytes are being written
         for slot in unsafe { buf.unfilled_mut() } {
             slot.write(self.byte);

--- a/library/std/src/io/util/tests.rs
+++ b/library/std/src/io/util/tests.rs
@@ -81,25 +81,25 @@ fn empty_reads() {
 
     let mut buf = [];
     let mut buf = ReadBuf::uninit(&mut buf);
-    e.read_buf(&mut buf).unwrap();
+    e.read_buf(buf.borrow()).unwrap();
     assert_eq!(buf.filled_len(), 0);
     assert_eq!(buf.initialized_len(), 0);
 
     let mut buf = [MaybeUninit::uninit()];
     let mut buf = ReadBuf::uninit(&mut buf);
-    e.read_buf(&mut buf).unwrap();
+    e.read_buf(buf.borrow()).unwrap();
     assert_eq!(buf.filled_len(), 0);
     assert_eq!(buf.initialized_len(), 0);
 
     let mut buf = [MaybeUninit::uninit(); 1024];
     let mut buf = ReadBuf::uninit(&mut buf);
-    e.read_buf(&mut buf).unwrap();
+    e.read_buf(buf.borrow()).unwrap();
     assert_eq!(buf.filled_len(), 0);
     assert_eq!(buf.initialized_len(), 0);
 
     let mut buf = [MaybeUninit::uninit(); 1024];
     let mut buf = ReadBuf::uninit(&mut buf);
-    e.by_ref().read_buf(&mut buf).unwrap();
+    e.by_ref().read_buf(buf.borrow()).unwrap();
     assert_eq!(buf.filled_len(), 0);
     assert_eq!(buf.initialized_len(), 0);
 }

--- a/library/std/src/sys/hermit/fs.rs
+++ b/library/std/src/sys/hermit/fs.rs
@@ -2,7 +2,7 @@ use crate::ffi::{CStr, CString, OsString};
 use crate::fmt;
 use crate::hash::{Hash, Hasher};
 use crate::io::{self, Error, ErrorKind};
-use crate::io::{IoSlice, IoSliceMut, ReadBuf, SeekFrom};
+use crate::io::{IoSlice, IoSliceMut, ReadBufRef, SeekFrom};
 use crate::os::unix::ffi::OsStrExt;
 use crate::path::{Path, PathBuf};
 use crate::sys::cvt;
@@ -312,7 +312,7 @@ impl File {
         false
     }
 
-    pub fn read_buf(&self, buf: &mut ReadBuf<'_>) -> io::Result<()> {
+    pub fn read_buf(&self, buf: ReadBufRef<'_, '_>) -> io::Result<()> {
         crate::io::default_read_buf(|buf| self.read(buf), buf)
     }
 

--- a/library/std/src/sys/solid/fs.rs
+++ b/library/std/src/sys/solid/fs.rs
@@ -339,7 +339,7 @@ impl File {
         }
     }
 
-    pub fn read_buf(&self, buf: &mut ReadBuf<'_>) -> io::Result<()> {
+    pub fn read_buf(&self, buf: ReadBufRef<'_, '_>) -> io::Result<()> {
         unsafe {
             let len = buf.remaining();
             let mut out_num_bytes = MaybeUninit::uninit();

--- a/library/std/src/sys/unix/fd.rs
+++ b/library/std/src/sys/unix/fd.rs
@@ -4,7 +4,7 @@
 mod tests;
 
 use crate::cmp;
-use crate::io::{self, IoSlice, IoSliceMut, Read, ReadBuf};
+use crate::io::{self, IoSlice, IoSliceMut, Read, ReadBufRef};
 use crate::os::unix::io::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, OwnedFd, RawFd};
 use crate::sys::cvt;
 use crate::sys_common::{AsInner, FromInner, IntoInner};
@@ -115,7 +115,7 @@ impl FileDesc {
         }
     }
 
-    pub fn read_buf(&self, buf: &mut ReadBuf<'_>) -> io::Result<()> {
+    pub fn read_buf(&self, mut buf: ReadBufRef<'_, '_>) -> io::Result<()> {
         let ret = cvt(unsafe {
             libc::read(
                 self.as_raw_fd(),

--- a/library/std/src/sys/unix/fs.rs
+++ b/library/std/src/sys/unix/fs.rs
@@ -2,7 +2,7 @@ use crate::os::unix::prelude::*;
 
 use crate::ffi::{CStr, CString, OsStr, OsString};
 use crate::fmt;
-use crate::io::{self, Error, IoSlice, IoSliceMut, ReadBuf, SeekFrom};
+use crate::io::{self, Error, IoSlice, IoSliceMut, ReadBufRef, SeekFrom};
 use crate::mem;
 use crate::os::unix::io::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd};
 use crate::path::{Path, PathBuf};
@@ -892,7 +892,7 @@ impl File {
         self.0.read_at(buf, offset)
     }
 
-    pub fn read_buf(&self, buf: &mut ReadBuf<'_>) -> io::Result<()> {
+    pub fn read_buf(&self, buf: ReadBufRef<'_, '_>) -> io::Result<()> {
         self.0.read_buf(buf)
     }
 

--- a/library/std/src/sys/unsupported/fs.rs
+++ b/library/std/src/sys/unsupported/fs.rs
@@ -1,7 +1,7 @@
 use crate::ffi::OsString;
 use crate::fmt;
 use crate::hash::{Hash, Hasher};
-use crate::io::{self, IoSlice, IoSliceMut, ReadBuf, SeekFrom};
+use crate::io::{self, IoSlice, IoSliceMut, ReadBufRef, SeekFrom};
 use crate::path::{Path, PathBuf};
 use crate::sys::time::SystemTime;
 use crate::sys::unsupported;
@@ -206,7 +206,7 @@ impl File {
         self.0
     }
 
-    pub fn read_buf(&self, _buf: &mut ReadBuf<'_>) -> io::Result<()> {
+    pub fn read_buf(&self, _buf: ReadBufRef<'_, '_>) -> io::Result<()> {
         self.0
     }
 

--- a/library/std/src/sys/wasi/fs.rs
+++ b/library/std/src/sys/wasi/fs.rs
@@ -3,7 +3,7 @@
 use super::fd::WasiFd;
 use crate::ffi::{CStr, CString, OsStr, OsString};
 use crate::fmt;
-use crate::io::{self, IoSlice, IoSliceMut, ReadBuf, SeekFrom};
+use crate::io::{self, IoSlice, IoSliceMut, ReadBufRef, SeekFrom};
 use crate::iter;
 use crate::mem::{self, ManuallyDrop};
 use crate::os::raw::c_int;
@@ -423,7 +423,7 @@ impl File {
         true
     }
 
-    pub fn read_buf(&self, buf: &mut ReadBuf<'_>) -> io::Result<()> {
+    pub fn read_buf(&self, buf: ReadBufRef<'_, '_>) -> io::Result<()> {
         crate::io::default_read_buf(|buf| self.read(buf), buf)
     }
 

--- a/library/std/src/sys/windows/fs.rs
+++ b/library/std/src/sys/windows/fs.rs
@@ -2,7 +2,7 @@ use crate::os::windows::prelude::*;
 
 use crate::ffi::OsString;
 use crate::fmt;
-use crate::io::{self, Error, IoSlice, IoSliceMut, ReadBuf, SeekFrom};
+use crate::io::{self, Error, IoSlice, IoSliceMut, ReadBufRef, SeekFrom};
 use crate::mem;
 use crate::os::windows::io::{AsHandle, BorrowedHandle};
 use crate::path::{Path, PathBuf};
@@ -420,7 +420,7 @@ impl File {
         self.handle.read_at(buf, offset)
     }
 
-    pub fn read_buf(&self, buf: &mut ReadBuf<'_>) -> io::Result<()> {
+    pub fn read_buf(&self, buf: ReadBufRef<'_, '_>) -> io::Result<()> {
         self.handle.read_buf(buf)
     }
 

--- a/library/std/src/sys/windows/handle.rs
+++ b/library/std/src/sys/windows/handle.rs
@@ -1,7 +1,7 @@
 #![unstable(issue = "none", feature = "windows_handle")]
 
 use crate::cmp;
-use crate::io::{self, ErrorKind, IoSlice, IoSliceMut, Read, ReadBuf};
+use crate::io::{self, ErrorKind, IoSlice, IoSliceMut, Read, ReadBufRef};
 use crate::mem;
 use crate::os::windows::io::{
     AsHandle, AsRawHandle, BorrowedHandle, FromRawHandle, IntoRawHandle, OwnedHandle, RawHandle,
@@ -130,7 +130,7 @@ impl Handle {
         }
     }
 
-    pub fn read_buf(&self, buf: &mut ReadBuf<'_>) -> io::Result<()> {
+    pub fn read_buf(&self, mut buf: ReadBufRef<'_, '_>) -> io::Result<()> {
         let mut read = 0;
         let len = cmp::min(buf.remaining(), <c::DWORD>::MAX as usize) as c::DWORD;
         let res = cvt(unsafe {


### PR DESCRIPTION
Adds `ReadBufRef`, a wrapper around `&mut ReadBuf` that prevents its buffer from being swapped with a different buffer and makes `Read::read_buf` use it.

Fixes #93305