### PR TITLE
Only emit pointer-like metadata for `Box<T, A>` when `A` is ZST

### DIFF
--- a/src/test/ui/debuginfo/debuginfo-box-with-large-allocator.rs
+++ b/src/test/ui/debuginfo/debuginfo-box-with-large-allocator.rs
@@ -1,0 +1,23 @@
+// build-pass
+// compile-flags: -Cdebuginfo=2
+// fixes issue #94725
+
+#![feature(allocator_api)]
+
+use std::alloc::{AllocError, Allocator, Layout};
+use std::ptr::NonNull;
+
+struct ZST;
+
+unsafe impl Allocator for &ZST {
+    fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+        todo!()
+    }
+    unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
+        todo!()
+    }
+}
+
+fn main() {
+    let _ = Box::<i32, &ZST>::new_in(43, &ZST);
+}

--- a/src/test/ui/debuginfo/debuginfo_with_uninhabitable_field_and_unsized.rs
+++ b/src/test/ui/debuginfo/debuginfo_with_uninhabitable_field_and_unsized.rs
@@ -1,4 +1,4 @@
-// check-pass
+// build-pass
 // compile-flags: -Cdebuginfo=2
 // fixes issue #94149
 


### PR DESCRIPTION
Basically copy the change in #94043, but for debuginfo.

r? @michaelwoerister 

Fixes #94725