### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
@@ -5,16 +5,21 @@ use rustc_errors::{Applicability, Diagnostic, DiagnosticBuilder, ErrorReported};
 use rustc_hir as hir;
 use rustc_hir::def_id::DefId;
 use rustc_hir::{AsyncGeneratorKind, GeneratorKind};
+use rustc_infer::infer::TyCtxtInferExt;
+use rustc_infer::traits::ObligationCause;
 use rustc_middle::mir::{
     self, AggregateKind, BindingForm, BorrowKind, ClearCrossCrate, ConstraintCategory,
     FakeReadCause, LocalDecl, LocalInfo, LocalKind, Location, Operand, Place, PlaceRef,
     ProjectionElem, Rvalue, Statement, StatementKind, Terminator, TerminatorKind, VarBindingForm,
 };
-use rustc_middle::ty::{self, suggest_constraining_type_param, Ty};
+use rustc_middle::ty::{
+    self, suggest_constraining_type_param, suggest_constraining_type_params, PredicateKind, Ty,
+};
 use rustc_mir_dataflow::move_paths::{InitKind, MoveOutIndex, MovePathIndex};
 use rustc_span::symbol::sym;
 use rustc_span::{BytePos, MultiSpan, Span, DUMMY_SP};
 use rustc_trait_selection::infer::InferCtxtExt;
+use rustc_trait_selection::traits::TraitEngineExt as _;
 
 use crate::borrow_set::TwoPhaseActivation;
 use crate::borrowck_errors;
@@ -423,7 +428,63 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                             None,
                         );
                     }
+                } else {
+                    // Try to find predicates on *generic params* that would allow copying `ty`
+
+                    let tcx = self.infcx.tcx;
+                    let generics = tcx.generics_of(self.mir_def_id());
+                    if let Some(hir_generics) = tcx
+                        .typeck_root_def_id(self.mir_def_id().to_def_id())
+                        .as_local()
+                        .and_then(|def_id| tcx.hir().get_generics(def_id))
+                    {
+                        let predicates: Result<Vec<_>, _> = tcx.infer_ctxt().enter(|infcx| {
+                            let mut fulfill_cx =
+                                <dyn rustc_infer::traits::TraitEngine<'_>>::new(infcx.tcx);
+
+                            let copy_did = infcx.tcx.lang_items().copy_trait().unwrap();
+                            let cause = ObligationCause::new(
+                                span,
+                                self.mir_hir_id(),
+                                rustc_infer::traits::ObligationCauseCode::MiscObligation,
+                            );
+                            fulfill_cx.register_bound(&infcx, self.param_env, ty, copy_did, cause);
+                            let errors = fulfill_cx.select_where_possible(&infcx);
+
+                            // Only emit suggestion if all required predicates are on generic
+                            errors
+                                .into_iter()
+                                .map(|err| match err.obligation.predicate.kind().skip_binder() {
+                                    PredicateKind::Trait(predicate) => {
+                                        match predicate.self_ty().kind() {
+                                            ty::Param(param_ty) => Ok((
+                                                generics.type_param(param_ty, tcx),
+                                                predicate
+                                                    .trait_ref
+                                                    .print_only_trait_path()
+                                                    .to_string(),
+                                            )),
+                                            _ => Err(()),
+                                        }
+                                    }
+                                    _ => Err(()),
+                                })
+                                .collect()
+                        });
+
+                        if let Ok(predicates) = predicates {
+                            suggest_constraining_type_params(
+                                tcx,
+                                hir_generics,
+                                &mut err,
+                                predicates.iter().map(|(param, constraint)| {
+                                    (param.name.as_str(), &**constraint, None)
+                                }),
+                            );
+                        }
+                    }
                 }
