### PR TITLE
Implement Write trait for MaybeUninit<u8>

### DIFF
--- a/library/std/src/io/impls/tests.rs
+++ b/library/std/src/io/impls/tests.rs
@@ -1,4 +1,5 @@
 use crate::io::prelude::*;
+use crate::mem::MaybeUninit;
 
 #[bench]
 fn bench_read_slice(b: &mut test::Bencher) {
@@ -44,7 +45,21 @@ fn bench_read_vec(b: &mut test::Bencher) {
 
 #[bench]
 fn bench_write_vec(b: &mut test::Bencher) {
-    let mut buf = Vec::with_capacity(1024);
+    let mut buf = Vec::<u8>::with_capacity(1024);
+    let src = [5; 128];
+
+    b.iter(|| {
+        let mut wr = &mut buf[..];
+        for _ in 0..8 {
+            let _ = wr.write_all(&src);
+            test::black_box(&wr);
+        }
+    })
+}
+
+#[bench]
+fn bench_write_maybeuninit(b: &mut test::Bencher) {
+    let mut buf = [MaybeUninit::<u8>::uninit(); 1024];
     let src = [5; 128];
 
     b.iter(|| {


### PR DESCRIPTION
This PR makes it possible to write something like the following:
```rust
let mut buf = [MaybeUninit::<u8>::uninit(); 20];
let written = {
    let slice = buf.as_mut_slice();
    write!(slice, "{}", u64_int).unwrap();
    buf.len() - slice.len()
};
let buf: [u8] = unsafe { mem::transmute(buf[..written]) };
```