### PR TITLE
At opt-level=0, don't apply !nonnull or !range metadata to loads

### DIFF
--- a/compiler/rustc_codegen_llvm/src/builder.rs
+++ b/compiler/rustc_codegen_llvm/src/builder.rs
@@ -19,6 +19,7 @@ use rustc_middle::ty::layout::{
     FnAbiError, FnAbiOfHelpers, FnAbiRequest, LayoutError, LayoutOfHelpers, TyAndLayout,
 };
 use rustc_middle::ty::{self, Ty, TyCtxt};
+use rustc_session::config;
 use rustc_span::Span;
 use rustc_target::abi::{self, call::FnAbi, Align, Size, WrappingRange};
 use rustc_target::spec::{HasTargetSpec, Target};
@@ -578,6 +579,10 @@ impl<'a, 'll, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'll, 'tcx> {
             // optimization.
             return;
         }
+        if self.sess().opts.optimize == config::OptLevel::No {
+            // range metadata is only useful when optimizing
+            return;
+        }
 
         unsafe {
             let llty = self.cx.val_ty(load);
@@ -595,6 +600,11 @@ impl<'a, 'll, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'll, 'tcx> {
     }
 
     fn nonnull_metadata(&mut self, load: &'ll Value) {
+        if self.sess().opts.optimize == config::OptLevel::No {
+            // nonnull metadata is only useful when optimizing
+            return;
+        }
+
         unsafe {
             llvm::LLVMSetMetadata(
                 load,

--- a/src/test/codegen/loads-noopt.rs
+++ b/src/test/codegen/loads-noopt.rs
@@ -1,0 +1,45 @@
+// compile-flags: -C opt-level=0 -C no-prepopulate-passes
+
+// This test checks that load instructions in opt-level=0 builds,
+// while lacking metadata used for optimization, still get `align` attributes.
+
+#![crate_type = "lib"]
+
+pub struct Bytes {
+    a: u8,
+    b: u8,
+    c: u8,
+    d: u8,
+}
+
+#[derive(Copy, Clone)]
+#[repr(align(4))]
+pub struct Align4(i16);
+
+// CHECK-LABEL: @load_bool
+#[no_mangle]
+pub fn load_bool(x: &bool) -> bool {
+// CHECK: load i8, i8* %x, align 1
+    *x
+}
+
+// CHECK-LABEL: small_array_alignment
+#[no_mangle]
+pub fn small_array_alignment(x: [i8; 4]) -> [i8; 4] {
+// CHECK: load i32, i32* %{{.*}}, align 1
+    x
+}
+
+// CHECK-LABEL: small_struct_alignment
+#[no_mangle]
+pub fn small_struct_alignment(x: Bytes) -> Bytes {
+// CHECK: load i32, i32* %{{.*}}, align 1
+    x
+}
+
+// CHECK-LABEL: @load_higher_alignment
+#[no_mangle]
+pub fn load_higher_alignment(x: &Align4) -> Align4 {
+// CHECK: load i32, i32* %{{.*}}, align 4
+    *x
+}


### PR DESCRIPTION
This metadata is only used for optimization, so it shouldn't have any significant effect with the minimal LLVM pipeline at opt-level=0.

This may provide a small perf improvement for debug builds. (needs a perf run to confirm)