### PR TITLE
rustdoc: Stop textually replacing `Self` in doc links before resolving them

### DIFF
--- a/src/test/rustdoc/intra-doc/associated-items.rs
+++ b/src/test/rustdoc/intra-doc/associated-items.rs
@@ -57,4 +57,12 @@ impl T2 for S {
     fn ambiguous_method() {}
 }
 
+// @has associated_items/enum.MyEnum.html '//a/@href' 'enum.MyEnum.html#variant.MyVariant'
+/// Link to [MyEnumAlias::MyVariant]
+pub enum MyEnum {
+    MyVariant,
+}
+
+pub type MyEnumAlias = MyEnum;
+
 fn main() {}


### PR DESCRIPTION
Resolve it directly to a type / def-id instead.

Also never pass `Self` to `Resolver`, it is useless because it's guaranteed that no resolution will be found.

This is a pre-requisite for https://github.com/rust-lang/rust/issues/83761.