### PR TITLE
Check extra function arg exprs even if the fn is not C-variadic

### DIFF
--- a/src/test/ui/tuple/wrong_argument_ice-4.rs
+++ b/src/test/ui/tuple/wrong_argument_ice-4.rs
@@ -1,0 +1,6 @@
+fn main() {
+    (|| {})(|| {
+        //~^ ERROR this function takes 0 arguments but 1 argument was supplied
+        let b = 1;
+    });
+}

--- a/src/test/ui/tuple/wrong_argument_ice-4.stderr
+++ b/src/test/ui/tuple/wrong_argument_ice-4.stderr
@@ -1,0 +1,15 @@
+error[E0057]: this function takes 0 arguments but 1 argument was supplied
+  --> $DIR/wrong_argument_ice-4.rs:2:5
+   |
+LL |       (|| {})(|| {
+   |  _____^^^^^^^_-
+   | |     |
+   | |     expected 0 arguments
+LL | |
+LL | |         let b = 1;
+LL | |     });
+   | |_____- supplied 1 argument
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0057`.


### PR DESCRIPTION
We should still call check_expr on the args that exceed the formal input ty count, so that we have expr types to emit during writeback.

Not sure where this regressed, but it wasn't due to the same root cause as #94334 I think. I thought this might've regressed in #92360, but I think that is in stable, ad the test I provided (which minimizes #94599) passes on stable in playground. Maybe it regressed in #93118.

Anywho, fixes #94599.