### PR TITLE
create `-Z force-allocator-shim` codegen option

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -299,13 +299,12 @@ fn link_rlib<'a, B: ArchiveBuilder<'a>>(
         }
     }
 
-    match flavor {
-        RlibFlavor::Normal => {}
-        RlibFlavor::StaticlibBase => {
-            let obj = codegen_results.allocator_module.as_ref().and_then(|m| m.object.as_ref());
-            if let Some(obj) = obj {
-                ab.add_file(obj);
-            }
+    if flavor == RlibFlavor::StaticlibBase
+        || sess.opts.debugging_opts.force_allocator_shim.unwrap_or(false)
+    {
+        let obj = codegen_results.allocator_module.as_ref().and_then(|m| m.object.as_ref());
+        if let Some(obj) = obj {
+            ab.add_file(obj);
         }
     }
 

--- a/compiler/rustc_interface/src/tests.rs
+++ b/compiler/rustc_interface/src/tests.rs
@@ -732,6 +732,7 @@ fn test_debugging_options_tracking_hash() {
     tracked!(drop_tracking, true);
     tracked!(dual_proc_macros, true);
     tracked!(fewer_names, Some(true));
+    tracked!(force_allocator_shim, Some(false));
     tracked!(force_unstable_if_unmarked, true);
     tracked!(fuel, Some(("abc".to_string(), 99)));
     tracked!(function_sections, Some(false));

--- a/compiler/rustc_metadata/src/creader.rs
+++ b/compiler/rustc_metadata/src/creader.rs
@@ -809,7 +809,9 @@ impl<'a> CrateLoader<'a> {
         // if our compilation session actually needs an allocator based on what
         // we're emitting.
         let all_rlib = self.sess.crate_types().iter().all(|ct| matches!(*ct, CrateType::Rlib));
-        if all_rlib {
+        let force_allocator_shim =
+            self.sess.opts.debugging_opts.force_allocator_shim.unwrap_or(false);
+        if all_rlib && !force_allocator_shim {
             return;
         }
 

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -1222,6 +1222,8 @@ options! {
     fewer_names: Option<bool> = (None, parse_opt_bool, [TRACKED],
         "reduce memory use by retaining fewer names within compilation artifacts (LLVM-IR) \
         (default: no)"),
+    force_allocator_shim: Option<bool> = (None, parse_opt_bool, [TRACKED],
+        "force generation of an allocator shim"),
     force_unstable_if_unmarked: bool = (false, parse_bool, [TRACKED],
         "force all crates to be `rustc_private` unstable (default: no)"),
     fuel: Option<(String, u64)> = (None, parse_optimization_fuel, [TRACKED],

--- a/src/test/run-make/force-allocator-shim/Makefile
+++ b/src/test/run-make/force-allocator-shim/Makefile
@@ -1,0 +1,12 @@
+-include ../../run-make-fulldeps/tools.mk
+
+# Tests that the `-Z force-allocator-shim` flag causes an allocator shim to be
+# generated when expected.
+
+all:
+	$(RUSTC) foo.rs --crate-type rlib -Z force-allocator-shim
+	nm $(TMPDIR)/libfoo.rlib | $(CGREP) "__rust_alloc" && \
+	nm $(TMPDIR)/libfoo.rlib | $(CGREP) "__rust_alloc_error_handler" && \
+	nm $(TMPDIR)/libfoo.rlib | $(CGREP) "__rust_alloc_zeroed" && \
+	nm $(TMPDIR)/libfoo.rlib | $(CGREP) "__rust_dealloc" && \
+	nm $(TMPDIR)/libfoo.rlib | $(CGREP) "__rust_realloc"

--- a/src/test/run-make/force-allocator-shim/foo.rs
+++ b/src/test/run-make/force-allocator-shim/foo.rs
@@ -1,0 +1,1 @@
+pub fn foo() {}


### PR DESCRIPTION
Related to issue #73632 "Formal support for linking rlibs using a non-Rust linker" - a solution to that issue will involve something like this.

A related PR which has been open since July: https://github.com/rust-lang/rust/pull/86844 "Support #[global_allocator] without the allocator shim" by @bjorn3. It'd suit my needs, but I had mostly finished this before I saw #86844 and thought putting another option up in a PR might spur the discussion forward.

Rust's behavior of bundling dependencies and the standard library into `staticlib` crates makes it difficult to gradually integrate Rust into large pre-existing C++ codebases. Some projects work around that by providing unbundled `rlib`s to their C++ linker, but doing so leaves them without an allocator shim. Issue #73632 discusses how to officially support this use case but a solution will probably still involve something like this PR: a way to generate an allocator shim for more crate types.

### This PR

If `-Z force-allocator-shim` is provided to `rustc` then `rustc` will:
- not skip choosing an `allocator_kind` in `rustc_metadata/src/creader.rs`
  - as a result, allocator shim codegen won't be skipped in `rustc_codegen_ssa/src/base.rs`
- not skip adding the allocator shim CGU to the output archive

Notable TODOs:
- Test coverage / documentation - is there more to do? A way not to use `run-make`?
- Get feedback on the approach / what handling is needed for other crate types

Pointers and feedback greatly appreciated! I'm new to Rust and certainly to `rustc`.

### Compared to PR #86844

PR #86844 would serve this use case by making an allocator shim *unnecessary* if `#[global_allocator]` is declared. `#[global_allocator]` will produce `__rust_alloc` and friends directly, and only if it isn't present will an allocator shim be generated to divert `__rust_alloc` and friends to the corresponding `__rdl_*` functions.

I can't evaluate which approach is nicer. PR #86844 is actually done so it's got a leg up on this PR, but this PR is backend-agnostic and hides the changed behavior behind a command line flag which seem like nice qualities.

There's discussion in issue #73632 about whether `--emit=obj` or emitting an `rlib`-like archive is better for that use case. I think #86844 would work with both strategies while this PR only works with an `rlib`-like archive.

No worries if #86844 is the right way forward - it still solves my problem and the fun I've had so far with this PR is its own reward :)