### PR TITLE
Build libcore as 2021 in a few more places

### DIFF
--- a/library/core/Cargo.toml
+++ b/library/core/Cargo.toml
@@ -6,6 +6,8 @@ repository = "https://github.com/rust-lang/rust.git"
 description = "The Rust Core Library"
 autotests = false
 autobenches = false
+# If you update this, be sure to update it in a bunch of other places too!
+# As of 2022, it was the ci/pgo.sh script and the core-no-fp-fmt-parse test.
 edition = "2021"
 
 [lib]

--- a/src/ci/pgo.sh
+++ b/src/ci/pgo.sh
@@ -14,10 +14,10 @@ python3 ../x.py build --target=$PGO_HOST --host=$PGO_HOST \
     --llvm-profile-generate
 
 # Profile libcore compilation in opt-level=0 and opt-level=3
-RUSTC_BOOTSTRAP=1 ./build/$PGO_HOST/stage2/bin/rustc --edition=2018 \
-    --crate-type=lib ../library/core/src/lib.rs
-RUSTC_BOOTSTRAP=1 ./build/$PGO_HOST/stage2/bin/rustc --edition=2018 \
-    --crate-type=lib -Copt-level=3 ../library/core/src/lib.rs
+RUSTC_BOOTSTRAP=1 ./build/$PGO_HOST/stage2/bin/rustc \
+    --edition=2021 --crate-type=lib ../library/core/src/lib.rs
+RUSTC_BOOTSTRAP=1 ./build/$PGO_HOST/stage2/bin/rustc \
+    --edition=2021 --crate-type=lib -Copt-level=3 ../library/core/src/lib.rs
 
 # Merge the profile data we gathered for LLVM
 # Note that this uses the profdata from the clang we used to build LLVM,
@@ -37,10 +37,10 @@ python3 ../x.py build --target=$PGO_HOST --host=$PGO_HOST \
     --rust-profile-generate=/tmp/rustc-pgo
 
 # Profile libcore compilation in opt-level=0 and opt-level=3
-RUSTC_BOOTSTRAP=1 ./build/$PGO_HOST/stage2/bin/rustc --edition=2018 \
-    --crate-type=lib ../library/core/src/lib.rs
-RUSTC_BOOTSTRAP=1 ./build/$PGO_HOST/stage2/bin/rustc --edition=2018 \
-    --crate-type=lib -Copt-level=3 ../library/core/src/lib.rs
+RUSTC_BOOTSTRAP=1 ./build/$PGO_HOST/stage2/bin/rustc \
+    --edition=2021 --crate-type=lib ../library/core/src/lib.rs
+RUSTC_BOOTSTRAP=1 ./build/$PGO_HOST/stage2/bin/rustc \
+    --edition=2021 --crate-type=lib -Copt-level=3 ../library/core/src/lib.rs
 
 cp -r /tmp/rustc-perf ./
 chown -R $(whoami): ./rustc-perf

--- a/src/test/run-make-fulldeps/core-no-fp-fmt-parse/Makefile
+++ b/src/test/run-make-fulldeps/core-no-fp-fmt-parse/Makefile
@@ -1,4 +1,4 @@
 -include ../tools.mk
 
 all:
-	$(RUSTC) --edition=2018 --crate-type=rlib ../../../../library/core/src/lib.rs --cfg no_fp_fmt_parse
+	$(RUSTC) --edition=2021 --crate-type=rlib ../../../../library/core/src/lib.rs --cfg no_fp_fmt_parse


### PR DESCRIPTION
The `Cargo.toml` has `edition = "2021"` (as of #92068), so that's what these command lines should use too.