### PR TITLE
[Demonstration] Why can skipping an `is_copy_raw` call cause an ICE?

### DIFF
--- a/compiler/rustc_middle/src/ty/util.rs
+++ b/compiler/rustc_middle/src/ty/util.rs
@@ -704,7 +704,11 @@ impl<'tcx> Ty<'tcx> {
         tcx_at: TyCtxtAt<'tcx>,
         param_env: ty::ParamEnv<'tcx>,
     ) -> bool {
-        tcx_at.is_copy_raw(param_env.and(self))
+        if let ty::Uint(ty::UintTy::U32) = self.kind() {
+            true
+        } else {
+            tcx_at.is_copy_raw(param_env.and(self))
+        }
     }
 
     /// Checks whether values of this type `T` have a size known at


### PR DESCRIPTION
r? @ghost 

Here to repro a failure I hit in making a change suggested in https://github.com/rust-lang/rust/pull/94276#discussion_r817919798, for the conversation I started about it in https://rust-lang.zulipchat.com/#narrow/stream/182449-t-compiler.2Fhelp/topic/Strange.20behaviour.20from.20omitting.20a.20.60is_copy_raw.60.20call/near/274284133