### PR TITLE
`Clone` suggestions

### DIFF
--- a/src/test/ui/moves/issue-46099-move-in-macro.stderr
+++ b/src/test/ui/moves/issue-46099-move-in-macro.stderr
@@ -5,6 +5,11 @@ LL |     let b = Box::new(true);
    |         - move occurs because `b` has type `Box<bool>`, which does not implement the `Copy` trait
 LL |     test!({b});
    |            ^ value used here after move
+   |
+help: consider cloning `b`
+   |
+LL |     test!({b.clone()});
+   |             ++++++++
 
 error: aborting due to previous error
 

--- a/src/test/ui/moves/move-fn-self-receiver.stderr
+++ b/src/test/ui/moves/move-fn-self-receiver.stderr
@@ -12,6 +12,10 @@ note: this function takes ownership of the receiver `self`, which moves `val.0`
 LL |     fn into_iter(self) -> Self::IntoIter;
    |                  ^^^^
    = note: move occurs because `val.0` has type `Vec<bool>`, which does not implement the `Copy` trait
+help: consider cloning `val.0`
+   |
+LL |     val.0.clone().into_iter().next();
+   |          ++++++++
 
 error[E0382]: use of moved value: `foo`
   --> $DIR/move-fn-self-receiver.rs:34:5
@@ -96,6 +100,10 @@ note: this function takes ownership of the receiver `self`, which moves `rc_foo`
    |
 LL |     fn use_rc_self(self: Rc<Self>) {}
    |                    ^^^^
+help: consider cloning `rc_foo`
+   |
+LL |     rc_foo.clone().use_rc_self();
+   |           ++++++++
 
 error[E0382]: use of moved value: `foo_add`
   --> $DIR/move-fn-self-receiver.rs:59:5
@@ -127,6 +135,10 @@ help: consider iterating over a slice of the `Vec<bool>`'s content to avoid movi
    |
 LL |     for _val in &implicit_into_iter {}
    |                 +
+help: consider cloning `implicit_into_iter`
+   |
+LL |     for _val in implicit_into_iter.clone() {}
+   |                                   ++++++++
 
 error[E0382]: use of moved value: `explicit_into_iter`
   --> $DIR/move-fn-self-receiver.rs:67:5
@@ -137,6 +149,11 @@ LL |     for _val in explicit_into_iter.into_iter() {}
    |                                    ----------- `explicit_into_iter` moved due to this method call
 LL |     explicit_into_iter;
    |     ^^^^^^^^^^^^^^^^^^ value used here after move
+   |
+help: consider cloning `explicit_into_iter`
+   |
+LL |     for _val in explicit_into_iter.clone().into_iter() {}
+   |                                   ++++++++
 
 error[E0382]: use of moved value: `container`
   --> $DIR/move-fn-self-receiver.rs:71:5

--- a/src/test/ui/moves/move-guard-same-consts.stderr
+++ b/src/test/ui/moves/move-guard-same-consts.stderr
@@ -8,6 +8,11 @@ LL |         (1, 2) if take(x) => (),
    |                        - value moved here
 LL |         (1, 2) if take(x) => (),
    |                        ^ value used here after move
+   |
+help: consider cloning `x`
+   |
+LL |         (1, 2) if take(x.clone()) => (),
+   |                         ++++++++
 
 error: aborting due to previous error
 

--- a/src/test/ui/moves/move-in-guard-1.stderr
+++ b/src/test/ui/moves/move-in-guard-1.stderr
@@ -8,6 +8,11 @@ LL |         (1, _) if take(x) => (),
    |                        - value moved here
 LL |         (_, 2) if take(x) => (),
    |                        ^ value used here after move
+   |
+help: consider cloning `x`
+   |
+LL |         (1, _) if take(x.clone()) => (),
+   |                         ++++++++
 
 error: aborting due to previous error
 

--- a/src/test/ui/moves/move-in-guard-2.stderr
+++ b/src/test/ui/moves/move-in-guard-2.stderr
@@ -6,6 +6,11 @@ LL |     let x: Box<_> = Box::new(1);
 ...
 LL |         (_, 2) if take(x) => (),
    |                        ^ value used here after move
