### PR TITLE
Fix duplicated impl links

### DIFF
--- a/src/test/rustdoc/issue-78701.rs
+++ b/src/test/rustdoc/issue-78701.rs
@@ -1,0 +1,20 @@
+#![crate_name = "foo"]
+
+// This test ensures that if a blanket impl has the same ID as another impl, it'll
+// link to the blanket impl and not the other impl. Basically, we're checking if
+// the ID is correctly derived.
+
+// @has 'foo/struct.AnotherStruct.html'
+// @count - '//*[@class="sidebar"]//a[@href="#impl-AnAmazingTrait"]' 1
+// @count - '//*[@class="sidebar"]//a[@href="#impl-AnAmazingTrait-1"]' 1
+
+pub trait Something {}
+
+pub trait AnAmazingTrait {}
+
+impl<T: Something> AnAmazingTrait for T {}
+
+pub struct AnotherStruct<T>(T);
+
+impl<T: Something> Something for AnotherStruct<T> {}
+impl AnAmazingTrait for AnotherStruct<()> {}


### PR DESCRIPTION
Fixes #78701.

The problem is that the blanket impl has the same ID as the other impl, except that we don't derive IDs when we generate the sidebar. We now do.

r? @notriddle 