### PR TITLE
Allow inlining of `ensure_sufficient_stack()`

### DIFF
--- a/compiler/rustc_data_structures/src/stack.rs
+++ b/compiler/rustc_data_structures/src/stack.rs
@@ -12,6 +12,7 @@ const STACK_PER_RECURSION: usize = 1 * 1024 * 1024; // 1MB
 /// from this.
 ///
 /// Should not be sprinkled around carelessly, as it causes a little bit of overhead.
+#[inline]
 pub fn ensure_sufficient_stack<R>(f: impl FnOnce() -> R) -> R {
     stacker::maybe_grow(RED_ZONE, STACK_PER_RECURSION, f)
 }


### PR DESCRIPTION
This functions is monomorphized a lot and allowing the compiler to inline it improves instructions count and max RSS significantly in my local tests.