### PR TITLE
Fix rustdoc const display

### DIFF
--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1382,7 +1382,8 @@ impl Clean<Type> for hir::Ty<'_> {
                 let length = match length {
                     hir::ArrayLen::Infer(_, _) => "_".to_string(),
                     hir::ArrayLen::Body(anon_const) => {
-                        let def_id = cx.tcx.hir().local_def_id(anon_const.hir_id);
+                        let tcx = cx.tcx;
+                        let def_id = tcx.hir().local_def_id(anon_const.hir_id);
                         // NOTE(min_const_generics): We can't use `const_eval_poly` for constants
                         // as we currently do not supply the parent generics to anonymous constants
                         // but do allow `ConstKind::Param`.
@@ -1390,9 +1391,9 @@ impl Clean<Type> for hir::Ty<'_> {
                         // `const_eval_poly` tries to to first substitute generic parameters which
                         // results in an ICE while manually constructing the constant and using `eval`
                         // does nothing for `ConstKind::Param`.
-                        let ct = ty::Const::from_anon_const(cx.tcx, def_id);
-                        let param_env = cx.tcx.param_env(def_id);
-                        print_const(cx, ct.eval(cx.tcx, param_env))
+                        let ct = ty::Const::from_anon_const(tcx, def_id);
+                        let param_env = tcx.param_env(def_id);
+                        print_const(tcx, ct.eval(tcx, param_env))
                     }
                 };
 
@@ -1468,7 +1469,7 @@ impl<'tcx> Clean<Type> for Ty<'tcx> {
             ty::Array(ty, n) => {
                 let mut n = cx.tcx.lift(n).expect("array lift failed");
                 n = n.eval(cx.tcx, ty::ParamEnv::reveal_all());
-                let n = print_const(cx, n);
+                let n = print_const(cx.tcx, n);
                 Array(box ty.clean(cx), n)
             }
             ty::RawPtr(mt) => RawPointer(mt.mutbl, box mt.ty.clean(cx)),

--- a/src/librustdoc/clean/utils.rs
+++ b/src/librustdoc/clean/utils.rs
@@ -226,14 +226,14 @@ crate fn name_from_pat(p: &hir::Pat<'_>) -> Symbol {
     })
 }
 
