### PR TITLE
Store rlink data in opaque binary format on disk

### DIFF
--- a/compiler/rustc_driver/src/lib.rs
+++ b/compiler/rustc_driver/src/lib.rs
@@ -29,7 +29,7 @@ use rustc_log::stdout_isatty;
 use rustc_metadata::locator;
 use rustc_save_analysis as save;
 use rustc_save_analysis::DumpHandler;
-use rustc_serialize::json::{self, ToJson};
+use rustc_serialize::json::ToJson;
 use rustc_session::config::{nightly_options, CG_OPTIONS, DB_OPTIONS};
 use rustc_session::config::{ErrorOutputType, Input, OutputType, PrintRequest, TrimmedDefPaths};
 use rustc_session::cstore::MetadataLoader;
@@ -595,10 +595,12 @@ impl RustcDefaultCalls {
                 // FIXME: #![crate_type] and #![crate_name] support not implemented yet
                 sess.init_crate_types(collect_crate_types(sess, &[]));
                 let outputs = compiler.build_output_filenames(sess, &[]);
-                let rlink_data = fs::read_to_string(file).unwrap_or_else(|err| {
+                let rlink_data = fs::read(file).unwrap_or_else(|err| {
                     sess.fatal(&format!("failed to read rlink file: {}", err));
                 });
-                let codegen_results: CodegenResults = json::decode(&rlink_data);
+                let mut decoder = rustc_serialize::opaque::Decoder::new(&rlink_data, 0);
+                let codegen_results: CodegenResults =
+                    rustc_serialize::Decodable::decode(&mut decoder);
                 let result = compiler.codegen_backend().link(sess, codegen_results, &outputs);
                 abort_on_err(result, sess);
             } else {

--- a/compiler/rustc_interface/src/queries.rs
+++ b/compiler/rustc_interface/src/queries.rs
@@ -13,7 +13,6 @@ use rustc_middle::arena::Arena;
 use rustc_middle::dep_graph::DepGraph;
 use rustc_middle::ty::{GlobalCtxt, TyCtxt};
 use rustc_query_impl::Queries as TcxQueries;
-use rustc_serialize::json;
 use rustc_session::config::{self, OutputFilenames, OutputType};
 use rustc_session::{output::find_crate_name, Session};
 use rustc_span::symbol::sym;
@@ -367,12 +366,10 @@ impl Linker {
         }
 
         if sess.opts.debugging_opts.no_link {
-            // FIXME: use a binary format to encode the `.rlink` file
-            let rlink_data = json::encode(&codegen_results).map_err(|err| {
-                sess.fatal(&format!("failed to encode rlink: {}", err));
-            })?;
+            let mut encoder = rustc_serialize::opaque::Encoder::new(Vec::new());
+            rustc_serialize::Encodable::encode(&codegen_results, &mut encoder).unwrap();
             let rlink_file = self.prepare_outputs.with_extension(config::RLINK_EXT);
-            std::fs::write(&rlink_file, rlink_data).map_err(|err| {
+            std::fs::write(&rlink_file, encoder.into_inner()).map_err(|err| {
                 sess.fatal(&format!("failed to write file {}: {}", rlink_file.display(), err));
             })?;
             return Ok(());


### PR DESCRIPTION
This removes one of the only uses of JSON decoding (to Rust structs) from the compiler, and fixes the FIXME comment. It's not clear to me what the reason for using JSON here originally was, and from what I can tell nothing outside of rustc expects to read the emitted information, so it seems like a reasonable step to move it to the metadata-encoding format (rustc_serialize::opaque).

Mostly intended as a FIXME fix, though potentially a stepping stone to dropping the support for Decodable to be used to decode JSON entirely (allowing for better/faster APIs on the Decoder trait).

cc #64191