### PR TITLE
Type params and assoc types have unit metadata if they are sized

### DIFF
--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -2282,19 +2282,18 @@ impl<'tcx> Ty<'tcx> {
             ty::Str | ty::Slice(_) => (tcx.types.usize, false),
             ty::Dynamic(..) => {
                 let dyn_metadata = tcx.lang_items().dyn_metadata().unwrap();
-                (tcx.type_of(dyn_metadata).subst(tcx, &[self.into()]), false)
+                (tcx.type_of(dyn_metadata).subst(tcx, &[tail.into()]), false)
             },
 
             // type parameters only have unit metadata if they're sized, so return true
             // to make sure we double check this during confirmation
-            ty::Param(_) |  ty::Projection(_) => (tcx.types.unit, true),
+            ty::Param(_) |  ty::Projection(_) | ty::Opaque(..) => (tcx.types.unit, true),
 
-            ty::Opaque(..)
-            | ty::Infer(ty::TyVar(_))
+            ty::Infer(ty::TyVar(_))
             | ty::Bound(..)
             | ty::Placeholder(..)
             | ty::Infer(ty::FreshTy(_) | ty::FreshIntTy(_) | ty::FreshFloatTy(_)) => {
-                bug!("`ptr_metadata_ty` applied to unexpected type: {:?}", self)
+                bug!("`ptr_metadata_ty` applied to unexpected type: {:?} (tail = {:?})", self, tail)
             }
         }
     }

--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -2244,12 +2244,13 @@ impl<'tcx> Ty<'tcx> {
         }
     }
 
-    /// Returns the type of metadata for (potentially fat) pointers to this type.
+    /// Returns the type of metadata for (potentially fat) pointers to this type,
+    /// and a boolean signifying if this is conditional on this type being `Sized`.
     pub fn ptr_metadata_ty(
         self,
         tcx: TyCtxt<'tcx>,
         normalize: impl FnMut(Ty<'tcx>) -> Ty<'tcx>,
-    ) -> Ty<'tcx> {
+    ) -> (Ty<'tcx>, bool) {
         let tail = tcx.struct_tail_with_normalize(self, normalize);
         match tail.kind() {
             // Sized types
@@ -2269,28 +2270,31 @@ impl<'tcx> Ty<'tcx> {
             | ty::Closure(..)
             | ty::Never
             | ty::Error(_)
+            // Extern types have metadata = ().
             | ty::Foreign(..)
             // If returned by `struct_tail_without_normalization` this is a unit struct
             // without any fields, or not a struct, and therefore is Sized.
             | ty::Adt(..)
             // If returned by `struct_tail_without_normalization` this is the empty tuple,
             // a.k.a. unit type, which is Sized
-            | ty::Tuple(..) => tcx.types.unit,
+            | ty::Tuple(..) => (tcx.types.unit, false),
 
-            ty::Str | ty::Slice(_) => tcx.types.usize,
+            ty::Str | ty::Slice(_) => (tcx.types.usize, false),
             ty::Dynamic(..) => {
                 let dyn_metadata = tcx.lang_items().dyn_metadata().unwrap();
-                tcx.type_of(dyn_metadata).subst(tcx, &[tail.into()])
+                (tcx.type_of(dyn_metadata).subst(tcx, &[self.into()]), false)
             },
 
-            ty::Projection(_)
-            | ty::Param(_)
-            | ty::Opaque(..)
+            // type parameters only have unit metadata if they're sized, so return true
+            // to make sure we double check this during confirmation
+            ty::Param(_) |  ty::Projection(_) => (tcx.types.unit, true),
+
+            ty::Opaque(..)
             | ty::Infer(ty::TyVar(_))
             | ty::Bound(..)
             | ty::Placeholder(..)
             | ty::Infer(ty::FreshTy(_) | ty::FreshIntTy(_) | ty::FreshFloatTy(_)) => {
-                bug!("`ptr_metadata_ty` applied to unexpected type: {:?}", tail)
+                bug!("`ptr_metadata_ty` applied to unexpected type: {:?}", self)
             }
         }
     }

--- a/src/test/ui/traits/pointee-tail-is-generic-errors.rs
+++ b/src/test/ui/traits/pointee-tail-is-generic-errors.rs
@@ -1,0 +1,22 @@
+// edition:2018
+
+#![feature(ptr_metadata)]
+#![feature(type_alias_impl_trait)]
+
+type Opaque = impl std::fmt::Debug + ?Sized;
+
+fn opaque() -> &'static Opaque {
+    &[1] as &[i32]
+}
+
+fn a<T: ?Sized>() {
+    is_thin::<T>();
+    //~^ ERROR type mismatch resolving `<T as Pointee>::Metadata == ()`
+
+    is_thin::<Opaque>();
+    //~^ ERROR type mismatch resolving `<impl Debug + ?Sized as Pointee>::Metadata == ()`
+}
+
+fn is_thin<T: std::ptr::Pointee<Metadata = ()> + ?Sized>() {}
+
+fn main() {}

