### PR TITLE
Update cargo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,7 +327,7 @@ dependencies = [
  "cargo-test-macro",
  "cargo-test-support",
  "cargo-util",
- "clap 3.0.13",
+ "clap 3.1.1",
  "crates-io",
  "crossbeam-utils",
  "curl",
@@ -606,9 +606,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.0.13"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08799f92c961c7a1cf0cc398a9073da99e21ce388b46372c37f3191f2f3eed3e"
+checksum = "6d76c22c9b9b215eeb8d016ad3a90417bd13cb24cf8142756e6472445876cab7"
 dependencies = [
  "atty",
  "bitflags",


### PR DESCRIPTION
8 commits in ea2a21c994ca1e4d4c49412827b3cf4dcb158b1d..d6cdde584a1f15ea086bae922e20fd27f7165431
2022-02-15 04:24:07 +0000 to 2022-02-22 19:55:51 +0000
- Add common profile validation. (rust-lang/cargo#10411)
- Add -Z check-cfg-features to enable compile-time checking of features (rust-lang/cargo#10408)
- Remove invalid target-specific dependency example. (rust-lang/cargo#10401)
- Fix errors in `cargo fetch` usage guide (rust-lang/cargo#10398)
- Fix some broken doc links. (rust-lang/cargo#10404)
- Implement "artifact dependencies" (RFC-3028) (rust-lang/cargo#9992)
- Print executable name on cargo test --no-run rust-lang/cargo#2 (rust-lang/cargo#10346)
- Avoid new deprecation warnings from clap 3.1.0 (rust-lang/cargo#10396)