### PR TITLE
Remove out-of-context line at end of E0284 message

### DIFF
--- a/compiler/rustc_error_codes/src/error_codes/E0284.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0284.md
@@ -30,5 +30,3 @@ fn main() {
     d = d + m;
 }
 ```
-
-Note that the type of `v` can now be inferred from the type of `temp`.


### PR DESCRIPTION
Removed the last line of E0284 message because it was out of context (probably kept by accident when changing whole error message).