### PR TITLE
configure: don't serialize empty array elements

### DIFF
--- a/src/bootstrap/configure.py
+++ b/src/bootstrap/configure.py
@@ -279,6 +279,10 @@ def build():
 
 
 def set(key, value):
+    if isinstance(value, list):
+        # Remove empty values, which value.split(',') tends to generate.
+        value = [v for v in value if v]
+
     s = "{:20} := {}".format(key, value)
     if len(s) < 70:
         p(s)


### PR DESCRIPTION
Before this change:

    $ ./configure --codegen-backends=
    [..]
    $ grep -P '^codegen-backends' config.toml
    codegen-backends = ['']

After this change:

    $ ./configure --codegen-backends=
    [..]
    $ grep -P '^codegen-backends' config.toml
    codegen-backends = []