### PR TITLE
Update LLVM used for building rustc in CI for x64

### DIFF
--- a/src/ci/docker/host-x86_64/dist-x86_64-linux/build-clang.sh
+++ b/src/ci/docker/host-x86_64/dist-x86_64-linux/build-clang.sh
@@ -4,7 +4,7 @@ set -ex
 
 source shared.sh
 
-LLVM=llvmorg-13.0.0
+LLVM=llvmorg-14.0.2
 
 mkdir llvm-project
 cd llvm-project
@@ -30,7 +30,12 @@ hide_output \
       -DCMAKE_BUILD_TYPE=Release \
       -DCMAKE_INSTALL_PREFIX=/rustroot \
       -DCOMPILER_RT_BUILD_SANITIZERS=OFF \
+      -DCOMPILER_RT_BUILD_XRAY=OFF \
+      -DCOMPILER_RT_BUILD_MEMPROF=OFF \
       -DLLVM_TARGETS_TO_BUILD=X86 \
+      -DLLVM_INCLUDE_BENCHMARKS=OFF \
+      -DLLVM_INCLUDE_TESTS=OFF \
+      -DLLVM_INCLUDE_EXAMPLES=OFF \
       -DLLVM_ENABLE_PROJECTS="clang;lld;compiler-rt" \
       -DC_INCLUDE_DIRS="$INC"
 

--- a/src/ci/docker/host-x86_64/dist-x86_64-linux/build-gcc.sh
+++ b/src/ci/docker/host-x86_64/dist-x86_64-linux/build-gcc.sh
@@ -3,7 +3,7 @@ set -ex
 
 source shared.sh
 
-GCC=5.5.0
+GCC=7.5.0
 
 curl https://ftp.gnu.org/gnu/gcc/gcc-$GCC/gcc-$GCC.tar.xz | xzcat | tar xf -
 cd gcc-$GCC


### PR DESCRIPTION
LLVM 14 was tagged. It is needed for building [BOLT](https://github.com/rust-lang/rust/pull/94381), and it also improves max RSS quite [a lot](https://perf.rust-lang.org/compare.html?start=6970f88db3ac2a9cefa9c585228291ae1f18fb04&end=67acb7e3ffcc11d67abfd29c390aac629f3c0e97&stat=max-rss).

GCC was bumped to allow building the new LLVM version. The changes in building LLVM were done to speed up the build a bit by ignoring unused parts and to turn off parts that were problematic to compile even with the bumped GCC.