### PR TITLE
Rework GAT `where` clause check

### DIFF
--- a/compiler/rustc_typeck/src/check/wfcheck.rs
+++ b/compiler/rustc_typeck/src/check/wfcheck.rs
@@ -342,7 +342,6 @@ fn check_gat_where_clauses(tcx: TyCtxt<'_>, associated_items: &[hir::TraitItemRe
                             param_env,
                             required_bounds_by_item.get(&item_def_id),
                         );
-                        // FIXME(compiler-errors): Do we want to add a assoc ty default to the wf_tys?
                         gather_gat_bounds(
                             tcx,
                             param_env,

--- a/src/test/ui/generic-associated-types/self-outlives-lint.rs
+++ b/src/test/ui/generic-associated-types/self-outlives-lint.rs
@@ -1,5 +1,7 @@
 #![feature(generic_associated_types)]
 
+// check-fail
+
 use std::fmt::Debug;
 
 // We have a `&'a self`, so we need a `Self: 'a`
@@ -115,6 +117,7 @@ trait TraitLifetime<'a> {
 }
 
 // Like above, but we have a where clause that can prove what we want
+// FIXME: we require two bounds (`where Self: 'a, Self: 'b`) when we should only require one
 trait TraitLifetimeWhere<'a> where Self: 'a {
     type Bar<'b>;
     //~^ missing required

--- a/src/test/ui/generic-associated-types/self-outlives-lint.rs
+++ b/src/test/ui/generic-associated-types/self-outlives-lint.rs
@@ -1,7 +1,5 @@
 #![feature(generic_associated_types)]
 
-// check-fail
-
 use std::fmt::Debug;
 
 // We have a `&'a self`, so we need a `Self: 'a`
@@ -117,7 +115,6 @@ trait TraitLifetime<'a> {
 }
 
 // Like above, but we have a where clause that can prove what we want
-// FIXME: we require two bounds (`where Self: 'a, Self: 'b`) when we should only require one
 trait TraitLifetimeWhere<'a> where Self: 'a {
     type Bar<'b>;
     //~^ missing required
@@ -140,8 +137,16 @@ trait NotInReturn {
 // We obviously error for `Iterator`, but we should also error for `Item`
 trait IterableTwo {
     type Item<'a>;
+    //~^ missing required
     type Iterator<'a>: Iterator<Item = Self::Item<'a>>;
     //~^ missing required
+    fn iter<'a>(&'a self) -> Self::Iterator<'a>;
+}
+
+trait IterableTwoWhere {
+    type Item<'a>;
+    //~^ missing required
+    type Iterator<'a>: Iterator<Item = Self::Item<'a>> where Self: 'a;
     fn iter<'a>(&'a self) -> Self::Iterator<'a>;
 }
 

--- a/src/test/ui/generic-associated-types/self-outlives-lint.stderr
+++ b/src/test/ui/generic-associated-types/self-outlives-lint.stderr
@@ -1,5 +1,5 @@
 error: missing required bound on `Item`
-  --> $DIR/self-outlives-lint.rs:7:5
+  --> $DIR/self-outlives-lint.rs:9:5
    |
 LL |     type Item<'x>;
    |     ^^^^^^^^^^^^^-
@@ -10,7 +10,7 @@ LL |     type Item<'x>;
    = note: we are soliciting feedback, see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
 
 error: missing required bound on `Out`
-  --> $DIR/self-outlives-lint.rs:23:5
+  --> $DIR/self-outlives-lint.rs:25:5
    |
 LL |     type Out<'x>;
    |     ^^^^^^^^^^^^-
@@ -21,7 +21,7 @@ LL |     type Out<'x>;
    = note: we are soliciting feedback, see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
 
 error: missing required bound on `Out`
-  --> $DIR/self-outlives-lint.rs:37:5
+  --> $DIR/self-outlives-lint.rs:39:5
    |
 LL |     type Out<'x>;
    |     ^^^^^^^^^^^^-
@@ -32,7 +32,7 @@ LL |     type Out<'x>;
    = note: we are soliciting feedback, see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
 
 error: missing required bounds on `Out`
-  --> $DIR/self-outlives-lint.rs:44:5
+  --> $DIR/self-outlives-lint.rs:46:5
    |
 LL |     type Out<'x, 'y>;
    |     ^^^^^^^^^^^^^^^^-
@@ -43,7 +43,7 @@ LL |     type Out<'x, 'y>;
    = note: we are soliciting feedback, see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
 
 error: missing required bound on `Out`
-  --> $DIR/self-outlives-lint.rs:59:5
+  --> $DIR/self-outlives-lint.rs:61:5
    |
 LL |     type Out<'x, D>;
    |     ^^^^^^^^^^^^^^^-
@@ -54,7 +54,7 @@ LL |     type Out<'x, D>;
    = note: we are soliciting feedback, see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
 
 error: missing required bound on `Out`
-  --> $DIR/self-outlives-lint.rs:75:5
+  --> $DIR/self-outlives-lint.rs:77:5
    |
 LL |     type Out<'x, D>;
    |     ^^^^^^^^^^^^^^^-
