### PR TITLE
Rollup of 9 pull requests

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
@@ -1921,17 +1921,16 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                 err.span_label(assigned_span, format!("first assignment to {}", place_description));
             }
         }
-        if let Some(decl) = local_decl {
-            if let Some(name) = local_name {
-                if decl.can_be_made_mutable() {
-                    err.span_suggestion(
-                        decl.source_info.span,
-                        "consider making this binding mutable",
-                        format!("mut {}", name),
-                        Applicability::MachineApplicable,
-                    );
-                }
-            }
+        if let Some(decl) = local_decl
+            && let Some(name) = local_name
+            && decl.can_be_made_mutable()
+        {
+            err.span_suggestion(
+                decl.source_info.span,
+                "consider making this binding mutable",
+                format!("mut {}", name),
+                Applicability::MachineApplicable,
+            );
         }
         err.span_label(span, msg);
         self.buffer_error(err);

--- a/compiler/rustc_borrowck/src/diagnostics/explain_borrow.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/explain_borrow.rs
@@ -375,15 +375,12 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
 
             Some(Cause::DropVar(local, location)) => {
                 let mut should_note_order = false;
-                if self.local_names[local].is_some() {
-                    if let Some((WriteKind::StorageDeadOrDrop, place)) = kind_place {
-                        if let Some(borrowed_local) = place.as_local() {
-                            if self.local_names[borrowed_local].is_some() && local != borrowed_local
-                            {
-                                should_note_order = true;
-                            }
-                        }
-                    }
+                if self.local_names[local].is_some()
+                    && let Some((WriteKind::StorageDeadOrDrop, place)) = kind_place
+                    && let Some(borrowed_local) = place.as_local()
+                    && self.local_names[borrowed_local].is_some() && local != borrowed_local
+                {
+                    should_note_order = true;
                 }
 
                 BorrowExplanation::UsedLaterWhenDropped {

--- a/compiler/rustc_borrowck/src/diagnostics/region_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/region_errors.rs
@@ -140,14 +140,11 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
 
     /// Returns `true` if a closure is inferred to be an `FnMut` closure.
     fn is_closure_fn_mut(&self, fr: RegionVid) -> bool {
-        if let Some(ty::ReFree(free_region)) = self.to_error_region(fr).as_deref() {
-            if let ty::BoundRegionKind::BrEnv = free_region.bound_region {
-                if let DefiningTy::Closure(_, substs) =
-                    self.regioncx.universal_regions().defining_ty
-                {
-                    return substs.as_closure().kind() == ty::ClosureKind::FnMut;
-                }
-            }
+        if let Some(ty::ReFree(free_region)) = self.to_error_region(fr).as_deref()
+            && let ty::BoundRegionKind::BrEnv = free_region.bound_region
+            && let DefiningTy::Closure(_, substs) = self.regioncx.universal_regions().defining_ty
+        {
+            return substs.as_closure().kind() == ty::ClosureKind::FnMut;
         }
 
         false

--- a/compiler/rustc_borrowck/src/lib.rs
+++ b/compiler/rustc_borrowck/src/lib.rs
@@ -1,15 +1,16 @@
 //! This query borrow-checks the MIR to (further) ensure it is not broken.
 
+#![allow(rustc::potential_query_instability)]
 #![feature(bool_to_option)]
 #![feature(box_patterns)]
 #![feature(crate_visibility_modifier)]
+#![feature(let_chains)]
 #![feature(let_else)]
 #![feature(min_specialization)]
 #![feature(stmt_expr_attributes)]
 #![feature(trusted_step)]
 #![feature(try_blocks)]
 #![recursion_limit = "256"]
-#![allow(rustc::potential_query_instability)]
 
 #[macro_use]
 extern crate rustc_middle;
@@ -159,16 +160,14 @@ fn do_mir_borrowck<'a, 'tcx>(
     for var_debug_info in &input_body.var_debug_info {
         if let VarDebugInfoContents::Place(place) = var_debug_info.value {
             if let Some(local) = place.as_local() {
-                if let Some(prev_name) = local_names[local] {
-                    if var_debug_info.name != prev_name {
-                        span_bug!(
-                            var_debug_info.source_info.span,
-                            "local {:?} has many names (`{}` vs `{}`)",
-                            local,
-                            prev_name,
-                            var_debug_info.name
-                        );
-                    }
+                if let Some(prev_name) = local_names[local] && var_debug_info.name != prev_name {
+                    span_bug!(
+                        var_debug_info.source_info.span,
+                        "local {:?} has many names (`{}` vs `{}`)",
+                        local,
+                        prev_name,
+                        var_debug_info.name
+                    );
                 }
                 local_names[local] = Some(var_debug_info.name);
             }

--- a/compiler/rustc_borrowck/src/places_conflict.rs
+++ b/compiler/rustc_borrowck/src/places_conflict.rs
@@ -60,10 +60,8 @@ pub(super) fn borrow_conflicts_with_place<'tcx>(
 
     // This Local/Local case is handled by the more general code below, but
     // it's so common that it's a speed win to check for it first.
-    if let Some(l1) = borrow_place.as_local() {
-        if let Some(l2) = access_place.as_local() {
-            return l1 == l2;
-        }
+    if let Some(l1) = borrow_place.as_local() && let Some(l2) = access_place.as_local() {
+        return l1 == l2;
     }
 
     place_components_conflict(tcx, body, borrow_place, borrow_kind, access_place, access, bias)

--- a/compiler/rustc_interface/src/util.rs
+++ b/compiler/rustc_interface/src/util.rs
@@ -236,13 +236,9 @@ pub fn get_codegen_backend(
     static LOAD: SyncOnceCell<unsafe fn() -> Box<dyn CodegenBackend>> = SyncOnceCell::new();
 
     let load = LOAD.get_or_init(|| {
-        #[cfg(feature = "llvm")]
-        const DEFAULT_CODEGEN_BACKEND: &str = "llvm";
+        let default_codegen_backend = option_env!("CFG_DEFAULT_CODEGEN_BACKEND").unwrap_or("llvm");
 
-        #[cfg(not(feature = "llvm"))]
-        const DEFAULT_CODEGEN_BACKEND: &str = "cranelift";
-
-        match backend_name.unwrap_or(DEFAULT_CODEGEN_BACKEND) {
+        match backend_name.unwrap_or(default_codegen_backend) {
             filename if filename.contains('.') => load_backend_from_dylib(filename.as_ref()),
             #[cfg(feature = "llvm")]
             "llvm" => rustc_codegen_llvm::LlvmCodegenBackend::new,

--- a/compiler/rustc_lint/src/context.rs
+++ b/compiler/rustc_lint/src/context.rs
@@ -166,7 +166,12 @@ impl LintStore {
         self.early_passes.push(Box::new(pass));
     }
 
-    /// Used by clippy.
+    /// This lint pass is softly deprecated. It misses expanded code and has caused a few
+    /// errors in the past. Currently, it is only used in Clippy. New implementations
+    /// should avoid using this interface, as it might be removed in the future.
+    ///
+    /// * See [rust#69838](https://github.com/rust-lang/rust/pull/69838)
+    /// * See [rust-clippy#5518](https://github.com/rust-lang/rust-clippy/pull/5518)
     pub fn register_pre_expansion_pass(
         &mut self,
         pass: impl Fn() -> EarlyLintPassObject + 'static + sync::Send + sync::Sync,

--- a/compiler/rustc_typeck/src/astconv/mod.rs
+++ b/compiler/rustc_typeck/src/astconv/mod.rs
@@ -1054,12 +1054,11 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
         let mut result = Vec::new();
 
         for ast_bound in ast_bounds {
-            if let Some(trait_ref) = ast_bound.trait_ref() {
-                if let Some(trait_did) = trait_ref.trait_def_id() {
-                    if self.tcx().trait_may_define_assoc_type(trait_did, assoc_name) {
-                        result.push(ast_bound.clone());
-                    }
-                }
+            if let Some(trait_ref) = ast_bound.trait_ref()
+                && let Some(trait_did) = trait_ref.trait_def_id()
+                && self.tcx().trait_may_define_assoc_type(trait_did, assoc_name)
+            {
+                result.push(ast_bound.clone());
             }
         }
 

--- a/compiler/rustc_typeck/src/check/check.rs
+++ b/compiler/rustc_typeck/src/check/check.rs
@@ -282,13 +282,12 @@ pub(super) fn check_fn<'a, 'tcx>(
                         sess.span_err(decl.inputs[0].span, "argument should be `&PanicInfo`");
                     }
 
-                    if let Node::Item(item) = hir.get(fn_id) {
-                        if let ItemKind::Fn(_, ref generics, _) = item.kind {
-                            if !generics.params.is_empty() {
+                    if let Node::Item(item) = hir.get(fn_id)
+                        && let ItemKind::Fn(_, ref generics, _) = item.kind
+                        && !generics.params.is_empty()
+                    {
                                 sess.span_err(span, "should have no type parameters");
                             }
-                        }
-                    }
                 } else {
                     let span = sess.source_map().guess_head_span(span);
                     sess.span_err(span, "function should have one argument");
@@ -319,17 +318,15 @@ pub(super) fn check_fn<'a, 'tcx>(
                         sess.span_err(decl.inputs[0].span, "argument should be `Layout`");
                     }
 
-                    if let Node::Item(item) = hir.get(fn_id) {
-                        if let ItemKind::Fn(_, ref generics, _) = item.kind {
-                            if !generics.params.is_empty() {
+                    if let Node::Item(item) = hir.get(fn_id)
+                        && let ItemKind::Fn(_, ref generics, _) = item.kind
+                        && !generics.params.is_empty()
+                    {
                                 sess.span_err(
                                     span,
-                                    "`#[alloc_error_handler]` function should have no type \
-                                     parameters",
+                            "`#[alloc_error_handler]` function should have no type parameters",
                                 );
                             }
-                        }
-                    }
                 } else {
                     let span = sess.source_map().guess_head_span(span);
                     sess.span_err(span, "function should have one argument");
@@ -1146,9 +1143,10 @@ pub(super) fn check_packed(tcx: TyCtxt<'_>, sp: Span, def: &ty::AdtDef) {
     if repr.packed() {
         for attr in tcx.get_attrs(def.did).iter() {
             for r in attr::find_repr_attrs(&tcx.sess, attr) {
-                if let attr::ReprPacked(pack) = r {
-                    if let Some(repr_pack) = repr.pack {
-                        if pack as u64 != repr_pack.bytes() {
+                if let attr::ReprPacked(pack) = r
+                    && let Some(repr_pack) = repr.pack
+                    && pack as u64 != repr_pack.bytes()
+                {
                             struct_span_err!(
                                 tcx.sess,
                                 sp,
@@ -1156,8 +1154,6 @@ pub(super) fn check_packed(tcx: TyCtxt<'_>, sp: Span, def: &ty::AdtDef) {
                                 "type has conflicting packed representation hints"
                             )
                             .emit();
-                        }
-                    }
                 }
             }
         }
@@ -1399,12 +1395,11 @@ fn display_discriminant_value<'tcx>(
 ) -> String {
     if let Some(expr) = &variant.disr_expr {
         let body = &tcx.hir().body(expr.body).value;
-        if let hir::ExprKind::Lit(lit) = &body.kind {
-            if let rustc_ast::LitKind::Int(lit_value, _int_kind) = &lit.node {
-                if evaluated != *lit_value {
+        if let hir::ExprKind::Lit(lit) = &body.kind
+            && let rustc_ast::LitKind::Int(lit_value, _int_kind) = &lit.node
+            && evaluated != *lit_value
+        {
                     return format!("`{}` (overflowed from `{}`)", evaluated, lit_value);
-                }
-            }
         }
     }
     format!("`{}`", evaluated)

--- a/compiler/rustc_typeck/src/check/coercion.rs
+++ b/compiler/rustc_typeck/src/check/coercion.rs
@@ -1696,13 +1696,12 @@ impl<'tcx, 'exprs, E: AsCoercionSite> CoerceMany<'tcx, 'exprs, E> {
     }
 
     fn is_return_ty_unsized<'a>(&self, fcx: &FnCtxt<'a, 'tcx>, blk_id: hir::HirId) -> bool {
-        if let Some((fn_decl, _)) = fcx.get_fn_decl(blk_id) {
-            if let hir::FnRetTy::Return(ty) = fn_decl.output {
-                let ty = <dyn AstConv<'_>>::ast_ty_to_ty(fcx, ty);
-                if let ty::Dynamic(..) = ty.kind() {
+        if let Some((fn_decl, _)) = fcx.get_fn_decl(blk_id)
+            && let hir::FnRetTy::Return(ty) = fn_decl.output
+            && let ty = <dyn AstConv<'_>>::ast_ty_to_ty(fcx, ty)
+            && let ty::Dynamic(..) = ty.kind()
+        {
                     return true;
-                }
-            }
         }
         false
     }

--- a/compiler/rustc_typeck/src/check/demand.rs
+++ b/compiler/rustc_typeck/src/check/demand.rs
@@ -587,9 +587,10 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         match (&expr.kind, expected.kind(), checked_ty.kind()) {
             (_, &ty::Ref(_, exp, _), &ty::Ref(_, check, _)) => match (exp.kind(), check.kind()) {
                 (&ty::Str, &ty::Array(arr, _) | &ty::Slice(arr)) if arr == self.tcx.types.u8 => {
-                    if let hir::ExprKind::Lit(_) = expr.kind {
-                        if let Ok(src) = sm.span_to_snippet(sp) {
-                            if replace_prefix(&src, "b\"", "\"").is_some() {
+                    if let hir::ExprKind::Lit(_) = expr.kind
+                        && let Ok(src) = sm.span_to_snippet(sp)
+                        && replace_prefix(&src, "b\"", "\"").is_some()
+                    {
                                 let pos = sp.lo() + BytePos(1);
                                 return Some((
                                     sp.with_hi(pos),
@@ -600,12 +601,11 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                                 ));
                             }
                         }
-                    }
-                }
                 (&ty::Array(arr, _) | &ty::Slice(arr), &ty::Str) if arr == self.tcx.types.u8 => {
-                    if let hir::ExprKind::Lit(_) = expr.kind {
-                        if let Ok(src) = sm.span_to_snippet(sp) {
-                            if replace_prefix(&src, "\"", "b\"").is_some() {
+                    if let hir::ExprKind::Lit(_) = expr.kind
+                        && let Ok(src) = sm.span_to_snippet(sp)
+                        && replace_prefix(&src, "\"", "b\"").is_some()
+                    {
                                 return Some((
                                     sp.shrink_to_lo(),
                                     "consider adding a leading `b`",
@@ -613,8 +613,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                                     Applicability::MachineApplicable,
                                     true,
                                 ));
-                            }
-                        }
+
                     }
                 }
                 _ => {}

--- a/compiler/rustc_typeck/src/check/expr.rs
+++ b/compiler/rustc_typeck/src/check/expr.rs
@@ -810,10 +810,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         // Use the span of the trailing expression for our cause,
         // not the span of the entire function
         if !explicit_return {
-            if let ExprKind::Block(body, _) = return_expr.kind {
-                if let Some(last_expr) = body.expr {
-                    span = last_expr.span;
-                }
+            if let ExprKind::Block(body, _) = return_expr.kind && let Some(last_expr) = body.expr {
+                span = last_expr.span;
             }
         }
         ret_coercion.borrow_mut().coerce(

--- a/compiler/rustc_typeck/src/check/fn_ctxt/checks.rs
+++ b/compiler/rustc_typeck/src/check/fn_ctxt/checks.rs
@@ -402,25 +402,23 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     if arg_count == 0 || i + 1 == arg_count { &label } else { "" },
                 );
             }
-            if let Some(def_id) = fn_def_id {
-                if let Some(def_span) = tcx.def_ident_span(def_id) {
-                    let mut spans: MultiSpan = def_span.into();
+            if let Some(def_id) = fn_def_id && let Some(def_span) = tcx.def_ident_span(def_id) {
+                let mut spans: MultiSpan = def_span.into();
 
-                    let params = tcx
-                        .hir()
-                        .get_if_local(def_id)
-                        .and_then(|node| node.body_id())
-                        .into_iter()
-                        .map(|id| tcx.hir().body(id).params)
-                        .flatten();
+                let params = tcx
+                    .hir()
+                    .get_if_local(def_id)
+                    .and_then(|node| node.body_id())
+                    .into_iter()
+                    .map(|id| tcx.hir().body(id).params)
+                    .flatten();
 
-                    for param in params {
-                        spans.push_span_label(param.span, String::new());
-                    }
-
-                    let def_kind = tcx.def_kind(def_id);
-                    err.span_note(spans, &format!("{} defined here", def_kind.descr(def_id)));
+                for param in params {
+                    spans.push_span_label(param.span, String::new());
                 }
+
+                let def_kind = tcx.def_kind(def_id);
+                err.span_note(spans, &format!("{} defined here", def_kind.descr(def_id)));
             }
             if sugg_unit {
                 let sugg_span = tcx.sess.source_map().end_point(call_expr.span);

--- a/compiler/rustc_typeck/src/check/pat.rs
+++ b/compiler/rustc_typeck/src/check/pat.rs
@@ -685,9 +685,10 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     }
 
     pub fn check_dereferenceable(&self, span: Span, expected: Ty<'tcx>, inner: &Pat<'_>) -> bool {
-        if let PatKind::Binding(..) = inner.kind {
-            if let Some(mt) = self.shallow_resolve(expected).builtin_deref(true) {
-                if let ty::Dynamic(..) = mt.ty.kind() {
+        if let PatKind::Binding(..) = inner.kind
+            && let Some(mt) = self.shallow_resolve(expected).builtin_deref(true)
+            && let ty::Dynamic(..) = mt.ty.kind()
+        {
                     // This is "x = SomeTrait" being reduced from
                     // "let &x = &SomeTrait" or "let box x = Box<SomeTrait>", an error.
                     let type_str = self.ty_to_string(expected);
@@ -705,8 +706,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     err.emit();
                     return false;
                 }
-            }
-        }
         true
     }
 

--- a/compiler/rustc_typeck/src/collect.rs
+++ b/compiler/rustc_typeck/src/collect.rs
@@ -190,25 +190,23 @@ crate fn placeholder_type_error<'tcx>(
         let mut is_fn = false;
         let mut is_const_or_static = false;
 
-        if let Some(hir_ty) = hir_ty {
-            if let hir::TyKind::BareFn(_) = hir_ty.kind {
-                is_fn = true;
+        if let Some(hir_ty) = hir_ty && let hir::TyKind::BareFn(_) = hir_ty.kind {
+            is_fn = true;
 
-                // Check if parent is const or static
-                let parent_id = tcx.hir().get_parent_node(hir_ty.hir_id);
-                let parent_node = tcx.hir().get(parent_id);
+            // Check if parent is const or static
+            let parent_id = tcx.hir().get_parent_node(hir_ty.hir_id);
+            let parent_node = tcx.hir().get(parent_id);
 
-                is_const_or_static = matches!(
-                    parent_node,
-                    Node::Item(&hir::Item {
-                        kind: hir::ItemKind::Const(..) | hir::ItemKind::Static(..),
-                        ..
-                    }) | Node::TraitItem(&hir::TraitItem {
-                        kind: hir::TraitItemKind::Const(..),
-                        ..
-                    }) | Node::ImplItem(&hir::ImplItem { kind: hir::ImplItemKind::Const(..), .. })
-                );
-            }
+            is_const_or_static = matches!(
+                parent_node,
+                Node::Item(&hir::Item {
+                    kind: hir::ItemKind::Const(..) | hir::ItemKind::Static(..),
+                    ..
+                }) | Node::TraitItem(&hir::TraitItem {
+                    kind: hir::TraitItemKind::Const(..),
+                    ..
+                }) | Node::ImplItem(&hir::ImplItem { kind: hir::ImplItemKind::Const(..), .. })
+            );
         }
 
         // if function is wrapped around a const or static,
@@ -2417,16 +2415,14 @@ fn const_evaluatable_predicates_of<'tcx>(
     let node = tcx.hir().get(hir_id);
 
     let mut collector = ConstCollector { tcx, preds: FxIndexSet::default() };
-    if let hir::Node::Item(item) = node {
-        if let hir::ItemKind::Impl(ref impl_) = item.kind {
-            if let Some(of_trait) = &impl_.of_trait {
-                debug!("const_evaluatable_predicates_of({:?}): visit impl trait_ref", def_id);
-                collector.visit_trait_ref(of_trait);
-            }
-
-            debug!("const_evaluatable_predicates_of({:?}): visit_self_ty", def_id);
-            collector.visit_ty(impl_.self_ty);
+    if let hir::Node::Item(item) = node && let hir::ItemKind::Impl(ref impl_) = item.kind {
+        if let Some(of_trait) = &impl_.of_trait {
+            debug!("const_evaluatable_predicates_of({:?}): visit impl trait_ref", def_id);
+            collector.visit_trait_ref(of_trait);
         }
+
+        debug!("const_evaluatable_predicates_of({:?}): visit_self_ty", def_id);
+        collector.visit_ty(impl_.self_ty);
     }
 
     if let Some(generics) = node.generics() {
@@ -3280,15 +3276,14 @@ fn asm_target_features<'tcx>(tcx: TyCtxt<'tcx>, id: DefId) -> &'tcx FxHashSet<Sy
 /// Checks if the provided DefId is a method in a trait impl for a trait which has track_caller
 /// applied to the method prototype.
 fn should_inherit_track_caller(tcx: TyCtxt<'_>, def_id: DefId) -> bool {
-    if let Some(impl_item) = tcx.opt_associated_item(def_id) {
-        if let ty::AssocItemContainer::ImplContainer(_) = impl_item.container {
-            if let Some(trait_item) = impl_item.trait_item_def_id {
-                return tcx
-                    .codegen_fn_attrs(trait_item)
-                    .flags
-                    .intersects(CodegenFnAttrFlags::TRACK_CALLER);
-            }
-        }
+    if let Some(impl_item) = tcx.opt_associated_item(def_id)
+        && let ty::AssocItemContainer::ImplContainer(_) = impl_item.container
+        && let Some(trait_item) = impl_item.trait_item_def_id
+    {
+        return tcx
+            .codegen_fn_attrs(trait_item)
+            .flags
+            .intersects(CodegenFnAttrFlags::TRACK_CALLER);
     }
 
     false

--- a/compiler/rustc_typeck/src/lib.rs
+++ b/compiler/rustc_typeck/src/lib.rs
@@ -55,22 +55,23 @@ This API is completely unstable and subject to change.
 
 */
 
+#![allow(rustc::potential_query_instability)]
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
 #![feature(bool_to_option)]
+#![feature(control_flow_enum)]
 #![feature(crate_visibility_modifier)]
+#![feature(hash_drain_filter)]
 #![feature(if_let_guard)]
 #![feature(is_sorted)]
+#![feature(let_chains)]
 #![feature(let_else)]
 #![feature(min_specialization)]
-#![feature(nll)]
-#![feature(try_blocks)]
 #![feature(never_type)]
-#![feature(slice_partition_dedup)]
-#![feature(control_flow_enum)]
-#![feature(hash_drain_filter)]
+#![feature(nll)]
 #![feature(once_cell)]
+#![feature(slice_partition_dedup)]
+#![feature(try_blocks)]
 #![recursion_limit = "256"]
-#![allow(rustc::potential_query_instability)]
 
 #[macro_use]
 extern crate tracing;

--- a/compiler/rustc_typeck/src/outlives/implicit_infer.rs
+++ b/compiler/rustc_typeck/src/outlives/implicit_infer.rs
@@ -304,13 +304,12 @@ pub fn check_explicit_predicates<'tcx>(
         // = X` binding from the object type (there must be such a
         // binding) and thus infer an outlives requirement that `X:
         // 'b`.
-        if let Some(self_ty) = ignored_self_ty {
-            if let GenericArgKind::Type(ty) = outlives_predicate.0.unpack() {
-                if ty.walk().any(|arg| arg == self_ty.into()) {
-                    debug!("skipping self ty = {:?}", &ty);
-                    continue;
-                }
-            }
+        if let Some(self_ty) = ignored_self_ty
+            && let GenericArgKind::Type(ty) = outlives_predicate.0.unpack()
+            && ty.walk().any(|arg| arg == self_ty.into())
+        {
+            debug!("skipping self ty = {:?}", &ty);
+            continue;
         }
 
         let predicate = outlives_predicate.subst(tcx, substs);

--- a/config.toml.example
+++ b/config.toml.example
@@ -551,7 +551,9 @@ changelog-seen = 2
 
 # This is an array of the codegen backends that will be compiled for the rustc
 # that's being compiled. The default is to only build the LLVM codegen backend,
-# and currently the only standard options supported are `"llvm"` and `"cranelift"`.
+# and currently the only standard options supported are `"llvm"`, `"cranelift"`
+# and `"gcc"`. The first backend in this list will be used as default by rustc
+# when no explicit backend is specified.
 #codegen-backends = ["llvm"]
 
 # Indicates whether LLD will be compiled and made available in the sysroot for

--- a/library/std/src/net/tcp.rs
+++ b/library/std/src/net/tcp.rs
@@ -710,7 +710,7 @@ impl TcpListener {
     /// Default "backlog" for [`TcpListener::bind`]. See
     /// [`TcpListener::bind_with_backlog`] for an explanation of backlog
     /// values.
-    #[unstable(feature = "bind_with_backlog", issue = "none")]
+    #[unstable(feature = "bind_with_backlog", issue = "94406")]
     pub const DEFAULT_BACKLOG: usize = 128;
 
     /// Creates a new `TcpListener` which will be bound to the specified
@@ -741,7 +741,7 @@ impl TcpListener {
     /// The specified backlog may be larger than supported by the underlying
     /// system. In this case an [`io::Error`] with
     /// [`io::ErrorKind::InvalidData`] will be returned.
-    #[unstable(feature = "bind_with_backlog", issue = "none")]
+    #[unstable(feature = "bind_with_backlog", issue = "94406")]
     pub fn bind_with_backlog<A: ToSocketAddrs>(addr: A, backlog: usize) -> io::Result<TcpListener> {
         super::each_addr(addr, move |a| net_imp::TcpListener::bind_with_backlog(a, backlog))
             .map(TcpListener)

--- a/library/std/src/net/tcp.rs
+++ b/library/std/src/net/tcp.rs
@@ -730,6 +730,7 @@ impl TcpListener {
     /// Creates a TCP listener bound to `127.0.0.1:80` with a backlog of 1000:
     ///
     /// ```no_run
+    /// #![feature(bind_with_backlog)]
     /// use std::net::TcpListener;
     ///
     /// let listener = TcpListener::bind_with_backlog("127.0.0.1:80", 1000).unwrap();

--- a/library/std/src/net/tcp.rs
+++ b/library/std/src/net/tcp.rs
@@ -707,11 +707,8 @@ impl fmt::Debug for TcpStream {
 }
 
 impl TcpListener {
-    /// Default "backlog" for [`TcpListener::bind`]. See
-    /// [`TcpListener::bind_with_backlog`] for an explanation of backlog
-    /// values.
-    #[unstable(feature = "bind_with_backlog", issue = "94406")]
-    pub const DEFAULT_BACKLOG: usize = 128;
+    /// Default listen backlog.
+    const DEFAULT_BACKLOG: usize = 128;
 
     /// Creates a new `TcpListener` which will be bound to the specified
     /// address.
@@ -719,8 +716,7 @@ impl TcpListener {
     /// The given backlog specifies the maximum number of outstanding
     /// connections that will be buffered in the OS waiting to be accepted by
     /// [`TcpListener::accept`]. The backlog argument overrides the default
-    /// specified by [`TcpListener::DEFAULT_BACKLOG`]; that default is
-    /// reasonable for most use cases.
+    /// value of 128; that default is reasonable for most use cases.
     ///
     /// This function is otherwise [`TcpListener::bind`]: see that
     /// documentation for full details of operation.
@@ -751,8 +747,7 @@ impl TcpListener {
     /// address. The returned listener is ready for accepting
     /// connections.
     ///
-    /// The listener will have a backlog given by
-    /// [`TcpListener::DEFAULT_BACKLOG`]. See the documentation for
+    /// The listener will have a backlog of 128.  See the documentation for
     /// [`TcpListener::bind_with_backlog`] for further information.
     ///
     /// Binding with a port number of 0 will request that the OS assigns a port

--- a/library/std/src/os/unix/net/listener.rs
+++ b/library/std/src/os/unix/net/listener.rs
@@ -98,6 +98,7 @@ impl UnixListener {
     /// # Examples
     ///
     /// ```no_run
+    /// #![feature(bind_with_backlog)]
     /// use std::os::unix::net::UnixListener;
     ///
     /// let listener = match UnixListener::bind_with_backlog("/path/to/the/socket", 1000) {

--- a/library/std/src/os/unix/net/listener.rs
+++ b/library/std/src/os/unix/net/listener.rs
@@ -54,16 +54,12 @@ impl fmt::Debug for UnixListener {
 }
 
 impl UnixListener {
-    /// Default "backlog" for [`UnixListener::bind`] and
-    /// [`UnixListener::bind_addr`]. See [`UnixListener::bind_with_backlog`]
-    /// for an explanation of backlog values.
-    #[unstable(feature = "bind_with_backlog", issue = "94406")]
-    pub const DEFAULT_BACKLOG: usize = 128;
+    /// Default backlog for `bind` and `bind_addr`.
+    const DEFAULT_BACKLOG: usize = 128;
 
     /// Creates a new `UnixListener` bound to the specified socket.
     ///
-    /// The listener will have a backlog given by
-    /// [`UnixListener::DEFAULT_BACKLOG`]. See the documentation for
+    /// The listener will have a backlog of 128. See the documentation for
     /// [`UnixListener::bind_with_backlog`] for further information.
     ///
     /// # Examples
@@ -87,10 +83,10 @@ impl UnixListener {
     /// Creates a new `UnixListener` bound to the specified socket.
     ///
     /// The given backlog specifies the maximum number of outstanding
-    /// connections that will be buffered in the OS waiting to be accepted by
-    /// [`UnixListener::accept`]. The backlog argument overrides the default
-    /// specified by [`UnixListener::DEFAULT_BACKLOG`]; that default is
-    /// reasonable for most use cases.
+    /// connections that will be buffered in the OS waiting to be accepted
+    /// by [`UnixListener::accept`]. The backlog argument overrides the
+    /// default backlog of 128; that default is reasonable for most use
+    /// cases.
     ///
     /// This function is otherwise [`UnixListener::bind`]: see that
     /// documentation for full details of operation.
@@ -133,6 +129,9 @@ impl UnixListener {
 
     /// Creates a new `UnixListener` bound to the specified [`socket address`].
     ///
+    /// The listener will have a backlog of 128. See the documentation for
+    /// [`UnixListener::bind_addr_with_backlog`] for further information.
+    ///
     /// [`socket address`]: crate::os::unix::net::SocketAddr
     ///
     /// # Examples
@@ -163,10 +162,9 @@ impl UnixListener {
     /// Creates a new `UnixListener` bound to the specified [`socket address`].
     ///
     /// The given backlog specifies the maximum number of outstanding
-    /// connections that will be buffered in the OS waiting to be accepted by
-    /// [`UnixListener::accept`]. The backlog argument overrides the default
-    /// specified by [`UnixListener::DEFAULT_BACKLOG`]; that default is
-    /// reasonable for most use cases.
+    /// connections that will be buffered in the OS waiting to be accepted
+    /// by [`UnixListener::accept`]. The backlog argument overrides the
+    /// default of 128; that default is reasonable for most use cases.
     ///
     /// This function is otherwise [`UnixListener::bind_addr`]: see that
     /// documentation for full details of operation.

--- a/library/std/src/os/unix/net/listener.rs
+++ b/library/std/src/os/unix/net/listener.rs
@@ -57,7 +57,7 @@ impl UnixListener {
     /// Default "backlog" for [`UnixListener::bind`] and
     /// [`UnixListener::bind_addr`]. See [`UnixListener::bind_with_backlog`]
     /// for an explanation of backlog values.
-    #[unstable(feature = "bind_with_backlog", issue = "none")]
+    #[unstable(feature = "bind_with_backlog", issue = "94406")]
     pub const DEFAULT_BACKLOG: usize = 128;
 
     /// Creates a new `UnixListener` bound to the specified socket.
@@ -115,7 +115,7 @@ impl UnixListener {
     /// The specified backlog may be larger than supported by the underlying
     /// system. In this case an [`io::Error`] with
     /// [`io::ErrorKind::InvalidData`] will be returned.
-    #[unstable(feature = "bind_with_backlog", issue = "none")]
+    #[unstable(feature = "bind_with_backlog", issue = "94406")]
     pub fn bind_with_backlog<P: AsRef<Path>>(path: P, backlog: usize) -> io::Result<UnixListener> {
         unsafe {
             let backlog = backlog
@@ -195,7 +195,7 @@ impl UnixListener {
     /// }
     /// ```
     //#[unstable(feature = "unix_socket_abstract", issue = "85410")]
-    #[unstable(feature = "bind_with_backlog", issue = "none")]
+    #[unstable(feature = "bind_with_backlog", issue = "94406")]
     pub fn bind_addr_with_backlog(
         socket_addr: &SocketAddr,
         backlog: usize,

--- a/library/std/src/os/unix/net/tests.rs
+++ b/library/std/src/os/unix/net/tests.rs
@@ -41,7 +41,7 @@ fn basic() {
     let msg1 = b"hello";
     let msg2 = b"world!";
 
-    let listener = or_panic!(UnixListener::bind(&socket_path));
+    let listener = or_panic!(UnixListener::bind_with_backlog(&socket_path, 1));
     let thread = thread::spawn(move || {
         let mut stream = or_panic!(listener.accept()).0;
         let mut buf = [0; 5];
@@ -111,7 +111,7 @@ fn try_clone() {
     let msg1 = b"hello";
     let msg2 = b"world";
 
-    let listener = or_panic!(UnixListener::bind(&socket_path));
+    let listener = or_panic!(UnixListener::bind_with_backlog(&socket_path, 1));
     let thread = thread::spawn(move || {
         let mut stream = or_panic!(listener.accept()).0;
         or_panic!(stream.write_all(msg1));
@@ -135,7 +135,7 @@ fn iter() {
     let dir = tmpdir();
     let socket_path = dir.path().join("sock");
 
-    let listener = or_panic!(UnixListener::bind(&socket_path));
+    let listener = or_panic!(UnixListener::bind_with_backlog(&socket_path, 2));
     let thread = thread::spawn(move || {
         for stream in listener.incoming().take(2) {
             let mut stream = or_panic!(stream);
@@ -423,7 +423,7 @@ fn test_abstract_stream_connect() {
     let msg2 = b"world";
 
     let socket_addr = or_panic!(SocketAddr::from_abstract_namespace(b"namespace"));
-    let listener = or_panic!(UnixListener::bind_addr(&socket_addr));
+    let listener = or_panic!(UnixListener::bind_addr_with_backlog(&socket_addr, 1));
 
     let thread = thread::spawn(move || {
         let mut stream = or_panic!(listener.accept()).0;
@@ -451,7 +451,7 @@ fn test_abstract_stream_connect() {
 #[test]
 fn test_abstract_stream_iter() {
     let addr = or_panic!(SocketAddr::from_abstract_namespace(b"hidden"));
-    let listener = or_panic!(UnixListener::bind_addr(&addr));
+    let listener = or_panic!(UnixListener::bind_addr_with_backlog(&addr, 2));
 
     let thread = thread::spawn(move || {
         for stream in listener.incoming().take(2) {

--- a/library/std/src/sys_common/net.rs
+++ b/library/std/src/sys_common/net.rs
@@ -363,8 +363,16 @@ pub struct TcpListener {
 }
 
 impl TcpListener {
-    pub fn bind(addr: io::Result<&SocketAddr>) -> io::Result<TcpListener> {
+    pub fn bind_with_backlog(
+        addr: io::Result<&SocketAddr>,
+        backlog: usize,
+    ) -> io::Result<TcpListener> {
         let addr = addr?;
+
+        // Type-convert the backlog
+        let backlog = backlog
+            .try_into()
+            .map_err(|e| crate::io::Error::new(crate::io::ErrorKind::InvalidData, e))?;
 
         init();
 
@@ -385,7 +393,7 @@ impl TcpListener {
         cvt(unsafe { c::bind(sock.as_raw(), addrp, len as _) })?;
 
         // Start listening
-        cvt(unsafe { c::listen(sock.as_raw(), 128) })?;
+        cvt(unsafe { c::listen(sock.as_raw(), backlog) })?;
         Ok(TcpListener { inner: sock })
     }
 

--- a/src/bootstrap/build.rs
+++ b/src/bootstrap/build.rs
@@ -4,13 +4,13 @@ use std::path::PathBuf;
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-env-changed=RUSTC");
-    println!("cargo:rerun-if-env-changed=PATH");
     println!("cargo:rustc-env=BUILD_TRIPLE={}", env::var("HOST").unwrap());
 
     // This may not be a canonicalized path.
     let mut rustc = PathBuf::from(env::var_os("RUSTC").unwrap());
 
     if rustc.is_relative() {
+        println!("cargo:rerun-if-env-changed=PATH");
         for dir in env::split_paths(&env::var_os("PATH").unwrap_or_default()) {
             let absolute = dir.join(&rustc);
             if absolute.exists() {

--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -662,6 +662,10 @@ pub fn rustc_cargo_env(builder: &Builder<'_>, cargo: &mut Cargo, target: TargetS
         .env("CFG_RELEASE_CHANNEL", &builder.config.channel)
         .env("CFG_VERSION", builder.rust_version());
 
+    if let Some(backend) = builder.config.rust_codegen_backends.get(0) {
+        cargo.env("CFG_DEFAULT_CODEGEN_BACKEND", backend);
+    }
+
     let libdir_relative = builder.config.libdir_relative().unwrap_or_else(|| Path::new("lib"));
     let target_config = builder.config.target_config.get(&target);
 

--- a/src/test/rustdoc-ui/issue-79465.rs
+++ b/src/test/rustdoc-ui/issue-79465.rs
@@ -1,0 +1,3 @@
+pub fn f1<T>(x: T::A) {}
+//~^ ERROR
+//~^^ ERROR

--- a/src/test/rustdoc-ui/issue-79465.stderr
+++ b/src/test/rustdoc-ui/issue-79465.stderr
@@ -1,0 +1,15 @@
+error[E0220]: associated type `A` not found for `T`
+  --> $DIR/issue-79465.rs:1:20
+   |
+LL | pub fn f1<T>(x: T::A) {}
+   |                    ^ associated type `A` not found
+
+error[E0220]: associated type `A` not found for `T`
+  --> $DIR/issue-79465.rs:1:20
+   |
+LL | pub fn f1<T>(x: T::A) {}
+   |                    ^ associated type `A` not found
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0220`.

--- a/src/test/ui/error-codes/E0081.rs
+++ b/src/test/ui/error-codes/E0081.rs
@@ -10,10 +10,10 @@ enum Enum {
 #[repr(u8)]
 enum EnumOverflowRepr {
     P = 257,
-    //~^ NOTE first use of `1` (overflowed from `257`)
+    //~^ NOTE first use of `255` (overflowed from `257`)
     X = 513,
-    //~^ ERROR discriminant value `1` already exists
-    //~| NOTE enum already has `1` (overflowed from `513`)
+    //~^ ERROR discriminant value `255` already exists
+    //~| NOTE enum already has `255` (overflowed from `513`)
 }
 
 fn main() {

--- a/src/test/ui/error-codes/E0081.stderr
+++ b/src/test/ui/error-codes/E0081.stderr
@@ -7,14 +7,14 @@ LL |
 LL |     X = 3,
    |         ^ enum already has `3`
 
-error[E0081]: discriminant value `1` already exists
+error[E0081]: discriminant value `255` already exists
   --> $DIR/E0081.rs:14:9
    |
 LL |     P = 257,
-   |         --- first use of `1` (overflowed from `257`)
+   |         --- first use of `255` (overflowed from `257`)
 LL |
 LL |     X = 513,
-   |         ^^^ enum already has `1` (overflowed from `513`)
+   |         ^^^ enum already has `255` (overflowed from `513`)
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-94239.rs
+++ b/src/test/ui/issues/issue-94239.rs
@@ -1,0 +1,8 @@
+pub const fn test_match_range(len: usize) -> usize {
+    match len {
+        10000000000000000000..=99999999999999999999 => 0, //~ ERROR literal out of range for `usize`
+        _ => unreachable!(),
+    }
+}
+
+fn main() {}

--- a/src/test/ui/issues/issue-94239.rs
+++ b/src/test/ui/issues/issue-94239.rs
@@ -1,6 +1,6 @@
-pub const fn test_match_range(len: usize) -> usize {
+pub const fn test_match_range(len: u64) -> u64 {
     match len {
-        10000000000000000000..=99999999999999999999 => 0, //~ ERROR literal out of range for `usize`
+        10000000000000000000..=99999999999999999999 => 0, //~ ERROR literal out of range for `u64`
         _ => unreachable!(),
     }
 }

--- a/src/test/ui/issues/issue-94239.stderr
+++ b/src/test/ui/issues/issue-94239.stderr
@@ -1,0 +1,11 @@
+error: literal out of range for `usize`
+  --> $DIR/issue-94239.rs:3:32
+   |
+LL |         10000000000000000000..=99999999999999999999 => 0,
+   |                                ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `#[deny(overflowing_literals)]` on by default
+   = note: the literal `99999999999999999999` does not fit into the type `usize` whose range is `0..=18446744073709551615`
+
+error: aborting due to previous error
+

--- a/src/test/ui/issues/issue-94239.stderr
+++ b/src/test/ui/issues/issue-94239.stderr
@@ -1,11 +1,11 @@
-error: literal out of range for `usize`
+error: literal out of range for `u64`
   --> $DIR/issue-94239.rs:3:32
    |
 LL |         10000000000000000000..=99999999999999999999 => 0,
    |                                ^^^^^^^^^^^^^^^^^^^^
    |
    = note: `#[deny(overflowing_literals)]` on by default
-   = note: the literal `99999999999999999999` does not fit into the type `usize` whose range is `0..=18446744073709551615`
+   = note: the literal `99999999999999999999` does not fit into the type `u64` whose range is `0..=18446744073709551615`
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Successful merges:

 - #94354 (Fix show error message when literal overflows in match patterns)
 - #94396 (1 - Make more use of `let_chains`)
 - #94397 (Document that pre-expansion lint passes are softly deprecated)
 - #94399 (Add test for #79465 to prevent regression)
 - #94407 (Add `with_backlog` functionality to `TcpListener` and `UnixListener`)
 - #94409 (avoid rebuilding bootstrap when PATH changes)
 - #94412 (For MIRI, cfg out the swap vectorization logic from 94212)
 - #94415 (Use the first codegen backend in the config.toml as default)
 - #94420 (3 - Make more use of `let_chains`)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=94354,94396,94397,94399,94407,94409,94412,94415,94420)
<!-- homu-ignore:end -->