### PR TITLE
fix error handling for pthread_sigmask(3)

### DIFF
--- a/library/std/src/sys/unix/process/process_common/tests.rs
+++ b/library/std/src/sys/unix/process/process_common/tests.rs
@@ -3,7 +3,7 @@ use super::*;
 use crate::ffi::OsStr;
 use crate::mem;
 use crate::ptr;
-use crate::sys::cvt;
+use crate::sys::{cvt, cvt_nz};
 
 macro_rules! t {
     ($e:expr) => {
@@ -39,7 +39,7 @@ fn test_process_mask() {
         let mut old_set = mem::MaybeUninit::<libc::sigset_t>::uninit();
         t!(cvt(sigemptyset(set.as_mut_ptr())));
         t!(cvt(sigaddset(set.as_mut_ptr(), libc::SIGINT)));
-        t!(cvt(libc::pthread_sigmask(libc::SIG_SETMASK, set.as_ptr(), old_set.as_mut_ptr())));
+        t!(cvt_nz(libc::pthread_sigmask(libc::SIG_SETMASK, set.as_ptr(), old_set.as_mut_ptr())));
 
         cmd.stdin(Stdio::MakePipe);
         cmd.stdout(Stdio::MakePipe);
@@ -48,7 +48,7 @@ fn test_process_mask() {
         let stdin_write = pipes.stdin.take().unwrap();
         let stdout_read = pipes.stdout.take().unwrap();
 
-        t!(cvt(libc::pthread_sigmask(libc::SIG_SETMASK, old_set.as_ptr(), ptr::null_mut())));
+        t!(cvt_nz(libc::pthread_sigmask(libc::SIG_SETMASK, old_set.as_ptr(), ptr::null_mut())));
 
         t!(cvt(libc::kill(cat.id() as libc::pid_t, libc::SIGINT)));
         // We need to wait until SIGINT is definitely delivered. The

--- a/library/std/src/sys/unix/process/process_unix.rs
+++ b/library/std/src/sys/unix/process/process_unix.rs
@@ -279,7 +279,7 @@ impl Command {
         stdio: ChildPipes,
         maybe_envp: Option<&CStringArray>,
     ) -> Result<!, io::Error> {
-        use crate::sys::{self, cvt_r};
+        use crate::sys::{self, cvt_nz, cvt_r};
 
         if let Some(fd) = stdio.stdin.fd() {
             cvt_r(|| libc::dup2(fd, libc::STDIN_FILENO))?;
@@ -333,7 +333,7 @@ impl Command {
             // we're about to run.
             let mut set = MaybeUninit::<libc::sigset_t>::uninit();
             cvt(sigemptyset(set.as_mut_ptr()))?;
-            cvt(libc::pthread_sigmask(libc::SIG_SETMASK, set.as_ptr(), ptr::null_mut()))?;
+            cvt_nz(libc::pthread_sigmask(libc::SIG_SETMASK, set.as_ptr(), ptr::null_mut()))?;
 
             #[cfg(target_os = "android")] // see issue #88585
             {

--- a/library/std/src/sys/unix/process/process_unix.rs
+++ b/library/std/src/sys/unix/process/process_unix.rs
@@ -279,7 +279,7 @@ impl Command {
         stdio: ChildPipes,
         maybe_envp: Option<&CStringArray>,
     ) -> Result<!, io::Error> {
-        use crate::sys::{self, cvt_nz, cvt_r};
+        use crate::sys::{self, cvt_r};
 
         if let Some(fd) = stdio.stdin.fd() {
             cvt_r(|| libc::dup2(fd, libc::STDIN_FILENO))?;
@@ -324,6 +324,7 @@ impl Command {
         #[cfg(not(target_os = "emscripten"))]
         {
             use crate::mem::MaybeUninit;
+            use crate::sys::cvt_nz;
             // Reset signal handling so the child process starts in a
             // standardized state. libstd ignores SIGPIPE, and signal-handling
             // libraries often set a mask. Child processes inherit ignored


### PR DESCRIPTION
Errors from `pthread_sigmask(3)` were handled using `cvt()`, which expects a return value of `-1` on error and uses `errno`.
However, `pthread_sigmask(3)` returns `0` on success and an error number otherwise.

Fix it by replacing `cvt()` with `cvt_nz()`.