### PR TITLE
Introduced `llvm-libtool` option

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -157,6 +157,9 @@ changelog-seen = 2
 # Whether to build the clang compiler.
 #clang = false
 
+# The value specified here will be passed as `-DCMAKE_LIBTOOL` to CMake.
+#libtool = "/path/to/libtool"
+
 # =============================================================================
 # General build configuration options
 # =============================================================================

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -104,6 +104,7 @@ pub struct Config {
     pub llvm_link_jobs: Option<u32>,
     pub llvm_version_suffix: Option<String>,
     pub llvm_use_linker: Option<String>,
+    pub llvm_libtool: Option<String>,
     pub llvm_allow_old_toolchain: bool,
     pub llvm_polly: bool,
     pub llvm_clang: bool,
@@ -473,6 +474,7 @@ derive_merge! {
         ldflags: Option<String>,
         use_libcxx: Option<bool>,
         use_linker: Option<String>,
+        libtool: Option<String>,
         allow_old_toolchain: Option<bool>,
         polly: Option<bool>,
         clang: Option<bool>,
@@ -804,6 +806,7 @@ impl Config {
             config.llvm_ldflags = llvm.ldflags.clone();
             set(&mut config.llvm_use_libcxx, llvm.use_libcxx);
             config.llvm_use_linker = llvm.use_linker.clone();
+            config.llvm_libtool = llvm.libtool.clone();
             config.llvm_allow_old_toolchain = llvm.allow_old_toolchain.unwrap_or(false);
             config.llvm_polly = llvm.polly.unwrap_or(false);
             config.llvm_clang = llvm.clang.unwrap_or(false);
@@ -873,6 +876,7 @@ impl Config {
                 check_ci_llvm!(llvm.ldflags);
                 check_ci_llvm!(llvm.use_libcxx);
                 check_ci_llvm!(llvm.use_linker);
+                check_ci_llvm!(llvm.libtool);
                 check_ci_llvm!(llvm.allow_old_toolchain);
                 check_ci_llvm!(llvm.polly);
                 check_ci_llvm!(llvm.clang);

--- a/src/bootstrap/configure.py
+++ b/src/bootstrap/configure.py
@@ -68,6 +68,8 @@ v("llvm-ldflags", "llvm.ldflags", "build LLVM with these extra linker flags")
 
 v("llvm-libunwind", "rust.llvm-libunwind", "use LLVM libunwind")
 
+v("llvm-libtool", "llvm.libtool", "build LLVM with specified libtool")
+
 # Optimization and debugging options. These may be overridden by the release
 # channel, etc.
 o("optimize", "rust.optimize", "build optimized rust code")

--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -351,6 +351,10 @@ impl Step for Llvm {
             cfg.define("LLVM_TEMPORARILY_ALLOW_OLD_TOOLCHAIN", "YES");
         }
 
+        if let Some(ref libtool) = builder.config.llvm_libtool {
+            cfg.define("CMAKE_LIBTOOL", libtool);
+        }
+
         configure_cmake(builder, target, &mut cfg, true);
 
         // FIXME: we don't actually need to build all LLVM tools and all LLVM


### PR DESCRIPTION
An idea to allow to control used `libtool` to build LLVM. Useful in attmept to build / bootsrap rust to old or wired systems.