### PR TITLE
Add support for control-flow protection

### DIFF
--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -63,6 +63,22 @@ pub enum CFGuard {
     Checks,
 }
 
+/// The different settings that the `-Z cf-protection` flag can have.
+#[derive(Clone, Copy, PartialEq, Hash, Debug)]
+pub enum CFProtection {
+    /// Do not enable control-flow protection
+    None,
+
+    /// Emit control-flow protection for branches (enables indirect branch tracking).
+    Branch,
+
+    /// Emit control-flow protection for returns.
+    Return,
+
+    /// Emit control-flow protection for both branches and returns.
+    Full,
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Hash)]
 pub enum OptLevel {
     No,         // -O0
@@ -2630,11 +2646,11 @@ impl PpMode {
 /// we have an opt-in scheme here, so one is hopefully forced to think about
 /// how the hash should be calculated when adding a new command-line argument.
 crate mod dep_tracking {
-    use super::LdImpl;
     use super::{
-        BranchProtection, CFGuard, CrateType, DebugInfo, ErrorOutputType, InstrumentCoverage,
-        LinkerPluginLto, LocationDetail, LtoCli, OptLevel, OutputType, OutputTypes, Passes,
-        SourceFileHashAlgorithm, SwitchWithOptPath, SymbolManglingVersion, TrimmedDefPaths,
+        BranchProtection, CFGuard, CFProtection, CrateType, DebugInfo, ErrorOutputType,
+        InstrumentCoverage, LdImpl, LinkerPluginLto, LocationDetail, LtoCli, OptLevel, OutputType,
+        OutputTypes, Passes, SourceFileHashAlgorithm, SwitchWithOptPath, SymbolManglingVersion,
+        TrimmedDefPaths,
     };
     use crate::lint;
     use crate::options::WasiExecModel;
@@ -2715,6 +2731,7 @@ crate mod dep_tracking {
         NativeLibKind,
         SanitizerSet,
         CFGuard,
+        CFProtection,
         TargetTriple,
         Edition,
         LinkerPluginLto,

--- a/src/doc/unstable-book/src/compiler-flags/cf-protection.md
+++ b/src/doc/unstable-book/src/compiler-flags/cf-protection.md
@@ -1,0 +1,40 @@
+# `cf-protection`
+
+This option enables control-flow enforcement technology (CET) on x86; a more detailed description of
+CET is available [here]. Similar to `clang`, this flag takes one of the following values:
+
+- `none` - Disable CET completely (this is the default).
+- `branch` - Enable indirect branch tracking (`IBT`).
+- `return` - Enable shadow stack (`SHSTK`).
+- `full` - Enable both `branch` and `return`.
+
+[here]: https://www.intel.com/content/www/us/en/develop/articles/technical-look-control-flow-enforcement-technology.html
+
+This flag only applies to the LLVM backend: it sets the `cf-protection-branch` and
+`cf-protection-return` flags on LLVM modules. Note, however, that all compiled modules linked
+together must have the flags set for the compiled output to be CET-enabled. Currently, Rust's
+standard library does not ship with CET enabled by default, so you may need to rebuild all standard
+modules with a `cargo` command like:
+
+```sh
+$ RUSTFLAGS="-Z cf-protection=full" RUSTC="rustc-custom" cargo +nightly build -Z build-std --target x86_64-unknown-linux-gnu
+```
+
+### Detection
+
+An ELF binary is CET-enabled if it has the `IBT` and `SHSTK` tags, e.g.:
+
+```sh
+$ readelf -a target/x86_64-unknown-linux-gnu/debug/example | grep feature:
+      Properties: x86 feature: IBT, SHSTK
+```
+
+### Troubleshooting
+
+To display modules that are not CET enabled, examine the linker errors available when `cet-report` is enabled:
+
+```sh
+$ RUSTC_LOG=rustc_codegen_ssa::back::link=info rustc-custom -v -Z cf-protection=full -C link-arg="-Wl,-z,cet-report=warning" -o example example.rs
+...
+/usr/bin/ld: /.../build/x86_64-unknown-linux-gnu/stage1/lib/rustlib/x86_64-unknown-linux-gnu/lib/libstd-d73f7266be14cb8b.rlib(std-d73f7266be14cb8b.std.f7443020-cgu.12.rcgu.o): warning: missing IBT and SHSTK properties
+```

--- a/src/test/codegen/cf-protection.rs
+++ b/src/test/codegen/cf-protection.rs
@@ -1,0 +1,38 @@
+// Test that the correct module flags are emitted with different control-flow protection flags.
+
+// revisions: undefined none branch return full
+// needs-llvm-components: x86
+// [undefined] compile-flags:
+// [none] compile-flags: -Z cf-protection=none
+// [branch] compile-flags: -Z cf-protection=branch
+// [return] compile-flags: -Z cf-protection=return
+// [full] compile-flags: -Z cf-protection=full
+// compile-flags: --target x86_64-unknown-linux-gnu
+
+#![crate_type = "lib"]
+#![feature(no_core, lang_items)]
+#![no_core]
+
+#[lang="sized"]
+trait Sized { }
+
+// A basic test function.
+pub fn test() {
+}
+
+// undefined-NOT: !"cf-protection-branch"
+// undefined-NOT: !"cf-protection-return"
+
+// none-NOT: !"cf-protection-branch"
+// none-NOT: !"cf-protection-return"
+
+// branch-NOT: !"cf-protection-return"
+// branch: !"cf-protection-branch", i32 1
+// branch-NOT: !"cf-protection-return"
+
+// return-NOT: !"cf-protection-branch"
+// return: !"cf-protection-return", i32 1
+// return-NOT: !"cf-protection-branch"
+
+// full: !"cf-protection-branch", i32 1
+// full: !"cf-protection-return", i32 1


### PR DESCRIPTION
This change adds a flag for configuring control-flow protection in the LLVM backend. In Clang, this flag is exposed as `-fcf-protection` with options `none|branch|return|full`. This convention is followed for `rustc`, though as a codegen option: `rustc -Z cf-protection=<none|branch|return|full>`. Tracking issue for future work is #93754.
