### PR TITLE
Fix show error message when literal overflows in match patterns

### DIFF
--- a/src/test/ui/error-codes/E0081.rs
+++ b/src/test/ui/error-codes/E0081.rs
@@ -10,10 +10,10 @@ enum Enum {
 #[repr(u8)]
 enum EnumOverflowRepr {
     P = 257,
-    //~^ NOTE first use of `1` (overflowed from `257`)
+    //~^ NOTE first use of `255` (overflowed from `257`)
     X = 513,
-    //~^ ERROR discriminant value `1` already exists
-    //~| NOTE enum already has `1` (overflowed from `513`)
+    //~^ ERROR discriminant value `255` already exists
+    //~| NOTE enum already has `255` (overflowed from `513`)
 }
 
 fn main() {

--- a/src/test/ui/error-codes/E0081.stderr
+++ b/src/test/ui/error-codes/E0081.stderr
@@ -7,14 +7,14 @@ LL |
 LL |     X = 3,
    |         ^ enum already has `3`
 
-error[E0081]: discriminant value `1` already exists
+error[E0081]: discriminant value `255` already exists
   --> $DIR/E0081.rs:14:9
    |
 LL |     P = 257,
-   |         --- first use of `1` (overflowed from `257`)
+   |         --- first use of `255` (overflowed from `257`)
 LL |
 LL |     X = 513,
-   |         ^^^ enum already has `1` (overflowed from `513`)
+   |         ^^^ enum already has `255` (overflowed from `513`)
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-94239.rs
+++ b/src/test/ui/issues/issue-94239.rs
@@ -1,0 +1,8 @@
+pub const fn test_match_range(len: usize) -> usize {
+    match len {
+        10000000000000000000..=99999999999999999999 => 0, //~ ERROR literal out of range for `usize`
+        _ => unreachable!(),
+    }
+}
+
+fn main() {}

--- a/src/test/ui/issues/issue-94239.rs
+++ b/src/test/ui/issues/issue-94239.rs
@@ -1,6 +1,6 @@
-pub const fn test_match_range(len: usize) -> usize {
+pub const fn test_match_range(len: u64) -> u64 {
     match len {
-        10000000000000000000..=99999999999999999999 => 0, //~ ERROR literal out of range for `usize`
+        10000000000000000000..=99999999999999999999 => 0, //~ ERROR literal out of range for `u64`
         _ => unreachable!(),
     }
 }

--- a/src/test/ui/issues/issue-94239.stderr
+++ b/src/test/ui/issues/issue-94239.stderr
@@ -1,0 +1,11 @@
+error: literal out of range for `usize`
+  --> $DIR/issue-94239.rs:3:32
+   |
+LL |         10000000000000000000..=99999999999999999999 => 0,
+   |                                ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `#[deny(overflowing_literals)]` on by default
+   = note: the literal `99999999999999999999` does not fit into the type `usize` whose range is `0..=18446744073709551615`
+
+error: aborting due to previous error
+

--- a/src/test/ui/issues/issue-94239.stderr
+++ b/src/test/ui/issues/issue-94239.stderr
@@ -1,11 +1,11 @@
-error: literal out of range for `usize`
+error: literal out of range for `u64`
   --> $DIR/issue-94239.rs:3:32
    |
 LL |         10000000000000000000..=99999999999999999999 => 0,
    |                                ^^^^^^^^^^^^^^^^^^^^
    |
    = note: `#[deny(overflowing_literals)]` on by default
-   = note: the literal `99999999999999999999` does not fit into the type `usize` whose range is `0..=18446744073709551615`
+   = note: the literal `99999999999999999999` does not fit into the type `u64` whose range is `0..=18446744073709551615`
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Fix #94239 
This changes overflow behavior in [fn lit_to_const](https://github.com/rust-lang/rust/blob/master/compiler/rustc_mir_build/src/thir/constant.rs#L10)