### PR TITLE
Add the let else tests found missing in the stabilization report

### DIFF
--- a/src/test/ui/let-else/let-else-allow-in-expr.rs
+++ b/src/test/ui/let-else/let-else-allow-in-expr.rs
@@ -1,0 +1,30 @@
+#![feature(let_else)]
+
+#![deny(unused_variables)]
+
+fn main() {
+    let Some(_): Option<u32> = ({
+        let x = 1; //~ ERROR unused variable: `x`
+        Some(1)
+    }) else {
+        return;
+    };
+
+    #[allow(unused_variables)]
+    let Some(_): Option<u32> = ({
+        let x = 1;
+        Some(1)
+    }) else {
+        return;
+    };
+
+    let Some(_): Option<u32> = ({
+        #[allow(unused_variables)]
+        let x = 1;
+        Some(1)
+    }) else {
+        return;
+    };
+
+    let x = 1; //~ ERROR unused variable: `x`
+}

--- a/src/test/ui/let-else/let-else-allow-in-expr.stderr
+++ b/src/test/ui/let-else/let-else-allow-in-expr.stderr
@@ -1,0 +1,20 @@
+error: unused variable: `x`
+  --> $DIR/let-else-allow-in-expr.rs:7:13
+   |
+LL |         let x = 1;
+   |             ^ help: if this is intentional, prefix it with an underscore: `_x`
+   |
+note: the lint level is defined here
+  --> $DIR/let-else-allow-in-expr.rs:3:9
+   |
+LL | #![deny(unused_variables)]
+   |         ^^^^^^^^^^^^^^^^
+
+error: unused variable: `x`
+  --> $DIR/let-else-allow-in-expr.rs:29:9
+   |
+LL |     let x = 1;
+   |         ^ help: if this is intentional, prefix it with an underscore: `_x`
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/let-else/let-else-allow-unused.rs
+++ b/src/test/ui/let-else/let-else-allow-unused.rs
@@ -1,4 +1,3 @@
-// check-pass
 // issue #89807
 
 #![feature(let_else)]
@@ -10,5 +9,7 @@ fn main() {
     #[allow(unused)]
     let banana = 1;
     #[allow(unused)]
-    let Some(chaenomeles) = value else { return }; // OK
+    let Some(chaenomeles) = value.clone() else { return }; // OK
+
+    let Some(chaenomeles) = value else { return }; //~ ERROR unused variable: `chaenomeles`
 }

--- a/src/test/ui/let-else/let-else-allow-unused.stderr
+++ b/src/test/ui/let-else/let-else-allow-unused.stderr
@@ -1,0 +1,14 @@
+error: unused variable: `chaenomeles`
+  --> $DIR/let-else-allow-unused.rs:14:14
+   |
+LL |     let Some(chaenomeles) = value else { return };
+   |              ^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_chaenomeles`
+   |
+note: the lint level is defined here
+  --> $DIR/let-else-allow-unused.rs:5:8
+   |
+LL | #[deny(unused_variables)]
+   |        ^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+

--- a/src/test/ui/let-else/let-else-check.rs
+++ b/src/test/ui/let-else/let-else-check.rs
@@ -10,5 +10,10 @@ fn main() {
         return;
     };
 
+    let Some(_): Option<u32> = Some(Default::default()) else {
+        let x = 1; //~ ERROR unused variable: `x`
+        return;
+    };
+
     let x = 1; //~ ERROR unused variable: `x`
 }

--- a/src/test/ui/let-else/let-else-check.stderr
+++ b/src/test/ui/let-else/let-else-check.stderr
@@ -1,5 +1,5 @@
 error: unused variable: `x`
-  --> $DIR/let-else-check.rs:13:9
+  --> $DIR/let-else-check.rs:18:9
    |
 LL |     let x = 1;
    |         ^ help: if this is intentional, prefix it with an underscore: `_x`
@@ -10,5 +10,11 @@ note: the lint level is defined here
 LL | #![deny(unused_variables)]
    |         ^^^^^^^^^^^^^^^^
 
-error: aborting due to previous error
+error: unused variable: `x`
+  --> $DIR/let-else-check.rs:14:13
+   |
+LL |         let x = 1;
+   |             ^ help: if this is intentional, prefix it with an underscore: `_x`
+
+error: aborting due to 2 previous errors
 

--- a/src/test/ui/let-else/let-else-slicing-error.rs
+++ b/src/test/ui/let-else/let-else-slicing-error.rs
@@ -1,0 +1,9 @@
+// issue #92069
+#![feature(let_else)]
+
+fn main() {
+    let nums = vec![5, 4, 3, 2, 1];
+    let [x, y] = nums else { //~ ERROR expected an array or slice
+        return;
+    };
+}

--- a/src/test/ui/let-else/let-else-slicing-error.stderr
+++ b/src/test/ui/let-else/let-else-slicing-error.stderr
@@ -1,0 +1,11 @@
+error[E0529]: expected an array or slice, found `Vec<{integer}>`
+  --> $DIR/let-else-slicing-error.rs:6:9
+   |
+LL |     let [x, y] = nums else {
+   |         ^^^^^^   ---- help: consider slicing here: `nums[..]`
+   |         |
+   |         pattern cannot match with input type `Vec<{integer}>`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0529`.


### PR DESCRIPTION
In the stabilization report of `let else`, in #93628, I found various cases which weren't tested. This PR adds them.