--- a/src/test/ui/traits/pointee-tail-is-generic-errors.stderr
+++ b/src/test/ui/traits/pointee-tail-is-generic-errors.stderr
@@ -1,0 +1,40 @@
+error[E0271]: type mismatch resolving `<T as Pointee>::Metadata == ()`
+  --> $DIR/pointee-tail-is-generic-errors.rs:13:5
+   |
+LL |     is_thin::<T>();
+   |     ^^^^^^^^^^^^ expected `()`, found associated type
+   |
+   = note:    expected unit type `()`
+           found associated type `<T as Pointee>::Metadata`
+   = help: consider constraining the associated type `<T as Pointee>::Metadata` to `()`
+   = note: for more information, visit https://doc.rust-lang.org/book/ch19-03-advanced-traits.html
+note: required by a bound in `is_thin`
+  --> $DIR/pointee-tail-is-generic-errors.rs:20:33
+   |
+LL | fn is_thin<T: std::ptr::Pointee<Metadata = ()> + ?Sized>() {}
+   |                                 ^^^^^^^^^^^^^ required by this bound in `is_thin`
+
+error[E0271]: type mismatch resolving `<impl Debug + ?Sized as Pointee>::Metadata == ()`
+  --> $DIR/pointee-tail-is-generic-errors.rs:16:5
+   |
+LL | type Opaque = impl std::fmt::Debug + ?Sized;
+   |               ----------------------------- the found opaque type
+...
+LL |     is_thin::<Opaque>();
+   |     ^^^^^^^^^^^^^^^^^ expected `()`, found associated type
+   |
+   = note:    expected unit type `()`
+           found associated type `<impl Debug + ?Sized as Pointee>::Metadata`
+note: required by a bound in `is_thin`
+  --> $DIR/pointee-tail-is-generic-errors.rs:20:33
+   |
+LL | fn is_thin<T: std::ptr::Pointee<Metadata = ()> + ?Sized>() {}
+   |                                 ^^^^^^^^^^^^^ required by this bound in `is_thin`
+help: consider constraining the associated type `<impl Debug + ?Sized as Pointee>::Metadata` to `()`
+   |
+LL | type Opaque = impl std::fmt::Debug<Metadata = ()> + ?Sized;
+   |                                   +++++++++++++++
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0271`.

--- a/src/test/ui/traits/pointee-tail-is-generic.rs
+++ b/src/test/ui/traits/pointee-tail-is-generic.rs
@@ -1,0 +1,12 @@
+// check-pass
+
+#![feature(ptr_metadata)]
+
+fn a<T>() {
+    b::<T>();
+    b::<std::cell::Cell<T>>();
+}
+
+fn b<T: std::ptr::Pointee<Metadata = ()>>() {}
+
+fn main() {}

--- a/src/test/ui/traits/pointee-tail-is-generic.rs
+++ b/src/test/ui/traits/pointee-tail-is-generic.rs
@@ -1,12 +1,29 @@
 // check-pass
+// edition:2018
 
 #![feature(ptr_metadata)]
+#![feature(type_alias_impl_trait)]
 
-fn a<T>() {
-    b::<T>();
-    b::<std::cell::Cell<T>>();
+type Opaque = impl std::future::Future;
+
+fn opaque() -> Opaque {
+    async {}
 }
 
-fn b<T: std::ptr::Pointee<Metadata = ()>>() {}
+fn a<T>() {
+    // type parameter T is known to be sized
+    is_thin::<T>();
+    // tail of ADT (which is a type param) is known to be sized
+    is_thin::<std::cell::Cell<T>>();
+    // opaque type is known to be sized
+    is_thin::<Opaque>();
+}
+
+fn a2<T: Iterator>() {
+    // associated type is known to be sized
+    is_thin::<T::Item>();
+}
+
+fn is_thin<T: std::ptr::Pointee<Metadata = ()>>() {}
 
 fn main() {}


### PR DESCRIPTION
Extend the logic in `Pointee` projection to ensure that we can satisfy `<T as Pointee>::Metadata = ()` if `T: Sized`.

cc: @SimonSapin and #93959 