### PR TITLE
`s/compiler-flags/compile-flags` in compiletest

### DIFF
--- a/src/test/ui/ptr_ops/issue-80309-safe.rs
+++ b/src/test/ui/ptr_ops/issue-80309-safe.rs
@@ -1,6 +1,6 @@
 // run-pass
 // min-llvm-version: 13.0
-// compiler-flags: -O
+// compile-flags: -O
 
 // Regression test for issue #80309
 

--- a/src/test/ui/ptr_ops/issue-80309.rs
+++ b/src/test/ui/ptr_ops/issue-80309.rs
@@ -1,6 +1,6 @@
 // run-pass
 // min-llvm-version: 13.0
-// compiler-flags: -O
+// compile-flags: -O
 
 // Regression test for issue #80309
 

--- a/src/test/ui/rfc-2632-const-trait-impl/without-tilde.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/without-tilde.rs
@@ -1,4 +1,4 @@
-// compiler-flags: -Z parse-only
+// compile-flags: -Z parse-only
 
 #![feature(const_trait_impl)]
 

--- a/src/tools/compiletest/src/header.rs
+++ b/src/tools/compiletest/src/header.rs
@@ -189,6 +189,8 @@ mod directives {
     pub const STDERR_PER_BITWIDTH: &'static str = "stderr-per-bitwidth";
     pub const INCREMENTAL: &'static str = "incremental";
     pub const KNOWN_BUG: &'static str = "known-bug";
+    // This isn't a real directive, just one that is probably mistyped often
+    pub const INCORRECT_COMPILER_FLAGS: &'static str = "compiler-flags";
 }
 
 impl TestProps {
@@ -281,6 +283,9 @@ impl TestProps {
 
                 if let Some(flags) = config.parse_name_value_directive(ln, COMPILE_FLAGS) {
                     self.compile_flags.extend(flags.split_whitespace().map(|s| s.to_owned()));
+                }
+                if config.parse_name_value_directive(ln, INCORRECT_COMPILER_FLAGS).is_some() {
+                    panic!("`compiler-flags` directive should be spelled `compile-flags`");
                 }
 
                 if let Some(edition) = config.parse_edition(ln) {


### PR DESCRIPTION
Also make compiletest panic so this doesn't happen in the future! I literally always forget which it's called, so I wanted to make my life easier in the future.

Also open to the possibility of parsing both.