### PR TITLE
`.join()` for implementors of `ToString`

### DIFF
--- a/library/alloc/src/str.rs
+++ b/library/alloc/src/str.rs
@@ -94,11 +94,11 @@ impl<S: Borrow<str>> Join<&str> for [S] {
     }
 }
 
-impl<S> Join<&str> for [S] 
+impl<S> Join<S> for [S] 
 where S: crate::string::ToString {
     type Output = String;
     
-    fn join(slice: &Self, sep: &str) -> String {
+    fn join(slice: &Self, sep: &S) -> String {
         // Reuse the [&str] impl of Join.
         let slice = slice.iter().map(
             |s| s.to_string()

--- a/library/alloc/src/str.rs
+++ b/library/alloc/src/str.rs
@@ -94,8 +94,8 @@ impl<S: Borrow<str>> Join<&str> for [S] {
     }
 }
 
-impl<S> Join<Borrow<Str>> for [S] 
-where S: std::fmt::Display {
+impl<S> Join<&str> for [S] 
+where S: crate::string::ToString {
     type Output = String;
     
     fn join(slice: &Self, sep: &str) -> String {

--- a/library/alloc/src/str.rs
+++ b/library/alloc/src/str.rs
@@ -94,14 +94,14 @@ impl<S: Borrow<str>> Join<&str> for [S] {
     }
 }
 
-impl<'_, S> Join<&'_ str> for [S] 
+impl<S> Join<crate::string::ToString> for [S] 
 where S: crate::string::ToString + Clone {
     type Output = String;
     
     fn join(slice: &Self, sep: &S) -> String {
         // Reuse the [&str] impl of Join.
         let slice = slice.iter().map(
-            |s| s.to_string()
+            Self::to_string
         ).collect::<Vec<String>>();
         
         slice.join(sep)

--- a/library/alloc/src/str.rs
+++ b/library/alloc/src/str.rs
@@ -104,7 +104,7 @@ where S: crate::string::ToString + Clone {
             Self::to_string
         ).collect::<Vec<String>>();
         
-        slice.join(sep)
+        slice.join(&sep.to_string())
     }
 }
 

--- a/library/alloc/src/str.rs
+++ b/library/alloc/src/str.rs
@@ -95,7 +95,7 @@ impl<S: Borrow<str>> Join<&str> for [S] {
 }
 
 impl<'_, S> Join<&'_ str> for [S] 
-where S: crate::string::ToString {
+where S: crate::string::ToString + Clone {
     type Output = String;
     
     fn join(slice: &Self, sep: &S) -> String {

--- a/library/alloc/src/str.rs
+++ b/library/alloc/src/str.rs
@@ -94,7 +94,7 @@ impl<S: Borrow<str>> Join<&str> for [S] {
     }
 }
 
-impl<S> Join<S> for [S] 
+impl<'_, S> Join<&'_ str> for [S] 
 where S: crate::string::ToString {
     type Output = String;
     

--- a/library/alloc/src/str.rs
+++ b/library/alloc/src/str.rs
@@ -79,7 +79,7 @@ pub use core::str::{RSplitTerminator, SplitTerminator};
 impl<S: Borrow<str>> Concat<str> for [S] {
     type Output = String;
 
-    fn concat(slice: &Self) -> String {
+    fn concat(slice: &Self) -> String { 
         Join::join(slice, "")
     }
 }
@@ -93,6 +93,21 @@ impl<S: Borrow<str>> Join<&str> for [S] {
         unsafe { String::from_utf8_unchecked(join_generic_copy(slice, sep.as_bytes())) }
     }
 }
+
+impl<S> Join<Borrow<Str>> for [S] 
+where S: std::fmt::Display {
+    type Output = String;
+    
+    fn join(slice: &Self, sep: &str) -> String {
+        // Reuse the [&str] impl of Join.
+        let slice = slice.iter().map(
+            |s| s.to_string()
+        ).collect::<Vec<String>>();
+        
+        slice.join(sep)
+    }
+}
+
 
 #[cfg(not(no_global_oom_handling))]
 macro_rules! specialize_for_lengths {


### PR DESCRIPTION
This simply reuses the implementation of `Join` for the `[&str]` array.

I think this simple change goes a long way for quality of life when trying to join several elements that implement `Display`, such as integers, floats, and custom types that implement it. What are your thoughts?

```rs
let num_arr = [1, 2, 3]

println!("{}", num_arr.join(","));
```

versus

```rs
let num_arr = [1, 2, 3];

// Not exactly ergonomic :(
let display_arr = num_arr.iter().map(|s| s.to_string()).collect::<Vec<String>>().join(",");

println!("{}", display_arr);

// Not strictly necessary to drop depending on scenario (and scope), but conserves RAM if necessary.
drop(display_arr);
```