### PR TITLE
Drop time dependency from bootstrap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,7 +236,6 @@ dependencies = [
  "pretty_assertions",
  "serde",
  "serde_json",
- "time",
  "toml",
  "winapi",
 ]

--- a/src/bootstrap/Cargo.toml
+++ b/src/bootstrap/Cargo.toml
@@ -44,14 +44,22 @@ libc = "0.2"
 serde = { version = "1.0.8", features = ["derive"] }
 serde_json = "1.0.2"
 toml = "0.5"
-time = "0.1"
 ignore = "0.4.10"
 opener = "0.5"
 once_cell = "1.7.2"
 
 [target.'cfg(windows)'.dependencies.winapi]
 version = "0.3"
-features = ["fileapi", "ioapiset", "jobapi2", "handleapi", "winioctl", "psapi", "impl-default"]
+features = [
+    "fileapi",
+    "ioapiset",
+    "jobapi2",
+    "handleapi",
+    "winioctl",
+    "psapi",
+    "impl-default",
+    "timezoneapi",
+]
 
 [dev-dependencies]
 pretty_assertions = "0.6"

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -106,8 +106,7 @@
 use std::cell::{Cell, RefCell};
 use std::collections::{HashMap, HashSet};
 use std::env;
-use std::fs::{self, File, OpenOptions};
-use std::io::{Read, Seek, SeekFrom, Write};
+use std::fs::{self, File};
 use std::path::{Path, PathBuf};
 use std::process::{self, Command};
 use std::str;
@@ -1333,23 +1332,6 @@ impl Build {
             let mtime = FileTime::from_last_modification_time(&metadata);
             t!(filetime::set_file_times(dst, atime, mtime));
         }
-    }
-
-    /// Search-and-replaces within a file. (Not maximally efficiently: allocates a
-    /// new string for each replacement.)
-    pub fn replace_in_file(&self, path: &Path, replacements: &[(&str, &str)]) {
-        if self.config.dry_run {
-            return;
-        }
-        let mut contents = String::new();
-        let mut file = t!(OpenOptions::new().read(true).write(true).open(path));
-        t!(file.read_to_string(&mut contents));
-        for &(target, replacement) in replacements {
-            contents = contents.replace(target, replacement);
-        }
-        t!(file.seek(SeekFrom::Start(0)));
-        t!(file.set_len(0));
-        t!(file.write_all(contents.as_bytes()));
     }
 
     /// Copies the `src` directory recursively to `dst`. Both are assumed to exist

--- a/src/doc/man/rustc.1
+++ b/src/doc/man/rustc.1
@@ -1,4 +1,4 @@
-.TH RUSTC "1" "<INSERT DATE HERE>" "rustc <INSERT VERSION HERE>" "User Commands"
+.TH RUSTC "1" "April 2019" "rustc <INSERT VERSION HERE>" "User Commands"
 .SH NAME
 rustc \- The Rust compiler
 .SH SYNOPSIS

--- a/src/doc/man/rustdoc.1
+++ b/src/doc/man/rustdoc.1
@@ -1,4 +1,4 @@
-.TH RUSTDOC "1" "<INSERT DATE HERE>" "rustdoc <INSERT VERSION HERE>" "User Commands"
+.TH RUSTDOC "1" "July 2018" "rustdoc <INSERT VERSION HERE>" "User Commands"
 .SH NAME
 rustdoc \- generate documentation from Rust source code
 .SH SYNOPSIS


### PR DESCRIPTION
This was only used for the inclusion of 'current' dates into our manpages, but
it is not clear that this is practically necessary. The manpage is essentially
never updated, and so we can likely afford to keep a manual date in these files.
It also seems possible to just omit it, but that may cause other tools trouble,
so avoid doing that for now.

This is largely done to reduce bootstrap complexity; the time crate is not particularly
small and in #92480 would have started pulling in num-threads, which does runtime
thread count detection. I would prefer to avoid that, so filing this to just drop the nearly
unused dependency entirely.

r? @pietroalbini 