### PR TITLE
Erase trivial caller-bounds when typechecking MIR after optimizations

### DIFF
--- a/compiler/rustc_const_eval/src/transform/validate.rs
+++ b/compiler/rustc_const_eval/src/transform/validate.rs
@@ -171,9 +171,10 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
             return true;
         }
         // Normalize projections and things like that.
-        // FIXME: We need to reveal_all, as some optimizations change types in ways
-        // that require unfolding opaque types.
-        let param_env = self.param_env.with_reveal_all_normalized(self.tcx);
+        // FIXME: We need to reveal_all and erase any trivial caller bounds (see query description)
+        // due to the fact that certain optimizations (e.g. inlining) change the way that types are
+        // normalized.
+        let param_env = self.tcx.reveal_all_and_erase_trivial_caller_bounds(self.param_env);
         let src = self.tcx.normalize_erasing_regions(param_env, src);
         let dest = self.tcx.normalize_erasing_regions(param_env, dest);
 

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -1152,6 +1152,16 @@ rustc_queries! {
         desc { |tcx| "computing revealed normalized predicates of `{}`", tcx.def_path_str(def_id) }
     }
 
+    /// Like `ty::ParamEnv::reveal_all_normalized`, but returns the `ParamEnv` with any
+    /// where clause bounds removed if they hold "trivially" -- that is, if they are
+    /// satisfied by the input param-env with that bound removed, such as if they match a
+    /// global `impl` or are a duplicated bound in the where clause.
+    ///
+    /// This is a query because it is computationally expensive, and we want to cache it.
+    query reveal_all_and_erase_trivial_caller_bounds(key: ty::ParamEnv<'tcx>) -> ty::ParamEnv<'tcx> {
+        desc { |tcx| "normalizing and erasing trivial predicates of `{:?}`", key }
+    }
+
     /// Trait selection queries. These are best used by invoking `ty.is_copy_modulo_regions()`,
     /// `ty.is_copy()`, etc, since that will prune the environment where possible.
     query is_copy_raw(env: ty::ParamEnvAnd<'tcx, Ty<'tcx>>) -> bool {

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -1455,6 +1455,12 @@ impl<'tcx> ParamEnv<'tcx> {
         Self::new(List::empty(), self.reveal(), self.constness())
     }
 
+    /// Returns this same environment but with new caller bounds.
+    #[inline]
+    pub fn with_caller_bounds(self, caller_bounds: &'tcx List<Predicate<'tcx>>) -> Self {
+        Self::new(caller_bounds, self.reveal(), self.constness())
+    }
+
     /// Creates a suitable environment in which to perform trait
     /// queries on the given value. When type-checking, this is simply
     /// the pair of the environment plus value. But when reveal is set to

--- a/src/test/ui/mir/mir-inlining/caller-with-trivial-bound.rs
+++ b/src/test/ui/mir/mir-inlining/caller-with-trivial-bound.rs
@@ -1,0 +1,21 @@
+// check-pass
+// compile-flags: -Zmir-opt-level=3 --crate-type=lib
+
+pub trait Factory<T> {
+    type Item;
+}
+
+pub struct IntFactory;
+
+impl<T> Factory<T> for IntFactory {
+    type Item = usize;
+}
+
+pub fn foo<T>() where IntFactory: Factory<T> {
+    let mut x: <IntFactory as Factory<T>>::Item = bar::<T>();
+}
+
+#[inline]
+pub fn bar<T>() -> <IntFactory as Factory<T>>::Item {
+    0usize
+}


### PR DESCRIPTION
Fixes an ICE when inlining this code (with `-Zmir-opt-level=3`):

```rust
trait Factory<T> {
    type Item;
}

struct IntFactory;

impl<T> Factory<T> for IntFactory {
    type Item = usize;
}

fn foo<T>() where IntFactory: Factory<T> {
    let mut x: <IntFactory as Factory<T>>::Item = bar::<T>();
}

#[inline]
fn bar<T>() -> <IntFactory as Factory<T>>::Item {
    0usize
}
```

Specifically, inside of `bar`, we normalize `<IntFactory as Factory<T>>::Item` to `usize`, but we cannot do the same inside of `foo`, because param-env candidates have precedence over impl candidates when satisfying the projection. This usually isn't a problem, but becomes one when we inline `bar` into `baz` and cannot unify `usize` with `<IntFactory as Factory<T>>::Item`.

This attempts to solve the issue by filtering thru the ParamEnv and removing any predicates that are "trivial" -- that is, that are satisfied by the ParamEnv when the bound is removed from the ParamEnv's caller bounds. This ensures that we never allow a trivial `<Ty as Trait>` predicate in the ParamEnv interfere with projection normalization during codegen. 

-----

cc: https://github.com/rust-lang/rust/pull/91743#issuecomment-1046311165
cc: @cjgillot since it helps a get rid of a few (but not all) ICEs seen from nalgebra-v0.21.1 in #91743 

NOTE: this is kinda a hack, a super heavy hammer that I'm not sure if we should implement in the first place. I'm open to closing this piece of garbage out for a better brainstorming session for how to handle ambiguities as noted above. :smile: