### PR TITLE
Fix rustdoc const computed value

### DIFF
--- a/compiler/rustc_middle/src/mir/interpret/value.rs
+++ b/compiler/rustc_middle/src/mir/interpret/value.rs
@@ -456,6 +456,11 @@ impl<'tcx, Tag: Provenance> Scalar<Tag> {
         // Going through `u64` to check size and truncation.
         Ok(Double::from_bits(self.to_u64()?.into()))
     }
+
+    // FIXME: Replace current `impl Display for Scalar` with `impl LowerHex`.
+    pub fn rustdoc_display(&self) -> String {
+        if let Scalar::Int(int) = self { int.to_string() } else { self.to_string() }
+    }
 }
 
 #[derive(Clone, Copy, Eq, PartialEq, TyEncodable, TyDecodable, HashStable, Hash)]

--- a/compiler/rustc_middle/src/ty/consts/int.rs
+++ b/compiler/rustc_middle/src/ty/consts/int.rs
@@ -374,3 +374,10 @@ impl fmt::UpperHex for ScalarInt {
         write!(f, "{:01$X}", { self.data }, self.size as usize * 2)
     }
 }
+
+impl fmt::Display for ScalarInt {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.check_data();
+        write!(f, "{}", { self.data })
+    }
+}

--- a/src/librustdoc/clean/utils.rs
+++ b/src/librustdoc/clean/utils.rs
@@ -302,7 +302,11 @@ fn print_const_with_custom_print_scalar(tcx: TyCtxt<'_>, ct: &ty::Const<'_>) -> 
     // For all other types, fallback to the original `pretty_print_const`.
     match (ct.val, ct.ty.kind()) {
         (ty::ConstKind::Value(ConstValue::Scalar(int)), ty::Uint(ui)) => {
-            format!("{}{}", format_integer_with_underscore_sep(&int.to_string()), ui.name_str())
+            format!(
+                "{}{}",
+                format_integer_with_underscore_sep(&int.rustdoc_display()),
+                ui.name_str()
+            )
         }
         (ty::ConstKind::Value(ConstValue::Scalar(int)), ty::Int(i)) => {
             let ty = tcx.lift(ct.ty).unwrap();

--- a/src/test/rustdoc/const-value-display.rs
+++ b/src/test/rustdoc/const-value-display.rs
@@ -1,0 +1,9 @@
+#![crate_name = "foo"]
+
+// @has 'foo/constant.HOUR_IN_SECONDS.html'
+// @has - '//*[@class="docblock item-decl"]//code' 'pub const HOUR_IN_SECONDS: u64 = 60 * 60; // 3_600u64'
+pub const HOUR_IN_SECONDS: u64 = 60 * 60;
+
+// @has 'foo/constant.NEGATIVE.html'
+// @has - '//*[@class="docblock item-decl"]//code' 'pub const NEGATIVE: i64 = -60 * 60; // -3_600i64'
+pub const NEGATIVE: i64 = -60 * 60;


### PR DESCRIPTION
Fixes #85088.

It looks like this now (instead of hexadecimal):

![Screenshot from 2022-02-17 17-55-39](https://user-images.githubusercontent.com/3050060/154532115-0f9861a0-406f-4c9c-957f-32bedd8aca7d.png)

r? @oli-obk 
