### PR TITLE
Perhaps improve the documentation of drain members further

### DIFF
--- a/library/alloc/src/collections/binary_heap.rs
+++ b/library/alloc/src/collections/binary_heap.rs
@@ -754,6 +754,12 @@ impl<T: Ord> BinaryHeap<T> {
     /// * `.drain_sorted()` is *O*(*n* \* log(*n*)); much slower than `.drain()`.
     ///   You should use the latter for most cases.
     ///
+    /// # Leaking
+    ///
+    /// In case the iterator disappears without getting dropped (using
+    /// [`mem::forget`], for example), it is unspecified whether the
+    /// remaining elements are still in the heap or leaked.
+    ///
     /// # Examples
     ///
     /// Basic usage:
@@ -1161,6 +1167,14 @@ impl<T> BinaryHeap<T> {
     /// Clears the binary heap, returning an iterator over the removed elements.
     ///
     /// The elements are removed in arbitrary order.
+    ///
+    /// # Leaking
+    ///
+    /// When the iterator **is** dropped, it drops any elements that it has not
+    /// yet yielded (none if the iterator was fully consumed).
+    /// If the iterator **is not** dropped (with [`mem::forget`], for example),
+    /// it is unspecified whether the elements not yet yielded are still in the
+    /// heap or leaked.
     ///
     /// # Examples
     ///

--- a/library/alloc/src/collections/binary_heap.rs
+++ b/library/alloc/src/collections/binary_heap.rs
@@ -748,7 +748,7 @@ impl<T: Ord> BinaryHeap<T> {
 
     /// Returns an iterator which retrieves elements in heap order.
     /// The retrieved elements are removed from the original heap.
-    /// The remaining elements will be removed on drop in heap order.
+    /// On drop, the remaining elements are removed and dropped in heap order.
     ///
     /// Note:
     /// * `.drain_sorted()` is *O*(*n* \* log(*n*)); much slower than `.drain()`.

--- a/library/alloc/src/collections/linked_list.rs
+++ b/library/alloc/src/collections/linked_list.rs
@@ -970,6 +970,14 @@ impl<T> LinkedList<T> {
     /// Note that `drain_filter` lets you mutate every element in the filter closure, regardless of
     /// whether you choose to keep or remove it.
     ///
+    /// # Leaking
+    ///
+    /// When the iterator **is** dropped, it drops any elements that it has not
+    /// yet yielded and for which the closure returns true.
+    /// If the iterator **is not** dropped (with [`mem::forget`], for example),
+    /// it is unspecified whether the elements not yet yielded are still in the
+    /// list or leaked.
+    ///
     /// # Examples
     ///
     /// Splitting a list into evens and odds, reusing the original list:

--- a/library/alloc/src/collections/vec_deque/mod.rs
+++ b/library/alloc/src/collections/vec_deque/mod.rs
@@ -1218,6 +1218,8 @@ impl<T, A: Allocator> VecDeque<T, A> {
     /// Removes the specified range from the `VecDeque`, returning all removed
     /// elements as an iterator.
     ///
+    /// # Leaking
+    ///
     /// When the iterator **is** dropped, it drops any elements that it has not
     /// yet yielded (none if the iterator was fully consumed).
     /// If the iterator **is not** dropped (with [`mem::forget`], for example),

--- a/library/alloc/src/collections/vec_deque/mod.rs
+++ b/library/alloc/src/collections/vec_deque/mod.rs
@@ -1215,15 +1215,14 @@ impl<T, A: Allocator> VecDeque<T, A> {
         unsafe { IterMut::new(ring, tail, head, PhantomData) }
     }
 
-    /// Creates a draining iterator that removes the specified range in the
-    /// `VecDeque` and yields the removed items.
+    /// Removes the specified range from the `VecDeque`, returning all removed
+    /// elements as an iterator.
     ///
-    /// Note 1: The element range is removed even if the iterator is not
-    /// consumed until the end.
-    ///
-    /// Note 2: It is unspecified how many elements are removed from the deque,
-    /// if the `Drain` value is not dropped, but the borrow it holds expires
-    /// (e.g., due to `mem::forget`).
+    /// When the iterator **is** dropped, it drops any elements that it has not
+    /// yet yielded (none if the iterator was fully consumed).
+    /// If the iterator **is not** dropped (with [`mem::forget`], for example),
+    /// it is unspecified which elements remain in the vector; even elements
+    /// outside the range may have been removed and leaked.
     ///
     /// # Panics
     ///
@@ -1240,7 +1239,7 @@ impl<T, A: Allocator> VecDeque<T, A> {
     /// assert_eq!(drained, [3]);
     /// assert_eq!(v, [1, 2]);
     ///
-    /// // A full range clears all contents
+    /// // A full range clears all contents, like `clear()` does
     /// v.drain(..);
     /// assert!(v.is_empty());
     /// ```

--- a/library/alloc/src/string.rs
+++ b/library/alloc/src/string.rs
@@ -1628,11 +1628,8 @@ impl String {
         self.vec.clear()
     }
 
-    /// Creates a draining iterator that removes the specified range in the `String`
-    /// and yields the removed `chars`.
-    ///
-    /// Note: The element range is removed even if the iterator is not
-    /// consumed until the end.
+    /// Removes the specified range from the string, returning all removed
+    /// characters as an iterator.
     ///
     /// # Panics
     ///
@@ -1652,7 +1649,7 @@ impl String {
     /// assert_eq!(t, "α is alpha, ");
     /// assert_eq!(s, "β is beta");
     ///
-    /// // A full range clears the string
+    /// // A full range clears the string, like `clear()` does
     /// s.drain(..);
     /// assert_eq!(s, "");
     /// ```

--- a/library/alloc/src/string.rs
+++ b/library/alloc/src/string.rs
@@ -1631,6 +1631,11 @@ impl String {
     /// Removes the specified range from the string, returning all removed
     /// characters as an iterator.
     ///
+    /// # Leaking
+    ///
+    /// In case the iterator disappears without getting dropped (using
+    /// [`core::mem::forget`], for example), the range remains in the string.
+    ///
     /// # Panics
     ///
     /// Panics if the starting point or end point do not lie on a [`char`]

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -1799,13 +1799,14 @@ impl<T, A: Allocator> Vec<T, A> {
         self.len += count;
     }
 
-    /// Creates a draining iterator that removes the specified range in the vector
-    /// and yields the removed items.
+    /// Removes the specified range from the vector, returning all removed
+    /// elements as an iterator.
     ///
-    /// When the iterator **is** dropped, all elements in the range are removed
-    /// from the vector, even if the iterator was not fully consumed. If the
-    /// iterator **is not** dropped (with [`mem::forget`] for example), it is
-    /// unspecified how many elements are removed.
+    /// When the iterator **is** dropped, it drops any elements that it has not
+    /// yet yielded (none if the iterator was fully consumed).
+    /// If the iterator **is not** dropped (with [`mem::forget`], for example),
+    /// it is unspecified which elements remain in the vector; even elements
+    /// outside the range may have been removed and leaked.
     ///
     /// # Panics
     ///
@@ -1820,7 +1821,7 @@ impl<T, A: Allocator> Vec<T, A> {
     /// assert_eq!(v, &[1]);
     /// assert_eq!(u, &[2, 3]);
     ///
-    /// // A full range clears the vector
+    /// // A full range clears the vector, like `clear()` does
     /// v.drain(..);
     /// assert_eq!(v, &[]);
     /// ```

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -1802,6 +1802,8 @@ impl<T, A: Allocator> Vec<T, A> {
     /// Removes the specified range from the vector, returning all removed
     /// elements as an iterator.
     ///
+    /// # Leaking
+    ///
     /// When the iterator **is** dropped, it drops any elements that it has not
     /// yet yielded (none if the iterator was fully consumed).
     /// If the iterator **is not** dropped (with [`mem::forget`], for example),
@@ -2731,6 +2733,14 @@ impl<T, A: Allocator> Vec<T, A> {
     ///
     /// Note that `drain_filter` also lets you mutate every element in the filter closure,
     /// regardless of whether you choose to keep or remove it.
+    ///
+    /// # Leaking
+    ///
+    /// When the iterator **is** dropped, it drops any elements that it has not
+    /// yet yielded and for which the closure returns true.
+    /// If the iterator **is not** dropped (with [`mem::forget`], for example),
+    /// it is unspecified which elements remain in the vector; even elements
+    /// outside the range may have been removed and leaked.
     ///
     /// # Examples
     ///

--- a/library/std/src/collections/hash/set.rs
+++ b/library/std/src/collections/hash/set.rs
@@ -227,7 +227,7 @@ impl<T, S> HashSet<T, S> {
         self.base.is_empty()
     }
 
-    /// Clears the set, returning all elements in an iterator.
+    /// Clears the set, returning all elements as an iterator.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
Building on #92902, let's try adding clauses about mem::forget in all of the drainy functions.

Reasons to do that:
- These methods consume (part of) the contents a container, but obviously the argument type does not make that clear and has to be a plain `&mut`. That makes a huge difference compared to `into_iter`.
- Apparently people do use `mem::forget` a lot and are surprised by its effect, see the history of the notice on `vec::drain`.

Reasons not to do that:
- It makes the description overwhelming. To mitigate that, I moved these paragraphs into a separate section.
- It may lock in a contract that a later implementation may wish to violate. Though as far as I see that's only the case for `string::drain`.

I'd rather move the Leaking section below Panics because it seems much more of a detail, just didn't do that to reduce changes where the clause exists already.

r? @yaahc