### PR TITLE
Re-enable parallel debuginfo tests

### DIFF
--- a/src/tools/compiletest/src/main.rs
+++ b/src/tools/compiletest/src/main.rs
@@ -487,11 +487,6 @@ fn configure_lldb(config: &Config) -> Option<Config> {
         return None;
     }
 
-    // Some older versions of LLDB seem to have problems with multiple
-    // instances running in parallel, so only run one test thread at a
-    // time.
-    env::set_var("RUST_TEST_THREADS", "1");
-
     Some(Config { debugger: Some(Debugger::Lldb), ..config.clone() })
 }
 


### PR DESCRIPTION
Debuginfo tests are serialized due to some older version of LLDB.
However, that comment was last touched in 2014, so presumably these
older versions are long since obsolete.

Partially fixes bug #72719.