### PR TITLE
riscv32imc_esp_espidf: set max_atomic_width to 64

### DIFF
--- a/compiler/rustc_target/src/spec/riscv32imc_esp_espidf.rs
+++ b/compiler/rustc_target/src/spec/riscv32imc_esp_espidf.rs
@@ -18,11 +18,11 @@ pub fn target() -> Target {
             cpu: "generic-rv32".to_string(),
 
             // While the RiscV32IMC architecture does not natively support atomics, ESP-IDF does support
-            // the __atomic* and __sync* GCC builtins, so setting `max_atomic_width` to `Some(32)`
+            // the __atomic* and __sync* GCC builtins, so setting `max_atomic_width` to `Some(64)`
             // and `atomic_cas` to `true` will cause the compiler to emit libcalls to these builtins.
             //
             // Support for atomics is necessary for the Rust STD library, which is supported by the ESP-IDF framework.
-            max_atomic_width: Some(32),
+            max_atomic_width: Some(64),
             atomic_cas: true,
 
             features: "+m,+c".to_string(),


### PR DESCRIPTION
For espidf targets without native atomics, there is atomic emulation inside [the newlib component of espidf](https://github.com/espressif/esp-idf/blob/master/components/newlib/stdatomic.c), this has been extended to support emulation up to 64bits therefore we are safe to increase the atomic width for the `riscv32imc_esp_espidf` target.

Closes https://github.com/esp-rs/rust/issues/107

cc: @ivmarkov 