### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/compiler/rustc_error_codes/src/error_codes/E0284.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0284.md
@@ -30,5 +30,3 @@ fn main() {
     d = d + m;
 }
 ```
-
-Note that the type of `v` can now be inferred from the type of `temp`.

--- a/compiler/rustc_expand/src/mbe/macro_parser.rs
+++ b/compiler/rustc_expand/src/mbe/macro_parser.rs
@@ -345,6 +345,38 @@ fn initial_matcher_pos<'root, 'tt>(ms: &'tt [TokenTree]) -> MatcherPos<'root, 't
 /// token tree. The depth of the `NamedMatch` structure will therefore depend
 /// only on the nesting depth of `ast::TTSeq`s in the originating
 /// token tree it was derived from.
+///
+/// In layman's terms: `NamedMatch` will form a tree representing nested matches of a particular
+/// meta variable. For example, if we are matching the following macro against the following
+/// invocation...
+///
+/// ```rust
+/// macro_rules! foo {
+///   ($($($x:ident),+);+) => {}
+/// }
+///
+/// foo!(a, b, c, d; a, b, c, d, e);
+/// ```
+///
+/// Then, the tree will have the following shape:
+///
+/// ```rust
+/// MatchedSeq([
+///   MatchedSeq([
+///     MatchedNonterminal(a),
+///     MatchedNonterminal(b),
+///     MatchedNonterminal(c),
+///     MatchedNonterminal(d),
+///   ]),
+///   MatchedSeq([
+///     MatchedNonterminal(a),
+///     MatchedNonterminal(b),
+///     MatchedNonterminal(c),
+///     MatchedNonterminal(d),
+///     MatchedNonterminal(e),
+///   ])
+/// ])
+/// ```
 #[derive(Debug, Clone)]
 crate enum NamedMatch {
     MatchedSeq(Lrc<NamedMatchVec>),

--- a/compiler/rustc_expand/src/mbe/transcribe.rs
+++ b/compiler/rustc_expand/src/mbe/transcribe.rs
@@ -358,6 +358,12 @@ impl LockstepIterSize {
 /// Note that if `repeats` does not match the exact correct depth of a meta-var,
 /// `lookup_cur_matched` will return `None`, which is why this still works even in the presence of
 /// multiple nested matcher sequences.
+///
+/// Example: `$($($x $y)+*);+` -- we need to make sure that `x` and `y` repeat the same amount as
+/// each other at the given depth when the macro was invoked. If they don't it might mean they were
+/// declared at unequal depths or there was a compile bug. For example, if we have 3 repetitions of
+/// the outer sequence and 4 repetitions of the inner sequence for `x`, we should have the same for
+/// `y`; otherwise, we can't transcribe them both at the given depth.
 fn lockstep_iter_size(
     tree: &mbe::TokenTree,
     interpolations: &FxHashMap<MacroRulesNormalizedIdent, NamedMatch>,

--- a/compiler/rustc_infer/src/infer/error_reporting/need_type_info.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/need_type_info.rs
@@ -114,28 +114,25 @@ impl<'a, 'tcx> Visitor<'tcx> for FindHirNodeVisitor<'a, 'tcx> {
     }
 
     fn visit_expr(&mut self, expr: &'tcx Expr<'tcx>) {
-        if let ExprKind::Match(scrutinee, [_, arm], MatchSource::ForLoopDesugar) = expr.kind {
-            if let Some(pat) = arm.pat.for_loop_some() {
-                if let Some(ty) = self.node_ty_contains_target(pat.hir_id) {
-                    self.found_for_loop_iter = Some(scrutinee);
-                    self.found_node_ty = Some(ty);
-                    return;
-                }
-            }
+        if let ExprKind::Match(scrutinee, [_, arm], MatchSource::ForLoopDesugar) = expr.kind
+            && let Some(pat) = arm.pat.for_loop_some()
+            && let Some(ty) = self.node_ty_contains_target(pat.hir_id)
+        {
+            self.found_for_loop_iter = Some(scrutinee);
+            self.found_node_ty = Some(ty);
+            return;
         }
-        if let ExprKind::MethodCall(segment, exprs, _) = expr.kind {
-            if segment.ident.span == self.target_span
-                && Some(self.target)
-                    == self.infcx.in_progress_typeck_results.and_then(|typeck_results| {
-                        typeck_results
-                            .borrow()
-                            .node_type_opt(exprs.first().unwrap().hir_id)
-                            .map(Into::into)
-                    })
-            {
-                self.found_exact_method_call = Some(&expr);
-                return;
-            }
+        if let ExprKind::MethodCall(segment, exprs, _) = expr.kind
+            && segment.ident.span == self.target_span
+            && Some(self.target) == self.infcx.in_progress_typeck_results.and_then(|typeck_results| {
+                typeck_results
+                    .borrow()
+                    .node_type_opt(exprs.first().unwrap().hir_id)
+                    .map(Into::into)
+            })
+        {
+            self.found_exact_method_call = Some(&expr);
+            return;
         }
 
         // FIXME(const_generics): Currently, any uninferred `const` generics arguments
@@ -602,10 +599,8 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
         );
 
         let use_diag = local_visitor.found_use_diagnostic.as_ref();
-        if let Some(use_diag) = use_diag {
-            if use_diag.applies_to(err_span) {
-                use_diag.attach_note(&mut err);
-            }
+        if let Some(use_diag) = use_diag && use_diag.applies_to(err_span) {
+            use_diag.attach_note(&mut err);
         }
 
         let param_type = arg_data.kind.descr();
@@ -736,29 +731,27 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                 //    |               help: specify type like: `<Impl as Into<u32>>::into(foo_impl)`
                 //    |
                 //    = note: cannot satisfy `Impl: Into<_>`
-                if !impl_candidates.is_empty() && e.span.contains(span) {
-                    if let Some(expr) = exprs.first() {
-                        if let ExprKind::Path(hir::QPath::Resolved(_, path)) = expr.kind {
-                            if let [path_segment] = path.segments {
-                                let candidate_len = impl_candidates.len();
-                                let suggestions = impl_candidates.iter().map(|candidate| {
-                                    format!(
-                                        "{}::{}({})",
-                                        candidate, segment.ident, path_segment.ident
-                                    )
-                                });
-                                err.span_suggestions(
-                                    e.span,
-                                    &format!(
-                                        "use the fully qualified path for the potential candidate{}",
-                                        pluralize!(candidate_len),
-                                    ),
-                                    suggestions,
-                                    Applicability::MaybeIncorrect,
-                                );
-                            }
-                        }
-                    };
+                if !impl_candidates.is_empty() && e.span.contains(span)
+                    && let Some(expr) = exprs.first()
+                    && let ExprKind::Path(hir::QPath::Resolved(_, path)) = expr.kind
+                    && let [path_segment] = path.segments
+                {
+                    let candidate_len = impl_candidates.len();
+                    let suggestions = impl_candidates.iter().map(|candidate| {
+                        format!(
+                            "{}::{}({})",
+                            candidate, segment.ident, path_segment.ident
+                        )
+                    });
+                    err.span_suggestions(
+                        e.span,
+                        &format!(
+                            "use the fully qualified path for the potential candidate{}",
+                            pluralize!(candidate_len),
+                        ),
+                        suggestions,
+                        Applicability::MaybeIncorrect,
+                    );
                 }
                 // Suggest specifying type params or point out the return type of the call:
                 //

--- a/compiler/rustc_infer/src/infer/fudge.rs
+++ b/compiler/rustc_infer/src/infer/fudge.rs
@@ -220,12 +220,10 @@ impl<'a, 'tcx> TypeFolder<'tcx> for InferenceFudger<'a, 'tcx> {
     }
 
     fn fold_region(&mut self, r: ty::Region<'tcx>) -> ty::Region<'tcx> {
-        if let ty::ReVar(vid) = *r {
-            if self.region_vars.0.contains(&vid) {
-                let idx = vid.index() - self.region_vars.0.start.index();
-                let origin = self.region_vars.1[idx];
-                return self.infcx.next_region_var(origin);
-            }
+        if let ty::ReVar(vid) = *r && self.region_vars.0.contains(&vid) {
+            let idx = vid.index() - self.region_vars.0.start.index();
+            let origin = self.region_vars.1[idx];
+            return self.infcx.next_region_var(origin);
         }
         r
     }

--- a/compiler/rustc_infer/src/infer/lexical_region_resolve/mod.rs
+++ b/compiler/rustc_infer/src/infer/lexical_region_resolve/mod.rs
@@ -304,10 +304,8 @@ impl<'cx, 'tcx> LexicalResolver<'cx, 'tcx> {
                 // check below for a common case, here purely as an
                 // optimization.
                 let b_universe = self.var_infos[b_vid].universe;
-                if let ReEmpty(a_universe) = *a_region {
-                    if a_universe == b_universe {
-                        return false;
-                    }
+                if let ReEmpty(a_universe) = *a_region && a_universe == b_universe {
+                    return false;
                 }
 
                 let mut lub = self.lub_concrete_regions(a_region, cur_region);
@@ -324,10 +322,8 @@ impl<'cx, 'tcx> LexicalResolver<'cx, 'tcx> {
                 // tighter bound than `'static`.
                 //
                 // (This might e.g. arise from being asked to prove `for<'a> { 'b: 'a }`.)
-                if let ty::RePlaceholder(p) = *lub {
-                    if b_universe.cannot_name(p.universe) {
-                        lub = self.tcx().lifetimes.re_static;
-                    }
+                if let ty::RePlaceholder(p) = *lub && b_universe.cannot_name(p.universe) {
+                    lub = self.tcx().lifetimes.re_static;
                 }
 
                 debug!("Expanding value of {:?} from {:?} to {:?}", b_vid, cur_region, lub);

--- a/compiler/rustc_infer/src/infer/nll_relate/mod.rs
+++ b/compiler/rustc_infer/src/infer/nll_relate/mod.rs
@@ -963,10 +963,8 @@ where
     ) -> RelateResult<'tcx, ty::Region<'tcx>> {
         debug!("TypeGeneralizer::regions(a={:?})", a);
 
-        if let ty::ReLateBound(debruijn, _) = *a {
-            if debruijn < self.first_free_index {
-                return Ok(a);
-            }
+        if let ty::ReLateBound(debruijn, _) = *a && debruijn < self.first_free_index {
+            return Ok(a);
         }
 
         // For now, we just always create a fresh region variable to

--- a/compiler/rustc_infer/src/infer/region_constraints/mod.rs
+++ b/compiler/rustc_infer/src/infer/region_constraints/mod.rs
@@ -470,10 +470,8 @@ impl<'tcx> RegionConstraintCollector<'_, 'tcx> {
         debug!("RegionConstraintCollector: add_verify({:?})", verify);
 
         // skip no-op cases known to be satisfied
-        if let VerifyBound::AllBounds(ref bs) = verify.bound {
-            if bs.is_empty() {
-                return;
-            }
+        if let VerifyBound::AllBounds(ref bs) = verify.bound && bs.is_empty() {
+            return;
         }
 
         let index = self.data.verifys.len();

--- a/compiler/rustc_infer/src/lib.rs
+++ b/compiler/rustc_infer/src/lib.rs
@@ -12,18 +12,19 @@
 //!
 //! This API is completely unstable and subject to change.
 
+#![allow(rustc::potential_query_instability)]
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
 #![feature(bool_to_option)]
 #![feature(box_patterns)]
+#![feature(control_flow_enum)]
 #![feature(derive_default_enum)]
 #![feature(extend_one)]
-#![feature(let_else)]
-#![feature(never_type)]
-#![feature(control_flow_enum)]
-#![feature(min_specialization)]
 #![feature(label_break_value)]
+#![feature(let_chains)]
+#![feature(let_else)]
+#![feature(min_specialization)]
+#![feature(never_type)]
 #![recursion_limit = "512"] // For rustdoc
-#![allow(rustc::potential_query_instability)]
 
 #[macro_use]
 extern crate rustc_macros;

--- a/compiler/rustc_infer/src/traits/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/traits/error_reporting/mod.rs
@@ -60,12 +60,10 @@ pub fn report_object_safety_error<'tcx>(
     let mut multi_span = vec![];
     let mut messages = vec![];
     for violation in violations {
-        if let ObjectSafetyViolation::SizedSelf(sp) = &violation {
-            if !sp.is_empty() {
-                // Do not report `SizedSelf` without spans pointing at `SizedSelf` obligations
-                // with a `Span`.
-                reported_violations.insert(ObjectSafetyViolation::SizedSelf(vec![].into()));
-            }
+        if let ObjectSafetyViolation::SizedSelf(sp) = &violation && !sp.is_empty() {
+            // Do not report `SizedSelf` without spans pointing at `SizedSelf` obligations
+            // with a `Span`.
+            reported_violations.insert(ObjectSafetyViolation::SizedSelf(vec![].into()));
         }
         if reported_violations.insert(violation.clone()) {
             let spans = violation.spans();

--- a/library/std/src/ffi/mod.rs
+++ b/library/std/src/ffi/mod.rs
@@ -159,6 +159,15 @@ pub use self::os_str::{OsStr, OsString};
 #[stable(feature = "core_c_void", since = "1.30.0")]
 pub use core::ffi::c_void;
 
+#[unstable(feature = "core_ffi_c", issue = "94501")]
+pub use core::ffi::{
+    c_char, c_double, c_float, c_int, c_long, c_longlong, c_schar, c_short, c_uchar, c_uint,
+    c_ulong, c_ulonglong, c_ushort,
+};
+
+#[unstable(feature = "c_size_t", issue = "88345")]
+pub use core::ffi::{c_ptrdiff_t, c_size_t, c_ssize_t};
+
 #[unstable(
     feature = "c_variadic",
     reason = "the `c_variadic` feature has not been properly tested on \

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -261,6 +261,7 @@
 #![feature(const_socketaddr)]
 #![feature(const_trait_impl)]
 #![feature(container_error_extra)]
+#![feature(c_size_t)]
 #![feature(core_ffi_c)]
 #![feature(core_intrinsics)]
 #![feature(core_panic)]

--- a/library/std/src/os/fd/raw.rs
+++ b/library/std/src/os/fd/raw.rs
@@ -7,9 +7,9 @@ use crate::io;
 use crate::os::raw;
 #[cfg(unix)]
 use crate::os::unix::io::OwnedFd;
-#[all(cfg(doc), unix)]
+#[cfg(all(doc, unix))]
 use crate::os::unix::io::{AsFd, FromFd, IntoFd};
-#[all(cfg(doc), target_os = "wasi")]
+#[cfg(all(doc, target_os = "wasi"))]
 use crate::os::unix::io::{AsFd, FromFd, IntoFd};
 #[cfg(target_os = "wasi")]
 use crate::os::wasi::io::OwnedFd;

--- a/library/std/src/os/fd/raw.rs
+++ b/library/std/src/os/fd/raw.rs
@@ -5,12 +5,12 @@
 use crate::fs;
 use crate::io;
 use crate::os::raw;
-#[cfg(unix)]
-use crate::os::unix::io::OwnedFd;
 #[cfg(all(doc, unix))]
 use crate::os::unix::io::AsFd;
 #[cfg(all(doc, target_os = "wasi"))]
 use crate::os::unix::io::AsFd;
+#[cfg(unix)]
+use crate::os::unix::io::OwnedFd;
 #[cfg(target_os = "wasi")]
 use crate::os::wasi::io::OwnedFd;
 use crate::sys_common::{AsInner, IntoInner};

--- a/library/std/src/os/fd/raw.rs
+++ b/library/std/src/os/fd/raw.rs
@@ -8,9 +8,9 @@ use crate::os::raw;
 #[cfg(unix)]
 use crate::os::unix::io::OwnedFd;
 #[cfg(all(doc, unix))]
-use crate::os::unix::io::{AsFd, FromFd, IntoFd};
+use crate::os::unix::io::AsFd;
 #[cfg(all(doc, target_os = "wasi"))]
-use crate::os::unix::io::{AsFd, FromFd, IntoFd};
+use crate::os::unix::io::AsFd;
 #[cfg(target_os = "wasi")]
 use crate::os::wasi::io::OwnedFd;
 use crate::sys_common::{AsInner, IntoInner};
@@ -69,8 +69,9 @@ pub trait FromRawFd {
     /// will take responsibility for closing it when the object goes out of
     /// scope.
     ///
-    /// However, consuming ownership is not strictly required. See
-    /// [`FromFd::from_fd`] for an API which strictly consumes ownership.
+    /// However, consuming ownership is not strictly required. Use a
+    /// [`From<OwnedFd>::from`] implementation for an API which strictly
+    /// consumes ownership.
     ///
     /// # Safety
     ///
@@ -109,8 +110,9 @@ pub trait IntoRawFd {
     /// file descriptor to the caller. When used in this way, callers are then the unique
     /// owners of the file descriptor and must close it once it's no longer needed.
     ///
-    /// However, transferring ownership is not strictly required. See
-    /// [`IntoFd::into_fd`] for an API which strictly transfers ownership.
+    /// However, transferring ownership is not strictly required. Use a
+    /// [`Into<OwnedFd>::into`] implementation for an API which strictly
+    /// transfers ownership.
     ///
     /// # Example
     ///

--- a/library/std/src/os/fd/raw.rs
+++ b/library/std/src/os/fd/raw.rs
@@ -5,9 +5,7 @@
 use crate::fs;
 use crate::io;
 use crate::os::raw;
-#[cfg(all(doc, unix))]
-use crate::os::unix::io::AsFd;
-#[cfg(all(doc, target_os = "wasi"))]
+#[cfg(doc)]
 use crate::os::unix::io::AsFd;
 #[cfg(unix)]
 use crate::os::unix::io::OwnedFd;

--- a/library/std/src/os/fd/raw.rs
+++ b/library/std/src/os/fd/raw.rs
@@ -31,7 +31,7 @@ pub trait AsRawFd {
     /// destroyed.
     ///
     /// However, borrowing is not strictly required. See [`AsFd::as_fd`]
-    /// for an API which strictly borrows a handle.
+    /// for an API which strictly borrows a file descriptor.
     ///
     /// # Example
     ///

--- a/library/std/src/os/fd/raw.rs
+++ b/library/std/src/os/fd/raw.rs
@@ -24,9 +24,14 @@ pub type RawFd = raw::c_int;
 pub trait AsRawFd {
     /// Extracts the raw file descriptor.
     ///
-    /// This method does **not** pass ownership of the raw file descriptor
-    /// to the caller. The descriptor is only guaranteed to be valid while
-    /// the original object has not yet been destroyed.
+    /// This function is typically used to **borrow** an owned file descriptor.
+    /// When used in this way, this method does **not** pass ownership of the
+    /// raw file descriptor to the caller, and the file descriptor is only
+    /// guaranteed to be valid while the original object has not yet been
+    /// destroyed.
+    ///
+    /// However, borrowing is not strictly required. See [`AsFd::as_fd`]
+    /// for an API which strictly borrows a handle.
     ///
     /// # Example
     ///
@@ -55,15 +60,17 @@ pub trait FromRawFd {
     /// Constructs a new instance of `Self` from the given raw file
     /// descriptor.
     ///
-    /// This function **consumes ownership** of the specified file
-    /// descriptor. The returned object will take responsibility for closing
-    /// it when the object goes out of scope.
+    /// This function is typically used to **consume ownership** of the
+    /// specified file descriptor. When used in this way, the returned object
+    /// will take responsibility for closing it when the object goes out of
+    /// scope.
     ///
-    /// This function is also unsafe as the primitives currently returned
-    /// have the contract that they are the sole owner of the file
-    /// descriptor they are wrapping. Usage of this function could
-    /// accidentally allow violating this contract which can cause memory
-    /// unsafety in code that relies on it being true.
+    /// However, consuming ownership is not strictly required. See
+    /// [`FromFd::from_fd`] for an API which strictly consumes ownership.
+    ///
+    /// # Safety
+    ///
+    /// The `fd` passed in must be a valid an open file descriptor.
     ///
     /// # Example
     ///
@@ -94,9 +101,12 @@ pub trait FromRawFd {
 pub trait IntoRawFd {
     /// Consumes this object, returning the raw underlying file descriptor.
     ///
-    /// This function **transfers ownership** of the underlying file descriptor
-    /// to the caller. Callers are then the unique owners of the file descriptor
-    /// and must close the descriptor once it's no longer needed.
+    /// This function is typically used to **transfer ownership** of the underlying
+    /// file descriptor to the caller. When used in this way, callers are then the unique
+    /// owners of the file descriptor and must close it once it's no longer needed.
+    ///
+    /// However, transferring ownership is not strictly required. See
+    /// [`IntoFd::into_fd`] for an API which strictly transfers ownership.
     ///
     /// # Example
     ///

--- a/library/std/src/os/fd/raw.rs
+++ b/library/std/src/os/fd/raw.rs
@@ -7,6 +7,10 @@ use crate::io;
 use crate::os::raw;
 #[cfg(unix)]
 use crate::os::unix::io::OwnedFd;
+#[all(cfg(doc), unix)]
+use crate::os::unix::io::{AsFd, FromFd, IntoFd};
+#[all(cfg(doc), target_os = "wasi")]
+use crate::os::unix::io::{AsFd, FromFd, IntoFd};
 #[cfg(target_os = "wasi")]
 use crate::os::wasi::io::OwnedFd;
 use crate::sys_common::{AsInner, IntoInner};

--- a/library/std/src/os/windows/io/handle.rs
+++ b/library/std/src/os/windows/io/handle.rs
@@ -232,7 +232,7 @@ impl HandleOrNull {
     ///
     /// [here]: https://devblogs.microsoft.com/oldnewthing/20040302-00/?p=40443
     #[inline]
-    unsafe fn from_raw_handle(handle: RawHandle) -> Self {
+    pub unsafe fn from_raw_handle(handle: RawHandle) -> Self {
         Self(OwnedHandle::from_raw_handle(handle))
     }
 }
@@ -254,7 +254,7 @@ impl HandleOrInvalid {
     ///
     /// [here]: https://devblogs.microsoft.com/oldnewthing/20040302-00/?p=40443
     #[inline]
-    unsafe fn from_raw_handle(handle: RawHandle) -> Self {
+    pub unsafe fn from_raw_handle(handle: RawHandle) -> Self {
         Self(OwnedHandle::from_raw_handle(handle))
     }
 }

--- a/library/std/src/os/windows/io/handle.rs
+++ b/library/std/src/os/windows/io/handle.rs
@@ -210,29 +210,13 @@ impl IntoRawHandle for OwnedHandle {
 }
 
 impl FromRawHandle for OwnedHandle {
-    /// Constructs a new instance of `Self` from the given raw handle.
-    ///
-    /// # Safety
-    ///
-    /// The resource pointed to by `handle` must be open and suitable for
-    /// assuming ownership. The resource must not require any cleanup other
-    /// than `CloseHandle`.
-    ///
-    /// In particular, it must not be used with handles to open registry
-    /// keys which need to be closed with [`RegCloseKey`] instead.
-    ///
-    /// Note that it *may* have the value `INVALID_HANDLE_VALUE` (-1), which is
-    /// sometimes a valid handle value. See [here] for the full story.
-    ///
-    /// [`RegCloseKey`]: https://docs.microsoft.com/en-us/windows/win32/api/winreg/nf-winreg-regclosekey
-    /// [here]: https://devblogs.microsoft.com/oldnewthing/20040302-00/?p=40443
     #[inline]
     unsafe fn from_raw_handle(handle: RawHandle) -> Self {
         Self { handle }
     }
 }
 
-impl FromRawHandle for HandleOrNull {
+impl HandleOrNull {
     /// Constructs a new instance of `Self` from the given `RawHandle` returned
     /// from a Windows API that uses null to indicate failure, such as
     /// `CreateThread`.
@@ -242,9 +226,9 @@ impl FromRawHandle for HandleOrNull {
     ///
     /// # Safety
     ///
-    /// The resource pointed to by `handle` must be either open and otherwise
-    /// unowned, or null. Note that not all Windows APIs use null for errors;
-    /// see [here] for the full story.
+    /// The passed `handle` value must either satisfy the safety requirements
+    /// of [`FromRawHandle::from_raw_handle`], or be null. Note that not all
+    /// Windows APIs use null for errors; see [here] for the full story.
     ///
     /// [here]: https://devblogs.microsoft.com/oldnewthing/20040302-00/?p=40443
     #[inline]
@@ -253,7 +237,7 @@ impl FromRawHandle for HandleOrNull {
     }
 }
 
-impl FromRawHandle for HandleOrInvalid {
+impl HandleOrInvalid {
     /// Constructs a new instance of `Self` from the given `RawHandle` returned
     /// from a Windows API that uses `INVALID_HANDLE_VALUE` to indicate
     /// failure, such as `CreateFileW`.
@@ -263,10 +247,10 @@ impl FromRawHandle for HandleOrInvalid {
     ///
     /// # Safety
     ///
-    /// The resource pointed to by `handle` must be either open and otherwise
-    /// unowned, null, or equal to `INVALID_HANDLE_VALUE` (-1). Note that not
-    /// all Windows APIs use `INVALID_HANDLE_VALUE` for errors; see [here] for
-    /// the full story.
+    /// The passed `handle` value must either satisfy the safety requirements
+    /// of [`FromRawHandle::from_raw_handle`], or be
+    /// `INVALID_HANDLE_VALUE` (-1). Note that not all Windows APIs use
+    /// `INVALID_HANDLE_VALUE` for errors; see [here] for the full story.
     ///
     /// [here]: https://devblogs.microsoft.com/oldnewthing/20040302-00/?p=40443
     #[inline]

--- a/library/std/src/os/windows/io/raw.rs
+++ b/library/std/src/os/windows/io/raw.rs
@@ -5,6 +5,8 @@
 use crate::fs;
 use crate::io;
 use crate::net;
+#[all(cfg(doc), unix)]
+use crate::os::windows::io::{AsHandle, AsSocket, FromHandle, FromSocket, IntoHandle, IntoSocket};
 use crate::os::windows::io::{OwnedHandle, OwnedSocket};
 use crate::os::windows::raw;
 use crate::sys;

--- a/library/std/src/os/windows/io/raw.rs
+++ b/library/std/src/os/windows/io/raw.rs
@@ -22,7 +22,15 @@ pub type RawSocket = raw::SOCKET;
 /// Extracts raw handles.
 #[stable(feature = "rust1", since = "1.0.0")]
 pub trait AsRawHandle {
-    /// Extracts the raw handle, without taking any ownership.
+    /// Extracts the raw handle.
+    ///
+    /// This function is typically used to **borrow** an owned handle.
+    /// When used in this way, this method does **not** pass ownership of the
+    /// raw handle to the caller, and the handle is only guaranteed
+    /// to be valid while the original object has not yet been destroyed.
+    ///
+    /// However, borrowing is not strictly required. See [`AsHandle::as_handle`]
+    /// for an API which strictly borrows a handle.
     #[stable(feature = "rust1", since = "1.0.0")]
     fn as_raw_handle(&self) -> RawHandle;
 }
@@ -32,15 +40,29 @@ pub trait AsRawHandle {
 pub trait FromRawHandle {
     /// Constructs a new I/O object from the specified raw handle.
     ///
-    /// This function will **consume ownership** of the handle given,
-    /// passing responsibility for closing the handle to the returned
-    /// object.
+    /// This function is typically used to **consume ownership** of the handle
+    /// given, passing responsibility for closing the handle to the returned
+    /// object. When used in this way, the returned object
+    /// will take responsibility for closing it when the object goes out of
+    /// scope.
     ///
-    /// This function is also unsafe as the primitives currently returned
-    /// have the contract that they are the sole owner of the file
-    /// descriptor they are wrapping. Usage of this function could
-    /// accidentally allow violating this contract which can cause memory
-    /// unsafety in code that relies on it being true.
+    /// However, consuming ownership is not strictly required. See
+    /// [`FromHandle::from_handle`] for an API which strictly consumes ownership.
+    ///
+    /// # Safety
+    ///
+    /// The `handle` passed in must:
+    ///   - be a valid an open handle,
+    ///   - be a handle opened for synchronous I/O, *without* the
+    ///     `FILE_FLAG_OVERLAPPED` flag, and
+    ///   - be a handle for a resource that may be freed via [`CloseHandle`]
+    ///     (as opposed to `RegCloseKey` or other close functions).
+    ///
+    /// Note that the handle *may* have the value `INVALID_HANDLE_VALUE` (-1),
+    /// which is sometimes a valid handle value. See [here] for the full story.
+    ///
+    /// [`CloseHandle`]: https://docs.microsoft.com/en-us/windows/win32/api/handleapi/nf-handleapi-closehandle
+    /// [here]: https://devblogs.microsoft.com/oldnewthing/20040302-00/?p=40443
     #[stable(feature = "from_raw_os", since = "1.1.0")]
     unsafe fn from_raw_handle(handle: RawHandle) -> Self;
 }
@@ -51,9 +73,12 @@ pub trait FromRawHandle {
 pub trait IntoRawHandle {
     /// Consumes this object, returning the raw underlying handle.
     ///
-    /// This function **transfers ownership** of the underlying handle to the
-    /// caller. Callers are then the unique owners of the handle and must close
-    /// it once it's no longer needed.
+    /// This function is typically used to **transfer ownership** of the underlying
+    /// handle to the caller. When used in this way, callers are then the unique
+    /// owners of the handle and must close it once it's no longer needed.
+    ///
+    /// However, transferring ownership is not strictly required. See
+    /// [`IntoHandle::into_handle`] for an API which strictly transfers ownership.
     #[stable(feature = "into_raw_os", since = "1.4.0")]
     fn into_raw_handle(self) -> RawHandle;
 }
@@ -130,7 +155,15 @@ impl IntoRawHandle for fs::File {
 /// Extracts raw sockets.
 #[stable(feature = "rust1", since = "1.0.0")]
 pub trait AsRawSocket {
-    /// Extracts the underlying raw socket from this object.
+    /// Extracts the raw socket.
+    ///
+    /// This function is typically used to **borrow** an owned socket.
+    /// When used in this way, this method does **not** pass ownership of the
+    /// raw socket to the caller, and the socket is only guaranteed
+    /// to be valid while the original object has not yet been destroyed.
+    ///
+    /// However, borrowing is not strictly required. See [`AsSocket::as_socket`]
+    /// for an API which strictly borrows a socket.
     #[stable(feature = "rust1", since = "1.0.0")]
     fn as_raw_socket(&self) -> RawSocket;
 }
@@ -138,16 +171,24 @@ pub trait AsRawSocket {
 /// Creates I/O objects from raw sockets.
 #[stable(feature = "from_raw_os", since = "1.1.0")]
 pub trait FromRawSocket {
-    /// Creates a new I/O object from the given raw socket.
+    /// Constructs a new I/O object from the specified raw socket.
     ///
-    /// This function will **consume ownership** of the socket provided and
-    /// it will be closed when the returned object goes out of scope.
+    /// This function is typically used to **consume ownership** of the socket
+    /// given, passing responsibility for closing the socket to the returned
+    /// object. When used in this way, the returned object
+    /// will take responsibility for closing it when the object goes out of
+    /// scope.
     ///
-    /// This function is also unsafe as the primitives currently returned
-    /// have the contract that they are the sole owner of the file
-    /// descriptor they are wrapping. Usage of this function could
-    /// accidentally allow violating this contract which can cause memory
-    /// unsafety in code that relies on it being true.
+    /// However, consuming ownership is not strictly required. See
+    /// [`FromSocket::from_socket`] for an API which strictly consumes ownership.
+    ///
+    /// # Safety
+    ///
+    /// The `socket` passed in must:
+    ///   - be a valid an open socket,
+    ///   - be a handle for a resource that may be freed via [`closesocket`].
+    ///
+    /// [`closesocket`]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-closesocket
     #[stable(feature = "from_raw_os", since = "1.1.0")]
     unsafe fn from_raw_socket(sock: RawSocket) -> Self;
 }
@@ -158,9 +199,12 @@ pub trait FromRawSocket {
 pub trait IntoRawSocket {
     /// Consumes this object, returning the raw underlying socket.
     ///
-    /// This function **transfers ownership** of the underlying socket to the
-    /// caller. Callers are then the unique owners of the socket and must close
-    /// it once it's no longer needed.
+    /// This function is typically used to **transfer ownership** of the underlying
+    /// socket to the caller. When used in this way, callers are then the unique
+    /// owners of the socket and must close it once it's no longer needed.
+    ///
+    /// However, transferring ownership is not strictly required. See
+    /// [`IntoSocket::into_socket`] for an API which strictly transfers ownership.
     #[stable(feature = "into_raw_os", since = "1.4.0")]
     fn into_raw_socket(self) -> RawSocket;
 }

--- a/library/std/src/os/windows/io/raw.rs
+++ b/library/std/src/os/windows/io/raw.rs
@@ -186,7 +186,7 @@ pub trait FromRawSocket {
     ///
     /// The `socket` passed in must:
     ///   - be a valid an open socket,
-    ///   - be a handle for a resource that may be freed via [`closesocket`].
+    ///   - be a socket that may be freed via [`closesocket`].
     ///
     /// [`closesocket`]: https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-closesocket
     #[stable(feature = "from_raw_os", since = "1.1.0")]

--- a/library/std/src/os/windows/io/raw.rs
+++ b/library/std/src/os/windows/io/raw.rs
@@ -5,7 +5,7 @@
 use crate::fs;
 use crate::io;
 use crate::net;
-#[all(cfg(doc), unix)]
+#[cfg(doc)]
 use crate::os::windows::io::{AsHandle, AsSocket, FromHandle, FromSocket, IntoHandle, IntoSocket};
 use crate::os::windows::io::{OwnedHandle, OwnedSocket};
 use crate::os::windows::raw;

--- a/library/std/src/os/windows/io/raw.rs
+++ b/library/std/src/os/windows/io/raw.rs
@@ -56,8 +56,6 @@ pub trait FromRawHandle {
     ///
     /// The `handle` passed in must:
     ///   - be a valid an open handle,
-    ///   - be a handle opened for synchronous I/O, *without* the
-    ///     `FILE_FLAG_OVERLAPPED` flag, and
     ///   - be a handle for a resource that may be freed via [`CloseHandle`]
     ///     (as opposed to `RegCloseKey` or other close functions).
     ///

--- a/library/std/src/os/windows/io/raw.rs
+++ b/library/std/src/os/windows/io/raw.rs
@@ -6,7 +6,7 @@ use crate::fs;
 use crate::io;
 use crate::net;
 #[cfg(doc)]
-use crate::os::windows::io::{AsHandle, AsSocket, FromHandle, FromSocket, IntoHandle, IntoSocket};
+use crate::os::windows::io::{AsHandle, AsSocket};
 use crate::os::windows::io::{OwnedHandle, OwnedSocket};
 use crate::os::windows::raw;
 use crate::sys;
@@ -48,8 +48,9 @@ pub trait FromRawHandle {
     /// will take responsibility for closing it when the object goes out of
     /// scope.
     ///
-    /// However, consuming ownership is not strictly required. See
-    /// [`FromHandle::from_handle`] for an API which strictly consumes ownership.
+    /// However, consuming ownership is not strictly required. Use a
+    /// `From<OwnedHandle>::from` implementation for an API which strictly
+    /// consumes ownership.
     ///
     /// # Safety
     ///
@@ -79,8 +80,9 @@ pub trait IntoRawHandle {
     /// handle to the caller. When used in this way, callers are then the unique
     /// owners of the handle and must close it once it's no longer needed.
     ///
-    /// However, transferring ownership is not strictly required. See
-    /// [`IntoHandle::into_handle`] for an API which strictly transfers ownership.
+    /// However, transferring ownership is not strictly required. Use a
+    /// `Into<OwnedHandle>::into` implementation for an API which strictly
+    /// transfers ownership.
     #[stable(feature = "into_raw_os", since = "1.4.0")]
     fn into_raw_handle(self) -> RawHandle;
 }
@@ -181,8 +183,9 @@ pub trait FromRawSocket {
     /// will take responsibility for closing it when the object goes out of
     /// scope.
     ///
-    /// However, consuming ownership is not strictly required. See
-    /// [`FromSocket::from_socket`] for an API which strictly consumes ownership.
+    /// However, consuming ownership is not strictly required. Use a
+    /// `From<OwnedSocket>::from` implementation for an API which strictly
+    /// consumes ownership.
     ///
     /// # Safety
     ///
@@ -205,8 +208,9 @@ pub trait IntoRawSocket {
     /// socket to the caller. When used in this way, callers are then the unique
     /// owners of the socket and must close it once it's no longer needed.
     ///
-    /// However, transferring ownership is not strictly required. See
-    /// [`IntoSocket::into_socket`] for an API which strictly transfers ownership.
+    /// However, transferring ownership is not strictly required. Use a
+    /// `Into<OwnedSocket>::into` implementation for an API which strictly
+    /// transfers ownership.
     #[stable(feature = "into_raw_os", since = "1.4.0")]
     fn into_raw_socket(self) -> RawSocket;
 }

--- a/library/std/src/os/windows/io/socket.rs
+++ b/library/std/src/os/windows/io/socket.rs
@@ -168,13 +168,6 @@ impl IntoRawSocket for OwnedSocket {
 }
 
 impl FromRawSocket for OwnedSocket {
-    /// Constructs a new instance of `Self` from the given raw socket.
-    ///
-    /// # Safety
-    ///
-    /// The resource pointed to by `socket` must be open and suitable for
-    /// assuming ownership. The resource must not require cleanup other than
-    /// `closesocket`.
     #[inline]
     unsafe fn from_raw_socket(socket: RawSocket) -> Self {
         debug_assert_ne!(socket, c::INVALID_SOCKET as RawSocket);

--- a/src/test/rustdoc/strip-enum-variant.rs
+++ b/src/test/rustdoc/strip-enum-variant.rs
@@ -1,0 +1,9 @@
+// @has strip_enum_variant/enum.MyThing.html
+// @has - '//code' 'Shown'
+// @!has - '//code' 'NotShown'
+// @has - '//code' '// some variants omitted'
+pub enum MyThing {
+    Shown,
+    #[doc(hidden)]
+    NotShown,
+}

--- a/src/tools/clippy/clippy_lints/src/lib.register_all.rs
+++ b/src/tools/clippy/clippy_lints/src/lib.register_all.rs
@@ -281,7 +281,6 @@ store.register_group(true, "clippy::all", Some("clippy_all"), vec![
     LintId::of(transmute::TRANSMUTE_INT_TO_FLOAT),
     LintId::of(transmute::TRANSMUTE_NUM_TO_BYTES),
     LintId::of(transmute::TRANSMUTE_PTR_TO_REF),
-    LintId::of(transmute::TRANSMUTE_UNDEFINED_REPR),
     LintId::of(transmute::UNSOUND_COLLECTION_TRANSMUTE),
     LintId::of(transmute::WRONG_TRANSMUTE),
     LintId::of(transmuting_null::TRANSMUTING_NULL),

--- a/src/tools/clippy/clippy_lints/src/lib.register_correctness.rs
+++ b/src/tools/clippy/clippy_lints/src/lib.register_correctness.rs
@@ -58,7 +58,6 @@ store.register_group(true, "clippy::correctness", Some("clippy_correctness"), ve
     LintId::of(serde_api::SERDE_API_MISUSE),
     LintId::of(size_of_in_element_count::SIZE_OF_IN_ELEMENT_COUNT),
     LintId::of(swap::ALMOST_SWAPPED),
-    LintId::of(transmute::TRANSMUTE_UNDEFINED_REPR),
     LintId::of(transmute::UNSOUND_COLLECTION_TRANSMUTE),
     LintId::of(transmute::WRONG_TRANSMUTE),
     LintId::of(transmuting_null::TRANSMUTING_NULL),

--- a/src/tools/clippy/clippy_lints/src/lib.register_nursery.rs
+++ b/src/tools/clippy/clippy_lints/src/lib.register_nursery.rs
@@ -26,6 +26,7 @@ store.register_group(true, "clippy::nursery", Some("clippy_nursery"), vec![
     LintId::of(strings::STRING_LIT_AS_BYTES),
     LintId::of(suspicious_operation_groupings::SUSPICIOUS_OPERATION_GROUPINGS),
     LintId::of(trailing_empty_array::TRAILING_EMPTY_ARRAY),
+    LintId::of(transmute::TRANSMUTE_UNDEFINED_REPR),
     LintId::of(transmute::USELESS_TRANSMUTE),
     LintId::of(use_self::USE_SELF),
 ])

--- a/src/tools/clippy/clippy_lints/src/transmute/mod.rs
+++ b/src/tools/clippy/clippy_lints/src/transmute/mod.rs
@@ -377,7 +377,7 @@ declare_clippy_lint! {
     /// ```
     #[clippy::version = "1.60.0"]
     pub TRANSMUTE_UNDEFINED_REPR,
-    correctness,
+    nursery,
     "transmute to or from a type with an undefined representation"
 }
 


### PR DESCRIPTION
Successful merges:

 - #93562 (Update the documentation for `{As,Into,From}Raw{Fd,Handle,Socket}`.)
 - #94101 (rustdoc: add test cases for hidden enum variants)
 - #94484 (8 - Make more use of `let_chains`)
 - #94522 (Remove out-of-context line at end of E0284 message)
 - #94534 (Re-export (unstable) core::ffi types from std::ffi)
 - #94536 (Move transmute_undefined_repr back to nursery again)
 - #94537 (Use ? operator in one instance instead of manual match)
 - #94544 (Add some examples to comments in mbe code)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=93562,94101,94484,94522,94534,94536,94537,94544)
<!-- homu-ignore:end -->