### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/compiler/rustc_codegen_ssa/src/debuginfo/type_names.rs
+++ b/compiler/rustc_codegen_ssa/src/debuginfo/type_names.rs
@@ -212,13 +212,18 @@ fn push_debuginfo_type_name<'tcx>(
                 if projection_bounds.len() != 0 {
                     if principal_has_generic_params {
                         // push_generic_params_internal() above added a `>` but we actually
-                        // want to add more items to that list, so remove that again.
+                        // want to add more items to that list, so remove that again...
                         pop_close_angle_bracket(output);
+                        // .. and add a comma to separate the regular generic args from the
+                        // associated types.
+                        push_arg_separator(cpp_like_debuginfo, output);
+                    } else {
+                        // push_generic_params_internal() did not add `<...>`, so we open
+                        // angle brackets here.
+                        output.push('<');
                     }
 
                     for (item_def_id, ty) in projection_bounds {
-                        push_arg_separator(cpp_like_debuginfo, output);
-
                         if cpp_like_debuginfo {
                             output.push_str("assoc$<");
                             push_item_name(tcx, item_def_id, false, output);
@@ -230,8 +235,10 @@ fn push_debuginfo_type_name<'tcx>(
                             output.push('=');
                             push_debuginfo_type_name(tcx, ty, true, output, visited);
                         }
+                        push_arg_separator(cpp_like_debuginfo, output);
                     }
 
+                    pop_arg_separator(output);
                     push_close_angle_bracket(cpp_like_debuginfo, output);
                 }
 