+   |
+help: consider cloning `x`
+   |
+LL |         (_, 2) if take(x.clone()) => (),
+   |                         ++++++++
 
 error: aborting due to previous error
 

--- a/src/test/ui/moves/move-out-of-tuple-field.stderr
+++ b/src/test/ui/moves/move-out-of-tuple-field.stderr
@@ -7,6 +7,10 @@ LL |     let z = x.0;
    |             ^^^ value used here after move
    |
    = note: move occurs because `x.0` has type `Box<i32>`, which does not implement the `Copy` trait
+help: consider cloning `x.0`
+   |
+LL |     let y = x.0.clone();
+   |                ++++++++
 
 error[E0382]: use of moved value: `x.0`
   --> $DIR/move-out-of-tuple-field.rs:12:13
@@ -17,6 +21,10 @@ LL |     let z = x.0;
    |             ^^^ value used here after move
    |
    = note: move occurs because `x.0` has type `Box<isize>`, which does not implement the `Copy` trait
+help: consider cloning `x.0`
+   |
+LL |     let y = x.0.clone();
+   |                ++++++++
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/moves/moves-based-on-type-access-to-field.stderr
+++ b/src/test/ui/moves/moves-based-on-type-access-to-field.stderr
@@ -13,6 +13,10 @@ note: this function takes ownership of the receiver `self`, which moves `x`
    |
 LL |     fn into_iter(self) -> Self::IntoIter;
    |                  ^^^^
+help: consider cloning `x`
+   |
+LL |     consume(x.clone().into_iter().next().unwrap());
+   |              ++++++++
 
 error: aborting due to previous error
 

--- a/src/test/ui/moves/moves-based-on-type-capture-clause-bad.stderr
+++ b/src/test/ui/moves/moves-based-on-type-capture-clause-bad.stderr
@@ -12,6 +12,10 @@ LL |     println!("{}", x);
    |                    ^ value borrowed here after move
    |
    = note: this error originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider cloning `x`
+   |
+LL |         println!("{}", x.clone());
+   |                         ++++++++
 
 error: aborting due to previous error
 

--- a/src/test/ui/moves/moves-based-on-type-distribute-copy-over-paren.stderr
+++ b/src/test/ui/moves/moves-based-on-type-distribute-copy-over-paren.stderr
@@ -9,6 +9,11 @@ LL |     let _y = Foo { f:x };
 LL |
 LL |     touch(&x);
    |           ^^ value borrowed here after move
+   |
+help: consider cloning `x`
+   |
+LL |     let _y = Foo { f:x.clone() };
+   |                       ++++++++
 
 error[E0382]: borrow of moved value: `x`
   --> $DIR/moves-based-on-type-distribute-copy-over-paren.rs:21:11
@@ -21,6 +26,11 @@ LL |     let _y = Foo { f:(((x))) };
 LL |
 LL |     touch(&x);
    |           ^^ value borrowed here after move
+   |
+help: consider cloning `x`
+   |
+LL |     let _y = Foo { f:(((x))).clone() };
+   |                             ++++++++
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/moves/moves-based-on-type-exprs.stderr
+++ b/src/test/ui/moves/moves-based-on-type-exprs.stderr
@@ -7,6 +7,11 @@ LL |     let _y = Foo { f:x };
    |                      - value moved here
 LL |     touch(&x);
    |           ^^ value borrowed here after move
+   |
+help: consider cloning `x`
+   |
+LL |     let _y = Foo { f:x.clone() };
+   |                       ++++++++
 
 error[E0382]: borrow of moved value: `x`
   --> $DIR/moves-based-on-type-exprs.rs:18:11
@@ -17,6 +22,11 @@ LL |     let _y = (x, 3);
    |               - value moved here
 LL |     touch(&x);
    |           ^^ value borrowed here after move
+   |
+help: consider cloning `x`
+   |
+LL |     let _y = (x.clone(), 3);
+   |                ++++++++
 
 error[E0382]: borrow of moved value: `x`
   --> $DIR/moves-based-on-type-exprs.rs:35:11
@@ -29,6 +39,11 @@ LL |         x
 ...
 LL |     touch(&x);
    |           ^^ value borrowed here after move
