### PR TITLE
Make `Const::val()` return a ref, to avoid copies.

### DIFF
--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -384,7 +384,7 @@ impl<'a, 'b, 'tcx> Visitor<'tcx> for TypeVerifier<'a, 'b, 'tcx> {
             let tcx = self.tcx();
             let maybe_uneval = match constant.literal {
                 ConstantKind::Ty(ct) => match ct.val() {
-                    ty::ConstKind::Unevaluated(uv) => Some(uv),
+                    &ty::ConstKind::Unevaluated(uv) => Some(uv),
                     _ => None,
                 },
                 _ => None,
@@ -1956,7 +1956,7 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
         if let Operand::Constant(constant) = op {
             let maybe_uneval = match constant.literal {
                 ConstantKind::Ty(ct) => match ct.val() {
-                    ty::ConstKind::Unevaluated(uv) => Some(uv),
+                    &ty::ConstKind::Unevaluated(uv) => Some(uv),
                     _ => None,
                 },
                 _ => None,

--- a/compiler/rustc_codegen_cranelift/src/constant.rs
+++ b/compiler/rustc_codegen_cranelift/src/constant.rs
@@ -48,7 +48,7 @@ pub(crate) fn check_constants(fx: &mut FunctionCx<'_, '_, '_>) -> bool {
         };
         match const_.val() {
             ConstKind::Value(_) => {}
-            ConstKind::Unevaluated(unevaluated) => {
+            &ConstKind::Unevaluated(unevaluated) => {
                 if let Err(err) =
                     fx.tcx.const_eval_resolve(ParamEnv::reveal_all(), unevaluated, None)
                 {
@@ -128,7 +128,7 @@ pub(crate) fn codegen_constant<'tcx>(
         ConstantKind::Val(val, ty) => return codegen_const_value(fx, val, ty),
     };
     let const_val = match const_.val() {
-        ConstKind::Value(const_val) => const_val,
+        &ConstKind::Value(const_val) => const_val,
         ConstKind::Unevaluated(ty::Unevaluated { def, substs, promoted })
             if fx.tcx.is_static(def.did) =>
         {
@@ -137,7 +137,7 @@ pub(crate) fn codegen_constant<'tcx>(
 
             return codegen_static_ref(fx, def.did, fx.layout_of(const_.ty())).to_cvalue(fx);
         }
-        ConstKind::Unevaluated(unevaluated) => {
+        &ConstKind::Unevaluated(unevaluated) => {
             match fx.tcx.const_eval_resolve(ParamEnv::reveal_all(), unevaluated, None) {
                 Ok(const_val) => const_val,
                 Err(_) => {

--- a/compiler/rustc_codegen_ssa/src/mir/constant.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/constant.rs
@@ -30,7 +30,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
             mir::ConstantKind::Val(val, _) => return Ok(val),
         };
         match ct.val() {
-            ty::ConstKind::Unevaluated(ct) => self
+            &ty::ConstKind::Unevaluated(ct) => self
                 .cx
                 .tcx()
                 .const_eval_resolve(ty::ParamEnv::reveal_all(), ct, None)
@@ -38,7 +38,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                     self.cx.tcx().sess.span_err(constant.span, "erroneous constant encountered");
                     err
                 }),
-            ty::ConstKind::Value(value) => Ok(value),
+            &ty::ConstKind::Value(value) => Ok(value),
             err => span_bug!(
                 constant.span,
                 "encountered bad ConstKind after monomorphizing: {:?}",

--- a/compiler/rustc_const_eval/src/interpret/operand.rs
+++ b/compiler/rustc_const_eval/src/interpret/operand.rs
@@ -574,7 +574,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             ty::ConstKind::Infer(..) | ty::ConstKind::Placeholder(..) => {
                 span_bug!(self.cur_span(), "const_to_op: Unexpected ConstKind {:?}", val)
             }
-            ty::ConstKind::Value(val_val) => self.const_val_to_op(val_val, val.ty(), layout),
+            &ty::ConstKind::Value(val_val) => self.const_val_to_op(val_val, val.ty(), layout),
         }
     }
 

--- a/compiler/rustc_infer/src/infer/canonical/canonicalizer.rs
+++ b/compiler/rustc_infer/src/infer/canonical/canonicalizer.rs
@@ -477,7 +477,7 @@ impl<'cx, 'tcx> TypeFolder<'tcx> for Canonicalizer<'cx, 'tcx> {
 
     fn fold_const(&mut self, ct: ty::Const<'tcx>) -> ty::Const<'tcx> {
         match ct.val() {
-            ty::ConstKind::Infer(InferConst::Var(vid)) => {
+            &ty::ConstKind::Infer(InferConst::Var(vid)) => {
                 debug!("canonical: const var found with vid {:?}", vid);
                 match self.infcx.probe_const_var(vid) {
                     Ok(c) => {
@@ -502,14 +502,14 @@ impl<'cx, 'tcx> TypeFolder<'tcx> for Canonicalizer<'cx, 'tcx> {
             ty::ConstKind::Infer(InferConst::Fresh(_)) => {
                 bug!("encountered a fresh const during canonicalization")
             }
-            ty::ConstKind::Bound(debruijn, _) => {
+            &ty::ConstKind::Bound(debruijn, _) => {
                 if debruijn >= self.binder_index {
                     bug!("escaping bound type during canonicalization")
                 } else {
                     return ct;
                 }
             }
-            ty::ConstKind::Placeholder(placeholder) => {
+            &ty::ConstKind::Placeholder(placeholder) => {
                 return self.canonicalize_const_var(
                     CanonicalVarInfo { kind: CanonicalVarKind::PlaceholderConst(placeholder) },
                     ct,

--- a/compiler/rustc_infer/src/infer/canonical/query_response.rs
+++ b/compiler/rustc_infer/src/infer/canonical/query_response.rs
@@ -437,7 +437,7 @@ impl<'cx, 'tcx> InferCtxt<'cx, 'tcx> {
                     }
                 }
                 GenericArgKind::Const(result_value) => {
-                    if let ty::ConstKind::Bound(debrujin, b) = result_value.val() {
+                    if let &ty::ConstKind::Bound(debrujin, b) = result_value.val() {
                         // ...in which case we would set `canonical_vars[0]` to `Some(const X)`.
 
                         // We only allow a `ty::INNERMOST` index in substitutions.

--- a/compiler/rustc_infer/src/infer/combine.rs
+++ b/compiler/rustc_infer/src/infer/combine.rs
@@ -141,8 +141,8 @@ impl<'infcx, 'tcx> InferCtxt<'infcx, 'tcx> {
 
         match (a.val(), b.val()) {
             (
-                ty::ConstKind::Infer(InferConst::Var(a_vid)),
-                ty::ConstKind::Infer(InferConst::Var(b_vid)),
+                &ty::ConstKind::Infer(InferConst::Var(a_vid)),
+                &ty::ConstKind::Infer(InferConst::Var(b_vid)),
             ) => {
                 self.inner
                     .borrow_mut()
@@ -158,11 +158,11 @@ impl<'infcx, 'tcx> InferCtxt<'infcx, 'tcx> {
                 bug!("tried to combine ConstKind::Infer/ConstKind::Infer(InferConst::Var)")
             }
 
-            (ty::ConstKind::Infer(InferConst::Var(vid)), _) => {
+            (&ty::ConstKind::Infer(InferConst::Var(vid)), _) => {
                 return self.unify_const_variable(relation.param_env(), vid, b, a_is_expected);
             }
 
-            (_, ty::ConstKind::Infer(InferConst::Var(vid))) => {
+            (_, &ty::ConstKind::Infer(InferConst::Var(vid))) => {
                 return self.unify_const_variable(relation.param_env(), vid, a, !a_is_expected);
             }
             (ty::ConstKind::Unevaluated(..), _) if self.tcx.lazy_normalization() => {
@@ -722,7 +722,7 @@ impl<'tcx> TypeRelation<'tcx> for Generalizer<'_, 'tcx> {
         assert_eq!(c, c2); // we are abusing TypeRelation here; both LHS and RHS ought to be ==
 
         match c.val() {
-            ty::ConstKind::Infer(InferConst::Var(vid)) => {
+            &ty::ConstKind::Infer(InferConst::Var(vid)) => {
                 let mut inner = self.infcx.inner.borrow_mut();
                 let variable_table = &mut inner.const_unification_table();
                 let var_value = variable_table.probe_value(vid);
@@ -744,7 +744,7 @@ impl<'tcx> TypeRelation<'tcx> for Generalizer<'_, 'tcx> {
                     }
                 }
             }
-            ty::ConstKind::Unevaluated(ty::Unevaluated { def, substs, promoted })
+            &ty::ConstKind::Unevaluated(ty::Unevaluated { def, substs, promoted })
                 if self.tcx().lazy_normalization() =>
             {
                 assert_eq!(promoted, None);
@@ -952,7 +952,7 @@ impl<'tcx> TypeRelation<'tcx> for ConstInferUnifier<'_, 'tcx> {
         debug!("ConstInferUnifier: c={:?}", c);
 
         match c.val() {
-            ty::ConstKind::Infer(InferConst::Var(vid)) => {
+            &ty::ConstKind::Infer(InferConst::Var(vid)) => {
                 // Check if the current unification would end up
                 // unifying `target_vid` with a const which contains
                 // an inference variable which is unioned with `target_vid`.
@@ -990,7 +990,7 @@ impl<'tcx> TypeRelation<'tcx> for ConstInferUnifier<'_, 'tcx> {
                     }
                 }
             }
-            ty::ConstKind::Unevaluated(ty::Unevaluated { def, substs, promoted })
+            &ty::ConstKind::Unevaluated(ty::Unevaluated { def, substs, promoted })
                 if self.tcx().lazy_normalization() =>
             {
                 assert_eq!(promoted, None);

--- a/compiler/rustc_infer/src/infer/error_reporting/need_type_info.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/need_type_info.rs
@@ -410,7 +410,7 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
             }
             GenericArgKind::Const(ct) => {
                 match ct.val() {
-                    ty::ConstKind::Infer(InferConst::Var(vid)) => {
+                    &ty::ConstKind::Infer(InferConst::Var(vid)) => {
                         let origin = self
                             .inner
                             .borrow_mut()

--- a/compiler/rustc_infer/src/infer/freshen.rs
+++ b/compiler/rustc_infer/src/infer/freshen.rs
@@ -223,7 +223,7 @@ impl<'a, 'tcx> TypeFolder<'tcx> for TypeFreshener<'a, 'tcx> {
 
     fn fold_const(&mut self, ct: ty::Const<'tcx>) -> ty::Const<'tcx> {
         match ct.val() {
-            ty::ConstKind::Infer(ty::InferConst::Var(v)) => {
+            &ty::ConstKind::Infer(ty::InferConst::Var(v)) => {
                 let opt_ct = self
                     .infcx
                     .inner
@@ -239,7 +239,7 @@ impl<'a, 'tcx> TypeFolder<'tcx> for TypeFreshener<'a, 'tcx> {
                     ct.ty(),
                 );
             }
-            ty::ConstKind::Infer(ty::InferConst::Fresh(i)) => {
+            &ty::ConstKind::Infer(ty::InferConst::Fresh(i)) => {
                 if i >= self.const_freshen_count {
                     bug!(
                         "Encountered a freshend const with id {} \

--- a/compiler/rustc_infer/src/infer/mod.rs
+++ b/compiler/rustc_infer/src/infer/mod.rs
@@ -1761,7 +1761,7 @@ impl<'tcx> TyOrConstInferVar<'tcx> {
     /// for constants other than `ty::ConstKind::Infer(_)` (or `InferConst::Fresh`).
     pub fn maybe_from_const(ct: ty::Const<'tcx>) -> Option<Self> {
         match ct.val() {
-            ty::ConstKind::Infer(InferConst::Var(v)) => Some(TyOrConstInferVar::Const(v)),
+            &ty::ConstKind::Infer(InferConst::Var(v)) => Some(TyOrConstInferVar::Const(v)),
             _ => None,
         }
     }
@@ -1781,7 +1781,7 @@ impl<'a, 'tcx> TypeFolder<'tcx> for ShallowResolver<'a, 'tcx> {
     }
 
     fn fold_const(&mut self, ct: ty::Const<'tcx>) -> ty::Const<'tcx> {
-        if let ty::ConstKind::Infer(InferConst::Var(vid)) = ct.val() {
+        if let &ty::ConstKind::Infer(InferConst::Var(vid)) = ct.val() {
             self.infcx
                 .inner
                 .borrow_mut()

--- a/compiler/rustc_infer/src/infer/nll_relate/mod.rs
+++ b/compiler/rustc_infer/src/infer/nll_relate/mod.rs
@@ -999,7 +999,7 @@ where
             ty::ConstKind::Infer(InferConst::Var(_)) if D::forbid_inference_vars() => {
                 bug!("unexpected inference variable encountered in NLL generalization: {:?}", a);
             }
-            ty::ConstKind::Infer(InferConst::Var(vid)) => {
+            &ty::ConstKind::Infer(InferConst::Var(vid)) => {
                 let mut inner = self.infcx.inner.borrow_mut();
                 let variable_table = &mut inner.const_unification_table();
                 let var_value = variable_table.probe_value(vid);

--- a/compiler/rustc_infer/src/infer/resolve.rs
+++ b/compiler/rustc_infer/src/infer/resolve.rs
@@ -224,7 +224,7 @@ impl<'a, 'tcx> FallibleTypeFolder<'tcx> for FullTypeResolver<'a, 'tcx> {
         } else {
             let c = self.infcx.shallow_resolve(c);
             match c.val() {
-                ty::ConstKind::Infer(InferConst::Var(vid)) => {
+                &ty::ConstKind::Infer(InferConst::Var(vid)) => {
                     return Err(FixupError::UnresolvedConst(vid));
                 }
                 ty::ConstKind::Infer(InferConst::Fresh(_)) => {

--- a/compiler/rustc_middle/src/infer/unify_key.rs
+++ b/compiler/rustc_middle/src/infer/unify_key.rs
@@ -176,7 +176,7 @@ where
     V: snapshot_vec::VecLike<unify::Delegate<ty::ConstVid<'tcx>>>,
     L: UndoLogs<snapshot_vec::UndoLog<unify::Delegate<ty::ConstVid<'tcx>>>>,
 {
-    if let ty::ConstKind::Infer(InferConst::Var(vid)) = c.val() {
+    if let &ty::ConstKind::Infer(InferConst::Var(vid)) = c.val() {
         match table.probe_value(vid).val.known() {
             Some(c) => c,
             None => c,

--- a/compiler/rustc_middle/src/mir/pretty.rs
+++ b/compiler/rustc_middle/src/mir/pretty.rs
@@ -682,7 +682,7 @@ pub fn write_allocations<'tcx>(
 
     impl<'tcx> Visitor<'tcx> for CollectAllocIds {
         fn visit_const(&mut self, c: ty::Const<'tcx>, _loc: Location) {
-            if let ty::ConstKind::Value(val) = c.val() {
+            if let &ty::ConstKind::Value(val) = c.val() {
                 self.0.extend(alloc_ids_from_const(val));
             }
         }

--- a/compiler/rustc_middle/src/ty/consts.rs
+++ b/compiler/rustc_middle/src/ty/consts.rs
@@ -21,7 +21,6 @@ pub use valtree::*;
 
 /// Use this rather than `ConstS`, whenever possible.
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, HashStable)]
-#[cfg_attr(not(bootstrap), rustc_pass_by_value)]
 pub struct Const<'tcx>(pub Interned<'tcx, ConstS<'tcx>>);
 
 impl<'tcx> fmt::Debug for Const<'tcx> {
@@ -48,8 +47,8 @@ impl<'tcx> Const<'tcx> {
         self.0.ty
     }
 
-    pub fn val(self) -> ConstKind<'tcx> {
-        self.0.val
+    pub fn val(&self) -> &ConstKind<'tcx> {
+        &self.0.val
     }
 
     /// Literals and const generic parameters are eagerly converted to a constant, everything else

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -870,7 +870,7 @@ impl<'tcx> CanonicalUserType<'tcx> {
                         },
 
                         GenericArgKind::Const(ct) => match ct.val() {
-                            ty::ConstKind::Bound(debruijn, b) => {
+                            &ty::ConstKind::Bound(debruijn, b) => {
                                 // We only allow a `ty::INNERMOST` index in substitutions.
                                 assert_eq!(debruijn, ty::INNERMOST);
                                 cvar == b

--- a/compiler/rustc_middle/src/ty/diagnostics.rs
+++ b/compiler/rustc_middle/src/ty/diagnostics.rs
@@ -76,7 +76,7 @@ impl<'tcx> Ty<'tcx> {
             }
         }
 
-        fn const_is_suggestable(kind: ConstKind<'_>) -> bool {
+        fn const_is_suggestable(kind: &ConstKind<'_>) -> bool {
             match kind {
                 ConstKind::Infer(..)
                 | ConstKind::Bound(..)

--- a/compiler/rustc_middle/src/ty/flags.rs
+++ b/compiler/rustc_middle/src/ty/flags.rs
@@ -289,7 +289,7 @@ impl FlagComputation {
     fn add_const(&mut self, c: ty::Const<'_>) {
         self.add_ty(c.ty());
         match c.val() {
-            ty::ConstKind::Unevaluated(unevaluated) => self.add_unevaluated_const(unevaluated),
+            &ty::ConstKind::Unevaluated(unevaluated) => self.add_unevaluated_const(unevaluated),
             ty::ConstKind::Infer(infer) => {
                 self.add_flags(TypeFlags::STILL_FURTHER_SPECIALIZABLE);
                 match infer {
@@ -297,7 +297,7 @@ impl FlagComputation {
                     InferConst::Var(_) => self.add_flags(TypeFlags::HAS_CT_INFER),
                 }
             }
-            ty::ConstKind::Bound(debruijn, _) => {
+            &ty::ConstKind::Bound(debruijn, _) => {
                 self.add_bound_var(debruijn);
             }
             ty::ConstKind::Param(_) => {

--- a/compiler/rustc_middle/src/ty/fold.rs
+++ b/compiler/rustc_middle/src/ty/fold.rs
@@ -689,7 +689,7 @@ impl<'a, 'tcx> TypeFolder<'tcx> for BoundVarReplacer<'a, 'tcx> {
 
     fn fold_const(&mut self, ct: ty::Const<'tcx>) -> ty::Const<'tcx> {
         match ct.val() {
-            ty::ConstKind::Bound(debruijn, bound_const) if debruijn == self.current_index => {
+            &ty::ConstKind::Bound(debruijn, bound_const) if debruijn == self.current_index => {
                 if let Some(fld_c) = self.fld_c.as_mut() {
                     let ct = fld_c(bound_const, ct.ty());
                     return ty::fold::shift_vars(self.tcx, ct, self.current_index.as_u32());
@@ -1083,7 +1083,7 @@ impl<'tcx> TypeFolder<'tcx> for Shifter<'tcx> {
     }
 
     fn fold_const(&mut self, ct: ty::Const<'tcx>) -> ty::Const<'tcx> {
-        if let ty::ConstKind::Bound(debruijn, bound_ct) = ct.val() {
+        if let &ty::ConstKind::Bound(debruijn, bound_ct) = ct.val() {
             if self.amount == 0 || debruijn < self.current_index {
                 ct
             } else {
@@ -1200,7 +1200,7 @@ impl<'tcx> TypeVisitor<'tcx> for HasEscapingVarsVisitor {
         // const, as it has types/regions embedded in a lot of other
         // places.
         match ct.val() {
-            ty::ConstKind::Bound(debruijn, _) if debruijn >= self.outer_index => {
+            &ty::ConstKind::Bound(debruijn, _) if debruijn >= self.outer_index => {
                 ControlFlow::Break(FoundEscapingVars)
             }
             _ => ct.super_visit_with(self),

--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -1199,7 +1199,7 @@ pub trait PrettyPrinter<'tcx>:
                     }
                 }
             }
-            ty::ConstKind::Infer(infer_ct) => {
+            &ty::ConstKind::Infer(infer_ct) => {
                 match infer_ct {
                     ty::InferConst::Var(ct_vid)
                         if let Some(name) = self.const_infer_name(ct_vid) =>
@@ -1208,11 +1208,11 @@ pub trait PrettyPrinter<'tcx>:
                 }
             }
             ty::ConstKind::Param(ParamConst { name, .. }) => p!(write("{}", name)),
-            ty::ConstKind::Value(value) => {
+            &ty::ConstKind::Value(value) => {
                 return self.pretty_print_const_value(value, ct.ty(), print_ty);
             }
 
-            ty::ConstKind::Bound(debruijn, bound_var) => {
+            &ty::ConstKind::Bound(debruijn, bound_var) => {
                 self.pretty_print_bound_var(debruijn, bound_var)?
             }
             ty::ConstKind::Placeholder(placeholder) => p!(write("Placeholder({:?})", placeholder)),

--- a/compiler/rustc_middle/src/ty/relate.rs
+++ b/compiler/rustc_middle/src/ty/relate.rs
@@ -580,7 +580,7 @@ pub fn super_relate_consts<'tcx, R: TypeRelation<'tcx>>(
 
         (ty::ConstKind::Param(a_p), ty::ConstKind::Param(b_p)) => a_p.index == b_p.index,
         (ty::ConstKind::Placeholder(p1), ty::ConstKind::Placeholder(p2)) => p1 == p2,
-        (ty::ConstKind::Value(a_val), ty::ConstKind::Value(b_val)) => {
+        (&ty::ConstKind::Value(a_val), &ty::ConstKind::Value(b_val)) => {
             check_const_value_eq(relation, a_val, b_val, a, b)?
         }
 

--- a/compiler/rustc_middle/src/ty/structural_impls.rs
+++ b/compiler/rustc_middle/src/ty/structural_impls.rs
@@ -1159,7 +1159,7 @@ impl<'tcx> TypeFoldable<'tcx> for ty::Const<'tcx> {
     ) -> Result<Self, F::Error> {
         let ty = self.ty().try_fold_with(folder)?;
         let val = self.val().try_fold_with(folder)?;
-        if ty != self.ty() || val != self.val() {
+        if ty != self.ty() || val != *self.val() {
             Ok(folder.tcx().mk_const(ty::ConstS { ty, val }))
         } else {
             Ok(self)

--- a/compiler/rustc_middle/src/ty/subst.rs
+++ b/compiler/rustc_middle/src/ty/subst.rs
@@ -521,7 +521,7 @@ impl<'a, 'tcx> TypeFolder<'tcx> for SubstFolder<'a, 'tcx> {
     }
 
     fn fold_const(&mut self, c: ty::Const<'tcx>) -> ty::Const<'tcx> {
-        if let ty::ConstKind::Param(p) = c.val() {
+        if let &ty::ConstKind::Param(p) = c.val() {
             self.const_for_param(p, c)
         } else {
             c.super_fold_with(self)

--- a/compiler/rustc_mir_build/src/thir/pattern/mod.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/mod.rs
@@ -792,8 +792,8 @@ crate fn compare_const_vals<'tcx>(
 
     if let ty::Str = ty.kind() {
         if let (
-            ty::ConstKind::Value(a_val @ ConstValue::Slice { .. }),
-            ty::ConstKind::Value(b_val @ ConstValue::Slice { .. }),
+            &ty::ConstKind::Value(a_val @ ConstValue::Slice { .. }),
+            &ty::ConstKind::Value(b_val @ ConstValue::Slice { .. }),
         ) = (a.val(), b.val())
         {
             let a_bytes = get_slice_bytes(&tcx, a_val);

--- a/compiler/rustc_monomorphize/src/collector.rs
+++ b/compiler/rustc_monomorphize/src/collector.rs
@@ -710,8 +710,8 @@ impl<'a, 'tcx> MirVisitor<'tcx> for MirNeighborCollector<'a, 'tcx> {
         let val = match literal {
             mir::ConstantKind::Val(val, _) => val,
             mir::ConstantKind::Ty(ct) => match ct.val() {
-                ty::ConstKind::Value(val) => val,
-                ty::ConstKind::Unevaluated(ct) => {
+                &ty::ConstKind::Value(val) => val,
+                &ty::ConstKind::Unevaluated(ct) => {
                     let param_env = ty::ParamEnv::reveal_all();
                     match self.tcx.const_eval_resolve(param_env, ct, None) {
                         // The `monomorphize` call should have evaluated that constant already.
@@ -738,8 +738,8 @@ impl<'a, 'tcx> MirVisitor<'tcx> for MirNeighborCollector<'a, 'tcx> {
         let param_env = ty::ParamEnv::reveal_all();
 
         match substituted_constant.val() {
-            ty::ConstKind::Value(val) => collect_const_value(self.tcx, val, self.output),
-            ty::ConstKind::Unevaluated(unevaluated) => {
+            &ty::ConstKind::Value(val) => collect_const_value(self.tcx, val, self.output),
+            &ty::ConstKind::Unevaluated(unevaluated) => {
                 match self.tcx.const_eval_resolve(param_env, unevaluated, None) {
                     // The `monomorphize` call should have evaluated that constant already.
                     Ok(val) => span_bug!(

--- a/compiler/rustc_monomorphize/src/polymorphize.rs
+++ b/compiler/rustc_monomorphize/src/polymorphize.rs
@@ -289,7 +289,7 @@ impl<'a, 'tcx> TypeVisitor<'tcx> for MarkUsedGenericParams<'a, 'tcx> {
                 self.unused_parameters.clear(param.index);
                 ControlFlow::CONTINUE
             }
-            ty::ConstKind::Unevaluated(ty::Unevaluated { def, substs: _, promoted: Some(p)})
+            &ty::ConstKind::Unevaluated(ty::Unevaluated { def, substs: _, promoted: Some(p)})
                 // Avoid considering `T` unused when constants are of the form:
                 //   `<Self as Foo<T>>::foo::promoted[p]`
                 if self.def_id == def.did && !self.tcx.generics_of(def.did).has_self =>

--- a/compiler/rustc_symbol_mangling/src/v0.rs
+++ b/compiler/rustc_symbol_mangling/src/v0.rs
@@ -628,7 +628,7 @@ impl<'tcx> Printer<'tcx> for &mut SymbolMangler<'tcx> {
             ty::Ref(_, ty, hir::Mutability::Not) if *ty == self.tcx.types.str_ => {
                 self.push("R");
                 match ct.val() {
-                    ty::ConstKind::Value(ConstValue::Slice { data, start, end }) => {
+                    &ty::ConstKind::Value(ConstValue::Slice { data, start, end }) => {
                         // NOTE(eddyb) the following comment was kept from `ty::print::pretty`:
                         // The `inspect` here is okay since we checked the bounds, and there are no
                         // relocations (we have an active `str` reference here). We don't use this

--- a/compiler/rustc_trait_selection/src/traits/auto_trait.rs
+++ b/compiler/rustc_trait_selection/src/traits/auto_trait.rs
@@ -810,7 +810,7 @@ impl<'tcx> AutoTraitFinder<'tcx> {
                 }
                 ty::PredicateKind::ConstEquate(c1, c2) => {
                     let evaluate = |c: ty::Const<'tcx>| {
-                        if let ty::ConstKind::Unevaluated(unevaluated) = c.val() {
+                        if let &ty::ConstKind::Unevaluated(unevaluated) = c.val() {
                             match select.infcx().const_eval_resolve(
                                 obligation.param_env,
                                 unevaluated,

--- a/compiler/rustc_trait_selection/src/traits/fulfill.rs
+++ b/compiler/rustc_trait_selection/src/traits/fulfill.rs
@@ -573,7 +573,7 @@ impl<'a, 'b, 'tcx> FulfillProcessor<'a, 'b, 'tcx> {
                     let stalled_on = &mut pending_obligation.stalled_on;
 
                     let mut evaluate = |c: Const<'tcx>| {
-                        if let ty::ConstKind::Unevaluated(unevaluated) = c.val() {
+                        if let &ty::ConstKind::Unevaluated(unevaluated) = c.val() {
                             match self.selcx.infcx().const_eval_resolve(
                                 obligation.param_env,
                                 unevaluated,

--- a/compiler/rustc_trait_selection/src/traits/project.rs
+++ b/compiler/rustc_trait_selection/src/traits/project.rs
@@ -631,7 +631,7 @@ impl<'tcx> TypeFolder<'tcx> for BoundVarReplacer<'_, 'tcx> {
             {
                 bug!("Bound vars outside of `self.universe_indices`");
             }
-            ty::ConstKind::Bound(debruijn, bound_const) if debruijn >= self.current_index => {
+            &ty::ConstKind::Bound(debruijn, bound_const) if debruijn >= self.current_index => {
                 let universe = self.universe_for(debruijn);
                 let p = ty::PlaceholderConst {
                     universe,

--- a/compiler/rustc_trait_selection/src/traits/query/normalize.rs
+++ b/compiler/rustc_trait_selection/src/traits/query/normalize.rs
@@ -142,7 +142,7 @@ impl<'tcx> TypeVisitor<'tcx> for MaxEscapingBoundVarVisitor {
 
     fn visit_const(&mut self, ct: ty::Const<'tcx>) -> ControlFlow<Self::BreakTy> {
         match ct.val() {
-            ty::ConstKind::Bound(debruijn, _) if debruijn >= self.outer_index => {
+            &ty::ConstKind::Bound(debruijn, _) if debruijn >= self.outer_index => {
                 self.escaping =
                     self.escaping.max(debruijn.as_usize() - self.outer_index.as_usize());
                 ControlFlow::CONTINUE

--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -652,7 +652,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                     }
 
                     let evaluate = |c: ty::Const<'tcx>| {
-                        if let ty::ConstKind::Unevaluated(unevaluated) = c.val() {
+                        if let &ty::ConstKind::Unevaluated(unevaluated) = c.val() {
                             self.infcx
                                 .const_eval_resolve(
                                     obligation.param_env,

--- a/compiler/rustc_trait_selection/src/traits/wf.rs
+++ b/compiler/rustc_trait_selection/src/traits/wf.rs
@@ -42,7 +42,7 @@ pub fn obligations<'a, 'tcx>(
         }
         GenericArgKind::Const(ct) => {
             match ct.val() {
-                ty::ConstKind::Infer(infer) => {
+                &ty::ConstKind::Infer(infer) => {
                     let resolved = infcx.shallow_resolve(infer);
                     if resolved == infer {
                         // No progress.
@@ -460,7 +460,7 @@ impl<'a, 'tcx> WfPredicates<'a, 'tcx> {
                                 predicate,
                             ));
                         }
-                        ty::ConstKind::Infer(infer) => {
+                        &ty::ConstKind::Infer(infer) => {
                             let resolved = self.infcx.shallow_resolve(infer);
                             // the `InferConst` changed, meaning that we made progress.
                             if resolved != infer {

--- a/compiler/rustc_traits/src/chalk/lowering.rs
+++ b/compiler/rustc_traits/src/chalk/lowering.rs
@@ -507,10 +507,10 @@ impl<'tcx> LowerInto<'tcx, chalk_ir::Const<RustInterner<'tcx>>> for ty::Const<'t
     fn lower_into(self, interner: RustInterner<'tcx>) -> chalk_ir::Const<RustInterner<'tcx>> {
         let ty = self.ty().lower_into(interner);
         let value = match self.val() {
-            ty::ConstKind::Value(val) => {
+            &ty::ConstKind::Value(val) => {
                 chalk_ir::ConstValue::Concrete(chalk_ir::ConcreteConst { interned: val })
             }
-            ty::ConstKind::Bound(db, bound) => chalk_ir::ConstValue::BoundVar(
+            &ty::ConstKind::Bound(db, bound) => chalk_ir::ConstValue::BoundVar(
                 chalk_ir::BoundVar::new(chalk_ir::DebruijnIndex::new(db.as_u32()), bound.index()),
             ),
             _ => unimplemented!("Const not implemented. {:?}", self),

--- a/compiler/rustc_typeck/src/constrained_generic_params.rs
+++ b/compiler/rustc_typeck/src/constrained_generic_params.rs
@@ -85,7 +85,7 @@ impl<'tcx> TypeVisitor<'tcx> for ParameterCollector {
                 // Constant expressions are not injective
                 return c.ty().visit_with(self);
             }
-            ty::ConstKind::Param(data) => {
+            &ty::ConstKind::Param(data) => {
                 self.parameters.push(Parameter::from(data));
             }
             _ => {}

--- a/src/tools/clippy/clippy_utils/src/consts.rs
+++ b/src/tools/clippy/clippy_utils/src/consts.rs
@@ -570,7 +570,7 @@ impl<'a, 'tcx> ConstEvalLateContext<'a, 'tcx> {
 pub fn miri_to_const(result: ty::Const<'_>) -> Option<Constant> {
     use rustc_middle::mir::interpret::ConstValue;
     match result.val() {
-        ty::ConstKind::Value(ConstValue::Scalar(Scalar::Int(int))) => {
+        &ty::ConstKind::Value(ConstValue::Scalar(Scalar::Int(int))) => {
             match result.ty().kind() {
                 ty::Bool => Some(Constant::Bool(int == ScalarInt::TRUE)),
                 ty::Uint(_) | ty::Int(_) => Some(Constant::Int(int.assert_bits(int.size()))),
@@ -590,7 +590,7 @@ pub fn miri_to_const(result: ty::Const<'_>) -> Option<Constant> {
                 _ => None,
             }
         },
-        ty::ConstKind::Value(ConstValue::Slice { data, start, end }) => match result.ty().kind() {
+        &ty::ConstKind::Value(ConstValue::Slice { data, start, end }) => match result.ty().kind() {
             ty::Ref(_, tam, _) => match tam.kind() {
                 ty::Str => String::from_utf8(
                     data.inspect_with_uninit_and_ptr_outside_interpreter(start..end)


### PR DESCRIPTION
The idea comes from the last commit of #90951.

r? @ghost