### PR TITLE
bootstrap: Don't panic if LLDB python dir cannot be found.

### DIFF
--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -1394,26 +1394,17 @@ note: if you're sure you want to do this, please open an issue as to why. In the
             cmd.arg("--gdb").arg(gdb);
         }
 
-        let run = |cmd: &mut Command| {
-            cmd.output().map(|output| {
-                String::from_utf8_lossy(&output.stdout)
-                    .lines()
-                    .next()
-                    .unwrap_or_else(|| panic!("{:?} failed {:?}", cmd, output))
-                    .to_string()
-            })
+        let single_line_result = |cmd: &mut Command| {
+            cmd.output().map(|output| String::from_utf8_lossy(&output.stdout).trim().to_string())
         };
+
         let lldb_exe = "lldb";
-        let lldb_version = Command::new(lldb_exe)
-            .arg("--version")
-            .output()
-            .map(|output| String::from_utf8_lossy(&output.stdout).to_string())
-            .ok();
-        if let Some(ref vers) = lldb_version {
-            cmd.arg("--lldb-version").arg(vers);
-            let lldb_python_dir = run(Command::new(lldb_exe).arg("-P")).ok();
-            if let Some(ref dir) = lldb_python_dir {
-                cmd.arg("--lldb-python-dir").arg(dir);
+        let lldb_version = single_line_result(Command::new(lldb_exe).arg("--version"));
+        if let Ok(ref vers) = lldb_version {
+            cmd.arg("--lldb-version").arg(&vers[..]);
+            let lldb_python_dir = single_line_result(Command::new(lldb_exe).arg("-P"));
+            if let Ok(ref dir) = lldb_python_dir {
+                cmd.arg("--lldb-python-dir").arg(&dir[..]);
             }
         }
 


### PR DESCRIPTION
If there is a broken `lldb` on PATH (e.g. if LLVM is installed on Windows) then bootstrap will currently unconditionally panic, even if no debuginfo tests are run. This PR handles makes bootstrap handle this situation without panicking.