### PR TITLE
Move theme picker button to the right and display it on all pages

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -791,7 +791,13 @@ nav.main .separator {
 	margin: 0 20px;
 }
 nav.sum { text-align: right; }
-nav.sub form { display: inline; }
+nav.sub form {
+	flex-grow: 1;
+}
+
+nav.sub form input {
+	height: 100%;
+}
 
 a {
 	text-decoration: none;
@@ -883,6 +889,7 @@ table,
 	position: relative;
 	display: flex;
 	height: 34px;
+	width: 100%;
 }
 .search-container > * {
 	height: 100%;
@@ -1379,16 +1386,13 @@ pre.rust {
 }
 
 .theme-picker {
-	position: absolute;
-	left: -38px;
-	top: 4px;
+	position: relative;
 }
-
 .theme-picker button {
 	outline: none;
 }
 
-#settings-menu, #help-button {
+#settings-menu, #help-button, .theme-picker {
 	margin-left: 4px;
 	outline: none;
 }
@@ -1425,7 +1429,7 @@ pre.rust {
 	display: none;
 	position: absolute;
 	left: 0;
-	top: 28px;
+	top: 31px;
 	border: 1px solid;
 	border-radius: 3px;
 	z-index: 1;
@@ -1832,7 +1836,7 @@ details.rustdoc-toggle[open] > summary.hideme::after {
 	}
 
 	/* Space is at a premium on mobile, so remove the theme-picker icon. */
-	#theme-picker {
+	.theme-picker {
 		display: none;
 		width: 0;
 	}

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1835,12 +1835,6 @@ details.rustdoc-toggle[open] > summary.hideme::after {
 		margin-left: 32px;
 	}
 
-	/* Space is at a premium on mobile, so remove the theme-picker icon. */
-	.theme-picker {
-		display: none;
-		width: 0;
-	}
-
 	.content {
 		margin-left: 0px;
 	}

--- a/src/librustdoc/html/static/js/main.js
+++ b/src/librustdoc/html/static/js/main.js
@@ -135,14 +135,9 @@ function hideThemeButtonState() {
 
 // Set up the theme picker list.
 (function () {
-    if (!document.location.href.startsWith("file:///")) {
-        return;
-    }
     var themeChoices = getThemesElement();
     var themePicker = getThemePickerElement();
     var availableThemes = getVar("themes").split(",");
-
-    removeClass(themeChoices.parentElement, "hidden");
 
     function switchThemeButtonState() {
         if (themeChoices.style.display === "block") {

--- a/src/librustdoc/html/templates/page.html
+++ b/src/librustdoc/html/templates/page.html
@@ -108,15 +108,8 @@
                     {%- endif -%}
                 </a> {#- -#}
                 <nav class="sub"> {#- -#}
-                    <div class="theme-picker"> {#- -#}
-                        <button id="theme-picker" aria-label="Pick another theme!" aria-haspopup="menu" title="themes"> {#- -#}
-                            <img width="22" height="22" alt="Pick another theme!" {# -#}
-                             src="{{static_root_path|safe}}brush{{page.resource_suffix}}.svg"> {#- -#}
-                        </button> {#- -#}
-                        <div id="theme-choices" role="menu"></div> {#- -#}
-                    </div> {#- -#}
-                    <form class="search-form"> {#- -#}
-                        <div class="search-container"> {#- -#}
+                    <div class="search-container"> {#- -#}
+                        <form class="search-form"> {#- -#}
                             <span></span> {#- This empty span is a hacky fix for Safari - See #93184 -#}
                             <input {# -#}
                                 class="search-input" {# -#}
@@ -125,13 +118,20 @@
                                 spellcheck="false" {# -#}
                                 placeholder="Click or press ‘S’ to search, ‘?’ for more options…" {# -#}
                                 type="search"> {#- -#}
-                            <button type="button" id="help-button" title="help">?</button> {#- -#}
-                            <a id="settings-menu" href="{{page.root_path|safe}}settings.html" title="settings"> {#- -#}
-                                <img width="22" height="22" alt="Change settings" {# -#}
-                                     src="{{static_root_path|safe}}wheel{{page.resource_suffix}}.svg"> {#- -#}
-                            </a> {#- -#}
+                        </form> {#- -#}
+                        <button type="button" id="help-button" title="help">?</button> {#- -#}
+                        <div class="theme-picker"> {#- -#}
+                            <button id="theme-picker" aria-label="Pick another theme!" aria-haspopup="menu" title="themes"> {#- -#}
+                                <img width="22" height="22" alt="Pick another theme!" {# -#}
+                                 src="{{static_root_path|safe}}brush{{page.resource_suffix}}.svg"> {#- -#}
+                            </button> {#- -#}
+                            <div id="theme-choices" role="menu"></div> {#- -#}
                         </div> {#- -#}
-                    </form> {#- -#}
+                        <a id="settings-menu" href="{{page.root_path|safe}}settings.html" title="settings"> {#- -#}
+                            <img width="22" height="22" alt="Change settings" {# -#}
+                                 src="{{static_root_path|safe}}wheel{{page.resource_suffix}}.svg"> {#- -#}
+                        </a> {#- -#}
+                    </div> {#- -#}
                 </nav> {#- -#}
             </div> {#- -#}
             <section id="main-content" class="content">{{- content|safe -}}</section> {#- -#}

--- a/src/librustdoc/html/templates/page.html
+++ b/src/librustdoc/html/templates/page.html
@@ -108,7 +108,7 @@
                     {%- endif -%}
                 </a> {#- -#}
                 <nav class="sub"> {#- -#}
-                    <div class="theme-picker hidden"> {#- -#}
+                    <div class="theme-picker"> {#- -#}
                         <button id="theme-picker" aria-label="Pick another theme!" aria-haspopup="menu" title="themes"> {#- -#}
                             <img width="22" height="22" alt="Pick another theme!" {# -#}
                              src="{{static_root_path|safe}}brush{{page.resource_suffix}}.svg"> {#- -#}


### PR DESCRIPTION
Fixes #93216.
Kind of linked to #94048.

So more explanations about this: we received a lot of complains about the removal of the theme picker button. The idea behind this change was to reduce the visual distraction. We have a more global plan about settings to have them displayed like the "firefox pocket". To do so, the first step is https://github.com/rust-lang/rust/pull/93097 (it's blocked on https://github.com/rust-lang/rust/pull/90630 for the time being). Then once it's fully switched to JS, we can easily change how it's displayed.

So for the moment and as suggested, I move the theme picker button with the other ones one the right. It now looks like this:

![Screenshot from 2022-03-04 14-59-27](https://user-images.githubusercontent.com/3050060/156780102-d43e1403-b01b-4554-a3c1-e02c0eb4259c.png)
![Screenshot from 2022-03-04 14-59-24](https://user-images.githubusercontent.com/3050060/156780105-215f1485-5796-453b-ad5b-16140a523de8.png)

You can test it online [here](https://rustdoc.crud.net/imperio/theme-picker-display/foo/index.html).

r? @jsha