### PR TITLE
Unify impl blocks by wrapping them into a div

### DIFF
--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -1460,6 +1460,7 @@ fn init_id_map() -> FxHashMap<String, usize> {
     map.insert("provided-methods".to_owned(), 1);
     map.insert("implementors".to_owned(), 1);
     map.insert("synthetic-implementors".to_owned(), 1);
+    map.insert("implementations-list".to_owned(), 1);
     map.insert("trait-implementations-list".to_owned(), 1);
     map.insert("synthetic-implementations-list".to_owned(), 1);
     map.insert("blanket-implementations-list".to_owned(), 1);

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -1065,14 +1065,15 @@ fn render_assoc_items_inner(
     let (non_trait, traits): (Vec<_>, _) = v.iter().partition(|i| i.inner_impl().trait_.is_none());
     if !non_trait.is_empty() {
         let mut tmp_buf = Buffer::empty_from(w);
-        let render_mode = match what {
+        let (render_mode, id) = match what {
             AssocItemRender::All => {
                 tmp_buf.write_str(
                     "<h2 id=\"implementations\" class=\"small-section-header\">\
-                         Implementations<a href=\"#implementations\" class=\"anchor\"></a>\
-                    </h2>",
+                         Implementations\
+                         <a href=\"#implementations\" class=\"anchor\"></a>\
+                     </h2>",
                 );
-                RenderMode::Normal
+                (RenderMode::Normal, "implementations-list".to_owned())
             }
             AssocItemRender::DerefFor { trait_, type_, deref_mut_ } => {
                 let id =
@@ -1090,7 +1091,7 @@ fn render_assoc_items_inner(
                     trait_ = trait_.print(cx),
                     type_ = type_.print(cx),
                 );
-                RenderMode::ForDeref { mut_: deref_mut_ }
+                (RenderMode::ForDeref { mut_: deref_mut_ }, cx.derive_id(id))
             }
         };
         let mut impls_buf = Buffer::empty_from(w);
@@ -1115,7 +1116,9 @@ fn render_assoc_items_inner(
         }
         if !impls_buf.is_empty() {
             w.push_buffer(tmp_buf);
+            write!(w, "<div id=\"{}\">", id);
             w.push_buffer(impls_buf);
+            w.write_str("</div>");
         }
     }
 
@@ -1146,7 +1149,8 @@ fn render_assoc_items_inner(
             write!(
                 w,
                 "<h2 id=\"trait-implementations\" class=\"small-section-header\">\
-                     Trait Implementations<a href=\"#trait-implementations\" class=\"anchor\"></a>\
+                     Trait Implementations\
+                     <a href=\"#trait-implementations\" class=\"anchor\"></a>\
                  </h2>\
                  <div id=\"trait-implementations-list\">{}</div>",
                 impls

--- a/src/librustdoc/html/static/js/main.js
+++ b/src/librustdoc/html/static/js/main.js
@@ -741,7 +741,7 @@ function hideThemeButtonState() {
         } else {
             addClass(innerToggle, "will-expand");
             onEachLazy(document.getElementsByClassName("rustdoc-toggle"), function(e) {
-                if (e.parentNode.id !== MAIN_ID ||
+                if (e.parentNode.id !== "implementations-list" ||
                     (!hasClass(e, "implementors-toggle") &&
                      !hasClass(e, "type-contents-toggle")))
                 {

--- a/src/test/rustdoc-gui/docblock-table-overflow.goml
+++ b/src/test/rustdoc-gui/docblock-table-overflow.goml
@@ -12,10 +12,10 @@ assert-property: (".top-doc .docblock table", {"scrollWidth": "1573"})
 
 // Logically, the ".docblock" and the "<p>" should have the same scroll width.
 compare-elements-property: (
-    "#implementations + details .docblock",
-    "#implementations + details .docblock > p",
+    "#implementations-list > details .docblock",
+    "#implementations-list > details .docblock > p",
     ["scrollWidth"],
 )
-assert-property: ("#implementations + details .docblock", {"scrollWidth": "801"})
+assert-property: ("#implementations-list > details .docblock", {"scrollWidth": "801"})
 // However, since there is overflow in the <table>, its scroll width is bigger.
-assert-property: ("#implementations + details .docblock table", {"scrollWidth": "1573"})
+assert-property: ("#implementations-list > details .docblock table", {"scrollWidth": "1573"})

--- a/src/test/rustdoc-gui/hash-item-expansion.goml
+++ b/src/test/rustdoc-gui/hash-item-expansion.goml
@@ -3,9 +3,9 @@ goto: file://|DOC_PATH|/test_docs/struct.Foo.html#method.borrow
 // In the blanket implementations list, "Borrow" is the second one, hence the ":nth(2)".
 assert-attribute: ("#blanket-implementations-list > details:nth-child(2)", {"open": ""})
 // We first check that the impl block is open by default.
-assert-attribute: ("#implementations + details", {"open": ""})
+assert-attribute: ("#implementations-list details", {"open": ""})
 // To ensure that we will click on the currently hidden method.
 assert-text: (".sidebar-elems section .block li > a", "must_use")
 click: ".sidebar-elems section .block li > a"
 // We check that the impl block was opened as expected so that we can see the method.
-assert-attribute: ("#implementations + details", {"open": ""})
+assert-attribute: ("#implementations-list > details", {"open": ""})

--- a/src/test/rustdoc-gui/impl-default-expansion.goml
+++ b/src/test/rustdoc-gui/impl-default-expansion.goml
@@ -1,3 +1,3 @@
 // This test ensures that the impl blocks are open by default.
 goto: file://|DOC_PATH|/test_docs/struct.Foo.html
-assert-attribute: ("#main-content > details.implementors-toggle", {"open": ""})
+assert-attribute: ("#implementations-list details.implementors-toggle", {"open": ""})

--- a/src/test/rustdoc-gui/toggle-docs-mobile.goml
+++ b/src/test/rustdoc-gui/toggle-docs-mobile.goml
@@ -14,7 +14,7 @@ assert-attribute: (".top-doc", {"open": ""})
 // Assert the position of the toggle on the top doc block.
 assert-position: (".top-doc summary::before", {"x": 4})
 // Assert the position of the toggle on the impl block.
-assert-position: ("#implementations + details > summary::before", {"x": 4})
+assert-position: ("#implementations-list > details > summary::before", {"x": 4})
 // Assert the position of the toggle on a method.
 assert-position: (
     "#trait-implementations-list .impl-items .method-toggle > summary::before",

--- a/src/test/rustdoc-gui/toggle-docs.goml
+++ b/src/test/rustdoc-gui/toggle-docs.goml
@@ -24,7 +24,7 @@ wait-for: 50
 assert-text: ("#toggle-all-docs", "[+]")
 // We check that all <details> are collapsed (except for the impl block ones).
 assert-attribute-false: ("details.rustdoc-toggle:not(.implementors-toggle)", {"open": ""}, ALL)
-assert-attribute: ("details.rustdoc-toggle.implementors-toggle", {"open": ""})
+assert-attribute: ("#implementations-list > details.implementors-toggle", {"open": ""})
 // We now check that the other impl blocks are collapsed.
 assert-attribute-false: (
     "#blanket-implementations-list > details.rustdoc-toggle.implementors-toggle",

--- a/src/test/rustdoc/duplicate_impls/issue-33054.rs
+++ b/src/test/rustdoc/duplicate_impls/issue-33054.rs
@@ -2,7 +2,7 @@
 // @has - '//h3[@class="code-header in-band"]' 'impl Foo'
 // @has - '//h3[@class="code-header in-band"]' 'impl Bar for Foo'
 // @count - '//*[@id="trait-implementations-list"]//*[@class="impl has-srclink"]' 1
-// @count - '//*[@id="main-content"]/details/summary/*[@class="impl has-srclink"]' 1
+// @count - '//*[@id="main-content"]/div[@id="implementations-list"]/details/summary/*[@class="impl has-srclink"]' 1
 // @has issue_33054/impls/bar/trait.Bar.html
 // @has - '//h3[@class="code-header in-band"]' 'impl Bar for Foo'
 // @count - '//*[@class="struct"]' 1

--- a/src/test/rustdoc/duplicate_impls/issue-33054.rs
+++ b/src/test/rustdoc/duplicate_impls/issue-33054.rs
@@ -1,3 +1,5 @@
+// ignore-tidy-linelength
+
 // @has issue_33054/impls/struct.Foo.html
 // @has - '//h3[@class="code-header in-band"]' 'impl Foo'
 // @has - '//h3[@class="code-header in-band"]' 'impl Bar for Foo'


### PR DESCRIPTION
The blanket and "auto traits" sections are wrapped into a `div` with an ID. This PR fixes this incoherence by wrapping each impl section (the "deref impl" and the "inherent impl" sections were missing it). It'll also make some tests simpler to write.

r? @notriddle 