### PR TITLE
diagnostics: single colon within `<>` probably, not type ascription

### DIFF
--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -2080,7 +2080,7 @@ impl<'a> Parser<'a> {
                     // Find a mistake like "foo::var:A".
                     err.span_suggestion(
                         snapshot.token.span,
-                        "you might have meant to write a path",
+                        "write a path separator here",
                         "::".to_string(),
                         Applicability::MaybeIncorrect,
                     );

--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -2073,6 +2073,19 @@ impl<'a> Parser<'a> {
                     let value = self.mk_expr_err(start.to(expr.span));
                     err.emit();
                     return Ok(GenericArg::Const(AnonConst { id: ast::DUMMY_NODE_ID, value }));
+                } else if token::Colon == snapshot.token.kind
+                    && expr.span.lo() == snapshot.token.span.hi()
+                    && matches!(expr.kind, ExprKind::Path(..))
+                {
+                    // Find a mistake like "foo::var:A".
+                    err.span_suggestion(
+                        snapshot.token.span,
+                        "you might have meant to write a path",
+                        "::".to_string(),
+                        Applicability::MaybeIncorrect,
+                    );
+                    err.emit();
+                    return Ok(GenericArg::Type(self.mk_ty(start.to(expr.span), TyKind::Err)));
                 } else if token::Comma == self.token.kind || self.token.kind.should_end_const_arg()
                 {
                     // Avoid the following output by checking that we consumed a full const arg:

--- a/src/test/ui/generics/single-colon-path-not-const-generics.rs
+++ b/src/test/ui/generics/single-colon-path-not-const-generics.rs
@@ -7,7 +7,7 @@ pub mod foo {
 pub struct Foo {
   a: Vec<foo::bar:A>,
   //~^ ERROR expected
-  //~| HELP you might have meant to write a path
+  //~| HELP path separator
 }
 
 fn main() {}

--- a/src/test/ui/generics/single-colon-path-not-const-generics.rs
+++ b/src/test/ui/generics/single-colon-path-not-const-generics.rs
@@ -1,0 +1,13 @@
+pub mod foo {
+    pub mod bar {
+        pub struct A;
+    }
+}
+
+pub struct Foo {
+  a: Vec<foo::bar:A>,
+  //~^ ERROR expected
+  //~| HELP you might have meant to write a path
+}
+
+fn main() {}

--- a/src/test/ui/generics/single-colon-path-not-const-generics.stderr
+++ b/src/test/ui/generics/single-colon-path-not-const-generics.stderr
@@ -1,0 +1,11 @@
+error: expected one of `,` or `>`, found `:`
+  --> $DIR/single-colon-path-not-const-generics.rs:8:18
+   |
+LL |   a: Vec<foo::bar:A>,
+   |                  ^
+   |                  |
+   |                  expected one of `,` or `>`
+   |                  help: you might have meant to write a path: `::`
+
+error: aborting due to previous error
+

--- a/src/test/ui/generics/single-colon-path-not-const-generics.stderr
+++ b/src/test/ui/generics/single-colon-path-not-const-generics.stderr
@@ -5,7 +5,7 @@ LL |   a: Vec<foo::bar:A>,
    |                  ^
    |                  |
    |                  expected one of `,` or `>`
-   |                  help: you might have meant to write a path: `::`
+   |                  help: write a path separator here: `::`
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Fixes #94812