### PR TITLE
Re-enable some gdb tests

### DIFF
--- a/src/test/debuginfo/basic-types-globals-metadata.rs
+++ b/src/test/debuginfo/basic-types-globals-metadata.rs
@@ -1,5 +1,4 @@
 // min-lldb-version: 310
-// ignore-gdb // Test temporarily ignored due to debuginfo tests being disabled, see PR 47155
 
 // compile-flags:-g
 // gdb-command:run
@@ -9,9 +8,10 @@
 // gdbg-command:whatis 'basic_types_globals_metadata::I'
 // gdbr-command:whatis basic_types_globals_metadata::I
 // gdb-check:type = isize
-// gdbg-command:whatis 'basic_types_globals_metadata::C'
-// gdbr-command:whatis basic_types_globals_metadata::C
-// gdb-check:type = char
+
+// Note we don't check the 'char' type here, as gdb only got support
+// for DW_ATE_UTF in 11.2.  This is handled by a different test.
+
 // gdbg-command:whatis 'basic_types_globals_metadata::I8'
 // gdbr-command:whatis basic_types_globals_metadata::I8
 // gdb-check:type = i8

--- a/src/test/debuginfo/basic-types-globals.rs
+++ b/src/test/debuginfo/basic-types-globals.rs
@@ -1,11 +1,4 @@
-// Caveats - gdb prints any 8-bit value (meaning rust I8 and u8 values)
-// as its numerical value along with its associated ASCII char, there
-// doesn't seem to be any way around this. Also, gdb doesn't know
-// about UTF-32 character encoding and will print a rust char as only
-// its numerical value.
-
 // min-lldb-version: 310
-// ignore-gdb // Test temporarily ignored due to debuginfo tests being disabled, see PR 47155
 
 // compile-flags:-g
 // gdb-command:run
@@ -15,10 +8,9 @@
 // gdbg-command:print 'basic_types_globals::I'
 // gdbr-command:print I
 // gdb-check:$2 = -1
-// gdbg-command:print 'basic_types_globals::C'
-// gdbr-command:print C
-// gdbg-check:$3 = 97
-// gdbr-check:$3 = 97 'a'
+// gdbg-command:print/d 'basic_types_globals::C'
+// gdbr-command:print/d C
+// gdb-check:$3 = 97
 // gdbg-command:print/d 'basic_types_globals::I8'
 // gdbr-command:print I8
 // gdb-check:$4 = 68

--- a/src/test/debuginfo/basic-types-metadata.rs
+++ b/src/test/debuginfo/basic-types-metadata.rs
@@ -1,5 +1,4 @@
 // min-lldb-version: 310
-// ignore-gdb // Test temporarily ignored due to debuginfo tests being disabled, see PR 47155
 
 // compile-flags:-g
 // gdb-command:run
@@ -9,8 +8,10 @@
 // gdb-check:type = bool
 // gdb-command:whatis i
 // gdb-check:type = isize
-// gdb-command:whatis c
-// gdb-check:type = char
+
+// Note we don't check the 'char' type here, as gdb only got support
+// for DW_ATE_UTF in 11.2.  This is handled by a different test.
+
 // gdb-command:whatis i8
 // gdb-check:type = i8
 // gdb-command:whatis i16
@@ -34,31 +35,19 @@
 // gdb-command:whatis f64
 // gdb-check:type = f64
 // gdb-command:whatis fnptr
-// gdb-check:type = [...] (*)([...])
+// gdb-check:type = [...] ([...])
 // gdb-command:info functions _yyy
 // gdbg-check:[...]![...]_yyy([...]);
-// gdbr-check:static fn basic_types_metadata::_yyy() -> !;
+// gdbr-check:static fn basic_types_metadata::_yyy()[...]
+
+// Just check that something is emitted, this changed already once and
+// it's not extremely informative.
 // gdb-command:ptype closure_0
-// gdbr-check: type = struct closure
-// gdbg-check: type = struct closure {
-// gdbg-check:     <no data fields>
-// gdbg-check: }
+// gdb-check: type = [...]closure[...]
 // gdb-command:ptype closure_1
-// gdbg-check: type = struct closure {
-// gdbg-check:     bool *__0;
-// gdbg-check: }
-// gdbr-check: type = struct closure (
-// gdbr-check:     bool *,
-// gdbr-check: )
+// gdb-check: type = [...]closure[...]
 // gdb-command:ptype closure_2
-// gdbg-check: type = struct closure {
-// gdbg-check:     bool *__0;
-// gdbg-check:     isize *__1;
-// gdbg-check: }
-// gdbr-check: type = struct closure (
-// gdbr-check:     bool *,
-// gdbr-check:     isize *,
-// gdbr-check: )
+// gdb-check: type = [...]closure[...]
 
 //
 // gdb-command:continue

