### PR TITLE
Enable draining iterator/stream elements into a `()`

### DIFF
--- a/library/core/src/iter/traits/collect.rs
+++ b/library/core/src/iter/traits/collect.rs
@@ -374,11 +374,11 @@ pub trait Extend<A> {
 }
 
 #[stable(feature = "extend_for_unit", since = "1.28.0")]
-impl Extend<()> for () {
-    fn extend<T: IntoIterator<Item = ()>>(&mut self, iter: T) {
+impl<T> Extend<T> for () {
+    fn extend<A: IntoIterator<Item = T>>(&mut self, iter: A) {
         iter.into_iter().for_each(drop)
     }
-    fn extend_one(&mut self, _item: ()) {}
+    fn extend_one(&mut self, _item: T) {}
 }
 
 #[stable(feature = "extend_for_tuple", since = "1.56.0")]

--- a/library/core/src/unit.rs
+++ b/library/core/src/unit.rs
@@ -1,9 +1,10 @@
 use crate::iter::FromIterator;
 
-/// Collapses all unit items from an iterator into one.
+/// Drains all items from an iterator.
 ///
-/// This is more useful when combined with higher-level abstractions, like
-/// collecting to a `Result<(), E>` where you only care about errors:
+/// This is useful to run an iterator to completion when you don't
+/// care about the result, or to collect into a `Result<(), E>` when
+/// you only care about errors:
 ///
 /// ```
 /// use std::io::*;
@@ -14,8 +15,8 @@ use crate::iter::FromIterator;
 /// assert!(res.is_ok());
 /// ```
 #[stable(feature = "unit_from_iter", since = "1.23.0")]
-impl FromIterator<()> for () {
-    fn from_iter<I: IntoIterator<Item = ()>>(iter: I) -> Self {
-        iter.into_iter().for_each(|()| {})
+impl<T> FromIterator<T> for () {
+    fn from_iter<A: IntoIterator<Item = T>>(iter: A) -> Self {
+        iter.into_iter().for_each(|_| {})
     }
 }


### PR DESCRIPTION
The current implementation of `Extend` for `()` was added in https://github.com/rust-lang/rust/pull/50234 because:

> This is useful in some generic code which wants to collect iterators of items into a result.

Making the implementation generic makes something like [`stream.collect::<()>`](https://docs.rs/futures/0.3.21/futures/stream/trait.StreamExt.html#method.collect) possible for *any*  stream, vs. `stream.map(drop).collect::<()>`.

Similarly, `impl<T> FromIterator<T> for ()` makes `iter.collect::<()>` a generic replacement for `iter.for_each(drop)`.