### PR TITLE
Typo fix: Close inline-code backtick

### DIFF
--- a/src/doc/unstable-book/src/compiler-flags/debug_info_for_profiling.md
+++ b/src/doc/unstable-book/src/compiler-flags/debug_info_for_profiling.md
@@ -1,4 +1,4 @@
-# `debug-info-for-profiling
+# `debug-info-for-profiling`
 
 ---
 


### PR DESCRIPTION
A drop in the ocean.