### PR TITLE
improve custom message format in assert_eq macro

### DIFF
--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -39,10 +39,12 @@ macro_rules! assert_eq {
             (left_val, right_val) => {
                 if !(*left_val == *right_val) {
                     let kind = $crate::panicking::AssertKind::Eq;
+                    let left_name = stringify!($left);
+                    let right_name = stringify!($right);
                     // The reborrows below are intentional. Without them, the stack slot for the
                     // borrow is initialized even before the values are compared, leading to a
                     // noticeable slow down.
-                    $crate::panicking::assert_failed(kind, &*left_val, &*right_val, $crate::option::Option::None);
+                    $crate::panicking::assert_failed(kind, &*left_val, &*right_val, left_name, right_name, $crate::option::Option::None);
                 }
             }
         }
@@ -52,10 +54,12 @@ macro_rules! assert_eq {
             (left_val, right_val) => {
                 if !(*left_val == *right_val) {
                     let kind = $crate::panicking::AssertKind::Eq;
+                    let left_name = stringify!($left);
+                    let right_name = stringify!($right);
                     // The reborrows below are intentional. Without them, the stack slot for the
                     // borrow is initialized even before the values are compared, leading to a
                     // noticeable slow down.
-                    $crate::panicking::assert_failed(kind, &*left_val, &*right_val, $crate::option::Option::Some($crate::format_args!($($arg)+)));
+                    $crate::panicking::assert_failed(kind, &*left_val, &*right_val, left_name, right_name, $crate::option::Option::Some($crate::format_args!($($arg)+)));
                 }
             }
         }
@@ -89,10 +93,12 @@ macro_rules! assert_ne {
             (left_val, right_val) => {
                 if *left_val == *right_val {
                     let kind = $crate::panicking::AssertKind::Ne;
+                    let left_name = stringify!($left);
+                    let right_name = stringify!($right);
                     // The reborrows below are intentional. Without them, the stack slot for the
                     // borrow is initialized even before the values are compared, leading to a
                     // noticeable slow down.
-                    $crate::panicking::assert_failed(kind, &*left_val, &*right_val, $crate::option::Option::None);
+                    $crate::panicking::assert_failed(kind, &*left_val, &*right_val, left_name, right_name, $crate::option::Option::None);
                 }
             }
         }
@@ -102,10 +108,12 @@ macro_rules! assert_ne {
             (left_val, right_val) => {
                 if *left_val == *right_val {
                     let kind = $crate::panicking::AssertKind::Ne;
+                    let left_name = stringify!($left);
+                    let right_name = stringify!($right);
                     // The reborrows below are intentional. Without them, the stack slot for the
                     // borrow is initialized even before the values are compared, leading to a
                     // noticeable slow down.
-                    $crate::panicking::assert_failed(kind, &*left_val, &*right_val, $crate::option::Option::Some($crate::format_args!($($arg)+)));
+                    $crate::panicking::assert_failed(kind, &*left_val, &*right_val, left_name, right_name, $crate::option::Option::Some($crate::format_args!($($arg)+)));
                 }
             }
         }

