### PR TITLE
Make `Encodable` and `Encoder` infallible.

### DIFF
--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -31,7 +31,7 @@ use rustc_data_structures::stack::ensure_sufficient_stack;
 use rustc_data_structures::sync::Lrc;
 use rustc_data_structures::thin_vec::ThinVec;
 use rustc_macros::HashStable_Generic;
-use rustc_serialize::{self, Decoder, Encoder};
+use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
 use rustc_span::source_map::{respan, Spanned};
 use rustc_span::symbol::{kw, sym, Ident, Symbol};
 use rustc_span::{Span, DUMMY_SP};
@@ -2472,11 +2472,11 @@ rustc_index::newtype_index! {
     }
 }
 
-impl<S: Encoder> rustc_serialize::Encodable<S> for AttrId {
+impl<S: Encoder> Encodable<S> for AttrId {
     fn encode(&self, _s: &mut S) {}
 }
 
-impl<D: Decoder> rustc_serialize::Decodable<D> for AttrId {
+impl<D: Decoder> Decodable<D> for AttrId {
     fn decode(_: &mut D) -> AttrId {
         crate::attr::mk_attr_id()
     }

--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -2473,9 +2473,7 @@ rustc_index::newtype_index! {
 }
 
 impl<S: Encoder> rustc_serialize::Encodable<S> for AttrId {
-    fn encode(&self, _s: &mut S) -> Result<(), S::Error> {
-        Ok(())
-    }
+    fn encode(&self, _s: &mut S) {}
 }
 
 impl<D: Decoder> rustc_serialize::Decodable<D> for AttrId {

--- a/compiler/rustc_ast/src/ptr.rs
+++ b/compiler/rustc_ast/src/ptr.rs
@@ -121,8 +121,8 @@ impl<D: Decoder, T: 'static + Decodable<D>> Decodable<D> for P<T> {
 }
 
 impl<S: Encoder, T: Encodable<S>> Encodable<S> for P<T> {
-    fn encode(&self, s: &mut S) -> Result<(), S::Error> {
-        (**self).encode(s)
+    fn encode(&self, s: &mut S) {
+        (**self).encode(s);
     }
 }
 
@@ -191,8 +191,8 @@ impl<'a, T> IntoIterator for &'a P<[T]> {
 }
 
 impl<S: Encoder, T: Encodable<S>> Encodable<S> for P<[T]> {
-    fn encode(&self, s: &mut S) -> Result<(), S::Error> {
-        Encodable::encode(&**self, s)
+    fn encode(&self, s: &mut S) {
+        Encodable::encode(&**self, s);
     }
 }
 

--- a/compiler/rustc_ast/src/tokenstream.rs
+++ b/compiler/rustc_ast/src/tokenstream.rs
@@ -142,9 +142,9 @@ impl fmt::Debug for LazyTokenStream {
 }
 
 impl<S: Encoder> Encodable<S> for LazyTokenStream {
-    fn encode(&self, s: &mut S) -> Result<(), S::Error> {
+    fn encode(&self, s: &mut S) {
         // Used by AST json printing.
-        Encodable::encode(&self.create_token_stream(), s)
+        Encodable::encode(&self.create_token_stream(), s);
     }
 }
 

--- a/compiler/rustc_codegen_ssa/src/lib.rs
+++ b/compiler/rustc_codegen_ssa/src/lib.rs
@@ -29,7 +29,7 @@ use rustc_middle::dep_graph::WorkProduct;
 use rustc_middle::middle::dependency_format::Dependencies;
 use rustc_middle::middle::exported_symbols::SymbolExportKind;
 use rustc_middle::ty::query::{ExternProviders, Providers};
-use rustc_serialize::{opaque, Decodable, Decoder, Encoder};
+use rustc_serialize::{opaque, Decodable, Decoder, Encodable, Encoder};
 use rustc_session::config::{CrateType, OutputFilenames, OutputType, RUST_CGU_EXT};
 use rustc_session::cstore::{self, CrateSource};
 use rustc_session::utils::NativeLibKind;
@@ -204,13 +204,13 @@ const RUSTC_VERSION: Option<&str> = option_env!("CFG_VERSION");
 impl CodegenResults {
     pub fn serialize_rlink(codegen_results: &CodegenResults) -> Vec<u8> {
         let mut encoder = opaque::Encoder::new();
-        encoder.emit_raw_bytes(RLINK_MAGIC).unwrap();
+        encoder.emit_raw_bytes(RLINK_MAGIC);
         // `emit_raw_bytes` is used to make sure that the version representation does not depend on
         // Encoder's inner representation of `u32`.
-        encoder.emit_raw_bytes(&RLINK_VERSION.to_be_bytes()).unwrap();
-        encoder.emit_str(RUSTC_VERSION.unwrap()).unwrap();
-        rustc_serialize::Encodable::encode(codegen_results, &mut encoder).unwrap();
-        encoder.into_inner()
+        encoder.emit_raw_bytes(&RLINK_VERSION.to_be_bytes());
+        encoder.emit_str(RUSTC_VERSION.unwrap());
+        Encodable::encode(codegen_results, &mut encoder);
+        encoder.finish().unwrap()
     }
 
     pub fn deserialize_rlink(data: Vec<u8>) -> Result<Self, String> {

--- a/compiler/rustc_codegen_ssa/src/lib.rs
+++ b/compiler/rustc_codegen_ssa/src/lib.rs
@@ -209,8 +209,6 @@ impl CodegenResults {
         // Encoder's inner representation of `u32`.
         encoder.emit_raw_bytes(&RLINK_VERSION.to_be_bytes()).unwrap();
         encoder.emit_str(RUSTC_VERSION.unwrap()).unwrap();
-
-        let mut encoder = rustc_serialize::opaque::Encoder::new(encoder.into_inner());
         rustc_serialize::Encodable::encode(codegen_results, &mut encoder).unwrap();
         encoder.into_inner()
     }

--- a/compiler/rustc_codegen_ssa/src/lib.rs
+++ b/compiler/rustc_codegen_ssa/src/lib.rs
@@ -203,7 +203,7 @@ const RUSTC_VERSION: Option<&str> = option_env!("CFG_VERSION");
 
 impl CodegenResults {
     pub fn serialize_rlink(codegen_results: &CodegenResults) -> Vec<u8> {
-        let mut encoder = opaque::Encoder::new(vec![]);
+        let mut encoder = opaque::Encoder::new();
         encoder.emit_raw_bytes(RLINK_MAGIC).unwrap();
         // `emit_raw_bytes` is used to make sure that the version representation does not depend on
         // Encoder's inner representation of `u32`.

--- a/compiler/rustc_codegen_ssa/src/lib.rs
+++ b/compiler/rustc_codegen_ssa/src/lib.rs
@@ -29,7 +29,8 @@ use rustc_middle::dep_graph::WorkProduct;
 use rustc_middle::middle::dependency_format::Dependencies;
 use rustc_middle::middle::exported_symbols::SymbolExportKind;
 use rustc_middle::ty::query::{ExternProviders, Providers};
-use rustc_serialize::{opaque, Decodable, Decoder, Encodable, Encoder};
+use rustc_serialize::opaque::{MemDecoder, MemEncoder};
+use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
 use rustc_session::config::{CrateType, OutputFilenames, OutputType, RUST_CGU_EXT};
 use rustc_session::cstore::{self, CrateSource};
 use rustc_session::utils::NativeLibKind;
@@ -203,7 +204,7 @@ const RUSTC_VERSION: Option<&str> = option_env!("CFG_VERSION");
 
 impl CodegenResults {
     pub fn serialize_rlink(codegen_results: &CodegenResults) -> Vec<u8> {
-        let mut encoder = opaque::Encoder::new();
+        let mut encoder = MemEncoder::new();
         encoder.emit_raw_bytes(RLINK_MAGIC);
         // `emit_raw_bytes` is used to make sure that the version representation does not depend on
         // Encoder's inner representation of `u32`.
@@ -230,7 +231,7 @@ impl CodegenResults {
             return Err(".rlink file was produced with encoding version {version_array}, but the current version is {RLINK_VERSION}".to_string());
         }
 
-        let mut decoder = opaque::Decoder::new(&data[4..], 0);
+        let mut decoder = MemDecoder::new(&data[4..], 0);
         let rustc_version = decoder.read_str();
         let current_version = RUSTC_VERSION.unwrap();
         if rustc_version != current_version {

--- a/compiler/rustc_codegen_ssa/src/lib.rs
+++ b/compiler/rustc_codegen_ssa/src/lib.rs
@@ -210,7 +210,7 @@ impl CodegenResults {
         encoder.emit_raw_bytes(&RLINK_VERSION.to_be_bytes());
         encoder.emit_str(RUSTC_VERSION.unwrap());
         Encodable::encode(codegen_results, &mut encoder);
-        encoder.finish().unwrap()
+        encoder.finish()
     }
 
     pub fn deserialize_rlink(data: Vec<u8>) -> Result<Self, String> {

--- a/compiler/rustc_data_structures/src/fingerprint.rs
+++ b/compiler/rustc_data_structures/src/fingerprint.rs
@@ -1,5 +1,5 @@
 use crate::stable_hasher;
-use rustc_serialize::{Decodable, Encodable};
+use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
 use std::convert::TryInto;
 use std::hash::{Hash, Hasher};
 
@@ -142,14 +142,14 @@ impl stable_hasher::StableHasherResult for Fingerprint {
 
 impl_stable_hash_via_hash!(Fingerprint);
 
-impl<E: rustc_serialize::Encoder> Encodable<E> for Fingerprint {
+impl<E: Encoder> Encodable<E> for Fingerprint {
     #[inline]
     fn encode(&self, s: &mut E) {
         s.emit_raw_bytes(&self.to_le_bytes());
     }
 }
 
-impl<D: rustc_serialize::Decoder> Decodable<D> for Fingerprint {
+impl<D: Decoder> Decodable<D> for Fingerprint {
     #[inline]
     fn decode(d: &mut D) -> Self {
         Fingerprint::from_le_bytes(d.read_raw_bytes(16).try_into().unwrap())
@@ -184,7 +184,7 @@ impl std::fmt::Display for PackedFingerprint {
     }
 }
 
-impl<E: rustc_serialize::Encoder> Encodable<E> for PackedFingerprint {
+impl<E: Encoder> Encodable<E> for PackedFingerprint {
     #[inline]
     fn encode(&self, s: &mut E) {
         // Copy to avoid taking reference to packed field.
@@ -193,7 +193,7 @@ impl<E: rustc_serialize::Encoder> Encodable<E> for PackedFingerprint {
     }
 }
 
-impl<D: rustc_serialize::Decoder> Decodable<D> for PackedFingerprint {
+impl<D: Decoder> Decodable<D> for PackedFingerprint {
     #[inline]
     fn decode(d: &mut D) -> Self {
         Self(Fingerprint::decode(d))

--- a/compiler/rustc_data_structures/src/fingerprint.rs
+++ b/compiler/rustc_data_structures/src/fingerprint.rs
@@ -144,9 +144,8 @@ impl_stable_hash_via_hash!(Fingerprint);
 
 impl<E: rustc_serialize::Encoder> Encodable<E> for Fingerprint {
     #[inline]
-    fn encode(&self, s: &mut E) -> Result<(), E::Error> {
-        s.emit_raw_bytes(&self.to_le_bytes())?;
-        Ok(())
+    fn encode(&self, s: &mut E) {
+        s.emit_raw_bytes(&self.to_le_bytes());
     }
 }
 
@@ -187,10 +186,10 @@ impl std::fmt::Display for PackedFingerprint {
 
 impl<E: rustc_serialize::Encoder> Encodable<E> for PackedFingerprint {
     #[inline]
-    fn encode(&self, s: &mut E) -> Result<(), E::Error> {
+    fn encode(&self, s: &mut E) {
         // Copy to avoid taking reference to packed field.
         let copy = self.0;
-        copy.encode(s)
+        copy.encode(s);
     }
 }
 

--- a/compiler/rustc_data_structures/src/svh.rs
+++ b/compiler/rustc_data_structures/src/svh.rs
@@ -49,8 +49,8 @@ impl fmt::Display for Svh {
 }
 
 impl<S: Encoder> Encodable<S> for Svh {
-    fn encode(&self, s: &mut S) -> Result<(), S::Error> {
-        s.emit_u64(self.as_u64().to_le())
+    fn encode(&self, s: &mut S) {
+        s.emit_u64(self.as_u64().to_le());
     }
 }
 

--- a/compiler/rustc_incremental/src/persist/load.rs
+++ b/compiler/rustc_incremental/src/persist/load.rs
@@ -4,7 +4,7 @@ use rustc_data_structures::fx::FxHashMap;
 use rustc_data_structures::memmap::Mmap;
 use rustc_middle::dep_graph::{SerializedDepGraph, WorkProduct, WorkProductId};
 use rustc_middle::ty::OnDiskCache;
-use rustc_serialize::opaque::Decoder;
+use rustc_serialize::opaque::MemDecoder;
 use rustc_serialize::Decodable;
 use rustc_session::config::IncrementalStateAssertion;
 use rustc_session::Session;
@@ -156,7 +156,7 @@ pub fn load_dep_graph(sess: &Session) -> DepGraphFuture {
 
         if let LoadResult::Ok { data: (work_products_data, start_pos) } = load_result {
             // Decode the list of work_products
-            let mut work_product_decoder = Decoder::new(&work_products_data[..], start_pos);
+            let mut work_product_decoder = MemDecoder::new(&work_products_data[..], start_pos);
             let work_products: Vec<SerializedWorkProduct> =
                 Decodable::decode(&mut work_product_decoder);
 
@@ -193,7 +193,7 @@ pub fn load_dep_graph(sess: &Session) -> DepGraphFuture {
             LoadResult::DataOutOfDate => LoadResult::DataOutOfDate,
             LoadResult::Error { message } => LoadResult::Error { message },
             LoadResult::Ok { data: (bytes, start_pos) } => {
-                let mut decoder = Decoder::new(&bytes, start_pos);
+                let mut decoder = MemDecoder::new(&bytes, start_pos);
                 let prev_commandline_args_hash = u64::decode(&mut decoder);
 
                 if prev_commandline_args_hash != expected_hash {

--- a/compiler/rustc_incremental/src/persist/save.rs
+++ b/compiler/rustc_incremental/src/persist/save.rs
@@ -3,7 +3,7 @@ use rustc_data_structures::sync::join;
 use rustc_middle::dep_graph::{DepGraph, SerializedDepGraph, WorkProduct, WorkProductId};
 use rustc_middle::ty::TyCtxt;
 use rustc_serialize::opaque::{FileEncodeResult, FileEncoder};
-use rustc_serialize::Encodable as RustcEncodable;
+use rustc_serialize::{Encodable as RustcEncodable, Encoder};
 use rustc_session::Session;
 use std::fs;
 
@@ -96,8 +96,9 @@ pub fn save_work_product_index(
     debug!("save_work_product_index()");
     dep_graph.assert_ignored();
     let path = work_products_path(sess);
-    file_format::save_in(sess, path, "work product index", |e| {
-        encode_work_product_index(&new_work_products, e)
+    file_format::save_in(sess, path, "work product index", |mut e| {
+        encode_work_product_index(&new_work_products, &mut e);
+        e.finish()
     });
 
     // We also need to clean out old work-products, as not all of them are
@@ -123,7 +124,7 @@ pub fn save_work_product_index(
 fn encode_work_product_index(
     work_products: &FxHashMap<WorkProductId, WorkProduct>,
     encoder: &mut FileEncoder,
-) -> FileEncodeResult {
+) {
     let serialized_products: Vec<_> = work_products
         .iter()
         .map(|(id, work_product)| SerializedWorkProduct {
@@ -135,7 +136,7 @@ fn encode_work_product_index(
     serialized_products.encode(encoder)
 }
 
-fn encode_query_cache(tcx: TyCtxt<'_>, encoder: &mut FileEncoder) -> FileEncodeResult {
+fn encode_query_cache(tcx: TyCtxt<'_>, encoder: FileEncoder) -> FileEncodeResult {
     tcx.sess.time("incr_comp_serialize_result_cache", || tcx.serialize_query_result_cache(encoder))
 }
 
@@ -170,24 +171,10 @@ pub fn build_dep_graph(
         }
     };
 
-    if let Err(err) = file_format::write_file_header(&mut encoder, sess.is_nightly_build()) {
-        sess.err(&format!(
-            "failed to write dependency graph header to `{}`: {}",
-            path_buf.display(),
-            err
-        ));
-        return None;
-    }
+    file_format::write_file_header(&mut encoder, sess.is_nightly_build());
 
     // First encode the commandline arguments hash
-    if let Err(err) = sess.opts.dep_tracking_hash(false).encode(&mut encoder) {
-        sess.err(&format!(
-            "failed to write dependency graph hash `{}`: {}",
-            path_buf.display(),
-            err
-        ));
-        return None;
-    }
+    sess.opts.dep_tracking_hash(false).encode(&mut encoder);
 
     Some(DepGraph::new(
         &sess.prof,

--- a/compiler/rustc_incremental/src/persist/save.rs
+++ b/compiler/rustc_incremental/src/persist/save.rs
@@ -3,7 +3,7 @@ use rustc_data_structures::sync::join;
 use rustc_middle::dep_graph::{DepGraph, SerializedDepGraph, WorkProduct, WorkProductId};
 use rustc_middle::ty::TyCtxt;
 use rustc_serialize::opaque::{FileEncodeResult, FileEncoder};
-use rustc_serialize::{Encodable as RustcEncodable, Encoder};
+use rustc_serialize::Encodable as RustcEncodable;
 use rustc_session::Session;
 use std::fs;
 

--- a/compiler/rustc_incremental/src/persist/save.rs
+++ b/compiler/rustc_incremental/src/persist/save.rs
@@ -3,7 +3,7 @@ use rustc_data_structures::sync::join;
 use rustc_middle::dep_graph::{DepGraph, SerializedDepGraph, WorkProduct, WorkProductId};
 use rustc_middle::ty::TyCtxt;
 use rustc_serialize::opaque::{FileEncodeResult, FileEncoder};
-use rustc_serialize::Encodable as RustcEncodable;
+use rustc_serialize::Encodable;
 use rustc_session::Session;
 use std::fs;
 

--- a/compiler/rustc_index/src/vec.rs
+++ b/compiler/rustc_index/src/vec.rs
@@ -60,8 +60,8 @@ pub struct IndexVec<I: Idx, T> {
 unsafe impl<I: Idx, T> Send for IndexVec<I, T> where T: Send {}
 
 impl<S: Encoder, I: Idx, T: Encodable<S>> Encodable<S> for IndexVec<I, T> {
-    fn encode(&self, s: &mut S) -> Result<(), S::Error> {
-        Encodable::encode(&self.raw, s)
+    fn encode(&self, s: &mut S) {
+        Encodable::encode(&self.raw, s);
     }
 }
 

--- a/compiler/rustc_macros/src/newtype.rs
+++ b/compiler/rustc_macros/src/newtype.rs
@@ -137,8 +137,8 @@ impl Parse for Newtype {
                     }
                 }
                 impl<E: ::rustc_serialize::Encoder> ::rustc_serialize::Encodable<E> for #name {
-                    fn encode(&self, e: &mut E) -> Result<(), E::Error> {
-                        e.emit_u32(self.private)
+                    fn encode(&self, e: &mut E) {
+                        e.emit_u32(self.private);
                     }
                 }
             }

--- a/compiler/rustc_macros/src/serialize.rs
+++ b/compiler/rustc_macros/src/serialize.rs
@@ -146,21 +146,17 @@ fn encodable_body(
                     .map(|binding| {
                         let bind_ident = &binding.binding;
                         let result = quote! {
-                            match ::rustc_serialize::Encodable::<#encoder_ty>::encode(
+                            ::rustc_serialize::Encodable::<#encoder_ty>::encode(
                                 #bind_ident,
                                 __encoder,
-                            ) {
-                                ::std::result::Result::Ok(()) => (),
-                                ::std::result::Result::Err(__err)
-                                    => return ::std::result::Result::Err(__err),
-                            }
+                            );
                         };
                         result
                     })
                     .collect::<TokenStream>()
             });
             quote! {
-                ::std::result::Result::Ok(match *self { #encode_inner })
+                match *self { #encode_inner }
             }
         }
         _ => {
@@ -172,14 +168,10 @@ fn encodable_body(
                     .map(|binding| {
                         let bind_ident = &binding.binding;
                         let result = quote! {
-                            match ::rustc_serialize::Encodable::<#encoder_ty>::encode(
+                            ::rustc_serialize::Encodable::<#encoder_ty>::encode(
                                 #bind_ident,
                                 __encoder,
-                            ) {
-                                ::std::result::Result::Ok(()) => (),
-                                ::std::result::Result::Err(__err)
-                                    => return ::std::result::Result::Err(__err),
-                            }
+                            );
                         };
                         result
                     })
@@ -190,7 +182,7 @@ fn encodable_body(
                         ::rustc_serialize::Encoder::emit_enum_variant(
                             __encoder,
                             #variant_idx,
-                            |__encoder| { ::std::result::Result::Ok({ #encode_fields }) }
+                            |__encoder| { #encode_fields }
                         )
                     }
                 } else {
@@ -223,7 +215,7 @@ fn encodable_body(
             fn encode(
                 &self,
                 __encoder: &mut #encoder_ty,
-            ) -> ::std::result::Result<(), <#encoder_ty as ::rustc_serialize::Encoder>::Error> {
+            ) {
                 #lints
                 #encode_body
             }

--- a/compiler/rustc_metadata/src/rmeta/def_path_hash_map.rs
+++ b/compiler/rustc_metadata/src/rmeta/def_path_hash_map.rs
@@ -4,7 +4,7 @@ use crate::rmeta::MetadataBlob;
 use rustc_data_structures::owning_ref::OwningRef;
 use rustc_hir::def_path_hash_map::{Config as HashMapConfig, DefPathHashMap};
 use rustc_middle::parameterized_over_tcx;
-use rustc_serialize::{opaque, Decodable, Decoder, Encodable, Encoder};
+use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
 use rustc_span::def_id::{DefIndex, DefPathHash};
 
 pub(crate) enum DefPathHashMapRef<'tcx> {
@@ -29,12 +29,12 @@ impl DefPathHashMapRef<'_> {
 }
 
 impl<'a, 'tcx> Encodable<EncodeContext<'a, 'tcx>> for DefPathHashMapRef<'tcx> {
-    fn encode(&self, e: &mut EncodeContext<'a, 'tcx>) -> opaque::EncodeResult {
+    fn encode(&self, e: &mut EncodeContext<'a, 'tcx>) {
         match *self {
             DefPathHashMapRef::BorrowedFromTcx(def_path_hash_map) => {
                 let bytes = def_path_hash_map.raw_bytes();
-                e.emit_usize(bytes.len())?;
-                e.emit_raw_bytes(bytes)
+                e.emit_usize(bytes.len());
+                e.emit_raw_bytes(bytes);
             }
             DefPathHashMapRef::OwnedFromMetadata(_) => {
                 panic!("DefPathHashMap::OwnedFromMetadata variant only exists for deserialization")

--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -2194,7 +2194,7 @@ pub fn encode_metadata(tcx: TyCtxt<'_>) -> EncodedMetadata {
 }
 
 fn encode_metadata_impl(tcx: TyCtxt<'_>) -> EncodedMetadata {
-    let mut encoder = opaque::Encoder::new(vec![]);
+    let mut encoder = opaque::Encoder::new();
     encoder.emit_raw_bytes(METADATA_HEADER).unwrap();
 
     // Will be filled with the root position after encoding everything.

--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -86,14 +86,15 @@ macro_rules! empty_proc_macro {
 
 macro_rules! encoder_methods {
     ($($name:ident($ty:ty);)*) => {
-        $(fn $name(&mut self, value: $ty) -> Result<(), Self::Error> {
+        $(fn $name(&mut self, value: $ty) {
             self.opaque.$name(value)
         })*
     }
 }
 
 impl<'a, 'tcx> Encoder for EncodeContext<'a, 'tcx> {
-    type Error = <opaque::Encoder as Encoder>::Error;
+    type Ok = <opaque::Encoder as Encoder>::Ok;
+    type Err = <opaque::Encoder as Encoder>::Err;
 
     encoder_methods! {
         emit_usize(usize);
@@ -117,60 +118,63 @@ impl<'a, 'tcx> Encoder for EncodeContext<'a, 'tcx> {
         emit_str(&str);
         emit_raw_bytes(&[u8]);
     }
+
+    fn finish(self) -> Result<Self::Ok, Self::Err> {
+        self.opaque.finish()
+    }
 }
 
 impl<'a, 'tcx, T> Encodable<EncodeContext<'a, 'tcx>> for LazyValue<T> {
-    fn encode(&self, e: &mut EncodeContext<'a, 'tcx>) -> opaque::EncodeResult {
-        e.emit_lazy_distance(self.position)
+    fn encode(&self, e: &mut EncodeContext<'a, 'tcx>) {
+        e.emit_lazy_distance(self.position);
     }
 }
 
 impl<'a, 'tcx, T> Encodable<EncodeContext<'a, 'tcx>> for LazyArray<T> {
-    fn encode(&self, e: &mut EncodeContext<'a, 'tcx>) -> opaque::EncodeResult {
-        e.emit_usize(self.num_elems)?;
-        if self.num_elems == 0 {
-            return Ok(());
+    fn encode(&self, e: &mut EncodeContext<'a, 'tcx>) {
+        e.emit_usize(self.num_elems);
+        if self.num_elems > 0 {
+            e.emit_lazy_distance(self.position)
         }
-        e.emit_lazy_distance(self.position)
     }
 }
 
 impl<'a, 'tcx, I, T> Encodable<EncodeContext<'a, 'tcx>> for LazyTable<I, T> {
-    fn encode(&self, e: &mut EncodeContext<'a, 'tcx>) -> opaque::EncodeResult {
-        e.emit_usize(self.encoded_size)?;
-        e.emit_lazy_distance(self.position)
+    fn encode(&self, e: &mut EncodeContext<'a, 'tcx>) {
+        e.emit_usize(self.encoded_size);
+        e.emit_lazy_distance(self.position);
     }
 }
 
 impl<'a, 'tcx> Encodable<EncodeContext<'a, 'tcx>> for CrateNum {
-    fn encode(&self, s: &mut EncodeContext<'a, 'tcx>) -> opaque::EncodeResult {
+    fn encode(&self, s: &mut EncodeContext<'a, 'tcx>) {
         if *self != LOCAL_CRATE && s.is_proc_macro {
             panic!("Attempted to encode non-local CrateNum {:?} for proc-macro crate", self);
         }
-        s.emit_u32(self.as_u32())
+        s.emit_u32(self.as_u32());
     }
 }
 
 impl<'a, 'tcx> Encodable<EncodeContext<'a, 'tcx>> for DefIndex {
-    fn encode(&self, s: &mut EncodeContext<'a, 'tcx>) -> opaque::EncodeResult {
-        s.emit_u32(self.as_u32())
+    fn encode(&self, s: &mut EncodeContext<'a, 'tcx>) {
+        s.emit_u32(self.as_u32());
     }
 }
 
 impl<'a, 'tcx> Encodable<EncodeContext<'a, 'tcx>> for ExpnIndex {
-    fn encode(&self, s: &mut EncodeContext<'a, 'tcx>) -> opaque::EncodeResult {
-        s.emit_u32(self.as_u32())
+    fn encode(&self, s: &mut EncodeContext<'a, 'tcx>) {
+        s.emit_u32(self.as_u32());
     }
 }
 
 impl<'a, 'tcx> Encodable<EncodeContext<'a, 'tcx>> for SyntaxContext {
-    fn encode(&self, s: &mut EncodeContext<'a, 'tcx>) -> opaque::EncodeResult {
-        rustc_span::hygiene::raw_encode_syntax_context(*self, &s.hygiene_ctxt, s)
+    fn encode(&self, s: &mut EncodeContext<'a, 'tcx>) {
+        rustc_span::hygiene::raw_encode_syntax_context(*self, &s.hygiene_ctxt, s);
     }
 }
 
 impl<'a, 'tcx> Encodable<EncodeContext<'a, 'tcx>> for ExpnId {
-    fn encode(&self, s: &mut EncodeContext<'a, 'tcx>) -> opaque::EncodeResult {
+    fn encode(&self, s: &mut EncodeContext<'a, 'tcx>) {
         if self.krate == LOCAL_CRATE {
             // We will only write details for local expansions.  Non-local expansions will fetch
             // data from the corresponding crate's metadata.
@@ -178,13 +182,13 @@ impl<'a, 'tcx> Encodable<EncodeContext<'a, 'tcx>> for ExpnId {
             // metadata from proc-macro crates.
             s.hygiene_ctxt.schedule_expn_data_for_encoding(*self);
         }
-        self.krate.encode(s)?;
-        self.local_id.encode(s)
+        self.krate.encode(s);
+        self.local_id.encode(s);
     }
 }
 
 impl<'a, 'tcx> Encodable<EncodeContext<'a, 'tcx>> for Span {
-    fn encode(&self, s: &mut EncodeContext<'a, 'tcx>) -> opaque::EncodeResult {
+    fn encode(&self, s: &mut EncodeContext<'a, 'tcx>) {
         let span = self.data();
 
         // Don't serialize any `SyntaxContext`s from a proc-macro crate,
@@ -219,9 +223,9 @@ impl<'a, 'tcx> Encodable<EncodeContext<'a, 'tcx>> for Span {
         // `rustc_span::hygiene::raw_encode_expn_id` to handle
         // encoding `ExpnData` for proc-macro crates.
         if s.is_proc_macro {
-            SyntaxContext::root().encode(s)?;
+            SyntaxContext::root().encode(s);
         } else {
-            span.ctxt.encode(s)?;
+            span.ctxt.encode(s);
         }
 
         if self.is_dummy() {
@@ -289,22 +293,20 @@ impl<'a, 'tcx> Encodable<EncodeContext<'a, 'tcx>> for Span {
             (TAG_VALID_SPAN_LOCAL, span.lo, span.hi)
         };
 
-        tag.encode(s)?;
-        lo.encode(s)?;
+        tag.encode(s);
+        lo.encode(s);
 
         // Encode length which is usually less than span.hi and profits more
         // from the variable-length integer encoding that we use.
         let len = hi - lo;
-        len.encode(s)?;
+        len.encode(s);
 
         if tag == TAG_VALID_SPAN_FOREIGN {
             // This needs to be two lines to avoid holding the `s.source_file_cache`
             // while calling `cnum.encode(s)`
             let cnum = s.source_file_cache.0.cnum;
-            cnum.encode(s)?;
+            cnum.encode(s);
         }
-
-        Ok(())
     }
 }
 
@@ -325,13 +327,10 @@ impl<'a, 'tcx> TyEncoder for EncodeContext<'a, 'tcx> {
         &mut self.predicate_shorthands
     }
 
-    fn encode_alloc_id(
-        &mut self,
-        alloc_id: &rustc_middle::mir::interpret::AllocId,
-    ) -> Result<(), Self::Error> {
+    fn encode_alloc_id(&mut self, alloc_id: &rustc_middle::mir::interpret::AllocId) {
         let (index, _) = self.interpret_allocs.insert_full(*alloc_id);
 
-        index.encode(self)
+        index.encode(self);
     }
 }
 
@@ -360,10 +359,7 @@ macro_rules! record_array {
 }
 
 impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
-    fn emit_lazy_distance(
-        &mut self,
-        position: NonZeroUsize,
-    ) -> Result<(), <Self as Encoder>::Error> {
+    fn emit_lazy_distance(&mut self, position: NonZeroUsize) {
         let pos = position.get();
         let distance = match self.lazy_state {
             LazyState::NoNode => bug!("emit_lazy_distance: outside of a metadata node"),
@@ -382,7 +378,7 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
             }
         };
         self.lazy_state = LazyState::Previous(NonZeroUsize::new(pos).unwrap());
-        self.emit_usize(distance)
+        self.emit_usize(distance);
     }
 
     fn lazy<T: ParameterizedOverTcx, B: Borrow<T::Value<'tcx>>>(&mut self, value: B) -> LazyValue<T>
@@ -393,7 +389,7 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
 
         assert_eq!(self.lazy_state, LazyState::NoNode);
         self.lazy_state = LazyState::NodeStart(pos);
-        value.borrow().encode(self).unwrap();
+        value.borrow().encode(self);
         self.lazy_state = LazyState::NoNode;
 
         assert!(pos.get() <= self.position());
@@ -412,7 +408,7 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
 
         assert_eq!(self.lazy_state, LazyState::NoNode);
         self.lazy_state = LazyState::NodeStart(pos);
-        let len = values.into_iter().map(|value| value.borrow().encode(self).unwrap()).count();
+        let len = values.into_iter().map(|value| value.borrow().encode(self)).count();
         self.lazy_state = LazyState::NoNode;
 
         assert!(pos.get() <= self.position());
@@ -615,7 +611,7 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
                     let id = self.interpret_allocs[idx];
                     let pos = self.position() as u32;
                     interpret_alloc_index.push(pos);
-                    interpret::specialized_encode_alloc_id(self, tcx, id).unwrap();
+                    interpret::specialized_encode_alloc_id(self, tcx, id);
                 }
                 n = new_n;
             }
@@ -1640,18 +1636,16 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
         let mut expn_data_table: TableBuilder<_, _> = Default::default();
         let mut expn_hash_table: TableBuilder<_, _> = Default::default();
 
-        let _: Result<(), !> = self.hygiene_ctxt.encode(
+        self.hygiene_ctxt.encode(
             &mut (&mut *self, &mut syntax_contexts, &mut expn_data_table, &mut expn_hash_table),
             |(this, syntax_contexts, _, _), index, ctxt_data| {
                 syntax_contexts.set(index, this.lazy(ctxt_data));
-                Ok(())
             },
             |(this, _, expn_data_table, expn_hash_table), index, expn_data, hash| {
                 if let Some(index) = index.as_local() {
                     expn_data_table.set(index.as_raw(), this.lazy(expn_data));
                     expn_hash_table.set(index.as_raw(), this.lazy(hash));
                 }
-                Ok(())
             },
         );
 
@@ -2195,10 +2189,10 @@ pub fn encode_metadata(tcx: TyCtxt<'_>) -> EncodedMetadata {
 
 fn encode_metadata_impl(tcx: TyCtxt<'_>) -> EncodedMetadata {
     let mut encoder = opaque::Encoder::new();
-    encoder.emit_raw_bytes(METADATA_HEADER).unwrap();
+    encoder.emit_raw_bytes(METADATA_HEADER);
 
     // Will be filled with the root position after encoding everything.
-    encoder.emit_raw_bytes(&[0, 0, 0, 0]).unwrap();
+    encoder.emit_raw_bytes(&[0, 0, 0, 0]);
 
     let source_map_files = tcx.sess.source_map().files();
     let source_file_cache = (source_map_files[0].clone(), 0);
@@ -2223,13 +2217,13 @@ fn encode_metadata_impl(tcx: TyCtxt<'_>) -> EncodedMetadata {
     };
 
     // Encode the rustc version string in a predictable location.
-    rustc_version().encode(&mut ecx).unwrap();
+    rustc_version().encode(&mut ecx);
 
     // Encode all the entries and extra information in the crate,
     // culminating in the `CrateRoot` which points to all of it.
     let root = ecx.encode_crate_root();
 
-    let mut result = ecx.opaque.into_inner();
+    let mut result = ecx.opaque.finish().unwrap();
 
     // Encode the root position.
     let header = METADATA_HEADER.len();

--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -93,9 +93,6 @@ macro_rules! encoder_methods {
 }
 
 impl<'a, 'tcx> Encoder for EncodeContext<'a, 'tcx> {
-    type Ok = <opaque::Encoder as Encoder>::Ok;
-    type Err = <opaque::Encoder as Encoder>::Err;
-
     encoder_methods! {
         emit_usize(usize);
         emit_u128(u128);
@@ -117,10 +114,6 @@ impl<'a, 'tcx> Encoder for EncodeContext<'a, 'tcx> {
         emit_char(char);
         emit_str(&str);
         emit_raw_bytes(&[u8]);
-    }
-
-    fn finish(self) -> Result<Self::Ok, Self::Err> {
-        self.opaque.finish()
     }
 }
 
@@ -2223,7 +2216,7 @@ fn encode_metadata_impl(tcx: TyCtxt<'_>) -> EncodedMetadata {
     // culminating in the `CrateRoot` which points to all of it.
     let root = ecx.encode_crate_root();
 
-    let mut result = ecx.opaque.finish().unwrap();
+    let mut result = ecx.opaque.finish();
 
     // Encode the root position.
     let header = METADATA_HEADER.len();

--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -27,7 +27,8 @@ use rustc_middle::ty::codec::TyEncoder;
 use rustc_middle::ty::fast_reject::{self, SimplifiedType, TreatParams};
 use rustc_middle::ty::query::Providers;
 use rustc_middle::ty::{self, SymbolName, Ty, TyCtxt};
-use rustc_serialize::{opaque, Encodable, Encoder};
+use rustc_serialize::opaque::MemEncoder;
+use rustc_serialize::{Encodable, Encoder};
 use rustc_session::config::CrateType;
 use rustc_session::cstore::{ForeignModule, LinkagePreference, NativeLib};
 use rustc_span::hygiene::{ExpnIndex, HygieneEncodeContext, MacroKind};
@@ -43,7 +44,7 @@ use std::num::NonZeroUsize;
 use tracing::{debug, trace};
 
 pub(super) struct EncodeContext<'a, 'tcx> {
-    opaque: opaque::Encoder,
+    opaque: MemEncoder,
     tcx: TyCtxt<'tcx>,
     feat: &'tcx rustc_feature::Features,
 
@@ -2181,7 +2182,7 @@ pub fn encode_metadata(tcx: TyCtxt<'_>) -> EncodedMetadata {
 }
 
 fn encode_metadata_impl(tcx: TyCtxt<'_>) -> EncodedMetadata {
-    let mut encoder = opaque::Encoder::new();
+    let mut encoder = MemEncoder::new();
     encoder.emit_raw_bytes(METADATA_HEADER);
 
     // Will be filled with the root position after encoding everything.

--- a/compiler/rustc_metadata/src/rmeta/mod.rs
+++ b/compiler/rustc_metadata/src/rmeta/mod.rs
@@ -22,7 +22,7 @@ use rustc_middle::ty::fast_reject::SimplifiedType;
 use rustc_middle::ty::query::Providers;
 use rustc_middle::ty::{self, ReprOptions, Ty};
 use rustc_middle::ty::{GeneratorDiagnosticData, ParameterizedOverTcx, TyCtxt};
-use rustc_serialize::opaque::Encoder;
+use rustc_serialize::opaque::MemEncoder;
 use rustc_session::config::SymbolManglingVersion;
 use rustc_session::cstore::{CrateDepKind, ForeignModule, LinkagePreference, NativeLib};
 use rustc_span::edition::Edition;
@@ -323,7 +323,7 @@ macro_rules! define_tables {
         }
 
         impl TableBuilders {
-            fn encode(&self, buf: &mut Encoder) -> LazyTables {
+            fn encode(&self, buf: &mut MemEncoder) -> LazyTables {
                 LazyTables {
                     $($name: self.$name.encode(buf)),+
                 }

--- a/compiler/rustc_metadata/src/rmeta/table.rs
+++ b/compiler/rustc_metadata/src/rmeta/table.rs
@@ -287,7 +287,7 @@ where
     {
         let pos = buf.position();
         for block in &self.blocks {
-            buf.emit_raw_bytes(block).unwrap();
+            buf.emit_raw_bytes(block);
         }
         let num_bytes = self.blocks.len() * N;
         LazyTable::from_position_and_encoded_size(

--- a/compiler/rustc_metadata/src/rmeta/table.rs
+++ b/compiler/rustc_metadata/src/rmeta/table.rs
@@ -4,8 +4,8 @@ use rustc_data_structures::fingerprint::Fingerprint;
 use rustc_hir::def::{CtorKind, CtorOf};
 use rustc_index::vec::Idx;
 use rustc_middle::ty::ParameterizedOverTcx;
-use rustc_serialize::opaque::Encoder;
-use rustc_serialize::Encoder as _;
+use rustc_serialize::opaque::MemEncoder;
+use rustc_serialize::Encoder;
 use rustc_span::hygiene::MacroKind;
 use std::convert::TryInto;
 use std::marker::PhantomData;
@@ -281,7 +281,7 @@ where
         Some(value).write_to_bytes(&mut self.blocks[i]);
     }
 
-    pub(crate) fn encode<const N: usize>(&self, buf: &mut Encoder) -> LazyTable<I, T>
+    pub(crate) fn encode<const N: usize>(&self, buf: &mut MemEncoder) -> LazyTable<I, T>
     where
         Option<T>: FixedSizeEncoding<ByteArray = [u8; N]>,
     {

--- a/compiler/rustc_middle/src/mir/graph_cyclic_cache.rs
+++ b/compiler/rustc_middle/src/mir/graph_cyclic_cache.rs
@@ -38,8 +38,8 @@ impl GraphIsCyclicCache {
 
 impl<S: serialize::Encoder> serialize::Encodable<S> for GraphIsCyclicCache {
     #[inline]
-    fn encode(&self, s: &mut S) -> Result<(), S::Error> {
-        serialize::Encodable::encode(&(), s)
+    fn encode(&self, s: &mut S) {
+        serialize::Encodable::encode(&(), s);
     }
 }
 

--- a/compiler/rustc_middle/src/mir/graph_cyclic_cache.rs
+++ b/compiler/rustc_middle/src/mir/graph_cyclic_cache.rs
@@ -3,7 +3,7 @@ use rustc_data_structures::graph::{
 };
 use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
 use rustc_data_structures::sync::OnceCell;
-use rustc_serialize as serialize;
+use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
 
 /// Helper type to cache the result of `graph::is_cyclic`.
 #[derive(Clone, Debug)]
@@ -36,17 +36,17 @@ impl GraphIsCyclicCache {
     }
 }
 
-impl<S: serialize::Encoder> serialize::Encodable<S> for GraphIsCyclicCache {
+impl<S: Encoder> Encodable<S> for GraphIsCyclicCache {
     #[inline]
     fn encode(&self, s: &mut S) {
-        serialize::Encodable::encode(&(), s);
+        Encodable::encode(&(), s);
     }
 }
 
-impl<D: serialize::Decoder> serialize::Decodable<D> for GraphIsCyclicCache {
+impl<D: Decoder> Decodable<D> for GraphIsCyclicCache {
     #[inline]
     fn decode(d: &mut D) -> Self {
-        let () = serialize::Decodable::decode(d);
+        let () = Decodable::decode(d);
         Self::new()
     }
 }

--- a/compiler/rustc_middle/src/mir/interpret/mod.rs
+++ b/compiler/rustc_middle/src/mir/interpret/mod.rs
@@ -207,27 +207,26 @@ pub fn specialized_encode_alloc_id<'tcx, E: TyEncoder<I = TyCtxt<'tcx>>>(
     encoder: &mut E,
     tcx: TyCtxt<'tcx>,
     alloc_id: AllocId,
-) -> Result<(), E::Error> {
+) {
     match tcx.global_alloc(alloc_id) {
         GlobalAlloc::Memory(alloc) => {
             trace!("encoding {:?} with {:#?}", alloc_id, alloc);
-            AllocDiscriminant::Alloc.encode(encoder)?;
-            alloc.encode(encoder)?;
+            AllocDiscriminant::Alloc.encode(encoder);
+            alloc.encode(encoder);
         }
         GlobalAlloc::Function(fn_instance) => {
             trace!("encoding {:?} with {:#?}", alloc_id, fn_instance);
-            AllocDiscriminant::Fn.encode(encoder)?;
-            fn_instance.encode(encoder)?;
+            AllocDiscriminant::Fn.encode(encoder);
+            fn_instance.encode(encoder);
         }
         GlobalAlloc::Static(did) => {
             assert!(!tcx.is_thread_local_static(did));
             // References to statics doesn't need to know about their allocations,
             // just about its `DefId`.
-            AllocDiscriminant::Static.encode(encoder)?;
-            did.encode(encoder)?;
+            AllocDiscriminant::Static.encode(encoder);
+            did.encode(encoder);
         }
     }
-    Ok(())
 }
 
 // Used to avoid infinite recursion when decoding cyclic allocations.

--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -672,16 +672,16 @@ const TAG_CLEAR_CROSS_CRATE_SET: u8 = 1;
 
 impl<E: TyEncoder, T: Encodable<E>> Encodable<E> for ClearCrossCrate<T> {
     #[inline]
-    fn encode(&self, e: &mut E) -> Result<(), E::Error> {
+    fn encode(&self, e: &mut E) {
         if E::CLEAR_CROSS_CRATE {
-            return Ok(());
+            return;
         }
 
         match *self {
             ClearCrossCrate::Clear => TAG_CLEAR_CROSS_CRATE_CLEAR.encode(e),
             ClearCrossCrate::Set(ref val) => {
-                TAG_CLEAR_CROSS_CRATE_SET.encode(e)?;
-                val.encode(e)
+                TAG_CLEAR_CROSS_CRATE_SET.encode(e);
+                val.encode(e);
             }
         }
     }

--- a/compiler/rustc_middle/src/mir/predecessors.rs
+++ b/compiler/rustc_middle/src/mir/predecessors.rs
@@ -3,7 +3,7 @@
 use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
 use rustc_data_structures::sync::OnceCell;
 use rustc_index::vec::IndexVec;
-use rustc_serialize as serialize;
+use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
 use smallvec::SmallVec;
 
 use crate::mir::{BasicBlock, BasicBlockData};
@@ -54,12 +54,12 @@ impl PredecessorCache {
     }
 }
 
-impl<S: serialize::Encoder> serialize::Encodable<S> for PredecessorCache {
+impl<S: Encoder> Encodable<S> for PredecessorCache {
     #[inline]
     fn encode(&self, _s: &mut S) {}
 }
 
-impl<D: serialize::Decoder> serialize::Decodable<D> for PredecessorCache {
+impl<D: Decoder> Decodable<D> for PredecessorCache {
     #[inline]
     fn decode(_: &mut D) -> Self {
         Self::new()

--- a/compiler/rustc_middle/src/mir/predecessors.rs
+++ b/compiler/rustc_middle/src/mir/predecessors.rs
@@ -56,9 +56,7 @@ impl PredecessorCache {
 
 impl<S: serialize::Encoder> serialize::Encodable<S> for PredecessorCache {
     #[inline]
-    fn encode(&self, _s: &mut S) -> Result<(), S::Error> {
-        Ok(())
-    }
+    fn encode(&self, _s: &mut S) {}
 }
 
 impl<D: serialize::Decoder> serialize::Decodable<D> for PredecessorCache {

--- a/compiler/rustc_middle/src/mir/switch_sources.rs
+++ b/compiler/rustc_middle/src/mir/switch_sources.rs
@@ -5,7 +5,7 @@ use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
 use rustc_data_structures::stable_map::FxHashMap;
 use rustc_data_structures::sync::OnceCell;
 use rustc_index::vec::IndexVec;
-use rustc_serialize as serialize;
+use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
 use smallvec::SmallVec;
 
 use crate::mir::{BasicBlock, BasicBlockData, Terminator, TerminatorKind};
@@ -54,12 +54,12 @@ impl SwitchSourceCache {
     }
 }
 
-impl<S: serialize::Encoder> serialize::Encodable<S> for SwitchSourceCache {
+impl<S: Encoder> Encodable<S> for SwitchSourceCache {
     #[inline]
     fn encode(&self, _s: &mut S) {}
 }
 
-impl<D: serialize::Decoder> serialize::Decodable<D> for SwitchSourceCache {
+impl<D: Decoder> Decodable<D> for SwitchSourceCache {
     #[inline]
     fn decode(_: &mut D) -> Self {
         Self::new()

--- a/compiler/rustc_middle/src/mir/switch_sources.rs
+++ b/compiler/rustc_middle/src/mir/switch_sources.rs
@@ -56,9 +56,7 @@ impl SwitchSourceCache {
 
 impl<S: serialize::Encoder> serialize::Encodable<S> for SwitchSourceCache {
     #[inline]
-    fn encode(&self, _s: &mut S) -> Result<(), S::Error> {
-        Ok(())
-    }
+    fn encode(&self, _s: &mut S) {}
 }
 
 impl<D: serialize::Decoder> serialize::Decodable<D> for SwitchSourceCache {

--- a/compiler/rustc_middle/src/mir/traversal.rs
+++ b/compiler/rustc_middle/src/mir/traversal.rs
@@ -367,9 +367,7 @@ impl PostorderCache {
 
 impl<S: serialize::Encoder> serialize::Encodable<S> for PostorderCache {
     #[inline]
-    fn encode(&self, _s: &mut S) -> Result<(), S::Error> {
-        Ok(())
-    }
+    fn encode(&self, _s: &mut S) {}
 }
 
 impl<D: serialize::Decoder> serialize::Decodable<D> for PostorderCache {

--- a/compiler/rustc_middle/src/mir/traversal.rs
+++ b/compiler/rustc_middle/src/mir/traversal.rs
@@ -1,7 +1,7 @@
 use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
 use rustc_data_structures::sync::OnceCell;
 use rustc_index::bit_set::BitSet;
-use rustc_serialize as serialize;
+use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
 
 use super::*;
 
@@ -365,12 +365,12 @@ impl PostorderCache {
     }
 }
 
-impl<S: serialize::Encoder> serialize::Encodable<S> for PostorderCache {
+impl<S: Encoder> Encodable<S> for PostorderCache {
     #[inline]
     fn encode(&self, _s: &mut S) {}
 }
 
-impl<D: serialize::Decoder> serialize::Decodable<D> for PostorderCache {
+impl<D: Decoder> Decodable<D> for PostorderCache {
     #[inline]
     fn decode(_: &mut D) -> Self {
         Self::new()

--- a/compiler/rustc_middle/src/ty/consts/int.rs
+++ b/compiler/rustc_middle/src/ty/consts/int.rs
@@ -140,9 +140,9 @@ impl<CTX> crate::ty::HashStable<CTX> for ScalarInt {
 }
 
 impl<S: Encoder> Encodable<S> for ScalarInt {
-    fn encode(&self, s: &mut S) -> Result<(), S::Error> {
-        s.emit_u128(self.data)?;
-        s.emit_u8(self.size)
+    fn encode(&self, s: &mut S) {
+        s.emit_u128(self.data);
+        s.emit_u8(self.size);
     }
 }
 

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -87,7 +87,7 @@ pub trait OnDiskCache<'tcx>: rustc_data_structures::sync::Sync {
 
     fn drop_serialized_data(&self, tcx: TyCtxt<'tcx>);
 
-    fn serialize(&self, tcx: TyCtxt<'tcx>, encoder: &mut FileEncoder) -> FileEncodeResult;
+    fn serialize(&self, tcx: TyCtxt<'tcx>, encoder: FileEncoder) -> FileEncodeResult;
 }
 
 #[allow(rustc::usage_of_ty_tykind)]
@@ -1466,8 +1466,8 @@ impl<'tcx> TyCtxt<'tcx> {
         )
     }
 
-    pub fn serialize_query_result_cache(self, encoder: &mut FileEncoder) -> FileEncodeResult {
-        self.on_disk_cache.as_ref().map_or(Ok(()), |c| c.serialize(self, encoder))
+    pub fn serialize_query_result_cache(self, encoder: FileEncoder) -> FileEncodeResult {
+        self.on_disk_cache.as_ref().map_or(Ok(0), |c| c.serialize(self, encoder))
     }
 
     /// If `true`, we should use lazy normalization for constants, otherwise

--- a/compiler/rustc_middle/src/ty/list.rs
+++ b/compiler/rustc_middle/src/ty/list.rs
@@ -117,8 +117,8 @@ impl<T: fmt::Debug> fmt::Debug for List<T> {
 
 impl<S: Encoder, T: Encodable<S>> Encodable<S> for List<T> {
     #[inline]
-    fn encode(&self, s: &mut S) -> Result<(), S::Error> {
-        (**self).encode(s)
+    fn encode(&self, s: &mut S) {
+        (**self).encode(s);
     }
 }
 

--- a/compiler/rustc_middle/src/ty/subst.rs
+++ b/compiler/rustc_middle/src/ty/subst.rs
@@ -217,7 +217,7 @@ impl<'tcx> TypeFoldable<'tcx> for GenericArg<'tcx> {
 }
 
 impl<'tcx, E: TyEncoder<I = TyCtxt<'tcx>>> Encodable<E> for GenericArg<'tcx> {
-    fn encode(&self, e: &mut E) -> Result<(), E::Error> {
+    fn encode(&self, e: &mut E) {
         self.unpack().encode(e)
     }
 }

--- a/compiler/rustc_query_impl/src/lib.rs
+++ b/compiler/rustc_query_impl/src/lib.rs
@@ -2,6 +2,7 @@
 
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
 #![feature(min_specialization)]
+#![feature(never_type)]
 #![feature(once_cell)]
 #![feature(rustc_attrs)]
 #![recursion_limit = "256"]

--- a/compiler/rustc_query_impl/src/on_disk_cache.rs
+++ b/compiler/rustc_query_impl/src/on_disk_cache.rs
@@ -221,7 +221,7 @@ impl<'sess> rustc_middle::ty::OnDiskCache<'sess> for OnDiskCache<'sess> {
         *self.serialized_data.write() = None;
     }
 
-    fn serialize<'tcx>(&self, tcx: TyCtxt<'tcx>, encoder: &mut FileEncoder) -> FileEncodeResult {
+    fn serialize<'tcx>(&self, tcx: TyCtxt<'tcx>, encoder: FileEncoder) -> FileEncodeResult {
         // Serializing the `DepGraph` should not modify it.
         tcx.dep_graph.with_ignore(|| {
             // Allocate `SourceFileIndex`es.
@@ -259,27 +259,25 @@ impl<'sess> rustc_middle::ty::OnDiskCache<'sess> for OnDiskCache<'sess> {
             // Encode query results.
             let mut query_result_index = EncodedDepNodeIndex::new();
 
-            tcx.sess.time("encode_query_results", || -> FileEncodeResult {
+            tcx.sess.time("encode_query_results", || {
                 let enc = &mut encoder;
                 let qri = &mut query_result_index;
-                QueryCtxt::from_tcx(tcx).encode_query_results(enc, qri)
-            })?;
+                QueryCtxt::from_tcx(tcx).encode_query_results(enc, qri);
+            });
 
             // Encode side effects.
             let side_effects_index: EncodedDepNodeIndex = self
                 .current_side_effects
                 .borrow()
                 .iter()
-                .map(
-                    |(dep_node_index, side_effects)| -> Result<_, <FileEncoder as Encoder>::Error> {
-                        let pos = AbsoluteBytePos::new(encoder.position());
-                        let dep_node_index = SerializedDepNodeIndex::new(dep_node_index.index());
-                        encoder.encode_tagged(dep_node_index, side_effects)?;
+                .map(|(dep_node_index, side_effects)| {
+                    let pos = AbsoluteBytePos::new(encoder.position());
+                    let dep_node_index = SerializedDepNodeIndex::new(dep_node_index.index());
+                    encoder.encode_tagged(dep_node_index, side_effects);
 
-                        Ok((dep_node_index, pos))
-                    },
-                )
-                .collect::<Result<_, _>>()?;
+                    (dep_node_index, pos)
+                })
+                .collect();
 
             let interpret_alloc_index = {
                 let mut interpret_alloc_index = Vec::new();
@@ -296,7 +294,7 @@ impl<'sess> rustc_middle::ty::OnDiskCache<'sess> for OnDiskCache<'sess> {
                         let id = encoder.interpret_allocs[idx];
                         let pos = encoder.position() as u32;
                         interpret_alloc_index.push(pos);
-                        interpret::specialized_encode_alloc_id(&mut encoder, tcx, id)?;
+                        interpret::specialized_encode_alloc_id(&mut encoder, tcx, id);
                     }
                     n = new_n;
                 }
@@ -312,23 +310,21 @@ impl<'sess> rustc_middle::ty::OnDiskCache<'sess> for OnDiskCache<'sess> {
 
             hygiene_encode_context.encode(
                 &mut encoder,
-                |encoder, index, ctxt_data| -> FileEncodeResult {
+                |encoder, index, ctxt_data| {
                     let pos = AbsoluteBytePos::new(encoder.position());
-                    encoder.encode_tagged(TAG_SYNTAX_CONTEXT, ctxt_data)?;
+                    encoder.encode_tagged(TAG_SYNTAX_CONTEXT, ctxt_data);
                     syntax_contexts.insert(index, pos);
-                    Ok(())
                 },
-                |encoder, expn_id, data, hash| -> FileEncodeResult {
+                |encoder, expn_id, data, hash| {
                     if expn_id.krate == LOCAL_CRATE {
                         let pos = AbsoluteBytePos::new(encoder.position());
-                        encoder.encode_tagged(TAG_EXPN_DATA, data)?;
+                        encoder.encode_tagged(TAG_EXPN_DATA, data);
                         expn_data.insert(hash, pos);
                     } else {
                         foreign_expn_data.insert(hash, expn_id.local_id.as_u32());
                     }
-                    Ok(())
                 },
-            )?;
+            );
 
             // `Encode the file footer.
             let footer_pos = encoder.position() as u64;
@@ -343,16 +339,16 @@ impl<'sess> rustc_middle::ty::OnDiskCache<'sess> for OnDiskCache<'sess> {
                     expn_data,
                     foreign_expn_data,
                 },
-            )?;
+            );
 
             // Encode the position of the footer as the last 8 bytes of the
             // file so we know where to look for it.
-            IntEncodedWithFixedSize(footer_pos).encode(encoder.encoder)?;
+            IntEncodedWithFixedSize(footer_pos).encode(&mut encoder.encoder);
 
             // DO NOT WRITE ANYTHING TO THE ENCODER AFTER THIS POINT! The address
             // of the footer must be the last thing in the data stream.
 
-            Ok(())
+            encoder.finish()
         })
     }
 }
@@ -825,7 +821,7 @@ impl OpaqueEncoder for FileEncoder {
 /// An encoder that can write to the incremental compilation cache.
 pub struct CacheEncoder<'a, 'tcx, E: OpaqueEncoder> {
     tcx: TyCtxt<'tcx>,
-    encoder: &'a mut E,
+    encoder: E,
     type_shorthands: FxHashMap<Ty<'tcx>, usize>,
     predicate_shorthands: FxHashMap<ty::PredicateKind<'tcx>, usize>,
     interpret_allocs: FxIndexSet<interpret::AllocId>,
@@ -836,7 +832,7 @@ pub struct CacheEncoder<'a, 'tcx, E: OpaqueEncoder> {
 
 impl<'a, 'tcx, E> CacheEncoder<'a, 'tcx, E>
 where
-    E: 'a + OpaqueEncoder,
+    E: OpaqueEncoder,
 {
     fn source_file_index(&mut self, source_file: Lrc<SourceFile>) -> SourceFileIndex {
         self.file_to_file_index[&(&*source_file as *const SourceFile)]
@@ -847,48 +843,44 @@ where
     /// encode the specified tag, then the given value, then the number of
     /// bytes taken up by tag and value. On decoding, we can then verify that
     /// we get the expected tag and read the expected number of bytes.
-    fn encode_tagged<T: Encodable<Self>, V: Encodable<Self>>(
-        &mut self,
-        tag: T,
-        value: &V,
-    ) -> Result<(), E::Error> {
+    fn encode_tagged<T: Encodable<Self>, V: Encodable<Self>>(&mut self, tag: T, value: &V) {
         let start_pos = self.position();
 
-        tag.encode(self)?;
-        value.encode(self)?;
+        tag.encode(self);
+        value.encode(self);
 
         let end_pos = self.position();
-        ((end_pos - start_pos) as u64).encode(self)
+        ((end_pos - start_pos) as u64).encode(self);
     }
 }
 
 impl<'a, 'tcx, E> Encodable<CacheEncoder<'a, 'tcx, E>> for SyntaxContext
 where
-    E: 'a + OpaqueEncoder,
+    E: OpaqueEncoder,
 {
-    fn encode(&self, s: &mut CacheEncoder<'a, 'tcx, E>) -> Result<(), E::Error> {
-        rustc_span::hygiene::raw_encode_syntax_context(*self, s.hygiene_context, s)
+    fn encode(&self, s: &mut CacheEncoder<'a, 'tcx, E>) {
+        rustc_span::hygiene::raw_encode_syntax_context(*self, s.hygiene_context, s);
     }
 }
 
 impl<'a, 'tcx, E> Encodable<CacheEncoder<'a, 'tcx, E>> for ExpnId
 where
-    E: 'a + OpaqueEncoder,
+    E: OpaqueEncoder,
 {
-    fn encode(&self, s: &mut CacheEncoder<'a, 'tcx, E>) -> Result<(), E::Error> {
+    fn encode(&self, s: &mut CacheEncoder<'a, 'tcx, E>) {
         s.hygiene_context.schedule_expn_data_for_encoding(*self);
-        self.expn_hash().encode(s)
+        self.expn_hash().encode(s);
     }
 }
 
 impl<'a, 'tcx, E> Encodable<CacheEncoder<'a, 'tcx, E>> for Span
 where
-    E: 'a + OpaqueEncoder,
+    E: OpaqueEncoder,
 {
-    fn encode(&self, s: &mut CacheEncoder<'a, 'tcx, E>) -> Result<(), E::Error> {
+    fn encode(&self, s: &mut CacheEncoder<'a, 'tcx, E>) {
         let span_data = self.data_untracked();
-        span_data.ctxt.encode(s)?;
-        span_data.parent.encode(s)?;
+        span_data.ctxt.encode(s);
+        span_data.parent.encode(s);
 
         if span_data.is_dummy() {
             return TAG_PARTIAL_SPAN.encode(s);
@@ -897,10 +889,10 @@ where
         if let Some(parent) = span_data.parent {
             let enclosing = s.tcx.definitions_untracked().def_span(parent).data_untracked();
             if enclosing.contains(span_data) {
-                TAG_RELATIVE_SPAN.encode(s)?;
-                (span_data.lo - enclosing.lo).to_u32().encode(s)?;
-                (span_data.hi - enclosing.lo).to_u32().encode(s)?;
-                return Ok(());
+                TAG_RELATIVE_SPAN.encode(s);
+                (span_data.lo - enclosing.lo).to_u32().encode(s);
+                (span_data.hi - enclosing.lo).to_u32().encode(s);
+                return;
             }
         }
 
@@ -920,17 +912,17 @@ where
 
         let source_file_index = s.source_file_index(file_lo);
 
-        TAG_FULL_SPAN.encode(s)?;
-        source_file_index.encode(s)?;
-        line_lo.encode(s)?;
-        col_lo.encode(s)?;
-        len.encode(s)
+        TAG_FULL_SPAN.encode(s);
+        source_file_index.encode(s);
+        line_lo.encode(s);
+        col_lo.encode(s);
+        len.encode(s);
     }
 }
 
 impl<'a, 'tcx, E> TyEncoder for CacheEncoder<'a, 'tcx, E>
 where
-    E: 'a + OpaqueEncoder,
+    E: OpaqueEncoder,
 {
     type I = TyCtxt<'tcx>;
     const CLEAR_CROSS_CRATE: bool = false;
@@ -944,36 +936,36 @@ where
     fn predicate_shorthands(&mut self) -> &mut FxHashMap<ty::PredicateKind<'tcx>, usize> {
         &mut self.predicate_shorthands
     }
-    fn encode_alloc_id(&mut self, alloc_id: &interpret::AllocId) -> Result<(), Self::Error> {
+    fn encode_alloc_id(&mut self, alloc_id: &interpret::AllocId) {
         let (index, _) = self.interpret_allocs.insert_full(*alloc_id);
 
-        index.encode(self)
+        index.encode(self);
     }
 }
 
 impl<'a, 'tcx, E> Encodable<CacheEncoder<'a, 'tcx, E>> for CrateNum
 where
-    E: 'a + OpaqueEncoder,
+    E: OpaqueEncoder,
 {
-    fn encode(&self, s: &mut CacheEncoder<'a, 'tcx, E>) -> Result<(), E::Error> {
-        s.tcx.stable_crate_id(*self).encode(s)
+    fn encode(&self, s: &mut CacheEncoder<'a, 'tcx, E>) {
+        s.tcx.stable_crate_id(*self).encode(s);
     }
 }
 
 impl<'a, 'tcx, E> Encodable<CacheEncoder<'a, 'tcx, E>> for DefId
 where
-    E: 'a + OpaqueEncoder,
+    E: OpaqueEncoder,
 {
-    fn encode(&self, s: &mut CacheEncoder<'a, 'tcx, E>) -> Result<(), E::Error> {
-        s.tcx.def_path_hash(*self).encode(s)
+    fn encode(&self, s: &mut CacheEncoder<'a, 'tcx, E>) {
+        s.tcx.def_path_hash(*self).encode(s);
     }
 }
 
 impl<'a, 'tcx, E> Encodable<CacheEncoder<'a, 'tcx, E>> for DefIndex
 where
-    E: 'a + OpaqueEncoder,
+    E: OpaqueEncoder,
 {
-    fn encode(&self, _: &mut CacheEncoder<'a, 'tcx, E>) -> Result<(), E::Error> {
+    fn encode(&self, _: &mut CacheEncoder<'a, 'tcx, E>) {
         bug!("encoding `DefIndex` without context");
     }
 }
@@ -981,7 +973,7 @@ where
 macro_rules! encoder_methods {
     ($($name:ident($ty:ty);)*) => {
         #[inline]
-        $(fn $name(&mut self, value: $ty) -> Result<(), Self::Error> {
+        $(fn $name(&mut self, value: $ty) {
             self.encoder.$name(value)
         })*
     }
@@ -989,9 +981,10 @@ macro_rules! encoder_methods {
 
 impl<'a, 'tcx, E> Encoder for CacheEncoder<'a, 'tcx, E>
 where
-    E: 'a + OpaqueEncoder,
+    E: OpaqueEncoder,
 {
-    type Error = E::Error;
+    type Ok = E::Ok;
+    type Err = E::Err;
 
     encoder_methods! {
         emit_usize(usize);
@@ -1015,6 +1008,10 @@ where
         emit_str(&str);
         emit_raw_bytes(&[u8]);
     }
+
+    fn finish(self) -> Result<E::Ok, E::Err> {
+        self.encoder.finish()
+    }
 }
 
 // This ensures that the `Encodable<opaque::FileEncoder>::encode` specialization for byte slices
@@ -1022,8 +1019,8 @@ where
 // Unfortunately, we have to manually opt into specializations this way, given how `CacheEncoder`
 // and the encoding traits currently work.
 impl<'a, 'tcx> Encodable<CacheEncoder<'a, 'tcx, FileEncoder>> for [u8] {
-    fn encode(&self, e: &mut CacheEncoder<'a, 'tcx, FileEncoder>) -> FileEncodeResult {
-        self.encode(e.encoder)
+    fn encode(&self, e: &mut CacheEncoder<'a, 'tcx, FileEncoder>) {
+        self.encode(&mut e.encoder);
     }
 }
 
@@ -1031,8 +1028,7 @@ pub fn encode_query_results<'a, 'tcx, CTX, Q>(
     tcx: CTX,
     encoder: &mut CacheEncoder<'a, 'tcx, FileEncoder>,
     query_result_index: &mut EncodedDepNodeIndex,
-) -> FileEncodeResult
-where
+) where
     CTX: QueryContext + 'tcx,
     Q: super::QueryDescription<CTX>,
     Q::Value: Encodable<CacheEncoder<'a, 'tcx, FileEncoder>>,
@@ -1044,11 +1040,7 @@ where
 
     assert!(Q::query_state(tcx).all_inactive());
     let cache = Q::query_cache(tcx);
-    let mut res = Ok(());
     cache.iter(&mut |key, value, dep_node| {
-        if res.is_err() {
-            return;
-        }
         if Q::cache_on_disk(*tcx.dep_context(), &key) {
             let dep_node = SerializedDepNodeIndex::new(dep_node.index());
 
@@ -1057,14 +1049,7 @@ where
 
             // Encode the type check tables with the `SerializedDepNodeIndex`
             // as tag.
-            match encoder.encode_tagged(dep_node, value) {
-                Ok(()) => {}
-                Err(e) => {
-                    res = Err(e);
-                }
-            }
+            encoder.encode_tagged(dep_node, value);
         }
     });
-
-    res
 }

--- a/compiler/rustc_query_impl/src/on_disk_cache.rs
+++ b/compiler/rustc_query_impl/src/on_disk_cache.rs
@@ -25,6 +25,7 @@ use rustc_span::hygiene::{
 use rustc_span::source_map::{SourceMap, StableSourceFileId};
 use rustc_span::CachingSourceMapView;
 use rustc_span::{BytePos, ExpnData, ExpnHash, Pos, SourceFile, Span};
+use std::io;
 use std::mem;
 
 const TAG_FILE_FOOTER: u128 = 0xC0FFEE_C0FFEE_C0FFEE_C0FFEE_C0FFEE;
@@ -807,21 +808,10 @@ impl_ref_decoder! {<'tcx>
 
 //- ENCODING -------------------------------------------------------------------
 
-pub trait OpaqueEncoder: Encoder {
-    fn position(&self) -> usize;
-}
-
-impl OpaqueEncoder for FileEncoder {
-    #[inline]
-    fn position(&self) -> usize {
-        FileEncoder::position(self)
-    }
-}
-
 /// An encoder that can write to the incremental compilation cache.
-pub struct CacheEncoder<'a, 'tcx, E: OpaqueEncoder> {
+pub struct CacheEncoder<'a, 'tcx> {
     tcx: TyCtxt<'tcx>,
-    encoder: E,
+    encoder: FileEncoder,
     type_shorthands: FxHashMap<Ty<'tcx>, usize>,
     predicate_shorthands: FxHashMap<ty::PredicateKind<'tcx>, usize>,
     interpret_allocs: FxIndexSet<interpret::AllocId>,
@@ -830,10 +820,7 @@ pub struct CacheEncoder<'a, 'tcx, E: OpaqueEncoder> {
     hygiene_context: &'a HygieneEncodeContext,
 }
 
-impl<'a, 'tcx, E> CacheEncoder<'a, 'tcx, E>
-where
-    E: OpaqueEncoder,
-{
+impl<'a, 'tcx> CacheEncoder<'a, 'tcx> {
     fn source_file_index(&mut self, source_file: Lrc<SourceFile>) -> SourceFileIndex {
         self.file_to_file_index[&(&*source_file as *const SourceFile)]
     }
@@ -852,32 +839,27 @@ where
         let end_pos = self.position();
         ((end_pos - start_pos) as u64).encode(self);
     }
+
+    fn finish(self) -> Result<usize, io::Error> {
+        self.encoder.finish()
+    }
 }
 
-impl<'a, 'tcx, E> Encodable<CacheEncoder<'a, 'tcx, E>> for SyntaxContext
-where
-    E: OpaqueEncoder,
-{
-    fn encode(&self, s: &mut CacheEncoder<'a, 'tcx, E>) {
+impl<'a, 'tcx> Encodable<CacheEncoder<'a, 'tcx>> for SyntaxContext {
+    fn encode(&self, s: &mut CacheEncoder<'a, 'tcx>) {
         rustc_span::hygiene::raw_encode_syntax_context(*self, s.hygiene_context, s);
     }
 }
 
-impl<'a, 'tcx, E> Encodable<CacheEncoder<'a, 'tcx, E>> for ExpnId
-where
-    E: OpaqueEncoder,
-{
-    fn encode(&self, s: &mut CacheEncoder<'a, 'tcx, E>) {
+impl<'a, 'tcx> Encodable<CacheEncoder<'a, 'tcx>> for ExpnId {
+    fn encode(&self, s: &mut CacheEncoder<'a, 'tcx>) {
         s.hygiene_context.schedule_expn_data_for_encoding(*self);
         self.expn_hash().encode(s);
     }
 }
 
-impl<'a, 'tcx, E> Encodable<CacheEncoder<'a, 'tcx, E>> for Span
-where
-    E: OpaqueEncoder,
-{
-    fn encode(&self, s: &mut CacheEncoder<'a, 'tcx, E>) {
+impl<'a, 'tcx> Encodable<CacheEncoder<'a, 'tcx>> for Span {
+    fn encode(&self, s: &mut CacheEncoder<'a, 'tcx>) {
         let span_data = self.data_untracked();
         span_data.ctxt.encode(s);
         span_data.parent.encode(s);
@@ -920,10 +902,7 @@ where
     }
 }
 
-impl<'a, 'tcx, E> TyEncoder for CacheEncoder<'a, 'tcx, E>
-where
-    E: OpaqueEncoder,
-{
+impl<'a, 'tcx> TyEncoder for CacheEncoder<'a, 'tcx> {
     type I = TyCtxt<'tcx>;
     const CLEAR_CROSS_CRATE: bool = false;
 
@@ -943,29 +922,20 @@ where
     }
 }
 
-impl<'a, 'tcx, E> Encodable<CacheEncoder<'a, 'tcx, E>> for CrateNum
-where
-    E: OpaqueEncoder,
-{
-    fn encode(&self, s: &mut CacheEncoder<'a, 'tcx, E>) {
+impl<'a, 'tcx> Encodable<CacheEncoder<'a, 'tcx>> for CrateNum {
+    fn encode(&self, s: &mut CacheEncoder<'a, 'tcx>) {
         s.tcx.stable_crate_id(*self).encode(s);
     }
 }
 
-impl<'a, 'tcx, E> Encodable<CacheEncoder<'a, 'tcx, E>> for DefId
-where
-    E: OpaqueEncoder,
-{
-    fn encode(&self, s: &mut CacheEncoder<'a, 'tcx, E>) {
+impl<'a, 'tcx> Encodable<CacheEncoder<'a, 'tcx>> for DefId {
+    fn encode(&self, s: &mut CacheEncoder<'a, 'tcx>) {
         s.tcx.def_path_hash(*self).encode(s);
     }
 }
 
-impl<'a, 'tcx, E> Encodable<CacheEncoder<'a, 'tcx, E>> for DefIndex
-where
-    E: OpaqueEncoder,
-{
-    fn encode(&self, _: &mut CacheEncoder<'a, 'tcx, E>) {
+impl<'a, 'tcx> Encodable<CacheEncoder<'a, 'tcx>> for DefIndex {
+    fn encode(&self, _: &mut CacheEncoder<'a, 'tcx>) {
         bug!("encoding `DefIndex` without context");
     }
 }
@@ -979,13 +949,7 @@ macro_rules! encoder_methods {
     }
 }
 
-impl<'a, 'tcx, E> Encoder for CacheEncoder<'a, 'tcx, E>
-where
-    E: OpaqueEncoder,
-{
-    type Ok = E::Ok;
-    type Err = E::Err;
-
+impl<'a, 'tcx> Encoder for CacheEncoder<'a, 'tcx> {
     encoder_methods! {
         emit_usize(usize);
         emit_u128(u128);
@@ -1008,30 +972,26 @@ where
         emit_str(&str);
         emit_raw_bytes(&[u8]);
     }
-
-    fn finish(self) -> Result<E::Ok, E::Err> {
-        self.encoder.finish()
-    }
 }
 
 // This ensures that the `Encodable<opaque::FileEncoder>::encode` specialization for byte slices
 // is used when a `CacheEncoder` having an `opaque::FileEncoder` is passed to `Encodable::encode`.
 // Unfortunately, we have to manually opt into specializations this way, given how `CacheEncoder`
 // and the encoding traits currently work.
-impl<'a, 'tcx> Encodable<CacheEncoder<'a, 'tcx, FileEncoder>> for [u8] {
-    fn encode(&self, e: &mut CacheEncoder<'a, 'tcx, FileEncoder>) {
+impl<'a, 'tcx> Encodable<CacheEncoder<'a, 'tcx>> for [u8] {
+    fn encode(&self, e: &mut CacheEncoder<'a, 'tcx>) {
         self.encode(&mut e.encoder);
     }
 }
 
 pub fn encode_query_results<'a, 'tcx, CTX, Q>(
     tcx: CTX,
-    encoder: &mut CacheEncoder<'a, 'tcx, FileEncoder>,
+    encoder: &mut CacheEncoder<'a, 'tcx>,
     query_result_index: &mut EncodedDepNodeIndex,
 ) where
     CTX: QueryContext + 'tcx,
     Q: super::QueryDescription<CTX>,
-    Q::Value: Encodable<CacheEncoder<'a, 'tcx, FileEncoder>>,
+    Q::Value: Encodable<CacheEncoder<'a, 'tcx>>,
 {
     let _timer = tcx
         .dep_context()

--- a/compiler/rustc_query_impl/src/on_disk_cache.rs
+++ b/compiler/rustc_query_impl/src/on_disk_cache.rs
@@ -15,7 +15,7 @@ use rustc_middle::ty::{self, Ty, TyCtxt};
 use rustc_query_system::dep_graph::DepContext;
 use rustc_query_system::query::{QueryCache, QueryContext, QuerySideEffects};
 use rustc_serialize::{
-    opaque::{self, FileEncodeResult, FileEncoder, IntEncodedWithFixedSize},
+    opaque::{FileEncodeResult, FileEncoder, IntEncodedWithFixedSize, MemDecoder},
     Decodable, Decoder, Encodable, Encoder,
 };
 use rustc_session::Session;
@@ -159,7 +159,7 @@ impl<'sess> rustc_middle::ty::OnDiskCache<'sess> for OnDiskCache<'sess> {
 
         // Wrap in a scope so we can borrow `data`.
         let footer: Footer = {
-            let mut decoder = opaque::Decoder::new(&data, start_pos);
+            let mut decoder = MemDecoder::new(&data, start_pos);
 
             // Decode the *position* of the footer, which can be found in the
             // last 8 bytes of the file.
@@ -438,7 +438,7 @@ impl<'sess> OnDiskCache<'sess> {
         let serialized_data = self.serialized_data.read();
         let mut decoder = CacheDecoder {
             tcx,
-            opaque: opaque::Decoder::new(serialized_data.as_deref().unwrap_or(&[]), pos.to_usize()),
+            opaque: MemDecoder::new(serialized_data.as_deref().unwrap_or(&[]), pos.to_usize()),
             source_map: self.source_map,
             file_index_to_file: &self.file_index_to_file,
             file_index_to_stable_id: &self.file_index_to_stable_id,
@@ -459,7 +459,7 @@ impl<'sess> OnDiskCache<'sess> {
 /// will also handle things that contain `Ty` instances.
 pub struct CacheDecoder<'a, 'tcx> {
     tcx: TyCtxt<'tcx>,
-    opaque: opaque::Decoder<'a>,
+    opaque: MemDecoder<'a>,
     source_map: &'a SourceMap,
     file_index_to_file: &'a Lock<FxHashMap<SourceFileIndex, Lrc<SourceFile>>>,
     file_index_to_stable_id: &'a FxHashMap<SourceFileIndex, EncodedSourceFileId>,
@@ -511,7 +511,7 @@ trait DecoderWithPosition: Decoder {
     fn position(&self) -> usize;
 }
 
-impl<'a> DecoderWithPosition for opaque::Decoder<'a> {
+impl<'a> DecoderWithPosition for MemDecoder<'a> {
     fn position(&self) -> usize {
         self.position()
     }
@@ -587,7 +587,7 @@ impl<'a, 'tcx> TyDecoder for CacheDecoder<'a, 'tcx> {
     {
         debug_assert!(pos < self.opaque.data.len());
 
-        let new_opaque = opaque::Decoder::new(self.opaque.data, pos);
+        let new_opaque = MemDecoder::new(self.opaque.data, pos);
         let old_opaque = mem::replace(&mut self.opaque, new_opaque);
         let r = f(self);
         self.opaque = old_opaque;

--- a/compiler/rustc_query_impl/src/plumbing.rs
+++ b/compiler/rustc_query_impl/src/plumbing.rs
@@ -12,7 +12,6 @@ use rustc_query_system::query::{QueryContext, QueryJobId, QueryMap, QuerySideEff
 use rustc_data_structures::sync::Lock;
 use rustc_data_structures::thin_vec::ThinVec;
 use rustc_errors::{Diagnostic, Handler};
-use rustc_serialize::opaque;
 
 use std::any::Any;
 use std::num::NonZeroU64;
@@ -140,7 +139,7 @@ impl<'tcx> QueryCtxt<'tcx> {
 
     pub(super) fn encode_query_results(
         self,
-        encoder: &mut on_disk_cache::CacheEncoder<'_, 'tcx, opaque::FileEncoder>,
+        encoder: &mut on_disk_cache::CacheEncoder<'_, 'tcx>,
         query_result_index: &mut on_disk_cache::EncodedDepNodeIndex,
     ) {
         macro_rules! encode_queries {

--- a/compiler/rustc_query_impl/src/plumbing.rs
+++ b/compiler/rustc_query_impl/src/plumbing.rs
@@ -142,7 +142,7 @@ impl<'tcx> QueryCtxt<'tcx> {
         self,
         encoder: &mut on_disk_cache::CacheEncoder<'_, 'tcx, opaque::FileEncoder>,
         query_result_index: &mut on_disk_cache::EncodedDepNodeIndex,
-    ) -> opaque::FileEncodeResult {
+    ) {
         macro_rules! encode_queries {
             ($($query:ident,)*) => {
                 $(
@@ -150,14 +150,12 @@ impl<'tcx> QueryCtxt<'tcx> {
                         self,
                         encoder,
                         query_result_index
-                    )?;
+                    );
                 )*
             }
         }
 
         rustc_cached_queries!(encode_queries!);
-
-        Ok(())
     }
 
     pub fn try_print_query_stack(

--- a/compiler/rustc_query_system/src/dep_graph/graph.rs
+++ b/compiler/rustc_query_system/src/dep_graph/graph.rs
@@ -842,7 +842,7 @@ impl<K: DepKind> DepGraph<K> {
         if let Some(data) = &self.data {
             data.current.encoder.steal().finish(profiler)
         } else {
-            Ok(())
+            Ok(0)
         }
     }
 

--- a/compiler/rustc_query_system/src/dep_graph/serialized.rs
+++ b/compiler/rustc_query_system/src/dep_graph/serialized.rs
@@ -20,7 +20,7 @@ use rustc_data_structures::profiling::SelfProfilerRef;
 use rustc_data_structures::sync::Lock;
 use rustc_index::vec::{Idx, IndexVec};
 use rustc_serialize::opaque::{self, FileEncodeResult, FileEncoder, IntEncodedWithFixedSize};
-use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
+use rustc_serialize::{Decodable, Decoder, Encodable};
 use smallvec::SmallVec;
 use std::convert::TryInto;
 

--- a/compiler/rustc_query_system/src/dep_graph/serialized.rs
+++ b/compiler/rustc_query_system/src/dep_graph/serialized.rs
@@ -19,7 +19,7 @@ use rustc_data_structures::fx::FxHashMap;
 use rustc_data_structures::profiling::SelfProfilerRef;
 use rustc_data_structures::sync::Lock;
 use rustc_index::vec::{Idx, IndexVec};
-use rustc_serialize::opaque::{self, FileEncodeResult, FileEncoder, IntEncodedWithFixedSize};
+use rustc_serialize::opaque::{FileEncodeResult, FileEncoder, IntEncodedWithFixedSize, MemDecoder};
 use rustc_serialize::{Decodable, Decoder, Encodable};
 use smallvec::SmallVec;
 use std::convert::TryInto;
@@ -96,11 +96,11 @@ impl<K: DepKind> SerializedDepGraph<K> {
     }
 }
 
-impl<'a, K: DepKind + Decodable<opaque::Decoder<'a>>> Decodable<opaque::Decoder<'a>>
+impl<'a, K: DepKind + Decodable<MemDecoder<'a>>> Decodable<MemDecoder<'a>>
     for SerializedDepGraph<K>
 {
     #[instrument(level = "debug", skip(d))]
-    fn decode(d: &mut opaque::Decoder<'a>) -> SerializedDepGraph<K> {
+    fn decode(d: &mut MemDecoder<'a>) -> SerializedDepGraph<K> {
         let start_position = d.position();
 
         // The last 16 bytes are the node count and edge count.

--- a/compiler/rustc_serialize/src/collection_impls.rs
+++ b/compiler/rustc_serialize/src/collection_impls.rs
@@ -10,9 +10,9 @@ use std::sync::Arc;
 use smallvec::{Array, SmallVec};
 
 impl<S: Encoder, A: Array<Item: Encodable<S>>> Encodable<S> for SmallVec<A> {
-    fn encode(&self, s: &mut S) -> Result<(), S::Error> {
+    fn encode(&self, s: &mut S) {
         let slice: &[A::Item] = self;
-        slice.encode(s)
+        slice.encode(s);
     }
 }
 
@@ -24,12 +24,11 @@ impl<D: Decoder, A: Array<Item: Decodable<D>>> Decodable<D> for SmallVec<A> {
 }
 
 impl<S: Encoder, T: Encodable<S>> Encodable<S> for LinkedList<T> {
-    fn encode(&self, s: &mut S) -> Result<(), S::Error> {
-        s.emit_usize(self.len())?;
+    fn encode(&self, s: &mut S) {
+        s.emit_usize(self.len());
         for e in self.iter() {
-            e.encode(s)?;
+            e.encode(s);
         }
-        Ok(())
     }
 }
 
@@ -41,12 +40,11 @@ impl<D: Decoder, T: Decodable<D>> Decodable<D> for LinkedList<T> {
 }
 
 impl<S: Encoder, T: Encodable<S>> Encodable<S> for VecDeque<T> {
-    fn encode(&self, s: &mut S) -> Result<(), S::Error> {
-        s.emit_usize(self.len())?;
+    fn encode(&self, s: &mut S) {
+        s.emit_usize(self.len());
         for e in self.iter() {
-            e.encode(s)?;
+            e.encode(s);
         }
-        Ok(())
     }
 }
 
@@ -62,13 +60,12 @@ where
     K: Encodable<S> + PartialEq + Ord,
     V: Encodable<S>,
 {
-    fn encode(&self, e: &mut S) -> Result<(), S::Error> {
-        e.emit_usize(self.len())?;
+    fn encode(&self, e: &mut S) {
+        e.emit_usize(self.len());
         for (key, val) in self.iter() {
-            key.encode(e)?;
-            val.encode(e)?;
+            key.encode(e);
+            val.encode(e);
         }
-        Ok(())
     }
 }
 
@@ -93,12 +90,11 @@ impl<S: Encoder, T> Encodable<S> for BTreeSet<T>
 where
     T: Encodable<S> + PartialEq + Ord,
 {
-    fn encode(&self, s: &mut S) -> Result<(), S::Error> {
-        s.emit_usize(self.len())?;
+    fn encode(&self, s: &mut S) {
+        s.emit_usize(self.len());
         for e in self.iter() {
-            e.encode(s)?;
+            e.encode(s);
         }
-        Ok(())
     }
 }
 
@@ -122,13 +118,12 @@ where
     V: Encodable<E>,
     S: BuildHasher,
 {
-    fn encode(&self, e: &mut E) -> Result<(), E::Error> {
-        e.emit_usize(self.len())?;
+    fn encode(&self, e: &mut E) {
+        e.emit_usize(self.len());
         for (key, val) in self.iter() {
-            key.encode(e)?;
-            val.encode(e)?;
+            key.encode(e);
+            val.encode(e);
         }
-        Ok(())
     }
 }
 
@@ -156,12 +151,11 @@ where
     T: Encodable<E> + Eq,
     S: BuildHasher,
 {
-    fn encode(&self, s: &mut E) -> Result<(), E::Error> {
-        s.emit_usize(self.len())?;
+    fn encode(&self, s: &mut E) {
+        s.emit_usize(self.len());
         for e in self.iter() {
-            e.encode(s)?;
+            e.encode(s);
         }
-        Ok(())
     }
 }
 
@@ -187,13 +181,12 @@ where
     V: Encodable<E>,
     S: BuildHasher,
 {
-    fn encode(&self, e: &mut E) -> Result<(), E::Error> {
-        e.emit_usize(self.len())?;
+    fn encode(&self, e: &mut E) {
+        e.emit_usize(self.len());
         for (key, val) in self.iter() {
-            key.encode(e)?;
-            val.encode(e)?;
+            key.encode(e);
+            val.encode(e);
         }
-        Ok(())
     }
 }
 
@@ -221,12 +214,11 @@ where
     T: Encodable<E> + Hash + Eq,
     S: BuildHasher,
 {
-    fn encode(&self, s: &mut E) -> Result<(), E::Error> {
-        s.emit_usize(self.len())?;
+    fn encode(&self, s: &mut E) {
+        s.emit_usize(self.len());
         for e in self.iter() {
-            e.encode(s)?;
+            e.encode(s);
         }
-        Ok(())
     }
 }
 
@@ -247,9 +239,9 @@ where
 }
 
 impl<E: Encoder, T: Encodable<E>> Encodable<E> for Rc<[T]> {
-    fn encode(&self, s: &mut E) -> Result<(), E::Error> {
+    fn encode(&self, s: &mut E) {
         let slice: &[T] = self;
-        slice.encode(s)
+        slice.encode(s);
     }
 }
 
@@ -261,9 +253,9 @@ impl<D: Decoder, T: Decodable<D>> Decodable<D> for Rc<[T]> {
 }
 
 impl<E: Encoder, T: Encodable<E>> Encodable<E> for Arc<[T]> {
-    fn encode(&self, s: &mut E) -> Result<(), E::Error> {
+    fn encode(&self, s: &mut E) {
         let slice: &[T] = self;
-        slice.encode(s)
+        slice.encode(s);
     }
 }
 

--- a/compiler/rustc_serialize/src/opaque.rs
+++ b/compiler/rustc_serialize/src/opaque.rs
@@ -1,5 +1,5 @@
 use crate::leb128::{self, max_leb128_len};
-use crate::serialize::{self, Decoder as _, Encoder as _};
+use crate::serialize::{Decodable, Decoder, Encodable, Encoder};
 use std::convert::TryInto;
 use std::fs::File;
 use std::io::{self, Write};
@@ -11,13 +11,13 @@ use std::ptr;
 // Encoder
 // -----------------------------------------------------------------------------
 
-pub struct Encoder {
+pub struct MemEncoder {
     pub data: Vec<u8>,
 }
 
-impl Encoder {
-    pub fn new() -> Encoder {
-        Encoder { data: vec![] }
+impl MemEncoder {
+    pub fn new() -> MemEncoder {
+        MemEncoder { data: vec![] }
     }
 
     #[inline]
@@ -57,7 +57,7 @@ macro_rules! write_leb128 {
 /// [utf8]: https://en.wikipedia.org/w/index.php?title=UTF-8&oldid=1058865525#Codepage_layout
 const STR_SENTINEL: u8 = 0xC1;
 
-impl serialize::Encoder for Encoder {
+impl Encoder for MemEncoder {
     #[inline]
     fn emit_usize(&mut self, v: usize) {
         write_leb128!(self, v, usize, write_usize_leb128)
@@ -158,7 +158,7 @@ pub type FileEncodeResult = Result<usize, io::Error>;
 // `FileEncoder` encodes data to file via fixed-size buffer.
 //
 // When encoding large amounts of data to a file, using `FileEncoder` may be
-// preferred over using `Encoder` to encode to a `Vec`, and then writing the
+// preferred over using `MemEncoder` to encode to a `Vec`, and then writing the
 // `Vec` to file, as the latter uses as much memory as there is encoded data,
 // while the former uses the fixed amount of memory allocated to the buffer.
 // `FileEncoder` also has the advantage of not needing to reallocate as data
@@ -429,7 +429,7 @@ macro_rules! file_encoder_write_leb128 {
     }};
 }
 
-impl serialize::Encoder for FileEncoder {
+impl Encoder for FileEncoder {
     #[inline]
     fn emit_usize(&mut self, v: usize) {
         file_encoder_write_leb128!(self, v, usize, write_usize_leb128)
@@ -529,15 +529,15 @@ impl serialize::Encoder for FileEncoder {
 // Decoder
 // -----------------------------------------------------------------------------
 
-pub struct Decoder<'a> {
+pub struct MemDecoder<'a> {
     pub data: &'a [u8],
     position: usize,
 }
 
-impl<'a> Decoder<'a> {
+impl<'a> MemDecoder<'a> {
     #[inline]
-    pub fn new(data: &'a [u8], position: usize) -> Decoder<'a> {
-        Decoder { data, position }
+    pub fn new(data: &'a [u8], position: usize) -> MemDecoder<'a> {
+        MemDecoder { data, position }
     }
 
     #[inline]
@@ -560,7 +560,7 @@ macro_rules! read_leb128 {
     ($dec:expr, $fun:ident) => {{ leb128::$fun($dec.data, &mut $dec.position) }};
 }
 
-impl<'a> serialize::Decoder for Decoder<'a> {
+impl<'a> Decoder for MemDecoder<'a> {
     #[inline]
     fn read_u128(&mut self) -> u128 {
         read_leb128!(self, read_u128_leb128)
@@ -682,25 +682,25 @@ impl<'a> serialize::Decoder for Decoder<'a> {
 
 // Specialize encoding byte slices. This specialization also applies to encoding `Vec<u8>`s, etc.,
 // since the default implementations call `encode` on their slices internally.
-impl serialize::Encodable<Encoder> for [u8] {
-    fn encode(&self, e: &mut Encoder) {
-        serialize::Encoder::emit_usize(e, self.len());
+impl Encodable<MemEncoder> for [u8] {
+    fn encode(&self, e: &mut MemEncoder) {
+        Encoder::emit_usize(e, self.len());
         e.emit_raw_bytes(self);
     }
 }
 
-impl serialize::Encodable<FileEncoder> for [u8] {
+impl Encodable<FileEncoder> for [u8] {
     fn encode(&self, e: &mut FileEncoder) {
-        serialize::Encoder::emit_usize(e, self.len());
+        Encoder::emit_usize(e, self.len());
         e.emit_raw_bytes(self);
     }
 }
 
 // Specialize decoding `Vec<u8>`. This specialization also applies to decoding `Box<[u8]>`s, etc.,
 // since the default implementations call `decode` to produce a `Vec<u8>` internally.
-impl<'a> serialize::Decodable<Decoder<'a>> for Vec<u8> {
-    fn decode(d: &mut Decoder<'a>) -> Self {
-        let len = serialize::Decoder::read_usize(d);
+impl<'a> Decodable<MemDecoder<'a>> for Vec<u8> {
+    fn decode(d: &mut MemDecoder<'a>) -> Self {
+        let len = Decoder::read_usize(d);
         d.read_raw_bytes(len).to_owned()
     }
 }
@@ -712,9 +712,9 @@ impl IntEncodedWithFixedSize {
     pub const ENCODED_SIZE: usize = 8;
 }
 
-impl serialize::Encodable<Encoder> for IntEncodedWithFixedSize {
+impl Encodable<MemEncoder> for IntEncodedWithFixedSize {
     #[inline]
-    fn encode(&self, e: &mut Encoder) {
+    fn encode(&self, e: &mut MemEncoder) {
         let _start_pos = e.position();
         e.emit_raw_bytes(&self.0.to_le_bytes());
         let _end_pos = e.position();
@@ -722,7 +722,7 @@ impl serialize::Encodable<Encoder> for IntEncodedWithFixedSize {
     }
 }
 
-impl serialize::Encodable<FileEncoder> for IntEncodedWithFixedSize {
+impl Encodable<FileEncoder> for IntEncodedWithFixedSize {
     #[inline]
     fn encode(&self, e: &mut FileEncoder) {
         let _start_pos = e.position();
@@ -732,9 +732,9 @@ impl serialize::Encodable<FileEncoder> for IntEncodedWithFixedSize {
     }
 }
 
-impl<'a> serialize::Decodable<Decoder<'a>> for IntEncodedWithFixedSize {
+impl<'a> Decodable<MemDecoder<'a>> for IntEncodedWithFixedSize {
     #[inline]
-    fn decode(decoder: &mut Decoder<'a>) -> IntEncodedWithFixedSize {
+    fn decode(decoder: &mut MemDecoder<'a>) -> IntEncodedWithFixedSize {
         let _start_pos = decoder.position();
         let bytes = decoder.read_raw_bytes(IntEncodedWithFixedSize::ENCODED_SIZE);
         let value = u64::from_le_bytes(bytes.try_into().unwrap());

--- a/compiler/rustc_serialize/src/opaque.rs
+++ b/compiler/rustc_serialize/src/opaque.rs
@@ -18,8 +18,8 @@ pub struct Encoder {
 }
 
 impl Encoder {
-    pub fn new(data: Vec<u8>) -> Encoder {
-        Encoder { data }
+    pub fn new() -> Encoder {
+        Encoder { data: vec![] }
     }
 
     pub fn into_inner(self) -> Vec<u8> {

--- a/compiler/rustc_serialize/src/serialize.rs
+++ b/compiler/rustc_serialize/src/serialize.rs
@@ -11,36 +11,47 @@ use std::path;
 use std::rc::Rc;
 use std::sync::Arc;
 
+/// A note about error handling.
+///
+/// Encoders may be fallible, but in practice failure is rare and there are so
+/// many nested calls that typical Rust error handling (via `Result` and `?`)
+/// is pervasive and has non-trivial cost. Instead, impls of this trait must
+/// implement a delayed error handling strategy. If a failure occurs, they
+/// should record this internally, and all subsequent encoding operations can
+/// be processed or ignored, whichever is appropriate. Then when `finish()` is
+/// called, an error result should be returned to indicate the failure. If no
+/// failures occurred, then `finish()` should return a success result.
 pub trait Encoder {
-    type Error;
+    type Ok;
+    type Err;
 
     // Primitive types:
-    fn emit_usize(&mut self, v: usize) -> Result<(), Self::Error>;
-    fn emit_u128(&mut self, v: u128) -> Result<(), Self::Error>;
-    fn emit_u64(&mut self, v: u64) -> Result<(), Self::Error>;
-    fn emit_u32(&mut self, v: u32) -> Result<(), Self::Error>;
-    fn emit_u16(&mut self, v: u16) -> Result<(), Self::Error>;
-    fn emit_u8(&mut self, v: u8) -> Result<(), Self::Error>;
-    fn emit_isize(&mut self, v: isize) -> Result<(), Self::Error>;
-    fn emit_i128(&mut self, v: i128) -> Result<(), Self::Error>;
-    fn emit_i64(&mut self, v: i64) -> Result<(), Self::Error>;
-    fn emit_i32(&mut self, v: i32) -> Result<(), Self::Error>;
-    fn emit_i16(&mut self, v: i16) -> Result<(), Self::Error>;
-    fn emit_i8(&mut self, v: i8) -> Result<(), Self::Error>;
-    fn emit_bool(&mut self, v: bool) -> Result<(), Self::Error>;
-    fn emit_f64(&mut self, v: f64) -> Result<(), Self::Error>;
-    fn emit_f32(&mut self, v: f32) -> Result<(), Self::Error>;
-    fn emit_char(&mut self, v: char) -> Result<(), Self::Error>;
-    fn emit_str(&mut self, v: &str) -> Result<(), Self::Error>;
-    fn emit_raw_bytes(&mut self, s: &[u8]) -> Result<(), Self::Error>;
+    fn emit_usize(&mut self, v: usize);
+    fn emit_u128(&mut self, v: u128);
+    fn emit_u64(&mut self, v: u64);
+    fn emit_u32(&mut self, v: u32);
+    fn emit_u16(&mut self, v: u16);
+    fn emit_u8(&mut self, v: u8);
+    fn emit_isize(&mut self, v: isize);
+    fn emit_i128(&mut self, v: i128);
+    fn emit_i64(&mut self, v: i64);
+    fn emit_i32(&mut self, v: i32);
+    fn emit_i16(&mut self, v: i16);
+    fn emit_i8(&mut self, v: i8);
+    fn emit_bool(&mut self, v: bool);
+    fn emit_f64(&mut self, v: f64);
+    fn emit_f32(&mut self, v: f32);
+    fn emit_char(&mut self, v: char);
+    fn emit_str(&mut self, v: &str);
+    fn emit_raw_bytes(&mut self, s: &[u8]);
 
     // Convenience for the derive macro:
-    fn emit_enum_variant<F>(&mut self, v_id: usize, f: F) -> Result<(), Self::Error>
+    fn emit_enum_variant<F>(&mut self, v_id: usize, f: F)
     where
-        F: FnOnce(&mut Self) -> Result<(), Self::Error>,
+        F: FnOnce(&mut Self),
     {
-        self.emit_usize(v_id)?;
-        f(self)
+        self.emit_usize(v_id);
+        f(self);
     }
 
     // We put the field index in a const generic to allow the emit_usize to be
@@ -50,9 +61,12 @@ pub trait Encoder {
     // optimization that would otherwise be necessary here, likely due to the
     // multiple levels of inlining and const-prop that are needed.
     #[inline]
-    fn emit_fieldless_enum_variant<const ID: usize>(&mut self) -> Result<(), Self::Error> {
+    fn emit_fieldless_enum_variant<const ID: usize>(&mut self) {
         self.emit_usize(ID)
     }
+
+    // Consume the encoder, getting the result.
+    fn finish(self) -> Result<Self::Ok, Self::Err>;
 }
 
 // Note: all the methods in this trait are infallible, which may be surprising.
@@ -95,7 +109,7 @@ pub trait Decoder {
 /// * `TyEncodable` should be used for types that are only serialized in crate
 ///   metadata or the incremental cache. This is most types in `rustc_middle`.
 pub trait Encodable<S: Encoder> {
-    fn encode(&self, s: &mut S) -> Result<(), S::Error>;
+    fn encode(&self, s: &mut S);
 }
 
 /// Trait for types that can be deserialized
@@ -117,8 +131,8 @@ macro_rules! direct_serialize_impls {
     ($($ty:ident $emit_method:ident $read_method:ident),*) => {
         $(
             impl<S: Encoder> Encodable<S> for $ty {
-                fn encode(&self, s: &mut S) -> Result<(), S::Error> {
-                    s.$emit_method(*self)
+                fn encode(&self, s: &mut S) {
+                    s.$emit_method(*self);
                 }
             }
 
@@ -138,12 +152,14 @@ direct_serialize_impls! {
     u32 emit_u32 read_u32,
     u64 emit_u64 read_u64,
     u128 emit_u128 read_u128,
+
     isize emit_isize read_isize,
     i8 emit_i8 read_i8,
     i16 emit_i16 read_i16,
     i32 emit_i32 read_i32,
     i64 emit_i64 read_i64,
     i128 emit_i128 read_i128,
+
     f32 emit_f32 read_f32,
     f64 emit_f64 read_f64,
     bool emit_bool read_bool,
@@ -154,14 +170,14 @@ impl<S: Encoder, T: ?Sized> Encodable<S> for &T
 where
     T: Encodable<S>,
 {
-    fn encode(&self, s: &mut S) -> Result<(), S::Error> {
+    fn encode(&self, s: &mut S) {
         (**self).encode(s)
     }
 }
 
 impl<S: Encoder> Encodable<S> for ! {
-    fn encode(&self, _s: &mut S) -> Result<(), S::Error> {
-        unreachable!()
+    fn encode(&self, _s: &mut S) {
+        unreachable!();
     }
 }
 
@@ -172,8 +188,8 @@ impl<D: Decoder> Decodable<D> for ! {
 }
 
 impl<S: Encoder> Encodable<S> for ::std::num::NonZeroU32 {
-    fn encode(&self, s: &mut S) -> Result<(), S::Error> {
-        s.emit_u32(self.get())
+    fn encode(&self, s: &mut S) {
+        s.emit_u32(self.get());
     }
 }
 
@@ -184,14 +200,14 @@ impl<D: Decoder> Decodable<D> for ::std::num::NonZeroU32 {
 }
 
 impl<S: Encoder> Encodable<S> for str {
-    fn encode(&self, s: &mut S) -> Result<(), S::Error> {
-        s.emit_str(self)
+    fn encode(&self, s: &mut S) {
+        s.emit_str(self);
     }
 }
 
 impl<S: Encoder> Encodable<S> for String {
-    fn encode(&self, s: &mut S) -> Result<(), S::Error> {
-        s.emit_str(&self[..])
+    fn encode(&self, s: &mut S) {
+        s.emit_str(&self[..]);
     }
 }
 
@@ -202,9 +218,7 @@ impl<D: Decoder> Decodable<D> for String {
 }
 
 impl<S: Encoder> Encodable<S> for () {
-    fn encode(&self, _s: &mut S) -> Result<(), S::Error> {
-        Ok(())
-    }
+    fn encode(&self, _s: &mut S) {}
 }
 
 impl<D: Decoder> Decodable<D> for () {
@@ -212,9 +226,7 @@ impl<D: Decoder> Decodable<D> for () {
 }
 
 impl<S: Encoder, T> Encodable<S> for PhantomData<T> {
-    fn encode(&self, _s: &mut S) -> Result<(), S::Error> {
-        Ok(())
-    }
+    fn encode(&self, _s: &mut S) {}
 }
 
 impl<D: Decoder, T> Decodable<D> for PhantomData<T> {
@@ -231,8 +243,8 @@ impl<D: Decoder, T: Decodable<D>> Decodable<D> for Box<[T]> {
 }
 
 impl<S: Encoder, T: Encodable<S>> Encodable<S> for Rc<T> {
-    fn encode(&self, s: &mut S) -> Result<(), S::Error> {
-        (**self).encode(s)
+    fn encode(&self, s: &mut S) {
+        (**self).encode(s);
     }
 }
 
@@ -243,19 +255,18 @@ impl<D: Decoder, T: Decodable<D>> Decodable<D> for Rc<T> {
 }
 
 impl<S: Encoder, T: Encodable<S>> Encodable<S> for [T] {
-    default fn encode(&self, s: &mut S) -> Result<(), S::Error> {
-        s.emit_usize(self.len())?;
+    default fn encode(&self, s: &mut S) {
+        s.emit_usize(self.len());
         for e in self.iter() {
-            e.encode(s)?
+            e.encode(s);
         }
-        Ok(())
     }
 }
 
 impl<S: Encoder, T: Encodable<S>> Encodable<S> for Vec<T> {
-    fn encode(&self, s: &mut S) -> Result<(), S::Error> {
+    fn encode(&self, s: &mut S) {
         let slice: &[T] = self;
-        slice.encode(s)
+        slice.encode(s);
     }
 }
 
@@ -277,9 +288,9 @@ impl<D: Decoder, T: Decodable<D>> Decodable<D> for Vec<T> {
 }
 
 impl<S: Encoder, T: Encodable<S>, const N: usize> Encodable<S> for [T; N] {
-    fn encode(&self, s: &mut S) -> Result<(), S::Error> {
+    fn encode(&self, s: &mut S) {
         let slice: &[T] = self;
-        slice.encode(s)
+        slice.encode(s);
     }
 }
 
@@ -299,9 +310,9 @@ impl<'a, S: Encoder, T: Encodable<S>> Encodable<S> for Cow<'a, [T]>
 where
     [T]: ToOwned<Owned = Vec<T>>,
 {
-    fn encode(&self, s: &mut S) -> Result<(), S::Error> {
+    fn encode(&self, s: &mut S) {
         let slice: &[T] = self;
-        slice.encode(s)
+        slice.encode(s);
     }
 }
 
@@ -316,7 +327,7 @@ where
 }
 
 impl<'a, S: Encoder> Encodable<S> for Cow<'a, str> {
-    fn encode(&self, s: &mut S) -> Result<(), S::Error> {
+    fn encode(&self, s: &mut S) {
         let val: &str = self;
         val.encode(s)
     }
@@ -330,9 +341,9 @@ impl<'a, D: Decoder> Decodable<D> for Cow<'a, str> {
 }
 
 impl<S: Encoder, T: Encodable<S>> Encodable<S> for Option<T> {
-    fn encode(&self, s: &mut S) -> Result<(), S::Error> {
+    fn encode(&self, s: &mut S) {
         match *self {
-            None => s.emit_enum_variant(0, |_| Ok(())),
+            None => s.emit_enum_variant(0, |_| {}),
             Some(ref v) => s.emit_enum_variant(1, |s| v.encode(s)),
         }
     }
@@ -349,7 +360,7 @@ impl<D: Decoder, T: Decodable<D>> Decodable<D> for Option<T> {
 }
 
 impl<S: Encoder, T1: Encodable<S>, T2: Encodable<S>> Encodable<S> for Result<T1, T2> {
-    fn encode(&self, s: &mut S) -> Result<(), S::Error> {
+    fn encode(&self, s: &mut S) {
         match *self {
             Ok(ref v) => s.emit_enum_variant(0, |s| v.encode(s)),
             Err(ref v) => s.emit_enum_variant(1, |s| v.encode(s)),
@@ -381,10 +392,9 @@ macro_rules! tuple {
         }
         impl<S: Encoder, $($name: Encodable<S>),+> Encodable<S> for ($($name,)+) {
             #[allow(non_snake_case)]
-            fn encode(&self, s: &mut S) -> Result<(), S::Error> {
+            fn encode(&self, s: &mut S) {
                 let ($(ref $name,)+) = *self;
-                $($name.encode(s)?;)+
-                Ok(())
+                $($name.encode(s);)+
             }
         }
         peel! { $($name,)+ }
@@ -394,14 +404,14 @@ macro_rules! tuple {
 tuple! { T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, }
 
 impl<S: Encoder> Encodable<S> for path::Path {
-    fn encode(&self, e: &mut S) -> Result<(), S::Error> {
-        self.to_str().unwrap().encode(e)
+    fn encode(&self, e: &mut S) {
+        self.to_str().unwrap().encode(e);
     }
 }
 
 impl<S: Encoder> Encodable<S> for path::PathBuf {
-    fn encode(&self, e: &mut S) -> Result<(), S::Error> {
-        path::Path::encode(self, e)
+    fn encode(&self, e: &mut S) {
+        path::Path::encode(self, e);
     }
 }
 
@@ -413,8 +423,8 @@ impl<D: Decoder> Decodable<D> for path::PathBuf {
 }
 
 impl<S: Encoder, T: Encodable<S> + Copy> Encodable<S> for Cell<T> {
-    fn encode(&self, s: &mut S) -> Result<(), S::Error> {
-        self.get().encode(s)
+    fn encode(&self, s: &mut S) {
+        self.get().encode(s);
     }
 }
 
@@ -430,8 +440,8 @@ impl<D: Decoder, T: Decodable<D> + Copy> Decodable<D> for Cell<T> {
 // from `encode` when `try_borrow` returns `None`.
 
 impl<S: Encoder, T: Encodable<S>> Encodable<S> for RefCell<T> {
-    fn encode(&self, s: &mut S) -> Result<(), S::Error> {
-        self.borrow().encode(s)
+    fn encode(&self, s: &mut S) {
+        self.borrow().encode(s);
     }
 }
 
@@ -442,8 +452,8 @@ impl<D: Decoder, T: Decodable<D>> Decodable<D> for RefCell<T> {
 }
 
 impl<S: Encoder, T: Encodable<S>> Encodable<S> for Arc<T> {
-    fn encode(&self, s: &mut S) -> Result<(), S::Error> {
-        (**self).encode(s)
+    fn encode(&self, s: &mut S) {
+        (**self).encode(s);
     }
 }
 
@@ -454,8 +464,8 @@ impl<D: Decoder, T: Decodable<D>> Decodable<D> for Arc<T> {
 }
 
 impl<S: Encoder, T: ?Sized + Encodable<S>> Encodable<S> for Box<T> {
-    fn encode(&self, s: &mut S) -> Result<(), S::Error> {
-        (**self).encode(s)
+    fn encode(&self, s: &mut S) {
+        (**self).encode(s);
     }
 }
 impl<D: Decoder, T: Decodable<D>> Decodable<D> for Box<T> {

--- a/compiler/rustc_serialize/src/serialize.rs
+++ b/compiler/rustc_serialize/src/serialize.rs
@@ -18,13 +18,10 @@ use std::sync::Arc;
 /// is pervasive and has non-trivial cost. Instead, impls of this trait must
 /// implement a delayed error handling strategy. If a failure occurs, they
 /// should record this internally, and all subsequent encoding operations can
-/// be processed or ignored, whichever is appropriate. Then when `finish()` is
-/// called, an error result should be returned to indicate the failure. If no
-/// failures occurred, then `finish()` should return a success result.
+/// be processed or ignored, whichever is appropriate. Then they should provide
+/// a `finish` method that finishes up encoding. If the encoder is fallible,
+/// `finish` should return a `Result` that indicates success or failure.
 pub trait Encoder {
-    type Ok;
-    type Err;
-
     // Primitive types:
     fn emit_usize(&mut self, v: usize);
     fn emit_u128(&mut self, v: u128);
@@ -64,9 +61,6 @@ pub trait Encoder {
     fn emit_fieldless_enum_variant<const ID: usize>(&mut self) {
         self.emit_usize(ID)
     }
-
-    // Consume the encoder, getting the result.
-    fn finish(self) -> Result<Self::Ok, Self::Err>;
 }
 
 // Note: all the methods in this trait are infallible, which may be surprising.

--- a/compiler/rustc_serialize/tests/opaque.rs
+++ b/compiler/rustc_serialize/tests/opaque.rs
@@ -31,7 +31,7 @@ struct Struct {
 fn check_round_trip<T: Encodable<Encoder> + for<'a> Decodable<Decoder<'a>> + PartialEq + Debug>(
     values: Vec<T>,
 ) {
-    let mut encoder = Encoder::new(Vec::new());
+    let mut encoder = Encoder::new();
 
     for value in &values {
         Encodable::encode(value, &mut encoder).unwrap();

--- a/compiler/rustc_serialize/tests/opaque.rs
+++ b/compiler/rustc_serialize/tests/opaque.rs
@@ -2,7 +2,7 @@
 
 use rustc_macros::{Decodable, Encodable};
 use rustc_serialize::opaque::{Decoder, Encoder};
-use rustc_serialize::{Decodable, Encodable};
+use rustc_serialize::{Decodable, Encodable, Encoder as EncoderTrait};
 use std::fmt::Debug;
 
 #[derive(PartialEq, Clone, Debug, Encodable, Decodable)]
@@ -32,12 +32,11 @@ fn check_round_trip<T: Encodable<Encoder> + for<'a> Decodable<Decoder<'a>> + Par
     values: Vec<T>,
 ) {
     let mut encoder = Encoder::new();
-
     for value in &values {
-        Encodable::encode(value, &mut encoder).unwrap();
+        Encodable::encode(value, &mut encoder);
     }
 
-    let data = encoder.into_inner();
+    let data = encoder.finish().unwrap();
     let mut decoder = Decoder::new(&data[..], 0);
 
     for value in values {

--- a/compiler/rustc_serialize/tests/opaque.rs
+++ b/compiler/rustc_serialize/tests/opaque.rs
@@ -1,7 +1,7 @@
 #![allow(rustc::internal)]
 
 use rustc_macros::{Decodable, Encodable};
-use rustc_serialize::opaque::{Decoder, Encoder};
+use rustc_serialize::opaque::{MemDecoder, MemEncoder};
 use rustc_serialize::{Decodable, Encodable};
 use std::fmt::Debug;
 
@@ -28,16 +28,18 @@ struct Struct {
     q: Option<u32>,
 }
 
-fn check_round_trip<T: Encodable<Encoder> + for<'a> Decodable<Decoder<'a>> + PartialEq + Debug>(
+fn check_round_trip<
+    T: Encodable<MemEncoder> + for<'a> Decodable<MemDecoder<'a>> + PartialEq + Debug,
+>(
     values: Vec<T>,
 ) {
-    let mut encoder = Encoder::new();
+    let mut encoder = MemEncoder::new();
     for value in &values {
         Encodable::encode(value, &mut encoder);
     }
 
     let data = encoder.finish();
-    let mut decoder = Decoder::new(&data[..], 0);
+    let mut decoder = MemDecoder::new(&data[..], 0);
 
     for value in values {
         let decoded = Decodable::decode(&mut decoder);

--- a/compiler/rustc_serialize/tests/opaque.rs
+++ b/compiler/rustc_serialize/tests/opaque.rs
@@ -2,7 +2,7 @@
 
 use rustc_macros::{Decodable, Encodable};
 use rustc_serialize::opaque::{Decoder, Encoder};
-use rustc_serialize::{Decodable, Encodable, Encoder as EncoderTrait};
+use rustc_serialize::{Decodable, Encodable};
 use std::fmt::Debug;
 
 #[derive(PartialEq, Clone, Debug, Encodable, Decodable)]
@@ -36,7 +36,7 @@ fn check_round_trip<T: Encodable<Encoder> + for<'a> Decodable<Decoder<'a>> + Par
         Encodable::encode(value, &mut encoder);
     }
 
-    let data = encoder.finish().unwrap();
+    let data = encoder.finish();
     let mut decoder = Decoder::new(&data[..], 0);
 
     for value in values {

--- a/compiler/rustc_span/src/def_id.rs
+++ b/compiler/rustc_span/src/def_id.rs
@@ -41,8 +41,8 @@ impl fmt::Display for CrateNum {
 /// As a local identifier, a `CrateNum` is only meaningful within its context, e.g. within a tcx.
 /// Therefore, make sure to include the context when encode a `CrateNum`.
 impl<E: Encoder> Encodable<E> for CrateNum {
-    default fn encode(&self, s: &mut E) -> Result<(), E::Error> {
-        s.emit_u32(self.as_u32())
+    default fn encode(&self, s: &mut E) {
+        s.emit_u32(self.as_u32());
     }
 }
 
@@ -203,7 +203,7 @@ rustc_index::newtype_index! {
 }
 
 impl<E: Encoder> Encodable<E> for DefIndex {
-    default fn encode(&self, _: &mut E) -> Result<(), E::Error> {
+    default fn encode(&self, _: &mut E) {
         panic!("cannot encode `DefIndex` with `{}`", std::any::type_name::<E>());
     }
 }
@@ -306,9 +306,9 @@ impl DefId {
 }
 
 impl<E: Encoder> Encodable<E> for DefId {
-    default fn encode(&self, s: &mut E) -> Result<(), E::Error> {
-        self.krate.encode(s)?;
-        self.index.encode(s)
+    default fn encode(&self, s: &mut E) {
+        self.krate.encode(s);
+        self.index.encode(s);
     }
 }
 
@@ -382,8 +382,8 @@ impl fmt::Debug for LocalDefId {
 }
 
 impl<E: Encoder> Encodable<E> for LocalDefId {
-    fn encode(&self, s: &mut E) -> Result<(), E::Error> {
-        self.to_def_id().encode(s)
+    fn encode(&self, s: &mut E) {
+        self.to_def_id().encode(s);
     }
 }
 

--- a/compiler/rustc_span/src/hygiene.rs
+++ b/compiler/rustc_span/src/hygiene.rs
@@ -1189,12 +1189,12 @@ impl HygieneEncodeContext {
         }
     }
 
-    pub fn encode<T, R>(
+    pub fn encode<T>(
         &self,
         encoder: &mut T,
-        mut encode_ctxt: impl FnMut(&mut T, u32, &SyntaxContextData) -> Result<(), R>,
-        mut encode_expn: impl FnMut(&mut T, ExpnId, &ExpnData, ExpnHash) -> Result<(), R>,
-    ) -> Result<(), R> {
+        mut encode_ctxt: impl FnMut(&mut T, u32, &SyntaxContextData),
+        mut encode_expn: impl FnMut(&mut T, ExpnId, &ExpnData, ExpnHash),
+    ) {
         // When we serialize a `SyntaxContextData`, we may end up serializing
         // a `SyntaxContext` that we haven't seen before
         while !self.latest_ctxts.lock().is_empty() || !self.latest_expns.lock().is_empty() {
@@ -1213,22 +1213,19 @@ impl HygieneEncodeContext {
             // order
             for_all_ctxts_in(latest_ctxts.into_iter(), |index, ctxt, data| {
                 if self.serialized_ctxts.lock().insert(ctxt) {
-                    encode_ctxt(encoder, index, data)?;
+                    encode_ctxt(encoder, index, data);
                 }
-                Ok(())
-            })?;
+            });
 
             let latest_expns = { std::mem::take(&mut *self.latest_expns.lock()) };
 
             for_all_expns_in(latest_expns.into_iter(), |expn, data, hash| {
                 if self.serialized_expns.lock().insert(expn) {
-                    encode_expn(encoder, expn, data, hash)?;
+                    encode_expn(encoder, expn, data, hash);
                 }
-                Ok(())
-            })?;
+            });
         }
         debug!("encode_hygiene: Done serializing SyntaxContextData");
-        Ok(())
     }
 }
 
@@ -1378,40 +1375,38 @@ pub fn decode_syntax_context<D: Decoder, F: FnOnce(&mut D, u32) -> SyntaxContext
     new_ctxt
 }
 
-fn for_all_ctxts_in<E, F: FnMut(u32, SyntaxContext, &SyntaxContextData) -> Result<(), E>>(
+fn for_all_ctxts_in<F: FnMut(u32, SyntaxContext, &SyntaxContextData)>(
     ctxts: impl Iterator<Item = SyntaxContext>,
     mut f: F,
-) -> Result<(), E> {
+) {
     let all_data: Vec<_> = HygieneData::with(|data| {
         ctxts.map(|ctxt| (ctxt, data.syntax_context_data[ctxt.0 as usize].clone())).collect()
     });
     for (ctxt, data) in all_data.into_iter() {
-        f(ctxt.0, ctxt, &data)?;
+        f(ctxt.0, ctxt, &data);
     }
-    Ok(())
 }
 
-fn for_all_expns_in<E>(
+fn for_all_expns_in(
     expns: impl Iterator<Item = ExpnId>,
-    mut f: impl FnMut(ExpnId, &ExpnData, ExpnHash) -> Result<(), E>,
-) -> Result<(), E> {
+    mut f: impl FnMut(ExpnId, &ExpnData, ExpnHash),
+) {
     let all_data: Vec<_> = HygieneData::with(|data| {
         expns.map(|expn| (expn, data.expn_data(expn).clone(), data.expn_hash(expn))).collect()
     });
     for (expn, data, hash) in all_data.into_iter() {
-        f(expn, &data, hash)?;
+        f(expn, &data, hash);
     }
-    Ok(())
 }
 
 impl<E: Encoder> Encodable<E> for LocalExpnId {
-    fn encode(&self, e: &mut E) -> Result<(), E::Error> {
-        self.to_expn_id().encode(e)
+    fn encode(&self, e: &mut E) {
+        self.to_expn_id().encode(e);
     }
 }
 
 impl<E: Encoder> Encodable<E> for ExpnId {
-    default fn encode(&self, _: &mut E) -> Result<(), E::Error> {
+    default fn encode(&self, _: &mut E) {
         panic!("cannot encode `ExpnId` with `{}`", std::any::type_name::<E>());
     }
 }
@@ -1432,15 +1427,15 @@ pub fn raw_encode_syntax_context<E: Encoder>(
     ctxt: SyntaxContext,
     context: &HygieneEncodeContext,
     e: &mut E,
-) -> Result<(), E::Error> {
+) {
     if !context.serialized_ctxts.lock().contains(&ctxt) {
         context.latest_ctxts.lock().insert(ctxt);
     }
-    ctxt.0.encode(e)
+    ctxt.0.encode(e);
 }
 
 impl<E: Encoder> Encodable<E> for SyntaxContext {
-    default fn encode(&self, _: &mut E) -> Result<(), E::Error> {
+    default fn encode(&self, _: &mut E) {
         panic!("cannot encode `SyntaxContext` with `{}`", std::any::type_name::<E>());
     }
 }

--- a/compiler/rustc_span/src/lib.rs
+++ b/compiler/rustc_span/src/lib.rs
@@ -1911,13 +1911,13 @@ impl_pos! {
     pub struct CharPos(pub usize);
 }
 
-impl<S: rustc_serialize::Encoder> Encodable<S> for BytePos {
+impl<S: Encoder> Encodable<S> for BytePos {
     fn encode(&self, s: &mut S) {
         s.emit_u32(self.0);
     }
 }
 
-impl<D: rustc_serialize::Decoder> Decodable<D> for BytePos {
+impl<D: Decoder> Decodable<D> for BytePos {
     fn decode(d: &mut D) -> BytePos {
         BytePos(d.read_u32())
     }

--- a/compiler/rustc_span/src/lib.rs
+++ b/compiler/rustc_span/src/lib.rs
@@ -194,12 +194,10 @@ impl Hash for RealFileName {
 // This is functionally identical to #[derive(Encodable)], with the exception of
 // an added assert statement
 impl<S: Encoder> Encodable<S> for RealFileName {
-    fn encode(&self, encoder: &mut S) -> Result<(), S::Error> {
+    fn encode(&self, encoder: &mut S) {
         match *self {
             RealFileName::LocalPath(ref local_path) => encoder.emit_enum_variant(0, |encoder| {
-                Ok({
-                    local_path.encode(encoder)?;
-                })
+                local_path.encode(encoder);
             }),
 
             RealFileName::Remapped { ref local_path, ref virtual_name } => encoder
@@ -207,9 +205,8 @@ impl<S: Encoder> Encodable<S> for RealFileName {
                     // For privacy and build reproducibility, we must not embed host-dependant path in artifacts
                     // if they have been remapped by --remap-path-prefix
                     assert!(local_path.is_none());
-                    local_path.encode(encoder)?;
-                    virtual_name.encode(encoder)?;
-                    Ok(())
+                    local_path.encode(encoder);
+                    virtual_name.encode(encoder);
                 }),
         }
     }
@@ -946,10 +943,10 @@ impl Default for Span {
 }
 
 impl<E: Encoder> Encodable<E> for Span {
-    default fn encode(&self, s: &mut E) -> Result<(), E::Error> {
+    default fn encode(&self, s: &mut E) {
         let span = self.data();
-        span.lo.encode(s)?;
-        span.hi.encode(s)
+        span.lo.encode(s);
+        span.hi.encode(s);
     }
 }
 impl<D: Decoder> Decodable<D> for Span {
@@ -1297,17 +1294,17 @@ pub struct SourceFile {
 }
 
 impl<S: Encoder> Encodable<S> for SourceFile {
-    fn encode(&self, s: &mut S) -> Result<(), S::Error> {
-        self.name.encode(s)?;
-        self.src_hash.encode(s)?;
-        self.start_pos.encode(s)?;
-        self.end_pos.encode(s)?;
+    fn encode(&self, s: &mut S) {
+        self.name.encode(s);
+        self.src_hash.encode(s);
+        self.start_pos.encode(s);
+        self.end_pos.encode(s);
 
         // We are always in `Lines` form by the time we reach here.
         assert!(self.lines.borrow().is_lines());
         self.lines(|lines| {
             // Store the length.
-            s.emit_u32(lines.len() as u32)?;
+            s.emit_u32(lines.len() as u32);
 
             // Compute and store the difference list.
             if lines.len() != 0 {
@@ -1329,10 +1326,10 @@ impl<S: Encoder> Encodable<S> for SourceFile {
                 };
 
                 // Encode the number of bytes used per diff.
-                s.emit_u8(bytes_per_diff as u8)?;
+                s.emit_u8(bytes_per_diff as u8);
 
                 // Encode the first element.
-                lines[0].encode(s)?;
+                lines[0].encode(s);
 
                 // Encode the difference list.
                 let diff_iter = lines.array_windows().map(|&[fst, snd]| snd - fst);
@@ -1359,16 +1356,15 @@ impl<S: Encoder> Encodable<S> for SourceFile {
                     }
                     _ => unreachable!(),
                 }
-                s.emit_raw_bytes(&raw_diffs)?;
+                s.emit_raw_bytes(&raw_diffs);
             }
-            Ok(())
-        })?;
+        });
 
-        self.multibyte_chars.encode(s)?;
-        self.non_narrow_chars.encode(s)?;
-        self.name_hash.encode(s)?;
-        self.normalized_pos.encode(s)?;
-        self.cnum.encode(s)
+        self.multibyte_chars.encode(s);
+        self.non_narrow_chars.encode(s);
+        self.name_hash.encode(s);
+        self.normalized_pos.encode(s);
+        self.cnum.encode(s);
     }
 }
 
@@ -1916,8 +1912,8 @@ impl_pos! {
 }
 
 impl<S: rustc_serialize::Encoder> Encodable<S> for BytePos {
-    fn encode(&self, s: &mut S) -> Result<(), S::Error> {
-        s.emit_u32(self.0)
+    fn encode(&self, s: &mut S) {
+        s.emit_u32(self.0);
     }
 }
 

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1802,8 +1802,8 @@ impl fmt::Display for Symbol {
 }
 
 impl<S: Encoder> Encodable<S> for Symbol {
-    fn encode(&self, s: &mut S) -> Result<(), S::Error> {
-        s.emit_str(self.as_str())
+    fn encode(&self, s: &mut S) {
+        s.emit_str(self.as_str());
     }
 }
 

--- a/compiler/rustc_type_ir/src/codec.rs
+++ b/compiler/rustc_type_ir/src/codec.rs
@@ -31,10 +31,7 @@ pub trait TyEncoder: Encoder {
     fn predicate_shorthands(
         &mut self,
     ) -> &mut FxHashMap<<Self::I as Interner>::PredicateKind, usize>;
-    fn encode_alloc_id(
-        &mut self,
-        alloc_id: &<Self::I as Interner>::AllocId,
-    ) -> Result<(), Self::Error>;
+    fn encode_alloc_id(&mut self, alloc_id: &<Self::I as Interner>::AllocId);
 }
 
 pub trait TyDecoder: Decoder {

--- a/compiler/rustc_type_ir/src/sty.rs
+++ b/compiler/rustc_type_ir/src/sty.rs
@@ -14,7 +14,7 @@ use crate::UintTy;
 use self::TyKind::*;
 
 use rustc_data_structures::stable_hasher::HashStable;
-use rustc_serialize::{Decodable, Encodable};
+use rustc_serialize::{Decodable, Decoder, Encodable};
 
 /// Defines the kinds of types used by the type system.
 ///
@@ -833,56 +833,34 @@ where
     I::AllocId: Decodable<D>,
 {
     fn decode(d: &mut D) -> Self {
-        match rustc_serialize::Decoder::read_usize(d) {
+        match Decoder::read_usize(d) {
             0 => Bool,
             1 => Char,
-            2 => Int(rustc_serialize::Decodable::decode(d)),
-            3 => Uint(rustc_serialize::Decodable::decode(d)),
-            4 => Float(rustc_serialize::Decodable::decode(d)),
-            5 => Adt(rustc_serialize::Decodable::decode(d), rustc_serialize::Decodable::decode(d)),
-            6 => Foreign(rustc_serialize::Decodable::decode(d)),
+            2 => Int(Decodable::decode(d)),
+            3 => Uint(Decodable::decode(d)),
+            4 => Float(Decodable::decode(d)),
+            5 => Adt(Decodable::decode(d), Decodable::decode(d)),
+            6 => Foreign(Decodable::decode(d)),
             7 => Str,
-            8 => {
-                Array(rustc_serialize::Decodable::decode(d), rustc_serialize::Decodable::decode(d))
-            }
-            9 => Slice(rustc_serialize::Decodable::decode(d)),
-            10 => RawPtr(rustc_serialize::Decodable::decode(d)),
-            11 => Ref(
-                rustc_serialize::Decodable::decode(d),
-                rustc_serialize::Decodable::decode(d),
-                rustc_serialize::Decodable::decode(d),
-            ),
-            12 => {
-                FnDef(rustc_serialize::Decodable::decode(d), rustc_serialize::Decodable::decode(d))
-            }
-            13 => FnPtr(rustc_serialize::Decodable::decode(d)),
-            14 => Dynamic(
-                rustc_serialize::Decodable::decode(d),
-                rustc_serialize::Decodable::decode(d),
-            ),
-            15 => Closure(
-                rustc_serialize::Decodable::decode(d),
-                rustc_serialize::Decodable::decode(d),
-            ),
-            16 => Generator(
-                rustc_serialize::Decodable::decode(d),
-                rustc_serialize::Decodable::decode(d),
-                rustc_serialize::Decodable::decode(d),
-            ),
-            17 => GeneratorWitness(rustc_serialize::Decodable::decode(d)),
+            8 => Array(Decodable::decode(d), Decodable::decode(d)),
+            9 => Slice(Decodable::decode(d)),
+            10 => RawPtr(Decodable::decode(d)),
+            11 => Ref(Decodable::decode(d), Decodable::decode(d), Decodable::decode(d)),
+            12 => FnDef(Decodable::decode(d), Decodable::decode(d)),
+            13 => FnPtr(Decodable::decode(d)),
+            14 => Dynamic(Decodable::decode(d), Decodable::decode(d)),
+            15 => Closure(Decodable::decode(d), Decodable::decode(d)),
+            16 => Generator(Decodable::decode(d), Decodable::decode(d), Decodable::decode(d)),
+            17 => GeneratorWitness(Decodable::decode(d)),
             18 => Never,
-            19 => Tuple(rustc_serialize::Decodable::decode(d)),
-            20 => Projection(rustc_serialize::Decodable::decode(d)),
-            21 => {
-                Opaque(rustc_serialize::Decodable::decode(d), rustc_serialize::Decodable::decode(d))
-            }
-            22 => Param(rustc_serialize::Decodable::decode(d)),
-            23 => {
-                Bound(rustc_serialize::Decodable::decode(d), rustc_serialize::Decodable::decode(d))
-            }
-            24 => Placeholder(rustc_serialize::Decodable::decode(d)),
-            25 => Infer(rustc_serialize::Decodable::decode(d)),
-            26 => Error(rustc_serialize::Decodable::decode(d)),
+            19 => Tuple(Decodable::decode(d)),
+            20 => Projection(Decodable::decode(d)),
+            21 => Opaque(Decodable::decode(d), Decodable::decode(d)),
+            22 => Param(Decodable::decode(d)),
+            23 => Bound(Decodable::decode(d), Decodable::decode(d)),
+            24 => Placeholder(Decodable::decode(d)),
+            25 => Infer(Decodable::decode(d)),
+            26 => Error(Decodable::decode(d)),
             _ => panic!(
                 "{}",
                 format!(

--- a/compiler/rustc_type_ir/src/sty.rs
+++ b/compiler/rustc_type_ir/src/sty.rs
@@ -715,115 +715,92 @@ where
     I::PredicateKind: Encodable<E>,
     I::AllocId: Encodable<E>,
 {
-    fn encode(&self, e: &mut E) -> Result<(), <E as rustc_serialize::Encoder>::Error> {
+    fn encode(&self, e: &mut E) {
         let disc = discriminant(self);
         match self {
-            Bool => e.emit_enum_variant(disc, |_| Ok(())),
-            Char => e.emit_enum_variant(disc, |_| Ok(())),
+            Bool => e.emit_enum_variant(disc, |_| {}),
+            Char => e.emit_enum_variant(disc, |_| {}),
             Int(i) => e.emit_enum_variant(disc, |e| {
-                i.encode(e)?;
-                Ok(())
+                i.encode(e);
             }),
             Uint(u) => e.emit_enum_variant(disc, |e| {
-                u.encode(e)?;
-                Ok(())
+                u.encode(e);
             }),
             Float(f) => e.emit_enum_variant(disc, |e| {
-                f.encode(e)?;
-                Ok(())
+                f.encode(e);
             }),
             Adt(adt, substs) => e.emit_enum_variant(disc, |e| {
-                adt.encode(e)?;
-                substs.encode(e)?;
-                Ok(())
+                adt.encode(e);
+                substs.encode(e);
             }),
             Foreign(def_id) => e.emit_enum_variant(disc, |e| {
-                def_id.encode(e)?;
-                Ok(())
+                def_id.encode(e);
             }),
-            Str => e.emit_enum_variant(disc, |_| Ok(())),
+            Str => e.emit_enum_variant(disc, |_| {}),
             Array(t, c) => e.emit_enum_variant(disc, |e| {
-                t.encode(e)?;
-                c.encode(e)?;
-                Ok(())
+                t.encode(e);
+                c.encode(e);
             }),
             Slice(t) => e.emit_enum_variant(disc, |e| {
-                t.encode(e)?;
-                Ok(())
+                t.encode(e);
             }),
             RawPtr(tam) => e.emit_enum_variant(disc, |e| {
-                tam.encode(e)?;
-                Ok(())
+                tam.encode(e);
             }),
             Ref(r, t, m) => e.emit_enum_variant(disc, |e| {
-                r.encode(e)?;
-                t.encode(e)?;
-                m.encode(e)?;
-                Ok(())
+                r.encode(e);
+                t.encode(e);
+                m.encode(e);
             }),
             FnDef(def_id, substs) => e.emit_enum_variant(disc, |e| {
-                def_id.encode(e)?;
-                substs.encode(e)?;
-                Ok(())
+                def_id.encode(e);
+                substs.encode(e);
             }),
             FnPtr(polyfnsig) => e.emit_enum_variant(disc, |e| {
-                polyfnsig.encode(e)?;
-                Ok(())
+                polyfnsig.encode(e);
             }),
             Dynamic(l, r) => e.emit_enum_variant(disc, |e| {
-                l.encode(e)?;
-                r.encode(e)?;
-                Ok(())
+                l.encode(e);
+                r.encode(e);
             }),
             Closure(def_id, substs) => e.emit_enum_variant(disc, |e| {
-                def_id.encode(e)?;
-                substs.encode(e)?;
-                Ok(())
+                def_id.encode(e);
+                substs.encode(e);
             }),
             Generator(def_id, substs, m) => e.emit_enum_variant(disc, |e| {
-                def_id.encode(e)?;
-                substs.encode(e)?;
-                m.encode(e)?;
-                Ok(())
+                def_id.encode(e);
+                substs.encode(e);
+                m.encode(e);
             }),
             GeneratorWitness(b) => e.emit_enum_variant(disc, |e| {
-                b.encode(e)?;
-                Ok(())
+                b.encode(e);
             }),
-            Never => e.emit_enum_variant(disc, |_| Ok(())),
+            Never => e.emit_enum_variant(disc, |_| {}),
             Tuple(substs) => e.emit_enum_variant(disc, |e| {
-                substs.encode(e)?;
-                Ok(())
+                substs.encode(e);
             }),
             Projection(p) => e.emit_enum_variant(disc, |e| {
-                p.encode(e)?;
-                Ok(())
+                p.encode(e);
             }),
             Opaque(def_id, substs) => e.emit_enum_variant(disc, |e| {
-                def_id.encode(e)?;
-                substs.encode(e)?;
-                Ok(())
+                def_id.encode(e);
+                substs.encode(e);
             }),
             Param(p) => e.emit_enum_variant(disc, |e| {
-                p.encode(e)?;
-                Ok(())
+                p.encode(e);
             }),
             Bound(d, b) => e.emit_enum_variant(disc, |e| {
-                d.encode(e)?;
-                b.encode(e)?;
-                Ok(())
+                d.encode(e);
+                b.encode(e);
             }),
             Placeholder(p) => e.emit_enum_variant(disc, |e| {
-                p.encode(e)?;
-                Ok(())
+                p.encode(e);
             }),
             Infer(i) => e.emit_enum_variant(disc, |e| {
-                i.encode(e)?;
-                Ok(())
+                i.encode(e);
             }),
             Error(d) => e.emit_enum_variant(disc, |e| {
-                d.encode(e)?;
-                Ok(())
+                d.encode(e);
             }),
         }
     }

--- a/src/librustdoc/scrape_examples.rs
+++ b/src/librustdoc/scrape_examples.rs
@@ -17,7 +17,7 @@ use rustc_middle::hir::map::Map;
 use rustc_middle::hir::nested_filter;
 use rustc_middle::ty::{self, TyCtxt};
 use rustc_serialize::{
-    opaque::{Decoder, FileEncoder},
+    opaque::{FileEncoder, MemDecoder},
     Decodable, Encodable,
 };
 use rustc_session::getopts;
@@ -336,7 +336,7 @@ pub(crate) fn load_call_locations(
         let mut all_calls: AllCallLocations = FxHashMap::default();
         for path in with_examples {
             let bytes = fs::read(&path).map_err(|e| format!("{} (for path {})", e, path))?;
-            let mut decoder = Decoder::new(&bytes, 0);
+            let mut decoder = MemDecoder::new(&bytes, 0);
             let calls = AllCallLocations::decode(&mut decoder);
 
             for (function, fn_calls) in calls.into_iter() {

--- a/src/librustdoc/scrape_examples.rs
+++ b/src/librustdoc/scrape_examples.rs
@@ -18,7 +18,7 @@ use rustc_middle::hir::nested_filter;
 use rustc_middle::ty::{self, TyCtxt};
 use rustc_serialize::{
     opaque::{Decoder, FileEncoder},
-    Decodable, Encodable,
+    Decodable, Encodable, Encoder,
 };
 use rustc_session::getopts;
 use rustc_span::{
@@ -314,8 +314,8 @@ pub(crate) fn run(
 
         // Save output to provided path
         let mut encoder = FileEncoder::new(options.output_path).map_err(|e| e.to_string())?;
-        calls.encode(&mut encoder).map_err(|e| e.to_string())?;
-        encoder.flush().map_err(|e| e.to_string())?;
+        calls.encode(&mut encoder);
+        encoder.finish().map_err(|e| e.to_string())?;
 
         Ok(())
     };

--- a/src/librustdoc/scrape_examples.rs
+++ b/src/librustdoc/scrape_examples.rs
@@ -18,7 +18,7 @@ use rustc_middle::hir::nested_filter;
 use rustc_middle::ty::{self, TyCtxt};
 use rustc_serialize::{
     opaque::{Decoder, FileEncoder},
-    Decodable, Encodable, Encoder,
+    Decodable, Encodable,
 };
 use rustc_session::getopts;
 use rustc_span::{

--- a/src/test/ui-fulldeps/deriving-encodable-decodable-box.rs
+++ b/src/test/ui-fulldeps/deriving-encodable-decodable-box.rs
@@ -20,7 +20,7 @@ fn main() {
 
     let mut encoder = opaque::Encoder::new();
     obj.encode(&mut encoder);
-    let data = encoder.finish().unwrap();
+    let data = encoder.finish();
 
     let mut decoder = opaque::Decoder::new(&data, 0);
     let obj2 = A::decode(&mut decoder);

--- a/src/test/ui-fulldeps/deriving-encodable-decodable-box.rs
+++ b/src/test/ui-fulldeps/deriving-encodable-decodable-box.rs
@@ -8,7 +8,7 @@ extern crate rustc_serialize;
 
 use rustc_macros::{Decodable, Encodable};
 use rustc_serialize::opaque;
-use rustc_serialize::{Decodable, Encodable};
+use rustc_serialize::{Decodable, Encodable, Encoder};
 
 #[derive(Encodable, Decodable)]
 struct A {
@@ -17,9 +17,13 @@ struct A {
 
 fn main() {
     let obj = A { foo: Box::new([true, false]) };
-    let mut encoder = opaque::Encoder::new(vec![]);
-    obj.encode(&mut encoder).unwrap();
-    let mut decoder = opaque::Decoder::new(&encoder.data, 0);
+
+    let mut encoder = opaque::Encoder::new();
+    obj.encode(&mut encoder);
+    let data = encoder.finish().unwrap();
+
+    let mut decoder = opaque::Decoder::new(&data, 0);
     let obj2 = A::decode(&mut decoder);
+
     assert_eq!(obj.foo, obj2.foo);
 }

--- a/src/test/ui-fulldeps/deriving-encodable-decodable-box.rs
+++ b/src/test/ui-fulldeps/deriving-encodable-decodable-box.rs
@@ -7,7 +7,7 @@ extern crate rustc_macros;
 extern crate rustc_serialize;
 
 use rustc_macros::{Decodable, Encodable};
-use rustc_serialize::opaque;
+use rustc_serialize::opaque::{MemDecoder, MemEncoder};
 use rustc_serialize::{Decodable, Encodable, Encoder};
 
 #[derive(Encodable, Decodable)]
@@ -18,11 +18,11 @@ struct A {
 fn main() {
     let obj = A { foo: Box::new([true, false]) };
 
-    let mut encoder = opaque::Encoder::new();
+    let mut encoder = MemEncoder::new();
     obj.encode(&mut encoder);
     let data = encoder.finish();
 
-    let mut decoder = opaque::Decoder::new(&data, 0);
+    let mut decoder = MemDecoder::new(&data, 0);
     let obj2 = A::decode(&mut decoder);
 
     assert_eq!(obj.foo, obj2.foo);

--- a/src/test/ui-fulldeps/deriving-encodable-decodable-cell-refcell.rs
+++ b/src/test/ui-fulldeps/deriving-encodable-decodable-cell-refcell.rs
@@ -29,7 +29,7 @@ fn main() {
 
     let mut encoder = opaque::Encoder::new();
     obj.encode(&mut encoder);
-    let data = encoder.finish().unwrap();
+    let data = encoder.finish();
 
     let mut decoder = opaque::Decoder::new(&data, 0);
     let obj2 = B::decode(&mut decoder);

--- a/src/test/ui-fulldeps/deriving-encodable-decodable-cell-refcell.rs
+++ b/src/test/ui-fulldeps/deriving-encodable-decodable-cell-refcell.rs
@@ -10,7 +10,7 @@ extern crate rustc_serialize;
 
 use rustc_macros::{Decodable, Encodable};
 use rustc_serialize::opaque;
-use rustc_serialize::{Decodable, Encodable};
+use rustc_serialize::{Decodable, Encodable, Encoder};
 use std::cell::{Cell, RefCell};
 
 #[derive(Encodable, Decodable)]
@@ -26,10 +26,14 @@ struct B {
 
 fn main() {
     let obj = B { foo: Cell::new(true), bar: RefCell::new(A { baz: 2 }) };
-    let mut encoder = opaque::Encoder::new(vec![]);
-    obj.encode(&mut encoder).unwrap();
-    let mut decoder = opaque::Decoder::new(&encoder.data, 0);
+
+    let mut encoder = opaque::Encoder::new();
+    obj.encode(&mut encoder);
+    let data = encoder.finish().unwrap();
+
+    let mut decoder = opaque::Decoder::new(&data, 0);
     let obj2 = B::decode(&mut decoder);
+
     assert_eq!(obj.foo.get(), obj2.foo.get());
     assert_eq!(obj.bar.borrow().baz, obj2.bar.borrow().baz);
 }

--- a/src/test/ui-fulldeps/deriving-encodable-decodable-cell-refcell.rs
+++ b/src/test/ui-fulldeps/deriving-encodable-decodable-cell-refcell.rs
@@ -9,7 +9,7 @@ extern crate rustc_macros;
 extern crate rustc_serialize;
 
 use rustc_macros::{Decodable, Encodable};
-use rustc_serialize::opaque;
+use rustc_serialize::opaque::{MemDecoder, MemEncoder};
 use rustc_serialize::{Decodable, Encodable, Encoder};
 use std::cell::{Cell, RefCell};
 
@@ -27,11 +27,11 @@ struct B {
 fn main() {
     let obj = B { foo: Cell::new(true), bar: RefCell::new(A { baz: 2 }) };
 
-    let mut encoder = opaque::Encoder::new();
+    let mut encoder = MemEncoder::new();
     obj.encode(&mut encoder);
     let data = encoder.finish();
 
-    let mut decoder = opaque::Decoder::new(&data, 0);
+    let mut decoder = MemDecoder::new(&data, 0);
     let obj2 = B::decode(&mut decoder);
 
     assert_eq!(obj.foo.get(), obj2.foo.get());

--- a/src/test/ui-fulldeps/issue-11881.rs
+++ b/src/test/ui-fulldeps/issue-11881.rs
@@ -75,6 +75,7 @@ enum WireProtocol {
 fn encode_json<T: for<'a> Encodable<JsonEncoder<'a>>>(val: &T, wr: &mut Cursor<Vec<u8>>) {
     write!(wr, "{}", as_json(val));
 }
+
 fn encode_opaque<T: Encodable<OpaqueEncoder>>(val: &T, wr: Vec<u8>) {
     let mut encoder = OpaqueEncoder(wr);
     val.encode(&mut encoder);

--- a/src/test/ui-fulldeps/issue-14021.rs
+++ b/src/test/ui-fulldeps/issue-14021.rs
@@ -9,16 +9,20 @@ extern crate rustc_serialize;
 
 use rustc_macros::{Decodable, Encodable};
 use rustc_serialize::opaque;
-use rustc_serialize::{Decodable, Encodable};
+use rustc_serialize::{Decodable, Encodable, Encoder};
 
 #[derive(Encodable, Decodable, PartialEq, Debug)]
 struct UnitLikeStruct;
 
 pub fn main() {
     let obj = UnitLikeStruct;
-    let mut encoder = opaque::Encoder::new(vec![]);
-    obj.encode(&mut encoder).unwrap();
-    let mut decoder = opaque::Decoder::new(&encoder.data, 0);
+
+    let mut encoder = opaque::Encoder::new();
+    obj.encode(&mut encoder);
+    let data = encoder.finish().unwrap();
+
+    let mut decoder = opaque::Decoder::new(&data, 0);
     let obj2 = UnitLikeStruct::decode(&mut decoder);
+
     assert_eq!(obj, obj2);
 }

--- a/src/test/ui-fulldeps/issue-14021.rs
+++ b/src/test/ui-fulldeps/issue-14021.rs
@@ -8,7 +8,7 @@ extern crate rustc_macros;
 extern crate rustc_serialize;
 
 use rustc_macros::{Decodable, Encodable};
-use rustc_serialize::opaque;
+use rustc_serialize::opaque::{MemDecoder, MemEncoder};
 use rustc_serialize::{Decodable, Encodable, Encoder};
 
 #[derive(Encodable, Decodable, PartialEq, Debug)]
@@ -17,11 +17,11 @@ struct UnitLikeStruct;
 pub fn main() {
     let obj = UnitLikeStruct;
 
-    let mut encoder = opaque::Encoder::new();
+    let mut encoder = MemEncoder::new();
     obj.encode(&mut encoder);
     let data = encoder.finish();
 
-    let mut decoder = opaque::Decoder::new(&data, 0);
+    let mut decoder = MemDecoder::new(&data, 0);
     let obj2 = UnitLikeStruct::decode(&mut decoder);
 
     assert_eq!(obj, obj2);

--- a/src/test/ui-fulldeps/issue-14021.rs
+++ b/src/test/ui-fulldeps/issue-14021.rs
@@ -19,7 +19,7 @@ pub fn main() {
 
     let mut encoder = opaque::Encoder::new();
     obj.encode(&mut encoder);
-    let data = encoder.finish().unwrap();
+    let data = encoder.finish();
 
     let mut decoder = opaque::Decoder::new(&data, 0);
     let obj2 = UnitLikeStruct::decode(&mut decoder);


### PR DESCRIPTION
A follow-up to #93066.

r? @ghost