### PR TITLE
do not attempt to open cgroup files under Miri

### DIFF
--- a/library/std/src/sys/unix/thread.rs
+++ b/library/std/src/sys/unix/thread.rs
@@ -384,6 +384,11 @@ fn cgroup2_quota() -> usize {
     use crate::path::PathBuf;
 
     let mut quota = usize::MAX;
+    if cfg!(miri) {
+        // Attempting to open a file fails under default flags due to isolation.
+        // And Miri does not have parallelism anyway.
+        return quota;
+    }
 
     let _: Option<()> = try {
         let mut buf = Vec::with_capacity(128);


### PR DESCRIPTION
Since https://github.com/rust-lang/rust/pull/92697, `cargo miri test` always fails under default flags, and one would have to use `MIRIFLAGS=-Zmiri-disable-isolation cargo miri test` instead. This PR fixes that problem.

Cc @the8472 @joshtriplett 