### PR TITLE
Remove unused ordering derivations and bounds for `SimplifiedTypeGen`

### DIFF
--- a/compiler/rustc_middle/src/ty/fast_reject.rs
+++ b/compiler/rustc_middle/src/ty/fast_reject.rs
@@ -17,7 +17,7 @@ pub type SimplifiedType = SimplifiedTypeGen<DefId>;
 /// because we sometimes need to use SimplifiedTypeGen values as stable sorting
 /// keys (in which case we use a DefPathHash as id-type) but in the general case
 /// the non-stable but fast to construct DefId-version is the better choice.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, TyEncodable, TyDecodable)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, TyEncodable, TyDecodable)]
 pub enum SimplifiedTypeGen<D>
 where
     D: Copy + Debug + Eq,
@@ -124,7 +124,7 @@ pub fn simplify_type(
     }
 }
 
-impl<D: Copy + Debug + Ord + Eq> SimplifiedTypeGen<D> {
+impl<D: Copy + Debug + Eq> SimplifiedTypeGen<D> {
     pub fn def(self) -> Option<D> {
         match self {
             AdtSimplifiedType(d)
@@ -140,7 +140,7 @@ impl<D: Copy + Debug + Ord + Eq> SimplifiedTypeGen<D> {
     pub fn map_def<U, F>(self, map: F) -> SimplifiedTypeGen<U>
     where
         F: Fn(D) -> U,
-        U: Copy + Debug + Ord + Eq,
+        U: Copy + Debug + Eq,
     {
         match self {
             BoolSimplifiedType => BoolSimplifiedType,
@@ -171,7 +171,7 @@ impl<D: Copy + Debug + Ord + Eq> SimplifiedTypeGen<D> {
 
 impl<'a, D> HashStable<StableHashingContext<'a>> for SimplifiedTypeGen<D>
 where
-    D: Copy + Debug + Ord + Eq + HashStable<StableHashingContext<'a>>,
+    D: Copy + Debug + Eq + HashStable<StableHashingContext<'a>>,
 {
     fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
         mem::discriminant(self).hash_stable(hcx, hasher);


### PR DESCRIPTION
This is another small PR clearing the way for work on #90317.