### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/compiler/rustc_ast_lowering/src/asm.rs
+++ b/compiler/rustc_ast_lowering/src/asm.rs
@@ -64,13 +64,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
         let mut clobber_abis = FxHashMap::default();
         if let Some(asm_arch) = asm_arch {
             for (abi_name, abi_span) in &asm.clobber_abis {
-                match asm::InlineAsmClobberAbi::parse(
-                    asm_arch,
-                    self.sess.relocation_model(),
-                    &self.sess.target_features,
-                    &self.sess.target,
-                    *abi_name,
-                ) {
+                match asm::InlineAsmClobberAbi::parse(asm_arch, &self.sess.target, *abi_name) {
                     Ok(abi) => {
                         // If the abi was already in the list, emit an error
                         match clobber_abis.get(&abi) {
@@ -130,18 +124,10 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
             .operands
             .iter()
             .map(|(op, op_sp)| {
-                let lower_reg = |reg, is_clobber| match reg {
+                let lower_reg = |reg| match reg {
                     InlineAsmRegOrRegClass::Reg(s) => {
                         asm::InlineAsmRegOrRegClass::Reg(if let Some(asm_arch) = asm_arch {
-                            asm::InlineAsmReg::parse(
-                                asm_arch,
-                                sess.relocation_model(),
-                                &sess.target_features,
-                                &sess.target,
-                                is_clobber,
-                                s,
-                            )
-                            .unwrap_or_else(|e| {
+                            asm::InlineAsmReg::parse(asm_arch, s).unwrap_or_else(|e| {
                                 let msg = format!("invalid register `{}`: {}", s.as_str(), e);
                                 sess.struct_span_err(*op_sp, &msg).emit();
                                 asm::InlineAsmReg::Err
@@ -165,24 +151,24 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
 
                 let op = match *op {
                     InlineAsmOperand::In { reg, ref expr } => hir::InlineAsmOperand::In {
-                        reg: lower_reg(reg, false),
+                        reg: lower_reg(reg),
                         expr: self.lower_expr_mut(expr),
                     },
                     InlineAsmOperand::Out { reg, late, ref expr } => hir::InlineAsmOperand::Out {
-                        reg: lower_reg(reg, expr.is_none()),
+                        reg: lower_reg(reg),
                         late,
                         expr: expr.as_ref().map(|expr| self.lower_expr_mut(expr)),
                     },
                     InlineAsmOperand::InOut { reg, late, ref expr } => {
                         hir::InlineAsmOperand::InOut {
-                            reg: lower_reg(reg, false),
+                            reg: lower_reg(reg),
                             late,
                             expr: self.lower_expr_mut(expr),
                         }
                     }
                     InlineAsmOperand::SplitInOut { reg, late, ref in_expr, ref out_expr } => {
                         hir::InlineAsmOperand::SplitInOut {
-                            reg: lower_reg(reg, false),
+                            reg: lower_reg(reg),
                             late,
                             in_expr: self.lower_expr_mut(in_expr),
                             out_expr: out_expr.as_ref().map(|expr| self.lower_expr_mut(expr)),

--- a/compiler/rustc_ast_lowering/src/asm.rs
+++ b/compiler/rustc_ast_lowering/src/asm.rs
@@ -66,6 +66,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
             for (abi_name, abi_span) in &asm.clobber_abis {
                 match asm::InlineAsmClobberAbi::parse(
                     asm_arch,
+                    self.sess.relocation_model(),
                     &self.sess.target_features,
                     &self.sess.target,
                     *abi_name,
@@ -134,6 +135,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                         asm::InlineAsmRegOrRegClass::Reg(if let Some(asm_arch) = asm_arch {
                             asm::InlineAsmReg::parse(
                                 asm_arch,
+                                sess.relocation_model(),
                                 &sess.target_features,
                                 &sess.target,
                                 is_clobber,

--- a/compiler/rustc_codegen_cranelift/src/inline_asm.rs
+++ b/compiler/rustc_codegen_cranelift/src/inline_asm.rs
@@ -182,7 +182,12 @@ struct InlineAssemblyGenerator<'a, 'tcx> {
 impl<'tcx> InlineAssemblyGenerator<'_, 'tcx> {
     fn allocate_registers(&mut self) {
         let sess = self.tcx.sess;
-        let map = allocatable_registers(self.arch, &sess.target_features, &sess.target);
+        let map = allocatable_registers(
+            self.arch,
+            sess.relocation_model(),
+            &sess.target_features,
+            &sess.target,
+        );
         let mut allocated = FxHashMap::<_, (bool, bool)>::default();
         let mut regs = vec![None; self.operands.len()];
 
@@ -315,6 +320,7 @@ impl<'tcx> InlineAssemblyGenerator<'_, 'tcx> {
         // Allocate stack slots for saving clobbered registers
         let abi_clobber = InlineAsmClobberAbi::parse(
             self.arch,
+            self.tcx.sess.relocation_model(),
             &self.tcx.sess.target_features,
             &self.tcx.sess.target,
             sym::C,

--- a/compiler/rustc_codegen_ssa/src/target_features.rs
+++ b/compiler/rustc_codegen_ssa/src/target_features.rs
@@ -36,7 +36,6 @@ const ARM_ALLOWED_FEATURES: &[(&str, Option<Symbol>)] = &[
     // #[target_feature].
     ("thumb-mode", Some(sym::arm_target_feature)),
     ("thumb2", Some(sym::arm_target_feature)),
-    ("reserve-r9", Some(sym::arm_target_feature)),
 ];
 
 const AARCH64_ALLOWED_FEATURES: &[(&str, Option<Symbol>)] = &[

--- a/compiler/rustc_const_eval/src/interpret/validity.rs
+++ b/compiler/rustc_const_eval/src/interpret/validity.rs
@@ -697,7 +697,7 @@ impl<'rt, 'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> ValueVisitor<'mir, 'tcx, M>
                 this.ecx.read_discriminant(op),
                 this.path,
                 err_ub!(InvalidTag(val)) =>
-                    { "{}", val } expected { "a valid enum tag" },
+                    { "{:x}", val } expected { "a valid enum tag" },
                 err_ub!(InvalidUninitBytes(None)) =>
                     { "uninitialized bytes" } expected { "a valid enum tag" },
                 err_unsup!(ReadPointerAsBytes) =>

--- a/compiler/rustc_expand/src/config.rs
+++ b/compiler/rustc_expand/src/config.rs
@@ -167,6 +167,7 @@ fn get_features(
             if let Some(Feature { since, .. }) = ACCEPTED_FEATURES.iter().find(|f| name == f.name) {
                 let since = Some(Symbol::intern(since));
                 features.declared_lang_features.push((name, mi.span(), since));
+                features.active_features.insert(name);
                 continue;
             }
 
@@ -187,10 +188,12 @@ fn get_features(
             if let Some(f) = ACTIVE_FEATURES.iter().find(|f| name == f.name) {
                 f.set(&mut features, mi.span());
                 features.declared_lang_features.push((name, mi.span(), None));
+                features.active_features.insert(name);
                 continue;
             }
 
             features.declared_lib_features.push((name, mi.span()));
+            features.active_features.insert(name);
         }
     }
 

--- a/compiler/rustc_feature/src/active.rs
+++ b/compiler/rustc_feature/src/active.rs
@@ -2,6 +2,7 @@
 
 use super::{to_nonzero, Feature, State};
 
+use rustc_data_structures::fx::FxHashSet;
 use rustc_span::edition::Edition;
 use rustc_span::symbol::{sym, Symbol};
 use rustc_span::Span;
@@ -47,6 +48,8 @@ macro_rules! declare_features {
             pub declared_lang_features: Vec<(Symbol, Span, Option<Symbol>)>,
             /// `#![feature]` attrs for non-language (library) features.
             pub declared_lib_features: Vec<(Symbol, Span)>,
+            /// Features enabled for this crate.
+            pub active_features: FxHashSet<Symbol>,
             $(
                 $(#[doc = $doc])*
                 pub $feature: bool
@@ -56,6 +59,11 @@ macro_rules! declare_features {
         impl Features {
             pub fn walk_feature_fields(&self, mut f: impl FnMut(&str, bool)) {
                 $(f(stringify!($feature), self.$feature);)+
+            }
+
+            /// Is the given feature active?
+            pub fn active(&self, feature: Symbol) -> bool {
+                self.active_features.contains(&feature)
             }
 
             /// Is the given feature enabled?

--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -925,6 +925,11 @@ fn analysis(tcx: TyCtxt<'_>, (): ()) -> Result<()> {
                 });
             },
             {
+                sess.time("unused_lib_feature_checking", || {
+                    rustc_passes::stability::check_unused_or_stable_features(tcx)
+                });
+            },
+            {
                 // We force these querie to run,
                 // since they might not otherwise get called.
                 // This marks the corresponding crate-level attributes
@@ -1001,11 +1006,6 @@ fn analysis(tcx: TyCtxt<'_>, (): ()) -> Result<()> {
                     {
                         tcx.hir()
                             .par_for_each_module(|module| tcx.ensure().check_mod_deathness(module));
-                    },
-                    {
-                        sess.time("unused_lib_feature_checking", || {
-                            rustc_passes::stability::check_unused_or_stable_features(tcx)
-                        });
                     },
                     {
                         sess.time("lint_checking", || {

--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -930,6 +930,7 @@ fn analysis(tcx: TyCtxt<'_>, (): ()) -> Result<()> {
                 // This marks the corresponding crate-level attributes
                 // as used, and ensures that their values are valid.
                 tcx.ensure().limits(());
+                tcx.ensure().stability_index(());
             }
         );
     });

--- a/compiler/rustc_middle/src/middle/stability.rs
+++ b/compiler/rustc_middle/src/middle/stability.rs
@@ -11,7 +11,7 @@ use rustc_errors::{Applicability, DiagnosticBuilder};
 use rustc_feature::GateIssue;
 use rustc_hir as hir;
 use rustc_hir::def::DefKind;
-use rustc_hir::def_id::{CrateNum, DefId, LocalDefId, CRATE_DEF_INDEX};
+use rustc_hir::def_id::{DefId, LocalDefId, CRATE_DEF_INDEX};
 use rustc_hir::{self, HirId};
 use rustc_middle::ty::print::with_no_trimmed_paths;
 use rustc_session::lint::builtin::{DEPRECATED, DEPRECATED_IN_FUTURE, SOFT_UNSTABLE};
@@ -63,9 +63,6 @@ pub struct Index<'tcx> {
     pub stab_map: FxHashMap<LocalDefId, &'tcx Stability>,
     pub const_stab_map: FxHashMap<LocalDefId, &'tcx ConstStability>,
     pub depr_map: FxHashMap<LocalDefId, DeprecationEntry>,
-
-    /// Maps for each crate whether it is part of the staged API.
-    pub staged_api: FxHashMap<CrateNum, bool>,
 }
 
 impl<'tcx> Index<'tcx> {

--- a/compiler/rustc_middle/src/middle/stability.rs
+++ b/compiler/rustc_middle/src/middle/stability.rs
@@ -6,7 +6,7 @@ pub use self::StabilityLevel::*;
 use crate::ty::{self, DefIdTree, TyCtxt};
 use rustc_ast::NodeId;
 use rustc_attr::{self as attr, ConstStability, Deprecation, Stability};
-use rustc_data_structures::fx::{FxHashMap, FxHashSet};
+use rustc_data_structures::fx::FxHashMap;
 use rustc_errors::{Applicability, DiagnosticBuilder};
 use rustc_feature::GateIssue;
 use rustc_hir as hir;
@@ -66,9 +66,6 @@ pub struct Index<'tcx> {
 
     /// Maps for each crate whether it is part of the staged API.
     pub staged_api: FxHashMap<CrateNum, bool>,
-
-    /// Features enabled for this crate.
-    pub active_features: FxHashSet<Symbol>,
 }
 
 impl<'tcx> Index<'tcx> {
@@ -423,7 +420,7 @@ impl<'tcx> TyCtxt<'tcx> {
                     debug!("stability: skipping span={:?} since it is internal", span);
                     return EvalResult::Allow;
                 }
-                if self.stability().active_features.contains(&feature) {
+                if self.features().active(feature) {
                     return EvalResult::Allow;
                 }
 

--- a/compiler/rustc_middle/src/mir/interpret/error.rs
+++ b/compiler/rustc_middle/src/mir/interpret/error.rs
@@ -370,7 +370,7 @@ impl fmt::Display for UndefinedBehaviorInfo<'_> {
             InvalidChar(c) => {
                 write!(f, "interpreting an invalid 32-bit value as a char: 0x{:08x}", c)
             }
-            InvalidTag(val) => write!(f, "enum value has invalid tag: {}", val),
+            InvalidTag(val) => write!(f, "enum value has invalid tag: {:x}", val),
             InvalidFunctionPointer(p) => {
                 write!(f, "using {:?} as function pointer but it does not point to a function", p)
             }

--- a/compiler/rustc_middle/src/mir/interpret/value.rs
+++ b/compiler/rustc_middle/src/mir/interpret/value.rs
@@ -153,7 +153,16 @@ impl<Tag: Provenance> fmt::Display for Scalar<Tag> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Scalar::Ptr(ptr, _size) => write!(f, "pointer to {:?}", ptr),
-            Scalar::Int(int) => write!(f, "{:?}", int),
+            Scalar::Int(int) => write!(f, "{}", int),
+        }
+    }
+}
+
+impl<Tag: Provenance> fmt::LowerHex for Scalar<Tag> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Scalar::Ptr(ptr, _size) => write!(f, "pointer to {:?}", ptr),
+            Scalar::Int(int) => write!(f, "0x{:x}", int),
         }
     }
 }
@@ -456,11 +465,6 @@ impl<'tcx, Tag: Provenance> Scalar<Tag> {
         // Going through `u64` to check size and truncation.
         Ok(Double::from_bits(self.to_u64()?.into()))
     }
-
-    // FIXME: Replace current `impl Display for Scalar` with `impl LowerHex`.
-    pub fn rustdoc_display(&self) -> String {
-        if let Scalar::Int(int) = self { int.to_string() } else { self.to_string() }
-    }
 }
 
 #[derive(Clone, Copy, Eq, PartialEq, TyEncodable, TyDecodable, HashStable, Hash)]
@@ -494,7 +498,7 @@ impl<Tag: Provenance> fmt::Display for ScalarMaybeUninit<Tag> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             ScalarMaybeUninit::Uninit => write!(f, "uninitialized bytes"),
-            ScalarMaybeUninit::Scalar(s) => write!(f, "{}", s),
+            ScalarMaybeUninit::Scalar(s) => write!(f, "{:x}", s),
         }
     }
 }

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -1040,6 +1040,10 @@ rustc_queries! {
         cache_on_disk_if { true }
     }
 
+    query asm_target_features(def_id: DefId) -> &'tcx FxHashSet<Symbol> {
+        desc { |tcx| "computing target features for inline asm of `{}`", tcx.def_path_str(def_id) }
+    }
+
     query fn_arg_names(def_id: DefId) -> &'tcx [rustc_span::symbol::Ident] {
         desc { |tcx| "looking up function parameter names for `{}`", tcx.def_path_str(def_id) }
         separate_provide_extern

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -2964,11 +2964,6 @@ pub fn provide(providers: &mut ty::query::Providers) {
         tcx.arena.alloc(tcx.resolutions(()).glob_map.get(&id).cloned().unwrap_or_default())
     };
 
-    providers.lookup_stability = |tcx, id| tcx.stability().local_stability(id.expect_local());
-    providers.lookup_const_stability =
-        |tcx, id| tcx.stability().local_const_stability(id.expect_local());
-    providers.lookup_deprecation_entry =
-        |tcx, id| tcx.stability().local_deprecation_entry(id.expect_local());
     providers.extern_mod_stmt_cnum =
         |tcx, id| tcx.resolutions(()).extern_crate_map.get(&id).cloned();
     providers.output_filenames = |tcx, ()| &tcx.output_filenames;

--- a/compiler/rustc_passes/src/intrinsicck.rs
+++ b/compiler/rustc_passes/src/intrinsicck.rs
@@ -1,4 +1,5 @@
 use rustc_ast::InlineAsmTemplatePiece;
+use rustc_data_structures::stable_set::FxHashSet;
 use rustc_errors::struct_span_err;
 use rustc_hir as hir;
 use rustc_hir::def::{DefKind, Res};
@@ -141,7 +142,7 @@ impl<'tcx> ExprVisitor<'tcx> {
         template: &[InlineAsmTemplatePiece],
         is_input: bool,
         tied_input: Option<(&hir::Expr<'tcx>, Option<InlineAsmType>)>,
-        target_features: &[Symbol],
+        target_features: &FxHashSet<Symbol>,
     ) -> Option<InlineAsmType> {
         // Check the type against the allowed types for inline asm.
         let ty = self.typeck_results.expr_ty_adjusted(expr);
@@ -294,9 +295,7 @@ impl<'tcx> ExprVisitor<'tcx> {
         // (!). In that case we still need the earlier check to verify that the
         // register class is usable at all.
         if let Some(feature) = feature {
-            if !self.tcx.sess.target_features.contains(&feature)
-                && !target_features.contains(&feature)
-            {
+            if !target_features.contains(&feature) {
                 let msg = &format!("`{}` target feature is not enabled", feature);
                 let mut err = self.tcx.sess.struct_span_err(expr.span, msg);
                 err.note(&format!(
@@ -356,7 +355,8 @@ impl<'tcx> ExprVisitor<'tcx> {
         let hir = self.tcx.hir();
         let enclosing_id = hir.enclosing_body_owner(hir_id);
         let enclosing_def_id = hir.local_def_id(enclosing_id).to_def_id();
-        let attrs = self.tcx.codegen_fn_attrs(enclosing_def_id);
+        let target_features = self.tcx.asm_target_features(enclosing_def_id);
+        let asm_arch = self.tcx.sess.asm_arch.unwrap();
         for (idx, (op, op_sp)) in asm.operands.iter().enumerate() {
             // Validate register classes against currently enabled target
             // features. We check that at least one type is available for
@@ -369,16 +369,29 @@ impl<'tcx> ExprVisitor<'tcx> {
             // Note that this is only possible for explicit register
             // operands, which cannot be used in the asm string.
             if let Some(reg) = op.reg() {
+                // Some explicit registers cannot be used depending on the
+                // target. Reject those here.
+                if let InlineAsmRegOrRegClass::Reg(reg) = reg {
+                    if let Err(msg) = reg.validate(
+                        asm_arch,
+                        self.tcx.sess.relocation_model(),
+                        &target_features,
+                        &self.tcx.sess.target,
+                        op.is_clobber(),
+                    ) {
+                        let msg = format!("cannot use register `{}`: {}", reg.name(), msg);
+                        self.tcx.sess.struct_span_err(*op_sp, &msg).emit();
+                        continue;
+                    }
+                }
+
                 if !op.is_clobber() {
                     let mut missing_required_features = vec![];
                     let reg_class = reg.reg_class();
-                    for &(_, feature) in reg_class.supported_types(self.tcx.sess.asm_arch.unwrap())
-                    {
+                    for &(_, feature) in reg_class.supported_types(asm_arch) {
                         match feature {
                             Some(feature) => {
-                                if self.tcx.sess.target_features.contains(&feature)
-                                    || attrs.target_features.contains(&feature)
-                                {
+                                if target_features.contains(&feature) {
                                     missing_required_features.clear();
                                     break;
                                 } else {
@@ -434,7 +447,7 @@ impl<'tcx> ExprVisitor<'tcx> {
                         asm.template,
                         true,
                         None,
-                        &attrs.target_features,
+                        &target_features,
                     );
                 }
                 hir::InlineAsmOperand::Out { reg, late: _, ref expr } => {
@@ -446,7 +459,7 @@ impl<'tcx> ExprVisitor<'tcx> {
                             asm.template,
                             false,
                             None,
-                            &attrs.target_features,
+                            &target_features,
                         );
                     }
                 }
@@ -458,7 +471,7 @@ impl<'tcx> ExprVisitor<'tcx> {
                         asm.template,
                         false,
                         None,
-                        &attrs.target_features,
+                        &target_features,
                     );
                 }
                 hir::InlineAsmOperand::SplitInOut { reg, late: _, ref in_expr, ref out_expr } => {
@@ -469,7 +482,7 @@ impl<'tcx> ExprVisitor<'tcx> {
                         asm.template,
                         true,
                         None,
-                        &attrs.target_features,
+                        &target_features,
                     );
                     if let Some(out_expr) = out_expr {
                         self.check_asm_operand_type(
@@ -479,7 +492,7 @@ impl<'tcx> ExprVisitor<'tcx> {
                             asm.template,
                             false,
                             Some((in_expr, in_ty)),
-                            &attrs.target_features,
+                            &target_features,
                         );
                     }
                 }

--- a/compiler/rustc_passes/src/stability.rs
+++ b/compiler/rustc_passes/src/stability.rs
@@ -714,7 +714,16 @@ fn check_mod_unstable_api_usage(tcx: TyCtxt<'_>, module_def_id: LocalDefId) {
 }
 
 pub(crate) fn provide(providers: &mut Providers) {
-    *providers = Providers { check_mod_unstable_api_usage, stability_index, ..*providers };
+    *providers = Providers {
+        check_mod_unstable_api_usage,
+        stability_index,
+        lookup_stability: |tcx, id| tcx.stability().local_stability(id.expect_local()),
+        lookup_const_stability: |tcx, id| tcx.stability().local_const_stability(id.expect_local()),
+        lookup_deprecation_entry: |tcx, id| {
+            tcx.stability().local_deprecation_entry(id.expect_local())
+        },
+        ..*providers
+    };
 }
 
 struct Checker<'tcx> {

--- a/compiler/rustc_passes/src/stability.rs
+++ b/compiler/rustc_passes/src/stability.rs
@@ -665,18 +665,7 @@ fn stability_index<'tcx>(tcx: TyCtxt<'tcx>, (): ()) -> Index<'tcx> {
         stab_map: Default::default(),
         const_stab_map: Default::default(),
         depr_map: Default::default(),
-        active_features: Default::default(),
     };
-
-    let active_lib_features = &tcx.features().declared_lib_features;
-    let active_lang_features = &tcx.features().declared_lang_features;
-
-    // Put the active features into a map for quick lookup.
-    index.active_features = active_lib_features
-        .iter()
-        .map(|&(s, ..)| s)
-        .chain(active_lang_features.iter().map(|&(s, ..)| s))
-        .collect();
 
     {
         let mut annotator = Annotator {

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1122,7 +1122,6 @@ symbols! {
         repr_packed,
         repr_simd,
         repr_transparent,
-        reserved_r9: "reserved-r9",
         residual,
         result,
         rhs,

--- a/compiler/rustc_target/src/asm/aarch64.rs
+++ b/compiler/rustc_target/src/asm/aarch64.rs
@@ -1,5 +1,5 @@
 use super::{InlineAsmArch, InlineAsmType};
-use crate::spec::{Target, RelocModel};
+use crate::spec::{RelocModel, Target};
 use rustc_data_structures::stable_set::FxHashSet;
 use rustc_macros::HashStable_Generic;
 use rustc_span::Symbol;
@@ -73,18 +73,18 @@ impl AArch64InlineAsmRegClass {
     }
 }
 
-pub fn reserved_x18(
+pub fn target_reserves_x18(target: &Target) -> bool {
+    target.os == "android" || target.is_like_fuchsia || target.is_like_osx || target.is_like_windows
+}
+
+fn reserved_x18(
     _arch: InlineAsmArch,
     _reloc_model: RelocModel,
     _target_features: &FxHashSet<Symbol>,
     target: &Target,
     _is_clobber: bool,
 ) -> Result<(), &'static str> {
-    if target.os == "android"
-        || target.is_like_fuchsia
-        || target.is_like_osx
-        || target.is_like_windows
-    {
+    if target_reserves_x18(target) {
         Err("x18 is a reserved register on this target")
     } else {
         Ok(())

--- a/compiler/rustc_target/src/asm/aarch64.rs
+++ b/compiler/rustc_target/src/asm/aarch64.rs
@@ -1,5 +1,5 @@
 use super::{InlineAsmArch, InlineAsmType};
-use crate::spec::Target;
+use crate::spec::{Target, RelocModel};
 use rustc_data_structures::stable_set::FxHashSet;
 use rustc_macros::HashStable_Generic;
 use rustc_span::Symbol;
@@ -75,6 +75,7 @@ impl AArch64InlineAsmRegClass {
 
 pub fn reserved_x18(
     _arch: InlineAsmArch,
+    _reloc_model: RelocModel,
     _target_features: &FxHashSet<Symbol>,
     target: &Target,
     _is_clobber: bool,

--- a/compiler/rustc_target/src/asm/bpf.rs
+++ b/compiler/rustc_target/src/asm/bpf.rs
@@ -1,7 +1,6 @@
-use super::{InlineAsmArch, InlineAsmType, Target};
-use rustc_data_structures::stable_set::FxHashSet;
+use super::{InlineAsmArch, InlineAsmType};
 use rustc_macros::HashStable_Generic;
-use rustc_span::{sym, Symbol};
+use rustc_span::Symbol;
 use std::fmt;
 
 def_reg_class! {
@@ -43,19 +42,6 @@ impl BpfInlineAsmRegClass {
     }
 }
 
-fn only_alu32(
-    _arch: InlineAsmArch,
-    target_features: &FxHashSet<Symbol>,
-    _target: &Target,
-    _is_clobber: bool,
-) -> Result<(), &'static str> {
-    if !target_features.contains(&sym::alu32) {
-        Err("register can't be used without the `alu32` target feature")
-    } else {
-        Ok(())
-    }
-}
-
 def_regs! {
     Bpf BpfInlineAsmReg BpfInlineAsmRegClass {
         r0: reg = ["r0"],
@@ -68,16 +54,16 @@ def_regs! {
         r7: reg = ["r7"],
         r8: reg = ["r8"],
         r9: reg = ["r9"],
-        w0: wreg = ["w0"] % only_alu32,
-        w1: wreg = ["w1"] % only_alu32,
-        w2: wreg = ["w2"] % only_alu32,
-        w3: wreg = ["w3"] % only_alu32,
-        w4: wreg = ["w4"] % only_alu32,
-        w5: wreg = ["w5"] % only_alu32,
-        w6: wreg = ["w6"] % only_alu32,
-        w7: wreg = ["w7"] % only_alu32,
-        w8: wreg = ["w8"] % only_alu32,
-        w9: wreg = ["w9"] % only_alu32,
+        w0: wreg = ["w0"],
+        w1: wreg = ["w1"],
+        w2: wreg = ["w2"],
+        w3: wreg = ["w3"],
+        w4: wreg = ["w4"],
+        w5: wreg = ["w5"],
+        w6: wreg = ["w6"],
+        w7: wreg = ["w7"],
+        w8: wreg = ["w8"],
+        w9: wreg = ["w9"],
 
         #error = ["r10", "w10"] =>
             "the stack pointer cannot be used as an operand for inline asm",

--- a/compiler/rustc_target/src/asm/mod.rs
+++ b/compiler/rustc_target/src/asm/mod.rs
@@ -1,5 +1,5 @@
-use crate::abi::Size;
 use crate::spec::Target;
+use crate::{abi::Size, spec::RelocModel};
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_macros::HashStable_Generic;
 use rustc_span::Symbol;
@@ -81,6 +81,7 @@ macro_rules! def_regs {
 
             pub fn parse(
                 _arch: super::InlineAsmArch,
+                _reloc_model: crate::spec::RelocModel,
                 _target_features: &rustc_data_structures::fx::FxHashSet<Symbol>,
                 _target: &crate::spec::Target,
                 _is_clobber: bool,
@@ -89,7 +90,7 @@ macro_rules! def_regs {
                 match name {
                     $(
                         $($alias)|* | $reg_name => {
-                            $($filter(_arch, _target_features, _target, _is_clobber)?;)?
+                            $($filter(_arch, _reloc_model, _target_features, _target, _is_clobber)?;)?
                             Ok(Self::$reg)
                         }
                     )*
@@ -103,6 +104,7 @@ macro_rules! def_regs {
 
         pub(super) fn fill_reg_map(
             _arch: super::InlineAsmArch,
+            _reloc_model: crate::spec::RelocModel,
             _target_features: &rustc_data_structures::fx::FxHashSet<Symbol>,
             _target: &crate::spec::Target,
             _map: &mut rustc_data_structures::fx::FxHashMap<
@@ -113,7 +115,7 @@ macro_rules! def_regs {
             #[allow(unused_imports)]
             use super::{InlineAsmReg, InlineAsmRegClass};
             $(
-                if $($filter(_arch, _target_features, _target, false).is_ok() &&)? true {
+                if $($filter(_arch, _reloc_model, _target_features, _target, false).is_ok() &&)? true {
                     if let Some(set) = _map.get_mut(&InlineAsmRegClass::$arch($arch_regclass::$class)) {
                         set.insert(InlineAsmReg::$arch($arch_reg::$reg));
                     }
@@ -297,6 +299,7 @@ impl InlineAsmReg {
 
     pub fn parse(
         arch: InlineAsmArch,
+        reloc_model: RelocModel,
         target_features: &FxHashSet<Symbol>,
         target: &Target,
         is_clobber: bool,
@@ -307,75 +310,75 @@ impl InlineAsmReg {
         let name = name.as_str();
         Ok(match arch {
             InlineAsmArch::X86 | InlineAsmArch::X86_64 => {
-                Self::X86(X86InlineAsmReg::parse(arch, target_features, target, is_clobber, name)?)
+                Self::X86(X86InlineAsmReg::parse(arch, reloc_model,target_features, target, is_clobber, name)?)
             }
             InlineAsmArch::Arm => {
-                Self::Arm(ArmInlineAsmReg::parse(arch, target_features, target, is_clobber, name)?)
+                Self::Arm(ArmInlineAsmReg::parse(arch, reloc_model,target_features, target, is_clobber, name)?)
             }
             InlineAsmArch::AArch64 => Self::AArch64(AArch64InlineAsmReg::parse(
                 arch,
-                target_features,
+                reloc_model,target_features,
                 target,
                 is_clobber,
                 name,
             )?),
             InlineAsmArch::RiscV32 | InlineAsmArch::RiscV64 => Self::RiscV(
-                RiscVInlineAsmReg::parse(arch, target_features, target, is_clobber, name)?,
+                RiscVInlineAsmReg::parse(arch, reloc_model,target_features, target, is_clobber, name)?,
             ),
             InlineAsmArch::Nvptx64 => Self::Nvptx(NvptxInlineAsmReg::parse(
                 arch,
-                target_features,
+                reloc_model,target_features,
                 target,
                 is_clobber,
                 name,
             )?),
             InlineAsmArch::PowerPC | InlineAsmArch::PowerPC64 => Self::PowerPC(
-                PowerPCInlineAsmReg::parse(arch, target_features, target, is_clobber, name)?,
+                PowerPCInlineAsmReg::parse(arch, reloc_model,target_features, target, is_clobber, name)?,
             ),
             InlineAsmArch::Hexagon => Self::Hexagon(HexagonInlineAsmReg::parse(
                 arch,
-                target_features,
+                reloc_model,target_features,
                 target,
                 is_clobber,
                 name,
             )?),
             InlineAsmArch::Mips | InlineAsmArch::Mips64 => Self::Mips(MipsInlineAsmReg::parse(
                 arch,
-                target_features,
+                reloc_model,target_features,
                 target,
                 is_clobber,
                 name,
             )?),
             InlineAsmArch::S390x => Self::S390x(S390xInlineAsmReg::parse(
                 arch,
-                target_features,
+                reloc_model,target_features,
                 target,
                 is_clobber,
                 name,
             )?),
             InlineAsmArch::SpirV => Self::SpirV(SpirVInlineAsmReg::parse(
                 arch,
-                target_features,
+                reloc_model,target_features,
                 target,
                 is_clobber,
                 name,
             )?),
             InlineAsmArch::Wasm32 | InlineAsmArch::Wasm64 => Self::Wasm(WasmInlineAsmReg::parse(
                 arch,
-                target_features,
+                reloc_model,target_features,
                 target,
                 is_clobber,
                 name,
             )?),
             InlineAsmArch::Bpf => {
-                Self::Bpf(BpfInlineAsmReg::parse(arch, target_features, target, is_clobber, name)?)
+                Self::Bpf(BpfInlineAsmReg::parse(arch, reloc_model,target_features, target, is_clobber, name)?)
             }
             InlineAsmArch::Avr => {
-                Self::Avr(AvrInlineAsmReg::parse(arch, target_features, target, is_clobber, name)?)
+                Self::Avr(AvrInlineAsmReg::parse(arch, reloc_model,target_features, target, is_clobber, name)?)
             }
             InlineAsmArch::Msp430 => Self::Msp430(Msp430InlineAsmReg::parse(
                 arch,
-                target_features,
+                reloc_model,target_features,
                 target,
                 is_clobber,
                 name,
@@ -749,78 +752,79 @@ impl fmt::Display for InlineAsmType {
 // falling back to an external assembler.
 pub fn allocatable_registers(
     arch: InlineAsmArch,
+    reloc_model: RelocModel,
     target_features: &FxHashSet<Symbol>,
     target: &crate::spec::Target,
 ) -> FxHashMap<InlineAsmRegClass, FxHashSet<InlineAsmReg>> {
     match arch {
         InlineAsmArch::X86 | InlineAsmArch::X86_64 => {
             let mut map = x86::regclass_map();
-            x86::fill_reg_map(arch, target_features, target, &mut map);
+            x86::fill_reg_map(arch, reloc_model, target_features, target, &mut map);
             map
         }
         InlineAsmArch::Arm => {
             let mut map = arm::regclass_map();
-            arm::fill_reg_map(arch, target_features, target, &mut map);
+            arm::fill_reg_map(arch, reloc_model, target_features, target, &mut map);
             map
         }
         InlineAsmArch::AArch64 => {
             let mut map = aarch64::regclass_map();
-            aarch64::fill_reg_map(arch, target_features, target, &mut map);
+            aarch64::fill_reg_map(arch, reloc_model, target_features, target, &mut map);
             map
         }
         InlineAsmArch::RiscV32 | InlineAsmArch::RiscV64 => {
             let mut map = riscv::regclass_map();
-            riscv::fill_reg_map(arch, target_features, target, &mut map);
+            riscv::fill_reg_map(arch, reloc_model, target_features, target, &mut map);
             map
         }
         InlineAsmArch::Nvptx64 => {
             let mut map = nvptx::regclass_map();
-            nvptx::fill_reg_map(arch, target_features, target, &mut map);
+            nvptx::fill_reg_map(arch, reloc_model, target_features, target, &mut map);
             map
         }
         InlineAsmArch::PowerPC | InlineAsmArch::PowerPC64 => {
             let mut map = powerpc::regclass_map();
-            powerpc::fill_reg_map(arch, target_features, target, &mut map);
+            powerpc::fill_reg_map(arch, reloc_model, target_features, target, &mut map);
             map
         }
         InlineAsmArch::Hexagon => {
             let mut map = hexagon::regclass_map();
-            hexagon::fill_reg_map(arch, target_features, target, &mut map);
+            hexagon::fill_reg_map(arch, reloc_model, target_features, target, &mut map);
             map
         }
         InlineAsmArch::Mips | InlineAsmArch::Mips64 => {
             let mut map = mips::regclass_map();
-            mips::fill_reg_map(arch, target_features, target, &mut map);
+            mips::fill_reg_map(arch, reloc_model, target_features, target, &mut map);
             map
         }
         InlineAsmArch::S390x => {
             let mut map = s390x::regclass_map();
-            s390x::fill_reg_map(arch, target_features, target, &mut map);
+            s390x::fill_reg_map(arch, reloc_model, target_features, target, &mut map);
             map
         }
         InlineAsmArch::SpirV => {
             let mut map = spirv::regclass_map();
-            spirv::fill_reg_map(arch, target_features, target, &mut map);
+            spirv::fill_reg_map(arch, reloc_model, target_features, target, &mut map);
             map
         }
         InlineAsmArch::Wasm32 | InlineAsmArch::Wasm64 => {
             let mut map = wasm::regclass_map();
-            wasm::fill_reg_map(arch, target_features, target, &mut map);
+            wasm::fill_reg_map(arch, reloc_model, target_features, target, &mut map);
             map
         }
         InlineAsmArch::Bpf => {
             let mut map = bpf::regclass_map();
-            bpf::fill_reg_map(arch, target_features, target, &mut map);
+            bpf::fill_reg_map(arch, reloc_model, target_features, target, &mut map);
             map
         }
         InlineAsmArch::Avr => {
             let mut map = avr::regclass_map();
-            avr::fill_reg_map(arch, target_features, target, &mut map);
+            avr::fill_reg_map(arch, reloc_model, target_features, target, &mut map);
             map
         }
         InlineAsmArch::Msp430 => {
             let mut map = msp430::regclass_map();
-            msp430::fill_reg_map(arch, target_features, target, &mut map);
+            msp430::fill_reg_map(arch, reloc_model, target_features, target, &mut map);
             map
         }
     }
@@ -853,6 +857,7 @@ impl InlineAsmClobberAbi {
     /// clobber ABIs for the target.
     pub fn parse(
         arch: InlineAsmArch,
+        reloc_model: RelocModel,
         target_features: &FxHashSet<Symbol>,
         target: &Target,
         name: Symbol,
@@ -878,7 +883,7 @@ impl InlineAsmClobberAbi {
             },
             InlineAsmArch::AArch64 => match name {
                 "C" | "system" | "efiapi" => {
-                    Ok(if aarch64::reserved_x18(arch, target_features, target, true).is_err() {
+                    Ok(if aarch64::reserved_x18(arch, reloc_model, target_features, target, true).is_err() {
                         InlineAsmClobberAbi::AArch64NoX18
                     } else {
                         InlineAsmClobberAbi::AArch64

--- a/compiler/rustc_target/src/asm/riscv.rs
+++ b/compiler/rustc_target/src/asm/riscv.rs
@@ -1,5 +1,5 @@
 use super::{InlineAsmArch, InlineAsmType};
-use crate::spec::{Target, RelocModel};
+use crate::spec::{RelocModel, Target};
 use rustc_data_structures::stable_set::FxHashSet;
 use rustc_macros::HashStable_Generic;
 use rustc_span::{sym, Symbol};

--- a/compiler/rustc_target/src/asm/riscv.rs
+++ b/compiler/rustc_target/src/asm/riscv.rs
@@ -1,5 +1,5 @@
 use super::{InlineAsmArch, InlineAsmType};
-use crate::spec::Target;
+use crate::spec::{Target, RelocModel};
 use rustc_data_structures::stable_set::FxHashSet;
 use rustc_macros::HashStable_Generic;
 use rustc_span::{sym, Symbol};
@@ -54,6 +54,7 @@ impl RiscVInlineAsmRegClass {
 
 fn not_e(
     _arch: InlineAsmArch,
+    _reloc_model: RelocModel,
     target_features: &FxHashSet<Symbol>,
     _target: &Target,
     _is_clobber: bool,

--- a/compiler/rustc_target/src/asm/x86.rs
+++ b/compiler/rustc_target/src/asm/x86.rs
@@ -1,5 +1,5 @@
 use super::{InlineAsmArch, InlineAsmType};
-use crate::spec::{Target, RelocModel};
+use crate::spec::{RelocModel, Target};
 use rustc_data_structures::stable_set::FxHashSet;
 use rustc_macros::HashStable_Generic;
 use rustc_span::Symbol;

--- a/compiler/rustc_target/src/asm/x86.rs
+++ b/compiler/rustc_target/src/asm/x86.rs
@@ -1,5 +1,5 @@
 use super::{InlineAsmArch, InlineAsmType};
-use crate::spec::Target;
+use crate::spec::{Target, RelocModel};
 use rustc_data_structures::stable_set::FxHashSet;
 use rustc_macros::HashStable_Generic;
 use rustc_span::Symbol;
@@ -139,6 +139,7 @@ impl X86InlineAsmRegClass {
 
 fn x86_64_only(
     arch: InlineAsmArch,
+    _reloc_model: RelocModel,
     _target_features: &FxHashSet<Symbol>,
     _target: &Target,
     _is_clobber: bool,
@@ -152,6 +153,7 @@ fn x86_64_only(
 
 fn high_byte(
     arch: InlineAsmArch,
+    _reloc_model: RelocModel,
     _target_features: &FxHashSet<Symbol>,
     _target: &Target,
     _is_clobber: bool,
@@ -164,6 +166,7 @@ fn high_byte(
 
 fn rbx_reserved(
     arch: InlineAsmArch,
+    _reloc_model: RelocModel,
     _target_features: &FxHashSet<Symbol>,
     _target: &Target,
     _is_clobber: bool,
@@ -179,6 +182,7 @@ fn rbx_reserved(
 
 fn esi_reserved(
     arch: InlineAsmArch,
+    _reloc_model: RelocModel,
     _target_features: &FxHashSet<Symbol>,
     _target: &Target,
     _is_clobber: bool,

--- a/compiler/rustc_typeck/src/collect.rs
+++ b/compiler/rustc_typeck/src/collect.rs
@@ -88,6 +88,7 @@ pub fn provide(providers: &mut Providers) {
         static_mutability,
         generator_kind,
         codegen_fn_attrs,
+        asm_target_features,
         collect_mod_item_types,
         should_inherit_track_caller,
         ..*providers
@@ -3265,6 +3266,24 @@ fn codegen_fn_attrs(tcx: TyCtxt<'_>, id: DefId) -> CodegenFnAttrs {
     }
 
     codegen_fn_attrs
+}
+
+/// Computes the set of target features used in a function for the purposes of
+/// inline assembly.
+fn asm_target_features<'tcx>(tcx: TyCtxt<'tcx>, id: DefId) -> &'tcx FxHashSet<Symbol> {
+    let mut target_features = tcx.sess.target_features.clone();
+    let attrs = tcx.codegen_fn_attrs(id);
+    target_features.extend(&attrs.target_features);
+    match attrs.instruction_set {
+        None => {}
+        Some(InstructionSetAttr::ArmA32) => {
+            target_features.remove(&sym::thumb_mode);
+        }
+        Some(InstructionSetAttr::ArmT32) => {
+            target_features.insert(sym::thumb_mode);
+        }
+    }
+    tcx.arena.alloc(target_features)
 }
 
 /// Checks if the provided DefId is a method in a trait impl for a trait which has track_caller

--- a/library/core/src/future/future.rs
+++ b/library/core/src/future/future.rs
@@ -5,7 +5,7 @@ use crate::ops;
 use crate::pin::Pin;
 use crate::task::{Context, Poll};
 
-/// A future represents an asynchronous computation.
+/// A future represents an asynchronous computation obtained by use of [`async`].
 ///
 /// A future is a value that might not have finished computing yet. This kind of
 /// "asynchronous value" makes it possible for a thread to continue doing useful
@@ -23,6 +23,7 @@ use crate::task::{Context, Poll};
 /// When using a future, you generally won't call `poll` directly, but instead
 /// `.await` the value.
 ///
+/// [`async`]: ../../std/keyword.async.html
 /// [`Waker`]: crate::task::Waker
 #[doc(notable_trait)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]

--- a/library/core/src/future/mod.rs
+++ b/library/core/src/future/mod.rs
@@ -1,6 +1,13 @@
 #![stable(feature = "futures_api", since = "1.36.0")]
 
-//! Asynchronous values.
+//! Asynchronous basic functionality.
+//!
+//! Please see the fundamental [`async`] and [`await`] keywords and the [async book]
+//! for more information on asynchronous programming in Rust.
+//!
+//! [`async`]: ../../std/keyword.async.html
+//! [`await`]: ../../std/keyword.await.html
+//! [async book]: https://rust-lang.github.io/async-book/
 
 use crate::{
     ops::{Generator, GeneratorState},

--- a/library/std/src/keyword_docs.rs
+++ b/library/std/src/keyword_docs.rs
@@ -2203,17 +2203,18 @@ mod where_keyword {}
 ///
 /// Use `async` in front of `fn`, `closure`, or a `block` to turn the marked code into a `Future`.
 /// As such the code will not be run immediately, but will only be evaluated when the returned
-/// future is `.await`ed.
+/// future is [`.await`]ed.
 ///
-/// We have written an [async book] detailing async/await and trade-offs compared to using threads.
+/// We have written an [async book] detailing `async`/`await` and trade-offs compared to using threads.
 ///
 /// ## Editions
 ///
 /// `async` is a keyword from the 2018 edition onwards.
 ///
-/// It is available for use in stable rust from version 1.39 onwards.
+/// It is available for use in stable Rust from version 1.39 onwards.
 ///
 /// [`Future`]: future::Future
+/// [`.await`]: ../std/keyword.await.html
 /// [async book]: https://rust-lang.github.io/async-book/
 mod async_keyword {}
 
@@ -2221,19 +2222,20 @@ mod async_keyword {}
 //
 /// Suspend execution until the result of a [`Future`] is ready.
 ///
-/// `.await`ing a future will suspend the current function's execution until the `executor`
+/// `.await`ing a future will suspend the current function's execution until the executor
 /// has run the future to completion.
 ///
-/// Read the [async book] for details on how async/await and executors work.
+/// Read the [async book] for details on how [`async`]/`await` and executors work.
 ///
 /// ## Editions
 ///
 /// `await` is a keyword from the 2018 edition onwards.
 ///
-/// It is available for use in stable rust from version 1.39 onwards.
+/// It is available for use in stable Rust from version 1.39 onwards.
 ///
 /// [`Future`]: future::Future
 /// [async book]: https://rust-lang.github.io/async-book/
+/// [`async`]: ../std/keyword.async.html
 mod await_keyword {}
 
 #[doc(keyword = "dyn")]

--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -17,7 +17,6 @@ use std::process::{exit, Command, Stdio};
 use std::str;
 
 use build_helper::{output, t, up_to_date};
-use filetime::FileTime;
 use serde::Deserialize;
 
 use crate::builder::Cargo;
@@ -1334,8 +1333,9 @@ pub fn run_cargo(
                     .map(|s| s.starts_with('-') && s.ends_with(&extension[..]))
                     .unwrap_or(false)
         });
-        let max = candidates
-            .max_by_key(|&&(_, _, ref metadata)| FileTime::from_last_modification_time(metadata));
+        let max = candidates.max_by_key(|&&(_, _, ref metadata)| {
+            metadata.modified().expect("mtime should be available on all relevant OSes")
+        });
         let path_to_add = match max {
             Some(triple) => triple.0.to_str().unwrap(),
             None => panic!("no output generated for {:?} {:?}", prefix, extension),

--- a/src/librustdoc/clean/utils.rs
+++ b/src/librustdoc/clean/utils.rs
@@ -302,11 +302,7 @@ fn print_const_with_custom_print_scalar(tcx: TyCtxt<'_>, ct: ty::Const<'_>) -> S
     // For all other types, fallback to the original `pretty_print_const`.
     match (ct.val(), ct.ty().kind()) {
         (ty::ConstKind::Value(ConstValue::Scalar(int)), ty::Uint(ui)) => {
-            format!(
-                "{}{}",
-                format_integer_with_underscore_sep(&int.rustdoc_display()),
-                ui.name_str()
-            )
+            format!("{}{}", format_integer_with_underscore_sep(&int.to_string()), ui.name_str())
         }
         (ty::ConstKind::Value(ConstValue::Scalar(int)), ty::Int(i)) => {
             let ty = tcx.lift(ct.ty()).unwrap();

--- a/src/test/ui/alloc-error/alloc-error-handler-bad-signature-1.rs
+++ b/src/test/ui/alloc-error/alloc-error-handler-bad-signature-1.rs
@@ -1,6 +1,6 @@
 // compile-flags:-C panic=abort
 
-#![feature(alloc_error_handler, panic_handler)]
+#![feature(alloc_error_handler)]
 #![no_std]
 #![no_main]
 

--- a/src/test/ui/alloc-error/alloc-error-handler-bad-signature-2.rs
+++ b/src/test/ui/alloc-error/alloc-error-handler-bad-signature-2.rs
@@ -1,6 +1,6 @@
 // compile-flags:-C panic=abort
 
-#![feature(alloc_error_handler, panic_handler)]
+#![feature(alloc_error_handler)]
 #![no_std]
 #![no_main]
 

--- a/src/test/ui/alloc-error/alloc-error-handler-bad-signature-3.rs
+++ b/src/test/ui/alloc-error/alloc-error-handler-bad-signature-3.rs
@@ -1,6 +1,6 @@
 // compile-flags:-C panic=abort
 
-#![feature(alloc_error_handler, panic_handler)]
+#![feature(alloc_error_handler)]
 #![no_std]
 #![no_main]
 

--- a/src/test/ui/asm/issue-85247.rs
+++ b/src/test/ui/asm/issue-85247.rs
@@ -1,0 +1,26 @@
+// revisions: ropi rwpi
+
+// [ropi] compile-flags: --target armv7-unknown-linux-gnueabihf -C relocation-model=ropi
+// [rwpi] compile-flags: --target armv7-unknown-linux-gnueabihf -C relocation-model=rwpi
+// [ropi] needs-llvm-components: arm
+// [rwpi] needs-llvm-components: arm
+// [ropi] build-pass
+
+#![feature(no_core, lang_items, rustc_attrs)]
+#![no_core]
+#![crate_type = "rlib"]
+
+#[rustc_builtin_macro]
+macro_rules! asm {
+    () => {};
+}
+#[lang = "sized"]
+trait Sized {}
+
+// R9 is reserved as the RWPI base register
+fn main() {
+    unsafe {
+        asm!("", out("r9") _);
+        //[rwpi]~^ cannot use register `r9`
+    }
+}

--- a/src/test/ui/asm/issue-85247.rwpi.stderr
+++ b/src/test/ui/asm/issue-85247.rwpi.stderr
@@ -1,0 +1,8 @@
+error: cannot use register `r9`: the RWPI static base register (r9) cannot be used as an operand for inline asm
+  --> $DIR/issue-85247.rs:23:18
+   |
+LL |         asm!("", out("r9") _);
+   |                  ^^^^^^^^^^^
+
+error: aborting due to previous error
+

--- a/src/test/ui/asm/issue-92378.rs
+++ b/src/test/ui/asm/issue-92378.rs
@@ -1,0 +1,30 @@
+// compile-flags: --target armv5te-unknown-linux-gnueabi
+// needs-llvm-components: arm
+// build-pass
+
+#![feature(no_core, lang_items, rustc_attrs, isa_attribute)]
+#![no_core]
+#![crate_type = "rlib"]
+
+#[rustc_builtin_macro]
+macro_rules! asm {
+    () => {};
+}
+#[lang = "sized"]
+trait Sized {}
+
+// ARM uses R11 for the frame pointer, make sure R7 is usable.
+#[instruction_set(arm::a32)]
+pub fn arm() {
+    unsafe {
+        asm!("", out("r7") _);
+    }
+}
+
+// Thumb uses R7 for the frame pointer, make sure R11 is usable.
+#[instruction_set(arm::t32)]
+pub fn thumb() {
+    unsafe {
+        asm!("", out("r11") _);
+    }
+}

--- a/src/test/ui/asm/naked-functions.rs
+++ b/src/test/ui/asm/naked-functions.rs
@@ -4,7 +4,6 @@
 // ignore-wasm32
 
 #![feature(naked_functions)]
-#![feature(or_patterns)]
 #![feature(asm_const, asm_sym, asm_unwind)]
 #![crate_type = "lib"]
 

--- a/src/test/ui/asm/naked-functions.stderr
+++ b/src/test/ui/asm/naked-functions.stderr
@@ -1,35 +1,35 @@
 error: asm with the `pure` option must have at least one output
-  --> $DIR/naked-functions.rs:111:14
+  --> $DIR/naked-functions.rs:110:14
    |
 LL |     asm!("", options(readonly, nostack), options(pure));
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^
 
 error: patterns not allowed in naked function parameters
-  --> $DIR/naked-functions.rs:21:5
+  --> $DIR/naked-functions.rs:20:5
    |
 LL |     mut a: u32,
    |     ^^^^^
 
 error: patterns not allowed in naked function parameters
-  --> $DIR/naked-functions.rs:23:5
+  --> $DIR/naked-functions.rs:22:5
    |
 LL |     &b: &i32,
    |     ^^
 
 error: patterns not allowed in naked function parameters
-  --> $DIR/naked-functions.rs:25:6
+  --> $DIR/naked-functions.rs:24:6
    |
 LL |     (None | Some(_)): Option<std::ptr::NonNull<u8>>,
    |      ^^^^^^^^^^^^^^
 
 error: patterns not allowed in naked function parameters
-  --> $DIR/naked-functions.rs:27:5
+  --> $DIR/naked-functions.rs:26:5
    |
 LL |     P { x, y }: P,
    |     ^^^^^^^^^^
 
 error: referencing function parameters is not allowed in naked functions
-  --> $DIR/naked-functions.rs:36:5
+  --> $DIR/naked-functions.rs:35:5
    |
 LL |     a + 1
    |     ^
@@ -37,7 +37,7 @@ LL |     a + 1
    = help: follow the calling convention in asm block to use parameters
 
 error[E0787]: naked functions must contain a single asm block
-  --> $DIR/naked-functions.rs:34:1
+  --> $DIR/naked-functions.rs:33:1
    |
 LL | / pub unsafe extern "C" fn inc(a: u32) -> u32 {
 LL | |
@@ -48,7 +48,7 @@ LL | | }
    | |_^
 
 error: referencing function parameters is not allowed in naked functions
-  --> $DIR/naked-functions.rs:42:31
+  --> $DIR/naked-functions.rs:41:31
    |
 LL |     asm!("/* {0} */", in(reg) a, options(noreturn));
    |                               ^
@@ -56,13 +56,13 @@ LL |     asm!("/* {0} */", in(reg) a, options(noreturn));
    = help: follow the calling convention in asm block to use parameters
 
 error[E0787]: only `const` and `sym` operands are supported in naked functions
-  --> $DIR/naked-functions.rs:42:23
+  --> $DIR/naked-functions.rs:41:23
    |
 LL |     asm!("/* {0} */", in(reg) a, options(noreturn));
    |                       ^^^^^^^^^
 
 error[E0787]: naked functions must contain a single asm block
-  --> $DIR/naked-functions.rs:48:1
+  --> $DIR/naked-functions.rs:47:1
    |
 LL | / pub unsafe extern "C" fn inc_closure(a: u32) -> u32 {
 LL | |
@@ -72,7 +72,7 @@ LL | | }
    | |_^
 
 error[E0787]: only `const` and `sym` operands are supported in naked functions
-  --> $DIR/naked-functions.rs:65:10
+  --> $DIR/naked-functions.rs:64:10
    |
 LL |          in(reg) a,
    |          ^^^^^^^^^
@@ -87,7 +87,7 @@ LL |          out(reg) e,
    |          ^^^^^^^^^^
 
 error[E0787]: asm in naked functions must use `noreturn` option
-  --> $DIR/naked-functions.rs:63:5
+  --> $DIR/naked-functions.rs:62:5
    |
 LL | /     asm!("/* {0} {1} {2} {3} {4} {5} {6} */",
 LL | |
@@ -99,7 +99,7 @@ LL | |     );
    | |_____^
 
 error[E0787]: naked functions must contain a single asm block
-  --> $DIR/naked-functions.rs:54:1
+  --> $DIR/naked-functions.rs:53:1
    |
 LL | / pub unsafe extern "C" fn unsupported_operands() {
 LL | |
@@ -119,7 +119,7 @@ LL | | }
    | |_^
 
 error[E0787]: naked functions must contain a single asm block
-  --> $DIR/naked-functions.rs:77:1
+  --> $DIR/naked-functions.rs:76:1
    |
 LL | / pub extern "C" fn missing_assembly() {
 LL | |
@@ -127,25 +127,25 @@ LL | | }
    | |_^
 
 error[E0787]: asm in naked functions must use `noreturn` option
-  --> $DIR/naked-functions.rs:84:5
+  --> $DIR/naked-functions.rs:83:5
    |
 LL |     asm!("");
    |     ^^^^^^^^
 
 error[E0787]: asm in naked functions must use `noreturn` option
-  --> $DIR/naked-functions.rs:86:5
+  --> $DIR/naked-functions.rs:85:5
    |
 LL |     asm!("");
    |     ^^^^^^^^
 
 error[E0787]: asm in naked functions must use `noreturn` option
-  --> $DIR/naked-functions.rs:88:5
+  --> $DIR/naked-functions.rs:87:5
    |
 LL |     asm!("");
    |     ^^^^^^^^
 
 error[E0787]: naked functions must contain a single asm block
-  --> $DIR/naked-functions.rs:82:1
+  --> $DIR/naked-functions.rs:81:1
    |
 LL | / pub extern "C" fn too_many_asm_blocks() {
 LL | |
@@ -163,7 +163,7 @@ LL | | }
    | |_^
 
 error: referencing function parameters is not allowed in naked functions
-  --> $DIR/naked-functions.rs:97:11
+  --> $DIR/naked-functions.rs:96:11
    |
 LL |         *&y
    |           ^
@@ -171,7 +171,7 @@ LL |         *&y
    = help: follow the calling convention in asm block to use parameters
 
 error[E0787]: naked functions must contain a single asm block
-  --> $DIR/naked-functions.rs:95:5
+  --> $DIR/naked-functions.rs:94:5
    |
 LL | /     pub extern "C" fn inner(y: usize) -> usize {
 LL | |
@@ -182,31 +182,31 @@ LL | |     }
    | |_____^
 
 error[E0787]: asm options unsupported in naked functions: `nomem`, `preserves_flags`
-  --> $DIR/naked-functions.rs:105:5
+  --> $DIR/naked-functions.rs:104:5
    |
 LL |     asm!("", options(nomem, preserves_flags, noreturn));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0787]: asm options unsupported in naked functions: `nostack`, `pure`, `readonly`
-  --> $DIR/naked-functions.rs:111:5
+  --> $DIR/naked-functions.rs:110:5
    |
 LL |     asm!("", options(readonly, nostack), options(pure));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0787]: asm in naked functions must use `noreturn` option
-  --> $DIR/naked-functions.rs:111:5
+  --> $DIR/naked-functions.rs:110:5
    |
 LL |     asm!("", options(readonly, nostack), options(pure));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0787]: asm options unsupported in naked functions: `may_unwind`
-  --> $DIR/naked-functions.rs:119:5
+  --> $DIR/naked-functions.rs:118:5
    |
 LL |     asm!("", options(noreturn, may_unwind));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: Rust ABI is unsupported in naked functions
-  --> $DIR/naked-functions.rs:124:15
+  --> $DIR/naked-functions.rs:123:15
    |
 LL | pub unsafe fn default_abi() {
    |               ^^^^^^^^^^^
@@ -214,43 +214,43 @@ LL | pub unsafe fn default_abi() {
    = note: `#[warn(undefined_naked_function_abi)]` on by default
 
 warning: Rust ABI is unsupported in naked functions
-  --> $DIR/naked-functions.rs:130:15
+  --> $DIR/naked-functions.rs:129:15
    |
 LL | pub unsafe fn rust_abi() {
    |               ^^^^^^^^
 
 error: naked functions cannot be inlined
-  --> $DIR/naked-functions.rs:170:1
+  --> $DIR/naked-functions.rs:169:1
    |
 LL | #[inline]
    | ^^^^^^^^^
 
 error: naked functions cannot be inlined
-  --> $DIR/naked-functions.rs:177:1
+  --> $DIR/naked-functions.rs:176:1
    |
 LL | #[inline(always)]
    | ^^^^^^^^^^^^^^^^^
 
 error: naked functions cannot be inlined
-  --> $DIR/naked-functions.rs:184:1
+  --> $DIR/naked-functions.rs:183:1
    |
 LL | #[inline(never)]
    | ^^^^^^^^^^^^^^^^
 
 error: naked functions cannot be inlined
-  --> $DIR/naked-functions.rs:191:1
+  --> $DIR/naked-functions.rs:190:1
    |
 LL | #[inline]
    | ^^^^^^^^^
 
 error: naked functions cannot be inlined
-  --> $DIR/naked-functions.rs:193:1
+  --> $DIR/naked-functions.rs:192:1
    |
 LL | #[inline(always)]
    | ^^^^^^^^^^^^^^^^^
 
 error: naked functions cannot be inlined
-  --> $DIR/naked-functions.rs:195:1
+  --> $DIR/naked-functions.rs:194:1
    |
 LL | #[inline(never)]
    | ^^^^^^^^^^^^^^^^

--- a/src/test/ui/asm/x86_64/bad-reg.rs
+++ b/src/test/ui/asm/x86_64/bad-reg.rs
@@ -31,8 +31,6 @@ fn main() {
         //~^ ERROR invalid register `ip`: the instruction pointer cannot be used as an operand
         asm!("", in("k0") foo);
         //~^ ERROR invalid register `k0`: the k0 AVX mask register cannot be used as an operand
-        asm!("", in("ah") foo);
-        //~^ ERROR invalid register `ah`: high byte registers cannot be used as an operand
 
         asm!("", in("st(2)") foo);
         //~^ ERROR register class `x87_reg` can only be used as a clobber, not as an input or output

--- a/src/test/ui/asm/x86_64/bad-reg.stderr
+++ b/src/test/ui/asm/x86_64/bad-reg.stderr
@@ -70,50 +70,44 @@ error: invalid register `k0`: the k0 AVX mask register cannot be used as an oper
 LL |         asm!("", in("k0") foo);
    |                  ^^^^^^^^^^^^
 
-error: invalid register `ah`: high byte registers cannot be used as an operand on x86_64
-  --> $DIR/bad-reg.rs:34:18
-   |
-LL |         asm!("", in("ah") foo);
-   |                  ^^^^^^^^^^^^
-
 error: register class `x87_reg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:37:18
+  --> $DIR/bad-reg.rs:35:18
    |
 LL |         asm!("", in("st(2)") foo);
    |                  ^^^^^^^^^^^^^^^
 
 error: register class `mmx_reg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:39:18
+  --> $DIR/bad-reg.rs:37:18
    |
 LL |         asm!("", in("mm0") foo);
    |                  ^^^^^^^^^^^^^
 
 error: register class `x87_reg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:43:20
+  --> $DIR/bad-reg.rs:41:20
    |
 LL |         asm!("{}", in(x87_reg) foo);
    |                    ^^^^^^^^^^^^^^^
 
 error: register class `mmx_reg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:45:20
+  --> $DIR/bad-reg.rs:43:20
    |
 LL |         asm!("{}", in(mmx_reg) foo);
    |                    ^^^^^^^^^^^^^^^
 
 error: register class `x87_reg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:47:20
+  --> $DIR/bad-reg.rs:45:20
    |
 LL |         asm!("{}", out(x87_reg) _);
    |                    ^^^^^^^^^^^^^^
 
 error: register class `mmx_reg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:49:20
+  --> $DIR/bad-reg.rs:47:20
    |
 LL |         asm!("{}", out(mmx_reg) _);
    |                    ^^^^^^^^^^^^^^
 
 error: register `al` conflicts with register `ax`
-  --> $DIR/bad-reg.rs:55:33
+  --> $DIR/bad-reg.rs:53:33
    |
 LL |         asm!("", in("eax") foo, in("al") bar);
    |                  -------------  ^^^^^^^^^^^^ register `al`
@@ -121,7 +115,7 @@ LL |         asm!("", in("eax") foo, in("al") bar);
    |                  register `ax`
 
 error: register `ax` conflicts with register `ax`
-  --> $DIR/bad-reg.rs:57:33
+  --> $DIR/bad-reg.rs:55:33
    |
 LL |         asm!("", in("rax") foo, out("rax") bar);
    |                  -------------  ^^^^^^^^^^^^^^ register `ax`
@@ -129,13 +123,13 @@ LL |         asm!("", in("rax") foo, out("rax") bar);
    |                  register `ax`
    |
 help: use `lateout` instead of `out` to avoid conflict
-  --> $DIR/bad-reg.rs:57:18
+  --> $DIR/bad-reg.rs:55:18
    |
 LL |         asm!("", in("rax") foo, out("rax") bar);
    |                  ^^^^^^^^^^^^^
 
 error: register `ymm0` conflicts with register `xmm0`
-  --> $DIR/bad-reg.rs:60:34
+  --> $DIR/bad-reg.rs:58:34
    |
 LL |         asm!("", in("xmm0") foo, in("ymm0") bar);
    |                  --------------  ^^^^^^^^^^^^^^ register `ymm0`
@@ -143,7 +137,7 @@ LL |         asm!("", in("xmm0") foo, in("ymm0") bar);
    |                  register `xmm0`
 
 error: register `ymm0` conflicts with register `xmm0`
-  --> $DIR/bad-reg.rs:62:34
+  --> $DIR/bad-reg.rs:60:34
    |
 LL |         asm!("", in("xmm0") foo, out("ymm0") bar);
    |                  --------------  ^^^^^^^^^^^^^^^ register `ymm0`
@@ -151,10 +145,10 @@ LL |         asm!("", in("xmm0") foo, out("ymm0") bar);
    |                  register `xmm0`
    |
 help: use `lateout` instead of `out` to avoid conflict
-  --> $DIR/bad-reg.rs:62:18
+  --> $DIR/bad-reg.rs:60:18
    |
 LL |         asm!("", in("xmm0") foo, out("ymm0") bar);
    |                  ^^^^^^^^^^^^^^
 
-error: aborting due to 21 previous errors
+error: aborting due to 20 previous errors
 

--- a/src/test/ui/associated-consts/associated-const-in-trait.rs
+++ b/src/test/ui/associated-consts/associated-const-in-trait.rs
@@ -1,7 +1,5 @@
 // #29924
 
-#![feature(associated_consts)]
-
 trait Trait {
     const N: usize;
 }

--- a/src/test/ui/associated-consts/associated-const-in-trait.stderr
+++ b/src/test/ui/associated-consts/associated-const-in-trait.stderr
@@ -1,11 +1,11 @@
 error[E0038]: the trait `Trait` cannot be made into an object
-  --> $DIR/associated-const-in-trait.rs:9:6
+  --> $DIR/associated-const-in-trait.rs:7:6
    |
 LL | impl dyn Trait {
    |      ^^^^^^^^^ `Trait` cannot be made into an object
    |
 note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
-  --> $DIR/associated-const-in-trait.rs:6:11
+  --> $DIR/associated-const-in-trait.rs:4:11
    |
 LL | trait Trait {
    |       ----- this trait cannot be made into an object...

--- a/src/test/ui/async-await/try-on-option-in-async.rs
+++ b/src/test/ui/async-await/try-on-option-in-async.rs
@@ -1,4 +1,4 @@
-#![feature(try_trait, async_closure)]
+#![feature(async_closure)]
 // edition:2018
 fn main() {}
 

--- a/src/test/ui/attributes/const-stability-on-macro.rs
+++ b/src/test/ui/attributes/const-stability-on-macro.rs
@@ -1,3 +1,6 @@
+#![feature(staged_api)]
+#![stable(feature = "rust1", since = "1.0.0")]
+
 #[rustc_const_stable(feature = "foo", since = "0")]
 //~^ ERROR macros cannot have const stability attributes
 macro_rules! foo {

--- a/src/test/ui/attributes/const-stability-on-macro.stderr
+++ b/src/test/ui/attributes/const-stability-on-macro.stderr
@@ -1,5 +1,5 @@
 error: macros cannot have const stability attributes
-  --> $DIR/const-stability-on-macro.rs:1:1
+  --> $DIR/const-stability-on-macro.rs:4:1
    |
 LL | #[rustc_const_stable(feature = "foo", since = "0")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ invalid const stability attribute
@@ -8,7 +8,7 @@ LL | macro_rules! foo {
    | ---------------- const stability attribute affects this macro
 
 error: macros cannot have const stability attributes
-  --> $DIR/const-stability-on-macro.rs:7:1
+  --> $DIR/const-stability-on-macro.rs:10:1
    |
 LL | #[rustc_const_unstable(feature = "bar", issue="none")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ invalid const stability attribute

--- a/src/test/ui/attributes/extented-attribute-macro-error.rs
+++ b/src/test/ui/attributes/extented-attribute-macro-error.rs
@@ -1,6 +1,5 @@
 // normalize-stderr-test: "couldn't read.*" -> "couldn't read the file"
 
-#![feature(extended_key_value_attributes)]
 #![doc = include_str!("../not_existing_file.md")]
 struct Documented {}
 //~^^ ERROR couldn't read

--- a/src/test/ui/attributes/extented-attribute-macro-error.stderr
+++ b/src/test/ui/attributes/extented-attribute-macro-error.stderr
@@ -1,5 +1,5 @@
 error: couldn't read the file
-  --> $DIR/extented-attribute-macro-error.rs:4:10
+  --> $DIR/extented-attribute-macro-error.rs:3:10
    |
 LL | #![doc = include_str!("../not_existing_file.md")]
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/const-generics/issues/issue-82956.rs
+++ b/src/test/ui/const-generics/issues/issue-82956.rs
@@ -1,4 +1,4 @@
-#![feature(generic_const_exprs, array_map)]
+#![feature(generic_const_exprs)]
 #![allow(incomplete_features)]
 
 pub struct ConstCheck<const CHECK: bool>;

--- a/src/test/ui/consts/const-array-oob-arith.rs
+++ b/src/test/ui/consts/const-array-oob-arith.rs
@@ -1,5 +1,3 @@
-#![feature(const_indexing)]
-
 const ARR: [i32; 6] = [42, 43, 44, 45, 46, 47];
 const IDX: usize = 3;
 const VAL: i32 = ARR[IDX];

--- a/src/test/ui/consts/const-array-oob-arith.stderr
+++ b/src/test/ui/consts/const-array-oob-arith.stderr
@@ -1,11 +1,11 @@
 error[E0308]: mismatched types
-  --> $DIR/const-array-oob-arith.rs:7:45
+  --> $DIR/const-array-oob-arith.rs:5:45
    |
 LL | const BLUB: [i32; (ARR[0] - 40) as usize] = [5];
    |                                             ^^^ expected an array with a fixed size of 2 elements, found one with 1 element
 
 error[E0308]: mismatched types
-  --> $DIR/const-array-oob-arith.rs:10:44
+  --> $DIR/const-array-oob-arith.rs:8:44
    |
 LL | const BOO: [i32; (ARR[0] - 41) as usize] = [5, 99];
    |                                            ^^^^^^^ expected an array with a fixed size of 1 element, found one with 2 elements

--- a/src/test/ui/consts/const-array-oob.rs
+++ b/src/test/ui/consts/const-array-oob.rs
@@ -1,5 +1,3 @@
-#![feature(const_indexing)]
-
 const FOO: [usize; 3] = [1, 2, 3];
 const BAR: usize = FOO[5]; // no error, because the error below occurs before regular const eval
 

--- a/src/test/ui/consts/const-array-oob.stderr
+++ b/src/test/ui/consts/const-array-oob.stderr
@@ -1,5 +1,5 @@
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-array-oob.rs:6:19
+  --> $DIR/const-array-oob.rs:4:19
    |
 LL | const BLUB: [u32; FOO[4]] = [5, 6];
    |                   ^^^^^^ index out of bounds: the length is 3 but the index is 4

--- a/src/test/ui/consts/const-eval/transmute-const-promotion.rs
+++ b/src/test/ui/consts/const-eval/transmute-const-promotion.rs
@@ -1,5 +1,3 @@
-#![feature(const_transmute)]
-
 use std::mem;
 
 fn main() {

--- a/src/test/ui/consts/const-eval/transmute-const-promotion.stderr
+++ b/src/test/ui/consts/const-eval/transmute-const-promotion.stderr
@@ -1,5 +1,5 @@
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/transmute-const-promotion.rs:6:37
+  --> $DIR/transmute-const-promotion.rs:4:37
    |
 LL |     let x: &'static u32 = unsafe { &mem::transmute(3.0f32) };
    |            ------------             ^^^^^^^^^^^^^^^^^^^^^^ creates a temporary which is freed while still in use

--- a/src/test/ui/consts/issue-87046.rs
+++ b/src/test/ui/consts/issue-87046.rs
@@ -2,7 +2,6 @@
 
 #![crate_type="lib"]
 #![allow(unreachable_patterns)]
-#![feature(const_fn_union)]
 
 #[derive(PartialEq, Eq)]
 #[repr(transparent)]

--- a/src/test/ui/consts/issue-87046.stderr
+++ b/src/test/ui/consts/issue-87046.stderr
@@ -1,5 +1,5 @@
 error: cannot use unsized non-slice type `Username` in constant patterns
-  --> $DIR/issue-87046.rs:29:13
+  --> $DIR/issue-87046.rs:28:13
    |
 LL |             ROOT_USER => true,
    |             ^^^^^^^^^

--- a/src/test/ui/consts/min_const_fn/allow_const_fn_ptr.rs
+++ b/src/test/ui/consts/min_const_fn/allow_const_fn_ptr.rs
@@ -1,5 +1,6 @@
 #![feature(rustc_attrs, staged_api, rustc_allow_const_fn_unstable)]
 #![feature(const_fn_fn_ptr_basics)]
+#![stable(feature = "rust1", since = "1.0.0")]
 
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_const_stable(since="1.0.0", feature = "mep")]

--- a/src/test/ui/consts/min_const_fn/allow_const_fn_ptr.stderr
+++ b/src/test/ui/consts/min_const_fn/allow_const_fn_ptr.stderr
@@ -1,5 +1,5 @@
 error: const-stable function cannot use `#[feature(const_fn_fn_ptr_basics)]`
-  --> $DIR/allow_const_fn_ptr.rs:6:16
+  --> $DIR/allow_const_fn_ptr.rs:7:16
    |
 LL | const fn error(_: fn()) {}
    |                ^

--- a/src/test/ui/consts/min_const_fn/min_const_fn_libstd_stability.rs
+++ b/src/test/ui/consts/min_const_fn/min_const_fn_libstd_stability.rs
@@ -15,7 +15,7 @@ const fn foo() -> u32 { 42 }
 // can't call non-min_const_fn
 const fn bar() -> u32 { foo() } //~ ERROR not yet stable as a const fn
 
-#[unstable(feature = "rust1", issue = "none")]
+#[unstable(feature = "foo2", issue = "none")]
 const fn foo2() -> u32 { 42 }
 
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/test/ui/consts/min_const_fn/min_const_unsafe_fn_libstd_stability.rs
+++ b/src/test/ui/consts/min_const_fn/min_const_unsafe_fn_libstd_stability.rs
@@ -15,7 +15,7 @@ const unsafe fn foo() -> u32 { 42 }
 // can't call non-min_const_fn
 const unsafe fn bar() -> u32 { unsafe { foo() } } //~ ERROR not yet stable as a const fn
 
-#[unstable(feature = "rust1", issue = "none")]
+#[unstable(feature = "foo2", issue = "none")]
 const unsafe fn foo2() -> u32 { 42 }
 
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/test/ui/consts/min_const_fn/min_const_unsafe_fn_libstd_stability2.rs
+++ b/src/test/ui/consts/min_const_fn/min_const_unsafe_fn_libstd_stability2.rs
@@ -15,7 +15,7 @@ const fn foo() -> u32 { 42 }
 // can't call non-min_const_fn
 const unsafe fn bar() -> u32 { foo() } //~ ERROR not yet stable as a const fn
 
-#[unstable(feature = "rust1", issue = "none")]
+#[unstable(feature = "foo2", issue = "none")]
 const fn foo2() -> u32 { 42 }
 
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/test/ui/consts/transmute-size-mismatch-before-typeck.rs
+++ b/src/test/ui/consts/transmute-size-mismatch-before-typeck.rs
@@ -1,5 +1,3 @@
-#![feature(const_transmute)]
-
 // normalize-stderr-64bit "64 bits" -> "word size"
 // normalize-stderr-32bit "32 bits" -> "word size"
 // normalize-stderr-64bit "128 bits" -> "2 * word size"

--- a/src/test/ui/consts/transmute-size-mismatch-before-typeck.stderr
+++ b/src/test/ui/consts/transmute-size-mismatch-before-typeck.stderr
@@ -1,5 +1,5 @@
 error: any use of this value will cause an error
-  --> $DIR/transmute-size-mismatch-before-typeck.rs:15:29
+  --> $DIR/transmute-size-mismatch-before-typeck.rs:13:29
    |
 LL | const ZST: &[u8] = unsafe { std::mem::transmute(1usize) };
    | ----------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^---
@@ -11,13 +11,13 @@ LL | const ZST: &[u8] = unsafe { std::mem::transmute(1usize) };
    = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: could not evaluate constant pattern
-  --> $DIR/transmute-size-mismatch-before-typeck.rs:10:9
+  --> $DIR/transmute-size-mismatch-before-typeck.rs:8:9
    |
 LL |         ZST => {}
    |         ^^^
 
 error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
-  --> $DIR/transmute-size-mismatch-before-typeck.rs:15:29
+  --> $DIR/transmute-size-mismatch-before-typeck.rs:13:29
    |
 LL | const ZST: &[u8] = unsafe { std::mem::transmute(1usize) };
    |                             ^^^^^^^^^^^^^^^^^^^
@@ -26,7 +26,7 @@ LL | const ZST: &[u8] = unsafe { std::mem::transmute(1usize) };
    = note: target type: `&[u8]` (2 * word size)
 
 error: could not evaluate constant pattern
-  --> $DIR/transmute-size-mismatch-before-typeck.rs:10:9
+  --> $DIR/transmute-size-mismatch-before-typeck.rs:8:9
    |
 LL |         ZST => {}
    |         ^^^

--- a/src/test/ui/consts/unstable-const-fn-in-libcore.rs
+++ b/src/test/ui/consts/unstable-const-fn-in-libcore.rs
@@ -4,7 +4,6 @@
 // gate was not enabled in libcore.
 
 #![stable(feature = "core", since = "1.6.0")]
-#![feature(rustc_const_unstable)]
 #![feature(staged_api)]
 #![feature(const_fn_trait_bound)]
 

--- a/src/test/ui/consts/unstable-const-fn-in-libcore.stderr
+++ b/src/test/ui/consts/unstable-const-fn-in-libcore.stderr
@@ -1,5 +1,5 @@
 error[E0015]: cannot call non-const closure in constant functions
-  --> $DIR/unstable-const-fn-in-libcore.rs:24:26
+  --> $DIR/unstable-const-fn-in-libcore.rs:23:26
    |
 LL |             Opt::None => f(),
    |                          ^^^
@@ -11,7 +11,7 @@ LL |     const fn unwrap_or_else<F: FnOnce() -> T + ~const std::ops::FnOnce<()>>
    |                                              +++++++++++++++++++++++++++++
 
 error[E0493]: destructors cannot be evaluated at compile-time
-  --> $DIR/unstable-const-fn-in-libcore.rs:19:53
+  --> $DIR/unstable-const-fn-in-libcore.rs:18:53
    |
 LL |     const fn unwrap_or_else<F: FnOnce() -> T>(self, f: F) -> T {
    |                                                     ^ constant functions cannot evaluate destructors
@@ -20,7 +20,7 @@ LL |     }
    |     - value is dropped here
 
 error[E0493]: destructors cannot be evaluated at compile-time
-  --> $DIR/unstable-const-fn-in-libcore.rs:19:47
+  --> $DIR/unstable-const-fn-in-libcore.rs:18:47
    |
 LL |     const fn unwrap_or_else<F: FnOnce() -> T>(self, f: F) -> T {
    |                                               ^^^^ constant functions cannot evaluate destructors

--- a/src/test/ui/deprecation/deprecation-in-staged-api.stderr
+++ b/src/test/ui/deprecation/deprecation-in-staged-api.stderr
@@ -3,8 +3,6 @@ error: `#[deprecated]` cannot be used in staged API
    |
 LL | #[deprecated]
    | ^^^^^^^^^^^^^ use `#[rustc_deprecated]` instead
-LL | fn main() {}
-   | ------------
 
 error: aborting due to previous error
 

--- a/src/test/ui/explore-issue-38412.rs
+++ b/src/test/ui/explore-issue-38412.rs
@@ -1,7 +1,5 @@
 // aux-build:pub-and-stability.rs
 
-#![feature(unused_feature)]
-
 // A big point of this test is that we *declare* `unstable_declared`,
 // but do *not* declare `unstable_undeclared`. This way we can check
 // that the compiler is letting in uses of declared feature-gated

--- a/src/test/ui/explore-issue-38412.stderr
+++ b/src/test/ui/explore-issue-38412.stderr
@@ -1,5 +1,5 @@
 error[E0658]: use of unstable library feature 'unstable_undeclared'
-  --> $DIR/explore-issue-38412.rs:21:63
+  --> $DIR/explore-issue-38412.rs:19:63
    |
 LL |     let Record { a_stable_pub: _, a_unstable_declared_pub: _, a_unstable_undeclared_pub: _, .. } =
    |                                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -8,7 +8,7 @@ LL |     let Record { a_stable_pub: _, a_unstable_declared_pub: _, a_unstable_un
    = help: add `#![feature(unstable_undeclared)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_undeclared'
-  --> $DIR/explore-issue-38412.rs:30:5
+  --> $DIR/explore-issue-38412.rs:28:5
    |
 LL |     r.a_unstable_undeclared_pub;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -17,25 +17,25 @@ LL |     r.a_unstable_undeclared_pub;
    = help: add `#![feature(unstable_undeclared)]` to the crate attributes to enable
 
 error[E0616]: field `b_crate` of struct `Record` is private
-  --> $DIR/explore-issue-38412.rs:31:7
+  --> $DIR/explore-issue-38412.rs:29:7
    |
 LL |     r.b_crate;
    |       ^^^^^^^ private field
 
 error[E0616]: field `c_mod` of struct `Record` is private
-  --> $DIR/explore-issue-38412.rs:32:7
+  --> $DIR/explore-issue-38412.rs:30:7
    |
 LL |     r.c_mod;
    |       ^^^^^ private field
 
 error[E0616]: field `d_priv` of struct `Record` is private
-  --> $DIR/explore-issue-38412.rs:33:7
+  --> $DIR/explore-issue-38412.rs:31:7
    |
 LL |     r.d_priv;
    |       ^^^^^^ private field
 
 error[E0658]: use of unstable library feature 'unstable_undeclared'
-  --> $DIR/explore-issue-38412.rs:37:5
+  --> $DIR/explore-issue-38412.rs:35:5
    |
 LL |     t.2;
    |     ^^^
@@ -44,25 +44,25 @@ LL |     t.2;
    = help: add `#![feature(unstable_undeclared)]` to the crate attributes to enable
 
 error[E0616]: field `3` of struct `Tuple` is private
-  --> $DIR/explore-issue-38412.rs:38:7
+  --> $DIR/explore-issue-38412.rs:36:7
    |
 LL |     t.3;
    |       ^ private field
 
 error[E0616]: field `4` of struct `Tuple` is private
-  --> $DIR/explore-issue-38412.rs:39:7
+  --> $DIR/explore-issue-38412.rs:37:7
    |
 LL |     t.4;
    |       ^ private field
 
 error[E0616]: field `5` of struct `Tuple` is private
-  --> $DIR/explore-issue-38412.rs:40:7
+  --> $DIR/explore-issue-38412.rs:38:7
    |
 LL |     t.5;
    |       ^ private field
 
 error[E0658]: use of unstable library feature 'unstable_undeclared'
-  --> $DIR/explore-issue-38412.rs:44:7
+  --> $DIR/explore-issue-38412.rs:42:7
    |
 LL |     r.unstable_undeclared_trait_method();
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -71,7 +71,7 @@ LL |     r.unstable_undeclared_trait_method();
    = help: add `#![feature(unstable_undeclared)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_undeclared'
-  --> $DIR/explore-issue-38412.rs:48:7
+  --> $DIR/explore-issue-38412.rs:46:7
    |
 LL |     r.unstable_undeclared();
    |       ^^^^^^^^^^^^^^^^^^^
@@ -80,7 +80,7 @@ LL |     r.unstable_undeclared();
    = help: add `#![feature(unstable_undeclared)]` to the crate attributes to enable
 
 error[E0624]: associated function `pub_crate` is private
-  --> $DIR/explore-issue-38412.rs:50:7
+  --> $DIR/explore-issue-38412.rs:48:7
    |
 LL |     r.pub_crate();
    |       ^^^^^^^^^ private associated function
@@ -91,7 +91,7 @@ LL |         pub(crate) fn pub_crate(&self) -> i32 { self.d_priv }
    |         ------------------------------------- private associated function defined here
 
 error[E0624]: associated function `pub_mod` is private
-  --> $DIR/explore-issue-38412.rs:51:7
+  --> $DIR/explore-issue-38412.rs:49:7
    |
 LL |     r.pub_mod();
    |       ^^^^^^^ private associated function
@@ -102,7 +102,7 @@ LL |         pub(in m) fn pub_mod(&self) -> i32 { self.d_priv }
    |         ---------------------------------- private associated function defined here
 
 error[E0624]: associated function `private` is private
-  --> $DIR/explore-issue-38412.rs:52:7
+  --> $DIR/explore-issue-38412.rs:50:7
    |
 LL |     r.private();
    |       ^^^^^^^ private associated function
@@ -113,7 +113,7 @@ LL |         fn private(&self) -> i32 { self.d_priv }
    |         ------------------------ private associated function defined here
 
 error[E0658]: use of unstable library feature 'unstable_undeclared'
-  --> $DIR/explore-issue-38412.rs:57:7
+  --> $DIR/explore-issue-38412.rs:55:7
    |
 LL |     t.unstable_undeclared_trait_method();
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -122,7 +122,7 @@ LL |     t.unstable_undeclared_trait_method();
    = help: add `#![feature(unstable_undeclared)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_undeclared'
-  --> $DIR/explore-issue-38412.rs:61:7
+  --> $DIR/explore-issue-38412.rs:59:7
    |
 LL |     t.unstable_undeclared();
    |       ^^^^^^^^^^^^^^^^^^^
@@ -131,7 +131,7 @@ LL |     t.unstable_undeclared();
    = help: add `#![feature(unstable_undeclared)]` to the crate attributes to enable
 
 error[E0624]: associated function `pub_crate` is private
-  --> $DIR/explore-issue-38412.rs:63:7
+  --> $DIR/explore-issue-38412.rs:61:7
    |
 LL |     t.pub_crate();
    |       ^^^^^^^^^ private associated function
@@ -142,7 +142,7 @@ LL |         pub(crate) fn pub_crate(&self) -> i32 { self.0 }
    |         ------------------------------------- private associated function defined here
 
 error[E0624]: associated function `pub_mod` is private
-  --> $DIR/explore-issue-38412.rs:64:7
+  --> $DIR/explore-issue-38412.rs:62:7
    |
 LL |     t.pub_mod();
    |       ^^^^^^^ private associated function
@@ -153,7 +153,7 @@ LL |         pub(in m) fn pub_mod(&self) -> i32 { self.0 }
    |         ---------------------------------- private associated function defined here
 
 error[E0624]: associated function `private` is private
-  --> $DIR/explore-issue-38412.rs:65:7
+  --> $DIR/explore-issue-38412.rs:63:7
    |
 LL |     t.private();
    |       ^^^^^^^ private associated function

--- a/src/test/ui/feature-gates/feature-gate-staged_api.stderr
+++ b/src/test/ui/feature-gates/feature-gate-staged_api.stderr
@@ -1,14 +1,14 @@
 error[E0734]: stability attributes may not be used outside of the standard library
-  --> $DIR/feature-gate-staged_api.rs:1:1
-   |
-LL | #![stable(feature = "a", since = "b")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error[E0734]: stability attributes may not be used outside of the standard library
   --> $DIR/feature-gate-staged_api.rs:8:1
    |
 LL | #[stable(feature = "a", since = "b")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0734]: stability attributes may not be used outside of the standard library
+  --> $DIR/feature-gate-staged_api.rs:1:1
+   |
+LL | #![stable(feature = "a", since = "b")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/feature-gates/gated-bad-feature.rs
+++ b/src/test/ui/feature-gates/gated-bad-feature.rs
@@ -1,10 +1,10 @@
 #![feature(foo_bar_baz, foo(bar), foo = "baz", foo)]
 //~^ ERROR malformed `feature`
 //~| ERROR malformed `feature`
-
+//~| ERROR unknown feature `foo`
+//~| ERROR unknown feature `foo_bar_baz`
 #![feature] //~ ERROR malformed `feature` attribute
 #![feature = "foo"] //~ ERROR malformed `feature` attribute
-
 #![feature(test_removed_feature)] //~ ERROR: feature has been removed
 
 fn main() {}

--- a/src/test/ui/feature-gates/gated-bad-feature.stderr
+++ b/src/test/ui/feature-gates/gated-bad-feature.stderr
@@ -17,18 +17,30 @@ LL | #![feature(test_removed_feature)]
    |            ^^^^^^^^^^^^^^^^^^^^ feature has been removed
 
 error: malformed `feature` attribute input
-  --> $DIR/gated-bad-feature.rs:5:1
+  --> $DIR/gated-bad-feature.rs:6:1
    |
 LL | #![feature]
    | ^^^^^^^^^^^ help: must be of the form: `#![feature(name1, name1, ...)]`
 
 error: malformed `feature` attribute input
-  --> $DIR/gated-bad-feature.rs:6:1
+  --> $DIR/gated-bad-feature.rs:7:1
    |
 LL | #![feature = "foo"]
    | ^^^^^^^^^^^^^^^^^^^ help: must be of the form: `#![feature(name1, name1, ...)]`
 
-error: aborting due to 5 previous errors
+error[E0635]: unknown feature `foo_bar_baz`
+  --> $DIR/gated-bad-feature.rs:1:12
+   |
+LL | #![feature(foo_bar_baz, foo(bar), foo = "baz", foo)]
+   |            ^^^^^^^^^^^
 
-Some errors have detailed explanations: E0556, E0557.
+error[E0635]: unknown feature `foo`
+  --> $DIR/gated-bad-feature.rs:1:48
+   |
+LL | #![feature(foo_bar_baz, foo(bar), foo = "baz", foo)]
+   |                                                ^^^
+
+error: aborting due to 7 previous errors
+
+Some errors have detailed explanations: E0556, E0557, E0635.
 For more information about an error, try `rustc --explain E0556`.

--- a/src/test/ui/feature-gates/issue-43106-gating-of-rustc_deprecated.rs
+++ b/src/test/ui/feature-gates/issue-43106-gating-of-rustc_deprecated.rs
@@ -6,25 +6,38 @@
 
 #![rustc_deprecated()]
 //~^ ERROR stability attributes may not be used outside of the standard library
+//~| ERROR missing 'since' [E0542]
 
 #[rustc_deprecated()]
 //~^ ERROR stability attributes may not be used outside of the standard library
+//~| ERROR missing 'since' [E0542]
 mod rustc_deprecated {
-    mod inner { #![rustc_deprecated()] }
-    //~^ ERROR stability attributes may not be used outside of the standard library
+    mod inner {
+        #![rustc_deprecated()]
+        //~^ ERROR stability attributes may not be used outside of the standard library
+        //~| ERROR missing 'since' [E0542]
+    }
 
-    #[rustc_deprecated()] fn f() { }
+    #[rustc_deprecated()]
     //~^ ERROR stability attributes may not be used outside of the standard library
+    //~| ERROR missing 'since' [E0542]
+    fn f() {}
 
-    #[rustc_deprecated()] struct S;
+    #[rustc_deprecated()]
     //~^ ERROR stability attributes may not be used outside of the standard library
-    //~| ERROR stability attributes may not be used outside of the standard library
+    //~| ERROR missing 'since' [E0542]
+    //~| ERROR missing 'since' [E0542]
+    struct S;
 
-    #[rustc_deprecated()] type T = S;
+    #[rustc_deprecated()]
     //~^ ERROR stability attributes may not be used outside of the standard library
+    //~| ERROR missing 'since' [E0542]
+    type T = S;
 
-    #[rustc_deprecated()] impl S { }
+    #[rustc_deprecated()]
     //~^ ERROR stability attributes may not be used outside of the standard library
+    //~| ERROR missing 'since' [E0542]
+    impl S {}
 }
 
 fn main() {}

--- a/src/test/ui/feature-gates/issue-43106-gating-of-rustc_deprecated.stderr
+++ b/src/test/ui/feature-gates/issue-43106-gating-of-rustc_deprecated.stderr
@@ -1,51 +1,94 @@
 error[E0734]: stability attributes may not be used outside of the standard library
-  --> $DIR/issue-43106-gating-of-rustc_deprecated.rs:7:1
+  --> $DIR/issue-43106-gating-of-rustc_deprecated.rs:16:9
    |
-LL | #![rustc_deprecated()]
-   | ^^^^^^^^^^^^^^^^^^^^^^
+LL |         #![rustc_deprecated()]
+   |         ^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0734]: stability attributes may not be used outside of the standard library
-  --> $DIR/issue-43106-gating-of-rustc_deprecated.rs:10:1
+  --> $DIR/issue-43106-gating-of-rustc_deprecated.rs:21:5
    |
-LL | #[rustc_deprecated()]
-   | ^^^^^^^^^^^^^^^^^^^^^
-
-error[E0734]: stability attributes may not be used outside of the standard library
-  --> $DIR/issue-43106-gating-of-rustc_deprecated.rs:13:17
-   |
-LL |     mod inner { #![rustc_deprecated()] }
-   |                 ^^^^^^^^^^^^^^^^^^^^^^
-
-error[E0734]: stability attributes may not be used outside of the standard library
-  --> $DIR/issue-43106-gating-of-rustc_deprecated.rs:16:5
-   |
-LL |     #[rustc_deprecated()] fn f() { }
-   |     ^^^^^^^^^^^^^^^^^^^^^
-
-error[E0734]: stability attributes may not be used outside of the standard library
-  --> $DIR/issue-43106-gating-of-rustc_deprecated.rs:19:5
-   |
-LL |     #[rustc_deprecated()] struct S;
-   |     ^^^^^^^^^^^^^^^^^^^^^
-
-error[E0734]: stability attributes may not be used outside of the standard library
-  --> $DIR/issue-43106-gating-of-rustc_deprecated.rs:19:5
-   |
-LL |     #[rustc_deprecated()] struct S;
-   |     ^^^^^^^^^^^^^^^^^^^^^
-
-error[E0734]: stability attributes may not be used outside of the standard library
-  --> $DIR/issue-43106-gating-of-rustc_deprecated.rs:23:5
-   |
-LL |     #[rustc_deprecated()] type T = S;
+LL |     #[rustc_deprecated()]
    |     ^^^^^^^^^^^^^^^^^^^^^
 
 error[E0734]: stability attributes may not be used outside of the standard library
   --> $DIR/issue-43106-gating-of-rustc_deprecated.rs:26:5
    |
-LL |     #[rustc_deprecated()] impl S { }
+LL |     #[rustc_deprecated()]
    |     ^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 8 previous errors
+error[E0734]: stability attributes may not be used outside of the standard library
+  --> $DIR/issue-43106-gating-of-rustc_deprecated.rs:32:5
+   |
+LL |     #[rustc_deprecated()]
+   |     ^^^^^^^^^^^^^^^^^^^^^
 
-For more information about this error, try `rustc --explain E0734`.
+error[E0734]: stability attributes may not be used outside of the standard library
+  --> $DIR/issue-43106-gating-of-rustc_deprecated.rs:37:5
+   |
+LL |     #[rustc_deprecated()]
+   |     ^^^^^^^^^^^^^^^^^^^^^
+
+error[E0734]: stability attributes may not be used outside of the standard library
+  --> $DIR/issue-43106-gating-of-rustc_deprecated.rs:11:1
+   |
+LL | #[rustc_deprecated()]
+   | ^^^^^^^^^^^^^^^^^^^^^
+
+error[E0734]: stability attributes may not be used outside of the standard library
+  --> $DIR/issue-43106-gating-of-rustc_deprecated.rs:7:1
+   |
+LL | #![rustc_deprecated()]
+   | ^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0542]: missing 'since'
+  --> $DIR/issue-43106-gating-of-rustc_deprecated.rs:7:1
+   |
+LL | #![rustc_deprecated()]
+   | ^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0542]: missing 'since'
+  --> $DIR/issue-43106-gating-of-rustc_deprecated.rs:11:1
+   |
+LL | #[rustc_deprecated()]
+   | ^^^^^^^^^^^^^^^^^^^^^
+
+error[E0542]: missing 'since'
+  --> $DIR/issue-43106-gating-of-rustc_deprecated.rs:16:9
+   |
+LL |         #![rustc_deprecated()]
+   |         ^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0542]: missing 'since'
+  --> $DIR/issue-43106-gating-of-rustc_deprecated.rs:21:5
+   |
+LL |     #[rustc_deprecated()]
+   |     ^^^^^^^^^^^^^^^^^^^^^
+
+error[E0542]: missing 'since'
+  --> $DIR/issue-43106-gating-of-rustc_deprecated.rs:26:5
+   |
+LL |     #[rustc_deprecated()]
+   |     ^^^^^^^^^^^^^^^^^^^^^
+
+error[E0542]: missing 'since'
+  --> $DIR/issue-43106-gating-of-rustc_deprecated.rs:26:5
+   |
+LL |     #[rustc_deprecated()]
+   |     ^^^^^^^^^^^^^^^^^^^^^
+
+error[E0542]: missing 'since'
+  --> $DIR/issue-43106-gating-of-rustc_deprecated.rs:32:5
+   |
+LL |     #[rustc_deprecated()]
+   |     ^^^^^^^^^^^^^^^^^^^^^
+
+error[E0542]: missing 'since'
+  --> $DIR/issue-43106-gating-of-rustc_deprecated.rs:37:5
+   |
+LL |     #[rustc_deprecated()]
+   |     ^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 15 previous errors
+
+Some errors have detailed explanations: E0542, E0734.
+For more information about an error, try `rustc --explain E0542`.

--- a/src/test/ui/feature-gates/issue-43106-gating-of-stable.rs
+++ b/src/test/ui/feature-gates/issue-43106-gating-of-stable.rs
@@ -10,21 +10,26 @@
 #[stable()]
 //~^ ERROR stability attributes may not be used outside of the standard library
 mod stable {
-    mod inner { #![stable()] }
-    //~^ ERROR stability attributes may not be used outside of the standard library
+    mod inner {
+        #![stable()]
+        //~^ ERROR stability attributes may not be used outside of the standard library
+    }
 
-    #[stable()] fn f() { }
+    #[stable()]
     //~^ ERROR stability attributes may not be used outside of the standard library
+    fn f() {}
 
-    #[stable()] struct S;
+    #[stable()]
     //~^ ERROR stability attributes may not be used outside of the standard library
-    //~| ERROR stability attributes may not be used outside of the standard library
+    struct S;
 
-    #[stable()] type T = S;
+    #[stable()]
     //~^ ERROR stability attributes may not be used outside of the standard library
+    type T = S;
 
-    #[stable()] impl S { }
+    #[stable()]
     //~^ ERROR stability attributes may not be used outside of the standard library
+    impl S {}
 }
 
 fn main() {}

--- a/src/test/ui/feature-gates/issue-43106-gating-of-stable.stderr
+++ b/src/test/ui/feature-gates/issue-43106-gating-of-stable.stderr
@@ -1,8 +1,32 @@
 error[E0734]: stability attributes may not be used outside of the standard library
-  --> $DIR/issue-43106-gating-of-stable.rs:7:1
+  --> $DIR/issue-43106-gating-of-stable.rs:14:9
    |
-LL | #![stable()]
-   | ^^^^^^^^^^^^
+LL |         #![stable()]
+   |         ^^^^^^^^^^^^
+
+error[E0734]: stability attributes may not be used outside of the standard library
+  --> $DIR/issue-43106-gating-of-stable.rs:18:5
+   |
+LL |     #[stable()]
+   |     ^^^^^^^^^^^
+
+error[E0734]: stability attributes may not be used outside of the standard library
+  --> $DIR/issue-43106-gating-of-stable.rs:22:5
+   |
+LL |     #[stable()]
+   |     ^^^^^^^^^^^
+
+error[E0734]: stability attributes may not be used outside of the standard library
+  --> $DIR/issue-43106-gating-of-stable.rs:26:5
+   |
+LL |     #[stable()]
+   |     ^^^^^^^^^^^
+
+error[E0734]: stability attributes may not be used outside of the standard library
+  --> $DIR/issue-43106-gating-of-stable.rs:30:5
+   |
+LL |     #[stable()]
+   |     ^^^^^^^^^^^
 
 error[E0734]: stability attributes may not be used outside of the standard library
   --> $DIR/issue-43106-gating-of-stable.rs:10:1
@@ -11,41 +35,11 @@ LL | #[stable()]
    | ^^^^^^^^^^^
 
 error[E0734]: stability attributes may not be used outside of the standard library
-  --> $DIR/issue-43106-gating-of-stable.rs:13:17
+  --> $DIR/issue-43106-gating-of-stable.rs:7:1
    |
-LL |     mod inner { #![stable()] }
-   |                 ^^^^^^^^^^^^
+LL | #![stable()]
+   | ^^^^^^^^^^^^
 
-error[E0734]: stability attributes may not be used outside of the standard library
-  --> $DIR/issue-43106-gating-of-stable.rs:16:5
-   |
-LL |     #[stable()] fn f() { }
-   |     ^^^^^^^^^^^
-
-error[E0734]: stability attributes may not be used outside of the standard library
-  --> $DIR/issue-43106-gating-of-stable.rs:19:5
-   |
-LL |     #[stable()] struct S;
-   |     ^^^^^^^^^^^
-
-error[E0734]: stability attributes may not be used outside of the standard library
-  --> $DIR/issue-43106-gating-of-stable.rs:19:5
-   |
-LL |     #[stable()] struct S;
-   |     ^^^^^^^^^^^
-
-error[E0734]: stability attributes may not be used outside of the standard library
-  --> $DIR/issue-43106-gating-of-stable.rs:23:5
-   |
-LL |     #[stable()] type T = S;
-   |     ^^^^^^^^^^^
-
-error[E0734]: stability attributes may not be used outside of the standard library
-  --> $DIR/issue-43106-gating-of-stable.rs:26:5
-   |
-LL |     #[stable()] impl S { }
-   |     ^^^^^^^^^^^
-
-error: aborting due to 8 previous errors
+error: aborting due to 7 previous errors
 
 For more information about this error, try `rustc --explain E0734`.

--- a/src/test/ui/feature-gates/issue-43106-gating-of-unstable.rs
+++ b/src/test/ui/feature-gates/issue-43106-gating-of-unstable.rs
@@ -10,21 +10,26 @@
 #[unstable()]
 //~^ ERROR stability attributes may not be used outside of the standard library
 mod unstable {
-    mod inner { #![unstable()] }
-    //~^ ERROR stability attributes may not be used outside of the standard library
+    mod inner {
+        #![unstable()]
+        //~^ ERROR stability attributes may not be used outside of the standard library
+    }
 
-    #[unstable()] fn f() { }
+    #[unstable()]
     //~^ ERROR stability attributes may not be used outside of the standard library
+    fn f() {}
 
-    #[unstable()] struct S;
+    #[unstable()]
     //~^ ERROR stability attributes may not be used outside of the standard library
-    //~| ERROR stability attributes may not be used outside of the standard library
+    struct S;
 
-    #[unstable()] type T = S;
+    #[unstable()]
     //~^ ERROR stability attributes may not be used outside of the standard library
+    type T = S;
 
-    #[unstable()] impl S { }
+    #[unstable()]
     //~^ ERROR stability attributes may not be used outside of the standard library
+    impl S {}
 }
 
 fn main() {}

--- a/src/test/ui/feature-gates/issue-43106-gating-of-unstable.stderr
+++ b/src/test/ui/feature-gates/issue-43106-gating-of-unstable.stderr
@@ -1,8 +1,32 @@
 error[E0734]: stability attributes may not be used outside of the standard library
-  --> $DIR/issue-43106-gating-of-unstable.rs:7:1
+  --> $DIR/issue-43106-gating-of-unstable.rs:14:9
    |
-LL | #![unstable()]
-   | ^^^^^^^^^^^^^^
+LL |         #![unstable()]
+   |         ^^^^^^^^^^^^^^
+
+error[E0734]: stability attributes may not be used outside of the standard library
+  --> $DIR/issue-43106-gating-of-unstable.rs:18:5
+   |
+LL |     #[unstable()]
+   |     ^^^^^^^^^^^^^
+
+error[E0734]: stability attributes may not be used outside of the standard library
+  --> $DIR/issue-43106-gating-of-unstable.rs:22:5
+   |
+LL |     #[unstable()]
+   |     ^^^^^^^^^^^^^
+
+error[E0734]: stability attributes may not be used outside of the standard library
+  --> $DIR/issue-43106-gating-of-unstable.rs:26:5
+   |
+LL |     #[unstable()]
+   |     ^^^^^^^^^^^^^
+
+error[E0734]: stability attributes may not be used outside of the standard library
+  --> $DIR/issue-43106-gating-of-unstable.rs:30:5
+   |
+LL |     #[unstable()]
+   |     ^^^^^^^^^^^^^
 
 error[E0734]: stability attributes may not be used outside of the standard library
   --> $DIR/issue-43106-gating-of-unstable.rs:10:1
@@ -11,41 +35,11 @@ LL | #[unstable()]
    | ^^^^^^^^^^^^^
 
 error[E0734]: stability attributes may not be used outside of the standard library
-  --> $DIR/issue-43106-gating-of-unstable.rs:13:17
+  --> $DIR/issue-43106-gating-of-unstable.rs:7:1
    |
-LL |     mod inner { #![unstable()] }
-   |                 ^^^^^^^^^^^^^^
+LL | #![unstable()]
+   | ^^^^^^^^^^^^^^
 
-error[E0734]: stability attributes may not be used outside of the standard library
-  --> $DIR/issue-43106-gating-of-unstable.rs:16:5
-   |
-LL |     #[unstable()] fn f() { }
-   |     ^^^^^^^^^^^^^
-
-error[E0734]: stability attributes may not be used outside of the standard library
-  --> $DIR/issue-43106-gating-of-unstable.rs:19:5
-   |
-LL |     #[unstable()] struct S;
-   |     ^^^^^^^^^^^^^
-
-error[E0734]: stability attributes may not be used outside of the standard library
-  --> $DIR/issue-43106-gating-of-unstable.rs:19:5
-   |
-LL |     #[unstable()] struct S;
-   |     ^^^^^^^^^^^^^
-
-error[E0734]: stability attributes may not be used outside of the standard library
-  --> $DIR/issue-43106-gating-of-unstable.rs:23:5
-   |
-LL |     #[unstable()] type T = S;
-   |     ^^^^^^^^^^^^^
-
-error[E0734]: stability attributes may not be used outside of the standard library
-  --> $DIR/issue-43106-gating-of-unstable.rs:26:5
-   |
-LL |     #[unstable()] impl S { }
-   |     ^^^^^^^^^^^^^
-
-error: aborting due to 8 previous errors
+error: aborting due to 7 previous errors
 
 For more information about this error, try `rustc --explain E0734`.

--- a/src/test/ui/generator/dropck.rs
+++ b/src/test/ui/generator/dropck.rs
@@ -1,4 +1,4 @@
-#![feature(generators, generator_trait, box_leak)]
+#![feature(generators, generator_trait)]
 
 use std::cell::RefCell;
 use std::ops::Generator;

--- a/src/test/ui/impl-trait/issues/universal-issue-48703.rs
+++ b/src/test/ui/impl-trait/issues/universal-issue-48703.rs
@@ -1,5 +1,3 @@
-#![feature(universal_impl_trait)]
-
 use std::fmt::Debug;
 
 fn foo<T>(x: impl Debug) { }

--- a/src/test/ui/impl-trait/issues/universal-issue-48703.stderr
+++ b/src/test/ui/impl-trait/issues/universal-issue-48703.stderr
@@ -1,5 +1,5 @@
 error[E0632]: cannot provide explicit generic arguments when `impl Trait` is used in argument position
-  --> $DIR/universal-issue-48703.rs:8:11
+  --> $DIR/universal-issue-48703.rs:6:11
    |
 LL |     foo::<String>('a');
    |           ^^^^^^ explicit generic argument not allowed

--- a/src/test/ui/inference/question-mark-type-infer.rs
+++ b/src/test/ui/inference/question-mark-type-infer.rs
@@ -1,5 +1,3 @@
-#![feature(question_mark, question_mark_carrier)]
-
 // Test that type inference fails where there are multiple possible return types
 // for the `?` operator.
 

--- a/src/test/ui/inference/question-mark-type-infer.stderr
+++ b/src/test/ui/inference/question-mark-type-infer.stderr
@@ -1,5 +1,5 @@
 error[E0284]: type annotations needed
-  --> $DIR/question-mark-type-infer.rs:12:21
+  --> $DIR/question-mark-type-infer.rs:10:21
    |
 LL |     l.iter().map(f).collect()?
    |                     ^^^^^^^ cannot infer type

--- a/src/test/ui/issues/issue-16538.mir.stderr
+++ b/src/test/ui/issues/issue-16538.mir.stderr
@@ -1,5 +1,5 @@
 error[E0015]: cannot call non-const fn `Y::foo` in statics
-  --> $DIR/issue-16538.rs:15:23
+  --> $DIR/issue-16538.rs:14:23
    |
 LL | static foo: &Y::X = &*Y::foo(Y::x as *const Y::X);
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -7,7 +7,7 @@ LL | static foo: &Y::X = &*Y::foo(Y::x as *const Y::X);
    = note: calls in statics are limited to constant functions, tuple structs and tuple variants
 
 error[E0133]: use of extern static is unsafe and requires unsafe function or block
-  --> $DIR/issue-16538.rs:15:30
+  --> $DIR/issue-16538.rs:14:30
    |
 LL | static foo: &Y::X = &*Y::foo(Y::x as *const Y::X);
    |                              ^^^^ use of extern static
@@ -15,7 +15,7 @@ LL | static foo: &Y::X = &*Y::foo(Y::x as *const Y::X);
    = note: extern statics are not controlled by the Rust type system: invalid data, aliasing violations or data races will cause undefined behavior
 
 error[E0133]: dereference of raw pointer is unsafe and requires unsafe function or block
-  --> $DIR/issue-16538.rs:15:21
+  --> $DIR/issue-16538.rs:14:21
    |
 LL | static foo: &Y::X = &*Y::foo(Y::x as *const Y::X);
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ dereference of raw pointer

--- a/src/test/ui/issues/issue-16538.rs
+++ b/src/test/ui/issues/issue-16538.rs
@@ -1,7 +1,6 @@
 // revisions: mir thir
 // [thir]compile-flags: -Z thir-unsafeck
 
-#![feature(const_raw_ptr_deref)]
 mod Y {
     pub type X = usize;
     extern "C" {

--- a/src/test/ui/issues/issue-16538.thir.stderr
+++ b/src/test/ui/issues/issue-16538.thir.stderr
@@ -1,5 +1,5 @@
 error[E0133]: dereference of raw pointer is unsafe and requires unsafe function or block
-  --> $DIR/issue-16538.rs:15:22
+  --> $DIR/issue-16538.rs:14:22
    |
 LL | static foo: &Y::X = &*Y::foo(Y::x as *const Y::X);
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ dereference of raw pointer
@@ -7,7 +7,7 @@ LL | static foo: &Y::X = &*Y::foo(Y::x as *const Y::X);
    = note: raw pointers may be null, dangling or unaligned; they can violate aliasing rules and cause data races: all of these are undefined behavior
 
 error[E0133]: use of extern static is unsafe and requires unsafe function or block
-  --> $DIR/issue-16538.rs:15:30
+  --> $DIR/issue-16538.rs:14:30
    |
 LL | static foo: &Y::X = &*Y::foo(Y::x as *const Y::X);
    |                              ^^^^ use of extern static
@@ -15,7 +15,7 @@ LL | static foo: &Y::X = &*Y::foo(Y::x as *const Y::X);
    = note: extern statics are not controlled by the Rust type system: invalid data, aliasing violations or data races will cause undefined behavior
 
 error[E0015]: cannot call non-const fn `Y::foo` in statics
-  --> $DIR/issue-16538.rs:15:23
+  --> $DIR/issue-16538.rs:14:23
    |
 LL | static foo: &Y::X = &*Y::foo(Y::x as *const Y::X);
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/issues/issue-27078.rs
+++ b/src/test/ui/issues/issue-27078.rs
@@ -1,5 +1,3 @@
-#![feature(associated_consts)]
-
 trait Foo {
     const BAR: i32;
     fn foo(self) -> &'static i32 {

--- a/src/test/ui/issues/issue-27078.stderr
+++ b/src/test/ui/issues/issue-27078.stderr
@@ -1,5 +1,5 @@
 error[E0277]: the size for values of type `Self` cannot be known at compilation time
-  --> $DIR/issue-27078.rs:5:12
+  --> $DIR/issue-27078.rs:3:12
    |
 LL |     fn foo(self) -> &'static i32 {
    |            ^^^^ doesn't have a size known at compile-time

--- a/src/test/ui/issues/issue-39211.rs
+++ b/src/test/ui/issues/issue-39211.rs
@@ -1,5 +1,3 @@
-#![feature(associated_consts)]
-
 trait VecN {
     const DIM: usize;
 }

--- a/src/test/ui/issues/issue-39211.stderr
+++ b/src/test/ui/issues/issue-39211.stderr
@@ -1,5 +1,5 @@
 error: constant expression depends on a generic parameter
-  --> $DIR/issue-39211.rs:11:17
+  --> $DIR/issue-39211.rs:9:17
    |
 LL |     let a = [3; M::Row::DIM];
    |                 ^^^^^^^^^^^

--- a/src/test/ui/issues/issue-46101.rs
+++ b/src/test/ui/issues/issue-46101.rs
@@ -1,4 +1,3 @@
-#![feature(use_extern_macros)]
 trait Foo {}
 #[derive(Foo::Anything)] //~ ERROR failed to resolve: partially resolved path in a derive macro
                          //~| ERROR failed to resolve: partially resolved path in a derive macro

--- a/src/test/ui/issues/issue-46101.stderr
+++ b/src/test/ui/issues/issue-46101.stderr
@@ -1,11 +1,11 @@
 error[E0433]: failed to resolve: partially resolved path in a derive macro
-  --> $DIR/issue-46101.rs:3:10
+  --> $DIR/issue-46101.rs:2:10
    |
 LL | #[derive(Foo::Anything)]
    |          ^^^^^^^^^^^^^ partially resolved path in a derive macro
 
 error[E0433]: failed to resolve: partially resolved path in a derive macro
-  --> $DIR/issue-46101.rs:3:10
+  --> $DIR/issue-46101.rs:2:10
    |
 LL | #[derive(Foo::Anything)]
    |          ^^^^^^^^^^^^^ partially resolved path in a derive macro

--- a/src/test/ui/issues/issue-6596-2.rs
+++ b/src/test/ui/issues/issue-6596-2.rs
@@ -1,5 +1,3 @@
-#![feature(macro_rules)]
-
 macro_rules! g {
     ($inp:ident) => (
         { $inp $nonexistent }

--- a/src/test/ui/issues/issue-6596-2.stderr
+++ b/src/test/ui/issues/issue-6596-2.stderr
@@ -1,5 +1,5 @@
 error: expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator, found `$`
-  --> $DIR/issue-6596-2.rs:5:16
+  --> $DIR/issue-6596-2.rs:3:16
    |
 LL |         { $inp $nonexistent }
    |                ^^^^^^^^^^^^ expected one of 8 possible tokens

--- a/src/test/ui/issues/issue-75777.rs
+++ b/src/test/ui/issues/issue-75777.rs
@@ -1,8 +1,6 @@
 // Regression test for #75777.
 // Checks that a boxed future can be properly constructed.
 
-#![feature(future_readiness_fns)]
-
 use std::future::{self, Future};
 use std::pin::Pin;
 

--- a/src/test/ui/issues/issue-75777.stderr
+++ b/src/test/ui/issues/issue-75777.stderr
@@ -1,16 +1,16 @@
 error[E0495]: cannot infer an appropriate lifetime due to conflicting requirements
-  --> $DIR/issue-75777.rs:13:14
+  --> $DIR/issue-75777.rs:11:14
    |
 LL |     Box::new(move |_| fut)
    |              ^^^^^^^^^^^^
    |
 note: first, the lifetime cannot outlive the lifetime `'a` as defined here...
-  --> $DIR/issue-75777.rs:11:11
+  --> $DIR/issue-75777.rs:9:11
    |
 LL | fn inject<'a, Env: 'a, A: 'a + Send>(v: A) -> Box<dyn FnOnce(&'a Env) -> BoxFuture<'a, A>> {
    |           ^^
 note: ...so that the types are compatible
-  --> $DIR/issue-75777.rs:13:14
+  --> $DIR/issue-75777.rs:11:14
    |
 LL |     Box::new(move |_| fut)
    |              ^^^^^^^^^^^^
@@ -18,7 +18,7 @@ LL |     Box::new(move |_| fut)
               found `(Pin<Box<(dyn Future<Output = A> + Send + 'a)>>,)`
    = note: but, the lifetime must be valid for the static lifetime...
 note: ...so that the types are compatible
-  --> $DIR/issue-75777.rs:13:5
+  --> $DIR/issue-75777.rs:11:5
    |
 LL |     Box::new(move |_| fut)
    |     ^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/issues/issue-78957.rs
+++ b/src/test/ui/issues/issue-78957.rs
@@ -1,5 +1,4 @@
 #![deny(unused_attributes)]
-#![feature(min_const_generics)]
 
 use std::marker::PhantomData;
 

--- a/src/test/ui/issues/issue-78957.stderr
+++ b/src/test/ui/issues/issue-78957.stderr
@@ -1,11 +1,11 @@
 error[E0518]: attribute should be applied to function or closure
-  --> $DIR/issue-78957.rs:6:16
+  --> $DIR/issue-78957.rs:5:16
    |
 LL | pub struct Foo<#[inline] const N: usize>;
    |                ^^^^^^^^^       - not a function or closure
 
 error: attribute should be applied to a function
-  --> $DIR/issue-78957.rs:8:16
+  --> $DIR/issue-78957.rs:7:16
    |
 LL | pub struct Bar<#[cold] const N: usize>;
    |                ^^^^^^^       - not a function
@@ -18,19 +18,19 @@ LL | #![deny(unused_attributes)]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 error[E0517]: attribute should be applied to a struct, enum, or union
-  --> $DIR/issue-78957.rs:11:23
+  --> $DIR/issue-78957.rs:10:23
    |
 LL | pub struct Baz<#[repr(C)] const N: usize>;
    |                       ^         - not a struct, enum, or union
 
 error[E0518]: attribute should be applied to function or closure
-  --> $DIR/issue-78957.rs:14:17
+  --> $DIR/issue-78957.rs:13:17
    |
 LL | pub struct Foo2<#[inline] 'a>(PhantomData<&'a ()>);
    |                 ^^^^^^^^^ -- not a function or closure
 
 error: attribute should be applied to a function
-  --> $DIR/issue-78957.rs:16:17
+  --> $DIR/issue-78957.rs:15:17
    |
 LL | pub struct Bar2<#[cold] 'a>(PhantomData<&'a ()>);
    |                 ^^^^^^^ -- not a function
@@ -38,19 +38,19 @@ LL | pub struct Bar2<#[cold] 'a>(PhantomData<&'a ()>);
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 error[E0517]: attribute should be applied to a struct, enum, or union
-  --> $DIR/issue-78957.rs:19:24
+  --> $DIR/issue-78957.rs:18:24
    |
 LL | pub struct Baz2<#[repr(C)] 'a>(PhantomData<&'a ()>);
    |                        ^   -- not a struct, enum, or union
 
 error[E0518]: attribute should be applied to function or closure
-  --> $DIR/issue-78957.rs:22:17
+  --> $DIR/issue-78957.rs:21:17
    |
 LL | pub struct Foo3<#[inline] T>(PhantomData<T>);
    |                 ^^^^^^^^^ - not a function or closure
 
 error: attribute should be applied to a function
-  --> $DIR/issue-78957.rs:24:17
+  --> $DIR/issue-78957.rs:23:17
    |
 LL | pub struct Bar3<#[cold] T>(PhantomData<T>);
    |                 ^^^^^^^ - not a function
@@ -58,7 +58,7 @@ LL | pub struct Bar3<#[cold] T>(PhantomData<T>);
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 error[E0517]: attribute should be applied to a struct, enum, or union
-  --> $DIR/issue-78957.rs:27:24
+  --> $DIR/issue-78957.rs:26:24
    |
 LL | pub struct Baz3<#[repr(C)] T>(PhantomData<T>);
    |                        ^   - not a struct, enum, or union

--- a/src/test/ui/macros/macro-non-lifetime.rs
+++ b/src/test/ui/macros/macro-non-lifetime.rs
@@ -1,7 +1,5 @@
 // Test for issue #50381: non-lifetime passed to :lifetime.
 
-#![feature(macro_lifetime_matcher)]
-
 macro_rules! m { ($x:lifetime) => { } }
 
 fn main() {

--- a/src/test/ui/macros/macro-non-lifetime.stderr
+++ b/src/test/ui/macros/macro-non-lifetime.stderr
@@ -1,5 +1,5 @@
 error: no rules expected the token `a`
-  --> $DIR/macro-non-lifetime.rs:8:8
+  --> $DIR/macro-non-lifetime.rs:6:8
    |
 LL | macro_rules! m { ($x:lifetime) => { } }
    | -------------- when calling this macro

--- a/src/test/ui/macros/macro-path-prelude-fail-1.rs
+++ b/src/test/ui/macros/macro-path-prelude-fail-1.rs
@@ -1,5 +1,3 @@
-#![feature(extern_prelude)]
-
 mod m {
     fn check() {
         Vec::clone!(); //~ ERROR failed to resolve: `Vec` is a struct, not a module

--- a/src/test/ui/macros/macro-path-prelude-fail-1.stderr
+++ b/src/test/ui/macros/macro-path-prelude-fail-1.stderr
@@ -1,11 +1,11 @@
 error[E0433]: failed to resolve: `Vec` is a struct, not a module
-  --> $DIR/macro-path-prelude-fail-1.rs:5:9
+  --> $DIR/macro-path-prelude-fail-1.rs:3:9
    |
 LL |         Vec::clone!();
    |         ^^^ `Vec` is a struct, not a module
 
 error[E0433]: failed to resolve: `u8` is a builtin type, not a module
-  --> $DIR/macro-path-prelude-fail-1.rs:6:9
+  --> $DIR/macro-path-prelude-fail-1.rs:4:9
    |
 LL |         u8::clone!();
    |         ^^ `u8` is a builtin type, not a module

--- a/src/test/ui/macros/macro-path-prelude-shadowing.rs
+++ b/src/test/ui/macros/macro-path-prelude-shadowing.rs
@@ -1,6 +1,6 @@
 // aux-build:macro-in-other-crate.rs
 
-#![feature(decl_macro, extern_prelude)]
+#![feature(decl_macro)]
 
 macro_rules! add_macro_expanded_things_to_macro_prelude {() => {
     #[macro_use]

--- a/src/test/ui/macros/macro-stability.rs
+++ b/src/test/ui/macros/macro-stability.rs
@@ -2,7 +2,10 @@
 
 #![feature(decl_macro)]
 #![feature(staged_api)]
-#[macro_use] extern crate unstable_macros;
+#![stable(feature = "rust1", since = "1.0.0")]
+
+#[macro_use]
+extern crate unstable_macros;
 
 #[unstable(feature = "local_unstable", issue = "none")]
 macro_rules! local_unstable { () => () }

--- a/src/test/ui/macros/macro-stability.stderr
+++ b/src/test/ui/macros/macro-stability.stderr
@@ -1,5 +1,5 @@
 error[E0658]: use of unstable library feature 'local_unstable'
-  --> $DIR/macro-stability.rs:19:5
+  --> $DIR/macro-stability.rs:22:5
    |
 LL |     local_unstable!();
    |     ^^^^^^^^^^^^^^
@@ -7,7 +7,7 @@ LL |     local_unstable!();
    = help: add `#![feature(local_unstable)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'local_unstable'
-  --> $DIR/macro-stability.rs:20:5
+  --> $DIR/macro-stability.rs:23:5
    |
 LL |     local_unstable_modern!();
    |     ^^^^^^^^^^^^^^^^^^^^^
@@ -15,7 +15,7 @@ LL |     local_unstable_modern!();
    = help: add `#![feature(local_unstable)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_macros'
-  --> $DIR/macro-stability.rs:21:5
+  --> $DIR/macro-stability.rs:24:5
    |
 LL |     unstable_macro!();
    |     ^^^^^^^^^^^^^^
@@ -23,7 +23,7 @@ LL |     unstable_macro!();
    = help: add `#![feature(unstable_macros)]` to the crate attributes to enable
 
 warning: use of deprecated macro `deprecated_macro`: deprecation reason
-  --> $DIR/macro-stability.rs:24:5
+  --> $DIR/macro-stability.rs:27:5
    |
 LL |     deprecated_macro!();
    |     ^^^^^^^^^^^^^^^^
@@ -31,7 +31,7 @@ LL |     deprecated_macro!();
    = note: `#[warn(deprecated)]` on by default
 
 warning: use of deprecated macro `local_deprecated`: local deprecation reason
-  --> $DIR/macro-stability.rs:26:5
+  --> $DIR/macro-stability.rs:29:5
    |
 LL |     local_deprecated!();
    |     ^^^^^^^^^^^^^^^^

--- a/src/test/ui/missing/missing-alloc_error_handler.rs
+++ b/src/test/ui/missing/missing-alloc_error_handler.rs
@@ -3,7 +3,7 @@
 
 #![no_std]
 #![crate_type = "staticlib"]
-#![feature(panic_handler, alloc_error_handler)]
+#![feature(alloc_error_handler)]
 
 #[panic_handler]
 fn panic(_: &core::panic::PanicInfo) -> ! {

--- a/src/test/ui/missing/missing-allocator.rs
+++ b/src/test/ui/missing/missing-allocator.rs
@@ -3,7 +3,7 @@
 
 #![no_std]
 #![crate_type = "staticlib"]
-#![feature(panic_handler, alloc_error_handler)]
+#![feature(alloc_error_handler)]
 
 #[panic_handler]
 fn panic(_: &core::panic::PanicInfo) -> ! {

--- a/src/test/ui/not-panic/not-panic-safe.rs
+++ b/src/test/ui/not-panic/not-panic-safe.rs
@@ -1,5 +1,4 @@
 #![allow(dead_code)]
-#![feature(recover)]
 
 use std::panic::UnwindSafe;
 

--- a/src/test/ui/not-panic/not-panic-safe.stderr
+++ b/src/test/ui/not-panic/not-panic-safe.stderr
@@ -1,5 +1,5 @@
 error[E0277]: the type `&mut i32` may not be safely transferred across an unwind boundary
-  --> $DIR/not-panic-safe.rs:9:5
+  --> $DIR/not-panic-safe.rs:8:5
    |
 LL |     assert::<&mut i32>();
    |     ^^^^^^^^^^^^^^^^^^ `&mut i32` may not be safely transferred across an unwind boundary
@@ -7,7 +7,7 @@ LL |     assert::<&mut i32>();
    = help: the trait `UnwindSafe` is not implemented for `&mut i32`
    = note: `UnwindSafe` is implemented for `&i32`, but not for `&mut i32`
 note: required by a bound in `assert`
-  --> $DIR/not-panic-safe.rs:6:14
+  --> $DIR/not-panic-safe.rs:5:14
    |
 LL | fn assert<T: UnwindSafe + ?Sized>() {}
    |              ^^^^^^^^^^ required by this bound in `assert`

--- a/src/test/ui/object-lifetime/object-lifetime-default-from-rptr-struct-error.rs
+++ b/src/test/ui/object-lifetime/object-lifetime-default-from-rptr-struct-error.rs
@@ -2,7 +2,6 @@
 // through the `MyBox` struct.
 
 #![allow(dead_code)]
-#![feature(rustc_error)]
 
 trait Test {
     fn foo(&self) { }

--- a/src/test/ui/object-lifetime/object-lifetime-default-from-rptr-struct-error.stderr
+++ b/src/test/ui/object-lifetime/object-lifetime-default-from-rptr-struct-error.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/object-lifetime-default-from-rptr-struct-error.rs:21:12
+  --> $DIR/object-lifetime-default-from-rptr-struct-error.rs:20:12
    |
 LL |     ss.t = t;
    |            ^ lifetime mismatch
@@ -7,7 +7,7 @@ LL |     ss.t = t;
    = note: expected reference `&'a MyBox<(dyn Test + 'static)>`
               found reference `&'a MyBox<(dyn Test + 'a)>`
 note: the lifetime `'a` as defined here...
-  --> $DIR/object-lifetime-default-from-rptr-struct-error.rs:20:6
+  --> $DIR/object-lifetime-default-from-rptr-struct-error.rs:19:6
    |
 LL | fn c<'a>(t: &'a MyBox<dyn Test+'a>, mut ss: SomeStruct<'a>) {
    |      ^^

--- a/src/test/ui/once-cant-call-twice-on-heap.rs
+++ b/src/test/ui/once-cant-call-twice-on-heap.rs
@@ -1,7 +1,6 @@
 // Testing guarantees provided by once functions.
 // This program would segfault if it were legal.
 
-#![feature(once_fns)]
 use std::sync::Arc;
 
 fn foo<F:FnOnce()>(blk: F) {

--- a/src/test/ui/once-cant-call-twice-on-heap.stderr
+++ b/src/test/ui/once-cant-call-twice-on-heap.stderr
@@ -1,5 +1,5 @@
 error[E0382]: use of moved value: `blk`
-  --> $DIR/once-cant-call-twice-on-heap.rs:9:5
+  --> $DIR/once-cant-call-twice-on-heap.rs:8:5
    |
 LL | fn foo<F:FnOnce()>(blk: F) {
    |                    --- move occurs because `blk` has type `F`, which does not implement the `Copy` trait
@@ -9,7 +9,7 @@ LL |     blk();
    |     ^^^ value used here after move
    |
 note: this value implements `FnOnce`, which causes it to be moved when called
-  --> $DIR/once-cant-call-twice-on-heap.rs:8:5
+  --> $DIR/once-cant-call-twice-on-heap.rs:7:5
    |
 LL |     blk();
    |     ^^^

--- a/src/test/ui/or-patterns/nested-undelimited-precedence.rs
+++ b/src/test/ui/or-patterns/nested-undelimited-precedence.rs
@@ -5,8 +5,6 @@
 // types of patterns that allow undelimited subpatterns that could cause the same ambiguity.
 // Currently, those should be impossible due to precedence rule. This test enforces that.
 
-#![feature(or_patterns)]
-
 enum E {
     A,
     B,

--- a/src/test/ui/or-patterns/nested-undelimited-precedence.stderr
+++ b/src/test/ui/or-patterns/nested-undelimited-precedence.stderr
@@ -1,35 +1,35 @@
 error: top-level or-patterns are not allowed in `let` bindings
-  --> $DIR/nested-undelimited-precedence.rs:21:9
+  --> $DIR/nested-undelimited-precedence.rs:19:9
    |
 LL |     let b @ A | B: E = A;
    |         ^^^^^^^^^ help: wrap the pattern in parentheses: `(b @ A | B)`
 
 error: top-level or-patterns are not allowed in `let` bindings
-  --> $DIR/nested-undelimited-precedence.rs:36:9
+  --> $DIR/nested-undelimited-precedence.rs:34:9
    |
 LL |     let &A(_) | B(_): F = A(3);
    |         ^^^^^^^^^^^^ help: wrap the pattern in parentheses: `(&A(_) | B(_))`
 
 error: top-level or-patterns are not allowed in `let` bindings
-  --> $DIR/nested-undelimited-precedence.rs:38:9
+  --> $DIR/nested-undelimited-precedence.rs:36:9
    |
 LL |     let &&A(_) | B(_): F = A(3);
    |         ^^^^^^^^^^^^^ help: wrap the pattern in parentheses: `(&&A(_) | B(_))`
 
 error: top-level or-patterns are not allowed in `let` bindings
-  --> $DIR/nested-undelimited-precedence.rs:40:9
+  --> $DIR/nested-undelimited-precedence.rs:38:9
    |
 LL |     let &mut A(_) | B(_): F = A(3);
    |         ^^^^^^^^^^^^^^^^ help: wrap the pattern in parentheses: `(&mut A(_) | B(_))`
 
 error: top-level or-patterns are not allowed in `let` bindings
-  --> $DIR/nested-undelimited-precedence.rs:42:9
+  --> $DIR/nested-undelimited-precedence.rs:40:9
    |
 LL |     let &&mut A(_) | B(_): F = A(3);
    |         ^^^^^^^^^^^^^^^^^ help: wrap the pattern in parentheses: `(&&mut A(_) | B(_))`
 
 error[E0408]: variable `b` is not bound in all patterns
-  --> $DIR/nested-undelimited-precedence.rs:21:17
+  --> $DIR/nested-undelimited-precedence.rs:19:17
    |
 LL |     let b @ A | B: E = A;
    |         -       ^ pattern doesn't bind `b`
@@ -37,7 +37,7 @@ LL |     let b @ A | B: E = A;
    |         variable not in all patterns
 
 error[E0308]: mismatched types
-  --> $DIR/nested-undelimited-precedence.rs:36:9
+  --> $DIR/nested-undelimited-precedence.rs:34:9
    |
 LL |     let &A(_) | B(_): F = A(3);
    |         ^^^^^         - expected due to this
@@ -48,7 +48,7 @@ LL |     let &A(_) | B(_): F = A(3);
            found reference `&_`
 
 error[E0308]: mismatched types
-  --> $DIR/nested-undelimited-precedence.rs:38:9
+  --> $DIR/nested-undelimited-precedence.rs:36:9
    |
 LL |     let &&A(_) | B(_): F = A(3);
    |         ^^^^^^         - expected due to this
@@ -59,7 +59,7 @@ LL |     let &&A(_) | B(_): F = A(3);
            found reference `&_`
 
 error[E0308]: mismatched types
-  --> $DIR/nested-undelimited-precedence.rs:40:9
+  --> $DIR/nested-undelimited-precedence.rs:38:9
    |
 LL |     let &mut A(_) | B(_): F = A(3);
    |         ^^^^^^^^^         - expected due to this
@@ -70,7 +70,7 @@ LL |     let &mut A(_) | B(_): F = A(3);
            found mutable reference `&mut _`
 
 error[E0308]: mismatched types
-  --> $DIR/nested-undelimited-precedence.rs:42:9
+  --> $DIR/nested-undelimited-precedence.rs:40:9
    |
 LL |     let &&mut A(_) | B(_): F = A(3);
    |         ^^^^^^^^^^         - expected due to this

--- a/src/test/ui/or-patterns/or-patterns-syntactic-fail-2018.rs
+++ b/src/test/ui/or-patterns/or-patterns-syntactic-fail-2018.rs
@@ -2,8 +2,6 @@
 
 // edition:2018
 
-#![feature(or_patterns)]
-
 fn main() {}
 
 // Test the `pat` macro fragment parser:

--- a/src/test/ui/or-patterns/or-patterns-syntactic-fail-2018.stderr
+++ b/src/test/ui/or-patterns/or-patterns-syntactic-fail-2018.stderr
@@ -1,5 +1,5 @@
 error: no rules expected the token `|`
-  --> $DIR/or-patterns-syntactic-fail-2018.rs:14:15
+  --> $DIR/or-patterns-syntactic-fail-2018.rs:12:15
    |
 LL | macro_rules! accept_pat {
    | ----------------------- when calling this macro
@@ -8,7 +8,7 @@ LL | accept_pat!(p | q);
    |               ^ no rules expected this token in macro call
 
 error: no rules expected the token `|`
-  --> $DIR/or-patterns-syntactic-fail-2018.rs:15:13
+  --> $DIR/or-patterns-syntactic-fail-2018.rs:13:13
    |
 LL | macro_rules! accept_pat {
    | ----------------------- when calling this macro

--- a/src/test/ui/pattern/usefulness/integer-ranges/exhaustiveness.rs
+++ b/src/test/ui/pattern/usefulness/integer-ranges/exhaustiveness.rs
@@ -1,5 +1,4 @@
 #![feature(exclusive_range_pattern)]
-#![feature(assoc_char_consts)]
 #![allow(overlapping_range_endpoints)]
 #![deny(unreachable_patterns)]
 

--- a/src/test/ui/pattern/usefulness/integer-ranges/exhaustiveness.stderr
+++ b/src/test/ui/pattern/usefulness/integer-ranges/exhaustiveness.stderr
@@ -1,5 +1,5 @@
 error[E0004]: non-exhaustive patterns: `u8::MAX` not covered
-  --> $DIR/exhaustiveness.rs:48:8
+  --> $DIR/exhaustiveness.rs:47:8
    |
 LL |     m!(0u8, 0..255);
    |        ^^^ pattern `u8::MAX` not covered
@@ -8,7 +8,7 @@ LL |     m!(0u8, 0..255);
    = note: the matched value is of type `u8`
 
 error[E0004]: non-exhaustive patterns: `u8::MAX` not covered
-  --> $DIR/exhaustiveness.rs:49:8
+  --> $DIR/exhaustiveness.rs:48:8
    |
 LL |     m!(0u8, 0..=254);
    |        ^^^ pattern `u8::MAX` not covered
@@ -17,7 +17,7 @@ LL |     m!(0u8, 0..=254);
    = note: the matched value is of type `u8`
 
 error[E0004]: non-exhaustive patterns: `0_u8` not covered
-  --> $DIR/exhaustiveness.rs:50:8
+  --> $DIR/exhaustiveness.rs:49:8
    |
 LL |     m!(0u8, 1..=255);
    |        ^^^ pattern `0_u8` not covered
@@ -26,7 +26,7 @@ LL |     m!(0u8, 1..=255);
    = note: the matched value is of type `u8`
 
 error[E0004]: non-exhaustive patterns: `42_u8` not covered
-  --> $DIR/exhaustiveness.rs:51:8
+  --> $DIR/exhaustiveness.rs:50:8
    |
 LL |     m!(0u8, 0..42 | 43..=255);
    |        ^^^ pattern `42_u8` not covered
@@ -35,7 +35,7 @@ LL |     m!(0u8, 0..42 | 43..=255);
    = note: the matched value is of type `u8`
 
 error[E0004]: non-exhaustive patterns: `i8::MAX` not covered
-  --> $DIR/exhaustiveness.rs:52:8
+  --> $DIR/exhaustiveness.rs:51:8
    |
 LL |     m!(0i8, -128..127);
    |        ^^^ pattern `i8::MAX` not covered
@@ -44,7 +44,7 @@ LL |     m!(0i8, -128..127);
    = note: the matched value is of type `i8`
 
 error[E0004]: non-exhaustive patterns: `i8::MAX` not covered
-  --> $DIR/exhaustiveness.rs:53:8
+  --> $DIR/exhaustiveness.rs:52:8
    |
 LL |     m!(0i8, -128..=126);
    |        ^^^ pattern `i8::MAX` not covered
@@ -53,7 +53,7 @@ LL |     m!(0i8, -128..=126);
    = note: the matched value is of type `i8`
 
 error[E0004]: non-exhaustive patterns: `i8::MIN` not covered
-  --> $DIR/exhaustiveness.rs:54:8
+  --> $DIR/exhaustiveness.rs:53:8
    |
 LL |     m!(0i8, -127..=127);
    |        ^^^ pattern `i8::MIN` not covered
@@ -62,7 +62,7 @@ LL |     m!(0i8, -127..=127);
    = note: the matched value is of type `i8`
 
 error[E0004]: non-exhaustive patterns: `0_i8` not covered
-  --> $DIR/exhaustiveness.rs:55:11
+  --> $DIR/exhaustiveness.rs:54:11
    |
 LL |     match 0i8 {
    |           ^^^ pattern `0_i8` not covered
@@ -71,7 +71,7 @@ LL |     match 0i8 {
    = note: the matched value is of type `i8`
 
 error[E0004]: non-exhaustive patterns: `u128::MAX` not covered
-  --> $DIR/exhaustiveness.rs:60:8
+  --> $DIR/exhaustiveness.rs:59:8
    |
 LL |     m!(0u128, 0..=ALMOST_MAX);
    |        ^^^^^ pattern `u128::MAX` not covered
@@ -80,7 +80,7 @@ LL |     m!(0u128, 0..=ALMOST_MAX);
    = note: the matched value is of type `u128`
 
 error[E0004]: non-exhaustive patterns: `5_u128..=u128::MAX` not covered
-  --> $DIR/exhaustiveness.rs:61:8
+  --> $DIR/exhaustiveness.rs:60:8
    |
 LL |     m!(0u128, 0..=4);
    |        ^^^^^ pattern `5_u128..=u128::MAX` not covered
@@ -89,7 +89,7 @@ LL |     m!(0u128, 0..=4);
    = note: the matched value is of type `u128`
 
 error[E0004]: non-exhaustive patterns: `0_u128` not covered
-  --> $DIR/exhaustiveness.rs:62:8
+  --> $DIR/exhaustiveness.rs:61:8
    |
 LL |     m!(0u128, 1..=u128::MAX);
    |        ^^^^^ pattern `0_u128` not covered
@@ -98,7 +98,7 @@ LL |     m!(0u128, 1..=u128::MAX);
    = note: the matched value is of type `u128`
 
 error[E0004]: non-exhaustive patterns: `(126_u8..=127_u8, false)` not covered
-  --> $DIR/exhaustiveness.rs:70:11
+  --> $DIR/exhaustiveness.rs:69:11
    |
 LL |     match (0u8, true) {
    |           ^^^^^^^^^^^ pattern `(126_u8..=127_u8, false)` not covered

--- a/src/test/ui/pub/pub-restricted-error.rs
+++ b/src/test/ui/pub/pub-restricted-error.rs
@@ -1,5 +1,3 @@
-#![feature(pub_restricted)]
-
 struct Bar(pub(()));
 
 struct Foo {

--- a/src/test/ui/pub/pub-restricted-error.stderr
+++ b/src/test/ui/pub/pub-restricted-error.stderr
@@ -1,5 +1,5 @@
 error: expected identifier, found `(`
-  --> $DIR/pub-restricted-error.rs:6:16
+  --> $DIR/pub-restricted-error.rs:4:16
    |
 LL |     pub(crate) () foo: usize,
    |                ^ expected identifier

--- a/src/test/ui/pub/pub-restricted.rs
+++ b/src/test/ui/pub/pub-restricted.rs
@@ -1,5 +1,3 @@
-#![feature(pub_restricted)]
-
 mod a {}
 
 pub (a) fn afn() {} //~ incorrect visibility restriction

--- a/src/test/ui/pub/pub-restricted.stderr
+++ b/src/test/ui/pub/pub-restricted.stderr
@@ -1,5 +1,5 @@
 error[E0704]: incorrect visibility restriction
-  --> $DIR/pub-restricted.rs:5:6
+  --> $DIR/pub-restricted.rs:3:6
    |
 LL | pub (a) fn afn() {}
    |      ^ help: make this visible only to module `a` with `in`: `in a`
@@ -10,7 +10,7 @@ LL | pub (a) fn afn() {}
            `pub(in path::to::module)`: visible only on the specified path
 
 error[E0704]: incorrect visibility restriction
-  --> $DIR/pub-restricted.rs:6:6
+  --> $DIR/pub-restricted.rs:4:6
    |
 LL | pub (b) fn bfn() {}
    |      ^ help: make this visible only to module `b` with `in`: `in b`
@@ -21,7 +21,7 @@ LL | pub (b) fn bfn() {}
            `pub(in path::to::module)`: visible only on the specified path
 
 error[E0704]: incorrect visibility restriction
-  --> $DIR/pub-restricted.rs:7:6
+  --> $DIR/pub-restricted.rs:5:6
    |
 LL | pub (crate::a) fn cfn() {}
    |      ^^^^^^^^ help: make this visible only to module `crate::a` with `in`: `in crate::a`
@@ -32,7 +32,7 @@ LL | pub (crate::a) fn cfn() {}
            `pub(in path::to::module)`: visible only on the specified path
 
 error[E0704]: incorrect visibility restriction
-  --> $DIR/pub-restricted.rs:24:14
+  --> $DIR/pub-restricted.rs:22:14
    |
 LL |         pub (a) invalid: usize,
    |              ^ help: make this visible only to module `a` with `in`: `in a`
@@ -43,7 +43,7 @@ LL |         pub (a) invalid: usize,
            `pub(in path::to::module)`: visible only on the specified path
 
 error[E0704]: incorrect visibility restriction
-  --> $DIR/pub-restricted.rs:33:6
+  --> $DIR/pub-restricted.rs:31:6
    |
 LL | pub (xyz) fn xyz() {}
    |      ^^^ help: make this visible only to module `xyz` with `in`: `in xyz`
@@ -54,7 +54,7 @@ LL | pub (xyz) fn xyz() {}
            `pub(in path::to::module)`: visible only on the specified path
 
 error[E0742]: visibilities can only be restricted to ancestor modules
-  --> $DIR/pub-restricted.rs:25:17
+  --> $DIR/pub-restricted.rs:23:17
    |
 LL |         pub (in x) non_parent_invalid: usize,
    |                 ^

--- a/src/test/ui/repr/repr-transparent-other-reprs.rs
+++ b/src/test/ui/repr/repr-transparent-other-reprs.rs
@@ -1,5 +1,3 @@
-#![feature(repr_align)]
-
 // See also repr-transparent.rs
 
 #[repr(transparent, C)] //~ ERROR cannot have other repr

--- a/src/test/ui/repr/repr-transparent-other-reprs.stderr
+++ b/src/test/ui/repr/repr-transparent-other-reprs.stderr
@@ -1,23 +1,23 @@
 error[E0692]: transparent struct cannot have other repr hints
-  --> $DIR/repr-transparent-other-reprs.rs:5:8
+  --> $DIR/repr-transparent-other-reprs.rs:3:8
    |
 LL | #[repr(transparent, C)]
    |        ^^^^^^^^^^^  ^
 
 error[E0692]: transparent struct cannot have other repr hints
-  --> $DIR/repr-transparent-other-reprs.rs:10:8
+  --> $DIR/repr-transparent-other-reprs.rs:8:8
    |
 LL | #[repr(transparent, packed)]
    |        ^^^^^^^^^^^  ^^^^^^
 
 error[E0692]: transparent struct cannot have other repr hints
-  --> $DIR/repr-transparent-other-reprs.rs:13:8
+  --> $DIR/repr-transparent-other-reprs.rs:11:8
    |
 LL | #[repr(transparent, align(2))]
    |        ^^^^^^^^^^^  ^^^^^^^^
 
 error[E0692]: transparent struct cannot have other repr hints
-  --> $DIR/repr-transparent-other-reprs.rs:16:8
+  --> $DIR/repr-transparent-other-reprs.rs:14:8
    |
 LL | #[repr(transparent)]
    |        ^^^^^^^^^^^

--- a/src/test/ui/rfc-2093-infer-outlives/explicit-dyn.rs
+++ b/src/test/ui/rfc-2093-infer-outlives/explicit-dyn.rs
@@ -1,4 +1,3 @@
-#![feature(dyn_trait)]
 #![feature(rustc_attrs)]
 
 trait Trait<'x, T> where T: 'x {

--- a/src/test/ui/rfc-2093-infer-outlives/explicit-dyn.stderr
+++ b/src/test/ui/rfc-2093-infer-outlives/explicit-dyn.stderr
@@ -1,5 +1,5 @@
 error: rustc_outlives
-  --> $DIR/explicit-dyn.rs:8:1
+  --> $DIR/explicit-dyn.rs:7:1
    |
 LL | / struct Foo<'a, A>
 LL | | {

--- a/src/test/ui/rfc-2093-infer-outlives/self-dyn.rs
+++ b/src/test/ui/rfc-2093-infer-outlives/self-dyn.rs
@@ -1,4 +1,3 @@
-#![feature(dyn_trait)]
 #![feature(rustc_attrs)]
 
 trait Trait<'x, 's, T> where T: 'x,

--- a/src/test/ui/rfc-2093-infer-outlives/self-dyn.stderr
+++ b/src/test/ui/rfc-2093-infer-outlives/self-dyn.stderr
@@ -1,5 +1,5 @@
 error: rustc_outlives
-  --> $DIR/self-dyn.rs:9:1
+  --> $DIR/self-dyn.rs:8:1
    |
 LL | / struct Foo<'a, 'b, A>
 LL | | {

--- a/src/test/ui/rfc-2126-crate-paths/crate-path-non-absolute.rs
+++ b/src/test/ui/rfc-2126-crate-paths/crate-path-non-absolute.rs
@@ -1,5 +1,3 @@
-#![feature(crate_in_paths)]
-
 struct S;
 
 pub mod m {

--- a/src/test/ui/rfc-2126-crate-paths/crate-path-non-absolute.stderr
+++ b/src/test/ui/rfc-2126-crate-paths/crate-path-non-absolute.stderr
@@ -1,11 +1,11 @@
 error[E0433]: failed to resolve: `crate` in paths can only be used in start position
-  --> $DIR/crate-path-non-absolute.rs:7:22
+  --> $DIR/crate-path-non-absolute.rs:5:22
    |
 LL |         let s = ::m::crate::S;
    |                      ^^^^^ `crate` in paths can only be used in start position
 
 error[E0433]: failed to resolve: global paths cannot start with `crate`
-  --> $DIR/crate-path-non-absolute.rs:8:20
+  --> $DIR/crate-path-non-absolute.rs:6:20
    |
 LL |         let s1 = ::crate::S;
    |                    ^^^^^ global paths cannot start with `crate`

--- a/src/test/ui/rfc-2126-crate-paths/keyword-crate-as-identifier.rs
+++ b/src/test/ui/rfc-2126-crate-paths/keyword-crate-as-identifier.rs
@@ -1,5 +1,3 @@
-#![feature(crate_in_paths)]
-
 fn main() {
     let crate = 0;
     //~^ ERROR expected unit struct, unit variant or constant, found module `crate`

--- a/src/test/ui/rfc-2126-crate-paths/keyword-crate-as-identifier.stderr
+++ b/src/test/ui/rfc-2126-crate-paths/keyword-crate-as-identifier.stderr
@@ -1,5 +1,5 @@
 error[E0532]: expected unit struct, unit variant or constant, found module `crate`
-  --> $DIR/keyword-crate-as-identifier.rs:4:9
+  --> $DIR/keyword-crate-as-identifier.rs:2:9
    |
 LL |     let crate = 0;
    |         ^^^^^ not a unit struct, unit variant or constant

--- a/src/test/ui/rfc-2632-const-trait-impl/stability.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/stability.rs
@@ -2,7 +2,9 @@
 #![feature(const_add)]
 #![feature(const_trait_impl)]
 #![feature(staged_api)]
+#![stable(feature = "rust1", since = "1.0.0")]
 
+#[stable(feature = "rust1", since = "1.0.0")]
 pub struct Int(i32);
 
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -16,6 +18,7 @@ impl const std::ops::Sub for Int {
     }
 }
 
+#[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_const_unstable(feature = "const_add", issue = "none")]
 impl const std::ops::Add for Int {
     type Output = Self;

--- a/src/test/ui/rfc-2632-const-trait-impl/stability.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/stability.stderr
@@ -1,5 +1,5 @@
 error: trait methods cannot be stable const fn
-  --> $DIR/stability.rs:13:5
+  --> $DIR/stability.rs:15:5
    |
 LL | /     fn sub(self, rhs: Self) -> Self {
 LL | |
@@ -8,7 +8,7 @@ LL | |     }
    | |_____^
 
 error: `<Int as Add>::add` is not yet stable as a const fn
-  --> $DIR/stability.rs:31:5
+  --> $DIR/stability.rs:34:5
    |
 LL |     Int(1i32) + Int(2i32)
    |     ^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/rust-2018/uniform-paths/issue-56596.rs
+++ b/src/test/ui/rust-2018/uniform-paths/issue-56596.rs
@@ -2,8 +2,6 @@
 // compile-flags: --extern issue_56596
 // aux-build:issue-56596.rs
 
-#![feature(uniform_paths)]
-
 mod m {
     pub mod issue_56596 {}
 }

--- a/src/test/ui/rust-2018/uniform-paths/issue-56596.stderr
+++ b/src/test/ui/rust-2018/uniform-paths/issue-56596.stderr
@@ -1,5 +1,5 @@
 error[E0659]: `issue_56596` is ambiguous
-  --> $DIR/issue-56596.rs:12:5
+  --> $DIR/issue-56596.rs:10:5
    |
 LL | use issue_56596;
    |     ^^^^^^^^^^^ ambiguous name
@@ -8,7 +8,7 @@ LL | use issue_56596;
    = note: `issue_56596` could refer to a crate passed with `--extern`
    = help: use `::issue_56596` to refer to this crate unambiguously
 note: `issue_56596` could also refer to the module imported here
-  --> $DIR/issue-56596.rs:11:5
+  --> $DIR/issue-56596.rs:9:5
    |
 LL | use m::*;
    |     ^^^^

--- a/src/test/ui/span/issue-23827.rs
+++ b/src/test/ui/span/issue-23827.rs
@@ -1,6 +1,6 @@
 // Regression test for #23827
 
-#![feature(core, fn_traits, unboxed_closures)]
+#![feature(fn_traits, unboxed_closures)]
 
 pub struct Prototype {
     pub target: u32

--- a/src/test/ui/stability-attribute/stability-attribute-non-staged-force-unstable.rs
+++ b/src/test/ui/stability-attribute/stability-attribute-non-staged-force-unstable.rs
@@ -3,4 +3,5 @@
 #[unstable()] //~ ERROR: stability attributes may not be used
 #[stable()] //~ ERROR: stability attributes may not be used
 #[rustc_deprecated()] //~ ERROR: stability attributes may not be used
-fn main() { }
+//~^ ERROR missing 'since'
+fn main() {}

--- a/src/test/ui/stability-attribute/stability-attribute-non-staged-force-unstable.stderr
+++ b/src/test/ui/stability-attribute/stability-attribute-non-staged-force-unstable.stderr
@@ -16,6 +16,13 @@ error[E0734]: stability attributes may not be used outside of the standard libra
 LL | #[rustc_deprecated()]
    | ^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 3 previous errors
+error[E0542]: missing 'since'
+  --> $DIR/stability-attribute-non-staged-force-unstable.rs:5:1
+   |
+LL | #[rustc_deprecated()]
+   | ^^^^^^^^^^^^^^^^^^^^^
 
-For more information about this error, try `rustc --explain E0734`.
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0542, E0734.
+For more information about an error, try `rustc --explain E0542`.

--- a/src/test/ui/stability-attribute/stability-attribute-non-staged.rs
+++ b/src/test/ui/stability-attribute/stability-attribute-non-staged.rs
@@ -1,4 +1,5 @@
 #[unstable()] //~ ERROR: stability attributes may not be used
 #[stable()] //~ ERROR: stability attributes may not be used
 #[rustc_deprecated()] //~ ERROR: stability attributes may not be used
-fn main() { }
+//~^ ERROR missing 'since'
+fn main() {}

--- a/src/test/ui/stability-attribute/stability-attribute-non-staged.stderr
+++ b/src/test/ui/stability-attribute/stability-attribute-non-staged.stderr
@@ -16,6 +16,13 @@ error[E0734]: stability attributes may not be used outside of the standard libra
 LL | #[rustc_deprecated()]
    | ^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 3 previous errors
+error[E0542]: missing 'since'
+  --> $DIR/stability-attribute-non-staged.rs:3:1
+   |
+LL | #[rustc_deprecated()]
+   | ^^^^^^^^^^^^^^^^^^^^^
 
-For more information about this error, try `rustc --explain E0734`.
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0542, E0734.
+For more information about an error, try `rustc --explain E0542`.

--- a/src/test/ui/stability-attribute/stability-attribute-sanity-4.rs
+++ b/src/test/ui/stability-attribute/stability-attribute-sanity-4.rs
@@ -19,10 +19,12 @@ mod bogus_attribute_types_2 {
 
     #[stable(feature = "a", since = "b")]
     #[rustc_deprecated] //~ ERROR malformed `rustc_deprecated` attribute
+                        //~^ ERROR missing 'since'
     fn f5() { }
 
     #[stable(feature = "a", since = "b")]
     #[rustc_deprecated = "a"] //~ ERROR malformed `rustc_deprecated` attribute
+                              //~^ ERROR missing 'since'
     fn f6() { }
 }
 

--- a/src/test/ui/stability-attribute/stability-attribute-sanity-4.stderr
+++ b/src/test/ui/stability-attribute/stability-attribute-sanity-4.stderr
@@ -29,10 +29,23 @@ LL |     #[rustc_deprecated]
    |     ^^^^^^^^^^^^^^^^^^^ help: must be of the form: `#[rustc_deprecated(since = "version", reason = "...")]`
 
 error: malformed `rustc_deprecated` attribute input
-  --> $DIR/stability-attribute-sanity-4.rs:25:5
+  --> $DIR/stability-attribute-sanity-4.rs:26:5
    |
 LL |     #[rustc_deprecated = "a"]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^ help: must be of the form: `#[rustc_deprecated(since = "version", reason = "...")]`
 
-error: aborting due to 6 previous errors
+error[E0542]: missing 'since'
+  --> $DIR/stability-attribute-sanity-4.rs:21:5
+   |
+LL |     #[rustc_deprecated]
+   |     ^^^^^^^^^^^^^^^^^^^
 
+error[E0542]: missing 'since'
+  --> $DIR/stability-attribute-sanity-4.rs:26:5
+   |
+LL |     #[rustc_deprecated = "a"]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 8 previous errors
+
+For more information about this error, try `rustc --explain E0542`.

--- a/src/test/ui/stability-attribute/stability-attribute-sanity.rs
+++ b/src/test/ui/stability-attribute/stability-attribute-sanity.rs
@@ -65,6 +65,7 @@ fn multiple3() { }
 pub const fn multiple4() { }
 
 #[stable(feature = "a", since = "1.0.0")] //~ ERROR invalid deprecation version found
+//~^ ERROR feature `a` is declared stable since 1.0.0
 #[rustc_deprecated(since = "invalid", reason = "text")]
 fn invalid_deprecation_version() {}
 

--- a/src/test/ui/stability-attribute/stability-attribute-sanity.stderr
+++ b/src/test/ui/stability-attribute/stability-attribute-sanity.stderr
@@ -110,17 +110,23 @@ error: invalid deprecation version found
    |
 LL | #[stable(feature = "a", since = "1.0.0")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ invalid deprecation version
-LL | #[rustc_deprecated(since = "invalid", reason = "text")]
+...
 LL | fn invalid_deprecation_version() {}
    | ----------------------------------- the stability attribute annotates this item
 
 error[E0549]: rustc_deprecated attribute must be paired with either stable or unstable attribute
-  --> $DIR/stability-attribute-sanity.rs:71:1
+  --> $DIR/stability-attribute-sanity.rs:72:1
    |
 LL | #[rustc_deprecated(since = "a", reason = "text")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 19 previous errors
+error[E0711]: feature `a` is declared stable since 1.0.0, but was previously declared stable since b
+  --> $DIR/stability-attribute-sanity.rs:67:1
+   |
+LL | #[stable(feature = "a", since = "1.0.0")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 20 previous errors
 
 Some errors have detailed explanations: E0539, E0541, E0542, E0543, E0544, E0546, E0547, E0549, E0550.
 For more information about an error, try `rustc --explain E0539`.

--- a/src/test/ui/target-feature/invalid-attribute.rs
+++ b/src/test/ui/target-feature/invalid-attribute.rs
@@ -12,7 +12,6 @@
 // ignore-sparc
 // ignore-sparc64
 
-#![feature(target_feature)]
 #![warn(unused_attributes)]
 
 #[target_feature = "+sse2"]

--- a/src/test/ui/target-feature/invalid-attribute.stderr
+++ b/src/test/ui/target-feature/invalid-attribute.stderr
@@ -1,29 +1,29 @@
 error: malformed `target_feature` attribute input
-  --> $DIR/invalid-attribute.rs:18:1
+  --> $DIR/invalid-attribute.rs:17:1
    |
 LL | #[target_feature = "+sse2"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: must be of the form: `#[target_feature(enable = "name")]`
 
 error: the feature named `foo` is not valid for this target
-  --> $DIR/invalid-attribute.rs:20:18
+  --> $DIR/invalid-attribute.rs:19:18
    |
 LL | #[target_feature(enable = "foo")]
    |                  ^^^^^^^^^^^^^^ `foo` is not valid for this target
 
 error: malformed `target_feature` attribute input
-  --> $DIR/invalid-attribute.rs:23:18
+  --> $DIR/invalid-attribute.rs:22:18
    |
 LL | #[target_feature(bar)]
    |                  ^^^ help: must be of the form: `enable = ".."`
 
 error: malformed `target_feature` attribute input
-  --> $DIR/invalid-attribute.rs:25:18
+  --> $DIR/invalid-attribute.rs:24:18
    |
 LL | #[target_feature(disable = "baz")]
    |                  ^^^^^^^^^^^^^^^ help: must be of the form: `enable = ".."`
 
 error[E0658]: `#[target_feature(..)]` can only be applied to `unsafe` functions
-  --> $DIR/invalid-attribute.rs:29:1
+  --> $DIR/invalid-attribute.rs:28:1
    |
 LL | #[target_feature(enable = "sse2")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -35,7 +35,7 @@ LL | fn bar() {}
    = help: add `#![feature(target_feature_11)]` to the crate attributes to enable
 
 error: attribute should be applied to a function
-  --> $DIR/invalid-attribute.rs:35:1
+  --> $DIR/invalid-attribute.rs:34:1
    |
 LL | #[target_feature(enable = "sse2")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -44,7 +44,7 @@ LL | mod another {}
    | -------------- not a function
 
 error: attribute should be applied to a function
-  --> $DIR/invalid-attribute.rs:40:1
+  --> $DIR/invalid-attribute.rs:39:1
    |
 LL | #[target_feature(enable = "sse2")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -53,7 +53,7 @@ LL | const FOO: usize = 7;
    | --------------------- not a function
 
 error: attribute should be applied to a function
-  --> $DIR/invalid-attribute.rs:45:1
+  --> $DIR/invalid-attribute.rs:44:1
    |
 LL | #[target_feature(enable = "sse2")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -62,7 +62,7 @@ LL | struct Foo;
    | ----------- not a function
 
 error: attribute should be applied to a function
-  --> $DIR/invalid-attribute.rs:50:1
+  --> $DIR/invalid-attribute.rs:49:1
    |
 LL | #[target_feature(enable = "sse2")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -71,7 +71,7 @@ LL | enum Bar {}
    | ----------- not a function
 
 error: attribute should be applied to a function
-  --> $DIR/invalid-attribute.rs:55:1
+  --> $DIR/invalid-attribute.rs:54:1
    |
 LL |   #[target_feature(enable = "sse2")]
    |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -84,7 +84,7 @@ LL | | }
    | |_- not a function
 
 error: attribute should be applied to a function
-  --> $DIR/invalid-attribute.rs:63:1
+  --> $DIR/invalid-attribute.rs:62:1
    |
 LL | #[target_feature(enable = "sse2")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -93,13 +93,13 @@ LL | trait Baz {}
    | ------------ not a function
 
 error: cannot use `#[inline(always)]` with `#[target_feature]`
-  --> $DIR/invalid-attribute.rs:68:1
+  --> $DIR/invalid-attribute.rs:67:1
    |
 LL | #[inline(always)]
    | ^^^^^^^^^^^^^^^^^
 
 error: attribute should be applied to a function
-  --> $DIR/invalid-attribute.rs:86:5
+  --> $DIR/invalid-attribute.rs:85:5
    |
 LL |       #[target_feature(enable = "sse2")]
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -111,7 +111,7 @@ LL | |     }
    | |_____- not a function
 
 error: attribute should be applied to a function
-  --> $DIR/invalid-attribute.rs:94:5
+  --> $DIR/invalid-attribute.rs:93:5
    |
 LL |     #[target_feature(enable = "sse2")]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -120,7 +120,7 @@ LL |     || {};
    |     ----- not a function
 
 error[E0658]: `#[target_feature(..)]` can only be applied to `unsafe` functions
-  --> $DIR/invalid-attribute.rs:78:5
+  --> $DIR/invalid-attribute.rs:77:5
    |
 LL |     #[target_feature(enable = "sse2")]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/try-trait/try-on-option-diagnostics.rs
+++ b/src/test/ui/try-trait/try-on-option-diagnostics.rs
@@ -1,5 +1,5 @@
-#![feature(try_trait)]
 // edition:2018
+
 fn main() {}
 
 fn a_function() -> u32 {

--- a/src/test/ui/try-trait/try-on-option.rs
+++ b/src/test/ui/try-trait/try-on-option.rs
@@ -1,5 +1,3 @@
-#![feature(try_trait)]
-
 fn main() {}
 
 fn foo() -> Result<u32, ()> {

--- a/src/test/ui/try-trait/try-on-option.stderr
+++ b/src/test/ui/try-trait/try-on-option.stderr
@@ -1,5 +1,5 @@
 error[E0277]: the `?` operator can only be used on `Result`s, not `Option`s, in a function that returns `Result`
-  --> $DIR/try-on-option.rs:7:6
+  --> $DIR/try-on-option.rs:5:6
    |
 LL | / fn foo() -> Result<u32, ()> {
 LL | |     let x: Option<u32> = None;
@@ -12,7 +12,7 @@ LL | | }
    = help: the trait `FromResidual<Option<Infallible>>` is not implemented for `Result<u32, ()>`
 
 error[E0277]: the `?` operator can only be used in a function that returns `Result` or `Option` (or another type that implements `FromResidual`)
-  --> $DIR/try-on-option.rs:13:6
+  --> $DIR/try-on-option.rs:11:6
    |
 LL | / fn bar() -> u32 {
 LL | |     let x: Option<u32> = None;

--- a/src/test/ui/type-alias-impl-trait/issue-63355.rs
+++ b/src/test/ui/type-alias-impl-trait/issue-63355.rs
@@ -1,5 +1,4 @@
 #![feature(type_alias_impl_trait)]
-#![feature(type_alias_impl_trait)]
 #![allow(incomplete_features)]
 
 pub trait Foo {}

--- a/src/test/ui/type-alias-impl-trait/issue-63355.stderr
+++ b/src/test/ui/type-alias-impl-trait/issue-63355.stderr
@@ -1,5 +1,5 @@
 error[E0271]: type mismatch resolving `<() as Bar>::Foo == ()`
-  --> $DIR/issue-63355.rs:34:20
+  --> $DIR/issue-63355.rs:33:20
    |
 LL | pub type FooImpl = impl Foo;
    |                    -------- the found opaque type
@@ -7,7 +7,7 @@ LL | pub type BarImpl = impl Bar<Foo = FooImpl>;
    |                    ^^^^^^^^^^^^^^^^^^^^^^^ type mismatch resolving `<() as Bar>::Foo == ()`
    |
 note: expected this to be `()`
-  --> $DIR/issue-63355.rs:24:16
+  --> $DIR/issue-63355.rs:23:16
    |
 LL |     type Foo = FooImpl;
    |                ^^^^^^^

--- a/src/test/ui/type-alias-impl-trait/issue-65384.rs
+++ b/src/test/ui/type-alias-impl-trait/issue-65384.rs
@@ -1,5 +1,4 @@
 #![feature(type_alias_impl_trait)]
-#![feature(type_alias_impl_trait)]
 #![allow(incomplete_features)]
 
 trait MyTrait {}

--- a/src/test/ui/type-alias-impl-trait/issue-65384.stderr
+++ b/src/test/ui/type-alias-impl-trait/issue-65384.stderr
@@ -1,11 +1,11 @@
 error: cannot implement trait on type alias impl trait
-  --> $DIR/issue-65384.rs:11:1
+  --> $DIR/issue-65384.rs:10:1
    |
 LL | impl MyTrait for Bar {}
    | ^^^^^^^^^^^^^^^^^^^^
    |
 note: type alias impl trait defined here
-  --> $DIR/issue-65384.rs:9:12
+  --> $DIR/issue-65384.rs:8:12
    |
 LL | type Bar = impl MyTrait;
    |            ^^^^^^^^^^^^

--- a/src/test/ui/type/type-parameter-defaults-referencing-Self.rs
+++ b/src/test/ui/type/type-parameter-defaults-referencing-Self.rs
@@ -1,8 +1,6 @@
 // Test a default that references `Self` which is then used in an object type.
 // Issue #18956.
 
-#![feature(default_type_params)]
-
 trait Foo<T=Self> {
     fn method(&self);
 }

--- a/src/test/ui/type/type-parameter-defaults-referencing-Self.stderr
+++ b/src/test/ui/type/type-parameter-defaults-referencing-Self.stderr
@@ -1,5 +1,5 @@
 error[E0393]: the type parameter `T` must be explicitly specified
-  --> $DIR/type-parameter-defaults-referencing-Self.rs:10:16
+  --> $DIR/type-parameter-defaults-referencing-Self.rs:8:16
    |
 LL | / trait Foo<T=Self> {
 LL | |     fn method(&self);

--- a/src/test/ui/unboxed-closures/unboxed-closures-fnmut-as-fn.rs
+++ b/src/test/ui/unboxed-closures/unboxed-closures-fnmut-as-fn.rs
@@ -2,7 +2,6 @@
 // Fn to be used where FnMut is implemented.
 
 #![feature(fn_traits, unboxed_closures)]
-#![feature(overloaded_calls)]
 
 use std::ops::{Fn,FnMut,FnOnce};
 

--- a/src/test/ui/unboxed-closures/unboxed-closures-fnmut-as-fn.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closures-fnmut-as-fn.stderr
@@ -1,5 +1,5 @@
 error[E0277]: expected a `Fn<(isize,)>` closure, found `S`
-  --> $DIR/unboxed-closures-fnmut-as-fn.rs:28:21
+  --> $DIR/unboxed-closures-fnmut-as-fn.rs:27:21
    |
 LL |     let x = call_it(&S, 22);
    |             ------- ^^ expected an `Fn<(isize,)>` closure, found `S`
@@ -8,7 +8,7 @@ LL |     let x = call_it(&S, 22);
    |
    = help: the trait `Fn<(isize,)>` is not implemented for `S`
 note: required by a bound in `call_it`
-  --> $DIR/unboxed-closures-fnmut-as-fn.rs:23:14
+  --> $DIR/unboxed-closures-fnmut-as-fn.rs:22:14
    |
 LL | fn call_it<F:Fn(isize)->isize>(f: &F, x: isize) -> isize {
    |              ^^^^^^^^^^^^^^^^ required by this bound in `call_it`

--- a/src/test/ui/unboxed-closures/unboxed-closures-recursive-fn-using-fn-mut.rs
+++ b/src/test/ui/unboxed-closures/unboxed-closures-recursive-fn-using-fn-mut.rs
@@ -1,4 +1,4 @@
-#![feature(core, fn_traits, unboxed_closures)]
+#![feature(fn_traits, unboxed_closures)]
 
 use std::marker::PhantomData;
 


### PR DESCRIPTION
Successful merges:

 - #91192 (Some improvements to the async docs)
 - #94096 (Ensure stability directives are checked in all cases)
 - #94169 (Fix several asm! related issues)
 - #94189 (Implement LowerHex on Scalar to clean up their display in rustdoc)
 - #94190 (Use Metadata::modified instead of FileTime::from_last_modification_ti…)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=91192,94096,94169,94189,94190)
<!-- homu-ignore:end -->