### PR TITLE
Fix HashStable implementation on AllocId

### DIFF
--- a/compiler/rustc_codegen_cranelift/src/vtable.rs
+++ b/compiler/rustc_codegen_cranelift/src/vtable.rs
@@ -68,7 +68,8 @@ pub(crate) fn get_vtable<'tcx>(
     ty: Ty<'tcx>,
     trait_ref: Option<ty::PolyExistentialTraitRef<'tcx>>,
 ) -> Value {
-    let alloc_id = fx.tcx.vtable_allocation((ty, trait_ref));
+    let alloc = fx.tcx.vtable_allocation((ty, trait_ref));
+    let alloc_id = fx.tcx.create_memory_alloc(alloc);
     let data_id =
         data_id_for_alloc_id(&mut fx.constants_cx, &mut *fx.module, alloc_id, Mutability::Not);
     let local_data_id = fx.module.declare_data_in_func(data_id, &mut fx.bcx.func);

--- a/compiler/rustc_codegen_cranelift/src/vtable.rs
+++ b/compiler/rustc_codegen_cranelift/src/vtable.rs
@@ -68,7 +68,7 @@ pub(crate) fn get_vtable<'tcx>(
     ty: Ty<'tcx>,
     trait_ref: Option<ty::PolyExistentialTraitRef<'tcx>>,
 ) -> Value {
-    let alloc = fx.tcx.vtable_allocation((ty, trait_ref));
+    let alloc = fx.tcx.vtable_allocation((ty, trait_ref)).0;
     let alloc_id = fx.tcx.create_memory_alloc(alloc);
     let data_id =
         data_id_for_alloc_id(&mut fx.constants_cx, &mut *fx.module, alloc_id, Mutability::Not);

--- a/compiler/rustc_codegen_ssa/src/meth.rs
+++ b/compiler/rustc_codegen_ssa/src/meth.rs
@@ -72,7 +72,7 @@ pub fn get_vtable<'tcx, Cx: CodegenMethods<'tcx>>(
         return val;
     }
 
-    let vtable_allocation = tcx.vtable_allocation((ty, trait_ref));
+    let vtable_allocation = tcx.vtable_allocation((ty, trait_ref)).0;
     let vtable_const = cx.const_data_from_alloc(vtable_allocation);
     let align = cx.data_layout().pointer_align.abi;
     let vtable = cx.static_addr_of(vtable_const, align, Some("vtable"));

--- a/compiler/rustc_codegen_ssa/src/meth.rs
+++ b/compiler/rustc_codegen_ssa/src/meth.rs
@@ -72,8 +72,7 @@ pub fn get_vtable<'tcx, Cx: CodegenMethods<'tcx>>(
         return val;
     }
 
-    let vtable_alloc_id = tcx.vtable_allocation((ty, trait_ref));
-    let vtable_allocation = tcx.global_alloc(vtable_alloc_id).unwrap_memory();
+    let vtable_allocation = tcx.vtable_allocation((ty, trait_ref));
     let vtable_const = cx.const_data_from_alloc(vtable_allocation);
     let align = cx.data_layout().pointer_align.abi;
     let vtable = cx.static_addr_of(vtable_const, align, Some("vtable"));

--- a/compiler/rustc_const_eval/src/interpret/traits.rs
+++ b/compiler/rustc_const_eval/src/interpret/traits.rs
@@ -30,7 +30,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
         ensure_monomorphic_enough(*self.tcx, ty)?;
         ensure_monomorphic_enough(*self.tcx, poly_trait_ref)?;
 
-        let vtable_allocation = self.tcx.vtable_allocation((ty, poly_trait_ref));
+        let vtable_allocation = self.tcx.vtable_allocation((ty, poly_trait_ref)).0;
         let vtable_allocation_id = self.tcx.create_memory_alloc(vtable_allocation);
         let vtable_ptr = self.memory.global_base_pointer(Pointer::from(vtable_allocation_id))?;
 

--- a/compiler/rustc_const_eval/src/interpret/traits.rs
+++ b/compiler/rustc_const_eval/src/interpret/traits.rs
@@ -31,8 +31,8 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
         ensure_monomorphic_enough(*self.tcx, poly_trait_ref)?;
 
         let vtable_allocation = self.tcx.vtable_allocation((ty, poly_trait_ref));
-
-        let vtable_ptr = self.memory.global_base_pointer(Pointer::from(vtable_allocation))?;
+        let vtable_allocation_id = self.tcx.create_memory_alloc(vtable_allocation);
+        let vtable_ptr = self.memory.global_base_pointer(Pointer::from(vtable_allocation_id))?;
 
         Ok(vtable_ptr.into())
     }

--- a/compiler/rustc_data_structures/src/stable_hasher.rs
+++ b/compiler/rustc_data_structures/src/stable_hasher.rs
@@ -223,6 +223,12 @@ impl<CTX> HashStable<CTX> for ::std::num::NonZeroU32 {
     }
 }
 
