### PR TITLE
rustc_trait_selection: adopt let else in more places

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/auto_trait.rs
+++ b/compiler/rustc_trait_selection/src/traits/auto_trait.rs
@@ -148,7 +148,7 @@ impl<'tcx> AutoTraitFinder<'tcx> {
             // traits::project will see that 'T: SomeTrait' is in our ParamEnv, allowing
             // SelectionContext to return it back to us.
 
-            let (new_env, user_env) = match self.evaluate_predicates(
+            let Some((new_env, user_env)) = self.evaluate_predicates(
                 &infcx,
                 trait_did,
                 ty,
@@ -156,9 +156,8 @@ impl<'tcx> AutoTraitFinder<'tcx> {
                 orig_env,
                 &mut fresh_preds,
                 false,
-            ) {
-                Some(e) => e,
-                None => return AutoTraitResult::NegativeImpl,
+            ) else {
+                return AutoTraitResult::NegativeImpl;
             };
 
             let (full_env, full_user_env) = self

--- a/compiler/rustc_trait_selection/src/traits/coherence.rs
+++ b/compiler/rustc_trait_selection/src/traits/coherence.rs
@@ -335,18 +335,15 @@ fn negative_impl<'cx, 'tcx>(
             impl_trait_ref_and_oblig(selcx, impl1_env, impl2_def_id, impl2_substs);
 
         // do the impls unify? If not, not disjoint.
-        let more_obligations = match infcx
+        let Ok(InferOk { obligations: more_obligations, .. }) = infcx
             .at(&ObligationCause::dummy(), impl1_env)
             .eq(impl1_trait_ref, impl2_trait_ref)
-        {
-            Ok(InferOk { obligations, .. }) => obligations,
-            Err(_) => {
-                debug!(
-                    "explicit_disjoint: {:?} does not unify with {:?}",
-                    impl1_trait_ref, impl2_trait_ref
-                );
-                return false;
-            }
+        else {
+            debug!(
+                "explicit_disjoint: {:?} does not unify with {:?}",
+                impl1_trait_ref, impl2_trait_ref
+            );
+            return false;
         };
 
         let opt_failing_obligation = obligations

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
@@ -801,9 +801,8 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                     return;
                 }
 
-                let found_trait_ty = match found_trait_ref.self_ty().no_bound_vars() {
-                    Some(ty) => ty,
-                    None => return,
+                let Some(found_trait_ty) = found_trait_ref.self_ty().no_bound_vars() else {
+                    return;
                 };
 
                 let found_did = match *found_trait_ty.kind() {
@@ -2115,26 +2114,24 @@ impl<'a, 'tcx> InferCtxtPrivExt<'a, 'tcx> for InferCtxt<'a, 'tcx> {
         err: &mut DiagnosticBuilder<'tcx>,
         obligation: &PredicateObligation<'tcx>,
     ) {
-        let (pred, item_def_id, span) = match (
+        let (
+            ty::PredicateKind::Trait(pred),
+            &ObligationCauseCode::BindingObligation(item_def_id, span),
+        ) = (
             obligation.predicate.kind().skip_binder(),
             obligation.cause.code().peel_derives(),
-        ) {
-            (
-                ty::PredicateKind::Trait(pred),
-                &ObligationCauseCode::BindingObligation(item_def_id, span),
-            ) => (pred, item_def_id, span),
-            _ => return,
+        )  else {
+            return;
         };
         debug!(
             "suggest_unsized_bound_if_applicable: pred={:?} item_def_id={:?} span={:?}",
             pred, item_def_id, span
         );
-        let node = match (
+        let (Some(node), true) = (
             self.tcx.hir().get_if_local(item_def_id),
             Some(pred.def_id()) == self.tcx.lang_items().sized_trait(),
-        ) {
-            (Some(node), true) => node,
-            _ => return,
+        ) else {
+            return;
         };
         self.maybe_suggest_unsized_generics(err, span, node);
     }
@@ -2145,9 +2142,8 @@ impl<'a, 'tcx> InferCtxtPrivExt<'a, 'tcx> for InferCtxt<'a, 'tcx> {
         span: Span,
         node: Node<'hir>,
     ) {
-        let generics = match node.generics() {
-            Some(generics) => generics,
-            None => return,
+        let Some(generics) = node.generics() else {
+            return;
         };
         let sized_trait = self.tcx.lang_items().sized_trait();
         debug!("maybe_suggest_unsized_generics: generics.params={:?}", generics.params);
@@ -2160,9 +2156,8 @@ impl<'a, 'tcx> InferCtxtPrivExt<'a, 'tcx> for InferCtxt<'a, 'tcx> {
                 .iter()
                 .all(|bound| bound.trait_ref().and_then(|tr| tr.trait_def_id()) != sized_trait)
         });
-        let param = match param {
-            Some(param) => param,
-            _ => return,
+        let Some(param) = param else {
+            return;
         };
         let param_def_id = self.tcx.hir().local_def_id(param.hir_id).to_def_id();
         let preds = generics.where_clause.predicates.iter();

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -513,9 +513,8 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
             | ObligationCauseCode::BuiltinDerivedObligation(cause) => cause.parent_trait_pred,
             _ => trait_pred,
         };
-        let real_ty = match real_trait_pred.self_ty().no_bound_vars() {
-            Some(ty) => ty,
-            None => return,
+        let Some(real_ty) = real_trait_pred.self_ty().no_bound_vars() else {
+            return;
         };
 
         if let ty::Ref(region, base_ty, mutbl) = *real_ty.kind() {
@@ -593,9 +592,8 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
         err: &mut DiagnosticBuilder<'_>,
         trait_pred: ty::PolyTraitPredicate<'tcx>,
     ) {
-        let self_ty = match trait_pred.self_ty().no_bound_vars() {
-            None => return,
-            Some(ty) => ty,
+        let Some(self_ty) = trait_pred.self_ty().no_bound_vars() else {
+            return;
         };
 
         let (def_id, output_ty, callable) = match *self_ty.kind() {
@@ -607,9 +605,8 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
 
         // `mk_trait_obligation_with_new_self_ty` only works for types with no escaping bound
         // variables, so bail out if we have any.
-        let output_ty = match output_ty.no_bound_vars() {
-            Some(ty) => ty,
-            None => return,
+        let Some(output_ty) = output_ty.no_bound_vars() else {
+            return;
         };
 
         let new_obligation =
@@ -631,9 +628,8 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                 ..
             })) => {
                 err.span_label(*span, "consider calling this closure");
-                let name = match self.get_closure_name(def_id, err, &msg) {
-                    Some(name) => name,
-                    None => return,
+                let Some(name) = self.get_closure_name(def_id, err, &msg) else {
+                    return;
                 };
                 let args = decl.inputs.iter().map(|_| "_").collect::<Vec<_>>().join(", ");
                 let sugg = format!("({})", args);
@@ -830,9 +826,8 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                 return;
             }
 
-            let mut suggested_ty = match trait_pred.self_ty().no_bound_vars() {
-                Some(ty) => ty,
-                None => return,
+            let Some(mut suggested_ty) = trait_pred.self_ty().no_bound_vars() else {
+                return;
             };
 
             for refs_remaining in 0..refs_number {
@@ -1050,9 +1045,8 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
     fn return_type_span(&self, obligation: &PredicateObligation<'tcx>) -> Option<Span> {
         let hir = self.tcx.hir();
         let parent_node = hir.get_parent_node(obligation.cause.body_id);
-        let sig = match hir.find(parent_node) {
-            Some(hir::Node::Item(hir::Item { kind: hir::ItemKind::Fn(sig, ..), .. })) => sig,
-            _ => return None,
+        let Some(hir::Node::Item(hir::Item { kind: hir::ItemKind::Fn(sig, ..), .. })) = hir.find(parent_node) else {
+            return None;
         };
 
         if let hir::FnRetTy::Return(ret_ty) = sig.decl.output { Some(ret_ty.span) } else { None }
@@ -1502,11 +1496,8 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
 
         // Only continue if a generator was found.
         debug!(?generator, ?trait_ref, ?target_ty, "maybe_note_obligation_cause_for_async_await");
-        let (generator_did, trait_ref, target_ty) = match (generator, trait_ref, target_ty) {
-            (Some(generator_did), Some(trait_ref), Some(target_ty)) => {
-                (generator_did, trait_ref, target_ty)
-            }
-            _ => return false,
+        let (Some(generator_did), Some(trait_ref), Some(target_ty)) = (generator, trait_ref, target_ty) else {
+            return false;
         };
 
         let span = self.tcx.def_span(generator_did);

--- a/compiler/rustc_trait_selection/src/traits/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/mod.rs
@@ -340,19 +340,16 @@ pub fn normalize_param_env_or_error<'tcx>(
         "normalize_param_env_or_error: predicates=(non-outlives={:?}, outlives={:?})",
         predicates, outlives_predicates
     );
-    let non_outlives_predicates = match do_normalize_predicates(
+    let Ok(non_outlives_predicates) = do_normalize_predicates(
         tcx,
         region_context,
         cause.clone(),
         elaborated_env,
         predicates,
-    ) {
-        Ok(predicates) => predicates,
+    ) else {
         // An unnormalized env is better than nothing.
-        Err(ErrorReported) => {
-            debug!("normalize_param_env_or_error: errored resolving non-outlives predicates");
-            return elaborated_env;
-        }
+        debug!("normalize_param_env_or_error: errored resolving non-outlives predicates");
+        return elaborated_env;
     };
 
     debug!("normalize_param_env_or_error: non-outlives predicates={:?}", non_outlives_predicates);
@@ -367,19 +364,16 @@ pub fn normalize_param_env_or_error<'tcx>(
         unnormalized_env.reveal(),
         unnormalized_env.constness(),
     );
-    let outlives_predicates = match do_normalize_predicates(
+    let Ok(outlives_predicates) = do_normalize_predicates(
         tcx,
         region_context,
         cause,
         outlives_env,
         outlives_predicates,
-    ) {
-        Ok(predicates) => predicates,
+    ) else {
         // An unnormalized env is better than nothing.
-        Err(ErrorReported) => {
-            debug!("normalize_param_env_or_error: errored resolving outlives predicates");
-            return elaborated_env;
-        }
+        debug!("normalize_param_env_or_error: errored resolving outlives predicates");
+        return elaborated_env;
     };
     debug!("normalize_param_env_or_error: outlives predicates={:?}", outlives_predicates);
 
@@ -834,9 +828,8 @@ pub fn vtable_trait_upcasting_coercion_new_vptr_slot<'tcx>(
         selcx.select(&obligation).unwrap()
     });
 
-    let implsrc_traitcasting = match implsrc {
-        Some(ImplSource::TraitUpcasting(data)) => data,
-        _ => bug!(),
+    let Some(ImplSource::TraitUpcasting(implsrc_traitcasting)) = implsrc else {
+        bug!();
     };
 
     implsrc_traitcasting.vtable_vptr_slot

--- a/compiler/rustc_trait_selection/src/traits/object_safety.rs
+++ b/compiler/rustc_trait_selection/src/traits/object_safety.rs
@@ -322,11 +322,8 @@ fn trait_has_sized_self(tcx: TyCtxt<'_>, trait_def_id: DefId) -> bool {
 }
 
 fn generics_require_sized_self(tcx: TyCtxt<'_>, def_id: DefId) -> bool {
-    let sized_def_id = match tcx.lang_items().sized_trait() {
-        Some(def_id) => def_id,
-        None => {
-            return false; /* No Sized trait, can't require it! */
-        }
+    let Some(sized_def_id) = tcx.lang_items().sized_trait() else {
+        return false; /* No Sized trait, can't require it! */
     };
 
     // Search for a predicate like `Self : Sized` amongst the trait bounds.

--- a/compiler/rustc_trait_selection/src/traits/project.rs
+++ b/compiler/rustc_trait_selection/src/traits/project.rs
@@ -1832,9 +1832,8 @@ fn confirm_impl_candidate<'cx, 'tcx>(
     let trait_def_id = tcx.trait_id_of_impl(impl_def_id).unwrap();
 
     let param_env = obligation.param_env;
-    let assoc_ty = match assoc_def(selcx, impl_def_id, assoc_item_id) {
-        Ok(assoc_ty) => assoc_ty,
-        Err(ErrorReported) => return Progress { term: tcx.ty_error().into(), obligations: nested },
+    let Ok(assoc_ty) = assoc_def(selcx, impl_def_id, assoc_item_id) else {
+        return Progress { term: tcx.ty_error().into(), obligations: nested };
     };
 
     if !assoc_ty.item.defaultness.has_value() {

--- a/compiler/rustc_trait_selection/src/traits/select/candidate_assembly.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/candidate_assembly.rs
@@ -436,11 +436,8 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         obligation: &TraitObligation<'tcx>,
         candidates: &mut SelectionCandidateSet<'tcx>,
     ) {
-        let kind = match self.tcx().fn_trait_kind_from_lang_item(obligation.predicate.def_id()) {
-            Some(k) => k,
-            None => {
-                return;
-            }
+        let Some(kind) = self.tcx().fn_trait_kind_from_lang_item(obligation.predicate.def_id()) else {
+            return;
         };
 
         // Okay to skip binder because the substs on closure types never
@@ -763,12 +760,9 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         //     T: Trait
         // so it seems ok if we (conservatively) fail to accept that `Unsize`
         // obligation above. Should be possible to extend this in the future.
-        let source = match obligation.self_ty().no_bound_vars() {
-            Some(t) => t,
-            None => {
-                // Don't add any candidates if there are bound regions.
-                return;
-            }
+        let Some(source) = obligation.self_ty().no_bound_vars() else {
+            // Don't add any candidates if there are bound regions.
+            return;
         };
         let target = obligation.predicate.skip_binder().trait_ref.substs.type_at(1);
 

--- a/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
@@ -272,9 +272,8 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             } else {
                 bug!("unexpected builtin trait {:?}", trait_def)
             };
-            let nested = match conditions {
-                BuiltinImplConditions::Where(nested) => nested,
-                _ => bug!("obligation {:?} had matched a builtin impl but now doesn't", obligation),
+            let BuiltinImplConditions::Where(nested) = conditions else {
+                bug!("obligation {:?} had matched a builtin impl but now doesn't", obligation);
             };
 
             let cause = obligation.derived_cause(BuiltinDerivedObligation);
@@ -421,9 +420,8 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         let trait_predicate = self.infcx.replace_bound_vars_with_placeholders(obligation.predicate);
         let self_ty = self.infcx.shallow_resolve(trait_predicate.self_ty());
         let obligation_trait_ref = ty::Binder::dummy(trait_predicate.trait_ref);
-        let data = match *self_ty.kind() {
-            ty::Dynamic(data, ..) => data,
-            _ => span_bug!(obligation.cause.span, "object candidate with non-object"),
+        let ty::Dynamic(data, ..) = *self_ty.kind() else {
+            span_bug!(obligation.cause.span, "object candidate with non-object");
         };
 
         let object_trait_ref = data.principal().unwrap_or_else(|| {
@@ -608,9 +606,8 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         // touch bound regions, they just capture the in-scope
         // type/region parameters.
         let self_ty = self.infcx.shallow_resolve(obligation.self_ty().skip_binder());
-        let (generator_def_id, substs) = match *self_ty.kind() {
-            ty::Generator(id, substs, _) => (id, substs),
-            _ => bug!("closure candidate for non-closure {:?}", obligation),
+        let ty::Generator(generator_def_id, substs, _) = *self_ty.kind() else {
+            bug!("closure candidate for non-closure {:?}", obligation);
         };
 
         debug!(?obligation, ?generator_def_id, ?substs, "confirm_generator_candidate");
@@ -652,9 +649,8 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         // touch bound regions, they just capture the in-scope
         // type/region parameters.
         let self_ty = self.infcx.shallow_resolve(obligation.self_ty().skip_binder());
-        let (closure_def_id, substs) = match *self_ty.kind() {
-            ty::Closure(id, substs) => (id, substs),
-            _ => bug!("closure candidate for non-closure {:?}", obligation),
+        let ty::Closure(closure_def_id, substs) = *self_ty.kind() else {
+            bug!("closure candidate for non-closure {:?}", obligation);
         };
 
         let obligation_predicate = obligation.predicate;

--- a/compiler/rustc_trait_selection/src/traits/specialize/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/specialize/mod.rs
@@ -192,18 +192,15 @@ fn fulfill_implication<'a, 'tcx>(
         impl_trait_ref_and_oblig(selcx, param_env, target_impl, target_substs);
 
     // do the impls unify? If not, no specialization.
-    let more_obligations =
-        match infcx.at(&ObligationCause::dummy(), param_env).eq(source_trait_ref, target_trait_ref)
-        {
-            Ok(InferOk { obligations, .. }) => obligations,
-            Err(_) => {
-                debug!(
-                    "fulfill_implication: {:?} does not unify with {:?}",
-                    source_trait_ref, target_trait_ref
-                );
-                return Err(());
-            }
-        };
+    let Ok(InferOk { obligations: more_obligations, .. }) =
+        infcx.at(&ObligationCause::dummy(), param_env).eq(source_trait_ref, target_trait_ref)
+    else {
+        debug!(
+            "fulfill_implication: {:?} does not unify with {:?}",
+            source_trait_ref, target_trait_ref
+        );
+        return Err(());
+    };
 
     // attempt to prove all of the predicates for impl2 given those for impl1
     // (which are packed up in penv)


### PR DESCRIPTION
Continuation of #89933, #91018, #91481, #93046, #93590, #94011.

I have extended my clippy lint to also recognize tuple passing and match statements. The diff caused by fixing it is way above 1 thousand lines. Thus, I split it up into multiple pull requests to make reviewing easier. This PR handles rustc_trait_selection.
