### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3403,7 +3403,6 @@ dependencies = [
 name = "rustc_arena"
 version = "0.0.0"
 dependencies = [
- "rustc_data_structures",
  "smallvec",
 ]
 

--- a/compiler/rustc_arena/Cargo.toml
+++ b/compiler/rustc_arena/Cargo.toml
@@ -4,5 +4,4 @@ version = "0.0.0"
 edition = "2021"
 
 [dependencies]
-rustc_data_structures = { path = "../rustc_data_structures" }
 smallvec = { version = "1.6.1", features = ["union", "may_dangle"] }

--- a/compiler/rustc_ast_lowering/src/item.rs
+++ b/compiler/rustc_ast_lowering/src/item.rs
@@ -471,9 +471,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 // two imports.
                 for new_node_id in [id1, id2] {
                     let new_id = self.resolver.local_def_id(new_node_id);
-                    let res = if let Some(res) = resolutions.next() {
-                        res
-                    } else {
+                    let Some(res) = resolutions.next() else {
                         // Associate an HirId to both ids even if there is no resolution.
                         let _old = self
                             .node_id_to_hir_id

--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -32,6 +32,7 @@
 
 #![feature(crate_visibility_modifier)]
 #![feature(box_patterns)]
+#![feature(let_else)]
 #![feature(never_type)]
 #![recursion_limit = "256"]
 #![cfg_attr(not(bootstrap), allow(rustc::potential_query_instability))]

--- a/compiler/rustc_attr/src/lib.rs
+++ b/compiler/rustc_attr/src/lib.rs
@@ -4,6 +4,8 @@
 //! The goal is to move the definition of `MetaItem` and things that don't need to be in `syntax`
 //! to this crate.
 
+#![feature(let_else)]
+
 #[macro_use]
 extern crate rustc_macros;
 

--- a/compiler/rustc_borrowck/src/lib.rs
+++ b/compiler/rustc_borrowck/src/lib.rs
@@ -1427,9 +1427,8 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                             bug!("temporary should be initialized exactly once")
                         };
 
-                        let loc = match init.location {
-                            InitLocation::Statement(stmt) => stmt,
-                            _ => bug!("temporary initialized in arguments"),
+                        let InitLocation::Statement(loc) = init.location else {
+                            bug!("temporary initialized in arguments")
                         };
 
                         let body = self.body;

--- a/compiler/rustc_data_structures/src/fingerprint.rs
+++ b/compiler/rustc_data_structures/src/fingerprint.rs
@@ -3,6 +3,9 @@ use rustc_serialize::{Decodable, Encodable};
 use std::convert::TryInto;
 use std::hash::{Hash, Hasher};
 
+#[cfg(test)]
+mod tests;
+
 #[derive(Eq, PartialEq, Ord, PartialOrd, Debug, Clone, Copy)]
 #[repr(C)]
 pub struct Fingerprint(u64, u64);
@@ -54,7 +57,7 @@ impl Fingerprint {
 
         let c = a.wrapping_add(b);
 
-        Fingerprint((c >> 64) as u64, c as u64)
+        Fingerprint(c as u64, (c >> 64) as u64)
     }
 
     pub fn to_hex(&self) -> String {

--- a/compiler/rustc_data_structures/src/fingerprint/tests.rs
+++ b/compiler/rustc_data_structures/src/fingerprint/tests.rs
@@ -1,0 +1,14 @@
+use super::*;
+
+// Check that `combine_commutative` is order independent.
+#[test]
+fn combine_commutative_is_order_independent() {
+    let a = Fingerprint::new(0xf6622fb349898b06, 0x70be9377b2f9c610);
+    let b = Fingerprint::new(0xa9562bf5a2a5303c, 0x67d9b6c82034f13d);
+    let c = Fingerprint::new(0x0d013a27811dbbc3, 0x9a3f7b3d9142ec43);
+    let permutations = [(a, b, c), (a, c, b), (b, a, c), (b, c, a), (c, a, b), (c, b, a)];
+    let f = a.combine_commutative(b).combine_commutative(c);
+    for p in &permutations {
+        assert_eq!(f, p.0.combine_commutative(p.1).combine_commutative(p.2));
+    }
+}

--- a/compiler/rustc_save_analysis/src/dump_visitor.rs
+++ b/compiler/rustc_save_analysis/src/dump_visitor.rs
@@ -47,11 +47,10 @@ use rls_data::{
 
 use tracing::{debug, error};
 
+#[rustfmt::skip] // https://github.com/rust-lang/rustfmt/issues/5213
 macro_rules! down_cast_data {
     ($id:ident, $kind:ident, $sp:expr) => {
-        let $id = if let super::Data::$kind(data) = $id {
-            data
-        } else {
+        let super::Data::$kind($id) = $id else {
             span_bug!($sp, "unexpected data kind: {:?}", $id);
         };
     };

--- a/compiler/rustc_save_analysis/src/lib.rs
+++ b/compiler/rustc_save_analysis/src/lib.rs
@@ -1,6 +1,7 @@
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
 #![feature(if_let_guard)]
 #![feature(nll)]
+#![feature(let_else)]
 #![recursion_limit = "256"]
 #![cfg_attr(not(bootstrap), allow(rustc::potential_query_instability))]
 

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1426,15 +1426,25 @@ fn normalize<'tcx>(cx: &mut DocContext<'tcx>, ty: Ty<'_>) -> Option<Ty<'tcx>> {
         return None;
     }
 
+    use crate::rustc_trait_selection::infer::TyCtxtInferExt;
+    use crate::rustc_trait_selection::traits::query::normalize::AtExt;
+    use rustc_middle::traits::ObligationCause;
+
     // Try to normalize `<X as Y>::T` to a type
     let lifted = ty.lift_to_tcx(cx.tcx).unwrap();
-    match cx.tcx.try_normalize_erasing_regions(cx.param_env, lifted) {
+    let normalized = cx.tcx.infer_ctxt().enter(|infcx| {
+        infcx
+            .at(&ObligationCause::dummy(), cx.param_env)
+            .normalize(lifted)
+            .map(|resolved| infcx.resolve_vars_if_possible(resolved.value))
+    });
+    match normalized {
         Ok(normalized_value) => {
-            trace!("normalized {:?} to {:?}", ty, normalized_value);
+            debug!("normalized {:?} to {:?}", ty, normalized_value);
             Some(normalized_value)
         }
         Err(err) => {
-            info!("failed to normalize {:?}: {:?}", ty, err);
+            debug!("failed to normalize {:?}: {:?}", ty, err);
             None
         }
     }

--- a/src/test/rustdoc/lifetime-name.rs
+++ b/src/test/rustdoc/lifetime-name.rs
@@ -1,0 +1,5 @@
+#![crate_name = "foo"]
+
+// @has 'foo/type.Resolutions.html'
+// @has - '//*[@class="rust typedef"]' "pub type Resolutions<'tcx> = &'tcx u8;"
+pub type Resolutions<'tcx> = &'tcx u8;

--- a/src/test/ui/borrowck/issue-93093.rs
+++ b/src/test/ui/borrowck/issue-93093.rs
@@ -1,0 +1,14 @@
+// edition:2018
+struct S {
+    foo: usize,
+}
+impl S {
+    async fn bar(&self) { //~ HELP consider changing this to be a mutable reference
+        //~| SUGGESTION &mut self
+        self.foo += 1; //~ ERROR cannot assign to `self.foo`, which is behind a `&` reference [E0594]
+    }
+}
+
+fn main() {
+    S { foo: 1 }.bar();
+}

--- a/src/test/ui/borrowck/issue-93093.stderr
+++ b/src/test/ui/borrowck/issue-93093.stderr
@@ -1,0 +1,12 @@
+error[E0594]: cannot assign to `self.foo`, which is behind a `&` reference
+  --> $DIR/issue-93093.rs:8:9
+   |
+LL |     async fn bar(&self) {
+   |                  ----- help: consider changing this to be a mutable reference: `&mut self`
+LL |
+LL |         self.foo += 1;
+   |         ^^^^^^^^^^^^^ `self` is a `&` reference, so the data it refers to cannot be written
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0594`.

--- a/src/test/ui/parser/bad-struct-following-where.rs
+++ b/src/test/ui/parser/bad-struct-following-where.rs
@@ -1,0 +1,2 @@
+struct A where T: Sized !
+//~^ ERROR expected `{` after struct name, found

--- a/src/test/ui/parser/bad-struct-following-where.stderr
+++ b/src/test/ui/parser/bad-struct-following-where.stderr
@@ -1,0 +1,8 @@
+error: expected `{` after struct name, found `!`
+  --> $DIR/bad-struct-following-where.rs:1:25
+   |
+LL | struct A where T: Sized !
+   |                         ^ expected `{` after struct name
+
+error: aborting due to previous error
+

--- a/src/test/ui/parser/duplicate-where-clauses.rs
+++ b/src/test/ui/parser/duplicate-where-clauses.rs
@@ -1,0 +1,19 @@
+struct A where (): Sized where (): Sized {}
+//~^ ERROR cannot define duplicate `where` clauses on an item
+
+fn b() where (): Sized where (): Sized {}
+//~^ ERROR cannot define duplicate `where` clauses on an item
+
+enum C where (): Sized where (): Sized {}
+//~^ ERROR cannot define duplicate `where` clauses on an item
+
+struct D where (): Sized, where (): Sized {}
+//~^ ERROR cannot define duplicate `where` clauses on an item
+
+fn e() where (): Sized, where (): Sized {}
+//~^ ERROR cannot define duplicate `where` clauses on an item
+
+enum F where (): Sized, where (): Sized {}
+//~^ ERROR cannot define duplicate `where` clauses on an item
+
+fn main() {}

--- a/src/test/ui/parser/duplicate-where-clauses.stderr
+++ b/src/test/ui/parser/duplicate-where-clauses.stderr
@@ -1,0 +1,80 @@
+error: cannot define duplicate `where` clauses on an item
+  --> $DIR/duplicate-where-clauses.rs:1:32
+   |
+LL | struct A where (): Sized where (): Sized {}
+   |                -               ^
+   |                |
+   |                previous `where` clause starts here
+   |
+help: consider joining the two `where` clauses into one
+   |
+LL | struct A where (): Sized, (): Sized {}
+   |                         ~
+
+error: cannot define duplicate `where` clauses on an item
+  --> $DIR/duplicate-where-clauses.rs:4:30
+   |
+LL | fn b() where (): Sized where (): Sized {}
+   |              -               ^
+   |              |
+   |              previous `where` clause starts here
+   |
+help: consider joining the two `where` clauses into one
+   |
+LL | fn b() where (): Sized, (): Sized {}
+   |                       ~
+
+error: cannot define duplicate `where` clauses on an item
+  --> $DIR/duplicate-where-clauses.rs:7:30
+   |
+LL | enum C where (): Sized where (): Sized {}
+   |              -               ^
+   |              |
+   |              previous `where` clause starts here
+   |
+help: consider joining the two `where` clauses into one
+   |
+LL | enum C where (): Sized, (): Sized {}
+   |                       ~
+
+error: cannot define duplicate `where` clauses on an item
+  --> $DIR/duplicate-where-clauses.rs:10:33
+   |
+LL | struct D where (): Sized, where (): Sized {}
+   |                -                ^
+   |                |
+   |                previous `where` clause starts here
+   |
+help: consider joining the two `where` clauses into one
+   |
+LL | struct D where (): Sized, (): Sized {}
+   |                         ~
+
+error: cannot define duplicate `where` clauses on an item
+  --> $DIR/duplicate-where-clauses.rs:13:31
+   |
+LL | fn e() where (): Sized, where (): Sized {}
+   |              -                ^
+   |              |
+   |              previous `where` clause starts here
+   |
+help: consider joining the two `where` clauses into one
+   |
+LL | fn e() where (): Sized, (): Sized {}
+   |                       ~
+
+error: cannot define duplicate `where` clauses on an item
+  --> $DIR/duplicate-where-clauses.rs:16:31
+   |
+LL | enum F where (): Sized, where (): Sized {}
+   |              -                ^
+   |              |
+   |              previous `where` clause starts here
+   |
+help: consider joining the two `where` clauses into one
+   |
+LL | enum F where (): Sized, (): Sized {}
+   |                       ~
+
+error: aborting due to 6 previous errors
+

--- a/src/test/ui/typeck/issue-93486.rs
+++ b/src/test/ui/typeck/issue-93486.rs
@@ -1,0 +1,6 @@
+fn main() {
+    while let 1 = 1 {
+        vec![].last_mut().unwrap() = 3_u8;
+        //~^ ERROR invalid left-hand side of assignment
+    }
+}

--- a/src/test/ui/typeck/issue-93486.stderr
+++ b/src/test/ui/typeck/issue-93486.stderr
@@ -1,0 +1,11 @@
+error[E0070]: invalid left-hand side of assignment
+  --> $DIR/issue-93486.rs:3:36
+   |
+LL |         vec![].last_mut().unwrap() = 3_u8;
+   |         -------------------------- ^
+   |         |
+   |         cannot assign to this expression
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0070`.


### PR DESCRIPTION
Successful merges:

 - #92528 (Make `Fingerprint::combine_commutative` associative)
 - #93221 ([borrowck] Fix help on mutating &self in async fns)
 - #93542 (Prevent lifetime elision in type alias)
 - #93546 (Validate that values in switch int terminator are unique)
 - #93571 (better suggestion for duplicated `where` clause)
 - #93574 (don't suggest adding `let` due to bad assignment expressions inside of `while` loop)
 - #93590 (More let_else adoptions)
 - #93592 (Remove unused dep from rustc_arena)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=92528,93221,93542,93546,93571,93574,93590,93592)
<!-- homu-ignore:end -->