### PR TITLE
Fix source code pages scroll

### DIFF
--- a/src/librustdoc/html/static/js/source-script.js
+++ b/src/librustdoc/html/static/js/source-script.js
@@ -149,7 +149,7 @@ function createSourceSidebar() {
 
 var lineNumbersRegex = /^#?(\d+)(?:-(\d+))?$/;
 
-function highlightSourceLines(scrollTo, match) {
+function highlightSourceLines(match) {
     if (typeof match === "undefined") {
         match = window.location.hash.match(lineNumbersRegex);
     }
@@ -170,11 +170,9 @@ function highlightSourceLines(scrollTo, match) {
     if (!elem) {
         return;
     }
-    if (scrollTo) {
-        var x = document.getElementById(from);
-        if (x) {
-            x.scrollIntoView();
-        }
+    var x = document.getElementById(from);
+    if (x) {
+        x.scrollIntoView();
     }
     onEachLazy(document.getElementsByClassName("line-numbers"), function(e) {
         onEachLazy(e.getElementsByTagName("span"), function(i_e) {
@@ -198,7 +196,7 @@ var handleSourceHighlight = (function() {
             y = window.scrollY;
         if (searchState.browserSupportsHistoryApi()) {
             history.replaceState(null, null, "#" + name);
-            highlightSourceLines(true);
+            highlightSourceLines();
         } else {
             location.replace("#" + name);
         }
@@ -230,7 +228,7 @@ var handleSourceHighlight = (function() {
 window.addEventListener("hashchange", function() {
     var match = window.location.hash.match(lineNumbersRegex);
     if (match) {
-        return highlightSourceLines(false, match);
+        return highlightSourceLines(match);
     }
 });
 
@@ -238,7 +236,7 @@ onEachLazy(document.getElementsByClassName("line-numbers"), function(el) {
     el.addEventListener("click", handleSourceHighlight);
 });
 
-highlightSourceLines(true);
+highlightSourceLines();
 
 window.createSourceSidebar = createSourceSidebar;
 })();

--- a/src/test/rustdoc-gui/source-anchor-scroll.goml
+++ b/src/test/rustdoc-gui/source-anchor-scroll.goml
@@ -1,0 +1,20 @@
+// We check that when the anchor changes and is output of the displayed content,
+// the page is scrolled to it.
+goto: file://|DOC_PATH|/src/link_to_definition/lib.rs.html
+
+// We reduce the window size to make it easier to make an element "out of the page".
+size: (600, 800)
+// We check that the scroll is at the top first.
+assert-property: ("html", {"scrollTop": "0"})
+
+click: '//a[text() = "barbar"]'
+assert-property: ("html", {"scrollTop": "125"})
+click: '//a[text() = "bar"]'
+assert-property: ("html", {"scrollTop": "166"})
+click: '//a[text() = "sub_fn"]'
+assert-property: ("html", {"scrollTop": "53"})
+
+// We now check that clicking on lines doesn't change the scroll
+// Extra information: the "sub_fn" function header is on line 1.
+click: '//*[@id="6"]'
+assert-property: ("html", {"scrollTop": "53"})

--- a/src/test/rustdoc-gui/src/link_to_definition/lib.rs
+++ b/src/test/rustdoc-gui/src/link_to_definition/lib.rs
@@ -1,6 +1,35 @@
+pub fn sub_fn() {
+    barbar();
+}
+fn barbar() {
+    bar(vec![], vec![], vec![], vec![], Bar { a: "a".into(), b: 0 });
+}
+
 pub struct Bar {
     pub a: String,
     pub b: u32,
 }
 
 pub fn foo(_b: &Bar) {}
+
+// The goal now is to add
+// a lot of lines so
+// that the next content
+// will be out of the screen
+// to allow us to test that
+// if the anchor changes to
+// something outside of the
+// current view, it'll
+// scroll to it as expected.
+
+// More filling content.
+
+pub fn bar(
+  _a: Vec<String>,
+  _b: Vec<String>,
+  _c: Vec<String>,
+  _d: Vec<String>,
+  _e: Bar,
+) {
+    sub_fn();
+}


### PR DESCRIPTION
To reproduce the bug, go to https://doc.rust-lang.org/nightly/nightly-rustc/src/rustc_ast/ast.rs.html#537-541 and click on the `Path` link. The page won't scroll to the content.

r? @Urgau 