### PR TITLE
Normalize late-bound projections with inference variables in fulfillment

### DIFF
--- a/compiler/rustc_middle/src/ty/flags.rs
+++ b/compiler/rustc_middle/src/ty/flags.rs
@@ -163,7 +163,13 @@ impl FlagComputation {
 
             &ty::Projection(data) => {
                 self.add_flags(TypeFlags::HAS_TY_PROJECTION);
+                // Check if this projection type captures any late-bound variables in its substs
+                let old_outer = std::mem::replace(&mut self.outer_exclusive_binder, ty::INNERMOST);
                 self.add_projection_ty(data);
+                if self.outer_exclusive_binder > ty::INNERMOST {
+                    self.add_flags(TypeFlags::HAS_LATE_IN_PROJECTION);
+                }
+                self.outer_exclusive_binder = self.outer_exclusive_binder.max(old_outer);
             }
 
             &ty::Opaque(_, substs) => {

--- a/compiler/rustc_middle/src/ty/fold.rs
+++ b/compiler/rustc_middle/src/ty/fold.rs
@@ -209,6 +209,14 @@ pub trait TypeFoldable<'tcx>: fmt::Debug + Clone {
     fn still_further_specializable(&self) -> bool {
         self.has_type_flags(TypeFlags::STILL_FURTHER_SPECIALIZABLE)
     }
+
+    // Indicates that this value has projection types which capture late-bound variables,
+    // which is a sign that the projection types within need further normalization. This
+    // is because we do not replace projections with inference variables when they capture
+    // late-bound variables.
+    fn has_late_bound_vars_in_projection(&self) -> bool {
+        self.has_type_flags(TypeFlags::HAS_LATE_IN_PROJECTION)
+    }
 }
 
 /// This trait is implemented for every folding traversal. There is a fold

--- a/compiler/rustc_type_ir/src/lib.rs
+++ b/compiler/rustc_type_ir/src/lib.rs
@@ -107,6 +107,9 @@ bitflags! {
 
         /// Does this value have `InferConst::Fresh`?
         const HAS_CT_FRESH                = 1 << 19;
+
+        // Does this value have any late-bound vars in any projection type substs?
+        const HAS_LATE_IN_PROJECTION      = 1 << 20;
     }
 }
 

--- a/compiler/rustc_typeck/src/check/fn_ctxt/_impl.rs
+++ b/compiler/rustc_typeck/src/check/fn_ctxt/_impl.rs
@@ -474,7 +474,13 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     ) {
         if !ty.references_error() {
             let lang_item = self.tcx.require_lang_item(LangItem::Sized, None);
-            self.require_type_meets(ty, span, code, lang_item);
+            self.require_type_meets(
+                // We normalize this type because we possibly got it from HIR
+                self.normalize_associated_types_in(span, ty),
+                span,
+                code,
+                lang_item,
+            );
         }
     }
 

--- a/src/test/ui/associated-types/issue-59324.rs
+++ b/src/test/ui/associated-types/issue-59324.rs
@@ -15,9 +15,9 @@ pub trait ThriftService<Bug: NotFoo>:
 {
     fn get_service(
     //~^ ERROR the trait bound `Bug: Foo` is not satisfied
+    //~| ERROR the trait bound `Bug: Foo` is not satisfied
         &self,
     ) -> Self::AssocType;
-    //~^ the trait bound `Bug: Foo` is not satisfied
 }
 
 fn with_factory<H>(factory: dyn ThriftService<()>) {}

--- a/src/test/ui/associated-types/issue-59324.stderr
+++ b/src/test/ui/associated-types/issue-59324.stderr
@@ -6,7 +6,7 @@ LL | |
 LL | |
 LL | |     Service<AssocType = <Bug as Foo>::OnlyFoo>
 ...  |
-LL | |
+LL | |     ) -> Self::AssocType;
 LL | | }
    | |_^ the trait `Foo` is not implemented for `Bug`
    |
@@ -23,7 +23,7 @@ LL | |
 LL | |
 LL | |     Service<AssocType = <Bug as Foo>::OnlyFoo>
 ...  |
-LL | |
+LL | |     ) -> Self::AssocType;
 LL | | }
    | |_^ the trait `Foo` is not implemented for `Bug`
    |
@@ -37,6 +37,7 @@ error[E0277]: the trait bound `Bug: Foo` is not satisfied
    |
 LL | /     fn get_service(
 LL | |
+LL | |
 LL | |         &self,
 LL | |     ) -> Self::AssocType;
    | |_________________________^ the trait `Foo` is not implemented for `Bug`
