### PR TITLE
Draft: Miri/CTFE engine: Unions are not scalar

### DIFF
--- a/compiler/rustc_const_eval/src/const_eval/eval_queries.rs
+++ b/compiler/rustc_const_eval/src/const_eval/eval_queries.rs
@@ -118,8 +118,9 @@ pub(super) fn op_to_const<'tcx>(
     // instead allow `ConstValue::Scalar` to store `ScalarMaybeUninit`, but that would affect all
     // the usual cases of extracting e.g. a `usize`, without there being a real use case for the
     // `Undef` situation.
+    // FIXME: This is all a horrible hack and should go away once we are properly using valtrees.
     let try_as_immediate = match op.layout.abi {
-        Abi::Scalar(..) => true,
+        Abi::Scalar(..) if crate::interpret::type_is_scalar(ecx.tcx.tcx, op.layout.ty) => true,
         Abi::ScalarPair(..) => match op.layout.ty.kind() {
             ty::Ref(_, inner, _) => match *inner.kind() {
                 ty::Slice(elem) => elem == ecx.tcx.types.u8,

--- a/compiler/rustc_const_eval/src/interpret/mod.rs
+++ b/compiler/rustc_const_eval/src/interpret/mod.rs
@@ -30,4 +30,5 @@ pub use self::validity::{CtfeValidationMode, RefTracking};
 pub use self::visitor::{MutValueVisitor, ValueVisitor};
 
 crate use self::intrinsics::eval_nullary_intrinsic;
+crate use self::operand::type_is_scalar;
 use eval_context::{from_known_layout, mir_assign_valid_types};

--- a/compiler/rustc_const_eval/src/interpret/operand.rs
+++ b/compiler/rustc_const_eval/src/interpret/operand.rs
@@ -281,9 +281,7 @@ pub(crate) fn type_is_scalar<'tcx>(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>) -> bool {
         // FIXME: can these ever have Scalar ABI?
         ty::Closure(..) | ty::Generator(..) => false,
         // Types that don't have scalar layout to begin with.
-        ty::Array(..) | ty::Slice(..) | ty::Str | ty::Dynamic(..) | ty::Foreign(..) => {
-            false
-        }
+        ty::Array(..) | ty::Slice(..) | ty::Str | ty::Dynamic(..) | ty::Foreign(..) => false,
         // Types we should not uusally see here, but when called from CTFE op_to_const these can
         // actually happen.
         ty::Error(_)

--- a/src/test/ui/consts/issue-69488.rs
+++ b/src/test/ui/consts/issue-69488.rs
@@ -1,0 +1,33 @@
+// run-pass
+
+#![feature(const_ptr_write)]
+#![feature(const_fn_trait_bound)]
+#![feature(const_mut_refs)]
+
+// Or, equivalently: `MaybeUninit`.
+pub union BagOfBits<T: Copy> {
+    uninit: (),
+    _storage: T,
+}
+
+pub const fn make_1u8_bag<T: Copy>() -> BagOfBits<T> {
+    assert!(core::mem::size_of::<T>() >= 1);
+    let mut bag = BagOfBits { uninit: () };
+    unsafe { (&mut bag as *mut _ as *mut u8).write(1); };
+    bag
+}
+
+pub fn check_bag<T: Copy>(bag: &BagOfBits<T>) {
+    let val = unsafe { (bag as *const _ as *const u8).read() };
+    assert_eq!(val, 1);
+}
+
+fn main() {
+    check_bag(&make_1u8_bag::<[usize; 1]>()); // Fine
+    check_bag(&make_1u8_bag::<usize>()); // Fine
+
+    const CONST_ARRAY_BAG: BagOfBits<[usize; 1]> = make_1u8_bag();
+    check_bag(&CONST_ARRAY_BAG); // Fine.
+    const CONST_USIZE_BAG: BagOfBits<usize> = make_1u8_bag();
+    check_bag(&CONST_USIZE_BAG); // Panics
+}

--- a/src/test/ui/consts/issue-94371.rs
+++ b/src/test/ui/consts/issue-94371.rs
@@ -1,0 +1,16 @@
+// check-pass
+
+#![feature(const_swap)]
+#![feature(const_mut_refs)]
+
+#[repr(C)]
+struct Demo(u64, bool, u64, u32, u64, u64, u64);
+
+const C: (Demo, Demo) = {
+    let mut x = Demo(1, true, 3, 4, 5, 6, 7);
+    let mut y = Demo(10, false, 12, 13, 14, 15, 16);
+    std::mem::swap(&mut x, &mut y);
+    (x, y)
+};
+
+fn main() {}


### PR DESCRIPTION
To fix https://github.com/rust-lang/rust/issues/69488 and by extension https://github.com/rust-lang/rust/issues/94371, we should stop treating types like `MaybeUninit<usize>` as something that the `Scalar` type in the interpreter engine can represent. So we add a new test `type_is_scalar` which checks if a type can be represented as a `Scalar`.

This is a draft since it still ICEs in Miri, but I need help figuring out the best way to avoid that.

r? @oli-obk 