### PR TITLE
Reverted atomic_mut_ptr feature removal causing compilation break

### DIFF
--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -231,6 +231,7 @@
 #![feature(assert_matches)]
 #![feature(associated_type_bounds)]
 #![feature(async_iterator)]
+#![feature(atomic_mut_ptr)]
 #![feature(bench_black_box)]
 #![feature(box_syntax)]
 #![feature(c_unwind)]


### PR DESCRIPTION
Fixes a regression introduced as part of https://github.com/rust-lang/rust/pull/94546

Std no longer compiles on nightly while using the following commnd:

export RUSTFLAGS='-C target-feature=+atomics,+bulk-memory' 
cargo build --target wasm32-unknown-unknown -Z build-std=panic_abort,std

I can help add tests to avoid future breaks but i couldn't understand the test framework