### PR TITLE
[draft] debuginfo: Don't emit default generic args in type names.

### DIFF
--- a/compiler/rustc_codegen_llvm/src/debuginfo/mod.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/mod.rs
@@ -345,6 +345,7 @@ impl<'ll, 'tcx> DebugInfoMethods<'tcx> for CodegenCx<'ll, 'tcx> {
 
         type_names::push_generic_params(
             tcx,
+            generics,
             tcx.normalize_erasing_regions(ty::ParamEnv::reveal_all(), substs),
             &mut name,
         );

--- a/src/test/debuginfo/type-names.rs
+++ b/src/test/debuginfo/type-names.rs
@@ -47,10 +47,10 @@
 
 // BOX
 // gdb-command:whatis box1
-// gdb-check:type = (alloc::boxed::Box<f32, alloc::alloc::Global>, i32)
+// gdb-check:type = (alloc::boxed::Box<f32>, i32)
 
 // gdb-command:whatis box2
-// gdb-check:type = (alloc::boxed::Box<type_names::mod1::mod2::Enum3<f32>, alloc::alloc::Global>, i32)
+// gdb-check:type = (alloc::boxed::Box<type_names::mod1::mod2::Enum3<f32>>, i32)
 
 // REFERENCES
 // gdb-command:whatis ref1
@@ -99,7 +99,7 @@
 
 // TRAITS
 // gdb-command:whatis box_trait
-// gdb-check:type = alloc::boxed::Box<dyn type_names::Trait1, alloc::alloc::Global>
+// gdb-check:type = alloc::boxed::Box<dyn type_names::Trait1>
 
 // gdb-command:whatis ref_trait
 // gdb-check:type = &dyn type_names::Trait1
@@ -108,7 +108,7 @@
 // gdb-check:type = &mut dyn type_names::Trait1
 
 // gdb-command:whatis generic_box_trait
-// gdb-check:type = alloc::boxed::Box<dyn type_names::Trait2<i32, type_names::mod1::Struct2>, alloc::alloc::Global>
+// gdb-check:type = alloc::boxed::Box<dyn type_names::Trait2<i32, type_names::mod1::Struct2>>
 
 // gdb-command:whatis generic_ref_trait
 // gdb-check:type = &dyn type_names::Trait2<type_names::Struct1, type_names::Struct1>
@@ -117,7 +117,7 @@
 // gdb-check:type = &mut dyn type_names::Trait2<type_names::mod1::mod2::Struct3, type_names::GenericStruct<usize, isize>>
 
 // gdb-command:whatis no_principal_trait
-// gdb-check:type = alloc::boxed::Box<(dyn core::marker::Send + core::marker::Sync), alloc::alloc::Global>
+// gdb-check:type = alloc::boxed::Box<(dyn core::marker::Send + core::marker::Sync)>
 
 // gdb-command:whatis has_associated_type_trait
 // gdb-check:type = &(dyn type_names::Trait3<u32, AssocType=isize> + core::marker::Send)


### PR DESCRIPTION
This helps readability of type names. For example `alloc::boxed::Box<f32, alloc::alloc::Global>` becomes just `alloc::boxed::Box<f32>`.

r? @ghost