### PR TITLE
Fix docs for default rmeta filename.

### DIFF
--- a/src/doc/rustc/src/command-line-arguments.md
+++ b/src/doc/rustc/src/command-line-arguments.md
@@ -118,7 +118,7 @@ The valid emit kinds are:
 - `llvm-ir` — Generates a file containing [LLVM IR]. The default output
   filename is `CRATE_NAME.ll`.
 - `metadata` — Generates a file containing metadata about the crate. The
-  default output filename is `CRATE_NAME.rmeta`.
+  default output filename is `libCRATE_NAME.rmeta`.
 - `mir` — Generates a file containing rustc's mid-level intermediate
   representation. The default output filename is `CRATE_NAME.mir`.
 - `obj` — Generates a native object file. The default output filename is


### PR DESCRIPTION
The docs for the default filename for `--emit=metadata` was wrong, it was missing the `lib` prefix.  The current implementation for that default is [here](https://github.com/rust-lang/rust/blob/f2661cfe341f88bea919daf52a07015dceaf7a6a/compiler/rustc_session/src/output.rs#L140).  Perhaps somewhat confusing, but `lib` is used for all crate types.

cc https://github.com/rust-lang/rust/issues/68839#issuecomment-1073118716