### PR TITLE
vec: add try_* methods and a try_vec! macro to make Vec usable in without infallible allocation methods

### DIFF
--- a/library/alloc/src/collections/mod.rs
+++ b/library/alloc/src/collections/mod.rs
@@ -74,6 +74,13 @@ impl TryReserveError {
     pub fn kind(&self) -> TryReserveErrorKind {
         self.kind.clone()
     }
+
+    /// Create a new [`TryReserveError`] indicating that there was an allocation failure.
+    #[must_use]
+    #[unstable(feature = "more_fallible_allocation_methods", issue = "86942")]
+    pub fn alloc_error(layout: Layout) -> Self {
+        Self { kind: TryReserveErrorKind::AllocError { layout, non_exhaustive: () } }
+    }
 }
 
 /// Details of the allocation that caused a `TryReserveError`

--- a/library/alloc/src/raw_vec/tests.rs
+++ b/library/alloc/src/raw_vec/tests.rs
@@ -104,13 +104,14 @@ fn zst() {
     let v: RawVec<ZST> = RawVec::with_capacity_in(100, Global);
     zst_sanity(&v);
 
-    let v: RawVec<ZST> = RawVec::allocate_in(0, AllocInit::Uninitialized, Global);
+    let v: RawVec<ZST> = RawVec::allocate_in::<!>(0, AllocInit::Uninitialized, Global).unwrap();
     zst_sanity(&v);
 
-    let v: RawVec<ZST> = RawVec::allocate_in(100, AllocInit::Uninitialized, Global);
+    let v: RawVec<ZST> = RawVec::allocate_in::<!>(100, AllocInit::Uninitialized, Global).unwrap();
     zst_sanity(&v);
 
-    let mut v: RawVec<ZST> = RawVec::allocate_in(usize::MAX, AllocInit::Uninitialized, Global);
+    let mut v: RawVec<ZST> =
+        RawVec::allocate_in::<!>(usize::MAX, AllocInit::Uninitialized, Global).unwrap();
     zst_sanity(&v);
 
     // Check all these operations work as expected with zero-sized elements.
@@ -127,20 +128,20 @@ fn zst() {
     //v.reserve_exact(101, usize::MAX - 100); // panics, in `zst_reserve_exact_panic` below
     zst_sanity(&v);
 
-    assert_eq!(v.try_reserve(100, usize::MAX - 100), Ok(()));
-    assert_eq!(v.try_reserve(101, usize::MAX - 100), cap_err);
+    assert_eq!(v.reserve_impl::<TryReserveError>(100, usize::MAX - 100), Ok(()));
+    assert_eq!(v.reserve_impl::<TryReserveError>(101, usize::MAX - 100), cap_err);
     zst_sanity(&v);
 
     assert_eq!(v.try_reserve_exact(100, usize::MAX - 100), Ok(()));
     assert_eq!(v.try_reserve_exact(101, usize::MAX - 100), cap_err);
     zst_sanity(&v);
 
-    assert_eq!(v.grow_amortized(100, usize::MAX - 100), cap_err);
-    assert_eq!(v.grow_amortized(101, usize::MAX - 100), cap_err);
+    assert_eq!(v.grow_amortized::<TryReserveError>(100, usize::MAX - 100), cap_err);
+    assert_eq!(v.grow_amortized::<TryReserveError>(101, usize::MAX - 100), cap_err);
     zst_sanity(&v);
 
-    assert_eq!(v.grow_exact(100, usize::MAX - 100), cap_err);
-    assert_eq!(v.grow_exact(101, usize::MAX - 100), cap_err);
+    assert_eq!(v.grow_exact::<TryReserveError>(100, usize::MAX - 100), cap_err);
+    assert_eq!(v.grow_exact::<TryReserveError>(101, usize::MAX - 100), cap_err);
     zst_sanity(&v);
 }
 

--- a/library/alloc/src/vec/into_iter.rs
+++ b/library/alloc/src/vec/into_iter.rs
@@ -1,4 +1,3 @@
-#[cfg(not(no_global_oom_handling))]
 use super::AsVecIntoIter;
 use crate::alloc::{Allocator, Global};
 use crate::raw_vec::RawVec;
@@ -109,7 +108,6 @@ impl<T, A: Allocator> IntoIter<T, A> {
     ///
     /// This method is used by in-place iteration, refer to the vec::in_place_collect
     /// documentation for an overview.
-    #[cfg(not(no_global_oom_handling))]
     pub(super) fn forget_allocation_drop_remaining(&mut self) {
         let remaining = self.as_raw_mut_slice();
 
@@ -393,7 +391,6 @@ unsafe impl<T, A: Allocator> SourceIter for IntoIter<T, A> {
     }
 }
 
-#[cfg(not(no_global_oom_handling))]
 unsafe impl<T> AsVecIntoIter for IntoIter<T> {
     type Item = T;
 

--- a/library/alloc/src/vec/spec_extend.rs
+++ b/library/alloc/src/vec/spec_extend.rs
@@ -3,18 +3,18 @@ use core::iter::TrustedLen;
 use core::ptr::{self};
 use core::slice::{self};
 
-use super::{IntoIter, SetLenOnDrop, Vec};
+use super::{IntoIter, SetLenOnDrop, Vec, VecError};
 
 // Specialization trait used for Vec::extend
 pub(super) trait SpecExtend<T, I> {
-    fn spec_extend(&mut self, iter: I);
+    fn spec_extend<TError: VecError>(&mut self, iter: I) -> Result<(), TError>;
 }
 
 impl<T, I, A: Allocator> SpecExtend<T, I> for Vec<T, A>
 where
     I: Iterator<Item = T>,
 {
-    default fn spec_extend(&mut self, iter: I) {
+    default fn spec_extend<TError: VecError>(&mut self, iter: I) -> Result<(), TError> {
         self.extend_desugared(iter)
     }
 }
@@ -23,7 +23,7 @@ impl<T, I, A: Allocator> SpecExtend<T, I> for Vec<T, A>
 where
     I: TrustedLen<Item = T>,
 {
-    default fn spec_extend(&mut self, iterator: I) {
+    default fn spec_extend<TError: VecError>(&mut self, iterator: I) -> Result<(), TError> {
         // This is the case for a TrustedLen iterator.
         let (low, high) = iterator.size_hint();
         if let Some(additional) = high {
@@ -33,7 +33,7 @@ where
                 "TrustedLen iterator's size hint is not exact: {:?}",
                 (low, high)
             );
-            self.reserve(additional);
+            self.reserve_impl(additional)?;
             unsafe {
                 let mut ptr = self.as_mut_ptr().add(self.len());
                 let mut local_len = SetLenOnDrop::new(&mut self.len);
@@ -46,23 +46,26 @@ where
                     local_len.increment_len(1);
                 });
             }
+
+            Ok(())
         } else {
             // Per TrustedLen contract a `None` upper bound means that the iterator length
             // truly exceeds usize::MAX, which would eventually lead to a capacity overflow anyway.
             // Since the other branch already panics eagerly (via `reserve()`) we do the same here.
             // This avoids additional codegen for a fallback code path which would eventually
             // panic anyway.
-            panic!("capacity overflow");
+            Err(TError::capacity_overflow())
         }
     }
 }
 
 impl<T, A: Allocator> SpecExtend<T, IntoIter<T>> for Vec<T, A> {
-    fn spec_extend(&mut self, mut iterator: IntoIter<T>) {
+    fn spec_extend<TError: VecError>(&mut self, mut iterator: IntoIter<T>) -> Result<(), TError> {
         unsafe {
-            self.append_elements(iterator.as_slice() as _);
+            self.append_elements(iterator.as_slice() as _)?;
         }
         iterator.forget_remaining_elements();
+        Ok(())
     }
 }
 
@@ -71,7 +74,7 @@ where
     I: Iterator<Item = &'a T>,
     T: Clone,
 {
-    default fn spec_extend(&mut self, iterator: I) {
+    default fn spec_extend<TError: VecError>(&mut self, iterator: I) -> Result<(), TError> {
         self.spec_extend(iterator.cloned())
     }
 }
@@ -80,8 +83,11 @@ impl<'a, T: 'a, A: Allocator + 'a> SpecExtend<&'a T, slice::Iter<'a, T>> for Vec
 where
     T: Copy,
 {
-    fn spec_extend(&mut self, iterator: slice::Iter<'a, T>) {
+    fn spec_extend<TError: VecError>(
+        &mut self,
+        iterator: slice::Iter<'a, T>,
+    ) -> Result<(), TError> {
         let slice = iterator.as_slice();
-        unsafe { self.append_elements(slice) };
+        unsafe { self.append_elements(slice) }
     }
 }

--- a/library/alloc/src/vec/spec_from_elem.rs
+++ b/library/alloc/src/vec/spec_from_elem.rs
@@ -3,59 +3,79 @@ use core::ptr;
 use crate::alloc::Allocator;
 use crate::raw_vec::RawVec;
 
-use super::{ExtendElement, IsZero, Vec};
+use super::{ExtendElement, IsZero, Vec, VecError};
 
 // Specialization trait used for Vec::from_elem
 pub(super) trait SpecFromElem: Sized {
-    fn from_elem<A: Allocator>(elem: Self, n: usize, alloc: A) -> Vec<Self, A>;
+    fn from_elem<A: Allocator, TError: VecError>(
+        elem: Self,
+        n: usize,
+        alloc: A,
+    ) -> Result<Vec<Self, A>, TError>;
 }
 
 impl<T: Clone> SpecFromElem for T {
-    default fn from_elem<A: Allocator>(elem: Self, n: usize, alloc: A) -> Vec<Self, A> {
-        let mut v = Vec::with_capacity_in(n, alloc);
-        v.extend_with(n, ExtendElement(elem));
-        v
+    default fn from_elem<A: Allocator, TError: VecError>(
+        elem: Self,
+        n: usize,
+        alloc: A,
+    ) -> Result<Vec<Self, A>, TError> {
+        let mut v = Vec::with_capacity_in_impl(n, alloc)?;
+        v.extend_with_impl(n, ExtendElement(elem))?;
+        Ok(v)
     }
 }
 
 impl<T: Clone + IsZero> SpecFromElem for T {
     #[inline]
-    default fn from_elem<A: Allocator>(elem: T, n: usize, alloc: A) -> Vec<T, A> {
+    default fn from_elem<A: Allocator, TError: VecError>(
+        elem: T,
+        n: usize,
+        alloc: A,
+    ) -> Result<Vec<T, A>, TError> {
         if elem.is_zero() {
-            return Vec { buf: RawVec::with_capacity_zeroed_in(n, alloc), len: n };
+            return Ok(Vec { buf: RawVec::with_capacity_zeroed_in_impl(n, alloc)?, len: n });
         }
-        let mut v = Vec::with_capacity_in(n, alloc);
-        v.extend_with(n, ExtendElement(elem));
-        v
+        let mut v = Vec::with_capacity_in_impl(n, alloc)?;
+        v.extend_with_impl(n, ExtendElement(elem))?;
+        Ok(v)
     }
 }
 
 impl SpecFromElem for i8 {
     #[inline]
-    fn from_elem<A: Allocator>(elem: i8, n: usize, alloc: A) -> Vec<i8, A> {
+    fn from_elem<A: Allocator, TError: VecError>(
+        elem: i8,
+        n: usize,
+        alloc: A,
+    ) -> Result<Vec<i8, A>, TError> {
         if elem == 0 {
-            return Vec { buf: RawVec::with_capacity_zeroed_in(n, alloc), len: n };
+            return Ok(Vec { buf: RawVec::with_capacity_zeroed_in_impl(n, alloc)?, len: n });
         }
         unsafe {
-            let mut v = Vec::with_capacity_in(n, alloc);
+            let mut v = Vec::with_capacity_in_impl(n, alloc)?;
             ptr::write_bytes(v.as_mut_ptr(), elem as u8, n);
             v.set_len(n);
-            v
+            Ok(v)
         }
     }
 }
 
 impl SpecFromElem for u8 {
     #[inline]
-    fn from_elem<A: Allocator>(elem: u8, n: usize, alloc: A) -> Vec<u8, A> {
+    fn from_elem<A: Allocator, TError: VecError>(
+        elem: u8,
+        n: usize,
+        alloc: A,
+    ) -> Result<Vec<u8, A>, TError> {
         if elem == 0 {
-            return Vec { buf: RawVec::with_capacity_zeroed_in(n, alloc), len: n };
+            return Ok(Vec { buf: RawVec::with_capacity_zeroed_in_impl(n, alloc)?, len: n });
         }
         unsafe {
-            let mut v = Vec::with_capacity_in(n, alloc);
+            let mut v = Vec::with_capacity_in_impl(n, alloc)?;
             ptr::write_bytes(v.as_mut_ptr(), elem, n);
             v.set_len(n);
-            v
+            Ok(v)
         }
     }
 }

--- a/library/alloc/src/vec/spec_from_iter.rs
+++ b/library/alloc/src/vec/spec_from_iter.rs
@@ -1,7 +1,7 @@
 use core::mem::ManuallyDrop;
 use core::ptr::{self};
 
-use super::{IntoIter, SpecExtend, SpecFromIterNested, Vec};
+use super::{IntoIter, SpecExtend, SpecFromIterNested, Vec, VecError};
 
 /// Specialization trait used for Vec::from_iter
 ///
@@ -21,21 +21,24 @@ use super::{IntoIter, SpecExtend, SpecFromIterNested, Vec};
 /// |  SourceIterMarker---fallback-+  |  +---------------------+
 /// +---------------------------------+
 /// ```
-pub(super) trait SpecFromIter<T, I> {
-    fn from_iter(iter: I) -> Self;
+pub(super) trait SpecFromIter<T, I, TError: VecError>
+where
+    Self: Sized,
+{
+    fn from_iter(iter: I) -> Result<Self, TError>;
 }
 
-impl<T, I> SpecFromIter<T, I> for Vec<T>
+impl<T, I, TError: VecError> SpecFromIter<T, I, TError> for Vec<T>
 where
     I: Iterator<Item = T>,
 {
-    default fn from_iter(iterator: I) -> Self {
+    default fn from_iter(iterator: I) -> Result<Self, TError> {
         SpecFromIterNested::from_iter(iterator)
     }
 }
 
-impl<T> SpecFromIter<T, IntoIter<T>> for Vec<T> {
-    fn from_iter(iterator: IntoIter<T>) -> Self {
+impl<T, TError: VecError> SpecFromIter<T, IntoIter<T>, TError> for Vec<T> {
+    fn from_iter(iterator: IntoIter<T>) -> Result<Self, TError> {
         // A common case is passing a vector into a function which immediately
         // re-collects into a vector. We can short circuit this if the IntoIter
         // has not been advanced at all.
@@ -51,14 +54,14 @@ impl<T> SpecFromIter<T, IntoIter<T>> for Vec<T> {
                 if has_advanced {
                     ptr::copy(it.ptr, it.buf.as_ptr(), it.len());
                 }
-                return Vec::from_raw_parts(it.buf.as_ptr(), it.len(), it.cap);
+                return Ok(Vec::from_raw_parts(it.buf.as_ptr(), it.len(), it.cap));
             }
         }
 
         let mut vec = Vec::new();
         // must delegate to spec_extend() since extend() itself delegates
         // to spec_from for empty Vecs
-        vec.spec_extend(iterator);
-        vec
+        vec.spec_extend(iterator)?;
+        Ok(vec)
     }
 }

--- a/library/alloc/src/vec/spec_from_iter_nested.rs
+++ b/library/alloc/src/vec/spec_from_iter_nested.rs
@@ -2,34 +2,37 @@ use core::cmp;
 use core::iter::TrustedLen;
 use core::ptr;
 
-use crate::raw_vec::RawVec;
+use crate::{alloc::Global, raw_vec::RawVec};
 
-use super::{SpecExtend, Vec};
+use super::{SpecExtend, Vec, VecError};
 
 /// Another specialization trait for Vec::from_iter
 /// necessary to manually prioritize overlapping specializations
 /// see [`SpecFromIter`](super::SpecFromIter) for details.
-pub(super) trait SpecFromIterNested<T, I> {
-    fn from_iter(iter: I) -> Self;
+pub(super) trait SpecFromIterNested<T, I, TError: VecError>
+where
+    Self: Sized,
+{
+    fn from_iter(iter: I) -> Result<Self, TError>;
 }
 
-impl<T, I> SpecFromIterNested<T, I> for Vec<T>
+impl<T, I, TError: VecError> SpecFromIterNested<T, I, TError> for Vec<T>
 where
     I: Iterator<Item = T>,
 {
-    default fn from_iter(mut iterator: I) -> Self {
+    default fn from_iter(mut iterator: I) -> Result<Self, TError> {
         // Unroll the first iteration, as the vector is going to be
         // expanded on this iteration in every case when the iterable is not
         // empty, but the loop in extend_desugared() is not going to see the
         // vector being full in the few subsequent loop iterations.
         // So we get better branch prediction.
         let mut vector = match iterator.next() {
-            None => return Vec::new(),
+            None => return Ok(Vec::new()),
             Some(element) => {
                 let (lower, _) = iterator.size_hint();
                 let initial_capacity =
                     cmp::max(RawVec::<T>::MIN_NON_ZERO_CAP, lower.saturating_add(1));
-                let mut vector = Vec::with_capacity(initial_capacity);
+                let mut vector = Self::with_capacity_in_impl(initial_capacity, Global)?;
                 unsafe {
                     // SAFETY: We requested capacity at least 1
                     ptr::write(vector.as_mut_ptr(), element);
@@ -40,18 +43,18 @@ where
         };
         // must delegate to spec_extend() since extend() itself delegates
         // to spec_from for empty Vecs
-        <Vec<T> as SpecExtend<T, I>>::spec_extend(&mut vector, iterator);
-        vector
+        <Vec<T> as SpecExtend<T, I>>::spec_extend(&mut vector, iterator)?;
+        Ok(vector)
     }
 }
 
-impl<T, I> SpecFromIterNested<T, I> for Vec<T>
+impl<T, I, TError: VecError> SpecFromIterNested<T, I, TError> for Vec<T>
 where
     I: TrustedLen<Item = T>,
 {
-    fn from_iter(iterator: I) -> Self {
+    fn from_iter(iterator: I) -> Result<Self, TError> {
         let mut vector = match iterator.size_hint() {
-            (_, Some(upper)) => Vec::with_capacity(upper),
+            (_, Some(upper)) => Self::with_capacity_in_impl(upper, Global)?,
             // TrustedLen contract guarantees that `size_hint() == (_, None)` means that there
             // are more than `usize::MAX` elements.
             // Since the previous branch would eagerly panic if the capacity is too large
@@ -59,7 +62,7 @@ where
             _ => panic!("capacity overflow"),
         };
         // reuse extend specialization for TrustedLen
-        vector.spec_extend(iterator);
-        vector
+        <Vec<T> as SpecExtend<T, I>>::spec_extend(&mut vector, iterator)?;
+        Ok(vector)
     }
 }

--- a/library/core/src/result.rs
+++ b/library/core/src/result.rs
@@ -2123,3 +2123,24 @@ impl<T, E, F: From<E>> ops::FromResidual<ops::Yeet<E>> for Result<T, F> {
 impl<T, E> const ops::Residual<T> for Result<convert::Infallible, E> {
     type TryType = Result<T, E>;
 }
+
+#[unstable(feature = "never_type", issue = "35121")]
+impl<T> Result<T, !> {
+    /// Returns the contained [`Ok`] value, consuming the `self` value,
+    /// where the [`Err`] variant is known to be unreachable.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(never_type)]
+    ///
+    /// let x: Result<u32, !> = Ok(2);
+    /// assert_eq!(x.unwrap_infallible(), 2);
+    /// ```
+    #[inline(always)]
+    pub fn unwrap_infallible(self) -> T {
+        match self {
+            Ok(t) => t,
+        }
+    }
+}


### PR DESCRIPTION
As a part of the work for #86942 the `no_global_oom_handling` cfg was added in #84266, however enabling that cfg makes it difficult to use `Vec`: the `vec!` macro is missing and there is no way to insert or push new elements, nor to create a `Vec` from an iterator (without resorting to `unsafe` APIs to manually expand and write to the underlying buffer).

This change adds `try_` equivalent methods for all methods in `Vec` that are disabled by `no_global_oom_handling` as well as a `try_vec!` as the equivalent of `vec!`.

Performance and implementation notes: A goal of this change was to make sure to NOT regress the performance of the existing infallible methods - a naive approach would be to move the actual implementation into the fallible method, then call it from the infallible method and `unwrap()`, but this would add extra compare+branch instructions into the infallible methods. It would also be possible to simply duplicate the code for the fallible version - I did opt for this in a few cases, but where the code was larger and more complex this would lead to a maintenance nightmare. Instead, I moved the implementation into an `*_impl` method that was then specialized based on a new `VecError` trait and returned `Result<_, VecError>`, this trait also provided a pair of methods for raising errors. Never (`!`) was used as the infallible version of this trait (and always panics) and `TryReserveError` as the fallible version (and returns the correct error object). All these `VecError` method were marked with `#[inline]`, so after inlining the compiler could see for the infallible version always returns `Ok()` on success (and panics on error) thus the `?` operator or `unwrap()` call was a no-op, and so the same non-branching instructions as before are generated.

I also added `try_from_iter` and `try_expand` methods for completeness, even though their infallible equivalents are trait implementations.

List of Vec APIs added:
```rust
try_vec!

impl<T> Vec<T> {
    pub fn try_with_capacity(capacity: usize) -> Result<Self, TryReserveError>;
    pub fn try_from_iter<I: IntoIterator<Item = T>>(iter: I) -> Result<Vec<T>, TryReserveError>;
}

impl<T, A: Allocator> Vec<T, A> {
    pub fn try_append(&mut self, other: &mut Self) -> Result<(), TryReserveError>;
    pub fn try_extend<I: IntoIterator<Item = T>>(&mut self, iter: I, ) -> Result<(), TryReserveError>;
    pub fn try_extend_from_slice(&mut self, other: &[T]) -> Result<(), TryReserveError>;
    pub fn try_extend_from_within<R>(&mut self, src: R) -> Result<(), TryReserveError> where R: RangeBounds<usize>; // NOTE: still panics if given an invalid range
    pub fn try_insert(&mut self, index: usize, element: T) -> Result<(), TryReserveError>; // NOTE: still panics if given an invalid index
    pub fn try_into_boxed_slice(self) -> Result<Box<[T], A>, TryReserveError>;
    pub fn try_push(&mut self, value: T) -> Result<(), TryReserveError>;
    pub fn try_resize(&mut self, new_len: usize, value: T) -> Result<(), TryReserveError>;
    pub fn try_resize_with<F>(&mut self, new_len: usize, f: F) -> Result<(), TryReserveError> where F: FnMut() -> T;
    pub fn try_shrink_to(&mut self, min_capacity: usize) -> Result<(), TryReserveError>;
    pub fn try_shrink_to_fit(&mut self) -> Result<(), TryReserveError>;
    pub fn try_split_off(&mut self, at: usize) -> Result<Self, TryReserveError> where A: Clone; // NOTE: still panics if given an invalid index
    pub fn try_with_capacity_in(capacity: usize, alloc: A) -> Result<Self, TryReserveError>;
}

#[doc(hidden)]
pub fn try_from_elem<T: Clone>(elem: T, n: usize) -> Result<Vec<T>, TryReserveError>;

#[doc(hidden)]
pub fn try_from_elem_in<T: Clone, A: Allocator>(elem: T, n: usize, alloc: A) -> Result<Vec<T, A>, TryReserveError>;

```

Other helper APIs added, than can be made `pub(crate)` if folks prefer:
```rust
impl TryReserveError {
    pub fn alloc_error(layout: Layout) -> Self;
}

impl<T> Result<T, !> {
    pub fn unwrap_infallible(self) -> T;
}
```