### PR TITLE
Add #[inline] to trivial AsRef/AsMut impls

### DIFF
--- a/library/core/src/convert/mod.rs
+++ b/library/core/src/convert/mod.rs
@@ -486,6 +486,7 @@ impl<T: ?Sized, U: ?Sized> const AsRef<U> for &T
 where
     T: ~const AsRef<U>,
 {
+    #[inline]
     fn as_ref(&self) -> &U {
         <T as AsRef<U>>::as_ref(*self)
     }
@@ -498,6 +499,7 @@ impl<T: ?Sized, U: ?Sized> const AsRef<U> for &mut T
 where
     T: ~const AsRef<U>,
 {
+    #[inline]
     fn as_ref(&self) -> &U {
         <T as AsRef<U>>::as_ref(*self)
     }
@@ -518,6 +520,7 @@ impl<T: ?Sized, U: ?Sized> const AsMut<U> for &mut T
 where
     T: ~const AsMut<U>,
 {
+    #[inline]
     fn as_mut(&mut self) -> &mut U {
         (*self).as_mut()
     }


### PR DESCRIPTION
These appeared uninlined in some perf runs, but they're trivial.

r? @ghost