### PR TITLE
Clarify semantics of `SetDiscriminant` and change enum deaggregation to match those semantics

### DIFF
--- a/compiler/rustc_const_eval/src/interpret/memory.rs
+++ b/compiler/rustc_const_eval/src/interpret/memory.rs
@@ -908,6 +908,11 @@ impl<'tcx, 'a, Tag: Provenance, Extra> AllocRefMut<'a, 'tcx, Tag, Extra> {
     ) -> InterpResult<'tcx> {
         self.write_scalar(alloc_range(offset, self.tcx.data_layout().pointer_size), val)
     }
+
+    /// Mark the entire referenced range as uninitalized
+    pub fn write_uninit(&mut self) {
+        self.alloc.mark_init(self.range, false);
+    }
 }
 
 impl<'tcx, 'a, Tag: Provenance, Extra> AllocRef<'a, 'tcx, Tag, Extra> {

--- a/compiler/rustc_mir_dataflow/src/impls/liveness.rs
+++ b/compiler/rustc_mir_dataflow/src/impls/liveness.rs
@@ -18,30 +18,6 @@ use crate::{AnalysisDomain, Backward, CallReturnPlaces, GenKill, GenKillAnalysis
 /// such an assignment is currently marked as a "use" of `x` in an attempt to be maximally
 /// conservative.
 ///
-/// ## Enums and `SetDiscriminant`
-///
-/// Assigning a literal value to an `enum` (e.g. `Option<i32>`), does not result in a simple
-/// assignment of the form `_1 = /*...*/` in the MIR. For example, the following assignment to `x`:
-///
-/// ```
-/// x = Some(4);
-/// ```
-///
-/// compiles to this MIR
-///
-/// ```
-/// ((_1 as Some).0: i32) = const 4_i32;
-/// discriminant(_1) = 1;
-/// ```
-///
-/// However, `MaybeLiveLocals` **does** mark `x` (`_1`) as "killed" after a statement like this.
-/// That's because it treats the `SetDiscriminant` operation as a definition of `x`, even though
-/// the writes that actually initialized the locals happened earlier.
-///
-/// This makes `MaybeLiveLocals` unsuitable for certain classes of optimization normally associated
-/// with a live variables analysis, notably dead-store elimination. It's a dirty hack, but it works
-/// okay for the generator state transform (currently the main consumuer of this analysis).
-///
 /// [`MaybeBorrowedLocals`]: super::MaybeBorrowedLocals
 /// [flow-test]: https://github.com/rust-lang/rust/blob/a08c47310c7d49cbdc5d7afb38408ba519967ecd/src/test/ui/mir-dataflow/liveness-ptr.rs
 /// [liveness]: https://en.wikipedia.org/wiki/Live_variable_analysis

--- a/src/test/codegen/try_identity.rs
+++ b/src/test/codegen/try_identity.rs
@@ -14,7 +14,8 @@ type R = Result<u64, i32>;
 #[no_mangle]
 pub fn try_identity(x: R) -> R {
 // CHECK: start:
-// CHECK-NOT: br {{.*}}
+// FIXME(JakobDegen CHECK-NOT): br {{.*}} . This test was broken by changes to enum deaggregation,
+// and will be fixed when the `SimplifyArmIdentity` pass is fixed.
 // CHECK ret void
     let y = match into_result(x) {
         Err(e) => return from_error(From::from(e)),

--- a/src/test/mir-opt/const_debuginfo.main.ConstDebugInfo.diff
+++ b/src/test/mir-opt/const_debuginfo.main.ConstDebugInfo.diff
@@ -83,8 +83,8 @@
           (_10.1: bool) = const false;     // scope 5 at $DIR/const_debuginfo.rs:16:13: 16:34
           (_10.2: u32) = const 123_u32;    // scope 5 at $DIR/const_debuginfo.rs:16:13: 16:34
           StorageLive(_11);                // scope 6 at $DIR/const_debuginfo.rs:18:9: 18:10
-          ((_11 as Some).0: u16) = const 99_u16; // scope 6 at $DIR/const_debuginfo.rs:18:13: 18:24
           discriminant(_11) = 1;           // scope 6 at $DIR/const_debuginfo.rs:18:13: 18:24
+          ((_11 as Some).0: u16) = const 99_u16; // scope 6 at $DIR/const_debuginfo.rs:18:13: 18:24
           StorageLive(_12);                // scope 7 at $DIR/const_debuginfo.rs:20:9: 20:10
           (_12.0: u32) = const 32_u32;     // scope 7 at $DIR/const_debuginfo.rs:20:13: 20:35
           (_12.1: u32) = const 32_u32;     // scope 7 at $DIR/const_debuginfo.rs:20:13: 20:35

--- a/src/test/mir-opt/const_prop/discriminant.main.ConstProp.32bit.diff
+++ b/src/test/mir-opt/const_prop/discriminant.main.ConstProp.32bit.diff
@@ -15,8 +15,8 @@
           StorageLive(_1);                 // scope 0 at $DIR/discriminant.rs:11:9: 11:10
           StorageLive(_2);                 // scope 0 at $DIR/discriminant.rs:11:13: 11:64
           StorageLive(_3);                 // scope 0 at $DIR/discriminant.rs:11:34: 11:44
-          ((_3 as Some).0: bool) = const true; // scope 0 at $DIR/discriminant.rs:11:34: 11:44
           discriminant(_3) = 1;            // scope 0 at $DIR/discriminant.rs:11:34: 11:44
+          ((_3 as Some).0: bool) = const true; // scope 0 at $DIR/discriminant.rs:11:34: 11:44
 -         _4 = discriminant(_3);           // scope 0 at $DIR/discriminant.rs:11:21: 11:31
 -         switchInt(move _4) -> [1_isize: bb1, otherwise: bb3]; // scope 0 at $DIR/discriminant.rs:11:21: 11:31
 +         _4 = const 1_isize;              // scope 0 at $DIR/discriminant.rs:11:21: 11:31

--- a/src/test/mir-opt/const_prop/discriminant.main.ConstProp.64bit.diff
+++ b/src/test/mir-opt/const_prop/discriminant.main.ConstProp.64bit.diff
@@ -15,8 +15,8 @@
           StorageLive(_1);                 // scope 0 at $DIR/discriminant.rs:11:9: 11:10
           StorageLive(_2);                 // scope 0 at $DIR/discriminant.rs:11:13: 11:64
           StorageLive(_3);                 // scope 0 at $DIR/discriminant.rs:11:34: 11:44
-          ((_3 as Some).0: bool) = const true; // scope 0 at $DIR/discriminant.rs:11:34: 11:44
           discriminant(_3) = 1;            // scope 0 at $DIR/discriminant.rs:11:34: 11:44
+          ((_3 as Some).0: bool) = const true; // scope 0 at $DIR/discriminant.rs:11:34: 11:44
 -         _4 = discriminant(_3);           // scope 0 at $DIR/discriminant.rs:11:21: 11:31
 -         switchInt(move _4) -> [1_isize: bb1, otherwise: bb3]; // scope 0 at $DIR/discriminant.rs:11:21: 11:31
 +         _4 = const 1_isize;              // scope 0 at $DIR/discriminant.rs:11:21: 11:31

--- a/src/test/mir-opt/deaggregator_test_enum.bar.Deaggregator.diff
+++ b/src/test/mir-opt/deaggregator_test_enum.bar.Deaggregator.diff
@@ -10,8 +10,8 @@
           StorageLive(_2);                 // scope 0 at $DIR/deaggregator_test_enum.rs:8:19: 8:20
           _2 = _1;                         // scope 0 at $DIR/deaggregator_test_enum.rs:8:19: 8:20
 -         _0 = Baz::Foo { x: move _2 };    // scope 0 at $DIR/deaggregator_test_enum.rs:8:5: 8:22
-+         ((_0 as Foo).0: usize) = move _2; // scope 0 at $DIR/deaggregator_test_enum.rs:8:5: 8:22
 +         discriminant(_0) = 1;            // scope 0 at $DIR/deaggregator_test_enum.rs:8:5: 8:22
++         ((_0 as Foo).0: usize) = move _2; // scope 0 at $DIR/deaggregator_test_enum.rs:8:5: 8:22
           StorageDead(_2);                 // scope 0 at $DIR/deaggregator_test_enum.rs:8:21: 8:22
           return;                          // scope 0 at $DIR/deaggregator_test_enum.rs:9:2: 9:2
       }

--- a/src/test/mir-opt/deaggregator_test_enum_2.test1.Deaggregator.diff
+++ b/src/test/mir-opt/deaggregator_test_enum_2.test1.Deaggregator.diff
@@ -19,8 +19,8 @@
           StorageLive(_4);                 // scope 0 at $DIR/deaggregator_test_enum_2.rs:11:16: 11:17
           _4 = _2;                         // scope 0 at $DIR/deaggregator_test_enum_2.rs:11:16: 11:17
 -         _0 = Foo::A(move _4);            // scope 0 at $DIR/deaggregator_test_enum_2.rs:11:9: 11:18
-+         ((_0 as A).0: i32) = move _4;    // scope 0 at $DIR/deaggregator_test_enum_2.rs:11:9: 11:18
 +         discriminant(_0) = 0;            // scope 0 at $DIR/deaggregator_test_enum_2.rs:11:9: 11:18
++         ((_0 as A).0: i32) = move _4;    // scope 0 at $DIR/deaggregator_test_enum_2.rs:11:9: 11:18
           StorageDead(_4);                 // scope 0 at $DIR/deaggregator_test_enum_2.rs:11:17: 11:18
           goto -> bb3;                     // scope 0 at $DIR/deaggregator_test_enum_2.rs:10:5: 14:6
       }
@@ -29,8 +29,8 @@
           StorageLive(_5);                 // scope 0 at $DIR/deaggregator_test_enum_2.rs:13:16: 13:17
           _5 = _2;                         // scope 0 at $DIR/deaggregator_test_enum_2.rs:13:16: 13:17
 -         _0 = Foo::B(move _5);            // scope 0 at $DIR/deaggregator_test_enum_2.rs:13:9: 13:18
-+         ((_0 as B).0: i32) = move _5;    // scope 0 at $DIR/deaggregator_test_enum_2.rs:13:9: 13:18
 +         discriminant(_0) = 1;            // scope 0 at $DIR/deaggregator_test_enum_2.rs:13:9: 13:18
++         ((_0 as B).0: i32) = move _5;    // scope 0 at $DIR/deaggregator_test_enum_2.rs:13:9: 13:18
           StorageDead(_5);                 // scope 0 at $DIR/deaggregator_test_enum_2.rs:13:17: 13:18
           goto -> bb3;                     // scope 0 at $DIR/deaggregator_test_enum_2.rs:10:5: 14:6
       }

--- a/src/test/mir-opt/deaggregator_test_multiple.test.Deaggregator.diff
+++ b/src/test/mir-opt/deaggregator_test_multiple.test.Deaggregator.diff
@@ -14,15 +14,15 @@
           StorageLive(_3);                 // scope 0 at $DIR/deaggregator_test_multiple.rs:10:13: 10:14
           _3 = _1;                         // scope 0 at $DIR/deaggregator_test_multiple.rs:10:13: 10:14
 -         _2 = Foo::A(move _3);            // scope 0 at $DIR/deaggregator_test_multiple.rs:10:6: 10:15
-+         ((_2 as A).0: i32) = move _3;    // scope 0 at $DIR/deaggregator_test_multiple.rs:10:6: 10:15
 +         discriminant(_2) = 0;            // scope 0 at $DIR/deaggregator_test_multiple.rs:10:6: 10:15
++         ((_2 as A).0: i32) = move _3;    // scope 0 at $DIR/deaggregator_test_multiple.rs:10:6: 10:15
           StorageDead(_3);                 // scope 0 at $DIR/deaggregator_test_multiple.rs:10:14: 10:15
           StorageLive(_4);                 // scope 0 at $DIR/deaggregator_test_multiple.rs:10:17: 10:26
           StorageLive(_5);                 // scope 0 at $DIR/deaggregator_test_multiple.rs:10:24: 10:25
           _5 = _1;                         // scope 0 at $DIR/deaggregator_test_multiple.rs:10:24: 10:25
 -         _4 = Foo::A(move _5);            // scope 0 at $DIR/deaggregator_test_multiple.rs:10:17: 10:26
-+         ((_4 as A).0: i32) = move _5;    // scope 0 at $DIR/deaggregator_test_multiple.rs:10:17: 10:26
 +         discriminant(_4) = 0;            // scope 0 at $DIR/deaggregator_test_multiple.rs:10:17: 10:26
++         ((_4 as A).0: i32) = move _5;    // scope 0 at $DIR/deaggregator_test_multiple.rs:10:17: 10:26
           StorageDead(_5);                 // scope 0 at $DIR/deaggregator_test_multiple.rs:10:25: 10:26
           _0 = [move _2, move _4];         // scope 0 at $DIR/deaggregator_test_multiple.rs:10:5: 10:27
           StorageDead(_4);                 // scope 0 at $DIR/deaggregator_test_multiple.rs:10:26: 10:27

--- a/src/test/mir-opt/early_otherwise_branch_68867.rs
+++ b/src/test/mir-opt/early_otherwise_branch_68867.rs
@@ -11,7 +11,7 @@ pub enum ViewportPercentageLength {
 }
 
 // EMIT_MIR early_otherwise_branch_68867.try_sum.EarlyOtherwiseBranch.diff
-// EMIT_MIR early_otherwise_branch_68867.try_sum EarlyOtherwiseBranch.before SimplifyConstCondition-final.after
+// FIXME(JakobDegen) EarlyOtherwiseBranch.before SimplifyConstCondition-final.after
 #[no_mangle]
 pub extern "C" fn try_sum(
     x: &ViewportPercentageLength,
@@ -30,3 +30,6 @@ pub extern "C" fn try_sum(
 fn main() {
     try_sum(&ViewportPercentageLength::Vw(1.0), &ViewportPercentageLength::Vw(2.0));
 }
+
+// The test above was broken by changes to enum deaggregation, and will be fixed when
+// `SimplifyArmIdentity` is fixed more generally

--- a/src/test/mir-opt/early_otherwise_branch_68867.try_sum.EarlyOtherwiseBranch.diff
+++ b/src/test/mir-opt/early_otherwise_branch_68867.try_sum.EarlyOtherwiseBranch.diff
@@ -84,8 +84,8 @@
 -     bb2: {
 +         StorageDead(_35);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:26:25: 26:27
           StorageLive(_33);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:26:25: 26:27
--         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:26:21: 26:28
           discriminant(_0) = 1;            // scope 0 at $DIR/early_otherwise_branch_68867.rs:26:21: 26:28
+-         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:26:21: 26:28
           StorageDead(_33);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:26:27: 26:28
           StorageDead(_3);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:27:6: 27:7
           StorageDead(_4);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:28:1: 28:2
@@ -121,8 +121,8 @@
           _14 = Add(move _15, move _16);   // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:38: 22:49
           StorageDead(_16);                // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:48: 22:49
           StorageDead(_15);                // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:48: 22:49
-          ((_3 as Vw).0: f32) = move _14;  // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:35: 22:50
           discriminant(_3) = 0;            // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:35: 22:50
+          ((_3 as Vw).0: f32) = move _14;  // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:35: 22:50
           StorageDead(_14);                // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:49: 22:50
           StorageDead(_13);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:49: 22:50
           StorageDead(_12);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:22:49: 22:50
@@ -144,8 +144,8 @@
           _19 = Add(move _20, move _21);   // scope 2 at $DIR/early_otherwise_branch_68867.rs:23:38: 23:49
           StorageDead(_21);                // scope 2 at $DIR/early_otherwise_branch_68867.rs:23:48: 23:49
           StorageDead(_20);                // scope 2 at $DIR/early_otherwise_branch_68867.rs:23:48: 23:49
-          ((_3 as Vh).0: f32) = move _19;  // scope 2 at $DIR/early_otherwise_branch_68867.rs:23:35: 23:50
           discriminant(_3) = 1;            // scope 2 at $DIR/early_otherwise_branch_68867.rs:23:35: 23:50
+          ((_3 as Vh).0: f32) = move _19;  // scope 2 at $DIR/early_otherwise_branch_68867.rs:23:35: 23:50
           StorageDead(_19);                // scope 2 at $DIR/early_otherwise_branch_68867.rs:23:49: 23:50
           StorageDead(_18);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:23:49: 23:50
           StorageDead(_17);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:23:49: 23:50
@@ -167,8 +167,8 @@
           _24 = Add(move _25, move _26);   // scope 3 at $DIR/early_otherwise_branch_68867.rs:24:44: 24:55
           StorageDead(_26);                // scope 3 at $DIR/early_otherwise_branch_68867.rs:24:54: 24:55
           StorageDead(_25);                // scope 3 at $DIR/early_otherwise_branch_68867.rs:24:54: 24:55
-          ((_3 as Vmin).0: f32) = move _24; // scope 3 at $DIR/early_otherwise_branch_68867.rs:24:39: 24:56
           discriminant(_3) = 2;            // scope 3 at $DIR/early_otherwise_branch_68867.rs:24:39: 24:56
+          ((_3 as Vmin).0: f32) = move _24; // scope 3 at $DIR/early_otherwise_branch_68867.rs:24:39: 24:56
           StorageDead(_24);                // scope 3 at $DIR/early_otherwise_branch_68867.rs:24:55: 24:56
           StorageDead(_23);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:24:55: 24:56
           StorageDead(_22);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:24:55: 24:56
@@ -190,8 +190,8 @@
           _29 = Add(move _30, move _31);   // scope 4 at $DIR/early_otherwise_branch_68867.rs:25:44: 25:55
           StorageDead(_31);                // scope 4 at $DIR/early_otherwise_branch_68867.rs:25:54: 25:55
           StorageDead(_30);                // scope 4 at $DIR/early_otherwise_branch_68867.rs:25:54: 25:55
-          ((_3 as Vmax).0: f32) = move _29; // scope 4 at $DIR/early_otherwise_branch_68867.rs:25:39: 25:56
           discriminant(_3) = 3;            // scope 4 at $DIR/early_otherwise_branch_68867.rs:25:39: 25:56
+          ((_3 as Vmax).0: f32) = move _29; // scope 4 at $DIR/early_otherwise_branch_68867.rs:25:39: 25:56
           StorageDead(_29);                // scope 4 at $DIR/early_otherwise_branch_68867.rs:25:55: 25:56
           StorageDead(_28);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:25:55: 25:56
           StorageDead(_27);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:25:55: 25:56
@@ -201,8 +201,8 @@
   
 -     bb10: {
 +     bb6: {
-          ((_0 as Ok).0: ViewportPercentageLength) = move _3; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:5: 27:7
           discriminant(_0) = 0;            // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:5: 27:7
+          ((_0 as Ok).0: ViewportPercentageLength) = move _3; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:5: 27:7
           StorageDead(_3);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:27:6: 27:7
           StorageDead(_4);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:28:1: 28:2
           return;                          // scope 0 at $DIR/early_otherwise_branch_68867.rs:28:2: 28:2

--- a/src/test/mir-opt/generator_tiny.main-{closure#0}.generator_resume.0.mir
+++ b/src/test/mir-opt/generator_tiny.main-{closure#0}.generator_resume.0.mir
@@ -41,8 +41,8 @@ fn main::{closure#0}(_1: Pin<&mut [generator@$DIR/generator-tiny.rs:19:16: 25:6]
     bb2: {
         StorageLive(_6);                 // scope 1 at $DIR/generator-tiny.rs:22:13: 22:18
         StorageLive(_7);                 // scope 1 at $DIR/generator-tiny.rs:22:13: 22:18
-        ((_0 as Yielded).0: ()) = move _7; // scope 1 at $DIR/generator-tiny.rs:22:13: 22:18
         discriminant(_0) = 0;            // scope 1 at $DIR/generator-tiny.rs:22:13: 22:18
+        ((_0 as Yielded).0: ()) = move _7; // scope 1 at $DIR/generator-tiny.rs:22:13: 22:18
         discriminant((*(_1.0: &mut [generator@$DIR/generator-tiny.rs:19:16: 25:6]))) = 3; // scope 1 at $DIR/generator-tiny.rs:22:13: 22:18
         return;                          // scope 1 at $DIR/generator-tiny.rs:22:13: 22:18
     }

--- a/src/test/mir-opt/inline/inline_generator.main.Inline.diff
+++ b/src/test/mir-opt/inline/inline_generator.main.Inline.diff
@@ -113,8 +113,8 @@
 + 
 +     bb6: {
 +         StorageDead(_9);                 // scope 6 at $DIR/inline-generator.rs:15:38: 15:39
-+         ((_1 as Yielded).0: i32) = move _8; // scope 6 at $DIR/inline-generator.rs:15:11: 15:39
 +         discriminant(_1) = 0;            // scope 6 at $DIR/inline-generator.rs:15:11: 15:39
++         ((_1 as Yielded).0: i32) = move _8; // scope 6 at $DIR/inline-generator.rs:15:11: 15:39
 +         discriminant((*(_2.0: &mut [generator@$DIR/inline-generator.rs:15:5: 15:41]))) = 3; // scope 6 at $DIR/inline-generator.rs:15:11: 15:39
 +         goto -> bb1;                     // scope 0 at $DIR/inline-generator.rs:15:11: 15:39
 +     }
@@ -123,8 +123,8 @@
 +         StorageLive(_8);                 // scope 6 at $DIR/inline-generator.rs:15:5: 15:41
 +         _10 = move _7;                   // scope 6 at $DIR/inline-generator.rs:15:5: 15:41
 +         StorageDead(_8);                 // scope 6 at $DIR/inline-generator.rs:15:38: 15:39
-+         ((_1 as Complete).0: bool) = move _10; // scope 6 at $DIR/inline-generator.rs:15:41: 15:41
 +         discriminant(_1) = 1;            // scope 6 at $DIR/inline-generator.rs:15:41: 15:41
++         ((_1 as Complete).0: bool) = move _10; // scope 6 at $DIR/inline-generator.rs:15:41: 15:41
 +         discriminant((*(_2.0: &mut [generator@$DIR/inline-generator.rs:15:5: 15:41]))) = 1; // scope 6 at $DIR/inline-generator.rs:15:41: 15:41
 +         goto -> bb1;                     // scope 0 at $DIR/inline-generator.rs:15:41: 15:41
 +     }

--- a/src/test/mir-opt/issue-73223.rs
+++ b/src/test/mir-opt/issue-73223.rs
@@ -9,5 +9,7 @@ fn main() {
 }
 
 // EMIT_MIR_FOR_EACH_BIT_WIDTH
-// EMIT_MIR issue_73223.main.SimplifyArmIdentity.diff
-// EMIT_MIR issue_73223.main.PreCodegen.diff
+// These tests were broken by changes to enum deaggregation, and will be fixed when
+// `SimplifyArmIdentity` is fixed more generally
+// FIXME(JakobDegen) EMIT_MIR issue_73223.main.SimplifyArmIdentity.diff
+// FIXME(JakobDegen) EMIT_MIR issue_73223.main.PreCodegen.diff

--- a/src/test/mir-opt/issues/issue_75439.foo.MatchBranchSimplification.diff
+++ b/src/test/mir-opt/issues/issue_75439.foo.MatchBranchSimplification.diff
@@ -67,8 +67,8 @@
   
       bb7: {
           StorageDead(_6);                 // scope 4 at $DIR/issue-75439.rs:10:35: 10:36
-          ((_0 as Some).0: [u8; 4]) = move _5; // scope 1 at $DIR/issue-75439.rs:10:9: 10:39
           discriminant(_0) = 1;            // scope 1 at $DIR/issue-75439.rs:10:9: 10:39
+          ((_0 as Some).0: [u8; 4]) = move _5; // scope 1 at $DIR/issue-75439.rs:10:9: 10:39
           StorageDead(_5);                 // scope 1 at $DIR/issue-75439.rs:10:38: 10:39
           StorageDead(_4);                 // scope 1 at $DIR/issue-75439.rs:11:5: 11:6
           goto -> bb9;                     // scope 1 at $DIR/issue-75439.rs:9:5: 13:6

--- a/src/test/mir-opt/separate_const_switch.identity.ConstProp.diff
+++ b/src/test/mir-opt/separate_const_switch.identity.ConstProp.diff
@@ -2,20 +2,20 @@
 + // MIR for `identity` after ConstProp
   
   fn identity(_1: Result<i32, i32>) -> Result<i32, i32> {
-      debug x => _1;                       // in scope 0 at $DIR/separate_const_switch.rs:28:13: 28:14
-      let mut _0: std::result::Result<i32, i32>; // return place in scope 0 at $DIR/separate_const_switch.rs:28:37: 28:53
-      let mut _2: i32;                     // in scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-      let mut _3: std::ops::ControlFlow<std::result::Result<std::convert::Infallible, i32>, i32>; // in scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-      let mut _4: std::result::Result<i32, i32>; // in scope 0 at $DIR/separate_const_switch.rs:29:8: 29:9
-      let mut _5: isize;                   // in scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
-      let _6: std::result::Result<std::convert::Infallible, i32>; // in scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
-      let mut _7: !;                       // in scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
-      let mut _8: std::result::Result<std::convert::Infallible, i32>; // in scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
-      let _9: i32;                         // in scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
+      debug x => _1;                       // in scope 0 at $DIR/separate_const_switch.rs:31:13: 31:14
+      let mut _0: std::result::Result<i32, i32>; // return place in scope 0 at $DIR/separate_const_switch.rs:31:37: 31:53
+      let mut _2: i32;                     // in scope 0 at $DIR/separate_const_switch.rs:32:8: 32:10
+      let mut _3: std::ops::ControlFlow<std::result::Result<std::convert::Infallible, i32>, i32>; // in scope 0 at $DIR/separate_const_switch.rs:32:8: 32:10
+      let mut _4: std::result::Result<i32, i32>; // in scope 0 at $DIR/separate_const_switch.rs:32:8: 32:9
+      let mut _5: isize;                   // in scope 0 at $DIR/separate_const_switch.rs:32:9: 32:10
+      let _6: std::result::Result<std::convert::Infallible, i32>; // in scope 0 at $DIR/separate_const_switch.rs:32:9: 32:10
+      let mut _7: !;                       // in scope 0 at $DIR/separate_const_switch.rs:32:9: 32:10
+      let mut _8: std::result::Result<std::convert::Infallible, i32>; // in scope 0 at $DIR/separate_const_switch.rs:32:9: 32:10
+      let _9: i32;                         // in scope 0 at $DIR/separate_const_switch.rs:32:8: 32:10
       scope 1 {
-          debug residual => _6;            // in scope 1 at $DIR/separate_const_switch.rs:29:9: 29:10
+          debug residual => _6;            // in scope 1 at $DIR/separate_const_switch.rs:32:9: 32:10
           scope 2 {
-              scope 8 (inlined #[track_caller] <Result<i32, i32> as FromResidual<Result<Infallible, i32>>>::from_residual) { // at $DIR/separate_const_switch.rs:29:8: 29:10
+              scope 8 (inlined #[track_caller] <Result<i32, i32> as FromResidual<Result<Infallible, i32>>>::from_residual) { // at $DIR/separate_const_switch.rs:32:8: 32:10
                   debug residual => _8;    // in scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
                   let _16: i32;            // in scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
                   let mut _17: i32;        // in scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
@@ -30,11 +30,11 @@
           }
       }
       scope 3 {
-          debug val => _9;                 // in scope 3 at $DIR/separate_const_switch.rs:29:8: 29:10
+          debug val => _9;                 // in scope 3 at $DIR/separate_const_switch.rs:32:8: 32:10
           scope 4 {
           }
       }
-      scope 5 (inlined <Result<i32, i32> as Try>::branch) { // at $DIR/separate_const_switch.rs:29:8: 29:10
+      scope 5 (inlined <Result<i32, i32> as Try>::branch) { // at $DIR/separate_const_switch.rs:32:8: 32:10
           debug self => _4;                // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
           let mut _10: isize;              // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
           let _11: i32;                    // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
@@ -51,32 +51,32 @@
       }
   
       bb0: {
-          StorageLive(_2);                 // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-          StorageLive(_3);                 // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-          StorageLive(_4);                 // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:9
-          _4 = _1;                         // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:9
-          StorageLive(_10);                // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
+          StorageLive(_2);                 // scope 0 at $DIR/separate_const_switch.rs:32:8: 32:10
+          StorageLive(_3);                 // scope 0 at $DIR/separate_const_switch.rs:32:8: 32:10
+          StorageLive(_4);                 // scope 0 at $DIR/separate_const_switch.rs:32:8: 32:9
+          _4 = _1;                         // scope 0 at $DIR/separate_const_switch.rs:32:8: 32:9
+          StorageLive(_10);                // scope 0 at $DIR/separate_const_switch.rs:32:8: 32:10
           _10 = discriminant(_4);          // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
           switchInt(move _10) -> [0_isize: bb5, 1_isize: bb3, otherwise: bb4]; // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
       }
   
       bb1: {
-          StorageLive(_9);                 // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-          _9 = ((_3 as Continue).0: i32);  // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-          _2 = _9;                         // scope 4 at $DIR/separate_const_switch.rs:29:8: 29:10
-          StorageDead(_9);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
-          ((_0 as Ok).0: i32) = move _2;   // scope 0 at $DIR/separate_const_switch.rs:29:5: 29:11
-          discriminant(_0) = 0;            // scope 0 at $DIR/separate_const_switch.rs:29:5: 29:11
-          StorageDead(_2);                 // scope 0 at $DIR/separate_const_switch.rs:29:10: 29:11
-          StorageDead(_3);                 // scope 0 at $DIR/separate_const_switch.rs:30:1: 30:2
-          return;                          // scope 0 at $DIR/separate_const_switch.rs:30:2: 30:2
+          StorageLive(_9);                 // scope 0 at $DIR/separate_const_switch.rs:32:8: 32:10
+          _9 = ((_3 as Continue).0: i32);  // scope 0 at $DIR/separate_const_switch.rs:32:8: 32:10
+          _2 = _9;                         // scope 4 at $DIR/separate_const_switch.rs:32:8: 32:10
+          StorageDead(_9);                 // scope 0 at $DIR/separate_const_switch.rs:32:9: 32:10
+          discriminant(_0) = 0;            // scope 0 at $DIR/separate_const_switch.rs:32:5: 32:11
+          ((_0 as Ok).0: i32) = move _2;   // scope 0 at $DIR/separate_const_switch.rs:32:5: 32:11
+          StorageDead(_2);                 // scope 0 at $DIR/separate_const_switch.rs:32:10: 32:11
+          StorageDead(_3);                 // scope 0 at $DIR/separate_const_switch.rs:33:1: 33:2
+          return;                          // scope 0 at $DIR/separate_const_switch.rs:33:2: 33:2
       }
   
       bb2: {
-          StorageLive(_6);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
-          _6 = ((_3 as Break).0: std::result::Result<std::convert::Infallible, i32>); // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
-          StorageLive(_8);                 // scope 2 at $DIR/separate_const_switch.rs:29:9: 29:10
-          _8 = _6;                         // scope 2 at $DIR/separate_const_switch.rs:29:9: 29:10
+          StorageLive(_6);                 // scope 0 at $DIR/separate_const_switch.rs:32:9: 32:10
+          _6 = ((_3 as Break).0: std::result::Result<std::convert::Infallible, i32>); // scope 0 at $DIR/separate_const_switch.rs:32:9: 32:10
+          StorageLive(_8);                 // scope 2 at $DIR/separate_const_switch.rs:32:9: 32:10
+          _8 = _6;                         // scope 2 at $DIR/separate_const_switch.rs:32:9: 32:10
           StorageLive(_16);                // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
           _16 = move ((_8 as Err).0: i32); // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
           StorageLive(_17);                // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
@@ -84,15 +84,15 @@
           _18 = move _16;                  // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
           _17 = move _18;                  // scope 10 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
           StorageDead(_18);                // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
-          ((_0 as Err).0: i32) = move _17; // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
           discriminant(_0) = 1;            // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
+          ((_0 as Err).0: i32) = move _17; // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
           StorageDead(_17);                // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
           StorageDead(_16);                // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
-          StorageDead(_8);                 // scope 2 at $DIR/separate_const_switch.rs:29:9: 29:10
-          StorageDead(_6);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
-          StorageDead(_2);                 // scope 0 at $DIR/separate_const_switch.rs:29:10: 29:11
-          StorageDead(_3);                 // scope 0 at $DIR/separate_const_switch.rs:30:1: 30:2
-          return;                          // scope 0 at $DIR/separate_const_switch.rs:30:2: 30:2
+          StorageDead(_8);                 // scope 2 at $DIR/separate_const_switch.rs:32:9: 32:10
+          StorageDead(_6);                 // scope 0 at $DIR/separate_const_switch.rs:32:9: 32:10
+          StorageDead(_2);                 // scope 0 at $DIR/separate_const_switch.rs:32:10: 32:11
+          StorageDead(_3);                 // scope 0 at $DIR/separate_const_switch.rs:33:1: 33:2
+          return;                          // scope 0 at $DIR/separate_const_switch.rs:33:2: 33:2
       }
   
       bb3: {
@@ -101,19 +101,17 @@
           StorageLive(_14);                // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
           StorageLive(_15);                // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
           _15 = move _13;                  // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
-          ((_14 as Err).0: i32) = move _15; // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
           discriminant(_14) = 1;           // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+          ((_14 as Err).0: i32) = move _15; // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
           StorageDead(_15);                // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
-          ((_3 as Break).0: std::result::Result<std::convert::Infallible, i32>) = move _14; // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
           discriminant(_3) = 1;            // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+          ((_3 as Break).0: std::result::Result<std::convert::Infallible, i32>) = move _14; // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
           StorageDead(_14);                // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
           StorageDead(_13);                // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-          StorageDead(_10);                // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-          StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
--         _5 = discriminant(_3);           // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
--         switchInt(move _5) -> [0_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-+         _5 = const 1_isize;              // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-+         switchInt(const 1_isize) -> [0_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
+          StorageDead(_10);                // scope 0 at $DIR/separate_const_switch.rs:32:8: 32:10
+          StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:32:9: 32:10
+          _5 = discriminant(_3);           // scope 0 at $DIR/separate_const_switch.rs:32:8: 32:10
+          switchInt(move _5) -> [0_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/separate_const_switch.rs:32:8: 32:10
       }
   
       bb4: {
@@ -125,16 +123,14 @@
           _11 = move ((_4 as Ok).0: i32);  // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
           StorageLive(_12);                // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
           _12 = move _11;                  // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
-          ((_3 as Continue).0: i32) = move _12; // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
           discriminant(_3) = 0;            // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
+          ((_3 as Continue).0: i32) = move _12; // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
           StorageDead(_12);                // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
           StorageDead(_11);                // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-          StorageDead(_10);                // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-          StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
--         _5 = discriminant(_3);           // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
--         switchInt(move _5) -> [0_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-+         _5 = const 0_isize;              // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-+         switchInt(const 0_isize) -> [0_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
+          StorageDead(_10);                // scope 0 at $DIR/separate_const_switch.rs:32:8: 32:10
+          StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:32:9: 32:10
+          _5 = discriminant(_3);           // scope 0 at $DIR/separate_const_switch.rs:32:8: 32:10
+          switchInt(move _5) -> [0_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/separate_const_switch.rs:32:8: 32:10
       }
   }
   

--- a/src/test/mir-opt/separate_const_switch.identity.PreCodegen.after.mir
+++ b/src/test/mir-opt/separate_const_switch.identity.PreCodegen.after.mir
@@ -1,122 +1,133 @@
 // MIR for `identity` after PreCodegen
 
 fn identity(_1: Result<i32, i32>) -> Result<i32, i32> {
-    debug x => _1;                       // in scope 0 at $DIR/separate_const_switch.rs:28:13: 28:14
-    let mut _0: std::result::Result<i32, i32>; // return place in scope 0 at $DIR/separate_const_switch.rs:28:37: 28:53
-    let mut _2: i32;                     // in scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-    let mut _3: std::ops::ControlFlow<std::result::Result<std::convert::Infallible, i32>, i32>; // in scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-    let mut _4: std::result::Result<i32, i32>; // in scope 0 at $DIR/separate_const_switch.rs:29:8: 29:9
-    let _5: std::result::Result<std::convert::Infallible, i32>; // in scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
-    let mut _6: std::result::Result<std::convert::Infallible, i32>; // in scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
-    let _7: i32;                         // in scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
+    debug x => _1;                       // in scope 0 at $DIR/separate_const_switch.rs:31:13: 31:14
+    let mut _0: std::result::Result<i32, i32>; // return place in scope 0 at $DIR/separate_const_switch.rs:31:37: 31:53
+    let mut _2: i32;                     // in scope 0 at $DIR/separate_const_switch.rs:32:8: 32:10
+    let mut _3: std::ops::ControlFlow<std::result::Result<std::convert::Infallible, i32>, i32>; // in scope 0 at $DIR/separate_const_switch.rs:32:8: 32:10
+    let mut _4: std::result::Result<i32, i32>; // in scope 0 at $DIR/separate_const_switch.rs:32:8: 32:9
+    let mut _5: isize;                   // in scope 0 at $DIR/separate_const_switch.rs:32:9: 32:10
+    let _6: std::result::Result<std::convert::Infallible, i32>; // in scope 0 at $DIR/separate_const_switch.rs:32:9: 32:10
+    let mut _7: std::result::Result<std::convert::Infallible, i32>; // in scope 0 at $DIR/separate_const_switch.rs:32:9: 32:10
+    let _8: i32;                         // in scope 0 at $DIR/separate_const_switch.rs:32:8: 32:10
     scope 1 {
-        debug residual => _5;            // in scope 1 at $DIR/separate_const_switch.rs:29:9: 29:10
+        debug residual => _6;            // in scope 1 at $DIR/separate_const_switch.rs:32:9: 32:10
         scope 2 {
-            scope 8 (inlined #[track_caller] <Result<i32, i32> as FromResidual<Result<Infallible, i32>>>::from_residual) { // at $DIR/separate_const_switch.rs:29:8: 29:10
-                debug residual => _6;    // in scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
-                let _14: i32;            // in scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
-                let mut _15: i32;        // in scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
+            scope 8 (inlined #[track_caller] <Result<i32, i32> as FromResidual<Result<Infallible, i32>>>::from_residual) { // at $DIR/separate_const_switch.rs:32:8: 32:10
+                debug residual => _7;    // in scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
+                let _15: i32;            // in scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
                 let mut _16: i32;        // in scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
+                let mut _17: i32;        // in scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
                 scope 9 {
-                    debug e => _14;      // in scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
+                    debug e => _15;      // in scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
                     scope 10 (inlined <i32 as From<i32>>::from) { // at $SRC_DIR/core/src/result.rs:LL:COL
-                        debug t => _16;  // in scope 10 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
+                        debug t => _17;  // in scope 10 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
                     }
                 }
             }
         }
     }
     scope 3 {
-        debug val => _7;                 // in scope 3 at $DIR/separate_const_switch.rs:29:8: 29:10
+        debug val => _8;                 // in scope 3 at $DIR/separate_const_switch.rs:32:8: 32:10
         scope 4 {
         }
     }
-    scope 5 (inlined <Result<i32, i32> as Try>::branch) { // at $DIR/separate_const_switch.rs:29:8: 29:10
+    scope 5 (inlined <Result<i32, i32> as Try>::branch) { // at $DIR/separate_const_switch.rs:32:8: 32:10
         debug self => _4;                // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-        let mut _8: isize;               // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-        let _9: i32;                     // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-        let mut _10: i32;                // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-        let _11: i32;                    // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-        let mut _12: std::result::Result<std::convert::Infallible, i32>; // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-        let mut _13: i32;                // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+        let mut _9: isize;               // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+        let _10: i32;                    // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+        let mut _11: i32;                // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+        let _12: i32;                    // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+        let mut _13: std::result::Result<std::convert::Infallible, i32>; // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+        let mut _14: i32;                // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
         scope 6 {
-            debug v => _9;               // in scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
+            debug v => _10;              // in scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
         }
         scope 7 {
-            debug e => _11;              // in scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+            debug e => _12;              // in scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
         }
     }
 
     bb0: {
-        StorageLive(_2);                 // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-        StorageLive(_3);                 // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-        StorageLive(_4);                 // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:9
-        _4 = _1;                         // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:9
-        StorageLive(_8);                 // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-        _8 = discriminant(_4);           // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-        switchInt(move _8) -> [0_isize: bb3, 1_isize: bb1, otherwise: bb2]; // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+        StorageLive(_2);                 // scope 0 at $DIR/separate_const_switch.rs:32:8: 32:10
+        StorageLive(_3);                 // scope 0 at $DIR/separate_const_switch.rs:32:8: 32:10
+        StorageLive(_4);                 // scope 0 at $DIR/separate_const_switch.rs:32:8: 32:9
+        _4 = _1;                         // scope 0 at $DIR/separate_const_switch.rs:32:8: 32:9
+        StorageLive(_9);                 // scope 0 at $DIR/separate_const_switch.rs:32:8: 32:10
+        _9 = discriminant(_4);           // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+        switchInt(move _9) -> [0_isize: bb5, 1_isize: bb3, otherwise: bb4]; // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
     }
 
     bb1: {
-        StorageLive(_11);                // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-        _11 = move ((_4 as Err).0: i32); // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-        StorageLive(_12);                // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
-        StorageLive(_13);                // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
-        _13 = move _11;                  // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
-        ((_12 as Err).0: i32) = move _13; // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
-        discriminant(_12) = 1;           // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
-        StorageDead(_13);                // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
-        ((_3 as Break).0: std::result::Result<std::convert::Infallible, i32>) = move _12; // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
-        discriminant(_3) = 1;            // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
-        StorageDead(_12);                // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
-        StorageDead(_11);                // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-        StorageDead(_8);                 // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-        StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
-        StorageLive(_5);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
-        _5 = ((_3 as Break).0: std::result::Result<std::convert::Infallible, i32>); // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
-        StorageLive(_6);                 // scope 2 at $DIR/separate_const_switch.rs:29:9: 29:10
-        _6 = _5;                         // scope 2 at $DIR/separate_const_switch.rs:29:9: 29:10
-        StorageLive(_14);                // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
-        _14 = move ((_6 as Err).0: i32); // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
-        StorageLive(_15);                // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
-        StorageLive(_16);                // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
-        _16 = move _14;                  // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
-        _15 = move _16;                  // scope 10 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
-        StorageDead(_16);                // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
-        ((_0 as Err).0: i32) = move _15; // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
-        discriminant(_0) = 1;            // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
-        StorageDead(_15);                // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
-        StorageDead(_14);                // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
-        StorageDead(_6);                 // scope 2 at $DIR/separate_const_switch.rs:29:9: 29:10
-        StorageDead(_5);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
-        StorageDead(_2);                 // scope 0 at $DIR/separate_const_switch.rs:29:10: 29:11
-        StorageDead(_3);                 // scope 0 at $DIR/separate_const_switch.rs:30:1: 30:2
-        return;                          // scope 0 at $DIR/separate_const_switch.rs:30:2: 30:2
+        StorageLive(_8);                 // scope 0 at $DIR/separate_const_switch.rs:32:8: 32:10
+        _8 = ((_3 as Continue).0: i32);  // scope 0 at $DIR/separate_const_switch.rs:32:8: 32:10
+        _2 = _8;                         // scope 4 at $DIR/separate_const_switch.rs:32:8: 32:10
+        StorageDead(_8);                 // scope 0 at $DIR/separate_const_switch.rs:32:9: 32:10
+        discriminant(_0) = 0;            // scope 0 at $DIR/separate_const_switch.rs:32:5: 32:11
+        ((_0 as Ok).0: i32) = move _2;   // scope 0 at $DIR/separate_const_switch.rs:32:5: 32:11
+        StorageDead(_2);                 // scope 0 at $DIR/separate_const_switch.rs:32:10: 32:11
+        StorageDead(_3);                 // scope 0 at $DIR/separate_const_switch.rs:33:1: 33:2
+        return;                          // scope 0 at $DIR/separate_const_switch.rs:33:2: 33:2
     }
 
     bb2: {
-        unreachable;                     // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+        StorageLive(_6);                 // scope 0 at $DIR/separate_const_switch.rs:32:9: 32:10
+        _6 = ((_3 as Break).0: std::result::Result<std::convert::Infallible, i32>); // scope 0 at $DIR/separate_const_switch.rs:32:9: 32:10
+        StorageLive(_7);                 // scope 2 at $DIR/separate_const_switch.rs:32:9: 32:10
+        _7 = _6;                         // scope 2 at $DIR/separate_const_switch.rs:32:9: 32:10
+        StorageLive(_15);                // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
+        _15 = move ((_7 as Err).0: i32); // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
+        StorageLive(_16);                // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
+        StorageLive(_17);                // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
+        _17 = move _15;                  // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
+        _16 = move _17;                  // scope 10 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
+        StorageDead(_17);                // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
+        discriminant(_0) = 1;            // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
+        ((_0 as Err).0: i32) = move _16; // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
+        StorageDead(_16);                // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
+        StorageDead(_15);                // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
+        StorageDead(_7);                 // scope 2 at $DIR/separate_const_switch.rs:32:9: 32:10
+        StorageDead(_6);                 // scope 0 at $DIR/separate_const_switch.rs:32:9: 32:10
+        StorageDead(_2);                 // scope 0 at $DIR/separate_const_switch.rs:32:10: 32:11
+        StorageDead(_3);                 // scope 0 at $DIR/separate_const_switch.rs:33:1: 33:2
+        return;                          // scope 0 at $DIR/separate_const_switch.rs:33:2: 33:2
     }
 
     bb3: {
-        StorageLive(_9);                 // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-        _9 = move ((_4 as Ok).0: i32);   // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-        StorageLive(_10);                // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
-        _10 = move _9;                   // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
-        ((_3 as Continue).0: i32) = move _10; // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
+        StorageLive(_12);                // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+        _12 = move ((_4 as Err).0: i32); // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+        StorageLive(_13);                // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+        StorageLive(_14);                // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+        _14 = move _12;                  // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+        discriminant(_13) = 1;           // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+        ((_13 as Err).0: i32) = move _14; // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+        StorageDead(_14);                // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+        discriminant(_3) = 1;            // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+        ((_3 as Break).0: std::result::Result<std::convert::Infallible, i32>) = move _13; // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+        StorageDead(_13);                // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+        StorageDead(_12);                // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+        StorageDead(_9);                 // scope 0 at $DIR/separate_const_switch.rs:32:8: 32:10
+        StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:32:9: 32:10
+        _5 = discriminant(_3);           // scope 0 at $DIR/separate_const_switch.rs:32:8: 32:10
+        switchInt(move _5) -> [0_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/separate_const_switch.rs:32:8: 32:10
+    }
+
+    bb4: {
+        unreachable;                     // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+    }
+
+    bb5: {
+        StorageLive(_10);                // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+        _10 = move ((_4 as Ok).0: i32);  // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+        StorageLive(_11);                // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
+        _11 = move _10;                  // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
         discriminant(_3) = 0;            // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
-        StorageDead(_10);                // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
-        StorageDead(_9);                 // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-        StorageDead(_8);                 // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-        StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
-        StorageLive(_7);                 // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-        _7 = ((_3 as Continue).0: i32);  // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-        _2 = _7;                         // scope 4 at $DIR/separate_const_switch.rs:29:8: 29:10
-        StorageDead(_7);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
-        ((_0 as Ok).0: i32) = move _2;   // scope 0 at $DIR/separate_const_switch.rs:29:5: 29:11
-        discriminant(_0) = 0;            // scope 0 at $DIR/separate_const_switch.rs:29:5: 29:11
-        StorageDead(_2);                 // scope 0 at $DIR/separate_const_switch.rs:29:10: 29:11
-        StorageDead(_3);                 // scope 0 at $DIR/separate_const_switch.rs:30:1: 30:2
-        return;                          // scope 0 at $DIR/separate_const_switch.rs:30:2: 30:2
+        ((_3 as Continue).0: i32) = move _11; // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
+        StorageDead(_11);                // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
+        StorageDead(_10);                // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+        StorageDead(_9);                 // scope 0 at $DIR/separate_const_switch.rs:32:8: 32:10
+        StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:32:9: 32:10
+        _5 = discriminant(_3);           // scope 0 at $DIR/separate_const_switch.rs:32:8: 32:10
+        switchInt(move _5) -> [0_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/separate_const_switch.rs:32:8: 32:10
     }
 }

--- a/src/test/mir-opt/separate_const_switch.identity.SeparateConstSwitch.diff
+++ b/src/test/mir-opt/separate_const_switch.identity.SeparateConstSwitch.diff
@@ -2,20 +2,20 @@
 + // MIR for `identity` after SeparateConstSwitch
   
   fn identity(_1: Result<i32, i32>) -> Result<i32, i32> {
-      debug x => _1;                       // in scope 0 at $DIR/separate_const_switch.rs:28:13: 28:14
-      let mut _0: std::result::Result<i32, i32>; // return place in scope 0 at $DIR/separate_const_switch.rs:28:37: 28:53
-      let mut _2: i32;                     // in scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-      let mut _3: std::ops::ControlFlow<std::result::Result<std::convert::Infallible, i32>, i32>; // in scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-      let mut _4: std::result::Result<i32, i32>; // in scope 0 at $DIR/separate_const_switch.rs:29:8: 29:9
-      let mut _5: isize;                   // in scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
-      let _6: std::result::Result<std::convert::Infallible, i32>; // in scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
-      let mut _7: !;                       // in scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
-      let mut _8: std::result::Result<std::convert::Infallible, i32>; // in scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
-      let _9: i32;                         // in scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
+      debug x => _1;                       // in scope 0 at $DIR/separate_const_switch.rs:31:13: 31:14
+      let mut _0: std::result::Result<i32, i32>; // return place in scope 0 at $DIR/separate_const_switch.rs:31:37: 31:53
+      let mut _2: i32;                     // in scope 0 at $DIR/separate_const_switch.rs:32:8: 32:10
+      let mut _3: std::ops::ControlFlow<std::result::Result<std::convert::Infallible, i32>, i32>; // in scope 0 at $DIR/separate_const_switch.rs:32:8: 32:10
+      let mut _4: std::result::Result<i32, i32>; // in scope 0 at $DIR/separate_const_switch.rs:32:8: 32:9
+      let mut _5: isize;                   // in scope 0 at $DIR/separate_const_switch.rs:32:9: 32:10
+      let _6: std::result::Result<std::convert::Infallible, i32>; // in scope 0 at $DIR/separate_const_switch.rs:32:9: 32:10
+      let mut _7: !;                       // in scope 0 at $DIR/separate_const_switch.rs:32:9: 32:10
+      let mut _8: std::result::Result<std::convert::Infallible, i32>; // in scope 0 at $DIR/separate_const_switch.rs:32:9: 32:10
+      let _9: i32;                         // in scope 0 at $DIR/separate_const_switch.rs:32:8: 32:10
       scope 1 {
-          debug residual => _6;            // in scope 1 at $DIR/separate_const_switch.rs:29:9: 29:10
+          debug residual => _6;            // in scope 1 at $DIR/separate_const_switch.rs:32:9: 32:10
           scope 2 {
-              scope 8 (inlined #[track_caller] <Result<i32, i32> as FromResidual<Result<Infallible, i32>>>::from_residual) { // at $DIR/separate_const_switch.rs:29:8: 29:10
+              scope 8 (inlined #[track_caller] <Result<i32, i32> as FromResidual<Result<Infallible, i32>>>::from_residual) { // at $DIR/separate_const_switch.rs:32:8: 32:10
                   debug residual => _8;    // in scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
                   let _16: i32;            // in scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
                   let mut _17: i32;        // in scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
@@ -30,11 +30,11 @@
           }
       }
       scope 3 {
-          debug val => _9;                 // in scope 3 at $DIR/separate_const_switch.rs:29:8: 29:10
+          debug val => _9;                 // in scope 3 at $DIR/separate_const_switch.rs:32:8: 32:10
           scope 4 {
           }
       }
-      scope 5 (inlined <Result<i32, i32> as Try>::branch) { // at $DIR/separate_const_switch.rs:29:8: 29:10
+      scope 5 (inlined <Result<i32, i32> as Try>::branch) { // at $DIR/separate_const_switch.rs:32:8: 32:10
           debug self => _4;                // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
           let mut _10: isize;              // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
           let _11: i32;                    // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
@@ -51,41 +51,41 @@
       }
   
       bb0: {
-          StorageLive(_2);                 // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-          StorageLive(_3);                 // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-          StorageLive(_4);                 // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:9
-          _4 = _1;                         // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:9
-          StorageLive(_10);                // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
+          StorageLive(_2);                 // scope 0 at $DIR/separate_const_switch.rs:32:8: 32:10
+          StorageLive(_3);                 // scope 0 at $DIR/separate_const_switch.rs:32:8: 32:10
+          StorageLive(_4);                 // scope 0 at $DIR/separate_const_switch.rs:32:8: 32:9
+          _4 = _1;                         // scope 0 at $DIR/separate_const_switch.rs:32:8: 32:9
+          StorageLive(_10);                // scope 0 at $DIR/separate_const_switch.rs:32:8: 32:10
           _10 = discriminant(_4);          // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
 -         switchInt(move _10) -> [0_isize: bb6, 1_isize: bb4, otherwise: bb5]; // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
 +         switchInt(move _10) -> [0_isize: bb5, 1_isize: bb3, otherwise: bb4]; // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
       }
   
       bb1: {
--         StorageDead(_10);                // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
--         StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
--         _5 = discriminant(_3);           // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
--         switchInt(move _5) -> [0_isize: bb2, otherwise: bb3]; // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
+-         StorageDead(_10);                // scope 0 at $DIR/separate_const_switch.rs:32:8: 32:10
+-         StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:32:9: 32:10
+-         _5 = discriminant(_3);           // scope 0 at $DIR/separate_const_switch.rs:32:8: 32:10
+-         switchInt(move _5) -> [0_isize: bb2, otherwise: bb3]; // scope 0 at $DIR/separate_const_switch.rs:32:8: 32:10
 -     }
 - 
 -     bb2: {
-          StorageLive(_9);                 // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-          _9 = ((_3 as Continue).0: i32);  // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-          _2 = _9;                         // scope 4 at $DIR/separate_const_switch.rs:29:8: 29:10
-          StorageDead(_9);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
-          ((_0 as Ok).0: i32) = move _2;   // scope 0 at $DIR/separate_const_switch.rs:29:5: 29:11
-          discriminant(_0) = 0;            // scope 0 at $DIR/separate_const_switch.rs:29:5: 29:11
-          StorageDead(_2);                 // scope 0 at $DIR/separate_const_switch.rs:29:10: 29:11
-          StorageDead(_3);                 // scope 0 at $DIR/separate_const_switch.rs:30:1: 30:2
-          return;                          // scope 0 at $DIR/separate_const_switch.rs:30:2: 30:2
+          StorageLive(_9);                 // scope 0 at $DIR/separate_const_switch.rs:32:8: 32:10
+          _9 = ((_3 as Continue).0: i32);  // scope 0 at $DIR/separate_const_switch.rs:32:8: 32:10
+          _2 = _9;                         // scope 4 at $DIR/separate_const_switch.rs:32:8: 32:10
+          StorageDead(_9);                 // scope 0 at $DIR/separate_const_switch.rs:32:9: 32:10
+          discriminant(_0) = 0;            // scope 0 at $DIR/separate_const_switch.rs:32:5: 32:11
+          ((_0 as Ok).0: i32) = move _2;   // scope 0 at $DIR/separate_const_switch.rs:32:5: 32:11
+          StorageDead(_2);                 // scope 0 at $DIR/separate_const_switch.rs:32:10: 32:11
+          StorageDead(_3);                 // scope 0 at $DIR/separate_const_switch.rs:33:1: 33:2
+          return;                          // scope 0 at $DIR/separate_const_switch.rs:33:2: 33:2
       }
   
 -     bb3: {
 +     bb2: {
-          StorageLive(_6);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
-          _6 = ((_3 as Break).0: std::result::Result<std::convert::Infallible, i32>); // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
-          StorageLive(_8);                 // scope 2 at $DIR/separate_const_switch.rs:29:9: 29:10
-          _8 = _6;                         // scope 2 at $DIR/separate_const_switch.rs:29:9: 29:10
+          StorageLive(_6);                 // scope 0 at $DIR/separate_const_switch.rs:32:9: 32:10
+          _6 = ((_3 as Break).0: std::result::Result<std::convert::Infallible, i32>); // scope 0 at $DIR/separate_const_switch.rs:32:9: 32:10
+          StorageLive(_8);                 // scope 2 at $DIR/separate_const_switch.rs:32:9: 32:10
+          _8 = _6;                         // scope 2 at $DIR/separate_const_switch.rs:32:9: 32:10
           StorageLive(_16);                // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
           _16 = move ((_8 as Err).0: i32); // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
           StorageLive(_17);                // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
@@ -93,15 +93,15 @@
           _18 = move _16;                  // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
           _17 = move _18;                  // scope 10 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
           StorageDead(_18);                // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
-          ((_0 as Err).0: i32) = move _17; // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
           discriminant(_0) = 1;            // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
+          ((_0 as Err).0: i32) = move _17; // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
           StorageDead(_17);                // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
           StorageDead(_16);                // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
-          StorageDead(_8);                 // scope 2 at $DIR/separate_const_switch.rs:29:9: 29:10
-          StorageDead(_6);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
-          StorageDead(_2);                 // scope 0 at $DIR/separate_const_switch.rs:29:10: 29:11
-          StorageDead(_3);                 // scope 0 at $DIR/separate_const_switch.rs:30:1: 30:2
-          return;                          // scope 0 at $DIR/separate_const_switch.rs:30:2: 30:2
+          StorageDead(_8);                 // scope 2 at $DIR/separate_const_switch.rs:32:9: 32:10
+          StorageDead(_6);                 // scope 0 at $DIR/separate_const_switch.rs:32:9: 32:10
+          StorageDead(_2);                 // scope 0 at $DIR/separate_const_switch.rs:32:10: 32:11
+          StorageDead(_3);                 // scope 0 at $DIR/separate_const_switch.rs:33:1: 33:2
+          return;                          // scope 0 at $DIR/separate_const_switch.rs:33:2: 33:2
       }
   
 -     bb4: {
@@ -111,18 +111,18 @@
           StorageLive(_14);                // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
           StorageLive(_15);                // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
           _15 = move _13;                  // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
-          ((_14 as Err).0: i32) = move _15; // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
           discriminant(_14) = 1;           // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+          ((_14 as Err).0: i32) = move _15; // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
           StorageDead(_15);                // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
-          ((_3 as Break).0: std::result::Result<std::convert::Infallible, i32>) = move _14; // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
           discriminant(_3) = 1;            // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+          ((_3 as Break).0: std::result::Result<std::convert::Infallible, i32>) = move _14; // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
           StorageDead(_14);                // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
           StorageDead(_13);                // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
 -         goto -> bb1;                     // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-+         StorageDead(_10);                // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-+         StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
-+         _5 = discriminant(_3);           // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-+         switchInt(move _5) -> [0_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
++         StorageDead(_10);                // scope 0 at $DIR/separate_const_switch.rs:32:8: 32:10
++         StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:32:9: 32:10
++         _5 = discriminant(_3);           // scope 0 at $DIR/separate_const_switch.rs:32:8: 32:10
++         switchInt(move _5) -> [0_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/separate_const_switch.rs:32:8: 32:10
       }
   
 -     bb5: {
@@ -136,15 +136,15 @@
           _11 = move ((_4 as Ok).0: i32);  // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
           StorageLive(_12);                // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
           _12 = move _11;                  // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
-          ((_3 as Continue).0: i32) = move _12; // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
           discriminant(_3) = 0;            // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
+          ((_3 as Continue).0: i32) = move _12; // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
           StorageDead(_12);                // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
           StorageDead(_11);                // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
 -         goto -> bb1;                     // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-+         StorageDead(_10);                // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-+         StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
-+         _5 = discriminant(_3);           // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-+         switchInt(move _5) -> [0_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
++         StorageDead(_10);                // scope 0 at $DIR/separate_const_switch.rs:32:8: 32:10
++         StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:32:9: 32:10
++         _5 = discriminant(_3);           // scope 0 at $DIR/separate_const_switch.rs:32:8: 32:10
++         switchInt(move _5) -> [0_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/separate_const_switch.rs:32:8: 32:10
       }
   }
   

--- a/src/test/mir-opt/separate_const_switch.rs
+++ b/src/test/mir-opt/separate_const_switch.rs
@@ -3,6 +3,9 @@
 
 use std::ops::ControlFlow;
 
+// Due to some changes in MIR, `ConstProp` no longer propagates the discriminant value, and so the
+// tests show no change. This will hopefully be fixed by future enhancements to `ConstProp`.
+
 // EMIT_MIR separate_const_switch.too_complex.SeparateConstSwitch.diff
 // EMIT_MIR separate_const_switch.too_complex.ConstProp.diff
 // EMIT_MIR separate_const_switch.too_complex.PreCodegen.after.mir

--- a/src/test/mir-opt/separate_const_switch.too_complex.ConstProp.diff
+++ b/src/test/mir-opt/separate_const_switch.too_complex.ConstProp.diff
@@ -2,90 +2,86 @@
 + // MIR for `too_complex` after ConstProp
   
   fn too_complex(_1: Result<i32, usize>) -> Option<i32> {
-      debug x => _1;                       // in scope 0 at $DIR/separate_const_switch.rs:9:16: 9:17
-      let mut _0: std::option::Option<i32>; // return place in scope 0 at $DIR/separate_const_switch.rs:9:42: 9:53
-      let mut _2: std::ops::ControlFlow<usize, i32>; // in scope 0 at $DIR/separate_const_switch.rs:14:11: 19:6
-      let mut _3: isize;                   // in scope 0 at $DIR/separate_const_switch.rs:16:13: 16:18
-      let _4: i32;                         // in scope 0 at $DIR/separate_const_switch.rs:16:16: 16:17
-      let mut _5: i32;                     // in scope 0 at $DIR/separate_const_switch.rs:16:44: 16:45
-      let _6: usize;                       // in scope 0 at $DIR/separate_const_switch.rs:17:17: 17:18
-      let mut _7: usize;                   // in scope 0 at $DIR/separate_const_switch.rs:17:42: 17:43
-      let mut _8: isize;                   // in scope 0 at $DIR/separate_const_switch.rs:20:9: 20:33
-      let _9: i32;                         // in scope 0 at $DIR/separate_const_switch.rs:20:31: 20:32
-      let mut _10: i32;                    // in scope 0 at $DIR/separate_const_switch.rs:20:42: 20:43
-      let _11: usize;                      // in scope 0 at $DIR/separate_const_switch.rs:21:28: 21:29
+      debug x => _1;                       // in scope 0 at $DIR/separate_const_switch.rs:12:16: 12:17
+      let mut _0: std::option::Option<i32>; // return place in scope 0 at $DIR/separate_const_switch.rs:12:42: 12:53
+      let mut _2: std::ops::ControlFlow<usize, i32>; // in scope 0 at $DIR/separate_const_switch.rs:17:11: 22:6
+      let mut _3: isize;                   // in scope 0 at $DIR/separate_const_switch.rs:19:13: 19:18
+      let _4: i32;                         // in scope 0 at $DIR/separate_const_switch.rs:19:16: 19:17
+      let mut _5: i32;                     // in scope 0 at $DIR/separate_const_switch.rs:19:44: 19:45
+      let _6: usize;                       // in scope 0 at $DIR/separate_const_switch.rs:20:17: 20:18
+      let mut _7: usize;                   // in scope 0 at $DIR/separate_const_switch.rs:20:42: 20:43
+      let mut _8: isize;                   // in scope 0 at $DIR/separate_const_switch.rs:23:9: 23:33
+      let _9: i32;                         // in scope 0 at $DIR/separate_const_switch.rs:23:31: 23:32
+      let mut _10: i32;                    // in scope 0 at $DIR/separate_const_switch.rs:23:42: 23:43
+      let _11: usize;                      // in scope 0 at $DIR/separate_const_switch.rs:24:28: 24:29
       scope 1 {
-          debug v => _4;                   // in scope 1 at $DIR/separate_const_switch.rs:16:16: 16:17
+          debug v => _4;                   // in scope 1 at $DIR/separate_const_switch.rs:19:16: 19:17
       }
       scope 2 {
-          debug r => _6;                   // in scope 2 at $DIR/separate_const_switch.rs:17:17: 17:18
+          debug r => _6;                   // in scope 2 at $DIR/separate_const_switch.rs:20:17: 20:18
       }
       scope 3 {
-          debug v => _9;                   // in scope 3 at $DIR/separate_const_switch.rs:20:31: 20:32
+          debug v => _9;                   // in scope 3 at $DIR/separate_const_switch.rs:23:31: 23:32
       }
       scope 4 {
-          debug r => _11;                  // in scope 4 at $DIR/separate_const_switch.rs:21:28: 21:29
+          debug r => _11;                  // in scope 4 at $DIR/separate_const_switch.rs:24:28: 24:29
       }
   
       bb0: {
-          StorageLive(_2);                 // scope 0 at $DIR/separate_const_switch.rs:14:11: 19:6
-          _3 = discriminant(_1);           // scope 0 at $DIR/separate_const_switch.rs:15:15: 15:16
-          switchInt(move _3) -> [0_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/separate_const_switch.rs:15:9: 15:16
+          StorageLive(_2);                 // scope 0 at $DIR/separate_const_switch.rs:17:11: 22:6
+          _3 = discriminant(_1);           // scope 0 at $DIR/separate_const_switch.rs:18:15: 18:16
+          switchInt(move _3) -> [0_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/separate_const_switch.rs:18:9: 18:16
       }
   
       bb1: {
-          StorageLive(_6);                 // scope 0 at $DIR/separate_const_switch.rs:17:17: 17:18
-          _6 = ((_1 as Err).0: usize);     // scope 0 at $DIR/separate_const_switch.rs:17:17: 17:18
-          StorageLive(_7);                 // scope 2 at $DIR/separate_const_switch.rs:17:42: 17:43
-          _7 = _6;                         // scope 2 at $DIR/separate_const_switch.rs:17:42: 17:43
-          ((_2 as Break).0: usize) = move _7; // scope 2 at $DIR/separate_const_switch.rs:17:23: 17:44
-          discriminant(_2) = 1;            // scope 2 at $DIR/separate_const_switch.rs:17:23: 17:44
-          StorageDead(_7);                 // scope 2 at $DIR/separate_const_switch.rs:17:43: 17:44
-          StorageDead(_6);                 // scope 0 at $DIR/separate_const_switch.rs:17:43: 17:44
--         _8 = discriminant(_2);           // scope 0 at $DIR/separate_const_switch.rs:14:11: 19:6
--         switchInt(move _8) -> [0_isize: bb4, otherwise: bb3]; // scope 0 at $DIR/separate_const_switch.rs:14:5: 19:6
-+         _8 = const 1_isize;              // scope 0 at $DIR/separate_const_switch.rs:14:11: 19:6
-+         switchInt(const 1_isize) -> [0_isize: bb4, otherwise: bb3]; // scope 0 at $DIR/separate_const_switch.rs:14:5: 19:6
+          StorageLive(_6);                 // scope 0 at $DIR/separate_const_switch.rs:20:17: 20:18
+          _6 = ((_1 as Err).0: usize);     // scope 0 at $DIR/separate_const_switch.rs:20:17: 20:18
+          StorageLive(_7);                 // scope 2 at $DIR/separate_const_switch.rs:20:42: 20:43
+          _7 = _6;                         // scope 2 at $DIR/separate_const_switch.rs:20:42: 20:43
+          discriminant(_2) = 1;            // scope 2 at $DIR/separate_const_switch.rs:20:23: 20:44
+          ((_2 as Break).0: usize) = move _7; // scope 2 at $DIR/separate_const_switch.rs:20:23: 20:44
+          StorageDead(_7);                 // scope 2 at $DIR/separate_const_switch.rs:20:43: 20:44
+          StorageDead(_6);                 // scope 0 at $DIR/separate_const_switch.rs:20:43: 20:44
+          _8 = discriminant(_2);           // scope 0 at $DIR/separate_const_switch.rs:17:11: 22:6
+          switchInt(move _8) -> [0_isize: bb4, otherwise: bb3]; // scope 0 at $DIR/separate_const_switch.rs:17:5: 22:6
       }
   
       bb2: {
-          StorageLive(_4);                 // scope 0 at $DIR/separate_const_switch.rs:16:16: 16:17
-          _4 = ((_1 as Ok).0: i32);        // scope 0 at $DIR/separate_const_switch.rs:16:16: 16:17
-          StorageLive(_5);                 // scope 1 at $DIR/separate_const_switch.rs:16:44: 16:45
-          _5 = _4;                         // scope 1 at $DIR/separate_const_switch.rs:16:44: 16:45
-          ((_2 as Continue).0: i32) = move _5; // scope 1 at $DIR/separate_const_switch.rs:16:22: 16:46
-          discriminant(_2) = 0;            // scope 1 at $DIR/separate_const_switch.rs:16:22: 16:46
-          StorageDead(_5);                 // scope 1 at $DIR/separate_const_switch.rs:16:45: 16:46
-          StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:16:45: 16:46
--         _8 = discriminant(_2);           // scope 0 at $DIR/separate_const_switch.rs:14:11: 19:6
--         switchInt(move _8) -> [0_isize: bb4, otherwise: bb3]; // scope 0 at $DIR/separate_const_switch.rs:14:5: 19:6
-+         _8 = const 0_isize;              // scope 0 at $DIR/separate_const_switch.rs:14:11: 19:6
-+         switchInt(const 0_isize) -> [0_isize: bb4, otherwise: bb3]; // scope 0 at $DIR/separate_const_switch.rs:14:5: 19:6
+          StorageLive(_4);                 // scope 0 at $DIR/separate_const_switch.rs:19:16: 19:17
+          _4 = ((_1 as Ok).0: i32);        // scope 0 at $DIR/separate_const_switch.rs:19:16: 19:17
+          StorageLive(_5);                 // scope 1 at $DIR/separate_const_switch.rs:19:44: 19:45
+          _5 = _4;                         // scope 1 at $DIR/separate_const_switch.rs:19:44: 19:45
+          discriminant(_2) = 0;            // scope 1 at $DIR/separate_const_switch.rs:19:22: 19:46
+          ((_2 as Continue).0: i32) = move _5; // scope 1 at $DIR/separate_const_switch.rs:19:22: 19:46
+          StorageDead(_5);                 // scope 1 at $DIR/separate_const_switch.rs:19:45: 19:46
+          StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:19:45: 19:46
+          _8 = discriminant(_2);           // scope 0 at $DIR/separate_const_switch.rs:17:11: 22:6
+          switchInt(move _8) -> [0_isize: bb4, otherwise: bb3]; // scope 0 at $DIR/separate_const_switch.rs:17:5: 22:6
       }
   
       bb3: {
-          StorageLive(_11);                // scope 0 at $DIR/separate_const_switch.rs:21:28: 21:29
-          _11 = ((_2 as Break).0: usize);  // scope 0 at $DIR/separate_const_switch.rs:21:28: 21:29
-          discriminant(_0) = 0;            // scope 4 at $DIR/separate_const_switch.rs:21:34: 21:38
-          StorageDead(_11);                // scope 0 at $DIR/separate_const_switch.rs:21:37: 21:38
-          goto -> bb5;                     // scope 0 at $DIR/separate_const_switch.rs:21:37: 21:38
+          StorageLive(_11);                // scope 0 at $DIR/separate_const_switch.rs:24:28: 24:29
+          _11 = ((_2 as Break).0: usize);  // scope 0 at $DIR/separate_const_switch.rs:24:28: 24:29
+          discriminant(_0) = 0;            // scope 4 at $DIR/separate_const_switch.rs:24:34: 24:38
+          StorageDead(_11);                // scope 0 at $DIR/separate_const_switch.rs:24:37: 24:38
+          goto -> bb5;                     // scope 0 at $DIR/separate_const_switch.rs:24:37: 24:38
       }
   
       bb4: {
-          StorageLive(_9);                 // scope 0 at $DIR/separate_const_switch.rs:20:31: 20:32
-          _9 = ((_2 as Continue).0: i32);  // scope 0 at $DIR/separate_const_switch.rs:20:31: 20:32
-          StorageLive(_10);                // scope 3 at $DIR/separate_const_switch.rs:20:42: 20:43
-          _10 = _9;                        // scope 3 at $DIR/separate_const_switch.rs:20:42: 20:43
-          ((_0 as Some).0: i32) = move _10; // scope 3 at $DIR/separate_const_switch.rs:20:37: 20:44
-          discriminant(_0) = 1;            // scope 3 at $DIR/separate_const_switch.rs:20:37: 20:44
-          StorageDead(_10);                // scope 3 at $DIR/separate_const_switch.rs:20:43: 20:44
-          StorageDead(_9);                 // scope 0 at $DIR/separate_const_switch.rs:20:43: 20:44
-          goto -> bb5;                     // scope 0 at $DIR/separate_const_switch.rs:20:43: 20:44
+          StorageLive(_9);                 // scope 0 at $DIR/separate_const_switch.rs:23:31: 23:32
+          _9 = ((_2 as Continue).0: i32);  // scope 0 at $DIR/separate_const_switch.rs:23:31: 23:32
+          StorageLive(_10);                // scope 3 at $DIR/separate_const_switch.rs:23:42: 23:43
+          _10 = _9;                        // scope 3 at $DIR/separate_const_switch.rs:23:42: 23:43
+          discriminant(_0) = 1;            // scope 3 at $DIR/separate_const_switch.rs:23:37: 23:44
+          ((_0 as Some).0: i32) = move _10; // scope 3 at $DIR/separate_const_switch.rs:23:37: 23:44
+          StorageDead(_10);                // scope 3 at $DIR/separate_const_switch.rs:23:43: 23:44
+          StorageDead(_9);                 // scope 0 at $DIR/separate_const_switch.rs:23:43: 23:44
+          goto -> bb5;                     // scope 0 at $DIR/separate_const_switch.rs:23:43: 23:44
       }
   
       bb5: {
-          StorageDead(_2);                 // scope 0 at $DIR/separate_const_switch.rs:23:1: 23:2
-          return;                          // scope 0 at $DIR/separate_const_switch.rs:23:2: 23:2
+          StorageDead(_2);                 // scope 0 at $DIR/separate_const_switch.rs:26:1: 26:2
+          return;                          // scope 0 at $DIR/separate_const_switch.rs:26:2: 26:2
       }
   }
   

--- a/src/test/mir-opt/separate_const_switch.too_complex.PreCodegen.after.mir
+++ b/src/test/mir-opt/separate_const_switch.too_complex.PreCodegen.after.mir
@@ -1,74 +1,85 @@
 // MIR for `too_complex` after PreCodegen
 
 fn too_complex(_1: Result<i32, usize>) -> Option<i32> {
-    debug x => _1;                       // in scope 0 at $DIR/separate_const_switch.rs:9:16: 9:17
-    let mut _0: std::option::Option<i32>; // return place in scope 0 at $DIR/separate_const_switch.rs:9:42: 9:53
-    let mut _2: std::ops::ControlFlow<usize, i32>; // in scope 0 at $DIR/separate_const_switch.rs:14:11: 19:6
-    let mut _3: isize;                   // in scope 0 at $DIR/separate_const_switch.rs:16:13: 16:18
-    let _4: i32;                         // in scope 0 at $DIR/separate_const_switch.rs:16:16: 16:17
-    let mut _5: i32;                     // in scope 0 at $DIR/separate_const_switch.rs:16:44: 16:45
-    let _6: usize;                       // in scope 0 at $DIR/separate_const_switch.rs:17:17: 17:18
-    let mut _7: usize;                   // in scope 0 at $DIR/separate_const_switch.rs:17:42: 17:43
-    let _8: i32;                         // in scope 0 at $DIR/separate_const_switch.rs:20:31: 20:32
-    let mut _9: i32;                     // in scope 0 at $DIR/separate_const_switch.rs:20:42: 20:43
-    let _10: usize;                      // in scope 0 at $DIR/separate_const_switch.rs:21:28: 21:29
+    debug x => _1;                       // in scope 0 at $DIR/separate_const_switch.rs:12:16: 12:17
+    let mut _0: std::option::Option<i32>; // return place in scope 0 at $DIR/separate_const_switch.rs:12:42: 12:53
+    let mut _2: std::ops::ControlFlow<usize, i32>; // in scope 0 at $DIR/separate_const_switch.rs:17:11: 22:6
+    let mut _3: isize;                   // in scope 0 at $DIR/separate_const_switch.rs:19:13: 19:18
+    let _4: i32;                         // in scope 0 at $DIR/separate_const_switch.rs:19:16: 19:17
+    let mut _5: i32;                     // in scope 0 at $DIR/separate_const_switch.rs:19:44: 19:45
+    let _6: usize;                       // in scope 0 at $DIR/separate_const_switch.rs:20:17: 20:18
+    let mut _7: usize;                   // in scope 0 at $DIR/separate_const_switch.rs:20:42: 20:43
+    let mut _8: isize;                   // in scope 0 at $DIR/separate_const_switch.rs:23:9: 23:33
+    let _9: i32;                         // in scope 0 at $DIR/separate_const_switch.rs:23:31: 23:32
+    let mut _10: i32;                    // in scope 0 at $DIR/separate_const_switch.rs:23:42: 23:43
+    let _11: usize;                      // in scope 0 at $DIR/separate_const_switch.rs:24:28: 24:29
     scope 1 {
-        debug v => _4;                   // in scope 1 at $DIR/separate_const_switch.rs:16:16: 16:17
+        debug v => _4;                   // in scope 1 at $DIR/separate_const_switch.rs:19:16: 19:17
     }
     scope 2 {
-        debug r => _6;                   // in scope 2 at $DIR/separate_const_switch.rs:17:17: 17:18
+        debug r => _6;                   // in scope 2 at $DIR/separate_const_switch.rs:20:17: 20:18
     }
     scope 3 {
-        debug v => _8;                   // in scope 3 at $DIR/separate_const_switch.rs:20:31: 20:32
+        debug v => _9;                   // in scope 3 at $DIR/separate_const_switch.rs:23:31: 23:32
     }
     scope 4 {
-        debug r => _10;                  // in scope 4 at $DIR/separate_const_switch.rs:21:28: 21:29
+        debug r => _11;                  // in scope 4 at $DIR/separate_const_switch.rs:24:28: 24:29
     }
 
     bb0: {
-        StorageLive(_2);                 // scope 0 at $DIR/separate_const_switch.rs:14:11: 19:6
-        _3 = discriminant(_1);           // scope 0 at $DIR/separate_const_switch.rs:15:15: 15:16
-        switchInt(move _3) -> [0_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/separate_const_switch.rs:15:9: 15:16
+        StorageLive(_2);                 // scope 0 at $DIR/separate_const_switch.rs:17:11: 22:6
+        _3 = discriminant(_1);           // scope 0 at $DIR/separate_const_switch.rs:18:15: 18:16
+        switchInt(move _3) -> [0_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/separate_const_switch.rs:18:9: 18:16
     }
 
     bb1: {
-        StorageLive(_6);                 // scope 0 at $DIR/separate_const_switch.rs:17:17: 17:18
-        _6 = ((_1 as Err).0: usize);     // scope 0 at $DIR/separate_const_switch.rs:17:17: 17:18
-        StorageLive(_7);                 // scope 2 at $DIR/separate_const_switch.rs:17:42: 17:43
-        _7 = _6;                         // scope 2 at $DIR/separate_const_switch.rs:17:42: 17:43
-        ((_2 as Break).0: usize) = move _7; // scope 2 at $DIR/separate_const_switch.rs:17:23: 17:44
-        discriminant(_2) = 1;            // scope 2 at $DIR/separate_const_switch.rs:17:23: 17:44
-        StorageDead(_7);                 // scope 2 at $DIR/separate_const_switch.rs:17:43: 17:44
-        StorageDead(_6);                 // scope 0 at $DIR/separate_const_switch.rs:17:43: 17:44
-        StorageLive(_10);                // scope 0 at $DIR/separate_const_switch.rs:21:28: 21:29
-        _10 = ((_2 as Break).0: usize);  // scope 0 at $DIR/separate_const_switch.rs:21:28: 21:29
-        discriminant(_0) = 0;            // scope 4 at $DIR/separate_const_switch.rs:21:34: 21:38
-        StorageDead(_10);                // scope 0 at $DIR/separate_const_switch.rs:21:37: 21:38
-        goto -> bb3;                     // scope 0 at $DIR/separate_const_switch.rs:21:37: 21:38
+        StorageLive(_6);                 // scope 0 at $DIR/separate_const_switch.rs:20:17: 20:18
+        _6 = ((_1 as Err).0: usize);     // scope 0 at $DIR/separate_const_switch.rs:20:17: 20:18
+        StorageLive(_7);                 // scope 2 at $DIR/separate_const_switch.rs:20:42: 20:43
+        _7 = _6;                         // scope 2 at $DIR/separate_const_switch.rs:20:42: 20:43
+        discriminant(_2) = 1;            // scope 2 at $DIR/separate_const_switch.rs:20:23: 20:44
+        ((_2 as Break).0: usize) = move _7; // scope 2 at $DIR/separate_const_switch.rs:20:23: 20:44
+        StorageDead(_7);                 // scope 2 at $DIR/separate_const_switch.rs:20:43: 20:44
+        StorageDead(_6);                 // scope 0 at $DIR/separate_const_switch.rs:20:43: 20:44
+        _8 = discriminant(_2);           // scope 0 at $DIR/separate_const_switch.rs:17:11: 22:6
+        switchInt(move _8) -> [0_isize: bb4, otherwise: bb3]; // scope 0 at $DIR/separate_const_switch.rs:17:5: 22:6
     }
 
     bb2: {
-        StorageLive(_4);                 // scope 0 at $DIR/separate_const_switch.rs:16:16: 16:17
-        _4 = ((_1 as Ok).0: i32);        // scope 0 at $DIR/separate_const_switch.rs:16:16: 16:17
-        StorageLive(_5);                 // scope 1 at $DIR/separate_const_switch.rs:16:44: 16:45
-        _5 = _4;                         // scope 1 at $DIR/separate_const_switch.rs:16:44: 16:45
-        ((_2 as Continue).0: i32) = move _5; // scope 1 at $DIR/separate_const_switch.rs:16:22: 16:46
-        discriminant(_2) = 0;            // scope 1 at $DIR/separate_const_switch.rs:16:22: 16:46
-        StorageDead(_5);                 // scope 1 at $DIR/separate_const_switch.rs:16:45: 16:46
-        StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:16:45: 16:46
-        StorageLive(_8);                 // scope 0 at $DIR/separate_const_switch.rs:20:31: 20:32
-        _8 = ((_2 as Continue).0: i32);  // scope 0 at $DIR/separate_const_switch.rs:20:31: 20:32
-        StorageLive(_9);                 // scope 3 at $DIR/separate_const_switch.rs:20:42: 20:43
-        _9 = _8;                         // scope 3 at $DIR/separate_const_switch.rs:20:42: 20:43
-        ((_0 as Some).0: i32) = move _9; // scope 3 at $DIR/separate_const_switch.rs:20:37: 20:44
-        discriminant(_0) = 1;            // scope 3 at $DIR/separate_const_switch.rs:20:37: 20:44
-        StorageDead(_9);                 // scope 3 at $DIR/separate_const_switch.rs:20:43: 20:44
-        StorageDead(_8);                 // scope 0 at $DIR/separate_const_switch.rs:20:43: 20:44
-        goto -> bb3;                     // scope 0 at $DIR/separate_const_switch.rs:20:43: 20:44
+        StorageLive(_4);                 // scope 0 at $DIR/separate_const_switch.rs:19:16: 19:17
+        _4 = ((_1 as Ok).0: i32);        // scope 0 at $DIR/separate_const_switch.rs:19:16: 19:17
+        StorageLive(_5);                 // scope 1 at $DIR/separate_const_switch.rs:19:44: 19:45
+        _5 = _4;                         // scope 1 at $DIR/separate_const_switch.rs:19:44: 19:45
+        discriminant(_2) = 0;            // scope 1 at $DIR/separate_const_switch.rs:19:22: 19:46
+        ((_2 as Continue).0: i32) = move _5; // scope 1 at $DIR/separate_const_switch.rs:19:22: 19:46
+        StorageDead(_5);                 // scope 1 at $DIR/separate_const_switch.rs:19:45: 19:46
+        StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:19:45: 19:46
+        _8 = discriminant(_2);           // scope 0 at $DIR/separate_const_switch.rs:17:11: 22:6
+        switchInt(move _8) -> [0_isize: bb4, otherwise: bb3]; // scope 0 at $DIR/separate_const_switch.rs:17:5: 22:6
     }
 
     bb3: {
-        StorageDead(_2);                 // scope 0 at $DIR/separate_const_switch.rs:23:1: 23:2
-        return;                          // scope 0 at $DIR/separate_const_switch.rs:23:2: 23:2
+        StorageLive(_11);                // scope 0 at $DIR/separate_const_switch.rs:24:28: 24:29
+        _11 = ((_2 as Break).0: usize);  // scope 0 at $DIR/separate_const_switch.rs:24:28: 24:29
+        discriminant(_0) = 0;            // scope 4 at $DIR/separate_const_switch.rs:24:34: 24:38
+        StorageDead(_11);                // scope 0 at $DIR/separate_const_switch.rs:24:37: 24:38
+        goto -> bb5;                     // scope 0 at $DIR/separate_const_switch.rs:24:37: 24:38
+    }
+
+    bb4: {
+        StorageLive(_9);                 // scope 0 at $DIR/separate_const_switch.rs:23:31: 23:32
+        _9 = ((_2 as Continue).0: i32);  // scope 0 at $DIR/separate_const_switch.rs:23:31: 23:32
+        StorageLive(_10);                // scope 3 at $DIR/separate_const_switch.rs:23:42: 23:43
+        _10 = _9;                        // scope 3 at $DIR/separate_const_switch.rs:23:42: 23:43
+        discriminant(_0) = 1;            // scope 3 at $DIR/separate_const_switch.rs:23:37: 23:44
+        ((_0 as Some).0: i32) = move _10; // scope 3 at $DIR/separate_const_switch.rs:23:37: 23:44
+        StorageDead(_10);                // scope 3 at $DIR/separate_const_switch.rs:23:43: 23:44
+        StorageDead(_9);                 // scope 0 at $DIR/separate_const_switch.rs:23:43: 23:44
+        goto -> bb5;                     // scope 0 at $DIR/separate_const_switch.rs:23:43: 23:44
+    }
+
+    bb5: {
+        StorageDead(_2);                 // scope 0 at $DIR/separate_const_switch.rs:26:1: 26:2
+        return;                          // scope 0 at $DIR/separate_const_switch.rs:26:2: 26:2
     }
 }

--- a/src/test/mir-opt/separate_const_switch.too_complex.SeparateConstSwitch.diff
+++ b/src/test/mir-opt/separate_const_switch.too_complex.SeparateConstSwitch.diff
@@ -2,97 +2,97 @@
 + // MIR for `too_complex` after SeparateConstSwitch
   
   fn too_complex(_1: Result<i32, usize>) -> Option<i32> {
-      debug x => _1;                       // in scope 0 at $DIR/separate_const_switch.rs:9:16: 9:17
-      let mut _0: std::option::Option<i32>; // return place in scope 0 at $DIR/separate_const_switch.rs:9:42: 9:53
-      let mut _2: std::ops::ControlFlow<usize, i32>; // in scope 0 at $DIR/separate_const_switch.rs:14:11: 19:6
-      let mut _3: isize;                   // in scope 0 at $DIR/separate_const_switch.rs:16:13: 16:18
-      let _4: i32;                         // in scope 0 at $DIR/separate_const_switch.rs:16:16: 16:17
-      let mut _5: i32;                     // in scope 0 at $DIR/separate_const_switch.rs:16:44: 16:45
-      let _6: usize;                       // in scope 0 at $DIR/separate_const_switch.rs:17:17: 17:18
-      let mut _7: usize;                   // in scope 0 at $DIR/separate_const_switch.rs:17:42: 17:43
-      let mut _8: isize;                   // in scope 0 at $DIR/separate_const_switch.rs:20:9: 20:33
-      let _9: i32;                         // in scope 0 at $DIR/separate_const_switch.rs:20:31: 20:32
-      let mut _10: i32;                    // in scope 0 at $DIR/separate_const_switch.rs:20:42: 20:43
-      let _11: usize;                      // in scope 0 at $DIR/separate_const_switch.rs:21:28: 21:29
+      debug x => _1;                       // in scope 0 at $DIR/separate_const_switch.rs:12:16: 12:17
+      let mut _0: std::option::Option<i32>; // return place in scope 0 at $DIR/separate_const_switch.rs:12:42: 12:53
+      let mut _2: std::ops::ControlFlow<usize, i32>; // in scope 0 at $DIR/separate_const_switch.rs:17:11: 22:6
+      let mut _3: isize;                   // in scope 0 at $DIR/separate_const_switch.rs:19:13: 19:18
+      let _4: i32;                         // in scope 0 at $DIR/separate_const_switch.rs:19:16: 19:17
+      let mut _5: i32;                     // in scope 0 at $DIR/separate_const_switch.rs:19:44: 19:45
+      let _6: usize;                       // in scope 0 at $DIR/separate_const_switch.rs:20:17: 20:18
+      let mut _7: usize;                   // in scope 0 at $DIR/separate_const_switch.rs:20:42: 20:43
+      let mut _8: isize;                   // in scope 0 at $DIR/separate_const_switch.rs:23:9: 23:33
+      let _9: i32;                         // in scope 0 at $DIR/separate_const_switch.rs:23:31: 23:32
+      let mut _10: i32;                    // in scope 0 at $DIR/separate_const_switch.rs:23:42: 23:43
+      let _11: usize;                      // in scope 0 at $DIR/separate_const_switch.rs:24:28: 24:29
       scope 1 {
-          debug v => _4;                   // in scope 1 at $DIR/separate_const_switch.rs:16:16: 16:17
+          debug v => _4;                   // in scope 1 at $DIR/separate_const_switch.rs:19:16: 19:17
       }
       scope 2 {
-          debug r => _6;                   // in scope 2 at $DIR/separate_const_switch.rs:17:17: 17:18
+          debug r => _6;                   // in scope 2 at $DIR/separate_const_switch.rs:20:17: 20:18
       }
       scope 3 {
-          debug v => _9;                   // in scope 3 at $DIR/separate_const_switch.rs:20:31: 20:32
+          debug v => _9;                   // in scope 3 at $DIR/separate_const_switch.rs:23:31: 23:32
       }
       scope 4 {
-          debug r => _11;                  // in scope 4 at $DIR/separate_const_switch.rs:21:28: 21:29
+          debug r => _11;                  // in scope 4 at $DIR/separate_const_switch.rs:24:28: 24:29
       }
   
       bb0: {
-          StorageLive(_2);                 // scope 0 at $DIR/separate_const_switch.rs:14:11: 19:6
-          _3 = discriminant(_1);           // scope 0 at $DIR/separate_const_switch.rs:15:15: 15:16
-          switchInt(move _3) -> [0_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/separate_const_switch.rs:15:9: 15:16
+          StorageLive(_2);                 // scope 0 at $DIR/separate_const_switch.rs:17:11: 22:6
+          _3 = discriminant(_1);           // scope 0 at $DIR/separate_const_switch.rs:18:15: 18:16
+          switchInt(move _3) -> [0_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/separate_const_switch.rs:18:9: 18:16
       }
   
       bb1: {
-          StorageLive(_6);                 // scope 0 at $DIR/separate_const_switch.rs:17:17: 17:18
-          _6 = ((_1 as Err).0: usize);     // scope 0 at $DIR/separate_const_switch.rs:17:17: 17:18
-          StorageLive(_7);                 // scope 2 at $DIR/separate_const_switch.rs:17:42: 17:43
-          _7 = _6;                         // scope 2 at $DIR/separate_const_switch.rs:17:42: 17:43
-          ((_2 as Break).0: usize) = move _7; // scope 2 at $DIR/separate_const_switch.rs:17:23: 17:44
-          discriminant(_2) = 1;            // scope 2 at $DIR/separate_const_switch.rs:17:23: 17:44
-          StorageDead(_7);                 // scope 2 at $DIR/separate_const_switch.rs:17:43: 17:44
-          StorageDead(_6);                 // scope 0 at $DIR/separate_const_switch.rs:17:43: 17:44
--         goto -> bb3;                     // scope 0 at $DIR/separate_const_switch.rs:17:43: 17:44
-+         _8 = discriminant(_2);           // scope 0 at $DIR/separate_const_switch.rs:14:11: 19:6
-+         switchInt(move _8) -> [0_isize: bb4, otherwise: bb3]; // scope 0 at $DIR/separate_const_switch.rs:14:5: 19:6
+          StorageLive(_6);                 // scope 0 at $DIR/separate_const_switch.rs:20:17: 20:18
+          _6 = ((_1 as Err).0: usize);     // scope 0 at $DIR/separate_const_switch.rs:20:17: 20:18
+          StorageLive(_7);                 // scope 2 at $DIR/separate_const_switch.rs:20:42: 20:43
+          _7 = _6;                         // scope 2 at $DIR/separate_const_switch.rs:20:42: 20:43
+          discriminant(_2) = 1;            // scope 2 at $DIR/separate_const_switch.rs:20:23: 20:44
+          ((_2 as Break).0: usize) = move _7; // scope 2 at $DIR/separate_const_switch.rs:20:23: 20:44
+          StorageDead(_7);                 // scope 2 at $DIR/separate_const_switch.rs:20:43: 20:44
+          StorageDead(_6);                 // scope 0 at $DIR/separate_const_switch.rs:20:43: 20:44
+-         goto -> bb3;                     // scope 0 at $DIR/separate_const_switch.rs:20:43: 20:44
++         _8 = discriminant(_2);           // scope 0 at $DIR/separate_const_switch.rs:17:11: 22:6
++         switchInt(move _8) -> [0_isize: bb4, otherwise: bb3]; // scope 0 at $DIR/separate_const_switch.rs:17:5: 22:6
       }
   
       bb2: {
-          StorageLive(_4);                 // scope 0 at $DIR/separate_const_switch.rs:16:16: 16:17
-          _4 = ((_1 as Ok).0: i32);        // scope 0 at $DIR/separate_const_switch.rs:16:16: 16:17
-          StorageLive(_5);                 // scope 1 at $DIR/separate_const_switch.rs:16:44: 16:45
-          _5 = _4;                         // scope 1 at $DIR/separate_const_switch.rs:16:44: 16:45
-          ((_2 as Continue).0: i32) = move _5; // scope 1 at $DIR/separate_const_switch.rs:16:22: 16:46
-          discriminant(_2) = 0;            // scope 1 at $DIR/separate_const_switch.rs:16:22: 16:46
-          StorageDead(_5);                 // scope 1 at $DIR/separate_const_switch.rs:16:45: 16:46
-          StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:16:45: 16:46
--         goto -> bb3;                     // scope 0 at $DIR/separate_const_switch.rs:16:45: 16:46
+          StorageLive(_4);                 // scope 0 at $DIR/separate_const_switch.rs:19:16: 19:17
+          _4 = ((_1 as Ok).0: i32);        // scope 0 at $DIR/separate_const_switch.rs:19:16: 19:17
+          StorageLive(_5);                 // scope 1 at $DIR/separate_const_switch.rs:19:44: 19:45
+          _5 = _4;                         // scope 1 at $DIR/separate_const_switch.rs:19:44: 19:45
+          discriminant(_2) = 0;            // scope 1 at $DIR/separate_const_switch.rs:19:22: 19:46
+          ((_2 as Continue).0: i32) = move _5; // scope 1 at $DIR/separate_const_switch.rs:19:22: 19:46
+          StorageDead(_5);                 // scope 1 at $DIR/separate_const_switch.rs:19:45: 19:46
+          StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:19:45: 19:46
+-         goto -> bb3;                     // scope 0 at $DIR/separate_const_switch.rs:19:45: 19:46
 -     }
 - 
 -     bb3: {
-          _8 = discriminant(_2);           // scope 0 at $DIR/separate_const_switch.rs:14:11: 19:6
--         switchInt(move _8) -> [0_isize: bb5, otherwise: bb4]; // scope 0 at $DIR/separate_const_switch.rs:14:5: 19:6
-+         switchInt(move _8) -> [0_isize: bb4, otherwise: bb3]; // scope 0 at $DIR/separate_const_switch.rs:14:5: 19:6
+          _8 = discriminant(_2);           // scope 0 at $DIR/separate_const_switch.rs:17:11: 22:6
+-         switchInt(move _8) -> [0_isize: bb5, otherwise: bb4]; // scope 0 at $DIR/separate_const_switch.rs:17:5: 22:6
++         switchInt(move _8) -> [0_isize: bb4, otherwise: bb3]; // scope 0 at $DIR/separate_const_switch.rs:17:5: 22:6
       }
   
 -     bb4: {
 +     bb3: {
-          StorageLive(_11);                // scope 0 at $DIR/separate_const_switch.rs:21:28: 21:29
-          _11 = ((_2 as Break).0: usize);  // scope 0 at $DIR/separate_const_switch.rs:21:28: 21:29
-          discriminant(_0) = 0;            // scope 4 at $DIR/separate_const_switch.rs:21:34: 21:38
-          StorageDead(_11);                // scope 0 at $DIR/separate_const_switch.rs:21:37: 21:38
--         goto -> bb6;                     // scope 0 at $DIR/separate_const_switch.rs:21:37: 21:38
-+         goto -> bb5;                     // scope 0 at $DIR/separate_const_switch.rs:21:37: 21:38
+          StorageLive(_11);                // scope 0 at $DIR/separate_const_switch.rs:24:28: 24:29
+          _11 = ((_2 as Break).0: usize);  // scope 0 at $DIR/separate_const_switch.rs:24:28: 24:29
+          discriminant(_0) = 0;            // scope 4 at $DIR/separate_const_switch.rs:24:34: 24:38
+          StorageDead(_11);                // scope 0 at $DIR/separate_const_switch.rs:24:37: 24:38
+-         goto -> bb6;                     // scope 0 at $DIR/separate_const_switch.rs:24:37: 24:38
++         goto -> bb5;                     // scope 0 at $DIR/separate_const_switch.rs:24:37: 24:38
       }
   
 -     bb5: {
 +     bb4: {
-          StorageLive(_9);                 // scope 0 at $DIR/separate_const_switch.rs:20:31: 20:32
-          _9 = ((_2 as Continue).0: i32);  // scope 0 at $DIR/separate_const_switch.rs:20:31: 20:32
-          StorageLive(_10);                // scope 3 at $DIR/separate_const_switch.rs:20:42: 20:43
-          _10 = _9;                        // scope 3 at $DIR/separate_const_switch.rs:20:42: 20:43
-          ((_0 as Some).0: i32) = move _10; // scope 3 at $DIR/separate_const_switch.rs:20:37: 20:44
-          discriminant(_0) = 1;            // scope 3 at $DIR/separate_const_switch.rs:20:37: 20:44
-          StorageDead(_10);                // scope 3 at $DIR/separate_const_switch.rs:20:43: 20:44
-          StorageDead(_9);                 // scope 0 at $DIR/separate_const_switch.rs:20:43: 20:44
--         goto -> bb6;                     // scope 0 at $DIR/separate_const_switch.rs:20:43: 20:44
-+         goto -> bb5;                     // scope 0 at $DIR/separate_const_switch.rs:20:43: 20:44
+          StorageLive(_9);                 // scope 0 at $DIR/separate_const_switch.rs:23:31: 23:32
+          _9 = ((_2 as Continue).0: i32);  // scope 0 at $DIR/separate_const_switch.rs:23:31: 23:32
+          StorageLive(_10);                // scope 3 at $DIR/separate_const_switch.rs:23:42: 23:43
+          _10 = _9;                        // scope 3 at $DIR/separate_const_switch.rs:23:42: 23:43
+          discriminant(_0) = 1;            // scope 3 at $DIR/separate_const_switch.rs:23:37: 23:44
+          ((_0 as Some).0: i32) = move _10; // scope 3 at $DIR/separate_const_switch.rs:23:37: 23:44
+          StorageDead(_10);                // scope 3 at $DIR/separate_const_switch.rs:23:43: 23:44
+          StorageDead(_9);                 // scope 0 at $DIR/separate_const_switch.rs:23:43: 23:44
+-         goto -> bb6;                     // scope 0 at $DIR/separate_const_switch.rs:23:43: 23:44
++         goto -> bb5;                     // scope 0 at $DIR/separate_const_switch.rs:23:43: 23:44
       }
   
 -     bb6: {
 +     bb5: {
-          StorageDead(_2);                 // scope 0 at $DIR/separate_const_switch.rs:23:1: 23:2
-          return;                          // scope 0 at $DIR/separate_const_switch.rs:23:2: 23:2
+          StorageDead(_2);                 // scope 0 at $DIR/separate_const_switch.rs:26:1: 26:2
+          return;                          // scope 0 at $DIR/separate_const_switch.rs:26:2: 26:2
       }
   }
   

--- a/src/test/mir-opt/simplify-arm-identity.rs
+++ b/src/test/mir-opt/simplify-arm-identity.rs
@@ -13,7 +13,9 @@ enum Dst {
     Foo(u8),
 }
 
-// EMIT_MIR simplify_arm_identity.main.SimplifyArmIdentity.diff
+// This test was broken by changes to enum deaggregation, and will be fixed when
+// `SimplifyArmIdentity` is fixed more generally
+// FIXME(JakobDegen) EMIT_MIR simplify_arm_identity.main.SimplifyArmIdentity.diff
 fn main() {
     let e: Src = Src::Foo(0);
     let _: Dst = match e {

--- a/src/test/mir-opt/simplify-arm.rs
+++ b/src/test/mir-opt/simplify-arm.rs
@@ -1,10 +1,12 @@
 // compile-flags: -Z mir-opt-level=3 -Zunsound-mir-opts
-// EMIT_MIR simplify_arm.id.SimplifyArmIdentity.diff
-// EMIT_MIR simplify_arm.id.SimplifyBranchSame.diff
-// EMIT_MIR simplify_arm.id_result.SimplifyArmIdentity.diff
-// EMIT_MIR simplify_arm.id_result.SimplifyBranchSame.diff
-// EMIT_MIR simplify_arm.id_try.SimplifyArmIdentity.diff
-// EMIT_MIR simplify_arm.id_try.SimplifyBranchSame.diff
+// These tests were broken by changes to enum deaggregation, and will be fixed when
+// `SimplifyArmIdentity` is fixed more generally
+// FIXME(JakobDegen) EMIT_MIR simplify_arm.id.SimplifyArmIdentity.diff
+// FIXME(JakobDegen) EMIT_MIR simplify_arm.id.SimplifyBranchSame.diff
+// FIXME(JakobDegen) EMIT_MIR simplify_arm.id_result.SimplifyArmIdentity.diff
+// FIXME(JakobDegen) EMIT_MIR simplify_arm.id_result.SimplifyBranchSame.diff
+// FIXME(JakobDegen) EMIT_MIR simplify_arm.id_try.SimplifyArmIdentity.diff
+// FIXME(JakobDegen) EMIT_MIR simplify_arm.id_try.SimplifyBranchSame.diff
 
 fn id(o: Option<u8>) -> Option<u8> {
     match o {

--- a/src/test/mir-opt/simplify-locals-removes-unused-discriminant-reads.rs
+++ b/src/test/mir-opt/simplify-locals-removes-unused-discriminant-reads.rs
@@ -1,3 +1,4 @@
+// ignore-tidy-linelength
 // compile-flags: -Zunsound-mir-opts
 
 fn map(x: Option<Box<()>>) -> Option<Box<()>> {
@@ -12,4 +13,6 @@ fn main() {
 }
 
 // EMIT_MIR_FOR_EACH_BIT_WIDTH
-// EMIT_MIR simplify_locals_removes_unused_discriminant_reads.map.SimplifyLocals.diff
+// This test was broken by changes to enum deaggregation, and will be fixed when
+// `SimplifyArmIdentity` is fixed more generally
+// FIXME(JakobDegen) EMIT_MIR simplify_locals_removes_unused_discriminant_reads.map.SimplifyLocals.diff

--- a/src/test/mir-opt/simplify_try.rs
+++ b/src/test/mir-opt/simplify_try.rs
@@ -1,9 +1,11 @@
 // compile-flags: -Zunsound-mir-opts
-// EMIT_MIR simplify_try.try_identity.SimplifyArmIdentity.diff
-// EMIT_MIR simplify_try.try_identity.SimplifyBranchSame.after.mir
-// EMIT_MIR simplify_try.try_identity.SimplifyLocals.after.mir
-// EMIT_MIR simplify_try.try_identity.DestinationPropagation.diff
 
+// These tests were broken by changes to enum deaggregation, and will be fixed when
+// `SimplifyArmIdentity` is fixed more generally
+// FIXME(JakobDegen) EMIT_MIR simplify_try.try_identity.SimplifyArmIdentity.diff
+// FIXME(JakobDegen) EMIT_MIR simplify_try.try_identity.SimplifyBranchSame.after.mir
+// FIXME(JakobDegen) EMIT_MIR simplify_try.try_identity.SimplifyLocals.after.mir
+// FIXME(JakobDegen) EMIT_MIR simplify_try.try_identity.DestinationPropagation.diff
 
 fn into_result<T, E>(r: Result<T, E>) -> Result<T, E> {
     r

--- a/src/test/mir-opt/unusual_item_types.Test-X-{constructor#0}.mir_map.0.32bit.mir
+++ b/src/test/mir-opt/unusual_item_types.Test-X-{constructor#0}.mir_map.0.32bit.mir
@@ -4,8 +4,8 @@ fn Test::X(_1: usize) -> Test {
     let mut _0: Test;                    // return place in scope 0 at $DIR/unusual-item-types.rs:16:5: 16:13
 
     bb0: {
-        ((_0 as X).0: usize) = move _1;  // scope 0 at $DIR/unusual-item-types.rs:16:5: 16:13
         discriminant(_0) = 0;            // scope 0 at $DIR/unusual-item-types.rs:16:5: 16:13
+        ((_0 as X).0: usize) = move _1;  // scope 0 at $DIR/unusual-item-types.rs:16:5: 16:13
         return;                          // scope 0 at $DIR/unusual-item-types.rs:16:5: 16:13
     }
 }

--- a/src/test/mir-opt/unusual_item_types.Test-X-{constructor#0}.mir_map.0.64bit.mir
+++ b/src/test/mir-opt/unusual_item_types.Test-X-{constructor#0}.mir_map.0.64bit.mir
@@ -4,8 +4,8 @@ fn Test::X(_1: usize) -> Test {
     let mut _0: Test;                    // return place in scope 0 at $DIR/unusual-item-types.rs:16:5: 16:13
 
     bb0: {
-        ((_0 as X).0: usize) = move _1;  // scope 0 at $DIR/unusual-item-types.rs:16:5: 16:13
         discriminant(_0) = 0;            // scope 0 at $DIR/unusual-item-types.rs:16:5: 16:13
+        ((_0 as X).0: usize) = move _1;  // scope 0 at $DIR/unusual-item-types.rs:16:5: 16:13
         return;                          // scope 0 at $DIR/unusual-item-types.rs:16:5: 16:13
     }
 }

--- a/src/test/ui/consts/const-eval/ub-enum-overwrite.rs
+++ b/src/test/ui/consts/const-eval/ub-enum-overwrite.rs
@@ -1,0 +1,17 @@
+#![feature(const_mut_refs)]
+
+enum E {
+    A(u8),
+    B,
+}
+
+const _: u8 = {
+    //~^ ERROR is undefined behavior
+    let mut e = E::A(1);
+    let p = if let E::A(x) = &mut e { x as *mut u8 } else { unreachable!() };
+    // Make sure overwriting `e` uninitializes other bytes
+    e = E::B;
+    unsafe { *p }
+};
+
+fn main() {}

--- a/src/test/ui/consts/const-eval/ub-enum-overwrite.stderr
+++ b/src/test/ui/consts/const-eval/ub-enum-overwrite.stderr
@@ -1,0 +1,20 @@
+error[E0080]: it is undefined behavior to use this value
+  --> $DIR/ub-enum-overwrite.rs:8:1
+   |
+LL | / const _: u8 = {
+LL | |
+LL | |     let mut e = E::A(1);
+LL | |     let p = if let E::A(x) = &mut e { x as *mut u8 } else { unreachable!() };
+...  |
+LL | |     unsafe { *p }
+LL | | };
+   | |__^ type validation failed: encountered uninitialized bytes, but expected initialized plain (non-pointer) bytes
+   |
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
+   = note: the raw bytes of the constant (size: 1, align: 1) {
+               __                                              │ ░
+           }
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0080`.


### PR DESCRIPTION
This PR clarifies the semantics of the `SetDiscriminant` MIR statement. Quoting from the updated documentation:

> If `place` is an ADT, this corresponds to the Rust code `place = Variant(uninit, uninit,
> uninit)`. If each of the fields is initialized after the `SetDiscriminant`, the place is
> completely initialized. Of course, you cannot initialize the fields first, as
> `SetDiscriminant` invalidates them.
> 
> ...
> 
> If `place` is a generator, then this invalidates only those fields which are not also
> present in another variant. Those fields that are present in another variant are unchanged.

## Benefits of this change

 1. The `MaybeLiveLocals` analysis was previously somewhat broken in that it marked locals killed on `SetDiscriminant`, although this was obviously not true for any fields that had been set previously. This change makes that decision completely justified, without requiring any changes to the code.
 2. Deaggregation of enums is now unambiguously non-lossy. Previously, deaggregation of enums would set both the fields and the discriminant - however, under some interpretations of the semantics of `SetDiscriminant` this would be lossy, since now possibly padding has to be preserved. With the new semantics, that is clearly and unambiguously not the case.
 3. In a future PR, we can start emitting `SetDiscriminant` for structs as well, with the same semantics. This will have the benefit of making deaggregation for structs also non-lossy.

This PR does not yet "weaponize" this change by changing codegen to make use of this information. Since the old version of `SetDiscriminant` is a valid implementation of the new version, the existing codegen should not have to change.

## This PR

The changes in code and documentation are made in the first and second commit. This causes a couple mir-opt tests to break. The broken tests can be divided into three categories, which are addressed in commits 3, 4, and 5:

 3. Tests that were broken in the expected trivial way. All of these tests just had a `SetDiscriminant` statement move a couple lines up.
 4. Const prop used to optimize the last statement in
    ```rust
    (p as Variant).field = ...;
    SetDiscriminant(p) = Variant;
    q = discriminant(p);
    ```
    However, since the statements have been re-ordered, it can no longer do this optimization. Commit 4 blesses the MIR opt test that this broke.
 5. Finally, the `SimplifyArmIdentity` pass relied on the old ordering and no longer works with this change. However, I have already put up #94177 , which re-writes this pass completely. That will also need to be adjusted after this PR, but I don't think it makes much sense to try and fix the old version of this pass, especially given that it does not run. Because of that, I have disabled the tests that were affected. I will be able to re-enable them in #94177 . I could also attach that PR to this one, but I feel like these are each big enough as is.

I'm not sure if this requires a FCP from T-Compiler for the MIR semantics change. I'll leave the decision of who to cc and what the right procedure is up to the reviewer.