### PR TITLE
Tweak move error

### DIFF
--- a/src/test/ui/borrowck/borrowck-feature-nll-overrides-migrate.edition.stderr
+++ b/src/test/ui/borrowck/borrowck-feature-nll-overrides-migrate.edition.stderr
@@ -2,10 +2,8 @@ error[E0507]: cannot move out of `foo` in pattern guard
   --> $DIR/borrowck-feature-nll-overrides-migrate.rs:22:18
    |
 LL |                 (|| { let bar = foo; bar.take() })();
-   |                  ^^             ---
-   |                  |              |
-   |                  |              move occurs because `foo` has type `&mut Option<&i32>`, which does not implement the `Copy` trait
-   |                  |              move occurs due to use in closure
+   |                  ^^             --- move occurs because `foo` has type `&mut Option<&i32>`, which does not implement the `Copy` trait
+   |                  |
    |                  move out of `foo` occurs here
    |
    = note: variables bound in patterns cannot be moved from until after the end of the pattern guard

--- a/src/test/ui/borrowck/borrowck-feature-nll-overrides-migrate.zflag.stderr
+++ b/src/test/ui/borrowck/borrowck-feature-nll-overrides-migrate.zflag.stderr
@@ -2,10 +2,8 @@ error[E0507]: cannot move out of `foo` in pattern guard
   --> $DIR/borrowck-feature-nll-overrides-migrate.rs:22:18
    |
 LL |                 (|| { let bar = foo; bar.take() })();
-   |                  ^^             ---
-   |                  |              |
-   |                  |              move occurs because `foo` has type `&mut Option<&i32>`, which does not implement the `Copy` trait
-   |                  |              move occurs due to use in closure
+   |                  ^^             --- move occurs because `foo` has type `&mut Option<&i32>`, which does not implement the `Copy` trait
+   |                  |
    |                  move out of `foo` occurs here
    |
    = note: variables bound in patterns cannot be moved from until after the end of the pattern guard

--- a/src/test/ui/borrowck/borrowck-move-by-capture.stderr
+++ b/src/test/ui/borrowck/borrowck-move-by-capture.stderr
@@ -8,8 +8,8 @@ LL |       let _g = to_fn_mut(|| {
 LL | |         let _h = to_fn_once(move || -> isize { *bar });
    | |                             ^^^^^^^^^^^^^^^^   ----
    | |                             |                  |
+   | |                             |                  variable moved due to use in closure
    | |                             |                  move occurs because `bar` has type `Box<isize>`, which does not implement the `Copy` trait
-   | |                             |                  move occurs due to use in closure
    | |                             move out of `bar` occurs here
 LL | |     });
    | |_____- captured by this `FnMut` closure

--- a/src/test/ui/borrowck/borrowck-move-out-of-overloaded-auto-deref.stderr
+++ b/src/test/ui/borrowck/borrowck-move-out-of-overloaded-auto-deref.stderr
@@ -2,7 +2,16 @@ error[E0507]: cannot move out of an `Rc`
   --> $DIR/borrowck-move-out-of-overloaded-auto-deref.rs:4:14
    |
 LL |     let _x = Rc::new(vec![1, 2]).into_iter();
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ move occurs because value has type `Vec<i32>`, which does not implement the `Copy` trait
+   |              ^^^^^^^^^^^^^^^^^^^^-----------
+   |              |                   |
+   |              |                   value moved due to this method call
+   |              move occurs because value has type `Vec<i32>`, which does not implement the `Copy` trait
+   |
+note: this function takes ownership of the receiver `self`, which moves value
+  --> $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
+   |
+LL |     fn into_iter(self) -> Self::IntoIter;
+   |                  ^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/issue-27282-mutation-in-guard.stderr
+++ b/src/test/ui/borrowck/issue-27282-mutation-in-guard.stderr
@@ -2,10 +2,8 @@ error[E0507]: cannot move out of `foo` in pattern guard
   --> $DIR/issue-27282-mutation-in-guard.rs:6:18
    |
 LL |                 (|| { let bar = foo; bar.take() })();
-   |                  ^^             ---
-   |                  |              |
-   |                  |              move occurs because `foo` has type `&mut Option<&i32>`, which does not implement the `Copy` trait
-   |                  |              move occurs due to use in closure
+   |                  ^^             --- move occurs because `foo` has type `&mut Option<&i32>`, which does not implement the `Copy` trait
+   |                  |
    |                  move out of `foo` occurs here
    |
    = note: variables bound in patterns cannot be moved from until after the end of the pattern guard

