### PR TITLE
debuginfo: Fix bug in type name generation for dyn types with associated types but no other generic arguments.

### DIFF
--- a/compiler/rustc_codegen_ssa/src/debuginfo/type_names.rs
+++ b/compiler/rustc_codegen_ssa/src/debuginfo/type_names.rs
@@ -212,13 +212,18 @@ fn push_debuginfo_type_name<'tcx>(
                 if projection_bounds.len() != 0 {
                     if principal_has_generic_params {
                         // push_generic_params_internal() above added a `>` but we actually
-                        // want to add more items to that list, so remove that again.
+                        // want to add more items to that list, so remove that again...
                         pop_close_angle_bracket(output);
+                        // .. and add a comma to separate the regular generic args from the
+                        // associated types.
+                        push_arg_separator(cpp_like_debuginfo, output);
+                    } else {
+                        // push_generic_params_internal() did not add `<...>`, so we open
+                        // angle brackets here.
+                        output.push('<');
                     }
 
                     for (item_def_id, ty) in projection_bounds {
-                        push_arg_separator(cpp_like_debuginfo, output);
-
                         if cpp_like_debuginfo {
                             output.push_str("assoc$<");
                             push_item_name(tcx, item_def_id, false, output);
@@ -230,8 +235,10 @@ fn push_debuginfo_type_name<'tcx>(
                             output.push('=');
                             push_debuginfo_type_name(tcx, ty, true, output, visited);
                         }
+                        push_arg_separator(cpp_like_debuginfo, output);
                     }
 
+                    pop_arg_separator(output);
                     push_close_angle_bracket(cpp_like_debuginfo, output);
                 }
 

--- a/src/test/debuginfo/type-names.rs
+++ b/src/test/debuginfo/type-names.rs
@@ -122,6 +122,9 @@
 // gdb-command:whatis has_associated_type_trait
 // gdb-check:type = &(dyn type_names::Trait3<u32, AssocType=isize> + core::marker::Send)
 
+// gdb-command:whatis has_associated_type_but_no_generics_trait
+// gdb-check:type = &dyn type_names::TraitNoGenericsButWithAssocType<Output=isize>
+
 // BARE FUNCTIONS
 // gdb-command:whatis rust_fn
 // gdb-check:type = (fn(core::option::Option<isize>, core::option::Option<&type_names::mod1::Struct2>), usize)
@@ -228,6 +231,7 @@
 // cdb-check:struct ref_mut$<dyn$<type_names::Trait1> > mut_ref_trait = [...]
 // cdb-check:struct alloc::boxed::Box<dyn$<core::marker::Send,core::marker::Sync>,alloc::alloc::Global> no_principal_trait = [...]
 // cdb-check:struct ref$<dyn$<type_names::Trait3<u32,assoc$<AssocType,isize> >,core::marker::Send> > has_associated_type_trait = struct ref$<dyn$<type_names::Trait3<u32,assoc$<AssocType,isize> >,core::marker::Send> >
+// cdb-check:struct ref$<dyn$<type_names::TraitNoGenericsButWithAssocType<assoc$<Output,isize> > > > has_associated_type_but_no_generics_trait = struct ref$<dyn$<type_names::TraitNoGenericsButWithAssocType<assoc$<Output,isize> > > >
 
 // BARE FUNCTIONS
 // cdb-command:dv /t *_fn*
@@ -318,11 +322,21 @@ trait Trait3<T> {
         panic!()
     }
 }
+trait TraitNoGenericsButWithAssocType {
+    type Output;
+    fn foo(&self) -> Self::Output;
+}
 
 impl Trait1 for isize {}
 impl<T1, T2> Trait2<T1, T2> for isize {}
 impl<T> Trait3<T> for isize {
     type AssocType = isize;
+}
+impl TraitNoGenericsButWithAssocType for isize {
+    type Output = isize;
+    fn foo(&self) -> Self::Output {
+        *self
+    }
 }
 
 fn rust_fn(_: Option<isize>, _: Option<&mod1::Struct2>) {}
@@ -414,6 +428,8 @@ fn main() {
     let mut_ref_trait = (&mut mut_int1) as &mut dyn Trait1;
     let no_principal_trait = Box::new(0_isize) as Box<(dyn Send + Sync)>;
     let has_associated_type_trait = &0_isize as &(dyn Trait3<u32, AssocType = isize> + Send);
+    let has_associated_type_but_no_generics_trait =
+        &0_isize as &dyn TraitNoGenericsButWithAssocType<Output = isize>;
 
     let generic_box_trait = Box::new(0_isize) as Box<dyn Trait2<i32, mod1::Struct2>>;
     let generic_ref_trait = (&0_isize) as &dyn Trait2<Struct1, Struct1>;


### PR DESCRIPTION
For types like `&dyn Future<Output=bool>` the compiler currently emits invalid types names in debuginfo. This PR fixes this.

Before:
```txt
// DWARF
&dyn core::future::future::Future, Output=bool> 

// CodeView
ref$<dyn$<core::future::future::Future,assoc$<Output,bool> > > >
```

After:
```txt
// DWARF
&dyn core::future::future::Future<Output=bool> 

// CodeView
ref$<dyn$<core::future::future::Future<assoc$<Output,bool> > > >
```

These syntactically incorrect type names can cause downstream tools (e.g. debugger extensions) crash when trying to parse them.

r? @wesleywiser 