### PR TITLE
[WIP] Introduce `ast::StmtKind::LetElse` to allow the usage of `let_else` with `let_chains`

### DIFF
--- a/compiler/rustc_ast/src/ast_like.rs
+++ b/compiler/rustc_ast/src/ast_like.rs
@@ -2,7 +2,7 @@ use super::ptr::P;
 use super::token::Nonterminal;
 use super::tokenstream::LazyTokenStream;
 use super::{Arm, Crate, ExprField, FieldDef, GenericParam, Param, PatField, Variant};
-use super::{AssocItem, Expr, ForeignItem, Item, Local, MacCallStmt};
+use super::{AssocItem, Expr, ForeignItem, Item, LetElse, Local, MacCallStmt};
 use super::{AttrItem, AttrKind, Block, Pat, Path, Ty, Visibility};
 use super::{AttrVec, Attribute, Stmt, StmtKind};
 
@@ -104,6 +104,7 @@ impl AstLike for StmtKind {
 
     fn attrs(&self) -> &[Attribute] {
         match self {
+            StmtKind::LetElse(let_else) => let_else.attrs(),
             StmtKind::Local(local) => local.attrs(),
             StmtKind::Expr(expr) | StmtKind::Semi(expr) => expr.attrs(),
             StmtKind::Item(item) => item.attrs(),
@@ -114,6 +115,7 @@ impl AstLike for StmtKind {
 
     fn visit_attrs(&mut self, f: impl FnOnce(&mut Vec<Attribute>)) {
         match self {
+            StmtKind::LetElse(let_else) => let_else.visit_attrs(f),
             StmtKind::Local(local) => local.visit_attrs(f),
             StmtKind::Expr(expr) | StmtKind::Semi(expr) => expr.visit_attrs(f),
             StmtKind::Item(item) => item.visit_attrs(f),
@@ -123,6 +125,7 @@ impl AstLike for StmtKind {
     }
     fn tokens_mut(&mut self) -> Option<&mut Option<LazyTokenStream>> {
         Some(match self {
+            StmtKind::LetElse(let_else) => &mut let_else.tokens,
             StmtKind::Local(local) => &mut local.tokens,
             StmtKind::Item(item) => &mut item.tokens,
             StmtKind::Expr(expr) | StmtKind::Semi(expr) => &mut expr.tokens,
@@ -271,7 +274,7 @@ derive_has_tokens_and_attrs! {
 
 derive_has_tokens_and_attrs! {
     const SUPPORTS_CUSTOM_INNER_ATTRS: bool = false;
-    Local, MacCallStmt, Expr
+    LetElse, Local, MacCallStmt, Expr
 }
 
 // These ast nodes only support inert attributes, so they don't

--- a/compiler/rustc_ast_pretty/src/pprust/state.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state.rs
@@ -1073,26 +1073,27 @@ impl<'a> State<'a> {
     crate fn print_stmt(&mut self, st: &ast::Stmt) {
         self.maybe_print_comment(st.span.lo());
         match st.kind {
+            ast::StmtKind::LetElse(ref let_else) => {
+                self.print_outer_attributes(&let_else.attrs);
+                self.space_if_not_bol();
+                self.ibox(INDENT_UNIT);
+                self.word_nbsp("let");
+                self.print_expr(&let_else.expr);
+                self.cbox(INDENT_UNIT);
+                self.ibox(INDENT_UNIT);
+                self.word(" else ");
+                self.print_block(&let_else.r#else);
+                self.word(";");
+                self.end(); // `let` ibox
+            }
             ast::StmtKind::Local(ref loc) => {
                 self.print_outer_attributes(&loc.attrs);
                 self.space_if_not_bol();
                 self.ibox(INDENT_UNIT);
                 self.word_nbsp("let");
-
                 self.ibox(INDENT_UNIT);
                 self.print_local_decl(loc);
                 self.end();
-                if let Some((init, els)) = loc.kind.init_else_opt() {
-                    self.nbsp();
-                    self.word_space("=");
-                    self.print_expr(init);
-                    if let Some(els) = els {
-                        self.cbox(INDENT_UNIT);
-                        self.ibox(INDENT_UNIT);
-                        self.word(" else ");
-                        self.print_block(els);
-                    }
-                }
                 self.word(";");
                 self.end(); // `let` ibox
             }

--- a/compiler/rustc_expand/src/expand.rs
+++ b/compiler/rustc_expand/src/expand.rs
@@ -1364,7 +1364,7 @@ impl InvocationCollectorNode for ast::Stmt {
             StmtKind::Item(item) => matches!(item.kind, ItemKind::MacCall(..)),
             StmtKind::Semi(expr) => matches!(expr.kind, ExprKind::MacCall(..)),
             StmtKind::Expr(..) => unreachable!(),
-            StmtKind::Local(..) | StmtKind::Empty => false,
+            StmtKind::LetElse(..) | StmtKind::Local(..) | StmtKind::Empty => false,
         }
     }
     fn take_mac_call(self) -> (ast::MacCall, Self::AttrsTy, AddSemicolon) {

--- a/compiler/rustc_lint/src/builtin.rs
+++ b/compiler/rustc_lint/src/builtin.rs
@@ -1054,7 +1054,7 @@ fn warn_if_doc(cx: &EarlyContext<'_>, node_span: Span, node_kind: &str, attrs: &
 impl EarlyLintPass for UnusedDocComment {
     fn check_stmt(&mut self, cx: &EarlyContext<'_>, stmt: &ast::Stmt) {
         let kind = match stmt.kind {
-            ast::StmtKind::Local(..) => "statements",
+            ast::StmtKind::LetElse(..) | ast::StmtKind::Local(..) => "statements",
             // Disabled pending discussion in #78306
             ast::StmtKind::Item(..) => return,
             // expressions will be reported by `check_expr`.

--- a/compiler/rustc_lint/src/unused.rs
+++ b/compiler/rustc_lint/src/unused.rs
@@ -623,11 +623,8 @@ trait UnusedDelimLint {
     fn check_stmt(&mut self, cx: &EarlyContext<'_>, s: &ast::Stmt) {
         match s.kind {
             StmtKind::Local(ref local) if Self::LINT_EXPR_IN_PATTERN_MATCHING_CTX => {
-                if let Some((init, els)) = local.kind.init_else_opt() {
-                    let ctx = match els {
-                        None => UnusedDelimsCtx::AssignedValue,
-                        Some(_) => UnusedDelimsCtx::AssignedValueLetElse,
-                    };
+                if let Some(init) = local.kind.init() {
+                    let ctx = UnusedDelimsCtx::AssignedValue;
                     self.check_unused_delims_expr(cx, init, ctx, false, None, None);
                 }
             }

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -1500,13 +1500,8 @@ impl<'a: 'ast, 'b, 'ast> LateResolutionVisitor<'a, 'b, 'ast> {
         walk_list!(self, visit_ty, &local.ty);
 
         // Resolve the initializer.
-        if let Some((init, els)) = local.kind.init_else_opt() {
+        if let Some(init) = local.kind.init() {
             self.visit_expr(init);
-
-            // Resolve the `else` block
-            if let Some(els) = els {
-                self.visit_block(els);
-            }
         }
 
         // Resolve the pattern.

--- a/src/tools/clippy/clippy_lints/src/non_expressive_names.rs
+++ b/src/tools/clippy/clippy_lints/src/non_expressive_names.rs
@@ -319,11 +319,8 @@ impl<'a, 'b> SimilarNamesLocalVisitor<'a, 'b> {
 
 impl<'a, 'tcx> Visitor<'tcx> for SimilarNamesLocalVisitor<'a, 'tcx> {
     fn visit_local(&mut self, local: &'tcx Local) {
-        if let Some((init, els)) = &local.kind.init_else_opt() {
+        if let Some(init) = &local.kind.init() {
             self.apply(|this| walk_expr(this, init));
-            if let Some(els) = els {
-                self.apply(|this| walk_block(this, els));
-            }
         }
         // add the pattern after the expression because the bindings aren't available
         // yet in the init

--- a/src/tools/clippy/clippy_utils/src/ast_utils.rs
+++ b/src/tools/clippy/clippy_utils/src/ast_utils.rs
@@ -232,8 +232,6 @@ pub fn eq_local_kind(l: &LocalKind, r: &LocalKind) -> bool {
     use LocalKind::*;
     match (l, r) {
         (Decl, Decl) => true,
-        (Init(l), Init(r)) => eq_expr(l, r),
-        (InitElse(li, le), InitElse(ri, re)) => eq_expr(li, ri) && eq_block(le, re),
         _ => false,
     }
 }

--- a/src/tools/rustfmt/src/attr.rs
+++ b/src/tools/rustfmt/src/attr.rs
@@ -40,6 +40,7 @@ pub(crate) fn get_attrs_from_stmt(stmt: &ast::Stmt) -> &[ast::Attribute] {
 
 pub(crate) fn get_span_without_attrs(stmt: &ast::Stmt) -> Span {
     match stmt.kind {
+        ast::StmtKind::LetElse(ref let_else) => let_else.span,
         ast::StmtKind::Local(ref local) => local.span,
         ast::StmtKind::Item(ref item) => item.span,
         ast::StmtKind::Expr(ref expr) | ast::StmtKind::Semi(ref expr) => expr.span,

--- a/src/tools/rustfmt/src/items.rs
+++ b/src/tools/rustfmt/src/items.rs
@@ -54,7 +54,7 @@ impl Rewrite for ast::Local {
 
         skip_out_of_file_lines_range!(context, self.span);
 
-        if contains_skip(&self.attrs) || matches!(self.kind, ast::LocalKind::InitElse(..)) {
+        if contains_skip(&self.attrs) {
             return None;
         }
 
@@ -112,7 +112,7 @@ impl Rewrite for ast::Local {
 
         result.push_str(&infix);
 
-        if let Some((init, _els)) = self.kind.init_else_opt() {
+        if let Some(init) = self.kind.init() {
             // 1 = trailing semicolon;
             let nested_shape = shape.sub_width(1)?;
 

--- a/src/tools/rustfmt/src/spanned.rs
+++ b/src/tools/rustfmt/src/spanned.rs
@@ -61,6 +61,7 @@ implement_spanned!(ast::Local);
 impl Spanned for ast::Stmt {
     fn span(&self) -> Span {
         match self.kind {
+            ast::StmtKind::LetElse(_) => { todo!() }
             ast::StmtKind::Local(ref local) => mk_sp(local.span().lo(), self.span.hi()),
             ast::StmtKind::Item(ref item) => mk_sp(item.span().lo(), self.span.hi()),
             ast::StmtKind::Expr(ref expr) | ast::StmtKind::Semi(ref expr) => {

--- a/src/tools/rustfmt/src/stmt.rs
+++ b/src/tools/rustfmt/src/stmt.rs
@@ -99,6 +99,7 @@ fn format_stmt(
     skip_out_of_file_lines_range!(context, stmt.span());
 
     let result = match stmt.kind {
+        ast::StmtKind::LetElse(_) => { todo!() },
         ast::StmtKind::Local(ref local) => local.rewrite(context, shape),
         ast::StmtKind::Expr(ref ex) | ast::StmtKind::Semi(ref ex) => {
             let suffix = if semicolon_for_stmt(context, stmt) {

--- a/src/tools/rustfmt/src/visitor.rs
+++ b/src/tools/rustfmt/src/visitor.rs
@@ -153,7 +153,7 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
                 self.visit_item(item);
                 self.last_pos = stmt.span().hi();
             }
-            ast::StmtKind::Local(..) | ast::StmtKind::Expr(..) | ast::StmtKind::Semi(..) => {
+            ast::StmtKind::LetElse(..) | ast::StmtKind::Local(..) | ast::StmtKind::Expr(..) | ast::StmtKind::Semi(..) => {
                 let attrs = get_attrs_from_stmt(stmt.as_ast_node());
                 if contains_skip(attrs) {
                     self.push_skipped_with_span(


### PR DESCRIPTION
Not sure if you guys will accept this PR, thus the reason of opening it early. In fact, only `./x.py check` is currently working.

In order to allow "multiple local declarations" as well as different `ast::Binary`/`ast::Let` structure combinations of a let chain, `LocalKind::InitElse` was superseded by `StmtKind::LetElse`.

It was the most natural path to follow in my opinion but feel free to discuss more alternatives.

```rust
/// A `let .. && let && .. else { .. }` declaration.
#[derive(Clone, Encodable, Decodable, Debug)]
pub struct LetElse {
    pub attrs: AttrVec,
    pub expr: P<Expr>,
    pub id: NodeId,
    pub r#else: P<Block>,
    pub span: Span,
    pub tokens: Option<LazyTokenStream>,
}

pub enum StmtKind {
    /// See [`LetElse`].
    LetElse(P<LetElse>),
    ...
}
```

Taking aside possible Clippy and Rustfmt changes, the overall structure probably won't pass beyond AST.

cc @camsteffen 
cc @matthewjasper 
cc @petrochenkov 