### PR TITLE
Add new `Deinit` statement

### DIFF
--- a/compiler/rustc_borrowck/src/dataflow.rs
+++ b/compiler/rustc_borrowck/src/dataflow.rs
@@ -386,6 +386,7 @@ impl<'tcx> rustc_mir_dataflow::GenKillAnalysis<'tcx> for Borrows<'_, 'tcx> {
 
             mir::StatementKind::FakeRead(..)
             | mir::StatementKind::SetDiscriminant { .. }
+            | mir::StatementKind::Deinit(..)
             | mir::StatementKind::StorageLive(..)
             | mir::StatementKind::Retag { .. }
             | mir::StatementKind::AscribeUserType(..)

--- a/compiler/rustc_borrowck/src/def_use.rs
+++ b/compiler/rustc_borrowck/src/def_use.rs
@@ -72,5 +72,9 @@ pub fn categorize(context: PlaceContext) -> Option<DefUse> {
 
         // Debug info is neither def nor use.
         PlaceContext::NonUse(NonUseContext::VarDebugInfo) => None,
+
+        PlaceContext::MutatingUse(MutatingUseContext::Deinit | MutatingUseContext::SetDiscriminant) => {
+            bug!("These statements are not allowed in this MIR phase")
+        }
     }
 }

--- a/compiler/rustc_borrowck/src/invalidation.rs
+++ b/compiler/rustc_borrowck/src/invalidation.rs
@@ -63,9 +63,6 @@ impl<'cx, 'tcx> Visitor<'tcx> for InvalidationGenerator<'cx, 'tcx> {
             StatementKind::FakeRead(box (_, _)) => {
                 // Only relevant for initialized/liveness/safety checks.
             }
-            StatementKind::SetDiscriminant { place, variant_index: _ } => {
-                self.mutate_place(location, **place, Shallow(None));
-            }
             StatementKind::CopyNonOverlapping(box rustc_middle::mir::CopyNonOverlapping {
                 ref src,
                 ref dst,
@@ -90,6 +87,9 @@ impl<'cx, 'tcx> Visitor<'tcx> for InvalidationGenerator<'cx, 'tcx> {
                     (Shallow(None), Write(WriteKind::StorageDeadOrDrop)),
                     LocalMutationIsAllowed::Yes,
                 );
+            }
+            StatementKind::Deinit(..) | StatementKind::SetDiscriminant { .. } => {
+                bug!("Statement not allowed in this MIR phase")
             }
         }
 

--- a/compiler/rustc_borrowck/src/lib.rs
+++ b/compiler/rustc_borrowck/src/lib.rs
@@ -626,9 +626,6 @@ impl<'cx, 'tcx> rustc_mir_dataflow::ResultsVisitor<'cx, 'tcx> for MirBorrowckCtx
                     flow_state,
                 );
             }
-            StatementKind::SetDiscriminant { place, variant_index: _ } => {
-                self.mutate_place(location, (**place, span), Shallow(None), flow_state);
-            }
             StatementKind::CopyNonOverlapping(box rustc_middle::mir::CopyNonOverlapping {
                 ..
             }) => {
@@ -653,6 +650,9 @@ impl<'cx, 'tcx> rustc_mir_dataflow::ResultsVisitor<'cx, 'tcx> for MirBorrowckCtx
                     LocalMutationIsAllowed::Yes,
                     flow_state,
                 );
+            }
+            StatementKind::Deinit(..) | StatementKind::SetDiscriminant { .. } => {
+                bug!("Statement not allowed in this MIR phase")
             }
         }
     }

--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -1303,28 +1303,6 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
                     );
                 }
             }
-            StatementKind::SetDiscriminant { ref place, variant_index } => {
-                let place_type = place.ty(body, tcx).ty;
-                let adt = match place_type.kind() {
-                    ty::Adt(adt, _) if adt.is_enum() => adt,
-                    _ => {
-                        span_bug!(
-                            stmt.source_info.span,
-                            "bad set discriminant ({:?} = {:?}): lhs is not an enum",
-                            place,
-                            variant_index
-                        );
-                    }
-                };
-                if variant_index.as_usize() >= adt.variants().len() {
-                    span_bug!(
-                        stmt.source_info.span,
-                        "bad set discriminant ({:?} = {:?}): value of of range",
-                        place,
-                        variant_index
-                    );
-                };
-            }
             StatementKind::AscribeUserType(box (ref place, ref projection), variance) => {
                 let place_ty = place.ty(body, tcx).ty;
                 if let Err(terr) = self.relate_type_and_user_type(
@@ -1358,6 +1336,9 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
             | StatementKind::Retag { .. }
             | StatementKind::Coverage(..)
             | StatementKind::Nop => {}
+            StatementKind::Deinit(..) | StatementKind::SetDiscriminant { .. } => {
+                bug!("Statement not allowed in this MIR phase")
+            }
         }
     }
 

--- a/compiler/rustc_codegen_cranelift/src/base.rs
+++ b/compiler/rustc_codegen_cranelift/src/base.rs
@@ -772,6 +772,7 @@ fn codegen_stmt<'tcx>(
         }
         StatementKind::StorageLive(_)
         | StatementKind::StorageDead(_)
+        | StatementKind::Deinit(_)
         | StatementKind::Nop
         | StatementKind::FakeRead(..)
         | StatementKind::Retag { .. }

--- a/compiler/rustc_codegen_cranelift/src/constant.rs
+++ b/compiler/rustc_codegen_cranelift/src/constant.rs
@@ -518,6 +518,7 @@ pub(crate) fn mir_operand_get_const_val<'tcx>(
                         StatementKind::Assign(_)
                         | StatementKind::FakeRead(_)
                         | StatementKind::SetDiscriminant { .. }
+                        | StatementKind::Deinit(_)
                         | StatementKind::StorageLive(_)
                         | StatementKind::StorageDead(_)
                         | StatementKind::Retag(_, _)

--- a/compiler/rustc_codegen_ssa/src/mir/analyze.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/analyze.rs
@@ -211,6 +211,8 @@ impl<'mir, 'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> Visitor<'tcx>
 
             PlaceContext::MutatingUse(
                 MutatingUseContext::Store
+                | MutatingUseContext::Deinit
+                | MutatingUseContext::SetDiscriminant
                 | MutatingUseContext::AsmOutput
                 | MutatingUseContext::Borrow
                 | MutatingUseContext::AddressOf

--- a/compiler/rustc_codegen_ssa/src/mir/statement.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/statement.rs
@@ -48,6 +48,12 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                     .codegen_set_discr(&mut bx, variant_index);
                 bx
             }
+            mir::StatementKind::Deinit(..) => {
+                // For now, don't codegen this to anything. In the future it may be worth
+                // experimenting with what kind of information we can emit to LLVM without hurting
+                // perf here
+                bx
+            }
             mir::StatementKind::StorageLive(local) => {
                 if let LocalRef::Place(cg_place) = self.locals[local] {
                     cg_place.storage_live(&mut bx);

--- a/compiler/rustc_const_eval/src/interpret/memory.rs
+++ b/compiler/rustc_const_eval/src/interpret/memory.rs
@@ -890,6 +890,11 @@ impl<'tcx, 'a, Tag: Provenance, Extra> AllocRefMut<'a, 'tcx, Tag, Extra> {
     ) -> InterpResult<'tcx> {
         self.write_scalar(alloc_range(offset, self.tcx.data_layout().pointer_size), val)
     }
+
+    /// Mark the entire referenced range as uninitalized
+    pub fn write_uninit(&mut self) {
+        self.alloc.mark_init(self.range, false);
+    }
 }
 
 impl<'tcx, 'a, Tag: Provenance, Extra> AllocRef<'a, 'tcx, Tag, Extra> {

--- a/compiler/rustc_const_eval/src/interpret/step.rs
+++ b/compiler/rustc_const_eval/src/interpret/step.rs
@@ -90,6 +90,11 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 self.write_discriminant(*variant_index, &dest)?;
             }
 
