### PR TITLE
Suggest a float literal when dividing a floating-point type by `{integer}`

### DIFF
--- a/compiler/rustc_middle/src/traits/mod.rs
+++ b/compiler/rustc_middle/src/traits/mod.rs
@@ -368,6 +368,11 @@ pub enum ObligationCauseCode<'tcx> {
 
     /// From `match_impl`. The cause for us having to match an impl, and the DefId we are matching against.
     MatchImpl(ObligationCause<'tcx>, DefId),
+
+    BinOp {
+        rhs_span: Option<Span>,
+        is_lit: bool,
+    },
 }
 
 /// The 'location' at which we try to perform HIR-based wf checking.

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
@@ -501,6 +501,7 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                             err.span_label(enclosing_scope_span, s.as_str());
                         }
 
+                        self.suggest_floating_point_literal(&obligation, &mut err, &trait_ref);
                         self.suggest_dereferences(&obligation, &mut err, trait_predicate);
                         self.suggest_fn_call(&obligation, &mut err, trait_predicate);
                         self.suggest_remove_reference(&obligation, &mut err, trait_predicate);

--- a/compiler/rustc_typeck/src/check/fn_ctxt/_impl.rs
+++ b/compiler/rustc_typeck/src/check/fn_ctxt/_impl.rs
@@ -438,6 +438,30 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         )
     }
 
