### PR TITLE
rustdoc: remove tooltip from source link

### DIFF
--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -182,7 +182,7 @@ impl StylePath {
 
 fn write_srclink(cx: &Context<'_>, item: &clean::Item, buf: &mut Buffer) {
     if let Some(l) = cx.src_href(item) {
-        write!(buf, "<a class=\"srclink\" href=\"{}\" title=\"goto source code\">source</a>", l)
+        write!(buf, "<a class=\"srclink\" href=\"{}\">source</a>", l)
     }
 }
 

--- a/src/librustdoc/html/templates/print_item.html
+++ b/src/librustdoc/html/templates/print_item.html
@@ -20,7 +20,7 @@
         {% endif %}
         {%- match src_href -%}
             {%- when Some with (href) -%}
-                <a class="srclink" href="{{href|safe}}" title="goto source code">source</a> · {# -#}
+                <a class="srclink" href="{{href|safe}}">source</a> · {# -#}
             {%- else -%}
         {%- endmatch -%}
         <a id="toggle-all-docs" href="javascript:void(0)" title="collapse all docs"> {#- -#}


### PR DESCRIPTION
This made more sense back when it was abbreviated, but now it seems redundant.