### PR TITLE
add `#[rustc_pass_by_value]` to more types

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/mutability_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/mutability_errors.rs
@@ -220,8 +220,8 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
             PlaceRef {
                 local,
                 projection:
-                    [
-                        proj_base @ ..,
+                    &[
+                        ref proj_base @ ..,
                         ProjectionElem::Deref,
                         ProjectionElem::Field(field, _),
                         ProjectionElem::Deref,
@@ -342,7 +342,7 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
                     Applicability::MachineApplicable,
                 );
                 let tcx = self.infcx.tcx;
-                if let ty::Closure(id, _) = the_place_err.ty(self.body, tcx).ty.kind() {
+                if let ty::Closure(id, _) = *the_place_err.ty(self.body, tcx).ty.kind() {
                     self.show_mutating_upvar(tcx, id, the_place_err, &mut err);
                 }
             }
@@ -382,7 +382,7 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
                 let tcx = self.infcx.tcx;
                 if let ty::Ref(_, ty, Mutability::Mut) = the_place_err.ty(self.body, tcx).ty.kind()
                 {
-                    if let ty::Closure(id, _) = ty.kind() {
+                    if let ty::Closure(id, _) = *ty.kind() {
                         self.show_mutating_upvar(tcx, id, the_place_err, &mut err);
                     }
                 }
@@ -687,7 +687,7 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
     fn show_mutating_upvar(
         &self,
         tcx: TyCtxt<'_>,
-        id: &hir::def_id::DefId,
+        id: hir::def_id::DefId,
         the_place_err: PlaceRef<'tcx>,
         err: &mut Diagnostic,
     ) {
@@ -701,7 +701,7 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
                 let upvar = ty::place_to_string_for_capture(tcx, closure_kind_origin);
                 let root_hir_id = upvar_id.var_path.hir_id;
                 // we have an origin for this closure kind starting at this root variable so it's safe to unwrap here
-                let captured_places = tables.closure_min_captures[id].get(&root_hir_id).unwrap();
+                let captured_places = tables.closure_min_captures[&id].get(&root_hir_id).unwrap();
 
                 let origin_projection = closure_kind_origin
                     .projections
@@ -1083,7 +1083,7 @@ fn is_closure_or_generator(ty: Ty<'_>) -> bool {
 fn get_mut_span_in_struct_field<'tcx>(
     tcx: TyCtxt<'tcx>,
     ty: Ty<'tcx>,
-    field: &mir::Field,
+    field: mir::Field,
 ) -> Option<Span> {
     // Expect our local to be a reference to a struct of some kind.
     if let ty::Ref(_, ty, _) = ty.kind()

--- a/compiler/rustc_borrowck/src/location.rs
+++ b/compiler/rustc_borrowck/src/location.rs
@@ -100,7 +100,7 @@ impl LocationTable {
 }
 
 impl LocationIndex {
-    fn is_start(&self) -> bool {
+    fn is_start(self) -> bool {
         // even indices are start points; odd indices are mid points
         (self.index() % 2) == 0
     }

--- a/compiler/rustc_borrowck/src/nll.rs
+++ b/compiler/rustc_borrowck/src/nll.rs
@@ -85,7 +85,7 @@ fn populate_polonius_move_facts(
 ) {
     all_facts
         .path_is_var
-        .extend(move_data.rev_lookup.iter_locals_enumerated().map(|(v, &m)| (m, v)));
+        .extend(move_data.rev_lookup.iter_locals_enumerated().map(|(l, r)| (r, l)));
 
     for (child, move_path) in move_data.move_paths.iter_enumerated() {
         if let Some(parent) = move_path.parent {
@@ -135,7 +135,7 @@ fn populate_polonius_move_facts(
         }
     }
 
-    for (local, &path) in move_data.rev_lookup.iter_locals_enumerated() {
+    for (local, path) in move_data.rev_lookup.iter_locals_enumerated() {
         if body.local_kind(local) != LocalKind::Arg {
             // Non-arguments start out deinitialised; we simulate this with an
             // initial move:
@@ -226,7 +226,7 @@ pub(crate) fn compute_regions<'cx, 'tcx>(
                      fr1={:?}, fr2={:?}",
                     fr1, fr2
                 );
-                all_facts.known_placeholder_subset.push((*fr1, *fr2));
+                all_facts.known_placeholder_subset.push((fr1, fr2));
             }
         }
     }

--- a/compiler/rustc_borrowck/src/region_infer/mod.rs
+++ b/compiler/rustc_borrowck/src/region_infer/mod.rs
@@ -942,14 +942,14 @@ impl<'tcx> RegionInferenceContext<'tcx> {
 
             debug!("try_promote_type_test: ur={:?}", ur);
 
-            let non_local_ub = self.universal_region_relations.non_local_upper_bounds(&ur);
+            let non_local_ub = self.universal_region_relations.non_local_upper_bounds(ur);
             debug!("try_promote_type_test: non_local_ub={:?}", non_local_ub);
 
             // This is slightly too conservative. To show T: '1, given `'2: '1`
             // and `'3: '1` we only need to prove that T: '2 *or* T: '3, but to
             // avoid potential non-determinism we approximate this by requiring
             // T: '1 and T: '2.
-            for &upper_bound in non_local_ub {
+            for upper_bound in non_local_ub {
                 debug_assert!(self.universal_regions.is_universal_region(upper_bound));
                 debug_assert!(!self.universal_regions.is_local_free_region(upper_bound));
 
@@ -1588,12 +1588,12 @@ impl<'tcx> RegionInferenceContext<'tcx> {
                 // always will.)  We'll call them `shorter_fr+` -- they're ever
                 // so slightly larger than `shorter_fr`.
                 let shorter_fr_plus =
-                    self.universal_region_relations.non_local_upper_bounds(&shorter_fr);
+                    self.universal_region_relations.non_local_upper_bounds(shorter_fr);
                 debug!(
                     "try_propagate_universal_region_error: shorter_fr_plus={:?}",
                     shorter_fr_plus
                 );
-                for &&fr in &shorter_fr_plus {
+                for fr in shorter_fr_plus {
                     // Push the constraint `fr-: shorter_fr+`
                     propagated_outlives_requirements.push(ClosureOutlivesRequirement {
                         subject: ClosureOutlivesSubject::Region(fr_minus),

--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -1198,7 +1198,7 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
                 tcx,
                 self.param_env,
                 proj,
-                |this, field, &()| {
+                |this, field, ()| {
                     let ty = this.field_ty(tcx, field);
                     self.normalize(ty, locations)
                 },

--- a/compiler/rustc_codegen_llvm/src/coverageinfo/mod.rs
+++ b/compiler/rustc_codegen_llvm/src/coverageinfo/mod.rs
@@ -90,7 +90,7 @@ impl<'ll, 'tcx> CoverageInfoMethods<'tcx> for CodegenCx<'ll, 'tcx> {
     /// call. Since the function is never called, all other `CodeRegion`s can be
     /// added as `unreachable_region`s.
     fn define_unused_fn(&self, def_id: DefId) {
-        let instance = declare_unused_fn(self, &def_id);
+        let instance = declare_unused_fn(self, def_id);
         codegen_unused_fn_and_counter(self, instance);
         add_unused_function_coverage(self, instance, def_id);
     }
@@ -184,12 +184,12 @@ impl<'tcx> CoverageInfoBuilderMethods<'tcx> for Builder<'_, '_, 'tcx> {
     }
 }
 
-fn declare_unused_fn<'tcx>(cx: &CodegenCx<'_, 'tcx>, def_id: &DefId) -> Instance<'tcx> {
+fn declare_unused_fn<'tcx>(cx: &CodegenCx<'_, 'tcx>, def_id: DefId) -> Instance<'tcx> {
     let tcx = cx.tcx;
 
     let instance = Instance::new(
-        *def_id,
-        InternalSubsts::for_item(tcx, *def_id, |param, _| {
+        def_id,
+        InternalSubsts::for_item(tcx, def_id, |param, _| {
             if let ty::GenericParamDefKind::Lifetime = param.kind {
                 tcx.lifetimes.re_erased.into()
             } else {

--- a/compiler/rustc_data_structures/src/transitive_relation.rs
+++ b/compiler/rustc_data_structures/src/transitive_relation.rs
@@ -49,7 +49,7 @@ struct Edge {
     target: Index,
 }
 
-impl<T: Eq + Hash> TransitiveRelation<T> {
+impl<T: Eq + Hash + Copy> TransitiveRelation<T> {
     pub fn is_empty(&self) -> bool {
         self.edges.is_empty()
     }
@@ -58,8 +58,8 @@ impl<T: Eq + Hash> TransitiveRelation<T> {
         self.elements.iter()
     }
 
-    fn index(&self, a: &T) -> Option<Index> {
-        self.elements.get_index_of(a).map(Index)
+    fn index(&self, a: T) -> Option<Index> {
+        self.elements.get_index_of(&a).map(Index)
     }
 
     fn add_index(&mut self, a: T) -> Index {
@@ -76,12 +76,12 @@ impl<T: Eq + Hash> TransitiveRelation<T> {
     /// `None`.
     pub fn maybe_map<F, U>(&self, mut f: F) -> Option<TransitiveRelation<U>>
     where
-        F: FnMut(&T) -> Option<U>,
-        U: Clone + Debug + Eq + Hash + Clone,
+        F: FnMut(T) -> Option<U>,
+        U: Clone + Debug + Eq + Hash + Copy,
     {
         let mut result = TransitiveRelation::default();
         for edge in &self.edges {
-            result.add(f(&self.elements[edge.source.0])?, f(&self.elements[edge.target.0])?);
+            result.add(f(self.elements[edge.source.0])?, f(self.elements[edge.target.0])?);
         }
         Some(result)
     }
@@ -100,7 +100,7 @@ impl<T: Eq + Hash> TransitiveRelation<T> {
     }
 
     /// Checks whether `a < target` (transitively)
-    pub fn contains(&self, a: &T, b: &T) -> bool {
+    pub fn contains(&self, a: T, b: T) -> bool {
         match (self.index(a), self.index(b)) {
             (Some(a), Some(b)) => self.with_closure(|closure| closure.contains(a.0, b.0)),
             (None, _) | (_, None) => false,
@@ -113,10 +113,10 @@ impl<T: Eq + Hash> TransitiveRelation<T> {
     /// Really this probably ought to be `impl Iterator<Item = &T>`, but
     /// I'm too lazy to make that work, and -- given the caching
     /// strategy -- it'd be a touch tricky anyhow.
-    pub fn reachable_from(&self, a: &T) -> Vec<&T> {
+    pub fn reachable_from(&self, a: T) -> Vec<T> {
         match self.index(a) {
             Some(a) => {
-                self.with_closure(|closure| closure.iter(a.0).map(|i| &self.elements[i]).collect())
+                self.with_closure(|closure| closure.iter(a.0).map(|i| self.elements[i]).collect())
             }
             None => vec![],
         }
@@ -157,7 +157,7 @@ impl<T: Eq + Hash> TransitiveRelation<T> {
     /// a -> a1
     /// b -> b1
     /// ```
-    pub fn postdom_upper_bound(&self, a: &T, b: &T) -> Option<&T> {
+    pub fn postdom_upper_bound(&self, a: T, b: T) -> Option<T> {
         let mubs = self.minimal_upper_bounds(a, b);
         self.mutual_immediate_postdominator(mubs)
     }
@@ -165,7 +165,7 @@ impl<T: Eq + Hash> TransitiveRelation<T> {
     /// Viewing the relation as a graph, computes the "mutual
     /// immediate postdominator" of a set of points (if one
     /// exists). See `postdom_upper_bound` for details.
-    pub fn mutual_immediate_postdominator<'a>(&'a self, mut mubs: Vec<&'a T>) -> Option<&'a T> {
+    pub fn mutual_immediate_postdominator<'a>(&'a self, mut mubs: Vec<T>) -> Option<T> {
         loop {
             match mubs.len() {
                 0 => return None,
@@ -189,7 +189,7 @@ impl<T: Eq + Hash> TransitiveRelation<T> {
     ///     internal indices).
     ///
     /// Note that this set can, in principle, have any size.
-    pub fn minimal_upper_bounds(&self, a: &T, b: &T) -> Vec<&T> {
+    pub fn minimal_upper_bounds(&self, a: T, b: T) -> Vec<T> {
         let (Some(mut a), Some(mut b)) = (self.index(a), self.index(b)) else {
             return vec![];
         };
@@ -267,7 +267,7 @@ impl<T: Eq + Hash> TransitiveRelation<T> {
         lub_indices
             .into_iter()
             .rev() // (4)
-            .map(|i| &self.elements[i])
+            .map(|i| self.elements[i])
             .collect()
     }
 
@@ -290,7 +290,7 @@ impl<T: Eq + Hash> TransitiveRelation<T> {
     ///
     /// then `parents(a)` returns `[b, c]`. The `postdom_parent` function
     /// would further reduce this to just `f`.
-    pub fn parents(&self, a: &T) -> Vec<&T> {
+    pub fn parents(&self, a: T) -> Vec<T> {
         let Some(a) = self.index(a) else {
             return vec![];
         };
@@ -314,7 +314,7 @@ impl<T: Eq + Hash> TransitiveRelation<T> {
         ancestors
             .into_iter()
             .rev() // (4)
-            .map(|i| &self.elements[i])
+            .map(|i| self.elements[i])
             .collect()
     }
 
@@ -350,10 +350,10 @@ impl<T: Eq + Hash> TransitiveRelation<T> {
 
     /// Lists all the base edges in the graph: the initial _non-transitive_ set of element
     /// relations, which will be later used as the basis for the transitive closure computation.
-    pub fn base_edges(&self) -> impl Iterator<Item = (&T, &T)> {
+    pub fn base_edges(&self) -> impl Iterator<Item = (T, T)> + '_ {
         self.edges
             .iter()
-            .map(move |edge| (&self.elements[edge.source.0], &self.elements[edge.target.0]))
+            .map(move |edge| (self.elements[edge.source.0], self.elements[edge.target.0]))
     }
 }
 

--- a/compiler/rustc_data_structures/src/transitive_relation/tests.rs
+++ b/compiler/rustc_data_structures/src/transitive_relation/tests.rs
@@ -1,9 +1,9 @@
 use super::*;
 
-impl<T: Eq + Hash> TransitiveRelation<T> {
+impl<T: Eq + Hash + Copy> TransitiveRelation<T> {
     /// A "best" parent in some sense. See `parents` and
     /// `postdom_upper_bound` for more details.
-    fn postdom_parent(&self, a: &T) -> Option<&T> {
+    fn postdom_parent(&self, a: T) -> Option<T> {
         self.mutual_immediate_postdominator(self.parents(a))
     }
 }
@@ -13,10 +13,10 @@ fn test_one_step() {
     let mut relation = TransitiveRelation::default();
     relation.add("a", "b");
     relation.add("a", "c");
-    assert!(relation.contains(&"a", &"c"));
-    assert!(relation.contains(&"a", &"b"));
-    assert!(!relation.contains(&"b", &"a"));
-    assert!(!relation.contains(&"a", &"d"));
+    assert!(relation.contains("a", "c"));
+    assert!(relation.contains("a", "b"));
+    assert!(!relation.contains("b", "a"));
+    assert!(!relation.contains("a", "d"));
 }
 
 #[test]
@@ -32,17 +32,17 @@ fn test_many_steps() {
 
     relation.add("e", "g");
 
-    assert!(relation.contains(&"a", &"b"));
-    assert!(relation.contains(&"a", &"c"));
-    assert!(relation.contains(&"a", &"d"));
-    assert!(relation.contains(&"a", &"e"));
-    assert!(relation.contains(&"a", &"f"));
-    assert!(relation.contains(&"a", &"g"));
+    assert!(relation.contains("a", "b"));
+    assert!(relation.contains("a", "c"));
+    assert!(relation.contains("a", "d"));
+    assert!(relation.contains("a", "e"));
+    assert!(relation.contains("a", "f"));
+    assert!(relation.contains("a", "g"));
 
-    assert!(relation.contains(&"b", &"g"));
+    assert!(relation.contains("b", "g"));
 
-    assert!(!relation.contains(&"a", &"x"));
-    assert!(!relation.contains(&"b", &"f"));
+    assert!(!relation.contains("a", "x"));
+    assert!(!relation.contains("b", "f"));
 }
 
 #[test]
@@ -54,9 +54,9 @@ fn mubs_triangle() {
     let mut relation = TransitiveRelation::default();
     relation.add("a", "tcx");
     relation.add("b", "tcx");
-    assert_eq!(relation.minimal_upper_bounds(&"a", &"b"), vec![&"tcx"]);
-    assert_eq!(relation.parents(&"a"), vec![&"tcx"]);
-    assert_eq!(relation.parents(&"b"), vec![&"tcx"]);
+    assert_eq!(relation.minimal_upper_bounds("a", "b"), vec!["tcx"]);
+    assert_eq!(relation.parents("a"), vec!["tcx"]);
+    assert_eq!(relation.parents("b"), vec!["tcx"]);
 }
 
 #[test]
@@ -81,10 +81,10 @@ fn mubs_best_choice1() {
     relation.add("3", "1");
     relation.add("3", "2");
 
-    assert_eq!(relation.minimal_upper_bounds(&"0", &"3"), vec![&"2"]);
-    assert_eq!(relation.parents(&"0"), vec![&"2"]);
-    assert_eq!(relation.parents(&"2"), vec![&"1"]);
-    assert!(relation.parents(&"1").is_empty());
+    assert_eq!(relation.minimal_upper_bounds("0", "3"), vec!["2"]);
+    assert_eq!(relation.parents("0"), vec!["2"]);
+    assert_eq!(relation.parents("2"), vec!["1"]);
+    assert!(relation.parents("1").is_empty());
 }
 
 #[test]
@@ -108,10 +108,10 @@ fn mubs_best_choice2() {
     relation.add("3", "1");
     relation.add("3", "2");
 
-    assert_eq!(relation.minimal_upper_bounds(&"0", &"3"), vec![&"1"]);
-    assert_eq!(relation.parents(&"0"), vec![&"1"]);
-    assert_eq!(relation.parents(&"1"), vec![&"2"]);
-    assert!(relation.parents(&"2").is_empty());
+    assert_eq!(relation.minimal_upper_bounds("0", "3"), vec!["1"]);
+    assert_eq!(relation.parents("0"), vec!["1"]);
+    assert_eq!(relation.parents("1"), vec!["2"]);
+    assert!(relation.parents("2").is_empty());
 }
 
 #[test]
@@ -125,9 +125,9 @@ fn mubs_no_best_choice() {
     relation.add("3", "1");
     relation.add("3", "2");
 
-    assert_eq!(relation.minimal_upper_bounds(&"0", &"3"), vec![&"1", &"2"]);
-    assert_eq!(relation.parents(&"0"), vec![&"1", &"2"]);
-    assert_eq!(relation.parents(&"3"), vec![&"1", &"2"]);
+    assert_eq!(relation.minimal_upper_bounds("0", "3"), vec!["1", "2"]);
+    assert_eq!(relation.parents("0"), vec!["1", "2"]);
+    assert_eq!(relation.parents("3"), vec!["1", "2"]);
 }
 
 #[test]
@@ -145,8 +145,8 @@ fn mubs_best_choice_scc() {
     relation.add("3", "1");
     relation.add("3", "2");
 
-    assert_eq!(relation.minimal_upper_bounds(&"0", &"3"), vec![&"1"]);
-    assert_eq!(relation.parents(&"0"), vec![&"1"]);
+    assert_eq!(relation.minimal_upper_bounds("0", "3"), vec!["1"]);
+    assert_eq!(relation.parents("0"), vec!["1"]);
 }
 
 #[test]
@@ -165,10 +165,10 @@ fn pdub_crisscross() {
     relation.add("a1", "x");
     relation.add("b1", "x");
 
-    assert_eq!(relation.minimal_upper_bounds(&"a", &"b"), vec![&"a1", &"b1"]);
-    assert_eq!(relation.postdom_upper_bound(&"a", &"b"), Some(&"x"));
-    assert_eq!(relation.postdom_parent(&"a"), Some(&"x"));
-    assert_eq!(relation.postdom_parent(&"b"), Some(&"x"));
+    assert_eq!(relation.minimal_upper_bounds("a", "b"), vec!["a1", "b1"]);
+    assert_eq!(relation.postdom_upper_bound("a", "b"), Some("x"));
+    assert_eq!(relation.postdom_parent("a"), Some("x"));
+    assert_eq!(relation.postdom_parent("b"), Some("x"));
 }
 
 #[test]
@@ -195,12 +195,12 @@ fn pdub_crisscross_more() {
     relation.add("a3", "x");
     relation.add("b2", "x");
 
-    assert_eq!(relation.minimal_upper_bounds(&"a", &"b"), vec![&"a1", &"b1"]);
-    assert_eq!(relation.minimal_upper_bounds(&"a1", &"b1"), vec![&"a2", &"b2"]);
-    assert_eq!(relation.postdom_upper_bound(&"a", &"b"), Some(&"x"));
+    assert_eq!(relation.minimal_upper_bounds("a", "b"), vec!["a1", "b1"]);
+    assert_eq!(relation.minimal_upper_bounds("a1", "b1"), vec!["a2", "b2"]);
+    assert_eq!(relation.postdom_upper_bound("a", "b"), Some("x"));
 
-    assert_eq!(relation.postdom_parent(&"a"), Some(&"x"));
-    assert_eq!(relation.postdom_parent(&"b"), Some(&"x"));
+    assert_eq!(relation.postdom_parent("a"), Some("x"));
+    assert_eq!(relation.postdom_parent("b"), Some("x"));
 }
 
 #[test]
@@ -216,13 +216,13 @@ fn pdub_lub() {
     relation.add("a1", "x");
     relation.add("b1", "x");
 
-    assert_eq!(relation.minimal_upper_bounds(&"a", &"b"), vec![&"x"]);
-    assert_eq!(relation.postdom_upper_bound(&"a", &"b"), Some(&"x"));
+    assert_eq!(relation.minimal_upper_bounds("a", "b"), vec!["x"]);
+    assert_eq!(relation.postdom_upper_bound("a", "b"), Some("x"));
 
-    assert_eq!(relation.postdom_parent(&"a"), Some(&"a1"));
-    assert_eq!(relation.postdom_parent(&"b"), Some(&"b1"));
-    assert_eq!(relation.postdom_parent(&"a1"), Some(&"x"));
-    assert_eq!(relation.postdom_parent(&"b1"), Some(&"x"));
+    assert_eq!(relation.postdom_parent("a"), Some("a1"));
+    assert_eq!(relation.postdom_parent("b"), Some("b1"));
+    assert_eq!(relation.postdom_parent("a1"), Some("x"));
+    assert_eq!(relation.postdom_parent("b1"), Some("x"));
 }
 
 #[test]
@@ -238,7 +238,7 @@ fn mubs_intermediate_node_on_one_side_only() {
     relation.add("c", "d");
     relation.add("b", "d");
 
-    assert_eq!(relation.minimal_upper_bounds(&"a", &"b"), vec![&"d"]);
+    assert_eq!(relation.minimal_upper_bounds("a", "b"), vec!["d"]);
 }
 
 #[test]
@@ -259,7 +259,7 @@ fn mubs_scc_1() {
     relation.add("a", "d");
     relation.add("b", "d");
 
-    assert_eq!(relation.minimal_upper_bounds(&"a", &"b"), vec![&"c"]);
+    assert_eq!(relation.minimal_upper_bounds("a", "b"), vec!["c"]);
 }
 
 #[test]
@@ -279,7 +279,7 @@ fn mubs_scc_2() {
     relation.add("b", "d");
     relation.add("b", "c");
 
-    assert_eq!(relation.minimal_upper_bounds(&"a", &"b"), vec![&"c"]);
+    assert_eq!(relation.minimal_upper_bounds("a", "b"), vec!["c"]);
 }
 
 #[test]
@@ -300,7 +300,7 @@ fn mubs_scc_3() {
     relation.add("b", "d");
     relation.add("b", "e");
 
-    assert_eq!(relation.minimal_upper_bounds(&"a", &"b"), vec![&"c"]);
+    assert_eq!(relation.minimal_upper_bounds("a", "b"), vec!["c"]);
 }
 
 #[test]
@@ -322,7 +322,7 @@ fn mubs_scc_4() {
     relation.add("a", "d");
     relation.add("b", "e");
 
-    assert_eq!(relation.minimal_upper_bounds(&"a", &"b"), vec![&"c"]);
+    assert_eq!(relation.minimal_upper_bounds("a", "b"), vec!["c"]);
 }
 
 #[test]
@@ -357,6 +357,6 @@ fn parent() {
         relation.add(a, b);
     }
 
-    let p = relation.postdom_parent(&3);
-    assert_eq!(p, Some(&0));
+    let p = relation.postdom_parent(3);
+    assert_eq!(p, Some(0));
 }

--- a/compiler/rustc_hir/src/hir_id.rs
+++ b/compiler/rustc_hir/src/hir_id.rs
@@ -13,6 +13,7 @@ use std::fmt;
 /// the code base.
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
 #[derive(Encodable, Decodable)]
+#[rustc_pass_by_value]
 pub struct HirId {
     pub owner: LocalDefId,
     pub local_id: ItemLocalId,

--- a/compiler/rustc_hir/src/lib.rs
+++ b/compiler/rustc_hir/src/lib.rs
@@ -9,6 +9,7 @@
 #![feature(once_cell)]
 #![feature(min_specialization)]
 #![feature(never_type)]
+#![feature(rustc_attrs)]
 #![recursion_limit = "256"]
 
 #[macro_use]

--- a/compiler/rustc_infer/src/infer/free_regions.rs
+++ b/compiler/rustc_infer/src/infer/free_regions.rs
@@ -86,7 +86,7 @@ impl<'tcx> FreeRegionMap<'tcx> {
 
     /// Check whether `r_a <= r_b` is found in the relation.
     fn check_relation(&self, r_a: Region<'tcx>, r_b: Region<'tcx>) -> bool {
-        r_a == r_b || self.relation.contains(&r_a, &r_b)
+        r_a == r_b || self.relation.contains(r_a, r_b)
     }
 
     /// True for free regions other than `'static`.
@@ -119,9 +119,9 @@ impl<'tcx> FreeRegionMap<'tcx> {
         let result = if r_a == r_b {
             r_a
         } else {
-            match self.relation.postdom_upper_bound(&r_a, &r_b) {
+            match self.relation.postdom_upper_bound(r_a, r_b) {
                 None => tcx.lifetimes.re_static,
-                Some(r) => *r,
+                Some(r) => r,
             }
         };
         debug!("lub_free_regions(r_a={:?}, r_b={:?}) = {:?}", r_a, r_b, result);
@@ -132,6 +132,6 @@ impl<'tcx> FreeRegionMap<'tcx> {
 impl<'a, 'tcx> Lift<'tcx> for FreeRegionMap<'a> {
     type Lifted = FreeRegionMap<'tcx>;
     fn lift_to_tcx(self, tcx: TyCtxt<'tcx>) -> Option<FreeRegionMap<'tcx>> {
-        self.relation.maybe_map(|&fr| tcx.lift(fr)).map(|relation| FreeRegionMap { relation })
+        self.relation.maybe_map(|fr| tcx.lift(fr)).map(|relation| FreeRegionMap { relation })
     }
 }

--- a/compiler/rustc_macros/src/newtype.rs
+++ b/compiler/rustc_macros/src/newtype.rs
@@ -197,6 +197,7 @@ impl Parse for Newtype {
             #(#attrs)*
             #[derive(Clone, Copy, PartialEq, Eq, Hash, #(#derive_paths),*)]
             #[rustc_layout_scalar_valid_range_end(#max)]
+            #[rustc_pass_by_value]
             #vis struct #name {
                 private: u32,
             }

--- a/compiler/rustc_middle/src/lib.rs
+++ b/compiler/rustc_middle/src/lib.rs
@@ -44,6 +44,7 @@
 #![feature(let_else)]
 #![feature(min_specialization)]
 #![feature(trusted_len)]
+#![feature(type_alias_impl_trait)]
 #![feature(crate_visibility_modifier)]
 #![feature(associated_type_bounds)]
 #![feature(rustc_attrs)]

--- a/compiler/rustc_middle/src/mir/coverage.rs
+++ b/compiler/rustc_middle/src/mir/coverage.rs
@@ -46,7 +46,7 @@ impl CounterValueReference {
 
     /// Returns explicitly-requested zero-based version of the counter id, used
     /// during codegen. LLVM expects zero-based indexes.
-    pub fn zero_based_index(&self) -> u32 {
+    pub fn zero_based_index(self) -> u32 {
         let one_based_index = self.as_u32();
         debug_assert!(one_based_index > 0);
         one_based_index - 1

--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -1292,6 +1292,8 @@ pub enum InlineAsmOperand<'tcx> {
 /// Type for MIR `Assert` terminator error messages.
 pub type AssertMessage<'tcx> = AssertKind<Operand<'tcx>>;
 
+// FIXME: Change `Successors` to `impl Iterator<Item = BasicBlock>`.
+#[allow(rustc::pass_by_value)]
 pub type Successors<'a> =
     iter::Chain<option::IntoIter<&'a BasicBlock>, slice::Iter<'a, BasicBlock>>;
 pub type SuccessorsMut<'a> =
@@ -1832,7 +1834,8 @@ impl<V, T> ProjectionElem<V, T> {
 /// and the index is a local.
 pub type PlaceElem<'tcx> = ProjectionElem<Local, Ty<'tcx>>;
 
-// At least on 64 bit systems, `PlaceElem` should not be larger than two pointers.
+// This type is fairly frequently used, so we shouldn't unintentionally increase
+// its size.
 #[cfg(all(target_arch = "x86_64", target_pointer_width = "64"))]
 static_assert_size!(PlaceElem<'_>, 24);
 

--- a/compiler/rustc_middle/src/mir/tcx.rs
+++ b/compiler/rustc_middle/src/mir/tcx.rs
@@ -33,7 +33,7 @@ impl<'tcx> PlaceTy<'tcx> {
     /// not carry a `Ty` for `T`.)
     ///
     /// Note that the resulting type has not been normalized.
-    pub fn field_ty(self, tcx: TyCtxt<'tcx>, f: &Field) -> Ty<'tcx> {
+    pub fn field_ty(self, tcx: TyCtxt<'tcx>, f: Field) -> Ty<'tcx> {
         let answer = match self.ty.kind() {
             ty::Adt(adt_def, substs) => {
                 let variant_def = match self.variant_index {
@@ -57,7 +57,7 @@ impl<'tcx> PlaceTy<'tcx> {
     /// `PlaceElem`, where we can just use the `Ty` that is already
     /// stored inline on field projection elems.
     pub fn projection_ty(self, tcx: TyCtxt<'tcx>, elem: PlaceElem<'tcx>) -> PlaceTy<'tcx> {
-        self.projection_ty_core(tcx, ty::ParamEnv::empty(), &elem, |_, _, &ty| ty)
+        self.projection_ty_core(tcx, ty::ParamEnv::empty(), &elem, |_, _, ty| ty)
     }
 
     /// `place_ty.projection_ty_core(tcx, elem, |...| { ... })`
@@ -70,11 +70,11 @@ impl<'tcx> PlaceTy<'tcx> {
         tcx: TyCtxt<'tcx>,
         param_env: ty::ParamEnv<'tcx>,
         elem: &ProjectionElem<V, T>,
-        mut handle_field: impl FnMut(&Self, &Field, &T) -> Ty<'tcx>,
+        mut handle_field: impl FnMut(&Self, Field, T) -> Ty<'tcx>,
     ) -> PlaceTy<'tcx>
     where
         V: ::std::fmt::Debug,
-        T: ::std::fmt::Debug,
+        T: ::std::fmt::Debug + Copy,
     {
         let answer = match *elem {
             ProjectionElem::Deref => {
@@ -105,7 +105,7 @@ impl<'tcx> PlaceTy<'tcx> {
             ProjectionElem::Downcast(_name, index) => {
                 PlaceTy { ty: self.ty, variant_index: Some(index) }
             }
-            ProjectionElem::Field(ref f, ref fty) => PlaceTy::from_ty(handle_field(&self, f, fty)),
+            ProjectionElem::Field(f, fty) => PlaceTy::from_ty(handle_field(&self, f, fty)),
         };
         debug!("projection_ty self: {:?} elem: {:?} yields: {:?}", self, elem, answer);
         answer

--- a/compiler/rustc_middle/src/mir/visit.rs
+++ b/compiler/rustc_middle/src/mir/visit.rs
@@ -225,12 +225,14 @@ macro_rules! make_mir_visitor {
                 self.super_var_debug_info(var_debug_info);
             }
 
+            #[allow(rustc::pass_by_value)]
             fn visit_local(&mut self,
                             _local: & $($mutability)? Local,
                             _context: PlaceContext,
                             _location: Location) {
             }
 
+            #[allow(rustc::pass_by_value)]
             fn visit_source_scope(&mut self,
                                       scope: & $($mutability)? SourceScope) {
                 self.super_source_scope(scope);
@@ -851,6 +853,7 @@ macro_rules! make_mir_visitor {
                 }
             }
 
+            #[allow(rustc::pass_by_value)]
             fn super_source_scope(&mut self,
                                       _scope: & $($mutability)? SourceScope) {
             }

--- a/compiler/rustc_mir_dataflow/src/move_paths/mod.rs
+++ b/compiler/rustc_mir_dataflow/src/move_paths/mod.rs
@@ -37,8 +37,8 @@ rustc_index::newtype_index! {
 }
 
 impl MoveOutIndex {
-    pub fn move_path_index(&self, move_data: &MoveData<'_>) -> MovePathIndex {
-        move_data.moves[*self].path
+    pub fn move_path_index(self, move_data: &MoveData<'_>) -> MovePathIndex {
+        move_data.moves[self].path
     }
 }
 
@@ -338,8 +338,8 @@ impl MovePathLookup {
     /// `MovePathIndex`es.
     pub fn iter_locals_enumerated(
         &self,
-    ) -> impl DoubleEndedIterator<Item = (Local, &MovePathIndex)> + ExactSizeIterator {
-        self.locals.iter_enumerated()
+    ) -> impl DoubleEndedIterator<Item = (Local, MovePathIndex)> + ExactSizeIterator + '_ {
+        self.locals.iter_enumerated().map(|(l, &idx)| (l, idx))
     }
 }
 

--- a/compiler/rustc_mir_transform/src/coverage/graph.rs
+++ b/compiler/rustc_mir_transform/src/coverage/graph.rs
@@ -48,7 +48,7 @@ impl CoverageGraph {
                 let mut bcb_successors = Vec::new();
                 for successor in
                     bcb_filtered_successors(&mir_body, &bcb_data.terminator(mir_body).kind)
-                        .filter_map(|&successor_bb| bb_to_bcb[successor_bb])
+                        .filter_map(|successor_bb| bb_to_bcb[successor_bb])
                 {
                     if !seen[successor] {
                         seen[successor] = true;
@@ -483,7 +483,7 @@ impl std::fmt::Debug for BcbBranch {
 fn bcb_filtered_successors<'a, 'tcx>(
     body: &'tcx &'a mir::Body<'tcx>,
     term_kind: &'tcx TerminatorKind<'tcx>,
-) -> Box<dyn Iterator<Item = &'a BasicBlock> + 'a> {
+) -> Box<dyn Iterator<Item = BasicBlock> + 'a> {
     let mut successors = term_kind.successors();
     Box::new(
         match &term_kind {
@@ -494,9 +494,8 @@ fn bcb_filtered_successors<'a, 'tcx>(
             // `next().into_iter()`) into the `mir::Successors` aliased type.
             _ => successors.next().into_iter().chain(&[]),
         }
-        .filter(move |&&successor| {
-            body[successor].terminator().kind != TerminatorKind::Unreachable
-        }),
+        .copied()
+        .filter(move |&successor| body[successor].terminator().kind != TerminatorKind::Unreachable),
     )
 }
 
@@ -695,7 +694,7 @@ pub struct ShortCircuitPreorder<
     F: Fn(
         &'tcx &'a mir::Body<'tcx>,
         &'tcx TerminatorKind<'tcx>,
-    ) -> Box<dyn Iterator<Item = &'a BasicBlock> + 'a>,
+    ) -> Box<dyn Iterator<Item = BasicBlock> + 'a>,
 > {
     body: &'tcx &'a mir::Body<'tcx>,
     visited: BitSet<BasicBlock>,
@@ -709,7 +708,7 @@ impl<
     F: Fn(
         &'tcx &'a mir::Body<'tcx>,
         &'tcx TerminatorKind<'tcx>,
-    ) -> Box<dyn Iterator<Item = &'a BasicBlock> + 'a>,
+    ) -> Box<dyn Iterator<Item = BasicBlock> + 'a>,
 > ShortCircuitPreorder<'a, 'tcx, F>
 {
     pub fn new(
@@ -733,7 +732,7 @@ impl<
     F: Fn(
         &'tcx &'a mir::Body<'tcx>,
         &'tcx TerminatorKind<'tcx>,
-    ) -> Box<dyn Iterator<Item = &'a BasicBlock> + 'a>,
+    ) -> Box<dyn Iterator<Item = BasicBlock> + 'a>,
 > Iterator for ShortCircuitPreorder<'a, 'tcx, F>
 {
     type Item = (BasicBlock, &'a BasicBlockData<'tcx>);

--- a/compiler/rustc_span/src/def_id.rs
+++ b/compiler/rustc_span/src/def_id.rs
@@ -27,8 +27,8 @@ impl CrateNum {
     }
 
     #[inline]
-    pub fn as_def_id(&self) -> DefId {
-        DefId { krate: *self, index: CRATE_DEF_INDEX }
+    pub fn as_def_id(self) -> DefId {
+        DefId { krate: self, index: CRATE_DEF_INDEX }
     }
 }
 
@@ -222,6 +222,7 @@ impl<D: Decoder> Decodable<D> for DefIndex {
 // On below-64 bit systems we can simply use the derived `Hash` impl
 #[cfg_attr(not(target_pointer_width = "64"), derive(Hash))]
 #[repr(C)]
+#[rustc_pass_by_value]
 // We guarantee field order. Note that the order is essential here, see below why.
 pub struct DefId {
     // cfg-ing the order of fields so that the `DefIndex` which is high entropy always ends up in

--- a/compiler/rustc_typeck/src/check/upvar.rs
+++ b/compiler/rustc_typeck/src/check/upvar.rs
@@ -785,7 +785,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             // Add a label pointing to where a captured variable affected by drop order
                             // is dropped
                             if lint_note.reason.drop_order {
-                                let drop_location_span = drop_location_span(self.tcx, &closure_hir_id);
+                                let drop_location_span = drop_location_span(self.tcx, closure_hir_id);
 
                                 match &lint_note.captures_info {
                                     UpvarMigrationInfo::CapturingPrecise { var_name: captured_name, .. } => {
@@ -1697,8 +1697,8 @@ fn apply_capture_kind_on_capture_ty<'tcx>(
 }
 
 /// Returns the Span of where the value with the provided HirId would be dropped
-fn drop_location_span<'tcx>(tcx: TyCtxt<'tcx>, hir_id: &hir::HirId) -> Span {
-    let owner_id = tcx.hir().get_enclosing_scope(*hir_id).unwrap();
+fn drop_location_span<'tcx>(tcx: TyCtxt<'tcx>, hir_id: hir::HirId) -> Span {
+    let owner_id = tcx.hir().get_enclosing_scope(hir_id).unwrap();
 
     let owner_node = tcx.hir().get(owner_id);
     let owner_span = match owner_node {

--- a/compiler/rustc_typeck/src/expr_use_visitor.rs
+++ b/compiler/rustc_typeck/src/expr_use_visitor.rs
@@ -702,10 +702,10 @@ impl<'a, 'tcx> ExprUseVisitor<'a, 'tcx> {
     fn walk_captures(&mut self, closure_expr: &hir::Expr<'_>) {
         fn upvar_is_local_variable<'tcx>(
             upvars: Option<&'tcx FxIndexMap<hir::HirId, hir::Upvar>>,
-            upvar_id: &hir::HirId,
+            upvar_id: hir::HirId,
             body_owner_is_closure: bool,
         ) -> bool {
-            upvars.map(|upvars| !upvars.contains_key(upvar_id)).unwrap_or(body_owner_is_closure)
+            upvars.map(|upvars| !upvars.contains_key(&upvar_id)).unwrap_or(body_owner_is_closure)
         }
 
         debug!("walk_captures({:?})", closure_expr);
@@ -727,7 +727,7 @@ impl<'a, 'tcx> ExprUseVisitor<'a, 'tcx> {
                     PlaceBase::Upvar(upvar_id) => {
                         if upvar_is_local_variable(
                             upvars,
-                            &upvar_id.var_path.hir_id,
+                            upvar_id.var_path.hir_id,
                             body_owner_is_closure,
                         ) {
                             // The nested closure might be fake reading the current (enclosing) closure's local variables.

--- a/src/tools/clippy/clippy_lints/src/redundant_clone.rs
+++ b/src/tools/clippy/clippy_lints/src/redundant_clone.rs
@@ -543,10 +543,10 @@ impl<'a, 'tcx> PossibleBorrowerVisitor<'a, 'tcx> {
                 continue;
             }
 
-            let borrowers = self.possible_borrower.reachable_from(&row);
+            let borrowers = self.possible_borrower.reachable_from(row);
             if !borrowers.is_empty() {
                 let mut bs = HybridBitSet::new_empty(self.body.local_decls.len());
-                for &c in borrowers {
+                for c in borrowers {
                     if c != mir::Local::from_usize(0) {
                         bs.insert(c);
                     }
@@ -663,10 +663,10 @@ impl<'a, 'tcx> PossibleOriginVisitor<'a, 'tcx> {
                 continue;
             }
 
-            let borrowers = self.possible_origin.reachable_from(&row);
+            let borrowers = self.possible_origin.reachable_from(row);
             if !borrowers.is_empty() {
                 let mut bs = HybridBitSet::new_empty(self.body.local_decls.len());
-                for &c in borrowers {
+                for c in borrowers {
                     if c != mir::Local::from_usize(0) {
                         bs.insert(c);
                     }

--- a/src/tools/clippy/clippy_utils/src/lib.rs
+++ b/src/tools/clippy/clippy_utils/src/lib.rs
@@ -489,7 +489,8 @@ pub fn def_path_res(cx: &LateContext<'_>, path: &[&str]) -> Res {
     fn find_crate(tcx: TyCtxt<'_>, name: &str) -> Option<DefId> {
         tcx.crates(())
             .iter()
-            .find(|&&num| tcx.crate_name(num).as_str() == name)
+            .copied()
+            .find(|&num| tcx.crate_name(num).as_str() == name)
             .map(CrateNum::as_def_id)
     }
 


### PR DESCRIPTION
the only interesting changes here should be to `TransitiveRelation`, but I believe to be highly unlikely that we will ever use a non `Copy` type with this type.