### PR TITLE
Fix definition of Box in ssa-analysis-regression-50041.rs

### DIFF
--- a/src/test/ui/mir/ssa-analysis-regression-50041.rs
+++ b/src/test/ui/mir/ssa-analysis-regression-50041.rs
@@ -6,7 +6,7 @@
 #![no_std]
 
 #[lang = "owned_box"]
-pub struct Box<T: ?Sized>(*mut T);
+pub struct Box<T: ?Sized>(*mut T, ());
 
 impl<T: ?Sized> Drop for Box<T> {
     fn drop(&mut self) {
@@ -15,7 +15,7 @@ impl<T: ?Sized> Drop for Box<T> {
 
 #[lang = "box_free"]
 #[inline(always)]
-unsafe fn box_free<T: ?Sized>(ptr: *mut T) {
+unsafe fn box_free<T: ?Sized>(ptr: *mut T, _: ()) {
     dealloc(ptr)
 }
 


### PR DESCRIPTION
The Box in liballoc always has a field for the allocator. It is quite
hard to support both the old and new definition of Box in cg_clif so
this change uses the new definition in this test too.