### PR TITLE
tests: accept llvm intrinsic in align-checking test

### DIFF
--- a/src/test/codegen/dst-vtable-align-nonzero.rs
+++ b/src/test/codegen/dst-vtable-align-nonzero.rs
@@ -24,6 +24,7 @@ pub fn eliminates_runtime_check_when_align_1(
     x: &Struct<WrapperWithAlign1<dyn Trait>>
 ) -> &WrapperWithAlign1<dyn Trait> {
     // CHECK: load [[USIZE:i[0-9]+]], {{.+}} !range [[RANGE_META:![0-9]+]]
+    // CHECK-NOT: tail call i64 @llvm.umax.i64
     // CHECK-NOT: icmp
     // CHECK-NOT: select
     // CHECK: ret
@@ -36,8 +37,7 @@ pub fn does_not_eliminate_runtime_check_when_align_2(
     x: &Struct<WrapperWithAlign2<dyn Trait>>
 ) -> &WrapperWithAlign2<dyn Trait> {
     // CHECK: [[X0:%[0-9]+]] = load [[USIZE]], {{.+}} !range [[RANGE_META]]
-    // CHECK: [[X1:%[0-9]+]] = icmp {{.+}} [[X0]]
-    // CHECK: [[X2:%[0-9]+]] = select {{.+}} [[X1]]
+    // CHECK: {{icmp|llvm.umax.i64}}
     // CHECK: ret
     &x.dst
 }

--- a/src/test/codegen/dst-vtable-align-nonzero.rs
+++ b/src/test/codegen/dst-vtable-align-nonzero.rs
@@ -24,7 +24,7 @@ pub fn eliminates_runtime_check_when_align_1(
     x: &Struct<WrapperWithAlign1<dyn Trait>>
 ) -> &WrapperWithAlign1<dyn Trait> {
     // CHECK: load [[USIZE:i[0-9]+]], {{.+}} !range [[RANGE_META:![0-9]+]]
-    // CHECK-NOT: tail call i64 @llvm.umax.i64
+    // CHECK-NOT: llvm.umax
     // CHECK-NOT: icmp
     // CHECK-NOT: select
     // CHECK: ret
@@ -37,7 +37,7 @@ pub fn does_not_eliminate_runtime_check_when_align_2(
     x: &Struct<WrapperWithAlign2<dyn Trait>>
 ) -> &WrapperWithAlign2<dyn Trait> {
     // CHECK: [[X0:%[0-9]+]] = load [[USIZE]], {{.+}} !range [[RANGE_META]]
-    // CHECK: {{icmp|llvm.umax.i64}}
+    // CHECK: {{icmp|llvm.umax}}
     // CHECK: ret
     &x.dst
 }


### PR DESCRIPTION
This changed in upstream change https://reviews.llvm.org/D98152 (aka
https://github.com/llvm/llvm-project/commit/a266af721153fab6452094207b09ed265ab0be7b)
wherein LLVM got smarter about using intrinsics. As best I can tell the
change I've made here preserves the intent of the test on LLVM 14 and
before while also passing on LLVM 15 and later.