### PR TITLE
Remove a duplicate space

### DIFF
--- a/compiler/rustc_typeck/src/check/fn_ctxt/suggestions.rs
+++ b/compiler/rustc_typeck/src/check/fn_ctxt/suggestions.rs
@@ -637,7 +637,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             })
             .collect::<Result<Vec<_>, _>>();
 
-        let Ok(where_predicates) =  where_predicates else { return };
+        let Ok(where_predicates) = where_predicates else { return };
 
         // now get all predicates in the same types as the where bounds, so we can chain them
         let predicates_from_where =


### PR DESCRIPTION
rustfmt doesn't format `let ... else`.