### PR TITLE
Skip pointing out ambiguous impls in alloc/std crates too in inference errors

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
@@ -1973,7 +1973,7 @@ impl<'a, 'tcx> InferCtxtPrivExt<'a, 'tcx> for InferCtxt<'a, 'tcx> {
 
         if self.is_tainted_by_errors()
             && crate_names.len() == 1
-            && crate_names[0] == "`core`"
+            && ["`core`", "`alloc`", "`std`"].contains(&crate_names[0].as_str())
             && spans.len() == 0
         {
             // Avoid complaining about other inference issues for expressions like

--- a/src/test/ui/impl-trait/equality.rs
+++ b/src/test/ui/impl-trait/equality.rs
@@ -17,7 +17,7 @@ fn two(x: bool) -> impl Foo {
     //~| expected `i32`, found `u32`
 }
 
-fn sum_to(n: u32) -> impl Foo { //~ ERROR type annotations needed
+fn sum_to(n: u32) -> impl Foo {
     if n == 0 {
         0
     } else {

--- a/src/test/ui/impl-trait/equality.stderr
+++ b/src/test/ui/impl-trait/equality.stderr
@@ -34,22 +34,7 @@ LL |         n + sum_to(n - 1)
    |
    = help: the trait `Add<impl Foo>` is not implemented for `u32`
 
-error[E0283]: type annotations needed
-  --> $DIR/equality.rs:20:22
-   |
-LL | fn sum_to(n: u32) -> impl Foo {
-   |                      ^^^^^^^^ cannot infer type for type `{integer}`
-   |
-   = note: multiple `impl`s satisfying `{integer}: ToString` found in the `alloc` crate:
-           - impl ToString for i8;
-           - impl ToString for u8;
-note: required because of the requirements on the impl of `Foo` for `{integer}`
-  --> $DIR/equality.rs:5:26
-   |
-LL | impl<T: Copy + ToString> Foo for T {}
-   |                          ^^^     ^
+error: aborting due to 2 previous errors; 1 warning emitted
 
-error: aborting due to 3 previous errors; 1 warning emitted
-
-Some errors have detailed explanations: E0277, E0283, E0308.
+Some errors have detailed explanations: E0277, E0308.
 For more information about an error, try `rustc --explain E0277`.

--- a/src/test/ui/issues/issue-72690.rs
+++ b/src/test/ui/issues/issue-72690.rs
@@ -10,7 +10,6 @@ fn err() {
 
 fn arg_pat_closure_err() {
     |x| String::from("x".as_ref()); //~ ERROR type annotations needed
-    //~^ ERROR type annotations needed
     //~| ERROR type annotations needed
 }
 

--- a/src/test/ui/issues/issue-72690.stderr
+++ b/src/test/ui/issues/issue-72690.stderr
@@ -30,16 +30,6 @@ LL |     |x| String::from("x".as_ref());
    |      ^ consider giving this closure parameter a type
 
 error[E0283]: type annotations needed
-  --> $DIR/issue-72690.rs:12:9
-   |
-LL |     |x| String::from("x".as_ref());
-   |         ^^^^^^^^^^^^ cannot infer type for reference `&_`
-   |
-   = note: multiple `impl`s satisfying `String: From<&_>` found in the `alloc` crate:
-           - impl<> From<&String> for String;
-           - impl<> From<&str> for String;
-
-error[E0283]: type annotations needed
   --> $DIR/issue-72690.rs:12:26
    |
 LL |     |x| String::from("x".as_ref());
@@ -55,7 +45,7 @@ LL |     |x| String::from("x".as_ref());
            - impl AsRef<str> for str;
 
 error[E0283]: type annotations needed for `&T`
-  --> $DIR/issue-72690.rs:18:17
+  --> $DIR/issue-72690.rs:17:17
    |
 LL |     let _ = "x".as_ref();
    |         -       ^^^^^^ cannot infer type for type parameter `T` declared on the trait `AsRef`
@@ -69,7 +59,7 @@ LL |     let _ = "x".as_ref();
            - impl AsRef<str> for str;
 
 error[E0283]: type annotations needed
-  --> $DIR/issue-72690.rs:22:5
+  --> $DIR/issue-72690.rs:21:5
    |
 LL |     String::from("x".as_ref());
    |     ^^^^^^^^^^^^ cannot infer type for reference `&_`
@@ -79,7 +69,7 @@ LL |     String::from("x".as_ref());
            - impl<> From<&str> for String;
 
 error[E0283]: type annotations needed
-  --> $DIR/issue-72690.rs:22:22
+  --> $DIR/issue-72690.rs:21:22
    |
 LL |     String::from("x".as_ref());
    |                  ----^^^^^^--
@@ -94,7 +84,7 @@ LL |     String::from("x".as_ref());
            - impl AsRef<str> for str;
 
 error[E0283]: type annotations needed
-  --> $DIR/issue-72690.rs:29:5
+  --> $DIR/issue-72690.rs:28:5
    |
 LL |     String::from("x".as_ref());
    |     ^^^^^^^^^^^^ cannot infer type for reference `&_`
@@ -104,7 +94,7 @@ LL |     String::from("x".as_ref());
            - impl<> From<&str> for String;
 
 error[E0283]: type annotations needed
-  --> $DIR/issue-72690.rs:29:22
+  --> $DIR/issue-72690.rs:28:22
    |
 LL |     String::from("x".as_ref());
    |                  ----^^^^^^--
@@ -119,7 +109,7 @@ LL |     String::from("x".as_ref());
            - impl AsRef<str> for str;
 
 error[E0283]: type annotations needed
-  --> $DIR/issue-72690.rs:38:5
+  --> $DIR/issue-72690.rs:37:5
    |
 LL |     String::from("x".as_ref());
    |     ^^^^^^^^^^^^ cannot infer type for reference `&_`
@@ -129,7 +119,7 @@ LL |     String::from("x".as_ref());
            - impl<> From<&str> for String;
 
 error[E0283]: type annotations needed
-  --> $DIR/issue-72690.rs:38:22
+  --> $DIR/issue-72690.rs:37:22
    |
 LL |     String::from("x".as_ref());
    |                  ----^^^^^^--
@@ -144,7 +134,7 @@ LL |     String::from("x".as_ref());
            - impl AsRef<str> for str;
 
 error[E0283]: type annotations needed
-  --> $DIR/issue-72690.rs:47:5
+  --> $DIR/issue-72690.rs:46:5
    |
 LL |     String::from("x".as_ref());
    |     ^^^^^^^^^^^^ cannot infer type for reference `&_`
@@ -154,7 +144,7 @@ LL |     String::from("x".as_ref());
            - impl<> From<&str> for String;
 
 error[E0283]: type annotations needed
-  --> $DIR/issue-72690.rs:47:22
+  --> $DIR/issue-72690.rs:46:22
    |
 LL |     String::from("x".as_ref());
    |                  ----^^^^^^--
@@ -169,7 +159,7 @@ LL |     String::from("x".as_ref());
            - impl AsRef<str> for str;
 
 error[E0283]: type annotations needed
-  --> $DIR/issue-72690.rs:54:5
+  --> $DIR/issue-72690.rs:53:5
    |
 LL |     String::from("x".as_ref());
    |     ^^^^^^^^^^^^ cannot infer type for reference `&_`
@@ -179,7 +169,7 @@ LL |     String::from("x".as_ref());
            - impl<> From<&str> for String;
 
 error[E0283]: type annotations needed
-  --> $DIR/issue-72690.rs:54:22
+  --> $DIR/issue-72690.rs:53:22
    |
 LL |     String::from("x".as_ref());
    |                  ----^^^^^^--
@@ -194,7 +184,7 @@ LL |     String::from("x".as_ref());
            - impl AsRef<str> for str;
 
 error[E0283]: type annotations needed
-  --> $DIR/issue-72690.rs:63:5
+  --> $DIR/issue-72690.rs:62:5
    |
 LL |     String::from("x".as_ref());
    |     ^^^^^^^^^^^^ cannot infer type for reference `&_`
@@ -204,7 +194,7 @@ LL |     String::from("x".as_ref());
            - impl<> From<&str> for String;
 
 error[E0283]: type annotations needed
-  --> $DIR/issue-72690.rs:63:22
+  --> $DIR/issue-72690.rs:62:22
    |
 LL |     String::from("x".as_ref());
    |                  ----^^^^^^--
@@ -218,7 +208,7 @@ LL |     String::from("x".as_ref());
            - impl AsRef<[u8]> for str;
            - impl AsRef<str> for str;
 
-error: aborting due to 18 previous errors
+error: aborting due to 17 previous errors
 
 Some errors have detailed explanations: E0282, E0283.
 For more information about an error, try `rustc --explain E0282`.


### PR DESCRIPTION
This generalizes the logic in `annotate_source_of_ambiguity` to skip printing ambiguity errors traits in `alloc` and `std` as well, not just `core`.

While this does spot-fix the issue mentioned below, it would be nicer to generalize this logic, for example to detect when the trait predicate's `self_ty` has any numerical inference variables. Is it worthwhile to scrap this solution for one like that?

Fixes #93450 

r? @estebank 
feel free to reassign