+    pub(in super::super) fn normalize_op_associated_types_in_as_infer_ok<T>(
+        &self,
+        span: Span,
+        value: T,
+        opt_input_expr: Option<&hir::Expr<'_>>,
+    ) -> InferOk<'tcx, T>
+    where
+        T: TypeFoldable<'tcx>,
+    {
+        self.inh.partially_normalize_associated_types_in(
+            ObligationCause::new(
+                span,
+                self.body_id,
+                traits::BinOp {
+                    rhs_span: opt_input_expr.map(|expr| expr.span),
+                    is_lit: opt_input_expr
+                        .map_or(false, |expr| matches!(expr.kind, ExprKind::Lit(_))),
+                },
+            ),
+            self.param_env,
+            value,
+        )
+    }
+
     pub fn require_type_meets(
         &self,
         ty: Ty<'tcx>,

--- a/src/test/ui/issues/issue-24352.stderr
+++ b/src/test/ui/issues/issue-24352.stderr
@@ -5,6 +5,10 @@ LL |     1.0f64 - 1
    |            ^ no implementation for `f64 - {integer}`
    |
    = help: the trait `Sub<{integer}>` is not implemented for `f64`
+help: consider using a floating-point literal by writing it with `.0`
+   |
+LL |     1.0f64 - 1.0
+   |               ++
 
 error: aborting due to previous error
 

--- a/src/test/ui/numbers-arithmetic/not-suggest-float-literal.rs
+++ b/src/test/ui/numbers-arithmetic/not-suggest-float-literal.rs
@@ -1,0 +1,53 @@
+fn add_float_to_integer(x: u8) -> f32 {
+    x + 100.0 //~ ERROR cannot add `{float}` to `u8`
+}
+
+fn add_str_to_float(x: f64) -> f64 {
+    x + "foo" //~ ERROR cannot add `&str` to `f64`
+}
+
+fn add_lvar_to_float(x: f64) -> f64 {
+    let y = 3;
+    x + y //~ ERROR cannot add `{integer}` to `f64`
+}
+
+fn subtract_float_from_integer(x: u8) -> f32 {
+    x - 100.0 //~ ERROR cannot subtract `{float}` from `u8`
+}
+
+fn subtract_str_from_f64(x: f64) -> f64 {
+    x - "foo" //~ ERROR cannot subtract `&str` from `f64`
+}
+
+fn subtract_lvar_from_f64(x: f64) -> f64 {
+    let y = 3;
+    x - y //~ ERROR cannot subtract `{integer}` from `f64`
+}
+
+fn multiply_integer_by_float(x: u8) -> f32 {
+    x * 100.0 //~ ERROR cannot multiply `u8` by `{float}`
+}
+
+fn multiply_f64_by_str(x: f64) -> f64 {
+    x * "foo" //~ ERROR cannot multiply `f64` by `&str`
+}
+
+fn multiply_f64_by_lvar(x: f64) -> f64 {
+    let y = 3;
+    x * y //~ ERROR cannot multiply `f64` by `{integer}`
+}
+
+fn divide_integer_by_float(x: u8) -> u8 {
+    x / 100.0 //~ ERROR cannot divide `u8` by `{float}`
+}
+
+fn divide_f64_by_str(x: f64) -> f64 {
+    x / "foo" //~ ERROR cannot divide `f64` by `&str`
+}
+
+fn divide_f64_by_lvar(x: f64) -> f64 {
+    let y = 3;
+    x / y //~ ERROR cannot divide `f64` by `{integer}`
+}
+
+fn main() {}

--- a/src/test/ui/numbers-arithmetic/not-suggest-float-literal.stderr
+++ b/src/test/ui/numbers-arithmetic/not-suggest-float-literal.stderr
@@ -1,0 +1,99 @@
+error[E0277]: cannot add `{float}` to `u8`
+  --> $DIR/not-suggest-float-literal.rs:2:7
+   |
+LL |     x + 100.0
+   |       ^ no implementation for `u8 + {float}`
+   |
+   = help: the trait `Add<{float}>` is not implemented for `u8`
+
+error[E0277]: cannot add `&str` to `f64`
+  --> $DIR/not-suggest-float-literal.rs:6:7
+   |
+LL |     x + "foo"
+   |       ^ no implementation for `f64 + &str`
+   |
+   = help: the trait `Add<&str>` is not implemented for `f64`
+
+error[E0277]: cannot add `{integer}` to `f64`
+  --> $DIR/not-suggest-float-literal.rs:11:7
+   |
+LL |     x + y
+   |       ^ no implementation for `f64 + {integer}`
+   |
+   = help: the trait `Add<{integer}>` is not implemented for `f64`
+
+error[E0277]: cannot subtract `{float}` from `u8`
+  --> $DIR/not-suggest-float-literal.rs:15:7
+   |
+LL |     x - 100.0
+   |       ^ no implementation for `u8 - {float}`
+   |
+   = help: the trait `Sub<{float}>` is not implemented for `u8`
+
+error[E0277]: cannot subtract `&str` from `f64`
+  --> $DIR/not-suggest-float-literal.rs:19:7
+   |
+LL |     x - "foo"
+   |       ^ no implementation for `f64 - &str`
+   |
+   = help: the trait `Sub<&str>` is not implemented for `f64`
+
+error[E0277]: cannot subtract `{integer}` from `f64`
+  --> $DIR/not-suggest-float-literal.rs:24:7
+   |
+LL |     x - y
+   |       ^ no implementation for `f64 - {integer}`
+   |
+   = help: the trait `Sub<{integer}>` is not implemented for `f64`
+
+error[E0277]: cannot multiply `u8` by `{float}`
+  --> $DIR/not-suggest-float-literal.rs:28:7
+   |
+LL |     x * 100.0
+   |       ^ no implementation for `u8 * {float}`
+   |
+   = help: the trait `Mul<{float}>` is not implemented for `u8`
+
+error[E0277]: cannot multiply `f64` by `&str`
+  --> $DIR/not-suggest-float-literal.rs:32:7
+   |
+LL |     x * "foo"
+   |       ^ no implementation for `f64 * &str`
+   |
+   = help: the trait `Mul<&str>` is not implemented for `f64`
+
+error[E0277]: cannot multiply `f64` by `{integer}`
+  --> $DIR/not-suggest-float-literal.rs:37:7
+   |
+LL |     x * y
+   |       ^ no implementation for `f64 * {integer}`
+   |
+   = help: the trait `Mul<{integer}>` is not implemented for `f64`
+
+error[E0277]: cannot divide `u8` by `{float}`
+  --> $DIR/not-suggest-float-literal.rs:41:7
+   |
+LL |     x / 100.0
+   |       ^ no implementation for `u8 / {float}`
+   |
+   = help: the trait `Div<{float}>` is not implemented for `u8`
+
+error[E0277]: cannot divide `f64` by `&str`
+  --> $DIR/not-suggest-float-literal.rs:45:7
+   |
+LL |     x / "foo"
+   |       ^ no implementation for `f64 / &str`
+   |
+   = help: the trait `Div<&str>` is not implemented for `f64`
+
+error[E0277]: cannot divide `f64` by `{integer}`
+  --> $DIR/not-suggest-float-literal.rs:50:7
+   |
+LL |     x / y
+   |       ^ no implementation for `f64 / {integer}`
+   |
+   = help: the trait `Div<{integer}>` is not implemented for `f64`
+
+error: aborting due to 12 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/numbers-arithmetic/suggest-float-literal.fixed
+++ b/src/test/ui/numbers-arithmetic/suggest-float-literal.fixed
@@ -1,0 +1,37 @@
+// run-rustfix
+
+#![allow(dead_code)]
+
+fn add_integer_to_f32(x: f32) -> f32 {
+    x + 100.0 //~ ERROR cannot add `{integer}` to `f32`
+}
+
+fn add_integer_to_f64(x: f64) -> f64 {
+    x + 100.0 //~ ERROR cannot add `{integer}` to `f64`
+}
+
+fn subtract_integer_from_f32(x: f32) -> f32 {
+    x - 100.0 //~ ERROR cannot subtract `{integer}` from `f32`
+}
+
+fn subtract_integer_from_f64(x: f64) -> f64 {
+    x - 100.0 //~ ERROR cannot subtract `{integer}` from `f64`
+}
+
+fn multiply_f32_by_integer(x: f32) -> f32 {
+    x * 100.0 //~ ERROR cannot multiply `f32` by `{integer}`
+}
+
+fn multiply_f64_by_integer(x: f64) -> f64 {
+    x * 100.0 //~ ERROR cannot multiply `f64` by `{integer}`
+}
+
+fn divide_f32_by_integer(x: f32) -> f32 {
+    x / 100.0 //~ ERROR cannot divide `f32` by `{integer}`
+}
+
+fn divide_f64_by_integer(x: f64) -> f64 {
+    x / 100.0 //~ ERROR cannot divide `f64` by `{integer}`
+}
+
+fn main() {}

--- a/src/test/ui/numbers-arithmetic/suggest-float-literal.rs
+++ b/src/test/ui/numbers-arithmetic/suggest-float-literal.rs
@@ -1,0 +1,37 @@
+// run-rustfix
+
+#![allow(dead_code)]
+
+fn add_integer_to_f32(x: f32) -> f32 {
+    x + 100 //~ ERROR cannot add `{integer}` to `f32`
+}
+
+fn add_integer_to_f64(x: f64) -> f64 {
+    x + 100 //~ ERROR cannot add `{integer}` to `f64`
+}
+
+fn subtract_integer_from_f32(x: f32) -> f32 {
+    x - 100 //~ ERROR cannot subtract `{integer}` from `f32`
+}
+
+fn subtract_integer_from_f64(x: f64) -> f64 {
+    x - 100 //~ ERROR cannot subtract `{integer}` from `f64`
+}
+
+fn multiply_f32_by_integer(x: f32) -> f32 {
+    x * 100 //~ ERROR cannot multiply `f32` by `{integer}`
+}
+
+fn multiply_f64_by_integer(x: f64) -> f64 {
+    x * 100 //~ ERROR cannot multiply `f64` by `{integer}`
+}
+
+fn divide_f32_by_integer(x: f32) -> f32 {
+    x / 100 //~ ERROR cannot divide `f32` by `{integer}`
+}
+
+fn divide_f64_by_integer(x: f64) -> f64 {
+    x / 100 //~ ERROR cannot divide `f64` by `{integer}`
+}
+
+fn main() {}

--- a/src/test/ui/numbers-arithmetic/suggest-float-literal.stderr
+++ b/src/test/ui/numbers-arithmetic/suggest-float-literal.stderr
@@ -1,0 +1,99 @@
+error[E0277]: cannot add `{integer}` to `f32`
+  --> $DIR/suggest-float-literal.rs:6:7
+   |
+LL |     x + 100
+   |       ^ no implementation for `f32 + {integer}`
+   |
+   = help: the trait `Add<{integer}>` is not implemented for `f32`
+help: consider using a floating-point literal by writing it with `.0`
+   |
+LL |     x + 100.0
+   |            ++
+
+error[E0277]: cannot add `{integer}` to `f64`
+  --> $DIR/suggest-float-literal.rs:10:7
+   |
+LL |     x + 100
+   |       ^ no implementation for `f64 + {integer}`
+   |
+   = help: the trait `Add<{integer}>` is not implemented for `f64`
+help: consider using a floating-point literal by writing it with `.0`
+   |
+LL |     x + 100.0
+   |            ++
+
+error[E0277]: cannot subtract `{integer}` from `f32`
+  --> $DIR/suggest-float-literal.rs:14:7
+   |
+LL |     x - 100
+   |       ^ no implementation for `f32 - {integer}`
+   |
+   = help: the trait `Sub<{integer}>` is not implemented for `f32`
+help: consider using a floating-point literal by writing it with `.0`
+   |
+LL |     x - 100.0
+   |            ++
+
+error[E0277]: cannot subtract `{integer}` from `f64`
+  --> $DIR/suggest-float-literal.rs:18:7
+   |
+LL |     x - 100
+   |       ^ no implementation for `f64 - {integer}`
+   |
+   = help: the trait `Sub<{integer}>` is not implemented for `f64`
+help: consider using a floating-point literal by writing it with `.0`
+   |
+LL |     x - 100.0
+   |            ++
+
+error[E0277]: cannot multiply `f32` by `{integer}`
+  --> $DIR/suggest-float-literal.rs:22:7
+   |
+LL |     x * 100
+   |       ^ no implementation for `f32 * {integer}`
+   |
+   = help: the trait `Mul<{integer}>` is not implemented for `f32`
+help: consider using a floating-point literal by writing it with `.0`
+   |
+LL |     x * 100.0
+   |            ++
+
+error[E0277]: cannot multiply `f64` by `{integer}`
+  --> $DIR/suggest-float-literal.rs:26:7
+   |
+LL |     x * 100
+   |       ^ no implementation for `f64 * {integer}`
+   |
+   = help: the trait `Mul<{integer}>` is not implemented for `f64`
+help: consider using a floating-point literal by writing it with `.0`
+   |
+LL |     x * 100.0
+   |            ++
+
+error[E0277]: cannot divide `f32` by `{integer}`
+  --> $DIR/suggest-float-literal.rs:30:7
+   |
+LL |     x / 100
+   |       ^ no implementation for `f32 / {integer}`
+   |
+   = help: the trait `Div<{integer}>` is not implemented for `f32`
+help: consider using a floating-point literal by writing it with `.0`
+   |
+LL |     x / 100.0
+   |            ++
+
+error[E0277]: cannot divide `f64` by `{integer}`
+  --> $DIR/suggest-float-literal.rs:34:7
+   |
+LL |     x / 100
+   |       ^ no implementation for `f64 / {integer}`
+   |
+   = help: the trait `Div<{integer}>` is not implemented for `f64`
+help: consider using a floating-point literal by writing it with `.0`
+   |
+LL |     x / 100.0
+   |            ++
+
+error: aborting due to 8 previous errors
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
closes #93829