### PR TITLE
Add missing | between print options

### DIFF
--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -1188,7 +1188,7 @@ pub fn rustc_short_optgroups() -> Vec<RustcOptGroup> {
             "Compiler information to print on stdout",
             "[crate-name|file-names|sysroot|target-libdir|cfg|target-list|\
              target-cpus|target-features|relocation-models|code-models|\
-             tls-models|target-spec-json|native-static-libs|stack-protector-strategies\
+             tls-models|target-spec-json|native-static-libs|stack-protector-strategies|\
              link-args]",
         ),
         opt::flagmulti_s("g", "", "Equivalent to -C debuginfo=2"),


### PR DESCRIPTION
The help text for the newly stabilized print option is missing a | between stack-protector-strategies and link-args.