### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/compiler/rustc_interface/src/interface.rs
+++ b/compiler/rustc_interface/src/interface.rs
@@ -207,6 +207,9 @@ pub fn parse_check_cfg(specs: Vec<String>) -> CheckCfg {
                                             "`values()` first argument must be a simple identifer"
                                         );
                                     }
+                                } else if args.is_empty() {
+                                    cfg.well_known_values = true;
+                                    continue 'specs;
                                 }
                             }
                         }

--- a/compiler/rustc_resolve/src/imports.rs
+++ b/compiler/rustc_resolve/src/imports.rs
@@ -720,7 +720,9 @@ impl<'a, 'b> ImportResolver<'a, 'b> {
                     note: Vec::new(),
                     suggestion: None,
                 };
-                errors.push((path, err));
+                if path.contains("::") {
+                    errors.push((path, err))
+                }
             }
         }
 

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -1025,13 +1025,19 @@ pub fn to_crate_config(cfg: FxHashSet<(String, Option<String>)>) -> CrateConfig 
 pub struct CheckCfg<T = String> {
     /// The set of all `names()`, if None no name checking is performed
     pub names_valid: Option<FxHashSet<T>>,
+    /// Is well known values activated
+    pub well_known_values: bool,
     /// The set of all `values()`
     pub values_valid: FxHashMap<T, FxHashSet<T>>,
 }
 
 impl<T> Default for CheckCfg<T> {
     fn default() -> Self {
-        CheckCfg { names_valid: Default::default(), values_valid: Default::default() }
+        CheckCfg {
+            names_valid: Default::default(),
+            values_valid: Default::default(),
+            well_known_values: false,
+        }
     }
 }
 
@@ -1047,6 +1053,7 @@ impl<T> CheckCfg<T> {
                 .iter()
                 .map(|(a, b)| (f(a), b.iter().map(|b| f(b)).collect()))
                 .collect(),
+            well_known_values: self.well_known_values,
         }
     }
 }

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -13,6 +13,7 @@ use rustc_data_structures::impl_stable_hash_via_hash;
 
 use rustc_target::abi::{Align, TargetDataLayout};
 use rustc_target::spec::{LinkerFlavor, SplitDebuginfo, Target, TargetTriple, TargetWarnings};
+use rustc_target::spec::{PanicStrategy, SanitizerSet, TARGETS};
 
 use rustc_serialize::json;
 
