### PR TITLE
Change `AsFd::as_fd` etc. from `&self` to `self`.

### DIFF
--- a/library/std/src/os/fd/owned.rs
+++ b/library/std/src/os/fd/owned.rs
@@ -177,7 +177,7 @@ impl fmt::Debug for OwnedFd {
 /// call the method. Windows platforms have a corresponding `AsHandle` and
 /// `AsSocket` set of traits.
 #[unstable(feature = "io_safety", issue = "87074")]
-pub trait AsFd {
+pub trait AsFd<'a> {
     /// Borrows the file descriptor.
     ///
     /// # Example
@@ -197,21 +197,21 @@ pub trait AsFd {
     /// # Ok::<(), io::Error>(())
     /// ```
     #[unstable(feature = "io_safety", issue = "87074")]
-    fn as_fd(&self) -> BorrowedFd<'_>;
+    fn as_fd(self) -> BorrowedFd<'a>;
 }
 
 #[unstable(feature = "io_safety", issue = "87074")]
-impl AsFd for BorrowedFd<'_> {
+impl<'a> AsFd<'a> for &'a BorrowedFd<'_> {
     #[inline]
-    fn as_fd(&self) -> BorrowedFd<'_> {
+    fn as_fd(self) -> BorrowedFd<'a> {
         *self
     }
 }
 
 #[unstable(feature = "io_safety", issue = "87074")]
-impl AsFd for OwnedFd {
+impl<'a> AsFd<'a> for &'a OwnedFd {
     #[inline]
-    fn as_fd(&self) -> BorrowedFd<'_> {
+    fn as_fd(self) -> BorrowedFd<'a> {
         // Safety: `OwnedFd` and `BorrowedFd` have the same validity
         // invariants, and the `BorrowdFd` is bounded by the lifetime
         // of `&self`.
@@ -220,9 +220,9 @@ impl AsFd for OwnedFd {
 }
 
 #[unstable(feature = "io_safety", issue = "87074")]
-impl AsFd for fs::File {
+impl<'a> AsFd<'a> for &'a fs::File {
     #[inline]
-    fn as_fd(&self) -> BorrowedFd<'_> {
+    fn as_fd(self) -> BorrowedFd<'a> {
         self.as_inner().as_fd()
     }
 }
@@ -244,9 +244,9 @@ impl From<OwnedFd> for fs::File {
 }
 
 #[unstable(feature = "io_safety", issue = "87074")]
-impl AsFd for crate::net::TcpStream {
+impl<'a> AsFd<'a> for &'a crate::net::TcpStream {
     #[inline]
-    fn as_fd(&self) -> BorrowedFd<'_> {
+    fn as_fd(self) -> BorrowedFd<'a> {
         self.as_inner().socket().as_fd()
     }
 }
@@ -270,9 +270,9 @@ impl From<OwnedFd> for crate::net::TcpStream {
 }
 
 #[unstable(feature = "io_safety", issue = "87074")]
-impl AsFd for crate::net::TcpListener {
+impl<'a> AsFd<'a> for &'a crate::net::TcpListener {
     #[inline]
-    fn as_fd(&self) -> BorrowedFd<'_> {
+    fn as_fd(self) -> BorrowedFd<'a> {
         self.as_inner().socket().as_fd()
     }
 }
@@ -296,9 +296,9 @@ impl From<OwnedFd> for crate::net::TcpListener {
 }
 
 #[unstable(feature = "io_safety", issue = "87074")]
-impl AsFd for crate::net::UdpSocket {
+impl<'a> AsFd<'a> for &'a crate::net::UdpSocket {
     #[inline]
-    fn as_fd(&self) -> BorrowedFd<'_> {
+    fn as_fd(self) -> BorrowedFd<'a> {
         self.as_inner().socket().as_fd()
     }
 }

--- a/library/std/src/os/linux/process.rs
+++ b/library/std/src/os/linux/process.rs
@@ -87,8 +87,8 @@ impl IntoRawFd for PidFd {
     }
 }
 
-impl AsFd for PidFd {
-    fn as_fd(&self) -> BorrowedFd<'_> {
+impl<'a> AsFd<'a> for &'a PidFd {
+    fn as_fd(self) -> BorrowedFd<'a> {
         self.as_inner().as_fd()
     }
 }

