### PR TITLE
Debug-format fat pointers with their metadata for better insight

### DIFF
--- a/library/core/src/fmt/mod.rs
+++ b/library/core/src/fmt/mod.rs
@@ -6,6 +6,7 @@ use crate::cell::{Cell, Ref, RefCell, RefMut, UnsafeCell};
 use crate::char::EscapeDebugExtArgs;
 use crate::marker::PhantomData;
 use crate::mem;
+use crate::ptr::{self, DynMetadata};
 use crate::num::fmt as numfmt;
 use crate::ops::Deref;
 use crate::result;
@@ -2281,16 +2282,51 @@ impl<T: ?Sized> Pointer for &mut T {
 
 // Implementation of Display/Debug for various core types
 
+/// A local trait for pointer Debug impl so that we can have
+/// min_specialization-compliant specializations for two types of fat ptrs.
+trait PtrMetadataFmt {
+    fn fmt_ptr(&self, ptr: *const (), f: &mut Formatter<'_>) -> Result;
+}
+
+// Regular pointer / default impl
+impl<T> PtrMetadataFmt for T {
+    #[inline]
+    default fn fmt_ptr(&self, ptr: *const (), f: &mut Formatter<'_>) -> Result {
+        Pointer::fmt(&ptr, f)
+    }
+}
+
+// Pointer + length
+impl PtrMetadataFmt for usize {
+    #[inline]
+    fn fmt_ptr(&self, ptr: *const (), f: &mut Formatter<'_>) -> Result {
+        write!(f, "({:p}, {})", ptr, *self)
+    }
+}
+
+// Pointer + vtable
+impl<Dyn: ?Sized> PtrMetadataFmt for DynMetadata<Dyn> {
+    #[inline]
+    fn fmt_ptr(&self, ptr: *const (), f: &mut Formatter<'_>) -> Result {
+        f.debug_tuple("")
+            .field(&ptr)
+            .field(self)
+            .finish()
+   }
+}
+
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: ?Sized> Debug for *const T {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        Pointer::fmt(self, f)
+        let meta = ptr::metadata(*self);
+        meta.fmt_ptr(*self as *const (), f)
     }
 }
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: ?Sized> Debug for *mut T {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        Pointer::fmt(self, f)
+        let ptr: *const T = *self;
+        Debug::fmt(&ptr, f)
     }
 }
 


### PR DESCRIPTION
New iteration of #84927 (since I can no longer reopen that one).

Basically, add metadata via `ptr::metadata()` to debug prints of fat pointers (ie. to slices and trait objects).
Thin ptr debug format as well as _all_ `{:p}` should be unadffected.

Example prints:
```
(0x56486780e7e3, 5)                            // pointer to a slice
0x7f0abc000d20, DynMetadata(0x564ef9f9e938))   // pointer to a trait object
```

This time I managed to leverage specialization instead of `size_of` shennanigans.

Blocked on #81513