### PR TITLE
Have the spans of TAIT type conflict errors point to the actual site instead of the owning function

### DIFF
--- a/compiler/rustc_borrowck/src/nll.rs
+++ b/compiler/rustc_borrowck/src/nll.rs
@@ -9,7 +9,7 @@ use rustc_middle::mir::{
     BasicBlock, Body, ClosureOutlivesSubject, ClosureRegionRequirements, LocalKind, Location,
     Promoted,
 };
-use rustc_middle::ty::{self, OpaqueTypeKey, RegionKind, RegionVid, Ty};
+use rustc_middle::ty::{self, OpaqueHiddenType, OpaqueTypeKey, RegionKind, RegionVid};
 use rustc_span::symbol::sym;
 use std::env;
 use std::fmt::Debug;
@@ -44,7 +44,7 @@ pub type PoloniusOutput = Output<RustcFacts>;
 /// closure requirements to propagate, and any generated errors.
 crate struct NllOutput<'tcx> {
     pub regioncx: RegionInferenceContext<'tcx>,
-    pub opaque_type_values: VecMap<OpaqueTypeKey<'tcx>, Ty<'tcx>>,
+    pub opaque_type_values: VecMap<OpaqueTypeKey<'tcx>, OpaqueHiddenType<'tcx>>,
     pub polonius_input: Option<Box<AllFacts>>,
     pub polonius_output: Option<Rc<PoloniusOutput>>,
     pub opt_closure_req: Option<ClosureRegionRequirements<'tcx>>,
@@ -305,7 +305,7 @@ pub(crate) fn compute_regions<'cx, 'tcx>(
         infcx.set_tainted_by_errors();
     }
 