+impl<CTX> HashStable<CTX> for ::std::num::NonZeroU64 {
+    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
+        self.get().hash_stable(ctx, hasher)
+    }
+}
+
 impl<CTX> HashStable<CTX> for ::std::num::NonZeroUsize {
     fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
         self.get().hash_stable(ctx, hasher)

--- a/compiler/rustc_middle/src/mir/interpret/mod.rs
+++ b/compiler/rustc_middle/src/mir/interpret/mod.rs
@@ -93,6 +93,7 @@ mod allocation;
 mod error;
 mod pointer;
 mod queries;
+mod structural_impls;
 mod value;
 
 use std::convert::TryFrom;
@@ -126,7 +127,8 @@ pub use self::error::{
 pub use self::value::{get_slice_bytes, ConstAlloc, ConstValue, Scalar, ScalarMaybeUninit};
 
 pub use self::allocation::{
-    alloc_range, AllocRange, Allocation, InitChunk, InitChunkIter, InitMask, Relocations,
+    alloc_range, AllocRange, Allocation, AllocationModuloRelocations, InitChunk, InitChunkIter,
+    InitMask, Relocations,
 };
 
 pub use self::pointer::{Pointer, PointerArithmetic, Provenance};
@@ -379,7 +381,7 @@ impl<'s> AllocDecodingSession<'s> {
 
 /// An allocation in the global (tcx-managed) memory can be either a function pointer,
 /// a static, or a "real" allocation with some data in it.
-#[derive(Debug, Clone, Eq, PartialEq, Hash, TyDecodable, TyEncodable, HashStable)]
+#[derive(Debug, Clone, TyDecodable, TyEncodable)]
 pub enum GlobalAlloc<'tcx> {
     /// The alloc ID is used as a function pointer.
     Function(Instance<'tcx>),

--- a/compiler/rustc_middle/src/mir/interpret/structural_impls.rs
+++ b/compiler/rustc_middle/src/mir/interpret/structural_impls.rs
@@ -30,6 +30,7 @@ impl<'a> HashStable<StableHashingContext<'a>> for ConstValue<'_> {
                         let (ptr, offset) = ptr.into_parts();
                         tcx.get_global_alloc(ptr).hash_stable(hcx, hasher);
                         offset.hash_stable(hcx, hasher);
+                        // FIXME(compiler-errors): Do we need to hash `size`?
                         size.hash_stable(hcx, hasher);
                     }
                 }
@@ -322,6 +323,7 @@ impl Hash for ConstValue<'_> {
                         let (ptr, offset) = ptr.into_parts();
                         tcx.get_global_alloc(ptr).hash(state);
                         offset.hash(state);
+                        // FIXME(compiler-errors): Do we need to hash `size`?
                         size.hash(state);
                     }
                 }

