### PR TITLE
Add option to pass environment variables

### DIFF
--- a/compiler/rustc_builtin_macros/src/env.rs
+++ b/compiler/rustc_builtin_macros/src/env.rs
@@ -21,7 +21,12 @@ pub fn expand_option_env<'cx>(
     };
 
     let sp = cx.with_def_site_ctxt(sp);
-    let value = env::var(var.as_str()).ok().as_deref().map(Symbol::intern);
+
+    let injected_value =
+        cx.sess.opts.injected_env_vars.get(var.as_str()).map(|s| Symbol::intern(s));
+    let value =
+        injected_value.or_else(|| env::var(var.as_str()).ok().as_deref().map(Symbol::intern));
+
     cx.sess.parse_sess.env_depinfo.borrow_mut().insert((var, value));
     let e = match value {
         None => {
@@ -78,7 +83,11 @@ pub fn expand_env<'cx>(
     }
 
     let sp = cx.with_def_site_ctxt(sp);
-    let value = env::var(var.as_str()).ok().as_deref().map(Symbol::intern);
+
+    let key = var.as_str();
+    let injected_value = cx.sess.opts.injected_env_vars.get(key).map(|s| Symbol::intern(s));
+    let value = injected_value.or_else(|| env::var(key).ok().as_deref().map(Symbol::intern));
+
     cx.sess.parse_sess.env_depinfo.borrow_mut().insert((var, value));
     let e = match value {
         None => {

--- a/compiler/rustc_expand/src/proc_macro_server.rs
+++ b/compiler/rustc_expand/src/proc_macro_server.rs
@@ -375,6 +375,10 @@ impl server::Types for Rustc<'_, '_> {
 }
 
 impl server::FreeFunctions for Rustc<'_, '_> {
+    fn injected_env_var(&mut self, var: &str) -> Option<String> {
+        self.ecx.sess.opts.injected_env_vars.get(var).cloned()
+    }
+
     fn track_env_var(&mut self, var: &str, value: Option<&str>) {
         self.sess()
             .env_depinfo

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -10,6 +10,8 @@ use rustc_target::spec::{
     RelocModel, RelroLevel, SplitDebuginfo, StackProtector, TargetTriple, TlsModel,
 };
 
+use rustc_data_structures::fx::FxHashMap;
+
 use rustc_feature::UnstableFeatures;
 use rustc_span::edition::Edition;
 use rustc_span::RealFileName;
@@ -210,6 +212,9 @@ top_level_options!(
 
         /// The (potentially remapped) working directory
         working_dir: RealFileName [TRACKED],
+
+        /// Overridden env vars used for `env!` and `option_env!`
+        injected_env_vars: FxHashMap<String, String> [UNTRACKED],
     }
 );
 

--- a/library/proc_macro/src/bridge/mod.rs
+++ b/library/proc_macro/src/bridge/mod.rs
@@ -54,6 +54,7 @@ macro_rules! with_api {
         $m! {
             FreeFunctions {
                 fn drop($self: $S::FreeFunctions);
+                fn injected_env_var(var: &str) -> Option<String>;
                 fn track_env_var(var: &str, value: Option<&str>);
                 fn track_path(path: &str);
                 fn literal_from_str(s: &str) -> Result<Literal<$S::Span, $S::Symbol>, ()>;

--- a/library/proc_macro/src/lib.rs
+++ b/library/proc_macro/src/lib.rs
@@ -1505,7 +1505,10 @@ pub mod tracked_env {
     #[unstable(feature = "proc_macro_tracked_env", issue = "99515")]
     pub fn var<K: AsRef<OsStr> + AsRef<str>>(key: K) -> Result<String, VarError> {
         let key: &str = key.as_ref();
-        let value = env::var(key);
+        let injected_value = crate::bridge::client::FreeFunctions::injected_env_var(key);
+        let env_value = env::var(key);
+
+        let value = injected_value.map_or_else(env_value, Ok);
         crate::bridge::client::FreeFunctions::track_env_var(key, value.as_deref().ok());
         value
     }

--- a/library/proc_macro/src/lib.rs
+++ b/library/proc_macro/src/lib.rs
@@ -1508,7 +1508,7 @@ pub mod tracked_env {
         let injected_value = crate::bridge::client::FreeFunctions::injected_env_var(key);
         let env_value = env::var(key);
 
-        let value = injected_value.map_or_else(env_value, Ok);
+        let value = injected_value.map_or(env_value, Ok);
         crate::bridge::client::FreeFunctions::track_env_var(key, value.as_deref().ok());
         value
     }

--- a/src/test/run-make/env-dep-info/Makefile
+++ b/src/test/run-make/env-dep-info/Makefile
@@ -7,7 +7,7 @@ ADDITIONAL_ARGS := $(RUSTFLAGS)
 endif
 
 all:
-	EXISTING_ENV=1 EXISTING_OPT_ENV=1 OVERRIDEN_INJECTED_ENV=0 $(RUSTC) --emit dep-info --env INJECTED_ENV=1 --env OVERRIDEN_ENV=1 main.rs
+	EXISTING_ENV=1 EXISTING_OPT_ENV=1 OVERRIDEN_INJECTED_ENV=0 $(RUSTC) --emit dep-info -Zunstable-options --env INJECTED_ENV=1 --env OVERRIDEN_ENV=1 main.rs
 	$(CGREP) "# env-dep:EXISTING_ENV=1" < $(TMPDIR)/main.d
 	$(CGREP) "# env-dep:EXISTING_OPT_ENV=1" < $(TMPDIR)/main.d
 	$(CGREP) "# env-dep:NONEXISTENT_OPT_ENV" < $(TMPDIR)/main.d
@@ -16,7 +16,7 @@ all:
 	$(CGREP) "# env-dep:OVERRIDEN_ENV=1" < $(TMPDIR)/main.d
 	# Proc macro
 	$(BARE_RUSTC) $(ADDITIONAL_ARGS) --out-dir $(TMPDIR) macro_def.rs
-	EXISTING_PROC_MACRO_ENV=1 OVERRIDEN_PROC_MACRO_ENV=0 $(RUSTC) --emit dep-info --env INJECTED_PROC_MACRO_ENV=1 --env OVERRIDEN_PROC_MACRO_ENV=1 macro_use.rs
+	EXISTING_PROC_MACRO_ENV=1 OVERRIDEN_PROC_MACRO_ENV=0 $(RUSTC) --emit dep-info -Zunstable-options --env INJECTED_PROC_MACRO_ENV=1 --env OVERRIDEN_PROC_MACRO_ENV=1 macro_use.rs
 	$(CGREP) "# env-dep:EXISTING_PROC_MACRO_ENV=1" < $(TMPDIR)/macro_use.d
 	$(CGREP) "# env-dep:NONEXISTENT_PROC_MACEO_ENV" < $(TMPDIR)/macro_use.d
 	$(CGREP) "# env-dep:INJECTED_PROC_MACRO_ENV=1" < $(TMPDIR)/macro_use.d

--- a/src/test/run-make/env-dep-info/Makefile
+++ b/src/test/run-make/env-dep-info/Makefile
@@ -7,13 +7,17 @@ ADDITIONAL_ARGS := $(RUSTFLAGS)
 endif
 
 all:
-	EXISTING_ENV=1 EXISTING_OPT_ENV=1 $(RUSTC) --emit dep-info main.rs
+	EXISTING_ENV=1 EXISTING_OPT_ENV=1 OVERRIDEN_INJECTED_ENV=0 $(RUSTC) --emit dep-info --env INJECTED_ENV=1 --env OVERRIDEN_ENV=1 main.rs
 	$(CGREP) "# env-dep:EXISTING_ENV=1" < $(TMPDIR)/main.d
 	$(CGREP) "# env-dep:EXISTING_OPT_ENV=1" < $(TMPDIR)/main.d
 	$(CGREP) "# env-dep:NONEXISTENT_OPT_ENV" < $(TMPDIR)/main.d
 	$(CGREP) "# env-dep:ESCAPE\nESCAPE\\" < $(TMPDIR)/main.d
+	$(CGREP) "# env-dep:INJECTED_ENV=1" < $(TMPDIR)/main.d
+	$(CGREP) "# env-dep:OVERRIDEN_ENV=1" < $(TMPDIR)/main.d
 	# Proc macro
 	$(BARE_RUSTC) $(ADDITIONAL_ARGS) --out-dir $(TMPDIR) macro_def.rs
-	EXISTING_PROC_MACRO_ENV=1 $(RUSTC) --emit dep-info macro_use.rs
+	EXISTING_PROC_MACRO_ENV=1 OVERRIDEN_PROC_MACRO_ENV=0 $(RUSTC) --emit dep-info --env INJECTED_PROC_MACRO_ENV=1 --env OVERRIDEN_PROC_MACRO_ENV=1 macro_use.rs
 	$(CGREP) "# env-dep:EXISTING_PROC_MACRO_ENV=1" < $(TMPDIR)/macro_use.d
 	$(CGREP) "# env-dep:NONEXISTENT_PROC_MACEO_ENV" < $(TMPDIR)/macro_use.d
+	$(CGREP) "# env-dep:INJECTED_PROC_MACRO_ENV=1" < $(TMPDIR)/macro_use.d
+	$(CGREP) "# env-dep:OVERRIDEN_PROC_MACRO_ENV=1" < $(TMPDIR)/macro_use.d

--- a/src/test/run-make/env-dep-info/Makefile
+++ b/src/test/run-make/env-dep-info/Makefile
@@ -7,7 +7,7 @@ ADDITIONAL_ARGS := $(RUSTFLAGS)
 endif
 
 all:
-	EXISTING_ENV=1 EXISTING_OPT_ENV=1 OVERRIDEN_INJECTED_ENV=0 $(RUSTC) --emit dep-info -Zunstable-options --env INJECTED_ENV=1 --env OVERRIDEN_ENV=1 main.rs
+	EXISTING_ENV=1 EXISTING_OPT_ENV=1 OVERRIDEN_ENV=0 $(RUSTC) --emit dep-info -Zunstable-options --env INJECTED_ENV=1 --env OVERRIDEN_ENV=1 main.rs
 	$(CGREP) "# env-dep:EXISTING_ENV=1" < $(TMPDIR)/main.d
 	$(CGREP) "# env-dep:EXISTING_OPT_ENV=1" < $(TMPDIR)/main.d
 	$(CGREP) "# env-dep:NONEXISTENT_OPT_ENV" < $(TMPDIR)/main.d

--- a/src/test/run-make/env-dep-info/macro_def.rs
+++ b/src/test/run-make/env-dep-info/macro_def.rs
@@ -8,5 +8,7 @@ use proc_macro::*;
 pub fn access_env_vars(_: TokenStream) -> TokenStream {
     let _ = tracked_env::var("EXISTING_PROC_MACRO_ENV");
     let _ = tracked_env::var("NONEXISTENT_PROC_MACEO_ENV");
+    let _ = tracked_env::var("INJECTED_PROC_MACRO_ENV");
+    let _ = tracked_env::var("OVERRIDEN_PROC_MACRO_ENV");
     TokenStream::new()
 }

--- a/src/test/run-make/env-dep-info/main.rs
+++ b/src/test/run-make/env-dep-info/main.rs
@@ -3,4 +3,6 @@ fn main() {
     option_env!("EXISTING_OPT_ENV");
     option_env!("NONEXISTENT_OPT_ENV");
     option_env!("ESCAPE\nESCAPE\\");
+    env!("INJECTED_ENV");
+    env!("OVERRIDEN_ENV");
 }

--- a/src/test/ui/extenv/extenv-injected.rs
+++ b/src/test/ui/extenv/extenv-injected.rs
@@ -1,0 +1,8 @@
+// run-pass
+// rustc_env: overridden=no
+// compile-flags: -Z unstable-options --env x=y --env overridden=yes
+
+fn main() {
+    assert_eq!(env!("x"), "y");
+    assert_eq!(env!("overridden"), "yes");
+}

--- a/src/tools/rust-analyzer/crates/proc-macro-srv/src/abis/abi_sysroot/ra_server.rs
+++ b/src/tools/rust-analyzer/crates/proc-macro-srv/src/abis/abi_sysroot/ra_server.rs
@@ -72,6 +72,10 @@ impl server::Types for RustAnalyzer {
 }
 
 impl server::FreeFunctions for RustAnalyzer {
+    fn injected_env_var(&mut self, _var: &str) -> Option<String> {
+        None
+    }
+
     fn track_env_var(&mut self, _var: &str, _value: Option<&str>) {
         // FIXME: track env var accesses
         // https://github.com/rust-lang/rust/pull/71858


### PR DESCRIPTION
Closes #80792. Adds the unstable `--env VAR=VALUE` option, which injects environment variables into the program, allowing them to be read by the `env!` and `option_env!` macros.