### PR TITLE
rustdoc: Put GenericArg::Type into a Box

### DIFF
--- a/src/librustdoc/clean/auto_trait.rs
+++ b/src/librustdoc/clean/auto_trait.rs
@@ -362,7 +362,7 @@ impl<'a, 'tcx> AutoTraitFinder<'a, 'tcx> {
                             let types = args
                                 .iter()
                                 .filter_map(|arg| match arg {
-                                    GenericArg::Type(ty) => Some(ty.clone()),
+                                    GenericArg::Type(ty) => Some((**ty).clone()),
                                     _ => None,
                                 })
                                 .collect();

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1767,7 +1767,7 @@ impl Clean<GenericArgs> for hir::GenericArgs<'_> {
                         GenericArg::Lifetime(lt.clean(cx))
                     }
                     hir::GenericArg::Lifetime(_) => GenericArg::Lifetime(Lifetime::elided()),
-                    hir::GenericArg::Type(ty) => GenericArg::Type(ty.clean(cx)),
+                    hir::GenericArg::Type(ty) => GenericArg::Type(Box::new(ty.clean(cx))),
                     hir::GenericArg::Const(ct) => GenericArg::Const(Box::new(ct.clean(cx))),
                     hir::GenericArg::Infer(_inf) => GenericArg::Infer,
                 })

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -1985,7 +1985,7 @@ impl Path {
                 Some(
                     args.iter()
                         .filter_map(|arg| match arg {
-                            GenericArg::Type(ty) => Some(ty),
+                            GenericArg::Type(ty) => Some(&**ty),
                             _ => None,
                         })
                         .collect(),
@@ -2010,7 +2010,7 @@ impl Path {
 #[derive(Clone, PartialEq, Eq, Debug, Hash)]
 crate enum GenericArg {
     Lifetime(Lifetime),
-    Type(Type),
+    Type(Box<Type>),
     Const(Box<Constant>),
     Infer,
 }
@@ -2018,7 +2018,7 @@ crate enum GenericArg {
 // `GenericArg` can occur many times in a single `Path`, so make sure it
 // doesn't increase in size unexpectedly.
 #[cfg(all(target_arch = "x86_64", target_pointer_width = "64"))]
-rustc_data_structures::static_assert_size!(GenericArg, 80);
+rustc_data_structures::static_assert_size!(GenericArg, 16);
 
 #[derive(Clone, PartialEq, Eq, Debug, Hash)]
 crate enum GenericArgs {

--- a/src/librustdoc/clean/utils.rs
+++ b/src/librustdoc/clean/utils.rs
@@ -101,7 +101,7 @@ fn external_generic_args(
             }
             GenericArgKind::Type(ty) => {
                 ty_kind = Some(ty.kind());
-                Some(GenericArg::Type(ty.clean(cx)))
+                Some(GenericArg::Type(Box::new(ty.clean(cx))))
             }
             GenericArgKind::Const(ct) => Some(GenericArg::Const(Box::new(ct.clean(cx)))),
         })

--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -136,7 +136,7 @@ impl FromWithTcx<clean::GenericArg> for GenericArg {
         use clean::GenericArg::*;
         match arg {
             Lifetime(l) => GenericArg::Lifetime(l.0.to_string()),
-            Type(t) => GenericArg::Type(t.into_tcx(tcx)),
+            Type(t) => GenericArg::Type((*t).into_tcx(tcx)),
             Const(box c) => GenericArg::Const(c.into_tcx(tcx)),
             Infer => GenericArg::Infer,
         }


### PR DESCRIPTION
This is a small experiment to see how it'll impact performance (I think it'll increase memory usage a bit). I don't think it'll be worthwhile to merge it.

r? @camelid 