### PR TITLE
check for simd type before calling simd_extract in const eval

### DIFF
--- a/compiler/rustc_const_eval/src/interpret/operand.rs
+++ b/compiler/rustc_const_eval/src/interpret/operand.rs
@@ -444,7 +444,11 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
     ) -> InterpResult<'tcx, (MPlaceTy<'tcx, M::PointerTag>, u64)> {
         // Basically we just transmute this place into an array following simd_size_and_type.
         // This only works in memory, but repr(simd) types should never be immediates anyway.
-        assert!(base.layout.ty.is_simd());
+        assert!(
+            base.layout.ty.is_simd(),
+            "expected a simd type, instead found {:?}",
+            base.layout.ty
+        );
         self.mplace_to_simd(&base.assert_mem_place())
     }
 

--- a/src/test/ui/simd/issue-94382.rs
+++ b/src/test/ui/simd/issue-94382.rs
@@ -1,0 +1,17 @@
+#![feature(platform_intrinsics)] //~ ERROR module has missing stability attribute
+#![feature(staged_api)]
+
+struct U16x2(u16, u16);
+
+extern "platform-intrinsic" {
+    #[rustc_const_stable(feature = "foo", since = "1.3.37")]
+    fn simd_extract<T, U>(x: T, idx: u32) -> U;
+}
+
+fn main() {
+    const U: U16x2 = U16x2(13, 14);
+    const V: U16x2 = U;
+    const Y0: i8 = unsafe { simd_extract(V, 0) };
+}
+//~^^ ERROR any use of this value will cause an error [const_err]
+//~| WARN 14:29: 14:47: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!

--- a/src/test/ui/simd/issue-94382.stderr
+++ b/src/test/ui/simd/issue-94382.stderr
@@ -1,0 +1,26 @@
+error: module has missing stability attribute
+  --> $DIR/issue-94382.rs:1:1
+   |
+LL | / #![feature(platform_intrinsics)]
+LL | | #![feature(staged_api)]
+LL | |
+LL | | struct U16x2(u16, u16);
+...  |
+LL | |     const Y0: i8 = unsafe { simd_extract(V, 0) };  
+LL | | }
+   | |_^
+
+error: any use of this value will cause an error
+  --> $DIR/issue-94382.rs:14:29
+   |
+LL |     const Y0: i8 = unsafe { simd_extract(V, 0) };  
+   |     ------------------------^^^^^^^^^^^^^^^^^^---
+   |                             |
+   |                             aborted execution: type `U16x2` is not `#[repr(simd)]`
+   |
+   = note: `#[deny(const_err)]` on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Fix for #94382 

This is my first PR in this part of the codebase, so happy to change things as others see fit. I'm not super familiar with SIMD in particular but I'm assuming that a type shouldn't be eligible for SIMD platform intrinsics unless explicitly opted into with `#[repr(simd)]`.

Like I say I'm pretty unsure about whether this is the right direction, but thought it can't hurt to try to fix it and see what other people say about it 😁 