### PR TITLE
rustdoc: Special-case macro lookups less

### DIFF
--- a/src/test/rustdoc-ui/intra-doc/macro-rules.rs
+++ b/src/test/rustdoc-ui/intra-doc/macro-rules.rs
@@ -1,0 +1,9 @@
+// check-pass
+#![allow(rustdoc::private_intra_doc_links)]
+
+macro_rules! foo {
+    () => {};
+}
+
+/// [foo!]
+pub fn baz() {}


### PR DESCRIPTION
Previously, rustdoc had 3 fallbacks it used:
1. `resolve_macro_path`
2. `all_macros`
3. `resolve_str_path_error`

Ideally, it would only use `resolve_str_path_error`, to be consistent with other namespaces.
Unfortunately, that doesn't consider macros that aren't defined at module scope;
consider for instance
```rust
{
    struct S;

    macro_rules! mac { () => {} }
    // `mac`'s scope starts here

    /// `mac` <- `resolve_str_path_error` won't see this
   struct Z;

    //`mac`'s scope ends here
}
```

This changes it to only use `all_macros` and `resolve_str_path_error`, and gives
`resolve_str_path_error` precedence over `all_macros` in case there are two macros with the same
name in the same module.

This is a smaller version of https://github.com/rust-lang/rust/pull/91427.

r? @petrochenkov