### PR TITLE
Update dist-x86_64-musl to Ubuntu 20.04

### DIFF
--- a/src/ci/docker/host-x86_64/dist-x86_64-musl/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-x86_64-musl/Dockerfile
@@ -1,6 +1,6 @@
-FROM ubuntu:16.04
+FROM ubuntu:20.04
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
   g++ \
   make \
   ninja-build \


### PR DESCRIPTION
This updates the dist-x86_64-musl image to use Ubuntu 20.04. The current Ubuntu 16.04 based image only works due to the Docker cache, it's not possible anymore to run it locally because of the usual certificate expiration issue.

I believe updating the OS here is relatively safe because this targets musl, so there are no concerns about raising the glibc baseline. There is some risk here in that it updates the compiler toolchain used to produce artifacts, though I'm not aware of any specific issues that could cause.

r? @Mark-Simulacrum 