### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -173,7 +173,7 @@ Kyle J Strand <batmanaod@gmail.com> <kyle.j.strand@gmail.com>
 Kyle J Strand <batmanaod@gmail.com> <kyle.strand@pieinsurance.com>
 Kyle J Strand <batmanaod@gmail.com> <kyle.strand@rms.com>
 Laurențiu Nicola <lnicola@dend.ro>
-lcnr <bastian_kauschke@hotmail.de>
+lcnr <rust@lcnr.de> <bastian_kauschke@hotmail.de>
 Lee Jeffery <leejeffery@gmail.com> Lee Jeffery <lee@leejeffery.co.uk>
 Lee Wondong <wdlee91@gmail.com>
 Lennart Kudling <github@kudling.de>

--- a/compiler/rustc_infer/src/infer/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/mod.rs
@@ -2068,7 +2068,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                                 if let Some(code) =
                                     code.strip_prefix('"').and_then(|s| s.strip_suffix('"'))
                                 {
-                                    if code.chars().nth(1).is_none() {
+                                    if code.chars().count() == 1 {
                                         err.span_suggestion(
                                             span,
                                             "if you meant to write a `char` literal, use single quotes",

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -2470,7 +2470,7 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                 let projection_ty = ty::ProjectionTy {
                     // `T`
                     substs: self.tcx.mk_substs_trait(
-                        trait_ref.self_ty().skip_binder(),
+                        trait_pred.self_ty().skip_binder(),
                         &self.fresh_substs_for_item(span, item_def_id)[1..],
                     ),
                     // `Future::Output`

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -2470,8 +2470,8 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                 let projection_ty = ty::ProjectionTy {
                     // `T`
                     substs: self.tcx.mk_substs_trait(
-                        trait_pred.self_ty().skip_binder(),
-                        self.fresh_substs_for_item(span, item_def_id),
+                        trait_ref.self_ty().skip_binder(),
+                        &self.fresh_substs_for_item(span, item_def_id)[1..],
                     ),
                     // `Future::Output`
                     item_def_id,

--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -1521,16 +1521,6 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             infer_predicate.projection_ty
         };
 
-        // If the obligation contains any inference types or consts in associated
-        // type substs, then we don't match any projection candidates against it.
-        // This isn't really correct, but otherwise we can end up in a case where
-        // we constrain inference variables by selecting a single predicate, when
-        // we need to stay general. See issue #91762.
-        let (_, predicate_own_substs) =
-            obligation.predicate.trait_ref_and_own_substs(self.infcx.tcx);
-        if predicate_own_substs.iter().any(|g| g.has_infer_types_or_consts()) {
-            return false;
-        }
         self.infcx
             .at(&obligation.cause, obligation.param_env)
             .sup(obligation.predicate, infer_projection)

--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -2044,7 +2044,7 @@ pub fn remove_dir<P: AsRef<Path>>(path: P) -> io::Result<()> {
 ///
 /// This function currently corresponds to `openat`, `fdopendir`, `unlinkat` and `lstat` functions
 /// on Unix (except for macOS before version 10.10 and REDOX) and the `CreateFileW`,
-/// `GetFileInformationByHandleEx`, `SetFileInformationByHandle`, and `NtOpenFile` functions on
+/// `GetFileInformationByHandleEx`, `SetFileInformationByHandle`, and `NtCreateFile` functions on
 /// Windows. Note that, this [may change in the future][changes].
 ///
 /// [changes]: io#platform-specific-behavior

--- a/library/std/src/sys/windows/c.rs
+++ b/library/std/src/sys/windows/c.rs
@@ -88,6 +88,7 @@ pub const FILE_SHARE_DELETE: DWORD = 0x4;
 pub const FILE_SHARE_READ: DWORD = 0x1;
 pub const FILE_SHARE_WRITE: DWORD = 0x2;
 
+pub const FILE_OPEN: ULONG = 0x00000001;
 pub const FILE_OPEN_REPARSE_POINT: ULONG = 0x200000;
 pub const OBJ_DONT_REPARSE: ULONG = 0x1000;
 
@@ -1228,15 +1229,20 @@ compat_fn! {
 
 compat_fn! {
     "ntdll":
-    pub fn NtOpenFile(
+    pub fn NtCreateFile(
         FileHandle: *mut HANDLE,
         DesiredAccess: ACCESS_MASK,
         ObjectAttributes: *const OBJECT_ATTRIBUTES,
         IoStatusBlock: *mut IO_STATUS_BLOCK,
+        AllocationSize: *mut i64,
+        FileAttributes: ULONG,
         ShareAccess: ULONG,
-        OpenOptions: ULONG
+        CreateDisposition: ULONG,
+        CreateOptions: ULONG,
+        EaBuffer: *mut c_void,
+        EaLength: ULONG
     ) -> NTSTATUS {
-        panic!("`NtOpenFile` not available");
+        panic!("`NtCreateFile` not available");
     }
     pub fn RtlNtStatusToDosError(
         Status: NTSTATUS

--- a/src/test/ui/allocator/not-an-allocator.stderr
+++ b/src/test/ui/allocator/not-an-allocator.stderr
@@ -1,40 +1,40 @@
 error[E0277]: the trait bound `usize: GlobalAlloc` is not satisfied
-  --> $DIR/not-an-allocator.rs:2:1
+  --> $DIR/not-an-allocator.rs:2:11
    |
 LL | #[global_allocator]
    | ------------------- in this procedural macro expansion
 LL | static A: usize = 0;
-   | ^^^^^^^^^^^^^^^^^^^^ the trait `GlobalAlloc` is not implemented for `usize`
+   |           ^^^^^ the trait `GlobalAlloc` is not implemented for `usize`
    |
    = note: this error originates in the attribute macro `global_allocator` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `usize: GlobalAlloc` is not satisfied
-  --> $DIR/not-an-allocator.rs:2:1
+  --> $DIR/not-an-allocator.rs:2:11
    |
 LL | #[global_allocator]
    | ------------------- in this procedural macro expansion
 LL | static A: usize = 0;
-   | ^^^^^^^^^^^^^^^^^^^^ the trait `GlobalAlloc` is not implemented for `usize`
+   |           ^^^^^ the trait `GlobalAlloc` is not implemented for `usize`
    |
    = note: this error originates in the attribute macro `global_allocator` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `usize: GlobalAlloc` is not satisfied
-  --> $DIR/not-an-allocator.rs:2:1
+  --> $DIR/not-an-allocator.rs:2:11
    |
 LL | #[global_allocator]
    | ------------------- in this procedural macro expansion
 LL | static A: usize = 0;
-   | ^^^^^^^^^^^^^^^^^^^^ the trait `GlobalAlloc` is not implemented for `usize`
+   |           ^^^^^ the trait `GlobalAlloc` is not implemented for `usize`
    |
    = note: this error originates in the attribute macro `global_allocator` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `usize: GlobalAlloc` is not satisfied
-  --> $DIR/not-an-allocator.rs:2:1
+  --> $DIR/not-an-allocator.rs:2:11
    |
 LL | #[global_allocator]
    | ------------------- in this procedural macro expansion
 LL | static A: usize = 0;
-   | ^^^^^^^^^^^^^^^^^^^^ the trait `GlobalAlloc` is not implemented for `usize`
+   |           ^^^^^ the trait `GlobalAlloc` is not implemented for `usize`
    |
    = note: this error originates in the attribute macro `global_allocator` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/src/test/ui/generic-associated-types/issue-74824.rs
+++ b/src/test/ui/generic-associated-types/issue-74824.rs
@@ -17,6 +17,7 @@ impl<T> UnsafeCopy for T {}
 fn main() {
     let b = Box::new(42usize);
     let copy = <()>::copy(&b);
+    //~^ type annotations needed
 
     let raw_b = Box::deref(&b) as *const _;
     let raw_copy = Box::deref(&copy) as *const _;

--- a/src/test/ui/generic-associated-types/issue-74824.stderr
+++ b/src/test/ui/generic-associated-types/issue-74824.stderr
@@ -27,6 +27,13 @@ help: consider restricting type parameter `T`
 LL |     type Copy<T: std::clone::Clone>: Copy = Box<T>;
    |                +++++++++++++++++++
 
-error: aborting due to 2 previous errors
+error[E0282]: type annotations needed
+  --> $DIR/issue-74824.rs:19:16
+   |
+LL |     let copy = <()>::copy(&b);
+   |                ^^^^^^^^^^ cannot infer type for type parameter `T` declared on the associated function `copy`
 
-For more information about this error, try `rustc --explain E0277`.
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0277, E0282.
+For more information about an error, try `rustc --explain E0277`.

--- a/src/test/ui/generic-associated-types/issue-91762.rs
+++ b/src/test/ui/generic-associated-types/issue-91762.rs
@@ -23,7 +23,7 @@ pub trait FunctorExt<T>: Sized {
 
         arg = self;
         ret = <Self::Base as Functor>::fmap(arg);
-        //~^ mismatched types
+        //~^ type annotations needed
     }
 }
 

--- a/src/test/ui/generic-associated-types/issue-91762.rs
+++ b/src/test/ui/generic-associated-types/issue-91762.rs
@@ -1,0 +1,30 @@
+// check-fail
+
+// FIXME(generic_associated_types): We almost certaintly want this to pass, but
+// it's particularly difficult currently, because we need a way of specifying
+// that `<Self::Base as Functor>::With<T> = Self` without using that when we have
+// a `U`. See `https://github.com/rust-lang/rust/pull/92728` for a (hacky)
+// solution. This might be better to just wait for Chalk.
+
+#![feature(generic_associated_types)]
+
+pub trait Functor {
+    type With<T>;
+
+    fn fmap<T, U>(this: Self::With<T>) -> Self::With<U>;
+}
+
+pub trait FunctorExt<T>: Sized {
+    type Base: Functor<With<T> = Self>;
+
+    fn fmap<U>(self) {
+        let arg: <Self::Base as Functor>::With<T>;
+        let ret: <Self::Base as Functor>::With<U>;
+
+        arg = self;
+        ret = <Self::Base as Functor>::fmap(arg);
+        //~^ mismatched types
+    }
+}
+
+fn main() {}

--- a/src/test/ui/generic-associated-types/issue-91762.stderr
+++ b/src/test/ui/generic-associated-types/issue-91762.stderr
@@ -1,0 +1,22 @@
+error[E0308]: mismatched types
+  --> $DIR/issue-91762.rs:25:45
+   |
+LL | / pub trait FunctorExt<T>: Sized {
+LL | |     type Base: Functor<With<T> = Self>;
+LL | |
+LL | |     fn fmap<U>(self) {
+...  |
+LL | |         ret = <Self::Base as Functor>::fmap(arg);
+   | |                                             ^^^ expected associated type, found type parameter `Self`
+LL | |
+LL | |     }
+LL | | }
+   | |_- this type parameter
+   |
+   = note: expected associated type `<<Self as FunctorExt<T>>::Base as Functor>::With<_>`
+               found type parameter `Self`
+   = note: you might be missing a type parameter or trait bound
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/generic-associated-types/issue-91762.stderr
+++ b/src/test/ui/generic-associated-types/issue-91762.stderr
@@ -1,22 +1,9 @@
-error[E0308]: mismatched types
-  --> $DIR/issue-91762.rs:25:45
+error[E0282]: type annotations needed
+  --> $DIR/issue-91762.rs:25:15
    |
-LL | / pub trait FunctorExt<T>: Sized {
-LL | |     type Base: Functor<With<T> = Self>;
-LL | |
-LL | |     fn fmap<U>(self) {
-...  |
-LL | |         ret = <Self::Base as Functor>::fmap(arg);
-   | |                                             ^^^ expected associated type, found type parameter `Self`
-LL | |
-LL | |     }
-LL | | }
-   | |_- this type parameter
-   |
-   = note: expected associated type `<<Self as FunctorExt<T>>::Base as Functor>::With<_>`
-               found type parameter `Self`
-   = note: you might be missing a type parameter or trait bound
+LL |         ret = <Self::Base as Functor>::fmap(arg);
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type for type parameter `T` declared on the associated function `fmap`
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0308`.
+For more information about this error, try `rustc --explain E0282`.

--- a/src/test/ui/implied-bounds/hrlt-implied-trait-bounds-guard.rs
+++ b/src/test/ui/implied-bounds/hrlt-implied-trait-bounds-guard.rs
@@ -1,0 +1,51 @@
+// A test exploiting the bug behind #25860 except with
+// implied trait bounds which currently don't exist,
+//
+// please ping @lcnr if your changes end up causing `badboi` to compile.
+use std::marker::PhantomData;
+struct Foo<'a, 'b, T>(PhantomData<(&'a (), &'b (), T)>)
+where
+    T: Convert<'a, 'b>;
+
+trait Convert<'a, 'b>: Sized {
+    fn cast(&'a self) -> &'b Self;
+}
+impl<'long: 'short, 'short, T> Convert<'long, 'short> for T {
+    fn cast(&'long self) -> &'short T {
+        self
+    }
+}
+
+// This function will compile once we add implied trait bounds.
+//
+// If we're not careful with our impl, the transformations
+// in `bad` would succeed, which is unsound ✨
+//
+// FIXME: the error is pretty bad, this should say
+//
+//     `T: Convert<'in_, 'out>` is not implemented
+//
+// help: needed by `Foo<'in_, 'out, T>`
+fn badboi<'in_, 'out, T>(x: Foo<'in_, 'out, T>, sadness: &'in_ T) -> &'out T {
+    //~^ ERROR lifetime mismatch
+    sadness.cast()
+}
+
+fn bad<'short, T>(value: &'short T) -> &'static T {
+    let x: for<'in_, 'out> fn(Foo<'in_, 'out, T>, &'in_ T) -> &'out T = badboi;
+    let x: for<'out> fn(Foo<'short, 'out, T>, &'short T) -> &'out T = x;
+    let x: for<'out> fn(Foo<'static, 'out, T>, &'short T) -> &'out T = x;
+    let x: fn(Foo<'static, 'static, T>, &'short T) -> &'static T = x;
+    x(Foo(PhantomData), value)
+}
+
+// Use `bad` to cause a segfault.
+fn main() {
+    let mut outer: Option<&'static u32> = Some(&3);
+    let static_ref: &'static &'static u32 = match outer {
+        Some(ref reference) => bad(reference),
+        None => unreachable!(),
+    };
+    outer = None;
+    println!("{}", static_ref);
+}

--- a/src/test/ui/implied-bounds/hrlt-implied-trait-bounds-guard.rs
+++ b/src/test/ui/implied-bounds/hrlt-implied-trait-bounds-guard.rs
@@ -1,7 +1,5 @@
 // A test exploiting the bug behind #25860 except with
-// implied trait bounds which currently don't exist,
-//
-// please ping @lcnr if your changes end up causing `badboi` to compile.
+// implied trait bounds which currently don't exist without `-Zchalk`.
 use std::marker::PhantomData;
 struct Foo<'a, 'b, T>(PhantomData<(&'a (), &'b (), T)>)
 where
@@ -26,6 +24,8 @@ impl<'long: 'short, 'short, T> Convert<'long, 'short> for T {
 //     `T: Convert<'in_, 'out>` is not implemented
 //
 // help: needed by `Foo<'in_, 'out, T>`
+//
+// Please ping @lcnr if your changes end up causing `badboi` to compile.
 fn badboi<'in_, 'out, T>(x: Foo<'in_, 'out, T>, sadness: &'in_ T) -> &'out T {
     //~^ ERROR lifetime mismatch
     sadness.cast()

--- a/src/test/ui/implied-bounds/hrlt-implied-trait-bounds-guard.stderr
+++ b/src/test/ui/implied-bounds/hrlt-implied-trait-bounds-guard.stderr
@@ -1,0 +1,12 @@
+error[E0623]: lifetime mismatch
+  --> $DIR/hrlt-implied-trait-bounds-guard.rs:29:29
+   |
+LL | fn badboi<'in_, 'out, T>(x: Foo<'in_, 'out, T>, sadness: &'in_ T) -> &'out T {
+   |                             ^^^^^^^^^^^^^^^^^^                       -------
+   |                             |
+   |                             this parameter and the return type are declared with different lifetimes...
+   |                             ...but data from `x` is returned here
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0623`.

--- a/src/test/ui/implied-bounds/hrlt-implied-trait-bounds-roundtrip.rs
+++ b/src/test/ui/implied-bounds/hrlt-implied-trait-bounds-roundtrip.rs
@@ -1,0 +1,35 @@
+// check-pass
+struct Foo<'a>(&'a ())
+where
+    (): Trait<'a>;
+
+trait Trait<'a> {
+    fn id<T>(value: &'a T) -> &'static T;
+}
+
+impl Trait<'static> for () {
+    fn id<T>(value: &'static T) -> &'static T {
+        value
+    }
+}
+
+fn could_use_implied_bounds<'a, T>(_: Foo<'a>, x: &'a T) -> &'static T
+where
+    (): Trait<'a>, // This could be an implied bound
+{
+    <()>::id(x)
+}
+
+fn main() {
+    let bar: for<'a, 'b> fn(Foo<'a>, &'b ()) = |_, _| {};
+
+    // If `could_use_implied_bounds` were to use implied bounds,
+    // keeping 'a late-bound, then we could assign that function
+    // to this variable.
+    let bar: for<'a> fn(Foo<'a>, &'a ()) = bar;
+
+    // In this case, the subtyping relation here would be unsound,
+    // allowing us to transmute lifetimes. This currently compiles
+    // because we incorrectly deal with implied bounds inside of binders.
+    let _bar: for<'a, 'b> fn(Foo<'a>, &'b ()) = bar;
+}

--- a/src/test/ui/inference/char-as-str-multi.rs
+++ b/src/test/ui/inference/char-as-str-multi.rs
@@ -1,6 +1,7 @@
-// When a MULTI-character string literal is used where a char should be,
+// When a MULTI/NO-character string literal is used where a char should be,
 // DO NOT suggest changing to single quotes.
 
 fn main() {
     let _: char = "foo"; //~ ERROR mismatched types
+    let _: char = ""; //~ ERROR mismatched types
 }

--- a/src/test/ui/inference/char-as-str-multi.stderr
+++ b/src/test/ui/inference/char-as-str-multi.stderr
@@ -6,6 +6,14 @@ LL |     let _: char = "foo";
    |            |
    |            expected due to this
 
-error: aborting due to previous error
+error[E0308]: mismatched types
+  --> $DIR/char-as-str-multi.rs:6:19
+   |
+LL |     let _: char = "";
+   |            ----   ^^ expected `char`, found `&str`
+   |            |
+   |            expected due to this
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Successful merges:

 - #91950 (Point at type when a `static` `#[global_allocator]` doesn't `impl` `GlobalAlloc`)
 - #92715 (Do not suggest char literal for zero-length strings)
 - #92917 (Don't constrain projection predicates with inference vars in GAT substs)
 - #93206 (Use `NtCreateFile` instead of `NtOpenFile` to open a file)
 - #93732 (add fut/back compat tests for implied trait bounds)
 - #93764 (:arrow_up: rust-analyzer)
 - #93767 (deduplicate `lcnr` in mailmap)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=91950,92715,92917,93206,93732,93764,93767)
<!-- homu-ignore:end -->