### PR TITLE
don't suggest adding `let` due to bad assignment expressions inside of `while` loop

### DIFF
--- a/src/test/ui/typeck/issue-93486.rs
+++ b/src/test/ui/typeck/issue-93486.rs
@@ -1,0 +1,6 @@
+fn main() {
+    while let 1 = 1 {
+        vec![].last_mut().unwrap() = 3_u8;
+        //~^ ERROR invalid left-hand side of assignment
+    }
+}

--- a/src/test/ui/typeck/issue-93486.stderr
+++ b/src/test/ui/typeck/issue-93486.stderr
@@ -1,0 +1,11 @@
+error[E0070]: invalid left-hand side of assignment
+  --> $DIR/issue-93486.rs:3:36
+   |
+LL |         vec![].last_mut().unwrap() = 3_u8;
+   |         -------------------------- ^
+   |         |
+   |         cannot assign to this expression
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0070`.


### PR DESCRIPTION
adds a check that our `lhs` expression is actually within the conditional part of the `while` loop, instead of anywhere in the `while` body.

fixes #93486