### PR TITLE
Implement Copy, Clone, PartialEq and Eq for core::fmt::Alignment

### DIFF
--- a/library/core/src/fmt/mod.rs
+++ b/library/core/src/fmt/mod.rs
@@ -20,7 +20,7 @@ mod num;
 
 #[stable(feature = "fmt_flags_align", since = "1.28.0")]
 /// Possible alignments returned by `Formatter::align`
-#[derive(Debug)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum Alignment {
     #[stable(feature = "fmt_flags_align", since = "1.28.0")]
     /// Indication that contents should be left-aligned.


### PR DESCRIPTION
Alignment is a fieldless exhaustive enum, so it is already possible to
clone and compare it by matching, but it is inconvenient to do so. For
example, if one would like to create a struct describing a formatter
configuration and provide a clone implementation:

```rust
pub struct Format {
    fill: char,
    width: Option<usize>,
    align: fmt::Alignment,
}

impl Clone for Format {
    fn clone(&self) -> Self {
        Format {
            align: match self.align {
                fmt::Alignment::Left => fmt::Alignment::Left,
                fmt::Alignment::Right => fmt::Alignment::Right,
                fmt::Alignment::Center => fmt::Alignment::Center,
            },
            .. *self
        }
    }
}
```

Derive Copy, Clone, PartialEq, and Eq for Alignment for convenience.

