### PR TITLE
Fix debug_assert in unused lint pass

### DIFF
--- a/compiler/rustc_lint/src/unused.rs
+++ b/compiler/rustc_lint/src/unused.rs
@@ -240,17 +240,17 @@ impl<'tcx> LateLintPass<'tcx> for UnusedResults {
                 }
                 ty::Tuple(ref tys) => {
                     let mut has_emitted = false;
-                    let spans = if let hir::ExprKind::Tup(comps) = &expr.kind {
+                    let comps = if let hir::ExprKind::Tup(comps) = expr.kind {
                         debug_assert_eq!(comps.len(), tys.len());
-                        comps.iter().map(|e| e.span).collect()
+                        comps
                     } else {
-                        vec![]
+                        &[]
                     };
                     for (i, ty) in tys.iter().enumerate() {
                         let descr_post = &format!(" in tuple element {}", i);
-                        let span = *spans.get(i).unwrap_or(&span);
-                        if check_must_use_ty(cx, ty, expr, span, descr_pre, descr_post, plural_len)
-                        {
+                        let e = comps.get(i).unwrap_or(expr);
+                        let span = e.span;
+                        if check_must_use_ty(cx, ty, e, span, descr_pre, descr_post, plural_len) {
                             has_emitted = true;
                         }
                     }

--- a/src/test/ui/lint/unused/must_use-array.stderr
+++ b/src/test/ui/lint/unused/must_use-array.stderr
@@ -32,7 +32,7 @@ error: unused array of boxed `T` trait objects in tuple element 1 that must be u
   --> $DIR/must_use-array.rs:43:5
    |
 LL |     impl_array();
-   |     ^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^
 
 error: unused array of arrays of arrays of `S` that must be used
   --> $DIR/must_use-array.rs:45:5

--- a/src/test/ui/lint/unused/must_use-trait.stderr
+++ b/src/test/ui/lint/unused/must_use-trait.stderr
@@ -26,13 +26,13 @@ error: unused boxed `Critical` trait object in tuple element 1 that must be used
   --> $DIR/must_use-trait.rs:37:5
    |
 LL |     get_critical_tuple();
-   |     ^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^
 
 error: unused implementer of `Critical` in tuple element 2 that must be used
   --> $DIR/must_use-trait.rs:37:5
    |
 LL |     get_critical_tuple();
-   |     ^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/lint/unused/must_use-tuple.stderr
+++ b/src/test/ui/lint/unused/must_use-tuple.stderr
@@ -31,15 +31,15 @@ error: unused `Result` in tuple element 0 that must be used
   --> $DIR/must_use-tuple.rs:14:5
    |
 LL |     foo();
-   |     ^^^^^^
+   |     ^^^^^
    |
    = note: this `Result` may be an `Err` variant, which should be handled
 
 error: unused `Result` in tuple element 0 that must be used
-  --> $DIR/must_use-tuple.rs:16:6
+  --> $DIR/must_use-tuple.rs:16:7
    |
 LL |     ((Err::<(), ()>(()), ()), ());
-   |      ^^^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^^^^^^^^
    |
    = note: this `Result` may be an `Err` variant, which should be handled
 


### PR DESCRIPTION
This fixes a debug assertion in the unused lint pass. As a side effect, this also improves the span generated for tuples in the `unused_must_use` lint.

found in #94329

A reproducer for this would be 

```rust
fn main() { (1, (3,)); }
```

Not sure, if I should add a regression test for a `debug_assert`.