### PR TITLE
Remove first headings indent

### DIFF
--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -565,7 +565,7 @@ impl<'a, 'b, 'ids, I: Iterator<Item = SpannedEvent<'a>>> Iterator
             self.buf.push_back((Event::Html(format!("</a></h{}>", level).into()), 0..0));
 
             let start_tags = format!(
-                "<h{level} id=\"{id}\" class=\"section-header\">\
+                "<h{level} id=\"{id}\">\
                     <a href=\"#{id}\">",
                 id = id,
                 level = level

--- a/src/librustdoc/html/markdown/tests.rs
+++ b/src/librustdoc/html/markdown/tests.rs
@@ -161,23 +161,23 @@ fn test_header() {
 
     t(
         "# Foo bar",
-        "<h2 id=\"foo-bar\" class=\"section-header\"><a href=\"#foo-bar\">Foo bar</a></h2>",
+        "<h2 id=\"foo-bar\"><a href=\"#foo-bar\">Foo bar</a></h2>",
     );
     t(
         "## Foo-bar_baz qux",
-        "<h3 id=\"foo-bar_baz-qux\" class=\"section-header\">\
+        "<h3 id=\"foo-bar_baz-qux\">\
          <a href=\"#foo-bar_baz-qux\">Foo-bar_baz qux</a></h3>",
     );
     t(
         "### **Foo** *bar* baz!?!& -_qux_-%",
-        "<h4 id=\"foo-bar-baz--qux-\" class=\"section-header\">\
+        "<h4 id=\"foo-bar-baz--qux-\">\
             <a href=\"#foo-bar-baz--qux-\"><strong>Foo</strong> \
             <em>bar</em> baz!?!&amp; -<em>qux</em>-%</a>\
          </h4>",
     );
     t(
         "#### **Foo?** & \\*bar?!*  _`baz`_ ❤ #qux",
-        "<h5 id=\"foo--bar--baz--qux\" class=\"section-header\">\
+        "<h5 id=\"foo--bar--baz--qux\">\
              <a href=\"#foo--bar--baz--qux\"><strong>Foo?</strong> &amp; *bar?!*  \
              <em><code>baz</code></em> ❤ #qux</a>\
          </h5>",
@@ -204,32 +204,32 @@ fn test_header_ids_multiple_blocks() {
     t(
         &mut map,
         "# Example",
-        "<h2 id=\"example\" class=\"section-header\"><a href=\"#example\">Example</a></h2>",
+        "<h2 id=\"example\"><a href=\"#example\">Example</a></h2>",
     );
     t(
         &mut map,
         "# Panics",
-        "<h2 id=\"panics\" class=\"section-header\"><a href=\"#panics\">Panics</a></h2>",
+        "<h2 id=\"panics\"><a href=\"#panics\">Panics</a></h2>",
     );
     t(
         &mut map,
         "# Example",
-        "<h2 id=\"example-1\" class=\"section-header\"><a href=\"#example-1\">Example</a></h2>",
+        "<h2 id=\"example-1\"><a href=\"#example-1\">Example</a></h2>",
     );
     t(
         &mut map,
         "# Search",
-        "<h2 id=\"search-1\" class=\"section-header\"><a href=\"#search-1\">Search</a></h2>",
+        "<h2 id=\"search-1\"><a href=\"#search-1\">Search</a></h2>",
     );
     t(
         &mut map,
         "# Example",
-        "<h2 id=\"example-2\" class=\"section-header\"><a href=\"#example-2\">Example</a></h2>",
+        "<h2 id=\"example-2\"><a href=\"#example-2\">Example</a></h2>",
     );
     t(
         &mut map,
         "# Panics",
-        "<h2 id=\"panics-1\" class=\"section-header\"><a href=\"#panics-1\">Panics</a></h2>",
+        "<h2 id=\"panics-1\"><a href=\"#panics-1\">Panics</a></h2>",
     );
 }
 

--- a/src/librustdoc/html/markdown/tests.rs
+++ b/src/librustdoc/html/markdown/tests.rs
@@ -159,10 +159,7 @@ fn test_header() {
         assert_eq!(output, expect, "original: {}", input);
     }
 
-    t(
-        "# Foo bar",
-        "<h2 id=\"foo-bar\"><a href=\"#foo-bar\">Foo bar</a></h2>",
-    );
+    t("# Foo bar", "<h2 id=\"foo-bar\"><a href=\"#foo-bar\">Foo bar</a></h2>");
     t(
         "## Foo-bar_baz qux",
         "<h3 id=\"foo-bar_baz-qux\">\
@@ -201,36 +198,12 @@ fn test_header_ids_multiple_blocks() {
         assert_eq!(output, expect, "original: {}", input);
     }
 
-    t(
-        &mut map,
-        "# Example",
-        "<h2 id=\"example\"><a href=\"#example\">Example</a></h2>",
-    );
-    t(
-        &mut map,
-        "# Panics",
-        "<h2 id=\"panics\"><a href=\"#panics\">Panics</a></h2>",
-    );
-    t(
-        &mut map,
-        "# Example",
-        "<h2 id=\"example-1\"><a href=\"#example-1\">Example</a></h2>",
-    );
-    t(
-        &mut map,
-        "# Search",
-        "<h2 id=\"search-1\"><a href=\"#search-1\">Search</a></h2>",
-    );
-    t(
-        &mut map,
-        "# Example",
-        "<h2 id=\"example-2\"><a href=\"#example-2\">Example</a></h2>",
-    );
-    t(
-        &mut map,
-        "# Panics",
-        "<h2 id=\"panics-1\"><a href=\"#panics-1\">Panics</a></h2>",
-    );
+    t(&mut map, "# Example", "<h2 id=\"example\"><a href=\"#example\">Example</a></h2>");
+    t(&mut map, "# Panics", "<h2 id=\"panics\"><a href=\"#panics\">Panics</a></h2>");
+    t(&mut map, "# Example", "<h2 id=\"example-1\"><a href=\"#example-1\">Example</a></h2>");
+    t(&mut map, "# Search", "<h2 id=\"search-1\"><a href=\"#search-1\">Search</a></h2>");
+    t(&mut map, "# Example", "<h2 id=\"example-2\"><a href=\"#example-2\">Example</a></h2>");
+    t(&mut map, "# Panics", "<h2 id=\"panics-1\"><a href=\"#panics-1\">Panics</a></h2>");
 }
 
 #[test]

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -2567,7 +2567,7 @@ fn render_call_locations(w: &mut Buffer, cx: &Context<'_>, item: &clean::Item) {
         w,
         "<div class=\"docblock scraped-example-list\">\
           <span></span>\
-          <h5 id=\"{id}\" class=\"section-header\">\
+          <h5 id=\"{id}\">\
              <a href=\"#{id}\">Examples found in repository</a>\
           </h5>",
         id = id

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1141,16 +1141,6 @@ a.test-arrow {
 a.test-arrow:hover{
 	text-decoration: none;
 }
-.section-header:hover a:before {
-	position: absolute;
-	left: -25px;
-	padding-right: 10px; /* avoid gap that causes hover to disappear */
-	content: '\2002\00a7\2002';
-}
-
-.section-header:hover a {
-	text-decoration: none;
-}
 
 .code-attribute {
 	font-weight: 300;
@@ -1194,17 +1184,6 @@ h3.variant {
 	display: inline-block;
 	margin-left: 4px;
 	margin-top: 3px;
-}
-
-.top-doc .docblock > .section-header:first-child {
-	margin-left: 15px;
-}
-.top-doc .docblock > .section-header:first-child:hover > a:before {
-	left: -10px;
-}
-
-.docblock > .section-header:first-child {
-	margin-top: 0;
 }
 
 :target > code, :target > .code-header {

--- a/src/test/rustdoc-gui/anchors.goml
+++ b/src/test/rustdoc-gui/anchors.goml
@@ -31,46 +31,4 @@ assert-css: ("h2#implementations a.anchor", {"color": "rgb(0, 0, 0)"})
 move-cursor-to: "#impl"
 assert-css: ("#impl a.anchor", {"color": "rgb(0, 0, 0)"})
 
-// Now we check the positions: only the first heading of the top doc comment should
-// have a different position.
-move-cursor-to: ".top-doc .docblock .section-header:first-child"
-assert-css: (
-    ".top-doc .docblock .section-header:first-child > a::before",
-    {"left": "-10px", "padding-right": "10px"},
-)
-// We also check that the heading itself has a different indent.
-assert-css: (".top-doc .docblock .section-header:first-child", {"margin-left": "15px"})
-
-move-cursor-to: ".top-doc .docblock .section-header:not(:first-child)"
-assert-css: (
-    ".top-doc .docblock .section-header:not(:first-child) > a::before",
-    {"left": "-25px", "padding-right": "10px"},
-)
-assert-css: (".top-doc .docblock .section-header:not(:first-child)", {"margin-left": "0px"})
-
-// Now let's check some other docblock headings...
-// First the impl block docs.
-move-cursor-to: "#title-for-struct-impl-doc"
-assert-css: (
-    "#title-for-struct-impl-doc > a::before",
-    {"left": "-25px", "padding-right": "10px"},
-)
-assert-css: ("#title-for-struct-impl-doc", {"margin-left": "0px"})
-// Now a method docs.
-move-cursor-to: "#title-for-struct-impl-item-doc"
-assert-css: (
-    "#title-for-struct-impl-item-doc > a::before",
-    {"left": "-25px", "padding-right": "10px"},
-)
 assert-css: ("#title-for-struct-impl-item-doc", {"margin-left": "0px"})
-
-// Finally, we want to ensure that if the first element of the doc block isn't a heading,
-// if there is a heading afterwards, it won't have the indent.
-goto: file://|DOC_PATH|/test_docs/enum.WhoLetTheDogOut.html
-
-move-cursor-to: ".top-doc .docblock .section-header"
-assert-css: (
-    ".top-doc .docblock .section-header > a::before",
-    {"left": "-25px", "padding-right": "10px"},
-)
-assert-css: (".top-doc .docblock .section-header", {"margin-left": "0px"})

--- a/src/test/rustdoc-gui/headers-color.goml
+++ b/src/test/rustdoc-gui/headers-color.goml
@@ -40,7 +40,8 @@ goto: file://|DOC_PATH|/test_docs/index.html
 assert-css: (".small-section-header a", {"color": "rgb(197, 197, 197)"}, ALL)
 
 goto: file://|DOC_PATH|/test_docs/struct.HeavilyDocumentedStruct.html
-assert-css: (".section-header a", {"color": "rgb(57, 175, 215)"}, ALL)
+// We select headings (h2, h3, h...).
+assert-css: (".docblock > :not(p) > a", {"color": "rgb(57, 175, 215)"}, ALL)
 
 // Dark theme
 local-storage: {
@@ -78,7 +79,8 @@ goto: file://|DOC_PATH|/test_docs/index.html
 assert-css: (".small-section-header a", {"color": "rgb(221, 221, 221)"}, ALL)
 
 goto: file://|DOC_PATH|/test_docs/struct.HeavilyDocumentedStruct.html
-assert-css: (".section-header a", {"color": "rgb(210, 153, 29)"}, ALL)
+// We select headings (h2, h3, h...).
+assert-css: (".docblock > :not(p) > a", {"color": "rgb(210, 153, 29)"}, ALL)
 
 // Light theme
 local-storage: {"rustdoc-theme": "light", "rustdoc-use-system-theme": "false"}
@@ -111,4 +113,5 @@ goto: file://|DOC_PATH|/test_docs/index.html
 assert-css: (".small-section-header a", {"color": "rgb(0, 0, 0)"}, ALL)
 
 goto: file://|DOC_PATH|/test_docs/struct.HeavilyDocumentedStruct.html
-assert-css: (".section-header a", {"color": "rgb(56, 115, 173)"}, ALL)
+// We select headings (h2, h3, h...).
+assert-css: (".docblock > :not(p) > a", {"color": "rgb(56, 115, 173)"}, ALL)


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/92975.

I removed the anchors displayed on hover because the cursor changes when you hover them in any case, removing the need for the indent altogether.

[Demo](https://rustdoc.crud.net/imperio/headings-indent/std/index.html).

Screenshot of the result:

![Screenshot from 2022-02-09 14-46-12](https://user-images.githubusercontent.com/3050060/153213824-74ef0b62-4f2b-4816-8912-6f2f3beacd29.png)

r? @jsha