### PR TITLE
Include all contents of first line of scraped item in Rustdoc

### DIFF
--- a/src/librustdoc/scrape_examples.rs
+++ b/src/librustdoc/scrape_examples.rs
@@ -196,7 +196,8 @@ where
                 return;
             }
 
-            let file = tcx.sess.source_map().lookup_char_pos(span.lo()).file;
+            let source_map = tcx.sess.source_map();
+            let file = source_map.lookup_char_pos(span.lo()).file;
             let file_path = match file.name.clone() {
                 FileName::Real(real_filename) => real_filename.into_local_path(),
                 _ => None,
@@ -217,6 +218,8 @@ where
                 let fn_entries = self.calls.entry(fn_key).or_default();
 
                 trace!("Including expr: {:?}", span);
+                let enclosing_item_span =
+                    source_map.span_extend_to_prev_char(enclosing_item_span, '\n', false);
                 let location = CallLocation::new(span, enclosing_item_span, &file);
                 fn_entries.entry(abs_path).or_insert_with(mk_call_data).locations.push(location);
             }

--- a/src/test/run-make/rustdoc-scrape-examples-whitespace/Makefile
+++ b/src/test/run-make/rustdoc-scrape-examples-whitespace/Makefile
@@ -1,0 +1,5 @@
+deps := ex
+
+-include ../rustdoc-scrape-examples-multiple/scrape.mk
+
+all: scrape

--- a/src/test/run-make/rustdoc-scrape-examples-whitespace/examples/ex.rs
+++ b/src/test/run-make/rustdoc-scrape-examples-whitespace/examples/ex.rs
@@ -1,0 +1,8 @@
+struct Foo;
+impl Foo {
+  fn bar() { foobar::ok(); }
+}
+
+fn main() {
+  Foo::bar();
+}

--- a/src/test/run-make/rustdoc-scrape-examples-whitespace/src/lib.rs
+++ b/src/test/run-make/rustdoc-scrape-examples-whitespace/src/lib.rs
@@ -1,0 +1,3 @@
+// @has foobar/fn.ok.html '//*[@class="docblock scraped-example-list"]//code' '  '
+
+pub fn ok() {}


### PR DESCRIPTION
This fixes #93528. When scraping examples, it extends the span of the enclosing item to include all characters up to the start of the first line of the span.

r? @camelid 