--- a/src/test/debuginfo/basic-types-mut-globals.rs
+++ b/src/test/debuginfo/basic-types-mut-globals.rs
@@ -1,11 +1,4 @@
-// Caveats - gdb prints any 8-bit value (meaning rust I8 and u8 values)
-// as its numerical value along with its associated ASCII char, there
-// doesn't seem to be any way around this. Also, gdb doesn't know
-// about UTF-32 character encoding and will print a rust char as only
-// its numerical value.
-
 // min-lldb-version: 310
-// ignore-gdb // Test temporarily ignored due to debuginfo tests being disabled, see PR 47155
 
 // compile-flags:-g
 
@@ -19,9 +12,8 @@
 // gdbr-command:print I
 // gdb-check:$2 = -1
 // gdbg-command:print/d 'basic_types_mut_globals::C'
-// gdbr-command:print C
-// gdbg-check:$3 = 97
-// gdbr-check:$3 = 97 'a'
+// gdbr-command:print/d C
+// gdb-check:$3 = 97
 // gdbg-command:print/d 'basic_types_mut_globals::I8'
 // gdbr-command:print I8
 // gdb-check:$4 = 68
@@ -65,9 +57,8 @@
 // gdbr-command:print I
 // gdb-check:$16 = 2
 // gdbg-command:print/d 'basic_types_mut_globals'::C
-// gdbr-command:print C
-// gdbg-check:$17 = 102
-// gdbr-check:$17 = 102 'f'
+// gdbr-command:print/d C
+// gdb-check:$17 = 102
 // gdbg-command:print/d 'basic_types_mut_globals'::I8
 // gdbr-command:print/d I8
 // gdb-check:$18 = 78

--- a/src/test/debuginfo/by-value-non-immediate-argument.rs
+++ b/src/test/debuginfo/by-value-non-immediate-argument.rs
@@ -1,4 +1,4 @@
-// ignore-test // Test temporarily ignored due to debuginfo tests being disabled, see PR 47155
+// ignore-lldb // Test temporarily ignored due to debuginfo tests being disabled, see PR 47155
 // min-lldb-version: 310
 
 // compile-flags:-g

--- a/src/test/debuginfo/c-style-enum.rs
+++ b/src/test/debuginfo/c-style-enum.rs
@@ -1,5 +1,4 @@
 // ignore-aarch64
-// ignore-gdb // Test temporarily ignored due to debuginfo tests being disabled, see PR 47155
 // min-lldb-version: 310
 
 // compile-flags:-g

--- a/src/test/debuginfo/drop-locations.rs
+++ b/src/test/debuginfo/drop-locations.rs
@@ -1,6 +1,6 @@
 // ignore-windows
 // ignore-android
-// ignore-test // Test temporarily ignored due to debuginfo tests being disabled, see PR 47155
+// ignore-lldb // Test temporarily ignored due to debuginfo tests being disabled, see PR 47155
 // min-lldb-version: 310
 
 #![allow(unused)]

--- a/src/test/debuginfo/drop-locations.rs
+++ b/src/test/debuginfo/drop-locations.rs
@@ -1,6 +1,6 @@
 // ignore-windows
 // ignore-android
-// ignore-lldb // Test temporarily ignored due to debuginfo tests being disabled, see PR 47155
+// ignore-test // Test temporarily ignored due to debuginfo tests being disabled, see PR 47155
 // min-lldb-version: 310
 
 #![allow(unused)]

--- a/src/test/debuginfo/function-arg-initialization.rs
+++ b/src/test/debuginfo/function-arg-initialization.rs
@@ -1,4 +1,4 @@
-// ignore-test // Test temporarily ignored due to debuginfo tests being disabled, see PR 47155
+// ignore-lldb // Test temporarily ignored due to debuginfo tests being disabled, see PR 47155
 // min-lldb-version: 310
 
 // This test case checks if function arguments already have the correct value

--- a/src/test/debuginfo/gdb-char.rs
+++ b/src/test/debuginfo/gdb-char.rs
@@ -9,15 +9,23 @@
 // gdb-command:run
 // gdb-command:print ch
 // gdb-check:$1 = 97 'a'
+// gdb-command:whatis ch
+// gdb-check:type = char
+// gdb-command:whatis gdb_char::C
+// gdb-check:type = char
 
 #![allow(unused_variables)]
 #![feature(omit_gdb_pretty_printer_section)]
 #![omit_gdb_pretty_printer_section]
 
+static mut C: char = 'a';
+
 fn main() {
     let ch: char = 'a';
 
     zzz(); // #break
+
+    let a = unsafe { (C, ) };
 }
 
 fn zzz() {()}

--- a/src/test/debuginfo/lexical-scopes-in-block-expression.rs
+++ b/src/test/debuginfo/lexical-scopes-in-block-expression.rs
@@ -1,5 +1,4 @@
 // min-lldb-version: 310
-// ignore-gdb // Test temporarily ignored due to debuginfo tests being disabled, see PR 47155
 
 // compile-flags:-g
 

--- a/src/test/debuginfo/limited-debuginfo.rs
+++ b/src/test/debuginfo/limited-debuginfo.rs
@@ -1,5 +1,4 @@
 // ignore-lldb
