### PR TITLE
Make dead code check a query.

### DIFF
--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -999,7 +999,8 @@ fn analysis(tcx: TyCtxt<'_>, (): ()) -> Result<()> {
                         tcx.ensure().check_private_in_public(());
                     },
                     {
-                        sess.time("death_checking", || rustc_passes::dead::check_crate(tcx));
+                        tcx.hir()
+                            .par_for_each_module(|module| tcx.ensure().check_mod_deathness(module));
                     },
                     {
                         sess.time("unused_lib_feature_checking", || {

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -750,6 +750,22 @@ rustc_queries! {
         desc { |tcx| "checking liveness of variables in {}", describe_as_module(key, tcx) }
     }
 
+    /// Return the live symbols in the crate for dead code check.
+    ///
+    /// The second return value maps from ADTs to ignored derived traits (e.g. Debug and Clone) and
+    /// their respective impl (i.e., part of the derive macro)
+    query live_symbols_and_ignored_derived_traits(_: ()) -> (
+        FxHashSet<LocalDefId>,
+        FxHashMap<LocalDefId, Vec<(DefId, DefId)>>
+    ) {
+        storage(ArenaCacheSelector<'tcx>)
+        desc { "find live symbols in crate" }
+    }
+
+    query check_mod_deathness(key: LocalDefId) -> () {
+        desc { |tcx| "checking deathness of variables in {}", describe_as_module(key, tcx) }
+    }
+
     query check_mod_impl_wf(key: LocalDefId) -> () {
         desc { |tcx| "checking that impls are well-formed in {}", describe_as_module(key, tcx) }
     }

--- a/compiler/rustc_passes/src/lib.rs
+++ b/compiler/rustc_passes/src/lib.rs
@@ -44,6 +44,7 @@ mod weak_lang_items;
 pub fn provide(providers: &mut Providers) {
     check_attr::provide(providers);
     check_const::provide(providers);
+    dead::provide(providers);
     diagnostic_items::provide(providers);
     entry::provide(providers);
     lang_items::provide(providers);

--- a/src/test/ui/lint/dead-code/lint-dead-code-1.stderr
+++ b/src/test/ui/lint/dead-code/lint-dead-code-1.stderr
@@ -1,20 +1,14 @@
-error: struct is never constructed: `Bar`
-  --> $DIR/lint-dead-code-1.rs:12:16
+error: static is never used: `priv_static`
+  --> $DIR/lint-dead-code-1.rs:20:1
    |
-LL |     pub struct Bar;
-   |                ^^^
+LL | static priv_static: isize = 0;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: the lint level is defined here
   --> $DIR/lint-dead-code-1.rs:5:9
    |
 LL | #![deny(dead_code)]
    |         ^^^^^^^^^
-
-error: static is never used: `priv_static`
-  --> $DIR/lint-dead-code-1.rs:20:1
-   |
-LL | static priv_static: isize = 0;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: constant is never used: `priv_const`
   --> $DIR/lint-dead-code-1.rs:27:1
@@ -63,6 +57,12 @@ error: function is never used: `baz`
    |
 LL | fn baz() -> impl Copy {
    |    ^^^
+
+error: struct is never constructed: `Bar`
+  --> $DIR/lint-dead-code-1.rs:12:16
+   |
+LL |     pub struct Bar;
+   |                ^^^
 
 error: aborting due to 10 previous errors
 


### PR DESCRIPTION
Dead code check is run for each invocation of the compiler, even if no modifications were involved.
This PR makes dead code check a query keyed on the module. This allows to skip the check when a module has not changed.
To perform this, a query `live_symbols_and_ignored_derived_traits` is introduced to encapsulate the global analysis of finding live symbols. The second query `check_mod_deathness` outputs diagnostics for each module based on this first query's results.