### PR TITLE
Rollup of 2 pull requests

### DIFF
--- a/compiler/rustc_typeck/src/collect.rs
+++ b/compiler/rustc_typeck/src/collect.rs
@@ -2778,6 +2778,13 @@ fn codegen_fn_attrs(tcx: TyCtxt<'_>, id: DefId) -> CodegenFnAttrs {
         }
     }
 
+    // The panic_no_unwind function called by TerminatorKind::Abort will never
+    // unwind. If the panic handler that it invokes unwind then it will simply
+    // call the panic handler again.
+    if Some(id) == tcx.lang_items().panic_no_unwind() {
+        codegen_fn_attrs.flags |= CodegenFnAttrFlags::NEVER_UNWIND;
+    }
+
     let supported_target_features = tcx.supported_target_features(LOCAL_CRATE);
 
     let mut inline_span = None;

--- a/library/core/src/array/mod.rs
+++ b/library/core/src/array/mod.rs
@@ -512,6 +512,7 @@ impl<T, const N: usize> [T; N] {
 
     /// Returns a slice containing the entire array. Equivalent to `&s[..]`.
     #[stable(feature = "array_as_slice", since = "1.57.0")]
+    #[rustc_const_stable(feature = "array_as_slice", since = "1.57.0")]
     pub const fn as_slice(&self) -> &[T] {
         self
     }

--- a/library/core/src/cell.rs
+++ b/library/core/src/cell.rs
@@ -1959,6 +1959,7 @@ impl<T: ?Sized> UnsafeCell<T> {
     /// ```
     #[inline(always)]
     #[stable(feature = "unsafe_cell_raw_get", since = "1.56.0")]
+    #[rustc_const_stable(feature = "unsafe_cell_raw_get", since = "1.56.0")]
     pub const fn raw_get(this: *const Self) -> *mut T {
         // We can just cast the pointer from `UnsafeCell<T>` to `T` because of
         // #[repr(transparent)]. This exploits libstd's special status, there is

--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -1064,6 +1064,7 @@ macro_rules! int_impl {
         ///
         /// ```
         #[stable(feature = "saturating_div", since = "1.58.0")]
+        #[rustc_const_stable(feature = "saturating_div", since = "1.58.0")]
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]

--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -972,6 +972,7 @@ macro_rules! nonzero_unsigned_is_power_of_two {
                 /// ```
                 #[must_use]
                 #[stable(feature = "nonzero_is_power_of_two", since = "1.59.0")]
+                #[rustc_const_stable(feature = "nonzero_is_power_of_two", since = "1.59.0")]
                 #[inline]
                 pub const fn is_power_of_two(self) -> bool {
                     // LLVM 11 normalizes `unchecked_sub(x, 1) & x == 0` to the implementation seen here.

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -1132,6 +1132,7 @@ macro_rules! uint_impl {
         ///
         /// ```
         #[stable(feature = "saturating_div", since = "1.58.0")]
+        #[rustc_const_stable(feature = "saturating_div", since = "1.58.0")]
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]

--- a/library/core/src/panic/panic_info.rs
+++ b/library/core/src/panic/panic_info.rs
@@ -136,6 +136,10 @@ impl<'a> PanicInfo<'a> {
     /// This is true for most kinds of panics with the exception of panics
     /// caused by trying to unwind out of a `Drop` implementation or a function
     /// whose ABI does not support unwinding.
+    ///
+    /// It is safe for a panic handler to unwind even when this function returns
+    /// true, however this will simply cause the panic handler to be called
+    /// again.
     #[must_use]
     #[unstable(feature = "panic_can_unwind", issue = "92988")]
     pub fn can_unwind(&self) -> bool {

--- a/src/test/ui/stability-attribute/missing-const-stability.rs
+++ b/src/test/ui/stability-attribute/missing-const-stability.rs
@@ -1,11 +1,12 @@
 #![feature(staged_api)]
+#![feature(const_trait_impl)]
 #![stable(feature = "stable", since = "1.0.0")]
 
 #[stable(feature = "stable", since = "1.0.0")]
 pub const fn foo() {} //~ ERROR function has missing const stability attribute
 
 #[unstable(feature = "unstable", issue = "none")]
-pub const fn bar() {} // ok for now
+pub const fn bar() {} // ok because function is unstable
 
 #[stable(feature = "stable", since = "1.0.0")]
 pub struct Foo;
@@ -14,11 +15,12 @@ impl Foo {
     pub const fn foo() {} //~ ERROR associated function has missing const stability attribute
 
     #[unstable(feature = "unstable", issue = "none")]
-    pub const fn bar() {} // ok for now
+    pub const fn bar() {} // ok because function is unstable
 }
 
-// FIXME When #![feature(const_trait_impl)] is stabilized, add tests for const
-// trait impls. Right now, a "trait methods cannot be stable const fn" error is
-// emitted, but that's not in the scope of this test.
+// FIXME Once #![feature(const_trait_impl)] is allowed to be stable, add a test
+// for const trait impls. Right now, a "trait methods cannot be stable const fn"
+// error is emitted. This occurs prior to the lint being tested here, such that
+// the lint cannot currently be tested on this use case.
 
 fn main() {}

--- a/src/test/ui/stability-attribute/missing-const-stability.rs
+++ b/src/test/ui/stability-attribute/missing-const-stability.rs
@@ -1,12 +1,24 @@
 #![feature(staged_api)]
+#![stable(feature = "stable", since = "1.0.0")]
 
-#![stable(feature = "rust1", since = "1.0.0")]
+#[stable(feature = "stable", since = "1.0.0")]
+pub const fn foo() {} //~ ERROR function has missing const stability attribute
 
-#[stable(feature = "foo", since = "1.0.0")]
-pub const fn foo() {}
-//~^ ERROR rustc_const_stable
+#[unstable(feature = "unstable", issue = "none")]
+pub const fn bar() {} // ok for now
 
-#[unstable(feature = "bar", issue = "none")]
-pub const fn bar() {} // ok
+#[stable(feature = "stable", since = "1.0.0")]
+pub struct Foo;
+impl Foo {
+    #[stable(feature = "stable", since = "1.0.0")]
+    pub const fn foo() {} //~ ERROR associated function has missing const stability attribute
+
+    #[unstable(feature = "unstable", issue = "none")]
+    pub const fn bar() {} // ok for now
+}
+
+// FIXME When #![feature(const_trait_impl)] is stabilized, add tests for const
+// trait impls. Right now, a "trait methods cannot be stable const fn" error is
+// emitted, but that's not in the scope of this test.
 
 fn main() {}

--- a/src/test/ui/stability-attribute/missing-const-stability.stderr
+++ b/src/test/ui/stability-attribute/missing-const-stability.stderr
@@ -1,11 +1,11 @@
 error: function has missing const stability attribute
-  --> $DIR/missing-const-stability.rs:5:1
+  --> $DIR/missing-const-stability.rs:6:1
    |
 LL | pub const fn foo() {}
    | ^^^^^^^^^^^^^^^^^^^^^
 
 error: associated function has missing const stability attribute
-  --> $DIR/missing-const-stability.rs:14:5
+  --> $DIR/missing-const-stability.rs:15:5
    |
 LL |     pub const fn foo() {}
    |     ^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/stability-attribute/missing-const-stability.stderr
+++ b/src/test/ui/stability-attribute/missing-const-stability.stderr
@@ -1,8 +1,14 @@
-error: `#[stable]` const functions must also be either `#[rustc_const_stable]` or `#[rustc_const_unstable]`
-  --> $DIR/missing-const-stability.rs:6:1
+error: function has missing const stability attribute
+  --> $DIR/missing-const-stability.rs:5:1
    |
 LL | pub const fn foo() {}
    | ^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to previous error
+error: associated function has missing const stability attribute
+  --> $DIR/missing-const-stability.rs:14:5
+   |
+LL |     pub const fn foo() {}
+   |     ^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
 


### PR DESCRIPTION
Successful merges:

 - #90998 (Require const stability attribute on all stable functions that are `const`)
 - #93489 (Mark the panic_no_unwind lang item as nounwind)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=90998,93489)
<!-- homu-ignore:end -->