### PR TITLE
impl Try for ExitStatus

### DIFF
--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -300,6 +300,7 @@
 #![feature(thin_box)]
 #![feature(toowned_clone_into)]
 #![feature(try_reserve_kind)]
+#![feature(try_trait_v2)]
 #![feature(vec_into_raw_parts)]
 //
 // Library features (unwind):


### PR DESCRIPTION
I figured I could take a stab at issue #54889,

Currently just sys/unix is implemented,
More work needs to be done with testing and platforms which I don't have access to.

But given that i've not done much coding in libstd, and this is a bit roundabout with `imp::process` calling `crate::process`,
in a call from `crate::process` calling `imp::`...

Along with the `from_output` where we need to materialize an imp::ExitStatus out of `()`, I figured it'd be good to get some feedback early if possible.

Thanks