### PR TITLE
rustc_typeck: adopt let else in more places

### DIFF
--- a/compiler/rustc_typeck/src/astconv/mod.rs
+++ b/compiler/rustc_typeck/src/astconv/mod.rs
@@ -1808,12 +1808,9 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
             (_, Res::SelfTy { trait_: Some(_), alias_to: Some((impl_def_id, _)) }) => {
                 // `Self` in an impl of a trait -- we have a concrete self type and a
                 // trait reference.
-                let trait_ref = match tcx.impl_trait_ref(impl_def_id) {
-                    Some(trait_ref) => trait_ref,
-                    None => {
-                        // A cycle error occurred, most likely.
-                        return Err(ErrorReported);
-                    }
+                let Some(trait_ref) = tcx.impl_trait_ref(impl_def_id) else {
+                    // A cycle error occurred, most likely.
+                    return Err(ErrorReported);
                 };
 
                 self.one_bound_for_assoc_type(

--- a/compiler/rustc_typeck/src/check/callee.rs
+++ b/compiler/rustc_typeck/src/check/callee.rs
@@ -219,10 +219,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             (self.tcx.lang_items().fn_mut_trait(), Ident::with_dummy_span(sym::call_mut), true),
             (self.tcx.lang_items().fn_once_trait(), Ident::with_dummy_span(sym::call_once), false),
         ] {
-            let trait_def_id = match opt_trait_def_id {
-                Some(def_id) => def_id,
-                None => continue,
-            };
+            let Some(trait_def_id) = opt_trait_def_id else { continue };
 
             let opt_input_types = opt_arg_exprs.map(|arg_exprs| {
                 [self.tcx.mk_tup(arg_exprs.iter().map(|e| {
@@ -246,11 +243,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 if borrow {
                     // Check for &self vs &mut self in the method signature. Since this is either
                     // the Fn or FnMut trait, it should be one of those.
-                    let (region, mutbl) = if let ty::Ref(r, _, mutbl) =
-                        method.sig.inputs()[0].kind()
-                    {
-                        (r, mutbl)
-                    } else {
+                    let ty::Ref(region, _, mutbl) = method.sig.inputs()[0].kind() else {
                         // The `fn`/`fn_mut` lang item is ill-formed, which should have
                         // caused an error elsewhere.
                         self.tcx

--- a/compiler/rustc_typeck/src/check/cast.rs
+++ b/compiler/rustc_typeck/src/check/cast.rs
@@ -799,10 +799,9 @@ impl<'a, 'tcx> CastCheck<'tcx> {
         let expr_kind = fcx.pointer_kind(m_expr.ty, self.span)?;
         let cast_kind = fcx.pointer_kind(m_cast.ty, self.span)?;
 
-        let cast_kind = match cast_kind {
+        let Some(cast_kind) = cast_kind else {
             // We can't cast if target pointer kind is unknown
-            None => return Err(CastError::UnknownCastPtrKind),
-            Some(cast_kind) => cast_kind,
+            return Err(CastError::UnknownCastPtrKind);
         };
 
         // Cast to thin pointer is OK
@@ -810,10 +809,9 @@ impl<'a, 'tcx> CastCheck<'tcx> {
             return Ok(CastKind::PtrPtrCast);
         }
 
-        let expr_kind = match expr_kind {
+        let Some(expr_kind) = expr_kind else {
             // We can't cast to fat pointer if source pointer kind is unknown
-            None => return Err(CastError::UnknownExprPtrKind),
-            Some(expr_kind) => expr_kind,
+            return Err(CastError::UnknownExprPtrKind);
         };
 
         // thin -> fat? report invalid cast (don't complain about vtable kinds)

--- a/compiler/rustc_typeck/src/check/closure.rs
+++ b/compiler/rustc_typeck/src/check/closure.rs
@@ -676,12 +676,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         // We do not expect any bound regions in our predicate, so
         // skip past the bound vars.
-        let predicate = match predicate.no_bound_vars() {
-            Some(p) => p,
-            None => {
-                debug!("deduce_future_output_from_projection: has late-bound regions");
-                return None;
-            }
+        let Some(predicate) = predicate.no_bound_vars() else {
+            debug!("deduce_future_output_from_projection: has late-bound regions");
+            return None;
         };
 
         // Check that this is a projection from the `Future` trait.

--- a/compiler/rustc_typeck/src/check/expr.rs
+++ b/compiler/rustc_typeck/src/check/expr.rs
@@ -622,15 +622,12 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             // the `enclosing_loops` field and let's coerce the
             // type of `expr_opt` into what is expected.
             let mut enclosing_breakables = self.enclosing_breakables.borrow_mut();
-            let ctxt = match enclosing_breakables.opt_find_breakable(target_id) {
-                Some(ctxt) => ctxt,
-                None => {
-                    // Avoid ICE when `break` is inside a closure (#65383).
-                    return tcx.ty_error_with_message(
-                        expr.span,
-                        "break was outside loop, but no error was emitted",
-                    );
-                }
+            let Some(ctxt) = enclosing_breakables.opt_find_breakable(target_id) else {
+                // Avoid ICE when `break` is inside a closure (#65383).
+                return tcx.ty_error_with_message(
+                    expr.span,
+                    "break was outside loop, but no error was emitted",
+                );
             };
 
             if let Some(ref mut coerce) = ctxt.coerce {

--- a/compiler/rustc_typeck/src/check/fn_ctxt/suggestions.rs
+++ b/compiler/rustc_typeck/src/check/fn_ctxt/suggestions.rs
@@ -434,9 +434,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 // is and we were expecting a Box, ergo Pin<Box<expected>>, we
                 // can suggest Box::pin.
                 let parent = self.tcx.hir().get_parent_node(expr.hir_id);
-                let fn_name = match self.tcx.hir().find(parent) {
-                    Some(Node::Expr(Expr { kind: ExprKind::Call(fn_name, _), .. })) => fn_name,
-                    _ => return false,
+                let Some(Node::Expr(Expr { kind: ExprKind::Call(fn_name, _), .. })) = self.tcx.hir().find(parent) else {
+                    return false;
                 };
                 match fn_name.kind {
                     ExprKind::Path(QPath::TypeRelative(

--- a/compiler/rustc_typeck/src/check/method/confirm.rs
+++ b/compiler/rustc_typeck/src/check/method/confirm.rs
@@ -149,14 +149,11 @@ impl<'a, 'tcx> ConfirmContext<'a, 'tcx> {
         // time writing the results into the various typeck results.
         let mut autoderef =
             self.autoderef_overloaded_span(self.span, unadjusted_self_ty, self.call_expr.span);
-        let (ty, n) = match autoderef.nth(pick.autoderefs) {
-            Some(n) => n,
-            None => {
-                return self.tcx.ty_error_with_message(
-                    rustc_span::DUMMY_SP,
-                    &format!("failed autoderef {}", pick.autoderefs),
-                );
-            }
+        let Some((ty, n)) = autoderef.nth(pick.autoderefs) else {
+            return self.tcx.ty_error_with_message(
+                rustc_span::DUMMY_SP,
+                &format!("failed autoderef {}", pick.autoderefs),
+            );
         };
         assert_eq!(n, pick.autoderefs);
 
@@ -520,10 +517,7 @@ impl<'a, 'tcx> ConfirmContext<'a, 'tcx> {
         &self,
         predicates: &ty::InstantiatedPredicates<'tcx>,
     ) -> Option<Span> {
-        let sized_def_id = match self.tcx.lang_items().sized_trait() {
-            Some(def_id) => def_id,
-            None => return None,
-        };
+        let sized_def_id = self.tcx.lang_items().sized_trait()?;
 
         traits::elaborate_predicates(self.tcx, predicates.predicates.iter().copied())
             // We don't care about regions here.

--- a/compiler/rustc_typeck/src/check/method/mod.rs
+++ b/compiler/rustc_typeck/src/check/method/mod.rs
@@ -371,15 +371,12 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         // Trait must have a method named `m_name` and it should not have
         // type parameters or early-bound regions.
         let tcx = self.tcx;
-        let method_item = match self.associated_value(trait_def_id, m_name) {
-            Some(method_item) => method_item,
-            None => {
-                tcx.sess.delay_span_bug(
-                    span,
-                    "operator trait does not have corresponding operator method",
-                );
-                return None;
-            }
+        let Some(method_item) = self.associated_value(trait_def_id, m_name) else {
+            tcx.sess.delay_span_bug(
+                span,
+                "operator trait does not have corresponding operator method",
+            );
+            return None;
         };
         let def_id = method_item.def_id;
         let generics = tcx.generics_of(def_id);

--- a/compiler/rustc_typeck/src/check/method/probe.rs
+++ b/compiler/rustc_typeck/src/check/method/probe.rs
@@ -1246,9 +1246,8 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
             return None;
         }
 
-        let ty = match self_ty.kind() {
-            &ty::RawPtr(ty::TypeAndMut { ty, mutbl: hir::Mutability::Mut }) => ty,
-            _ => return None,
+        let &ty::RawPtr(ty::TypeAndMut { ty, mutbl: hir::Mutability::Mut }) = self_ty.kind() else {
+            return None;
         };
 
         let const_self_ty = ty::TypeAndMut { ty, mutbl: hir::Mutability::Not };

--- a/compiler/rustc_typeck/src/check/pat.rs
+++ b/compiler/rustc_typeck/src/check/pat.rs
@@ -981,9 +981,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         if subpats.len() == variant.fields.len()
             || subpats.len() < variant.fields.len() && ddpos.is_some()
         {
-            let substs = match pat_ty.kind() {
-                ty::Adt(_, substs) => substs,
-                _ => bug!("unexpected pattern type {:?}", pat_ty),
+            let ty::Adt(_, substs) = pat_ty.kind() else {
+                bug!("unexpected pattern type {:?}", pat_ty);
             };
             for (i, subpat) in subpats.iter().enumerate_and_adjust(variant.fields.len(), ddpos) {
                 let field_ty = self.field_ty(subpat.span, &variant.fields[i], substs);
@@ -1221,9 +1220,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     ) -> bool {
         let tcx = self.tcx;
 
-        let (substs, adt) = match adt_ty.kind() {
-            ty::Adt(adt, substs) => (substs, adt),
-            _ => span_bug!(pat.span, "struct pattern is not an ADT"),
+        let ty::Adt(adt, substs) = adt_ty.kind() else {
+            span_bug!(pat.span, "struct pattern is not an ADT");
         };
 
         // Index the struct fields' types.

--- a/compiler/rustc_typeck/src/check/upvar.rs
+++ b/compiler/rustc_typeck/src/check/upvar.rs
@@ -533,19 +533,16 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 base => bug!("Expected upvar, found={:?}", base),
             };
 
-            let min_cap_list = match root_var_min_capture_list.get_mut(&var_hir_id) {
-                None => {
-                    let mutability = self.determine_capture_mutability(&typeck_results, &place);
-                    let min_cap_list = vec![ty::CapturedPlace {
-                        place,
-                        info: capture_info,
-                        mutability,
-                        region: None,
-                    }];
-                    root_var_min_capture_list.insert(var_hir_id, min_cap_list);
-                    continue;
-                }
-                Some(min_cap_list) => min_cap_list,
+            let Some(min_cap_list) = root_var_min_capture_list.get_mut(&var_hir_id) else {
+                let mutability = self.determine_capture_mutability(&typeck_results, &place);
+                let min_cap_list = vec![ty::CapturedPlace {
+                    place,
+                    info: capture_info,
+                    mutability,
+                    region: None,
+                }];
+                root_var_min_capture_list.insert(var_hir_id, min_cap_list);
+                continue;
             };
 
             // Go through each entry in the current list of min_captures

--- a/compiler/rustc_typeck/src/coherence/inherent_impls.rs
+++ b/compiler/rustc_typeck/src/coherence/inherent_impls.rs
@@ -40,11 +40,8 @@ struct InherentCollect<'tcx> {
 
 impl<'tcx> ItemLikeVisitor<'_> for InherentCollect<'tcx> {
     fn visit_item(&mut self, item: &hir::Item<'_>) {
-        let (ty, assoc_items) = match item.kind {
-            hir::ItemKind::Impl(hir::Impl { of_trait: None, ref self_ty, items, .. }) => {
-                (self_ty, items)
-            }
-            _ => return,
+        let hir::ItemKind::Impl(hir::Impl { of_trait: None, self_ty: ty, items: assoc_items, .. }) = item.kind else {
+            return;
         };
 
         let self_ty = self.tcx.type_of(item.def_id);

--- a/compiler/rustc_typeck/src/coherence/orphan.rs
+++ b/compiler/rustc_typeck/src/coherence/orphan.rs
@@ -38,9 +38,8 @@ fn orphan_check_impl(tcx: TyCtxt<'_>, def_id: LocalDefId) -> Result<(), ErrorRep
     let trait_def_id = trait_ref.def_id;
 
     let item = tcx.hir().item(hir::ItemId { def_id });
-    let impl_ = match item.kind {
-        hir::ItemKind::Impl(ref impl_) => impl_,
-        _ => bug!("{:?} is not an impl: {:?}", def_id, item),
+    let hir::ItemKind::Impl(ref impl_) = item.kind else {
+        bug!("{:?} is not an impl: {:?}", def_id, item);
     };
     let sp = tcx.sess.source_map().guess_head_span(item.span);
     let tr = impl_.of_trait.as_ref().unwrap();

--- a/compiler/rustc_typeck/src/impl_wf_check/min_specialization.rs
+++ b/compiler/rustc_typeck/src/impl_wf_check/min_specialization.rs
@@ -164,12 +164,9 @@ fn get_impl_substs<'tcx>(
     // Conservatively use an empty `ParamEnv`.
     let outlives_env = OutlivesEnvironment::new(ty::ParamEnv::empty());
     infcx.resolve_regions_and_report_errors(impl1_def_id, &outlives_env, RegionckMode::default());
-    let impl2_substs = match infcx.fully_resolve(impl2_substs) {
-        Ok(s) => s,
-        Err(_) => {
-            tcx.sess.struct_span_err(span, "could not resolve substs on overridden impl").emit();
-            return None;
-        }
+    let Ok(impl2_substs) = infcx.fully_resolve(impl2_substs) else {
+        tcx.sess.struct_span_err(span, "could not resolve substs on overridden impl").emit();
+        return None;
     };
     Some((impl1_substs, impl2_substs))
 }

--- a/compiler/rustc_typeck/src/outlives/outlives_bounds.rs
+++ b/compiler/rustc_typeck/src/outlives/outlives_bounds.rs
@@ -71,12 +71,9 @@ impl<'cx, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'cx, 'tcx> {
             result,
         );
         debug!("implied_outlives_bounds for {:?}: {:#?}", ty, result);
-        let result = match result {
-            Ok(v) => v,
-            Err(_) => {
-                self.tcx.sess.delay_span_bug(span, "implied_outlives_bounds failed to instantiate");
-                return vec![];
-            }
+        let Ok(result) = result else {
+            self.tcx.sess.delay_span_bug(span, "implied_outlives_bounds failed to instantiate");
+            return vec![];
         };
 
         // Instantiation may have produced new inference variables and constraints on those


### PR DESCRIPTION
Continuation of https://github.com/rust-lang/rust/pull/89933, https://github.com/rust-lang/rust/pull/91018, https://github.com/rust-lang/rust/pull/91481, https://github.com/rust-lang/rust/pull/93046, https://github.com/rust-lang/rust/pull/93590, https://github.com/rust-lang/rust/pull/94011.

I have extended my clippy lint to also recognize tuple passing and match statements. The diff caused by fixing it is way above 1 thousand lines. Thus, I split it up into multiple pull requests to make reviewing easier. This PR handles rustc_typeck.