### PR TITLE
linkchecker: fix panic on directory symlinks

### DIFF
--- a/src/tools/linkchecker/main.rs
+++ b/src/tools/linkchecker/main.rs
@@ -182,8 +182,9 @@ impl Checker {
     fn walk(&mut self, dir: &Path, report: &mut Report) {
         for entry in t!(dir.read_dir()).map(|e| t!(e)) {
             let path = entry.path();
-            let kind = t!(entry.file_type());
-            if kind.is_dir() {
+            // Goes through symlinks
+            let metadata = t!(fs::metadata(&path));
+            if metadata.is_dir() {
                 self.walk(&path, report);
             } else {
                 self.check(&path, report);


### PR DESCRIPTION
In Debian and Ubuntu, there are some patches that change the rustc/fonts
directory to a symlink to the system fonts. This triggers a latent bug
in linkchecker, as the DirEntry filetype isn't a dir but later on the
file itself, when opened, is one, triggering an unreachable!() clause.

This patch fixes the situation by using std::fs::metadata, which goes
through symlinks.

I'd have added a test case but `tidy` doesn't seem to like symlinks, and
moreover I'm not sure how Git deals with symlinks on Windows.

Signed-off-by: Simon Chopin <simon.chopin@canonical.com>