### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
@@ -196,8 +196,8 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                         .map(|n| format!("`{}`", n))
                         .unwrap_or_else(|| "value".to_owned());
                     match kind {
-                        CallKind::FnCall(once_did)
-                            if Some(once_did) == self.infcx.tcx.lang_items().fn_once_trait() =>
+                        CallKind::FnCall { fn_trait_id, .. }
+                            if Some(fn_trait_id) == self.infcx.tcx.lang_items().fn_once_trait() =>
                         {
                             err.span_label(
                                 fn_call_span,

--- a/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
@@ -1,4 +1,5 @@
 use either::Either;
+use rustc_const_eval::util::{CallDesugaringKind, CallKind};
 use rustc_data_structures::fx::FxHashSet;
 use rustc_errors::{Applicability, DiagnosticBuilder};
 use rustc_hir as hir;
@@ -26,7 +27,7 @@ use crate::{
 
 use super::{
     explain_borrow::{BorrowExplanation, LaterUseKind},
-    FnSelfUseKind, IncludingDowncast, RegionName, RegionNameSource, UseSpans,
+    IncludingDowncast, RegionName, RegionNameSource, UseSpans,
 };
 
 #[derive(Debug)]
@@ -195,7 +196,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                         .map(|n| format!("`{}`", n))
                         .unwrap_or_else(|| "value".to_owned());
                     match kind {
-                        FnSelfUseKind::FnOnceCall => {
+                        CallKind::FnCall(once_did) if Some(once_did) == self.infcx.tcx.lang_items().fn_once_trait() => {
                             err.span_label(
                                 fn_call_span,
                                 &format!(
@@ -208,7 +209,8 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                                 "this value implements `FnOnce`, which causes it to be moved when called",
                             );
                         }
-                        FnSelfUseKind::Operator { self_arg } => {
+                        CallKind::Operator { self_arg, .. } => {
+                            let self_arg = self_arg.unwrap();
                             err.span_label(
                                 fn_call_span,
                                 &format!(
@@ -235,12 +237,9 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                                 );
                             }
                         }
-                        FnSelfUseKind::Normal {
-                            self_arg,
-                            implicit_into_iter,
-                            is_option_or_result,
-                        } => {
-                            if implicit_into_iter {
+                        CallKind::Normal { self_arg, desugaring, is_option_or_result } => {
+                            let self_arg = self_arg.unwrap();
+                            if let Some((CallDesugaringKind::ForLoopIntoIter, _)) = desugaring {
                                 err.span_label(
                                     fn_call_span,
                                     &format!(
@@ -305,8 +304,8 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                                     );
                             }
                         }
-                        // Deref::deref takes &self, which cannot cause a move
-                        FnSelfUseKind::DerefCoercion { .. } => unreachable!(),
+                        // Other desugarings takes &self, which cannot cause a move
+                        _ => unreachable!(),
                     }
                 } else {
                     err.span_label(
@@ -433,7 +432,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
             }
 
             if let UseSpans::FnSelfUse {
-                kind: FnSelfUseKind::DerefCoercion { deref_target, deref_target_ty },
+                kind: CallKind::DerefCoercion { deref_target, deref_target_ty, .. },
                 ..
             } = use_spans
             {

--- a/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
@@ -196,7 +196,9 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                         .map(|n| format!("`{}`", n))
                         .unwrap_or_else(|| "value".to_owned());
                     match kind {
-                        CallKind::FnCall(once_did) if Some(once_did) == self.infcx.tcx.lang_items().fn_once_trait() => {
+                        CallKind::FnCall(once_did)
+                            if Some(once_did) == self.infcx.tcx.lang_items().fn_once_trait() =>
+                        {
                             err.span_label(
                                 fn_call_span,
                                 &format!(

--- a/compiler/rustc_borrowck/src/diagnostics/move_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/move_errors.rs
@@ -1,3 +1,4 @@
+use rustc_const_eval::util::CallDesugaringKind;
 use rustc_errors::{Applicability, DiagnosticBuilder};
 use rustc_infer::infer::TyCtxtInferExt;
 use rustc_middle::mir::*;
@@ -8,7 +9,7 @@ use rustc_mir_dataflow::move_paths::{
 use rustc_span::{sym, Span, DUMMY_SP};
 use rustc_trait_selection::traits::type_known_to_meet_bound_modulo_regions;
 
-use crate::diagnostics::{FnSelfUseKind, UseSpans};
+use crate::diagnostics::{CallKind, UseSpans};
 use crate::prefixes::PrefixSet;
 use crate::MirBorrowckCtxt;
 
@@ -410,7 +411,8 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
                 Applicability::MaybeIncorrect,
             );
         } else if let Some(UseSpans::FnSelfUse {
-            kind: FnSelfUseKind::Normal { implicit_into_iter: true, .. },
+            kind:
+                CallKind::Normal { desugaring: Some((CallDesugaringKind::ForLoopIntoIter, _)), .. },
             ..
         }) = use_spans
         {

--- a/compiler/rustc_const_eval/src/transform/check_consts/check.rs
+++ b/compiler/rustc_const_eval/src/transform/check_consts/check.rs
@@ -797,7 +797,7 @@ impl<'tcx> Visitor<'tcx> for Checker<'_, 'tcx> {
                 if let Some(trait_id) = tcx.trait_of_item(callee) {
                     trace!("attempting to call a trait method");
                     if !self.tcx.features().const_trait_impl {
-                        self.check_op(ops::FnCallNonConst(Some((callee, substs))));
+                        self.check_op(ops::FnCallNonConst(callee, substs));
                         return;
                     }
 
@@ -856,7 +856,7 @@ impl<'tcx> Visitor<'tcx> for Checker<'_, 'tcx> {
                             }
 
                             if !nonconst_call_permission {
-                                self.check_op(ops::FnCallNonConst(None));
+                                self.check_op(ops::FnCallNonConst(callee, substs));
                                 return;
                             }
                         }
@@ -925,7 +925,7 @@ impl<'tcx> Visitor<'tcx> for Checker<'_, 'tcx> {
                     }
 
                     if !nonconst_call_permission {
-                        self.check_op(ops::FnCallNonConst(None));
+                        self.check_op(ops::FnCallNonConst(callee, substs));
                         return;
                     }
                 }

--- a/compiler/rustc_const_eval/src/transform/check_consts/check.rs
+++ b/compiler/rustc_const_eval/src/transform/check_consts/check.rs
@@ -14,6 +14,7 @@ use rustc_middle::ty::{self, adjustment::PointerCast, Instance, InstanceDef, Ty,
 use rustc_middle::ty::{Binder, TraitPredicate, TraitRef};
 use rustc_mir_dataflow::{self, Analysis};
 use rustc_span::{sym, Span, Symbol};
+use rustc_trait_selection::traits::error_reporting::InferCtxtExt;
 use rustc_trait_selection::traits::SelectionContext;
 
 use std::mem;
@@ -808,15 +809,13 @@ impl<'tcx> Visitor<'tcx> for Checker<'_, 'tcx> {
                     }
 
                     let trait_ref = TraitRef::from_method(tcx, trait_id, substs);
-                    let obligation = Obligation::new(
-                        ObligationCause::dummy(),
-                        param_env,
-                        Binder::dummy(TraitPredicate {
-                            trait_ref,
-                            constness: ty::BoundConstness::NotConst,
-                            polarity: ty::ImplPolarity::Positive,
-                        }),
-                    );
+                    let poly_trait_pred = Binder::dummy(TraitPredicate {
+                        trait_ref,
+                        constness: ty::BoundConstness::ConstIfConst,
+                        polarity: ty::ImplPolarity::Positive,
+                    });
+                    let obligation =
+                        Obligation::new(ObligationCause::dummy(), param_env, poly_trait_pred);
 
                     let implsrc = tcx.infer_ctxt().enter(|infcx| {
                         let mut selcx = SelectionContext::new(&infcx);
@@ -860,15 +859,37 @@ impl<'tcx> Visitor<'tcx> for Checker<'_, 'tcx> {
                             // #[default_method_body_is_const], and the callee is in the same
                             // trait.
                             let callee_trait = tcx.trait_of_item(callee);
-                            if callee_trait.is_some() {
-                                if tcx.has_attr(caller, sym::default_method_body_is_const) {
-                                    if tcx.trait_of_item(caller) == callee_trait {
-                                        nonconst_call_permission = true;
-                                    }
-                                }
+                            if callee_trait.is_some()
+                                && tcx.has_attr(caller, sym::default_method_body_is_const)
+                                && callee_trait == tcx.trait_of_item(caller)
+                                // Can only call methods when it's `<Self as TheTrait>::f`.
+                                && tcx.types.self_param == substs.type_at(0)
+                            {
+                                nonconst_call_permission = true;
                             }
 
                             if !nonconst_call_permission {
+                                let obligation = Obligation::new(
+                                    ObligationCause::dummy_with_span(*fn_span),
+                                    param_env,
+                                    tcx.mk_predicate(
+                                        poly_trait_pred.map_bound(ty::PredicateKind::Trait),
+                                    ),
+                                );
+
+                                // improve diagnostics by showing what failed. Our requirements are stricter this time
+                                // as we are going to error again anyways.
+                                tcx.infer_ctxt().enter(|infcx| {
+                                    if let Err(e) = implsrc {
+                                        infcx.report_selection_error(
+                                            obligation.clone(),
+                                            &obligation,
+                                            &e,
+                                            false,
+                                        );
+                                    }
+                                });
+
                                 self.check_op(ops::FnCallNonConst {
                                     caller,
                                     callee,

--- a/compiler/rustc_const_eval/src/transform/check_consts/check.rs
+++ b/compiler/rustc_const_eval/src/transform/check_consts/check.rs
@@ -293,13 +293,13 @@ impl<'mir, 'tcx> Checker<'mir, 'tcx> {
     }
 
     /// Emits an error if an expression cannot be evaluated in the current context.
-    pub fn check_op(&mut self, op: impl NonConstOp) {
+    pub fn check_op(&mut self, op: impl NonConstOp<'tcx>) {
         self.check_op_spanned(op, self.span);
     }
 
     /// Emits an error at the given `span` if an expression cannot be evaluated in the current
     /// context.
-    pub fn check_op_spanned<O: NonConstOp>(&mut self, op: O, span: Span) {
+    pub fn check_op_spanned<O: NonConstOp<'tcx>>(&mut self, op: O, span: Span) {
         let gate = match op.status_in_item(self.ccx) {
             Status::Allowed => return,
 
@@ -773,7 +773,7 @@ impl<'tcx> Visitor<'tcx> for Checker<'_, 'tcx> {
         self.super_terminator(terminator, location);
 
         match &terminator.kind {
-            TerminatorKind::Call { func, args, .. } => {
+            TerminatorKind::Call { func, args, fn_span, from_hir_call, .. } => {
                 let ConstCx { tcx, body, param_env, .. } = *self.ccx;
                 let caller = self.def_id().to_def_id();
 
@@ -797,7 +797,13 @@ impl<'tcx> Visitor<'tcx> for Checker<'_, 'tcx> {
                 if let Some(trait_id) = tcx.trait_of_item(callee) {
                     trace!("attempting to call a trait method");
                     if !self.tcx.features().const_trait_impl {
-                        self.check_op(ops::FnCallNonConst(callee, substs));
+                        self.check_op(ops::FnCallNonConst {
+                            caller,
+                            callee,
+                            substs,
+                            span: *fn_span,
+                            from_hir_call: *from_hir_call,
+                        });
                         return;
                     }
 
@@ -856,7 +862,13 @@ impl<'tcx> Visitor<'tcx> for Checker<'_, 'tcx> {
                             }
 
                             if !nonconst_call_permission {
-                                self.check_op(ops::FnCallNonConst(callee, substs));
+                                self.check_op(ops::FnCallNonConst {
+                                    caller,
+                                    callee,
+                                    substs,
+                                    span: *fn_span,
+                                    from_hir_call: *from_hir_call,
+                                });
                                 return;
                             }
                         }
@@ -925,7 +937,13 @@ impl<'tcx> Visitor<'tcx> for Checker<'_, 'tcx> {
                     }
 
                     if !nonconst_call_permission {
-                        self.check_op(ops::FnCallNonConst(callee, substs));
+                        self.check_op(ops::FnCallNonConst {
+                            caller,
+                            callee,
+                            substs,
+                            span: *fn_span,
+                            from_hir_call: *from_hir_call,
+                        });
                         return;
                     }
                 }

--- a/compiler/rustc_const_eval/src/transform/check_consts/ops.rs
+++ b/compiler/rustc_const_eval/src/transform/check_consts/ops.rs
@@ -125,7 +125,7 @@ impl<'tcx> NonConstOp<'tcx> for FnCallNonConst<'tcx> {
                         param_env,
                         Binder::dummy(TraitPredicate {
                             trait_ref,
-                            constness: BoundConstness::ConstIfConst,
+                            constness: BoundConstness::NotConst,
                             polarity: ImplPolarity::Positive,
                         }),
                     );

--- a/compiler/rustc_const_eval/src/util/call_kind.rs
+++ b/compiler/rustc_const_eval/src/util/call_kind.rs
@@ -1,0 +1,145 @@
+//! Common logic for borrowck use-after-move errors when moved into a `fn(self)`,
+//! as well as errors when attempting to call a non-const function in a const
+//! context.
+
+use rustc_hir::def_id::DefId;
+use rustc_hir::lang_items::LangItemGroup;
+use rustc_middle::ty::subst::SubstsRef;
+use rustc_middle::ty::{self, AssocItemContainer, DefIdTree, Instance, ParamEnv, Ty, TyCtxt};
+use rustc_span::symbol::Ident;
+use rustc_span::{sym, DesugaringKind, Span};
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum CallDesugaringKind {
+    /// for _ in x {} calls x.into_iter()
+    ForLoopIntoIter,
+    /// x? calls x.branch()
+    QuestionBranch,
+    /// x? calls type_of(x)::from_residual()
+    QuestionFromResidual,
+    /// try { ..; x } calls type_of(x)::from_output(x)
+    TryBlockFromOutput,
+}
+
+impl CallDesugaringKind {
+    pub fn trait_def_id(self, tcx: TyCtxt<'_>) -> DefId {
+        match self {
+            Self::ForLoopIntoIter => tcx.get_diagnostic_item(sym::IntoIterator).unwrap(),
+            Self::QuestionBranch | Self::TryBlockFromOutput => {
+                tcx.lang_items().try_trait().unwrap()
+            }
+            Self::QuestionFromResidual => tcx.get_diagnostic_item(sym::FromResidual).unwrap(),
+        }
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum CallKind<'tcx> {
+    /// A normal method call of the form `receiver.foo(a, b, c)`
+    Normal {
+        self_arg: Option<Ident>,
+        desugaring: Option<(CallDesugaringKind, Ty<'tcx>)>,
+        /// Whether the self type of the method call has an `.as_ref()` method.
+        /// Used for better diagnostics.
+        is_option_or_result: bool,
+    },
+    /// A call to `Fn(..)::call(..)`, desugared from `my_closure(a, b, c)`
+    FnCall(DefId),
+    /// A call to an operator trait, desuraged from operator syntax (e.g. `a << b`)
+    Operator { self_arg: Option<Ident>, trait_id: DefId, self_ty: Ty<'tcx> },
+    DerefCoercion {
+        /// The `Span` of the `Target` associated type
+        /// in the `Deref` impl we are using.
+        deref_target: Span,
+        /// The type `T::Deref` we are dereferencing to
+        deref_target_ty: Ty<'tcx>,
+        self_ty: Ty<'tcx>,
+    },
+}
+
+pub fn call_kind<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    param_env: ParamEnv<'tcx>,
+    method_did: DefId,
+    method_substs: SubstsRef<'tcx>,
+    fn_call_span: Span,
+    from_hir_call: bool,
+    self_arg: Option<Ident>,
+) -> CallKind<'tcx> {
+    let parent = tcx.opt_associated_item(method_did).and_then(|assoc| match assoc.container {
+        AssocItemContainer::ImplContainer(impl_did) => tcx.trait_id_of_impl(impl_did),
+        AssocItemContainer::TraitContainer(trait_did) => Some(trait_did),
+    });
+
+    let fn_call = (!from_hir_call)
+        .then(|| parent)
+        .flatten()
+        .and_then(|p| tcx.lang_items().group(LangItemGroup::Fn).iter().find(|did| **did == p));
+
+    let operator = (!from_hir_call)
+        .then(|| parent)
+        .flatten()
+        .and_then(|p| tcx.lang_items().group(LangItemGroup::Op).iter().find(|did| **did == p));
+
+    let is_deref = !from_hir_call && tcx.is_diagnostic_item(sym::deref_method, method_did);
+
+    // Check for a 'special' use of 'self' -
+    // an FnOnce call, an operator (e.g. `<<`), or a
+    // deref coercion.
+    let kind = if let Some(&trait_id) = fn_call {
+        Some(CallKind::FnCall(trait_id))
+    } else if let Some(&trait_id) = operator {
+        Some(CallKind::Operator { self_arg, trait_id, self_ty: method_substs.type_at(0) })
+    } else if is_deref {
+        let deref_target = tcx.get_diagnostic_item(sym::deref_target).and_then(|deref_target| {
+            Instance::resolve(tcx, param_env, deref_target, method_substs).transpose()
+        });
+        if let Some(Ok(instance)) = deref_target {
+            let deref_target_ty = instance.ty(tcx, param_env);
+            Some(CallKind::DerefCoercion {
+                deref_target: tcx.def_span(instance.def_id()),
+                deref_target_ty,
+                self_ty: method_substs.type_at(0),
+            })
+        } else {
+            None
+        }
+    } else {
+        None
+    };
+
+    kind.unwrap_or_else(|| {
+        // This isn't a 'special' use of `self`
+        debug!(?method_did, ?fn_call_span);
+        let desugaring = if Some(method_did) == tcx.lang_items().into_iter_fn()
+            && fn_call_span.desugaring_kind() == Some(DesugaringKind::ForLoop)
+        {
+            Some((CallDesugaringKind::ForLoopIntoIter, method_substs.type_at(0)))
+        } else if fn_call_span.desugaring_kind() == Some(DesugaringKind::QuestionMark) {
+            if Some(method_did) == tcx.lang_items().branch_fn() {
+                Some((CallDesugaringKind::QuestionBranch, method_substs.type_at(0)))
+            } else if Some(method_did) == tcx.lang_items().from_residual_fn() {
+                Some((CallDesugaringKind::QuestionFromResidual, method_substs.type_at(0)))
+            } else {
+                None
+            }
+        } else if Some(method_did) == tcx.lang_items().from_output_fn()
+            && fn_call_span.desugaring_kind() == Some(DesugaringKind::TryBlock)
+        {
+            Some((CallDesugaringKind::TryBlockFromOutput, method_substs.type_at(0)))
+        } else {
+            None
+        };
+        let parent_self_ty = tcx
+            .parent(method_did)
+            .filter(|did| tcx.def_kind(*did) == rustc_hir::def::DefKind::Impl)
+            .and_then(|did| match tcx.type_of(did).kind() {
+                ty::Adt(def, ..) => Some(def.did),
+                _ => None,
+            });
+        let is_option_or_result = parent_self_ty.map_or(false, |def_id| {
+            matches!(tcx.get_diagnostic_name(def_id), Some(sym::Option | sym::Result))
+        });
+        CallKind::Normal { self_arg, desugaring, is_option_or_result }
+    })
+}

--- a/compiler/rustc_const_eval/src/util/call_kind.rs
+++ b/compiler/rustc_const_eval/src/util/call_kind.rs
@@ -44,7 +44,7 @@ pub enum CallKind<'tcx> {
         is_option_or_result: bool,
     },
     /// A call to `Fn(..)::call(..)`, desugared from `my_closure(a, b, c)`
-    FnCall(DefId),
+    FnCall { fn_trait_id: DefId, self_ty: Ty<'tcx> },
     /// A call to an operator trait, desuraged from operator syntax (e.g. `a << b`)
     Operator { self_arg: Option<Ident>, trait_id: DefId, self_ty: Ty<'tcx> },
     DerefCoercion {
@@ -85,7 +85,7 @@ pub fn call_kind<'tcx>(
     // an FnOnce call, an operator (e.g. `<<`), or a
     // deref coercion.
     let kind = if let Some(&trait_id) = fn_call {
-        Some(CallKind::FnCall(trait_id))
+        Some(CallKind::FnCall { fn_trait_id: trait_id, self_ty: method_substs.type_at(0) })
     } else if let Some(&trait_id) = operator {
         Some(CallKind::Operator { self_arg, trait_id, self_ty: method_substs.type_at(0) })
     } else if is_deref {

--- a/compiler/rustc_const_eval/src/util/call_kind.rs
+++ b/compiler/rustc_const_eval/src/util/call_kind.rs
@@ -71,9 +71,7 @@ pub fn call_kind<'tcx>(
         AssocItemContainer::TraitContainer(trait_did) => Some(trait_did),
     });
 
-    let fn_call = (!from_hir_call)
-        .then(|| parent)
-        .flatten()
+    let fn_call = parent
         .and_then(|p| tcx.lang_items().group(LangItemGroup::Fn).iter().find(|did| **did == p));
 
     let operator = (!from_hir_call)

--- a/compiler/rustc_const_eval/src/util/mod.rs
+++ b/compiler/rustc_const_eval/src/util/mod.rs
@@ -1,8 +1,10 @@
 pub mod aggregate;
 mod alignment;
+mod call_kind;
 pub mod collect_writes;
 mod find_self_call;
 
 pub use self::aggregate::expand_aggregate;
 pub use self::alignment::is_disaligned;
+pub use self::call_kind::{call_kind, CallDesugaringKind, CallKind};
 pub use self::find_self_call::find_self_call;

--- a/compiler/rustc_hir/src/lang_items.rs
+++ b/compiler/rustc_hir/src/lang_items.rs
@@ -24,7 +24,7 @@ pub enum LangItemGroup {
     Fn,
 }
 
-const NUM_GROUPS: usize = 1;
+const NUM_GROUPS: usize = 2;
 
 macro_rules! expand_group {
     () => {
@@ -99,11 +99,12 @@ macro_rules! language_item_table {
             /// Construct an empty collection of lang items and no missing ones.
             pub fn new() -> Self {
                 fn init_none(_: LangItem) -> Option<DefId> { None }
+                const EMPTY: Vec<DefId> = Vec::new();
 
                 Self {
                     items: vec![$(init_none(LangItem::$variant)),*],
                     missing: Vec::new(),
-                    groups: [vec![]; NUM_GROUPS],
+                    groups: [EMPTY; NUM_GROUPS],
                 }
             }
 

--- a/compiler/rustc_hir/src/lang_items.rs
+++ b/compiler/rustc_hir/src/lang_items.rs
@@ -21,6 +21,7 @@ use std::lazy::SyncLazy;
 
 pub enum LangItemGroup {
     Op,
+    Fn,
 }
 
 const NUM_GROUPS: usize = 1;
@@ -251,9 +252,9 @@ language_item_table! {
     DerefTarget,             sym::deref_target,        deref_target,               Target::AssocTy,        GenericRequirement::None;
     Receiver,                sym::receiver,            receiver_trait,             Target::Trait,          GenericRequirement::None;
 
-    Fn,                      kw::Fn,                   fn_trait,                   Target::Trait,          GenericRequirement::Exact(1);
-    FnMut,                   sym::fn_mut,              fn_mut_trait,               Target::Trait,          GenericRequirement::Exact(1);
-    FnOnce,                  sym::fn_once,             fn_once_trait,              Target::Trait,          GenericRequirement::Exact(1);
+    Fn(Fn),                  kw::Fn,                   fn_trait,                   Target::Trait,          GenericRequirement::Exact(1);
+    FnMut(Fn),               sym::fn_mut,              fn_mut_trait,               Target::Trait,          GenericRequirement::Exact(1);
+    FnOnce(Fn),              sym::fn_once,             fn_once_trait,              Target::Trait,          GenericRequirement::Exact(1);
 
     FnOnceOutput,            sym::fn_once_output,      fn_once_output,             Target::AssocTy,        GenericRequirement::None;
 
@@ -264,8 +265,8 @@ language_item_table! {
     Unpin,                   sym::unpin,               unpin_trait,                Target::Trait,          GenericRequirement::None;
     Pin,                     sym::pin,                 pin_type,                   Target::Struct,         GenericRequirement::None;
 
-    PartialEq,               sym::eq,                  eq_trait,                   Target::Trait,          GenericRequirement::Exact(1);
-    PartialOrd,              sym::partial_ord,         partial_ord_trait,          Target::Trait,          GenericRequirement::Exact(1);
+    PartialEq(Op),           sym::eq,                  eq_trait,                   Target::Trait,          GenericRequirement::Exact(1);
+    PartialOrd(Op),          sym::partial_ord,         partial_ord_trait,          Target::Trait,          GenericRequirement::Exact(1);
 
     // A number of panic-related lang items. The `panic` item corresponds to divide-by-zero and
     // various panic cases with `match`. The `panic_bounds_check` item is for indexing arrays.

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -63,6 +63,22 @@ pub enum CFGuard {
     Checks,
 }
 
+/// The different settings that the `-Z cf-protection` flag can have.
+#[derive(Clone, Copy, PartialEq, Hash, Debug)]
+pub enum CFProtection {
+    /// Do not enable control-flow protection
+    None,
+
+    /// Emit control-flow protection for branches (enables indirect branch tracking).
+    Branch,
+
+    /// Emit control-flow protection for returns.
+    Return,
+
+    /// Emit control-flow protection for both branches and returns.
+    Full,
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Hash)]
 pub enum OptLevel {
     No,         // -O0
@@ -2632,11 +2648,11 @@ impl PpMode {
 /// we have an opt-in scheme here, so one is hopefully forced to think about
 /// how the hash should be calculated when adding a new command-line argument.
 crate mod dep_tracking {
-    use super::LdImpl;
     use super::{
-        BranchProtection, CFGuard, CrateType, DebugInfo, ErrorOutputType, InstrumentCoverage,
-        LinkerPluginLto, LocationDetail, LtoCli, OptLevel, OutputType, OutputTypes, Passes,
-        SourceFileHashAlgorithm, SwitchWithOptPath, SymbolManglingVersion, TrimmedDefPaths,
+        BranchProtection, CFGuard, CFProtection, CrateType, DebugInfo, ErrorOutputType,
+        InstrumentCoverage, LdImpl, LinkerPluginLto, LocationDetail, LtoCli, OptLevel, OutputType,
+        OutputTypes, Passes, SourceFileHashAlgorithm, SwitchWithOptPath, SymbolManglingVersion,
+        TrimmedDefPaths,
     };
     use crate::lint;
     use crate::options::WasiExecModel;
@@ -2717,6 +2733,7 @@ crate mod dep_tracking {
         NativeLibKind,
         SanitizerSet,
         CFGuard,
+        CFProtection,
         TargetTriple,
         Edition,
         LinkerPluginLto,

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -384,6 +384,7 @@ mod desc {
     pub const parse_sanitizer_memory_track_origins: &str = "0, 1, or 2";
     pub const parse_cfguard: &str =
         "either a boolean (`yes`, `no`, `on`, `off`, etc), `checks`, or `nochecks`";
+    pub const parse_cfprotection: &str = "`none`|`no`|`n` (default), `branch`, `return`, or `full`|`yes`|`y` (equivalent to `branch` and `return`)";
     pub const parse_strip: &str = "either `none`, `debuginfo`, or `symbols`";
     pub const parse_linker_flavor: &str = ::rustc_target::spec::LinkerFlavor::one_of();
     pub const parse_optimization_fuel: &str = "crate=integer";
@@ -694,6 +695,25 @@ mod parse {
             None => CFGuard::Checks,
             Some("checks") => CFGuard::Checks,
             Some("nochecks") => CFGuard::NoChecks,
+            Some(_) => return false,
+        };
+        true
+    }
+
+    crate fn parse_cfprotection(slot: &mut CFProtection, v: Option<&str>) -> bool {
+        if v.is_some() {
+            let mut bool_arg = None;
+            if parse_opt_bool(&mut bool_arg, v) {
+                *slot = if bool_arg.unwrap() { CFProtection::Full } else { CFProtection::None };
+                return true;
+            }
+        }
+
+        *slot = match v {
+            None | Some("none") => CFProtection::None,
+            Some("branch") => CFProtection::Branch,
+            Some("return") => CFProtection::Return,
+            Some("full") => CFProtection::Full,
             Some(_) => return false,
         };
         true
@@ -1146,6 +1166,8 @@ options! {
         "select which borrowck is used (`mir` or `migrate`) (default: `migrate`)"),
     branch_protection: BranchProtection = (BranchProtection::default(), parse_branch_protection, [TRACKED],
         "set options for branch target identification and pointer authentication on AArch64"),
+    cf_protection: CFProtection = (CFProtection::None, parse_cfprotection, [TRACKED],
+        "instrument control-flow architecture protection"),
     cgu_partitioning_strategy: Option<String> = (None, parse_opt_string, [TRACKED],
         "the codegen unit partitioning strategy to use"),
     chalk: bool = (false, parse_bool, [TRACKED],

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -184,6 +184,7 @@ symbols! {
         Formatter,
         From,
         FromIterator,
+        FromResidual,
         Future,
         FxHashMap,
         FxHashSet,

--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -872,7 +872,7 @@ pub(crate) mod builtin {
         ($fmt:expr, $($args:tt)*) => {{ /* compiler built-in */ }};
     }
 
-    /// Same as `format_args`, but can be used in some const contexts.
+    /// Same as [`format_args`], but can be used in some const contexts.
     ///
     /// This macro is used by the panic macros for the `const_panic` feature.
     ///
@@ -886,7 +886,7 @@ pub(crate) mod builtin {
         ($fmt:expr, $($args:tt)*) => {{ /* compiler built-in */ }};
     }
 
-    /// Same as `format_args`, but adds a newline in the end.
+    /// Same as [`format_args`], but adds a newline in the end.
     #[unstable(
         feature = "format_args_nl",
         issue = "none",

--- a/library/core/src/ops/try_trait.rs
+++ b/library/core/src/ops/try_trait.rs
@@ -302,6 +302,7 @@ pub trait Try: FromResidual {
         enclosing_scope = "this function should return `Result` or `Option` to accept `?`"
     ),
 )]
+#[rustc_diagnostic_item = "FromResidual"]
 #[unstable(feature = "try_trait_v2", issue = "84277")]
 pub trait FromResidual<R = <Self as Try>::Residual> {
     /// Constructs the type from a compatible `Residual` type.

--- a/src/doc/unstable-book/src/compiler-flags/cf-protection.md
+++ b/src/doc/unstable-book/src/compiler-flags/cf-protection.md
@@ -1,0 +1,40 @@
+# `cf-protection`
+
+This option enables control-flow enforcement technology (CET) on x86; a more detailed description of
+CET is available [here]. Similar to `clang`, this flag takes one of the following values:
+
+- `none` - Disable CET completely (this is the default).
+- `branch` - Enable indirect branch tracking (`IBT`).
+- `return` - Enable shadow stack (`SHSTK`).
+- `full` - Enable both `branch` and `return`.
+
+[here]: https://www.intel.com/content/www/us/en/develop/articles/technical-look-control-flow-enforcement-technology.html
+
+This flag only applies to the LLVM backend: it sets the `cf-protection-branch` and
+`cf-protection-return` flags on LLVM modules. Note, however, that all compiled modules linked
+together must have the flags set for the compiled output to be CET-enabled. Currently, Rust's
+standard library does not ship with CET enabled by default, so you may need to rebuild all standard
+modules with a `cargo` command like:
+
+```sh
+$ RUSTFLAGS="-Z cf-protection=full" RUSTC="rustc-custom" cargo +nightly build -Z build-std --target x86_64-unknown-linux-gnu
+```
+
+### Detection
+
+An ELF binary is CET-enabled if it has the `IBT` and `SHSTK` tags, e.g.:
+
+```sh
+$ readelf -a target/x86_64-unknown-linux-gnu/debug/example | grep feature:
+      Properties: x86 feature: IBT, SHSTK
+```
+
+### Troubleshooting
+
+To display modules that are not CET enabled, examine the linker errors available when `cet-report` is enabled:
+
+```sh
+$ RUSTC_LOG=rustc_codegen_ssa::back::link=info rustc-custom -v -Z cf-protection=full -C link-arg="-Wl,-z,cet-report=warning" -o example example.rs
+...
+/usr/bin/ld: /.../build/x86_64-unknown-linux-gnu/stage1/lib/rustlib/x86_64-unknown-linux-gnu/lib/libstd-d73f7266be14cb8b.rlib(std-d73f7266be14cb8b.std.f7443020-cgu.12.rcgu.o): warning: missing IBT and SHSTK properties
+```

--- a/src/test/codegen/cf-protection.rs
+++ b/src/test/codegen/cf-protection.rs
@@ -1,0 +1,33 @@
+// Test that the correct module flags are emitted with different control-flow protection flags.
+
+// revisions: undefined none branch return full
+// needs-llvm-components: x86
+// [undefined] compile-flags:
+// [none] compile-flags: -Z cf-protection=none
+// [branch] compile-flags: -Z cf-protection=branch
+// [return] compile-flags: -Z cf-protection=return
+// [full] compile-flags: -Z cf-protection=full
+// compile-flags: --target x86_64-unknown-linux-gnu
+
+#![crate_type = "lib"]
+
+// A basic test function.
+pub fn test() {
+}
+
+// undefined-NOT: !"cf-protection-branch"
+// undefined-NOT: !"cf-protection-return"
+
+// none-NOT: !"cf-protection-branch"
+// none-NOT: !"cf-protection-return"
+
+// branch-NOT: !"cf-protection-return"
+// branch: !"cf-protection-branch", i32 1
+// branch-NOT: !"cf-protection-return"
+
+// return-NOT: !"cf-protection-branch"
+// return: !"cf-protection-return", i32 1
+// return-NOT: !"cf-protection-branch"
+
+// full: !"cf-protection-branch", i32 1
+// full: !"cf-protection-return", i32 1

--- a/src/test/ui/borrowck/issue-64453.rs
+++ b/src/test/ui/borrowck/issue-64453.rs
@@ -2,7 +2,7 @@ struct Project;
 struct Value;
 
 static settings_dir: String = format!("");
-//~^ ERROR calls in statics are limited to constant functions
+//~^ ERROR cannot call non-const fn
 //~| ERROR is not yet stable as a const
 
 fn from_string(_: String) -> Value {

--- a/src/test/ui/borrowck/issue-64453.stderr
+++ b/src/test/ui/borrowck/issue-64453.stderr
@@ -7,12 +7,13 @@ LL | static settings_dir: String = format!("");
    = help: add `#![feature(const_fmt_arguments_new)]` to the crate attributes to enable
    = note: this error originates in the macro `$crate::__export::format_args` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0015]: calls in statics are limited to constant functions, tuple structs and tuple variants
+error[E0015]: cannot call non-const fn `format` in statics
   --> $DIR/issue-64453.rs:4:31
    |
 LL | static settings_dir: String = format!("");
    |                               ^^^^^^^^^^^
    |
+   = note: calls in statics are limited to constant functions, tuple structs and tuple variants
    = note: this error originates in the macro `format` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0507]: cannot move out of static item `settings_dir`

--- a/src/test/ui/check-static-values-constraints.rs
+++ b/src/test/ui/check-static-values-constraints.rs
@@ -87,7 +87,7 @@ static mut STATIC13: SafeStruct = SafeStruct{field1: SafeEnum::Variant1,
 static mut STATIC14: SafeStruct = SafeStruct {
     field1: SafeEnum::Variant1,
     field2: SafeEnum::Variant4("str".to_string())
-//~^ ERROR calls in statics are limited to constant functions
+//~^ ERROR cannot call non-const fn
 };
 
 static STATIC15: &'static [Box<MyOwned>] = &[

--- a/src/test/ui/check-static-values-constraints.stderr
+++ b/src/test/ui/check-static-values-constraints.stderr
@@ -15,11 +15,13 @@ error[E0010]: allocations are not allowed in statics
 LL | static STATIC11: Box<MyOwned> = box MyOwned;
    |                                 ^^^^^^^^^^^ allocation not allowed in statics
 
-error[E0015]: calls in statics are limited to constant functions, tuple structs and tuple variants
-  --> $DIR/check-static-values-constraints.rs:89:32
+error[E0015]: cannot call non-const fn `<str as ToString>::to_string` in statics
+  --> $DIR/check-static-values-constraints.rs:89:38
    |
 LL |     field2: SafeEnum::Variant4("str".to_string())
-   |                                ^^^^^^^^^^^^^^^^^
+   |                                      ^^^^^^^^^^^
+   |
+   = note: calls in statics are limited to constant functions, tuple structs and tuple variants
 
 error[E0010]: allocations are not allowed in statics
   --> $DIR/check-static-values-constraints.rs:94:5

--- a/src/test/ui/const-generics/issue-93647.rs
+++ b/src/test/ui/const-generics/issue-93647.rs
@@ -1,6 +1,6 @@
 struct X<const N: usize = {
     (||1usize)()
-    //~^ ERROR calls in constants are limited to
+    //~^ ERROR cannot call
 }>;
 
 fn main() {}

--- a/src/test/ui/const-generics/issue-93647.stderr
+++ b/src/test/ui/const-generics/issue-93647.stderr
@@ -1,8 +1,11 @@
-error[E0015]: calls in constants are limited to constant functions, tuple structs and tuple variants
+error[E0015]: cannot call non-const closure in constants
   --> $DIR/issue-93647.rs:2:5
    |
 LL |     (||1usize)()
    |     ^^^^^^^^^^^^
+   |
+   = note: closures need an RFC before allowed to be called in constants
+   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
 
 error: aborting due to previous error
 

--- a/src/test/ui/const-generics/issues/issue-90318.rs
+++ b/src/test/ui/const-generics/issues/issue-90318.rs
@@ -13,7 +13,7 @@ fn consume<T: 'static>(_val: T)
 where
     If<{ TypeId::of::<T>() != TypeId::of::<()>() }>: True,
     //~^ ERROR: overly complex generic constant
-    //~| ERROR: calls in constants are limited to constant functions
+    //~| ERROR: cannot call non-const operator in constants
 {
 }
 
@@ -21,7 +21,7 @@ fn test<T: 'static>()
 where
     If<{ TypeId::of::<T>() != TypeId::of::<()>() }>: True,
     //~^ ERROR: overly complex generic constant
-    //~| ERROR: calls in constants are limited to constant functions
+    //~| ERROR: cannot call non-const operator in constants
 {
 }
 

--- a/src/test/ui/const-generics/issues/issue-90318.stderr
+++ b/src/test/ui/const-generics/issues/issue-90318.stderr
@@ -9,11 +9,19 @@ LL |     If<{ TypeId::of::<T>() != TypeId::of::<()>() }>: True,
    = help: consider moving this anonymous constant into a `const` function
    = note: this operation may be supported in the future
 
-error[E0015]: calls in constants are limited to constant functions, tuple structs and tuple variants
+error[E0015]: cannot call non-const operator in constants
   --> $DIR/issue-90318.rs:14:10
    |
 LL |     If<{ TypeId::of::<T>() != TypeId::of::<()>() }>: True,
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: impl defined here, but it is not `const`
+  --> $SRC_DIR/core/src/any.rs:LL:COL
+   |
+LL | #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
+   |                       ^^^^^^^^^
+   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
+   = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: overly complex generic constant
   --> $DIR/issue-90318.rs:22:8
@@ -26,11 +34,19 @@ LL |     If<{ TypeId::of::<T>() != TypeId::of::<()>() }>: True,
    = help: consider moving this anonymous constant into a `const` function
    = note: this operation may be supported in the future
 
-error[E0015]: calls in constants are limited to constant functions, tuple structs and tuple variants
+error[E0015]: cannot call non-const operator in constants
   --> $DIR/issue-90318.rs:22:10
    |
 LL |     If<{ TypeId::of::<T>() != TypeId::of::<()>() }>: True,
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: impl defined here, but it is not `const`
+  --> $SRC_DIR/core/src/any.rs:LL:COL
+   |
+LL | #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
+   |                       ^^^^^^^^^
+   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
+   = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/const-generics/nested-type.full.stderr
+++ b/src/test/ui/const-generics/nested-type.full.stderr
@@ -1,8 +1,10 @@
-error[E0015]: calls in constants are limited to constant functions, tuple structs and tuple variants
+error[E0015]: cannot call non-const fn `Foo::{constant#0}::Foo::<17_usize>::value` in constants
   --> $DIR/nested-type.rs:15:5
    |
 LL |     Foo::<17>::value()
    |     ^^^^^^^^^^^^^^^^^^
+   |
+   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
 
 error: aborting due to previous error
 

--- a/src/test/ui/const-generics/nested-type.min.stderr
+++ b/src/test/ui/const-generics/nested-type.min.stderr
@@ -14,11 +14,13 @@ LL | | }]>;
    = note: the only supported types are integers, `bool` and `char`
    = help: more complex types are supported with `#![feature(adt_const_params)]`
 
-error[E0015]: calls in constants are limited to constant functions, tuple structs and tuple variants
+error[E0015]: cannot call non-const fn `Foo::{constant#0}::Foo::<17_usize>::value` in constants
   --> $DIR/nested-type.rs:15:5
    |
 LL |     Foo::<17>::value()
    |     ^^^^^^^^^^^^^^^^^^
+   |
+   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/const-generics/nested-type.rs
+++ b/src/test/ui/const-generics/nested-type.rs
@@ -13,7 +13,7 @@ struct Foo<const N: [u8; { //[min]~ ERROR `[u8; _]` is forbidden
     }
 
     Foo::<17>::value()
-    //~^ ERROR calls in constants are limited to constant functions
+    //~^ ERROR cannot call non-const fn
 }]>;
 
 fn main() {}

--- a/src/test/ui/consts/const-call.rs
+++ b/src/test/ui/consts/const-call.rs
@@ -4,5 +4,5 @@ fn f(x: usize) -> usize {
 
 fn main() {
     let _ = [0; f(2)];
-    //~^ ERROR calls in constants are limited to constant functions
+    //~^ ERROR cannot call non-const fn
 }

--- a/src/test/ui/consts/const-call.stderr
+++ b/src/test/ui/consts/const-call.stderr
@@ -1,8 +1,10 @@
-error[E0015]: calls in constants are limited to constant functions, tuple structs and tuple variants
+error[E0015]: cannot call non-const fn `f` in constants
   --> $DIR/const-call.rs:6:17
    |
 LL |     let _ = [0; f(2)];
    |                 ^^^^
+   |
+   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/const-extern-fn/const-extern-fn-call-extern-fn.rs
+++ b/src/test/ui/consts/const-extern-fn/const-extern-fn-call-extern-fn.rs
@@ -7,7 +7,7 @@ extern "C" {
 const extern "C" fn bar() {
     unsafe {
         regular_in_block();
-        //~^ ERROR: calls in constant functions
+        //~^ ERROR: cannot call non-const fn
     }
 }
 
@@ -16,7 +16,7 @@ extern "C" fn regular() {}
 const extern "C" fn foo() {
     unsafe {
         regular();
-        //~^ ERROR: calls in constant functions
+        //~^ ERROR: cannot call non-const fn
     }
 }
 

--- a/src/test/ui/consts/const-extern-fn/const-extern-fn-call-extern-fn.stderr
+++ b/src/test/ui/consts/const-extern-fn/const-extern-fn-call-extern-fn.stderr
@@ -1,14 +1,18 @@
-error[E0015]: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+error[E0015]: cannot call non-const fn `regular_in_block` in constant functions
   --> $DIR/const-extern-fn-call-extern-fn.rs:9:9
    |
 LL |         regular_in_block();
    |         ^^^^^^^^^^^^^^^^^^
+   |
+   = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
 
-error[E0015]: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+error[E0015]: cannot call non-const fn `regular` in constant functions
   --> $DIR/const-extern-fn-call-extern-fn.rs:18:9
    |
 LL |         regular();
    |         ^^^^^^^^^
+   |
+   = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/consts/const-fn-error.rs
+++ b/src/test/ui/consts/const-fn-error.rs
@@ -4,8 +4,9 @@ const fn f(x: usize) -> usize {
     let mut sum = 0;
     for i in 0..x {
         //~^ ERROR mutable references
-        //~| ERROR calls in constant functions
-        //~| ERROR calls in constant functions
+        //~| ERROR cannot convert
+        //~| ERROR cannot call non-const fn
+        //~| ERROR E0080
         //~| ERROR `for` is not allowed in a `const fn`
         sum += i;
     }

--- a/src/test/ui/consts/const-fn-error.rs
+++ b/src/test/ui/consts/const-fn-error.rs
@@ -6,7 +6,6 @@ const fn f(x: usize) -> usize {
         //~^ ERROR mutable references
         //~| ERROR cannot convert
         //~| ERROR cannot call non-const fn
-        //~| ERROR E0080
         //~| ERROR `for` is not allowed in a `const fn`
         sum += i;
     }

--- a/src/test/ui/consts/const-fn-error.stderr
+++ b/src/test/ui/consts/const-fn-error.stderr
@@ -13,11 +13,18 @@ LL | |     }
    = note: see issue #87575 <https://github.com/rust-lang/rust/issues/87575> for more information
    = help: add `#![feature(const_for)]` to the crate attributes to enable
 
-error[E0015]: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+error[E0015]: cannot convert `std::ops::Range<usize>` into an iterator in constant functions
   --> $DIR/const-fn-error.rs:5:14
    |
 LL |     for i in 0..x {
    |              ^^^^
+   |
+note: impl defined here, but it is not `const`
+  --> $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
+   |
+LL | impl<I: Iterator> IntoIterator for I {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
 
 error[E0658]: mutable references are not allowed in constant functions
   --> $DIR/const-fn-error.rs:5:14
@@ -28,11 +35,13 @@ LL |     for i in 0..x {
    = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
 
-error[E0015]: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+error[E0015]: cannot call non-const fn `<std::ops::Range<usize> as Iterator>::next` in constant functions
   --> $DIR/const-fn-error.rs:5:14
    |
 LL |     for i in 0..x {
    |              ^^^^
+   |
+   = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/consts/const-fn-not-safe-for-const.stderr
+++ b/src/test/ui/consts/const-fn-not-safe-for-const.stderr
@@ -1,8 +1,10 @@
-error[E0015]: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+error[E0015]: cannot call non-const fn `random` in constant functions
   --> $DIR/const-fn-not-safe-for-const.rs:14:5
    |
 LL |     random()
    |     ^^^^^^^^
+   |
+   = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
 
 error[E0013]: constant functions cannot refer to statics
   --> $DIR/const-fn-not-safe-for-const.rs:20:5

--- a/src/test/ui/consts/const-for.rs
+++ b/src/test/ui/consts/const-for.rs
@@ -3,8 +3,8 @@
 
 const _: () = {
     for _ in 0..5 {}
-    //~^ error: calls in constants are limited to
-    //~| error: calls in constants are limited to
+    //~^ error: cannot convert
+    //~| error: cannot call non-const fn
 };
 
 fn main() {}

--- a/src/test/ui/consts/const-for.stderr
+++ b/src/test/ui/consts/const-for.stderr
@@ -1,14 +1,23 @@
-error[E0015]: calls in constants are limited to constant functions, tuple structs and tuple variants
+error[E0015]: cannot convert `std::ops::Range<i32>` into an iterator in constants
   --> $DIR/const-for.rs:5:14
    |
 LL |     for _ in 0..5 {}
    |              ^^^^
+   |
+note: impl defined here, but it is not `const`
+  --> $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
+   |
+LL | impl<I: Iterator> IntoIterator for I {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
 
-error[E0015]: calls in constants are limited to constant functions, tuple structs and tuple variants
+error[E0015]: cannot call non-const fn `<std::ops::Range<i32> as Iterator>::next` in constants
   --> $DIR/const-for.rs:5:14
    |
 LL |     for _ in 0..5 {}
    |              ^^^^
+   |
+   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/consts/control-flow/issue-46843.rs
+++ b/src/test/ui/consts/control-flow/issue-46843.rs
@@ -8,7 +8,7 @@ fn non_const() -> Thing {
 }
 
 pub const Q: i32 = match non_const() {
-    //~^ ERROR calls in constants are limited to constant functions
+    //~^ ERROR cannot call non-const fn
     Thing::This => 1,
     Thing::That => 0
 };

--- a/src/test/ui/consts/control-flow/issue-46843.stderr
+++ b/src/test/ui/consts/control-flow/issue-46843.stderr
@@ -1,8 +1,10 @@
-error[E0015]: calls in constants are limited to constant functions, tuple structs and tuple variants
+error[E0015]: cannot call non-const fn `non_const` in constants
   --> $DIR/issue-46843.rs:10:26
    |
 LL | pub const Q: i32 = match non_const() {
    |                          ^^^^^^^^^^^
+   |
+   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/intrinsic_without_const_stab.rs
+++ b/src/test/ui/consts/intrinsic_without_const_stab.rs
@@ -11,7 +11,7 @@ pub const unsafe fn copy<T>(src: *const T, dst: *mut T, count: usize) {
     }
 
     unsafe { copy(src, dst, count) }
-    //~^ ERROR calls in constant functions are limited to constant functions
+    //~^ ERROR cannot call non-const fn
 }
 
 fn main() {}

--- a/src/test/ui/consts/intrinsic_without_const_stab.stderr
+++ b/src/test/ui/consts/intrinsic_without_const_stab.stderr
@@ -1,8 +1,10 @@
-error[E0015]: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+error[E0015]: cannot call non-const fn `copy::copy::<T>` in constant functions
   --> $DIR/intrinsic_without_const_stab.rs:13:14
    |
 LL |     unsafe { copy(src, dst, count) }
    |              ^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/intrinsic_without_const_stab_fail.rs
+++ b/src/test/ui/consts/intrinsic_without_const_stab_fail.rs
@@ -9,7 +9,7 @@ extern "rust-intrinsic" {
 #[rustc_const_unstable(feature = "const_intrinsic_copy", issue = "80697")]
 #[inline]
 pub const unsafe fn stuff<T>(src: *const T, dst: *mut T, count: usize) {
-    unsafe { copy(src, dst, count) } //~ ERROR calls in constant functions are limited
+    unsafe { copy(src, dst, count) } //~ ERROR cannot call non-const fn
 }
 
 fn main() {}

--- a/src/test/ui/consts/intrinsic_without_const_stab_fail.stderr
+++ b/src/test/ui/consts/intrinsic_without_const_stab_fail.stderr
@@ -1,8 +1,10 @@
-error[E0015]: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+error[E0015]: cannot call non-const fn `copy::<T>` in constant functions
   --> $DIR/intrinsic_without_const_stab_fail.rs:12:14
    |
 LL |     unsafe { copy(src, dst, count) }
    |              ^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/issue-28113.rs
+++ b/src/test/ui/consts/issue-28113.rs
@@ -2,7 +2,7 @@
 
 const X: u8 =
     || -> u8 { 5 }()
-    //~^ ERROR cannot call non-const fn
+    //~^ ERROR cannot call non-const closure
 ;
 
 fn main() {}

--- a/src/test/ui/consts/issue-28113.rs
+++ b/src/test/ui/consts/issue-28113.rs
@@ -2,7 +2,7 @@
 
 const X: u8 =
     || -> u8 { 5 }()
-    //~^ ERROR calls in constants are limited to constant functions
+    //~^ ERROR cannot call non-const fn
 ;
 
 fn main() {}

--- a/src/test/ui/consts/issue-28113.stderr
+++ b/src/test/ui/consts/issue-28113.stderr
@@ -1,9 +1,10 @@
-error[E0015]: cannot call non-const fn `<[closure@$DIR/issue-28113.rs:4:5: 4:19] as Fn<()>>::call` in constants
+error[E0015]: cannot call non-const closure in constants
   --> $DIR/issue-28113.rs:4:5
    |
 LL |     || -> u8 { 5 }()
    |     ^^^^^^^^^^^^^^^^
    |
+   = note: closures need an RFC before allowed to be called in constants
    = note: calls in constants are limited to constant functions, tuple structs and tuple variants
 
 error: aborting due to previous error

--- a/src/test/ui/consts/issue-28113.stderr
+++ b/src/test/ui/consts/issue-28113.stderr
@@ -1,8 +1,10 @@
-error[E0015]: calls in constants are limited to constant functions, tuple structs and tuple variants
+error[E0015]: cannot call non-const fn `<[closure@$DIR/issue-28113.rs:4:5: 4:19] as Fn<()>>::call` in constants
   --> $DIR/issue-28113.rs:4:5
    |
 LL |     || -> u8 { 5 }()
    |     ^^^^^^^^^^^^^^^^
+   |
+   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/issue-32829-2.rs
+++ b/src/test/ui/consts/issue-32829-2.rs
@@ -8,7 +8,7 @@ const bad : u32 = {
 const bad_two : u32 = {
     {
         invalid();
-        //~^ ERROR: calls in constants are limited to constant functions, tuple structs and tuple variants
+        //~^ ERROR: cannot call non-const fn `invalid`
         0
     }
 };
@@ -30,7 +30,7 @@ static bad_four : u32 = {
 static bad_five : u32 = {
     {
         invalid();
-        //~^ ERROR: calls in statics are limited to constant functions, tuple structs and tuple variants
+        //~^ ERROR: cannot call non-const fn `invalid`
         0
     }
 };
@@ -52,7 +52,7 @@ static mut bad_seven : u32 = {
 static mut bad_eight : u32 = {
     {
         invalid();
-        //~^ ERROR: calls in statics are limited to constant functions, tuple structs and tuple variants
+        //~^ ERROR: cannot call non-const fn `invalid`
         0
     }
 };

--- a/src/test/ui/consts/issue-32829-2.stderr
+++ b/src/test/ui/consts/issue-32829-2.stderr
@@ -1,20 +1,26 @@
-error[E0015]: calls in constants are limited to constant functions, tuple structs and tuple variants
+error[E0015]: cannot call non-const fn `invalid` in constants
   --> $DIR/issue-32829-2.rs:10:9
    |
 LL |         invalid();
    |         ^^^^^^^^^
+   |
+   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
 
-error[E0015]: calls in statics are limited to constant functions, tuple structs and tuple variants
+error[E0015]: cannot call non-const fn `invalid` in statics
   --> $DIR/issue-32829-2.rs:32:9
    |
 LL |         invalid();
    |         ^^^^^^^^^
+   |
+   = note: calls in statics are limited to constant functions, tuple structs and tuple variants
 
-error[E0015]: calls in statics are limited to constant functions, tuple structs and tuple variants
+error[E0015]: cannot call non-const fn `invalid` in statics
   --> $DIR/issue-32829-2.rs:54:9
    |
 LL |         invalid();
    |         ^^^^^^^^^
+   |
+   = note: calls in statics are limited to constant functions, tuple structs and tuple variants
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/consts/issue-43105.rs
+++ b/src/test/ui/consts/issue-43105.rs
@@ -1,7 +1,7 @@
 fn xyz() -> u8 { 42 }
 
 const NUM: u8 = xyz();
-//~^ ERROR calls in constants are limited to constant functions, tuple structs and tuple variants
+//~^ ERROR cannot call non-const fn
 
 fn main() {
     match 1 {

--- a/src/test/ui/consts/issue-43105.stderr
+++ b/src/test/ui/consts/issue-43105.stderr
@@ -1,8 +1,10 @@
-error[E0015]: calls in constants are limited to constant functions, tuple structs and tuple variants
+error[E0015]: cannot call non-const fn `xyz` in constants
   --> $DIR/issue-43105.rs:3:17
    |
 LL | const NUM: u8 = xyz();
    |                 ^^^^^
+   |
+   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
 
 error: could not evaluate constant pattern
   --> $DIR/issue-43105.rs:8:9

--- a/src/test/ui/consts/issue-56164.rs
+++ b/src/test/ui/consts/issue-56164.rs
@@ -1,7 +1,7 @@
 #![feature(const_fn_fn_ptr_basics)]
 
 const fn foo() { (||{})() }
-//~^ ERROR cannot call non-const fn
+//~^ ERROR cannot call non-const closure
 
 const fn bad(input: fn()) {
     input()

--- a/src/test/ui/consts/issue-56164.rs
+++ b/src/test/ui/consts/issue-56164.rs
@@ -1,7 +1,7 @@
 #![feature(const_fn_fn_ptr_basics)]
 
 const fn foo() { (||{})() }
-//~^ ERROR calls in constant functions
+//~^ ERROR cannot call non-const fn
 
 const fn bad(input: fn()) {
     input()

--- a/src/test/ui/consts/issue-56164.stderr
+++ b/src/test/ui/consts/issue-56164.stderr
@@ -1,9 +1,10 @@
-error[E0015]: cannot call non-const fn `<[closure@$DIR/issue-56164.rs:3:18: 3:24] as Fn<()>>::call` in constant functions
+error[E0015]: cannot call non-const closure in constant functions
   --> $DIR/issue-56164.rs:3:18
    |
 LL | const fn foo() { (||{})() }
    |                  ^^^^^^^^
    |
+   = note: closures need an RFC before allowed to be called in constant functions
    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
 
 error: function pointers are not allowed in const fn

--- a/src/test/ui/consts/issue-56164.stderr
+++ b/src/test/ui/consts/issue-56164.stderr
@@ -1,8 +1,10 @@
-error[E0015]: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+error[E0015]: cannot call non-const fn `<[closure@$DIR/issue-56164.rs:3:18: 3:24] as Fn<()>>::call` in constant functions
   --> $DIR/issue-56164.rs:3:18
    |
 LL | const fn foo() { (||{})() }
    |                  ^^^^^^^^
+   |
+   = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
 
 error: function pointers are not allowed in const fn
   --> $DIR/issue-56164.rs:7:5

--- a/src/test/ui/consts/issue-68542-closure-in-array-len.rs
+++ b/src/test/ui/consts/issue-68542-closure-in-array-len.rs
@@ -3,7 +3,7 @@
 // in the length part of an array.
 
 struct Bug {
-    a: [(); (|| { 0 })()] //~ ERROR calls in constants are limited to
+    a: [(); (|| { 0 })()] //~ ERROR cannot call non-const fn
 }
 
 fn main() {}

--- a/src/test/ui/consts/issue-68542-closure-in-array-len.rs
+++ b/src/test/ui/consts/issue-68542-closure-in-array-len.rs
@@ -3,7 +3,7 @@
 // in the length part of an array.
 
 struct Bug {
-    a: [(); (|| { 0 })()] //~ ERROR cannot call non-const fn
+    a: [(); (|| { 0 })()] //~ ERROR cannot call non-const closure
 }
 
 fn main() {}

--- a/src/test/ui/consts/issue-68542-closure-in-array-len.stderr
+++ b/src/test/ui/consts/issue-68542-closure-in-array-len.stderr
@@ -1,8 +1,10 @@
-error[E0015]: calls in constants are limited to constant functions, tuple structs and tuple variants
+error[E0015]: cannot call non-const fn `<[closure@$DIR/issue-68542-closure-in-array-len.rs:6:13: 6:23] as Fn<()>>::call` in constants
   --> $DIR/issue-68542-closure-in-array-len.rs:6:13
    |
 LL |     a: [(); (|| { 0 })()]
    |             ^^^^^^^^^^^^
+   |
+   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/issue-68542-closure-in-array-len.stderr
+++ b/src/test/ui/consts/issue-68542-closure-in-array-len.stderr
@@ -1,9 +1,10 @@
-error[E0015]: cannot call non-const fn `<[closure@$DIR/issue-68542-closure-in-array-len.rs:6:13: 6:23] as Fn<()>>::call` in constants
+error[E0015]: cannot call non-const closure in constants
   --> $DIR/issue-68542-closure-in-array-len.rs:6:13
    |
 LL |     a: [(); (|| { 0 })()]
    |             ^^^^^^^^^^^^
    |
+   = note: closures need an RFC before allowed to be called in constants
    = note: calls in constants are limited to constant functions, tuple structs and tuple variants
 
 error: aborting due to previous error

--- a/src/test/ui/consts/issue-90870.fixed
+++ b/src/test/ui/consts/issue-90870.fixed
@@ -6,20 +6,20 @@
 
 const fn f(a: &u8, b: &u8) -> bool {
     *a == *b
-    //~^ ERROR: calls in constant functions are limited to constant functions, tuple structs and tuple variants [E0015]
+    //~^ ERROR: cannot call non-const operator in constant functions [E0015]
     //~| HELP: consider dereferencing here
 }
 
 const fn g(a: &&&&i64, b: &&&&i64) -> bool {
     ****a == ****b
-    //~^ ERROR: calls in constant functions are limited to constant functions, tuple structs and tuple variants [E0015]
+    //~^ ERROR: cannot call non-const operator in constant functions [E0015]
     //~| HELP: consider dereferencing here
 }
 
 const fn h(mut a: &[u8], mut b: &[u8]) -> bool {
     while let ([l, at @ ..], [r, bt @ ..]) = (a, b) {
         if *l == *r {
-        //~^ ERROR: calls in constant functions are limited to constant functions, tuple structs and tuple variants [E0015]
+        //~^ ERROR: cannot call non-const operator in constant functions [E0015]
         //~| HELP: consider dereferencing here
             a = at;
             b = bt;

--- a/src/test/ui/consts/issue-90870.rs
+++ b/src/test/ui/consts/issue-90870.rs
@@ -6,20 +6,20 @@
 
 const fn f(a: &u8, b: &u8) -> bool {
     a == b
-    //~^ ERROR: calls in constant functions are limited to constant functions, tuple structs and tuple variants [E0015]
+    //~^ ERROR: cannot call non-const operator in constant functions [E0015]
     //~| HELP: consider dereferencing here
 }
 
 const fn g(a: &&&&i64, b: &&&&i64) -> bool {
     a == b
-    //~^ ERROR: calls in constant functions are limited to constant functions, tuple structs and tuple variants [E0015]
+    //~^ ERROR: cannot call non-const operator in constant functions [E0015]
     //~| HELP: consider dereferencing here
 }
 
 const fn h(mut a: &[u8], mut b: &[u8]) -> bool {
     while let ([l, at @ ..], [r, bt @ ..]) = (a, b) {
         if l == r {
-        //~^ ERROR: calls in constant functions are limited to constant functions, tuple structs and tuple variants [E0015]
+        //~^ ERROR: cannot call non-const operator in constant functions [E0015]
         //~| HELP: consider dereferencing here
             a = at;
             b = bt;

--- a/src/test/ui/consts/issue-90870.stderr
+++ b/src/test/ui/consts/issue-90870.stderr
@@ -1,31 +1,34 @@
-error[E0015]: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+error[E0015]: cannot call non-const operator in constant functions
   --> $DIR/issue-90870.rs:8:5
    |
 LL |     a == b
    |     ^^^^^^
    |
+   = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
 help: consider dereferencing here
    |
 LL |     *a == *b
    |     +     +
 
-error[E0015]: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+error[E0015]: cannot call non-const operator in constant functions
   --> $DIR/issue-90870.rs:14:5
    |
 LL |     a == b
    |     ^^^^^^
    |
+   = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
 help: consider dereferencing here
    |
 LL |     ****a == ****b
    |     ++++     ++++
 
-error[E0015]: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+error[E0015]: cannot call non-const operator in constant functions
   --> $DIR/issue-90870.rs:21:12
    |
 LL |         if l == r {
    |            ^^^^^^
    |
+   = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
 help: consider dereferencing here
    |
 LL |         if *l == *r {

--- a/src/test/ui/consts/min_const_fn/bad_const_fn_body_ice.rs
+++ b/src/test/ui/consts/min_const_fn/bad_const_fn_body_ice.rs
@@ -1,7 +1,7 @@
 const fn foo(a: i32) -> Vec<i32> {
     vec![1, 2, 3]
     //~^ ERROR allocations are not allowed
-    //~| ERROR calls in constant functions
+    //~| ERROR cannot call non-const fn
 }
 
 fn main() {}

--- a/src/test/ui/consts/min_const_fn/bad_const_fn_body_ice.stderr
+++ b/src/test/ui/consts/min_const_fn/bad_const_fn_body_ice.stderr
@@ -6,12 +6,13 @@ LL |     vec![1, 2, 3]
    |
    = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0015]: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+error[E0015]: cannot call non-const fn `slice::<impl [i32]>::into_vec::<std::alloc::Global>` in constant functions
   --> $DIR/bad_const_fn_body_ice.rs:2:5
    |
 LL |     vec![1, 2, 3]
    |     ^^^^^^^^^^^^^
    |
+   = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
    = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/consts/mir_check_nonconst.rs
+++ b/src/test/ui/consts/mir_check_nonconst.rs
@@ -6,6 +6,6 @@ fn bar() -> Foo {
 }
 
 static foo: Foo = bar();
-//~^ ERROR calls in statics are limited to constant functions, tuple structs and tuple variants
+//~^ ERROR cannot call non-const fn
 
 fn main() {}

--- a/src/test/ui/consts/mir_check_nonconst.stderr
+++ b/src/test/ui/consts/mir_check_nonconst.stderr
@@ -1,8 +1,10 @@
-error[E0015]: calls in statics are limited to constant functions, tuple structs and tuple variants
+error[E0015]: cannot call non-const fn `bar` in statics
   --> $DIR/mir_check_nonconst.rs:8:19
    |
 LL | static foo: Foo = bar();
    |                   ^^^^^
+   |
+   = note: calls in statics are limited to constant functions, tuple structs and tuple variants
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/unstable-const-fn-in-libcore.stderr
+++ b/src/test/ui/consts/unstable-const-fn-in-libcore.stderr
@@ -1,8 +1,10 @@
-error[E0015]: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+error[E0015]: cannot call non-const fn `<F as FnOnce<()>>::call_once` in constant functions
   --> $DIR/unstable-const-fn-in-libcore.rs:24:26
    |
 LL |             Opt::None => f(),
    |                          ^^^
+   |
+   = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
 
 error[E0493]: destructors cannot be evaluated at compile-time
   --> $DIR/unstable-const-fn-in-libcore.rs:19:53

--- a/src/test/ui/consts/unstable-const-fn-in-libcore.stderr
+++ b/src/test/ui/consts/unstable-const-fn-in-libcore.stderr
@@ -1,10 +1,14 @@
-error[E0015]: cannot call non-const fn `<F as FnOnce<()>>::call_once` in constant functions
+error[E0015]: cannot call non-const closure in constant functions
   --> $DIR/unstable-const-fn-in-libcore.rs:24:26
    |
 LL |             Opt::None => f(),
    |                          ^^^
    |
    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+help: consider further restricting this bound
+   |
+LL |     const fn unwrap_or_else<F: FnOnce() -> T + ~const std::ops::FnOnce<()>>(self, f: F) -> T {
+   |                                              +++++++++++++++++++++++++++++
 
 error[E0493]: destructors cannot be evaluated at compile-time
   --> $DIR/unstable-const-fn-in-libcore.rs:19:53

--- a/src/test/ui/issues/issue-16538.mir.stderr
+++ b/src/test/ui/issues/issue-16538.mir.stderr
@@ -1,8 +1,10 @@
-error[E0015]: calls in statics are limited to constant functions, tuple structs and tuple variants
+error[E0015]: cannot call non-const fn `Y::foo` in statics
   --> $DIR/issue-16538.rs:15:23
    |
 LL | static foo: &Y::X = &*Y::foo(Y::x as *const Y::X);
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: calls in statics are limited to constant functions, tuple structs and tuple variants
 
 error[E0133]: use of extern static is unsafe and requires unsafe function or block
   --> $DIR/issue-16538.rs:15:30

--- a/src/test/ui/issues/issue-16538.thir.stderr
+++ b/src/test/ui/issues/issue-16538.thir.stderr
@@ -14,11 +14,13 @@ LL | static foo: &Y::X = &*Y::foo(Y::x as *const Y::X);
    |
    = note: extern statics are not controlled by the Rust type system: invalid data, aliasing violations or data races will cause undefined behavior
 
-error[E0015]: calls in statics are limited to constant functions, tuple structs and tuple variants
+error[E0015]: cannot call non-const fn `Y::foo` in statics
   --> $DIR/issue-16538.rs:15:23
    |
 LL | static foo: &Y::X = &*Y::foo(Y::x as *const Y::X);
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: calls in statics are limited to constant functions, tuple structs and tuple variants
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/issues/issue-25901.rs
+++ b/src/test/ui/issues/issue-25901.rs
@@ -2,7 +2,7 @@ struct A;
 struct B;
 
 static S: &'static B = &A;
-//~^ ERROR calls in statics are limited to constant functions
+//~^ ERROR cannot perform deref coercion on `A` in statics
 
 use std::ops::Deref;
 

--- a/src/test/ui/issues/issue-25901.stderr
+++ b/src/test/ui/issues/issue-25901.stderr
@@ -1,8 +1,21 @@
-error[E0015]: calls in statics are limited to constant functions, tuple structs and tuple variants
+error[E0015]: cannot perform deref coercion on `A` in statics
   --> $DIR/issue-25901.rs:4:24
    |
 LL | static S: &'static B = &A;
    |                        ^^
+   |
+   = note: attempting to deref into `B`
+note: deref defined here
+  --> $DIR/issue-25901.rs:10:5
+   |
+LL |     type Target = B;
+   |     ^^^^^^^^^^^^^^^^
+note: impl defined here, but it is not `const`
+  --> $DIR/issue-25901.rs:9:1
+   |
+LL | impl Deref for A {
+   | ^^^^^^^^^^^^^^^^
+   = note: calls in statics are limited to constant functions, tuple structs and tuple variants
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-39559-2.stderr
+++ b/src/test/ui/issues/issue-39559-2.stderr
@@ -1,14 +1,18 @@
-error[E0015]: calls in constants are limited to constant functions, tuple structs and tuple variants
+error[E0015]: cannot call non-const fn `<Dim3 as Dim>::dim` in constants
   --> $DIR/issue-39559-2.rs:14:24
    |
 LL |     let array: [usize; Dim3::dim()]
    |                        ^^^^^^^^^^^
+   |
+   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
 
-error[E0015]: calls in constants are limited to constant functions, tuple structs and tuple variants
+error[E0015]: cannot call non-const fn `<Dim3 as Dim>::dim` in constants
   --> $DIR/issue-39559-2.rs:16:15
    |
 LL |         = [0; Dim3::dim()];
    |               ^^^^^^^^^^^
+   |
+   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/never_type/issue-52443.rs
+++ b/src/test/ui/never_type/issue-52443.rs
@@ -8,7 +8,7 @@ fn main() {
 
     [(); { for _ in 0usize.. {}; 0}];
     //~^ ERROR `for` is not allowed in a `const`
-    //~| ERROR calls in constants are limited to constant functions
+    //~| ERROR cannot convert
     //~| ERROR mutable references are not allowed in constants
-    //~| ERROR calls in constants are limited to constant functions
+    //~| ERROR cannot call non-const fn
 }

--- a/src/test/ui/never_type/issue-52443.stderr
+++ b/src/test/ui/never_type/issue-52443.stderr
@@ -38,11 +38,18 @@ LL |     [(); loop { break }];
    |                 expected `usize`, found `()`
    |                 help: give it a value of the expected type: `break 42`
 
-error[E0015]: calls in constants are limited to constant functions, tuple structs and tuple variants
+error[E0015]: cannot convert `RangeFrom<usize>` into an iterator in constants
   --> $DIR/issue-52443.rs:9:21
    |
 LL |     [(); { for _ in 0usize.. {}; 0}];
    |                     ^^^^^^^^
+   |
+note: impl defined here, but it is not `const`
+  --> $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
+   |
+LL | impl<I: Iterator> IntoIterator for I {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
 
 error[E0658]: mutable references are not allowed in constants
   --> $DIR/issue-52443.rs:9:21
@@ -53,11 +60,13 @@ LL |     [(); { for _ in 0usize.. {}; 0}];
    = note: see issue #57349 <https://github.com/rust-lang/rust/issues/57349> for more information
    = help: add `#![feature(const_mut_refs)]` to the crate attributes to enable
 
-error[E0015]: calls in constants are limited to constant functions, tuple structs and tuple variants
+error[E0015]: cannot call non-const fn `<RangeFrom<usize> as Iterator>::next` in constants
   --> $DIR/issue-52443.rs:9:21
    |
 LL |     [(); { for _ in 0usize.. {}; 0}];
    |                     ^^^^^^^^
+   |
+   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
 
 error: aborting due to 6 previous errors; 1 warning emitted
 

--- a/src/test/ui/rfc-2632-const-trait-impl/call-const-trait-method-fail.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/call-const-trait-method-fail.rs
@@ -22,7 +22,8 @@ pub const fn add_i32(a: i32, b: i32) -> i32 {
 
 pub const fn add_u32(a: u32, b: u32) -> u32 {
     a.plus(b)
-    //~^ ERROR cannot call non-const fn
+    //~^ ERROR the trait bound
+    //~| ERROR cannot call non-const fn
 }
 
 fn main() {}

--- a/src/test/ui/rfc-2632-const-trait-impl/call-const-trait-method-fail.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/call-const-trait-method-fail.rs
@@ -22,7 +22,7 @@ pub const fn add_i32(a: i32, b: i32) -> i32 {
 
 pub const fn add_u32(a: u32, b: u32) -> u32 {
     a.plus(b)
-    //~^ ERROR calls in constant functions are limited to constant functions
+    //~^ ERROR cannot call non-const fn
 }
 
 fn main() {}

--- a/src/test/ui/rfc-2632-const-trait-impl/call-const-trait-method-fail.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/call-const-trait-method-fail.stderr
@@ -3,6 +3,12 @@ error[E0277]: the trait bound `u32: ~const Plus` is not satisfied
    |
 LL |     a.plus(b)
    |       ^^^^^^^ the trait `~const Plus` is not implemented for `u32`
+   |
+note: the trait `Plus` is implemented for `u32`, but that implementation is not `const`
+  --> $DIR/call-const-trait-method-fail.rs:24:7
+   |
+LL |     a.plus(b)
+   |       ^^^^^^^
 
 error[E0015]: cannot call non-const fn `<u32 as Plus>::plus` in constant functions
   --> $DIR/call-const-trait-method-fail.rs:24:7

--- a/src/test/ui/rfc-2632-const-trait-impl/call-const-trait-method-fail.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/call-const-trait-method-fail.stderr
@@ -1,3 +1,9 @@
+error[E0277]: the trait bound `u32: ~const Plus` is not satisfied
+  --> $DIR/call-const-trait-method-fail.rs:24:7
+   |
+LL |     a.plus(b)
+   |       ^^^^^^^ the trait `~const Plus` is not implemented for `u32`
+
 error[E0015]: cannot call non-const fn `<u32 as Plus>::plus` in constant functions
   --> $DIR/call-const-trait-method-fail.rs:24:7
    |
@@ -6,6 +12,7 @@ LL |     a.plus(b)
    |
    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
 
-error: aborting due to previous error
+error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0015`.
+Some errors have detailed explanations: E0015, E0277.
+For more information about an error, try `rustc --explain E0015`.

--- a/src/test/ui/rfc-2632-const-trait-impl/call-const-trait-method-fail.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/call-const-trait-method-fail.stderr
@@ -1,8 +1,10 @@
-error[E0015]: calls in constant functions are limited to constant functions, tuple structs and tuple variants
-  --> $DIR/call-const-trait-method-fail.rs:24:5
+error[E0015]: cannot call non-const fn `<u32 as Plus>::plus` in constant functions
+  --> $DIR/call-const-trait-method-fail.rs:24:7
    |
 LL |     a.plus(b)
-   |     ^^^^^^^^^
+   |       ^^^^^^^
+   |
+   = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
 
 error: aborting due to previous error
 

--- a/src/test/ui/rfc-2632-const-trait-impl/call-generic-method-fail.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/call-generic-method-fail.rs
@@ -3,7 +3,7 @@
 
 pub const fn equals_self<T: PartialEq>(t: &T) -> bool {
     *t == *t
-    //~^ ERROR calls in constant functions are limited to constant functions
+    //~^ ERROR cannot call non-const operator
 }
 
 fn main() {}

--- a/src/test/ui/rfc-2632-const-trait-impl/call-generic-method-fail.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/call-generic-method-fail.rs
@@ -3,7 +3,8 @@
 
 pub const fn equals_self<T: PartialEq>(t: &T) -> bool {
     *t == *t
-    //~^ ERROR cannot call non-const operator
+    //~^ ERROR can't compare
+    //~| ERROR cannot call non-const
 }
 
 fn main() {}

--- a/src/test/ui/rfc-2632-const-trait-impl/call-generic-method-fail.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/call-generic-method-fail.stderr
@@ -1,8 +1,14 @@
-error[E0015]: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+error[E0015]: cannot call non-const operator in constant functions
   --> $DIR/call-generic-method-fail.rs:5:5
    |
 LL |     *t == *t
    |     ^^^^^^^^
+   |
+   = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+help: consider further restricting this bound
+   |
+LL | pub const fn equals_self<T: PartialEq + ~const std::cmp::PartialEq>(t: &T) -> bool {
+   |                                       ++++++++++++++++++++++++++++
 
 error: aborting due to previous error
 

--- a/src/test/ui/rfc-2632-const-trait-impl/call-generic-method-fail.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/call-generic-method-fail.stderr
@@ -3,6 +3,12 @@ error[E0277]: can't compare `T` with `T` in const contexts
    |
 LL |     *t == *t
    |     ^^^^^^^^ no implementation for `T == T`
+   |
+note: the trait `PartialEq` is implemented for `T`, but that implementation is not `const`
+  --> $DIR/call-generic-method-fail.rs:5:5
+   |
+LL |     *t == *t
+   |     ^^^^^^^^
 
 error[E0015]: cannot call non-const operator in constant functions
   --> $DIR/call-generic-method-fail.rs:5:5

--- a/src/test/ui/rfc-2632-const-trait-impl/call-generic-method-fail.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/call-generic-method-fail.stderr
@@ -1,3 +1,9 @@
+error[E0277]: can't compare `T` with `T` in const contexts
+  --> $DIR/call-generic-method-fail.rs:5:5
+   |
+LL |     *t == *t
+   |     ^^^^^^^^ no implementation for `T == T`
+
 error[E0015]: cannot call non-const operator in constant functions
   --> $DIR/call-generic-method-fail.rs:5:5
    |
@@ -10,6 +16,7 @@ help: consider further restricting this bound
 LL | pub const fn equals_self<T: PartialEq + ~const std::cmp::PartialEq>(t: &T) -> bool {
    |                                       ++++++++++++++++++++++++++++
 
-error: aborting due to previous error
+error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0015`.
+Some errors have detailed explanations: E0015, E0277.
+For more information about an error, try `rustc --explain E0015`.

--- a/src/test/ui/rfc-2632-const-trait-impl/const-check-fns-in-const-impl.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/const-check-fns-in-const-impl.rs
@@ -9,7 +9,7 @@ fn non_const() {}
 
 impl const T for S {
     fn foo() { non_const() }
-    //~^ ERROR calls in constant functions
+    //~^ ERROR cannot call non-const fn
 }
 
 fn main() {}

--- a/src/test/ui/rfc-2632-const-trait-impl/const-check-fns-in-const-impl.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/const-check-fns-in-const-impl.stderr
@@ -1,8 +1,10 @@
-error[E0015]: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+error[E0015]: cannot call non-const fn `non_const` in constant functions
   --> $DIR/const-check-fns-in-const-impl.rs:11:16
    |
 LL |     fn foo() { non_const() }
    |                ^^^^^^^^^^^
+   |
+   = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
 
 error: aborting due to previous error
 

--- a/src/test/ui/rfc-2632-const-trait-impl/const-default-method-bodies.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/const-default-method-bodies.rs
@@ -23,7 +23,8 @@ impl const ConstDefaultFn for ConstImpl {
 
 const fn test() {
     NonConstImpl.a();
-    //~^ ERROR cannot call non-const fn
+    //~^ ERROR the trait bound
+    //~| ERROR cannot call non-const fn
     ConstImpl.a();
 }
 

--- a/src/test/ui/rfc-2632-const-trait-impl/const-default-method-bodies.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/const-default-method-bodies.rs
@@ -23,7 +23,7 @@ impl const ConstDefaultFn for ConstImpl {
 
 const fn test() {
     NonConstImpl.a();
-    //~^ ERROR calls in constant functions are limited to constant functions, tuple structs and tuple variants
+    //~^ ERROR cannot call non-const fn
     ConstImpl.a();
 }
 

--- a/src/test/ui/rfc-2632-const-trait-impl/const-default-method-bodies.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/const-default-method-bodies.stderr
@@ -1,8 +1,10 @@
-error[E0015]: calls in constant functions are limited to constant functions, tuple structs and tuple variants
-  --> $DIR/const-default-method-bodies.rs:25:5
+error[E0015]: cannot call non-const fn `<NonConstImpl as ConstDefaultFn>::a` in constant functions
+  --> $DIR/const-default-method-bodies.rs:25:18
    |
 LL |     NonConstImpl.a();
-   |     ^^^^^^^^^^^^^^^^
+   |                  ^^^
+   |
+   = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
 
 error: aborting due to previous error
 

--- a/src/test/ui/rfc-2632-const-trait-impl/const-default-method-bodies.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/const-default-method-bodies.stderr
@@ -3,6 +3,12 @@ error[E0277]: the trait bound `NonConstImpl: ~const ConstDefaultFn` is not satis
    |
 LL |     NonConstImpl.a();
    |                  ^^^ the trait `~const ConstDefaultFn` is not implemented for `NonConstImpl`
+   |
+note: the trait `ConstDefaultFn` is implemented for `NonConstImpl`, but that implementation is not `const`
+  --> $DIR/const-default-method-bodies.rs:25:18
+   |
+LL |     NonConstImpl.a();
+   |                  ^^^
 
 error[E0015]: cannot call non-const fn `<NonConstImpl as ConstDefaultFn>::a` in constant functions
   --> $DIR/const-default-method-bodies.rs:25:18

--- a/src/test/ui/rfc-2632-const-trait-impl/const-default-method-bodies.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/const-default-method-bodies.stderr
@@ -1,3 +1,9 @@
+error[E0277]: the trait bound `NonConstImpl: ~const ConstDefaultFn` is not satisfied
+  --> $DIR/const-default-method-bodies.rs:25:18
+   |
+LL |     NonConstImpl.a();
+   |                  ^^^ the trait `~const ConstDefaultFn` is not implemented for `NonConstImpl`
+
 error[E0015]: cannot call non-const fn `<NonConstImpl as ConstDefaultFn>::a` in constant functions
   --> $DIR/const-default-method-bodies.rs:25:18
    |
@@ -6,6 +12,7 @@ LL |     NonConstImpl.a();
    |
    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
 
-error: aborting due to previous error
+error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0015`.
+Some errors have detailed explanations: E0015, E0277.
+For more information about an error, try `rustc --explain E0015`.

--- a/src/test/ui/rfc-2632-const-trait-impl/cross-crate.gated.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/cross-crate.gated.stderr
@@ -1,8 +1,10 @@
-error[E0015]: calls in constant functions are limited to constant functions, tuple structs and tuple variants
-  --> $DIR/cross-crate.rs:15:5
+error[E0015]: cannot call non-const fn `<cross_crate::NonConst as cross_crate::MyTrait>::func` in constant functions
+  --> $DIR/cross-crate.rs:15:14
    |
 LL |     NonConst.func();
-   |     ^^^^^^^^^^^^^^^
+   |              ^^^^^^
+   |
+   = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
 
 error: aborting due to previous error
 

--- a/src/test/ui/rfc-2632-const-trait-impl/cross-crate.gated.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/cross-crate.gated.stderr
@@ -3,6 +3,12 @@ error[E0277]: the trait bound `cross_crate::NonConst: ~const cross_crate::MyTrai
    |
 LL |     NonConst.func();
    |              ^^^^^^ the trait `~const cross_crate::MyTrait` is not implemented for `cross_crate::NonConst`
+   |
+note: the trait `cross_crate::MyTrait` is implemented for `cross_crate::NonConst`, but that implementation is not `const`
+  --> $DIR/cross-crate.rs:15:14
+   |
+LL |     NonConst.func();
+   |              ^^^^^^
 
 error[E0015]: cannot call non-const fn `<cross_crate::NonConst as cross_crate::MyTrait>::func` in constant functions
   --> $DIR/cross-crate.rs:15:14

--- a/src/test/ui/rfc-2632-const-trait-impl/cross-crate.gated.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/cross-crate.gated.stderr
@@ -1,3 +1,9 @@
+error[E0277]: the trait bound `cross_crate::NonConst: ~const cross_crate::MyTrait` is not satisfied
+  --> $DIR/cross-crate.rs:15:14
+   |
+LL |     NonConst.func();
+   |              ^^^^^^ the trait `~const cross_crate::MyTrait` is not implemented for `cross_crate::NonConst`
+
 error[E0015]: cannot call non-const fn `<cross_crate::NonConst as cross_crate::MyTrait>::func` in constant functions
   --> $DIR/cross-crate.rs:15:14
    |
@@ -6,6 +12,7 @@ LL |     NonConst.func();
    |
    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
 
-error: aborting due to previous error
+error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0015`.
+Some errors have detailed explanations: E0015, E0277.
+For more information about an error, try `rustc --explain E0015`.

--- a/src/test/ui/rfc-2632-const-trait-impl/cross-crate.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/cross-crate.rs
@@ -12,8 +12,8 @@ fn non_const_context() {
 }
 
 const fn const_context() {
-    NonConst.func();
-    //~^ ERROR: cannot call non-const fn
+    NonConst.func(); //~ ERROR: cannot call non-const fn
+    //[gated]~^ ERROR: the trait bound
     Const.func();
     //[stock]~^ ERROR: cannot call non-const fn
 }

--- a/src/test/ui/rfc-2632-const-trait-impl/cross-crate.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/cross-crate.rs
@@ -13,9 +13,9 @@ fn non_const_context() {
 
 const fn const_context() {
     NonConst.func();
-    //~^ ERROR: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+    //~^ ERROR: cannot call non-const fn
     Const.func();
-    //[stock]~^ ERROR: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+    //[stock]~^ ERROR: cannot call non-const fn
 }
 
 fn main() {}

--- a/src/test/ui/rfc-2632-const-trait-impl/cross-crate.stock.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/cross-crate.stock.stderr
@@ -1,14 +1,18 @@
-error[E0015]: calls in constant functions are limited to constant functions, tuple structs and tuple variants
-  --> $DIR/cross-crate.rs:15:5
+error[E0015]: cannot call non-const fn `<cross_crate::NonConst as cross_crate::MyTrait>::func` in constant functions
+  --> $DIR/cross-crate.rs:15:14
    |
 LL |     NonConst.func();
-   |     ^^^^^^^^^^^^^^^
+   |              ^^^^^^
+   |
+   = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
 
-error[E0015]: calls in constant functions are limited to constant functions, tuple structs and tuple variants
-  --> $DIR/cross-crate.rs:17:5
+error[E0015]: cannot call non-const fn `<cross_crate::Const as cross_crate::MyTrait>::func` in constant functions
+  --> $DIR/cross-crate.rs:17:11
    |
 LL |     Const.func();
-   |     ^^^^^^^^^^^^
+   |           ^^^^^^
+   |
+   = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/rfc-2632-const-trait-impl/default-method-body-is-const-same-trait-ck.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/default-method-body-is-const-same-trait-ck.rs
@@ -8,7 +8,8 @@ pub trait Tr {
     #[default_method_body_is_const]
     fn b(&self) {
         ().a()
-        //~^ ERROR calls in constant functions are limited
+        //~^ ERROR the trait bound
+        //~| ERROR cannot call
     }
 }
 

--- a/src/test/ui/rfc-2632-const-trait-impl/default-method-body-is-const-same-trait-ck.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/default-method-body-is-const-same-trait-ck.stderr
@@ -1,9 +1,18 @@
-error[E0015]: calls in constant functions are limited to constant functions, tuple structs and tuple variants
-  --> $DIR/default-method-body-is-const-same-trait-ck.rs:10:9
+error[E0277]: the trait bound `(): ~const Tr` is not satisfied
+  --> $DIR/default-method-body-is-const-same-trait-ck.rs:10:12
    |
 LL |         ().a()
-   |         ^^^^^^
+   |            ^^^ the trait `~const Tr` is not implemented for `()`
 
-error: aborting due to previous error
+error[E0015]: cannot call non-const fn `<() as Tr>::a` in constant functions
+  --> $DIR/default-method-body-is-const-same-trait-ck.rs:10:12
+   |
+LL |         ().a()
+   |            ^^^
+   |
+   = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
 
-For more information about this error, try `rustc --explain E0015`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0015, E0277.
+For more information about an error, try `rustc --explain E0015`.

--- a/src/test/ui/rfc-2632-const-trait-impl/default-method-body-is-const-same-trait-ck.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/default-method-body-is-const-same-trait-ck.stderr
@@ -3,6 +3,12 @@ error[E0277]: the trait bound `(): ~const Tr` is not satisfied
    |
 LL |         ().a()
    |            ^^^ the trait `~const Tr` is not implemented for `()`
+   |
+note: the trait `Tr` is implemented for `()`, but that implementation is not `const`
+  --> $DIR/default-method-body-is-const-same-trait-ck.rs:10:12
+   |
+LL |         ().a()
+   |            ^^^
 
 error[E0015]: cannot call non-const fn `<() as Tr>::a` in constant functions
   --> $DIR/default-method-body-is-const-same-trait-ck.rs:10:12

--- a/src/test/ui/rfc-2632-const-trait-impl/issue-88155.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/issue-88155.rs
@@ -7,7 +7,7 @@ pub trait A {
 
 pub const fn foo<T: A>() -> bool {
     T::assoc()
-    //~^ ERROR calls in constant functions are limited
+    //~^ ERROR cannot call non-const fn
 }
 
 fn main() {}

--- a/src/test/ui/rfc-2632-const-trait-impl/issue-88155.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/issue-88155.rs
@@ -7,7 +7,8 @@ pub trait A {
 
 pub const fn foo<T: A>() -> bool {
     T::assoc()
-    //~^ ERROR cannot call non-const fn
+    //~^ ERROR the trait bound
+    //~| ERROR cannot call non-const fn
 }
 
 fn main() {}

--- a/src/test/ui/rfc-2632-const-trait-impl/issue-88155.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/issue-88155.stderr
@@ -1,8 +1,10 @@
-error[E0015]: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+error[E0015]: cannot call non-const fn `<T as A>::assoc` in constant functions
   --> $DIR/issue-88155.rs:9:5
    |
 LL |     T::assoc()
    |     ^^^^^^^^^^
+   |
+   = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
 
 error: aborting due to previous error
 

--- a/src/test/ui/rfc-2632-const-trait-impl/issue-88155.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/issue-88155.stderr
@@ -3,6 +3,12 @@ error[E0277]: the trait bound `T: ~const A` is not satisfied
    |
 LL |     T::assoc()
    |     ^^^^^^^^^^ the trait `~const A` is not implemented for `T`
+   |
+note: the trait `A` is implemented for `T`, but that implementation is not `const`
+  --> $DIR/issue-88155.rs:9:5
+   |
+LL |     T::assoc()
+   |     ^^^^^^^^^^
 
 error[E0015]: cannot call non-const fn `<T as A>::assoc` in constant functions
   --> $DIR/issue-88155.rs:9:5

--- a/src/test/ui/rfc-2632-const-trait-impl/issue-88155.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/issue-88155.stderr
@@ -1,3 +1,9 @@
+error[E0277]: the trait bound `T: ~const A` is not satisfied
+  --> $DIR/issue-88155.rs:9:5
+   |
+LL |     T::assoc()
+   |     ^^^^^^^^^^ the trait `~const A` is not implemented for `T`
+
 error[E0015]: cannot call non-const fn `<T as A>::assoc` in constant functions
   --> $DIR/issue-88155.rs:9:5
    |
@@ -6,6 +12,7 @@ LL |     T::assoc()
    |
    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
 
-error: aborting due to previous error
+error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0015`.
+Some errors have detailed explanations: E0015, E0277.
+For more information about an error, try `rustc --explain E0015`.

--- a/src/test/ui/rfc-2632-const-trait-impl/std-impl-gate.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/std-impl-gate.rs
@@ -11,7 +11,7 @@ fn non_const_context() -> Vec<usize> {
 
 const fn const_context() -> Vec<usize> {
     Default::default()
-    //[stock]~^ ERROR calls in constant functions are limited
+    //[stock]~^ ERROR cannot call non-const fn
 }
 
 fn main() {

--- a/src/test/ui/rfc-2632-const-trait-impl/std-impl-gate.stock.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/std-impl-gate.stock.stderr
@@ -1,8 +1,10 @@
-error[E0015]: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+error[E0015]: cannot call non-const fn `<Vec<usize> as Default>::default` in constant functions
   --> $DIR/std-impl-gate.rs:13:5
    |
 LL |     Default::default()
    |     ^^^^^^^^^^^^^^^^^^
+   |
+   = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
 
 error: aborting due to previous error
 

--- a/src/test/ui/static/static-vec-repeat-not-constant.stderr
+++ b/src/test/ui/static/static-vec-repeat-not-constant.stderr
@@ -1,8 +1,10 @@
-error[E0015]: calls in statics are limited to constant functions, tuple structs and tuple variants
+error[E0015]: cannot call non-const fn `foo` in statics
   --> $DIR/static-vec-repeat-not-constant.rs:3:25
    |
 LL | static a: [isize; 2] = [foo(); 2];
    |                         ^^^^^
+   |
+   = note: calls in statics are limited to constant functions, tuple structs and tuple variants
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Successful merges:

 - #90532 (More informative error message for E0015)
 - #93439 (Add support for control-flow protection)
 - #93885 (bootstrap.py: Suggest disabling download-ci-llvm option if url fails to download)
 - #93930 (add link to format_args! when mention it in docs)
 - #93939 (update miri)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=90532,93439,93885,93930,93939)
<!-- homu-ignore:end -->