--- a/src/test/ui/borrowck/unboxed-closures-move-upvar-from-non-once-ref-closure.stderr
+++ b/src/test/ui/borrowck/unboxed-closures-move-upvar-from-non-once-ref-closure.stderr
@@ -6,10 +6,18 @@ LL |       let y = vec![format!("World")];
 LL |       call(|| {
    |  __________-
 LL | |         y.into_iter();
-   | |         ^ move occurs because `y` has type `Vec<String>`, which does not implement the `Copy` trait
+   | |         ^ ----------- `y` moved due to this method call
+   | |         |
+   | |         move occurs because `y` has type `Vec<String>`, which does not implement the `Copy` trait
 LL | |
 LL | |     });
    | |_____- captured by this `Fn` closure
+   |
+note: this function takes ownership of the receiver `self`, which moves `y`
+  --> $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
+   |
+LL |     fn into_iter(self) -> Self::IntoIter;
+   |                  ^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/error-codes/E0507.stderr
+++ b/src/test/ui/error-codes/E0507.stderr
@@ -2,7 +2,16 @@ error[E0507]: cannot move out of dereference of `Ref<'_, TheDarkKnight>`
   --> $DIR/E0507.rs:12:5
    |
 LL |     x.borrow().nothing_is_true();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ move occurs because value has type `TheDarkKnight`, which does not implement the `Copy` trait
+   |     ^^^^^^^^^^^-----------------
+   |     |          |
+   |     |          value moved due to this method call
+   |     move occurs because value has type `TheDarkKnight`, which does not implement the `Copy` trait
+   |
+note: this function takes ownership of the receiver `self`, which moves value
+  --> $DIR/E0507.rs:6:24
+   |
+LL |     fn nothing_is_true(self) {}
+   |                        ^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-27282-move-ref-mut-into-guard.stderr
+++ b/src/test/ui/issues/issue-27282-move-ref-mut-into-guard.stderr
@@ -2,10 +2,8 @@ error[E0507]: cannot move out of `foo` in pattern guard
   --> $DIR/issue-27282-move-ref-mut-into-guard.rs:9:19
    |
 LL |             if { (|| { let bar = foo; bar.take() })(); false } => {},
-   |                   ^^             ---
-   |                   |              |
-   |                   |              move occurs because `foo` has type `&mut Option<&i32>`, which does not implement the `Copy` trait
-   |                   |              move occurs due to use in closure
+   |                   ^^             --- move occurs because `foo` has type `&mut Option<&i32>`, which does not implement the `Copy` trait
+   |                   |
    |                   move out of `foo` occurs here
    |
    = note: variables bound in patterns cannot be moved from until after the end of the pattern guard

