### PR TITLE
better errors when resolving bad Self in impl block

### DIFF
--- a/compiler/rustc_hir/src/def.rs
+++ b/compiler/rustc_hir/src/def.rs
@@ -317,7 +317,7 @@ pub enum Res<Id = hir::HirId> {
         /// Optionally, the trait associated with this `Self` type.
         Option<DefId>,
         /// Optionally, the impl associated with this `Self` type.
-        Option<(DefId, bool)>,
+        Option<ResImpl>,
     ),
     /// A tool attribute module; e.g., the `rustfmt` in `#[rustfmt::skip]`.
     ///
@@ -351,6 +351,14 @@ pub enum Res<Id = hir::HirId> {
     ///
     /// **Not bound to a specific namespace.**
     Err,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Encodable, Decodable, Hash, Debug)]
+#[derive(HashStable_Generic)]
+pub struct ResImpl {
+    pub def_id: DefId,
+    pub generics_allowed: bool,
+    pub in_trait_ref: bool,
 }
 
 /// The result of resolving a path before lowering to HIR,

--- a/compiler/rustc_lint/src/internal.rs
+++ b/compiler/rustc_lint/src/internal.rs
@@ -202,8 +202,8 @@ fn is_ty_or_ty_ctxt(cx: &LateContext<'_>, ty: &Ty<'_>) -> Option<String> {
                 }
             }
             // Only lint on `&Ty` and `&TyCtxt` if it is used outside of a trait.
