### PR TITLE
rustdoc: make item-infos dimmer on dark theme

### DIFF
--- a/src/librustdoc/html/static/css/themes/ayu.css
+++ b/src/librustdoc/html/static/css/themes/ayu.css
@@ -203,20 +203,9 @@ details.rustdoc-toggle > summary::before {
 	color: #000;
 }
 
-/* Created this empty rule to satisfy the theme checks. */
-.stab.empty-impl {}
-.stab.must_implement {}
-
-.stab.unstable,
-.stab.deprecated,
-.stab.portability,
-.stab.empty-impl,
-.stab.must_implement {
+.stab {
 	color: #c5c5c5;
 	background: #314559 !important;
-	border-style: none !important;
-	border-radius: 4px;
-	padding: 3px 6px 3px 6px;
 }
 
 .stab.portability > code {

--- a/src/librustdoc/html/static/css/themes/dark.css
+++ b/src/librustdoc/html/static/css/themes/dark.css
@@ -173,12 +173,12 @@ details.rustdoc-toggle > summary::before {
 	border-color: #008dfd;
 }
 
-.stab.empty-impl { background: #FFF5D6; border-color: #FFC600; color: #2f2f2f; }
-.stab.unstable { background: #FFF5D6; border-color: #FFC600; color: #2f2f2f; }
-.stab.deprecated { background: #ffc4c4; border-color: #db7b7b; color: #2f2f2f; }
-.stab.must_implement { background: #F3DFFF; border-color: #b07bdb; color: #2f2f2f; }
-.stab.portability { background: #F3DFFF; border-color: #b07bdb; color: #2f2f2f; }
-.stab.portability > code { background: none; }
+.stab { background: #314559; }
+
+.stab.portability > code {
+	color: #e6e1cf;
+	background: none;
+}
 
 .rightside,
 .out-of-band {

--- a/src/librustdoc/html/static/css/themes/light.css
+++ b/src/librustdoc/html/static/css/themes/light.css
@@ -160,11 +160,7 @@ details.rustdoc-toggle > summary::before {
 	border-color: #66afe9;
 }
 
-.stab.empty-impl { background: #FFF5D6; border-color: #FFC600; }
-.stab.unstable { background: #FFF5D6; border-color: #FFC600; }
-.stab.deprecated { background: #ffc4c4; border-color: #db7b7b; }
-.stab.must_implement { background: #F3DFFF; border-color: #b07bdb; }
-.stab.portability { background: #F3DFFF; border-color: #b07bdb; }
+.stab { background: #FFF5D6; border-color: #FFC600; }
 .stab.portability > code { background: none; }
 
 .rightside,

--- a/src/test/rustdoc-gui/label-next-to-symbol.goml
+++ b/src/test/rustdoc-gui/label-next-to-symbol.goml
@@ -7,14 +7,14 @@ size: (1080, 600)
 assert: (".stab.deprecated")
 assert: (".stab.portability")
 
-// make sure that deprecated and portability are different colours
+// make sure that deprecated and portability have the right colors
 assert-css: (
     ".item-table .item-left .stab.deprecated",
-    { "background-color": "rgb(255, 196, 196)" },
+    { "background-color": "rgb(255, 245, 214)" },
 )
 assert-css: (
     ".item-table .item-left .stab.portability",
-    { "background-color": "rgb(243, 223, 255)" },
+    { "background-color": "rgb(255, 245, 214)" },
 )
 
 // table like view
@@ -51,7 +51,7 @@ assert-css: (".item-right.docblock-short", { "padding-left": "32px" })
 compare-elements-position-near: (
     "//*[@class='item-left module-item']//a[text()='replaced_function']",
     ".item-left .stab.deprecated",
-    {"y": 1},
+    {"y": 2},
 )
 compare-elements-position: (
     ".item-left .stab.deprecated",


### PR DESCRIPTION
Previously the item-info background colors were too bright for a dark theme, making a bright rectangle that draws the attention.

Demo:

https://rustdoc.crud.net/jsha/dark-colors/std/os/linux/process/struct.PidFd.html
https://rustdoc.crud.net/jsha/dark-colors/std/error/trait.Error.html#method.description

Before:

<img width=300 src="https://user-images.githubusercontent.com/220205/153565049-f35ee83e-181d-491c-b2af-7cce1baa4912.png">

After:

<img width=300 src="https://user-images.githubusercontent.com/220205/181166727-b4218e96-daf1-46cd-a2df-5fd870eaa857.png">

r? @GuillaumeGomez 