### PR TITLE
Rename `first*`/`last*` `BTree{Set,Map}` methods to `min*`/`max*`

### DIFF
--- a/library/alloc/benches/btree/map.rs
+++ b/library/alloc/benches/btree/map.rs
@@ -227,17 +227,17 @@ pub fn iteration_mut_100000(b: &mut Bencher) {
     bench_iteration_mut(b, 100000);
 }
 
-fn bench_first_and_last_nightly(b: &mut Bencher, size: i32) {
+fn bench_min_and_max_nightly(b: &mut Bencher, size: i32) {
     let map: BTreeMap<_, _> = (0..size).map(|i| (i, i)).collect();
     b.iter(|| {
         for _ in 0..10 {
-            black_box(map.first_key_value());
-            black_box(map.last_key_value());
+            black_box(map.min_key_value());
+            black_box(map.max_key_value());
         }
     });
 }
 
-fn bench_first_and_last_stable(b: &mut Bencher, size: i32) {
+fn bench_min_and_max_stable(b: &mut Bencher, size: i32) {
     let map: BTreeMap<_, _> = (0..size).map(|i| (i, i)).collect();
     b.iter(|| {
         for _ in 0..10 {
@@ -248,33 +248,33 @@ fn bench_first_and_last_stable(b: &mut Bencher, size: i32) {
 }
 
 #[bench]
-pub fn first_and_last_0_nightly(b: &mut Bencher) {
-    bench_first_and_last_nightly(b, 0);
+pub fn min_and_max_0_nightly(b: &mut Bencher) {
+    bench_min_and_max_nightly(b, 0);
 }
 
 #[bench]
-pub fn first_and_last_0_stable(b: &mut Bencher) {
-    bench_first_and_last_stable(b, 0);
+pub fn min_and_max_0_stable(b: &mut Bencher) {
+    bench_min_and_max_stable(b, 0);
 }
 
 #[bench]
-pub fn first_and_last_100_nightly(b: &mut Bencher) {
-    bench_first_and_last_nightly(b, 100);
+pub fn min_and_max_100_nightly(b: &mut Bencher) {
+    bench_min_and_max_nightly(b, 100);
 }
 
 #[bench]
-pub fn first_and_last_100_stable(b: &mut Bencher) {
-    bench_first_and_last_stable(b, 100);
+pub fn min_and_max_100_stable(b: &mut Bencher) {
+    bench_min_and_max_stable(b, 100);
 }
 
 #[bench]
-pub fn first_and_last_10k_nightly(b: &mut Bencher) {
-    bench_first_and_last_nightly(b, 10_000);
+pub fn min_and_max_10k_nightly(b: &mut Bencher) {
+    bench_min_and_max_nightly(b, 10_000);
 }
 
 #[bench]
-pub fn first_and_last_10k_stable(b: &mut Bencher) {
-    bench_first_and_last_stable(b, 10_000);
+pub fn min_and_max_10k_stable(b: &mut Bencher) {
+    bench_min_and_max_stable(b, 10_000);
 }
 
 const BENCH_RANGE_SIZE: i32 = 145;
@@ -410,7 +410,7 @@ pub fn clone_slim_100_and_pop_all(b: &mut Bencher) {
     let src = slim_map(100);
     b.iter(|| {
         let mut map = src.clone();
-        while map.pop_first().is_some() {}
+        while map.pop_min().is_some() {}
         map
     });
 }
@@ -481,7 +481,7 @@ pub fn clone_slim_10k_and_pop_all(b: &mut Bencher) {
     let src = slim_map(10_000);
     b.iter(|| {
         let mut map = src.clone();
-        while map.pop_first().is_some() {}
+        while map.pop_min().is_some() {}
         map
     });
 }
@@ -552,7 +552,7 @@ pub fn clone_fat_val_100_and_pop_all(b: &mut Bencher) {
     let src = fat_val_map(100);
     b.iter(|| {
         let mut map = src.clone();
-        while map.pop_first().is_some() {}
+        while map.pop_min().is_some() {}
         map
     });
 }

--- a/library/alloc/benches/btree/set.rs
+++ b/library/alloc/benches/btree/set.rs
@@ -93,7 +93,7 @@ pub fn clone_100_and_pop_all(b: &mut Bencher) {
     let src = slim_set(100);
     b.iter(|| {
         let mut set = src.clone();
-        while set.pop_first().is_some() {}
+        while set.pop_min().is_some() {}
         set
     });
 }
@@ -164,7 +164,7 @@ pub fn clone_10k_and_pop_all(b: &mut Bencher) {
     let src = slim_set(10_000);
     b.iter(|| {
         let mut set = src.clone();
-        while set.pop_first().is_some() {}
+        while set.pop_min().is_some() {}
         set
     });
 }

--- a/library/alloc/src/collections/btree/map.rs
+++ b/library/alloc/src/collections/btree/map.rs
@@ -600,8 +600,7 @@ impl<K, V> BTreeMap<K, V> {
         }
     }
 
-    /// Returns the first key-value pair in the map.
-    /// The key in this pair is the minimum key in the map.
+    /// Returns the key-value pair with the minimum key in the map.
     ///
     /// # Examples
     ///
@@ -612,13 +611,13 @@ impl<K, V> BTreeMap<K, V> {
     /// use std::collections::BTreeMap;
     ///
     /// let mut map = BTreeMap::new();
-    /// assert_eq!(map.first_key_value(), None);
+    /// assert_eq!(map.min_key_value(), None);
     /// map.insert(1, "b");
     /// map.insert(2, "a");
-    /// assert_eq!(map.first_key_value(), Some((&1, &"b")));
+    /// assert_eq!(map.min_key_value(), Some((&1, &"b")));
     /// ```
     #[unstable(feature = "map_first_last", issue = "62924")]
-    pub fn first_key_value(&self) -> Option<(&K, &V)>
+    pub fn min_key_value(&self) -> Option<(&K, &V)>
     where
         K: Ord,
     {
@@ -626,8 +625,7 @@ impl<K, V> BTreeMap<K, V> {
         root_node.first_leaf_edge().right_kv().ok().map(Handle::into_kv)
     }
 
-    /// Returns the first entry in the map for in-place manipulation.
-    /// The key of this entry is the minimum key in the map.
+    /// Returns the entry with the minimum key in the map for in-place manipulation.
     ///
     /// # Examples
     ///
@@ -638,16 +636,16 @@ impl<K, V> BTreeMap<K, V> {
     /// let mut map = BTreeMap::new();
     /// map.insert(1, "a");
     /// map.insert(2, "b");
-    /// if let Some(mut entry) = map.first_entry() {
+    /// if let Some(mut entry) = map.min_entry() {
     ///     if *entry.key() > 0 {
-    ///         entry.insert("first");
+    ///         entry.insert("min");
     ///     }
     /// }
-    /// assert_eq!(*map.get(&1).unwrap(), "first");
+    /// assert_eq!(*map.get(&1).unwrap(), "min");
     /// assert_eq!(*map.get(&2).unwrap(), "b");
     /// ```
     #[unstable(feature = "map_first_last", issue = "62924")]
-    pub fn first_entry(&mut self) -> Option<OccupiedEntry<'_, K, V>>
+    pub fn min_entry(&mut self) -> Option<OccupiedEntry<'_, K, V>>
     where
         K: Ord,
     {
@@ -657,8 +655,7 @@ impl<K, V> BTreeMap<K, V> {
         Some(OccupiedEntry { handle: kv.forget_node_type(), dormant_map, _marker: PhantomData })
     }
 
-    /// Removes and returns the first element in the map.
-    /// The key of this element is the minimum key that was in the map.
+    /// Removes and returns the key-value pair with the minimum key in the map.
     ///
     /// # Examples
     ///
@@ -671,21 +668,21 @@ impl<K, V> BTreeMap<K, V> {
     /// let mut map = BTreeMap::new();
     /// map.insert(1, "a");
     /// map.insert(2, "b");
-    /// while let Some((key, _val)) = map.pop_first() {
+    /// while let Some((key, _val)) = map.pop_min() {
     ///     assert!(map.iter().all(|(k, _v)| *k > key));
     /// }
     /// assert!(map.is_empty());
     /// ```
     #[unstable(feature = "map_first_last", issue = "62924")]
-    pub fn pop_first(&mut self) -> Option<(K, V)>
+    pub fn pop_min(&mut self) -> Option<(K, V)>
     where
         K: Ord,
     {
-        self.first_entry().map(|entry| entry.remove_entry())
+        self.min_entry().map(|entry| entry.remove_entry())
     }
 
-    /// Returns the last key-value pair in the map.
-    /// The key in this pair is the maximum key in the map.
+    /// Returns the key-value pair with the maximum key in the
+    /// map. The key in this pair is the maximum key in the map.
     ///
     /// # Examples
     ///
@@ -698,10 +695,10 @@ impl<K, V> BTreeMap<K, V> {
     /// let mut map = BTreeMap::new();
     /// map.insert(1, "b");
     /// map.insert(2, "a");
-    /// assert_eq!(map.last_key_value(), Some((&2, &"a")));
+    /// assert_eq!(map.max_key_value(), Some((&2, &"a")));
     /// ```
     #[unstable(feature = "map_first_last", issue = "62924")]
-    pub fn last_key_value(&self) -> Option<(&K, &V)>
+    pub fn max_key_value(&self) -> Option<(&K, &V)>
     where
         K: Ord,
     {
@@ -709,8 +706,7 @@ impl<K, V> BTreeMap<K, V> {
         root_node.last_leaf_edge().left_kv().ok().map(Handle::into_kv)
     }
 
-    /// Returns the last entry in the map for in-place manipulation.
-    /// The key of this entry is the maximum key in the map.
+    /// Returns the entry with the maximum key in the map for in-place manipulation.
     ///
     /// # Examples
     ///
@@ -721,16 +717,16 @@ impl<K, V> BTreeMap<K, V> {
     /// let mut map = BTreeMap::new();
     /// map.insert(1, "a");
     /// map.insert(2, "b");
-    /// if let Some(mut entry) = map.last_entry() {
+    /// if let Some(mut entry) = map.max_entry() {
     ///     if *entry.key() > 0 {
-    ///         entry.insert("last");
+    ///         entry.insert("max");
     ///     }
     /// }
     /// assert_eq!(*map.get(&1).unwrap(), "a");
-    /// assert_eq!(*map.get(&2).unwrap(), "last");
+    /// assert_eq!(*map.get(&2).unwrap(), "max");
     /// ```
     #[unstable(feature = "map_first_last", issue = "62924")]
-    pub fn last_entry(&mut self) -> Option<OccupiedEntry<'_, K, V>>
+    pub fn max_entry(&mut self) -> Option<OccupiedEntry<'_, K, V>>
     where
         K: Ord,
     {
@@ -740,8 +736,7 @@ impl<K, V> BTreeMap<K, V> {
         Some(OccupiedEntry { handle: kv.forget_node_type(), dormant_map, _marker: PhantomData })
     }
 
-    /// Removes and returns the last element in the map.
-    /// The key of this element is the maximum key that was in the map.
+    /// Removes and returns the key-value pair with the maximum key in the map.
     ///
     /// # Examples
     ///
@@ -754,17 +749,17 @@ impl<K, V> BTreeMap<K, V> {
     /// let mut map = BTreeMap::new();
     /// map.insert(1, "a");
     /// map.insert(2, "b");
-    /// while let Some((key, _val)) = map.pop_last() {
+    /// while let Some((key, _val)) = map.pop_max() {
     ///     assert!(map.iter().all(|(k, _v)| *k < key));
     /// }
     /// assert!(map.is_empty());
     /// ```
     #[unstable(feature = "map_first_last", issue = "62924")]
-    pub fn pop_last(&mut self) -> Option<(K, V)>
+    pub fn pop_max(&mut self) -> Option<(K, V)>
     where
         K: Ord,
     {
-        self.last_entry().map(|entry| entry.remove_entry())
+        self.max_entry().map(|entry| entry.remove_entry())
     }
 
     /// Returns `true` if the map contains a value for the specified key.

--- a/library/alloc/src/collections/btree/map/tests.rs
+++ b/library/alloc/src/collections/btree/map/tests.rs
@@ -144,7 +144,7 @@ fn test_levels() {
 
     map.insert(0, ());
     while map.height() == Some(0) {
-        let last_key = *map.last_key_value().unwrap().0;
+        let last_key = *map.max_key_value().unwrap().0;
         map.insert(last_key + 1, ());
     }
     map.check();
@@ -156,7 +156,7 @@ fn test_levels() {
     assert_eq!(map.len(), MIN_INSERTS_HEIGHT_1, "{}", map.dump_keys());
 
     while map.height() == Some(1) {
-        let last_key = *map.last_key_value().unwrap().0;
+        let last_key = *map.max_key_value().unwrap().0;
         map.insert(last_key + 1, ());
     }
     map.check();
@@ -203,10 +203,10 @@ fn test_basic_large() {
         assert_eq!(map.len(), i + 1);
     }
 
-    assert_eq!(map.first_key_value(), Some((&0, &0)));
-    assert_eq!(map.last_key_value(), Some((&(size - 1), &(10 * (size - 1)))));
-    assert_eq!(map.first_entry().unwrap().key(), &0);
-    assert_eq!(map.last_entry().unwrap().key(), &(size - 1));
+    assert_eq!(map.min_key_value(), Some((&0, &0)));
+    assert_eq!(map.max_key_value(), Some((&(size - 1), &(10 * (size - 1)))));
+    assert_eq!(map.min_entry().unwrap().key(), &0);
+    assert_eq!(map.max_entry().unwrap().key(), &(size - 1));
 
     for i in 0..size {
         assert_eq!(map.get(&i).unwrap(), &(i * 10));
@@ -251,8 +251,8 @@ fn test_basic_small() {
     assert_eq!(map.len(), 0);
     assert_eq!(map.get(&1), None);
     assert_eq!(map.get_mut(&1), None);
-    assert_eq!(map.first_key_value(), None);
-    assert_eq!(map.last_key_value(), None);
+    assert_eq!(map.min_key_value(), None);
+    assert_eq!(map.max_key_value(), None);
     assert_eq!(map.keys().count(), 0);
     assert_eq!(map.values().count(), 0);
     assert_eq!(map.range(..).next(), None);
@@ -269,16 +269,16 @@ fn test_basic_small() {
     assert_eq!(map.len(), 1);
     assert_eq!(map.get(&1), Some(&1));
     assert_eq!(map.get_mut(&1), Some(&mut 1));
-    assert_eq!(map.first_key_value(), Some((&1, &1)));
-    assert_eq!(map.last_key_value(), Some((&1, &1)));
+    assert_eq!(map.min_key_value(), Some((&1, &1)));
+    assert_eq!(map.max_key_value(), Some((&1, &1)));
     assert_eq!(map.keys().collect::<Vec<_>>(), vec![&1]);
     assert_eq!(map.values().collect::<Vec<_>>(), vec![&1]);
     assert_eq!(map.insert(1, 2), Some(1));
     assert_eq!(map.len(), 1);
     assert_eq!(map.get(&1), Some(&2));
     assert_eq!(map.get_mut(&1), Some(&mut 2));
-    assert_eq!(map.first_key_value(), Some((&1, &2)));
-    assert_eq!(map.last_key_value(), Some((&1, &2)));
+    assert_eq!(map.min_key_value(), Some((&1, &2)));
+    assert_eq!(map.max_key_value(), Some((&1, &2)));
     assert_eq!(map.keys().collect::<Vec<_>>(), vec![&1]);
     assert_eq!(map.values().collect::<Vec<_>>(), vec![&2]);
     assert_eq!(map.insert(2, 4), None);
@@ -289,8 +289,8 @@ fn test_basic_small() {
     assert_eq!(map.len(), 2);
     assert_eq!(map.get(&2), Some(&4));
     assert_eq!(map.get_mut(&2), Some(&mut 4));
-    assert_eq!(map.first_key_value(), Some((&1, &2)));
-    assert_eq!(map.last_key_value(), Some((&2, &4)));
+    assert_eq!(map.min_key_value(), Some((&1, &2)));
+    assert_eq!(map.max_key_value(), Some((&2, &4)));
     assert_eq!(map.keys().collect::<Vec<_>>(), vec![&1, &2]);
     assert_eq!(map.values().collect::<Vec<_>>(), vec![&2, &4]);
     assert_eq!(map.remove(&1), Some(2));
@@ -303,8 +303,8 @@ fn test_basic_small() {
     assert_eq!(map.get_mut(&1), None);
     assert_eq!(map.get(&2), Some(&4));
     assert_eq!(map.get_mut(&2), Some(&mut 4));
-    assert_eq!(map.first_key_value(), Some((&2, &4)));
-    assert_eq!(map.last_key_value(), Some((&2, &4)));
+    assert_eq!(map.min_key_value(), Some((&2, &4)));
+    assert_eq!(map.max_key_value(), Some((&2, &4)));
     assert_eq!(map.keys().collect::<Vec<_>>(), vec![&2]);
     assert_eq!(map.values().collect::<Vec<_>>(), vec![&4]);
     assert_eq!(map.remove(&2), Some(4));
@@ -315,8 +315,8 @@ fn test_basic_small() {
     assert_eq!(map.len(), 0);
     assert_eq!(map.get(&1), None);
     assert_eq!(map.get_mut(&1), None);
-    assert_eq!(map.first_key_value(), None);
-    assert_eq!(map.last_key_value(), None);
+    assert_eq!(map.min_key_value(), None);
+    assert_eq!(map.max_key_value(), None);
     assert_eq!(map.keys().count(), 0);
     assert_eq!(map.values().count(), 0);
     assert_eq!(map.range(..).next(), None);
@@ -1160,8 +1160,8 @@ mod test_drain_filter {
         assert_eq!(b.dropped(), 0);
         assert_eq!(c.dropped(), 0);
         assert_eq!(map.len(), 2);
-        assert_eq!(map.first_entry().unwrap().key().id(), 1);
-        assert_eq!(map.last_entry().unwrap().key().id(), 2);
+        assert_eq!(map.min_entry().unwrap().key().id(), 1);
+        assert_eq!(map.max_entry().unwrap().key().id(), 2);
         map.check();
     }
 
@@ -1192,8 +1192,8 @@ mod test_drain_filter {
         assert_eq!(b.dropped(), 0);
         assert_eq!(c.dropped(), 0);
         assert_eq!(map.len(), 2);
-        assert_eq!(map.first_entry().unwrap().key().id(), 1);
-        assert_eq!(map.last_entry().unwrap().key().id(), 2);
+        assert_eq!(map.min_entry().unwrap().key().id(), 1);
+        assert_eq!(map.max_entry().unwrap().key().id(), 2);
         map.check();
     }
 }
@@ -1823,27 +1823,27 @@ fn test_vacant_entry_key() {
 }
 
 #[test]
-fn test_first_last_entry() {
+fn test_min_max_entry() {
     let mut a = BTreeMap::new();
-    assert!(a.first_entry().is_none());
-    assert!(a.last_entry().is_none());
+    assert!(a.min_entry().is_none());
+    assert!(a.max_entry().is_none());
     a.insert(1, 42);
-    assert_eq!(a.first_entry().unwrap().key(), &1);
-    assert_eq!(a.last_entry().unwrap().key(), &1);
+    assert_eq!(a.min_entry().unwrap().key(), &1);
+    assert_eq!(a.max_entry().unwrap().key(), &1);
     a.insert(2, 24);
-    assert_eq!(a.first_entry().unwrap().key(), &1);
-    assert_eq!(a.last_entry().unwrap().key(), &2);
+    assert_eq!(a.min_entry().unwrap().key(), &1);
+    assert_eq!(a.max_entry().unwrap().key(), &2);
     a.insert(0, 6);
-    assert_eq!(a.first_entry().unwrap().key(), &0);
-    assert_eq!(a.last_entry().unwrap().key(), &2);
-    let (k1, v1) = a.first_entry().unwrap().remove_entry();
+    assert_eq!(a.min_entry().unwrap().key(), &0);
+    assert_eq!(a.max_entry().unwrap().key(), &2);
+    let (k1, v1) = a.min_entry().unwrap().remove_entry();
     assert_eq!(k1, 0);
     assert_eq!(v1, 6);
-    let (k2, v2) = a.last_entry().unwrap().remove_entry();
+    let (k2, v2) = a.max_entry().unwrap().remove_entry();
     assert_eq!(k2, 2);
     assert_eq!(v2, 24);
-    assert_eq!(a.first_entry().unwrap().key(), &1);
-    assert_eq!(a.last_entry().unwrap().key(), &1);
+    assert_eq!(a.min_entry().unwrap().key(), &1);
+    assert_eq!(a.max_entry().unwrap().key(), &1);
     a.check();
 }
 
@@ -2013,8 +2013,8 @@ fn test_split_off_tiny_left_height_2() {
     right.check();
     assert_eq!(left.len(), 1);
     assert_eq!(right.len(), MIN_INSERTS_HEIGHT_2 - 1);
-    assert_eq!(*left.first_key_value().unwrap().0, 0);
-    assert_eq!(*right.first_key_value().unwrap().0, 1);
+    assert_eq!(*left.min_key_value().unwrap().0, 0);
+    assert_eq!(*right.min_key_value().unwrap().0, 1);
 }
 
 // In a tree with 3 levels, if only part of the last leaf node is split off,
@@ -2024,14 +2024,14 @@ fn test_split_off_tiny_right_height_2() {
     let pairs = (0..MIN_INSERTS_HEIGHT_2).map(|i| (i, i));
     let last = MIN_INSERTS_HEIGHT_2 - 1;
     let mut left = BTreeMap::from_iter(pairs.clone());
-    assert_eq!(*left.last_key_value().unwrap().0, last);
+    assert_eq!(*left.max_key_value().unwrap().0, last);
     let right = left.split_off(&last);
     left.check();
     right.check();
     assert_eq!(left.len(), MIN_INSERTS_HEIGHT_2 - 1);
     assert_eq!(right.len(), 1);
-    assert_eq!(*left.last_key_value().unwrap().0, last - 1);
-    assert_eq!(*right.last_key_value().unwrap().0, last);
+    assert_eq!(*left.max_key_value().unwrap().0, last - 1);
+    assert_eq!(*right.max_key_value().unwrap().0, last);
 }
 
 #[test]

--- a/library/alloc/src/collections/btree/set.rs
+++ b/library/alloc/src/collections/btree/set.rs
@@ -324,13 +324,13 @@ impl<T> BTreeSet<T> {
         T: Ord,
     {
         let (self_min, self_max) =
-            if let (Some(self_min), Some(self_max)) = (self.first(), self.last()) {
+            if let (Some(self_min), Some(self_max)) = (self.get_min(), self.get_max()) {
                 (self_min, self_max)
             } else {
                 return Difference { inner: DifferenceInner::Iterate(self.iter()) };
             };
         let (other_min, other_max) =
-            if let (Some(other_min), Some(other_max)) = (other.first(), other.last()) {
+            if let (Some(other_min), Some(other_max)) = (other.get_min(), other.get_max()) {
                 (other_min, other_max)
             } else {
                 return Difference { inner: DifferenceInner::Iterate(self.iter()) };
@@ -413,13 +413,13 @@ impl<T> BTreeSet<T> {
         T: Ord,
     {
         let (self_min, self_max) =
-            if let (Some(self_min), Some(self_max)) = (self.first(), self.last()) {
+            if let (Some(self_min), Some(self_max)) = (self.get_min(), self.get_max()) {
                 (self_min, self_max)
             } else {
                 return Intersection { inner: IntersectionInner::Answer(None) };
             };
         let (other_min, other_max) =
-            if let (Some(other_min), Some(other_max)) = (other.first(), other.last()) {
+            if let (Some(other_min), Some(other_max)) = (other.get_min(), other.get_max()) {
                 (other_min, other_max)
             } else {
                 return Intersection { inner: IntersectionInner::Answer(None) };
@@ -587,13 +587,13 @@ impl<T> BTreeSet<T> {
             return false;
         }
         let (self_min, self_max) =
-            if let (Some(self_min), Some(self_max)) = (self.first(), self.last()) {
+            if let (Some(self_min), Some(self_max)) = (self.get_min(), self.get_max()) {
                 (self_min, self_max)
             } else {
                 return true; // self is empty
             };
         let (other_min, other_max) =
-            if let (Some(other_min), Some(other_max)) = (other.first(), other.last()) {
+            if let (Some(other_min), Some(other_max)) = (other.get_min(), other.get_max()) {
                 (other_min, other_max)
             } else {
                 return false; // other is empty
@@ -664,8 +664,7 @@ impl<T> BTreeSet<T> {
         other.is_subset(self)
     }
 
-    /// Returns a reference to the first element in the set, if any.
-    /// This element is always the minimum of all elements in the set.
+    /// Returns a reference to the minumum element in the set, if any.
     ///
     /// # Examples
     ///
@@ -676,23 +675,22 @@ impl<T> BTreeSet<T> {
     /// use std::collections::BTreeSet;
     ///
     /// let mut set = BTreeSet::new();
-    /// assert_eq!(set.first(), None);
+    /// assert_eq!(set.get_min(), None);
     /// set.insert(1);
-    /// assert_eq!(set.first(), Some(&1));
+    /// assert_eq!(set.get_min(), Some(&1));
     /// set.insert(2);
-    /// assert_eq!(set.first(), Some(&1));
+    /// assert_eq!(set.get_min(), Some(&1));
     /// ```
     #[must_use]
     #[unstable(feature = "map_first_last", issue = "62924")]
-    pub fn first(&self) -> Option<&T>
+    pub fn get_min(&self) -> Option<&T>
     where
         T: Ord,
     {
-        self.map.first_key_value().map(|(k, _)| k)
+        self.map.min_key_value().map(|(k, _)| k)
     }
 
-    /// Returns a reference to the last element in the set, if any.
-    /// This element is always the maximum of all elements in the set.
+    /// Returns a reference to the maximum element in the set, if any.
     ///
     /// # Examples
     ///
@@ -703,23 +701,22 @@ impl<T> BTreeSet<T> {
     /// use std::collections::BTreeSet;
     ///
     /// let mut set = BTreeSet::new();
-    /// assert_eq!(set.last(), None);
+    /// assert_eq!(set.get_max(), None);
     /// set.insert(1);
-    /// assert_eq!(set.last(), Some(&1));
+    /// assert_eq!(set.get_max(), Some(&1));
     /// set.insert(2);
-    /// assert_eq!(set.last(), Some(&2));
+    /// assert_eq!(set.get_max(), Some(&2));
     /// ```
     #[must_use]
     #[unstable(feature = "map_first_last", issue = "62924")]
-    pub fn last(&self) -> Option<&T>
+    pub fn get_max(&self) -> Option<&T>
     where
         T: Ord,
     {
-        self.map.last_key_value().map(|(k, _)| k)
+        self.map.max_key_value().map(|(k, _)| k)
     }
 
-    /// Removes the first element from the set and returns it, if any.
-    /// The first element is always the minimum element in the set.
+    /// Removes the minimum element from the set and returns it, if any.
     ///
     /// # Examples
     ///
@@ -730,21 +727,20 @@ impl<T> BTreeSet<T> {
     /// let mut set = BTreeSet::new();
     ///
     /// set.insert(1);
-    /// while let Some(n) = set.pop_first() {
+    /// while let Some(n) = set.pop_min() {
     ///     assert_eq!(n, 1);
     /// }
     /// assert!(set.is_empty());
     /// ```
     #[unstable(feature = "map_first_last", issue = "62924")]
-    pub fn pop_first(&mut self) -> Option<T>
+    pub fn pop_min(&mut self) -> Option<T>
     where
         T: Ord,
     {
-        self.map.pop_first().map(|kv| kv.0)
+        self.map.pop_min().map(|kv| kv.0)
     }
 
-    /// Removes the last element from the set and returns it, if any.
-    /// The last element is always the maximum element in the set.
+    /// Removes the maximum element from the set and returns it, if any.
     ///
     /// # Examples
     ///
@@ -755,17 +751,17 @@ impl<T> BTreeSet<T> {
     /// let mut set = BTreeSet::new();
     ///
     /// set.insert(1);
-    /// while let Some(n) = set.pop_last() {
+    /// while let Some(n) = set.pop_max() {
     ///     assert_eq!(n, 1);
     /// }
     /// assert!(set.is_empty());
     /// ```
     #[unstable(feature = "map_first_last", issue = "62924")]
-    pub fn pop_last(&mut self) -> Option<T>
+    pub fn pop_max(&mut self) -> Option<T>
     where
         T: Ord,
     {
-        self.map.pop_last().map(|kv| kv.0)
+        self.map.pop_max().map(|kv| kv.0)
     }
 
     /// Adds a value to the set.

--- a/library/alloc/src/collections/btree/set/tests.rs
+++ b/library/alloc/src/collections/btree/set/tests.rs
@@ -379,8 +379,8 @@ fn test_drain_filter_pred_panic_leak() {
     assert_eq!(b.dropped(), 0);
     assert_eq!(c.dropped(), 0);
     assert_eq!(set.len(), 2);
-    assert_eq!(set.first().unwrap().id(), 1);
-    assert_eq!(set.last().unwrap().id(), 2);
+    assert_eq!(set.get_min().unwrap().id(), 1);
+    assert_eq!(set.get_max().unwrap().id(), 2);
 }
 
 #[test]
@@ -690,36 +690,36 @@ fn test_append() {
 }
 
 #[test]
-fn test_first_last() {
+fn test_min_max() {
     let mut a = BTreeSet::new();
-    assert_eq!(a.first(), None);
-    assert_eq!(a.last(), None);
+    assert_eq!(a.get_min(), None);
+    assert_eq!(a.get_max(), None);
     a.insert(1);
-    assert_eq!(a.first(), Some(&1));
-    assert_eq!(a.last(), Some(&1));
+    assert_eq!(a.get_min(), Some(&1));
+    assert_eq!(a.get_max(), Some(&1));
     a.insert(2);
-    assert_eq!(a.first(), Some(&1));
-    assert_eq!(a.last(), Some(&2));
+    assert_eq!(a.get_min(), Some(&1));
+    assert_eq!(a.get_max(), Some(&2));
     for i in 3..=12 {
         a.insert(i);
     }
-    assert_eq!(a.first(), Some(&1));
-    assert_eq!(a.last(), Some(&12));
-    assert_eq!(a.pop_first(), Some(1));
-    assert_eq!(a.pop_last(), Some(12));
-    assert_eq!(a.pop_first(), Some(2));
-    assert_eq!(a.pop_last(), Some(11));
-    assert_eq!(a.pop_first(), Some(3));
-    assert_eq!(a.pop_last(), Some(10));
-    assert_eq!(a.pop_first(), Some(4));
-    assert_eq!(a.pop_first(), Some(5));
-    assert_eq!(a.pop_first(), Some(6));
-    assert_eq!(a.pop_first(), Some(7));
-    assert_eq!(a.pop_first(), Some(8));
-    assert_eq!(a.clone().pop_last(), Some(9));
-    assert_eq!(a.pop_first(), Some(9));
-    assert_eq!(a.pop_first(), None);
-    assert_eq!(a.pop_last(), None);
+    assert_eq!(a.get_min(), Some(&1));
+    assert_eq!(a.get_max(), Some(&12));
+    assert_eq!(a.pop_min(), Some(1));
+    assert_eq!(a.pop_max(), Some(12));
+    assert_eq!(a.pop_min(), Some(2));
+    assert_eq!(a.pop_max(), Some(11));
+    assert_eq!(a.pop_min(), Some(3));
+    assert_eq!(a.pop_max(), Some(10));
+    assert_eq!(a.pop_min(), Some(4));
+    assert_eq!(a.pop_min(), Some(5));
+    assert_eq!(a.pop_min(), Some(6));
+    assert_eq!(a.pop_min(), Some(7));
+    assert_eq!(a.pop_min(), Some(8));
+    assert_eq!(a.clone().pop_max(), Some(9));
+    assert_eq!(a.pop_min(), Some(9));
+    assert_eq!(a.pop_min(), None);
+    assert_eq!(a.pop_max(), None);
 }
 
 // Unlike the function with the same name in map/tests, returns no values.


### PR DESCRIPTION
On the [tracking issue](https://github.com/rust-lang/rust/issues/62924) there a lot of discussions on the names of these methods.

I propose that
1. libs team should make a final decision about the names, so we can move towards stabilization
2. the names should be changed to `min*`/`max*` (reasoning below)

----

TL;DR this PR renames first*/last* methods of `BTreeMap` and `BTreeSet` as follows:
```rust
impl<K: Ord, V> BTreeMap<K, V> {
    pub fn min_key_value(&self) -> Option<(&K, &V)>;
    pub fn max_key_value(&self) -> Option<(&K, &V)>;

    pub fn min_entry(&mut self) -> Option<OccupiedEntry<'_, K, V>>;
    pub fn max_entry(&mut self) -> Option<OccupiedEntry<'_, K, V>>;

    pub fn pop_min(&mut self) -> Option<(K, V)>;
    pub fn pop_max(&mut self) -> Option<(K, V)>;
}

impl<T: Ord> BTreeSet {
    pub fn get_min(&self) -> Option<&T>;
    pub fn get_max(&self) -> Option<&T>;

    pub fn pop_min(&mut self) -> Option<T>;
    pub fn pop_max(&mut self) -> Option<T>;
}
```
----

In my opinion min/max terminology is a lot more self-documenting and less ambiguous. You can actually see that documentation is simplified a little, because there is no need to explain what "first" and "last" mean. The fact that first/last required explanation that they actually mean min/max suggests that min/max is a better naming.

You may also notice that std's usage of `BTreeSet` binded values returned from these methods to variables with `_min` and `_max`, which implies that this is what the code cares about and not firstness/lastness:
>  ```diff 
>  -if let (Some(self_min), Some(self_max)) = (self.first(), self.last()) {
>  +if let (Some(self_min), Some(self_max)) = (self.get_min(), self.get_max()) {
>  ```