--- a/library/std/src/os/unix/fs.rs
+++ b/library/std/src/os/unix/fs.rs
@@ -966,12 +966,12 @@ pub fn chown<P: AsRef<Path>>(dir: P, uid: Option<u32>, gid: Option<u32>) -> io::
 ///
 /// fn main() -> std::io::Result<()> {
 ///     let f = std::fs::File::open("/file")?;
-///     fs::fchown(f, Some(0), Some(0))?;
+///     fs::fchown(&f, Some(0), Some(0))?;
 ///     Ok(())
 /// }
 /// ```
 #[unstable(feature = "unix_chown", issue = "88989")]
-pub fn fchown<F: AsFd>(fd: F, uid: Option<u32>, gid: Option<u32>) -> io::Result<()> {
+pub fn fchown<'a, F: AsFd<'a>>(fd: F, uid: Option<u32>, gid: Option<u32>) -> io::Result<()> {
     sys::fs::fchown(fd.as_fd().as_raw_fd(), uid.unwrap_or(u32::MAX), gid.unwrap_or(u32::MAX))
 }
 

--- a/library/std/src/os/unix/net/datagram.rs
+++ b/library/std/src/os/unix/net/datagram.rs
@@ -1008,9 +1008,9 @@ impl IntoRawFd for UnixDatagram {
 }
 
 #[unstable(feature = "io_safety", issue = "87074")]
-impl AsFd for UnixDatagram {
+impl<'a> AsFd<'a> for &'a UnixDatagram {
     #[inline]
-    fn as_fd(&self) -> BorrowedFd<'_> {
+    fn as_fd(self) -> BorrowedFd<'a> {
         self.0.as_inner().as_fd()
     }
 }

--- a/library/std/src/os/unix/net/listener.rs
+++ b/library/std/src/os/unix/net/listener.rs
@@ -301,9 +301,9 @@ impl IntoRawFd for UnixListener {
 }
 
 #[unstable(feature = "io_safety", issue = "87074")]
-impl AsFd for UnixListener {
+impl<'a> AsFd<'a> for &'a UnixListener {
     #[inline]
-    fn as_fd(&self) -> BorrowedFd<'_> {
+    fn as_fd(self) -> BorrowedFd<'a> {
         self.0.as_inner().as_fd()
     }
 }

--- a/library/std/src/os/unix/net/stream.rs
+++ b/library/std/src/os/unix/net/stream.rs
@@ -707,9 +707,9 @@ impl IntoRawFd for UnixStream {
 }
 
 #[unstable(feature = "io_safety", issue = "87074")]
-impl AsFd for UnixStream {
+impl<'a> AsFd<'a> for &'a UnixStream {
     #[inline]
-    fn as_fd(&self) -> BorrowedFd<'_> {
+    fn as_fd(self) -> BorrowedFd<'a> {
         self.0.as_fd()
     }
 }

--- a/library/std/src/os/unix/process.rs
+++ b/library/std/src/os/unix/process.rs
@@ -388,9 +388,9 @@ impl IntoRawFd for process::ChildStderr {
 }
 
 #[unstable(feature = "io_safety", issue = "87074")]
-impl AsFd for crate::process::ChildStdin {
+impl<'a> AsFd<'a> for &'a crate::process::ChildStdin {
     #[inline]
-    fn as_fd(&self) -> BorrowedFd<'_> {
+    fn as_fd(self) -> BorrowedFd<'a> {
         self.as_inner().as_fd()
     }
 }
@@ -404,9 +404,9 @@ impl From<crate::process::ChildStdin> for OwnedFd {
 }
 
 #[unstable(feature = "io_safety", issue = "87074")]
-impl AsFd for crate::process::ChildStdout {
+impl<'a> AsFd<'a> for &'a crate::process::ChildStdout {
     #[inline]
-    fn as_fd(&self) -> BorrowedFd<'_> {
+    fn as_fd(self) -> BorrowedFd<'a> {
         self.as_inner().as_fd()
     }
 }
@@ -420,9 +420,9 @@ impl From<crate::process::ChildStdout> for OwnedFd {
 }
 
 #[unstable(feature = "io_safety", issue = "87074")]
-impl AsFd for crate::process::ChildStderr {
+impl<'a> AsFd<'a> for &'a crate::process::ChildStderr {
     #[inline]
-    fn as_fd(&self) -> BorrowedFd<'_> {
+    fn as_fd(self) -> BorrowedFd<'a> {
         self.as_inner().as_fd()
     }
 }

