### PR TITLE
Change desugaring of let-else to ensure temporary is dropped earlier

### DIFF
--- a/compiler/rustc_ast_lowering/src/block.rs
+++ b/compiler/rustc_ast_lowering/src/block.rs
@@ -159,6 +159,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
             span,
             kind: hir::ExprKind::If(let_expr, then_expr, Some(else_expr)),
         });
+        let drop_temps = self.expr_drop_temps(span, if_expr, AttrVec::new());
         if !self.sess.features_untracked().let_else {
             feature_err(
                 &self.sess.parse_sess,
@@ -168,6 +169,6 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
             )
             .emit();
         }
-        if_expr
+        drop_temps
     }
 }

--- a/compiler/rustc_typeck/src/check/expr.rs
+++ b/compiler/rustc_typeck/src/check/expr.rs
@@ -225,6 +225,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             | ExprKind::If(..)
             | ExprKind::Let(..)
             | ExprKind::Loop(..)
+            | ExprKind::DropTemps(..)
             | ExprKind::Match(..) => {}
             // If `expr` is a result of desugaring the try block and is an ok-wrapped
             // diverging expression (e.g. it arose from desugaring of `try { return }`),

--- a/src/test/ui/let-else/let-else-allow-unused.rs
+++ b/src/test/ui/let-else/let-else-allow-unused.rs
@@ -1,4 +1,3 @@
-// check-pass
 // issue #89807
 
 #![feature(let_else)]
@@ -6,9 +5,11 @@
 #[deny(unused_variables)]
 
 fn main() {
-    let value = Some(String::new());
+    let value = Some(5);
     #[allow(unused)]
     let banana = 1;
     #[allow(unused)]
     let Some(chaenomeles) = value else { return }; // OK
+    let Some(unused) = value else { return };
+    //~^ ERROR unused variable: `unused`
 }

--- a/src/test/ui/let-else/let-else-allow-unused.stderr
+++ b/src/test/ui/let-else/let-else-allow-unused.stderr
@@ -1,0 +1,14 @@
+error: unused variable: `unused`
+  --> $DIR/let-else-allow-unused.rs:13:14
+   |
+LL |     let Some(unused) = value else { return };
+   |              ^^^^^^ help: if this is intentional, prefix it with an underscore: `_unused`
+   |
+note: the lint level is defined here
+  --> $DIR/let-else-allow-unused.rs:5:8
+   |
+LL | #[deny(unused_variables)]
+   |        ^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+

--- a/src/test/ui/let-else/let-else-temp-borrowck.rs
+++ b/src/test/ui/let-else/let-else-temp-borrowck.rs
@@ -12,12 +12,12 @@ fn foo<'a>(x: &'a str) -> Result<impl Debug + 'a, ()> {
 
 fn let_else() {
     let x = String::from("Hey");
-    let Ok(s) = foo(&x) else { return };
+    let Ok(_) = foo(&x) else { return };
 }
 
 fn if_let() {
     let x = String::from("Hey");
-    let s = if let Ok(s) = foo(&x) { s } else { return };
+    let _ = if let Ok(s) = foo(&x) { s } else { return };
 }
 
 fn main() {

--- a/src/test/ui/let-else/let-else-temp-borrowck.rs
+++ b/src/test/ui/let-else/let-else-temp-borrowck.rs
@@ -1,0 +1,26 @@
+// check-pass
+//
+// from issue #93951, where borrowck complained the temporary that `foo(&x)` was stored in was to
+// be dropped sometime after `x` was. It then suggested adding a semicolon that was already there.
+
+#![feature(let_else)]
+use std::fmt::Debug;
+
+fn foo<'a>(x: &'a str) -> Result<impl Debug + 'a, ()> {
+    Ok(x)
+}
+
+fn let_else() {
+    let x = String::from("Hey");
+    let Ok(s) = foo(&x) else { return };
+}
+
+fn if_let() {
+    let x = String::from("Hey");
+    let s = if let Ok(s) = foo(&x) { s } else { return };
+}
+
+fn main() {
+    let_else();
+    if_let();
+}

