### PR TITLE
Complete removal of #[main] attribute from compiler

### DIFF
--- a/compiler/rustc_feature/src/builtin_attrs.rs
+++ b/compiler/rustc_feature/src/builtin_attrs.rs
@@ -339,7 +339,6 @@ pub const BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     ),
 
     // Entry point:
-    ungated!(main, Normal, template!(Word), WarnFollowing),
     ungated!(start, Normal, template!(Word), WarnFollowing),
     ungated!(no_start, CrateLevel, template!(Word), WarnFollowing),
     ungated!(no_main, CrateLevel, template!(Word), WarnFollowing),

--- a/src/test/ui/attributes/main-removed-1.rs
+++ b/src/test/ui/attributes/main-removed-1.rs
@@ -1,0 +1,2 @@
+#[main]  //~ ERROR cannot find attribute `main` in this scope
+fn main() {}

--- a/src/test/ui/attributes/main-removed-1.stderr
+++ b/src/test/ui/attributes/main-removed-1.stderr
@@ -1,0 +1,10 @@
+error: cannot find attribute `main` in this scope
+  --> $DIR/main-removed-1.rs:1:3
+   |
+LL | #[main]
+   |   ^^^^
+   |
+   = note: `main` is in scope, but it is a function, not an attribute
+
+error: aborting due to previous error
+

--- a/src/test/ui/attributes/main-removed-2/auxiliary/tokyo.rs
+++ b/src/test/ui/attributes/main-removed-2/auxiliary/tokyo.rs
@@ -1,0 +1,12 @@
+// force-host
+// no-prefer-dynamic
+
+#![crate_type = "proc-macro"]
+
+extern crate proc_macro;
+use proc_macro::TokenStream;
+
+#[proc_macro_attribute]
+pub fn main(_: TokenStream, input: TokenStream) -> TokenStream {
+    "fn main() { println!(\"Hello Tokyo!\"); }".parse().unwrap()
+}

--- a/src/test/ui/attributes/main-removed-2/main.rs
+++ b/src/test/ui/attributes/main-removed-2/main.rs
@@ -1,0 +1,11 @@
+// run-pass
+// aux-build:tokyo.rs
+// compile-flags:--extern tokyo
+// edition:2021
+
+use tokyo::main;
+
+#[main]
+fn main() {
+    panic!("the #[main] macro should replace this with non-panicking code")
+}


### PR DESCRIPTION
resolves #93786

---

The `#[main]` attribute was mostly removed from the language in #84217, but not completely. It is still recognized as a builtin attribute by the compiler, but it has no effect. However, this no-op attribute is no longer gated by `#[feature(main)]` (which no longer exists), so it's possible to include it in code *on stable* without any errors, which seems unintentional. For example, the following code is accepted ([playground link](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&code=%23%5Bmain%5D%0Afn%20main()%20%7B%0A%20%20%20%20println!(%22hello%20world%22)%3B%0A%7D%0A)).

```rust
#[main]
fn main() {
    println!("hello world");
}
```

Aside from that oddity, the existence of this attribute causes code like the following to fail ([playground link](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&code=use%20tokio%3A%3Amain%3B%0A%0A%23%5Bmain%5D%0Afn%20main()%20%7B%0A%20%20%20%20println!(%22hello%20world%22)%3B%0A%7D%0A)). According https://github.com/rust-lang/rust/pull/84062#issuecomment-825038275, the removal of `#[main]` was expected to eliminate this conflict (previously reported as #62127).

```rust
use tokio::main;

#[main]
fn main() {
    println!("hello world");
}
```

```
error[E0659]: `main` is ambiguous
 --> src/main.rs:3:3
  |
3 | #[main]
  |   ^^^^ ambiguous name
  |
  = note: ambiguous because of a name conflict with a builtin attribute
  = note: `main` could refer to a built-in attribute
```

[This error message can be confusing](https://stackoverflow.com/q/71024443/1114), as the mostly-removed `#[main]` attribute is not mentioned in any documentation.

Since the current availability of `#[main]` on stable seems unintentional, and to needlessly block use of the `main` identifier in the attribute namespace, this PR finishes removing the `#[main]` attribute as described in https://github.com/rust-lang/rust/issues/29634#issuecomment-274951753 by deleting it from `builtin_attrs.rs`, and adds two test cases to ensure that the attribute is no longer accepted and no longer conflicts with other attributes imported as `main`.