### PR TITLE
update comment wrt const param defaults

### DIFF
--- a/compiler/rustc_builtin_macros/src/deriving/mod.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/mod.rs
@@ -134,7 +134,7 @@ fn inject_impl_of_structural_trait(
 
     // Create the type of `self`.
     //
-    // in addition, remove defaults from type params (impls cannot have them).
+    // in addition, remove defaults from generic params (impls cannot have them).
     let self_params: Vec<_> = generics
         .params
         .iter_mut()


### PR DESCRIPTION
after #93669 i looked through all other uses of `GenericParamKind::Const` again to detect if we missed the `default` there as well, but afaict we really only missed lifetime resolution '^^ at least i found an outdated comment :3

