### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/compiler/rustc_codegen_llvm/src/back/archive.rs
+++ b/compiler/rustc_codegen_llvm/src/back/archive.rs
@@ -219,7 +219,7 @@ impl<'a> ArchiveBuilder<'a> for LlvmArchiveBuilder<'a> {
 
             match result {
                 Err(e) => {
-                    self.config.sess.fatal(&format!("Error calling dlltool: {}", e.to_string()));
+                    self.config.sess.fatal(&format!("Error calling dlltool: {}", e));
                 }
                 Ok(output) if !output.status.success() => self.config.sess.fatal(&format!(
                     "Dlltool could not create import library: {}\n{}",

--- a/compiler/rustc_interface/src/interface.rs
+++ b/compiler/rustc_interface/src/interface.rs
@@ -126,7 +126,7 @@ pub fn parse_cfgspecs(cfgspecs: Vec<String>) -> FxHashSet<(String, Option<String
 
                 // If the user tried to use a key="value" flag, but is missing the quotes, provide
                 // a hint about how to resolve this.
-                if s.contains("=") && !s.contains("=\"") && !s.ends_with("\"") {
+                if s.contains('=') && !s.contains("=\"") && !s.ends_with('"') {
                     error!(concat!(
                         r#"expected `key` or `key="value"`, ensure escaping is appropriate"#,
                         r#" for your shell, try 'key="value"' or key=\"value\""#

--- a/compiler/rustc_middle/src/ty/assoc.rs
+++ b/compiler/rustc_middle/src/ty/assoc.rs
@@ -160,12 +160,11 @@ impl<'tcx> AssocItems<'tcx> {
         &self,
         tcx: TyCtxt<'_>,
         ident: Ident,
+        // Sorted in order of what kinds to look at
         kinds: &[AssocKind],
         parent_def_id: DefId,
     ) -> Option<&ty::AssocItem> {
-        self.filter_by_name_unhygienic(ident.name)
-            .filter(|item| kinds.contains(&item.kind))
-            .find(|item| tcx.hygienic_eq(ident, item.ident(tcx), parent_def_id))
+        kinds.iter().find_map(|kind| self.find_by_name_and_kind(tcx, ident, *kind, parent_def_id))
     }
 
     /// Returns the associated item with the given name in the given `Namespace`, if one exists.

--- a/compiler/rustc_mir_dataflow/src/elaborate_drops.rs
+++ b/compiler/rustc_mir_dataflow/src/elaborate_drops.rs
@@ -8,7 +8,7 @@ use rustc_middle::ty::subst::SubstsRef;
 use rustc_middle::ty::util::IntTypeExt;
 use rustc_middle::ty::{self, Ty, TyCtxt};
 use rustc_target::abi::VariantIdx;
-use std::fmt;
+use std::{fmt, iter};
 
 /// The value of an inserted drop flag.
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
@@ -329,8 +329,7 @@ where
         mut succ: BasicBlock,
         fields: &[(Place<'tcx>, Option<D::Path>)],
     ) -> Vec<BasicBlock> {
-        Some(succ)
-            .into_iter()
+        iter::once(succ)
             .chain(fields.iter().rev().zip(unwind_ladder).map(|(&(place, path), &unwind_succ)| {
                 succ = self.drop_subpath(place, path, succ, unwind_succ);
                 succ

--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -1702,11 +1702,11 @@ impl<'a> Parser<'a> {
 
         // Try to lowercase the prefix if it's a valid base prefix.
         fn fix_base_capitalisation(s: &str) -> Option<String> {
-            if let Some(stripped) = s.strip_prefix("B") {
+            if let Some(stripped) = s.strip_prefix('B') {
                 Some(format!("0b{stripped}"))
-            } else if let Some(stripped) = s.strip_prefix("O") {
+            } else if let Some(stripped) = s.strip_prefix('O') {
                 Some(format!("0o{stripped}"))
-            } else if let Some(stripped) = s.strip_prefix("X") {
+            } else if let Some(stripped) = s.strip_prefix('X') {
                 Some(format!("0x{stripped}"))
             } else {
                 None

--- a/compiler/rustc_typeck/src/check/expr.rs
+++ b/compiler/rustc_typeck/src/check/expr.rs
@@ -1587,10 +1587,10 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     ) {
         let len = remaining_fields.len();
 
-        let mut displayable_field_names =
-            remaining_fields.keys().map(|ident| ident.as_str()).collect::<Vec<_>>();
-
-        displayable_field_names.sort();
+        let mut displayable_field_names: Vec<&str> =
+            remaining_fields.keys().map(|ident| ident.as_str()).collect();
+        // sorting &str primitives here, sort_unstable is ok
+        displayable_field_names.sort_unstable();
 
         let mut truncated_fields_error = String::new();
         let remaining_fields_names = match &displayable_field_names[..] {

--- a/src/ci/docker/host-x86_64/x86_64-gnu-tools/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-tools/Dockerfile
@@ -72,7 +72,7 @@ ENV PATH="/node-v14.4.0-linux-x64/bin:${PATH}"
 # https://github.com/puppeteer/puppeteer/issues/375
 #
 # We also specify the version in case we need to update it to go around cache limitations.
-RUN npm install -g browser-ui-test@0.5.8 --unsafe-perm=true
+RUN npm install -g browser-ui-test@0.7.0 --unsafe-perm=true
 
 ENV RUST_CONFIGURE_ARGS \
   --build=x86_64-unknown-linux-gnu \

--- a/src/test/ui/associated-consts/shadowed-const.rs
+++ b/src/test/ui/associated-consts/shadowed-const.rs
@@ -1,0 +1,23 @@
+// Checking that none of these ICE, which was introduced in
+// https://github.com/rust-lang/rust/issues/93553
+trait Foo {
+    type Bar;
+}
+
+trait Baz: Foo {
+    const Bar: Self::Bar;
+}
+
+trait Baz2: Foo {
+    const Bar: u32;
+
+    fn foo() -> Self::Bar;
+}
+
+trait Baz3 {
+  const BAR: usize;
+  const QUX: Self::BAR;
+  //~^ ERROR found associated const
+}
+
+fn main() {}

--- a/src/test/ui/associated-consts/shadowed-const.stderr
+++ b/src/test/ui/associated-consts/shadowed-const.stderr
@@ -1,0 +1,8 @@
+error: found associated const `BAR` when type was expected
+  --> $DIR/shadowed-const.rs:19:14
+   |
+LL |   const QUX: Self::BAR;
+   |              ^^^^^^^^^
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Successful merges:

 - #93593 (Fix ret > 1 bound if shadowed by const)
 - #93597 (Update browser-ui-test version)
 - #93630 (clippy::perf fixes)
 - #93631 (rustc_mir_dataflow: use iter::once instead of Some().into_iter)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=93593,93597,93630,93631)
<!-- homu-ignore:end -->