### PR TITLE
Extend --check-cfg tests to all predicate inside all/any

### DIFF
--- a/src/test/ui/check-cfg/mix.rs
+++ b/src/test/ui/check-cfg/mix.rs
@@ -45,6 +45,28 @@ fn test_cfg_macro() {
     //~^ WARNING unexpected `cfg` condition name
     cfg!(any(feature = "bad", windows));
     //~^ WARNING unexpected `cfg` condition value
+    cfg!(any(windows, xxx));
+    //~^ WARNING unexpected `cfg` condition name
+    cfg!(all(unix, xxx));
+    //~^ WARNING unexpected `cfg` condition name
+    cfg!(all(aa, bb));
+    //~^ WARNING unexpected `cfg` condition name
+    //~| WARNING unexpected `cfg` condition name
+    cfg!(any(aa, bb));
+    //~^ WARNING unexpected `cfg` condition name
+    //~| WARNING unexpected `cfg` condition name
+    cfg!(any(unix, feature = "zebra"));
+    //~^ WARNING unexpected `cfg` condition value
+    cfg!(any(xxx, feature = "zebra"));
+    //~^ WARNING unexpected `cfg` condition name
+    //~| WARNING unexpected `cfg` condition value
+    cfg!(any(xxx, unix, xxx));
+    //~^ WARNING unexpected `cfg` condition name
+    //~| WARNING unexpected `cfg` condition name
+    cfg!(all(feature = "zebra", feature = "zebra", feature = "zebra"));
+    //~^ WARNING unexpected `cfg` condition value
+    //~| WARNING unexpected `cfg` condition value
+    //~| WARNING unexpected `cfg` condition value
 }
 
 fn main() {}

--- a/src/test/ui/check-cfg/mix.stderr
+++ b/src/test/ui/check-cfg/mix.stderr
@@ -62,5 +62,99 @@ LL |     cfg!(any(feature = "bad", windows));
    |
    = note: expected values for `feature` are: bar, foo
 
-warning: 9 warnings emitted
+warning: unexpected `cfg` condition name
+  --> $DIR/mix.rs:48:23
+   |
+LL |     cfg!(any(windows, xxx));
+   |                       ^^^
+
+warning: unexpected `cfg` condition name
+  --> $DIR/mix.rs:50:20
+   |
+LL |     cfg!(all(unix, xxx));
+   |                    ^^^
+
+warning: unexpected `cfg` condition name
+  --> $DIR/mix.rs:52:14
+   |
+LL |     cfg!(all(aa, bb));
+   |              ^^
+
+warning: unexpected `cfg` condition name
+  --> $DIR/mix.rs:52:18
+   |
+LL |     cfg!(all(aa, bb));
+   |                  ^^
+
+warning: unexpected `cfg` condition name
+  --> $DIR/mix.rs:55:14
+   |
+LL |     cfg!(any(aa, bb));
+   |              ^^
+
+warning: unexpected `cfg` condition name
+  --> $DIR/mix.rs:55:18
+   |
+LL |     cfg!(any(aa, bb));
+   |                  ^^
+
+warning: unexpected `cfg` condition value
+  --> $DIR/mix.rs:58:20
+   |
+LL |     cfg!(any(unix, feature = "zebra"));
+   |                    ^^^^^^^^^^^^^^^^^
+   |
+   = note: expected values for `feature` are: bar, foo
+
+warning: unexpected `cfg` condition name
+  --> $DIR/mix.rs:60:14
+   |
+LL |     cfg!(any(xxx, feature = "zebra"));
+   |              ^^^
+
+warning: unexpected `cfg` condition value
+  --> $DIR/mix.rs:60:19
+   |
+LL |     cfg!(any(xxx, feature = "zebra"));
+   |                   ^^^^^^^^^^^^^^^^^
+   |
+   = note: expected values for `feature` are: bar, foo
+
+warning: unexpected `cfg` condition name
+  --> $DIR/mix.rs:63:14
+   |
+LL |     cfg!(any(xxx, unix, xxx));
+   |              ^^^
+
+warning: unexpected `cfg` condition name
+  --> $DIR/mix.rs:63:25
+   |
+LL |     cfg!(any(xxx, unix, xxx));
+   |                         ^^^
+
+warning: unexpected `cfg` condition value
+  --> $DIR/mix.rs:66:14
+   |
+LL |     cfg!(all(feature = "zebra", feature = "zebra", feature = "zebra"));
+   |              ^^^^^^^^^^^^^^^^^
+   |
+   = note: expected values for `feature` are: bar, foo
+
+warning: unexpected `cfg` condition value
+  --> $DIR/mix.rs:66:33
+   |
+LL |     cfg!(all(feature = "zebra", feature = "zebra", feature = "zebra"));
+   |                                 ^^^^^^^^^^^^^^^^^
+   |
+   = note: expected values for `feature` are: bar, foo
+
+warning: unexpected `cfg` condition value
+  --> $DIR/mix.rs:66:52
+   |
+LL |     cfg!(all(feature = "zebra", feature = "zebra", feature = "zebra"));
+   |                                                    ^^^^^^^^^^^^^^^^^
+   |
+   = note: expected values for `feature` are: bar, foo
+
+warning: 23 warnings emitted
 


### PR DESCRIPTION
Now that https://github.com/rust-lang/rust/pull/94295 is merged it's time to add more tests to check that all predicate inside `all` and `any` are always checked.

r? @petrochenkov 