### PR TITLE
Update cargo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1502,9 +1502,9 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e7d3b96ec1fcaa8431cf04a4f1ef5caafe58d5cf7bcc31f09c1626adddb0ffe"
+checksum = "3826a6e0e2215d7a41c2bfc7c9244123969273f3476b939a226aac0ab56e9e3c"
 dependencies = [
  "bitflags",
  "libc",
@@ -1974,9 +1974,9 @@ dependencies = [
 
 [[package]]
 name = "libgit2-sys"
-version = "0.13.1+1.4.2"
+version = "0.13.2+1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43e598aa7a4faedf1ea1b4608f582b06f0f40211eec551b7ef36019ae3f62def"
+checksum = "3a42de9a51a5c12e00fc0e4ca6bc2ea43582fc6418488e8f615e905d886f258b"
 dependencies = [
  "cc",
  "libc",


### PR DESCRIPTION
9 commits in 65c82664263feddc5fe2d424be0993c28d46377a..109bfbd055325ef87a6e7f63d67da7e838f8300b
2022-03-09 02:32:56 +0000 to 2022-03-17 21:43:09 +0000
- Refactor RegistryData::load to handle management of the index cache (rust-lang/cargo#10482)
- Separate VCS command paths with "--" (rust-lang/cargo#10483)
- Fix panic when artifact target is used for `[target.'cfg(&lt;target&gt;)'.dependencies` (rust-lang/cargo#10433)
- Bump git2@0.14.2 and libgit2-sys@0.13.2 (rust-lang/cargo#10479)
- vendor: Don't allow multiple values for --sync (rust-lang/cargo#10448)
- Use types to make clere (credential process || token) (rust-lang/cargo#10471)
- Warning on conflicting keys (rust-lang/cargo#10316)
- Registry functions return Poll to enable parallel fetching of index data (rust-lang/cargo#10064)
- Refine the contributor guide (rust-lang/cargo#10468)