### PR TITLE
Fix invalid lint_node_id being put on a removed stmt

### DIFF
--- a/compiler/rustc_expand/src/expand.rs
+++ b/compiler/rustc_expand/src/expand.rs
@@ -1841,7 +1841,7 @@ impl<'a, 'b> MutVisitor for InvocationCollector<'a, 'b> {
         self.flat_map_node(node)
     }
 
-    fn flat_map_stmt(&mut self, mut node: ast::Stmt) -> SmallVec<[ast::Stmt; 1]> {
+    fn flat_map_stmt(&mut self, node: ast::Stmt) -> SmallVec<[ast::Stmt; 1]> {
         // FIXME: invocations in semicolon-less expressions positions are expanded as expressions,
         // changing that requires some compatibility measures.
         if node.is_expr() {
@@ -1863,7 +1863,7 @@ impl<'a, 'b> MutVisitor for InvocationCollector<'a, 'b> {
                     self.cx.current_expansion.is_trailing_mac = false;
                     res
                 }
-                _ => assign_id!(self, &mut node.id, || noop_flat_map_stmt(node, self)),
+                _ => noop_flat_map_stmt(node, self),
             };
         }
 

--- a/src/test/ui/check-cfg/stmt-no-ice.rs
+++ b/src/test/ui/check-cfg/stmt-no-ice.rs
@@ -1,0 +1,10 @@
+// This test checks that there is no ICE with this code
+//
+// check-pass
+// compile-flags:--check-cfg=names() -Z unstable-options
+
+fn main() {
+    #[cfg(crossbeam_loom)]
+    //~^ WARNING unexpected `cfg` condition name
+    {}
+}

--- a/src/test/ui/check-cfg/stmt-no-ice.stderr
+++ b/src/test/ui/check-cfg/stmt-no-ice.stderr
@@ -1,0 +1,10 @@
+warning: unexpected `cfg` condition name
+  --> $DIR/stmt-no-ice.rs:7:11
+   |
+LL |     #[cfg(crossbeam_loom)]
+   |           ^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(unexpected_cfgs)]` on by default
+
+warning: 1 warning emitted
+


### PR DESCRIPTION
This pull-request remove a invalid `assign_id!` being put on an stmt node.

The problem is that this node is being removed away by a cfg making it unreachable when triggering a buffered lint.
The comment in the other match arm already tell to not assign a id because it could have a `#[cfg()]` so this is just respecting the comment.

Fixes https://github.com/rust-lang/rust/issues/94523
r? @petrochenkov 