### PR TITLE
Add MAIN_SEPARATOR_STR

### DIFF
--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -268,6 +268,12 @@ pub fn is_separator(c: char) -> bool {
 #[stable(feature = "rust1", since = "1.0.0")]
 pub const MAIN_SEPARATOR: char = crate::sys::path::MAIN_SEP;
 
+/// The primary separator of path components for the current platform.
+///
+/// For example, `/` on Unix and `\` on Windows.
+#[unstable(feature = "main_separator_str", issue = "94071")]
+pub const MAIN_SEPARATOR_STR: &str = crate::sys::path::MAIN_SEP_STR;
+
 ////////////////////////////////////////////////////////////////////////////////
 // Misc helpers
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Currently, if someone needs access to the path separator as a str, they need to go through this mess:

```rust
unsafe {
    std::str::from_utf8_unchecked(slice::from_ref(&(MAIN_SEPARATOR as u8)))
}
```

This PR just re-exports an existing path separator str API.