### PR TITLE
Add miri to the well known conditional compilation names and values

### DIFF
--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -1072,6 +1072,7 @@ impl CrateCheckConfig {
         // NOTE: This should be kept in sync with `default_configuration` and
         // `fill_well_known_values`
         const WELL_KNOWN_NAMES: &[Symbol] = &[
+            // rustc
             sym::unix,
             sym::windows,
             sym::target_os,
@@ -1091,9 +1092,12 @@ impl CrateCheckConfig {
             sym::debug_assertions,
             sym::proc_macro,
             sym::test,
+            sym::feature,
+            // rustdoc
             sym::doc,
             sym::doctest,
-            sym::feature,
+            // miri
+            sym::miri,
         ];
 
         // We only insert well-known names if `names()` was activated
@@ -1128,13 +1132,14 @@ impl CrateCheckConfig {
 
         // No-values
         for name in [
-            sym::unix,
-            sym::windows,
-            sym::debug_assertions,
-            sym::proc_macro,
-            sym::test,
             sym::doc,
+            sym::miri,
+            sym::unix,
+            sym::test,
             sym::doctest,
+            sym::windows,
+            sym::proc_macro,
+            sym::debug_assertions,
             sym::target_thread_local,
         ] {
             self.values_valid.entry(name).or_default();

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -891,6 +891,7 @@ symbols! {
         minnumf32,
         minnumf64,
         mips_target_feature,
+        miri,
         misc,
         mmx_reg,
         modifiers,

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -193,7 +193,6 @@ const EXTRA_CHECK_CFGS: &[(Option<Mode>, &'static str, Option<&[&'static str]>)]
     (None, "bootstrap", None),
     (Some(Mode::Rustc), "parallel_compiler", None),
     (Some(Mode::ToolRustc), "parallel_compiler", None),
-    (Some(Mode::Std), "miri", None),
     (Some(Mode::Std), "stdarch_intel_sde", None),
     (Some(Mode::Std), "no_fp_fmt_parse", None),
     (Some(Mode::Std), "no_global_oom_handling", None),

--- a/src/test/ui/check-cfg/well-known-names.rs
+++ b/src/test/ui/check-cfg/well-known-names.rs
@@ -24,4 +24,10 @@ fn unix_misspell() {}
 #[cfg(unix)]
 fn unix() {}
 
+#[cfg(miri)]
+fn miri() {}
+
+#[cfg(doc)]
+fn doc() {}
+
 fn main() {}

--- a/src/test/ui/check-cfg/well-known-values.rs
+++ b/src/test/ui/check-cfg/well-known-values.rs
@@ -25,4 +25,18 @@ fn unix_with_value() {}
 #[cfg(unix)]
 fn unix() {}
 
+#[cfg(miri = "miri")]
+//~^ WARNING unexpected `cfg` condition value
+fn miri_with_value() {}
+
+#[cfg(miri)]
+fn miri() {}
+
+#[cfg(doc = "linux")]
+//~^ WARNING unexpected `cfg` condition value
+fn doc_with_value() {}
+
+#[cfg(doc)]
+fn doc() {}
+
 fn main() {}

--- a/src/test/ui/check-cfg/well-known-values.stderr
+++ b/src/test/ui/check-cfg/well-known-values.stderr
@@ -29,5 +29,25 @@ LL | #[cfg(unix = "aa")]
    |
    = note: no expected value for `unix`
 
-warning: 3 warnings emitted
+warning: unexpected `cfg` condition value
+  --> $DIR/well-known-values.rs:28:7
+   |
+LL | #[cfg(miri = "miri")]
+   |       ^^^^---------
+   |           |
+   |           help: remove the value
+   |
+   = note: no expected value for `miri`
+
+warning: unexpected `cfg` condition value
+  --> $DIR/well-known-values.rs:35:7
+   |
+LL | #[cfg(doc = "linux")]
+   |       ^^^----------
+   |          |
+   |          help: remove the value
+   |
+   = note: no expected value for `doc`
+
+warning: 5 warnings emitted
 


### PR DESCRIPTION
This pull request adds `miri` to the list of well known names and values of the conditional compilation checking (`--check-cfg`).

This was brought up in [Zulip](https://rust-lang.zulipchat.com/#narrow/stream/246057-t-cargo/topic/RFC.203013.3A.20Checking.20conditional.20compilation.20at.20compile.20time/near/274513827) when discussing about the future of `--check-cfg`.

r? @petrochenkov