### PR TITLE
Pretty print ItemKind::Use in rustfmt style

### DIFF
--- a/compiler/rustc_ast_pretty/src/pp/convenience.rs
+++ b/compiler/rustc_ast_pretty/src/pp/convenience.rs
@@ -75,6 +75,10 @@ impl Printer {
     }
 
     pub fn trailing_comma(&mut self) {
+        self.scan_break(BreakToken { pre_break: Some(','), ..BreakToken::default() });
+    }
+
+    pub fn trailing_comma_or_space(&mut self) {
         self.scan_break(BreakToken {
             blank_space: 1,
             pre_break: Some(','),

--- a/compiler/rustc_ast_pretty/src/pprust/state/expr.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state/expr.rs
@@ -142,7 +142,7 @@ impl<'a> State<'a> {
             if !field.is_last || has_rest {
                 self.word_space(",");
             } else {
-                self.trailing_comma();
+                self.trailing_comma_or_space();
             }
         }
         if has_rest {

--- a/src/test/pretty/use-tree.rs
+++ b/src/test/pretty/use-tree.rs
@@ -1,0 +1,17 @@
+// pp-exact
+// edition:2021
+
+#![allow(unused_imports)]
+
+use ::std::fmt::{self, Debug, Display, Write as _};
+
+use core::option::Option::*;
+
+use core::{cmp::{Eq, Ord, PartialEq, PartialOrd},
+    convert::{AsMut, AsRef, From, Into},
+    iter::{DoubleEndedIterator, ExactSizeIterator, Extend, FromIterator,
+    IntoIterator, Iterator},
+    marker::{Copy as Copy, Send as Send, Sized as Sized, Sync as Sync, Unpin
+    as U}, ops::{*, Drop, Fn, FnMut, FnOnce}};
+
+fn main() {}

--- a/src/test/pretty/use-tree.rs
+++ b/src/test/pretty/use-tree.rs
@@ -7,11 +7,17 @@ use ::std::fmt::{self, Debug, Display, Write as _};
 
 use core::option::Option::*;
 
-use core::{cmp::{Eq, Ord, PartialEq, PartialOrd},
+use core::{
+    cmp::{Eq, Ord, PartialEq, PartialOrd},
     convert::{AsMut, AsRef, From, Into},
-    iter::{DoubleEndedIterator, ExactSizeIterator, Extend, FromIterator,
-    IntoIterator, Iterator},
-    marker::{Copy as Copy, Send as Send, Sized as Sized, Sync as Sync, Unpin
-    as U}, ops::{*, Drop, Fn, FnMut, FnOnce}};
+    iter::{
+        DoubleEndedIterator, ExactSizeIterator, Extend, FromIterator,
+        IntoIterator, Iterator,
+    },
+    marker::{
+        Copy as Copy, Send as Send, Sized as Sized, Sync as Sync, Unpin as U,
+    },
+    ops::{*, Drop, Fn, FnMut, FnOnce},
+};
 
 fn main() {}


### PR DESCRIPTION
This PR backports the formatting for `use` items from https://github.com/dtolnay/prettyplease into rustc_ast_pretty.

Before:

```rust
use core::{cmp::{Eq, Ord, PartialEq, PartialOrd},
    convert::{AsMut, AsRef, From, Into},
    iter::{DoubleEndedIterator, ExactSizeIterator, Extend, FromIterator,
    IntoIterator, Iterator},
    marker::{Copy as Copy, Send as Send, Sized as Sized, Sync as Sync, Unpin
    as U}, ops::{*, Drop, Fn, FnMut, FnOnce}};
```

After:

```rust
use core::{
    cmp::{Eq, Ord, PartialEq, PartialOrd},
    convert::{AsMut, AsRef, From, Into},
    iter::{
        DoubleEndedIterator, ExactSizeIterator, Extend, FromIterator,
        IntoIterator, Iterator,
    },
    marker::{
        Copy as Copy, Send as Send, Sized as Sized, Sync as Sync, Unpin as U,
    },
    ops::{*, Drop, Fn, FnMut, FnOnce},
};
```