### PR TITLE
rustdoc: Collect traits in scope for lang items

### DIFF
--- a/compiler/rustc_metadata/src/rmeta/decoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder.rs
@@ -1032,13 +1032,11 @@ impl<'a, 'tcx> CrateMetadataRef<'a> {
     }
 
     /// Iterates over the language items in the given crate.
-    fn get_lang_items(self, tcx: TyCtxt<'tcx>) -> &'tcx [(DefId, usize)] {
-        tcx.arena.alloc_from_iter(
-            self.root
-                .lang_items
-                .decode(self)
-                .map(|(def_index, index)| (self.local_def_id(def_index), index)),
-        )
+    fn get_lang_items(self) -> impl Iterator<Item = (DefId, usize)> + 'a {
+        self.root
+            .lang_items
+            .decode(self)
+            .map(move |(def_index, index)| (self.local_def_id(def_index), index))
     }
 
     /// Iterates over the diagnostic items in the given crate.

--- a/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
@@ -200,7 +200,7 @@ provide! { <'tcx> tcx, def_id, other, cdata,
         tcx.arena.alloc_slice(&result)
     }
     defined_lib_features => { cdata.get_lib_features(tcx) }
-    defined_lang_items => { cdata.get_lang_items(tcx) }
+    defined_lang_items => { tcx.arena.alloc_from_iter(cdata.get_lang_items()) }
     diagnostic_items => { cdata.get_diagnostic_items() }
     missing_lang_items => { cdata.get_missing_lang_items(tcx) }
 
@@ -500,6 +500,11 @@ impl CStore {
         cnum: CrateNum,
     ) -> impl Iterator<Item = (DefId, DefId)> + '_ {
         self.get_crate_data(cnum).get_inherent_impls()
+    }
+
+    /// Decodes all lang items in the crate (for rustdoc).
+    pub fn lang_items_untracked(&self, cnum: CrateNum) -> impl Iterator<Item = DefId> + '_ {
+        self.get_crate_data(cnum).get_lang_items().map(|(def_id, _)| def_id)
     }
 }
 

--- a/src/librustdoc/passes/collect_intra_doc_links/early.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links/early.rs
@@ -118,6 +118,7 @@ impl IntraLinkCrateLoader<'_, '_> {
                 Vec::from_iter(self.resolver.cstore().trait_impls_in_crate_untracked(cnum));
             let all_inherent_impls =
                 Vec::from_iter(self.resolver.cstore().inherent_impls_in_crate_untracked(cnum));
+            let all_lang_items = Vec::from_iter(self.resolver.cstore().lang_items_untracked(cnum));
 
             // Querying traits in scope is expensive so we try to prune the impl and traits lists
             // using privacy, private traits and impls from other crates are never documented in
@@ -140,6 +141,9 @@ impl IntraLinkCrateLoader<'_, '_> {
                 if self.resolver.cstore().visibility_untracked(ty_def_id) == Visibility::Public {
                     self.add_traits_in_parent_scope(impl_def_id);
                 }
+            }
+            for def_id in all_lang_items {
+                self.add_traits_in_parent_scope(def_id);
             }
 
             self.all_traits.extend(all_traits);

--- a/src/test/rustdoc/intra-doc/auxiliary/extern-lang-item-impl-dep.rs
+++ b/src/test/rustdoc/intra-doc/auxiliary/extern-lang-item-impl-dep.rs
@@ -1,0 +1,29 @@
+// no-prefer-dynamic
+
+#![feature(lang_items)]
+
+#![crate_type = "rlib"]
+#![no_std]
+
+pub struct DerefsToF64(f64);
+
+impl core::ops::Deref for DerefsToF64 {
+    type Target = f64;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+mod inner {
+    #[lang = "f64_runtime"]
+    impl f64 {
+        /// [f64::clone]
+        pub fn method() {}
+    }
+}
+
+#[lang = "eh_personality"]
+fn foo() {}
+
+#[panic_handler]
+fn bar(_: &core::panic::PanicInfo) -> ! { loop {} }

--- a/src/test/rustdoc/intra-doc/extern-lang-item-impl.rs
+++ b/src/test/rustdoc/intra-doc/extern-lang-item-impl.rs
@@ -1,0 +1,11 @@
+// Reexport of a structure that derefs to a type with lang item impls having doc links in their
+// comments. The doc link points to an associated item, so we check that traits in scope for that
+// link are populated.
+
+// aux-build:extern-lang-item-impl-dep.rs
+
+#![no_std]
+
+extern crate extern_lang_item_impl_dep;
+
+pub use extern_lang_item_impl_dep::DerefsToF64;


### PR DESCRIPTION
Inherent impls on primitive types are not included in the list of all inherent impls in the crate (`inherent_impls_in_crate_untracked`), they are taken from the list of lang items instead, but such impls can also be inlined by rustdoc, e.g. if something derefs to a primitive type.

r? @camelid
Fixes https://github.com/rust-lang/rust/issues/93698

