### PR TITLE
Fix incorrect register conflict detection in asm!

### DIFF
--- a/compiler/rustc_ast_lowering/src/asm.rs
+++ b/compiler/rustc_ast_lowering/src/asm.rs
@@ -373,7 +373,9 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                                     err.emit();
                                 }
                                 Entry::Vacant(v) => {
-                                    v.insert(idx);
+                                    if r == reg {
+                                        v.insert(idx);
+                                    }
                                 }
                             }
                         };

--- a/src/test/ui/asm/reg-conflict.rs
+++ b/src/test/ui/asm/reg-conflict.rs
@@ -1,0 +1,20 @@
+// compile-flags: --target armv7-unknown-linux-gnueabihf
+// needs-llvm-components: arm
+
+#![feature(no_core, lang_items, rustc_attrs)]
+#![no_core]
+
+#[rustc_builtin_macro]
+macro_rules! asm {
+    () => {};
+}
+#[lang = "sized"]
+trait Sized {}
+
+fn main() {
+    unsafe {
+        asm!("", out("d0") _, out("d1") _);
+        asm!("", out("d0") _, out("s1") _);
+        //~^ ERROR register `s1` conflicts with register `d0`
+    }
+}

--- a/src/test/ui/asm/reg-conflict.stderr
+++ b/src/test/ui/asm/reg-conflict.stderr
@@ -1,0 +1,10 @@
+error: register `s1` conflicts with register `d0`
+  --> $DIR/reg-conflict.rs:17:31
+   |
+LL |         asm!("", out("d0") _, out("s1") _);
+   |                  -----------  ^^^^^^^^^^^ register `s1`
+   |                  |
+   |                  register `d0`
+
+error: aborting due to previous error
+


### PR DESCRIPTION
This would previously incorrectly reject two subregisters that were
distinct but part of the same larger register, for example `al` and
`ah`.