+   |
+help: consider cloning `x`
+   |
+LL |         x.clone()
+   |          ++++++++
 
 error[E0382]: borrow of moved value: `y`
   --> $DIR/moves-based-on-type-exprs.rs:36:11
@@ -41,6 +56,11 @@ LL |         y
 ...
 LL |     touch(&y);
    |           ^^ value borrowed here after move
+   |
+help: consider cloning `y`
+   |
+LL |         y.clone()
+   |          ++++++++
 
 error[E0382]: borrow of moved value: `x`
   --> $DIR/moves-based-on-type-exprs.rs:46:11
@@ -53,6 +73,11 @@ LL |         true => x,
 ...
 LL |     touch(&x);
    |           ^^ value borrowed here after move
+   |
+help: consider cloning `x`
+   |
+LL |         true => x.clone(),
+   |                  ++++++++
 
 error[E0382]: borrow of moved value: `y`
   --> $DIR/moves-based-on-type-exprs.rs:47:11
@@ -65,6 +90,11 @@ LL |         false => y
 ...
 LL |     touch(&y);
    |           ^^ value borrowed here after move
+   |
+help: consider cloning `y`
+   |
+LL |         false => y.clone()
+   |                   ++++++++
 
 error[E0382]: borrow of moved value: `x`
   --> $DIR/moves-based-on-type-exprs.rs:58:11
@@ -77,6 +107,11 @@ LL |         _ if guard(x) => 10,
 ...
 LL |     touch(&x);
    |           ^^ value borrowed here after move
+   |
+help: consider cloning `x`
+   |
+LL |         _ if guard(x.clone()) => 10,
+   |                     ++++++++
 
 error[E0382]: borrow of moved value: `x`
   --> $DIR/moves-based-on-type-exprs.rs:65:11
@@ -87,6 +122,11 @@ LL |     let _y = [x];
    |               - value moved here
 LL |     touch(&x);
    |           ^^ value borrowed here after move
+   |
+help: consider cloning `x`
+   |
+LL |     let _y = [x.clone()];
+   |                ++++++++
 
 error[E0382]: borrow of moved value: `x`
   --> $DIR/moves-based-on-type-exprs.rs:71:11
@@ -97,6 +137,11 @@ LL |     let _y = vec![x];
    |                   - value moved here
 LL |     touch(&x);
    |           ^^ value borrowed here after move
+   |
+help: consider cloning `x`
+   |
+LL |     let _y = vec![x.clone()];
+   |                    ++++++++
 
 error[E0382]: borrow of moved value: `x`
   --> $DIR/moves-based-on-type-exprs.rs:77:11
@@ -113,6 +158,10 @@ note: this function takes ownership of the receiver `self`, which moves `x`
    |
 LL |     fn into_iter(self) -> Self::IntoIter;
    |                  ^^^^
+help: consider cloning `x`
+   |
+LL |     let _y = x.clone().into_iter().next().unwrap();
+   |               ++++++++
 
 error[E0382]: borrow of moved value: `x`
   --> $DIR/moves-based-on-type-exprs.rs:83:11
@@ -129,6 +178,10 @@ note: this function takes ownership of the receiver `self`, which moves `x`
    |
 LL |     fn into_iter(self) -> Self::IntoIter;
    |                  ^^^^
+help: consider cloning `x`
+   |
+LL |     let _y = [x.clone().into_iter().next().unwrap(); 1];
+   |                ++++++++
 
 error: aborting due to 11 previous errors
 

--- a/src/test/ui/moves/moves-based-on-type-match-bindings.stderr
+++ b/src/test/ui/moves/moves-based-on-type-match-bindings.stderr
@@ -8,6 +8,10 @@ LL |     touch(&x);
    |           ^^ value borrowed here after partial move
    |
    = note: partial move occurs because `x.f` has type `String`, which does not implement the `Copy` trait
+help: consider cloning `x.f`
+   |
+LL |         Foo {f.clone()} => {}
+   |               ++++++++
 
 error: aborting due to previous error
 

--- a/src/test/ui/moves/moves-based-on-type-tuple.stderr
+++ b/src/test/ui/moves/moves-based-on-type-tuple.stderr
@@ -8,6 +8,11 @@ LL |     Box::new((x, x))
    |               -  ^ value used here after move
    |               |
    |               value moved here