--- a/compiler/rustc_middle/src/mir/interpret/structural_impls.rs
+++ b/compiler/rustc_middle/src/mir/interpret/structural_impls.rs
@@ -1,0 +1,379 @@
+use std::{cmp::Ordering, hash::Hash};
+
+use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
+use rustc_query_system::ich::StableHashingContext;
+
+use crate::ty;
+
+use super::{AllocationModuloRelocations, ConstAlloc, ConstValue, GlobalAlloc, Scalar};
+
+impl<'a> HashStable<StableHashingContext<'a>> for ConstAlloc<'_> {
+    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
+        self.ty.hash_stable(hcx, hasher);
+        ty::tls::with_opt(|tcx| {
+            let tcx = tcx.expect("can't hash AllocIds during hir lowering");
+            tcx.get_global_alloc(self.alloc_id).hash_stable(hcx, hasher);
+        });
+    }
+}
+
+impl<'a> HashStable<StableHashingContext<'a>> for ConstValue<'_> {
+    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
+        std::mem::discriminant(self).hash_stable(hcx, hasher);
+        ty::tls::with_opt(|tcx| match self {
+            ConstValue::Scalar(scalar) => {
+                std::mem::discriminant(scalar).hash_stable(hcx, hasher);
+                match scalar {
+                    Scalar::Int(int) => int.hash_stable(hcx, hasher),
+                    Scalar::Ptr(ptr, size) => {
+                        let tcx = tcx.expect("can't hash AllocIds during hir lowering");
+                        let (ptr, offset) = ptr.into_parts();
+                        tcx.get_global_alloc(ptr).hash_stable(hcx, hasher);
+                        offset.hash_stable(hcx, hasher);
+                        size.hash_stable(hcx, hasher);
+                    }
+                }
+            }
+            ConstValue::Slice { data, start, end } => {
+                AllocationModuloRelocations(*data).hash_stable(hcx, hasher);
+                start.hash_stable(hcx, hasher);
+                end.hash_stable(hcx, hasher);
+            }
+            ConstValue::ByRef { alloc, offset } => {
+                AllocationModuloRelocations(*alloc).hash_stable(hcx, hasher);
+                offset.hash_stable(hcx, hasher);
+            }
+        })
+    }
+}
+
+impl<'a> HashStable<StableHashingContext<'a>> for GlobalAlloc<'_> {
+    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
+        std::mem::discriminant(self).hash_stable(hcx, hasher);
+        match self {
+            Self::Function(f) => {
+                f.hash_stable(hcx, hasher);
+            }
+            Self::Static(s) => {
+                s.hash_stable(hcx, hasher);
+            }
+            Self::Memory(m) => {
+                AllocationModuloRelocations(m).hash_stable(hcx, hasher);
+            }
+        }
+    }
+}
+
+impl<'a> HashStable<StableHashingContext<'a>> for AllocationModuloRelocations<'_> {
+    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
+        let AllocationModuloRelocations(alloc) = *self;
+        alloc.bytes.hash_stable(hcx, hasher);
+        alloc.init_mask.hash_stable(hcx, hasher);
+        alloc.align.hash_stable(hcx, hasher);
+        alloc.mutability.hash_stable(hcx, hasher);
+        alloc.extra.hash_stable(hcx, hasher);
+        alloc.relocations.len().hash_stable(hcx, hasher);
+        ty::tls::with_opt(|tcx| {
+            if alloc.relocations.is_empty() {
+                return;
+            }
+            let tcx = tcx.expect("can't compare AllocIds during hir lowering");
+            for (size, ptr) in alloc.relocations.iter() {
+                size.hash_stable(hcx, hasher);
+                tcx.get_global_alloc(*ptr).hash_stable(hcx, hasher);
+            }
+        })
+    }
+}
+
+impl PartialEq for ConstAlloc<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        self.ty == other.ty
+            && ty::tls::with_opt(|tcx| {
+                let tcx = tcx.expect("can't compare AllocIds during hir lowering");
+                tcx.get_global_alloc(self.alloc_id) == tcx.get_global_alloc(other.alloc_id)
+            })
+    }
+}
+
+impl PartialEq for ConstValue<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        ty::tls::with_opt(|tcx| match (self, other) {
+            (Self::Scalar(Scalar::Int(a_int)), Self::Scalar(Scalar::Int(b_int))) => a_int == b_int,
+            (
+                Self::Scalar(Scalar::Ptr(a_ptr, a_size)),
+                Self::Scalar(Scalar::Ptr(b_ptr, b_size)),
+            ) => {
+                let tcx = tcx.expect("can't hash AllocIds during hir lowering");
+                let (a_ptr, a_offset) = a_ptr.into_parts();
+                let (b_ptr, b_offset) = b_ptr.into_parts();
+                a_offset == b_offset
+                    && a_size == b_size
+                    && tcx.get_global_alloc(a_ptr) == tcx.get_global_alloc(b_ptr)
+            }
+            (
+                Self::Slice { data: a_data, start: a_start, end: a_end },
+                Self::Slice { data: b_data, start: b_start, end: b_end },
+            ) => {
+                a_start == b_start
+                    && a_end == b_end
+                    && AllocationModuloRelocations(*a_data)
+                        .eq(&AllocationModuloRelocations(*b_data))
+            }
+            (
+                Self::ByRef { alloc: a_alloc, offset: a_offset },
+                Self::ByRef { alloc: b_alloc, offset: b_offset },
+            ) => {
+                a_offset == b_offset
+                    && AllocationModuloRelocations(*a_alloc)
+                        .eq(&AllocationModuloRelocations(*b_alloc))
+            }
+            _ => false,
+        })
+    }
+}
+
+impl PartialEq for GlobalAlloc<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Function(a), Self::Function(b)) => a == b,
+            (Self::Static(a), Self::Static(b)) => a == b,
+            (Self::Memory(a), Self::Memory(b)) => {
+                AllocationModuloRelocations(a).eq(&AllocationModuloRelocations(*b))
+            }
+            _ => false,
+        }
+    }
+}
+
+impl PartialEq for AllocationModuloRelocations<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        let AllocationModuloRelocations(alloc) = *self;
+        let AllocationModuloRelocations(other) = *other;
+        alloc.init_mask == other.init_mask
+            && alloc.align == other.align
+            && alloc.mutability == other.mutability
+            && alloc.extra == other.extra
+            && alloc.bytes == other.bytes
+            && alloc.relocations.len() == other.relocations.len()
+            && ty::tls::with_opt(|tcx| {
+                if alloc.relocations.is_empty() {
+                    return true;
+                }
+                let tcx = tcx.expect("can't compare AllocIds during hir lowering");
+                alloc.relocations.iter().zip(other.relocations.iter()).all(
+                    |((a_size, a_ptr), (b_size, b_ptr))| {
+                        a_size == b_size
+                            && tcx.get_global_alloc(*a_ptr) == tcx.get_global_alloc(*b_ptr)
+                    },
+                )
+            })
+    }
+}
+
+impl Eq for ConstAlloc<'_> {}
+
+impl Eq for ConstValue<'_> {}
+
+impl Eq for GlobalAlloc<'_> {}
+
+impl Eq for AllocationModuloRelocations<'_> {}
+
+impl PartialOrd for ConstValue<'_> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl PartialOrd for GlobalAlloc<'_> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl PartialOrd for AllocationModuloRelocations<'_> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for ConstValue<'_> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        ty::tls::with_opt(|tcx| {
+            match (self, other) {
+                (Self::Scalar(Scalar::Int(a_int)), Self::Scalar(Scalar::Int(b_int))) => {
+                    a_int.cmp(&b_int)
+                }
+                (
+                    Self::Scalar(Scalar::Ptr(a_ptr, a_size)),
+                    Self::Scalar(Scalar::Ptr(b_ptr, b_size)),
+                ) => {
+                    let tcx = tcx.expect("can't hash AllocIds during hir lowering");
+                    let (a_ptr, a_offset) = a_ptr.into_parts();
+                    let (b_ptr, b_offset) = b_ptr.into_parts();
+                    a_offset
+                        .cmp(&b_offset)
+                        .then_with(|| a_size.cmp(&b_size))
+                        .then_with(|| tcx.get_global_alloc(a_ptr).cmp(&tcx.get_global_alloc(b_ptr)))
+                }
+                (
+                    Self::Slice { data: a_data, start: a_start, end: a_end },
+                    Self::Slice { data: b_data, start: b_start, end: b_end },
+                ) => a_start.cmp(b_start).then_with(|| a_end.cmp(b_end)).then_with(|| {
+                    AllocationModuloRelocations(*a_data).cmp(&AllocationModuloRelocations(*b_data))
+                }),
+                (
+                    Self::ByRef { alloc: a_alloc, offset: a_offset },
+                    Self::ByRef { alloc: b_alloc, offset: b_offset },
+                ) => a_offset.cmp(b_offset).then_with(|| {
+                    AllocationModuloRelocations(*a_alloc)
+                        .cmp(&AllocationModuloRelocations(*b_alloc))
+                }),
+                // discriminant-based ordering
+                (Self::Scalar(Scalar::Int(_)), Self::Scalar(Scalar::Ptr(..)))
+                | (Self::Scalar(Scalar::Ptr(..)), Self::Scalar(Scalar::Int(_)))
+                | (Self::Scalar(_), Self::Slice { .. })
+                | (Self::Scalar(_), Self::ByRef { .. })
+                | (Self::Slice { .. }, Self::Scalar(_)) => Ordering::Less,
+                (Self::Slice { .. }, Self::ByRef { .. })
+                | (Self::ByRef { .. }, Self::Scalar(_))
+                | (Self::ByRef { .. }, Self::Slice { .. }) => Ordering::Greater,
+            }
+        })
+    }
+}
+
+impl Ord for GlobalAlloc<'_> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        match (self, other) {
+            (Self::Function(a), Self::Function(b)) => a.cmp(b),
+            (Self::Static(a), Self::Static(b)) => a.cmp(b),
+            (Self::Memory(a), Self::Memory(b)) => {
+                AllocationModuloRelocations(a).cmp(&AllocationModuloRelocations(b))
+            }
+
+            (Self::Function(_), Self::Static(_))
+            | (Self::Function(_), Self::Memory(_))
+            | (Self::Static(_), Self::Memory(_)) => Ordering::Less,
+
+            (Self::Static(_), Self::Function(_))
+            | (Self::Memory(_), Self::Function(_))
+            | (Self::Memory(_), Self::Static(_)) => Ordering::Greater,
+        }
+    }
+}
+
+impl Ord for AllocationModuloRelocations<'_> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        let AllocationModuloRelocations(alloc) = *self;
+        let AllocationModuloRelocations(other) = *other;
+        alloc
+            .init_mask
+            .cmp(&other.init_mask)
+            .then_with(|| alloc.align.cmp(&other.align))
+            .then_with(|| alloc.mutability.cmp(&other.mutability))
+            .then_with(|| alloc.extra.cmp(&other.extra))
+            .then_with(|| alloc.bytes.cmp(&other.bytes))
+            .then_with(|| alloc.relocations.len().cmp(&other.relocations.len()))
+            .then_with(|| {
+                ty::tls::with_opt(|tcx| {
+                    if alloc.relocations.is_empty() {
+                        return Ordering::Equal;
+                    }
+                    let tcx = tcx.expect("can't compare AllocIds during hir lowering");
+                    for ((a_size, a_ptr), (b_size, b_ptr)) in
+                        alloc.relocations.iter().zip(other.relocations.iter())
+                    {
+                        let ord = a_size.cmp(b_size).then_with(|| {
+                            tcx.get_global_alloc(*a_ptr).cmp(&tcx.get_global_alloc(*b_ptr))
+                        });
+                        if ord != Ordering::Equal {
+                            return ord;
+                        }
+                    }
+                    Ordering::Equal
+                })
+            })
+    }
+}
+
+impl Hash for ConstAlloc<'_> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.ty.hash(state);
+        ty::tls::with_opt(|tcx| {
+            let tcx = tcx.expect("can't hash AllocIds during hir lowering");
+            tcx.get_global_alloc(self.alloc_id).hash(state);
+        });
+    }
+}
+
+impl Hash for ConstValue<'_> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        std::mem::discriminant(self).hash(state);
+        ty::tls::with_opt(|tcx| match self {
+            ConstValue::Scalar(scalar) => {
+                std::mem::discriminant(scalar).hash(state);
+                match scalar {
+                    Scalar::Int(int) => {
+                        int.hash(state);
+                    }
+                    Scalar::Ptr(ptr, size) => {
+                        let tcx = tcx.expect("can't hash AllocIds during hir lowering");
+                        let (ptr, offset) = ptr.into_parts();
+                        tcx.get_global_alloc(ptr).hash(state);
+                        offset.hash(state);
+                        size.hash(state);
+                    }
+                }
+            }
+            ConstValue::Slice { data, start, end } => {
+                AllocationModuloRelocations(*data).hash(state);
+                start.hash(state);
+                end.hash(state);
+            }
+            ConstValue::ByRef { alloc, offset } => {
+                AllocationModuloRelocations(*alloc).hash(state);
+                offset.hash(state);
+            }
+        })
+    }
+}
+
+impl Hash for GlobalAlloc<'_> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        std::mem::discriminant(self).hash(state);
+        match self {
+            Self::Function(f) => {
+                f.hash(state);
+            }
+            Self::Static(s) => {
+                s.hash(state);
+            }
+            Self::Memory(m) => {
+                AllocationModuloRelocations(*m).hash(state);
+            }
+        }
+    }
+}
+
+impl Hash for AllocationModuloRelocations<'_> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        let AllocationModuloRelocations(alloc) = *self;
+        alloc.bytes.hash(state);
+        alloc.init_mask.hash(state);
+        alloc.align.hash(state);
+        alloc.mutability.hash(state);
+        alloc.extra.hash(state);
+        alloc.relocations.len().hash(state);
+        ty::tls::with_opt(|tcx| {
+            if alloc.relocations.is_empty() {
+                return;
+            }
+            let tcx = tcx.expect("can't compare AllocIds during hir lowering");
+            for (size, ptr) in alloc.relocations.iter() {
+                size.hash(state);
+                tcx.get_global_alloc(*ptr).hash(state);
+            }
+        })
+    }
+}

