### PR TITLE
Doc: Fix use of quote instead of backstick in Adapter::map.

### DIFF
--- a/library/core/src/iter/adapters/map.rs
+++ b/library/core/src/iter/adapters/map.rs
@@ -38,7 +38,7 @@ use crate::ops::Try;
 /// }
 /// ```
 ///
-/// This will print "('a', 1), ('b', 2), ('c', 3)".
+/// This will print `('a', 1), ('b', 2), ('c', 3)`.
 ///
 /// Now consider this twist where we add a call to `rev`. This version will
 /// print `('c', 1), ('b', 2), ('a', 3)`. Note that the letters are reversed,


### PR DESCRIPTION
A little commit to fix documentation rendering and semantics in https://doc.rust-lang.org/std/iter/struct.Map.html#notes-about-side-effects `"` where used around an expression instead \`.

Screenshot on doc.rust-lang.org:
![2022-03-03 11-21-43_backstick](https://user-images.githubusercontent.com/2827553/156546536-569b7692-7ac4-4388-8e93-c1628ddc6a0f.png)

Looking forward: Maybe reworking the doc to use assert_eq like the upper paragraph:
```
let v: Vec<i32> = vec![1, 2, 3].into_iter().map(|x| x + 1).rev().collect();

assert_eq!(v, [4, 3, 2]);
```