### PR TITLE
compiletest: Print process output info with less whitespace

### DIFF
--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -3753,23 +3753,27 @@ pub struct ProcRes {
 
 impl ProcRes {
     pub fn print_info(&self) {
-        print!(
-            "\
-             status: {}\n\
-             command: {}\n\
-             stdout:\n\
-             ------------------------------------------\n\
-             {}\n\
-             ------------------------------------------\n\
-             stderr:\n\
-             ------------------------------------------\n\
-             {}\n\
-             ------------------------------------------\n\
-             \n",
+        fn render(name: &str, contents: &str) -> String {
+            let contents = json::extract_rendered(contents);
+            let contents = contents.trim();
+            if contents.is_empty() {
+                format!("{name}: none")
+            } else {
+                format!(
+                    "\
+                     --- {name} -------------------------------\n\
+                     {contents}\n\
+                     ------------------------------------------",
+                )
+            }
+        }
+
+        println!(
+            "status: {}\ncommand: {}\n{}\n{}\n",
             self.status,
             self.cmdline,
-            json::extract_rendered(&self.stdout),
-            json::extract_rendered(&self.stderr),
+            render("stdout", &self.stdout),
+            render("stderr", &self.stderr),
         );
     }
 


### PR DESCRIPTION
Before:

```
error: jsondocck failed!
status: exit status: 1
command: "/data/ne321/rust/build/x86_64-unknown-linux-gnu/stage0-tools-bin/jsondocck" "--doc-dir" "/data/ne321/rust/build/x86_64-unknown-linux-gnu/test/rustdoc-json/traits/supertrait" "--template" "/data/ne321/rust/src/test/rustdoc-json/traits/supertrait.rs"
stdout:
------------------------------------------

------------------------------------------
stderr:
------------------------------------------
Invalid command: Tried to use the previous path in the first command on line 10
Error: "Jsondocck failed for /data/ne321/rust/src/test/rustdoc-json/traits/supertrait.rs"

------------------------------------------

Rustdoc Output:
status: exit status: 0
command: "/data/ne321/rust/build/x86_64-unknown-linux-gnu/stage2/bin/rustdoc" "-L" "/data/ne321/rust/build/x86_64-unknown-linux-gnu/stage2/lib/rustlib/x86_64-unknown-linux-gnu/lib" "-L" "/data/ne321/rust/build/x86_64-unknown-linux-gnu/test/rustdoc-json/traits/supertrait/auxiliary" "-o" "/data/ne321/rust/build/x86_64-unknown-linux-gnu/test/rustdoc-json/traits/supertrait" "--deny" "warnings" "/data/ne321/rust/src/test/rustdoc-json/traits/supertrait.rs" "--output-format" "json" "-Zunstable-options"
stdout:
------------------------------------------

------------------------------------------
stderr:
------------------------------------------

------------------------------------------

```

After:

```

error: jsondocck failed!
status: exit status: 1
command: "/data/ne321/rust/build/x86_64-unknown-linux-gnu/stage0-tools-bin/jsondocck" "--doc-dir" "/data/ne321/rust/build/x86_64-unknown-linux-gnu/test/rustdoc-json/traits/supertrait" "--template" "/data/ne321/rust/src/test/rustdoc-json/traits/supertrait.rs"
stdout: none
--- stderr -------------------------------
Invalid command: Tried to use the previous path in the first command on line 10
Error: "Jsondocck failed for /data/ne321/rust/src/test/rustdoc-json/traits/supertrait.rs"
------------------------------------------

Rustdoc Output:
status: exit status: 0
command: "/data/ne321/rust/build/x86_64-unknown-linux-gnu/stage2/bin/rustdoc" "-L" "/data/ne321/rust/build/x86_64-unknown-linux-gnu/stage2/lib/rustlib/x86_64-unknown-linux-gnu/lib" "-L" "/data/ne321/rust/build/x86_64-unknown-linux-gnu/test/rustdoc-json/traits/supertrait/auxiliary" "-o" "/data/ne321/rust/build/x86_64-unknown-linux-gnu/test/rustdoc-json/traits/supertrait" "--deny" "warnings" "/data/ne321/rust/src/test/rustdoc-json/traits/supertrait.rs" "--output-format" "json" "-Zunstable-options"
stdout: none
stderr: none

```