### PR TITLE
Fix regression from lazy opaque types

### DIFF
--- a/compiler/rustc_typeck/src/check/fn_ctxt/_impl.rs
+++ b/compiler/rustc_typeck/src/check/fn_ctxt/_impl.rs
@@ -730,7 +730,32 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     ) -> Vec<Ty<'tcx>> {
         let formal_ret = self.resolve_vars_with_obligations(formal_ret);
         let ret_ty = match expected_ret.only_has_type(self) {
-            Some(ret) => ret,
+            Some(ret) => {
+                // HACK(oli-obk): This is a backwards compatibility hack. Without it, the inference
+                // variable will get instantiated with the opaque type. The inference variable often
+                // has various helpful obligations registered for it that help closures figure out their
+                // signature. If we infer the inference var to the opaque type, the closure won't be able
+                // to find those obligations anymore, and it can't necessarily find them from the opaque
+                // type itself. We could be more powerful with inference if we *combined* the obligations
+                // so that we got both the obligations from the opaque type and the ones from the inference
+                // variable. That will accept more code than we do right now, so we need to carefully consider
+                // the implications.
+                // Note: this check is pessimistic, as the inference type could be matched with something other
+                // than the opaque type, but then we need a new `TypeRelation` just for this specific case and
+                // can't re-use `sup` below.
+                if formal_ret.has_infer_types() {
+                    for ty in ret.walk() {
+                        if let ty::subst::GenericArgKind::Type(ty) = ty.unpack() {
+                            if let ty::Opaque(def_id, _) = *ty.kind() {
+                                if self.infcx.opaque_type_origin(def_id, DUMMY_SP).is_some() {
+                                    return Vec::new();
+                                }
+                            }
+                        }
+                    }
+                }
+                ret
+            }
             None => return Vec::new(),
         };
         let expect_args = self

--- a/src/test/ui/impl-trait/hidden-type-is-opaque-2.rs
+++ b/src/test/ui/impl-trait/hidden-type-is-opaque-2.rs
@@ -1,0 +1,34 @@
+// This doesn't work, because we don't flow information from opaque types
+// into function arguments via the function's generic parameters
+// FIXME(oli-obk): make `expected_inputs_for_expected_output` support this
+
+fn reify_as() -> Thunk<impl FnOnce(Continuation) -> Continuation> {
+    Thunk::new(|mut cont| { //~ ERROR type annotations needed
+        cont.reify_as();
+        cont
+    })
+}
+
+#[must_use]
+struct Thunk<F>(F);
+
+impl<F> Thunk<F> {
+    fn new(f: F) -> Self
+    where
+        F: ContFn,
+    {
+        Thunk(f)
+    }
+}
+
+trait ContFn {}
+
+impl<F: FnOnce(Continuation) -> Continuation> ContFn for F {}
+
+struct Continuation;
+
+impl Continuation {
+    fn reify_as(&mut self) {}
+}
+
+fn main() {}

--- a/src/test/ui/impl-trait/hidden-type-is-opaque-2.stderr
+++ b/src/test/ui/impl-trait/hidden-type-is-opaque-2.stderr
@@ -1,0 +1,11 @@
+error[E0282]: type annotations needed
+  --> $DIR/hidden-type-is-opaque-2.rs:6:17
+   |
+LL |     Thunk::new(|mut cont| {
+   |                 ^^^^^^^^ consider giving this closure parameter a type
+   |
+   = note: type must be known at this point
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0282`.

--- a/src/test/ui/impl-trait/hidden-type-is-opaque.rs
+++ b/src/test/ui/impl-trait/hidden-type-is-opaque.rs
@@ -1,0 +1,32 @@
+// check-pass
+
+fn reify_as() -> Thunk<impl ContFn> {
+    Thunk::new(|mut cont| {
+        cont.reify_as();
+        cont
+    })
+}
+
+#[must_use]
+struct Thunk<F>(F);
+
+impl<F> Thunk<F> {
+    fn new(f: F) -> Self
+    where
+        F: FnOnce(Continuation) -> Continuation,
+    {
+        Thunk(f)
+    }
+}
+
+trait ContFn {}
+
+impl<F: FnOnce(Continuation) -> Continuation> ContFn for F {}
+
+struct Continuation;
+
+impl Continuation {
+    fn reify_as(&mut self) {}
+}
+
+fn main() {}

--- a/src/test/ui/impl-trait/issues/issue-70877.rs
+++ b/src/test/ui/impl-trait/issues/issue-70877.rs
@@ -13,7 +13,7 @@ impl Iterator for Bar {
     type Item = FooItem;
 
     fn next(&mut self) -> Option<Self::Item> {
-        Some(Box::new(quux))
+        Some(Box::new(quux)) //~ ERROR mismatched types
     }
 }
 

--- a/src/test/ui/impl-trait/issues/issue-70877.stderr
+++ b/src/test/ui/impl-trait/issues/issue-70877.stderr
@@ -1,3 +1,17 @@
+error[E0308]: mismatched types
+  --> $DIR/issue-70877.rs:16:9
+   |
+LL | type FooRet = impl std::fmt::Debug;
+   |               -------------------- the expected opaque type
+...
+LL |     fn next(&mut self) -> Option<Self::Item> {
+   |                           ------------------ expected `Option<Box<(dyn for<'r> Fn(&'r (dyn ToString + 'r)) -> FooRet + 'static)>>` because of return type
+LL |         Some(Box::new(quux))
+   |         ^^^^^^^^^^^^^^^^^^^^ expected trait object `dyn Fn`, found fn item
+   |
+   = note: expected enum `Option<Box<(dyn for<'r> Fn(&'r (dyn ToString + 'r)) -> FooRet + 'static)>>`
+              found enum `Option<Box<for<'r> fn(&'r (dyn ToString + 'r)) -> FooRet {quux}>>`
+
 error: opaque type's hidden type cannot be another opaque type from the same scope
   --> $DIR/issue-70877.rs:31:12
    |
@@ -15,5 +29,6 @@ note: opaque type being used as hidden type
 LL | type FooRet = impl std::fmt::Debug;
    |               ^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to previous error
+error: aborting due to 2 previous errors
 
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
The breakage was found in https://github.com/rust-lang/rust/pull/92007#issuecomment-1032203011 and has not hit nightly yet.