### PR TITLE
Add a bit more padding in search box

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -933,7 +933,7 @@ table,
 	outline: none;
 	border: 1px solid;
 	border-radius: 2px;
-	padding: 5px 8px;
+	padding: 8px;
 	font-size: 1rem;
 	transition: border-color 300ms ease;
 	width: 100%;


### PR DESCRIPTION
As asked in https://github.com/rust-lang/rust/pull/93113#issuecomment-1021565703, here is a bit more padding.

You can check it [here](https://rustdoc.crud.net/imperio/search-input-padding/foo/index.html).

r? @camelid 