-// ignore-gdb // Test temporarily ignored due to debuginfo tests being disabled, see PR 47155
 
 // compile-flags:-C debuginfo=1
 

--- a/src/test/debuginfo/method-on-enum.rs
+++ b/src/test/debuginfo/method-on-enum.rs
@@ -1,5 +1,5 @@
 // min-lldb-version: 310
-// ignore-test // Test temporarily ignored due to debuginfo tests being disabled, see PR 47155
+// ignore-lldb // Test temporarily ignored due to debuginfo tests being disabled, see PR 47155
 
 // compile-flags:-g
 

--- a/src/test/debuginfo/option-like-enum.rs
+++ b/src/test/debuginfo/option-like-enum.rs
@@ -1,4 +1,4 @@
-// ignore-test // Test temporarily ignored due to debuginfo tests being disabled, see PR 47155
+// ignore-lldb // Test temporarily ignored due to debuginfo tests being disabled, see PR 47155
 
 // min-lldb-version: 310
 
@@ -22,7 +22,7 @@
 
 // gdbg-command:print empty_gdb->discr
 // gdbr-command:print empty_gdb.discr
-// gdb-check:$4 = (isize *) 0x0
+// gdb-check:$4 = (*mut isize) 0x1
 
 // gdb-command:print droid
 // gdbg-check:$5 = {RUST$ENCODED$ENUM$2$Void = {id = 675675, range = 10000001, internals = 0x43218765}}
@@ -30,11 +30,11 @@
 
 // gdbg-command:print void_droid_gdb->internals
 // gdbr-command:print void_droid_gdb.internals
-// gdb-check:$6 = (isize *) 0x0
+// gdb-check:$6 = (*mut isize) 0x0
 
 // gdb-command:print nested_non_zero_yep
 // gdbg-check:$7 = {RUST$ENCODED$ENUM$1$2$Nope = {__0 = 10.5, __1 = {a = 10, b = 20, c = [...]}}}
-// gdbr-check:$7 = option_like_enum::NestedNonZero::Yep(10.5, option_like_enum::NestedNonZeroField {a: 10, b: 20, c: 0x[...] "x[...]"})
+// gdbr-check:$7 = option_like_enum::NestedNonZero::Yep(10.5, option_like_enum::NestedNonZeroField {a: 10, b: 20, c: 0x[...]})
 
 // gdb-command:print nested_non_zero_nope
 // gdbg-check:$8 = {RUST$ENCODED$ENUM$1$2$Nope = {__0 = [...], __1 = {a = [...], b = [...], c = 0x0}}}

--- a/src/test/debuginfo/simple-struct.rs
+++ b/src/test/debuginfo/simple-struct.rs
@@ -1,5 +1,4 @@
 // min-lldb-version: 310
-// ignore-gdb // Test temporarily ignored due to debuginfo tests being disabled, see PR 47155
 
 // compile-flags:-g
 

--- a/src/test/debuginfo/simple-tuple.rs
+++ b/src/test/debuginfo/simple-tuple.rs
@@ -1,5 +1,4 @@
 // min-lldb-version: 310
-// ignore-gdb // Test temporarily ignored due to debuginfo tests being disabled, see PR 47155
 
 // compile-flags:-g
 

--- a/src/test/debuginfo/struct-in-enum.rs
+++ b/src/test/debuginfo/struct-in-enum.rs
@@ -1,6 +1,6 @@
 // min-lldb-version: 310
 // ignore-gdb-version: 7.11.90 - 7.12.9
-// ignore-test // Test temporarily ignored due to debuginfo tests being disabled, see PR 47155
+// ignore-lldb // Test temporarily ignored due to debuginfo tests being disabled, see PR 47155
 
 // compile-flags:-g
 

--- a/src/test/debuginfo/union-smoke.rs
+++ b/src/test/debuginfo/union-smoke.rs
@@ -1,5 +1,4 @@
 // min-lldb-version: 310
-// ignore-gdb // Test temporarily ignored due to debuginfo tests being disabled, see PR 47155
 
 // ignore-gdb-version: 7.11.90 - 7.12.9
 

--- a/src/test/debuginfo/vec.rs
+++ b/src/test/debuginfo/vec.rs
@@ -1,5 +1,4 @@
 // min-lldb-version: 310
-// ignore-gdb // Test temporarily ignored due to debuginfo tests being disabled, see PR 47155
 
 // compile-flags:-g
 


### PR DESCRIPTION
Bug #47163 points out that some debug tests were disabled.  This patch
re-enables many of them for gdb (I don't know enough about recent
versions of lldb to make this change there).  One test that only works
for a relatively new gdb, due to the use of DW_ATE_UTF, is moved to a
version-specific test.  In a couple of spot, I simplified the check
expression where I thought that it made sense to do so -- sometimes it
isn't very worthwhile to match exactly what is emitted, particularly
where this has changed over time.  I tested this with both a
DW_ATE_UTF-capable gdb, and an older version.