### PR TITLE
Delay bug in expr adjustment when check_expr is called multiple times

### DIFF
--- a/compiler/rustc_typeck/src/check/fn_ctxt/_impl.rs
+++ b/compiler/rustc_typeck/src/check/fn_ctxt/_impl.rs
@@ -315,11 +315,14 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     }
                     // FIXME: currently we never try to compose autoderefs
                     // and ReifyFnPointer/UnsafeFnPointer, but we could.
-                    _ => bug!(
-                        "while adjusting {:?}, can't compose {:?} and {:?}",
-                        expr,
-                        entry.get(),
-                        adj
+                    _ => self.tcx.sess.delay_span_bug(
+                        expr.span,
+                        &format!(
+                            "while adjusting {:?}, can't compose {:?} and {:?}",
+                            expr,
+                            entry.get(),
+                            adj
+                        ),
                     ),
                 };
                 *entry.get_mut() = adj;

--- a/compiler/rustc_typeck/src/check/fn_ctxt/checks.rs
+++ b/compiler/rustc_typeck/src/check/fn_ctxt/checks.rs
@@ -234,11 +234,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         // This is more complicated than just checking type equality, as arguments could be coerced
         // This version writes those types back so further type checking uses the narrowed types
         let demand_compatible = |idx, final_arg_types: &mut Vec<Option<(Ty<'tcx>, Ty<'tcx>)>>| {
-            // Do not check argument compatibility if the number of args do not match
-            if arg_count_error.is_some() {
-                return;
-            }
-
             let formal_input_ty: Ty<'tcx> = formal_input_tys[idx];
             let expected_input_ty: Ty<'tcx> = expected_input_tys[idx];
             let provided_arg = &provided_args[idx];

--- a/src/test/ui/mismatched_types/overloaded-calls-bad.rs
+++ b/src/test/ui/mismatched_types/overloaded-calls-bad.rs
@@ -30,4 +30,5 @@ fn main() {
     //~^ ERROR this function takes 1 argument but 0 arguments were supplied
     let ans = s("burma", "shave");
     //~^ ERROR this function takes 1 argument but 2 arguments were supplied
+    //~| ERROR mismatched types
 }

--- a/src/test/ui/mismatched_types/overloaded-calls-bad.stderr
+++ b/src/test/ui/mismatched_types/overloaded-calls-bad.stderr
@@ -18,6 +18,12 @@ note: associated function defined here
 LL |     extern "rust-call" fn call_mut(&mut self, args: Args) -> Self::Output;
    |                           ^^^^^^^^
 
+error[E0308]: mismatched types
+  --> $DIR/overloaded-calls-bad.rs:31:17
+   |
+LL |     let ans = s("burma", "shave");
+   |                 ^^^^^^^ expected `isize`, found `&str`
+
 error[E0057]: this function takes 1 argument but 2 arguments were supplied
   --> $DIR/overloaded-calls-bad.rs:31:15
    |
@@ -32,7 +38,7 @@ note: associated function defined here
 LL |     extern "rust-call" fn call_mut(&mut self, args: Args) -> Self::Output;
    |                           ^^^^^^^^
 
-error: aborting due to 3 previous errors
+error: aborting due to 4 previous errors
 
 Some errors have detailed explanations: E0057, E0308.
 For more information about an error, try `rustc --explain E0057`.

--- a/src/test/ui/tuple/wrong_argument_ice-3.rs
+++ b/src/test/ui/tuple/wrong_argument_ice-3.rs
@@ -1,0 +1,17 @@
+struct Process;
+
+pub type Group = (Vec<String>, Vec<Process>);
+
+fn test(process: &Process, groups: Vec<Group>) -> Vec<Group> {
+    let new_group = vec![String::new()];
+
+    if groups.capacity() == 0 {
+        groups.push(new_group, vec![process]);
+        //~^ ERROR this function takes 1 argument but 2 arguments were supplied
+        return groups;
+    }
+
+    todo!()
+}
+
+fn main() {}

--- a/src/test/ui/tuple/wrong_argument_ice-3.stderr
+++ b/src/test/ui/tuple/wrong_argument_ice-3.stderr
@@ -1,0 +1,17 @@
+error[E0061]: this function takes 1 argument but 2 arguments were supplied
+  --> $DIR/wrong_argument_ice-3.rs:9:16
+   |
+LL |         groups.push(new_group, vec![process]);
+   |                ^^^^ ---------  ------------- supplied 2 arguments
+   |                |
+   |                expected 1 argument
+   |
+note: associated function defined here
+  --> $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
+   |
+LL |     pub fn push(&mut self, value: T) {
+   |            ^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0061`.


### PR DESCRIPTION
Instead of including slightly more complicated logic in `check_argument_types` to fix the bug (#94516) I introduced in #94438, and inevitably have this bug appear once again when some other diagnostic is written that causes `check_expr` to be called an expression during a (bad) code path, just delay the bug in adjustment logic.

I am open to other implementations that don't delay the bug here.

Fixes #94516