### PR TITLE
Only create a single expansion for each inline integration.

### DIFF
--- a/compiler/rustc_errors/src/emitter.rs
+++ b/compiler/rustc_errors/src/emitter.rs
@@ -408,8 +408,8 @@ pub trait Emitter {
                             "this derive macro expansion".into()
                         }
                         ExpnKind::Macro(MacroKind::Bang, _) => "this macro invocation".into(),
-                        ExpnKind::Inlined => "the inlined copy of this code".into(),
-                        ExpnKind::Root => "in the crate root".into(),
+                        ExpnKind::Inlined => "this inlined function call".into(),
+                        ExpnKind::Root => "the crate root".into(),
                         ExpnKind::AstPass(kind) => kind.descr().into(),
                         ExpnKind::Desugaring(kind) => {
                             format!("this {} desugaring", kind.descr()).into()

--- a/compiler/rustc_span/src/hygiene.rs
+++ b/compiler/rustc_span/src/hygiene.rs
@@ -874,19 +874,13 @@ impl Span {
     /// other compiler-generated code to set per-span properties like allowed unstable features.
     /// The returned span belongs to the created expansion and has the new properties,
     /// but its location is inherited from the current span.
-    pub fn fresh_expansion(self, expn_data: ExpnData, ctx: impl HashStableContext) -> Span {
-        self.fresh_expansion_with_transparency(expn_data, Transparency::Transparent, ctx)
-    }
-
-    pub fn fresh_expansion_with_transparency(
-        self,
-        expn_data: ExpnData,
-        transparency: Transparency,
-        ctx: impl HashStableContext,
-    ) -> Span {
-        let expn_id = LocalExpnId::fresh(expn_data, ctx).to_expn_id();
+    pub fn fresh_expansion(self, expn_id: LocalExpnId) -> Span {
         HygieneData::with(|data| {
-            self.with_ctxt(data.apply_mark(SyntaxContext::root(), expn_id, transparency))
+            self.with_ctxt(data.apply_mark(
+                SyntaxContext::root(),
+                expn_id.to_expn_id(),
+                Transparency::Transparent,
+            ))
         })
     }
 
@@ -903,7 +897,8 @@ impl Span {
             allow_internal_unstable,
             ..ExpnData::default(ExpnKind::Desugaring(reason), self, edition, None, None)
         };
-        self.fresh_expansion(expn_data, ctx)
+        let expn_id = LocalExpnId::fresh(expn_data, ctx);
+        self.fresh_expansion(expn_id)
     }
 }
 

--- a/src/librustdoc/passes/check_code_block_syntax.rs
+++ b/src/librustdoc/passes/check_code_block_syntax.rs
@@ -4,8 +4,9 @@ use rustc_errors::{emitter::Emitter, Applicability, Diagnostic, Handler};
 use rustc_middle::lint::LintDiagnosticBuilder;
 use rustc_parse::parse_stream_from_source_str;
 use rustc_session::parse::ParseSess;
+use rustc_span::hygiene::{AstPass, ExpnData, ExpnKind, LocalExpnId};
 use rustc_span::source_map::{FilePathMapping, SourceMap};
-use rustc_span::{hygiene::AstPass, ExpnData, ExpnKind, FileName, InnerSpan, DUMMY_SP};
+use rustc_span::{FileName, InnerSpan, DUMMY_SP};
 
 use crate::clean;
 use crate::core::DocContext;
@@ -46,7 +47,8 @@ impl<'a, 'tcx> SyntaxChecker<'a, 'tcx> {
             None,
             None,
         );
-        let span = DUMMY_SP.fresh_expansion(expn_data, self.cx.tcx.create_stable_hashing_context());
+        let expn_id = LocalExpnId::fresh(expn_data, self.cx.tcx.create_stable_hashing_context());
+        let span = DUMMY_SP.fresh_expansion(expn_id);
 
         let is_empty = rustc_driver::catch_fatal_errors(|| {
             parse_stream_from_source_str(

--- a/src/test/mir-opt/deduplicate_blocks.is_line_doc_comment_2.DeduplicateBlocks.diff
+++ b/src/test/mir-opt/deduplicate_blocks.is_line_doc_comment_2.DeduplicateBlocks.diff
@@ -11,8 +11,8 @@
       let mut _6: usize;                   // in scope 0 at $DIR/deduplicate_blocks.rs:4:9: 4:37
       let mut _7: bool;                    // in scope 0 at $DIR/deduplicate_blocks.rs:4:9: 4:37
       scope 1 (inlined core::str::<impl str>::as_bytes) { // at $DIR/deduplicate_blocks.rs:3:11: 3:23
-          debug self => _3;                // in scope 1 at $DIR/deduplicate_blocks.rs:3:11: 3:23
-          let mut _8: &str;                // in scope 1 at $DIR/deduplicate_blocks.rs:3:11: 3:23
+          debug self => _3;                // in scope 1 at $SRC_DIR/core/src/str/mod.rs:LL:COL
+          let mut _8: &str;                // in scope 1 at $SRC_DIR/core/src/str/mod.rs:LL:COL
           scope 2 {
           }
       }
@@ -21,12 +21,12 @@
           StorageLive(_2);                 // scope 0 at $DIR/deduplicate_blocks.rs:3:11: 3:23
           StorageLive(_3);                 // scope 0 at $DIR/deduplicate_blocks.rs:3:11: 3:23
           _3 = _1;                         // scope 0 at $DIR/deduplicate_blocks.rs:3:11: 3:23
-          StorageLive(_8);                 // scope 2 at $DIR/deduplicate_blocks.rs:3:11: 3:23
-          _8 = _3;                         // scope 2 at $DIR/deduplicate_blocks.rs:3:11: 3:23
--         _2 = transmute::<&str, &[u8]>(move _8) -> bb14; // scope 2 at $DIR/deduplicate_blocks.rs:3:11: 3:23
-+         _2 = transmute::<&str, &[u8]>(move _8) -> bb12; // scope 2 at $DIR/deduplicate_blocks.rs:3:11: 3:23
+          StorageLive(_8);                 // scope 2 at $SRC_DIR/core/src/str/mod.rs:LL:COL
+          _8 = _3;                         // scope 2 at $SRC_DIR/core/src/str/mod.rs:LL:COL
+-         _2 = transmute::<&str, &[u8]>(move _8) -> bb14; // scope 2 at $SRC_DIR/core/src/str/mod.rs:LL:COL
++         _2 = transmute::<&str, &[u8]>(move _8) -> bb12; // scope 2 at $SRC_DIR/core/src/str/mod.rs:LL:COL
                                            // mir::Constant
-                                           // + span: $DIR/deduplicate_blocks.rs:3:11: 3:23
+                                           // + span: $SRC_DIR/core/src/str/mod.rs:LL:COL
                                            // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(&str) -> &[u8] {transmute::<&str, &[u8]>}, val: Value(Scalar(<ZST>)) }
       }
   
@@ -97,7 +97,7 @@
   
 -     bb14: {
 +     bb12: {
-          StorageDead(_8);                 // scope 2 at $DIR/deduplicate_blocks.rs:3:11: 3:23
+          StorageDead(_8);                 // scope 2 at $SRC_DIR/core/src/str/mod.rs:LL:COL
           StorageDead(_3);                 // scope 0 at $DIR/deduplicate_blocks.rs:3:22: 3:23
           _6 = Len((*_2));                 // scope 0 at $DIR/deduplicate_blocks.rs:4:9: 4:37
           _7 = Ge(move _6, const 4_usize); // scope 0 at $DIR/deduplicate_blocks.rs:4:9: 4:37

--- a/src/test/mir-opt/dest-prop/cycle.main.DestinationPropagation.diff
+++ b/src/test/mir-opt/dest-prop/cycle.main.DestinationPropagation.diff
@@ -19,7 +19,7 @@
 -                 debug z => _3;           // in scope 3 at $DIR/cycle.rs:11:9: 11:10
 +                 debug z => _4;           // in scope 3 at $DIR/cycle.rs:11:9: 11:10
                   scope 4 (inlined std::mem::drop::<i32>) { // at $DIR/cycle.rs:14:5: 14:12
-                      debug _x => _6;      // in scope 4 at $DIR/cycle.rs:14:5: 14:12
+                      debug _x => _6;      // in scope 4 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
                   }
               }
           }

--- a/src/test/mir-opt/dest-prop/union.main.DestinationPropagation.diff
+++ b/src/test/mir-opt/dest-prop/union.main.DestinationPropagation.diff
@@ -12,7 +12,7 @@
           scope 2 {
           }
           scope 3 (inlined std::mem::drop::<u32>) { // at $DIR/union.rs:15:5: 15:27
-              debug _x => _4;              // in scope 3 at $DIR/union.rs:15:5: 15:27
+              debug _x => _4;              // in scope 3 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
           }
       }
   

--- a/src/test/mir-opt/inline/inline_any_operand.bar.Inline.after.mir
+++ b/src/test/mir-opt/inline/inline_any_operand.bar.Inline.after.mir
@@ -9,10 +9,10 @@ fn bar() -> bool {
     scope 1 {
         debug f => _1;                   // in scope 1 at $DIR/inline-any-operand.rs:11:9: 11:10
         scope 2 (inlined foo) {          // at $DIR/inline-any-operand.rs:12:5: 12:13
-            debug x => _3;               // in scope 2 at $DIR/inline-any-operand.rs:12:5: 12:13
-            debug y => _4;               // in scope 2 at $DIR/inline-any-operand.rs:12:5: 12:13
-            let mut _5: i32;             // in scope 2 at $DIR/inline-any-operand.rs:12:5: 12:13
-            let mut _6: i32;             // in scope 2 at $DIR/inline-any-operand.rs:12:5: 12:13
+            debug x => _3;               // in scope 2 at $DIR/inline-any-operand.rs:16:8: 16:9
+            debug y => _4;               // in scope 2 at $DIR/inline-any-operand.rs:16:16: 16:17
+            let mut _5: i32;             // in scope 2 at $DIR/inline-any-operand.rs:17:5: 17:6
+            let mut _6: i32;             // in scope 2 at $DIR/inline-any-operand.rs:17:10: 17:11
         }
     }
 
@@ -28,13 +28,13 @@ fn bar() -> bool {
         _3 = const 1_i32;                // scope 1 at $DIR/inline-any-operand.rs:12:5: 12:13
         StorageLive(_4);                 // scope 1 at $DIR/inline-any-operand.rs:12:5: 12:13
         _4 = const -1_i32;               // scope 1 at $DIR/inline-any-operand.rs:12:5: 12:13
-        StorageLive(_5);                 // scope 2 at $DIR/inline-any-operand.rs:12:5: 12:13
-        _5 = _3;                         // scope 2 at $DIR/inline-any-operand.rs:12:5: 12:13
-        StorageLive(_6);                 // scope 2 at $DIR/inline-any-operand.rs:12:5: 12:13
-        _6 = _4;                         // scope 2 at $DIR/inline-any-operand.rs:12:5: 12:13
-        _0 = Eq(move _5, move _6);       // scope 2 at $DIR/inline-any-operand.rs:12:5: 12:13
-        StorageDead(_6);                 // scope 2 at $DIR/inline-any-operand.rs:12:5: 12:13
-        StorageDead(_5);                 // scope 2 at $DIR/inline-any-operand.rs:12:5: 12:13
+        StorageLive(_5);                 // scope 2 at $DIR/inline-any-operand.rs:17:5: 17:6
+        _5 = _3;                         // scope 2 at $DIR/inline-any-operand.rs:17:5: 17:6
+        StorageLive(_6);                 // scope 2 at $DIR/inline-any-operand.rs:17:10: 17:11
+        _6 = _4;                         // scope 2 at $DIR/inline-any-operand.rs:17:10: 17:11
+        _0 = Eq(move _5, move _6);       // scope 2 at $DIR/inline-any-operand.rs:17:5: 17:11
+        StorageDead(_6);                 // scope 2 at $DIR/inline-any-operand.rs:17:10: 17:11
+        StorageDead(_5);                 // scope 2 at $DIR/inline-any-operand.rs:17:10: 17:11
         StorageDead(_4);                 // scope 1 at $DIR/inline-any-operand.rs:12:5: 12:13
         StorageDead(_3);                 // scope 1 at $DIR/inline-any-operand.rs:12:5: 12:13
         StorageDead(_2);                 // scope 1 at $DIR/inline-any-operand.rs:12:12: 12:13

--- a/src/test/mir-opt/inline/inline_closure.foo.Inline.after.mir
+++ b/src/test/mir-opt/inline/inline_closure.foo.Inline.after.mir
@@ -14,8 +14,8 @@ fn foo(_1: T, _2: i32) -> i32 {
     scope 1 {
         debug x => _3;                   // in scope 1 at $DIR/inline-closure.rs:11:9: 11:10
         scope 2 (inlined foo::<T>::{closure#0}) { // at $DIR/inline-closure.rs:12:5: 12:12
-            debug _t => _8;              // in scope 2 at $DIR/inline-closure.rs:12:5: 12:12
-            debug _q => _9;              // in scope 2 at $DIR/inline-closure.rs:12:5: 12:12
+            debug _t => _8;              // in scope 2 at $DIR/inline-closure.rs:11:14: 11:16
+            debug _q => _9;              // in scope 2 at $DIR/inline-closure.rs:11:18: 11:20
         }
     }
 
@@ -34,7 +34,7 @@ fn foo(_1: T, _2: i32) -> i32 {
         _8 = move (_5.0: i32);           // scope 1 at $DIR/inline-closure.rs:12:5: 12:12
         StorageLive(_9);                 // scope 1 at $DIR/inline-closure.rs:12:5: 12:12
         _9 = move (_5.1: i32);           // scope 1 at $DIR/inline-closure.rs:12:5: 12:12
-        _0 = _8;                         // scope 2 at $DIR/inline-closure.rs:12:5: 12:12
+        _0 = _8;                         // scope 2 at $DIR/inline-closure.rs:11:22: 11:24
         StorageDead(_9);                 // scope 1 at $DIR/inline-closure.rs:12:5: 12:12
         StorageDead(_8);                 // scope 1 at $DIR/inline-closure.rs:12:5: 12:12
         StorageDead(_7);                 // scope 1 at $DIR/inline-closure.rs:12:11: 12:12

--- a/src/test/mir-opt/inline/inline_closure_borrows_arg.foo.Inline.after.mir
+++ b/src/test/mir-opt/inline/inline_closure_borrows_arg.foo.Inline.after.mir
@@ -14,11 +14,11 @@ fn foo(_1: T, _2: &i32) -> i32 {
     scope 1 {
         debug x => _3;                   // in scope 1 at $DIR/inline-closure-borrows-arg.rs:12:9: 12:10
         scope 2 (inlined foo::<T>::{closure#0}) { // at $DIR/inline-closure-borrows-arg.rs:16:5: 16:12
-            debug r => _8;               // in scope 2 at $DIR/inline-closure-borrows-arg.rs:16:5: 16:12
-            debug _s => _9;              // in scope 2 at $DIR/inline-closure-borrows-arg.rs:16:5: 16:12
-            let _10: &i32;               // in scope 2 at $DIR/inline-closure-borrows-arg.rs:16:5: 16:12
+            debug r => _8;               // in scope 2 at $DIR/inline-closure-borrows-arg.rs:12:14: 12:15
+            debug _s => _9;              // in scope 2 at $DIR/inline-closure-borrows-arg.rs:12:23: 12:25
+            let _10: &i32;               // in scope 2 at $DIR/inline-closure-borrows-arg.rs:13:13: 13:21
             scope 3 {
-                debug variable => _10;   // in scope 3 at $DIR/inline-closure-borrows-arg.rs:16:5: 16:12
+                debug variable => _10;   // in scope 3 at $DIR/inline-closure-borrows-arg.rs:13:13: 13:21
             }
         }
     }
@@ -38,10 +38,10 @@ fn foo(_1: T, _2: &i32) -> i32 {
         _8 = move (_5.0: &i32);          // scope 1 at $DIR/inline-closure-borrows-arg.rs:16:5: 16:12
         StorageLive(_9);                 // scope 1 at $DIR/inline-closure-borrows-arg.rs:16:5: 16:12
         _9 = move (_5.1: &i32);          // scope 1 at $DIR/inline-closure-borrows-arg.rs:16:5: 16:12
-        StorageLive(_10);                // scope 2 at $DIR/inline-closure-borrows-arg.rs:16:5: 16:12
-        _10 = _8;                        // scope 2 at $DIR/inline-closure-borrows-arg.rs:16:5: 16:12
-        _0 = (*_10);                     // scope 3 at $DIR/inline-closure-borrows-arg.rs:16:5: 16:12
-        StorageDead(_10);                // scope 2 at $DIR/inline-closure-borrows-arg.rs:16:5: 16:12
+        StorageLive(_10);                // scope 2 at $DIR/inline-closure-borrows-arg.rs:13:13: 13:21
+        _10 = _8;                        // scope 2 at $DIR/inline-closure-borrows-arg.rs:13:24: 13:27
+        _0 = (*_10);                     // scope 3 at $DIR/inline-closure-borrows-arg.rs:14:9: 14:18
+        StorageDead(_10);                // scope 2 at $DIR/inline-closure-borrows-arg.rs:15:5: 15:6
         StorageDead(_9);                 // scope 1 at $DIR/inline-closure-borrows-arg.rs:16:5: 16:12
         StorageDead(_8);                 // scope 1 at $DIR/inline-closure-borrows-arg.rs:16:5: 16:12
         StorageDead(_7);                 // scope 1 at $DIR/inline-closure-borrows-arg.rs:16:11: 16:12

--- a/src/test/mir-opt/inline/inline_closure_captures.foo.Inline.after.mir
+++ b/src/test/mir-opt/inline/inline_closure_captures.foo.Inline.after.mir
@@ -14,11 +14,11 @@ fn foo(_1: T, _2: i32) -> (i32, T) {
     scope 1 {
         debug x => _3;                   // in scope 1 at $DIR/inline-closure-captures.rs:11:9: 11:10
         scope 2 (inlined foo::<T>::{closure#0}) { // at $DIR/inline-closure-captures.rs:12:5: 12:9
-            debug _q => _9;              // in scope 2 at $DIR/inline-closure-captures.rs:12:5: 12:9
-            debug q => (*((*_6).0: &i32)); // in scope 2 at $DIR/inline-closure-captures.rs:12:5: 12:9
-            debug t => (*((*_6).1: &T)); // in scope 2 at $DIR/inline-closure-captures.rs:12:5: 12:9
-            let mut _10: i32;            // in scope 2 at $DIR/inline-closure-captures.rs:12:5: 12:9
-            let mut _11: T;              // in scope 2 at $DIR/inline-closure-captures.rs:12:5: 12:9
+            debug _q => _9;              // in scope 2 at $DIR/inline-closure-captures.rs:11:14: 11:16
+            debug q => (*((*_6).0: &i32)); // in scope 2 at $DIR/inline-closure-captures.rs:10:23: 10:24
+            debug t => (*((*_6).1: &T)); // in scope 2 at $DIR/inline-closure-captures.rs:10:17: 10:18
+            let mut _10: i32;            // in scope 2 at $DIR/inline-closure-captures.rs:11:19: 11:20
+            let mut _11: T;              // in scope 2 at $DIR/inline-closure-captures.rs:11:22: 11:23
         }
     }
 
@@ -40,14 +40,14 @@ fn foo(_1: T, _2: i32) -> (i32, T) {
         (_7.0: i32) = move _8;           // scope 1 at $DIR/inline-closure-captures.rs:12:5: 12:9
         StorageLive(_9);                 // scope 1 at $DIR/inline-closure-captures.rs:12:5: 12:9
         _9 = move (_7.0: i32);           // scope 1 at $DIR/inline-closure-captures.rs:12:5: 12:9
-        StorageLive(_10);                // scope 2 at $DIR/inline-closure-captures.rs:12:5: 12:9
-        _10 = (*((*_6).0: &i32));        // scope 2 at $DIR/inline-closure-captures.rs:12:5: 12:9
-        StorageLive(_11);                // scope 2 at $DIR/inline-closure-captures.rs:12:5: 12:9
-        _11 = (*((*_6).1: &T));          // scope 2 at $DIR/inline-closure-captures.rs:12:5: 12:9
-        (_0.0: i32) = move _10;          // scope 2 at $DIR/inline-closure-captures.rs:12:5: 12:9
-        (_0.1: T) = move _11;            // scope 2 at $DIR/inline-closure-captures.rs:12:5: 12:9
-        StorageDead(_11);                // scope 2 at $DIR/inline-closure-captures.rs:12:5: 12:9
-        StorageDead(_10);                // scope 2 at $DIR/inline-closure-captures.rs:12:5: 12:9
+        StorageLive(_10);                // scope 2 at $DIR/inline-closure-captures.rs:11:19: 11:20
+        _10 = (*((*_6).0: &i32));        // scope 2 at $DIR/inline-closure-captures.rs:11:19: 11:20
+        StorageLive(_11);                // scope 2 at $DIR/inline-closure-captures.rs:11:22: 11:23
+        _11 = (*((*_6).1: &T));          // scope 2 at $DIR/inline-closure-captures.rs:11:22: 11:23
+        (_0.0: i32) = move _10;          // scope 2 at $DIR/inline-closure-captures.rs:11:18: 11:24
+        (_0.1: T) = move _11;            // scope 2 at $DIR/inline-closure-captures.rs:11:18: 11:24
+        StorageDead(_11);                // scope 2 at $DIR/inline-closure-captures.rs:11:23: 11:24
+        StorageDead(_10);                // scope 2 at $DIR/inline-closure-captures.rs:11:23: 11:24
         StorageDead(_9);                 // scope 1 at $DIR/inline-closure-captures.rs:12:5: 12:9
         StorageDead(_8);                 // scope 1 at $DIR/inline-closure-captures.rs:12:8: 12:9
         StorageDead(_7);                 // scope 1 at $DIR/inline-closure-captures.rs:12:8: 12:9

--- a/src/test/mir-opt/inline/inline_cycle.one.Inline.diff
+++ b/src/test/mir-opt/inline/inline_cycle.one.Inline.diff
@@ -10,11 +10,11 @@
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/inline-cycle.rs:14:5: 14:24
 -         _1 = <C as Call>::call() -> bb1; // scope 0 at $DIR/inline-cycle.rs:14:5: 14:24
-+         _1 = <A<C> as Call>::call() -> bb1; // scope 1 at $DIR/inline-cycle.rs:14:5: 14:24
++         _1 = <A<C> as Call>::call() -> bb1; // scope 1 at $DIR/inline-cycle.rs:43:9: 43:23
                                            // mir::Constant
 -                                          // + span: $DIR/inline-cycle.rs:14:5: 14:22
 -                                          // + literal: Const { ty: fn() {<C as Call>::call}, val: Value(Scalar(<ZST>)) }
-+                                          // + span: $DIR/inline-cycle.rs:14:5: 14:24
++                                          // + span: $DIR/inline-cycle.rs:43:9: 43:21
 +                                          // + literal: Const { ty: fn() {<A<C> as Call>::call}, val: Value(Scalar(<ZST>)) }
       }
   

--- a/src/test/mir-opt/inline/inline_cycle.two.Inline.diff
+++ b/src/test/mir-opt/inline/inline_cycle.two.Inline.diff
@@ -5,12 +5,12 @@
       let mut _0: ();                      // return place in scope 0 at $DIR/inline-cycle.rs:48:10: 48:10
       let _1: ();                          // in scope 0 at $DIR/inline-cycle.rs:49:5: 49:12
 +     let mut _2: fn() {f};                // in scope 0 at $DIR/inline-cycle.rs:49:5: 49:12
-+     let mut _5: ();                      // in scope 0 at $DIR/inline-cycle.rs:49:5: 49:12
++     let mut _5: ();                      // in scope 0 at $DIR/inline-cycle.rs:54:5: 54:8
 +     scope 1 (inlined call::<fn() {f}>) { // at $DIR/inline-cycle.rs:49:5: 49:12
-+         debug f => _2;                   // in scope 1 at $DIR/inline-cycle.rs:49:5: 49:12
-+         let _3: ();                      // in scope 1 at $DIR/inline-cycle.rs:49:5: 49:12
-+         let mut _4: fn() {f};            // in scope 1 at $DIR/inline-cycle.rs:49:5: 49:12
-+         scope 2 (inlined <fn() {f} as FnOnce<()>>::call_once - shim(fn() {f})) { // at $DIR/inline-cycle.rs:49:5: 49:12
++         debug f => _2;                   // in scope 1 at $DIR/inline-cycle.rs:53:22: 53:23
++         let _3: ();                      // in scope 1 at $DIR/inline-cycle.rs:54:5: 54:8
++         let mut _4: fn() {f};            // in scope 1 at $DIR/inline-cycle.rs:54:5: 54:6
++         scope 2 (inlined <fn() {f} as FnOnce<()>>::call_once - shim(fn() {f})) { // at $DIR/inline-cycle.rs:54:5: 54:8
 +         }
 +     }
   
@@ -25,18 +25,18 @@
 -                                          // mir::Constant
                                            // + span: $DIR/inline-cycle.rs:49:10: 49:11
                                            // + literal: Const { ty: fn() {f}, val: Value(Scalar(<ZST>)) }
-+         StorageLive(_3);                 // scope 1 at $DIR/inline-cycle.rs:49:5: 49:12
-+         StorageLive(_4);                 // scope 1 at $DIR/inline-cycle.rs:49:5: 49:12
-+         _4 = move _2;                    // scope 1 at $DIR/inline-cycle.rs:49:5: 49:12
-+         StorageLive(_5);                 // scope 1 at $DIR/inline-cycle.rs:49:5: 49:12
-+         _5 = const ();                   // scope 1 at $DIR/inline-cycle.rs:49:5: 49:12
-+         _3 = move _4() -> bb1;           // scope 2 at $DIR/inline-cycle.rs:49:5: 49:12
++         StorageLive(_3);                 // scope 1 at $DIR/inline-cycle.rs:54:5: 54:8
++         StorageLive(_4);                 // scope 1 at $DIR/inline-cycle.rs:54:5: 54:6
++         _4 = move _2;                    // scope 1 at $DIR/inline-cycle.rs:54:5: 54:6
++         StorageLive(_5);                 // scope 1 at $DIR/inline-cycle.rs:54:5: 54:8
++         _5 = const ();                   // scope 1 at $DIR/inline-cycle.rs:54:5: 54:8
++         _3 = move _4() -> bb1;           // scope 2 at $SRC_DIR/core/src/ops/function.rs:LL:COL
       }
   
       bb1: {
-+         StorageDead(_5);                 // scope 1 at $DIR/inline-cycle.rs:49:5: 49:12
-+         StorageDead(_4);                 // scope 1 at $DIR/inline-cycle.rs:49:5: 49:12
-+         StorageDead(_3);                 // scope 1 at $DIR/inline-cycle.rs:49:5: 49:12
++         StorageDead(_5);                 // scope 1 at $DIR/inline-cycle.rs:54:5: 54:8
++         StorageDead(_4);                 // scope 1 at $DIR/inline-cycle.rs:54:7: 54:8
++         StorageDead(_3);                 // scope 1 at $DIR/inline-cycle.rs:54:8: 54:9
 +         StorageDead(_2);                 // scope 0 at $DIR/inline-cycle.rs:49:5: 49:12
           StorageDead(_1);                 // scope 0 at $DIR/inline-cycle.rs:49:12: 49:13
           _0 = const ();                   // scope 0 at $DIR/inline-cycle.rs:48:10: 50:2

--- a/src/test/mir-opt/inline/inline_cycle_generic.main.Inline.diff
+++ b/src/test/mir-opt/inline/inline_cycle_generic.main.Inline.diff
@@ -5,18 +5,18 @@
       let mut _0: ();                      // return place in scope 0 at $DIR/inline-cycle-generic.rs:8:11: 8:11
       let _1: ();                          // in scope 0 at $DIR/inline-cycle-generic.rs:9:5: 9:24
 +     scope 1 (inlined <C as Call>::call) { // at $DIR/inline-cycle-generic.rs:9:5: 9:24
-+         scope 2 (inlined <B<A> as Call>::call) { // at $DIR/inline-cycle-generic.rs:9:5: 9:24
++         scope 2 (inlined <B<A> as Call>::call) { // at $DIR/inline-cycle-generic.rs:38:9: 38:31
 +         }
 +     }
   
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/inline-cycle-generic.rs:9:5: 9:24
 -         _1 = <C as Call>::call() -> bb1; // scope 0 at $DIR/inline-cycle-generic.rs:9:5: 9:24
-+         _1 = <A as Call>::call() -> bb1; // scope 2 at $DIR/inline-cycle-generic.rs:9:5: 9:24
++         _1 = <A as Call>::call() -> bb1; // scope 2 at $DIR/inline-cycle-generic.rs:31:9: 31:28
                                            // mir::Constant
 -                                          // + span: $DIR/inline-cycle-generic.rs:9:5: 9:22
 -                                          // + literal: Const { ty: fn() {<C as Call>::call}, val: Value(Scalar(<ZST>)) }
-+                                          // + span: $DIR/inline-cycle-generic.rs:9:5: 9:24
++                                          // + span: $DIR/inline-cycle-generic.rs:31:9: 31:26
 +                                          // + literal: Const { ty: fn() {<A as Call>::call}, val: Value(Scalar(<ZST>)) }
       }
   

--- a/src/test/mir-opt/inline/inline_diverging.f.Inline.diff
+++ b/src/test/mir-opt/inline/inline_diverging.f.Inline.diff
@@ -20,7 +20,7 @@
 +     }
 + 
 +     bb1: {
-+         goto -> bb1;                     // scope 1 at $DIR/inline-diverging.rs:8:5: 8:12
++         goto -> bb1;                     // scope 1 at $DIR/inline-diverging.rs:39:5: 39:12
       }
   }
   

--- a/src/test/mir-opt/inline/inline_diverging.g.Inline.diff
+++ b/src/test/mir-opt/inline/inline_diverging.g.Inline.diff
@@ -35,14 +35,14 @@
           StorageLive(_6);                 // scope 0 at $DIR/inline-diverging.rs:16:9: 16:16
 -         panic();                         // scope 0 at $DIR/inline-diverging.rs:16:9: 16:16
 +         StorageLive(_7);                 // scope 0 at $DIR/inline-diverging.rs:16:9: 16:16
-+         begin_panic::<&str>(const "explicit panic"); // scope 1 at $DIR/inline-diverging.rs:16:9: 16:16
++         begin_panic::<&str>(const "explicit panic"); // scope 1 at $SRC_DIR/std/src/panic.rs:LL:COL
                                            // mir::Constant
 -                                          // + span: $DIR/inline-diverging.rs:16:9: 16:14
 -                                          // + literal: Const { ty: fn() -> ! {panic}, val: Value(Scalar(<ZST>)) }
-+                                          // + span: $DIR/inline-diverging.rs:16:9: 16:16
++                                          // + span: $SRC_DIR/std/src/panic.rs:LL:COL
 +                                          // + literal: Const { ty: fn(&str) -> ! {begin_panic::<&str>}, val: Value(Scalar(<ZST>)) }
 +                                          // mir::Constant
-+                                          // + span: $DIR/inline-diverging.rs:16:9: 16:16
++                                          // + span: $SRC_DIR/std/src/panic.rs:LL:COL
 +                                          // + literal: Const { ty: &str, val: Value(Slice { data: Allocation { bytes: [101, 120, 112, 108, 105, 99, 105, 116, 32, 112, 97, 110, 105, 99], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [16383], len: Size { raw: 14 } }, align: Align { pow2: 0 }, mutability: Not, extra: () }, start: 0, end: 14 }) }
       }
   }

--- a/src/test/mir-opt/inline/inline_diverging.h.Inline.diff
+++ b/src/test/mir-opt/inline/inline_diverging.h.Inline.diff
@@ -5,28 +5,28 @@
       let mut _0: ();                      // return place in scope 0 at $DIR/inline-diverging.rs:21:12: 21:12
       let _1: (!, !);                      // in scope 0 at $DIR/inline-diverging.rs:22:5: 22:22
 +     let mut _2: fn() -> ! {sleep};       // in scope 0 at $DIR/inline-diverging.rs:22:5: 22:22
-+     let mut _9: ();                      // in scope 0 at $DIR/inline-diverging.rs:22:5: 22:22
-+     let mut _10: ();                     // in scope 0 at $DIR/inline-diverging.rs:22:5: 22:22
++     let mut _9: ();                      // in scope 0 at $DIR/inline-diverging.rs:27:13: 27:16
++     let mut _10: ();                     // in scope 0 at $DIR/inline-diverging.rs:28:13: 28:16
 +     scope 1 (inlined call_twice::<!, fn() -> ! {sleep}>) { // at $DIR/inline-diverging.rs:22:5: 22:22
-+         debug f => _2;                   // in scope 1 at $DIR/inline-diverging.rs:22:5: 22:22
-+         let _3: !;                       // in scope 1 at $DIR/inline-diverging.rs:22:5: 22:22
-+         let mut _4: &fn() -> ! {sleep};  // in scope 1 at $DIR/inline-diverging.rs:22:5: 22:22
-+         let mut _6: &fn() -> ! {sleep};  // in scope 1 at $DIR/inline-diverging.rs:22:5: 22:22
-+         let mut _7: !;                   // in scope 1 at $DIR/inline-diverging.rs:22:5: 22:22
-+         let mut _8: !;                   // in scope 1 at $DIR/inline-diverging.rs:22:5: 22:22
++         debug f => _2;                   // in scope 1 at $DIR/inline-diverging.rs:26:36: 26:37
++         let _3: !;                       // in scope 1 at $DIR/inline-diverging.rs:27:9: 27:10
++         let mut _4: &fn() -> ! {sleep};  // in scope 1 at $DIR/inline-diverging.rs:27:13: 27:14
++         let mut _6: &fn() -> ! {sleep};  // in scope 1 at $DIR/inline-diverging.rs:28:13: 28:14
++         let mut _7: !;                   // in scope 1 at $DIR/inline-diverging.rs:29:6: 29:7
++         let mut _8: !;                   // in scope 1 at $DIR/inline-diverging.rs:29:9: 29:10
 +         scope 2 {
-+             debug a => _3;               // in scope 2 at $DIR/inline-diverging.rs:22:5: 22:22
-+             let _5: !;                   // in scope 2 at $DIR/inline-diverging.rs:22:5: 22:22
++             debug a => _3;               // in scope 2 at $DIR/inline-diverging.rs:27:9: 27:10
++             let _5: !;                   // in scope 2 at $DIR/inline-diverging.rs:28:9: 28:10
 +             scope 3 {
-+                 debug b => _5;           // in scope 3 at $DIR/inline-diverging.rs:22:5: 22:22
++                 debug b => _5;           // in scope 3 at $DIR/inline-diverging.rs:28:9: 28:10
 +             }
-+             scope 6 (inlined <fn() -> ! {sleep} as Fn<()>>::call - shim(fn() -> ! {sleep})) { // at $DIR/inline-diverging.rs:22:5: 22:22
-+                 scope 7 (inlined sleep) { // at $DIR/inline-diverging.rs:22:5: 22:22
++             scope 6 (inlined <fn() -> ! {sleep} as Fn<()>>::call - shim(fn() -> ! {sleep})) { // at $DIR/inline-diverging.rs:28:13: 28:16
++                 scope 7 (inlined sleep) { // at $SRC_DIR/core/src/ops/function.rs:LL:COL
 +                 }
 +             }
 +         }
-+         scope 4 (inlined <fn() -> ! {sleep} as Fn<()>>::call - shim(fn() -> ! {sleep})) { // at $DIR/inline-diverging.rs:22:5: 22:22
-+             scope 5 (inlined sleep) {    // at $DIR/inline-diverging.rs:22:5: 22:22
++         scope 4 (inlined <fn() -> ! {sleep} as Fn<()>>::call - shim(fn() -> ! {sleep})) { // at $DIR/inline-diverging.rs:27:13: 27:16
++             scope 5 (inlined sleep) {    // at $SRC_DIR/core/src/ops/function.rs:LL:COL
 +             }
 +         }
 +     }
@@ -42,19 +42,19 @@
 -                                          // mir::Constant
                                            // + span: $DIR/inline-diverging.rs:22:16: 22:21
                                            // + literal: Const { ty: fn() -> ! {sleep}, val: Value(Scalar(<ZST>)) }
-+         StorageLive(_3);                 // scope 1 at $DIR/inline-diverging.rs:22:5: 22:22
-+         StorageLive(_4);                 // scope 1 at $DIR/inline-diverging.rs:22:5: 22:22
-+         _4 = &_2;                        // scope 1 at $DIR/inline-diverging.rs:22:5: 22:22
-+         StorageLive(_9);                 // scope 1 at $DIR/inline-diverging.rs:22:5: 22:22
-+         _9 = const ();                   // scope 1 at $DIR/inline-diverging.rs:22:5: 22:22
-+         goto -> bb1;                     // scope 5 at $DIR/inline-diverging.rs:22:5: 22:22
++         StorageLive(_3);                 // scope 1 at $DIR/inline-diverging.rs:27:9: 27:10
++         StorageLive(_4);                 // scope 1 at $DIR/inline-diverging.rs:27:13: 27:14
++         _4 = &_2;                        // scope 1 at $DIR/inline-diverging.rs:27:13: 27:14
++         StorageLive(_9);                 // scope 1 at $DIR/inline-diverging.rs:27:13: 27:16
++         _9 = const ();                   // scope 1 at $DIR/inline-diverging.rs:27:13: 27:16
++         goto -> bb1;                     // scope 5 at $DIR/inline-diverging.rs:39:5: 39:12
       }
   
       bb1: {
 -         StorageDead(_1);                 // scope 0 at $DIR/inline-diverging.rs:22:22: 22:23
 -         _0 = const ();                   // scope 0 at $DIR/inline-diverging.rs:21:12: 23:2
 -         return;                          // scope 0 at $DIR/inline-diverging.rs:23:2: 23:2
-+         goto -> bb1;                     // scope 5 at $DIR/inline-diverging.rs:22:5: 22:22
++         goto -> bb1;                     // scope 5 at $DIR/inline-diverging.rs:39:5: 39:12
       }
   }
   

--- a/src/test/mir-opt/inline/inline_generator.main.Inline.diff
+++ b/src/test/mir-opt/inline/inline_generator.main.Inline.diff
@@ -14,22 +14,22 @@
 +     scope 2 (inlined g) {                // at $DIR/inline-generator.rs:9:28: 9:31
 +     }
 +     scope 3 (inlined Pin::<&mut [generator@$DIR/inline-generator.rs:15:5: 15:41]>::new) { // at $DIR/inline-generator.rs:9:14: 9:32
-+         debug pointer => _3;             // in scope 3 at $DIR/inline-generator.rs:9:14: 9:32
-+         let mut _5: &mut [generator@$DIR/inline-generator.rs:15:5: 15:41]; // in scope 3 at $DIR/inline-generator.rs:9:14: 9:32
++         debug pointer => _3;             // in scope 3 at $SRC_DIR/core/src/pin.rs:LL:COL
++         let mut _5: &mut [generator@$DIR/inline-generator.rs:15:5: 15:41]; // in scope 3 at $SRC_DIR/core/src/pin.rs:LL:COL
 +         scope 4 {
-+             scope 5 (inlined Pin::<&mut [generator@$DIR/inline-generator.rs:15:5: 15:41]>::new_unchecked) { // at $DIR/inline-generator.rs:9:14: 9:32
-+                 debug pointer => _5;     // in scope 5 at $DIR/inline-generator.rs:9:14: 9:32
-+                 let mut _6: &mut [generator@$DIR/inline-generator.rs:15:5: 15:41]; // in scope 5 at $DIR/inline-generator.rs:9:14: 9:32
++             scope 5 (inlined Pin::<&mut [generator@$DIR/inline-generator.rs:15:5: 15:41]>::new_unchecked) { // at $SRC_DIR/core/src/pin.rs:LL:COL
++                 debug pointer => _5;     // in scope 5 at $SRC_DIR/core/src/pin.rs:LL:COL
++                 let mut _6: &mut [generator@$DIR/inline-generator.rs:15:5: 15:41]; // in scope 5 at $SRC_DIR/core/src/pin.rs:LL:COL
 +             }
 +         }
 +     }
 +     scope 6 (inlined g::{closure#0}) {   // at $DIR/inline-generator.rs:9:14: 9:46
-+         debug a => _11;                  // in scope 6 at $DIR/inline-generator.rs:9:14: 9:46
-+         let mut _8: i32;                 // in scope 6 at $DIR/inline-generator.rs:9:14: 9:46
-+         let mut _9: bool;                // in scope 6 at $DIR/inline-generator.rs:9:14: 9:46
-+         let mut _10: bool;               // in scope 6 at $DIR/inline-generator.rs:9:14: 9:46
-+         let _11: bool;                   // in scope 6 at $DIR/inline-generator.rs:9:14: 9:46
-+         let mut _12: u32;                // in scope 6 at $DIR/inline-generator.rs:9:14: 9:46
++         debug a => _11;                  // in scope 6 at $DIR/inline-generator.rs:15:6: 15:7
++         let mut _8: i32;                 // in scope 6 at $DIR/inline-generator.rs:15:17: 15:39
++         let mut _9: bool;                // in scope 6 at $DIR/inline-generator.rs:15:20: 15:21
++         let mut _10: bool;               // in scope 6 at $DIR/inline-generator.rs:15:9: 15:9
++         let _11: bool;                   // in scope 6 at $DIR/inline-generator.rs:15:6: 15:7
++         let mut _12: u32;                // in scope 6 at $DIR/inline-generator.rs:15:5: 15:41
 +     }
   
       bb0: {
@@ -44,7 +44,7 @@
 -     }
 - 
 -     bb1: {
-+         discriminant(_4) = 0;            // scope 2 at $DIR/inline-generator.rs:9:28: 9:31
++         discriminant(_4) = 0;            // scope 2 at $DIR/inline-generator.rs:15:5: 15:41
           _3 = &mut _4;                    // scope 0 at $DIR/inline-generator.rs:9:23: 9:31
 -         _2 = Pin::<&mut impl Generator<bool>>::new(move _3) -> [return: bb2, unwind: bb4]; // scope 0 at $DIR/inline-generator.rs:9:14: 9:32
 -                                          // mir::Constant
@@ -54,13 +54,13 @@
 -     }
 - 
 -     bb2: {
-+         StorageLive(_5);                 // scope 4 at $DIR/inline-generator.rs:9:14: 9:32
-+         _5 = move _3;                    // scope 4 at $DIR/inline-generator.rs:9:14: 9:32
-+         StorageLive(_6);                 // scope 5 at $DIR/inline-generator.rs:9:14: 9:32
-+         _6 = move _5;                    // scope 5 at $DIR/inline-generator.rs:9:14: 9:32
-+         (_2.0: &mut [generator@$DIR/inline-generator.rs:15:5: 15:41]) = move _6; // scope 5 at $DIR/inline-generator.rs:9:14: 9:32
-+         StorageDead(_6);                 // scope 5 at $DIR/inline-generator.rs:9:14: 9:32
-+         StorageDead(_5);                 // scope 4 at $DIR/inline-generator.rs:9:14: 9:32
++         StorageLive(_5);                 // scope 4 at $SRC_DIR/core/src/pin.rs:LL:COL
++         _5 = move _3;                    // scope 4 at $SRC_DIR/core/src/pin.rs:LL:COL
++         StorageLive(_6);                 // scope 5 at $SRC_DIR/core/src/pin.rs:LL:COL
++         _6 = move _5;                    // scope 5 at $SRC_DIR/core/src/pin.rs:LL:COL
++         (_2.0: &mut [generator@$DIR/inline-generator.rs:15:5: 15:41]) = move _6; // scope 5 at $SRC_DIR/core/src/pin.rs:LL:COL
++         StorageDead(_6);                 // scope 5 at $SRC_DIR/core/src/pin.rs:LL:COL
++         StorageDead(_5);                 // scope 4 at $SRC_DIR/core/src/pin.rs:LL:COL
           StorageDead(_3);                 // scope 0 at $DIR/inline-generator.rs:9:31: 9:32
 -         _1 = <impl Generator<bool> as Generator<bool>>::resume(move _2, const false) -> [return: bb3, unwind: bb4]; // scope 0 at $DIR/inline-generator.rs:9:14: 9:46
 -                                          // mir::Constant
@@ -71,8 +71,8 @@
 +         StorageLive(_10);                // scope 0 at $DIR/inline-generator.rs:9:14: 9:46
 +         StorageLive(_11);                // scope 0 at $DIR/inline-generator.rs:9:14: 9:46
 +         StorageLive(_12);                // scope 0 at $DIR/inline-generator.rs:9:14: 9:46
-+         _12 = discriminant((*(_2.0: &mut [generator@$DIR/inline-generator.rs:15:5: 15:41]))); // scope 6 at $DIR/inline-generator.rs:9:14: 9:46
-+         switchInt(move _12) -> [0_u32: bb3, 1_u32: bb8, 3_u32: bb7, otherwise: bb9]; // scope 6 at $DIR/inline-generator.rs:9:14: 9:46
++         _12 = discriminant((*(_2.0: &mut [generator@$DIR/inline-generator.rs:15:5: 15:41]))); // scope 6 at $DIR/inline-generator.rs:15:5: 15:41
++         switchInt(move _12) -> [0_u32: bb3, 1_u32: bb8, 3_u32: bb7, otherwise: bb9]; // scope 6 at $DIR/inline-generator.rs:15:5: 15:41
       }
   
 -     bb3: {
@@ -94,47 +94,47 @@
 +     }
 + 
 +     bb3: {
-+         _11 = move _7;                   // scope 6 at $DIR/inline-generator.rs:9:14: 9:46
-+         StorageLive(_8);                 // scope 6 at $DIR/inline-generator.rs:9:14: 9:46
-+         StorageLive(_9);                 // scope 6 at $DIR/inline-generator.rs:9:14: 9:46
-+         _9 = _11;                        // scope 6 at $DIR/inline-generator.rs:9:14: 9:46
-+         switchInt(move _9) -> [false: bb5, otherwise: bb4]; // scope 6 at $DIR/inline-generator.rs:9:14: 9:46
++         _11 = move _7;                   // scope 6 at $DIR/inline-generator.rs:15:5: 15:41
++         StorageLive(_8);                 // scope 6 at $DIR/inline-generator.rs:15:17: 15:39
++         StorageLive(_9);                 // scope 6 at $DIR/inline-generator.rs:15:20: 15:21
++         _9 = _11;                        // scope 6 at $DIR/inline-generator.rs:15:20: 15:21
++         switchInt(move _9) -> [false: bb5, otherwise: bb4]; // scope 6 at $DIR/inline-generator.rs:15:20: 15:21
 +     }
 + 
 +     bb4: {
-+         _8 = const 7_i32;                // scope 6 at $DIR/inline-generator.rs:9:14: 9:46
-+         goto -> bb6;                     // scope 6 at $DIR/inline-generator.rs:9:14: 9:46
++         _8 = const 7_i32;                // scope 6 at $DIR/inline-generator.rs:15:24: 15:25
++         goto -> bb6;                     // scope 6 at $DIR/inline-generator.rs:15:17: 15:39
 +     }
 + 
 +     bb5: {
-+         _8 = const 13_i32;               // scope 6 at $DIR/inline-generator.rs:9:14: 9:46
-+         goto -> bb6;                     // scope 6 at $DIR/inline-generator.rs:9:14: 9:46
++         _8 = const 13_i32;               // scope 6 at $DIR/inline-generator.rs:15:35: 15:37
++         goto -> bb6;                     // scope 6 at $DIR/inline-generator.rs:15:17: 15:39
 +     }
 + 
 +     bb6: {
-+         StorageDead(_9);                 // scope 6 at $DIR/inline-generator.rs:9:14: 9:46
-+         ((_1 as Yielded).0: i32) = move _8; // scope 6 at $DIR/inline-generator.rs:9:14: 9:46
-+         discriminant(_1) = 0;            // scope 6 at $DIR/inline-generator.rs:9:14: 9:46
-+         discriminant((*(_2.0: &mut [generator@$DIR/inline-generator.rs:15:5: 15:41]))) = 3; // scope 6 at $DIR/inline-generator.rs:9:14: 9:46
++         StorageDead(_9);                 // scope 6 at $DIR/inline-generator.rs:15:38: 15:39
++         ((_1 as Yielded).0: i32) = move _8; // scope 6 at $DIR/inline-generator.rs:15:11: 15:39
++         discriminant(_1) = 0;            // scope 6 at $DIR/inline-generator.rs:15:11: 15:39
++         discriminant((*(_2.0: &mut [generator@$DIR/inline-generator.rs:15:5: 15:41]))) = 3; // scope 6 at $DIR/inline-generator.rs:15:11: 15:39
 +         goto -> bb1;                     // scope 0 at $DIR/inline-generator.rs:15:11: 15:39
 +     }
 + 
 +     bb7: {
-+         StorageLive(_8);                 // scope 6 at $DIR/inline-generator.rs:9:14: 9:46
-+         _10 = move _7;                   // scope 6 at $DIR/inline-generator.rs:9:14: 9:46
-+         StorageDead(_8);                 // scope 6 at $DIR/inline-generator.rs:9:14: 9:46
-+         ((_1 as Complete).0: bool) = move _10; // scope 6 at $DIR/inline-generator.rs:9:14: 9:46
-+         discriminant(_1) = 1;            // scope 6 at $DIR/inline-generator.rs:9:14: 9:46
-+         discriminant((*(_2.0: &mut [generator@$DIR/inline-generator.rs:15:5: 15:41]))) = 1; // scope 6 at $DIR/inline-generator.rs:9:14: 9:46
++         StorageLive(_8);                 // scope 6 at $DIR/inline-generator.rs:15:5: 15:41
++         _10 = move _7;                   // scope 6 at $DIR/inline-generator.rs:15:5: 15:41
++         StorageDead(_8);                 // scope 6 at $DIR/inline-generator.rs:15:38: 15:39
++         ((_1 as Complete).0: bool) = move _10; // scope 6 at $DIR/inline-generator.rs:15:41: 15:41
++         discriminant(_1) = 1;            // scope 6 at $DIR/inline-generator.rs:15:41: 15:41
++         discriminant((*(_2.0: &mut [generator@$DIR/inline-generator.rs:15:5: 15:41]))) = 1; // scope 6 at $DIR/inline-generator.rs:15:41: 15:41
 +         goto -> bb1;                     // scope 0 at $DIR/inline-generator.rs:15:41: 15:41
 +     }
 + 
 +     bb8: {
-+         assert(const false, "generator resumed after completion") -> [success: bb8, unwind: bb2]; // scope 6 at $DIR/inline-generator.rs:9:14: 9:46
++         assert(const false, "generator resumed after completion") -> [success: bb8, unwind: bb2]; // scope 6 at $DIR/inline-generator.rs:15:5: 15:41
 +     }
 + 
 +     bb9: {
-+         unreachable;                     // scope 6 at $DIR/inline-generator.rs:9:14: 9:46
++         unreachable;                     // scope 6 at $DIR/inline-generator.rs:15:5: 15:41
       }
   }
   

--- a/src/test/mir-opt/inline/inline_into_box_place.main.Inline.32bit.diff
+++ b/src/test/mir-opt/inline/inline_into_box_place.main.Inline.32bit.diff
@@ -34,7 +34,7 @@
 -         (*_5) = Vec::<u32>::new() -> [return: bb2, unwind: bb5]; // scope 0 at $DIR/inline-into-box-place.rs:8:33: 8:43
 +         StorageLive(_7);                 // scope 0 at $DIR/inline-into-box-place.rs:8:33: 8:43
 +         _7 = &mut (*_5);                 // scope 0 at $DIR/inline-into-box-place.rs:8:33: 8:43
-+         ((*_7).0: alloc::raw_vec::RawVec<u32>) = const alloc::raw_vec::RawVec::<u32> { ptr: Unique::<u32> { pointer: {0x4 as *const u32}, _marker: PhantomData::<u32> }, cap: 0_usize, alloc: std::alloc::Global }; // scope 3 at $DIR/inline-into-box-place.rs:8:33: 8:43
++         ((*_7).0: alloc::raw_vec::RawVec<u32>) = const alloc::raw_vec::RawVec::<u32> { ptr: Unique::<u32> { pointer: {0x4 as *const u32}, _marker: PhantomData::<u32> }, cap: 0_usize, alloc: std::alloc::Global }; // scope 3 at $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
                                            // mir::Constant
 -                                          // + span: $DIR/inline-into-box-place.rs:8:33: 8:41
 -                                          // + user_ty: UserType(1)
@@ -42,10 +42,10 @@
 -     }
 - 
 -     bb2: {
-+                                          // + span: $DIR/inline-into-box-place.rs:8:33: 8:43
++                                          // + span: $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
 +                                          // + user_ty: UserType(0)
 +                                          // + literal: Const { ty: alloc::raw_vec::RawVec<u32>, val: Value(ByRef { alloc: Allocation { bytes: [4, 0, 0, 0, 0, 0, 0, 0], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [255], len: Size { raw: 8 } }, align: Align { pow2: 2 }, mutability: Not, extra: () }, offset: Size { raw: 0 } }) }
-+         ((*_7).1: usize) = const 0_usize; // scope 3 at $DIR/inline-into-box-place.rs:8:33: 8:43
++         ((*_7).1: usize) = const 0_usize; // scope 3 at $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
 +         StorageDead(_7);                 // scope 0 at $DIR/inline-into-box-place.rs:8:33: 8:43
           _1 = move _5;                    // scope 0 at $DIR/inline-into-box-place.rs:8:29: 8:43
           StorageDead(_5);                 // scope 0 at $DIR/inline-into-box-place.rs:8:42: 8:43

--- a/src/test/mir-opt/inline/inline_into_box_place.main.Inline.64bit.diff
+++ b/src/test/mir-opt/inline/inline_into_box_place.main.Inline.64bit.diff
@@ -34,7 +34,7 @@
 -         (*_5) = Vec::<u32>::new() -> [return: bb2, unwind: bb5]; // scope 0 at $DIR/inline-into-box-place.rs:8:33: 8:43
 +         StorageLive(_7);                 // scope 0 at $DIR/inline-into-box-place.rs:8:33: 8:43
 +         _7 = &mut (*_5);                 // scope 0 at $DIR/inline-into-box-place.rs:8:33: 8:43
-+         ((*_7).0: alloc::raw_vec::RawVec<u32>) = const alloc::raw_vec::RawVec::<u32> { ptr: Unique::<u32> { pointer: {0x4 as *const u32}, _marker: PhantomData::<u32> }, cap: 0_usize, alloc: std::alloc::Global }; // scope 3 at $DIR/inline-into-box-place.rs:8:33: 8:43
++         ((*_7).0: alloc::raw_vec::RawVec<u32>) = const alloc::raw_vec::RawVec::<u32> { ptr: Unique::<u32> { pointer: {0x4 as *const u32}, _marker: PhantomData::<u32> }, cap: 0_usize, alloc: std::alloc::Global }; // scope 3 at $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
                                            // mir::Constant
 -                                          // + span: $DIR/inline-into-box-place.rs:8:33: 8:41
 -                                          // + user_ty: UserType(1)
@@ -42,10 +42,10 @@
 -     }
 - 
 -     bb2: {
-+                                          // + span: $DIR/inline-into-box-place.rs:8:33: 8:43
++                                          // + span: $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
 +                                          // + user_ty: UserType(0)
 +                                          // + literal: Const { ty: alloc::raw_vec::RawVec<u32>, val: Value(ByRef { alloc: Allocation { bytes: [4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [65535], len: Size { raw: 16 } }, align: Align { pow2: 3 }, mutability: Not, extra: () }, offset: Size { raw: 0 } }) }
-+         ((*_7).1: usize) = const 0_usize; // scope 3 at $DIR/inline-into-box-place.rs:8:33: 8:43
++         ((*_7).1: usize) = const 0_usize; // scope 3 at $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
 +         StorageDead(_7);                 // scope 0 at $DIR/inline-into-box-place.rs:8:33: 8:43
           _1 = move _5;                    // scope 0 at $DIR/inline-into-box-place.rs:8:29: 8:43
           StorageDead(_5);                 // scope 0 at $DIR/inline-into-box-place.rs:8:42: 8:43

--- a/src/test/mir-opt/inline/inline_options.main.Inline.after.mir
+++ b/src/test/mir-opt/inline/inline_options.main.Inline.after.mir
@@ -5,9 +5,9 @@ fn main() -> () {
     let _1: ();                          // in scope 0 at $DIR/inline-options.rs:9:5: 9:18
     let _2: ();                          // in scope 0 at $DIR/inline-options.rs:10:5: 10:21
     scope 1 (inlined inlined::<u32>) {   // at $DIR/inline-options.rs:10:5: 10:21
-        let _3: ();                      // in scope 1 at $DIR/inline-options.rs:10:5: 10:21
-        let _4: ();                      // in scope 1 at $DIR/inline-options.rs:10:5: 10:21
-        let _5: ();                      // in scope 1 at $DIR/inline-options.rs:10:5: 10:21
+        let _3: ();                      // in scope 1 at $DIR/inline-options.rs:16:23: 16:26
+        let _4: ();                      // in scope 1 at $DIR/inline-options.rs:16:28: 16:31
+        let _5: ();                      // in scope 1 at $DIR/inline-options.rs:16:33: 16:36
     }
 
     bb0: {
@@ -21,33 +21,33 @@ fn main() -> () {
     bb1: {
         StorageDead(_1);                 // scope 0 at $DIR/inline-options.rs:9:18: 9:19
         StorageLive(_2);                 // scope 0 at $DIR/inline-options.rs:10:5: 10:21
-        StorageLive(_3);                 // scope 1 at $DIR/inline-options.rs:10:5: 10:21
-        _3 = g() -> bb2;                 // scope 1 at $DIR/inline-options.rs:10:5: 10:21
+        StorageLive(_3);                 // scope 1 at $DIR/inline-options.rs:16:23: 16:26
+        _3 = g() -> bb2;                 // scope 1 at $DIR/inline-options.rs:16:23: 16:26
                                          // mir::Constant
-                                         // + span: $DIR/inline-options.rs:10:5: 10:21
+                                         // + span: $DIR/inline-options.rs:16:23: 16:24
                                          // + literal: Const { ty: fn() {g}, val: Value(Scalar(<ZST>)) }
     }
 
     bb2: {
-        StorageDead(_3);                 // scope 1 at $DIR/inline-options.rs:10:5: 10:21
-        StorageLive(_4);                 // scope 1 at $DIR/inline-options.rs:10:5: 10:21
-        _4 = g() -> bb3;                 // scope 1 at $DIR/inline-options.rs:10:5: 10:21
+        StorageDead(_3);                 // scope 1 at $DIR/inline-options.rs:16:26: 16:27
+        StorageLive(_4);                 // scope 1 at $DIR/inline-options.rs:16:28: 16:31
+        _4 = g() -> bb3;                 // scope 1 at $DIR/inline-options.rs:16:28: 16:31
                                          // mir::Constant
-                                         // + span: $DIR/inline-options.rs:10:5: 10:21
+                                         // + span: $DIR/inline-options.rs:16:28: 16:29
                                          // + literal: Const { ty: fn() {g}, val: Value(Scalar(<ZST>)) }
     }
 
     bb3: {
-        StorageDead(_4);                 // scope 1 at $DIR/inline-options.rs:10:5: 10:21
-        StorageLive(_5);                 // scope 1 at $DIR/inline-options.rs:10:5: 10:21
-        _5 = g() -> bb4;                 // scope 1 at $DIR/inline-options.rs:10:5: 10:21
+        StorageDead(_4);                 // scope 1 at $DIR/inline-options.rs:16:31: 16:32
+        StorageLive(_5);                 // scope 1 at $DIR/inline-options.rs:16:33: 16:36
+        _5 = g() -> bb4;                 // scope 1 at $DIR/inline-options.rs:16:33: 16:36
                                          // mir::Constant
-                                         // + span: $DIR/inline-options.rs:10:5: 10:21
+                                         // + span: $DIR/inline-options.rs:16:33: 16:34
                                          // + literal: Const { ty: fn() {g}, val: Value(Scalar(<ZST>)) }
     }
 
     bb4: {
-        StorageDead(_5);                 // scope 1 at $DIR/inline-options.rs:10:5: 10:21
+        StorageDead(_5);                 // scope 1 at $DIR/inline-options.rs:16:36: 16:37
         StorageDead(_2);                 // scope 0 at $DIR/inline-options.rs:10:21: 10:22
         _0 = const ();                   // scope 0 at $DIR/inline-options.rs:8:11: 11:2
         return;                          // scope 0 at $DIR/inline-options.rs:11:2: 11:2

--- a/src/test/mir-opt/inline/inline_retag.bar.Inline.after.mir
+++ b/src/test/mir-opt/inline/inline_retag.bar.Inline.after.mir
@@ -15,10 +15,10 @@ fn bar() -> bool {
         let mut _9: &i32;                // in scope 1 at $DIR/inline-retag.rs:12:11: 12:14
         let mut _10: &i32;               // in scope 1 at $DIR/inline-retag.rs:12:7: 12:9
         scope 2 (inlined foo) {          // at $DIR/inline-retag.rs:12:5: 12:15
-            debug x => _3;               // in scope 2 at $DIR/inline-retag.rs:12:5: 12:15
-            debug y => _6;               // in scope 2 at $DIR/inline-retag.rs:12:5: 12:15
-            let mut _11: i32;            // in scope 2 at $DIR/inline-retag.rs:12:5: 12:15
-            let mut _12: i32;            // in scope 2 at $DIR/inline-retag.rs:12:5: 12:15
+            debug x => _3;               // in scope 2 at $DIR/inline-retag.rs:16:8: 16:9
+            debug y => _6;               // in scope 2 at $DIR/inline-retag.rs:16:17: 16:18
+            let mut _11: i32;            // in scope 2 at $DIR/inline-retag.rs:17:5: 17:7
+            let mut _12: i32;            // in scope 2 at $DIR/inline-retag.rs:17:11: 17:13
         }
     }
 
@@ -52,15 +52,15 @@ fn bar() -> bool {
         Retag(_7);                       // scope 1 at $DIR/inline-retag.rs:12:11: 12:14
         _6 = &(*_7);                     // scope 1 at $DIR/inline-retag.rs:12:11: 12:14
         Retag(_6);                       // scope 1 at $DIR/inline-retag.rs:12:11: 12:14
-        Retag(_3);                       // scope 2 at $DIR/inline-retag.rs:12:5: 12:15
-        Retag(_6);                       // scope 2 at $DIR/inline-retag.rs:12:5: 12:15
-        StorageLive(_11);                // scope 2 at $DIR/inline-retag.rs:12:5: 12:15
-        _11 = (*_3);                     // scope 2 at $DIR/inline-retag.rs:12:5: 12:15
-        StorageLive(_12);                // scope 2 at $DIR/inline-retag.rs:12:5: 12:15
-        _12 = (*_6);                     // scope 2 at $DIR/inline-retag.rs:12:5: 12:15
-        _0 = Eq(move _11, move _12);     // scope 2 at $DIR/inline-retag.rs:12:5: 12:15
-        StorageDead(_12);                // scope 2 at $DIR/inline-retag.rs:12:5: 12:15
-        StorageDead(_11);                // scope 2 at $DIR/inline-retag.rs:12:5: 12:15
+        Retag(_3);                       // scope 2 at $DIR/inline-retag.rs:16:1: 18:2
+        Retag(_6);                       // scope 2 at $DIR/inline-retag.rs:16:1: 18:2
+        StorageLive(_11);                // scope 2 at $DIR/inline-retag.rs:17:5: 17:7
+        _11 = (*_3);                     // scope 2 at $DIR/inline-retag.rs:17:5: 17:7
+        StorageLive(_12);                // scope 2 at $DIR/inline-retag.rs:17:11: 17:13
+        _12 = (*_6);                     // scope 2 at $DIR/inline-retag.rs:17:11: 17:13
+        _0 = Eq(move _11, move _12);     // scope 2 at $DIR/inline-retag.rs:17:5: 17:13
+        StorageDead(_12);                // scope 2 at $DIR/inline-retag.rs:17:12: 17:13
+        StorageDead(_11);                // scope 2 at $DIR/inline-retag.rs:17:12: 17:13
         StorageDead(_6);                 // scope 1 at $DIR/inline-retag.rs:12:14: 12:15
         StorageDead(_3);                 // scope 1 at $DIR/inline-retag.rs:12:14: 12:15
         StorageDead(_2);                 // scope 1 at $DIR/inline-retag.rs:12:14: 12:15

--- a/src/test/mir-opt/inline/inline_shims.clone.Inline.diff
+++ b/src/test/mir-opt/inline/inline_shims.clone.Inline.diff
@@ -18,7 +18,7 @@
 -     }
 - 
 -     bb1: {
-+         _0 = (*_2);                      // scope 1 at $DIR/inline-shims.rs:6:5: 6:14
++         _0 = (*_2);                      // scope 1 at $SRC_DIR/core/src/clone.rs:LL:COL
           StorageDead(_2);                 // scope 0 at $DIR/inline-shims.rs:6:13: 6:14
           return;                          // scope 0 at $DIR/inline-shims.rs:7:2: 7:2
       }

--- a/src/test/mir-opt/inline/inline_shims.drop.Inline.diff
+++ b/src/test/mir-opt/inline/inline_shims.drop.Inline.diff
@@ -12,8 +12,8 @@
       }
       scope 2 {
 +         scope 3 (inlined std::ptr::drop_in_place::<Option<B>> - shim(Some(Option<B>))) { // at $DIR/inline-shims.rs:12:14: 12:40
-+             let mut _6: isize;           // in scope 3 at $DIR/inline-shims.rs:12:14: 12:40
-+             let mut _7: isize;           // in scope 3 at $DIR/inline-shims.rs:12:14: 12:40
++             let mut _6: isize;           // in scope 3 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
++             let mut _7: isize;           // in scope 3 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
 +         }
       }
   
@@ -38,8 +38,8 @@
 -                                          // + literal: Const { ty: unsafe fn(*mut Option<B>) {std::ptr::drop_in_place::<Option<B>>}, val: Value(Scalar(<ZST>)) }
 +         StorageLive(_6);                 // scope 2 at $DIR/inline-shims.rs:12:14: 12:40
 +         StorageLive(_7);                 // scope 2 at $DIR/inline-shims.rs:12:14: 12:40
-+         _6 = discriminant((*_5));        // scope 3 at $DIR/inline-shims.rs:12:14: 12:40
-+         switchInt(move _6) -> [0_isize: bb2, otherwise: bb3]; // scope 3 at $DIR/inline-shims.rs:12:14: 12:40
++         _6 = discriminant((*_5));        // scope 3 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
++         switchInt(move _6) -> [0_isize: bb2, otherwise: bb3]; // scope 3 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
       }
   
       bb2: {
@@ -50,7 +50,7 @@
 +     }
 + 
 +     bb3: {
-+         drop((((*_5) as Some).0: B)) -> bb2; // scope 3 at $DIR/inline-shims.rs:12:14: 12:40
++         drop((((*_5) as Some).0: B)) -> bb2; // scope 3 at $SRC_DIR/core/src/ptr/mod.rs:LL:COL
       }
   }
   

--- a/src/test/mir-opt/inline/inline_specialization.main.Inline.diff
+++ b/src/test/mir-opt/inline/inline_specialization.main.Inline.diff
@@ -19,7 +19,7 @@
 -     }
 - 
 -     bb1: {
-+         _1 = const 123_u32;              // scope 2 at $DIR/inline-specialization.rs:5:13: 5:38
++         _1 = const 123_u32;              // scope 2 at $DIR/inline-specialization.rs:14:31: 14:34
           _0 = const ();                   // scope 0 at $DIR/inline-specialization.rs:4:11: 6:2
           StorageDead(_1);                 // scope 0 at $DIR/inline-specialization.rs:6:1: 6:2
           return;                          // scope 0 at $DIR/inline-specialization.rs:6:2: 6:2

--- a/src/test/mir-opt/inline/inline_trait_method_2.test2.Inline.after.mir
+++ b/src/test/mir-opt/inline/inline_trait_method_2.test2.Inline.after.mir
@@ -6,8 +6,8 @@ fn test2(_1: &dyn X) -> bool {
     let mut _2: &dyn X;                  // in scope 0 at $DIR/inline-trait-method_2.rs:5:10: 5:11
     let mut _3: &dyn X;                  // in scope 0 at $DIR/inline-trait-method_2.rs:5:10: 5:11
     scope 1 (inlined test) {             // at $DIR/inline-trait-method_2.rs:5:5: 5:12
-        debug x => _2;                   // in scope 1 at $DIR/inline-trait-method_2.rs:5:5: 5:12
-        let mut _4: &dyn X;              // in scope 1 at $DIR/inline-trait-method_2.rs:5:5: 5:12
+        debug x => _2;                   // in scope 1 at $DIR/inline-trait-method_2.rs:9:9: 9:10
+        let mut _4: &dyn X;              // in scope 1 at $DIR/inline-trait-method_2.rs:10:5: 10:10
     }
 
     bb0: {
@@ -16,16 +16,16 @@ fn test2(_1: &dyn X) -> bool {
         _3 = &(*_1);                     // scope 0 at $DIR/inline-trait-method_2.rs:5:10: 5:11
         _2 = move _3 as &dyn X (Pointer(Unsize)); // scope 0 at $DIR/inline-trait-method_2.rs:5:10: 5:11
         StorageDead(_3);                 // scope 0 at $DIR/inline-trait-method_2.rs:5:10: 5:11
-        StorageLive(_4);                 // scope 1 at $DIR/inline-trait-method_2.rs:5:5: 5:12
-        _4 = _2;                         // scope 1 at $DIR/inline-trait-method_2.rs:5:5: 5:12
-        _0 = <dyn X as X>::y(move _4) -> bb1; // scope 1 at $DIR/inline-trait-method_2.rs:5:5: 5:12
+        StorageLive(_4);                 // scope 1 at $DIR/inline-trait-method_2.rs:10:5: 10:10
+        _4 = _2;                         // scope 1 at $DIR/inline-trait-method_2.rs:10:5: 10:10
+        _0 = <dyn X as X>::y(move _4) -> bb1; // scope 1 at $DIR/inline-trait-method_2.rs:10:5: 10:10
                                          // mir::Constant
-                                         // + span: $DIR/inline-trait-method_2.rs:5:5: 5:12
+                                         // + span: $DIR/inline-trait-method_2.rs:10:7: 10:8
                                          // + literal: Const { ty: for<'r> fn(&'r dyn X) -> bool {<dyn X as X>::y}, val: Value(Scalar(<ZST>)) }
     }
 
     bb1: {
-        StorageDead(_4);                 // scope 1 at $DIR/inline-trait-method_2.rs:5:5: 5:12
+        StorageDead(_4);                 // scope 1 at $DIR/inline-trait-method_2.rs:10:9: 10:10
         StorageDead(_2);                 // scope 0 at $DIR/inline-trait-method_2.rs:5:11: 5:12
         return;                          // scope 0 at $DIR/inline-trait-method_2.rs:6:2: 6:2
     }

--- a/src/test/mir-opt/inline/issue_58867_inline_as_ref_as_mut.a.Inline.after.mir
+++ b/src/test/mir-opt/inline/issue_58867_inline_as_ref_as_mut.a.Inline.after.mir
@@ -7,8 +7,8 @@ fn a(_1: &mut [T]) -> &mut [T] {
     let mut _3: &mut [T];                // in scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:3:5: 3:15
     let mut _4: &mut [T];                // in scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:3:5: 3:15
     scope 1 (inlined <[T] as AsMut<[T]>>::as_mut) { // at $DIR/issue-58867-inline-as-ref-as-mut.rs:3:5: 3:15
-        debug self => _4;                // in scope 1 at $DIR/issue-58867-inline-as-ref-as-mut.rs:3:5: 3:15
-        let mut _5: &mut [T];            // in scope 1 at $DIR/issue-58867-inline-as-ref-as-mut.rs:3:5: 3:15
+        debug self => _4;                // in scope 1 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
+        let mut _5: &mut [T];            // in scope 1 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
     }
 
     bb0: {
@@ -16,10 +16,10 @@ fn a(_1: &mut [T]) -> &mut [T] {
         StorageLive(_3);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:3:5: 3:15
         StorageLive(_4);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:3:5: 3:15
         _4 = &mut (*_1);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:3:5: 3:15
-        StorageLive(_5);                 // scope 1 at $DIR/issue-58867-inline-as-ref-as-mut.rs:3:5: 3:15
-        _5 = &mut (*_4);                 // scope 1 at $DIR/issue-58867-inline-as-ref-as-mut.rs:3:5: 3:15
-        _3 = &mut (*_5);                 // scope 1 at $DIR/issue-58867-inline-as-ref-as-mut.rs:3:5: 3:15
-        StorageDead(_5);                 // scope 1 at $DIR/issue-58867-inline-as-ref-as-mut.rs:3:5: 3:15
+        StorageLive(_5);                 // scope 1 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
+        _5 = &mut (*_4);                 // scope 1 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
+        _3 = &mut (*_5);                 // scope 1 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
+        StorageDead(_5);                 // scope 1 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
         _2 = &mut (*_3);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:3:5: 3:15
         StorageDead(_4);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:3:14: 3:15
         _0 = &mut (*_2);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:3:5: 3:15

--- a/src/test/mir-opt/inline/issue_58867_inline_as_ref_as_mut.b.Inline.after.mir
+++ b/src/test/mir-opt/inline/issue_58867_inline_as_ref_as_mut.b.Inline.after.mir
@@ -7,9 +7,9 @@ fn b(_1: &mut Box<T>) -> &mut T {
     let mut _3: &mut T;                  // in scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:8:5: 8:15
     let mut _4: &mut std::boxed::Box<T>; // in scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:8:5: 8:15
     scope 1 (inlined <Box<T> as AsMut<T>>::as_mut) { // at $DIR/issue-58867-inline-as-ref-as-mut.rs:8:5: 8:15
-        debug self => _4;                // in scope 1 at $DIR/issue-58867-inline-as-ref-as-mut.rs:8:5: 8:15
-        let mut _5: &mut T;              // in scope 1 at $DIR/issue-58867-inline-as-ref-as-mut.rs:8:5: 8:15
-        let mut _6: &mut T;              // in scope 1 at $DIR/issue-58867-inline-as-ref-as-mut.rs:8:5: 8:15
+        debug self => _4;                // in scope 1 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
+        let mut _5: &mut T;              // in scope 1 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
+        let mut _6: &mut T;              // in scope 1 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
     }
 
     bb0: {
@@ -17,13 +17,13 @@ fn b(_1: &mut Box<T>) -> &mut T {
         StorageLive(_3);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:8:5: 8:15
         StorageLive(_4);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:8:5: 8:15
         _4 = &mut (*_1);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:8:5: 8:15
-        StorageLive(_5);                 // scope 1 at $DIR/issue-58867-inline-as-ref-as-mut.rs:8:5: 8:15
-        StorageLive(_6);                 // scope 1 at $DIR/issue-58867-inline-as-ref-as-mut.rs:8:5: 8:15
-        _6 = &mut (*(*_4));              // scope 1 at $DIR/issue-58867-inline-as-ref-as-mut.rs:8:5: 8:15
-        _5 = &mut (*_6);                 // scope 1 at $DIR/issue-58867-inline-as-ref-as-mut.rs:8:5: 8:15
-        _3 = &mut (*_5);                 // scope 1 at $DIR/issue-58867-inline-as-ref-as-mut.rs:8:5: 8:15
-        StorageDead(_6);                 // scope 1 at $DIR/issue-58867-inline-as-ref-as-mut.rs:8:5: 8:15
-        StorageDead(_5);                 // scope 1 at $DIR/issue-58867-inline-as-ref-as-mut.rs:8:5: 8:15
+        StorageLive(_5);                 // scope 1 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
+        StorageLive(_6);                 // scope 1 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
+        _6 = &mut (*(*_4));              // scope 1 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
+        _5 = &mut (*_6);                 // scope 1 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
+        _3 = &mut (*_5);                 // scope 1 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
+        StorageDead(_6);                 // scope 1 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
+        StorageDead(_5);                 // scope 1 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
         _2 = &mut (*_3);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:8:5: 8:15
         StorageDead(_4);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:8:14: 8:15
         _0 = &mut (*_2);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:8:5: 8:15

--- a/src/test/mir-opt/inline/issue_58867_inline_as_ref_as_mut.c.Inline.after.mir
+++ b/src/test/mir-opt/inline/issue_58867_inline_as_ref_as_mut.c.Inline.after.mir
@@ -6,14 +6,14 @@ fn c(_1: &[T]) -> &[T] {
     let _2: &[T];                        // in scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:13:5: 13:15
     let mut _3: &[T];                    // in scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:13:5: 13:15
     scope 1 (inlined <[T] as AsRef<[T]>>::as_ref) { // at $DIR/issue-58867-inline-as-ref-as-mut.rs:13:5: 13:15
-        debug self => _3;                // in scope 1 at $DIR/issue-58867-inline-as-ref-as-mut.rs:13:5: 13:15
+        debug self => _3;                // in scope 1 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
     }
 
     bb0: {
         StorageLive(_2);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:13:5: 13:15
         StorageLive(_3);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:13:5: 13:15
         _3 = &(*_1);                     // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:13:5: 13:15
-        _2 = _3;                         // scope 1 at $DIR/issue-58867-inline-as-ref-as-mut.rs:13:5: 13:15
+        _2 = _3;                         // scope 1 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
         _0 = &(*_2);                     // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:13:5: 13:15
         StorageDead(_3);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:13:14: 13:15
         StorageDead(_2);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:14:1: 14:2

--- a/src/test/mir-opt/inline/issue_58867_inline_as_ref_as_mut.d.Inline.after.mir
+++ b/src/test/mir-opt/inline/issue_58867_inline_as_ref_as_mut.d.Inline.after.mir
@@ -6,14 +6,14 @@ fn d(_1: &Box<T>) -> &T {
     let _2: &T;                          // in scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:18:5: 18:15
     let mut _3: &std::boxed::Box<T>;     // in scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:18:5: 18:15
     scope 1 (inlined <Box<T> as AsRef<T>>::as_ref) { // at $DIR/issue-58867-inline-as-ref-as-mut.rs:18:5: 18:15
-        debug self => _3;                // in scope 1 at $DIR/issue-58867-inline-as-ref-as-mut.rs:18:5: 18:15
+        debug self => _3;                // in scope 1 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
     }
 
     bb0: {
         StorageLive(_2);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:18:5: 18:15
         StorageLive(_3);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:18:5: 18:15
         _3 = &(*_1);                     // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:18:5: 18:15
-        _2 = &(*(*_3));                  // scope 1 at $DIR/issue-58867-inline-as-ref-as-mut.rs:18:5: 18:15
+        _2 = &(*(*_3));                  // scope 1 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
         _0 = &(*_2);                     // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:18:5: 18:15
         StorageDead(_3);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:18:14: 18:15
         StorageDead(_2);                 // scope 0 at $DIR/issue-58867-inline-as-ref-as-mut.rs:19:1: 19:2

--- a/src/test/mir-opt/inline/issue_76997_inline_scopes_parenting.main.Inline.after.mir
+++ b/src/test/mir-opt/inline/issue_76997_inline_scopes_parenting.main.Inline.after.mir
@@ -10,10 +10,10 @@ fn main() -> () {
     scope 1 {
         debug f => _1;                   // in scope 1 at $DIR/issue-76997-inline-scopes-parenting.rs:5:9: 5:10
         scope 2 (inlined main::{closure#0}) { // at $DIR/issue-76997-inline-scopes-parenting.rs:6:5: 6:10
-            debug x => _5;               // in scope 2 at $DIR/issue-76997-inline-scopes-parenting.rs:6:5: 6:10
-            let _6: ();                  // in scope 2 at $DIR/issue-76997-inline-scopes-parenting.rs:6:5: 6:10
+            debug x => _5;               // in scope 2 at $DIR/issue-76997-inline-scopes-parenting.rs:5:14: 5:15
+            let _6: ();                  // in scope 2 at $DIR/issue-76997-inline-scopes-parenting.rs:5:23: 5:24
             scope 3 {
-                debug y => _6;           // in scope 3 at $DIR/issue-76997-inline-scopes-parenting.rs:6:5: 6:10
+                debug y => _6;           // in scope 3 at $DIR/issue-76997-inline-scopes-parenting.rs:5:23: 5:24
             }
         }
     }
@@ -27,8 +27,8 @@ fn main() -> () {
         (_3.0: ()) = move _4;            // scope 1 at $DIR/issue-76997-inline-scopes-parenting.rs:6:5: 6:10
         StorageLive(_5);                 // scope 1 at $DIR/issue-76997-inline-scopes-parenting.rs:6:5: 6:10
         _5 = move (_3.0: ());            // scope 1 at $DIR/issue-76997-inline-scopes-parenting.rs:6:5: 6:10
-        StorageLive(_6);                 // scope 2 at $DIR/issue-76997-inline-scopes-parenting.rs:6:5: 6:10
-        StorageDead(_6);                 // scope 2 at $DIR/issue-76997-inline-scopes-parenting.rs:6:5: 6:10
+        StorageLive(_6);                 // scope 2 at $DIR/issue-76997-inline-scopes-parenting.rs:5:23: 5:24
+        StorageDead(_6);                 // scope 2 at $DIR/issue-76997-inline-scopes-parenting.rs:5:32: 5:33
         StorageDead(_5);                 // scope 1 at $DIR/issue-76997-inline-scopes-parenting.rs:6:5: 6:10
         StorageDead(_4);                 // scope 1 at $DIR/issue-76997-inline-scopes-parenting.rs:6:9: 6:10
         StorageDead(_3);                 // scope 1 at $DIR/issue-76997-inline-scopes-parenting.rs:6:9: 6:10

--- a/src/test/mir-opt/inline/issue_78442.bar.Inline.diff
+++ b/src/test/mir-opt/inline/issue_78442.bar.Inline.diff
@@ -29,7 +29,7 @@
 -                                          // mir::Constant
 -                                          // + span: $DIR/issue-78442.rs:11:5: 11:15
 -                                          // + literal: Const { ty: for<'r> extern "rust-call" fn(&'r impl Fn(), ()) -> <impl Fn() as FnOnce<()>>::Output {<impl Fn() as Fn<()>>::call}, val: Value(Scalar(<ZST>)) }
-+         _2 = move (*_3)() -> [return: bb5, unwind: bb3]; // scope 1 at $DIR/issue-78442.rs:11:5: 11:17
++         _2 = move (*_3)() -> [return: bb5, unwind: bb3]; // scope 1 at $SRC_DIR/core/src/ops/function.rs:LL:COL
       }
   
       bb2: {

--- a/src/test/mir-opt/issues/issue_59352.num_to_digit.PreCodegen.after.mir
+++ b/src/test/mir-opt/issues/issue_59352.num_to_digit.PreCodegen.after.mir
@@ -7,23 +7,23 @@ fn num_to_digit(_1: char) -> u32 {
     let mut _3: std::option::Option<u32>; // in scope 0 at $DIR/issue-59352.rs:14:26: 14:41
     let mut _4: char;                    // in scope 0 at $DIR/issue-59352.rs:14:26: 14:29
     let mut _5: u32;                     // in scope 0 at $DIR/issue-59352.rs:14:8: 14:23
-    let mut _11: isize;                  // in scope 0 at $DIR/issue-59352.rs:14:8: 14:23
+    let mut _11: isize;                  // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
     scope 1 (inlined char::methods::<impl char>::is_digit) { // at $DIR/issue-59352.rs:14:8: 14:23
-        debug self => _2;                // in scope 1 at $DIR/issue-59352.rs:14:8: 14:23
-        debug radix => _5;               // in scope 1 at $DIR/issue-59352.rs:14:8: 14:23
-        let mut _6: &std::option::Option<u32>; // in scope 1 at $DIR/issue-59352.rs:14:8: 14:23
-        let _7: std::option::Option<u32>; // in scope 1 at $DIR/issue-59352.rs:14:8: 14:23
-        let mut _8: char;                // in scope 1 at $DIR/issue-59352.rs:14:8: 14:23
-        scope 2 (inlined Option::<u32>::is_some) { // at $DIR/issue-59352.rs:14:8: 14:23
-            debug self => _6;            // in scope 2 at $DIR/issue-59352.rs:14:8: 14:23
-            let mut _9: isize;           // in scope 2 at $DIR/issue-59352.rs:14:8: 14:23
+        debug self => _2;                // in scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
+        debug radix => _5;               // in scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
+        let mut _6: &std::option::Option<u32>; // in scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
+        let _7: std::option::Option<u32>; // in scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
+        let mut _8: char;                // in scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
+        scope 2 (inlined Option::<u32>::is_some) { // at $SRC_DIR/core/src/char/methods.rs:LL:COL
+            debug self => _6;            // in scope 2 at $SRC_DIR/core/src/option.rs:LL:COL
+            let mut _9: isize;           // in scope 2 at $SRC_DIR/core/src/option.rs:LL:COL
         }
     }
     scope 3 (inlined #[track_caller] Option::<u32>::unwrap) { // at $DIR/issue-59352.rs:14:26: 14:50
-        debug self => _3;                // in scope 3 at $DIR/issue-59352.rs:14:26: 14:50
-        let mut _10: isize;              // in scope 3 at $DIR/issue-59352.rs:14:26: 14:50
+        debug self => _3;                // in scope 3 at $SRC_DIR/core/src/option.rs:LL:COL
+        let mut _10: isize;              // in scope 3 at $SRC_DIR/core/src/option.rs:LL:COL
         scope 4 {
-            debug val => _0;             // in scope 4 at $DIR/issue-59352.rs:14:26: 14:50
+            debug val => _0;             // in scope 4 at $SRC_DIR/core/src/option.rs:LL:COL
         }
     }
 
@@ -32,13 +32,13 @@ fn num_to_digit(_1: char) -> u32 {
         _2 = _1;                         // scope 0 at $DIR/issue-59352.rs:14:8: 14:11
         StorageLive(_5);                 // scope 0 at $DIR/issue-59352.rs:14:8: 14:23
         _5 = const 8_u32;                // scope 0 at $DIR/issue-59352.rs:14:8: 14:23
-        StorageLive(_6);                 // scope 1 at $DIR/issue-59352.rs:14:8: 14:23
-        StorageLive(_7);                 // scope 1 at $DIR/issue-59352.rs:14:8: 14:23
-        StorageLive(_8);                 // scope 1 at $DIR/issue-59352.rs:14:8: 14:23
-        _8 = _2;                         // scope 1 at $DIR/issue-59352.rs:14:8: 14:23
-        _7 = char::methods::<impl char>::to_digit(move _8, const 8_u32) -> bb5; // scope 1 at $DIR/issue-59352.rs:14:8: 14:23
+        StorageLive(_6);                 // scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
+        StorageLive(_7);                 // scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
+        StorageLive(_8);                 // scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
+        _8 = _2;                         // scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
+        _7 = char::methods::<impl char>::to_digit(move _8, const 8_u32) -> bb5; // scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
                                          // mir::Constant
-                                         // + span: $DIR/issue-59352.rs:14:8: 14:23
+                                         // + span: $SRC_DIR/core/src/char/methods.rs:LL:COL
                                          // + literal: Const { ty: fn(char, u32) -> Option<u32> {char::methods::<impl char>::to_digit}, val: Value(Scalar(<ZST>)) }
     }
 
@@ -56,8 +56,8 @@ fn num_to_digit(_1: char) -> u32 {
     bb2: {
         StorageDead(_4);                 // scope 0 at $DIR/issue-59352.rs:14:40: 14:41
         StorageLive(_10);                // scope 0 at $DIR/issue-59352.rs:14:26: 14:50
-        _10 = discriminant(_3);          // scope 3 at $DIR/issue-59352.rs:14:26: 14:50
-        switchInt(move _10) -> [0_isize: bb6, 1_isize: bb8, otherwise: bb7]; // scope 3 at $DIR/issue-59352.rs:14:26: 14:50
+        _10 = discriminant(_3);          // scope 3 at $SRC_DIR/core/src/option.rs:LL:COL
+        switchInt(move _10) -> [0_isize: bb6, 1_isize: bb8, otherwise: bb7]; // scope 3 at $SRC_DIR/core/src/option.rs:LL:COL
     }
 
     bb3: {
@@ -71,36 +71,36 @@ fn num_to_digit(_1: char) -> u32 {
     }
 
     bb5: {
-        _6 = &_7;                        // scope 1 at $DIR/issue-59352.rs:14:8: 14:23
-        StorageDead(_8);                 // scope 1 at $DIR/issue-59352.rs:14:8: 14:23
-        StorageLive(_9);                 // scope 1 at $DIR/issue-59352.rs:14:8: 14:23
-        _9 = discriminant((*_6));        // scope 2 at $DIR/issue-59352.rs:14:8: 14:23
-        StorageLive(_11);                // scope 2 at $DIR/issue-59352.rs:14:8: 14:23
-        _11 = move _9;                   // scope 2 at $DIR/issue-59352.rs:14:8: 14:23
-        StorageDead(_9);                 // scope 1 at $DIR/issue-59352.rs:14:8: 14:23
-        StorageDead(_6);                 // scope 1 at $DIR/issue-59352.rs:14:8: 14:23
-        StorageDead(_7);                 // scope 1 at $DIR/issue-59352.rs:14:8: 14:23
+        _6 = &_7;                        // scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
+        StorageDead(_8);                 // scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
+        StorageLive(_9);                 // scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
+        _9 = discriminant((*_6));        // scope 2 at $SRC_DIR/core/src/option.rs:LL:COL
+        StorageLive(_11);                // scope 2 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        _11 = move _9;                   // scope 2 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        StorageDead(_9);                 // scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
+        StorageDead(_6);                 // scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
+        StorageDead(_7);                 // scope 1 at $SRC_DIR/core/src/char/methods.rs:LL:COL
         StorageDead(_5);                 // scope 0 at $DIR/issue-59352.rs:14:8: 14:23
         StorageDead(_2);                 // scope 0 at $DIR/issue-59352.rs:14:22: 14:23
         switchInt(move _11) -> [1_isize: bb1, otherwise: bb3]; // scope 0 at $DIR/issue-59352.rs:14:8: 14:23
     }
 
     bb6: {
-        core::panicking::panic(const "called `Option::unwrap()` on a `None` value"); // scope 3 at $DIR/issue-59352.rs:14:26: 14:50
+        core::panicking::panic(const "called `Option::unwrap()` on a `None` value"); // scope 3 at $SRC_DIR/core/src/option.rs:LL:COL
                                          // mir::Constant
-                                         // + span: $DIR/issue-59352.rs:14:26: 14:50
+                                         // + span: $SRC_DIR/core/src/option.rs:LL:COL
                                          // + literal: Const { ty: fn(&'static str) -> ! {core::panicking::panic}, val: Value(Scalar(<ZST>)) }
                                          // mir::Constant
-                                         // + span: $DIR/issue-59352.rs:14:26: 14:50
+                                         // + span: $SRC_DIR/core/src/option.rs:LL:COL
                                          // + literal: Const { ty: &str, val: Value(Slice { data: Allocation { bytes: [99, 97, 108, 108, 101, 100, 32, 96, 79, 112, 116, 105, 111, 110, 58, 58, 117, 110, 119, 114, 97, 112, 40, 41, 96, 32, 111, 110, 32, 97, 32, 96, 78, 111, 110, 101, 96, 32, 118, 97, 108, 117, 101], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [8796093022207], len: Size { raw: 43 } }, align: Align { pow2: 0 }, mutability: Not, extra: () }, start: 0, end: 43 }) }
     }
 
     bb7: {
-        unreachable;                     // scope 3 at $DIR/issue-59352.rs:14:26: 14:50
+        unreachable;                     // scope 3 at $SRC_DIR/core/src/option.rs:LL:COL
     }
 
     bb8: {
-        _0 = move ((_3 as Some).0: u32); // scope 3 at $DIR/issue-59352.rs:14:26: 14:50
+        _0 = move ((_3 as Some).0: u32); // scope 3 at $SRC_DIR/core/src/option.rs:LL:COL
         StorageDead(_10);                // scope 0 at $DIR/issue-59352.rs:14:26: 14:50
         StorageDead(_3);                 // scope 0 at $DIR/issue-59352.rs:14:49: 14:50
         goto -> bb4;                     // scope 0 at $DIR/issue-59352.rs:14:5: 14:63

--- a/src/test/mir-opt/lower_intrinsics.f_u64.PreCodegen.before.mir
+++ b/src/test/mir-opt/lower_intrinsics.f_u64.PreCodegen.before.mir
@@ -4,28 +4,28 @@ fn f_u64() -> () {
     let mut _0: ();                      // return place in scope 0 at $DIR/lower_intrinsics.rs:39:16: 39:16
     let mut _1: u64;                     // in scope 0 at $DIR/lower_intrinsics.rs:40:5: 40:21
     scope 1 (inlined f_dispatch::<u64>) { // at $DIR/lower_intrinsics.rs:40:5: 40:21
-        debug t => _1;                   // in scope 1 at $DIR/lower_intrinsics.rs:40:5: 40:21
-        let _2: ();                      // in scope 1 at $DIR/lower_intrinsics.rs:40:5: 40:21
-        let mut _3: u64;                 // in scope 1 at $DIR/lower_intrinsics.rs:40:5: 40:21
-        scope 2 (inlined std::mem::size_of::<u64>) { // at $DIR/lower_intrinsics.rs:40:5: 40:21
+        debug t => _1;                   // in scope 1 at $DIR/lower_intrinsics.rs:44:22: 44:23
+        let _2: ();                      // in scope 1 at $DIR/lower_intrinsics.rs:48:9: 48:21
+        let mut _3: u64;                 // in scope 1 at $DIR/lower_intrinsics.rs:48:19: 48:20
+        scope 2 (inlined std::mem::size_of::<u64>) { // at $DIR/lower_intrinsics.rs:45:8: 45:32
         }
     }
 
     bb0: {
         StorageLive(_1);                 // scope 0 at $DIR/lower_intrinsics.rs:40:5: 40:21
         _1 = const 0_u64;                // scope 0 at $DIR/lower_intrinsics.rs:40:5: 40:21
-        StorageLive(_2);                 // scope 1 at $DIR/lower_intrinsics.rs:40:5: 40:21
-        StorageLive(_3);                 // scope 1 at $DIR/lower_intrinsics.rs:40:5: 40:21
-        _3 = move _1;                    // scope 1 at $DIR/lower_intrinsics.rs:40:5: 40:21
-        _2 = f_non_zst::<u64>(move _3) -> bb1; // scope 1 at $DIR/lower_intrinsics.rs:40:5: 40:21
+        StorageLive(_2);                 // scope 1 at $DIR/lower_intrinsics.rs:48:9: 48:21
+        StorageLive(_3);                 // scope 1 at $DIR/lower_intrinsics.rs:48:19: 48:20
+        _3 = move _1;                    // scope 1 at $DIR/lower_intrinsics.rs:48:19: 48:20
+        _2 = f_non_zst::<u64>(move _3) -> bb1; // scope 1 at $DIR/lower_intrinsics.rs:48:9: 48:21
                                          // mir::Constant
-                                         // + span: $DIR/lower_intrinsics.rs:40:5: 40:21
+                                         // + span: $DIR/lower_intrinsics.rs:48:9: 48:18
                                          // + literal: Const { ty: fn(u64) {f_non_zst::<u64>}, val: Value(Scalar(<ZST>)) }
     }
 
     bb1: {
-        StorageDead(_3);                 // scope 1 at $DIR/lower_intrinsics.rs:40:5: 40:21
-        StorageDead(_2);                 // scope 1 at $DIR/lower_intrinsics.rs:40:5: 40:21
+        StorageDead(_3);                 // scope 1 at $DIR/lower_intrinsics.rs:48:20: 48:21
+        StorageDead(_2);                 // scope 1 at $DIR/lower_intrinsics.rs:48:21: 48:22
         StorageDead(_1);                 // scope 0 at $DIR/lower_intrinsics.rs:40:5: 40:21
         return;                          // scope 0 at $DIR/lower_intrinsics.rs:41:2: 41:2
     }

--- a/src/test/mir-opt/lower_intrinsics.f_unit.PreCodegen.before.mir
+++ b/src/test/mir-opt/lower_intrinsics.f_unit.PreCodegen.before.mir
@@ -4,23 +4,23 @@ fn f_unit() -> () {
     let mut _0: ();                      // return place in scope 0 at $DIR/lower_intrinsics.rs:33:17: 33:17
     let mut _1: ();                      // in scope 0 at $DIR/lower_intrinsics.rs:34:16: 34:18
     scope 1 (inlined f_dispatch::<()>) { // at $DIR/lower_intrinsics.rs:34:5: 34:19
-        debug t => _1;                   // in scope 1 at $DIR/lower_intrinsics.rs:34:5: 34:19
-        let _2: ();                      // in scope 1 at $DIR/lower_intrinsics.rs:34:5: 34:19
-        scope 2 (inlined std::mem::size_of::<()>) { // at $DIR/lower_intrinsics.rs:34:5: 34:19
+        debug t => _1;                   // in scope 1 at $DIR/lower_intrinsics.rs:44:22: 44:23
+        let _2: ();                      // in scope 1 at $DIR/lower_intrinsics.rs:46:9: 46:17
+        scope 2 (inlined std::mem::size_of::<()>) { // at $DIR/lower_intrinsics.rs:45:8: 45:32
         }
     }
 
     bb0: {
         StorageLive(_1);                 // scope 0 at $DIR/lower_intrinsics.rs:34:16: 34:18
-        StorageLive(_2);                 // scope 1 at $DIR/lower_intrinsics.rs:34:5: 34:19
-        _2 = f_zst::<()>(const ()) -> bb1; // scope 1 at $DIR/lower_intrinsics.rs:34:5: 34:19
+        StorageLive(_2);                 // scope 1 at $DIR/lower_intrinsics.rs:46:9: 46:17
+        _2 = f_zst::<()>(const ()) -> bb1; // scope 1 at $DIR/lower_intrinsics.rs:46:9: 46:17
                                          // mir::Constant
-                                         // + span: $DIR/lower_intrinsics.rs:34:5: 34:19
+                                         // + span: $DIR/lower_intrinsics.rs:46:9: 46:14
                                          // + literal: Const { ty: fn(()) {f_zst::<()>}, val: Value(Scalar(<ZST>)) }
     }
 
     bb1: {
-        StorageDead(_2);                 // scope 1 at $DIR/lower_intrinsics.rs:34:5: 34:19
+        StorageDead(_2);                 // scope 1 at $DIR/lower_intrinsics.rs:46:17: 46:18
         StorageDead(_1);                 // scope 0 at $DIR/lower_intrinsics.rs:34:18: 34:19
         return;                          // scope 0 at $DIR/lower_intrinsics.rs:35:2: 35:2
     }

--- a/src/test/mir-opt/remove_storage_markers.main.RemoveStorageMarkers.diff
+++ b/src/test/mir-opt/remove_storage_markers.main.RemoveStorageMarkers.diff
@@ -24,12 +24,12 @@
                   debug i => _12;          // in scope 3 at $DIR/remove_storage_markers.rs:8:9: 8:10
               }
               scope 5 (inlined iter::range::<impl Iterator for std::ops::Range<i32>>::next) { // at $DIR/remove_storage_markers.rs:8:14: 8:19
-                  debug self => _8;        // in scope 5 at $DIR/remove_storage_markers.rs:8:14: 8:19
-                  let mut _14: &mut std::ops::Range<i32>; // in scope 5 at $DIR/remove_storage_markers.rs:8:14: 8:19
+                  debug self => _8;        // in scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+                  let mut _14: &mut std::ops::Range<i32>; // in scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
               }
           }
           scope 4 (inlined <std::ops::Range<i32> as IntoIterator>::into_iter) { // at $DIR/remove_storage_markers.rs:8:14: 8:19
-              debug self => _3;            // in scope 4 at $DIR/remove_storage_markers.rs:8:14: 8:19
+              debug self => _3;            // in scope 4 at $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
           }
       }
   
@@ -40,7 +40,7 @@
 -         StorageLive(_3);                 // scope 1 at $DIR/remove_storage_markers.rs:8:14: 8:19
           (_3.0: i32) = const 0_i32;       // scope 1 at $DIR/remove_storage_markers.rs:8:14: 8:19
           (_3.1: i32) = const 10_i32;      // scope 1 at $DIR/remove_storage_markers.rs:8:14: 8:19
-          _2 = move _3;                    // scope 4 at $DIR/remove_storage_markers.rs:8:14: 8:19
+          _2 = move _3;                    // scope 4 at $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
 -         StorageDead(_3);                 // scope 1 at $DIR/remove_storage_markers.rs:8:18: 8:19
 -         StorageLive(_4);                 // scope 1 at $DIR/remove_storage_markers.rs:8:14: 8:19
           _4 = move _2;                    // scope 1 at $DIR/remove_storage_markers.rs:8:14: 8:19
@@ -54,11 +54,11 @@
 -         StorageLive(_9);                 // scope 2 at $DIR/remove_storage_markers.rs:8:14: 8:19
           _9 = &mut _4;                    // scope 2 at $DIR/remove_storage_markers.rs:8:14: 8:19
           _8 = &mut (*_9);                 // scope 2 at $DIR/remove_storage_markers.rs:8:14: 8:19
--         StorageLive(_14);                // scope 5 at $DIR/remove_storage_markers.rs:8:14: 8:19
-          _14 = &mut (*_8);                // scope 5 at $DIR/remove_storage_markers.rs:8:14: 8:19
-          _7 = <std::ops::Range<i32> as iter::range::RangeIteratorImpl>::spec_next(move _14) -> bb4; // scope 5 at $DIR/remove_storage_markers.rs:8:14: 8:19
+-         StorageLive(_14);                // scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+          _14 = &mut (*_8);                // scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
+          _7 = <std::ops::Range<i32> as iter::range::RangeIteratorImpl>::spec_next(move _14) -> bb4; // scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
                                            // mir::Constant
-                                           // + span: $DIR/remove_storage_markers.rs:8:14: 8:19
+                                           // + span: $SRC_DIR/core/src/iter/range.rs:LL:COL
                                            // + literal: Const { ty: for<'r> fn(&'r mut std::ops::Range<i32>) -> Option<<std::ops::Range<i32> as iter::range::RangeIteratorImpl>::Item> {<std::ops::Range<i32> as iter::range::RangeIteratorImpl>::spec_next}, val: Value(Scalar(<ZST>)) }
       }
   
@@ -90,7 +90,7 @@
       }
   
       bb4: {
--         StorageDead(_14);                // scope 5 at $DIR/remove_storage_markers.rs:8:14: 8:19
+-         StorageDead(_14);                // scope 5 at $SRC_DIR/core/src/iter/range.rs:LL:COL
 -         StorageDead(_8);                 // scope 2 at $DIR/remove_storage_markers.rs:8:18: 8:19
           _10 = discriminant(_7);          // scope 2 at $DIR/remove_storage_markers.rs:8:14: 8:19
           switchInt(move _10) -> [0_isize: bb3, otherwise: bb2]; // scope 2 at $DIR/remove_storage_markers.rs:8:14: 8:19

--- a/src/test/mir-opt/remove_unneeded_drops.cannot_opt_generic.RemoveUnneededDrops.diff
+++ b/src/test/mir-opt/remove_unneeded_drops.cannot_opt_generic.RemoveUnneededDrops.diff
@@ -7,14 +7,14 @@
       let _2: ();                          // in scope 0 at $DIR/remove_unneeded_drops.rs:21:5: 21:12
       let mut _3: T;                       // in scope 0 at $DIR/remove_unneeded_drops.rs:21:10: 21:11
       scope 1 (inlined std::mem::drop::<T>) { // at $DIR/remove_unneeded_drops.rs:21:5: 21:12
-          debug _x => _3;                  // in scope 1 at $DIR/remove_unneeded_drops.rs:21:5: 21:12
+          debug _x => _3;                  // in scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
       }
   
       bb0: {
           StorageLive(_2);                 // scope 0 at $DIR/remove_unneeded_drops.rs:21:5: 21:12
           StorageLive(_3);                 // scope 0 at $DIR/remove_unneeded_drops.rs:21:10: 21:11
           _3 = move _1;                    // scope 0 at $DIR/remove_unneeded_drops.rs:21:10: 21:11
-          drop(_3) -> [return: bb2, unwind: bb1]; // scope 1 at $DIR/remove_unneeded_drops.rs:21:5: 21:12
+          drop(_3) -> [return: bb2, unwind: bb1]; // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
       }
   
       bb1 (cleanup): {

--- a/src/test/mir-opt/remove_unneeded_drops.dont_opt.RemoveUnneededDrops.diff
+++ b/src/test/mir-opt/remove_unneeded_drops.dont_opt.RemoveUnneededDrops.diff
@@ -7,14 +7,14 @@
       let _2: ();                          // in scope 0 at $DIR/remove_unneeded_drops.rs:9:5: 9:12
       let mut _3: std::vec::Vec<bool>;     // in scope 0 at $DIR/remove_unneeded_drops.rs:9:10: 9:11
       scope 1 (inlined std::mem::drop::<Vec<bool>>) { // at $DIR/remove_unneeded_drops.rs:9:5: 9:12
-          debug _x => _3;                  // in scope 1 at $DIR/remove_unneeded_drops.rs:9:5: 9:12
+          debug _x => _3;                  // in scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
       }
   
       bb0: {
           StorageLive(_2);                 // scope 0 at $DIR/remove_unneeded_drops.rs:9:5: 9:12
           StorageLive(_3);                 // scope 0 at $DIR/remove_unneeded_drops.rs:9:10: 9:11
           _3 = move _1;                    // scope 0 at $DIR/remove_unneeded_drops.rs:9:10: 9:11
-          drop(_3) -> [return: bb2, unwind: bb1]; // scope 1 at $DIR/remove_unneeded_drops.rs:9:5: 9:12
+          drop(_3) -> [return: bb2, unwind: bb1]; // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
       }
   
       bb1 (cleanup): {

--- a/src/test/mir-opt/remove_unneeded_drops.opt.RemoveUnneededDrops.diff
+++ b/src/test/mir-opt/remove_unneeded_drops.opt.RemoveUnneededDrops.diff
@@ -7,14 +7,14 @@
       let _2: ();                          // in scope 0 at $DIR/remove_unneeded_drops.rs:4:5: 4:12
       let mut _3: bool;                    // in scope 0 at $DIR/remove_unneeded_drops.rs:4:10: 4:11
       scope 1 (inlined std::mem::drop::<bool>) { // at $DIR/remove_unneeded_drops.rs:4:5: 4:12
-          debug _x => _3;                  // in scope 1 at $DIR/remove_unneeded_drops.rs:4:5: 4:12
+          debug _x => _3;                  // in scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
       }
   
       bb0: {
           StorageLive(_2);                 // scope 0 at $DIR/remove_unneeded_drops.rs:4:5: 4:12
           StorageLive(_3);                 // scope 0 at $DIR/remove_unneeded_drops.rs:4:10: 4:11
           _3 = _1;                         // scope 0 at $DIR/remove_unneeded_drops.rs:4:10: 4:11
--         drop(_3) -> bb1;                 // scope 1 at $DIR/remove_unneeded_drops.rs:4:5: 4:12
+-         drop(_3) -> bb1;                 // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
 -     }
 - 
 -     bb1: {

--- a/src/test/mir-opt/remove_unneeded_drops.opt_generic_copy.RemoveUnneededDrops.diff
+++ b/src/test/mir-opt/remove_unneeded_drops.opt_generic_copy.RemoveUnneededDrops.diff
@@ -7,14 +7,14 @@
       let _2: ();                          // in scope 0 at $DIR/remove_unneeded_drops.rs:14:5: 14:12
       let mut _3: T;                       // in scope 0 at $DIR/remove_unneeded_drops.rs:14:10: 14:11
       scope 1 (inlined std::mem::drop::<T>) { // at $DIR/remove_unneeded_drops.rs:14:5: 14:12
-          debug _x => _3;                  // in scope 1 at $DIR/remove_unneeded_drops.rs:14:5: 14:12
+          debug _x => _3;                  // in scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
       }
   
       bb0: {
           StorageLive(_2);                 // scope 0 at $DIR/remove_unneeded_drops.rs:14:5: 14:12
           StorageLive(_3);                 // scope 0 at $DIR/remove_unneeded_drops.rs:14:10: 14:11
           _3 = _1;                         // scope 0 at $DIR/remove_unneeded_drops.rs:14:10: 14:11
--         drop(_3) -> bb1;                 // scope 1 at $DIR/remove_unneeded_drops.rs:14:5: 14:12
+-         drop(_3) -> bb1;                 // scope 1 at $SRC_DIR/core/src/mem/mod.rs:LL:COL
 -     }
 - 
 -     bb1: {

--- a/src/test/mir-opt/separate_const_switch.identity.ConstProp.diff
+++ b/src/test/mir-opt/separate_const_switch.identity.ConstProp.diff
@@ -16,14 +16,14 @@
           debug residual => _6;            // in scope 1 at $DIR/separate_const_switch.rs:29:9: 29:10
           scope 2 {
               scope 8 (inlined #[track_caller] <Result<i32, i32> as FromResidual<Result<Infallible, i32>>>::from_residual) { // at $DIR/separate_const_switch.rs:29:8: 29:10
-                  debug residual => _8;    // in scope 8 at $DIR/separate_const_switch.rs:29:8: 29:10
-                  let _16: i32;            // in scope 8 at $DIR/separate_const_switch.rs:29:8: 29:10
-                  let mut _17: i32;        // in scope 8 at $DIR/separate_const_switch.rs:29:8: 29:10
-                  let mut _18: i32;        // in scope 8 at $DIR/separate_const_switch.rs:29:8: 29:10
+                  debug residual => _8;    // in scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
+                  let _16: i32;            // in scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
+                  let mut _17: i32;        // in scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
+                  let mut _18: i32;        // in scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
                   scope 9 {
-                      debug e => _16;      // in scope 9 at $DIR/separate_const_switch.rs:29:8: 29:10
-                      scope 10 (inlined <i32 as From<i32>>::from) { // at $DIR/separate_const_switch.rs:29:8: 29:10
-                          debug t => _18;  // in scope 10 at $DIR/separate_const_switch.rs:29:8: 29:10
+                      debug e => _16;      // in scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
+                      scope 10 (inlined <i32 as From<i32>>::from) { // at $SRC_DIR/core/src/result.rs:LL:COL
+                          debug t => _18;  // in scope 10 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
                       }
                   }
               }
@@ -35,18 +35,18 @@
           }
       }
       scope 5 (inlined <Result<i32, i32> as Try>::branch) { // at $DIR/separate_const_switch.rs:29:8: 29:10
-          debug self => _4;                // in scope 5 at $DIR/separate_const_switch.rs:29:8: 29:10
-          let mut _10: isize;              // in scope 5 at $DIR/separate_const_switch.rs:29:8: 29:10
-          let _11: i32;                    // in scope 5 at $DIR/separate_const_switch.rs:29:8: 29:10
-          let mut _12: i32;                // in scope 5 at $DIR/separate_const_switch.rs:29:8: 29:10
-          let _13: i32;                    // in scope 5 at $DIR/separate_const_switch.rs:29:8: 29:10
-          let mut _14: std::result::Result<std::convert::Infallible, i32>; // in scope 5 at $DIR/separate_const_switch.rs:29:8: 29:10
-          let mut _15: i32;                // in scope 5 at $DIR/separate_const_switch.rs:29:8: 29:10
+          debug self => _4;                // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+          let mut _10: isize;              // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+          let _11: i32;                    // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+          let mut _12: i32;                // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+          let _13: i32;                    // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+          let mut _14: std::result::Result<std::convert::Infallible, i32>; // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+          let mut _15: i32;                // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
           scope 6 {
-              debug v => _11;              // in scope 6 at $DIR/separate_const_switch.rs:29:8: 29:10
+              debug v => _11;              // in scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
           }
           scope 7 {
-              debug e => _13;              // in scope 7 at $DIR/separate_const_switch.rs:29:8: 29:10
+              debug e => _13;              // in scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
           }
       }
   
@@ -56,8 +56,8 @@
           StorageLive(_4);                 // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:9
           _4 = _1;                         // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:9
           StorageLive(_10);                // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-          _10 = discriminant(_4);          // scope 5 at $DIR/separate_const_switch.rs:29:8: 29:10
-          switchInt(move _10) -> [0_isize: bb5, 1_isize: bb3, otherwise: bb4]; // scope 5 at $DIR/separate_const_switch.rs:29:8: 29:10
+          _10 = discriminant(_4);          // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+          switchInt(move _10) -> [0_isize: bb5, 1_isize: bb3, otherwise: bb4]; // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
       }
   
       bb1: {
@@ -77,17 +77,17 @@
           _6 = ((_3 as Break).0: std::result::Result<std::convert::Infallible, i32>); // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
           StorageLive(_8);                 // scope 2 at $DIR/separate_const_switch.rs:29:9: 29:10
           _8 = _6;                         // scope 2 at $DIR/separate_const_switch.rs:29:9: 29:10
-          StorageLive(_16);                // scope 8 at $DIR/separate_const_switch.rs:29:8: 29:10
-          _16 = move ((_8 as Err).0: i32); // scope 8 at $DIR/separate_const_switch.rs:29:8: 29:10
-          StorageLive(_17);                // scope 9 at $DIR/separate_const_switch.rs:29:8: 29:10
-          StorageLive(_18);                // scope 9 at $DIR/separate_const_switch.rs:29:8: 29:10
-          _18 = move _16;                  // scope 9 at $DIR/separate_const_switch.rs:29:8: 29:10
-          _17 = move _18;                  // scope 10 at $DIR/separate_const_switch.rs:29:8: 29:10
-          StorageDead(_18);                // scope 9 at $DIR/separate_const_switch.rs:29:8: 29:10
-          ((_0 as Err).0: i32) = move _17; // scope 9 at $DIR/separate_const_switch.rs:29:8: 29:10
-          discriminant(_0) = 1;            // scope 9 at $DIR/separate_const_switch.rs:29:8: 29:10
-          StorageDead(_17);                // scope 9 at $DIR/separate_const_switch.rs:29:8: 29:10
-          StorageDead(_16);                // scope 8 at $DIR/separate_const_switch.rs:29:8: 29:10
+          StorageLive(_16);                // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
+          _16 = move ((_8 as Err).0: i32); // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
+          StorageLive(_17);                // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
+          StorageLive(_18);                // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
+          _18 = move _16;                  // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
+          _17 = move _18;                  // scope 10 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
+          StorageDead(_18);                // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
+          ((_0 as Err).0: i32) = move _17; // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
+          discriminant(_0) = 1;            // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
+          StorageDead(_17);                // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
+          StorageDead(_16);                // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
           StorageDead(_8);                 // scope 2 at $DIR/separate_const_switch.rs:29:9: 29:10
           StorageDead(_6);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
           StorageDead(_2);                 // scope 0 at $DIR/separate_const_switch.rs:29:10: 29:11
@@ -96,18 +96,18 @@
       }
   
       bb3: {
-          StorageLive(_13);                // scope 5 at $DIR/separate_const_switch.rs:29:8: 29:10
-          _13 = move ((_4 as Err).0: i32); // scope 5 at $DIR/separate_const_switch.rs:29:8: 29:10
-          StorageLive(_14);                // scope 7 at $DIR/separate_const_switch.rs:29:8: 29:10
-          StorageLive(_15);                // scope 7 at $DIR/separate_const_switch.rs:29:8: 29:10
-          _15 = move _13;                  // scope 7 at $DIR/separate_const_switch.rs:29:8: 29:10
-          ((_14 as Err).0: i32) = move _15; // scope 7 at $DIR/separate_const_switch.rs:29:8: 29:10
-          discriminant(_14) = 1;           // scope 7 at $DIR/separate_const_switch.rs:29:8: 29:10
-          StorageDead(_15);                // scope 7 at $DIR/separate_const_switch.rs:29:8: 29:10
-          ((_3 as Break).0: std::result::Result<std::convert::Infallible, i32>) = move _14; // scope 7 at $DIR/separate_const_switch.rs:29:8: 29:10
-          discriminant(_3) = 1;            // scope 7 at $DIR/separate_const_switch.rs:29:8: 29:10
-          StorageDead(_14);                // scope 7 at $DIR/separate_const_switch.rs:29:8: 29:10
-          StorageDead(_13);                // scope 5 at $DIR/separate_const_switch.rs:29:8: 29:10
+          StorageLive(_13);                // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+          _13 = move ((_4 as Err).0: i32); // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+          StorageLive(_14);                // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+          StorageLive(_15);                // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+          _15 = move _13;                  // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+          ((_14 as Err).0: i32) = move _15; // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+          discriminant(_14) = 1;           // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+          StorageDead(_15);                // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+          ((_3 as Break).0: std::result::Result<std::convert::Infallible, i32>) = move _14; // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+          discriminant(_3) = 1;            // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+          StorageDead(_14);                // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+          StorageDead(_13);                // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
           StorageDead(_10);                // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
           StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
 -         _5 = discriminant(_3);           // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
@@ -117,18 +117,18 @@
       }
   
       bb4: {
-          unreachable;                     // scope 5 at $DIR/separate_const_switch.rs:29:8: 29:10
+          unreachable;                     // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
       }
   
       bb5: {
-          StorageLive(_11);                // scope 5 at $DIR/separate_const_switch.rs:29:8: 29:10
-          _11 = move ((_4 as Ok).0: i32);  // scope 5 at $DIR/separate_const_switch.rs:29:8: 29:10
-          StorageLive(_12);                // scope 6 at $DIR/separate_const_switch.rs:29:8: 29:10
-          _12 = move _11;                  // scope 6 at $DIR/separate_const_switch.rs:29:8: 29:10
-          ((_3 as Continue).0: i32) = move _12; // scope 6 at $DIR/separate_const_switch.rs:29:8: 29:10
-          discriminant(_3) = 0;            // scope 6 at $DIR/separate_const_switch.rs:29:8: 29:10
-          StorageDead(_12);                // scope 6 at $DIR/separate_const_switch.rs:29:8: 29:10
-          StorageDead(_11);                // scope 5 at $DIR/separate_const_switch.rs:29:8: 29:10
+          StorageLive(_11);                // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+          _11 = move ((_4 as Ok).0: i32);  // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+          StorageLive(_12);                // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
+          _12 = move _11;                  // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
+          ((_3 as Continue).0: i32) = move _12; // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
+          discriminant(_3) = 0;            // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
+          StorageDead(_12);                // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
+          StorageDead(_11);                // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
           StorageDead(_10);                // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
           StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
 -         _5 = discriminant(_3);           // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10

--- a/src/test/mir-opt/separate_const_switch.identity.PreCodegen.after.mir
+++ b/src/test/mir-opt/separate_const_switch.identity.PreCodegen.after.mir
@@ -13,14 +13,14 @@ fn identity(_1: Result<i32, i32>) -> Result<i32, i32> {
         debug residual => _5;            // in scope 1 at $DIR/separate_const_switch.rs:29:9: 29:10
         scope 2 {
             scope 8 (inlined #[track_caller] <Result<i32, i32> as FromResidual<Result<Infallible, i32>>>::from_residual) { // at $DIR/separate_const_switch.rs:29:8: 29:10
-                debug residual => _6;    // in scope 8 at $DIR/separate_const_switch.rs:29:8: 29:10
-                let _14: i32;            // in scope 8 at $DIR/separate_const_switch.rs:29:8: 29:10
-                let mut _15: i32;        // in scope 8 at $DIR/separate_const_switch.rs:29:8: 29:10
-                let mut _16: i32;        // in scope 8 at $DIR/separate_const_switch.rs:29:8: 29:10
+                debug residual => _6;    // in scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
+                let _14: i32;            // in scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
+                let mut _15: i32;        // in scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
+                let mut _16: i32;        // in scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
                 scope 9 {
-                    debug e => _14;      // in scope 9 at $DIR/separate_const_switch.rs:29:8: 29:10
-                    scope 10 (inlined <i32 as From<i32>>::from) { // at $DIR/separate_const_switch.rs:29:8: 29:10
-                        debug t => _16;  // in scope 10 at $DIR/separate_const_switch.rs:29:8: 29:10
+                    debug e => _14;      // in scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
+                    scope 10 (inlined <i32 as From<i32>>::from) { // at $SRC_DIR/core/src/result.rs:LL:COL
+                        debug t => _16;  // in scope 10 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
                     }
                 }
             }
@@ -32,18 +32,18 @@ fn identity(_1: Result<i32, i32>) -> Result<i32, i32> {
         }
     }
     scope 5 (inlined <Result<i32, i32> as Try>::branch) { // at $DIR/separate_const_switch.rs:29:8: 29:10
-        debug self => _4;                // in scope 5 at $DIR/separate_const_switch.rs:29:8: 29:10
-        let mut _8: isize;               // in scope 5 at $DIR/separate_const_switch.rs:29:8: 29:10
-        let _9: i32;                     // in scope 5 at $DIR/separate_const_switch.rs:29:8: 29:10
-        let mut _10: i32;                // in scope 5 at $DIR/separate_const_switch.rs:29:8: 29:10
-        let _11: i32;                    // in scope 5 at $DIR/separate_const_switch.rs:29:8: 29:10
-        let mut _12: std::result::Result<std::convert::Infallible, i32>; // in scope 5 at $DIR/separate_const_switch.rs:29:8: 29:10
-        let mut _13: i32;                // in scope 5 at $DIR/separate_const_switch.rs:29:8: 29:10
+        debug self => _4;                // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+        let mut _8: isize;               // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+        let _9: i32;                     // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+        let mut _10: i32;                // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+        let _11: i32;                    // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+        let mut _12: std::result::Result<std::convert::Infallible, i32>; // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+        let mut _13: i32;                // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
         scope 6 {
-            debug v => _9;               // in scope 6 at $DIR/separate_const_switch.rs:29:8: 29:10
+            debug v => _9;               // in scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
         }
         scope 7 {
-            debug e => _11;              // in scope 7 at $DIR/separate_const_switch.rs:29:8: 29:10
+            debug e => _11;              // in scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
         }
     }
 
@@ -53,40 +53,40 @@ fn identity(_1: Result<i32, i32>) -> Result<i32, i32> {
         StorageLive(_4);                 // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:9
         _4 = _1;                         // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:9
         StorageLive(_8);                 // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-        _8 = discriminant(_4);           // scope 5 at $DIR/separate_const_switch.rs:29:8: 29:10
-        switchInt(move _8) -> [0_isize: bb3, 1_isize: bb1, otherwise: bb2]; // scope 5 at $DIR/separate_const_switch.rs:29:8: 29:10
+        _8 = discriminant(_4);           // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+        switchInt(move _8) -> [0_isize: bb3, 1_isize: bb1, otherwise: bb2]; // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
     }
 
     bb1: {
-        StorageLive(_11);                // scope 5 at $DIR/separate_const_switch.rs:29:8: 29:10
-        _11 = move ((_4 as Err).0: i32); // scope 5 at $DIR/separate_const_switch.rs:29:8: 29:10
-        StorageLive(_12);                // scope 7 at $DIR/separate_const_switch.rs:29:8: 29:10
-        StorageLive(_13);                // scope 7 at $DIR/separate_const_switch.rs:29:8: 29:10
-        _13 = move _11;                  // scope 7 at $DIR/separate_const_switch.rs:29:8: 29:10
-        ((_12 as Err).0: i32) = move _13; // scope 7 at $DIR/separate_const_switch.rs:29:8: 29:10
-        discriminant(_12) = 1;           // scope 7 at $DIR/separate_const_switch.rs:29:8: 29:10
-        StorageDead(_13);                // scope 7 at $DIR/separate_const_switch.rs:29:8: 29:10
-        ((_3 as Break).0: std::result::Result<std::convert::Infallible, i32>) = move _12; // scope 7 at $DIR/separate_const_switch.rs:29:8: 29:10
-        discriminant(_3) = 1;            // scope 7 at $DIR/separate_const_switch.rs:29:8: 29:10
-        StorageDead(_12);                // scope 7 at $DIR/separate_const_switch.rs:29:8: 29:10
-        StorageDead(_11);                // scope 5 at $DIR/separate_const_switch.rs:29:8: 29:10
+        StorageLive(_11);                // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+        _11 = move ((_4 as Err).0: i32); // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+        StorageLive(_12);                // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+        StorageLive(_13);                // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+        _13 = move _11;                  // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+        ((_12 as Err).0: i32) = move _13; // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+        discriminant(_12) = 1;           // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+        StorageDead(_13);                // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+        ((_3 as Break).0: std::result::Result<std::convert::Infallible, i32>) = move _12; // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+        discriminant(_3) = 1;            // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+        StorageDead(_12);                // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+        StorageDead(_11);                // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
         StorageDead(_8);                 // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
         StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
         StorageLive(_5);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
         _5 = ((_3 as Break).0: std::result::Result<std::convert::Infallible, i32>); // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
         StorageLive(_6);                 // scope 2 at $DIR/separate_const_switch.rs:29:9: 29:10
         _6 = _5;                         // scope 2 at $DIR/separate_const_switch.rs:29:9: 29:10
-        StorageLive(_14);                // scope 8 at $DIR/separate_const_switch.rs:29:8: 29:10
-        _14 = move ((_6 as Err).0: i32); // scope 8 at $DIR/separate_const_switch.rs:29:8: 29:10
-        StorageLive(_15);                // scope 9 at $DIR/separate_const_switch.rs:29:8: 29:10
-        StorageLive(_16);                // scope 9 at $DIR/separate_const_switch.rs:29:8: 29:10
-        _16 = move _14;                  // scope 9 at $DIR/separate_const_switch.rs:29:8: 29:10
-        _15 = move _16;                  // scope 10 at $DIR/separate_const_switch.rs:29:8: 29:10
-        StorageDead(_16);                // scope 9 at $DIR/separate_const_switch.rs:29:8: 29:10
-        ((_0 as Err).0: i32) = move _15; // scope 9 at $DIR/separate_const_switch.rs:29:8: 29:10
-        discriminant(_0) = 1;            // scope 9 at $DIR/separate_const_switch.rs:29:8: 29:10
-        StorageDead(_15);                // scope 9 at $DIR/separate_const_switch.rs:29:8: 29:10
-        StorageDead(_14);                // scope 8 at $DIR/separate_const_switch.rs:29:8: 29:10
+        StorageLive(_14);                // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
+        _14 = move ((_6 as Err).0: i32); // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
+        StorageLive(_15);                // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
+        StorageLive(_16);                // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
+        _16 = move _14;                  // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
+        _15 = move _16;                  // scope 10 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
+        StorageDead(_16);                // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
+        ((_0 as Err).0: i32) = move _15; // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
+        discriminant(_0) = 1;            // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
+        StorageDead(_15);                // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
+        StorageDead(_14);                // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
         StorageDead(_6);                 // scope 2 at $DIR/separate_const_switch.rs:29:9: 29:10
         StorageDead(_5);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
         StorageDead(_2);                 // scope 0 at $DIR/separate_const_switch.rs:29:10: 29:11
@@ -95,18 +95,18 @@ fn identity(_1: Result<i32, i32>) -> Result<i32, i32> {
     }
 
     bb2: {
-        unreachable;                     // scope 5 at $DIR/separate_const_switch.rs:29:8: 29:10
+        unreachable;                     // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
     }
 
     bb3: {
-        StorageLive(_9);                 // scope 5 at $DIR/separate_const_switch.rs:29:8: 29:10
-        _9 = move ((_4 as Ok).0: i32);   // scope 5 at $DIR/separate_const_switch.rs:29:8: 29:10
-        StorageLive(_10);                // scope 6 at $DIR/separate_const_switch.rs:29:8: 29:10
-        _10 = move _9;                   // scope 6 at $DIR/separate_const_switch.rs:29:8: 29:10
-        ((_3 as Continue).0: i32) = move _10; // scope 6 at $DIR/separate_const_switch.rs:29:8: 29:10
-        discriminant(_3) = 0;            // scope 6 at $DIR/separate_const_switch.rs:29:8: 29:10
-        StorageDead(_10);                // scope 6 at $DIR/separate_const_switch.rs:29:8: 29:10
-        StorageDead(_9);                 // scope 5 at $DIR/separate_const_switch.rs:29:8: 29:10
+        StorageLive(_9);                 // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+        _9 = move ((_4 as Ok).0: i32);   // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+        StorageLive(_10);                // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
+        _10 = move _9;                   // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
+        ((_3 as Continue).0: i32) = move _10; // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
+        discriminant(_3) = 0;            // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
+        StorageDead(_10);                // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
+        StorageDead(_9);                 // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
         StorageDead(_8);                 // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
         StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
         StorageLive(_7);                 // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10

--- a/src/test/mir-opt/separate_const_switch.identity.SeparateConstSwitch.diff
+++ b/src/test/mir-opt/separate_const_switch.identity.SeparateConstSwitch.diff
@@ -16,14 +16,14 @@
           debug residual => _6;            // in scope 1 at $DIR/separate_const_switch.rs:29:9: 29:10
           scope 2 {
               scope 8 (inlined #[track_caller] <Result<i32, i32> as FromResidual<Result<Infallible, i32>>>::from_residual) { // at $DIR/separate_const_switch.rs:29:8: 29:10
-                  debug residual => _8;    // in scope 8 at $DIR/separate_const_switch.rs:29:8: 29:10
-                  let _16: i32;            // in scope 8 at $DIR/separate_const_switch.rs:29:8: 29:10
-                  let mut _17: i32;        // in scope 8 at $DIR/separate_const_switch.rs:29:8: 29:10
-                  let mut _18: i32;        // in scope 8 at $DIR/separate_const_switch.rs:29:8: 29:10
+                  debug residual => _8;    // in scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
+                  let _16: i32;            // in scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
+                  let mut _17: i32;        // in scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
+                  let mut _18: i32;        // in scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
                   scope 9 {
-                      debug e => _16;      // in scope 9 at $DIR/separate_const_switch.rs:29:8: 29:10
-                      scope 10 (inlined <i32 as From<i32>>::from) { // at $DIR/separate_const_switch.rs:29:8: 29:10
-                          debug t => _18;  // in scope 10 at $DIR/separate_const_switch.rs:29:8: 29:10
+                      debug e => _16;      // in scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
+                      scope 10 (inlined <i32 as From<i32>>::from) { // at $SRC_DIR/core/src/result.rs:LL:COL
+                          debug t => _18;  // in scope 10 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
                       }
                   }
               }
@@ -35,18 +35,18 @@
           }
       }
       scope 5 (inlined <Result<i32, i32> as Try>::branch) { // at $DIR/separate_const_switch.rs:29:8: 29:10
-          debug self => _4;                // in scope 5 at $DIR/separate_const_switch.rs:29:8: 29:10
-          let mut _10: isize;              // in scope 5 at $DIR/separate_const_switch.rs:29:8: 29:10
-          let _11: i32;                    // in scope 5 at $DIR/separate_const_switch.rs:29:8: 29:10
-          let mut _12: i32;                // in scope 5 at $DIR/separate_const_switch.rs:29:8: 29:10
-          let _13: i32;                    // in scope 5 at $DIR/separate_const_switch.rs:29:8: 29:10
-          let mut _14: std::result::Result<std::convert::Infallible, i32>; // in scope 5 at $DIR/separate_const_switch.rs:29:8: 29:10
-          let mut _15: i32;                // in scope 5 at $DIR/separate_const_switch.rs:29:8: 29:10
+          debug self => _4;                // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+          let mut _10: isize;              // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+          let _11: i32;                    // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+          let mut _12: i32;                // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+          let _13: i32;                    // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+          let mut _14: std::result::Result<std::convert::Infallible, i32>; // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+          let mut _15: i32;                // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
           scope 6 {
-              debug v => _11;              // in scope 6 at $DIR/separate_const_switch.rs:29:8: 29:10
+              debug v => _11;              // in scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
           }
           scope 7 {
-              debug e => _13;              // in scope 7 at $DIR/separate_const_switch.rs:29:8: 29:10
+              debug e => _13;              // in scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
           }
       }
   
@@ -56,9 +56,9 @@
           StorageLive(_4);                 // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:9
           _4 = _1;                         // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:9
           StorageLive(_10);                // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-          _10 = discriminant(_4);          // scope 5 at $DIR/separate_const_switch.rs:29:8: 29:10
--         switchInt(move _10) -> [0_isize: bb6, 1_isize: bb4, otherwise: bb5]; // scope 5 at $DIR/separate_const_switch.rs:29:8: 29:10
-+         switchInt(move _10) -> [0_isize: bb5, 1_isize: bb3, otherwise: bb4]; // scope 5 at $DIR/separate_const_switch.rs:29:8: 29:10
+          _10 = discriminant(_4);          // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+-         switchInt(move _10) -> [0_isize: bb6, 1_isize: bb4, otherwise: bb5]; // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
++         switchInt(move _10) -> [0_isize: bb5, 1_isize: bb3, otherwise: bb4]; // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
       }
   
       bb1: {
@@ -86,17 +86,17 @@
           _6 = ((_3 as Break).0: std::result::Result<std::convert::Infallible, i32>); // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
           StorageLive(_8);                 // scope 2 at $DIR/separate_const_switch.rs:29:9: 29:10
           _8 = _6;                         // scope 2 at $DIR/separate_const_switch.rs:29:9: 29:10
-          StorageLive(_16);                // scope 8 at $DIR/separate_const_switch.rs:29:8: 29:10
-          _16 = move ((_8 as Err).0: i32); // scope 8 at $DIR/separate_const_switch.rs:29:8: 29:10
-          StorageLive(_17);                // scope 9 at $DIR/separate_const_switch.rs:29:8: 29:10
-          StorageLive(_18);                // scope 9 at $DIR/separate_const_switch.rs:29:8: 29:10
-          _18 = move _16;                  // scope 9 at $DIR/separate_const_switch.rs:29:8: 29:10
-          _17 = move _18;                  // scope 10 at $DIR/separate_const_switch.rs:29:8: 29:10
-          StorageDead(_18);                // scope 9 at $DIR/separate_const_switch.rs:29:8: 29:10
-          ((_0 as Err).0: i32) = move _17; // scope 9 at $DIR/separate_const_switch.rs:29:8: 29:10
-          discriminant(_0) = 1;            // scope 9 at $DIR/separate_const_switch.rs:29:8: 29:10
-          StorageDead(_17);                // scope 9 at $DIR/separate_const_switch.rs:29:8: 29:10
-          StorageDead(_16);                // scope 8 at $DIR/separate_const_switch.rs:29:8: 29:10
+          StorageLive(_16);                // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
+          _16 = move ((_8 as Err).0: i32); // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
+          StorageLive(_17);                // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
+          StorageLive(_18);                // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
+          _18 = move _16;                  // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
+          _17 = move _18;                  // scope 10 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
+          StorageDead(_18);                // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
+          ((_0 as Err).0: i32) = move _17; // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
+          discriminant(_0) = 1;            // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
+          StorageDead(_17);                // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
+          StorageDead(_16);                // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
           StorageDead(_8);                 // scope 2 at $DIR/separate_const_switch.rs:29:9: 29:10
           StorageDead(_6);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
           StorageDead(_2);                 // scope 0 at $DIR/separate_const_switch.rs:29:10: 29:11
@@ -106,19 +106,19 @@
   
 -     bb4: {
 +     bb3: {
-          StorageLive(_13);                // scope 5 at $DIR/separate_const_switch.rs:29:8: 29:10
-          _13 = move ((_4 as Err).0: i32); // scope 5 at $DIR/separate_const_switch.rs:29:8: 29:10
-          StorageLive(_14);                // scope 7 at $DIR/separate_const_switch.rs:29:8: 29:10
-          StorageLive(_15);                // scope 7 at $DIR/separate_const_switch.rs:29:8: 29:10
-          _15 = move _13;                  // scope 7 at $DIR/separate_const_switch.rs:29:8: 29:10
-          ((_14 as Err).0: i32) = move _15; // scope 7 at $DIR/separate_const_switch.rs:29:8: 29:10
-          discriminant(_14) = 1;           // scope 7 at $DIR/separate_const_switch.rs:29:8: 29:10
-          StorageDead(_15);                // scope 7 at $DIR/separate_const_switch.rs:29:8: 29:10
-          ((_3 as Break).0: std::result::Result<std::convert::Infallible, i32>) = move _14; // scope 7 at $DIR/separate_const_switch.rs:29:8: 29:10
-          discriminant(_3) = 1;            // scope 7 at $DIR/separate_const_switch.rs:29:8: 29:10
-          StorageDead(_14);                // scope 7 at $DIR/separate_const_switch.rs:29:8: 29:10
-          StorageDead(_13);                // scope 5 at $DIR/separate_const_switch.rs:29:8: 29:10
--         goto -> bb1;                     // scope 5 at $DIR/separate_const_switch.rs:29:8: 29:10
+          StorageLive(_13);                // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+          _13 = move ((_4 as Err).0: i32); // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+          StorageLive(_14);                // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+          StorageLive(_15);                // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+          _15 = move _13;                  // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+          ((_14 as Err).0: i32) = move _15; // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+          discriminant(_14) = 1;           // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+          StorageDead(_15);                // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+          ((_3 as Break).0: std::result::Result<std::convert::Infallible, i32>) = move _14; // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+          discriminant(_3) = 1;            // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+          StorageDead(_14);                // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+          StorageDead(_13);                // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+-         goto -> bb1;                     // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
 +         StorageDead(_10);                // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
 +         StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
 +         _5 = discriminant(_3);           // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
@@ -127,20 +127,20 @@
   
 -     bb5: {
 +     bb4: {
-          unreachable;                     // scope 5 at $DIR/separate_const_switch.rs:29:8: 29:10
+          unreachable;                     // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
       }
   
 -     bb6: {
 +     bb5: {
-          StorageLive(_11);                // scope 5 at $DIR/separate_const_switch.rs:29:8: 29:10
-          _11 = move ((_4 as Ok).0: i32);  // scope 5 at $DIR/separate_const_switch.rs:29:8: 29:10
-          StorageLive(_12);                // scope 6 at $DIR/separate_const_switch.rs:29:8: 29:10
-          _12 = move _11;                  // scope 6 at $DIR/separate_const_switch.rs:29:8: 29:10
-          ((_3 as Continue).0: i32) = move _12; // scope 6 at $DIR/separate_const_switch.rs:29:8: 29:10
-          discriminant(_3) = 0;            // scope 6 at $DIR/separate_const_switch.rs:29:8: 29:10
-          StorageDead(_12);                // scope 6 at $DIR/separate_const_switch.rs:29:8: 29:10
-          StorageDead(_11);                // scope 5 at $DIR/separate_const_switch.rs:29:8: 29:10
--         goto -> bb1;                     // scope 5 at $DIR/separate_const_switch.rs:29:8: 29:10
+          StorageLive(_11);                // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+          _11 = move ((_4 as Ok).0: i32);  // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+          StorageLive(_12);                // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
+          _12 = move _11;                  // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
+          ((_3 as Continue).0: i32) = move _12; // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
+          discriminant(_3) = 0;            // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
+          StorageDead(_12);                // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
+          StorageDead(_11);                // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+-         goto -> bb1;                     // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
 +         StorageDead(_10);                // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
 +         StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
 +         _5 = discriminant(_3);           // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10

--- a/src/test/mir-opt/simplify_arm.id_try.SimplifyArmIdentity.diff
+++ b/src/test/mir-opt/simplify_arm.id_try.SimplifyArmIdentity.diff
@@ -22,12 +22,12 @@
 -         debug e => _6;                   // in scope 2 at $DIR/simplify-arm.rs:37:13: 37:14
 +         debug e => ((_0 as Err).0: i32); // in scope 2 at $DIR/simplify-arm.rs:37:13: 37:14
           scope 5 (inlined <i32 as From<i32>>::from) { // at $DIR/simplify-arm.rs:37:37: 37:50
--             debug t => _9;               // in scope 5 at $DIR/simplify-arm.rs:37:37: 37:50
-+             debug t => ((_0 as Err).0: i32); // in scope 5 at $DIR/simplify-arm.rs:37:37: 37:50
+-             debug t => _9;               // in scope 5 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
++             debug t => ((_0 as Err).0: i32); // in scope 5 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
           }
           scope 6 (inlined from_error::<u8, i32>) { // at $DIR/simplify-arm.rs:37:26: 37:51
--             debug e => _8;               // in scope 6 at $DIR/simplify-arm.rs:37:26: 37:51
-+             debug e => ((_0 as Err).0: i32); // in scope 6 at $DIR/simplify-arm.rs:37:26: 37:51
+-             debug e => _8;               // in scope 6 at $DIR/simplify-arm.rs:27:21: 27:22
++             debug e => ((_0 as Err).0: i32); // in scope 6 at $DIR/simplify-arm.rs:27:21: 27:22
           }
       }
       scope 3 {
@@ -35,7 +35,7 @@
 +         debug v => ((_0 as Ok).0: u8);   // in scope 3 at $DIR/simplify-arm.rs:38:12: 38:13
       }
       scope 4 (inlined into_result::<u8, i32>) { // at $DIR/simplify-arm.rs:36:19: 36:33
-          debug r => _4;                   // in scope 4 at $DIR/simplify-arm.rs:36:19: 36:33
+          debug r => _4;                   // in scope 4 at $DIR/simplify-arm.rs:23:22: 23:23
       }
   
       bb0: {
@@ -43,7 +43,7 @@
           StorageLive(_3);                 // scope 0 at $DIR/simplify-arm.rs:36:19: 36:33
           StorageLive(_4);                 // scope 0 at $DIR/simplify-arm.rs:36:31: 36:32
           _4 = _1;                         // scope 0 at $DIR/simplify-arm.rs:36:31: 36:32
-          _3 = move _4;                    // scope 4 at $DIR/simplify-arm.rs:36:19: 36:33
+          _3 = move _4;                    // scope 4 at $DIR/simplify-arm.rs:24:5: 24:6
           StorageDead(_4);                 // scope 0 at $DIR/simplify-arm.rs:36:32: 36:33
           _5 = discriminant(_3);           // scope 0 at $DIR/simplify-arm.rs:36:19: 36:33
           switchInt(move _5) -> [0_isize: bb1, 1_isize: bb3, otherwise: bb2]; // scope 0 at $DIR/simplify-arm.rs:36:13: 36:33
@@ -75,13 +75,13 @@
 -         StorageLive(_8);                 // scope 2 at $DIR/simplify-arm.rs:37:37: 37:50
 -         StorageLive(_9);                 // scope 2 at $DIR/simplify-arm.rs:37:48: 37:49
 -         _9 = _6;                         // scope 2 at $DIR/simplify-arm.rs:37:48: 37:49
--         _8 = move _9;                    // scope 5 at $DIR/simplify-arm.rs:37:37: 37:50
+-         _8 = move _9;                    // scope 5 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
 -         StorageDead(_9);                 // scope 2 at $DIR/simplify-arm.rs:37:49: 37:50
--         ((_0 as Err).0: i32) = move _8;  // scope 6 at $DIR/simplify-arm.rs:37:26: 37:51
--         discriminant(_0) = 1;            // scope 6 at $DIR/simplify-arm.rs:37:26: 37:51
+-         ((_0 as Err).0: i32) = move _8;  // scope 6 at $DIR/simplify-arm.rs:28:9: 28:10
+-         discriminant(_0) = 1;            // scope 6 at $DIR/simplify-arm.rs:28:5: 28:11
 -         StorageDead(_8);                 // scope 2 at $DIR/simplify-arm.rs:37:50: 37:51
 -         StorageDead(_6);                 // scope 0 at $DIR/simplify-arm.rs:37:50: 37:51
-+         _0 = move _3;                    // scope 6 at $DIR/simplify-arm.rs:37:26: 37:51
++         _0 = move _3;                    // scope 6 at $DIR/simplify-arm.rs:28:5: 28:11
           StorageDead(_3);                 // scope 0 at $DIR/simplify-arm.rs:39:6: 39:7
           StorageDead(_2);                 // scope 0 at $DIR/simplify-arm.rs:41:1: 41:2
           goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:41:2: 41:2

--- a/src/test/mir-opt/simplify_arm.id_try.SimplifyBranchSame.diff
+++ b/src/test/mir-opt/simplify_arm.id_try.SimplifyBranchSame.diff
@@ -20,17 +20,17 @@
       scope 2 {
           debug e => ((_0 as Err).0: i32); // in scope 2 at $DIR/simplify-arm.rs:37:13: 37:14
           scope 5 (inlined <i32 as From<i32>>::from) { // at $DIR/simplify-arm.rs:37:37: 37:50
-              debug t => ((_0 as Err).0: i32); // in scope 5 at $DIR/simplify-arm.rs:37:37: 37:50
+              debug t => ((_0 as Err).0: i32); // in scope 5 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
           }
           scope 6 (inlined from_error::<u8, i32>) { // at $DIR/simplify-arm.rs:37:26: 37:51
-              debug e => ((_0 as Err).0: i32); // in scope 6 at $DIR/simplify-arm.rs:37:26: 37:51
+              debug e => ((_0 as Err).0: i32); // in scope 6 at $DIR/simplify-arm.rs:27:21: 27:22
           }
       }
       scope 3 {
           debug v => ((_0 as Ok).0: u8);   // in scope 3 at $DIR/simplify-arm.rs:38:12: 38:13
       }
       scope 4 (inlined into_result::<u8, i32>) { // at $DIR/simplify-arm.rs:36:19: 36:33
-          debug r => _4;                   // in scope 4 at $DIR/simplify-arm.rs:36:19: 36:33
+          debug r => _4;                   // in scope 4 at $DIR/simplify-arm.rs:23:22: 23:23
       }
   
       bb0: {
@@ -38,7 +38,7 @@
           StorageLive(_3);                 // scope 0 at $DIR/simplify-arm.rs:36:19: 36:33
           StorageLive(_4);                 // scope 0 at $DIR/simplify-arm.rs:36:31: 36:32
           _4 = _1;                         // scope 0 at $DIR/simplify-arm.rs:36:31: 36:32
-          _3 = move _4;                    // scope 4 at $DIR/simplify-arm.rs:36:19: 36:33
+          _3 = move _4;                    // scope 4 at $DIR/simplify-arm.rs:24:5: 24:6
           StorageDead(_4);                 // scope 0 at $DIR/simplify-arm.rs:36:32: 36:33
           _5 = discriminant(_3);           // scope 0 at $DIR/simplify-arm.rs:36:19: 36:33
 -         switchInt(move _5) -> [0_isize: bb1, 1_isize: bb3, otherwise: bb2]; // scope 0 at $DIR/simplify-arm.rs:36:13: 36:33
@@ -58,7 +58,7 @@
 -     }
 - 
 -     bb3: {
--         _0 = move _3;                    // scope 6 at $DIR/simplify-arm.rs:37:26: 37:51
+-         _0 = move _3;                    // scope 6 at $DIR/simplify-arm.rs:28:5: 28:11
 -         StorageDead(_3);                 // scope 0 at $DIR/simplify-arm.rs:39:6: 39:7
 -         StorageDead(_2);                 // scope 0 at $DIR/simplify-arm.rs:41:1: 41:2
 -         goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:41:2: 41:2

--- a/src/test/mir-opt/simplify_try.try_identity.DestinationPropagation.diff
+++ b/src/test/mir-opt/simplify_try.try_identity.DestinationPropagation.diff
@@ -20,18 +20,18 @@
       scope 2 {
           debug e => ((_0 as Err).0: i32); // in scope 2 at $DIR/simplify_try.rs:22:13: 22:14
           scope 5 (inlined <i32 as From<i32>>::from) { // at $DIR/simplify_try.rs:22:37: 22:50
-              debug t => ((_0 as Err).0: i32); // in scope 5 at $DIR/simplify_try.rs:22:37: 22:50
+              debug t => ((_0 as Err).0: i32); // in scope 5 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
           }
           scope 6 (inlined from_error::<u32, i32>) { // at $DIR/simplify_try.rs:22:26: 22:51
-              debug e => ((_0 as Err).0: i32); // in scope 6 at $DIR/simplify_try.rs:22:26: 22:51
+              debug e => ((_0 as Err).0: i32); // in scope 6 at $DIR/simplify_try.rs:12:21: 12:22
           }
       }
       scope 3 {
           debug v => ((_0 as Ok).0: u32);  // in scope 3 at $DIR/simplify_try.rs:23:12: 23:13
       }
       scope 4 (inlined into_result::<u32, i32>) { // at $DIR/simplify_try.rs:21:19: 21:33
--         debug r => _4;                   // in scope 4 at $DIR/simplify_try.rs:21:19: 21:33
-+         debug r => _0;                   // in scope 4 at $DIR/simplify_try.rs:21:19: 21:33
+-         debug r => _4;                   // in scope 4 at $DIR/simplify_try.rs:8:22: 8:23
++         debug r => _0;                   // in scope 4 at $DIR/simplify_try.rs:8:22: 8:23
       }
   
       bb0: {
@@ -39,13 +39,13 @@
 -         StorageLive(_3);                 // scope 0 at $DIR/simplify_try.rs:21:19: 21:33
 -         StorageLive(_4);                 // scope 0 at $DIR/simplify_try.rs:21:31: 21:32
 -         _4 = _1;                         // scope 0 at $DIR/simplify_try.rs:21:31: 21:32
--         _3 = move _4;                    // scope 4 at $DIR/simplify_try.rs:21:19: 21:33
+-         _3 = move _4;                    // scope 4 at $DIR/simplify_try.rs:9:5: 9:6
 -         StorageDead(_4);                 // scope 0 at $DIR/simplify_try.rs:21:32: 21:33
 -         _5 = discriminant(_3);           // scope 0 at $DIR/simplify_try.rs:21:19: 21:33
 +         nop;                             // scope 0 at $DIR/simplify_try.rs:21:19: 21:33
 +         nop;                             // scope 0 at $DIR/simplify_try.rs:21:31: 21:32
 +         _0 = _1;                         // scope 0 at $DIR/simplify_try.rs:21:31: 21:32
-+         nop;                             // scope 4 at $DIR/simplify_try.rs:21:19: 21:33
++         nop;                             // scope 4 at $DIR/simplify_try.rs:9:5: 9:6
 +         nop;                             // scope 0 at $DIR/simplify_try.rs:21:32: 21:33
 +         _5 = discriminant(_0);           // scope 0 at $DIR/simplify_try.rs:21:19: 21:33
           goto -> bb1;                     // scope 0 at $DIR/simplify_try.rs:21:13: 21:33

--- a/src/test/mir-opt/simplify_try.try_identity.SimplifyArmIdentity.diff
+++ b/src/test/mir-opt/simplify_try.try_identity.SimplifyArmIdentity.diff
@@ -22,12 +22,12 @@
 -         debug e => _6;                   // in scope 2 at $DIR/simplify_try.rs:22:13: 22:14
 +         debug e => ((_0 as Err).0: i32); // in scope 2 at $DIR/simplify_try.rs:22:13: 22:14
           scope 5 (inlined <i32 as From<i32>>::from) { // at $DIR/simplify_try.rs:22:37: 22:50
--             debug t => _9;               // in scope 5 at $DIR/simplify_try.rs:22:37: 22:50
-+             debug t => ((_0 as Err).0: i32); // in scope 5 at $DIR/simplify_try.rs:22:37: 22:50
+-             debug t => _9;               // in scope 5 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
++             debug t => ((_0 as Err).0: i32); // in scope 5 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
           }
           scope 6 (inlined from_error::<u32, i32>) { // at $DIR/simplify_try.rs:22:26: 22:51
--             debug e => _8;               // in scope 6 at $DIR/simplify_try.rs:22:26: 22:51
-+             debug e => ((_0 as Err).0: i32); // in scope 6 at $DIR/simplify_try.rs:22:26: 22:51
+-             debug e => _8;               // in scope 6 at $DIR/simplify_try.rs:12:21: 12:22
++             debug e => ((_0 as Err).0: i32); // in scope 6 at $DIR/simplify_try.rs:12:21: 12:22
           }
       }
       scope 3 {
@@ -35,7 +35,7 @@
 +         debug v => ((_0 as Ok).0: u32);  // in scope 3 at $DIR/simplify_try.rs:23:12: 23:13
       }
       scope 4 (inlined into_result::<u32, i32>) { // at $DIR/simplify_try.rs:21:19: 21:33
-          debug r => _4;                   // in scope 4 at $DIR/simplify_try.rs:21:19: 21:33
+          debug r => _4;                   // in scope 4 at $DIR/simplify_try.rs:8:22: 8:23
       }
   
       bb0: {
@@ -43,7 +43,7 @@
           StorageLive(_3);                 // scope 0 at $DIR/simplify_try.rs:21:19: 21:33
           StorageLive(_4);                 // scope 0 at $DIR/simplify_try.rs:21:31: 21:32
           _4 = _1;                         // scope 0 at $DIR/simplify_try.rs:21:31: 21:32
-          _3 = move _4;                    // scope 4 at $DIR/simplify_try.rs:21:19: 21:33
+          _3 = move _4;                    // scope 4 at $DIR/simplify_try.rs:9:5: 9:6
           StorageDead(_4);                 // scope 0 at $DIR/simplify_try.rs:21:32: 21:33
           _5 = discriminant(_3);           // scope 0 at $DIR/simplify_try.rs:21:19: 21:33
           switchInt(move _5) -> [0_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/simplify_try.rs:21:13: 21:33
@@ -71,13 +71,13 @@
 -         StorageLive(_8);                 // scope 2 at $DIR/simplify_try.rs:22:37: 22:50
 -         StorageLive(_9);                 // scope 2 at $DIR/simplify_try.rs:22:48: 22:49
 -         _9 = _6;                         // scope 2 at $DIR/simplify_try.rs:22:48: 22:49
--         _8 = move _9;                    // scope 5 at $DIR/simplify_try.rs:22:37: 22:50
+-         _8 = move _9;                    // scope 5 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
 -         StorageDead(_9);                 // scope 2 at $DIR/simplify_try.rs:22:49: 22:50
--         ((_0 as Err).0: i32) = move _8;  // scope 6 at $DIR/simplify_try.rs:22:26: 22:51
--         discriminant(_0) = 1;            // scope 6 at $DIR/simplify_try.rs:22:26: 22:51
+-         ((_0 as Err).0: i32) = move _8;  // scope 6 at $DIR/simplify_try.rs:13:9: 13:10
+-         discriminant(_0) = 1;            // scope 6 at $DIR/simplify_try.rs:13:5: 13:11
 -         StorageDead(_8);                 // scope 2 at $DIR/simplify_try.rs:22:50: 22:51
 -         StorageDead(_6);                 // scope 0 at $DIR/simplify_try.rs:22:50: 22:51
-+         _0 = move _3;                    // scope 6 at $DIR/simplify_try.rs:22:26: 22:51
++         _0 = move _3;                    // scope 6 at $DIR/simplify_try.rs:13:5: 13:11
           StorageDead(_3);                 // scope 0 at $DIR/simplify_try.rs:24:6: 24:7
           StorageDead(_2);                 // scope 0 at $DIR/simplify_try.rs:26:1: 26:2
           return;                          // scope 0 at $DIR/simplify_try.rs:26:2: 26:2

--- a/src/test/mir-opt/simplify_try.try_identity.SimplifyBranchSame.after.mir
+++ b/src/test/mir-opt/simplify_try.try_identity.SimplifyBranchSame.after.mir
@@ -19,17 +19,17 @@ fn try_identity(_1: Result<u32, i32>) -> Result<u32, i32> {
     scope 2 {
         debug e => ((_0 as Err).0: i32); // in scope 2 at $DIR/simplify_try.rs:22:13: 22:14
         scope 5 (inlined <i32 as From<i32>>::from) { // at $DIR/simplify_try.rs:22:37: 22:50
-            debug t => ((_0 as Err).0: i32); // in scope 5 at $DIR/simplify_try.rs:22:37: 22:50
+            debug t => ((_0 as Err).0: i32); // in scope 5 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
         }
         scope 6 (inlined from_error::<u32, i32>) { // at $DIR/simplify_try.rs:22:26: 22:51
-            debug e => ((_0 as Err).0: i32); // in scope 6 at $DIR/simplify_try.rs:22:26: 22:51
+            debug e => ((_0 as Err).0: i32); // in scope 6 at $DIR/simplify_try.rs:12:21: 12:22
         }
     }
     scope 3 {
         debug v => ((_0 as Ok).0: u32);  // in scope 3 at $DIR/simplify_try.rs:23:12: 23:13
     }
     scope 4 (inlined into_result::<u32, i32>) { // at $DIR/simplify_try.rs:21:19: 21:33
-        debug r => _4;                   // in scope 4 at $DIR/simplify_try.rs:21:19: 21:33
+        debug r => _4;                   // in scope 4 at $DIR/simplify_try.rs:8:22: 8:23
     }
 
     bb0: {
@@ -37,7 +37,7 @@ fn try_identity(_1: Result<u32, i32>) -> Result<u32, i32> {
         StorageLive(_3);                 // scope 0 at $DIR/simplify_try.rs:21:19: 21:33
         StorageLive(_4);                 // scope 0 at $DIR/simplify_try.rs:21:31: 21:32
         _4 = _1;                         // scope 0 at $DIR/simplify_try.rs:21:31: 21:32
-        _3 = move _4;                    // scope 4 at $DIR/simplify_try.rs:21:19: 21:33
+        _3 = move _4;                    // scope 4 at $DIR/simplify_try.rs:9:5: 9:6
         StorageDead(_4);                 // scope 0 at $DIR/simplify_try.rs:21:32: 21:33
         _5 = discriminant(_3);           // scope 0 at $DIR/simplify_try.rs:21:19: 21:33
         goto -> bb1;                     // scope 0 at $DIR/simplify_try.rs:21:13: 21:33

--- a/src/test/mir-opt/simplify_try.try_identity.SimplifyLocals.after.mir
+++ b/src/test/mir-opt/simplify_try.try_identity.SimplifyLocals.after.mir
@@ -9,17 +9,17 @@ fn try_identity(_1: Result<u32, i32>) -> Result<u32, i32> {
     scope 2 {
         debug e => ((_0 as Err).0: i32); // in scope 2 at $DIR/simplify_try.rs:22:13: 22:14
         scope 5 (inlined <i32 as From<i32>>::from) { // at $DIR/simplify_try.rs:22:37: 22:50
-            debug t => ((_0 as Err).0: i32); // in scope 5 at $DIR/simplify_try.rs:22:37: 22:50
+            debug t => ((_0 as Err).0: i32); // in scope 5 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
         }
         scope 6 (inlined from_error::<u32, i32>) { // at $DIR/simplify_try.rs:22:26: 22:51
-            debug e => ((_0 as Err).0: i32); // in scope 6 at $DIR/simplify_try.rs:22:26: 22:51
+            debug e => ((_0 as Err).0: i32); // in scope 6 at $DIR/simplify_try.rs:12:21: 12:22
         }
     }
     scope 3 {
         debug v => ((_0 as Ok).0: u32);  // in scope 3 at $DIR/simplify_try.rs:23:12: 23:13
     }
     scope 4 (inlined into_result::<u32, i32>) { // at $DIR/simplify_try.rs:21:19: 21:33
-        debug r => _0;                   // in scope 4 at $DIR/simplify_try.rs:21:19: 21:33
+        debug r => _0;                   // in scope 4 at $DIR/simplify_try.rs:8:22: 8:23
     }
 
     bb0: {

--- a/src/test/ui/const_prop/inline_spans.rs
+++ b/src/test/ui/const_prop/inline_spans.rs
@@ -5,10 +5,14 @@
 
 fn main() {
     let _ = add(u8::MAX, 1);
-    //~^ ERROR this arithmetic operation will overflow
+    //~^ NOTE in this expansion of inlined source
+    //~| NOTE in this expansion of inlined source
 }
 
 #[inline(always)]
 fn add(x: u8, y: u8) -> u8 {
     x + y
+    //~^ ERROR this arithmetic operation will overflow
+    //~| NOTE attempt to compute `u8::MAX + 1_u8`, which would overflow
+    //~| NOTE `#[deny(arithmetic_overflow)]` on by default
 }

--- a/src/test/ui/const_prop/inline_spans.stderr
+++ b/src/test/ui/const_prop/inline_spans.stderr
@@ -1,11 +1,11 @@
 error: this arithmetic operation will overflow
-  --> $DIR/inline_spans.rs:7:13
+  --> $DIR/inline_spans.rs:14:5
    |
 LL |     let _ = add(u8::MAX, 1);
-   |             ^^^^^^^^^^^^^^^ attempt to compute `u8::MAX + 1_u8`, which would overflow
+   |             --------------- in this inlined function call
 ...
 LL |     x + y
-   |     ----- in the inlined copy of this code
+   |     ^^^^^ attempt to compute `u8::MAX + 1_u8`, which would overflow
    |
    = note: `#[deny(arithmetic_overflow)]` on by default
 


### PR DESCRIPTION
The inlining integrator used to create one expansion for each span from the callee body.
This PR reverses the logic to create a single expansion for the whole call,
which is more consistent with how macro expansions work for macros.

This should remove the large memory regression in #91743.
