### PR TITLE
rustdoc & doc: no `shortcut` for `rel="icon"`

### DIFF
--- a/src/doc/favicon.inc
+++ b/src/doc/favicon.inc
@@ -1,1 +1,1 @@
-<link rel="shortcut icon" href="https://www.rust-lang.org/favicon.ico">
+<link rel="icon" href="https://www.rust-lang.org/favicon.ico">

--- a/src/doc/redirect.inc
+++ b/src/doc/redirect.inc
@@ -1,2 +1,2 @@
 <meta name="robots" content="noindex,follow">
-<link rel="shortcut icon" href="https://www.rust-lang.org/favicon.ico">
+<link rel="icon" href="https://www.rust-lang.org/favicon.ico">

--- a/src/doc/rustdoc/src/the-doc-attribute.md
+++ b/src/doc/rustdoc/src/the-doc-attribute.md
@@ -59,7 +59,7 @@ This form of the `doc` attribute lets you control the favicon of your docs.
 #![doc(html_favicon_url = "https://example.com/favicon.ico")]
 ```
 
-This will put `<link rel="shortcut icon" href="{}">` into your docs, where
+This will put `<link rel="icon" href="{}">` into your docs, where
 the string for the attribute goes into the `{}`.
 
 If you don't use this attribute, there will be no favicon.

--- a/src/librustdoc/html/templates/page.html
+++ b/src/librustdoc/html/templates/page.html
@@ -54,7 +54,7 @@
             href="{{static_root_path|safe}}theme{{page.resource_suffix}}.css"> {#- -#}
     {%- endif -%}
     {%- if !layout.favicon.is_empty() -%}
-        <link rel="shortcut icon" href="{{layout.favicon}}"> {#- -#}
+        <link rel="icon" href="{{layout.favicon}}"> {#- -#}
     {%- else -%}
         <link rel="alternate icon" type="image/png" {# -#}
             href="{{static_root_path|safe}}favicon-16x16{{page.resource_suffix}}.png"> {#- -#}


### PR DESCRIPTION
According to https://html.spec.whatwg.org/multipage/links.html#rel-icon:

> For historical reasons, the `icon` keyword may be preceded by the keyword "`shortcut`".

And to https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types:

> **Warning:** The `shortcut` link type is often seen before `icon`, but this link type is non-conforming, ignored and **web authors must not use it anymore.**

While it was removed from the Rust logo case a while ago in commit 085679c ("Use theme-adaptive SVG favicon from other Rust sites"), it is still there for the custom logo case.

Also updated a few other instances.

Signed-off-by: Miguel Ojeda <ojeda@kernel.org>