### PR TITLE
Create `NonZero` trait with primitive associated type

### DIFF
--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -422,3 +422,11 @@ pub mod simd {
 }
 
 include!("primitive_docs.rs");
+
+mod sealed {
+    /// This trait being unreachable from outside the crate
+    /// prevents outside implementations of our extension traits.
+    /// This allows adding more trait methods in the future.
+    #[unstable(feature = "sealed", issue = "none")]
+    pub trait Sealed {}
+}

--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -13,7 +13,7 @@ use crate::{intrinsics, sealed::Sealed};
 /// # Safety
 ///
 /// Implementors of this trait must not have a memory representation for zero.
-#[unstable(feature = "nonzero_trait", issue = "none")]
+#[unstable(feature = "nonzero_trait", issue = "95157")]
 pub unsafe trait NonZero: Sealed {
     /// The primitive scalar type.
     ///
@@ -70,7 +70,7 @@ macro_rules! nonzero_integers {
             #[unstable(feature = "sealed", issue = "none")]
             impl Sealed for $Ty {}
 
-            #[unstable(feature = "nonzero_trait", issue = "none")]
+            #[unstable(feature = "nonzero_trait", issue = "95157")]
             unsafe impl NonZero for $Ty {
                 type Scalar = $Int;
             }

--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -13,6 +13,7 @@ use crate::{intrinsics, sealed::Sealed};
 /// # Safety
 ///
 /// Implementors of this trait must not have a memory representation for zero.
+#[unstable(feature = "nonzero_trait", issue = "none")]
 pub unsafe trait NonZero: Sealed {
     /// The primitive scalar type.
     ///
@@ -66,8 +67,10 @@ macro_rules! nonzero_integers {
             #[rustc_nonnull_optimization_guaranteed]
             pub struct $Ty($Int);
 
+            #[unstable(feature = "sealed", issue = "none")]
             impl Sealed for $Ty {}
 
+            #[unstable(feature = "nonzero_trait", issue = "none")]
             unsafe impl NonZero for $Ty {
                 type Scalar = $Int;
             }


### PR DESCRIPTION
This enables getting the primitive integer type for a nonzero type through a type alias.

r? @yaahc