### PR TITLE
Hide failed command unless in verbose mode

### DIFF
--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -851,7 +851,7 @@ impl Build {
             return;
         }
         self.verbose(&format!("running: {:?}", cmd));
-        run(cmd)
+        run(cmd, self.is_verbose())
     }
 
     /// Runs a command, printing out nice contextual information if it fails.
@@ -871,7 +871,7 @@ impl Build {
             return true;
         }
         self.verbose(&format!("running: {:?}", cmd));
-        try_run(cmd)
+        try_run(cmd, self.is_verbose())
     }
 
     /// Runs a command, printing out nice contextual information if it fails.

--- a/src/build_helper/lib.rs
+++ b/src/build_helper/lib.rs
@@ -55,18 +55,18 @@ pub fn restore_library_path() {
     }
 }
 
-pub fn run(cmd: &mut Command) {
-    if !try_run(cmd) {
+pub fn run(cmd: &mut Command, print_cmd_on_fail: bool) {
+    if !try_run(cmd, print_cmd_on_fail) {
         std::process::exit(1);
     }
 }
 
-pub fn try_run(cmd: &mut Command) -> bool {
+pub fn try_run(cmd: &mut Command, print_cmd_on_fail: bool) -> bool {
     let status = match cmd.status() {
         Ok(status) => status,
         Err(e) => fail(&format!("failed to execute command: {:?}\nerror: {}", cmd, e)),
     };
-    if !status.success() {
+    if !status.success() && print_cmd_on_fail {
         println!(
             "\n\ncommand did not execute successfully: {:?}\n\
              expected success, got: {}\n\n",


### PR DESCRIPTION
This is particularly intended for invoking compiletest; the command line there
is long (3,350 characters on my system) and takes up a lot of screen real estate
for little benefit to the majority of those running bootstrap. This moves
printing it to verbose mode (-v must be passed) which means that it's still
possible to access when needed for debugging.

The main downside is that CI logs will by-default become less usable for
debugging (particularly) spurious failures, but it is pretty rare for us to
really need the information there -- it's usually fairly obvious what is being
run with a little investigation.

r? @ehuss as you've done some of the spurious failure investigations, so can
(hopefully) confirm my intuition that this won't seriously hinder them.