### PR TITLE
librustdoc: adopt let else in more places

### DIFF
--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -107,9 +107,9 @@ impl Clean<Option<GenericBound>> for hir::GenericBound<'_> {
                 let trait_ref = ty::TraitRef::identity(cx.tcx, def_id).skip_binder();
 
                 let generic_args = generic_args.clean(cx);
-                let bindings = match generic_args {
-                    GenericArgs::AngleBracketed { bindings, .. } => bindings,
-                    _ => bug!("clean: parenthesized `GenericBound::LangItemTrait`"),
+                let GenericArgs::AngleBracketed { bindings, .. } = generic_args
+                else {
+                    bug!("clean: parenthesized `GenericBound::LangItemTrait`");
                 };
 
                 let trait_ = clean_trait_ref_with_bindings(cx, trait_ref, &bindings);
@@ -1282,10 +1282,7 @@ impl Clean<Item> for ty::AssocItem {
 
 fn clean_qpath(hir_ty: &hir::Ty<'_>, cx: &mut DocContext<'_>) -> Type {
     let hir::Ty { hir_id: _, span, ref kind } = *hir_ty;
-    let qpath = match kind {
-        hir::TyKind::Path(qpath) => qpath,
-        _ => unreachable!(),
-    };
+    let hir::TyKind::Path(qpath) = kind else { unreachable!() };
 
     match qpath {
         hir::QPath::Resolved(None, ref path) => {

--- a/src/librustdoc/clean/simplify.rs
+++ b/src/librustdoc/clean/simplify.rs
@@ -54,14 +54,8 @@ crate fn where_clauses(cx: &DocContext<'_>, clauses: Vec<WP>) -> Vec<WP> {
         let Some((self_, trait_did, name)) = lhs.projection() else {
             return true;
         };
-        let generic = match self_ {
-            clean::Generic(s) => s,
-            _ => return true,
-        };
-        let (bounds, _) = match params.get_mut(generic) {
-            Some(bound) => bound,
-            None => return true,
-        };
+        let clean::Generic(generic) = self_ else { return true };
+        let Some((bounds, _)) = params.get_mut(generic) else { return true };
 
         merge_bounds(cx, bounds, trait_did, name, rhs)
     });

--- a/src/librustdoc/clean/utils.rs
+++ b/src/librustdoc/clean/utils.rs
@@ -57,10 +57,8 @@ crate fn krate(cx: &mut DocContext<'_>) -> Crate {
     let primitives = local_crate.primitives(cx.tcx);
     let keywords = local_crate.keywords(cx.tcx);
     {
-        let m = match *module.kind {
-            ItemKind::ModuleItem(ref mut m) => m,
-            _ => unreachable!(),
-        };
+        let ItemKind::ModuleItem(ref mut m) = *module.kind
+        else { unreachable!() };
         m.items.extend(primitives.iter().map(|&(def_id, prim)| {
             Item::from_def_id_and_parts(
                 def_id,

--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -562,7 +562,7 @@ impl Options {
         let edition = config::parse_crate_edition(matches);
 
         let mut id_map = html::markdown::IdMap::new();
-        let external_html = match ExternalHtml::load(
+        let Some(external_html) = ExternalHtml::load(
             &matches.opt_strs("html-in-header"),
             &matches.opt_strs("html-before-content"),
             &matches.opt_strs("html-after-content"),
@@ -573,9 +573,8 @@ impl Options {
             &mut id_map,
             edition,
             &None,
-        ) {
-            Some(eh) => eh,
-            None => return Err(3),
+        ) else {
+            return Err(3);
         };
 
         match matches.opt_str("r").as_deref() {

--- a/src/librustdoc/doctest.rs
+++ b/src/librustdoc/doctest.rs
@@ -614,13 +614,11 @@ crate fn make_test(
             (found_main, found_extern_crate, found_macro)
         })
     });
-    let (already_has_main, already_has_extern_crate, found_macro) = match result {
-        Ok(result) => result,
-        Err(ErrorGuaranteed) => {
-            // If the parser panicked due to a fatal error, pass the test code through unchanged.
-            // The error will be reported during compilation.
-            return (s.to_owned(), 0, false);
-        }
+    let Ok((already_has_main, already_has_extern_crate, found_macro)) = result
+    else {
+        // If the parser panicked due to a fatal error, pass the test code through unchanged.
+        // The error will be reported during compilation.
+        return (s.to_owned(), 0, false);
     };
 
     // If a doctest's `fn main` is being masked by a wrapper macro, the parsing loop above won't

--- a/src/librustdoc/externalfiles.rs
+++ b/src/librustdoc/externalfiles.rs
@@ -99,10 +99,7 @@ crate fn load_string<P: AsRef<Path>>(
 fn load_external_files(names: &[String], diag: &rustc_errors::Handler) -> Option<String> {
     let mut out = String::new();
     for name in names {
-        let s = match load_string(name, diag) {
-            Ok(s) => s,
-            Err(_) => return None,
-        };
+        let Ok(s) = load_string(name, diag) else { return None };
         out.push_str(&s);
         out.push('\n');
     }

--- a/src/librustdoc/formats/renderer.rs
+++ b/src/librustdoc/formats/renderer.rs
@@ -77,10 +77,8 @@ crate fn run_format<'tcx, T: FormatRenderer<'tcx>>(
                 prof.generic_activity_with_arg("render_mod_item", item.name.unwrap().to_string());
 
             cx.mod_item_in(&item)?;
-            let module = match *item.kind {
-                clean::StrippedItem(box clean::ModuleItem(m)) | clean::ModuleItem(m) => m,
-                _ => unreachable!(),
-            };
+            let (clean::StrippedItem(box clean::ModuleItem(module)) | clean::ModuleItem(module)) = *item.kind
+            else { unreachable!() };
             for it in module.items {
                 debug!("Adding {:?} to worklist", it.name);
                 work.push((cx.make_child_renderer(), it));

--- a/src/librustdoc/html/highlight.rs
+++ b/src/librustdoc/html/highlight.rs
@@ -689,16 +689,12 @@ fn string<T: Display>(
     klass: Option<Class>,
     context_info: &Option<ContextInfo<'_, '_, '_>>,
 ) {
-    let klass = match klass {
-        None => return write!(out, "{}", text),
-        Some(klass) => klass,
-    };
-    let def_span = match klass.get_span() {
-        Some(d) => d,
-        None => {
-            write!(out, "<span class=\"{}\">{}</span>", klass.as_html(), text);
-            return;
-        }
+    let Some(klass) = klass
+    else { return write!(out, "{}", text) };
+    let Some(def_span) = klass.get_span()
+    else {
+        write!(out, "<span class=\"{}\">{}</span>", klass.as_html(), text);
+        return;
     };
     let mut text_s = text.to_string();
     if text_s.contains("::") {

--- a/src/librustdoc/html/render/context.rs
+++ b/src/librustdoc/html/render/context.rs
@@ -655,10 +655,8 @@ impl<'tcx> FormatRenderer<'tcx> for Context<'tcx> {
 
         // Render sidebar-items.js used throughout this module.
         if !self.render_redirect_pages {
-            let module = match *item.kind {
-                clean::StrippedItem(box clean::ModuleItem(ref m)) | clean::ModuleItem(ref m) => m,
-                _ => unreachable!(),
-            };
+            let (clean::StrippedItem(box clean::ModuleItem(ref module)) | clean::ModuleItem(ref module)) = *item.kind
+            else { unreachable!() };
             let items = self.build_sidebar_items(module);
             let js_dst = self.dst.join(&format!("sidebar-items{}.js", self.shared.resource_suffix));
             let v = format!("initSidebarItems({});", serde_json::to_string(&items).unwrap());

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -1058,10 +1058,7 @@ fn render_assoc_items_inner(
 ) {
     info!("Documenting associated items of {:?}", containing_item.name);
     let cache = cx.cache();
-    let v = match cache.impls.get(&it) {
-        Some(v) => v,
-        None => return,
-    };
+    let Some(v) = cache.impls.get(&it) else { return };
     let (non_trait, traits): (Vec<_>, _) = v.iter().partition(|i| i.inner_impl().trait_.is_none());
     if !non_trait.is_empty() {
         let mut tmp_buf = Buffer::empty_from(w);
@@ -2654,12 +2651,7 @@ fn render_call_locations(w: &mut Buffer, cx: &Context<'_>, item: &clean::Item) {
     let tcx = cx.tcx();
     let def_id = item.def_id.expect_def_id();
     let key = tcx.def_path_hash(def_id);
-    let call_locations = match cx.shared.call_locations.get(&key) {
-        Some(call_locations) => call_locations,
-        _ => {
-            return;
-        }
-    };
+    let Some(call_locations) = cx.shared.call_locations.get(&key) else { return };
 
     // Generate a unique ID so users can link to this section for a given method
     let id = cx.id_map.borrow_mut().derive("scraped-examples");

--- a/src/librustdoc/passes/bare_urls.rs
+++ b/src/librustdoc/passes/bare_urls.rs
@@ -61,12 +61,10 @@ crate fn check_bare_urls(krate: Crate, cx: &mut DocContext<'_>) -> Crate {
 
 impl<'a, 'tcx> DocVisitor for BareUrlsLinter<'a, 'tcx> {
     fn visit_item(&mut self, item: &Item) {
-        let hir_id = match DocContext::as_local_hir_id(self.cx.tcx, item.def_id) {
-            Some(hir_id) => hir_id,
-            None => {
-                // If non-local, no need to check anything.
-                return;
-            }
+        let Some(hir_id) = DocContext::as_local_hir_id(self.cx.tcx, item.def_id)
+        else {
+            // If non-local, no need to check anything.
+            return;
         };
         let dox = item.attrs.collapsed_doc_value().unwrap_or_default();
         if !dox.is_empty() {

--- a/src/librustdoc/passes/check_code_block_syntax.rs
+++ b/src/librustdoc/passes/check_code_block_syntax.rs
@@ -67,11 +67,11 @@ impl<'a, 'tcx> SyntaxChecker<'a, 'tcx> {
             return;
         }
 
-        let local_id = match item.def_id.as_def_id().and_then(|x| x.as_local()) {
-            Some(id) => id,
+        let Some(local_id) = item.def_id.as_def_id().and_then(|x| x.as_local())
+        else {
             // We don't need to check the syntax for other crates so returning
             // without doing anything should not be a problem.
-            None => return,
+            return;
         };
 
         let hir_id = self.cx.tcx.hir().local_def_id_to_hir_id(local_id);

--- a/src/librustdoc/passes/check_doc_test_visibility.rs
+++ b/src/librustdoc/passes/check_doc_test_visibility.rs
@@ -107,12 +107,10 @@ crate fn should_have_doc_example(cx: &DocContext<'_>, item: &clean::Item) -> boo
 }
 
 crate fn look_for_tests<'tcx>(cx: &DocContext<'tcx>, dox: &str, item: &Item) {
-    let hir_id = match DocContext::as_local_hir_id(cx.tcx, item.def_id) {
-        Some(hir_id) => hir_id,
-        None => {
-            // If non-local, no need to check anything.
-            return;
-        }
+    let Some(hir_id) = DocContext::as_local_hir_id(cx.tcx, item.def_id)
+    else {
+        // If non-local, no need to check anything.
+        return;
     };
 
     let mut tests = Tests { found_tests: 0 };

--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -1868,13 +1868,11 @@ fn report_diagnostic(
     DiagnosticInfo { item, ori_link: _, dox, link_range }: &DiagnosticInfo<'_>,
     decorate: impl FnOnce(&mut Diagnostic, Option<rustc_span::Span>),
 ) {
-    let hir_id = match DocContext::as_local_hir_id(tcx, item.def_id) {
-        Some(hir_id) => hir_id,
-        None => {
-            // If non-local, no need to check anything.
-            info!("ignoring warning from parent crate: {}", msg);
-            return;
-        }
+    let Some(hir_id) = DocContext::as_local_hir_id(tcx, item.def_id)
+    else {
+        // If non-local, no need to check anything.
+        info!("ignoring warning from parent crate: {}", msg);
+        return;
     };
 
     let sp = item.attr_span(tcx);

--- a/src/librustdoc/passes/html_tags.rs
+++ b/src/librustdoc/passes/html_tags.rs
@@ -197,13 +197,9 @@ fn extract_tags(
 impl<'a, 'tcx> DocVisitor for InvalidHtmlTagsLinter<'a, 'tcx> {
     fn visit_item(&mut self, item: &Item) {
         let tcx = self.cx.tcx;
-        let hir_id = match DocContext::as_local_hir_id(tcx, item.def_id) {
-            Some(hir_id) => hir_id,
-            None => {
-                // If non-local, no need to check anything.
-                return;
-            }
-        };
+        let Some(hir_id) = DocContext::as_local_hir_id(tcx, item.def_id)
+        // If non-local, no need to check anything.
+        else { return };
         let dox = item.attrs.collapsed_doc_value().unwrap_or_default();
         if !dox.is_empty() {
             let report_diag = |msg: &str, range: &Range<usize>, is_open_tag: bool| {

--- a/src/librustdoc/passes/unindent_comments.rs
+++ b/src/librustdoc/passes/unindent_comments.rs
@@ -80,7 +80,7 @@ fn unindent_fragments(docs: &mut Vec<DocFragment>) {
     // In here, the `min_indent` is 1 (because non-sugared fragment are always counted with minimum
     // 1 whitespace), meaning that "hello!" will be considered a codeblock because it starts with 4
     // (5 - 1) whitespaces.
-    let min_indent = match docs
+    let Some(min_indent) = docs
         .iter()
         .map(|fragment| {
             fragment.doc.as_str().lines().fold(usize::MAX, |min_indent, line| {
@@ -96,9 +96,8 @@ fn unindent_fragments(docs: &mut Vec<DocFragment>) {
             })
         })
         .min()
-    {
-        Some(x) => x,
-        None => return,
+    else {
+        return;
     };
 
     for fragment in docs {


### PR DESCRIPTION
Continuation of #89933, #91018, #91481, #93046, #93590, #94011.

I have extended my clippy lint to also recognize tuple passing and match statements. The diff caused by fixing it is way above 1 thousand lines. Thus, I split it up into multiple pull requests to make reviewing easier. This PR handles librustdoc.