### PR TITLE
Fix suggestion to slice if scurtinee is a reference to `Result` or `Option`

### DIFF
--- a/src/test/ui/typeck/issue-91328.fixed
+++ b/src/test/ui/typeck/issue-91328.fixed
@@ -34,4 +34,14 @@ fn baz(v: Vec<i32>) -> i32 {
     }
 }
 
+fn qux(a: &Option<Box<[i32; 2]>>) -> i32 {
+    match a.as_deref() {
+    //~^ HELP: consider using `as_deref` here
+        Some([a, b]) => a + b,
+        //~^ ERROR: expected an array or slice
+        //~| NOTE: pattern cannot match with input type
+        _ => 42,
+    }
+}
+
 fn main() {}

--- a/src/test/ui/typeck/issue-91328.rs
+++ b/src/test/ui/typeck/issue-91328.rs
@@ -34,4 +34,14 @@ fn baz(v: Vec<i32>) -> i32 {
     }
 }
 
+fn qux(a: &Option<Box<[i32; 2]>>) -> i32 {
+    match a {
+    //~^ HELP: consider using `as_deref` here
+        Some([a, b]) => a + b,
+        //~^ ERROR: expected an array or slice
+        //~| NOTE: pattern cannot match with input type
+        _ => 42,
+    }
+}
+
 fn main() {}

--- a/src/test/ui/typeck/issue-91328.stderr
+++ b/src/test/ui/typeck/issue-91328.stderr
@@ -25,6 +25,15 @@ LL |
 LL |         [a, b] => a + b,
    |         ^^^^^^ pattern cannot match with input type `Vec<i32>`
 
-error: aborting due to 3 previous errors
+error[E0529]: expected an array or slice, found `Box<[i32; 2]>`
+  --> $DIR/issue-91328.rs:40:14
+   |
+LL |     match a {
+   |           - help: consider using `as_deref` here: `a.as_deref()`
+LL |
+LL |         Some([a, b]) => a + b,
+   |              ^^^^^^ pattern cannot match with input type `Box<[i32; 2]>`
+
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0529`.


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/pull/91343#issuecomment-1037718339 and https://github.com/rust-lang/rust/pull/91343#discussion_r761466979.