### PR TITLE
Allow `trait A: ~const B`

### DIFF
--- a/compiler/rustc_ast_passes/src/ast_validation.rs
+++ b/compiler/rustc_ast_passes/src/ast_validation.rs
@@ -1272,7 +1272,7 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
                 self.visit_vis(&item.vis);
                 self.visit_ident(item.ident);
                 self.visit_generics(generics);
-                self.with_banned_tilde_const(|this| {
+                self.with_tilde_const_allowed(|this| {
                     walk_list!(this, visit_param_bound, bounds, BoundKind::SuperTraits)
                 });
                 walk_list!(self, visit_assoc_item, items, AssocCtxt::Trait);

--- a/compiler/rustc_infer/src/traits/util.rs
+++ b/compiler/rustc_infer/src/traits/util.rs
@@ -145,7 +145,12 @@ impl<'tcx> Elaborator<'tcx> {
                 // Get predicates declared on the trait.
                 let predicates = tcx.super_predicates_of(data.def_id());
 
-                let obligations = predicates.predicates.iter().map(|&(pred, _)| {
+                let obligations = predicates.predicates.iter().map(|&(mut pred, _)| {
+                    // when parent predicate is non-const, elaborate it to non-const predicates.
+                    if data.constness == ty::BoundConstness::NotConst {
+                        pred = pred.without_const(tcx);
+                    }
+
                     predicate_obligation(
                         pred.subst_supertrait(tcx, &bound_predicate.rebind(data.trait_ref)),
                         obligation.param_env,

--- a/src/test/ui/rfc-2632-const-trait-impl/super-traits-fail-2.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/super-traits-fail-2.rs
@@ -1,0 +1,14 @@
+#![feature(const_trait_impl)]
+
+trait Foo {
+    fn a(&self);
+}
+trait Bar: ~const Foo {}
+
+const fn foo<T: Bar>(x: &T) {
+    x.a();
+    //~^ ERROR the trait bound
+    //~| ERROR cannot call
+}
+
+fn main() {}

--- a/src/test/ui/rfc-2632-const-trait-impl/super-traits-fail-2.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/super-traits-fail-2.stderr
@@ -1,0 +1,24 @@
+error[E0277]: the trait bound `T: ~const Foo` is not satisfied
+  --> $DIR/super-traits-fail-2.rs:9:7
+   |
+LL |     x.a();
+   |       ^^^ the trait `~const Foo` is not implemented for `T`
+   |
+note: the trait `Foo` is implemented for `T`, but that implementation is not `const`
+  --> $DIR/super-traits-fail-2.rs:9:7
+   |
+LL |     x.a();
+   |       ^^^
+
+error[E0015]: cannot call non-const fn `<T as Foo>::a` in constant functions
+  --> $DIR/super-traits-fail-2.rs:9:7
+   |
+LL |     x.a();
+   |       ^^^
+   |
+   = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0015, E0277.
+For more information about an error, try `rustc --explain E0015`.

--- a/src/test/ui/rfc-2632-const-trait-impl/super-traits-fail.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/super-traits-fail.rs
@@ -1,0 +1,16 @@
+#![feature(const_trait_impl)]
+
+trait Foo {
+    fn a(&self);
+}
+trait Bar: ~const Foo {}
+
+struct S;
+impl Foo for S {
+    fn a(&self) {}
+}
+
+impl const Bar for S {}
+//~^ ERROR the trait bound
+
+fn main() {}

--- a/src/test/ui/rfc-2632-const-trait-impl/super-traits-fail.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/super-traits-fail.stderr
@@ -1,0 +1,24 @@
+error[E0277]: the trait bound `S: ~const Foo` is not satisfied
+  --> $DIR/super-traits-fail.rs:13:12
+   |
+LL | impl const Bar for S {}
+   |            ^^^ the trait `~const Foo` is not implemented for `S`
+   |
+note: the trait `Foo` is implemented for `S`, but that implementation is not `const`
+  --> $DIR/super-traits-fail.rs:13:12
+   |
+LL | impl const Bar for S {}
+   |            ^^^
+note: required by a bound in `Bar`
+  --> $DIR/super-traits-fail.rs:6:12
+   |
+LL | trait Bar: ~const Foo {}
+   |            ^^^^^^^^^^ required by this bound in `Bar`
+help: consider introducing a `where` clause, but there might be an alternative better way to express this requirement
+   |
+LL | impl const Bar for S where S: ~const Foo {}
+   |                      +++++++++++++++++++
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/rfc-2632-const-trait-impl/super-traits.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/super-traits.rs
@@ -1,0 +1,22 @@
+// check-pass
+#![feature(const_trait_impl)]
+
+trait Foo {
+    fn a(&self);
+}
+trait Bar: ~const Foo {}
+
+struct S;
+impl const Foo for S {
+    fn a(&self) {}
+}
+
+impl const Bar for S {}
+
+const fn foo<T: ~const Bar>(t: &T) {
+    t.a();
+}
+
+const _: () = foo(&S);
+
+fn main() {}


### PR DESCRIPTION
What's included: a minimal working change set for `~const` supertraits to work.

r? @oli-obk