### PR TITLE
[beta] backports

### DIFF
--- a/compiler/rustc_builtin_macros/src/test.rs
+++ b/compiler/rustc_builtin_macros/src/test.rs
@@ -105,14 +105,18 @@ pub fn expand_test_or_bench(
 
     // Note: non-associated fn items are already handled by `expand_test_or_bench`
     if !matches!(item.kind, ast::ItemKind::Fn(_)) {
-        cx.sess
-            .parse_sess
-            .span_diagnostic
-            .struct_span_err(
-                attr_sp,
-                "the `#[test]` attribute may only be used on a non-associated function",
-            )
-            .note("the `#[test]` macro causes a a function to be run on a test and has no effect on non-functions")
+        let diag = &cx.sess.parse_sess.span_diagnostic;
+        let msg = "the `#[test]` attribute may only be used on a non-associated function";
+        let mut err = match item.kind {
+            // These were a warning before #92959 and need to continue being that to avoid breaking
+            // stable user code (#94508).
+            ast::ItemKind::MacCall(_) => diag.struct_span_warn(attr_sp, msg),
+            // `.forget_guarantee()` needed to get these two arms to match types. Because of how
+            // locally close the `.emit()` call is I'm comfortable with it, but if it can be
+            // reworked in the future to not need it, it'd be nice.
+            _ => diag.struct_span_err(attr_sp, msg).forget_guarantee(),
+        };
+        err.span_label(attr_sp, "the `#[test]` macro causes a a function to be run on a test and has no effect on non-functions")
             .span_label(item.span, format!("expected a non-associated function, found {} {}", item.kind.article(), item.kind.descr()))
             .span_suggestion(attr_sp, "replace with conditional compilation to make the item only exist when tests are being run", String::from("#[cfg(test)]"), Applicability::MaybeIncorrect)
             .emit();

--- a/compiler/rustc_builtin_macros/src/test.rs
+++ b/compiler/rustc_builtin_macros/src/test.rs
@@ -111,10 +111,7 @@ pub fn expand_test_or_bench(
             // These were a warning before #92959 and need to continue being that to avoid breaking
             // stable user code (#94508).
             ast::ItemKind::MacCall(_) => diag.struct_span_warn(attr_sp, msg),
-            // `.forget_guarantee()` needed to get these two arms to match types. Because of how
-            // locally close the `.emit()` call is I'm comfortable with it, but if it can be
-            // reworked in the future to not need it, it'd be nice.
-            _ => diag.struct_span_err(attr_sp, msg).forget_guarantee(),
+            _ => diag.struct_span_err(attr_sp, msg),
         };
         err.span_label(attr_sp, "the `#[test]` macro causes a a function to be run on a test and has no effect on non-functions")
             .span_label(item.span, format!("expected a non-associated function, found {} {}", item.kind.article(), item.kind.descr()))

--- a/compiler/rustc_codegen_llvm/src/llvm_util.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm_util.rs
@@ -475,8 +475,9 @@ pub(crate) fn should_use_new_llvm_pass_manager(user_opt: &Option<bool>, target_a
     // The new pass manager is enabled by default for LLVM >= 13.
     // This matches Clang, which also enables it since Clang 13.
 
-    // FIXME: There are some perf issues with the new pass manager
-    // when targeting s390x, so it is temporarily disabled for that
-    // arch, see https://github.com/rust-lang/rust/issues/89609
-    user_opt.unwrap_or_else(|| target_arch != "s390x" && llvm_util::get_version() >= (13, 0, 0))
+    // There are some perf issues with the new pass manager when targeting
+    // s390x with LLVM 13, so enable the new pass manager only with LLVM 14.
+    // See https://github.com/rust-lang/rust/issues/89609.
+    let min_version = if target_arch == "s390x" { 14 } else { 13 };
+    user_opt.unwrap_or_else(|| llvm_util::get_version() >= (min_version, 0, 0))
 }

--- a/compiler/rustc_typeck/src/check/demand.rs
+++ b/compiler/rustc_typeck/src/check/demand.rs
@@ -475,7 +475,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             _ => return None,
         };
 
-        let self_ty = self.typeck_results.borrow().node_type(method_expr[0].hir_id);
+        let self_ty = self.typeck_results.borrow().expr_ty(&method_expr[0]);
         let self_ty = format!("{:?}", self_ty);
         let name = method_path.ident.name;
         let is_as_ref_able = (self_ty.starts_with("&std::option::Option")

--- a/compiler/rustc_typeck/src/check/expr.rs
+++ b/compiler/rustc_typeck/src/check/expr.rs
@@ -1507,7 +1507,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 }
             } else {
                 self.check_expr_has_type_or_error(base_expr, adt_ty, |_| {
-                    let base_ty = self.typeck_results.borrow().node_type(base_expr.hir_id);
+                    let base_ty = self.typeck_results.borrow().expr_ty(*base_expr);
                     let same_adt = match (adt_ty.kind(), base_ty.kind()) {
                         (ty::Adt(adt, _), ty::Adt(base_adt, _)) if adt == base_adt => true,
                         _ => false,

--- a/compiler/rustc_typeck/src/check/fn_ctxt/_impl.rs
+++ b/compiler/rustc_typeck/src/check/fn_ctxt/_impl.rs
@@ -315,11 +315,14 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     }
                     // FIXME: currently we never try to compose autoderefs
                     // and ReifyFnPointer/UnsafeFnPointer, but we could.
-                    _ => bug!(
-                        "while adjusting {:?}, can't compose {:?} and {:?}",
-                        expr,
-                        entry.get(),
-                        adj
+                    _ => self.tcx.sess.delay_span_bug(
+                        expr.span,
+                        &format!(
+                            "while adjusting {:?}, can't compose {:?} and {:?}",
+                            expr,
+                            entry.get(),
+                            adj
+                        ),
                     ),
                 };
                 *entry.get_mut() = adj;

--- a/library/core/src/ops/control_flow.rs
+++ b/library/core/src/ops/control_flow.rs
@@ -134,7 +134,6 @@ impl<B, C> ControlFlow<B, C> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(control_flow_enum)]
     /// use std::ops::ControlFlow;
     ///
     /// assert!(ControlFlow::<i32, String>::Break(3).is_break());
@@ -151,7 +150,6 @@ impl<B, C> ControlFlow<B, C> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(control_flow_enum)]
     /// use std::ops::ControlFlow;
     ///
     /// assert!(!ControlFlow::<i32, String>::Break(3).is_continue());

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -26,7 +26,7 @@ use crate::run;
 use crate::test;
 use crate::tool::{self, SourceType};
 use crate::util::{self, add_dylib_path, add_link_lib_path, exe, libdir};
-use crate::{Build, DocTests, GitRepo, Mode};
+use crate::{Build, CLang, DocTests, GitRepo, Mode};
 
 pub use crate::Compiler;
 // FIXME: replace with std::lazy after it gets stabilized and reaches beta
@@ -1511,7 +1511,7 @@ impl<'a> Builder<'a> {
             let cc = ccacheify(&self.cc(target));
             cargo.env(format!("CC_{}", target.triple), &cc);
 
-            let cflags = self.cflags(target, GitRepo::Rustc).join(" ");
+            let cflags = self.cflags(target, GitRepo::Rustc, CLang::C).join(" ");
             cargo.env(format!("CFLAGS_{}", target.triple), &cflags);
 
             if let Some(ar) = self.ar(target) {
@@ -1523,9 +1523,10 @@ impl<'a> Builder<'a> {
 
             if let Ok(cxx) = self.cxx(target) {
                 let cxx = ccacheify(&cxx);
+                let cxxflags = self.cflags(target, GitRepo::Rustc, CLang::Cxx).join(" ");
                 cargo
                     .env(format!("CXX_{}", target.triple), &cxx)
-                    .env(format!("CXXFLAGS_{}", target.triple), cflags);
+                    .env(format!("CXXFLAGS_{}", target.triple), cxxflags);
             }
         }
 

--- a/src/bootstrap/cc_detect.rs
+++ b/src/bootstrap/cc_detect.rs
@@ -29,7 +29,7 @@ use std::{env, iter};
 use build_helper::output;
 
 use crate::config::{Target, TargetSelection};
-use crate::{Build, GitRepo};
+use crate::{Build, CLang, GitRepo};
 
 // The `cc` crate doesn't provide a way to obtain a path to the detected archiver,
 // so use some simplified logic here. First we respect the environment variable `AR`, then
@@ -109,7 +109,7 @@ pub fn find(build: &mut Build) {
         };
 
         build.cc.insert(target, compiler.clone());
-        let cflags = build.cflags(target, GitRepo::Rustc);
+        let cflags = build.cflags(target, GitRepo::Rustc, CLang::C);
 
         // If we use llvm-libunwind, we will need a C++ compiler as well for all targets
         // We'll need one anyways if the target triple is also a host triple
@@ -142,8 +142,9 @@ pub fn find(build: &mut Build) {
         build.verbose(&format!("CC_{} = {:?}", &target.triple, build.cc(target)));
         build.verbose(&format!("CFLAGS_{} = {:?}", &target.triple, cflags));
         if let Ok(cxx) = build.cxx(target) {
+            let cxxflags = build.cflags(target, GitRepo::Rustc, CLang::Cxx);
             build.verbose(&format!("CXX_{} = {:?}", &target.triple, cxx));
-            build.verbose(&format!("CXXFLAGS_{} = {:?}", &target.triple, cflags));
+            build.verbose(&format!("CXXFLAGS_{} = {:?}", &target.triple, cxxflags));
         }
         if let Some(ar) = ar {
             build.verbose(&format!("AR_{} = {:?}", &target.triple, ar));

--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -29,7 +29,7 @@ use crate::native;
 use crate::tool::SourceType;
 use crate::util::{exe, is_debug_info, is_dylib, symlink_dir};
 use crate::LLVM_TOOLS;
-use crate::{Compiler, DependencyType, GitRepo, Mode};
+use crate::{CLang, Compiler, DependencyType, GitRepo, Mode};
 
 #[derive(Debug, PartialOrd, Ord, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct Std {
@@ -250,7 +250,7 @@ fn copy_self_contained_objects(
         }
     } else if target.contains("windows-gnu") {
         for obj in ["crt2.o", "dllcrt2.o"].iter() {
-            let src = compiler_file(builder, builder.cc(target), target, obj);
+            let src = compiler_file(builder, builder.cc(target), target, CLang::C, obj);
             let target = libdir_self_contained.join(obj);
             builder.copy(&src, &target);
             target_deps.push((target, DependencyType::TargetSelfContained));
@@ -724,7 +724,13 @@ pub fn rustc_cargo_env(builder: &Builder<'_>, cargo: &mut Cargo, target: TargetS
             && !target.contains("msvc")
             && !target.contains("apple")
         {
-            let file = compiler_file(builder, builder.cxx(target).unwrap(), target, "libstdc++.a");
+            let file = compiler_file(
+                builder,
+                builder.cxx(target).unwrap(),
+                target,
+                CLang::Cxx,
+                "libstdc++.a",
+            );
             cargo.env("LLVM_STATIC_STDCPP", file);
         }
         if builder.config.llvm_link_shared {
@@ -945,10 +951,11 @@ pub fn compiler_file(
     builder: &Builder<'_>,
     compiler: &Path,
     target: TargetSelection,
+    c: CLang,
     file: &str,
 ) -> PathBuf {
     let mut cmd = Command::new(compiler);
-    cmd.args(builder.cflags(target, GitRepo::Rustc));
+    cmd.args(builder.cflags(target, GitRepo::Rustc, c));
     cmd.arg(format!("-print-file-name={}", file));
     let out = output(&mut cmd);
     PathBuf::from(out.trim())

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -338,6 +338,11 @@ impl Mode {
     }
 }
 
+pub enum CLang {
+    C,
+    Cxx,
+}
+
 impl Build {
     /// Creates a new set of build configuration from the `flags` on the command
     /// line and the filesystem `config`.
@@ -940,10 +945,15 @@ impl Build {
 
     /// Returns a list of flags to pass to the C compiler for the target
     /// specified.
-    fn cflags(&self, target: TargetSelection, which: GitRepo) -> Vec<String> {
+    fn cflags(&self, target: TargetSelection, which: GitRepo, c: CLang) -> Vec<String> {
+        let base = match c {
+            CLang::C => &self.cc[&target],
+            CLang::Cxx => &self.cxx[&target],
+        };
+
         // Filter out -O and /O (the optimization flags) that we picked up from
         // cc-rs because the build scripts will determine that for themselves.
-        let mut base = self.cc[&target]
+        let mut base = base
             .args()
             .iter()
             .map(|s| s.to_string_lossy().into_owned())

--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -21,7 +21,7 @@ use build_helper::{output, t};
 use crate::builder::{Builder, RunConfig, ShouldRun, Step};
 use crate::config::TargetSelection;
 use crate::util::{self, exe};
-use crate::GitRepo;
+use crate::{CLang, GitRepo};
 use build_helper::up_to_date;
 
 pub struct Meta {
@@ -517,7 +517,7 @@ fn configure_cmake(
     }
 
     cfg.build_arg("-j").build_arg(builder.jobs().to_string());
-    let mut cflags: OsString = builder.cflags(target, GitRepo::Llvm).join(" ").into();
+    let mut cflags: OsString = builder.cflags(target, GitRepo::Llvm, CLang::C).join(" ").into();
     if let Some(ref s) = builder.config.llvm_cflags {
         cflags.push(" ");
         cflags.push(s);
@@ -533,22 +533,14 @@ fn configure_cmake(
     if builder.config.llvm_clang_cl.is_some() {
         cflags.push(&format!(" --target={}", target));
     }
-    if let Some(flags) = env::var_os("CFLAGS") {
-        cflags.push(" ");
-        cflags.push(flags);
-    }
     cfg.define("CMAKE_C_FLAGS", cflags);
-    let mut cxxflags: OsString = builder.cflags(target, GitRepo::Llvm).join(" ").into();
+    let mut cxxflags: OsString = builder.cflags(target, GitRepo::Llvm, CLang::Cxx).join(" ").into();
     if let Some(ref s) = builder.config.llvm_cxxflags {
         cxxflags.push(" ");
         cxxflags.push(s);
     }
     if builder.config.llvm_clang_cl.is_some() {
         cxxflags.push(&format!(" --target={}", target));
-    }
-    if let Some(flags) = env::var_os("CXXFLAGS") {
-        cxxflags.push(" ");
-        cxxflags.push(flags);
     }
     cfg.define("CMAKE_CXX_FLAGS", cxxflags);
     if let Some(ar) = builder.ar(target) {
@@ -571,7 +563,7 @@ fn configure_cmake(
         ldflags.push_all(flags);
     }
 
-    if let Some(flags) = env::var_os("LDFLAGS") {
+    if let Some(flags) = get_var("LDFLAGS", &builder.config.build.triple, &target.triple) {
         ldflags.push_all(&flags);
     }
 
@@ -594,6 +586,16 @@ fn configure_cmake(
     if env::var_os("SCCACHE_ERROR_LOG").is_some() {
         cfg.env("RUSTC_LOG", "sccache=warn");
     }
+}
+
+// Adapted from https://github.com/alexcrichton/cc-rs/blob/fba7feded71ee4f63cfe885673ead6d7b4f2f454/src/lib.rs#L2347-L2365
+fn get_var(var_base: &str, host: &str, target: &str) -> Option<OsString> {
+    let kind = if host == target { "HOST" } else { "TARGET" };
+    let target_u = target.replace("-", "_");
+    env::var_os(&format!("{}_{}", var_base, target))
+        .or_else(|| env::var_os(&format!("{}_{}", var_base, target_u)))
+        .or_else(|| env::var_os(&format!("{}_{}", kind, var_base)))
+        .or_else(|| env::var_os(var_base))
 }
 
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]

--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -262,18 +262,6 @@ impl Step for Llvm {
             cfg.define("LLVM_LINK_LLVM_DYLIB", "ON");
         }
 
-        // For distribution we want the LLVM tools to be *statically* linked to libstdc++.
-        // We also do this if the user explicitly requested static libstdc++.
-        if builder.config.llvm_tools_enabled || builder.config.llvm_static_stdcpp {
-            if !target.contains("msvc") && !target.contains("netbsd") {
-                if target.contains("apple") {
-                    ldflags.push_all("-static-libstdc++");
-                } else {
-                    ldflags.push_all("-Wl,-Bsymbolic -static-libstdc++");
-                }
-            }
-        }
-
         if target.starts_with("riscv") && !target.contains("freebsd") {
             // RISC-V GCC erroneously requires linking against
             // `libatomic` when using 1-byte and 2-byte C++
@@ -585,6 +573,18 @@ fn configure_cmake(
 
     if let Some(flags) = env::var_os("LDFLAGS") {
         ldflags.push_all(&flags);
+    }
+
+    // For distribution we want the LLVM tools to be *statically* linked to libstdc++.
+    // We also do this if the user explicitly requested static libstdc++.
+    if builder.config.llvm_tools_enabled || builder.config.llvm_static_stdcpp {
+        if !target.contains("msvc") && !target.contains("netbsd") {
+            if target.contains("apple") {
+                ldflags.push_all("-static-libstdc++");
+            } else {
+                ldflags.push_all("-Wl,-Bsymbolic -static-libstdc++");
+            }
+        }
     }
 
     cfg.define("CMAKE_SHARED_LINKER_FLAGS", &ldflags.shared);

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -24,7 +24,7 @@ use crate::tool::{self, SourceType, Tool};
 use crate::toolstate::ToolState;
 use crate::util::{self, add_link_lib_path, dylib_path, dylib_path_var};
 use crate::Crate as CargoCrate;
-use crate::{envify, DocTests, GitRepo, Mode};
+use crate::{envify, CLang, DocTests, GitRepo, Mode};
 
 const ADB_TEST_DIR: &str = "/data/tmp/work";
 
@@ -1509,7 +1509,9 @@ note: if you're sure you want to do this, please open an issue as to why. In the
                 .arg("--cxx")
                 .arg(builder.cxx(target).unwrap())
                 .arg("--cflags")
-                .arg(builder.cflags(target, GitRepo::Rustc).join(" "));
+                .arg(builder.cflags(target, GitRepo::Rustc, CLang::C).join(" "))
+                .arg("--cxxflags")
+                .arg(builder.cflags(target, GitRepo::Rustc, CLang::Cxx).join(" "));
             copts_passed = true;
             if let Some(ar) = builder.ar(target) {
                 cmd.arg("--ar").arg(ar);
@@ -1520,7 +1522,14 @@ note: if you're sure you want to do this, please open an issue as to why. In the
             cmd.arg("--llvm-components").arg("");
         }
         if !copts_passed {
-            cmd.arg("--cc").arg("").arg("--cxx").arg("").arg("--cflags").arg("");
+            cmd.arg("--cc")
+                .arg("")
+                .arg("--cxx")
+                .arg("")
+                .arg("--cflags")
+                .arg("")
+                .arg("--cxxflags")
+                .arg("");
         }
 
         if builder.remote_tested(target) {

--- a/src/test/ui/issues/issue-23036.rs
+++ b/src/test/ui/issues/issue-23036.rs
@@ -1,5 +1,4 @@
 // run-pass
-// ignore-wasm32-bare FIXME(#93923) llvm miscompilation
 
 use std::collections::HashMap;
 use std::path::Path;

--- a/src/test/ui/mismatched_types/overloaded-calls-bad.rs
+++ b/src/test/ui/mismatched_types/overloaded-calls-bad.rs
@@ -30,5 +30,4 @@ fn main() {
     //~^ ERROR this function takes 1 argument but 0 arguments were supplied
     let ans = s("burma", "shave");
     //~^ ERROR this function takes 1 argument but 2 arguments were supplied
-    //~| ERROR mismatched types
 }

--- a/src/test/ui/mismatched_types/overloaded-calls-bad.stderr
+++ b/src/test/ui/mismatched_types/overloaded-calls-bad.stderr
@@ -18,12 +18,6 @@ note: associated function defined here
 LL |     extern "rust-call" fn call_mut(&mut self, args: Args) -> Self::Output;
    |                           ^^^^^^^^
 
-error[E0308]: mismatched types
-  --> $DIR/overloaded-calls-bad.rs:31:17
-   |
-LL |     let ans = s("burma", "shave");
-   |                 ^^^^^^^ expected `isize`, found `&str`
-
 error[E0057]: this function takes 1 argument but 2 arguments were supplied
   --> $DIR/overloaded-calls-bad.rs:31:15
    |
@@ -38,7 +32,7 @@ note: associated function defined here
 LL |     extern "rust-call" fn call_mut(&mut self, args: Args) -> Self::Output;
    |                           ^^^^^^^^
 
-error: aborting due to 4 previous errors
+error: aborting due to 3 previous errors
 
 Some errors have detailed explanations: E0057, E0308.
 For more information about an error, try `rustc --explain E0057`.

--- a/src/test/ui/test-attrs/test-on-not-fn.rs
+++ b/src/test/ui/test-attrs/test-on-not-fn.rs
@@ -58,7 +58,7 @@ macro_rules! foo {
     () => {};
 }
 
-#[test] //~ ERROR: the `#[test]` attribute may only be used on a non-associated function
+#[test] //~ WARN: the `#[test]` attribute may only be used on a non-associated function
 foo!();
 
 // make sure it doesn't erroneously trigger on a real test

--- a/src/test/ui/test-attrs/test-on-not-fn.stderr
+++ b/src/test/ui/test-attrs/test-on-not-fn.stderr
@@ -2,11 +2,10 @@ error: the `#[test]` attribute may only be used on a non-associated function
   --> $DIR/test-on-not-fn.rs:3:1
    |
 LL | #[test]
-   | ^^^^^^^
+   | ^^^^^^^ the `#[test]` macro causes a a function to be run on a test and has no effect on non-functions
 LL | mod test {}
    | ----------- expected a non-associated function, found a module
    |
-   = note: the `#[test]` macro causes a a function to be run on a test and has no effect on non-functions
 help: replace with conditional compilation to make the item only exist when tests are being run
    |
 LL | #[cfg(test)]
@@ -16,7 +15,7 @@ error: the `#[test]` attribute may only be used on a non-associated function
   --> $DIR/test-on-not-fn.rs:6:1
    |
 LL |   #[test]
-   |   ^^^^^^^
+   |   ^^^^^^^ the `#[test]` macro causes a a function to be run on a test and has no effect on non-functions
 LL | / mod loooooooooooooong_teeeeeeeeeest {
 LL | |     /*
 LL | |     this is a comment
@@ -26,7 +25,6 @@ LL | |     */
 LL | | }
    | |_- expected a non-associated function, found a module
    |
-   = note: the `#[test]` macro causes a a function to be run on a test and has no effect on non-functions
 help: replace with conditional compilation to make the item only exist when tests are being run
    |
 LL | #[cfg(test)]
@@ -36,11 +34,10 @@ error: the `#[test]` attribute may only be used on a non-associated function
   --> $DIR/test-on-not-fn.rs:20:1
    |
 LL | #[test]
-   | ^^^^^^^
+   | ^^^^^^^ the `#[test]` macro causes a a function to be run on a test and has no effect on non-functions
 LL | extern "C" {}
    | ------------- expected a non-associated function, found an extern block
    |
-   = note: the `#[test]` macro causes a a function to be run on a test and has no effect on non-functions
 help: replace with conditional compilation to make the item only exist when tests are being run
    |
 LL | #[cfg(test)]
@@ -50,11 +47,10 @@ error: the `#[test]` attribute may only be used on a non-associated function
   --> $DIR/test-on-not-fn.rs:23:1
    |
 LL | #[test]
-   | ^^^^^^^
+   | ^^^^^^^ the `#[test]` macro causes a a function to be run on a test and has no effect on non-functions
 LL | trait Foo {}
    | ------------ expected a non-associated function, found a trait
    |
-   = note: the `#[test]` macro causes a a function to be run on a test and has no effect on non-functions
 help: replace with conditional compilation to make the item only exist when tests are being run
    |
 LL | #[cfg(test)]
@@ -64,11 +60,10 @@ error: the `#[test]` attribute may only be used on a non-associated function
   --> $DIR/test-on-not-fn.rs:26:1
    |
 LL | #[test]
-   | ^^^^^^^
+   | ^^^^^^^ the `#[test]` macro causes a a function to be run on a test and has no effect on non-functions
 LL | impl Foo for i32 {}
    | ------------------- expected a non-associated function, found an implementation
    |
-   = note: the `#[test]` macro causes a a function to be run on a test and has no effect on non-functions
 help: replace with conditional compilation to make the item only exist when tests are being run
    |
 LL | #[cfg(test)]
@@ -78,11 +73,10 @@ error: the `#[test]` attribute may only be used on a non-associated function
   --> $DIR/test-on-not-fn.rs:29:1
    |
 LL | #[test]
-   | ^^^^^^^
+   | ^^^^^^^ the `#[test]` macro causes a a function to be run on a test and has no effect on non-functions
 LL | const FOO: i32 = -1_i32;
    | ------------------------ expected a non-associated function, found a constant item
    |
-   = note: the `#[test]` macro causes a a function to be run on a test and has no effect on non-functions
 help: replace with conditional compilation to make the item only exist when tests are being run
    |
 LL | #[cfg(test)]
@@ -92,11 +86,10 @@ error: the `#[test]` attribute may only be used on a non-associated function
   --> $DIR/test-on-not-fn.rs:32:1
    |
 LL | #[test]
-   | ^^^^^^^
+   | ^^^^^^^ the `#[test]` macro causes a a function to be run on a test and has no effect on non-functions
 LL | static BAR: u64 = 10_000_u64;
    | ----------------------------- expected a non-associated function, found a static item
    |
-   = note: the `#[test]` macro causes a a function to be run on a test and has no effect on non-functions
 help: replace with conditional compilation to make the item only exist when tests are being run
    |
 LL | #[cfg(test)]
@@ -106,13 +99,12 @@ error: the `#[test]` attribute may only be used on a non-associated function
   --> $DIR/test-on-not-fn.rs:35:1
    |
 LL |   #[test]
-   |   ^^^^^^^
+   |   ^^^^^^^ the `#[test]` macro causes a a function to be run on a test and has no effect on non-functions
 LL | / enum MyUnit {
 LL | |     Unit,
 LL | | }
    | |_- expected a non-associated function, found an enum
    |
-   = note: the `#[test]` macro causes a a function to be run on a test and has no effect on non-functions
 help: replace with conditional compilation to make the item only exist when tests are being run
    |
 LL | #[cfg(test)]
@@ -122,11 +114,10 @@ error: the `#[test]` attribute may only be used on a non-associated function
   --> $DIR/test-on-not-fn.rs:40:1
    |
 LL | #[test]
-   | ^^^^^^^
+   | ^^^^^^^ the `#[test]` macro causes a a function to be run on a test and has no effect on non-functions
 LL | struct NewI32(i32);
    | ------------------- expected a non-associated function, found a struct
    |
-   = note: the `#[test]` macro causes a a function to be run on a test and has no effect on non-functions
 help: replace with conditional compilation to make the item only exist when tests are being run
    |
 LL | #[cfg(test)]
@@ -136,14 +127,13 @@ error: the `#[test]` attribute may only be used on a non-associated function
   --> $DIR/test-on-not-fn.rs:43:1
    |
 LL |   #[test]
-   |   ^^^^^^^
+   |   ^^^^^^^ the `#[test]` macro causes a a function to be run on a test and has no effect on non-functions
 LL | / union Spooky {
 LL | |     x: i32,
 LL | |     y: u32,
 LL | | }
    | |_- expected a non-associated function, found a union
    |
-   = note: the `#[test]` macro causes a a function to be run on a test and has no effect on non-functions
 help: replace with conditional compilation to make the item only exist when tests are being run
    |
 LL | #[cfg(test)]
@@ -153,7 +143,7 @@ error: the `#[test]` attribute may only be used on a non-associated function
   --> $DIR/test-on-not-fn.rs:50:1
    |
 LL |   #[test]
-   |   ^^^^^^^
+   |   ^^^^^^^ the `#[test]` macro causes a a function to be run on a test and has no effect on non-functions
 LL |   #[derive(Copy, Clone, Debug)]
 LL | / struct MoreAttrs {
 LL | |     a: i32,
@@ -161,25 +151,23 @@ LL | |     b: u64,
 LL | | }
    | |_- expected a non-associated function, found a struct
    |
-   = note: the `#[test]` macro causes a a function to be run on a test and has no effect on non-functions
 help: replace with conditional compilation to make the item only exist when tests are being run
    |
 LL | #[cfg(test)]
    | ~~~~~~~~~~~~
 
-error: the `#[test]` attribute may only be used on a non-associated function
+warning: the `#[test]` attribute may only be used on a non-associated function
   --> $DIR/test-on-not-fn.rs:61:1
    |
 LL | #[test]
-   | ^^^^^^^
+   | ^^^^^^^ the `#[test]` macro causes a a function to be run on a test and has no effect on non-functions
 LL | foo!();
    | ------- expected a non-associated function, found an item macro invocation
    |
-   = note: the `#[test]` macro causes a a function to be run on a test and has no effect on non-functions
 help: replace with conditional compilation to make the item only exist when tests are being run
    |
 LL | #[cfg(test)]
    | ~~~~~~~~~~~~
 
-error: aborting due to 12 previous errors
+error: aborting due to 11 previous errors; 1 warning emitted
 

--- a/src/test/ui/tuple/wrong_argument_ice-2.rs
+++ b/src/test/ui/tuple/wrong_argument_ice-2.rs
@@ -1,0 +1,17 @@
+fn test(t: (i32, i32)) {}
+
+struct Foo;
+
+impl Foo {
+    fn qux(&self) -> i32 {
+        0
+    }
+}
+
+fn bar() {
+    let x = Foo;
+    test(x.qux(), x.qux());
+    //~^ ERROR this function takes 1 argument but 2 arguments were supplied
+}
+
+fn main() {}

--- a/src/test/ui/tuple/wrong_argument_ice-2.stderr
+++ b/src/test/ui/tuple/wrong_argument_ice-2.stderr
@@ -1,0 +1,19 @@
+error[E0061]: this function takes 1 argument but 2 arguments were supplied
+  --> $DIR/wrong_argument_ice-2.rs:13:5
+   |
+LL |     test(x.qux(), x.qux());
+   |     ^^^^ -------  ------- supplied 2 arguments
+   |
+note: function defined here
+  --> $DIR/wrong_argument_ice-2.rs:1:4
+   |
+LL | fn test(t: (i32, i32)) {}
+   |    ^^^^ -------------
+help: use parentheses to construct a tuple
+   |
+LL |     test((x.qux(), x.qux()));
+   |          +                +
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0061`.

--- a/src/test/ui/tuple/wrong_argument_ice-3.rs
+++ b/src/test/ui/tuple/wrong_argument_ice-3.rs
@@ -1,0 +1,17 @@
+struct Process;
+
+pub type Group = (Vec<String>, Vec<Process>);
+
+fn test(process: &Process, groups: Vec<Group>) -> Vec<Group> {
+    let new_group = vec![String::new()];
+
+    if groups.capacity() == 0 {
+        groups.push(new_group, vec![process]);
+        //~^ ERROR this function takes 1 argument but 2 arguments were supplied
+        return groups;
+    }
+
+    todo!()
+}
+
+fn main() {}

--- a/src/test/ui/tuple/wrong_argument_ice-3.stderr
+++ b/src/test/ui/tuple/wrong_argument_ice-3.stderr
@@ -1,0 +1,17 @@
+error[E0061]: this function takes 1 argument but 2 arguments were supplied
+  --> $DIR/wrong_argument_ice-3.rs:9:16
+   |
+LL |         groups.push(new_group, vec![process]);
+   |                ^^^^ ---------  ------------- supplied 2 arguments
+   |                |
+   |                expected 1 argument
+   |
+note: associated function defined here
+  --> $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
+   |
+LL |     pub fn push(&mut self, value: T) {
+   |            ^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0061`.

--- a/src/tools/compiletest/src/common.rs
+++ b/src/tools/compiletest/src/common.rs
@@ -357,6 +357,7 @@ pub struct Config {
     pub cc: String,
     pub cxx: String,
     pub cflags: String,
+    pub cxxflags: String,
     pub ar: String,
     pub linker: Option<String>,
     pub llvm_components: String,

--- a/src/tools/compiletest/src/header/tests.rs
+++ b/src/tools/compiletest/src/header/tests.rs
@@ -52,6 +52,7 @@ fn config() -> Config {
         "--cc=c",
         "--cxx=c++",
         "--cflags=",
+        "--cxxflags=",
         "--llvm-components=",
         "--android-cross-path=",
         "--target=x86_64-unknown-linux-gnu",

--- a/src/tools/compiletest/src/main.rs
+++ b/src/tools/compiletest/src/main.rs
@@ -126,6 +126,7 @@ pub fn parse_config(args: Vec<String>) -> Config {
         .reqopt("", "cc", "path to a C compiler", "PATH")
         .reqopt("", "cxx", "path to a C++ compiler", "PATH")
         .reqopt("", "cflags", "flags for the C compiler", "FLAGS")
+        .reqopt("", "cxxflags", "flags for the CXX compiler", "FLAGS")
         .optopt("", "ar", "path to an archiver", "PATH")
         .optopt("", "linker", "path to a linker", "PATH")
         .reqopt("", "llvm-components", "list of LLVM components built in", "LIST")
@@ -288,6 +289,7 @@ pub fn parse_config(args: Vec<String>) -> Config {
         cc: matches.opt_str("cc").unwrap(),
         cxx: matches.opt_str("cxx").unwrap(),
         cflags: matches.opt_str("cflags").unwrap(),
+        cxxflags: matches.opt_str("cxxflags").unwrap(),
         ar: matches.opt_str("ar").unwrap_or_else(|| String::from("ar")),
         linker: matches.opt_str("linker"),
         llvm_components: matches.opt_str("llvm-components").unwrap(),

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -2919,15 +2919,22 @@ impl<'test> TestCx<'test> {
                 .map(|s| s.replace("/", "-"))
                 .collect::<Vec<_>>()
                 .join(" ");
+            let cxxflags = self
+                .config
+                .cxxflags
+                .split(' ')
+                .map(|s| s.replace("/", "-"))
+                .collect::<Vec<_>>()
+                .join(" ");
 
             cmd.env("IS_MSVC", "1")
                 .env("IS_WINDOWS", "1")
                 .env("MSVC_LIB", format!("'{}' -nologo", lib.display()))
                 .env("CC", format!("'{}' {}", self.config.cc, cflags))
-                .env("CXX", format!("'{}'", &self.config.cxx));
+                .env("CXX", format!("'{}' {}", &self.config.cxx, cxxflags));
         } else {
             cmd.env("CC", format!("{} {}", self.config.cc, self.config.cflags))
-                .env("CXX", format!("{} {}", self.config.cxx, self.config.cflags))
+                .env("CXX", format!("{} {}", self.config.cxx, self.config.cxxflags))
                 .env("AR", &self.config.ar);
 
             if self.config.target.contains("windows") {


### PR DESCRIPTION
* Update LLVM submodule #94764 
* Statically compile libstdc++ everywhere if asked #94719 
* Downgrade #[test] on macro call to warning #94624 
* Delay bug in expr adjustment when check_expr is called multiple times #94596
* bootstrap: correct reading of flags for llvm #94466 
* Check method input expressions once #94438 
* remove feature gate in control_flow examples #94283 

r? @Mark-Simulacrum 