--- a/compiler/rustc_middle/src/mir/interpret/value.rs
+++ b/compiler/rustc_middle/src/mir/interpret/value.rs
@@ -15,7 +15,7 @@ use super::{
 };
 
 /// Represents the result of const evaluation via the `eval_to_allocation` query.
-#[derive(Copy, Clone, HashStable, TyEncodable, TyDecodable, Debug, Hash, Eq, PartialEq)]
+#[derive(Copy, Clone, TyEncodable, TyDecodable, Debug)]
 pub struct ConstAlloc<'tcx> {
     // the value lives here, at offset 0, and that allocation definitely is an `AllocKind::Memory`
     // (so you can use `AllocMap::unwrap_memory`).
@@ -25,8 +25,7 @@ pub struct ConstAlloc<'tcx> {
 
 /// Represents a constant value in Rust. `Scalar` and `Slice` are optimizations for
 /// array length computations, enum discriminants and the pattern matching logic.
-#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord, TyEncodable, TyDecodable, Hash)]
-#[derive(HashStable)]
+#[derive(Copy, Clone, Debug, TyEncodable, TyDecodable)]
 pub enum ConstValue<'tcx> {
     /// Used only for types with `layout::abi::Scalar` ABI and ZSTs.
     ///

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -1066,7 +1066,7 @@ rustc_queries! {
             key.1, key.0 }
     }
 
