### PR TITLE
Fix `isize` optimization in `StableHasher` for big-endian architectures

### DIFF
--- a/compiler/rustc_data_structures/src/stable_hasher/tests.rs
+++ b/compiler/rustc_data_structures/src/stable_hasher/tests.rs
@@ -159,4 +159,5 @@ fn test_isize_compression() {
     check_hash(0xAAAA, 0xAAAAAA);
     check_hash(0xAAAAAA, 0xAAAAAAAA);
     check_hash(0xFF, 0xFFFFFFFFFFFFFFFF);
+    check_hash(u64::MAX /* -1 */, 1);
 }


### PR DESCRIPTION
This PR fixes a problem with the stable hash optimization introduced in https://github.com/rust-lang/rust/pull/93432. As @michaelwoerister has [found out](https://github.com/rust-lang/rust/pull/93432#issuecomment-1028756212), the original implementation wouldn't produce the same hash on little/big architectures.

r? @the8472