--- a/library/std/src/os/windows/io/handle.rs
+++ b/library/std/src/os/windows/io/handle.rs
@@ -298,7 +298,7 @@ impl fmt::Debug for OwnedHandle {
 
 /// A trait to borrow the handle from an underlying object.
 #[unstable(feature = "io_safety", issue = "87074")]
-pub trait AsHandle {
+pub trait AsHandle<'a> {
     /// Borrows the handle.
     ///
     /// # Example
@@ -313,19 +313,19 @@ pub trait AsHandle {
     /// let borrowed_handle: BorrowedHandle<'_> = f.as_handle();
     /// # Ok::<(), io::Error>(())
     /// ```
-    fn as_handle(&self) -> BorrowedHandle<'_>;
+    fn as_handle(self) -> BorrowedHandle<'a>;
 }
 
-impl AsHandle for BorrowedHandle<'_> {
+impl<'a> AsHandle<'a> for &'a BorrowedHandle<'_> {
     #[inline]
-    fn as_handle(&self) -> BorrowedHandle<'_> {
+    fn as_handle(self) -> BorrowedHandle<'a> {
         *self
     }
 }
 
-impl AsHandle for OwnedHandle {
+impl<'a> AsHandle<'a> for &'a OwnedHandle {
     #[inline]
-    fn as_handle(&self) -> BorrowedHandle<'_> {
+    fn as_handle(self) -> BorrowedHandle<'a> {
         // Safety: `OwnedHandle` and `BorrowedHandle` have the same validity
         // invariants, and the `BorrowdHandle` is bounded by the lifetime
         // of `&self`.
@@ -333,9 +333,9 @@ impl AsHandle for OwnedHandle {
     }
 }
 
-impl AsHandle for fs::File {
+impl<'a> AsHandle<'a> for &'a fs::File {
     #[inline]
-    fn as_handle(&self) -> BorrowedHandle<'_> {
+    fn as_handle(self) -> BorrowedHandle<'a> {
         self.as_inner().as_handle()
     }
 }
@@ -354,51 +354,51 @@ impl From<OwnedHandle> for fs::File {
     }
 }
 
-impl AsHandle for crate::io::Stdin {
+impl<'a> AsHandle<'a> for &'a crate::io::Stdin {
     #[inline]
-    fn as_handle(&self) -> BorrowedHandle<'_> {
+    fn as_handle(self) -> BorrowedHandle<'a> {
         unsafe { BorrowedHandle::borrow_raw_handle(self.as_raw_handle()) }
     }
 }
 
-impl<'a> AsHandle for crate::io::StdinLock<'a> {
+impl<'a, 'b> AsHandle<'a> for &'a crate::io::StdinLock<'b> {
     #[inline]
-    fn as_handle(&self) -> BorrowedHandle<'_> {
+    fn as_handle(self) -> BorrowedHandle<'a> {
         unsafe { BorrowedHandle::borrow_raw_handle(self.as_raw_handle()) }
     }
 }
 
-impl AsHandle for crate::io::Stdout {
+impl<'a> AsHandle<'a> for &'a crate::io::Stdout {
     #[inline]
-    fn as_handle(&self) -> BorrowedHandle<'_> {
+    fn as_handle(self) -> BorrowedHandle<'a> {
         unsafe { BorrowedHandle::borrow_raw_handle(self.as_raw_handle()) }
     }
 }
 
-impl<'a> AsHandle for crate::io::StdoutLock<'a> {
+impl<'a, 'b> AsHandle<'a> for &'a crate::io::StdoutLock<'b> {
     #[inline]
-    fn as_handle(&self) -> BorrowedHandle<'_> {
+    fn as_handle(self) -> BorrowedHandle<'a> {
         unsafe { BorrowedHandle::borrow_raw_handle(self.as_raw_handle()) }
     }
 }
 
-impl AsHandle for crate::io::Stderr {
+impl<'a> AsHandle<'a> for &'a crate::io::Stderr {
     #[inline]
-    fn as_handle(&self) -> BorrowedHandle<'_> {
+    fn as_handle(self) -> BorrowedHandle<'a> {
         unsafe { BorrowedHandle::borrow_raw_handle(self.as_raw_handle()) }
     }
 }
 
-impl<'a> AsHandle for crate::io::StderrLock<'a> {
+impl<'a, 'b> AsHandle<'a> for &'a crate::io::StderrLock<'b> {
     #[inline]
-    fn as_handle(&self) -> BorrowedHandle<'_> {
+    fn as_handle(self) -> BorrowedHandle<'a> {
         unsafe { BorrowedHandle::borrow_raw_handle(self.as_raw_handle()) }
     }
 }
 
