### PR TITLE
Restrict query recursion in `needs_significant_drop`

### DIFF
--- a/src/test/ui/closures/2229_closure_analysis/issue-92724-needsdrop-query-cycle.rs
+++ b/src/test/ui/closures/2229_closure_analysis/issue-92724-needsdrop-query-cycle.rs
@@ -1,0 +1,14 @@
+// ICEs if checking if there is a significant destructor causes a query cycle
+// check-pass
+
+#![warn(rust_2021_incompatible_closure_captures)]
+pub struct Foo(Bar);
+pub struct Bar(Baz);
+pub struct Baz(Vec<Foo>);
+
+impl Foo {
+    pub fn baz(self, v: Baz) -> Baz {
+        (|| v)()
+    }
+}
+fn main() {}


### PR DESCRIPTION
Overly aggressive use of the query system to improve caching lead to query cycles and consequently ICEs. This patch fixes this by restricting the use of the query system as a cache to those cases where it is definitely correct.

Closes #92725 .

This is essentially a revert of #90845 for the significant drop case only. The general `needs_drop` still does the same thing. The hope is that this is enough to preserve the performance improvements of that PR while fixing the ICE. Should get a perf run to verify that this is the case.

cc @cjgillot 