### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -449,6 +449,16 @@ impl<'a> Parser<'a> {
         if end.is_doc_comment() {
             err.span_label(end.span, "this doc comment doesn't document anything");
         }
+        if end.meta_kind().is_some() {
+            if self.token.kind == TokenKind::Semi {
+                err.span_suggestion_verbose(
+                    self.token.span,
+                    "consider removing this semicolon",
+                    String::new(),
+                    Applicability::MaybeIncorrect,
+                );
+            }
+        }
         if let [.., penultimate, _] = attrs {
             err.span_label(start.span.to(penultimate.span), "other attributes here");
         }

--- a/library/std/src/sys/unix/thread.rs
+++ b/library/std/src/sys/unix/thread.rs
@@ -384,6 +384,11 @@ fn cgroup2_quota() -> usize {
     use crate::path::PathBuf;
 
     let mut quota = usize::MAX;
+    if cfg!(miri) {
+        // Attempting to open a file fails under default flags due to isolation.
+        // And Miri does not have parallelism anyway.
+        return quota;
+    }
 
     let _: Option<()> = try {
         let mut buf = Vec::with_capacity(128);

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -73,7 +73,8 @@ Tier Policy.
 
 All tier 2 targets with host tools support the full standard library.
 
-**NOTE:** Tier 2 targets currently do not build the `rust-docs` component.
+**NOTE:** The `rust-docs` component is not usually built for tier 2 targets,
+so Rustup may install the documentation for a similar tier 1 target instead.
 
 target | notes
 -------|-------
@@ -114,7 +115,8 @@ The `std` column in the table below has the following meanings:
 
 [`no_std`]: https://rust-embedded.github.io/book/intro/no-std.html
 
-**NOTE:** Tier 2 targets currently do not build the `rust-docs` component.
+**NOTE:** The `rust-docs` component is not usually built for tier 2 targets,
+so Rustup may install the documentation for a similar tier 1 target instead.
 
 target | std | notes
 -------|:---:|-------

--- a/src/librustdoc/html/static/js/source-script.js
+++ b/src/librustdoc/html/static/js/source-script.js
@@ -149,7 +149,7 @@ function createSourceSidebar() {
 
 var lineNumbersRegex = /^#?(\d+)(?:-(\d+))?$/;
 
-function highlightSourceLines(scrollTo, match) {
+function highlightSourceLines(match) {
     if (typeof match === "undefined") {
         match = window.location.hash.match(lineNumbersRegex);
     }
@@ -170,11 +170,9 @@ function highlightSourceLines(scrollTo, match) {
     if (!elem) {
         return;
     }
-    if (scrollTo) {
-        var x = document.getElementById(from);
-        if (x) {
-            x.scrollIntoView();
-        }
+    var x = document.getElementById(from);
+    if (x) {
+        x.scrollIntoView();
     }
     onEachLazy(document.getElementsByClassName("line-numbers"), function(e) {
         onEachLazy(e.getElementsByTagName("span"), function(i_e) {
@@ -198,7 +196,7 @@ var handleSourceHighlight = (function() {
             y = window.scrollY;
         if (searchState.browserSupportsHistoryApi()) {
             history.replaceState(null, null, "#" + name);
-            highlightSourceLines(true);
+            highlightSourceLines();
         } else {
             location.replace("#" + name);
         }
@@ -230,7 +228,7 @@ var handleSourceHighlight = (function() {
 window.addEventListener("hashchange", function() {
     var match = window.location.hash.match(lineNumbersRegex);
     if (match) {
-        return highlightSourceLines(false, match);
+        return highlightSourceLines(match);
     }
 });
 
@@ -238,7 +236,7 @@ onEachLazy(document.getElementsByClassName("line-numbers"), function(el) {
     el.addEventListener("click", handleSourceHighlight);
 });
 
-highlightSourceLines(true);
+highlightSourceLines();
 
 window.createSourceSidebar = createSourceSidebar;
 })();

--- a/src/test/rustdoc-gui/source-anchor-scroll.goml
+++ b/src/test/rustdoc-gui/source-anchor-scroll.goml
@@ -1,0 +1,20 @@
+// We check that when the anchor changes and is output of the displayed content,
+// the page is scrolled to it.
+goto: file://|DOC_PATH|/src/link_to_definition/lib.rs.html
+
+// We reduce the window size to make it easier to make an element "out of the page".
+size: (600, 800)
+// We check that the scroll is at the top first.
+assert-property: ("html", {"scrollTop": "0"})
+
+click: '//a[text() = "barbar"]'
+assert-property: ("html", {"scrollTop": "125"})
+click: '//a[text() = "bar"]'
+assert-property: ("html", {"scrollTop": "166"})
+click: '//a[text() = "sub_fn"]'
+assert-property: ("html", {"scrollTop": "53"})
+
+// We now check that clicking on lines doesn't change the scroll
+// Extra information: the "sub_fn" function header is on line 1.
+click: '//*[@id="6"]'
+assert-property: ("html", {"scrollTop": "53"})

--- a/src/test/rustdoc-gui/src/link_to_definition/lib.rs
+++ b/src/test/rustdoc-gui/src/link_to_definition/lib.rs
@@ -1,6 +1,35 @@
+pub fn sub_fn() {
+    barbar();
+}
+fn barbar() {
+    bar(vec![], vec![], vec![], vec![], Bar { a: "a".into(), b: 0 });
+}
+
 pub struct Bar {
     pub a: String,
     pub b: u32,
 }
 
 pub fn foo(_b: &Bar) {}
+
+// The goal now is to add
+// a lot of lines so
+// that the next content
+// will be out of the screen
+// to allow us to test that
+// if the anchor changes to
+// something outside of the
+// current view, it'll
+// scroll to it as expected.
+
+// More filling content.
+
+pub fn bar(
+  _a: Vec<String>,
+  _b: Vec<String>,
+  _c: Vec<String>,
+  _d: Vec<String>,
+  _e: Bar,
+) {
+    sub_fn();
+}

--- a/src/test/ui/parser/attr-with-a-semicolon.rs
+++ b/src/test/ui/parser/attr-with-a-semicolon.rs
@@ -1,0 +1,4 @@
+#[derive(Debug, Clone)]; //~ERROR expected item after attributes
+struct Foo;
+
+fn main() {}

--- a/src/test/ui/parser/attr-with-a-semicolon.stderr
+++ b/src/test/ui/parser/attr-with-a-semicolon.stderr
@@ -1,0 +1,14 @@
+error: expected item after attributes
+  --> $DIR/attr-with-a-semicolon.rs:1:1
+   |
+LL | #[derive(Debug, Clone)];
+   | ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider removing this semicolon
+   |
+LL - #[derive(Debug, Clone)];
+LL + #[derive(Debug, Clone)]
+   | 
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Successful merges:

 - #94630 (Update note about tier 2 docs.)
 - #94633 (Suggest removing a semicolon after derive attributes)
 - #94642 (Fix source code pages scroll)
 - #94645 (do not attempt to open cgroup files under Miri)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=94630,94633,94642,94645)
<!-- homu-ignore:end -->