### PR TITLE
Stabilize `array_from_fn`

### DIFF
--- a/library/core/src/array/mod.rs
+++ b/library/core/src/array/mod.rs
@@ -31,14 +31,12 @@ pub use iter::IntoIter;
 /// # Example
 ///
 /// ```rust
-/// #![feature(array_from_fn)]
-///
 /// let array = core::array::from_fn(|i| i);
 /// assert_eq!(array, [0, 1, 2, 3, 4]);
 /// ```
 #[inline]
-#[unstable(feature = "array_from_fn", issue = "89379")]
-pub fn from_fn<F, T, const N: usize>(mut cb: F) -> [T; N]
+#[stable(feature = "array_from_fn", since = "1.63.0")]
+pub fn from_fn<T, const N: usize, F>(mut cb: F) -> [T; N]
 where
     F: FnMut(usize) -> T,
 {
@@ -65,7 +63,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// #![feature(array_from_fn)]
+/// #![feature(array_try_from_fn)]
 ///
 /// let array: Result<[u8; 5], _> = std::array::try_from_fn(|i| i.try_into());
 /// assert_eq!(array, Ok([0, 1, 2, 3, 4]));
@@ -80,8 +78,8 @@ where
 /// assert_eq!(array, None);
 /// ```
 #[inline]
-#[unstable(feature = "array_from_fn", issue = "89379")]
-pub fn try_from_fn<F, R, const N: usize>(cb: F) -> ChangeOutputType<R, [R::Output; N]>
+#[unstable(feature = "array_try_from_fn", issue = "89379")]
+pub fn try_from_fn<R, const N: usize, F>(cb: F) -> ChangeOutputType<R, [R::Output; N]>
 where
     F: FnMut(usize) -> R,
     R: Try,

--- a/library/core/tests/array.rs
+++ b/library/core/tests/array.rs
@@ -388,7 +388,7 @@ fn array_try_from_fn() {
     let array = core::array::try_from_fn(|i| Ok::<_, SomeError>(i));
     assert_eq!(array, Ok([0, 1, 2, 3, 4]));
 
-    let another_array = core::array::try_from_fn::<_, Result<(), _>, 2>(|_| Err(SomeError::Foo));
+    let another_array = core::array::try_from_fn::<Result<(), _>, 2, _>(|_| Err(SomeError::Foo));
     assert_eq!(another_array, Err(SomeError::Foo));
 }
 

--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -35,7 +35,7 @@
 #![feature(float_minimum_maximum)]
 #![feature(future_join)]
 #![feature(future_poll_fn)]
-#![feature(array_from_fn)]
+#![feature(array_try_from_fn)]
 #![feature(hasher_prefixfree_extras)]
 #![feature(hashmap_internals)]
 #![feature(try_find)]


### PR DESCRIPTION
## Overall

Stabilizes `core::array::from_fn` ~~and `core::array::try_from_fn`~~ to allow the creation of custom infallible ~~and fallible~~ arrays.

Signature proposed for stabilization here, tweaked as requested in the meeting:

```rust
// in core::array

pub fn from_fn<T, const N: usize, F>(_: F) -> [T; N];
```

Examples in https://doc.rust-lang.org/nightly/std/array/fn.from_fn.html

## History

* On 2020-08-17, implementation was [proposed](https://github.com/rust-lang/rust/pull/75644).
* On 2021-09-29, tracking issue was [created](https://github.com/rust-lang/rust/issues/89379).
* On 2021-10-09, the proposed implementation was [merged](https://github.com/rust-lang-ci/rust/commit/bc8ad24020a160e1acd7ac9f7671947dcc01264c).
* On 2021-12-03, the return type of `try_from_fn` was [changed](https://github.com/rust-lang/rust/pull/91286#issuecomment-985513407).

## Considerations

* It is being assumed that indices are useful and shouldn't be removed from the callbacks
* The fact that `try_from_fn` returns an unstable type `R: Try` does not prevent stabilization. Although I'm honestly not sure about it.
* The addition or not of repeat-like variants is orthogonal to this PR.

These considerations are not ways of saying what is better or what is worse. In reality, they are an attempt to move things forward, anything really.

cc https://github.com/rust-lang/rust/issues/89379