### PR TITLE
Check that `#[rustc_must_implement_one_of]` is applied to a trait

### DIFF
--- a/src/test/ui/traits/default-method/rustc_must_implement_one_of_misuse.rs
+++ b/src/test/ui/traits/default-method/rustc_must_implement_one_of_misuse.rs
@@ -35,4 +35,12 @@ trait Tr5 {
     fn b(); //~ This function doesn't have a default implementation
 }
 
+#[rustc_must_implement_one_of(abc, xyz)]
+//~^ attribute can only be applied to a trait
+fn function() {}
+
+#[rustc_must_implement_one_of(abc, xyz)]
+//~^ attribute can only be applied to a trait
+struct Struct {}
+
 fn main() {}

--- a/src/test/ui/traits/default-method/rustc_must_implement_one_of_misuse.stderr
+++ b/src/test/ui/traits/default-method/rustc_must_implement_one_of_misuse.stderr
@@ -4,6 +4,24 @@ error: malformed `rustc_must_implement_one_of` attribute input
 LL | #[rustc_must_implement_one_of]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: must be of the form: `#[rustc_must_implement_one_of(function1, function2, ...)]`
 
+error: attribute can only be applied to a trait
+  --> $DIR/rustc_must_implement_one_of_misuse.rs:38:1
+   |
+LL | #[rustc_must_implement_one_of(abc, xyz)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |
+LL | fn function() {}
+   | ---------------- not a trait
+
+error: attribute can only be applied to a trait
+  --> $DIR/rustc_must_implement_one_of_misuse.rs:42:1
+   |
+LL | #[rustc_must_implement_one_of(abc, xyz)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |
+LL | struct Struct {}
+   | ---------------- not a trait
+
 error: Function not found in this trait
   --> $DIR/rustc_must_implement_one_of_misuse.rs:3:31
    |
@@ -78,5 +96,5 @@ note: required by this annotation
 LL | #[rustc_must_implement_one_of(a, b)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 9 previous errors
+error: aborting due to 11 previous errors
 


### PR DESCRIPTION
`#[rustc_must_implement_one_of]` only makes sense when applied to a trait, so it's sensible to emit an error otherwise.