+   |
+help: consider cloning `x`
+   |
+LL |     Box::new((x.clone(), x))
+   |                ++++++++
 
 error: aborting due to previous error
 

--- a/src/test/ui/moves/moves-sru-moved-field.stderr
+++ b/src/test/ui/moves/moves-sru-moved-field.stderr
@@ -7,6 +7,10 @@ LL |     let _c = Foo {noncopyable: h, ..f};
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^ value used here after move
    |
    = note: move occurs because `f.moved` has type `Box<isize>`, which does not implement the `Copy` trait
+help: consider cloning `f.moved`
+   |
+LL |     let _b = Foo {noncopyable: g, ..f}.clone();
+   |                                       ++++++++
 
 error: aborting due to previous error
 

--- a/src/test/ui/moves/use_of_moved_value_clone_suggestions.fixed
+++ b/src/test/ui/moves/use_of_moved_value_clone_suggestions.fixed
@@ -4,28 +4,28 @@
 // `Rc` is not ever `Copy`, we should not suggest adding `T: Copy` constraint.
 // But should suggest adding `.clone()`.
 fn move_rc<T>(t: std::rc::Rc<T>) {
-    [t, t]; //~ use of moved value: `t`
+    [t.clone(), t]; //~ use of moved value: `t`
 }
 
 // Even though `T` could be `Copy` it's already `Clone`
 // so don't suggest adding `T: Copy` constraint,
 // instead suggest adding `.clone()`.
 fn move_clone_already<T: Clone>(t: T) {
-    [t, t]; //~ use of moved value: `t`
+    [t.clone(), t]; //~ use of moved value: `t`
 }
 
 // Same as `Rc`
