### PR TITLE
Move `{core,std}::stream::Stream` to `{core,std}::async_iter::AsyncIterator`

### DIFF
--- a/library/alloc/src/boxed.rs
+++ b/library/alloc/src/boxed.rs
@@ -133,6 +133,7 @@
 #![stable(feature = "rust1", since = "1.0.0")]
 
 use core::any::Any;
+use core::async_iter::AsyncIterator;
 use core::borrow;
 use core::cmp::Ordering;
 use core::convert::{From, TryFrom};
@@ -149,7 +150,6 @@ use core::ops::{
 };
 use core::pin::Pin;
 use core::ptr::{self, Unique};
-use core::stream::Stream;
 use core::task::{Context, Poll};
 
 #[cfg(not(no_global_oom_handling))]
@@ -1992,8 +1992,8 @@ where
     }
 }
 
-#[unstable(feature = "async_stream", issue = "79024")]
-impl<S: ?Sized + Stream + Unpin> Stream for Box<S> {
+#[unstable(feature = "async_iterator", issue = "79024")]
+impl<S: ?Sized + AsyncIterator + Unpin> AsyncIterator for Box<S> {
     type Item = S::Item;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {

--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -91,7 +91,7 @@
 #![feature(array_chunks)]
 #![feature(array_methods)]
 #![feature(array_windows)]
-#![feature(async_stream)]
+#![feature(async_iterator)]
 #![feature(coerce_unsized)]
 #![cfg_attr(not(no_global_oom_handling), feature(const_alloc_error))]
 #![feature(const_box)]

--- a/library/core/src/async_iter/async_iter.rs
+++ b/library/core/src/async_iter/async_iter.rs
@@ -4,50 +4,50 @@ use crate::task::{Context, Poll};
 
 /// An interface for dealing with asynchronous iterators.
 ///
-/// This is the main stream trait. For more about the concept of streams
+/// This is the main async iterator trait. For more about the concept of async iterators
 /// generally, please see the [module-level documentation]. In particular, you
-/// may want to know how to [implement `Stream`][impl].
+/// may want to know how to [implement `AsyncIterator`][impl].
 ///
 /// [module-level documentation]: index.html
-/// [impl]: index.html#implementing-stream
-#[unstable(feature = "async_stream", issue = "79024")]
-#[must_use = "streams do nothing unless polled"]
-pub trait Stream {
-    /// The type of items yielded by the stream.
+/// [impl]: index.html#implementing-async-iterator
+#[unstable(feature = "async_iterator", issue = "79024")]
+#[must_use = "async iterators do nothing unless polled"]
+pub trait AsyncIterator {
+    /// The type of items yielded by the async iterator.
     type Item;
 
-    /// Attempt to pull out the next value of this stream, registering the
+    /// Attempt to pull out the next value of this async iterator, registering the
     /// current task for wakeup if the value is not yet available, and returning
-    /// `None` if the stream is exhausted.
+    /// `None` if the async iterator is exhausted.
     ///
     /// # Return value
     ///
     /// There are several possible return values, each indicating a distinct
-    /// stream state:
+    /// async iterator state:
     ///
-    /// - `Poll::Pending` means that this stream's next value is not ready
+    /// - `Poll::Pending` means that this async iterator's next value is not ready
     /// yet. Implementations will ensure that the current task will be notified
     /// when the next value may be ready.
     ///
-    /// - `Poll::Ready(Some(val))` means that the stream has successfully
+    /// - `Poll::Ready(Some(val))` means that the async iterator has successfully
     /// produced a value, `val`, and may produce further values on subsequent
     /// `poll_next` calls.
     ///
-    /// - `Poll::Ready(None)` means that the stream has terminated, and
+    /// - `Poll::Ready(None)` means that the async iterator has terminated, and
     /// `poll_next` should not be invoked again.
     ///
     /// # Panics
     ///
-    /// Once a stream has finished (returned `Ready(None)` from `poll_next`), calling its
+    /// Once an async iterator has finished (returned `Ready(None)` from `poll_next`), calling its
     /// `poll_next` method again may panic, block forever, or cause other kinds of
-    /// problems; the `Stream` trait places no requirements on the effects of
+    /// problems; the `AsyncIterator` trait places no requirements on the effects of
     /// such a call. However, as the `poll_next` method is not marked `unsafe`,
     /// Rust's usual rules apply: calls must never cause undefined behavior
     /// (memory corruption, incorrect use of `unsafe` functions, or the like),
-    /// regardless of the stream's state.
+    /// regardless of the async iterator's state.
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>>;
 
-    /// Returns the bounds on the remaining length of the stream.
+    /// Returns the bounds on the remaining length of the async iterator.
     ///
     /// Specifically, `size_hint()` returns a tuple where the first element
     /// is the lower bound, and the second element is the upper bound.
@@ -58,12 +58,12 @@ pub trait Stream {
     ///
     /// # Implementation notes
     ///
-    /// It is not enforced that a stream implementation yields the declared
-    /// number of elements. A buggy stream may yield less than the lower bound
+    /// It is not enforced that an async iterator implementation yields the declared
+    /// number of elements. A buggy async iterator may yield less than the lower bound
     /// or more than the upper bound of elements.
     ///
     /// `size_hint()` is primarily intended to be used for optimizations such as
-    /// reserving space for the elements of the stream, but must not be
+    /// reserving space for the elements of the async iterator, but must not be
     /// trusted to e.g., omit bounds checks in unsafe code. An incorrect
     /// implementation of `size_hint()` should not lead to memory safety
     /// violations.
@@ -72,15 +72,15 @@ pub trait Stream {
     /// because otherwise it would be a violation of the trait's protocol.
     ///
     /// The default implementation returns <code>(0, [None])</code> which is correct for any
-    /// stream.
+    /// async iterator.
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         (0, None)
     }
 }
 
-#[unstable(feature = "async_stream", issue = "79024")]
-impl<S: ?Sized + Stream + Unpin> Stream for &mut S {
+#[unstable(feature = "async_iterator", issue = "79024")]
+impl<S: ?Sized + AsyncIterator + Unpin> AsyncIterator for &mut S {
     type Item = S::Item;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
@@ -92,16 +92,16 @@ impl<S: ?Sized + Stream + Unpin> Stream for &mut S {
     }
 }
 
-#[unstable(feature = "async_stream", issue = "79024")]
-impl<P> Stream for Pin<P>
+#[unstable(feature = "async_iterator", issue = "79024")]
+impl<P> AsyncIterator for Pin<P>
 where
     P: DerefMut,
-    P::Target: Stream,
+    P::Target: AsyncIterator,
 {
-    type Item = <P::Target as Stream>::Item;
+    type Item = <P::Target as AsyncIterator>::Item;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        <P::Target as Stream>::poll_next(self.as_deref_mut(), cx)
+        <P::Target as AsyncIterator>::poll_next(self.as_deref_mut(), cx)
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {

--- a/library/core/src/async_iter/from_iter.rs
+++ b/library/core/src/async_iter/from_iter.rs
@@ -1,31 +1,31 @@
 use crate::pin::Pin;
 
-use crate::stream::Stream;
+use crate::async_iter::AsyncIterator;
 use crate::task::{Context, Poll};
 
-/// A stream that was created from iterator.
+/// An async iterator that was created from iterator.
 ///
-/// This stream is created by the [`from_iter`] function.
+/// This async iterator is created by the [`from_iter`] function.
 /// See it documentation for more.
 ///
 /// [`from_iter`]: fn.from_iter.html
-#[unstable(feature = "stream_from_iter", issue = "81798")]
+#[unstable(feature = "async_iter_from_iter", issue = "81798")]
 #[derive(Clone, Debug)]
 pub struct FromIter<I> {
     iter: I,
 }
 
-#[unstable(feature = "stream_from_iter", issue = "81798")]
+#[unstable(feature = "async_iter_from_iter", issue = "81798")]
 impl<I> Unpin for FromIter<I> {}
 
-/// Converts an iterator into a stream.
-#[unstable(feature = "stream_from_iter", issue = "81798")]
+/// Converts an iterator into an async iterator.
+#[unstable(feature = "async_iter_from_iter", issue = "81798")]
 pub fn from_iter<I: IntoIterator>(iter: I) -> FromIter<I::IntoIter> {
     FromIter { iter: iter.into_iter() }
 }
 
-#[unstable(feature = "stream_from_iter", issue = "81798")]
-impl<I: Iterator> Stream for FromIter<I> {
+#[unstable(feature = "async_iter_from_iter", issue = "81798")]
+impl<I: Iterator> AsyncIterator for FromIter<I> {
     type Item = I::Item;
 
     fn poll_next(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -304,6 +304,8 @@ pub mod ops;
 pub mod any;
 pub mod array;
 pub mod ascii;
+#[unstable(feature = "async_iterator", issue = "79024")]
+pub mod async_iter;
 pub mod cell;
 pub mod char;
 pub mod ffi;
@@ -315,8 +317,6 @@ pub mod panic;
 pub mod panicking;
 pub mod pin;
 pub mod result;
-#[unstable(feature = "async_stream", issue = "79024")]
-pub mod stream;
 pub mod sync;
 
 pub mod fmt;

--- a/library/core/src/panic/unwind_safe.rs
+++ b/library/core/src/panic/unwind_safe.rs
@@ -1,10 +1,10 @@
+use crate::async_iter::AsyncIterator;
 use crate::cell::UnsafeCell;
 use crate::fmt;
 use crate::future::Future;
 use crate::ops::{Deref, DerefMut};
 use crate::pin::Pin;
 use crate::ptr::{NonNull, Unique};
-use crate::stream::Stream;
 use crate::task::{Context, Poll};
 
 /// A marker trait which represents "panic safe" types in Rust.
@@ -290,8 +290,8 @@ impl<F: Future> Future for AssertUnwindSafe<F> {
     }
 }
 
-#[unstable(feature = "async_stream", issue = "79024")]
-impl<S: Stream> Stream for AssertUnwindSafe<S> {
+#[unstable(feature = "async_iterator", issue = "79024")]
+impl<S: AsyncIterator> AsyncIterator for AssertUnwindSafe<S> {
     type Item = S::Item;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<S::Item>> {

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -232,7 +232,7 @@
 #![feature(array_error_internals)]
 #![feature(assert_matches)]
 #![feature(associated_type_bounds)]
-#![feature(async_stream)]
+#![feature(async_iterator)]
 #![feature(atomic_mut_ptr)]
 #![feature(auto_traits)]
 #![feature(bench_black_box)]
@@ -403,6 +403,8 @@ pub use alloc_crate::vec;
 pub use core::any;
 #[stable(feature = "core_array", since = "1.36.0")]
 pub use core::array;
+#[unstable(feature = "async_iterator", issue = "79024")]
+pub use core::async_iter;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use core::cell;
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -457,8 +459,6 @@ pub use core::pin;
 pub use core::ptr;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use core::result;
-#[unstable(feature = "async_stream", issue = "79024")]
-pub use core::stream;
 #[stable(feature = "i128", since = "1.26.0")]
 #[allow(deprecated, deprecated_in_future)]
 pub use core::u128;


### PR DESCRIPTION
Following amendments in https://github.com/rust-lang/rfcs/pull/3208/. 

cc #79024
cc @yoshuawuyts @joshtriplett 