### PR TITLE
Add JoinError that fails Span::join when hygiene is different.

### DIFF
--- a/compiler/rustc_expand/src/proc_macro_server.rs
+++ b/compiler/rustc_expand/src/proc_macro_server.rs
@@ -828,7 +828,7 @@ impl server::Span for Rustc<'_, '_> {
             return Err(JoinError::DifferentHygiene);
         }
 
-        Some(first.to(second))
+        Ok(first.to(second))
     }
     fn resolved_at(&mut self, span: Self::Span, at: Self::Span) -> Self::Span {
         span.with_ctxt(at.ctxt())

--- a/library/proc_macro/src/bridge/mod.rs
+++ b/library/proc_macro/src/bridge/mod.rs
@@ -364,6 +364,7 @@ mark_noop! {
     Level,
     LineColumn,
     Spacing,
+    JoinError,
     Bound<usize>,
 }
 

--- a/library/proc_macro/src/bridge/mod.rs
+++ b/library/proc_macro/src/bridge/mod.rs
@@ -8,7 +8,7 @@
 
 #![deny(unsafe_code)]
 
-use crate::{Delimiter, Level, LineColumn, Spacing};
+use crate::{Delimiter, JoinError, Level, LineColumn, Spacing};
 use std::fmt;
 use std::hash::Hash;
 use std::marker;
@@ -165,7 +165,7 @@ macro_rules! with_api {
                 fn end($self: $S::Span) -> LineColumn;
                 fn before($self: $S::Span) -> $S::Span;
                 fn after($self: $S::Span) -> $S::Span;
-                fn join($self: $S::Span, other: $S::Span) -> Option<$S::Span>;
+                fn join($self: $S::Span, other: $S::Span) -> Result<$S::Span, JoinError>;
                 fn resolved_at($self: $S::Span, at: $S::Span) -> $S::Span;
                 fn source_text($self: $S::Span) -> Option<String>;
                 fn save_span($self: $S::Span) -> usize;
@@ -388,6 +388,13 @@ rpc_encode_decode!(
     enum Spacing {
         Alone,
         Joint,
+    }
+);
+
+rpc_encode_decode!(
+    enum JoinError {
+        DifferentFile,
+        DifferentHygiene,
     }
 );
 

--- a/library/proc_macro/src/lib.rs
+++ b/library/proc_macro/src/lib.rs
@@ -405,9 +405,9 @@ impl Span {
 
     /// Creates a new span encompassing `self` and `other`.
     ///
-    /// Returns `None` if `self` and `other` are from different files.
+    /// Returns `None` if `self` and `other` are from different files or have a different hygiene.
     #[unstable(feature = "proc_macro_span", issue = "54725")]
-    pub fn join(&self, other: Span) -> Option<Span> {
+    pub fn join(&self, other: Span) -> Result<Span, JoinError> {
         self.0.join(other.0).map(Span)
     }
 
@@ -844,6 +844,21 @@ pub enum Spacing {
     /// Additionally, single quote `'` can join with identifiers to form lifetimes: `'ident`.
     #[stable(feature = "proc_macro_lib2", since = "1.29.0")]
     Joint,
+}
+
+/// Error returned by [`Span::join`] when it fails to join.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[unstable(feature = "proc_macro_span", issue = "54725")]
+pub enum JoinError {
+    /// The `other` span belongs to a different file than `self`.
+    #[unstable(feature = "proc_macro_span", issue = "54725")]
+    DifferentFile,
+    /// The `other` span resolves at a different site than `self`.
+    ///
+    /// E.g.: [`Span::join`] will fail with this error when `self` has
+    /// call-site hygiene and `other` has mixed-site hygiene.
+    #[unstable(feature = "proc_macro_span", issue = "54725")]
+    DifferentHygiene,
 }
 
 impl Punct {

--- a/src/test/ui/proc-macro/auxiliary/span-join.rs
+++ b/src/test/ui/proc-macro/auxiliary/span-join.rs
@@ -1,0 +1,19 @@
+#![crate_type = "proc-macro"]
+
+extern crate proc_macro;
+
+use proc_macro::{Ident, JoinError, Span, TokenStream};
+
+#[proc_macro]
+fn hygiene_differ(input: TokenStream) -> TokenStream {
+    let ident = input.into_iter().next();
+
+    let mixed_site_ident = Ident::new("other", Span::mixed_site());
+
+    let e =
+        ident.join(mixed_site_ident).expect_err("successfully joined despite different hygiene");
+
+    assert_eq(e, JoinError::DifferentHygiene);
+
+    TokenStream::new()
+}

--- a/src/test/ui/proc-macro/auxiliary/span-join.rs
+++ b/src/test/ui/proc-macro/auxiliary/span-join.rs
@@ -6,12 +6,14 @@ use proc_macro::{Ident, JoinError, Span, TokenStream};
 
 #[proc_macro]
 fn hygiene_differ(input: TokenStream) -> TokenStream {
-    let ident = input.into_iter().next();
+    let call_site_ident = input.into_iter().next();
 
     let mixed_site_ident = Ident::new("other", Span::mixed_site());
 
-    let e =
-        ident.join(mixed_site_ident).expect_err("successfully joined despite different hygiene");
+    let e = call_site_ident
+        .span()
+        .join(mixed_site_ident.span())
+        .expect_err("successfully joined despite different hygiene");
 
     assert_eq(e, JoinError::DifferentHygiene);
 

--- a/src/test/ui/proc-macro/span-join.rs
+++ b/src/test/ui/proc-macro/span-join.rs
@@ -1,0 +1,4 @@
+extern crate span_join;
+
+// This macro invocation will panic if it successfully joins 2 spans.
+span_join::different_hygiene!(token);


### PR DESCRIPTION
Currently, Span::join has an undefined behaviour when 2 spans are from a different hygiene, this pull request makes Span::join to return a JoinError that fails Span::join when hygiene is different.

See: https://github.com/rust-lang/rust/issues/54725#issuecomment-649078500