### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/compiler/rustc_borrowck/src/nll.rs
+++ b/compiler/rustc_borrowck/src/nll.rs
@@ -189,6 +189,7 @@ pub(crate) fn compute_regions<'cx, 'tcx>(
             move_data,
             elements,
             upvars,
+            use_polonius,
         );
 
     if let Some(all_facts) = &mut all_facts {

--- a/compiler/rustc_borrowck/src/type_check/liveness/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/liveness/mod.rs
@@ -37,6 +37,7 @@ pub(super) fn generate<'mir, 'tcx>(
     flow_inits: &mut ResultsCursor<'mir, 'tcx, MaybeInitializedPlaces<'mir, 'tcx>>,
     move_data: &MoveData<'tcx>,
     location_table: &LocationTable,
+    use_polonius: bool,
 ) {
     debug!("liveness::generate");
 
@@ -46,7 +47,7 @@ pub(super) fn generate<'mir, 'tcx>(
         &typeck.borrowck_context.constraints.outlives_constraints,
     );
     let live_locals = compute_live_locals(typeck.tcx(), &free_regions, &body);
-    let facts_enabled = AllFacts::enabled(typeck.tcx());
+    let facts_enabled = use_polonius || AllFacts::enabled(typeck.tcx());
 
     let polonius_drop_used = if facts_enabled {
         let mut drop_used = Vec::new();

--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -136,6 +136,7 @@ pub(crate) fn type_check<'mir, 'tcx>(
     move_data: &MoveData<'tcx>,
     elements: &Rc<RegionValueElements>,
     upvars: &[Upvar<'tcx>],
+    use_polonius: bool,
 ) -> MirTypeckResults<'tcx> {
     let implicit_region_bound = infcx.tcx.mk_region(ty::ReVar(universal_regions.fr_fn_body));
     let mut universe_causes = FxHashMap::default();
@@ -187,7 +188,15 @@ pub(crate) fn type_check<'mir, 'tcx>(
         &mut borrowck_context,
         |mut cx| {
             cx.equate_inputs_and_outputs(&body, universal_regions, &normalized_inputs_and_output);
-            liveness::generate(&mut cx, body, elements, flow_inits, move_data, location_table);
+            liveness::generate(
+                &mut cx,
+                body,
+                elements,
+                flow_inits,
+                move_data,
+                location_table,
+                use_polonius,
+            );
 
             translate_outlives_facts(&mut cx);
             let opaque_type_values = mem::take(&mut infcx.inner.borrow_mut().opaque_types);

--- a/compiler/rustc_expand/src/expand.rs
+++ b/compiler/rustc_expand/src/expand.rs
@@ -21,7 +21,7 @@ use rustc_data_structures::sync::Lrc;
 use rustc_errors::{Applicability, PResult};
 use rustc_feature::Features;
 use rustc_parse::parser::{
-    AttemptLocalParseRecovery, ForceCollect, Parser, RecoverColon, RecoverComma,
+    AttemptLocalParseRecovery, CommaRecoveryMode, ForceCollect, Parser, RecoverColon, RecoverComma,
 };
 use rustc_parse::validate_attr;
 use rustc_session::lint::builtin::{UNUSED_ATTRIBUTES, UNUSED_DOC_COMMENTS};
@@ -914,6 +914,7 @@ pub fn parse_ast_fragment<'a>(
             None,
             RecoverComma::No,
             RecoverColon::Yes,
+            CommaRecoveryMode::LikelyTuple,
         )?),
         AstFragmentKind::Crate => AstFragment::Crate(this.parse_crate_mod()?),
         AstFragmentKind::Arms

--- a/compiler/rustc_mir_dataflow/src/impls/mod.rs
+++ b/compiler/rustc_mir_dataflow/src/impls/mod.rs
@@ -710,24 +710,27 @@ fn switch_on_enum_discriminant<'mir, 'tcx>(
     block: &'mir mir::BasicBlockData<'tcx>,
     switch_on: mir::Place<'tcx>,
 ) -> Option<(mir::Place<'tcx>, &'tcx ty::AdtDef)> {
-    match block.statements.last().map(|stmt| &stmt.kind) {
-        Some(mir::StatementKind::Assign(box (lhs, mir::Rvalue::Discriminant(discriminated))))
-            if *lhs == switch_on =>
-        {
-            match &discriminated.ty(body, tcx).ty.kind() {
-                ty::Adt(def, _) => Some((*discriminated, def)),
+    for statement in block.statements.iter().rev() {
+        match &statement.kind {
+            mir::StatementKind::Assign(box (lhs, mir::Rvalue::Discriminant(discriminated)))
+                if *lhs == switch_on =>
+            {
+                match &discriminated.ty(body, tcx).ty.kind() {
+                    ty::Adt(def, _) => return Some((*discriminated, def)),
 
-                // `Rvalue::Discriminant` is also used to get the active yield point for a
-                // generator, but we do not need edge-specific effects in that case. This may
-                // change in the future.
-                ty::Generator(..) => None,
+                    // `Rvalue::Discriminant` is also used to get the active yield point for a
+                    // generator, but we do not need edge-specific effects in that case. This may
+                    // change in the future.
+                    ty::Generator(..) => return None,
 
-                t => bug!("`discriminant` called on unexpected type {:?}", t),
+                    t => bug!("`discriminant` called on unexpected type {:?}", t),
+                }
             }
+            mir::StatementKind::Coverage(_) => continue,
+            _ => return None,
         }
-
-        _ => None,
     }
+    None
 }
 
 struct OnMutBorrow<F>(F);

--- a/compiler/rustc_parse/src/lib.rs
+++ b/compiler/rustc_parse/src/lib.rs
@@ -3,6 +3,7 @@
 #![feature(array_windows)]
 #![feature(crate_visibility_modifier)]
 #![feature(if_let_guard)]
+#![feature(let_else)]
 #![feature(box_patterns)]
 #![recursion_limit = "256"]
 

--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -1,8 +1,8 @@
 use super::pat::Expected;
 use super::ty::AllowPlus;
 use super::{
-    BlockMode, Parser, PathStyle, RecoverColon, RecoverComma, Restrictions, SemiColonMode, SeqSep,
-    TokenExpectType, TokenType,
+    BlockMode, CommaRecoveryMode, Parser, PathStyle, RecoverColon, RecoverComma, Restrictions,
+    SemiColonMode, SeqSep, TokenExpectType, TokenType,
 };
 
 use rustc_ast as ast;
@@ -2200,12 +2200,32 @@ impl<'a> Parser<'a> {
         first_pat
     }
 
+    crate fn maybe_recover_unexpected_block_label(&mut self) -> bool {
+        let Some(label) = self.eat_label().filter(|_| {
+            self.eat(&token::Colon) && self.token.kind == token::OpenDelim(token::Brace)
+        }) else {
+            return false;
+        };
+        let span = label.ident.span.to(self.prev_token.span);
+        let mut err = self.struct_span_err(span, "block label not supported here");
+        err.span_label(span, "not supported here");
+        err.tool_only_span_suggestion(
+            label.ident.span.until(self.token.span),
+            "remove this block label",
+            String::new(),
+            Applicability::MachineApplicable,
+        );
+        err.emit();
+        true
+    }
+
     /// Some special error handling for the "top-level" patterns in a match arm,
     /// `for` loop, `let`, &c. (in contrast to subpatterns within such).
     crate fn maybe_recover_unexpected_comma(
         &mut self,
         lo: Span,
         rc: RecoverComma,
+        rt: CommaRecoveryMode,
     ) -> PResult<'a, ()> {
         if rc == RecoverComma::No || self.token != token::Comma {
             return Ok(());
@@ -2225,20 +2245,25 @@ impl<'a> Parser<'a> {
         let seq_span = lo.to(self.prev_token.span);
         let mut err = self.struct_span_err(comma_span, "unexpected `,` in pattern");
         if let Ok(seq_snippet) = self.span_to_snippet(seq_span) {
-            const MSG: &str = "try adding parentheses to match on a tuple...";
-
-            err.span_suggestion(
-                seq_span,
-                MSG,
-                format!("({})", seq_snippet),
+            err.multipart_suggestion(
+                &format!(
+                    "try adding parentheses to match on a tuple{}",
+                    if let CommaRecoveryMode::LikelyTuple = rt { "" } else { "..." },
+                ),
+                vec![
+                    (seq_span.shrink_to_lo(), "(".to_string()),
+                    (seq_span.shrink_to_hi(), ")".to_string()),
+                ],
                 Applicability::MachineApplicable,
             );
-            err.span_suggestion(
-                seq_span,
-                "...or a vertical bar to match on multiple alternatives",
-                seq_snippet.replace(',', " |"),
-                Applicability::MachineApplicable,
-            );
+            if let CommaRecoveryMode::EitherTupleOrPipe = rt {
+                err.span_suggestion(
+                    seq_span,
+                    "...or a vertical bar to match on multiple alternatives",
+                    seq_snippet.replace(',', " |"),
+                    Applicability::MachineApplicable,
+                );
+            }
         }
         Err(err)
     }

--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -1,4 +1,4 @@
-use super::pat::{RecoverColon, RecoverComma, PARAM_EXPECTED};
+use super::pat::{CommaRecoveryMode, RecoverColon, RecoverComma, PARAM_EXPECTED};
 use super::ty::{AllowPlus, RecoverQPath, RecoverReturnSign};
 use super::{
     AttrWrapper, BlockMode, ClosureSpans, ForceCollect, Parser, PathStyle, Restrictions, TokenType,
@@ -1269,18 +1269,27 @@ impl<'a> Parser<'a> {
         } else if let Some(label) = self.eat_label() {
             self.parse_labeled_expr(label, attrs, true)
         } else if self.eat_keyword(kw::Loop) {
-            self.parse_loop_expr(None, self.prev_token.span, attrs)
+            let sp = self.prev_token.span;
+            self.parse_loop_expr(None, self.prev_token.span, attrs).map_err(|mut err| {
+                err.span_label(sp, "while parsing this `loop` expression");
+                err
+            })
         } else if self.eat_keyword(kw::Continue) {
             let kind = ExprKind::Continue(self.eat_label());
             Ok(self.mk_expr(lo.to(self.prev_token.span), kind, attrs))
         } else if self.eat_keyword(kw::Match) {
             let match_sp = self.prev_token.span;
             self.parse_match_expr(attrs).map_err(|mut err| {
-                err.span_label(match_sp, "while parsing this match expression");
+                err.span_label(match_sp, "while parsing this `match` expression");
                 err
             })
         } else if self.eat_keyword(kw::Unsafe) {
+            let sp = self.prev_token.span;
             self.parse_block_expr(None, lo, BlockCheckMode::Unsafe(ast::UserProvided), attrs)
+                .map_err(|mut err| {
+                    err.span_label(sp, "while parsing this `unsafe` expression");
+                    err
+                })
         } else if self.check_inline_const(0) {
             self.parse_const_block(lo.to(self.token.span), false)
         } else if self.is_do_catch_block() {
@@ -2110,7 +2119,12 @@ impl<'a> Parser<'a> {
     /// The `let` token has already been eaten.
     fn parse_let_expr(&mut self, attrs: AttrVec) -> PResult<'a, P<Expr>> {
         let lo = self.prev_token.span;
-        let pat = self.parse_pat_allow_top_alt(None, RecoverComma::Yes, RecoverColon::Yes)?;
+        let pat = self.parse_pat_allow_top_alt(
+            None,
+            RecoverComma::Yes,
+            RecoverColon::Yes,
+            CommaRecoveryMode::LikelyTuple,
+        )?;
         self.expect(&token::Eq)?;
         let expr = self.with_res(self.restrictions | Restrictions::NO_STRUCT_LITERAL, |this| {
             this.parse_assoc_expr_with(1 + prec_let_scrutinee_needs_par(), None.into())
@@ -2173,7 +2187,12 @@ impl<'a> Parser<'a> {
             _ => None,
         };
 
-        let pat = self.parse_pat_allow_top_alt(None, RecoverComma::Yes, RecoverColon::Yes)?;
+        let pat = self.parse_pat_allow_top_alt(
+            None,
+            RecoverComma::Yes,
+            RecoverColon::Yes,
+            CommaRecoveryMode::LikelyTuple,
+        )?;
         if !self.eat_keyword(kw::In) {
             self.error_missing_in_for_loop();
         }
@@ -2216,8 +2235,15 @@ impl<'a> Parser<'a> {
         lo: Span,
         mut attrs: AttrVec,
     ) -> PResult<'a, P<Expr>> {
-        let cond = self.parse_cond_expr()?;
-        let (iattrs, body) = self.parse_inner_attrs_and_block()?;
+        let cond = self.parse_cond_expr().map_err(|mut err| {
+            err.span_label(lo, "while parsing the condition of this `while` expression");
+            err
+        })?;
+        let (iattrs, body) = self.parse_inner_attrs_and_block().map_err(|mut err| {
+            err.span_label(lo, "while parsing the body of this `while` expression");
+            err.span_label(cond.span, "this `while` condition successfully parsed");
+            err
+        })?;
         attrs.extend(iattrs);
         Ok(self.mk_expr(lo.to(self.prev_token.span), ExprKind::While(cond, body, opt_label), attrs))
     }
@@ -2234,7 +2260,7 @@ impl<'a> Parser<'a> {
         Ok(self.mk_expr(lo.to(self.prev_token.span), ExprKind::Loop(body, opt_label), attrs))
     }
 
-    fn eat_label(&mut self) -> Option<Label> {
+    crate fn eat_label(&mut self) -> Option<Label> {
         self.token.lifetime().map(|ident| {
             self.bump();
             Label { ident }
@@ -2255,7 +2281,12 @@ impl<'a> Parser<'a> {
                     Applicability::MaybeIncorrect, // speculative
                 );
             }
-            return Err(e);
+            if self.maybe_recover_unexpected_block_label() {
+                e.cancel();
+                self.bump();
+            } else {
+                return Err(e);
+            }
         }
         attrs.extend(self.parse_inner_attributes()?);
 
@@ -2380,7 +2411,12 @@ impl<'a> Parser<'a> {
         let attrs = self.parse_outer_attributes()?;
         self.collect_tokens_trailing_token(attrs, ForceCollect::No, |this, attrs| {
             let lo = this.token.span;
-            let pat = this.parse_pat_allow_top_alt(None, RecoverComma::Yes, RecoverColon::Yes)?;
+            let pat = this.parse_pat_allow_top_alt(
+                None,
+                RecoverComma::Yes,
+                RecoverColon::Yes,
+                CommaRecoveryMode::EitherTupleOrPipe,
+            )?;
             let guard = if this.eat_keyword(kw::If) {
                 let if_span = this.prev_token.span;
                 let cond = this.parse_expr()?;

--- a/compiler/rustc_parse/src/parser/mod.rs
+++ b/compiler/rustc_parse/src/parser/mod.rs
@@ -15,7 +15,7 @@ pub use attr_wrapper::AttrWrapper;
 pub use diagnostics::AttemptLocalParseRecovery;
 use diagnostics::Error;
 pub(crate) use item::FnParseMode;
-pub use pat::{RecoverColon, RecoverComma};
+pub use pat::{CommaRecoveryMode, RecoverColon, RecoverComma};
 pub use path::PathStyle;
 
 use rustc_ast::ptr::P;

--- a/compiler/rustc_parse/src/parser/nonterminal.rs
+++ b/compiler/rustc_parse/src/parser/nonterminal.rs
@@ -5,7 +5,7 @@ use rustc_ast_pretty::pprust;
 use rustc_errors::PResult;
 use rustc_span::symbol::{kw, Ident};
 
-use crate::parser::pat::{RecoverColon, RecoverComma};
+use crate::parser::pat::{CommaRecoveryMode, RecoverColon, RecoverComma};
 use crate::parser::{FollowedByType, ForceCollect, Parser, PathStyle};
 
 impl<'a> Parser<'a> {
@@ -125,7 +125,7 @@ impl<'a> Parser<'a> {
                 token::NtPat(self.collect_tokens_no_attrs(|this| match kind {
                     NonterminalKind::PatParam { .. } => this.parse_pat_no_top_alt(None),
                     NonterminalKind::PatWithOr { .. } => {
-                        this.parse_pat_allow_top_alt(None, RecoverComma::No, RecoverColon::No)
+                        this.parse_pat_allow_top_alt(None, RecoverComma::No, RecoverColon::No, CommaRecoveryMode::EitherTupleOrPipe)
                     }
                     _ => unreachable!(),
                 })?)

--- a/compiler/rustc_parse/src/parser/stmt.rs
+++ b/compiler/rustc_parse/src/parser/stmt.rs
@@ -421,6 +421,8 @@ impl<'a> Parser<'a> {
             Ok(Some(_))
                 if self.look_ahead(1, |t| t == &token::OpenDelim(token::Brace))
                     || do_not_suggest_help => {}
+            // Do not suggest `if foo println!("") {;}` (as would be seen in test for #46836).
+            Ok(Some(Stmt { kind: StmtKind::Empty, .. })) => {}
             Ok(Some(stmt)) => {
                 let stmt_own_line = self.sess.source_map().is_line_before_span_empty(sp);
                 let stmt_span = if stmt_own_line && self.eat(&token::Semi) {
@@ -429,15 +431,15 @@ impl<'a> Parser<'a> {
                 } else {
                     stmt.span
                 };
-                if let Ok(snippet) = self.span_to_snippet(stmt_span) {
-                    e.span_suggestion(
-                        stmt_span,
-                        "try placing this code inside a block",
-                        format!("{{ {} }}", snippet),
-                        // Speculative; has been misleading in the past (#46836).
-                        Applicability::MaybeIncorrect,
-                    );
-                }
+                e.multipart_suggestion(
+                    "try placing this code inside a block",
+                    vec![
+                        (stmt_span.shrink_to_lo(), "{ ".to_string()),
+                        (stmt_span.shrink_to_hi(), " }".to_string()),
+                    ],
+                    // Speculative; has been misleading in the past (#46836).
+                    Applicability::MaybeIncorrect,
+                );
             }
             Err(mut e) => {
                 self.recover_stmt_(SemiColonMode::Break, BlockMode::Ignore);
@@ -470,15 +472,15 @@ impl<'a> Parser<'a> {
     ) -> PResult<'a, (Vec<Attribute>, P<Block>)> {
         maybe_whole!(self, NtBlock, |x| (Vec::new(), x));
 
+        self.maybe_recover_unexpected_block_label();
         if !self.eat(&token::OpenDelim(token::Brace)) {
             return self.error_block_no_opening_brace();
         }
 
         let attrs = self.parse_inner_attributes()?;
-        let tail = if let Some(tail) = self.maybe_suggest_struct_literal(lo, blk_mode) {
-            tail?
-        } else {
-            self.parse_block_tail(lo, blk_mode, AttemptLocalParseRecovery::Yes)?
+        let tail = match self.maybe_suggest_struct_literal(lo, blk_mode) {
+            Some(tail) => tail?,
+            None => self.parse_block_tail(lo, blk_mode, AttemptLocalParseRecovery::Yes)?,
         };
         Ok((attrs, tail))
     }
@@ -524,9 +526,8 @@ impl<'a> Parser<'a> {
         // Skip looking for a trailing semicolon when we have an interpolated statement.
         maybe_whole!(self, NtStmt, |x| Some(x));
 
-        let mut stmt = match self.parse_stmt_without_recovery(true, ForceCollect::No)? {
-            Some(stmt) => stmt,
-            None => return Ok(None),
+        let Some(mut stmt) = self.parse_stmt_without_recovery(true, ForceCollect::No)? else {
+            return Ok(None);
         };
 
         let mut eat_semi = true;
@@ -575,11 +576,11 @@ impl<'a> Parser<'a> {
                 // We might be at the `,` in `let x = foo<bar, baz>;`. Try to recover.
                 match &mut local.kind {
                     LocalKind::Init(expr) | LocalKind::InitElse(expr, _) => {
-                            self.check_mistyped_turbofish_with_multiple_type_params(e, expr)?;
-                            // We found `foo<bar, baz>`, have we fully recovered?
-                            self.expect_semi()?;
-                        }
-                        LocalKind::Decl => return Err(e),
+                        self.check_mistyped_turbofish_with_multiple_type_params(e, expr)?;
+                        // We found `foo<bar, baz>`, have we fully recovered?
+                        self.expect_semi()?;
+                    }
+                    LocalKind::Decl => return Err(e),
                 }
                 eat_semi = false;
             }

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -1740,8 +1740,8 @@ impl CheckAttrVisitor<'_> {
     fn check_used(&self, attrs: &[Attribute], target: Target) {
         let mut used_linker_span = None;
         let mut used_compiler_span = None;
-        for attr in attrs {
-            if attr.has_name(sym::used) && target != Target::Static {
+        for attr in attrs.iter().filter(|attr| attr.has_name(sym::used)) {
+            if target != Target::Static {
                 self.tcx
                     .sess
                     .span_err(attr.span, "attribute must be applied to a `static` variable");

--- a/compiler/rustc_typeck/src/check/fn_ctxt/_impl.rs
+++ b/compiler/rustc_typeck/src/check/fn_ctxt/_impl.rs
@@ -313,6 +313,15 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     ) => {
                         // A reborrow has no effect before a dereference.
                     }
+                    // Catch cases which have Deref(None)
+                    // having them slip to bug! causes ICE
+                    // see #94291 for more info
+                    (&[Adjustment { kind: Adjust::Deref(None), .. }], _) => {
+                        self.tcx.sess.delay_span_bug(
+                            DUMMY_SP,
+                            &format!("Can't compose Deref(None) expressions"),
+                        )
+                    }
                     // FIXME: currently we never try to compose autoderefs
                     // and ReifyFnPointer/UnsafeFnPointer, but we could.
                     _ => bug!(

--- a/library/core/src/fmt/builders.rs
+++ b/library/core/src/fmt/builders.rs
@@ -138,7 +138,7 @@ impl<'a, 'b: 'a> DebugStruct<'a, 'b> {
                 }
                 let mut slot = None;
                 let mut state = Default::default();
-                let mut writer = PadAdapter::wrap(&mut self.fmt, &mut slot, &mut state);
+                let mut writer = PadAdapter::wrap(self.fmt, &mut slot, &mut state);
                 writer.write_str(name)?;
                 writer.write_str(": ")?;
                 value.fmt(&mut writer)?;
@@ -189,7 +189,7 @@ impl<'a, 'b: 'a> DebugStruct<'a, 'b> {
                 if self.is_pretty() {
                     let mut slot = None;
                     let mut state = Default::default();
-                    let mut writer = PadAdapter::wrap(&mut self.fmt, &mut slot, &mut state);
+                    let mut writer = PadAdapter::wrap(self.fmt, &mut slot, &mut state);
                     writer.write_str("..\n")?;
                     self.fmt.write_str("}")
                 } else {
@@ -323,7 +323,7 @@ impl<'a, 'b: 'a> DebugTuple<'a, 'b> {
                 }
                 let mut slot = None;
                 let mut state = Default::default();
-                let mut writer = PadAdapter::wrap(&mut self.fmt, &mut slot, &mut state);
+                let mut writer = PadAdapter::wrap(self.fmt, &mut slot, &mut state);
                 value.fmt(&mut writer)?;
                 writer.write_str(",\n")
             } else {
@@ -394,7 +394,7 @@ impl<'a, 'b: 'a> DebugInner<'a, 'b> {
                 }
                 let mut slot = None;
                 let mut state = Default::default();
-                let mut writer = PadAdapter::wrap(&mut self.fmt, &mut slot, &mut state);
+                let mut writer = PadAdapter::wrap(self.fmt, &mut slot, &mut state);
                 entry.fmt(&mut writer)?;
                 writer.write_str(",\n")
             } else {
@@ -789,7 +789,7 @@ impl<'a, 'b: 'a> DebugMap<'a, 'b> {
                 }
                 let mut slot = None;
                 self.state = Default::default();
-                let mut writer = PadAdapter::wrap(&mut self.fmt, &mut slot, &mut self.state);
+                let mut writer = PadAdapter::wrap(self.fmt, &mut slot, &mut self.state);
                 key.fmt(&mut writer)?;
                 writer.write_str(": ")?;
             } else {
@@ -845,7 +845,7 @@ impl<'a, 'b: 'a> DebugMap<'a, 'b> {
 
             if self.is_pretty() {
                 let mut slot = None;
-                let mut writer = PadAdapter::wrap(&mut self.fmt, &mut slot, &mut self.state);
+                let mut writer = PadAdapter::wrap(self.fmt, &mut slot, &mut self.state);
                 value.fmt(&mut writer)?;
                 writer.write_str(",\n")?;
             } else {

--- a/src/test/ui/async-await/await-keyword/incorrect-syntax-suggestions.stderr
+++ b/src/test/ui/async-await/await-keyword/incorrect-syntax-suggestions.stderr
@@ -132,7 +132,7 @@ error: expected one of `.`, `?`, `{`, or an operator, found `}`
 LL |     match await { await => () }
    |     -----                      - expected one of `.`, `?`, `{`, or an operator
    |     |
-   |     while parsing this match expression
+   |     while parsing this `match` expression
 ...
 LL | }
    | ^ unexpected token

--- a/src/test/ui/attributes/used_with_arg_no_mangle.rs
+++ b/src/test/ui/attributes/used_with_arg_no_mangle.rs
@@ -1,0 +1,9 @@
+// check-pass
+
+#![feature(used_with_arg)]
+
+#[used(linker)]
+#[no_mangle] // accidentally detected as `used(compiler)`
+pub static GLOB: usize = 0;
+
+fn main() {}

--- a/src/test/ui/consts/precise-drop-with-coverage.rs
+++ b/src/test/ui/consts/precise-drop-with-coverage.rs
@@ -1,0 +1,16 @@
+// Checks that code coverage doesn't interfere with const_precise_live_drops.
+// Regression test for issue #93848.
+//
+// check-pass
+// compile-flags: --crate-type=lib -Cinstrument-coverage  -Zno-profiler-runtime
+
+#![feature(const_precise_live_drops)]
+
+#[inline]
+pub const fn transpose<T, E>(this: Option<Result<T, E>>) -> Result<Option<T>, E> {
+    match this {
+        Some(Ok(x)) => Ok(Some(x)),
+        Some(Err(e)) => Err(e),
+        None => Ok(None),
+    }
+}

--- a/src/test/ui/did_you_mean/issue-46836-identifier-not-instead-of-negation.stderr
+++ b/src/test/ui/did_you_mean/issue-46836-identifier-not-instead-of-negation.stderr
@@ -28,10 +28,7 @@ error: expected `{`, found `;`
 LL |     if not  // lack of braces is [sic]
    |     -- this `if` expression has a condition, but no block
 LL |         println!("Then when?");
-   |                               ^
-   |                               |
-   |                               expected `{`
-   |                               help: try placing this code inside a block: `{ ; }`
+   |                               ^ expected `{`
 
 error: unexpected `2` after identifier
   --> $DIR/issue-46836-identifier-not-instead-of-negation.rs:26:24

--- a/src/test/ui/did_you_mean/issue-48492-tuple-destructure-missing-parens.stderr
+++ b/src/test/ui/did_you_mean/issue-48492-tuple-destructure-missing-parens.stderr
@@ -2,16 +2,14 @@ error: unexpected `,` in pattern
   --> $DIR/issue-48492-tuple-destructure-missing-parens.rs:38:17
    |
 LL |     while let b1, b2, b3 = reading_frame.next().expect("there should be a start codon") {
-   |                 ^
+   |     -----       ^
+   |     |
+   |     while parsing the condition of this `while` expression
    |
-help: try adding parentheses to match on a tuple...
+help: try adding parentheses to match on a tuple
    |
 LL |     while let (b1, b2, b3) = reading_frame.next().expect("there should be a start codon") {
-   |               ~~~~~~~~~~~~
-help: ...or a vertical bar to match on multiple alternatives
-   |
-LL |     while let b1 | b2 | b3 = reading_frame.next().expect("there should be a start codon") {
-   |               ~~~~~~~~~~~~
+   |               +          +
 
 error: unexpected `,` in pattern
   --> $DIR/issue-48492-tuple-destructure-missing-parens.rs:49:14
@@ -19,14 +17,10 @@ error: unexpected `,` in pattern
 LL |     if let b1, b2, b3 = reading_frame.next().unwrap() {
    |              ^
    |
-help: try adding parentheses to match on a tuple...
+help: try adding parentheses to match on a tuple
    |
 LL |     if let (b1, b2, b3) = reading_frame.next().unwrap() {
-   |            ~~~~~~~~~~~~
-help: ...or a vertical bar to match on multiple alternatives
-   |
-LL |     if let b1 | b2 | b3 = reading_frame.next().unwrap() {
-   |            ~~~~~~~~~~~~
+   |            +          +
 
 error: unexpected `,` in pattern
   --> $DIR/issue-48492-tuple-destructure-missing-parens.rs:59:28
@@ -37,7 +31,7 @@ LL |         Nucleotide::Adenine, Nucleotide::Cytosine, _ => true
 help: try adding parentheses to match on a tuple...
    |
 LL |         (Nucleotide::Adenine, Nucleotide::Cytosine, _) => true
-   |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |         +                                            +
 help: ...or a vertical bar to match on multiple alternatives
    |
 LL |         Nucleotide::Adenine | Nucleotide::Cytosine | _ => true
@@ -49,14 +43,10 @@ error: unexpected `,` in pattern
 LL |     for x, _barr_body in women.iter().map(|woman| woman.allosomes.clone()) {
    |          ^
    |
-help: try adding parentheses to match on a tuple...
+help: try adding parentheses to match on a tuple
    |
 LL |     for (x, _barr_body) in women.iter().map(|woman| woman.allosomes.clone()) {
-   |         ~~~~~~~~~~~~~~~
-help: ...or a vertical bar to match on multiple alternatives
-   |
-LL |     for x | _barr_body in women.iter().map(|woman| woman.allosomes.clone()) {
-   |         ~~~~~~~~~~~~~~
+   |         +             +
 
 error: unexpected `,` in pattern
   --> $DIR/issue-48492-tuple-destructure-missing-parens.rs:75:10
@@ -64,14 +54,10 @@ error: unexpected `,` in pattern
 LL |     for x, y @ Allosome::Y(_) in men.iter().map(|man| man.allosomes.clone()) {
    |          ^
    |
-help: try adding parentheses to match on a tuple...
+help: try adding parentheses to match on a tuple
    |
 LL |     for (x, y @ Allosome::Y(_)) in men.iter().map(|man| man.allosomes.clone()) {
-   |         ~~~~~~~~~~~~~~~~~~~~~~~
-help: ...or a vertical bar to match on multiple alternatives
-   |
-LL |     for x | y @ Allosome::Y(_) in men.iter().map(|man| man.allosomes.clone()) {
-   |         ~~~~~~~~~~~~~~~~~~~~~~
+   |         +                     +
 
 error: unexpected `,` in pattern
   --> $DIR/issue-48492-tuple-destructure-missing-parens.rs:84:14
@@ -79,14 +65,10 @@ error: unexpected `,` in pattern
 LL |     let women, men: (Vec<Genome>, Vec<Genome>) = genomes.iter().cloned()
    |              ^
    |
-help: try adding parentheses to match on a tuple...
+help: try adding parentheses to match on a tuple
    |
 LL |     let (women, men): (Vec<Genome>, Vec<Genome>) = genomes.iter().cloned()
-   |         ~~~~~~~~~~~~
-help: ...or a vertical bar to match on multiple alternatives
-   |
-LL |     let women | men: (Vec<Genome>, Vec<Genome>) = genomes.iter().cloned()
-   |         ~~~~~~~~~~~
+   |         +          +
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/issues/issue-39848.stderr
+++ b/src/test/ui/issues/issue-39848.stderr
@@ -2,16 +2,18 @@ error: expected `{`, found `foo`
   --> $DIR/issue-39848.rs:3:21
    |
 LL |         if $tgt.has_$field() {}
-   |         --          ^^^^^^--
-   |         |           |
-   |         |           expected `{`
-   |         |           help: try placing this code inside a block: `{ $field() }`
+   |         --          ^^^^^^ expected `{`
+   |         |
    |         this `if` expression has a condition, but no block
 ...
 LL |     get_opt!(bar, foo);
    |     ------------------ in this macro invocation
    |
    = note: this error originates in the macro `get_opt` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: try placing this code inside a block
+   |
+LL |         if $tgt.has_{ $field() } {}
+   |                     +          +
 
 error: aborting due to previous error
 

--- a/src/test/ui/label/label_break_value_illegal_uses.fixed
+++ b/src/test/ui/label/label_break_value_illegal_uses.fixed
@@ -5,19 +5,19 @@
 
 #[allow(unused_unsafe)]
 fn labeled_unsafe() {
-    unsafe 'b: {} //~ ERROR block label not supported here
+    unsafe {} //~ ERROR block label not supported here
 }
 
 fn labeled_if() {
-    if true 'b: {} //~ ERROR block label not supported here
+    if true {} //~ ERROR block label not supported here
 }
 
 fn labeled_else() {
-    if true {} else 'b: {} //~ ERROR block label not supported here
+    if true {} else {} //~ ERROR block label not supported here
 }
 
 fn labeled_match() {
-    match false 'b: { //~ ERROR block label not supported here
+    match false { //~ ERROR block label not supported here
         _ => {}
     }
 }

--- a/src/test/ui/label/label_break_value_illegal_uses.stderr
+++ b/src/test/ui/label/label_break_value_illegal_uses.stderr
@@ -1,38 +1,26 @@
-error: expected `{`, found `'b`
-  --> $DIR/label_break_value_illegal_uses.rs:6:12
+error: block label not supported here
+  --> $DIR/label_break_value_illegal_uses.rs:8:12
    |
 LL |     unsafe 'b: {}
-   |            ^^----
-   |            |
-   |            expected `{`
-   |            help: try placing this code inside a block: `{ 'b: {} }`
+   |            ^^^ not supported here
 
-error: expected `{`, found `'b`
-  --> $DIR/label_break_value_illegal_uses.rs:10:13
+error: block label not supported here
+  --> $DIR/label_break_value_illegal_uses.rs:12:13
    |
 LL |     if true 'b: {}
-   |     --      ^^----
-   |     |       |
-   |     |       expected `{`
-   |     |       help: try placing this code inside a block: `{ 'b: {} }`
-   |     this `if` expression has a condition, but no block
+   |             ^^^ not supported here
 
-error: expected `{`, found `'b`
-  --> $DIR/label_break_value_illegal_uses.rs:14:21
+error: block label not supported here
+  --> $DIR/label_break_value_illegal_uses.rs:16:21
    |
 LL |     if true {} else 'b: {}
-   |                     ^^----
-   |                     |
-   |                     expected `{`
-   |                     help: try placing this code inside a block: `{ 'b: {} }`
+   |                     ^^^ not supported here
 
-error: expected one of `.`, `?`, `{`, or an operator, found `'b`
-  --> $DIR/label_break_value_illegal_uses.rs:18:17
+error: block label not supported here
+  --> $DIR/label_break_value_illegal_uses.rs:20:17
    |
-LL |     match false 'b: {}
-   |     -----       ^^ expected one of `.`, `?`, `{`, or an operator
-   |     |
-   |     while parsing this match expression
+LL |     match false 'b: {
+   |                 ^^^ not supported here
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/let-else/let-else-if.stderr
+++ b/src/test/ui/let-else/let-else-if.stderr
@@ -7,10 +7,10 @@ LL |     let Some(_) = Some(()) else if true {
 help: try placing this code inside a block
    |
 LL ~     let Some(_) = Some(()) else { if true {
-LL +
-LL +         return;
-LL +     } else {
-LL +         return;
+LL |
+LL |         return;
+LL |     } else {
+LL |         return;
 LL ~     } };
    |
 

--- a/src/test/ui/missing/missing-block-hint.stderr
+++ b/src/test/ui/missing/missing-block-hint.stderr
@@ -12,10 +12,12 @@ error: expected `{`, found `bar`
 LL |         if (foo)
    |         -- this `if` expression has a condition, but no block
 LL |             bar;
-   |             ^^^-
-   |             |
-   |             expected `{`
-   |             help: try placing this code inside a block: `{ bar; }`
+   |             ^^^ expected `{`
+   |
+help: try placing this code inside a block
+   |
+LL |             { bar; }
+   |             +      +
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/parser/block-no-opening-brace.stderr
+++ b/src/test/ui/parser/block-no-opening-brace.stderr
@@ -1,29 +1,41 @@
 error: expected `{`, found keyword `let`
   --> $DIR/block-no-opening-brace.rs:9:9
    |
+LL |     loop
+   |     ---- while parsing this `loop` expression
 LL |         let x = 0;
-   |         ^^^-------
-   |         |
-   |         expected `{`
-   |         help: try placing this code inside a block: `{ let x = 0; }`
+   |         ^^^ expected `{`
+   |
+help: try placing this code inside a block
+   |
+LL |         { let x = 0; }
+   |         +            +
 
 error: expected `{`, found keyword `let`
   --> $DIR/block-no-opening-brace.rs:15:9
    |
+LL |     while true
+   |     ----- ---- this `while` condition successfully parsed
+   |     |
+   |     while parsing the body of this `while` expression
 LL |         let x = 0;
-   |         ^^^-------
-   |         |
-   |         expected `{`
-   |         help: try placing this code inside a block: `{ let x = 0; }`
+   |         ^^^ expected `{`
+   |
+help: try placing this code inside a block
+   |
+LL |         { let x = 0; }
+   |         +            +
 
 error: expected `{`, found keyword `let`
   --> $DIR/block-no-opening-brace.rs:20:9
    |
 LL |         let x = 0;
-   |         ^^^-------
-   |         |
-   |         expected `{`
-   |         help: try placing this code inside a block: `{ let x = 0; }`
+   |         ^^^ expected `{`
+   |
+help: try placing this code inside a block
+   |
+LL |         { let x = 0; }
+   |         +            +
 
 error: expected expression, found reserved keyword `try`
   --> $DIR/block-no-opening-brace.rs:24:5

--- a/src/test/ui/parser/closure-return-syntax.stderr
+++ b/src/test/ui/parser/closure-return-syntax.stderr
@@ -2,10 +2,12 @@ error: expected `{`, found `22`
   --> $DIR/closure-return-syntax.rs:5:23
    |
 LL |     let x = || -> i32 22;
-   |                       ^^
-   |                       |
-   |                       expected `{`
-   |                       help: try placing this code inside a block: `{ 22 }`
+   |                       ^^ expected `{`
+   |
+help: try placing this code inside a block
+   |
+LL |     let x = || -> i32 { 22 };
+   |                       +    +
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/issues/issue-62554.stderr
+++ b/src/test/ui/parser/issues/issue-62554.stderr
@@ -63,9 +63,8 @@ LL | fn foo(u: u8) { if u8 macro_rules! u8 { (u6) => { fn uuuuuuuuuuu() { use s 
    |
 help: try placing this code inside a block
    |
-LL ~ fn foo(u: u8) { if u8 { macro_rules! u8 { (u6) => { fn uuuuuuuuuuu() { use s loo mod u8 {
-LL +  }
-   |
+LL | fn foo(u: u8) { if u8 { macro_rules! u8 { (u6) => { fn uuuuuuuuuuu() { use s loo mod u8 { }
+   |                       +                                                                    +
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/parser/issues/issue-62973.stderr
+++ b/src/test/ui/parser/issues/issue-62973.stderr
@@ -50,7 +50,7 @@ error: expected one of `.`, `?`, `{`, or an operator, found `}`
   --> $DIR/issue-62973.rs:8:2
    |
 LL | fn p() { match s { v, E { [) {) }
-   |          ----- while parsing this match expression
+   |          ----- while parsing this `match` expression
 LL | 
 LL | 
    |  ^ expected one of `.`, `?`, `{`, or an operator

--- a/src/test/ui/parser/match-refactor-to-expr.fixed
+++ b/src/test/ui/parser/match-refactor-to-expr.fixed
@@ -2,7 +2,7 @@
 
 fn main() {
     let foo =
-         //~ NOTE while parsing this match expression
+         //~ NOTE while parsing this `match` expression
         Some(4).unwrap_or(5)
         //~^ NOTE expected one of `.`, `?`, `{`, or an operator
         ; //~ NOTE unexpected token

--- a/src/test/ui/parser/match-refactor-to-expr.rs
+++ b/src/test/ui/parser/match-refactor-to-expr.rs
@@ -2,7 +2,7 @@
 
 fn main() {
     let foo =
-        match //~ NOTE while parsing this match expression
+        match //~ NOTE while parsing this `match` expression
         Some(4).unwrap_or(5)
         //~^ NOTE expected one of `.`, `?`, `{`, or an operator
         ; //~ NOTE unexpected token

--- a/src/test/ui/parser/match-refactor-to-expr.stderr
+++ b/src/test/ui/parser/match-refactor-to-expr.stderr
@@ -4,7 +4,7 @@ error: expected one of `.`, `?`, `{`, or an operator, found `;`
 LL |         match
    |         -----
    |         |
-   |         while parsing this match expression
+   |         while parsing this `match` expression
    |         help: try removing this `match`
 LL |         Some(4).unwrap_or(5)
    |                             - expected one of `.`, `?`, `{`, or an operator

--- a/src/test/ui/parser/while-if-let-without-body.rs
+++ b/src/test/ui/parser/while-if-let-without-body.rs
@@ -1,0 +1,13 @@
+fn main() {
+    let container = vec![Some(1), Some(2), None];
+
+    let mut i = 0;
+    while if let Some(thing) = container.get(i) {
+        //~^ NOTE while parsing the body of this `while` expression
+        //~| NOTE this `while` condition successfully parsed
+        println!("{:?}", thing);
+        i += 1;
+    }
+}
+//~^ ERROR expected `{`, found `}`
+//~| NOTE expected `{`

--- a/src/test/ui/parser/while-if-let-without-body.stderr
+++ b/src/test/ui/parser/while-if-let-without-body.stderr
@@ -1,0 +1,18 @@
+error: expected `{`, found `}`
+  --> $DIR/while-if-let-without-body.rs:11:1
+   |
+LL |       while if let Some(thing) = container.get(i) {
+   |  _____-----_-
+   | |     |
+   | |     while parsing the body of this `while` expression
+LL | |
+LL | |
+LL | |         println!("{:?}", thing);
+LL | |         i += 1;
+LL | |     }
+   | |_____- this `while` condition successfully parsed
+LL |   }
+   |   ^ expected `{`
+
+error: aborting due to previous error
+

--- a/src/test/ui/tuple/wrong_argument_ice.rs
+++ b/src/test/ui/tuple/wrong_argument_ice.rs
@@ -1,0 +1,17 @@
+use std::collections::VecDeque;
+
+pub struct BuildPlanBuilder {
+    acc: VecDeque<(String, String)>,
+    current_provides: String,
+    current_requires: String,
+}
+
+impl BuildPlanBuilder {
+    pub fn or(&mut self) -> &mut Self {
+        self.acc.push_back(self.current_provides, self.current_requires);
+        //~^ ERROR this function takes 1 argument but 2 arguments were supplied
+        self
+    }
+}
+
+fn main() {}

--- a/src/test/ui/tuple/wrong_argument_ice.stderr
+++ b/src/test/ui/tuple/wrong_argument_ice.stderr
@@ -1,0 +1,19 @@
+error[E0061]: this function takes 1 argument but 2 arguments were supplied
+  --> $DIR/wrong_argument_ice.rs:11:18
+   |
+LL |         self.acc.push_back(self.current_provides, self.current_requires);
+   |                  ^^^^^^^^^ ---------------------  --------------------- supplied 2 arguments
+   |
+note: associated function defined here
+  --> $SRC_DIR/alloc/src/collections/vec_deque/mod.rs:LL:COL
+   |
+LL |     pub fn push_back(&mut self, value: T) {
+   |            ^^^^^^^^^
+help: use parentheses to construct a tuple
+   |
+LL |         self.acc.push_back((self.current_provides, self.current_requires));
+   |                            +                                            +
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0061`.

--- a/src/test/ui/unsafe/unsafe-block-without-braces.stderr
+++ b/src/test/ui/unsafe/unsafe-block-without-braces.stderr
@@ -1,11 +1,15 @@
 error: expected `{`, found `std`
   --> $DIR/unsafe-block-without-braces.rs:3:9
    |
+LL |     unsafe //{
+   |     ------ while parsing this `unsafe` expression
 LL |         std::mem::transmute::<f32, u32>(1.0);
-   |         ^^^----------------------------------
-   |         |
-   |         expected `{`
-   |         help: try placing this code inside a block: `{ std::mem::transmute::<f32, u32>(1.0); }`
+   |         ^^^ expected `{`
+   |
+help: try placing this code inside a block
+   |
+LL |         { std::mem::transmute::<f32, u32>(1.0); }
+   |         +                                       +
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Successful merges:

 - #92823 (Tweak diagnostics)
 - #93603 (Populate liveness facts when calling `get_body_with_borrowck_facts` without `-Z polonius`)
 - #93870 (Fix switch on discriminant detection in a presence of coverage counters)
 - #94355 (Add one more case to avoid ICE)
 - #94363 (Remove needless borrows from core::fmt)
 - #94377 (`check_used` should only look at actual `used` attributes)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=92823,93603,93870,94355,94363,94377)
<!-- homu-ignore:end -->