### PR TITLE
don't special case `DefKind::Ctor` in encoding

### DIFF
--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -6,7 +6,7 @@ use rustc_data_structures::fx::{FxHashMap, FxIndexSet};
 use rustc_data_structures::stable_hasher::StableHasher;
 use rustc_data_structures::sync::{join, par_iter, Lrc, ParallelIterator};
 use rustc_hir as hir;
-use rustc_hir::def::{CtorOf, DefKind};
+use rustc_hir::def::DefKind;
 use rustc_hir::def_id::{
     CrateNum, DefId, DefIndex, LocalDefId, CRATE_DEF_ID, CRATE_DEF_INDEX, LOCAL_CRATE,
 };
@@ -983,12 +983,7 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
             let def_id = local_id.to_def_id();
             let def_kind = tcx.opt_def_kind(local_id);
             let Some(def_kind) = def_kind else { continue };
-            record!(self.tables.opt_def_kind[def_id] <- match def_kind {
-                // Replace Ctor by the enclosing object to avoid leaking details in children crates.
-                DefKind::Ctor(CtorOf::Struct, _) => DefKind::Struct,
-                DefKind::Ctor(CtorOf::Variant, _) => DefKind::Variant,
-                def_kind => def_kind,
-            });
+            record!(self.tables.opt_def_kind[def_id] <- def_kind);
             record!(self.tables.def_span[def_id] <- tcx.def_span(def_id));
             record!(self.tables.attributes[def_id] <- tcx.get_attrs(def_id));
             record!(self.tables.expn_that_defined[def_id] <- self.tcx.expn_that_defined(def_id));

--- a/src/test/ui/deprecation/deprecation-lint.rs
+++ b/src/test/ui/deprecation/deprecation-lint.rs
@@ -35,21 +35,21 @@ mod cross_crate {
             i: 0 //~ ERROR use of deprecated field `deprecation_lint::DeprecatedStruct::i`: text
         };
 
-        let _ = DeprecatedUnitStruct; //~ ERROR use of deprecated struct `deprecation_lint::DeprecatedUnitStruct`: text
+        let _ = DeprecatedUnitStruct; //~ ERROR use of deprecated unit struct `deprecation_lint::DeprecatedUnitStruct`: text
 
-        let _ = Enum::DeprecatedVariant; //~ ERROR use of deprecated variant `deprecation_lint::Enum::DeprecatedVariant`: text
+        let _ = Enum::DeprecatedVariant; //~ ERROR use of deprecated unit variant `deprecation_lint::Enum::DeprecatedVariant`: text
 
-        let _ = DeprecatedTupleStruct (1); //~ ERROR use of deprecated struct `deprecation_lint::DeprecatedTupleStruct`: text
+        let _ = DeprecatedTupleStruct (1); //~ ERROR use of deprecated tuple struct `deprecation_lint::DeprecatedTupleStruct`: text
 
         let _ = nested::DeprecatedStruct { //~ ERROR use of deprecated struct `deprecation_lint::nested::DeprecatedStruct`: text
             i: 0 //~ ERROR use of deprecated field `deprecation_lint::nested::DeprecatedStruct::i`: text
         };
 
-        let _ = nested::DeprecatedUnitStruct; //~ ERROR use of deprecated struct `deprecation_lint::nested::DeprecatedUnitStruct`: text
+        let _ = nested::DeprecatedUnitStruct; //~ ERROR use of deprecated unit struct `deprecation_lint::nested::DeprecatedUnitStruct`: text
 
-        let _ = nested::Enum::DeprecatedVariant; //~ ERROR use of deprecated variant `deprecation_lint::nested::Enum::DeprecatedVariant`: text
+        let _ = nested::Enum::DeprecatedVariant; //~ ERROR use of deprecated unit variant `deprecation_lint::nested::Enum::DeprecatedVariant`: text
 
-        let _ = nested::DeprecatedTupleStruct (1); //~ ERROR use of deprecated struct `deprecation_lint::nested::DeprecatedTupleStruct`: text
+        let _ = nested::DeprecatedTupleStruct (1); //~ ERROR use of deprecated tuple struct `deprecation_lint::nested::DeprecatedTupleStruct`: text
 
         // At the moment, the lint checker only checks stability in
         // in the arguments of macros.
