### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/compiler/rustc_data_structures/src/graph/dominators/mod.rs
+++ b/compiler/rustc_data_structures/src/graph/dominators/mod.rs
@@ -241,9 +241,19 @@ fn compress(
     v: PreorderIndex,
 ) {
     assert!(is_processed(v, lastlinked));
-    let u = ancestor[v];
-    if is_processed(u, lastlinked) {
-        compress(ancestor, lastlinked, semi, label, u);
+    // Compute the processed list of ancestors
+    //
+    // We use a heap stack here to avoid recursing too deeply, exhausting the
+    // stack space.
+    let mut stack: smallvec::SmallVec<[_; 8]> = smallvec::smallvec![v];
+    let mut u = ancestor[v];
+    while is_processed(u, lastlinked) {
+        stack.push(u);
+        u = ancestor[u];
+    }
+
+    // Then in reverse order, popping the stack
+    for &[v, u] in stack.array_windows().rev() {
         if semi[label[u]] < semi[label[v]] {
             label[v] = label[u];
         }

--- a/compiler/rustc_middle/src/traits/mod.rs
+++ b/compiler/rustc_middle/src/traits/mod.rs
@@ -368,6 +368,11 @@ pub enum ObligationCauseCode<'tcx> {
 
     /// From `match_impl`. The cause for us having to match an impl, and the DefId we are matching against.
     MatchImpl(ObligationCause<'tcx>, DefId),
+
+    BinOp {
+        rhs_span: Option<Span>,
+        is_lit: bool,
+    },
 }
 
 /// The 'location' at which we try to perform HIR-based wf checking.

--- a/compiler/rustc_mir_dataflow/src/impls/borrowed_locals.rs
+++ b/compiler/rustc_mir_dataflow/src/impls/borrowed_locals.rs
@@ -10,38 +10,11 @@ use rustc_middle::mir::*;
 /// At present, this is used as a very limited form of alias analysis. For example,
 /// `MaybeBorrowedLocals` is used to compute which locals are live during a yield expression for
 /// immovable generators.
-pub struct MaybeBorrowedLocals {
-    ignore_borrow_on_drop: bool,
-}
+pub struct MaybeBorrowedLocals;
 
 impl MaybeBorrowedLocals {
-    /// A dataflow analysis that records whether a pointer or reference exists that may alias the
-    /// given local.
-    pub fn all_borrows() -> Self {
-        MaybeBorrowedLocals { ignore_borrow_on_drop: false }
-    }
-}
-
-impl MaybeBorrowedLocals {
-    /// During dataflow analysis, ignore the borrow that may occur when a place is dropped.
-    ///
-    /// Drop terminators may call custom drop glue (`Drop::drop`), which takes `&mut self` as a
-    /// parameter. In the general case, a drop impl could launder that reference into the
-    /// surrounding environment through a raw pointer, thus creating a valid `*mut` pointing to the
-    /// dropped local. We are not yet willing to declare this particular case UB, so we must treat
-    /// all dropped locals as mutably borrowed for now. See discussion on [#61069].
-    ///
-    /// In some contexts, we know that this borrow will never occur. For example, during
-    /// const-eval, custom drop glue cannot be run. Code that calls this should document the
-    /// assumptions that justify ignoring `Drop` terminators in this way.
-    ///
-    /// [#61069]: https://github.com/rust-lang/rust/pull/61069
-    pub fn unsound_ignore_borrow_on_drop(self) -> Self {
-        MaybeBorrowedLocals { ignore_borrow_on_drop: true, ..self }
-    }
-
     fn transfer_function<'a, T>(&'a self, trans: &'a mut T) -> TransferFunction<'a, T> {
-        TransferFunction { trans, ignore_borrow_on_drop: self.ignore_borrow_on_drop }
+        TransferFunction { trans }
     }
 }
 
@@ -92,7 +65,6 @@ impl<'tcx> GenKillAnalysis<'tcx> for MaybeBorrowedLocals {
 /// A `Visitor` that defines the transfer function for `MaybeBorrowedLocals`.
 struct TransferFunction<'a, T> {
     trans: &'a mut T,
-    ignore_borrow_on_drop: bool,
 }
 
 impl<'tcx, T> Visitor<'tcx> for TransferFunction<'_, T>
@@ -146,10 +118,15 @@ where
         match terminator.kind {
             mir::TerminatorKind::Drop { place: dropped_place, .. }
             | mir::TerminatorKind::DropAndReplace { place: dropped_place, .. } => {
-                // See documentation for `unsound_ignore_borrow_on_drop` for an explanation.
-                if !self.ignore_borrow_on_drop {
-                    self.trans.gen(dropped_place.local);
-                }
+                // Drop terminators may call custom drop glue (`Drop::drop`), which takes `&mut
+                // self` as a parameter. In the general case, a drop impl could launder that
+                // reference into the surrounding environment through a raw pointer, thus creating
+                // a valid `*mut` pointing to the dropped local. We are not yet willing to declare
+                // this particular case UB, so we must treat all dropped locals as mutably borrowed
+                // for now. See discussion on [#61069].
+                //
+                // [#61069]: https://github.com/rust-lang/rust/pull/61069
+                self.trans.gen(dropped_place.local);
             }
 
             TerminatorKind::Abort

--- a/compiler/rustc_mir_transform/src/generator.rs
+++ b/compiler/rustc_mir_transform/src/generator.rs
@@ -463,10 +463,8 @@ fn locals_live_across_suspend_points<'tcx>(
 
     // Calculate the MIR locals which have been previously
     // borrowed (even if they are still active).
-    let borrowed_locals_results = MaybeBorrowedLocals::all_borrows()
-        .into_engine(tcx, body_ref)
-        .pass_name("generator")
-        .iterate_to_fixpoint();
+    let borrowed_locals_results =
+        MaybeBorrowedLocals.into_engine(tcx, body_ref).pass_name("generator").iterate_to_fixpoint();
 
     let mut borrowed_locals_cursor =
         rustc_mir_dataflow::ResultsCursor::new(body_ref, &borrowed_locals_results);

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
@@ -499,6 +499,7 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                             err.span_label(enclosing_scope_span, s.as_str());
                         }
 
+                        self.suggest_floating_point_literal(&obligation, &mut err, &trait_ref);
                         self.suggest_dereferences(&obligation, &mut err, trait_predicate);
                         self.suggest_fn_call(&obligation, &mut err, trait_predicate);
                         self.suggest_remove_reference(&obligation, &mut err, trait_predicate);

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -182,6 +182,13 @@ pub trait InferCtxtExt<'tcx> {
         trait_pred: ty::PolyTraitPredicate<'tcx>,
         span: Span,
     );
+
+    fn suggest_floating_point_literal(
+        &self,
+        obligation: &PredicateObligation<'tcx>,
+        err: &mut DiagnosticBuilder<'_>,
+        trait_ref: &ty::PolyTraitRef<'tcx>,
+    );
 }
 
 fn predicate_constraint(generics: &hir::Generics<'_>, pred: String) -> (Span, String) {
@@ -1928,8 +1935,9 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
             | ObligationCauseCode::AwaitableExpr(_)
             | ObligationCauseCode::ForLoopIterator
             | ObligationCauseCode::QuestionMark
+            | ObligationCauseCode::CheckAssociatedTypeBounds { .. }
             | ObligationCauseCode::LetElse
-            | ObligationCauseCode::CheckAssociatedTypeBounds { .. } => {}
+            | ObligationCauseCode::BinOp { .. } => {}
             ObligationCauseCode::SliceOrArrayElem => {
                 err.note("slice and array elements must have `Sized` type");
             }
@@ -2511,6 +2519,32 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                     }
                 }
             }
