### PR TITLE
compiletest: Set RUST_BACKTRACE=1 to make compiler panics easier to debug

### DIFF
--- a/src/tools/compiletest/src/main.rs
+++ b/src/tools/compiletest/src/main.rs
@@ -379,6 +379,9 @@ pub fn run_tests(config: Config) {
     // Let tests know which target they're running as
     env::set_var("TARGET", &config.target);
 
+    // If we get panics in the compiler, we want backtraces of them.
+    env::set_var("RUST_BACKTRACE", "1");
+
     let opts = test_opts(&config);
 
     let mut configs = Vec::new();


### PR DESCRIPTION
When running the testsuite, if we get a panic inside the compiler, we
want to know where that panic came from to make it easier to debug.
