### PR TITLE
Give more details in `Display` for `hir::Target`

### DIFF
--- a/compiler/rustc_hir/src/target.rs
+++ b/compiler/rustc_hir/src/target.rs
@@ -86,7 +86,11 @@ impl Display for Target {
                 Target::Statement => "statement",
                 Target::Arm => "match arm",
                 Target::AssocConst => "associated const",
-                Target::Method(_) => "method",
+                Target::Method(kind) => match kind {
+                    MethodKind::Inherent => "inherent method",
+                    MethodKind::Trait { body: false } => "required trait method",
+                    MethodKind::Trait { body: true } => "provided trait method",
+                },
                 Target::AssocTy => "associated type",
                 Target::ForeignFn => "foreign function",
                 Target::ForeignStatic => "foreign static item",


### PR DESCRIPTION
Made because I was making a code change and got a very confusing "should be applied to a method, not a method" error.

```
error[E0718]: `into_try_type` language item must be applied to a method
   --> library\core\src\ops\try_trait.rs:352:32
    |
352 |     #[cfg_attr(not(bootstrap), lang = "into_try_type")]
    |                                ^^^^^^^^^^^^^^^^^^^^^^ attribute should be applied to a method, not a method
```

With this change the error is more actionable

```
error[E0718]: `into_try_type` language item must be applied to a required trait method
   --> library\core\src\ops\try_trait.rs:352:32
    |
352 |     #[cfg_attr(not(bootstrap), lang = "into_try_type")]
    |                                ^^^^^^^^^^^^^^^^^^^^^^ attribute should be applied to a required trait method, not a provided trait method
```