### PR TITLE
Optimize ChunkedBitSet dense relations

### DIFF
--- a/compiler/rustc_index/src/bit_set.rs
+++ b/compiler/rustc_index/src/bit_set.rs
@@ -152,7 +152,7 @@ impl<T: Idx> BitSet<T> {
 
     /// Count the number of set bits in the set.
     pub fn count(&self) -> usize {
-        self.words.iter().map(|e| e.count_ones() as usize).sum()
+        bit_count(&self.words)
     }
 
     /// Returns `true` if `self` contains `elem`.
@@ -628,10 +628,7 @@ impl<T: Idx> BitRelations<ChunkedBitSet<T>> for ChunkedBitSet<T> {
                             op,
                         );
                         debug_assert!(has_changed);
-                        *self_chunk_count = self_chunk_words[0..num_words]
-                            .iter()
-                            .map(|w| w.count_ones() as ChunkSize)
-                            .sum();
+                        *self_chunk_count = bit_count(&self_chunk_words[0..num_words]) as ChunkSize;
                         if *self_chunk_count == *self_chunk_domain_size {
                             *self_chunk = Ones(*self_chunk_domain_size);
                         }
@@ -705,21 +702,12 @@ impl Chunk {
                 assert!(0 < count && count < chunk_domain_size);
 
                 // Check the number of set bits matches `count`.
-                assert_eq!(
-                    words.iter().map(|w| w.count_ones() as ChunkSize).sum::<ChunkSize>(),
-                    count
-                );
+                assert_eq!(bit_count(words.as_ref()) as ChunkSize, count);
 
                 // Check the not-in-use words are all zeroed.
                 let num_words = num_words(chunk_domain_size as usize);
                 if num_words < CHUNK_WORDS {
-                    assert_eq!(
-                        words[num_words..]
-                            .iter()
-                            .map(|w| w.count_ones() as ChunkSize)
-                            .sum::<ChunkSize>(),
-                        0
-                    );
+                    assert_eq!(bit_count(&words[num_words..]), 0);
                 }
             }
         }
@@ -1585,7 +1573,7 @@ impl<R: Idx, C: Idx> BitMatrix<R, C> {
     /// Returns the number of elements in `row`.
     pub fn count(&self, row: R) -> usize {
         let (start, end) = self.range(row);
-        self.words[start..end].iter().map(|e| e.count_ones() as usize).sum()
+        bit_count(&self.words[start..end])
     }
 }
 
@@ -1794,6 +1782,11 @@ fn clear_excess_bits_in_final_word(domain_size: usize, words: &mut [Word]) {
 #[inline]
 fn max_bit(word: Word) -> usize {
     WORD_BITS - 1 - word.leading_zeros() as usize
+}
+
+#[inline]
+fn bit_count(words: &[Word]) -> usize {
+    words.iter().map(|w| w.count_ones() as usize).sum()
 }
 
 /// Integral type used to represent the bit set.

--- a/compiler/rustc_index/src/bit_set/tests.rs
+++ b/compiler/rustc_index/src/bit_set/tests.rs
@@ -340,6 +340,37 @@ fn chunked_bitset() {
     assert_eq!(b10000.count(), 6000);
     b10000.assert_valid();
     b10000b.assert_valid();
+
+    //-----------------------------------------------------------------------
+
+    let mut b6900 = ChunkedBitSet::<usize>::new_empty(6900);
+    b6900.insert(3);
+    b6900.insert(17);
+    b6900.insert(68);
+    b6900.insert(2000);
+    b6900.insert(2500);
+
+    let mut b6900b = BitSet::<usize>::new_empty(6900);
+    b6900b.insert(17);
+    b6900b.insert(42);
+    b6900b.insert(68);
+    b6900b.insert(2000);
+    b6900b.insert(4200);
+
+    b6900.subtract(&b6900b);
+    b6900.assert_valid();
+    assert!(b6900.contains(3));
+    assert!(b6900.contains(2500));
+    assert_eq!(b6900.count(), 2);
+
+    b6900.union(&b6900b);
+    b6900.assert_valid();
+    assert_eq!(b6900.count(), 7);
+
+    b6900.subtract(&BitSet::<usize>::new_filled(6900));
+    b6900.assert_valid();
+    assert_eq!(b6900.count(), 0);
+    assert_eq!(b6900.chunks(), vec![Zeros(2048), Zeros(2048), Zeros(2048), Zeros(756)],);
 }
 
 #[test]


### PR DESCRIPTION
`ChunkedBitSet::subtract(&HybridBitSet)` showed up in a callgrind profile grabbed of the `helloworld` benchmark while playing around with [rustc-perf](https://github.com/rust-lang/rustc-perf), and the FIXMEs left behind there by @nnethercote pointed to a way to optimize it.

The resulting improvements on the `rustc-perf` benchmarks are [meager](https://user-images.githubusercontent.com/458783/156841723-d89230d8-dfce-4fb5-a66d-c23737505bd5.png) to say the least, but perhaps the changes are of interest anyway.

I'm unacquainted with the compiler code and the tooling in general so I apologize in advance for any missteps!

PS: Sorry for the double PR, the first one was supposed to be a draft!

r? @nnethercote
