### PR TITLE
erase late-bound regions in dyn projection types for debuginfo

### DIFF
--- a/compiler/rustc_codegen_ssa/src/debuginfo/type_names.rs
+++ b/compiler/rustc_codegen_ssa/src/debuginfo/type_names.rs
@@ -217,7 +217,8 @@ fn push_debuginfo_type_name<'tcx>(
                 let projection_bounds: SmallVec<[_; 4]> = trait_data
                     .projection_bounds()
                     .map(|bound| {
-                        let ExistentialProjection { item_def_id, term, .. } = bound.skip_binder();
+                        let ExistentialProjection { item_def_id, term, .. } =
+                            tcx.erase_late_bound_regions(bound);
                         // FIXME(associated_const_equality): allow for consts here
                         (item_def_id, term.ty().unwrap())
                     })

--- a/src/test/ui/debuginfo/late-bound-projection.rs
+++ b/src/test/ui/debuginfo/late-bound-projection.rs
@@ -1,0 +1,7 @@
+// build-pass
+// compile-flags: -Cdebuginfo=2 --crate-type=rlib
+// Fixes issue #94998
+
+pub trait Trait {}
+
+pub fn run(_: &dyn FnOnce(&()) -> Box<dyn Trait + '_>) {}


### PR DESCRIPTION
simply skipping the binder leaves late-bound regions that will cause debug assertions to fail when checking the layout of the projection ty, so let's erase the regions instead.

sorry for taking so long to put this up, had trouble getting rustc set up on a new computer.

fixes #94998