### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/compiler/rustc_builtin_macros/src/format.rs
+++ b/compiler/rustc_builtin_macros/src/format.rs
@@ -1237,13 +1237,15 @@ fn may_contain_yield_point(e: &ast::Expr) -> bool {
 
     impl Visitor<'_> for MayContainYieldPoint {
         fn visit_expr(&mut self, e: &ast::Expr) {
-            if let ast::ExprKind::Await(_) | ast::ExprKind::Yield(_) | ast::ExprKind::MacCall(_) =
-                e.kind
-            {
+            if let ast::ExprKind::Await(_) | ast::ExprKind::Yield(_) = e.kind {
                 self.0 = true;
             } else {
                 visit::walk_expr(self, e);
             }
+        }
+
+        fn visit_mac_call(&mut self, _: &ast::MacCall) {
+            self.0 = true;
         }
 
         fn visit_attribute(&mut self, _: &ast::Attribute) {

--- a/compiler/rustc_builtin_macros/src/format.rs
+++ b/compiler/rustc_builtin_macros/src/format.rs
@@ -4,6 +4,7 @@ use Position::*;
 use rustc_ast as ast;
 use rustc_ast::ptr::P;
 use rustc_ast::tokenstream::TokenStream;
+use rustc_ast::visit::{self, Visitor};
 use rustc_ast::{token, BlockCheckMode, UnsafeSource};
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_errors::{pluralize, Applicability, DiagnosticBuilder};
@@ -788,17 +789,31 @@ impl<'a, 'b> Context<'a, 'b> {
         // the order provided to fmt::Arguments. When arguments are repeated, we
         // want the expression evaluated only once.
         //
-        // Thus in the not nicely ordered case we emit the following instead:
+        // Further, if any arg _after the first one_ contains a yield point such
+        // as `await` or `yield`, the above short form is inconvenient for the
+        // caller because it would keep a temporary of type ArgumentV1 alive
+        // across the yield point. ArgumentV1 can't implement Send since it
+        // holds a type-erased arbitrary type.
+        //
+        // Thus in the not nicely ordered case, and in the yielding case, we
+        // emit the following instead:
         //
         //     match (&$arg0, &$arg1, …) {
         //         args => [ArgumentV1::new(args.$i, …), ArgumentV1::new(args.$j, …), …]
         //     }
         //
         // for the sequence of indices $i, $j, … governed by fmt_arg_index_and_ty.
+        // This more verbose representation ensures that all arguments are
+        // evaluated a single time each, in the order written by the programmer,
+        // and that the surrounding future/generator (if any) is Send whenever
+        // possible.
+        let no_need_for_match =
+            nicely_ordered && !original_args.iter().skip(1).any(|e| may_contain_yield_point(e));
+
         for (arg_index, arg_ty) in fmt_arg_index_and_ty {
             let e = &mut original_args[arg_index];
             let span = e.span;
-            let arg = if nicely_ordered {
+            let arg = if no_need_for_match {
                 let expansion_span = e.span.with_ctxt(self.macsp.ctxt());
                 // The indices are strictly ordered so e has not been taken yet.
                 self.ecx.expr_addr_of(expansion_span, P(e.take()))
@@ -814,10 +829,10 @@ impl<'a, 'b> Context<'a, 'b> {
         let args_array = self.ecx.expr_vec(self.macsp, fmt_args);
         let args_slice = self.ecx.expr_addr_of(
             self.macsp,
-            if nicely_ordered {
+            if no_need_for_match {
                 args_array
             } else {
-                // In the !nicely_ordered case, none of the exprs were moved
+                // In the !no_need_for_match case, none of the exprs were moved
                 // away in the previous loop.
                 //
                 // This uses the arg span for `&arg` so that borrowck errors
@@ -1215,4 +1230,34 @@ pub fn expand_preparsed_format_args(
     }
 
     cx.into_expr()
+}
+
+fn may_contain_yield_point(e: &ast::Expr) -> bool {
+    struct MayContainYieldPoint(bool);
+
+    impl Visitor<'_> for MayContainYieldPoint {
+        fn visit_expr(&mut self, e: &ast::Expr) {
+            if let ast::ExprKind::Await(_) | ast::ExprKind::Yield(_) | ast::ExprKind::MacCall(_) =
+                e.kind
+            {
+                self.0 = true;
+            } else {
+                visit::walk_expr(self, e);
+            }
+        }
+
+        fn visit_attribute(&mut self, _: &ast::Attribute) {
+            // Conservatively assume this may be a proc macro attribute in
+            // expression position.
+            self.0 = true;
+        }
+
+        fn visit_item(&mut self, _: &ast::Item) {
+            // Do not recurse into nested items.
+        }
+    }
+
+    let mut visitor = MayContainYieldPoint(false);
+    visitor.visit_expr(e);
+    visitor.0
 }

--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -192,10 +192,10 @@ impl<'a> Parser<'a> {
                 if ident.is_raw_guess()
                     && self.look_ahead(1, |t| valid_follow.contains(&t.kind)) =>
             {
-                err.span_suggestion(
-                    ident.span,
-                    "you can escape reserved keywords to use them as identifiers",
-                    format!("r#{}", ident.name),
+                err.span_suggestion_verbose(
+                    ident.span.shrink_to_lo(),
+                    &format!("escape `{}` to use it as an identifier", ident.name),
+                    "r#".to_owned(),
                     Applicability::MaybeIncorrect,
                 );
             }

--- a/library/core/src/num/f32.rs
+++ b/library/core/src/num/f32.rs
@@ -1008,29 +1008,37 @@ impl f32 {
         Self::from_bits(u32::from_ne_bytes(bytes))
     }
 
-    /// Returns an ordering between self and other values.
+    /// Return the ordering between `self` and `other`.
+    ///
     /// Unlike the standard partial comparison between floating point numbers,
     /// this comparison always produces an ordering in accordance to
-    /// the totalOrder predicate as defined in IEEE 754 (2008 revision)
-    /// floating point standard. The values are ordered in following order:
-    /// - Negative quiet NaN
-    /// - Negative signaling NaN
-    /// - Negative infinity
-    /// - Negative numbers
-    /// - Negative subnormal numbers
-    /// - Negative zero
-    /// - Positive zero
-    /// - Positive subnormal numbers
-    /// - Positive numbers
-    /// - Positive infinity
-    /// - Positive signaling NaN
-    /// - Positive quiet NaN
+    /// the `totalOrder` predicate as defined in the IEEE 754 (2008 revision)
+    /// floating point standard. The values are ordered in the following sequence:
     ///
-    /// Note that this function does not always agree with the [`PartialOrd`]
-    /// and [`PartialEq`] implementations of `f32`. In particular, they regard
-    /// negative and positive zero as equal, while `total_cmp` doesn't.
+    /// - negative quiet NaN
+    /// - negative signaling NaN
+    /// - negative infinity
+    /// - negative numbers
+    /// - negative subnormal numbers
+    /// - negative zero
+    /// - positive zero
+    /// - positive subnormal numbers
+    /// - positive numbers
+    /// - positive infinity
+    /// - positive signaling NaN
+    /// - positive quiet NaN.
+    ///
+    /// The ordering established by this function does not always agree with the
+    /// [`PartialOrd`] and [`PartialEq`] implementations of `f32`. For example,
+    /// they consider negative and positive zero equal, while `total_cmp`
+    /// doesn't.
+    ///
+    /// The interpretation of the signaling NaN bit follows the definition in
+    /// the IEEE 754 standard, which may not match the interpretation by some of
+    /// the older, non-conformant (e.g. MIPS) hardware implementations.
     ///
     /// # Example
+    ///
     /// ```
     /// #![feature(total_cmp)]
     /// struct GoodBoy {

--- a/library/core/src/num/f64.rs
+++ b/library/core/src/num/f64.rs
@@ -1024,29 +1024,37 @@ impl f64 {
         Self::from_bits(u64::from_ne_bytes(bytes))
     }
 
-    /// Returns an ordering between self and other values.
+    /// Return the ordering between `self` and `other`.
+    ///
     /// Unlike the standard partial comparison between floating point numbers,
     /// this comparison always produces an ordering in accordance to
-    /// the totalOrder predicate as defined in IEEE 754 (2008 revision)
-    /// floating point standard. The values are ordered in following order:
-    /// - Negative quiet NaN
-    /// - Negative signaling NaN
-    /// - Negative infinity
-    /// - Negative numbers
-    /// - Negative subnormal numbers
-    /// - Negative zero
-    /// - Positive zero
-    /// - Positive subnormal numbers
-    /// - Positive numbers
-    /// - Positive infinity
-    /// - Positive signaling NaN
-    /// - Positive quiet NaN
+    /// the `totalOrder` predicate as defined in the IEEE 754 (2008 revision)
+    /// floating point standard. The values are ordered in the following sequence:
     ///
-    /// Note that this function does not always agree with the [`PartialOrd`]
-    /// and [`PartialEq`] implementations of `f64`. In particular, they regard
-    /// negative and positive zero as equal, while `total_cmp` doesn't.
+    /// - negative quiet NaN
+    /// - negative signaling NaN
+    /// - negative infinity
+    /// - negative numbers
+    /// - negative subnormal numbers
+    /// - negative zero
+    /// - positive zero
+    /// - positive subnormal numbers
+    /// - positive numbers
+    /// - positive infinity
+    /// - positive signaling NaN
+    /// - positive quiet NaN.
+    ///
+    /// The ordering established by this function does not always agree with the
+    /// [`PartialOrd`] and [`PartialEq`] implementations of `f64`. For example,
+    /// they consider negative and positive zero equal, while `total_cmp`
+    /// doesn't.
+    ///
+    /// The interpretation of the signaling NaN bit follows the definition in
+    /// the IEEE 754 standard, which may not match the interpretation by some of
+    /// the older, non-conformant (e.g. MIPS) hardware implementations.
     ///
     /// # Example
+    ///
     /// ```
     /// #![feature(total_cmp)]
     /// struct GoodBoy {

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -2559,50 +2559,6 @@ impl<T> [T] {
     }
 
     /// Reorder the slice such that the element at `index` is at its final sorted position.
-    #[unstable(feature = "slice_partition_at_index", issue = "55300")]
-    #[rustc_deprecated(since = "1.49.0", reason = "use the select_nth_unstable() instead")]
-    #[inline]
-    pub fn partition_at_index(&mut self, index: usize) -> (&mut [T], &mut T, &mut [T])
-    where
-        T: Ord,
-    {
-        self.select_nth_unstable(index)
-    }
-
-    /// Reorder the slice with a comparator function such that the element at `index` is at its
-    /// final sorted position.
-    #[unstable(feature = "slice_partition_at_index", issue = "55300")]
-    #[rustc_deprecated(since = "1.49.0", reason = "use select_nth_unstable_by() instead")]
-    #[inline]
-    pub fn partition_at_index_by<F>(
-        &mut self,
-        index: usize,
-        compare: F,
-    ) -> (&mut [T], &mut T, &mut [T])
-    where
-        F: FnMut(&T, &T) -> Ordering,
-    {
-        self.select_nth_unstable_by(index, compare)
-    }
-
-    /// Reorder the slice with a key extraction function such that the element at `index` is at its
-    /// final sorted position.
-    #[unstable(feature = "slice_partition_at_index", issue = "55300")]
-    #[rustc_deprecated(since = "1.49.0", reason = "use the select_nth_unstable_by_key() instead")]
-    #[inline]
-    pub fn partition_at_index_by_key<K, F>(
-        &mut self,
-        index: usize,
-        f: F,
-    ) -> (&mut [T], &mut T, &mut [T])
-    where
-        F: FnMut(&T) -> K,
-        K: Ord,
-    {
-        self.select_nth_unstable_by_key(index, f)
-    }
-
-    /// Reorder the slice such that the element at `index` is at its final sorted position.
     ///
     /// This reordering has the additional property that any value at position `i < index` will be
     /// less than or equal to any value at a position `j > index`. Additionally, this reordering is

--- a/library/core/src/slice/sort.rs
+++ b/library/core/src/slice/sort.rs
@@ -773,7 +773,7 @@ where
                 let mid = partition_equal(v, pivot, is_less);
 
                 // Continue sorting elements greater than the pivot.
-                v = &mut { v }[mid..];
+                v = &mut v[mid..];
                 continue;
             }
         }
@@ -784,7 +784,7 @@ where
         was_partitioned = was_p;
 
         // Split the slice into `left`, `pivot`, and `right`.
-        let (left, right) = { v }.split_at_mut(mid);
+        let (left, right) = v.split_at_mut(mid);
         let (pivot, right) = right.split_at_mut(1);
         let pivot = &pivot[0];
 
@@ -860,7 +860,7 @@ fn partition_at_index_loop<'a, T, F>(
         let (mid, _) = partition(v, pivot, is_less);
 
         // Split the slice into `left`, `pivot`, and `right`.
-        let (left, right) = { v }.split_at_mut(mid);
+        let (left, right) = v.split_at_mut(mid);
         let (pivot, right) = right.split_at_mut(1);
         let pivot = &pivot[0];
 

--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -46,7 +46,6 @@
 #![feature(is_sorted)]
 #![feature(pattern)]
 #![feature(sort_internals)]
-#![feature(slice_partition_at_index)]
 #![feature(slice_take)]
 #![feature(maybe_uninit_uninit_array)]
 #![feature(maybe_uninit_array_assume_init)]

--- a/library/std/src/sys/unix/fs.rs
+++ b/library/std/src/sys/unix/fs.rs
@@ -590,7 +590,7 @@ impl DirEntry {
         target_os = "vxworks"
     ))]
     pub fn file_type(&self) -> io::Result<FileType> {
-        lstat(&self.path()).map(|m| m.file_type())
+        self.metadata().map(|m| m.file_type())
     }
 
     #[cfg(not(any(
@@ -608,7 +608,7 @@ impl DirEntry {
             libc::DT_SOCK => Ok(FileType { mode: libc::S_IFSOCK }),
             libc::DT_DIR => Ok(FileType { mode: libc::S_IFDIR }),
             libc::DT_BLK => Ok(FileType { mode: libc::S_IFBLK }),
-            _ => lstat(&self.path()).map(|m| m.file_type()),
+            _ => self.metadata().map(|m| m.file_type()),
         }
     }
 

--- a/library/std/src/time.rs
+++ b/library/std/src/time.rs
@@ -176,7 +176,12 @@ pub struct Instant(time::Instant);
 /// }
 /// ```
 ///
-/// # Underlying System calls
+/// # Platform-specific behavior
+///
+/// The precision of `SystemTime` can depend on the underlying OS-specific time format.
+/// For example, on Windows the time is represented in 100 nanosecond intervals whereas Linux
+/// can represent nanosecond intervals.
+///
 /// Currently, the following system calls are being used to get the current time using `now()`:
 ///
 /// |  Platform |               System call                                            |

--- a/src/test/ui/async-await/await-keyword/2018-edition-error-in-non-macro-position.stderr
+++ b/src/test/ui/async-await/await-keyword/2018-edition-error-in-non-macro-position.stderr
@@ -4,10 +4,10 @@ error: expected identifier, found keyword `await`
 LL |     pub mod await {
    |             ^^^^^ expected identifier, found keyword
    |
-help: you can escape reserved keywords to use them as identifiers
+help: escape `await` to use it as an identifier
    |
 LL |     pub mod r#await {
-   |             ~~~~~~~
+   |             ++
 
 error: expected identifier, found keyword `await`
   --> $DIR/2018-edition-error-in-non-macro-position.rs:7:20
@@ -15,10 +15,10 @@ error: expected identifier, found keyword `await`
 LL |         pub struct await;
    |                    ^^^^^ expected identifier, found keyword
    |
-help: you can escape reserved keywords to use them as identifiers
+help: escape `await` to use it as an identifier
    |
 LL |         pub struct r#await;
-   |                    ~~~~~~~
+   |                    ++
 
 error: expected identifier, found keyword `await`
   --> $DIR/2018-edition-error-in-non-macro-position.rs:10:22
@@ -26,10 +26,10 @@ error: expected identifier, found keyword `await`
 LL | use self::outer_mod::await::await;
    |                      ^^^^^ expected identifier, found keyword
    |
-help: you can escape reserved keywords to use them as identifiers
+help: escape `await` to use it as an identifier
    |
 LL | use self::outer_mod::r#await::await;
-   |                      ~~~~~~~
+   |                      ++
 
 error: expected identifier, found keyword `await`
   --> $DIR/2018-edition-error-in-non-macro-position.rs:10:29
@@ -37,10 +37,10 @@ error: expected identifier, found keyword `await`
 LL | use self::outer_mod::await::await;
    |                             ^^^^^ expected identifier, found keyword
    |
-help: you can escape reserved keywords to use them as identifiers
+help: escape `await` to use it as an identifier
    |
 LL | use self::outer_mod::await::r#await;
-   |                             ~~~~~~~
+   |                             ++
 
 error: expected identifier, found keyword `await`
   --> $DIR/2018-edition-error-in-non-macro-position.rs:13:14
@@ -48,10 +48,10 @@ error: expected identifier, found keyword `await`
 LL | struct Foo { await: () }
    |              ^^^^^ expected identifier, found keyword
    |
-help: you can escape reserved keywords to use them as identifiers
+help: escape `await` to use it as an identifier
    |
 LL | struct Foo { r#await: () }
-   |              ~~~~~~~
+   |              ++
 
 error: expected identifier, found keyword `await`
   --> $DIR/2018-edition-error-in-non-macro-position.rs:16:15
@@ -59,10 +59,10 @@ error: expected identifier, found keyword `await`
 LL | impl Foo { fn await() {} }
    |               ^^^^^ expected identifier, found keyword
    |
-help: you can escape reserved keywords to use them as identifiers
+help: escape `await` to use it as an identifier
    |
 LL | impl Foo { fn r#await() {} }
-   |               ~~~~~~~
+   |               ++
 
 error: expected identifier, found keyword `await`
   --> $DIR/2018-edition-error-in-non-macro-position.rs:19:14
@@ -70,10 +70,10 @@ error: expected identifier, found keyword `await`
 LL | macro_rules! await {
    |              ^^^^^ expected identifier, found keyword
    |
-help: you can escape reserved keywords to use them as identifiers
+help: escape `await` to use it as an identifier
    |
 LL | macro_rules! r#await {
-   |              ~~~~~~~
+   |              ++
 
 error: aborting due to 7 previous errors
 

--- a/src/test/ui/async-await/await-keyword/2018-edition-error.stderr
+++ b/src/test/ui/async-await/await-keyword/2018-edition-error.stderr
@@ -4,10 +4,10 @@ error: expected identifier, found keyword `await`
 LL |     pub mod await {
    |             ^^^^^ expected identifier, found keyword
    |
-help: you can escape reserved keywords to use them as identifiers
+help: escape `await` to use it as an identifier
    |
 LL |     pub mod r#await {
-   |             ~~~~~~~
+   |             ++
 
 error: expected identifier, found keyword `await`
   --> $DIR/2018-edition-error.rs:6:20
@@ -15,10 +15,10 @@ error: expected identifier, found keyword `await`
 LL |         pub struct await;
    |                    ^^^^^ expected identifier, found keyword
    |
-help: you can escape reserved keywords to use them as identifiers
+help: escape `await` to use it as an identifier
    |
 LL |         pub struct r#await;
-   |                    ~~~~~~~
+   |                    ++
 
 error: expected identifier, found keyword `await`
   --> $DIR/2018-edition-error.rs:9:22
@@ -26,10 +26,10 @@ error: expected identifier, found keyword `await`
 LL | use self::outer_mod::await::await;
    |                      ^^^^^ expected identifier, found keyword
    |
-help: you can escape reserved keywords to use them as identifiers
+help: escape `await` to use it as an identifier
    |
 LL | use self::outer_mod::r#await::await;
-   |                      ~~~~~~~
+   |                      ++
 
 error: expected identifier, found keyword `await`
   --> $DIR/2018-edition-error.rs:9:29
@@ -37,10 +37,10 @@ error: expected identifier, found keyword `await`
 LL | use self::outer_mod::await::await;
    |                             ^^^^^ expected identifier, found keyword
    |
-help: you can escape reserved keywords to use them as identifiers
+help: escape `await` to use it as an identifier
    |
 LL | use self::outer_mod::await::r#await;
-   |                             ~~~~~~~
+   |                             ++
 
 error: expected identifier, found keyword `await`
   --> $DIR/2018-edition-error.rs:12:14
@@ -48,10 +48,10 @@ error: expected identifier, found keyword `await`
 LL | macro_rules! await { () => {}; }
    |              ^^^^^ expected identifier, found keyword
    |
-help: you can escape reserved keywords to use them as identifiers
+help: escape `await` to use it as an identifier
    |
 LL | macro_rules! r#await { () => {}; }
-   |              ~~~~~~~
+   |              ++
 
 error: expected expression, found `)`
   --> $DIR/2018-edition-error.rs:15:12

--- a/src/test/ui/editions/edition-keywords-2015-2018-expansion.stderr
+++ b/src/test/ui/editions/edition-keywords-2015-2018-expansion.stderr
@@ -5,10 +5,10 @@ LL |     produces_async! {}
    |     ^^^^^^^^^^^^^^^^^^ expected identifier, found keyword
    |
    = note: this error originates in the macro `produces_async` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: you can escape reserved keywords to use them as identifiers
+help: escape `async` to use it as an identifier
    |
 LL |     () => (pub fn r#async() {})
-   |                   ~~~~~~~
+   |                   ++
 
 error: aborting due to previous error
 

--- a/src/test/ui/editions/edition-keywords-2018-2015-parsing.stderr
+++ b/src/test/ui/editions/edition-keywords-2018-2015-parsing.stderr
@@ -4,10 +4,10 @@ error: expected identifier, found keyword `async`
 LL |     let mut async = 1;
    |             ^^^^^ expected identifier, found keyword
    |
-help: you can escape reserved keywords to use them as identifiers
+help: escape `async` to use it as an identifier
    |
 LL |     let mut r#async = 1;
-   |             ~~~~~~~
+   |             ++
 
 error: expected identifier, found keyword `async`
   --> $DIR/edition-keywords-2018-2015-parsing.rs:26:13
@@ -15,10 +15,10 @@ error: expected identifier, found keyword `async`
 LL |     module::async();
    |             ^^^^^ expected identifier, found keyword
    |
-help: you can escape reserved keywords to use them as identifiers
+help: escape `async` to use it as an identifier
    |
 LL |     module::r#async();
-   |             ~~~~~~~
+   |             ++
 
 error: no rules expected the token `r#async`
   --> $DIR/edition-keywords-2018-2015-parsing.rs:20:31

--- a/src/test/ui/editions/edition-keywords-2018-2018-expansion.stderr
+++ b/src/test/ui/editions/edition-keywords-2018-2018-expansion.stderr
@@ -5,10 +5,10 @@ LL |     produces_async! {}
    |     ^^^^^^^^^^^^^^^^^^ expected identifier, found keyword
    |
    = note: this error originates in the macro `produces_async` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: you can escape reserved keywords to use them as identifiers
+help: escape `async` to use it as an identifier
    |
 LL |     () => (pub fn r#async() {})
-   |                   ~~~~~~~
+   |                   ++
 
 error: aborting due to previous error
 

--- a/src/test/ui/editions/edition-keywords-2018-2018-parsing.stderr
+++ b/src/test/ui/editions/edition-keywords-2018-2018-parsing.stderr
@@ -4,10 +4,10 @@ error: expected identifier, found keyword `async`
 LL |     let mut async = 1;
    |             ^^^^^ expected identifier, found keyword
    |
-help: you can escape reserved keywords to use them as identifiers
+help: escape `async` to use it as an identifier
    |
 LL |     let mut r#async = 1;
-   |             ~~~~~~~
+   |             ++
 
 error: expected identifier, found keyword `async`
   --> $DIR/edition-keywords-2018-2018-parsing.rs:26:13
@@ -15,10 +15,10 @@ error: expected identifier, found keyword `async`
 LL |     module::async();
    |             ^^^^^ expected identifier, found keyword
    |
-help: you can escape reserved keywords to use them as identifiers
+help: escape `async` to use it as an identifier
    |
 LL |     module::r#async();
-   |             ~~~~~~~
+   |             ++
 
 error: no rules expected the token `r#async`
   --> $DIR/edition-keywords-2018-2018-parsing.rs:20:31

--- a/src/test/ui/fmt/format-with-yield-point.rs
+++ b/src/test/ui/fmt/format-with-yield-point.rs
@@ -11,13 +11,23 @@ async fn with_await() {
     println!("{} {:?}", "", async {}.await);
 }
 
-async fn with_macro_call() {
+async fn with_macro_call_expr() {
     println!("{} {:?}", "", m!());
+}
+
+async fn with_macro_call_stmt_semi() {
+    println!("{} {:?}", "", { m!(); });
+}
+
+async fn with_macro_call_stmt_braced() {
+    println!("{} {:?}", "", { m!{} });
 }
 
 fn assert_send(_: impl Send) {}
 
 fn main() {
     assert_send(with_await());
-    assert_send(with_macro_call());
+    assert_send(with_macro_call_expr());
+    assert_send(with_macro_call_stmt_semi());
+    assert_send(with_macro_call_stmt_braced());
 }

--- a/src/test/ui/fmt/format-with-yield-point.rs
+++ b/src/test/ui/fmt/format-with-yield-point.rs
@@ -1,0 +1,23 @@
+// check-pass
+// edition:2021
+
+macro_rules! m {
+    () => {
+        async {}.await
+    };
+}
+
+async fn with_await() {
+    println!("{} {:?}", "", async {}.await);
+}
+
+async fn with_macro_call() {
+    println!("{} {:?}", "", m!());
+}
+
+fn assert_send(_: impl Send) {}
+
+fn main() {
+    assert_send(with_await());
+    assert_send(with_macro_call());
+}

--- a/src/test/ui/keyword/extern/keyword-extern-as-identifier-pat.stderr
+++ b/src/test/ui/keyword/extern/keyword-extern-as-identifier-pat.stderr
@@ -4,10 +4,10 @@ error: expected identifier, found keyword `extern`
 LL |     let extern = 0;
    |         ^^^^^^ expected identifier, found keyword
    |
-help: you can escape reserved keywords to use them as identifiers
+help: escape `extern` to use it as an identifier
    |
 LL |     let r#extern = 0;
-   |         ~~~~~~~~
+   |         ++
 
 error: aborting due to previous error
 

--- a/src/test/ui/keyword/extern/keyword-extern-as-identifier-use.stderr
+++ b/src/test/ui/keyword/extern/keyword-extern-as-identifier-use.stderr
@@ -4,10 +4,10 @@ error: expected identifier, found keyword `extern`
 LL | use extern::foo;
    |     ^^^^^^ expected identifier, found keyword
    |
-help: you can escape reserved keywords to use them as identifiers
+help: escape `extern` to use it as an identifier
    |
 LL | use r#extern::foo;
-   |     ~~~~~~~~
+   |     ++
 
 error[E0432]: unresolved import `r#extern`
   --> $DIR/keyword-extern-as-identifier-use.rs:1:5

--- a/src/test/ui/parser/bad-value-ident-false.stderr
+++ b/src/test/ui/parser/bad-value-ident-false.stderr
@@ -4,10 +4,10 @@ error: expected identifier, found keyword `false`
 LL | fn false() { }
    |    ^^^^^ expected identifier, found keyword
    |
-help: you can escape reserved keywords to use them as identifiers
+help: escape `false` to use it as an identifier
    |
 LL | fn r#false() { }
-   |    ~~~~~~~
+   |    ++
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/bad-value-ident-true.stderr
+++ b/src/test/ui/parser/bad-value-ident-true.stderr
@@ -4,10 +4,10 @@ error: expected identifier, found keyword `true`
 LL | fn true() { }
    |    ^^^^ expected identifier, found keyword
    |
-help: you can escape reserved keywords to use them as identifiers
+help: escape `true` to use it as an identifier
    |
 LL | fn r#true() { }
-   |    ~~~~~~
+   |    ++
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/issues/issue-15980.stderr
+++ b/src/test/ui/parser/issues/issue-15980.stderr
@@ -7,10 +7,10 @@ LL |
 LL |             return
    |             ^^^^^^ expected identifier, found keyword
    |
-help: you can escape reserved keywords to use them as identifiers
+help: escape `return` to use it as an identifier
    |
 LL |             r#return
-   |
+   |             ++
 
 error: expected one of `.`, `=>`, `?`, or an operator, found reserved identifier `_`
   --> $DIR/issue-15980.rs:13:9

--- a/src/test/ui/parser/issues/issue-44406.stderr
+++ b/src/test/ui/parser/issues/issue-44406.stderr
@@ -4,10 +4,10 @@ error: expected identifier, found keyword `true`
 LL |     foo!(true);
    |          ^^^^ expected identifier, found keyword
    |
-help: you can escape reserved keywords to use them as identifiers
+help: escape `true` to use it as an identifier
    |
 LL |     foo!(r#true);
-   |          ~~~~~~
+   |          ++
 
 error: invalid `struct` delimiters or `fn` call arguments
   --> $DIR/issue-44406.rs:3:9

--- a/src/test/ui/parser/issues/issue-57198.stderr
+++ b/src/test/ui/parser/issues/issue-57198.stderr
@@ -4,10 +4,10 @@ error: expected identifier, found keyword `for`
 LL |     m::for();
    |        ^^^ expected identifier, found keyword
    |
-help: you can escape reserved keywords to use them as identifiers
+help: escape `for` to use it as an identifier
    |
 LL |     m::r#for();
-   |        ~~~~~
+   |        ++
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/issues/issue-81806.stderr
+++ b/src/test/ui/parser/issues/issue-81806.stderr
@@ -8,10 +8,10 @@ LL | impl
 LL | }
    | - the item list ends here
    |
-help: you can escape reserved keywords to use them as identifiers
+help: escape `impl` to use it as an identifier
    |
 LL | r#impl
-   | ~~~~~~
+   | ++
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/keyword-abstract.stderr
+++ b/src/test/ui/parser/keyword-abstract.stderr
@@ -4,10 +4,10 @@ error: expected identifier, found reserved keyword `abstract`
 LL |     let abstract = ();
    |         ^^^^^^^^ expected identifier, found reserved keyword
    |
-help: you can escape reserved keywords to use them as identifiers
+help: escape `abstract` to use it as an identifier
    |
 LL |     let r#abstract = ();
-   |         ~~~~~~~~~~
+   |         ++
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/keyword-as-as-identifier.stderr
+++ b/src/test/ui/parser/keyword-as-as-identifier.stderr
@@ -4,10 +4,10 @@ error: expected identifier, found keyword `as`
 LL |     let as = "foo";
    |         ^^ expected identifier, found keyword
    |
-help: you can escape reserved keywords to use them as identifiers
+help: escape `as` to use it as an identifier
    |
 LL |     let r#as = "foo";
-   |         ~~~~
+   |         ++
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/keyword-break-as-identifier.stderr
+++ b/src/test/ui/parser/keyword-break-as-identifier.stderr
@@ -4,10 +4,10 @@ error: expected identifier, found keyword `break`
 LL |     let break = "foo";
    |         ^^^^^ expected identifier, found keyword
    |
-help: you can escape reserved keywords to use them as identifiers
+help: escape `break` to use it as an identifier
    |
 LL |     let r#break = "foo";
-   |         ~~~~~~~
+   |         ++
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/keyword-const-as-identifier.stderr
+++ b/src/test/ui/parser/keyword-const-as-identifier.stderr
@@ -4,10 +4,10 @@ error: expected identifier, found keyword `const`
 LL |     let const = "foo";
    |         ^^^^^ expected identifier, found keyword
    |
-help: you can escape reserved keywords to use them as identifiers
+help: escape `const` to use it as an identifier
    |
 LL |     let r#const = "foo";
-   |         ~~~~~~~
+   |         ++
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/keyword-continue-as-identifier.stderr
+++ b/src/test/ui/parser/keyword-continue-as-identifier.stderr
@@ -4,10 +4,10 @@ error: expected identifier, found keyword `continue`
 LL |     let continue = "foo";
    |         ^^^^^^^^ expected identifier, found keyword
    |
-help: you can escape reserved keywords to use them as identifiers
+help: escape `continue` to use it as an identifier
    |
 LL |     let r#continue = "foo";
-   |         ~~~~~~~~~~
+   |         ++
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/keyword-else-as-identifier.stderr
+++ b/src/test/ui/parser/keyword-else-as-identifier.stderr
@@ -4,10 +4,10 @@ error: expected identifier, found keyword `else`
 LL |     let else = "foo";
    |         ^^^^ expected identifier, found keyword
    |
-help: you can escape reserved keywords to use them as identifiers
+help: escape `else` to use it as an identifier
    |
 LL |     let r#else = "foo";
-   |         ~~~~~~
+   |         ++
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/keyword-enum-as-identifier.stderr
+++ b/src/test/ui/parser/keyword-enum-as-identifier.stderr
@@ -4,10 +4,10 @@ error: expected identifier, found keyword `enum`
 LL |     let enum = "foo";
    |         ^^^^ expected identifier, found keyword
    |
-help: you can escape reserved keywords to use them as identifiers
+help: escape `enum` to use it as an identifier
    |
 LL |     let r#enum = "foo";
-   |         ~~~~~~
+   |         ++
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/keyword-final.stderr
+++ b/src/test/ui/parser/keyword-final.stderr
@@ -4,10 +4,10 @@ error: expected identifier, found reserved keyword `final`
 LL |     let final = ();
    |         ^^^^^ expected identifier, found reserved keyword
    |
-help: you can escape reserved keywords to use them as identifiers
+help: escape `final` to use it as an identifier
    |
 LL |     let r#final = ();
-   |         ~~~~~~~
+   |         ++
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/keyword-fn-as-identifier.stderr
+++ b/src/test/ui/parser/keyword-fn-as-identifier.stderr
@@ -4,10 +4,10 @@ error: expected identifier, found keyword `fn`
 LL |     let fn = "foo";
    |         ^^ expected identifier, found keyword
    |
-help: you can escape reserved keywords to use them as identifiers
+help: escape `fn` to use it as an identifier
    |
 LL |     let r#fn = "foo";
-   |         ~~~~
+   |         ++
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/keyword-for-as-identifier.stderr
+++ b/src/test/ui/parser/keyword-for-as-identifier.stderr
@@ -4,10 +4,10 @@ error: expected identifier, found keyword `for`
 LL |     let for = "foo";
    |         ^^^ expected identifier, found keyword
    |
-help: you can escape reserved keywords to use them as identifiers
+help: escape `for` to use it as an identifier
    |
 LL |     let r#for = "foo";
-   |         ~~~~~
+   |         ++
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/keyword-if-as-identifier.stderr
+++ b/src/test/ui/parser/keyword-if-as-identifier.stderr
@@ -4,10 +4,10 @@ error: expected identifier, found keyword `if`
 LL |     let if = "foo";
    |         ^^ expected identifier, found keyword
    |
-help: you can escape reserved keywords to use them as identifiers
+help: escape `if` to use it as an identifier
    |
 LL |     let r#if = "foo";
-   |         ~~~~
+   |         ++
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/keyword-impl-as-identifier.stderr
+++ b/src/test/ui/parser/keyword-impl-as-identifier.stderr
@@ -4,10 +4,10 @@ error: expected identifier, found keyword `impl`
 LL |     let impl = "foo";
    |         ^^^^ expected identifier, found keyword
    |
-help: you can escape reserved keywords to use them as identifiers
+help: escape `impl` to use it as an identifier
    |
 LL |     let r#impl = "foo";
-   |         ~~~~~~
+   |         ++
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/keyword-let-as-identifier.stderr
+++ b/src/test/ui/parser/keyword-let-as-identifier.stderr
@@ -4,10 +4,10 @@ error: expected identifier, found keyword `let`
 LL |     let let = "foo";
    |         ^^^ expected identifier, found keyword
    |
-help: you can escape reserved keywords to use them as identifiers
+help: escape `let` to use it as an identifier
    |
 LL |     let r#let = "foo";
-   |         ~~~~~
+   |         ++
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/keyword-loop-as-identifier.stderr
+++ b/src/test/ui/parser/keyword-loop-as-identifier.stderr
@@ -4,10 +4,10 @@ error: expected identifier, found keyword `loop`
 LL |     let loop = "foo";
    |         ^^^^ expected identifier, found keyword
    |
-help: you can escape reserved keywords to use them as identifiers
+help: escape `loop` to use it as an identifier
    |
 LL |     let r#loop = "foo";
-   |         ~~~~~~
+   |         ++
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/keyword-match-as-identifier.stderr
+++ b/src/test/ui/parser/keyword-match-as-identifier.stderr
@@ -4,10 +4,10 @@ error: expected identifier, found keyword `match`
 LL |     let match = "foo";
    |         ^^^^^ expected identifier, found keyword
    |
-help: you can escape reserved keywords to use them as identifiers
+help: escape `match` to use it as an identifier
    |
 LL |     let r#match = "foo";
-   |         ~~~~~~~
+   |         ++
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/keyword-mod-as-identifier.stderr
+++ b/src/test/ui/parser/keyword-mod-as-identifier.stderr
@@ -4,10 +4,10 @@ error: expected identifier, found keyword `mod`
 LL |     let mod = "foo";
    |         ^^^ expected identifier, found keyword
    |
-help: you can escape reserved keywords to use them as identifiers
+help: escape `mod` to use it as an identifier
    |
 LL |     let r#mod = "foo";
-   |         ~~~~~
+   |         ++
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/keyword-move-as-identifier.stderr
+++ b/src/test/ui/parser/keyword-move-as-identifier.stderr
@@ -4,10 +4,10 @@ error: expected identifier, found keyword `move`
 LL |     let move = "foo";
    |         ^^^^ expected identifier, found keyword
    |
-help: you can escape reserved keywords to use them as identifiers
+help: escape `move` to use it as an identifier
    |
 LL |     let r#move = "foo";
-   |         ~~~~~~
+   |         ++
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/keyword-override.stderr
+++ b/src/test/ui/parser/keyword-override.stderr
@@ -4,10 +4,10 @@ error: expected identifier, found reserved keyword `override`
 LL |     let override = ();
    |         ^^^^^^^^ expected identifier, found reserved keyword
    |
-help: you can escape reserved keywords to use them as identifiers
+help: escape `override` to use it as an identifier
    |
 LL |     let r#override = ();
-   |         ~~~~~~~~~~
+   |         ++
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/keyword-pub-as-identifier.stderr
+++ b/src/test/ui/parser/keyword-pub-as-identifier.stderr
@@ -4,10 +4,10 @@ error: expected identifier, found keyword `pub`
 LL |     let pub = "foo";
    |         ^^^ expected identifier, found keyword
    |
-help: you can escape reserved keywords to use them as identifiers
+help: escape `pub` to use it as an identifier
    |
 LL |     let r#pub = "foo";
-   |         ~~~~~
+   |         ++
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/keyword-return-as-identifier.stderr
+++ b/src/test/ui/parser/keyword-return-as-identifier.stderr
@@ -4,10 +4,10 @@ error: expected identifier, found keyword `return`
 LL |     let return = "foo";
    |         ^^^^^^ expected identifier, found keyword
    |
-help: you can escape reserved keywords to use them as identifiers
+help: escape `return` to use it as an identifier
    |
 LL |     let r#return = "foo";
-   |         ~~~~~~~~
+   |         ++
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/keyword-static-as-identifier.stderr
+++ b/src/test/ui/parser/keyword-static-as-identifier.stderr
@@ -4,10 +4,10 @@ error: expected identifier, found keyword `static`
 LL |     let static = "foo";
    |         ^^^^^^ expected identifier, found keyword
    |
-help: you can escape reserved keywords to use them as identifiers
+help: escape `static` to use it as an identifier
    |
 LL |     let r#static = "foo";
-   |         ~~~~~~~~
+   |         ++
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/keyword-struct-as-identifier.stderr
+++ b/src/test/ui/parser/keyword-struct-as-identifier.stderr
@@ -4,10 +4,10 @@ error: expected identifier, found keyword `struct`
 LL |     let struct = "foo";
    |         ^^^^^^ expected identifier, found keyword
    |
-help: you can escape reserved keywords to use them as identifiers
+help: escape `struct` to use it as an identifier
    |
 LL |     let r#struct = "foo";
-   |         ~~~~~~~~
+   |         ++
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/keyword-trait-as-identifier.stderr
+++ b/src/test/ui/parser/keyword-trait-as-identifier.stderr
@@ -4,10 +4,10 @@ error: expected identifier, found keyword `trait`
 LL |     let trait = "foo";
    |         ^^^^^ expected identifier, found keyword
    |
-help: you can escape reserved keywords to use them as identifiers
+help: escape `trait` to use it as an identifier
    |
 LL |     let r#trait = "foo";
-   |         ~~~~~~~
+   |         ++
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/keyword-try-as-identifier-edition2018.stderr
+++ b/src/test/ui/parser/keyword-try-as-identifier-edition2018.stderr
@@ -4,10 +4,10 @@ error: expected identifier, found reserved keyword `try`
 LL |     let try = "foo";
    |         ^^^ expected identifier, found reserved keyword
    |
-help: you can escape reserved keywords to use them as identifiers
+help: escape `try` to use it as an identifier
    |
 LL |     let r#try = "foo";
-   |         ~~~~~
+   |         ++
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/keyword-type-as-identifier.stderr
+++ b/src/test/ui/parser/keyword-type-as-identifier.stderr
@@ -4,10 +4,10 @@ error: expected identifier, found keyword `type`
 LL |     let type = "foo";
    |         ^^^^ expected identifier, found keyword
    |
-help: you can escape reserved keywords to use them as identifiers
+help: escape `type` to use it as an identifier
    |
 LL |     let r#type = "foo";
-   |         ~~~~~~
+   |         ++
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/keyword-typeof.stderr
+++ b/src/test/ui/parser/keyword-typeof.stderr
@@ -4,10 +4,10 @@ error: expected identifier, found reserved keyword `typeof`
 LL |     let typeof = ();
    |         ^^^^^^ expected identifier, found reserved keyword
    |
-help: you can escape reserved keywords to use them as identifiers
+help: escape `typeof` to use it as an identifier
    |
 LL |     let r#typeof = ();
-   |         ~~~~~~~~
+   |         ++
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/keyword-unsafe-as-identifier.stderr
+++ b/src/test/ui/parser/keyword-unsafe-as-identifier.stderr
@@ -4,10 +4,10 @@ error: expected identifier, found keyword `unsafe`
 LL |     let unsafe = "foo";
    |         ^^^^^^ expected identifier, found keyword
    |
-help: you can escape reserved keywords to use them as identifiers
+help: escape `unsafe` to use it as an identifier
    |
 LL |     let r#unsafe = "foo";
-   |         ~~~~~~~~
+   |         ++
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/keyword-use-as-identifier.stderr
+++ b/src/test/ui/parser/keyword-use-as-identifier.stderr
@@ -4,10 +4,10 @@ error: expected identifier, found keyword `use`
 LL |     let use = "foo";
    |         ^^^ expected identifier, found keyword
    |
-help: you can escape reserved keywords to use them as identifiers
+help: escape `use` to use it as an identifier
    |
 LL |     let r#use = "foo";
-   |         ~~~~~
+   |         ++
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/keyword-where-as-identifier.stderr
+++ b/src/test/ui/parser/keyword-where-as-identifier.stderr
@@ -4,10 +4,10 @@ error: expected identifier, found keyword `where`
 LL |     let where = "foo";
    |         ^^^^^ expected identifier, found keyword
    |
-help: you can escape reserved keywords to use them as identifiers
+help: escape `where` to use it as an identifier
    |
 LL |     let r#where = "foo";
-   |         ~~~~~~~
+   |         ++
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/keyword-while-as-identifier.stderr
+++ b/src/test/ui/parser/keyword-while-as-identifier.stderr
@@ -4,10 +4,10 @@ error: expected identifier, found keyword `while`
 LL |     let while = "foo";
    |         ^^^^^ expected identifier, found keyword
    |
-help: you can escape reserved keywords to use them as identifiers
+help: escape `while` to use it as an identifier
    |
 LL |     let r#while = "foo";
-   |         ~~~~~~~
+   |         ++
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/keyword.stderr
+++ b/src/test/ui/parser/keyword.stderr
@@ -4,10 +4,10 @@ error: expected identifier, found keyword `break`
 LL | pub mod break {
    |         ^^^^^ expected identifier, found keyword
    |
-help: you can escape reserved keywords to use them as identifiers
+help: escape `break` to use it as an identifier
    |
 LL | pub mod r#break {
-   |         ~~~~~~~
+   |         ++
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/macro-keyword.stderr
+++ b/src/test/ui/parser/macro-keyword.stderr
@@ -4,10 +4,10 @@ error: expected identifier, found reserved keyword `macro`
 LL | fn macro() {
    |    ^^^^^ expected identifier, found reserved keyword
    |
-help: you can escape reserved keywords to use them as identifiers
+help: escape `macro` to use it as an identifier
    |
 LL | fn r#macro() {
-   |    ~~~~~~~
+   |    ++
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/mut-patterns.stderr
+++ b/src/test/ui/parser/mut-patterns.stderr
@@ -56,10 +56,10 @@ error: expected identifier, found reserved keyword `yield`
 LL |     let mut mut yield(become, await) = r#yield(0, 0);
    |                 ^^^^^ expected identifier, found reserved keyword
    |
-help: you can escape reserved keywords to use them as identifiers
+help: escape `yield` to use it as an identifier
    |
 LL |     let mut mut r#yield(become, await) = r#yield(0, 0);
-   |                 ~~~~~~~
+   |                 ++
 
 error: expected identifier, found reserved keyword `become`
   --> $DIR/mut-patterns.rs:28:23
@@ -67,10 +67,10 @@ error: expected identifier, found reserved keyword `become`
 LL |     let mut mut yield(become, await) = r#yield(0, 0);
    |                       ^^^^^^ expected identifier, found reserved keyword
    |
-help: you can escape reserved keywords to use them as identifiers
+help: escape `become` to use it as an identifier
    |
 LL |     let mut mut yield(r#become, await) = r#yield(0, 0);
-   |                       ~~~~~~~~
+   |                       ++
 
 error: expected identifier, found keyword `await`
   --> $DIR/mut-patterns.rs:28:31
@@ -78,10 +78,10 @@ error: expected identifier, found keyword `await`
 LL |     let mut mut yield(become, await) = r#yield(0, 0);
    |                               ^^^^^ expected identifier, found keyword
    |
-help: you can escape reserved keywords to use them as identifiers
+help: escape `await` to use it as an identifier
    |
 LL |     let mut mut yield(become, r#await) = r#yield(0, 0);
-   |                               ~~~~~~~
+   |                               ++
 
 error: `mut` must be attached to each individual binding
   --> $DIR/mut-patterns.rs:28:9

--- a/src/test/ui/reserved/reserved-become.stderr
+++ b/src/test/ui/reserved/reserved-become.stderr
@@ -4,10 +4,10 @@ error: expected identifier, found reserved keyword `become`
 LL |     let become = 0;
    |         ^^^^^^ expected identifier, found reserved keyword
    |
-help: you can escape reserved keywords to use them as identifiers
+help: escape `become` to use it as an identifier
    |
 LL |     let r#become = 0;
-   |         ~~~~~~~~
+   |         ++
 
 error: aborting due to previous error
 

--- a/src/test/ui/rust-2018/dyn-trait-compatibility.stderr
+++ b/src/test/ui/rust-2018/dyn-trait-compatibility.stderr
@@ -4,10 +4,10 @@ error: expected identifier, found keyword `dyn`
 LL | type A1 = dyn::dyn;
    |                ^^^ expected identifier, found keyword
    |
-help: you can escape reserved keywords to use them as identifiers
+help: escape `dyn` to use it as an identifier
    |
 LL | type A1 = dyn::r#dyn;
-   |                ~~~~~
+   |                ++
 
 error: expected identifier, found `<`
   --> $DIR/dyn-trait-compatibility.rs:5:14

--- a/src/test/ui/suggestions/raw-name-use-suggestion.stderr
+++ b/src/test/ui/suggestions/raw-name-use-suggestion.stderr
@@ -4,10 +4,10 @@ error: expected identifier, found keyword `break`
 LL |     pub fn break() {}
    |            ^^^^^ expected identifier, found keyword
    |
-help: you can escape reserved keywords to use them as identifiers
+help: escape `break` to use it as an identifier
    |
 LL |     pub fn r#break() {}
-   |            ~~~~~~~
+   |            ++
 
 error: expected identifier, found keyword `let`
   --> $DIR/raw-name-use-suggestion.rs:7:10
@@ -15,10 +15,10 @@ error: expected identifier, found keyword `let`
 LL |     foo::let();
    |          ^^^ expected identifier, found keyword
    |
-help: you can escape reserved keywords to use them as identifiers
+help: escape `let` to use it as an identifier
    |
 LL |     foo::r#let();
-   |          ~~~~~
+   |          ++
 
 error[E0425]: cannot find function `r#break` in this scope
   --> $DIR/raw-name-use-suggestion.rs:8:5


### PR DESCRIPTION
Successful merges:

 - #93395 (Improve suggestion for escaping reserved keywords)
 - #93403 (review the total_cmp documentation)
 - #93461 (Accommodate yield points in the format_args expansion)
 - #93462 (Document `SystemTime` platform precision)
 - #93471 (unix: Use metadata for `DirEntry::file_type` fallback)
 - #93480 (Remove deprecated and unstable slice_partition_at_index functions)
 - #93485 (core: Remove some redundant {}s from the sorting code)
 - #93494 (kmc-solid: Inherit the calling task's base priority in `Thread::new`)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=93395,93403,93461,93462,93471,93480,93485,93494)
<!-- homu-ignore:end -->