### PR TITLE
Fix signature of u8::escape_ascii

### DIFF
--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -806,8 +806,8 @@ impl u8 {
                   without modifying the original"]
     #[unstable(feature = "inherent_ascii_escape", issue = "77174")]
     #[inline]
-    pub fn escape_ascii(&self) -> ascii::EscapeDefault {
-        ascii::escape_default(*self)
+    pub fn escape_ascii(self) -> ascii::EscapeDefault {
+        ascii::escape_default(self)
     }
 
     pub(crate) fn is_utf8_char_boundary(self) -> bool {


### PR DESCRIPTION
Per discussion in #93886, the FCP was done for this method under the assumption its signature was not by-reference, so, this is just to change the signature to reflect FCP. Decision on when/how to stabilise will be done after.

r? @Mark-Simulacrum 