### PR TITLE
Make GATs object safe under generic_associated_types_extended feature

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/object_safety.rs
+++ b/compiler/rustc_trait_selection/src/traits/object_safety.rs
@@ -131,16 +131,18 @@ fn object_safety_violations_for_trait(
             }),
     );
 
-    violations.extend(
-        tcx.associated_items(trait_def_id)
-            .in_definition_order()
-            .filter(|item| item.kind == ty::AssocKind::Type)
-            .filter(|item| !tcx.generics_of(item.def_id).params.is_empty())
-            .map(|item| {
-                let ident = item.ident(tcx);
-                ObjectSafetyViolation::GAT(ident.name, ident.span)
-            }),
-    );
+    if !tcx.features().generic_associated_types_extended {
+        violations.extend(
+            tcx.associated_items(trait_def_id)
+                .in_definition_order()
+                .filter(|item| item.kind == ty::AssocKind::Type)
+                .filter(|item| !tcx.generics_of(item.def_id).params.is_empty())
+                .map(|item| {
+                    let ident = item.ident(tcx);
+                    ObjectSafetyViolation::GAT(ident.name, ident.span)
+                }),
+        );
+    }
 
     debug!(
         "object_safety_violations_for_trait(trait_def_id={:?}) = {:?}",

--- a/src/test/ui/generic-associated-types/gat-in-trait-path.base.stderr
+++ b/src/test/ui/generic-associated-types/gat-in-trait-path.base.stderr
@@ -1,11 +1,11 @@
 error[E0038]: the trait `Foo` cannot be made into an object
-  --> $DIR/gat-in-trait-path.rs:21:17
+  --> $DIR/gat-in-trait-path.rs:27:17
    |
 LL | fn f(_arg : Box<dyn for<'a> Foo<A<'a> = &'a ()>>) {}
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Foo` cannot be made into an object
    |
 note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
-  --> $DIR/gat-in-trait-path.rs:5:10
+  --> $DIR/gat-in-trait-path.rs:11:10
    |
 LL | trait Foo {
    |       --- this trait cannot be made into an object...

--- a/src/test/ui/generic-associated-types/gat-in-trait-path.rs
+++ b/src/test/ui/generic-associated-types/gat-in-trait-path.rs
@@ -1,5 +1,11 @@
+// revisions: base extended
+//[base] check-fail
+//[extended] check-pass
+
 #![feature(generic_associated_types)]
 #![feature(associated_type_defaults)]
+#![cfg_attr(extended, feature(generic_associated_types_extended))]
+#![cfg_attr(extended, allow(incomplete_features))]
 
 trait Foo {
     type A<'a> where Self: 'a;
@@ -19,7 +25,7 @@ impl<T> Foo for Fooer<T> {
 }
 
 fn f(_arg : Box<dyn for<'a> Foo<A<'a> = &'a ()>>) {}
-//~^ the trait `Foo` cannot be made into an object
+//[base]~^ the trait `Foo` cannot be made into an object
 
 
 fn main() {

--- a/src/test/ui/generic-associated-types/issue-67510-pass.base.stderr
+++ b/src/test/ui/generic-associated-types/issue-67510-pass.base.stderr
@@ -1,11 +1,11 @@
 error[E0038]: the trait `X` cannot be made into an object
-  --> $DIR/issue-67510-pass.rs:7:23
+  --> $DIR/issue-67510-pass.rs:13:23
    |
 LL | fn _func1<'a>(_x: Box<dyn X<Y<'a>=&'a ()>>) {}
    |                       ^^^^^^^^^^^^^^^^^^^ `X` cannot be made into an object
    |
 note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
-  --> $DIR/issue-67510-pass.rs:4:10
+  --> $DIR/issue-67510-pass.rs:10:10
    |
 LL | trait X {
    |       - this trait cannot be made into an object...

--- a/src/test/ui/generic-associated-types/issue-67510-pass.rs
+++ b/src/test/ui/generic-associated-types/issue-67510-pass.rs
@@ -1,10 +1,16 @@
+// revisions: base extended
+//[base] check-fail
+//[extended] check-pass
+
 #![feature(generic_associated_types)]
+#![cfg_attr(extended, feature(generic_associated_types_extended))]
+#![cfg_attr(extended, allow(incomplete_features))]
 
 trait X {
     type Y<'a>;
 }
 
 fn _func1<'a>(_x: Box<dyn X<Y<'a>=&'a ()>>) {}
-//~^ ERROR the trait `X` cannot be made into an object
+//[base]~^ ERROR the trait `X` cannot be made into an object
 
 fn main() {}

--- a/src/test/ui/generic-associated-types/issue-76535.base.stderr
+++ b/src/test/ui/generic-associated-types/issue-76535.base.stderr
@@ -1,11 +1,11 @@
 error[E0107]: missing generics for associated type `SuperTrait::SubType`
-  --> $DIR/issue-76535.rs:36:33
+  --> $DIR/issue-76535.rs:40:33
    |
 LL |     let sub: Box<dyn SuperTrait<SubType = SubStruct>> = Box::new(SuperStruct::new(0));
    |                                 ^^^^^^^ expected 1 lifetime argument
    |
 note: associated type defined here, with 1 lifetime parameter: `'a`
-  --> $DIR/issue-76535.rs:6:10
+  --> $DIR/issue-76535.rs:10:10
    |
 LL |     type SubType<'a>: SubTrait where Self: 'a;
    |          ^^^^^^^ --
@@ -15,13 +15,13 @@ LL |     let sub: Box<dyn SuperTrait<SubType<'a> = SubStruct>> = Box::new(SuperS
    |                                 ~~~~~~~~~~~
 
 error[E0038]: the trait `SuperTrait` cannot be made into an object
-  --> $DIR/issue-76535.rs:36:14
+  --> $DIR/issue-76535.rs:40:14
    |
 LL |     let sub: Box<dyn SuperTrait<SubType = SubStruct>> = Box::new(SuperStruct::new(0));
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `SuperTrait` cannot be made into an object
    |
 note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
-  --> $DIR/issue-76535.rs:6:10
+  --> $DIR/issue-76535.rs:10:10
    |
 LL | pub trait SuperTrait {
    |           ---------- this trait cannot be made into an object...
@@ -30,13 +30,13 @@ LL |     type SubType<'a>: SubTrait where Self: 'a;
    = help: consider moving `SubType` to another trait
 
 error[E0038]: the trait `SuperTrait` cannot be made into an object
-  --> $DIR/issue-76535.rs:36:57
+  --> $DIR/issue-76535.rs:40:57
    |
 LL |     let sub: Box<dyn SuperTrait<SubType = SubStruct>> = Box::new(SuperStruct::new(0));
    |                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `SuperTrait` cannot be made into an object
    |
 note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
-  --> $DIR/issue-76535.rs:6:10
+  --> $DIR/issue-76535.rs:10:10
    |
 LL | pub trait SuperTrait {
    |           ---------- this trait cannot be made into an object...

--- a/src/test/ui/generic-associated-types/issue-76535.extended.stderr
+++ b/src/test/ui/generic-associated-types/issue-76535.extended.stderr
@@ -1,0 +1,19 @@
+error[E0107]: missing generics for associated type `SuperTrait::SubType`
+  --> $DIR/issue-76535.rs:40:33
+   |
+LL |     let sub: Box<dyn SuperTrait<SubType = SubStruct>> = Box::new(SuperStruct::new(0));
+   |                                 ^^^^^^^ expected 1 lifetime argument
+   |
+note: associated type defined here, with 1 lifetime parameter: `'a`
+  --> $DIR/issue-76535.rs:10:10
+   |
+LL |     type SubType<'a>: SubTrait where Self: 'a;
+   |          ^^^^^^^ --
+help: add missing lifetime argument
+   |
+LL |     let sub: Box<dyn SuperTrait<SubType<'a> = SubStruct>> = Box::new(SuperStruct::new(0));
+   |                                 ~~~~~~~~~~~
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0107`.

--- a/src/test/ui/generic-associated-types/issue-76535.rs
+++ b/src/test/ui/generic-associated-types/issue-76535.rs
@@ -1,4 +1,8 @@
+// revisions: base extended
+
 #![feature(generic_associated_types)]
+#![cfg_attr(extended, feature(generic_associated_types_extended))]
+#![cfg_attr(extended, allow(incomplete_features))]
 
 pub trait SubTrait {}
 
@@ -35,6 +39,6 @@ impl SuperTrait for SuperStruct {
 fn main() {
     let sub: Box<dyn SuperTrait<SubType = SubStruct>> = Box::new(SuperStruct::new(0));
       //~^ ERROR missing generics for associated type
-      //~^^ ERROR the trait
-      //~| ERROR the trait
+      //[base]~^^ ERROR the trait
+      //[base]~| ERROR the trait
 }

--- a/src/test/ui/generic-associated-types/issue-78671.base.stderr
+++ b/src/test/ui/generic-associated-types/issue-78671.base.stderr
@@ -1,11 +1,11 @@
 error[E0107]: missing generics for associated type `CollectionFamily::Member`
-  --> $DIR/issue-78671.rs:7:47
+  --> $DIR/issue-78671.rs:11:47
    |
 LL |     Box::new(Family) as &dyn CollectionFamily<Member=usize>
    |                                               ^^^^^^ expected 1 generic argument
    |
 note: associated type defined here, with 1 generic parameter: `T`
-  --> $DIR/issue-78671.rs:4:10
+  --> $DIR/issue-78671.rs:8:10
    |
 LL |     type Member<T>;
    |          ^^^^^^ -
@@ -15,13 +15,13 @@ LL |     Box::new(Family) as &dyn CollectionFamily<Member<T>=usize>
    |                                               ~~~~~~~~~
 
 error[E0038]: the trait `CollectionFamily` cannot be made into an object
-  --> $DIR/issue-78671.rs:7:25
+  --> $DIR/issue-78671.rs:11:25
    |
 LL |     Box::new(Family) as &dyn CollectionFamily<Member=usize>
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `CollectionFamily` cannot be made into an object
    |
 note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
-  --> $DIR/issue-78671.rs:4:10
+  --> $DIR/issue-78671.rs:8:10
    |
 LL | trait CollectionFamily {
    |       ---------------- this trait cannot be made into an object...

--- a/src/test/ui/generic-associated-types/issue-78671.extended.stderr
+++ b/src/test/ui/generic-associated-types/issue-78671.extended.stderr
@@ -1,0 +1,19 @@
+error[E0107]: missing generics for associated type `CollectionFamily::Member`
+  --> $DIR/issue-78671.rs:11:47
+   |
+LL |     Box::new(Family) as &dyn CollectionFamily<Member=usize>
+   |                                               ^^^^^^ expected 1 generic argument
+   |
+note: associated type defined here, with 1 generic parameter: `T`
+  --> $DIR/issue-78671.rs:8:10
+   |
+LL |     type Member<T>;
+   |          ^^^^^^ -
+help: add missing generic argument
+   |
+LL |     Box::new(Family) as &dyn CollectionFamily<Member<T>=usize>
+   |                                               ~~~~~~~~~
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0107`.

--- a/src/test/ui/generic-associated-types/issue-78671.rs
+++ b/src/test/ui/generic-associated-types/issue-78671.rs
@@ -1,4 +1,8 @@
+// revisions: base extended
+
 #![feature(generic_associated_types)]
+#![cfg_attr(extended, feature(generic_associated_types_extended))]
+#![cfg_attr(extended, allow(incomplete_features))]
 
 trait CollectionFamily {
     type Member<T>;
@@ -6,7 +10,7 @@ trait CollectionFamily {
 fn floatify() {
     Box::new(Family) as &dyn CollectionFamily<Member=usize>
     //~^ ERROR: missing generics for associated type
-    //~| ERROR: the trait `CollectionFamily` cannot be made into an object
+    //[base]~^^ ERROR: the trait `CollectionFamily` cannot be made into an object
 }
 
 struct Family;

--- a/src/test/ui/generic-associated-types/issue-79422.base.stderr
+++ b/src/test/ui/generic-associated-types/issue-79422.base.stderr
@@ -1,11 +1,11 @@
 error[E0107]: missing generics for associated type `MapLike::VRefCont`
-  --> $DIR/issue-79422.rs:42:36
+  --> $DIR/issue-79422.rs:48:36
    |
 LL |         as Box<dyn MapLike<u8, u8, VRefCont = dyn RefCont<'_, u8>>>;
    |                                    ^^^^^^^^ expected 1 lifetime argument
    |
 note: associated type defined here, with 1 lifetime parameter: `'a`
-  --> $DIR/issue-79422.rs:20:10
+  --> $DIR/issue-79422.rs:24:10
    |
 LL |     type VRefCont<'a>: RefCont<'a, V> where Self: 'a;
    |          ^^^^^^^^ --
@@ -15,13 +15,13 @@ LL |         as Box<dyn MapLike<u8, u8, VRefCont<'a> = dyn RefCont<'_, u8>>>;
    |                                    ~~~~~~~~~~~~
 
 error[E0038]: the trait `MapLike` cannot be made into an object
-  --> $DIR/issue-79422.rs:42:12
+  --> $DIR/issue-79422.rs:48:12
    |
 LL |         as Box<dyn MapLike<u8, u8, VRefCont = dyn RefCont<'_, u8>>>;
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `MapLike` cannot be made into an object
    |
 note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
-  --> $DIR/issue-79422.rs:20:10
+  --> $DIR/issue-79422.rs:24:10
    |
 LL | trait MapLike<K, V> {
    |       ------- this trait cannot be made into an object...
@@ -30,13 +30,13 @@ LL |     type VRefCont<'a>: RefCont<'a, V> where Self: 'a;
    = help: consider moving `VRefCont` to another trait
 
 error[E0038]: the trait `MapLike` cannot be made into an object
-  --> $DIR/issue-79422.rs:41:13
+  --> $DIR/issue-79422.rs:45:13
    |
 LL |     let m = Box::new(std::collections::BTreeMap::<u8, u8>::new())
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `MapLike` cannot be made into an object
    |
 note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
-  --> $DIR/issue-79422.rs:20:10
+  --> $DIR/issue-79422.rs:24:10
    |
 LL | trait MapLike<K, V> {
    |       ------- this trait cannot be made into an object...

--- a/src/test/ui/generic-associated-types/issue-79422.extended.stderr
+++ b/src/test/ui/generic-associated-types/issue-79422.extended.stderr
@@ -1,0 +1,35 @@
+error[E0107]: missing generics for associated type `MapLike::VRefCont`
+  --> $DIR/issue-79422.rs:48:36
+   |
+LL |         as Box<dyn MapLike<u8, u8, VRefCont = dyn RefCont<'_, u8>>>;
+   |                                    ^^^^^^^^ expected 1 lifetime argument
+   |
+note: associated type defined here, with 1 lifetime parameter: `'a`
+  --> $DIR/issue-79422.rs:24:10
+   |
+LL |     type VRefCont<'a>: RefCont<'a, V> where Self: 'a;
+   |          ^^^^^^^^ --
+help: add missing lifetime argument
+   |
+LL |         as Box<dyn MapLike<u8, u8, VRefCont<'a> = dyn RefCont<'_, u8>>>;
+   |                                    ~~~~~~~~~~~~
+
+error[E0271]: type mismatch resolving `<BTreeMap<u8, u8> as MapLike<u8, u8>>::VRefCont<'_> == (dyn RefCont<'_, u8> + 'static)`
+  --> $DIR/issue-79422.rs:45:13
+   |
+LL |     let m = Box::new(std::collections::BTreeMap::<u8, u8>::new())
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type mismatch resolving `<BTreeMap<u8, u8> as MapLike<u8, u8>>::VRefCont<'_> == (dyn RefCont<'_, u8> + 'static)`
+   |
+note: expected this to be `(dyn RefCont<'_, u8> + 'static)`
+  --> $DIR/issue-79422.rs:29:25
+   |
+LL |     type VRefCont<'a> = &'a V where Self: 'a;
+   |                         ^^^^^
+   = note: expected trait object `(dyn RefCont<'_, u8> + 'static)`
+                 found reference `&u8`
+   = note: required for the cast to the object type `dyn MapLike<u8, u8, VRefCont = (dyn RefCont<'_, u8> + 'static)>`
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0107, E0271.
+For more information about an error, try `rustc --explain E0107`.

--- a/src/test/ui/generic-associated-types/issue-79422.rs
+++ b/src/test/ui/generic-associated-types/issue-79422.rs
@@ -1,4 +1,8 @@
+// revisions: base extended
+
 #![feature(generic_associated_types)]
+#![cfg_attr(extended, feature(generic_associated_types_extended))]
+#![cfg_attr(extended, allow(incomplete_features))]
 
 trait RefCont<'a, T> {
     fn t(&'a self) -> &'a T;
@@ -39,8 +43,9 @@ impl<K, V: Default> MapLike<K, V> for Source {
 
 fn main() {
     let m = Box::new(std::collections::BTreeMap::<u8, u8>::new())
+    //[base]~^ ERROR the trait
+    //[extended]~^^ type mismatch
         as Box<dyn MapLike<u8, u8, VRefCont = dyn RefCont<'_, u8>>>;
       //~^ ERROR missing generics for associated type
-      //~^^ ERROR the trait
-      //~^^^^ ERROR the trait
+      //[base]~^^ ERROR the trait
 }

--- a/src/test/ui/generic-associated-types/trait-objects.base.stderr
+++ b/src/test/ui/generic-associated-types/trait-objects.base.stderr
@@ -1,11 +1,11 @@
 error[E0038]: the trait `StreamingIterator` cannot be made into an object
-  --> $DIR/trait-objects.rs:10:21
+  --> $DIR/trait-objects.rs:14:21
    |
 LL | fn min_size(x: &mut dyn for<'a> StreamingIterator<Item<'a> = &'a i32>) -> usize {
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `StreamingIterator` cannot be made into an object
    |
 note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
-  --> $DIR/trait-objects.rs:4:10
+  --> $DIR/trait-objects.rs:8:10
    |
 LL | trait StreamingIterator {
    |       ----------------- this trait cannot be made into an object...

--- a/src/test/ui/generic-associated-types/trait-objects.extended.nll.stderr
+++ b/src/test/ui/generic-associated-types/trait-objects.extended.nll.stderr
@@ -1,0 +1,17 @@
+error[E0521]: borrowed data escapes outside of function
+  --> $DIR/trait-objects.rs:16:5
+   |
+LL | fn min_size(x: &mut dyn for<'a> StreamingIterator<Item<'a> = &'a i32>) -> usize {
+   |             -  - let's call the lifetime of this reference `'1`
+   |             |
+   |             `x` is a reference that is only valid in the function body
+LL |
+LL |     x.size_hint().0
+   |     ^^^^^^^^^^^^^
+   |     |
+   |     `x` escapes the function body here
+   |     argument requires that `'1` must outlive `'static`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0521`.

--- a/src/test/ui/generic-associated-types/trait-objects.extended.stderr
+++ b/src/test/ui/generic-associated-types/trait-objects.extended.stderr
@@ -1,0 +1,12 @@
+error[E0621]: explicit lifetime required in the type of `x`
+  --> $DIR/trait-objects.rs:16:7
+   |
+LL | fn min_size(x: &mut dyn for<'a> StreamingIterator<Item<'a> = &'a i32>) -> usize {
+   |                ------------------------------------------------------ help: add explicit lifetime `'a` to the type of `x`: `&'a mut (dyn StreamingIterator<for<'a> Item = &'a i32> + 'a)`
+LL |
+LL |     x.size_hint().0
+   |       ^^^^^^^^^ lifetime `'a` required
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0621`.

--- a/src/test/ui/generic-associated-types/trait-objects.rs
+++ b/src/test/ui/generic-associated-types/trait-objects.rs
@@ -1,4 +1,8 @@
+// revisions: base extended
+
 #![feature(generic_associated_types)]
+#![cfg_attr(extended, feature(generic_associated_types_extended))]
+#![cfg_attr(extended, allow(incomplete_features))]
 
 trait StreamingIterator {
     type Item<'a> where Self: 'a;
@@ -8,8 +12,9 @@ trait StreamingIterator {
 }
 
 fn min_size(x: &mut dyn for<'a> StreamingIterator<Item<'a> = &'a i32>) -> usize {
-    //~^ the trait `StreamingIterator` cannot be made into an object
+    //[base]~^ the trait `StreamingIterator` cannot be made into an object
     x.size_hint().0
+    //[extended]~^ explicit lifetime required
 }
 
 fn main() {}


### PR DESCRIPTION
Based on #94869

Let's say we have
```rust
trait StreamingIterator {
    type Item<'a> where Self: 'a;
}
```
And `dyn for<'a> StreamingIterator<Item<'a> = &'a i32>`.

If we ask `(dyn for<'a> StreamingIterator<Item<'a> = &'a i32>): StreamingIterator`, then we have to prove that `for<'x> (&'x i32): Sized`. So, we generate *new* bound vars to subst for the GAT generics.

Importantly, this doesn't fully verify that these are usable and sound.

r? @nikomatsakis 