### PR TITLE
Move unstable is_{arch}_feature_detected! macros to std::arch

### DIFF
--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -403,13 +403,6 @@ pub use alloc_crate::string;
 pub use alloc_crate::vec;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use core::any;
-#[stable(feature = "simd_arch", since = "1.27.0")]
-// The `no_inline`-attribute is required to make the documentation of all
-// targets available.
-// See https://github.com/rust-lang/rust/pull/57808#issuecomment-457390549 for
-// more information.
-#[doc(no_inline)] // Note (#82861): required for correct documentation
-pub use core::arch;
 #[stable(feature = "core_array", since = "1.36.0")]
 pub use core::array;
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -527,6 +520,31 @@ pub mod task {
     pub use alloc::task::*;
 }
 
+#[doc = include_str!("../../stdarch/crates/core_arch/src/core_arch_docs.md")]
+#[stable(feature = "simd_arch", since = "1.27.0")]
+pub mod arch {
+    #[stable(feature = "simd_arch", since = "1.27.0")]
+    // The `no_inline`-attribute is required to make the documentation of all
+    // targets available.
+    // See https://github.com/rust-lang/rust/pull/57808#issuecomment-457390549 for
+    // more information.
+    #[doc(no_inline)] // Note (#82861): required for correct documentation
+    pub use core::arch::*;
+
+    #[stable(feature = "simd_x86", since = "1.27.0")]
+    pub use std_detect::is_x86_feature_detected;
+    #[unstable(feature = "stdsimd", issue = "48556")]
+    pub use std_detect::{
+        is_aarch64_feature_detected, is_arm_feature_detected, is_mips64_feature_detected,
+        is_mips_feature_detected, is_powerpc64_feature_detected, is_powerpc_feature_detected,
+        is_riscv_feature_detected,
+    };
+}
+
+// This was stabilized in the crate root so we have to keep it there.
+#[stable(feature = "simd_x86", since = "1.27.0")]
+pub use std_detect::is_x86_feature_detected;
+
 // The runtime entry point and a few unstable public functions used by the
 // compiler
 #[macro_use]
@@ -544,18 +562,6 @@ mod panicking;
 #[path = "../../backtrace/src/lib.rs"]
 #[allow(dead_code, unused_attributes)]
 mod backtrace_rs;
-
-#[stable(feature = "simd_x86", since = "1.27.0")]
-pub use std_detect::is_x86_feature_detected;
-#[doc(hidden)]
-#[unstable(feature = "stdsimd", issue = "48556")]
-pub use std_detect::*;
-#[unstable(feature = "stdsimd", issue = "48556")]
-pub use std_detect::{
-    is_aarch64_feature_detected, is_arm_feature_detected, is_mips64_feature_detected,
-    is_mips_feature_detected, is_powerpc64_feature_detected, is_powerpc_feature_detected,
-    is_riscv_feature_detected,
-};
 
 // Re-export macros defined in libcore.
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/library/std/tests/run-time-detect.rs
+++ b/library/std/tests/run-time-detect.rs
@@ -14,6 +14,7 @@
 #[test]
 #[cfg(all(target_arch = "arm", any(target_os = "linux", target_os = "android")))]
 fn arm_linux() {
+    use std::arch::is_arm_feature_detected;
     println!("neon: {}", is_arm_feature_detected!("neon"));
     println!("pmull: {}", is_arm_feature_detected!("pmull"));
     println!("crypto: {}", is_arm_feature_detected!("crypto"));
@@ -25,6 +26,7 @@ fn arm_linux() {
 #[test]
 #[cfg(all(target_arch = "aarch64", any(target_os = "linux", target_os = "android")))]
 fn aarch64_linux() {
+    use std::arch::is_aarch64_feature_detected;
     println!("neon: {}", is_aarch64_feature_detected!("neon"));
     println!("asimd: {}", is_aarch64_feature_detected!("asimd"));
     println!("pmull: {}", is_aarch64_feature_detected!("pmull"));
@@ -71,6 +73,7 @@ fn aarch64_linux() {
 #[test]
 #[cfg(all(target_arch = "powerpc", target_os = "linux"))]
 fn powerpc_linux() {
+    use std::arch::is_powerpc_feature_detected;
     println!("altivec: {}", is_powerpc_feature_detected!("altivec"));
     println!("vsx: {}", is_powerpc_feature_detected!("vsx"));
     println!("power8: {}", is_powerpc_feature_detected!("power8"));
@@ -79,6 +82,7 @@ fn powerpc_linux() {
 #[test]
 #[cfg(all(target_arch = "powerpc64", target_os = "linux"))]
 fn powerpc64_linux() {
+    use std::arch::is_powerpc64_feature_detected;
     println!("altivec: {}", is_powerpc64_feature_detected!("altivec"));
     println!("vsx: {}", is_powerpc64_feature_detected!("vsx"));
     println!("power8: {}", is_powerpc64_feature_detected!("power8"));
@@ -87,6 +91,8 @@ fn powerpc64_linux() {
 #[test]
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 fn x86_all() {
+    use std::arch::is_x86_feature_detected;
+
     // the below is the set of features we can test at runtime, but don't actually
     // use to gate anything and are thus not part of the X86_ALLOWED_FEATURES list
 


### PR DESCRIPTION
These macros are unstable, except for `is_x86_feature_detected` which is still exported from the crate root for backwards-compatibility.

This should unblock the stabilization of `is_aarch64_feature_detected`.

r? @m-ou-se 