-impl AsHandle for crate::process::ChildStdin {
+impl<'a> AsHandle<'a> for &'a crate::process::ChildStdin {
     #[inline]
-    fn as_handle(&self) -> BorrowedHandle<'_> {
+    fn as_handle(self) -> BorrowedHandle<'a> {
         unsafe { BorrowedHandle::borrow_raw_handle(self.as_raw_handle()) }
     }
 }
@@ -410,9 +410,9 @@ impl From<crate::process::ChildStdin> for OwnedHandle {
     }
 }
 
-impl AsHandle for crate::process::ChildStdout {
+impl<'a> AsHandle<'a> for &'a crate::process::ChildStdout {
     #[inline]
-    fn as_handle(&self) -> BorrowedHandle<'_> {
+    fn as_handle(self) -> BorrowedHandle<'a> {
         unsafe { BorrowedHandle::borrow_raw_handle(self.as_raw_handle()) }
     }
 }
@@ -424,9 +424,9 @@ impl From<crate::process::ChildStdout> for OwnedHandle {
     }
 }
 
-impl AsHandle for crate::process::ChildStderr {
+impl<'a> AsHandle<'a> for &'a crate::process::ChildStderr {
     #[inline]
-    fn as_handle(&self) -> BorrowedHandle<'_> {
+    fn as_handle(self) -> BorrowedHandle<'a> {
         unsafe { BorrowedHandle::borrow_raw_handle(self.as_raw_handle()) }
     }
 }
@@ -438,9 +438,9 @@ impl From<crate::process::ChildStderr> for OwnedHandle {
     }
 }
 
-impl<T> AsHandle for crate::thread::JoinHandle<T> {
+impl<'a, T> AsHandle<'a> for &'a crate::thread::JoinHandle<T> {
     #[inline]
-    fn as_handle(&self) -> BorrowedHandle<'_> {
+    fn as_handle(self) -> BorrowedHandle<'a> {
         unsafe { BorrowedHandle::borrow_raw_handle(self.as_raw_handle()) }
     }
 }

--- a/library/std/src/os/windows/io/socket.rs
+++ b/library/std/src/os/windows/io/socket.rs
@@ -205,21 +205,21 @@ impl fmt::Debug for OwnedSocket {
 
 /// A trait to borrow the socket from an underlying object.
 #[unstable(feature = "io_safety", issue = "87074")]
-pub trait AsSocket {
+pub trait AsSocket<'a> {
     /// Borrows the socket.
-    fn as_socket(&self) -> BorrowedSocket<'_>;
+    fn as_socket(self) -> BorrowedSocket<'a>;
 }
 
-impl AsSocket for BorrowedSocket<'_> {
+impl<'a> AsSocket<'a> for &'a BorrowedSocket<'_> {
     #[inline]
-    fn as_socket(&self) -> BorrowedSocket<'_> {
+    fn as_socket(self) -> BorrowedSocket<'a> {
         *self
     }
 }
 
-impl AsSocket for OwnedSocket {
+impl<'a> AsSocket<'a> for &'a OwnedSocket {
     #[inline]
-    fn as_socket(&self) -> BorrowedSocket<'_> {
+    fn as_socket(self) -> BorrowedSocket<'a> {
         // Safety: `OwnedSocket` and `BorrowedSocket` have the same validity
         // invariants, and the `BorrowdSocket` is bounded by the lifetime
         // of `&self`.
@@ -227,9 +227,9 @@ impl AsSocket for OwnedSocket {
     }
 }
 
-impl AsSocket for crate::net::TcpStream {
+impl<'a> AsSocket<'a> for &'a crate::net::TcpStream {
     #[inline]
-    fn as_socket(&self) -> BorrowedSocket<'_> {
+    fn as_socket(self) -> BorrowedSocket<'a> {
         unsafe { BorrowedSocket::borrow_raw_socket(self.as_raw_socket()) }
     }
 }
@@ -248,9 +248,9 @@ impl From<OwnedSocket> for crate::net::TcpStream {
     }
 }
 
