### PR TITLE
Rename JoinHandle::is_running to is_finished.

### DIFF
--- a/library/std/src/thread/mod.rs
+++ b/library/std/src/thread/mod.rs
@@ -1443,13 +1443,18 @@ impl<T> JoinHandle<T> {
         self.0.join()
     }
 
-    /// Checks if the associated thread is still running its main function.
+    /// Checks if the associated thread has finished running its main function.
     ///
-    /// This might return `false` for a brief moment after the thread's main
+    /// This might return `true` for a brief moment after the thread's main
     /// function has returned, but before the thread itself has stopped running.
+    /// However, once this returns `true`, [`join`][Self::join] can be expected
+    /// to return quickly, without blocking for any significant amount of time.
+    ///
+    /// This function does not block. To block while waiting on the thread to finish,
+    /// use [`join`][Self::join].
     #[unstable(feature = "thread_is_running", issue = "90470")]
-    pub fn is_running(&self) -> bool {
-        Arc::strong_count(&self.0.packet) > 1
+    pub fn is_finished(&self) -> bool {
+        Arc::strong_count(&self.0.packet) == 1
     }
 }
 

--- a/library/std/src/thread/scoped.rs
+++ b/library/std/src/thread/scoped.rs
@@ -240,7 +240,6 @@ impl<'scope, T> ScopedJoinHandle<'scope, T> {
     ///
     /// ```
     /// #![feature(scoped_threads)]
-    /// #![feature(thread_is_running)]
     ///
     /// use std::thread;
     ///
@@ -274,7 +273,6 @@ impl<'scope, T> ScopedJoinHandle<'scope, T> {
     ///
     /// ```
     /// #![feature(scoped_threads)]
-    /// #![feature(thread_is_running)]
     ///
     /// use std::thread;
     ///

--- a/library/std/src/thread/scoped.rs
+++ b/library/std/src/thread/scoped.rs
@@ -289,13 +289,18 @@ impl<'scope, T> ScopedJoinHandle<'scope, T> {
         self.0.join()
     }
 
-    /// Checks if the associated thread is still running its main function.
+    /// Checks if the associated thread has finished running its main function.
     ///
-    /// This might return `false` for a brief moment after the thread's main
+    /// This might return `true` for a brief moment after the thread's main
     /// function has returned, but before the thread itself has stopped running.
+    /// However, once this returns `true`, [`join`][Self::join] can be expected
+    /// to return quickly, without blocking for any significant amount of time.
+    ///
+    /// This function does not block. To block while waiting on the thread to finish,
+    /// use [`join`][Self::join].
     #[unstable(feature = "thread_is_running", issue = "90470")]
-    pub fn is_running(&self) -> bool {
-        Arc::strong_count(&self.0.packet) > 1
+    pub fn is_finished(&self) -> bool {
+        Arc::strong_count(&self.0.packet) == 1
     }
 }
 

--- a/library/std/src/thread/tests.rs
+++ b/library/std/src/thread/tests.rs
@@ -52,7 +52,7 @@ fn test_run_basic() {
 }
 
 #[test]
-fn test_is_running() {
+fn test_is_finished() {
     let b = Arc::new(Barrier::new(2));
     let t = thread::spawn({
         let b = b.clone();
@@ -63,14 +63,14 @@ fn test_is_running() {
     });
 
     // Thread is definitely running here, since it's still waiting for the barrier.
-    assert_eq!(t.is_running(), true);
+    assert_eq!(t.is_finished(), false);
 
     // Unblock the barrier.
     b.wait();
 
-    // Now check that t.is_running() becomes false within a reasonable time.
+    // Now check that t.is_finished() becomes true within a reasonable time.
     let start = Instant::now();
-    while t.is_running() {
+    while !t.is_finished() {
         assert!(start.elapsed() < Duration::from_secs(2));
         thread::sleep(Duration::from_millis(15));
     }


### PR DESCRIPTION
This is renaming `is_running` to `is_finished` as discussed on the tracking issue here: https://github.com/rust-lang/rust/issues/90470#issuecomment-1050188499

Taking some of the docs suggestions from https://github.com/rust-lang/rust/pull/94033