### PR TITLE
Ignore `close_read_wakes_up` test on SGX platform

### DIFF
--- a/library/std/src/net/tcp/tests.rs
+++ b/library/std/src/net/tcp/tests.rs
@@ -508,6 +508,7 @@ fn close_readwrite_smoke() {
 }
 
 #[test]
+#[cfg_attr(target_env = "sgx", ignore)]
 fn close_read_wakes_up() {
     each_ip(&mut |addr| {
         let a = t!(TcpListener::bind(&addr));


### PR DESCRIPTION
PR #94714 enabled the `close_read_wakes_up` test for all platforms. This is incorrect. This test should be ignored at least for the SGX platform.

cc: @mzohreva @jethrogb