### PR TITLE
Fix typo in `std::fmt` docs

### DIFF
--- a/library/alloc/src/fmt.rs
+++ b/library/alloc/src/fmt.rs
@@ -74,7 +74,7 @@
 //! identifier '=' expression
 //! ```
 //!
-//! For example, the following [`format!`] expressions all use named argument:
+//! For example, the following [`format!`] expressions all use named arguments:
 //!
 //! ```
 //! format!("{argument}", argument = "test");   // => "test"


### PR DESCRIPTION
Hey!

Reading the docs (https://doc.rust-lang.org/std/fmt/#named-parameters), this seems like a typo?

The docs here also seem to mix “named argument” and “named parameter”? Intentional? Mistake?