### PR TITLE
fix: Remove extra newlines from junit output

### DIFF
--- a/library/test/src/formatters/junit.rs
+++ b/library/test/src/formatters/junit.rs
@@ -33,7 +33,6 @@ impl<T: Write> OutputFormatter for JunitFormatter<T> {
         _shuffle_seed: Option<u64>,
     ) -> io::Result<()> {
         // We write xml header on run start
-        self.out.write_all(b"\n")?;
         self.write_message("<?xml version=\"1.0\" encoding=\"UTF-8\"?>")
     }
 
@@ -138,7 +137,7 @@ impl<T: Write> OutputFormatter for JunitFormatter<T> {
         self.write_message("</testsuite>")?;
         self.write_message("</testsuites>")?;
 
-        self.out.write_all(b"\n\n")?;
+        self.out.write_all(b"\n")?;
 
         Ok(state.failed == 0)
     }


### PR DESCRIPTION
This PR fixes extra newline in junit output https://github.com/rust-lang/rust/issues/93454

