### PR TITLE
Return early to fix ICE

### DIFF
--- a/compiler/rustc_middle/src/ty/diagnostics.rs
+++ b/compiler/rustc_middle/src/ty/diagnostics.rs
@@ -325,12 +325,6 @@ pub fn suggest_constraining_type_params<'a>(
             }
         }
 
-        // This check is always run on non-valid code
-        // to not trigger ICE
-        if constraints.is_empty() && suggestions.is_empty() {
-            return false;
-        }
-
         if constraints.is_empty() {
             continue;
         }
@@ -518,7 +512,7 @@ pub fn suggest_constraining_type_params<'a>(
         };
 
         err.span_suggestion_verbose(span, msg, suggestion, applicability);
-    } else {
+    } else if suggestions.len() > 1 {
         err.multipart_suggestion_verbose(
             "consider restricting type parameters",
             suggestions.into_iter().map(|(span, suggestion, _)| (span, suggestion)).collect(),

--- a/compiler/rustc_middle/src/ty/diagnostics.rs
+++ b/compiler/rustc_middle/src/ty/diagnostics.rs
@@ -325,6 +325,12 @@ pub fn suggest_constraining_type_params<'a>(
             }
         }
 
+        // This check is always run on non-valid code
+        // to not trigger ICE
+        if constraints.is_empty() && suggestions.is_empty() {
+            return false;
+        }
+
         if constraints.is_empty() {
             continue;
         }

--- a/src/test/ui/suggestions/constrain-suggest-ice.rs
+++ b/src/test/ui/suggestions/constrain-suggest-ice.rs
@@ -1,0 +1,11 @@
+struct Bug<S>{ //~ ERROR parameter `S` is never used [E0392]
+    A: [(); {
+        let x: [u8; Self::W] = [0; Self::W]; //~ ERROR generic `Self` types are currently not permitted in anonymous constants
+        //~^ ERROR generic `Self` types are currently not permitted in anonymous constants
+        //~^^ ERROR the size for values of type `S` cannot be known at compilation time [E0277]
+        F //~ ERROR cannot find value `F` in this scope [E0425]
+    }
+} //~ ERROR mismatched closing delimiter: `}`
+//~^ ERROR mismatched closing delimiter: `}`
+
+fn main() {}

--- a/src/test/ui/suggestions/constrain-suggest-ice.stderr
+++ b/src/test/ui/suggestions/constrain-suggest-ice.stderr
@@ -1,0 +1,81 @@
+error: mismatched closing delimiter: `}`
+  --> $DIR/constrain-suggest-ice.rs:2:8
+   |
+LL | struct Bug<S>{
+   |              - closing delimiter possibly meant for this
+LL |     A: [(); {
+   |        ^ unclosed delimiter
+...
+LL | }
+   | ^ mismatched closing delimiter
+
+error: mismatched closing delimiter: `}`
+  --> $DIR/constrain-suggest-ice.rs:2:8
+   |
+LL | struct Bug<S>{
+   |              - closing delimiter possibly meant for this
+LL |     A: [(); {
+   |        ^ unclosed delimiter
+...
+LL | }
+   | ^ mismatched closing delimiter
+
+error[E0425]: cannot find value `F` in this scope
+  --> $DIR/constrain-suggest-ice.rs:6:9
+   |
+LL |         F
+   |         ^
+   |
+help: a local variable with a similar name exists
+   |
+LL |         x
+   |         ~
+help: you might be missing a type parameter
+   |
+LL | struct Bug<S, F>{
+   |             +++
+
+error: generic `Self` types are currently not permitted in anonymous constants
+  --> $DIR/constrain-suggest-ice.rs:3:21
+   |
+LL |         let x: [u8; Self::W] = [0; Self::W];
+   |                     ^^^^
+
+error: generic `Self` types are currently not permitted in anonymous constants
+  --> $DIR/constrain-suggest-ice.rs:3:36
+   |
+LL |         let x: [u8; Self::W] = [0; Self::W];
+   |                                    ^^^^
+
+error[E0277]: the size for values of type `S` cannot be known at compilation time
+  --> $DIR/constrain-suggest-ice.rs:3:36
+   |
+LL | struct Bug<S>{
+   |            - this type parameter needs to be `std::marker::Sized`
+LL |     A: [(); {
+LL |         let x: [u8; Self::W] = [0; Self::W];
+   |                                    ^^^^^^^ doesn't have a size known at compile-time
+   |
+note: required by a bound in `Bug`
+  --> $DIR/constrain-suggest-ice.rs:1:12
+   |
+LL | struct Bug<S>{
+   |            ^ required by this bound in `Bug`
+help: consider relaxing the implicit `Sized` restriction
+   |
+LL | struct Bug<S: ?Sized>{
+   |             ++++++++
+
+error[E0392]: parameter `S` is never used
+  --> $DIR/constrain-suggest-ice.rs:1:12
+   |
+LL | struct Bug<S>{
+   |            ^ unused parameter
+   |
+   = help: consider removing `S`, referring to it in a field, or using a marker such as `PhantomData`
+   = help: if you intended `S` to be a const parameter, use `const S: usize` instead
+
+error: aborting due to 7 previous errors
+
+Some errors have detailed explanations: E0277, E0392, E0425.
+For more information about an error, try `rustc --explain E0277`.


### PR DESCRIPTION
This fixes #94627, ICE happens because compiler tries to suggest constraining type parameter but the only constraint is implicit `std::Sized` one, so it gets removed and there is nothing to suggest resulting in ICE.

