### PR TITLE
Update browser-ui-test version used in CI

### DIFF
--- a/src/ci/docker/host-x86_64/x86_64-gnu-tools/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-tools/Dockerfile
@@ -72,7 +72,7 @@ ENV PATH="/node-v14.4.0-linux-x64/bin:${PATH}"
 # https://github.com/puppeteer/puppeteer/issues/375
 #
 # We also specify the version in case we need to update it to go around cache limitations.
-RUN npm install -g browser-ui-test@0.8.0 --unsafe-perm=true
+RUN npm install -g browser-ui-test@0.8.1 --unsafe-perm=true
 
 ENV RUST_CONFIGURE_ARGS \
   --build=x86_64-unknown-linux-gnu \


### PR DESCRIPTION
I realized that the extension of `assert-text*` commands was generated not completely valid (it stopped at first "success" and moved instead of running all checks). It was fixed in [this PR](https://github.com/GuillaumeGomez/browser-UI-test/pull/280).

We don't use this feature currently in the rustdoc GUI tests, but just in case...

r? @notriddle 