### PR TITLE
Fix MinGW target detection in raw-dylib

### DIFF
--- a/compiler/rustc_codegen_llvm/src/back/archive.rs
+++ b/compiler/rustc_codegen_llvm/src/back/archive.rs
@@ -151,7 +151,9 @@ impl<'a> ArchiveBuilder<'a> for LlvmArchiveBuilder<'a> {
             output_path.with_extension("lib")
         };
 
-        let mingw_gnu_toolchain = self.config.sess.target.llvm_target.ends_with("pc-windows-gnu");
+        let target = &self.config.sess.target;
+        let mingw_gnu_toolchain =
+            target.vendor == "pc" && target.os == "windows" && target.env == "gnu";
 
         let import_name_and_ordinal_vector: Vec<(String, Option<u16>)> = dll_imports
             .iter()


### PR DESCRIPTION
LLVM target doesn't have to be the same as Rust target so relying on it is wrong.

It was one of concerns in https://github.com/rust-lang/rust/pull/88801 that was not fixed in https://github.com/rust-lang/rust/pull/90782.