@@ -65,7 +65,7 @@ LL |     type Out<'x, D>;
    = note: we are soliciting feedback, see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
 
 error: missing required bound on `Out`
-  --> $DIR/self-outlives-lint.rs:90:5
+  --> $DIR/self-outlives-lint.rs:92:5
    |
 LL |     type Out<'x, D>;
    |     ^^^^^^^^^^^^^^^-
@@ -76,7 +76,7 @@ LL |     type Out<'x, D>;
    = note: we are soliciting feedback, see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
 
 error: missing required bounds on `Bar`
-  --> $DIR/self-outlives-lint.rs:112:5
+  --> $DIR/self-outlives-lint.rs:114:5
    |
 LL |     type Bar<'b>;
    |     ^^^^^^^^^^^^-
@@ -87,7 +87,7 @@ LL |     type Bar<'b>;
    = note: we are soliciting feedback, see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
 
 error: missing required bound on `Bar`
-  --> $DIR/self-outlives-lint.rs:119:5
+  --> $DIR/self-outlives-lint.rs:122:5
    |
 LL |     type Bar<'b>;
    |     ^^^^^^^^^^^^-
@@ -98,7 +98,7 @@ LL |     type Bar<'b>;
    = note: we are soliciting feedback, see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
 
 error: missing required bound on `Bar`
-  --> $DIR/self-outlives-lint.rs:126:5
+  --> $DIR/self-outlives-lint.rs:129:5
    |
 LL |     type Bar<'b>;
    |     ^^^^^^^^^^^^-
@@ -109,7 +109,7 @@ LL |     type Bar<'b>;
    = note: we are soliciting feedback, see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
 
 error: missing required bound on `Item`
-  --> $DIR/self-outlives-lint.rs:139:5
+  --> $DIR/self-outlives-lint.rs:142:5
    |
 LL |     type Item<'a>;
    |     ^^^^^^^^^^^^^-
@@ -120,7 +120,7 @@ LL |     type Item<'a>;
    = note: we are soliciting feedback, see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
 
 error: missing required bound on `Iterator`
-  --> $DIR/self-outlives-lint.rs:141:5
+  --> $DIR/self-outlives-lint.rs:144:5
    |
 LL |     type Iterator<'a>: Iterator<Item = Self::Item<'a>>;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
@@ -131,7 +131,7 @@ LL |     type Iterator<'a>: Iterator<Item = Self::Item<'a>>;
    = note: we are soliciting feedback, see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
 
 error: missing required bound on `Item`
-  --> $DIR/self-outlives-lint.rs:147:5
+  --> $DIR/self-outlives-lint.rs:150:5
    |
 LL |     type Item<'a>;
    |     ^^^^^^^^^^^^^-
@@ -142,7 +142,7 @@ LL |     type Item<'a>;
    = note: we are soliciting feedback, see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
 
 error: missing required bound on `Bar`
-  --> $DIR/self-outlives-lint.rs:156:5
+  --> $DIR/self-outlives-lint.rs:159:5
    |
 LL |     type Bar<'a, 'b>;
    |     ^^^^^^^^^^^^^^^^-
@@ -153,7 +153,7 @@ LL |     type Bar<'a, 'b>;
    = note: we are soliciting feedback, see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
 
 error: missing required bound on `Fut`
-  --> $DIR/self-outlives-lint.rs:172:5
+  --> $DIR/self-outlives-lint.rs:175:5
    |
 LL |     type Fut<'out>;
    |     ^^^^^^^^^^^^^^-

--- a/src/test/ui/generic-associated-types/self-outlives-lint.stderr
+++ b/src/test/ui/generic-associated-types/self-outlives-lint.stderr
@@ -1,5 +1,5 @@
 error: missing required bound on `Item`
-  --> $DIR/self-outlives-lint.rs:9:5
+  --> $DIR/self-outlives-lint.rs:7:5
    |
 LL |     type Item<'x>;
    |     ^^^^^^^^^^^^^-
@@ -10,7 +10,7 @@ LL |     type Item<'x>;
    = note: we are soliciting feedback, see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
 
 error: missing required bound on `Out`
-  --> $DIR/self-outlives-lint.rs:25:5
+  --> $DIR/self-outlives-lint.rs:23:5
    |
 LL |     type Out<'x>;
    |     ^^^^^^^^^^^^-
@@ -21,7 +21,7 @@ LL |     type Out<'x>;
    = note: we are soliciting feedback, see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
 
 error: missing required bound on `Out`
-  --> $DIR/self-outlives-lint.rs:39:5
+  --> $DIR/self-outlives-lint.rs:37:5
    |
 LL |     type Out<'x>;
    |     ^^^^^^^^^^^^-
@@ -32,7 +32,7 @@ LL |     type Out<'x>;
    = note: we are soliciting feedback, see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
 
 error: missing required bounds on `Out`
-  --> $DIR/self-outlives-lint.rs:46:5
+  --> $DIR/self-outlives-lint.rs:44:5
    |
 LL |     type Out<'x, 'y>;
    |     ^^^^^^^^^^^^^^^^-
