### PR TITLE
Extend the irrefutable_let_patterns lint to let chains

### DIFF
--- a/src/test/ui/mir/mir_let_chains_drop_order.rs
+++ b/src/test/ui/mir/mir_let_chains_drop_order.rs
@@ -5,6 +5,7 @@
 // See `mir_drop_order.rs` for more information
 
 #![feature(let_chains)]
+#![allow(irrefutable_let_patterns)]
 
 use std::cell::RefCell;
 use std::panic;

--- a/src/test/ui/rfc-2497-if-let-chains/ast-lowering-does-not-wrap-let-chains.rs
+++ b/src/test/ui/rfc-2497-if-let-chains/ast-lowering-does-not-wrap-let-chains.rs
@@ -1,6 +1,7 @@
 // run-pass
 
 #![feature(let_chains)]
+#![allow(irrefutable_let_patterns)]
 
 fn main() {
     let first = Some(1);

--- a/src/test/ui/rfc-2497-if-let-chains/irrefutable-lets.disallowed.stderr
+++ b/src/test/ui/rfc-2497-if-let-chains/irrefutable-lets.disallowed.stderr
@@ -1,0 +1,115 @@
+error: leading irrefutable pattern in let chain
+  --> $DIR/irrefutable-lets.rs:13:8
+   |
+LL |     if let first = &opt && let Some(ref second) = first && let None = second.start {}
+   |        ^^^^^^^^^^^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/irrefutable-lets.rs:6:30
+   |
+LL | #![cfg_attr(disallowed, deny(irrefutable_let_patterns))]
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: this pattern will always match
+   = help: consider moving it outside of the construct
+
+error: irrefutable `if let` patterns
+  --> $DIR/irrefutable-lets.rs:19:8
+   |
+LL |     if let first = &opt && let (a, b) = (1, 2) {}
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: these patterns will always match, so the `if let` is useless
+   = help: consider replacing the `if let` with a `let`
+
+error: leading irrefutable pattern in let chain
+  --> $DIR/irrefutable-lets.rs:22:8
+   |
+LL |     if let first = &opt && let Some(ref second) = first && let None = second.start && let v = 0 {}
+   |        ^^^^^^^^^^^^^^^^
+   |
+   = note: this pattern will always match
+   = help: consider moving it outside of the construct
+
+error: trailing irrefutable pattern in let chain
+  --> $DIR/irrefutable-lets.rs:22:87
+   |
+LL |     if let first = &opt && let Some(ref second) = first && let None = second.start && let v = 0 {}
+   |                                                                                       ^^^^^^^^^
+   |
+   = note: this pattern will always match
+   = help: consider moving it into the body
+
+error: trailing irrefutable patterns in let chain
+  --> $DIR/irrefutable-lets.rs:26:37
+   |
+LL |     if let Some(ref first) = opt && let second = first && let _third = second {}
+   |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: these patterns will always match
+   = help: consider moving them into the body
+
+error: leading irrefutable pattern in let chain
+  --> $DIR/irrefutable-lets.rs:29:8
+   |
+LL |     if let Range { start: local_start, end: _ } = (None..Some(1)) && let None = local_start {}
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this pattern will always match
+   = help: consider moving it outside of the construct
+
+error: leading irrefutable pattern in let chain
+  --> $DIR/irrefutable-lets.rs:32:8
+   |
+LL |     if let (a, b, c) = (Some(1), Some(1), Some(1)) && let None = Some(1) {}
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this pattern will always match
+   = help: consider moving it outside of the construct
+
+error: leading irrefutable pattern in let chain
+  --> $DIR/irrefutable-lets.rs:35:8
+   |
+LL |     if let first = &opt && let None = Some(1) {}
+   |        ^^^^^^^^^^^^^^^^
+   |
+   = note: this pattern will always match
+   = help: consider moving it outside of the construct
+
+error: irrefutable `let` patterns
+  --> $DIR/irrefutable-lets.rs:44:28
+   |
+LL |         Some(ref first) if let second = first && let _third = second && let v = 4 + 4 => {},
+   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: these patterns will always match, so the `let` is useless
+   = help: consider removing `let`
+
+error: leading irrefutable pattern in let chain
+  --> $DIR/irrefutable-lets.rs:50:28
+   |
+LL |         Some(ref first) if let Range { start: local_start, end: _ } = first
+   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this pattern will always match
+   = help: consider moving it outside of the construct
+
+error: irrefutable `while let` patterns
+  --> $DIR/irrefutable-lets.rs:59:11
+   |
+LL |     while let first = &opt && let (a, b) = (1, 2) {}
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: these patterns will always match, so the loop will never exit
+   = help: consider instead using a `loop { ... }` with a `let` inside it
+
+error: trailing irrefutable patterns in let chain
+  --> $DIR/irrefutable-lets.rs:62:40
+   |
+LL |     while let Some(ref first) = opt && let second = first && let _third = second {}
+   |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: these patterns will always match
+   = help: consider moving them into the body
+
+error: aborting due to 12 previous errors
+

--- a/src/test/ui/rfc-2497-if-let-chains/irrefutable-lets.rs
+++ b/src/test/ui/rfc-2497-if-let-chains/irrefutable-lets.rs
@@ -1,35 +1,67 @@
-// check-pass
+// revisions: allowed disallowed
+//[allowed] check-pass
 
 #![feature(if_let_guard, let_chains)]
+#![cfg_attr(allowed, allow(irrefutable_let_patterns))]
+#![cfg_attr(disallowed, deny(irrefutable_let_patterns))]
 
 use std::ops::Range;
 
 fn main() {
     let opt = Some(None..Some(1));
 
-    if let first = &opt && let Some(ref second) = first && let None = second.start {
-    }
-    if let Some(ref first) = opt && let second = first && let _third = second {
-    }
+    if let first = &opt && let Some(ref second) = first && let None = second.start {}
+    //[disallowed]~^ ERROR leading irrefutable pattern in let chain
+
+    // No lint as the irrefutable pattern is surrounded by other stuff
+    if 4 * 2 == 0 && let first = &opt && let Some(ref second) = first && let None = second.start {}
+
+    if let first = &opt && let (a, b) = (1, 2) {}
+    //[disallowed]~^ ERROR irrefutable `if let` patterns
+
+    if let first = &opt && let Some(ref second) = first && let None = second.start && let v = 0 {}
+    //[disallowed]~^ ERROR leading irrefutable pattern in let chain
+    //[disallowed]~^^ ERROR trailing irrefutable pattern in let chain
+
+    if let Some(ref first) = opt && let second = first && let _third = second {}
+    //[disallowed]~^ ERROR trailing irrefutable patterns in let chain
+
+    if let Range { start: local_start, end: _ } = (None..Some(1)) && let None = local_start {}
+    //[disallowed]~^ ERROR leading irrefutable pattern in let chain
+
+    if let (a, b, c) = (Some(1), Some(1), Some(1)) && let None = Some(1) {}
+    //[disallowed]~^ ERROR leading irrefutable pattern in let chain
+
+    if let first = &opt && let None = Some(1) {}
+    //[disallowed]~^ ERROR leading irrefutable pattern in let chain
+
     if let Some(ref first) = opt
         && let Range { start: local_start, end: _ } = first
         && let None = local_start {
     }
 
     match opt {
-        Some(ref first) if let second = first && let _third = second => {},
+        Some(ref first) if let second = first && let _third = second && let v = 4 + 4 => {},
+        //[disallowed]~^ ERROR irrefutable `let` patterns
         _ => {}
     }
+
     match opt {
         Some(ref first) if let Range { start: local_start, end: _ } = first
+        //[disallowed]~^ ERROR leading irrefutable pattern in let chain
             && let None = local_start => {},
         _ => {}
     }
 
-    while let first = &opt && let Some(ref second) = first && let None = second.start {
-    }
-    while let Some(ref first) = opt && let second = first && let _third = second {
-    }
+    // No error, despite the prefix being irrefutable
+    while let first = &opt && let Some(ref second) = first && let None = second.start {}
+
+    while let first = &opt && let (a, b) = (1, 2) {}
+    //[disallowed]~^ ERROR irrefutable `while let` patterns
+
+    while let Some(ref first) = opt && let second = first && let _third = second {}
+    //[disallowed]~^ ERROR trailing irrefutable patterns in let chain
+
     while let Some(ref first) = opt
         && let Range { start: local_start, end: _ } = first
         && let None = local_start {


### PR DESCRIPTION
Implements the suggestion from https://github.com/rust-lang/rust/pull/94927#issuecomment-1067078300

We only look for complete suffixes or prefixes of irrefutable let patterns, so
that an irrefutable let pattern in a chain surrounded by refutable ones is
not linted, as it is an useful pattern that has no low-cost replacement (unlike suffixes or prefixes which can just be moved outside of the `if`: either into the `if`'s block, or the block surrounding the `if`).
If all patterns in a let chain are irrefutable, we lint as well.

Depends on #94958 ~~so I included it into the PR for now~~ *which has been merged since*. 

r? @estebank 

cc @joshtriplett @c410-f3r