### PR TITLE
Added `Box::take()` method

### DIFF
--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -101,6 +101,7 @@
 #![feature(const_size_of_val)]
 #![feature(const_align_of_val)]
 #![feature(const_ptr_read)]
+#![feature(const_maybe_uninit_assume_init_read)]
 #![feature(const_maybe_uninit_write)]
 #![feature(const_maybe_uninit_as_mut_ptr)]
 #![feature(const_refs_to_cell)]


### PR DESCRIPTION
The new `Box::take()` method allows to read from `Box` and reuse the
allocation safely. This commit also changes some `unsafe` code in the
compiler to use this method instead and becomes safe.

This was suggested in https://github.com/rust-lang/rust/issues/63291#issuecomment-950739645 where it got two thumbs ups and no objections and is pretty simple, so should be OK without RFC. It reuses the feature `new_uninit`, hope it's OK.

Related: I noticed number of `unsafe` casts of `Box<T>, A` to `Box<U, A>`, maybe we should have a `pub` common `unsafe` method `cast_unchecked` for these? It'd be clearer and less boilerplate-y. Also cast (`From`) `Box<T, A>` -> `Box<MaybeUninit<T>, A>` could be safe (though leaking). Can open a new PR for this if there's interest.