### PR TITLE
solaris build environment should include libsendfile/liblgrp

### DIFF
--- a/src/ci/docker/host-x86_64/dist-various-2/build-solaris-toolchain.sh
+++ b/src/ci/docker/host-x86_64/dist-various-2/build-solaris-toolchain.sh
@@ -33,14 +33,18 @@ cd solaris
 dpkg --add-architecture $APT_ARCH
 apt-get update
 apt-get download $(apt-cache depends --recurse --no-replaces \
-  libc:$APT_ARCH           \
-  libm-dev:$APT_ARCH       \
-  libpthread:$APT_ARCH     \
-  libresolv:$APT_ARCH      \
-  librt:$APT_ARCH          \
-  libsocket:$APT_ARCH      \
-  system-crt:$APT_ARCH     \
-  system-header:$APT_ARCH  \
+  libc:$APT_ARCH                                             \
+  liblgrp-dev:$APT_ARCH                                      \
+  liblgrp:$APT_ARCH                                          \
+  libm-dev:$APT_ARCH                                         \
+  libpthread:$APT_ARCH                                       \
+  libresolv:$APT_ARCH                                        \
+  librt:$APT_ARCH                                            \
+  libsendfile-dev:$APT_ARCH                                  \
+  libsendfile:$APT_ARCH                                      \
+  libsocket:$APT_ARCH                                        \
+  system-crt:$APT_ARCH                                       \
+  system-header:$APT_ARCH                                    \
   | grep "^\w")
 
 for deb in *$APT_ARCH.deb; do


### PR DESCRIPTION
As of version 0.2.120 of the libc crate, the solaris target now requires
some additional libraries to be present in the sysroot.  Note that the
solaris target doesn't really build against files from Solaris, but
rather against some files from DilOS (a platform similar to both Solaris
and illumos).  Pull in the extra libraries and their compilation links
from that apt repository.

This aims to assist with rust-lang/rust#94052.