### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/compiler/rustc_codegen_llvm/src/back/archive.rs
+++ b/compiler/rustc_codegen_llvm/src/back/archive.rs
@@ -151,7 +151,9 @@ impl<'a> ArchiveBuilder<'a> for LlvmArchiveBuilder<'a> {
             output_path.with_extension("lib")
         };
 
-        let mingw_gnu_toolchain = self.config.sess.target.llvm_target.ends_with("pc-windows-gnu");
+        let target = &self.config.sess.target;
+        let mingw_gnu_toolchain =
+            target.vendor == "pc" && target.os == "windows" && target.env == "gnu";
 
         let import_name_and_ordinal_vector: Vec<(String, Option<u16>)> = dll_imports
             .iter()

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -71,6 +71,9 @@ pub use raw::{from_raw_parts, from_raw_parts_mut};
 #[stable(feature = "from_ref", since = "1.28.0")]
 pub use raw::{from_mut, from_ref};
 
+#[unstable(feature = "slice_from_ptr_range", issue = "89792")]
+pub use raw::{from_mut_ptr_range, from_ptr_range};
+
 // This function is public only because there is no other way to unit test heapsort.
 #[unstable(feature = "sort_internals", reason = "internal to sort module", issue = "none")]
 pub use sort::heapsort;

--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -48,6 +48,7 @@
 #![feature(pin_macro)]
 #![feature(sort_internals)]
 #![feature(slice_take)]
+#![feature(slice_from_ptr_range)]
 #![feature(maybe_uninit_uninit_array)]
 #![feature(maybe_uninit_array_assume_init)]
 #![feature(maybe_uninit_write_slice)]

--- a/library/core/tests/slice.rs
+++ b/library/core/tests/slice.rs
@@ -2,6 +2,7 @@ use core::cell::Cell;
 use core::cmp::Ordering;
 use core::mem::MaybeUninit;
 use core::result::Result::{Err, Ok};
+use core::slice;
 
 #[test]
 fn test_position() {
@@ -2479,4 +2480,25 @@ take_tests! {
     (take_mut_in_bounds_max_range_to, (..usize::MAX), Some(empty_max_mut!()), &mut [(); 0]),
     (take_mut_oob_max_range_to_inclusive, (..=usize::MAX), None, empty_max_mut!()),
     (take_mut_in_bounds_max_range_from, (usize::MAX..), Some(&mut [] as _), empty_max_mut!()),
+}
+
+#[test]
+fn test_slice_from_ptr_range() {
+    let arr = ["foo".to_owned(), "bar".to_owned()];
+    let range = arr.as_ptr_range();
+    unsafe {
+        assert_eq!(slice::from_ptr_range(range), &arr);
+    }
+
+    let mut arr = [1, 2, 3];
+    let range = arr.as_mut_ptr_range();
+    unsafe {
+        assert_eq!(slice::from_mut_ptr_range(range), &mut [1, 2, 3]);
+    }
+
+    let arr: [Vec<String>; 0] = [];
+    let range = arr.as_ptr_range();
+    unsafe {
+        assert_eq!(slice::from_ptr_range(range), &arr);
+    }
 }

--- a/src/doc/not_found.md
+++ b/src/doc/not_found.md
@@ -84,7 +84,7 @@ function on_submit(event) {
     if (form['from'].value === 'duckduckgo') {
         document.location.href = form.action + '?q=' + encodeURIComponent(q + ' site:doc.rust-lang.org');
     } else if (form['from'].value === 'library') {
-        document.location.href = 'std/index.html?search=' + encodeURIComponent(q);
+        document.location.href = '/std/index.html?search=' + encodeURIComponent(q);
     }
 }
 

--- a/src/doc/rustdoc/src/what-to-include.md
+++ b/src/doc/rustdoc/src/what-to-include.md
@@ -118,7 +118,7 @@ rustdoc --theme awesome.css src/lib.rs
 
 Here is an example of a new theme, [Ayu].
 
-[Ayu]: https://github.com/rust-lang/rust/blob/master/src/librustdoc/html/static/themes/ayu.css
+[Ayu]: https://github.com/rust-lang/rust/blob/master/src/librustdoc/html/static/css/themes/ayu.css
 [API Guidelines]: https://rust-lang.github.io/api-guidelines/documentation.html#rustdoc-does-not-show-unhelpful-implementation-details-c-hidden
 [Documentation tests]: documentation-tests.md
 [on this blog]: https://blog.guillaume-gomez.fr/articles/2016-09-16+Generating+doc+with+rustdoc+and+a+custom+theme

--- a/src/test/ui/const-generics/generic_const_exprs/issue-90847.rs
+++ b/src/test/ui/const-generics/generic_const_exprs/issue-90847.rs
@@ -1,0 +1,9 @@
+// check-pass
+
+#![allow(incomplete_features)]
+#![feature(generic_const_exprs)]
+#![feature(adt_const_params)]
+
+struct Foo<const A: [(); 0 + 0]> where [(); 0 + 0]: Sized;
+
+fn main() {}


### PR DESCRIPTION
Successful merges:

 - #89793 (Add `slice::{from_ptr_range, from_mut_ptr_range} `)
 - #92642 (Update search location from a relative path to absolute)
 - #93389 (regression for issue 90847)
 - #93413 (Fix broken link from rustdoc docs to ayu theme)
 - #94365 (Fix MinGW target detection in raw-dylib)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=89793,92642,93389,93413,94365)
<!-- homu-ignore:end -->