### PR TITLE
rustdoc: Reduce number of call to cx.tcx()

### DIFF
--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -2108,6 +2108,8 @@ fn sidebar_deref_methods(
             _ => None,
         })
     {
+        let tcx = cx.tcx();
+
         debug!("found target, real_target: {:?} {:?}", target, real_target);
         if let Some(did) = target.def_id(c) {
             if let Some(type_did) = impl_.inner_impl().for_.def_id(c) {
@@ -2118,7 +2120,7 @@ fn sidebar_deref_methods(
                 }
             }
         }
-        let deref_mut = v.iter().any(|i| i.trait_did() == cx.tcx().lang_items().deref_mut_trait());
+        let deref_mut = v.iter().any(|i| i.trait_did() == tcx.lang_items().deref_mut_trait());
         let inner_impl = target
             .def_id(c)
             .or_else(|| {
@@ -2131,9 +2133,7 @@ fn sidebar_deref_methods(
             let mut ret = impls
                 .iter()
                 .filter(|i| i.inner_impl().trait_.is_none())
-                .flat_map(|i| {
-                    get_methods(i.inner_impl(), true, &mut used_links, deref_mut, cx.tcx())
-                })
+                .flat_map(|i| get_methods(i.inner_impl(), true, &mut used_links, deref_mut, tcx))
                 .collect::<Vec<_>>();
             if !ret.is_empty() {
                 let map;
@@ -2161,7 +2161,7 @@ fn sidebar_deref_methods(
                     i.inner_impl()
                         .trait_
                         .as_ref()
-                        .map(|t| Some(t.def_id()) == cx.tcx().lang_items().deref_trait())
+                        .map(|t| Some(t.def_id()) == tcx.lang_items().deref_trait())
                         .unwrap_or(false)
                 }) {
                     sidebar_deref_methods(cx, out, target_deref_impl, target_impls, derefs);

--- a/src/librustdoc/html/render/write_shared.rs
+++ b/src/librustdoc/html/render/write_shared.rs
@@ -387,6 +387,8 @@ pub(super) fn write_shared(
         }
     }
 
+    let tcx = cx.tcx();
+
     if cx.include_sources {
         let mut hierarchy = Hierarchy::new(OsString::new());
         for source in cx
@@ -418,10 +420,10 @@ pub(super) fn write_shared(
         let dst = cx.dst.join(&format!("source-files{}.js", cx.shared.resource_suffix));
         let make_sources = || {
             let (mut all_sources, _krates) =
-                try_err!(collect(&dst, krate.name(cx.tcx()).as_str(), "sourcesIndex"), &dst);
+                try_err!(collect(&dst, krate.name(tcx).as_str(), "sourcesIndex"), &dst);
             all_sources.push(format!(
                 "sourcesIndex[\"{}\"] = {};",
-                &krate.name(cx.tcx()),
+                &krate.name(tcx),
                 hierarchy.to_json_string()
             ));
             all_sources.sort();
@@ -437,9 +439,9 @@ pub(super) fn write_shared(
     // Update the search index and crate list.
     let dst = cx.dst.join(&format!("search-index{}.js", cx.shared.resource_suffix));
     let (mut all_indexes, mut krates) =
-        try_err!(collect_json(&dst, krate.name(cx.tcx()).as_str()), &dst);
+        try_err!(collect_json(&dst, krate.name(tcx).as_str()), &dst);
     all_indexes.push(search_index);
-    krates.push(krate.name(cx.tcx()).to_string());
+    krates.push(krate.name(tcx).to_string());
     krates.sort();
 
     // Sort the indexes by crate so the file will be generated identically even
@@ -556,7 +558,7 @@ pub(super) fn write_shared(
 
         let implementors = format!(
             r#"implementors["{}"] = {};"#,
-            krate.name(cx.tcx()),
+            krate.name(tcx),
             serde_json::to_string(&implementors).unwrap()
         );
 
@@ -568,7 +570,7 @@ pub(super) fn write_shared(
         mydst.push(&format!("{}.{}.js", remote_item_type, remote_path[remote_path.len() - 1]));
 
         let (mut all_implementors, _) =
-            try_err!(collect(&mydst, krate.name(cx.tcx()).as_str(), "implementors"), &mydst);
+            try_err!(collect(&mydst, krate.name(tcx).as_str(), "implementors"), &mydst);
         all_implementors.push(implementors);
         // Sort the implementors by crate so the file will be generated
         // identically even with rustdoc running in parallel.


### PR DESCRIPTION
While working on something else, I came across this. Instead of having multiple calls of `cx.tcx()`, I stored it into a variable instead. I only did it when I encountered it more than twice in a same function.

r? @notriddle 