### PR TITLE
Statically compile libstdc++ everywhere if asked

### DIFF
--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -259,18 +259,6 @@ impl Step for Llvm {
             cfg.define("LLVM_LINK_LLVM_DYLIB", "ON");
         }
 
-        // For distribution we want the LLVM tools to be *statically* linked to libstdc++.
-        // We also do this if the user explicitly requested static libstdc++.
-        if builder.config.llvm_tools_enabled || builder.config.llvm_static_stdcpp {
-            if !target.contains("msvc") && !target.contains("netbsd") {
-                if target.contains("apple") {
-                    ldflags.push_all("-static-libstdc++");
-                } else {
-                    ldflags.push_all("-Wl,-Bsymbolic -static-libstdc++");
-                }
-            }
-        }
-
         if target.starts_with("riscv") && !target.contains("freebsd") {
             // RISC-V GCC erroneously requires linking against
             // `libatomic` when using 1-byte and 2-byte C++
@@ -574,6 +562,18 @@ fn configure_cmake(
 
     if let Some(flags) = get_var("LDFLAGS", &builder.config.build.triple, &target.triple) {
         ldflags.push_all(&flags);
+    }
+
+    // For distribution we want the LLVM tools to be *statically* linked to libstdc++.
+    // We also do this if the user explicitly requested static libstdc++.
+    if builder.config.llvm_tools_enabled || builder.config.llvm_static_stdcpp {
+        if !target.contains("msvc") && !target.contains("netbsd") {
+            if target.contains("apple") {
+                ldflags.push_all("-static-libstdc++");
+            } else {
+                ldflags.push_all("-Wl,-Bsymbolic -static-libstdc++");
+            }
+        }
     }
 
     cfg.define("CMAKE_SHARED_LINKER_FLAGS", &ldflags.shared);


### PR DESCRIPTION
PR #93918 made it so that `-static-libstdc++` was only set in one place,
and was only set during linking, but accidentally also made it so that
it is no longer passed when building LLD, only when building LLVM
itself. This moves the logic for setting `-static-libstdc++` in the
linker flags to `configure_cmake` so that it takes effect for all CMake
invocations in `native.rs`.

As a side-effect, this also causes libstdc++ to be statically compiled
into sanitizers, whereas previously the `llvm-static-stdcpp` flag had no
effect on sanitizers. It also makes it so that LLD will be compiled
statically if `llvm-tools-enabled` is set, even though previously it was
only linked statically if `llvm-static-stdcpp` was set explicitly. Both
of these seem like they match expected behavior than what was there
prior to #93918.