@@ -47,10 +48,10 @@ LL | pub trait ThriftService<Bug: NotFoo + Foo>:
    |                                     +++++
 
 error[E0277]: the trait bound `Bug: Foo` is not satisfied
-  --> $DIR/issue-59324.rs:19:10
+  --> $DIR/issue-59324.rs:16:8
    |
-LL |     ) -> Self::AssocType;
-   |          ^^^^^^^^^^^^^^^ the trait `Foo` is not implemented for `Bug`
+LL |     fn get_service(
+   |        ^^^^^^^^^^^ the trait `Foo` is not implemented for `Bug`
    |
 help: consider further restricting this bound
    |

--- a/src/test/ui/generic-associated-types/issue-91139.rs
+++ b/src/test/ui/generic-associated-types/issue-91139.rs
@@ -1,13 +1,4 @@
-// revisions: migrate nll
-//[nll]compile-flags: -Z borrowck=mir
-
-// Since we are testing nll (and migration) explicitly as a separate
-// revisions, don't worry about the --compare-mode=nll on this test.
-
-// ignore-compare-mode-nll
-
-//[nll] check-pass
-//[migrate] check-fail
+// check-pass
 
 #![feature(generic_associated_types)]
 
@@ -25,7 +16,6 @@ impl<T> Foo<T> for () {
 
 fn foo<T>() {
     let _: for<'a> fn(<() as Foo<T>>::Type<'a>, &'a T) = |_, _| ();
-    //[migrate]~^ the parameter type `T` may not live long enough
 }
 
 pub fn main() {}

--- a/src/test/ui/higher-rank-trait-bounds/normalize-under-binder/issue-85455.rs
+++ b/src/test/ui/higher-rank-trait-bounds/normalize-under-binder/issue-85455.rs
@@ -7,7 +7,6 @@ trait SomeTrait<'a> {
 fn give_me_ice<T>() {
     callee::<fn(&()) -> <T as SomeTrait<'_>>::Associated>();
     //~^ ERROR the trait bound `T: SomeTrait<'_>` is not satisfied [E0277]
-    //~| ERROR the trait bound `T: SomeTrait<'_>` is not satisfied [E0277]
 }
 
 fn callee<T: Fn<(&'static (),)>>() {

--- a/src/test/ui/higher-rank-trait-bounds/normalize-under-binder/issue-85455.stderr
+++ b/src/test/ui/higher-rank-trait-bounds/normalize-under-binder/issue-85455.stderr
@@ -9,17 +9,6 @@ help: consider restricting type parameter `T`
 LL | fn give_me_ice<T: SomeTrait<'_>>() {
    |                 +++++++++++++++
 
-error[E0277]: the trait bound `T: SomeTrait<'_>` is not satisfied
-  --> $DIR/issue-85455.rs:8:14
-   |
-LL |     callee::<fn(&()) -> <T as SomeTrait<'_>>::Associated>();
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `SomeTrait<'_>` is not implemented for `T`
-   |
-help: consider restricting type parameter `T`
-   |
-LL | fn give_me_ice<T: SomeTrait<'_>>() {
-   |                 +++++++++++++++
-
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/type-alias-impl-trait/generic_duplicate_param_use9.stderr
+++ b/src/test/ui/type-alias-impl-trait/generic_duplicate_param_use9.stderr
@@ -10,12 +10,13 @@ note: previous use here
 LL | fn two<T: Debug + Foo, U: Debug>(t: T, u: U) -> Two<T, U> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0277]: the trait bound `A: Foo` is not satisfied
+error[E0277]: the trait bound `A: Foo` is not satisfied in `(A, B, <A as Foo>::Bar)`
   --> $DIR/generic_duplicate_param_use9.rs:7:18
    |
 LL | type Two<A, B> = impl Debug;
-   |                  ^^^^^^^^^^ the trait `Foo` is not implemented for `A`
+   |                  ^^^^^^^^^^ within `(A, B, <A as Foo>::Bar)`, the trait `Foo` is not implemented for `A`
    |
+   = note: required because it appears within the type `(A, B, <A as Foo>::Bar)`
 help: consider restricting type parameter `A`
    |
 LL | type Two<A: Foo, B> = impl Debug;
@@ -27,7 +28,7 @@ error[E0277]: `A` doesn't implement `Debug`
 LL | type Two<A, B> = impl Debug;
    |                  ^^^^^^^^^^ `A` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
-   = note: required because of the requirements on the impl of `Debug` for `(A, B, _)`
+   = note: required because of the requirements on the impl of `Debug` for `(A, B, <A as Foo>::Bar)`
 help: consider restricting type parameter `A`
    |
 LL | type Two<A: std::fmt::Debug, B> = impl Debug;
@@ -39,7 +40,7 @@ error[E0277]: `B` doesn't implement `Debug`
 LL | type Two<A, B> = impl Debug;
    |                  ^^^^^^^^^^ `B` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
-   = note: required because of the requirements on the impl of `Debug` for `(A, B, _)`
+   = note: required because of the requirements on the impl of `Debug` for `(A, B, <A as Foo>::Bar)`
 help: consider restricting type parameter `B`
    |
 LL | type Two<A, B: std::fmt::Debug> = impl Debug;

--- a/src/test/ui/type-alias-impl-trait/issue-89686.rs
+++ b/src/test/ui/type-alias-impl-trait/issue-89686.rs
@@ -5,7 +5,8 @@
 use std::future::Future;
 
 type G<'a, T> = impl Future<Output = ()>;
-//~^ ERROR: the trait bound `T: Trait` is not satisfied
+//~^ ERROR <impl Future<Output = [async output]> as Future>::Output == ()
+//~| ERROR the trait bound `T: Trait` is not satisfied
 
 trait Trait {
     type F: Future<Output = ()>;

--- a/src/test/ui/type-alias-impl-trait/issue-89686.stderr
+++ b/src/test/ui/type-alias-impl-trait/issue-89686.stderr
@@ -1,3 +1,22 @@
+error[E0271]: type mismatch resolving `<impl Future<Output = [async output]> as Future>::Output == ()`
+  --> $DIR/issue-89686.rs:7:17
+   |
+LL | type G<'a, T> = impl Future<Output = ()>;
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^ expected `()`, found associated type
+...
+LL |         async move { self.f().await }
+   |                    ------------------ the found `async` block
+   |
+  ::: $SRC_DIR/core/src/future/mod.rs:LL:COL
+   |
+LL | pub const fn from_generator<T>(gen: T) -> impl Future<Output = T::Return>
+   |                                           ------------------------------- the found opaque type
+   |
+   = note:    expected unit type `()`
+           found associated type `<impl Future<Output = [async output]> as Future>::Output`
+   = help: consider constraining the associated type `<impl Future<Output = [async output]> as Future>::Output` to `()`
+   = note: for more information, visit https://doc.rust-lang.org/book/ch19-03-advanced-traits.html
+
 error[E0277]: the trait bound `T: Trait` is not satisfied
   --> $DIR/issue-89686.rs:7:17
    |
@@ -9,6 +28,7 @@ help: consider restricting type parameter `T`
 LL | type G<'a, T: Trait> = impl Future<Output = ()>;
    |             +++++++
 
-error: aborting due to previous error
+error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0277`.
+Some errors have detailed explanations: E0271, E0277.
+For more information about an error, try `rustc --explain E0271`.


### PR DESCRIPTION
I modified the PR #90887 <i>"Try to normalize associated types before processing obligations"</i> to only attempt normalization when these two conditions are both true:
1. the projection type has escaping late-bound variables, and 
2. the projection has remaining inference variables.

The only projections that we expect to see inside of a predicate during fulfillment (and which we have any hope of normalizing further) are those that have remaining inference variables that need to be resolved, and which have late-bound vars which opted them out of being replaced with a fresh inference variable in the first place. We rely on existing normalization that is speckled through typeck and confirmation (e.g. [here](https://github.com/rust-lang/rust/blob/master/compiler/rustc_trait_selection/src/traits/select/mod.rs#L2339)) to uphold this invariant, which means we can skip a large portion of the normalization calls that we saw in #90887.

As seen in the (really messy) initial PR I put up for a perf run, it [seems to have improved performance](https://github.com/rust-lang/rust/pull/94042#issuecomment-1041303420).

----

Reasoning about why these two conditions together are sufficient: 
1. If we see a projection during the fulfillment loop that has inference but no late-bound variables, we probably are missing a normalization call somewhere else, since that projection should've been replaced with an inference variable when we got the type from HIR. This means we should track down that missing normalization call to somewhere in typeck or confirmation.
2. If we see a projection with escaping late-bound variables (but no inference variables), then we probably don't have a solution to that projection variable in the first place, since we should have been able to normalize it (since we have all the information we can have about the type).

This probably needs more discussion, but I'm putting this up for initial review, and we can perhaps discuss it in the GATs meeting.

r? @nikomatsakis 
cc @jackh726 

Fixes #90729
Fixes #93341
Fixes #93342
Fixes #94160