### PR TITLE
Fix unnecessary error when using `neon` target feature

### DIFF
--- a/compiler/rustc_codegen_llvm/src/attributes.rs
+++ b/compiler/rustc_codegen_llvm/src/attributes.rs
@@ -325,7 +325,7 @@ pub fn from_fn_attrs<'ll, 'tcx>(
 
     if let Some(f) = llvm_util::check_tied_features(
         cx.tcx.sess,
-        &function_features.iter().map(|f| (*f, true)).collect(),
+        &mut function_features.iter().map(|f| (*f, true)).collect(),
     ) {
         let span = cx
             .tcx

--- a/src/test/ui/target-feature/tied-features-cli.rs
+++ b/src/test/ui/target-feature/tied-features-cli.rs
@@ -1,4 +1,4 @@
-// revisions: one two three
+// revisions: one two three four five
 // compile-flags: --crate-type=rlib --target=aarch64-unknown-linux-gnu
 // needs-llvm-components: aarch64
 //
@@ -11,6 +11,8 @@
 // [three] compile-flags: -C target-feature=+paca,+pacg,-paca
 // [four] build-pass
 // [four] compile-flags: -C target-feature=-paca,+pacg -C target-feature=+paca
+// [five] build-pass
+// [five] compile-flags: -C target-feature=+neon
 #![feature(no_core, lang_items)]
 #![no_core]
 

--- a/src/test/ui/target-feature/tied-features.rs
+++ b/src/test/ui/target-feature/tied-features.rs
@@ -19,6 +19,7 @@ pub fn main() {
         bar();
         baz();
         inner();
+        implicit_fp();
     }
 }
 
@@ -26,10 +27,12 @@ pub fn main() {
 //~^ ERROR must all be either enabled or disabled together
 unsafe fn foo() {}
 
-
 #[target_feature(enable = "paca,pacg")]
 unsafe fn bar() {}
 
 #[target_feature(enable = "paca")]
 #[target_feature(enable = "pacg")]
 unsafe fn baz() {}
+
+#[target_feature(enable = "neon")]
+unsafe fn implicit_fp() {}

--- a/src/test/ui/target-feature/tied-features.stderr
+++ b/src/test/ui/target-feature/tied-features.stderr
@@ -7,7 +7,7 @@ LL |     #[target_feature(enable = "pacg")]
    = help: add the missing features in a `target_feature` attribute
 
 error: the target features paca, pacg must all be either enabled or disabled together
-  --> $DIR/tied-features.rs:25:1
+  --> $DIR/tied-features.rs:26:1
    |
 LL | #[target_feature(enable = "paca")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/95002

We previously made the decision https://github.com/rust-lang/rust/pull/91608 to tie neon and fp, breaking code that just use #[target_feature(enable = "neon")]. However a [deeper search](https://github.com/search?q=target_feature+enable+neon+extension%3Ars&type=Code&ref=advsearch&l=&l=) revealed that this pattern was much more common than our first search suggested, including in all the aarch64/ARM neon intrinsics. Hence the proper fix should probably be to not error in this case.

r? @Amanieu 