### PR TITLE
[diagnostics] Add mentions to `Copy` types being valid for `union` fields

### DIFF
--- a/compiler/rustc_typeck/src/check/check.rs
+++ b/compiler/rustc_typeck/src/check/check.rs
@@ -382,10 +382,15 @@ fn check_union_fields(tcx: TyCtxt<'_>, span: Span, item_def_id: LocalDefId) -> b
                     tcx.sess,
                     field_span,
                     E0740,
-                    "unions may not contain fields that need dropping"
+                    "unions cannot contain fields that may need dropping"
+                )
+                .note(
+                    "a type is guaranteed not to need dropping \
+                    when it implements `Copy`, or when it is the special `ManuallyDrop<_>` type",
                 )
                 .multipart_suggestion_verbose(
-                    "wrap the type with `std::mem::ManuallyDrop` and ensure it is manually dropped",
+                    "when the type does not implement `Copy`, \
+                    wrap it inside a `ManuallyDrop<_>` and ensure it is manually dropped",
                     vec![
                         (ty_span.shrink_to_lo(), format!("std::mem::ManuallyDrop<")),
                         (ty_span.shrink_to_hi(), ">".into()),

--- a/src/test/ui/feature-gates/feature-gate-untagged_unions.rs
+++ b/src/test/ui/feature-gates/feature-gate-untagged_unions.rs
@@ -13,7 +13,7 @@ union U22<T> { // OK
 }
 
 union U3 {
-    a: String, //~ ERROR unions may not contain fields that need dropping
+    a: String, //~ ERROR unions cannot contain fields that may need dropping
 }
 
 union U32 { // field that does not drop but is not `Copy`, either -- this is the real feature gate test!
@@ -21,7 +21,7 @@ union U32 { // field that does not drop but is not `Copy`, either -- this is the
 }
 
 union U4<T> {
-    a: T, //~ ERROR unions may not contain fields that need dropping
+    a: T, //~ ERROR unions cannot contain fields that may need dropping
 }
 
 union U5 { // Having a drop impl is OK

--- a/src/test/ui/feature-gates/feature-gate-untagged_unions.stderr
+++ b/src/test/ui/feature-gates/feature-gate-untagged_unions.stderr
@@ -7,24 +7,26 @@ LL |     a: std::cell::RefCell<i32>,
    = note: see issue #55149 <https://github.com/rust-lang/rust/issues/55149> for more information
    = help: add `#![feature(untagged_unions)]` to the crate attributes to enable
 
-error[E0740]: unions may not contain fields that need dropping
+error[E0740]: unions cannot contain fields that may need dropping
   --> $DIR/feature-gate-untagged_unions.rs:16:5
    |
 LL |     a: String,
    |     ^^^^^^^^^
    |
-help: wrap the type with `std::mem::ManuallyDrop` and ensure it is manually dropped
+   = note: a type is guaranteed not to need dropping when it implements `Copy`, or when it is the special `ManuallyDrop<_>` type
+help: when the type does not implement `Copy`, wrap it inside a `ManuallyDrop<_>` and ensure it is manually dropped
    |
 LL |     a: std::mem::ManuallyDrop<String>,
    |        +++++++++++++++++++++++      +
 
-error[E0740]: unions may not contain fields that need dropping
+error[E0740]: unions cannot contain fields that may need dropping
   --> $DIR/feature-gate-untagged_unions.rs:24:5
    |
 LL |     a: T,
    |     ^^^^
    |
-help: wrap the type with `std::mem::ManuallyDrop` and ensure it is manually dropped
+   = note: a type is guaranteed not to need dropping when it implements `Copy`, or when it is the special `ManuallyDrop<_>` type
+help: when the type does not implement `Copy`, wrap it inside a `ManuallyDrop<_>` and ensure it is manually dropped
    |
 LL |     a: std::mem::ManuallyDrop<T>,
    |        +++++++++++++++++++++++ +

--- a/src/test/ui/union/issue-41073.rs
+++ b/src/test/ui/union/issue-41073.rs
@@ -1,7 +1,7 @@
 #![feature(untagged_unions)]
 
 union Test {
-    a: A, //~ ERROR unions may not contain fields that need dropping
+    a: A, //~ ERROR unions cannot contain fields that may need dropping
     b: B
 }
 

--- a/src/test/ui/union/issue-41073.stderr
+++ b/src/test/ui/union/issue-41073.stderr
@@ -1,10 +1,11 @@
-error[E0740]: unions may not contain fields that need dropping
+error[E0740]: unions cannot contain fields that may need dropping
   --> $DIR/issue-41073.rs:4:5
    |
 LL |     a: A,
    |     ^^^^
    |
-help: wrap the type with `std::mem::ManuallyDrop` and ensure it is manually dropped
+   = note: a type is guaranteed not to need dropping when it implements `Copy`, or when it is the special `ManuallyDrop<_>` type
+help: when the type does not implement `Copy`, wrap it inside a `ManuallyDrop<_>` and ensure it is manually dropped
    |
 LL |     a: std::mem::ManuallyDrop<A>,
    |        +++++++++++++++++++++++ +

--- a/src/test/ui/union/union-custom-drop.rs
+++ b/src/test/ui/union/union-custom-drop.rs
@@ -4,7 +4,7 @@
 #![feature(untagged_unions)]
 
 union Foo {
-    bar: Bar, //~ ERROR unions may not contain fields that need dropping
+    bar: Bar, //~ ERROR unions cannot contain fields that may need dropping
 }
 
 union Bar {

--- a/src/test/ui/union/union-custom-drop.stderr
+++ b/src/test/ui/union/union-custom-drop.stderr
@@ -1,10 +1,11 @@
-error[E0740]: unions may not contain fields that need dropping
+error[E0740]: unions cannot contain fields that may need dropping
   --> $DIR/union-custom-drop.rs:7:5
    |
 LL |     bar: Bar,
    |     ^^^^^^^^
    |
-help: wrap the type with `std::mem::ManuallyDrop` and ensure it is manually dropped
+   = note: a type is guaranteed not to need dropping when it implements `Copy`, or when it is the special `ManuallyDrop<_>` type
+help: when the type does not implement `Copy`, wrap it inside a `ManuallyDrop<_>` and ensure it is manually dropped
    |
 LL |     bar: std::mem::ManuallyDrop<Bar>,
    |          +++++++++++++++++++++++   +

--- a/src/test/ui/union/union-with-drop-fields.mirunsafeck.stderr
+++ b/src/test/ui/union/union-with-drop-fields.mirunsafeck.stderr
@@ -1,32 +1,35 @@
-error[E0740]: unions may not contain fields that need dropping
+error[E0740]: unions cannot contain fields that may need dropping
   --> $DIR/union-with-drop-fields.rs:11:5
    |
 LL |     a: String,
    |     ^^^^^^^^^
    |
-help: wrap the type with `std::mem::ManuallyDrop` and ensure it is manually dropped
+   = note: a type is guaranteed not to need dropping when it implements `Copy`, or when it is the special `ManuallyDrop<_>` type
+help: when the type does not implement `Copy`, wrap it inside a `ManuallyDrop<_>` and ensure it is manually dropped
    |
 LL |     a: std::mem::ManuallyDrop<String>,
    |        +++++++++++++++++++++++      +
 
-error[E0740]: unions may not contain fields that need dropping
+error[E0740]: unions cannot contain fields that may need dropping
   --> $DIR/union-with-drop-fields.rs:19:5
    |
 LL |     a: S,
    |     ^^^^
    |
-help: wrap the type with `std::mem::ManuallyDrop` and ensure it is manually dropped
+   = note: a type is guaranteed not to need dropping when it implements `Copy`, or when it is the special `ManuallyDrop<_>` type
+help: when the type does not implement `Copy`, wrap it inside a `ManuallyDrop<_>` and ensure it is manually dropped
    |
 LL |     a: std::mem::ManuallyDrop<S>,
    |        +++++++++++++++++++++++ +
 
-error[E0740]: unions may not contain fields that need dropping
+error[E0740]: unions cannot contain fields that may need dropping
   --> $DIR/union-with-drop-fields.rs:24:5
    |
 LL |     a: T,
    |     ^^^^
    |
-help: wrap the type with `std::mem::ManuallyDrop` and ensure it is manually dropped
+   = note: a type is guaranteed not to need dropping when it implements `Copy`, or when it is the special `ManuallyDrop<_>` type
+help: when the type does not implement `Copy`, wrap it inside a `ManuallyDrop<_>` and ensure it is manually dropped
    |
 LL |     a: std::mem::ManuallyDrop<T>,
    |        +++++++++++++++++++++++ +

--- a/src/test/ui/union/union-with-drop-fields.rs
+++ b/src/test/ui/union/union-with-drop-fields.rs
@@ -8,7 +8,7 @@ union U {
 }
 
 union W {
-    a: String, //~ ERROR unions may not contain fields that need dropping
+    a: String, //~ ERROR unions cannot contain fields that may need dropping
     b: String, // OK, only one field is reported
 }
 
@@ -16,12 +16,12 @@ struct S(String);
 
 // `S` doesn't implement `Drop` trait, but still has non-trivial destructor
 union Y {
-    a: S, //~ ERROR unions may not contain fields that need dropping
+    a: S, //~ ERROR unions cannot contain fields that may need dropping
 }
 
 // We don't know if `T` is trivially-destructable or not until trans
 union J<T> {
-    a: T, //~ ERROR unions may not contain fields that need dropping
+    a: T, //~ ERROR unions cannot contain fields that may need dropping
 }
 
 union H<T: Copy> {

--- a/src/test/ui/union/union-with-drop-fields.thirunsafeck.stderr
+++ b/src/test/ui/union/union-with-drop-fields.thirunsafeck.stderr
@@ -1,32 +1,35 @@
-error[E0740]: unions may not contain fields that need dropping
+error[E0740]: unions cannot contain fields that may need dropping
   --> $DIR/union-with-drop-fields.rs:11:5
    |
 LL |     a: String,
    |     ^^^^^^^^^
    |
-help: wrap the type with `std::mem::ManuallyDrop` and ensure it is manually dropped
+   = note: a type is guaranteed not to need dropping when it implements `Copy`, or when it is the special `ManuallyDrop<_>` type
+help: when the type does not implement `Copy`, wrap it inside a `ManuallyDrop<_>` and ensure it is manually dropped
    |
 LL |     a: std::mem::ManuallyDrop<String>,
    |        +++++++++++++++++++++++      +
 
-error[E0740]: unions may not contain fields that need dropping
+error[E0740]: unions cannot contain fields that may need dropping
   --> $DIR/union-with-drop-fields.rs:19:5
    |
 LL |     a: S,
    |     ^^^^
    |
-help: wrap the type with `std::mem::ManuallyDrop` and ensure it is manually dropped
+   = note: a type is guaranteed not to need dropping when it implements `Copy`, or when it is the special `ManuallyDrop<_>` type
+help: when the type does not implement `Copy`, wrap it inside a `ManuallyDrop<_>` and ensure it is manually dropped
    |
 LL |     a: std::mem::ManuallyDrop<S>,
    |        +++++++++++++++++++++++ +
 
-error[E0740]: unions may not contain fields that need dropping
+error[E0740]: unions cannot contain fields that may need dropping
   --> $DIR/union-with-drop-fields.rs:24:5
    |
 LL |     a: T,
    |     ^^^^
    |
-help: wrap the type with `std::mem::ManuallyDrop` and ensure it is manually dropped
+   = note: a type is guaranteed not to need dropping when it implements `Copy`, or when it is the special `ManuallyDrop<_>` type
+help: when the type does not implement `Copy`, wrap it inside a `ManuallyDrop<_>` and ensure it is manually dropped
    |
 LL |     a: std::mem::ManuallyDrop<T>,
    |        +++++++++++++++++++++++ +


### PR DESCRIPTION
This came up from some user on Discord which was using a `T : PrimitiveInt` generic type, and they wanted to use in a `union`. Rather than adding a `Copy` bound, they started pondering about the `ManuallyDrop<T>` road, and how to correctly use `unsafe` to perform the drops.

<img width="648" alt="Screen Shot 2022-02-15 at 22 28 34" src="https://user-images.githubusercontent.com/9920355/154152496-8f9be74b-ad59-4724-8f9e-48b446774e06.png">

  - [Discord link](https://discord.com/channels/442252698964721669/443150878111694848/943092778534072320)

So, it seemed like the error message for types with potential drop glue on `union` fields could be improved to also mention the `Copy` alternative, since in many cases where `union`s are concerned, people are dealing with PODs / `Copy` types anyways 🙂 

___

@rustbot modify labels: +A-diagnostics +D-terse