### PR TITLE
Only build a regex in the linker code when necessary

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -39,7 +39,7 @@ use std::borrow::Borrow;
 use std::ffi::OsString;
 use std::fs::{File, OpenOptions};
 use std::io::{BufWriter, Write};
-use std::lazy::{OnceCell, Lazy};
+use std::lazy::{Lazy, OnceCell};
 use std::path::{Path, PathBuf};
 use std::process::{ExitStatus, Output, Stdio};
 use std::{ascii, char, env, fmt, fs, io, mem, str};


### PR DESCRIPTION
Regexes are somewhat expensive to build