-    query vtable_allocation(key: (Ty<'tcx>, Option<ty::PolyExistentialTraitRef<'tcx>>)) -> mir::interpret::AllocId {
+    query vtable_allocation(key: (Ty<'tcx>, Option<ty::PolyExistentialTraitRef<'tcx>>)) -> &'tcx mir::interpret::Allocation {
         desc { |tcx| "vtable const allocation for <{} as {}>",
             key.0,
             key.1.map(|trait_ref| format!("{}", trait_ref)).unwrap_or("_".to_owned())

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -1066,7 +1066,7 @@ rustc_queries! {
             key.1, key.0 }
     }
 
-    query vtable_allocation(key: (Ty<'tcx>, Option<ty::PolyExistentialTraitRef<'tcx>>)) -> &'tcx mir::interpret::Allocation {
+    query vtable_allocation(key: (Ty<'tcx>, Option<ty::PolyExistentialTraitRef<'tcx>>)) -> mir::interpret::AllocationModuloRelocations<'tcx> {
         desc { |tcx| "vtable const allocation for <{} as {}>",
             key.0,
             key.1.map(|trait_ref| format!("{}", trait_ref)).unwrap_or("_".to_owned())

--- a/compiler/rustc_middle/src/ty/instance.rs
+++ b/compiler/rustc_middle/src/ty/instance.rs
@@ -16,7 +16,7 @@ use std::fmt;
 /// Monomorphization happens on-the-fly and no monomorphized MIR is ever created. Instead, this type
 /// simply couples a potentially generic `InstanceDef` with some substs, and codegen and const eval
 /// will do all required substitution as they run.
-#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug, TyEncodable, TyDecodable)]
+#[derive(Copy, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Debug, TyEncodable, TyDecodable)]
 #[derive(HashStable, Lift)]
 pub struct Instance<'tcx> {
     pub def: InstanceDef<'tcx>,

--- a/compiler/rustc_middle/src/ty/relate.rs
+++ b/compiler/rustc_middle/src/ty/relate.rs
@@ -634,6 +634,7 @@ fn check_const_value_eq<'tcx, R: TypeRelation<'tcx>>(
             ConstValue::Scalar(Scalar::Ptr(a_val, _a_size)),
             ConstValue::Scalar(Scalar::Ptr(b_val, _b_size)),
         ) => {
+            // FIXME(compiler-errors): this is possibly suspicious
             a_val == b_val
                 || match (tcx.global_alloc(a_val.provenance), tcx.global_alloc(b_val.provenance)) {
                     (GlobalAlloc::Function(a_instance), GlobalAlloc::Function(b_instance)) => {

--- a/compiler/rustc_middle/src/ty/vtable.rs
+++ b/compiler/rustc_middle/src/ty/vtable.rs
@@ -1,7 +1,9 @@
 use std::convert::TryFrom;
 use std::fmt;
 
-use crate::mir::interpret::{alloc_range, Allocation, Pointer, Scalar, ScalarMaybeUninit};
+use crate::mir::interpret::{
+    alloc_range, Allocation, AllocationModuloRelocations, Pointer, Scalar, ScalarMaybeUninit,
+};
 use crate::ty::{self, Instance, PolyTraitRef, Ty, TyCtxt};
 use rustc_ast::Mutability;
 
@@ -48,7 +50,7 @@ pub const COMMON_VTABLE_ENTRIES_ALIGN: usize = 2;
 pub(super) fn vtable_allocation_provider<'tcx>(
     tcx: TyCtxt<'tcx>,
     key: (Ty<'tcx>, Option<ty::PolyExistentialTraitRef<'tcx>>),
-) -> &'tcx Allocation {
+) -> AllocationModuloRelocations<'tcx> {
     let (ty, poly_trait_ref) = key;
 
     let vtable_entries = if let Some(poly_trait_ref) = poly_trait_ref {
@@ -99,7 +101,7 @@ pub(super) fn vtable_allocation_provider<'tcx>(
             VtblEntry::TraitVPtr(trait_ref) => {
                 let super_trait_ref = trait_ref
                     .map_bound(|trait_ref| ty::ExistentialTraitRef::erase_self_ty(tcx, trait_ref));
-                let supertrait_alloc = tcx.vtable_allocation((ty, Some(super_trait_ref)));
+                let supertrait_alloc = tcx.vtable_allocation((ty, Some(super_trait_ref))).0;
                 let supertrait_alloc_id = tcx.create_memory_alloc(supertrait_alloc);
                 let vptr = Pointer::from(supertrait_alloc_id);
                 ScalarMaybeUninit::from_pointer(vptr, &tcx)
@@ -111,5 +113,5 @@ pub(super) fn vtable_allocation_provider<'tcx>(
     }
 
     vtable.mutability = Mutability::Not;
-    tcx.intern_const_alloc(vtable)
+    AllocationModuloRelocations(tcx.intern_const_alloc(vtable))
 }

--- a/src/test/ui/consts/const-eval/const-pointer-values-in-various-types.64bit.stderr
+++ b/src/test/ui/consts/const-eval/const-pointer-values-in-various-types.64bit.stderr
@@ -47,11 +47,11 @@ error[E0080]: it is undefined behavior to use this value
   --> $DIR/const-pointer-values-in-various-types.rs:41:5
    |
 LL |     const I32_REF_U64_UNION: u64 = unsafe { Nonsense { int_32_ref: &3 }.uint_64 };
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc19, but expected initialized plain (non-pointer) bytes
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc3, but expected initialized plain (non-pointer) bytes
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 8, align: 8) {
-               ╾───────alloc19───────╼                         │ ╾──────╼
+               ╾───────alloc3────────╼                         │ ╾──────╼
            }
 
 error[E0080]: it is undefined behavior to use this value
@@ -102,11 +102,11 @@ error[E0080]: it is undefined behavior to use this value
   --> $DIR/const-pointer-values-in-various-types.rs:59:5
    |
 LL |     const I32_REF_I64_UNION: i64 = unsafe { Nonsense { int_32_ref: &3 }.int_64 };
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc39, but expected initialized plain (non-pointer) bytes
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc3, but expected initialized plain (non-pointer) bytes
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 8, align: 8) {
-               ╾───────alloc39───────╼                         │ ╾──────╼
+               ╾───────alloc3────────╼                         │ ╾──────╼
            }
 
 error[E0080]: it is undefined behavior to use this value
@@ -135,11 +135,11 @@ error[E0080]: it is undefined behavior to use this value
   --> $DIR/const-pointer-values-in-various-types.rs:69:5
    |
 LL |     const I32_REF_F64_UNION: f64 = unsafe { Nonsense { int_32_ref: &3 }.float_64 };
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc51, but expected initialized plain (non-pointer) bytes
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc3, but expected initialized plain (non-pointer) bytes
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 8, align: 8) {
-               ╾───────alloc51───────╼                         │ ╾──────╼
+               ╾───────alloc3────────╼                         │ ╾──────╼
            }
 
 error: any use of this value will cause an error

