### PR TITLE
Support custom options for LLVM build

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -157,6 +157,9 @@ changelog-seen = 2
 # Whether to build the clang compiler.
 #clang = false
 
+# Custom CMake defines to set when building LLVM.
+#build-config = {}
+
 # =============================================================================
 # General build configuration options
 # =============================================================================

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -108,6 +108,7 @@ pub struct Config {
     pub llvm_polly: bool,
     pub llvm_clang: bool,
     pub llvm_from_ci: bool,
+    pub llvm_build_config: HashMap<String, String>,
 
     pub use_lld: bool,
     pub lld_enabled: bool,
@@ -477,6 +478,7 @@ derive_merge! {
         polly: Option<bool>,
         clang: Option<bool>,
         download_ci_llvm: Option<StringOrBool>,
+        build_config: Option<HashMap<String, String>>,
     }
 }
 
@@ -807,6 +809,7 @@ impl Config {
             config.llvm_allow_old_toolchain = llvm.allow_old_toolchain.unwrap_or(false);
             config.llvm_polly = llvm.polly.unwrap_or(false);
             config.llvm_clang = llvm.clang.unwrap_or(false);
+            config.llvm_build_config = llvm.build_config.clone().unwrap_or(Default::default());
             config.llvm_from_ci = match llvm.download_ci_llvm {
                 Some(StringOrBool::String(s)) => {
                     assert!(s == "if-available", "unknown option `{}` for download-ci-llvm", s);
@@ -876,6 +879,7 @@ impl Config {
                 check_ci_llvm!(llvm.allow_old_toolchain);
                 check_ci_llvm!(llvm.polly);
                 check_ci_llvm!(llvm.clang);
+                check_ci_llvm!(llvm.build_config);
                 check_ci_llvm!(llvm.plugins);
 
                 // CI-built LLVM can be either dynamic or static.

--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -353,6 +353,10 @@ impl Step for Llvm {
 
         configure_cmake(builder, target, &mut cfg, true);
 
+        for (key, val) in &builder.config.llvm_build_config {
+            cfg.define(key, val);
+        }
+
         // FIXME: we don't actually need to build all LLVM tools and all LLVM
         //        libraries here, e.g., we just want a few components and a few
         //        tools. Figure out how to filter them down and only build the right


### PR DESCRIPTION
The LLVM build has a lot of options that rustbuild doesn't need to know about. We should allow the user to customize the LLVM build directly.

Here are some [example customizations][recipe] we'd like to do.

[recipe]: https://fuchsia.googlesource.com/infra/recipes/+/90105e5e4e37b0441c8dde538df54a55f79b3d22/recipes/contrib/clang_toolchain.py#579
