### PR TITLE
Destabilize cfg(target_has_atomic_load_store = ...)

### DIFF
--- a/compiler/rustc_feature/src/accepted.rs
+++ b/compiler/rustc_feature/src/accepted.rs
@@ -72,8 +72,6 @@ declare_features! (
     (accepted, cfg_doctest, "1.40.0", Some(62210), None),
     /// Allows `cfg(target_feature = "...")`.
     (accepted, cfg_target_feature, "1.27.0", Some(29717), None),
-    /// Allows `cfg(target_has_atomic = "...")`.
-    (accepted, cfg_target_has_atomic, "1.60.0", Some(32976), None),
     /// Allows `cfg(target_vendor = "...")`.
     (accepted, cfg_target_vendor, "1.33.0", Some(29718), None),
     /// Allows implementing `Clone` for closures where possible (RFC 2132).

--- a/compiler/rustc_feature/src/active.rs
+++ b/compiler/rustc_feature/src/active.rs
@@ -312,6 +312,8 @@ declare_features! (
     (active, cfg_sanitize, "1.41.0", Some(39699), None),
     /// Allows `cfg(target_abi = "...")`.
     (active, cfg_target_abi, "1.55.0", Some(80970), None),
+    /// Allows `cfg(target_has_atomic_load_store = "...")`.
+    (active, cfg_target_has_atomic, "1.60.0", Some(94039), None),
     /// Allows `cfg(target_has_atomic_equal_alignment = "...")`.
     (active, cfg_target_has_atomic_equal_alignment, "1.60.0", Some(93822), None),
     /// Allows `cfg(target_thread_local)`.

--- a/compiler/rustc_feature/src/builtin_attrs.rs
+++ b/compiler/rustc_feature/src/builtin_attrs.rs
@@ -31,6 +31,7 @@ const GATED_CFGS: &[GatedCfg] = &[
         sym::cfg_target_has_atomic_equal_alignment,
         cfg_fn!(cfg_target_has_atomic_equal_alignment),
     ),
+    (sym::target_has_atomic_load_store, sym::cfg_target_has_atomic, cfg_fn!(cfg_target_has_atomic)),
     (sym::sanitize, sym::cfg_sanitize, cfg_fn!(cfg_sanitize)),
     (sym::version, sym::cfg_version, cfg_fn!(cfg_version)),
     (sym::panic, sym::cfg_panic, cfg_fn!(cfg_panic)),

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -423,6 +423,7 @@ symbols! {
         cfg_target_feature,
         cfg_target_has_atomic,
         cfg_target_has_atomic_equal_alignment,
+        cfg_target_has_atomic_load_store,
         cfg_target_thread_local,
         cfg_target_vendor,
         cfg_version,

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -155,7 +155,7 @@
 #![feature(allow_internal_unstable)]
 #![feature(associated_type_bounds)]
 #![feature(auto_traits)]
-#![cfg_attr(bootstrap, feature(cfg_target_has_atomic))]
+#![feature(cfg_target_has_atomic)]
 #![cfg_attr(not(bootstrap), feature(cfg_target_has_atomic_equal_alignment))]
 #![feature(const_fn_floating_point_arithmetic)]
 #![feature(const_fn_fn_ptr_basics)]

--- a/src/test/ui/feature-gates/feature-gate-cfg-target-has-atomic.rs
+++ b/src/test/ui/feature-gates/feature-gate-cfg-target-has-atomic.rs
@@ -1,0 +1,14 @@
+fn main() {
+    cfg!(target_has_atomic_load_store = "8");
+    //~^ ERROR `cfg(target_has_atomic_load_store)` is experimental and subject to change
+    cfg!(target_has_atomic_load_store = "16");
+    //~^ ERROR `cfg(target_has_atomic_load_store)` is experimental and subject to change
+    cfg!(target_has_atomic_load_store = "32");
+    //~^ ERROR `cfg(target_has_atomic_load_store)` is experimental and subject to change
+    cfg!(target_has_atomic_load_store = "64");
+    //~^ ERROR `cfg(target_has_atomic_load_store)` is experimental and subject to change
+    cfg!(target_has_atomic_load_store = "128");
+    //~^ ERROR `cfg(target_has_atomic_load_store)` is experimental and subject to change
+    cfg!(target_has_atomic_load_store = "ptr");
+    //~^ ERROR `cfg(target_has_atomic_load_store)` is experimental and subject to change
+}

--- a/src/test/ui/feature-gates/feature-gate-cfg-target-has-atomic.stderr
+++ b/src/test/ui/feature-gates/feature-gate-cfg-target-has-atomic.stderr
@@ -1,0 +1,57 @@
+error[E0658]: `cfg(target_has_atomic_load_store)` is experimental and subject to change
+  --> $DIR/feature-gate-cfg-target-has-atomic.rs:2:10
+   |
+LL |     cfg!(target_has_atomic_load_store = "8");
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #94039 <https://github.com/rust-lang/rust/issues/94039> for more information
+   = help: add `#![feature(cfg_target_has_atomic)]` to the crate attributes to enable
+
+error[E0658]: `cfg(target_has_atomic_load_store)` is experimental and subject to change
+  --> $DIR/feature-gate-cfg-target-has-atomic.rs:4:10
+   |
+LL |     cfg!(target_has_atomic_load_store = "16");
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #94039 <https://github.com/rust-lang/rust/issues/94039> for more information
+   = help: add `#![feature(cfg_target_has_atomic)]` to the crate attributes to enable
+
+error[E0658]: `cfg(target_has_atomic_load_store)` is experimental and subject to change
+  --> $DIR/feature-gate-cfg-target-has-atomic.rs:6:10
+   |
+LL |     cfg!(target_has_atomic_load_store = "32");
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #94039 <https://github.com/rust-lang/rust/issues/94039> for more information
+   = help: add `#![feature(cfg_target_has_atomic)]` to the crate attributes to enable
+
+error[E0658]: `cfg(target_has_atomic_load_store)` is experimental and subject to change
+  --> $DIR/feature-gate-cfg-target-has-atomic.rs:8:10
+   |
+LL |     cfg!(target_has_atomic_load_store = "64");
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #94039 <https://github.com/rust-lang/rust/issues/94039> for more information
+   = help: add `#![feature(cfg_target_has_atomic)]` to the crate attributes to enable
+
+error[E0658]: `cfg(target_has_atomic_load_store)` is experimental and subject to change
+  --> $DIR/feature-gate-cfg-target-has-atomic.rs:10:10
+   |
+LL |     cfg!(target_has_atomic_load_store = "128");
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #94039 <https://github.com/rust-lang/rust/issues/94039> for more information
+   = help: add `#![feature(cfg_target_has_atomic)]` to the crate attributes to enable
+
+error[E0658]: `cfg(target_has_atomic_load_store)` is experimental and subject to change
+  --> $DIR/feature-gate-cfg-target-has-atomic.rs:12:10
+   |
+LL |     cfg!(target_has_atomic_load_store = "ptr");
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #94039 <https://github.com/rust-lang/rust/issues/94039> for more information
+   = help: add `#![feature(cfg_target_has_atomic)]` to the crate attributes to enable
+
+error: aborting due to 6 previous errors
+
+For more information about this error, try `rustc --explain E0658`.


### PR DESCRIPTION
This was not intended to be stabilized yet.

This keeps the cfg_target_has_atomic feature gate name since compiler-builtins otherwise depends on it and I'd rather not try to manage a bump across a crates.io published repository given the time-sensitivity here (we need to land this quickly to avoid a beta backport).

Closes https://github.com/rust-lang/rust/issues/32976

r? @Amanieu 