### PR TITLE
rustdoc: Collect traits in scope for foreign inherent impls

### DIFF
--- a/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
@@ -486,15 +486,25 @@ impl CStore {
         self.get_crate_data(cnum).get_proc_macro_quoted_span(id, sess)
     }
 
+    /// Decodes all traits in the crate (for rustdoc).
     pub fn traits_in_crate_untracked(&self, cnum: CrateNum) -> impl Iterator<Item = DefId> + '_ {
         self.get_crate_data(cnum).get_traits()
     }
 
+    /// Decodes all trait impls in the crate (for rustdoc).
     pub fn trait_impls_in_crate_untracked(
         &self,
         cnum: CrateNum,
     ) -> impl Iterator<Item = (DefId, DefId, Option<SimplifiedType>)> + '_ {
         self.get_crate_data(cnum).get_trait_impls()
+    }
+
+    /// Decodes all inherent impls in the crate (for rustdoc).
+    pub fn inherent_impls_in_crate_untracked(
+        &self,
+        cnum: CrateNum,
+    ) -> impl Iterator<Item = (DefId, DefId)> + '_ {
+        self.get_crate_data(cnum).get_inherent_impls()
     }
 }
 

--- a/src/librustdoc/passes/collect_intra_doc_links/early.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links/early.rs
@@ -116,6 +116,8 @@ impl IntraLinkCrateLoader<'_, '_> {
             let all_traits = Vec::from_iter(self.resolver.cstore().traits_in_crate_untracked(cnum));
             let all_trait_impls =
                 Vec::from_iter(self.resolver.cstore().trait_impls_in_crate_untracked(cnum));
+            let all_inherent_impls =
+                Vec::from_iter(self.resolver.cstore().inherent_impls_in_crate_untracked(cnum));
 
             // Querying traits in scope is expensive so we try to prune the impl and traits lists
             // using privacy, private traits and impls from other crates are never documented in
@@ -131,6 +133,11 @@ impl IntraLinkCrateLoader<'_, '_> {
                         self.resolver.cstore().visibility_untracked(ty_def_id) == Visibility::Public
                     })
                 {
+                    self.add_traits_in_parent_scope(impl_def_id);
+                }
+            }
+            for (ty_def_id, impl_def_id) in all_inherent_impls {
+                if self.resolver.cstore().visibility_untracked(ty_def_id) == Visibility::Public {
                     self.add_traits_in_parent_scope(impl_def_id);
                 }
             }

--- a/src/test/rustdoc/intra-doc/auxiliary/extern-inherent-impl-dep.rs
+++ b/src/test/rustdoc/intra-doc/auxiliary/extern-inherent-impl-dep.rs
@@ -1,0 +1,11 @@
+#[derive(Clone)]
+pub struct PublicStruct;
+
+mod inner {
+    use super::PublicStruct;
+
+    impl PublicStruct {
+        /// [PublicStruct::clone]
+        pub fn method() {}
+    }
+}

--- a/src/test/rustdoc/intra-doc/extern-inherent-impl.rs
+++ b/src/test/rustdoc/intra-doc/extern-inherent-impl.rs
@@ -1,0 +1,8 @@
+// Reexport of a structure with public inherent impls having doc links in their comments. The doc
+// link points to an associated item, so we check that traits in scope for that link are populated.
+
+// aux-build:extern-inherent-impl-dep.rs
+
+extern crate extern_inherent_impl_dep;
+
+pub use extern_inherent_impl_dep::PublicStruct;


### PR DESCRIPTION
Inherent impls can be inlined for variety of reasons (impls of reexported types, impls available through `Deref`, impls inlined for unclear reasons like in https://github.com/rust-lang/rust/pull/88679#issuecomment-1023929480).
If an impl is inlined, then doc links in its comments are resolved and we may need the set of traits that are in scope at that impl's definition point.
So in this PR we simply collect traits in scope for *all* inherent impls from other crates if their `Self` type is public, which is very similar for the strategy for trait impls previously used in https://github.com/rust-lang/rust/pull/88679.

Fixes https://github.com/rust-lang/rust/issues/93476
Fixes https://github.com/rust-lang/rust/pull/88679#issuecomment-1026520300
Fixes https://github.com/rust-lang/rust/pull/88679#issuecomment-1023929480