--- a/compiler/rustc_index/src/bit_set.rs
+++ b/compiler/rustc_index/src/bit_set.rs
@@ -656,7 +656,7 @@ impl<T: Idx> BitRelations<HybridBitSet<T>> for ChunkedBitSet<T> {
     fn union(&mut self, other: &HybridBitSet<T>) -> bool {
         // FIXME: This is slow if `other` is dense, but it hasn't been a problem
         // in practice so far.
-        // If a a faster implementation of this operation is required, consider
+        // If a faster implementation of this operation is required, consider
         // reopening https://github.com/rust-lang/rust/pull/94625
         assert_eq!(self.domain_size, other.domain_size());
         sequential_update(|elem| self.insert(elem), other.iter())
@@ -665,7 +665,7 @@ impl<T: Idx> BitRelations<HybridBitSet<T>> for ChunkedBitSet<T> {
     fn subtract(&mut self, other: &HybridBitSet<T>) -> bool {
         // FIXME: This is slow if `other` is dense, but it hasn't been a problem
         // in practice so far.
-        // If a a faster implementation of this operation is required, consider
+        // If a faster implementation of this operation is required, consider
         // reopening https://github.com/rust-lang/rust/pull/94625
         assert_eq!(self.domain_size, other.domain_size());
         sequential_update(|elem| self.remove(elem), other.iter())

--- a/compiler/rustc_lint/src/builtin.rs
+++ b/compiler/rustc_lint/src/builtin.rs
@@ -328,7 +328,7 @@ impl UnsafeCode {
         cx.struct_span_lint(UNSAFE_CODE, span, decorate);
     }
 
-    fn report_overriden_symbol_name(&self, cx: &EarlyContext<'_>, span: Span, msg: &str) {
+    fn report_overridden_symbol_name(&self, cx: &EarlyContext<'_>, span: Span, msg: &str) {
         self.report_unsafe(cx, span, |lint| {
             lint.build(msg)
                 .note(
@@ -380,14 +380,14 @@ impl EarlyLintPass for UnsafeCode {
 
             ast::ItemKind::Fn(..) => {
                 if let Some(attr) = cx.sess().find_by_name(&it.attrs, sym::no_mangle) {
-                    self.report_overriden_symbol_name(
+                    self.report_overridden_symbol_name(
                         cx,
                         attr.span,
                         "declaration of a `no_mangle` function",
                     );
                 }
                 if let Some(attr) = cx.sess().find_by_name(&it.attrs, sym::export_name) {
-                    self.report_overriden_symbol_name(
+                    self.report_overridden_symbol_name(
                         cx,
                         attr.span,
                         "declaration of a function with `export_name`",
@@ -397,14 +397,14 @@ impl EarlyLintPass for UnsafeCode {
 
             ast::ItemKind::Static(..) => {
                 if let Some(attr) = cx.sess().find_by_name(&it.attrs, sym::no_mangle) {
-                    self.report_overriden_symbol_name(
+                    self.report_overridden_symbol_name(
                         cx,
                         attr.span,
                         "declaration of a `no_mangle` static",
                     );
                 }
                 if let Some(attr) = cx.sess().find_by_name(&it.attrs, sym::export_name) {
-                    self.report_overriden_symbol_name(
+                    self.report_overridden_symbol_name(
                         cx,
                         attr.span,
                         "declaration of a static with `export_name`",
@@ -419,14 +419,14 @@ impl EarlyLintPass for UnsafeCode {
     fn check_impl_item(&mut self, cx: &EarlyContext<'_>, it: &ast::AssocItem) {
         if let ast::AssocItemKind::Fn(..) = it.kind {
             if let Some(attr) = cx.sess().find_by_name(&it.attrs, sym::no_mangle) {
-                self.report_overriden_symbol_name(
+                self.report_overridden_symbol_name(
                     cx,
                     attr.span,
                     "declaration of a `no_mangle` method",
                 );
             }
             if let Some(attr) = cx.sess().find_by_name(&it.attrs, sym::export_name) {
-                self.report_overriden_symbol_name(
+                self.report_overridden_symbol_name(
                     cx,
                     attr.span,
                     "declaration of a method with `export_name`",

--- a/compiler/rustc_lint/src/levels.rs
+++ b/compiler/rustc_lint/src/levels.rs
@@ -116,7 +116,7 @@ impl<'s> LintLevelsBuilder<'s> {
                 continue
             };
             for id in ids {
-                // ForceWarn and Forbid cannot be overriden
+                // ForceWarn and Forbid cannot be overridden
                 if let Some((Level::ForceWarn | Level::Forbid, _)) = self.current_specs().get(&id) {
                     continue;
                 }
@@ -137,7 +137,7 @@ impl<'s> LintLevelsBuilder<'s> {
             self.sets.get_lint_level(id.lint, self.cur, Some(self.current_specs()), &self.sess);
         // Setting to a non-forbid level is an error if the lint previously had
         // a forbid level. Note that this is not necessarily true even with a
-        // `#[forbid(..)]` attribute present, as that is overriden by `--cap-lints`.
+        // `#[forbid(..)]` attribute present, as that is overridden by `--cap-lints`.
         //
         // This means that this only errors if we're truly lowering the lint
         // level from forbid.

--- a/compiler/rustc_lint_defs/src/lib.rs
+++ b/compiler/rustc_lint_defs/src/lib.rs
@@ -20,6 +20,12 @@ macro_rules! pluralize {
     ($x:expr) => {
         if $x != 1 { "s" } else { "" }
     };
+    ("is", $x:expr) => {
+        if $x == 1 { "is" } else { "are" }
+    };
+    ("this", $x:expr) => {
+        if $x == 1 { "this" } else { "these" }
+    };
 }
 
 /// Indicates the confidence in the correctness of a suggestion.

--- a/compiler/rustc_middle/src/mir/generic_graph.rs
+++ b/compiler/rustc_middle/src/mir/generic_graph.rs
@@ -50,7 +50,7 @@ fn bb_to_graph_node(block: BasicBlock, body: &Body<'_>, dark_mode: bool) -> Node
     let style = NodeStyle { title_bg: Some(bgcolor.to_owned()), ..Default::default() };
     let mut stmts: Vec<String> = data.statements.iter().map(|x| format!("{:?}", x)).collect();
 
-    // add the terminator to the stmts, gsgdt can print it out seperately
+    // add the terminator to the stmts, gsgdt can print it out separately
     let mut terminator_head = String::new();
     data.terminator().kind.fmt_head(&mut terminator_head).unwrap();
     stmts.push(terminator_head);

--- a/compiler/rustc_middle/src/mir/interpret/error.rs
+++ b/compiler/rustc_middle/src/mir/interpret/error.rs
@@ -400,7 +400,7 @@ impl fmt::Display for UndefinedBehaviorInfo<'_> {
                 Pointer::new(*alloc, access.access_offset),
                 access.uninit_size.bytes(),
                 pluralize!(access.uninit_size.bytes()),
-                if access.uninit_size.bytes() != 1 { "are" } else { "is" },
+                pluralize!("is", access.uninit_size.bytes()),
                 Pointer::new(*alloc, access.uninit_offset),
             ),
             InvalidUninitBytes(None) => write!(

--- a/compiler/rustc_middle/src/mir/query.rs
+++ b/compiler/rustc_middle/src/mir/query.rs
@@ -250,7 +250,7 @@ pub struct BorrowCheckResult<'tcx> {
 
 /// The result of the `mir_const_qualif` query.
 ///
-/// Each field (except `error_occured`) corresponds to an implementer of the `Qualif` trait in
+/// Each field (except `error_occurred`) corresponds to an implementer of the `Qualif` trait in
 /// `rustc_const_eval/src/transform/check_consts/qualifs.rs`. See that file for more information on each
 /// `Qualif`.
 #[derive(Clone, Copy, Debug, Default, TyEncodable, TyDecodable, HashStable)]

--- a/compiler/rustc_middle/src/ty/error.rs
+++ b/compiler/rustc_middle/src/ty/error.rs
@@ -847,7 +847,7 @@ fn foo(&self) -> Self::T { String::new() }
                 "{some} method{s} {are} available that return{r} `{ty}`",
                 some = if methods.len() == 1 { "a" } else { "some" },
                 s = pluralize!(methods.len()),
-                are = if methods.len() == 1 { "is" } else { "are" },
+                are = pluralize!("is", methods.len()),
                 r = if methods.len() == 1 { "s" } else { "" },
                 ty = expected
             );

--- a/compiler/rustc_mir_build/src/check_unsafety.rs
+++ b/compiler/rustc_mir_build/src/check_unsafety.rs
@@ -608,7 +608,7 @@ pub fn check_unsafety<'tcx>(tcx: TyCtxt<'tcx>, def: ty::WithOptConstParam<LocalD
 
     let (thir, expr) = tcx.thir_body(def);
     let thir = &thir.borrow();
-    // If `thir` is empty, a type error occured, skip this body.
+    // If `thir` is empty, a type error occurred, skip this body.
     if thir.exprs.is_empty() {
         return;
     }

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -1410,7 +1410,7 @@ impl CheckAttrVisitor<'_> {
                             span,
                             format!(
                                 "there {} only {} argument{}",
-                                if arg_count != 1 { "are" } else { "is" },
+                                pluralize!("is", arg_count),
                                 arg_count,
                                 pluralize!(arg_count)
                             ),

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -504,9 +504,9 @@ impl<'a: 'ast, 'ast> LateResolutionVisitor<'a, '_, 'ast> {
                     for sp in spans {
                         let msg = if sp == last_bound_span {
                             format!(
-                                "...because of {} bound{}",
-                                if bounds.len() <= 2 { "this" } else { "these" },
-                                if bounds.len() <= 2 { "" } else { "s" },
+                                "...because of {these} bound{s}",
+                                these = pluralize!("this", bounds.len() - 1),
+                                s = pluralize!(bounds.len() - 1),
                             )
                         } else {
                             String::new()

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -394,7 +394,7 @@ mod desc {
     pub const parse_linker_plugin_lto: &str =
         "either a boolean (`yes`, `no`, `on`, `off`, etc), or the path to the linker plugin";
     pub const parse_location_detail: &str =
-        "comma seperated list of location details to track: `file`, `line`, or `column`";
+        "comma separated list of location details to track: `file`, `line`, or `column`";
     pub const parse_switch_with_opt_path: &str =
         "an optional path to the profiling data output directory";
     pub const parse_merge_functions: &str = "one of: `disabled`, `trampolines`, or `aliases`";
@@ -1283,7 +1283,7 @@ options! {
     llvm_time_trace: bool = (false, parse_bool, [UNTRACKED],
         "generate JSON tracing data file from LLVM data (default: no)"),
     location_detail: LocationDetail = (LocationDetail::all(), parse_location_detail, [TRACKED],
-        "comma seperated list of location details to be tracked when using caller_location \
+        "comma separated list of location details to be tracked when using caller_location \
         valid options are `file`, `line`, and `column` (default: all)"),
     ls: bool = (false, parse_bool, [UNTRACKED],
         "list the symbols defined by a library crate (default: no)"),

--- a/compiler/rustc_session/src/parse.rs
+++ b/compiler/rustc_session/src/parse.rs
@@ -69,7 +69,7 @@ pub struct SymbolGallery {
 
 impl SymbolGallery {
     /// Insert a symbol and its span into symbol gallery.
-    /// If the symbol has occurred before, ignore the new occurance.
+    /// If the symbol has occurred before, ignore the new occurrance.
     pub fn insert(&self, symbol: Symbol, span: Span) {
         self.symbols.lock().entry(symbol).or_insert(span);
     }

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
@@ -369,7 +369,7 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                                         (true, Some(None)) => {
                                             Some(format!("{cannot_do_this} in const contexts"))
                                         }
-                                        // overriden post message
+                                        // overridden post message
                                         (true, Some(Some(post_message))) => {
                                             Some(format!("{cannot_do_this}{post_message}"))
                                         }

--- a/compiler/rustc_typeck/src/check/pat.rs
+++ b/compiler/rustc_typeck/src/check/pat.rs
@@ -1761,7 +1761,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             sp,
             &format!(
                 "include the missing field{} in the pattern{}",
-                if len == 1 { "" } else { "s" },
+                pluralize!(len),
                 if have_inaccessible_fields { " and ignore the inaccessible fields" } else { "" }
             ),
             format!(
@@ -1780,10 +1780,10 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         err.span_suggestion(
             sp,
             &format!(
-                "if you don't care about {} missing field{}, you can explicitly ignore {}",
-                if len == 1 { "this" } else { "these" },
-                if len == 1 { "" } else { "s" },
-                if len == 1 { "it" } else { "them" },
+                "if you don't care about {these} missing field{s}, you can explicitly ignore {them}",
+                these = pluralize!("this", len),
+                s = pluralize!(len),
+                them = if len == 1 { "it" } else { "them" },
             ),
             format!("{}..{}", prefix, postfix),
             Applicability::MachineApplicable,

--- a/compiler/rustc_typeck/src/coherence/inherent_impls.rs
+++ b/compiler/rustc_typeck/src/coherence/inherent_impls.rs
@@ -7,7 +7,7 @@
 //! `tcx.inherent_impls(def_id)`). That value, however,
 //! is computed by selecting an idea from this table.
 
-use rustc_errors::struct_span_err;
+use rustc_errors::{pluralize, struct_span_err};
 use rustc_hir as hir;
 use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_hir::itemlikevisit::ItemLikeVisitor;
@@ -410,7 +410,6 @@ impl<'tcx> InherentCollect<'tcx> {
                 let to_implement = if assoc_items.is_empty() {
                     String::new()
                 } else {
-                    let plural = assoc_items.len() > 1;
                     let assoc_items_kind = {
                         let item_types = assoc_items.iter().map(|x| x.kind);
                         if item_types.clone().all(|x| x == hir::AssocItemKind::Const) {
@@ -427,9 +426,9 @@ impl<'tcx> InherentCollect<'tcx> {
 
                     format!(
                         " to implement {} {}{}",
-                        if plural { "these" } else { "this" },
+                        pluralize!("this", assoc_items.len()),
                         assoc_items_kind,
-                        if plural { "s" } else { "" }
+                        pluralize!(assoc_items.len()),
                     )
                 };
 

--- a/compiler/rustc_typeck/src/structured_errors/wrong_number_of_generic_args.rs
+++ b/compiler/rustc_typeck/src/structured_errors/wrong_number_of_generic_args.rs
@@ -657,10 +657,9 @@ impl<'a, 'tcx> WrongNumberOfGenericArgs<'a, 'tcx> {
 
             let num_redundant_lt_args = lt_arg_spans.len() - self.num_expected_lifetime_args();
             let msg_lifetimes = format!(
-                "remove {} {} argument{}",
-                if num_redundant_lt_args == 1 { "this" } else { "these" },
-                "lifetime",
-                pluralize!(num_redundant_lt_args),
+                "remove {these} lifetime argument{s}",
+                these = pluralize!("this", num_redundant_lt_args),
+                s = pluralize!(num_redundant_lt_args),
             );
 
             err.span_suggestion(
@@ -700,10 +699,9 @@ impl<'a, 'tcx> WrongNumberOfGenericArgs<'a, 'tcx> {
             let num_redundant_gen_args =
                 gen_arg_spans.len() - self.num_expected_type_or_const_args();
             let msg_types_or_consts = format!(
-                "remove {} {} argument{}",
-                if num_redundant_gen_args == 1 { "this" } else { "these" },
-                "generic",
-                pluralize!(num_redundant_type_or_const_args),
+                "remove {these} generic argument{s}",
+                these = pluralize!("this", num_redundant_gen_args),
+                s = pluralize!(num_redundant_gen_args),
             );
 
             err.span_suggestion(

--- a/library/alloc/src/collections/btree/set/tests.rs
+++ b/library/alloc/src/collections/btree/set/tests.rs
@@ -609,7 +609,7 @@ fn assert_send() {
 
 #[allow(dead_code)]
 // Check that the member-like functions conditionally provided by #[derive()]
-// are not overriden by genuine member functions with a different signature.
+// are not overridden by genuine member functions with a different signature.
 fn assert_derives() {
     fn hash<T: Hash, H: Hasher>(v: BTreeSet<T>, state: &mut H) {
         v.hash(state);

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -1795,7 +1795,7 @@ impl Rustflags {
     }
 
     /// By default, cargo will pick up on various variables in the environment. However, bootstrap
-    /// reuses those variables to pass additional flags to rustdoc, so by default they get overriden.
+    /// reuses those variables to pass additional flags to rustdoc, so by default they get overridden.
     /// Explicitly add back any previous value in the environment.
     ///
     /// `prefix` is usually `RUSTFLAGS` or `RUSTDOCFLAGS`.

--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -948,7 +948,7 @@ fn resolve_associated_trait_item<'a>(
 ///
 /// This function returns `None` if no associated item was found in the impl.
 /// This can occur when the trait associated item has a default value that is
-/// not overriden in the impl.
+/// not overridden in the impl.
 ///
 /// This is just a wrapper around [`TyCtxt::impl_item_implementor_ids()`] and
 /// [`TyCtxt::associated_item()`] (with some helpful logging added).

--- a/src/librustdoc/visit_ast.rs
+++ b/src/librustdoc/visit_ast.rs
@@ -326,7 +326,7 @@ impl<'a, 'tcx> RustdocVisitor<'a, 'tcx> {
                 om.items.push((item, renamed))
             }
             hir::ItemKind::Macro(ref macro_def, _) => {
-                // `#[macro_export] macro_rules!` items are handled seperately in `visit()`,
+                // `#[macro_export] macro_rules!` items are handled separately in `visit()`,
                 // above, since they need to be documented at the module top level. Accordingly,
                 // we only want to handle macros if one of three conditions holds:
                 //

--- a/src/test/debuginfo/type-names.rs
+++ b/src/test/debuginfo/type-names.rs
@@ -122,6 +122,9 @@
 // gdb-command:whatis has_associated_type_trait
 // gdb-check:type = &(dyn type_names::Trait3<u32, AssocType=isize> + core::marker::Send)
 
+// gdb-command:whatis has_associated_type_but_no_generics_trait
+// gdb-check:type = &dyn type_names::TraitNoGenericsButWithAssocType<Output=isize>
+
 // BARE FUNCTIONS
 // gdb-command:whatis rust_fn
 // gdb-check:type = (fn(core::option::Option<isize>, core::option::Option<&type_names::mod1::Struct2>), usize)
@@ -228,6 +231,7 @@
 // cdb-check:struct ref_mut$<dyn$<type_names::Trait1> > mut_ref_trait = [...]
 // cdb-check:struct alloc::boxed::Box<dyn$<core::marker::Send,core::marker::Sync>,alloc::alloc::Global> no_principal_trait = [...]
 // cdb-check:struct ref$<dyn$<type_names::Trait3<u32,assoc$<AssocType,isize> >,core::marker::Send> > has_associated_type_trait = struct ref$<dyn$<type_names::Trait3<u32,assoc$<AssocType,isize> >,core::marker::Send> >
+// cdb-check:struct ref$<dyn$<type_names::TraitNoGenericsButWithAssocType<assoc$<Output,isize> > > > has_associated_type_but_no_generics_trait = struct ref$<dyn$<type_names::TraitNoGenericsButWithAssocType<assoc$<Output,isize> > > >
 
 // BARE FUNCTIONS
 // cdb-command:dv /t *_fn*
@@ -318,11 +322,21 @@ trait Trait3<T> {
         panic!()
     }
 }
+trait TraitNoGenericsButWithAssocType {
+    type Output;
+    fn foo(&self) -> Self::Output;
+}
 
 impl Trait1 for isize {}
 impl<T1, T2> Trait2<T1, T2> for isize {}
 impl<T> Trait3<T> for isize {
     type AssocType = isize;
+}
+impl TraitNoGenericsButWithAssocType for isize {
+    type Output = isize;
+    fn foo(&self) -> Self::Output {
+        *self
+    }
 }
 
 fn rust_fn(_: Option<isize>, _: Option<&mod1::Struct2>) {}
@@ -414,6 +428,8 @@ fn main() {
     let mut_ref_trait = (&mut mut_int1) as &mut dyn Trait1;
     let no_principal_trait = Box::new(0_isize) as Box<(dyn Send + Sync)>;
     let has_associated_type_trait = &0_isize as &(dyn Trait3<u32, AssocType = isize> + Send);
+    let has_associated_type_but_no_generics_trait =
+        &0_isize as &dyn TraitNoGenericsButWithAssocType<Output = isize>;
 
     let generic_box_trait = Box::new(0_isize) as Box<dyn Trait2<i32, mod1::Struct2>>;
     let generic_ref_trait = (&0_isize) as &dyn Trait2<Struct1, Struct1>;

--- a/src/test/rustdoc-ui/display-output.rs
+++ b/src/test/rustdoc-ui/display-output.rs
@@ -1,4 +1,4 @@
-// Test that `--show-output` has an effect and `allow(unused)` can be overriden.
+// Test that `--show-output` has an effect and `allow(unused)` can be overridden.
 
 // check-pass
 // edition:2018

--- a/src/test/ui/lint/cli-lint-override.rs
+++ b/src/test/ui/lint/cli-lint-override.rs
@@ -1,5 +1,5 @@
 // Tests that subsequent lints specified via the command line override
-// each other, except for ForceWarn and Forbid, which cannot be overriden.
+// each other, except for ForceWarn and Forbid, which cannot be overridden.
 //
 // revisions: warn_deny forbid_warn force_warn_deny
 //

--- a/src/tools/clippy/.github/ISSUE_TEMPLATE/ice.yml
+++ b/src/tools/clippy/.github/ISSUE_TEMPLATE/ice.yml
@@ -10,7 +10,7 @@ body:
     attributes:
       label: Summary
       description: |
-        If possible, try to provide a minimal verifiable example. You can read ["Rust Bug Minimization Patterns"][mve] for how to create smaller examples. Otherwise, provide the crate where the ICE occured.
+        If possible, try to provide a minimal verifiable example. You can read ["Rust Bug Minimization Patterns"][mve] for how to create smaller examples. Otherwise, provide the crate where the ICE occurred.
 
         [mve]: http://blog.pnkfx.org/blog/2019/11/18/rust-bug-minimization-patterns/
     validations:

--- a/src/tools/clippy/clippy_lints/src/upper_case_acronyms.rs
+++ b/src/tools/clippy/clippy_lints/src/upper_case_acronyms.rs
@@ -114,7 +114,7 @@ impl LateLintPass<'_> for UpperCaseAcronyms {
                 check_ident(cx, &it.ident, self.upper_case_acronyms_aggressive);
             },
             ItemKind::Enum(ref enumdef, _) => {
-                // check enum variants seperately because again we only want to lint on private enums and
+                // check enum variants separately because again we only want to lint on private enums and
                 // the fn check_variant does not know about the vis of the enum of its variants
                 enumdef
                     .variants


### PR DESCRIPTION
Successful merges:

 - #94810 (debuginfo: Fix bug in type name generation for dyn types with associated types but no other generic arguments.)
 - #94947 (fix typos)
 - #94956 (Fix small typo in FIXME)
 - #94958 (Support other types of pluralization in pluralize macro)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=94810,94947,94956,94958)
<!-- homu-ignore:end -->