### PR TITLE
rustdoc: resolve intra-doc links when checking HTML

### DIFF
--- a/src/test/rustdoc-ui/intra-doc/html-as-generics-intra-doc.rs
+++ b/src/test/rustdoc-ui/intra-doc/html-as-generics-intra-doc.rs
@@ -1,0 +1,25 @@
+#![deny(rustdoc::invalid_html_tags)]
+#![deny(rustdoc::broken_intra_doc_links)]
+
+pub struct ExistentStruct<T>(T);
+
+/// This [test][ExistentStruct<i32>] thing!
+pub struct NoError;
+
+/// This [ExistentStruct<i32>] thing!
+//~^ ERROR unclosed HTML tag `i32`
+pub struct PartialErrorOnlyHtml;
+
+/// This [test][NonExistentStruct<i32>] thing!
+//~^ ERROR unresolved link
+pub struct PartialErrorOnlyResolve;
+
+/// This [NonExistentStruct2<i32>] thing!
+//~^ ERROR unclosed HTML tag `i32`
+//~| ERROR unresolved link
+pub struct YesError;
+
+/// This [NonExistentStruct3<i32>][] thing!
+//~^ ERROR unclosed HTML tag `i32`
+//~| ERROR unresolved link
+pub struct YesErrorCollapsed;

--- a/src/test/rustdoc-ui/intra-doc/html-as-generics-intra-doc.stderr
+++ b/src/test/rustdoc-ui/intra-doc/html-as-generics-intra-doc.stderr
@@ -1,0 +1,69 @@
+error: unresolved link to `NonExistentStruct`
+  --> $DIR/html-as-generics-intra-doc.rs:13:17
+   |
+LL | /// This [test][NonExistentStruct<i32>] thing!
+   |                 ^^^^^^^^^^^^^^^^^^^^^^ no item named `NonExistentStruct` in scope
+   |
+note: the lint level is defined here
+  --> $DIR/html-as-generics-intra-doc.rs:2:9
+   |
+LL | #![deny(rustdoc::broken_intra_doc_links)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
+
+error: unresolved link to `NonExistentStruct2`
+  --> $DIR/html-as-generics-intra-doc.rs:17:11
+   |
+LL | /// This [NonExistentStruct2<i32>] thing!
+   |           ^^^^^^^^^^^^^^^^^^^^^^^ no item named `NonExistentStruct2` in scope
+   |
+   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
+
+error: unresolved link to `NonExistentStruct3`
+  --> $DIR/html-as-generics-intra-doc.rs:22:11
+   |
+LL | /// This [NonExistentStruct3<i32>][] thing!
+   |           ^^^^^^^^^^^^^^^^^^^^^^^ no item named `NonExistentStruct3` in scope
+   |
+   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
+
+error: unclosed HTML tag `i32`
+  --> $DIR/html-as-generics-intra-doc.rs:9:25
+   |
+LL | /// This [ExistentStruct<i32>] thing!
+   |                         ^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/html-as-generics-intra-doc.rs:1:9
+   |
+LL | #![deny(rustdoc::invalid_html_tags)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: try marking as source code
+   |
+LL | /// This [`ExistentStruct<i32>`] thing!
+   |           +                   +
+
+error: unclosed HTML tag `i32`
+  --> $DIR/html-as-generics-intra-doc.rs:17:29
+   |
+LL | /// This [NonExistentStruct2<i32>] thing!
+   |                             ^^^^^
+   |
+help: try marking as source code
+   |
+LL | /// This [`NonExistentStruct2<i32>`] thing!
+   |           +                       +
+
+error: unclosed HTML tag `i32`
+  --> $DIR/html-as-generics-intra-doc.rs:22:29
+   |
+LL | /// This [NonExistentStruct3<i32>][] thing!
+   |                             ^^^^^
+   |
+help: try marking as source code
+   |
+LL | /// This [`NonExistentStruct3<i32>`][] thing!
+   |           +                       +
+
+error: aborting due to 6 previous errors
+


### PR DESCRIPTION
Similar to #86451

CC #67799

Given this test case:

```rust
#![warn(rustdoc::invalid_html_tags)]
#![warn(rustdoc::broken_intra_doc_links)]

pub struct ExistentStruct<T>(T);

/// This [test][ExistentStruct<i32>] thing!
pub struct NoError;
```

This pull request silences the following, spurious warning:

```text
warning: unclosed HTML tag `i32`
 --> test.rs:6:31
  |
6 | /// This [test][ExistentStruct<i32>] thing!
  |                               ^^^^^
  |
note: the lint level is defined here
 --> test.rs:1:9
  |
1 | #![warn(rustdoc::invalid_html_tags)]
  |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
help: try marking as source code
  |
6 | /// This [test][`ExistentStruct<i32>`] thing!
  |                 +                   +

warning: 1 warning emitted
```