### PR TITLE
Force rlibs to be linked in whole for cdylib and bin

### DIFF
--- a/src/test/run-make/issue-47384/Makefile
+++ b/src/test/run-make/issue-47384/Makefile
@@ -1,0 +1,12 @@
+-include ../../run-make-fulldeps/tools.mk
+
+# ignore-windows
+# ignore-cross-compile
+
+all: main.rs
+	$(RUSTC) --crate-type lib lib.rs
+	$(RUSTC) --crate-type cdylib -Clink-args="-Tlinker.ld" main.rs
+	# Ensure `#[used]` and `KEEP`-ed section is there
+	objdump -s -j".static" $(TMPDIR)/libmain.so
+	# Ensure `#[no_mangle]` symbol is there
+	nm $(TMPDIR)/libmain.so | $(CGREP) bar

--- a/src/test/run-make/issue-47384/lib.rs
+++ b/src/test/run-make/issue-47384/lib.rs
@@ -1,0 +1,12 @@
+mod foo {
+    #[link_section = ".rodata.STATIC"]
+    #[used]
+    static STATIC: [u32; 10] = [1; 10];
+}
+
+mod bar {
+    #[no_mangle]
+    extern "C" fn bar() -> i32 {
+        0
+    }
+}

--- a/src/test/run-make/issue-47384/linker.ld
+++ b/src/test/run-make/issue-47384/linker.ld
@@ -1,0 +1,7 @@
+SECTIONS
+{
+    .static : ALIGN(4)
+    {
+        KEEP(*(.rodata.STATIC));
+    }
+}

--- a/src/test/run-make/issue-47384/main.rs
+++ b/src/test/run-make/issue-47384/main.rs
@@ -1,0 +1,1 @@
+extern crate lib;


### PR DESCRIPTION
Fix #50007 and #47384

These issues are caused by the fact that linker will perform archive member selection. By default, an object file in an archive won't be selected unless it is needed to satisfy an undefined reference. This step precedes any linker script and section GC. To address this issue, we can just the whole rlibs to be linked (this is `--whole-archive` for ELF targets).