### PR TITLE
Stabilize Termination and ExitCode

### DIFF
--- a/library/std/src/process.rs
+++ b/library/std/src/process.rs
@@ -1648,8 +1648,8 @@ impl crate::error::Error for ExitStatusError {}
 /// This type represents the status code the current process can return
 /// to its parent under normal termination.
 ///
-/// ExitCode is intended to be consumed only by the standard library (via
-/// `Termination::report()`), and intentionally does not provide accessors like
+/// `ExitCode` is intended to be consumed only by the standard library (via
+/// [`Termination::report()`]), and intentionally does not provide accessors like
 /// `PartialEq`, `Eq`, or `Hash`. Instead the standard library provides the
 /// canonical `SUCCESS` and `FAILURE` exit codes as well as `From<u8> for
 /// ExitCode` for constructing other arbitrary exit codes.
@@ -1673,13 +1673,31 @@ impl crate::error::Error for ExitStatusError {}
 /// compatibility differences and their expected usage; it is not generally
 /// possible to exactly reproduce an ExitStatus from a child for the current
 /// process after the fact.
+///
+/// # Examples
+///
+/// `ExitCode` can be returned from the `main` function of a crate, as it implements
+/// [`Termination`]:
+///
+/// ```
+/// use std::process::ExitCode;
+/// # fn check_foo() -> bool { true }
+///
+/// fn main() -> ExitCode {
+///     if !check_foo() {
+///         return ExitCode::from(42);
+///     }
+///
+///     ExitCode::SUCCESS
+/// }
+/// ```
 #[derive(Clone, Copy, Debug)]
 #[stable(feature = "process_exitcode", since = "1.60.0")]
 pub struct ExitCode(imp::ExitCode);
 
 #[stable(feature = "process_exitcode", since = "1.60.0")]
 impl ExitCode {
-    /// The canonical ExitCode for successful termination on this platform.
+    /// The canonical `ExitCode` for successful termination on this platform.
     ///
     /// Note that a `()`-returning `main` implicitly results in a successful
     /// termination, so there's no need to return this from `main` unless
@@ -1687,7 +1705,7 @@ impl ExitCode {
     #[stable(feature = "process_exitcode", since = "1.60.0")]
     pub const SUCCESS: ExitCode = ExitCode(imp::ExitCode::SUCCESS);
 
-    /// The canonical ExitCode for unsuccessful termination on this platform.
+    /// The canonical `ExitCode` for unsuccessful termination on this platform.
     ///
     /// If you're only returning this and `SUCCESS` from `main`, consider
     /// instead returning `Err(_)` and `Ok(())` respectively, which will
@@ -1697,19 +1715,20 @@ impl ExitCode {
 }
 
 impl ExitCode {
-    // This should not be stabilized when stabilizing ExitCode, we don't know that i32 will serve
+    // This is private/perma-unstable because ExitCode is opaque; we don't know that i32 will serve
     // all usecases, for example windows seems to use u32, unix uses the 8-15th bits of an i32, we
     // likely want to isolate users anything that could restrict the platform specific
     // representation of an ExitCode
     //
     // More info: https://internals.rust-lang.org/t/mini-pre-rfc-redesigning-process-exitstatus/5426
-    /// Convert an ExitCode into an i32
+    /// Convert an `ExitCode` into an i32
     #[unstable(
         feature = "process_exitcode_internals",
         reason = "exposed only for libstd",
         issue = "none"
     )]
     #[inline]
+    #[doc(hidden)]
     pub fn to_i32(self) -> i32 {
         self.0.as_i32()
     }
@@ -1717,7 +1736,7 @@ impl ExitCode {
 
 #[stable(feature = "process_exitcode", since = "1.60.0")]
 impl From<u8> for ExitCode {
-    /// Construct an exit code from an arbitrary u8 value.
+    /// Construct an `ExitCode` from an arbitrary u8 value.
     fn from(code: u8) -> Self {
         ExitCode(imp::ExitCode::from(code))
     }

--- a/library/test/src/lib.rs
+++ b/library/test/src/lib.rs
@@ -19,8 +19,7 @@
 #![feature(bench_black_box)]
 #![feature(internal_output_capture)]
 #![feature(staged_api)]
-#![feature(termination_trait_lib)]
-#![feature(process_exitcode_placeholder)]
+#![feature(process_exitcode_internals)]
 #![feature(test)]
 #![feature(total_cmp)]
 

--- a/src/test/ui/rfcs/rfc-1937-termination-trait/termination-trait-for-exitcode.rs
+++ b/src/test/ui/rfcs/rfc-1937-termination-trait/termination-trait-for-exitcode.rs
@@ -1,5 +1,4 @@
 // run-pass
-#![feature(process_exitcode_placeholder)]
 
 use std::process::ExitCode;
 

--- a/src/test/ui/rfcs/rfc-1937-termination-trait/termination-trait-for-impl-termination.rs
+++ b/src/test/ui/rfcs/rfc-1937-termination-trait/termination-trait-for-impl-termination.rs
@@ -1,4 +1,3 @@
 // run-pass
-#![feature(termination_trait_lib)]
 
 fn main() -> impl std::process::Termination { }


### PR DESCRIPTION
From https://github.com/rust-lang/rust/issues/43301

This PR stabilizes the Termination trait and associated ExitCode type. It also adjusts the ExitCode feature flag to replace the placeholder flag with a more permanent name, as well as splitting off the `to_i32` method behind its own permanently unstable feature flag.

This PR stabilizes the termination trait with the following signature:

```rust
pub trait Termination {
    fn report(self) -> ExitCode;
}
```

The existing impls of `Termination` are effectively already stable due to the prior stabilization of `?` in main.

This PR also stabilizes the following APIs on exit code

```rust
#[derive(Clone, Copy, Debug)]
pub struct ExitCode(_);

impl ExitCode {
    pub const SUCCESS: ExitCode;
    pub const FAILURE: ExitCode;
}

impl From<u8> for ExitCode { /* ... */ }
```

---

All of the previous blockers have been resolved. The main ones that were resolved recently are:

* The trait's name: We decided against changing this since none of the alternatives seemed particularly compelling. Instead we decided to end the bikeshedding and stick with the current name. ([link to the discussion](https://rust-lang.zulipchat.com/#narrow/stream/219381-t-libs/topic/Termination.2FExit.20Status.20Stabilization/near/269793887))
* Issues around platform specific representations: We resolved this issue by changing the return type of `report` from `i32` to the opaque type `ExitCode`. That way we can change the underlying representation without affecting the API, letting us offer full support for platform specific exit code APIs in the future.
* Custom exit codes: We resolved this by adding `From<u8> for ExitCode`. We choose to only support u8 initially because it is the least common denominator between the sets of exit codes supported by our current platforms. In the future we anticipate adding platform specific extension traits to ExitCode for constructors from larger or negative numbers, as needed.