### PR TITLE
rustdoc: fix colors for top buttons and search box

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -902,7 +902,6 @@ table,
 	margin-left: 0.25em;
 	padding-left: 0.3125em;
 	padding-right: 23px;
-	border: 0;
 	border-radius: 4px;
 	outline: none;
 	cursor: pointer;

--- a/src/librustdoc/html/static/css/themes/ayu.css
+++ b/src/librustdoc/html/static/css/themes/ayu.css
@@ -26,10 +26,6 @@ h4 {
 	border: none;
 }
 
-.in-band {
-	background-color: #0f1419;
-}
-
 .invisible {
 	background: rgba(0, 0, 0, 0);
 }

--- a/src/librustdoc/html/static/css/themes/ayu.css
+++ b/src/librustdoc/html/static/css/themes/ayu.css
@@ -234,14 +234,19 @@ details.undocumented > summary::before {
 	filter: invert(100%);
 }
 
-#crate-search, .search-input {
+#theme-picker, #settings-menu, #help-button,
+#crate-search, .search-input, .search-input::placeholder {
 	background-color: #141920;
 	border-color: #424c57;
-	color: #c5c5c5;
+	color: grey;
+}
+
+#crate-search {
+	color: white;
 }
 
 .search-input {
-	color: #ffffff;
+	color: white;
 }
 
 .module-item .stab,
@@ -531,14 +536,12 @@ kbd {
 	box-shadow: inset 0 -1px 0 #5c6773;
 }
 
-#theme-picker, #settings-menu, #help-button {
-	border-color: #5c6773;
-	background-color: #0f1419;
-	color: #fff;
-}
-
 #theme-picker > img, #settings-menu > img {
 	filter: invert(100);
+}
+
+.sub-container img {
+	opacity: 50%;
 }
 
 #copy-path {

--- a/src/librustdoc/html/static/css/themes/ayu.css
+++ b/src/librustdoc/html/static/css/themes/ayu.css
@@ -237,14 +237,6 @@ details.undocumented > summary::before {
 	color: grey;
 }
 
-#crate-search {
-	color: white;
-}
-
-.search-input {
-	color: white;
-}
-
 .module-item .stab,
 .import-item .stab {
 	color: #000;

--- a/src/librustdoc/html/static/css/themes/dark.css
+++ b/src/librustdoc/html/static/css/themes/dark.css
@@ -214,14 +214,23 @@ details.undocumented > summary::before {
 	filter: invert(100%);
 }
 
-#crate-search, .search-input {
-	color: #111;
-	background-color: #f0f0f0;
-	border-color: #000;
+#theme-picker, #settings-menu, #help-button,
+#crate-search, .search-input, .search-input::placeholder {
+	color: grey;
+	background-color: #353535;
+	border-color: #505050;
+}
+
+#theme-picker > img, #settings-menu > img {
+	filter: invert(50%);
+}
+
+#crate-search {
+	color: white;
 }
 
 .search-input {
-	border-color: #e0e0e0;
+	color: white;
 }
 
 .search-input:focus {
@@ -406,12 +415,6 @@ kbd {
 	border-color: #d1d5da;
 	border-bottom-color: #c6cbd1;
 	box-shadow: inset 0 -1px 0 #c6cbd1;
-}
-
-#theme-picker, #settings-menu, #help-button {
-	border-color: #e0e0e0;
-	background: #f0f0f0;
-	color: #000;
 }
 
 #theme-picker:hover, #theme-picker:focus,

--- a/src/librustdoc/html/static/css/themes/dark.css
+++ b/src/librustdoc/html/static/css/themes/dark.css
@@ -211,22 +211,14 @@ details.undocumented > summary::before {
 }
 
 #theme-picker, #settings-menu, #help-button,
-#crate-search, .search-input, .search-input::placeholder {
-	color: grey;
+#crate-search, .search-input {
+	color: white;
 	background-color: #353535;
 	border-color: #505050;
 }
 
 #theme-picker > img, #settings-menu > img {
-	filter: invert(50%);
-}
-
-#crate-search {
-	color: white;
-}
-
-.search-input {
-	color: white;
+	filter: invert(100%);
 }
 
 .search-input:focus {

--- a/src/librustdoc/html/static/css/themes/dark.css
+++ b/src/librustdoc/html/static/css/themes/dark.css
@@ -13,10 +13,6 @@ h2, h3, h4 {
 	border-bottom-color: #d2d2d2;
 }
 
-.in-band {
-	background-color: #353535;
-}
-
 .invisible {
 	background: rgba(0, 0, 0, 0);
 }

--- a/src/librustdoc/html/static/css/themes/light.css
+++ b/src/librustdoc/html/static/css/themes/light.css
@@ -211,18 +211,10 @@ details.undocumented > summary::before {
 }
 
 #theme-picker, #settings-menu, #help-button,
-#crate-search, .search-input, .search-input::placeholder {
-	color: grey;
+#crate-search, .search-input {
+	color: black;
 	background-color: white;
 	border-color: #e0e0e0;
-}
-
-#crate-search {
-	color: black;
-}
-
-.sub-container img {
-	opacity: 50%;
 }
 
 .search-input:focus {

--- a/src/librustdoc/html/static/css/themes/light.css
+++ b/src/librustdoc/html/static/css/themes/light.css
@@ -208,10 +208,25 @@ details.undocumented > summary::before {
 	color: #999;
 }
 
-#crate-search, .search-input {
-	color: #555;
+#theme-picker:hover, #theme-picker:focus,
+#settings-menu:hover, #settings-menu:focus,
+#help-button:hover, #help-button:focus {
+	border-color: #717171;
+}
+
+#theme-picker, #settings-menu, #help-button,
+#crate-search, .search-input, .search-input::placeholder {
+	color: grey;
 	background-color: white;
 	border-color: #e0e0e0;
