### PR TITLE
[perf test/don't merge] Revert "RustWrapper: add missing include"

### DIFF
--- a/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
@@ -9,7 +9,6 @@
 #include "llvm/Object/Archive.h"
 #include "llvm/Object/COFFImportFile.h"
 #include "llvm/Object/ObjectFile.h"
-#include "llvm/Pass.h"
 #include "llvm/Bitcode/BitcodeWriterPass.h"
 #include "llvm/Support/Signals.h"
 #include "llvm/ADT/Optional.h"


### PR DESCRIPTION

This reverts commit 185e3b95ca198ec10e6777d31e2c8d92c43f2ce2.
cc https://github.com/rust-lang/rust/pull/94814#issuecomment-1067945114

r? @ghost