### PR TITLE
Add `doc(html_root_url)` to `rustc_hir` crate

### DIFF
--- a/compiler/rustc_hir/src/lib.rs
+++ b/compiler/rustc_hir/src/lib.rs
@@ -2,6 +2,7 @@
 //!
 //! [rustc dev guide]: https://rustc-dev-guide.rust-lang.org/hir.html
 
+#![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
 #![feature(associated_type_defaults)]
 #![feature(const_btree_new)]
 #![feature(crate_visibility_modifier)]


### PR DESCRIPTION
This helps some IDE's open the rustc API docs at https://doc.rust-lang.org/nightly/nightly-rustc.

The consensus was against this change in https://github.com/rust-lang/rust/pull/91810. However, about half of the rustc crates already use this attribute (which was not mentioned in that discussion):

```
$ cd rust/compiler/
$ ls | wc -l
61
$ rg html_root_url --stats
rustc_apfloat/src/lib.rs:33:8:#![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
rustc_arena/src/lib.rs:11:5:html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/",
rustc_ast/src/lib.rs:8:5:html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/",
rustc_builtin_macros/src/lib.rs:4:8:#![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
rustc_codegen_llvm/src/lib.rs:7:8:#![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
rustc_codegen_ssa/src/lib.rs:1:8:#![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
rustc_data_structures/src/lib.rs:9:8:#![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
rustc_driver/src/lib.rs:7:8:#![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
rustc_errors/src/lib.rs:5:8:#![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
rustc_graphviz/src/lib.rs:275:5:html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/",
rustc_incremental/src/lib.rs:4:8:#![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
rustc_infer/src/lib.rs:15:8:#![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
rustc_lint/src/lib.rs:28:8:#![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
rustc_llvm/src/lib.rs:3:8:#![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
rustc_metadata/src/lib.rs:1:8:#![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
rustc_middle/src/lib.rs:25:8:#![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
rustc_parse_format/src/lib.rs:8:5:html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/",
rustc_passes/src/check_attr.rs:962:32:| sym::html_root_url
rustc_passes/src/check_attr.rs:993:32:| sym::html_root_url
rustc_passes/src/lib.rs:7:8:#![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
rustc_plugin_impl/src/lib.rs:9:8:#![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
rustc_privacy/src/lib.rs:1:8:#![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
rustc_query_impl/src/lib.rs:3:8:#![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
rustc_resolve/src/lib.rs:11:8:#![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
rustc_save_analysis/src/lib.rs:1:8:#![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
rustc_serialize/src/lib.rs:8:5:html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/",
rustc_span/src/lib.rs:16:8:#![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
rustc_span/src/symbol.rs:740:9:html_root_url,
rustc_symbol_mangling/src/lib.rs:90:8:#![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
rustc_target/src/lib.rs:10:8:#![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
rustc_trait_selection/src/lib.rs:13:8:#![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
rustc_ty_utils/src/lib.rs:7:8:#![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
rustc_typeck/src/lib.rs:58:8:#![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]

33 matches
```

I'd also be in favor of adding this to all `rustc_*` crates.