--- a/src/test/ui/consts/const-eval/ub-enum.32bit.stderr
+++ b/src/test/ui/consts/const-eval/ub-enum.32bit.stderr
@@ -24,11 +24,11 @@ error[E0080]: it is undefined behavior to use this value
   --> $DIR/ub-enum.rs:30:1
    |
 LL | const BAD_ENUM_WRAPPED: Wrap<Enum> = unsafe { mem::transmute(&1) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .0.<enum-tag>: encountered pointer to alloc13, but expected initialized plain (non-pointer) bytes
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .0.<enum-tag>: encountered pointer to alloc9, but expected initialized plain (non-pointer) bytes
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 4, align: 4) {
-               ╾─alloc13─╼                                     │ ╾──╼
+               ╾─alloc9──╼                                     │ ╾──╼
            }
 
 error[E0080]: it is undefined behavior to use this value
@@ -57,11 +57,11 @@ error[E0080]: it is undefined behavior to use this value
   --> $DIR/ub-enum.rs:47:1
    |
 LL | const BAD_ENUM2_WRAPPED: Wrap<Enum2> = unsafe { mem::transmute(&0) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .0.<enum-tag>: encountered pointer to alloc23, but expected initialized plain (non-pointer) bytes
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .0.<enum-tag>: encountered pointer to alloc19, but expected initialized plain (non-pointer) bytes
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 4, align: 4) {
-               ╾─alloc23─╼                                     │ ╾──╼
+               ╾─alloc19─╼                                     │ ╾──╼
            }
 
 error[E0080]: it is undefined behavior to use this value
@@ -79,11 +79,11 @@ error[E0080]: it is undefined behavior to use this value
   --> $DIR/ub-enum.rs:60:1
    |
 LL | const BAD_ENUM2_OPTION_PTR: Option<Enum2> = unsafe { mem::transmute(&0) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .<enum-tag>: encountered pointer to alloc29, but expected initialized plain (non-pointer) bytes
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .<enum-tag>: encountered pointer to alloc19, but expected initialized plain (non-pointer) bytes
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 4, align: 4) {
-               ╾─alloc29─╼                                     │ ╾──╼
+               ╾─alloc19─╼                                     │ ╾──╼
            }
 
 error[E0080]: it is undefined behavior to use this value

--- a/src/test/ui/consts/const-eval/ub-enum.64bit.stderr
+++ b/src/test/ui/consts/const-eval/ub-enum.64bit.stderr
@@ -24,11 +24,11 @@ error[E0080]: it is undefined behavior to use this value
   --> $DIR/ub-enum.rs:30:1
    |
 LL | const BAD_ENUM_WRAPPED: Wrap<Enum> = unsafe { mem::transmute(&1) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .0.<enum-tag>: encountered pointer to alloc13, but expected initialized plain (non-pointer) bytes
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .0.<enum-tag>: encountered pointer to alloc9, but expected initialized plain (non-pointer) bytes
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 8, align: 8) {
-               ╾───────alloc13───────╼                         │ ╾──────╼
+               ╾───────alloc9────────╼                         │ ╾──────╼
            }
 
 error[E0080]: it is undefined behavior to use this value
@@ -57,11 +57,11 @@ error[E0080]: it is undefined behavior to use this value
   --> $DIR/ub-enum.rs:47:1
    |
 LL | const BAD_ENUM2_WRAPPED: Wrap<Enum2> = unsafe { mem::transmute(&0) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .0.<enum-tag>: encountered pointer to alloc23, but expected initialized plain (non-pointer) bytes
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .0.<enum-tag>: encountered pointer to alloc19, but expected initialized plain (non-pointer) bytes
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 8, align: 8) {
-               ╾───────alloc23───────╼                         │ ╾──────╼
+               ╾───────alloc19───────╼                         │ ╾──────╼
            }
 
 error[E0080]: it is undefined behavior to use this value
