### PR TITLE
Fix HashMap not displaying correctly in VS debugger

### DIFF
--- a/src/etc/natvis/libstd.natvis
+++ b/src/etc/natvis/libstd.natvis
@@ -41,7 +41,7 @@
           <If Condition="(base.table.table.ctrl.pointer[i] &amp; 0x80) == 0">
             <!-- Bucket is populated -->
             <Exec>n--</Exec>
-            <Item Name="{((tuple$&lt;$T1, $T2&gt;*)base.table.table.ctrl.pointer)[-(i + 1)].__0}">((tuple$&lt;$T1, $T2&gt;*)base.table.table.ctrl.pointer)[-(i + 1)].__1</Item>
+            <Item Name="{((tuple$&lt;$T1,$T2&gt;*)base.table.table.ctrl.pointer)[-(i + 1)].__0}">((tuple$&lt;$T1,$T2&gt;*)base.table.table.ctrl.pointer)[-(i + 1)].__1</Item>
           </If>
           <Exec>i++</Exec>
         </Loop>


### PR DESCRIPTION
The natvis to render HashMaps was not working correctly in Visual Studio
because the type names for tuples changed from `tuple$<A, B>` to
`tuple$<A,B>` (notice the missing space). WinDbg and cdb continued to
parse this type name which is why no tests in CI broke. VS however is
slightly more strict and this caused the visualizer to break.

Since we cannot test the VS debugger in CI, I'm not checking in any
test changes.

Fixes #92286

r? @michaelwoerister 