### PR TITLE
Add basic platform support to library/{panic_}unwind for m68k

### DIFF
--- a/library/panic_unwind/src/gcc.rs
+++ b/library/panic_unwind/src/gcc.rs
@@ -105,6 +105,9 @@ const UNWIND_DATA_REG: (i32, i32) = (0, 1); // RAX, RDX
 #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
 const UNWIND_DATA_REG: (i32, i32) = (0, 1); // R0, R1 / X0, X1
 
+#[cfg(target_arch = "m68k")]
+const UNWIND_DATA_REG: (i32, i32) = (0, 1); // D0, D1
+
 #[cfg(any(target_arch = "mips", target_arch = "mips64"))]
 const UNWIND_DATA_REG: (i32, i32) = (4, 5); // A0, A1
 

--- a/library/unwind/src/libunwind.rs
+++ b/library/unwind/src/libunwind.rs
@@ -42,6 +42,9 @@ pub const unwinder_private_data_size: usize = 2;
 #[cfg(all(target_arch = "aarch64", target_pointer_width = "32"))]
 pub const unwinder_private_data_size: usize = 5;
 
+#[cfg(target_arch = "m68k")]
+pub const unwinder_private_data_size: usize = 2;
+
 #[cfg(target_arch = "mips")]
 pub const unwinder_private_data_size: usize = 2;
 


### PR DESCRIPTION
This PR adds basic platform support for m68k for library/{panic_}unwind for m68k.

Register information for UNWIND_DATA_REG has been extracted from LLVM.