### PR TITLE
Slightly improve metadata encoding efficiency

### DIFF
--- a/compiler/rustc_metadata/src/rmeta/decoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder.rs
@@ -1384,7 +1384,9 @@ impl<'a, 'tcx> CrateMetadataRef<'a> {
 
     fn get_proc_macro_quoted_span(self, index: usize, sess: &Session) -> Span {
         self.root
-            .tables
+            .proc_macro_data
+            .as_ref()
+            .expect("not a proc macro")
             .proc_macro_quoted_spans
             .get(self, index)
             .unwrap_or_else(|| panic!("Missing proc macro quoted span: {:?}", index))

--- a/compiler/rustc_metadata/src/rmeta/decoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder.rs
@@ -1434,8 +1434,8 @@ impl<'a, 'tcx> CrateMetadataRef<'a> {
     fn is_const_fn_raw(self, id: DefIndex) -> bool {
         let constness = match self.kind(id) {
             EntryKind::AssocFn(data) => data.decode(self).fn_data.constness,
-            EntryKind::Fn(data) => data.decode(self).constness,
-            EntryKind::ForeignFn(data) => data.decode(self).constness,
+            EntryKind::Fn(data) => data.constness,
+            EntryKind::ForeignFn(data) => data.constness,
             EntryKind::Variant(..) | EntryKind::Struct(..) => hir::Constness::Const,
             _ => hir::Constness::NotConst,
         };

--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -1643,9 +1643,10 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
             let macros =
                 self.lazy(tcx.resolutions(()).proc_macros.iter().map(|p| p.local_def_index));
             let spans = self.tcx.sess.parse_sess.proc_macro_quoted_spans();
+            let mut proc_macro_quoted_spans = TableBuilder::default();
             for (i, span) in spans.into_iter().enumerate() {
                 let span = self.lazy(span);
-                self.tables.proc_macro_quoted_spans.set(i, span);
+                proc_macro_quoted_spans.set(i, span);
             }
 
             record!(self.tables.opt_def_kind[LOCAL_CRATE.as_def_id()] <- DefKind::Mod);
@@ -1701,7 +1702,12 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
                 }
             }
 
-            Some(ProcMacroData { proc_macro_decls_static, stability, macros })
+            Some(ProcMacroData {
+                proc_macro_decls_static,
+                stability,
+                macros,
+                proc_macro_quoted_spans: proc_macro_quoted_spans.encode(&mut self.opaque),
+            })
         } else {
             None
         }

--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -1399,7 +1399,7 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
                 record!(self.tables.fn_arg_names[def_id] <- self.tcx.hir().body_param_names(body));
                 let data = FnData { constness: sig.header.constness };
 
-                EntryKind::Fn(self.lazy(data))
+                EntryKind::Fn(data)
             }
             hir::ItemKind::Macro(ref macro_def, _) => {
                 EntryKind::MacroDef(self.lazy(&*macro_def.body), macro_def.macro_rules)
@@ -1878,7 +1878,7 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
                         hir::Constness::NotConst
                     },
                 };
-                record!(self.tables.kind[def_id] <- EntryKind::ForeignFn(self.lazy(data)));
+                record!(self.tables.kind[def_id] <- EntryKind::ForeignFn(data));
             }
             hir::ForeignItemKind::Static(_, hir::Mutability::Mut) => {
                 record!(self.tables.kind[def_id] <- EntryKind::ForeignMutStatic);

--- a/compiler/rustc_metadata/src/rmeta/mod.rs
+++ b/compiler/rustc_metadata/src/rmeta/mod.rs
@@ -170,6 +170,7 @@ crate struct ProcMacroData {
     proc_macro_decls_static: DefIndex,
     stability: Option<attr::Stability>,
     macros: Lazy<[DefIndex]>,
+    proc_macro_quoted_spans: Lazy!(Table<usize, Lazy<Span>>),
 }
 
 /// Serialized metadata for a crate.
@@ -324,7 +325,6 @@ define_tables! {
     // definitions from any given crate.
     def_keys: Table<DefIndex, Lazy<DefKey>>,
     def_path_hashes: Table<DefIndex, Lazy<DefPathHash>>,
-    proc_macro_quoted_spans: Table<usize, Lazy<Span>>,
 }
 
 #[derive(Copy, Clone, MetadataEncodable, MetadataDecodable)]

--- a/compiler/rustc_metadata/src/rmeta/mod.rs
+++ b/compiler/rustc_metadata/src/rmeta/mod.rs
@@ -347,8 +347,8 @@ enum EntryKind {
     Variant(Lazy<VariantData>),
     Struct(Lazy<VariantData>, ReprOptions),
     Union(Lazy<VariantData>, ReprOptions),
-    Fn(Lazy<FnData>),
-    ForeignFn(Lazy<FnData>),
+    Fn(FnData),
+    ForeignFn(FnData),
     Mod(Lazy<[ModChild]>),
     MacroDef(Lazy<ast::MacArgs>, /*macro_rules*/ bool),
     ProcMacro(MacroKind),
@@ -362,7 +362,7 @@ enum EntryKind {
     TraitAlias,
 }
 
-#[derive(MetadataEncodable, MetadataDecodable)]
+#[derive(Copy, Clone, MetadataEncodable, MetadataDecodable)]
 struct FnData {
     constness: hir::Constness,
 }


### PR DESCRIPTION
Remove a `Lazy` that likely only slows things down and only encode the `proc_macro_quoted_spans` table pointer for proc-macros.