### PR TITLE
move `adt_const_params`  to its own tracking issue

### DIFF
--- a/compiler/rustc_feature/src/active.rs
+++ b/compiler/rustc_feature/src/active.rs
@@ -287,7 +287,7 @@ declare_features! (
     /// Allows `extern "x86-interrupt" fn()`.
     (active, abi_x86_interrupt, "1.17.0", Some(40180), None),
     /// Allows additional const parameter types, such as `&'static str` or user defined types
-    (incomplete, adt_const_params, "1.56.0", Some(44580), None),
+    (incomplete, adt_const_params, "1.56.0", Some(95174), None),
     /// Allows defining an `#[alloc_error_handler]`.
     (active, alloc_error_handler, "1.29.0", Some(51540), None),
     /// Allows explicit discriminants on non-unit enum variants.

--- a/src/test/ui/consts/refs_check_const_eq-issue-88384.stderr
+++ b/src/test/ui/consts/refs_check_const_eq-issue-88384.stderr
@@ -5,7 +5,7 @@ LL | #![feature(adt_const_params)]
    |            ^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
-   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
+   = note: see issue #95174 <https://github.com/rust-lang/rust/issues/95174> for more information
 
 warning: 1 warning emitted
 

--- a/src/test/ui/error-codes/E0771.stderr
+++ b/src/test/ui/error-codes/E0771.stderr
@@ -5,7 +5,7 @@ LL | #![feature(adt_const_params)]
    |            ^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
-   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
+   = note: see issue #95174 <https://github.com/rust-lang/rust/issues/95174> for more information
 
 error[E0771]: use of non-static lifetime `'a` in const generic
   --> $DIR/E0771.rs:4:41

--- a/src/test/ui/issues/issue-28561.rs
+++ b/src/test/ui/issues/issue-28561.rs
@@ -1,44 +1,6 @@
 // check-pass
-#[derive(Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Clone, Copy)]
 struct Array<T> {
-    f00: [T; 00],
-    f01: [T; 01],
-    f02: [T; 02],
-    f03: [T; 03],
-    f04: [T; 04],
-    f05: [T; 05],
-    f06: [T; 06],
-    f07: [T; 07],
-    f08: [T; 08],
-    f09: [T; 09],
-    f10: [T; 10],
-    f11: [T; 11],
-    f12: [T; 12],
-    f13: [T; 13],
-    f14: [T; 14],
-    f15: [T; 15],
-    f16: [T; 16],
-    f17: [T; 17],
-    f18: [T; 18],
-    f19: [T; 19],
-    f20: [T; 20],
-    f21: [T; 21],
-    f22: [T; 22],
-    f23: [T; 23],
-    f24: [T; 24],
-    f25: [T; 25],
-    f26: [T; 26],
-    f27: [T; 27],
-    f28: [T; 28],
-    f29: [T; 29],
-    f30: [T; 30],
-    f31: [T; 31],
-    f32: [T; 32],
-}
-
-// FIXME(#44580): merge with `Array` once `[T; N]: Clone` where `T: Clone`
-#[derive(Clone, Copy)]
-struct CopyArray<T: Copy> {
     f00: [T; 00],
     f01: [T; 01],
     f02: [T; 02],


### PR DESCRIPTION
the new tracking issue is  #95174 

r? @rust-lang/project-const-generics 