-crate fn print_const(cx: &DocContext<'_>, n: ty::Const<'_>) -> String {
+crate fn print_const(tcx: TyCtxt<'_>, n: ty::Const<'_>) -> String {
     match n.val() {
         ty::ConstKind::Unevaluated(ty::Unevaluated { def, substs: _, promoted }) => {
             let mut s = if let Some(def) = def.as_local() {
-                let hir_id = cx.tcx.hir().local_def_id_to_hir_id(def.did);
-                print_const_expr(cx.tcx, cx.tcx.hir().body_owned_by(hir_id))
+                let hir_id = tcx.hir().local_def_id_to_hir_id(def.did);
+                print_const_expr(tcx, tcx.hir().body_owned_by(hir_id))
             } else {
-                inline::print_inlined_const(cx.tcx, def.did)
+                inline::print_inlined_const(tcx, def.did)
             };
             if let Some(promoted) = promoted {
                 s.push_str(&format!("::{:?}", promoted))

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -374,12 +374,10 @@ impl clean::Lifetime {
 
 impl clean::Constant {
     crate fn print(&self, tcx: TyCtxt<'_>) -> impl fmt::Display + '_ {
-        let expr = self.expr(tcx);
-        display_fn(
-            move |f| {
-                if f.alternate() { f.write_str(&expr) } else { write!(f, "{}", Escape(&expr)) }
-            },
-        )
+        let value = self.value(tcx).unwrap_or_else(|| self.expr(tcx));
+        display_fn(move |f| {
+            if f.alternate() { f.write_str(&value) } else { write!(f, "{}", Escape(&value)) }
+        })
     }
 }
 

--- a/src/test/rustdoc/const-generics/const-impl.rs
+++ b/src/test/rustdoc/const-generics/const-impl.rs
@@ -15,14 +15,14 @@ pub struct VSet<T, const ORDER: Order> {
     inner: Vec<T>,
 }
 
-// @has foo/struct.VSet.html '//*[@id="impl"]/h3[@class="code-header in-band"]' 'impl<T> VSet<T, { Order::Sorted }>'
+// @has foo/struct.VSet.html '//*[@id="impl"]/h3[@class="code-header in-band"]' 'impl<T> VSet<T, Order::Sorted>'
 impl<T> VSet<T, { Order::Sorted }> {
     pub fn new() -> Self {
         Self { inner: Vec::new() }
     }
 }
 
-// @has foo/struct.VSet.html '//*[@id="impl-1"]/h3[@class="code-header in-band"]' 'impl<T> VSet<T, { Order::Unsorted }>'
+// @has foo/struct.VSet.html '//*[@id="impl-1"]/h3[@class="code-header in-band"]' 'impl<T> VSet<T, Order::Unsorted>'
 impl<T> VSet<T, { Order::Unsorted }> {
     pub fn new() -> Self {
         Self { inner: Vec::new() }

--- a/src/test/rustdoc/const-values-display.rs
+++ b/src/test/rustdoc/const-values-display.rs
@@ -1,0 +1,39 @@
+#![crate_name = "foo"]
+
+pub trait Test {}
+pub struct Array<T, const N: usize>([T; N]);
+
+// @has 'foo/trait.Test.html'
+// @has - '//*[@class="code-header in-band"]' 'impl Test for [u8; 2]'
+impl Test for [u8; 1 + 1] {}
+// @has - '//*[@class="code-header in-band"]' 'impl Test for Array<u8, 2>'
+impl Test for Array<u8, {1 + 1}> {}
+
+type ArrayType<T, const N: usize> = [T; N];
+
+// @has 'foo/type.A0.html'
+// @has - '//*[@class="docblock item-decl"]' 'pub type A0 = [i32; 5];'
+pub type A0 = [i32; 3 + 2];
+// @has 'foo/type.A1.html'
+// @has - '//*[@class="docblock item-decl"]' 'pub type A1 = Array<i32, 5>;'
+pub type A1 = Array<i32, { 3 + 2 }>;
+// @has 'foo/struct.B0.html'
+// @has - '//*[@class="docblock item-decl"]' 'pub struct B0(pub [i32; 6]);'
+// @has - '//*[@id="structfield.0"]' '0: [i32; 6]'
+pub struct B0(pub [i32; 3 * 2]);
+// @has 'foo/struct.B1.html'
+// @has - '//*[@class="docblock item-decl"]' 'pub struct B1(pub Array<i32, 5>);'
+// @has - '//*[@id="structfield.0"]' '0: Array<i32, 5>'
+pub struct B1(pub Array<i32, {3 + 2}>);
+// @has 'foo/struct.C0.html'
+// @has - '//*[@class="docblock item-decl"]' 'pub foo: [i32; 6],'
+// @has - '//*[@id="structfield.foo"]' 'foo: [i32; 6]'
+pub struct C0 { pub foo: [i32; 3 * 2] }
+// @has 'foo/struct.C1.html'
+// @has - '//*[@class="docblock item-decl"]' 'pub foo: Array<i32, 5>,'
+// @has - '//*[@id="structfield.foo"]' 'foo: Array<i32, 5>'
+pub struct C1 { pub foo: Array<i32, {3 + 2}> }
+
+// @has 'foo/constant.X.html'
+// @has - '//*[@class="docblock item-decl"]' 'pub const X: u32 = 14 * 2; // 28u32'
+pub const X: u32 = 14 * 2;


### PR DESCRIPTION
Fixes #82852.

Instead of using `expr`, I used `value` to display constants in generics. Another change is that now, `ConstantKind::Anonymous` doesn't return `None` when calling `value`.

r? @camelid 