### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,7 @@ __pycache__/
 ## Node
 node_modules
 package-lock.json
+package.json
 
 ## Rustdoc GUI tests
 src/test/rustdoc-gui/src/**.lock

--- a/compiler/rustc_codegen_llvm/src/back/archive.rs
+++ b/compiler/rustc_codegen_llvm/src/back/archive.rs
@@ -219,7 +219,7 @@ impl<'a> ArchiveBuilder<'a> for LlvmArchiveBuilder<'a> {
 
             match result {
                 Err(e) => {
-                    self.config.sess.fatal(&format!("Error calling dlltool: {}", e.to_string()));
+                    self.config.sess.fatal(&format!("Error calling dlltool: {}", e));
                 }
                 Ok(output) if !output.status.success() => self.config.sess.fatal(&format!(
                     "Dlltool could not create import library: {}\n{}",

--- a/compiler/rustc_interface/src/interface.rs
+++ b/compiler/rustc_interface/src/interface.rs
@@ -126,7 +126,7 @@ pub fn parse_cfgspecs(cfgspecs: Vec<String>) -> FxHashSet<(String, Option<String
 
                 // If the user tried to use a key="value" flag, but is missing the quotes, provide
                 // a hint about how to resolve this.
-                if s.contains("=") && !s.contains("=\"") && !s.ends_with("\"") {
+                if s.contains('=') && !s.contains("=\"") && !s.ends_with('"') {
                     error!(concat!(
                         r#"expected `key` or `key="value"`, ensure escaping is appropriate"#,
                         r#" for your shell, try 'key="value"' or key=\"value\""#

--- a/compiler/rustc_middle/src/ty/assoc.rs
+++ b/compiler/rustc_middle/src/ty/assoc.rs
@@ -160,12 +160,11 @@ impl<'tcx> AssocItems<'tcx> {
         &self,
         tcx: TyCtxt<'_>,
         ident: Ident,
+        // Sorted in order of what kinds to look at
         kinds: &[AssocKind],
         parent_def_id: DefId,
     ) -> Option<&ty::AssocItem> {
-        self.filter_by_name_unhygienic(ident.name)
-            .filter(|item| kinds.contains(&item.kind))
-            .find(|item| tcx.hygienic_eq(ident, item.ident(tcx), parent_def_id))
+        kinds.iter().find_map(|kind| self.find_by_name_and_kind(tcx, ident, *kind, parent_def_id))
     }
 
     /// Returns the associated item with the given name in the given `Namespace`, if one exists.

--- a/compiler/rustc_mir_dataflow/src/elaborate_drops.rs
+++ b/compiler/rustc_mir_dataflow/src/elaborate_drops.rs
@@ -8,7 +8,7 @@ use rustc_middle::ty::subst::SubstsRef;
 use rustc_middle::ty::util::IntTypeExt;
 use rustc_middle::ty::{self, Ty, TyCtxt};
 use rustc_target::abi::VariantIdx;
-use std::fmt;
+use std::{fmt, iter};
 
 /// The value of an inserted drop flag.
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
@@ -329,8 +329,7 @@ where
         mut succ: BasicBlock,
         fields: &[(Place<'tcx>, Option<D::Path>)],
     ) -> Vec<BasicBlock> {
-        Some(succ)
-            .into_iter()
+        iter::once(succ)
             .chain(fields.iter().rev().zip(unwind_ladder).map(|(&(place, path), &unwind_succ)| {
                 succ = self.drop_subpath(place, path, succ, unwind_succ);
                 succ

--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -1702,11 +1702,11 @@ impl<'a> Parser<'a> {
 
         // Try to lowercase the prefix if it's a valid base prefix.
         fn fix_base_capitalisation(s: &str) -> Option<String> {
-            if let Some(stripped) = s.strip_prefix("B") {
+            if let Some(stripped) = s.strip_prefix('B') {
                 Some(format!("0b{stripped}"))
-            } else if let Some(stripped) = s.strip_prefix("O") {
+            } else if let Some(stripped) = s.strip_prefix('O') {
                 Some(format!("0o{stripped}"))
-            } else if let Some(stripped) = s.strip_prefix("X") {
+            } else if let Some(stripped) = s.strip_prefix('X') {
                 Some(format!("0x{stripped}"))
             } else {
                 None

--- a/compiler/rustc_typeck/src/check/expr.rs
+++ b/compiler/rustc_typeck/src/check/expr.rs
@@ -1587,10 +1587,10 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     ) {
         let len = remaining_fields.len();
 
-        let mut displayable_field_names =
-            remaining_fields.keys().map(|ident| ident.as_str()).collect::<Vec<_>>();
-
-        displayable_field_names.sort();
+        let mut displayable_field_names: Vec<&str> =
+            remaining_fields.keys().map(|ident| ident.as_str()).collect();
+        // sorting &str primitives here, sort_unstable is ok
+        displayable_field_names.sort_unstable();
 
         let mut truncated_fields_error = String::new();
         let remaining_fields_names = match &displayable_field_names[..] {

--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -2288,7 +2288,7 @@ impl AsInnerMut<fs_imp::DirBuilder> for DirBuilder {
 /// This function will traverse symbolic links to query information about the
 /// destination file. In case of broken symbolic links this will return `Ok(false)`.
 ///
-/// As opposed to the `exists()` method, this one doesn't silently ignore errors
+/// As opposed to the [`Path::exists`] method, this one doesn't silently ignore errors
 /// unrelated to the path not existing. (E.g. it will return `Err(_)` in case of permission
 /// denied on some of the parent directories.)
 ///
@@ -2301,6 +2301,8 @@ impl AsInnerMut<fs_imp::DirBuilder> for DirBuilder {
 /// assert!(!fs::try_exists("does_not_exist.txt").expect("Can't check existence of file does_not_exist.txt"));
 /// assert!(fs::try_exists("/root/secret_file.txt").is_err());
 /// ```
+///
+/// [`Path::exists`]: crate::path::Path::exists
 // FIXME: stabilization should modify documentation of `exists()` to recommend this method
 // instead.
 #[unstable(feature = "path_try_exists", issue = "83186")]

--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -2730,7 +2730,7 @@ impl Path {
     /// This function will traverse symbolic links to query information about the
     /// destination file. In case of broken symbolic links this will return `Ok(false)`.
     ///
-    /// As opposed to the `exists()` method, this one doesn't silently ignore errors
+    /// As opposed to the [`exists()`] method, this one doesn't silently ignore errors
     /// unrelated to the path not existing. (E.g. it will return `Err(_)` in case of permission
     /// denied on some of the parent directories.)
     ///
@@ -2743,6 +2743,8 @@ impl Path {
     /// assert!(!Path::new("does_not_exist.txt").try_exists().expect("Can't check existence of file does_not_exist.txt"));
     /// assert!(Path::new("/root/secret_file.txt").try_exists().is_err());
     /// ```
+    ///
+    /// [`exists()`]: Self::exists
     // FIXME: stabilization should modify documentation of `exists()` to recommend this method
     // instead.
     #[unstable(feature = "path_try_exists", issue = "83186")]

--- a/library/std/src/sys/solid/time.rs
+++ b/library/std/src/sys/solid/time.rs
@@ -21,7 +21,7 @@ impl SystemTime {
                 tm_min: rtc.tm_min,
                 tm_hour: rtc.tm_hour,
                 tm_mday: rtc.tm_mday,
-                tm_mon: rtc.tm_mon,
+                tm_mon: rtc.tm_mon - 1,
                 tm_year: rtc.tm_year,
                 tm_wday: rtc.tm_wday,
                 tm_yday: 0,

--- a/src/test/ui/associated-consts/shadowed-const.rs
+++ b/src/test/ui/associated-consts/shadowed-const.rs
@@ -1,0 +1,23 @@
+// Checking that none of these ICE, which was introduced in
+// https://github.com/rust-lang/rust/issues/93553
+trait Foo {
+    type Bar;
+}
+
+trait Baz: Foo {
+    const Bar: Self::Bar;
+}
+
+trait Baz2: Foo {
+    const Bar: u32;
+
+    fn foo() -> Self::Bar;
+}
+
+trait Baz3 {
+  const BAR: usize;
+  const QUX: Self::BAR;
+  //~^ ERROR found associated const
+}
+
+fn main() {}

--- a/src/test/ui/associated-consts/shadowed-const.stderr
+++ b/src/test/ui/associated-consts/shadowed-const.stderr
@@ -1,0 +1,8 @@
+error: found associated const `BAR` when type was expected
+  --> $DIR/shadowed-const.rs:19:14
+   |
+LL |   const QUX: Self::BAR;
+   |              ^^^^^^^^^
+
+error: aborting due to previous error
+

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -2412,7 +2412,10 @@ impl<'test> TestCx<'test> {
         );
 
         if !res.status.success() {
-            self.fatal_proc_rec("jsondocck failed!", &res)
+            self.fatal_proc_rec_with_ctx("jsondocck failed!", &res, |_| {
+                println!("Rustdoc Output:");
+                proc_res.print_info();
+            })
         }
 
         let mut json_out = out_dir.join(self.testpaths.file.file_stem().unwrap());
@@ -3759,10 +3762,7 @@ pub struct ProcRes {
 }
 
 impl ProcRes {
-    pub fn fatal(&self, err: Option<&str>, on_failure: impl FnOnce()) -> ! {
-        if let Some(e) = err {
-            println!("\nerror: {}", e);
-        }
+    pub fn print_info(&self) {
         print!(
             "\
              status: {}\n\
@@ -3781,6 +3781,13 @@ impl ProcRes {
             json::extract_rendered(&self.stdout),
             json::extract_rendered(&self.stderr),
         );
+    }
+
+    pub fn fatal(&self, err: Option<&str>, on_failure: impl FnOnce()) -> ! {
+        if let Some(e) = err {
+            println!("\nerror: {}", e);
+        }
+        self.print_info();
         on_failure();
         // Use resume_unwind instead of panic!() to prevent a panic message + backtrace from
         // compiletest, which is unnecessary noise.


### PR DESCRIPTION
Successful merges:

 - #93495 (kmc-solid: Fix off-by-one error in `SystemTime::now`)
 - #93508 (Add rustdoc info to jsondocck output)
 - #93551 (Add package.json in gitignore)
 - #93555 (Link `try_exists` docs to `Path::exists`)
 - #93593 (Fix ret > 1 bound if shadowed by const)
 - #93630 (clippy::perf fixes)
 - #93631 (rustc_mir_dataflow: use iter::once instead of Some().into_iter)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=93495,93508,93551,93555,93593,93630,93631)
<!-- homu-ignore:end -->