### PR TITLE
kmc-solid: Fix off-by-one error in `SystemTime::now`

### DIFF
--- a/library/std/src/sys/solid/time.rs
+++ b/library/std/src/sys/solid/time.rs
@@ -21,7 +21,7 @@ impl SystemTime {
                 tm_min: rtc.tm_min,
                 tm_hour: rtc.tm_hour,
                 tm_mday: rtc.tm_mday,
-                tm_mon: rtc.tm_mon,
+                tm_mon: rtc.tm_mon - 1,
                 tm_year: rtc.tm_year,
                 tm_wday: rtc.tm_wday,
                 tm_yday: 0,


### PR DESCRIPTION
Fixes a miscalculation of `SystemTime`  on the [`*-kmc-solid_*`](https://doc.rust-lang.org/nightly/rustc/platform-support/kmc-solid.html) Tier 3 targets.

Unlike the identically-named libc counterpart `tm::tm_mon`, `SOLID_RTC_TIME::tm_mon` contains a 1-based month number.