### PR TITLE
Change `ResultShunt` to be generic over `Try`

### DIFF
--- a/library/core/src/iter/mod.rs
+++ b/library/core/src/iter/mod.rs
@@ -417,7 +417,7 @@ pub use self::adapters::{
 #[unstable(feature = "iter_intersperse", reason = "recently added", issue = "79524")]
 pub use self::adapters::{Intersperse, IntersperseWith};
 
-pub(crate) use self::adapters::process_results;
+pub(crate) use self::adapters::try_process;
 
 mod adapters;
 mod range;

--- a/library/core/src/iter/traits/accum.rs
+++ b/library/core/src/iter/traits/accum.rs
@@ -167,7 +167,7 @@ where
     where
         I: Iterator<Item = Result<U, E>>,
     {
-        iter::process_results(iter, |i| i.sum())
+        iter::try_process(iter, |i| i.sum())
     }
 }
 
@@ -183,7 +183,7 @@ where
     where
         I: Iterator<Item = Result<U, E>>,
     {
-        iter::process_results(iter, |i| i.product())
+        iter::try_process(iter, |i| i.product())
     }
 }
 
@@ -210,7 +210,7 @@ where
     where
         I: Iterator<Item = Option<U>>,
     {
-        iter.map(|x| x.ok_or(())).sum::<Result<_, _>>().ok()
+        iter::try_process(iter, |i| i.sum())
     }
 }
 
@@ -226,6 +226,6 @@ where
     where
         I: Iterator<Item = Option<U>>,
     {
-        iter.map(|x| x.ok_or(())).product::<Result<_, _>>().ok()
+        iter::try_process(iter, |i| i.product())
     }
 }

--- a/library/core/src/ops/try_trait.rs
+++ b/library/core/src/ops/try_trait.rs
@@ -359,6 +359,14 @@ pub(crate) type ChangeOutputType<T, V> = <<T as Try>::Residual as Residual<V>>::
 #[repr(transparent)]
 pub(crate) struct NeverShortCircuit<T>(pub T);
 
+impl<T> NeverShortCircuit<T> {
+    /// Wrap a binary `FnMut` to return its result wrapped in a `NeverShortCircuit`.
+    #[inline]
+    pub fn wrap_mut_2<A, B>(mut f: impl FnMut(A, B) -> T) -> impl FnMut(A, B) -> Self {
+        move |a, b| NeverShortCircuit(f(a, b))
+    }
+}
+
 pub(crate) enum NeverShortCircuitResidual {}
 
 impl<T> Try for NeverShortCircuit<T> {

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -500,7 +500,7 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
-use crate::iter::{FromIterator, FusedIterator, TrustedLen};
+use crate::iter::{self, FromIterator, FusedIterator, TrustedLen};
 use crate::panicking::{panic, panic_str};
 use crate::pin::Pin;
 use crate::{
@@ -2233,7 +2233,7 @@ impl<A, V: FromIterator<A>> FromIterator<Option<A>> for Option<V> {
         // FIXME(#11084): This could be replaced with Iterator::scan when this
         // performance bug is closed.
 
-        iter.into_iter().map(|x| x.ok_or(())).collect::<Result<_, _>>().ok()
+        iter::try_process(iter.into_iter(), |i| i.collect())
     }
 }
 

--- a/library/core/src/result.rs
+++ b/library/core/src/result.rs
@@ -2016,7 +2016,7 @@ impl<A, E, V: FromIterator<A>> FromIterator<Result<A, E>> for Result<V, E> {
         // FIXME(#11084): This could be replaced with Iterator::scan when this
         // performance bug is closed.
 
-        iter::process_results(iter.into_iter(), |i| i.collect())
+        iter::try_process(iter.into_iter(), |i| i.collect())
     }
 }
 


### PR DESCRIPTION
Just a refactor (and rename) for now, so it's not `Result`-specific.

This could be used for a future `Iterator::try_collect`, or similar, but anything like that is left for a future PR.