### PR TITLE
use `fold_list` in `try_super_fold_with` for `SubstsRef`

### DIFF
--- a/compiler/rustc_middle/src/ty/subst.rs
+++ b/compiler/rustc_middle/src/ty/subst.rs
@@ -396,15 +396,7 @@ impl<'tcx> TypeFoldable<'tcx> for SubstsRef<'tcx> {
                 }
             }
             0 => Ok(self),
-            _ => {
-                let params: SmallVec<[_; 8]> =
-                    self.iter().map(|k| k.try_fold_with(folder)).collect::<Result<_, _>>()?;
-                if params[..] == self[..] {
-                    Ok(self)
-                } else {
-                    Ok(folder.tcx().intern_substs(&params))
-                }
-            }
+            _ => ty::util::fold_list(self, folder, |tcx, v| tcx.intern_substs(v)),
         }
     }
 


### PR DESCRIPTION
split out from #93505 as this by itself is responsible for most of the perf improvements there

r? @michaelwoerister 