### PR TITLE
debuginfo: Support fat pointers to unsized tuples.

### DIFF
--- a/src/test/debuginfo/unsized.rs
+++ b/src/test/debuginfo/unsized.rs
@@ -16,6 +16,14 @@
 // gdbg-check:$3 = {pointer = [...], vtable = [...]}
 // gdbr-check:$3 = &unsized::Foo<dyn core::fmt::Debug> {pointer: [...], vtable: [...]}
 
+// gdb-command:print tuple_slice
+// gdbg-check:$4 = {data_ptr = [...], length = 2}
+// gdbr-check:$4 = &(i32, i32, [i32]) {data_ptr: [...], length: 2}
+
+// gdb-command:print tuple_dyn
+// gdbg-check:$5 = {pointer = [...], vtable = [...]}
+// gdbr-check:$5 = &(i32, i32, dyn core::fmt::Debug) {pointer: [...], vtable: [...]}
+
 // === CDB TESTS ===================================================================================
 
 // cdb-command: g
@@ -34,6 +42,17 @@
 // cdb-check:    [+0x000] pointer          : 0x[...] [Type: unsized::Foo<dyn$<core::fmt::Debug> > *]
 // cdb-check:    [...] vtable           : 0x[...] [Type: unsigned [...]int[...] (*)[3]]
 
+// cdb-command:dx tuple_slice
+// cdb-check:tuple_slice      [Type: ref$<tuple$<i32,i32,slice$<i32> > >]
+// cdb-check:    [+0x000] data_ptr         : 0x[...] [Type: tuple$<i32,i32,slice$<i32> > *]
+// cdb-check:    [...] length           : 0x2 [Type: unsigned [...]int[...]
+
+// cdb-command:dx tuple_dyn
+// cdb-check:tuple_dyn        [Type: ref$<tuple$<i32,i32,dyn$<core::fmt::Debug> > >]
+// cdb-check:    [+0x000] pointer          : 0x[...] [Type: tuple$<i32,i32,dyn$<core::fmt::Debug> > *]
+// cdb-check:    [...] vtable           : 0x[...] [Type: unsigned [...]int[...] (*)[3]]
+
+#![feature(unsized_tuple_coercion)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
 
@@ -50,6 +69,10 @@ fn main() {
     let a: &Foo<[u8]> = &foo.value;
     let b: &Foo<Foo<[u8]>> = &foo;
     let c: &Foo<dyn std::fmt::Debug> = &Foo { value: 7i32 };
+
+    // Also check unsized tuples
+    let tuple_slice: &(i32, i32, [i32]) = &(0, 1, [2, 3]);
+    let tuple_dyn: &(i32, i32, dyn std::fmt::Debug) = &(0, 1, &3u64);
 
     zzz(); // #break
 }


### PR DESCRIPTION
This PR makes fat pointer debuginfo generation handle the case of unsized tuples.

Fixes #93871