### PR TITLE
Fix debuginfo tests with GDB 11.2

### DIFF
--- a/src/test/debuginfo/borrowed-basic.rs
+++ b/src/test/debuginfo/borrowed-basic.rs
@@ -1,6 +1,3 @@
-// Gdb doesn't know about UTF-32 character encoding and will print a rust char as only
-// its numerical value.
-
 // compile-flags:-g
 // min-lldb-version: 310
 
@@ -13,7 +10,7 @@
 // gdb-command:print *int_ref
 // gdb-check:$2 = -1
 
-// gdb-command:print *char_ref
+// gdb-command:print/d *char_ref
 // gdb-check:$3 = 97
 
 // gdb-command:print *i8_ref

--- a/src/test/debuginfo/borrowed-unique-basic.rs
+++ b/src/test/debuginfo/borrowed-unique-basic.rs
@@ -1,8 +1,5 @@
 // min-lldb-version: 310
 
-// Gdb doesn't know about UTF-32 character encoding and will print a rust char as only
-// its numerical value.
-
 // compile-flags:-g
 
 // === GDB TESTS ===================================================================================
@@ -15,7 +12,7 @@
 // gdb-command:print *int_ref
 // gdb-check:$2 = -1
 
-// gdb-command:print *char_ref
+// gdb-command:print/d *char_ref
 // gdb-check:$3 = 97
 
 // gdb-command:print/d *i8_ref

--- a/src/test/debuginfo/gdb-char.rs
+++ b/src/test/debuginfo/gdb-char.rs
@@ -1,0 +1,23 @@
+// GDB got support for DW_ATE_UTF in 11.2, see
+// https://sourceware.org/bugzilla/show_bug.cgi?id=28637.
+
+// min-gdb-version: 11.2
+// compile-flags: -g
+
+// === GDB TESTS ===================================================================================
+
+// gdb-command:run
+// gdb-command:print ch
+// gdb-check:$1 = 97 'a'
+
+#![allow(unused_variables)]
+#![feature(omit_gdb_pretty_printer_section)]
+#![omit_gdb_pretty_printer_section]
+
+fn main() {
+    let ch: char = 'a';
+
+    zzz(); // #break
+}
+
+fn zzz() {()}


### PR DESCRIPTION
GDB 11.2 added support for DW_ATE_UTF, which caused some test
failures.  This fixes these tests by changing the format that is used,
and adds a new test to verify that characters are emitted as something
that GDB can print in a char-like way.

Fixes #94458