### PR TITLE
`iterate_to_fixpoint` -> `iterate_reachable_to_fixpoint`

### DIFF
--- a/compiler/rustc_mir_transform/src/generator.rs
+++ b/compiler/rustc_mir_transform/src/generator.rs
@@ -473,7 +473,7 @@ fn locals_live_across_suspend_points<'tcx>(
     // for.
     let requires_storage_results = MaybeRequiresStorage::new(body, &borrowed_locals_results)
         .into_engine(tcx, body_ref)
-        .iterate_to_fixpoint();
+        .iterate_reachable_to_fixpoint();
     let mut requires_storage_cursor =
         rustc_mir_dataflow::ResultsCursor::new(body_ref, &requires_storage_results);
 


### PR DESCRIPTION
The `rustc_mir_dataflow::framework::Engine` computes a fixpoint over just the reachable basic blocks instead of all of them, and does not offer a way to do the latter. This PR addresses that problem.

Specifically, this PR does the following:

* Renames `iterate_to_fixpoint` to `iterate_reachable_to_fixpoint`.
* Adds to `framework::Enginge` a new method with the old name (`iterate_to_fixpoint`). The new method computes the fixpoint over all basic blocks, instead of just the reachable ones.
* Changes one occurrence of `iterate_to_fixpoint` to `iterate_reachable_to_fixpoint` where the analysis seemed to care about only reachable basic blocks.

For context, I asked [this question](https://users.rust-lang.org/t/questions-about-rustc-mir-dataflow-analyses/72464) in the Rust language forum. Then I noticed that `framework::Results` has both [`visit_with`](https://github.com/rust-lang/rust/tree/8769f4ef2fe1efddd1f072485f97f568e7328f79/compiler/rustc_mir_dataflow/src/framework/engine.rs#L52) and [`visit_reachable_with`](https://github.com/rust-lang/rust/blob/8769f4ef2fe1efddd1f072485f97f568e7328f79/compiler/rustc_mir_dataflow/src/framework/engine.rs#L61) methods.

Arguably, the current API is inconsistent (and perhaps even dangerous). Why would someone visit all basic blocks when `iterate_to_fixpoint` computes the fixpoint over just the reachable ones? It seems unlikely that someone would do this intentionally.

Currently, there is just one call to `visit_reachable_with` in the `compiler` directory. That one call is related to a use of `MaybeRequiresStorage`. This PR changes its associated call to `iterate_to_fixpoint` to `iterate_reachable_to_fixpoint`, since that analysis seemed to really want just reachable basic blocks.

Presumably, all calls to `visit_with` are either agnostic to whether they visit all or only reachable basic blocks, or really want *all* basic blocks. This PR effectively changes those calls to use the new method with the old name.