### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -1486,7 +1486,7 @@ impl<'a> Parser<'a> {
                             // `check_trailing_angle_brackets` already emitted a nicer error
                             // NOTE(eddyb) this was `.cancel()`, but `err`
                             // gets returned, so we can't fully defuse it.
-                            err.downgrade_to_delayed_bug();
+                            err.delay_as_bug();
                         }
                     }
                 }

--- a/compiler/rustc_typeck/src/check/method/suggest.rs
+++ b/compiler/rustc_typeck/src/check/method/suggest.rs
@@ -599,7 +599,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
                     // Make sure that, if any traits other than the found ones were involved,
                     // we don't don't report an unimplemented trait.
-                    // We don't want to say that `iter::Cloned` is not an interator, just
+                    // We don't want to say that `iter::Cloned` is not an iterator, just
                     // because of some non-Clone item being iterated over.
                     for (predicate, _parent_pred, _cause) in &unsatisfied_predicates {
                         match predicate.kind().skip_binder() {

--- a/library/std/src/sys/windows/process/tests.rs
+++ b/library/std/src/sys/windows/process/tests.rs
@@ -186,8 +186,15 @@ fn windows_exe_resolver() {
     let temp = tmpdir();
     let mut exe_path = temp.path().to_owned();
     exe_path.push("exists.exe");
-    symlink("<DOES NOT EXIST>".as_ref(), &exe_path).unwrap();
 
     // A broken symlink should still be resolved.
-    assert!(resolve_exe(OsStr::new("exists.exe"), empty_paths, Some(temp.path().as_ref())).is_ok());
+    // Skip this check if not in CI and creating symlinks isn't possible.
+    let is_ci = env::var("CI").is_ok();
+    let result = symlink("<DOES NOT EXIST>".as_ref(), &exe_path);
+    if is_ci || result.is_ok() {
+        result.unwrap();
+        assert!(
+            resolve_exe(OsStr::new("exists.exe"), empty_paths, Some(temp.path().as_ref())).is_ok()
+        );
+    }
 }

--- a/src/doc/rustc/src/command-line-arguments.md
+++ b/src/doc/rustc/src/command-line-arguments.md
@@ -118,7 +118,7 @@ The valid emit kinds are:
 - `llvm-ir` — Generates a file containing [LLVM IR]. The default output
   filename is `CRATE_NAME.ll`.
 - `metadata` — Generates a file containing metadata about the crate. The
-  default output filename is `CRATE_NAME.rmeta`.
+  default output filename is `libCRATE_NAME.rmeta`.
 - `mir` — Generates a file containing rustc's mid-level intermediate
   representation. The default output filename is `CRATE_NAME.mir`.
 - `obj` — Generates a native object file. The default output filename is

--- a/src/test/ui/parser/recover-field-extra-angle-brackets-in-struct-with-a-field.rs
+++ b/src/test/ui/parser/recover-field-extra-angle-brackets-in-struct-with-a-field.rs
@@ -1,0 +1,6 @@
+struct TypedArenaChunk {
+    next: Option<String>>
+    //~^ ERROR unmatched angle bracket
+}
+
+fn main() {}

--- a/src/test/ui/parser/recover-field-extra-angle-brackets-in-struct-with-a-field.stderr
+++ b/src/test/ui/parser/recover-field-extra-angle-brackets-in-struct-with-a-field.stderr
@@ -1,0 +1,11 @@
+error: unmatched angle bracket
+  --> $DIR/recover-field-extra-angle-brackets-in-struct-with-a-field.rs:2:25
+   |
+LL |       next: Option<String>>
+   |  _________________________^
+LL | |
+LL | | }
+   | |_ help: remove extra angle bracket
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Successful merges:

 - #95114 (Skip a test if symlink creation is not possible)
 - #95131 (Fix docs for default rmeta filename.)
 - #95135 (Fix a not emitted unmatched angle bracket error)
 - #95145 (Fix typo interator->iterator)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=95114,95131,95135,95145)
<!-- homu-ignore:end -->