### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -2080,7 +2080,7 @@ impl<'a> Parser<'a> {
                     // Find a mistake like "foo::var:A".
                     err.span_suggestion(
                         snapshot.token.span,
-                        "you might have meant to write a path",
+                        "write a path separator here",
                         "::".to_string(),
                         Applicability::MaybeIncorrect,
                     );

--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -2073,6 +2073,19 @@ impl<'a> Parser<'a> {
                     let value = self.mk_expr_err(start.to(expr.span));
                     err.emit();
                     return Ok(GenericArg::Const(AnonConst { id: ast::DUMMY_NODE_ID, value }));
+                } else if token::Colon == snapshot.token.kind
+                    && expr.span.lo() == snapshot.token.span.hi()
+                    && matches!(expr.kind, ExprKind::Path(..))
+                {
+                    // Find a mistake like "foo::var:A".
+                    err.span_suggestion(
+                        snapshot.token.span,
+                        "you might have meant to write a path",
+                        "::".to_string(),
+                        Applicability::MaybeIncorrect,
+                    );
+                    err.emit();
+                    return Ok(GenericArg::Type(self.mk_ty(start.to(expr.span), TyKind::Err)));
                 } else if token::Comma == self.token.kind || self.token.kind.should_end_const_arg()
                 {
                     // Avoid the following output by checking that we consumed a full const arg:

--- a/src/ci/docker/host-x86_64/x86_64-gnu-tools/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-tools/Dockerfile
@@ -72,7 +72,7 @@ ENV PATH="/node-v14.4.0-linux-x64/bin:${PATH}"
 # https://github.com/puppeteer/puppeteer/issues/375
 #
 # We also specify the version in case we need to update it to go around cache limitations.
-RUN npm install -g browser-ui-test@0.8.0 --unsafe-perm=true
+RUN npm install -g browser-ui-test@0.8.1 --unsafe-perm=true
 
 ENV RUST_CONFIGURE_ARGS \
   --build=x86_64-unknown-linux-gnu \

--- a/src/test/ui/generics/single-colon-path-not-const-generics.rs
+++ b/src/test/ui/generics/single-colon-path-not-const-generics.rs
@@ -7,7 +7,7 @@ pub mod foo {
 pub struct Foo {
   a: Vec<foo::bar:A>,
   //~^ ERROR expected
-  //~| HELP you might have meant to write a path
+  //~| HELP path separator
 }
 
 fn main() {}

--- a/src/test/ui/generics/single-colon-path-not-const-generics.rs
+++ b/src/test/ui/generics/single-colon-path-not-const-generics.rs
@@ -1,0 +1,13 @@
+pub mod foo {
+    pub mod bar {
+        pub struct A;
+    }
+}
+
+pub struct Foo {
+  a: Vec<foo::bar:A>,
+  //~^ ERROR expected
+  //~| HELP you might have meant to write a path
+}
+
+fn main() {}

--- a/src/test/ui/generics/single-colon-path-not-const-generics.stderr
+++ b/src/test/ui/generics/single-colon-path-not-const-generics.stderr
@@ -1,0 +1,11 @@
+error: expected one of `,` or `>`, found `:`
+  --> $DIR/single-colon-path-not-const-generics.rs:8:18
+   |
+LL |   a: Vec<foo::bar:A>,
+   |                  ^
+   |                  |
+   |                  expected one of `,` or `>`
+   |                  help: you might have meant to write a path: `::`
+
+error: aborting due to previous error
+

--- a/src/test/ui/generics/single-colon-path-not-const-generics.stderr
+++ b/src/test/ui/generics/single-colon-path-not-const-generics.stderr
@@ -5,7 +5,7 @@ LL |   a: Vec<foo::bar:A>,
    |                  ^
    |                  |
    |                  expected one of `,` or `>`
-   |                  help: you might have meant to write a path: `::`
+   |                  help: write a path separator here: `::`
 
 error: aborting due to previous error
 

--- a/src/test/ui/methods/issues/issue-84495.rs
+++ b/src/test/ui/methods/issues/issue-84495.rs
@@ -1,0 +1,4 @@
+fn main() {
+    let x: i32 = 1;
+    println!("{:?}", x.count()); //~ ERROR is not an iterator
+}

--- a/src/test/ui/methods/issues/issue-84495.stderr
+++ b/src/test/ui/methods/issues/issue-84495.stderr
@@ -1,0 +1,13 @@
+error[E0599]: `i32` is not an iterator
+  --> $DIR/issue-84495.rs:3:24
+   |
+LL |     println!("{:?}", x.count());
+   |                        ^^^^^ `i32` is not an iterator
+   |
+   = note: the following trait bounds were not satisfied:
+           `i32: Iterator`
+           which is required by `&mut i32: Iterator`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0599`.


### PR DESCRIPTION
Successful merges:

 - #94865 (diagnostics: single colon within `<>` probably, not type ascription)
 - #94867 (Add regression test for `<i32 as Iterator>::count`)
 - #94886 (Update browser-ui-test version used in CI)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=94865,94867,94886)
<!-- homu-ignore:end -->