### PR TITLE
Add `with_backlog` functionality to `TcpListener` and `UnixListener`

### DIFF
--- a/library/std/src/net/tcp.rs
+++ b/library/std/src/net/tcp.rs
@@ -710,7 +710,7 @@ impl TcpListener {
     /// Default "backlog" for [`TcpListener::bind`]. See
     /// [`TcpListener::bind_with_backlog`] for an explanation of backlog
     /// values.
-    #[unstable(feature = "bind_with_backlog", issue = "none")]
+    #[unstable(feature = "bind_with_backlog", issue = "94406")]
     pub const DEFAULT_BACKLOG: usize = 128;
 
     /// Creates a new `TcpListener` which will be bound to the specified
@@ -741,7 +741,7 @@ impl TcpListener {
     /// The specified backlog may be larger than supported by the underlying
     /// system. In this case an [`io::Error`] with
     /// [`io::ErrorKind::InvalidData`] will be returned.
-    #[unstable(feature = "bind_with_backlog", issue = "none")]
+    #[unstable(feature = "bind_with_backlog", issue = "94406")]
     pub fn bind_with_backlog<A: ToSocketAddrs>(addr: A, backlog: usize) -> io::Result<TcpListener> {
         super::each_addr(addr, move |a| net_imp::TcpListener::bind_with_backlog(a, backlog))
             .map(TcpListener)

--- a/library/std/src/net/tcp.rs
+++ b/library/std/src/net/tcp.rs
@@ -730,6 +730,7 @@ impl TcpListener {
     /// Creates a TCP listener bound to `127.0.0.1:80` with a backlog of 1000:
     ///
     /// ```no_run
+    /// #![feature(bind_with_backlog)]
     /// use std::net::TcpListener;
     ///
     /// let listener = TcpListener::bind_with_backlog("127.0.0.1:80", 1000).unwrap();

--- a/library/std/src/net/tcp.rs
+++ b/library/std/src/net/tcp.rs
@@ -707,11 +707,8 @@ impl fmt::Debug for TcpStream {
 }
 
 impl TcpListener {
-    /// Default "backlog" for [`TcpListener::bind`]. See
-    /// [`TcpListener::bind_with_backlog`] for an explanation of backlog
-    /// values.
-    #[unstable(feature = "bind_with_backlog", issue = "94406")]
-    pub const DEFAULT_BACKLOG: usize = 128;
+    /// Default listen backlog.
+    const DEFAULT_BACKLOG: usize = 128;
 
     /// Creates a new `TcpListener` which will be bound to the specified
     /// address.
@@ -719,8 +716,7 @@ impl TcpListener {
     /// The given backlog specifies the maximum number of outstanding
     /// connections that will be buffered in the OS waiting to be accepted by
     /// [`TcpListener::accept`]. The backlog argument overrides the default
-    /// specified by [`TcpListener::DEFAULT_BACKLOG`]; that default is
-    /// reasonable for most use cases.
+    /// value of 128; that default is reasonable for most use cases.
     ///
     /// This function is otherwise [`TcpListener::bind`]: see that
     /// documentation for full details of operation.
@@ -751,8 +747,7 @@ impl TcpListener {
     /// address. The returned listener is ready for accepting
     /// connections.
     ///
-    /// The listener will have a backlog given by
-    /// [`TcpListener::DEFAULT_BACKLOG`]. See the documentation for
+    /// The listener will have a backlog of 128.  See the documentation for
     /// [`TcpListener::bind_with_backlog`] for further information.
     ///
     /// Binding with a port number of 0 will request that the OS assigns a port

--- a/library/std/src/os/unix/net/listener.rs
+++ b/library/std/src/os/unix/net/listener.rs
@@ -98,6 +98,7 @@ impl UnixListener {
     /// # Examples
     ///
     /// ```no_run
+    /// #![feature(bind_with_backlog)]
     /// use std::os::unix::net::UnixListener;
     ///
     /// let listener = match UnixListener::bind_with_backlog("/path/to/the/socket", 1000) {

--- a/library/std/src/os/unix/net/listener.rs
+++ b/library/std/src/os/unix/net/listener.rs
@@ -54,16 +54,12 @@ impl fmt::Debug for UnixListener {
 }
 
 impl UnixListener {
-    /// Default "backlog" for [`UnixListener::bind`] and
-    /// [`UnixListener::bind_addr`]. See [`UnixListener::bind_with_backlog`]
-    /// for an explanation of backlog values.
-    #[unstable(feature = "bind_with_backlog", issue = "94406")]
-    pub const DEFAULT_BACKLOG: usize = 128;
+    /// Default backlog for `bind` and `bind_addr`.
+    const DEFAULT_BACKLOG: usize = 128;
 
     /// Creates a new `UnixListener` bound to the specified socket.
     ///
-    /// The listener will have a backlog given by
-    /// [`UnixListener::DEFAULT_BACKLOG`]. See the documentation for
+    /// The listener will have a backlog of 128. See the documentation for
     /// [`UnixListener::bind_with_backlog`] for further information.
     ///
     /// # Examples
@@ -87,10 +83,10 @@ impl UnixListener {
     /// Creates a new `UnixListener` bound to the specified socket.
     ///
     /// The given backlog specifies the maximum number of outstanding
-    /// connections that will be buffered in the OS waiting to be accepted by
-    /// [`UnixListener::accept`]. The backlog argument overrides the default
-    /// specified by [`UnixListener::DEFAULT_BACKLOG`]; that default is
-    /// reasonable for most use cases.
+    /// connections that will be buffered in the OS waiting to be accepted
+    /// by [`UnixListener::accept`]. The backlog argument overrides the
+    /// default backlog of 128; that default is reasonable for most use
+    /// cases.
     ///
     /// This function is otherwise [`UnixListener::bind`]: see that
     /// documentation for full details of operation.
@@ -133,6 +129,9 @@ impl UnixListener {
 
     /// Creates a new `UnixListener` bound to the specified [`socket address`].
     ///
+    /// The listener will have a backlog of 128. See the documentation for
+    /// [`UnixListener::bind_addr_with_backlog`] for further information.
+    ///
     /// [`socket address`]: crate::os::unix::net::SocketAddr
     ///
     /// # Examples
@@ -163,10 +162,9 @@ impl UnixListener {
     /// Creates a new `UnixListener` bound to the specified [`socket address`].
     ///
     /// The given backlog specifies the maximum number of outstanding
-    /// connections that will be buffered in the OS waiting to be accepted by
-    /// [`UnixListener::accept`]. The backlog argument overrides the default
-    /// specified by [`UnixListener::DEFAULT_BACKLOG`]; that default is
-    /// reasonable for most use cases.
+    /// connections that will be buffered in the OS waiting to be accepted
+    /// by [`UnixListener::accept`]. The backlog argument overrides the
+    /// default of 128; that default is reasonable for most use cases.
     ///
     /// This function is otherwise [`UnixListener::bind_addr`]: see that
     /// documentation for full details of operation.

--- a/library/std/src/os/unix/net/listener.rs
+++ b/library/std/src/os/unix/net/listener.rs
@@ -57,7 +57,7 @@ impl UnixListener {
     /// Default "backlog" for [`UnixListener::bind`] and
     /// [`UnixListener::bind_addr`]. See [`UnixListener::bind_with_backlog`]
     /// for an explanation of backlog values.
-    #[unstable(feature = "bind_with_backlog", issue = "none")]
+    #[unstable(feature = "bind_with_backlog", issue = "94406")]
     pub const DEFAULT_BACKLOG: usize = 128;
 
     /// Creates a new `UnixListener` bound to the specified socket.
@@ -115,7 +115,7 @@ impl UnixListener {
     /// The specified backlog may be larger than supported by the underlying
     /// system. In this case an [`io::Error`] with
     /// [`io::ErrorKind::InvalidData`] will be returned.
-    #[unstable(feature = "bind_with_backlog", issue = "none")]
+    #[unstable(feature = "bind_with_backlog", issue = "94406")]
     pub fn bind_with_backlog<P: AsRef<Path>>(path: P, backlog: usize) -> io::Result<UnixListener> {
         unsafe {
             let backlog = backlog
@@ -195,7 +195,7 @@ impl UnixListener {
     /// }
     /// ```
     //#[unstable(feature = "unix_socket_abstract", issue = "85410")]
-    #[unstable(feature = "bind_with_backlog", issue = "none")]
+    #[unstable(feature = "bind_with_backlog", issue = "94406")]
     pub fn bind_addr_with_backlog(
         socket_addr: &SocketAddr,
         backlog: usize,

--- a/library/std/src/os/unix/net/tests.rs
+++ b/library/std/src/os/unix/net/tests.rs
@@ -41,7 +41,7 @@ fn basic() {
     let msg1 = b"hello";
     let msg2 = b"world!";
 
-    let listener = or_panic!(UnixListener::bind(&socket_path));
+    let listener = or_panic!(UnixListener::bind_with_backlog(&socket_path, 1));
     let thread = thread::spawn(move || {
         let mut stream = or_panic!(listener.accept()).0;
         let mut buf = [0; 5];
@@ -111,7 +111,7 @@ fn try_clone() {
     let msg1 = b"hello";
     let msg2 = b"world";
 
-    let listener = or_panic!(UnixListener::bind(&socket_path));
+    let listener = or_panic!(UnixListener::bind_with_backlog(&socket_path, 1));
     let thread = thread::spawn(move || {
         let mut stream = or_panic!(listener.accept()).0;
         or_panic!(stream.write_all(msg1));
@@ -135,7 +135,7 @@ fn iter() {
     let dir = tmpdir();
     let socket_path = dir.path().join("sock");
 
-    let listener = or_panic!(UnixListener::bind(&socket_path));
+    let listener = or_panic!(UnixListener::bind_with_backlog(&socket_path, 2));
     let thread = thread::spawn(move || {
         for stream in listener.incoming().take(2) {
             let mut stream = or_panic!(stream);
@@ -423,7 +423,7 @@ fn test_abstract_stream_connect() {
     let msg2 = b"world";
 
     let socket_addr = or_panic!(SocketAddr::from_abstract_namespace(b"namespace"));
-    let listener = or_panic!(UnixListener::bind_addr(&socket_addr));
+    let listener = or_panic!(UnixListener::bind_addr_with_backlog(&socket_addr, 1));
 
     let thread = thread::spawn(move || {
         let mut stream = or_panic!(listener.accept()).0;
@@ -451,7 +451,7 @@ fn test_abstract_stream_connect() {
 #[test]
 fn test_abstract_stream_iter() {
     let addr = or_panic!(SocketAddr::from_abstract_namespace(b"hidden"));
-    let listener = or_panic!(UnixListener::bind_addr(&addr));
+    let listener = or_panic!(UnixListener::bind_addr_with_backlog(&addr, 2));
 
     let thread = thread::spawn(move || {
         for stream in listener.incoming().take(2) {

--- a/library/std/src/sys/unix/l4re.rs
+++ b/library/std/src/sys/unix/l4re.rs
@@ -276,6 +276,10 @@ pub mod net {
             unimpl!();
         }
 
+        pub fn bind_with_backlog(_: io::Result<&SocketAddr>, _: usize) -> io::Result<TcpListener> {
+            unimpl!();
+        }
+
         pub fn socket(&self) -> &Socket {
             &self.inner
         }

--- a/library/std/src/sys/unsupported/net.rs
+++ b/library/std/src/sys/unsupported/net.rs
@@ -122,6 +122,10 @@ impl TcpListener {
         unsupported()
     }
 
+    pub fn bind_with_backlog(_: io::Result<&SocketAddr>, _: usize) -> io::Result<TcpListener> {
+        unsupported()
+    }
+
     pub fn socket_addr(&self) -> io::Result<SocketAddr> {
         self.0
     }

--- a/library/std/src/sys/wasi/net.rs
+++ b/library/std/src/sys/wasi/net.rs
@@ -205,6 +205,10 @@ impl TcpListener {
         unsupported()
     }
 
+    pub fn bind_with_backlog(_: io::Result<&SocketAddr>, _: usize) -> io::Result<TcpListener> {
+        unsupported()
+    }
+
     pub fn socket_addr(&self) -> io::Result<SocketAddr> {
         unsupported()
     }

--- a/library/std/src/sys_common/net.rs
+++ b/library/std/src/sys_common/net.rs
@@ -363,8 +363,16 @@ pub struct TcpListener {
 }
 
 impl TcpListener {
-    pub fn bind(addr: io::Result<&SocketAddr>) -> io::Result<TcpListener> {
+    pub fn bind_with_backlog(
+        addr: io::Result<&SocketAddr>,
+        backlog: usize,
+    ) -> io::Result<TcpListener> {
         let addr = addr?;
+
+        // Type-convert the backlog
+        let backlog = backlog
+            .try_into()
+            .map_err(|e| crate::io::Error::new(crate::io::ErrorKind::InvalidData, e))?;
 
         init();
 
@@ -385,7 +393,7 @@ impl TcpListener {
         cvt(unsafe { c::bind(sock.as_raw(), addrp, len as _) })?;
 
         // Start listening
-        cvt(unsafe { c::listen(sock.as_raw(), 128) })?;
+        cvt(unsafe { c::listen(sock.as_raw(), backlog) })?;
         Ok(TcpListener { inner: sock })
     }
 


### PR DESCRIPTION
Adds

* `std::net::TcpListener::DEFAULT_BACKLOG`
* `std::net::TcpListener::bind_with_backlog`
* `std::os::unix::net::UnixListener::DEFAULT_BACKLOG`
* `std::os::unix::net::UnixListener::bind_with_backlog`
* `std::os::unix::net::UnixListener::bind_addr_with_backlog`

Closes #94406