+        }
+    }
+
+    fn suggest_floating_point_literal(
+        &self,
+        obligation: &PredicateObligation<'tcx>,
+        err: &mut DiagnosticBuilder<'_>,
+        trait_ref: &ty::PolyTraitRef<'tcx>,
+    ) {
+        let rhs_span = match obligation.cause.code() {
+            ObligationCauseCode::BinOp { rhs_span: Some(span), is_lit } if *is_lit => span,
+            _ => return,
+        };
+        match (
+            trait_ref.skip_binder().self_ty().kind(),
+            trait_ref.skip_binder().substs.type_at(1).kind(),
+        ) {
+            (ty::Float(_), ty::Infer(InferTy::IntVar(_))) => {
+                err.span_suggestion_verbose(
+                    rhs_span.shrink_to_hi(),
+                    "consider using a floating-point literal by writing it with `.0`",
+                    String::from(".0"),
+                    Applicability::MaybeIncorrect,
+                );
+            }
+            _ => {}
         }
     }
 }

--- a/compiler/rustc_traits/src/chalk/lowering.rs
+++ b/compiler/rustc_traits/src/chalk/lowering.rs
@@ -323,7 +323,10 @@ impl<'tcx> LowerInto<'tcx, chalk_ir::Ty<RustInterner<'tcx>>> for Ty<'tcx> {
             ty::Closure(def_id, substs) => {
                 chalk_ir::TyKind::Closure(chalk_ir::ClosureId(def_id), substs.lower_into(interner))
             }
-            ty::Generator(_def_id, _substs, _) => unimplemented!(),
+            ty::Generator(def_id, substs, _) => chalk_ir::TyKind::Generator(
+                chalk_ir::GeneratorId(def_id),
+                substs.lower_into(interner),
+            ),
             ty::GeneratorWitness(_) => unimplemented!(),
             ty::Never => chalk_ir::TyKind::Never,
             ty::Tuple(types) => {

--- a/compiler/rustc_typeck/src/astconv/generics.rs
+++ b/compiler/rustc_typeck/src/astconv/generics.rs
@@ -512,61 +512,69 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
             explicit_late_bound == ExplicitLateBound::Yes,
         );
 
-        let mut check_types_and_consts =
-            |expected_min, expected_max, provided, params_offset, args_offset| {
-                debug!(
-                    ?expected_min,
-                    ?expected_max,
-                    ?provided,
-                    ?params_offset,
-                    ?args_offset,
-                    "check_types_and_consts"
+        let mut check_types_and_consts = |expected_min,
+                                          expected_max,
+                                          expected_max_with_synth,
+                                          provided,
+                                          params_offset,
+                                          args_offset| {
+            debug!(
+                ?expected_min,
+                ?expected_max,
+                ?provided,
+                ?params_offset,
+                ?args_offset,
+                "check_types_and_consts"
+            );
+            if (expected_min..=expected_max).contains(&provided) {
+                return true;
+            }
+
+            let num_default_params = expected_max - expected_min;
+
+            let gen_args_info = if provided > expected_max {
+                invalid_args.extend(
+                    gen_args.args[args_offset + expected_max..args_offset + provided]
+                        .iter()
+                        .map(|arg| arg.span()),
                 );
-                if (expected_min..=expected_max).contains(&provided) {
-                    return true;
+                let num_redundant_args = provided - expected_max;
+
+                // Provide extra note if synthetic arguments like `impl Trait` are specified.
+                let synth_provided = provided <= expected_max_with_synth;
+
+                GenericArgsInfo::ExcessTypesOrConsts {
+                    num_redundant_args,
+                    num_default_params,
+                    args_offset,
+                    synth_provided,
                 }
+            } else {
+                let num_missing_args = expected_max - provided;
 
-                let num_default_params = expected_max - expected_min;
-
-                let gen_args_info = if provided > expected_max {
-                    invalid_args.extend(
-                        gen_args.args[args_offset + expected_max..args_offset + provided]
-                            .iter()
-                            .map(|arg| arg.span()),
-                    );
-                    let num_redundant_args = provided - expected_max;
-
-                    GenericArgsInfo::ExcessTypesOrConsts {
-                        num_redundant_args,
-                        num_default_params,
-                        args_offset,
-                    }
-                } else {
-                    let num_missing_args = expected_max - provided;
-
-                    GenericArgsInfo::MissingTypesOrConsts {
-                        num_missing_args,
-                        num_default_params,
-                        args_offset,
-                    }
-                };
-
-                debug!(?gen_args_info);
-
-                WrongNumberOfGenericArgs::new(
-                    tcx,
-                    gen_args_info,
-                    seg,
-                    gen_params,
-                    params_offset,
-                    gen_args,
-                    def_id,
-                )
-                .diagnostic()
-                .emit_unless(gen_args.has_err());
-
-                false
+                GenericArgsInfo::MissingTypesOrConsts {
+                    num_missing_args,
+                    num_default_params,
+                    args_offset,
+                }
             };
+
+            debug!(?gen_args_info);
+
+            WrongNumberOfGenericArgs::new(
+                tcx,
+                gen_args_info,
+                seg,
+                gen_params,
+                params_offset,
+                gen_args,
+                def_id,
+            )
+            .diagnostic()
+            .emit_unless(gen_args.has_err());
+
+            false
+        };
 
         let args_correct = {
             let expected_min = if infer_args {
@@ -582,6 +590,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
             check_types_and_consts(
                 expected_min,
                 param_counts.consts + named_type_param_count,
+                param_counts.consts + named_type_param_count + synth_type_param_count,
                 gen_args.num_generic_params(),
                 param_counts.lifetimes + has_self as usize,
                 gen_args.num_lifetime_params(),

--- a/compiler/rustc_typeck/src/check/fn_ctxt/_impl.rs
+++ b/compiler/rustc_typeck/src/check/fn_ctxt/_impl.rs
@@ -429,6 +429,30 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         )
     }
 
+    pub(in super::super) fn normalize_op_associated_types_in_as_infer_ok<T>(
+        &self,
+        span: Span,
+        value: T,
+        opt_input_expr: Option<&hir::Expr<'_>>,
+    ) -> InferOk<'tcx, T>
+    where
+        T: TypeFoldable<'tcx>,
+    {
+        self.inh.partially_normalize_associated_types_in(
+            ObligationCause::new(
+                span,
+                self.body_id,
+                traits::BinOp {
+                    rhs_span: opt_input_expr.map(|expr| expr.span),
+                    is_lit: opt_input_expr
+                        .map_or(false, |expr| matches!(expr.kind, ExprKind::Lit(_))),
+                },
+            ),
+            self.param_env,
+            value,
+        )
+    }
+
     pub fn require_type_meets(
         &self,
         ty: Ty<'tcx>,

--- a/compiler/rustc_typeck/src/lib.rs
+++ b/compiler/rustc_typeck/src/lib.rs
@@ -68,6 +68,7 @@ This API is completely unstable and subject to change.
 #![feature(slice_partition_dedup)]
 #![feature(control_flow_enum)]
 #![feature(hash_drain_filter)]
+#![feature(once_cell)]
 #![recursion_limit = "256"]
 #![cfg_attr(not(bootstrap), allow(rustc::potential_query_instability))]
 

--- a/src/test/ui/chalkify/bugs/async.rs
+++ b/src/test/ui/chalkify/bugs/async.rs
@@ -1,0 +1,9 @@
+// check-fail
+// known-bug
+// compile-flags: -Z chalk --edition=2021
+
+fn main() -> () {}
+
+async fn foo(x: u32) -> u32 {
+    x
+}

--- a/src/test/ui/chalkify/bugs/async.stderr
+++ b/src/test/ui/chalkify/bugs/async.stderr
@@ -1,0 +1,39 @@
+error[E0277]: the trait bound `[static generator@$DIR/async.rs:7:29: 9:2]: Generator<ResumeTy>` is not satisfied
+  --> $DIR/async.rs:7:29
+   |
+LL |   async fn foo(x: u32) -> u32 {
+   |  _____________________________^
+LL | |     x
+LL | | }
+   | |_^ the trait `Generator<ResumeTy>` is not implemented for `[static generator@$DIR/async.rs:7:29: 9:2]`
+   |
+note: required by a bound in `from_generator`
+  --> $SRC_DIR/core/src/future/mod.rs:LL:COL
+   |
+LL |     T: Generator<ResumeTy, Yield = ()>,
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `from_generator`
+
+error[E0280]: the requirement `<[static generator@$DIR/async.rs:7:29: 9:2] as Generator<ResumeTy>>::Yield == ()` is not satisfied
+  --> $DIR/async.rs:7:29
+   |
+LL |   async fn foo(x: u32) -> u32 {
+   |  _____________________________^
+LL | |     x
+LL | | }
+   | |_^
+   |
+note: required by a bound in `from_generator`
+  --> $SRC_DIR/core/src/future/mod.rs:LL:COL
+   |
+LL |     T: Generator<ResumeTy, Yield = ()>,
+   |                            ^^^^^^^^^^ required by this bound in `from_generator`
+
+error[E0280]: the requirement `<impl Future<Output = [async output]> as Future>::Output == u32` is not satisfied
+  --> $DIR/async.rs:7:25
+   |
+LL | async fn foo(x: u32) -> u32 {
+   |                         ^^^
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/impl-trait/explicit-generic-args-with-impl-trait/explicit-generic-args-for-impl.stderr
+++ b/src/test/ui/impl-trait/explicit-generic-args-with-impl-trait/explicit-generic-args-for-impl.stderr
@@ -11,6 +11,7 @@ note: function defined here, with 1 generic parameter: `T`
    |
 LL | fn foo<T: ?Sized>(_f: impl AsRef<T>) {}
    |    ^^^ -
+   = note: `impl Trait` cannot be explicitly specified as a generic argument
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-17904-2.stderr
+++ b/src/test/ui/issues/issue-17904-2.stderr
@@ -5,7 +5,6 @@ LL | struct Foo<T> where T: Copy;
    |            ^ unused parameter
    |
    = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`
-   = help: if you intended `T` to be a const parameter, use `const T: usize` instead
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-24352.stderr
+++ b/src/test/ui/issues/issue-24352.stderr
@@ -5,6 +5,10 @@ LL |     1.0f64 - 1
    |            ^ no implementation for `f64 - {integer}`
    |
    = help: the trait `Sub<{integer}>` is not implemented for `f64`
+help: consider using a floating-point literal by writing it with `.0`
+   |
+LL |     1.0f64 - 1.0
+   |               ++
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-37534.stderr
+++ b/src/test/ui/issues/issue-37534.stderr
@@ -22,7 +22,6 @@ LL | struct Foo<T: ?Hash> { }
    |            ^ unused parameter
    |
    = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`
-   = help: if you intended `T` to be a const parameter, use `const T: usize` instead
 
 error: aborting due to 2 previous errors; 1 warning emitted
 

--- a/src/test/ui/numbers-arithmetic/not-suggest-float-literal.rs
+++ b/src/test/ui/numbers-arithmetic/not-suggest-float-literal.rs
@@ -1,0 +1,53 @@
+fn add_float_to_integer(x: u8) -> f32 {
+    x + 100.0 //~ ERROR cannot add `{float}` to `u8`
+}
+
+fn add_str_to_float(x: f64) -> f64 {
+    x + "foo" //~ ERROR cannot add `&str` to `f64`
+}
+
+fn add_lvar_to_float(x: f64) -> f64 {
+    let y = 3;
+    x + y //~ ERROR cannot add `{integer}` to `f64`
+}
+
+fn subtract_float_from_integer(x: u8) -> f32 {
+    x - 100.0 //~ ERROR cannot subtract `{float}` from `u8`
+}
+
+fn subtract_str_from_f64(x: f64) -> f64 {
+    x - "foo" //~ ERROR cannot subtract `&str` from `f64`
+}
+
+fn subtract_lvar_from_f64(x: f64) -> f64 {
+    let y = 3;
+    x - y //~ ERROR cannot subtract `{integer}` from `f64`
+}
+
+fn multiply_integer_by_float(x: u8) -> f32 {
+    x * 100.0 //~ ERROR cannot multiply `u8` by `{float}`
+}
+
+fn multiply_f64_by_str(x: f64) -> f64 {
+    x * "foo" //~ ERROR cannot multiply `f64` by `&str`
+}
+
+fn multiply_f64_by_lvar(x: f64) -> f64 {
+    let y = 3;
+    x * y //~ ERROR cannot multiply `f64` by `{integer}`
+}
+
+fn divide_integer_by_float(x: u8) -> u8 {
+    x / 100.0 //~ ERROR cannot divide `u8` by `{float}`
+}
+
+fn divide_f64_by_str(x: f64) -> f64 {
+    x / "foo" //~ ERROR cannot divide `f64` by `&str`
+}
+
+fn divide_f64_by_lvar(x: f64) -> f64 {
+    let y = 3;
+    x / y //~ ERROR cannot divide `f64` by `{integer}`
+}
+
+fn main() {}

--- a/src/test/ui/numbers-arithmetic/not-suggest-float-literal.stderr
+++ b/src/test/ui/numbers-arithmetic/not-suggest-float-literal.stderr
@@ -1,0 +1,99 @@
+error[E0277]: cannot add `{float}` to `u8`
+  --> $DIR/not-suggest-float-literal.rs:2:7
+   |
+LL |     x + 100.0
+   |       ^ no implementation for `u8 + {float}`
+   |
+   = help: the trait `Add<{float}>` is not implemented for `u8`
+
+error[E0277]: cannot add `&str` to `f64`
+  --> $DIR/not-suggest-float-literal.rs:6:7
+   |
+LL |     x + "foo"
+   |       ^ no implementation for `f64 + &str`
+   |
+   = help: the trait `Add<&str>` is not implemented for `f64`
+
+error[E0277]: cannot add `{integer}` to `f64`
+  --> $DIR/not-suggest-float-literal.rs:11:7
+   |
+LL |     x + y
+   |       ^ no implementation for `f64 + {integer}`
+   |
+   = help: the trait `Add<{integer}>` is not implemented for `f64`
+
+error[E0277]: cannot subtract `{float}` from `u8`
+  --> $DIR/not-suggest-float-literal.rs:15:7
+   |
+LL |     x - 100.0
+   |       ^ no implementation for `u8 - {float}`
+   |
+   = help: the trait `Sub<{float}>` is not implemented for `u8`
+
+error[E0277]: cannot subtract `&str` from `f64`
+  --> $DIR/not-suggest-float-literal.rs:19:7
+   |
+LL |     x - "foo"
+   |       ^ no implementation for `f64 - &str`
+   |
+   = help: the trait `Sub<&str>` is not implemented for `f64`
+
+error[E0277]: cannot subtract `{integer}` from `f64`
+  --> $DIR/not-suggest-float-literal.rs:24:7
+   |
+LL |     x - y
+   |       ^ no implementation for `f64 - {integer}`
+   |
+   = help: the trait `Sub<{integer}>` is not implemented for `f64`
+
+error[E0277]: cannot multiply `u8` by `{float}`
+  --> $DIR/not-suggest-float-literal.rs:28:7
+   |
+LL |     x * 100.0
+   |       ^ no implementation for `u8 * {float}`
+   |
+   = help: the trait `Mul<{float}>` is not implemented for `u8`
+
+error[E0277]: cannot multiply `f64` by `&str`
+  --> $DIR/not-suggest-float-literal.rs:32:7
+   |
+LL |     x * "foo"
+   |       ^ no implementation for `f64 * &str`
+   |
+   = help: the trait `Mul<&str>` is not implemented for `f64`
+
+error[E0277]: cannot multiply `f64` by `{integer}`
+  --> $DIR/not-suggest-float-literal.rs:37:7
+   |
+LL |     x * y
+   |       ^ no implementation for `f64 * {integer}`
+   |
+   = help: the trait `Mul<{integer}>` is not implemented for `f64`
+
+error[E0277]: cannot divide `u8` by `{float}`
+  --> $DIR/not-suggest-float-literal.rs:41:7
+   |
+LL |     x / 100.0
+   |       ^ no implementation for `u8 / {float}`
+   |
+   = help: the trait `Div<{float}>` is not implemented for `u8`
+
+error[E0277]: cannot divide `f64` by `&str`
+  --> $DIR/not-suggest-float-literal.rs:45:7
+   |
+LL |     x / "foo"
+   |       ^ no implementation for `f64 / &str`
+   |
+   = help: the trait `Div<&str>` is not implemented for `f64`
+
+error[E0277]: cannot divide `f64` by `{integer}`
+  --> $DIR/not-suggest-float-literal.rs:50:7
+   |
+LL |     x / y
+   |       ^ no implementation for `f64 / {integer}`
+   |
+   = help: the trait `Div<{integer}>` is not implemented for `f64`
+
+error: aborting due to 12 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/numbers-arithmetic/suggest-float-literal.fixed
+++ b/src/test/ui/numbers-arithmetic/suggest-float-literal.fixed
@@ -1,0 +1,37 @@
+// run-rustfix
+
+#![allow(dead_code)]
+
+fn add_integer_to_f32(x: f32) -> f32 {
+    x + 100.0 //~ ERROR cannot add `{integer}` to `f32`
+}
+
+fn add_integer_to_f64(x: f64) -> f64 {
+    x + 100.0 //~ ERROR cannot add `{integer}` to `f64`
+}
+
+fn subtract_integer_from_f32(x: f32) -> f32 {
+    x - 100.0 //~ ERROR cannot subtract `{integer}` from `f32`
+}
+
+fn subtract_integer_from_f64(x: f64) -> f64 {
+    x - 100.0 //~ ERROR cannot subtract `{integer}` from `f64`
+}
+
+fn multiply_f32_by_integer(x: f32) -> f32 {
+    x * 100.0 //~ ERROR cannot multiply `f32` by `{integer}`
+}
+
+fn multiply_f64_by_integer(x: f64) -> f64 {
+    x * 100.0 //~ ERROR cannot multiply `f64` by `{integer}`
+}
+
+fn divide_f32_by_integer(x: f32) -> f32 {
+    x / 100.0 //~ ERROR cannot divide `f32` by `{integer}`
+}
+
+fn divide_f64_by_integer(x: f64) -> f64 {
+    x / 100.0 //~ ERROR cannot divide `f64` by `{integer}`
+}
+
+fn main() {}

--- a/src/test/ui/numbers-arithmetic/suggest-float-literal.rs
+++ b/src/test/ui/numbers-arithmetic/suggest-float-literal.rs
@@ -1,0 +1,37 @@
+// run-rustfix
+
+#![allow(dead_code)]
+
+fn add_integer_to_f32(x: f32) -> f32 {
+    x + 100 //~ ERROR cannot add `{integer}` to `f32`
+}
+
+fn add_integer_to_f64(x: f64) -> f64 {
+    x + 100 //~ ERROR cannot add `{integer}` to `f64`
+}
+
+fn subtract_integer_from_f32(x: f32) -> f32 {
+    x - 100 //~ ERROR cannot subtract `{integer}` from `f32`
+}
+
+fn subtract_integer_from_f64(x: f64) -> f64 {
+    x - 100 //~ ERROR cannot subtract `{integer}` from `f64`
+}
+
+fn multiply_f32_by_integer(x: f32) -> f32 {
+    x * 100 //~ ERROR cannot multiply `f32` by `{integer}`
+}
+
+fn multiply_f64_by_integer(x: f64) -> f64 {
+    x * 100 //~ ERROR cannot multiply `f64` by `{integer}`
+}
+
+fn divide_f32_by_integer(x: f32) -> f32 {
+    x / 100 //~ ERROR cannot divide `f32` by `{integer}`
+}
+
+fn divide_f64_by_integer(x: f64) -> f64 {
+    x / 100 //~ ERROR cannot divide `f64` by `{integer}`
+}
+
+fn main() {}

--- a/src/test/ui/numbers-arithmetic/suggest-float-literal.stderr
+++ b/src/test/ui/numbers-arithmetic/suggest-float-literal.stderr
@@ -1,0 +1,99 @@
+error[E0277]: cannot add `{integer}` to `f32`
+  --> $DIR/suggest-float-literal.rs:6:7
+   |
+LL |     x + 100
+   |       ^ no implementation for `f32 + {integer}`
+   |
+   = help: the trait `Add<{integer}>` is not implemented for `f32`
+help: consider using a floating-point literal by writing it with `.0`
+   |
+LL |     x + 100.0
+   |            ++
+
+error[E0277]: cannot add `{integer}` to `f64`
+  --> $DIR/suggest-float-literal.rs:10:7
+   |
+LL |     x + 100
+   |       ^ no implementation for `f64 + {integer}`
+   |
+   = help: the trait `Add<{integer}>` is not implemented for `f64`
+help: consider using a floating-point literal by writing it with `.0`
+   |
+LL |     x + 100.0
+   |            ++
+
+error[E0277]: cannot subtract `{integer}` from `f32`
+  --> $DIR/suggest-float-literal.rs:14:7
+   |
+LL |     x - 100
+   |       ^ no implementation for `f32 - {integer}`
+   |
+   = help: the trait `Sub<{integer}>` is not implemented for `f32`
+help: consider using a floating-point literal by writing it with `.0`
+   |
+LL |     x - 100.0
+   |            ++
+
+error[E0277]: cannot subtract `{integer}` from `f64`
+  --> $DIR/suggest-float-literal.rs:18:7
+   |
+LL |     x - 100
+   |       ^ no implementation for `f64 - {integer}`
+   |
+   = help: the trait `Sub<{integer}>` is not implemented for `f64`
+help: consider using a floating-point literal by writing it with `.0`
+   |
+LL |     x - 100.0
+   |            ++
+
+error[E0277]: cannot multiply `f32` by `{integer}`
+  --> $DIR/suggest-float-literal.rs:22:7
+   |
+LL |     x * 100
+   |       ^ no implementation for `f32 * {integer}`
+   |
+   = help: the trait `Mul<{integer}>` is not implemented for `f32`
+help: consider using a floating-point literal by writing it with `.0`
+   |
+LL |     x * 100.0
+   |            ++
+
+error[E0277]: cannot multiply `f64` by `{integer}`
+  --> $DIR/suggest-float-literal.rs:26:7
+   |
+LL |     x * 100
+   |       ^ no implementation for `f64 * {integer}`
+   |
+   = help: the trait `Mul<{integer}>` is not implemented for `f64`
+help: consider using a floating-point literal by writing it with `.0`
+   |
+LL |     x * 100.0
+   |            ++
+
+error[E0277]: cannot divide `f32` by `{integer}`
+  --> $DIR/suggest-float-literal.rs:30:7
+   |
+LL |     x / 100
+   |       ^ no implementation for `f32 / {integer}`
+   |
+   = help: the trait `Div<{integer}>` is not implemented for `f32`
+help: consider using a floating-point literal by writing it with `.0`
+   |
+LL |     x / 100.0
+   |            ++
+
+error[E0277]: cannot divide `f64` by `{integer}`
+  --> $DIR/suggest-float-literal.rs:34:7
+   |
+LL |     x / 100
+   |       ^ no implementation for `f64 / {integer}`
+   |
+   = help: the trait `Div<{integer}>` is not implemented for `f64`
+help: consider using a floating-point literal by writing it with `.0`
+   |
+LL |     x / 100.0
+   |            ++
+
+error: aborting due to 8 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/variance/variance-unused-type-param.rs
+++ b/src/test/ui/variance/variance-unused-type-param.rs
@@ -16,4 +16,13 @@ enum ListCell<T> {
     Nil
 }
 
+struct WithBounds<T: Sized> {}
+//~^ ERROR parameter `T` is never used
+
+struct WithWhereBounds<T> where T: Sized {}
+//~^ ERROR parameter `T` is never used
+
+struct WithOutlivesBounds<T: 'static> {}
+//~^ ERROR parameter `T` is never used
+
 fn main() {}

--- a/src/test/ui/variance/variance-unused-type-param.stderr
+++ b/src/test/ui/variance/variance-unused-type-param.stderr
@@ -25,6 +25,30 @@ LL | enum ListCell<T> {
    = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`
    = help: if you intended `T` to be a const parameter, use `const T: usize` instead
 
-error: aborting due to 3 previous errors
+error[E0392]: parameter `T` is never used
+  --> $DIR/variance-unused-type-param.rs:19:19
+   |
+LL | struct WithBounds<T: Sized> {}
+   |                   ^ unused parameter
+   |
+   = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`
+
+error[E0392]: parameter `T` is never used
+  --> $DIR/variance-unused-type-param.rs:22:24
+   |
+LL | struct WithWhereBounds<T> where T: Sized {}
+   |                        ^ unused parameter
+   |
+   = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`
+
+error[E0392]: parameter `T` is never used
+  --> $DIR/variance-unused-type-param.rs:25:27
+   |
+LL | struct WithOutlivesBounds<T: 'static> {}
+   |                           ^ unused parameter
+   |
+   = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`
+
+error: aborting due to 6 previous errors
 
 For more information about this error, try `rustc --explain E0392`.

--- a/src/tools/tidy/src/error_codes_check.rs
+++ b/src/tools/tidy/src/error_codes_check.rs
@@ -10,8 +10,8 @@ use regex::Regex;
 
 // A few of those error codes can't be tested but all the others can and *should* be tested!
 const EXEMPTED_FROM_TEST: &[&str] = &[
-    "E0279", "E0280", "E0313", "E0377", "E0461", "E0462", "E0465", "E0476", "E0514", "E0519",
-    "E0523", "E0554", "E0640", "E0717", "E0729",
+    "E0279", "E0313", "E0377", "E0461", "E0462", "E0465", "E0476", "E0514", "E0519", "E0523",
+    "E0554", "E0640", "E0717", "E0729",
 ];
 
 // Some error codes don't have any tests apparently...


### PR DESCRIPTION
Successful merges:

 - #93400 (Do not suggest using a const parameter when there are bounds on an unused type parameter)
 - #93982 (Provide extra note if synthetic type args are specified)
 - #94078 (Suggest a float literal when dividing a floating-point type by `{integer}`)
 - #94087 (Remove unused `unsound_ignore_borrow_on_drop`)
 - #94235 (chalk: Fix wrong debrujin index in opaque type handling.)
 - #94306 (Avoid exhausting stack space in dominator compression)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=93400,93982,94078,94087,94235,94306)
<!-- homu-ignore:end -->