### PR TITLE
Suggest dereferencing non-lval mutable reference on assignment

### DIFF
--- a/compiler/rustc_typeck/src/check/demand.rs
+++ b/compiler/rustc_typeck/src/check/demand.rs
@@ -696,28 +696,13 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         };
 
                         if let Some(hir::Node::Expr(hir::Expr {
-                            kind: hir::ExprKind::Assign(left_expr, ..),
+                            kind: hir::ExprKind::Assign(..),
                             ..
                         })) = self.tcx.hir().find(self.tcx.hir().get_parent_node(expr.hir_id))
                         {
                             if mutability == hir::Mutability::Mut {
-                                // Found the following case:
-                                // fn foo(opt: &mut Option<String>){ opt = None }
-                                //                                   ---   ^^^^
-                                //                                   |     |
-                                //    consider dereferencing here: `*opt`  |
-                                // expected mutable reference, found enum `Option`
-                                if sm.span_to_snippet(left_expr.span).is_ok() {
-                                    return Some((
-                                        left_expr.span.shrink_to_lo(),
-                                        "consider dereferencing here to assign to the mutable \
-                                         borrowed piece of memory"
-                                            .to_string(),
-                                        "*".to_string(),
-                                        Applicability::MachineApplicable,
-                                        true,
-                                    ));
-                                }
+                                // Suppressing this diagnostic, we'll properly print it in `check_expr_assign`
+                                return None;
                             }
                         }
 

