### PR TITLE
Add needs-* directives to many tests

### DIFF
--- a/src/test/ui/abi/abi-sysv64-register-usage.rs
+++ b/src/test/ui/abi/abi-sysv64-register-usage.rs
@@ -5,6 +5,7 @@
 // ignore-android
 // ignore-arm
 // ignore-aarch64
+// needs-asm-support
 #![feature(asm_sym)]
 
 #[cfg(target_arch = "x86_64")]

--- a/src/test/ui/asm/aarch64/const.rs
+++ b/src/test/ui/asm/aarch64/const.rs
@@ -1,5 +1,6 @@
 // only-aarch64
 // run-pass
+// needs-asm-support
 // revisions: mirunsafeck thirunsafeck
 // [thirunsafeck]compile-flags: -Z thir-unsafeck
 

--- a/src/test/ui/asm/aarch64/duplicate-options.fixed
+++ b/src/test/ui/asm/aarch64/duplicate-options.fixed
@@ -1,4 +1,5 @@
 // only-aarch64
+// needs-asm-support
 // run-rustfix
 
 use std::arch::asm;

--- a/src/test/ui/asm/aarch64/duplicate-options.rs
+++ b/src/test/ui/asm/aarch64/duplicate-options.rs
@@ -1,4 +1,5 @@
 // only-aarch64
+// needs-asm-support
 // run-rustfix
 
 use std::arch::asm;

--- a/src/test/ui/asm/aarch64/duplicate-options.stderr
+++ b/src/test/ui/asm/aarch64/duplicate-options.stderr
@@ -1,53 +1,53 @@
 error: the `nomem` option was already provided
-  --> $DIR/duplicate-options.rs:8:33
+  --> $DIR/duplicate-options.rs:9:33
    |
 LL |         asm!("", options(nomem, nomem));
    |                                 ^^^^^ this option was already provided
 
 error: the `preserves_flags` option was already provided
-  --> $DIR/duplicate-options.rs:10:43
+  --> $DIR/duplicate-options.rs:11:43
    |
 LL |         asm!("", options(preserves_flags, preserves_flags));
    |                                           ^^^^^^^^^^^^^^^ this option was already provided
 
 error: the `nostack` option was already provided
-  --> $DIR/duplicate-options.rs:12:61
+  --> $DIR/duplicate-options.rs:13:61
    |
 LL |         asm!("", options(nostack, preserves_flags), options(nostack));
    |                                                             ^^^^^^^ this option was already provided
 
 error: the `nostack` option was already provided
-  --> $DIR/duplicate-options.rs:14:35
+  --> $DIR/duplicate-options.rs:15:35
    |
 LL |         asm!("", options(nostack, nostack), options(nostack), options(nostack));
    |                                   ^^^^^^^ this option was already provided
 
 error: the `nostack` option was already provided
-  --> $DIR/duplicate-options.rs:14:53
+  --> $DIR/duplicate-options.rs:15:53
    |
 LL |         asm!("", options(nostack, nostack), options(nostack), options(nostack));
    |                                                     ^^^^^^^ this option was already provided
 
 error: the `nostack` option was already provided
-  --> $DIR/duplicate-options.rs:14:71
+  --> $DIR/duplicate-options.rs:15:71
    |
 LL |         asm!("", options(nostack, nostack), options(nostack), options(nostack));
    |                                                                       ^^^^^^^ this option was already provided
 
 error: the `noreturn` option was already provided
-  --> $DIR/duplicate-options.rs:21:38
+  --> $DIR/duplicate-options.rs:22:38
    |
 LL |             options(preserves_flags, noreturn),
    |                                      ^^^^^^^^ this option was already provided
 
 error: the `nomem` option was already provided
-  --> $DIR/duplicate-options.rs:22:21
+  --> $DIR/duplicate-options.rs:23:21
    |
 LL |             options(nomem, nostack),
    |                     ^^^^^ this option was already provided
 
 error: the `noreturn` option was already provided
-  --> $DIR/duplicate-options.rs:23:21
+  --> $DIR/duplicate-options.rs:24:21
    |
 LL |             options(noreturn),
    |                     ^^^^^^^^ this option was already provided

--- a/src/test/ui/asm/aarch64/interpolated-idents.rs
+++ b/src/test/ui/asm/aarch64/interpolated-idents.rs
@@ -1,5 +1,5 @@
 // only-aarch64
