### PR TITLE
Use 32-bit integer hashing algorithm to avoid the biased swapping in sort_unstable

### DIFF
--- a/library/core/src/slice/sort.rs
+++ b/library/core/src/slice/sort.rs
@@ -606,11 +606,11 @@ fn break_patterns<T>(v: &mut [T]) {
         // See http://burtleburtle.net/bob/hash/integer.html for more algorithm details.
         let mut random = len as u32;
         let mut gen_u32 = || {
-            random -= random << 6;
+            random = random.wrapping_sub(random << 6);
             random ^= random >> 17;
-            random -= random << 9;
+            random = random.wrapping_sub(random << 9);
             random ^= random << 4;
-            random -= random << 3;
+            random = random.wrapping_sub(random << 3);
             random ^= random << 10;
             random ^= random >> 15;
             random

--- a/library/core/src/slice/sort.rs
+++ b/library/core/src/slice/sort.rs
@@ -600,12 +600,19 @@ where
 fn break_patterns<T>(v: &mut [T]) {
     let len = v.len();
     if len >= 8 {
-        // Pseudorandom number generator from the "Xorshift RNGs" paper by George Marsaglia.
+        // Pseudo-random number generator from the 32-bit integer hashing algorithm
+        // to avoid the bias caused by the low entropy of `len` seed.
+        // See https://github.com/rust-lang/rust/issues/74928 for more test results.
+        // See http://burtleburtle.net/bob/hash/integer.html for more algorithm details.
         let mut random = len as u32;
         let mut gen_u32 = || {
-            random ^= random << 13;
+            random -= random << 6;
             random ^= random >> 17;
-            random ^= random << 5;
+            random -= random << 9;
+            random ^= random << 4;
+            random -= random << 3;
+            random ^= random << 10;
+            random ^= random >> 15;
             random
         };
         let mut gen_usize = || {


### PR DESCRIPTION
Signed-off-by: JmPotato <ghzpotato@gmail.com>

Close https://github.com/rust-lang/rust/issues/74928. This PR updates the RNG used by the `break_patterns` to a [32-bit integer hashing algorithm](http://burtleburtle.net/bob/hash/integer.html).

cc @TheIronBorn

I wrote a [benchmark test](https://github.com/JmPotato/rust_playground/blob/bdba4a1f5a55ea128b2a2fb52dbfbeca3caa8f83/benches/sort_unstable_benchmark.rs) to get different versions of `sort_unstable` to run on the same randomly generated dataset. The following criterion output benchmark results show the difference between the changes in this PR and the `rustc 1.61.0-nightly (10cc7a6d0 2022-02-26)` version.

```shell
sort_unstable/length: 25, modulus: 5
                        time:   [232.12 ns 232.22 ns 232.31 ns]
                        change: [+0.8973% +0.9809% +1.0550%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 95 outliers among 5000 measurements (1.90%)
  68 (1.36%) high mild
  27 (0.54%) high severe

sort_unstable/length: 25, modulus: 10
                        time:   [217.90 ns 217.98 ns 218.07 ns]
                        change: [-0.6770% -0.6201% -0.5633%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 153 outliers among 5000 measurements (3.06%)
  88 (1.76%) high mild
  65 (1.30%) high severe

sort_unstable/length: 25, modulus: 100
                        time:   [236.16 ns 236.23 ns 236.29 ns]
                        change: [-0.6861% -0.6373% -0.5879%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 234 outliers among 5000 measurements (4.68%)
  162 (3.24%) high mild
  72 (1.44%) high severe

sort_unstable/length: 25, modulus: 1000
                        time:   [241.44 ns 241.51 ns 241.58 ns]
                        change: [-0.3108% -0.2499% -0.1931%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 403 outliers among 5000 measurements (8.06%)
  3 (0.06%) low severe
  77 (1.54%) low mild
  193 (3.86%) high mild
  130 (2.60%) high severe

sort_unstable/length: 500, modulus: 5
                        time:   [4.6595 us 4.6606 us 4.6617 us]
                        change: [-0.3552% -0.2725% -0.2065%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 426 outliers among 5000 measurements (8.52%)
  294 (5.88%) high mild
  132 (2.64%) high severe

sort_unstable/length: 500, modulus: 10
                        time:   [6.2531 us 6.2546 us 6.2561 us]
                        change: [-1.3431% -1.1181% -0.9313%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 648 outliers among 5000 measurements (12.96%)
  306 (6.12%) high mild
  342 (6.84%) high severe

sort_unstable/length: 500, modulus: 100
                        time:   [9.9634 us 9.9661 us 9.9690 us]
                        change: [-0.3713% -0.2830% -0.2078%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 625 outliers among 5000 measurements (12.50%)
  299 (5.98%) high mild
  326 (6.52%) high severe

sort_unstable/length: 500, modulus: 1000
                        time:   [9.7691 us 9.7710 us 9.7730 us]
                        change: [-0.1566% -0.1237% -0.0913%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 624 outliers among 5000 measurements (12.48%)
  293 (5.86%) high mild
  331 (6.62%) high severe
```