### PR TITLE
DO NOT MERGE: Try using stacker fast path optimization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2847,9 +2847,8 @@ dependencies = [
 
 [[package]]
 name = "psm"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd136ff4382c4753fc061cb9e4712ab2af263376b95bbd5bd8cd50c020b78e69"
+version = "0.1.17"
+source = "git+https://github.com/hkratz/stacker.git?rev=f2b4078e0c32adffeed3c62ae7e152dbd18fd32b#f2b4078e0c32adffeed3c62ae7e152dbd18fd32b"
 dependencies = [
  "cc",
 ]
@@ -4760,8 +4759,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 [[package]]
 name = "stacker"
 version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90939d5171a4420b3ff5fbc8954d641e7377335454c259dcb80786f3f21dc9b4"
+source = "git+https://github.com/hkratz/stacker.git?rev=f2b4078e0c32adffeed3c62ae7e152dbd18fd32b#f2b4078e0c32adffeed3c62ae7e152dbd18fd32b"
 dependencies = [
  "cc",
  "cfg-if 1.0.0",

--- a/compiler/rustc_data_structures/Cargo.toml
+++ b/compiler/rustc_data_structures/Cargo.toml
@@ -25,7 +25,7 @@ rustc_index = { path = "../rustc_index", package = "rustc_index" }
 bitflags = "1.2.1"
 measureme = "10.0.0"
 libc = "0.2"
-stacker = "0.1.14"
+stacker = { git = "https://github.com/hkratz/stacker.git", rev = "f2b4078e0c32adffeed3c62ae7e152dbd18fd32b", features = ["fast_path_optimization"] }
 tempfile = "3.2"
 
 [dependencies.parking_lot]

--- a/compiler/rustc_data_structures/src/stack.rs
+++ b/compiler/rustc_data_structures/src/stack.rs
@@ -12,6 +12,7 @@ const STACK_PER_RECURSION: usize = 1 * 1024 * 1024; // 1MB
 /// from this.
 ///
 /// Should not be sprinkled around carelessly, as it causes a little bit of overhead.
+#[inline]
 pub fn ensure_sufficient_stack<R>(f: impl FnOnce() -> R) -> R {
     stacker::maybe_grow(RED_ZONE, STACK_PER_RECURSION, f)
 }

--- a/src/tools/tidy/src/extdeps.rs
+++ b/src/tools/tidy/src/extdeps.rs
@@ -4,7 +4,10 @@ use std::fs;
 use std::path::Path;
 
 /// List of allowed sources for packages.
-const ALLOWED_SOURCES: &[&str] = &["\"registry+https://github.com/rust-lang/crates.io-index\""];
+const ALLOWED_SOURCES: &[&str] = &[
+    "\"registry+https://github.com/rust-lang/crates.io-index\"",
+    "\"git+https://github.com/hkratz/stacker.git?rev=f2b4078e0c32adffeed3c62ae7e152dbd18fd32b#f2b4078e0c32adffeed3c62ae7e152dbd18fd32b\"",
+];
 
 /// Checks for external package sources. `root` is the path to the directory that contains the
 /// workspace `Cargo.toml`.


### PR DESCRIPTION
Some stacker optimizations in a private branch (see https://github.com/rust-lang/stacker/compare/master...hkratz:optimize-fast-path) that I want to try with a perf run to see if that is worth pursuing. Assembly and local perf run look promising.

Also includes accepted, but not yet merged #93934.

r? @ghost
@rustbot label S-waiting-on-author