### PR TITLE
Remove Config::stderr

### DIFF
--- a/compiler/rustc_driver/src/lib.rs
+++ b/compiler/rustc_driver/src/lib.rs
@@ -226,7 +226,6 @@ fn run_compiler(
         output_dir: odir,
         file_loader,
         diagnostic_output,
-        stderr: None,
         lint_caps: Default::default(),
         parse_sess_created: None,
         register_lints: None,

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -256,7 +256,6 @@ crate fn create_config(
         output_dir: None,
         file_loader: None,
         diagnostic_output: DiagnosticOutput::Default,
-        stderr: None,
         lint_caps,
         parse_sess_created: None,
         register_lints: Some(box crate::lint::register_lints),

--- a/src/librustdoc/doctest.rs
+++ b/src/librustdoc/doctest.rs
@@ -97,7 +97,6 @@ crate fn run(options: RustdocOptions) -> Result<(), ErrorReported> {
         output_dir: None,
         file_loader: None,
         diagnostic_output: DiagnosticOutput::Default,
-        stderr: None,
         lint_caps,
         parse_sess_created: None,
         register_lints: Some(box crate::lint::register_lints),

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -691,7 +691,6 @@ fn main_args(at_args: &[String]) -> MainResult {
     rustc_interface::util::run_in_thread_pool_with_globals(
         options.edition,
         1, // this runs single-threaded, even in a parallel compiler
-        &None,
         move || main_options(options),
     )
 }

--- a/src/test/run-make-fulldeps/issue-19371/foo.rs
+++ b/src/test/run-make-fulldeps/issue-19371/foo.rs
@@ -55,7 +55,6 @@ fn compile(code: String, output: PathBuf, sysroot: PathBuf) {
         output_dir: None,
         file_loader: None,
         diagnostic_output: DiagnosticOutput::Default,
-        stderr: None,
         lint_caps: Default::default(),
         parse_sess_created: None,
         register_lints: None,


### PR DESCRIPTION
1. It captured stdout and not stderr
2. It isn't used anywhere
3. All error messages should go to the DiagnosticOutput instead
4. It modifies thread local state

Marking as blocked as it will conflict a bit with https://github.com/rust-lang/rust/pull/93936.