### PR TITLE
rustc_query_impl: reduce visibility of some modules/fn's

### DIFF
--- a/compiler/rustc_query_impl/src/plumbing.rs
+++ b/compiler/rustc_query_impl/src/plumbing.rs
@@ -402,7 +402,7 @@ macro_rules! define_queries {
                 }
             }
 
-            $(pub fn $name()-> DepKindStruct {
+            $(pub(crate) fn $name()-> DepKindStruct {
                 let is_anon = is_anon!([$($modifiers)*]);
                 let is_eval_always = is_eval_always!([$($modifiers)*]);
 

--- a/compiler/rustc_query_impl/src/plumbing.rs
+++ b/compiler/rustc_query_impl/src/plumbing.rs
@@ -299,7 +299,7 @@ macro_rules! define_queries {
         }
 
         #[allow(nonstandard_style)]
-        pub mod queries {
+        mod queries {
             use std::marker::PhantomData;
 
             $(pub struct $name<$tcx> {
@@ -353,7 +353,7 @@ macro_rules! define_queries {
         })*
 
         #[allow(nonstandard_style)]
-        pub mod query_callbacks {
+        mod query_callbacks {
             use super::*;
             use rustc_middle::dep_graph::DepNode;
             use rustc_middle::ty::query::query_keys;


### PR DESCRIPTION
Locally this reduces number of exported functions from 15221 -> 14952 and size a little.

Perf run please?