### PR TITLE
Don't declare test_variadic_fnptr with two conflicting signatures

### DIFF
--- a/compiler/rustc_codegen_cranelift/patches/0022-sysroot-Disable-not-compiling-tests.patch
+++ b/compiler/rustc_codegen_cranelift/patches/0022-sysroot-Disable-not-compiling-tests.patch
@@ -30,25 +30,5 @@ index 0000000..46fd999
 +
 +[dependencies]
 +rand = "0.7"
-diff --git a/library/core/tests/ptr.rs b/library/core/tests/ptr.rs
-index 1a6be3a..42dbd59 100644
---- a/library/core/tests/ptr.rs
-+++ b/library/core/tests/ptr.rs
-@@ -250,6 +250,7 @@ fn test_unsized_nonnull() {
-     };
- }
- 
-+/*
- #[test]
- #[allow(warnings)]
- // Have a symbol for the test below. It doesn’t need to be an actual variadic function, match the
-@@ -277,6 +277,7 @@ pub fn test_variadic_fnptr() {
-     let mut s = SipHasher::new();
-     assert_eq!(p.hash(&mut s), q.hash(&mut s));
- }
-+*/
- 
- #[test]
- fn write_unaligned_drop() {
 --
 2.21.0 (Apple Git-122)

--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -23,6 +23,7 @@
 #![feature(const_ptr_offset)]
 #![feature(const_trait_impl)]
 #![feature(const_likely)]
+#![feature(core_ffi_c)]
 #![feature(core_intrinsics)]
 #![feature(core_private_bignum)]
 #![feature(core_private_diy_float)]

--- a/library/core/tests/ptr.rs
+++ b/library/core/tests/ptr.rs
@@ -289,7 +289,7 @@ fn test_const_nonnull_new() {
 }
 
 #[test]
-#[cfg(any(unix, windows))] // printf may not be available on other platforms
+#[cfg(unix)] // printf may not be available on other platforms
 #[allow(deprecated)] // For SipHasher
 pub fn test_variadic_fnptr() {
     use core::ffi;


### PR DESCRIPTION
It is UB for LLVM and results in a compile error for Cranelift.

cc https://github.com/bjorn3/rustc_codegen_cranelift/issues/806
Fixes https://github.com/rust-lang/rust/issues/66690