-    let remapped_opaque_tys = regioncx.infer_opaque_types(&infcx, opaque_type_values, body.span);
+    let remapped_opaque_tys = regioncx.infer_opaque_types(&infcx, opaque_type_values);
 
     NllOutput {
         regioncx,
@@ -372,7 +372,7 @@ pub(super) fn dump_annotation<'a, 'tcx>(
     body: &Body<'tcx>,
     regioncx: &RegionInferenceContext<'tcx>,
     closure_region_requirements: &Option<ClosureRegionRequirements<'_>>,
-    opaque_type_values: &VecMap<OpaqueTypeKey<'tcx>, Ty<'tcx>>,
+    opaque_type_values: &VecMap<OpaqueTypeKey<'tcx>, OpaqueHiddenType<'tcx>>,
     errors_buffer: &mut Vec<Diagnostic>,
 ) {
     let tcx = infcx.tcx;

--- a/compiler/rustc_infer/src/infer/opaque_types.rs
+++ b/compiler/rustc_infer/src/infer/opaque_types.rs
@@ -8,7 +8,9 @@ use rustc_hir as hir;
 use rustc_middle::traits::ObligationCause;
 use rustc_middle::ty::fold::BottomUpFolder;
 use rustc_middle::ty::subst::{GenericArgKind, Subst};
-use rustc_middle::ty::{self, OpaqueTypeKey, Ty, TyCtxt, TypeFoldable, TypeVisitor};
+use rustc_middle::ty::{
+    self, OpaqueHiddenType, OpaqueTypeKey, Ty, TyCtxt, TypeFoldable, TypeVisitor,
+};
 use rustc_span::Span;
 
 use std::ops::ControlFlow;
@@ -33,38 +35,6 @@ pub struct OpaqueTypeDecl<'tcx> {
 
     /// The origin of the opaque type.
     pub origin: hir::OpaqueTyOrigin,
-}
-
-#[derive(Copy, Clone, Debug, TypeFoldable)]
-pub struct OpaqueHiddenType<'tcx> {
-    /// The span of this particular definition of the opaque type. So
-    /// for example:
-    ///
-    /// ```ignore (incomplete snippet)
-    /// type Foo = impl Baz;
-    /// fn bar() -> Foo {
-    /// //          ^^^ This is the span we are looking for!
-    /// }
-    /// ```
-    ///
-    /// In cases where the fn returns `(impl Trait, impl Trait)` or
-    /// other such combinations, the result is currently
-    /// over-approximated, but better than nothing.
-    pub span: Span,
-
-    /// The type variable that represents the value of the opaque type
-    /// that we require. In other words, after we compile this function,
-    /// we will be created a constraint like:
-    ///
-    ///     Foo<'a, T> = ?C
-    ///
-    /// where `?C` is the value of this type variable. =) It may
-    /// naturally refer to the type and lifetime parameters in scope
-    /// in this function, though ultimately it should only reference
-    /// those that are arguments to `Foo` in the constraint above. (In
-    /// other words, `?C` should not include `'b`, even though it's a
-    /// lifetime parameter on `foo`.)
-    pub ty: Ty<'tcx>,
 }
 
 impl<'a, 'tcx> InferCtxt<'a, 'tcx> {

--- a/compiler/rustc_infer/src/infer/opaque_types/table.rs
+++ b/compiler/rustc_infer/src/infer/opaque_types/table.rs
@@ -1,11 +1,11 @@
 use rustc_data_structures::undo_log::UndoLogs;
 use rustc_hir::OpaqueTyOrigin;
-use rustc_middle::ty::{self, OpaqueTypeKey, Ty};
+use rustc_middle::ty::{self, OpaqueHiddenType, OpaqueTypeKey, Ty};
 use rustc_span::DUMMY_SP;
 
 use crate::infer::{InferCtxtUndoLogs, UndoLog};
 
-use super::{OpaqueHiddenType, OpaqueTypeDecl, OpaqueTypeMap};
+use super::{OpaqueTypeDecl, OpaqueTypeMap};
 
 #[derive(Default, Debug)]
 pub struct OpaqueTypeStorage<'tcx> {

--- a/compiler/rustc_infer/src/infer/undo_log.rs
+++ b/compiler/rustc_infer/src/infer/undo_log.rs
@@ -4,14 +4,12 @@ use rustc_data_structures::snapshot_vec as sv;
 use rustc_data_structures::undo_log::{Rollback, UndoLogs};
 use rustc_data_structures::unify as ut;
 use rustc_middle::infer::unify_key::RegionVidKey;
-use rustc_middle::ty::{self, OpaqueTypeKey};
+use rustc_middle::ty::{self, OpaqueHiddenType, OpaqueTypeKey};
 
 use crate::{
     infer::{region_constraints, type_variable, InferCtxtInner},
     traits,
 };
-
-use super::opaque_types::OpaqueHiddenType;
 
 pub struct Snapshot<'tcx> {
     pub(crate) undo_len: usize,

--- a/compiler/rustc_middle/src/mir/query.rs
+++ b/compiler/rustc_middle/src/mir/query.rs
@@ -1,7 +1,7 @@
 //! Values computed by queries that use MIR.
 
 use crate::mir::{Body, Promoted};
-use crate::ty::{self, Ty, TyCtxt};
+use crate::ty::{self, OpaqueHiddenType, Ty, TyCtxt};
 use rustc_data_structures::sync::Lrc;
 use rustc_data_structures::vec_map::VecMap;
 use rustc_errors::ErrorReported;
@@ -211,7 +211,7 @@ pub struct BorrowCheckResult<'tcx> {
     /// All the opaque types that are restricted to concrete types
     /// by this function. Unlike the value in `TypeckResults`, this has
     /// unerased regions.
-    pub concrete_opaque_types: VecMap<OpaqueTypeKey<'tcx>, Ty<'tcx>>,
+    pub concrete_opaque_types: VecMap<OpaqueTypeKey<'tcx>, OpaqueHiddenType<'tcx>>,
     pub closure_requirements: Option<ClosureRegionRequirements<'tcx>>,
     pub used_mut_upvars: SmallVec<[Field; 8]>,
 }

