### PR TITLE
mips64-openwrt-linux-musl: correct soft-foat

### DIFF
--- a/compiler/rustc_target/src/spec/mips64_openwrt_linux_musl.rs
+++ b/compiler/rustc_target/src/spec/mips64_openwrt_linux_musl.rs
@@ -6,7 +6,7 @@ use crate::spec::{Target, TargetOptions};
 pub fn target() -> Target {
     let mut base = super::linux_musl_base::opts();
     base.cpu = "mips64r2".to_string();
-    base.features = "+mips64r2".to_string();
+    base.features = "+mips64r2,+soft-float".to_string();
     base.max_atomic_width = Some(64);
     base.crt_static_default = false;
 


### PR DESCRIPTION
MIPS64 targets under OpenWrt require soft-float fpu support.

Rust-lang requires soft-float defined in tuple definition and
isn't over-ridden by toolchain compile-time CFLAGS/LDFLAGS

Set explicit soft-float for tuple.

Signed-off-by: Donald Hoskins <grommish@gmail.com>