### PR TITLE
Docs: Remove unnecessary -Zunstable-flags in docs

### DIFF
--- a/src/doc/rustc/src/instrument-coverage.md
+++ b/src/doc/rustc/src/instrument-coverage.md
@@ -21,7 +21,7 @@ When running a coverage-instrumented program, the counter values are written to 
 [`llvm.instrprof.increment`]: https://llvm.org/docs/LangRef.html#llvm-instrprof-increment-intrinsic
 [llvm code coverage mapping format]: https://llvm.org/docs/CoverageMappingFormat.html
 
-> **Note**: `-C instrument-coverage` also automatically enables `-C symbol-mangling-version=v0` (tracking issue [#60705]). The `v0` symbol mangler is strongly recommended. The `v0` demangler can be overridden by explicitly adding `-Z unstable-options -C symbol-mangling-version=legacy`.
+> **Note**: `-C instrument-coverage` also automatically enables `-C symbol-mangling-version=v0` (tracking issue [#60705]). The `v0` symbol mangler is strongly recommended. The `v0` demangler can be overridden by explicitly adding `-C symbol-mangling-version=legacy`.
 
 [#60705]: https://github.com/rust-lang/rust/issues/60705
 


### PR DESCRIPTION
PR #90132 stabilized instrument-coverage, but missed removing an occurance of -Zunstable-flags when changing -Z to -C.