### PR TITLE
Rename unix::net::SocketAddr::from_path to from_pathname and stabilize it

### DIFF
--- a/library/std/src/os/unix/net/addr.rs
+++ b/library/std/src/os/unix/net/addr.rs
@@ -145,7 +145,7 @@ impl SocketAddr {
     /// use std::path::Path;
     ///
     /// # fn main() -> std::io::Result<()> {
-    /// let address = SocketAddr::from_path("/path/to/socket")?;
+    /// let address = SocketAddr::from_pathname("/path/to/socket")?;
     /// assert_eq!(address.as_pathname(), Some(Path::new("/path/to/socket")));
     /// # Ok(())
     /// # }
@@ -157,10 +157,10 @@ impl SocketAddr {
     /// #![feature(unix_socket_creation)]
     /// use std::os::unix::net::SocketAddr;
     ///
-    /// assert!(SocketAddr::from_path("/path/with/\0/bytes").is_err());
+    /// assert!(SocketAddr::from_pathname("/path/with/\0/bytes").is_err());
     /// ```
     #[unstable(feature = "unix_socket_creation", issue = "93423")]
-    pub fn from_path<P>(path: P) -> io::Result<SocketAddr>
+    pub fn from_pathname<P>(path: P) -> io::Result<SocketAddr>
     where
         P: AsRef<Path>,
     {

--- a/library/std/src/os/unix/net/addr.rs
+++ b/library/std/src/os/unix/net/addr.rs
@@ -140,7 +140,6 @@ impl SocketAddr {
     /// # Examples
     ///
     /// ```
-    /// #![feature(unix_socket_creation)]
     /// use std::os::unix::net::SocketAddr;
     /// use std::path::Path;
     ///
@@ -154,12 +153,11 @@ impl SocketAddr {
     /// Creating a `SocketAddr` with a NULL byte results in an error.
     ///
     /// ```
-    /// #![feature(unix_socket_creation)]
     /// use std::os::unix::net::SocketAddr;
     ///
     /// assert!(SocketAddr::from_pathname("/path/with/\0/bytes").is_err());
     /// ```
-    #[unstable(feature = "unix_socket_creation", issue = "93423")]
+    #[stable(feature = "unix_socket_creation", since = "1.61.0")]
     pub fn from_pathname<P>(path: P) -> io::Result<SocketAddr>
     where
         P: AsRef<Path>,


### PR DESCRIPTION
Stabilizes `unix_socket_creation`.

Closes https://github.com/rust-lang/rust/issues/93423
r? @m-ou-se 