### PR TITLE
Fix some CSS warnings and errors from VS Code

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1502,7 +1502,6 @@ kbd {
 	vertical-align: middle;
 	border: solid 1px;
 	border-radius: 3px;
-	box-shadow: inset 0 -1px 0;
 	cursor: default;
 }
 

--- a/src/librustdoc/html/static/css/themes/ayu.css
+++ b/src/librustdoc/html/static/css/themes/ayu.css
@@ -531,7 +531,7 @@ kbd {
 	background-color: #314559;
 	border-color: #5c6773;
 	border-bottom-color: #5c6773;
-	box-shadow-color: #c6cbd1;
+	box-shadow: inset 0 -1px 0 #5c6773;
 }
 
 #theme-picker, #settings-menu, #help-button {
@@ -630,5 +630,5 @@ input:checked + .slider {
 	background: #616161;
 }
 .toggle-line:hover .toggle-line-inner {
-	background: ##898989;
+	background: #898989;
 }

--- a/src/librustdoc/html/static/css/themes/dark.css
+++ b/src/librustdoc/html/static/css/themes/dark.css
@@ -407,7 +407,7 @@ kbd {
 	background-color: #fafbfc;
 	border-color: #d1d5da;
 	border-bottom-color: #c6cbd1;
-	box-shadow-color: #c6cbd1;
+	box-shadow: inset 0 -1px 0 #c6cbd1;
 }
 
 #theme-picker, #settings-menu, #help-button {
@@ -496,5 +496,5 @@ div.files > .selected {
 	background: #616161;
 }
 .toggle-line:hover .toggle-line-inner {
-	background: ##898989;
+	background: #898989;
 }

--- a/src/librustdoc/html/static/css/themes/light.css
+++ b/src/librustdoc/html/static/css/themes/light.css
@@ -44,7 +44,9 @@ pre, .rustdoc.source .example-wrap {
 }
 
 .rust-logo {
-	/* No need for a border in here! */
+	/* This rule exists to force other themes to explicitly style the logo.
+	 * Rustdoc has a custom linter for this purpose.
+	 */
 }
 
 /* Improve the scrollbar display on webkit-based browsers */
@@ -391,7 +393,7 @@ kbd {
 	background-color: #fafbfc;
 	border-color: #d1d5da;
 	border-bottom-color: #c6cbd1;
-	box-shadow-color: #c6cbd1;
+	box-shadow: inset 0 -1px 0 #c6cbd1;
 }
 
 #theme-picker, #settings-menu, #help-button {


### PR DESCRIPTION
There's no such CSS rule as `box-shadow-color`, so I instead copied the
whole `box-shadow` property to each rule to make it actually apply.

r? @jsha
