### PR TITLE
Fix SGX docs build

### DIFF
--- a/library/std/src/os/fd/owned.rs
+++ b/library/std/src/os/fd/owned.rs
@@ -8,7 +8,7 @@ use crate::fmt;
 use crate::fs;
 use crate::marker::PhantomData;
 use crate::mem::forget;
-#[cfg(not(target_os = "wasi"))]
+#[cfg(not(any(target_os = "wasi", target_env = "sgx")))]
 use crate::sys::cvt;
 use crate::sys_common::{AsInner, FromInner, IntoInner};
 


### PR DESCRIPTION
Without this, I get
```
error[E0432]: unresolved import `crate::sys::cvt`
  --> library/std/src/os/fd/owned.rs:12:5
   |
12 | use crate::sys::cvt;
   |     ^^^^^^^^^^^^^^^ no `cvt` in `sys`
```
when running rustdoc on `std` for the x86_64-fortanix-unknown-sgx target.