### PR TITLE
Fix rustdoc infinite redirection generation

### DIFF
--- a/src/test/rustdoc/infinite-redirection.rs
+++ b/src/test/rustdoc/infinite-redirection.rs
@@ -1,0 +1,29 @@
+#![crate_name = "foo"]
+
+// This test ensures that there is no "infinite redirection" file generated (a
+// file which redirects to itself).
+
+// We check it's not a redirection file.
+// @has 'foo/builders/struct.ActionRowBuilder.html'
+// @has - '//*[@id="synthetic-implementations"]' 'Auto Trait Implementations'
+
+// And that the link in the module is targetting it.
+// @has 'foo/builders/index.html'
+// @has - '//a[@href="struct.ActionRowBuilder.html"]' 'ActionRowBuilder'
+
+mod auto {
+    mod action_row {
+        pub struct ActionRowBuilder;
+    }
+
+    #[doc(hidden)]
+    pub mod builders {
+        pub use super::action_row::ActionRowBuilder;
+    }
+}
+
+pub use auto::*;
+
+pub mod builders {
+    pub use crate::auto::builders::*;
+}


### PR DESCRIPTION
Someone came to me about a funny bug they had when clicking on any link on [this page](https://world.pages.gitlab.gnome.org/Rust/libadwaita-rs/stable/latest/docs/libadwaita/builders/index.html): it ended one page redirecting to itself indefinitely.

I was able to make a minimum reproducible case to trigger this bug which I now use as a test.

r? @notriddle 