@@ -43,7 +43,7 @@ LL |     type Out<'x, 'y>;
    = note: we are soliciting feedback, see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
 
 error: missing required bound on `Out`
-  --> $DIR/self-outlives-lint.rs:61:5
+  --> $DIR/self-outlives-lint.rs:59:5
    |
 LL |     type Out<'x, D>;
    |     ^^^^^^^^^^^^^^^-
@@ -54,7 +54,7 @@ LL |     type Out<'x, D>;
    = note: we are soliciting feedback, see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
 
 error: missing required bound on `Out`
-  --> $DIR/self-outlives-lint.rs:77:5
+  --> $DIR/self-outlives-lint.rs:75:5
    |
 LL |     type Out<'x, D>;
    |     ^^^^^^^^^^^^^^^-
@@ -65,7 +65,7 @@ LL |     type Out<'x, D>;
    = note: we are soliciting feedback, see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
 
 error: missing required bound on `Out`
-  --> $DIR/self-outlives-lint.rs:92:5
+  --> $DIR/self-outlives-lint.rs:90:5
    |
 LL |     type Out<'x, D>;
    |     ^^^^^^^^^^^^^^^-
@@ -76,7 +76,7 @@ LL |     type Out<'x, D>;
    = note: we are soliciting feedback, see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
 
 error: missing required bounds on `Bar`
-  --> $DIR/self-outlives-lint.rs:114:5
+  --> $DIR/self-outlives-lint.rs:112:5
    |
 LL |     type Bar<'b>;
    |     ^^^^^^^^^^^^-
@@ -87,7 +87,7 @@ LL |     type Bar<'b>;
    = note: we are soliciting feedback, see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
 
 error: missing required bound on `Bar`
-  --> $DIR/self-outlives-lint.rs:122:5
+  --> $DIR/self-outlives-lint.rs:119:5
    |
 LL |     type Bar<'b>;
    |     ^^^^^^^^^^^^-
@@ -98,7 +98,7 @@ LL |     type Bar<'b>;
    = note: we are soliciting feedback, see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
 
 error: missing required bound on `Bar`
-  --> $DIR/self-outlives-lint.rs:129:5
+  --> $DIR/self-outlives-lint.rs:126:5
    |
 LL |     type Bar<'b>;
    |     ^^^^^^^^^^^^-
@@ -108,8 +108,19 @@ LL |     type Bar<'b>;
    = note: this bound is currently required to ensure that impls have maximum flexibility
    = note: we are soliciting feedback, see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
 
+error: missing required bound on `Item`
+  --> $DIR/self-outlives-lint.rs:139:5
+   |
+LL |     type Item<'a>;
+   |     ^^^^^^^^^^^^^-
+   |                  |
+   |                  help: add the required where clause: `where Self: 'a`
+   |
+   = note: this bound is currently required to ensure that impls have maximum flexibility
+   = note: we are soliciting feedback, see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
+
 error: missing required bound on `Iterator`
-  --> $DIR/self-outlives-lint.rs:143:5
+  --> $DIR/self-outlives-lint.rs:141:5
    |
 LL |     type Iterator<'a>: Iterator<Item = Self::Item<'a>>;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
@@ -119,8 +130,19 @@ LL |     type Iterator<'a>: Iterator<Item = Self::Item<'a>>;
    = note: this bound is currently required to ensure that impls have maximum flexibility
    = note: we are soliciting feedback, see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
 
+error: missing required bound on `Item`
+  --> $DIR/self-outlives-lint.rs:147:5
+   |
+LL |     type Item<'a>;
+   |     ^^^^^^^^^^^^^-
+   |                  |
+   |                  help: add the required where clause: `where Self: 'a`
+   |
+   = note: this bound is currently required to ensure that impls have maximum flexibility
+   = note: we are soliciting feedback, see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
+
 error: missing required bound on `Bar`
-  --> $DIR/self-outlives-lint.rs:151:5
+  --> $DIR/self-outlives-lint.rs:156:5
    |
 LL |     type Bar<'a, 'b>;
    |     ^^^^^^^^^^^^^^^^-
@@ -131,7 +153,7 @@ LL |     type Bar<'a, 'b>;
    = note: we are soliciting feedback, see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
 
 error: missing required bound on `Fut`
-  --> $DIR/self-outlives-lint.rs:167:5
+  --> $DIR/self-outlives-lint.rs:172:5
    |
 LL |     type Fut<'out>;
    |     ^^^^^^^^^^^^^^-
@@ -141,5 +163,5 @@ LL |     type Fut<'out>;
    = note: this bound is currently required to ensure that impls have maximum flexibility
    = note: we are soliciting feedback, see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
 
-error: aborting due to 13 previous errors
+error: aborting due to 15 previous errors
 


### PR DESCRIPTION
rework the GAT where check to use a fixed-point algorithm, and check all GATs in a trait at once

fixes #93278

r? @jackh726 
cc @nikomatsakis