@@ -79,11 +79,11 @@ error[E0080]: it is undefined behavior to use this value
   --> $DIR/ub-enum.rs:60:1
    |
 LL | const BAD_ENUM2_OPTION_PTR: Option<Enum2> = unsafe { mem::transmute(&0) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .<enum-tag>: encountered pointer to alloc29, but expected initialized plain (non-pointer) bytes
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .<enum-tag>: encountered pointer to alloc19, but expected initialized plain (non-pointer) bytes
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 8, align: 8) {
-               ╾───────alloc29───────╼                         │ ╾──────╼
+               ╾───────alloc19───────╼                         │ ╾──────╼
            }
 
 error[E0080]: it is undefined behavior to use this value

--- a/src/test/ui/consts/const-eval/ub-incorrect-vtable.32bit.stderr
+++ b/src/test/ui/consts/const-eval/ub-incorrect-vtable.32bit.stderr
@@ -19,7 +19,7 @@ LL | |     unsafe { std::mem::transmute((&92u8, &(drop_me as fn(*mut usize), 1us
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾─allocN─╼ ╾─allocN─╼                         │ ╾──╼╾──╼
+               ╾─allocN──╼ ╾─allocN─╼                         │ ╾──╼╾──╼
            }
 
 error[E0080]: it is undefined behavior to use this value
@@ -31,7 +31,7 @@ LL | |     unsafe { std::mem::transmute((&92u8, &(drop_me as fn(*mut usize), usi
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾─allocN─╼ ╾─allocN─╼                         │ ╾──╼╾──╼
+               ╾─allocN──╼ ╾─allocN─╼                         │ ╾──╼╾──╼
            }
 
 error: aborting due to 4 previous errors

--- a/src/test/ui/consts/const-eval/ub-incorrect-vtable.64bit.stderr
+++ b/src/test/ui/consts/const-eval/ub-incorrect-vtable.64bit.stderr
@@ -19,7 +19,7 @@ LL | |     unsafe { std::mem::transmute((&92u8, &(drop_me as fn(*mut usize), 1us
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾───────allocN───────╼ ╾───────allocN───────╼ │ ╾──────╼╾──────╼
+               ╾───────allocN────────╼ ╾───────allocN───────╼ │ ╾──────╼╾──────╼
            }
 
 error[E0080]: it is undefined behavior to use this value
@@ -31,7 +31,7 @@ LL | |     unsafe { std::mem::transmute((&92u8, &(drop_me as fn(*mut usize), usi
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾───────allocN───────╼ ╾───────allocN───────╼ │ ╾──────╼╾──────╼
+               ╾───────allocN────────╼ ╾───────allocN───────╼ │ ╾──────╼╾──────╼
            }
 
 error: aborting due to 4 previous errors

--- a/src/test/ui/consts/const-eval/ub-ref-ptr.32bit.stderr
+++ b/src/test/ui/consts/const-eval/ub-ref-ptr.32bit.stderr
@@ -17,7 +17,7 @@ LL | const UNALIGNED_BOX: Box<u16> = unsafe { mem::transmute(&[0u8; 4]) };
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 4, align: 4) {
-               ╾─alloc7──╼                                     │ ╾──╼
+               ╾─alloc3──╼                                     │ ╾──╼
            }
 
 error[E0080]: it is undefined behavior to use this value

--- a/src/test/ui/consts/const-eval/ub-ref-ptr.64bit.stderr
+++ b/src/test/ui/consts/const-eval/ub-ref-ptr.64bit.stderr
@@ -17,7 +17,7 @@ LL | const UNALIGNED_BOX: Box<u16> = unsafe { mem::transmute(&[0u8; 4]) };
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 8, align: 8) {
-               ╾───────alloc7────────╼                         │ ╾──────╼
+               ╾───────alloc3────────╼                         │ ╾──────╼
            }
 
 error[E0080]: it is undefined behavior to use this value

--- a/src/test/ui/consts/const-eval/ub-wide-ptr.32bit.stderr
+++ b/src/test/ui/consts/const-eval/ub-wide-ptr.32bit.stderr
@@ -28,7 +28,7 @@ LL | const STR_LENGTH_PTR: &str = unsafe { mem::transmute((&42u8, &3)) };
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾─allocN─╼ ╾─allocN─╼                         │ ╾──╼╾──╼
+               ╾─allocN──╼ ╾─allocN─╼                         │ ╾──╼╾──╼
            }
 
 error[E0080]: it is undefined behavior to use this value
@@ -39,7 +39,7 @@ LL | const MY_STR_LENGTH_PTR: &MyStr = unsafe { mem::transmute((&42u8, &3)) };
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾─allocN─╼ ╾─allocN─╼                         │ ╾──╼╾──╼
+               ╾─allocN──╼ ╾─allocN─╼                         │ ╾──╼╾──╼
            }
 
 error[E0080]: it is undefined behavior to use this value
@@ -50,7 +50,7 @@ LL | const MY_STR_MUCH_TOO_LONG: &MyStr = unsafe { mem::transmute((&42u8, usize:
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾─allocN─╼ ff ff ff ff                         │ ╾──╼....
+               ╾─allocN──╼ ff ff ff ff                         │ ╾──╼....
            }
 
 error[E0080]: it is undefined behavior to use this value
@@ -98,7 +98,7 @@ LL | const SLICE_TOO_LONG: &[u8] = unsafe { mem::transmute((&42u8, 999usize)) };
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾─allocN─╼ e7 03 00 00                         │ ╾──╼....
+               ╾─allocN──╼ e7 03 00 00                         │ ╾──╼....
            }
 
 error[E0080]: it is undefined behavior to use this value
@@ -109,7 +109,7 @@ LL | const SLICE_LENGTH_PTR: &[u8] = unsafe { mem::transmute((&42u8, &3)) };
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾─allocN─╼ ╾─allocN─╼                         │ ╾──╼╾──╼
+               ╾─allocN──╼ ╾─allocN─╼                         │ ╾──╼╾──╼
            }
 
 error[E0080]: it is undefined behavior to use this value
@@ -120,7 +120,7 @@ LL | const SLICE_TOO_LONG_BOX: Box<[u8]> = unsafe { mem::transmute((&42u8, 999us
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾─allocN─╼ e7 03 00 00                         │ ╾──╼....
+               ╾─allocN──╼ e7 03 00 00                         │ ╾──╼....
            }
 
 error[E0080]: it is undefined behavior to use this value
@@ -131,7 +131,7 @@ LL | const SLICE_LENGTH_PTR_BOX: Box<[u8]> = unsafe { mem::transmute((&42u8, &3)
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾─allocN─╼ ╾─allocN─╼                         │ ╾──╼╾──╼
+               ╾─allocN──╼ ╾─allocN─╼                         │ ╾──╼╾──╼
            }
 
 error[E0080]: it is undefined behavior to use this value

--- a/src/test/ui/consts/const-eval/ub-wide-ptr.64bit.stderr
+++ b/src/test/ui/consts/const-eval/ub-wide-ptr.64bit.stderr
@@ -28,7 +28,7 @@ LL | const STR_LENGTH_PTR: &str = unsafe { mem::transmute((&42u8, &3)) };
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾───────allocN───────╼ ╾───────allocN───────╼ │ ╾──────╼╾──────╼
+               ╾───────allocN────────╼ ╾───────allocN───────╼ │ ╾──────╼╾──────╼
            }
 
 error[E0080]: it is undefined behavior to use this value
@@ -39,7 +39,7 @@ LL | const MY_STR_LENGTH_PTR: &MyStr = unsafe { mem::transmute((&42u8, &3)) };
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾───────allocN───────╼ ╾───────allocN───────╼ │ ╾──────╼╾──────╼
+               ╾───────allocN────────╼ ╾───────allocN───────╼ │ ╾──────╼╾──────╼
            }
 
 error[E0080]: it is undefined behavior to use this value
@@ -50,7 +50,7 @@ LL | const MY_STR_MUCH_TOO_LONG: &MyStr = unsafe { mem::transmute((&42u8, usize:
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾───────allocN───────╼ ff ff ff ff ff ff ff ff │ ╾──────╼........
+               ╾───────allocN────────╼ ff ff ff ff ff ff ff ff │ ╾──────╼........
            }
 
 error[E0080]: it is undefined behavior to use this value
@@ -98,7 +98,7 @@ LL | const SLICE_TOO_LONG: &[u8] = unsafe { mem::transmute((&42u8, 999usize)) };
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾───────allocN───────╼ e7 03 00 00 00 00 00 00 │ ╾──────╼........
+               ╾───────allocN────────╼ e7 03 00 00 00 00 00 00 │ ╾──────╼........
            }
 
 error[E0080]: it is undefined behavior to use this value
@@ -109,7 +109,7 @@ LL | const SLICE_LENGTH_PTR: &[u8] = unsafe { mem::transmute((&42u8, &3)) };
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾───────allocN───────╼ ╾───────allocN───────╼ │ ╾──────╼╾──────╼
+               ╾───────allocN────────╼ ╾───────allocN───────╼ │ ╾──────╼╾──────╼
            }
 
 error[E0080]: it is undefined behavior to use this value
@@ -120,7 +120,7 @@ LL | const SLICE_TOO_LONG_BOX: Box<[u8]> = unsafe { mem::transmute((&42u8, 999us
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾───────allocN───────╼ e7 03 00 00 00 00 00 00 │ ╾──────╼........
+               ╾───────allocN────────╼ e7 03 00 00 00 00 00 00 │ ╾──────╼........
            }
 
 error[E0080]: it is undefined behavior to use this value
@@ -131,7 +131,7 @@ LL | const SLICE_LENGTH_PTR_BOX: Box<[u8]> = unsafe { mem::transmute((&42u8, &3)
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾───────allocN───────╼ ╾───────allocN───────╼ │ ╾──────╼╾──────╼
+               ╾───────allocN────────╼ ╾───────allocN───────╼ │ ╾──────╼╾──────╼
            }
 
 error[E0080]: it is undefined behavior to use this value

--- a/src/test/ui/consts/issue-93470.rs
+++ b/src/test/ui/consts/issue-93470.rs
@@ -1,0 +1,31 @@
+// check-pass
+// incremental
+
+#[derive(PartialEq, Eq)]
+pub struct Key {
+    path: &'static str,
+}
+
+pub const CONST_A: Key = Key {
+    path: "time_zone/formats@1",
+};
+
+pub const CONST_B: Key = Key {
+    path: "time_zone/formats@1",
+};
+
+fn foo(key: Key) -> Result<(), &'static str> {
+    match key {
+        CONST_B => Ok(()),
+        _ => Err(""),
+    }
+}
+
+fn bar(key: Key) -> Result<(), &'static str> {
+    match key {
+        CONST_A => Ok(()),
+        _ => Err(""),
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
(take 2:)

This PR removes the `HashStable` implementation from `AllocId`, and fixes the `HashStable` implementation on `ConstValue`, `ConstAlloc`, and `Allocation` so that their `Eq` and `HashStable` implementations agree (as required by `HashStable`).

Fixes #93470

r? @oli-obk