### PR TITLE
kmc-solid: Implement `net::FileDesc::duplicate`

### DIFF
--- a/library/std/src/sys/solid/abi/sockets.rs
+++ b/library/std/src/sys/solid/abi/sockets.rs
@@ -175,6 +175,9 @@ extern "C" {
     #[link_name = "SOLID_NET_Close"]
     pub fn close(s: c_int) -> c_int;
 
+    #[link_name = "SOLID_NET_Dup"]
+    pub fn dup(s: c_int) -> c_int;
+
     #[link_name = "SOLID_NET_GetPeerName"]
     pub fn getpeername(s: c_int, name: *mut sockaddr, namelen: *mut socklen_t) -> c_int;
 

--- a/library/std/src/sys/solid/net.rs
+++ b/library/std/src/sys/solid/net.rs
@@ -107,7 +107,7 @@ impl FileDesc {
     }
 
     fn duplicate(&self) -> io::Result<FileDesc> {
-        super::unsupported()
+        cvt(unsafe { netc::dup(self.fd) }).map(Self::new)
     }
 }
 


### PR DESCRIPTION
This PR implements `std::sys::solid::net::FileDesc::duplicate`, which was accidentally left out when this target was added by #86191.