### PR TITLE
rustdoc: fix spacing of non-toggled impl blocks

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1041,7 +1041,7 @@ body.blur > :not(#help) {
 }
 
 .item-info .stab {
-	display: table;
+	display: inline-block;
 }
 .stab {
 	padding: 3px;
@@ -2039,7 +2039,8 @@ details.rustdoc-toggle[open] > summary.hideme::after {
 }
 
 .method-toggle summary,
-.implementors-toggle summary {
+.implementors-toggle summary,
+.impl {
 	margin-bottom: 0.75em;
 }
 

--- a/src/test/rustdoc-gui/implementors.goml
+++ b/src/test/rustdoc-gui/implementors.goml
@@ -14,3 +14,7 @@ assert: ("#implementors-list .impl:nth-child(2) > a.anchor")
 assert-attribute: ("#implementors-list .impl:nth-child(2)", {"id": "impl-Whatever-1"})
 assert-attribute: ("#implementors-list .impl:nth-child(2) > a.anchor", {"href": "#impl-Whatever-1"})
 assert: "#implementors-list .impl:nth-child(2) > .code-header.in-band"
+
+goto: file://|DOC_PATH|/test_docs/struct.HasEmptyTraits.html
+compare-elements-position-near-false: ("#impl-EmptyTrait1", "#impl-EmptyTrait2", {"y": 30})
+compare-elements-position-near: ("#impl-EmptyTrait3 h3", "#impl-EmptyTrait3 .item-info", {"y": 30})

--- a/src/test/rustdoc-gui/item-info-width.goml
+++ b/src/test/rustdoc-gui/item-info-width.goml
@@ -4,5 +4,5 @@ goto: file://|DOC_PATH|/lib2/struct.Foo.html
 size: (1100, 800)
 // We check that ".item-info" is bigger than its content.
 assert-css: (".item-info", {"width": "790px"})
-assert-css: (".item-info .stab", {"width": "340px"})
+assert-css: (".item-info .stab", {"width": "339.562px"})
 assert-position: (".item-info .stab", {"x": 295})

--- a/src/test/rustdoc-gui/src/test_docs/Cargo.toml
+++ b/src/test/rustdoc-gui/src/test_docs/Cargo.toml
@@ -7,3 +7,7 @@ build = "build.rs"
 
 [lib]
 path = "lib.rs"
+
+[features]
+default = ["some-feature"]
+some-feature = []

--- a/src/test/rustdoc-gui/src/test_docs/lib.rs
+++ b/src/test/rustdoc-gui/src/test_docs/lib.rs
@@ -260,3 +260,14 @@ impl HeavilyDocumentedUnion {
 macro_rules! heavily_documented_macro {
     () => {};
 }
+
+pub trait EmptyTrait1 {}
+pub trait EmptyTrait2 {}
+pub trait EmptyTrait3 {}
+
+pub struct HasEmptyTraits{}
+
+impl EmptyTrait1 for HasEmptyTraits {}
+impl EmptyTrait2 for HasEmptyTraits {}
+#[doc(cfg(feature = "some-feature"))]
+impl EmptyTrait3 for HasEmptyTraits {}


### PR DESCRIPTION
We [recently removed the "up here" arrows on item-infos](https://github.com/rust-lang/rust/pull/92651), and adjusted
vertical spacing so that even without the arrow, it would be visually
clear which item the item-info belonged to. The new CSS styles for
vertical spacing only applied to toggles, though. This missed
non-toggled impl blocks - for instance, those without any methods, like
https://doc.rust-lang.org/nightly/std/marker/trait.Send.html#implementors.
The result was lists of implementors that were spaced too closely. This
PR fixes the spacing by making it apply to non-toggled impl blocks as
well.

This also fixes an issue where item-infos were displayed too far below
their items. That was a result of display: table on .item-info .stab.
Changed that to display: inline-block.

Demo: https://rustdoc.crud.net/jsha/re-space-empty-impls/std/marker/trait.Send.html

Before:

<img width=300 src="https://user-images.githubusercontent.com/220205/152954394-ec0b80e7-2573-4f06-9d7a-7b10b8ceac60.png">


After:

<img width=300 src="https://user-images.githubusercontent.com/220205/152954228-abac1d30-a76d-4ab1-89ec-ef7549fe8c9c.png">


r? @GuillaumeGomez