+}
+
+#crate-search {
+	color: black;
+}
+
+.sub-container img {
+	opacity: 50%;
 }
 
 .search-input:focus {
@@ -392,17 +407,6 @@ kbd {
 	border-color: #d1d5da;
 	border-bottom-color: #c6cbd1;
 	box-shadow: inset 0 -1px 0 #c6cbd1;
-}
-
-#theme-picker, #settings-menu, #help-button {
-	border-color: #e0e0e0;
-	background-color: #fff;
-}
-
-#theme-picker:hover, #theme-picker:focus,
-#settings-menu:hover, #settings-menu:focus,
-#help-button:hover, #help-button:focus {
-	border-color: #717171;
 }
 
 #copy-path {

--- a/src/librustdoc/html/static/css/themes/light.css
+++ b/src/librustdoc/html/static/css/themes/light.css
@@ -15,10 +15,6 @@ h2, h3, h4 {
 	border-bottom-color: #DDDDDD;
 }
 
-.in-band {
-	background-color: white;
-}
-
 .invisible {
 	background: rgba(0, 0, 0, 0);
 }

--- a/src/test/rustdoc-gui/headers-color.goml
+++ b/src/test/rustdoc-gui/headers-color.goml
@@ -19,9 +19,12 @@ assert-css: (
 )
 assert-css: (
     ".impl .code-header",
-    {"color": "rgb(230, 225, 207)", "background-color": "rgb(15, 20, 25)"},
+    {"color": "rgb(230, 225, 207)", "background-color": "rgba(0, 0, 0, 0)"},
     ALL,
 )
+
+compare-elements-css: ("#settings-menu", "#help-button", ["border-color", "background-color", "color"])
+compare-elements-css: ("#settings-menu", ".search-input", ["border-color", "color"])
 
 goto: file://|DOC_PATH|/test_docs/struct.Foo.html#impl
 assert-css: (
@@ -58,7 +61,7 @@ assert-css: (
 )
 assert-css: (
     ".impl .code-header",
-    {"color": "rgb(221, 221, 221)", "background-color": "rgb(53, 53, 53)"},
+    {"color": "rgb(221, 221, 221)", "background-color": "rgba(0, 0, 0, 0)"},
     ALL,
 )
 
@@ -74,6 +77,9 @@ assert-css: (
     {"color": "rgb(221, 221, 221)", "background-color": "rgb(73, 74, 61)"},
     ALL,
 )
+
+compare-elements-css: ("#settings-menu", "#help-button", ["border-color", "background-color", "color"])
+compare-elements-css: ("#settings-menu", ".search-input", ["border-color", "color"])
 
 goto: file://|DOC_PATH|/test_docs/index.html
 assert-css: (".small-section-header a", {"color": "rgb(221, 221, 221)"}, ALL)
@@ -95,9 +101,12 @@ assert-css: (
 )
 assert-css: (
     ".impl .code-header",
-    {"color": "rgb(0, 0, 0)", "background-color": "rgb(255, 255, 255)"},
+    {"color": "rgb(0, 0, 0)", "background-color": "rgba(0, 0, 0, 0)"},
     ALL,
 )
+
+compare-elements-css: ("#settings-menu", "#help-button", ["border-color", "background-color", "color"])
+compare-elements-css: ("#settings-menu", ".search-input", ["border-color", "color"])
 
 goto: file://|DOC_PATH|/test_docs/struct.Foo.html#impl
 assert-css: ("#impl", {"color": "rgb(0, 0, 0)", "background-color": "rgb(253, 255, 211)"})


### PR DESCRIPTION
Previously these had a lighter border than the search box.

Before:

<img width=100 src="https://user-images.githubusercontent.com/220205/151940365-badf820b-a184-46b5-8b63-e6e33ac8ebd6.png">

After:

<img width=100 src="https://user-images.githubusercontent.com/220205/153373083-7da65717-3f2f-4313-9b3b-138e6d06d498.png">

Also, remove background-color on .in-band

This was overwriting the style for :target on impl headings. Instead of showing the whole summary of a :target'ed heading as yellow (on light theme), it would show the summary as white.

Before:

![image](https://user-images.githubusercontent.com/220205/151942427-ec3f2493-615a-44ef-8b9a-fddcc7dfa837.png)

After:

![image](https://user-images.githubusercontent.com/220205/151942625-730e97c3-4705-4b2c-b905-828f91cbbbc0.png)

Demo: https://rustdoc.crud.net/jsha/ayu-border-color/std/string/trait.ToString.html