### PR TITLE
Allow `cargo run` instead of `cargo run -p bootstrap`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+default-members = ["src/bootstrap"]
 members = [
   "src/bootstrap",
   "compiler/rustc",


### PR DESCRIPTION
This was part of @Mark-Simulacrum 's original PR in https://github.com/rust-lang/rust/commit/ecb424f12992a4aebace8a153d5efea040327a01,
but I missed it when writing #92260.

This also has the side effect of allowing `cargo build --bins` instead of `cargo build -p bootstrap --bins`. I'm not sure when you would want to run cargo build/check/test without going through bootstrap, but this still allows you to do so as long as you pass `-p` for all the crates you want to build.