-
+// needs-asm-support
 use std::arch::asm;
 
 macro_rules! m {

--- a/src/test/ui/asm/aarch64/srcloc.rs
+++ b/src/test/ui/asm/aarch64/srcloc.rs
@@ -1,5 +1,6 @@
 // only-aarch64
 // build-fail
+// needs-asm-support
 // compile-flags: -Ccodegen-units=1
 
 use std::arch::asm;

--- a/src/test/ui/asm/aarch64/srcloc.stderr
+++ b/src/test/ui/asm/aarch64/srcloc.stderr
@@ -1,5 +1,5 @@
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:11:15
+  --> $DIR/srcloc.rs:12:15
    |
 LL |         asm!("invalid_instruction");
    |               ^
@@ -11,7 +11,7 @@ LL |     invalid_instruction
    |     ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:15:13
+  --> $DIR/srcloc.rs:16:13
    |
 LL |             invalid_instruction
    |             ^
@@ -23,7 +23,7 @@ LL |             invalid_instruction
    |             ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:20:13
+  --> $DIR/srcloc.rs:21:13
    |
 LL |             invalid_instruction
    |             ^
@@ -35,7 +35,7 @@ LL |             invalid_instruction
    |             ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:26:13
+  --> $DIR/srcloc.rs:27:13
    |
 LL |             invalid_instruction
    |             ^
@@ -47,7 +47,7 @@ LL |             invalid_instruction
    |             ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:33:13
+  --> $DIR/srcloc.rs:34:13
    |
 LL |             invalid_instruction
    |             ^
@@ -59,7 +59,7 @@ LL |             invalid_instruction
    |             ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:38:14
+  --> $DIR/srcloc.rs:39:14
    |
 LL |         asm!(concat!("invalid", "_", "instruction"));
    |              ^
@@ -71,7 +71,7 @@ LL |     invalid_instruction
    |     ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:42:14
+  --> $DIR/srcloc.rs:43:14
    |
 LL |             "invalid_instruction",
    |              ^
@@ -83,7 +83,7 @@ LL |     invalid_instruction
    |     ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:48:14
+  --> $DIR/srcloc.rs:49:14
    |
 LL |             "invalid_instruction",
    |              ^
@@ -95,7 +95,7 @@ LL | invalid_instruction
    | ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:55:14
+  --> $DIR/srcloc.rs:56:14
    |
 LL |             "invalid_instruction",
    |              ^
@@ -107,7 +107,7 @@ LL | invalid_instruction
    | ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:62:13
+  --> $DIR/srcloc.rs:63:13
    |
 LL |             concat!("invalid", "_", "instruction"),
    |             ^
@@ -119,7 +119,7 @@ LL | invalid_instruction
    | ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:69:13
+  --> $DIR/srcloc.rs:70:13
    |
 LL |             concat!("invalid", "_", "instruction"),
    |             ^
@@ -131,7 +131,7 @@ LL | invalid_instruction
    | ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:76:14
+  --> $DIR/srcloc.rs:77:14
    |
 LL |             "invalid_instruction1",
    |              ^
@@ -143,7 +143,7 @@ LL |     invalid_instruction1
    |     ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:77:14
+  --> $DIR/srcloc.rs:78:14
    |
 LL |             "invalid_instruction2",
    |              ^
@@ -155,7 +155,7 @@ LL | invalid_instruction2
    | ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:83:13
+  --> $DIR/srcloc.rs:84:13
    |
 LL |             concat!(
    |             ^
@@ -167,7 +167,7 @@ LL |     invalid_instruction1
    |     ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:83:13
+  --> $DIR/srcloc.rs:84:13
    |
 LL |             concat!(
    |             ^
@@ -179,7 +179,7 @@ LL | invalid_instruction2
    | ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:92:13
+  --> $DIR/srcloc.rs:93:13
    |
 LL |             concat!(
    |             ^
@@ -191,7 +191,7 @@ LL |     invalid_instruction1
    |     ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:92:13
+  --> $DIR/srcloc.rs:93:13
    |
 LL |             concat!(
    |             ^
@@ -203,7 +203,7 @@ LL | invalid_instruction2
    | ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:96:13
+  --> $DIR/srcloc.rs:97:13
    |
 LL |             concat!(
    |             ^
@@ -215,7 +215,7 @@ LL | invalid_instruction3
    | ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:96:13
+  --> $DIR/srcloc.rs:97:13
    |
 LL |             concat!(
    |             ^
@@ -227,7 +227,7 @@ LL | invalid_instruction4
    | ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:107:13
+  --> $DIR/srcloc.rs:108:13
    |
 LL |             concat!(
    |             ^
@@ -239,7 +239,7 @@ LL |     invalid_instruction1
    |     ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:107:13
+  --> $DIR/srcloc.rs:108:13
    |
 LL |             concat!(
    |             ^
@@ -251,7 +251,7 @@ LL | invalid_instruction2
    | ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:111:13
+  --> $DIR/srcloc.rs:112:13
    |
 LL |             concat!(
    |             ^
@@ -263,7 +263,7 @@ LL | invalid_instruction3
    | ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:111:13
+  --> $DIR/srcloc.rs:112:13
    |
 LL |             concat!(
    |             ^

--- a/src/test/ui/asm/aarch64/sym.rs
+++ b/src/test/ui/asm/aarch64/sym.rs
@@ -1,5 +1,6 @@
 // only-aarch64
 // only-linux
+// needs-asm-support
 // run-pass
 
 #![feature(thread_local, asm_sym)]

--- a/src/test/ui/asm/inline-syntax.arm.stderr
+++ b/src/test/ui/asm/inline-syntax.arm.stderr
@@ -13,7 +13,7 @@ LL | .intel_syntax noprefix
    | ^
 
 error: unknown directive
-  --> $DIR/inline-syntax.rs:31:15
+  --> $DIR/inline-syntax.rs:32:15
    |
 LL |         asm!(".intel_syntax noprefix", "nop");
    |               ^
@@ -25,7 +25,7 @@ LL |     .intel_syntax noprefix
    |     ^
 
 error: unknown directive
-  --> $DIR/inline-syntax.rs:34:15
+  --> $DIR/inline-syntax.rs:35:15
    |
 LL |         asm!(".intel_syntax aaa noprefix", "nop");
    |               ^
@@ -37,7 +37,7 @@ LL |     .intel_syntax aaa noprefix
    |     ^
 
 error: unknown directive
-  --> $DIR/inline-syntax.rs:37:15
+  --> $DIR/inline-syntax.rs:38:15
    |
 LL |         asm!(".att_syntax noprefix", "nop");
    |               ^
@@ -49,7 +49,7 @@ LL |     .att_syntax noprefix
    |     ^
 
 error: unknown directive
-  --> $DIR/inline-syntax.rs:40:15
+  --> $DIR/inline-syntax.rs:41:15
    |
 LL |         asm!(".att_syntax bbb noprefix", "nop");
    |               ^
@@ -61,7 +61,7 @@ LL |     .att_syntax bbb noprefix
    |     ^
 
 error: unknown directive
-  --> $DIR/inline-syntax.rs:43:15
+  --> $DIR/inline-syntax.rs:44:15
    |
 LL |         asm!(".intel_syntax noprefix; nop");
    |               ^
@@ -73,7 +73,7 @@ LL |     .intel_syntax noprefix; nop
    |     ^
 
 error: unknown directive
-  --> $DIR/inline-syntax.rs:49:13
+  --> $DIR/inline-syntax.rs:50:13
    |
 LL |             .intel_syntax noprefix
    |             ^

--- a/src/test/ui/asm/inline-syntax.rs
+++ b/src/test/ui/asm/inline-syntax.rs
@@ -8,6 +8,7 @@
 //[arm] compile-flags: --target armv7-unknown-linux-gnueabihf
 //[arm] build-fail
 //[arm] needs-llvm-components: arm
+// needs-asm-support
 
 #![feature(no_core, lang_items, rustc_attrs)]
 #![crate_type = "rlib"]

--- a/src/test/ui/asm/inline-syntax.x86_64.stderr
+++ b/src/test/ui/asm/inline-syntax.x86_64.stderr
@@ -1,5 +1,5 @@
 warning: avoid using `.intel_syntax`, Intel syntax is the default
-  --> $DIR/inline-syntax.rs:57:14
+  --> $DIR/inline-syntax.rs:58:14
    |
 LL | global_asm!(".intel_syntax noprefix", "nop");
    |              ^^^^^^^^^^^^^^^^^^^^^^
@@ -7,37 +7,37 @@ LL | global_asm!(".intel_syntax noprefix", "nop");
    = note: `#[warn(bad_asm_style)]` on by default
 
 warning: avoid using `.intel_syntax`, Intel syntax is the default
-  --> $DIR/inline-syntax.rs:31:15
+  --> $DIR/inline-syntax.rs:32:15
    |
 LL |         asm!(".intel_syntax noprefix", "nop");
    |               ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: avoid using `.intel_syntax`, Intel syntax is the default
-  --> $DIR/inline-syntax.rs:34:15
+  --> $DIR/inline-syntax.rs:35:15
    |
 LL |         asm!(".intel_syntax aaa noprefix", "nop");
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: avoid using `.att_syntax`, prefer using `options(att_syntax)` instead
-  --> $DIR/inline-syntax.rs:37:15
+  --> $DIR/inline-syntax.rs:38:15
    |
 LL |         asm!(".att_syntax noprefix", "nop");
    |               ^^^^^^^^^^^^^^^^^^^^
 
 warning: avoid using `.att_syntax`, prefer using `options(att_syntax)` instead
-  --> $DIR/inline-syntax.rs:40:15
+  --> $DIR/inline-syntax.rs:41:15
    |
 LL |         asm!(".att_syntax bbb noprefix", "nop");
    |               ^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: avoid using `.intel_syntax`, Intel syntax is the default
-  --> $DIR/inline-syntax.rs:43:15
+  --> $DIR/inline-syntax.rs:44:15
    |
 LL |         asm!(".intel_syntax noprefix; nop");
    |               ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: avoid using `.intel_syntax`, Intel syntax is the default
-  --> $DIR/inline-syntax.rs:49:13
+  --> $DIR/inline-syntax.rs:50:13
    |
 LL |             .intel_syntax noprefix
    |             ^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/asm/issue-92378.rs
+++ b/src/test/ui/asm/issue-92378.rs
@@ -1,5 +1,6 @@
 // compile-flags: --target armv5te-unknown-linux-gnueabi
 // needs-llvm-components: arm
+// needs-asm-support
 // build-pass
 
 #![feature(no_core, lang_items, rustc_attrs, isa_attribute)]

--- a/src/test/ui/asm/naked-functions-unused.aarch64.stderr
+++ b/src/test/ui/asm/naked-functions-unused.aarch64.stderr
@@ -1,66 +1,66 @@
 error: unused variable: `a`
-  --> $DIR/naked-functions-unused.rs:16:32
+  --> $DIR/naked-functions-unused.rs:17:32
    |
 LL |     pub extern "C" fn function(a: usize, b: usize) -> usize {
    |                                ^ help: if this is intentional, prefix it with an underscore: `_a`
    |
 note: the lint level is defined here
-  --> $DIR/naked-functions-unused.rs:4:9
+  --> $DIR/naked-functions-unused.rs:5:9
    |
 LL | #![deny(unused)]
    |         ^^^^^^
    = note: `#[deny(unused_variables)]` implied by `#[deny(unused)]`
 
 error: unused variable: `b`
-  --> $DIR/naked-functions-unused.rs:16:42
+  --> $DIR/naked-functions-unused.rs:17:42
    |
 LL |     pub extern "C" fn function(a: usize, b: usize) -> usize {
    |                                          ^ help: if this is intentional, prefix it with an underscore: `_b`
 
 error: unused variable: `a`
-  --> $DIR/naked-functions-unused.rs:25:38
+  --> $DIR/naked-functions-unused.rs:26:38
    |
 LL |         pub extern "C" fn associated(a: usize, b: usize) -> usize {
    |                                      ^ help: if this is intentional, prefix it with an underscore: `_a`
 
 error: unused variable: `b`
-  --> $DIR/naked-functions-unused.rs:25:48
+  --> $DIR/naked-functions-unused.rs:26:48
    |
 LL |         pub extern "C" fn associated(a: usize, b: usize) -> usize {
    |                                                ^ help: if this is intentional, prefix it with an underscore: `_b`
 
 error: unused variable: `a`
-  --> $DIR/naked-functions-unused.rs:31:41
+  --> $DIR/naked-functions-unused.rs:32:41
    |
 LL |         pub extern "C" fn method(&self, a: usize, b: usize) -> usize {
    |                                         ^ help: if this is intentional, prefix it with an underscore: `_a`
 
 error: unused variable: `b`
-  --> $DIR/naked-functions-unused.rs:31:51
+  --> $DIR/naked-functions-unused.rs:32:51
    |
 LL |         pub extern "C" fn method(&self, a: usize, b: usize) -> usize {
    |                                                   ^ help: if this is intentional, prefix it with an underscore: `_b`
 
 error: unused variable: `a`
-  --> $DIR/naked-functions-unused.rs:39:40
+  --> $DIR/naked-functions-unused.rs:40:40
    |
 LL |         extern "C" fn trait_associated(a: usize, b: usize) -> usize {
    |                                        ^ help: if this is intentional, prefix it with an underscore: `_a`
 
 error: unused variable: `b`
-  --> $DIR/naked-functions-unused.rs:39:50
+  --> $DIR/naked-functions-unused.rs:40:50
    |
 LL |         extern "C" fn trait_associated(a: usize, b: usize) -> usize {
    |                                                  ^ help: if this is intentional, prefix it with an underscore: `_b`
 
 error: unused variable: `a`
-  --> $DIR/naked-functions-unused.rs:45:43
+  --> $DIR/naked-functions-unused.rs:46:43
    |
 LL |         extern "C" fn trait_method(&self, a: usize, b: usize) -> usize {
    |                                           ^ help: if this is intentional, prefix it with an underscore: `_a`
 
 error: unused variable: `b`
-  --> $DIR/naked-functions-unused.rs:45:53
+  --> $DIR/naked-functions-unused.rs:46:53
    |
 LL |         extern "C" fn trait_method(&self, a: usize, b: usize) -> usize {
    |                                                     ^ help: if this is intentional, prefix it with an underscore: `_b`

--- a/src/test/ui/asm/naked-functions-unused.rs
+++ b/src/test/ui/asm/naked-functions-unused.rs
@@ -1,4 +1,5 @@
 // revisions: x86_64 aarch64
+// needs-asm-support
 //[x86_64] only-x86_64
 //[aarch64] only-aarch64
 #![deny(unused)]

--- a/src/test/ui/asm/naked-functions-unused.x86_64.stderr
+++ b/src/test/ui/asm/naked-functions-unused.x86_64.stderr
@@ -1,66 +1,66 @@
 error: unused variable: `a`
-  --> $DIR/naked-functions-unused.rs:16:32
+  --> $DIR/naked-functions-unused.rs:17:32
    |
 LL |     pub extern "C" fn function(a: usize, b: usize) -> usize {
    |                                ^ help: if this is intentional, prefix it with an underscore: `_a`
    |
 note: the lint level is defined here
-  --> $DIR/naked-functions-unused.rs:4:9
+  --> $DIR/naked-functions-unused.rs:5:9
    |
 LL | #![deny(unused)]
    |         ^^^^^^
    = note: `#[deny(unused_variables)]` implied by `#[deny(unused)]`
 
 error: unused variable: `b`
-  --> $DIR/naked-functions-unused.rs:16:42
+  --> $DIR/naked-functions-unused.rs:17:42
    |
 LL |     pub extern "C" fn function(a: usize, b: usize) -> usize {
    |                                          ^ help: if this is intentional, prefix it with an underscore: `_b`
 
 error: unused variable: `a`
-  --> $DIR/naked-functions-unused.rs:25:38
+  --> $DIR/naked-functions-unused.rs:26:38
    |
 LL |         pub extern "C" fn associated(a: usize, b: usize) -> usize {
    |                                      ^ help: if this is intentional, prefix it with an underscore: `_a`
 
 error: unused variable: `b`
-  --> $DIR/naked-functions-unused.rs:25:48
+  --> $DIR/naked-functions-unused.rs:26:48
    |
 LL |         pub extern "C" fn associated(a: usize, b: usize) -> usize {
    |                                                ^ help: if this is intentional, prefix it with an underscore: `_b`
 
 error: unused variable: `a`
-  --> $DIR/naked-functions-unused.rs:31:41
+  --> $DIR/naked-functions-unused.rs:32:41
    |
 LL |         pub extern "C" fn method(&self, a: usize, b: usize) -> usize {
    |                                         ^ help: if this is intentional, prefix it with an underscore: `_a`
 
 error: unused variable: `b`
-  --> $DIR/naked-functions-unused.rs:31:51
+  --> $DIR/naked-functions-unused.rs:32:51
    |
 LL |         pub extern "C" fn method(&self, a: usize, b: usize) -> usize {
    |                                                   ^ help: if this is intentional, prefix it with an underscore: `_b`
 
 error: unused variable: `a`
-  --> $DIR/naked-functions-unused.rs:39:40
+  --> $DIR/naked-functions-unused.rs:40:40
    |
 LL |         extern "C" fn trait_associated(a: usize, b: usize) -> usize {
    |                                        ^ help: if this is intentional, prefix it with an underscore: `_a`
 
 error: unused variable: `b`
-  --> $DIR/naked-functions-unused.rs:39:50
+  --> $DIR/naked-functions-unused.rs:40:50
    |
 LL |         extern "C" fn trait_associated(a: usize, b: usize) -> usize {
    |                                                  ^ help: if this is intentional, prefix it with an underscore: `_b`
 
 error: unused variable: `a`
-  --> $DIR/naked-functions-unused.rs:45:43
+  --> $DIR/naked-functions-unused.rs:46:43
    |
 LL |         extern "C" fn trait_method(&self, a: usize, b: usize) -> usize {
    |                                           ^ help: if this is intentional, prefix it with an underscore: `_a`
 
 error: unused variable: `b`
-  --> $DIR/naked-functions-unused.rs:45:53
+  --> $DIR/naked-functions-unused.rs:46:53
    |
 LL |         extern "C" fn trait_method(&self, a: usize, b: usize) -> usize {
    |                                                     ^ help: if this is intentional, prefix it with an underscore: `_b`

--- a/src/test/ui/asm/x86_64/const.rs
+++ b/src/test/ui/asm/x86_64/const.rs
@@ -1,5 +1,6 @@
 // only-x86_64
 // run-pass
+// needs-asm-support
 // revisions: mirunsafeck thirunsafeck
 // [thirunsafeck]compile-flags: -Z thir-unsafeck
 

--- a/src/test/ui/asm/x86_64/issue-89875.rs
+++ b/src/test/ui/asm/x86_64/issue-89875.rs
@@ -1,4 +1,5 @@
 // build-pass
+// needs-asm-support
 // only-x86_64
 
 #![feature(target_feature_11)]

--- a/src/test/ui/asm/x86_64/sym.rs
+++ b/src/test/ui/asm/x86_64/sym.rs
@@ -1,6 +1,7 @@
 // min-llvm-version: 12.0.1
 // only-x86_64
 // only-linux
+// needs-asm-support
 // run-pass
 
 #![feature(thread_local, asm_sym)]

--- a/src/test/ui/numbers-arithmetic/issue-8460.rs
+++ b/src/test/ui/numbers-arithmetic/issue-8460.rs
@@ -1,6 +1,7 @@
 // run-pass
 #![allow(unused_must_use)]
 // ignore-emscripten no threads support
+// needs-unwind
 #![feature(rustc_attrs)]
 
 use std::thread;

--- a/src/test/ui/panic-while-printing.rs
+++ b/src/test/ui/panic-while-printing.rs
@@ -1,4 +1,5 @@
 // run-pass
+// needs-unwind
 // ignore-emscripten no subprocess support
 
 #![feature(internal_output_capture)]

--- a/src/test/ui/process/multi-panic.rs
+++ b/src/test/ui/process/multi-panic.rs
@@ -1,6 +1,7 @@
 // run-pass
 // ignore-emscripten no processes
 // ignore-sgx no processes
+// needs-unwind
 
 fn check_for_no_backtrace(test: std::process::Output) {
     assert!(!test.status.success());

--- a/src/test/ui/test-attrs/test-panic-while-printing.rs
+++ b/src/test/ui/test-attrs/test-panic-while-printing.rs
@@ -1,5 +1,6 @@
 // compile-flags:--test
 // run-pass
+// needs-unwind
 // ignore-emscripten no subprocess support
 
 use std::fmt;


### PR DESCRIPTION
These are necessary to ignore tests that need features unsupported by cg_clif.