### PR TITLE
Do not cache ParamEnv candidates globally

### DIFF
--- a/src/test/ui/higher-rank-trait-bounds/normalize-under-binder/issue-80706.rs
+++ b/src/test/ui/higher-rank-trait-bounds/normalize-under-binder/issue-80706.rs
@@ -1,4 +1,4 @@
-// check-pass
+// build-pass
 // edition:2018
 
 type BoxFuture<T> = std::pin::Pin<Box<dyn std::future::Future<Output=T>>>;


### PR DESCRIPTION
Fixes #94903

The issue here is that we're _globally_ caching a trait selection result we get from the ParamEnv, specifically `TraitPredicate(<SaveUser<ReErased> as StorageRequestReturnType>, polarity:Positive)`. Not sure where that erased bound comes from.

Not sure how to trigger this with a more structured test, but changing `check-pass` to `build-pass` triggers the case that #94903 detected.