### PR TITLE
suggest using raw strings when invalid escapes appear in literals

### DIFF
--- a/compiler/rustc_parse/src/lexer/unescape_error_reporting.rs
+++ b/compiler/rustc_parse/src/lexer/unescape_error_reporting.rs
@@ -185,6 +185,15 @@ pub(crate) fn emit_unescape_error(
                      version control settings",
                 );
             } else {
+                if !mode.is_bytes() {
+                    diag.span_suggestion(
+                        span_with_quotes,
+                        "if you meant to write a literal backslash (perhaps escaping in a regular expression), consider a raw string literal",
+                        format!("r\"{}\"", lit),
+                        Applicability::MaybeIncorrect,
+                    );
+                }
+
                 diag.help(
                     "for more information, visit \
                      <https://static.rust-lang.org/doc/master/reference.html#literals>",

--- a/src/test/ui/lexer/lex-bad-char-literals-1.stderr
+++ b/src/test/ui/lexer/lex-bad-char-literals-1.stderr
@@ -17,6 +17,10 @@ LL |     '\●'
    |       ^ unknown character escape
    |
    = help: for more information, visit <https://static.rust-lang.org/doc/master/reference.html#literals>
+help: if you meant to write a literal backslash (perhaps escaping in a regular expression), consider a raw string literal
+   |
+LL |     r"\●"
+   |     ~~~~~
 
 error: unknown character escape: `\u{25cf}`
   --> $DIR/lex-bad-char-literals-1.rs:14:7
@@ -25,6 +29,10 @@ LL |     "\●"
    |       ^ unknown character escape
    |
    = help: for more information, visit <https://static.rust-lang.org/doc/master/reference.html#literals>
+help: if you meant to write a literal backslash (perhaps escaping in a regular expression), consider a raw string literal
+   |
+LL |     r"\●"
+   |     ~~~~~
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/parser/bad-escape-suggest-raw-string.rs
+++ b/src/test/ui/parser/bad-escape-suggest-raw-string.rs
@@ -1,0 +1,7 @@
+fn main() {
+    let ok = r"ab\[c";
+    let bad = "ab\[c";
+    //~^ ERROR unknown character escape: `[`
+    //~| HELP for more information, visit <https://static.rust-lang.org/doc/master/reference.html#literals>
+    //~| HELP if you meant to write a literal backslash (perhaps escaping in a regular expression), consider a raw string literal
+}

--- a/src/test/ui/parser/bad-escape-suggest-raw-string.stderr
+++ b/src/test/ui/parser/bad-escape-suggest-raw-string.stderr
@@ -1,0 +1,14 @@
+error: unknown character escape: `[`
+  --> $DIR/bad-escape-suggest-raw-string.rs:3:19
+   |
+LL |     let bad = "ab\[c";
+   |                   ^ unknown character escape
+   |
+   = help: for more information, visit <https://static.rust-lang.org/doc/master/reference.html#literals>
+help: if you meant to write a literal backslash (perhaps escaping in a regular expression), consider a raw string literal
+   |
+LL |     let bad = r"ab\[c";
+   |               ~~~~~~~~
+
+error: aborting due to previous error
+


### PR DESCRIPTION
i'd guess about 70% of "bad escape" cases occur when someone meant to use a raw string literal because they're passing it directly to `Regex::new()`.
this emits an advisory (`Applicability::MaybeIncorrect`) `help:` suggestion to the user that they use an `r""` string, on top of the normal notes about looking at the string literal documentation/spec.