### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1965,9 +1965,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.116"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "565dbd88872dbe4cc8a46e527f26483c1d1f7afa6b884a3bd6cd893d4f98da74"
+checksum = "efaa7b300f3b5fe8eb6bf21ce3895e1751d9665086af2d64b42f19701015ff4f"
 dependencies = [
  "rustc-std-workspace-core",
 ]

--- a/compiler/rustc_attr/src/builtin.rs
+++ b/compiler/rustc_attr/src/builtin.rs
@@ -763,10 +763,10 @@ where
                                     meta.span(),
                                     AttrError::UnknownMetaItem(
                                         pprust::path_to_string(&mi.path),
-                                        if attr.has_name(sym::deprecated) {
-                                            &["since", "note"]
-                                        } else {
+                                        if sess.features_untracked().deprecated_suggestion {
                                             &["since", "note", "suggestion"]
+                                        } else {
+                                            &["since", "note"]
                                         },
                                     ),
                                 );

--- a/compiler/rustc_attr/src/builtin.rs
+++ b/compiler/rustc_attr/src/builtin.rs
@@ -750,8 +750,7 @@ where
                                     if sess.is_nightly_build() {
                                         diag.help("add `#![feature(deprecated_suggestion)]` to the crate root");
                                     }
-                                    // FIXME(jhpratt) change this to an actual tracking issue
-                                    diag.note("see #XXX for more details").emit();
+                                    diag.note("see #94785 for more details").emit();
                                 }
 
                                 if !get(mi, &mut suggestion) {

--- a/compiler/rustc_codegen_cranelift/patches/0022-sysroot-Disable-not-compiling-tests.patch
+++ b/compiler/rustc_codegen_cranelift/patches/0022-sysroot-Disable-not-compiling-tests.patch
@@ -39,26 +39,6 @@ index a35897e..f0bf645 100644
  
  pub fn decode_finite<T: DecodableFloat>(v: T) -> Decoded {
      match decode(v).1 {
-diff --git a/library/core/tests/ptr.rs b/library/core/tests/ptr.rs
-index 1a6be3a..42dbd59 100644
---- a/library/core/tests/ptr.rs
-+++ b/library/core/tests/ptr.rs
-@@ -250,6 +250,7 @@ fn test_unsized_nonnull() {
-     };
- }
- 
-+/*
- #[test]
- #[allow(warnings)]
- // Have a symbol for the test below. It doesn’t need to be an actual variadic function, match the
-@@ -277,6 +277,7 @@ pub fn test_variadic_fnptr() {
-     let mut s = SipHasher::new();
-     assert_eq!(p.hash(&mut s), q.hash(&mut s));
- }
-+*/
- 
- #[test]
- fn write_unaligned_drop() {
 diff --git a/library/core/tests/slice.rs b/library/core/tests/slice.rs
 index 6609bc3..241b497 100644
 --- a/library/core/tests/slice.rs

--- a/compiler/rustc_hir/src/target.rs
+++ b/compiler/rustc_hir/src/target.rs
@@ -86,7 +86,11 @@ impl Display for Target {
                 Target::Statement => "statement",
                 Target::Arm => "match arm",
                 Target::AssocConst => "associated const",
-                Target::Method(_) => "method",
+                Target::Method(kind) => match kind {
+                    MethodKind::Inherent => "inherent method",
+                    MethodKind::Trait { body: false } => "required trait method",
+                    MethodKind::Trait { body: true } => "provided trait method",
+                },
                 Target::AssocTy => "associated type",
                 Target::ForeignFn => "foreign function",
                 Target::ForeignStatic => "foreign static item",

--- a/library/core/src/async_iter/async_iter.rs
+++ b/library/core/src/async_iter/async_iter.rs
@@ -12,6 +12,7 @@ use crate::task::{Context, Poll};
 /// [impl]: index.html#implementing-async-iterator
 #[unstable(feature = "async_iterator", issue = "79024")]
 #[must_use = "async iterators do nothing unless polled"]
+#[doc(alias = "Stream")]
 pub trait AsyncIterator {
     /// The type of items yielded by the async iterator.
     type Item;

--- a/library/core/src/convert/mod.rs
+++ b/library/core/src/convert/mod.rs
@@ -154,7 +154,7 @@ pub const fn identity<T>(x: T) -> T {
 #[stable(feature = "rust1", since = "1.0.0")]
 #[cfg_attr(not(test), rustc_diagnostic_item = "AsRef")]
 pub trait AsRef<T: ?Sized> {
-    /// Performs the conversion.
+    /// Converts this type into a shared reference of the (usually inferred) input type.
     #[stable(feature = "rust1", since = "1.0.0")]
     fn as_ref(&self) -> &T;
 }
@@ -196,7 +196,7 @@ pub trait AsRef<T: ?Sized> {
 #[stable(feature = "rust1", since = "1.0.0")]
 #[cfg_attr(not(test), rustc_diagnostic_item = "AsMut")]
 pub trait AsMut<T: ?Sized> {
-    /// Performs the conversion.
+    /// Converts this type into a mutable reference of the (usually inferred) input type.
     #[stable(feature = "rust1", since = "1.0.0")]
     fn as_mut(&mut self) -> &mut T;
 }
@@ -272,7 +272,7 @@ pub trait AsMut<T: ?Sized> {
 #[rustc_diagnostic_item = "Into"]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub trait Into<T>: Sized {
-    /// Performs the conversion.
+    /// Converts this type into the (usually inferred) input type.
     #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
     fn into(self) -> T;
@@ -367,7 +367,7 @@ pub trait Into<T>: Sized {
     note = "to coerce a `{T}` into a `{Self}`, use `&*` as a prefix",
 ))]
 pub trait From<T>: Sized {
-    /// Performs the conversion.
+    /// Converts to this type from the input type.
     #[lang = "from"]
     #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]

--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -23,6 +23,7 @@
 #![feature(const_ptr_offset)]
 #![feature(const_trait_impl)]
 #![feature(const_likely)]
+#![feature(core_ffi_c)]
 #![feature(core_intrinsics)]
 #![feature(core_private_bignum)]
 #![feature(core_private_diy_float)]

--- a/src/test/debuginfo/borrowed-basic.rs
+++ b/src/test/debuginfo/borrowed-basic.rs
@@ -1,6 +1,3 @@
-// Gdb doesn't know about UTF-32 character encoding and will print a rust char as only
-// its numerical value.
-
 // compile-flags:-g
 // min-lldb-version: 310
 
@@ -13,7 +10,7 @@
 // gdb-command:print *int_ref
 // gdb-check:$2 = -1
 
-// gdb-command:print *char_ref
+// gdb-command:print/d *char_ref
 // gdb-check:$3 = 97
 
 // gdb-command:print *i8_ref

--- a/src/test/debuginfo/borrowed-unique-basic.rs
+++ b/src/test/debuginfo/borrowed-unique-basic.rs
@@ -1,8 +1,5 @@
 // min-lldb-version: 310
 
-// Gdb doesn't know about UTF-32 character encoding and will print a rust char as only
-// its numerical value.
-
 // compile-flags:-g
 
 // === GDB TESTS ===================================================================================
@@ -15,7 +12,7 @@
 // gdb-command:print *int_ref
 // gdb-check:$2 = -1
 
-// gdb-command:print *char_ref
+// gdb-command:print/d *char_ref
 // gdb-check:$3 = 97
 
 // gdb-command:print/d *i8_ref

--- a/src/test/debuginfo/gdb-char.rs
+++ b/src/test/debuginfo/gdb-char.rs
@@ -1,0 +1,23 @@
+// GDB got support for DW_ATE_UTF in 11.2, see
+// https://sourceware.org/bugzilla/show_bug.cgi?id=28637.
+
+// min-gdb-version: 11.2
+// compile-flags: -g
+
+// === GDB TESTS ===================================================================================
+
+// gdb-command:run
+// gdb-command:print ch
+// gdb-check:$1 = 97 'a'
+
+#![allow(unused_variables)]
+#![feature(omit_gdb_pretty_printer_section)]
+#![omit_gdb_pretty_printer_section]
+
+fn main() {
+    let ch: char = 'a';
+
+    zzz(); // #break
+}
+
+fn zzz() {()}

--- a/src/test/ui/deprecation/feature-gate-deprecated_suggestion.stderr
+++ b/src/test/ui/deprecation/feature-gate-deprecated_suggestion.stderr
@@ -5,7 +5,7 @@ LL | #[deprecated(suggestion = "foo")]
    |              ^^^^^^^^^^^^^^^^^^
    |
    = help: add `#![feature(deprecated_suggestion)]` to the crate root
-   = note: see #XXX for more details
+   = note: see #94785 for more details
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Successful merges:

 - #94052 (Update libc to 0.2.121)
 - #94948 (Fix diagnostics for `#![feature(deprecated_suggestion)]`)
 - #94989 (Add Stream alias for AsyncIterator)
 - #95063 (Fix debuginfo tests with GDB 11.2)
 - #95088 (Don't declare test_variadic_fnptr with two conflicting signatures)
 - #95108 (Give more details in `Display` for `hir::Target`)
 - #95110 (Provide more useful documentation of conversion methods)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=94052,94948,94989,95063,95088,95108,95110)
<!-- homu-ignore:end -->