### PR TITLE
Rerun bootstrap's build script when RUSTC changes

### DIFF
--- a/src/bootstrap/build.rs
+++ b/src/bootstrap/build.rs
@@ -3,6 +3,8 @@ use std::path::PathBuf;
 
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-env-changed=RUSTC");
+    println!("cargo:rerun-if-env-changed=PATH");
     println!("cargo:rustc-env=BUILD_TRIPLE={}", env::var("HOST").unwrap());
 
     // This may not be a canonicalized path.


### PR DESCRIPTION
Previously, rustbuild would give strange errors if you tried to reuse the same build directory under two names:

```
$ mkdir tmp && cd tmp
$ ../x.py check
Building rustbuild
    Finished dev [unoptimized] target(s) in 35.27s
Checking stage0 std artifacts (x86_64-unknown-linux-gnu -> x86_64-unknown-linux-gnu)
^C
$ cd ..
$ mv tmp/build build
$ ./x.py check
Building rustbuild
   Compiling bootstrap v0.0.0 (/home/jnelson/rust-lang/rust/src/bootstrap)
    Finished dev [unoptimized] target(s) in 11.18s

failed to execute command: "/home/jnelson/rust-lang/rust/tmp/build/x86_64-unknown-linux-gnu/stage0/bin/rustc" "--target" "x86_64-unknown-linux-gnu" "--print" "target-libdir"
error: No such file or directory (os error 2)
```

This fixes the error. Reusing the same build directory is useful if you want to test path-related things in
bootstrap itself, without having to recompile it each time.

For good measure, this also reruns the build script when PATH changes.