### PR TITLE
rustbuild: Fix compiletest warning when building outside of root.

### DIFF
--- a/src/bootstrap/util.rs
+++ b/src/bootstrap/util.rs
@@ -282,9 +282,10 @@ pub fn is_valid_test_suite_arg<'a, P: AsRef<Path>>(
     if !path.starts_with(suite_path) {
         return None;
     }
-    let exists = path.is_dir() || path.is_file();
+    let abs_path = builder.src.join(path);
+    let exists = abs_path.is_dir() || abs_path.is_file();
     if !exists {
-        if let Some(p) = path.to_str() {
+        if let Some(p) = abs_path.to_str() {
             builder.info(&format!("Warning: Skipping \"{}\": not a regular file or directory", p));
         }
         return None;


### PR DESCRIPTION
This fixes a warning that would happen when passing arguments to compiletest (like `x.py test src/test/ui`) when running `x.py` outside of the root source directory. For example, the CI builders do this, which causes a confusing warning message. This also fixes it so that passing a full path works (like `x.py test src/test/ui/hello.rs`) in the same scenario (previously it would just ignore the `hello.rs` part).
