### PR TITLE
Mark `uint::wrapping_next_power_of_two` as `#[inline]`

### DIFF
--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -2225,6 +2225,7 @@ macro_rules! uint_impl {
         #[doc = concat!("assert_eq!(3", stringify!($SelfT), ".wrapping_next_power_of_two(), 4);")]
         #[doc = concat!("assert_eq!(", stringify!($SelfT), "::MAX.wrapping_next_power_of_two(), 0);")]
         /// ```
+        #[inline]
         #[unstable(feature = "wrapping_next_power_of_two", issue = "32463",
                    reason = "needs decision on wrapping behaviour")]
         #[rustc_const_unstable(feature = "wrapping_next_power_of_two", issue = "32463")]


### PR DESCRIPTION
This brings it in line with `next_power_of_two` and `checked_next_power_of_two`

https://godbolt.org/z/Tr18GnqKj

<details>
<summary> Output as of `rustc 1.61.0-nightly (4ce374923 2022-02-28)` </summary>

```asm
example::npot:
        lea     eax, [rdi - 1]
        movzx   eax, al
        lzcnt   ecx, eax
        add     ecx, -24
        mov     al, -1
        shr     al, cl
        inc     al
        cmp     dil, 2
        movzx   ecx, al
        mov     eax, 1
        cmovae  eax, ecx
        ret

example::cnpot:
        lea     eax, [rdi - 1]
        movzx   eax, al
        lzcnt   ecx, eax
        add     ecx, -24
        mov     al, -1
        shr     al, cl
        xor     ecx, ecx
        cmp     dil, 2
        movzx   edx, al
        cmovb   edx, ecx
        inc     dl
        setne   al
        ret

example::wrapping_next_power_of_two:
        jmp     qword ptr [rip + _ZN4core3num20_$LT$impl$u20$u8$GT$26wrapping_next_power_of_two17hd879a85055735264E@GOTPCREL]
```

</details>