### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -1642,7 +1642,7 @@ pub enum FakeReadCause {
     ForMatchedPlace(Option<DefId>),
 
     /// A fake read of the RefWithinGuard version of a bind-by-value variable
-    /// in a match guard to ensure that it's value hasn't change by the time
+    /// in a match guard to ensure that its value hasn't change by the time
     /// we create the OutsideGuard version.
     ForGuardBinding,
 
@@ -2939,7 +2939,7 @@ impl Location {
         let mut visited = FxHashSet::default();
 
         while let Some(block) = queue.pop() {
-            // If we haven't visited this block before, then make sure we visit it's predecessors.
+            // If we haven't visited this block before, then make sure we visit its predecessors.
             if visited.insert(block) {
                 queue.extend(predecessors[block].iter().cloned());
             } else {

--- a/compiler/rustc_passes/src/entry.rs
+++ b/compiler/rustc_passes/src/entry.rs
@@ -218,9 +218,9 @@ fn no_main_err(tcx: TyCtxt<'_>, visitor: &EntryContext<'_, '_>) {
     // The file may be empty, which leads to the diagnostic machinery not emitting this
     // note. This is a relatively simple way to detect that case and emit a span-less
     // note instead.
-    if tcx.sess.source_map().lookup_line(sp.lo()).is_ok() {
-        err.set_span(sp);
-        err.span_label(sp, &note);
+    if tcx.sess.source_map().lookup_line(sp.hi()).is_ok() {
+        err.set_span(sp.shrink_to_hi());
+        err.span_label(sp.shrink_to_hi(), &note);
     } else {
         err.note(&note);
     }

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -1188,7 +1188,7 @@ pub fn rustc_short_optgroups() -> Vec<RustcOptGroup> {
             "Compiler information to print on stdout",
             "[crate-name|file-names|sysroot|target-libdir|cfg|target-list|\
              target-cpus|target-features|relocation-models|code-models|\
-             tls-models|target-spec-json|native-static-libs|stack-protector-strategies\
+             tls-models|target-spec-json|native-static-libs|stack-protector-strategies|\
              link-args]",
         ),
         opt::flagmulti_s("g", "", "Equivalent to -C debuginfo=2"),

--- a/library/core/src/primitive_docs.rs
+++ b/library/core/src/primitive_docs.rs
@@ -275,6 +275,7 @@ mod prim_bool {}
 mod prim_never {}
 
 #[doc(primitive = "char")]
+#[allow(rustdoc::invalid_rust_codeblocks)]
 /// A character type.
 ///
 /// The `char` type represents a single character. More specifically, since
@@ -295,7 +296,7 @@ mod prim_never {}
 /// No `char` may be constructed, whether as a literal or at runtime, that is not a
 /// Unicode scalar value:
 ///
-/// ```text
+/// ```compile_fail
 /// // Each of these is a compiler error
 /// ['\u{D800}', '\u{DFFF}', '\u{110000}'];
 /// ```
@@ -305,7 +306,7 @@ mod prim_never {}
 /// char::from_u32(0xDE01).unwrap();
 /// ```
 ///
-/// ```
+/// ```no_run
 /// // Undefined behaviour
 /// unsafe { char::from_u32_unchecked(0x110000) };
 /// ```

--- a/library/core/src/primitive_docs.rs
+++ b/library/core/src/primitive_docs.rs
@@ -289,32 +289,52 @@ mod prim_never {}
 ///
 /// A `char` is a '[Unicode scalar value]', which is any '[Unicode code point]'
 /// other than a [surrogate code point]. This has a fixed numerical definition:
-/// code points are in the range `'\0'` to `char::MAX` (`'\u{10FFFF}'`), inclusive.
-/// Surrogate code points, used by UTF-16, are in the range U+D800 to U+DFFF.
+/// code points are in the range 0 to 0x10FFFF, inclusive.
+/// Surrogate code points, used by UTF-16, are in the range 0xD800 to 0xDFFF.
 ///
 /// No `char` may be constructed, whether as a literal or at runtime, that is not a
 /// Unicode scalar value:
 ///
 /// ```text
-/// let forbidden_chars = [
-///     // Each of these is a compiler error
-///     '\u{D800}', '\u{DFFF}', '\u{110000}',
-///
-///     // Panics; from_u32 returns None.
-///     char::from_u32(0xDE01).unwrap(),
-///
-///     // Undefined behaviour
-///     unsafe { char::from_u32_unchecked(0x110000) },
-/// ];
+/// // Each of these is a compiler error
+/// ['\u{D800}', '\u{DFFF}', '\u{110000}'];
 /// ```
 ///
-/// Unicode is regularly updated. Many USVs are not currently assigned to a
-/// character, but may be in the future ("reserved"); some will never be a character
-/// ("noncharacters"); and some may be given different meanings by different users
-/// ("private use").
+/// ```should_panic
+/// // Panics; from_u32 returns None.
+/// char::from_u32(0xDE01).unwrap();
+/// ```
 ///
-/// [Unicode scalar value]: https://www.unicode.org/glossary/#unicode_scalar_value
+/// ```
+/// // Undefined behaviour
+/// unsafe { char::from_u32_unchecked(0x110000) };
+/// ```
+///
+/// USVs are also the exact set of values that may be encoded in UTF-8. Because
+/// `char` values are USVs and `str` values are valid UTF-8, it is safe to store
+/// any `char` in a `str` or read any character from a `str` as a `char`.
+///
+/// The gap in valid `char` values is understood by the compiler, so in the
+/// below example the two ranges are understood to cover the whole range of
+/// possible `char` values and there is no error for a [non-exhaustive match].
+///
+/// ```
+/// let c: char = 'a';
+/// match c {
+///     '\0' ..= '\u{D7FF}' => false,
+///     '\u{E000}' ..= '\u{10FFFF}' => true,
+/// };
+/// ```
+///
+/// All USVs are valid `char` values, but not all of them represent a real
+/// character. Many USVs are not currently assigned to a character, but may be
+/// in the future ("reserved"); some will never be a character
+/// ("noncharacters"); and some may be given different meanings by different
+/// users ("private use").
+///
 /// [Unicode code point]: https://www.unicode.org/glossary/#code_point
+/// [Unicode scalar value]: https://www.unicode.org/glossary/#unicode_scalar_value
+/// [non-exhaustive match]: ../book/ch06-02-match.html#matches-are-exhaustive
 /// [surrogate code point]: https://www.unicode.org/glossary/#surrogate_code_point
 ///
 /// # Representation

--- a/library/core/src/primitive_docs.rs
+++ b/library/core/src/primitive_docs.rs
@@ -279,15 +279,43 @@ mod prim_never {}
 ///
 /// The `char` type represents a single character. More specifically, since
 /// 'character' isn't a well-defined concept in Unicode, `char` is a '[Unicode
-/// scalar value]', which is similar to, but not the same as, a '[Unicode code
-/// point]'.
-///
-/// [Unicode scalar value]: https://www.unicode.org/glossary/#unicode_scalar_value
-/// [Unicode code point]: https://www.unicode.org/glossary/#code_point
+/// scalar value]'.
 ///
 /// This documentation describes a number of methods and trait implementations on the
 /// `char` type. For technical reasons, there is additional, separate
 /// documentation in [the `std::char` module](char/index.html) as well.
+///
+/// # Validity
+///
+/// A `char` is a '[Unicode scalar value]', which is any '[Unicode code point]'
+/// other than a [surrogate code point]. This has a fixed numerical definition:
+/// code points are in the range `'\0'` to `char::MAX` (`'\u{10FFFF}'`), inclusive.
+/// Surrogate code points, used by UTF-16, are in the range U+D800 to U+DFFF.
+///
+/// No `char` may be constructed, whether as a literal or at runtime, that is not a
+/// Unicode scalar value:
+///
+/// ```text
+/// let forbidden_chars = [
+///     // Each of these is a compiler error
+///     '\u{D800}', '\u{DFFF}', '\u{110000}',
+///
+///     // Panics; from_u32 returns None.
+///     char::from_u32(0xDE01).unwrap(),
+///
+///     // Undefined behaviour
+///     unsafe { char::from_u32_unchecked(0x110000) },
+/// ];
+/// ```
+///
+/// Unicode is regularly updated. Many USVs are not currently assigned to a
+/// character, but may be in the future ("reserved"); some will never be a character
+/// ("noncharacters"); and some may be given different meanings by different users
+/// ("private use").
+///
+/// [Unicode scalar value]: https://www.unicode.org/glossary/#unicode_scalar_value
+/// [Unicode code point]: https://www.unicode.org/glossary/#code_point
+/// [surrogate code point]: https://www.unicode.org/glossary/#surrogate_code_point
 ///
 /// # Representation
 ///

--- a/library/std/src/net/tcp.rs
+++ b/library/std/src/net/tcp.rs
@@ -405,7 +405,7 @@ impl TcpStream {
     /// use std::net::TcpStream;
     ///
     /// let stream = TcpStream::connect("127.0.0.1:8000")
-    ///                        .expect("couldn't bind to address");
+    ///                        .expect("Couldn't connect to the server...");
     /// let mut buf = [0; 10];
     /// let len = stream.peek(&mut buf).expect("peek failed");
     /// ```

--- a/library/std/src/primitive_docs.rs
+++ b/library/std/src/primitive_docs.rs
@@ -275,6 +275,7 @@ mod prim_bool {}
 mod prim_never {}
 
 #[doc(primitive = "char")]
+#[allow(rustdoc::invalid_rust_codeblocks)]
 /// A character type.
 ///
 /// The `char` type represents a single character. More specifically, since
@@ -295,7 +296,7 @@ mod prim_never {}
 /// No `char` may be constructed, whether as a literal or at runtime, that is not a
 /// Unicode scalar value:
 ///
-/// ```text
+/// ```compile_fail
 /// // Each of these is a compiler error
 /// ['\u{D800}', '\u{DFFF}', '\u{110000}'];
 /// ```
@@ -305,7 +306,7 @@ mod prim_never {}
 /// char::from_u32(0xDE01).unwrap();
 /// ```
 ///
-/// ```
+/// ```no_run
 /// // Undefined behaviour
 /// unsafe { char::from_u32_unchecked(0x110000) };
 /// ```

--- a/library/std/src/primitive_docs.rs
+++ b/library/std/src/primitive_docs.rs
@@ -289,32 +289,52 @@ mod prim_never {}
 ///
 /// A `char` is a '[Unicode scalar value]', which is any '[Unicode code point]'
 /// other than a [surrogate code point]. This has a fixed numerical definition:
-/// code points are in the range `'\0'` to `char::MAX` (`'\u{10FFFF}'`), inclusive.
-/// Surrogate code points, used by UTF-16, are in the range U+D800 to U+DFFF.
+/// code points are in the range 0 to 0x10FFFF, inclusive.
+/// Surrogate code points, used by UTF-16, are in the range 0xD800 to 0xDFFF.
 ///
 /// No `char` may be constructed, whether as a literal or at runtime, that is not a
 /// Unicode scalar value:
 ///
 /// ```text
-/// let forbidden_chars = [
-///     // Each of these is a compiler error
-///     '\u{D800}', '\u{DFFF}', '\u{110000}',
-///
-///     // Panics; from_u32 returns None.
-///     char::from_u32(0xDE01).unwrap(),
-///
-///     // Undefined behaviour
-///     unsafe { char::from_u32_unchecked(0x110000) },
-/// ];
+/// // Each of these is a compiler error
+/// ['\u{D800}', '\u{DFFF}', '\u{110000}'];
 /// ```
 ///
-/// Unicode is regularly updated. Many USVs are not currently assigned to a
-/// character, but may be in the future ("reserved"); some will never be a character
-/// ("noncharacters"); and some may be given different meanings by different users
-/// ("private use").
+/// ```should_panic
+/// // Panics; from_u32 returns None.
+/// char::from_u32(0xDE01).unwrap();
+/// ```
 ///
-/// [Unicode scalar value]: https://www.unicode.org/glossary/#unicode_scalar_value
+/// ```
+/// // Undefined behaviour
+/// unsafe { char::from_u32_unchecked(0x110000) };
+/// ```
+///
+/// USVs are also the exact set of values that may be encoded in UTF-8. Because
+/// `char` values are USVs and `str` values are valid UTF-8, it is safe to store
+/// any `char` in a `str` or read any character from a `str` as a `char`.
+///
+/// The gap in valid `char` values is understood by the compiler, so in the
+/// below example the two ranges are understood to cover the whole range of
+/// possible `char` values and there is no error for a [non-exhaustive match].
+///
+/// ```
+/// let c: char = 'a';
+/// match c {
+///     '\0' ..= '\u{D7FF}' => false,
+///     '\u{E000}' ..= '\u{10FFFF}' => true,
+/// };
+/// ```
+///
+/// All USVs are valid `char` values, but not all of them represent a real
+/// character. Many USVs are not currently assigned to a character, but may be
+/// in the future ("reserved"); some will never be a character
+/// ("noncharacters"); and some may be given different meanings by different
+/// users ("private use").
+///
 /// [Unicode code point]: https://www.unicode.org/glossary/#code_point
+/// [Unicode scalar value]: https://www.unicode.org/glossary/#unicode_scalar_value
+/// [non-exhaustive match]: ../book/ch06-02-match.html#matches-are-exhaustive
 /// [surrogate code point]: https://www.unicode.org/glossary/#surrogate_code_point
 ///
 /// # Representation

--- a/library/std/src/primitive_docs.rs
+++ b/library/std/src/primitive_docs.rs
@@ -279,15 +279,43 @@ mod prim_never {}
 ///
 /// The `char` type represents a single character. More specifically, since
 /// 'character' isn't a well-defined concept in Unicode, `char` is a '[Unicode
-/// scalar value]', which is similar to, but not the same as, a '[Unicode code
-/// point]'.
-///
-/// [Unicode scalar value]: https://www.unicode.org/glossary/#unicode_scalar_value
-/// [Unicode code point]: https://www.unicode.org/glossary/#code_point
+/// scalar value]'.
 ///
 /// This documentation describes a number of methods and trait implementations on the
 /// `char` type. For technical reasons, there is additional, separate
 /// documentation in [the `std::char` module](char/index.html) as well.
+///
+/// # Validity
+///
+/// A `char` is a '[Unicode scalar value]', which is any '[Unicode code point]'
+/// other than a [surrogate code point]. This has a fixed numerical definition:
+/// code points are in the range `'\0'` to `char::MAX` (`'\u{10FFFF}'`), inclusive.
+/// Surrogate code points, used by UTF-16, are in the range U+D800 to U+DFFF.
+///
+/// No `char` may be constructed, whether as a literal or at runtime, that is not a
+/// Unicode scalar value:
+///
+/// ```text
+/// let forbidden_chars = [
+///     // Each of these is a compiler error
+///     '\u{D800}', '\u{DFFF}', '\u{110000}',
+///
+///     // Panics; from_u32 returns None.
+///     char::from_u32(0xDE01).unwrap(),
+///
+///     // Undefined behaviour
+///     unsafe { char::from_u32_unchecked(0x110000) },
+/// ];
+/// ```
+///
+/// Unicode is regularly updated. Many USVs are not currently assigned to a
+/// character, but may be in the future ("reserved"); some will never be a character
+/// ("noncharacters"); and some may be given different meanings by different users
+/// ("private use").
+///
+/// [Unicode scalar value]: https://www.unicode.org/glossary/#unicode_scalar_value
+/// [Unicode code point]: https://www.unicode.org/glossary/#code_point
+/// [surrogate code point]: https://www.unicode.org/glossary/#surrogate_code_point
 ///
 /// # Representation
 ///

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -64,6 +64,12 @@ crate struct Buffer {
     buffer: String,
 }
 
+impl core::fmt::Write for Buffer {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        self.buffer.write_str(s)
+    }
+}
+
 impl Buffer {
     crate fn empty_from(v: &Buffer) -> Buffer {
         Buffer { for_html: v.for_html, buffer: String::new() }

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -65,8 +65,19 @@ crate struct Buffer {
 }
 
 impl core::fmt::Write for Buffer {
+    #[inline]
     fn write_str(&mut self, s: &str) -> fmt::Result {
         self.buffer.write_str(s)
+    }
+
+    #[inline]
+    fn write_char(&mut self, c: char) -> fmt::Result {
+        self.buffer.write_char(c)
+    }
+
+    #[inline]
+    fn write_fmt(self: &mut Self, args: fmt::Arguments<'_>) -> fmt::Result {
+        self.buffer.write_fmt(args)
     }
 }
 

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -376,7 +376,7 @@ impl Setting {
                 description,
             ),
             Setting::Select { js_data_name, description, default_value, ref options } => format!(
-                "<div class=\"setting-line\"><div class=\"radio-line\" id=\"{}\"><span class=\"setting-name\">{}</span>{}</div></div>",
+                "<div class=\"setting-line\"><div class=\"radio-line\" id=\"{}\"><span class=\"setting-name\">{}</span><div class=\"choices\">{}</div></div></div>",
                 js_data_name,
                 description,
                 options

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -139,8 +139,7 @@ pub(super) fn print_item(cx: &Context<'_>, item: &clean::Item, buf: &mut Buffer,
         src_href: src_href.as_deref(),
     };
 
-    let heading = item_vars.render().unwrap();
-    buf.write_str(&heading);
+    item_vars.render_into(buf).unwrap();
 
     match *item.kind {
         clean::ModuleItem(ref m) => item_module(buf, cx, item, &m.items),

--- a/src/librustdoc/html/static/css/settings.css
+++ b/src/librustdoc/html/static/css/settings.css
@@ -1,5 +1,5 @@
 .setting-line {
-	padding: 5px;
+	margin: 0.6em 0 0.6em 0.3em;
 	position: relative;
 }
 
@@ -17,17 +17,16 @@
 	border-bottom: 1px solid;
 }
 
-.setting-line .radio-line {
+.setting-line .radio-line,
+.setting-line .choices {
 	display: flex;
 	flex-wrap: wrap;
 }
 
-.setting-line .radio-line > * {
-	padding: 0.3em;
-}
-
 .setting-line .radio-line .setting-name {
 	flex-grow: 1;
+	margin-top: auto;
+	margin-bottom: auto;
 }
 
 .setting-line .radio-line input {
@@ -38,7 +37,10 @@
 	border-radius: 0.1em;
 	border: 1px solid;
 	margin-left: 0.5em;
-	min-width: 3.5em;
+	margin-top: 0.1em;
+	margin-bottom: 0.1em;
+	min-width: 3.8em;
+	padding: 0.3em;
 }
 
 .toggle {

--- a/src/test/rustdoc-gui/mobile.goml
+++ b/src/test/rustdoc-gui/mobile.goml
@@ -15,3 +15,9 @@ assert-css: (".content .out-of-band .since::before", { "content": "\"Since \"" }
 
 size: (1000, 1000)
 assert-css-false: (".content .out-of-band .since::before", { "content": "\"Since \"" })
+
+// On the settings page, the theme buttons should not line-wrap. Instead, they should
+// all be placed as a group on a line below the setting name "Theme."
+goto: file://|DOC_PATH|/settings.html
+size: (400, 600)
+compare-elements-position-near-false: ("#preferred-light-theme .setting-name", "#preferred-light-theme .choice", {"y": 16})

--- a/src/test/ui/attributes/issue-90873.rs
+++ b/src/test/ui/attributes/issue-90873.rs
@@ -1,9 +1,9 @@
 #![u=||{static d=||1;}]
 //~^ unexpected token
 //~| cannot find attribute `u` in this scope
-//~| `main` function not found in crate `issue_90873`
 //~| missing type for `static` item
 
 #![a={impl std::ops::Neg for i8 {}}]
 //~^ ERROR unexpected token
 //~| ERROR cannot find attribute `a` in this scope
+//~| ERROR `main` function not found in crate `issue_90873`

--- a/src/test/ui/attributes/issue-90873.stderr
+++ b/src/test/ui/attributes/issue-90873.stderr
@@ -10,7 +10,7 @@ LL | #![u=||{static d=||1;}]
 error: unexpected token: `{
            impl std::ops::Neg for i8 {}
        }`
-  --> $DIR/issue-90873.rs:7:6
+  --> $DIR/issue-90873.rs:6:6
    |
 LL | #![a={impl std::ops::Neg for i8 {}}]
    |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -22,22 +22,16 @@ LL | #![u=||{static d=||1;}]
    |    ^
 
 error: cannot find attribute `a` in this scope
-  --> $DIR/issue-90873.rs:7:4
+  --> $DIR/issue-90873.rs:6:4
    |
 LL | #![a={impl std::ops::Neg for i8 {}}]
    |    ^
 
 error[E0601]: `main` function not found in crate `issue_90873`
-  --> $DIR/issue-90873.rs:1:1
+  --> $DIR/issue-90873.rs:6:37
    |
-LL | / #![u=||{static d=||1;}]
-LL | |
-LL | |
-LL | |
-LL | |
-LL | |
-LL | | #![a={impl std::ops::Neg for i8 {}}]
-   | |____________________________________^ consider adding a `main` function to `$DIR/issue-90873.rs`
+LL | #![a={impl std::ops::Neg for i8 {}}]
+   |                                     ^ consider adding a `main` function to `$DIR/issue-90873.rs`
 
 error: missing type for `static` item
   --> $DIR/issue-90873.rs:1:16

--- a/src/test/ui/conditional-compilation/cfg-attr-cfg-2.stderr
+++ b/src/test/ui/conditional-compilation/cfg-attr-cfg-2.stderr
@@ -1,9 +1,8 @@
 error[E0601]: `main` function not found in crate `cfg_attr_cfg_2`
-  --> $DIR/cfg-attr-cfg-2.rs:8:1
+  --> $DIR/cfg-attr-cfg-2.rs:9:14
    |
-LL | / #[cfg_attr(foo, cfg(bar))]
-LL | | fn main() { }
-   | |_____________^ consider adding a `main` function to `$DIR/cfg-attr-cfg-2.rs`
+LL | fn main() { }
+   |              ^ consider adding a `main` function to `$DIR/cfg-attr-cfg-2.rs`
 
 error: aborting due to previous error
 

--- a/src/test/ui/conditional-compilation/cfg-in-crate-1.stderr
+++ b/src/test/ui/conditional-compilation/cfg-in-crate-1.stderr
@@ -1,8 +1,8 @@
 error[E0601]: `main` function not found in crate `cfg_in_crate_1`
-  --> $DIR/cfg-in-crate-1.rs:3:1
+  --> $DIR/cfg-in-crate-1.rs:3:13
    |
 LL | #![cfg(bar)]
-   | ^^^^^^^^^^^^ consider adding a `main` function to `$DIR/cfg-in-crate-1.rs`
+   |             ^ consider adding a `main` function to `$DIR/cfg-in-crate-1.rs`
 
 error: aborting due to previous error
 

--- a/src/test/ui/continue-after-missing-main.rs
+++ b/src/test/ui/continue-after-missing-main.rs
@@ -1,4 +1,4 @@
-#![allow(dead_code)] //~ ERROR `main` function not found in crate
+#![allow(dead_code)]
 
 struct Tableau<'a, MP> {
     provider: &'a MP,
@@ -27,4 +27,4 @@ fn create_and_solve_subproblems<'data_provider, 'original_data, MP>(
 ) {
     let _: AdaptedMatrixProvider<'original_data, MP> = tableau.provider().clone_with_extra_bound();
     //~^ ERROR lifetime mismatch
-}
+} //~ ERROR `main` function not found in crate

--- a/src/test/ui/continue-after-missing-main.stderr
+++ b/src/test/ui/continue-after-missing-main.stderr
@@ -1,14 +1,8 @@
 error[E0601]: `main` function not found in crate `continue_after_missing_main`
-  --> $DIR/continue-after-missing-main.rs:1:1
+  --> $DIR/continue-after-missing-main.rs:30:2
    |
-LL | / #![allow(dead_code)]
-LL | |
-LL | | struct Tableau<'a, MP> {
-LL | |     provider: &'a MP,
-...  |
-LL | |
-LL | | }
-   | |_^ consider adding a `main` function to `$DIR/continue-after-missing-main.rs`
+LL | }
+   |  ^ consider adding a `main` function to `$DIR/continue-after-missing-main.rs`
 
 error[E0623]: lifetime mismatch
   --> $DIR/continue-after-missing-main.rs:28:56

--- a/src/test/ui/elided-test.stderr
+++ b/src/test/ui/elided-test.stderr
@@ -1,10 +1,8 @@
 error[E0601]: `main` function not found in crate `elided_test`
-  --> $DIR/elided-test.rs:5:1
+  --> $DIR/elided-test.rs:7:2
    |
-LL | / #[test]
-LL | | fn main() {
-LL | | }
-   | |_^ consider adding a `main` function to `$DIR/elided-test.rs`
+LL | }
+   |  ^ consider adding a `main` function to `$DIR/elided-test.rs`
 
 error: aborting due to previous error
 

--- a/src/test/ui/entry-point/imported_main_const_fn_item_type_forbidden.rs
+++ b/src/test/ui/entry-point/imported_main_const_fn_item_type_forbidden.rs
@@ -1,7 +1,6 @@
 #![feature(imported_main)]
 #![feature(type_alias_impl_trait)]
 #![allow(incomplete_features)]
-//~^^^ ERROR `main` function not found in crate
 pub mod foo {
     type MainFn = impl Fn();
     //~^ ERROR could not find defining uses
@@ -11,4 +10,4 @@ pub mod foo {
     //~^ ERROR mismatched types [E0308]
 }
 
-use foo::BAR as main;
+use foo::BAR as main; //~ ERROR `main` function not found in crate

--- a/src/test/ui/entry-point/imported_main_const_fn_item_type_forbidden.stderr
+++ b/src/test/ui/entry-point/imported_main_const_fn_item_type_forbidden.stderr
@@ -1,19 +1,13 @@
 error[E0601]: `main` function not found in crate `imported_main_const_fn_item_type_forbidden`
-  --> $DIR/imported_main_const_fn_item_type_forbidden.rs:1:1
+  --> $DIR/imported_main_const_fn_item_type_forbidden.rs:13:22
    |
-LL | / #![feature(imported_main)]
-LL | | #![feature(type_alias_impl_trait)]
-LL | | #![allow(incomplete_features)]
-LL | |
-...  |
-LL | |
-LL | | use foo::BAR as main;
-   | |_____----------------^ consider adding a `main` function to `$DIR/imported_main_const_fn_item_type_forbidden.rs`
-   |       |
-   |       non-function item at `crate::main` is found
+LL | use foo::BAR as main;
+   |     ---------------- ^ consider adding a `main` function to `$DIR/imported_main_const_fn_item_type_forbidden.rs`
+   |     |
+   |     non-function item at `crate::main` is found
 
 error[E0308]: mismatched types
-  --> $DIR/imported_main_const_fn_item_type_forbidden.rs:10:29
+  --> $DIR/imported_main_const_fn_item_type_forbidden.rs:9:29
    |
 LL |     type MainFn = impl Fn();
    |                   --------- the expected opaque type
@@ -25,7 +19,7 @@ LL |     pub const BAR: MainFn = bar;
                   found fn item `fn() {bar}`
 
 error: could not find defining uses
-  --> $DIR/imported_main_const_fn_item_type_forbidden.rs:6:19
+  --> $DIR/imported_main_const_fn_item_type_forbidden.rs:5:19
    |
 LL |     type MainFn = impl Fn();
    |                   ^^^^^^^^^

--- a/src/test/ui/entry-point/imported_main_const_forbidden.rs
+++ b/src/test/ui/entry-point/imported_main_const_forbidden.rs
@@ -1,7 +1,6 @@
 #![feature(imported_main)]
-//~^ ERROR `main` function not found in crate
 pub mod foo {
     pub const BAR: usize = 42;
 }
 
-use foo::BAR as main;
+use foo::BAR as main; //~ ERROR `main` function not found in crate

--- a/src/test/ui/entry-point/imported_main_const_forbidden.stderr
+++ b/src/test/ui/entry-point/imported_main_const_forbidden.stderr
@@ -1,16 +1,10 @@
 error[E0601]: `main` function not found in crate `imported_main_const_forbidden`
-  --> $DIR/imported_main_const_forbidden.rs:1:1
+  --> $DIR/imported_main_const_forbidden.rs:6:22
    |
-LL | / #![feature(imported_main)]
-LL | |
-LL | | pub mod foo {
-LL | |     pub const BAR: usize = 42;
-LL | | }
-LL | |
-LL | | use foo::BAR as main;
-   | |_____----------------^ consider adding a `main` function to `$DIR/imported_main_const_forbidden.rs`
-   |       |
-   |       non-function item at `crate::main` is found
+LL | use foo::BAR as main;
+   |     ---------------- ^ consider adding a `main` function to `$DIR/imported_main_const_forbidden.rs`
+   |     |
+   |     non-function item at `crate::main` is found
 
 error: aborting due to previous error
 

--- a/src/test/ui/main-wrong-location.rs
+++ b/src/test/ui/main-wrong-location.rs
@@ -1,6 +1,5 @@
 mod m {
-//~^ ERROR `main` function not found
     // An inferred main entry point
     // must appear at the top of the crate
     fn main() { }
-}
+} //~ ERROR `main` function not found

--- a/src/test/ui/main-wrong-location.stderr
+++ b/src/test/ui/main-wrong-location.stderr
@@ -1,16 +1,11 @@
 error[E0601]: `main` function not found in crate `main_wrong_location`
-  --> $DIR/main-wrong-location.rs:1:1
+  --> $DIR/main-wrong-location.rs:5:2
    |
-LL | / mod m {
-LL | |
-LL | |     // An inferred main entry point
-LL | |     // must appear at the top of the crate
-LL | |     fn main() { }
-LL | | }
-   | |_^ the main function must be defined at the crate level (in `$DIR/main-wrong-location.rs`)
+LL | }
+   |  ^ the main function must be defined at the crate level (in `$DIR/main-wrong-location.rs`)
    |
 note: here is a function named `main`
-  --> $DIR/main-wrong-location.rs:5:5
+  --> $DIR/main-wrong-location.rs:4:5
    |
 LL |     fn main() { }
    |     ^^^^^^^^^^^^^

--- a/src/test/ui/missing/missing-main.stderr
+++ b/src/test/ui/missing/missing-main.stderr
@@ -1,8 +1,8 @@
 error[E0601]: `main` function not found in crate `missing_main`
-  --> $DIR/missing-main.rs:2:1
+  --> $DIR/missing-main.rs:2:14
    |
 LL | fn mian() { }
-   | ^^^^^^^^^^^^^ consider adding a `main` function to `$DIR/missing-main.rs`
+   |              ^ consider adding a `main` function to `$DIR/missing-main.rs`
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/issues/issue-49040.stderr
+++ b/src/test/ui/parser/issues/issue-49040.stderr
@@ -5,10 +5,10 @@ LL | #![allow(unused_variables)];
    |                            ^ help: remove this semicolon
 
 error[E0601]: `main` function not found in crate `issue_49040`
-  --> $DIR/issue-49040.rs:1:1
+  --> $DIR/issue-49040.rs:1:29
    |
 LL | #![allow(unused_variables)];
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ consider adding a `main` function to `$DIR/issue-49040.rs`
+   |                             ^ consider adding a `main` function to `$DIR/issue-49040.rs`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/suggestions/type-ascription-instead-of-path-in-type.rs
+++ b/src/test/ui/suggestions/type-ascription-instead-of-path-in-type.rs
@@ -1,0 +1,14 @@
+enum A {
+    B,
+}
+
+fn main() {
+    let _: Vec<A:B> = A::B;
+    //~^ ERROR cannot find trait `B` in this scope
+    //~| HELP you might have meant to write a path instead of an associated type bound
+    //~| ERROR associated type bounds are unstable
+    //~| HELP add `#![feature(associated_type_bounds)]` to the crate attributes to enable
+    //~| ERROR struct takes at least 1 generic argument but 0 generic arguments were supplied
+    //~| HELP add missing generic argument
+    //~| ERROR associated type bindings are not allowed here
+}

--- a/src/test/ui/suggestions/type-ascription-instead-of-path-in-type.stderr
+++ b/src/test/ui/suggestions/type-ascription-instead-of-path-in-type.stderr
@@ -1,0 +1,46 @@
+error[E0405]: cannot find trait `B` in this scope
+  --> $DIR/type-ascription-instead-of-path-in-type.rs:6:18
+   |
+LL |     let _: Vec<A:B> = A::B;
+   |                  ^ not found in this scope
+   |
+help: you might have meant to write a path instead of an associated type bound
+   |
+LL |     let _: Vec<A::B> = A::B;
+   |                 ~~
+
+error[E0658]: associated type bounds are unstable
+  --> $DIR/type-ascription-instead-of-path-in-type.rs:6:16
+   |
+LL |     let _: Vec<A:B> = A::B;
+   |                ^^^
+   |
+   = note: see issue #52662 <https://github.com/rust-lang/rust/issues/52662> for more information
+   = help: add `#![feature(associated_type_bounds)]` to the crate attributes to enable
+
+error[E0107]: this struct takes at least 1 generic argument but 0 generic arguments were supplied
+  --> $DIR/type-ascription-instead-of-path-in-type.rs:6:12
+   |
+LL |     let _: Vec<A:B> = A::B;
+   |            ^^^ expected at least 1 generic argument
+   |
+note: struct defined here, with at least 1 generic parameter: `T`
+  --> $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
+   |
+LL | pub struct Vec<T, #[unstable(feature = "allocator_api", issue = "32838")] A: Allocator = Global> {
+   |            ^^^ -
+help: add missing generic argument
+   |
+LL |     let _: Vec<T, A:B> = A::B;
+   |                ++
+
+error[E0229]: associated type bindings are not allowed here
+  --> $DIR/type-ascription-instead-of-path-in-type.rs:6:16
+   |
+LL |     let _: Vec<A:B> = A::B;
+   |                ^^^ associated type not allowed here
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0107, E0229, E0405, E0658.
+For more information about an error, try `rustc --explain E0107`.


### PR DESCRIPTION
Successful merges:

 - #92758 (librustdoc: impl core::fmt::Write for rustdoc::html::render::Buffer)
 - #92788 (Detect `::` -> `:` typo in type argument)
 - #93142 (Do not point at whole file missing `fn main`)
 - #93420 (Improve wrapping on settings page)
 - #93493 (Document valid values of the char type)
 - #93531 (Fix incorrect panic message in example)
 - #93559 (Add missing | between print options)
 - #93560 (Fix two incorrect "it's" (typos in comments))

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=92758,92788,93142,93420,93493,93531,93559,93560)
<!-- homu-ignore:end -->