### PR TITLE
Print `ParamTy` and `ParamConst` instead of displaying them

### DIFF
--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -612,7 +612,7 @@ pub trait PrettyPrinter<'tcx>:
                 }
             }
             ty::Error(_) => p!("[type error]"),
-            ty::Param(ref param_ty) => p!(write("{}", param_ty)),
+            ty::Param(ref param_ty) => p!(print(param_ty)),
             ty::Bound(debruijn, bound_ty) => match bound_ty.kind {
                 ty::BoundTyKind::Anon => self.pretty_print_bound_var(debruijn, bound_ty.var)?,
                 ty::BoundTyKind::Param(p) => p!(write("{}", p)),
@@ -754,7 +754,7 @@ pub trait PrettyPrinter<'tcx>:
                 } else if let Some(n) = sz.val().try_to_bits(self.tcx().data_layout.pointer_size) {
                     p!(write("{}", n));
                 } else if let ty::ConstKind::Param(param) = sz.val() {
-                    p!(write("{}", param));
+                    p!(print(param));
                 } else {
                     p!("_");
                 }


### PR DESCRIPTION
Display for `ParamTy` and `ParamConst` is implemented in terms of print.
Using print avoids creating a new `FmtPrinter` just to display the
parameter name.

r? @Mark-Simulacrum 