### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/compiler/rustc_borrowck/src/nll.rs
+++ b/compiler/rustc_borrowck/src/nll.rs
@@ -189,6 +189,7 @@ pub(crate) fn compute_regions<'cx, 'tcx>(
             move_data,
             elements,
             upvars,
+            use_polonius,
         );
 
     if let Some(all_facts) = &mut all_facts {

--- a/compiler/rustc_borrowck/src/type_check/liveness/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/liveness/mod.rs
@@ -37,6 +37,7 @@ pub(super) fn generate<'mir, 'tcx>(
     flow_inits: &mut ResultsCursor<'mir, 'tcx, MaybeInitializedPlaces<'mir, 'tcx>>,
     move_data: &MoveData<'tcx>,
     location_table: &LocationTable,
+    use_polonius: bool,
 ) {
     debug!("liveness::generate");
 
@@ -46,7 +47,7 @@ pub(super) fn generate<'mir, 'tcx>(
         &typeck.borrowck_context.constraints.outlives_constraints,
     );
     let live_locals = compute_live_locals(typeck.tcx(), &free_regions, &body);
-    let facts_enabled = AllFacts::enabled(typeck.tcx());
+    let facts_enabled = use_polonius || AllFacts::enabled(typeck.tcx());
 
     let polonius_drop_used = if facts_enabled {
         let mut drop_used = Vec::new();

--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -136,6 +136,7 @@ pub(crate) fn type_check<'mir, 'tcx>(
     move_data: &MoveData<'tcx>,
     elements: &Rc<RegionValueElements>,
     upvars: &[Upvar<'tcx>],
+    use_polonius: bool,
 ) -> MirTypeckResults<'tcx> {
     let implicit_region_bound = infcx.tcx.mk_region(ty::ReVar(universal_regions.fr_fn_body));
     let mut universe_causes = FxHashMap::default();
@@ -187,7 +188,15 @@ pub(crate) fn type_check<'mir, 'tcx>(
         &mut borrowck_context,
         |mut cx| {
             cx.equate_inputs_and_outputs(&body, universal_regions, &normalized_inputs_and_output);
-            liveness::generate(&mut cx, body, elements, flow_inits, move_data, location_table);
+            liveness::generate(
+                &mut cx,
+                body,
+                elements,
+                flow_inits,
+                move_data,
+                location_table,
+                use_polonius,
+            );
 
             translate_outlives_facts(&mut cx);
             let opaque_type_values = mem::take(&mut infcx.inner.borrow_mut().opaque_types);

--- a/compiler/rustc_mir_dataflow/src/impls/mod.rs
+++ b/compiler/rustc_mir_dataflow/src/impls/mod.rs
@@ -710,24 +710,27 @@ fn switch_on_enum_discriminant<'mir, 'tcx>(
     block: &'mir mir::BasicBlockData<'tcx>,
     switch_on: mir::Place<'tcx>,
 ) -> Option<(mir::Place<'tcx>, &'tcx ty::AdtDef)> {
-    match block.statements.last().map(|stmt| &stmt.kind) {
-        Some(mir::StatementKind::Assign(box (lhs, mir::Rvalue::Discriminant(discriminated))))
-            if *lhs == switch_on =>
-        {
-            match &discriminated.ty(body, tcx).ty.kind() {
-                ty::Adt(def, _) => Some((*discriminated, def)),
+    for statement in block.statements.iter().rev() {
+        match &statement.kind {
+            mir::StatementKind::Assign(box (lhs, mir::Rvalue::Discriminant(discriminated)))
+                if *lhs == switch_on =>
+            {
+                match &discriminated.ty(body, tcx).ty.kind() {
+                    ty::Adt(def, _) => return Some((*discriminated, def)),
 
-                // `Rvalue::Discriminant` is also used to get the active yield point for a
-                // generator, but we do not need edge-specific effects in that case. This may
-                // change in the future.
-                ty::Generator(..) => None,
+                    // `Rvalue::Discriminant` is also used to get the active yield point for a
+                    // generator, but we do not need edge-specific effects in that case. This may
+                    // change in the future.
+                    ty::Generator(..) => return None,
 
-                t => bug!("`discriminant` called on unexpected type {:?}", t),
+                    t => bug!("`discriminant` called on unexpected type {:?}", t),
+                }
             }
+            mir::StatementKind::Coverage(_) => continue,
+            _ => return None,
         }
-
-        _ => None,
     }
+    None
 }
 
 struct OnMutBorrow<F>(F);

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -1740,8 +1740,8 @@ impl CheckAttrVisitor<'_> {
     fn check_used(&self, attrs: &[Attribute], target: Target) {
         let mut used_linker_span = None;
         let mut used_compiler_span = None;
-        for attr in attrs {
-            if attr.has_name(sym::used) && target != Target::Static {
+        for attr in attrs.iter().filter(|attr| attr.has_name(sym::used)) {
+            if target != Target::Static {
                 self.tcx
                     .sess
                     .span_err(attr.span, "attribute must be applied to a `static` variable");

--- a/compiler/rustc_typeck/src/check/fn_ctxt/_impl.rs
+++ b/compiler/rustc_typeck/src/check/fn_ctxt/_impl.rs
@@ -313,6 +313,15 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     ) => {
                         // A reborrow has no effect before a dereference.
                     }
+                    // Catch cases which have Deref(None)
+                    // having them slip to bug! causes ICE
+                    // see #94291 for more info
+                    (&[Adjustment { kind: Adjust::Deref(None), .. }], _) => {
+                        self.tcx.sess.delay_span_bug(
+                            DUMMY_SP,
+                            &format!("Can't compose Deref(None) expressions"),
+                        )
+                    }
                     // FIXME: currently we never try to compose autoderefs
                     // and ReifyFnPointer/UnsafeFnPointer, but we could.
                     _ => bug!(

--- a/library/core/src/fmt/builders.rs
+++ b/library/core/src/fmt/builders.rs
@@ -138,7 +138,7 @@ impl<'a, 'b: 'a> DebugStruct<'a, 'b> {
                 }
                 let mut slot = None;
                 let mut state = Default::default();
-                let mut writer = PadAdapter::wrap(&mut self.fmt, &mut slot, &mut state);
+                let mut writer = PadAdapter::wrap(self.fmt, &mut slot, &mut state);
                 writer.write_str(name)?;
                 writer.write_str(": ")?;
                 value.fmt(&mut writer)?;
@@ -189,7 +189,7 @@ impl<'a, 'b: 'a> DebugStruct<'a, 'b> {
                 if self.is_pretty() {
                     let mut slot = None;
                     let mut state = Default::default();
-                    let mut writer = PadAdapter::wrap(&mut self.fmt, &mut slot, &mut state);
+                    let mut writer = PadAdapter::wrap(self.fmt, &mut slot, &mut state);
                     writer.write_str("..\n")?;
                     self.fmt.write_str("}")
                 } else {
@@ -323,7 +323,7 @@ impl<'a, 'b: 'a> DebugTuple<'a, 'b> {
                 }
                 let mut slot = None;
                 let mut state = Default::default();
-                let mut writer = PadAdapter::wrap(&mut self.fmt, &mut slot, &mut state);
+                let mut writer = PadAdapter::wrap(self.fmt, &mut slot, &mut state);
                 value.fmt(&mut writer)?;
                 writer.write_str(",\n")
             } else {
@@ -394,7 +394,7 @@ impl<'a, 'b: 'a> DebugInner<'a, 'b> {
                 }
                 let mut slot = None;
                 let mut state = Default::default();
-                let mut writer = PadAdapter::wrap(&mut self.fmt, &mut slot, &mut state);
+                let mut writer = PadAdapter::wrap(self.fmt, &mut slot, &mut state);
                 entry.fmt(&mut writer)?;
                 writer.write_str(",\n")
             } else {
@@ -789,7 +789,7 @@ impl<'a, 'b: 'a> DebugMap<'a, 'b> {
                 }
                 let mut slot = None;
                 self.state = Default::default();
-                let mut writer = PadAdapter::wrap(&mut self.fmt, &mut slot, &mut self.state);
+                let mut writer = PadAdapter::wrap(self.fmt, &mut slot, &mut self.state);
                 key.fmt(&mut writer)?;
                 writer.write_str(": ")?;
             } else {
@@ -845,7 +845,7 @@ impl<'a, 'b: 'a> DebugMap<'a, 'b> {
 
             if self.is_pretty() {
                 let mut slot = None;
-                let mut writer = PadAdapter::wrap(&mut self.fmt, &mut slot, &mut self.state);
+                let mut writer = PadAdapter::wrap(self.fmt, &mut slot, &mut self.state);
                 value.fmt(&mut writer)?;
                 writer.write_str(",\n")?;
             } else {

--- a/src/test/ui/attributes/used_with_arg_no_mangle.rs
+++ b/src/test/ui/attributes/used_with_arg_no_mangle.rs
@@ -1,0 +1,9 @@
+// check-pass
+
+#![feature(used_with_arg)]
+
+#[used(linker)]
+#[no_mangle] // accidentally detected as `used(compiler)`
+pub static GLOB: usize = 0;
+
+fn main() {}

--- a/src/test/ui/consts/precise-drop-with-coverage.rs
+++ b/src/test/ui/consts/precise-drop-with-coverage.rs
@@ -1,0 +1,16 @@
+// Checks that code coverage doesn't interfere with const_precise_live_drops.
+// Regression test for issue #93848.
+//
+// check-pass
+// compile-flags: --crate-type=lib -Cinstrument-coverage  -Zno-profiler-runtime
+
+#![feature(const_precise_live_drops)]
+
+#[inline]
+pub const fn transpose<T, E>(this: Option<Result<T, E>>) -> Result<Option<T>, E> {
+    match this {
+        Some(Ok(x)) => Ok(Some(x)),
+        Some(Err(e)) => Err(e),
+        None => Ok(None),
+    }
+}

--- a/src/test/ui/tuple/wrong_argument_ice.rs
+++ b/src/test/ui/tuple/wrong_argument_ice.rs
@@ -1,0 +1,17 @@
+use std::collections::VecDeque;
+
+pub struct BuildPlanBuilder {
+    acc: VecDeque<(String, String)>,
+    current_provides: String,
+    current_requires: String,
+}
+
+impl BuildPlanBuilder {
+    pub fn or(&mut self) -> &mut Self {
+        self.acc.push_back(self.current_provides, self.current_requires);
+        //~^ ERROR this function takes 1 argument but 2 arguments were supplied
+        self
+    }
+}
+
+fn main() {}

--- a/src/test/ui/tuple/wrong_argument_ice.stderr
+++ b/src/test/ui/tuple/wrong_argument_ice.stderr
@@ -1,0 +1,19 @@
+error[E0061]: this function takes 1 argument but 2 arguments were supplied
+  --> $DIR/wrong_argument_ice.rs:11:18
+   |
+LL |         self.acc.push_back(self.current_provides, self.current_requires);
+   |                  ^^^^^^^^^ ---------------------  --------------------- supplied 2 arguments
+   |
+note: associated function defined here
+  --> $SRC_DIR/alloc/src/collections/vec_deque/mod.rs:LL:COL
+   |
+LL |     pub fn push_back(&mut self, value: T) {
+   |            ^^^^^^^^^
+help: use parentheses to construct a tuple
+   |
+LL |         self.acc.push_back((self.current_provides, self.current_requires));
+   |                            +                                            +
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0061`.


### PR DESCRIPTION
Successful merges:

 - #93603 (Populate liveness facts when calling `get_body_with_borrowck_facts` without `-Z polonius`)
 - #93870 (Fix switch on discriminant detection in a presence of coverage counters)
 - #94355 (Add one more case to avoid ICE)
 - #94363 (Remove needless borrows from core::fmt)
 - #94377 (`check_used` should only look at actual `used` attributes)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=93603,93870,94355,94363,94377)
<!-- homu-ignore:end -->