### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/compiler/rustc_ast/src/attr/mod.rs
+++ b/compiler/rustc_ast/src/attr/mod.rs
@@ -75,12 +75,11 @@ impl NestedMetaItem {
     pub fn name_value_literal(&self) -> Option<(Symbol, &Lit)> {
         self.meta_item().and_then(|meta_item| {
             meta_item.meta_item_list().and_then(|meta_item_list| {
-                if meta_item_list.len() == 1 {
-                    if let Some(ident) = meta_item.ident() {
-                        if let Some(lit) = meta_item_list[0].literal() {
-                            return Some((ident.name, lit));
-                        }
-                    }
+                if meta_item_list.len() == 1
+                    && let Some(ident) = meta_item.ident()
+                    && let Some(lit) = meta_item_list[0].literal()
+                {
+                    return Some((ident.name, lit));
                 }
                 None
             })

--- a/compiler/rustc_ast/src/lib.rs
+++ b/compiler/rustc_ast/src/lib.rs
@@ -12,11 +12,12 @@
 #![feature(crate_visibility_modifier)]
 #![feature(if_let_guard)]
 #![feature(label_break_value)]
-#![feature(nll)]
+#![feature(let_chains)]
 #![feature(min_specialization)]
-#![recursion_limit = "256"]
+#![feature(nll)]
 #![feature(slice_internals)]
 #![feature(stmt_expr_attributes)]
+#![recursion_limit = "256"]
 
 #[macro_use]
 extern crate rustc_macros;

--- a/compiler/rustc_ast/src/token.rs
+++ b/compiler/rustc_ast/src/token.rs
@@ -504,10 +504,8 @@ impl Token {
 
     /// Returns `true` if the token is an interpolated path.
     fn is_path(&self) -> bool {
-        if let Interpolated(ref nt) = self.kind {
-            if let NtPath(..) = **nt {
-                return true;
-            }
+        if let Interpolated(ref nt) = self.kind && let NtPath(..) = **nt {
+            return true;
         }
         false
     }
@@ -516,10 +514,10 @@ impl Token {
     /// That is, is this a pre-parsed expression dropped into the token stream
     /// (which happens while parsing the result of macro expansion)?
     pub fn is_whole_expr(&self) -> bool {
-        if let Interpolated(ref nt) = self.kind {
-            if let NtExpr(_) | NtLiteral(_) | NtPath(_) | NtIdent(..) | NtBlock(_) = **nt {
-                return true;
-            }
+        if let Interpolated(ref nt) = self.kind
+            && let NtExpr(_) | NtLiteral(_) | NtPath(_) | NtIdent(..) | NtBlock(_) = **nt
+        {
+            return true;
         }
 
         false
@@ -527,10 +525,8 @@ impl Token {
 
     // Is the token an interpolated block (`$b:block`)?
     pub fn is_whole_block(&self) -> bool {
-        if let Interpolated(ref nt) = self.kind {
-            if let NtBlock(..) = **nt {
-                return true;
-            }
+        if let Interpolated(ref nt) = self.kind && let NtBlock(..) = **nt {
+            return true;
         }
         false
     }

--- a/compiler/rustc_ast/src/util/literal.rs
+++ b/compiler/rustc_ast/src/util/literal.rs
@@ -222,10 +222,10 @@ impl Lit {
             }
             token::Literal(lit) => lit,
             token::Interpolated(ref nt) => {
-                if let token::NtExpr(expr) | token::NtLiteral(expr) = &**nt {
-                    if let ast::ExprKind::Lit(lit) = &expr.kind {
-                        return Ok(lit.clone());
-                    }
+                if let token::NtExpr(expr) | token::NtLiteral(expr) = &**nt
+                    && let ast::ExprKind::Lit(lit) = &expr.kind
+                {
+                    return Ok(lit.clone());
                 }
                 return Err(LitError::NotLiteral);
             }

--- a/compiler/rustc_lint/src/context.rs
+++ b/compiler/rustc_lint/src/context.rs
@@ -166,7 +166,12 @@ impl LintStore {
         self.early_passes.push(Box::new(pass));
     }
 
-    /// Used by clippy.
+    /// This lint pass is softly deprecated. It misses expanded code and has caused a few
+    /// errors in the past. Currently, it is only used in Clippy. New implementations
+    /// should avoid using this interface, as it might be removed in the future.
+    ///
+    /// * See [rust#69838](https://github.com/rust-lang/rust/pull/69838)
+    /// * See [rust-clippy#5518](https://github.com/rust-lang/rust-clippy/pull/5518)
     pub fn register_pre_expansion_pass(
         &mut self,
         pass: impl Fn() -> EarlyLintPassObject + 'static + sync::Send + sync::Sync,

--- a/compiler/rustc_trait_selection/src/traits/auto_trait.rs
+++ b/compiler/rustc_trait_selection/src/traits/auto_trait.rs
@@ -148,7 +148,7 @@ impl<'tcx> AutoTraitFinder<'tcx> {
             // traits::project will see that 'T: SomeTrait' is in our ParamEnv, allowing
             // SelectionContext to return it back to us.
 
-            let (new_env, user_env) = match self.evaluate_predicates(
+            let Some((new_env, user_env)) = self.evaluate_predicates(
                 &infcx,
                 trait_did,
                 ty,
@@ -156,9 +156,8 @@ impl<'tcx> AutoTraitFinder<'tcx> {
                 orig_env,
                 &mut fresh_preds,
                 false,
-            ) {
-                Some(e) => e,
-                None => return AutoTraitResult::NegativeImpl,
+            ) else {
+                return AutoTraitResult::NegativeImpl;
             };
 
             let (full_env, full_user_env) = self

--- a/compiler/rustc_trait_selection/src/traits/coherence.rs
+++ b/compiler/rustc_trait_selection/src/traits/coherence.rs
@@ -335,18 +335,15 @@ fn negative_impl<'cx, 'tcx>(
             impl_trait_ref_and_oblig(selcx, impl1_env, impl2_def_id, impl2_substs);
 
         // do the impls unify? If not, not disjoint.
-        let more_obligations = match infcx
+        let Ok(InferOk { obligations: more_obligations, .. }) = infcx
             .at(&ObligationCause::dummy(), impl1_env)
             .eq(impl1_trait_ref, impl2_trait_ref)
-        {
-            Ok(InferOk { obligations, .. }) => obligations,
-            Err(_) => {
-                debug!(
-                    "explicit_disjoint: {:?} does not unify with {:?}",
-                    impl1_trait_ref, impl2_trait_ref
-                );
-                return false;
-            }
+        else {
+            debug!(
+                "explicit_disjoint: {:?} does not unify with {:?}",
+                impl1_trait_ref, impl2_trait_ref
+            );
+            return false;
         };
 
         let opt_failing_obligation = obligations

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
@@ -801,9 +801,8 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                     return;
                 }
 
-                let found_trait_ty = match found_trait_ref.self_ty().no_bound_vars() {
-                    Some(ty) => ty,
-                    None => return,
+                let Some(found_trait_ty) = found_trait_ref.self_ty().no_bound_vars() else {
+                    return;
                 };
 
                 let found_did = match *found_trait_ty.kind() {
@@ -2115,26 +2114,24 @@ impl<'a, 'tcx> InferCtxtPrivExt<'a, 'tcx> for InferCtxt<'a, 'tcx> {
         err: &mut DiagnosticBuilder<'tcx>,
         obligation: &PredicateObligation<'tcx>,
     ) {
-        let (pred, item_def_id, span) = match (
+        let (
+            ty::PredicateKind::Trait(pred),
+            &ObligationCauseCode::BindingObligation(item_def_id, span),
+        ) = (
             obligation.predicate.kind().skip_binder(),
             obligation.cause.code().peel_derives(),
-        ) {
-            (
-                ty::PredicateKind::Trait(pred),
-                &ObligationCauseCode::BindingObligation(item_def_id, span),
-            ) => (pred, item_def_id, span),
-            _ => return,
+        )  else {
+            return;
         };
         debug!(
             "suggest_unsized_bound_if_applicable: pred={:?} item_def_id={:?} span={:?}",
             pred, item_def_id, span
         );
-        let node = match (
+        let (Some(node), true) = (
             self.tcx.hir().get_if_local(item_def_id),
             Some(pred.def_id()) == self.tcx.lang_items().sized_trait(),
-        ) {
-            (Some(node), true) => node,
-            _ => return,
+        ) else {
+            return;
         };
         self.maybe_suggest_unsized_generics(err, span, node);
     }
@@ -2145,9 +2142,8 @@ impl<'a, 'tcx> InferCtxtPrivExt<'a, 'tcx> for InferCtxt<'a, 'tcx> {
         span: Span,
         node: Node<'hir>,
     ) {
-        let generics = match node.generics() {
-            Some(generics) => generics,
-            None => return,
+        let Some(generics) = node.generics() else {
+            return;
         };
         let sized_trait = self.tcx.lang_items().sized_trait();
         debug!("maybe_suggest_unsized_generics: generics.params={:?}", generics.params);
@@ -2160,9 +2156,8 @@ impl<'a, 'tcx> InferCtxtPrivExt<'a, 'tcx> for InferCtxt<'a, 'tcx> {
                 .iter()
                 .all(|bound| bound.trait_ref().and_then(|tr| tr.trait_def_id()) != sized_trait)
         });
-        let param = match param {
-            Some(param) => param,
-            _ => return,
+        let Some(param) = param else {
+            return;
         };
         let param_def_id = self.tcx.hir().local_def_id(param.hir_id).to_def_id();
         let preds = generics.where_clause.predicates.iter();

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -513,9 +513,8 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
             | ObligationCauseCode::BuiltinDerivedObligation(cause) => cause.parent_trait_pred,
             _ => trait_pred,
         };
-        let real_ty = match real_trait_pred.self_ty().no_bound_vars() {
-            Some(ty) => ty,
-            None => return,
+        let Some(real_ty) = real_trait_pred.self_ty().no_bound_vars() else {
+            return;
         };
 
         if let ty::Ref(region, base_ty, mutbl) = *real_ty.kind() {
@@ -593,9 +592,8 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
         err: &mut DiagnosticBuilder<'_>,
         trait_pred: ty::PolyTraitPredicate<'tcx>,
     ) {
-        let self_ty = match trait_pred.self_ty().no_bound_vars() {
-            None => return,
-            Some(ty) => ty,
+        let Some(self_ty) = trait_pred.self_ty().no_bound_vars() else {
+            return;
         };
 
         let (def_id, output_ty, callable) = match *self_ty.kind() {
@@ -607,9 +605,8 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
 
         // `mk_trait_obligation_with_new_self_ty` only works for types with no escaping bound
         // variables, so bail out if we have any.
-        let output_ty = match output_ty.no_bound_vars() {
-            Some(ty) => ty,
-            None => return,
+        let Some(output_ty) = output_ty.no_bound_vars() else {
+            return;
         };
 
         let new_obligation =
@@ -631,9 +628,8 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                 ..
             })) => {
                 err.span_label(*span, "consider calling this closure");
-                let name = match self.get_closure_name(def_id, err, &msg) {
-                    Some(name) => name,
-                    None => return,
+                let Some(name) = self.get_closure_name(def_id, err, &msg) else {
+                    return;
                 };
                 let args = decl.inputs.iter().map(|_| "_").collect::<Vec<_>>().join(", ");
                 let sugg = format!("({})", args);
@@ -830,9 +826,8 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                 return;
             }
 
-            let mut suggested_ty = match trait_pred.self_ty().no_bound_vars() {
-                Some(ty) => ty,
-                None => return,
+            let Some(mut suggested_ty) = trait_pred.self_ty().no_bound_vars() else {
+                return;
             };
 
             for refs_remaining in 0..refs_number {
@@ -1050,9 +1045,8 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
     fn return_type_span(&self, obligation: &PredicateObligation<'tcx>) -> Option<Span> {
         let hir = self.tcx.hir();
         let parent_node = hir.get_parent_node(obligation.cause.body_id);
-        let sig = match hir.find(parent_node) {
-            Some(hir::Node::Item(hir::Item { kind: hir::ItemKind::Fn(sig, ..), .. })) => sig,
-            _ => return None,
+        let Some(hir::Node::Item(hir::Item { kind: hir::ItemKind::Fn(sig, ..), .. })) = hir.find(parent_node) else {
+            return None;
         };
 
         if let hir::FnRetTy::Return(ret_ty) = sig.decl.output { Some(ret_ty.span) } else { None }
@@ -1502,11 +1496,8 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
 
         // Only continue if a generator was found.
         debug!(?generator, ?trait_ref, ?target_ty, "maybe_note_obligation_cause_for_async_await");
-        let (generator_did, trait_ref, target_ty) = match (generator, trait_ref, target_ty) {
-            (Some(generator_did), Some(trait_ref), Some(target_ty)) => {
-                (generator_did, trait_ref, target_ty)
-            }
-            _ => return false,
+        let (Some(generator_did), Some(trait_ref), Some(target_ty)) = (generator, trait_ref, target_ty) else {
+            return false;
         };
 
         let span = self.tcx.def_span(generator_did);

--- a/compiler/rustc_trait_selection/src/traits/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/mod.rs
@@ -340,19 +340,16 @@ pub fn normalize_param_env_or_error<'tcx>(
         "normalize_param_env_or_error: predicates=(non-outlives={:?}, outlives={:?})",
         predicates, outlives_predicates
     );
-    let non_outlives_predicates = match do_normalize_predicates(
+    let Ok(non_outlives_predicates) = do_normalize_predicates(
         tcx,
         region_context,
         cause.clone(),
         elaborated_env,
         predicates,
-    ) {
-        Ok(predicates) => predicates,
+    ) else {
         // An unnormalized env is better than nothing.
-        Err(ErrorReported) => {
-            debug!("normalize_param_env_or_error: errored resolving non-outlives predicates");
-            return elaborated_env;
-        }
+        debug!("normalize_param_env_or_error: errored resolving non-outlives predicates");
+        return elaborated_env;
     };
 
     debug!("normalize_param_env_or_error: non-outlives predicates={:?}", non_outlives_predicates);
@@ -367,19 +364,16 @@ pub fn normalize_param_env_or_error<'tcx>(
         unnormalized_env.reveal(),
         unnormalized_env.constness(),
     );
-    let outlives_predicates = match do_normalize_predicates(
+    let Ok(outlives_predicates) = do_normalize_predicates(
         tcx,
         region_context,
         cause,
         outlives_env,
         outlives_predicates,
-    ) {
-        Ok(predicates) => predicates,
+    ) else {
         // An unnormalized env is better than nothing.
-        Err(ErrorReported) => {
-            debug!("normalize_param_env_or_error: errored resolving outlives predicates");
-            return elaborated_env;
-        }
+        debug!("normalize_param_env_or_error: errored resolving outlives predicates");
+        return elaborated_env;
     };
     debug!("normalize_param_env_or_error: outlives predicates={:?}", outlives_predicates);
 
@@ -834,9 +828,8 @@ pub fn vtable_trait_upcasting_coercion_new_vptr_slot<'tcx>(
         selcx.select(&obligation).unwrap()
     });
 
-    let implsrc_traitcasting = match implsrc {
-        Some(ImplSource::TraitUpcasting(data)) => data,
-        _ => bug!(),
+    let Some(ImplSource::TraitUpcasting(implsrc_traitcasting)) = implsrc else {
+        bug!();
     };
 
     implsrc_traitcasting.vtable_vptr_slot

--- a/compiler/rustc_trait_selection/src/traits/object_safety.rs
+++ b/compiler/rustc_trait_selection/src/traits/object_safety.rs
@@ -322,11 +322,8 @@ fn trait_has_sized_self(tcx: TyCtxt<'_>, trait_def_id: DefId) -> bool {
 }
 
 fn generics_require_sized_self(tcx: TyCtxt<'_>, def_id: DefId) -> bool {
-    let sized_def_id = match tcx.lang_items().sized_trait() {
-        Some(def_id) => def_id,
-        None => {
-            return false; /* No Sized trait, can't require it! */
-        }
+    let Some(sized_def_id) = tcx.lang_items().sized_trait() else {
+        return false; /* No Sized trait, can't require it! */
     };
 
     // Search for a predicate like `Self : Sized` amongst the trait bounds.

--- a/compiler/rustc_trait_selection/src/traits/project.rs
+++ b/compiler/rustc_trait_selection/src/traits/project.rs
@@ -1832,9 +1832,8 @@ fn confirm_impl_candidate<'cx, 'tcx>(
     let trait_def_id = tcx.trait_id_of_impl(impl_def_id).unwrap();
 
     let param_env = obligation.param_env;
-    let assoc_ty = match assoc_def(selcx, impl_def_id, assoc_item_id) {
-        Ok(assoc_ty) => assoc_ty,
-        Err(ErrorReported) => return Progress { term: tcx.ty_error().into(), obligations: nested },
+    let Ok(assoc_ty) = assoc_def(selcx, impl_def_id, assoc_item_id) else {
+        return Progress { term: tcx.ty_error().into(), obligations: nested };
     };
 
     if !assoc_ty.item.defaultness.has_value() {

--- a/compiler/rustc_trait_selection/src/traits/select/candidate_assembly.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/candidate_assembly.rs
@@ -436,11 +436,8 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         obligation: &TraitObligation<'tcx>,
         candidates: &mut SelectionCandidateSet<'tcx>,
     ) {
-        let kind = match self.tcx().fn_trait_kind_from_lang_item(obligation.predicate.def_id()) {
-            Some(k) => k,
-            None => {
-                return;
-            }
+        let Some(kind) = self.tcx().fn_trait_kind_from_lang_item(obligation.predicate.def_id()) else {
+            return;
         };
 
         // Okay to skip binder because the substs on closure types never
@@ -763,12 +760,9 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         //     T: Trait
         // so it seems ok if we (conservatively) fail to accept that `Unsize`
         // obligation above. Should be possible to extend this in the future.
-        let source = match obligation.self_ty().no_bound_vars() {
-            Some(t) => t,
-            None => {
-                // Don't add any candidates if there are bound regions.
-                return;
-            }
+        let Some(source) = obligation.self_ty().no_bound_vars() else {
+            // Don't add any candidates if there are bound regions.
+            return;
         };
         let target = obligation.predicate.skip_binder().trait_ref.substs.type_at(1);
 

--- a/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
@@ -272,9 +272,8 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             } else {
                 bug!("unexpected builtin trait {:?}", trait_def)
             };
-            let nested = match conditions {
-                BuiltinImplConditions::Where(nested) => nested,
-                _ => bug!("obligation {:?} had matched a builtin impl but now doesn't", obligation),
+            let BuiltinImplConditions::Where(nested) = conditions else {
+                bug!("obligation {:?} had matched a builtin impl but now doesn't", obligation);
             };
 
             let cause = obligation.derived_cause(BuiltinDerivedObligation);
@@ -421,9 +420,8 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         let trait_predicate = self.infcx.replace_bound_vars_with_placeholders(obligation.predicate);
         let self_ty = self.infcx.shallow_resolve(trait_predicate.self_ty());
         let obligation_trait_ref = ty::Binder::dummy(trait_predicate.trait_ref);
-        let data = match *self_ty.kind() {
-            ty::Dynamic(data, ..) => data,
-            _ => span_bug!(obligation.cause.span, "object candidate with non-object"),
+        let ty::Dynamic(data, ..) = *self_ty.kind() else {
+            span_bug!(obligation.cause.span, "object candidate with non-object");
         };
 
         let object_trait_ref = data.principal().unwrap_or_else(|| {
@@ -608,9 +606,8 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         // touch bound regions, they just capture the in-scope
         // type/region parameters.
         let self_ty = self.infcx.shallow_resolve(obligation.self_ty().skip_binder());
-        let (generator_def_id, substs) = match *self_ty.kind() {
-            ty::Generator(id, substs, _) => (id, substs),
-            _ => bug!("closure candidate for non-closure {:?}", obligation),
+        let ty::Generator(generator_def_id, substs, _) = *self_ty.kind() else {
+            bug!("closure candidate for non-closure {:?}", obligation);
         };
 
         debug!(?obligation, ?generator_def_id, ?substs, "confirm_generator_candidate");
@@ -652,9 +649,8 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         // touch bound regions, they just capture the in-scope
         // type/region parameters.
         let self_ty = self.infcx.shallow_resolve(obligation.self_ty().skip_binder());
-        let (closure_def_id, substs) = match *self_ty.kind() {
-            ty::Closure(id, substs) => (id, substs),
-            _ => bug!("closure candidate for non-closure {:?}", obligation),
+        let ty::Closure(closure_def_id, substs) = *self_ty.kind() else {
+            bug!("closure candidate for non-closure {:?}", obligation);
         };
 
         let obligation_predicate = obligation.predicate;

--- a/compiler/rustc_trait_selection/src/traits/specialize/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/specialize/mod.rs
@@ -192,18 +192,15 @@ fn fulfill_implication<'a, 'tcx>(
         impl_trait_ref_and_oblig(selcx, param_env, target_impl, target_substs);
 
     // do the impls unify? If not, no specialization.
-    let more_obligations =
-        match infcx.at(&ObligationCause::dummy(), param_env).eq(source_trait_ref, target_trait_ref)
-        {
-            Ok(InferOk { obligations, .. }) => obligations,
-            Err(_) => {
-                debug!(
-                    "fulfill_implication: {:?} does not unify with {:?}",
-                    source_trait_ref, target_trait_ref
-                );
-                return Err(());
-            }
-        };
+    let Ok(InferOk { obligations: more_obligations, .. }) =
+        infcx.at(&ObligationCause::dummy(), param_env).eq(source_trait_ref, target_trait_ref)
+    else {
+        debug!(
+            "fulfill_implication: {:?} does not unify with {:?}",
+            source_trait_ref, target_trait_ref
+        );
+        return Err(());
+    };
 
     // attempt to prove all of the predicates for impl2 given those for impl1
     // (which are packed up in penv)

--- a/src/test/rustdoc-ui/issue-79465.rs
+++ b/src/test/rustdoc-ui/issue-79465.rs
@@ -1,0 +1,3 @@
+pub fn f1<T>(x: T::A) {}
+//~^ ERROR
+//~^^ ERROR

--- a/src/test/rustdoc-ui/issue-79465.stderr
+++ b/src/test/rustdoc-ui/issue-79465.stderr
@@ -1,0 +1,15 @@
+error[E0220]: associated type `A` not found for `T`
+  --> $DIR/issue-79465.rs:1:20
+   |
+LL | pub fn f1<T>(x: T::A) {}
+   |                    ^ associated type `A` not found
+
+error[E0220]: associated type `A` not found for `T`
+  --> $DIR/issue-79465.rs:1:20
+   |
+LL | pub fn f1<T>(x: T::A) {}
+   |                    ^ associated type `A` not found
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0220`.

--- a/src/test/ui/error-codes/E0081.rs
+++ b/src/test/ui/error-codes/E0081.rs
@@ -10,10 +10,10 @@ enum Enum {
 #[repr(u8)]
 enum EnumOverflowRepr {
     P = 257,
-    //~^ NOTE first use of `1` (overflowed from `257`)
+    //~^ NOTE first use of `255` (overflowed from `257`)
     X = 513,
-    //~^ ERROR discriminant value `1` already exists
-    //~| NOTE enum already has `1` (overflowed from `513`)
+    //~^ ERROR discriminant value `255` already exists
+    //~| NOTE enum already has `255` (overflowed from `513`)
 }
 
 fn main() {

--- a/src/test/ui/error-codes/E0081.stderr
+++ b/src/test/ui/error-codes/E0081.stderr
@@ -7,14 +7,14 @@ LL |
 LL |     X = 3,
    |         ^ enum already has `3`
 
-error[E0081]: discriminant value `1` already exists
+error[E0081]: discriminant value `255` already exists
   --> $DIR/E0081.rs:14:9
    |
 LL |     P = 257,
-   |         --- first use of `1` (overflowed from `257`)
+   |         --- first use of `255` (overflowed from `257`)
 LL |
 LL |     X = 513,
-   |         ^^^ enum already has `1` (overflowed from `513`)
+   |         ^^^ enum already has `255` (overflowed from `513`)
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-94239.rs
+++ b/src/test/ui/issues/issue-94239.rs
@@ -1,0 +1,8 @@
+pub const fn test_match_range(len: usize) -> usize {
+    match len {
+        10000000000000000000..=99999999999999999999 => 0, //~ ERROR literal out of range for `usize`
+        _ => unreachable!(),
+    }
+}
+
+fn main() {}

--- a/src/test/ui/issues/issue-94239.rs
+++ b/src/test/ui/issues/issue-94239.rs
@@ -1,6 +1,6 @@
-pub const fn test_match_range(len: usize) -> usize {
+pub const fn test_match_range(len: u64) -> u64 {
     match len {
-        10000000000000000000..=99999999999999999999 => 0, //~ ERROR literal out of range for `usize`
+        10000000000000000000..=99999999999999999999 => 0, //~ ERROR literal out of range for `u64`
         _ => unreachable!(),
     }
 }

--- a/src/test/ui/issues/issue-94239.stderr
+++ b/src/test/ui/issues/issue-94239.stderr
@@ -1,0 +1,11 @@
+error: literal out of range for `usize`
+  --> $DIR/issue-94239.rs:3:32
+   |
+LL |         10000000000000000000..=99999999999999999999 => 0,
+   |                                ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `#[deny(overflowing_literals)]` on by default
+   = note: the literal `99999999999999999999` does not fit into the type `usize` whose range is `0..=18446744073709551615`
+
+error: aborting due to previous error
+

--- a/src/test/ui/issues/issue-94239.stderr
+++ b/src/test/ui/issues/issue-94239.stderr
@@ -1,11 +1,11 @@
-error: literal out of range for `usize`
+error: literal out of range for `u64`
   --> $DIR/issue-94239.rs:3:32
    |
 LL |         10000000000000000000..=99999999999999999999 => 0,
    |                                ^^^^^^^^^^^^^^^^^^^^
    |
    = note: `#[deny(overflowing_literals)]` on by default
-   = note: the literal `99999999999999999999` does not fit into the type `usize` whose range is `0..=18446744073709551615`
+   = note: the literal `99999999999999999999` does not fit into the type `u64` whose range is `0..=18446744073709551615`
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Successful merges:

 - #94144 (rustc_trait_selection: adopt let else in more places)
 - #94354 (Fix show error message when literal overflows in match patterns)
 - #94397 (Document that pre-expansion lint passes are softly deprecated)
 - #94399 (Add test for #79465 to prevent regression)
 - #94400 (2 - Make more use of `let_chains`)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=94144,94354,94397,94399,94400)
<!-- homu-ignore:end -->