### PR TITLE
(minor) sync changes in helper

### DIFF
--- a/compiler/rustc_ast/src/token.rs
+++ b/compiler/rustc_ast/src/token.rs
@@ -416,8 +416,10 @@ impl Token {
     pub fn can_begin_bound(&self) -> bool {
         self.is_path_start()
             || self.is_lifetime()
-            || self.is_keyword(kw::For)
+            || self == &Not
             || self == &Question
+            || self == &Tilde
+            || self.is_keyword(kw::For)
             || self == &OpenDelim(Paren)
     }
 


### PR DESCRIPTION
Added missing conditions to a helper, as a similar function in the parser states that they must be kept in sync:
https://github.com/rust-lang/rust/blob/b7cd0f786492aacf7426008cff48a25bc54b5f85/compiler/rustc_parse/src/parser/ty.rs#L651-L660

The changed helper is only ever called once in the codebase (547):

https://github.com/rust-lang/rust/blob/b7cd0f786492aacf7426008cff48a25bc54b5f85/compiler/rustc_parse/src/parser/ty.rs#L542-L549