-fn move_clone_only<T>(t: (T, String)) {
-    [t, t]; //~ use of moved value: `t`
+fn move_clone_only<T: Clone>(t: (T, String)) {
+    [t.clone(), t]; //~ use of moved value: `t`
 }
 
 // loop
 fn move_in_a_loop<T: Clone>(t: T) {
     loop {
         if true {
-            drop(t); //~ use of moved value: `t`
+            drop(t.clone()); //~ use of moved value: `t`
         } else {
-            drop(t);
+            drop(t.clone());
         }
     }
 }

--- a/src/test/ui/moves/use_of_moved_value_clone_suggestions.rs
+++ b/src/test/ui/moves/use_of_moved_value_clone_suggestions.rs
@@ -1,6 +1,32 @@
-// `Rc` is not ever `Copy`, we should not suggest adding `T: Copy` constraint
-fn duplicate_rc<T>(t: std::rc::Rc<T>) -> (std::rc::Rc<T>, std::rc::Rc<T>) {
-    (t, t) //~ use of moved value: `t`
+// run-rustfix
+#![allow(dead_code)]
+
+// `Rc` is not ever `Copy`, we should not suggest adding `T: Copy` constraint.
+// But should suggest adding `.clone()`.
+fn move_rc<T>(t: std::rc::Rc<T>) {
+    [t, t]; //~ use of moved value: `t`
+}
+
+// Even though `T` could be `Copy` it's already `Clone` so don't suggest adding `T: Copy` constraint,
+// instead suggest adding `.clone()`.
+fn move_clone_already<T: Clone>(t: T) {
+    [t, t]; //~ use of moved value: `t`
+}
+
+// Same as `Rc`
+fn move_clone_only<T>(t: (T, String)) {
+    [t, t]; //~ use of moved value: `t`
+}
+
+// loop
+fn move_in_a_loop<T: Clone>(t: T) {
+    loop {
+        if true {
+            drop(t); //~ use of moved value: `t`
+        } else {
+            drop(t);
+        }
+    }
 }
 
 fn main() {}

--- a/src/test/ui/moves/use_of_moved_value_clone_suggestions.stderr
+++ b/src/test/ui/moves/use_of_moved_value_clone_suggestions.stderr
@@ -1,13 +1,71 @@
 error[E0382]: use of moved value: `t`
-  --> $DIR/use_of_moved_value_clone_suggestions.rs:3:9
+  --> $DIR/use_of_moved_value_clone_suggestions.rs:7:9
    |
-LL | fn duplicate_rc<T>(t: std::rc::Rc<T>) -> (std::rc::Rc<T>, std::rc::Rc<T>) {
-   |                    - move occurs because `t` has type `Rc<T>`, which does not implement the `Copy` trait
-LL |     (t, t)
+LL | fn move_rc<T>(t: std::rc::Rc<T>) {
+   |               - move occurs because `t` has type `Rc<T>`, which does not implement the `Copy` trait
+LL |     [t, t];
    |      -  ^ value used here after move
    |      |
    |      value moved here
+   |
+help: consider cloning `t`
+   |
+LL |     [t.clone(), t];
+   |       ++++++++
 
-error: aborting due to previous error
+error[E0382]: use of moved value: `t`
+  --> $DIR/use_of_moved_value_clone_suggestions.rs:14:9
+   |
+LL | fn move_clone_already<T: Clone>(t: T) {
+   |                                 - move occurs because `t` has type `T`, which does not implement the `Copy` trait
+LL |     [t, t];
+   |      -  ^ value used here after move
+   |      |
+   |      value moved here
+   |
+help: consider cloning `t`
+   |
+LL |     [t.clone(), t];
+   |       ++++++++
+
+error[E0382]: use of moved value: `t`
+  --> $DIR/use_of_moved_value_clone_suggestions.rs:19:9
+   |
+LL | fn move_clone_only<T>(t: (T, String)) {
+   |                       - move occurs because `t` has type `(T, String)`, which does not implement the `Copy` trait
+LL |     [t, t];
+   |      -  ^ value used here after move
+   |      |
+   |      value moved here
+   |
+help: consider restricting type parameter `T`
+   |
+LL | fn move_clone_only<T: Clone>(t: (T, String)) {
+   |                     +++++++
+help: ...and cloning `t`
+   |
+LL |     [t.clone(), t];
+   |       ++++++++
+
+error[E0382]: use of moved value: `t`
+  --> $DIR/use_of_moved_value_clone_suggestions.rs:26:18
+   |
+LL | fn move_in_a_loop<T: Clone>(t: T) {
+   |                             - move occurs because `t` has type `T`, which does not implement the `Copy` trait
+...
+LL |             drop(t);
+   |                  ^ value moved here, in previous iteration of loop
+LL |         } else {
+LL |             drop(t);
+   |                  - value moved here, in previous iteration of loop
+   |
+help: consider cloning `t`
+   |
+LL ~             drop(t.clone());
+LL |         } else {
+LL ~             drop(t.clone());
+   |
+
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0382`.

--- a/src/test/ui/moves/use_of_moved_value_clone_suggestions_bad.rs
+++ b/src/test/ui/moves/use_of_moved_value_clone_suggestions_bad.rs
@@ -1,0 +1,27 @@
+// Bad `.clone()` suggestions
+
+struct S<A> {
+    t: A,
+}
+
+fn struct_field_shortcut_move<T: Clone>(t: T) {
+    S { t };
+    t; //~ use of moved value: `t`
+}
+
+fn closure_clone_will_not_help<T: Clone>(t: T) {
+    (move || {
+        t;
+    })();
+    t; //~ use of moved value: `t`
+}
+
+#[derive(Clone)]
+struct CloneOnly;
+
+fn update_syntax<T: Clone>(s: S<T>) {
+    S { ..s };
+    S { ..s }; //~ use of moved value: `s.t`
+}
+
+fn main() {}

--- a/src/test/ui/moves/use_of_moved_value_clone_suggestions_bad.stderr
+++ b/src/test/ui/moves/use_of_moved_value_clone_suggestions_bad.stderr
@@ -1,0 +1,50 @@
+error[E0382]: use of moved value: `t`
+  --> $DIR/use_of_moved_value_clone_suggestions_bad.rs:9:5
+   |
+LL | fn struct_field_shortcut_move<T: Clone>(t: T) {
+   |                                         - move occurs because `t` has type `T`, which does not implement the `Copy` trait
+LL |     S { t };
+   |         - value moved here
+LL |     t;
+   |     ^ value used here after move
+   |
+help: consider cloning `t`
+   |
+LL |     S { t.clone() };
+   |          ++++++++
+
+error[E0382]: use of moved value: `t`
+  --> $DIR/use_of_moved_value_clone_suggestions_bad.rs:16:5
+   |
+LL | fn closure_clone_will_not_help<T: Clone>(t: T) {
+   |                                          - move occurs because `t` has type `T`, which does not implement the `Copy` trait
+LL |     (move || {
+   |      ------- value moved into closure here
+LL |         t;
+   |         - variable moved due to use in closure
+LL |     })();
+LL |     t;
+   |     ^ value used here after move
+   |
+help: consider cloning `t`
+   |
+LL |         t.clone();
+   |          ++++++++
+
+error[E0382]: use of moved value: `s.t`
+  --> $DIR/use_of_moved_value_clone_suggestions_bad.rs:24:5
+   |
+LL |     S { ..s };
+   |     --------- value moved here
+LL |     S { ..s };
+   |     ^^^^^^^^^ value used here after move
+   |
+   = note: move occurs because `s.t` has type `T`, which does not implement the `Copy` trait
+help: consider cloning `s.t`
+   |
+LL |     S { ..s }.clone();
+   |              ++++++++
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0382`.

--- a/src/test/ui/moves/use_of_moved_value_no_suggestions.rs
+++ b/src/test/ui/moves/use_of_moved_value_no_suggestions.rs
@@ -1,0 +1,9 @@
+// No suggestions? :(
+
+// In the future, we may want to suggest deriving `Clone, Copy` for `No` (and then adding `T: Copy`)
+struct No;
+fn move_non_clone_non_copy<T>(t: (T, No)) {
+    [t, t]; //~ use of moved value: `t`
+}
+
+fn main() {}

--- a/src/test/ui/moves/use_of_moved_value_no_suggestions.stderr
+++ b/src/test/ui/moves/use_of_moved_value_no_suggestions.stderr
@@ -1,0 +1,13 @@
+error[E0382]: use of moved value: `t`
+  --> $DIR/use_of_moved_value_no_suggestions.rs:6:9
+   |
+LL | fn move_non_clone_non_copy<T>(t: (T, No)) {
+   |                               - move occurs because `t` has type `(T, No)`, which does not implement the `Copy` trait
+LL |     [t, t];
+   |      -  ^ value used here after move
+   |      |
+   |      value moved here
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0382`.

--- a/src/test/ui/nll/move-subpaths-moves-root.stderr
+++ b/src/test/ui/nll/move-subpaths-moves-root.stderr
@@ -7,6 +7,10 @@ LL |     drop(x);
    |          ^ value used here after partial move
    |
    = note: partial move occurs because `x.0` has type `Vec<i32>`, which does not implement the `Copy` trait
+help: consider cloning `x.0`
+   |
+LL |     drop(x.0.clone());
+   |             ++++++++
 
 error: aborting due to previous error
 


### PR DESCRIPTION
This continues the work from #94375 by also suggestion cloning sometimes, instead of coping. The rules are as follows:
- If the type (being used after move) is already `Clone`, suggest adding `.clone()` calls
- If the type can be `Copy`, suggest adding bounds requited to make it `Copy`
- If the type can be `Clone`, suggest adding bounds requited to make it `Clone` and suggest adding `.clone()` calls
- Otherwise don't suggest anything

For example for this code:
```rust
fn move_rc<T>(t: std::rc::Rc<T>) {
    [t, t]; //~ use of moved value: `t`
}
```
we now produce the following diagnostics:
```text
error[E0382]: use of moved value: `t`
  --> $DIR/use_of_moved_value_clone_suggestions.rs:7:9
   |
LL | fn move_rc<T>(t: std::rc::Rc<T>) {
   |               - move occurs because `t` has type `Rc<T>`, which does not implement the `Copy` trait
LL |     [t, t];
   |      -  ^ value used here after move
   |      |
   |      value moved here
   |
help: consider cloning `t`
   |
LL |     [t.clone(), t];
   |       ++++++++
```
Which is quite nice in my opinion!

However, there are some corner-cases where the suggestion is wrong and I don't know how to fix it. See `use_of_moved_value_clone_suggestions_bad.rs` test for examples of broken suggestions that I could find.

r? @estebank
@rustbot label +A-diagnostics +A-suggestion-diagnostics +C-enhancement