### PR TITLE
Update compiler_builtins to fix duplicate symbols in `armv7-linux-androideabi` rlib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -761,9 +761,9 @@ dependencies = [
 
 [[package]]
 name = "compiler_builtins"
-version = "0.1.66"
+version = "0.1.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "191424db7756bbed2c4996959a0fbda94388abcf4f5a2728a8af17481ad9c4f7"
+checksum = "a68c69e9451f1df4b215c9588c621670c12286b53e60fb5ec4b59aaa1138d18e"
 dependencies = [
  "cc",
  "rustc-std-workspace-core",

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -16,7 +16,7 @@ panic_unwind = { path = "../panic_unwind", optional = true }
 panic_abort = { path = "../panic_abort" }
 core = { path = "../core" }
 libc = { version = "0.2.116", default-features = false, features = ['rustc-dep-of-std'] }
-compiler_builtins = { version = "0.1.66" }
+compiler_builtins = { version = "0.1.67" }
 profiler_builtins = { path = "../profiler_builtins", optional = true }
 unwind = { path = "../unwind" }
 hashbrown = { version = "0.12", default-features = false, features = ['rustc-dep-of-std'] }


### PR DESCRIPTION
I ran `./x.py dist --host= --target=armv7-linux-androideabi` before this diff:
```
$ nm build/x86_64-unknown-linux-gnu/stage2/lib/rustlib/armv7-linux-androideabi/lib/libcompiler_builtins-3d9661a82c59c66a.rlib 2> /dev/null | grep __sync_fetch_and_add_4 | wc -l
2
```
And after:
```
$ nm build/x86_64-unknown-linux-gnu/stage2/lib/rustlib/armv7-linux-androideabi/lib/libcompiler_builtins-ffd2745070943321.rlib 2> /dev/null | grep __sync_fetch_and_add_4 | wc -l
1
```
Fixes #93310

See also https://github.com/rust-lang/compiler-builtins/issues/449 and https://github.com/rust-lang/compiler-builtins/pull/450