### PR TITLE
only disable SIMD for doctests in Miri (not for the stdlib build itself)

### DIFF
--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -408,12 +408,12 @@ pub mod arch {
 #[allow(missing_debug_implementations, dead_code, unsafe_op_in_unsafe_fn, unused_unsafe)]
 #[allow(rustdoc::bare_urls)]
 #[unstable(feature = "portable_simd", issue = "86656")]
-#[cfg(not(all(miri, doctest)))] // Miri does not support all SIMD intrinsics
+#[cfg(not(all(miri, doctest)))] // Skip SIMD doctests in Miri
 mod core_simd;
 
 #[doc = include_str!("../../portable-simd/crates/core_simd/src/core_simd_docs.md")]
 #[unstable(feature = "portable_simd", issue = "86656")]
-#[cfg(not(all(miri, doctest)))] // Miri does not support all SIMD intrinsics
+#[cfg(not(all(miri, doctest)))] // Skip SIMD doctests in Miri
 pub mod simd {
     #[unstable(feature = "portable_simd", issue = "86656")]
     pub use crate::core_simd::simd::*;

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -16,7 +16,7 @@ use crate::option::Option::{None, Some};
 use crate::ptr;
 use crate::result::Result;
 use crate::result::Result::{Err, Ok};
-#[cfg(not(miri))] // Miri does not support all SIMD intrinsics
+#[cfg(not(all(miri, doctest)))] // Miri skips SIMD doctests
 use crate::simd::{self, Simd};
 use crate::slice;
 
@@ -3540,7 +3540,7 @@ impl<T> [T] {
     /// assert_eq!(basic_simd_sum(&numbers[1..99]), 4949.0);
     /// ```
     #[unstable(feature = "portable_simd", issue = "86656")]
-    #[cfg(not(miri))] // Miri does not support all SIMD intrinsics
+    #[cfg(not(all(miri, doctest)))] // Miri skips SIMD doctests
     pub fn as_simd<const LANES: usize>(&self) -> (&[T], &[Simd<T, LANES>], &[T])
     where
         Simd<T, LANES>: AsRef<[T; LANES]>,
@@ -3584,7 +3584,7 @@ impl<T> [T] {
     /// be lifted in a way that would make it possible to see panics from this
     /// method for something like `LANES == 3`.
     #[unstable(feature = "portable_simd", issue = "86656")]
-    #[cfg(not(miri))] // Miri does not support all SIMD intrinsics
+    #[cfg(not(all(miri, doctest)))] // Miri skips SIMD doctests
     pub fn as_simd_mut<const LANES: usize>(&mut self) -> (&mut [T], &mut [Simd<T, LANES>], &mut [T])
     where
         Simd<T, LANES>: AsMut<[T; LANES]>,

--- a/library/core/tests/simd.rs
+++ b/library/core/tests/simd.rs
@@ -1,5 +1,3 @@
-#![cfg(not(miri))] // Miri does not support all SIMD intrinsics
-
 use core::simd::f32x4;
 
 #[test]

--- a/library/core/tests/slice.rs
+++ b/library/core/tests/slice.rs
@@ -2457,9 +2457,11 @@ take_tests! {
     (take_last_mut_empty, (), None, &mut []),
 }
 
+#[cfg(not(miri))] // unused in Miri
 const EMPTY_MAX: &'static [()] = &[(); usize::MAX];
 
 // can't be a constant due to const mutability rules
+#[cfg(not(miri))] // unused in Miri
 macro_rules! empty_max_mut {
     () => {
         &mut [(); usize::MAX] as _


### PR DESCRIPTION
Also we can enable library/core/tests/simd.rs now, Miri supports enough SIMD for that.