### PR TITLE
Resolve lifetimes for const generic defaults

### DIFF
--- a/compiler/rustc_resolve/src/late/lifetimes.rs
+++ b/compiler/rustc_resolve/src/late/lifetimes.rs
@@ -1339,11 +1339,14 @@ impl<'a, 'tcx> Visitor<'tcx> for LifetimeContext<'a, 'tcx> {
                             this.visit_ty(&ty);
                         }
                     }
-                    GenericParamKind::Const { ref ty, .. } => {
+                    GenericParamKind::Const { ref ty, default } => {
                         let was_in_const_generic = this.is_in_const_generic;
                         this.is_in_const_generic = true;
                         walk_list!(this, visit_param_bound, param.bounds);
                         this.visit_ty(&ty);
+                        if let Some(default) = default {
+                            this.visit_body(this.tcx.hir().body(default.body));
+                        }
                         this.is_in_const_generic = was_in_const_generic;
                     }
                 }

--- a/src/test/ui/const-generics/issue-93647.rs
+++ b/src/test/ui/const-generics/issue-93647.rs
@@ -1,0 +1,6 @@
+struct X<const N: usize = {
+    (||1usize)()
+    //~^ ERROR calls in constants are limited to
+}>;
+
+fn main() {}

--- a/src/test/ui/const-generics/issue-93647.stderr
+++ b/src/test/ui/const-generics/issue-93647.stderr
@@ -1,0 +1,9 @@
+error[E0015]: calls in constants are limited to constant functions, tuple structs and tuple variants
+  --> $DIR/issue-93647.rs:2:5
+   |
+LL |     (||1usize)()
+   |     ^^^^^^^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0015`.

--- a/src/test/ui/const-generics/outer-lifetime-in-const-generic-default.rs
+++ b/src/test/ui/const-generics/outer-lifetime-in-const-generic-default.rs
@@ -1,0 +1,10 @@
+struct Foo<
+    'a,
+    const N: usize = {
+        let x: &'a ();
+        //~^ ERROR use of non-static lifetime `'a` in const generic
+        3
+    },
+>(&'a ());
+
+fn main() {}

--- a/src/test/ui/const-generics/outer-lifetime-in-const-generic-default.stderr
+++ b/src/test/ui/const-generics/outer-lifetime-in-const-generic-default.stderr
@@ -1,0 +1,11 @@
+error[E0771]: use of non-static lifetime `'a` in const generic
+  --> $DIR/outer-lifetime-in-const-generic-default.rs:4:17
+   |
+LL |         let x: &'a ();
+   |                 ^^
+   |
+   = note: for more information, see issue #74052 <https://github.com/rust-lang/rust/issues/74052>
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0771`.


### PR DESCRIPTION
We weren't visiting the const generic default argument in `rustc_resolve::late::lifetimes`. This seems to fix the issue, and we deny any non-`'static` lifetimes anyways.

Fixes #93647