### PR TITLE
Fix horizontal trim for block doc comments

### DIFF
--- a/compiler/rustc_ast/src/util/comments/tests.rs
+++ b/compiler/rustc_ast/src/util/comments/tests.rs
@@ -45,25 +45,17 @@ fn test_line_doc_comment() {
 #[test]
 fn test_doc_blocks() {
     create_default_session_globals_then(|| {
+        let stripped =
+            beautify_doc_string(Symbol::intern(" # Returns\n     *\n     "), CommentKind::Block);
+        assert_eq!(stripped.as_str(), " # Returns\n\n");
+
         let stripped = beautify_doc_string(
-            Symbol::intern(
-                " # Returns
-     *
-     ",
-            ),
+            Symbol::intern("\n     * # Returns\n     *\n     "),
             CommentKind::Block,
         );
         assert_eq!(stripped.as_str(), " # Returns\n\n");
 
-        let stripped = beautify_doc_string(
-            Symbol::intern(
-                "
-     * # Returns
-     *
-     ",
-            ),
-            CommentKind::Block,
-        );
-        assert_eq!(stripped.as_str(), " # Returns\n\n");
+        let stripped = beautify_doc_string(Symbol::intern("\n *     a\n "), CommentKind::Block);
+        assert_eq!(stripped.as_str(), "     a\n");
     })
 }

--- a/compiler/rustc_ast/src/util/comments/tests.rs
+++ b/compiler/rustc_ast/src/util/comments/tests.rs
@@ -24,7 +24,7 @@ fn test_block_doc_comment_3() {
     create_default_session_globals_then(|| {
         let comment = "\n let a: *i32;\n *a = 5;\n";
         let stripped = beautify_doc_string(Symbol::intern(comment), CommentKind::Block);
-        assert_eq!(stripped.as_str(), " let a: *i32;\n *a = 5;");
+        assert_eq!(stripped.as_str(), "let a: *i32;\n*a = 5;");
     })
 }
 
@@ -39,5 +39,31 @@ fn test_line_doc_comment() {
         assert_eq!(stripped.as_str(), "test");
         let stripped = beautify_doc_string(Symbol::intern("!test"), CommentKind::Line);
         assert_eq!(stripped.as_str(), "!test");
+    })
+}
+
+#[test]
+fn test_doc_blocks() {
+    create_default_session_globals_then(|| {
+        let stripped = beautify_doc_string(
+            Symbol::intern(
+                " # Returns
+     *
+     ",
+            ),
+            CommentKind::Block,
+        );
+        assert_eq!(stripped.as_str(), " # Returns\n\n");
+
+        let stripped = beautify_doc_string(
+            Symbol::intern(
+                "
+     * # Returns
+     *
+     ",
+            ),
+            CommentKind::Block,
+        );
+        assert_eq!(stripped.as_str(), " # Returns\n\n");
     })
 }

--- a/src/test/rustdoc-ui/block-doc-comment.rs
+++ b/src/test/rustdoc-ui/block-doc-comment.rs
@@ -1,0 +1,16 @@
+// check-pass
+// compile-flags:--test
+
+// This test ensures that no code block is detected in the doc comments.
+
+pub mod Wormhole {
+    /** # Returns
+     *
+     */
+    pub fn foofoo() {}
+    /**
+     * # Returns
+     *
+     */
+    pub fn barbar() {}
+}

--- a/src/test/rustdoc-ui/block-doc-comment.stdout
+++ b/src/test/rustdoc-ui/block-doc-comment.stdout
@@ -1,0 +1,5 @@
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+

--- a/src/test/rustdoc/strip-block-doc-comments-stars.rs
+++ b/src/test/rustdoc/strip-block-doc-comments-stars.rs
@@ -1,6 +1,6 @@
 #![crate_name = "foo"]
 
-// The goal of this test is to answer that it won't be generated as a list because
+// The goal of this test is to ensure that it won't be generated as a list because
 // block doc comments can have their lines starting with a star.
 
 // @has foo/fn.foo.html


### PR DESCRIPTION
Fixes #93662.
Fixes #93309.

r? @notriddle 