### PR TITLE
Update rls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3202,13 +3202,14 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "toml",
+ "toml_edit",
  "url 2.2.2",
  "walkdir",
 ]
 
 [[package]]
 name = "rls-analysis"
-version = "0.18.2"
+version = "0.18.3"
 dependencies = [
  "derive-new",
  "env_logger 0.9.0",


### PR DESCRIPTION
2 commits in f37425e33c864c697af06df66e7473444605c149..3df74381f37617ec800537c11fb0c3130f5f3616
2022-01-15 18:07:20 +0100 to 2022-02-10 07:33:33 -0800
- chore: Upgrade cargo (rust-lang/rls#1764)
- Bump rls-analysis version