### PR TITLE
Don't round stack size up for created threads in Windows

### DIFF
--- a/library/std/src/sys/windows/thread.rs
+++ b/library/std/src/sys/windows/thread.rs
@@ -28,12 +28,9 @@ impl Thread {
         // PTHREAD_STACK_MIN bytes big.  Windows has no such lower limit, it's
         // just that below a certain threshold you can't do anything useful.
         // That threshold is application and architecture-specific, however.
-        // Round up to the next 64 kB because that's what the NT kernel does,
-        // might as well make it explicit.
-        let stack_size = (stack + 0xfffe) & (!0xfffe);
         let ret = c::CreateThread(
             ptr::null_mut(),
-            stack_size,
+            stack,
             thread_start,
             p as *mut _,
             c::STACK_SIZE_PARAM_IS_A_RESERVATION,


### PR DESCRIPTION
Fixes #94454

Windows does the rounding itself, so there isn't a need to explicity do the rounding beforehand, as mentioned by @ChrisDenton in #94454

> The operating system rounds up the specified size to the nearest multiple of the system's allocation granularity (typically 64 KB). To retrieve the allocation granularity of the current system, use the [GetSystemInfo](https://docs.microsoft.com/en-us/windows/win32/api/sysinfoapi/nf-sysinfoapi-getsysteminfo) function.

https://docs.microsoft.com/en-us/windows/win32/procthread/thread-stack-size