### PR TITLE
Remove `match` and `memcpy` from `String::push`

### DIFF
--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -89,6 +89,7 @@
 #![allow(explicit_outlives_requirements)]
 //
 // Library features:
+#![feature(char_internals)]
 #![feature(alloc_layout_extra)]
 #![feature(allocator_api)]
 #![feature(array_chunks)]

--- a/library/alloc/src/string.rs
+++ b/library/alloc/src/string.rs
@@ -43,7 +43,7 @@
 #![stable(feature = "rust1", since = "1.0.0")]
 
 #[cfg(not(no_global_oom_handling))]
-use core::char::{self, decode_utf16, REPLACEMENT_CHARACTER};
+use core::char::{decode_utf16, REPLACEMENT_CHARACTER};
 use core::fmt;
 use core::hash;
 #[cfg(not(no_global_oom_handling))]
@@ -1154,7 +1154,7 @@ impl String {
             let len = self.len();
 
             let dst = self.vec.spare_capacity_mut();
-            let bytes = char::encode_utf8_raw(ch as u32, dst);
+            let bytes = core::char::encode_utf8_raw(ch as u32, dst);
             let len = len + bytes.len();
             self.vec.set_len(len);
         }

--- a/library/std/src/sys_common/wtf8.rs
+++ b/library/std/src/sys_common/wtf8.rs
@@ -26,7 +26,7 @@ use crate::collections::TryReserveError;
 use crate::fmt;
 use crate::hash::{Hash, Hasher};
 use crate::iter::FromIterator;
-use crate::mem;
+use crate::mem::{self, MaybeUninit};
 use crate::ops;
 use crate::rc::Rc;
 use crate::slice;
@@ -205,7 +205,7 @@ impl Wtf8Buf {
     /// Copied from String::push
     /// This does **not** include the WTF-8 concatenation check.
     fn push_code_point_unchecked(&mut self, code_point: CodePoint) {
-        let mut bytes = [0; 4];
+        let mut bytes = [MaybeUninit::uninit(); 4];
         let bytes = char::encode_utf8_raw(code_point.value, &mut bytes);
         self.bytes.extend_from_slice(bytes)
     }

--- a/library/std/src/sys_common/wtf8.rs
+++ b/library/std/src/sys_common/wtf8.rs
@@ -206,7 +206,8 @@ impl Wtf8Buf {
     /// This does **not** include the WTF-8 concatenation check.
     fn push_code_point_unchecked(&mut self, code_point: CodePoint) {
         let mut bytes = [MaybeUninit::uninit(); 4];
-        let bytes = char::encode_utf8_raw(code_point.value, &mut bytes);
+        // SAFETY: a buffer of 4 is long enough to encode any char
+        let bytes = unsafe { char::encode_utf8_raw(code_point.value, &mut bytes) };
         self.bytes.extend_from_slice(bytes)
     }
 


### PR DESCRIPTION
This all started as an experiment trying to remove the `memcpy` from the `self.vec.extend_from_slice` branch of `String::push`.

I haven't run any extensive benchmarks yet, for the moment results on the current benchmarks are ~~mixed~~ promising. ~~I don't like the fact that the `panic!` branch of `encode_utf8_raw` doesn't get optimized away anymore :disappointed:, probably because of an LLVM limitation. I have an idea for how to fix it.~~
Diff view: https://rust.godbolt.org/z/bKh6dfqo7

If this were to work the same optimization could be applied to `String::insert` in the future.