--- a/src/test/ui/let-else/let-else-then-diverge.rs
+++ b/src/test/ui/let-else/let-else-then-diverge.rs
@@ -1,0 +1,19 @@
+//
+// popped up in in #94012, where an alternative desugaring was
+// causing unreachable code errors
+
+#![feature(let_else)]
+#![deny(unused_variables)]
+#![deny(unreachable_code)]
+
+fn let_else_diverge() -> bool {
+    let Some(_) = Some("test") else {
+        let x = 5; //~ ERROR unused variable: `x`
+        return false;
+    };
+    return true;
+}
+
+fn main() {
+    let_else_diverge();
+}

--- a/src/test/ui/let-else/let-else-then-diverge.rs
+++ b/src/test/ui/let-else/let-else-then-diverge.rs
@@ -1,6 +1,7 @@
-//
 // popped up in in #94012, where an alternative desugaring was
-// causing unreachable code errors
+// causing unreachable code errors, and also we needed to check
+// that the desugaring's generated lints weren't applying to
+// the whole else block.
 
 #![feature(let_else)]
 #![deny(unused_variables)]

--- a/src/test/ui/let-else/let-else-then-diverge.stderr
+++ b/src/test/ui/let-else/let-else-then-diverge.stderr
@@ -1,0 +1,14 @@
+error: unused variable: `x`
+  --> $DIR/let-else-then-diverge.rs:11:13
+   |
+LL |         let x = 5;
+   |             ^ help: if this is intentional, prefix it with an underscore: `_x`
+   |
+note: the lint level is defined here
+  --> $DIR/let-else-then-diverge.rs:6:9
+   |
+LL | #![deny(unused_variables)]
+   |         ^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+

--- a/src/test/ui/let-else/let-else-then-diverge.stderr
+++ b/src/test/ui/let-else/let-else-then-diverge.stderr
@@ -1,11 +1,11 @@
 error: unused variable: `x`
-  --> $DIR/let-else-then-diverge.rs:11:13
+  --> $DIR/let-else-then-diverge.rs:12:13
    |
 LL |         let x = 5;
    |             ^ help: if this is intentional, prefix it with an underscore: `_x`
    |
 note: the lint level is defined here
-  --> $DIR/let-else-then-diverge.rs:6:9
+  --> $DIR/let-else-then-diverge.rs:7:9
    |
 LL | #![deny(unused_variables)]
    |         ^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Fixes #93951. Ref #87335. Now uses DropTemps per Cam's suggestion, which is equivalent to what I was doing earlier but obviously much better and now only a 3-line change.

~~This new desugaring introduces a named temporary to hold the result of evaluating the generated if-let. The named temporary surrounding the whole if-let allows borrowck to see that the unnamed temporary that holds `foo(&x)` is dropped before `x` is. I think in rustc terminology you can say there is now a destruction scope between `foo(&x)` and the `}` where `x` is dropped.~~

~~An alternative would be to introduce even finer-grained scopes in implicit return expressions. But that seems a much bigger change, and much more difficult for me. Or, of course, go back to the original strategy of extracting the pattern's bindings via a tuple.~~

From here:

> it's possible there's a solution without reintroducing that complexity. If you make the desugaring `let retval = if let Ok(s) = foo(&x) { /* trailing stmts */ } else { return; }; retval` then you no longer have a temporary that borrowck worries will be dropped after `x`: [playground](https://play.rust-lang.org/?version=nightly&mode=debug&edition=2021&gist=819934ee99812c4674e27a078ba672d5). That is, if we can't think of any other borrowck issues.
>
> _Originally posted by me in https://github.com/rust-lang/rust/issues/93628#issuecomment-1039776915_

```diff
 fn test() {
     let x = String::from("Hey");
     // input
     let Ok(s) = foo(&x) else { return };
     return;

     // desugaring
-    if let Ok(s) = foo(&x) { return; } else { return }
+    DropTemps(if let Ok(s) = foo(&x) { return; } else { return })
 }
```

r? @lcnr 