### PR TITLE
Update cargo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -345,7 +345,6 @@ dependencies = [
  "libgit2-sys",
  "log",
  "memchr",
- "num_cpus",
  "opener",
  "openssl",
  "os_info",
@@ -1503,9 +1502,9 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.13.23"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a8057932925d3a9d9e4434ea016570d37420ddb1ceed45a174d577f24ed6700"
+checksum = "6e7d3b96ec1fcaa8431cf04a4f1ef5caafe58d5cf7bcc31f09c1626adddb0ffe"
 dependencies = [
  "bitflags",
  "libc",
@@ -1518,9 +1517,9 @@ dependencies = [
 
 [[package]]
 name = "git2-curl"
-version = "0.14.1"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "883539cb0ea94bab3f8371a98cd8e937bbe9ee7c044499184aa4c17deb643a50"
+checksum = "1ee51709364c341fbb6fe2a385a290fb9196753bdde2fc45447d27cd31b11b13"
 dependencies = [
  "curl",
  "git2",
@@ -1975,9 +1974,9 @@ dependencies = [
 
 [[package]]
 name = "libgit2-sys"
-version = "0.12.24+1.3.0"
+version = "0.13.1+1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddbd6021eef06fb289a8f54b3c2acfdd85ff2a585dfbb24b8576325373d2152c"
+checksum = "43e598aa7a4faedf1ea1b4608f582b06f0f40211eec551b7ef36019ae3f62def"
 dependencies = [
  "cc",
  "libc",


### PR DESCRIPTION
11 commits in 3d6970d50e30e797b8e26b2b9b1bdf92dc381f34..65c82664263feddc5fe2d424be0993c28d46377a
2022-02-28 19:29:07 +0000 to 2022-03-09 02:32:56 +0000
- Remove remaining 2 warn(clippy::*) instances (rust-lang/cargo#10438)
- Use `available_parallelism` instead of `num_cpus` (rust-lang/cargo#10427)
- Wait up to one second while waiting for curl (rust-lang/cargo#10456)
- Improve code coverage (rust-lang/cargo#10460)
- Don't recommend leaking tokens into the console history (rust-lang/cargo#10458)
- fix some typos (rust-lang/cargo#10454)
- Use `extend` instead of `push`ing in a loop (rust-lang/cargo#10453)
- Use locked_version more (rust-lang/cargo#10449)
- Disable dependabot (rust-lang/cargo#10443)
- Update git2 dependencies (rust-lang/cargo#10442)
- Stop gating stable features (rust-lang/cargo#10434)