### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/compiler/rustc_infer/src/infer/higher_ranked/mod.rs
+++ b/compiler/rustc_infer/src/infer/higher_ranked/mod.rs
@@ -58,14 +58,11 @@ impl<'a, 'tcx> CombineFields<'a, 'tcx> {
 }
 
 impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
-    /// Replaces all regions (resp. types) bound by `binder` with placeholder
-    /// regions (resp. types) and return a map indicating which bound-region
-    /// placeholder region. This is the first step of checking subtyping
-    /// when higher-ranked things are involved.
+    /// Replaces all bound variables (lifetimes, types, and constants) bound by
+    /// `binder` with placeholder variables.
     ///
-    /// **Important:** You have to be careful to not leak these placeholders,
-    /// for more information about how placeholders and HRTBs work, see
-    /// the [rustc dev guide].
+    /// This is the first step of checking subtyping when higher-ranked things are involved.
+    /// For more details visit the relevant sections of the [rustc dev guide].
     ///
     /// [rustc dev guide]: https://rustc-dev-guide.rust-lang.org/traits/hrtb.html
     pub fn replace_bound_vars_with_placeholders<T>(&self, binder: ty::Binder<'tcx, T>) -> T

--- a/library/core/src/ascii.rs
+++ b/library/core/src/ascii.rs
@@ -99,24 +99,12 @@ pub fn escape_default(c: u8) -> EscapeDefault {
         b'"' => ([b'\\', b'"', 0, 0], 2),
         b'\x20'..=b'\x7e' => ([c, 0, 0, 0], 1),
         _ => {
-            let (b1, b2) = hexify(c);
-            ([b'\\', b'x', b1, b2], 4)
+            let hex_digits: &[u8; 16] = b"0123456789abcdef";
+            ([b'\\', b'x', hex_digits[(c >> 4) as usize], hex_digits[(c & 0xf) as usize]], 4)
         }
     };
 
     return EscapeDefault { range: 0..len, data };
-
-    #[inline]
-    fn hexify(b: u8) -> (u8, u8) {
-        let hex_digits: &[u8; 16] = b"0123456789abcdef";
-        // SAFETY: For all n: u8, n >> 4 < 16 and n & 0xf < 16
-        unsafe {
-            (
-                *hex_digits.get_unchecked((b >> 4) as usize),
-                *hex_digits.get_unchecked((b & 0xf) as usize),
-            )
-        }
-    }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/library/core/src/ascii.rs
+++ b/library/core/src/ascii.rs
@@ -110,6 +110,8 @@ pub fn escape_default(c: u8) -> EscapeDefault {
 #[stable(feature = "rust1", since = "1.0.0")]
 impl Iterator for EscapeDefault {
     type Item = u8;
+
+    #[inline]
     fn next(&mut self) -> Option<u8> {
         self.range.next().map(|i| self.data[i as usize])
     }

--- a/library/core/src/ascii.rs
+++ b/library/core/src/ascii.rs
@@ -98,15 +98,23 @@ pub fn escape_default(c: u8) -> EscapeDefault {
         b'\'' => ([b'\\', b'\'', 0, 0], 2),
         b'"' => ([b'\\', b'"', 0, 0], 2),
         b'\x20'..=b'\x7e' => ([c, 0, 0, 0], 1),
-        _ => ([b'\\', b'x', hexify(c >> 4), hexify(c & 0xf)], 4),
+        _ => {
+            let (b1, b2) = hexify(c);
+            ([b'\\', b'x', b1, b2], 4)
+        }
     };
 
     return EscapeDefault { range: 0..len, data };
 
-    fn hexify(b: u8) -> u8 {
-        match b {
-            0..=9 => b'0' + b,
-            _ => b'a' + b - 10,
+    #[inline]
+    fn hexify(b: u8) -> (u8, u8) {
+        let hex_digits: &[u8; 16] = b"0123456789abcdef";
+        // SAFETY: For all n: u8, n >> 4 < 16 and n & 0xf < 16
+        unsafe {
+            (
+                *hex_digits.get_unchecked((b >> 4) as usize),
+                *hex_digits.get_unchecked((b & 0xf) as usize),
+            )
         }
     }
 }

--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -2166,7 +2166,8 @@ macro_rules! int_impl {
 
             let r = try_opt!(self.checked_rem(rhs));
             let m = if (r > 0 && rhs < 0) || (r < 0 && rhs > 0) {
-                try_opt!(r.checked_add(rhs))
+                // r + rhs cannot overflow because they have opposite signs
+                r + rhs
             } else {
                 r
             };
@@ -2174,7 +2175,8 @@ macro_rules! int_impl {
             if m == 0 {
                 Some(self)
             } else {
-                self.checked_add(try_opt!(rhs.checked_sub(m)))
+                // rhs - m cannot overflow because m has the same sign as rhs
+                self.checked_add(rhs - m)
             }
         }
 

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -2119,7 +2119,8 @@ macro_rules! uint_impl {
         pub const fn checked_next_multiple_of(self, rhs: Self) -> Option<Self> {
             match try_opt!(self.checked_rem(rhs)) {
                 0 => Some(self),
-                r => self.checked_add(try_opt!(rhs.checked_sub(r)))
+                // rhs - r cannot overflow because r is smaller than rhs
+                r => self.checked_add(rhs - r)
             }
         }
 

--- a/library/std/src/fs/tests.rs
+++ b/library/std/src/fs/tests.rs
@@ -1,5 +1,6 @@
 use crate::io::prelude::*;
 
+use crate::env;
 use crate::fs::{self, File, OpenOptions};
 use crate::io::{ErrorKind, SeekFrom};
 use crate::path::Path;
@@ -906,7 +907,14 @@ fn read_link() {
         // junction
         assert_eq!(check!(fs::read_link(r"C:\Users\Default User")), Path::new(r"C:\Users\Default"));
         // junction with special permissions
-        assert_eq!(check!(fs::read_link(r"C:\Documents and Settings\")), Path::new(r"C:\Users"));
+        // Since not all localized windows versions contain the folder "Documents and Settings" in english,
+        // we will briefly check, if it exists and otherwise skip the test. Except during CI we will always execute the test.
+        if Path::new(r"C:\Documents and Settings\").exists() || env::var_os("CI").is_some() {
+            assert_eq!(
+                check!(fs::read_link(r"C:\Documents and Settings\")),
+                Path::new(r"C:\Users")
+            );
+        }
     }
     let tmpdir = tmpdir();
     let link = tmpdir.join("link");

--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -1233,16 +1233,18 @@ def bootstrap(help_triggered):
     build.verbose = args.verbose
     build.clean = args.clean
 
-    # Read from `--config`, then `RUST_BOOTSTRAP_CONFIG`, then fallback to `config.toml` (if it
-    # exists).
+    # Read from `--config`, then `RUST_BOOTSTRAP_CONFIG`, then `./config.toml`,
+    # then `config.toml` in the root directory.
     toml_path = args.config or os.getenv('RUST_BOOTSTRAP_CONFIG')
-    if not toml_path and os.path.exists('config.toml'):
+    using_default_path = toml_path is None
+    if using_default_path:
         toml_path = 'config.toml'
-
-    if toml_path:
         if not os.path.exists(toml_path):
             toml_path = os.path.join(build.rust_root, toml_path)
 
+    # Give a hard error if `--config` or `RUST_BOOTSTRAP_CONFIG` are set to a missing path,
+    # but not if `config.toml` hasn't been created.
+    if not using_default_path or os.path.exists(toml_path):
         with open(toml_path) as config:
             build.config_toml = config.read()
 


### PR DESCRIPTION
Successful merges:

 - #93283 (Fix for localized windows editions in testcase fn read_link() Issue#93211)
 - #94592 (Fallback to top-level config.toml if not present in current directory, and remove fallback for env vars and CLI flags)
 - #94776 (Optimize ascii::escape_default)
 - #94840 (update `replace_bound_vars_with_placeholders` doc comment)
 - #94842 (Remove unnecessary try_opt for operations that cannot fail)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=93283,94592,94776,94840,94842)
<!-- homu-ignore:end -->