### PR TITLE
Allow source link to wrap onto next line

### DIFF
--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -1403,7 +1403,6 @@ fn render_impl(
                         "<section id=\"{}\" class=\"{}{} has-srclink\">",
                         id, item_type, in_trait_class,
                     );
-                    render_rightside(w, cx, item, containing_item, render_mode);
                     write!(w, "<a href=\"#{}\" class=\"anchor\"></a>", id);
                     w.write_str("<h4 class=\"code-header\">");
                     render_assoc_item(
@@ -1415,6 +1414,7 @@ fn render_impl(
                         render_mode,
                     );
                     w.write_str("</h4>");
+                    render_rightside(w, cx, item, containing_item, render_mode);
                     w.write_str("</section>");
                 }
             }
@@ -1426,7 +1426,6 @@ fn render_impl(
                     "<section id=\"{}\" class=\"{}{} has-srclink\">",
                     id, item_type, in_trait_class
                 );
-                render_rightside(w, cx, item, containing_item, render_mode);
                 write!(w, "<a href=\"#{}\" class=\"anchor\"></a>", id);
                 w.write_str("<h4 class=\"code-header\">");
                 assoc_const(
@@ -1443,6 +1442,7 @@ fn render_impl(
                     cx,
                 );
                 w.write_str("</h4>");
+                render_rightside(w, cx, item, containing_item, render_mode);
                 w.write_str("</section>");
             }
             clean::TyAssocTypeItem(generics, bounds) => {
@@ -1698,7 +1698,6 @@ pub(crate) fn render_impl_summary(
         format!(" data-aliases=\"{}\"", aliases.join(","))
     };
     write!(w, "<section id=\"{}\" class=\"impl has-srclink\"{}>", id, aliases);
-    render_rightside(w, cx, &i.impl_item, containing_item, RenderMode::Normal);
     write!(w, "<a href=\"#{}\" class=\"anchor\"></a>", id);
     write!(w, "<h3 class=\"code-header in-band\">");
 
@@ -1726,6 +1725,9 @@ pub(crate) fn render_impl_summary(
         write!(w, "{}", i.inner_impl().print(false, cx));
     }
     write!(w, "</h3>");
+    render_rightside(w, cx, &i.impl_item, containing_item, RenderMode::Normal);
+
+    w.write_str("</section>");
 
     let is_trait = i.inner_impl().trait_.is_some();
     if is_trait {
@@ -1733,8 +1735,6 @@ pub(crate) fn render_impl_summary(
             write!(w, "<span class=\"item-info\">{}</span>", portability);
         }
     }
-
-    w.write_str("</section>");
 }
 
 fn print_sidebar(cx: &Context<'_>, it: &clean::Item, buffer: &mut Buffer) {

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -173,8 +173,6 @@ h4.code-header {
 	border-bottom-style: none;
 	margin: 0;
 	padding: 0;
-	margin-top: 0.6em;
-	margin-bottom: 0.4em;
 }
 .impl,
 .impl-items .method,
@@ -621,7 +619,6 @@ h2.location a {
 }
 
 .method > .code-header, .trait-impl > .code-header {
-	max-width: calc(100% - 41px);
 	display: block;
 }
 
@@ -1083,20 +1080,19 @@ body.blur > :not(#help) {
 	font-size: initial;
 }
 
-.rightside {
-	padding-left: 12px;
-	padding-right: 2px;
-	position: initial;
-}
-
 .impl-items .srclink, .impl .srclink, .methods .srclink {
 	/* Override header settings otherwise it's too bold */
 	font-weight: normal;
 	font-size: 1rem;
 }
 
-.rightside {
-	float: right;
+.has-srclink {
+	display: flex;
+	flex-wrap: wrap;
+	font-size: 1rem;
+	margin-bottom: 0.75rem;
+	/* Push the src link out to the right edge consistently */
+	justify-content: space-between;
 }
 
 .variants_table {
@@ -1713,7 +1709,8 @@ details.rustdoc-toggle[open] > summary.hideme::after {
 	}
 
 	.rustdoc,
-	.main-heading {
+	.main-heading,
+	.has-srclink {
 		flex-direction: column;
 	}
 
@@ -1854,12 +1851,6 @@ details.rustdoc-toggle[open] > summary.hideme::after {
 		display: none !important;
 	}
 
-	.notable-traits {
-		position: absolute;
-		left: -22px;
-		top: 24px;
-	}
-
 	#titles > button > div.count {
 		float: left;
 		width: 100%;
@@ -1959,7 +1950,7 @@ details.rustdoc-toggle[open] > summary.hideme::after {
 
 	/* Position of the "[-]" element. */
 	details.rustdoc-toggle:not(.top-doc) > summary {
-		margin-left: 10px;
+		margin-left: 12px;
 	}
 	.impl-items > details.rustdoc-toggle > summary:not(.hideme)::before,
 	#main-content > details.rustdoc-toggle:not(.top-doc) > summary::before,

--- a/src/test/rustdoc-gui/duplicate-macro-reexport.goml
+++ b/src/test/rustdoc-gui/duplicate-macro-reexport.goml
@@ -1,7 +1,7 @@
 // This test ensures that there is no macro duplicates in the sidebar.
 goto: file://|DOC_PATH|/test_docs/macro.a.html
 // Waiting for the elements in the sidebar to be rendered.
-wait-for: ".sidebar-elems .others .macro"
+wait-for: ".sidebar-elems .macro"
 // Check there is only one macro named "a" listed in the sidebar.
 assert-count: (
     "//*[@class='sidebar-elems']//*[@class='others']/*[@class='block macro']//li/a[text()='a']",

--- a/src/test/rustdoc-gui/toggle-click-deadspace.goml
+++ b/src/test/rustdoc-gui/toggle-click-deadspace.goml
@@ -4,8 +4,6 @@ goto: file://|DOC_PATH|/lib2/struct.Foo.html
 assert-attribute: (".impl-items .rustdoc-toggle", {"open": ""})
 click: "h4.code-header" // This is the position of "pub" in "pub fn a_method"
 assert-attribute: (".impl-items .rustdoc-toggle", {"open": ""})
-click: ".impl-items .rustdoc-toggle summary::before" // This is the position of "[-]" next to that pub fn.
-assert-attribute-false: (".impl-items .rustdoc-toggle", {"open": ""})
 
 // Click the "Trait" part of "impl Trait" and verify it navigates.
 click: "#impl-Trait h3 a:first-of-type"


### PR DESCRIPTION
Like the out-of-band information at the top of the page, this uses flex-wrap: wrap to allow `source` to move to the next line when space is tight. Also, on mobile layouts move it to the next line always, for a more consistent interface.

This allows more of the method signature to be displayed on a single line, and avoids confusing `source` with one of the items in the method signature.

Also tweak the padding on summary items slightly so they line up properly with their docblock.

Remove one of the cases in toggle-click-deadspace.goml that tries to click the `[-]` toggle. It was only "working" by happenstance before, since we don't have a good way to click CSS-generated items in browser-UI-test. And that case is not the core of what's being tested in that file.

Demo: https://rustdoc.crud.net/jsha/wrap-source-link/std/string/struct.String.html

r? @GuillaumeGomez

Fixes #93477