-            Res::SelfTy(None, Some((did, _))) => {
-                if let ty::Adt(adt, substs) = cx.tcx.type_of(did).kind() {
+            Res::SelfTy(None, Some(res_impl)) => {
+                if let ty::Adt(adt, substs) = cx.tcx.type_of(res_impl.def_id).kind() {
                     if let Some(name @ (sym::Ty | sym::TyCtxt)) =
                         cx.tcx.get_diagnostic_name(adt.did)
                     {

--- a/compiler/rustc_lint/src/pass_by_value.rs
+++ b/compiler/rustc_lint/src/pass_by_value.rs
@@ -54,8 +54,8 @@ fn path_for_pass_by_value(cx: &LateContext<'_>, ty: &hir::Ty<'_>) -> Option<Stri
                 let path_segment = path.segments.last().unwrap();
                 return Some(format!("{}{}", name, gen_args(cx, path_segment)));
             }
-            Res::SelfTy(None, Some((did, _))) => {
-                if let ty::Adt(adt, substs) = cx.tcx.type_of(did).kind() {
+            Res::SelfTy(None, Some(res_impl)) => {
+                if let ty::Adt(adt, substs) = cx.tcx.type_of(res_impl.def_id).kind() {
                     if cx.tcx.has_attr(adt.did, sym::rustc_pass_by_value) {
                         return Some(cx.tcx.def_path_str_with_substs(adt.did, substs));
                     }

--- a/compiler/rustc_passes/src/dead.rs
+++ b/compiler/rustc_passes/src/dead.rs
@@ -108,8 +108,8 @@ impl<'tcx> MarkSymbolVisitor<'tcx> {
                 if let Some(t) = t {
                     self.check_def_id(t);
                 }
-                if let Some((i, _)) = i {
-                    self.check_def_id(i);
+                if let Some(res_impl) = i {
+                    self.check_def_id(res_impl.def_id);
                 }
             }
             Res::ToolMod | Res::NonMacroAttr(..) | Res::Err => {}

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -123,16 +123,16 @@ impl<'a> Resolver<'a> {
 
                 let sm = self.session.source_map();
                 match outer_res {
-                    Res::SelfTy(maybe_trait_defid, maybe_impl_defid) => {
+                    Res::SelfTy(maybe_trait_defid, maybe_res_impl) => {
                         if let Some(impl_span) =
-                            maybe_impl_defid.and_then(|(def_id, _)| self.opt_span(def_id))
+                            maybe_res_impl.and_then(|res_impl| self.opt_span(res_impl.def_id))
                         {
                             err.span_label(
                                 reduce_impl_span_to_impl_keyword(sm, impl_span),
                                 "`Self` type implicitly declared here, by this `impl`",
                             );
                         }
-                        match (maybe_trait_defid, maybe_impl_defid) {
+                        match (maybe_trait_defid, maybe_res_impl) {
                             (Some(_), None) => {
                                 err.span_label(span, "can't use `Self` here");
                             }

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -42,8 +42,8 @@ use rustc_data_structures::ptr_key::PtrKey;
 use rustc_data_structures::sync::Lrc;
 use rustc_errors::{struct_span_err, Applicability, DiagnosticBuilder};
 use rustc_expand::base::{DeriveResolutions, SyntaxExtension, SyntaxExtensionKind};
-use rustc_hir::def::Namespace::*;
 use rustc_hir::def::{self, CtorOf, DefKind, NonMacroAttrKind, PartialRes};
+use rustc_hir::def::{Namespace::*, ResImpl};
 use rustc_hir::def_id::{CrateNum, DefId, DefIdMap, DefPathHash, LocalDefId};
 use rustc_hir::def_id::{CRATE_DEF_ID, CRATE_DEF_INDEX, LOCAL_CRATE};
 use rustc_hir::definitions::{DefKey, DefPathData, Definitions};
@@ -2804,8 +2804,11 @@ impl<'a> Resolver<'a> {
                                 // HACK(min_const_generics): If we encounter `Self` in an anonymous constant
                                 // we can't easily tell if it's generic at this stage, so we instead remember
                                 // this and then enforce the self type to be concrete later on.
-                                if let Res::SelfTy(trait_def, Some((impl_def, _))) = res {
-                                    res = Res::SelfTy(trait_def, Some((impl_def, true)));
+                                if let Res::SelfTy(trait_def, Some(res_impl)) = res {
+                                    res = Res::SelfTy(
+                                        trait_def,
+                                        Some(ResImpl { generics_allowed: false, ..res_impl }),
+                                    );
                                 } else {
                                     if record_used {
                                         self.report_error(

--- a/compiler/rustc_typeck/src/check/check.rs
+++ b/compiler/rustc_typeck/src/check/check.rs
@@ -524,7 +524,7 @@ pub(super) fn check_opaque_for_inheriting_lifetimes<'tcx>(
                 hir::TyKind::Path(hir::QPath::Resolved(None, path)) => match &path.segments {
                     [PathSegment { res: Some(Res::SelfTy(_, impl_ref)), .. }] => {
                         let impl_ty_name =
-                            impl_ref.map(|(def_id, _)| self.tcx.def_path_str(def_id));
+                            impl_ref.map(|res_impl| self.tcx.def_path_str(res_impl.def_id));
                         self.selftys.push((path.span, impl_ty_name));
                     }
                     _ => {}

--- a/src/librustdoc/clean/utils.rs
+++ b/src/librustdoc/clean/utils.rs
@@ -9,6 +9,7 @@ use crate::core::DocContext;
 use crate::formats::item_type::ItemType;
 use crate::visit_lib::LibEmbargoVisitor;
 
+use hir::def::ResImpl;
 use rustc_ast as ast;
 use rustc_ast::tokenstream::TokenTree;
 use rustc_data_structures::thin_vec::ThinVec;
@@ -400,8 +401,8 @@ crate fn register_res(cx: &mut DocContext<'_>, res: Res) -> DefId {
         // This is part of a trait definition; document the trait.
         Res::SelfTy(Some(trait_def_id), _) => (trait_def_id, ItemType::Trait),
         // This is an inherent impl; it doesn't have its own page.
-        Res::SelfTy(None, Some((impl_def_id, _))) => return impl_def_id,
-        Res::SelfTy(None, None)
+        Res::SelfTy(None, Some(ResImpl { def_id: impl_def_id, .. })) => return impl_def_id,
+        Res::SelfTy(None, _)
         | Res::PrimTy(_)
         | Res::ToolMod
         | Res::SelfCtor(_)

--- a/src/test/ui/resolve/issue-23305.rs
+++ b/src/test/ui/resolve/issue-23305.rs
@@ -3,6 +3,6 @@ pub trait ToNbt<T> {
 }
 
 impl dyn ToNbt<Self> {}
-//~^ ERROR cycle detected
+//~^ ERROR `Self` is not allowed in the self type of an `impl` block
 
 fn main() {}

--- a/src/test/ui/resolve/issue-23305.stderr
+++ b/src/test/ui/resolve/issue-23305.stderr
@@ -1,16 +1,10 @@
-error[E0391]: cycle detected when computing type of `<impl at $DIR/issue-23305.rs:5:1: 5:24>`
+error: `Self` is not allowed in the self type of an `impl` block
   --> $DIR/issue-23305.rs:5:16
    |
 LL | impl dyn ToNbt<Self> {}
    |                ^^^^
    |
-   = note: ...which immediately requires computing type of `<impl at $DIR/issue-23305.rs:5:1: 5:24>` again
-note: cycle used when collecting item types in top-level module
-  --> $DIR/issue-23305.rs:1:1
-   |
-LL | pub trait ToNbt<T> {
-   | ^^^^^^^^^^^^^^^^^^
+   = note: referencing `Self` in this position would produce an infinitely recursive type
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0391`.

--- a/src/test/ui/resolve/resolve-self-in-impl.rs
+++ b/src/test/ui/resolve/resolve-self-in-impl.rs
@@ -11,10 +11,15 @@ impl Tr for S where Self: Copy {} // OK
 impl Tr for S where S<Self>: Copy {} // OK
 impl Tr for S where Self::A: Copy {} // OK
 
-impl Tr for Self {} //~ ERROR cycle detected
-impl Tr for S<Self> {} //~ ERROR cycle detected
-impl Self {} //~ ERROR cycle detected
-impl S<Self> {} //~ ERROR cycle detected
-impl Tr<Self::A> for S {} //~ ERROR cycle detected
+impl Tr for Self {}
+//~^ ERROR `Self` is not allowed in the self type of an `impl` block
+impl Tr for S<Self> {}
+//~^ ERROR `Self` is not allowed in the self type of an `impl` block
+impl Self {}
+//~^ ERROR `Self` is not allowed in the self type of an `impl` block
+impl S<Self> {}
+//~^ ERROR `Self` is not allowed in the self type of an `impl` block
+impl Tr<Self::A> for S {}
+//~^ ERROR ambiguous associated type
 
 fn main() {}

--- a/src/test/ui/resolve/resolve-self-in-impl.stderr
+++ b/src/test/ui/resolve/resolve-self-in-impl.stderr
@@ -1,98 +1,41 @@
-error[E0391]: cycle detected when computing type of `<impl at $DIR/resolve-self-in-impl.rs:14:1: 14:20>`
+error: `Self` is not allowed in the self type of an `impl` block
   --> $DIR/resolve-self-in-impl.rs:14:13
    |
 LL | impl Tr for Self {}
    |             ^^^^
    |
-   = note: ...which immediately requires computing type of `<impl at $DIR/resolve-self-in-impl.rs:14:1: 14:20>` again
-note: cycle used when collecting item types in top-level module
-  --> $DIR/resolve-self-in-impl.rs:1:1
-   |
-LL | / #![feature(associated_type_defaults)]
-LL | |
-LL | | struct S<T = u8>(T);
-LL | | trait Tr<T = u8> {
-...  |
-LL | |
-LL | | fn main() {}
-   | |____________^
+   = note: referencing `Self` in this position would produce an infinitely recursive type
 
-error[E0391]: cycle detected when computing type of `<impl at $DIR/resolve-self-in-impl.rs:15:1: 15:23>`
-  --> $DIR/resolve-self-in-impl.rs:15:15
+error: `Self` is not allowed in the self type of an `impl` block
+  --> $DIR/resolve-self-in-impl.rs:16:15
    |
 LL | impl Tr for S<Self> {}
    |               ^^^^
    |
-   = note: ...which immediately requires computing type of `<impl at $DIR/resolve-self-in-impl.rs:15:1: 15:23>` again
-note: cycle used when collecting item types in top-level module
-  --> $DIR/resolve-self-in-impl.rs:1:1
-   |
-LL | / #![feature(associated_type_defaults)]
-LL | |
-LL | | struct S<T = u8>(T);
-LL | | trait Tr<T = u8> {
-...  |
-LL | |
-LL | | fn main() {}
-   | |____________^
+   = note: referencing `Self` in this position would produce an infinitely recursive type
 
-error[E0391]: cycle detected when computing type of `<impl at $DIR/resolve-self-in-impl.rs:16:1: 16:13>`
-  --> $DIR/resolve-self-in-impl.rs:16:6
+error: `Self` is not allowed in the self type of an `impl` block
+  --> $DIR/resolve-self-in-impl.rs:18:6
    |
 LL | impl Self {}
    |      ^^^^
    |
-   = note: ...which immediately requires computing type of `<impl at $DIR/resolve-self-in-impl.rs:16:1: 16:13>` again
-note: cycle used when collecting item types in top-level module
-  --> $DIR/resolve-self-in-impl.rs:1:1
-   |
-LL | / #![feature(associated_type_defaults)]
-LL | |
-LL | | struct S<T = u8>(T);
-LL | | trait Tr<T = u8> {
-...  |
-LL | |
-LL | | fn main() {}
-   | |____________^
+   = note: referencing `Self` in this position would produce an infinitely recursive type
 
-error[E0391]: cycle detected when computing type of `<impl at $DIR/resolve-self-in-impl.rs:17:1: 17:16>`
-  --> $DIR/resolve-self-in-impl.rs:17:8
+error: `Self` is not allowed in the self type of an `impl` block
+  --> $DIR/resolve-self-in-impl.rs:20:8
    |
 LL | impl S<Self> {}
    |        ^^^^
    |
-   = note: ...which immediately requires computing type of `<impl at $DIR/resolve-self-in-impl.rs:17:1: 17:16>` again
-note: cycle used when collecting item types in top-level module
-  --> $DIR/resolve-self-in-impl.rs:1:1
-   |
-LL | / #![feature(associated_type_defaults)]
-LL | |
-LL | | struct S<T = u8>(T);
-LL | | trait Tr<T = u8> {
-...  |
-LL | |
-LL | | fn main() {}
-   | |____________^
+   = note: referencing `Self` in this position would produce an infinitely recursive type
 
-error[E0391]: cycle detected when computing trait implemented by `<impl at $DIR/resolve-self-in-impl.rs:18:1: 18:26>`
-  --> $DIR/resolve-self-in-impl.rs:18:1
+error[E0223]: ambiguous associated type
+  --> $DIR/resolve-self-in-impl.rs:22:9
    |
 LL | impl Tr<Self::A> for S {}
-   | ^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: ...which immediately requires computing trait implemented by `<impl at $DIR/resolve-self-in-impl.rs:18:1: 18:26>` again
-note: cycle used when collecting item types in top-level module
-  --> $DIR/resolve-self-in-impl.rs:1:1
-   |
-LL | / #![feature(associated_type_defaults)]
-LL | |
-LL | | struct S<T = u8>(T);
-LL | | trait Tr<T = u8> {
-...  |
-LL | |
-LL | | fn main() {}
-   | |____________^
+   |         ^^^^^^^ help: use fully-qualified syntax: `<S as Trait>::A`
 
 error: aborting due to 5 previous errors
 
-For more information about this error, try `rustc --explain E0391`.
+For more information about this error, try `rustc --explain E0223`.


### PR DESCRIPTION
1. Fix the ICE when we see things like `impl Self` by resolving an impl's self type outside of its own scope.
2. Fix a cycle error when we have something like `impl Tr<Self::A> for Ty {}` by distinguishing when we're resolving an impl's trait ref, and marking any associated types in that trait ref as ambiguous.

Fixes #93952