### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/compiler/rustc_ast_lowering/src/item.rs
+++ b/compiler/rustc_ast_lowering/src/item.rs
@@ -896,9 +896,6 @@ impl<'hir> LoweringContext<'_, 'hir> {
             AssocItemKind::MacCall(..) => panic!("`TyMac` should have been expanded by now"),
         };
 
-        // Since `default impl` is not yet implemented, this is always true in impls.
-        let has_value = true;
-        let (defaultness, _) = self.lower_defaultness(i.kind.defaultness(), has_value);
         let hir_id = self.lower_node_id(i.id);
         self.lower_attrs(hir_id, &i.attrs);
         let item = hir::ImplItem {
@@ -906,7 +903,6 @@ impl<'hir> LoweringContext<'_, 'hir> {
             ident: self.lower_ident(i.ident),
             generics,
             vis: self.lower_visibility(&i.vis),
-            defaultness,
             kind,
             span: self.lower_span(i.span),
         };

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -2112,7 +2112,6 @@ pub struct ImplItem<'hir> {
     pub ident: Ident,
     pub def_id: LocalDefId,
     pub vis: Visibility<'hir>,
-    pub defaultness: Defaultness,
     pub generics: Generics<'hir>,
     pub kind: ImplItemKind<'hir>,
     pub span: Span,
