### PR TITLE
[rustdoc-json] Make enum tuple variants match tuple structs

### DIFF
--- a/src/etc/check_missing_items.py
+++ b/src/etc/check_missing_items.py
@@ -143,10 +143,7 @@ while work_list:
             set(item["inner"]["variants"]) | set(item["inner"]["impls"])
         ) - visited
     elif item["kind"] == "variant":
-        if item["inner"]["variant_kind"] == "tuple":
-            for ty in item["inner"]["variant_inner"]:
-                check_type(ty)
-        elif item["inner"]["variant_kind"] == "struct":
+        if item["inner"]["variant_kind"] == "struct" or item["inner"]["variant_kind"] == "tuple":
             work_list |= set(item["inner"]["variant_inner"]) - visited
     elif item["kind"] in ("function", "method"):
         check_generics(item["inner"]["generics"])

--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -602,22 +602,11 @@ impl FromWithTcx<clean::VariantStruct> for Struct {
 }
 
 impl FromWithTcx<clean::Variant> for Variant {
-    fn from_tcx(variant: clean::Variant, tcx: TyCtxt<'_>) -> Self {
+    fn from_tcx(variant: clean::Variant, _tcx: TyCtxt<'_>) -> Self {
         use clean::Variant::*;
         match variant {
             CLike => Variant::Plain,
-            Tuple(fields) => Variant::Tuple(
-                fields
-                    .into_iter()
-                    .map(|f| {
-                        if let clean::StructFieldItem(ty) = *f.kind {
-                            ty.into_tcx(tcx)
-                        } else {
-                            unreachable!()
-                        }
-                    })
-                    .collect(),
-            ),
+            Tuple(fields) => Variant::Tuple(ids(fields)),
             Struct(s) => Variant::Struct(ids(s.fields)),
         }
     }

--- a/src/rustdoc-json-types/lib.rs
+++ b/src/rustdoc-json-types/lib.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 use serde::{Deserialize, Serialize};
 
 /// rustdoc format-version.
-pub const FORMAT_VERSION: u32 = 14;
+pub const FORMAT_VERSION: u32 = 15;
 
 /// A `Crate` is the root of the emitted JSON blob. It contains all type/documentation information
 /// about the language items in the local crate, as well as info about external items to allow
@@ -277,7 +277,7 @@ pub struct Enum {
 #[serde(tag = "variant_kind", content = "variant_inner")]
 pub enum Variant {
     Plain,
-    Tuple(Vec<Type>),
+    Tuple(Vec<Id>),
     Struct(Vec<Id>),
 }
 
@@ -451,7 +451,7 @@ pub enum Type {
     Tuple(Vec<Type>),
     /// `[u32]`
     Slice(Box<Type>),
-    /// [u32; 15]
+    /// `[u32; 15]`
     Array {
         #[serde(rename = "type")]
         type_: Box<Type>,

--- a/src/test/rustdoc-json/enums/variant_tuple_struct.rs
+++ b/src/test/rustdoc-json/enums/variant_tuple_struct.rs
@@ -2,7 +2,15 @@
 // @has - "$.index[*][?(@.name=='EnumTupleStruct')].kind" \"enum\"
 pub enum EnumTupleStruct {
     // @has - "$.index[*][?(@.name=='VariantA')].inner.variant_kind" \"tuple\"
-    // @has - "$.index[*][?(@.name=='0')].kind" \"struct_field\"
-    // @has - "$.index[*][?(@.name=='1')].kind" \"struct_field\"
-    VariantA(u32, String),
+    VariantA(
+        // @set field_0 = - "$.index[*][?(@.name=='0')].id"
+        // @has - "$.index[*][?(@.name=='0')].kind" \"struct_field\"
+        u32,
+        // @set field_1 = - "$.index[*][?(@.name=='1')].id"
+        // @has - "$.index[*][?(@.name=='1')].kind" \"struct_field\"
+        String,
+    ),
 }
+
+// @has - "$.index[*][?(@.name=='VariantA')].inner.variant_inner[*]" $field_0
+// @has - "$.index[*][?(@.name=='VariantA')].inner.variant_inner[*]" $field_1


### PR DESCRIPTION
No more free-floating struct_field members without references
Fixes #92945