### PR TITLE
Imrpove E0617

### DIFF
--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -591,8 +591,7 @@ pub trait PrettyPrinter<'tcx>:
                 p!(")")
             }
             ty::FnDef(def_id, substs) => {
-                let sig = self.tcx().fn_sig(def_id).subst(self.tcx(), substs);
-                p!(print(sig), " {{", print_value_path(def_id, substs), "}}");
+                p!("{{individual function type for ", print_value_path(def_id, substs), "}}");
             }
             ty::FnPtr(ref bare_fn) => p!(print(bare_fn)),
             ty::Infer(infer_ty) => {

--- a/compiler/rustc_typeck/src/structured_errors/missing_cast_for_variadic_arg.rs
+++ b/compiler/rustc_typeck/src/structured_errors/missing_cast_for_variadic_arg.rs
@@ -26,18 +26,28 @@ impl<'tcx> StructuredDiagnostic<'tcx> for MissingCastForVariadicArg<'tcx> {
             &format!("can't pass `{}` to variadic function", self.ty),
             self.code(),
         );
+        
 
         if self.ty.references_error() {
             err.downgrade_to_delayed_bug();
         }
 
         if let Ok(snippet) = self.sess.source_map().span_to_snippet(self.span) {
-            err.span_suggestion(
-                self.span,
-                &format!("cast the value to `{}`", self.cast_ty),
-                format!("{} as {}", snippet, self.cast_ty),
-                Applicability::MachineApplicable,
-            );
+            if self.ty.is_fn() {
+                err.span_suggestion(
+                    self.span,
+                    "cast the value to a function pointer",
+                    format!("{} as {}", snippet, self.cast_ty),
+                    Applicability::MachineApplicable,
+                );
+            } else {
+                err.span_suggestion(
+                    self.span,
+                    &format!("cast the value to `{}`", self.cast_ty),
+                    format!("{} as {}", snippet, self.cast_ty),
+                    Applicability::MachineApplicable,
+                );
+            }
         } else {
             err.help(&format!("cast the value to `{}`", self.cast_ty));
         }

--- a/compiler/rustc_typeck/src/structured_errors/missing_cast_for_variadic_arg.rs
+++ b/compiler/rustc_typeck/src/structured_errors/missing_cast_for_variadic_arg.rs
@@ -39,10 +39,8 @@ impl<'tcx> StructuredDiagnostic<'tcx> for MissingCastForVariadicArg<'tcx> {
                     format!("{} as {}", snippet, self.cast_ty),
                     Applicability::MachineApplicable,
                 )
-                .help("a function item is zero-sized and needs to be casted \
-                    to a function pointer to be used in FFI")
-                .note("for more information on function items, visit \
-                    https://doc.rust-lang.org/reference/types/function-item.html");
+                .help("a function item is zero-sized and needs to be casted to a function pointer to be used in FFI")
+                .note("for more information on function items, visit https://doc.rust-lang.org/reference/types/function-item.html");
             } else {
                 err.span_suggestion(
                     self.span,

--- a/compiler/rustc_typeck/src/structured_errors/missing_cast_for_variadic_arg.rs
+++ b/compiler/rustc_typeck/src/structured_errors/missing_cast_for_variadic_arg.rs
@@ -26,7 +26,6 @@ impl<'tcx> StructuredDiagnostic<'tcx> for MissingCastForVariadicArg<'tcx> {
             &format!("can't pass `{}` to variadic function", self.ty),
             self.code(),
         );
-        
 
         if self.ty.references_error() {
             err.downgrade_to_delayed_bug();

--- a/compiler/rustc_typeck/src/structured_errors/missing_cast_for_variadic_arg.rs
+++ b/compiler/rustc_typeck/src/structured_errors/missing_cast_for_variadic_arg.rs
@@ -38,7 +38,11 @@ impl<'tcx> StructuredDiagnostic<'tcx> for MissingCastForVariadicArg<'tcx> {
                     "cast the value to a function pointer",
                     format!("{} as {}", snippet, self.cast_ty),
                     Applicability::MachineApplicable,
-                );
+                )
+                .help("a function item is zero-sized and needs to be casted \
+                    to a function pointer to be used in FFI")
+                .note("for more information on function items, visit \
+                    https://doc.rust-lang.org/reference/types/function-item.html");
             } else {
                 err.span_suggestion(
                     self.span,


### PR DESCRIPTION
This Pull Request improves the error message for E0617 when dealing with the difference between `fn` types and `fn` pointers.

The current implementation causes all other error messages that utilize the `Display` representation of `Ty` to show `{individual function type for <function path>}`, if the type is a function item, and hence needs further discussion whether to make such change.

We *could* only change such `Display` implementation if we're dealing with `fn` types and `fn` pointers and variadics.

(Possibly) closes #69232