### PR TITLE
std/OsString: Add detailed comment on args meaning

### DIFF
--- a/library/std/src/ffi/os_str.rs
+++ b/library/std/src/ffi/os_str.rs
@@ -188,6 +188,14 @@ impl OsString {
     ///
     /// See main `OsString` documentation information about encoding.
     ///
+    /// # Notes
+    ///
+    /// `capacity` represents the length of the units in the given `OsString`,
+    /// which is different from the size of "Rust string form" like `String` or
+    /// `str`. Also, they could be different on different platforms.
+    ///
+    /// Refer to [`OsString`] for more details.
+    ///
     /// # Examples
     ///
     /// ```
@@ -271,6 +279,14 @@ impl OsString {
     /// frequent reallocations. After calling `try_reserve`, capacity will be
     /// greater than or equal to `self.len() + additional`. Does nothing if
     /// capacity is already sufficient.
+    ///
+    /// # Notes
+    ///
+    /// `additional` represents the length of the units in the given `OsString`,
+    /// which is different from the size of "Rust string form" like `String` or
+    /// `str`. Also, they could be different on different platforms.
+    ///
+    /// Refer to [`OsString`] for more details.
     ///
     /// # Errors
     ///


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

Part of https://github.com/rust-lang/rust/issues/91789

Address the concern:

> do we need better docs about what the argument value means (not bytes) (https://github.com/rust-lang/rust/issues/91789#issuecomment-1027257918)