### PR TITLE
Enable `close_read_wakes_up` test on Windows

### DIFF
--- a/library/std/src/net/tcp/tests.rs
+++ b/library/std/src/net/tcp/tests.rs
@@ -508,7 +508,6 @@ fn close_readwrite_smoke() {
 }
 
 #[test]
-#[cfg(unix)] // test doesn't work on Windows, see #31657
 fn close_read_wakes_up() {
     each_ip(&mut |addr| {
         let a = t!(TcpListener::bind(&addr));


### PR DESCRIPTION
I wonder if we could/should try enabling this again? It was closed by #38867 due to #31657. I've tried running this test (along with other tests) on my machine a number of times and haven't seen this fail yet,

Caveat: the worst that can happen is this succeeds initially but then causes random hangs in CI. This is not a great failure mode and would be a reason not to do this.

If this does work out, closes #39006

r? @Mark-Simulacrum