### PR TITLE
Enable conditional checking of values in the Rust codebase

### DIFF
--- a/library/core/tests/iter/adapters/step_by.rs
+++ b/library/core/tests/iter/adapters/step_by.rs
@@ -50,8 +50,6 @@ fn test_iterator_step_by_nth() {
 
 #[test]
 fn test_iterator_step_by_nth_overflow() {
-    #[cfg(target_pointer_width = "8")]
-    type Bigger = u16;
     #[cfg(target_pointer_width = "16")]
     type Bigger = u32;
     #[cfg(target_pointer_width = "32")]

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -1101,7 +1101,12 @@ impl<'a> Builder<'a> {
             // cargo.arg("-Zcheck-cfg-features");
 
             // Enable cfg checking of rustc well-known names
-            rustflags.arg("-Zunstable-options").arg("--check-cfg=names()");
+            rustflags
+                .arg("-Zunstable-options")
+                // Enable checking of well known names
+                .arg("--check-cfg=names()")
+                // Enable checking of well known values
+                .arg("--check-cfg=values()");
 
             // Add extra cfg not defined in rustc
             for (restricted_mode, name, values) in EXTRA_CHECK_CFGS {

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -199,6 +199,15 @@ const EXTRA_CHECK_CFGS: &[(Option<Mode>, &'static str, Option<&[&'static str]>)]
     (Some(Mode::Std), "no_global_oom_handling", None),
     (Some(Mode::Std), "freebsd12", None),
     (Some(Mode::Std), "backtrace_in_libstd", None),
+    /* Extra values not defined in the built-in targets yet, but used in std */
+    (Some(Mode::Std), "target_env", Some(&["libnx"])),
+    (Some(Mode::Std), "target_os", Some(&["watchos"])),
+    (
+        Some(Mode::Std),
+        "target_arch",
+        Some(&["asmjs", "spirv", "nvptx", "nvptx64", "le32", "xtensa"]),
+    ),
+    /* Extra names used by dependencies */
     // FIXME: Used by rustfmt is their test but is invalid (neither cargo nor bootstrap ever set
     // this config) should probably by removed or use a allow attribute.
     (Some(Mode::ToolRustc), "release", None),


### PR DESCRIPTION
This pull-request enable conditional checking of (well known) values in the Rust codebase.

Well known values were added in https://github.com/rust-lang/rust/pull/94362. All the `target_*` values are taken from all the built-in targets which is why some extra values were needed do be added as they are not (yet ?) defined in any built-in targets.

r? @Mark-Simulacrum 