### PR TITLE
Upgrade libc to fix `Instant + Duration` producing wrong result on aarch64-apple-darwin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1972,9 +1972,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.116"
+version = "0.2.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "565dbd88872dbe4cc8a46e527f26483c1d1f7afa6b884a3bd6cd893d4f98da74"
+checksum = "1bf2e165bb3457c8e098ea76f3e3bc9db55f87aa90d52d0e6be741470916aaa4"
 dependencies = [
  "rustc-std-workspace-core",
 ]

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -15,7 +15,7 @@ cfg-if = { version = "0.1.8", features = ['rustc-dep-of-std'] }
 panic_unwind = { path = "../panic_unwind", optional = true }
 panic_abort = { path = "../panic_abort" }
 core = { path = "../core" }
-libc = { version = "0.2.116", default-features = false, features = ['rustc-dep-of-std'] }
+libc = { version = "0.2.119", default-features = false, features = ['rustc-dep-of-std'] }
 compiler_builtins = { version = "0.1.69" }
 profiler_builtins = { path = "../profiler_builtins", optional = true }
 unwind = { path = "../unwind" }

--- a/library/std/src/sys/unix/time.rs
+++ b/library/std/src/sys/unix/time.rs
@@ -288,7 +288,7 @@ mod inner {
             #[cfg(target_os = "macos")]
             const clock_id: clock_t = 8;
             #[cfg(not(target_os = "macos"))]
-            const clock_id: clock_t  = libc::CLOCK_MONOTONIC;
+            const clock_id: clock_t = libc::CLOCK_MONOTONIC;
             Instant { t: now(clock_id) }
         }
 

--- a/library/std/src/sys/unix/time.rs
+++ b/library/std/src/sys/unix/time.rs
@@ -151,7 +151,7 @@ mod inner {
             extern "C" {
                 fn clock_gettime_nsec_np(clock_type: u32) -> u64;
             }
-            Instant { t: unsafe { clock_gettime_nsec_np(8) } }
+            Instant { t: unsafe { clock_gettime_nsec_np(4) } }
         }
 
         pub fn checked_sub_instant(&self, other: &Instant) -> Option<Duration> {

--- a/library/std/src/sys/unix/time.rs
+++ b/library/std/src/sys/unix/time.rs
@@ -146,12 +146,14 @@ mod inner {
     type mach_timebase_info_t = *mut mach_timebase_info;
     type kern_return_t = libc::c_int;
 
+    pub type clockid_t = libc::clockid_t;
+
     impl Instant {
         pub fn now() -> Instant {
             extern "C" {
-                fn clock_gettime_nsec_np(clock_type: u32) -> u64;
+                fn clock_gettime_nsec_np(clock_id: clockid_t) -> u64;
             }
-            Instant { t: unsafe { clock_gettime_nsec_np(4) } }
+            Instant { t: unsafe { clock_gettime_nsec_np(8) } }
         }
 
         pub fn checked_sub_instant(&self, other: &Instant) -> Option<Duration> {

--- a/library/std/src/sys/unix/time.rs
+++ b/library/std/src/sys/unix/time.rs
@@ -286,7 +286,7 @@ mod inner {
     impl Instant {
         pub fn now() -> Instant {
             #[cfg(target_os = "macos")]
-            const clock_id: clock_t = 8;
+            const clock_id: clock_t = libc::CLOCK_UPTIME_RAW;
             #[cfg(not(target_os = "macos"))]
             const clock_id: clock_t = libc::CLOCK_MONOTONIC;
             Instant { t: now(clock_id) }

--- a/library/std/src/sys/unix/time.rs
+++ b/library/std/src/sys/unix/time.rs
@@ -149,9 +149,11 @@ mod inner {
     impl Instant {
         pub fn now() -> Instant {
             extern "C" {
-                fn mach_absolute_time() -> u64;
+                //fn mach_absolute_time() -> u64;
+                fn clock_gettime_nsec_np(clock_type: i64) -> u64;
             }
-            Instant { t: unsafe { mach_absolute_time() } }
+            Instant { t: unsafe { clock_gettime_nsec_np(4) } }
+            //Instant { t: unsafe { mach_absolute_time() } }
         }
 
         pub fn checked_sub_instant(&self, other: &Instant) -> Option<Duration> {

--- a/library/std/src/sys/unix/time.rs
+++ b/library/std/src/sys/unix/time.rs
@@ -149,11 +149,9 @@ mod inner {
     impl Instant {
         pub fn now() -> Instant {
             extern "C" {
-                //fn mach_absolute_time() -> u64;
-                fn clock_gettime_nsec_np(clock_type: i64) -> u64;
+                fn clock_gettime_nsec_np(clock_type: u32) -> u64;
             }
-            Instant { t: unsafe { clock_gettime_nsec_np(4) } }
-            //Instant { t: unsafe { mach_absolute_time() } }
+            Instant { t: unsafe { clock_gettime_nsec_np(8) } }
         }
 
         pub fn checked_sub_instant(&self, other: &Instant) -> Option<Duration> {

--- a/library/std/src/time/tests.rs
+++ b/library/std/src/time/tests.rs
@@ -14,7 +14,7 @@ macro_rules! assert_almost_eq {
 
 #[test]
 #[cfg(all(target_arch = "aarch64", target_os = "macos"))]
-fn wtf() {
+fn macos_resolution_regression() {
     let t0 = Instant::now();
     let t1 = t0 + Duration::from_nanos(50);
     let d = t1 - t0;

--- a/library/std/src/time/tests.rs
+++ b/library/std/src/time/tests.rs
@@ -13,7 +13,6 @@ macro_rules! assert_almost_eq {
 }
 
 #[test]
-#[cfg(all(target_arch = "aarch64", target_os = "macos"))]
 fn macos_resolution_regression() {
     let t0 = Instant::now();
     let t1 = t0 + Duration::from_nanos(50);

--- a/library/std/src/time/tests.rs
+++ b/library/std/src/time/tests.rs
@@ -18,7 +18,6 @@ fn macos_resolution_regression() {
     let t0 = Instant::now();
     let t1 = t0 + Duration::from_nanos(50);
     let d = t1 - t0;
-    dbg!(t0, t1, d);
     assert_eq!(t0 + d, t1);
 }
 

--- a/library/std/src/time/tests.rs
+++ b/library/std/src/time/tests.rs
@@ -13,6 +13,16 @@ macro_rules! assert_almost_eq {
 }
 
 #[test]
+#[cfg(all(target_arch = "aarch64", target_os = "macos"))]
+fn wtf() {
+    let t0 = Instant::now();
+    let t1 = t0 + Duration::from_nanos(50);
+    let d = t1 - t0;
+    dbg!(t0, t1, d);
+    assert_eq!(t0 + d, t1);
+}
+
+#[test]
 fn instant_monotonic() {
     let a = Instant::now();
     loop {


### PR DESCRIPTION
This is a regression test and a fixes https://github.com/rust-lang/rust/issues/91417 
It also bumps the libc version to 0.2.119 because it requires the constant introduced here: https://github.com/rust-lang/libc/pull/2689 