### PR TITLE
Bump autocfg to 1.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,9 +161,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "bitflags"


### PR DESCRIPTION
autocfg 1.1.0 makes it so that rustflags from the build are correctly
passed to the compiler probes, which in turn means those probes more
accurately reflect the outer build conditions. This is particularly
important if rustflags includes _required_ `-Clink-arg=` flags without
which builds will fail, as older versions of `autocfg` will then fail
the probe and erroneously report the probed feature as unavailable.

See also
https://github.com/rust-lang/rust/issues/94007#issuecomment-1040668261