### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/compiler/rustc_feature/src/active.rs
+++ b/compiler/rustc_feature/src/active.rs
@@ -287,7 +287,7 @@ declare_features! (
     /// Allows `extern "x86-interrupt" fn()`.
     (active, abi_x86_interrupt, "1.17.0", Some(40180), None),
     /// Allows additional const parameter types, such as `&'static str` or user defined types
-    (incomplete, adt_const_params, "1.56.0", Some(44580), None),
+    (incomplete, adt_const_params, "1.56.0", Some(95174), None),
     /// Allows defining an `#[alloc_error_handler]`.
     (active, alloc_error_handler, "1.29.0", Some(51540), None),
     /// Allows explicit discriminants on non-unit enum variants.

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -196,8 +196,7 @@ impl CheckAttrVisitor<'_> {
     fn inline_attr_str_error_with_macro_def(&self, hir_id: HirId, attr: &Attribute, sym: &str) {
         self.tcx.struct_span_lint_hir(UNUSED_ATTRIBUTES, hir_id, attr.span, |lint| {
             lint.build(&format!(
-                "`#[{}]` is ignored on struct fields, match arms and macro defs",
-                sym,
+                "`#[{sym}]` is ignored on struct fields, match arms and macro defs",
             ))
             .warn(
                 "this was previously accepted by the compiler but is \
@@ -214,7 +213,7 @@ impl CheckAttrVisitor<'_> {
 
     fn inline_attr_str_error_without_macro_def(&self, hir_id: HirId, attr: &Attribute, sym: &str) {
         self.tcx.struct_span_lint_hir(UNUSED_ATTRIBUTES, hir_id, attr.span, |lint| {
-            lint.build(&format!("`#[{}]` is ignored on struct fields and match arms", sym))
+            lint.build(&format!("`#[{sym}]` is ignored on struct fields and match arms"))
                 .warn(
                     "this was previously accepted by the compiler but is \
                  being phased out; it will become a hard error in \
@@ -721,7 +720,7 @@ impl CheckAttrVisitor<'_> {
                 .sess
                 .struct_span_err(
                     meta.name_value_literal_span().unwrap_or_else(|| meta.span()),
-                    &format!("`{}` is not a valid identifier", doc_keyword),
+                    &format!("`{doc_keyword}` is not a valid identifier"),
                 )
                 .emit();
             return false;
@@ -805,8 +804,7 @@ impl CheckAttrVisitor<'_> {
                 .struct_span_err(
                     meta.span(),
                     &format!(
-                        "`#![doc({} = \"...\")]` isn't allowed as a crate-level attribute",
-                        attr_name,
+                        "`#![doc({attr_name} = \"...\")]` isn't allowed as a crate-level attribute",
                     ),
                 )
                 .emit();
@@ -1035,8 +1033,7 @@ impl CheckAttrVisitor<'_> {
                                                 attr.meta().unwrap().span,
                                                 "use `doc = include_str!` instead",
                                                 format!(
-                                                    "#{}[doc = include_str!(\"{}\")]",
-                                                    inner, value
+                                                    "#{inner}[doc = include_str!(\"{value}\")]",
                                                 ),
                                                 applicability,
                                             );
@@ -1230,7 +1227,7 @@ impl CheckAttrVisitor<'_> {
                         if let Some(value) = attr.value_str() {
                             diag.span_help(
                                 attr.span,
-                                &format!(r#"try `#[link(name = "{}")]` instead"#, value),
+                                &format!(r#"try `#[link(name = "{value}")]` instead"#),
                             );
                         } else {
                             diag.span_help(attr.span, r#"try `#[link(name = "...")]` instead"#);
@@ -1518,15 +1515,14 @@ impl CheckAttrVisitor<'_> {
                 };
                 self.tcx.struct_span_lint_hir(UNUSED_ATTRIBUTES, hir_id, attr.span, |lint| {
                     lint.build(&format!(
-                        "`#[no_mangle]` has no effect on a foreign {}",
-                        foreign_item_kind
+                        "`#[no_mangle]` has no effect on a foreign {foreign_item_kind}"
                     ))
                     .warn(
                         "this was previously accepted by the compiler but is \
                             being phased out; it will become a hard error in \
                             a future release!",
                     )
-                    .span_label(span, format!("foreign {}", foreign_item_kind))
+                    .span_label(span, format!("foreign {foreign_item_kind}"))
                     .note("symbol names in extern blocks are not mangled")
                     .span_suggestion(
                         attr.span,
@@ -1692,9 +1688,9 @@ impl CheckAttrVisitor<'_> {
                 hint.span(),
                 E0517,
                 "{}",
-                &format!("attribute should be applied to {} {}", article, allowed_targets)
+                &format!("attribute should be applied to {article} {allowed_targets}")
             )
-            .span_label(span, &format!("not {} {}", article, allowed_targets))
+            .span_label(span, &format!("not {article} {allowed_targets}"))
             .emit();
         }
 

--- a/compiler/rustc_passes/src/check_const.rs
+++ b/compiler/rustc_passes/src/check_const.rs
@@ -80,8 +80,7 @@ impl<'tcx> hir::itemlikevisit::ItemLikeVisitor<'tcx> for CheckConstTraitVisitor<
     /// of the trait being implemented; as those provided functions can be non-const.
     fn visit_item<'hir>(&mut self, item: &'hir hir::Item<'hir>) {
         let _: Option<_> = try {
-            if let hir::ItemKind::Impl(ref imp) = item.kind {
-                if let hir::Constness::Const = imp.constness {
+            if let hir::ItemKind::Impl(ref imp) = item.kind && let hir::Constness::Const = imp.constness {
                     let trait_def_id = imp.of_trait.as_ref()?.trait_def_id()?;
                     let ancestors = self
                         .tcx
@@ -132,7 +131,6 @@ impl<'tcx> hir::itemlikevisit::ItemLikeVisitor<'tcx> for CheckConstTraitVisitor<
                             .note(&format!("`{}` not implemented", to_implement.join("`, `")))
                             .emit();
                     }
-                }
             }
         };
     }

--- a/compiler/rustc_passes/src/diagnostic_items.rs
+++ b/compiler/rustc_passes/src/diagnostic_items.rs
@@ -61,10 +61,9 @@ fn collect_item(tcx: TyCtxt<'_>, items: &mut DiagnosticItems, name: Symbol, item
     if let Some(original_def_id) = items.name_to_id.insert(name, item_def_id) {
         if original_def_id != item_def_id {
             let mut err = match tcx.hir().span_if_local(item_def_id) {
-                Some(span) => tcx.sess.struct_span_err(
-                    span,
-                    &format!("duplicate diagnostic item found: `{}`.", name),
-                ),
+                Some(span) => tcx
+                    .sess
+                    .struct_span_err(span, &format!("duplicate diagnostic item found: `{name}`.")),
                 None => tcx.sess.struct_err(&format!(
                     "duplicate diagnostic item in crate `{}`: `{}`.",
                     tcx.crate_name(item_def_id.krate),

--- a/src/doc/unstable-book/src/compiler-flags/check-cfg.md
+++ b/src/doc/unstable-book/src/compiler-flags/check-cfg.md
@@ -92,8 +92,6 @@ and `cfg!(name = "value")` call. It will check that the `"value"` specified is p
 list of expected values. If `"value"` is not in it, then `rustc` will report an `unexpected_cfgs`
 lint diagnostic. The default diagnostic level for this lint is `Warn`.
 
-The form `values()` is an error, because it does not specify a condition name.
-
 To enable checking of values, but to provide an empty set of valid values, use this form:
 
 ```bash
@@ -104,13 +102,17 @@ The `--check-cfg values(...)` option can be repeated, both for the same conditio
 different names. If it is repeated for the same condition name, then the sets of values for that
 condition are merged together.
 
+If `values()` is specified, then `rustc` will enable the checking of well-known values defined
+by itself. Note that it's necessary to specify the `values()` form to enable the checking of
+well known values, specifying the other forms doesn't implicitly enable it.
+
 ## Examples
 
 Consider this command line:
 
 ```bash
 rustc --check-cfg 'names(feature)' \
-      --check-cfg 'values(feature,"lion","zebra")' \
+      --check-cfg 'values(feature, "lion", "zebra")' \
       --cfg 'feature="lion"' -Z unstable-options \
       example.rs
 ```

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -400,7 +400,6 @@ nav.sub {
 .source .sidebar > *:not(#sidebar-toggle) {
 	opacity: 0;
 	visibility: hidden;
-	transition: opacity 0.5s;
 }
 
 .source .sidebar.expanded {
@@ -1675,12 +1674,6 @@ details.rustdoc-toggle[open] > summary.hideme::after {
 	search bar to have more space. */
 	.sidebar.expanded + main .width-limiter .sub-logo-container.rust-logo {
 		display: none;
-	}
-
-	/* It doesn't render well on mobile because of the layout, so better only have the transition
-	on desktop. */
-	.rustdoc.source .sidebar {
-		transition: width .5s;
 	}
 
 	.source .sidebar.expanded {

--- a/src/test/rustdoc-gui/code-sidebar-toggle.goml
+++ b/src/test/rustdoc-gui/code-sidebar-toggle.goml
@@ -3,6 +3,5 @@ goto: file://|DOC_PATH|/test_docs/index.html
 click: ".srclink"
 wait-for: "#sidebar-toggle"
 click: "#sidebar-toggle"
-wait-for: 500
 fail: true
 assert-css: ("#source-sidebar", { "left": "-300px" })

--- a/src/test/ui/abi/abi-sysv64-register-usage.rs
+++ b/src/test/ui/abi/abi-sysv64-register-usage.rs
@@ -5,6 +5,7 @@
 // ignore-android
 // ignore-arm
 // ignore-aarch64
+// needs-asm-support
 #![feature(asm_sym)]
 
 #[cfg(target_arch = "x86_64")]

--- a/src/test/ui/asm/aarch64/const.rs
+++ b/src/test/ui/asm/aarch64/const.rs
@@ -1,5 +1,6 @@
 // only-aarch64
 // run-pass
+// needs-asm-support
 // revisions: mirunsafeck thirunsafeck
 // [thirunsafeck]compile-flags: -Z thir-unsafeck
 

--- a/src/test/ui/asm/aarch64/duplicate-options.fixed
+++ b/src/test/ui/asm/aarch64/duplicate-options.fixed
@@ -1,4 +1,5 @@
 // only-aarch64
+// needs-asm-support
 // run-rustfix
 
 use std::arch::asm;

--- a/src/test/ui/asm/aarch64/duplicate-options.rs
+++ b/src/test/ui/asm/aarch64/duplicate-options.rs
@@ -1,4 +1,5 @@
 // only-aarch64
+// needs-asm-support
 // run-rustfix
 
 use std::arch::asm;

--- a/src/test/ui/asm/aarch64/duplicate-options.stderr
+++ b/src/test/ui/asm/aarch64/duplicate-options.stderr
@@ -1,53 +1,53 @@
 error: the `nomem` option was already provided
-  --> $DIR/duplicate-options.rs:8:33
+  --> $DIR/duplicate-options.rs:9:33
    |
 LL |         asm!("", options(nomem, nomem));
    |                                 ^^^^^ this option was already provided
 
 error: the `preserves_flags` option was already provided
-  --> $DIR/duplicate-options.rs:10:43
+  --> $DIR/duplicate-options.rs:11:43
    |
 LL |         asm!("", options(preserves_flags, preserves_flags));
    |                                           ^^^^^^^^^^^^^^^ this option was already provided
 
 error: the `nostack` option was already provided
-  --> $DIR/duplicate-options.rs:12:61
+  --> $DIR/duplicate-options.rs:13:61
    |
 LL |         asm!("", options(nostack, preserves_flags), options(nostack));
    |                                                             ^^^^^^^ this option was already provided
 
 error: the `nostack` option was already provided
-  --> $DIR/duplicate-options.rs:14:35
+  --> $DIR/duplicate-options.rs:15:35
    |
 LL |         asm!("", options(nostack, nostack), options(nostack), options(nostack));
    |                                   ^^^^^^^ this option was already provided
 
 error: the `nostack` option was already provided
-  --> $DIR/duplicate-options.rs:14:53
+  --> $DIR/duplicate-options.rs:15:53
    |
 LL |         asm!("", options(nostack, nostack), options(nostack), options(nostack));
    |                                                     ^^^^^^^ this option was already provided
 
 error: the `nostack` option was already provided
-  --> $DIR/duplicate-options.rs:14:71
+  --> $DIR/duplicate-options.rs:15:71
    |
 LL |         asm!("", options(nostack, nostack), options(nostack), options(nostack));
    |                                                                       ^^^^^^^ this option was already provided
 
 error: the `noreturn` option was already provided
-  --> $DIR/duplicate-options.rs:21:38
+  --> $DIR/duplicate-options.rs:22:38
    |
 LL |             options(preserves_flags, noreturn),
    |                                      ^^^^^^^^ this option was already provided
 
 error: the `nomem` option was already provided
-  --> $DIR/duplicate-options.rs:22:21
+  --> $DIR/duplicate-options.rs:23:21
    |
 LL |             options(nomem, nostack),
    |                     ^^^^^ this option was already provided
 
 error: the `noreturn` option was already provided
-  --> $DIR/duplicate-options.rs:23:21
+  --> $DIR/duplicate-options.rs:24:21
    |
 LL |             options(noreturn),
    |                     ^^^^^^^^ this option was already provided

--- a/src/test/ui/asm/aarch64/interpolated-idents.rs
+++ b/src/test/ui/asm/aarch64/interpolated-idents.rs
@@ -1,5 +1,5 @@
 // only-aarch64
-
+// needs-asm-support
 use std::arch::asm;
 
 macro_rules! m {

--- a/src/test/ui/asm/aarch64/srcloc.rs
+++ b/src/test/ui/asm/aarch64/srcloc.rs
@@ -1,5 +1,6 @@
 // only-aarch64
 // build-fail
+// needs-asm-support
 // compile-flags: -Ccodegen-units=1
 
 use std::arch::asm;

--- a/src/test/ui/asm/aarch64/srcloc.stderr
+++ b/src/test/ui/asm/aarch64/srcloc.stderr
@@ -1,5 +1,5 @@
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:11:15
+  --> $DIR/srcloc.rs:12:15
    |
 LL |         asm!("invalid_instruction");
    |               ^
@@ -11,7 +11,7 @@ LL |     invalid_instruction
    |     ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:15:13
+  --> $DIR/srcloc.rs:16:13
    |
 LL |             invalid_instruction
    |             ^
@@ -23,7 +23,7 @@ LL |             invalid_instruction
    |             ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:20:13
+  --> $DIR/srcloc.rs:21:13
    |
 LL |             invalid_instruction
    |             ^
@@ -35,7 +35,7 @@ LL |             invalid_instruction
    |             ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:26:13
+  --> $DIR/srcloc.rs:27:13
    |
 LL |             invalid_instruction
    |             ^
@@ -47,7 +47,7 @@ LL |             invalid_instruction
    |             ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:33:13
+  --> $DIR/srcloc.rs:34:13
    |
 LL |             invalid_instruction
    |             ^
@@ -59,7 +59,7 @@ LL |             invalid_instruction
    |             ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:38:14
+  --> $DIR/srcloc.rs:39:14
    |
 LL |         asm!(concat!("invalid", "_", "instruction"));
    |              ^
@@ -71,7 +71,7 @@ LL |     invalid_instruction
    |     ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:42:14
+  --> $DIR/srcloc.rs:43:14
    |
 LL |             "invalid_instruction",
    |              ^
@@ -83,7 +83,7 @@ LL |     invalid_instruction
    |     ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:48:14
+  --> $DIR/srcloc.rs:49:14
    |
 LL |             "invalid_instruction",
    |              ^
@@ -95,7 +95,7 @@ LL | invalid_instruction
    | ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:55:14
+  --> $DIR/srcloc.rs:56:14
    |
 LL |             "invalid_instruction",
    |              ^
@@ -107,7 +107,7 @@ LL | invalid_instruction
    | ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:62:13
+  --> $DIR/srcloc.rs:63:13
    |
 LL |             concat!("invalid", "_", "instruction"),
    |             ^
@@ -119,7 +119,7 @@ LL | invalid_instruction
    | ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:69:13
+  --> $DIR/srcloc.rs:70:13
    |
 LL |             concat!("invalid", "_", "instruction"),
    |             ^
@@ -131,7 +131,7 @@ LL | invalid_instruction
    | ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:76:14
+  --> $DIR/srcloc.rs:77:14
    |
 LL |             "invalid_instruction1",
    |              ^
@@ -143,7 +143,7 @@ LL |     invalid_instruction1
    |     ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:77:14
+  --> $DIR/srcloc.rs:78:14
    |
 LL |             "invalid_instruction2",
    |              ^
@@ -155,7 +155,7 @@ LL | invalid_instruction2
    | ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:83:13
+  --> $DIR/srcloc.rs:84:13
    |
 LL |             concat!(
    |             ^
@@ -167,7 +167,7 @@ LL |     invalid_instruction1
    |     ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:83:13
+  --> $DIR/srcloc.rs:84:13
    |
 LL |             concat!(
    |             ^
@@ -179,7 +179,7 @@ LL | invalid_instruction2
    | ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:92:13
+  --> $DIR/srcloc.rs:93:13
    |
 LL |             concat!(
    |             ^
@@ -191,7 +191,7 @@ LL |     invalid_instruction1
    |     ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:92:13
+  --> $DIR/srcloc.rs:93:13
    |
 LL |             concat!(
    |             ^
@@ -203,7 +203,7 @@ LL | invalid_instruction2
    | ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:96:13
+  --> $DIR/srcloc.rs:97:13
    |
 LL |             concat!(
    |             ^
@@ -215,7 +215,7 @@ LL | invalid_instruction3
    | ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:96:13
+  --> $DIR/srcloc.rs:97:13
    |
 LL |             concat!(
    |             ^
@@ -227,7 +227,7 @@ LL | invalid_instruction4
    | ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:107:13
+  --> $DIR/srcloc.rs:108:13
    |
 LL |             concat!(
    |             ^
@@ -239,7 +239,7 @@ LL |     invalid_instruction1
    |     ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:107:13
+  --> $DIR/srcloc.rs:108:13
    |
 LL |             concat!(
    |             ^
@@ -251,7 +251,7 @@ LL | invalid_instruction2
    | ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:111:13
+  --> $DIR/srcloc.rs:112:13
    |
 LL |             concat!(
    |             ^
@@ -263,7 +263,7 @@ LL | invalid_instruction3
    | ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:111:13
+  --> $DIR/srcloc.rs:112:13
    |
 LL |             concat!(
    |             ^

--- a/src/test/ui/asm/aarch64/sym.rs
+++ b/src/test/ui/asm/aarch64/sym.rs
@@ -1,5 +1,6 @@
 // only-aarch64
 // only-linux
+// needs-asm-support
 // run-pass
 
 #![feature(thread_local, asm_sym)]

--- a/src/test/ui/asm/inline-syntax.arm.stderr
+++ b/src/test/ui/asm/inline-syntax.arm.stderr
@@ -13,7 +13,7 @@ LL | .intel_syntax noprefix
    | ^
 
 error: unknown directive
-  --> $DIR/inline-syntax.rs:31:15
+  --> $DIR/inline-syntax.rs:32:15
    |
 LL |         asm!(".intel_syntax noprefix", "nop");
    |               ^
@@ -25,7 +25,7 @@ LL |     .intel_syntax noprefix
    |     ^
 
 error: unknown directive
-  --> $DIR/inline-syntax.rs:34:15
+  --> $DIR/inline-syntax.rs:35:15
    |
 LL |         asm!(".intel_syntax aaa noprefix", "nop");
    |               ^
@@ -37,7 +37,7 @@ LL |     .intel_syntax aaa noprefix
    |     ^
 
 error: unknown directive
-  --> $DIR/inline-syntax.rs:37:15
+  --> $DIR/inline-syntax.rs:38:15
    |
 LL |         asm!(".att_syntax noprefix", "nop");
    |               ^
@@ -49,7 +49,7 @@ LL |     .att_syntax noprefix
    |     ^
 
 error: unknown directive
-  --> $DIR/inline-syntax.rs:40:15
+  --> $DIR/inline-syntax.rs:41:15
    |
 LL |         asm!(".att_syntax bbb noprefix", "nop");
    |               ^
@@ -61,7 +61,7 @@ LL |     .att_syntax bbb noprefix
    |     ^
 
 error: unknown directive
-  --> $DIR/inline-syntax.rs:43:15
+  --> $DIR/inline-syntax.rs:44:15
    |
 LL |         asm!(".intel_syntax noprefix; nop");
    |               ^
@@ -73,7 +73,7 @@ LL |     .intel_syntax noprefix; nop
    |     ^
 
 error: unknown directive
-  --> $DIR/inline-syntax.rs:49:13
+  --> $DIR/inline-syntax.rs:50:13
    |
 LL |             .intel_syntax noprefix
    |             ^

--- a/src/test/ui/asm/inline-syntax.rs
+++ b/src/test/ui/asm/inline-syntax.rs
@@ -8,6 +8,7 @@
 //[arm] compile-flags: --target armv7-unknown-linux-gnueabihf
 //[arm] build-fail
 //[arm] needs-llvm-components: arm
+// needs-asm-support
 
 #![feature(no_core, lang_items, rustc_attrs)]
 #![crate_type = "rlib"]

--- a/src/test/ui/asm/inline-syntax.x86_64.stderr
+++ b/src/test/ui/asm/inline-syntax.x86_64.stderr
@@ -1,5 +1,5 @@
 warning: avoid using `.intel_syntax`, Intel syntax is the default
-  --> $DIR/inline-syntax.rs:57:14
+  --> $DIR/inline-syntax.rs:58:14
    |
 LL | global_asm!(".intel_syntax noprefix", "nop");
    |              ^^^^^^^^^^^^^^^^^^^^^^
@@ -7,37 +7,37 @@ LL | global_asm!(".intel_syntax noprefix", "nop");
    = note: `#[warn(bad_asm_style)]` on by default
 
 warning: avoid using `.intel_syntax`, Intel syntax is the default
-  --> $DIR/inline-syntax.rs:31:15
+  --> $DIR/inline-syntax.rs:32:15
    |
 LL |         asm!(".intel_syntax noprefix", "nop");
    |               ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: avoid using `.intel_syntax`, Intel syntax is the default
-  --> $DIR/inline-syntax.rs:34:15
+  --> $DIR/inline-syntax.rs:35:15
    |
 LL |         asm!(".intel_syntax aaa noprefix", "nop");
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: avoid using `.att_syntax`, prefer using `options(att_syntax)` instead
-  --> $DIR/inline-syntax.rs:37:15
+  --> $DIR/inline-syntax.rs:38:15
    |
 LL |         asm!(".att_syntax noprefix", "nop");
    |               ^^^^^^^^^^^^^^^^^^^^
 
 warning: avoid using `.att_syntax`, prefer using `options(att_syntax)` instead
-  --> $DIR/inline-syntax.rs:40:15
+  --> $DIR/inline-syntax.rs:41:15
    |
 LL |         asm!(".att_syntax bbb noprefix", "nop");
    |               ^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: avoid using `.intel_syntax`, Intel syntax is the default
-  --> $DIR/inline-syntax.rs:43:15
+  --> $DIR/inline-syntax.rs:44:15
    |
 LL |         asm!(".intel_syntax noprefix; nop");
    |               ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: avoid using `.intel_syntax`, Intel syntax is the default
-  --> $DIR/inline-syntax.rs:49:13
+  --> $DIR/inline-syntax.rs:50:13
    |
 LL |             .intel_syntax noprefix
    |             ^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/asm/issue-92378.rs
+++ b/src/test/ui/asm/issue-92378.rs
@@ -1,5 +1,6 @@
 // compile-flags: --target armv5te-unknown-linux-gnueabi
 // needs-llvm-components: arm
+// needs-asm-support
 // build-pass
 
 #![feature(no_core, lang_items, rustc_attrs, isa_attribute)]

--- a/src/test/ui/asm/naked-functions-unused.aarch64.stderr
+++ b/src/test/ui/asm/naked-functions-unused.aarch64.stderr
@@ -1,66 +1,66 @@
 error: unused variable: `a`
-  --> $DIR/naked-functions-unused.rs:16:32
+  --> $DIR/naked-functions-unused.rs:17:32
    |
 LL |     pub extern "C" fn function(a: usize, b: usize) -> usize {
    |                                ^ help: if this is intentional, prefix it with an underscore: `_a`
    |
 note: the lint level is defined here
-  --> $DIR/naked-functions-unused.rs:4:9
+  --> $DIR/naked-functions-unused.rs:5:9
    |
 LL | #![deny(unused)]
    |         ^^^^^^
    = note: `#[deny(unused_variables)]` implied by `#[deny(unused)]`
 
 error: unused variable: `b`
-  --> $DIR/naked-functions-unused.rs:16:42
+  --> $DIR/naked-functions-unused.rs:17:42
    |
 LL |     pub extern "C" fn function(a: usize, b: usize) -> usize {
    |                                          ^ help: if this is intentional, prefix it with an underscore: `_b`
 
 error: unused variable: `a`
-  --> $DIR/naked-functions-unused.rs:25:38
+  --> $DIR/naked-functions-unused.rs:26:38
    |
 LL |         pub extern "C" fn associated(a: usize, b: usize) -> usize {
    |                                      ^ help: if this is intentional, prefix it with an underscore: `_a`
 
 error: unused variable: `b`
-  --> $DIR/naked-functions-unused.rs:25:48
+  --> $DIR/naked-functions-unused.rs:26:48
    |
 LL |         pub extern "C" fn associated(a: usize, b: usize) -> usize {
    |                                                ^ help: if this is intentional, prefix it with an underscore: `_b`
 
 error: unused variable: `a`
-  --> $DIR/naked-functions-unused.rs:31:41
+  --> $DIR/naked-functions-unused.rs:32:41
    |
 LL |         pub extern "C" fn method(&self, a: usize, b: usize) -> usize {
    |                                         ^ help: if this is intentional, prefix it with an underscore: `_a`
 
 error: unused variable: `b`
-  --> $DIR/naked-functions-unused.rs:31:51
+  --> $DIR/naked-functions-unused.rs:32:51
    |
 LL |         pub extern "C" fn method(&self, a: usize, b: usize) -> usize {
    |                                                   ^ help: if this is intentional, prefix it with an underscore: `_b`
 
 error: unused variable: `a`
-  --> $DIR/naked-functions-unused.rs:39:40
+  --> $DIR/naked-functions-unused.rs:40:40
    |
 LL |         extern "C" fn trait_associated(a: usize, b: usize) -> usize {
    |                                        ^ help: if this is intentional, prefix it with an underscore: `_a`
 
 error: unused variable: `b`
-  --> $DIR/naked-functions-unused.rs:39:50
+  --> $DIR/naked-functions-unused.rs:40:50
    |
 LL |         extern "C" fn trait_associated(a: usize, b: usize) -> usize {
    |                                                  ^ help: if this is intentional, prefix it with an underscore: `_b`
 
 error: unused variable: `a`
-  --> $DIR/naked-functions-unused.rs:45:43
+  --> $DIR/naked-functions-unused.rs:46:43
    |
 LL |         extern "C" fn trait_method(&self, a: usize, b: usize) -> usize {
    |                                           ^ help: if this is intentional, prefix it with an underscore: `_a`
 
 error: unused variable: `b`
-  --> $DIR/naked-functions-unused.rs:45:53
+  --> $DIR/naked-functions-unused.rs:46:53
    |
 LL |         extern "C" fn trait_method(&self, a: usize, b: usize) -> usize {
    |                                                     ^ help: if this is intentional, prefix it with an underscore: `_b`

--- a/src/test/ui/asm/naked-functions-unused.rs
+++ b/src/test/ui/asm/naked-functions-unused.rs
@@ -1,4 +1,5 @@
 // revisions: x86_64 aarch64
+// needs-asm-support
 //[x86_64] only-x86_64
 //[aarch64] only-aarch64
 #![deny(unused)]

--- a/src/test/ui/asm/naked-functions-unused.x86_64.stderr
+++ b/src/test/ui/asm/naked-functions-unused.x86_64.stderr
@@ -1,66 +1,66 @@
 error: unused variable: `a`
-  --> $DIR/naked-functions-unused.rs:16:32
+  --> $DIR/naked-functions-unused.rs:17:32
    |
 LL |     pub extern "C" fn function(a: usize, b: usize) -> usize {
    |                                ^ help: if this is intentional, prefix it with an underscore: `_a`
    |
 note: the lint level is defined here
-  --> $DIR/naked-functions-unused.rs:4:9
+  --> $DIR/naked-functions-unused.rs:5:9
    |
 LL | #![deny(unused)]
    |         ^^^^^^
    = note: `#[deny(unused_variables)]` implied by `#[deny(unused)]`
 
 error: unused variable: `b`
-  --> $DIR/naked-functions-unused.rs:16:42
+  --> $DIR/naked-functions-unused.rs:17:42
    |
 LL |     pub extern "C" fn function(a: usize, b: usize) -> usize {
    |                                          ^ help: if this is intentional, prefix it with an underscore: `_b`
 
 error: unused variable: `a`
-  --> $DIR/naked-functions-unused.rs:25:38
+  --> $DIR/naked-functions-unused.rs:26:38
    |
 LL |         pub extern "C" fn associated(a: usize, b: usize) -> usize {
    |                                      ^ help: if this is intentional, prefix it with an underscore: `_a`
 
 error: unused variable: `b`
-  --> $DIR/naked-functions-unused.rs:25:48
+  --> $DIR/naked-functions-unused.rs:26:48
    |
 LL |         pub extern "C" fn associated(a: usize, b: usize) -> usize {
    |                                                ^ help: if this is intentional, prefix it with an underscore: `_b`
 
 error: unused variable: `a`
-  --> $DIR/naked-functions-unused.rs:31:41
+  --> $DIR/naked-functions-unused.rs:32:41
    |
 LL |         pub extern "C" fn method(&self, a: usize, b: usize) -> usize {
    |                                         ^ help: if this is intentional, prefix it with an underscore: `_a`
 
 error: unused variable: `b`
-  --> $DIR/naked-functions-unused.rs:31:51
+  --> $DIR/naked-functions-unused.rs:32:51
    |
 LL |         pub extern "C" fn method(&self, a: usize, b: usize) -> usize {
    |                                                   ^ help: if this is intentional, prefix it with an underscore: `_b`
 
 error: unused variable: `a`
-  --> $DIR/naked-functions-unused.rs:39:40
+  --> $DIR/naked-functions-unused.rs:40:40
    |
 LL |         extern "C" fn trait_associated(a: usize, b: usize) -> usize {
    |                                        ^ help: if this is intentional, prefix it with an underscore: `_a`
 
 error: unused variable: `b`
-  --> $DIR/naked-functions-unused.rs:39:50
+  --> $DIR/naked-functions-unused.rs:40:50
    |
 LL |         extern "C" fn trait_associated(a: usize, b: usize) -> usize {
    |                                                  ^ help: if this is intentional, prefix it with an underscore: `_b`
 
 error: unused variable: `a`
-  --> $DIR/naked-functions-unused.rs:45:43
+  --> $DIR/naked-functions-unused.rs:46:43
    |
 LL |         extern "C" fn trait_method(&self, a: usize, b: usize) -> usize {
    |                                           ^ help: if this is intentional, prefix it with an underscore: `_a`
 
 error: unused variable: `b`
-  --> $DIR/naked-functions-unused.rs:45:53
+  --> $DIR/naked-functions-unused.rs:46:53
    |
 LL |         extern "C" fn trait_method(&self, a: usize, b: usize) -> usize {
    |                                                     ^ help: if this is intentional, prefix it with an underscore: `_b`

--- a/src/test/ui/asm/x86_64/const.rs
+++ b/src/test/ui/asm/x86_64/const.rs
@@ -1,5 +1,6 @@
 // only-x86_64
 // run-pass
+// needs-asm-support
 // revisions: mirunsafeck thirunsafeck
 // [thirunsafeck]compile-flags: -Z thir-unsafeck
 

--- a/src/test/ui/asm/x86_64/issue-89875.rs
+++ b/src/test/ui/asm/x86_64/issue-89875.rs
@@ -1,4 +1,5 @@
 // build-pass
+// needs-asm-support
 // only-x86_64
 
 #![feature(target_feature_11)]

--- a/src/test/ui/asm/x86_64/sym.rs
+++ b/src/test/ui/asm/x86_64/sym.rs
@@ -1,6 +1,7 @@
 // min-llvm-version: 12.0.1
 // only-x86_64
 // only-linux
+// needs-asm-support
 // run-pass
 
 #![feature(thread_local, asm_sym)]

--- a/src/test/ui/consts/refs_check_const_eq-issue-88384.stderr
+++ b/src/test/ui/consts/refs_check_const_eq-issue-88384.stderr
@@ -5,7 +5,7 @@ LL | #![feature(adt_const_params)]
    |            ^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
-   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
+   = note: see issue #95174 <https://github.com/rust-lang/rust/issues/95174> for more information
 
 warning: 1 warning emitted
 

--- a/src/test/ui/error-codes/E0771.stderr
+++ b/src/test/ui/error-codes/E0771.stderr
@@ -5,7 +5,7 @@ LL | #![feature(adt_const_params)]
    |            ^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(incomplete_features)]` on by default
-   = note: see issue #44580 <https://github.com/rust-lang/rust/issues/44580> for more information
+   = note: see issue #95174 <https://github.com/rust-lang/rust/issues/95174> for more information
 
 error[E0771]: use of non-static lifetime `'a` in const generic
   --> $DIR/E0771.rs:4:41

--- a/src/test/ui/issues/issue-28561.rs
+++ b/src/test/ui/issues/issue-28561.rs
@@ -1,44 +1,6 @@
 // check-pass
-#[derive(Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, Clone, Copy)]
 struct Array<T> {
-    f00: [T; 00],
-    f01: [T; 01],
-    f02: [T; 02],
-    f03: [T; 03],
-    f04: [T; 04],
-    f05: [T; 05],
-    f06: [T; 06],
-    f07: [T; 07],
-    f08: [T; 08],
-    f09: [T; 09],
-    f10: [T; 10],
-    f11: [T; 11],
-    f12: [T; 12],
-    f13: [T; 13],
-    f14: [T; 14],
-    f15: [T; 15],
-    f16: [T; 16],
-    f17: [T; 17],
-    f18: [T; 18],
-    f19: [T; 19],
-    f20: [T; 20],
-    f21: [T; 21],
-    f22: [T; 22],
-    f23: [T; 23],
-    f24: [T; 24],
-    f25: [T; 25],
-    f26: [T; 26],
-    f27: [T; 27],
-    f28: [T; 28],
-    f29: [T; 29],
-    f30: [T; 30],
-    f31: [T; 31],
-    f32: [T; 32],
-}
-
-// FIXME(#44580): merge with `Array` once `[T; N]: Clone` where `T: Clone`
-#[derive(Clone, Copy)]
-struct CopyArray<T: Copy> {
     f00: [T; 00],
     f01: [T; 01],
     f02: [T; 02],

--- a/src/test/ui/lifetimes/issue-95023.rs
+++ b/src/test/ui/lifetimes/issue-95023.rs
@@ -1,0 +1,11 @@
+struct ErrorKind;
+struct Error(ErrorKind);
+impl Fn(&isize) for Error {
+    //~^ ERROR manual implementations of `Fn` are experimental [E0183]
+    //~^^ ERROR associated type bindings are not allowed here [E0229]
+    fn foo<const N: usize>(&self) -> Self::B<{N}>;
+    //~^ ERROR associated function in `impl` without body
+    //~^^ ERROR method `foo` is not a member of trait `Fn` [E0407]
+    //~^^^ ERROR associated type `B` not found for `Self` [E0220]
+}
+fn main() {}

--- a/src/test/ui/lifetimes/issue-95023.stderr
+++ b/src/test/ui/lifetimes/issue-95023.stderr
@@ -1,0 +1,38 @@
+error: associated function in `impl` without body
+  --> $DIR/issue-95023.rs:6:5
+   |
+LL |     fn foo<const N: usize>(&self) -> Self::B<{N}>;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
+   |                                                  |
+   |                                                  help: provide a definition for the function: `{ <body> }`
+
+error[E0407]: method `foo` is not a member of trait `Fn`
+  --> $DIR/issue-95023.rs:6:5
+   |
+LL |     fn foo<const N: usize>(&self) -> Self::B<{N}>;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not a member of trait `Fn`
+
+error[E0183]: manual implementations of `Fn` are experimental
+  --> $DIR/issue-95023.rs:3:6
+   |
+LL | impl Fn(&isize) for Error {
+   |      ^^^^^^^^^^ manual implementations of `Fn` are experimental
+   |
+   = help: add `#![feature(unboxed_closures)]` to the crate attributes to enable
+
+error[E0229]: associated type bindings are not allowed here
+  --> $DIR/issue-95023.rs:3:6
+   |
+LL | impl Fn(&isize) for Error {
+   |      ^^^^^^^^^^ associated type not allowed here
+
+error[E0220]: associated type `B` not found for `Self`
+  --> $DIR/issue-95023.rs:6:44
+   |
+LL |     fn foo<const N: usize>(&self) -> Self::B<{N}>;
+   |                                            ^ associated type `B` not found
+
+error: aborting due to 5 previous errors
+
+Some errors have detailed explanations: E0183, E0220, E0229, E0407.
+For more information about an error, try `rustc --explain E0183`.

--- a/src/test/ui/numbers-arithmetic/issue-8460.rs
+++ b/src/test/ui/numbers-arithmetic/issue-8460.rs
@@ -1,6 +1,7 @@
 // run-pass
 #![allow(unused_must_use)]
 // ignore-emscripten no threads support
+// needs-unwind
 #![feature(rustc_attrs)]
 
 use std::thread;

--- a/src/test/ui/panic-while-printing.rs
+++ b/src/test/ui/panic-while-printing.rs
@@ -1,4 +1,5 @@
 // run-pass
+// needs-unwind
 // ignore-emscripten no subprocess support
 
 #![feature(internal_output_capture)]

--- a/src/test/ui/process/multi-panic.rs
+++ b/src/test/ui/process/multi-panic.rs
@@ -1,6 +1,7 @@
 // run-pass
 // ignore-emscripten no processes
 // ignore-sgx no processes
+// needs-unwind
 
 fn check_for_no_backtrace(test: std::process::Output) {
     assert!(!test.status.success());

--- a/src/test/ui/test-attrs/test-panic-while-printing.rs
+++ b/src/test/ui/test-attrs/test-panic-while-printing.rs
@@ -1,5 +1,6 @@
 // compile-flags:--test
 // run-pass
+// needs-unwind
 // ignore-emscripten no subprocess support
 
 use std::fmt;

--- a/src/tools/tidy/src/ui_tests.rs
+++ b/src/tools/tidy/src/ui_tests.rs
@@ -7,7 +7,7 @@ use std::path::Path;
 
 const ENTRY_LIMIT: usize = 1000;
 // FIXME: The following limits should be reduced eventually.
-const ROOT_ENTRY_LIMIT: usize = 984;
+const ROOT_ENTRY_LIMIT: usize = 985;
 const ISSUES_ENTRY_LIMIT: usize = 2310;
 
 fn check_entries(path: &Path, bad: &mut bool) {


### PR DESCRIPTION
Successful merges:

 - #95074 (Refactor: use `format-args-capture` and remove unnecessary nested if blocks in some parts of `rust_passes`)
 - #95085 (Return err instead of ICE)
 - #95116 (Add needs-* directives to many tests)
 - #95129 (Remove animation on source sidebar)
 - #95166 (Update the unstable book with the new `values()` form of check-cfg)
 - #95175 (move `adt_const_params`  to its own tracking issue)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=95074,95085,95116,95129,95166,95175)
<!-- homu-ignore:end -->