### PR TITLE
Derive Eq for std::cmp::Ordering, instead of using manual impl.

### DIFF
--- a/library/core/src/cmp.rs
+++ b/library/core/src/cmp.rs
@@ -333,7 +333,7 @@ pub struct AssertParamIsEq<T: Eq + ?Sized> {
 /// let result = 2.cmp(&1);
 /// assert_eq!(Ordering::Greater, result);
 /// ```
-#[derive(Clone, Copy, PartialEq, Debug, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
 #[stable(feature = "rust1", since = "1.0.0")]
 #[repr(i8)]
 pub enum Ordering {
@@ -860,9 +860,6 @@ pub trait Ord: Eq + PartialOrd<Self> {
 pub macro Ord($item:item) {
     /* compiler built-in */
 }
-
-#[stable(feature = "rust1", since = "1.0.0")]
-impl Eq for Ordering {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl Ord for Ordering {

--- a/library/core/tests/cmp.rs
+++ b/library/core/tests/cmp.rs
@@ -134,6 +134,19 @@ fn ordering_const() {
 }
 
 #[test]
+fn ordering_structural_eq() {
+    // test that consts of type `Ordering` are usable in patterns
+
+    const ORDERING: Ordering = Greater;
+
+    const REVERSE: Ordering = ORDERING.reverse();
+    match Ordering::Less {
+        REVERSE => {}
+        _ => unreachable!(),
+    };
+}
+
+#[test]
 fn cmp_default() {
     // Test default methods in PartialOrd and PartialEq
 


### PR DESCRIPTION
This allows consts of type Ordering to be used in patterns, and with feature(adt_const_params) allows using `Ordering` as a const generic parameter.

Currently, `std::cmp::Ordering` implements `Eq` using a manually written `impl Eq for Ordering {}`, instead of `derive(Eq)`. This means that it does not implement `StructuralEq`.

This commit removes the manually written impl, and adds `derive(Eq)` to `Ordering`, so that it will implement `StructuralEq`.