### PR TITLE
Better error for normalization errors from parent crates that use `#![feature(generic_const_exprs)]`

### DIFF
--- a/compiler/rustc_trait_selection/src/lib.rs
+++ b/compiler/rustc_trait_selection/src/lib.rs
@@ -17,6 +17,7 @@
 #![feature(derive_default_enum)]
 #![feature(hash_drain_filter)]
 #![feature(label_break_value)]
+#![feature(let_chains)]
 #![feature(let_else)]
 #![feature(never_type)]
 #![feature(crate_visibility_modifier)]

--- a/src/test/ui/const-generics/generic_const_exprs/auxiliary/issue-94287-aux.rs
+++ b/src/test/ui/const-generics/generic_const_exprs/auxiliary/issue-94287-aux.rs
@@ -1,0 +1,21 @@
+#![feature(generic_const_exprs)]
+
+use std::str::FromStr;
+
+pub struct If<const CONDITION: bool>;
+
+pub trait True {}
+
+impl True for If<true> {}
+
+pub struct FixedI32<const FRAC: u32>;
+
+impl<const FRAC: u32> FromStr for FixedI32<FRAC>
+where
+    If<{ FRAC <= 32 }>: True,
+{
+    type Err = ();
+    fn from_str(_s: &str) -> Result<Self, Self::Err> {
+        unimplemented!()
+    }
+}

--- a/src/test/ui/const-generics/generic_const_exprs/issue-94287.rs
+++ b/src/test/ui/const-generics/generic_const_exprs/issue-94287.rs
@@ -1,0 +1,10 @@
+// aux-build:issue-94287-aux.rs
+// build-fail
+
+extern crate issue_94287_aux;
+
+use std::str::FromStr;
+
+fn main() {
+    let _ = <issue_94287_aux::FixedI32<16>>::from_str("");
+}

--- a/src/test/ui/const-generics/generic_const_exprs/issue-94287.stderr
+++ b/src/test/ui/const-generics/generic_const_exprs/issue-94287.stderr
@@ -1,0 +1,14 @@
+error: failed to evaluate generic const expression
+  --> $DIR/auxiliary/issue-94287-aux.rs:15:8
+   |
+LL |     If<{ FRAC <= 32 }>: True,
+   |        ^^^^^^^^^^^^^^
+   |
+   = note: the crate this constant originates from uses `#![feature(generic_const_exprs)]`
+help: consider enabling this feature
+   |
+LL | #![feature(generic_const_exprs)]
+   |
+
+error: aborting due to previous error
+


### PR DESCRIPTION
This PR implements a somewhat rudimentary heuristic to suggest using `#![feature(generic_const_exprs)]` in a child crate when a function from a foreign crate (that may have used `#![feature(generic_const_exprs)]`) fails to normalize during codegen.

cc: #79018 
cc: #94287 