### PR TITLE
Rustdoc ty consistency fixes

### DIFF
--- a/src/librustdoc/clean/blanket_impl.rs
+++ b/src/librustdoc/clean/blanket_impl.rs
@@ -101,27 +101,6 @@ impl<'a, 'tcx> BlanketImplFinder<'a, 'tcx> {
 
                     cx.generated_synthetics.insert((ty, trait_def_id));
 
-                    let hir_imp = impl_def_id.as_local()
-                        .map(|local| cx.tcx.hir().expect_item(local))
-                        .and_then(|item| if let hir::ItemKind::Impl(i) = &item.kind {
-                            Some(i)
-                        } else {
-                            None
-                        });
-
-                    let items = match hir_imp {
-                        Some(imp) => imp
-                            .items
-                            .iter()
-                            .map(|ii| cx.tcx.hir().impl_item(ii.id).clean(cx))
-                            .collect::<Vec<_>>(),
-                        None => cx.tcx
-                            .associated_items(impl_def_id)
-                            .in_definition_order()
-                            .map(|x| x.clean(cx))
-                            .collect::<Vec<_>>(),
-                    };
-
                     impls.push(Item {
                         name: None,
                         attrs: Default::default(),
@@ -138,7 +117,11 @@ impl<'a, 'tcx> BlanketImplFinder<'a, 'tcx> {
                             // the post-inference `trait_ref`, as it's more accurate.
                             trait_: Some(trait_ref.clean(cx)),
                             for_: ty.clean(cx),
-                            items,
+                            items: cx.tcx
+                                .associated_items(impl_def_id)
+                                .in_definition_order()
+                                .map(|x| x.clean(cx))
+                                .collect::<Vec<_>>(),
                             polarity: ty::ImplPolarity::Positive,
                             kind: ImplKind::Blanket(box trait_ref.self_ty().clean(cx)),
                         }),

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -228,7 +228,7 @@ fn build_external_function(cx: &mut DocContext<'_>, did: DefId) -> clean::Functi
     let (generics, decl) = clean::enter_impl_trait(cx, |cx| {
         // NOTE: generics need to be cleaned before the decl!
         let generics = clean_ty_generics(cx, cx.tcx.generics_of(did), predicates);
-        let decl = clean_fn_decl_from_did_and_sig(cx, did, sig);
+        let decl = clean_fn_decl_from_did_and_sig(cx, Some(did), sig);
         (generics, decl)
     });
     clean::Function {

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1204,7 +1204,16 @@ impl Clean<Item> for ty::AssocItem {
             }
         };
 
-        Item::from_def_id_and_parts(self.def_id, Some(self.name), kind, cx)
+        let mut output = Item::from_def_id_and_parts(self.def_id, Some(self.name), kind, cx);
+
+        // HACK: Override visibility for items in a trait implementation to match HIR
+        let impl_ref = tcx.parent(self.def_id).and_then(|did| tcx.impl_trait_ref(did));
+
+        if impl_ref.is_some() {
+            output.visibility = Visibility::Inherited;
+        }
+
+        output
     }
 }
 


### PR DESCRIPTION
Changes to make rustdoc cleaning of ty more consistent with hir, and hopefully use it in more places.

r? @camelid 