### PR TITLE
Fix cmake build.

### DIFF
--- a/src/ci/docker/scripts/cmake.sh
+++ b/src/ci/docker/scripts/cmake.sh
@@ -5,16 +5,16 @@ hide_output() {
   set +x
   on_err="
 echo ERROR: An error was encountered with the build.
-cat /tmp/build.log
+cat /tmp/cmake_build.log
 exit 1
 "
   trap "$on_err" ERR
   bash -c "while true; do sleep 30; echo \$(date) - building ...; done" &
   PING_LOOP_PID=$!
-  "$@" &> /tmp/build.log
+  "$@" &> /tmp/cmake_build.log
   trap - ERR
   kill $PING_LOOP_PID
-  rm /tmp/build.log
+  rm /tmp/cmake_build.log
   set -x
 }
 


### PR DESCRIPTION
This is an attempt to fix the cmake build. For some reason, it has recently started failing with a permission denied trying to overwrite `/tmp/build.log`.  This file exists from the `build-toolchains.sh` step, which is owned by the rustbuild user. I think there is some behavior where a sticky `/tmp` directory doesn't allow overwriting files owned by other users even when running as root.  I do not know why this has suddenly started, and I can't reproduce locally with my own docker setup. However, this fix seems to work on CI.

