### PR TITLE
rustdoc: load the set of in-scope traits for modules with no docstring

### DIFF
--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -920,6 +920,7 @@ fn trait_assoc_to_impl_assoc_item<'tcx>(
 ///
 /// NOTE: this cannot be a query because more traits could be available when more crates are compiled!
 /// So it is not stable to serialize cross-crate.
+#[instrument(level = "debug", skip(cx))]
 fn trait_impls_for<'a>(
     cx: &mut DocContext<'a>,
     ty: Ty<'a>,

--- a/src/test/rustdoc/intra-doc/crate-relative.rs
+++ b/src/test/rustdoc/intra-doc/crate-relative.rs
@@ -1,0 +1,13 @@
+pub struct Test<'a> {
+    data: &'a (),
+}
+
+impl<'a> Test<'a> {
+    pub fn do_test(&self) {}
+}
+
+// @has crate_relative/demo/index.html
+// @has - '//a/@href' '../struct.Test.html#method.do_test'
+pub mod demo {
+    //! [`crate::Test::do_test`]
+}

--- a/src/test/rustdoc/intra-doc/mod-relative.rs
+++ b/src/test/rustdoc/intra-doc/mod-relative.rs
@@ -1,0 +1,17 @@
+pub mod wrapper {
+
+    pub struct Test<'a> {
+        data: &'a (),
+    }
+
+    impl<'a> Test<'a> {
+        pub fn do_test(&self) {}
+    }
+
+    // @has mod_relative/wrapper/demo/index.html
+    // @has - '//a/@href' '../struct.Test.html#method.do_test'
+    /// [`Test::do_test`]
+    pub mod demo {
+    }
+
+}


### PR DESCRIPTION
Fixes #93428

This fix is a response to a couple of special cases related to the `module_id`, which is eventually used for trait candidates:

  * The module id is always set to the current crate, when checking `crate::`.

    Normally, the set of in-scope traits would be set in `load_links_in_attrs`, but if there are no doc comments, then that loop will never run.

  * the module id is set to the parent module, when resolving a module that is spelled like this:

        // Notice how we use an outlined doc comment here!
        // [`Test::my_fn`]
        mod something {
        }

    As with the above problem with `crate::`, we need to make sure the module gets its traits in scope resolved, even if it has no doc comments of its own.