### PR TITLE
Remove `assert` for unstable expectation IDs

### DIFF
--- a/compiler/rustc_errors/src/lib.rs
+++ b/compiler/rustc_errors/src/lib.rs
@@ -522,11 +522,6 @@ impl Drop for HandlerInner {
                 "no warnings or errors encountered even though `delayed_good_path_bugs` issued",
             );
         }
-
-        assert!(
-            self.unstable_expect_diagnostics.is_empty(),
-            "all diagnostics with unstable expectations should have been converted",
-        );
     }
 }
 


### PR DESCRIPTION
The `assert` requires that the `check_crate` query was executed before `HandlerInner` is dropped. This will not always be the case and can cause ICEs.

Closes #94953

The ICE was introduced in https://github.com/rust-lang/rust/pull/94670