### PR TITLE
rustdoc: Avoid duplicating macros in sidebar

### DIFF
--- a/src/test/rustdoc-gui/duplicate-macro-reexport.goml
+++ b/src/test/rustdoc-gui/duplicate-macro-reexport.goml
@@ -1,0 +1,14 @@
+// This test ensures that there is no macro duplicates in the sidebar.
+goto: file://|DOC_PATH|/test_docs/macro.a.html
+// Waiting for the elements in the sidebar to be rendered.
+wait-for: ".sidebar-elems .others .macro"
+// Check there is only one macro named "a" listed in the sidebar.
+assert-count: (
+    "//*[@class='sidebar-elems']//*[@class='others']/*[@class='block macro']//li/a[text()='a']",
+    1,
+)
+// Check there is only one macro named "b" listed in the sidebar.
+assert-count: (
+    "//*[@class='sidebar-elems']//*[@class='others']/*[@class='block macro']//li/a[text()='b']",
+    1,
+)

--- a/src/test/rustdoc-gui/src/test_docs/lib.rs
+++ b/src/test/rustdoc-gui/src/test_docs/lib.rs
@@ -271,3 +271,6 @@ impl EmptyTrait1 for HasEmptyTraits {}
 impl EmptyTrait2 for HasEmptyTraits {}
 #[doc(cfg(feature = "some-feature"))]
 impl EmptyTrait3 for HasEmptyTraits {}
+
+mod macros;
+pub use macros::*;

--- a/src/test/rustdoc-gui/src/test_docs/macros.rs
+++ b/src/test/rustdoc-gui/src/test_docs/macros.rs
@@ -1,0 +1,4 @@
+#[macro_export]
+macro_rules! a{ () => {}}
+#[macro_export]
+macro_rules! b{ () => {}}


### PR DESCRIPTION
Fixes #93912.

cc @jsha (for the GUI test)
r? @camelid 