-impl AsSocket for crate::net::TcpListener {
+impl<'a> AsSocket<'a> for &'a crate::net::TcpListener {
     #[inline]
-    fn as_socket(&self) -> BorrowedSocket<'_> {
+    fn as_socket(self) -> BorrowedSocket<'a> {
         unsafe { BorrowedSocket::borrow_raw_socket(self.as_raw_socket()) }
     }
 }
@@ -269,9 +269,9 @@ impl From<OwnedSocket> for crate::net::TcpListener {
     }
 }
 
-impl AsSocket for crate::net::UdpSocket {
+impl<'a> AsSocket<'a> for &'a crate::net::UdpSocket {
     #[inline]
-    fn as_socket(&self) -> BorrowedSocket<'_> {
+    fn as_socket(self) -> BorrowedSocket<'a> {
         unsafe { BorrowedSocket::borrow_raw_socket(self.as_raw_socket()) }
     }
 }

--- a/library/std/src/os/windows/process.rs
+++ b/library/std/src/os/windows/process.rs
@@ -40,9 +40,9 @@ impl AsRawHandle for process::Child {
 }
 
 #[unstable(feature = "io_safety", issue = "87074")]
-impl AsHandle for process::Child {
+impl<'a> AsHandle<'a> for &'a process::Child {
     #[inline]
-    fn as_handle(&self) -> BorrowedHandle<'_> {
+    fn as_handle(self) -> BorrowedHandle<'a> {
         self.as_inner().handle().as_handle()
     }
 }

--- a/library/std/src/sys/unix/fd.rs
+++ b/library/std/src/sys/unix/fd.rs
@@ -289,8 +289,8 @@ impl FromInner<OwnedFd> for FileDesc {
     }
 }
 
-impl AsFd for FileDesc {
-    fn as_fd(&self) -> BorrowedFd<'_> {
+impl<'a> AsFd<'a> for &'a FileDesc {
+    fn as_fd(self) -> BorrowedFd<'a> {
         self.0.as_fd()
     }
 }

--- a/library/std/src/sys/unix/fs.rs
+++ b/library/std/src/sys/unix/fs.rs
@@ -983,13 +983,15 @@ impl FromInner<FileDesc> for File {
     }
 }
 
-impl AsFd for File {
-    fn as_fd(&self) -> BorrowedFd<'_> {
+impl File {
+    pub fn as_fd(&self) -> BorrowedFd<'_> {
         self.0.as_fd()
     }
 }
 
 impl AsRawFd for File {
+    /// Similar to `AsFd::as_fd`, but doesn't require `File` to have
+    /// stability attributes.
     fn as_raw_fd(&self) -> RawFd {
         self.0.as_raw_fd()
     }

--- a/library/std/src/sys/unix/net.rs
+++ b/library/std/src/sys/unix/net.rs
@@ -461,13 +461,15 @@ impl FromInner<FileDesc> for Socket {
     }
 }
 
-impl AsFd for Socket {
-    fn as_fd(&self) -> BorrowedFd<'_> {
+impl Socket {
+    pub fn as_fd(&self) -> BorrowedFd<'_> {
         self.0.as_fd()
     }
 }
 
 impl AsRawFd for Socket {
+    /// Similar to `AsFd::as_fd`, but doesn't require `Socket` to have
+    /// stability attributes.
     fn as_raw_fd(&self) -> RawFd {
         self.0.as_raw_fd()
     }

--- a/library/std/src/sys/unix/pipe.rs
+++ b/library/std/src/sys/unix/pipe.rs
@@ -132,8 +132,10 @@ impl AsRawFd for AnonPipe {
     }
 }
 
-impl AsFd for AnonPipe {
-    fn as_fd(&self) -> BorrowedFd<'_> {
+impl AnonPipe {
+    /// Similar to `AsFd::as_fd`, but doesn't require `AnonPipe` to have
+    /// stability attributes.
+    pub fn as_fd(&self) -> BorrowedFd<'_> {
         self.0.as_fd()
     }
 }

--- a/library/std/src/sys/unix/stdio.rs
+++ b/library/std/src/sys/unix/stdio.rs
@@ -93,49 +93,49 @@ pub fn panic_output() -> Option<impl io::Write> {
 }
 
 #[unstable(feature = "io_safety", issue = "87074")]
-impl AsFd for io::Stdin {
+impl<'a> AsFd<'a> for &'a io::Stdin {
     #[inline]
-    fn as_fd(&self) -> BorrowedFd<'_> {
+    fn as_fd(self) -> BorrowedFd<'a> {
         unsafe { BorrowedFd::borrow_raw_fd(libc::STDIN_FILENO) }
     }
 }
 
 #[unstable(feature = "io_safety", issue = "87074")]
