### PR TITLE
[WIP] metadata: Split `ModChild` into two structures

### DIFF
--- a/compiler/rustc_metadata/src/rmeta/decoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder.rs
@@ -1159,9 +1159,9 @@ impl<'a, 'tcx> CrateMetadataRef<'a> {
         }
 
         match self.kind(id) {
-            EntryKind::Mod(exports) => {
-                for exp in exports.decode((self, sess)) {
-                    callback(exp);
+            EntryKind::Mod(reexports) => {
+                for reexport in reexports.decode((self, sess)) {
+                    callback(reexport.mod_child());
                 }
             }
             EntryKind::Enum(..) | EntryKind::Trait(..) => {}

--- a/compiler/rustc_metadata/src/rmeta/mod.rs
+++ b/compiler/rustc_metadata/src/rmeta/mod.rs
@@ -12,7 +12,7 @@ use rustc_hir::def_id::{DefId, DefIndex, DefPathHash, StableCrateId};
 use rustc_hir::definitions::DefKey;
 use rustc_hir::lang_items;
 use rustc_index::{bit_set::FiniteBitSet, vec::IndexVec};
-use rustc_middle::metadata::ModChild;
+use rustc_middle::metadata::Reexport;
 use rustc_middle::middle::exported_symbols::{ExportedSymbol, SymbolExportLevel};
 use rustc_middle::mir;
 use rustc_middle::thir;
@@ -349,7 +349,7 @@ enum EntryKind {
     Union(Lazy<VariantData>, ReprOptions),
     Fn(Lazy<FnData>),
     ForeignFn(Lazy<FnData>),
-    Mod(Lazy<[ModChild]>),
+    Mod(Lazy<[Reexport]>),
     MacroDef(Lazy<ast::MacArgs>, /*macro_rules*/ bool),
     ProcMacro(MacroKind),
     Closure,

--- a/compiler/rustc_middle/src/metadata.rs
+++ b/compiler/rustc_middle/src/metadata.rs
@@ -10,7 +10,7 @@ use rustc_span::Span;
 /// need to add more data in the future to correctly support macros 2.0, for example.
 /// Module child can be either a proper item or a reexport (including private imports).
 /// In case of reexport all the fields describe the reexport item itself, not what it refers to.
-#[derive(Copy, Clone, Debug, TyEncodable, TyDecodable, HashStable)]
+#[derive(Clone, Copy, Debug, HashStable)]
 pub struct ModChild {
     /// Name of the item.
     pub ident: Ident,
@@ -23,4 +23,25 @@ pub struct ModChild {
     pub span: Span,
     /// A proper `macro_rules` item (not a reexport).
     pub macro_rules: bool,
+}
+
+/// Same as `ModChild`, but without some data that is redundant for reexports.
+#[derive(Clone, Copy, Debug, HashStable, TyEncodable, TyDecodable)]
+pub struct Reexport {
+    /// Name of the item.
+    pub ident: Ident,
+    /// Resolution result corresponding to the item.
+    /// Local variables cannot be exported, so this `Res` doesn't need the ID parameter.
+    pub res: Res<!>,
+    /// Visibility of the item.
+    pub vis: ty::Visibility,
+    /// Span of the item.
+    pub span: Span,
+}
+
+impl Reexport {
+    pub fn mod_child(self) -> ModChild {
+        let Reexport { ident, res, vis, span } = self;
+        ModChild { ident, res, vis, span, macro_rules: false }
+    }
 }

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -1314,7 +1314,7 @@ rustc_queries! {
         desc { "traits in scope at a block" }
     }
 
-    query module_reexports(def_id: LocalDefId) -> Option<&'tcx [ModChild]> {
+    query module_reexports(def_id: LocalDefId) -> Option<&'tcx [Reexport]> {
         desc { |tcx| "looking up reexports of module `{}`", tcx.def_path_str(def_id.to_def_id()) }
     }
 

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -20,7 +20,7 @@ pub use generics::*;
 use rustc_data_structures::fingerprint::Fingerprint;
 pub use vtable::*;
 
-use crate::metadata::ModChild;
+use crate::metadata::Reexport;
 use crate::middle::privacy::AccessLevels;
 use crate::mir::{Body, GeneratorLayout};
 use crate::traits::{self, Reveal};
@@ -132,7 +132,7 @@ pub struct ResolverOutputs {
     pub extern_crate_map: FxHashMap<LocalDefId, CrateNum>,
     pub maybe_unused_trait_imports: FxHashSet<LocalDefId>,
     pub maybe_unused_extern_crates: Vec<(LocalDefId, Span)>,
-    pub reexport_map: FxHashMap<LocalDefId, Vec<ModChild>>,
+    pub reexport_map: FxHashMap<LocalDefId, Vec<Reexport>>,
     pub glob_map: FxHashMap<LocalDefId, FxHashSet<Symbol>>,
     /// Extern prelude entries. The value is `true` if the entry was introduced
     /// via `extern crate` item and not `--extern` option or compiler built-in.

--- a/compiler/rustc_middle/src/ty/query.rs
+++ b/compiler/rustc_middle/src/ty/query.rs
@@ -1,7 +1,7 @@
 use crate::dep_graph;
 use crate::infer::canonical::{self, Canonical};
 use crate::lint::LintLevelMap;
-use crate::metadata::ModChild;
+use crate::metadata::{ModChild, Reexport};
 use crate::middle::codegen_fn_attrs::CodegenFnAttrs;
 use crate::middle::exported_symbols::{ExportedSymbol, SymbolExportLevel};
 use crate::middle::lib_features::LibFeatures;

--- a/compiler/rustc_resolve/src/imports.rs
+++ b/compiler/rustc_resolve/src/imports.rs
@@ -15,7 +15,7 @@ use rustc_data_structures::intern::Interned;
 use rustc_errors::{pluralize, struct_span_err, Applicability};
 use rustc_hir::def::{self, PartialRes};
 use rustc_hir::def_id::DefId;
-use rustc_middle::metadata::ModChild;
+use rustc_middle::metadata::Reexport;
 use rustc_middle::span_bug;
 use rustc_middle::ty;
 use rustc_session::lint::builtin::{PUB_USE_OF_PRIVATE_EXTERN_CRATE, UNUSED_IMPORTS};
@@ -1410,13 +1410,7 @@ impl<'a, 'b> ImportResolver<'a, 'b> {
                 // Ambiguous imports are treated as errors at this point and are
                 // not exposed to other crates (see #36837 for more details).
                 if res != def::Res::Err && !binding.is_ambiguity() {
-                    reexports.push(ModChild {
-                        ident,
-                        res,
-                        vis: binding.vis,
-                        span: binding.span,
-                        macro_rules: false,
-                    });
+                    reexports.push(Reexport { ident, res, vis: binding.vis, span: binding.span });
                 }
             }
         });


### PR DESCRIPTION
to avoid encoding redundant data.

Implement the suggestion from https://github.com/rust-lang/rust/pull/91795#issuecomment-1029610436.
r? @cjgillot 