### PR TITLE
Optimize ascii::escape_default

### DIFF
--- a/library/core/src/ascii.rs
+++ b/library/core/src/ascii.rs
@@ -99,24 +99,12 @@ pub fn escape_default(c: u8) -> EscapeDefault {
         b'"' => ([b'\\', b'"', 0, 0], 2),
         b'\x20'..=b'\x7e' => ([c, 0, 0, 0], 1),
         _ => {
-            let (b1, b2) = hexify(c);
-            ([b'\\', b'x', b1, b2], 4)
+            let hex_digits: &[u8; 16] = b"0123456789abcdef";
+            ([b'\\', b'x', hex_digits[(c >> 4) as usize], hex_digits[(c & 0xf) as usize]], 4)
         }
     };
 
     return EscapeDefault { range: 0..len, data };
-
-    #[inline]
-    fn hexify(b: u8) -> (u8, u8) {
-        let hex_digits: &[u8; 16] = b"0123456789abcdef";
-        // SAFETY: For all n: u8, n >> 4 < 16 and n & 0xf < 16
-        unsafe {
-            (
-                *hex_digits.get_unchecked((b >> 4) as usize),
-                *hex_digits.get_unchecked((b & 0xf) as usize),
-            )
-        }
-    }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/library/core/src/ascii.rs
+++ b/library/core/src/ascii.rs
@@ -110,6 +110,8 @@ pub fn escape_default(c: u8) -> EscapeDefault {
 #[stable(feature = "rust1", since = "1.0.0")]
 impl Iterator for EscapeDefault {
     type Item = u8;
+
+    #[inline]
     fn next(&mut self) -> Option<u8> {
         self.range.next().map(|i| self.data[i as usize])
     }

--- a/library/core/src/ascii.rs
+++ b/library/core/src/ascii.rs
@@ -98,15 +98,23 @@ pub fn escape_default(c: u8) -> EscapeDefault {
         b'\'' => ([b'\\', b'\'', 0, 0], 2),
         b'"' => ([b'\\', b'"', 0, 0], 2),
         b'\x20'..=b'\x7e' => ([c, 0, 0, 0], 1),
-        _ => ([b'\\', b'x', hexify(c >> 4), hexify(c & 0xf)], 4),
+        _ => {
+            let (b1, b2) = hexify(c);
+            ([b'\\', b'x', b1, b2], 4)
+        }
     };
 
     return EscapeDefault { range: 0..len, data };
 
-    fn hexify(b: u8) -> u8 {
-        match b {
-            0..=9 => b'0' + b,
-            _ => b'a' + b - 10,
+    #[inline]
+    fn hexify(b: u8) -> (u8, u8) {
+        let hex_digits: &[u8; 16] = b"0123456789abcdef";
+        // SAFETY: For all n: u8, n >> 4 < 16 and n & 0xf < 16
+        unsafe {
+            (
+                *hex_digits.get_unchecked((b >> 4) as usize),
+                *hex_digits.get_unchecked((b & 0xf) as usize),
+            )
         }
     }
 }


### PR DESCRIPTION
`ascii::escape_default` showed up as a hot function when compiling `deunicode-1.3.1` in @nnethercote's [analysis](https://hackmd.io/mxdn4U58Su-UQXwzOHpHag) of @lqd's [rustc-benchmarking-data](https://github.com/lqd/rustc-benchmarking-data).
After taking a look at the generated assembly it looked like a LUT-based approach could be faster for `hexify()`-ing ascii characters, so that's what this PR implements

The patch looks like it provides about a 1-2% improvement in instructions for that particular crate. This should definitely be verified with a perf run as I'm still getting used to the `rustc-perf` tooling and might easily have made an error!