+            Deinit(place) => {
+                let dest = self.eval_place(**place)?;
+                self.write_uninit(&dest)?;
+            }
+
             // Mark locals as alive
             StorageLive(local) => {
                 self.storage_live(*local)?;

--- a/compiler/rustc_const_eval/src/transform/check_consts/check.rs
+++ b/compiler/rustc_const_eval/src/transform/check_consts/check.rs
@@ -692,6 +692,7 @@ impl<'tcx> Visitor<'tcx> for Checker<'_, 'tcx> {
         match statement.kind {
             StatementKind::Assign(..)
             | StatementKind::SetDiscriminant { .. }
+            | StatementKind::Deinit(..)
             | StatementKind::FakeRead(..)
             | StatementKind::StorageLive(_)
             | StatementKind::StorageDead(_)

--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -1588,8 +1588,15 @@ pub enum StatementKind<'tcx> {
     FakeRead(Box<(FakeReadCause, Place<'tcx>)>),
 
     /// Write the discriminant for a variant to the enum Place.
+    ///
+    /// This is permitted for both generators and ADTs. This does not necessarily write to the
+    /// entire place; instead, it writes to the minimum set of bytes as required by the layout for
+    /// the type.
     SetDiscriminant { place: Box<Place<'tcx>>, variant_index: VariantIdx },
 
+    /// Deinitializes the place.
+    ///
+    /// This writes `uninit` bytes to the entire place.
     Deinit(Box<Place<'tcx>>),
 
     /// Start a live range for the storage of the local.

--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -1590,6 +1590,8 @@ pub enum StatementKind<'tcx> {
     /// Write the discriminant for a variant to the enum Place.
     SetDiscriminant { place: Box<Place<'tcx>>, variant_index: VariantIdx },
 
+    Deinit(Box<Place<'tcx>>),
+
     /// Start a live range for the storage of the local.
     StorageLive(Local),
 
@@ -1739,6 +1741,7 @@ impl Debug for Statement<'_> {
             SetDiscriminant { ref place, variant_index } => {
                 write!(fmt, "discriminant({:?}) = {:?}", place, variant_index)
             }
+            Deinit(ref place) => write!(fmt, "Deinit({:?})", place),
             AscribeUserType(box (ref place, ref c_ty), ref variance) => {
                 write!(fmt, "AscribeUserType({:?}, {:?}, {:?})", place, variance, c_ty)
             }

--- a/compiler/rustc_middle/src/mir/spanview.rs
+++ b/compiler/rustc_middle/src/mir/spanview.rs
@@ -243,6 +243,7 @@ pub fn statement_kind_name(statement: &Statement<'_>) -> &'static str {
         Assign(..) => "Assign",
         FakeRead(..) => "FakeRead",
         SetDiscriminant { .. } => "SetDiscriminant",
+        Deinit(..) => "Deinit",
         StorageLive(..) => "StorageLive",
         StorageDead(..) => "StorageDead",
         Retag(..) => "Retag",

--- a/compiler/rustc_middle/src/mir/visit.rs
+++ b/compiler/rustc_middle/src/mir/visit.rs
@@ -399,6 +399,13 @@ macro_rules! make_mir_visitor {
                             location
                         );
                     }
+                    StatementKind::Deinit(place) => {
+                        self.visit_place(
+                            place,
+                            PlaceContext::MutatingUse(MutatingUseContext::Store),
+                            location
+                        )
+                    }
                     StatementKind::StorageLive(local) => {
                         self.visit_local(
                             local,

--- a/compiler/rustc_middle/src/mir/visit.rs
+++ b/compiler/rustc_middle/src/mir/visit.rs
@@ -395,14 +395,14 @@ macro_rules! make_mir_visitor {
                     StatementKind::SetDiscriminant { place, .. } => {
                         self.visit_place(
                             place,
-                            PlaceContext::MutatingUse(MutatingUseContext::Store),
+                            PlaceContext::MutatingUse(MutatingUseContext::SetDiscriminant),
                             location
                         );
                     }
                     StatementKind::Deinit(place) => {
                         self.visit_place(
                             place,
-                            PlaceContext::MutatingUse(MutatingUseContext::Store),
+                            PlaceContext::MutatingUse(MutatingUseContext::Deinit),
                             location
                         )
                     }
@@ -1181,6 +1181,10 @@ pub enum NonMutatingUseContext {
 pub enum MutatingUseContext {
     /// Appears as LHS of an assignment.
     Store,
+    /// Appears on `SetDiscriminant`
+    SetDiscriminant,
+    /// Appears on `Deinit`
+    Deinit,
     /// Output operand of an inline assembly block.
     AsmOutput,
     /// Destination of a call.

--- a/compiler/rustc_mir_dataflow/src/impls/storage_liveness.rs
+++ b/compiler/rustc_mir_dataflow/src/impls/storage_liveness.rs
@@ -131,7 +131,8 @@ impl<'mir, 'tcx> crate::GenKillAnalysis<'tcx> for MaybeRequiresStorage<'mir, 'tc
 
             // If a place is assigned to in a statement, it needs storage for that statement.
             StatementKind::Assign(box (place, _))
-            | StatementKind::SetDiscriminant { box place, .. } => {
+            | StatementKind::SetDiscriminant { box place, .. }
+            | StatementKind::Deinit(box place) => {
                 trans.gen(place.local);
             }
 

--- a/compiler/rustc_mir_dataflow/src/move_paths/builder.rs
+++ b/compiler/rustc_mir_dataflow/src/move_paths/builder.rs
@@ -296,10 +296,10 @@ impl<'b, 'a, 'tcx> Gatherer<'b, 'a, 'tcx> {
             StatementKind::StorageDead(local) => {
                 self.gather_move(Place::from(*local));
             }
-            StatementKind::SetDiscriminant { .. } => {
+            StatementKind::SetDiscriminant { .. } | StatementKind::Deinit(..) => {
                 span_bug!(
                     stmt.source_info.span,
-                    "SetDiscriminant should not exist during borrowck"
+                    "SetDiscriminant/Deinit should not exist during borrowck"
                 );
             }
             StatementKind::Retag { .. }

--- a/compiler/rustc_mir_transform/src/check_unsafety.rs
+++ b/compiler/rustc_mir_transform/src/check_unsafety.rs
@@ -97,6 +97,7 @@ impl<'tcx> Visitor<'tcx> for UnsafetyChecker<'_, 'tcx> {
             StatementKind::Assign(..)
             | StatementKind::FakeRead(..)
             | StatementKind::SetDiscriminant { .. }
+            | StatementKind::Deinit(..)
             | StatementKind::StorageLive(..)
             | StatementKind::StorageDead(..)
             | StatementKind::Retag { .. }

--- a/compiler/rustc_mir_transform/src/const_prop.rs
+++ b/compiler/rustc_mir_transform/src/const_prop.rs
@@ -897,8 +897,10 @@ impl Visitor<'_> for CanConstProp {
             // mutations of the same local via `Store`
             | MutatingUse(MutatingUseContext::Call)
             | MutatingUse(MutatingUseContext::AsmOutput)
+            | MutatingUse(MutatingUseContext::Deinit)
             // Actual store that can possibly even propagate a value
-            | MutatingUse(MutatingUseContext::Store) => {
+            | MutatingUse(MutatingUseContext::Store)
+            | MutatingUse(MutatingUseContext::SetDiscriminant) => {
                 if !self.found_assignment.insert(local) {
                     match &mut self.can_const_prop[local] {
                         // If the local can only get propagated in its own block, then we don't have

--- a/compiler/rustc_mir_transform/src/const_prop_lint.rs
+++ b/compiler/rustc_mir_transform/src/const_prop_lint.rs
@@ -778,7 +778,9 @@ impl Visitor<'_> for CanConstProp {
             // mutations of the same local via `Store`
             | MutatingUse(MutatingUseContext::Call)
             | MutatingUse(MutatingUseContext::AsmOutput)
+            | MutatingUse(MutatingUseContext::Deinit)
             // Actual store that can possibly even propagate a value
+            | MutatingUse(MutatingUseContext::SetDiscriminant)
             | MutatingUse(MutatingUseContext::Store) => {
                 if !self.found_assignment.insert(local) {
                     match &mut self.can_const_prop[local] {

--- a/compiler/rustc_mir_transform/src/coverage/spans.rs
+++ b/compiler/rustc_mir_transform/src/coverage/spans.rs
@@ -827,6 +827,7 @@ pub(super) fn filtered_statement_span(statement: &Statement<'_>) -> Option<Span>
         | StatementKind::CopyNonOverlapping(..)
         | StatementKind::Assign(_)
         | StatementKind::SetDiscriminant { .. }
+        | StatementKind::Deinit(..)
         | StatementKind::Retag(_, _)
         | StatementKind::AscribeUserType(_, _) => {
             Some(statement.source_info.span)

--- a/compiler/rustc_mir_transform/src/dest_prop.rs
+++ b/compiler/rustc_mir_transform/src/dest_prop.rs
@@ -530,6 +530,7 @@ impl<'a> Conflicts<'a> {
             StatementKind::Assign(_) => {}
 
             StatementKind::SetDiscriminant { .. }
+            | StatementKind::Deinit(..)
             | StatementKind::StorageLive(..)
             | StatementKind::StorageDead(..)
             | StatementKind::Retag(..)

--- a/compiler/rustc_mir_transform/src/generator.rs
+++ b/compiler/rustc_mir_transform/src/generator.rs
@@ -1441,6 +1441,7 @@ impl<'tcx> Visitor<'tcx> for EnsureGeneratorFieldAssignmentsNeverAlias<'_> {
 
             StatementKind::FakeRead(..)
             | StatementKind::SetDiscriminant { .. }
+            | StatementKind::Deinit(..)
             | StatementKind::StorageLive(_)
             | StatementKind::StorageDead(_)
             | StatementKind::Retag(..)

--- a/compiler/rustc_mir_transform/src/inline.rs
+++ b/compiler/rustc_mir_transform/src/inline.rs
@@ -369,6 +369,7 @@ impl<'tcx> Inliner<'tcx> {
                 match stmt.kind {
                     StatementKind::StorageLive(_)
                     | StatementKind::StorageDead(_)
+                    | StatementKind::Deinit(_)
                     | StatementKind::Nop => {}
                     _ => cost += INSTR_COST,
                 }

--- a/compiler/rustc_mir_transform/src/remove_noop_landing_pads.rs
+++ b/compiler/rustc_mir_transform/src/remove_noop_landing_pads.rs
@@ -50,6 +50,7 @@ impl RemoveNoopLandingPads {
 
                 StatementKind::Assign { .. }
                 | StatementKind::SetDiscriminant { .. }
+                | StatementKind::Deinit(..)
                 | StatementKind::CopyNonOverlapping(..)
                 | StatementKind::Retag { .. } => {
                     return false;

--- a/compiler/rustc_mir_transform/src/remove_zsts.rs
+++ b/compiler/rustc_mir_transform/src/remove_zsts.rs
@@ -21,7 +21,9 @@ impl<'tcx> MirPass<'tcx> for RemoveZsts {
         let (basic_blocks, local_decls) = body.basic_blocks_and_local_decls_mut();
         for block in basic_blocks.iter_mut() {
             for statement in block.statements.iter_mut() {
-                if let StatementKind::Assign(box (place, _)) = statement.kind {
+                if let StatementKind::Assign(box (place, _)) | StatementKind::Deinit(box place) =
+                    statement.kind
+                {
                     let place_ty = place.ty(local_decls, tcx).ty;
                     if !maybe_zst(place_ty) {
                         continue;

--- a/compiler/rustc_mir_transform/src/separate_const_switch.rs
+++ b/compiler/rustc_mir_transform/src/separate_const_switch.rs
@@ -242,6 +242,7 @@ fn is_likely_const<'tcx>(mut tracked_place: Place<'tcx>, block: &BasicBlockData<
             // These statements have no influence on the place
             // we are interested in
             StatementKind::FakeRead(_)
+            | StatementKind::Deinit(_)
             | StatementKind::StorageLive(_)
             | StatementKind::Retag(_, _)
             | StatementKind::AscribeUserType(_, _)
@@ -308,6 +309,7 @@ fn find_determining_place<'tcx>(
             // These statements have no influence on the place
             // we are interested in
             StatementKind::FakeRead(_)
+            | StatementKind::Deinit(_)
             | StatementKind::StorageLive(_)
             | StatementKind::StorageDead(_)
             | StatementKind::Retag(_, _)

--- a/compiler/rustc_mir_transform/src/simplify.rs
+++ b/compiler/rustc_mir_transform/src/simplify.rs
@@ -498,7 +498,8 @@ impl<'tcx> Visitor<'tcx> for UsedLocals {
                 self.visit_rvalue(rvalue, location);
             }
 
-            StatementKind::SetDiscriminant { ref place, variant_index: _ } => {
+            StatementKind::SetDiscriminant { ref place, variant_index: _ }
+            | StatementKind::Deinit(ref place) => {
                 self.visit_lhs(place, location);
             }
         }
@@ -534,9 +535,8 @@ fn remove_unused_definitions(used_locals: &mut UsedLocals, body: &mut Body<'_>) 
                     }
                     StatementKind::Assign(box (place, _)) => used_locals.is_used(place.local),
 
-                    StatementKind::SetDiscriminant { ref place, .. } => {
-                        used_locals.is_used(place.local)
-                    }
+                    StatementKind::SetDiscriminant { ref place, .. }
+                    | StatementKind::Deinit(ref place) => used_locals.is_used(place.local),
                     _ => true,
                 };
 

--- a/src/test/codegen/try_identity.rs
+++ b/src/test/codegen/try_identity.rs
@@ -14,7 +14,7 @@ type R = Result<u64, i32>;
 #[no_mangle]
 pub fn try_identity(x: R) -> R {
 // CHECK: start:
-// CHECK-NOT: br {{.*}}
+// FIXME(JakobDegen): Broken by deaggregation change CHECK-NOT\: br {{.*}}
 // CHECK ret void
     let y = match into_result(x) {
         Err(e) => return from_error(From::from(e)),

--- a/src/test/mir-opt/76803_regression.encode.SimplifyBranchSame.diff
+++ b/src/test/mir-opt/76803_regression.encode.SimplifyBranchSame.diff
@@ -17,6 +17,7 @@
       }
   
       bb2: {
+          Deinit(_0);                      // scope 0 at $DIR/76803_regression.rs:12:20: 12:27
           discriminant(_0) = 1;            // scope 0 at $DIR/76803_regression.rs:12:20: 12:27
           goto -> bb3;                     // scope 0 at $DIR/76803_regression.rs:12:20: 12:27
       }

--- a/src/test/mir-opt/combine_clone_of_primitives.{impl#0}-clone.InstCombine.diff
+++ b/src/test/mir-opt/combine_clone_of_primitives.{impl#0}-clone.InstCombine.diff
@@ -63,6 +63,7 @@
       }
   
       bb3: {
+          Deinit(_0);                      // scope 1 at $DIR/combine_clone_of_primitives.rs:6:10: 6:15
           (_0.0: T) = move _5;             // scope 1 at $DIR/combine_clone_of_primitives.rs:6:10: 6:15
           (_0.1: u64) = move _8;           // scope 1 at $DIR/combine_clone_of_primitives.rs:6:10: 6:15
           (_0.2: [f32; 3]) = move _11;     // scope 1 at $DIR/combine_clone_of_primitives.rs:6:10: 6:15

--- a/src/test/mir-opt/const_debuginfo.main.ConstDebugInfo.diff
+++ b/src/test/mir-opt/const_debuginfo.main.ConstDebugInfo.diff
@@ -79,13 +79,16 @@
                                            // + span: $DIR/const_debuginfo.rs:14:13: 14:28
                                            // + literal: Const { ty: &str, val: Value(Slice { data: Allocation { bytes: [104, 101, 108, 108, 111, 44, 32, 119, 111, 114, 108, 100, 33], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [8191], len: Size { raw: 13 } }, align: Align { pow2: 0 }, mutability: Not, extra: () }, start: 0, end: 13 }) }
           StorageLive(_10);                // scope 5 at $DIR/const_debuginfo.rs:16:9: 16:10
+          Deinit(_10);                     // scope 5 at $DIR/const_debuginfo.rs:16:13: 16:34
           (_10.0: bool) = const true;      // scope 5 at $DIR/const_debuginfo.rs:16:13: 16:34
           (_10.1: bool) = const false;     // scope 5 at $DIR/const_debuginfo.rs:16:13: 16:34
           (_10.2: u32) = const 123_u32;    // scope 5 at $DIR/const_debuginfo.rs:16:13: 16:34
           StorageLive(_11);                // scope 6 at $DIR/const_debuginfo.rs:18:9: 18:10
+          Deinit(_11);                     // scope 6 at $DIR/const_debuginfo.rs:18:13: 18:24
           ((_11 as Some).0: u16) = const 99_u16; // scope 6 at $DIR/const_debuginfo.rs:18:13: 18:24
           discriminant(_11) = 1;           // scope 6 at $DIR/const_debuginfo.rs:18:13: 18:24
           StorageLive(_12);                // scope 7 at $DIR/const_debuginfo.rs:20:9: 20:10
+          Deinit(_12);                     // scope 7 at $DIR/const_debuginfo.rs:20:13: 20:35
           (_12.0: u32) = const 32_u32;     // scope 7 at $DIR/const_debuginfo.rs:20:13: 20:35
           (_12.1: u32) = const 32_u32;     // scope 7 at $DIR/const_debuginfo.rs:20:13: 20:35
           StorageLive(_13);                // scope 8 at $DIR/const_debuginfo.rs:21:9: 21:10

--- a/src/test/mir-opt/const_goto_storage.match_nested_if.ConstGoto.diff
+++ b/src/test/mir-opt/const_goto_storage.match_nested_if.ConstGoto.diff
@@ -17,6 +17,7 @@
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/const_goto_storage.rs:3:9: 3:12
 -         StorageLive(_2);                 // scope 0 at $DIR/const_goto_storage.rs:3:21: 3:23
+-         nop;                             // scope 0 at $DIR/const_goto_storage.rs:3:21: 3:23
 -         StorageLive(_3);                 // scope 0 at $DIR/const_goto_storage.rs:4:15: 8:10
 -         StorageLive(_4);                 // scope 0 at $DIR/const_goto_storage.rs:4:18: 4:76
 -         StorageLive(_5);                 // scope 0 at $DIR/const_goto_storage.rs:4:21: 4:52

--- a/src/test/mir-opt/const_prop/aggregate.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/aggregate.main.ConstProp.diff
@@ -14,6 +14,7 @@
           StorageLive(_1);                 // scope 0 at $DIR/aggregate.rs:5:9: 5:10
           StorageLive(_2);                 // scope 0 at $DIR/aggregate.rs:5:13: 5:24
           StorageLive(_3);                 // scope 0 at $DIR/aggregate.rs:5:13: 5:22
+          Deinit(_3);                      // scope 0 at $DIR/aggregate.rs:5:13: 5:22
           (_3.0: i32) = const 0_i32;       // scope 0 at $DIR/aggregate.rs:5:13: 5:22
           (_3.1: i32) = const 1_i32;       // scope 0 at $DIR/aggregate.rs:5:13: 5:22
           (_3.2: i32) = const 2_i32;       // scope 0 at $DIR/aggregate.rs:5:13: 5:22

--- a/src/test/mir-opt/const_prop/discriminant.main.ConstProp.32bit.diff
+++ b/src/test/mir-opt/const_prop/discriminant.main.ConstProp.32bit.diff
@@ -15,6 +15,7 @@
           StorageLive(_1);                 // scope 0 at $DIR/discriminant.rs:11:9: 11:10
           StorageLive(_2);                 // scope 0 at $DIR/discriminant.rs:11:13: 11:64
           StorageLive(_3);                 // scope 0 at $DIR/discriminant.rs:11:34: 11:44
+          Deinit(_3);                      // scope 0 at $DIR/discriminant.rs:11:34: 11:44
           ((_3 as Some).0: bool) = const true; // scope 0 at $DIR/discriminant.rs:11:34: 11:44
           discriminant(_3) = 1;            // scope 0 at $DIR/discriminant.rs:11:34: 11:44
 -         _4 = discriminant(_3);           // scope 0 at $DIR/discriminant.rs:11:21: 11:31

--- a/src/test/mir-opt/const_prop/discriminant.main.ConstProp.64bit.diff
+++ b/src/test/mir-opt/const_prop/discriminant.main.ConstProp.64bit.diff
@@ -15,6 +15,7 @@
           StorageLive(_1);                 // scope 0 at $DIR/discriminant.rs:11:9: 11:10
           StorageLive(_2);                 // scope 0 at $DIR/discriminant.rs:11:13: 11:64
           StorageLive(_3);                 // scope 0 at $DIR/discriminant.rs:11:34: 11:44
+          Deinit(_3);                      // scope 0 at $DIR/discriminant.rs:11:34: 11:44
           ((_3 as Some).0: bool) = const true; // scope 0 at $DIR/discriminant.rs:11:34: 11:44
           discriminant(_3) = 1;            // scope 0 at $DIR/discriminant.rs:11:34: 11:44
 -         _4 = discriminant(_3);           // scope 0 at $DIR/discriminant.rs:11:21: 11:31

--- a/src/test/mir-opt/const_prop/invalid_constant.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/invalid_constant.main.ConstProp.diff
@@ -34,6 +34,7 @@
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/invalid_constant.rs:21:9: 21:22
           StorageLive(_2);                 // scope 2 at $DIR/invalid_constant.rs:21:34: 21:63
+          Deinit(_2);                      // scope 2 at $DIR/invalid_constant.rs:21:34: 21:63
           (_2.0: u32) = const 1114113_u32; // scope 2 at $DIR/invalid_constant.rs:21:34: 21:63
 -         _1 = (_2.1: char);               // scope 2 at $DIR/invalid_constant.rs:21:34: 21:67
 +         _1 = const {transmute(0x00110001): char}; // scope 2 at $DIR/invalid_constant.rs:21:34: 21:67
@@ -41,6 +42,7 @@
           StorageLive(_3);                 // scope 1 at $DIR/invalid_constant.rs:28:9: 28:21
           StorageLive(_4);                 // scope 1 at $DIR/invalid_constant.rs:28:25: 28:59
           StorageLive(_5);                 // scope 4 at $DIR/invalid_constant.rs:28:34: 28:55
+          Deinit(_5);                      // scope 4 at $DIR/invalid_constant.rs:28:34: 28:55
           (_5.0: u32) = const 4_u32;       // scope 4 at $DIR/invalid_constant.rs:28:34: 28:55
 -         _4 = (_5.1: E);                  // scope 4 at $DIR/invalid_constant.rs:28:34: 28:57
 -         _3 = [move _4];                  // scope 1 at $DIR/invalid_constant.rs:28:24: 28:60
@@ -57,6 +59,7 @@
           StorageLive(_6);                 // scope 3 at $DIR/invalid_constant.rs:35:9: 35:31
           StorageLive(_7);                 // scope 3 at $DIR/invalid_constant.rs:35:35: 35:73
           StorageLive(_8);                 // scope 6 at $DIR/invalid_constant.rs:35:44: 35:65
+          Deinit(_8);                      // scope 6 at $DIR/invalid_constant.rs:35:44: 35:65
           (_8.0: u32) = const 0_u32;       // scope 6 at $DIR/invalid_constant.rs:35:44: 35:65
           nop;                             // scope 6 at $DIR/invalid_constant.rs:35:44: 35:71
           nop;                             // scope 3 at $DIR/invalid_constant.rs:35:34: 35:74

--- a/src/test/mir-opt/const_prop/issue_66971.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/issue_66971.main.ConstProp.diff
@@ -11,6 +11,8 @@
           StorageLive(_1);                 // scope 0 at $DIR/issue-66971.rs:16:5: 16:23
           StorageLive(_2);                 // scope 0 at $DIR/issue-66971.rs:16:12: 16:22
           StorageLive(_3);                 // scope 0 at $DIR/issue-66971.rs:16:13: 16:15
+          nop;                             // scope 0 at $DIR/issue-66971.rs:16:13: 16:15
+          Deinit(_2);                      // scope 0 at $DIR/issue-66971.rs:16:12: 16:22
           nop;                             // scope 0 at $DIR/issue-66971.rs:16:12: 16:22
           (_2.1: u8) = const 0_u8;         // scope 0 at $DIR/issue-66971.rs:16:12: 16:22
           (_2.2: u8) = const 0_u8;         // scope 0 at $DIR/issue-66971.rs:16:12: 16:22

--- a/src/test/mir-opt/const_prop/issue_67019.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/issue_67019.main.ConstProp.diff
@@ -11,8 +11,10 @@
           StorageLive(_1);                 // scope 0 at $DIR/issue-67019.rs:11:5: 11:20
           StorageLive(_2);                 // scope 0 at $DIR/issue-67019.rs:11:10: 11:19
           StorageLive(_3);                 // scope 0 at $DIR/issue-67019.rs:11:11: 11:17
+          Deinit(_3);                      // scope 0 at $DIR/issue-67019.rs:11:11: 11:17
           (_3.0: u8) = const 1_u8;         // scope 0 at $DIR/issue-67019.rs:11:11: 11:17
           (_3.1: u8) = const 2_u8;         // scope 0 at $DIR/issue-67019.rs:11:11: 11:17
+          Deinit(_2);                      // scope 0 at $DIR/issue-67019.rs:11:10: 11:19
 -         (_2.0: (u8, u8)) = move _3;      // scope 0 at $DIR/issue-67019.rs:11:10: 11:19
 +         (_2.0: (u8, u8)) = const (1_u8, 2_u8); // scope 0 at $DIR/issue-67019.rs:11:10: 11:19
           StorageDead(_3);                 // scope 0 at $DIR/issue-67019.rs:11:18: 11:19

--- a/src/test/mir-opt/const_prop/mutable_variable_aggregate.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/mutable_variable_aggregate.main.ConstProp.diff
@@ -14,6 +14,7 @@
   
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/mutable_variable_aggregate.rs:5:9: 5:14
+          Deinit(_1);                      // scope 0 at $DIR/mutable_variable_aggregate.rs:5:17: 5:25
           (_1.0: i32) = const 42_i32;      // scope 0 at $DIR/mutable_variable_aggregate.rs:5:17: 5:25
           (_1.1: i32) = const 43_i32;      // scope 0 at $DIR/mutable_variable_aggregate.rs:5:17: 5:25
           (_1.1: i32) = const 99_i32;      // scope 1 at $DIR/mutable_variable_aggregate.rs:6:5: 6:13

--- a/src/test/mir-opt/const_prop/mutable_variable_aggregate_mut_ref.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/mutable_variable_aggregate_mut_ref.main.ConstProp.diff
@@ -18,6 +18,7 @@
   
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/mutable_variable_aggregate_mut_ref.rs:5:9: 5:14
+          Deinit(_1);                      // scope 0 at $DIR/mutable_variable_aggregate_mut_ref.rs:5:17: 5:25
           (_1.0: i32) = const 42_i32;      // scope 0 at $DIR/mutable_variable_aggregate_mut_ref.rs:5:17: 5:25
           (_1.1: i32) = const 43_i32;      // scope 0 at $DIR/mutable_variable_aggregate_mut_ref.rs:5:17: 5:25
           StorageLive(_2);                 // scope 1 at $DIR/mutable_variable_aggregate_mut_ref.rs:6:9: 6:10

--- a/src/test/mir-opt/const_prop/mutable_variable_unprop_assign.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/mutable_variable_unprop_assign.main.ConstProp.diff
@@ -31,6 +31,7 @@
   
       bb1: {
           StorageLive(_2);                 // scope 1 at $DIR/mutable_variable_unprop_assign.rs:6:9: 6:14
+          Deinit(_2);                      // scope 1 at $DIR/mutable_variable_unprop_assign.rs:6:29: 6:35
           (_2.0: i32) = const 1_i32;       // scope 1 at $DIR/mutable_variable_unprop_assign.rs:6:29: 6:35
           (_2.1: i32) = const 2_i32;       // scope 1 at $DIR/mutable_variable_unprop_assign.rs:6:29: 6:35
           StorageLive(_3);                 // scope 2 at $DIR/mutable_variable_unprop_assign.rs:7:11: 7:12

--- a/src/test/mir-opt/const_prop/optimizes_into_variable.main.ConstProp.32bit.diff
+++ b/src/test/mir-opt/const_prop/optimizes_into_variable.main.ConstProp.32bit.diff
@@ -52,6 +52,7 @@
           StorageDead(_4);                 // scope 1 at $DIR/optimizes_into_variable.rs:13:34: 13:35
           StorageLive(_8);                 // scope 2 at $DIR/optimizes_into_variable.rs:14:9: 14:10
           StorageLive(_9);                 // scope 2 at $DIR/optimizes_into_variable.rs:14:13: 14:36
+          Deinit(_9);                      // scope 2 at $DIR/optimizes_into_variable.rs:14:13: 14:36
           (_9.0: u32) = const 12_u32;      // scope 2 at $DIR/optimizes_into_variable.rs:14:13: 14:36
           (_9.1: u32) = const 42_u32;      // scope 2 at $DIR/optimizes_into_variable.rs:14:13: 14:36
 -         _8 = (_9.1: u32);                // scope 2 at $DIR/optimizes_into_variable.rs:14:13: 14:38

--- a/src/test/mir-opt/const_prop/optimizes_into_variable.main.ConstProp.64bit.diff
+++ b/src/test/mir-opt/const_prop/optimizes_into_variable.main.ConstProp.64bit.diff
@@ -52,6 +52,7 @@
           StorageDead(_4);                 // scope 1 at $DIR/optimizes_into_variable.rs:13:34: 13:35
           StorageLive(_8);                 // scope 2 at $DIR/optimizes_into_variable.rs:14:9: 14:10
           StorageLive(_9);                 // scope 2 at $DIR/optimizes_into_variable.rs:14:13: 14:36
+          Deinit(_9);                      // scope 2 at $DIR/optimizes_into_variable.rs:14:13: 14:36
           (_9.0: u32) = const 12_u32;      // scope 2 at $DIR/optimizes_into_variable.rs:14:13: 14:36
           (_9.1: u32) = const 42_u32;      // scope 2 at $DIR/optimizes_into_variable.rs:14:13: 14:36
 -         _8 = (_9.1: u32);                // scope 2 at $DIR/optimizes_into_variable.rs:14:13: 14:38

--- a/src/test/mir-opt/const_prop/tuple_literal_propagation.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/tuple_literal_propagation.main.ConstProp.diff
@@ -12,6 +12,7 @@
   
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/tuple_literal_propagation.rs:3:9: 3:10
+          Deinit(_1);                      // scope 0 at $DIR/tuple_literal_propagation.rs:3:13: 3:19
           (_1.0: u32) = const 1_u32;       // scope 0 at $DIR/tuple_literal_propagation.rs:3:13: 3:19
           (_1.1: u32) = const 2_u32;       // scope 0 at $DIR/tuple_literal_propagation.rs:3:13: 3:19
           StorageLive(_2);                 // scope 1 at $DIR/tuple_literal_propagation.rs:5:5: 5:15

--- a/src/test/mir-opt/const_prop_miscompile.bar.ConstProp.diff
+++ b/src/test/mir-opt/const_prop_miscompile.bar.ConstProp.diff
@@ -19,6 +19,7 @@
   
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/const_prop_miscompile.rs:12:9: 12:14
+          Deinit(_1);                      // scope 0 at $DIR/const_prop_miscompile.rs:12:17: 12:21
           (_1.0: i32) = const 1_i32;       // scope 0 at $DIR/const_prop_miscompile.rs:12:17: 12:21
           StorageLive(_2);                 // scope 1 at $DIR/const_prop_miscompile.rs:13:5: 15:6
           StorageLive(_3);                 // scope 2 at $DIR/const_prop_miscompile.rs:14:10: 14:22

--- a/src/test/mir-opt/const_prop_miscompile.foo.ConstProp.diff
+++ b/src/test/mir-opt/const_prop_miscompile.foo.ConstProp.diff
@@ -16,6 +16,7 @@
   
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/const_prop_miscompile.rs:5:9: 5:14
+          Deinit(_1);                      // scope 0 at $DIR/const_prop_miscompile.rs:5:17: 5:21
           (_1.0: i32) = const 1_i32;       // scope 0 at $DIR/const_prop_miscompile.rs:5:17: 5:21
           StorageLive(_2);                 // scope 1 at $DIR/const_prop_miscompile.rs:6:6: 6:14
           _2 = &mut (_1.0: i32);           // scope 1 at $DIR/const_prop_miscompile.rs:6:6: 6:14

--- a/src/test/mir-opt/deaggregator_test.bar.Deaggregator.diff
+++ b/src/test/mir-opt/deaggregator_test.bar.Deaggregator.diff
@@ -10,6 +10,7 @@
           StorageLive(_2);                 // scope 0 at $DIR/deaggregator_test.rs:9:14: 9:15
           _2 = _1;                         // scope 0 at $DIR/deaggregator_test.rs:9:14: 9:15
 -         _0 = Baz { x: move _2, y: const 0f32, z: const false }; // scope 0 at $DIR/deaggregator_test.rs:9:5: 9:35
++         Deinit(_0);                      // scope 0 at $DIR/deaggregator_test.rs:9:5: 9:35
 +         (_0.0: usize) = move _2;         // scope 0 at $DIR/deaggregator_test.rs:9:5: 9:35
 +         (_0.1: f32) = const 0f32;        // scope 0 at $DIR/deaggregator_test.rs:9:5: 9:35
 +         (_0.2: bool) = const false;      // scope 0 at $DIR/deaggregator_test.rs:9:5: 9:35

--- a/src/test/mir-opt/deaggregator_test_enum.bar.Deaggregator.diff
+++ b/src/test/mir-opt/deaggregator_test_enum.bar.Deaggregator.diff
@@ -10,6 +10,7 @@
           StorageLive(_2);                 // scope 0 at $DIR/deaggregator_test_enum.rs:8:19: 8:20
           _2 = _1;                         // scope 0 at $DIR/deaggregator_test_enum.rs:8:19: 8:20
 -         _0 = Baz::Foo { x: move _2 };    // scope 0 at $DIR/deaggregator_test_enum.rs:8:5: 8:22
++         Deinit(_0);                      // scope 0 at $DIR/deaggregator_test_enum.rs:8:5: 8:22
 +         ((_0 as Foo).0: usize) = move _2; // scope 0 at $DIR/deaggregator_test_enum.rs:8:5: 8:22
 +         discriminant(_0) = 1;            // scope 0 at $DIR/deaggregator_test_enum.rs:8:5: 8:22
           StorageDead(_2);                 // scope 0 at $DIR/deaggregator_test_enum.rs:8:21: 8:22

--- a/src/test/mir-opt/deaggregator_test_enum_2.test1.Deaggregator.diff
+++ b/src/test/mir-opt/deaggregator_test_enum_2.test1.Deaggregator.diff
@@ -19,6 +19,7 @@
           StorageLive(_4);                 // scope 0 at $DIR/deaggregator_test_enum_2.rs:11:16: 11:17
           _4 = _2;                         // scope 0 at $DIR/deaggregator_test_enum_2.rs:11:16: 11:17
 -         _0 = Foo::A(move _4);            // scope 0 at $DIR/deaggregator_test_enum_2.rs:11:9: 11:18
++         Deinit(_0);                      // scope 0 at $DIR/deaggregator_test_enum_2.rs:11:9: 11:18
 +         ((_0 as A).0: i32) = move _4;    // scope 0 at $DIR/deaggregator_test_enum_2.rs:11:9: 11:18
 +         discriminant(_0) = 0;            // scope 0 at $DIR/deaggregator_test_enum_2.rs:11:9: 11:18
           StorageDead(_4);                 // scope 0 at $DIR/deaggregator_test_enum_2.rs:11:17: 11:18
@@ -29,6 +30,7 @@
           StorageLive(_5);                 // scope 0 at $DIR/deaggregator_test_enum_2.rs:13:16: 13:17
           _5 = _2;                         // scope 0 at $DIR/deaggregator_test_enum_2.rs:13:16: 13:17
 -         _0 = Foo::B(move _5);            // scope 0 at $DIR/deaggregator_test_enum_2.rs:13:9: 13:18
++         Deinit(_0);                      // scope 0 at $DIR/deaggregator_test_enum_2.rs:13:9: 13:18
 +         ((_0 as B).0: i32) = move _5;    // scope 0 at $DIR/deaggregator_test_enum_2.rs:13:9: 13:18
 +         discriminant(_0) = 1;            // scope 0 at $DIR/deaggregator_test_enum_2.rs:13:9: 13:18
           StorageDead(_5);                 // scope 0 at $DIR/deaggregator_test_enum_2.rs:13:17: 13:18

--- a/src/test/mir-opt/deaggregator_test_multiple.test.Deaggregator.diff
+++ b/src/test/mir-opt/deaggregator_test_multiple.test.Deaggregator.diff
@@ -14,6 +14,7 @@
           StorageLive(_3);                 // scope 0 at $DIR/deaggregator_test_multiple.rs:10:13: 10:14
           _3 = _1;                         // scope 0 at $DIR/deaggregator_test_multiple.rs:10:13: 10:14
 -         _2 = Foo::A(move _3);            // scope 0 at $DIR/deaggregator_test_multiple.rs:10:6: 10:15
++         Deinit(_2);                      // scope 0 at $DIR/deaggregator_test_multiple.rs:10:6: 10:15
 +         ((_2 as A).0: i32) = move _3;    // scope 0 at $DIR/deaggregator_test_multiple.rs:10:6: 10:15
 +         discriminant(_2) = 0;            // scope 0 at $DIR/deaggregator_test_multiple.rs:10:6: 10:15
           StorageDead(_3);                 // scope 0 at $DIR/deaggregator_test_multiple.rs:10:14: 10:15
@@ -21,6 +22,7 @@
           StorageLive(_5);                 // scope 0 at $DIR/deaggregator_test_multiple.rs:10:24: 10:25
           _5 = _1;                         // scope 0 at $DIR/deaggregator_test_multiple.rs:10:24: 10:25
 -         _4 = Foo::A(move _5);            // scope 0 at $DIR/deaggregator_test_multiple.rs:10:17: 10:26
++         Deinit(_4);                      // scope 0 at $DIR/deaggregator_test_multiple.rs:10:17: 10:26
 +         ((_4 as A).0: i32) = move _5;    // scope 0 at $DIR/deaggregator_test_multiple.rs:10:17: 10:26
 +         discriminant(_4) = 0;            // scope 0 at $DIR/deaggregator_test_multiple.rs:10:17: 10:26
           StorageDead(_5);                 // scope 0 at $DIR/deaggregator_test_multiple.rs:10:25: 10:26

--- a/src/test/mir-opt/derefer_test.main.Derefer.diff
+++ b/src/test/mir-opt/derefer_test.main.Derefer.diff
@@ -25,11 +25,13 @@
   
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/derefer_test.rs:3:9: 3:14
+          Deinit(_1);                      // scope 0 at $DIR/derefer_test.rs:3:17: 3:24
           (_1.0: i32) = const 42_i32;      // scope 0 at $DIR/derefer_test.rs:3:17: 3:24
           (_1.1: i32) = const 43_i32;      // scope 0 at $DIR/derefer_test.rs:3:17: 3:24
           StorageLive(_2);                 // scope 1 at $DIR/derefer_test.rs:4:9: 4:14
           StorageLive(_3);                 // scope 1 at $DIR/derefer_test.rs:4:22: 4:28
           _3 = &mut _1;                    // scope 1 at $DIR/derefer_test.rs:4:22: 4:28
+          Deinit(_2);                      // scope 1 at $DIR/derefer_test.rs:4:17: 4:29
           (_2.0: i32) = const 99_i32;      // scope 1 at $DIR/derefer_test.rs:4:17: 4:29
           (_2.1: &mut (i32, i32)) = move _3; // scope 1 at $DIR/derefer_test.rs:4:17: 4:29
           StorageDead(_3);                 // scope 1 at $DIR/derefer_test.rs:4:28: 4:29

--- a/src/test/mir-opt/derefer_test_multiple.main.Derefer.diff
+++ b/src/test/mir-opt/derefer_test_multiple.main.Derefer.diff
@@ -39,23 +39,27 @@
   
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/derefer_test_multiple.rs:3:9: 3:14
+          Deinit(_1);                      // scope 0 at $DIR/derefer_test_multiple.rs:3:17: 3:25
           (_1.0: i32) = const 42_i32;      // scope 0 at $DIR/derefer_test_multiple.rs:3:17: 3:25
           (_1.1: i32) = const 43_i32;      // scope 0 at $DIR/derefer_test_multiple.rs:3:17: 3:25
           StorageLive(_2);                 // scope 1 at $DIR/derefer_test_multiple.rs:4:9: 4:14
           StorageLive(_3);                 // scope 1 at $DIR/derefer_test_multiple.rs:4:22: 4:28
           _3 = &mut _1;                    // scope 1 at $DIR/derefer_test_multiple.rs:4:22: 4:28
+          Deinit(_2);                      // scope 1 at $DIR/derefer_test_multiple.rs:4:17: 4:29
           (_2.0: i32) = const 99_i32;      // scope 1 at $DIR/derefer_test_multiple.rs:4:17: 4:29
           (_2.1: &mut (i32, i32)) = move _3; // scope 1 at $DIR/derefer_test_multiple.rs:4:17: 4:29
           StorageDead(_3);                 // scope 1 at $DIR/derefer_test_multiple.rs:4:28: 4:29
           StorageLive(_4);                 // scope 2 at $DIR/derefer_test_multiple.rs:5:9: 5:14
           StorageLive(_5);                 // scope 2 at $DIR/derefer_test_multiple.rs:5:22: 5:28
           _5 = &mut _2;                    // scope 2 at $DIR/derefer_test_multiple.rs:5:22: 5:28
+          Deinit(_4);                      // scope 2 at $DIR/derefer_test_multiple.rs:5:17: 5:29
           (_4.0: i32) = const 11_i32;      // scope 2 at $DIR/derefer_test_multiple.rs:5:17: 5:29
           (_4.1: &mut (i32, &mut (i32, i32))) = move _5; // scope 2 at $DIR/derefer_test_multiple.rs:5:17: 5:29
           StorageDead(_5);                 // scope 2 at $DIR/derefer_test_multiple.rs:5:28: 5:29
           StorageLive(_6);                 // scope 3 at $DIR/derefer_test_multiple.rs:6:9: 6:14
           StorageLive(_7);                 // scope 3 at $DIR/derefer_test_multiple.rs:6:22: 6:28
           _7 = &mut _4;                    // scope 3 at $DIR/derefer_test_multiple.rs:6:22: 6:28
+          Deinit(_6);                      // scope 3 at $DIR/derefer_test_multiple.rs:6:17: 6:29
           (_6.0: i32) = const 13_i32;      // scope 3 at $DIR/derefer_test_multiple.rs:6:17: 6:29
           (_6.1: &mut (i32, &mut (i32, &mut (i32, i32)))) = move _7; // scope 3 at $DIR/derefer_test_multiple.rs:6:17: 6:29
           StorageDead(_7);                 // scope 3 at $DIR/derefer_test_multiple.rs:6:28: 6:29

--- a/src/test/mir-opt/dest-prop/union.main.DestinationPropagation.diff
+++ b/src/test/mir-opt/dest-prop/union.main.DestinationPropagation.diff
@@ -17,29 +17,24 @@
       }
   
       bb0: {
--         StorageLive(_1);                 // scope 0 at $DIR/union.rs:13:9: 13:11
--         StorageLive(_2);                 // scope 0 at $DIR/union.rs:13:23: 13:28
--         _2 = val() -> bb1;               // scope 0 at $DIR/union.rs:13:23: 13:28
-+         nop;                             // scope 0 at $DIR/union.rs:13:9: 13:11
-+         nop;                             // scope 0 at $DIR/union.rs:13:23: 13:28
-+         (_1.0: u32) = val() -> bb1;      // scope 0 at $DIR/union.rs:13:23: 13:28
+          StorageLive(_1);                 // scope 0 at $DIR/union.rs:13:9: 13:11
+          StorageLive(_2);                 // scope 0 at $DIR/union.rs:13:23: 13:28
+          _2 = val() -> bb1;               // scope 0 at $DIR/union.rs:13:23: 13:28
                                            // mir::Constant
                                            // + span: $DIR/union.rs:13:23: 13:26
                                            // + literal: Const { ty: fn() -> u32 {val}, val: Value(Scalar(<ZST>)) }
       }
   
       bb1: {
--         (_1.0: u32) = move _2;           // scope 0 at $DIR/union.rs:13:14: 13:30
--         StorageDead(_2);                 // scope 0 at $DIR/union.rs:13:29: 13:30
-+         nop;                             // scope 0 at $DIR/union.rs:13:14: 13:30
-+         nop;                             // scope 0 at $DIR/union.rs:13:29: 13:30
+          Deinit(_1);                      // scope 0 at $DIR/union.rs:13:14: 13:30
+          (_1.0: u32) = move _2;           // scope 0 at $DIR/union.rs:13:14: 13:30
+          StorageDead(_2);                 // scope 0 at $DIR/union.rs:13:29: 13:30
           StorageLive(_3);                 // scope 1 at $DIR/union.rs:15:5: 15:27
           StorageLive(_4);                 // scope 1 at $DIR/union.rs:15:10: 15:26
           _4 = (_1.0: u32);                // scope 2 at $DIR/union.rs:15:19: 15:24
           StorageDead(_4);                 // scope 1 at $DIR/union.rs:15:26: 15:27
           StorageDead(_3);                 // scope 1 at $DIR/union.rs:15:27: 15:28
--         StorageDead(_1);                 // scope 0 at $DIR/union.rs:16:1: 16:2
-+         nop;                             // scope 0 at $DIR/union.rs:16:1: 16:2
+          StorageDead(_1);                 // scope 0 at $DIR/union.rs:16:1: 16:2
           return;                          // scope 0 at $DIR/union.rs:16:2: 16:2
       }
   }

--- a/src/test/mir-opt/dest-prop/union.main.DestinationPropagation.diff
+++ b/src/test/mir-opt/dest-prop/union.main.DestinationPropagation.diff
@@ -17,9 +17,12 @@
       }
   
       bb0: {
-          StorageLive(_1);                 // scope 0 at $DIR/union.rs:13:9: 13:11
-          StorageLive(_2);                 // scope 0 at $DIR/union.rs:13:23: 13:28
-          _2 = val() -> bb1;               // scope 0 at $DIR/union.rs:13:23: 13:28
+-         StorageLive(_1);                 // scope 0 at $DIR/union.rs:13:9: 13:11
+-         StorageLive(_2);                 // scope 0 at $DIR/union.rs:13:23: 13:28
+-         _2 = val() -> bb1;               // scope 0 at $DIR/union.rs:13:23: 13:28
++         nop;                             // scope 0 at $DIR/union.rs:13:9: 13:11
++         nop;                             // scope 0 at $DIR/union.rs:13:23: 13:28
++         (_1.0: u32) = val() -> bb1;      // scope 0 at $DIR/union.rs:13:23: 13:28
                                            // mir::Constant
                                            // + span: $DIR/union.rs:13:23: 13:26
                                            // + literal: Const { ty: fn() -> u32 {val}, val: Value(Scalar(<ZST>)) }
@@ -27,14 +30,17 @@
   
       bb1: {
           Deinit(_1);                      // scope 0 at $DIR/union.rs:13:14: 13:30
-          (_1.0: u32) = move _2;           // scope 0 at $DIR/union.rs:13:14: 13:30
-          StorageDead(_2);                 // scope 0 at $DIR/union.rs:13:29: 13:30
+-         (_1.0: u32) = move _2;           // scope 0 at $DIR/union.rs:13:14: 13:30
+-         StorageDead(_2);                 // scope 0 at $DIR/union.rs:13:29: 13:30
++         nop;                             // scope 0 at $DIR/union.rs:13:14: 13:30
++         nop;                             // scope 0 at $DIR/union.rs:13:29: 13:30
           StorageLive(_3);                 // scope 1 at $DIR/union.rs:15:5: 15:27
           StorageLive(_4);                 // scope 1 at $DIR/union.rs:15:10: 15:26
           _4 = (_1.0: u32);                // scope 2 at $DIR/union.rs:15:19: 15:24
           StorageDead(_4);                 // scope 1 at $DIR/union.rs:15:26: 15:27
           StorageDead(_3);                 // scope 1 at $DIR/union.rs:15:27: 15:28
-          StorageDead(_1);                 // scope 0 at $DIR/union.rs:16:1: 16:2
+-         StorageDead(_1);                 // scope 0 at $DIR/union.rs:16:1: 16:2
++         nop;                             // scope 0 at $DIR/union.rs:16:1: 16:2
           return;                          // scope 0 at $DIR/union.rs:16:2: 16:2
       }
   }

--- a/src/test/mir-opt/early_otherwise_branch.opt1.EarlyOtherwiseBranch.diff
+++ b/src/test/mir-opt/early_otherwise_branch.opt1.EarlyOtherwiseBranch.diff
@@ -25,6 +25,7 @@
           _4 = _1;                         // scope 0 at $DIR/early_otherwise_branch.rs:4:12: 4:13
           StorageLive(_5);                 // scope 0 at $DIR/early_otherwise_branch.rs:4:15: 4:16
           _5 = _2;                         // scope 0 at $DIR/early_otherwise_branch.rs:4:15: 4:16
+          Deinit(_3);                      // scope 0 at $DIR/early_otherwise_branch.rs:4:11: 4:17
           (_3.0: std::option::Option<u32>) = move _4; // scope 0 at $DIR/early_otherwise_branch.rs:4:11: 4:17
           (_3.1: std::option::Option<u32>) = move _5; // scope 0 at $DIR/early_otherwise_branch.rs:4:11: 4:17
           StorageDead(_5);                 // scope 0 at $DIR/early_otherwise_branch.rs:4:16: 4:17

--- a/src/test/mir-opt/early_otherwise_branch.opt2.EarlyOtherwiseBranch.diff
+++ b/src/test/mir-opt/early_otherwise_branch.opt2.EarlyOtherwiseBranch.diff
@@ -26,6 +26,7 @@
           _4 = _1;                         // scope 0 at $DIR/early_otherwise_branch.rs:12:12: 12:13
           StorageLive(_5);                 // scope 0 at $DIR/early_otherwise_branch.rs:12:15: 12:16
           _5 = _2;                         // scope 0 at $DIR/early_otherwise_branch.rs:12:15: 12:16
+          Deinit(_3);                      // scope 0 at $DIR/early_otherwise_branch.rs:12:11: 12:17
           (_3.0: std::option::Option<u32>) = move _4; // scope 0 at $DIR/early_otherwise_branch.rs:12:11: 12:17
           (_3.1: std::option::Option<u32>) = move _5; // scope 0 at $DIR/early_otherwise_branch.rs:12:11: 12:17
           StorageDead(_5);                 // scope 0 at $DIR/early_otherwise_branch.rs:12:16: 12:17

--- a/src/test/mir-opt/early_otherwise_branch.opt3.EarlyOtherwiseBranch.diff
+++ b/src/test/mir-opt/early_otherwise_branch.opt3.EarlyOtherwiseBranch.diff
@@ -25,6 +25,7 @@
           _4 = _1;                         // scope 0 at $DIR/early_otherwise_branch.rs:22:12: 22:13
           StorageLive(_5);                 // scope 0 at $DIR/early_otherwise_branch.rs:22:15: 22:16
           _5 = _2;                         // scope 0 at $DIR/early_otherwise_branch.rs:22:15: 22:16
+          Deinit(_3);                      // scope 0 at $DIR/early_otherwise_branch.rs:22:11: 22:17
           (_3.0: std::option::Option<u32>) = move _4; // scope 0 at $DIR/early_otherwise_branch.rs:22:11: 22:17
           (_3.1: std::option::Option<bool>) = move _5; // scope 0 at $DIR/early_otherwise_branch.rs:22:11: 22:17
           StorageDead(_5);                 // scope 0 at $DIR/early_otherwise_branch.rs:22:16: 22:17

--- a/src/test/mir-opt/early_otherwise_branch_3_element_tuple.opt1.EarlyOtherwiseBranch.diff
+++ b/src/test/mir-opt/early_otherwise_branch_3_element_tuple.opt1.EarlyOtherwiseBranch.diff
@@ -34,6 +34,7 @@
           _6 = _2;                         // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:15: 5:16
           StorageLive(_7);                 // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:18: 5:19
           _7 = _3;                         // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:18: 5:19
+          Deinit(_4);                      // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:11: 5:20
           (_4.0: std::option::Option<u32>) = move _5; // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:11: 5:20
           (_4.1: std::option::Option<u32>) = move _6; // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:11: 5:20
           (_4.2: std::option::Option<u32>) = move _7; // scope 0 at $DIR/early_otherwise_branch_3_element_tuple.rs:5:11: 5:20

--- a/src/test/mir-opt/early_otherwise_branch_68867.try_sum.EarlyOtherwiseBranch.before-SimplifyConstCondition-final.after.diff
+++ b/src/test/mir-opt/early_otherwise_branch_68867.try_sum.EarlyOtherwiseBranch.before-SimplifyConstCondition-final.after.diff
@@ -65,21 +65,17 @@
   
       bb0: {
 -         StorageLive(_3);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 27:6
--         StorageLive(_4);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
--         StorageLive(_5);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:15: 21:16
--         _5 = _1;                         // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:15: 21:16
 +         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 27:6
-+         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
-+         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:15: 21:16
-+         (_4.0: &ViewportPercentageLength) = _1; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:15: 21:16
+          StorageLive(_4);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
+          StorageLive(_5);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:15: 21:16
+          _5 = _1;                         // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:15: 21:16
           StorageLive(_6);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:18: 21:23
           _6 = _2;                         // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:18: 21:23
--         (_4.0: &ViewportPercentageLength) = move _5; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
-+         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
+          Deinit(_4);                      // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
+          (_4.0: &ViewportPercentageLength) = move _5; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
           (_4.1: &ViewportPercentageLength) = move _6; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
           StorageDead(_6);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:23: 21:24
--         StorageDead(_5);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:23: 21:24
-+         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:23: 21:24
+          StorageDead(_5);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:23: 21:24
           _11 = discriminant((*(_4.0: &ViewportPercentageLength))); // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
 -         switchInt(move _11) -> [0_isize: bb1, 1_isize: bb3, 2_isize: bb4, 3_isize: bb5, otherwise: bb11]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
 +         StorageLive(_34);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
@@ -98,13 +94,14 @@
 -     bb2: {
 +         StorageDead(_35);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:26:25: 26:27
           StorageLive(_33);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:26:25: 26:27
+-         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:26:25: 26:27
+          Deinit(_0);                      // scope 0 at $DIR/early_otherwise_branch_68867.rs:26:21: 26:28
 -         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:26:21: 26:28
           discriminant(_0) = 1;            // scope 0 at $DIR/early_otherwise_branch_68867.rs:26:21: 26:28
           StorageDead(_33);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:26:27: 26:28
 -         StorageDead(_3);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:27:6: 27:7
--         StorageDead(_4);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:28:1: 28:2
 +         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:27:6: 27:7
-+         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:28:1: 28:2
+          StorageDead(_4);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:28:1: 28:2
           return;                          // scope 0 at $DIR/early_otherwise_branch_68867.rs:28:2: 28:2
       }
   
@@ -121,6 +118,7 @@
 +         ((((_0 as Ok).0: ViewportPercentageLength) as Vw).0: f32) = Add(move _15, move _16); // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:38: 22:49
 +         nop;                             // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:48: 22:49
 +         nop;                             // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:48: 22:49
++         Deinit(((_0 as Ok).0: ViewportPercentageLength)); // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:35: 22:50
 +         nop;                             // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:35: 22:50
 +         discriminant(((_0 as Ok).0: ViewportPercentageLength)) = 0; // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:35: 22:50
 +         nop;                             // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:49: 22:50
@@ -144,6 +142,7 @@
 +         ((((_0 as Ok).0: ViewportPercentageLength) as Vh).0: f32) = Add(move _20, move _21); // scope 2 at $DIR/early_otherwise_branch_68867.rs:23:38: 23:49
 +         nop;                             // scope 2 at $DIR/early_otherwise_branch_68867.rs:23:48: 23:49
 +         nop;                             // scope 2 at $DIR/early_otherwise_branch_68867.rs:23:48: 23:49
++         Deinit(((_0 as Ok).0: ViewportPercentageLength)); // scope 2 at $DIR/early_otherwise_branch_68867.rs:23:35: 23:50
 +         nop;                             // scope 2 at $DIR/early_otherwise_branch_68867.rs:23:35: 23:50
 +         discriminant(((_0 as Ok).0: ViewportPercentageLength)) = 1; // scope 2 at $DIR/early_otherwise_branch_68867.rs:23:35: 23:50
 +         nop;                             // scope 2 at $DIR/early_otherwise_branch_68867.rs:23:49: 23:50
@@ -167,6 +166,7 @@
 +         ((((_0 as Ok).0: ViewportPercentageLength) as Vmin).0: f32) = Add(move _25, move _26); // scope 3 at $DIR/early_otherwise_branch_68867.rs:24:44: 24:55
 +         nop;                             // scope 3 at $DIR/early_otherwise_branch_68867.rs:24:54: 24:55
 +         nop;                             // scope 3 at $DIR/early_otherwise_branch_68867.rs:24:54: 24:55
++         Deinit(((_0 as Ok).0: ViewportPercentageLength)); // scope 3 at $DIR/early_otherwise_branch_68867.rs:24:39: 24:56
 +         nop;                             // scope 3 at $DIR/early_otherwise_branch_68867.rs:24:39: 24:56
 +         discriminant(((_0 as Ok).0: ViewportPercentageLength)) = 2; // scope 3 at $DIR/early_otherwise_branch_68867.rs:24:39: 24:56
 +         nop;                             // scope 3 at $DIR/early_otherwise_branch_68867.rs:24:55: 24:56
@@ -190,6 +190,7 @@
 +         ((((_0 as Ok).0: ViewportPercentageLength) as Vmax).0: f32) = Add(move _30, move _31); // scope 4 at $DIR/early_otherwise_branch_68867.rs:25:44: 25:55
 +         nop;                             // scope 4 at $DIR/early_otherwise_branch_68867.rs:25:54: 25:55
 +         nop;                             // scope 4 at $DIR/early_otherwise_branch_68867.rs:25:54: 25:55
++         Deinit(((_0 as Ok).0: ViewportPercentageLength)); // scope 4 at $DIR/early_otherwise_branch_68867.rs:25:39: 25:56
 +         nop;                             // scope 4 at $DIR/early_otherwise_branch_68867.rs:25:39: 25:56
 +         discriminant(((_0 as Ok).0: ViewportPercentageLength)) = 3; // scope 4 at $DIR/early_otherwise_branch_68867.rs:25:39: 25:56
 +         nop;                             // scope 4 at $DIR/early_otherwise_branch_68867.rs:25:55: 25:56
@@ -211,6 +212,7 @@
 -         _14 = Add(move _15, move _16);   // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:38: 22:49
 -         StorageDead(_16);                // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:48: 22:49
 -         StorageDead(_15);                // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:48: 22:49
+-         Deinit(_3);                      // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:35: 22:50
 -         ((_3 as Vw).0: f32) = move _14;  // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:35: 22:50
 -         discriminant(_3) = 0;            // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:35: 22:50
 -         StorageDead(_14);                // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:49: 22:50
@@ -232,6 +234,7 @@
 -         _19 = Add(move _20, move _21);   // scope 2 at $DIR/early_otherwise_branch_68867.rs:23:38: 23:49
 -         StorageDead(_21);                // scope 2 at $DIR/early_otherwise_branch_68867.rs:23:48: 23:49
 -         StorageDead(_20);                // scope 2 at $DIR/early_otherwise_branch_68867.rs:23:48: 23:49
+-         Deinit(_3);                      // scope 2 at $DIR/early_otherwise_branch_68867.rs:23:35: 23:50
 -         ((_3 as Vh).0: f32) = move _19;  // scope 2 at $DIR/early_otherwise_branch_68867.rs:23:35: 23:50
 -         discriminant(_3) = 1;            // scope 2 at $DIR/early_otherwise_branch_68867.rs:23:35: 23:50
 -         StorageDead(_19);                // scope 2 at $DIR/early_otherwise_branch_68867.rs:23:49: 23:50
@@ -253,6 +256,7 @@
 -         _24 = Add(move _25, move _26);   // scope 3 at $DIR/early_otherwise_branch_68867.rs:24:44: 24:55
 -         StorageDead(_26);                // scope 3 at $DIR/early_otherwise_branch_68867.rs:24:54: 24:55
 -         StorageDead(_25);                // scope 3 at $DIR/early_otherwise_branch_68867.rs:24:54: 24:55
+-         Deinit(_3);                      // scope 3 at $DIR/early_otherwise_branch_68867.rs:24:39: 24:56
 -         ((_3 as Vmin).0: f32) = move _24; // scope 3 at $DIR/early_otherwise_branch_68867.rs:24:39: 24:56
 -         discriminant(_3) = 2;            // scope 3 at $DIR/early_otherwise_branch_68867.rs:24:39: 24:56
 -         StorageDead(_24);                // scope 3 at $DIR/early_otherwise_branch_68867.rs:24:55: 24:56
@@ -274,6 +278,7 @@
 -         _29 = Add(move _30, move _31);   // scope 4 at $DIR/early_otherwise_branch_68867.rs:25:44: 25:55
 -         StorageDead(_31);                // scope 4 at $DIR/early_otherwise_branch_68867.rs:25:54: 25:55
 -         StorageDead(_30);                // scope 4 at $DIR/early_otherwise_branch_68867.rs:25:54: 25:55
+-         Deinit(_3);                      // scope 4 at $DIR/early_otherwise_branch_68867.rs:25:39: 25:56
 -         ((_3 as Vmax).0: f32) = move _29; // scope 4 at $DIR/early_otherwise_branch_68867.rs:25:39: 25:56
 -         discriminant(_3) = 3;            // scope 4 at $DIR/early_otherwise_branch_68867.rs:25:39: 25:56
 -         StorageDead(_29);                // scope 4 at $DIR/early_otherwise_branch_68867.rs:25:55: 25:56
@@ -283,13 +288,13 @@
 -     }
 - 
 -     bb10: {
+          Deinit(_0);                      // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:5: 27:7
 -         ((_0 as Ok).0: ViewportPercentageLength) = move _3; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:5: 27:7
 +         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:5: 27:7
           discriminant(_0) = 0;            // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:5: 27:7
 -         StorageDead(_3);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:27:6: 27:7
--         StorageDead(_4);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:28:1: 28:2
 +         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:27:6: 27:7
-+         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:28:1: 28:2
+          StorageDead(_4);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:28:1: 28:2
           return;                          // scope 0 at $DIR/early_otherwise_branch_68867.rs:28:2: 28:2
       }
   

--- a/src/test/mir-opt/early_otherwise_branch_68867.try_sum.EarlyOtherwiseBranch.before-SimplifyConstCondition-final.after.diff
+++ b/src/test/mir-opt/early_otherwise_branch_68867.try_sum.EarlyOtherwiseBranch.before-SimplifyConstCondition-final.after.diff
@@ -65,17 +65,22 @@
   
       bb0: {
 -         StorageLive(_3);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 27:6
+-         StorageLive(_4);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
+-         StorageLive(_5);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:15: 21:16
+-         _5 = _1;                         // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:15: 21:16
 +         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 27:6
-          StorageLive(_4);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
-          StorageLive(_5);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:15: 21:16
-          _5 = _1;                         // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:15: 21:16
++         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
++         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:15: 21:16
++         (_4.0: &ViewportPercentageLength) = _1; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:15: 21:16
           StorageLive(_6);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:18: 21:23
           _6 = _2;                         // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:18: 21:23
           Deinit(_4);                      // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
-          (_4.0: &ViewportPercentageLength) = move _5; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
+-         (_4.0: &ViewportPercentageLength) = move _5; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
++         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
           (_4.1: &ViewportPercentageLength) = move _6; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
           StorageDead(_6);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:23: 21:24
-          StorageDead(_5);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:23: 21:24
+-         StorageDead(_5);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:23: 21:24
++         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:23: 21:24
           _11 = discriminant((*(_4.0: &ViewportPercentageLength))); // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
 -         switchInt(move _11) -> [0_isize: bb1, 1_isize: bb3, 2_isize: bb4, 3_isize: bb5, otherwise: bb11]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
 +         StorageLive(_34);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
@@ -100,8 +105,9 @@
           discriminant(_0) = 1;            // scope 0 at $DIR/early_otherwise_branch_68867.rs:26:21: 26:28
           StorageDead(_33);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:26:27: 26:28
 -         StorageDead(_3);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:27:6: 27:7
+-         StorageDead(_4);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:28:1: 28:2
 +         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:27:6: 27:7
-          StorageDead(_4);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:28:1: 28:2
++         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:28:1: 28:2
           return;                          // scope 0 at $DIR/early_otherwise_branch_68867.rs:28:2: 28:2
       }
   
@@ -293,8 +299,9 @@
 +         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:5: 27:7
           discriminant(_0) = 0;            // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:5: 27:7
 -         StorageDead(_3);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:27:6: 27:7
+-         StorageDead(_4);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:28:1: 28:2
 +         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:27:6: 27:7
-          StorageDead(_4);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:28:1: 28:2
++         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:28:1: 28:2
           return;                          // scope 0 at $DIR/early_otherwise_branch_68867.rs:28:2: 28:2
       }
   

--- a/src/test/mir-opt/early_otherwise_branch_68867.try_sum.EarlyOtherwiseBranch.diff
+++ b/src/test/mir-opt/early_otherwise_branch_68867.try_sum.EarlyOtherwiseBranch.diff
@@ -62,6 +62,7 @@
           _5 = _1;                         // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:15: 21:16
           StorageLive(_6);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:18: 21:23
           _6 = _2;                         // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:18: 21:23
+          Deinit(_4);                      // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
           (_4.0: &ViewportPercentageLength) = move _5; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
           (_4.1: &ViewportPercentageLength) = move _6; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
           StorageDead(_6);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:23: 21:24
@@ -84,6 +85,8 @@
 -     bb2: {
 +         StorageDead(_35);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:26:25: 26:27
           StorageLive(_33);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:26:25: 26:27
+-         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:26:25: 26:27
+          Deinit(_0);                      // scope 0 at $DIR/early_otherwise_branch_68867.rs:26:21: 26:28
 -         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:26:21: 26:28
           discriminant(_0) = 1;            // scope 0 at $DIR/early_otherwise_branch_68867.rs:26:21: 26:28
           StorageDead(_33);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:26:27: 26:28
@@ -121,6 +124,7 @@
           _14 = Add(move _15, move _16);   // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:38: 22:49
           StorageDead(_16);                // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:48: 22:49
           StorageDead(_15);                // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:48: 22:49
+          Deinit(_3);                      // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:35: 22:50
           ((_3 as Vw).0: f32) = move _14;  // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:35: 22:50
           discriminant(_3) = 0;            // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:35: 22:50
           StorageDead(_14);                // scope 1 at $DIR/early_otherwise_branch_68867.rs:22:49: 22:50
@@ -144,6 +148,7 @@
           _19 = Add(move _20, move _21);   // scope 2 at $DIR/early_otherwise_branch_68867.rs:23:38: 23:49
           StorageDead(_21);                // scope 2 at $DIR/early_otherwise_branch_68867.rs:23:48: 23:49
           StorageDead(_20);                // scope 2 at $DIR/early_otherwise_branch_68867.rs:23:48: 23:49
+          Deinit(_3);                      // scope 2 at $DIR/early_otherwise_branch_68867.rs:23:35: 23:50
           ((_3 as Vh).0: f32) = move _19;  // scope 2 at $DIR/early_otherwise_branch_68867.rs:23:35: 23:50
           discriminant(_3) = 1;            // scope 2 at $DIR/early_otherwise_branch_68867.rs:23:35: 23:50
           StorageDead(_19);                // scope 2 at $DIR/early_otherwise_branch_68867.rs:23:49: 23:50
@@ -167,6 +172,7 @@
           _24 = Add(move _25, move _26);   // scope 3 at $DIR/early_otherwise_branch_68867.rs:24:44: 24:55
           StorageDead(_26);                // scope 3 at $DIR/early_otherwise_branch_68867.rs:24:54: 24:55
           StorageDead(_25);                // scope 3 at $DIR/early_otherwise_branch_68867.rs:24:54: 24:55
+          Deinit(_3);                      // scope 3 at $DIR/early_otherwise_branch_68867.rs:24:39: 24:56
           ((_3 as Vmin).0: f32) = move _24; // scope 3 at $DIR/early_otherwise_branch_68867.rs:24:39: 24:56
           discriminant(_3) = 2;            // scope 3 at $DIR/early_otherwise_branch_68867.rs:24:39: 24:56
           StorageDead(_24);                // scope 3 at $DIR/early_otherwise_branch_68867.rs:24:55: 24:56
@@ -190,6 +196,7 @@
           _29 = Add(move _30, move _31);   // scope 4 at $DIR/early_otherwise_branch_68867.rs:25:44: 25:55
           StorageDead(_31);                // scope 4 at $DIR/early_otherwise_branch_68867.rs:25:54: 25:55
           StorageDead(_30);                // scope 4 at $DIR/early_otherwise_branch_68867.rs:25:54: 25:55
+          Deinit(_3);                      // scope 4 at $DIR/early_otherwise_branch_68867.rs:25:39: 25:56
           ((_3 as Vmax).0: f32) = move _29; // scope 4 at $DIR/early_otherwise_branch_68867.rs:25:39: 25:56
           discriminant(_3) = 3;            // scope 4 at $DIR/early_otherwise_branch_68867.rs:25:39: 25:56
           StorageDead(_29);                // scope 4 at $DIR/early_otherwise_branch_68867.rs:25:55: 25:56
@@ -201,6 +208,7 @@
   
 -     bb10: {
 +     bb6: {
+          Deinit(_0);                      // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:5: 27:7
           ((_0 as Ok).0: ViewportPercentageLength) = move _3; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:5: 27:7
           discriminant(_0) = 0;            // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:5: 27:7
           StorageDead(_3);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:27:6: 27:7

--- a/src/test/mir-opt/early_otherwise_branch_noopt.noopt1.EarlyOtherwiseBranch.diff
+++ b/src/test/mir-opt/early_otherwise_branch_noopt.noopt1.EarlyOtherwiseBranch.diff
@@ -32,6 +32,7 @@
           _4 = _1;                         // scope 0 at $DIR/early_otherwise_branch_noopt.rs:8:12: 8:13
           StorageLive(_5);                 // scope 0 at $DIR/early_otherwise_branch_noopt.rs:8:15: 8:16
           _5 = _2;                         // scope 0 at $DIR/early_otherwise_branch_noopt.rs:8:15: 8:16
+          Deinit(_3);                      // scope 0 at $DIR/early_otherwise_branch_noopt.rs:8:11: 8:17
           (_3.0: std::option::Option<u32>) = move _4; // scope 0 at $DIR/early_otherwise_branch_noopt.rs:8:11: 8:17
           (_3.1: std::option::Option<u32>) = move _5; // scope 0 at $DIR/early_otherwise_branch_noopt.rs:8:11: 8:17
           StorageDead(_5);                 // scope 0 at $DIR/early_otherwise_branch_noopt.rs:8:16: 8:17

--- a/src/test/mir-opt/funky_arms.float_to_exponential_common.ConstProp.diff
+++ b/src/test/mir-opt/funky_arms.float_to_exponential_common.ConstProp.diff
@@ -51,11 +51,13 @@
       }
   
       bb2: {
+          Deinit(_6);                      // scope 1 at $DIR/funky_arms.rs:21:17: 21:41
           discriminant(_6) = 1;            // scope 1 at $DIR/funky_arms.rs:21:17: 21:41
           goto -> bb4;                     // scope 1 at $DIR/funky_arms.rs:21:17: 21:41
       }
   
       bb3: {
+          Deinit(_6);                      // scope 1 at $DIR/funky_arms.rs:20:18: 20:38
           discriminant(_6) = 0;            // scope 1 at $DIR/funky_arms.rs:20:18: 20:38
           goto -> bb4;                     // scope 1 at $DIR/funky_arms.rs:20:18: 20:38
       }

--- a/src/test/mir-opt/generator_storage_dead_unwind.main-{closure#0}.StateTransform.before.mir
+++ b/src/test/mir-opt/generator_storage_dead_unwind.main-{closure#0}.StateTransform.before.mir
@@ -21,11 +21,14 @@ yields ()
 
     bb0: {
         StorageLive(_3);                 // scope 0 at $DIR/generator-storage-dead-unwind.rs:23:13: 23:14
+        Deinit(_3);                      // scope 0 at $DIR/generator-storage-dead-unwind.rs:23:17: 23:23
         (_3.0: i32) = const 5_i32;       // scope 0 at $DIR/generator-storage-dead-unwind.rs:23:17: 23:23
         StorageLive(_4);                 // scope 1 at $DIR/generator-storage-dead-unwind.rs:24:13: 24:14
+        Deinit(_4);                      // scope 1 at $DIR/generator-storage-dead-unwind.rs:24:17: 24:23
         (_4.0: i32) = const 6_i32;       // scope 1 at $DIR/generator-storage-dead-unwind.rs:24:17: 24:23
         StorageLive(_5);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:25:9: 25:14
         StorageLive(_6);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:25:9: 25:14
+        Deinit(_6);                      // scope 2 at $DIR/generator-storage-dead-unwind.rs:25:9: 25:14
         _5 = yield(move _6) -> [resume: bb1, drop: bb5]; // scope 2 at $DIR/generator-storage-dead-unwind.rs:25:9: 25:14
     }
 

--- a/src/test/mir-opt/generator_tiny.main-{closure#0}.generator_resume.0.mir
+++ b/src/test/mir-opt/generator_tiny.main-{closure#0}.generator_resume.0.mir
@@ -1,13 +1,17 @@
 // MIR for `main::{closure#0}` 0 generator_resume
 /* generator_layout = GeneratorLayout {
-    field_tys: {},
+    field_tys: {
+        _0: HasDrop,
+    },
     variant_fields: {
         Unresumed(0): [],
         Returned (1): [],
         Panicked (2): [],
-        Suspend0 (3): [],
+        Suspend0 (3): [_0],
     },
-    storage_conflicts: BitMatrix(0x0) {},
+    storage_conflicts: BitMatrix(1x1) {
+        (_0, _0),
+    },
 } */
 
 fn main::{closure#0}(_1: Pin<&mut [generator@$DIR/generator-tiny.rs:19:16: 25:6]>, _2: u8) -> GeneratorState<(), ()> {
@@ -23,7 +27,7 @@ fn main::{closure#0}(_1: Pin<&mut [generator@$DIR/generator-tiny.rs:19:16: 25:6]
     let _10: u8;                         // in scope 0 at $DIR/generator-tiny.rs:19:17: 19:19
     let mut _11: u32;                    // in scope 0 at $DIR/generator-tiny.rs:19:16: 25:6
     scope 1 {
-        debug _d => _3;                  // in scope 1 at $DIR/generator-tiny.rs:20:13: 20:15
+        debug _d => (((*(_1.0: &mut [generator@$DIR/generator-tiny.rs:19:16: 25:6])) as variant#3).0: HasDrop); // in scope 1 at $DIR/generator-tiny.rs:20:13: 20:15
     }
 
     bb0: {
@@ -33,7 +37,8 @@ fn main::{closure#0}(_1: Pin<&mut [generator@$DIR/generator-tiny.rs:19:16: 25:6]
 
     bb1: {
         _10 = move _2;                   // scope 0 at $DIR/generator-tiny.rs:19:16: 25:6
-        StorageLive(_3);                 // scope 0 at $DIR/generator-tiny.rs:20:13: 20:15
+        nop;                             // scope 0 at $DIR/generator-tiny.rs:20:13: 20:15
+        Deinit((((*(_1.0: &mut [generator@$DIR/generator-tiny.rs:19:16: 25:6])) as variant#3).0: HasDrop)); // scope 0 at $DIR/generator-tiny.rs:20:18: 20:25
         StorageLive(_4);                 // scope 1 at $DIR/generator-tiny.rs:21:9: 24:10
         goto -> bb2;                     // scope 1 at $DIR/generator-tiny.rs:21:9: 24:10
     }
@@ -41,6 +46,8 @@ fn main::{closure#0}(_1: Pin<&mut [generator@$DIR/generator-tiny.rs:19:16: 25:6]
     bb2: {
         StorageLive(_6);                 // scope 1 at $DIR/generator-tiny.rs:22:13: 22:18
         StorageLive(_7);                 // scope 1 at $DIR/generator-tiny.rs:22:13: 22:18
+        Deinit(_7);                      // scope 1 at $DIR/generator-tiny.rs:22:13: 22:18
+        Deinit(_0);                      // scope 1 at $DIR/generator-tiny.rs:22:13: 22:18
         ((_0 as Yielded).0: ()) = move _7; // scope 1 at $DIR/generator-tiny.rs:22:13: 22:18
         discriminant(_0) = 0;            // scope 1 at $DIR/generator-tiny.rs:22:13: 22:18
         discriminant((*(_1.0: &mut [generator@$DIR/generator-tiny.rs:19:16: 25:6]))) = 3; // scope 1 at $DIR/generator-tiny.rs:22:13: 22:18
@@ -64,7 +71,6 @@ fn main::{closure#0}(_1: Pin<&mut [generator@$DIR/generator-tiny.rs:19:16: 25:6]
     }
 
     bb5: {
-        StorageLive(_3);                 // scope 0 at $DIR/generator-tiny.rs:19:16: 25:6
         StorageLive(_4);                 // scope 0 at $DIR/generator-tiny.rs:19:16: 25:6
         StorageLive(_6);                 // scope 0 at $DIR/generator-tiny.rs:19:16: 25:6
         StorageLive(_7);                 // scope 0 at $DIR/generator-tiny.rs:19:16: 25:6

--- a/src/test/mir-opt/inline/cycle.f.Inline.diff
+++ b/src/test/mir-opt/inline/cycle.f.Inline.diff
@@ -13,6 +13,7 @@
           StorageLive(_3);                 // scope 0 at $DIR/cycle.rs:6:5: 6:6
           _3 = &_1;                        // scope 0 at $DIR/cycle.rs:6:5: 6:6
           StorageLive(_4);                 // scope 0 at $DIR/cycle.rs:6:5: 6:8
+          Deinit(_4);                      // scope 0 at $DIR/cycle.rs:6:5: 6:8
           _2 = <impl Fn() as Fn<()>>::call(move _3, move _4) -> [return: bb1, unwind: bb3]; // scope 0 at $DIR/cycle.rs:6:5: 6:8
                                            // mir::Constant
                                            // + span: $DIR/cycle.rs:6:5: 6:6

--- a/src/test/mir-opt/inline/inline_closure.foo.Inline.after.mir
+++ b/src/test/mir-opt/inline/inline_closure.foo.Inline.after.mir
@@ -21,6 +21,7 @@ fn foo(_1: T, _2: i32) -> i32 {
 
     bb0: {
         StorageLive(_3);                 // scope 0 at $DIR/inline-closure.rs:11:9: 11:10
+        Deinit(_3);                      // scope 0 at $DIR/inline-closure.rs:11:13: 11:24
         StorageLive(_4);                 // scope 1 at $DIR/inline-closure.rs:12:5: 12:6
         _4 = &_3;                        // scope 1 at $DIR/inline-closure.rs:12:5: 12:6
         StorageLive(_5);                 // scope 1 at $DIR/inline-closure.rs:12:5: 12:12
@@ -28,6 +29,7 @@ fn foo(_1: T, _2: i32) -> i32 {
         _6 = _2;                         // scope 1 at $DIR/inline-closure.rs:12:7: 12:8
         StorageLive(_7);                 // scope 1 at $DIR/inline-closure.rs:12:10: 12:11
         _7 = _2;                         // scope 1 at $DIR/inline-closure.rs:12:10: 12:11
+        Deinit(_5);                      // scope 1 at $DIR/inline-closure.rs:12:5: 12:12
         (_5.0: i32) = move _6;           // scope 1 at $DIR/inline-closure.rs:12:5: 12:12
         (_5.1: i32) = move _7;           // scope 1 at $DIR/inline-closure.rs:12:5: 12:12
         StorageLive(_8);                 // scope 1 at $DIR/inline-closure.rs:12:5: 12:12

--- a/src/test/mir-opt/inline/inline_closure_borrows_arg.foo.Inline.after.mir
+++ b/src/test/mir-opt/inline/inline_closure_borrows_arg.foo.Inline.after.mir
@@ -25,6 +25,7 @@ fn foo(_1: T, _2: &i32) -> i32 {
 
     bb0: {
         StorageLive(_3);                 // scope 0 at $DIR/inline-closure-borrows-arg.rs:12:9: 12:10
+        Deinit(_3);                      // scope 0 at $DIR/inline-closure-borrows-arg.rs:12:13: 15:6
         StorageLive(_4);                 // scope 1 at $DIR/inline-closure-borrows-arg.rs:16:5: 16:6
         _4 = &_3;                        // scope 1 at $DIR/inline-closure-borrows-arg.rs:16:5: 16:6
         StorageLive(_5);                 // scope 1 at $DIR/inline-closure-borrows-arg.rs:16:5: 16:12
@@ -32,6 +33,7 @@ fn foo(_1: T, _2: &i32) -> i32 {
         _6 = &(*_2);                     // scope 1 at $DIR/inline-closure-borrows-arg.rs:16:7: 16:8
         StorageLive(_7);                 // scope 1 at $DIR/inline-closure-borrows-arg.rs:16:10: 16:11
         _7 = &(*_2);                     // scope 1 at $DIR/inline-closure-borrows-arg.rs:16:10: 16:11
+        Deinit(_5);                      // scope 1 at $DIR/inline-closure-borrows-arg.rs:16:5: 16:12
         (_5.0: &i32) = move _6;          // scope 1 at $DIR/inline-closure-borrows-arg.rs:16:5: 16:12
         (_5.1: &i32) = move _7;          // scope 1 at $DIR/inline-closure-borrows-arg.rs:16:5: 16:12
         StorageLive(_8);                 // scope 1 at $DIR/inline-closure-borrows-arg.rs:16:5: 16:12

--- a/src/test/mir-opt/inline/inline_closure_captures.foo.Inline.after.mir
+++ b/src/test/mir-opt/inline/inline_closure_captures.foo.Inline.after.mir
@@ -28,6 +28,7 @@ fn foo(_1: T, _2: i32) -> (i32, T) {
         _4 = &_2;                        // scope 0 at $DIR/inline-closure-captures.rs:11:13: 11:24
         StorageLive(_5);                 // scope 0 at $DIR/inline-closure-captures.rs:11:13: 11:24
         _5 = &_1;                        // scope 0 at $DIR/inline-closure-captures.rs:11:13: 11:24
+        Deinit(_3);                      // scope 0 at $DIR/inline-closure-captures.rs:11:13: 11:24
         (_3.0: &i32) = move _4;          // scope 0 at $DIR/inline-closure-captures.rs:11:13: 11:24
         (_3.1: &T) = move _5;            // scope 0 at $DIR/inline-closure-captures.rs:11:13: 11:24
         StorageDead(_5);                 // scope 0 at $DIR/inline-closure-captures.rs:11:23: 11:24
@@ -37,6 +38,7 @@ fn foo(_1: T, _2: i32) -> (i32, T) {
         StorageLive(_7);                 // scope 1 at $DIR/inline-closure-captures.rs:12:5: 12:9
         StorageLive(_8);                 // scope 1 at $DIR/inline-closure-captures.rs:12:7: 12:8
         _8 = _2;                         // scope 1 at $DIR/inline-closure-captures.rs:12:7: 12:8
+        Deinit(_7);                      // scope 1 at $DIR/inline-closure-captures.rs:12:5: 12:9
         (_7.0: i32) = move _8;           // scope 1 at $DIR/inline-closure-captures.rs:12:5: 12:9
         StorageLive(_9);                 // scope 1 at $DIR/inline-closure-captures.rs:12:5: 12:9
         _9 = move (_7.0: i32);           // scope 1 at $DIR/inline-closure-captures.rs:12:5: 12:9
@@ -44,6 +46,7 @@ fn foo(_1: T, _2: i32) -> (i32, T) {
         _10 = (*((*_6).0: &i32));        // scope 2 at $DIR/inline-closure-captures.rs:11:19: 11:20
         StorageLive(_11);                // scope 2 at $DIR/inline-closure-captures.rs:11:22: 11:23
         _11 = (*((*_6).1: &T));          // scope 2 at $DIR/inline-closure-captures.rs:11:22: 11:23
+        Deinit(_0);                      // scope 2 at $DIR/inline-closure-captures.rs:11:18: 11:24
         (_0.0: i32) = move _10;          // scope 2 at $DIR/inline-closure-captures.rs:11:18: 11:24
         (_0.1: T) = move _11;            // scope 2 at $DIR/inline-closure-captures.rs:11:18: 11:24
         StorageDead(_11);                // scope 2 at $DIR/inline-closure-captures.rs:11:23: 11:24

--- a/src/test/mir-opt/inline/inline_generator.main.Inline.diff
+++ b/src/test/mir-opt/inline/inline_generator.main.Inline.diff
@@ -44,6 +44,7 @@
 -     }
 - 
 -     bb1: {
++         Deinit(_4);                      // scope 2 at $DIR/inline-generator.rs:15:5: 15:41
 +         discriminant(_4) = 0;            // scope 2 at $DIR/inline-generator.rs:15:5: 15:41
           _3 = &mut _4;                    // scope 0 at $DIR/inline-generator.rs:9:23: 9:31
 -         _2 = Pin::<&mut [generator@$DIR/inline-generator.rs:15:5: 15:41]>::new(move _3) -> [return: bb2, unwind: bb4]; // scope 0 at $DIR/inline-generator.rs:9:14: 9:32
@@ -58,6 +59,7 @@
 +         _5 = move _3;                    // scope 4 at $SRC_DIR/core/src/pin.rs:LL:COL
 +         StorageLive(_6);                 // scope 5 at $SRC_DIR/core/src/pin.rs:LL:COL
 +         _6 = move _5;                    // scope 5 at $SRC_DIR/core/src/pin.rs:LL:COL
++         Deinit(_2);                      // scope 5 at $SRC_DIR/core/src/pin.rs:LL:COL
 +         (_2.0: &mut [generator@$DIR/inline-generator.rs:15:5: 15:41]) = move _6; // scope 5 at $SRC_DIR/core/src/pin.rs:LL:COL
 +         StorageDead(_6);                 // scope 5 at $SRC_DIR/core/src/pin.rs:LL:COL
 +         StorageDead(_5);                 // scope 4 at $SRC_DIR/core/src/pin.rs:LL:COL
@@ -113,6 +115,7 @@
 + 
 +     bb6: {
 +         StorageDead(_9);                 // scope 6 at $DIR/inline-generator.rs:15:38: 15:39
++         Deinit(_1);                      // scope 6 at $DIR/inline-generator.rs:15:11: 15:39
 +         ((_1 as Yielded).0: i32) = move _8; // scope 6 at $DIR/inline-generator.rs:15:11: 15:39
 +         discriminant(_1) = 0;            // scope 6 at $DIR/inline-generator.rs:15:11: 15:39
 +         discriminant((*(_2.0: &mut [generator@$DIR/inline-generator.rs:15:5: 15:41]))) = 3; // scope 6 at $DIR/inline-generator.rs:15:11: 15:39
@@ -123,6 +126,7 @@
 +         StorageLive(_8);                 // scope 6 at $DIR/inline-generator.rs:15:5: 15:41
 +         _10 = move _7;                   // scope 6 at $DIR/inline-generator.rs:15:5: 15:41
 +         StorageDead(_8);                 // scope 6 at $DIR/inline-generator.rs:15:38: 15:39
++         Deinit(_1);                      // scope 6 at $DIR/inline-generator.rs:15:41: 15:41
 +         ((_1 as Complete).0: bool) = move _10; // scope 6 at $DIR/inline-generator.rs:15:41: 15:41
 +         discriminant(_1) = 1;            // scope 6 at $DIR/inline-generator.rs:15:41: 15:41
 +         discriminant((*(_2.0: &mut [generator@$DIR/inline-generator.rs:15:5: 15:41]))) = 1; // scope 6 at $DIR/inline-generator.rs:15:41: 15:41

--- a/src/test/mir-opt/inline/inline_into_box_place.main.Inline.32bit.diff
+++ b/src/test/mir-opt/inline/inline_into_box_place.main.Inline.32bit.diff
@@ -34,6 +34,7 @@
 -         (*_5) = Vec::<u32>::new() -> [return: bb2, unwind: bb5]; // scope 0 at $DIR/inline-into-box-place.rs:8:33: 8:43
 +         StorageLive(_7);                 // scope 0 at $DIR/inline-into-box-place.rs:8:33: 8:43
 +         _7 = &mut (*_5);                 // scope 0 at $DIR/inline-into-box-place.rs:8:33: 8:43
++         Deinit((*_7));                   // scope 3 at $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
 +         ((*_7).0: alloc::raw_vec::RawVec<u32>) = const alloc::raw_vec::RawVec::<u32> { ptr: Unique::<u32> { pointer: {0x4 as *const u32}, _marker: PhantomData::<u32> }, cap: 0_usize, alloc: std::alloc::Global }; // scope 3 at $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
                                            // mir::Constant
 -                                          // + span: $DIR/inline-into-box-place.rs:8:33: 8:41

--- a/src/test/mir-opt/inline/inline_into_box_place.main.Inline.64bit.diff
+++ b/src/test/mir-opt/inline/inline_into_box_place.main.Inline.64bit.diff
@@ -34,6 +34,7 @@
 -         (*_5) = Vec::<u32>::new() -> [return: bb2, unwind: bb5]; // scope 0 at $DIR/inline-into-box-place.rs:8:33: 8:43
 +         StorageLive(_7);                 // scope 0 at $DIR/inline-into-box-place.rs:8:33: 8:43
 +         _7 = &mut (*_5);                 // scope 0 at $DIR/inline-into-box-place.rs:8:33: 8:43
++         Deinit((*_7));                   // scope 3 at $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
 +         ((*_7).0: alloc::raw_vec::RawVec<u32>) = const alloc::raw_vec::RawVec::<u32> { ptr: Unique::<u32> { pointer: {0x4 as *const u32}, _marker: PhantomData::<u32> }, cap: 0_usize, alloc: std::alloc::Global }; // scope 3 at $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
                                            // mir::Constant
 -                                          // + span: $DIR/inline-into-box-place.rs:8:33: 8:41

--- a/src/test/mir-opt/inline/issue_76997_inline_scopes_parenting.main.Inline.after.mir
+++ b/src/test/mir-opt/inline/issue_76997_inline_scopes_parenting.main.Inline.after.mir
@@ -20,10 +20,13 @@ fn main() -> () {
 
     bb0: {
         StorageLive(_1);                 // scope 0 at $DIR/issue-76997-inline-scopes-parenting.rs:5:9: 5:10
+        Deinit(_1);                      // scope 0 at $DIR/issue-76997-inline-scopes-parenting.rs:5:13: 5:33
         StorageLive(_2);                 // scope 1 at $DIR/issue-76997-inline-scopes-parenting.rs:6:5: 6:6
         _2 = &_1;                        // scope 1 at $DIR/issue-76997-inline-scopes-parenting.rs:6:5: 6:6
         StorageLive(_3);                 // scope 1 at $DIR/issue-76997-inline-scopes-parenting.rs:6:5: 6:10
         StorageLive(_4);                 // scope 1 at $DIR/issue-76997-inline-scopes-parenting.rs:6:7: 6:9
+        Deinit(_4);                      // scope 1 at $DIR/issue-76997-inline-scopes-parenting.rs:6:7: 6:9
+        Deinit(_3);                      // scope 1 at $DIR/issue-76997-inline-scopes-parenting.rs:6:5: 6:10
         (_3.0: ()) = move _4;            // scope 1 at $DIR/issue-76997-inline-scopes-parenting.rs:6:5: 6:10
         StorageLive(_5);                 // scope 1 at $DIR/issue-76997-inline-scopes-parenting.rs:6:5: 6:10
         _5 = move (_3.0: ());            // scope 1 at $DIR/issue-76997-inline-scopes-parenting.rs:6:5: 6:10

--- a/src/test/mir-opt/inline/issue_78442.bar.Inline.diff
+++ b/src/test/mir-opt/inline/issue_78442.bar.Inline.diff
@@ -25,6 +25,7 @@
       bb1: {
           _3 = &_4;                        // scope 0 at $DIR/issue-78442.rs:11:5: 11:15
           StorageLive(_5);                 // scope 0 at $DIR/issue-78442.rs:11:5: 11:17
+          Deinit(_5);                      // scope 0 at $DIR/issue-78442.rs:11:5: 11:17
 -         _2 = <fn() {foo} as Fn<()>>::call(move _3, move _5) -> [return: bb2, unwind: bb4]; // scope 0 at $DIR/issue-78442.rs:11:5: 11:17
 -                                          // mir::Constant
 -                                          // + span: $DIR/issue-78442.rs:11:5: 11:15

--- a/src/test/mir-opt/inline/issue_78442.bar.RevealAll.diff
+++ b/src/test/mir-opt/inline/issue_78442.bar.RevealAll.diff
@@ -24,7 +24,7 @@
       bb1: {
           _3 = &_4;                        // scope 0 at $DIR/issue-78442.rs:11:5: 11:15
           StorageLive(_5);                 // scope 0 at $DIR/issue-78442.rs:11:5: 11:17
-          nop;                             // scope 0 at $DIR/issue-78442.rs:11:5: 11:17
+          Deinit(_5);                      // scope 0 at $DIR/issue-78442.rs:11:5: 11:17
 -         _2 = <impl Fn() as Fn<()>>::call(move _3, move _5) -> [return: bb2, unwind: bb4]; // scope 0 at $DIR/issue-78442.rs:11:5: 11:17
 +         _2 = <fn() {foo} as Fn<()>>::call(move _3, move _5) -> [return: bb2, unwind: bb4]; // scope 0 at $DIR/issue-78442.rs:11:5: 11:17
                                            // mir::Constant

--- a/src/test/mir-opt/issue_73223.main.PreCodegen.32bit.diff
+++ b/src/test/mir-opt/issue_73223.main.PreCodegen.32bit.diff
@@ -43,6 +43,7 @@
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/issue-73223.rs:2:9: 2:14
           StorageLive(_2);                 // scope 0 at $DIR/issue-73223.rs:2:23: 2:30
+          Deinit(_2);                      // scope 0 at $DIR/issue-73223.rs:2:23: 2:30
           ((_2 as Some).0: i32) = const 1_i32; // scope 0 at $DIR/issue-73223.rs:2:23: 2:30
           discriminant(_2) = 1;            // scope 0 at $DIR/issue-73223.rs:2:23: 2:30
           StorageLive(_3);                 // scope 0 at $DIR/issue-73223.rs:3:14: 3:15
@@ -53,6 +54,7 @@
           StorageLive(_4);                 // scope 1 at $DIR/issue-73223.rs:7:9: 7:14
           StorageLive(_5);                 // scope 1 at $DIR/issue-73223.rs:7:22: 7:27
           _5 = _1;                         // scope 1 at $DIR/issue-73223.rs:7:22: 7:27
+          Deinit(_4);                      // scope 1 at $DIR/issue-73223.rs:7:17: 7:28
           ((_4 as Some).0: i32) = move _5; // scope 1 at $DIR/issue-73223.rs:7:17: 7:28
           discriminant(_4) = 1;            // scope 1 at $DIR/issue-73223.rs:7:17: 7:28
           StorageDead(_5);                 // scope 1 at $DIR/issue-73223.rs:7:27: 7:28
@@ -65,6 +67,7 @@
                                            // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // + literal: Const { ty: &i32, val: Unevaluated(main, [], Some(promoted[0])) }
           _8 = _20;                        // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          Deinit(_6);                      // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           (_6.0: &i32) = move _7;          // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           (_6.1: &i32) = move _8;          // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageDead(_8);                 // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
@@ -86,6 +89,7 @@
   
       bb1: {
           StorageLive(_14);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          Deinit(_14);                     // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           discriminant(_14) = 0;           // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageLive(_15);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageLive(_16);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
@@ -96,6 +100,7 @@
           _18 = _10;                       // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           _17 = _18;                       // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageLive(_19);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          Deinit(_19);                     // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           discriminant(_19) = 0;           // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           core::panicking::assert_failed::<i32, i32>(const core::panicking::AssertKind::Eq, move _15, move _17, move _19); // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // mir::Constant

--- a/src/test/mir-opt/issue_73223.main.PreCodegen.64bit.diff
+++ b/src/test/mir-opt/issue_73223.main.PreCodegen.64bit.diff
@@ -43,6 +43,7 @@
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/issue-73223.rs:2:9: 2:14
           StorageLive(_2);                 // scope 0 at $DIR/issue-73223.rs:2:23: 2:30
+          Deinit(_2);                      // scope 0 at $DIR/issue-73223.rs:2:23: 2:30
           ((_2 as Some).0: i32) = const 1_i32; // scope 0 at $DIR/issue-73223.rs:2:23: 2:30
           discriminant(_2) = 1;            // scope 0 at $DIR/issue-73223.rs:2:23: 2:30
           StorageLive(_3);                 // scope 0 at $DIR/issue-73223.rs:3:14: 3:15
@@ -53,6 +54,7 @@
           StorageLive(_4);                 // scope 1 at $DIR/issue-73223.rs:7:9: 7:14
           StorageLive(_5);                 // scope 1 at $DIR/issue-73223.rs:7:22: 7:27
           _5 = _1;                         // scope 1 at $DIR/issue-73223.rs:7:22: 7:27
+          Deinit(_4);                      // scope 1 at $DIR/issue-73223.rs:7:17: 7:28
           ((_4 as Some).0: i32) = move _5; // scope 1 at $DIR/issue-73223.rs:7:17: 7:28
           discriminant(_4) = 1;            // scope 1 at $DIR/issue-73223.rs:7:17: 7:28
           StorageDead(_5);                 // scope 1 at $DIR/issue-73223.rs:7:27: 7:28
@@ -65,6 +67,7 @@
                                            // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // + literal: Const { ty: &i32, val: Unevaluated(main, [], Some(promoted[0])) }
           _8 = _20;                        // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          Deinit(_6);                      // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           (_6.0: &i32) = move _7;          // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           (_6.1: &i32) = move _8;          // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageDead(_8);                 // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
@@ -86,6 +89,7 @@
   
       bb1: {
           StorageLive(_14);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          Deinit(_14);                     // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           discriminant(_14) = 0;           // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageLive(_15);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageLive(_16);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
@@ -96,6 +100,7 @@
           _18 = _10;                       // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           _17 = _18;                       // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageLive(_19);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          Deinit(_19);                     // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           discriminant(_19) = 0;           // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           core::panicking::assert_failed::<i32, i32>(const core::panicking::AssertKind::Eq, move _15, move _17, move _19); // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // mir::Constant

--- a/src/test/mir-opt/issue_73223.main.SimplifyArmIdentity.32bit.diff
+++ b/src/test/mir-opt/issue_73223.main.SimplifyArmIdentity.32bit.diff
@@ -51,6 +51,7 @@
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/issue-73223.rs:2:9: 2:14
           StorageLive(_2);                 // scope 0 at $DIR/issue-73223.rs:2:23: 2:30
+          Deinit(_2);                      // scope 0 at $DIR/issue-73223.rs:2:23: 2:30
           ((_2 as Some).0: i32) = const 1_i32; // scope 0 at $DIR/issue-73223.rs:2:23: 2:30
           discriminant(_2) = 1;            // scope 0 at $DIR/issue-73223.rs:2:23: 2:30
           _3 = const 1_isize;              // scope 0 at $DIR/issue-73223.rs:2:23: 2:30
@@ -73,6 +74,7 @@
           StorageLive(_6);                 // scope 1 at $DIR/issue-73223.rs:7:9: 7:14
           StorageLive(_7);                 // scope 1 at $DIR/issue-73223.rs:7:22: 7:27
           _7 = _1;                         // scope 1 at $DIR/issue-73223.rs:7:22: 7:27
+          Deinit(_6);                      // scope 1 at $DIR/issue-73223.rs:7:17: 7:28
           ((_6 as Some).0: i32) = move _7; // scope 1 at $DIR/issue-73223.rs:7:17: 7:28
           discriminant(_6) = 1;            // scope 1 at $DIR/issue-73223.rs:7:17: 7:28
           StorageDead(_7);                 // scope 1 at $DIR/issue-73223.rs:7:27: 7:28
@@ -86,6 +88,7 @@
                                            // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // + literal: Const { ty: &i32, val: Unevaluated(main, [], Some(promoted[0])) }
           _11 = _28;                       // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          Deinit(_9);                      // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           (_9.0: &i32) = move _10;         // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           (_9.1: &i32) = move _11;         // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageDead(_11);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
@@ -110,6 +113,7 @@
   
       bb3: {
           StorageLive(_20);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          Deinit(_20);                     // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           discriminant(_20) = 0;           // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageLive(_21);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageLive(_22);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
@@ -126,6 +130,7 @@
           _26 = _14;                       // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           _25 = _26;                       // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageLive(_27);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          Deinit(_27);                     // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           discriminant(_27) = 0;           // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           core::panicking::assert_failed::<i32, i32>(const core::panicking::AssertKind::Eq, move _23, move _25, move _27); // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // mir::Constant

--- a/src/test/mir-opt/issue_73223.main.SimplifyArmIdentity.64bit.diff
+++ b/src/test/mir-opt/issue_73223.main.SimplifyArmIdentity.64bit.diff
@@ -51,6 +51,7 @@
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/issue-73223.rs:2:9: 2:14
           StorageLive(_2);                 // scope 0 at $DIR/issue-73223.rs:2:23: 2:30
+          Deinit(_2);                      // scope 0 at $DIR/issue-73223.rs:2:23: 2:30
           ((_2 as Some).0: i32) = const 1_i32; // scope 0 at $DIR/issue-73223.rs:2:23: 2:30
           discriminant(_2) = 1;            // scope 0 at $DIR/issue-73223.rs:2:23: 2:30
           _3 = const 1_isize;              // scope 0 at $DIR/issue-73223.rs:2:23: 2:30
@@ -73,6 +74,7 @@
           StorageLive(_6);                 // scope 1 at $DIR/issue-73223.rs:7:9: 7:14
           StorageLive(_7);                 // scope 1 at $DIR/issue-73223.rs:7:22: 7:27
           _7 = _1;                         // scope 1 at $DIR/issue-73223.rs:7:22: 7:27
+          Deinit(_6);                      // scope 1 at $DIR/issue-73223.rs:7:17: 7:28
           ((_6 as Some).0: i32) = move _7; // scope 1 at $DIR/issue-73223.rs:7:17: 7:28
           discriminant(_6) = 1;            // scope 1 at $DIR/issue-73223.rs:7:17: 7:28
           StorageDead(_7);                 // scope 1 at $DIR/issue-73223.rs:7:27: 7:28
@@ -86,6 +88,7 @@
                                            // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // + literal: Const { ty: &i32, val: Unevaluated(main, [], Some(promoted[0])) }
           _11 = _28;                       // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          Deinit(_9);                      // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           (_9.0: &i32) = move _10;         // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           (_9.1: &i32) = move _11;         // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageDead(_11);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
@@ -110,6 +113,7 @@
   
       bb3: {
           StorageLive(_20);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          Deinit(_20);                     // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           discriminant(_20) = 0;           // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageLive(_21);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageLive(_22);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
@@ -126,6 +130,7 @@
           _26 = _14;                       // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           _25 = _26;                       // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           StorageLive(_27);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          Deinit(_27);                     // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           discriminant(_27) = 0;           // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           core::panicking::assert_failed::<i32, i32>(const core::panicking::AssertKind::Eq, move _23, move _25, move _27); // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // mir::Constant

--- a/src/test/mir-opt/issues/issue_75439.foo.MatchBranchSimplification.diff
+++ b/src/test/mir-opt/issues/issue_75439.foo.MatchBranchSimplification.diff
@@ -67,6 +67,7 @@
   
       bb7: {
           StorageDead(_6);                 // scope 4 at $DIR/issue-75439.rs:10:35: 10:36
+          Deinit(_0);                      // scope 1 at $DIR/issue-75439.rs:10:9: 10:39
           ((_0 as Some).0: [u8; 4]) = move _5; // scope 1 at $DIR/issue-75439.rs:10:9: 10:39
           discriminant(_0) = 1;            // scope 1 at $DIR/issue-75439.rs:10:9: 10:39
           StorageDead(_5);                 // scope 1 at $DIR/issue-75439.rs:10:38: 10:39
@@ -75,6 +76,7 @@
       }
   
       bb8: {
+          Deinit(_0);                      // scope 1 at $DIR/issue-75439.rs:12:9: 12:13
           discriminant(_0) = 0;            // scope 1 at $DIR/issue-75439.rs:12:9: 12:13
           goto -> bb9;                     // scope 1 at $DIR/issue-75439.rs:9:5: 13:6
       }

--- a/src/test/mir-opt/matches_reduce_branches.bar.MatchBranchSimplification.32bit.diff
+++ b/src/test/mir-opt/matches_reduce_branches.bar.MatchBranchSimplification.32bit.diff
@@ -41,6 +41,7 @@
 -         _3 = const false;                // scope 4 at $DIR/matches_reduce_branches.rs:29:13: 29:22
 -         _4 = const false;                // scope 4 at $DIR/matches_reduce_branches.rs:30:13: 30:22
 -         _5 = const true;                 // scope 4 at $DIR/matches_reduce_branches.rs:31:13: 31:21
+-         nop;                             // scope 4 at $DIR/matches_reduce_branches.rs:32:13: 32:15
 -         goto -> bb3;                     // scope 4 at $DIR/matches_reduce_branches.rs:32:13: 32:15
 -     }
 - 
@@ -53,6 +54,7 @@
 +         _3 = Eq(_11, const 7_i32);       // scope 4 at $DIR/matches_reduce_branches.rs:22:13: 22:21
           _4 = const false;                // scope 4 at $DIR/matches_reduce_branches.rs:23:13: 23:22
           _5 = const true;                 // scope 4 at $DIR/matches_reduce_branches.rs:24:13: 24:21
+-         nop;                             // scope 4 at $DIR/matches_reduce_branches.rs:25:13: 25:15
 -         goto -> bb3;                     // scope 4 at $DIR/matches_reduce_branches.rs:25:13: 25:15
 -     }
 - 
@@ -67,6 +69,7 @@
           _9 = _4;                         // scope 4 at $DIR/matches_reduce_branches.rs:36:12: 36:13
           StorageLive(_10);                // scope 4 at $DIR/matches_reduce_branches.rs:36:15: 36:16
           _10 = _5;                        // scope 4 at $DIR/matches_reduce_branches.rs:36:15: 36:16
+          Deinit(_0);                      // scope 4 at $DIR/matches_reduce_branches.rs:36:5: 36:17
           (_0.0: bool) = move _7;          // scope 4 at $DIR/matches_reduce_branches.rs:36:5: 36:17
           (_0.1: bool) = move _8;          // scope 4 at $DIR/matches_reduce_branches.rs:36:5: 36:17
           (_0.2: bool) = move _9;          // scope 4 at $DIR/matches_reduce_branches.rs:36:5: 36:17

--- a/src/test/mir-opt/matches_reduce_branches.bar.MatchBranchSimplification.64bit.diff
+++ b/src/test/mir-opt/matches_reduce_branches.bar.MatchBranchSimplification.64bit.diff
@@ -41,6 +41,7 @@
 -         _3 = const false;                // scope 4 at $DIR/matches_reduce_branches.rs:29:13: 29:22
 -         _4 = const false;                // scope 4 at $DIR/matches_reduce_branches.rs:30:13: 30:22
 -         _5 = const true;                 // scope 4 at $DIR/matches_reduce_branches.rs:31:13: 31:21
+-         nop;                             // scope 4 at $DIR/matches_reduce_branches.rs:32:13: 32:15
 -         goto -> bb3;                     // scope 4 at $DIR/matches_reduce_branches.rs:32:13: 32:15
 -     }
 - 
@@ -53,6 +54,7 @@
 +         _3 = Eq(_11, const 7_i32);       // scope 4 at $DIR/matches_reduce_branches.rs:22:13: 22:21
           _4 = const false;                // scope 4 at $DIR/matches_reduce_branches.rs:23:13: 23:22
           _5 = const true;                 // scope 4 at $DIR/matches_reduce_branches.rs:24:13: 24:21
+-         nop;                             // scope 4 at $DIR/matches_reduce_branches.rs:25:13: 25:15
 -         goto -> bb3;                     // scope 4 at $DIR/matches_reduce_branches.rs:25:13: 25:15
 -     }
 - 
@@ -67,6 +69,7 @@
           _9 = _4;                         // scope 4 at $DIR/matches_reduce_branches.rs:36:12: 36:13
           StorageLive(_10);                // scope 4 at $DIR/matches_reduce_branches.rs:36:15: 36:16
           _10 = _5;                        // scope 4 at $DIR/matches_reduce_branches.rs:36:15: 36:16
+          Deinit(_0);                      // scope 4 at $DIR/matches_reduce_branches.rs:36:5: 36:17
           (_0.0: bool) = move _7;          // scope 4 at $DIR/matches_reduce_branches.rs:36:5: 36:17
           (_0.1: bool) = move _8;          // scope 4 at $DIR/matches_reduce_branches.rs:36:5: 36:17
           (_0.2: bool) = move _9;          // scope 4 at $DIR/matches_reduce_branches.rs:36:5: 36:17

--- a/src/test/mir-opt/remove_storage_markers.main.RemoveStorageMarkers.diff
+++ b/src/test/mir-opt/remove_storage_markers.main.RemoveStorageMarkers.diff
@@ -38,6 +38,7 @@
           _1 = const 0_i32;                // scope 0 at $DIR/remove_storage_markers.rs:7:19: 7:20
 -         StorageLive(_2);                 // scope 1 at $DIR/remove_storage_markers.rs:8:14: 8:19
 -         StorageLive(_3);                 // scope 1 at $DIR/remove_storage_markers.rs:8:14: 8:19
+          Deinit(_3);                      // scope 1 at $DIR/remove_storage_markers.rs:8:14: 8:19
           (_3.0: i32) = const 0_i32;       // scope 1 at $DIR/remove_storage_markers.rs:8:14: 8:19
           (_3.1: i32) = const 10_i32;      // scope 1 at $DIR/remove_storage_markers.rs:8:14: 8:19
           _2 = move _3;                    // scope 4 at $SRC_DIR/core/src/iter/traits/collect.rs:LL:COL

--- a/src/test/mir-opt/remove_zsts_dont_touch_unions.get_union.RemoveZsts.after.mir
+++ b/src/test/mir-opt/remove_zsts_dont_touch_unions.get_union.RemoveZsts.after.mir
@@ -6,6 +6,8 @@ fn get_union() -> Foo {
 
     bb0: {
         StorageLive(_1);                 // scope 0 at $DIR/remove_zsts_dont_touch_unions.rs:13:14: 13:16
+        nop;                             // scope 0 at $DIR/remove_zsts_dont_touch_unions.rs:13:14: 13:16
+        Deinit(_0);                      // scope 0 at $DIR/remove_zsts_dont_touch_unions.rs:13:5: 13:18
         (_0.0: ()) = move _1;            // scope 0 at $DIR/remove_zsts_dont_touch_unions.rs:13:5: 13:18
         StorageDead(_1);                 // scope 0 at $DIR/remove_zsts_dont_touch_unions.rs:13:17: 13:18
         return;                          // scope 0 at $DIR/remove_zsts_dont_touch_unions.rs:14:2: 14:2

--- a/src/test/mir-opt/separate_const_switch.identity.ConstProp.diff
+++ b/src/test/mir-opt/separate_const_switch.identity.ConstProp.diff
@@ -15,15 +15,15 @@
       scope 1 {
           debug residual => _6;            // in scope 1 at $DIR/separate_const_switch.rs:29:9: 29:10
           scope 2 {
-              scope 5 (inlined #[track_caller] <Result<i32, i32> as FromResidual<Result<Infallible, i32>>>::from_residual) { // at $DIR/separate_const_switch.rs:29:8: 29:10
-                  debug residual => _8;    // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-                  let _10: i32;            // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-                  let mut _11: i32;        // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-                  let mut _12: i32;        // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-                  scope 6 {
-                      debug e => _10;      // in scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
-                      scope 7 (inlined <i32 as From<i32>>::from) { // at $SRC_DIR/core/src/result.rs:LL:COL
-                          debug t => _12;  // in scope 7 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
+              scope 8 (inlined #[track_caller] <Result<i32, i32> as FromResidual<Result<Infallible, i32>>>::from_residual) { // at $DIR/separate_const_switch.rs:29:8: 29:10
+                  debug residual => _8;    // in scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
+                  let _16: i32;            // in scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
+                  let mut _17: i32;        // in scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
+                  let mut _18: i32;        // in scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
+                  scope 9 {
+                      debug e => _16;      // in scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
+                      scope 10 (inlined <i32 as From<i32>>::from) { // at $SRC_DIR/core/src/result.rs:LL:COL
+                          debug t => _18;  // in scope 10 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
                       }
                   }
               }
@@ -34,25 +34,33 @@
           scope 4 {
           }
       }
+      scope 5 (inlined <Result<i32, i32> as Try>::branch) { // at $DIR/separate_const_switch.rs:29:8: 29:10
+          debug self => _4;                // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+          let mut _10: isize;              // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+          let _11: i32;                    // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+          let mut _12: i32;                // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+          let _13: i32;                    // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+          let mut _14: std::result::Result<std::convert::Infallible, i32>; // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+          let mut _15: i32;                // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+          scope 6 {
+              debug v => _11;              // in scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
+          }
+          scope 7 {
+              debug e => _13;              // in scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+          }
+      }
   
       bb0: {
           StorageLive(_2);                 // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
           StorageLive(_3);                 // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
           StorageLive(_4);                 // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:9
           _4 = _1;                         // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:9
-          _3 = <Result<i32, i32> as Try>::branch(move _4) -> bb1; // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-                                           // mir::Constant
-                                           // + span: $DIR/separate_const_switch.rs:29:8: 29:10
-                                           // + literal: Const { ty: fn(Result<i32, i32>) -> ControlFlow<<Result<i32, i32> as Try>::Residual, <Result<i32, i32> as Try>::Output> {<Result<i32, i32> as Try>::branch}, val: Value(Scalar(<ZST>)) }
+          StorageLive(_10);                // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
+          _10 = discriminant(_4);          // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+          switchInt(move _10) -> [0_isize: bb5, 1_isize: bb3, otherwise: bb4]; // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
       }
   
       bb1: {
-          StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
-          _5 = discriminant(_3);           // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-          switchInt(move _5) -> [0_isize: bb2, otherwise: bb3]; // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-      }
-  
-      bb2: {
           StorageLive(_9);                 // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
           _9 = ((_3 as Continue).0: i32);  // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
           _2 = _9;                         // scope 4 at $DIR/separate_const_switch.rs:29:8: 29:10
@@ -65,28 +73,73 @@
           return;                          // scope 0 at $DIR/separate_const_switch.rs:30:2: 30:2
       }
   
-      bb3: {
+      bb2: {
           StorageLive(_6);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
           _6 = ((_3 as Break).0: std::result::Result<std::convert::Infallible, i32>); // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
           StorageLive(_8);                 // scope 2 at $DIR/separate_const_switch.rs:29:9: 29:10
           _8 = _6;                         // scope 2 at $DIR/separate_const_switch.rs:29:9: 29:10
-          StorageLive(_10);                // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-          _10 = move ((_8 as Err).0: i32); // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-          StorageLive(_11);                // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
-          StorageLive(_12);                // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
-          _12 = move _10;                  // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
-          _11 = move _12;                  // scope 7 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
-          StorageDead(_12);                // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
-          Deinit(_0);                      // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
-          ((_0 as Err).0: i32) = move _11; // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
-          discriminant(_0) = 1;            // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
-          StorageDead(_11);                // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
-          StorageDead(_10);                // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+          StorageLive(_16);                // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
+          _16 = move ((_8 as Err).0: i32); // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
+          StorageLive(_17);                // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
+          StorageLive(_18);                // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
+          _18 = move _16;                  // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
+          _17 = move _18;                  // scope 10 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
+          StorageDead(_18);                // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
+          Deinit(_0);                      // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
+          ((_0 as Err).0: i32) = move _17; // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
+          discriminant(_0) = 1;            // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
+          StorageDead(_17);                // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
+          StorageDead(_16);                // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
           StorageDead(_8);                 // scope 2 at $DIR/separate_const_switch.rs:29:9: 29:10
           StorageDead(_6);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
           StorageDead(_2);                 // scope 0 at $DIR/separate_const_switch.rs:29:10: 29:11
           StorageDead(_3);                 // scope 0 at $DIR/separate_const_switch.rs:30:1: 30:2
           return;                          // scope 0 at $DIR/separate_const_switch.rs:30:2: 30:2
+      }
+  
+      bb3: {
+          StorageLive(_13);                // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+          _13 = move ((_4 as Err).0: i32); // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+          StorageLive(_14);                // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+          StorageLive(_15);                // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+          _15 = move _13;                  // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+          Deinit(_14);                     // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+          ((_14 as Err).0: i32) = move _15; // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+          discriminant(_14) = 1;           // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+          StorageDead(_15);                // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+          Deinit(_3);                      // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+          ((_3 as Break).0: std::result::Result<std::convert::Infallible, i32>) = move _14; // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+          discriminant(_3) = 1;            // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+          StorageDead(_14);                // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+          StorageDead(_13);                // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+          StorageDead(_10);                // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
+          StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
+-         _5 = discriminant(_3);           // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
+-         switchInt(move _5) -> [0_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
++         _5 = const 1_isize;              // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
++         switchInt(const 1_isize) -> [0_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
+      }
+  
+      bb4: {
+          unreachable;                     // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+      }
+  
+      bb5: {
+          StorageLive(_11);                // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+          _11 = move ((_4 as Ok).0: i32);  // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+          StorageLive(_12);                // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
+          _12 = move _11;                  // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
+          Deinit(_3);                      // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
+          ((_3 as Continue).0: i32) = move _12; // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
+          discriminant(_3) = 0;            // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
+          StorageDead(_12);                // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
+          StorageDead(_11);                // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+          StorageDead(_10);                // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
+          StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
+-         _5 = discriminant(_3);           // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
+-         switchInt(move _5) -> [0_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
++         _5 = const 0_isize;              // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
++         switchInt(const 0_isize) -> [0_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
       }
   }
   

--- a/src/test/mir-opt/separate_const_switch.identity.ConstProp.diff
+++ b/src/test/mir-opt/separate_const_switch.identity.ConstProp.diff
@@ -15,15 +15,15 @@
       scope 1 {
           debug residual => _6;            // in scope 1 at $DIR/separate_const_switch.rs:29:9: 29:10
           scope 2 {
-              scope 8 (inlined #[track_caller] <Result<i32, i32> as FromResidual<Result<Infallible, i32>>>::from_residual) { // at $DIR/separate_const_switch.rs:29:8: 29:10
-                  debug residual => _8;    // in scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
-                  let _16: i32;            // in scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
-                  let mut _17: i32;        // in scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
-                  let mut _18: i32;        // in scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
-                  scope 9 {
-                      debug e => _16;      // in scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
-                      scope 10 (inlined <i32 as From<i32>>::from) { // at $SRC_DIR/core/src/result.rs:LL:COL
-                          debug t => _18;  // in scope 10 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
+              scope 5 (inlined #[track_caller] <Result<i32, i32> as FromResidual<Result<Infallible, i32>>>::from_residual) { // at $DIR/separate_const_switch.rs:29:8: 29:10
+                  debug residual => _8;    // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+                  let _10: i32;            // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+                  let mut _11: i32;        // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+                  let mut _12: i32;        // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+                  scope 6 {
+                      debug e => _10;      // in scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
+                      scope 7 (inlined <i32 as From<i32>>::from) { // at $SRC_DIR/core/src/result.rs:LL:COL
+                          debug t => _12;  // in scope 7 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
                       }
                   }
               }
@@ -34,37 +34,30 @@
           scope 4 {
           }
       }
-      scope 5 (inlined <Result<i32, i32> as Try>::branch) { // at $DIR/separate_const_switch.rs:29:8: 29:10
-          debug self => _4;                // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-          let mut _10: isize;              // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-          let _11: i32;                    // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-          let mut _12: i32;                // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-          let _13: i32;                    // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-          let mut _14: std::result::Result<std::convert::Infallible, i32>; // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-          let mut _15: i32;                // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-          scope 6 {
-              debug v => _11;              // in scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
-          }
-          scope 7 {
-              debug e => _13;              // in scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
-          }
-      }
   
       bb0: {
           StorageLive(_2);                 // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
           StorageLive(_3);                 // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
           StorageLive(_4);                 // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:9
           _4 = _1;                         // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:9
-          StorageLive(_10);                // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-          _10 = discriminant(_4);          // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-          switchInt(move _10) -> [0_isize: bb5, 1_isize: bb3, otherwise: bb4]; // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+          _3 = <Result<i32, i32> as Try>::branch(move _4) -> bb1; // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
+                                           // mir::Constant
+                                           // + span: $DIR/separate_const_switch.rs:29:8: 29:10
+                                           // + literal: Const { ty: fn(Result<i32, i32>) -> ControlFlow<<Result<i32, i32> as Try>::Residual, <Result<i32, i32> as Try>::Output> {<Result<i32, i32> as Try>::branch}, val: Value(Scalar(<ZST>)) }
       }
   
       bb1: {
+          StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
+          _5 = discriminant(_3);           // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
+          switchInt(move _5) -> [0_isize: bb2, otherwise: bb3]; // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
+      }
+  
+      bb2: {
           StorageLive(_9);                 // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
           _9 = ((_3 as Continue).0: i32);  // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
           _2 = _9;                         // scope 4 at $DIR/separate_const_switch.rs:29:8: 29:10
           StorageDead(_9);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
+          Deinit(_0);                      // scope 0 at $DIR/separate_const_switch.rs:29:5: 29:11
           ((_0 as Ok).0: i32) = move _2;   // scope 0 at $DIR/separate_const_switch.rs:29:5: 29:11
           discriminant(_0) = 0;            // scope 0 at $DIR/separate_const_switch.rs:29:5: 29:11
           StorageDead(_2);                 // scope 0 at $DIR/separate_const_switch.rs:29:10: 29:11
@@ -72,69 +65,28 @@
           return;                          // scope 0 at $DIR/separate_const_switch.rs:30:2: 30:2
       }
   
-      bb2: {
+      bb3: {
           StorageLive(_6);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
           _6 = ((_3 as Break).0: std::result::Result<std::convert::Infallible, i32>); // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
           StorageLive(_8);                 // scope 2 at $DIR/separate_const_switch.rs:29:9: 29:10
           _8 = _6;                         // scope 2 at $DIR/separate_const_switch.rs:29:9: 29:10
-          StorageLive(_16);                // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
-          _16 = move ((_8 as Err).0: i32); // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
-          StorageLive(_17);                // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
-          StorageLive(_18);                // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
-          _18 = move _16;                  // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
-          _17 = move _18;                  // scope 10 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
-          StorageDead(_18);                // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
-          ((_0 as Err).0: i32) = move _17; // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
-          discriminant(_0) = 1;            // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
-          StorageDead(_17);                // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
-          StorageDead(_16);                // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
+          StorageLive(_10);                // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+          _10 = move ((_8 as Err).0: i32); // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+          StorageLive(_11);                // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
+          StorageLive(_12);                // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
+          _12 = move _10;                  // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
+          _11 = move _12;                  // scope 7 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
+          StorageDead(_12);                // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
+          Deinit(_0);                      // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
+          ((_0 as Err).0: i32) = move _11; // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
+          discriminant(_0) = 1;            // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
+          StorageDead(_11);                // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
+          StorageDead(_10);                // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
           StorageDead(_8);                 // scope 2 at $DIR/separate_const_switch.rs:29:9: 29:10
           StorageDead(_6);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
           StorageDead(_2);                 // scope 0 at $DIR/separate_const_switch.rs:29:10: 29:11
           StorageDead(_3);                 // scope 0 at $DIR/separate_const_switch.rs:30:1: 30:2
           return;                          // scope 0 at $DIR/separate_const_switch.rs:30:2: 30:2
-      }
-  
-      bb3: {
-          StorageLive(_13);                // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-          _13 = move ((_4 as Err).0: i32); // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-          StorageLive(_14);                // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
-          StorageLive(_15);                // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
-          _15 = move _13;                  // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
-          ((_14 as Err).0: i32) = move _15; // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
-          discriminant(_14) = 1;           // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
-          StorageDead(_15);                // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
-          ((_3 as Break).0: std::result::Result<std::convert::Infallible, i32>) = move _14; // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
-          discriminant(_3) = 1;            // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
-          StorageDead(_14);                // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
-          StorageDead(_13);                // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-          StorageDead(_10);                // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-          StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
--         _5 = discriminant(_3);           // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
--         switchInt(move _5) -> [0_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-+         _5 = const 1_isize;              // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-+         switchInt(const 1_isize) -> [0_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-      }
-  
-      bb4: {
-          unreachable;                     // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-      }
-  
-      bb5: {
-          StorageLive(_11);                // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-          _11 = move ((_4 as Ok).0: i32);  // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-          StorageLive(_12);                // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
-          _12 = move _11;                  // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
-          ((_3 as Continue).0: i32) = move _12; // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
-          discriminant(_3) = 0;            // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
-          StorageDead(_12);                // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
-          StorageDead(_11);                // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-          StorageDead(_10);                // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-          StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
--         _5 = discriminant(_3);           // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
--         switchInt(move _5) -> [0_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-+         _5 = const 0_isize;              // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-+         switchInt(const 0_isize) -> [0_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
       }
   }
   

--- a/src/test/mir-opt/separate_const_switch.identity.PreCodegen.after.mir
+++ b/src/test/mir-opt/separate_const_switch.identity.PreCodegen.after.mir
@@ -6,30 +6,44 @@ fn identity(_1: Result<i32, i32>) -> Result<i32, i32> {
     let mut _2: i32;                     // in scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
     let mut _3: std::ops::ControlFlow<std::result::Result<std::convert::Infallible, i32>, i32>; // in scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
     let mut _4: std::result::Result<i32, i32>; // in scope 0 at $DIR/separate_const_switch.rs:29:8: 29:9
-    let mut _5: isize;                   // in scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
-    let _6: std::result::Result<std::convert::Infallible, i32>; // in scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
-    let mut _7: std::result::Result<std::convert::Infallible, i32>; // in scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
-    let _8: i32;                         // in scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
+    let _5: std::result::Result<std::convert::Infallible, i32>; // in scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
+    let mut _6: std::result::Result<std::convert::Infallible, i32>; // in scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
+    let _7: i32;                         // in scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
     scope 1 {
-        debug residual => _6;            // in scope 1 at $DIR/separate_const_switch.rs:29:9: 29:10
+        debug residual => _5;            // in scope 1 at $DIR/separate_const_switch.rs:29:9: 29:10
         scope 2 {
-            scope 5 (inlined #[track_caller] <Result<i32, i32> as FromResidual<Result<Infallible, i32>>>::from_residual) { // at $DIR/separate_const_switch.rs:29:8: 29:10
-                debug residual => _7;    // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-                let _9: i32;             // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-                let mut _10: i32;        // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-                let mut _11: i32;        // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-                scope 6 {
-                    debug e => _9;       // in scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
-                    scope 7 (inlined <i32 as From<i32>>::from) { // at $SRC_DIR/core/src/result.rs:LL:COL
-                        debug t => _11;  // in scope 7 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
+            scope 8 (inlined #[track_caller] <Result<i32, i32> as FromResidual<Result<Infallible, i32>>>::from_residual) { // at $DIR/separate_const_switch.rs:29:8: 29:10
+                debug residual => _6;    // in scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
+                let _14: i32;            // in scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
+                let mut _15: i32;        // in scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
+                let mut _16: i32;        // in scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
+                scope 9 {
+                    debug e => _14;      // in scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
+                    scope 10 (inlined <i32 as From<i32>>::from) { // at $SRC_DIR/core/src/result.rs:LL:COL
+                        debug t => _16;  // in scope 10 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
                     }
                 }
             }
         }
     }
     scope 3 {
-        debug val => _8;                 // in scope 3 at $DIR/separate_const_switch.rs:29:8: 29:10
+        debug val => _7;                 // in scope 3 at $DIR/separate_const_switch.rs:29:8: 29:10
         scope 4 {
+        }
+    }
+    scope 5 (inlined <Result<i32, i32> as Try>::branch) { // at $DIR/separate_const_switch.rs:29:8: 29:10
+        debug self => _4;                // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+        let mut _8: isize;               // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+        let _9: i32;                     // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+        let mut _10: i32;                // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+        let _11: i32;                    // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+        let mut _12: std::result::Result<std::convert::Infallible, i32>; // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+        let mut _13: i32;                // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+        scope 6 {
+            debug v => _9;               // in scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
+        }
+        scope 7 {
+            debug e => _11;              // in scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
         }
     }
 
@@ -38,50 +52,74 @@ fn identity(_1: Result<i32, i32>) -> Result<i32, i32> {
         StorageLive(_3);                 // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
         StorageLive(_4);                 // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:9
         _4 = _1;                         // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:9
-        _3 = <Result<i32, i32> as Try>::branch(move _4) -> bb1; // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-                                         // mir::Constant
-                                         // + span: $DIR/separate_const_switch.rs:29:8: 29:10
-                                         // + literal: Const { ty: fn(Result<i32, i32>) -> ControlFlow<<Result<i32, i32> as Try>::Residual, <Result<i32, i32> as Try>::Output> {<Result<i32, i32> as Try>::branch}, val: Value(Scalar(<ZST>)) }
+        StorageLive(_8);                 // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
+        _8 = discriminant(_4);           // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+        switchInt(move _8) -> [0_isize: bb3, 1_isize: bb1, otherwise: bb2]; // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
     }
 
     bb1: {
+        StorageLive(_11);                // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+        _11 = move ((_4 as Err).0: i32); // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+        StorageLive(_12);                // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+        StorageLive(_13);                // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+        _13 = move _11;                  // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+        Deinit(_12);                     // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+        ((_12 as Err).0: i32) = move _13; // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+        discriminant(_12) = 1;           // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+        StorageDead(_13);                // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+        Deinit(_3);                      // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+        ((_3 as Break).0: std::result::Result<std::convert::Infallible, i32>) = move _12; // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+        discriminant(_3) = 1;            // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+        StorageDead(_12);                // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+        StorageDead(_11);                // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+        StorageDead(_8);                 // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
         StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
-        _5 = discriminant(_3);           // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-        switchInt(move _5) -> [0_isize: bb2, otherwise: bb3]; // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-    }
-
-    bb2: {
-        StorageLive(_8);                 // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-        _8 = ((_3 as Continue).0: i32);  // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-        _2 = _8;                         // scope 4 at $DIR/separate_const_switch.rs:29:8: 29:10
-        StorageDead(_8);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
-        Deinit(_0);                      // scope 0 at $DIR/separate_const_switch.rs:29:5: 29:11
-        ((_0 as Ok).0: i32) = move _2;   // scope 0 at $DIR/separate_const_switch.rs:29:5: 29:11
-        discriminant(_0) = 0;            // scope 0 at $DIR/separate_const_switch.rs:29:5: 29:11
+        StorageLive(_5);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
+        _5 = ((_3 as Break).0: std::result::Result<std::convert::Infallible, i32>); // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
+        StorageLive(_6);                 // scope 2 at $DIR/separate_const_switch.rs:29:9: 29:10
+        _6 = _5;                         // scope 2 at $DIR/separate_const_switch.rs:29:9: 29:10
+        StorageLive(_14);                // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
+        _14 = move ((_6 as Err).0: i32); // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
+        StorageLive(_15);                // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
+        StorageLive(_16);                // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
+        _16 = move _14;                  // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
+        _15 = move _16;                  // scope 10 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
+        StorageDead(_16);                // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
+        Deinit(_0);                      // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
+        ((_0 as Err).0: i32) = move _15; // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
+        discriminant(_0) = 1;            // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
+        StorageDead(_15);                // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
+        StorageDead(_14);                // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
+        StorageDead(_6);                 // scope 2 at $DIR/separate_const_switch.rs:29:9: 29:10
+        StorageDead(_5);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
         StorageDead(_2);                 // scope 0 at $DIR/separate_const_switch.rs:29:10: 29:11
         StorageDead(_3);                 // scope 0 at $DIR/separate_const_switch.rs:30:1: 30:2
         return;                          // scope 0 at $DIR/separate_const_switch.rs:30:2: 30:2
     }
 
+    bb2: {
+        unreachable;                     // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+    }
+
     bb3: {
-        StorageLive(_6);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
-        _6 = ((_3 as Break).0: std::result::Result<std::convert::Infallible, i32>); // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
-        StorageLive(_7);                 // scope 2 at $DIR/separate_const_switch.rs:29:9: 29:10
-        _7 = _6;                         // scope 2 at $DIR/separate_const_switch.rs:29:9: 29:10
         StorageLive(_9);                 // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-        _9 = move ((_7 as Err).0: i32);  // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+        _9 = move ((_4 as Ok).0: i32);   // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
         StorageLive(_10);                // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
-        StorageLive(_11);                // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
-        _11 = move _9;                   // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
-        _10 = move _11;                  // scope 7 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
-        StorageDead(_11);                // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
-        Deinit(_0);                      // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
-        ((_0 as Err).0: i32) = move _10; // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
-        discriminant(_0) = 1;            // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
+        _10 = move _9;                   // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
+        Deinit(_3);                      // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
+        ((_3 as Continue).0: i32) = move _10; // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
+        discriminant(_3) = 0;            // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
         StorageDead(_10);                // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
         StorageDead(_9);                 // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-        StorageDead(_7);                 // scope 2 at $DIR/separate_const_switch.rs:29:9: 29:10
-        StorageDead(_6);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
+        StorageDead(_8);                 // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
+        StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
+        StorageLive(_7);                 // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
+        _7 = ((_3 as Continue).0: i32);  // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
+        _2 = _7;                         // scope 4 at $DIR/separate_const_switch.rs:29:8: 29:10
+        StorageDead(_7);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
+        Deinit(_0);                      // scope 0 at $DIR/separate_const_switch.rs:29:5: 29:11
+        ((_0 as Ok).0: i32) = move _2;   // scope 0 at $DIR/separate_const_switch.rs:29:5: 29:11
+        discriminant(_0) = 0;            // scope 0 at $DIR/separate_const_switch.rs:29:5: 29:11
         StorageDead(_2);                 // scope 0 at $DIR/separate_const_switch.rs:29:10: 29:11
         StorageDead(_3);                 // scope 0 at $DIR/separate_const_switch.rs:30:1: 30:2
         return;                          // scope 0 at $DIR/separate_const_switch.rs:30:2: 30:2

--- a/src/test/mir-opt/separate_const_switch.identity.PreCodegen.after.mir
+++ b/src/test/mir-opt/separate_const_switch.identity.PreCodegen.after.mir
@@ -6,44 +6,30 @@ fn identity(_1: Result<i32, i32>) -> Result<i32, i32> {
     let mut _2: i32;                     // in scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
     let mut _3: std::ops::ControlFlow<std::result::Result<std::convert::Infallible, i32>, i32>; // in scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
     let mut _4: std::result::Result<i32, i32>; // in scope 0 at $DIR/separate_const_switch.rs:29:8: 29:9
-    let _5: std::result::Result<std::convert::Infallible, i32>; // in scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
-    let mut _6: std::result::Result<std::convert::Infallible, i32>; // in scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
-    let _7: i32;                         // in scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
+    let mut _5: isize;                   // in scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
+    let _6: std::result::Result<std::convert::Infallible, i32>; // in scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
+    let mut _7: std::result::Result<std::convert::Infallible, i32>; // in scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
+    let _8: i32;                         // in scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
     scope 1 {
-        debug residual => _5;            // in scope 1 at $DIR/separate_const_switch.rs:29:9: 29:10
+        debug residual => _6;            // in scope 1 at $DIR/separate_const_switch.rs:29:9: 29:10
         scope 2 {
-            scope 8 (inlined #[track_caller] <Result<i32, i32> as FromResidual<Result<Infallible, i32>>>::from_residual) { // at $DIR/separate_const_switch.rs:29:8: 29:10
-                debug residual => _6;    // in scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
-                let _14: i32;            // in scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
-                let mut _15: i32;        // in scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
-                let mut _16: i32;        // in scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
-                scope 9 {
-                    debug e => _14;      // in scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
-                    scope 10 (inlined <i32 as From<i32>>::from) { // at $SRC_DIR/core/src/result.rs:LL:COL
-                        debug t => _16;  // in scope 10 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
+            scope 5 (inlined #[track_caller] <Result<i32, i32> as FromResidual<Result<Infallible, i32>>>::from_residual) { // at $DIR/separate_const_switch.rs:29:8: 29:10
+                debug residual => _7;    // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+                let _9: i32;             // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+                let mut _10: i32;        // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+                let mut _11: i32;        // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+                scope 6 {
+                    debug e => _9;       // in scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
+                    scope 7 (inlined <i32 as From<i32>>::from) { // at $SRC_DIR/core/src/result.rs:LL:COL
+                        debug t => _11;  // in scope 7 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
                     }
                 }
             }
         }
     }
     scope 3 {
-        debug val => _7;                 // in scope 3 at $DIR/separate_const_switch.rs:29:8: 29:10
+        debug val => _8;                 // in scope 3 at $DIR/separate_const_switch.rs:29:8: 29:10
         scope 4 {
-        }
-    }
-    scope 5 (inlined <Result<i32, i32> as Try>::branch) { // at $DIR/separate_const_switch.rs:29:8: 29:10
-        debug self => _4;                // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-        let mut _8: isize;               // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-        let _9: i32;                     // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-        let mut _10: i32;                // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-        let _11: i32;                    // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-        let mut _12: std::result::Result<std::convert::Infallible, i32>; // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-        let mut _13: i32;                // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-        scope 6 {
-            debug v => _9;               // in scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
-        }
-        scope 7 {
-            debug e => _11;              // in scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
         }
     }
 
@@ -52,69 +38,50 @@ fn identity(_1: Result<i32, i32>) -> Result<i32, i32> {
         StorageLive(_3);                 // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
         StorageLive(_4);                 // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:9
         _4 = _1;                         // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:9
-        StorageLive(_8);                 // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-        _8 = discriminant(_4);           // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-        switchInt(move _8) -> [0_isize: bb3, 1_isize: bb1, otherwise: bb2]; // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+        _3 = <Result<i32, i32> as Try>::branch(move _4) -> bb1; // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
+                                         // mir::Constant
+                                         // + span: $DIR/separate_const_switch.rs:29:8: 29:10
+                                         // + literal: Const { ty: fn(Result<i32, i32>) -> ControlFlow<<Result<i32, i32> as Try>::Residual, <Result<i32, i32> as Try>::Output> {<Result<i32, i32> as Try>::branch}, val: Value(Scalar(<ZST>)) }
     }
 
     bb1: {
-        StorageLive(_11);                // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-        _11 = move ((_4 as Err).0: i32); // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-        StorageLive(_12);                // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
-        StorageLive(_13);                // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
-        _13 = move _11;                  // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
-        ((_12 as Err).0: i32) = move _13; // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
-        discriminant(_12) = 1;           // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
-        StorageDead(_13);                // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
-        ((_3 as Break).0: std::result::Result<std::convert::Infallible, i32>) = move _12; // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
-        discriminant(_3) = 1;            // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
-        StorageDead(_12);                // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
-        StorageDead(_11);                // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-        StorageDead(_8);                 // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
         StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
-        StorageLive(_5);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
-        _5 = ((_3 as Break).0: std::result::Result<std::convert::Infallible, i32>); // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
-        StorageLive(_6);                 // scope 2 at $DIR/separate_const_switch.rs:29:9: 29:10
-        _6 = _5;                         // scope 2 at $DIR/separate_const_switch.rs:29:9: 29:10
-        StorageLive(_14);                // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
-        _14 = move ((_6 as Err).0: i32); // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
-        StorageLive(_15);                // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
-        StorageLive(_16);                // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
-        _16 = move _14;                  // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
-        _15 = move _16;                  // scope 10 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
-        StorageDead(_16);                // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
-        ((_0 as Err).0: i32) = move _15; // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
-        discriminant(_0) = 1;            // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
-        StorageDead(_15);                // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
-        StorageDead(_14);                // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
-        StorageDead(_6);                 // scope 2 at $DIR/separate_const_switch.rs:29:9: 29:10
-        StorageDead(_5);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
+        _5 = discriminant(_3);           // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
+        switchInt(move _5) -> [0_isize: bb2, otherwise: bb3]; // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
+    }
+
+    bb2: {
+        StorageLive(_8);                 // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
+        _8 = ((_3 as Continue).0: i32);  // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
+        _2 = _8;                         // scope 4 at $DIR/separate_const_switch.rs:29:8: 29:10
+        StorageDead(_8);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
+        Deinit(_0);                      // scope 0 at $DIR/separate_const_switch.rs:29:5: 29:11
+        ((_0 as Ok).0: i32) = move _2;   // scope 0 at $DIR/separate_const_switch.rs:29:5: 29:11
+        discriminant(_0) = 0;            // scope 0 at $DIR/separate_const_switch.rs:29:5: 29:11
         StorageDead(_2);                 // scope 0 at $DIR/separate_const_switch.rs:29:10: 29:11
         StorageDead(_3);                 // scope 0 at $DIR/separate_const_switch.rs:30:1: 30:2
         return;                          // scope 0 at $DIR/separate_const_switch.rs:30:2: 30:2
     }
 
-    bb2: {
-        unreachable;                     // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-    }
-
     bb3: {
+        StorageLive(_6);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
+        _6 = ((_3 as Break).0: std::result::Result<std::convert::Infallible, i32>); // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
+        StorageLive(_7);                 // scope 2 at $DIR/separate_const_switch.rs:29:9: 29:10
+        _7 = _6;                         // scope 2 at $DIR/separate_const_switch.rs:29:9: 29:10
         StorageLive(_9);                 // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-        _9 = move ((_4 as Ok).0: i32);   // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+        _9 = move ((_7 as Err).0: i32);  // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
         StorageLive(_10);                // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
-        _10 = move _9;                   // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
-        ((_3 as Continue).0: i32) = move _10; // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
-        discriminant(_3) = 0;            // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
+        StorageLive(_11);                // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
+        _11 = move _9;                   // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
+        _10 = move _11;                  // scope 7 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
+        StorageDead(_11);                // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
+        Deinit(_0);                      // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
+        ((_0 as Err).0: i32) = move _10; // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
+        discriminant(_0) = 1;            // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
         StorageDead(_10);                // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
         StorageDead(_9);                 // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-        StorageDead(_8);                 // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-        StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
-        StorageLive(_7);                 // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-        _7 = ((_3 as Continue).0: i32);  // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-        _2 = _7;                         // scope 4 at $DIR/separate_const_switch.rs:29:8: 29:10
-        StorageDead(_7);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
-        ((_0 as Ok).0: i32) = move _2;   // scope 0 at $DIR/separate_const_switch.rs:29:5: 29:11
-        discriminant(_0) = 0;            // scope 0 at $DIR/separate_const_switch.rs:29:5: 29:11
+        StorageDead(_7);                 // scope 2 at $DIR/separate_const_switch.rs:29:9: 29:10
+        StorageDead(_6);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
         StorageDead(_2);                 // scope 0 at $DIR/separate_const_switch.rs:29:10: 29:11
         StorageDead(_3);                 // scope 0 at $DIR/separate_const_switch.rs:30:1: 30:2
         return;                          // scope 0 at $DIR/separate_const_switch.rs:30:2: 30:2

--- a/src/test/mir-opt/separate_const_switch.identity.SeparateConstSwitch.diff
+++ b/src/test/mir-opt/separate_const_switch.identity.SeparateConstSwitch.diff
@@ -15,15 +15,15 @@
       scope 1 {
           debug residual => _6;            // in scope 1 at $DIR/separate_const_switch.rs:29:9: 29:10
           scope 2 {
-              scope 5 (inlined #[track_caller] <Result<i32, i32> as FromResidual<Result<Infallible, i32>>>::from_residual) { // at $DIR/separate_const_switch.rs:29:8: 29:10
-                  debug residual => _8;    // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-                  let _10: i32;            // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-                  let mut _11: i32;        // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-                  let mut _12: i32;        // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-                  scope 6 {
-                      debug e => _10;      // in scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
-                      scope 7 (inlined <i32 as From<i32>>::from) { // at $SRC_DIR/core/src/result.rs:LL:COL
-                          debug t => _12;  // in scope 7 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
+              scope 8 (inlined #[track_caller] <Result<i32, i32> as FromResidual<Result<Infallible, i32>>>::from_residual) { // at $DIR/separate_const_switch.rs:29:8: 29:10
+                  debug residual => _8;    // in scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
+                  let _16: i32;            // in scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
+                  let mut _17: i32;        // in scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
+                  let mut _18: i32;        // in scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
+                  scope 9 {
+                      debug e => _16;      // in scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
+                      scope 10 (inlined <i32 as From<i32>>::from) { // at $SRC_DIR/core/src/result.rs:LL:COL
+                          debug t => _18;  // in scope 10 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
                       }
                   }
               }
@@ -34,25 +34,41 @@
           scope 4 {
           }
       }
+      scope 5 (inlined <Result<i32, i32> as Try>::branch) { // at $DIR/separate_const_switch.rs:29:8: 29:10
+          debug self => _4;                // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+          let mut _10: isize;              // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+          let _11: i32;                    // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+          let mut _12: i32;                // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+          let _13: i32;                    // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+          let mut _14: std::result::Result<std::convert::Infallible, i32>; // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+          let mut _15: i32;                // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+          scope 6 {
+              debug v => _11;              // in scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
+          }
+          scope 7 {
+              debug e => _13;              // in scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+          }
+      }
   
       bb0: {
           StorageLive(_2);                 // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
           StorageLive(_3);                 // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
           StorageLive(_4);                 // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:9
           _4 = _1;                         // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:9
-          _3 = <Result<i32, i32> as Try>::branch(move _4) -> bb1; // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-                                           // mir::Constant
-                                           // + span: $DIR/separate_const_switch.rs:29:8: 29:10
-                                           // + literal: Const { ty: fn(Result<i32, i32>) -> ControlFlow<<Result<i32, i32> as Try>::Residual, <Result<i32, i32> as Try>::Output> {<Result<i32, i32> as Try>::branch}, val: Value(Scalar(<ZST>)) }
+          StorageLive(_10);                // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
+          _10 = discriminant(_4);          // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+-         switchInt(move _10) -> [0_isize: bb6, 1_isize: bb4, otherwise: bb5]; // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
++         switchInt(move _10) -> [0_isize: bb5, 1_isize: bb3, otherwise: bb4]; // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
       }
   
       bb1: {
-          StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
-          _5 = discriminant(_3);           // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-          switchInt(move _5) -> [0_isize: bb2, otherwise: bb3]; // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-      }
-  
-      bb2: {
+-         StorageDead(_10);                // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
+-         StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
+-         _5 = discriminant(_3);           // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
+-         switchInt(move _5) -> [0_isize: bb2, otherwise: bb3]; // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
+-     }
+- 
+-     bb2: {
           StorageLive(_9);                 // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
           _9 = ((_3 as Continue).0: i32);  // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
           _2 = _9;                         // scope 4 at $DIR/separate_const_switch.rs:29:8: 29:10
@@ -65,28 +81,75 @@
           return;                          // scope 0 at $DIR/separate_const_switch.rs:30:2: 30:2
       }
   
-      bb3: {
+-     bb3: {
++     bb2: {
           StorageLive(_6);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
           _6 = ((_3 as Break).0: std::result::Result<std::convert::Infallible, i32>); // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
           StorageLive(_8);                 // scope 2 at $DIR/separate_const_switch.rs:29:9: 29:10
           _8 = _6;                         // scope 2 at $DIR/separate_const_switch.rs:29:9: 29:10
-          StorageLive(_10);                // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-          _10 = move ((_8 as Err).0: i32); // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-          StorageLive(_11);                // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
-          StorageLive(_12);                // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
-          _12 = move _10;                  // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
-          _11 = move _12;                  // scope 7 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
-          StorageDead(_12);                // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
-          Deinit(_0);                      // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
-          ((_0 as Err).0: i32) = move _11; // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
-          discriminant(_0) = 1;            // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
-          StorageDead(_11);                // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
-          StorageDead(_10);                // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+          StorageLive(_16);                // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
+          _16 = move ((_8 as Err).0: i32); // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
+          StorageLive(_17);                // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
+          StorageLive(_18);                // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
+          _18 = move _16;                  // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
+          _17 = move _18;                  // scope 10 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
+          StorageDead(_18);                // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
+          Deinit(_0);                      // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
+          ((_0 as Err).0: i32) = move _17; // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
+          discriminant(_0) = 1;            // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
+          StorageDead(_17);                // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
+          StorageDead(_16);                // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
           StorageDead(_8);                 // scope 2 at $DIR/separate_const_switch.rs:29:9: 29:10
           StorageDead(_6);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
           StorageDead(_2);                 // scope 0 at $DIR/separate_const_switch.rs:29:10: 29:11
           StorageDead(_3);                 // scope 0 at $DIR/separate_const_switch.rs:30:1: 30:2
           return;                          // scope 0 at $DIR/separate_const_switch.rs:30:2: 30:2
+      }
+  
+-     bb4: {
++     bb3: {
+          StorageLive(_13);                // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+          _13 = move ((_4 as Err).0: i32); // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+          StorageLive(_14);                // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+          StorageLive(_15);                // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+          _15 = move _13;                  // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+          Deinit(_14);                     // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+          ((_14 as Err).0: i32) = move _15; // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+          discriminant(_14) = 1;           // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+          StorageDead(_15);                // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+          Deinit(_3);                      // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+          ((_3 as Break).0: std::result::Result<std::convert::Infallible, i32>) = move _14; // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+          discriminant(_3) = 1;            // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+          StorageDead(_14);                // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
+          StorageDead(_13);                // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+-         goto -> bb1;                     // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
++         StorageDead(_10);                // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
++         StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
++         _5 = discriminant(_3);           // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
++         switchInt(move _5) -> [0_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
+      }
+  
+-     bb5: {
++     bb4: {
+          unreachable;                     // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+      }
+  
+-     bb6: {
++     bb5: {
+          StorageLive(_11);                // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+          _11 = move ((_4 as Ok).0: i32);  // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+          StorageLive(_12);                // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
+          _12 = move _11;                  // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
+          Deinit(_3);                      // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
+          ((_3 as Continue).0: i32) = move _12; // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
+          discriminant(_3) = 0;            // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
+          StorageDead(_12);                // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
+          StorageDead(_11);                // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+-         goto -> bb1;                     // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
++         StorageDead(_10);                // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
++         StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
++         _5 = discriminant(_3);           // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
++         switchInt(move _5) -> [0_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
       }
   }
   

--- a/src/test/mir-opt/separate_const_switch.identity.SeparateConstSwitch.diff
+++ b/src/test/mir-opt/separate_const_switch.identity.SeparateConstSwitch.diff
@@ -15,15 +15,15 @@
       scope 1 {
           debug residual => _6;            // in scope 1 at $DIR/separate_const_switch.rs:29:9: 29:10
           scope 2 {
-              scope 8 (inlined #[track_caller] <Result<i32, i32> as FromResidual<Result<Infallible, i32>>>::from_residual) { // at $DIR/separate_const_switch.rs:29:8: 29:10
-                  debug residual => _8;    // in scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
-                  let _16: i32;            // in scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
-                  let mut _17: i32;        // in scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
-                  let mut _18: i32;        // in scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
-                  scope 9 {
-                      debug e => _16;      // in scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
-                      scope 10 (inlined <i32 as From<i32>>::from) { // at $SRC_DIR/core/src/result.rs:LL:COL
-                          debug t => _18;  // in scope 10 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
+              scope 5 (inlined #[track_caller] <Result<i32, i32> as FromResidual<Result<Infallible, i32>>>::from_residual) { // at $DIR/separate_const_switch.rs:29:8: 29:10
+                  debug residual => _8;    // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+                  let _10: i32;            // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+                  let mut _11: i32;        // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+                  let mut _12: i32;        // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+                  scope 6 {
+                      debug e => _10;      // in scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
+                      scope 7 (inlined <i32 as From<i32>>::from) { // at $SRC_DIR/core/src/result.rs:LL:COL
+                          debug t => _12;  // in scope 7 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
                       }
                   }
               }
@@ -34,45 +34,30 @@
           scope 4 {
           }
       }
-      scope 5 (inlined <Result<i32, i32> as Try>::branch) { // at $DIR/separate_const_switch.rs:29:8: 29:10
-          debug self => _4;                // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-          let mut _10: isize;              // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-          let _11: i32;                    // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-          let mut _12: i32;                // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-          let _13: i32;                    // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-          let mut _14: std::result::Result<std::convert::Infallible, i32>; // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-          let mut _15: i32;                // in scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-          scope 6 {
-              debug v => _11;              // in scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
-          }
-          scope 7 {
-              debug e => _13;              // in scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
-          }
-      }
   
       bb0: {
           StorageLive(_2);                 // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
           StorageLive(_3);                 // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
           StorageLive(_4);                 // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:9
           _4 = _1;                         // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:9
-          StorageLive(_10);                // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-          _10 = discriminant(_4);          // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
--         switchInt(move _10) -> [0_isize: bb6, 1_isize: bb4, otherwise: bb5]; // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-+         switchInt(move _10) -> [0_isize: bb5, 1_isize: bb3, otherwise: bb4]; // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+          _3 = <Result<i32, i32> as Try>::branch(move _4) -> bb1; // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
+                                           // mir::Constant
+                                           // + span: $DIR/separate_const_switch.rs:29:8: 29:10
+                                           // + literal: Const { ty: fn(Result<i32, i32>) -> ControlFlow<<Result<i32, i32> as Try>::Residual, <Result<i32, i32> as Try>::Output> {<Result<i32, i32> as Try>::branch}, val: Value(Scalar(<ZST>)) }
       }
   
       bb1: {
--         StorageDead(_10);                // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
--         StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
--         _5 = discriminant(_3);           // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
--         switchInt(move _5) -> [0_isize: bb2, otherwise: bb3]; // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
--     }
-- 
--     bb2: {
+          StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
+          _5 = discriminant(_3);           // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
+          switchInt(move _5) -> [0_isize: bb2, otherwise: bb3]; // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
+      }
+  
+      bb2: {
           StorageLive(_9);                 // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
           _9 = ((_3 as Continue).0: i32);  // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
           _2 = _9;                         // scope 4 at $DIR/separate_const_switch.rs:29:8: 29:10
           StorageDead(_9);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
+          Deinit(_0);                      // scope 0 at $DIR/separate_const_switch.rs:29:5: 29:11
           ((_0 as Ok).0: i32) = move _2;   // scope 0 at $DIR/separate_const_switch.rs:29:5: 29:11
           discriminant(_0) = 0;            // scope 0 at $DIR/separate_const_switch.rs:29:5: 29:11
           StorageDead(_2);                 // scope 0 at $DIR/separate_const_switch.rs:29:10: 29:11
@@ -80,71 +65,28 @@
           return;                          // scope 0 at $DIR/separate_const_switch.rs:30:2: 30:2
       }
   
--     bb3: {
-+     bb2: {
+      bb3: {
           StorageLive(_6);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
           _6 = ((_3 as Break).0: std::result::Result<std::convert::Infallible, i32>); // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
           StorageLive(_8);                 // scope 2 at $DIR/separate_const_switch.rs:29:9: 29:10
           _8 = _6;                         // scope 2 at $DIR/separate_const_switch.rs:29:9: 29:10
-          StorageLive(_16);                // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
-          _16 = move ((_8 as Err).0: i32); // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
-          StorageLive(_17);                // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
-          StorageLive(_18);                // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
-          _18 = move _16;                  // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
-          _17 = move _18;                  // scope 10 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
-          StorageDead(_18);                // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
-          ((_0 as Err).0: i32) = move _17; // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
-          discriminant(_0) = 1;            // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
-          StorageDead(_17);                // scope 9 at $SRC_DIR/core/src/result.rs:LL:COL
-          StorageDead(_16);                // scope 8 at $SRC_DIR/core/src/result.rs:LL:COL
+          StorageLive(_10);                // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+          _10 = move ((_8 as Err).0: i32); // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
+          StorageLive(_11);                // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
+          StorageLive(_12);                // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
+          _12 = move _10;                  // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
+          _11 = move _12;                  // scope 7 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
+          StorageDead(_12);                // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
+          Deinit(_0);                      // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
+          ((_0 as Err).0: i32) = move _11; // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
+          discriminant(_0) = 1;            // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
+          StorageDead(_11);                // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
+          StorageDead(_10);                // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
           StorageDead(_8);                 // scope 2 at $DIR/separate_const_switch.rs:29:9: 29:10
           StorageDead(_6);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
           StorageDead(_2);                 // scope 0 at $DIR/separate_const_switch.rs:29:10: 29:11
           StorageDead(_3);                 // scope 0 at $DIR/separate_const_switch.rs:30:1: 30:2
           return;                          // scope 0 at $DIR/separate_const_switch.rs:30:2: 30:2
-      }
-  
--     bb4: {
-+     bb3: {
-          StorageLive(_13);                // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-          _13 = move ((_4 as Err).0: i32); // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-          StorageLive(_14);                // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
-          StorageLive(_15);                // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
-          _15 = move _13;                  // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
-          ((_14 as Err).0: i32) = move _15; // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
-          discriminant(_14) = 1;           // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
-          StorageDead(_15);                // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
-          ((_3 as Break).0: std::result::Result<std::convert::Infallible, i32>) = move _14; // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
-          discriminant(_3) = 1;            // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
-          StorageDead(_14);                // scope 7 at $SRC_DIR/core/src/result.rs:LL:COL
-          StorageDead(_13);                // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
--         goto -> bb1;                     // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-+         StorageDead(_10);                // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-+         StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
-+         _5 = discriminant(_3);           // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-+         switchInt(move _5) -> [0_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-      }
-  
--     bb5: {
-+     bb4: {
-          unreachable;                     // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-      }
-  
--     bb6: {
-+     bb5: {
-          StorageLive(_11);                // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-          _11 = move ((_4 as Ok).0: i32);  // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-          StorageLive(_12);                // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
-          _12 = move _11;                  // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
-          ((_3 as Continue).0: i32) = move _12; // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
-          discriminant(_3) = 0;            // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
-          StorageDead(_12);                // scope 6 at $SRC_DIR/core/src/result.rs:LL:COL
-          StorageDead(_11);                // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
--         goto -> bb1;                     // scope 5 at $SRC_DIR/core/src/result.rs:LL:COL
-+         StorageDead(_10);                // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-+         StorageDead(_4);                 // scope 0 at $DIR/separate_const_switch.rs:29:9: 29:10
-+         _5 = discriminant(_3);           // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
-+         switchInt(move _5) -> [0_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/separate_const_switch.rs:29:8: 29:10
       }
   }
   

--- a/src/test/mir-opt/separate_const_switch.too_complex.ConstProp.diff
+++ b/src/test/mir-opt/separate_const_switch.too_complex.ConstProp.diff
@@ -38,6 +38,7 @@
           _6 = ((_1 as Err).0: usize);     // scope 0 at $DIR/separate_const_switch.rs:17:17: 17:18
           StorageLive(_7);                 // scope 2 at $DIR/separate_const_switch.rs:17:42: 17:43
           _7 = _6;                         // scope 2 at $DIR/separate_const_switch.rs:17:42: 17:43
+          Deinit(_2);                      // scope 2 at $DIR/separate_const_switch.rs:17:23: 17:44
           ((_2 as Break).0: usize) = move _7; // scope 2 at $DIR/separate_const_switch.rs:17:23: 17:44
           discriminant(_2) = 1;            // scope 2 at $DIR/separate_const_switch.rs:17:23: 17:44
           StorageDead(_7);                 // scope 2 at $DIR/separate_const_switch.rs:17:43: 17:44
@@ -53,6 +54,7 @@
           _4 = ((_1 as Ok).0: i32);        // scope 0 at $DIR/separate_const_switch.rs:16:16: 16:17
           StorageLive(_5);                 // scope 1 at $DIR/separate_const_switch.rs:16:44: 16:45
           _5 = _4;                         // scope 1 at $DIR/separate_const_switch.rs:16:44: 16:45
+          Deinit(_2);                      // scope 1 at $DIR/separate_const_switch.rs:16:22: 16:46
           ((_2 as Continue).0: i32) = move _5; // scope 1 at $DIR/separate_const_switch.rs:16:22: 16:46
           discriminant(_2) = 0;            // scope 1 at $DIR/separate_const_switch.rs:16:22: 16:46
           StorageDead(_5);                 // scope 1 at $DIR/separate_const_switch.rs:16:45: 16:46
@@ -66,6 +68,7 @@
       bb3: {
           StorageLive(_11);                // scope 0 at $DIR/separate_const_switch.rs:21:28: 21:29
           _11 = ((_2 as Break).0: usize);  // scope 0 at $DIR/separate_const_switch.rs:21:28: 21:29
+          Deinit(_0);                      // scope 4 at $DIR/separate_const_switch.rs:21:34: 21:38
           discriminant(_0) = 0;            // scope 4 at $DIR/separate_const_switch.rs:21:34: 21:38
           StorageDead(_11);                // scope 0 at $DIR/separate_const_switch.rs:21:37: 21:38
           goto -> bb5;                     // scope 0 at $DIR/separate_const_switch.rs:21:37: 21:38
@@ -76,6 +79,7 @@
           _9 = ((_2 as Continue).0: i32);  // scope 0 at $DIR/separate_const_switch.rs:20:31: 20:32
           StorageLive(_10);                // scope 3 at $DIR/separate_const_switch.rs:20:42: 20:43
           _10 = _9;                        // scope 3 at $DIR/separate_const_switch.rs:20:42: 20:43
+          Deinit(_0);                      // scope 3 at $DIR/separate_const_switch.rs:20:37: 20:44
           ((_0 as Some).0: i32) = move _10; // scope 3 at $DIR/separate_const_switch.rs:20:37: 20:44
           discriminant(_0) = 1;            // scope 3 at $DIR/separate_const_switch.rs:20:37: 20:44
           StorageDead(_10);                // scope 3 at $DIR/separate_const_switch.rs:20:43: 20:44

--- a/src/test/mir-opt/separate_const_switch.too_complex.PreCodegen.after.mir
+++ b/src/test/mir-opt/separate_const_switch.too_complex.PreCodegen.after.mir
@@ -36,12 +36,14 @@ fn too_complex(_1: Result<i32, usize>) -> Option<i32> {
         _6 = ((_1 as Err).0: usize);     // scope 0 at $DIR/separate_const_switch.rs:17:17: 17:18
         StorageLive(_7);                 // scope 2 at $DIR/separate_const_switch.rs:17:42: 17:43
         _7 = _6;                         // scope 2 at $DIR/separate_const_switch.rs:17:42: 17:43
+        Deinit(_2);                      // scope 2 at $DIR/separate_const_switch.rs:17:23: 17:44
         ((_2 as Break).0: usize) = move _7; // scope 2 at $DIR/separate_const_switch.rs:17:23: 17:44
         discriminant(_2) = 1;            // scope 2 at $DIR/separate_const_switch.rs:17:23: 17:44
         StorageDead(_7);                 // scope 2 at $DIR/separate_const_switch.rs:17:43: 17:44
         StorageDead(_6);                 // scope 0 at $DIR/separate_const_switch.rs:17:43: 17:44
         StorageLive(_10);                // scope 0 at $DIR/separate_const_switch.rs:21:28: 21:29
         _10 = ((_2 as Break).0: usize);  // scope 0 at $DIR/separate_const_switch.rs:21:28: 21:29
+        Deinit(_0);                      // scope 4 at $DIR/separate_const_switch.rs:21:34: 21:38
         discriminant(_0) = 0;            // scope 4 at $DIR/separate_const_switch.rs:21:34: 21:38
         StorageDead(_10);                // scope 0 at $DIR/separate_const_switch.rs:21:37: 21:38
         goto -> bb3;                     // scope 0 at $DIR/separate_const_switch.rs:21:37: 21:38
@@ -52,6 +54,7 @@ fn too_complex(_1: Result<i32, usize>) -> Option<i32> {
         _4 = ((_1 as Ok).0: i32);        // scope 0 at $DIR/separate_const_switch.rs:16:16: 16:17
         StorageLive(_5);                 // scope 1 at $DIR/separate_const_switch.rs:16:44: 16:45
         _5 = _4;                         // scope 1 at $DIR/separate_const_switch.rs:16:44: 16:45
+        Deinit(_2);                      // scope 1 at $DIR/separate_const_switch.rs:16:22: 16:46
         ((_2 as Continue).0: i32) = move _5; // scope 1 at $DIR/separate_const_switch.rs:16:22: 16:46
         discriminant(_2) = 0;            // scope 1 at $DIR/separate_const_switch.rs:16:22: 16:46
         StorageDead(_5);                 // scope 1 at $DIR/separate_const_switch.rs:16:45: 16:46
@@ -60,6 +63,7 @@ fn too_complex(_1: Result<i32, usize>) -> Option<i32> {
         _8 = ((_2 as Continue).0: i32);  // scope 0 at $DIR/separate_const_switch.rs:20:31: 20:32
         StorageLive(_9);                 // scope 3 at $DIR/separate_const_switch.rs:20:42: 20:43
         _9 = _8;                         // scope 3 at $DIR/separate_const_switch.rs:20:42: 20:43
+        Deinit(_0);                      // scope 3 at $DIR/separate_const_switch.rs:20:37: 20:44
         ((_0 as Some).0: i32) = move _9; // scope 3 at $DIR/separate_const_switch.rs:20:37: 20:44
         discriminant(_0) = 1;            // scope 3 at $DIR/separate_const_switch.rs:20:37: 20:44
         StorageDead(_9);                 // scope 3 at $DIR/separate_const_switch.rs:20:43: 20:44

--- a/src/test/mir-opt/separate_const_switch.too_complex.SeparateConstSwitch.diff
+++ b/src/test/mir-opt/separate_const_switch.too_complex.SeparateConstSwitch.diff
@@ -38,6 +38,7 @@
           _6 = ((_1 as Err).0: usize);     // scope 0 at $DIR/separate_const_switch.rs:17:17: 17:18
           StorageLive(_7);                 // scope 2 at $DIR/separate_const_switch.rs:17:42: 17:43
           _7 = _6;                         // scope 2 at $DIR/separate_const_switch.rs:17:42: 17:43
+          Deinit(_2);                      // scope 2 at $DIR/separate_const_switch.rs:17:23: 17:44
           ((_2 as Break).0: usize) = move _7; // scope 2 at $DIR/separate_const_switch.rs:17:23: 17:44
           discriminant(_2) = 1;            // scope 2 at $DIR/separate_const_switch.rs:17:23: 17:44
           StorageDead(_7);                 // scope 2 at $DIR/separate_const_switch.rs:17:43: 17:44
@@ -52,6 +53,7 @@
           _4 = ((_1 as Ok).0: i32);        // scope 0 at $DIR/separate_const_switch.rs:16:16: 16:17
           StorageLive(_5);                 // scope 1 at $DIR/separate_const_switch.rs:16:44: 16:45
           _5 = _4;                         // scope 1 at $DIR/separate_const_switch.rs:16:44: 16:45
+          Deinit(_2);                      // scope 1 at $DIR/separate_const_switch.rs:16:22: 16:46
           ((_2 as Continue).0: i32) = move _5; // scope 1 at $DIR/separate_const_switch.rs:16:22: 16:46
           discriminant(_2) = 0;            // scope 1 at $DIR/separate_const_switch.rs:16:22: 16:46
           StorageDead(_5);                 // scope 1 at $DIR/separate_const_switch.rs:16:45: 16:46
@@ -69,6 +71,7 @@
 +     bb3: {
           StorageLive(_11);                // scope 0 at $DIR/separate_const_switch.rs:21:28: 21:29
           _11 = ((_2 as Break).0: usize);  // scope 0 at $DIR/separate_const_switch.rs:21:28: 21:29
+          Deinit(_0);                      // scope 4 at $DIR/separate_const_switch.rs:21:34: 21:38
           discriminant(_0) = 0;            // scope 4 at $DIR/separate_const_switch.rs:21:34: 21:38
           StorageDead(_11);                // scope 0 at $DIR/separate_const_switch.rs:21:37: 21:38
 -         goto -> bb6;                     // scope 0 at $DIR/separate_const_switch.rs:21:37: 21:38
@@ -81,6 +84,7 @@
           _9 = ((_2 as Continue).0: i32);  // scope 0 at $DIR/separate_const_switch.rs:20:31: 20:32
           StorageLive(_10);                // scope 3 at $DIR/separate_const_switch.rs:20:42: 20:43
           _10 = _9;                        // scope 3 at $DIR/separate_const_switch.rs:20:42: 20:43
+          Deinit(_0);                      // scope 3 at $DIR/separate_const_switch.rs:20:37: 20:44
           ((_0 as Some).0: i32) = move _10; // scope 3 at $DIR/separate_const_switch.rs:20:37: 20:44
           discriminant(_0) = 1;            // scope 3 at $DIR/separate_const_switch.rs:20:37: 20:44
           StorageDead(_10);                // scope 3 at $DIR/separate_const_switch.rs:20:43: 20:44

--- a/src/test/mir-opt/simplify_arm.id.SimplifyArmIdentity.diff
+++ b/src/test/mir-opt/simplify_arm.id.SimplifyArmIdentity.diff
@@ -8,8 +8,7 @@
       let _3: u8;                          // in scope 0 at $DIR/simplify-arm.rs:11:14: 11:15
       let mut _4: u8;                      // in scope 0 at $DIR/simplify-arm.rs:11:25: 11:26
       scope 1 {
--         debug v => _3;                   // in scope 1 at $DIR/simplify-arm.rs:11:14: 11:15
-+         debug v => ((_0 as Some).0: u8); // in scope 1 at $DIR/simplify-arm.rs:11:14: 11:15
+          debug v => _3;                   // in scope 1 at $DIR/simplify-arm.rs:11:14: 11:15
       }
   
       bb0: {
@@ -18,6 +17,7 @@
       }
   
       bb1: {
+          Deinit(_0);                      // scope 0 at $DIR/simplify-arm.rs:12:17: 12:21
           discriminant(_0) = 0;            // scope 0 at $DIR/simplify-arm.rs:12:17: 12:21
           goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:12:17: 12:21
       }
@@ -27,15 +27,15 @@
       }
   
       bb3: {
--         StorageLive(_3);                 // scope 0 at $DIR/simplify-arm.rs:11:14: 11:15
--         _3 = ((_1 as Some).0: u8);       // scope 0 at $DIR/simplify-arm.rs:11:14: 11:15
--         StorageLive(_4);                 // scope 1 at $DIR/simplify-arm.rs:11:25: 11:26
--         _4 = _3;                         // scope 1 at $DIR/simplify-arm.rs:11:25: 11:26
--         ((_0 as Some).0: u8) = move _4;  // scope 1 at $DIR/simplify-arm.rs:11:20: 11:27
--         discriminant(_0) = 1;            // scope 1 at $DIR/simplify-arm.rs:11:20: 11:27
--         StorageDead(_4);                 // scope 1 at $DIR/simplify-arm.rs:11:26: 11:27
--         StorageDead(_3);                 // scope 0 at $DIR/simplify-arm.rs:11:26: 11:27
-+         _0 = move _1;                    // scope 1 at $DIR/simplify-arm.rs:11:20: 11:27
+          StorageLive(_3);                 // scope 0 at $DIR/simplify-arm.rs:11:14: 11:15
+          _3 = ((_1 as Some).0: u8);       // scope 0 at $DIR/simplify-arm.rs:11:14: 11:15
+          StorageLive(_4);                 // scope 1 at $DIR/simplify-arm.rs:11:25: 11:26
+          _4 = _3;                         // scope 1 at $DIR/simplify-arm.rs:11:25: 11:26
+          Deinit(_0);                      // scope 1 at $DIR/simplify-arm.rs:11:20: 11:27
+          ((_0 as Some).0: u8) = move _4;  // scope 1 at $DIR/simplify-arm.rs:11:20: 11:27
+          discriminant(_0) = 1;            // scope 1 at $DIR/simplify-arm.rs:11:20: 11:27
+          StorageDead(_4);                 // scope 1 at $DIR/simplify-arm.rs:11:26: 11:27
+          StorageDead(_3);                 // scope 0 at $DIR/simplify-arm.rs:11:26: 11:27
           goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:11:26: 11:27
       }
   

--- a/src/test/mir-opt/simplify_arm.id.SimplifyBranchSame.diff
+++ b/src/test/mir-opt/simplify_arm.id.SimplifyBranchSame.diff
@@ -8,32 +8,38 @@
       let _3: u8;                          // in scope 0 at $DIR/simplify-arm.rs:11:14: 11:15
       let mut _4: u8;                      // in scope 0 at $DIR/simplify-arm.rs:11:25: 11:26
       scope 1 {
-          debug v => ((_0 as Some).0: u8); // in scope 1 at $DIR/simplify-arm.rs:11:14: 11:15
+          debug v => _3;                   // in scope 1 at $DIR/simplify-arm.rs:11:14: 11:15
       }
   
       bb0: {
           _2 = discriminant(_1);           // scope 0 at $DIR/simplify-arm.rs:10:11: 10:12
--         switchInt(move _2) -> [0_isize: bb1, 1_isize: bb3, otherwise: bb2]; // scope 0 at $DIR/simplify-arm.rs:10:5: 10:12
-+         goto -> bb1;                     // scope 0 at $DIR/simplify-arm.rs:10:5: 10:12
+          switchInt(move _2) -> [0_isize: bb1, 1_isize: bb3, otherwise: bb2]; // scope 0 at $DIR/simplify-arm.rs:10:5: 10:12
       }
   
       bb1: {
--         discriminant(_0) = 0;            // scope 0 at $DIR/simplify-arm.rs:12:17: 12:21
--         goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:12:17: 12:21
--     }
-- 
--     bb2: {
--         unreachable;                     // scope 0 at $DIR/simplify-arm.rs:10:11: 10:12
--     }
-- 
--     bb3: {
-          _0 = move _1;                    // scope 1 at $DIR/simplify-arm.rs:11:20: 11:27
--         goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:11:26: 11:27
-+         goto -> bb2;                     // scope 0 at $DIR/simplify-arm.rs:11:26: 11:27
+          Deinit(_0);                      // scope 0 at $DIR/simplify-arm.rs:12:17: 12:21
+          discriminant(_0) = 0;            // scope 0 at $DIR/simplify-arm.rs:12:17: 12:21
+          goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:12:17: 12:21
       }
   
--     bb4: {
-+     bb2: {
+      bb2: {
+          unreachable;                     // scope 0 at $DIR/simplify-arm.rs:10:11: 10:12
+      }
+  
+      bb3: {
+          StorageLive(_3);                 // scope 0 at $DIR/simplify-arm.rs:11:14: 11:15
+          _3 = ((_1 as Some).0: u8);       // scope 0 at $DIR/simplify-arm.rs:11:14: 11:15
+          StorageLive(_4);                 // scope 1 at $DIR/simplify-arm.rs:11:25: 11:26
+          _4 = _3;                         // scope 1 at $DIR/simplify-arm.rs:11:25: 11:26
+          Deinit(_0);                      // scope 1 at $DIR/simplify-arm.rs:11:20: 11:27
+          ((_0 as Some).0: u8) = move _4;  // scope 1 at $DIR/simplify-arm.rs:11:20: 11:27
+          discriminant(_0) = 1;            // scope 1 at $DIR/simplify-arm.rs:11:20: 11:27
+          StorageDead(_4);                 // scope 1 at $DIR/simplify-arm.rs:11:26: 11:27
+          StorageDead(_3);                 // scope 0 at $DIR/simplify-arm.rs:11:26: 11:27
+          goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:11:26: 11:27
+      }
+  
+      bb4: {
           return;                          // scope 0 at $DIR/simplify-arm.rs:14:2: 14:2
       }
   }

--- a/src/test/mir-opt/simplify_arm.id_result.SimplifyArmIdentity.diff
+++ b/src/test/mir-opt/simplify_arm.id_result.SimplifyArmIdentity.diff
@@ -10,12 +10,10 @@
       let _5: i32;                         // in scope 0 at $DIR/simplify-arm.rs:19:13: 19:14
       let mut _6: i32;                     // in scope 0 at $DIR/simplify-arm.rs:19:23: 19:24
       scope 1 {
--         debug x => _3;                   // in scope 1 at $DIR/simplify-arm.rs:18:12: 18:13
-+         debug x => ((_0 as Ok).0: u8);   // in scope 1 at $DIR/simplify-arm.rs:18:12: 18:13
+          debug x => _3;                   // in scope 1 at $DIR/simplify-arm.rs:18:12: 18:13
       }
       scope 2 {
--         debug y => _5;                   // in scope 2 at $DIR/simplify-arm.rs:19:13: 19:14
-+         debug y => ((_0 as Err).0: i32); // in scope 2 at $DIR/simplify-arm.rs:19:13: 19:14
+          debug y => _5;                   // in scope 2 at $DIR/simplify-arm.rs:19:13: 19:14
       }
   
       bb0: {
@@ -24,15 +22,15 @@
       }
   
       bb1: {
--         StorageLive(_5);                 // scope 0 at $DIR/simplify-arm.rs:19:13: 19:14
--         _5 = ((_1 as Err).0: i32);       // scope 0 at $DIR/simplify-arm.rs:19:13: 19:14
--         StorageLive(_6);                 // scope 2 at $DIR/simplify-arm.rs:19:23: 19:24
--         _6 = _5;                         // scope 2 at $DIR/simplify-arm.rs:19:23: 19:24
--         ((_0 as Err).0: i32) = move _6;  // scope 2 at $DIR/simplify-arm.rs:19:19: 19:25
--         discriminant(_0) = 1;            // scope 2 at $DIR/simplify-arm.rs:19:19: 19:25
--         StorageDead(_6);                 // scope 2 at $DIR/simplify-arm.rs:19:24: 19:25
--         StorageDead(_5);                 // scope 0 at $DIR/simplify-arm.rs:19:24: 19:25
-+         _0 = move _1;                    // scope 2 at $DIR/simplify-arm.rs:19:19: 19:25
+          StorageLive(_5);                 // scope 0 at $DIR/simplify-arm.rs:19:13: 19:14
+          _5 = ((_1 as Err).0: i32);       // scope 0 at $DIR/simplify-arm.rs:19:13: 19:14
+          StorageLive(_6);                 // scope 2 at $DIR/simplify-arm.rs:19:23: 19:24
+          _6 = _5;                         // scope 2 at $DIR/simplify-arm.rs:19:23: 19:24
+          Deinit(_0);                      // scope 2 at $DIR/simplify-arm.rs:19:19: 19:25
+          ((_0 as Err).0: i32) = move _6;  // scope 2 at $DIR/simplify-arm.rs:19:19: 19:25
+          discriminant(_0) = 1;            // scope 2 at $DIR/simplify-arm.rs:19:19: 19:25
+          StorageDead(_6);                 // scope 2 at $DIR/simplify-arm.rs:19:24: 19:25
+          StorageDead(_5);                 // scope 0 at $DIR/simplify-arm.rs:19:24: 19:25
           goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:19:24: 19:25
       }
   
@@ -41,15 +39,15 @@
       }
   
       bb3: {
--         StorageLive(_3);                 // scope 0 at $DIR/simplify-arm.rs:18:12: 18:13
--         _3 = ((_1 as Ok).0: u8);         // scope 0 at $DIR/simplify-arm.rs:18:12: 18:13
--         StorageLive(_4);                 // scope 1 at $DIR/simplify-arm.rs:18:21: 18:22
--         _4 = _3;                         // scope 1 at $DIR/simplify-arm.rs:18:21: 18:22
--         ((_0 as Ok).0: u8) = move _4;    // scope 1 at $DIR/simplify-arm.rs:18:18: 18:23
--         discriminant(_0) = 0;            // scope 1 at $DIR/simplify-arm.rs:18:18: 18:23
--         StorageDead(_4);                 // scope 1 at $DIR/simplify-arm.rs:18:22: 18:23
--         StorageDead(_3);                 // scope 0 at $DIR/simplify-arm.rs:18:22: 18:23
-+         _0 = move _1;                    // scope 1 at $DIR/simplify-arm.rs:18:18: 18:23
+          StorageLive(_3);                 // scope 0 at $DIR/simplify-arm.rs:18:12: 18:13
+          _3 = ((_1 as Ok).0: u8);         // scope 0 at $DIR/simplify-arm.rs:18:12: 18:13
+          StorageLive(_4);                 // scope 1 at $DIR/simplify-arm.rs:18:21: 18:22
+          _4 = _3;                         // scope 1 at $DIR/simplify-arm.rs:18:21: 18:22
+          Deinit(_0);                      // scope 1 at $DIR/simplify-arm.rs:18:18: 18:23
+          ((_0 as Ok).0: u8) = move _4;    // scope 1 at $DIR/simplify-arm.rs:18:18: 18:23
+          discriminant(_0) = 0;            // scope 1 at $DIR/simplify-arm.rs:18:18: 18:23
+          StorageDead(_4);                 // scope 1 at $DIR/simplify-arm.rs:18:22: 18:23
+          StorageDead(_3);                 // scope 0 at $DIR/simplify-arm.rs:18:22: 18:23
           goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:18:22: 18:23
       }
   

--- a/src/test/mir-opt/simplify_arm.id_result.SimplifyBranchSame.diff
+++ b/src/test/mir-opt/simplify_arm.id_result.SimplifyBranchSame.diff
@@ -10,35 +10,48 @@
       let _5: i32;                         // in scope 0 at $DIR/simplify-arm.rs:19:13: 19:14
       let mut _6: i32;                     // in scope 0 at $DIR/simplify-arm.rs:19:23: 19:24
       scope 1 {
-          debug x => ((_0 as Ok).0: u8);   // in scope 1 at $DIR/simplify-arm.rs:18:12: 18:13
+          debug x => _3;                   // in scope 1 at $DIR/simplify-arm.rs:18:12: 18:13
       }
       scope 2 {
-          debug y => ((_0 as Err).0: i32); // in scope 2 at $DIR/simplify-arm.rs:19:13: 19:14
+          debug y => _5;                   // in scope 2 at $DIR/simplify-arm.rs:19:13: 19:14
       }
   
       bb0: {
           _2 = discriminant(_1);           // scope 0 at $DIR/simplify-arm.rs:17:11: 17:12
--         switchInt(move _2) -> [0_isize: bb3, 1_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/simplify-arm.rs:17:5: 17:12
-+         goto -> bb1;                     // scope 0 at $DIR/simplify-arm.rs:17:5: 17:12
+          switchInt(move _2) -> [0_isize: bb3, 1_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/simplify-arm.rs:17:5: 17:12
       }
   
       bb1: {
--         _0 = move _1;                    // scope 2 at $DIR/simplify-arm.rs:19:19: 19:25
--         goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:19:24: 19:25
--     }
-- 
--     bb2: {
--         unreachable;                     // scope 0 at $DIR/simplify-arm.rs:17:11: 17:12
--     }
-- 
--     bb3: {
-          _0 = move _1;                    // scope 1 at $DIR/simplify-arm.rs:18:18: 18:23
--         goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:18:22: 18:23
-+         goto -> bb2;                     // scope 0 at $DIR/simplify-arm.rs:18:22: 18:23
+          StorageLive(_5);                 // scope 0 at $DIR/simplify-arm.rs:19:13: 19:14
+          _5 = ((_1 as Err).0: i32);       // scope 0 at $DIR/simplify-arm.rs:19:13: 19:14
+          StorageLive(_6);                 // scope 2 at $DIR/simplify-arm.rs:19:23: 19:24
+          _6 = _5;                         // scope 2 at $DIR/simplify-arm.rs:19:23: 19:24
+          Deinit(_0);                      // scope 2 at $DIR/simplify-arm.rs:19:19: 19:25
+          ((_0 as Err).0: i32) = move _6;  // scope 2 at $DIR/simplify-arm.rs:19:19: 19:25
+          discriminant(_0) = 1;            // scope 2 at $DIR/simplify-arm.rs:19:19: 19:25
+          StorageDead(_6);                 // scope 2 at $DIR/simplify-arm.rs:19:24: 19:25
+          StorageDead(_5);                 // scope 0 at $DIR/simplify-arm.rs:19:24: 19:25
+          goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:19:24: 19:25
       }
   
--     bb4: {
-+     bb2: {
+      bb2: {
+          unreachable;                     // scope 0 at $DIR/simplify-arm.rs:17:11: 17:12
+      }
+  
+      bb3: {
+          StorageLive(_3);                 // scope 0 at $DIR/simplify-arm.rs:18:12: 18:13
+          _3 = ((_1 as Ok).0: u8);         // scope 0 at $DIR/simplify-arm.rs:18:12: 18:13
+          StorageLive(_4);                 // scope 1 at $DIR/simplify-arm.rs:18:21: 18:22
+          _4 = _3;                         // scope 1 at $DIR/simplify-arm.rs:18:21: 18:22
+          Deinit(_0);                      // scope 1 at $DIR/simplify-arm.rs:18:18: 18:23
+          ((_0 as Ok).0: u8) = move _4;    // scope 1 at $DIR/simplify-arm.rs:18:18: 18:23
+          discriminant(_0) = 0;            // scope 1 at $DIR/simplify-arm.rs:18:18: 18:23
+          StorageDead(_4);                 // scope 1 at $DIR/simplify-arm.rs:18:22: 18:23
+          StorageDead(_3);                 // scope 0 at $DIR/simplify-arm.rs:18:22: 18:23
+          goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:18:22: 18:23
+      }
+  
+      bb4: {
           return;                          // scope 0 at $DIR/simplify-arm.rs:21:2: 21:2
       }
   }

--- a/src/test/mir-opt/simplify_arm.id_try.SimplifyArmIdentity.diff
+++ b/src/test/mir-opt/simplify_arm.id_try.SimplifyArmIdentity.diff
@@ -15,24 +15,19 @@
       let _10: u8;                         // in scope 0 at $DIR/simplify-arm.rs:38:12: 38:13
       let mut _11: u8;                     // in scope 0 at $DIR/simplify-arm.rs:40:8: 40:9
       scope 1 {
--         debug x => _2;                   // in scope 1 at $DIR/simplify-arm.rs:36:9: 36:10
-+         debug x => ((_0 as Ok).0: u8);   // in scope 1 at $DIR/simplify-arm.rs:36:9: 36:10
+          debug x => _2;                   // in scope 1 at $DIR/simplify-arm.rs:36:9: 36:10
       }
       scope 2 {
--         debug e => _6;                   // in scope 2 at $DIR/simplify-arm.rs:37:13: 37:14
-+         debug e => ((_0 as Err).0: i32); // in scope 2 at $DIR/simplify-arm.rs:37:13: 37:14
+          debug e => _6;                   // in scope 2 at $DIR/simplify-arm.rs:37:13: 37:14
           scope 5 (inlined <i32 as From<i32>>::from) { // at $DIR/simplify-arm.rs:37:37: 37:50
--             debug t => _9;               // in scope 5 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
-+             debug t => ((_0 as Err).0: i32); // in scope 5 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
+              debug t => _9;               // in scope 5 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
           }
           scope 6 (inlined from_error::<u8, i32>) { // at $DIR/simplify-arm.rs:37:26: 37:51
--             debug e => _8;               // in scope 6 at $DIR/simplify-arm.rs:27:21: 27:22
-+             debug e => ((_0 as Err).0: i32); // in scope 6 at $DIR/simplify-arm.rs:27:21: 27:22
+              debug e => _8;               // in scope 6 at $DIR/simplify-arm.rs:27:21: 27:22
           }
       }
       scope 3 {
--         debug v => _10;                  // in scope 3 at $DIR/simplify-arm.rs:38:12: 38:13
-+         debug v => ((_0 as Ok).0: u8);   // in scope 3 at $DIR/simplify-arm.rs:38:12: 38:13
+          debug v => _10;                  // in scope 3 at $DIR/simplify-arm.rs:38:12: 38:13
       }
       scope 4 (inlined into_result::<u8, i32>) { // at $DIR/simplify-arm.rs:36:19: 36:33
           debug r => _4;                   // in scope 4 at $DIR/simplify-arm.rs:23:22: 23:23
@@ -50,17 +45,17 @@
       }
   
       bb1: {
--         StorageLive(_10);                // scope 0 at $DIR/simplify-arm.rs:38:12: 38:13
--         _10 = ((_3 as Ok).0: u8);        // scope 0 at $DIR/simplify-arm.rs:38:12: 38:13
--         _2 = _10;                        // scope 3 at $DIR/simplify-arm.rs:38:18: 38:19
--         StorageDead(_10);                // scope 0 at $DIR/simplify-arm.rs:38:18: 38:19
-+         _0 = move _3;                    // scope 1 at $DIR/simplify-arm.rs:40:5: 40:10
+          StorageLive(_10);                // scope 0 at $DIR/simplify-arm.rs:38:12: 38:13
+          _10 = ((_3 as Ok).0: u8);        // scope 0 at $DIR/simplify-arm.rs:38:12: 38:13
+          _2 = _10;                        // scope 3 at $DIR/simplify-arm.rs:38:18: 38:19
+          StorageDead(_10);                // scope 0 at $DIR/simplify-arm.rs:38:18: 38:19
           StorageDead(_3);                 // scope 0 at $DIR/simplify-arm.rs:39:6: 39:7
--         StorageLive(_11);                // scope 1 at $DIR/simplify-arm.rs:40:8: 40:9
--         _11 = _2;                        // scope 1 at $DIR/simplify-arm.rs:40:8: 40:9
--         ((_0 as Ok).0: u8) = move _11;   // scope 1 at $DIR/simplify-arm.rs:40:5: 40:10
--         discriminant(_0) = 0;            // scope 1 at $DIR/simplify-arm.rs:40:5: 40:10
--         StorageDead(_11);                // scope 1 at $DIR/simplify-arm.rs:40:9: 40:10
+          StorageLive(_11);                // scope 1 at $DIR/simplify-arm.rs:40:8: 40:9
+          _11 = _2;                        // scope 1 at $DIR/simplify-arm.rs:40:8: 40:9
+          Deinit(_0);                      // scope 1 at $DIR/simplify-arm.rs:40:5: 40:10
+          ((_0 as Ok).0: u8) = move _11;   // scope 1 at $DIR/simplify-arm.rs:40:5: 40:10
+          discriminant(_0) = 0;            // scope 1 at $DIR/simplify-arm.rs:40:5: 40:10
+          StorageDead(_11);                // scope 1 at $DIR/simplify-arm.rs:40:9: 40:10
           StorageDead(_2);                 // scope 0 at $DIR/simplify-arm.rs:41:1: 41:2
           goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:41:2: 41:2
       }
@@ -70,18 +65,18 @@
       }
   
       bb3: {
--         StorageLive(_6);                 // scope 0 at $DIR/simplify-arm.rs:37:13: 37:14
--         _6 = ((_3 as Err).0: i32);       // scope 0 at $DIR/simplify-arm.rs:37:13: 37:14
--         StorageLive(_8);                 // scope 2 at $DIR/simplify-arm.rs:37:37: 37:50
--         StorageLive(_9);                 // scope 2 at $DIR/simplify-arm.rs:37:48: 37:49
--         _9 = _6;                         // scope 2 at $DIR/simplify-arm.rs:37:48: 37:49
--         _8 = move _9;                    // scope 5 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
--         StorageDead(_9);                 // scope 2 at $DIR/simplify-arm.rs:37:49: 37:50
--         ((_0 as Err).0: i32) = move _8;  // scope 6 at $DIR/simplify-arm.rs:28:9: 28:10
--         discriminant(_0) = 1;            // scope 6 at $DIR/simplify-arm.rs:28:5: 28:11
--         StorageDead(_8);                 // scope 2 at $DIR/simplify-arm.rs:37:50: 37:51
--         StorageDead(_6);                 // scope 0 at $DIR/simplify-arm.rs:37:50: 37:51
-+         _0 = move _3;                    // scope 6 at $DIR/simplify-arm.rs:28:5: 28:11
+          StorageLive(_6);                 // scope 0 at $DIR/simplify-arm.rs:37:13: 37:14
+          _6 = ((_3 as Err).0: i32);       // scope 0 at $DIR/simplify-arm.rs:37:13: 37:14
+          StorageLive(_8);                 // scope 2 at $DIR/simplify-arm.rs:37:37: 37:50
+          StorageLive(_9);                 // scope 2 at $DIR/simplify-arm.rs:37:48: 37:49
+          _9 = _6;                         // scope 2 at $DIR/simplify-arm.rs:37:48: 37:49
+          _8 = move _9;                    // scope 5 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
+          StorageDead(_9);                 // scope 2 at $DIR/simplify-arm.rs:37:49: 37:50
+          ((_0 as Err).0: i32) = move _8;  // scope 6 at $DIR/simplify-arm.rs:28:9: 28:10
+          Deinit(_0);                      // scope 6 at $DIR/simplify-arm.rs:28:5: 28:11
+          discriminant(_0) = 1;            // scope 6 at $DIR/simplify-arm.rs:28:5: 28:11
+          StorageDead(_8);                 // scope 2 at $DIR/simplify-arm.rs:37:50: 37:51
+          StorageDead(_6);                 // scope 0 at $DIR/simplify-arm.rs:37:50: 37:51
           StorageDead(_3);                 // scope 0 at $DIR/simplify-arm.rs:39:6: 39:7
           StorageDead(_2);                 // scope 0 at $DIR/simplify-arm.rs:41:1: 41:2
           goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:41:2: 41:2

--- a/src/test/mir-opt/simplify_arm.id_try.SimplifyBranchSame.diff
+++ b/src/test/mir-opt/simplify_arm.id_try.SimplifyBranchSame.diff
@@ -15,19 +15,19 @@
       let _10: u8;                         // in scope 0 at $DIR/simplify-arm.rs:38:12: 38:13
       let mut _11: u8;                     // in scope 0 at $DIR/simplify-arm.rs:40:8: 40:9
       scope 1 {
-          debug x => ((_0 as Ok).0: u8);   // in scope 1 at $DIR/simplify-arm.rs:36:9: 36:10
+          debug x => _2;                   // in scope 1 at $DIR/simplify-arm.rs:36:9: 36:10
       }
       scope 2 {
-          debug e => ((_0 as Err).0: i32); // in scope 2 at $DIR/simplify-arm.rs:37:13: 37:14
+          debug e => _6;                   // in scope 2 at $DIR/simplify-arm.rs:37:13: 37:14
           scope 5 (inlined <i32 as From<i32>>::from) { // at $DIR/simplify-arm.rs:37:37: 37:50
-              debug t => ((_0 as Err).0: i32); // in scope 5 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
+              debug t => _9;               // in scope 5 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
           }
           scope 6 (inlined from_error::<u8, i32>) { // at $DIR/simplify-arm.rs:37:26: 37:51
-              debug e => ((_0 as Err).0: i32); // in scope 6 at $DIR/simplify-arm.rs:27:21: 27:22
+              debug e => _8;               // in scope 6 at $DIR/simplify-arm.rs:27:21: 27:22
           }
       }
       scope 3 {
-          debug v => ((_0 as Ok).0: u8);   // in scope 3 at $DIR/simplify-arm.rs:38:12: 38:13
+          debug v => _10;                  // in scope 3 at $DIR/simplify-arm.rs:38:12: 38:13
       }
       scope 4 (inlined into_result::<u8, i32>) { // at $DIR/simplify-arm.rs:36:19: 36:33
           debug r => _4;                   // in scope 4 at $DIR/simplify-arm.rs:23:22: 23:23
@@ -41,30 +41,48 @@
           _3 = move _4;                    // scope 4 at $DIR/simplify-arm.rs:24:5: 24:6
           StorageDead(_4);                 // scope 0 at $DIR/simplify-arm.rs:36:32: 36:33
           _5 = discriminant(_3);           // scope 0 at $DIR/simplify-arm.rs:36:19: 36:33
--         switchInt(move _5) -> [0_isize: bb1, 1_isize: bb3, otherwise: bb2]; // scope 0 at $DIR/simplify-arm.rs:36:13: 36:33
-+         goto -> bb1;                     // scope 0 at $DIR/simplify-arm.rs:36:13: 36:33
+          switchInt(move _5) -> [0_isize: bb1, 1_isize: bb3, otherwise: bb2]; // scope 0 at $DIR/simplify-arm.rs:36:13: 36:33
       }
   
       bb1: {
-          _0 = move _3;                    // scope 1 at $DIR/simplify-arm.rs:40:5: 40:10
+          StorageLive(_10);                // scope 0 at $DIR/simplify-arm.rs:38:12: 38:13
+          _10 = ((_3 as Ok).0: u8);        // scope 0 at $DIR/simplify-arm.rs:38:12: 38:13
+          _2 = _10;                        // scope 3 at $DIR/simplify-arm.rs:38:18: 38:19
+          StorageDead(_10);                // scope 0 at $DIR/simplify-arm.rs:38:18: 38:19
           StorageDead(_3);                 // scope 0 at $DIR/simplify-arm.rs:39:6: 39:7
+          StorageLive(_11);                // scope 1 at $DIR/simplify-arm.rs:40:8: 40:9
+          _11 = _2;                        // scope 1 at $DIR/simplify-arm.rs:40:8: 40:9
+          Deinit(_0);                      // scope 1 at $DIR/simplify-arm.rs:40:5: 40:10
+          ((_0 as Ok).0: u8) = move _11;   // scope 1 at $DIR/simplify-arm.rs:40:5: 40:10
+          discriminant(_0) = 0;            // scope 1 at $DIR/simplify-arm.rs:40:5: 40:10
+          StorageDead(_11);                // scope 1 at $DIR/simplify-arm.rs:40:9: 40:10
           StorageDead(_2);                 // scope 0 at $DIR/simplify-arm.rs:41:1: 41:2
--         goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:41:2: 41:2
-+         goto -> bb2;                     // scope 0 at $DIR/simplify-arm.rs:41:2: 41:2
+          goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:41:2: 41:2
       }
   
       bb2: {
--         unreachable;                     // scope 0 at $DIR/simplify-arm.rs:36:19: 36:33
--     }
-- 
--     bb3: {
--         _0 = move _3;                    // scope 6 at $DIR/simplify-arm.rs:28:5: 28:11
--         StorageDead(_3);                 // scope 0 at $DIR/simplify-arm.rs:39:6: 39:7
--         StorageDead(_2);                 // scope 0 at $DIR/simplify-arm.rs:41:1: 41:2
--         goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:41:2: 41:2
--     }
-- 
--     bb4: {
+          unreachable;                     // scope 0 at $DIR/simplify-arm.rs:36:19: 36:33
+      }
+  
+      bb3: {
+          StorageLive(_6);                 // scope 0 at $DIR/simplify-arm.rs:37:13: 37:14
+          _6 = ((_3 as Err).0: i32);       // scope 0 at $DIR/simplify-arm.rs:37:13: 37:14
+          StorageLive(_8);                 // scope 2 at $DIR/simplify-arm.rs:37:37: 37:50
+          StorageLive(_9);                 // scope 2 at $DIR/simplify-arm.rs:37:48: 37:49
+          _9 = _6;                         // scope 2 at $DIR/simplify-arm.rs:37:48: 37:49
+          _8 = move _9;                    // scope 5 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
+          StorageDead(_9);                 // scope 2 at $DIR/simplify-arm.rs:37:49: 37:50
+          ((_0 as Err).0: i32) = move _8;  // scope 6 at $DIR/simplify-arm.rs:28:9: 28:10
+          Deinit(_0);                      // scope 6 at $DIR/simplify-arm.rs:28:5: 28:11
+          discriminant(_0) = 1;            // scope 6 at $DIR/simplify-arm.rs:28:5: 28:11
+          StorageDead(_8);                 // scope 2 at $DIR/simplify-arm.rs:37:50: 37:51
+          StorageDead(_6);                 // scope 0 at $DIR/simplify-arm.rs:37:50: 37:51
+          StorageDead(_3);                 // scope 0 at $DIR/simplify-arm.rs:39:6: 39:7
+          StorageDead(_2);                 // scope 0 at $DIR/simplify-arm.rs:41:1: 41:2
+          goto -> bb4;                     // scope 0 at $DIR/simplify-arm.rs:41:2: 41:2
+      }
+  
+      bb4: {
           return;                          // scope 0 at $DIR/simplify-arm.rs:41:2: 41:2
       }
   }

--- a/src/test/mir-opt/simplify_arm_identity.main.SimplifyArmIdentity.32bit.diff
+++ b/src/test/mir-opt/simplify_arm_identity.main.SimplifyArmIdentity.32bit.diff
@@ -19,6 +19,7 @@
   
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/simplify-arm-identity.rs:18:9: 18:10
+          Deinit(_1);                      // scope 0 at $DIR/simplify-arm-identity.rs:18:18: 18:29
           ((_1 as Foo).0: u8) = const 0_u8; // scope 0 at $DIR/simplify-arm-identity.rs:18:18: 18:29
           discriminant(_1) = 0;            // scope 0 at $DIR/simplify-arm-identity.rs:18:18: 18:29
           StorageLive(_2);                 // scope 1 at $DIR/simplify-arm-identity.rs:19:18: 22:6
@@ -27,6 +28,7 @@
       }
   
       bb1: {
+          Deinit(_2);                      // scope 1 at $DIR/simplify-arm-identity.rs:21:21: 21:32
           ((_2 as Foo).0: u8) = const 0_u8; // scope 1 at $DIR/simplify-arm-identity.rs:21:21: 21:32
           discriminant(_2) = 0;            // scope 1 at $DIR/simplify-arm-identity.rs:21:21: 21:32
           goto -> bb4;                     // scope 1 at $DIR/simplify-arm-identity.rs:21:21: 21:32
@@ -41,6 +43,7 @@
           _4 = ((_1 as Foo).0: u8);        // scope 1 at $DIR/simplify-arm-identity.rs:20:18: 20:19
           StorageLive(_5);                 // scope 3 at $DIR/simplify-arm-identity.rs:20:33: 20:34
           _5 = _4;                         // scope 3 at $DIR/simplify-arm-identity.rs:20:33: 20:34
+          Deinit(_2);                      // scope 3 at $DIR/simplify-arm-identity.rs:20:24: 20:35
           ((_2 as Foo).0: u8) = move _5;   // scope 3 at $DIR/simplify-arm-identity.rs:20:24: 20:35
           discriminant(_2) = 0;            // scope 3 at $DIR/simplify-arm-identity.rs:20:24: 20:35
           StorageDead(_5);                 // scope 3 at $DIR/simplify-arm-identity.rs:20:34: 20:35

--- a/src/test/mir-opt/simplify_arm_identity.main.SimplifyArmIdentity.64bit.diff
+++ b/src/test/mir-opt/simplify_arm_identity.main.SimplifyArmIdentity.64bit.diff
@@ -19,6 +19,7 @@
   
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/simplify-arm-identity.rs:18:9: 18:10
+          Deinit(_1);                      // scope 0 at $DIR/simplify-arm-identity.rs:18:18: 18:29
           ((_1 as Foo).0: u8) = const 0_u8; // scope 0 at $DIR/simplify-arm-identity.rs:18:18: 18:29
           discriminant(_1) = 0;            // scope 0 at $DIR/simplify-arm-identity.rs:18:18: 18:29
           StorageLive(_2);                 // scope 1 at $DIR/simplify-arm-identity.rs:19:18: 22:6
@@ -27,6 +28,7 @@
       }
   
       bb1: {
+          Deinit(_2);                      // scope 1 at $DIR/simplify-arm-identity.rs:21:21: 21:32
           ((_2 as Foo).0: u8) = const 0_u8; // scope 1 at $DIR/simplify-arm-identity.rs:21:21: 21:32
           discriminant(_2) = 0;            // scope 1 at $DIR/simplify-arm-identity.rs:21:21: 21:32
           goto -> bb4;                     // scope 1 at $DIR/simplify-arm-identity.rs:21:21: 21:32
@@ -41,6 +43,7 @@
           _4 = ((_1 as Foo).0: u8);        // scope 1 at $DIR/simplify-arm-identity.rs:20:18: 20:19
           StorageLive(_5);                 // scope 3 at $DIR/simplify-arm-identity.rs:20:33: 20:34
           _5 = _4;                         // scope 3 at $DIR/simplify-arm-identity.rs:20:33: 20:34
+          Deinit(_2);                      // scope 3 at $DIR/simplify-arm-identity.rs:20:24: 20:35
           ((_2 as Foo).0: u8) = move _5;   // scope 3 at $DIR/simplify-arm-identity.rs:20:24: 20:35
           discriminant(_2) = 0;            // scope 3 at $DIR/simplify-arm-identity.rs:20:24: 20:35
           StorageDead(_5);                 // scope 3 at $DIR/simplify-arm-identity.rs:20:34: 20:35

--- a/src/test/mir-opt/simplify_locals.d1.SimplifyLocals.diff
+++ b/src/test/mir-opt/simplify_locals.d1.SimplifyLocals.diff
@@ -9,6 +9,7 @@
   
       bb0: {
 -         StorageLive(_1);                 // scope 0 at $DIR/simplify-locals.rs:22:13: 22:17
+-         Deinit(_1);                      // scope 0 at $DIR/simplify-locals.rs:22:13: 22:17
 -         discriminant(_1) = 0;            // scope 0 at $DIR/simplify-locals.rs:22:13: 22:17
 -         StorageDead(_1);                 // scope 0 at $DIR/simplify-locals.rs:22:17: 22:18
           return;                          // scope 0 at $DIR/simplify-locals.rs:23:2: 23:2

--- a/src/test/mir-opt/simplify_locals.d2.SimplifyLocals.diff
+++ b/src/test/mir-opt/simplify_locals.d2.SimplifyLocals.diff
@@ -9,10 +9,13 @@
   
       bb0: {
 -         StorageLive(_1);                 // scope 0 at $DIR/simplify-locals.rs:28:22: 28:26
+-         Deinit(_1);                      // scope 0 at $DIR/simplify-locals.rs:28:22: 28:26
 -         discriminant(_1) = 1;            // scope 0 at $DIR/simplify-locals.rs:28:22: 28:26
 -         StorageLive(_2);                 // scope 0 at $DIR/simplify-locals.rs:28:5: 28:17
 -         StorageLive(_3);                 // scope 0 at $DIR/simplify-locals.rs:28:11: 28:15
+-         Deinit(_3);                      // scope 0 at $DIR/simplify-locals.rs:28:11: 28:15
 -         discriminant(_3) = 0;            // scope 0 at $DIR/simplify-locals.rs:28:11: 28:15
+-         Deinit(_2);                      // scope 0 at $DIR/simplify-locals.rs:28:6: 28:16
 -         (_2.0: i32) = const 10_i32;      // scope 0 at $DIR/simplify-locals.rs:28:6: 28:16
 -         (_2.1: E) = const E::A;          // scope 0 at $DIR/simplify-locals.rs:28:6: 28:16
 -                                          // mir::Constant

--- a/src/test/mir-opt/simplify_locals_fixedpoint.foo.SimplifyLocals.diff
+++ b/src/test/mir-opt/simplify_locals_fixedpoint.foo.SimplifyLocals.diff
@@ -18,9 +18,12 @@
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/simplify-locals-fixedpoint.rs:4:30: 4:69
           StorageLive(_2);                 // scope 0 at $DIR/simplify-locals-fixedpoint.rs:4:31: 4:49
+          Deinit(_2);                      // scope 0 at $DIR/simplify-locals-fixedpoint.rs:4:31: 4:49
           discriminant(_2) = 0;            // scope 0 at $DIR/simplify-locals-fixedpoint.rs:4:31: 4:49
           StorageLive(_3);                 // scope 0 at $DIR/simplify-locals-fixedpoint.rs:4:51: 4:68
+          Deinit(_3);                      // scope 0 at $DIR/simplify-locals-fixedpoint.rs:4:51: 4:68
           discriminant(_3) = 0;            // scope 0 at $DIR/simplify-locals-fixedpoint.rs:4:51: 4:68
+          Deinit(_1);                      // scope 0 at $DIR/simplify-locals-fixedpoint.rs:4:30: 4:69
           (_1.0: std::option::Option<u8>) = move _2; // scope 0 at $DIR/simplify-locals-fixedpoint.rs:4:30: 4:69
           (_1.1: std::option::Option<T>) = move _3; // scope 0 at $DIR/simplify-locals-fixedpoint.rs:4:30: 4:69
           StorageDead(_3);                 // scope 0 at $DIR/simplify-locals-fixedpoint.rs:4:68: 4:69

--- a/src/test/mir-opt/simplify_locals_removes_unused_consts.main.SimplifyLocals.diff
+++ b/src/test/mir-opt/simplify_locals_removes_unused_consts.main.SimplifyLocals.diff
@@ -47,6 +47,7 @@
 -         StorageLive(_9);                 // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:16:12: 16:34
 -         StorageLive(_10);                // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:16:12: 16:30
 -         StorageLive(_11);                // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:16:12: 16:28
+-         Deinit(_11);                     // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:16:12: 16:28
 -         (_11.0: u8) = const 40_u8;       // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:16:12: 16:28
 -         _10 = const 40_u8;               // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:16:12: 16:30
 -         _9 = const 42_u8;                // scope 1 at $DIR/simplify-locals-removes-unused-consts.rs:16:12: 16:34

--- a/src/test/mir-opt/simplify_locals_removes_unused_discriminant_reads.map.SimplifyLocals.32bit.diff
+++ b/src/test/mir-opt/simplify_locals_removes_unused_discriminant_reads.map.SimplifyLocals.32bit.diff
@@ -4,7 +4,7 @@
   fn map(_1: Option<Box<()>>) -> Option<Box<()>> {
       debug x => _1;                       // in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:3:8: 3:9
       let mut _0: std::option::Option<std::boxed::Box<()>>; // return place in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:3:31: 3:46
--     let mut _2: isize;                   // in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:5:9: 5:13
+      let mut _2: isize;                   // in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:5:9: 5:13
 -     let _3: std::boxed::Box<()>;         // in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:6:14: 6:15
 -     let mut _4: std::boxed::Box<()>;     // in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:6:25: 6:26
 -     let mut _5: bool;                    // in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:8:1: 8:2
@@ -17,8 +17,24 @@
       bb0: {
 -         _5 = const false;                // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:4:11: 4:12
 -         _5 = const true;                 // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:4:11: 4:12
--         _2 = discriminant(_1);           // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:4:11: 4:12
-          _0 = move _1;                    // scope 1 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:6:20: 6:27
+          _2 = discriminant(_1);           // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:4:11: 4:12
+          switchInt(move _2) -> [0_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:4:5: 4:12
+      }
+  
+      bb1: {
+          ((_0 as Some).0: std::boxed::Box<()>) = move ((_1 as Some).0: std::boxed::Box<()>); // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:6:14: 6:15
+          Deinit(_0);                      // scope 1 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:6:20: 6:27
+          discriminant(_0) = 1;            // scope 1 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:6:20: 6:27
+          goto -> bb3;                     // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:6:26: 6:27
+      }
+  
+      bb2: {
+          Deinit(_0);                      // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:5:17: 5:21
+          discriminant(_0) = 0;            // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:5:17: 5:21
+          goto -> bb3;                     // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:5:17: 5:21
+      }
+  
+      bb3: {
 -         _6 = discriminant(_1);           // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:8:1: 8:2
           return;                          // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:8:2: 8:2
       }

--- a/src/test/mir-opt/simplify_locals_removes_unused_discriminant_reads.map.SimplifyLocals.64bit.diff
+++ b/src/test/mir-opt/simplify_locals_removes_unused_discriminant_reads.map.SimplifyLocals.64bit.diff
@@ -4,7 +4,7 @@
   fn map(_1: Option<Box<()>>) -> Option<Box<()>> {
       debug x => _1;                       // in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:3:8: 3:9
       let mut _0: std::option::Option<std::boxed::Box<()>>; // return place in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:3:31: 3:46
--     let mut _2: isize;                   // in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:5:9: 5:13
+      let mut _2: isize;                   // in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:5:9: 5:13
 -     let _3: std::boxed::Box<()>;         // in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:6:14: 6:15
 -     let mut _4: std::boxed::Box<()>;     // in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:6:25: 6:26
 -     let mut _5: bool;                    // in scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:8:1: 8:2
@@ -17,8 +17,24 @@
       bb0: {
 -         _5 = const false;                // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:4:11: 4:12
 -         _5 = const true;                 // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:4:11: 4:12
--         _2 = discriminant(_1);           // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:4:11: 4:12
-          _0 = move _1;                    // scope 1 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:6:20: 6:27
+          _2 = discriminant(_1);           // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:4:11: 4:12
+          switchInt(move _2) -> [0_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:4:5: 4:12
+      }
+  
+      bb1: {
+          ((_0 as Some).0: std::boxed::Box<()>) = move ((_1 as Some).0: std::boxed::Box<()>); // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:6:14: 6:15
+          Deinit(_0);                      // scope 1 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:6:20: 6:27
+          discriminant(_0) = 1;            // scope 1 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:6:20: 6:27
+          goto -> bb3;                     // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:6:26: 6:27
+      }
+  
+      bb2: {
+          Deinit(_0);                      // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:5:17: 5:21
+          discriminant(_0) = 0;            // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:5:17: 5:21
+          goto -> bb3;                     // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:5:17: 5:21
+      }
+  
+      bb3: {
 -         _6 = discriminant(_1);           // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:8:1: 8:2
           return;                          // scope 0 at $DIR/simplify-locals-removes-unused-discriminant-reads.rs:8:2: 8:2
       }

--- a/src/test/mir-opt/simplify_try.try_identity.DestinationPropagation.diff
+++ b/src/test/mir-opt/simplify_try.try_identity.DestinationPropagation.diff
@@ -15,48 +15,100 @@
       let _10: u32;                        // in scope 0 at $DIR/simplify_try.rs:23:12: 23:13
       let mut _11: u32;                    // in scope 0 at $DIR/simplify_try.rs:25:8: 25:9
       scope 1 {
-          debug y => ((_0 as Ok).0: u32);  // in scope 1 at $DIR/simplify_try.rs:21:9: 21:10
+-         debug y => _2;                   // in scope 1 at $DIR/simplify_try.rs:21:9: 21:10
++         debug y => ((_0 as Ok).0: u32);  // in scope 1 at $DIR/simplify_try.rs:21:9: 21:10
       }
       scope 2 {
-          debug e => ((_0 as Err).0: i32); // in scope 2 at $DIR/simplify_try.rs:22:13: 22:14
+-         debug e => _6;                   // in scope 2 at $DIR/simplify_try.rs:22:13: 22:14
++         debug e => ((_0 as Err).0: i32); // in scope 2 at $DIR/simplify_try.rs:22:13: 22:14
           scope 5 (inlined <i32 as From<i32>>::from) { // at $DIR/simplify_try.rs:22:37: 22:50
-              debug t => ((_0 as Err).0: i32); // in scope 5 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
+-             debug t => _9;               // in scope 5 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
++             debug t => ((_0 as Err).0: i32); // in scope 5 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
           }
           scope 6 (inlined from_error::<u32, i32>) { // at $DIR/simplify_try.rs:22:26: 22:51
-              debug e => ((_0 as Err).0: i32); // in scope 6 at $DIR/simplify_try.rs:12:21: 12:22
+-             debug e => _8;               // in scope 6 at $DIR/simplify_try.rs:12:21: 12:22
++             debug e => ((_0 as Err).0: i32); // in scope 6 at $DIR/simplify_try.rs:12:21: 12:22
           }
       }
       scope 3 {
-          debug v => ((_0 as Ok).0: u32);  // in scope 3 at $DIR/simplify_try.rs:23:12: 23:13
+-         debug v => _10;                  // in scope 3 at $DIR/simplify_try.rs:23:12: 23:13
++         debug v => ((_0 as Ok).0: u32);  // in scope 3 at $DIR/simplify_try.rs:23:12: 23:13
       }
       scope 4 (inlined into_result::<u32, i32>) { // at $DIR/simplify_try.rs:21:19: 21:33
 -         debug r => _4;                   // in scope 4 at $DIR/simplify_try.rs:8:22: 8:23
-+         debug r => _0;                   // in scope 4 at $DIR/simplify_try.rs:8:22: 8:23
++         debug r => _3;                   // in scope 4 at $DIR/simplify_try.rs:8:22: 8:23
       }
   
       bb0: {
-          StorageLive(_2);                 // scope 0 at $DIR/simplify_try.rs:21:9: 21:10
+-         StorageLive(_2);                 // scope 0 at $DIR/simplify_try.rs:21:9: 21:10
 -         StorageLive(_3);                 // scope 0 at $DIR/simplify_try.rs:21:19: 21:33
 -         StorageLive(_4);                 // scope 0 at $DIR/simplify_try.rs:21:31: 21:32
 -         _4 = _1;                         // scope 0 at $DIR/simplify_try.rs:21:31: 21:32
 -         _3 = move _4;                    // scope 4 at $DIR/simplify_try.rs:9:5: 9:6
 -         StorageDead(_4);                 // scope 0 at $DIR/simplify_try.rs:21:32: 21:33
--         _5 = discriminant(_3);           // scope 0 at $DIR/simplify_try.rs:21:19: 21:33
++         nop;                             // scope 0 at $DIR/simplify_try.rs:21:9: 21:10
 +         nop;                             // scope 0 at $DIR/simplify_try.rs:21:19: 21:33
 +         nop;                             // scope 0 at $DIR/simplify_try.rs:21:31: 21:32
-+         _0 = _1;                         // scope 0 at $DIR/simplify_try.rs:21:31: 21:32
++         _3 = _1;                         // scope 0 at $DIR/simplify_try.rs:21:31: 21:32
 +         nop;                             // scope 4 at $DIR/simplify_try.rs:9:5: 9:6
 +         nop;                             // scope 0 at $DIR/simplify_try.rs:21:32: 21:33
-+         _5 = discriminant(_0);           // scope 0 at $DIR/simplify_try.rs:21:19: 21:33
-          goto -> bb1;                     // scope 0 at $DIR/simplify_try.rs:21:13: 21:33
+          _5 = discriminant(_3);           // scope 0 at $DIR/simplify_try.rs:21:19: 21:33
+          switchInt(move _5) -> [0_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/simplify_try.rs:21:13: 21:33
       }
   
       bb1: {
--         _0 = move _3;                    // scope 1 at $DIR/simplify_try.rs:25:5: 25:10
+-         StorageLive(_10);                // scope 0 at $DIR/simplify_try.rs:23:12: 23:13
+-         _10 = ((_3 as Ok).0: u32);       // scope 0 at $DIR/simplify_try.rs:23:12: 23:13
+-         _2 = _10;                        // scope 3 at $DIR/simplify_try.rs:23:18: 23:19
+-         StorageDead(_10);                // scope 0 at $DIR/simplify_try.rs:23:18: 23:19
 -         StorageDead(_3);                 // scope 0 at $DIR/simplify_try.rs:24:6: 24:7
-+         nop;                             // scope 1 at $DIR/simplify_try.rs:25:5: 25:10
+-         StorageLive(_11);                // scope 1 at $DIR/simplify_try.rs:25:8: 25:9
+-         _11 = _2;                        // scope 1 at $DIR/simplify_try.rs:25:8: 25:9
++         nop;                             // scope 0 at $DIR/simplify_try.rs:23:12: 23:13
++         ((_0 as Ok).0: u32) = ((_3 as Ok).0: u32); // scope 0 at $DIR/simplify_try.rs:23:12: 23:13
++         nop;                             // scope 3 at $DIR/simplify_try.rs:23:18: 23:19
++         nop;                             // scope 0 at $DIR/simplify_try.rs:23:18: 23:19
 +         nop;                             // scope 0 at $DIR/simplify_try.rs:24:6: 24:7
-          StorageDead(_2);                 // scope 0 at $DIR/simplify_try.rs:26:1: 26:2
++         nop;                             // scope 1 at $DIR/simplify_try.rs:25:8: 25:9
++         nop;                             // scope 1 at $DIR/simplify_try.rs:25:8: 25:9
+          Deinit(_0);                      // scope 1 at $DIR/simplify_try.rs:25:5: 25:10
+-         ((_0 as Ok).0: u32) = move _11;  // scope 1 at $DIR/simplify_try.rs:25:5: 25:10
++         nop;                             // scope 1 at $DIR/simplify_try.rs:25:5: 25:10
+          discriminant(_0) = 0;            // scope 1 at $DIR/simplify_try.rs:25:5: 25:10
+-         StorageDead(_11);                // scope 1 at $DIR/simplify_try.rs:25:9: 25:10
+-         StorageDead(_2);                 // scope 0 at $DIR/simplify_try.rs:26:1: 26:2
++         nop;                             // scope 1 at $DIR/simplify_try.rs:25:9: 25:10
++         nop;                             // scope 0 at $DIR/simplify_try.rs:26:1: 26:2
+          return;                          // scope 0 at $DIR/simplify_try.rs:26:2: 26:2
+      }
+  
+      bb2: {
+-         StorageLive(_6);                 // scope 0 at $DIR/simplify_try.rs:22:13: 22:14
+-         _6 = ((_3 as Err).0: i32);       // scope 0 at $DIR/simplify_try.rs:22:13: 22:14
+-         StorageLive(_8);                 // scope 2 at $DIR/simplify_try.rs:22:37: 22:50
+-         StorageLive(_9);                 // scope 2 at $DIR/simplify_try.rs:22:48: 22:49
+-         _9 = _6;                         // scope 2 at $DIR/simplify_try.rs:22:48: 22:49
+-         _8 = move _9;                    // scope 5 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
+-         StorageDead(_9);                 // scope 2 at $DIR/simplify_try.rs:22:49: 22:50
+-         ((_0 as Err).0: i32) = move _8;  // scope 6 at $DIR/simplify_try.rs:13:9: 13:10
++         nop;                             // scope 0 at $DIR/simplify_try.rs:22:13: 22:14
++         ((_0 as Err).0: i32) = ((_3 as Err).0: i32); // scope 0 at $DIR/simplify_try.rs:22:13: 22:14
++         nop;                             // scope 2 at $DIR/simplify_try.rs:22:37: 22:50
++         nop;                             // scope 2 at $DIR/simplify_try.rs:22:48: 22:49
++         nop;                             // scope 2 at $DIR/simplify_try.rs:22:48: 22:49
++         nop;                             // scope 5 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
++         nop;                             // scope 2 at $DIR/simplify_try.rs:22:49: 22:50
++         nop;                             // scope 6 at $DIR/simplify_try.rs:13:9: 13:10
+          Deinit(_0);                      // scope 6 at $DIR/simplify_try.rs:13:5: 13:11
+          discriminant(_0) = 1;            // scope 6 at $DIR/simplify_try.rs:13:5: 13:11
+-         StorageDead(_8);                 // scope 2 at $DIR/simplify_try.rs:22:50: 22:51
+-         StorageDead(_6);                 // scope 0 at $DIR/simplify_try.rs:22:50: 22:51
+-         StorageDead(_3);                 // scope 0 at $DIR/simplify_try.rs:24:6: 24:7
+-         StorageDead(_2);                 // scope 0 at $DIR/simplify_try.rs:26:1: 26:2
++         nop;                             // scope 2 at $DIR/simplify_try.rs:22:50: 22:51
++         nop;                             // scope 0 at $DIR/simplify_try.rs:22:50: 22:51
++         nop;                             // scope 0 at $DIR/simplify_try.rs:24:6: 24:7
++         nop;                             // scope 0 at $DIR/simplify_try.rs:26:1: 26:2
           return;                          // scope 0 at $DIR/simplify_try.rs:26:2: 26:2
       }
   }

--- a/src/test/mir-opt/simplify_try.try_identity.SimplifyArmIdentity.diff
+++ b/src/test/mir-opt/simplify_try.try_identity.SimplifyArmIdentity.diff
@@ -15,24 +15,19 @@
       let _10: u32;                        // in scope 0 at $DIR/simplify_try.rs:23:12: 23:13
       let mut _11: u32;                    // in scope 0 at $DIR/simplify_try.rs:25:8: 25:9
       scope 1 {
--         debug y => _2;                   // in scope 1 at $DIR/simplify_try.rs:21:9: 21:10
-+         debug y => ((_0 as Ok).0: u32);  // in scope 1 at $DIR/simplify_try.rs:21:9: 21:10
+          debug y => _2;                   // in scope 1 at $DIR/simplify_try.rs:21:9: 21:10
       }
       scope 2 {
--         debug e => _6;                   // in scope 2 at $DIR/simplify_try.rs:22:13: 22:14
-+         debug e => ((_0 as Err).0: i32); // in scope 2 at $DIR/simplify_try.rs:22:13: 22:14
+          debug e => _6;                   // in scope 2 at $DIR/simplify_try.rs:22:13: 22:14
           scope 5 (inlined <i32 as From<i32>>::from) { // at $DIR/simplify_try.rs:22:37: 22:50
--             debug t => _9;               // in scope 5 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
-+             debug t => ((_0 as Err).0: i32); // in scope 5 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
+              debug t => _9;               // in scope 5 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
           }
           scope 6 (inlined from_error::<u32, i32>) { // at $DIR/simplify_try.rs:22:26: 22:51
--             debug e => _8;               // in scope 6 at $DIR/simplify_try.rs:12:21: 12:22
-+             debug e => ((_0 as Err).0: i32); // in scope 6 at $DIR/simplify_try.rs:12:21: 12:22
+              debug e => _8;               // in scope 6 at $DIR/simplify_try.rs:12:21: 12:22
           }
       }
       scope 3 {
--         debug v => _10;                  // in scope 3 at $DIR/simplify_try.rs:23:12: 23:13
-+         debug v => ((_0 as Ok).0: u32);  // in scope 3 at $DIR/simplify_try.rs:23:12: 23:13
+          debug v => _10;                  // in scope 3 at $DIR/simplify_try.rs:23:12: 23:13
       }
       scope 4 (inlined into_result::<u32, i32>) { // at $DIR/simplify_try.rs:21:19: 21:33
           debug r => _4;                   // in scope 4 at $DIR/simplify_try.rs:8:22: 8:23
@@ -50,34 +45,34 @@
       }
   
       bb1: {
--         StorageLive(_10);                // scope 0 at $DIR/simplify_try.rs:23:12: 23:13
--         _10 = ((_3 as Ok).0: u32);       // scope 0 at $DIR/simplify_try.rs:23:12: 23:13
--         _2 = _10;                        // scope 3 at $DIR/simplify_try.rs:23:18: 23:19
--         StorageDead(_10);                // scope 0 at $DIR/simplify_try.rs:23:18: 23:19
-+         _0 = move _3;                    // scope 1 at $DIR/simplify_try.rs:25:5: 25:10
+          StorageLive(_10);                // scope 0 at $DIR/simplify_try.rs:23:12: 23:13
+          _10 = ((_3 as Ok).0: u32);       // scope 0 at $DIR/simplify_try.rs:23:12: 23:13
+          _2 = _10;                        // scope 3 at $DIR/simplify_try.rs:23:18: 23:19
+          StorageDead(_10);                // scope 0 at $DIR/simplify_try.rs:23:18: 23:19
           StorageDead(_3);                 // scope 0 at $DIR/simplify_try.rs:24:6: 24:7
--         StorageLive(_11);                // scope 1 at $DIR/simplify_try.rs:25:8: 25:9
--         _11 = _2;                        // scope 1 at $DIR/simplify_try.rs:25:8: 25:9
--         ((_0 as Ok).0: u32) = move _11;  // scope 1 at $DIR/simplify_try.rs:25:5: 25:10
--         discriminant(_0) = 0;            // scope 1 at $DIR/simplify_try.rs:25:5: 25:10
--         StorageDead(_11);                // scope 1 at $DIR/simplify_try.rs:25:9: 25:10
+          StorageLive(_11);                // scope 1 at $DIR/simplify_try.rs:25:8: 25:9
+          _11 = _2;                        // scope 1 at $DIR/simplify_try.rs:25:8: 25:9
+          Deinit(_0);                      // scope 1 at $DIR/simplify_try.rs:25:5: 25:10
+          ((_0 as Ok).0: u32) = move _11;  // scope 1 at $DIR/simplify_try.rs:25:5: 25:10
+          discriminant(_0) = 0;            // scope 1 at $DIR/simplify_try.rs:25:5: 25:10
+          StorageDead(_11);                // scope 1 at $DIR/simplify_try.rs:25:9: 25:10
           StorageDead(_2);                 // scope 0 at $DIR/simplify_try.rs:26:1: 26:2
           return;                          // scope 0 at $DIR/simplify_try.rs:26:2: 26:2
       }
   
       bb2: {
--         StorageLive(_6);                 // scope 0 at $DIR/simplify_try.rs:22:13: 22:14
--         _6 = ((_3 as Err).0: i32);       // scope 0 at $DIR/simplify_try.rs:22:13: 22:14
--         StorageLive(_8);                 // scope 2 at $DIR/simplify_try.rs:22:37: 22:50
--         StorageLive(_9);                 // scope 2 at $DIR/simplify_try.rs:22:48: 22:49
--         _9 = _6;                         // scope 2 at $DIR/simplify_try.rs:22:48: 22:49
--         _8 = move _9;                    // scope 5 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
--         StorageDead(_9);                 // scope 2 at $DIR/simplify_try.rs:22:49: 22:50
--         ((_0 as Err).0: i32) = move _8;  // scope 6 at $DIR/simplify_try.rs:13:9: 13:10
--         discriminant(_0) = 1;            // scope 6 at $DIR/simplify_try.rs:13:5: 13:11
--         StorageDead(_8);                 // scope 2 at $DIR/simplify_try.rs:22:50: 22:51
--         StorageDead(_6);                 // scope 0 at $DIR/simplify_try.rs:22:50: 22:51
-+         _0 = move _3;                    // scope 6 at $DIR/simplify_try.rs:13:5: 13:11
+          StorageLive(_6);                 // scope 0 at $DIR/simplify_try.rs:22:13: 22:14
+          _6 = ((_3 as Err).0: i32);       // scope 0 at $DIR/simplify_try.rs:22:13: 22:14
+          StorageLive(_8);                 // scope 2 at $DIR/simplify_try.rs:22:37: 22:50
+          StorageLive(_9);                 // scope 2 at $DIR/simplify_try.rs:22:48: 22:49
+          _9 = _6;                         // scope 2 at $DIR/simplify_try.rs:22:48: 22:49
+          _8 = move _9;                    // scope 5 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
+          StorageDead(_9);                 // scope 2 at $DIR/simplify_try.rs:22:49: 22:50
+          ((_0 as Err).0: i32) = move _8;  // scope 6 at $DIR/simplify_try.rs:13:9: 13:10
+          Deinit(_0);                      // scope 6 at $DIR/simplify_try.rs:13:5: 13:11
+          discriminant(_0) = 1;            // scope 6 at $DIR/simplify_try.rs:13:5: 13:11
+          StorageDead(_8);                 // scope 2 at $DIR/simplify_try.rs:22:50: 22:51
+          StorageDead(_6);                 // scope 0 at $DIR/simplify_try.rs:22:50: 22:51
           StorageDead(_3);                 // scope 0 at $DIR/simplify_try.rs:24:6: 24:7
           StorageDead(_2);                 // scope 0 at $DIR/simplify_try.rs:26:1: 26:2
           return;                          // scope 0 at $DIR/simplify_try.rs:26:2: 26:2

--- a/src/test/mir-opt/simplify_try.try_identity.SimplifyBranchSame.after.mir
+++ b/src/test/mir-opt/simplify_try.try_identity.SimplifyBranchSame.after.mir
@@ -14,19 +14,19 @@ fn try_identity(_1: Result<u32, i32>) -> Result<u32, i32> {
     let _10: u32;                        // in scope 0 at $DIR/simplify_try.rs:23:12: 23:13
     let mut _11: u32;                    // in scope 0 at $DIR/simplify_try.rs:25:8: 25:9
     scope 1 {
-        debug y => ((_0 as Ok).0: u32);  // in scope 1 at $DIR/simplify_try.rs:21:9: 21:10
+        debug y => _2;                   // in scope 1 at $DIR/simplify_try.rs:21:9: 21:10
     }
     scope 2 {
-        debug e => ((_0 as Err).0: i32); // in scope 2 at $DIR/simplify_try.rs:22:13: 22:14
+        debug e => _6;                   // in scope 2 at $DIR/simplify_try.rs:22:13: 22:14
         scope 5 (inlined <i32 as From<i32>>::from) { // at $DIR/simplify_try.rs:22:37: 22:50
-            debug t => ((_0 as Err).0: i32); // in scope 5 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
+            debug t => _9;               // in scope 5 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
         }
         scope 6 (inlined from_error::<u32, i32>) { // at $DIR/simplify_try.rs:22:26: 22:51
-            debug e => ((_0 as Err).0: i32); // in scope 6 at $DIR/simplify_try.rs:12:21: 12:22
+            debug e => _8;               // in scope 6 at $DIR/simplify_try.rs:12:21: 12:22
         }
     }
     scope 3 {
-        debug v => ((_0 as Ok).0: u32);  // in scope 3 at $DIR/simplify_try.rs:23:12: 23:13
+        debug v => _10;                  // in scope 3 at $DIR/simplify_try.rs:23:12: 23:13
     }
     scope 4 (inlined into_result::<u32, i32>) { // at $DIR/simplify_try.rs:21:19: 21:33
         debug r => _4;                   // in scope 4 at $DIR/simplify_try.rs:8:22: 8:23
@@ -40,11 +40,38 @@ fn try_identity(_1: Result<u32, i32>) -> Result<u32, i32> {
         _3 = move _4;                    // scope 4 at $DIR/simplify_try.rs:9:5: 9:6
         StorageDead(_4);                 // scope 0 at $DIR/simplify_try.rs:21:32: 21:33
         _5 = discriminant(_3);           // scope 0 at $DIR/simplify_try.rs:21:19: 21:33
-        goto -> bb1;                     // scope 0 at $DIR/simplify_try.rs:21:13: 21:33
+        switchInt(move _5) -> [0_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/simplify_try.rs:21:13: 21:33
     }
 
     bb1: {
-        _0 = move _3;                    // scope 1 at $DIR/simplify_try.rs:25:5: 25:10
+        StorageLive(_10);                // scope 0 at $DIR/simplify_try.rs:23:12: 23:13
+        _10 = ((_3 as Ok).0: u32);       // scope 0 at $DIR/simplify_try.rs:23:12: 23:13
+        _2 = _10;                        // scope 3 at $DIR/simplify_try.rs:23:18: 23:19
+        StorageDead(_10);                // scope 0 at $DIR/simplify_try.rs:23:18: 23:19
+        StorageDead(_3);                 // scope 0 at $DIR/simplify_try.rs:24:6: 24:7
+        StorageLive(_11);                // scope 1 at $DIR/simplify_try.rs:25:8: 25:9
+        _11 = _2;                        // scope 1 at $DIR/simplify_try.rs:25:8: 25:9
+        Deinit(_0);                      // scope 1 at $DIR/simplify_try.rs:25:5: 25:10
+        ((_0 as Ok).0: u32) = move _11;  // scope 1 at $DIR/simplify_try.rs:25:5: 25:10
+        discriminant(_0) = 0;            // scope 1 at $DIR/simplify_try.rs:25:5: 25:10
+        StorageDead(_11);                // scope 1 at $DIR/simplify_try.rs:25:9: 25:10
+        StorageDead(_2);                 // scope 0 at $DIR/simplify_try.rs:26:1: 26:2
+        return;                          // scope 0 at $DIR/simplify_try.rs:26:2: 26:2
+    }
+
+    bb2: {
+        StorageLive(_6);                 // scope 0 at $DIR/simplify_try.rs:22:13: 22:14
+        _6 = ((_3 as Err).0: i32);       // scope 0 at $DIR/simplify_try.rs:22:13: 22:14
+        StorageLive(_8);                 // scope 2 at $DIR/simplify_try.rs:22:37: 22:50
+        StorageLive(_9);                 // scope 2 at $DIR/simplify_try.rs:22:48: 22:49
+        _9 = _6;                         // scope 2 at $DIR/simplify_try.rs:22:48: 22:49
+        _8 = move _9;                    // scope 5 at $SRC_DIR/core/src/convert/mod.rs:LL:COL
+        StorageDead(_9);                 // scope 2 at $DIR/simplify_try.rs:22:49: 22:50
+        ((_0 as Err).0: i32) = move _8;  // scope 6 at $DIR/simplify_try.rs:13:9: 13:10
+        Deinit(_0);                      // scope 6 at $DIR/simplify_try.rs:13:5: 13:11
+        discriminant(_0) = 1;            // scope 6 at $DIR/simplify_try.rs:13:5: 13:11
+        StorageDead(_8);                 // scope 2 at $DIR/simplify_try.rs:22:50: 22:51
+        StorageDead(_6);                 // scope 0 at $DIR/simplify_try.rs:22:50: 22:51
         StorageDead(_3);                 // scope 0 at $DIR/simplify_try.rs:24:6: 24:7
         StorageDead(_2);                 // scope 0 at $DIR/simplify_try.rs:26:1: 26:2
         return;                          // scope 0 at $DIR/simplify_try.rs:26:2: 26:2

--- a/src/test/mir-opt/simplify_try.try_identity.SimplifyLocals.after.mir
+++ b/src/test/mir-opt/simplify_try.try_identity.SimplifyLocals.after.mir
@@ -3,6 +3,8 @@
 fn try_identity(_1: Result<u32, i32>) -> Result<u32, i32> {
     debug x => _1;                       // in scope 0 at $DIR/simplify_try.rs:20:17: 20:18
     let mut _0: std::result::Result<u32, i32>; // return place in scope 0 at $DIR/simplify_try.rs:20:41: 20:57
+    let mut _2: std::result::Result<u32, i32>; // in scope 0 at $DIR/simplify_try.rs:21:19: 21:33
+    let mut _3: isize;                   // in scope 0 at $DIR/simplify_try.rs:22:9: 22:15
     scope 1 {
         debug y => ((_0 as Ok).0: u32);  // in scope 1 at $DIR/simplify_try.rs:21:9: 21:10
     }
@@ -19,11 +21,26 @@ fn try_identity(_1: Result<u32, i32>) -> Result<u32, i32> {
         debug v => ((_0 as Ok).0: u32);  // in scope 3 at $DIR/simplify_try.rs:23:12: 23:13
     }
     scope 4 (inlined into_result::<u32, i32>) { // at $DIR/simplify_try.rs:21:19: 21:33
-        debug r => _0;                   // in scope 4 at $DIR/simplify_try.rs:8:22: 8:23
+        debug r => _2;                   // in scope 4 at $DIR/simplify_try.rs:8:22: 8:23
     }
 
     bb0: {
-        _0 = _1;                         // scope 0 at $DIR/simplify_try.rs:21:31: 21:32
+        _2 = _1;                         // scope 0 at $DIR/simplify_try.rs:21:31: 21:32
+        _3 = discriminant(_2);           // scope 0 at $DIR/simplify_try.rs:21:19: 21:33
+        switchInt(move _3) -> [0_isize: bb1, otherwise: bb2]; // scope 0 at $DIR/simplify_try.rs:21:13: 21:33
+    }
+
+    bb1: {
+        ((_0 as Ok).0: u32) = ((_2 as Ok).0: u32); // scope 0 at $DIR/simplify_try.rs:23:12: 23:13
+        Deinit(_0);                      // scope 1 at $DIR/simplify_try.rs:25:5: 25:10
+        discriminant(_0) = 0;            // scope 1 at $DIR/simplify_try.rs:25:5: 25:10
+        return;                          // scope 0 at $DIR/simplify_try.rs:26:2: 26:2
+    }
+
+    bb2: {
+        ((_0 as Err).0: i32) = ((_2 as Err).0: i32); // scope 0 at $DIR/simplify_try.rs:22:13: 22:14
+        Deinit(_0);                      // scope 6 at $DIR/simplify_try.rs:13:5: 13:11
+        discriminant(_0) = 1;            // scope 6 at $DIR/simplify_try.rs:13:5: 13:11
         return;                          // scope 0 at $DIR/simplify_try.rs:26:2: 26:2
     }
 }

--- a/src/test/mir-opt/uninhabited_enum_branching.main.SimplifyCfg-after-uninhabited-enum-branching.after.mir
+++ b/src/test/mir-opt/uninhabited_enum_branching.main.SimplifyCfg-after-uninhabited-enum-branching.after.mir
@@ -15,6 +15,7 @@ fn main() -> () {
     bb0: {
         StorageLive(_1);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:20:5: 24:6
         StorageLive(_2);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:20:11: 20:19
+        Deinit(_2);                      // scope 0 at $DIR/uninhabited_enum_branching.rs:20:11: 20:19
         discriminant(_2) = 2;            // scope 0 at $DIR/uninhabited_enum_branching.rs:20:11: 20:19
         _3 = discriminant(_2);           // scope 0 at $DIR/uninhabited_enum_branching.rs:20:11: 20:19
         StorageLive(_5);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:23:21: 23:24
@@ -28,6 +29,7 @@ fn main() -> () {
         StorageDead(_1);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:24:6: 24:7
         StorageLive(_6);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:26:5: 29:6
         StorageLive(_7);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:26:11: 26:19
+        Deinit(_7);                      // scope 0 at $DIR/uninhabited_enum_branching.rs:26:11: 26:19
         discriminant(_7) = 0;            // scope 0 at $DIR/uninhabited_enum_branching.rs:26:11: 26:19
         _8 = discriminant(_7);           // scope 0 at $DIR/uninhabited_enum_branching.rs:26:11: 26:19
         switchInt(move _8) -> [4_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/uninhabited_enum_branching.rs:26:5: 26:19

--- a/src/test/mir-opt/uninhabited_enum_branching.main.UninhabitedEnumBranching.diff
+++ b/src/test/mir-opt/uninhabited_enum_branching.main.UninhabitedEnumBranching.diff
@@ -16,6 +16,7 @@
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:20:5: 24:6
           StorageLive(_2);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:20:11: 20:19
+          Deinit(_2);                      // scope 0 at $DIR/uninhabited_enum_branching.rs:20:11: 20:19
           discriminant(_2) = 2;            // scope 0 at $DIR/uninhabited_enum_branching.rs:20:11: 20:19
           _3 = discriminant(_2);           // scope 0 at $DIR/uninhabited_enum_branching.rs:20:11: 20:19
 -         switchInt(move _3) -> [0_isize: bb2, 1_isize: bb3, otherwise: bb1]; // scope 0 at $DIR/uninhabited_enum_branching.rs:20:5: 20:19
@@ -57,6 +58,7 @@
           StorageDead(_1);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:24:6: 24:7
           StorageLive(_6);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:26:5: 29:6
           StorageLive(_7);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:26:11: 26:19
+          Deinit(_7);                      // scope 0 at $DIR/uninhabited_enum_branching.rs:26:11: 26:19
           discriminant(_7) = 0;            // scope 0 at $DIR/uninhabited_enum_branching.rs:26:11: 26:19
           _8 = discriminant(_7);           // scope 0 at $DIR/uninhabited_enum_branching.rs:26:11: 26:19
           switchInt(move _8) -> [4_isize: bb6, otherwise: bb5]; // scope 0 at $DIR/uninhabited_enum_branching.rs:26:5: 26:19

--- a/src/test/mir-opt/uninhabited_enum_branching2.main.SimplifyCfg-after-uninhabited-enum-branching.after.mir
+++ b/src/test/mir-opt/uninhabited_enum_branching2.main.SimplifyCfg-after-uninhabited-enum-branching.after.mir
@@ -22,7 +22,9 @@ fn main() -> () {
     bb0: {
         StorageLive(_1);                 // scope 0 at $DIR/uninhabited_enum_branching2.rs:19:9: 19:13
         StorageLive(_2);                 // scope 0 at $DIR/uninhabited_enum_branching2.rs:19:38: 19:46
+        Deinit(_2);                      // scope 0 at $DIR/uninhabited_enum_branching2.rs:19:38: 19:46
         discriminant(_2) = 2;            // scope 0 at $DIR/uninhabited_enum_branching2.rs:19:38: 19:46
+        Deinit(_1);                      // scope 0 at $DIR/uninhabited_enum_branching2.rs:19:16: 19:48
         (_1.0: u32) = const 51_u32;      // scope 0 at $DIR/uninhabited_enum_branching2.rs:19:16: 19:48
         (_1.1: Test1) = move _2;         // scope 0 at $DIR/uninhabited_enum_branching2.rs:19:16: 19:48
         StorageDead(_2);                 // scope 0 at $DIR/uninhabited_enum_branching2.rs:19:47: 19:48

--- a/src/test/mir-opt/uninhabited_enum_branching2.main.UninhabitedEnumBranching.diff
+++ b/src/test/mir-opt/uninhabited_enum_branching2.main.UninhabitedEnumBranching.diff
@@ -23,7 +23,9 @@
       bb0: {
           StorageLive(_1);                 // scope 0 at $DIR/uninhabited_enum_branching2.rs:19:9: 19:13
           StorageLive(_2);                 // scope 0 at $DIR/uninhabited_enum_branching2.rs:19:38: 19:46
+          Deinit(_2);                      // scope 0 at $DIR/uninhabited_enum_branching2.rs:19:38: 19:46
           discriminant(_2) = 2;            // scope 0 at $DIR/uninhabited_enum_branching2.rs:19:38: 19:46
+          Deinit(_1);                      // scope 0 at $DIR/uninhabited_enum_branching2.rs:19:16: 19:48
           (_1.0: u32) = const 51_u32;      // scope 0 at $DIR/uninhabited_enum_branching2.rs:19:16: 19:48
           (_1.1: Test1) = move _2;         // scope 0 at $DIR/uninhabited_enum_branching2.rs:19:16: 19:48
           StorageDead(_2);                 // scope 0 at $DIR/uninhabited_enum_branching2.rs:19:47: 19:48

--- a/src/test/mir-opt/unusual_item_types.Test-X-{constructor#0}.mir_map.0.32bit.mir
+++ b/src/test/mir-opt/unusual_item_types.Test-X-{constructor#0}.mir_map.0.32bit.mir
@@ -4,6 +4,7 @@ fn Test::X(_1: usize) -> Test {
     let mut _0: Test;                    // return place in scope 0 at $DIR/unusual-item-types.rs:16:5: 16:13
 
     bb0: {
+        Deinit(_0);                      // scope 0 at $DIR/unusual-item-types.rs:16:5: 16:13
         ((_0 as X).0: usize) = move _1;  // scope 0 at $DIR/unusual-item-types.rs:16:5: 16:13
         discriminant(_0) = 0;            // scope 0 at $DIR/unusual-item-types.rs:16:5: 16:13
         return;                          // scope 0 at $DIR/unusual-item-types.rs:16:5: 16:13

--- a/src/test/mir-opt/unusual_item_types.Test-X-{constructor#0}.mir_map.0.64bit.mir
+++ b/src/test/mir-opt/unusual_item_types.Test-X-{constructor#0}.mir_map.0.64bit.mir
@@ -4,6 +4,7 @@ fn Test::X(_1: usize) -> Test {
     let mut _0: Test;                    // return place in scope 0 at $DIR/unusual-item-types.rs:16:5: 16:13
 
     bb0: {
+        Deinit(_0);                      // scope 0 at $DIR/unusual-item-types.rs:16:5: 16:13
         ((_0 as X).0: usize) = move _1;  // scope 0 at $DIR/unusual-item-types.rs:16:5: 16:13
         discriminant(_0) = 0;            // scope 0 at $DIR/unusual-item-types.rs:16:5: 16:13
         return;                          // scope 0 at $DIR/unusual-item-types.rs:16:5: 16:13

--- a/src/test/mir-opt/while_let_loops.change_loop_body.ConstProp.32bit.diff
+++ b/src/test/mir-opt/while_let_loops.change_loop_body.ConstProp.32bit.diff
@@ -19,6 +19,7 @@
           StorageLive(_1);                 // scope 0 at $DIR/while_let_loops.rs:6:9: 6:15
           _1 = const 0_i32;                // scope 0 at $DIR/while_let_loops.rs:6:18: 6:19
           StorageLive(_3);                 // scope 1 at $DIR/while_let_loops.rs:7:28: 7:32
+          Deinit(_3);                      // scope 1 at $DIR/while_let_loops.rs:7:28: 7:32
           discriminant(_3) = 0;            // scope 1 at $DIR/while_let_loops.rs:7:28: 7:32
 -         _4 = discriminant(_3);           // scope 1 at $DIR/while_let_loops.rs:7:15: 7:25
 -         switchInt(move _4) -> [1_isize: bb1, otherwise: bb3]; // scope 1 at $DIR/while_let_loops.rs:7:15: 7:25

--- a/src/test/mir-opt/while_let_loops.change_loop_body.ConstProp.64bit.diff
+++ b/src/test/mir-opt/while_let_loops.change_loop_body.ConstProp.64bit.diff
@@ -19,6 +19,7 @@
           StorageLive(_1);                 // scope 0 at $DIR/while_let_loops.rs:6:9: 6:15
           _1 = const 0_i32;                // scope 0 at $DIR/while_let_loops.rs:6:18: 6:19
           StorageLive(_3);                 // scope 1 at $DIR/while_let_loops.rs:7:28: 7:32
+          Deinit(_3);                      // scope 1 at $DIR/while_let_loops.rs:7:28: 7:32
           discriminant(_3) = 0;            // scope 1 at $DIR/while_let_loops.rs:7:28: 7:32
 -         _4 = discriminant(_3);           // scope 1 at $DIR/while_let_loops.rs:7:15: 7:25
 -         switchInt(move _4) -> [1_isize: bb1, otherwise: bb3]; // scope 1 at $DIR/while_let_loops.rs:7:15: 7:25

--- a/src/test/ui/consts/const-eval/ub-enum-overwrite.rs
+++ b/src/test/ui/consts/const-eval/ub-enum-overwrite.rs
@@ -1,0 +1,17 @@
+#![feature(const_mut_refs)]
+
+enum E {
+    A(u8),
+    B,
+}
+
+const _: u8 = {
+    //~^ ERROR is undefined behavior
+    let mut e = E::A(1);
+    let p = if let E::A(x) = &mut e { x as *mut u8 } else { unreachable!() };
+    // Make sure overwriting `e` uninitializes other bytes
+    e = E::B;
+    unsafe { *p }
+};
+
+fn main() {}

--- a/src/test/ui/consts/const-eval/ub-enum-overwrite.stderr
+++ b/src/test/ui/consts/const-eval/ub-enum-overwrite.stderr
@@ -1,0 +1,20 @@
+error[E0080]: it is undefined behavior to use this value
+  --> $DIR/ub-enum-overwrite.rs:8:1
+   |
+LL | / const _: u8 = {
+LL | |
+LL | |     let mut e = E::A(1);
+LL | |     let p = if let E::A(x) = &mut e { x as *mut u8 } else { unreachable!() };
+...  |
+LL | |     unsafe { *p }
+LL | | };
+   | |__^ type validation failed: encountered uninitialized bytes, but expected initialized plain (non-pointer) bytes
+   |
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
+   = note: the raw bytes of the constant (size: 1, align: 1) {
+               __                                              │ ░
+           }
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/const-eval/ub-enum.32bit.stderr
+++ b/src/test/ui/consts/const-eval/ub-enum.32bit.stderr
@@ -79,11 +79,11 @@ error[E0080]: it is undefined behavior to use this value
   --> $DIR/ub-enum.rs:60:1
    |
 LL | const BAD_ENUM2_OPTION_PTR: Option<Enum2> = unsafe { mem::transmute(&0) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .<enum-tag>: encountered pointer to alloc29, but expected initialized plain (non-pointer) bytes
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .<enum-tag>: encountered pointer to alloc30, but expected initialized plain (non-pointer) bytes
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 4, align: 4) {
-               ╾─alloc29─╼                                     │ ╾──╼
+               ╾─alloc30─╼                                     │ ╾──╼
            }
 
 error[E0080]: it is undefined behavior to use this value

--- a/src/test/ui/consts/const-eval/ub-enum.64bit.stderr
+++ b/src/test/ui/consts/const-eval/ub-enum.64bit.stderr
@@ -79,11 +79,11 @@ error[E0080]: it is undefined behavior to use this value
   --> $DIR/ub-enum.rs:60:1
    |
 LL | const BAD_ENUM2_OPTION_PTR: Option<Enum2> = unsafe { mem::transmute(&0) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .<enum-tag>: encountered pointer to alloc29, but expected initialized plain (non-pointer) bytes
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .<enum-tag>: encountered pointer to alloc30, but expected initialized plain (non-pointer) bytes
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 8, align: 8) {
-               ╾───────alloc29───────╼                         │ ╾──────╼
+               ╾───────alloc30───────╼                         │ ╾──────╼
            }
 
 error[E0080]: it is undefined behavior to use this value

--- a/src/test/ui/consts/const-eval/ub-ref-ptr.32bit.stderr
+++ b/src/test/ui/consts/const-eval/ub-ref-ptr.32bit.stderr
@@ -145,11 +145,11 @@ error[E0080]: it is undefined behavior to use this value
   --> $DIR/ub-ref-ptr.rs:55:1
    |
 LL | const DATA_FN_PTR: fn() = unsafe { mem::transmute(&13) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc41, but expected a function pointer
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc43, but expected a function pointer
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 4, align: 4) {
-               ╾─alloc41─╼                                     │ ╾──╼
+               ╾─alloc43─╼                                     │ ╾──╼
            }
 
 error: aborting due to 14 previous errors

--- a/src/test/ui/consts/const-eval/ub-ref-ptr.64bit.stderr
+++ b/src/test/ui/consts/const-eval/ub-ref-ptr.64bit.stderr
@@ -145,11 +145,11 @@ error[E0080]: it is undefined behavior to use this value
   --> $DIR/ub-ref-ptr.rs:55:1
    |
 LL | const DATA_FN_PTR: fn() = unsafe { mem::transmute(&13) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc41, but expected a function pointer
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc43, but expected a function pointer
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 8, align: 8) {
-               ╾───────alloc41───────╼                         │ ╾──────╼
+               ╾───────alloc43───────╼                         │ ╾──────╼
            }
 
 error: aborting due to 14 previous errors

--- a/src/test/ui/consts/offset_from_ub.stderr
+++ b/src/test/ui/consts/offset_from_ub.stderr
@@ -40,19 +40,19 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/offset_from_ub.rs:52:14
    |
 LL |     unsafe { ptr_offset_from(end_ptr, start_ptr) }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ out-of-bounds offset_from: alloc18 has size 4, so pointer at offset 10 is out-of-bounds
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ out-of-bounds offset_from: alloc20 has size 4, so pointer at offset 10 is out-of-bounds
 
 error[E0080]: evaluation of constant value failed
   --> $DIR/offset_from_ub.rs:61:14
    |
 LL |     unsafe { ptr_offset_from(start_ptr, end_ptr) }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ out-of-bounds offset_from: alloc21 has size 4, so pointer at offset 10 is out-of-bounds
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ out-of-bounds offset_from: alloc23 has size 4, so pointer at offset 10 is out-of-bounds
 
 error[E0080]: evaluation of constant value failed
   --> $DIR/offset_from_ub.rs:69:14
    |
 LL |     unsafe { ptr_offset_from(end_ptr, end_ptr) }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ out-of-bounds offset_from: alloc24 has size 4, so pointer at offset 10 is out-of-bounds
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ out-of-bounds offset_from: alloc26 has size 4, so pointer at offset 10 is out-of-bounds
 
 error: aborting due to 8 previous errors
 

--- a/src/tools/clippy/clippy_utils/src/qualify_min_const_fn.rs
+++ b/src/tools/clippy/clippy_utils/src/qualify_min_const_fn.rs
@@ -211,7 +211,8 @@ fn check_statement<'tcx>(
 
         StatementKind::FakeRead(box (_, place)) => check_place(tcx, *place, span, body),
         // just an assignment
-        StatementKind::SetDiscriminant { place, .. } => check_place(tcx, **place, span, body),
+        StatementKind::SetDiscriminant { place, .. } | StatementKind::Deinit(place) => 
+            check_place(tcx, **place, span, body),
 
         StatementKind::CopyNonOverlapping(box rustc_middle::mir::CopyNonOverlapping { dst, src, count }) => {
             check_operand(tcx, dst, span, body)?;


### PR DESCRIPTION
This rvalue replaces `SetDiscriminant` for ADTs. This PR is an alternative to #94590 , which only specifies that the behavior of `SetDiscriminant` is the same as what this rvalue would do. The motivation for this change are discussed in that PR and [on Zulip](https://rust-lang.zulipchat.com/#narrow/stream/189540-t-compiler.2Fwg-mir-opt/topic/SetDiscriminant.20and.20aggregate.20initialization.20.2394590)

r? @oli-obk