@@ -3304,6 +3303,6 @@ mod size_asserts {
 
     rustc_data_structures::static_assert_size!(super::Item<'static>, 184);
     rustc_data_structures::static_assert_size!(super::TraitItem<'static>, 128);
-    rustc_data_structures::static_assert_size!(super::ImplItem<'static>, 152);
+    rustc_data_structures::static_assert_size!(super::ImplItem<'static>, 144);
     rustc_data_structures::static_assert_size!(super::ForeignItem<'static>, 136);
 }

--- a/compiler/rustc_hir/src/intravisit.rs
+++ b/compiler/rustc_hir/src/intravisit.rs
@@ -1020,12 +1020,10 @@ pub fn walk_trait_item_ref<'v, V: Visitor<'v>>(visitor: &mut V, trait_item_ref: 
 
 pub fn walk_impl_item<'v, V: Visitor<'v>>(visitor: &mut V, impl_item: &'v ImplItem<'v>) {
     // N.B., deliberately force a compilation error if/when new fields are added.
-    let ImplItem { def_id: _, ident, ref vis, ref defaultness, ref generics, ref kind, span: _ } =
-        *impl_item;
+    let ImplItem { def_id: _, ident, ref vis, ref generics, ref kind, span: _ } = *impl_item;
 
     visitor.visit_ident(ident);
     visitor.visit_vis(vis);
-    visitor.visit_defaultness(defaultness);
     visitor.visit_generics(generics);
     match *kind {
         ImplItemKind::Const(ref ty, body) => {

--- a/compiler/rustc_hir/src/stable_hash_impls.rs
+++ b/compiler/rustc_hir/src/stable_hash_impls.rs
@@ -164,13 +164,11 @@ impl<HirCtx: crate::HashStableContext> HashStable<HirCtx> for TraitItem<'_> {
 
 impl<HirCtx: crate::HashStableContext> HashStable<HirCtx> for ImplItem<'_> {
     fn hash_stable(&self, hcx: &mut HirCtx, hasher: &mut StableHasher) {
-        let ImplItem { def_id: _, ident, ref vis, defaultness, ref generics, ref kind, span } =
-            *self;
+        let ImplItem { def_id: _, ident, ref vis, ref generics, ref kind, span } = *self;
 
         hcx.hash_hir_item_like(|hcx| {
             ident.name.hash_stable(hcx, hasher);
             vis.hash_stable(hcx, hasher);
-            defaultness.hash_stable(hcx, hasher);
             generics.hash_stable(hcx, hasher);
             kind.hash_stable(hcx, hasher);
             span.hash_stable(hcx, hasher);

--- a/compiler/rustc_hir_pretty/src/lib.rs
+++ b/compiler/rustc_hir_pretty/src/lib.rs
@@ -923,7 +923,6 @@ impl<'a> State<'a> {
         self.hardbreak_if_not_bol();
         self.maybe_print_comment(ii.span.lo());
         self.print_outer_attributes(self.attrs(ii.hir_id()));
-        self.print_defaultness(ii.defaultness);
 
         match ii.kind {
             hir::ImplItemKind::Const(ref ty, expr) => {

--- a/compiler/rustc_interface/src/tests.rs
+++ b/compiler/rustc_interface/src/tests.rs
@@ -730,6 +730,7 @@ fn test_debugging_options_tracking_hash() {
     tracked!(debug_info_for_profiling, true);
     tracked!(debug_macros, true);
     tracked!(dep_info_omit_d_target, true);
+    tracked!(drop_tracking, true);
     tracked!(dual_proc_macros, true);
     tracked!(fewer_names, Some(true));
     tracked!(force_unstable_if_unmarked, true);

--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -211,6 +211,8 @@ pub enum TyKind<'tcx> {
     ///
     /// For RPIT the substitutions are for the generics of the function,
     /// while for TAIT it is used for the generic parameters of the alias.
+    ///
+    /// During codegen, `tcx.type_of(def_id)` can be used to get the underlying type.
     Opaque(DefId, SubstsRef<'tcx>),
 
     /// A type parameter; for example, `T` in `fn f<T>(x: T) {}`.

--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -74,10 +74,10 @@ impl BoundRegionKind {
     }
 }
 
-/// Defines the kinds of types.
+/// Defines the kinds of types used by the type system.
 ///
-/// N.B., if you change this, you'll probably want to change the corresponding
-/// AST structure in `rustc_ast/src/ast.rs` as well.
+/// Types written by the user start out as [hir::TyKind](rustc_hir::TyKind) and get
+/// converted to this representation using `AstConv::ast_ty_to_ty`.
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, TyEncodable, TyDecodable, Debug)]
 #[derive(HashStable)]
 #[rustc_diagnostic_item = "TyKind"]
@@ -100,10 +100,11 @@ pub enum TyKind<'tcx> {
 
     /// Algebraic data types (ADT). For example: structures, enumerations and unions.
     ///
-    /// InternalSubsts here, possibly against intuition, *may* contain `Param`s.
-    /// That is, even after substitution it is possible that there are type
-    /// variables. This happens when the `Adt` corresponds to an ADT
-    /// definition and not a concrete use of it.
+    /// For example, the type `List<i32>` would be represented using the `AdtDef`
+    /// for `struct List<T>` and the substs `[i32]`.
+    ///
+    /// Note that generic parameters in fields only get lazily substituted
+    /// by using something like `adt_def.all_fields().map(|field| field.ty(tcx, substs))`.
     Adt(&'tcx AdtDef, SubstsRef<'tcx>),
 
     /// An unsized FFI type that is opaque to Rust. Written as `extern type T`.
@@ -112,7 +113,7 @@ pub enum TyKind<'tcx> {
     /// The pointee of a string slice. Written as `str`.
     Str,
 
-    /// An array with the given length. Written as `[T; n]`.
+    /// An array with the given length. Written as `[T; N]`.
     Array(Ty<'tcx>, &'tcx ty::Const<'tcx>),
 
     /// The pointee of an array slice. Written as `[T]`.
@@ -126,11 +127,12 @@ pub enum TyKind<'tcx> {
     Ref(Region<'tcx>, Ty<'tcx>, hir::Mutability),
 
     /// The anonymous type of a function declaration/definition. Each
-    /// function has a unique type, which is output (for a function
-    /// named `foo` returning an `i32`) as `fn() -> i32 {foo}`.
+    /// function has a unique type.
+    ///
+    /// For the function `fn foo() -> i32 { 3 }` this type would be
+    /// shown to the user as `fn() -> i32 {foo}`.
     ///
     /// For example the type of `bar` here:
-    ///
     /// ```rust
     /// fn foo() -> i32 { 1 }
     /// let bar = foo; // bar: fn() -> i32 {foo}
@@ -138,6 +140,9 @@ pub enum TyKind<'tcx> {
     FnDef(DefId, SubstsRef<'tcx>),
 
     /// A pointer to a function. Written as `fn() -> i32`.
+    ///
+    /// Note that both functions and closures start out as either
+    /// [FnDef] or [Closure] which can be then be coerced to this variant.
     ///
     /// For example the type of `bar` here:
     ///
@@ -150,17 +155,41 @@ pub enum TyKind<'tcx> {
     /// A trait object. Written as `dyn for<'b> Trait<'b, Assoc = u32> + Send + 'a`.
     Dynamic(&'tcx List<Binder<'tcx, ExistentialPredicate<'tcx>>>, ty::Region<'tcx>),
 
-    /// The anonymous type of a closure. Used to represent the type of
-    /// `|a| a`.
-    /// For the order of the substs see the `ClosureSubsts` type's documentation.
+    /// The anonymous type of a closure. Used to represent the type of `|a| a`.
+    ///
+    /// Closure substs contain both the - potentially substituted - generic parameters
+    /// of its parent and some synthetic parameters. See the documentation for
+    /// [ClosureSubsts] for more details.
     Closure(DefId, SubstsRef<'tcx>),
 
     /// The anonymous type of a generator. Used to represent the type of
     /// `|a| yield a`.
+    ///
+    /// For more info about generator substs, visit the documentation for
+    /// [GeneratorSubsts].
     Generator(DefId, SubstsRef<'tcx>, hir::Movability),
 
     /// A type representing the types stored inside a generator.
-    /// This should only appear in GeneratorInteriors.
+    /// This should only appear as part of the [GeneratorSubsts].
+    ///
+    /// Note that the captured variables for generators are stored separately
+    /// using a tuple in the same way as for closures.
+    ///
+    /// Unlike upvars, the witness can reference lifetimes from
+    /// inside of the generator itself. To deal with them in
+    /// the type of the generator, we convert them to higher ranked
+    /// lifetimes bound by the witness itself.
+    ///
+    /// Looking at the following example, the witness for this generator
+    /// may end up as something like `for<'a> [Vec<i32>, &'a Vec<i32>]`:
+    ///
+    /// ```rust
+    /// |a| {
+    ///     let x = &vec![3];
+    ///     yield a;
+    ///     yield x[0];
+    /// }
+    /// ```
     GeneratorWitness(Binder<'tcx, &'tcx List<Ty<'tcx>>>),
 
     /// The never type `!`.
@@ -175,23 +204,42 @@ pub enum TyKind<'tcx> {
     Projection(ProjectionTy<'tcx>),
 
     /// Opaque (`impl Trait`) type found in a return type.
+    ///
     /// The `DefId` comes either from
     /// * the `impl Trait` ast::Ty node,
     /// * or the `type Foo = impl Trait` declaration
-    /// The substitutions are for the generics of the function in question.
-    /// After typeck, the concrete type can be found in the `types` map.
+    ///
+    /// For RTIT the substitutions are for the generics of the function,
+    /// while for TAIT it is used for the generic parameters of the alias.
     Opaque(DefId, SubstsRef<'tcx>),
 
     /// A type parameter; for example, `T` in `fn f<T>(x: T) {}`.
     Param(ParamTy),
 
-    /// Bound type variable, used only when preparing a trait query.
+    /// Bound type variable, used to represent the `'a` in `for<'a> fn(&'a ())`.
+    ///
+    /// For canonical queries, we replace inference variables with bound variables,
+    /// so e.g. when checking whether `&'_ (): Trait<_>` holds, we canonicalize that to
+    /// `for<'a, T> &'a (): Trait<T>` and then convert the introduced bound variables
+    /// back to inference variables in a new inference context when inside of the query.
+    ///
+    /// See the `rustc-dev-guide` for more details about
+    /// [higher-ranked trait bounds][1] and [canonical queries][2].
+    ///
+    /// [1]: https://rustc-dev-guide.rust-lang.org/traits/hrtb.html
+    /// [2]: https://rustc-dev-guide.rust-lang.org/traits/canonical-queries.html
     Bound(ty::DebruijnIndex, BoundTy),
 
-    /// A placeholder type - universally quantified higher-ranked type.
+    /// A placeholder type, used during higher ranked subtyping to instantiate
+    /// bound variables.
     Placeholder(ty::PlaceholderType),
 
     /// A type variable used during type checking.
+    ///
+    /// Similar to placeholders, inference variables also live in a universe to
+    /// correctly deal with higher ranked types. Though unlike placeholders,
+    /// that universe is stored in the `InferCtxt` instead of directly
+    /// inside of the type.
     Infer(InferTy),
 
     /// A placeholder for a type which could not be computed; this is

--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -209,7 +209,7 @@ pub enum TyKind<'tcx> {
     /// * the `impl Trait` ast::Ty node,
     /// * or the `type Foo = impl Trait` declaration
     ///
-    /// For RTIT the substitutions are for the generics of the function,
+    /// For RPIT the substitutions are for the generics of the function,
     /// while for TAIT it is used for the generic parameters of the alias.
     Opaque(DefId, SubstsRef<'tcx>),
 

--- a/compiler/rustc_query_impl/src/plumbing.rs
+++ b/compiler/rustc_query_impl/src/plumbing.rs
@@ -402,7 +402,7 @@ macro_rules! define_queries {
                 }
             }
 
-            $(pub fn $name()-> DepKindStruct {
+            $(pub(crate) fn $name()-> DepKindStruct {
                 let is_anon = is_anon!([$($modifiers)*]);
                 let is_eval_always = is_eval_always!([$($modifiers)*]);
 

--- a/compiler/rustc_query_impl/src/plumbing.rs
+++ b/compiler/rustc_query_impl/src/plumbing.rs
@@ -299,7 +299,7 @@ macro_rules! define_queries {
         }
 
         #[allow(nonstandard_style)]
-        pub mod queries {
+        mod queries {
             use std::marker::PhantomData;
 
             $(pub struct $name<$tcx> {
@@ -353,7 +353,7 @@ macro_rules! define_queries {
         })*
 
         #[allow(nonstandard_style)]
-        pub mod query_callbacks {
+        mod query_callbacks {
             use super::*;
             use rustc_middle::dep_graph::DepNode;
             use rustc_middle::ty::query::query_keys;

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -1173,6 +1173,8 @@ options! {
     dont_buffer_diagnostics: bool = (false, parse_bool, [UNTRACKED],
         "emit diagnostics rather than buffering (breaks NLL error downgrading, sorting) \
         (default: no)"),
+    drop_tracking: bool = (false, parse_bool, [TRACKED],
+        "enables drop tracking in generators (default: no)"),
     dual_proc_macros: bool = (false, parse_bool, [TRACKED],
         "load proc macros for both target and host, but only link to the target (default: no)"),
     dump_dep_graph: bool = (false, parse_bool, [UNTRACKED],

--- a/compiler/rustc_typeck/src/check/generator_interior.rs
+++ b/compiler/rustc_typeck/src/check/generator_interior.rs
@@ -208,7 +208,7 @@ pub fn resolve_interior<'a, 'tcx>(
     };
     intravisit::walk_body(&mut visitor, body);
 
-    // Check that we visited the same amount of expressions and the RegionResolutionVisitor
+    // Check that we visited the same amount of expressions as the RegionResolutionVisitor
     let region_expr_count = visitor.region_scope_tree.body_expr_count(body_id).unwrap();
     assert_eq!(region_expr_count, visitor.expr_count);
 

--- a/compiler/rustc_typeck/src/check/generator_interior.rs
+++ b/compiler/rustc_typeck/src/check/generator_interior.rs
@@ -22,11 +22,6 @@ use tracing::debug;
 
 mod drop_ranges;
 
-// FIXME(eholk): This flag is here to give a quick way to disable drop tracking in case we find
-// unexpected breakages while it's still new. It should be removed before too long. For example,
-// see #93161.
-const ENABLE_DROP_TRACKING: bool = false;
-
 struct InteriorVisitor<'a, 'tcx> {
     fcx: &'a FnCtxt<'a, 'tcx>,
     types: FxIndexSet<ty::GeneratorInteriorTypeCause<'tcx>>,
@@ -82,7 +77,7 @@ impl<'a, 'tcx> InteriorVisitor<'a, 'tcx> {
                                 yield_data.expr_and_pat_count, self.expr_count, source_span
                             );
 
-                            if ENABLE_DROP_TRACKING
+                            if self.fcx.sess().opts.debugging_opts.drop_tracking
                                 && self
                                     .drop_ranges
                                     .is_dropped_at(hir_id, yield_data.expr_and_pat_count)

--- a/compiler/rustc_typeck/src/check/generator_interior/drop_ranges.rs
+++ b/compiler/rustc_typeck/src/check/generator_interior/drop_ranges.rs
@@ -37,7 +37,7 @@ pub fn compute_drop_ranges<'a, 'tcx>(
     def_id: DefId,
     body: &'tcx Body<'tcx>,
 ) -> DropRanges {
-    if super::ENABLE_DROP_TRACKING {
+    if fcx.sess().opts.debugging_opts.drop_tracking {
         let consumed_borrowed_places = find_consumed_and_borrowed(fcx, def_id, body);
 
         let num_exprs = fcx.tcx.region_scope_tree(def_id).body_expr_count(body.id()).unwrap_or(0);

--- a/compiler/rustc_typeck/src/check/generator_interior/drop_ranges/record_consumed_borrow.rs
+++ b/compiler/rustc_typeck/src/check/generator_interior/drop_ranges/record_consumed_borrow.rs
@@ -96,9 +96,9 @@ impl<'tcx> expr_use_visitor::Delegate<'tcx> for ExprUseDelegate<'tcx> {
         _diag_expr_id: HirId,
         _bk: rustc_middle::ty::BorrowKind,
     ) {
-        place_with_id
-            .try_into()
-            .map_or(false, |tracked_value| self.places.borrowed.insert(tracked_value));
+        self.places
+            .borrowed
+            .insert(TrackedValue::from_place_with_projections_allowed(place_with_id));
     }
 
     fn mutate(

--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -2426,6 +2426,7 @@ macro_rules! int_impl {
         #[doc = concat!("assert_eq!(", stringify!($SelfT), "::MIN.abs_diff(", stringify!($SelfT), "::MAX), ", stringify!($UnsignedT), "::MAX);")]
         /// ```
         #[stable(feature = "int_abs_diff", since = "1.60.0")]
+        #[rustc_const_stable(feature = "int_abs_diff", since = "1.60.0")]
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]

--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -2419,14 +2419,13 @@ macro_rules! int_impl {
         /// Basic usage:
         ///
         /// ```
-        /// #![feature(int_abs_diff)]
         #[doc = concat!("assert_eq!(100", stringify!($SelfT), ".abs_diff(80), 20", stringify!($UnsignedT), ");")]
         #[doc = concat!("assert_eq!(100", stringify!($SelfT), ".abs_diff(110), 10", stringify!($UnsignedT), ");")]
         #[doc = concat!("assert_eq!((-100", stringify!($SelfT), ").abs_diff(80), 180", stringify!($UnsignedT), ");")]
         #[doc = concat!("assert_eq!((-100", stringify!($SelfT), ").abs_diff(-120), 20", stringify!($UnsignedT), ");")]
         #[doc = concat!("assert_eq!(", stringify!($SelfT), "::MIN.abs_diff(", stringify!($SelfT), "::MAX), ", stringify!($UnsignedT), "::MAX);")]
         /// ```
-        #[unstable(feature = "int_abs_diff", issue = "89492")]
+        #[stable(feature = "int_abs_diff", since = "1.60.0")]
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -1634,11 +1634,10 @@ macro_rules! uint_impl {
         /// Basic usage:
         ///
         /// ```
-        /// #![feature(int_abs_diff)]
         #[doc = concat!("assert_eq!(100", stringify!($SelfT), ".abs_diff(80), 20", stringify!($SelfT), ");")]
         #[doc = concat!("assert_eq!(100", stringify!($SelfT), ".abs_diff(110), 10", stringify!($SelfT), ");")]
         /// ```
-        #[unstable(feature = "int_abs_diff", issue = "89492")]
+        #[stable(feature = "int_abs_diff", since = "1.60.0")]
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -1638,6 +1638,7 @@ macro_rules! uint_impl {
         #[doc = concat!("assert_eq!(100", stringify!($SelfT), ".abs_diff(110), 10", stringify!($SelfT), ");")]
         /// ```
         #[stable(feature = "int_abs_diff", since = "1.60.0")]
+        #[rustc_const_stable(feature = "int_abs_diff", since = "1.60.0")]
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]

--- a/library/std/src/process.rs
+++ b/library/std/src/process.rs
@@ -1691,6 +1691,14 @@ impl ExitCode {
     }
 }
 
+#[unstable(feature = "process_exitcode_placeholder", issue = "48711")]
+impl From<u8> for ExitCode {
+    /// Construct an exit code from an arbitrary u8 value.
+    fn from(code: u8) -> Self {
+        ExitCode(imp::ExitCode::from(code))
+    }
+}
+
 impl Child {
     /// Forces the child process to exit. If the child has already exited, an [`InvalidInput`]
     /// error is returned.

--- a/library/std/src/sys/unix/process/process_common.rs
+++ b/library/std/src/sys/unix/process/process_common.rs
@@ -476,6 +476,12 @@ impl ExitCode {
     }
 }
 
+impl From<u8> for ExitCode {
+    fn from(code: u8) -> Self {
+        Self(code)
+    }
+}
+
 pub struct CommandArgs<'a> {
     iter: crate::slice::Iter<'a, CString>,
 }

--- a/library/std/src/sys/unsupported/process.rs
+++ b/library/std/src/sys/unsupported/process.rs
@@ -166,7 +166,7 @@ impl From<u8> for ExitCode {
     fn from(code: u8) -> Self {
         match code {
             0 => Self::SUCCESS,
-            1..255 => Self::FAILURE,
+            1..=255 => Self::FAILURE,
         }
     }
 }

--- a/library/std/src/sys/unsupported/process.rs
+++ b/library/std/src/sys/unsupported/process.rs
@@ -162,6 +162,15 @@ impl ExitCode {
     }
 }
 
+impl From<u8> for ExitCode {
+    fn from(code: u8) -> Self {
+        match code {
+            0 => Self::SUCCESS,
+            1..255 => Self::FAILURE,
+        }
+    }
+}
+
 pub struct Process(!);
 
 impl Process {

--- a/library/std/src/sys/windows/process.rs
+++ b/library/std/src/sys/windows/process.rs
@@ -666,6 +666,12 @@ impl ExitCode {
     }
 }
 
+impl From<u8> for ExitCode {
+    fn from(code: u8) -> Self {
+        ExitCode(c::DWORD::from(code))
+    }
+}
+
 fn zeroed_startupinfo() -> c::STARTUPINFO {
     c::STARTUPINFO {
         cb: 0,

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1014,7 +1014,8 @@ impl Clean<Item> for hir::ImplItem<'_> {
                     {
                         m.header.constness = hir::Constness::NotConst;
                     }
-                    MethodItem(m, Some(self.defaultness))
+                    let defaultness = cx.tcx.associated_item(self.def_id).defaultness;
+                    MethodItem(m, Some(defaultness))
                 }
                 hir::ImplItemKind::TyAlias(ref hir_ty) => {
                     let type_ = hir_ty.clean(cx);

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -108,7 +108,9 @@ html {
 /* General structure and fonts */
 
 body {
-	font: 1rem/1.4 "Source Serif 4", NanumBarunGothic, serif;
+	/* Line spacing at least 1.5 per Web Content Accessibility Guidelines
+	   https://www.w3.org/WAI/WCAG21/Understanding/visual-presentation.html */
+	font: 1rem/1.5 "Source Serif 4", NanumBarunGothic, serif;
 	margin: 0;
 	position: relative;
 	/* We use overflow-wrap: break-word for Safari, which doesn't recognize
@@ -124,13 +126,13 @@ body {
 }
 
 h1 {
-	font-size: 1.5rem;
+	font-size: 1.5rem; /* 24px */
 }
 h2 {
-	font-size: 1.4rem;
+	font-size: 1.375rem; /* 22px */
 }
 h3 {
-	font-size: 1.3rem;
+	font-size: 1.25rem; /* 20px */
 }
 h1, h2, h3, h4, h5, h6 {
 	font-weight: 500;
@@ -170,7 +172,7 @@ h2,
 	border-bottom: 1px solid;
 }
 h3.code-header {
-	font-size: 1.1rem;
+	font-size: 1.125rem; /* 18px */
 }
 h4.code-header {
 	font-size: 1rem;
@@ -221,19 +223,18 @@ a.srclink,
 	font-family: "Fira Sans", Arial, NanumBarunGothic, sans-serif;
 }
 
-.content ul.crate a.crate {
-	font-size: 1rem/1.6;
-}
-
 ol, ul {
-	padding-left: 25px;
+	padding-left: 24px;
 }
 ul ul, ol ul, ul ol, ol ol {
-	margin-bottom: .6em;
+	margin-bottom: .625em;
 }
 
 p {
-	margin: 0 0 .6em 0;
+	/* Paragraph spacing at least 1.5 times line spacing per Web Content Accessibility Guidelines.
+	   Line-height is 1.5rem, so line spacing is .5rem; .75em is 1.5 times that.
+	   https://www.w3.org/WAI/WCAG21/Understanding/visual-presentation.html */
+	margin: 0 0 .75em 0;
 }
 
 summary {
@@ -303,7 +304,7 @@ code, pre, a.test-arrow, .code-header {
 }
 .docblock code, .docblock-short code {
 	border-radius: 3px;
-	padding: 0 0.1em;
+	padding: 0 0.125em;
 }
 .docblock pre code, .docblock-short pre code {
 	padding: 0;
@@ -364,7 +365,7 @@ nav.sub {
 }
 
 .sidebar {
-	font-size: 0.9rem;
+	font-size: 0.875rem;
 	width: 250px;
 	min-width: 200px;
 	overflow-y: scroll;
@@ -476,8 +477,8 @@ nav.sub {
 .block a,
 h2.location a {
 	display: block;
-	padding: 0.3rem;
-	margin-left: -0.3rem;
+	padding: 0.25rem;
+	margin-left: -0.25rem;
 
 	text-overflow: ellipsis;
 	overflow: hidden;
@@ -497,7 +498,7 @@ h2.location a {
 }
 
 .sidebar h3 {
-	font-size: 1.1rem;
+	font-size: 1.125rem; /* 18px */
 	font-weight: 500;
 	padding: 0;
 	margin: 0;
@@ -598,18 +599,18 @@ h2.location a {
 	white-space: pre-wrap;
 }
 
-.top-doc .docblock h2 { font-size: 1.3rem; }
-.top-doc .docblock h3 { font-size: 1.15rem; }
+.top-doc .docblock h2 { font-size: 1.375rem; }
+.top-doc .docblock h3 { font-size: 1.25; }
 .top-doc .docblock h4,
 .top-doc .docblock h5 {
-	font-size: 1.1rem;
+	font-size: 1.125rem;
 }
 .top-doc .docblock h6 {
 	font-size: 1rem;
 }
 
 .docblock h5 { font-size: 1rem; }
-.docblock h6 { font-size: 0.95rem; }
+.docblock h6 { font-size: 0.875rem; }
 
 .docblock {
 	margin-left: 24px;
@@ -623,12 +624,12 @@ h2.location a {
 
 .content .out-of-band {
 	flex-grow: 0;
-	font-size: 1.15rem;
+	font-size: 1.125rem;
 	font-weight: normal;
 	float: right;
 }
 
-.method > .code-header, .trait-impl > .code-header, .invisible > .code-header {
+.method > .code-header, .trait-impl > .code-header {
 	max-width: calc(100% - 41px);
 	display: block;
 }
@@ -664,7 +665,7 @@ h2.location a {
 .content td { vertical-align: top; }
 .content td:first-child { padding-right: 20px; }
 .content td p:first-child { margin-top: 0; }
-.content td h1, .content td h2 { margin-left: 0; font-size: 1.1rem; }
+.content td h1, .content td h2 { margin-left: 0; font-size: 1.125rem; }
 .content tr:first-child td { border-top: 0; }
 
 .docblock table {
@@ -713,7 +714,7 @@ h2.location a {
 .content .fn .where,
 .content .where.fmt-newline {
 	display: block;
-	font-size: 0.8rem;
+	font-size: 0.875rem;
 }
 
 .content .methods > div:not(.notable-traits):not(.method) {
@@ -736,7 +737,7 @@ h2.location a {
 }
 
 .content .item-info code {
-	font-size: 0.81rem;
+	font-size: 0.875rem;
 }
 
 .content .item-info {
@@ -839,15 +840,6 @@ h2.small-section-header > .anchor {
 	text-decoration: underline;
 }
 
-.invisible > .srclink,
-.method > .code-header + .srclink {
-	position: absolute;
-	top: 0;
-	right: 0;
-	font-size: 1.0625rem;
-	font-weight: normal;
-}
-
 .block a.current.crate { font-weight: 500; }
 
 /*  In most contexts we use `overflow-wrap: anywhere` to ensure that we can wrap
@@ -885,7 +877,7 @@ table,
 	display: table-cell;
 }
 .item-left {
-	padding-right: 1.2rem;
+	padding-right: 1.25rem;
 }
 
 .search-container {
@@ -907,8 +899,8 @@ table,
 #crate-search {
 	min-width: 115px;
 	margin-top: 5px;
-	margin-left: 0.2em;
-	padding-left: 0.3em;
+	margin-left: 0.25em;
+	padding-left: 0.3125em;
 	padding-right: 23px;
 	border: 0;
 	border-radius: 4px;
@@ -942,7 +934,7 @@ table,
 	border: 1px solid;
 	border-radius: 2px;
 	padding: 5px 8px;
-	font-size: 1.0625rem;
+	font-size: 1rem;
 	transition: border-color 300ms ease;
 	width: 100%;
 }
@@ -1054,7 +1046,7 @@ body.blur > :not(#help) {
 .stab {
 	padding: 3px;
 	margin-bottom: 5px;
-	font-size: 0.9rem;
+	font-size: 0.875rem;
 	font-weight: normal;
 }
 .stab p {
@@ -1062,7 +1054,7 @@ body.blur > :not(#help) {
 }
 
 .stab .emoji {
-	font-size: 1.2rem;
+	font-size: 1.25rem;
 }
 
 /* Black one-pixel outline around emoji shapes */
@@ -1078,10 +1070,10 @@ body.blur > :not(#help) {
 .import-item .stab {
 	border-radius: 3px;
 	display: inline-block;
-	font-size: 0.8rem;
+	font-size: 0.875rem;
 	line-height: 1.2;
 	margin-bottom: 0;
-	margin-left: .3em;
+	margin-left: 0.3125em;
 	padding: 2px;
 	vertical-align: text-bottom;
 }
@@ -1106,9 +1098,6 @@ body.blur > :not(#help) {
 	/* Override header settings otherwise it's too bold */
 	font-weight: normal;
 	font-size: 1rem;
-}
-.impl .srclink {
-	font-size: 1.0625rem;
 }
 
 .rightside {
@@ -1141,7 +1130,7 @@ a.test-arrow {
 	position: absolute;
 	padding: 5px 10px 5px 10px;
 	border-radius: 5px;
-	font-size: 1.3rem;
+	font-size: 1.375rem;
 	top: 5px;
 	right: 5px;
 	z-index: 1;
@@ -1179,7 +1168,7 @@ a.test-arrow:hover{
 
 h3.variant {
 	font-weight: 600;
-	font-size: 1.1rem;
+	font-size: 1.125rem;
 	margin-bottom: 10px;
 	border-bottom: none;
 }
@@ -1391,7 +1380,7 @@ pre.rust {
 	left: 0;
 	cursor: pointer;
 	font-weight: bold;
-	font-size: 1.2rem;
+	font-size: 1.25rem;
 	border-bottom: 1px solid;
 	display: flex;
 	height: 40px;
@@ -1516,11 +1505,8 @@ kbd {
 }
 .table-display .out-of-band {
 	position: relative;
-	font-size: 1.1875rem;
+	font-size: 1.125rem;
 	display: block;
-}
-#implementors-list > .impl-items .table-display .out-of-band {
-	font-size: 1.0625rem;
 }
 
 .table-display td:hover .anchor {
@@ -1562,7 +1548,7 @@ div.name.expand + .children {
 div.name::before {
 	content: "\25B6";
 	padding-left: 4px;
-	font-size: 0.7rem;
+	font-size: 0.625rem;
 	position: absolute;
 	left: -16px;
 	top: 4px;
@@ -1595,8 +1581,8 @@ details.rustdoc-toggle > summary.hideme > span {
 details.rustdoc-toggle > summary::before {
 	content: "";
 	cursor: pointer;
-	width: 17px;
-	height: max(17px, 1.1em);
+	width: 16px;
+	height: 16px;
 	background-repeat: no-repeat;
 	background-position: top left;
 	display: inline-block;
@@ -1643,7 +1629,7 @@ details.rustdoc-toggle > summary.hideme::before {
 details.rustdoc-toggle > summary:not(.hideme)::before {
 	position: absolute;
 	left: -24px;
-	top: 3px;
+	top: 4px;
 }
 
 .impl-items > details.rustdoc-toggle > summary:not(.hideme)::before {
@@ -1680,8 +1666,8 @@ details.undocumented > summary::before, details.rustdoc-toggle > summary::before
 
 details.rustdoc-toggle[open] > summary::before,
 details.rustdoc-toggle[open] > summary.hideme::before {
-	width: 17px;
-	height: max(17px, 1.1em);
+	width: 16px;
+	height: 16px;
 	background-repeat: no-repeat;
 	background-position: top left;
 	display: inline-block;
@@ -1808,8 +1794,14 @@ details.rustdoc-toggle[open] > summary.hideme::after {
 		width: 0;
 	}
 
+	.mobile-topbar .location a {
+		padding: 0;
+		margin: 0;
+	}
+
 	.mobile-topbar .location {
 		border: none;
+		padding: 0;
 		margin: auto 0.5em auto auto;
 		text-overflow: ellipsis;
 		overflow: hidden;
@@ -1818,7 +1810,7 @@ details.rustdoc-toggle[open] > summary.hideme::after {
 		   height is specified in pixels, this also has to be specified in
 		   pixels to avoid overflowing the topbar when the user sets a bigger
 		   font size. */
-		font-size: 22.4px;
+		font-size: 24px;
 	}
 
 	.mobile-topbar .logo-container {

--- a/src/test/incremental/hashes/trait_impls.rs
+++ b/src/test/incremental/hashes/trait_impls.rs
@@ -358,9 +358,11 @@ pub trait AddDefaultTrait {
 
 #[cfg(any(cfail1,cfail4))]
 impl AddDefaultTrait for Foo {
-    // -------------------------------------------------------------------------------------------
+    // ----------------------------------------------------
     // -------------------------
-            fn method_name() { }
+    // ----------------------------------------------------
+    // -------------------------
+    fn         method_name() { }
 }
 
 #[cfg(not(any(cfail1,cfail4)))]
@@ -369,9 +371,9 @@ impl AddDefaultTrait for Foo {
 #[rustc_clean(except="hir_owner,hir_owner_nodes", cfg="cfail5")]
 #[rustc_clean(cfg="cfail6")]
 impl AddDefaultTrait for Foo {
-    #[rustc_clean(except="hir_owner,hir_owner_nodes,associated_item", cfg="cfail2")]
+    #[rustc_clean(except="associated_item", cfg="cfail2")]
     #[rustc_clean(cfg="cfail3")]
-    #[rustc_clean(except="hir_owner,hir_owner_nodes,associated_item,optimized_mir", cfg="cfail5")]
+    #[rustc_clean(except="associated_item", cfg="cfail5")]
     #[rustc_clean(cfg="cfail6")]
     default fn method_name() { }
 }

--- a/src/test/rustdoc-gui/docblock-big-code-mobile.goml
+++ b/src/test/rustdoc-gui/docblock-big-code-mobile.goml
@@ -6,4 +6,4 @@ goto: file://|DOC_PATH|/test_docs/long_code_block/index.html
 show-text: true // We need to enable text draw to be able to have the "real" size
 // Little explanations for this test: if the text wasn't displayed on two lines, it would take
 // around 20px (which is the font size).
-assert-property: (".docblock p > code", {"offsetHeight": "42"})
+assert-property: (".docblock p > code", {"offsetHeight": "44"})

--- a/src/test/rustdoc-gui/headings.goml
+++ b/src/test/rustdoc-gui/headings.goml
@@ -6,34 +6,33 @@
 // Most of these sizes are set in CSS in `em` units, so here's a conversion chart based on our
 // default 16px font size:
 // 24px    1.5em
-// 22.4px  1.4em
-// 20.8px  1.3em
-// 18.4px  1.15em
-// 17.6px  1.1em
-// 16px    1em
-// 15.2px  0.95em  
+// 22px  1.375rem
+// 20px  1.25rem
+// 18px  1.125em
+// 16px  1rem
+// 14px  0.875rem
 goto: file://|DOC_PATH|/test_docs/struct.HeavilyDocumentedStruct.html
 
 assert-css: ("h1.fqn", {"font-size": "24px"})
 
-assert-css: ("h2#top-doc-prose-title", {"font-size": "20.8px"})
+assert-css: ("h2#top-doc-prose-title", {"font-size": "22px"})
 assert-css: ("h2#top-doc-prose-title", {"border-bottom-width": "1px"})
-assert-css: ("h3#top-doc-prose-sub-heading", {"font-size": "18.4px"})
+assert-css: ("h3#top-doc-prose-sub-heading", {"font-size": "20px"})
 assert-css: ("h3#top-doc-prose-sub-heading", {"border-bottom-width": "1px"})
-assert-css: ("h4#top-doc-prose-sub-sub-heading", {"font-size": "17.6px"})
+assert-css: ("h4#top-doc-prose-sub-sub-heading", {"font-size": "18px"})
 assert-css: ("h4#top-doc-prose-sub-sub-heading", {"border-bottom-width": "1px"})
 
-assert-css: ("h2#fields", {"font-size": "22.4px"})
+assert-css: ("h2#fields", {"font-size": "22px"})
 assert-css: ("h2#fields", {"border-bottom-width": "1px"})
-assert-css: ("h3#title-for-field", {"font-size": "20.8px"})
+assert-css: ("h3#title-for-field", {"font-size": "20px"})
 assert-css: ("h3#title-for-field", {"border-bottom-width": "0px"})
 assert-css: ("h4#sub-heading-for-field", {"font-size": "16px"})
 assert-css: ("h4#sub-heading-for-field", {"border-bottom-width": "0px"})
 
-assert-css: ("h2#implementations", {"font-size": "22.4px"})
+assert-css: ("h2#implementations", {"font-size": "22px"})
 assert-css: ("h2#implementations", {"border-bottom-width": "1px"})
 
-assert-css: ("#impl > h3.code-header", {"font-size": "17.6px"})
+assert-css: ("#impl > h3.code-header", {"font-size": "18px"})
 assert-css: ("#impl > h3.code-header", {"border-bottom-width": "0px"})
 assert-css: ("#method\.do_nothing > h4.code-header", {"font-size": "16px"})
 assert-css: ("#method\.do_nothing > h4.code-header", {"border-bottom-width": "0px"})
@@ -42,27 +41,27 @@ assert-css: ("h4#title-for-struct-impl-doc", {"font-size": "16px"})
 assert-css: ("h4#title-for-struct-impl-doc", {"border-bottom-width": "0px"})
 assert-css: ("h5#sub-heading-for-struct-impl-doc", {"font-size": "16px"})
 assert-css: ("h5#sub-heading-for-struct-impl-doc", {"border-bottom-width": "0px"})
-assert-css: ("h6#sub-sub-heading-for-struct-impl-doc", {"font-size": "15.2px"})
+assert-css: ("h6#sub-sub-heading-for-struct-impl-doc", {"font-size": "14px"})
 assert-css: ("h6#sub-sub-heading-for-struct-impl-doc", {"border-bottom-width": "0px"})
 
 assert-css: ("h5#title-for-struct-impl-item-doc", {"font-size": "16px"})
 assert-css: ("h5#title-for-struct-impl-item-doc", {"border-bottom-width": "0px"})
-assert-css: ("h6#sub-heading-for-struct-impl-item-doc", {"font-size": "15.2px"})
+assert-css: ("h6#sub-heading-for-struct-impl-item-doc", {"font-size": "14px"})
 assert-css: ("h6#sub-heading-for-struct-impl-item-doc", {"border-bottom-width": "0px"})
-assert-css: ("h6#sub-sub-heading-for-struct-impl-item-doc", {"font-size": "15.2px"})
+assert-css: ("h6#sub-sub-heading-for-struct-impl-item-doc", {"font-size": "14px"})
 
 goto: file://|DOC_PATH|/test_docs/enum.HeavilyDocumentedEnum.html
 
 assert-css: ("h1.fqn", {"font-size": "24px"})
 
-assert-css: ("h2#top-doc-prose-title", {"font-size": "20.8px"})
+assert-css: ("h2#top-doc-prose-title", {"font-size": "22px"})
 assert-css: ("h2#top-doc-prose-title", {"border-bottom-width": "1px"})
-assert-css: ("h3#top-doc-prose-sub-heading", {"font-size": "18.4px"})
+assert-css: ("h3#top-doc-prose-sub-heading", {"font-size": "20px"})
 assert-css: ("h3#top-doc-prose-sub-heading", {"border-bottom-width": "1px"})
-assert-css: ("h4#top-doc-prose-sub-sub-heading", {"font-size": "17.6px"})
+assert-css: ("h4#top-doc-prose-sub-sub-heading", {"font-size": "18px"})
 assert-css: ("h4#top-doc-prose-sub-sub-heading", {"border-bottom-width": "1px"})
 
-assert-css: ("h2#variants", {"font-size": "22.4px"})
+assert-css: ("h2#variants", {"font-size": "22px"})
 assert-css: ("h2#variants", {"border-bottom-width": "1px"})
 
 assert-css: ("h4#none-prose-title", {"font-size": "16px"})
@@ -77,18 +76,18 @@ assert-css: ("h5#wrapped-prose-sub-heading", {"border-bottom-width": "0px"})
 
 assert-css: ("h5#wrapped0-prose-title", {"font-size": "16px"})
 assert-css: ("h5#wrapped0-prose-title", {"border-bottom-width": "0px"})
-assert-css: ("h6#wrapped0-prose-sub-heading", {"font-size": "15.2px"})
+assert-css: ("h6#wrapped0-prose-sub-heading", {"font-size": "14px"})
 assert-css: ("h6#wrapped0-prose-sub-heading", {"border-bottom-width": "0px"})
 
 assert-css: ("h5#structy-prose-title", {"font-size": "16px"})
 assert-css: ("h5#structy-prose-title", {"border-bottom-width": "0px"})
-assert-css: ("h6#structy-prose-sub-heading", {"font-size": "15.2px"})
+assert-css: ("h6#structy-prose-sub-heading", {"font-size": "14px"})
 assert-css: ("h6#structy-prose-sub-heading", {"border-bottom-width": "0px"})
 
-assert-css: ("h2#implementations", {"font-size": "22.4px"})
+assert-css: ("h2#implementations", {"font-size": "22px"})
 assert-css: ("h2#implementations", {"border-bottom-width": "1px"})
 
-assert-css: ("#impl > h3.code-header", {"font-size": "17.6px"})
+assert-css: ("#impl > h3.code-header", {"font-size": "18px"})
 assert-css: ("#impl > h3.code-header", {"border-bottom-width": "0px"})
 assert-css: ("#method\.do_nothing > h4.code-header", {"font-size": "16px"})
 assert-css: ("#method\.do_nothing > h4.code-header", {"border-bottom-width": "0px"})
@@ -97,14 +96,14 @@ assert-css: ("h4#title-for-enum-impl-doc", {"font-size": "16px"})
 assert-css: ("h4#title-for-enum-impl-doc", {"border-bottom-width": "0px"})
 assert-css: ("h5#sub-heading-for-enum-impl-doc", {"font-size": "16px"})
 assert-css: ("h5#sub-heading-for-enum-impl-doc", {"border-bottom-width": "0px"})
-assert-css: ("h6#sub-sub-heading-for-enum-impl-doc", {"font-size": "15.2px"})
+assert-css: ("h6#sub-sub-heading-for-enum-impl-doc", {"font-size": "14px"})
 assert-css: ("h6#sub-sub-heading-for-enum-impl-doc", {"border-bottom-width": "0px"})
 
 assert-css: ("h5#title-for-enum-impl-item-doc", {"font-size": "16px"})
 assert-css: ("h5#title-for-enum-impl-item-doc", {"border-bottom-width": "0px"})
-assert-css: ("h6#sub-heading-for-enum-impl-item-doc", {"font-size": "15.2px"})
+assert-css: ("h6#sub-heading-for-enum-impl-item-doc", {"font-size": "14px"})
 assert-css: ("h6#sub-heading-for-enum-impl-item-doc", {"border-bottom-width": "0px"})
-assert-css: ("h6#sub-sub-heading-for-enum-impl-item-doc", {"font-size": "15.2px"})
+assert-css: ("h6#sub-sub-heading-for-enum-impl-item-doc", {"font-size": "14px"})
 assert-css: ("h6#sub-sub-heading-for-enum-impl-item-doc", {"border-bottom-width": "0px"})
 
 assert-text: (".sidebar .others h3", "Modules")
@@ -114,23 +113,23 @@ goto: file://|DOC_PATH|/test_docs/union.HeavilyDocumentedUnion.html
 
 assert-css: ("h1.fqn", {"font-size": "24px"})
 
-assert-css: ("h2#top-doc-prose-title", {"font-size": "20.8px"})
+assert-css: ("h2#top-doc-prose-title", {"font-size": "22px"})
 assert-css: ("h2#top-doc-prose-title", {"border-bottom-width": "1px"})
-assert-css: ("h3#top-doc-prose-sub-heading", {"font-size": "18.4px"})
+assert-css: ("h3#top-doc-prose-sub-heading", {"font-size": "20px"})
 assert-css: ("h3#top-doc-prose-sub-heading", {"border-bottom-width": "1px"})
 
-assert-css: ("h2#fields", {"font-size": "22.4px"})
+assert-css: ("h2#fields", {"font-size": "22px"})
 assert-css: ("h2#fields", {"border-bottom-width": "1px"})
 
-assert-css: ("h3#title-for-union-variant", {"font-size": "20.8px"})
+assert-css: ("h3#title-for-union-variant", {"font-size": "20px"})
 assert-css: ("h3#title-for-union-variant", {"border-bottom-width": "0px"})
 assert-css: ("h4#sub-heading-for-union-variant", {"font-size": "16px"})
 assert-css: ("h4#sub-heading-for-union-variant", {"border-bottom-width": "0px"})
 
-assert-css: ("h2#implementations", {"font-size": "22.4px"})
+assert-css: ("h2#implementations", {"font-size": "22px"})
 assert-css: ("h2#implementations", {"border-bottom-width": "1px"})
 
-assert-css: ("#impl > h3.code-header", {"font-size": "17.6px"})
+assert-css: ("#impl > h3.code-header", {"font-size": "18px"})
 assert-css: ("#impl > h3.code-header", {"border-bottom-width": "0px"})
 assert-css: ("h4#title-for-union-impl-doc", {"font-size": "16px"})
 assert-css: ("h4#title-for-union-impl-doc", {"border-bottom-width": "0px"})
@@ -139,16 +138,16 @@ assert-css: ("h5#sub-heading-for-union-impl-doc", {"border-bottom-width": "0px"}
 
 assert-css: ("h5#title-for-union-impl-item-doc", {"font-size": "16px"})
 assert-css: ("h5#title-for-union-impl-item-doc", {"border-bottom-width": "0px"})
-assert-css: ("h6#sub-heading-for-union-impl-item-doc", {"font-size": "15.2px"})
+assert-css: ("h6#sub-heading-for-union-impl-item-doc", {"font-size": "14px"})
 assert-css: ("h6#sub-heading-for-union-impl-item-doc", {"border-bottom-width": "0px"})
 
 goto: file://|DOC_PATH|/test_docs/macro.heavily_documented_macro.html
 
 assert-css: ("h1.fqn", {"font-size": "24px"})
 
-assert-css: ("h2#top-doc-prose-title", {"font-size": "20.8px"})
+assert-css: ("h2#top-doc-prose-title", {"font-size": "22px"})
 assert-css: ("h2#top-doc-prose-title", {"border-bottom-width": "1px"})
-assert-css: ("h3#top-doc-prose-sub-heading", {"font-size": "18.4px"})
+assert-css: ("h3#top-doc-prose-sub-heading", {"font-size": "20px"})
 assert-css: ("h3#top-doc-prose-sub-heading", {"border-bottom-width": "1px"})
 
 goto: file://|DOC_PATH|/staged_api/struct.Foo.html

--- a/src/test/rustdoc-gui/item-info-width.goml
+++ b/src/test/rustdoc-gui/item-info-width.goml
@@ -4,5 +4,5 @@ goto: file://|DOC_PATH|/lib2/struct.Foo.html
 size: (1100, 800)
 // We check that ".item-info" is bigger than its content.
 assert-css: (".item-info", {"width": "790px"})
-assert-css: (".item-info .stab", {"width": "341px"})
+assert-css: (".item-info .stab", {"width": "340px"})
 assert-position: (".item-info .stab", {"x": 295})

--- a/src/test/rustdoc-gui/mobile.goml
+++ b/src/test/rustdoc-gui/mobile.goml
@@ -11,7 +11,7 @@ assert-css: (".main-heading", {
   "flex-direction": "column"
 })
 
-assert-property: (".mobile-topbar h2.location", {"offsetHeight": 48})
+assert-property: (".mobile-topbar h2.location", {"offsetHeight": 36})
 
 // Note: We can't use assert-text here because the 'Since' is set by CSS and
 // is therefore not part of the DOM.

--- a/src/test/rustdoc-gui/sidebar-source-code.goml
+++ b/src/test/rustdoc-gui/sidebar-source-code.goml
@@ -10,7 +10,7 @@ click: (10, 10)
 // We wait for the sidebar to be expanded (there is a 0.5s animation).
 wait-for: 600
 assert-css: ("nav.sidebar.expanded", {"width": "300px"})
-assert-css: ("nav.sidebar.expanded a", {"font-size": "14.4px"})
+assert-css: ("nav.sidebar.expanded a", {"font-size": "14px"})
 // We collapse the sidebar.
 click: (10, 10)
 // We wait for the sidebar to be collapsed (there is a 0.5s animation).

--- a/src/test/rustdoc-gui/sidebar.goml
+++ b/src/test/rustdoc-gui/sidebar.goml
@@ -77,7 +77,7 @@ assert-text: ("#functions + .item-table .item-left > a", "foo")
 
 // Links to trait implementations in the sidebar should not wrap even if they are long.
 goto: file://|DOC_PATH|/lib2/struct.HasALongTraitWithParams.html
-assert-property: (".sidebar-links a", {"offsetHeight": 30})
+assert-property: (".sidebar-links a", {"offsetHeight": 29})
 
 // Test that clicking on of the "In <module>" headings in the sidebar links to the
 // appropriate anchor in index.html.

--- a/src/test/rustdoc-gui/src-font-size.goml
+++ b/src/test/rustdoc-gui/src-font-size.goml
@@ -4,9 +4,8 @@
 goto: file://|DOC_PATH|/test_docs/struct.Foo.html
 show-text: true
 // Check the impl headers.
-assert-css: (".impl.has-srclink .srclink", {"font-size": "17px"}, ALL)
-// The ".6" part is because the font-size is actually "1.1em".
-assert-css: (".impl.has-srclink .code-header.in-band", {"font-size": "17.6px"}, ALL)
+assert-css: (".impl.has-srclink .srclink", {"font-size": "16px"}, ALL)
+assert-css: (".impl.has-srclink .code-header.in-band", {"font-size": "18px"}, ALL)
 // Check the impl items.
 assert-css: (".impl-items .has-srclink .srclink", {"font-size": "16px"}, ALL)
 assert-css: (".impl-items .has-srclink .code-header", {"font-size": "16px"}, ALL)

--- a/src/test/rustdoc-gui/type-declation-overflow.goml
+++ b/src/test/rustdoc-gui/type-declation-overflow.goml
@@ -32,6 +32,6 @@ assert-property: (".item-decl pre", {"scrollWidth": "950"})
 size: (600, 600)
 goto: file://|DOC_PATH|/lib2/too_long/struct.SuperIncrediblyLongLongLongLongLongLongLongGigaGigaGigaMegaLongLongLongStructName.html
 // It shouldn't have an overflow in the topbar either.
-assert-property: (".mobile-topbar .location", {"scrollWidth": "493"})
-assert-property: (".mobile-topbar .location", {"clientWidth": "493"})
+assert-property: (".mobile-topbar .location", {"scrollWidth": "492"})
+assert-property: (".mobile-topbar .location", {"clientWidth": "492"})
 assert-css: (".mobile-topbar .location", {"overflow-x": "hidden"})

--- a/src/test/ui/async-await/issue-93648.rs
+++ b/src/test/ui/async-await/issue-93648.rs
@@ -1,0 +1,12 @@
+// edition:2021
+// build-pass
+// compile-flags: -Zdrop-tracking
+
+fn main() {
+    let _ = async {
+        let mut s = (String::new(),);
+        s.0.push_str("abc");
+        std::mem::drop(s);
+        async {}.await;
+    };
+}

--- a/src/tools/clippy/clippy_lints/src/utils/inspector.rs
+++ b/src/tools/clippy/clippy_lints/src/utils/inspector.rs
@@ -54,9 +54,6 @@ impl<'tcx> LateLintPass<'tcx> for DeepCodeInspector {
             ),
             hir::VisibilityKind::Inherited => println!("visibility inherited from outer item"),
         }
-        if item.defaultness.is_default() {
-            println!("default");
-        }
         match item.kind {
             hir::ImplItemKind::Const(_, body_id) => {
                 println!("associated constant");


### PR DESCRIPTION
Successful merges:

 - #93445 (Add From<u8> for ExitCode)
 - #93694 (rustdoc: tweak line spacing and paragraph spacing for accessibility)
 - #93735 (Stabilize int_abs_diff in 1.60.0.)
 - #93746 (Remove defaultness from ImplItem.)
 - #93748 (rustc_query_impl: reduce visibility of some modules/fn's)
 - #93751 (Drop tracking: track borrows of projections)
 - #93781 (update `ty::TyKind` documentation)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=93445,93694,93735,93746,93748,93751,93781)
<!-- homu-ignore:end -->