### PR TITLE
debuginfo: Fix ICE when generating name for type that produces a layout error.

### DIFF
--- a/src/test/ui/debuginfo/debuginfo-type-name-layout-ice-94961-1.rs
+++ b/src/test/ui/debuginfo/debuginfo-type-name-layout-ice-94961-1.rs
@@ -1,0 +1,16 @@
+// Make sure the compiler does not ICE when trying to generate the debuginfo name of a type that
+// causes a layout error. See https://github.com/rust-lang/rust/issues/94961.
+
+// compile-flags:-C debuginfo=2
+// build-fail
+// error-pattern: too big for the current architecture
+// normalize-stderr-64bit "18446744073709551615" -> "SIZE"
+// normalize-stderr-32bit "4294967295" -> "SIZE"
+
+#![crate_type = "rlib"]
+
+pub struct Foo<T>([T; usize::MAX]);
+
+pub fn foo() -> usize {
+    std::mem::size_of::<Foo<u8>>()
+}

--- a/src/test/ui/debuginfo/debuginfo-type-name-layout-ice-94961-1.stderr
+++ b/src/test/ui/debuginfo/debuginfo-type-name-layout-ice-94961-1.stderr
@@ -1,0 +1,4 @@
+error: values of the type `[u8; SIZE]` are too big for the current architecture
+
+error: aborting due to previous error
+

--- a/src/test/ui/debuginfo/debuginfo-type-name-layout-ice-94961-2.rs
+++ b/src/test/ui/debuginfo/debuginfo-type-name-layout-ice-94961-2.rs
@@ -1,0 +1,20 @@
+// Make sure the compiler does not ICE when trying to generate the debuginfo name of a type that
+// causes a layout error.
+// This version of the test already ICE'd before the commit that introduce the ICE described in
+// https://github.com/rust-lang/rust/issues/94961.
+
+// compile-flags:-C debuginfo=2
+// build-fail
+// error-pattern: too big for the current architecture
+// normalize-stderr-64bit "18446744073709551615" -> "SIZE"
+// normalize-stderr-32bit "4294967295" -> "SIZE"
+
+#![crate_type = "rlib"]
+
+pub enum Foo<T> {
+    Bar([T; usize::MAX]),
+}
+
+pub fn foo() -> usize {
+    std::mem::size_of::<Foo<u8>>()
+}

--- a/src/test/ui/debuginfo/debuginfo-type-name-layout-ice-94961-2.stderr
+++ b/src/test/ui/debuginfo/debuginfo-type-name-layout-ice-94961-2.stderr
@@ -1,0 +1,4 @@
+error: values of the type `[u8; SIZE]` are too big for the current architecture
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/94961.