### PR TITLE
Return err instead of ICE

### DIFF
--- a/src/test/ui/lifetimes/issue-95023.rs
+++ b/src/test/ui/lifetimes/issue-95023.rs
@@ -1,0 +1,11 @@
+struct ErrorKind;
+struct Error(ErrorKind);
+impl Fn(&isize) for Error {
+    //~^ ERROR manual implementations of `Fn` are experimental [E0183]
+    //~^^ ERROR associated type bindings are not allowed here [E0229]
+    fn foo<const N: usize>(&self) -> Self::B<{N}>;
+    //~^ ERROR associated function in `impl` without body
+    //~^^ ERROR method `foo` is not a member of trait `Fn` [E0407]
+    //~^^^ ERROR associated type `B` not found for `Self` [E0220]
+}
+fn main() {}

--- a/src/test/ui/lifetimes/issue-95023.stderr
+++ b/src/test/ui/lifetimes/issue-95023.stderr
@@ -1,0 +1,38 @@
+error: associated function in `impl` without body
+  --> $DIR/issue-95023.rs:6:5
+   |
+LL |     fn foo<const N: usize>(&self) -> Self::B<{N}>;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
+   |                                                  |
+   |                                                  help: provide a definition for the function: `{ <body> }`
+
+error[E0407]: method `foo` is not a member of trait `Fn`
+  --> $DIR/issue-95023.rs:6:5
+   |
+LL |     fn foo<const N: usize>(&self) -> Self::B<{N}>;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not a member of trait `Fn`
+
+error[E0183]: manual implementations of `Fn` are experimental
+  --> $DIR/issue-95023.rs:3:6
+   |
+LL | impl Fn(&isize) for Error {
+   |      ^^^^^^^^^^ manual implementations of `Fn` are experimental
+   |
+   = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
+
+error[E0229]: associated type bindings are not allowed here
+  --> $DIR/issue-95023.rs:3:6
+   |
+LL | impl Fn(&isize) for Error {
+   |      ^^^^^^^^^^ associated type not allowed here
+
+error[E0220]: associated type `B` not found for `Self`
+  --> $DIR/issue-95023.rs:6:44
+   |
+LL |     fn foo<const N: usize>(&self) -> Self::B<{N}>;
+   |                                            ^ associated type `B` not found
+
+error: aborting due to 5 previous errors
+
+Some errors have detailed explanations: E0183, E0220, E0229, E0407.
+For more information about an error, try `rustc --explain E0183`.

--- a/src/tools/tidy/src/ui_tests.rs
+++ b/src/tools/tidy/src/ui_tests.rs
@@ -7,7 +7,7 @@ use std::path::Path;
 
 const ENTRY_LIMIT: usize = 1000;
 // FIXME: The following limits should be reduced eventually.
-const ROOT_ENTRY_LIMIT: usize = 984;
+const ROOT_ENTRY_LIMIT: usize = 985;
 const ISSUES_ENTRY_LIMIT: usize = 2310;
 
 fn check_entries(path: &Path, bad: &mut bool) {


### PR DESCRIPTION
Having `escaping_bound_vars` results in ICE when trying to create `ty::Binder::dummy`, to avoid it we return err like the line above. I think this requires a more sophisticated fix, I would love to investigate if mentorship is available 🤓 

Fixes #95023 and #85350 