--- a/library/core/src/panicking.rs
+++ b/library/core/src/panicking.rs
@@ -205,8 +205,8 @@ pub fn assert_matches_failed<T: fmt::Debug + ?Sized>(
 #[track_caller]
 fn assert_failed_inner(
     kind: AssertKind,
-    left: &dyn fmt::Debug,
-    right: &dyn fmt::Debug,
+    upper_bounds: &dyn fmt::Debug,
+    target: &dyn fmt::Debug,
     args: Option<fmt::Arguments<'_>>,
 ) -> ! {
     let op = match kind {
@@ -217,17 +217,17 @@ fn assert_failed_inner(
 
     match args {
         Some(args) => panic!(
-            r#"assertion failed: `(left {} right)`
-   left: `{:?}`,
-  right: `{:?}`,
-context: `{:?}`"#,
-            op, left, right, args
+            r#"assertion failed: `(upper_bounds {} target)`
+   Error: `{:?}`,        
+   upper_bounds: `{:?}`,
+   target: `{:?}`"#,
+            op, args, upper_bounds, target,
         ),
         None => panic!(
-            r#"assertion failed: `(left {} right)`
-  left: `{:?}`,
- right: `{:?}`"#,
-            op, left, right,
+            r#"assertion failed: `(upper_bounds {} target)`
+   upper_bounds: `{:?}`,
+   target: `{:?}`"#,
+            op, upper_bounds, target,
         ),
     }
 }

--- a/library/core/src/panicking.rs
+++ b/library/core/src/panicking.rs
@@ -218,7 +218,7 @@ fn assert_failed_inner(
     match args {
         Some(args) => panic!(
             r#"assertion failed: `(upper_bounds {} target)`
-   Error: `{:?}`,        
+   Error: `{:?}`,
    upper_bounds: `{:?}`,
    target: `{:?}`"#,
             op, args, upper_bounds, target,

--- a/library/core/src/panicking.rs
+++ b/library/core/src/panicking.rs
@@ -219,7 +219,8 @@ fn assert_failed_inner(
         Some(args) => panic!(
             r#"assertion failed: `(left {} right)`
   left: `{:?}`,
- right: `{:?}`: {}"#,
+ right: `{:?}`,
+context: `{:?}`"#,
             op, left, right, args
         ),
         None => panic!(

--- a/library/core/src/panicking.rs
+++ b/library/core/src/panicking.rs
@@ -218,8 +218,8 @@ fn assert_failed_inner(
     match args {
         Some(args) => panic!(
             r#"assertion failed: `(left {} right)`
-  left: `{:?}`,
- right: `{:?}`,
+   left: `{:?}`,
+  right: `{:?}`,
 context: `{:?}`"#,
             op, left, right, args
         ),

--- a/library/core/src/panicking.rs
+++ b/library/core/src/panicking.rs
@@ -171,15 +171,17 @@ pub enum AssertKind {
 #[doc(hidden)]
 pub fn assert_failed<T, U>(
     kind: AssertKind,
-    left: &T,
-    right: &U,
+    left_val: &T,
+    right_val: &U,
+    left_name: &'static str,
+    right_name: &'static str,
     args: Option<fmt::Arguments<'_>>,
 ) -> !
 where
     T: fmt::Debug + ?Sized,
     U: fmt::Debug + ?Sized,
 {
-    assert_failed_inner(kind, &left, &right, args)
+    assert_failed_inner(kind, &left_val, &right_val, &left_name, &right_name, args)
 }
 
 /// Internal function for `assert_match!`
@@ -198,15 +200,24 @@ pub fn assert_matches_failed<T: fmt::Debug + ?Sized>(
             fmt::Display::fmt(self.0, f)
         }
     }
-    assert_failed_inner(AssertKind::Match, &left, &Pattern(right), args);
+    assert_failed_inner(
+        AssertKind::Match,
+        &left,
+        &Pattern(right),
+        stringify!(&left),
+        stringify!(&right),
+        args,
+    );
 }
 
 /// Non-generic version of the above functions, to avoid code bloat.
 #[track_caller]
 fn assert_failed_inner(
     kind: AssertKind,
-    upper_bounds: &dyn fmt::Debug,
-    target: &dyn fmt::Debug,
+    left_val: &dyn fmt::Debug,
+    right_val: &dyn fmt::Debug,
+    left_name: &'static str,
+    right_name: &'static str,
     args: Option<fmt::Arguments<'_>>,
 ) -> ! {
     let op = match kind {
@@ -217,17 +228,16 @@ fn assert_failed_inner(
 
     match args {
         Some(args) => panic!(
-            r#"assertion failed: `(upper_bounds {} target)`
-   Error: `{:?}`,
-   upper_bounds: `{:?}`,
-   target: `{:?}`"#,
-            op, args, upper_bounds, target,
+            r#"assertion failed: `({left_name} {} {right_name})`
+  {left_name}: `{:?}`,
+ {right_name}: `{:?}`: {}"#,
+            op, left_val, right_val, args
         ),
         None => panic!(
-            r#"assertion failed: `(upper_bounds {} target)`
-   upper_bounds: `{:?}`,
-   target: `{:?}`"#,
-            op, upper_bounds, target,
+            r#"assertion failed: `({left_name} {} {right_name})`
+  {left_name}: `{:?}`,
+ {right_name}: `{:?}`"#,
+            op, left_val, right_val,
         ),
     }
 }

--- a/library/core/src/panicking.rs
+++ b/library/core/src/panicking.rs
@@ -229,14 +229,15 @@ fn assert_failed_inner(
     match args {
         Some(args) => panic!(
             r#"assertion failed: `({left_name} {} {right_name})`
-  {left_name}: `{:?}`,
- {right_name}: `{:?}`: {}"#,
+  left: `{:?}`,
+ right: `{:?}`: 
+    at: {}"#,
             op, left_val, right_val, args
         ),
         None => panic!(
             r#"assertion failed: `({left_name} {} {right_name})`
-  {left_name}: `{:?}`,
- {right_name}: `{:?}`"#,
+  left: `{:?}`,
+ right: `{:?}`"#,
             op, left_val, right_val,
         ),
     }

--- a/library/core/src/panicking.rs
+++ b/library/core/src/panicking.rs
@@ -171,15 +171,17 @@ pub enum AssertKind {
 #[doc(hidden)]
 pub fn assert_failed<T, U>(
     kind: AssertKind,
-    left: &T,
-    right: &U,
+    left_val: &T,
+    right_val: &U,
+    left_name: &'static str,
+    right_name: &'static str,
     args: Option<fmt::Arguments<'_>>,
 ) -> !
 where
     T: fmt::Debug + ?Sized,
     U: fmt::Debug + ?Sized,
 {
-    assert_failed_inner(kind, &left, &right, args)
+    assert_failed_inner(kind, &left_val, &right_val, &left_name, &right_name, args)
 }
 
 /// Internal function for `assert_match!`
@@ -198,15 +200,24 @@ pub fn assert_matches_failed<T: fmt::Debug + ?Sized>(
             fmt::Display::fmt(self.0, f)
         }
     }
-    assert_failed_inner(AssertKind::Match, &left, &Pattern(right), args);
+    assert_failed_inner(
+        AssertKind::Match,
+        &left,
+        &Pattern(right),
+        stringify!(&left),
+        stringify!(&right),
+        args,
+    );
 }
 
 /// Non-generic version of the above functions, to avoid code bloat.
 #[track_caller]
 fn assert_failed_inner(
     kind: AssertKind,
-    upper_bounds: &dyn fmt::Debug,
-    target: &dyn fmt::Debug,
+    left_val: &dyn fmt::Debug,
+    right_val: &dyn fmt::Debug,
+    left_name: &'static str,
+    right_name: &'static str,
     args: Option<fmt::Arguments<'_>>,
 ) -> ! {
     let op = match kind {
@@ -217,17 +228,16 @@ fn assert_failed_inner(
 
     match args {
         Some(args) => panic!(
-            r#"assertion failed: `(upper_bounds {} target)`
-   Error: `{:?}`,        
-   upper_bounds: `{:?}`,
-   target: `{:?}`"#,
-            op, args, upper_bounds, target,
+            r#"assertion failed: `({left_name} {} {right_name})`
+  {left_name}: `{:?}`,
+ {right_name}: `{:?}`: {}"#,
+            op, left_val, right_val, args
         ),
         None => panic!(
-            r#"assertion failed: `(upper_bounds {} target)`
-   upper_bounds: `{:?}`,
-   target: `{:?}`"#,
-            op, upper_bounds, target,
+            r#"assertion failed: `({left_name} {} {right_name})`
+  {left_name}: `{:?}`,
+ {right_name}: `{:?}`"#,
+            op, left_val, right_val,
         ),
     }
 }

--- a/library/core/src/panicking.rs
+++ b/library/core/src/panicking.rs
@@ -228,18 +228,10 @@ fn assert_failed_inner(
 
     match args {
         Some(args) => panic!(
-<<<<<<< HEAD
             r#"assertion failed: `({left_name} {} {right_name})`
   {left_name}: `{:?}`,
  {right_name}: `{:?}`: {}"#,
             op, left_val, right_val, args
-=======
-            r#"assertion failed: `(upper_bounds {} target)`
-   Error: `{:?}`,
-   upper_bounds: `{:?}`,
-   target: `{:?}`"#,
-            op, args, upper_bounds, target,
->>>>>>> 108f87e4604224132eedd8e3a6ec5d90f313764a
         ),
         None => panic!(
             r#"assertion failed: `({left_name} {} {right_name})`


### PR DESCRIPTION
I just change the message format in `assert_failed_inner` function. There may be other better modifications, such as splitting custom message and error location, but I can't assert. More info, see [#94005](https://github.com/rust-lang/rust/issues/94005)