### PR TITLE
Check method input expressions once

### DIFF
--- a/compiler/rustc_typeck/src/check/demand.rs
+++ b/compiler/rustc_typeck/src/check/demand.rs
@@ -470,7 +470,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             return None;
         };
 
-        let self_ty = self.typeck_results.borrow().node_type(method_expr[0].hir_id);
+        let self_ty = self.typeck_results.borrow().expr_ty(&method_expr[0]);
         let self_ty = format!("{:?}", self_ty);
         let name = method_path.ident.name;
         let is_as_ref_able = (self_ty.starts_with("&std::option::Option")

--- a/compiler/rustc_typeck/src/check/expr.rs
+++ b/compiler/rustc_typeck/src/check/expr.rs
@@ -1506,7 +1506,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 }
             } else {
                 self.check_expr_has_type_or_error(base_expr, adt_ty, |_| {
-                    let base_ty = self.typeck_results.borrow().node_type(base_expr.hir_id);
+                    let base_ty = self.typeck_results.borrow().expr_ty(*base_expr);
                     let same_adt = match (adt_ty.kind(), base_ty.kind()) {
                         (ty::Adt(adt, _), ty::Adt(base_adt, _)) if adt == base_adt => true,
                         _ => false,

--- a/compiler/rustc_typeck/src/check/fn_ctxt/_impl.rs
+++ b/compiler/rustc_typeck/src/check/fn_ctxt/_impl.rs
@@ -313,15 +313,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     ) => {
                         // A reborrow has no effect before a dereference.
                     }
-                    // Catch cases which have Deref(None)
-                    // having them slip to bug! causes ICE
-                    // see #94291 for more info
-                    (&[Adjustment { kind: Adjust::Deref(None), .. }], _) => {
-                        self.tcx.sess.delay_span_bug(
-                            DUMMY_SP,
-                            &format!("Can't compose Deref(None) expressions"),
-                        )
-                    }
                     // FIXME: currently we never try to compose autoderefs
                     // and ReifyFnPointer/UnsafeFnPointer, but we could.
                     _ => bug!(

--- a/src/test/ui/mismatched_types/overloaded-calls-bad.rs
+++ b/src/test/ui/mismatched_types/overloaded-calls-bad.rs
@@ -30,5 +30,4 @@ fn main() {
     //~^ ERROR this function takes 1 argument but 0 arguments were supplied
     let ans = s("burma", "shave");
     //~^ ERROR this function takes 1 argument but 2 arguments were supplied
-    //~| ERROR mismatched types
 }

--- a/src/test/ui/mismatched_types/overloaded-calls-bad.stderr
+++ b/src/test/ui/mismatched_types/overloaded-calls-bad.stderr
@@ -18,12 +18,6 @@ note: associated function defined here
 LL |     extern "rust-call" fn call_mut(&mut self, args: Args) -> Self::Output;
    |                           ^^^^^^^^
 
-error[E0308]: mismatched types
-  --> $DIR/overloaded-calls-bad.rs:31:17
-   |
-LL |     let ans = s("burma", "shave");
-   |                 ^^^^^^^ expected `isize`, found `&str`
-
 error[E0057]: this function takes 1 argument but 2 arguments were supplied
   --> $DIR/overloaded-calls-bad.rs:31:15
    |
@@ -38,7 +32,7 @@ note: associated function defined here
 LL |     extern "rust-call" fn call_mut(&mut self, args: Args) -> Self::Output;
    |                           ^^^^^^^^
 
-error: aborting due to 4 previous errors
+error: aborting due to 3 previous errors
 
 Some errors have detailed explanations: E0057, E0308.
 For more information about an error, try `rustc --explain E0057`.

--- a/src/test/ui/tuple/wrong_argument_ice-2.rs
+++ b/src/test/ui/tuple/wrong_argument_ice-2.rs
@@ -1,0 +1,17 @@
+fn test(t: (i32, i32)) {}
+
+struct Foo;
+
+impl Foo {
+    fn qux(&self) -> i32 {
+        0
+    }
+}
+
+fn bar() {
+    let x = Foo;
+    test(x.qux(), x.qux());
+    //~^ ERROR this function takes 1 argument but 2 arguments were supplied
+}
+
+fn main() {}

--- a/src/test/ui/tuple/wrong_argument_ice-2.stderr
+++ b/src/test/ui/tuple/wrong_argument_ice-2.stderr
@@ -1,0 +1,19 @@
+error[E0061]: this function takes 1 argument but 2 arguments were supplied
+  --> $DIR/wrong_argument_ice-2.rs:13:5
+   |
+LL |     test(x.qux(), x.qux());
+   |     ^^^^ -------  ------- supplied 2 arguments
+   |
+note: function defined here
+  --> $DIR/wrong_argument_ice-2.rs:1:4
+   |
+LL | fn test(t: (i32, i32)) {}
+   |    ^^^^ -------------
+help: use parentheses to construct a tuple
+   |
+LL |     test((x.qux(), x.qux()));
+   |          +                +
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0061`.


### PR DESCRIPTION
If the user mistakenly forgets to wrap their method args in a tuple, then the compiler tries to check that  types within the tuple match the expression args. This means we call `check_expr` once within this diagnostic code, so when we check the expr once again in `demand_compatible`, we attempt to apply expr adjustments twice, leading to ICEs.

This PR attempts to fix this by skipping the expression type check in `demand_compatible` if we have detected an method arg mismatch at all.

This does lead to a single UI test regressing slightly, due to a diagnostic disappearing, though I don't know if it is generally meaningful to even raise an type error after noting that the argument count is incorrect in a function call, since the user might be providing (in-context) meaningless expressions to the wrong method. 

I can adjust this to be a bit more targeted (to just skip checking exprs in `demand_compatible` in the tuple case) if this UI test regression is a problem.

fixes #94334
cc #94291

Also drive-by fixup of `.node_type(expr.hir_id)` to `.expr_ty(expr)`, since that method exists.