### PR TITLE
Only mark projection as ambiguous if GAT substs are constrained

### DIFF
--- a/compiler/rustc_infer/src/infer/type_variable.rs
+++ b/compiler/rustc_infer/src/infer/type_variable.rs
@@ -259,7 +259,7 @@ impl<'tcx> TypeVariableTable<'_, 'tcx> {
         let index = self.values().push(TypeVariableData { origin });
         assert_eq!(eq_key.vid.as_u32(), index as u32);
 
-        debug!("new_var(index={:?}, universe={:?}, origin={:?}", eq_key.vid, universe, origin,);
+        debug!("new_var(index={:?}, universe={:?}, origin={:?})", eq_key.vid, universe, origin);
 
         eq_key.vid
     }

--- a/compiler/rustc_trait_selection/src/traits/project.rs
+++ b/compiler/rustc_trait_selection/src/traits/project.rs
@@ -19,6 +19,7 @@ use super::{Normalized, NormalizedTy, ProjectionCacheEntry, ProjectionCacheKey};
 use crate::infer::type_variable::{TypeVariableOrigin, TypeVariableOriginKind};
 use crate::infer::{InferCtxt, InferOk, LateBoundRegionConversionTime};
 use crate::traits::error_reporting::InferCtxtExt as _;
+use crate::traits::select::ProjectionMatchesProjection;
 use rustc_data_structures::sso::SsoHashSet;
 use rustc_data_structures::stack::ensure_sufficient_stack;
 use rustc_errors::ErrorReported;
@@ -1248,7 +1249,7 @@ fn assemble_candidates_from_predicates<'cx, 'tcx>(
             });
 
             match is_match {
-                Some(true) => {
+                ProjectionMatchesProjection::Yes => {
                     candidate_set.push_candidate(ctor(data));
 
                     if potentially_unnormalized_candidates
@@ -1260,10 +1261,10 @@ fn assemble_candidates_from_predicates<'cx, 'tcx>(
                         return;
                     }
                 }
-                Some(false) => {}
-                None => {
+                ProjectionMatchesProjection::Ambiguous => {
                     candidate_set.mark_ambiguous();
                 }
+                ProjectionMatchesProjection::No => {}
             }
         }
     }

--- a/compiler/rustc_trait_selection/src/traits/project.rs
+++ b/compiler/rustc_trait_selection/src/traits/project.rs
@@ -1073,16 +1073,6 @@ fn project<'cx, 'tcx>(
         return Ok(Projected::Progress(Progress::error(selcx.tcx())));
     }
 
-    // If the obligation contains any inference types or consts in associated
-    // type substs, then we don't assemble any candidates.
-    // This isn't really correct, but otherwise we can end up in a case where
-    // we constrain inference variables by selecting a single predicate, when
-    // we need to stay general. See issue #91762.
-    let (_, predicate_own_substs) = obligation.predicate.trait_ref_and_own_substs(selcx.tcx());
-    if predicate_own_substs.iter().any(|g| g.has_infer_types_or_consts()) {
-        return Err(ProjectionError::TooManyCandidates);
-    }
-
     let mut candidates = ProjectionCandidateSet::None;
 
     // Make sure that the following procedures are kept in order. ParamEnv
@@ -1180,7 +1170,7 @@ fn assemble_candidates_from_trait_def<'cx, 'tcx>(
         ProjectionCandidate::TraitDef,
         bounds.iter(),
         true,
-    )
+    );
 }
 
 /// In the case of a trait object like