@@ -130,7 +130,7 @@ mod cross_crate {
             { .. } = x;
 
         let x = Deprecated2(1, 2, 3);
-        //~^ ERROR use of deprecated struct `deprecation_lint::Deprecated2`: text
+        //~^ ERROR use of deprecated tuple struct `deprecation_lint::Deprecated2`: text
 
         let _ = x.0;
         //~^ ERROR use of deprecated field `deprecation_lint::Deprecated2::0`: text
@@ -140,7 +140,7 @@ mod cross_crate {
         //~^ ERROR use of deprecated field `deprecation_lint::Deprecated2::2`: text
 
         let Deprecated2
-        //~^ ERROR use of deprecated struct `deprecation_lint::Deprecated2`: text
+        //~^ ERROR use of deprecated tuple struct `deprecation_lint::Deprecated2`: text
             (_,
              //~^ ERROR use of deprecated field `deprecation_lint::Deprecated2::0`: text
              _,
@@ -149,7 +149,7 @@ mod cross_crate {
              //~^ ERROR use of deprecated field `deprecation_lint::Deprecated2::2`: text
             = x;
         let Deprecated2
-        //~^ ERROR use of deprecated struct `deprecation_lint::Deprecated2`: text
+        //~^ ERROR use of deprecated tuple struct `deprecation_lint::Deprecated2`: text
             // the patterns are all fine:
             (..) = x;
     }

--- a/src/test/ui/deprecation/deprecation-lint.stderr
+++ b/src/test/ui/deprecation/deprecation-lint.stderr
@@ -46,19 +46,19 @@ error: use of deprecated struct `deprecation_lint::DeprecatedStruct`: text
 LL |         let _ = DeprecatedStruct {
    |                 ^^^^^^^^^^^^^^^^
 
-error: use of deprecated struct `deprecation_lint::DeprecatedUnitStruct`: text
+error: use of deprecated unit struct `deprecation_lint::DeprecatedUnitStruct`: text
   --> $DIR/deprecation-lint.rs:38:17
    |
 LL |         let _ = DeprecatedUnitStruct;
    |                 ^^^^^^^^^^^^^^^^^^^^
 
-error: use of deprecated variant `deprecation_lint::Enum::DeprecatedVariant`: text
+error: use of deprecated unit variant `deprecation_lint::Enum::DeprecatedVariant`: text
   --> $DIR/deprecation-lint.rs:40:23
    |
 LL |         let _ = Enum::DeprecatedVariant;
    |                       ^^^^^^^^^^^^^^^^^
 
-error: use of deprecated struct `deprecation_lint::DeprecatedTupleStruct`: text
+error: use of deprecated tuple struct `deprecation_lint::DeprecatedTupleStruct`: text
   --> $DIR/deprecation-lint.rs:42:17
    |
 LL |         let _ = DeprecatedTupleStruct (1);
@@ -70,19 +70,19 @@ error: use of deprecated struct `deprecation_lint::nested::DeprecatedStruct`: te
 LL |         let _ = nested::DeprecatedStruct {
    |                         ^^^^^^^^^^^^^^^^
 
-error: use of deprecated struct `deprecation_lint::nested::DeprecatedUnitStruct`: text
+error: use of deprecated unit struct `deprecation_lint::nested::DeprecatedUnitStruct`: text
   --> $DIR/deprecation-lint.rs:48:25
    |
 LL |         let _ = nested::DeprecatedUnitStruct;
    |                         ^^^^^^^^^^^^^^^^^^^^
 
-error: use of deprecated variant `deprecation_lint::nested::Enum::DeprecatedVariant`: text
+error: use of deprecated unit variant `deprecation_lint::nested::Enum::DeprecatedVariant`: text
   --> $DIR/deprecation-lint.rs:50:31
    |
 LL | ...   let _ = nested::Enum::DeprecatedVariant;
    |                             ^^^^^^^^^^^^^^^^^
 
-error: use of deprecated struct `deprecation_lint::nested::DeprecatedTupleStruct`: text
+error: use of deprecated tuple struct `deprecation_lint::nested::DeprecatedTupleStruct`: text
   --> $DIR/deprecation-lint.rs:52:25
    |
 LL | ...   let _ = nested::DeprecatedTupleStruct (1);
@@ -154,19 +154,19 @@ error: use of deprecated struct `deprecation_lint::Deprecated`: text
 LL |         let Deprecated
    |             ^^^^^^^^^^
 
-error: use of deprecated struct `deprecation_lint::Deprecated2`: text
+error: use of deprecated tuple struct `deprecation_lint::Deprecated2`: text
   --> $DIR/deprecation-lint.rs:132:17
    |
 LL |         let x = Deprecated2(1, 2, 3);
    |                 ^^^^^^^^^^^
 
-error: use of deprecated struct `deprecation_lint::Deprecated2`: text
+error: use of deprecated tuple struct `deprecation_lint::Deprecated2`: text
   --> $DIR/deprecation-lint.rs:142:13
    |
 LL |         let Deprecated2
    |             ^^^^^^^^^^^
 
-error: use of deprecated struct `deprecation_lint::Deprecated2`: text
+error: use of deprecated tuple struct `deprecation_lint::Deprecated2`: text
   --> $DIR/deprecation-lint.rs:151:13
    |
 LL |         let Deprecated2

--- a/src/test/ui/lint/lint-stability-deprecated.rs
+++ b/src/test/ui/lint/lint-stability-deprecated.rs
@@ -115,18 +115,18 @@ mod cross_crate {
         let _ = UnstableStruct { i: 0 };
         let _ = StableStruct { i: 0 };
 
-        let _ = DeprecatedUnitStruct; //~ WARN use of deprecated struct `lint_stability::DeprecatedUnitStruct`
-        let _ = DeprecatedUnstableUnitStruct; //~ WARN use of deprecated struct `lint_stability::DeprecatedUnstableUnitStruct`
+        let _ = DeprecatedUnitStruct; //~ WARN use of deprecated unit struct `lint_stability::DeprecatedUnitStruct`
+        let _ = DeprecatedUnstableUnitStruct; //~ WARN use of deprecated unit struct `lint_stability::DeprecatedUnstableUnitStruct`
         let _ = UnstableUnitStruct;
         let _ = StableUnitStruct;
 
-        let _ = Enum::DeprecatedVariant; //~ WARN use of deprecated variant `lint_stability::Enum::DeprecatedVariant`
-        let _ = Enum::DeprecatedUnstableVariant; //~ WARN use of deprecated variant `lint_stability::Enum::DeprecatedUnstableVariant`
+        let _ = Enum::DeprecatedVariant; //~ WARN use of deprecated unit variant `lint_stability::Enum::DeprecatedVariant`
+        let _ = Enum::DeprecatedUnstableVariant; //~ WARN use of deprecated unit variant `lint_stability::Enum::DeprecatedUnstableVariant`
         let _ = Enum::UnstableVariant;
         let _ = Enum::StableVariant;
 
-        let _ = DeprecatedTupleStruct (1); //~ WARN use of deprecated struct `lint_stability::DeprecatedTupleStruct`
-        let _ = DeprecatedUnstableTupleStruct (1); //~ WARN use of deprecated struct `lint_stability::DeprecatedUnstableTupleStruct`
+        let _ = DeprecatedTupleStruct (1); //~ WARN use of deprecated tuple struct `lint_stability::DeprecatedTupleStruct`
+        let _ = DeprecatedUnstableTupleStruct (1); //~ WARN use of deprecated tuple struct `lint_stability::DeprecatedUnstableTupleStruct`
         let _ = UnstableTupleStruct (1);
         let _ = StableTupleStruct (1);
 

--- a/src/test/ui/lint/lint-stability-deprecated.stderr
+++ b/src/test/ui/lint/lint-stability-deprecated.stderr
@@ -88,37 +88,37 @@ warning: use of deprecated struct `lint_stability::DeprecatedUnstableStruct`: te
 LL |         let _ = DeprecatedUnstableStruct {
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated struct `lint_stability::DeprecatedUnitStruct`: text
+warning: use of deprecated unit struct `lint_stability::DeprecatedUnitStruct`: text
   --> $DIR/lint-stability-deprecated.rs:118:17
    |
 LL |         let _ = DeprecatedUnitStruct;
    |                 ^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated struct `lint_stability::DeprecatedUnstableUnitStruct`: text
+warning: use of deprecated unit struct `lint_stability::DeprecatedUnstableUnitStruct`: text
   --> $DIR/lint-stability-deprecated.rs:119:17
    |
 LL |         let _ = DeprecatedUnstableUnitStruct;
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated variant `lint_stability::Enum::DeprecatedVariant`: text
+warning: use of deprecated unit variant `lint_stability::Enum::DeprecatedVariant`: text
   --> $DIR/lint-stability-deprecated.rs:123:23
    |
 LL |         let _ = Enum::DeprecatedVariant;
    |                       ^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated variant `lint_stability::Enum::DeprecatedUnstableVariant`: text
+warning: use of deprecated unit variant `lint_stability::Enum::DeprecatedUnstableVariant`: text
   --> $DIR/lint-stability-deprecated.rs:124:23
    |
 LL |         let _ = Enum::DeprecatedUnstableVariant;
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated struct `lint_stability::DeprecatedTupleStruct`: text
+warning: use of deprecated tuple struct `lint_stability::DeprecatedTupleStruct`: text
   --> $DIR/lint-stability-deprecated.rs:128:17
    |
 LL |         let _ = DeprecatedTupleStruct (1);
    |                 ^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of deprecated struct `lint_stability::DeprecatedUnstableTupleStruct`: text
+warning: use of deprecated tuple struct `lint_stability::DeprecatedUnstableTupleStruct`: text
   --> $DIR/lint-stability-deprecated.rs:129:17
    |
 LL |         let _ = DeprecatedUnstableTupleStruct (1);

--- a/src/test/ui/lint/lint-stability-fields-deprecated.rs
+++ b/src/test/ui/lint/lint-stability-fields-deprecated.rs
@@ -129,7 +129,7 @@ mod cross_crate {
             { .. } = x;
 
         let x = Deprecated2(1, 2, 3);
-        //~^ ERROR use of deprecated struct
+        //~^ ERROR use of deprecated tuple struct
 
         let _ = x.0;
         //~^ ERROR use of deprecated field
@@ -139,7 +139,7 @@ mod cross_crate {
         //~^ ERROR use of deprecated field
 
         let Deprecated2
-        //~^ ERROR use of deprecated struct
+        //~^ ERROR use of deprecated tuple struct
             (_,
              //~^ ERROR use of deprecated field
              _,
@@ -148,7 +148,7 @@ mod cross_crate {
              //~^ ERROR use of deprecated field
             = x;
         let Deprecated2
-        //~^ ERROR use of deprecated struct
+        //~^ ERROR use of deprecated tuple struct
             // the patterns are all fine:
             (..) = x;
     }

--- a/src/test/ui/lint/lint-stability-fields-deprecated.stderr
+++ b/src/test/ui/lint/lint-stability-fields-deprecated.stderr
@@ -22,19 +22,19 @@ error: use of deprecated struct `cross_crate::lint_stability_fields::Deprecated`
 LL |         let Deprecated
    |             ^^^^^^^^^^
 
-error: use of deprecated struct `cross_crate::lint_stability_fields::Deprecated2`: text
+error: use of deprecated tuple struct `cross_crate::lint_stability_fields::Deprecated2`: text
   --> $DIR/lint-stability-fields-deprecated.rs:131:17
    |
 LL |         let x = Deprecated2(1, 2, 3);
    |                 ^^^^^^^^^^^
 
-error: use of deprecated struct `cross_crate::lint_stability_fields::Deprecated2`: text
+error: use of deprecated tuple struct `cross_crate::lint_stability_fields::Deprecated2`: text
   --> $DIR/lint-stability-fields-deprecated.rs:141:13
    |
 LL |         let Deprecated2
    |             ^^^^^^^^^^^
 
-error: use of deprecated struct `cross_crate::lint_stability_fields::Deprecated2`: text
+error: use of deprecated tuple struct `cross_crate::lint_stability_fields::Deprecated2`: text
   --> $DIR/lint-stability-fields-deprecated.rs:150:13
    |
 LL |         let Deprecated2

--- a/src/test/ui/stability-attribute/generics-default-stability.rs
+++ b/src/test/ui/stability-attribute/generics-default-stability.rs
@@ -217,25 +217,25 @@ fn main() {
 
     let _ = ENUM4;
     let _: Enum4<isize> = Enum4::Some(1);
-    //~^ use of deprecated variant `unstable_generic_param::Enum4::Some`: test [deprecated]
+    //~^ use of deprecated tuple variant `unstable_generic_param::Enum4::Some`: test [deprecated]
     //~^^ use of deprecated enum `unstable_generic_param::Enum4`: test [deprecated]
     let _ = ENUM4;
     let _: Enum4 = ENUM4; //~ use of deprecated enum `unstable_generic_param::Enum4`: test [deprecated]
     let _: Enum4<usize> = ENUM4; //~ use of deprecated enum `unstable_generic_param::Enum4`: test [deprecated]
     let _: Enum4<isize> = Enum4::Some(0);
-    //~^ use of deprecated variant `unstable_generic_param::Enum4::Some`: test [deprecated]
+    //~^ use of deprecated tuple variant `unstable_generic_param::Enum4::Some`: test [deprecated]
     //~^^ use of deprecated enum `unstable_generic_param::Enum4`: test [deprecated]
 
     let _ = ENUM5;
     let _: Enum5<isize> = Enum5::Some(1); //~ ERROR use of unstable library feature 'unstable_default'
-    //~^ use of deprecated variant `unstable_generic_param::Enum5::Some`: test [deprecated]
+    //~^ use of deprecated tuple variant `unstable_generic_param::Enum5::Some`: test [deprecated]
     //~^^ use of deprecated enum `unstable_generic_param::Enum5`: test [deprecated]
     let _ = ENUM5;
     let _: Enum5 = ENUM5; //~ use of deprecated enum `unstable_generic_param::Enum5`: test [deprecated]
     let _: Enum5<usize> = ENUM5; //~ ERROR use of unstable library feature 'unstable_default'
     //~^ use of deprecated enum `unstable_generic_param::Enum5`: test [deprecated]
     let _: Enum5<isize> = Enum5::Some(0); //~ ERROR use of unstable library feature 'unstable_default'
-    //~^ use of deprecated variant `unstable_generic_param::Enum5::Some`: test [deprecated]
+    //~^ use of deprecated tuple variant `unstable_generic_param::Enum5::Some`: test [deprecated]
     //~^^ use of deprecated enum `unstable_generic_param::Enum5`: test [deprecated]
 
     let _: Enum6<isize> = Enum6::Some(1); // ok

--- a/src/test/ui/stability-attribute/generics-default-stability.stderr
+++ b/src/test/ui/stability-attribute/generics-default-stability.stderr
@@ -144,7 +144,7 @@ warning: use of deprecated type alias `unstable_generic_param::Alias5`: test
 LL |     let _: Alias5<isize> = Alias5::Some(0);
    |            ^^^^^^
 
-warning: use of deprecated variant `unstable_generic_param::Enum4::Some`: test
+warning: use of deprecated tuple variant `unstable_generic_param::Enum4::Some`: test
   --> $DIR/generics-default-stability.rs:219:34
    |
 LL |     let _: Enum4<isize> = Enum4::Some(1);
@@ -168,7 +168,7 @@ warning: use of deprecated enum `unstable_generic_param::Enum4`: test
 LL |     let _: Enum4<usize> = ENUM4;
    |            ^^^^^
 
-warning: use of deprecated variant `unstable_generic_param::Enum4::Some`: test
+warning: use of deprecated tuple variant `unstable_generic_param::Enum4::Some`: test
   --> $DIR/generics-default-stability.rs:225:34
    |
 LL |     let _: Enum4<isize> = Enum4::Some(0);
@@ -180,7 +180,7 @@ warning: use of deprecated enum `unstable_generic_param::Enum4`: test
 LL |     let _: Enum4<isize> = Enum4::Some(0);
    |            ^^^^^
 
-warning: use of deprecated variant `unstable_generic_param::Enum5::Some`: test
+warning: use of deprecated tuple variant `unstable_generic_param::Enum5::Some`: test
   --> $DIR/generics-default-stability.rs:230:34
    |
 LL |     let _: Enum5<isize> = Enum5::Some(1);
@@ -204,7 +204,7 @@ warning: use of deprecated enum `unstable_generic_param::Enum5`: test
 LL |     let _: Enum5<usize> = ENUM5;
    |            ^^^^^
 
-warning: use of deprecated variant `unstable_generic_param::Enum5::Some`: test
+warning: use of deprecated tuple variant `unstable_generic_param::Enum5::Some`: test
   --> $DIR/generics-default-stability.rs:237:34
    |
 LL |     let _: Enum5<isize> = Enum5::Some(0);


### PR DESCRIPTION
considering that we still use `DefKind::Ctor` for these in `Res`, this seems weird and definitely felt like a bug when encountering it while working on #89862.

r? @cjgillot 