-impl<'a> AsFd for io::StdinLock<'a> {
+impl<'a, 'b> AsFd<'a> for io::StdinLock<'b> {
     #[inline]
-    fn as_fd(&self) -> BorrowedFd<'_> {
+    fn as_fd(self) -> BorrowedFd<'a> {
         unsafe { BorrowedFd::borrow_raw_fd(libc::STDIN_FILENO) }
     }
 }
 
 #[unstable(feature = "io_safety", issue = "87074")]
-impl AsFd for io::Stdout {
+impl<'a> AsFd<'a> for &'a io::Stdout {
     #[inline]
-    fn as_fd(&self) -> BorrowedFd<'_> {
+    fn as_fd(self) -> BorrowedFd<'a> {
         unsafe { BorrowedFd::borrow_raw_fd(libc::STDOUT_FILENO) }
     }
 }
 
 #[unstable(feature = "io_safety", issue = "87074")]
-impl<'a> AsFd for io::StdoutLock<'a> {
+impl<'a, 'b> AsFd<'a> for &'a io::StdoutLock<'b> {
     #[inline]
-    fn as_fd(&self) -> BorrowedFd<'_> {
+    fn as_fd(self) -> BorrowedFd<'a> {
         unsafe { BorrowedFd::borrow_raw_fd(libc::STDOUT_FILENO) }
     }
 }
 
 #[unstable(feature = "io_safety", issue = "87074")]
-impl AsFd for io::Stderr {
+impl<'a> AsFd<'a> for &'a io::Stderr {
     #[inline]
-    fn as_fd(&self) -> BorrowedFd<'_> {
+    fn as_fd(self) -> BorrowedFd<'a> {
         unsafe { BorrowedFd::borrow_raw_fd(libc::STDERR_FILENO) }
     }
 }
 
 #[unstable(feature = "io_safety", issue = "87074")]
-impl<'a> AsFd for io::StderrLock<'a> {
+impl<'a, 'b> AsFd<'a> for &'a io::StderrLock<'b> {
     #[inline]
-    fn as_fd(&self) -> BorrowedFd<'_> {
+    fn as_fd(self) -> BorrowedFd<'a> {
         unsafe { BorrowedFd::borrow_raw_fd(libc::STDERR_FILENO) }
     }
 }

--- a/library/std/src/sys/wasi/fd.rs
+++ b/library/std/src/sys/wasi/fd.rs
@@ -282,8 +282,8 @@ impl FromInner<OwnedFd> for WasiFd {
     }
 }
 
-impl AsFd for WasiFd {
-    fn as_fd(&self) -> BorrowedFd<'_> {
+impl<'a> AsFd<'a> for &'a WasiFd {
+    fn as_fd(self) -> BorrowedFd<'a> {
         self.fd.as_fd()
     }
 }

--- a/library/std/src/sys/wasi/fs.rs
+++ b/library/std/src/sys/wasi/fs.rs
@@ -482,8 +482,8 @@ impl FromInner<WasiFd> for File {
     }
 }
 
-impl AsFd for File {
-    fn as_fd(&self) -> BorrowedFd<'_> {
+impl<'a> AsFd<'a> for &'a File {
+    fn as_fd(self) -> BorrowedFd<'a> {
         self.fd.as_fd()
     }
 }

--- a/library/std/src/sys/wasi/net.rs
+++ b/library/std/src/sys/wasi/net.rs
@@ -35,8 +35,8 @@ impl FromInner<WasiFd> for Socket {
     }
 }
 
-impl AsFd for Socket {
-    fn as_fd(&self) -> BorrowedFd<'_> {
+impl<'a> AsFd<'a> for &'a Socket {
+    fn as_fd(self) -> BorrowedFd<'a> {
         self.0.as_fd()
     }
 }

--- a/library/std/src/sys/windows/fs.rs
+++ b/library/std/src/sys/windows/fs.rs
@@ -784,8 +784,8 @@ impl FromInner<Handle> for File {
     }
 }
 
-impl AsHandle for File {
-    fn as_handle(&self) -> BorrowedHandle<'_> {
+impl<'a> AsHandle<'a> for &'a File {
+    fn as_handle(self) -> BorrowedHandle<'a> {
         self.as_inner().as_handle()
     }
 }

