### PR TITLE
Don't relabel to a team if there is already a team label

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -113,6 +113,9 @@ trigger_files = [
     "src/tools/rustdoc-js",
     "src/tools/rustdoc-themes",
 ]
+exclude_labels = [
+    "T-*",
+]
 
 [autolabel."T-compiler"]
 trigger_files = [
@@ -121,6 +124,9 @@ trigger_files = [
 
     # Tests
     "src/test/ui",
+]
+exclude_labels = [
+    "T-*",
 ]
 
 [notify-zulip."I-prioritize"]


### PR DESCRIPTION
Should prevent cases like #93628, where teams have been manually assigned, but changes are pushed. We give up adding new labels on *new* changes; but I feel like that is less frequent.

r? @Mark-Simulacrum 