### PR TITLE
Don't allocate trailing uninit bits in the `InitMap` of CTFE `Allocation`s

### DIFF
--- a/src/test/ui-fulldeps/uninit_mask.rs
+++ b/src/test/ui-fulldeps/uninit_mask.rs
@@ -11,7 +11,7 @@ use rustc_middle::mir::interpret::InitMask;
 use rustc_target::abi::Size;
 
 fn main() {
-    let mut mask = InitMask::new(Size::from_bytes(500), false);
+    let mut mask = InitMask::new_uninit(Size::from_bytes(500));
     assert!(!mask.get(Size::from_bytes(499)));
     mask.set(Size::from_bytes(499), true);
     assert!(mask.get(Size::from_bytes(499)));


### PR DESCRIPTION
This is part of a set of similar refactorings for Allocation, but I want to benchmark all parts on their own.

This PR changes the InitMask to only allocate up to the first initialized byte. Everything beyond the allocates space is considered uninitialized. Reading from it or defining it as uninitialized will not allocate.