### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/compiler/rustc_codegen_ssa/src/mir/place.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/place.rs
@@ -453,7 +453,18 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
         };
         for elem in place_ref.projection[base..].iter() {
             cg_base = match elem.clone() {
-                mir::ProjectionElem::Deref => bx.load_operand(cg_base).deref(bx.cx()),
+                mir::ProjectionElem::Deref => {
+                    // custom allocators can change box's abi, making it unable to be derefed directly
+                    if cg_base.layout.ty.is_box()
+                        && matches!(cg_base.layout.abi, Abi::Aggregate { .. })
+                    {
+                        let ptr = cg_base.project_field(bx, 0).project_field(bx, 0);
+
+                        bx.load_operand(ptr).deref(bx.cx())
+                    } else {
+                        bx.load_operand(cg_base).deref(bx.cx())
+                    }
+                }
                 mir::ProjectionElem::Field(ref field, _) => {
                     cg_base.project_field(bx, field.index())
                 }

--- a/compiler/rustc_codegen_ssa/src/mir/place.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/place.rs
@@ -456,7 +456,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                 mir::ProjectionElem::Deref => {
                     // custom allocators can change box's abi, making it unable to be derefed directly
                     if cg_base.layout.ty.is_box()
-                        && matches!(cg_base.layout.abi, Abi::Aggregate { .. })
+                        && matches!(cg_base.layout.abi, Abi::Aggregate { .. } | Abi::Uninhabited)
                     {
                         let ptr = cg_base.project_field(bx, 0).project_field(bx, 0);
 

--- a/compiler/rustc_error_codes/src/error_codes.rs
+++ b/compiler/rustc_error_codes/src/error_codes.rs
@@ -429,6 +429,7 @@ E0720: include_str!("./error_codes/E0720.md"),
 E0722: include_str!("./error_codes/E0722.md"),
 E0724: include_str!("./error_codes/E0724.md"),
 E0725: include_str!("./error_codes/E0725.md"),
+E0726: include_str!("./error_codes/E0726.md"),
 E0727: include_str!("./error_codes/E0727.md"),
 E0728: include_str!("./error_codes/E0728.md"),
 E0729: include_str!("./error_codes/E0729.md"),
@@ -641,6 +642,5 @@ E0787: include_str!("./error_codes/E0787.md"),
     E0717, // rustc_promotable without stability attribute
 //  E0721, // `await` keyword
 //  E0723, // unstable feature in `const` context
-    E0726, // non-explicit (not `'_`) elided lifetime in unsupported position
 //  E0738, // Removed; errored on `#[track_caller] fn`s in `extern "Rust" { ... }`.
 }

--- a/compiler/rustc_error_codes/src/error_codes/E0726.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0726.md
@@ -1,0 +1,46 @@
+An argument lifetime was elided in an async function.
+
+Erroneous code example:
+
+When a struct or a type is bound/declared with a lifetime it is important for
+the Rust compiler to know, on usage, the lifespan of the type. When the
+lifetime is not explicitly mentioned and the Rust Compiler cannot determine
+the lifetime of your type, the following error occurs.
+
+```compile_fail,E0726
+use futures::executor::block_on;
+struct Content<'a> {
+    title: &'a str,
+    body: &'a str,
+}
+async fn create(content: Content) { // error: implicit elided
+                                    // lifetime not allowed here
+    println!("title: {}", content.title);
+    println!("body: {}", content.body);
+}
+let content = Content { title: "Rust", body: "is great!" };
+let future = create(content);
+block_on(future);
+```
+
+Specify desired lifetime of parameter `content` or indicate the anonymous
+lifetime like `content: Content<'_>`. The anonymous lifetime tells the Rust
+compiler that `content` is only needed until create function is done with
+it's execution.
+
+The `implicit elision` meaning the omission of suggested lifetime that is
+`pub async fn create<'a>(content: Content<'a>) {}` is not allowed here as
+lifetime of the `content` can differ from current context:
+
+```ignore (needs futures dependency)
+async fn create(content: Content<'_>) { // ok!
+    println!("title: {}", content.title);
+    println!("body: {}", content.body);
+}
+```
+
+Know more about lifetime elision in this [chapter][lifetime-elision] and a
+chapter on lifetimes can be found [here][lifetimes].
+
+[lifetime-elision]: https://doc.rust-lang.org/book/ch10-03-lifetime-syntax.html#lifetime-elision
+[lifetimes]: https://doc.rust-lang.org/rust-by-example/scope/lifetime.html

--- a/compiler/rustc_expand/src/expand.rs
+++ b/compiler/rustc_expand/src/expand.rs
@@ -20,7 +20,7 @@ use rustc_data_structures::sync::Lrc;
 use rustc_errors::{Applicability, PResult};
 use rustc_feature::Features;
 use rustc_parse::parser::{
-    AttemptLocalParseRecovery, ForceCollect, Parser, RecoverColon, RecoverComma,
+    AttemptLocalParseRecovery, CommaRecoveryMode, ForceCollect, Parser, RecoverColon, RecoverComma,
 };
 use rustc_parse::validate_attr;
 use rustc_session::lint::builtin::{UNUSED_ATTRIBUTES, UNUSED_DOC_COMMENTS};
@@ -911,6 +911,7 @@ pub fn parse_ast_fragment<'a>(
             None,
             RecoverComma::No,
             RecoverColon::Yes,
+            CommaRecoveryMode::LikelyTuple,
         )?),
         AstFragmentKind::Crate => AstFragment::Crate(this.parse_crate_mod()?),
         AstFragmentKind::Arms

--- a/compiler/rustc_parse/src/lexer/tokentrees.rs
+++ b/compiler/rustc_parse/src/lexer/tokentrees.rs
@@ -282,14 +282,13 @@ struct TokenStreamBuilder {
 
 impl TokenStreamBuilder {
     fn push(&mut self, (tree, joint): TreeAndSpacing) {
-        if let Some((TokenTree::Token(prev_token), Joint)) = self.buf.last() {
-            if let TokenTree::Token(token) = &tree {
-                if let Some(glued) = prev_token.glue(token) {
-                    self.buf.pop();
-                    self.buf.push((TokenTree::Token(glued), joint));
-                    return;
-                }
-            }
+        if let Some((TokenTree::Token(prev_token), Joint)) = self.buf.last()
+            && let TokenTree::Token(token) = &tree
+            && let Some(glued) = prev_token.glue(token)
+        {
+            self.buf.pop();
+            self.buf.push((TokenTree::Token(glued), joint));
+            return;
         }
         self.buf.push((tree, joint))
     }

--- a/compiler/rustc_parse/src/lib.rs
+++ b/compiler/rustc_parse/src/lib.rs
@@ -1,9 +1,10 @@
 //! The main parser interface.
 
 #![feature(array_windows)]
+#![feature(box_patterns)]
 #![feature(crate_visibility_modifier)]
 #![feature(if_let_guard)]
-#![feature(box_patterns)]
+#![feature(let_chains)]
 #![feature(let_else)]
 #![recursion_limit = "256"]
 

--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -1,8 +1,8 @@
 use super::pat::Expected;
 use super::ty::{AllowPlus, IsAsCast};
 use super::{
-    BlockMode, Parser, PathStyle, RecoverColon, RecoverComma, Restrictions, SemiColonMode, SeqSep,
-    TokenExpectType, TokenType,
+    BlockMode, CommaRecoveryMode, Parser, PathStyle, RecoverColon, RecoverComma, Restrictions,
+    SemiColonMode, SeqSep, TokenExpectType, TokenType,
 };
 
 use rustc_ast as ast;
@@ -2245,12 +2245,32 @@ impl<'a> Parser<'a> {
         first_pat
     }
 
+    crate fn maybe_recover_unexpected_block_label(&mut self) -> bool {
+        let Some(label) = self.eat_label().filter(|_| {
+            self.eat(&token::Colon) && self.token.kind == token::OpenDelim(token::Brace)
+        }) else {
+            return false;
+        };
+        let span = label.ident.span.to(self.prev_token.span);
+        let mut err = self.struct_span_err(span, "block label not supported here");
+        err.span_label(span, "not supported here");
+        err.tool_only_span_suggestion(
+            label.ident.span.until(self.token.span),
+            "remove this block label",
+            String::new(),
+            Applicability::MachineApplicable,
+        );
+        err.emit();
+        true
+    }
+
     /// Some special error handling for the "top-level" patterns in a match arm,
     /// `for` loop, `let`, &c. (in contrast to subpatterns within such).
     crate fn maybe_recover_unexpected_comma(
         &mut self,
         lo: Span,
         rc: RecoverComma,
+        rt: CommaRecoveryMode,
     ) -> PResult<'a, ()> {
         if rc == RecoverComma::No || self.token != token::Comma {
             return Ok(());
@@ -2270,20 +2290,25 @@ impl<'a> Parser<'a> {
         let seq_span = lo.to(self.prev_token.span);
         let mut err = self.struct_span_err(comma_span, "unexpected `,` in pattern");
         if let Ok(seq_snippet) = self.span_to_snippet(seq_span) {
-            const MSG: &str = "try adding parentheses to match on a tuple...";
-
-            err.span_suggestion(
-                seq_span,
-                MSG,
-                format!("({})", seq_snippet),
+            err.multipart_suggestion(
+                &format!(
+                    "try adding parentheses to match on a tuple{}",
+                    if let CommaRecoveryMode::LikelyTuple = rt { "" } else { "..." },
+                ),
+                vec![
+                    (seq_span.shrink_to_lo(), "(".to_string()),
+                    (seq_span.shrink_to_hi(), ")".to_string()),
+                ],
                 Applicability::MachineApplicable,
             );
-            err.span_suggestion(
-                seq_span,
-                "...or a vertical bar to match on multiple alternatives",
-                seq_snippet.replace(',', " |"),
-                Applicability::MachineApplicable,
-            );
+            if let CommaRecoveryMode::EitherTupleOrPipe = rt {
+                err.span_suggestion(
+                    seq_span,
+                    "...or a vertical bar to match on multiple alternatives",
+                    seq_snippet.replace(',', " |"),
+                    Applicability::MachineApplicable,
+                );
+            }
         }
         Err(err)
     }

--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -102,14 +102,12 @@ impl<'a> Parser<'a> {
     ) -> PResult<'a, Option<Item>> {
         // Don't use `maybe_whole` so that we have precise control
         // over when we bump the parser
-        if let token::Interpolated(nt) = &self.token.kind {
-            if let token::NtItem(item) = &**nt {
-                let mut item = item.clone();
-                self.bump();
+        if let token::Interpolated(nt) = &self.token.kind && let token::NtItem(item) = &**nt {
+            let mut item = item.clone();
+            self.bump();
 
-                attrs.prepend_to_nt_inner(&mut item.attrs);
-                return Ok(Some(item.into_inner()));
-            }
+            attrs.prepend_to_nt_inner(&mut item.attrs);
+            return Ok(Some(item.into_inner()));
         };
 
         let mut unclosed_delims = vec![];

--- a/compiler/rustc_parse/src/parser/mod.rs
+++ b/compiler/rustc_parse/src/parser/mod.rs
@@ -15,7 +15,7 @@ pub use attr_wrapper::AttrWrapper;
 pub use diagnostics::AttemptLocalParseRecovery;
 use diagnostics::Error;
 pub(crate) use item::FnParseMode;
-pub use pat::{RecoverColon, RecoverComma};
+pub use pat::{CommaRecoveryMode, RecoverColon, RecoverComma};
 pub use path::PathStyle;
 
 use rustc_ast::ptr::P;

--- a/compiler/rustc_parse/src/parser/mod.rs
+++ b/compiler/rustc_parse/src/parser/mod.rs
@@ -97,15 +97,15 @@ macro_rules! maybe_whole {
 #[macro_export]
 macro_rules! maybe_recover_from_interpolated_ty_qpath {
     ($self: expr, $allow_qpath_recovery: expr) => {
-        if $allow_qpath_recovery && $self.look_ahead(1, |t| t == &token::ModSep) {
-            if let token::Interpolated(nt) = &$self.token.kind {
-                if let token::NtTy(ty) = &**nt {
+        if $allow_qpath_recovery
+                    && $self.look_ahead(1, |t| t == &token::ModSep)
+                    && let token::Interpolated(nt) = &$self.token.kind
+                    && let token::NtTy(ty) = &**nt
+                {
                     let ty = ty.clone();
                     $self.bump();
                     return $self.maybe_recover_from_bad_qpath_stage_2($self.prev_token.span, ty);
                 }
-            }
-        }
     };
 }
 

--- a/compiler/rustc_parse/src/parser/nonterminal.rs
+++ b/compiler/rustc_parse/src/parser/nonterminal.rs
@@ -5,7 +5,7 @@ use rustc_ast_pretty::pprust;
 use rustc_errors::PResult;
 use rustc_span::symbol::{kw, Ident};
 
-use crate::parser::pat::{RecoverColon, RecoverComma};
+use crate::parser::pat::{CommaRecoveryMode, RecoverColon, RecoverComma};
 use crate::parser::{FollowedByType, ForceCollect, Parser, PathStyle};
 
 impl<'a> Parser<'a> {
@@ -125,7 +125,7 @@ impl<'a> Parser<'a> {
                 token::NtPat(self.collect_tokens_no_attrs(|this| match kind {
                     NonterminalKind::PatParam { .. } => this.parse_pat_no_top_alt(None),
                     NonterminalKind::PatWithOr { .. } => {
-                        this.parse_pat_allow_top_alt(None, RecoverComma::No, RecoverColon::No)
+                        this.parse_pat_allow_top_alt(None, RecoverComma::No, RecoverColon::No, CommaRecoveryMode::EitherTupleOrPipe)
                     }
                     _ => unreachable!(),
                 })?)

--- a/compiler/rustc_parse/src/parser/path.rs
+++ b/compiler/rustc_parse/src/parser/path.rs
@@ -658,13 +658,13 @@ impl<'a> Parser<'a> {
         &self,
         gen_arg: GenericArg,
     ) -> Result<(Ident, Option<GenericArgs>), GenericArg> {
-        if let GenericArg::Type(ty) = &gen_arg {
-            if let ast::TyKind::Path(qself, path) = &ty.kind {
-                if qself.is_none() && path.segments.len() == 1 {
-                    let seg = &path.segments[0];
-                    return Ok((seg.ident, seg.args.as_deref().cloned()));
-                }
-            }
+        if let GenericArg::Type(ty) = &gen_arg
+            && let ast::TyKind::Path(qself, path) = &ty.kind
+            && qself.is_none()
+            && path.segments.len() == 1
+        {
+            let seg = &path.segments[0];
+            return Ok((seg.ident, seg.args.as_deref().cloned()));
         }
         Err(gen_arg)
     }

--- a/compiler/rustc_parse/src/parser/stmt.rs
+++ b/compiler/rustc_parse/src/parser/stmt.rs
@@ -434,6 +434,8 @@ impl<'a> Parser<'a> {
             Ok(Some(_))
                 if self.look_ahead(1, |t| t == &token::OpenDelim(token::Brace))
                     || do_not_suggest_help => {}
+            // Do not suggest `if foo println!("") {;}` (as would be seen in test for #46836).
+            Ok(Some(Stmt { kind: StmtKind::Empty, .. })) => {}
             Ok(Some(stmt)) => {
                 let stmt_own_line = self.sess.source_map().is_line_before_span_empty(sp);
                 let stmt_span = if stmt_own_line && self.eat(&token::Semi) {
@@ -442,15 +444,15 @@ impl<'a> Parser<'a> {
                 } else {
                     stmt.span
                 };
-                if let Ok(snippet) = self.span_to_snippet(stmt_span) {
-                    e.span_suggestion(
-                        stmt_span,
-                        "try placing this code inside a block",
-                        format!("{{ {} }}", snippet),
-                        // Speculative; has been misleading in the past (#46836).
-                        Applicability::MaybeIncorrect,
-                    );
-                }
+                e.multipart_suggestion(
+                    "try placing this code inside a block",
+                    vec![
+                        (stmt_span.shrink_to_lo(), "{ ".to_string()),
+                        (stmt_span.shrink_to_hi(), " }".to_string()),
+                    ],
+                    // Speculative; has been misleading in the past (#46836).
+                    Applicability::MaybeIncorrect,
+                );
             }
             Err(e) => {
                 self.recover_stmt_(SemiColonMode::Break, BlockMode::Ignore);
@@ -483,15 +485,15 @@ impl<'a> Parser<'a> {
     ) -> PResult<'a, (Vec<Attribute>, P<Block>)> {
         maybe_whole!(self, NtBlock, |x| (Vec::new(), x));
 
+        self.maybe_recover_unexpected_block_label();
         if !self.eat(&token::OpenDelim(token::Brace)) {
             return self.error_block_no_opening_brace();
         }
 
         let attrs = self.parse_inner_attributes()?;
-        let tail = if let Some(tail) = self.maybe_suggest_struct_literal(lo, blk_mode) {
-            tail?
-        } else {
-            self.parse_block_tail(lo, blk_mode, AttemptLocalParseRecovery::Yes)?
+        let tail = match self.maybe_suggest_struct_literal(lo, blk_mode) {
+            Some(tail) => tail?,
+            None => self.parse_block_tail(lo, blk_mode, AttemptLocalParseRecovery::Yes)?,
         };
         Ok((attrs, tail))
     }
@@ -587,11 +589,11 @@ impl<'a> Parser<'a> {
                 // We might be at the `,` in `let x = foo<bar, baz>;`. Try to recover.
                 match &mut local.kind {
                     LocalKind::Init(expr) | LocalKind::InitElse(expr, _) => {
-                            self.check_mistyped_turbofish_with_multiple_type_params(e, expr)?;
-                            // We found `foo<bar, baz>`, have we fully recovered?
-                            self.expect_semi()?;
-                        }
-                        LocalKind::Decl => return Err(e),
+                        self.check_mistyped_turbofish_with_multiple_type_params(e, expr)?;
+                        // We found `foo<bar, baz>`, have we fully recovered?
+                        self.expect_semi()?;
+                    }
+                    LocalKind::Decl => return Err(e),
                 }
                 eat_semi = false;
             }

--- a/compiler/rustc_parse/src/parser/stmt.rs
+++ b/compiler/rustc_parse/src/parser/stmt.rs
@@ -48,15 +48,13 @@ impl<'a> Parser<'a> {
 
         // Don't use `maybe_whole` so that we have precise control
         // over when we bump the parser
-        if let token::Interpolated(nt) = &self.token.kind {
-            if let token::NtStmt(stmt) = &**nt {
-                let mut stmt = stmt.clone();
-                self.bump();
-                stmt.visit_attrs(|stmt_attrs| {
-                    attrs.prepend_to_nt_inner(stmt_attrs);
-                });
-                return Ok(Some(stmt));
-            }
+        if let token::Interpolated(nt) = &self.token.kind && let token::NtStmt(stmt) = &**nt {
+            let mut stmt = stmt.clone();
+            self.bump();
+            stmt.visit_attrs(|stmt_attrs| {
+                attrs.prepend_to_nt_inner(stmt_attrs);
+            });
+            return Ok(Some(stmt));
         }
 
         Ok(Some(if self.token.is_keyword(kw::Let) {

--- a/compiler/rustc_typeck/src/check/expr.rs
+++ b/compiler/rustc_typeck/src/check/expr.rs
@@ -842,7 +842,27 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         );
         err.span_label(lhs.span, "cannot assign to this expression");
 
-        let mut parent = self.tcx.hir().get_parent_node(lhs.hir_id);
+        self.comes_from_while_condition(lhs.hir_id, |expr| {
+            err.span_suggestion_verbose(
+                expr.span.shrink_to_lo(),
+                "you might have meant to use pattern destructuring",
+                "let ".to_string(),
+                Applicability::MachineApplicable,
+            );
+        });
+
+        err.emit();
+    }
+
+    // Check if an expression `original_expr_id` comes from the condition of a while loop,
+    // as opposed from the body of a while loop, which we can naively check by iterating
+    // parents until we find a loop...
+    pub(super) fn comes_from_while_condition(
+        &self,
+        original_expr_id: HirId,
+        then: impl FnOnce(&hir::Expr<'_>),
+    ) {
+        let mut parent = self.tcx.hir().get_parent_node(original_expr_id);
         while let Some(node) = self.tcx.hir().find(parent) {
             match node {
                 hir::Node::Expr(hir::Expr {
@@ -863,8 +883,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         ),
                     ..
                 }) => {
-                    // Check if our lhs is a child of the condition of a while loop
-                    let expr_is_ancestor = std::iter::successors(Some(lhs.hir_id), |id| {
+                    // Check if our original expression is a child of the condition of a while loop
+                    let expr_is_ancestor = std::iter::successors(Some(original_expr_id), |id| {
                         self.tcx.hir().find_parent_node(*id)
                     })
                     .take_while(|id| *id != parent)
@@ -872,12 +892,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     // if it is, then we have a situation like `while Some(0) = value.get(0) {`,
                     // where `while let` was more likely intended.
                     if expr_is_ancestor {
-                        err.span_suggestion_verbose(
-                            expr.span.shrink_to_lo(),
-                            "you might have meant to use pattern destructuring",
-                            "let ".to_string(),
-                            Applicability::MachineApplicable,
-                        );
+                        then(expr);
                     }
                     break;
                 }
@@ -890,8 +905,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 }
             }
         }
-
-        err.emit();
     }
 
     // A generic function for checking the 'then' and 'else' clauses in an 'if'

--- a/compiler/rustc_typeck/src/check/fn_ctxt/checks.rs
+++ b/compiler/rustc_typeck/src/check/fn_ctxt/checks.rs
@@ -770,55 +770,57 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let prev_diverges = self.diverges.get();
         let ctxt = BreakableCtxt { coerce: Some(coerce), may_break: false };
 
-        let (ctxt, ()) = self.with_breakable_ctxt(blk.hir_id, ctxt, || {
-            for (pos, s) in blk.stmts.iter().enumerate() {
-                self.check_stmt(s, blk.stmts.len() - 1 == pos);
-            }
+        let (ctxt, ()) =
+            self.with_breakable_ctxt(blk.hir_id, ctxt, || {
+                for (pos, s) in blk.stmts.iter().enumerate() {
+                    self.check_stmt(s, blk.stmts.len() - 1 == pos);
+                }
 
-            // check the tail expression **without** holding the
-            // `enclosing_breakables` lock below.
-            let tail_expr_ty = tail_expr.map(|t| self.check_expr_with_expectation(t, expected));
+                // check the tail expression **without** holding the
+                // `enclosing_breakables` lock below.
+                let tail_expr_ty = tail_expr.map(|t| self.check_expr_with_expectation(t, expected));
 
-            let mut enclosing_breakables = self.enclosing_breakables.borrow_mut();
-            let ctxt = enclosing_breakables.find_breakable(blk.hir_id);
-            let coerce = ctxt.coerce.as_mut().unwrap();
-            if let Some(tail_expr_ty) = tail_expr_ty {
-                let tail_expr = tail_expr.unwrap();
-                let span = self.get_expr_coercion_span(tail_expr);
-                let cause = self.cause(span, ObligationCauseCode::BlockTailExpression(blk.hir_id));
-                coerce.coerce(self, &cause, tail_expr, tail_expr_ty);
-            } else {
-                // Subtle: if there is no explicit tail expression,
-                // that is typically equivalent to a tail expression
-                // of `()` -- except if the block diverges. In that
-                // case, there is no value supplied from the tail
-                // expression (assuming there are no other breaks,
-                // this implies that the type of the block will be
-                // `!`).
-                //
-                // #41425 -- label the implicit `()` as being the
-                // "found type" here, rather than the "expected type".
-                if !self.diverges.get().is_always() {
-                    // #50009 -- Do not point at the entire fn block span, point at the return type
-                    // span, as it is the cause of the requirement, and
-                    // `consider_hint_about_removing_semicolon` will point at the last expression
-                    // if it were a relevant part of the error. This improves usability in editors
-                    // that highlight errors inline.
-                    let mut sp = blk.span;
-                    let mut fn_span = None;
-                    if let Some((decl, ident)) = self.get_parent_fn_decl(blk.hir_id) {
-                        let ret_sp = decl.output.span();
-                        if let Some(block_sp) = self.parent_item_span(blk.hir_id) {
-                            // HACK: on some cases (`ui/liveness/liveness-issue-2163.rs`) the
-                            // output would otherwise be incorrect and even misleading. Make sure
-                            // the span we're aiming at correspond to a `fn` body.
-                            if block_sp == blk.span {
-                                sp = ret_sp;
-                                fn_span = Some(ident.span);
+                let mut enclosing_breakables = self.enclosing_breakables.borrow_mut();
+                let ctxt = enclosing_breakables.find_breakable(blk.hir_id);
+                let coerce = ctxt.coerce.as_mut().unwrap();
+                if let Some(tail_expr_ty) = tail_expr_ty {
+                    let tail_expr = tail_expr.unwrap();
+                    let span = self.get_expr_coercion_span(tail_expr);
+                    let cause =
+                        self.cause(span, ObligationCauseCode::BlockTailExpression(blk.hir_id));
+                    coerce.coerce(self, &cause, tail_expr, tail_expr_ty);
+                } else {
+                    // Subtle: if there is no explicit tail expression,
+                    // that is typically equivalent to a tail expression
+                    // of `()` -- except if the block diverges. In that
+                    // case, there is no value supplied from the tail
+                    // expression (assuming there are no other breaks,
+                    // this implies that the type of the block will be
+                    // `!`).
+                    //
+                    // #41425 -- label the implicit `()` as being the
+                    // "found type" here, rather than the "expected type".
+                    if !self.diverges.get().is_always() {
+                        // #50009 -- Do not point at the entire fn block span, point at the return type
+                        // span, as it is the cause of the requirement, and
+                        // `consider_hint_about_removing_semicolon` will point at the last expression
+                        // if it were a relevant part of the error. This improves usability in editors
+                        // that highlight errors inline.
+                        let mut sp = blk.span;
+                        let mut fn_span = None;
+                        if let Some((decl, ident)) = self.get_parent_fn_decl(blk.hir_id) {
+                            let ret_sp = decl.output.span();
+                            if let Some(block_sp) = self.parent_item_span(blk.hir_id) {
+                                // HACK: on some cases (`ui/liveness/liveness-issue-2163.rs`) the
+                                // output would otherwise be incorrect and even misleading. Make sure
+                                // the span we're aiming at correspond to a `fn` body.
+                                if block_sp == blk.span {
+                                    sp = ret_sp;
+                                    fn_span = Some(ident.span);
+                                }
                             }
                         }
-                    }
-                    coerce.coerce_forced_unit(
+                        coerce.coerce_forced_unit(
                         self,
                         &self.misc(sp),
                         &mut |err| {
@@ -827,19 +829,31 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                                 if expected_ty == self.tcx.types.bool {
                                     // If this is caused by a missing `let` in a `while let`,
                                     // silence this redundant error, as we already emit E0070.
-                                    let parent = self.tcx.hir().get_parent_node(blk.hir_id);
-                                    let parent = self.tcx.hir().get_parent_node(parent);
-                                    let parent = self.tcx.hir().get_parent_node(parent);
-                                    let parent = self.tcx.hir().get_parent_node(parent);
-                                    let parent = self.tcx.hir().get_parent_node(parent);
-                                    match self.tcx.hir().find(parent) {
-                                        Some(hir::Node::Expr(hir::Expr {
-                                            kind: hir::ExprKind::Loop(_, _, hir::LoopSource::While, _),
-                                            ..
-                                        })) => {
+
+                                    // Our block must be a `assign desugar local; assignment`
+                                    if let Some(hir::Node::Block(hir::Block {
+                                        stmts:
+                                            [hir::Stmt {
+                                                kind:
+                                                    hir::StmtKind::Local(hir::Local {
+                                                        source: hir::LocalSource::AssignDesugar(_),
+                                                        ..
+                                                    }),
+                                                ..
+                                            }, hir::Stmt {
+                                                kind:
+                                                    hir::StmtKind::Expr(hir::Expr {
+                                                        kind: hir::ExprKind::Assign(..),
+                                                        ..
+                                                    }),
+                                                ..
+                                            }],
+                                        ..
+                                    })) = self.tcx.hir().find(blk.hir_id)
+                                    {
+                                        self.comes_from_while_condition(blk.hir_id, |_| {
                                             err.downgrade_to_delayed_bug();
-                                        }
-                                        _ => {}
+                                        })
                                     }
                                 }
                             }
@@ -853,9 +867,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         },
                         false,
                     );
+                    }
                 }
-            }
-        });
+            });
 
         if ctxt.may_break {
             // If we can break from the block, then the block's exit is always reachable

--- a/library/alloc/src/collections/btree/map.rs
+++ b/library/alloc/src/collections/btree/map.rs
@@ -979,7 +979,7 @@ impl<K, V> BTreeMap<K, V> {
         self.drain_filter(|k, v| !f(k, v));
     }
 
-    /// Moves all elements from `other` into `Self`, leaving `other` empty.
+    /// Moves all elements from `other` into `self`, leaving `other` empty.
     ///
     /// # Examples
     ///

--- a/library/alloc/src/collections/btree/set.rs
+++ b/library/alloc/src/collections/btree/set.rs
@@ -892,7 +892,7 @@ impl<T> BTreeSet<T> {
         self.drain_filter(|v| !f(v));
     }
 
-    /// Moves all elements from `other` into `Self`, leaving `other` empty.
+    /// Moves all elements from `other` into `self`, leaving `other` empty.
     ///
     /// # Examples
     ///

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -1755,7 +1755,7 @@ impl<T, A: Allocator> Vec<T, A> {
         }
     }
 
-    /// Moves all the elements of `other` into `Self`, leaving `other` empty.
+    /// Moves all the elements of `other` into `self`, leaving `other` empty.
     ///
     /// # Panics
     ///
@@ -1780,7 +1780,7 @@ impl<T, A: Allocator> Vec<T, A> {
         }
     }
 
-    /// Appends elements to `Self` from other buffer.
+    /// Appends elements to `self` from other buffer.
     #[cfg(not(no_global_oom_handling))]
     #[inline]
     unsafe fn append_elements(&mut self, other: *const [T]) {

--- a/src/test/ui/async-await/async-fn-path-elision.stderr
+++ b/src/test/ui/async-await/async-fn-path-elision.stderr
@@ -8,3 +8,4 @@ LL | async fn error(lt: HasLifetime) {
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0726`.

--- a/src/test/ui/async-await/await-keyword/incorrect-syntax-suggestions.stderr
+++ b/src/test/ui/async-await/await-keyword/incorrect-syntax-suggestions.stderr
@@ -132,7 +132,7 @@ error: expected one of `.`, `?`, `{`, or an operator, found `}`
 LL |     match await { await => () }
    |     -----                      - expected one of `.`, `?`, `{`, or an operator
    |     |
-   |     while parsing this match expression
+   |     while parsing this `match` expression
 ...
 LL | }
    | ^ unexpected token

--- a/src/test/ui/box/issue-78459-ice.rs
+++ b/src/test/ui/box/issue-78459-ice.rs
@@ -1,6 +1,0 @@
-// check-pass
-#![feature(allocator_api)]
-
-fn main() {
-    Box::new_in((), &std::alloc::Global);
-}

--- a/src/test/ui/box/issue-81270-ice.rs
+++ b/src/test/ui/box/issue-81270-ice.rs
@@ -1,0 +1,22 @@
+// check-pass
+#![feature(allocator_api)]
+
+use std::alloc::Allocator;
+
+struct BigAllocator([usize; 2]);
+
+unsafe impl Allocator for BigAllocator {
+    fn allocate(
+        &self,
+        _: std::alloc::Layout,
+    ) -> Result<std::ptr::NonNull<[u8]>, std::alloc::AllocError> {
+        todo!()
+    }
+    unsafe fn deallocate(&self, _: std::ptr::NonNull<u8>, _: std::alloc::Layout) {
+        todo!()
+    }
+}
+
+fn main() {
+    Box::new_in((), BigAllocator([0; 2]));
+}

--- a/src/test/ui/box/large-allocator-ice.rs
+++ b/src/test/ui/box/large-allocator-ice.rs
@@ -1,4 +1,4 @@
-// check-pass
+// build-pass
 #![feature(allocator_api)]
 
 use std::alloc::Allocator;
@@ -18,5 +18,6 @@ unsafe impl Allocator for BigAllocator {
 }
 
 fn main() {
+    Box::new_in((), &std::alloc::Global);
     Box::new_in((), BigAllocator([0; 2]));
 }

--- a/src/test/ui/did_you_mean/issue-46836-identifier-not-instead-of-negation.stderr
+++ b/src/test/ui/did_you_mean/issue-46836-identifier-not-instead-of-negation.stderr
@@ -28,10 +28,7 @@ error: expected `{`, found `;`
 LL |     if not  // lack of braces is [sic]
    |     -- this `if` expression has a condition, but no block
 LL |         println!("Then when?");
-   |                               ^
-   |                               |
-   |                               expected `{`
-   |                               help: try placing this code inside a block: `{ ; }`
+   |                               ^ expected `{`
 
 error: unexpected `2` after identifier
   --> $DIR/issue-46836-identifier-not-instead-of-negation.rs:26:24

--- a/src/test/ui/did_you_mean/issue-48492-tuple-destructure-missing-parens.stderr
+++ b/src/test/ui/did_you_mean/issue-48492-tuple-destructure-missing-parens.stderr
@@ -2,16 +2,14 @@ error: unexpected `,` in pattern
   --> $DIR/issue-48492-tuple-destructure-missing-parens.rs:38:17
    |
 LL |     while let b1, b2, b3 = reading_frame.next().expect("there should be a start codon") {
-   |                 ^
+   |     -----       ^
+   |     |
+   |     while parsing the condition of this `while` expression
    |
-help: try adding parentheses to match on a tuple...
+help: try adding parentheses to match on a tuple
    |
 LL |     while let (b1, b2, b3) = reading_frame.next().expect("there should be a start codon") {
-   |               ~~~~~~~~~~~~
-help: ...or a vertical bar to match on multiple alternatives
-   |
-LL |     while let b1 | b2 | b3 = reading_frame.next().expect("there should be a start codon") {
-   |               ~~~~~~~~~~~~
+   |               +          +
 
 error: unexpected `,` in pattern
   --> $DIR/issue-48492-tuple-destructure-missing-parens.rs:49:14
@@ -19,14 +17,10 @@ error: unexpected `,` in pattern
 LL |     if let b1, b2, b3 = reading_frame.next().unwrap() {
    |              ^
    |
-help: try adding parentheses to match on a tuple...
+help: try adding parentheses to match on a tuple
    |
 LL |     if let (b1, b2, b3) = reading_frame.next().unwrap() {
-   |            ~~~~~~~~~~~~
-help: ...or a vertical bar to match on multiple alternatives
-   |
-LL |     if let b1 | b2 | b3 = reading_frame.next().unwrap() {
-   |            ~~~~~~~~~~~~
+   |            +          +
 
 error: unexpected `,` in pattern
   --> $DIR/issue-48492-tuple-destructure-missing-parens.rs:59:28
@@ -37,7 +31,7 @@ LL |         Nucleotide::Adenine, Nucleotide::Cytosine, _ => true
 help: try adding parentheses to match on a tuple...
    |
 LL |         (Nucleotide::Adenine, Nucleotide::Cytosine, _) => true
-   |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   |         +                                            +
 help: ...or a vertical bar to match on multiple alternatives
    |
 LL |         Nucleotide::Adenine | Nucleotide::Cytosine | _ => true
@@ -49,14 +43,10 @@ error: unexpected `,` in pattern
 LL |     for x, _barr_body in women.iter().map(|woman| woman.allosomes.clone()) {
    |          ^
    |
-help: try adding parentheses to match on a tuple...
+help: try adding parentheses to match on a tuple
    |
 LL |     for (x, _barr_body) in women.iter().map(|woman| woman.allosomes.clone()) {
-   |         ~~~~~~~~~~~~~~~
-help: ...or a vertical bar to match on multiple alternatives
-   |
-LL |     for x | _barr_body in women.iter().map(|woman| woman.allosomes.clone()) {
-   |         ~~~~~~~~~~~~~~
+   |         +             +
 
 error: unexpected `,` in pattern
   --> $DIR/issue-48492-tuple-destructure-missing-parens.rs:75:10
@@ -64,14 +54,10 @@ error: unexpected `,` in pattern
 LL |     for x, y @ Allosome::Y(_) in men.iter().map(|man| man.allosomes.clone()) {
    |          ^
    |
-help: try adding parentheses to match on a tuple...
+help: try adding parentheses to match on a tuple
    |
 LL |     for (x, y @ Allosome::Y(_)) in men.iter().map(|man| man.allosomes.clone()) {
-   |         ~~~~~~~~~~~~~~~~~~~~~~~
-help: ...or a vertical bar to match on multiple alternatives
-   |
-LL |     for x | y @ Allosome::Y(_) in men.iter().map(|man| man.allosomes.clone()) {
-   |         ~~~~~~~~~~~~~~~~~~~~~~
+   |         +                     +
 
 error: unexpected `,` in pattern
   --> $DIR/issue-48492-tuple-destructure-missing-parens.rs:84:14
@@ -79,14 +65,10 @@ error: unexpected `,` in pattern
 LL |     let women, men: (Vec<Genome>, Vec<Genome>) = genomes.iter().cloned()
    |              ^
    |
-help: try adding parentheses to match on a tuple...
+help: try adding parentheses to match on a tuple
    |
 LL |     let (women, men): (Vec<Genome>, Vec<Genome>) = genomes.iter().cloned()
-   |         ~~~~~~~~~~~~
-help: ...or a vertical bar to match on multiple alternatives
-   |
-LL |     let women | men: (Vec<Genome>, Vec<Genome>) = genomes.iter().cloned()
-   |         ~~~~~~~~~~~
+   |         +          +
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/impl-header-lifetime-elision/path-elided.stderr
+++ b/src/test/ui/impl-header-lifetime-elision/path-elided.stderr
@@ -8,3 +8,4 @@ LL | impl MyTrait for Foo {
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0726`.

--- a/src/test/ui/impl-header-lifetime-elision/trait-elided.stderr
+++ b/src/test/ui/impl-header-lifetime-elision/trait-elided.stderr
@@ -8,3 +8,4 @@ LL | impl MyTrait for u32 {
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0726`.

--- a/src/test/ui/issues/issue-10412.stderr
+++ b/src/test/ui/issues/issue-10412.stderr
@@ -67,4 +67,5 @@ LL | trait Serializable<'self, T: ?Sized> {
 
 error: aborting due to 9 previous errors
 
-For more information about this error, try `rustc --explain E0277`.
+Some errors have detailed explanations: E0277, E0726.
+For more information about an error, try `rustc --explain E0277`.

--- a/src/test/ui/issues/issue-39848.stderr
+++ b/src/test/ui/issues/issue-39848.stderr
@@ -2,16 +2,18 @@ error: expected `{`, found `foo`
   --> $DIR/issue-39848.rs:3:21
    |
 LL |         if $tgt.has_$field() {}
-   |         --          ^^^^^^--
-   |         |           |
-   |         |           expected `{`
-   |         |           help: try placing this code inside a block: `{ $field() }`
+   |         --          ^^^^^^ expected `{`
+   |         |
    |         this `if` expression has a condition, but no block
 ...
 LL |     get_opt!(bar, foo);
    |     ------------------ in this macro invocation
    |
    = note: this error originates in the macro `get_opt` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: try placing this code inside a block
+   |
+LL |         if $tgt.has_{ $field() } {}
+   |                     +          +
 
 error: aborting due to previous error
 

--- a/src/test/ui/label/label_break_value_illegal_uses.fixed
+++ b/src/test/ui/label/label_break_value_illegal_uses.fixed
@@ -5,19 +5,19 @@
 
 #[allow(unused_unsafe)]
 fn labeled_unsafe() {
-    unsafe 'b: {} //~ ERROR block label not supported here
+    unsafe {} //~ ERROR block label not supported here
 }
 
 fn labeled_if() {
-    if true 'b: {} //~ ERROR block label not supported here
+    if true {} //~ ERROR block label not supported here
 }
 
 fn labeled_else() {
-    if true {} else 'b: {} //~ ERROR block label not supported here
+    if true {} else {} //~ ERROR block label not supported here
 }
 
 fn labeled_match() {
-    match false 'b: { //~ ERROR block label not supported here
+    match false { //~ ERROR block label not supported here
         _ => {}
     }
 }

--- a/src/test/ui/label/label_break_value_illegal_uses.stderr
+++ b/src/test/ui/label/label_break_value_illegal_uses.stderr
@@ -1,38 +1,26 @@
-error: expected `{`, found `'b`
-  --> $DIR/label_break_value_illegal_uses.rs:6:12
+error: block label not supported here
+  --> $DIR/label_break_value_illegal_uses.rs:8:12
    |
 LL |     unsafe 'b: {}
-   |            ^^----
-   |            |
-   |            expected `{`
-   |            help: try placing this code inside a block: `{ 'b: {} }`
+   |            ^^^ not supported here
 
-error: expected `{`, found `'b`
-  --> $DIR/label_break_value_illegal_uses.rs:10:13
+error: block label not supported here
+  --> $DIR/label_break_value_illegal_uses.rs:12:13
    |
 LL |     if true 'b: {}
-   |     --      ^^----
-   |     |       |
-   |     |       expected `{`
-   |     |       help: try placing this code inside a block: `{ 'b: {} }`
-   |     this `if` expression has a condition, but no block
+   |             ^^^ not supported here
 
-error: expected `{`, found `'b`
-  --> $DIR/label_break_value_illegal_uses.rs:14:21
+error: block label not supported here
+  --> $DIR/label_break_value_illegal_uses.rs:16:21
    |
 LL |     if true {} else 'b: {}
-   |                     ^^----
-   |                     |
-   |                     expected `{`
-   |                     help: try placing this code inside a block: `{ 'b: {} }`
+   |                     ^^^ not supported here
 
-error: expected one of `.`, `?`, `{`, or an operator, found `'b`
-  --> $DIR/label_break_value_illegal_uses.rs:18:17
+error: block label not supported here
+  --> $DIR/label_break_value_illegal_uses.rs:20:17
    |
-LL |     match false 'b: {}
-   |     -----       ^^ expected one of `.`, `?`, `{`, or an operator
-   |     |
-   |     while parsing this match expression
+LL |     match false 'b: {
+   |                 ^^^ not supported here
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/let-else/let-else-if.stderr
+++ b/src/test/ui/let-else/let-else-if.stderr
@@ -7,10 +7,10 @@ LL |     let Some(_) = Some(()) else if true {
 help: try placing this code inside a block
    |
 LL ~     let Some(_) = Some(()) else { if true {
-LL +
-LL +         return;
-LL +     } else {
-LL +         return;
+LL |
+LL |         return;
+LL |     } else {
+LL |         return;
 LL ~     } };
    |
 

--- a/src/test/ui/missing/missing-block-hint.stderr
+++ b/src/test/ui/missing/missing-block-hint.stderr
@@ -12,10 +12,12 @@ error: expected `{`, found `bar`
 LL |         if (foo)
    |         -- this `if` expression has a condition, but no block
 LL |             bar;
-   |             ^^^-
-   |             |
-   |             expected `{`
-   |             help: try placing this code inside a block: `{ bar; }`
+   |             ^^^ expected `{`
+   |
+help: try placing this code inside a block
+   |
+LL |             { bar; }
+   |             +      +
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/parser/block-no-opening-brace.stderr
+++ b/src/test/ui/parser/block-no-opening-brace.stderr
@@ -1,29 +1,41 @@
 error: expected `{`, found keyword `let`
   --> $DIR/block-no-opening-brace.rs:9:9
    |
+LL |     loop
+   |     ---- while parsing this `loop` expression
 LL |         let x = 0;
-   |         ^^^-------
-   |         |
-   |         expected `{`
-   |         help: try placing this code inside a block: `{ let x = 0; }`
+   |         ^^^ expected `{`
+   |
+help: try placing this code inside a block
+   |
+LL |         { let x = 0; }
+   |         +            +
 
 error: expected `{`, found keyword `let`
   --> $DIR/block-no-opening-brace.rs:15:9
    |
+LL |     while true
+   |     ----- ---- this `while` condition successfully parsed
+   |     |
+   |     while parsing the body of this `while` expression
 LL |         let x = 0;
-   |         ^^^-------
-   |         |
-   |         expected `{`
-   |         help: try placing this code inside a block: `{ let x = 0; }`
+   |         ^^^ expected `{`
+   |
+help: try placing this code inside a block
+   |
+LL |         { let x = 0; }
+   |         +            +
 
 error: expected `{`, found keyword `let`
   --> $DIR/block-no-opening-brace.rs:20:9
    |
 LL |         let x = 0;
-   |         ^^^-------
-   |         |
-   |         expected `{`
-   |         help: try placing this code inside a block: `{ let x = 0; }`
+   |         ^^^ expected `{`
+   |
+help: try placing this code inside a block
+   |
+LL |         { let x = 0; }
+   |         +            +
 
 error: expected expression, found reserved keyword `try`
   --> $DIR/block-no-opening-brace.rs:24:5

--- a/src/test/ui/parser/closure-return-syntax.stderr
+++ b/src/test/ui/parser/closure-return-syntax.stderr
@@ -2,10 +2,12 @@ error: expected `{`, found `22`
   --> $DIR/closure-return-syntax.rs:5:23
    |
 LL |     let x = || -> i32 22;
-   |                       ^^
-   |                       |
-   |                       expected `{`
-   |                       help: try placing this code inside a block: `{ 22 }`
+   |                       ^^ expected `{`
+   |
+help: try placing this code inside a block
+   |
+LL |     let x = || -> i32 { 22 };
+   |                       +    +
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/issues/issue-62554.stderr
+++ b/src/test/ui/parser/issues/issue-62554.stderr
@@ -63,9 +63,8 @@ LL | fn foo(u: u8) { if u8 macro_rules! u8 { (u6) => { fn uuuuuuuuuuu() { use s 
    |
 help: try placing this code inside a block
    |
-LL ~ fn foo(u: u8) { if u8 { macro_rules! u8 { (u6) => { fn uuuuuuuuuuu() { use s loo mod u8 {
-LL +  }
-   |
+LL | fn foo(u: u8) { if u8 { macro_rules! u8 { (u6) => { fn uuuuuuuuuuu() { use s loo mod u8 { }
+   |                       +                                                                    +
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/parser/issues/issue-62973.stderr
+++ b/src/test/ui/parser/issues/issue-62973.stderr
@@ -50,7 +50,7 @@ error: expected one of `.`, `?`, `{`, or an operator, found `}`
   --> $DIR/issue-62973.rs:8:2
    |
 LL | fn p() { match s { v, E { [) {) }
-   |          ----- while parsing this match expression
+   |          ----- while parsing this `match` expression
 LL | 
 LL | 
    |  ^ expected one of `.`, `?`, `{`, or an operator

--- a/src/test/ui/parser/match-refactor-to-expr.fixed
+++ b/src/test/ui/parser/match-refactor-to-expr.fixed
@@ -2,7 +2,7 @@
 
 fn main() {
     let foo =
-         //~ NOTE while parsing this match expression
+         //~ NOTE while parsing this `match` expression
         Some(4).unwrap_or(5)
         //~^ NOTE expected one of `.`, `?`, `{`, or an operator
         ; //~ NOTE unexpected token

--- a/src/test/ui/parser/match-refactor-to-expr.rs
+++ b/src/test/ui/parser/match-refactor-to-expr.rs
@@ -2,7 +2,7 @@
 
 fn main() {
     let foo =
-        match //~ NOTE while parsing this match expression
+        match //~ NOTE while parsing this `match` expression
         Some(4).unwrap_or(5)
         //~^ NOTE expected one of `.`, `?`, `{`, or an operator
         ; //~ NOTE unexpected token

--- a/src/test/ui/parser/match-refactor-to-expr.stderr
+++ b/src/test/ui/parser/match-refactor-to-expr.stderr
@@ -4,7 +4,7 @@ error: expected one of `.`, `?`, `{`, or an operator, found `;`
 LL |         match
    |         -----
    |         |
-   |         while parsing this match expression
+   |         while parsing this `match` expression
    |         help: try removing this `match`
 LL |         Some(4).unwrap_or(5)
    |                             - expected one of `.`, `?`, `{`, or an operator

--- a/src/test/ui/parser/while-if-let-without-body.rs
+++ b/src/test/ui/parser/while-if-let-without-body.rs
@@ -1,0 +1,13 @@
+fn main() {
+    let container = vec![Some(1), Some(2), None];
+
+    let mut i = 0;
+    while if let Some(thing) = container.get(i) {
+        //~^ NOTE while parsing the body of this `while` expression
+        //~| NOTE this `while` condition successfully parsed
+        println!("{:?}", thing);
+        i += 1;
+    }
+}
+//~^ ERROR expected `{`, found `}`
+//~| NOTE expected `{`

--- a/src/test/ui/parser/while-if-let-without-body.stderr
+++ b/src/test/ui/parser/while-if-let-without-body.stderr
@@ -1,0 +1,18 @@
+error: expected `{`, found `}`
+  --> $DIR/while-if-let-without-body.rs:11:1
+   |
+LL |       while if let Some(thing) = container.get(i) {
+   |  _____-----_-
+   | |     |
+   | |     while parsing the body of this `while` expression
+LL | |
+LL | |
+LL | |         println!("{:?}", thing);
+LL | |         i += 1;
+LL | |     }
+   | |_____- this `while` condition successfully parsed
+LL |   }
+   |   ^ expected `{`
+
+error: aborting due to previous error
+

--- a/src/test/ui/typeck/while-loop-block-cond.rs
+++ b/src/test/ui/typeck/while-loop-block-cond.rs
@@ -1,0 +1,4 @@
+fn main() {
+    while {} {}
+    //~^ ERROR mismatched types [E0308]
+}

--- a/src/test/ui/typeck/while-loop-block-cond.stderr
+++ b/src/test/ui/typeck/while-loop-block-cond.stderr
@@ -1,0 +1,9 @@
+error[E0308]: mismatched types
+  --> $DIR/while-loop-block-cond.rs:2:11
+   |
+LL |     while {} {}
+   |           ^^ expected `bool`, found `()`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/unsafe/unsafe-block-without-braces.stderr
+++ b/src/test/ui/unsafe/unsafe-block-without-braces.stderr
@@ -1,11 +1,15 @@
 error: expected `{`, found `std`
   --> $DIR/unsafe-block-without-braces.rs:3:9
    |
+LL |     unsafe //{
+   |     ------ while parsing this `unsafe` expression
 LL |         std::mem::transmute::<f32, u32>(1.0);
-   |         ^^^----------------------------------
-   |         |
-   |         expected `{`
-   |         help: try placing this code inside a block: `{ std::mem::transmute::<f32, u32>(1.0); }`
+   |         ^^^ expected `{`
+   |
+help: try placing this code inside a block
+   |
+LL |         { std::mem::transmute::<f32, u32>(1.0); }
+   |         +                                       +
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-in-foreign-fn-decls-issue-80468.stderr
+++ b/src/test/ui/wf/wf-in-foreign-fn-decls-issue-80468.stderr
@@ -30,3 +30,4 @@ LL | impl Trait for Ref {}
 
 error: aborting due to 2 previous errors
 
+For more information about this error, try `rustc --explain E0726`.


### PR DESCRIPTION
Successful merges:

 - #92399 (fix typo in btree/vec doc: Self -> self)
 - #92823 (Tweak diagnostics)
 - #94248 (Fix ICE when passing block to while-loop condition)
 - #94414 (Fix ICE when using Box<T, A> with large A)
 - #94445 (4 - Make more use of `let_chains`)
 - #94449 (Add long explanation for E0726)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=92399,92823,94248,94414,94445,94449)
<!-- homu-ignore:end -->