--- a/library/std/src/sys/windows/fs.rs
+++ b/library/std/src/sys/windows/fs.rs
@@ -784,8 +784,10 @@ impl FromInner<Handle> for File {
     }
 }
 
-impl<'a> AsHandle<'a> for &'a File {
-    fn as_handle(self) -> BorrowedHandle<'a> {
+impl File {
+    /// Similar to `AsHandle::as_handle`, but doesn't require `File` to have
+    /// stability attributes.
+    pub fn as_handle(&self) -> BorrowedHandle<'_> {
         self.as_inner().as_handle()
     }
 }

--- a/library/std/src/sys/windows/handle.rs
+++ b/library/std/src/sys/windows/handle.rs
@@ -48,8 +48,8 @@ impl FromInner<OwnedHandle> for Handle {
     }
 }
 
-impl AsHandle for Handle {
-    fn as_handle(&self) -> BorrowedHandle<'_> {
+impl<'a> AsHandle<'a> for &'a Handle {
+    fn as_handle(self) -> BorrowedHandle<'a> {
         self.0.as_handle()
     }
 }

--- a/library/std/src/sys/windows/net.rs
+++ b/library/std/src/sys/windows/net.rs
@@ -451,8 +451,8 @@ impl IntoInner<OwnedSocket> for Socket {
     }
 }
 
-impl AsSocket for Socket {
-    fn as_socket(&self) -> BorrowedSocket<'_> {
+impl<'a> AsSocket<'a> for &'a Socket {
+    fn as_socket(self) -> BorrowedSocket<'a> {
         self.0.as_socket()
     }
 }


### PR DESCRIPTION
Change the `AsFd` trait from:

```rust
trait AsFd {
    fn as_fd(&self) -> BorrowedFd<'_>;
}
```

to:

```rust
trait AsFd<'a> {
    fn as_fd(self) -> BorrowedFd<'a>;
}
```

and similar for `AsHandle` and `AsSocket`. Instead of implementing `AsFd`
for `OwnedFd` etc., it's now implemented for `&'a OwnedFd` etc.

This means that implementing `AsFd` changes from:

```rust
impl AsFd for MyType {
   fn as_fd(&self) -> BorrowedFd<'_> {
      ...
   }
}
```

to:

```rust
impl<'a> AsFd<'a> for &'a MyType {
   fn as_fd(self) -> BorrowedFd<'a> {
      ...
   }
}
```

Defining a function that uses an `AsFd` changes from:

```rust
fn frob<Fd: AsFd>(fd: &Fd)
```

to:

```rust
fn frob<'a, Fd: AsFd<'a>>(fd: Fd)
```

It also means that users of such functions can pass a `BorrowedFd` to them
directly, instead of having to write an extra `&` to conceptually add an
extra borrow around `BorrowedFd`.

In total, it means somewhat more typing for implementors of the traits and
implementors of functions that take `AsFd` parameters. But it also
avoids a common confusion, and allows users to have fewer `&`s. And, it
means fewer "reference to reference"-like situations.

As an example of this in practice, the new unstable `fchown` function in std
is [already taking an `AsFd` by value instead of by reference]. As
written, it can't be passed a `&File`, and passing it a `File` consumes
and closes the file. With this PR, it accepts `&File` and never consumes
anything.

One subtle detail is that the Unix internal `File`, `Socket`, and
`AnonPipe` types need to stop implementing `AsFd`, so that they don't
require stability attributes which are otherwise apparently required.
Since these are internal types, this doesn't affect the public API.
There are comments in the code for these.

Another subtle detail is that with the convention of types implementing
`AsFd` for `&'a T`, they don't implement it for `&'a mut T`. For example,
with the `frob` function above, `frob(&mut file)` gets this error:

```
error[E0277]: the trait bound `&mut File: AsFd<'_>` is not satisfied
```

One needs to use `frob(&file)` instead. If one has a `mut T`, it's just
a matter of typing `&` instead of `&mut`, but if one has a `&mut T`, one
needs to use `&*`. This is a little awkward, however the only alternative
I know about is to oblige all types that implement `AsFd<'a>` for `&'a T`
to also implement `AsFd<'a>` for `&'a mut T`, which seems worse.

[already taking an `AsFd` by value instead of by reference]: https://github.com/rust-lang/rust/blob/734368a200904ef9c21db86c595dc04263c87be0/library/std/src/os/unix/fs.rs#L974