--- a/compiler/rustc_typeck/src/check/expr.rs
+++ b/compiler/rustc_typeck/src/check/expr.rs
@@ -1058,6 +1058,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         self.check_lhs_assignable(lhs, "E0070", span, |err| {
             let rhs_ty = self.check_expr(&rhs);
 
+            // FIXME: This could be done any time lhs_ty is DerefMut into something that
+            // is compatible with rhs_ty, and not _just_ `&mut`
             if let ty::Ref(_, lhs_inner_ty, hir::Mutability::Mut) = lhs_ty.kind() {
                 if self.can_coerce(rhs_ty, *lhs_inner_ty) {
                     err.span_suggestion_verbose(

--- a/compiler/rustc_typeck/src/check/op.rs
+++ b/compiler/rustc_typeck/src/check/op.rs
@@ -41,7 +41,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 return_ty
             };
 
-        self.check_lhs_assignable(lhs, "E0067", op.span);
+        self.check_lhs_assignable(lhs, "E0067", op.span, |_| {});
 
         ty
     }

--- a/compiler/rustc_typeck/src/check/op.rs
+++ b/compiler/rustc_typeck/src/check/op.rs
@@ -42,9 +42,14 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             };
 
         self.check_lhs_assignable(lhs, "E0067", op.span, |err| {
-            if let Ref(_, rty, hir::Mutability::Mut) = lhs_ty.kind() {
+            if let Some(lhs_deref_ty) = self.deref_once_mutably_for_diagnostic(lhs_ty) {
                 if self
-                    .lookup_op_method(*rty, Some(rhs_ty), Some(rhs), Op::Binary(op, IsAssign::Yes))
+                    .lookup_op_method(
+                        lhs_deref_ty,
+                        Some(rhs_ty),
+                        Some(rhs),
+                        Op::Binary(op, IsAssign::Yes),
+                    )
                     .is_ok()
                 {
                     // Suppress this error, since we already emitted
@@ -415,23 +420,16 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         (err, missing_trait, use_output)
                     }
                 };
-                if let Ref(_, rty, mutability) = lhs_ty.kind() {
-                    let is_copy =
-                        self.infcx.type_is_copy_modulo_regions(self.param_env, *rty, lhs_expr.span);
-                    // We should suggest `a + b` => `*a + b` if `a` is copy, and suggest
-                    // `a += b` => `*a += b` if a is a mut ref.
-                    // FIXME: This could be done any time lhs_ty is DerefMut into something that
-                    // is compatible with rhs_ty, and not _just_ `&mut` (for IsAssign::Yes).
-                    if ((is_assign == IsAssign::No && is_copy)
-                        || (is_assign == IsAssign::Yes && *mutability == hir::Mutability::Mut))
-                        && self
-                            .lookup_op_method(
-                                *rty,
-                                Some(rhs_ty),
-                                Some(rhs_expr),
-                                Op::Binary(op, is_assign),
-                            )
-                            .is_ok()
+
+                let mut suggest_deref_binop = |lhs_deref_ty: Ty<'tcx>| {
+                    if self
+                        .lookup_op_method(
+                            lhs_deref_ty,
+                            Some(rhs_ty),
+                            Some(rhs_expr),
+                            Op::Binary(op, is_assign),
+                        )
+                        .is_ok()
                     {
                         if let Ok(lstring) = source_map.span_to_snippet(lhs_expr.span) {
                             let msg = &format!(
@@ -441,7 +439,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                                     IsAssign::Yes => "=",
                                     IsAssign::No => "",
                                 },
-                                rty.peel_refs(),
+                                lhs_deref_ty.peel_refs(),
                                 lstring,
                             );
                             err.span_suggestion_verbose(
@@ -451,6 +449,18 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                                 rustc_errors::Applicability::MachineApplicable,
                             );
                         }
+                    }
+                };
+
+                // We should suggest `a + b` => `*a + b` if `a` is copy, and suggest
+                // `a += b` => `*a += b` if a is a mut ref.
+                if is_assign == IsAssign::Yes
+                    && let Some(lhs_deref_ty) = self.deref_once_mutably_for_diagnostic(lhs_ty) {
+                        suggest_deref_binop(lhs_deref_ty);
+                } else if is_assign == IsAssign::No
+                    && let Ref(_, lhs_deref_ty, _) = lhs_ty.kind() {
+                    if self.infcx.type_is_copy_modulo_regions(self.param_env, *lhs_deref_ty, lhs_expr.span) {
+                        suggest_deref_binop(*lhs_deref_ty);
                     }
                 }
                 if let Some(missing_trait) = missing_trait {

--- a/src/test/ui/issues/issue-5239-1.stderr
+++ b/src/test/ui/issues/issue-5239-1.stderr
@@ -5,11 +5,6 @@ LL |     let x = |ref x: isize| { x += 1; };
    |                              -^^^^^
    |                              |
    |                              cannot use `+=` on type `&isize`
-   |
-help: `+=` can be used on `isize`, you can dereference `x`
-   |
-LL |     let x = |ref x: isize| { *x += 1; };
-   |                              +
 
 error: aborting due to previous error
 

--- a/src/test/ui/suggestions/mut-ref-reassignment.stderr
+++ b/src/test/ui/suggestions/mut-ref-reassignment.stderr
@@ -8,7 +8,7 @@ LL |     opt = None;
    |
    = note: expected mutable reference `&mut Option<String>`
                            found enum `Option<_>`
-help: consider dereferencing here to assign to the mutable borrowed piece of memory
+help: consider dereferencing here to assign to the mutably borrowed value
    |
 LL |     *opt = None;
    |     +
@@ -34,7 +34,7 @@ LL |     opt = Some(String::new())
    |
    = note: expected mutable reference `&mut Option<String>`
                            found enum `Option<String>`
-help: consider dereferencing here to assign to the mutable borrowed piece of memory
+help: consider dereferencing here to assign to the mutably borrowed value
    |
 LL |     *opt = Some(String::new())
    |     +

--- a/src/test/ui/typeck/assign-non-lval-derefmut.fixed
+++ b/src/test/ui/typeck/assign-non-lval-derefmut.fixed
@@ -1,0 +1,15 @@
+// run-rustfix
+
+fn main() {
+    let x = std::sync::Mutex::new(1usize);
+    *x.lock().unwrap() = 2;
+    //~^ ERROR invalid left-hand side of assignment
+    *x.lock().unwrap() += 1;
+    //~^ ERROR binary assignment operation `+=` cannot be applied to type `MutexGuard<'_, usize>`
+
+    let mut y = x.lock().unwrap();
+    *y = 2;
+    //~^ ERROR mismatched types
+    *y += 1;
+    //~^ ERROR binary assignment operation `+=` cannot be applied to type `MutexGuard<'_, usize>`
+}

--- a/src/test/ui/typeck/assign-non-lval-derefmut.rs
+++ b/src/test/ui/typeck/assign-non-lval-derefmut.rs
@@ -1,0 +1,15 @@
+// run-rustfix
+
+fn main() {
+    let x = std::sync::Mutex::new(1usize);
+    x.lock().unwrap() = 2;
+    //~^ ERROR invalid left-hand side of assignment
+    x.lock().unwrap() += 1;
+    //~^ ERROR binary assignment operation `+=` cannot be applied to type `MutexGuard<'_, usize>`
+
+    let mut y = x.lock().unwrap();
+    y = 2;
+    //~^ ERROR mismatched types
+    y += 1;
+    //~^ ERROR binary assignment operation `+=` cannot be applied to type `MutexGuard<'_, usize>`
+}

--- a/src/test/ui/typeck/assign-non-lval-derefmut.stderr
+++ b/src/test/ui/typeck/assign-non-lval-derefmut.stderr
@@ -1,0 +1,58 @@
+error[E0070]: invalid left-hand side of assignment
+  --> $DIR/assign-non-lval-derefmut.rs:5:23
+   |
+LL |     x.lock().unwrap() = 2;
+   |     ----------------- ^
+   |     |
+   |     cannot assign to this expression
+   |
+help: consider dereferencing here to assign to the mutably borrowed value
+   |
+LL |     *x.lock().unwrap() = 2;
+   |     +
+
+error[E0368]: binary assignment operation `+=` cannot be applied to type `MutexGuard<'_, usize>`
+  --> $DIR/assign-non-lval-derefmut.rs:7:5
+   |
+LL |     x.lock().unwrap() += 1;
+   |     -----------------^^^^^
+   |     |
+   |     cannot use `+=` on type `MutexGuard<'_, usize>`
+   |
+help: `+=` can be used on `usize`, you can dereference `x.lock().unwrap()`
+   |
+LL |     *x.lock().unwrap() += 1;
+   |     +
+
+error[E0308]: mismatched types
+  --> $DIR/assign-non-lval-derefmut.rs:11:9
+   |
+LL |     let mut y = x.lock().unwrap();
+   |                 ----------------- expected due to this value
+LL |     y = 2;
+   |         ^ expected struct `MutexGuard`, found integer
+   |
+   = note: expected struct `MutexGuard<'_, usize>`
+                found type `{integer}`
+help: consider dereferencing here to assign to the mutably borrowed value
+   |
+LL |     *y = 2;
+   |     +
+
+error[E0368]: binary assignment operation `+=` cannot be applied to type `MutexGuard<'_, usize>`
+  --> $DIR/assign-non-lval-derefmut.rs:13:5
+   |
+LL |     y += 1;
+   |     -^^^^^
+   |     |
+   |     cannot use `+=` on type `MutexGuard<'_, usize>`
+   |
+help: `+=` can be used on `usize`, you can dereference `y`
+   |
+LL |     *y += 1;
+   |     +
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0070, E0308, E0368.
+For more information about an error, try `rustc --explain E0070`.

--- a/src/test/ui/typeck/assign-non-lval-mut-ref.fixed
+++ b/src/test/ui/typeck/assign-non-lval-mut-ref.fixed
@@ -2,6 +2,8 @@
 
 fn main() {
     let mut x = vec![1usize];
-    *x.last_mut().unwrap() = 2usize;
+    *x.last_mut().unwrap() = 2;
     //~^ ERROR invalid left-hand side of assignment
+    *x.last_mut().unwrap() += 1;
+    //~^ ERROR binary assignment operation `+=` cannot be applied to type `&mut usize`
 }

--- a/src/test/ui/typeck/assign-non-lval-mut-ref.fixed
+++ b/src/test/ui/typeck/assign-non-lval-mut-ref.fixed
@@ -6,4 +6,10 @@ fn main() {
     //~^ ERROR invalid left-hand side of assignment
     *x.last_mut().unwrap() += 1;
     //~^ ERROR binary assignment operation `+=` cannot be applied to type `&mut usize`
+
+    let y = x.last_mut().unwrap();
+    *y = 2;
+    //~^ ERROR mismatched types
+    *y += 1;
+    //~^ ERROR binary assignment operation `+=` cannot be applied to type `&mut usize`
 }

--- a/src/test/ui/typeck/assign-non-lval-mut-ref.fixed
+++ b/src/test/ui/typeck/assign-non-lval-mut-ref.fixed
@@ -1,0 +1,7 @@
+// run-rustfix
+
+fn main() {
+    let mut x = vec![1usize];
+    *x.last_mut().unwrap() = 2usize;
+    //~^ ERROR invalid left-hand side of assignment
+}

--- a/src/test/ui/typeck/assign-non-lval-mut-ref.rs
+++ b/src/test/ui/typeck/assign-non-lval-mut-ref.rs
@@ -1,0 +1,7 @@
+// run-rustfix
+
+fn main() {
+    let mut x = vec![1usize];
+    x.last_mut().unwrap() = 2usize;
+    //~^ ERROR invalid left-hand side of assignment
+}

--- a/src/test/ui/typeck/assign-non-lval-mut-ref.rs
+++ b/src/test/ui/typeck/assign-non-lval-mut-ref.rs
@@ -6,4 +6,10 @@ fn main() {
     //~^ ERROR invalid left-hand side of assignment
     x.last_mut().unwrap() += 1;
     //~^ ERROR binary assignment operation `+=` cannot be applied to type `&mut usize`
+
+    let y = x.last_mut().unwrap();
+    y = 2;
+    //~^ ERROR mismatched types
+    y += 1;
+    //~^ ERROR binary assignment operation `+=` cannot be applied to type `&mut usize`
 }

--- a/src/test/ui/typeck/assign-non-lval-mut-ref.rs
+++ b/src/test/ui/typeck/assign-non-lval-mut-ref.rs
@@ -2,6 +2,8 @@
 
 fn main() {
     let mut x = vec![1usize];
-    x.last_mut().unwrap() = 2usize;
+    x.last_mut().unwrap() = 2;
     //~^ ERROR invalid left-hand side of assignment
+    x.last_mut().unwrap() += 1;
+    //~^ ERROR binary assignment operation `+=` cannot be applied to type `&mut usize`
 }

--- a/src/test/ui/typeck/assign-non-lval-mut-ref.stderr
+++ b/src/test/ui/typeck/assign-non-lval-mut-ref.stderr
@@ -1,15 +1,15 @@
 error[E0070]: invalid left-hand side of assignment
-  --> $DIR/issue-93486.rs:3:36
+  --> $DIR/assign-non-lval-mut-ref.rs:5:27
    |
-LL |         vec![].last_mut().unwrap() = 3_u8;
-   |         -------------------------- ^
-   |         |
-   |         cannot assign to this expression
+LL |     x.last_mut().unwrap() = 2usize;
+   |     --------------------- ^
+   |     |
+   |     cannot assign to this expression
    |
 help: consider dereferencing here to assign to the mutable borrowed piece of memory
    |
-LL |         *vec![].last_mut().unwrap() = 3_u8;
-   |         +
+LL |     *x.last_mut().unwrap() = 2usize;
+   |     +
 
 error: aborting due to previous error
 

--- a/src/test/ui/typeck/assign-non-lval-mut-ref.stderr
+++ b/src/test/ui/typeck/assign-non-lval-mut-ref.stderr
@@ -1,16 +1,30 @@
 error[E0070]: invalid left-hand side of assignment
   --> $DIR/assign-non-lval-mut-ref.rs:5:27
    |
-LL |     x.last_mut().unwrap() = 2usize;
+LL |     x.last_mut().unwrap() = 2;
    |     --------------------- ^
    |     |
    |     cannot assign to this expression
    |
 help: consider dereferencing here to assign to the mutable borrowed piece of memory
    |
-LL |     *x.last_mut().unwrap() = 2usize;
+LL |     *x.last_mut().unwrap() = 2;
    |     +
 
-error: aborting due to previous error
+error[E0368]: binary assignment operation `+=` cannot be applied to type `&mut usize`
+  --> $DIR/assign-non-lval-mut-ref.rs:7:5
+   |
+LL |     x.last_mut().unwrap() += 1;
+   |     ---------------------^^^^^
+   |     |
+   |     cannot use `+=` on type `&mut usize`
+   |
+help: `+=` can be used on `usize`, you can dereference `x.last_mut().unwrap()`
+   |
+LL |     *x.last_mut().unwrap() += 1;
+   |     +
 
-For more information about this error, try `rustc --explain E0070`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0070, E0368.
+For more information about an error, try `rustc --explain E0070`.

--- a/src/test/ui/typeck/assign-non-lval-mut-ref.stderr
+++ b/src/test/ui/typeck/assign-non-lval-mut-ref.stderr
@@ -6,7 +6,7 @@ LL |     x.last_mut().unwrap() = 2;
    |     |
    |     cannot assign to this expression
    |
-help: consider dereferencing here to assign to the mutable borrowed piece of memory
+help: consider dereferencing here to assign to the mutably borrowed value
    |
 LL |     *x.last_mut().unwrap() = 2;
    |     +
@@ -24,7 +24,33 @@ help: `+=` can be used on `usize`, you can dereference `x.last_mut().unwrap()`
 LL |     *x.last_mut().unwrap() += 1;
    |     +
 
-error: aborting due to 2 previous errors
+error[E0308]: mismatched types
+  --> $DIR/assign-non-lval-mut-ref.rs:11:9
+   |
+LL |     let y = x.last_mut().unwrap();
+   |             --------------------- expected due to this value
+LL |     y = 2;
+   |         ^ expected `&mut usize`, found integer
+   |
+help: consider dereferencing here to assign to the mutably borrowed value
+   |
+LL |     *y = 2;
+   |     +
 
-Some errors have detailed explanations: E0070, E0368.
+error[E0368]: binary assignment operation `+=` cannot be applied to type `&mut usize`
+  --> $DIR/assign-non-lval-mut-ref.rs:13:5
+   |
+LL |     y += 1;
+   |     -^^^^^
+   |     |
+   |     cannot use `+=` on type `&mut usize`
+   |
+help: `+=` can be used on `usize`, you can dereference `y`
+   |
+LL |     *y += 1;
+   |     +
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0070, E0308, E0368.
 For more information about an error, try `rustc --explain E0070`.

--- a/src/test/ui/typeck/issue-93486.stderr
+++ b/src/test/ui/typeck/issue-93486.stderr
@@ -6,7 +6,7 @@ LL |         vec![].last_mut().unwrap() = 3_u8;
    |         |
    |         cannot assign to this expression
    |
-help: consider dereferencing here to assign to the mutable borrowed piece of memory
+help: consider dereferencing here to assign to the mutably borrowed value
    |
 LL |         *vec![].last_mut().unwrap() = 3_u8;
    |         +


### PR DESCRIPTION
1. Adds deref suggestions for LHS of assignment (or assign-binop) when it implements `DerefMut`
2. Fixes missing deref suggestions for LHS when it isn't a place expr

Fixes #46276
Fixes #93980