### PR TITLE
relax `suspicious_auto_trait_impls` lint wrt lifetimes

### DIFF
--- a/compiler/rustc_typeck/src/coherence/orphan.rs
+++ b/compiler/rustc_typeck/src/coherence/orphan.rs
@@ -297,17 +297,11 @@ impl<'tcx> TypeVisitor<'tcx> for AreUniqueParamsVisitor {
             _ => ControlFlow::Break(NotUniqueParam::NotParam(t.into())),
         }
     }
-    fn visit_region(&mut self, r: ty::Region<'tcx>) -> ControlFlow<Self::BreakTy> {
-        match *r {
-            ty::ReEarlyBound(p) => {
-                if self.seen.insert(p.index) {
-                    ControlFlow::CONTINUE
-                } else {
-                    ControlFlow::Break(NotUniqueParam::DuplicateParam(r.into()))
-                }
-            }
-            _ => ControlFlow::Break(NotUniqueParam::NotParam(r.into())),
-        }
+    fn visit_region(&mut self, _: ty::Region<'tcx>) -> ControlFlow<Self::BreakTy> {
+        // We don't drop candidates during candidate assembly because of region
+        // constraints, so the behavior for impls only constrained by regions
+        // will not change.
+        ControlFlow::CONTINUE
     }
     fn visit_const(&mut self, c: ty::Const<'tcx>) -> ControlFlow<Self::BreakTy> {
         match c.val() {

--- a/src/test/ui/auto-traits/suspicious-impls-lint.rs
+++ b/src/test/ui/auto-traits/suspicious-impls-lint.rs
@@ -41,4 +41,10 @@ unsafe impl<T> Send for WithPhantomDataSend<*const T, i8> {}
 //~^ ERROR
 //~| WARNING this will change its meaning
 
+pub struct WithLifetime<'a, T>(&'a (), T);
+unsafe impl<T> Send for WithLifetime<'static, T> {} // ok
+unsafe impl<T> Sync for WithLifetime<'static, Vec<T>> {}
+//~^ ERROR
+//~| WARNING this will change its meaning
+
 fn main() {}

--- a/src/test/ui/auto-traits/suspicious-impls-lint.stderr
+++ b/src/test/ui/auto-traits/suspicious-impls-lint.stderr
@@ -63,5 +63,20 @@ LL | pub struct WithPhantomDataSend<T, U>(PhantomData<T>, U);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: `*const T` is not a generic parameter
 
-error: aborting due to 4 previous errors
+error: cross-crate traits with a default impl, like `Sync`, should not be specialized
+  --> $DIR/suspicious-impls-lint.rs:46:1
+   |
+LL | unsafe impl<T> Sync for WithLifetime<'static, Vec<T>> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this will change its meaning in a future release!
+   = note: for more information, see issue #93367 <https://github.com/rust-lang/rust/issues/93367>
+note: try using the same sequence of generic parameters as the struct definition
+  --> $DIR/suspicious-impls-lint.rs:44:1
+   |
+LL | pub struct WithLifetime<'a, T>(&'a (), T);
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: `Vec<T>` is not a generic parameter
+
+error: aborting due to 5 previous errors
 


### PR DESCRIPTION
fixes the warning for https://github.com/rust-lang/rust/issues/93367#issuecomment-1063993489.