--- a/compiler/rustc_typeck/src/collect/type_of.rs
+++ b/compiler/rustc_typeck/src/collect/type_of.rs
@@ -639,7 +639,11 @@ fn find_opaque_ty_constraints(tcx: TyCtxt<'_>, def_id: LocalDefId) -> Ty<'_> {
                             concrete_type.span,
                             format!("expected `{}`, got `{}`", prev.ty, concrete_type.ty),
                         );
-                        err.span_note(prev.span, "previous use here");
+                        if prev.span == concrete_type.span {
+                            err.span_label(prev.span, "this expression supplies two conflicting concrete types for the same opaque type");
+                        } else {
+                            err.span_note(prev.span, "previous use here");
+                        }
                         err.emit();
                     }
                 } else {

--- a/src/test/ui/impl-trait/issue-86465.rs
+++ b/src/test/ui/impl-trait/issue-86465.rs
@@ -3,8 +3,8 @@
 type X<'a, 'b> = impl std::fmt::Debug;
 
 fn f<'t, 'u>(a: &'t u32, b: &'u u32) -> (X<'t, 'u>, X<'u, 't>) {
-    //~^ ERROR concrete type differs from previous defining opaque type use
     (a, a)
+    //~^ ERROR concrete type differs from previous defining opaque type use
 }
 
 fn main() {}

--- a/src/test/ui/impl-trait/issue-86465.stderr
+++ b/src/test/ui/impl-trait/issue-86465.stderr
@@ -1,14 +1,14 @@
 error: concrete type differs from previous defining opaque type use
-  --> $DIR/issue-86465.rs:5:1
+  --> $DIR/issue-86465.rs:6:5
    |
-LL | fn f<'t, 'u>(a: &'t u32, b: &'u u32) -> (X<'t, 'u>, X<'u, 't>) {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `&'a u32`, got `&'b u32`
+LL |     (a, a)
+   |     ^^^^^^ expected `&'a u32`, got `&'b u32`
    |
 note: previous use here
-  --> $DIR/issue-86465.rs:5:1
+  --> $DIR/issue-86465.rs:6:5
    |
-LL | fn f<'t, 'u>(a: &'t u32, b: &'u u32) -> (X<'t, 'u>, X<'u, 't>) {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     (a, a)
+   |     ^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/impl-trait/issue-86465.stderr
+++ b/src/test/ui/impl-trait/issue-86465.stderr
@@ -2,13 +2,10 @@ error: concrete type differs from previous defining opaque type use
   --> $DIR/issue-86465.rs:6:5
    |
 LL |     (a, a)
-   |     ^^^^^^ expected `&'a u32`, got `&'b u32`
-   |
-note: previous use here
-  --> $DIR/issue-86465.rs:6:5
-   |
-LL |     (a, a)
    |     ^^^^^^
+   |     |
+   |     expected `&'a u32`, got `&'b u32`
+   |     this expression supplies two conflicting concrete types for the same opaque type
 
 error: aborting due to previous error
 

--- a/src/test/ui/type-alias-impl-trait/different_defining_uses.rs
+++ b/src/test/ui/type-alias-impl-trait/different_defining_uses.rs
@@ -10,6 +10,6 @@ fn foo() -> Foo {
 }
 
 fn bar() -> Foo {
-    //~^ ERROR concrete type differs from previous
     42i32
+    //~^ ERROR concrete type differs from previous
 }

--- a/src/test/ui/type-alias-impl-trait/different_defining_uses.stderr
+++ b/src/test/ui/type-alias-impl-trait/different_defining_uses.stderr
@@ -1,14 +1,14 @@
 error: concrete type differs from previous defining opaque type use
-  --> $DIR/different_defining_uses.rs:12:1
+  --> $DIR/different_defining_uses.rs:13:5
    |
-LL | fn bar() -> Foo {
-   | ^^^^^^^^^^^^^^^ expected `&'static str`, got `i32`
+LL |     42i32
+   |     ^^^^^ expected `&'static str`, got `i32`
    |
 note: previous use here
-  --> $DIR/different_defining_uses.rs:8:1
+  --> $DIR/different_defining_uses.rs:9:5
    |
-LL | fn foo() -> Foo {
-   | ^^^^^^^^^^^^^^^
+LL |     ""
+   |     ^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/type-alias-impl-trait/different_lifetimes_defining_uses.rs
+++ b/src/test/ui/type-alias-impl-trait/different_lifetimes_defining_uses.rs
@@ -8,8 +8,8 @@ fn foo<'a, 'b>(a: &'a u32, b: &'b u32) -> OneLifetime<'a, 'b> {
 }
 
 fn bar<'a, 'b>(a: &'a u32, b: &'b u32) -> OneLifetime<'a, 'b> {
-    //~^ ERROR: concrete type differs from previous defining opaque type use
     b
+    //~^ ERROR: concrete type differs from previous defining opaque type use
 }
 
 fn main() {}

--- a/src/test/ui/type-alias-impl-trait/different_lifetimes_defining_uses.stderr
+++ b/src/test/ui/type-alias-impl-trait/different_lifetimes_defining_uses.stderr
@@ -1,14 +1,14 @@
 error: concrete type differs from previous defining opaque type use
-  --> $DIR/different_lifetimes_defining_uses.rs:10:1
+  --> $DIR/different_lifetimes_defining_uses.rs:11:5
    |
-LL | fn bar<'a, 'b>(a: &'a u32, b: &'b u32) -> OneLifetime<'a, 'b> {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `&'a u32`, got `&'b u32`
+LL |     b
+   |     ^ expected `&'a u32`, got `&'b u32`
    |
 note: previous use here
-  --> $DIR/different_lifetimes_defining_uses.rs:6:1
+  --> $DIR/different_lifetimes_defining_uses.rs:7:5
    |
-LL | fn foo<'a, 'b>(a: &'a u32, b: &'b u32) -> OneLifetime<'a, 'b> {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     a
+   |     ^
 
 error: aborting due to previous error
 

--- a/src/test/ui/type-alias-impl-trait/generic_different_defining_uses.rs
+++ b/src/test/ui/type-alias-impl-trait/generic_different_defining_uses.rs
@@ -9,6 +9,6 @@ fn my_iter<T>(t: T) -> MyIter<T> {
 }
 
 fn my_iter2<T>(t: T) -> MyIter<T> {
-    //~^ ERROR concrete type differs from previous
     Some(t).into_iter()
+    //~^ ERROR concrete type differs from previous
 }

--- a/src/test/ui/type-alias-impl-trait/generic_different_defining_uses.stderr
+++ b/src/test/ui/type-alias-impl-trait/generic_different_defining_uses.stderr
@@ -1,14 +1,14 @@
 error: concrete type differs from previous defining opaque type use
-  --> $DIR/generic_different_defining_uses.rs:11:1
+  --> $DIR/generic_different_defining_uses.rs:12:5
    |
-LL | fn my_iter2<T>(t: T) -> MyIter<T> {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `std::iter::Once<T>`, got `std::option::IntoIter<T>`
+LL |     Some(t).into_iter()
+   |     ^^^^^^^^^^^^^^^^^^^ expected `std::iter::Once<T>`, got `std::option::IntoIter<T>`
    |
 note: previous use here
-  --> $DIR/generic_different_defining_uses.rs:7:1
+  --> $DIR/generic_different_defining_uses.rs:8:5
    |
-LL | fn my_iter<T>(t: T) -> MyIter<T> {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     std::iter::once(t)
+   |     ^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/type-alias-impl-trait/generic_duplicate_param_use3.rs
+++ b/src/test/ui/type-alias-impl-trait/generic_duplicate_param_use3.rs
@@ -13,6 +13,6 @@ fn two<T: Debug, U>(t: T, _: U) -> Two<T, U> {
 }
 
 fn three<T, U: Debug>(_: T, u: U) -> Two<T, U> {
-    //~^ ERROR concrete type differs from previous defining opaque type use
     u
+    //~^ ERROR concrete type differs from previous defining opaque type use
 }

--- a/src/test/ui/type-alias-impl-trait/generic_duplicate_param_use3.stderr
+++ b/src/test/ui/type-alias-impl-trait/generic_duplicate_param_use3.stderr
@@ -1,14 +1,14 @@
 error: concrete type differs from previous defining opaque type use
-  --> $DIR/generic_duplicate_param_use3.rs:15:1
+  --> $DIR/generic_duplicate_param_use3.rs:16:5
    |
-LL | fn three<T, U: Debug>(_: T, u: U) -> Two<T, U> {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `T`, got `U`
+LL |     u
+   |     ^ expected `T`, got `U`
    |
 note: previous use here
-  --> $DIR/generic_duplicate_param_use3.rs:11:1
+  --> $DIR/generic_duplicate_param_use3.rs:12:5
    |
-LL | fn two<T: Debug, U>(t: T, _: U) -> Two<T, U> {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     t
+   |     ^
 
 error[E0277]: `T` doesn't implement `Debug`
   --> $DIR/generic_duplicate_param_use3.rs:8:18

--- a/src/test/ui/type-alias-impl-trait/generic_duplicate_param_use5.rs
+++ b/src/test/ui/type-alias-impl-trait/generic_duplicate_param_use5.rs
@@ -14,6 +14,6 @@ fn two<T: Debug, U: Debug>(t: T, u: U) -> Two<T, U> {
 }
 
 fn three<T: Debug, U: Debug>(t: T, u: U) -> Two<T, U> {
-    //~^ concrete type differs from previous
     (u, t)
+    //~^ concrete type differs from previous
 }

--- a/src/test/ui/type-alias-impl-trait/generic_duplicate_param_use5.stderr
+++ b/src/test/ui/type-alias-impl-trait/generic_duplicate_param_use5.stderr
@@ -1,14 +1,14 @@
 error: concrete type differs from previous defining opaque type use
-  --> $DIR/generic_duplicate_param_use5.rs:16:1
+  --> $DIR/generic_duplicate_param_use5.rs:17:5
    |
-LL | fn three<T: Debug, U: Debug>(t: T, u: U) -> Two<T, U> {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `(T, U)`, got `(U, T)`
+LL |     (u, t)
+   |     ^^^^^^ expected `(T, U)`, got `(U, T)`
    |
 note: previous use here
-  --> $DIR/generic_duplicate_param_use5.rs:12:1
+  --> $DIR/generic_duplicate_param_use5.rs:13:5
    |
-LL | fn two<T: Debug, U: Debug>(t: T, u: U) -> Two<T, U> {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     (t, u)
+   |     ^^^^^^
 
 error[E0277]: `T` doesn't implement `Debug`
   --> $DIR/generic_duplicate_param_use5.rs:8:18

--- a/src/test/ui/type-alias-impl-trait/generic_duplicate_param_use6.rs
+++ b/src/test/ui/type-alias-impl-trait/generic_duplicate_param_use6.rs
@@ -13,6 +13,6 @@ fn two<T: Copy + Debug, U: Debug>(t: T, u: U) -> Two<T, U> {
 }
 
 fn three<T: Copy + Debug, U: Debug>(t: T, u: U) -> Two<T, U> {
-    //~^ ERROR concrete type differs from previous
     (u, t)
+    //~^ ERROR concrete type differs from previous
 }

--- a/src/test/ui/type-alias-impl-trait/generic_duplicate_param_use6.stderr
+++ b/src/test/ui/type-alias-impl-trait/generic_duplicate_param_use6.stderr
@@ -1,14 +1,14 @@
 error: concrete type differs from previous defining opaque type use
-  --> $DIR/generic_duplicate_param_use6.rs:15:1
+  --> $DIR/generic_duplicate_param_use6.rs:16:5
    |
-LL | fn three<T: Copy + Debug, U: Debug>(t: T, u: U) -> Two<T, U> {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `(T, T)`, got `(U, T)`
+LL |     (u, t)
+   |     ^^^^^^ expected `(T, T)`, got `(U, T)`
    |
 note: previous use here
-  --> $DIR/generic_duplicate_param_use6.rs:11:1
+  --> $DIR/generic_duplicate_param_use6.rs:12:5
    |
-LL | fn two<T: Copy + Debug, U: Debug>(t: T, u: U) -> Two<T, U> {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     (t, t)
+   |     ^^^^^^
 
 error[E0277]: `T` doesn't implement `Debug`
   --> $DIR/generic_duplicate_param_use6.rs:8:18

--- a/src/test/ui/type-alias-impl-trait/generic_duplicate_param_use8.rs
+++ b/src/test/ui/type-alias-impl-trait/generic_duplicate_param_use8.rs
@@ -12,6 +12,6 @@ fn two<T: Debug, U: Debug>(t: T, _: U) -> Two<T, U> {
 }
 
 fn three<T: Debug, U: Debug>(_: T, u: U) -> Two<T, U> {
-    //~^ concrete type differs from previous
     (u, 4u32)
+    //~^ concrete type differs from previous
 }

--- a/src/test/ui/type-alias-impl-trait/generic_duplicate_param_use8.stderr
+++ b/src/test/ui/type-alias-impl-trait/generic_duplicate_param_use8.stderr
@@ -1,14 +1,14 @@
 error: concrete type differs from previous defining opaque type use
-  --> $DIR/generic_duplicate_param_use8.rs:14:1
+  --> $DIR/generic_duplicate_param_use8.rs:15:5
    |
-LL | fn three<T: Debug, U: Debug>(_: T, u: U) -> Two<T, U> {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `(T, u32)`, got `(U, u32)`
+LL |     (u, 4u32)
+   |     ^^^^^^^^^ expected `(T, u32)`, got `(U, u32)`
    |
 note: previous use here
-  --> $DIR/generic_duplicate_param_use8.rs:10:1
+  --> $DIR/generic_duplicate_param_use8.rs:11:5
    |
-LL | fn two<T: Debug, U: Debug>(t: T, _: U) -> Two<T, U> {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     (t, 4u32)
+   |     ^^^^^^^^^
 
 error[E0277]: `T` doesn't implement `Debug`
   --> $DIR/generic_duplicate_param_use8.rs:7:18

--- a/src/test/ui/type-alias-impl-trait/generic_duplicate_param_use9.rs
+++ b/src/test/ui/type-alias-impl-trait/generic_duplicate_param_use9.rs
@@ -19,5 +19,5 @@ fn two<T: Debug + Foo, U: Debug>(t: T, u: U) -> Two<T, U> {
 }
 
 fn three<T: Debug, U: Debug>(t: T, u: U) -> Two<T, U> {
-    (t, u, 42) //~^ ERROR concrete type differs from previous
+    (t, u, 42) //~ ERROR concrete type differs from previous
 }

--- a/src/test/ui/type-alias-impl-trait/generic_duplicate_param_use9.stderr
+++ b/src/test/ui/type-alias-impl-trait/generic_duplicate_param_use9.stderr
@@ -1,14 +1,14 @@
 error: concrete type differs from previous defining opaque type use
-  --> $DIR/generic_duplicate_param_use9.rs:21:1
+  --> $DIR/generic_duplicate_param_use9.rs:22:5
    |
-LL | fn three<T: Debug, U: Debug>(t: T, u: U) -> Two<T, U> {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `(A, B, <A as Foo>::Bar)`, got `(A, B, i32)`
+LL |     (t, u, 42)
+   |     ^^^^^^^^^^ expected `(A, B, <A as Foo>::Bar)`, got `(A, B, i32)`
    |
 note: previous use here
-  --> $DIR/generic_duplicate_param_use9.rs:17:1
+  --> $DIR/generic_duplicate_param_use9.rs:18:5
    |
-LL | fn two<T: Debug + Foo, U: Debug>(t: T, u: U) -> Two<T, U> {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     (t, u, T::BAR)
+   |     ^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `A: Foo` is not satisfied in `(A, B, <A as Foo>::Bar)`
   --> $DIR/generic_duplicate_param_use9.rs:7:18

--- a/src/test/ui/type-alias-impl-trait/issue-52843-closure-constrain.stderr
+++ b/src/test/ui/type-alias-impl-trait/issue-52843-closure-constrain.stderr
@@ -1,14 +1,14 @@
 error: concrete type differs from previous defining opaque type use
-  --> $DIR/issue-52843-closure-constrain.rs:10:16
+  --> $DIR/issue-52843-closure-constrain.rs:10:31
    |
 LL |     let null = || -> Opaque { 0 };
-   |                ^^^^^^^^^^^^^^^^^^ expected `String`, got `i32`
+   |                               ^ expected `String`, got `i32`
    |
 note: previous use here
-  --> $DIR/issue-52843-closure-constrain.rs:9:5
+  --> $DIR/issue-52843-closure-constrain.rs:9:30
    |
 LL |     fn _unused() -> Opaque { String::new() }
-   |     ^^^^^^^^^^^^^^^^^^^^^^
+   |                              ^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/type-alias-impl-trait/multiple-def-uses-in-one-fn-infer.rs
+++ b/src/test/ui/type-alias-impl-trait/multiple-def-uses-in-one-fn-infer.rs
@@ -7,7 +7,7 @@
 type Y<A, B> = impl std::fmt::Debug;
 
 fn g<A, B>() -> (Y<A, B>, Y<B, A>) {
-    (42_i64, 60) //~^ ERROR concrete type differs from previous defining opaque type use
+    (42_i64, 60) //~ ERROR concrete type differs from previous defining opaque type use
 }
 
 fn main() {}

--- a/src/test/ui/type-alias-impl-trait/multiple-def-uses-in-one-fn-infer.stderr
+++ b/src/test/ui/type-alias-impl-trait/multiple-def-uses-in-one-fn-infer.stderr
@@ -2,13 +2,10 @@ error: concrete type differs from previous defining opaque type use
   --> $DIR/multiple-def-uses-in-one-fn-infer.rs:10:5
    |
 LL |     (42_i64, 60)
-   |     ^^^^^^^^^^^^ expected `i64`, got `i32`
-   |
-note: previous use here
-  --> $DIR/multiple-def-uses-in-one-fn-infer.rs:10:5
-   |
-LL |     (42_i64, 60)
    |     ^^^^^^^^^^^^
+   |     |
+   |     expected `i64`, got `i32`
+   |     this expression supplies two conflicting concrete types for the same opaque type
 
 error: aborting due to previous error
 

--- a/src/test/ui/type-alias-impl-trait/multiple-def-uses-in-one-fn-infer.stderr
+++ b/src/test/ui/type-alias-impl-trait/multiple-def-uses-in-one-fn-infer.stderr
@@ -1,14 +1,14 @@
 error: concrete type differs from previous defining opaque type use
-  --> $DIR/multiple-def-uses-in-one-fn-infer.rs:9:1
+  --> $DIR/multiple-def-uses-in-one-fn-infer.rs:10:5
    |
-LL | fn g<A, B>() -> (Y<A, B>, Y<B, A>) {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `i64`, got `i32`
+LL |     (42_i64, 60)
+   |     ^^^^^^^^^^^^ expected `i64`, got `i32`
    |
 note: previous use here
-  --> $DIR/multiple-def-uses-in-one-fn-infer.rs:9:1
+  --> $DIR/multiple-def-uses-in-one-fn-infer.rs:10:5
    |
-LL | fn g<A, B>() -> (Y<A, B>, Y<B, A>) {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     (42_i64, 60)
+   |     ^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/type-alias-impl-trait/multiple-def-uses-in-one-fn-lifetimes.rs
+++ b/src/test/ui/type-alias-impl-trait/multiple-def-uses-in-one-fn-lifetimes.rs
@@ -3,7 +3,7 @@
 type Foo<'a, 'b> = impl std::fmt::Debug;
 
 fn foo<'x, 'y>(i: &'x i32, j: &'y i32) -> (Foo<'x, 'y>, Foo<'y, 'x>) {
-    (i, i) //~^ ERROR concrete type differs from previous
+    (i, i) //~ ERROR concrete type differs from previous
 }
 
 fn main() {}

--- a/src/test/ui/type-alias-impl-trait/multiple-def-uses-in-one-fn-lifetimes.stderr
+++ b/src/test/ui/type-alias-impl-trait/multiple-def-uses-in-one-fn-lifetimes.stderr
@@ -1,14 +1,14 @@
 error: concrete type differs from previous defining opaque type use
-  --> $DIR/multiple-def-uses-in-one-fn-lifetimes.rs:5:1
+  --> $DIR/multiple-def-uses-in-one-fn-lifetimes.rs:6:5
    |
-LL | fn foo<'x, 'y>(i: &'x i32, j: &'y i32) -> (Foo<'x, 'y>, Foo<'y, 'x>) {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `&'a i32`, got `&'b i32`
+LL |     (i, i)
+   |     ^^^^^^ expected `&'a i32`, got `&'b i32`
    |
 note: previous use here
-  --> $DIR/multiple-def-uses-in-one-fn-lifetimes.rs:5:1
+  --> $DIR/multiple-def-uses-in-one-fn-lifetimes.rs:6:5
    |
-LL | fn foo<'x, 'y>(i: &'x i32, j: &'y i32) -> (Foo<'x, 'y>, Foo<'y, 'x>) {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     (i, i)
+   |     ^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/type-alias-impl-trait/multiple-def-uses-in-one-fn-lifetimes.stderr
+++ b/src/test/ui/type-alias-impl-trait/multiple-def-uses-in-one-fn-lifetimes.stderr
@@ -2,13 +2,10 @@ error: concrete type differs from previous defining opaque type use
   --> $DIR/multiple-def-uses-in-one-fn-lifetimes.rs:6:5
    |
 LL |     (i, i)
-   |     ^^^^^^ expected `&'a i32`, got `&'b i32`
-   |
-note: previous use here
-  --> $DIR/multiple-def-uses-in-one-fn-lifetimes.rs:6:5
-   |
-LL |     (i, i)
    |     ^^^^^^
+   |     |
+   |     expected `&'a i32`, got `&'b i32`
+   |     this expression supplies two conflicting concrete types for the same opaque type
 
 error: aborting due to previous error
 

--- a/src/test/ui/type-alias-impl-trait/multiple-def-uses-in-one-fn2.rs
+++ b/src/test/ui/type-alias-impl-trait/multiple-def-uses-in-one-fn2.rs
@@ -7,8 +7,8 @@
 type X<A: ToString + Clone, B: ToString + Clone> = impl ToString;
 
 fn f<A: ToString + Clone, B: ToString + Clone>(a: A, b: B) -> (X<A, B>, X<B, A>) {
-    //~^ ERROR concrete type differs from previous defining opaque type
     (a.clone(), a)
+    //~^ ERROR concrete type differs from previous defining opaque type
 }
 
 fn main() {

--- a/src/test/ui/type-alias-impl-trait/multiple-def-uses-in-one-fn2.stderr
+++ b/src/test/ui/type-alias-impl-trait/multiple-def-uses-in-one-fn2.stderr
@@ -1,14 +1,14 @@
 error: concrete type differs from previous defining opaque type use
-  --> $DIR/multiple-def-uses-in-one-fn2.rs:9:1
+  --> $DIR/multiple-def-uses-in-one-fn2.rs:10:5
    |
-LL | fn f<A: ToString + Clone, B: ToString + Clone>(a: A, b: B) -> (X<A, B>, X<B, A>) {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `A`, got `B`
+LL |     (a.clone(), a)
+   |     ^^^^^^^^^^^^^^ expected `A`, got `B`
    |
 note: previous use here
-  --> $DIR/multiple-def-uses-in-one-fn2.rs:9:1
+  --> $DIR/multiple-def-uses-in-one-fn2.rs:10:5
    |
-LL | fn f<A: ToString + Clone, B: ToString + Clone>(a: A, b: B) -> (X<A, B>, X<B, A>) {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     (a.clone(), a)
+   |     ^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/type-alias-impl-trait/multiple-def-uses-in-one-fn2.stderr
+++ b/src/test/ui/type-alias-impl-trait/multiple-def-uses-in-one-fn2.stderr
@@ -2,13 +2,10 @@ error: concrete type differs from previous defining opaque type use
   --> $DIR/multiple-def-uses-in-one-fn2.rs:10:5
    |
 LL |     (a.clone(), a)
-   |     ^^^^^^^^^^^^^^ expected `A`, got `B`
-   |
-note: previous use here
-  --> $DIR/multiple-def-uses-in-one-fn2.rs:10:5
-   |
-LL |     (a.clone(), a)
    |     ^^^^^^^^^^^^^^
+   |     |
+   |     expected `A`, got `B`
+   |     this expression supplies two conflicting concrete types for the same opaque type
 
 error: aborting due to previous error
 

--- a/src/test/ui/type-alias-impl-trait/not_a_defining_use.rs
+++ b/src/test/ui/type-alias-impl-trait/not_a_defining_use.rs
@@ -22,8 +22,8 @@ impl Bar for u32 {
 }
 
 fn four<T: Debug, U: Bar>(t: T) -> Two<T, U> {
-    //~^ ERROR concrete type differs from previous
     (t, <U as Bar>::FOO)
+    //~^ ERROR concrete type differs from previous
 }
 
 fn is_sync<T: Sync>() {}

--- a/src/test/ui/type-alias-impl-trait/not_a_defining_use.stderr
+++ b/src/test/ui/type-alias-impl-trait/not_a_defining_use.stderr
@@ -1,14 +1,14 @@
 error: concrete type differs from previous defining opaque type use
-  --> $DIR/not_a_defining_use.rs:24:1
+  --> $DIR/not_a_defining_use.rs:25:5
    |
-LL | fn four<T: Debug, U: Bar>(t: T) -> Two<T, U> {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `(T, i8)`, got `(T, <U as Bar>::Blub)`
+LL |     (t, <U as Bar>::FOO)
+   |     ^^^^^^^^^^^^^^^^^^^^ expected `(T, i8)`, got `(T, <U as Bar>::Blub)`
    |
 note: previous use here
-  --> $DIR/not_a_defining_use.rs:10:1
+  --> $DIR/not_a_defining_use.rs:11:5
    |
-LL | fn three<T: Debug, U>(t: T) -> Two<T, U> {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     (t, 5i8)
+   |     ^^^^^^^^
 
 error[E0277]: `T` doesn't implement `Debug`
   --> $DIR/not_a_defining_use.rs:7:18


### PR DESCRIPTION
This means we now end up with spans in the query result of `borrowck`, but that is unavoidable (and there are already some in there, so it isn't too bad).