### PR TITLE
Suggest dereferencing LHS of assignment operator

### DIFF
--- a/compiler/rustc_typeck/src/check/op.rs
+++ b/compiler/rustc_typeck/src/check/op.rs
@@ -42,7 +42,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 return_ty
             };
 
-        self.check_lhs_assignable(lhs, "E0067", op.span);
+        if let Err(mut err) = self.check_lhs_assignable(lhs, "E0067", op.span) {
+            err.emit();
+        }
 
         ty
     }

--- a/src/test/ui/typeck/bad-lhs-should-deref.rs
+++ b/src/test/ui/typeck/bad-lhs-should-deref.rs
@@ -6,4 +6,10 @@ fn main() {
     mut_ref() = 1;
     //~^ ERROR invalid left-hand side of assignment
     //~| HELP consider dereferencing here to assign a value to the left-hand side
+
+    let x = Box::new(1);
+    x = 2;
+    //~^ ERROR mismatched types
+    //~| HELP store this in the heap by calling `Box::new`
+    //~| HELP consider dereferencing here to assign a value to the left-hand side
 }

--- a/src/test/ui/typeck/bad-lhs-should-deref.rs
+++ b/src/test/ui/typeck/bad-lhs-should-deref.rs
@@ -1,0 +1,9 @@
+fn mut_ref() -> &'static mut Box<usize> {
+    todo!();
+}
+
+fn main() {
+    mut_ref() = 1;
+    //~^ ERROR invalid left-hand side of assignment
+    //~| HELP consider dereferencing here to assign a value to the left-hand side
+}

--- a/src/test/ui/typeck/bad-lhs-should-deref.stderr
+++ b/src/test/ui/typeck/bad-lhs-should-deref.stderr
@@ -11,6 +11,27 @@ help: consider dereferencing here to assign a value to the left-hand side
 LL |     **mut_ref() = 1;
    |     ++
 
-error: aborting due to previous error
+error[E0308]: mismatched types
+  --> $DIR/bad-lhs-should-deref.rs:11:9
+   |
+LL |     let x = Box::new(1);
+   |             ----------- expected due to this value
+LL |     x = 2;
+   |         ^ expected struct `Box`, found integer
+   |
+   = note: expected struct `Box<{integer}>`
+                found type `{integer}`
+   = note: for more on the distinction between the stack and the heap, read https://doc.rust-lang.org/book/ch15-01-box.html, https://doc.rust-lang.org/rust-by-example/std/box.html, and https://doc.rust-lang.org/std/boxed/index.html
+help: store this in the heap by calling `Box::new`
+   |
+LL |     x = Box::new(2);
+   |         +++++++++ +
+help: consider dereferencing here to assign a value to the left-hand side
+   |
+LL |     *x = 2;
+   |     +
 
-For more information about this error, try `rustc --explain E0070`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0070, E0308.
+For more information about an error, try `rustc --explain E0070`.

--- a/src/test/ui/typeck/bad-lhs-should-deref.stderr
+++ b/src/test/ui/typeck/bad-lhs-should-deref.stderr
@@ -1,0 +1,16 @@
+error[E0070]: invalid left-hand side of assignment
+  --> $DIR/bad-lhs-should-deref.rs:6:15
+   |
+LL |     mut_ref() = 1;
+   |     --------- ^
+   |     |
+   |     cannot assign to this expression
+   |
+help: consider dereferencing here to assign a value to the left-hand side
+   |
+LL |     **mut_ref() = 1;
+   |     ++
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0070`.


### PR DESCRIPTION
Putting this diagnostic up for consideration, since I was dissatisfied with the unhelpful error message after I fixed the bug in #93574.

This suggestion isn't always correct, but it seems like many of our diagnostics are not, and it should be correct in simple cases. My only wish is that there were an `FnCtxt::autoderef` that only suggested `DerefMut` implementations so we can get the mutability correct...

Also I had to split the `check_expr_coercable_to_type` into `check_expr_with_hint` and `demand_coerce_diag` so I could delay emitting the coercion error, but that's basically what the former was doing in the first place. Let me know if I should refactor some of this logic into a helper fn.