@@ -1067,8 +1068,9 @@ pub fn to_crate_check_config(cfg: CheckCfg) -> CrateCheckConfig {
 
 impl CrateCheckConfig {
     /// Fills a `CrateCheckConfig` with well-known configuration names.
-    pub fn fill_well_known(&mut self) {
-        // NOTE: This should be kept in sync with `default_configuration`
+    fn fill_well_known_names(&mut self) {
+        // NOTE: This should be kept in sync with `default_configuration` and
+        // `fill_well_known_values`
         const WELL_KNOWN_NAMES: &[Symbol] = &[
             sym::unix,
             sym::windows,
@@ -1093,11 +1095,106 @@ impl CrateCheckConfig {
             sym::doctest,
             sym::feature,
         ];
+
+        // We only insert well-known names if `names()` was activated
         if let Some(names_valid) = &mut self.names_valid {
-            for &name in WELL_KNOWN_NAMES {
-                names_valid.insert(name);
-            }
+            names_valid.extend(WELL_KNOWN_NAMES);
         }
+    }
+
+    /// Fills a `CrateCheckConfig` with well-known configuration values.
+    fn fill_well_known_values(&mut self) {
+        if !self.well_known_values {
+            return;
+        }
+
+        // NOTE: This should be kept in sync with `default_configuration` and
+        // `fill_well_known_names`
+
+        let panic_values = &PanicStrategy::all();
+
+        let atomic_values = &[
+            sym::ptr,
+            sym::integer(8usize),
+            sym::integer(16usize),
+            sym::integer(32usize),
+            sym::integer(64usize),
+            sym::integer(128usize),
+        ];
+
+        let sanitize_values = SanitizerSet::all()
+            .into_iter()
+            .map(|sanitizer| Symbol::intern(sanitizer.as_str().unwrap()));
+
+        // No-values
+        for name in [
+            sym::unix,
+            sym::windows,
+            sym::debug_assertions,
+            sym::proc_macro,
+            sym::test,
+            sym::doc,
+            sym::doctest,
+            sym::target_thread_local,
+        ] {
+            self.values_valid.entry(name).or_default();
+        }
+
+        // Pre-defined values
+        self.values_valid.entry(sym::panic).or_default().extend(panic_values);
+        self.values_valid.entry(sym::sanitize).or_default().extend(sanitize_values);
+        self.values_valid.entry(sym::target_has_atomic).or_default().extend(atomic_values);
+        self.values_valid
+            .entry(sym::target_has_atomic_load_store)
+            .or_default()
+            .extend(atomic_values);
+        self.values_valid
+            .entry(sym::target_has_atomic_equal_alignment)
+            .or_default()
+            .extend(atomic_values);
+
+        // Target specific values
+        for target in
+            TARGETS.iter().map(|target| Target::expect_builtin(&TargetTriple::from_triple(target)))
+        {
+            self.values_valid
+                .entry(sym::target_os)
+                .or_default()
+                .insert(Symbol::intern(&target.options.os));
+            self.values_valid
+                .entry(sym::target_family)
+                .or_default()
+                .extend(target.options.families.iter().map(|family| Symbol::intern(family)));
+            self.values_valid
+                .entry(sym::target_arch)
+                .or_default()
+                .insert(Symbol::intern(&target.arch));
+            self.values_valid
+                .entry(sym::target_endian)
+                .or_default()
+                .insert(Symbol::intern(&target.options.endian.as_str()));
+            self.values_valid
+                .entry(sym::target_env)
+                .or_default()
+                .insert(Symbol::intern(&target.options.env));
+            self.values_valid
+                .entry(sym::target_abi)
+                .or_default()
+                .insert(Symbol::intern(&target.options.abi));
+            self.values_valid
+                .entry(sym::target_vendor)
+                .or_default()
+                .insert(Symbol::intern(&target.options.vendor));
+            self.values_valid
+                .entry(sym::target_pointer_width)
+                .or_default()
+                .insert(sym::integer(target.pointer_width));
+        }
+    }
+
+    pub fn fill_well_known(&mut self) {
+        self.fill_well_known_names();
+        self.fill_well_known_values();
     }
 
     /// Fills a `CrateCheckConfig` with configuration names and values that are actually active.

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1062,6 +1062,7 @@ symbols! {
         proc_macro_path_invoc,
         profiler_builtins,
         profiler_runtime,
+        ptr,
         ptr_guaranteed_eq,
         ptr_guaranteed_ne,
         ptr_null,

--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -186,11 +186,15 @@ impl PanicStrategy {
         }
     }
 
-    pub fn desc_symbol(&self) -> Symbol {
+    pub const fn desc_symbol(&self) -> Symbol {
         match *self {
             PanicStrategy::Unwind => sym::unwind,
             PanicStrategy::Abort => sym::abort,
         }
+    }
+
+    pub const fn all() -> [Symbol; 2] {
+        [Self::Abort.desc_symbol(), Self::Unwind.desc_symbol()]
     }
 }
 
@@ -614,7 +618,7 @@ impl SanitizerSet {
     /// Return sanitizer's name
     ///
     /// Returns none if the flags is a set of sanitizers numbering not exactly one.
-    fn as_str(self) -> Option<&'static str> {
+    pub fn as_str(self) -> Option<&'static str> {
         Some(match self {
             SanitizerSet::ADDRESS => "address",
             SanitizerSet::CFI => "cfi",
@@ -2135,6 +2139,18 @@ impl Target {
             base,
             TargetWarnings { unused_fields: remaining_keys.cloned().collect(), incorrect_type },
         ))
+    }
+
+    /// Load a built-in target
+    pub fn expect_builtin(target_triple: &TargetTriple) -> Target {
+        match *target_triple {
+            TargetTriple::TargetTriple(ref target_triple) => {
+                load_builtin(target_triple).expect("built-in target")
+            }
+            TargetTriple::TargetPath(..) => {
+                panic!("built-in targets doens't support target-paths")
+            }
+        }
     }
 
     /// Search for a JSON file specifying the given target triple.

--- a/compiler/rustc_typeck/src/check/fn_ctxt/_impl.rs
+++ b/compiler/rustc_typeck/src/check/fn_ctxt/_impl.rs
@@ -315,11 +315,14 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     }
                     // FIXME: currently we never try to compose autoderefs
                     // and ReifyFnPointer/UnsafeFnPointer, but we could.
-                    _ => bug!(
-                        "while adjusting {:?}, can't compose {:?} and {:?}",
-                        expr,
-                        entry.get(),
-                        adj
+                    _ => self.tcx.sess.delay_span_bug(
+                        expr.span,
+                        &format!(
+                            "while adjusting {:?}, can't compose {:?} and {:?}",
+                            expr,
+                            entry.get(),
+                            adj
+                        ),
                     ),
                 };
                 *entry.get_mut() = adj;

--- a/compiler/rustc_typeck/src/check/fn_ctxt/checks.rs
+++ b/compiler/rustc_typeck/src/check/fn_ctxt/checks.rs
@@ -234,11 +234,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         // This is more complicated than just checking type equality, as arguments could be coerced
         // This version writes those types back so further type checking uses the narrowed types
         let demand_compatible = |idx, final_arg_types: &mut Vec<Option<(Ty<'tcx>, Ty<'tcx>)>>| {
-            // Do not check argument compatibility if the number of args do not match
-            if arg_count_error.is_some() {
-                return;
-            }
-
             let formal_input_ty: Ty<'tcx> = formal_input_tys[idx];
             let expected_input_ty: Ty<'tcx> = expected_input_tys[idx];
             let provided_arg = &provided_args[idx];

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -408,12 +408,12 @@ pub mod arch {
 #[allow(missing_debug_implementations, dead_code, unsafe_op_in_unsafe_fn, unused_unsafe)]
 #[allow(rustdoc::bare_urls)]
 #[unstable(feature = "portable_simd", issue = "86656")]
-#[cfg(not(all(miri, doctest)))] // Miri does not support all SIMD intrinsics
+#[cfg(not(all(miri, doctest)))] // Skip SIMD doctests in Miri
 mod core_simd;
 
 #[doc = include_str!("../../portable-simd/crates/core_simd/src/core_simd_docs.md")]
 #[unstable(feature = "portable_simd", issue = "86656")]
-#[cfg(not(all(miri, doctest)))] // Miri does not support all SIMD intrinsics
+#[cfg(not(all(miri, doctest)))] // Skip SIMD doctests in Miri
 pub mod simd {
     #[unstable(feature = "portable_simd", issue = "86656")]
     pub use crate::core_simd::simd::*;

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -16,7 +16,7 @@ use crate::option::Option::{None, Some};
 use crate::ptr;
 use crate::result::Result;
 use crate::result::Result::{Err, Ok};
-#[cfg(not(miri))] // Miri does not support all SIMD intrinsics
+#[cfg(not(all(miri, doctest)))] // Miri skips SIMD doctests
 use crate::simd::{self, Simd};
 use crate::slice;
 
@@ -3540,7 +3540,7 @@ impl<T> [T] {
     /// assert_eq!(basic_simd_sum(&numbers[1..99]), 4949.0);
     /// ```
     #[unstable(feature = "portable_simd", issue = "86656")]
-    #[cfg(not(miri))] // Miri does not support all SIMD intrinsics
+    #[cfg(not(all(miri, doctest)))] // Miri skips SIMD doctests
     pub fn as_simd<const LANES: usize>(&self) -> (&[T], &[Simd<T, LANES>], &[T])
     where
         Simd<T, LANES>: AsRef<[T; LANES]>,
@@ -3584,7 +3584,7 @@ impl<T> [T] {
     /// be lifted in a way that would make it possible to see panics from this
     /// method for something like `LANES == 3`.
     #[unstable(feature = "portable_simd", issue = "86656")]
-    #[cfg(not(miri))] // Miri does not support all SIMD intrinsics
+    #[cfg(not(all(miri, doctest)))] // Miri skips SIMD doctests
     pub fn as_simd_mut<const LANES: usize>(&mut self) -> (&mut [T], &mut [Simd<T, LANES>], &mut [T])
     where
         Simd<T, LANES>: AsMut<[T; LANES]>,

--- a/library/core/tests/simd.rs
+++ b/library/core/tests/simd.rs
@@ -1,5 +1,3 @@
-#![cfg(not(miri))] // Miri does not support all SIMD intrinsics
-
 use core::simd::f32x4;
 
 #[test]

--- a/library/core/tests/slice.rs
+++ b/library/core/tests/slice.rs
@@ -2457,9 +2457,11 @@ take_tests! {
     (take_last_mut_empty, (), None, &mut []),
 }
 
+#[cfg(not(miri))] // unused in Miri
 const EMPTY_MAX: &'static [()] = &[(); usize::MAX];
 
 // can't be a constant due to const mutability rules
+#[cfg(not(miri))] // unused in Miri
 macro_rules! empty_max_mut {
     () => {
         &mut [(); usize::MAX] as _

--- a/library/std/src/sys/windows/thread.rs
+++ b/library/std/src/sys/windows/thread.rs
@@ -28,12 +28,9 @@ impl Thread {
         // PTHREAD_STACK_MIN bytes big.  Windows has no such lower limit, it's
         // just that below a certain threshold you can't do anything useful.
         // That threshold is application and architecture-specific, however.
-        // Round up to the next 64 kB because that's what the NT kernel does,
-        // might as well make it explicit.
-        let stack_size = (stack + 0xfffe) & (!0xfffe);
         let ret = c::CreateThread(
             ptr::null_mut(),
-            stack_size,
+            stack,
             thread_start,
             p as *mut _,
             c::STACK_SIZE_PARAM_IS_A_RESERVATION,

--- a/src/test/ui/check-cfg/empty-values.rs
+++ b/src/test/ui/check-cfg/empty-values.rs
@@ -1,6 +1,10 @@
-// Check that a an empty values() pass
+// Check warning for unexpected cfg value
 //
 // check-pass
 // compile-flags: --check-cfg=values() -Z unstable-options
+
+#[cfg(test = "value")]
+//~^ WARNING unexpected `cfg` condition value
+pub fn f() {}
 
 fn main() {}

--- a/src/test/ui/check-cfg/empty-values.rs
+++ b/src/test/ui/check-cfg/empty-values.rs
@@ -1,6 +1,6 @@
-// Check that a an empty values() is rejected
+// Check that a an empty values() pass
 //
-// check-fail
+// check-pass
 // compile-flags: --check-cfg=values() -Z unstable-options
 
 fn main() {}

--- a/src/test/ui/check-cfg/empty-values.stderr
+++ b/src/test/ui/check-cfg/empty-values.stderr
@@ -1,2 +1,0 @@
-error: invalid `--check-cfg` argument: `values()` (expected `names(name1, name2, ... nameN)` or `values(name, "value1", "value2", ... "valueN")`)
-

--- a/src/test/ui/check-cfg/empty-values.stderr
+++ b/src/test/ui/check-cfg/empty-values.stderr
@@ -1,0 +1,11 @@
+warning: unexpected `cfg` condition value
+  --> $DIR/empty-values.rs:6:7
+   |
+LL | #[cfg(test = "value")]
+   |       ^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(unexpected_cfgs)]` on by default
+   = note: no expected value for `test`
+
+warning: 1 warning emitted
+

--- a/src/test/ui/check-cfg/well-known-values.rs
+++ b/src/test/ui/check-cfg/well-known-values.rs
@@ -1,0 +1,28 @@
+// This test check that we lint on non well known values and that we don't lint on well known
+// values
+//
+// check-pass
+// compile-flags: --check-cfg=values() -Z unstable-options
+
+#[cfg(target_os = "linuz")]
+//~^ WARNING unexpected `cfg` condition value
+fn target_os_linux_misspell() {}
+
+#[cfg(target_os = "linux")]
+fn target_os_linux() {}
+
+#[cfg(target_has_atomic = "0")]
+//~^ WARNING unexpected `cfg` condition value
+fn target_has_atomic_invalid() {}
+
+#[cfg(target_has_atomic = "8")]
+fn target_has_atomic() {}
+
+#[cfg(unix = "aa")]
+//~^ WARNING unexpected `cfg` condition value
+fn unix_with_value() {}
+
+#[cfg(unix)]
+fn unix() {}
+
+fn main() {}

--- a/src/test/ui/check-cfg/well-known-values.stderr
+++ b/src/test/ui/check-cfg/well-known-values.stderr
@@ -1,0 +1,31 @@
+warning: unexpected `cfg` condition value
+  --> $DIR/well-known-values.rs:7:7
+   |
+LL | #[cfg(target_os = "linuz")]
+   |       ^^^^^^^^^^^^-------
+   |                   |
+   |                   help: did you mean: `"linux"`
+   |
+   = note: `#[warn(unexpected_cfgs)]` on by default
+   = note: expected values for `target_os` are: android, cuda, dragonfly, emscripten, espidf, freebsd, fuchsia, haiku, hermit, horizon, illumos, ios, l4re, linux, macos, netbsd, none, openbsd, psp, redox, solaris, solid_asp3, tvos, uefi, unknown, vxworks, wasi, windows
+
+warning: unexpected `cfg` condition value
+  --> $DIR/well-known-values.rs:14:7
+   |
+LL | #[cfg(target_has_atomic = "0")]
+   |       ^^^^^^^^^^^^^^^^^^^^---
+   |                           |
+   |                           help: did you mean: `"8"`
+   |
+   = note: expected values for `target_has_atomic` are: 128, 16, 32, 64, 8, ptr
+
+warning: unexpected `cfg` condition value
+  --> $DIR/well-known-values.rs:21:7
+   |
+LL | #[cfg(unix = "aa")]
+   |       ^^^^^^^^^^^
+   |
+   = note: no expected value for `unix`
+
+warning: 3 warnings emitted
+

--- a/src/test/ui/mismatched_types/overloaded-calls-bad.rs
+++ b/src/test/ui/mismatched_types/overloaded-calls-bad.rs
@@ -30,4 +30,5 @@ fn main() {
     //~^ ERROR this function takes 1 argument but 0 arguments were supplied
     let ans = s("burma", "shave");
     //~^ ERROR this function takes 1 argument but 2 arguments were supplied
+    //~| ERROR mismatched types
 }

--- a/src/test/ui/mismatched_types/overloaded-calls-bad.stderr
+++ b/src/test/ui/mismatched_types/overloaded-calls-bad.stderr
@@ -18,6 +18,12 @@ note: associated function defined here
 LL |     extern "rust-call" fn call_mut(&mut self, args: Args) -> Self::Output;
    |                           ^^^^^^^^
 
+error[E0308]: mismatched types
+  --> $DIR/overloaded-calls-bad.rs:31:17
+   |
+LL |     let ans = s("burma", "shave");
+   |                 ^^^^^^^ expected `isize`, found `&str`
+
 error[E0057]: this function takes 1 argument but 2 arguments were supplied
   --> $DIR/overloaded-calls-bad.rs:31:15
    |
@@ -32,7 +38,7 @@ note: associated function defined here
 LL |     extern "rust-call" fn call_mut(&mut self, args: Args) -> Self::Output;
    |                           ^^^^^^^^
 
-error: aborting due to 3 previous errors
+error: aborting due to 4 previous errors
 
 Some errors have detailed explanations: E0057, E0308.
 For more information about an error, try `rustc --explain E0057`.

--- a/src/test/ui/rust-2018/unresolved-asterisk-imports.rs
+++ b/src/test/ui/rust-2018/unresolved-asterisk-imports.rs
@@ -1,0 +1,6 @@
+// edition:2018
+
+use not_existing_crate::*; //~ ERROR unresolved import `not_existing_crate
+use std as foo;
+
+fn main() {}

--- a/src/test/ui/rust-2018/unresolved-asterisk-imports.stderr
+++ b/src/test/ui/rust-2018/unresolved-asterisk-imports.stderr
@@ -1,0 +1,9 @@
+error[E0432]: unresolved import `not_existing_crate`
+  --> $DIR/unresolved-asterisk-imports.rs:3:5
+   |
+LL | use not_existing_crate::*;
+   |     ^^^^^^^^^^^^^^^^^^ use of undeclared crate or module `not_existing_crate`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0432`.

--- a/src/test/ui/tuple/wrong_argument_ice-3.rs
+++ b/src/test/ui/tuple/wrong_argument_ice-3.rs
@@ -1,0 +1,17 @@
+struct Process;
+
+pub type Group = (Vec<String>, Vec<Process>);
+
+fn test(process: &Process, groups: Vec<Group>) -> Vec<Group> {
+    let new_group = vec![String::new()];
+
+    if groups.capacity() == 0 {
+        groups.push(new_group, vec![process]);
+        //~^ ERROR this function takes 1 argument but 2 arguments were supplied
+        return groups;
+    }
+
+    todo!()
+}
+
+fn main() {}

--- a/src/test/ui/tuple/wrong_argument_ice-3.stderr
+++ b/src/test/ui/tuple/wrong_argument_ice-3.stderr
@@ -1,0 +1,17 @@
+error[E0061]: this function takes 1 argument but 2 arguments were supplied
+  --> $DIR/wrong_argument_ice-3.rs:9:16
+   |
+LL |         groups.push(new_group, vec![process]);
+   |                ^^^^ ---------  ------------- supplied 2 arguments
+   |                |
+   |                expected 1 argument
+   |
+note: associated function defined here
+  --> $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
+   |
+LL |     pub fn push(&mut self, value: T) {
+   |            ^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0061`.

--- a/src/test/ui/unresolved/unresolved-asterisk-imports.rs
+++ b/src/test/ui/unresolved/unresolved-asterisk-imports.rs
@@ -1,0 +1,4 @@
+use not_existing_crate::*; //~ ERROR unresolved import `not_existing_crate
+use std as foo;
+
+fn main() {}

--- a/src/test/ui/unresolved/unresolved-asterisk-imports.stderr
+++ b/src/test/ui/unresolved/unresolved-asterisk-imports.stderr
@@ -1,0 +1,9 @@
+error[E0432]: unresolved import `not_existing_crate`
+  --> $DIR/unresolved-asterisk-imports.rs:1:5
+   |
+LL | use not_existing_crate::*;
+   |     ^^^^^^^^^^^^^^^^^^ maybe a missing crate `not_existing_crate`?
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0432`.


### PR DESCRIPTION
Successful merges:

 - #94362 (Add well known values to `--check-cfg` implementation)
 - #94577 (only disable SIMD for doctests in Miri (not for the stdlib build itself))
 - #94595 (Fix invalid `unresolved imports` errors for a single-segment import)
 - #94596 (Delay bug in expr adjustment when check_expr is called multiple times)
 - #94618 (Don't round stack size up for created threads in Windows)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=94362,94577,94595,94596,94618)
<!-- homu-ignore:end -->