### PR TITLE
Add `Option::reject` and `Iterator::reject`

### DIFF
--- a/library/core/src/iter/adapters/mod.rs
+++ b/library/core/src/iter/adapters/mod.rs
@@ -15,6 +15,7 @@ mod intersperse;
 mod map;
 mod map_while;
 mod peekable;
+mod reject;
 mod rev;
 mod scan;
 mod skip;
@@ -57,6 +58,9 @@ pub use self::zip::TrustedRandomAccessNoCoerce;
 
 #[stable(feature = "iter_zip", since = "1.59.0")]
 pub use self::zip::zip;
+
+#[unstable(feature = "option_iter_reject", issue = "none")]
+pub use self::reject::Reject;
 
 /// This trait provides transitive access to source-stage in an iterator-adapter pipeline
 /// under the conditions that

--- a/library/core/src/iter/adapters/reject.rs
+++ b/library/core/src/iter/adapters/reject.rs
@@ -1,0 +1,146 @@
+use crate::fmt;
+use crate::iter::{adapters::SourceIter, FusedIterator, InPlaceIterable};
+use crate::ops::Try;
+
+/// FIXME: add docs
+#[must_use = "iterators are lazy and do nothing unless consumed"]
+#[unstable(feature = "option_iter_reject", issue = "none")]
+#[derive(Clone)]
+pub struct Reject<I, P> {
+    iter: I,
+    predicate: P,
+}
+
+impl<I, P> Reject<I, P> {
+    pub(in crate::iter) fn new(iter: I, predicate: P) -> Reject<I, P> {
+        Reject { iter, predicate }
+    }
+}
+
+#[unstable(feature = "option_iter_reject", issue = "none")]
+impl<I: fmt::Debug, P> fmt::Debug for Reject<I, P> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Reject").field("iter", &self.iter).finish()
+    }
+}
+
+fn reject_fold<T, Acc>(
+    mut predicate: impl FnMut(&T) -> bool,
+    mut fold: impl FnMut(Acc, T) -> Acc,
+) -> impl FnMut(Acc, T) -> Acc {
+    move |acc, item| if !predicate(&item) { fold(acc, item) } else { acc }
+}
+
+fn reject_try_fold<'a, T, Acc, R: Try<Output = Acc>>(
+    predicate: &'a mut impl FnMut(&T) -> bool,
+    mut fold: impl FnMut(Acc, T) -> R + 'a,
+) -> impl FnMut(Acc, T) -> R + 'a {
+    move |acc, item| if !predicate(&item) { fold(acc, item) } else { try { acc } }
+}
+
+#[unstable(feature = "option_iter_reject", issue = "none")]
+impl<I: Iterator, P> Iterator for Reject<I, P>
+where
+    P: FnMut(&I::Item) -> bool,
+{
+    type Item = I::Item;
+
+    #[inline]
+    fn next(&mut self) -> Option<I::Item> {
+        self.iter.find(|v| !(self.predicate)(v))
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let (_, upper) = self.iter.size_hint();
+        (0, upper) // can't know a lower bound, due to the predicate
+    }
+
+    // this special case allows the compiler to make `.reject(_).count()`
+    // branchless. Barring perfect branch prediction (which is unattainable in
+    // the general case), this will be much faster in >90% of cases (containing
+    // virtually all real workloads) and only a tiny bit slower in the rest.
+    //
+    // Having this specialization thus allows us to write `.reject(p).count()`
+    // where we would otherwise write `.map(|x| !p(x) as usize).sum()`, which is
+    // less readable and also less backwards-compatible to Rust before 1.10.
+    //
+    // Using the branchless version will also simplify the LLVM byte code, thus
+    // leaving more budget for LLVM optimizations.
+    #[inline]
+    fn count(self) -> usize {
+        #[inline]
+        fn to_usize<T>(mut predicate: impl FnMut(&T) -> bool) -> impl FnMut(T) -> usize {
+            move |x| !predicate(&x) as usize
+        }
+
+        self.iter.map(to_usize(self.predicate)).sum()
+    }
+
+    #[inline]
+    fn try_fold<Acc, Fold, R>(&mut self, init: Acc, fold: Fold) -> R
+    where
+        Self: Sized,
+        Fold: FnMut(Acc, Self::Item) -> R,
+        R: Try<Output = Acc>,
+    {
+        self.iter.try_fold(init, reject_try_fold(&mut self.predicate, fold))
+    }
+
+    #[inline]
+    fn fold<Acc, Fold>(self, init: Acc, fold: Fold) -> Acc
+    where
+        Fold: FnMut(Acc, Self::Item) -> Acc,
+    {
+        self.iter.fold(init, reject_fold(self.predicate, fold))
+    }
+}
+
+#[unstable(feature = "option_iter_reject", issue = "none")]
+impl<I: DoubleEndedIterator, P> DoubleEndedIterator for Reject<I, P>
+where
+    P: FnMut(&I::Item) -> bool,
+{
+    #[inline]
+    fn next_back(&mut self) -> Option<I::Item> {
+        self.iter.rfind(|v| !(self.predicate)(v))
+    }
+
+    #[inline]
+    fn try_rfold<Acc, Fold, R>(&mut self, init: Acc, fold: Fold) -> R
+    where
+        Self: Sized,
+        Fold: FnMut(Acc, Self::Item) -> R,
+        R: Try<Output = Acc>,
+    {
+        self.iter.try_rfold(init, reject_try_fold(&mut self.predicate, fold))
+    }
+
+    #[inline]
+    fn rfold<Acc, Fold>(self, init: Acc, fold: Fold) -> Acc
+    where
+        Fold: FnMut(Acc, Self::Item) -> Acc,
+    {
+        self.iter.rfold(init, reject_fold(self.predicate, fold))
+    }
+}
+
+#[unstable(feature = "option_iter_reject", issue = "none")]
+impl<I: FusedIterator, P> FusedIterator for Reject<I, P> where P: FnMut(&I::Item) -> bool {}
+
+#[unstable(issue = "none", feature = "inplace_iteration")]
+unsafe impl<P, I> SourceIter for Reject<I, P>
+where
+    I: SourceIter,
+{
+    type Source = I::Source;
+
+    #[inline]
+    unsafe fn as_inner(&mut self) -> &mut I::Source {
+        // SAFETY: unsafe function forwarding to unsafe function with the same requirements
+        unsafe { SourceIter::as_inner(&mut self.iter) }
+    }
+}
+
+#[unstable(issue = "none", feature = "inplace_iteration")]
+unsafe impl<I: InPlaceIterable, P> InPlaceIterable for Reject<I, P> where P: FnMut(&I::Item) -> bool {}

