### PR TITLE
Stop using `exhaustive_patterns` in libcore

### DIFF
--- a/library/core/src/lazy.rs
+++ b/library/core/src/lazy.rs
@@ -176,6 +176,7 @@ impl<T> OnceCell<T> {
     {
         match self.get_or_try_init(|| Ok::<T, !>(f())) {
             Ok(val) => val,
+            Err(never) => match never {},
         }
     }
 

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -169,7 +169,6 @@
 #![feature(doc_cfg)]
 #![feature(doc_notable_trait)]
 #![feature(rustdoc_internals)]
-#![feature(exhaustive_patterns)]
 #![feature(doc_cfg_hide)]
 #![feature(extern_types)]
 #![feature(fundamental)]

--- a/library/core/src/ops/control_flow.rs
+++ b/library/core/src/ops/control_flow.rs
@@ -119,6 +119,7 @@ impl<B, C> ops::FromResidual for ControlFlow<B, C> {
     fn from_residual(residual: ControlFlow<B, convert::Infallible>) -> Self {
         match residual {
             ControlFlow::Break(b) => ControlFlow::Break(b),
+            ControlFlow::Continue(never) => match never {},
         }
     }
 }

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -2276,6 +2276,7 @@ impl<T> const ops::FromResidual for Option<T> {
     fn from_residual(residual: Option<convert::Infallible>) -> Self {
         match residual {
             None => None,
+            Some(never) => match never {},
         }
     }
 }

--- a/library/core/src/result.rs
+++ b/library/core/src/result.rs
@@ -2062,6 +2062,7 @@ impl<T, E, F: ~const From<E>> const ops::FromResidual<Result<convert::Infallible
     fn from_residual(residual: Result<convert::Infallible, E>) -> Self {
         match residual {
             Err(e) => Err(From::from(e)),
+            Ok(never) => match never {},
         }
     }
 }

--- a/library/core/src/task/poll.rs
+++ b/library/core/src/task/poll.rs
@@ -282,6 +282,7 @@ impl<T, E, F: From<E>> ops::FromResidual<Result<convert::Infallible, E>> for Pol
     fn from_residual(x: Result<convert::Infallible, E>) -> Self {
         match x {
             Err(e) => Poll::Ready(Err(From::from(e))),
+            Ok(never) => match never {},
         }
     }
 }
@@ -315,6 +316,7 @@ impl<T, E, F: From<E>> ops::FromResidual<Result<convert::Infallible, E>>
     fn from_residual(x: Result<convert::Infallible, E>) -> Self {
         match x {
             Err(e) => Poll::Ready(Some(Err(From::from(e)))),
+            Ok(never) => match never {},
         }
     }
 }

--- a/library/core/src/task/ready.rs
+++ b/library/core/src/task/ready.rs
@@ -95,6 +95,7 @@ impl<T> FromResidual for Ready<T> {
     fn from_residual(residual: Ready<convert::Infallible>) -> Self {
         match residual.0 {
             Poll::Pending => Ready(Poll::Pending),
+            Poll::Ready(never) => match never {},
         }
     }
 }
@@ -105,6 +106,7 @@ impl<T> FromResidual<Ready<convert::Infallible>> for Poll<T> {
     fn from_residual(residual: Ready<convert::Infallible>) -> Self {
         match residual.0 {
             Poll::Pending => Poll::Pending,
+            Poll::Ready(never) => match never {},
         }
     }
 }


### PR DESCRIPTION
Inspired be the meeting saying that there's a goal to use fewer unstable features.

Looks like every place but one that was using this was me, so here's a PR.