### PR TITLE
Correctly handle miniz_oxide extern crate declaration

### DIFF
--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -366,6 +366,7 @@ extern crate unwind;
 
 #[doc(masked)]
 #[allow(unused_extern_crates)]
+#[cfg(feature = "miniz_oxide")]
 extern crate miniz_oxide;
 
 // During testing, this crate is not actually the "real" std library, but rather


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/94219.

Follow-up of https://github.com/rust-lang/rust/pull/94122.

The `miniz_oxide` dependency is optional and therefore should allow be "imported" when it makes sense.

r? @ivmarkov