--- a/library/core/src/iter/mod.rs
+++ b/library/core/src/iter/mod.rs
@@ -401,6 +401,8 @@ pub use self::adapters::Copied;
 pub use self::adapters::Flatten;
 #[stable(feature = "iter_map_while", since = "1.57.0")]
 pub use self::adapters::MapWhile;
+#[unstable(feature = "option_iter_reject", issue = "none")]
+pub use self::adapters::Reject;
 #[unstable(feature = "inplace_iteration", issue = "none")]
 pub use self::adapters::SourceIter;
 #[stable(feature = "iterator_step_by", since = "1.28.0")]

--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -2,7 +2,7 @@ use crate::cmp::{self, Ordering};
 use crate::ops::{ChangeOutputType, ControlFlow, FromResidual, Residual, Try};
 
 use super::super::TrustedRandomAccessNoCoerce;
-use super::super::{Chain, Cloned, Copied, Cycle, Enumerate, Filter, FilterMap, Fuse};
+use super::super::{Chain, Cloned, Copied, Cycle, Enumerate, Filter, FilterMap, Fuse, Reject};
 use super::super::{FlatMap, Flatten};
 use super::super::{FromIterator, Intersperse, IntersperseWith, Product, Sum, Zip};
 use super::super::{
@@ -840,6 +840,17 @@ pub trait Iterator {
         P: FnMut(&Self::Item) -> bool,
     {
         Filter::new(self, predicate)
+    }
+
+    /// FIXME: add docs
+    #[inline]
+    #[unstable(feature = "option_iter_reject", issue = "none")]
+    fn reject<P>(self, predicate: P) -> Reject<Self, P>
+    where
+        Self: Sized,
+        P: FnMut(&Self::Item) -> bool,
+    {
+        Reject::new(self, predicate)
     }
 
     /// Creates an iterator that both filters and maps.

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -1270,6 +1270,24 @@ impl<T> Option<T> {
         None
     }
 
+    /// FIXME: add docs
+    #[inline]
+    #[unstable(feature = "option_iter_reject", issue = "none")]
+    #[rustc_const_unstable(feature = "const_option_ext", issue = "91930")]
+    pub const fn reject<P>(self, predicate: P) -> Self
+    where
+        T: ~const Drop,
+        P: ~const FnOnce(&T) -> bool,
+        P: ~const Drop,
+    {
+        if let Some(x) = &self {
+            if predicate(x) {
+                return None;
+            }
+        }
+        self
+    }
+
     /// Returns the option if it contains a value, otherwise returns `optb`.
     ///
     /// Arguments passed to `or` are eagerly evaluated; if you are passing the

--- a/library/core/tests/iter/adapters/mod.rs
+++ b/library/core/tests/iter/adapters/mod.rs
@@ -12,6 +12,7 @@ mod inspect;
 mod intersperse;
 mod map;
 mod peekable;
+mod reject;
 mod scan;
 mod skip;
 mod skip_while;

--- a/library/core/tests/iter/adapters/reject.rs
+++ b/library/core/tests/iter/adapters/reject.rs
@@ -1,0 +1,63 @@
+use core::iter::*;
+
+#[test]
+fn test_iterator_reject() {
+    let mut iter = [0, 1, 2, 3, 4, 5, 6, 7, 8].iter().reject(|&&x| x % 2 == 0);
+
+    assert_eq!(iter.next().unwrap(), &1);
+    assert_eq!(iter.next().unwrap(), &3);
+    assert_eq!(iter.next().unwrap(), &5);
+    assert_eq!(iter.next().unwrap(), &7);
+    assert_eq!(iter.next(), None);
+}
+
+#[test]
+fn test_iterator_reject_count() {
+    let xs = [0, 1, 2, 3, 4, 5, 6, 7, 8];
+    assert_eq!(xs.iter().reject(|&&x| x % 2 == 0).count(), 4);
+}
+
+#[test]
+fn test_iterator_reject_fold() {
+    let xs = [0, 1, 2, 3, 4, 5, 6, 7, 8];
+    let ys = [1, 3, 5, 7];
+    let it = xs.iter().reject(|&&x| x % 2 == 0);
+    let i = it.fold(0, |i, &x| {
+        assert_eq!(x, ys[i]);
+        i + 1
+    });
+    assert_eq!(i, ys.len());
+
+    let it = xs.iter().reject(|&&x| x % 2 == 0);
+    let i = it.rfold(ys.len(), |i, &x| {
+        assert_eq!(x, ys[i - 1]);
+        i - 1
+    });
+    assert_eq!(i, 0);
+}
+
+#[test]
+fn test_reject_try_folds() {
+    fn p(&x: &i32) -> bool {
+        x < 0 || x >= 10
+    }
+    let f = &|acc, x| i32::checked_add(2 * acc, x);
+    assert_eq!((-10..20).reject(p).try_fold(7, f), (0..10).try_fold(7, f));
+    assert_eq!((-10..20).reject(p).try_rfold(7, f), (0..10).try_rfold(7, f));
+
+    let mut iter = (0..40).reject(|&x| x % 2 == 1);
+    assert_eq!(iter.try_fold(0, i8::checked_add), None);
+    assert_eq!(iter.next(), Some(24));
+    assert_eq!(iter.try_rfold(0, i8::checked_add), None);
+    assert_eq!(iter.next_back(), Some(30));
+}
+
+#[test]
+fn test_double_ended_reject() {
+    let xs = [1, 2, 3, 4, 5, 6];
+    let mut it = xs.iter().reject(|&x| *x & 1 == 0);
+    assert_eq!(it.next_back().unwrap(), &5);
+    assert_eq!(it.next_back().unwrap(), &3);
+    assert_eq!(it.next().unwrap(), &1);
+    assert_eq!(it.next_back(), None);
+}

--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -77,6 +77,7 @@
 #![feature(ptr_metadata)]
 #![feature(once_cell)]
 #![feature(option_result_contains)]
+#![feature(option_iter_reject)]
 #![feature(unsized_tuple_coercion)]
 #![feature(const_option)]
 #![feature(const_option_ext)]

--- a/library/core/tests/option.rs
+++ b/library/core/tests/option.rs
@@ -553,3 +553,19 @@ fn zip_unzip_roundtrip() {
     let a = z.unzip();
     assert_eq!(a, (x, y));
 }
+
+#[test]
+fn reject_options() {
+    let x = Some(10);
+    let y = Some("foo");
+    let z: Option<usize> = None;
+
+    assert_eq!(x.reject(|n| *n == 10), None);
+    assert_eq!(x.reject(|n| *n == 0), x);
+
+    assert_eq!(y.reject(|s| *s == "foo"), None);
+    assert_eq!(y.reject(|s| *s == "something else"), y);
+
+    assert_eq!(z.reject(|n| *n == 10), None);
+    assert_eq!(z.reject(|n| *n == 0), None);
+}


### PR DESCRIPTION
See #65669 for discussion about the addition of this method. I'll add docs to the methods if we decide that we want to move forward with this PR.

The other day I was doing some code review and I come across code like this:

```rust
enum Action {
    Action1,
    Action2,
    Action3,
    // ...
}

// ...

fn some_action_determination_function(/* args */) -> Option<Action> {
    let action = {
        // long, branchy code to pick an action based on function inputs
    };

    match action {
        Some(action) if action == Action::Action2 => some_condition.then(|| action),
        _ => action
    }
}
```

Here we have some long, complicated code to possibly determine an action based on inputs, and then we have a catch-all case that says "if we ended up with this action, only keep the action if some condition is true".

I wanted to suggest code along the lines of:

```rust
fn some_action_determination_function(/* args */) -> Option<Action> {
    let action = {
        // long, branchy code to pick an action based on function inputs
    };

    action.reject(|a| a == Action::Action2 && !some_condition)
}
```

to simplify this logic from a readability perspective. However, the stdlib doesn't have a method that does this, so I was unable to do so. The equivalent using `filter` is less readable than the match statement:

```rust
fn some_action_determination_function(/* args */) -> Option<Action> {
    let action = {
        // long, branchy code to pick an action based on function inputs
    };

    action.filter(|a| a != Action::Action2 || some_condition)
}
```

Here I have to carefully process the predicate to understand its impact on the entire set of actions, whereas with the example using `reject` (or the explicit `match` statement) my brain can immediately scope down to "our predicate can affect this specific action only, and no others".

I then did a quick search for discussion about adding something like this to the stdlib and found #65669. That issue only mentions adding `Iterator::reject`, which I went ahead and did alongside `Option::reject`.

Thoughts welcome! Happy to close this PR out if we decide it's not worth adding.

## Unresolved questions

* Can we share code with `Iterator::filter` (ideally we just negate the predicate the user passes in and create a `Filter` with it?)