### PR TITLE
bootstrap: add rust-toolchain to the root directory

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,5 @@
+[toolchain]
+# not just `beta`, since during release week there are two different beta compilers
+channel = "beta-2022-02-22"
+components = ["rustfmt"]
+profile = "minimal"


### PR DESCRIPTION
Helps with https://github.com/rust-lang/rust/issues/94829.

This doesn't solve "bootstrap uses beta rustc but nightly rustfmt",
but in practice there should be very little difference between two.
Users can still override the toolchain used with `cargo +nightly` or similar.