--- a/src/test/ui/issues/issue-61108.stderr
+++ b/src/test/ui/issues/issue-61108.stderr
@@ -4,10 +4,7 @@ error[E0382]: borrow of moved value: `bad_letters`
 LL |     let mut bad_letters = vec!['e', 't', 'o', 'i'];
    |         --------------- move occurs because `bad_letters` has type `Vec<char>`, which does not implement the `Copy` trait
 LL |     for l in bad_letters {
-   |              -----------
-   |              |
-   |              `bad_letters` moved due to this implicit call to `.into_iter()`
-   |              help: consider borrowing to avoid moving into the for loop: `&bad_letters`
+   |              ----------- `bad_letters` moved due to this implicit call to `.into_iter()`
 ...
 LL |     bad_letters.push('s');
    |     ^^^^^^^^^^^^^^^^^^^^^ value borrowed here after move
@@ -17,6 +14,10 @@ note: this function takes ownership of the receiver `self`, which moves `bad_let
    |
 LL |     fn into_iter(self) -> Self::IntoIter;
    |                  ^^^^
+help: consider iterating over a slice of the `Vec<char>`'s content to avoid moving into the `for` loop
+   |
+LL |     for l in &bad_letters {
+   |              +
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-64559.stderr
+++ b/src/test/ui/issues/issue-64559.stderr
@@ -4,10 +4,7 @@ error[E0382]: use of moved value: `orig`
 LL |     let orig = vec![true];
    |         ---- move occurs because `orig` has type `Vec<bool>`, which does not implement the `Copy` trait
 LL |     for _val in orig {}
-   |                 ----
-   |                 |
-   |                 `orig` moved due to this implicit call to `.into_iter()`
-   |                 help: consider borrowing to avoid moving into the for loop: `&orig`
+   |                 ---- `orig` moved due to this implicit call to `.into_iter()`
 LL |     let _closure = || orig;
    |                    ^^ ---- use occurs due to use in closure
    |                    |
@@ -18,6 +15,10 @@ note: this function takes ownership of the receiver `self`, which moves `orig`
    |
 LL |     fn into_iter(self) -> Self::IntoIter;
    |                  ^^^^
+help: consider iterating over a slice of the `Vec<bool>`'s content to avoid moving into the `for` loop
+   |
+LL |     for _val in &orig {}
+   |                 +
 
 error: aborting due to previous error
 

--- a/src/test/ui/loops/issue-82916.stderr
+++ b/src/test/ui/loops/issue-82916.stderr
@@ -4,10 +4,7 @@ error[E0382]: use of moved value: `x`
 LL | fn foo(x: Vec<S>) {
    |        - move occurs because `x` has type `Vec<S>`, which does not implement the `Copy` trait
 LL |     for y in x {
-   |              -
-   |              |
-   |              `x` moved due to this implicit call to `.into_iter()`
-   |              help: consider borrowing to avoid moving into the for loop: `&x`
+   |              - `x` moved due to this implicit call to `.into_iter()`
 ...
 LL |     let z = x;
    |             ^ value used here after move
@@ -17,6 +14,10 @@ note: this function takes ownership of the receiver `self`, which moves `x`
    |
 LL |     fn into_iter(self) -> Self::IntoIter;
    |                  ^^^^
+help: consider iterating over a slice of the `Vec<S>`'s content to avoid moving into the `for` loop
+   |
+LL |     for y in &x {
+   |              +
 
 error: aborting due to previous error
 

--- a/src/test/ui/moves/issue-46099-move-in-macro.stderr
+++ b/src/test/ui/moves/issue-46099-move-in-macro.stderr
@@ -4,10 +4,7 @@ error[E0382]: use of moved value: `b`
 LL |     let b = Box::new(true);
    |         - move occurs because `b` has type `Box<bool>`, which does not implement the `Copy` trait
 LL |     test!({b});
-   |            ^
-   |            |
-   |            value moved here
-   |            value used here after move
+   |            ^ value used here after move
 
 error: aborting due to previous error
 

--- a/src/test/ui/moves/move-fn-self-receiver.stderr
+++ b/src/test/ui/moves/move-fn-self-receiver.stderr
@@ -119,12 +119,14 @@ error[E0382]: use of moved value: `implicit_into_iter`
 LL |     let implicit_into_iter = vec![true];
    |         ------------------ move occurs because `implicit_into_iter` has type `Vec<bool>`, which does not implement the `Copy` trait
 LL |     for _val in implicit_into_iter {}
-   |                 ------------------
-   |                 |
-   |                 `implicit_into_iter` moved due to this implicit call to `.into_iter()`
-   |                 help: consider borrowing to avoid moving into the for loop: `&implicit_into_iter`
+   |                 ------------------ `implicit_into_iter` moved due to this implicit call to `.into_iter()`
 LL |     implicit_into_iter;
    |     ^^^^^^^^^^^^^^^^^^ value used here after move
+   |
+help: consider iterating over a slice of the `Vec<bool>`'s content to avoid moving into the `for` loop
+   |
+LL |     for _val in &implicit_into_iter {}
+   |                 +
 
 error[E0382]: use of moved value: `explicit_into_iter`
   --> $DIR/move-fn-self-receiver.rs:67:5

--- a/src/test/ui/moves/move-in-guard-2.stderr
+++ b/src/test/ui/moves/move-in-guard-2.stderr
@@ -5,10 +5,7 @@ LL |     let x: Box<_> = Box::new(1);
    |         - move occurs because `x` has type `Box<i32>`, which does not implement the `Copy` trait
 ...
 LL |         (_, 2) if take(x) => (),
-   |                        ^
-   |                        |
-   |                        value moved here
-   |                        value used here after move
+   |                        ^ value used here after move
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/match-guards-always-borrow.stderr
+++ b/src/test/ui/nll/match-guards-always-borrow.stderr
@@ -2,10 +2,8 @@ error[E0507]: cannot move out of `foo` in pattern guard
   --> $DIR/match-guards-always-borrow.rs:8:14
    |
 LL |             (|| { let bar = foo; bar.take() })();
-   |              ^^             ---
-   |              |              |
-   |              |              move occurs because `foo` has type `&mut Option<&i32>`, which does not implement the `Copy` trait
-   |              |              move occurs due to use in closure
+   |              ^^             --- move occurs because `foo` has type `&mut Option<&i32>`, which does not implement the `Copy` trait
+   |              |
    |              move out of `foo` occurs here
    |
    = note: variables bound in patterns cannot be moved from until after the end of the pattern guard

--- a/src/test/ui/suggestions/borrow-for-loop-head.stderr
+++ b/src/test/ui/suggestions/borrow-for-loop-head.stderr
@@ -13,16 +13,17 @@ LL |     let a = vec![1, 2, 3];
    |         - move occurs because `a` has type `Vec<i32>`, which does not implement the `Copy` trait
 LL |     for i in &a {
 LL |         for j in a {
-   |                  ^
-   |                  |
-   |                  `a` moved due to this implicit call to `.into_iter()`, in previous iteration of loop
-   |                  help: consider borrowing to avoid moving into the for loop: `&a`
+   |                  ^ `a` moved due to this implicit call to `.into_iter()`, in previous iteration of loop
    |
 note: this function takes ownership of the receiver `self`, which moves `a`
   --> $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
    |
 LL |     fn into_iter(self) -> Self::IntoIter;
    |                  ^^^^
+help: consider iterating over a slice of the `Vec<i32>`'s content to avoid moving into the `for` loop
+   |
+LL |         for j in &a {
+   |                  +
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/suggestions/for-i-in-vec.stderr
+++ b/src/test/ui/suggestions/for-i-in-vec.stderr
@@ -2,9 +2,17 @@ error[E0507]: cannot move out of `self.v` which is behind a shared reference
   --> $DIR/for-i-in-vec.rs:11:18
    |
 LL |         for _ in self.v {
-   |                  ^^^^^^ move occurs because `self.v` has type `Vec<u32>`, which does not implement the `Copy` trait
+   |                  ^^^^^^
+   |                  |
+   |                  `self.v` moved due to this implicit call to `.into_iter()`
+   |                  move occurs because `self.v` has type `Vec<u32>`, which does not implement the `Copy` trait
    |
-help: consider iterating over a slice of the `Vec<u32>`'s content
+note: this function takes ownership of the receiver `self`, which moves `self.v`
+  --> $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
+   |
+LL |     fn into_iter(self) -> Self::IntoIter;
+   |                  ^^^^
+help: consider iterating over a slice of the `Vec<u32>`'s content to avoid moving into the `for` loop
    |
 LL |         for _ in &self.v {
    |                  +
@@ -13,9 +21,12 @@ error[E0507]: cannot move out of `self.h` which is behind a shared reference
   --> $DIR/for-i-in-vec.rs:13:18
    |
 LL |         for _ in self.h {
-   |                  ^^^^^^ move occurs because `self.h` has type `HashMap<i32, i32>`, which does not implement the `Copy` trait
+   |                  ^^^^^^
+   |                  |
+   |                  `self.h` moved due to this implicit call to `.into_iter()`
+   |                  move occurs because `self.h` has type `HashMap<i32, i32>`, which does not implement the `Copy` trait
    |
-help: consider iterating over a slice of the `HashMap<i32, i32>`'s content
+help: consider iterating over a slice of the `HashMap<i32, i32>`'s content to avoid moving into the `for` loop
    |
 LL |         for _ in &self.h {
    |                  +
@@ -24,9 +35,17 @@ error[E0507]: cannot move out of a shared reference
   --> $DIR/for-i-in-vec.rs:21:19
    |
 LL |     for loader in *LOADERS {
-   |                   ^^^^^^^^ move occurs because value has type `Vec<&u8>`, which does not implement the `Copy` trait
+   |                   ^^^^^^^^
+   |                   |
+   |                   value moved due to this implicit call to `.into_iter()`
+   |                   move occurs because value has type `Vec<&u8>`, which does not implement the `Copy` trait
    |
-help: consider iterating over a slice of the `Vec<&u8>`'s content
+note: this function takes ownership of the receiver `self`, which moves value
+  --> $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL
+   |
+LL |     fn into_iter(self) -> Self::IntoIter;
+   |                  ^^^^
+help: consider iterating over a slice of the `Vec<&u8>`'s content to avoid moving into the `for` loop
    |
 LL |     for loader in &*LOADERS {
    |                   +

--- a/src/test/ui/suggestions/option-content-move2.stderr
+++ b/src/test/ui/suggestions/option-content-move2.stderr
@@ -12,8 +12,8 @@ LL | |
 LL | |             var = Some(NotCopyable);
    | |             ---
    | |             |
+   | |             variable moved due to use in closure
    | |             move occurs because `var` has type `Option<NotCopyable>`, which does not implement the `Copy` trait
-   | |             move occurs due to use in closure
 LL | |         }
 LL | |     });
    | |_____- captured by this `FnMut` closure


### PR DESCRIPTION
Point at method definition that causes type to be consumed.

Fix #94056.