### PR TITLE
Introduce -Zsplit-metadata option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3595,7 +3595,6 @@ dependencies = [
  "rustc_symbol_mangling",
  "rustc_target",
  "smallvec",
- "snap",
  "tempfile",
  "thorin-dwp",
  "tracing",
@@ -3967,7 +3966,6 @@ dependencies = [
  "rustc_span",
  "rustc_target",
  "smallvec",
- "snap",
  "tracing",
 ]
 
@@ -4794,12 +4792,6 @@ name = "smallvec"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
-
-[[package]]
-name = "snap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da73c8f77aebc0e40c300b93f0a5f1bece7a248a36eee287d4e095f35c7b7d6e"
 
 [[package]]
 name = "socket2"

--- a/compiler/rustc_codegen_ssa/Cargo.toml
+++ b/compiler/rustc_codegen_ssa/Cargo.toml
@@ -16,7 +16,6 @@ jobserver = "0.1.22"
 tempfile = "3.2"
 thorin-dwp = "0.2"
 pathdiff = "0.2.0"
-snap = "1"
 smallvec = { version = "1.6.1", features = ["union", "may_dangle"] }
 regex = "1.4"
 

--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -359,7 +359,7 @@ fn link_rlib<'a, B: ArchiveBuilder<'a>>(
             // metadata in rlib files is wrapped in a "dummy" object file for
             // the target platform so the rlib can be processed entirely by
             // normal linkers for the platform.
-            let metadata = create_rmeta_file(sess, codegen_results.metadata.raw_data());
+            let metadata = create_rmeta_file(sess, codegen_results.metadata.maybe_reference());
             ab.add_file(&emit_metadata(sess, &metadata, tmpdir));
         }
 

--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -1036,7 +1036,7 @@ fn encode_and_write_metadata(
     enum MetadataKind {
         None,
         Uncompressed,
-        Compressed,
+        Compressed, // TODO remove this variant
     }
 
     let metadata_kind = tcx
@@ -1074,7 +1074,7 @@ fn encode_and_write_metadata(
             .tempdir_in(out_filename.parent().unwrap())
             .unwrap_or_else(|err| tcx.sess.fatal(&format!("couldn't create a temp dir: {}", err)));
         let metadata_tmpdir = MaybeTempDir::new(metadata_tmpdir, tcx.sess.opts.cg.save_temps);
-        let metadata_filename = emit_metadata(tcx.sess, metadata.raw_data(), &metadata_tmpdir);
+        let metadata_filename = emit_metadata(tcx.sess, metadata.full(), &metadata_tmpdir);
         if let Err(e) = util::non_durable_rename(&metadata_filename, &out_filename) {
             tcx.sess.fatal(&format!("failed to write {}: {}", out_filename.display(), e));
         }

--- a/compiler/rustc_interface/src/tests.rs
+++ b/compiler/rustc_interface/src/tests.rs
@@ -689,6 +689,7 @@ fn test_debugging_options_tracking_hash() {
     untracked!(self_profile_events, Some(vec![String::new()]));
     untracked!(span_debug, true);
     untracked!(span_free_formats, true);
+    untracked!(split_metadata, true);
     untracked!(temps_dir, Some(String::from("abc")));
     untracked!(terminal_width, Some(80));
     untracked!(threads, 99);

--- a/compiler/rustc_metadata/Cargo.toml
+++ b/compiler/rustc_metadata/Cargo.toml
@@ -9,7 +9,6 @@ doctest = false
 [dependencies]
 libloading = "0.7.1"
 odht = { version = "0.3.1", features = ["nightly"] }
-snap = "1"
 tracing = "0.1"
 smallvec = { version = "1.6.1", features = ["union", "may_dangle"] }
 rustc_middle = { path = "../rustc_middle" }

--- a/compiler/rustc_metadata/src/locator.rs
+++ b/compiler/rustc_metadata/src/locator.rs
@@ -503,9 +503,8 @@ impl<'a> CrateLocator<'a> {
     // the errors and notes are emitted about the set of libraries.
     //
     // With only one library in the set, this function will extract it, and then
-    // read the metadata from it if `*slot` is `None`. If the metadata couldn't
-    // be read, it is assumed that the file isn't a valid rust library (no
-    // errors are emitted).
+    // read the metadata from it. If the metadata couldn't be read, it is assumed
+    // that the file isn't a valid rust library (no errors are emitted).
     fn extract_one(
         &mut self,
         m: FxHashMap<PathBuf, PathKind>,
@@ -521,17 +520,8 @@ impl<'a> CrateLocator<'a> {
         //
         // See also #68149 which provides more detail on why emitting the
         // dependency on the rlib is a bad thing.
-        //
-        // We currently do not verify that these other sources are even in sync,
-        // and this is arguably a bug (see #10786), but because reading metadata
-        // is quite slow (especially from dylibs) we currently do not read it
-        // from the other crate sources.
-        if slot.is_some() {
-            if m.is_empty() || !self.needs_crate_flavor(flavor) {
-                return Ok(None);
-            } else if m.len() == 1 {
-                return Ok(Some(m.into_iter().next().unwrap()));
-            }
+        if slot.is_some() && !self.needs_crate_flavor(flavor) {
+            return Ok(None);
         }
 
         let mut ret: Option<(PathBuf, PathKind)> = None;

--- a/compiler/rustc_metadata/src/locator.rs
+++ b/compiler/rustc_metadata/src/locator.rs
@@ -619,6 +619,7 @@ impl<'a> CrateLocator<'a> {
                     return None;
                 }
             }
+            return Some(hash);
         }
 
         let root = metadata.get_root();

--- a/compiler/rustc_metadata/src/locator.rs
+++ b/compiler/rustc_metadata/src/locator.rs
@@ -589,32 +589,6 @@ impl<'a> CrateLocator<'a> {
                 continue;
             }
 
-            // Ok so at this point we've determined that `(lib, kind)` above is
-            // a candidate crate to load, and that `slot` is either none (this
-            // is the first crate of its kind) or if some the previous path has
-            // the exact same hash (e.g., it's the exact same crate).
-            //
-            // In principle these two candidate crates are exactly the same so
-            // we can choose either of them to link. As a stupidly gross hack,
-            // however, we favor crate in the sysroot.
-            //
-            // You can find more info in rust-lang/rust#39518 and various linked
-            // issues, but the general gist is that during testing libstd the
-            // compilers has two candidates to choose from: one in the sysroot
-            // and one in the deps folder. These two crates are the exact same
-            // crate but if the compiler chooses the one in the deps folder
-            // it'll cause spurious errors on Windows.
-            //
-            // As a result, we favor the sysroot crate here. Note that the
-            // candidates are all canonicalized, so we canonicalize the sysroot
-            // as well.
-            if let Some((prev, _)) = &ret {
-                let sysroot = self.sysroot;
-                let sysroot = sysroot.canonicalize().unwrap_or_else(|_| sysroot.to_path_buf());
-                if prev.starts_with(&sysroot) {
-                    continue;
-                }
-            }
             *slot = Some((hash, metadata));
             ret = Some((lib, kind));
         }

--- a/compiler/rustc_metadata/src/rmeta/decoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder.rs
@@ -647,10 +647,7 @@ impl<'tcx> MetadataBlob {
     crate fn get_root(&self) -> CrateRoot<'tcx> {
         let slice = &self.blob()[..];
         let offset = METADATA_HEADER.len();
-        let pos = (((slice[offset + 0] as u32) << 24)
-            | ((slice[offset + 1] as u32) << 16)
-            | ((slice[offset + 2] as u32) << 8)
-            | ((slice[offset + 3] as u32) << 0)) as usize;
+        let pos = (u32::from_le_bytes(slice[offset..offset + 4].try_into().unwrap())) as usize;
         Lazy::<CrateRoot<'tcx>>::from_position(NonZeroUsize::new(pos).unwrap()).decode(self)
     }
 

--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -2233,7 +2233,7 @@ fn encode_metadata_impl(tcx: TyCtxt<'_>) -> EncodedMetadata {
     // Encode the root position.
     let header = METADATA_HEADER.len() + 8;
     let pos = root.position.get();
-    result[header..header + 4].copy_from_slice(&pos.to_le_bytes());
+    result[header..header + 4].copy_from_slice(&u32::try_from(pos).unwrap().to_le_bytes());
 
     // Record metadata size for self-profiling
     tcx.prof.artifact_size("crate_metadata", "crate_metadata", result.len() as u64);

--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -2214,10 +2214,7 @@ fn encode_metadata_impl(tcx: TyCtxt<'_>) -> EncodedMetadata {
     // Encode the root position.
     let header = METADATA_HEADER.len();
     let pos = root.position.get();
-    result[header + 0] = (pos >> 24) as u8;
-    result[header + 1] = (pos >> 16) as u8;
-    result[header + 2] = (pos >> 8) as u8;
-    result[header + 3] = (pos >> 0) as u8;
+    result[header..header + 4].copy_from_slice(&pos.to_le_bytes());
 
     // Record metadata size for self-profiling
     tcx.prof.artifact_size("crate_metadata", "crate_metadata", result.len() as u64);

--- a/compiler/rustc_metadata/src/rmeta/mod.rs
+++ b/compiler/rustc_metadata/src/rmeta/mod.rs
@@ -54,10 +54,29 @@ const METADATA_VERSION: u8 = 6;
 
 /// Metadata header which includes `METADATA_VERSION`.
 ///
-/// This header is followed by the position of the `CrateRoot`,
-/// which is encoded as a 32-bit big-endian unsigned integer,
-/// and further followed by the rustc version string.
+/// # Format
+///
+/// |field   |size    |
+/// |--------|--------|
+/// |magic   |8       |
+/// |svh     |8       |
+/// |root    |4       |
+/// |reserved|4       |
+/// |version |variable|
 pub const METADATA_HEADER: &[u8] = &[b'r', b'u', b's', b't', 0, 0, 0, METADATA_VERSION];
+
+/// The previous metadata header.
+///
+/// This is only used for reporting the rustc version of the incompatible crate.
+///
+/// # Format
+///
+/// |field  |size    |
+/// |-------|--------|
+/// |magic  |8       |
+/// |root   |4       |
+/// |version|variable|
+pub const PREV_METADATA_HEADER: &[u8] = &[b'r', b'u', b's', b't', 0, 0, 0, 5];
 
 /// Additional metadata for a `Lazy<T>` where `T` may not be `Sized`,
 /// e.g. for `Lazy<[T]>`, this is the length (count of `T` values).

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -1427,6 +1427,8 @@ options! {
     split_dwarf_inlining: bool = (true, parse_bool, [UNTRACKED],
         "provide minimal debug info in the object/executable to facilitate online \
          symbolication/stack traces in the absence of .dwo/.dwp files when using Split DWARF"),
+    split_metadata: bool = (false, parse_bool, [UNTRACKED],
+        "split metadata out of libraries into .rmeta files"),
     symbol_mangling_version: Option<SymbolManglingVersion> = (None,
         parse_symbol_mangling_version, [TRACKED],
         "which mangling version to use for symbol names ('legacy' (default) or 'v0')"),

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -1095,6 +1095,11 @@ impl<'a> Builder<'a> {
             rustflags.arg("-Zunstable-options");
         }
 
+        if stage != 0 {
+            // FIXME remove once cargo enables this by default
+            rustflags.arg("-Zsplit-metadata");
+        }
+
         // FIXME: It might be better to use the same value for both `RUSTFLAGS` and `RUSTDOCFLAGS`,
         // but this breaks CI. At the very least, stage0 `rustdoc` needs `--cfg bootstrap`. See
         // #71458.

--- a/src/bootstrap/check.rs
+++ b/src/bootstrap/check.rs
@@ -90,14 +90,7 @@ impl Step for Std {
             "Checking stage{} std artifacts ({} -> {})",
             builder.top_stage, &compiler.host, target
         ));
-        run_cargo(
-            builder,
-            cargo,
-            args(builder),
-            &libstd_stamp(builder, compiler, target),
-            vec![],
-            true,
-        );
+        run_cargo(builder, cargo, args(builder), &libstd_stamp(builder, compiler, target), vec![]);
 
         // We skip populating the sysroot in non-zero stage because that'll lead
         // to rlib/rmeta conflicts if std gets built during this session.
@@ -146,7 +139,6 @@ impl Step for Std {
             args(builder),
             &libstd_test_stamp(builder, compiler, target),
             vec![],
-            true,
         );
     }
 }
@@ -222,7 +214,6 @@ impl Step for Rustc {
             args(builder),
             &librustc_stamp(builder, compiler, target),
             vec![],
-            true,
         );
 
         let libdir = builder.sysroot_libdir(compiler, target);
@@ -287,7 +278,6 @@ impl Step for CodegenBackend {
             args(builder),
             &codegen_backend_stamp(builder, compiler, target, backend),
             vec![],
-            true,
         );
     }
 }
@@ -354,7 +344,6 @@ macro_rules! tool_check_step {
                     args(builder),
                     &stamp(builder, compiler, target),
                     vec![],
-                    true,
                 );
 
                 /// Cargo's output path in a given stage, compiled by a particular

--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -112,14 +112,7 @@ impl Step for Std {
             "Building stage{} std artifacts ({} -> {})",
             compiler.stage, &compiler.host, target
         ));
-        run_cargo(
-            builder,
-            cargo,
-            vec![],
-            &libstd_stamp(builder, compiler, target),
-            target_deps,
-            false,
-        );
+        run_cargo(builder, cargo, vec![], &libstd_stamp(builder, compiler, target), target_deps);
 
         builder.ensure(StdLink {
             compiler: builder.compiler(compiler.stage, builder.config.build),
@@ -629,14 +622,7 @@ impl Step for Rustc {
             "Building stage{} compiler artifacts ({} -> {})",
             compiler.stage, &compiler.host, target
         ));
-        run_cargo(
-            builder,
-            cargo,
-            vec![],
-            &librustc_stamp(builder, compiler, target),
-            vec![],
-            false,
-        );
+        run_cargo(builder, cargo, vec![], &librustc_stamp(builder, compiler, target), vec![]);
 
         builder.ensure(RustcLink {
             compiler: builder.compiler(compiler.stage, builder.config.build),
@@ -839,7 +825,7 @@ impl Step for CodegenBackend {
             "Building stage{} codegen backend {} ({} -> {})",
             compiler.stage, backend, &compiler.host, target
         ));
-        let files = run_cargo(builder, cargo, vec![], &tmp_stamp, vec![], false);
+        let files = run_cargo(builder, cargo, vec![], &tmp_stamp, vec![]);
         if builder.config.dry_run {
             return;
         }
@@ -1232,7 +1218,6 @@ pub fn run_cargo(
     tail_args: Vec<String>,
     stamp: &Path,
     additional_target_deps: Vec<(PathBuf, DependencyType)>,
-    is_check: bool,
 ) -> Vec<PathBuf> {
     if builder.config.dry_run {
         return Vec::new();
@@ -1271,7 +1256,7 @@ pub fn run_cargo(
                 || filename.ends_with(".a")
                 || is_debug_info(&filename)
                 || is_dylib(&filename)
-                || (is_check && filename.ends_with(".rmeta")))
+                || filename.ends_with(".rmeta"))
             {
                 continue;
             }


### PR DESCRIPTION
This will split the crate metadata out of library files. Instead only the svh is preserved to allow for loading the right rmeta file. This significicantly reduces library size. In addition it allows for cheaper checks if different library files are the same crate.

Fixes https://github.com/rust-lang/rust/issues/23366
Fixes https://github.com/rust-lang/rust/issues/57076
Fixes https://github.com/rust-lang/rust/issues/10786 (through 453d9a0bf778e385b45ecced681a71315fe8517e)
Should fix https://github.com/rust-lang/rust/issues/82151 (through 453d9a0bf778e385b45ecced681a71315fe8517e, unconfirmed)