### PR TITLE
Unix path::absolute: Fix leading "." component

### DIFF
--- a/library/std/src/path/tests.rs
+++ b/library/std/src/path/tests.rs
@@ -1719,6 +1719,11 @@ fn test_unix_absolute() {
     assert_eq!(absolute("///a/b/c").unwrap(), Path::new("/a/b/c"));
     assert_eq!(absolute("/a/b/c/").unwrap(), Path::new("/a/b/c/"));
     assert_eq!(absolute("/a/./b/../c/.././..").unwrap(), Path::new("/a/b/../c/../.."));
+
+    // Test leading `.` and `..` components
+    let curdir = crate::env::current_dir().unwrap();
+    assert_eq!(absolute("./a").unwrap().as_os_str(), curdir.join("a").as_os_str());
+    assert_eq!(absolute("../a").unwrap().as_os_str(), curdir.join("../a").as_os_str()); // return /pwd/../a
 }
 
 #[test]

--- a/library/std/src/path/tests.rs
+++ b/library/std/src/path/tests.rs
@@ -1710,15 +1710,18 @@ fn test_unix_absolute() {
     let relative = "a/b";
     let mut expected = crate::env::current_dir().unwrap();
     expected.push(relative);
-    assert_eq!(absolute(relative).unwrap(), expected);
+    assert_eq!(absolute(relative).unwrap().as_os_str(), expected.as_os_str());
 
     // Test how components are collected.
-    assert_eq!(absolute("/a/b/c").unwrap(), Path::new("/a/b/c"));
-    assert_eq!(absolute("/a//b/c").unwrap(), Path::new("/a/b/c"));
-    assert_eq!(absolute("//a/b/c").unwrap(), Path::new("//a/b/c"));
-    assert_eq!(absolute("///a/b/c").unwrap(), Path::new("/a/b/c"));
-    assert_eq!(absolute("/a/b/c/").unwrap(), Path::new("/a/b/c/"));
-    assert_eq!(absolute("/a/./b/../c/.././..").unwrap(), Path::new("/a/b/../c/../.."));
+    assert_eq!(absolute("/a/b/c").unwrap().as_os_str(), Path::new("/a/b/c").as_os_str());
+    assert_eq!(absolute("/a//b/c").unwrap().as_os_str(), Path::new("/a/b/c").as_os_str());
+    assert_eq!(absolute("//a/b/c").unwrap().as_os_str(), Path::new("//a/b/c").as_os_str());
+    assert_eq!(absolute("///a/b/c").unwrap().as_os_str(), Path::new("/a/b/c").as_os_str());
+    assert_eq!(absolute("/a/b/c/").unwrap().as_os_str(), Path::new("/a/b/c/").as_os_str());
+    assert_eq!(
+        absolute("/a/./b/../c/.././..").unwrap().as_os_str(),
+        Path::new("/a/b/../c/../..").as_os_str()
+    );
 
     // Test leading `.` and `..` components
     let curdir = crate::env::current_dir().unwrap();

--- a/library/std/src/sys/unix/path.rs
+++ b/library/std/src/sys/unix/path.rs
@@ -28,7 +28,8 @@ pub(crate) fn absolute(path: &Path) -> io::Result<PathBuf> {
     // See 4.13 Pathname Resolution, IEEE Std 1003.1-2017
     // https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap04.html#tag_04_13
 
-    let mut components = path.components();
+    // Get the components, skipping the redundant leading "." component if it exists.
+    let mut components = path.strip_prefix(".").unwrap_or(path).components();
     let path_os = path.as_os_str().bytes();
 
     let mut normalized = if path.is_absolute() {


### PR DESCRIPTION
Testing leading `.` and `..` components were missing from the unix tests.

This PR adds them and fixes the leading `.` case. It also fixes the test cases so that they do an exact comparison.

This problem reported by @axetroy