### PR TITLE
BTree: let method clear recycle root memory

### DIFF
--- a/library/alloc/src/collections/btree/map/tests.rs
+++ b/library/alloc/src/collections/btree/map/tests.rs
@@ -1408,6 +1408,8 @@ fn test_bad_zst() {
 #[test]
 fn test_clear() {
     let mut map = BTreeMap::new();
+    map.clear();
+    assert_eq!(map.height(), None);
     for &len in &[MIN_INSERTS_HEIGHT_1, MIN_INSERTS_HEIGHT_2, 0, node::CAPACITY] {
         for i in 0..len {
             map.insert(i, ());
@@ -1415,7 +1417,7 @@ fn test_clear() {
         assert_eq!(map.len(), len);
         map.clear();
         map.check();
-        assert_eq!(map.height(), None);
+        assert_eq!(map.height(), Some(0), "len={len}");
     }
 }
 

--- a/library/alloc/src/collections/btree/set.rs
+++ b/library/alloc/src/collections/btree/set.rs
@@ -572,6 +572,7 @@ impl<T, A: Allocator> BTreeSet<T, A> {
     }
 
     /// Clears the set, removing all elements.
+    /// Keeps a part of the allocated memory for reuse.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
BTree's `clear` methods up to now literally drops and starts anew. [HashMap's clear](https://doc.rust-lang.org/std/collections/struct.HashMap.html#method.clear) "keeps the allocated memory for reuse.". This PR tries the simplest way to preserve the maximum of memory. If a map/set has multiple nodes, `clear` doesn't recycle the original root node but the last one in the tree, which is the last leaf node that was deallocated up to now and which would most likely have been the same memory allocated once you add elements to the cleared map.

This is a regression for those wanting to deallocate as much memory as possible. They could use `my_map = BTreeMap::new()` instead. Is there a regression in normal drop or into_iter? I have no idea.

Also, now two key-value pairs are allowed to panic-on-drop and unwinding continues, an abort only happens on the third pair panicking. This can be remedied, but I assumed it's acceptable behaviour.