@@ -1245,27 +1235,34 @@ fn assemble_candidates_from_predicates<'cx, 'tcx>(
         let bound_predicate = predicate.kind();
         if let ty::PredicateKind::Projection(data) = predicate.kind().skip_binder() {
             let data = bound_predicate.rebind(data);
-            let same_def_id = data.projection_def_id() == obligation.predicate.item_def_id;
+            if data.projection_def_id() != obligation.predicate.item_def_id {
+                continue;
+            }
 
-            let is_match = same_def_id
-                && infcx.probe(|_| {
-                    selcx.match_projection_projections(
-                        obligation,
-                        data,
-                        potentially_unnormalized_candidates,
-                    )
-                });
+            let is_match = infcx.probe(|_| {
+                selcx.match_projection_projections(
+                    obligation,
+                    data,
+                    potentially_unnormalized_candidates,
+                )
+            });
 
-            if is_match {
-                candidate_set.push_candidate(ctor(data));
+            match is_match {
+                Some(true) => {
+                    candidate_set.push_candidate(ctor(data));
 
-                if potentially_unnormalized_candidates
-                    && !obligation.predicate.has_infer_types_or_consts()
-                {
-                    // HACK: Pick the first trait def candidate for a fully
-                    // inferred predicate. This is to allow duplicates that
-                    // differ only in normalization.
-                    return;
+                    if potentially_unnormalized_candidates
+                        && !obligation.predicate.has_infer_types_or_consts()
+                    {
+                        // HACK: Pick the first trait def candidate for a fully
+                        // inferred predicate. This is to allow duplicates that
+                        // differ only in normalization.
+                        return;
+                    }
+                }
+                Some(false) => {}
+                None => {
+                    candidate_set.mark_ambiguous();
                 }
             }
         }

--- a/src/test/ui/generic-associated-types/issue-74824.rs
+++ b/src/test/ui/generic-associated-types/issue-74824.rs
@@ -17,7 +17,6 @@ impl<T> UnsafeCopy for T {}
 fn main() {
     let b = Box::new(42usize);
     let copy = <()>::copy(&b);
-    //~^ type annotations needed
 
     let raw_b = Box::deref(&b) as *const _;
     let raw_copy = Box::deref(&copy) as *const _;

--- a/src/test/ui/generic-associated-types/issue-74824.stderr
+++ b/src/test/ui/generic-associated-types/issue-74824.stderr
@@ -27,13 +27,6 @@ help: consider restricting type parameter `T`
 LL |     type Copy<T: std::clone::Clone>: Copy = Box<T>;
    |                +++++++++++++++++++
 
-error[E0282]: type annotations needed
-  --> $DIR/issue-74824.rs:19:16
-   |
-LL |     let copy = <()>::copy(&b);
-   |                ^^^^^^^^^^ cannot infer type for type parameter `T` declared on the associated function `copy`
+error: aborting due to 2 previous errors
 
-error: aborting due to 3 previous errors
-
-Some errors have detailed explanations: E0277, E0282.
-For more information about an error, try `rustc --explain E0277`.
+For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/generic-associated-types/issue-93874.rs
+++ b/src/test/ui/generic-associated-types/issue-93874.rs
@@ -1,0 +1,35 @@
+// check-pass
+
+#![feature(generic_associated_types)]
+
+pub trait Build {
+    type Output<O>;
+    fn build<O>(self, input: O) -> Self::Output<O>;
+}
+
+pub struct IdentityBuild;
+impl Build for IdentityBuild {
+    type Output<O> = O;
+    fn build<O>(self, input: O) -> Self::Output<O> {
+        input
+    }
+}
+
+fn a() {
+    let _x: u8 = IdentityBuild.build(10);
+}
+
+fn b() {
+    let _x: Vec<u8> = IdentityBuild.build(Vec::new());
+}
+
+fn c() {
+    let mut f = IdentityBuild.build(|| ());
+    (f)();
+}
+
+pub fn main() {
+    a();
+    b();
+    c();
+}


### PR DESCRIPTION
A slightly more targeted version of #92917, where we only give up with ambiguity if we infer something about the GATs substs when probing for a projection candidate.

fixes #93874
also note (but like the previous PR, does not fix) #91762

r? @jackh726 
cc @nikomatsakis who reviewed #92917