### PR TITLE
Relax `Allocator` bounds into pin-safe trait

### DIFF
--- a/library/alloc/src/alloc.rs
+++ b/library/alloc/src/alloc.rs
@@ -44,6 +44,8 @@ extern "Rust" {
 /// to the allocator registered with the `#[global_allocator]` attribute
 /// if there is one, or the `std` crate’s default.
 ///
+/// This type is always guaranteed to implement [`PinSafeAllocator`].
+///
 /// Note: while this type is unstable, the functionality it provides can be
 /// accessed through the [free functions in `alloc`](self#functions).
 #[unstable(feature = "allocator_api", issue = "32838")]
@@ -313,6 +315,11 @@ unsafe impl Allocator for Global {
         }
     }
 }
+
+// SAFETY: memory blocks allocated by `Global` are not invalidated when `Global` is dropped.
+#[unstable(feature = "allocator_api", issue = "32838")]
+#[cfg(not(test))]
+unsafe impl PinSafeAllocator for Global {}
 
 /// The allocator for unique pointers.
 #[cfg(all(not(no_global_oom_handling), not(test)))]

--- a/library/alloc/src/boxed.rs
+++ b/library/alloc/src/boxed.rs
@@ -575,7 +575,7 @@ impl<T, A: Allocator> Box<T, A> {
     #[inline(always)]
     pub const fn pin_in(x: T, alloc: A) -> Pin<Self>
     where
-        A: 'static + ~const Allocator + ~const Destruct,
+        A: ~const Allocator + ~const PinSafeAllocator + ~const Destruct,
     {
         Self::into_pin(Self::new_in(x, alloc))
     }

--- a/library/alloc/src/collections/btree/map/tests.rs
+++ b/library/alloc/src/collections/btree/map/tests.rs
@@ -116,7 +116,14 @@ impl<K, V> BTreeMap<K, V> {
     {
         let iter = mem::take(self).into_iter();
         if !iter.is_empty() {
-            self.root.insert(Root::new(*self.alloc)).bulk_push(iter, &mut self.length, *self.alloc);
+            // SAFETY: `self.alloc` is the allocator for this `BTreeMap`.
+            unsafe {
+                self.root.insert(Root::new(*self.alloc)).bulk_push(
+                    iter,
+                    &mut self.length,
+                    *self.alloc,
+                );
+            }
         }
     }
 }

--- a/library/alloc/src/collections/btree/node/tests.rs
+++ b/library/alloc/src/collections/btree/node/tests.rs
@@ -68,10 +68,13 @@ fn test_splitpoint() {
 
 #[test]
 fn test_partial_eq() {
-    let mut root1 = NodeRef::new_leaf(Global);
+    // SAFETY: `Global` is the allocator for the `BTreeMap` we're testing.
+    let mut root1 = unsafe { NodeRef::new_leaf(Global) };
     root1.borrow_mut().push(1, ());
-    let mut root1 = NodeRef::new_internal(root1.forget_type(), Global).forget_type();
-    let root2 = Root::new(Global);
+    // SAFETY: `Global` is the allocator for the `BTreeMap` we're testing.
+    let mut root1 = unsafe { NodeRef::new_internal(root1.forget_type(), Global).forget_type() };
+    // SAFETY: `Global` is the allocator for the `BTreeMap` we're testing.
+    let root2 = unsafe { Root::new(Global) };
     root1.reborrow().assert_back_pointers();
     root2.reborrow().assert_back_pointers();
 

--- a/library/alloc/src/collections/btree/split.rs
+++ b/library/alloc/src/collections/btree/split.rs
@@ -63,10 +63,20 @@ impl<K, V> Root<K, V> {
     }
 
     /// Creates a tree consisting of empty nodes.
+    ///
+    /// # Safety
+    ///
+    /// `alloc` must be the allocator for the owning `BTreeMap`.
     fn new_pillar<A: Allocator + Clone>(height: usize, alloc: A) -> Self {
-        let mut root = Root::new(alloc.clone());
+        // SAFETY: The caller has guaranteed that `alloc` is the allocator for the owning
+        // `BTreeMap`.
+        let mut root = unsafe { Root::new(alloc.clone()) };
         for _ in 0..height {
-            root.push_internal_level(alloc.clone());
+            // SAFETY: The caller has guaranteed that `alloc` is the allocator for the owning
+            // `BTreeMap`.
+            unsafe {
+                root.push_internal_level(alloc.clone());
+            }
         }
         root
     }

--- a/library/alloc/src/rc.rs
+++ b/library/alloc/src/rc.rs
@@ -630,6 +630,7 @@ impl<T> Rc<T> {
     #[stable(feature = "pin", since = "1.33.0")]
     #[must_use]
     pub fn pin(value: T) -> Pin<Rc<T>> {
+        // SAFETY: Global is a pin-safe allocator.
         unsafe { Pin::new_unchecked(Rc::new(value)) }
     }
 

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -530,6 +530,7 @@ impl<T> Arc<T> {
     #[stable(feature = "pin", since = "1.33.0")]
     #[must_use]
     pub fn pin(data: T) -> Pin<Arc<T>> {
+        // SAFETY: Global is a pin-safe allocator.
         unsafe { Pin::new_unchecked(Arc::new(data)) }
     }
 
@@ -537,6 +538,7 @@ impl<T> Arc<T> {
     #[unstable(feature = "allocator_api", issue = "32838")]
     #[inline]
     pub fn try_pin(data: T) -> Result<Pin<Arc<T>>, AllocError> {
+        // SAFETY: Global is a pin-safe allocator.
         unsafe { Ok(Pin::new_unchecked(Arc::try_new(data)?)) }
     }
 

--- a/library/alloc/tests/boxed.rs
+++ b/library/alloc/tests/boxed.rs
@@ -1,4 +1,4 @@
-use core::alloc::{AllocError, Allocator, Layout};
+use core::alloc::{AllocError, Allocator, Layout, PinSafeAllocator};
 use core::cell::Cell;
 use core::mem::MaybeUninit;
 use core::ptr::NonNull;
@@ -150,6 +150,9 @@ unsafe impl const Allocator for ConstAllocator {
         self
     }
 }
+
+// SAFETY: Memory allocated by `ConstAllocator` is never invalidated.
+unsafe impl const PinSafeAllocator for ConstAllocator {}
 
 #[test]
 fn const_box() {

--- a/src/test/ui/box/leak-alloc.stderr
+++ b/src/test/ui/box/leak-alloc.stderr
@@ -1,15 +1,28 @@
-error[E0505]: cannot move out of `alloc` because it is borrowed
-  --> $DIR/leak-alloc.rs:26:10
+error[E0597]: `alloc` does not live long enough
+  --> $DIR/leak-alloc.rs:24:33
    |
 LL |     let boxed = Box::new_in(10, alloc.by_ref());
-   |                                 -------------- borrow of `alloc` occurs here
-LL |     let theref = Box::leak(boxed);
+   |                                 ^^^^^^^^^^^^^^
+   |                                 |
+   |                                 borrowed value does not live long enough
+   |                                 argument requires that `alloc` is borrowed for `'static`
+...
+LL | }
+   | - `alloc` dropped here while still borrowed
+
+error[E0505]: cannot move out of `alloc` because it is borrowed
+  --> $DIR/leak-alloc.rs:27:10
+   |
+LL |     let boxed = Box::new_in(10, alloc.by_ref());
+   |                                 --------------
+   |                                 |
+   |                                 borrow of `alloc` occurs here
+   |                                 argument requires that `alloc` is borrowed for `'static`
+...
 LL |     drop(alloc);
    |          ^^^^^ move out of `alloc` occurs here
-LL |
-LL |     use_value(*theref)
-   |               ------- borrow later used here
 
-error: aborting due to previous error
+error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0505`.
+Some errors have detailed explanations: E0505, E0597.
+For more information about an error, try `rustc --explain E0505`.

--- a/src/test/ui/box/leak-alloc.stderr
+++ b/src/test/ui/box/leak-alloc.stderr
@@ -2,10 +2,10 @@ error[E0597]: `alloc` does not live long enough
   --> $DIR/leak-alloc.rs:24:33
    |
 LL |     let boxed = Box::new_in(10, alloc.by_ref());
-   |                                 ^^^^^^^^^^^^^^
-   |                                 |
-   |                                 borrowed value does not live long enough
-   |                                 argument requires that `alloc` is borrowed for `'static`
+   |                 ----------------^^^^^^^^^^^^^^-
+   |                 |               |
+   |                 |               borrowed value does not live long enough
+   |                 argument requires that `alloc` is borrowed for `'static`
 ...
 LL | }
    | - `alloc` dropped here while still borrowed
@@ -14,10 +14,10 @@ error[E0505]: cannot move out of `alloc` because it is borrowed
   --> $DIR/leak-alloc.rs:27:10
    |
 LL |     let boxed = Box::new_in(10, alloc.by_ref());
-   |                                 --------------
-   |                                 |
-   |                                 borrow of `alloc` occurs here
-   |                                 argument requires that `alloc` is borrowed for `'static`
+   |                 -------------------------------
+   |                 |               |
+   |                 |               borrow of `alloc` occurs here
+   |                 argument requires that `alloc` is borrowed for `'static`
 ...
 LL |     drop(alloc);
    |          ^^^^^ move out of `alloc` occurs here

--- a/src/test/ui/box/pin-safe-alloc.rs
+++ b/src/test/ui/box/pin-safe-alloc.rs
@@ -1,6 +1,5 @@
 // run-pass
 #![feature(allocator_api)]
-#![feature(box_into_pin)]
 
 use std::alloc::{AllocError, Allocator, Layout, PinSafeAllocator, System};
 use std::ptr::NonNull;

--- a/src/test/ui/box/pin-unsafe-alloc.rs
+++ b/src/test/ui/box/pin-unsafe-alloc.rs
@@ -1,8 +1,9 @@
 #![feature(allocator_api)]
+#![feature(box_into_pin)]
 
 use std::alloc::{AllocError, Allocator, Layout, System};
 use std::ptr::NonNull;
-
+use std::marker::PhantomPinned;
 use std::boxed::Box;
 
 struct Alloc {}
@@ -17,14 +18,17 @@ unsafe impl Allocator for Alloc {
     }
 }
 
-fn use_value(_: u32) {}
-
 fn main() {
+    struct MyPinned {
+        _value: u32,
+        _pinned: PhantomPinned,
+    }
+
+    let value = MyPinned {
+        _value: 0,
+        _pinned: PhantomPinned,
+    };
     let alloc = Alloc {};
-    let boxed = Box::new_in(10, alloc.by_ref());
-    //~^ ERROR `alloc` does not live long enough
-    let theref = Box::leak(boxed);
-    drop(alloc);
-    //~^ ERROR cannot move out of `alloc` because it is borrowed
-    use_value(*theref)
+    let _ = Box::pin_in(value, alloc);
+    //~^ ERROR the trait bound `Alloc: PinSafeAllocator` is not satisfied
 }

--- a/src/test/ui/box/pin-unsafe-alloc.rs
+++ b/src/test/ui/box/pin-unsafe-alloc.rs
@@ -1,5 +1,4 @@
 #![feature(allocator_api)]
-#![feature(box_into_pin)]
 
 use std::alloc::{AllocError, Allocator, Layout, System};
 use std::ptr::NonNull;

--- a/src/test/ui/box/pin-unsafe-alloc.stderr
+++ b/src/test/ui/box/pin-unsafe-alloc.stderr
@@ -1,5 +1,5 @@
 error[E0277]: the trait bound `Alloc: PinSafeAllocator` is not satisfied
-  --> $DIR/pin-unsafe-alloc.rs:32:32
+  --> $DIR/pin-unsafe-alloc.rs:31:32
    |
 LL |     let _ = Box::pin_in(value, alloc);
    |             -----------        ^^^^^ expected an implementor of trait `PinSafeAllocator`
@@ -9,7 +9,7 @@ LL |     let _ = Box::pin_in(value, alloc);
 note: required by a bound in `Box::<T, A>::pin_in`
   --> $SRC_DIR/alloc/src/boxed.rs:LL:COL
    |
-LL |         A: ~const Allocator + ~const PinSafeAllocator + ~const Drop + ~const Destruct,
+LL |         A: ~const Allocator + ~const PinSafeAllocator + ~const Destruct,
    |                               ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `Box::<T, A>::pin_in`
 help: consider borrowing here
    |

--- a/src/test/ui/box/pin-unsafe-alloc.stderr
+++ b/src/test/ui/box/pin-unsafe-alloc.stderr
@@ -1,0 +1,21 @@
+error[E0277]: the trait bound `Alloc: PinSafeAllocator` is not satisfied
+  --> $DIR/pin-unsafe-alloc.rs:32:32
+   |
+LL |     let _ = Box::pin_in(value, alloc);
+   |             -----------        ^^^^^ expected an implementor of trait `PinSafeAllocator`
+   |             |
+   |             required by a bound introduced by this call
+   |
+note: required by a bound in `Box::<T, A>::pin_in`
+  --> $SRC_DIR/alloc/src/boxed.rs:LL:COL
+   |
+LL |         A: ~const Allocator + ~const PinSafeAllocator + ~const Drop + ~const Destruct,
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `Box::<T, A>::pin_in`
+help: consider borrowing here
+   |
+LL |     let _ = Box::pin_in(value, &alloc);
+   |                                +
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
Because `Allocator` requires that returned memory blocks remain valid
until the instance and all clones are dropped, some types of allocators
cannot fulfill the safety requirements for the trait. This change
relaxes the safety requirements of `Allocator` to blocks remaining valid
until the allocator becomes unreachable and moves the bound into a
separate `PinSafeAllocator` trait.

It also relaxes some overly cautious bounds on the `Unpin` impls for
`Box` since unpinning a box doesn't require any special consideration.