### PR TITLE
Rollup of 9 pull requests

### DIFF
--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -2418,8 +2418,7 @@ impl<S: Encoder> rustc_serialize::Encodable<S> for AttrId {
 }
 
 impl<D: Decoder> rustc_serialize::Decodable<D> for AttrId {
-    fn decode(d: &mut D) -> AttrId {
-        d.read_unit();
+    fn decode(_: &mut D) -> AttrId {
         crate::attr::mk_attr_id()
     }
 }

--- a/compiler/rustc_codegen_llvm/src/debuginfo/metadata.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/metadata.rs
@@ -87,7 +87,7 @@ const DW_ATE_signed: c_uint = 0x05;
 #[allow(non_upper_case_globals)]
 const DW_ATE_unsigned: c_uint = 0x07;
 #[allow(non_upper_case_globals)]
-const DW_ATE_unsigned_char: c_uint = 0x08;
+const DW_ATE_UTF: c_uint = 0x10;
 
 pub const UNKNOWN_LINE_NUMBER: c_uint = 0;
 pub const UNKNOWN_COLUMN_NUMBER: c_uint = 0;
@@ -933,7 +933,7 @@ fn basic_type_metadata<'ll, 'tcx>(cx: &CodegenCx<'ll, 'tcx>, t: Ty<'tcx>) -> &'l
         ty::Never => ("!", DW_ATE_unsigned),
         ty::Tuple(elements) if elements.is_empty() => ("()", DW_ATE_unsigned),
         ty::Bool => ("bool", DW_ATE_boolean),
-        ty::Char => ("char", DW_ATE_unsigned_char),
+        ty::Char => ("char", DW_ATE_UTF),
         ty::Int(int_ty) if cpp_like_debuginfo => (int_ty.msvc_basic_name(), DW_ATE_signed),
         ty::Uint(uint_ty) if cpp_like_debuginfo => (uint_ty.msvc_basic_name(), DW_ATE_unsigned),
         ty::Float(float_ty) if cpp_like_debuginfo => (float_ty.msvc_basic_name(), DW_ATE_float),

--- a/compiler/rustc_data_structures/src/fingerprint.rs
+++ b/compiler/rustc_data_structures/src/fingerprint.rs
@@ -153,9 +153,7 @@ impl<E: rustc_serialize::Encoder> Encodable<E> for Fingerprint {
 impl<D: rustc_serialize::Decoder> Decodable<D> for Fingerprint {
     #[inline]
     fn decode(d: &mut D) -> Self {
-        let mut bytes = [0u8; 16];
-        d.read_raw_bytes_into(&mut bytes);
-        Fingerprint::from_le_bytes(bytes)
+        Fingerprint::from_le_bytes(d.read_raw_bytes(16).try_into().unwrap())
     }
 }
 

--- a/compiler/rustc_metadata/src/rmeta/decoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder.rs
@@ -316,7 +316,7 @@ impl<'a, 'tcx> DecodeContext<'a, 'tcx> {
     }
 
     #[inline]
-    pub fn read_raw_bytes(&mut self, len: usize) -> &'a [u8] {
+    pub fn read_raw_bytes(&mut self, len: usize) -> &[u8] {
         self.opaque.read_raw_bytes(len)
     }
 }

--- a/compiler/rustc_middle/src/mir/predecessors.rs
+++ b/compiler/rustc_middle/src/mir/predecessors.rs
@@ -63,8 +63,7 @@ impl<S: serialize::Encoder> serialize::Encodable<S> for PredecessorCache {
 
 impl<D: serialize::Decoder> serialize::Decodable<D> for PredecessorCache {
     #[inline]
-    fn decode(d: &mut D) -> Self {
-        let () = d.read_unit();
+    fn decode(_: &mut D) -> Self {
         Self::new()
     }
 }

--- a/compiler/rustc_middle/src/ty/codec.rs
+++ b/compiler/rustc_middle/src/ty/codec.rs
@@ -485,12 +485,12 @@ macro_rules! implement_ty_decoder {
                     read_f64 -> f64;
                     read_f32 -> f32;
                     read_char -> char;
-                    read_str -> Cow<'_, str>;
+                    read_str -> &str;
                 }
 
                 #[inline]
-                fn read_raw_bytes_into(&mut self, bytes: &mut [u8]) {
-                    self.opaque.read_raw_bytes_into(bytes)
+                fn read_raw_bytes(&mut self, len: usize) -> &[u8] {
+                    self.opaque.read_raw_bytes(len)
                 }
             }
         }

--- a/compiler/rustc_middle/src/ty/codec.rs
+++ b/compiler/rustc_middle/src/ty/codec.rs
@@ -465,8 +465,6 @@ macro_rules! implement_ty_decoder {
 
             impl<$($typaram ),*> Decoder for $DecoderName<$($typaram),*> {
                 $crate::__impl_decoder_methods! {
-                    read_unit -> ();
-
                     read_u128 -> u128;
                     read_u64 -> u64;
                     read_u32 -> u32;

--- a/compiler/rustc_middle/src/ty/fast_reject.rs
+++ b/compiler/rustc_middle/src/ty/fast_reject.rs
@@ -17,7 +17,7 @@ pub type SimplifiedType = SimplifiedTypeGen<DefId>;
 /// because we sometimes need to use SimplifiedTypeGen values as stable sorting
 /// keys (in which case we use a DefPathHash as id-type) but in the general case
 /// the non-stable but fast to construct DefId-version is the better choice.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, TyEncodable, TyDecodable)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, TyEncodable, TyDecodable)]
 pub enum SimplifiedTypeGen<D>
 where
     D: Copy + Debug + Eq,
@@ -124,7 +124,7 @@ pub fn simplify_type(
     }
 }
 
-impl<D: Copy + Debug + Ord + Eq> SimplifiedTypeGen<D> {
+impl<D: Copy + Debug + Eq> SimplifiedTypeGen<D> {
     pub fn def(self) -> Option<D> {
         match self {
             AdtSimplifiedType(d)
@@ -140,7 +140,7 @@ impl<D: Copy + Debug + Ord + Eq> SimplifiedTypeGen<D> {
     pub fn map_def<U, F>(self, map: F) -> SimplifiedTypeGen<U>
     where
         F: Fn(D) -> U,
-        U: Copy + Debug + Ord + Eq,
+        U: Copy + Debug + Eq,
     {
         match self {
             BoolSimplifiedType => BoolSimplifiedType,
@@ -171,7 +171,7 @@ impl<D: Copy + Debug + Ord + Eq> SimplifiedTypeGen<D> {
 
 impl<'a, D> HashStable<StableHashingContext<'a>> for SimplifiedTypeGen<D>
 where
-    D: Copy + Debug + Ord + Eq + HashStable<StableHashingContext<'a>>,
+    D: Copy + Debug + Eq + HashStable<StableHashingContext<'a>>,
 {
     fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
         mem::discriminant(self).hash_stable(hcx, hasher);

--- a/compiler/rustc_serialize/src/opaque.rs
+++ b/compiler/rustc_serialize/src/opaque.rs
@@ -1,6 +1,5 @@
 use crate::leb128::{self, max_leb128_len};
 use crate::serialize::{self, Encoder as _};
-use std::borrow::Cow;
 use std::convert::TryInto;
 use std::fs::File;
 use std::io::{self, Write};
@@ -663,7 +662,7 @@ impl<'a> serialize::Decoder for Decoder<'a> {
     }
 
     #[inline]
-    fn read_str(&mut self) -> Cow<'_, str> {
+    fn read_str(&mut self) -> &str {
         let len = self.read_usize();
         let sentinel = self.data[self.position + len];
         assert!(sentinel == STR_SENTINEL);
@@ -671,7 +670,7 @@ impl<'a> serialize::Decoder for Decoder<'a> {
             std::str::from_utf8_unchecked(&self.data[self.position..self.position + len])
         };
         self.position += len + 1;
-        Cow::Borrowed(s)
+        s
     }
 
     #[inline]

--- a/compiler/rustc_serialize/src/opaque.rs
+++ b/compiler/rustc_serialize/src/opaque.rs
@@ -556,11 +556,6 @@ macro_rules! read_leb128 {
 
 impl<'a> serialize::Decoder for Decoder<'a> {
     #[inline]
-    fn read_unit(&mut self) -> () {
-        ()
-    }
-
-    #[inline]
     fn read_u128(&mut self) -> u128 {
         read_leb128!(self, read_u128_leb128)
     }

--- a/compiler/rustc_serialize/src/serialize.rs
+++ b/compiler/rustc_serialize/src/serialize.rs
@@ -198,7 +198,7 @@ pub trait Decoder {
     fn read_f64(&mut self) -> f64;
     fn read_f32(&mut self) -> f32;
     fn read_char(&mut self) -> char;
-    fn read_str(&mut self) -> Cow<'_, str>;
+    fn read_str(&mut self) -> &str;
     fn read_raw_bytes_into(&mut self, s: &mut [u8]);
 }
 
@@ -313,7 +313,7 @@ impl<S: Encoder> Encodable<S> for String {
 
 impl<D: Decoder> Decodable<D> for String {
     fn decode(d: &mut D) -> String {
-        d.read_str().into_owned()
+        d.read_str().to_owned()
     }
 }
 

--- a/compiler/rustc_serialize/src/serialize.rs
+++ b/compiler/rustc_serialize/src/serialize.rs
@@ -199,7 +199,7 @@ pub trait Decoder {
     fn read_f32(&mut self) -> f32;
     fn read_char(&mut self) -> char;
     fn read_str(&mut self) -> &str;
-    fn read_raw_bytes_into(&mut self, s: &mut [u8]);
+    fn read_raw_bytes(&mut self, len: usize) -> &[u8];
 }
 
 /// Trait for types that can be serialized

--- a/compiler/rustc_serialize/src/serialize.rs
+++ b/compiler/rustc_serialize/src/serialize.rs
@@ -181,7 +181,6 @@ pub trait Encoder {
 // concise.
 pub trait Decoder {
     // Primitive types:
-    fn read_unit(&mut self) -> ();
     fn read_usize(&mut self) -> usize;
     fn read_u128(&mut self) -> u128;
     fn read_u64(&mut self) -> u64;
@@ -324,9 +323,7 @@ impl<S: Encoder> Encodable<S> for () {
 }
 
 impl<D: Decoder> Decodable<D> for () {
-    fn decode(d: &mut D) -> () {
-        d.read_unit()
-    }
+    fn decode(_: &mut D) -> () {}
 }
 
 impl<S: Encoder, T> Encodable<S> for PhantomData<T> {
@@ -336,8 +333,7 @@ impl<S: Encoder, T> Encodable<S> for PhantomData<T> {
 }
 
 impl<D: Decoder, T> Decodable<D> for PhantomData<T> {
-    fn decode(d: &mut D) -> PhantomData<T> {
-        d.read_unit();
+    fn decode(_: &mut D) -> PhantomData<T> {
         PhantomData
     }
 }

--- a/compiler/rustc_target/src/spec/riscv32imc_esp_espidf.rs
+++ b/compiler/rustc_target/src/spec/riscv32imc_esp_espidf.rs
@@ -18,11 +18,11 @@ pub fn target() -> Target {
             cpu: "generic-rv32".to_string(),
 
             // While the RiscV32IMC architecture does not natively support atomics, ESP-IDF does support
-            // the __atomic* and __sync* GCC builtins, so setting `max_atomic_width` to `Some(32)`
+            // the __atomic* and __sync* GCC builtins, so setting `max_atomic_width` to `Some(64)`
             // and `atomic_cas` to `true` will cause the compiler to emit libcalls to these builtins.
             //
             // Support for atomics is necessary for the Rust STD library, which is supported by the ESP-IDF framework.
-            max_atomic_width: Some(32),
+            max_atomic_width: Some(64),
             atomic_cas: true,
 
             features: "+m,+c".to_string(),

--- a/library/core/src/array/iter.rs
+++ b/library/core/src/array/iter.rs
@@ -93,7 +93,7 @@ impl<T, const N: usize> IntoIter<T, N> {
     ///
     /// - The `buffer[initialized]` elements must all be initialized.
     /// - The range must be canonical, with `initialized.start <= initialized.end`.
-    /// - The range must in in-bounds for the buffer, with `initialized.end <= N`.
+    /// - The range must be in-bounds for the buffer, with `initialized.end <= N`.
     ///   (Like how indexing `[0][100..100]` fails despite the range being empty.)
     ///
     /// It's sound to have more elements initialized than mentioned, though that

--- a/library/core/src/ops/control_flow.rs
+++ b/library/core/src/ops/control_flow.rs
@@ -134,7 +134,6 @@ impl<B, C> ControlFlow<B, C> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(control_flow_enum)]
     /// use std::ops::ControlFlow;
     ///
     /// assert!(ControlFlow::<i32, String>::Break(3).is_break());
@@ -151,7 +150,6 @@ impl<B, C> ControlFlow<B, C> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(control_flow_enum)]
     /// use std::ops::ControlFlow;
     ///
     /// assert!(!ControlFlow::<i32, String>::Break(3).is_continue());

--- a/library/std/src/io/error.rs
+++ b/library/std/src/io/error.rs
@@ -144,13 +144,13 @@ struct Custom {
 ///
 /// # Handling errors and matching on `ErrorKind`
 ///
-/// In application code, use `match` for the `ErrorKind` values you are 
+/// In application code, use `match` for the `ErrorKind` values you are
 /// expecting; use `_` to match "all other errors".
 ///
-/// In comprehensive and thorough tests that want to verify that a test doesn't 
-/// return any known incorrect error kind, you may want to cut-and-paste the 
-/// current full list of errors from here into your test code, and then match 
-/// `_` as the correct case. This seems counterintuitive, but it will make your 
+/// In comprehensive and thorough tests that want to verify that a test doesn't
+/// return any known incorrect error kind, you may want to cut-and-paste the
+/// current full list of errors from here into your test code, and then match
+/// `_` as the correct case. This seems counterintuitive, but it will make your
 /// tests more robust. In particular, if you want to verify that your code does
 /// produce an unrecognized error kind, the robust solution is to check for all
 /// the recognized error kinds and fail in those cases.

--- a/library/std/src/io/error.rs
+++ b/library/std/src/io/error.rs
@@ -141,6 +141,14 @@ struct Custom {
 /// It is used with the [`io::Error`] type.
 ///
 /// [`io::Error`]: Error
+///
+/// # Handling errors and matching on `ErrorKind`
+///
+/// In application code, use `match` for the `ErrorKind` values you are expecting; use `_` to match
+/// "all other errors".
+///
+/// In comprehensive and thorough tests, you may need to cut-and-paste the current list of
+/// errors from here into your test code.
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 #[stable(feature = "rust1", since = "1.0.0")]
 #[allow(deprecated)]

--- a/library/std/src/io/error.rs
+++ b/library/std/src/io/error.rs
@@ -148,7 +148,7 @@ struct Custom {
 /// "all other errors".
 ///
 /// In comprehensive and thorough tests that want to verify that a test doesn't return any known incorrect error kind,
-/// you may want to cut-and-paste the current list of errors from here into your test code. This seems counterintuitive,
+/// you may want to cut-and-paste the current full list of errors from here into your test code, and then match `_` as the correct case. This seems counterintuitive,
 /// but it will make your tests more robust. In particular, if you want to verify that your code does produce an
 /// unrecognized error kind, the robust solution is to check for all the recognized error kinds and fail in those cases.
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]

--- a/library/std/src/io/error.rs
+++ b/library/std/src/io/error.rs
@@ -144,13 +144,16 @@ struct Custom {
 ///
 /// # Handling errors and matching on `ErrorKind`
 ///
-/// In application code, use `match` for the `ErrorKind` values you are expecting; use `_` to match
-/// "all other errors".
+/// In application code, use `match` for the `ErrorKind` values you are 
+/// expecting; use `_` to match "all other errors".
 ///
-/// In comprehensive and thorough tests that want to verify that a test doesn't return any known incorrect error kind,
-/// you may want to cut-and-paste the current full list of errors from here into your test code, and then match `_` as the correct case. This seems counterintuitive,
-/// but it will make your tests more robust. In particular, if you want to verify that your code does produce an
-/// unrecognized error kind, the robust solution is to check for all the recognized error kinds and fail in those cases.
+/// In comprehensive and thorough tests that want to verify that a test doesn't 
+/// return any known incorrect error kind, you may want to cut-and-paste the 
+/// current full list of errors from here into your test code, and then match 
+/// `_` as the correct case. This seems counterintuitive, but it will make your 
+/// tests more robust. In particular, if you want to verify that your code does
+/// produce an unrecognized error kind, the robust solution is to check for all
+/// the recognized error kinds and fail in those cases.
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 #[stable(feature = "rust1", since = "1.0.0")]
 #[allow(deprecated)]

--- a/library/std/src/io/error.rs
+++ b/library/std/src/io/error.rs
@@ -147,7 +147,7 @@ struct Custom {
 /// In application code, use `match` for the `ErrorKind` values you are expecting; use `_` to match
 /// "all other errors".
 ///
-/// In comprehensive and thorough tests that want to verify that a test doesn't return any known incorrect error kind, 
+/// In comprehensive and thorough tests that want to verify that a test doesn't return any known incorrect error kind,
 /// you may want to cut-and-paste the current list of errors from here into your test code. This seems counterintuitive,
 /// but it will make your tests more robust. In particular, if you want to verify that your code does produce an
 /// unrecognized error kind, the robust solution is to check for all the recognized error kinds and fail in those cases.

--- a/library/std/src/io/error.rs
+++ b/library/std/src/io/error.rs
@@ -147,8 +147,10 @@ struct Custom {
 /// In application code, use `match` for the `ErrorKind` values you are expecting; use `_` to match
 /// "all other errors".
 ///
-/// In comprehensive and thorough tests, you may need to cut-and-paste the current list of
-/// errors from here into your test code.
+/// In comprehensive and thorough tests that want to verify that a test doesn't return any known incorrect error kind, 
+/// you may want to cut-and-paste the current list of errors from here into your test code. This seems counterintuitive,
+/// but it will make your tests more robust. In particular, if you want to verify that your code does produce an
+/// unrecognized error kind, the robust solution is to check for all the recognized error kinds and fail in those cases.
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 #[stable(feature = "rust1", since = "1.0.0")]
 #[allow(deprecated)]

--- a/src/test/debuginfo/basic-types.rs
+++ b/src/test/debuginfo/basic-types.rs
@@ -104,7 +104,8 @@
 // cdb-check:b                : false [Type: bool]
 // cdb-command:dx i
 // cdb-check:i                : -1 [Type: [...]]
-// The variable 'c' doesn't appear for some reason...
+// cdb-command:dx c
+// cdb-check:c                : 0x61 'a' [Type: char32_t]
 // cdb-command:dx i8
 // cdb-check:i8               : 68 [Type: char]
 // cdb-command:dx i16

--- a/src/test/debuginfo/borrowed-basic.rs
+++ b/src/test/debuginfo/borrowed-basic.rs
@@ -14,8 +14,7 @@
 // gdb-check:$2 = -1
 
 // gdb-command:print *char_ref
-// gdbg-check:$3 = 97
-// gdbr-check:$3 = 97 'a'
+// gdb-check:$3 = 97
 
 // gdb-command:print *i8_ref
 // gdbg-check:$4 = 68 'D'

--- a/src/test/debuginfo/borrowed-unique-basic.rs
+++ b/src/test/debuginfo/borrowed-unique-basic.rs
@@ -16,8 +16,7 @@
 // gdb-check:$2 = -1
 
 // gdb-command:print *char_ref
-// gdbg-check:$3 = 97
-// gdbr-check:$3 = 97 'a'
+// gdb-check:$3 = 97
 
 // gdb-command:print/d *i8_ref
 // gdb-check:$4 = 68

--- a/src/test/ui/consts/const-eval/ub-ref-ptr.32bit.stderr
+++ b/src/test/ui/consts/const-eval/ub-ref-ptr.32bit.stderr
@@ -43,7 +43,7 @@ LL | const NULL_BOX: Box<u16> = unsafe { mem::transmute(0usize) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-ref-ptr.rs:30:1
+  --> $DIR/ub-ref-ptr.rs:31:1
    |
 LL | const REF_AS_USIZE: usize = unsafe { mem::transmute(&0) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc15, but expected initialized plain (non-pointer) bytes
@@ -54,7 +54,7 @@ LL | const REF_AS_USIZE: usize = unsafe { mem::transmute(&0) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-ref-ptr.rs:33:1
+  --> $DIR/ub-ref-ptr.rs:34:1
    |
 LL | const REF_AS_USIZE_SLICE: &[usize] = &[unsafe { mem::transmute(&0) }];
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .<deref>: encountered a pointer, but expected plain (non-pointer) bytes
@@ -65,7 +65,7 @@ LL | const REF_AS_USIZE_SLICE: &[usize] = &[unsafe { mem::transmute(&0) }];
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-ref-ptr.rs:36:1
+  --> $DIR/ub-ref-ptr.rs:37:1
    |
 LL | const REF_AS_USIZE_BOX_SLICE: Box<[usize]> = unsafe { mem::transmute::<&[usize], _>(&[mem::transmute(&0)]) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .<deref>: encountered a pointer, but expected plain (non-pointer) bytes
@@ -76,7 +76,7 @@ LL | const REF_AS_USIZE_BOX_SLICE: Box<[usize]> = unsafe { mem::transmute::<&[us
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-ref-ptr.rs:39:1
+  --> $DIR/ub-ref-ptr.rs:40:1
    |
 LL | const USIZE_AS_REF: &'static u8 = unsafe { mem::transmute(1337usize) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a dangling reference (address 0x539 is unallocated)
@@ -87,7 +87,7 @@ LL | const USIZE_AS_REF: &'static u8 = unsafe { mem::transmute(1337usize) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-ref-ptr.rs:42:1
+  --> $DIR/ub-ref-ptr.rs:43:1
    |
 LL | const USIZE_AS_BOX: Box<u8> = unsafe { mem::transmute(1337usize) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a dangling box (address 0x539 is unallocated)
@@ -98,7 +98,7 @@ LL | const USIZE_AS_BOX: Box<u8> = unsafe { mem::transmute(1337usize) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-ref-ptr.rs:45:1
+  --> $DIR/ub-ref-ptr.rs:46:1
    |
 LL | const UNINIT_PTR: *const i32 = unsafe { MaybeUninit { uninit: () }.init };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered uninitialized raw pointer
@@ -109,16 +109,49 @@ LL | const UNINIT_PTR: *const i32 = unsafe { MaybeUninit { uninit: () }.init };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-ref-ptr.rs:47:1
+  --> $DIR/ub-ref-ptr.rs:49:1
+   |
+LL | const NULL_FN_PTR: fn() = unsafe { mem::transmute(0usize) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a potentially null function pointer
+   |
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
+   = note: the raw bytes of the constant (size: 4, align: 4) {
+               00 00 00 00                                     │ ....
+           }
+
+error[E0080]: it is undefined behavior to use this value
+  --> $DIR/ub-ref-ptr.rs:51:1
    |
 LL | const UNINIT_FN_PTR: fn() = unsafe { MaybeUninit { uninit: () }.init };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered uninitialized bytes, but expected a function pointer
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered uninitialized bytes, but expected a proper pointer or integer value
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 4, align: 4) {
                __ __ __ __                                     │ ░░░░
            }
 
-error: aborting due to 11 previous errors
+error[E0080]: it is undefined behavior to use this value
+  --> $DIR/ub-ref-ptr.rs:53:1
+   |
+LL | const DANGLING_FN_PTR: fn() = unsafe { mem::transmute(13usize) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 0x0000000d, but expected a function pointer
+   |
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
+   = note: the raw bytes of the constant (size: 4, align: 4) {
+               0d 00 00 00                                     │ ....
+           }
+
+error[E0080]: it is undefined behavior to use this value
+  --> $DIR/ub-ref-ptr.rs:55:1
+   |
+LL | const DATA_FN_PTR: fn() = unsafe { mem::transmute(&13) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc41, but expected a function pointer
+   |
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
+   = note: the raw bytes of the constant (size: 4, align: 4) {
+               ╾─alloc41─╼                                     │ ╾──╼
+           }
+
+error: aborting due to 14 previous errors
 
 For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/const-eval/ub-ref-ptr.64bit.stderr
+++ b/src/test/ui/consts/const-eval/ub-ref-ptr.64bit.stderr
@@ -43,7 +43,7 @@ LL | const NULL_BOX: Box<u16> = unsafe { mem::transmute(0usize) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-ref-ptr.rs:30:1
+  --> $DIR/ub-ref-ptr.rs:31:1
    |
 LL | const REF_AS_USIZE: usize = unsafe { mem::transmute(&0) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc15, but expected initialized plain (non-pointer) bytes
@@ -54,7 +54,7 @@ LL | const REF_AS_USIZE: usize = unsafe { mem::transmute(&0) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-ref-ptr.rs:33:1
+  --> $DIR/ub-ref-ptr.rs:34:1
    |
 LL | const REF_AS_USIZE_SLICE: &[usize] = &[unsafe { mem::transmute(&0) }];
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .<deref>: encountered a pointer, but expected plain (non-pointer) bytes
@@ -65,7 +65,7 @@ LL | const REF_AS_USIZE_SLICE: &[usize] = &[unsafe { mem::transmute(&0) }];
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-ref-ptr.rs:36:1
+  --> $DIR/ub-ref-ptr.rs:37:1
    |
 LL | const REF_AS_USIZE_BOX_SLICE: Box<[usize]> = unsafe { mem::transmute::<&[usize], _>(&[mem::transmute(&0)]) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .<deref>: encountered a pointer, but expected plain (non-pointer) bytes
@@ -76,7 +76,7 @@ LL | const REF_AS_USIZE_BOX_SLICE: Box<[usize]> = unsafe { mem::transmute::<&[us
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-ref-ptr.rs:39:1
+  --> $DIR/ub-ref-ptr.rs:40:1
    |
 LL | const USIZE_AS_REF: &'static u8 = unsafe { mem::transmute(1337usize) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a dangling reference (address 0x539 is unallocated)
@@ -87,7 +87,7 @@ LL | const USIZE_AS_REF: &'static u8 = unsafe { mem::transmute(1337usize) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-ref-ptr.rs:42:1
+  --> $DIR/ub-ref-ptr.rs:43:1
    |
 LL | const USIZE_AS_BOX: Box<u8> = unsafe { mem::transmute(1337usize) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a dangling box (address 0x539 is unallocated)
@@ -98,7 +98,7 @@ LL | const USIZE_AS_BOX: Box<u8> = unsafe { mem::transmute(1337usize) };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-ref-ptr.rs:45:1
+  --> $DIR/ub-ref-ptr.rs:46:1
    |
 LL | const UNINIT_PTR: *const i32 = unsafe { MaybeUninit { uninit: () }.init };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered uninitialized raw pointer
@@ -109,16 +109,49 @@ LL | const UNINIT_PTR: *const i32 = unsafe { MaybeUninit { uninit: () }.init };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-ref-ptr.rs:47:1
+  --> $DIR/ub-ref-ptr.rs:49:1
+   |
+LL | const NULL_FN_PTR: fn() = unsafe { mem::transmute(0usize) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a potentially null function pointer
+   |
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
+   = note: the raw bytes of the constant (size: 8, align: 8) {
+               00 00 00 00 00 00 00 00                         │ ........
+           }
+
+error[E0080]: it is undefined behavior to use this value
+  --> $DIR/ub-ref-ptr.rs:51:1
    |
 LL | const UNINIT_FN_PTR: fn() = unsafe { MaybeUninit { uninit: () }.init };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered uninitialized bytes, but expected a function pointer
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered uninitialized bytes, but expected a proper pointer or integer value
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 8, align: 8) {
                __ __ __ __ __ __ __ __                         │ ░░░░░░░░
            }
 
-error: aborting due to 11 previous errors
+error[E0080]: it is undefined behavior to use this value
+  --> $DIR/ub-ref-ptr.rs:53:1
+   |
+LL | const DANGLING_FN_PTR: fn() = unsafe { mem::transmute(13usize) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 0x000000000000000d, but expected a function pointer
+   |
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
+   = note: the raw bytes of the constant (size: 8, align: 8) {
+               0d 00 00 00 00 00 00 00                         │ ........
+           }
+
+error[E0080]: it is undefined behavior to use this value
+  --> $DIR/ub-ref-ptr.rs:55:1
+   |
+LL | const DATA_FN_PTR: fn() = unsafe { mem::transmute(&13) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc41, but expected a function pointer
+   |
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
+   = note: the raw bytes of the constant (size: 8, align: 8) {
+               ╾───────alloc41───────╼                         │ ╾──────╼
+           }
+
+error: aborting due to 14 previous errors
 
 For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/const-eval/ub-ref-ptr.rs
+++ b/src/test/ui/consts/const-eval/ub-ref-ptr.rs
@@ -24,6 +24,7 @@ const NULL: &u16 = unsafe { mem::transmute(0usize) };
 const NULL_BOX: Box<u16> = unsafe { mem::transmute(0usize) };
 //~^ ERROR it is undefined behavior to use this value
 
+
 // It is very important that we reject this: We do promote `&(4 * REF_AS_USIZE)`,
 // but that would fail to compile; so we ended up breaking user code that would
 // have worked fine had we not promoted.
@@ -44,7 +45,14 @@ const USIZE_AS_BOX: Box<u8> = unsafe { mem::transmute(1337usize) };
 
 const UNINIT_PTR: *const i32 = unsafe { MaybeUninit { uninit: () }.init };
 //~^ ERROR it is undefined behavior to use this value
+
+const NULL_FN_PTR: fn() = unsafe { mem::transmute(0usize) };
+//~^ ERROR it is undefined behavior to use this value
 const UNINIT_FN_PTR: fn() = unsafe { MaybeUninit { uninit: () }.init };
+//~^ ERROR it is undefined behavior to use this value
+const DANGLING_FN_PTR: fn() = unsafe { mem::transmute(13usize) };
+//~^ ERROR it is undefined behavior to use this value
+const DATA_FN_PTR: fn() = unsafe { mem::transmute(&13) };
 //~^ ERROR it is undefined behavior to use this value
 
 fn main() {}


### PR DESCRIPTION
Successful merges:

 - #89887 (Change `char` type in debuginfo to DW_ATE_UTF)
 - #94267 (Remove unused ordering derivations and bounds for `SimplifiedTypeGen`)
 - #94270 (Miri: relax fn ptr check)
 - #94273 (add matching doc to errorkind)
 - #94283 (remove feature gate in control_flow examples)
 - #94288 (Cleanup a few Decoder methods)
 - #94292 (riscv32imc_esp_espidf: set max_atomic_width to 64)
 - #94296 (:arrow_up: rust-analyzer)
 - #94300 (Fix a typo in documentation of `array::IntoIter::new_unchecked`)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=89887,94267,94270,94273,94283,94288,94292,94296,94300)
<!-- homu-ignore:end -->