### PR TITLE
Fix miniz_oxide types showing up in std docs

### DIFF
--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -365,6 +365,10 @@ extern crate libc;
 #[allow(unused_extern_crates)]
 extern crate unwind;
 
+#[doc(masked)]
+#[allow(unused_extern_crates)]
+extern crate miniz_oxide;
+
 // During testing, this crate is not actually the "real" std library, but rather
 // it links to the real std library, which was compiled from this same source
 // code. So any lang items std defines are conditionally excluded (or else they


### PR DESCRIPTION
Fixes #90526.

Thanks to @camelid, I rediscovered `doc(masked)`, allowing us to prevent `miniz_oxide` type to show up in std docs.

r? @notriddle 