+
                 let span = if let Some(local) = place.as_local() {
                     let decl = &self.body.local_decls[local];
                     Some(decl.source_info.span)

--- a/compiler/rustc_builtin_macros/src/cfg.rs
+++ b/compiler/rustc_builtin_macros/src/cfg.rs
@@ -19,7 +19,12 @@ pub fn expand_cfg(
 
     match parse_cfg(cx, sp, tts) {
         Ok(cfg) => {
-            let matches_cfg = attr::cfg_matches(&cfg, &cx.sess.parse_sess, cx.ecfg.features);
+            let matches_cfg = attr::cfg_matches(
+                &cfg,
+                &cx.sess.parse_sess,
+                cx.current_expansion.lint_node_id,
+                cx.ecfg.features,
+            );
             MacEager::expr(cx.expr_bool(sp, matches_cfg))
         }
         Err(mut err) => {

--- a/compiler/rustc_builtin_macros/src/cfg_eval.rs
+++ b/compiler/rustc_builtin_macros/src/cfg_eval.rs
@@ -5,6 +5,7 @@ use rustc_ast::mut_visit::MutVisitor;
 use rustc_ast::ptr::P;
 use rustc_ast::tokenstream::CanSynthesizeMissingTokens;
 use rustc_ast::visit::Visitor;
+use rustc_ast::NodeId;
 use rustc_ast::{mut_visit, visit};
 use rustc_ast::{AstLike, Attribute};
 use rustc_expand::base::{Annotatable, ExtCtxt};
@@ -26,15 +27,16 @@ crate fn expand(
 ) -> Vec<Annotatable> {
     check_builtin_macro_attribute(ecx, meta_item, sym::cfg_eval);
     warn_on_duplicate_attribute(&ecx, &annotatable, sym::cfg_eval);
-    vec![cfg_eval(ecx.sess, ecx.ecfg.features, annotatable)]
+    vec![cfg_eval(ecx.sess, ecx.ecfg.features, annotatable, ecx.current_expansion.lint_node_id)]
 }
 
 crate fn cfg_eval(
     sess: &Session,
     features: Option<&Features>,
     annotatable: Annotatable,
+    lint_node_id: NodeId,
 ) -> Annotatable {
-    CfgEval { cfg: &mut StripUnconfigured { sess, features, config_tokens: true } }
+    CfgEval { cfg: &mut StripUnconfigured { sess, features, config_tokens: true, lint_node_id } }
         .configure_annotatable(annotatable)
         // Since the item itself has already been configured by the `InvocationCollector`,
         // we know that fold result vector will contain exactly one element.

--- a/compiler/rustc_builtin_macros/src/derive.rs
+++ b/compiler/rustc_builtin_macros/src/derive.rs
@@ -64,7 +64,12 @@ impl MultiItemModifier for Expander {
                 match &mut resolutions[..] {
                     [] => {}
                     [(_, first_item, _), others @ ..] => {
-                        *first_item = cfg_eval(sess, features, item.clone());
+                        *first_item = cfg_eval(
+                            sess,
+                            features,
+                            item.clone(),
+                            ecx.current_expansion.lint_node_id,
+                        );
                         for (_, item, _) in others {
                             *item = first_item.clone();
                         }

--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -1,4 +1,5 @@
 use rustc_arena::TypedArena;
+use rustc_ast::CRATE_NODE_ID;
 use rustc_data_structures::fx::{FxHashSet, FxIndexMap};
 use rustc_data_structures::memmap::Mmap;
 use rustc_data_structures::temp_dir::MaybeTempDir;
@@ -2434,7 +2435,7 @@ fn add_upstream_native_libraries(
 
 fn relevant_lib(sess: &Session, lib: &NativeLib) -> bool {
     match lib.cfg {
-        Some(ref cfg) => rustc_attr::cfg_matches(cfg, &sess.parse_sess, None),
+        Some(ref cfg) => rustc_attr::cfg_matches(cfg, &sess.parse_sess, CRATE_NODE_ID, None),
         None => true,
     }
 }

--- a/compiler/rustc_codegen_ssa/src/target_features.rs
+++ b/compiler/rustc_codegen_ssa/src/target_features.rs
@@ -36,6 +36,7 @@ const ARM_ALLOWED_FEATURES: &[(&str, Option<Symbol>)] = &[
     // #[target_feature].
     ("thumb-mode", Some(sym::arm_target_feature)),
     ("thumb2", Some(sym::arm_target_feature)),
+    ("d32", Some(sym::arm_target_feature)),
 ];
 
 const AARCH64_ALLOWED_FEATURES: &[(&str, Option<Symbol>)] = &[

--- a/compiler/rustc_data_structures/src/sorted_map/index_map.rs
+++ b/compiler/rustc_data_structures/src/sorted_map/index_map.rs
@@ -152,6 +152,3 @@ impl<I: Idx, K, V> std::ops::Index<I> for SortedIndexMultiMap<I, K, V> {
         &self.items[idx].1
     }
 }
-
-#[cfg(tests)]
-mod tests;

--- a/compiler/rustc_expand/src/config.rs
+++ b/compiler/rustc_expand/src/config.rs
@@ -165,6 +165,7 @@ fn get_features(
             if let Some(Feature { since, .. }) = ACCEPTED_FEATURES.iter().find(|f| name == f.name) {
                 let since = Some(Symbol::intern(since));
                 features.declared_lang_features.push((name, mi.span(), since));
+                features.active_features.insert(name);
                 continue;
             }
 
@@ -185,10 +186,12 @@ fn get_features(
             if let Some(f) = ACTIVE_FEATURES.iter().find(|f| name == f.name) {
                 f.set(&mut features, mi.span());
                 features.declared_lang_features.push((name, mi.span(), None));
+                features.active_features.insert(name);
                 continue;
             }
 
             features.declared_lib_features.push((name, mi.span()));
+            features.active_features.insert(name);
         }
     }
 

--- a/compiler/rustc_expand/src/expand.rs
+++ b/compiler/rustc_expand/src/expand.rs
@@ -551,11 +551,6 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
                 // attribute is expanded. Therefore, we don't need to configure the tokens
                 // Derive macros *can* see the results of cfg-expansion - they are handled
                 // specially in `fully_expand_fragment`
-                cfg: StripUnconfigured {
-                    sess: &self.cx.sess,
-                    features: self.cx.ecfg.features,
-                    config_tokens: false,
-                },
                 cx: self.cx,
                 invocations: Vec::new(),
                 monotonic: self.monotonic,
@@ -1537,12 +1532,20 @@ impl InvocationCollectorNode for AstLikeWrapper<P<ast::Expr>, OptExprTag> {
 
 struct InvocationCollector<'a, 'b> {
     cx: &'a mut ExtCtxt<'b>,
-    cfg: StripUnconfigured<'a>,
     invocations: Vec<(Invocation, Option<Lrc<SyntaxExtension>>)>,
     monotonic: bool,
 }
 
 impl<'a, 'b> InvocationCollector<'a, 'b> {
+    fn cfg(&self) -> StripUnconfigured<'_> {
+        StripUnconfigured {
+            sess: &self.cx.sess,
+            features: self.cx.ecfg.features,
+            config_tokens: false,
+            lint_node_id: self.cx.current_expansion.lint_node_id,
+        }
+    }
+
     fn collect(&mut self, fragment_kind: AstFragmentKind, kind: InvocationKind) -> AstFragment {
         let expn_id = LocalExpnId::fresh_empty();
         let vis = kind.placeholder_visibility();
@@ -1682,7 +1685,7 @@ impl<'a, 'b> InvocationCollector<'a, 'b> {
         attr: ast::Attribute,
         pos: usize,
     ) -> bool {
-        let res = self.cfg.cfg_true(&attr);
+        let res = self.cfg().cfg_true(&attr);
         if res {
             // FIXME: `cfg(TRUE)` attributes do not currently remove themselves during expansion,
             // and some tools like rustdoc and clippy rely on that. Find a way to remove them
@@ -1695,7 +1698,7 @@ impl<'a, 'b> InvocationCollector<'a, 'b> {
 
     fn expand_cfg_attr(&self, node: &mut impl AstLike, attr: ast::Attribute, pos: usize) {
         node.visit_attrs(|attrs| {
-            attrs.splice(pos..pos, self.cfg.expand_cfg_attr(attr, false));
+            attrs.splice(pos..pos, self.cfg().expand_cfg_attr(attr, false));
         });
     }
 
@@ -1717,7 +1720,7 @@ impl<'a, 'b> InvocationCollector<'a, 'b> {
                         continue;
                     }
                     _ => {
-                        Node::pre_flat_map_node_collect_attr(&self.cfg, &attr);
+                        Node::pre_flat_map_node_collect_attr(&self.cfg(), &attr);
                         self.collect_attr((attr, pos, derives), node.to_annotatable(), Node::KIND)
                             .make_ast::<Node>()
                     }
@@ -1881,7 +1884,7 @@ impl<'a, 'b> MutVisitor for InvocationCollector<'a, 'b> {
     fn visit_expr(&mut self, node: &mut P<ast::Expr>) {
         // FIXME: Feature gating is performed inconsistently between `Expr` and `OptExpr`.
         if let Some(attr) = node.attrs.first() {
-            self.cfg.maybe_emit_expr_attr_err(attr);
+            self.cfg().maybe_emit_expr_attr_err(attr);
         }
         self.visit_node(node)
     }

--- a/compiler/rustc_feature/src/active.rs
+++ b/compiler/rustc_feature/src/active.rs
@@ -2,6 +2,7 @@
 
 use super::{to_nonzero, Feature, State};
 
+use rustc_data_structures::fx::FxHashSet;
 use rustc_span::edition::Edition;
 use rustc_span::symbol::{sym, Symbol};
 use rustc_span::Span;
@@ -47,6 +48,8 @@ macro_rules! declare_features {
             pub declared_lang_features: Vec<(Symbol, Span, Option<Symbol>)>,
             /// `#![feature]` attrs for non-language (library) features.
             pub declared_lib_features: Vec<(Symbol, Span)>,
+            /// Features enabled for this crate.
+            pub active_features: FxHashSet<Symbol>,
             $(
                 $(#[doc = $doc])*
                 pub $feature: bool
@@ -56,6 +59,11 @@ macro_rules! declare_features {
         impl Features {
             pub fn walk_feature_fields(&self, mut f: impl FnMut(&str, bool)) {
                 $(f(stringify!($feature), self.$feature);)+
+            }
+
+            /// Is the given feature active?
+            pub fn active(&self, feature: Symbol) -> bool {
+                self.active_features.contains(&feature)
             }
 
             /// Is the given feature enabled?

--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -2,6 +2,7 @@ use crate::interface::{Compiler, Result};
 use crate::proc_macro_decls;
 use crate::util;
 
+use ast::CRATE_NODE_ID;
 use rustc_ast::mut_visit::MutVisitor;
 use rustc_ast::{self as ast, visit};
 use rustc_borrowck as mir_borrowck;
@@ -188,7 +189,7 @@ pub fn register_plugins<'a>(
         )
     });
 
-    let (krate, features) = rustc_expand::config::features(sess, krate);
+    let (krate, features) = rustc_expand::config::features(sess, krate, CRATE_NODE_ID);
     // these need to be set "early" so that expansion sees `quote` if enabled.
     sess.init_features(features);
 

--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -938,6 +938,7 @@ fn analysis(tcx: TyCtxt<'_>, (): ()) -> Result<()> {
                 // This marks the corresponding crate-level attributes
                 // as used, and ensures that their values are valid.
                 tcx.ensure().limits(());
+                tcx.ensure().stability_index(());
             }
         );
     });

--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -933,6 +933,11 @@ fn analysis(tcx: TyCtxt<'_>, (): ()) -> Result<()> {
                 });
             },
             {
+                sess.time("unused_lib_feature_checking", || {
+                    rustc_passes::stability::check_unused_or_stable_features(tcx)
+                });
+            },
+            {
                 // We force these querie to run,
                 // since they might not otherwise get called.
                 // This marks the corresponding crate-level attributes
@@ -1009,11 +1014,6 @@ fn analysis(tcx: TyCtxt<'_>, (): ()) -> Result<()> {
                     {
                         tcx.hir()
                             .par_for_each_module(|module| tcx.ensure().check_mod_deathness(module));
-                    },
-                    {
-                        sess.time("unused_lib_feature_checking", || {
-                            rustc_passes::stability::check_unused_or_stable_features(tcx)
-                        });
                     },
                     {
                         sess.time("lint_checking", || {

--- a/compiler/rustc_metadata/src/native_libs.rs
+++ b/compiler/rustc_metadata/src/native_libs.rs
@@ -1,3 +1,4 @@
+use rustc_ast::CRATE_NODE_ID;
 use rustc_attr as attr;
 use rustc_data_structures::fx::FxHashSet;
 use rustc_errors::struct_span_err;
@@ -21,7 +22,7 @@ crate fn collect(tcx: TyCtxt<'_>) -> Vec<NativeLib> {
 
 crate fn relevant_lib(sess: &Session, lib: &NativeLib) -> bool {
     match lib.cfg {
-        Some(ref cfg) => attr::cfg_matches(cfg, &sess.parse_sess, None),
+        Some(ref cfg) => attr::cfg_matches(cfg, &sess.parse_sess, CRATE_NODE_ID, None),
         None => true,
     }
 }

--- a/compiler/rustc_middle/src/lib.rs
+++ b/compiler/rustc_middle/src/lib.rs
@@ -56,6 +56,7 @@
 #![feature(nonzero_ops)]
 #![feature(unwrap_infallible)]
 #![feature(decl_macro)]
+#![feature(drain_filter)]
 #![recursion_limit = "512"]
 #![allow(rustc::potential_query_instability)]
 

--- a/compiler/rustc_middle/src/middle/stability.rs
+++ b/compiler/rustc_middle/src/middle/stability.rs
@@ -6,7 +6,7 @@ pub use self::StabilityLevel::*;
 use crate::ty::{self, DefIdTree, TyCtxt};
 use rustc_ast::NodeId;
 use rustc_attr::{self as attr, ConstStability, Deprecation, Stability};
-use rustc_data_structures::fx::{FxHashMap, FxHashSet};
+use rustc_data_structures::fx::FxHashMap;
 use rustc_errors::{Applicability, Diagnostic};
 use rustc_feature::GateIssue;
 use rustc_hir as hir;
@@ -66,9 +66,6 @@ pub struct Index {
 
     /// Maps for each crate whether it is part of the staged API.
     pub staged_api: FxHashMap<CrateNum, bool>,
-
-    /// Features enabled for this crate.
-    pub active_features: FxHashSet<Symbol>,
 }
 
 impl Index {
@@ -423,7 +420,7 @@ impl<'tcx> TyCtxt<'tcx> {
                     debug!("stability: skipping span={:?} since it is internal", span);
                     return EvalResult::Allow;
                 }
-                if self.stability().active_features.contains(&feature) {
+                if self.features().active(feature) {
                     return EvalResult::Allow;
                 }
 

--- a/compiler/rustc_middle/src/middle/stability.rs
+++ b/compiler/rustc_middle/src/middle/stability.rs
@@ -11,7 +11,7 @@ use rustc_errors::{Applicability, Diagnostic};
 use rustc_feature::GateIssue;
 use rustc_hir as hir;
 use rustc_hir::def::DefKind;
-use rustc_hir::def_id::{CrateNum, DefId, LocalDefId, CRATE_DEF_INDEX};
+use rustc_hir::def_id::{DefId, LocalDefId, CRATE_DEF_INDEX};
 use rustc_hir::{self, HirId};
 use rustc_middle::ty::print::with_no_trimmed_paths;
 use rustc_session::lint::builtin::{DEPRECATED, DEPRECATED_IN_FUTURE, SOFT_UNSTABLE};
@@ -63,9 +63,6 @@ pub struct Index {
     pub stab_map: FxHashMap<LocalDefId, Stability>,
     pub const_stab_map: FxHashMap<LocalDefId, ConstStability>,
     pub depr_map: FxHashMap<LocalDefId, DeprecationEntry>,
-
-    /// Maps for each crate whether it is part of the staged API.
-    pub staged_api: FxHashMap<CrateNum, bool>,
 }
 
 impl Index {

--- a/compiler/rustc_middle/src/mir/interpret/error.rs
+++ b/compiler/rustc_middle/src/mir/interpret/error.rs
@@ -233,6 +233,10 @@ pub enum UndefinedBehaviorInfo<'tcx> {
     DivisionByZero,
     /// Something was "remainded" by 0 (x % 0).
     RemainderByZero,
+    /// Signed division overflowed (INT_MIN / -1).
+    DivisionOverflow,
+    /// Signed remainder overflowed (INT_MIN % -1).
+    RemainderOverflow,
     /// Overflowing inbounds pointer arithmetic.
     PointerArithOverflow,
     /// Invalid metadata in a wide pointer (using `str` to avoid allocations).
@@ -310,6 +314,8 @@ impl fmt::Display for UndefinedBehaviorInfo<'_> {
             }
             DivisionByZero => write!(f, "dividing by zero"),
             RemainderByZero => write!(f, "calculating the remainder with a divisor of zero"),
+            DivisionOverflow => write!(f, "overflow in signed division (dividing MIN by -1)"),
+            RemainderOverflow => write!(f, "overflow in signed remainder (dividing MIN by -1)"),
             PointerArithOverflow => write!(f, "overflowing in-bounds pointer arithmetic"),
             InvalidMeta(msg) => write!(f, "invalid metadata in wide pointer: {}", msg),
             InvalidVtableDropFn(sig) => write!(

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -2970,11 +2970,6 @@ pub fn provide(providers: &mut ty::query::Providers) {
         tcx.arena.alloc(tcx.resolutions(()).glob_map.get(&id).cloned().unwrap_or_default())
     };
 
-    providers.lookup_stability = |tcx, id| tcx.stability().local_stability(id.expect_local());
-    providers.lookup_const_stability =
-        |tcx, id| tcx.stability().local_const_stability(id.expect_local());
-    providers.lookup_deprecation_entry =
-        |tcx, id| tcx.stability().local_deprecation_entry(id.expect_local());
     providers.extern_mod_stmt_cnum =
         |tcx, id| tcx.resolutions(()).extern_crate_map.get(&id).cloned();
     providers.output_filenames = |tcx, ()| &tcx.output_filenames;

--- a/compiler/rustc_middle/src/ty/diagnostics.rs
+++ b/compiler/rustc_middle/src/ty/diagnostics.rs
@@ -7,6 +7,7 @@ use crate::ty::{
     ProjectionTy, Term, Ty, TyCtxt, TypeAndMut,
 };
 
+use rustc_data_structures::fx::FxHashMap;
 use rustc_errors::{Applicability, Diagnostic};
 use rustc_hir as hir;
 use rustc_hir::def_id::DefId;
@@ -157,9 +158,17 @@ pub fn suggest_arbitrary_trait_bound(
     true
 }
 
+#[derive(Debug)]
+enum SuggestChangingConstraintsMessage<'a> {
+    RestrictBoundFurther,
+    RestrictType { ty: &'a str },
+    RestrictTypeFurther { ty: &'a str },
+    RemovingQSized,
+}
+
 fn suggest_removing_unsized_bound(
     generics: &hir::Generics<'_>,
-    err: &mut Diagnostic,
+    suggestions: &mut Vec<(Span, String, SuggestChangingConstraintsMessage<'_>)>,
     param_name: &str,
     param: &hir::GenericParam<'_>,
     def_id: Option<DefId>,
@@ -221,13 +230,12 @@ fn suggest_removing_unsized_bound(
                         //             ^^^^^^^^^
                         (_, pos, _, _) => bounds[pos - 1].span().shrink_to_hi().to(bound.span()),
                     };
-                    err.span_suggestion_verbose(
+
+                    suggestions.push((
                         sp,
-                        "consider removing the `?Sized` bound to make the \
-                            type parameter `Sized`",
                         String::new(),
-                        Applicability::MaybeIncorrect,
-                    );
+                        SuggestChangingConstraintsMessage::RemovingQSized,
+                    ));
                 }
             }
             _ => {}
@@ -249,13 +257,12 @@ fn suggest_removing_unsized_bound(
                     //       ^^^^^^^^^
                     (_, pos) => param.bounds[pos - 1].span().shrink_to_hi().to(bound.span()),
                 };
-                err.span_suggestion_verbose(
+
+                suggestions.push((
                     sp,
-                    "consider removing the `?Sized` bound to make the type parameter \
-                        `Sized`",
                     String::new(),
-                    Applicability::MaybeIncorrect,
-                );
+                    SuggestChangingConstraintsMessage::RemovingQSized,
+                ));
             }
             _ => {}
         }
@@ -271,184 +278,249 @@ pub fn suggest_constraining_type_param(
     constraint: &str,
     def_id: Option<DefId>,
 ) -> bool {
-    let param = generics.params.iter().find(|p| p.name.ident().as_str() == param_name);
+    suggest_constraining_type_params(
+        tcx,
+        generics,
+        err,
+        [(param_name, constraint, def_id)].into_iter(),
+    )
+}
 
-    let Some(param) = param else {
-        return false;
-    };
+/// Suggest restricting a type param with a new bound.
+pub fn suggest_constraining_type_params<'a>(
+    tcx: TyCtxt<'_>,
+    generics: &hir::Generics<'_>,
+    err: &mut Diagnostic,
+    param_names_and_constraints: impl Iterator<Item = (&'a str, &'a str, Option<DefId>)>,
+) -> bool {
+    let mut grouped = FxHashMap::default();
+    param_names_and_constraints.for_each(|(param_name, constraint, def_id)| {
+        grouped.entry(param_name).or_insert(Vec::new()).push((constraint, def_id))
+    });
 
-    const MSG_RESTRICT_BOUND_FURTHER: &str = "consider further restricting this bound";
-    let msg_restrict_type = format!("consider restricting type parameter `{}`", param_name);
-    let msg_restrict_type_further =
-        format!("consider further restricting type parameter `{}`", param_name);
+    let mut applicability = Applicability::MachineApplicable;
+    let mut suggestions = Vec::new();
 
-    if def_id == tcx.lang_items().sized_trait() {
-        // Type parameters are already `Sized` by default.
-        err.span_label(param.span, &format!("this type parameter needs to be `{}`", constraint));
-        suggest_removing_unsized_bound(generics, err, param_name, param, def_id);
-        return true;
-    }
-    let mut suggest_restrict = |span| {
-        err.span_suggestion_verbose(
-            span,
-            MSG_RESTRICT_BOUND_FURTHER,
-            format!(" + {}", constraint),
-            Applicability::MachineApplicable,
-        );
-    };
+    for (param_name, mut constraints) in grouped {
+        let param = generics.params.iter().find(|p| p.name.ident().as_str() == param_name);
+        let Some(param) = param else { return false };
 
-    if param_name.starts_with("impl ") {
-        // If there's an `impl Trait` used in argument position, suggest
-        // restricting it:
-        //
-        //   fn foo(t: impl Foo) { ... }
-        //             --------
-        //             |
-        //             help: consider further restricting this bound with `+ Bar`
-        //
-        // Suggestion for tools in this case is:
-        //
-        //   fn foo(t: impl Foo) { ... }
-        //             --------
-        //             |
-        //             replace with: `impl Foo + Bar`
+        {
+            let mut sized_constraints =
+                constraints.drain_filter(|(_, def_id)| *def_id == tcx.lang_items().sized_trait());
+            if let Some((constraint, def_id)) = sized_constraints.next() {
+                applicability = Applicability::MaybeIncorrect;
 
-        suggest_restrict(param.span.shrink_to_hi());
-        return true;
-    }
+                err.span_label(
+                    param.span,
+                    &format!("this type parameter needs to be `{}`", constraint),
+                );
+                suggest_removing_unsized_bound(
+                    generics,
+                    &mut suggestions,
+                    param_name,
+                    param,
+                    def_id,
+                );
+            }
+        }
 
-    if generics.where_clause.predicates.is_empty()
-        // Given `trait Base<T = String>: Super<T>` where `T: Copy`, suggest restricting in the
-        // `where` clause instead of `trait Base<T: Copy = String>: Super<T>`.
-        && !matches!(param.kind, hir::GenericParamKind::Type { default: Some(_), .. })
-    {
-        if let Some(span) = param.bounds_span_for_suggestions() {
-            // If user has provided some bounds, suggest restricting them:
+        if constraints.is_empty() {
+            continue;
+        }
+
+        let constraint = constraints.iter().map(|&(c, _)| c).collect::<Vec<_>>().join(" + ");
+        let mut suggest_restrict = |span| {
+            suggestions.push((
+                span,
+                format!(" + {}", constraint),
+                SuggestChangingConstraintsMessage::RestrictBoundFurther,
+            ))
+        };
+
+        if param_name.starts_with("impl ") {
+            // If there's an `impl Trait` used in argument position, suggest
+            // restricting it:
             //
-            //   fn foo<T: Foo>(t: T) { ... }
-            //             ---
+            //   fn foo(t: impl Foo) { ... }
+            //             --------
             //             |
             //             help: consider further restricting this bound with `+ Bar`
             //
             // Suggestion for tools in this case is:
             //
-            //   fn foo<T: Foo>(t: T) { ... }
-            //          --
-            //          |
-            //          replace with: `T: Bar +`
-            suggest_restrict(span);
-        } else {
-            // If user hasn't provided any bounds, suggest adding a new one:
-            //
-            //   fn foo<T>(t: T) { ... }
-            //          - help: consider restricting this type parameter with `T: Foo`
-            err.span_suggestion_verbose(
-                param.span.shrink_to_hi(),
-                &msg_restrict_type,
-                format!(": {}", constraint),
-                Applicability::MachineApplicable,
-            );
+            //   fn foo(t: impl Foo) { ... }
+            //             --------
+            //             |
+            //             replace with: `impl Foo + Bar`
+
+            suggest_restrict(param.span.shrink_to_hi());
+            continue;
         }
 
-        true
-    } else {
-        // This part is a bit tricky, because using the `where` clause user can
-        // provide zero, one or many bounds for the same type parameter, so we
-        // have following cases to consider:
-        //
-        // 1) When the type parameter has been provided zero bounds
-        //
-        //    Message:
-        //      fn foo<X, Y>(x: X, y: Y) where Y: Foo { ... }
-        //             - help: consider restricting this type parameter with `where X: Bar`
-        //
-        //    Suggestion:
-        //      fn foo<X, Y>(x: X, y: Y) where Y: Foo { ... }
-        //                                           - insert: `, X: Bar`
-        //
-        //
-        // 2) When the type parameter has been provided one bound
-        //
-        //    Message:
-        //      fn foo<T>(t: T) where T: Foo { ... }
-        //                            ^^^^^^
-        //                            |
-        //                            help: consider further restricting this bound with `+ Bar`
-        //
-        //    Suggestion:
-        //      fn foo<T>(t: T) where T: Foo { ... }
-        //                            ^^
-        //                            |
-        //                            replace with: `T: Bar +`
-        //
-        //
-        // 3) When the type parameter has been provided many bounds
-        //
-        //    Message:
-        //      fn foo<T>(t: T) where T: Foo, T: Bar {... }
-        //             - help: consider further restricting this type parameter with `where T: Zar`
-        //
-        //    Suggestion:
-        //      fn foo<T>(t: T) where T: Foo, T: Bar {... }
-        //                                          - insert: `, T: Zar`
-        //
-        // Additionally, there may be no `where` clause whatsoever in the case that this was
-        // reached because the generic parameter has a default:
-        //
-        //    Message:
-        //      trait Foo<T=()> {... }
-        //             - help: consider further restricting this type parameter with `where T: Zar`
-        //
-        //    Suggestion:
-        //      trait Foo<T=()> where T: Zar {... }
-        //                     - insert: `where T: Zar`
-
-        if matches!(param.kind, hir::GenericParamKind::Type { default: Some(_), .. })
-            && generics.where_clause.predicates.len() == 0
+        if generics.where_clause.predicates.is_empty()
+        // Given `trait Base<T = String>: Super<T>` where `T: Copy`, suggest restricting in the
+        // `where` clause instead of `trait Base<T: Copy = String>: Super<T>`.
+        && !matches!(param.kind, hir::GenericParamKind::Type { default: Some(_), .. })
         {
-            // Suggest a bound, but there is no existing `where` clause *and* the type param has a
-            // default (`<T=Foo>`), so we suggest adding `where T: Bar`.
-            err.span_suggestion_verbose(
-                generics.where_clause.tail_span_for_suggestion(),
-                &msg_restrict_type_further,
-                format!(" where {}: {}", param_name, constraint),
-                Applicability::MachineApplicable,
-            );
+            if let Some(span) = param.bounds_span_for_suggestions() {
+                // If user has provided some bounds, suggest restricting them:
+                //
+                //   fn foo<T: Foo>(t: T) { ... }
+                //             ---
+                //             |
+                //             help: consider further restricting this bound with `+ Bar`
+                //
+                // Suggestion for tools in this case is:
+                //
+                //   fn foo<T: Foo>(t: T) { ... }
+                //          --
+                //          |
+                //          replace with: `T: Bar +`
+                suggest_restrict(span);
+            } else {
+                // If user hasn't provided any bounds, suggest adding a new one:
+                //
+                //   fn foo<T>(t: T) { ... }
+                //          - help: consider restricting this type parameter with `T: Foo`
+                suggestions.push((
+                    param.span.shrink_to_hi(),
+                    format!(": {}", constraint),
+                    SuggestChangingConstraintsMessage::RestrictType { ty: param_name },
+                ));
+            }
         } else {
-            let mut param_spans = Vec::new();
+            // This part is a bit tricky, because using the `where` clause user can
+            // provide zero, one or many bounds for the same type parameter, so we
+            // have following cases to consider:
+            //
+            // 1) When the type parameter has been provided zero bounds
+            //
+            //    Message:
+            //      fn foo<X, Y>(x: X, y: Y) where Y: Foo { ... }
+            //             - help: consider restricting this type parameter with `where X: Bar`
+            //
+            //    Suggestion:
+            //      fn foo<X, Y>(x: X, y: Y) where Y: Foo { ... }
+            //                                           - insert: `, X: Bar`
+            //
+            //
+            // 2) When the type parameter has been provided one bound
+            //
+            //    Message:
+            //      fn foo<T>(t: T) where T: Foo { ... }
+            //                            ^^^^^^
+            //                            |
+            //                            help: consider further restricting this bound with `+ Bar`
+            //
+            //    Suggestion:
+            //      fn foo<T>(t: T) where T: Foo { ... }
+            //                            ^^
+            //                            |
+            //                            replace with: `T: Bar +`
+            //
+            //
+            // 3) When the type parameter has been provided many bounds
+            //
+            //    Message:
+            //      fn foo<T>(t: T) where T: Foo, T: Bar {... }
+            //             - help: consider further restricting this type parameter with `where T: Zar`
+            //
+            //    Suggestion:
+            //      fn foo<T>(t: T) where T: Foo, T: Bar {... }
+            //                                          - insert: `, T: Zar`
+            //
+            // Additionally, there may be no `where` clause whatsoever in the case that this was
+            // reached because the generic parameter has a default:
+            //
+            //    Message:
+            //      trait Foo<T=()> {... }
+            //             - help: consider further restricting this type parameter with `where T: Zar`
+            //
+            //    Suggestion:
+            //      trait Foo<T=()> where T: Zar {... }
+            //                     - insert: `where T: Zar`
 
-            for predicate in generics.where_clause.predicates {
-                if let WherePredicate::BoundPredicate(WhereBoundPredicate {
-                    span,
-                    bounded_ty,
-                    ..
-                }) = predicate
-                {
-                    if let TyKind::Path(QPath::Resolved(_, path)) = &bounded_ty.kind {
-                        if let Some(segment) = path.segments.first() {
-                            if segment.ident.to_string() == param_name {
-                                param_spans.push(span);
+            if matches!(param.kind, hir::GenericParamKind::Type { default: Some(_), .. })
+                && generics.where_clause.predicates.len() == 0
+            {
+                // Suggest a bound, but there is no existing `where` clause *and* the type param has a
+                // default (`<T=Foo>`), so we suggest adding `where T: Bar`.
+                suggestions.push((
+                    generics.where_clause.tail_span_for_suggestion(),
+                    format!(" where {}: {}", param_name, constraint),
+                    SuggestChangingConstraintsMessage::RestrictTypeFurther { ty: param_name },
+                ));
+            } else {
+                let mut param_spans = Vec::new();
+
+                for predicate in generics.where_clause.predicates {
+                    if let WherePredicate::BoundPredicate(WhereBoundPredicate {
+                        span,
+                        bounded_ty,
+                        ..
+                    }) = predicate
+                    {
+                        if let TyKind::Path(QPath::Resolved(_, path)) = &bounded_ty.kind {
+                            if let Some(segment) = path.segments.first() {
+                                if segment.ident.to_string() == param_name {
+                                    param_spans.push(span);
+                                }
                             }
                         }
                     }
                 }
-            }
 
-            match param_spans[..] {
-                [&param_span] => suggest_restrict(param_span.shrink_to_hi()),
-                _ => {
-                    err.span_suggestion_verbose(
-                        generics.where_clause.tail_span_for_suggestion(),
-                        &msg_restrict_type_further,
-                        format!(", {}: {}", param_name, constraint),
-                        Applicability::MachineApplicable,
-                    );
+                match param_spans[..] {
+                    [&param_span] => suggest_restrict(param_span.shrink_to_hi()),
+                    _ => {
+                        suggestions.push((
+                            generics.where_clause.tail_span_for_suggestion(),
+                            constraints
+                                .iter()
+                                .map(|&(constraint, _)| format!(", {}: {}", param_name, constraint))
+                                .collect::<String>(),
+                            SuggestChangingConstraintsMessage::RestrictTypeFurther {
+                                ty: param_name,
+                            },
+                        ));
+                    }
                 }
             }
         }
-
-        true
     }
+
+    if suggestions.len() == 1 {
+        let (span, suggestion, msg) = suggestions.pop().unwrap();
+
+        let s;
+        let msg = match msg {
+            SuggestChangingConstraintsMessage::RestrictBoundFurther => {
+                "consider further restricting this bound"
+            }
+            SuggestChangingConstraintsMessage::RestrictType { ty } => {
+                s = format!("consider restricting type parameter `{}`", ty);
+                &s
+            }
+            SuggestChangingConstraintsMessage::RestrictTypeFurther { ty } => {
+                s = format!("consider further restricting type parameter `{}`", ty);
+                &s
+            }
+            SuggestChangingConstraintsMessage::RemovingQSized => {
+                "consider removing the `?Sized` bound to make the type parameter `Sized`"
+            }
+        };
+
+        err.span_suggestion_verbose(span, msg, suggestion, applicability);
+    } else {
+        err.multipart_suggestion_verbose(
+            "consider restricting type parameters",
+            suggestions.into_iter().map(|(span, suggestion, _)| (span, suggestion)).collect(),
+            applicability,
+        );
+    }
+
+    true
 }
 
 /// Collect al types that have an implicit `'static` obligation that we could suggest `'_` for.

--- a/compiler/rustc_mir_transform/src/const_prop.rs
+++ b/compiler/rustc_mir_transform/src/const_prop.rs
@@ -1200,12 +1200,21 @@ impl<'tcx> MutVisitor<'tcx> for ConstPropagator<'_, 'tcx> {
                             AssertKind::RemainderByZero(op) => {
                                 Some(AssertKind::RemainderByZero(eval_to_int(op)))
                             }
+                            AssertKind::Overflow(bin_op @ (BinOp::Div | BinOp::Rem), op1, op2) => {
+                                // Division overflow is *UB* in the MIR, and different than the
+                                // other overflow checks.
+                                Some(AssertKind::Overflow(
+                                    *bin_op,
+                                    eval_to_int(op1),
+                                    eval_to_int(op2),
+                                ))
+                            }
                             AssertKind::BoundsCheck { ref len, ref index } => {
                                 let len = eval_to_int(len);
                                 let index = eval_to_int(index);
                                 Some(AssertKind::BoundsCheck { len, index })
                             }
-                            // Overflow is are already covered by checks on the binary operators.
+                            // Remaining overflow errors are already covered by checks on the binary operators.
                             AssertKind::Overflow(..) | AssertKind::OverflowNeg(_) => None,
                             // Need proper const propagator for these.
                             _ => None,

--- a/compiler/rustc_passes/src/entry.rs
+++ b/compiler/rustc_passes/src/entry.rs
@@ -218,9 +218,9 @@ fn no_main_err(tcx: TyCtxt<'_>, visitor: &EntryContext<'_, '_>) {
     // The file may be empty, which leads to the diagnostic machinery not emitting this
     // note. This is a relatively simple way to detect that case and emit a span-less
     // note instead.
-    if tcx.sess.source_map().lookup_line(sp.lo()).is_ok() {
-        err.set_span(sp);
-        err.span_label(sp, &note);
+    if tcx.sess.source_map().lookup_line(sp.hi()).is_ok() {
+        err.set_span(sp.shrink_to_hi());
+        err.span_label(sp.shrink_to_hi(), &note);
     } else {
         err.note(&note);
     }

--- a/compiler/rustc_passes/src/stability.rs
+++ b/compiler/rustc_passes/src/stability.rs
@@ -712,7 +712,16 @@ fn check_mod_unstable_api_usage(tcx: TyCtxt<'_>, module_def_id: LocalDefId) {
 }
 
 pub(crate) fn provide(providers: &mut Providers) {
-    *providers = Providers { check_mod_unstable_api_usage, stability_index, ..*providers };
+    *providers = Providers {
+        check_mod_unstable_api_usage,
+        stability_index,
+        lookup_stability: |tcx, id| tcx.stability().local_stability(id.expect_local()),
+        lookup_const_stability: |tcx, id| tcx.stability().local_const_stability(id.expect_local()),
+        lookup_deprecation_entry: |tcx, id| {
+            tcx.stability().local_deprecation_entry(id.expect_local())
+        },
+        ..*providers
+    };
 }
 
 struct Checker<'tcx> {

--- a/compiler/rustc_passes/src/stability.rs
+++ b/compiler/rustc_passes/src/stability.rs
@@ -2,7 +2,7 @@
 //! propagating default levels lexically from parent to children ast nodes.
 
 use rustc_attr::{self as attr, ConstStability, Stability};
-use rustc_data_structures::fx::{FxHashMap, FxHashSet};
+use rustc_data_structures::fx::{FxHashSet, FxIndexMap};
 use rustc_errors::struct_span_err;
 use rustc_hir as hir;
 use rustc_hir::def::{DefKind, Res};
@@ -854,7 +854,7 @@ pub fn check_unused_or_stable_features(tcx: TyCtxt<'_>) {
     }
 
     let declared_lib_features = &tcx.features().declared_lib_features;
-    let mut remaining_lib_features = FxHashMap::default();
+    let mut remaining_lib_features = FxIndexMap::default();
     for (feature, span) in declared_lib_features {
         if !tcx.sess.opts.unstable_features.is_nightly_build() {
             struct_span_err!(
@@ -881,7 +881,7 @@ pub fn check_unused_or_stable_features(tcx: TyCtxt<'_>) {
     remaining_lib_features.remove(&sym::libc);
     remaining_lib_features.remove(&sym::test);
 
-    let check_features = |remaining_lib_features: &mut FxHashMap<_, _>, defined_features: &[_]| {
+    let check_features = |remaining_lib_features: &mut FxIndexMap<_, _>, defined_features: &[_]| {
         for &(feature, since) in defined_features {
             if let Some(since) = since {
                 if let Some(span) = remaining_lib_features.get(&feature) {

--- a/compiler/rustc_passes/src/stability.rs
+++ b/compiler/rustc_passes/src/stability.rs
@@ -1,7 +1,6 @@
 //! A pass that annotates every item and method with its stability level,
 //! propagating default levels lexically from parent to children ast nodes.
 
-use rustc_ast::Attribute;
 use rustc_attr::{self as attr, ConstStability, Stability};
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_errors::struct_span_err;
@@ -113,12 +112,8 @@ impl<'a, 'tcx> Annotator<'a, 'tcx> {
     {
         let attrs = self.tcx.get_attrs(def_id.to_def_id());
         debug!("annotate(id = {:?}, attrs = {:?})", def_id, attrs);
-        let mut did_error = false;
-        if !self.tcx.features().staged_api {
-            did_error = self.forbid_staged_api_attrs(def_id, attrs, inherit_deprecation.clone());
-        }
 
-        let depr = if did_error { None } else { attr::find_deprecation(&self.tcx.sess, attrs) };
+        let depr = attr::find_deprecation(&self.tcx.sess, attrs);
         let mut is_deprecated = false;
         if let Some((depr, span)) = &depr {
             is_deprecated = true;
@@ -148,16 +143,15 @@ impl<'a, 'tcx> Annotator<'a, 'tcx> {
             }
         }
 
-        if self.tcx.features().staged_api {
-            if let Some(a) = attrs.iter().find(|a| a.has_name(sym::deprecated)) {
-                self.tcx
-                    .sess
-                    .struct_span_err(a.span, "`#[deprecated]` cannot be used in staged API")
-                    .span_label(a.span, "use `#[rustc_deprecated]` instead")
-                    .span_label(item_sp, "")
-                    .emit();
+        if !self.tcx.features().staged_api {
+            // Propagate unstability.  This can happen even for non-staged-api crates in case
+            // -Zforce-unstable-if-unmarked is set.
+            if let Some(stab) = self.parent_stab {
+                if inherit_deprecation.yes() && stab.level.is_unstable() {
+                    self.index.stab_map.insert(def_id, stab);
+                }
             }
-        } else {
+
             self.recurse_with_stability_attrs(
                 depr.map(|(d, _)| DeprecationEntry::local(d, def_id)),
                 None,
@@ -328,47 +322,6 @@ impl<'a, 'tcx> Annotator<'a, 'tcx> {
         if let Some(orig_parent_const_stab) = replaced_parent_const_stab {
             self.parent_const_stab = orig_parent_const_stab;
         }
-    }
-
-    // returns true if an error occurred, used to suppress some spurious errors
-    fn forbid_staged_api_attrs(
-        &mut self,
-        def_id: LocalDefId,
-        attrs: &[Attribute],
-        inherit_deprecation: InheritDeprecation,
-    ) -> bool {
-        // Emit errors for non-staged-api crates.
-        let unstable_attrs = [
-            sym::unstable,
-            sym::stable,
-            sym::rustc_deprecated,
-            sym::rustc_const_unstable,
-            sym::rustc_const_stable,
-        ];
-        let mut has_error = false;
-        for attr in attrs {
-            let name = attr.name_or_empty();
-            if unstable_attrs.contains(&name) {
-                struct_span_err!(
-                    self.tcx.sess,
-                    attr.span,
-                    E0734,
-                    "stability attributes may not be used outside of the standard library",
-                )
-                .emit();
-                has_error = true;
-            }
-        }
-
-        // Propagate unstability.  This can happen even for non-staged-api crates in case
-        // -Zforce-unstable-if-unmarked is set.
-        if let Some(stab) = self.parent_stab {
-            if inherit_deprecation.yes() && stab.level.is_unstable() {
-                self.index.stab_map.insert(def_id, stab);
-            }
-        }
-
-        has_error
     }
 }
 

--- a/compiler/rustc_passes/src/stability.rs
+++ b/compiler/rustc_passes/src/stability.rs
@@ -663,18 +663,7 @@ fn stability_index(tcx: TyCtxt<'_>, (): ()) -> Index {
         stab_map: Default::default(),
         const_stab_map: Default::default(),
         depr_map: Default::default(),
-        active_features: Default::default(),
     };
-
-    let active_lib_features = &tcx.features().declared_lib_features;
-    let active_lang_features = &tcx.features().declared_lang_features;
-
-    // Put the active features into a map for quick lookup.
-    index.active_features = active_lib_features
-        .iter()
-        .map(|&(s, ..)| s)
-        .chain(active_lang_features.iter().map(|&(s, ..)| s))
-        .collect();
 
     {
         let mut annotator = Annotator {

--- a/compiler/rustc_passes/src/stability.rs
+++ b/compiler/rustc_passes/src/stability.rs
@@ -7,7 +7,7 @@ use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_errors::struct_span_err;
 use rustc_hir as hir;
 use rustc_hir::def::{DefKind, Res};
-use rustc_hir::def_id::{DefId, LocalDefId, CRATE_DEF_ID, CRATE_DEF_INDEX, LOCAL_CRATE};
+use rustc_hir::def_id::{DefId, LocalDefId, CRATE_DEF_ID, CRATE_DEF_INDEX};
 use rustc_hir::hir_id::CRATE_HIR_ID;
 use rustc_hir::intravisit::{self, Visitor};
 use rustc_hir::{FieldDef, Generics, HirId, Item, TraitRef, Ty, TyKind, Variant};
@@ -654,12 +654,7 @@ impl<'tcx> Visitor<'tcx> for MissingStabilityAnnotations<'tcx> {
 }
 
 fn stability_index(tcx: TyCtxt<'_>, (): ()) -> Index {
-    let is_staged_api =
-        tcx.sess.opts.debugging_opts.force_unstable_if_unmarked || tcx.features().staged_api;
-    let mut staged_api = FxHashMap::default();
-    staged_api.insert(LOCAL_CRATE, is_staged_api);
     let mut index = Index {
-        staged_api,
         stab_map: Default::default(),
         const_stab_map: Default::default(),
         depr_map: Default::default(),
@@ -873,9 +868,10 @@ impl<'tcx> Visitor<'tcx> for CheckTraitImplStable<'tcx> {
 /// were expected to be library features), and the list of features used from
 /// libraries, identify activated features that don't exist and error about them.
 pub fn check_unused_or_stable_features(tcx: TyCtxt<'_>) {
-    let access_levels = &tcx.privacy_access_levels(());
-
-    if tcx.stability().staged_api[&LOCAL_CRATE] {
+    let is_staged_api =
+        tcx.sess.opts.debugging_opts.force_unstable_if_unmarked || tcx.features().staged_api;
+    if is_staged_api {
+        let access_levels = &tcx.privacy_access_levels(());
         let mut missing = MissingStabilityAnnotations { tcx, access_levels };
         missing.check_missing_stability(CRATE_DEF_ID, tcx.hir().span(CRATE_HIR_ID));
         tcx.hir().walk_toplevel_module(&mut missing);

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -539,6 +539,7 @@ symbols! {
         custom_inner_attributes,
         custom_test_frameworks,
         d,
+        d32,
         dbg_macro,
         dead_code,
         dealloc,

--- a/compiler/rustc_target/src/asm/arm.rs
+++ b/compiler/rustc_target/src/asm/arm.rs
@@ -50,8 +50,11 @@ impl ArmInlineAsmRegClass {
         match self {
             Self::reg => types! { _: I8, I16, I32, F32; },
             Self::sreg | Self::sreg_low16 => types! { vfp2: I32, F32; },
-            Self::dreg | Self::dreg_low16 | Self::dreg_low8 => types! {
+            Self::dreg_low16 | Self::dreg_low8 => types! {
                 vfp2: I64, F64, VecI8(8), VecI16(4), VecI32(2), VecI64(1), VecF32(2);
+            },
+            Self::dreg => types! {
+                d32: I64, F64, VecI8(8), VecI16(4), VecI32(2), VecI64(1), VecF32(2);
             },
             Self::qreg | Self::qreg_low8 | Self::qreg_low4 => types! {
                 neon: VecI8(16), VecI16(8), VecI32(4), VecI64(2), VecF32(4);

--- a/library/core/src/mem/maybe_uninit.rs
+++ b/library/core/src/mem/maybe_uninit.rs
@@ -817,6 +817,7 @@ impl<T> MaybeUninit<T> {
     /// ### Correct usage of this method:
     ///
     /// ```rust
+    /// # #![allow(unexpected_cfgs)]
     /// use std::mem::MaybeUninit;
     ///
     /// # unsafe extern "C" fn initialize_buffer(buf: *mut [u8; 1024]) { *buf = [0; 1024] }

--- a/library/core/tests/num/wrapping.rs
+++ b/library/core/tests/num/wrapping.rs
@@ -308,3 +308,13 @@ fn wrapping_int_api() {
         }
     }
 }
+
+#[test]
+fn wrapping_const() {
+    // Specifically the wrapping behavior of division and remainder is subtle,
+    // see https://github.com/rust-lang/rust/pull/94512.
+    const _: () = {
+        assert!(i32::MIN.wrapping_div(-1) == i32::MIN);
+        assert!(i32::MIN.wrapping_rem(-1) == 0);
+    };
+}

--- a/library/std/src/os/windows/fs.rs
+++ b/library/std/src/os/windows/fs.rs
@@ -158,6 +158,7 @@ pub trait OpenOptionsExt {
     /// # Examples
     ///
     /// ```no_run
+    /// # #![allow(unexpected_cfgs)]
     /// # #[cfg(for_demonstration_only)]
     /// extern crate winapi;
     /// # mod winapi { pub const FILE_FLAG_DELETE_ON_CLOSE: u32 = 0x04000000; }
@@ -195,6 +196,7 @@ pub trait OpenOptionsExt {
     /// # Examples
     ///
     /// ```no_run
+    /// # #![allow(unexpected_cfgs)]
     /// # #[cfg(for_demonstration_only)]
     /// extern crate winapi;
     /// # mod winapi { pub const FILE_ATTRIBUTE_HIDDEN: u32 = 2; }
@@ -236,6 +238,7 @@ pub trait OpenOptionsExt {
     /// # Examples
     ///
     /// ```no_run
+    /// # #![allow(unexpected_cfgs)]
     /// # #[cfg(for_demonstration_only)]
     /// extern crate winapi;
     /// # mod winapi { pub const SECURITY_IDENTIFICATION: u32 = 0; }

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -26,6 +26,7 @@ use crate::run;
 use crate::test;
 use crate::tool::{self, SourceType};
 use crate::util::{self, add_dylib_path, add_link_lib_path, exe, libdir};
+use crate::EXTRA_CHECK_CFGS;
 use crate::{Build, DocTests, GitRepo, Mode};
 
 pub use crate::Compiler;
@@ -1093,6 +1094,33 @@ impl<'a> Builder<'a> {
         } else {
             rustflags.arg("-Csymbol-mangling-version=legacy");
             rustflags.arg("-Zunstable-options");
+        }
+
+        // #[cfg(not(bootstrap)]
+        if stage != 0 {
+            // Enable cfg checking of cargo features
+            // FIXME: De-comment this when cargo beta get support for it
+            // cargo.arg("-Zcheck-cfg-features");
+
+            // Enable cfg checking of rustc well-known names
+            rustflags.arg("-Zunstable-options").arg("--check-cfg=names()");
+
+            // Add extra cfg not defined in rustc
+            for (restricted_mode, name, values) in EXTRA_CHECK_CFGS {
+                if *restricted_mode == None || *restricted_mode == Some(mode) {
+                    // Creating a string of the values by concatenating each value:
+                    // ',"tvos","watchos"' or '' (nothing) when there are no values
+                    let values = match values {
+                        Some(values) => values
+                            .iter()
+                            .map(|val| [",", "\"", val, "\""])
+                            .flatten()
+                            .collect::<String>(),
+                        None => String::new(),
+                    };
+                    rustflags.arg(&format!("--check-cfg=values({name}{values})"));
+                }
+            }
         }
 
         // FIXME: It might be better to use the same value for both `RUSTFLAGS` and `RUSTDOCFLAGS`,

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -186,6 +186,25 @@ const LLVM_TOOLS: &[&str] = &[
 
 pub const VERSION: usize = 2;
 
+/// Extra --check-cfg to add when building
+/// (Mode restriction, config name, config values (if any))
+const EXTRA_CHECK_CFGS: &[(Option<Mode>, &'static str, Option<&[&'static str]>)] = &[
+    (None, "bootstrap", None),
+    (Some(Mode::Rustc), "parallel_compiler", None),
+    (Some(Mode::ToolRustc), "parallel_compiler", None),
+    // FIXME: Used by rustfmt is their test but is invalid (neither cargo nor bootstrap ever set
+    // this config) should probably by removed or use a allow attribute.
+    (Some(Mode::ToolRustc), "release", None),
+    (Some(Mode::Std), "miri", None),
+    (Some(Mode::Std), "stdarch_intel_sde", None),
+    (Some(Mode::Std), "no_fp_fmt_parse", None),
+    (Some(Mode::Std), "no_global_oom_handling", None),
+    (Some(Mode::Std), "freebsd12", None),
+    (Some(Mode::Std), "backtrace_in_libstd", None),
+    // FIXME: Used by stdarch in their test, should use a allow attribute instead.
+    (Some(Mode::Std), "dont_compile_me", None),
+];
+
 /// A structure representing a Rust compiler.
 ///
 /// Each compiler has a `stage` that it is associated with and a `host` that

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -139,7 +139,7 @@ target | std | notes
 `armv7r-none-eabi` | * | Bare ARMv7-R
 `armv7r-none-eabihf` | * | Bare ARMv7-R, hardfloat
 `asmjs-unknown-emscripten` | ✓ | asm.js via Emscripten
-`i586-pc-windows-msvc` | ✓ | 32-bit Windows w/o SSE
+`i586-pc-windows-msvc` | * | 32-bit Windows w/o SSE
 `i586-unknown-linux-gnu` | ✓ | 32-bit Linux w/o SSE (kernel 4.4, glibc 2.23)
 `i586-unknown-linux-musl` | ✓ | 32-bit Linux w/o SSE, MUSL
 `i686-linux-android` | ✓ | 32-bit x86 Android
@@ -236,7 +236,7 @@ target | std | host | notes
 `hexagon-unknown-linux-musl` | ? |  |
 `i386-apple-ios` | ✓ |  | 32-bit x86 iOS
 `i686-apple-darwin` | ✓ | ✓ | 32-bit macOS (10.7+, Lion+)
-`i686-pc-windows-msvc` | ✓ |  | 32-bit Windows XP support
+`i686-pc-windows-msvc` | * |  | 32-bit Windows XP support
 `i686-unknown-haiku` | ✓ | ✓ | 32-bit Haiku
 `i686-unknown-netbsd` | ✓ | ✓ | NetBSD/i386 with SSE2
 [`i686-unknown-openbsd`](platform-support/openbsd.md) | ✓ | ✓ | 32-bit OpenBSD
@@ -283,7 +283,7 @@ target | std | host | notes
 [`wasm64-unknown-unknown`](platform-support/wasm64-unknown-unknown.md) | ? |  | WebAssembly
 `x86_64-apple-ios-macabi` | ✓ |  | Apple Catalyst on x86_64
 `x86_64-apple-tvos` | * | | x86 64-bit tvOS
-`x86_64-pc-windows-msvc` | ✓ |  | 64-bit Windows XP support
+`x86_64-pc-windows-msvc` | * |  | 64-bit Windows XP support
 `x86_64-sun-solaris` | ? |  | Deprecated target for 64-bit Solaris 10/11, illumos
 `x86_64-unknown-dragonfly` | ✓ | ✓ | 64-bit DragonFlyBSD
 `x86_64-unknown-haiku` | ✓ | ✓ | 64-bit Haiku

--- a/src/test/ui/alloc-error/alloc-error-handler-bad-signature-1.rs
+++ b/src/test/ui/alloc-error/alloc-error-handler-bad-signature-1.rs
@@ -1,6 +1,6 @@
 // compile-flags:-C panic=abort
 
-#![feature(alloc_error_handler, panic_handler)]
+#![feature(alloc_error_handler)]
 #![no_std]
 #![no_main]
 

--- a/src/test/ui/alloc-error/alloc-error-handler-bad-signature-2.rs
+++ b/src/test/ui/alloc-error/alloc-error-handler-bad-signature-2.rs
@@ -1,6 +1,6 @@
 // compile-flags:-C panic=abort
 
-#![feature(alloc_error_handler, panic_handler)]
+#![feature(alloc_error_handler)]
 #![no_std]
 #![no_main]
 

--- a/src/test/ui/alloc-error/alloc-error-handler-bad-signature-3.rs
+++ b/src/test/ui/alloc-error/alloc-error-handler-bad-signature-3.rs
@@ -1,6 +1,6 @@
 // compile-flags:-C panic=abort
 
-#![feature(alloc_error_handler, panic_handler)]
+#![feature(alloc_error_handler)]
 #![no_std]
 #![no_main]
 

--- a/src/test/ui/asm/naked-functions.rs
+++ b/src/test/ui/asm/naked-functions.rs
@@ -4,7 +4,6 @@
 // ignore-wasm32
 
 #![feature(naked_functions)]
-#![feature(or_patterns)]
 #![feature(asm_const, asm_sym, asm_unwind)]
 #![crate_type = "lib"]
 

--- a/src/test/ui/asm/naked-functions.stderr
+++ b/src/test/ui/asm/naked-functions.stderr
@@ -1,35 +1,35 @@
 error: asm with the `pure` option must have at least one output
-  --> $DIR/naked-functions.rs:111:14
+  --> $DIR/naked-functions.rs:110:14
    |
 LL |     asm!("", options(readonly, nostack), options(pure));
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^
 
 error: patterns not allowed in naked function parameters
-  --> $DIR/naked-functions.rs:21:5
+  --> $DIR/naked-functions.rs:20:5
    |
 LL |     mut a: u32,
    |     ^^^^^
 
 error: patterns not allowed in naked function parameters
-  --> $DIR/naked-functions.rs:23:5
+  --> $DIR/naked-functions.rs:22:5
    |
 LL |     &b: &i32,
    |     ^^
 
 error: patterns not allowed in naked function parameters
-  --> $DIR/naked-functions.rs:25:6
+  --> $DIR/naked-functions.rs:24:6
    |
 LL |     (None | Some(_)): Option<std::ptr::NonNull<u8>>,
    |      ^^^^^^^^^^^^^^
 
 error: patterns not allowed in naked function parameters
-  --> $DIR/naked-functions.rs:27:5
+  --> $DIR/naked-functions.rs:26:5
    |
 LL |     P { x, y }: P,
    |     ^^^^^^^^^^
 
 error: referencing function parameters is not allowed in naked functions
-  --> $DIR/naked-functions.rs:36:5
+  --> $DIR/naked-functions.rs:35:5
    |
 LL |     a + 1
    |     ^
@@ -37,7 +37,7 @@ LL |     a + 1
    = help: follow the calling convention in asm block to use parameters
 
 error[E0787]: naked functions must contain a single asm block
-  --> $DIR/naked-functions.rs:34:1
+  --> $DIR/naked-functions.rs:33:1
    |
 LL | / pub unsafe extern "C" fn inc(a: u32) -> u32 {
 LL | |
@@ -48,7 +48,7 @@ LL | | }
    | |_^
 
 error: referencing function parameters is not allowed in naked functions
-  --> $DIR/naked-functions.rs:42:31
+  --> $DIR/naked-functions.rs:41:31
    |
 LL |     asm!("/* {0} */", in(reg) a, options(noreturn));
    |                               ^
@@ -56,13 +56,13 @@ LL |     asm!("/* {0} */", in(reg) a, options(noreturn));
    = help: follow the calling convention in asm block to use parameters
 
 error[E0787]: only `const` and `sym` operands are supported in naked functions
-  --> $DIR/naked-functions.rs:42:23
+  --> $DIR/naked-functions.rs:41:23
    |
 LL |     asm!("/* {0} */", in(reg) a, options(noreturn));
    |                       ^^^^^^^^^
 
 error[E0787]: naked functions must contain a single asm block
-  --> $DIR/naked-functions.rs:48:1
+  --> $DIR/naked-functions.rs:47:1
    |
 LL | / pub unsafe extern "C" fn inc_closure(a: u32) -> u32 {
 LL | |
@@ -72,7 +72,7 @@ LL | | }
    | |_^
 
 error[E0787]: only `const` and `sym` operands are supported in naked functions
-  --> $DIR/naked-functions.rs:65:10
+  --> $DIR/naked-functions.rs:64:10
    |
 LL |          in(reg) a,
    |          ^^^^^^^^^
@@ -87,7 +87,7 @@ LL |          out(reg) e,
    |          ^^^^^^^^^^
 
 error[E0787]: asm in naked functions must use `noreturn` option
-  --> $DIR/naked-functions.rs:63:5
+  --> $DIR/naked-functions.rs:62:5
    |
 LL | /     asm!("/* {0} {1} {2} {3} {4} {5} {6} */",
 LL | |
@@ -99,7 +99,7 @@ LL | |     );
    | |_____^
 
 error[E0787]: naked functions must contain a single asm block
-  --> $DIR/naked-functions.rs:54:1
+  --> $DIR/naked-functions.rs:53:1
    |
 LL | / pub unsafe extern "C" fn unsupported_operands() {
 LL | |
@@ -119,7 +119,7 @@ LL | | }
    | |_^
 
 error[E0787]: naked functions must contain a single asm block
-  --> $DIR/naked-functions.rs:77:1
+  --> $DIR/naked-functions.rs:76:1
    |
 LL | / pub extern "C" fn missing_assembly() {
 LL | |
@@ -127,25 +127,25 @@ LL | | }
    | |_^
 
 error[E0787]: asm in naked functions must use `noreturn` option
-  --> $DIR/naked-functions.rs:84:5
+  --> $DIR/naked-functions.rs:83:5
    |
 LL |     asm!("");
    |     ^^^^^^^^
 
 error[E0787]: asm in naked functions must use `noreturn` option
-  --> $DIR/naked-functions.rs:86:5
+  --> $DIR/naked-functions.rs:85:5
    |
 LL |     asm!("");
    |     ^^^^^^^^
 
 error[E0787]: asm in naked functions must use `noreturn` option
-  --> $DIR/naked-functions.rs:88:5
+  --> $DIR/naked-functions.rs:87:5
    |
 LL |     asm!("");
    |     ^^^^^^^^
 
 error[E0787]: naked functions must contain a single asm block
-  --> $DIR/naked-functions.rs:82:1
+  --> $DIR/naked-functions.rs:81:1
    |
 LL | / pub extern "C" fn too_many_asm_blocks() {
 LL | |
@@ -163,7 +163,7 @@ LL | | }
    | |_^
 
 error: referencing function parameters is not allowed in naked functions
-  --> $DIR/naked-functions.rs:97:11
+  --> $DIR/naked-functions.rs:96:11
    |
 LL |         *&y
    |           ^
@@ -171,7 +171,7 @@ LL |         *&y
    = help: follow the calling convention in asm block to use parameters
 
 error[E0787]: naked functions must contain a single asm block
-  --> $DIR/naked-functions.rs:95:5
+  --> $DIR/naked-functions.rs:94:5
    |
 LL | /     pub extern "C" fn inner(y: usize) -> usize {
 LL | |
@@ -182,31 +182,31 @@ LL | |     }
    | |_____^
 
 error[E0787]: asm options unsupported in naked functions: `nomem`, `preserves_flags`
-  --> $DIR/naked-functions.rs:105:5
+  --> $DIR/naked-functions.rs:104:5
    |
 LL |     asm!("", options(nomem, preserves_flags, noreturn));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0787]: asm options unsupported in naked functions: `nostack`, `pure`, `readonly`
-  --> $DIR/naked-functions.rs:111:5
+  --> $DIR/naked-functions.rs:110:5
    |
 LL |     asm!("", options(readonly, nostack), options(pure));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0787]: asm in naked functions must use `noreturn` option
-  --> $DIR/naked-functions.rs:111:5
+  --> $DIR/naked-functions.rs:110:5
    |
 LL |     asm!("", options(readonly, nostack), options(pure));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0787]: asm options unsupported in naked functions: `may_unwind`
-  --> $DIR/naked-functions.rs:119:5
+  --> $DIR/naked-functions.rs:118:5
    |
 LL |     asm!("", options(noreturn, may_unwind));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: Rust ABI is unsupported in naked functions
-  --> $DIR/naked-functions.rs:124:15
+  --> $DIR/naked-functions.rs:123:15
    |
 LL | pub unsafe fn default_abi() {
    |               ^^^^^^^^^^^
@@ -214,43 +214,43 @@ LL | pub unsafe fn default_abi() {
    = note: `#[warn(undefined_naked_function_abi)]` on by default
 
 warning: Rust ABI is unsupported in naked functions
-  --> $DIR/naked-functions.rs:130:15
+  --> $DIR/naked-functions.rs:129:15
    |
 LL | pub unsafe fn rust_abi() {
    |               ^^^^^^^^
 
 error: naked functions cannot be inlined
-  --> $DIR/naked-functions.rs:170:1
+  --> $DIR/naked-functions.rs:169:1
    |
 LL | #[inline]
    | ^^^^^^^^^
 
 error: naked functions cannot be inlined
-  --> $DIR/naked-functions.rs:177:1
+  --> $DIR/naked-functions.rs:176:1
    |
 LL | #[inline(always)]
    | ^^^^^^^^^^^^^^^^^
 
 error: naked functions cannot be inlined
-  --> $DIR/naked-functions.rs:184:1
+  --> $DIR/naked-functions.rs:183:1
    |
 LL | #[inline(never)]
    | ^^^^^^^^^^^^^^^^
 
 error: naked functions cannot be inlined
-  --> $DIR/naked-functions.rs:191:1
+  --> $DIR/naked-functions.rs:190:1
    |
 LL | #[inline]
    | ^^^^^^^^^
 
 error: naked functions cannot be inlined
-  --> $DIR/naked-functions.rs:193:1
+  --> $DIR/naked-functions.rs:192:1
    |
 LL | #[inline(always)]
    | ^^^^^^^^^^^^^^^^^
 
 error: naked functions cannot be inlined
-  --> $DIR/naked-functions.rs:195:1
+  --> $DIR/naked-functions.rs:194:1
    |
 LL | #[inline(never)]
    | ^^^^^^^^^^^^^^^^

--- a/src/test/ui/associated-consts/associated-const-in-trait.rs
+++ b/src/test/ui/associated-consts/associated-const-in-trait.rs
@@ -1,7 +1,5 @@
 // #29924
 
-#![feature(associated_consts)]
-
 trait Trait {
     const N: usize;
 }

--- a/src/test/ui/associated-consts/associated-const-in-trait.stderr
+++ b/src/test/ui/associated-consts/associated-const-in-trait.stderr
@@ -1,11 +1,11 @@
 error[E0038]: the trait `Trait` cannot be made into an object
-  --> $DIR/associated-const-in-trait.rs:9:6
+  --> $DIR/associated-const-in-trait.rs:7:6
    |
 LL | impl dyn Trait {
    |      ^^^^^^^^^ `Trait` cannot be made into an object
    |
 note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
-  --> $DIR/associated-const-in-trait.rs:6:11
+  --> $DIR/associated-const-in-trait.rs:4:11
    |
 LL | trait Trait {
    |       ----- this trait cannot be made into an object...

--- a/src/test/ui/async-await/try-on-option-in-async.rs
+++ b/src/test/ui/async-await/try-on-option-in-async.rs
@@ -1,4 +1,4 @@
-#![feature(try_trait, async_closure)]
+#![feature(async_closure)]
 // edition:2018
 fn main() {}
 

--- a/src/test/ui/attributes/const-stability-on-macro.rs
+++ b/src/test/ui/attributes/const-stability-on-macro.rs
@@ -1,3 +1,6 @@
+#![feature(staged_api)]
+#![stable(feature = "rust1", since = "1.0.0")]
+
 #[rustc_const_stable(feature = "foo", since = "0")]
 //~^ ERROR macros cannot have const stability attributes
 macro_rules! foo {

--- a/src/test/ui/attributes/const-stability-on-macro.stderr
+++ b/src/test/ui/attributes/const-stability-on-macro.stderr
@@ -1,5 +1,5 @@
 error: macros cannot have const stability attributes
-  --> $DIR/const-stability-on-macro.rs:1:1
+  --> $DIR/const-stability-on-macro.rs:4:1
    |
 LL | #[rustc_const_stable(feature = "foo", since = "0")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ invalid const stability attribute
@@ -8,7 +8,7 @@ LL | macro_rules! foo {
    | ---------------- const stability attribute affects this macro
 
 error: macros cannot have const stability attributes
-  --> $DIR/const-stability-on-macro.rs:7:1
+  --> $DIR/const-stability-on-macro.rs:10:1
    |
 LL | #[rustc_const_unstable(feature = "bar", issue="none")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ invalid const stability attribute

--- a/src/test/ui/attributes/extented-attribute-macro-error.rs
+++ b/src/test/ui/attributes/extented-attribute-macro-error.rs
@@ -1,6 +1,5 @@
 // normalize-stderr-test: "couldn't read.*" -> "couldn't read the file"
 
-#![feature(extended_key_value_attributes)]
 #![doc = include_str!("../not_existing_file.md")]
 struct Documented {}
 //~^^ ERROR couldn't read

--- a/src/test/ui/attributes/extented-attribute-macro-error.stderr
+++ b/src/test/ui/attributes/extented-attribute-macro-error.stderr
@@ -1,5 +1,5 @@
 error: couldn't read the file
-  --> $DIR/extented-attribute-macro-error.rs:4:10
+  --> $DIR/extented-attribute-macro-error.rs:3:10
    |
 LL | #![doc = include_str!("../not_existing_file.md")]
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/attributes/issue-90873.rs
+++ b/src/test/ui/attributes/issue-90873.rs
@@ -1,9 +1,9 @@
 #![u=||{static d=||1;}]
 //~^ unexpected token
 //~| cannot find attribute `u` in this scope
-//~| `main` function not found in crate `issue_90873`
 //~| missing type for `static` item
 
 #![a={impl std::ops::Neg for i8 {}}]
 //~^ ERROR unexpected token
 //~| ERROR cannot find attribute `a` in this scope
+//~| ERROR `main` function not found in crate `issue_90873`

--- a/src/test/ui/attributes/issue-90873.stderr
+++ b/src/test/ui/attributes/issue-90873.stderr
@@ -10,7 +10,7 @@ LL | #![u=||{static d=||1;}]
 error: unexpected token: `{
            impl std::ops::Neg for i8 {}
        }`
-  --> $DIR/issue-90873.rs:7:6
+  --> $DIR/issue-90873.rs:6:6
    |
 LL | #![a={impl std::ops::Neg for i8 {}}]
    |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -22,22 +22,16 @@ LL | #![u=||{static d=||1;}]
    |    ^
 
 error: cannot find attribute `a` in this scope
-  --> $DIR/issue-90873.rs:7:4
+  --> $DIR/issue-90873.rs:6:4
    |
 LL | #![a={impl std::ops::Neg for i8 {}}]
    |    ^
 
 error[E0601]: `main` function not found in crate `issue_90873`
-  --> $DIR/issue-90873.rs:1:1
+  --> $DIR/issue-90873.rs:6:37
    |
-LL | / #![u=||{static d=||1;}]
-LL | |
-LL | |
-LL | |
-LL | |
-LL | |
-LL | | #![a={impl std::ops::Neg for i8 {}}]
-   | |____________________________________^ consider adding a `main` function to `$DIR/issue-90873.rs`
+LL | #![a={impl std::ops::Neg for i8 {}}]
+   |                                     ^ consider adding a `main` function to `$DIR/issue-90873.rs`
 
 error: missing type for `static` item
   --> $DIR/issue-90873.rs:1:16

--- a/src/test/ui/check-cfg/allow-macro-cfg.rs
+++ b/src/test/ui/check-cfg/allow-macro-cfg.rs
@@ -1,0 +1,14 @@
+// This test check that local #[allow(unexpected_cfgs)] works
+//
+// check-pass
+// compile-flags:--check-cfg=names() -Z unstable-options
+
+#[allow(unexpected_cfgs)]
+fn foo() {
+    if cfg!(FALSE) {}
+}
+
+fn main() {
+    #[allow(unexpected_cfgs)]
+    if cfg!(FALSE) {}
+}

--- a/src/test/ui/check-cfg/allow-same-level.rs
+++ b/src/test/ui/check-cfg/allow-same-level.rs
@@ -1,0 +1,11 @@
+// This test check that #[allow(unexpected_cfgs)] doesn't work if put on the same level
+//
+// check-pass
+// compile-flags:--check-cfg=names() -Z unstable-options
+
+#[allow(unexpected_cfgs)]
+#[cfg(FALSE)]
+//~^ WARNING unexpected `cfg` condition name
+fn bar() {}
+
+fn main() {}

--- a/src/test/ui/check-cfg/allow-same-level.stderr
+++ b/src/test/ui/check-cfg/allow-same-level.stderr
@@ -1,0 +1,10 @@
+warning: unexpected `cfg` condition name
+  --> $DIR/allow-same-level.rs:7:7
+   |
+LL | #[cfg(FALSE)]
+   |       ^^^^^
+   |
+   = note: `#[warn(unexpected_cfgs)]` on by default
+
+warning: 1 warning emitted
+

--- a/src/test/ui/check-cfg/allow-top-level.rs
+++ b/src/test/ui/check-cfg/allow-top-level.rs
@@ -1,0 +1,15 @@
+// This test check that a top-level #![allow(unexpected_cfgs)] works
+//
+// check-pass
+// compile-flags:--check-cfg=names() -Z unstable-options
+
+#![allow(unexpected_cfgs)]
+
+#[cfg(FALSE)]
+fn bar() {}
+
+fn foo() {
+    if cfg!(FALSE) {}
+}
+
+fn main() {}

--- a/src/test/ui/check-cfg/allow-upper-level.rs
+++ b/src/test/ui/check-cfg/allow-upper-level.rs
@@ -1,0 +1,12 @@
+// This test check that #[allow(unexpected_cfgs)] work if put on an upper level
+//
+// check-pass
+// compile-flags:--check-cfg=names() -Z unstable-options
+
+#[allow(unexpected_cfgs)]
+mod aa {
+    #[cfg(FALSE)]
+    fn bar() {}
+}
+
+fn main() {}

--- a/src/test/ui/conditional-compilation/cfg-attr-cfg-2.stderr
+++ b/src/test/ui/conditional-compilation/cfg-attr-cfg-2.stderr
@@ -1,9 +1,8 @@
 error[E0601]: `main` function not found in crate `cfg_attr_cfg_2`
-  --> $DIR/cfg-attr-cfg-2.rs:8:1
+  --> $DIR/cfg-attr-cfg-2.rs:9:14
    |
-LL | / #[cfg_attr(foo, cfg(bar))]
-LL | | fn main() { }
-   | |_____________^ consider adding a `main` function to `$DIR/cfg-attr-cfg-2.rs`
+LL | fn main() { }
+   |              ^ consider adding a `main` function to `$DIR/cfg-attr-cfg-2.rs`
 
 error: aborting due to previous error
 

--- a/src/test/ui/conditional-compilation/cfg-in-crate-1.stderr
+++ b/src/test/ui/conditional-compilation/cfg-in-crate-1.stderr
@@ -1,8 +1,8 @@
 error[E0601]: `main` function not found in crate `cfg_in_crate_1`
-  --> $DIR/cfg-in-crate-1.rs:3:1
+  --> $DIR/cfg-in-crate-1.rs:3:13
    |
 LL | #![cfg(bar)]
-   | ^^^^^^^^^^^^ consider adding a `main` function to `$DIR/cfg-in-crate-1.rs`
+   |             ^ consider adding a `main` function to `$DIR/cfg-in-crate-1.rs`
 
 error: aborting due to previous error
 

--- a/src/test/ui/const-generics/issues/issue-82956.rs
+++ b/src/test/ui/const-generics/issues/issue-82956.rs
@@ -1,4 +1,4 @@
-#![feature(generic_const_exprs, array_map)]
+#![feature(generic_const_exprs)]
 #![allow(incomplete_features)]
 
 pub struct ConstCheck<const CHECK: bool>;

--- a/src/test/ui/consts/const-array-oob-arith.rs
+++ b/src/test/ui/consts/const-array-oob-arith.rs
@@ -1,5 +1,3 @@
-#![feature(const_indexing)]
-
 const ARR: [i32; 6] = [42, 43, 44, 45, 46, 47];
 const IDX: usize = 3;
 const VAL: i32 = ARR[IDX];

--- a/src/test/ui/consts/const-array-oob-arith.stderr
+++ b/src/test/ui/consts/const-array-oob-arith.stderr
@@ -1,11 +1,11 @@
 error[E0308]: mismatched types
-  --> $DIR/const-array-oob-arith.rs:7:45
+  --> $DIR/const-array-oob-arith.rs:5:45
    |
 LL | const BLUB: [i32; (ARR[0] - 40) as usize] = [5];
    |                                             ^^^ expected an array with a fixed size of 2 elements, found one with 1 element
 
 error[E0308]: mismatched types
-  --> $DIR/const-array-oob-arith.rs:10:44
+  --> $DIR/const-array-oob-arith.rs:8:44
    |
 LL | const BOO: [i32; (ARR[0] - 41) as usize] = [5, 99];
    |                                            ^^^^^^^ expected an array with a fixed size of 1 element, found one with 2 elements

--- a/src/test/ui/consts/const-array-oob.rs
+++ b/src/test/ui/consts/const-array-oob.rs
@@ -1,5 +1,3 @@
-#![feature(const_indexing)]
-
 const FOO: [usize; 3] = [1, 2, 3];
 const BAR: usize = FOO[5]; // no error, because the error below occurs before regular const eval
 

--- a/src/test/ui/consts/const-array-oob.stderr
+++ b/src/test/ui/consts/const-array-oob.stderr
@@ -1,5 +1,5 @@
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-array-oob.rs:6:19
+  --> $DIR/const-array-oob.rs:4:19
    |
 LL | const BLUB: [u32; FOO[4]] = [5, 6];
    |                   ^^^^^^ index out of bounds: the length is 3 but the index is 4

--- a/src/test/ui/consts/const-eval/transmute-const-promotion.rs
+++ b/src/test/ui/consts/const-eval/transmute-const-promotion.rs
@@ -1,5 +1,3 @@
-#![feature(const_transmute)]
-
 use std::mem;
 
 fn main() {

--- a/src/test/ui/consts/const-eval/transmute-const-promotion.stderr
+++ b/src/test/ui/consts/const-eval/transmute-const-promotion.stderr
@@ -1,5 +1,5 @@
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/transmute-const-promotion.rs:6:37
+  --> $DIR/transmute-const-promotion.rs:4:37
    |
 LL |     let x: &'static u32 = unsafe { &mem::transmute(3.0f32) };
    |            ------------             ^^^^^^^^^^^^^^^^^^^^^^ creates a temporary which is freed while still in use

--- a/src/test/ui/consts/const-int-unchecked.stderr
+++ b/src/test/ui/consts/const-int-unchecked.stderr
@@ -266,7 +266,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/const-int-unchecked.rs:134:25
    |
 LL | const _: i32 = unsafe { std::intrinsics::unchecked_div(i32::MIN, -1) };
-   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflow executing `unchecked_div`
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflow in signed division (dividing MIN by -1)
 
 error[E0080]: evaluation of constant value failed
   --> $DIR/const-int-unchecked.rs:137:25
@@ -278,7 +278,7 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/const-int-unchecked.rs:139:25
    |
 LL | const _: i32 = unsafe { std::intrinsics::unchecked_rem(i32::MIN, -1) };
-   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflow executing `unchecked_rem`
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflow in signed remainder (dividing MIN by -1)
 
 error[E0080]: evaluation of constant value failed
   --> $DIR/const-int-unchecked.rs:144:25

--- a/src/test/ui/consts/issue-87046.rs
+++ b/src/test/ui/consts/issue-87046.rs
@@ -2,7 +2,6 @@
 
 #![crate_type="lib"]
 #![allow(unreachable_patterns)]
-#![feature(const_fn_union)]
 
 #[derive(PartialEq, Eq)]
 #[repr(transparent)]

--- a/src/test/ui/consts/issue-87046.stderr
+++ b/src/test/ui/consts/issue-87046.stderr
@@ -1,5 +1,5 @@
 error: cannot use unsized non-slice type `Username` in constant patterns
-  --> $DIR/issue-87046.rs:29:13
+  --> $DIR/issue-87046.rs:28:13
    |
 LL |             ROOT_USER => true,
    |             ^^^^^^^^^

--- a/src/test/ui/consts/min_const_fn/allow_const_fn_ptr.rs
+++ b/src/test/ui/consts/min_const_fn/allow_const_fn_ptr.rs
@@ -1,5 +1,6 @@
 #![feature(rustc_attrs, staged_api, rustc_allow_const_fn_unstable)]
 #![feature(const_fn_fn_ptr_basics)]
+#![stable(feature = "rust1", since = "1.0.0")]
 
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_const_stable(since="1.0.0", feature = "mep")]

--- a/src/test/ui/consts/min_const_fn/allow_const_fn_ptr.stderr
+++ b/src/test/ui/consts/min_const_fn/allow_const_fn_ptr.stderr
@@ -1,5 +1,5 @@
 error: const-stable function cannot use `#[feature(const_fn_fn_ptr_basics)]`
-  --> $DIR/allow_const_fn_ptr.rs:6:16
+  --> $DIR/allow_const_fn_ptr.rs:7:16
    |
 LL | const fn error(_: fn()) {}
    |                ^

--- a/src/test/ui/consts/min_const_fn/min_const_fn_libstd_stability.rs
+++ b/src/test/ui/consts/min_const_fn/min_const_fn_libstd_stability.rs
@@ -15,7 +15,7 @@ const fn foo() -> u32 { 42 }
 // can't call non-min_const_fn
 const fn bar() -> u32 { foo() } //~ ERROR not yet stable as a const fn
 
-#[unstable(feature = "rust1", issue = "none")]
+#[unstable(feature = "foo2", issue = "none")]
 const fn foo2() -> u32 { 42 }
 
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/test/ui/consts/min_const_fn/min_const_unsafe_fn_libstd_stability.rs
+++ b/src/test/ui/consts/min_const_fn/min_const_unsafe_fn_libstd_stability.rs
@@ -15,7 +15,7 @@ const unsafe fn foo() -> u32 { 42 }
 // can't call non-min_const_fn
 const unsafe fn bar() -> u32 { unsafe { foo() } } //~ ERROR not yet stable as a const fn
 
-#[unstable(feature = "rust1", issue = "none")]
+#[unstable(feature = "foo2", issue = "none")]
 const unsafe fn foo2() -> u32 { 42 }
 
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/test/ui/consts/min_const_fn/min_const_unsafe_fn_libstd_stability2.rs
+++ b/src/test/ui/consts/min_const_fn/min_const_unsafe_fn_libstd_stability2.rs
@@ -15,7 +15,7 @@ const fn foo() -> u32 { 42 }
 // can't call non-min_const_fn
 const unsafe fn bar() -> u32 { foo() } //~ ERROR not yet stable as a const fn
 
-#[unstable(feature = "rust1", issue = "none")]
+#[unstable(feature = "foo2", issue = "none")]
 const fn foo2() -> u32 { 42 }
 
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/test/ui/consts/transmute-size-mismatch-before-typeck.rs
+++ b/src/test/ui/consts/transmute-size-mismatch-before-typeck.rs
@@ -1,5 +1,3 @@
-#![feature(const_transmute)]
-
 // normalize-stderr-64bit "64 bits" -> "word size"
 // normalize-stderr-32bit "32 bits" -> "word size"
 // normalize-stderr-64bit "128 bits" -> "2 * word size"

--- a/src/test/ui/consts/transmute-size-mismatch-before-typeck.stderr
+++ b/src/test/ui/consts/transmute-size-mismatch-before-typeck.stderr
@@ -1,5 +1,5 @@
 error: any use of this value will cause an error
-  --> $DIR/transmute-size-mismatch-before-typeck.rs:15:29
+  --> $DIR/transmute-size-mismatch-before-typeck.rs:13:29
    |
 LL | const ZST: &[u8] = unsafe { std::mem::transmute(1usize) };
    | ----------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^---
@@ -11,13 +11,13 @@ LL | const ZST: &[u8] = unsafe { std::mem::transmute(1usize) };
    = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
 error: could not evaluate constant pattern
-  --> $DIR/transmute-size-mismatch-before-typeck.rs:10:9
+  --> $DIR/transmute-size-mismatch-before-typeck.rs:8:9
    |
 LL |         ZST => {}
    |         ^^^
 
 error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
-  --> $DIR/transmute-size-mismatch-before-typeck.rs:15:29
+  --> $DIR/transmute-size-mismatch-before-typeck.rs:13:29
    |
 LL | const ZST: &[u8] = unsafe { std::mem::transmute(1usize) };
    |                             ^^^^^^^^^^^^^^^^^^^
@@ -26,7 +26,7 @@ LL | const ZST: &[u8] = unsafe { std::mem::transmute(1usize) };
    = note: target type: `&[u8]` (2 * word size)
 
 error: could not evaluate constant pattern
-  --> $DIR/transmute-size-mismatch-before-typeck.rs:10:9
+  --> $DIR/transmute-size-mismatch-before-typeck.rs:8:9
    |
 LL |         ZST => {}
    |         ^^^

--- a/src/test/ui/consts/unstable-const-fn-in-libcore.rs
+++ b/src/test/ui/consts/unstable-const-fn-in-libcore.rs
@@ -4,7 +4,6 @@
 // gate was not enabled in libcore.
 
 #![stable(feature = "core", since = "1.6.0")]
-#![feature(rustc_const_unstable)]
 #![feature(staged_api)]
 #![feature(const_fn_trait_bound)]
 

--- a/src/test/ui/consts/unstable-const-fn-in-libcore.stderr
+++ b/src/test/ui/consts/unstable-const-fn-in-libcore.stderr
@@ -1,5 +1,5 @@
 error[E0015]: cannot call non-const closure in constant functions
-  --> $DIR/unstable-const-fn-in-libcore.rs:24:26
+  --> $DIR/unstable-const-fn-in-libcore.rs:23:26
    |
 LL |             Opt::None => f(),
    |                          ^^^
@@ -11,7 +11,7 @@ LL |     const fn unwrap_or_else<F: FnOnce() -> T + ~const std::ops::FnOnce<()>>
    |                                              +++++++++++++++++++++++++++++
 
 error[E0493]: destructors cannot be evaluated at compile-time
-  --> $DIR/unstable-const-fn-in-libcore.rs:19:53
+  --> $DIR/unstable-const-fn-in-libcore.rs:18:53
    |
 LL |     const fn unwrap_or_else<F: FnOnce() -> T>(self, f: F) -> T {
    |                                                     ^ constant functions cannot evaluate destructors
@@ -20,7 +20,7 @@ LL |     }
    |     - value is dropped here
 
 error[E0493]: destructors cannot be evaluated at compile-time
-  --> $DIR/unstable-const-fn-in-libcore.rs:19:47
+  --> $DIR/unstable-const-fn-in-libcore.rs:18:47
    |
 LL |     const fn unwrap_or_else<F: FnOnce() -> T>(self, f: F) -> T {
    |                                               ^^^^ constant functions cannot evaluate destructors

--- a/src/test/ui/continue-after-missing-main.rs
+++ b/src/test/ui/continue-after-missing-main.rs
@@ -1,4 +1,4 @@
-#![allow(dead_code)] //~ ERROR `main` function not found in crate
+#![allow(dead_code)]
 
 struct Tableau<'a, MP> {
     provider: &'a MP,
@@ -27,4 +27,4 @@ fn create_and_solve_subproblems<'data_provider, 'original_data, MP>(
 ) {
     let _: AdaptedMatrixProvider<'original_data, MP> = tableau.provider().clone_with_extra_bound();
     //~^ ERROR lifetime mismatch
-}
+} //~ ERROR `main` function not found in crate

--- a/src/test/ui/continue-after-missing-main.stderr
+++ b/src/test/ui/continue-after-missing-main.stderr
@@ -1,14 +1,8 @@
 error[E0601]: `main` function not found in crate `continue_after_missing_main`
-  --> $DIR/continue-after-missing-main.rs:1:1
+  --> $DIR/continue-after-missing-main.rs:30:2
    |
-LL | / #![allow(dead_code)]
-LL | |
-LL | | struct Tableau<'a, MP> {
-LL | |     provider: &'a MP,
-...  |
-LL | |
-LL | | }
-   | |_^ consider adding a `main` function to `$DIR/continue-after-missing-main.rs`
+LL | }
+   |  ^ consider adding a `main` function to `$DIR/continue-after-missing-main.rs`
 
 error[E0623]: lifetime mismatch
   --> $DIR/continue-after-missing-main.rs:28:56

--- a/src/test/ui/deprecation/deprecation-in-staged-api.stderr
+++ b/src/test/ui/deprecation/deprecation-in-staged-api.stderr
@@ -3,8 +3,6 @@ error: `#[deprecated]` cannot be used in staged API
    |
 LL | #[deprecated]
    | ^^^^^^^^^^^^^ use `#[rustc_deprecated]` instead
-LL | fn main() {}
-   | ------------
 
 error: aborting due to previous error
 

--- a/src/test/ui/elided-test.stderr
+++ b/src/test/ui/elided-test.stderr
@@ -1,10 +1,8 @@
 error[E0601]: `main` function not found in crate `elided_test`
-  --> $DIR/elided-test.rs:5:1
+  --> $DIR/elided-test.rs:7:2
    |
-LL | / #[test]
-LL | | fn main() {
-LL | | }
-   | |_^ consider adding a `main` function to `$DIR/elided-test.rs`
+LL | }
+   |  ^ consider adding a `main` function to `$DIR/elided-test.rs`
 
 error: aborting due to previous error
 

--- a/src/test/ui/entry-point/imported_main_const_fn_item_type_forbidden.rs
+++ b/src/test/ui/entry-point/imported_main_const_fn_item_type_forbidden.rs
@@ -1,7 +1,6 @@
 #![feature(imported_main)]
 #![feature(type_alias_impl_trait)]
 #![allow(incomplete_features)]
-//~^^^ ERROR `main` function not found in crate
 pub mod foo {
     type MainFn = impl Fn();
     //~^ ERROR could not find defining uses
@@ -11,4 +10,4 @@ pub mod foo {
     //~^ ERROR mismatched types [E0308]
 }
 
-use foo::BAR as main;
+use foo::BAR as main; //~ ERROR `main` function not found in crate

--- a/src/test/ui/entry-point/imported_main_const_fn_item_type_forbidden.stderr
+++ b/src/test/ui/entry-point/imported_main_const_fn_item_type_forbidden.stderr
@@ -1,19 +1,13 @@
 error[E0601]: `main` function not found in crate `imported_main_const_fn_item_type_forbidden`
-  --> $DIR/imported_main_const_fn_item_type_forbidden.rs:1:1
+  --> $DIR/imported_main_const_fn_item_type_forbidden.rs:13:22
    |
-LL | / #![feature(imported_main)]
-LL | | #![feature(type_alias_impl_trait)]
-LL | | #![allow(incomplete_features)]
-LL | |
-...  |
-LL | |
-LL | | use foo::BAR as main;
-   | |_____----------------^ consider adding a `main` function to `$DIR/imported_main_const_fn_item_type_forbidden.rs`
-   |       |
-   |       non-function item at `crate::main` is found
+LL | use foo::BAR as main;
+   |     ---------------- ^ consider adding a `main` function to `$DIR/imported_main_const_fn_item_type_forbidden.rs`
+   |     |
+   |     non-function item at `crate::main` is found
 
 error[E0308]: mismatched types
-  --> $DIR/imported_main_const_fn_item_type_forbidden.rs:10:29
+  --> $DIR/imported_main_const_fn_item_type_forbidden.rs:9:29
    |
 LL |     type MainFn = impl Fn();
    |                   --------- the expected opaque type
@@ -25,7 +19,7 @@ LL |     pub const BAR: MainFn = bar;
                   found fn item `fn() {bar}`
 
 error: could not find defining uses
-  --> $DIR/imported_main_const_fn_item_type_forbidden.rs:6:19
+  --> $DIR/imported_main_const_fn_item_type_forbidden.rs:5:19
    |
 LL |     type MainFn = impl Fn();
    |                   ^^^^^^^^^

--- a/src/test/ui/entry-point/imported_main_const_forbidden.rs
+++ b/src/test/ui/entry-point/imported_main_const_forbidden.rs
@@ -1,7 +1,6 @@
 #![feature(imported_main)]
-//~^ ERROR `main` function not found in crate
 pub mod foo {
     pub const BAR: usize = 42;
 }
 
-use foo::BAR as main;
+use foo::BAR as main; //~ ERROR `main` function not found in crate

--- a/src/test/ui/entry-point/imported_main_const_forbidden.stderr
+++ b/src/test/ui/entry-point/imported_main_const_forbidden.stderr
@@ -1,16 +1,10 @@
 error[E0601]: `main` function not found in crate `imported_main_const_forbidden`
-  --> $DIR/imported_main_const_forbidden.rs:1:1
+  --> $DIR/imported_main_const_forbidden.rs:6:22
    |
-LL | / #![feature(imported_main)]
-LL | |
-LL | | pub mod foo {
-LL | |     pub const BAR: usize = 42;
-LL | | }
-LL | |
-LL | | use foo::BAR as main;
-   | |_____----------------^ consider adding a `main` function to `$DIR/imported_main_const_forbidden.rs`
-   |       |
-   |       non-function item at `crate::main` is found
+LL | use foo::BAR as main;
+   |     ---------------- ^ consider adding a `main` function to `$DIR/imported_main_const_forbidden.rs`
+   |     |
+   |     non-function item at `crate::main` is found
 
 error: aborting due to previous error
 

--- a/src/test/ui/explore-issue-38412.rs
+++ b/src/test/ui/explore-issue-38412.rs
@@ -1,7 +1,5 @@
 // aux-build:pub-and-stability.rs
 
-#![feature(unused_feature)]
-
 // A big point of this test is that we *declare* `unstable_declared`,
 // but do *not* declare `unstable_undeclared`. This way we can check
 // that the compiler is letting in uses of declared feature-gated

--- a/src/test/ui/explore-issue-38412.stderr
+++ b/src/test/ui/explore-issue-38412.stderr
@@ -1,5 +1,5 @@
 error[E0658]: use of unstable library feature 'unstable_undeclared'
-  --> $DIR/explore-issue-38412.rs:21:63
+  --> $DIR/explore-issue-38412.rs:19:63
    |
 LL |     let Record { a_stable_pub: _, a_unstable_declared_pub: _, a_unstable_undeclared_pub: _, .. } =
    |                                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -8,7 +8,7 @@ LL |     let Record { a_stable_pub: _, a_unstable_declared_pub: _, a_unstable_un
    = help: add `#![feature(unstable_undeclared)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_undeclared'
-  --> $DIR/explore-issue-38412.rs:30:5
+  --> $DIR/explore-issue-38412.rs:28:5
    |
 LL |     r.a_unstable_undeclared_pub;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -17,25 +17,25 @@ LL |     r.a_unstable_undeclared_pub;
    = help: add `#![feature(unstable_undeclared)]` to the crate attributes to enable
 
 error[E0616]: field `b_crate` of struct `Record` is private
-  --> $DIR/explore-issue-38412.rs:31:7
+  --> $DIR/explore-issue-38412.rs:29:7
    |
 LL |     r.b_crate;
    |       ^^^^^^^ private field
 
 error[E0616]: field `c_mod` of struct `Record` is private
-  --> $DIR/explore-issue-38412.rs:32:7
+  --> $DIR/explore-issue-38412.rs:30:7
    |
 LL |     r.c_mod;
    |       ^^^^^ private field
 
 error[E0616]: field `d_priv` of struct `Record` is private
-  --> $DIR/explore-issue-38412.rs:33:7
+  --> $DIR/explore-issue-38412.rs:31:7
    |
 LL |     r.d_priv;
    |       ^^^^^^ private field
 
 error[E0658]: use of unstable library feature 'unstable_undeclared'
-  --> $DIR/explore-issue-38412.rs:37:5
+  --> $DIR/explore-issue-38412.rs:35:5
    |
 LL |     t.2;
    |     ^^^
@@ -44,25 +44,25 @@ LL |     t.2;
    = help: add `#![feature(unstable_undeclared)]` to the crate attributes to enable
 
 error[E0616]: field `3` of struct `Tuple` is private
-  --> $DIR/explore-issue-38412.rs:38:7
+  --> $DIR/explore-issue-38412.rs:36:7
    |
 LL |     t.3;
    |       ^ private field
 
 error[E0616]: field `4` of struct `Tuple` is private
-  --> $DIR/explore-issue-38412.rs:39:7
+  --> $DIR/explore-issue-38412.rs:37:7
    |
 LL |     t.4;
    |       ^ private field
 
 error[E0616]: field `5` of struct `Tuple` is private
-  --> $DIR/explore-issue-38412.rs:40:7
+  --> $DIR/explore-issue-38412.rs:38:7
    |
 LL |     t.5;
    |       ^ private field
 
 error[E0658]: use of unstable library feature 'unstable_undeclared'
-  --> $DIR/explore-issue-38412.rs:44:7
+  --> $DIR/explore-issue-38412.rs:42:7
    |
 LL |     r.unstable_undeclared_trait_method();
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -71,7 +71,7 @@ LL |     r.unstable_undeclared_trait_method();
    = help: add `#![feature(unstable_undeclared)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_undeclared'
-  --> $DIR/explore-issue-38412.rs:48:7
+  --> $DIR/explore-issue-38412.rs:46:7
    |
 LL |     r.unstable_undeclared();
    |       ^^^^^^^^^^^^^^^^^^^
@@ -80,7 +80,7 @@ LL |     r.unstable_undeclared();
    = help: add `#![feature(unstable_undeclared)]` to the crate attributes to enable
 
 error[E0624]: associated function `pub_crate` is private
-  --> $DIR/explore-issue-38412.rs:50:7
+  --> $DIR/explore-issue-38412.rs:48:7
    |
 LL |     r.pub_crate();
    |       ^^^^^^^^^ private associated function
@@ -91,7 +91,7 @@ LL |         pub(crate) fn pub_crate(&self) -> i32 { self.d_priv }
    |         ------------------------------------- private associated function defined here
 
 error[E0624]: associated function `pub_mod` is private
-  --> $DIR/explore-issue-38412.rs:51:7
+  --> $DIR/explore-issue-38412.rs:49:7
    |
 LL |     r.pub_mod();
    |       ^^^^^^^ private associated function
@@ -102,7 +102,7 @@ LL |         pub(in m) fn pub_mod(&self) -> i32 { self.d_priv }
    |         ---------------------------------- private associated function defined here
 
 error[E0624]: associated function `private` is private
-  --> $DIR/explore-issue-38412.rs:52:7
+  --> $DIR/explore-issue-38412.rs:50:7
    |
 LL |     r.private();
    |       ^^^^^^^ private associated function
@@ -113,7 +113,7 @@ LL |         fn private(&self) -> i32 { self.d_priv }
    |         ------------------------ private associated function defined here
 
 error[E0658]: use of unstable library feature 'unstable_undeclared'
-  --> $DIR/explore-issue-38412.rs:57:7
+  --> $DIR/explore-issue-38412.rs:55:7
    |
 LL |     t.unstable_undeclared_trait_method();
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -122,7 +122,7 @@ LL |     t.unstable_undeclared_trait_method();
    = help: add `#![feature(unstable_undeclared)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_undeclared'
-  --> $DIR/explore-issue-38412.rs:61:7
+  --> $DIR/explore-issue-38412.rs:59:7
    |
 LL |     t.unstable_undeclared();
    |       ^^^^^^^^^^^^^^^^^^^
@@ -131,7 +131,7 @@ LL |     t.unstable_undeclared();
    = help: add `#![feature(unstable_undeclared)]` to the crate attributes to enable
 
 error[E0624]: associated function `pub_crate` is private
-  --> $DIR/explore-issue-38412.rs:63:7
+  --> $DIR/explore-issue-38412.rs:61:7
    |
 LL |     t.pub_crate();
    |       ^^^^^^^^^ private associated function
@@ -142,7 +142,7 @@ LL |         pub(crate) fn pub_crate(&self) -> i32 { self.0 }
    |         ------------------------------------- private associated function defined here
 
 error[E0624]: associated function `pub_mod` is private
-  --> $DIR/explore-issue-38412.rs:64:7
+  --> $DIR/explore-issue-38412.rs:62:7
    |
 LL |     t.pub_mod();
    |       ^^^^^^^ private associated function
@@ -153,7 +153,7 @@ LL |         pub(in m) fn pub_mod(&self) -> i32 { self.0 }
    |         ---------------------------------- private associated function defined here
 
 error[E0624]: associated function `private` is private
-  --> $DIR/explore-issue-38412.rs:65:7
+  --> $DIR/explore-issue-38412.rs:63:7
    |
 LL |     t.private();
    |       ^^^^^^^ private associated function

--- a/src/test/ui/feature-gates/feature-gate-staged_api.stderr
+++ b/src/test/ui/feature-gates/feature-gate-staged_api.stderr
@@ -1,14 +1,14 @@
 error[E0734]: stability attributes may not be used outside of the standard library
-  --> $DIR/feature-gate-staged_api.rs:1:1
-   |
-LL | #![stable(feature = "a", since = "b")]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error[E0734]: stability attributes may not be used outside of the standard library
   --> $DIR/feature-gate-staged_api.rs:8:1
    |
 LL | #[stable(feature = "a", since = "b")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0734]: stability attributes may not be used outside of the standard library
+  --> $DIR/feature-gate-staged_api.rs:1:1
+   |
+LL | #![stable(feature = "a", since = "b")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/feature-gates/gated-bad-feature.rs
+++ b/src/test/ui/feature-gates/gated-bad-feature.rs
@@ -1,10 +1,10 @@
 #![feature(foo_bar_baz, foo(bar), foo = "baz", foo)]
 //~^ ERROR malformed `feature`
 //~| ERROR malformed `feature`
-
+//~| ERROR unknown feature `foo`
+//~| ERROR unknown feature `foo_bar_baz`
 #![feature] //~ ERROR malformed `feature` attribute
 #![feature = "foo"] //~ ERROR malformed `feature` attribute
-
 #![feature(test_removed_feature)] //~ ERROR: feature has been removed
 
 fn main() {}

--- a/src/test/ui/feature-gates/gated-bad-feature.stderr
+++ b/src/test/ui/feature-gates/gated-bad-feature.stderr
@@ -17,18 +17,30 @@ LL | #![feature(test_removed_feature)]
    |            ^^^^^^^^^^^^^^^^^^^^ feature has been removed
 
 error: malformed `feature` attribute input
-  --> $DIR/gated-bad-feature.rs:5:1
+  --> $DIR/gated-bad-feature.rs:6:1
    |
 LL | #![feature]
    | ^^^^^^^^^^^ help: must be of the form: `#![feature(name1, name2, ...)]`
 
 error: malformed `feature` attribute input
-  --> $DIR/gated-bad-feature.rs:6:1
+  --> $DIR/gated-bad-feature.rs:7:1
    |
 LL | #![feature = "foo"]
    | ^^^^^^^^^^^^^^^^^^^ help: must be of the form: `#![feature(name1, name2, ...)]`
 
-error: aborting due to 5 previous errors
+error[E0635]: unknown feature `foo_bar_baz`
+  --> $DIR/gated-bad-feature.rs:1:12
+   |
+LL | #![feature(foo_bar_baz, foo(bar), foo = "baz", foo)]
+   |            ^^^^^^^^^^^
 
-Some errors have detailed explanations: E0556, E0557.
+error[E0635]: unknown feature `foo`
+  --> $DIR/gated-bad-feature.rs:1:48
+   |
+LL | #![feature(foo_bar_baz, foo(bar), foo = "baz", foo)]
+   |                                                ^^^
+
+error: aborting due to 7 previous errors
+
+Some errors have detailed explanations: E0556, E0557, E0635.
 For more information about an error, try `rustc --explain E0556`.

--- a/src/test/ui/feature-gates/issue-43106-gating-of-rustc_deprecated.rs
+++ b/src/test/ui/feature-gates/issue-43106-gating-of-rustc_deprecated.rs
@@ -6,25 +6,38 @@
 
 #![rustc_deprecated()]
 //~^ ERROR stability attributes may not be used outside of the standard library
+//~| ERROR missing 'since' [E0542]
 
 #[rustc_deprecated()]
 //~^ ERROR stability attributes may not be used outside of the standard library
+//~| ERROR missing 'since' [E0542]
 mod rustc_deprecated {
-    mod inner { #![rustc_deprecated()] }
-    //~^ ERROR stability attributes may not be used outside of the standard library
+    mod inner {
+        #![rustc_deprecated()]
+        //~^ ERROR stability attributes may not be used outside of the standard library
+        //~| ERROR missing 'since' [E0542]
+    }
 
-    #[rustc_deprecated()] fn f() { }
+    #[rustc_deprecated()]
     //~^ ERROR stability attributes may not be used outside of the standard library
+    //~| ERROR missing 'since' [E0542]
+    fn f() {}
 
-    #[rustc_deprecated()] struct S;
+    #[rustc_deprecated()]
     //~^ ERROR stability attributes may not be used outside of the standard library
-    //~| ERROR stability attributes may not be used outside of the standard library
+    //~| ERROR missing 'since' [E0542]
+    //~| ERROR missing 'since' [E0542]
+    struct S;
 
-    #[rustc_deprecated()] type T = S;
+    #[rustc_deprecated()]
     //~^ ERROR stability attributes may not be used outside of the standard library
+    //~| ERROR missing 'since' [E0542]
+    type T = S;
 
-    #[rustc_deprecated()] impl S { }
+    #[rustc_deprecated()]
     //~^ ERROR stability attributes may not be used outside of the standard library
+    //~| ERROR missing 'since' [E0542]
+    impl S {}
 }
 
 fn main() {}

--- a/src/test/ui/feature-gates/issue-43106-gating-of-rustc_deprecated.stderr
+++ b/src/test/ui/feature-gates/issue-43106-gating-of-rustc_deprecated.stderr
@@ -1,51 +1,94 @@
 error[E0734]: stability attributes may not be used outside of the standard library
-  --> $DIR/issue-43106-gating-of-rustc_deprecated.rs:7:1
+  --> $DIR/issue-43106-gating-of-rustc_deprecated.rs:16:9
    |
-LL | #![rustc_deprecated()]
-   | ^^^^^^^^^^^^^^^^^^^^^^
+LL |         #![rustc_deprecated()]
+   |         ^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0734]: stability attributes may not be used outside of the standard library
-  --> $DIR/issue-43106-gating-of-rustc_deprecated.rs:10:1
+  --> $DIR/issue-43106-gating-of-rustc_deprecated.rs:21:5
    |
-LL | #[rustc_deprecated()]
-   | ^^^^^^^^^^^^^^^^^^^^^
-
-error[E0734]: stability attributes may not be used outside of the standard library
-  --> $DIR/issue-43106-gating-of-rustc_deprecated.rs:13:17
-   |
-LL |     mod inner { #![rustc_deprecated()] }
-   |                 ^^^^^^^^^^^^^^^^^^^^^^
-
-error[E0734]: stability attributes may not be used outside of the standard library
-  --> $DIR/issue-43106-gating-of-rustc_deprecated.rs:16:5
-   |
-LL |     #[rustc_deprecated()] fn f() { }
-   |     ^^^^^^^^^^^^^^^^^^^^^
-
-error[E0734]: stability attributes may not be used outside of the standard library
-  --> $DIR/issue-43106-gating-of-rustc_deprecated.rs:19:5
-   |
-LL |     #[rustc_deprecated()] struct S;
-   |     ^^^^^^^^^^^^^^^^^^^^^
-
-error[E0734]: stability attributes may not be used outside of the standard library
-  --> $DIR/issue-43106-gating-of-rustc_deprecated.rs:19:5
-   |
-LL |     #[rustc_deprecated()] struct S;
-   |     ^^^^^^^^^^^^^^^^^^^^^
-
-error[E0734]: stability attributes may not be used outside of the standard library
-  --> $DIR/issue-43106-gating-of-rustc_deprecated.rs:23:5
-   |
-LL |     #[rustc_deprecated()] type T = S;
+LL |     #[rustc_deprecated()]
    |     ^^^^^^^^^^^^^^^^^^^^^
 
 error[E0734]: stability attributes may not be used outside of the standard library
   --> $DIR/issue-43106-gating-of-rustc_deprecated.rs:26:5
    |
-LL |     #[rustc_deprecated()] impl S { }
+LL |     #[rustc_deprecated()]
    |     ^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 8 previous errors
+error[E0734]: stability attributes may not be used outside of the standard library
+  --> $DIR/issue-43106-gating-of-rustc_deprecated.rs:32:5
+   |
+LL |     #[rustc_deprecated()]
+   |     ^^^^^^^^^^^^^^^^^^^^^
 
-For more information about this error, try `rustc --explain E0734`.
+error[E0734]: stability attributes may not be used outside of the standard library
+  --> $DIR/issue-43106-gating-of-rustc_deprecated.rs:37:5
+   |
+LL |     #[rustc_deprecated()]
+   |     ^^^^^^^^^^^^^^^^^^^^^
+
+error[E0734]: stability attributes may not be used outside of the standard library
+  --> $DIR/issue-43106-gating-of-rustc_deprecated.rs:11:1
+   |
+LL | #[rustc_deprecated()]
+   | ^^^^^^^^^^^^^^^^^^^^^
+
+error[E0734]: stability attributes may not be used outside of the standard library
+  --> $DIR/issue-43106-gating-of-rustc_deprecated.rs:7:1
+   |
+LL | #![rustc_deprecated()]
+   | ^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0542]: missing 'since'
+  --> $DIR/issue-43106-gating-of-rustc_deprecated.rs:7:1
+   |
+LL | #![rustc_deprecated()]
+   | ^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0542]: missing 'since'
+  --> $DIR/issue-43106-gating-of-rustc_deprecated.rs:11:1
+   |
+LL | #[rustc_deprecated()]
+   | ^^^^^^^^^^^^^^^^^^^^^
+
+error[E0542]: missing 'since'
+  --> $DIR/issue-43106-gating-of-rustc_deprecated.rs:16:9
+   |
+LL |         #![rustc_deprecated()]
+   |         ^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0542]: missing 'since'
+  --> $DIR/issue-43106-gating-of-rustc_deprecated.rs:21:5
+   |
+LL |     #[rustc_deprecated()]
+   |     ^^^^^^^^^^^^^^^^^^^^^
+
+error[E0542]: missing 'since'
+  --> $DIR/issue-43106-gating-of-rustc_deprecated.rs:26:5
+   |
+LL |     #[rustc_deprecated()]
+   |     ^^^^^^^^^^^^^^^^^^^^^
+
+error[E0542]: missing 'since'
+  --> $DIR/issue-43106-gating-of-rustc_deprecated.rs:26:5
+   |
+LL |     #[rustc_deprecated()]
+   |     ^^^^^^^^^^^^^^^^^^^^^
+
+error[E0542]: missing 'since'
+  --> $DIR/issue-43106-gating-of-rustc_deprecated.rs:32:5
+   |
+LL |     #[rustc_deprecated()]
+   |     ^^^^^^^^^^^^^^^^^^^^^
+
+error[E0542]: missing 'since'
+  --> $DIR/issue-43106-gating-of-rustc_deprecated.rs:37:5
+   |
+LL |     #[rustc_deprecated()]
+   |     ^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 15 previous errors
+
+Some errors have detailed explanations: E0542, E0734.
+For more information about an error, try `rustc --explain E0542`.

--- a/src/test/ui/feature-gates/issue-43106-gating-of-stable.rs
+++ b/src/test/ui/feature-gates/issue-43106-gating-of-stable.rs
@@ -10,21 +10,26 @@
 #[stable()]
 //~^ ERROR stability attributes may not be used outside of the standard library
 mod stable {
-    mod inner { #![stable()] }
-    //~^ ERROR stability attributes may not be used outside of the standard library
+    mod inner {
+        #![stable()]
+        //~^ ERROR stability attributes may not be used outside of the standard library
+    }
 
-    #[stable()] fn f() { }
+    #[stable()]
     //~^ ERROR stability attributes may not be used outside of the standard library
+    fn f() {}
 
-    #[stable()] struct S;
+    #[stable()]
     //~^ ERROR stability attributes may not be used outside of the standard library
-    //~| ERROR stability attributes may not be used outside of the standard library
+    struct S;
 
-    #[stable()] type T = S;
+    #[stable()]
     //~^ ERROR stability attributes may not be used outside of the standard library
+    type T = S;
 
-    #[stable()] impl S { }
+    #[stable()]
     //~^ ERROR stability attributes may not be used outside of the standard library
+    impl S {}
 }
 
 fn main() {}

--- a/src/test/ui/feature-gates/issue-43106-gating-of-stable.stderr
+++ b/src/test/ui/feature-gates/issue-43106-gating-of-stable.stderr
@@ -1,8 +1,32 @@
 error[E0734]: stability attributes may not be used outside of the standard library
-  --> $DIR/issue-43106-gating-of-stable.rs:7:1
+  --> $DIR/issue-43106-gating-of-stable.rs:14:9
    |
-LL | #![stable()]
-   | ^^^^^^^^^^^^
+LL |         #![stable()]
+   |         ^^^^^^^^^^^^
+
+error[E0734]: stability attributes may not be used outside of the standard library
+  --> $DIR/issue-43106-gating-of-stable.rs:18:5
+   |
+LL |     #[stable()]
+   |     ^^^^^^^^^^^
+
+error[E0734]: stability attributes may not be used outside of the standard library
+  --> $DIR/issue-43106-gating-of-stable.rs:22:5
+   |
+LL |     #[stable()]
+   |     ^^^^^^^^^^^
+
+error[E0734]: stability attributes may not be used outside of the standard library
+  --> $DIR/issue-43106-gating-of-stable.rs:26:5
+   |
+LL |     #[stable()]
+   |     ^^^^^^^^^^^
+
+error[E0734]: stability attributes may not be used outside of the standard library
+  --> $DIR/issue-43106-gating-of-stable.rs:30:5
+   |
+LL |     #[stable()]
+   |     ^^^^^^^^^^^
 
 error[E0734]: stability attributes may not be used outside of the standard library
   --> $DIR/issue-43106-gating-of-stable.rs:10:1
@@ -11,41 +35,11 @@ LL | #[stable()]
    | ^^^^^^^^^^^
 
 error[E0734]: stability attributes may not be used outside of the standard library
-  --> $DIR/issue-43106-gating-of-stable.rs:13:17
+  --> $DIR/issue-43106-gating-of-stable.rs:7:1
    |
-LL |     mod inner { #![stable()] }
-   |                 ^^^^^^^^^^^^
+LL | #![stable()]
+   | ^^^^^^^^^^^^
 
-error[E0734]: stability attributes may not be used outside of the standard library
-  --> $DIR/issue-43106-gating-of-stable.rs:16:5
-   |
-LL |     #[stable()] fn f() { }
-   |     ^^^^^^^^^^^
-
-error[E0734]: stability attributes may not be used outside of the standard library
-  --> $DIR/issue-43106-gating-of-stable.rs:19:5
-   |
-LL |     #[stable()] struct S;
-   |     ^^^^^^^^^^^
-
-error[E0734]: stability attributes may not be used outside of the standard library
-  --> $DIR/issue-43106-gating-of-stable.rs:19:5
-   |
-LL |     #[stable()] struct S;
-   |     ^^^^^^^^^^^
-
-error[E0734]: stability attributes may not be used outside of the standard library
-  --> $DIR/issue-43106-gating-of-stable.rs:23:5
-   |
-LL |     #[stable()] type T = S;
-   |     ^^^^^^^^^^^
-
-error[E0734]: stability attributes may not be used outside of the standard library
-  --> $DIR/issue-43106-gating-of-stable.rs:26:5
-   |
-LL |     #[stable()] impl S { }
-   |     ^^^^^^^^^^^
-
-error: aborting due to 8 previous errors
+error: aborting due to 7 previous errors
 
 For more information about this error, try `rustc --explain E0734`.

--- a/src/test/ui/feature-gates/issue-43106-gating-of-unstable.rs
+++ b/src/test/ui/feature-gates/issue-43106-gating-of-unstable.rs
@@ -10,21 +10,26 @@
 #[unstable()]
 //~^ ERROR stability attributes may not be used outside of the standard library
 mod unstable {
-    mod inner { #![unstable()] }
-    //~^ ERROR stability attributes may not be used outside of the standard library
+    mod inner {
+        #![unstable()]
+        //~^ ERROR stability attributes may not be used outside of the standard library
+    }
 
-    #[unstable()] fn f() { }
+    #[unstable()]
     //~^ ERROR stability attributes may not be used outside of the standard library
+    fn f() {}
 
-    #[unstable()] struct S;
+    #[unstable()]
     //~^ ERROR stability attributes may not be used outside of the standard library
-    //~| ERROR stability attributes may not be used outside of the standard library
+    struct S;
 
-    #[unstable()] type T = S;
+    #[unstable()]
     //~^ ERROR stability attributes may not be used outside of the standard library
+    type T = S;
 
-    #[unstable()] impl S { }
+    #[unstable()]
     //~^ ERROR stability attributes may not be used outside of the standard library
+    impl S {}
 }
 
 fn main() {}

--- a/src/test/ui/feature-gates/issue-43106-gating-of-unstable.stderr
+++ b/src/test/ui/feature-gates/issue-43106-gating-of-unstable.stderr
@@ -1,8 +1,32 @@
 error[E0734]: stability attributes may not be used outside of the standard library
-  --> $DIR/issue-43106-gating-of-unstable.rs:7:1
+  --> $DIR/issue-43106-gating-of-unstable.rs:14:9
    |
-LL | #![unstable()]
-   | ^^^^^^^^^^^^^^
+LL |         #![unstable()]
+   |         ^^^^^^^^^^^^^^
+
+error[E0734]: stability attributes may not be used outside of the standard library
+  --> $DIR/issue-43106-gating-of-unstable.rs:18:5
+   |
+LL |     #[unstable()]
+   |     ^^^^^^^^^^^^^
+
+error[E0734]: stability attributes may not be used outside of the standard library
+  --> $DIR/issue-43106-gating-of-unstable.rs:22:5
+   |
+LL |     #[unstable()]
+   |     ^^^^^^^^^^^^^
+
+error[E0734]: stability attributes may not be used outside of the standard library
+  --> $DIR/issue-43106-gating-of-unstable.rs:26:5
+   |
+LL |     #[unstable()]
+   |     ^^^^^^^^^^^^^
+
+error[E0734]: stability attributes may not be used outside of the standard library
+  --> $DIR/issue-43106-gating-of-unstable.rs:30:5
+   |
+LL |     #[unstable()]
+   |     ^^^^^^^^^^^^^
 
 error[E0734]: stability attributes may not be used outside of the standard library
   --> $DIR/issue-43106-gating-of-unstable.rs:10:1
@@ -11,41 +35,11 @@ LL | #[unstable()]
    | ^^^^^^^^^^^^^
 
 error[E0734]: stability attributes may not be used outside of the standard library
-  --> $DIR/issue-43106-gating-of-unstable.rs:13:17
+  --> $DIR/issue-43106-gating-of-unstable.rs:7:1
    |
-LL |     mod inner { #![unstable()] }
-   |                 ^^^^^^^^^^^^^^
+LL | #![unstable()]
+   | ^^^^^^^^^^^^^^
 
-error[E0734]: stability attributes may not be used outside of the standard library
-  --> $DIR/issue-43106-gating-of-unstable.rs:16:5
-   |
-LL |     #[unstable()] fn f() { }
-   |     ^^^^^^^^^^^^^
-
-error[E0734]: stability attributes may not be used outside of the standard library
-  --> $DIR/issue-43106-gating-of-unstable.rs:19:5
-   |
-LL |     #[unstable()] struct S;
-   |     ^^^^^^^^^^^^^
-
-error[E0734]: stability attributes may not be used outside of the standard library
-  --> $DIR/issue-43106-gating-of-unstable.rs:19:5
-   |
-LL |     #[unstable()] struct S;
-   |     ^^^^^^^^^^^^^
-
-error[E0734]: stability attributes may not be used outside of the standard library
-  --> $DIR/issue-43106-gating-of-unstable.rs:23:5
-   |
-LL |     #[unstable()] type T = S;
-   |     ^^^^^^^^^^^^^
-
-error[E0734]: stability attributes may not be used outside of the standard library
-  --> $DIR/issue-43106-gating-of-unstable.rs:26:5
-   |
-LL |     #[unstable()] impl S { }
-   |     ^^^^^^^^^^^^^
-
-error: aborting due to 8 previous errors
+error: aborting due to 7 previous errors
 
 For more information about this error, try `rustc --explain E0734`.

--- a/src/test/ui/generator/dropck.rs
+++ b/src/test/ui/generator/dropck.rs
@@ -1,4 +1,4 @@
-#![feature(generators, generator_trait, box_leak)]
+#![feature(generators, generator_trait)]
 
 use std::cell::RefCell;
 use std::ops::Generator;

--- a/src/test/ui/impl-trait/issues/universal-issue-48703.rs
+++ b/src/test/ui/impl-trait/issues/universal-issue-48703.rs
@@ -1,5 +1,3 @@
-#![feature(universal_impl_trait)]
-
 use std::fmt::Debug;
 
 fn foo<T>(x: impl Debug) { }

--- a/src/test/ui/impl-trait/issues/universal-issue-48703.stderr
+++ b/src/test/ui/impl-trait/issues/universal-issue-48703.stderr
@@ -1,5 +1,5 @@
 error[E0632]: cannot provide explicit generic arguments when `impl Trait` is used in argument position
-  --> $DIR/universal-issue-48703.rs:8:11
+  --> $DIR/universal-issue-48703.rs:6:11
    |
 LL |     foo::<String>('a');
    |           ^^^^^^ explicit generic argument not allowed

--- a/src/test/ui/inference/question-mark-type-infer.rs
+++ b/src/test/ui/inference/question-mark-type-infer.rs
@@ -1,5 +1,3 @@
-#![feature(question_mark, question_mark_carrier)]
-
 // Test that type inference fails where there are multiple possible return types
 // for the `?` operator.
 

--- a/src/test/ui/inference/question-mark-type-infer.stderr
+++ b/src/test/ui/inference/question-mark-type-infer.stderr
@@ -1,5 +1,5 @@
 error[E0284]: type annotations needed
-  --> $DIR/question-mark-type-infer.rs:12:21
+  --> $DIR/question-mark-type-infer.rs:10:21
    |
 LL |     l.iter().map(f).collect()?
    |                     ^^^^^^^ cannot infer type

--- a/src/test/ui/issues/issue-16538.mir.stderr
+++ b/src/test/ui/issues/issue-16538.mir.stderr
@@ -1,5 +1,5 @@
 error[E0015]: cannot call non-const fn `Y::foo` in statics
-  --> $DIR/issue-16538.rs:15:23
+  --> $DIR/issue-16538.rs:14:23
    |
 LL | static foo: &Y::X = &*Y::foo(Y::x as *const Y::X);
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -7,7 +7,7 @@ LL | static foo: &Y::X = &*Y::foo(Y::x as *const Y::X);
    = note: calls in statics are limited to constant functions, tuple structs and tuple variants
 
 error[E0133]: use of extern static is unsafe and requires unsafe function or block
-  --> $DIR/issue-16538.rs:15:30
+  --> $DIR/issue-16538.rs:14:30
    |
 LL | static foo: &Y::X = &*Y::foo(Y::x as *const Y::X);
    |                              ^^^^ use of extern static
@@ -15,7 +15,7 @@ LL | static foo: &Y::X = &*Y::foo(Y::x as *const Y::X);
    = note: extern statics are not controlled by the Rust type system: invalid data, aliasing violations or data races will cause undefined behavior
 
 error[E0133]: dereference of raw pointer is unsafe and requires unsafe function or block
-  --> $DIR/issue-16538.rs:15:21
+  --> $DIR/issue-16538.rs:14:21
    |
 LL | static foo: &Y::X = &*Y::foo(Y::x as *const Y::X);
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ dereference of raw pointer

--- a/src/test/ui/issues/issue-16538.rs
+++ b/src/test/ui/issues/issue-16538.rs
@@ -1,7 +1,6 @@
 // revisions: mir thir
 // [thir]compile-flags: -Z thir-unsafeck
 
-#![feature(const_raw_ptr_deref)]
 mod Y {
     pub type X = usize;
     extern "C" {

--- a/src/test/ui/issues/issue-16538.thir.stderr
+++ b/src/test/ui/issues/issue-16538.thir.stderr
@@ -1,5 +1,5 @@
 error[E0133]: dereference of raw pointer is unsafe and requires unsafe function or block
-  --> $DIR/issue-16538.rs:15:22
+  --> $DIR/issue-16538.rs:14:22
    |
 LL | static foo: &Y::X = &*Y::foo(Y::x as *const Y::X);
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ dereference of raw pointer
@@ -7,7 +7,7 @@ LL | static foo: &Y::X = &*Y::foo(Y::x as *const Y::X);
    = note: raw pointers may be null, dangling or unaligned; they can violate aliasing rules and cause data races: all of these are undefined behavior
 
 error[E0133]: use of extern static is unsafe and requires unsafe function or block
-  --> $DIR/issue-16538.rs:15:30
+  --> $DIR/issue-16538.rs:14:30
    |
 LL | static foo: &Y::X = &*Y::foo(Y::x as *const Y::X);
    |                              ^^^^ use of extern static
@@ -15,7 +15,7 @@ LL | static foo: &Y::X = &*Y::foo(Y::x as *const Y::X);
    = note: extern statics are not controlled by the Rust type system: invalid data, aliasing violations or data races will cause undefined behavior
 
 error[E0015]: cannot call non-const fn `Y::foo` in statics
-  --> $DIR/issue-16538.rs:15:23
+  --> $DIR/issue-16538.rs:14:23
    |
 LL | static foo: &Y::X = &*Y::foo(Y::x as *const Y::X);
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/issues/issue-27078.rs
+++ b/src/test/ui/issues/issue-27078.rs
@@ -1,5 +1,3 @@
-#![feature(associated_consts)]
-
 trait Foo {
     const BAR: i32;
     fn foo(self) -> &'static i32 {

--- a/src/test/ui/issues/issue-27078.stderr
+++ b/src/test/ui/issues/issue-27078.stderr
@@ -1,5 +1,5 @@
 error[E0277]: the size for values of type `Self` cannot be known at compilation time
-  --> $DIR/issue-27078.rs:5:12
+  --> $DIR/issue-27078.rs:3:12
    |
 LL |     fn foo(self) -> &'static i32 {
    |            ^^^^ doesn't have a size known at compile-time

--- a/src/test/ui/issues/issue-39211.rs
+++ b/src/test/ui/issues/issue-39211.rs
@@ -1,5 +1,3 @@
-#![feature(associated_consts)]
-
 trait VecN {
     const DIM: usize;
 }

--- a/src/test/ui/issues/issue-39211.stderr
+++ b/src/test/ui/issues/issue-39211.stderr
@@ -1,5 +1,5 @@
 error: constant expression depends on a generic parameter
-  --> $DIR/issue-39211.rs:11:17
+  --> $DIR/issue-39211.rs:9:17
    |
 LL |     let a = [3; M::Row::DIM];
    |                 ^^^^^^^^^^^

--- a/src/test/ui/issues/issue-46101.rs
+++ b/src/test/ui/issues/issue-46101.rs
@@ -1,4 +1,3 @@
-#![feature(use_extern_macros)]
 trait Foo {}
 #[derive(Foo::Anything)] //~ ERROR failed to resolve: partially resolved path in a derive macro
                          //~| ERROR failed to resolve: partially resolved path in a derive macro

--- a/src/test/ui/issues/issue-46101.stderr
+++ b/src/test/ui/issues/issue-46101.stderr
@@ -1,11 +1,11 @@
 error[E0433]: failed to resolve: partially resolved path in a derive macro
-  --> $DIR/issue-46101.rs:3:10
+  --> $DIR/issue-46101.rs:2:10
    |
 LL | #[derive(Foo::Anything)]
    |          ^^^^^^^^^^^^^ partially resolved path in a derive macro
 
 error[E0433]: failed to resolve: partially resolved path in a derive macro
-  --> $DIR/issue-46101.rs:3:10
+  --> $DIR/issue-46101.rs:2:10
    |
 LL | #[derive(Foo::Anything)]
    |          ^^^^^^^^^^^^^ partially resolved path in a derive macro

--- a/src/test/ui/issues/issue-6596-2.rs
+++ b/src/test/ui/issues/issue-6596-2.rs
@@ -1,5 +1,3 @@
-#![feature(macro_rules)]
-
 macro_rules! g {
     ($inp:ident) => (
         { $inp $nonexistent }

--- a/src/test/ui/issues/issue-6596-2.stderr
+++ b/src/test/ui/issues/issue-6596-2.stderr
@@ -1,5 +1,5 @@
 error: expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator, found `$`
-  --> $DIR/issue-6596-2.rs:5:16
+  --> $DIR/issue-6596-2.rs:3:16
    |
 LL |         { $inp $nonexistent }
    |                ^^^^^^^^^^^^ expected one of 8 possible tokens

--- a/src/test/ui/issues/issue-75777.rs
+++ b/src/test/ui/issues/issue-75777.rs
@@ -1,8 +1,6 @@
 // Regression test for #75777.
 // Checks that a boxed future can be properly constructed.
 
-#![feature(future_readiness_fns)]
-
 use std::future::{self, Future};
 use std::pin::Pin;
 

--- a/src/test/ui/issues/issue-75777.stderr
+++ b/src/test/ui/issues/issue-75777.stderr
@@ -1,16 +1,16 @@
 error[E0495]: cannot infer an appropriate lifetime due to conflicting requirements
-  --> $DIR/issue-75777.rs:13:14
+  --> $DIR/issue-75777.rs:11:14
    |
 LL |     Box::new(move |_| fut)
    |              ^^^^^^^^^^^^
    |
 note: first, the lifetime cannot outlive the lifetime `'a` as defined here...
-  --> $DIR/issue-75777.rs:11:11
+  --> $DIR/issue-75777.rs:9:11
    |
 LL | fn inject<'a, Env: 'a, A: 'a + Send>(v: A) -> Box<dyn FnOnce(&'a Env) -> BoxFuture<'a, A>> {
    |           ^^
 note: ...so that the types are compatible
-  --> $DIR/issue-75777.rs:13:14
+  --> $DIR/issue-75777.rs:11:14
    |
 LL |     Box::new(move |_| fut)
    |              ^^^^^^^^^^^^
@@ -18,7 +18,7 @@ LL |     Box::new(move |_| fut)
               found `(Pin<Box<(dyn Future<Output = A> + Send + 'a)>>,)`
    = note: but, the lifetime must be valid for the static lifetime...
 note: ...so that the types are compatible
-  --> $DIR/issue-75777.rs:13:5
+  --> $DIR/issue-75777.rs:11:5
    |
 LL |     Box::new(move |_| fut)
    |     ^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/issues/issue-78957.rs
+++ b/src/test/ui/issues/issue-78957.rs
@@ -1,5 +1,4 @@
 #![deny(unused_attributes)]
-#![feature(min_const_generics)]
 
 use std::marker::PhantomData;
 

--- a/src/test/ui/issues/issue-78957.stderr
+++ b/src/test/ui/issues/issue-78957.stderr
@@ -1,11 +1,11 @@
 error[E0518]: attribute should be applied to function or closure
-  --> $DIR/issue-78957.rs:6:16
+  --> $DIR/issue-78957.rs:5:16
    |
 LL | pub struct Foo<#[inline] const N: usize>;
    |                ^^^^^^^^^       - not a function or closure
 
 error: attribute should be applied to a function
-  --> $DIR/issue-78957.rs:8:16
+  --> $DIR/issue-78957.rs:7:16
    |
 LL | pub struct Bar<#[cold] const N: usize>;
    |                ^^^^^^^       - not a function
@@ -18,19 +18,19 @@ LL | #![deny(unused_attributes)]
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 error[E0517]: attribute should be applied to a struct, enum, or union
-  --> $DIR/issue-78957.rs:11:23
+  --> $DIR/issue-78957.rs:10:23
    |
 LL | pub struct Baz<#[repr(C)] const N: usize>;
    |                       ^         - not a struct, enum, or union
 
 error[E0518]: attribute should be applied to function or closure
-  --> $DIR/issue-78957.rs:14:17
+  --> $DIR/issue-78957.rs:13:17
    |
 LL | pub struct Foo2<#[inline] 'a>(PhantomData<&'a ()>);
    |                 ^^^^^^^^^ -- not a function or closure
 
 error: attribute should be applied to a function
-  --> $DIR/issue-78957.rs:16:17
+  --> $DIR/issue-78957.rs:15:17
    |
 LL | pub struct Bar2<#[cold] 'a>(PhantomData<&'a ()>);
    |                 ^^^^^^^ -- not a function
@@ -38,19 +38,19 @@ LL | pub struct Bar2<#[cold] 'a>(PhantomData<&'a ()>);
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 error[E0517]: attribute should be applied to a struct, enum, or union
-  --> $DIR/issue-78957.rs:19:24
+  --> $DIR/issue-78957.rs:18:24
    |
 LL | pub struct Baz2<#[repr(C)] 'a>(PhantomData<&'a ()>);
    |                        ^   -- not a struct, enum, or union
 
 error[E0518]: attribute should be applied to function or closure
-  --> $DIR/issue-78957.rs:22:17
+  --> $DIR/issue-78957.rs:21:17
    |
 LL | pub struct Foo3<#[inline] T>(PhantomData<T>);
    |                 ^^^^^^^^^ - not a function or closure
 
 error: attribute should be applied to a function
-  --> $DIR/issue-78957.rs:24:17
+  --> $DIR/issue-78957.rs:23:17
    |
 LL | pub struct Bar3<#[cold] T>(PhantomData<T>);
    |                 ^^^^^^^ - not a function
@@ -58,7 +58,7 @@ LL | pub struct Bar3<#[cold] T>(PhantomData<T>);
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
 
 error[E0517]: attribute should be applied to a struct, enum, or union
-  --> $DIR/issue-78957.rs:27:24
+  --> $DIR/issue-78957.rs:26:24
    |
 LL | pub struct Baz3<#[repr(C)] T>(PhantomData<T>);
    |                        ^   - not a struct, enum, or union

--- a/src/test/ui/macros/macro-non-lifetime.rs
+++ b/src/test/ui/macros/macro-non-lifetime.rs
@@ -1,7 +1,5 @@
 // Test for issue #50381: non-lifetime passed to :lifetime.
 
-#![feature(macro_lifetime_matcher)]
-
 macro_rules! m { ($x:lifetime) => { } }
 
 fn main() {

--- a/src/test/ui/macros/macro-non-lifetime.stderr
+++ b/src/test/ui/macros/macro-non-lifetime.stderr
@@ -1,5 +1,5 @@
 error: no rules expected the token `a`
-  --> $DIR/macro-non-lifetime.rs:8:8
+  --> $DIR/macro-non-lifetime.rs:6:8
    |
 LL | macro_rules! m { ($x:lifetime) => { } }
    | -------------- when calling this macro

--- a/src/test/ui/macros/macro-path-prelude-fail-1.rs
+++ b/src/test/ui/macros/macro-path-prelude-fail-1.rs
@@ -1,5 +1,3 @@
-#![feature(extern_prelude)]
-
 mod m {
     fn check() {
         Vec::clone!(); //~ ERROR failed to resolve: `Vec` is a struct, not a module

--- a/src/test/ui/macros/macro-path-prelude-fail-1.stderr
+++ b/src/test/ui/macros/macro-path-prelude-fail-1.stderr
@@ -1,11 +1,11 @@
 error[E0433]: failed to resolve: `Vec` is a struct, not a module
-  --> $DIR/macro-path-prelude-fail-1.rs:5:9
+  --> $DIR/macro-path-prelude-fail-1.rs:3:9
    |
 LL |         Vec::clone!();
    |         ^^^ `Vec` is a struct, not a module
 
 error[E0433]: failed to resolve: `u8` is a builtin type, not a module
-  --> $DIR/macro-path-prelude-fail-1.rs:6:9
+  --> $DIR/macro-path-prelude-fail-1.rs:4:9
    |
 LL |         u8::clone!();
    |         ^^ `u8` is a builtin type, not a module

--- a/src/test/ui/macros/macro-path-prelude-shadowing.rs
+++ b/src/test/ui/macros/macro-path-prelude-shadowing.rs
@@ -1,6 +1,6 @@
 // aux-build:macro-in-other-crate.rs
 
-#![feature(decl_macro, extern_prelude)]
+#![feature(decl_macro)]
 
 macro_rules! add_macro_expanded_things_to_macro_prelude {() => {
     #[macro_use]

--- a/src/test/ui/macros/macro-stability.rs
+++ b/src/test/ui/macros/macro-stability.rs
@@ -2,7 +2,10 @@
 
 #![feature(decl_macro)]
 #![feature(staged_api)]
-#[macro_use] extern crate unstable_macros;
+#![stable(feature = "rust1", since = "1.0.0")]
+
+#[macro_use]
+extern crate unstable_macros;
 
 #[unstable(feature = "local_unstable", issue = "none")]
 macro_rules! local_unstable { () => () }

--- a/src/test/ui/macros/macro-stability.stderr
+++ b/src/test/ui/macros/macro-stability.stderr
@@ -1,5 +1,5 @@
 error[E0658]: use of unstable library feature 'local_unstable'
-  --> $DIR/macro-stability.rs:19:5
+  --> $DIR/macro-stability.rs:22:5
    |
 LL |     local_unstable!();
    |     ^^^^^^^^^^^^^^
@@ -7,7 +7,7 @@ LL |     local_unstable!();
    = help: add `#![feature(local_unstable)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'local_unstable'
-  --> $DIR/macro-stability.rs:20:5
+  --> $DIR/macro-stability.rs:23:5
    |
 LL |     local_unstable_modern!();
    |     ^^^^^^^^^^^^^^^^^^^^^
@@ -15,7 +15,7 @@ LL |     local_unstable_modern!();
    = help: add `#![feature(local_unstable)]` to the crate attributes to enable
 
 error[E0658]: use of unstable library feature 'unstable_macros'
-  --> $DIR/macro-stability.rs:21:5
+  --> $DIR/macro-stability.rs:24:5
    |
 LL |     unstable_macro!();
    |     ^^^^^^^^^^^^^^
@@ -23,7 +23,7 @@ LL |     unstable_macro!();
    = help: add `#![feature(unstable_macros)]` to the crate attributes to enable
 
 warning: use of deprecated macro `deprecated_macro`: deprecation reason
-  --> $DIR/macro-stability.rs:24:5
+  --> $DIR/macro-stability.rs:27:5
    |
 LL |     deprecated_macro!();
    |     ^^^^^^^^^^^^^^^^
@@ -31,7 +31,7 @@ LL |     deprecated_macro!();
    = note: `#[warn(deprecated)]` on by default
 
 warning: use of deprecated macro `local_deprecated`: local deprecation reason
-  --> $DIR/macro-stability.rs:26:5
+  --> $DIR/macro-stability.rs:29:5
    |
 LL |     local_deprecated!();
    |     ^^^^^^^^^^^^^^^^

--- a/src/test/ui/main-wrong-location.rs
+++ b/src/test/ui/main-wrong-location.rs
@@ -1,6 +1,5 @@
 mod m {
-//~^ ERROR `main` function not found
     // An inferred main entry point
     // must appear at the top of the crate
     fn main() { }
-}
+} //~ ERROR `main` function not found

--- a/src/test/ui/main-wrong-location.stderr
+++ b/src/test/ui/main-wrong-location.stderr
@@ -1,16 +1,11 @@
 error[E0601]: `main` function not found in crate `main_wrong_location`
-  --> $DIR/main-wrong-location.rs:1:1
+  --> $DIR/main-wrong-location.rs:5:2
    |
-LL | / mod m {
-LL | |
-LL | |     // An inferred main entry point
-LL | |     // must appear at the top of the crate
-LL | |     fn main() { }
-LL | | }
-   | |_^ the main function must be defined at the crate level (in `$DIR/main-wrong-location.rs`)
+LL | }
+   |  ^ the main function must be defined at the crate level (in `$DIR/main-wrong-location.rs`)
    |
 note: here is a function named `main`
-  --> $DIR/main-wrong-location.rs:5:5
+  --> $DIR/main-wrong-location.rs:4:5
    |
 LL |     fn main() { }
    |     ^^^^^^^^^^^^^

--- a/src/test/ui/missing/missing-alloc_error_handler.rs
+++ b/src/test/ui/missing/missing-alloc_error_handler.rs
@@ -3,7 +3,7 @@
 
 #![no_std]
 #![crate_type = "staticlib"]
-#![feature(panic_handler, alloc_error_handler)]
+#![feature(alloc_error_handler)]
 
 #[panic_handler]
 fn panic(_: &core::panic::PanicInfo) -> ! {

--- a/src/test/ui/missing/missing-allocator.rs
+++ b/src/test/ui/missing/missing-allocator.rs
@@ -3,7 +3,7 @@
 
 #![no_std]
 #![crate_type = "staticlib"]
-#![feature(panic_handler, alloc_error_handler)]
+#![feature(alloc_error_handler)]
 
 #[panic_handler]
 fn panic(_: &core::panic::PanicInfo) -> ! {

--- a/src/test/ui/missing/missing-main.stderr
+++ b/src/test/ui/missing/missing-main.stderr
@@ -1,8 +1,8 @@
 error[E0601]: `main` function not found in crate `missing_main`
-  --> $DIR/missing-main.rs:2:1
+  --> $DIR/missing-main.rs:2:14
    |
 LL | fn mian() { }
-   | ^^^^^^^^^^^^^ consider adding a `main` function to `$DIR/missing-main.rs`
+   |              ^ consider adding a `main` function to `$DIR/missing-main.rs`
 
 error: aborting due to previous error
 

--- a/src/test/ui/moves/use_of_moved_value_clone_suggestions.rs
+++ b/src/test/ui/moves/use_of_moved_value_clone_suggestions.rs
@@ -1,0 +1,6 @@
+// `Rc` is not ever `Copy`, we should not suggest adding `T: Copy` constraint
+fn duplicate_rc<T>(t: std::rc::Rc<T>) -> (std::rc::Rc<T>, std::rc::Rc<T>) {
+    (t, t) //~ use of moved value: `t`
+}
+
+fn main() {}

--- a/src/test/ui/moves/use_of_moved_value_clone_suggestions.stderr
+++ b/src/test/ui/moves/use_of_moved_value_clone_suggestions.stderr
@@ -1,0 +1,13 @@
+error[E0382]: use of moved value: `t`
+  --> $DIR/use_of_moved_value_clone_suggestions.rs:3:9
+   |
+LL | fn duplicate_rc<T>(t: std::rc::Rc<T>) -> (std::rc::Rc<T>, std::rc::Rc<T>) {
+   |                    - move occurs because `t` has type `Rc<T>`, which does not implement the `Copy` trait
+LL |     (t, t)
+   |      -  ^ value used here after move
+   |      |
+   |      value moved here
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0382`.

--- a/src/test/ui/moves/use_of_moved_value_copy_suggestions.fixed
+++ b/src/test/ui/moves/use_of_moved_value_copy_suggestions.fixed
@@ -1,27 +1,27 @@
 // run-rustfix
 #![allow(dead_code)]
 
-fn duplicate_t<T>(t: T) -> (T, T) {
+fn duplicate_t<T: Copy>(t: T) -> (T, T) {
     //~^ HELP consider restricting type parameter `T`
     (t, t) //~ use of moved value: `t`
 }
 
-fn duplicate_opt<T>(t: Option<T>) -> (Option<T>, Option<T>) {
+fn duplicate_opt<T: Copy>(t: Option<T>) -> (Option<T>, Option<T>) {
     //~^ HELP consider restricting type parameter `T`
     (t, t) //~ use of moved value: `t`
 }
 
-fn duplicate_tup1<T>(t: (T,)) -> ((T,), (T,)) {
+fn duplicate_tup1<T: Copy>(t: (T,)) -> ((T,), (T,)) {
     //~^ HELP consider restricting type parameter `T`
     (t, t) //~ use of moved value: `t`
 }
 
-fn duplicate_tup2<A, B>(t: (A, B)) -> ((A, B), (A, B)) {
+fn duplicate_tup2<A: Copy, B: Copy>(t: (A, B)) -> ((A, B), (A, B)) {
     //~^ HELP consider restricting type parameters
     (t, t) //~ use of moved value: `t`
 }
 
-fn duplicate_custom<T>(t: S<T>) -> (S<T>, S<T>) {
+fn duplicate_custom<T: Trait + Copy>(t: S<T>) -> (S<T>, S<T>) {
     //~^ HELP consider restricting type parameter `T`
     (t, t) //~ use of moved value: `t`
 }
@@ -39,14 +39,14 @@ trait A {}
 trait B {}
 
 // Test where bounds are added with different bound placements
-fn duplicate_custom_1<T>(t: S<T>) -> (S<T>, S<T>) where {
+fn duplicate_custom_1<T: Trait + Copy>(t: S<T>) -> (S<T>, S<T>) where {
     //~^ HELP consider restricting type parameter `T`
     (t, t) //~ use of moved value: `t`
 }
 
 fn duplicate_custom_2<T>(t: S<T>) -> (S<T>, S<T>)
 where
-    T: A,
+    T: A + Trait + Copy,
     //~^ HELP consider further restricting this bound
 {
     (t, t) //~ use of moved value: `t`
@@ -55,7 +55,7 @@ where
 fn duplicate_custom_3<T>(t: S<T>) -> (S<T>, S<T>)
 where
     T: A,
-    T: B,
+    T: B, T: Trait, T: Copy
     //~^ HELP consider further restricting type parameter `T`
 {
     (t, t) //~ use of moved value: `t`
@@ -63,7 +63,7 @@ where
 
 fn duplicate_custom_4<T: A>(t: S<T>) -> (S<T>, S<T>)
 where
-    T: B,
+    T: B + Trait + Copy,
     //~^ HELP consider further restricting this bound
 {
     (t, t) //~ use of moved value: `t`

--- a/src/test/ui/moves/use_of_moved_value_copy_suggestions.rs
+++ b/src/test/ui/moves/use_of_moved_value_copy_suggestions.rs
@@ -1,0 +1,65 @@
+fn duplicate_t<T>(t: T) -> (T, T) {
+    (t, t) //~ use of moved value: `t`
+}
+
+fn duplicate_opt<T>(t: Option<T>) -> (Option<T>, Option<T>) {
+    (t, t) //~ use of moved value: `t`
+}
+
+fn duplicate_tup1<T>(t: (T,)) -> ((T,), (T,)) {
+    (t, t) //~ use of moved value: `t`
+}
+
+fn duplicate_tup2<A, B>(t: (A, B)) -> ((A, B), (A, B)) {
+    (t, t) //~ use of moved value: `t`
+}
+
+fn duplicate_custom<T>(t: S<T>) -> (S<T>, S<T>) {
+    (t, t) //~ use of moved value: `t`
+}
+
+struct S<T>(T);
+trait Trait {}
+impl<T: Trait + Clone> Clone for S<T> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+impl<T: Trait + Copy> Copy for S<T> {}
+
+trait A {}
+trait B {}
+
+// Test where bounds are added with different bound placements
+fn duplicate_custom_1<T>(t: S<T>) -> (S<T>, S<T>) where {
+    (t, t) //~ use of moved value: `t`
+}
+
+fn duplicate_custom_2<T>(t: S<T>) -> (S<T>, S<T>)
+where
+    T: A,
+{
+    (t, t) //~ use of moved value: `t`
+}
+
+fn duplicate_custom_3<T>(t: S<T>) -> (S<T>, S<T>)
+where
+    T: A,
+    T: B,
+{
+    (t, t) //~ use of moved value: `t`
+}
+
+fn duplicate_custom_4<T: A>(t: S<T>) -> (S<T>, S<T>)
+where
+    T: B,
+{
+    (t, t) //~ use of moved value: `t`
+}
+
+// `Rc` is not ever `Copy`, we should not suggest adding `T: Copy` constraint
+fn duplicate_rc<T>(t: std::rc::Rc<T>) -> (std::rc::Rc<T>, std::rc::Rc<T>) {
+    (t, t) //~ use of moved value: `t`
+}
+
+fn main() {}

--- a/src/test/ui/moves/use_of_moved_value_copy_suggestions.stderr
+++ b/src/test/ui/moves/use_of_moved_value_copy_suggestions.stderr
@@ -1,0 +1,151 @@
+error[E0382]: use of moved value: `t`
+  --> $DIR/use_of_moved_value_copy_suggestions.rs:2:9
+   |
+LL | fn duplicate_t<T>(t: T) -> (T, T) {
+   |                   - move occurs because `t` has type `T`, which does not implement the `Copy` trait
+LL |     (t, t)
+   |      -  ^ value used here after move
+   |      |
+   |      value moved here
+   |
+help: consider restricting type parameter `T`
+   |
+LL | fn duplicate_t<T: Copy>(t: T) -> (T, T) {
+   |                 ++++++
+
+error[E0382]: use of moved value: `t`
+  --> $DIR/use_of_moved_value_copy_suggestions.rs:6:9
+   |
+LL | fn duplicate_opt<T>(t: Option<T>) -> (Option<T>, Option<T>) {
+   |                     - move occurs because `t` has type `Option<T>`, which does not implement the `Copy` trait
+LL |     (t, t)
+   |      -  ^ value used here after move
+   |      |
+   |      value moved here
+   |
+help: consider restricting type parameter `T`
+   |
+LL | fn duplicate_opt<T: Copy>(t: Option<T>) -> (Option<T>, Option<T>) {
+   |                   ++++++
+
+error[E0382]: use of moved value: `t`
+  --> $DIR/use_of_moved_value_copy_suggestions.rs:10:9
+   |
+LL | fn duplicate_tup1<T>(t: (T,)) -> ((T,), (T,)) {
+   |                      - move occurs because `t` has type `(T,)`, which does not implement the `Copy` trait
+LL |     (t, t)
+   |      -  ^ value used here after move
+   |      |
+   |      value moved here
+   |
+help: consider restricting type parameter `T`
+   |
+LL | fn duplicate_tup1<T: Copy>(t: (T,)) -> ((T,), (T,)) {
+   |                    ++++++
+
+error[E0382]: use of moved value: `t`
+  --> $DIR/use_of_moved_value_copy_suggestions.rs:14:9
+   |
+LL | fn duplicate_tup2<A, B>(t: (A, B)) -> ((A, B), (A, B)) {
+   |                         - move occurs because `t` has type `(A, B)`, which does not implement the `Copy` trait
+LL |     (t, t)
+   |      -  ^ value used here after move
+   |      |
+   |      value moved here
+   |
+help: consider restricting type parameters
+   |
+LL | fn duplicate_tup2<A: Copy, B: Copy>(t: (A, B)) -> ((A, B), (A, B)) {
+   |                    ++++++   ++++++
+
+error[E0382]: use of moved value: `t`
+  --> $DIR/use_of_moved_value_copy_suggestions.rs:18:9
+   |
+LL | fn duplicate_custom<T>(t: S<T>) -> (S<T>, S<T>) {
+   |                        - move occurs because `t` has type `S<T>`, which does not implement the `Copy` trait
+LL |     (t, t)
+   |      -  ^ value used here after move
+   |      |
+   |      value moved here
+   |
+help: consider restricting type parameter `T`
+   |
+LL | fn duplicate_custom<T: Trait + Copy>(t: S<T>) -> (S<T>, S<T>) {
+   |                      ++++++++++++++
+
+error[E0382]: use of moved value: `t`
+  --> $DIR/use_of_moved_value_copy_suggestions.rs:35:9
+   |
+LL | fn duplicate_custom_1<T>(t: S<T>) -> (S<T>, S<T>) where {
+   |                          - move occurs because `t` has type `S<T>`, which does not implement the `Copy` trait
+LL |     (t, t)
+   |      -  ^ value used here after move
+   |      |
+   |      value moved here
+   |
+help: consider restricting type parameter `T`
+   |
+LL | fn duplicate_custom_1<T: Trait + Copy>(t: S<T>) -> (S<T>, S<T>) where {
+   |                        ++++++++++++++
+
+error[E0382]: use of moved value: `t`
+  --> $DIR/use_of_moved_value_copy_suggestions.rs:42:9
+   |
+LL | fn duplicate_custom_2<T>(t: S<T>) -> (S<T>, S<T>)
+   |                          - move occurs because `t` has type `S<T>`, which does not implement the `Copy` trait
+...
+LL |     (t, t)
+   |      -  ^ value used here after move
+   |      |
+   |      value moved here
+   |
+help: consider further restricting this bound
+   |
+LL |     T: A + Trait + Copy,
+   |          ++++++++++++++
+
+error[E0382]: use of moved value: `t`
+  --> $DIR/use_of_moved_value_copy_suggestions.rs:50:9
+   |
+LL | fn duplicate_custom_3<T>(t: S<T>) -> (S<T>, S<T>)
+   |                          - move occurs because `t` has type `S<T>`, which does not implement the `Copy` trait
+...
+LL |     (t, t)
+   |      -  ^ value used here after move
+   |      |
+   |      value moved here
+   |
+help: consider further restricting type parameter `T`
+   |
+LL |     T: B, T: Trait, T: Copy
+   |         ~~~~~~~~~~~~~~~~~~~
+
+error[E0382]: use of moved value: `t`
+  --> $DIR/use_of_moved_value_copy_suggestions.rs:57:9
+   |
+LL | fn duplicate_custom_4<T: A>(t: S<T>) -> (S<T>, S<T>)
+   |                             - move occurs because `t` has type `S<T>`, which does not implement the `Copy` trait
+...
+LL |     (t, t)
+   |      -  ^ value used here after move
+   |      |
+   |      value moved here
+   |
+help: consider further restricting this bound
+   |
+LL |     T: B + Trait + Copy,
+   |          ++++++++++++++
+
+error[E0382]: use of moved value: `t`
+  --> $DIR/use_of_moved_value_copy_suggestions.rs:62:9
+   |
+LL | fn duplicate_rc<T>(t: std::rc::Rc<T>) -> (std::rc::Rc<T>, std::rc::Rc<T>) {
+   |                    - move occurs because `t` has type `Rc<T>`, which does not implement the `Copy` trait
+LL |     (t, t)
+   |      -  ^ value used here after move
+   |      |
+   |      value moved here
+
+error: aborting due to 10 previous errors
+
+For more information about this error, try `rustc --explain E0382`.

--- a/src/test/ui/moves/use_of_moved_value_copy_suggestions.stderr
+++ b/src/test/ui/moves/use_of_moved_value_copy_suggestions.stderr
@@ -1,8 +1,9 @@
 error[E0382]: use of moved value: `t`
-  --> $DIR/use_of_moved_value_copy_suggestions.rs:2:9
+  --> $DIR/use_of_moved_value_copy_suggestions.rs:6:9
    |
 LL | fn duplicate_t<T>(t: T) -> (T, T) {
    |                   - move occurs because `t` has type `T`, which does not implement the `Copy` trait
+LL |
 LL |     (t, t)
    |      -  ^ value used here after move
    |      |
@@ -14,10 +15,11 @@ LL | fn duplicate_t<T: Copy>(t: T) -> (T, T) {
    |                 ++++++
 
 error[E0382]: use of moved value: `t`
-  --> $DIR/use_of_moved_value_copy_suggestions.rs:6:9
+  --> $DIR/use_of_moved_value_copy_suggestions.rs:11:9
    |
 LL | fn duplicate_opt<T>(t: Option<T>) -> (Option<T>, Option<T>) {
    |                     - move occurs because `t` has type `Option<T>`, which does not implement the `Copy` trait
+LL |
 LL |     (t, t)
    |      -  ^ value used here after move
    |      |
@@ -29,10 +31,11 @@ LL | fn duplicate_opt<T: Copy>(t: Option<T>) -> (Option<T>, Option<T>) {
    |                   ++++++
 
 error[E0382]: use of moved value: `t`
-  --> $DIR/use_of_moved_value_copy_suggestions.rs:10:9
+  --> $DIR/use_of_moved_value_copy_suggestions.rs:16:9
    |
 LL | fn duplicate_tup1<T>(t: (T,)) -> ((T,), (T,)) {
    |                      - move occurs because `t` has type `(T,)`, which does not implement the `Copy` trait
+LL |
 LL |     (t, t)
    |      -  ^ value used here after move
    |      |
@@ -44,10 +47,11 @@ LL | fn duplicate_tup1<T: Copy>(t: (T,)) -> ((T,), (T,)) {
    |                    ++++++
 
 error[E0382]: use of moved value: `t`
-  --> $DIR/use_of_moved_value_copy_suggestions.rs:14:9
+  --> $DIR/use_of_moved_value_copy_suggestions.rs:21:9
    |
 LL | fn duplicate_tup2<A, B>(t: (A, B)) -> ((A, B), (A, B)) {
    |                         - move occurs because `t` has type `(A, B)`, which does not implement the `Copy` trait
+LL |
 LL |     (t, t)
    |      -  ^ value used here after move
    |      |
@@ -59,10 +63,11 @@ LL | fn duplicate_tup2<A: Copy, B: Copy>(t: (A, B)) -> ((A, B), (A, B)) {
    |                    ++++++   ++++++
 
 error[E0382]: use of moved value: `t`
-  --> $DIR/use_of_moved_value_copy_suggestions.rs:18:9
+  --> $DIR/use_of_moved_value_copy_suggestions.rs:26:9
    |
 LL | fn duplicate_custom<T>(t: S<T>) -> (S<T>, S<T>) {
    |                        - move occurs because `t` has type `S<T>`, which does not implement the `Copy` trait
+LL |
 LL |     (t, t)
    |      -  ^ value used here after move
    |      |
@@ -74,10 +79,11 @@ LL | fn duplicate_custom<T: Trait + Copy>(t: S<T>) -> (S<T>, S<T>) {
    |                      ++++++++++++++
 
 error[E0382]: use of moved value: `t`
-  --> $DIR/use_of_moved_value_copy_suggestions.rs:35:9
+  --> $DIR/use_of_moved_value_copy_suggestions.rs:44:9
    |
 LL | fn duplicate_custom_1<T>(t: S<T>) -> (S<T>, S<T>) where {
    |                          - move occurs because `t` has type `S<T>`, which does not implement the `Copy` trait
+LL |
 LL |     (t, t)
    |      -  ^ value used here after move
    |      |
@@ -89,7 +95,7 @@ LL | fn duplicate_custom_1<T: Trait + Copy>(t: S<T>) -> (S<T>, S<T>) where {
    |                        ++++++++++++++
 
 error[E0382]: use of moved value: `t`
-  --> $DIR/use_of_moved_value_copy_suggestions.rs:42:9
+  --> $DIR/use_of_moved_value_copy_suggestions.rs:52:9
    |
 LL | fn duplicate_custom_2<T>(t: S<T>) -> (S<T>, S<T>)
    |                          - move occurs because `t` has type `S<T>`, which does not implement the `Copy` trait
@@ -105,7 +111,7 @@ LL |     T: A + Trait + Copy,
    |          ++++++++++++++
 
 error[E0382]: use of moved value: `t`
-  --> $DIR/use_of_moved_value_copy_suggestions.rs:50:9
+  --> $DIR/use_of_moved_value_copy_suggestions.rs:61:9
    |
 LL | fn duplicate_custom_3<T>(t: S<T>) -> (S<T>, S<T>)
    |                          - move occurs because `t` has type `S<T>`, which does not implement the `Copy` trait
@@ -121,7 +127,7 @@ LL |     T: B, T: Trait, T: Copy
    |         ~~~~~~~~~~~~~~~~~~~
 
 error[E0382]: use of moved value: `t`
-  --> $DIR/use_of_moved_value_copy_suggestions.rs:57:9
+  --> $DIR/use_of_moved_value_copy_suggestions.rs:69:9
    |
 LL | fn duplicate_custom_4<T: A>(t: S<T>) -> (S<T>, S<T>)
    |                             - move occurs because `t` has type `S<T>`, which does not implement the `Copy` trait
@@ -136,16 +142,6 @@ help: consider further restricting this bound
 LL |     T: B + Trait + Copy,
    |          ++++++++++++++
 
-error[E0382]: use of moved value: `t`
-  --> $DIR/use_of_moved_value_copy_suggestions.rs:62:9
-   |
-LL | fn duplicate_rc<T>(t: std::rc::Rc<T>) -> (std::rc::Rc<T>, std::rc::Rc<T>) {
-   |                    - move occurs because `t` has type `Rc<T>`, which does not implement the `Copy` trait
-LL |     (t, t)
-   |      -  ^ value used here after move
-   |      |
-   |      value moved here
-
-error: aborting due to 10 previous errors
+error: aborting due to 9 previous errors
 
 For more information about this error, try `rustc --explain E0382`.

--- a/src/test/ui/not-panic/not-panic-safe.rs
+++ b/src/test/ui/not-panic/not-panic-safe.rs
@@ -1,5 +1,4 @@
 #![allow(dead_code)]
-#![feature(recover)]
 
 use std::panic::UnwindSafe;
 

--- a/src/test/ui/not-panic/not-panic-safe.stderr
+++ b/src/test/ui/not-panic/not-panic-safe.stderr
@@ -1,5 +1,5 @@
 error[E0277]: the type `&mut i32` may not be safely transferred across an unwind boundary
-  --> $DIR/not-panic-safe.rs:9:5
+  --> $DIR/not-panic-safe.rs:8:5
    |
 LL |     assert::<&mut i32>();
    |     ^^^^^^^^^^^^^^^^^^ `&mut i32` may not be safely transferred across an unwind boundary
@@ -7,7 +7,7 @@ LL |     assert::<&mut i32>();
    = help: the trait `UnwindSafe` is not implemented for `&mut i32`
    = note: `UnwindSafe` is implemented for `&i32`, but not for `&mut i32`
 note: required by a bound in `assert`
-  --> $DIR/not-panic-safe.rs:6:14
+  --> $DIR/not-panic-safe.rs:5:14
    |
 LL | fn assert<T: UnwindSafe + ?Sized>() {}
    |              ^^^^^^^^^^ required by this bound in `assert`

--- a/src/test/ui/numbers-arithmetic/issue-8460-const.noopt.stderr
+++ b/src/test/ui/numbers-arithmetic/issue-8460-const.noopt.stderr
@@ -1,36 +1,36 @@
-error: this arithmetic operation will overflow
+error: this operation will panic at runtime
   --> $DIR/issue-8460-const.rs:13:36
    |
 LL |     assert!(thread::spawn(move|| { isize::MIN / -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^^^ attempt to compute `isize::MIN / -1_isize`, which would overflow
    |
-   = note: `#[deny(arithmetic_overflow)]` on by default
+   = note: `#[deny(unconditional_panic)]` on by default
 
-error: this arithmetic operation will overflow
+error: this operation will panic at runtime
   --> $DIR/issue-8460-const.rs:15:36
    |
 LL |     assert!(thread::spawn(move|| { i8::MIN / -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^ attempt to compute `i8::MIN / -1_i8`, which would overflow
 
-error: this arithmetic operation will overflow
+error: this operation will panic at runtime
   --> $DIR/issue-8460-const.rs:17:36
    |
 LL |     assert!(thread::spawn(move|| { i16::MIN / -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^ attempt to compute `i16::MIN / -1_i16`, which would overflow
 
-error: this arithmetic operation will overflow
+error: this operation will panic at runtime
   --> $DIR/issue-8460-const.rs:19:36
    |
 LL |     assert!(thread::spawn(move|| { i32::MIN / -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^ attempt to compute `i32::MIN / -1_i32`, which would overflow
 
-error: this arithmetic operation will overflow
+error: this operation will panic at runtime
   --> $DIR/issue-8460-const.rs:21:36
    |
 LL |     assert!(thread::spawn(move|| { i64::MIN / -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^ attempt to compute `i64::MIN / -1_i64`, which would overflow
 
-error: this arithmetic operation will overflow
+error: this operation will panic at runtime
   --> $DIR/issue-8460-const.rs:23:36
    |
 LL |     assert!(thread::spawn(move|| { i128::MIN / -1; }).join().is_err());
@@ -41,8 +41,6 @@ error: this operation will panic at runtime
    |
 LL |     assert!(thread::spawn(move|| { 1isize / 0; }).join().is_err());
    |                                    ^^^^^^^^^^ attempt to divide `1_isize` by zero
-   |
-   = note: `#[deny(unconditional_panic)]` on by default
 
 error: this operation will panic at runtime
   --> $DIR/issue-8460-const.rs:27:36
@@ -74,37 +72,37 @@ error: this operation will panic at runtime
 LL |     assert!(thread::spawn(move|| { 1i128 / 0; }).join().is_err());
    |                                    ^^^^^^^^^ attempt to divide `1_i128` by zero
 
-error: this arithmetic operation will overflow
+error: this operation will panic at runtime
   --> $DIR/issue-8460-const.rs:37:36
    |
 LL |     assert!(thread::spawn(move|| { isize::MIN % -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^^^ attempt to compute the remainder of `isize::MIN % -1_isize`, which would overflow
 
-error: this arithmetic operation will overflow
+error: this operation will panic at runtime
   --> $DIR/issue-8460-const.rs:39:36
    |
 LL |     assert!(thread::spawn(move|| { i8::MIN % -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^ attempt to compute the remainder of `i8::MIN % -1_i8`, which would overflow
 
-error: this arithmetic operation will overflow
+error: this operation will panic at runtime
   --> $DIR/issue-8460-const.rs:41:36
    |
 LL |     assert!(thread::spawn(move|| { i16::MIN % -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^ attempt to compute the remainder of `i16::MIN % -1_i16`, which would overflow
 
-error: this arithmetic operation will overflow
+error: this operation will panic at runtime
   --> $DIR/issue-8460-const.rs:43:36
    |
 LL |     assert!(thread::spawn(move|| { i32::MIN % -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^ attempt to compute the remainder of `i32::MIN % -1_i32`, which would overflow
 
-error: this arithmetic operation will overflow
+error: this operation will panic at runtime
   --> $DIR/issue-8460-const.rs:45:36
    |
 LL |     assert!(thread::spawn(move|| { i64::MIN % -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^ attempt to compute the remainder of `i64::MIN % -1_i64`, which would overflow
 
-error: this arithmetic operation will overflow
+error: this operation will panic at runtime
   --> $DIR/issue-8460-const.rs:47:36
    |
 LL |     assert!(thread::spawn(move|| { i128::MIN % -1; }).join().is_err());

--- a/src/test/ui/numbers-arithmetic/issue-8460-const.opt.stderr
+++ b/src/test/ui/numbers-arithmetic/issue-8460-const.opt.stderr
@@ -1,36 +1,36 @@
-error: this arithmetic operation will overflow
+error: this operation will panic at runtime
   --> $DIR/issue-8460-const.rs:13:36
    |
 LL |     assert!(thread::spawn(move|| { isize::MIN / -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^^^ attempt to compute `isize::MIN / -1_isize`, which would overflow
    |
-   = note: `#[deny(arithmetic_overflow)]` on by default
+   = note: `#[deny(unconditional_panic)]` on by default
 
-error: this arithmetic operation will overflow
+error: this operation will panic at runtime
   --> $DIR/issue-8460-const.rs:15:36
    |
 LL |     assert!(thread::spawn(move|| { i8::MIN / -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^ attempt to compute `i8::MIN / -1_i8`, which would overflow
 
-error: this arithmetic operation will overflow
+error: this operation will panic at runtime
   --> $DIR/issue-8460-const.rs:17:36
    |
 LL |     assert!(thread::spawn(move|| { i16::MIN / -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^ attempt to compute `i16::MIN / -1_i16`, which would overflow
 
-error: this arithmetic operation will overflow
+error: this operation will panic at runtime
   --> $DIR/issue-8460-const.rs:19:36
    |
 LL |     assert!(thread::spawn(move|| { i32::MIN / -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^ attempt to compute `i32::MIN / -1_i32`, which would overflow
 
-error: this arithmetic operation will overflow
+error: this operation will panic at runtime
   --> $DIR/issue-8460-const.rs:21:36
    |
 LL |     assert!(thread::spawn(move|| { i64::MIN / -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^ attempt to compute `i64::MIN / -1_i64`, which would overflow
 
-error: this arithmetic operation will overflow
+error: this operation will panic at runtime
   --> $DIR/issue-8460-const.rs:23:36
    |
 LL |     assert!(thread::spawn(move|| { i128::MIN / -1; }).join().is_err());
@@ -41,8 +41,6 @@ error: this operation will panic at runtime
    |
 LL |     assert!(thread::spawn(move|| { 1isize / 0; }).join().is_err());
    |                                    ^^^^^^^^^^ attempt to divide `1_isize` by zero
-   |
-   = note: `#[deny(unconditional_panic)]` on by default
 
 error: this operation will panic at runtime
   --> $DIR/issue-8460-const.rs:27:36
@@ -74,37 +72,37 @@ error: this operation will panic at runtime
 LL |     assert!(thread::spawn(move|| { 1i128 / 0; }).join().is_err());
    |                                    ^^^^^^^^^ attempt to divide `1_i128` by zero
 
-error: this arithmetic operation will overflow
+error: this operation will panic at runtime
   --> $DIR/issue-8460-const.rs:37:36
    |
 LL |     assert!(thread::spawn(move|| { isize::MIN % -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^^^ attempt to compute the remainder of `isize::MIN % -1_isize`, which would overflow
 
-error: this arithmetic operation will overflow
+error: this operation will panic at runtime
   --> $DIR/issue-8460-const.rs:39:36
    |
 LL |     assert!(thread::spawn(move|| { i8::MIN % -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^ attempt to compute the remainder of `i8::MIN % -1_i8`, which would overflow
 
-error: this arithmetic operation will overflow
+error: this operation will panic at runtime
   --> $DIR/issue-8460-const.rs:41:36
    |
 LL |     assert!(thread::spawn(move|| { i16::MIN % -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^ attempt to compute the remainder of `i16::MIN % -1_i16`, which would overflow
 
-error: this arithmetic operation will overflow
+error: this operation will panic at runtime
   --> $DIR/issue-8460-const.rs:43:36
    |
 LL |     assert!(thread::spawn(move|| { i32::MIN % -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^ attempt to compute the remainder of `i32::MIN % -1_i32`, which would overflow
 
-error: this arithmetic operation will overflow
+error: this operation will panic at runtime
   --> $DIR/issue-8460-const.rs:45:36
    |
 LL |     assert!(thread::spawn(move|| { i64::MIN % -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^ attempt to compute the remainder of `i64::MIN % -1_i64`, which would overflow
 
-error: this arithmetic operation will overflow
+error: this operation will panic at runtime
   --> $DIR/issue-8460-const.rs:47:36
    |
 LL |     assert!(thread::spawn(move|| { i128::MIN % -1; }).join().is_err());

--- a/src/test/ui/numbers-arithmetic/issue-8460-const.opt_with_overflow_checks.stderr
+++ b/src/test/ui/numbers-arithmetic/issue-8460-const.opt_with_overflow_checks.stderr
@@ -1,36 +1,36 @@
-error: this arithmetic operation will overflow
+error: this operation will panic at runtime
   --> $DIR/issue-8460-const.rs:13:36
    |
 LL |     assert!(thread::spawn(move|| { isize::MIN / -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^^^ attempt to compute `isize::MIN / -1_isize`, which would overflow
    |
-   = note: `#[deny(arithmetic_overflow)]` on by default
+   = note: `#[deny(unconditional_panic)]` on by default
 
-error: this arithmetic operation will overflow
+error: this operation will panic at runtime
   --> $DIR/issue-8460-const.rs:15:36
    |
 LL |     assert!(thread::spawn(move|| { i8::MIN / -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^ attempt to compute `i8::MIN / -1_i8`, which would overflow
 
-error: this arithmetic operation will overflow
+error: this operation will panic at runtime
   --> $DIR/issue-8460-const.rs:17:36
    |
 LL |     assert!(thread::spawn(move|| { i16::MIN / -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^ attempt to compute `i16::MIN / -1_i16`, which would overflow
 
-error: this arithmetic operation will overflow
+error: this operation will panic at runtime
   --> $DIR/issue-8460-const.rs:19:36
    |
 LL |     assert!(thread::spawn(move|| { i32::MIN / -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^ attempt to compute `i32::MIN / -1_i32`, which would overflow
 
-error: this arithmetic operation will overflow
+error: this operation will panic at runtime
   --> $DIR/issue-8460-const.rs:21:36
    |
 LL |     assert!(thread::spawn(move|| { i64::MIN / -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^ attempt to compute `i64::MIN / -1_i64`, which would overflow
 
-error: this arithmetic operation will overflow
+error: this operation will panic at runtime
   --> $DIR/issue-8460-const.rs:23:36
    |
 LL |     assert!(thread::spawn(move|| { i128::MIN / -1; }).join().is_err());
@@ -41,8 +41,6 @@ error: this operation will panic at runtime
    |
 LL |     assert!(thread::spawn(move|| { 1isize / 0; }).join().is_err());
    |                                    ^^^^^^^^^^ attempt to divide `1_isize` by zero
-   |
-   = note: `#[deny(unconditional_panic)]` on by default
 
 error: this operation will panic at runtime
   --> $DIR/issue-8460-const.rs:27:36
@@ -74,37 +72,37 @@ error: this operation will panic at runtime
 LL |     assert!(thread::spawn(move|| { 1i128 / 0; }).join().is_err());
    |                                    ^^^^^^^^^ attempt to divide `1_i128` by zero
 
-error: this arithmetic operation will overflow
+error: this operation will panic at runtime
   --> $DIR/issue-8460-const.rs:37:36
    |
 LL |     assert!(thread::spawn(move|| { isize::MIN % -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^^^ attempt to compute the remainder of `isize::MIN % -1_isize`, which would overflow
 
-error: this arithmetic operation will overflow
+error: this operation will panic at runtime
   --> $DIR/issue-8460-const.rs:39:36
    |
 LL |     assert!(thread::spawn(move|| { i8::MIN % -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^ attempt to compute the remainder of `i8::MIN % -1_i8`, which would overflow
 
-error: this arithmetic operation will overflow
+error: this operation will panic at runtime
   --> $DIR/issue-8460-const.rs:41:36
    |
 LL |     assert!(thread::spawn(move|| { i16::MIN % -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^ attempt to compute the remainder of `i16::MIN % -1_i16`, which would overflow
 
-error: this arithmetic operation will overflow
+error: this operation will panic at runtime
   --> $DIR/issue-8460-const.rs:43:36
    |
 LL |     assert!(thread::spawn(move|| { i32::MIN % -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^ attempt to compute the remainder of `i32::MIN % -1_i32`, which would overflow
 
-error: this arithmetic operation will overflow
+error: this operation will panic at runtime
   --> $DIR/issue-8460-const.rs:45:36
    |
 LL |     assert!(thread::spawn(move|| { i64::MIN % -1; }).join().is_err());
    |                                    ^^^^^^^^^^^^^ attempt to compute the remainder of `i64::MIN % -1_i64`, which would overflow
 
-error: this arithmetic operation will overflow
+error: this operation will panic at runtime
   --> $DIR/issue-8460-const.rs:47:36
    |
 LL |     assert!(thread::spawn(move|| { i128::MIN % -1; }).join().is_err());

--- a/src/test/ui/numbers-arithmetic/issue-8460-const.rs
+++ b/src/test/ui/numbers-arithmetic/issue-8460-const.rs
@@ -11,17 +11,17 @@ use std::thread;
 
 fn main() {
     assert!(thread::spawn(move|| { isize::MIN / -1; }).join().is_err());
-    //~^ ERROR arithmetic operation will overflow
+    //~^ ERROR operation will panic
     assert!(thread::spawn(move|| { i8::MIN / -1; }).join().is_err());
-    //~^ ERROR arithmetic operation will overflow
+    //~^ ERROR operation will panic
     assert!(thread::spawn(move|| { i16::MIN / -1; }).join().is_err());
-    //~^ ERROR arithmetic operation will overflow
+    //~^ ERROR operation will panic
     assert!(thread::spawn(move|| { i32::MIN / -1; }).join().is_err());
-    //~^ ERROR arithmetic operation will overflow
+    //~^ ERROR operation will panic
     assert!(thread::spawn(move|| { i64::MIN / -1; }).join().is_err());
-    //~^ ERROR arithmetic operation will overflow
+    //~^ ERROR operation will panic
     assert!(thread::spawn(move|| { i128::MIN / -1; }).join().is_err());
-    //~^ ERROR arithmetic operation will overflow
+    //~^ ERROR operation will panic
     assert!(thread::spawn(move|| { 1isize / 0; }).join().is_err());
     //~^ ERROR operation will panic
     assert!(thread::spawn(move|| { 1i8 / 0; }).join().is_err());
@@ -35,17 +35,17 @@ fn main() {
     assert!(thread::spawn(move|| { 1i128 / 0; }).join().is_err());
     //~^ ERROR operation will panic
     assert!(thread::spawn(move|| { isize::MIN % -1; }).join().is_err());
-    //~^ ERROR arithmetic operation will overflow
+    //~^ ERROR operation will panic
     assert!(thread::spawn(move|| { i8::MIN % -1; }).join().is_err());
-    //~^ ERROR arithmetic operation will overflow
+    //~^ ERROR operation will panic
     assert!(thread::spawn(move|| { i16::MIN % -1; }).join().is_err());
-    //~^ ERROR arithmetic operation will overflow
+    //~^ ERROR operation will panic
     assert!(thread::spawn(move|| { i32::MIN % -1; }).join().is_err());
-    //~^ ERROR arithmetic operation will overflow
+    //~^ ERROR operation will panic
     assert!(thread::spawn(move|| { i64::MIN % -1; }).join().is_err());
-    //~^ ERROR arithmetic operation will overflow
+    //~^ ERROR operation will panic
     assert!(thread::spawn(move|| { i128::MIN % -1; }).join().is_err());
-    //~^ ERROR arithmetic operation will overflow
+    //~^ ERROR operation will panic
     assert!(thread::spawn(move|| { 1isize % 0; }).join().is_err());
     //~^ ERROR operation will panic
     assert!(thread::spawn(move|| { 1i8 % 0; }).join().is_err());

--- a/src/test/ui/object-lifetime/object-lifetime-default-from-rptr-struct-error.rs
+++ b/src/test/ui/object-lifetime/object-lifetime-default-from-rptr-struct-error.rs
@@ -2,7 +2,6 @@
 // through the `MyBox` struct.
 
 #![allow(dead_code)]
-#![feature(rustc_error)]
 
 trait Test {
     fn foo(&self) { }

--- a/src/test/ui/object-lifetime/object-lifetime-default-from-rptr-struct-error.stderr
+++ b/src/test/ui/object-lifetime/object-lifetime-default-from-rptr-struct-error.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/object-lifetime-default-from-rptr-struct-error.rs:21:12
+  --> $DIR/object-lifetime-default-from-rptr-struct-error.rs:20:12
    |
 LL |     ss.t = t;
    |            ^ lifetime mismatch
@@ -7,7 +7,7 @@ LL |     ss.t = t;
    = note: expected reference `&'a MyBox<(dyn Test + 'static)>`
               found reference `&'a MyBox<(dyn Test + 'a)>`
 note: the lifetime `'a` as defined here...
-  --> $DIR/object-lifetime-default-from-rptr-struct-error.rs:20:6
+  --> $DIR/object-lifetime-default-from-rptr-struct-error.rs:19:6
    |
 LL | fn c<'a>(t: &'a MyBox<dyn Test+'a>, mut ss: SomeStruct<'a>) {
    |      ^^

--- a/src/test/ui/once-cant-call-twice-on-heap.rs
+++ b/src/test/ui/once-cant-call-twice-on-heap.rs
@@ -1,7 +1,6 @@
 // Testing guarantees provided by once functions.
 // This program would segfault if it were legal.
 
-#![feature(once_fns)]
 use std::sync::Arc;
 
 fn foo<F:FnOnce()>(blk: F) {

--- a/src/test/ui/once-cant-call-twice-on-heap.stderr
+++ b/src/test/ui/once-cant-call-twice-on-heap.stderr
@@ -1,5 +1,5 @@
 error[E0382]: use of moved value: `blk`
-  --> $DIR/once-cant-call-twice-on-heap.rs:9:5
+  --> $DIR/once-cant-call-twice-on-heap.rs:8:5
    |
 LL | fn foo<F:FnOnce()>(blk: F) {
    |                    --- move occurs because `blk` has type `F`, which does not implement the `Copy` trait
@@ -9,7 +9,7 @@ LL |     blk();
    |     ^^^ value used here after move
    |
 note: this value implements `FnOnce`, which causes it to be moved when called
-  --> $DIR/once-cant-call-twice-on-heap.rs:8:5
+  --> $DIR/once-cant-call-twice-on-heap.rs:7:5
    |
 LL |     blk();
    |     ^^^

--- a/src/test/ui/or-patterns/nested-undelimited-precedence.rs
+++ b/src/test/ui/or-patterns/nested-undelimited-precedence.rs
@@ -5,8 +5,6 @@
 // types of patterns that allow undelimited subpatterns that could cause the same ambiguity.
 // Currently, those should be impossible due to precedence rule. This test enforces that.
 
-#![feature(or_patterns)]
-
 enum E {
     A,
     B,

--- a/src/test/ui/or-patterns/nested-undelimited-precedence.stderr
+++ b/src/test/ui/or-patterns/nested-undelimited-precedence.stderr
@@ -1,35 +1,35 @@
 error: top-level or-patterns are not allowed in `let` bindings
-  --> $DIR/nested-undelimited-precedence.rs:21:9
+  --> $DIR/nested-undelimited-precedence.rs:19:9
    |
 LL |     let b @ A | B: E = A;
    |         ^^^^^^^^^ help: wrap the pattern in parentheses: `(b @ A | B)`
 
 error: top-level or-patterns are not allowed in `let` bindings
-  --> $DIR/nested-undelimited-precedence.rs:36:9
+  --> $DIR/nested-undelimited-precedence.rs:34:9
    |
 LL |     let &A(_) | B(_): F = A(3);
    |         ^^^^^^^^^^^^ help: wrap the pattern in parentheses: `(&A(_) | B(_))`
 
 error: top-level or-patterns are not allowed in `let` bindings
-  --> $DIR/nested-undelimited-precedence.rs:38:9
+  --> $DIR/nested-undelimited-precedence.rs:36:9
    |
 LL |     let &&A(_) | B(_): F = A(3);
    |         ^^^^^^^^^^^^^ help: wrap the pattern in parentheses: `(&&A(_) | B(_))`
 
 error: top-level or-patterns are not allowed in `let` bindings
-  --> $DIR/nested-undelimited-precedence.rs:40:9
+  --> $DIR/nested-undelimited-precedence.rs:38:9
    |
 LL |     let &mut A(_) | B(_): F = A(3);
    |         ^^^^^^^^^^^^^^^^ help: wrap the pattern in parentheses: `(&mut A(_) | B(_))`
 
 error: top-level or-patterns are not allowed in `let` bindings
-  --> $DIR/nested-undelimited-precedence.rs:42:9
+  --> $DIR/nested-undelimited-precedence.rs:40:9
    |
 LL |     let &&mut A(_) | B(_): F = A(3);
    |         ^^^^^^^^^^^^^^^^^ help: wrap the pattern in parentheses: `(&&mut A(_) | B(_))`
 
 error[E0408]: variable `b` is not bound in all patterns
-  --> $DIR/nested-undelimited-precedence.rs:21:17
+  --> $DIR/nested-undelimited-precedence.rs:19:17
    |
 LL |     let b @ A | B: E = A;
    |         -       ^ pattern doesn't bind `b`
@@ -37,7 +37,7 @@ LL |     let b @ A | B: E = A;
    |         variable not in all patterns
 
 error[E0308]: mismatched types
-  --> $DIR/nested-undelimited-precedence.rs:36:9
+  --> $DIR/nested-undelimited-precedence.rs:34:9
    |
 LL |     let &A(_) | B(_): F = A(3);
    |         ^^^^^         - expected due to this
@@ -48,7 +48,7 @@ LL |     let &A(_) | B(_): F = A(3);
            found reference `&_`
 
 error[E0308]: mismatched types
-  --> $DIR/nested-undelimited-precedence.rs:38:9
+  --> $DIR/nested-undelimited-precedence.rs:36:9
    |
 LL |     let &&A(_) | B(_): F = A(3);
    |         ^^^^^^         - expected due to this
@@ -59,7 +59,7 @@ LL |     let &&A(_) | B(_): F = A(3);
            found reference `&_`
 
 error[E0308]: mismatched types
-  --> $DIR/nested-undelimited-precedence.rs:40:9
+  --> $DIR/nested-undelimited-precedence.rs:38:9
    |
 LL |     let &mut A(_) | B(_): F = A(3);
    |         ^^^^^^^^^         - expected due to this
@@ -70,7 +70,7 @@ LL |     let &mut A(_) | B(_): F = A(3);
            found mutable reference `&mut _`
 
 error[E0308]: mismatched types
-  --> $DIR/nested-undelimited-precedence.rs:42:9
+  --> $DIR/nested-undelimited-precedence.rs:40:9
    |
 LL |     let &&mut A(_) | B(_): F = A(3);
    |         ^^^^^^^^^^         - expected due to this

--- a/src/test/ui/or-patterns/or-patterns-syntactic-fail-2018.rs
+++ b/src/test/ui/or-patterns/or-patterns-syntactic-fail-2018.rs
@@ -2,8 +2,6 @@
 
 // edition:2018
 
-#![feature(or_patterns)]
-
 fn main() {}
 
 // Test the `pat` macro fragment parser:

--- a/src/test/ui/or-patterns/or-patterns-syntactic-fail-2018.stderr
+++ b/src/test/ui/or-patterns/or-patterns-syntactic-fail-2018.stderr
@@ -1,5 +1,5 @@
 error: no rules expected the token `|`
-  --> $DIR/or-patterns-syntactic-fail-2018.rs:14:15
+  --> $DIR/or-patterns-syntactic-fail-2018.rs:12:15
    |
 LL | macro_rules! accept_pat {
    | ----------------------- when calling this macro
@@ -8,7 +8,7 @@ LL | accept_pat!(p | q);
    |               ^ no rules expected this token in macro call
 
 error: no rules expected the token `|`
-  --> $DIR/or-patterns-syntactic-fail-2018.rs:15:13
+  --> $DIR/or-patterns-syntactic-fail-2018.rs:13:13
    |
 LL | macro_rules! accept_pat {
    | ----------------------- when calling this macro

--- a/src/test/ui/parser/issues/issue-49040.stderr
+++ b/src/test/ui/parser/issues/issue-49040.stderr
@@ -5,10 +5,10 @@ LL | #![allow(unused_variables)];
    |                            ^ help: remove this semicolon
 
 error[E0601]: `main` function not found in crate `issue_49040`
-  --> $DIR/issue-49040.rs:1:1
+  --> $DIR/issue-49040.rs:1:29
    |
 LL | #![allow(unused_variables)];
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ consider adding a `main` function to `$DIR/issue-49040.rs`
+   |                             ^ consider adding a `main` function to `$DIR/issue-49040.rs`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/pattern/usefulness/integer-ranges/exhaustiveness.rs
+++ b/src/test/ui/pattern/usefulness/integer-ranges/exhaustiveness.rs
@@ -1,5 +1,4 @@
 #![feature(exclusive_range_pattern)]
-#![feature(assoc_char_consts)]
 #![allow(overlapping_range_endpoints)]
 #![deny(unreachable_patterns)]
 

--- a/src/test/ui/pattern/usefulness/integer-ranges/exhaustiveness.stderr
+++ b/src/test/ui/pattern/usefulness/integer-ranges/exhaustiveness.stderr
@@ -1,5 +1,5 @@
 error[E0004]: non-exhaustive patterns: `u8::MAX` not covered
-  --> $DIR/exhaustiveness.rs:48:8
+  --> $DIR/exhaustiveness.rs:47:8
    |
 LL |     m!(0u8, 0..255);
    |        ^^^ pattern `u8::MAX` not covered
@@ -8,7 +8,7 @@ LL |     m!(0u8, 0..255);
    = note: the matched value is of type `u8`
 
 error[E0004]: non-exhaustive patterns: `u8::MAX` not covered
-  --> $DIR/exhaustiveness.rs:49:8
+  --> $DIR/exhaustiveness.rs:48:8
    |
 LL |     m!(0u8, 0..=254);
    |        ^^^ pattern `u8::MAX` not covered
@@ -17,7 +17,7 @@ LL |     m!(0u8, 0..=254);
    = note: the matched value is of type `u8`
 
 error[E0004]: non-exhaustive patterns: `0_u8` not covered
-  --> $DIR/exhaustiveness.rs:50:8
+  --> $DIR/exhaustiveness.rs:49:8
    |
 LL |     m!(0u8, 1..=255);
    |        ^^^ pattern `0_u8` not covered
@@ -26,7 +26,7 @@ LL |     m!(0u8, 1..=255);
    = note: the matched value is of type `u8`
 
 error[E0004]: non-exhaustive patterns: `42_u8` not covered
-  --> $DIR/exhaustiveness.rs:51:8
+  --> $DIR/exhaustiveness.rs:50:8
    |
 LL |     m!(0u8, 0..42 | 43..=255);
    |        ^^^ pattern `42_u8` not covered
@@ -35,7 +35,7 @@ LL |     m!(0u8, 0..42 | 43..=255);
    = note: the matched value is of type `u8`
 
 error[E0004]: non-exhaustive patterns: `i8::MAX` not covered
-  --> $DIR/exhaustiveness.rs:52:8
+  --> $DIR/exhaustiveness.rs:51:8
    |
 LL |     m!(0i8, -128..127);
    |        ^^^ pattern `i8::MAX` not covered
@@ -44,7 +44,7 @@ LL |     m!(0i8, -128..127);
    = note: the matched value is of type `i8`
 
 error[E0004]: non-exhaustive patterns: `i8::MAX` not covered
-  --> $DIR/exhaustiveness.rs:53:8
+  --> $DIR/exhaustiveness.rs:52:8
    |
 LL |     m!(0i8, -128..=126);
    |        ^^^ pattern `i8::MAX` not covered
@@ -53,7 +53,7 @@ LL |     m!(0i8, -128..=126);
    = note: the matched value is of type `i8`
 
 error[E0004]: non-exhaustive patterns: `i8::MIN` not covered
-  --> $DIR/exhaustiveness.rs:54:8
+  --> $DIR/exhaustiveness.rs:53:8
    |
 LL |     m!(0i8, -127..=127);
    |        ^^^ pattern `i8::MIN` not covered
@@ -62,7 +62,7 @@ LL |     m!(0i8, -127..=127);
    = note: the matched value is of type `i8`
 
 error[E0004]: non-exhaustive patterns: `0_i8` not covered
-  --> $DIR/exhaustiveness.rs:55:11
+  --> $DIR/exhaustiveness.rs:54:11
    |
 LL |     match 0i8 {
    |           ^^^ pattern `0_i8` not covered
@@ -71,7 +71,7 @@ LL |     match 0i8 {
    = note: the matched value is of type `i8`
 
 error[E0004]: non-exhaustive patterns: `u128::MAX` not covered
-  --> $DIR/exhaustiveness.rs:60:8
+  --> $DIR/exhaustiveness.rs:59:8
    |
 LL |     m!(0u128, 0..=ALMOST_MAX);
    |        ^^^^^ pattern `u128::MAX` not covered
@@ -80,7 +80,7 @@ LL |     m!(0u128, 0..=ALMOST_MAX);
    = note: the matched value is of type `u128`
 
 error[E0004]: non-exhaustive patterns: `5_u128..=u128::MAX` not covered
-  --> $DIR/exhaustiveness.rs:61:8
+  --> $DIR/exhaustiveness.rs:60:8
    |
 LL |     m!(0u128, 0..=4);
    |        ^^^^^ pattern `5_u128..=u128::MAX` not covered
@@ -89,7 +89,7 @@ LL |     m!(0u128, 0..=4);
    = note: the matched value is of type `u128`
 
 error[E0004]: non-exhaustive patterns: `0_u128` not covered
-  --> $DIR/exhaustiveness.rs:62:8
+  --> $DIR/exhaustiveness.rs:61:8
    |
 LL |     m!(0u128, 1..=u128::MAX);
    |        ^^^^^ pattern `0_u128` not covered
@@ -98,7 +98,7 @@ LL |     m!(0u128, 1..=u128::MAX);
    = note: the matched value is of type `u128`
 
 error[E0004]: non-exhaustive patterns: `(126_u8..=127_u8, false)` not covered
-  --> $DIR/exhaustiveness.rs:70:11
+  --> $DIR/exhaustiveness.rs:69:11
    |
 LL |     match (0u8, true) {
    |           ^^^^^^^^^^^ pattern `(126_u8..=127_u8, false)` not covered

--- a/src/test/ui/pub/pub-restricted-error.rs
+++ b/src/test/ui/pub/pub-restricted-error.rs
@@ -1,5 +1,3 @@
-#![feature(pub_restricted)]
-
 struct Bar(pub(()));
 
 struct Foo {

--- a/src/test/ui/pub/pub-restricted-error.stderr
+++ b/src/test/ui/pub/pub-restricted-error.stderr
@@ -1,5 +1,5 @@
 error: expected identifier, found `(`
-  --> $DIR/pub-restricted-error.rs:6:16
+  --> $DIR/pub-restricted-error.rs:4:16
    |
 LL |     pub(crate) () foo: usize,
    |                ^ expected identifier

--- a/src/test/ui/pub/pub-restricted.rs
+++ b/src/test/ui/pub/pub-restricted.rs
@@ -1,5 +1,3 @@
-#![feature(pub_restricted)]
-
 mod a {}
 
 pub (a) fn afn() {} //~ incorrect visibility restriction

--- a/src/test/ui/pub/pub-restricted.stderr
+++ b/src/test/ui/pub/pub-restricted.stderr
@@ -1,5 +1,5 @@
 error[E0704]: incorrect visibility restriction
-  --> $DIR/pub-restricted.rs:5:6
+  --> $DIR/pub-restricted.rs:3:6
    |
 LL | pub (a) fn afn() {}
    |      ^ help: make this visible only to module `a` with `in`: `in a`
@@ -10,7 +10,7 @@ LL | pub (a) fn afn() {}
            `pub(in path::to::module)`: visible only on the specified path
 
 error[E0704]: incorrect visibility restriction
-  --> $DIR/pub-restricted.rs:6:6
+  --> $DIR/pub-restricted.rs:4:6
    |
 LL | pub (b) fn bfn() {}
    |      ^ help: make this visible only to module `b` with `in`: `in b`
@@ -21,7 +21,7 @@ LL | pub (b) fn bfn() {}
            `pub(in path::to::module)`: visible only on the specified path
 
 error[E0704]: incorrect visibility restriction
-  --> $DIR/pub-restricted.rs:7:6
+  --> $DIR/pub-restricted.rs:5:6
    |
 LL | pub (crate::a) fn cfn() {}
    |      ^^^^^^^^ help: make this visible only to module `crate::a` with `in`: `in crate::a`
@@ -32,7 +32,7 @@ LL | pub (crate::a) fn cfn() {}
            `pub(in path::to::module)`: visible only on the specified path
 
 error[E0704]: incorrect visibility restriction
-  --> $DIR/pub-restricted.rs:24:14
+  --> $DIR/pub-restricted.rs:22:14
    |
 LL |         pub (a) invalid: usize,
    |              ^ help: make this visible only to module `a` with `in`: `in a`
@@ -43,7 +43,7 @@ LL |         pub (a) invalid: usize,
            `pub(in path::to::module)`: visible only on the specified path
 
 error[E0704]: incorrect visibility restriction
-  --> $DIR/pub-restricted.rs:33:6
+  --> $DIR/pub-restricted.rs:31:6
    |
 LL | pub (xyz) fn xyz() {}
    |      ^^^ help: make this visible only to module `xyz` with `in`: `in xyz`
@@ -54,7 +54,7 @@ LL | pub (xyz) fn xyz() {}
            `pub(in path::to::module)`: visible only on the specified path
 
 error[E0742]: visibilities can only be restricted to ancestor modules
-  --> $DIR/pub-restricted.rs:25:17
+  --> $DIR/pub-restricted.rs:23:17
    |
 LL |         pub (in x) non_parent_invalid: usize,
    |                 ^

--- a/src/test/ui/repr/repr-transparent-other-reprs.rs
+++ b/src/test/ui/repr/repr-transparent-other-reprs.rs
@@ -1,5 +1,3 @@
-#![feature(repr_align)]
-
 // See also repr-transparent.rs
 
 #[repr(transparent, C)] //~ ERROR cannot have other repr

--- a/src/test/ui/repr/repr-transparent-other-reprs.stderr
+++ b/src/test/ui/repr/repr-transparent-other-reprs.stderr
@@ -1,23 +1,23 @@
 error[E0692]: transparent struct cannot have other repr hints
-  --> $DIR/repr-transparent-other-reprs.rs:5:8
+  --> $DIR/repr-transparent-other-reprs.rs:3:8
    |
 LL | #[repr(transparent, C)]
    |        ^^^^^^^^^^^  ^
 
 error[E0692]: transparent struct cannot have other repr hints
-  --> $DIR/repr-transparent-other-reprs.rs:10:8
+  --> $DIR/repr-transparent-other-reprs.rs:8:8
    |
 LL | #[repr(transparent, packed)]
    |        ^^^^^^^^^^^  ^^^^^^
 
 error[E0692]: transparent struct cannot have other repr hints
-  --> $DIR/repr-transparent-other-reprs.rs:13:8
+  --> $DIR/repr-transparent-other-reprs.rs:11:8
    |
 LL | #[repr(transparent, align(2))]
    |        ^^^^^^^^^^^  ^^^^^^^^
 
 error[E0692]: transparent struct cannot have other repr hints
-  --> $DIR/repr-transparent-other-reprs.rs:16:8
+  --> $DIR/repr-transparent-other-reprs.rs:14:8
    |
 LL | #[repr(transparent)]
    |        ^^^^^^^^^^^

--- a/src/test/ui/rfc-2093-infer-outlives/explicit-dyn.rs
+++ b/src/test/ui/rfc-2093-infer-outlives/explicit-dyn.rs
@@ -1,4 +1,3 @@
-#![feature(dyn_trait)]
 #![feature(rustc_attrs)]
 
 trait Trait<'x, T> where T: 'x {

--- a/src/test/ui/rfc-2093-infer-outlives/explicit-dyn.stderr
+++ b/src/test/ui/rfc-2093-infer-outlives/explicit-dyn.stderr
@@ -1,5 +1,5 @@
 error: rustc_outlives
-  --> $DIR/explicit-dyn.rs:8:1
+  --> $DIR/explicit-dyn.rs:7:1
    |
 LL | / struct Foo<'a, A>
 LL | | {

--- a/src/test/ui/rfc-2093-infer-outlives/self-dyn.rs
+++ b/src/test/ui/rfc-2093-infer-outlives/self-dyn.rs
@@ -1,4 +1,3 @@
-#![feature(dyn_trait)]
 #![feature(rustc_attrs)]
 
 trait Trait<'x, 's, T> where T: 'x,

--- a/src/test/ui/rfc-2093-infer-outlives/self-dyn.stderr
+++ b/src/test/ui/rfc-2093-infer-outlives/self-dyn.stderr
@@ -1,5 +1,5 @@
 error: rustc_outlives
-  --> $DIR/self-dyn.rs:9:1
+  --> $DIR/self-dyn.rs:8:1
    |
 LL | / struct Foo<'a, 'b, A>
 LL | | {

--- a/src/test/ui/rfc-2126-crate-paths/crate-path-non-absolute.rs
+++ b/src/test/ui/rfc-2126-crate-paths/crate-path-non-absolute.rs
@@ -1,5 +1,3 @@
-#![feature(crate_in_paths)]
-
 struct S;
 
 pub mod m {

--- a/src/test/ui/rfc-2126-crate-paths/crate-path-non-absolute.stderr
+++ b/src/test/ui/rfc-2126-crate-paths/crate-path-non-absolute.stderr
@@ -1,11 +1,11 @@
 error[E0433]: failed to resolve: `crate` in paths can only be used in start position
-  --> $DIR/crate-path-non-absolute.rs:7:22
+  --> $DIR/crate-path-non-absolute.rs:5:22
    |
 LL |         let s = ::m::crate::S;
    |                      ^^^^^ `crate` in paths can only be used in start position
 
 error[E0433]: failed to resolve: global paths cannot start with `crate`
-  --> $DIR/crate-path-non-absolute.rs:8:20
+  --> $DIR/crate-path-non-absolute.rs:6:20
    |
 LL |         let s1 = ::crate::S;
    |                    ^^^^^ global paths cannot start with `crate`

--- a/src/test/ui/rfc-2126-crate-paths/keyword-crate-as-identifier.rs
+++ b/src/test/ui/rfc-2126-crate-paths/keyword-crate-as-identifier.rs
@@ -1,5 +1,3 @@
-#![feature(crate_in_paths)]
-
 fn main() {
     let crate = 0;
     //~^ ERROR expected unit struct, unit variant or constant, found module `crate`

--- a/src/test/ui/rfc-2126-crate-paths/keyword-crate-as-identifier.stderr
+++ b/src/test/ui/rfc-2126-crate-paths/keyword-crate-as-identifier.stderr
@@ -1,5 +1,5 @@
 error[E0532]: expected unit struct, unit variant or constant, found module `crate`
-  --> $DIR/keyword-crate-as-identifier.rs:4:9
+  --> $DIR/keyword-crate-as-identifier.rs:2:9
    |
 LL |     let crate = 0;
    |         ^^^^^ not a unit struct, unit variant or constant

--- a/src/test/ui/rfc-2632-const-trait-impl/stability.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/stability.rs
@@ -2,7 +2,9 @@
 #![feature(const_add)]
 #![feature(const_trait_impl)]
 #![feature(staged_api)]
+#![stable(feature = "rust1", since = "1.0.0")]
 
+#[stable(feature = "rust1", since = "1.0.0")]
 pub struct Int(i32);
 
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -16,6 +18,7 @@ impl const std::ops::Sub for Int {
     }
 }
 
+#[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_const_unstable(feature = "const_add", issue = "none")]
 impl const std::ops::Add for Int {
     type Output = Self;

--- a/src/test/ui/rfc-2632-const-trait-impl/stability.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/stability.stderr
@@ -1,5 +1,5 @@
 error: trait methods cannot be stable const fn
-  --> $DIR/stability.rs:13:5
+  --> $DIR/stability.rs:15:5
    |
 LL | /     fn sub(self, rhs: Self) -> Self {
 LL | |
@@ -8,7 +8,7 @@ LL | |     }
    | |_____^
 
 error: `<Int as Add>::add` is not yet stable as a const fn
-  --> $DIR/stability.rs:31:5
+  --> $DIR/stability.rs:34:5
    |
 LL |     Int(1i32) + Int(2i32)
    |     ^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/rust-2018/uniform-paths/issue-56596.rs
+++ b/src/test/ui/rust-2018/uniform-paths/issue-56596.rs
@@ -2,8 +2,6 @@
 // compile-flags: --extern issue_56596
 // aux-build:issue-56596.rs
 
-#![feature(uniform_paths)]
-
 mod m {
     pub mod issue_56596 {}
 }

--- a/src/test/ui/rust-2018/uniform-paths/issue-56596.stderr
+++ b/src/test/ui/rust-2018/uniform-paths/issue-56596.stderr
@@ -1,5 +1,5 @@
 error[E0659]: `issue_56596` is ambiguous
-  --> $DIR/issue-56596.rs:12:5
+  --> $DIR/issue-56596.rs:10:5
    |
 LL | use issue_56596;
    |     ^^^^^^^^^^^ ambiguous name
@@ -8,7 +8,7 @@ LL | use issue_56596;
    = note: `issue_56596` could refer to a crate passed with `--extern`
    = help: use `::issue_56596` to refer to this crate unambiguously
 note: `issue_56596` could also refer to the module imported here
-  --> $DIR/issue-56596.rs:11:5
+  --> $DIR/issue-56596.rs:9:5
    |
 LL | use m::*;
    |     ^^^^

--- a/src/test/ui/span/issue-23827.rs
+++ b/src/test/ui/span/issue-23827.rs
@@ -1,6 +1,6 @@
 // Regression test for #23827
 
-#![feature(core, fn_traits, unboxed_closures)]
+#![feature(fn_traits, unboxed_closures)]
 
 pub struct Prototype {
     pub target: u32

--- a/src/test/ui/stability-attribute/stability-attribute-non-staged-force-unstable.rs
+++ b/src/test/ui/stability-attribute/stability-attribute-non-staged-force-unstable.rs
@@ -3,4 +3,5 @@
 #[unstable()] //~ ERROR: stability attributes may not be used
 #[stable()] //~ ERROR: stability attributes may not be used
 #[rustc_deprecated()] //~ ERROR: stability attributes may not be used
-fn main() { }
+//~^ ERROR missing 'since'
+fn main() {}

--- a/src/test/ui/stability-attribute/stability-attribute-non-staged-force-unstable.stderr
+++ b/src/test/ui/stability-attribute/stability-attribute-non-staged-force-unstable.stderr
@@ -16,6 +16,13 @@ error[E0734]: stability attributes may not be used outside of the standard libra
 LL | #[rustc_deprecated()]
    | ^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 3 previous errors
+error[E0542]: missing 'since'
+  --> $DIR/stability-attribute-non-staged-force-unstable.rs:5:1
+   |
+LL | #[rustc_deprecated()]
+   | ^^^^^^^^^^^^^^^^^^^^^
 
-For more information about this error, try `rustc --explain E0734`.
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0542, E0734.
+For more information about an error, try `rustc --explain E0542`.

--- a/src/test/ui/stability-attribute/stability-attribute-non-staged.rs
+++ b/src/test/ui/stability-attribute/stability-attribute-non-staged.rs
@@ -1,4 +1,5 @@
 #[unstable()] //~ ERROR: stability attributes may not be used
 #[stable()] //~ ERROR: stability attributes may not be used
 #[rustc_deprecated()] //~ ERROR: stability attributes may not be used
-fn main() { }
+//~^ ERROR missing 'since'
+fn main() {}

--- a/src/test/ui/stability-attribute/stability-attribute-non-staged.stderr
+++ b/src/test/ui/stability-attribute/stability-attribute-non-staged.stderr
@@ -16,6 +16,13 @@ error[E0734]: stability attributes may not be used outside of the standard libra
 LL | #[rustc_deprecated()]
    | ^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 3 previous errors
+error[E0542]: missing 'since'
+  --> $DIR/stability-attribute-non-staged.rs:3:1
+   |
+LL | #[rustc_deprecated()]
+   | ^^^^^^^^^^^^^^^^^^^^^
 
-For more information about this error, try `rustc --explain E0734`.
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0542, E0734.
+For more information about an error, try `rustc --explain E0542`.

--- a/src/test/ui/stability-attribute/stability-attribute-sanity-4.rs
+++ b/src/test/ui/stability-attribute/stability-attribute-sanity-4.rs
@@ -19,10 +19,12 @@ mod bogus_attribute_types_2 {
 
     #[stable(feature = "a", since = "b")]
     #[rustc_deprecated] //~ ERROR malformed `rustc_deprecated` attribute
+                        //~^ ERROR missing 'since'
     fn f5() { }
 
     #[stable(feature = "a", since = "b")]
     #[rustc_deprecated = "a"] //~ ERROR malformed `rustc_deprecated` attribute
+                              //~^ ERROR missing 'since'
     fn f6() { }
 }
 

--- a/src/test/ui/stability-attribute/stability-attribute-sanity-4.stderr
+++ b/src/test/ui/stability-attribute/stability-attribute-sanity-4.stderr
@@ -29,10 +29,23 @@ LL |     #[rustc_deprecated]
    |     ^^^^^^^^^^^^^^^^^^^ help: must be of the form: `#[rustc_deprecated(since = "version", reason = "...")]`
 
 error: malformed `rustc_deprecated` attribute input
-  --> $DIR/stability-attribute-sanity-4.rs:25:5
+  --> $DIR/stability-attribute-sanity-4.rs:26:5
    |
 LL |     #[rustc_deprecated = "a"]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^ help: must be of the form: `#[rustc_deprecated(since = "version", reason = "...")]`
 
-error: aborting due to 6 previous errors
+error[E0542]: missing 'since'
+  --> $DIR/stability-attribute-sanity-4.rs:21:5
+   |
+LL |     #[rustc_deprecated]
+   |     ^^^^^^^^^^^^^^^^^^^
 
+error[E0542]: missing 'since'
+  --> $DIR/stability-attribute-sanity-4.rs:26:5
+   |
+LL |     #[rustc_deprecated = "a"]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 8 previous errors
+
+For more information about this error, try `rustc --explain E0542`.

--- a/src/test/ui/stability-attribute/stability-attribute-sanity.rs
+++ b/src/test/ui/stability-attribute/stability-attribute-sanity.rs
@@ -65,6 +65,7 @@ fn multiple3() { }
 pub const fn multiple4() { }
 
 #[stable(feature = "a", since = "1.0.0")] //~ ERROR invalid deprecation version found
+//~^ ERROR feature `a` is declared stable since 1.0.0
 #[rustc_deprecated(since = "invalid", reason = "text")]
 fn invalid_deprecation_version() {}
 

--- a/src/test/ui/stability-attribute/stability-attribute-sanity.stderr
+++ b/src/test/ui/stability-attribute/stability-attribute-sanity.stderr
@@ -110,17 +110,23 @@ error: invalid deprecation version found
    |
 LL | #[stable(feature = "a", since = "1.0.0")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ invalid deprecation version
-LL | #[rustc_deprecated(since = "invalid", reason = "text")]
+...
 LL | fn invalid_deprecation_version() {}
    | ----------------------------------- the stability attribute annotates this item
 
 error[E0549]: rustc_deprecated attribute must be paired with either stable or unstable attribute
-  --> $DIR/stability-attribute-sanity.rs:71:1
+  --> $DIR/stability-attribute-sanity.rs:72:1
    |
 LL | #[rustc_deprecated(since = "a", reason = "text")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 19 previous errors
+error[E0711]: feature `a` is declared stable since 1.0.0, but was previously declared stable since b
+  --> $DIR/stability-attribute-sanity.rs:67:1
+   |
+LL | #[stable(feature = "a", since = "1.0.0")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 20 previous errors
 
 Some errors have detailed explanations: E0539, E0541, E0542, E0543, E0544, E0546, E0547, E0549, E0550.
 For more information about an error, try `rustc --explain E0539`.

--- a/src/test/ui/target-feature/invalid-attribute.rs
+++ b/src/test/ui/target-feature/invalid-attribute.rs
@@ -12,7 +12,6 @@
 // ignore-sparc
 // ignore-sparc64
 
-#![feature(target_feature)]
 #![warn(unused_attributes)]
 
 #[target_feature = "+sse2"]

--- a/src/test/ui/target-feature/invalid-attribute.stderr
+++ b/src/test/ui/target-feature/invalid-attribute.stderr
@@ -1,29 +1,29 @@
 error: malformed `target_feature` attribute input
-  --> $DIR/invalid-attribute.rs:18:1
+  --> $DIR/invalid-attribute.rs:17:1
    |
 LL | #[target_feature = "+sse2"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: must be of the form: `#[target_feature(enable = "name")]`
 
 error: the feature named `foo` is not valid for this target
-  --> $DIR/invalid-attribute.rs:20:18
+  --> $DIR/invalid-attribute.rs:19:18
    |
 LL | #[target_feature(enable = "foo")]
    |                  ^^^^^^^^^^^^^^ `foo` is not valid for this target
 
 error: malformed `target_feature` attribute input
-  --> $DIR/invalid-attribute.rs:23:18
+  --> $DIR/invalid-attribute.rs:22:18
    |
 LL | #[target_feature(bar)]
    |                  ^^^ help: must be of the form: `enable = ".."`
 
 error: malformed `target_feature` attribute input
-  --> $DIR/invalid-attribute.rs:25:18
+  --> $DIR/invalid-attribute.rs:24:18
    |
 LL | #[target_feature(disable = "baz")]
    |                  ^^^^^^^^^^^^^^^ help: must be of the form: `enable = ".."`
 
 error[E0658]: `#[target_feature(..)]` can only be applied to `unsafe` functions
-  --> $DIR/invalid-attribute.rs:29:1
+  --> $DIR/invalid-attribute.rs:28:1
    |
 LL | #[target_feature(enable = "sse2")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -35,7 +35,7 @@ LL | fn bar() {}
    = help: add `#![feature(target_feature_11)]` to the crate attributes to enable
 
 error: attribute should be applied to a function
-  --> $DIR/invalid-attribute.rs:35:1
+  --> $DIR/invalid-attribute.rs:34:1
    |
 LL | #[target_feature(enable = "sse2")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -44,7 +44,7 @@ LL | mod another {}
    | -------------- not a function
 
 error: attribute should be applied to a function
-  --> $DIR/invalid-attribute.rs:40:1
+  --> $DIR/invalid-attribute.rs:39:1
    |
 LL | #[target_feature(enable = "sse2")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -53,7 +53,7 @@ LL | const FOO: usize = 7;
    | --------------------- not a function
 
 error: attribute should be applied to a function
-  --> $DIR/invalid-attribute.rs:45:1
+  --> $DIR/invalid-attribute.rs:44:1
    |
 LL | #[target_feature(enable = "sse2")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -62,7 +62,7 @@ LL | struct Foo;
    | ----------- not a function
 
 error: attribute should be applied to a function
-  --> $DIR/invalid-attribute.rs:50:1
+  --> $DIR/invalid-attribute.rs:49:1
    |
 LL | #[target_feature(enable = "sse2")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -71,7 +71,7 @@ LL | enum Bar {}
    | ----------- not a function
 
 error: attribute should be applied to a function
-  --> $DIR/invalid-attribute.rs:55:1
+  --> $DIR/invalid-attribute.rs:54:1
    |
 LL |   #[target_feature(enable = "sse2")]
    |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -84,7 +84,7 @@ LL | | }
    | |_- not a function
 
 error: attribute should be applied to a function
-  --> $DIR/invalid-attribute.rs:63:1
+  --> $DIR/invalid-attribute.rs:62:1
    |
 LL | #[target_feature(enable = "sse2")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -93,13 +93,13 @@ LL | trait Baz {}
    | ------------ not a function
 
 error: cannot use `#[inline(always)]` with `#[target_feature]`
-  --> $DIR/invalid-attribute.rs:68:1
+  --> $DIR/invalid-attribute.rs:67:1
    |
 LL | #[inline(always)]
    | ^^^^^^^^^^^^^^^^^
 
 error: attribute should be applied to a function
-  --> $DIR/invalid-attribute.rs:86:5
+  --> $DIR/invalid-attribute.rs:85:5
    |
 LL |       #[target_feature(enable = "sse2")]
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -111,7 +111,7 @@ LL | |     }
    | |_____- not a function
 
 error: attribute should be applied to a function
-  --> $DIR/invalid-attribute.rs:94:5
+  --> $DIR/invalid-attribute.rs:93:5
    |
 LL |     #[target_feature(enable = "sse2")]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -120,7 +120,7 @@ LL |     || {};
    |     ----- not a function
 
 error[E0658]: `#[target_feature(..)]` can only be applied to `unsafe` functions
-  --> $DIR/invalid-attribute.rs:78:5
+  --> $DIR/invalid-attribute.rs:77:5
    |
 LL |     #[target_feature(enable = "sse2")]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/try-trait/try-on-option-diagnostics.rs
+++ b/src/test/ui/try-trait/try-on-option-diagnostics.rs
@@ -1,5 +1,5 @@
-#![feature(try_trait)]
 // edition:2018
+
 fn main() {}
 
 fn a_function() -> u32 {

--- a/src/test/ui/try-trait/try-on-option.rs
+++ b/src/test/ui/try-trait/try-on-option.rs
@@ -1,5 +1,3 @@
-#![feature(try_trait)]
-
 fn main() {}
 
 fn foo() -> Result<u32, ()> {

--- a/src/test/ui/try-trait/try-on-option.stderr
+++ b/src/test/ui/try-trait/try-on-option.stderr
@@ -1,5 +1,5 @@
 error[E0277]: the `?` operator can only be used on `Result`s, not `Option`s, in a function that returns `Result`
-  --> $DIR/try-on-option.rs:7:6
+  --> $DIR/try-on-option.rs:5:6
    |
 LL | / fn foo() -> Result<u32, ()> {
 LL | |     let x: Option<u32> = None;
@@ -12,7 +12,7 @@ LL | | }
    = help: the trait `FromResidual<Option<Infallible>>` is not implemented for `Result<u32, ()>`
 
 error[E0277]: the `?` operator can only be used in a function that returns `Result` or `Option` (or another type that implements `FromResidual`)
-  --> $DIR/try-on-option.rs:13:6
+  --> $DIR/try-on-option.rs:11:6
    |
 LL | / fn bar() -> u32 {
 LL | |     let x: Option<u32> = None;

--- a/src/test/ui/type-alias-impl-trait/issue-63355.rs
+++ b/src/test/ui/type-alias-impl-trait/issue-63355.rs
@@ -1,5 +1,4 @@
 #![feature(type_alias_impl_trait)]
-#![feature(type_alias_impl_trait)]
 #![allow(incomplete_features)]
 
 pub trait Foo {}

--- a/src/test/ui/type-alias-impl-trait/issue-63355.stderr
+++ b/src/test/ui/type-alias-impl-trait/issue-63355.stderr
@@ -1,5 +1,5 @@
 error[E0271]: type mismatch resolving `<() as Bar>::Foo == ()`
-  --> $DIR/issue-63355.rs:34:20
+  --> $DIR/issue-63355.rs:33:20
    |
 LL | pub type FooImpl = impl Foo;
    |                    -------- the found opaque type
@@ -7,7 +7,7 @@ LL | pub type BarImpl = impl Bar<Foo = FooImpl>;
    |                    ^^^^^^^^^^^^^^^^^^^^^^^ type mismatch resolving `<() as Bar>::Foo == ()`
    |
 note: expected this to be `()`
-  --> $DIR/issue-63355.rs:24:16
+  --> $DIR/issue-63355.rs:23:16
    |
 LL |     type Foo = FooImpl;
    |                ^^^^^^^

--- a/src/test/ui/type-alias-impl-trait/issue-65384.rs
+++ b/src/test/ui/type-alias-impl-trait/issue-65384.rs
@@ -1,5 +1,4 @@
 #![feature(type_alias_impl_trait)]
-#![feature(type_alias_impl_trait)]
 #![allow(incomplete_features)]
 
 trait MyTrait {}

--- a/src/test/ui/type-alias-impl-trait/issue-65384.stderr
+++ b/src/test/ui/type-alias-impl-trait/issue-65384.stderr
@@ -1,11 +1,11 @@
 error: cannot implement trait on type alias impl trait
-  --> $DIR/issue-65384.rs:11:1
+  --> $DIR/issue-65384.rs:10:1
    |
 LL | impl MyTrait for Bar {}
    | ^^^^^^^^^^^^^^^^^^^^
    |
 note: type alias impl trait defined here
-  --> $DIR/issue-65384.rs:9:12
+  --> $DIR/issue-65384.rs:8:12
    |
 LL | type Bar = impl MyTrait;
    |            ^^^^^^^^^^^^

--- a/src/test/ui/type/type-parameter-defaults-referencing-Self.rs
+++ b/src/test/ui/type/type-parameter-defaults-referencing-Self.rs
@@ -1,8 +1,6 @@
 // Test a default that references `Self` which is then used in an object type.
 // Issue #18956.
 
-#![feature(default_type_params)]
-
 trait Foo<T=Self> {
     fn method(&self);
 }

--- a/src/test/ui/type/type-parameter-defaults-referencing-Self.stderr
+++ b/src/test/ui/type/type-parameter-defaults-referencing-Self.stderr
@@ -1,5 +1,5 @@
 error[E0393]: the type parameter `T` must be explicitly specified
-  --> $DIR/type-parameter-defaults-referencing-Self.rs:10:16
+  --> $DIR/type-parameter-defaults-referencing-Self.rs:8:16
    |
 LL | / trait Foo<T=Self> {
 LL | |     fn method(&self);

--- a/src/test/ui/unboxed-closures/unboxed-closures-fnmut-as-fn.rs
+++ b/src/test/ui/unboxed-closures/unboxed-closures-fnmut-as-fn.rs
@@ -2,7 +2,6 @@
 // Fn to be used where FnMut is implemented.
 
 #![feature(fn_traits, unboxed_closures)]
-#![feature(overloaded_calls)]
 
 use std::ops::{Fn,FnMut,FnOnce};
 

--- a/src/test/ui/unboxed-closures/unboxed-closures-fnmut-as-fn.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closures-fnmut-as-fn.stderr
@@ -1,5 +1,5 @@
 error[E0277]: expected a `Fn<(isize,)>` closure, found `S`
-  --> $DIR/unboxed-closures-fnmut-as-fn.rs:28:21
+  --> $DIR/unboxed-closures-fnmut-as-fn.rs:27:21
    |
 LL |     let x = call_it(&S, 22);
    |             ------- ^^ expected an `Fn<(isize,)>` closure, found `S`
@@ -8,7 +8,7 @@ LL |     let x = call_it(&S, 22);
    |
    = help: the trait `Fn<(isize,)>` is not implemented for `S`
 note: required by a bound in `call_it`
-  --> $DIR/unboxed-closures-fnmut-as-fn.rs:23:14
+  --> $DIR/unboxed-closures-fnmut-as-fn.rs:22:14
    |
 LL | fn call_it<F:Fn(isize)->isize>(f: &F, x: isize) -> isize {
    |              ^^^^^^^^^^^^^^^^ required by this bound in `call_it`

--- a/src/test/ui/unboxed-closures/unboxed-closures-recursive-fn-using-fn-mut.rs
+++ b/src/test/ui/unboxed-closures/unboxed-closures-recursive-fn-using-fn-mut.rs
@@ -1,4 +1,4 @@
-#![feature(core, fn_traits, unboxed_closures)]
+#![feature(fn_traits, unboxed_closures)]
 
 use std::marker::PhantomData;
 


### PR DESCRIPTION
Successful merges:

 - #93142 (Do not point at whole file missing `fn main`)
 - #94096 (Ensure stability directives are checked in all cases)
 - #94298 (Enable conditional compilation checking on the Rust codebase)
 - #94339 (ARM: Only allow using d16-d31 with asm! when supported by the target)
 - #94375 (Adt copy suggestions)
 - #94433 (Improve allowness of the unexpected_cfgs lint)
 - #94499 (Documentation was missed when demoting Windows XP to no_std only)
 - #94512 (Miri/CTFE: properly treat overflow in (signed) division/rem as UB)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=93142,94096,94298,94339,94375,94433,94499,94512)
<!-- homu-ignore:end -->