### PR TITLE
Do not suggest wrapping an item if it has ambiguous un-imported methods

### DIFF
--- a/src/test/ui/rust-2021/future-prelude-collision-shadow.stderr
+++ b/src/test/ui/rust-2021/future-prelude-collision-shadow.stderr
@@ -4,34 +4,8 @@ error[E0599]: no method named `try_into` found for type `u8` in the current scop
 LL |         let _: u32 = 3u8.try_into().unwrap();
    |                          ^^^^^^^^ method not found in `u8`
    |
-  ::: $SRC_DIR/core/src/convert/mod.rs:LL:COL
-   |
-LL |     fn try_into(self) -> Result<T, Self::Error>;
-   |        --------
-   |        |
-   |        the method is available for `Box<u8>` here
-   |        the method is available for `Pin<u8>` here
-   |        the method is available for `Arc<u8>` here
-   |        the method is available for `Rc<u8>` here
-   |
    = help: items from traits can only be used if the trait is in scope
    = note: 'std::convert::TryInto' is included in the prelude starting in Edition 2021
-help: consider wrapping the receiver expression with the appropriate type
-   |
-LL |         let _: u32 = Box::new(3u8).try_into().unwrap();
-   |                      +++++++++   +
-help: consider wrapping the receiver expression with the appropriate type
-   |
-LL |         let _: u32 = Pin::new(3u8).try_into().unwrap();
-   |                      +++++++++   +
-help: consider wrapping the receiver expression with the appropriate type
-   |
-LL |         let _: u32 = Arc::new(3u8).try_into().unwrap();
-   |                      +++++++++   +
-help: consider wrapping the receiver expression with the appropriate type
-   |
-LL |         let _: u32 = Rc::new(3u8).try_into().unwrap();
-   |                      ++++++++   +
 help: the following traits are implemented but not in scope; perhaps add a `use` for one of them:
    |
 LL |     use crate::m::TryIntoU32;

--- a/src/test/ui/suggestions/dont-wrap-ambiguous-receivers.rs
+++ b/src/test/ui/suggestions/dont-wrap-ambiguous-receivers.rs
@@ -1,0 +1,21 @@
+mod banana {
+    //~^ HELP the following traits are implemented but not in scope
+    pub struct Chaenomeles;
+
+    pub trait Apple {
+        fn pick(&self) {}
+    }
+    impl Apple for Chaenomeles {}
+
+    pub trait Peach {
+        fn pick(&self, a: &mut ()) {}
+    }
+    impl<Mango: Peach> Peach for Box<Mango> {}
+    impl Peach for Chaenomeles {}
+}
+
+fn main() {
+    banana::Chaenomeles.pick()
+    //~^ ERROR no method named
+    //~| HELP items from traits can only be used if the trait is in scope
+}

--- a/src/test/ui/suggestions/dont-wrap-ambiguous-receivers.stderr
+++ b/src/test/ui/suggestions/dont-wrap-ambiguous-receivers.stderr
@@ -1,0 +1,20 @@
+error[E0599]: no method named `pick` found for struct `Chaenomeles` in the current scope
+  --> $DIR/dont-wrap-ambiguous-receivers.rs:18:25
+   |
+LL |     pub struct Chaenomeles;
+   |     ----------------------- method `pick` not found for this
+...
+LL |     banana::Chaenomeles.pick()
+   |                         ^^^^ method not found in `Chaenomeles`
+   |
+   = help: items from traits can only be used if the trait is in scope
+help: the following traits are implemented but not in scope; perhaps add a `use` for one of them:
+   |
+LL | use banana::Apple;
+   |
+LL | use banana::Peach;
+   |
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0599`.


### PR DESCRIPTION
If the method is defined for the receiver we have, but is ambiguous during probe, then it probably comes from one of several traits that just weren't `use`d. Don't suggest wrapping the receiver in `Box`/etc., even if that makes the method probe unambiguous.

Fixes #94218