### PR TITLE
Rollup of 9 pull requests

### DIFF
--- a/compiler/rustc_feature/src/active.rs
+++ b/compiler/rustc_feature/src/active.rs
@@ -332,7 +332,7 @@ declare_features! (
     /// Allows using and casting function pointers in a `const fn`.
     (active, const_fn_fn_ptr_basics, "1.48.0", Some(57563), None),
     /// Allows trait bounds in `const fn`.
-    (active, const_fn_trait_bound, "1.53.0", Some(57563), None),
+    (active, const_fn_trait_bound, "1.53.0", Some(93706), None),
     /// Allows `for _ in _` loops in const contexts.
     (active, const_for, "1.56.0", Some(87575), None),
     /// Allows argument and return position `impl Trait` in a `const fn`.

--- a/compiler/rustc_infer/src/infer/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/mod.rs
@@ -2045,18 +2045,14 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                         // parentheses around it, perhaps the user meant to write `(expr,)` to
                         // build a tuple (issue #86100)
                         (ty::Tuple(_), _) if expected.tuple_fields().count() == 1 => {
-                            if let Ok(code) = self.tcx.sess().source_map().span_to_snippet(span) {
-                                let code_stripped = code
-                                    .strip_prefix('(')
-                                    .and_then(|s| s.strip_suffix(')'))
-                                    .unwrap_or(&code);
-                                err.span_suggestion(
-                                    span,
-                                    "use a trailing comma to create a tuple with one element",
-                                    format!("({},)", code_stripped),
-                                    Applicability::MaybeIncorrect,
-                                );
-                            }
+                            err.multipart_suggestion(
+                                "use a trailing comma to create a tuple with one element",
+                                vec![
+                                    (span.shrink_to_lo(), "(".into()),
+                                    (span.shrink_to_hi(), ",)".into()),
+                                ],
+                                Applicability::MaybeIncorrect,
+                            );
                         }
                         // If a character was expected and the found expression is a string literal
                         // containing a single character, perhaps the user meant to write `'c'` to

--- a/compiler/rustc_infer/src/infer/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/mod.rs
@@ -2045,14 +2045,27 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                         // parentheses around it, perhaps the user meant to write `(expr,)` to
                         // build a tuple (issue #86100)
                         (ty::Tuple(_), _) if expected.tuple_fields().count() == 1 => {
-                            err.multipart_suggestion(
-                                "use a trailing comma to create a tuple with one element",
-                                vec![
-                                    (span.shrink_to_lo(), "(".into()),
-                                    (span.shrink_to_hi(), ",)".into()),
-                                ],
-                                Applicability::MaybeIncorrect,
-                            );
+                            if let Ok(code) = self.tcx.sess().source_map().span_to_snippet(span) {
+                                if code.starts_with('(') && code.ends_with(')') {
+                                    let before_close = span.hi() - BytePos::from_u32(1);
+
+                                    err.span_suggestion(
+                                        span.with_hi(before_close).shrink_to_hi(),
+                                        "use a trailing comma to create a tuple with one element",
+                                        ",".into(),
+                                        Applicability::MaybeIncorrect,
+                                    );
+                                } else {
+                                    err.multipart_suggestion(
+                                        "use a trailing comma to create a tuple with one element",
+                                        vec![
+                                            (span.shrink_to_lo(), "(".into()),
+                                            (span.shrink_to_hi(), ",)".into()),
+                                        ],
+                                        Applicability::MaybeIncorrect,
+                                    );
+                                }
+                            }
                         }
                         // If a character was expected and the found expression is a string literal
                         // containing a single character, perhaps the user meant to write `'c'` to

--- a/compiler/rustc_infer/src/infer/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/mod.rs
@@ -2125,22 +2125,19 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
         let Ok(code) = self.tcx.sess().source_map().span_to_snippet(span)
             else { return };
 
+        let msg = "use a trailing comma to create a tuple with one element";
         if code.starts_with('(') && code.ends_with(')') {
             let before_close = span.hi() - BytePos::from_u32(1);
-
             err.span_suggestion(
                 span.with_hi(before_close).shrink_to_hi(),
-                "use a trailing comma to create a tuple with one element",
+                msg,
                 ",".into(),
                 Applicability::MachineApplicable,
             );
         } else {
             err.multipart_suggestion(
-                "use a trailing comma to create a tuple with one element",
-                vec![
-                    (span.shrink_to_lo(), "(".into()),
-                    (span.shrink_to_hi(), ",)".into()),
-                ],
+                msg,
+                vec![(span.shrink_to_lo(), "(".into()), (span.shrink_to_hi(), ",)".into())],
                 Applicability::MachineApplicable,
             );
         }

--- a/compiler/rustc_infer/src/infer/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/mod.rs
@@ -2046,16 +2046,16 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                         // build a tuple (issue #86100)
                         (ty::Tuple(_), _) if expected.tuple_fields().count() == 1 => {
                             if let Ok(code) = self.tcx.sess().source_map().span_to_snippet(span) {
-                                if let Some(code) =
-                                    code.strip_prefix('(').and_then(|s| s.strip_suffix(')'))
-                                {
-                                    err.span_suggestion(
-                                        span,
-                                        "use a trailing comma to create a tuple with one element",
-                                        format!("({},)", code),
-                                        Applicability::MaybeIncorrect,
-                                    );
-                                }
+                                let code_stripped = code
+                                    .strip_prefix('(')
+                                    .and_then(|s| s.strip_suffix(')'))
+                                    .unwrap_or(&code);
+                                err.span_suggestion(
+                                    span,
+                                    "use a trailing comma to create a tuple with one element",
+                                    format!("({},)", code_stripped),
+                                    Applicability::MaybeIncorrect,
+                                );
                             }
                         }
                         // If a character was expected and the found expression is a string literal

--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -2145,8 +2145,8 @@ impl Target {
         use std::fs;
 
         fn load_file(path: &Path) -> Result<(Target, TargetWarnings), String> {
-            let contents = fs::read(path).map_err(|e| e.to_string())?;
-            let obj = json::from_reader(&mut &contents[..]).map_err(|e| e.to_string())?;
+            let contents = fs::read_to_string(path).map_err(|e| e.to_string())?;
+            let obj = json::from_str(&contents).map_err(|e| e.to_string())?;
             Target::from_json(obj)
         }
 

--- a/library/std/src/ffi/c_str.rs
+++ b/library/std/src/ffi/c_str.rs
@@ -1252,15 +1252,16 @@ impl CStr {
     /// assert!(cstr.is_err());
     /// ```
     #[stable(feature = "cstr_from_bytes", since = "1.10.0")]
-    pub fn from_bytes_with_nul(bytes: &[u8]) -> Result<&CStr, FromBytesWithNulError> {
+    pub fn from_bytes_with_nul(bytes: &[u8]) -> Result<&Self, FromBytesWithNulError> {
         let nul_pos = memchr::memchr(0, bytes);
-        if let Some(nul_pos) = nul_pos {
-            if nul_pos + 1 != bytes.len() {
-                return Err(FromBytesWithNulError::interior_nul(nul_pos));
+        match nul_pos {
+            Some(nul_pos) if nul_pos + 1 == bytes.len() => {
+                // SAFETY: We know there is only one nul byte, at the end
+                // of the byte slice.
+                Ok(unsafe { Self::from_bytes_with_nul_unchecked(bytes) })
             }
-            Ok(unsafe { CStr::from_bytes_with_nul_unchecked(bytes) })
-        } else {
-            Err(FromBytesWithNulError::not_nul_terminated())
+            Some(nul_pos) => Err(FromBytesWithNulError::interior_nul(nul_pos)),
+            None => Err(FromBytesWithNulError::not_nul_terminated()),
         }
     }
 

--- a/library/std/src/process.rs
+++ b/library/std/src/process.rs
@@ -1691,6 +1691,14 @@ impl ExitCode {
     }
 }
 
+#[unstable(feature = "process_exitcode_placeholder", issue = "48711")]
+impl From<u8> for ExitCode {
+    /// Construct an exit code from an arbitrary u8 value.
+    fn from(code: u8) -> Self {
+        ExitCode(imp::ExitCode::from(code))
+    }
+}
+
 impl Child {
     /// Forces the child process to exit. If the child has already exited, an [`InvalidInput`]
     /// error is returned.

--- a/library/std/src/sys/unix/process/process_common.rs
+++ b/library/std/src/sys/unix/process/process_common.rs
@@ -476,6 +476,12 @@ impl ExitCode {
     }
 }
 
+impl From<u8> for ExitCode {
+    fn from(code: u8) -> Self {
+        Self(code)
+    }
+}
+
 pub struct CommandArgs<'a> {
     iter: crate::slice::Iter<'a, CString>,
 }

--- a/library/std/src/sys/unsupported/process.rs
+++ b/library/std/src/sys/unsupported/process.rs
@@ -162,6 +162,15 @@ impl ExitCode {
     }
 }
 
+impl From<u8> for ExitCode {
+    fn from(code: u8) -> Self {
+        match code {
+            0 => Self::SUCCESS,
+            1..255 => Self::FAILURE,
+        }
+    }
+}
+
 pub struct Process(!);
 
 impl Process {

--- a/library/std/src/sys/windows/process.rs
+++ b/library/std/src/sys/windows/process.rs
@@ -666,6 +666,12 @@ impl ExitCode {
     }
 }
 
+impl From<u8> for ExitCode {
+    fn from(code: u8) -> Self {
+        ExitCode(c::DWORD::from(code))
+    }
+}
+
 fn zeroed_startupinfo() -> c::STARTUPINFO {
     c::STARTUPINFO {
         cb: 0,

--- a/src/bootstrap/build.rs
+++ b/src/bootstrap/build.rs
@@ -3,6 +3,8 @@ use std::path::PathBuf;
 
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-env-changed=RUSTC");
+    println!("cargo:rerun-if-env-changed=PATH");
     println!("cargo:rustc-env=BUILD_TRIPLE={}", env::var("HOST").unwrap());
 
     // This may not be a canonicalized path.

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -527,7 +527,7 @@ impl Build {
         // Try passing `--progress` to start, then run git again without if that fails.
         let update = |progress: bool| {
             let mut git = Command::new("git");
-            git.args(&["submodule", "update", "--init", "--recursive"]);
+            git.args(&["submodule", "update", "--init", "--recursive", "--depth=1"]);
             if progress {
                 git.arg("--progress");
             }

--- a/src/bootstrap/setup.rs
+++ b/src/bootstrap/setup.rs
@@ -1,7 +1,9 @@
 use crate::TargetSelection;
 use crate::{t, VERSION};
+use std::env::consts::EXE_SUFFIX;
 use std::fmt::Write as _;
-use std::path::{Path, PathBuf};
+use std::fs::File;
+use std::path::{Path, PathBuf, MAIN_SEPARATOR};
 use std::process::Command;
 use std::str::FromStr;
 use std::{
@@ -109,7 +111,8 @@ pub fn setup(src_path: &Path, profile: Profile) {
     println!("`x.py` will now use the configuration at {}", include_path.display());
 
     let build = TargetSelection::from_user(&env!("BUILD_TRIPLE"));
-    let stage_path = ["build", build.rustc_target_arg(), "stage1"].join("/");
+    let stage_path =
+        ["build", build.rustc_target_arg(), "stage1"].join(&MAIN_SEPARATOR.to_string());
 
     println!();
 
@@ -171,6 +174,13 @@ fn attempt_toolchain_link(stage_path: &str) {
         return;
     }
 
+    if !ensure_stage1_toolchain_placeholder_exists(stage_path) {
+        println!(
+            "Failed to create a template for stage 1 toolchain or confirm that it already exists"
+        );
+        return;
+    }
+
     if try_link_toolchain(&stage_path[..]) {
         println!(
             "Added `stage1` rustup toolchain; try `cargo +stage1 build` on a separate rust project to run a newly-built toolchain"
@@ -217,6 +227,33 @@ fn try_link_toolchain(stage_path: &str) -> bool {
         .args(&["toolchain", "link", "stage1", &stage_path[..]])
         .output()
         .map_or(false, |output| output.status.success())
+}
+
+fn ensure_stage1_toolchain_placeholder_exists(stage_path: &str) -> bool {
+    let pathbuf = PathBuf::from(stage_path);
+
+    if fs::create_dir_all(pathbuf.join("lib")).is_err() {
+        return false;
+    };
+
+    let pathbuf = pathbuf.join("bin");
+    if fs::create_dir_all(&pathbuf).is_err() {
+        return false;
+    };
+
+    let pathbuf = pathbuf.join(format!("rustc{}", EXE_SUFFIX));
+
+    if pathbuf.exists() {
+        return true;
+    }
+
+    // Take care not to overwrite the file
+    let result = File::options().append(true).create(true).open(&pathbuf);
+    if result.is_err() {
+        return false;
+    }
+
+    return true;
 }
 
 // Used to get the path for `Subcommand::Setup`

--- a/src/bootstrap/setup.rs
+++ b/src/bootstrap/setup.rs
@@ -191,9 +191,9 @@ fn install_git_hook_maybe(src_path: &Path) -> io::Result<()> {
     let mut input = String::new();
     println!(
         "Rust's CI will automatically fail if it doesn't pass `tidy`, the internal tool for ensuring code quality.
-If you'd like, x.py can install a git hook for you that will automatically run `tidy --bless` on each commit
-to ensure your code is up to par. If you decide later that this behavior is undesirable,
-simply delete the `pre-commit` file from .git/hooks."
+If you'd like, x.py can install a git hook for you that will automatically run `tidy --bless` before
+pushing your code to ensure your code is up to par. If you decide later that this behavior is
+undesirable, simply delete the `pre-push` file from .git/hooks."
     );
 
     let should_install = loop {
@@ -213,21 +213,21 @@ simply delete the `pre-commit` file from .git/hooks."
     };
 
     if should_install {
-        let src = src_path.join("src").join("etc").join("pre-commit.sh");
+        let src = src_path.join("src").join("etc").join("pre-push.sh");
         let git = t!(Command::new("git").args(&["rev-parse", "--git-common-dir"]).output().map(
             |output| {
                 assert!(output.status.success(), "failed to run `git`");
                 PathBuf::from(t!(String::from_utf8(output.stdout)).trim())
             }
         ));
-        let dst = git.join("hooks").join("pre-commit");
+        let dst = git.join("hooks").join("pre-push");
         match fs::hard_link(src, &dst) {
             Err(e) => println!(
                 "error: could not create hook {}: do you already have the git hook installed?\n{}",
                 dst.display(),
                 e
             ),
-            Ok(_) => println!("Linked `src/etc/pre-commit.sh` to `.git/hooks/pre-commit`"),
+            Ok(_) => println!("Linked `src/etc/pre-commit.sh` to `.git/hooks/pre-push`"),
         };
     } else {
         println!("Ok, skipping installation!");

--- a/src/etc/pre-push.sh
+++ b/src/etc/pre-push.sh
@@ -16,7 +16,7 @@ if [[ "$OSTYPE" == "msys" || "$OSTYPE" == "win32" ]]; then
   COMMAND="python $COMMAND"
 fi
 
-echo "Running pre-commit script '$COMMAND'"
+echo "Running pre-push script '$COMMAND'"
 
 cd "$ROOT_DIR"
 

--- a/src/test/ui/consts/const-tup-index-span.stderr
+++ b/src/test/ui/consts/const-tup-index-span.stderr
@@ -9,7 +9,7 @@ LL | const TUP: (usize,) = 5usize << 64;
 help: use a trailing comma to create a tuple with one element
    |
 LL | const TUP: (usize,) = (5usize << 64,);
-   |                       ~~~~~~~~~~~~~~~
+   |                       +            ++
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/const-tup-index-span.stderr
+++ b/src/test/ui/consts/const-tup-index-span.stderr
@@ -6,6 +6,10 @@ LL | const TUP: (usize,) = 5usize << 64;
    |
    = note: expected tuple `(usize,)`
                found type `usize`
+help: use a trailing comma to create a tuple with one element
+   |
+LL | const TUP: (usize,) = (5usize << 64,);
+   |                       ~~~~~~~~~~~~~~~
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/const_fn_trait_bound.stock.stderr
+++ b/src/test/ui/consts/const_fn_trait_bound.stock.stderr
@@ -4,7 +4,7 @@ error[E0658]: trait bounds other than `Sized` on const fn parameters are unstabl
 LL | const fn test1<T: std::ops::Add>() {}
    |                ^
    |
-   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
+   = note: see issue #93706 <https://github.com/rust-lang/rust/issues/93706> for more information
    = help: add `#![feature(const_fn_trait_bound)]` to the crate attributes to enable
 
 error[E0658]: trait objects in const fn are unstable
@@ -13,7 +13,7 @@ error[E0658]: trait objects in const fn are unstable
 LL | const fn test2(_x: &dyn Send) {}
    |                ^^
    |
-   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
+   = note: see issue #93706 <https://github.com/rust-lang/rust/issues/93706> for more information
    = help: add `#![feature(const_fn_trait_bound)]` to the crate attributes to enable
 
 error[E0658]: trait objects in const fn are unstable
@@ -22,7 +22,7 @@ error[E0658]: trait objects in const fn are unstable
 LL | const fn test3() -> &'static dyn Send { loop {} }
    |                     ^^^^^^^^^^^^^^^^^
    |
-   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
+   = note: see issue #93706 <https://github.com/rust-lang/rust/issues/93706> for more information
    = help: add `#![feature(const_fn_trait_bound)]` to the crate attributes to enable
 
 error: aborting due to 3 previous errors

--- a/src/test/ui/consts/min_const_fn/min_const_fn.stderr
+++ b/src/test/ui/consts/min_const_fn/min_const_fn.stderr
@@ -136,7 +136,7 @@ error[E0658]: trait bounds other than `Sized` on const fn parameters are unstabl
 LL | const fn foo11<T: std::fmt::Display>(t: T) -> T { t }
    |                ^
    |
-   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
+   = note: see issue #93706 <https://github.com/rust-lang/rust/issues/93706> for more information
    = help: add `#![feature(const_fn_trait_bound)]` to the crate attributes to enable
 
 error[E0658]: trait bounds other than `Sized` on const fn parameters are unstable
@@ -145,7 +145,7 @@ error[E0658]: trait bounds other than `Sized` on const fn parameters are unstabl
 LL | const fn foo11_2<T: Send>(t: T) -> T { t }
    |                  ^
    |
-   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
+   = note: see issue #93706 <https://github.com/rust-lang/rust/issues/93706> for more information
    = help: add `#![feature(const_fn_trait_bound)]` to the crate attributes to enable
 
 error[E0013]: constant functions cannot refer to statics
@@ -218,7 +218,7 @@ LL |
 LL |     const fn foo(&self) {}
    |     ------------------- function declared as const here
    |
-   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
+   = note: see issue #93706 <https://github.com/rust-lang/rust/issues/93706> for more information
    = help: add `#![feature(const_fn_trait_bound)]` to the crate attributes to enable
 
 error[E0658]: trait bounds other than `Sized` on const fn parameters are unstable
@@ -230,7 +230,7 @@ LL |
 LL |     const fn foo2(&self) {}
    |     -------------------- function declared as const here
    |
-   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
+   = note: see issue #93706 <https://github.com/rust-lang/rust/issues/93706> for more information
    = help: add `#![feature(const_fn_trait_bound)]` to the crate attributes to enable
 
 error[E0658]: trait bounds other than `Sized` on const fn parameters are unstable
@@ -242,7 +242,7 @@ LL |
 LL |     const fn foo3(&self) {}
    |     -------------------- function declared as const here
    |
-   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
+   = note: see issue #93706 <https://github.com/rust-lang/rust/issues/93706> for more information
    = help: add `#![feature(const_fn_trait_bound)]` to the crate attributes to enable
 
 error[E0658]: trait bounds other than `Sized` on const fn parameters are unstable
@@ -251,7 +251,7 @@ error[E0658]: trait bounds other than `Sized` on const fn parameters are unstabl
 LL | const fn no_apit2(_x: AlanTuring<impl std::fmt::Debug>) {}
    |                                  ^^^^^^^^^^^^^^^^^^^^
    |
-   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
+   = note: see issue #93706 <https://github.com/rust-lang/rust/issues/93706> for more information
    = help: add `#![feature(const_fn_trait_bound)]` to the crate attributes to enable
 
 error[E0493]: destructors cannot be evaluated at compile-time
@@ -268,7 +268,7 @@ error[E0658]: trait bounds other than `Sized` on const fn parameters are unstabl
 LL | const fn no_apit(_x: impl std::fmt::Debug) {}
    |                      ^^^^^^^^^^^^^^^^^^^^
    |
-   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
+   = note: see issue #93706 <https://github.com/rust-lang/rust/issues/93706> for more information
    = help: add `#![feature(const_fn_trait_bound)]` to the crate attributes to enable
 
 error[E0493]: destructors cannot be evaluated at compile-time
@@ -285,7 +285,7 @@ error[E0658]: trait objects in const fn are unstable
 LL | const fn no_dyn_trait(_x: &dyn std::fmt::Debug) {}
    |                       ^^
    |
-   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
+   = note: see issue #93706 <https://github.com/rust-lang/rust/issues/93706> for more information
    = help: add `#![feature(const_fn_trait_bound)]` to the crate attributes to enable
 
 error[E0658]: trait objects in const fn are unstable
@@ -294,7 +294,7 @@ error[E0658]: trait objects in const fn are unstable
 LL | const fn no_dyn_trait_ret() -> &'static dyn std::fmt::Debug { &() }
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
+   = note: see issue #93706 <https://github.com/rust-lang/rust/issues/93706> for more information
    = help: add `#![feature(const_fn_trait_bound)]` to the crate attributes to enable
 
 error[E0658]: trait objects in const fn are unstable
@@ -305,7 +305,7 @@ LL | const fn really_no_traits_i_mean_it() { (&() as &dyn std::fmt::Debug, ()).1
    | |
    | function declared as const here
    |
-   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
+   = note: see issue #93706 <https://github.com/rust-lang/rust/issues/93706> for more information
    = help: add `#![feature(const_fn_trait_bound)]` to the crate attributes to enable
 
 error[E0658]: trait objects in const fn are unstable
@@ -316,7 +316,7 @@ LL | const fn really_no_traits_i_mean_it() { (&() as &dyn std::fmt::Debug, ()).1
    | |
    | function declared as const here
    |
-   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
+   = note: see issue #93706 <https://github.com/rust-lang/rust/issues/93706> for more information
    = help: add `#![feature(const_fn_trait_bound)]` to the crate attributes to enable
 
 error[E0658]: trait objects in const fn are unstable
@@ -327,7 +327,7 @@ LL | const fn really_no_traits_i_mean_it() { (&() as &dyn std::fmt::Debug, ()).1
    | |
    | function declared as const here
    |
-   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
+   = note: see issue #93706 <https://github.com/rust-lang/rust/issues/93706> for more information
    = help: add `#![feature(const_fn_trait_bound)]` to the crate attributes to enable
 
 error[E0658]: function pointers cannot appear in constant functions

--- a/src/test/ui/consts/min_const_fn/min_const_fn_dyn.stderr
+++ b/src/test/ui/consts/min_const_fn/min_const_fn_dyn.stderr
@@ -6,7 +6,7 @@ LL | const fn no_inner_dyn_trait2(x: Hide) {
 LL |     x.0.field;
    |     ^^^^^^^^^
    |
-   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
+   = note: see issue #93706 <https://github.com/rust-lang/rust/issues/93706> for more information
    = help: add `#![feature(const_fn_trait_bound)]` to the crate attributes to enable
 
 error[E0658]: trait objects in const fn are unstable
@@ -17,7 +17,7 @@ LL | const fn no_inner_dyn_trait_ret() -> Hide { Hide(HasDyn { field: &0 }) }
    | |
    | function declared as const here
    |
-   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
+   = note: see issue #93706 <https://github.com/rust-lang/rust/issues/93706> for more information
    = help: add `#![feature(const_fn_trait_bound)]` to the crate attributes to enable
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/nll/issue-55825-const-fn.stderr
+++ b/src/test/ui/nll/issue-55825-const-fn.stderr
@@ -4,7 +4,7 @@ error[E0658]: trait objects in const fn are unstable
 LL | const fn no_dyn_trait_ret() -> &'static dyn std::fmt::Debug { &() }
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
+   = note: see issue #93706 <https://github.com/rust-lang/rust/issues/93706> for more information
    = help: add `#![feature(const_fn_trait_bound)]` to the crate attributes to enable
 
 error: aborting due to previous error

--- a/src/test/ui/suggestions/args-instead-of-tuple-errors.rs
+++ b/src/test/ui/suggestions/args-instead-of-tuple-errors.rs
@@ -10,6 +10,12 @@ fn main() {
 
     let _: Option<(i8,)> = Some();
     //~^ ERROR this enum variant takes 1 argument but 0 arguments were supplied
+
+    let _: Option<(i32,)> = Some(5_usize);
+    //~^ ERROR mismatched types
+
+    let _: Option<(i32,)> = Some((5_usize));
+    //~^ ERROR mismatched types
 }
 
 fn int_bool(_: (i32, bool)) {

--- a/src/test/ui/suggestions/args-instead-of-tuple-errors.stderr
+++ b/src/test/ui/suggestions/args-instead-of-tuple-errors.stderr
@@ -15,7 +15,7 @@ LL |     int_bool(1, 2);
    |     expected 1 argument
    |
 note: function defined here
-  --> $DIR/args-instead-of-tuple-errors.rs:15:4
+  --> $DIR/args-instead-of-tuple-errors.rs:21:4
    |
 LL | fn int_bool(_: (i32, bool)) {
    |    ^^^^^^^^ --------------
@@ -28,6 +28,25 @@ LL |     let _: Option<(i8,)> = Some();
    |                            |
    |                            expected 1 argument
 
-error: aborting due to 3 previous errors
+error[E0308]: mismatched types
+  --> $DIR/args-instead-of-tuple-errors.rs:14:34
+   |
+LL |     let _: Option<(i32,)> = Some(5_usize);
+   |                                  ^^^^^^^ expected tuple, found `usize`
+   |
+   = note: expected tuple `(i32,)`
+               found type `usize`
 
-For more information about this error, try `rustc --explain E0061`.
+error[E0308]: mismatched types
+  --> $DIR/args-instead-of-tuple-errors.rs:17:34
+   |
+LL |     let _: Option<(i32,)> = Some((5_usize));
+   |                                  ^^^^^^^^^ expected tuple, found `usize`
+   |
+   = note: expected tuple `(i32,)`
+               found type `usize`
+
+error: aborting due to 5 previous errors
+
+Some errors have detailed explanations: E0061, E0308.
+For more information about an error, try `rustc --explain E0061`.

--- a/src/test/ui/suggestions/args-instead-of-tuple.fixed
+++ b/src/test/ui/suggestions/args-instead-of-tuple.fixed
@@ -11,6 +11,12 @@ fn main() {
     let _: Option<()> = Some(());
     //~^ ERROR this enum variant takes 1 argument but 0 arguments were supplied
 
+    let _: Option<(i32,)> = Some((3,));
+    //~^ ERROR mismatched types
+
+    let _: Option<(i32,)> = Some((3,));
+    //~^ ERROR mismatched types
+
     two_ints((1, 2)); //~ ERROR this function takes 1 argument
 
     with_generic((3, 4)); //~ ERROR this function takes 1 argument

--- a/src/test/ui/suggestions/args-instead-of-tuple.rs
+++ b/src/test/ui/suggestions/args-instead-of-tuple.rs
@@ -11,6 +11,12 @@ fn main() {
     let _: Option<()> = Some();
     //~^ ERROR this enum variant takes 1 argument but 0 arguments were supplied
 
+    let _: Option<(i32,)> = Some(3);
+    //~^ ERROR mismatched types
+
+    let _: Option<(i32,)> = Some((3));
+    //~^ ERROR mismatched types
+
     two_ints(1, 2); //~ ERROR this function takes 1 argument
 
     with_generic(3, 4); //~ ERROR this function takes 1 argument

--- a/src/test/ui/suggestions/args-instead-of-tuple.stderr
+++ b/src/test/ui/suggestions/args-instead-of-tuple.stderr
@@ -31,14 +31,40 @@ help: expected the unit value `()`; create it with empty parentheses
 LL |     let _: Option<()> = Some(());
    |                              ++
 
+error[E0308]: mismatched types
+  --> $DIR/args-instead-of-tuple.rs:14:34
+   |
+LL |     let _: Option<(i32,)> = Some(3);
+   |                                  ^ expected tuple, found integer
+   |
+   = note: expected tuple `(i32,)`
+               found type `{integer}`
+help: use a trailing comma to create a tuple with one element
+   |
+LL |     let _: Option<(i32,)> = Some((3,));
+   |                                  + ++
+
+error[E0308]: mismatched types
+  --> $DIR/args-instead-of-tuple.rs:17:34
+   |
+LL |     let _: Option<(i32,)> = Some((3));
+   |                                  ^^^ expected tuple, found integer
+   |
+   = note: expected tuple `(i32,)`
+               found type `{integer}`
+help: use a trailing comma to create a tuple with one element
+   |
+LL |     let _: Option<(i32,)> = Some((3,));
+   |                                    +
+
 error[E0061]: this function takes 1 argument but 2 arguments were supplied
-  --> $DIR/args-instead-of-tuple.rs:14:5
+  --> $DIR/args-instead-of-tuple.rs:20:5
    |
 LL |     two_ints(1, 2);
    |     ^^^^^^^^ -  - supplied 2 arguments
    |
 note: function defined here
-  --> $DIR/args-instead-of-tuple.rs:19:4
+  --> $DIR/args-instead-of-tuple.rs:25:4
    |
 LL | fn two_ints(_: (i32, i32)) {
    |    ^^^^^^^^ -------------
@@ -48,13 +74,13 @@ LL |     two_ints((1, 2));
    |              +    +
 
 error[E0061]: this function takes 1 argument but 2 arguments were supplied
-  --> $DIR/args-instead-of-tuple.rs:16:5
+  --> $DIR/args-instead-of-tuple.rs:22:5
    |
 LL |     with_generic(3, 4);
    |     ^^^^^^^^^^^^ -  - supplied 2 arguments
    |
 note: function defined here
-  --> $DIR/args-instead-of-tuple.rs:22:4
+  --> $DIR/args-instead-of-tuple.rs:28:4
    |
 LL | fn with_generic<T: Copy + Send>((a, b): (i32, T)) {
    |    ^^^^^^^^^^^^                 ----------------
@@ -64,13 +90,13 @@ LL |     with_generic((3, 4));
    |                  +    +
 
 error[E0061]: this function takes 1 argument but 2 arguments were supplied
-  --> $DIR/args-instead-of-tuple.rs:25:9
+  --> $DIR/args-instead-of-tuple.rs:31:9
    |
 LL |         with_generic(a, b);
    |         ^^^^^^^^^^^^ -  - supplied 2 arguments
    |
 note: function defined here
-  --> $DIR/args-instead-of-tuple.rs:22:4
+  --> $DIR/args-instead-of-tuple.rs:28:4
    |
 LL | fn with_generic<T: Copy + Send>((a, b): (i32, T)) {
    |    ^^^^^^^^^^^^                 ----------------
@@ -79,6 +105,7 @@ help: use parentheses to construct a tuple
 LL |         with_generic((a, b));
    |                      +    +
 
-error: aborting due to 6 previous errors
+error: aborting due to 8 previous errors
 
-For more information about this error, try `rustc --explain E0061`.
+Some errors have detailed explanations: E0061, E0308.
+For more information about an error, try `rustc --explain E0061`.

--- a/src/test/ui/suggestions/issue-86100-tuple-paren-comma.stderr
+++ b/src/test/ui/suggestions/issue-86100-tuple-paren-comma.stderr
@@ -11,7 +11,7 @@ LL |     let _x: (i32,) = (5);
 help: use a trailing comma to create a tuple with one element
    |
 LL |     let _x: (i32,) = (5,);
-   |                      ~~~~
+   |                        +
 
 error[E0308]: mismatched types
   --> $DIR/issue-86100-tuple-paren-comma.rs:13:9
@@ -24,7 +24,7 @@ LL |     foo((Some(3)));
 help: use a trailing comma to create a tuple with one element
    |
 LL |     foo((Some(3),));
-   |         ~~~~~~~~~~
+   |                 +
 
 error[E0308]: mismatched types
   --> $DIR/issue-86100-tuple-paren-comma.rs:17:22
@@ -37,7 +37,7 @@ LL |     let _s = S { _s: ("abc".to_string()) };
 help: use a trailing comma to create a tuple with one element
    |
 LL |     let _s = S { _s: ("abc".to_string(),) };
-   |                      ~~~~~~~~~~~~~~~~~~~~
+   |                                        +
 
 error[E0308]: mismatched types
   --> $DIR/issue-86100-tuple-paren-comma.rs:23:22

--- a/src/test/ui/typeck/issue-84768.stderr
+++ b/src/test/ui/typeck/issue-84768.stderr
@@ -12,10 +12,6 @@ LL |     <F as FnOnce(&mut u8)>::call_once(f, 1)
    |
    = note: expected tuple `(&mut u8,)`
                found type `{integer}`
-help: use a trailing comma to create a tuple with one element
-   |
-LL |     <F as FnOnce(&mut u8)>::call_once(f, (1,))
-   |                                          + ++
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/typeck/issue-84768.stderr
+++ b/src/test/ui/typeck/issue-84768.stderr
@@ -12,6 +12,10 @@ LL |     <F as FnOnce(&mut u8)>::call_once(f, 1)
    |
    = note: expected tuple `(&mut u8,)`
                found type `{integer}`
+help: use a trailing comma to create a tuple with one element
+   |
+LL |     <F as FnOnce(&mut u8)>::call_once(f, (1,))
+   |                                          ~~~~
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/typeck/issue-84768.stderr
+++ b/src/test/ui/typeck/issue-84768.stderr
@@ -15,7 +15,7 @@ LL |     <F as FnOnce(&mut u8)>::call_once(f, 1)
 help: use a trailing comma to create a tuple with one element
    |
 LL |     <F as FnOnce(&mut u8)>::call_once(f, (1,))
-   |                                          ~~~~
+   |                                          + ++
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION
Successful merges:

 - #88313 (Make the pre-commit script pre-push instead)
 - #91530 (Suggest 1-tuple parentheses on exprs without existing parens)
 - #92724 (Cleanup c_str.rs)
 - #93445 (Add From<u8> for ExitCode)
 - #93487 (Fix linking stage1 toolchain in `./x.py setup`)
 - #93680 (Drop json::from_reader)
 - #93682 (Update tracking issue for `const_fn_trait_bound`)
 - #93722 (Use shallow clones for submodules managed by rustbuild, not just bootstrap.py)
 - #93723 (Rerun bootstrap's build script when RUSTC changes)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=88313,91530,92724,93445,93487,93680,93682,93722,93723)
<!-- homu-ignore:end -->