### PR TITLE
tidy: fire less "ignoring file length unneccessarily" warnings

### DIFF
--- a/src/tools/tidy/src/style.rs
+++ b/src/tools/tidy/src/style.rs
@@ -395,6 +395,9 @@ pub fn check(path: &Path, bad: &mut bool) {
                 );
             };
             suppressible_tidy_err!(err, skip_file_length, "");
+        } else if lines > (LINES * 7) / 10 {
+            // Just set it to something that doesn't trigger the "unneccessarily ignored" warning.
+            skip_file_length = Directive::Ignore(true);
         }
 
         if let Directive::Ignore(false) = skip_cr {


### PR DESCRIPTION
This avoids a situation where a file is at the border of the limit,
and alternates between hitting the limit and not hitting it, causing
a back and forth of addition of the ignore-tidy-linelength directive.

As an example, consider the ignore-tidy-filelength of compiler/rustc_typeck/src/collect.rs.

It was added in 2ca4964db5d263a8f9222846bd70a7f26cf414cf, removed in
37354ebc9794b0eb14b08c02177e3094c8fe91cd (a revert of the earlier commit), added again in 448d07683a6defd567996114793a09c9a8aef5df,
removed in 3171bd5bf54fb91f7f7df7c40df5adc7d8bd5dea, added in 438826fd1a9a119d00992ede948cdd479431ecbb,
and removed in bb0a2f985cb6e980cc026ea952733d53bb868f87.

To avoid this back and forth, we exempt files from the unneccessary
ignoring warning that have length of at least 70% of the limit.