### PR TITLE
bootstrap: untangle static-libstdcpp & llvm-tools

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -89,7 +89,7 @@ changelog-seen = 2
 
 # Link libstdc++ statically into the rustc_llvm instead of relying on a
 # dynamic version to be available.
-#static-libstdcpp = false
+#static-libstdcpp = true
 
 # Whether to use Ninja to build LLVM. This runs much faster than make.
 #ninja = true

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -591,6 +591,7 @@ impl Config {
         config.llvm_optimize = true;
         config.ninja_in_file = true;
         config.llvm_version_check = true;
+        config.llvm_static_stdcpp = true;
         config.backtrace = true;
         config.rust_optimize = true;
         config.rust_optimize_tests = true;

--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -566,7 +566,7 @@ fn configure_cmake(
 
     // For distribution we want the LLVM tools to be *statically* linked to libstdc++.
     // We also do this if the user explicitly requested static libstdc++.
-    if builder.config.llvm_tools_enabled || builder.config.llvm_static_stdcpp {
+    if builder.config.llvm_static_stdcpp {
         if !target.contains("msvc") && !target.contains("netbsd") {
             if target.contains("apple") {
                 ldflags.push_all("-static-libstdc++");


### PR DESCRIPTION
Previously, the static-libstdcpp setting was tied to llvm-tools such
that enabling the latter always enabled the latter. This seems
unfortunate, since it is entirely reasonable for someone to want to
_not_ statically link stdc++, but _also_ want to build the llvm-tools.
This patch therefore separates the two settings such that neither
implies the other.

On its own, that would change the default behavior in a way that's
likely to surprise users. Specifically, users who build llvm-tools
_likely_ want those tools to be statically compiled against libstdc++,
since otherwise users with older GLIBCXX will be unable to run the
vended tools. So, we also flip the default for the `static-libstdcpp`
setting such that builds always link statically against libstdc++ by
default, but it's _possible_ to opt out.

See also #94719.