### PR TITLE
rustc_expand: use a persistent vector to store matches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3684,6 +3684,7 @@ dependencies = [
 name = "rustc_expand"
 version = "0.0.0"
 dependencies = [
+ "im-rc",
  "rustc_ast",
  "rustc_ast_passes",
  "rustc_ast_pretty",

--- a/compiler/rustc_expand/Cargo.toml
+++ b/compiler/rustc_expand/Cargo.toml
@@ -24,3 +24,4 @@ rustc_parse = { path = "../rustc_parse" }
 rustc_session = { path = "../rustc_session" }
 smallvec = { version = "1.6.1", features = ["union", "may_dangle"] }
 rustc_ast = { path = "../rustc_ast" }
+im-rc = "15"


### PR DESCRIPTION
Avoid cloning every item in the list when they aren't all changed.

This seems to improve performance on html5ever running locally. Can we try it with the whole benchmark?