### PR TITLE
Stop flagging unexpected inner attributes as outer ones in certain diagnostics

### DIFF
--- a/compiler/rustc_builtin_macros/src/source_util.rs
+++ b/compiler/rustc_builtin_macros/src/source_util.rs
@@ -141,7 +141,7 @@ pub fn expand_include<'cx>(
 
         fn make_items(mut self: Box<ExpandResult<'a>>) -> Option<SmallVec<[P<ast::Item>; 1]>> {
             let mut ret = SmallVec::new();
-            while self.p.token != token::Eof {
+            loop {
                 match self.p.parse_item(ForceCollect::No) {
                     Err(mut err) => {
                         err.emit();
@@ -149,9 +149,12 @@ pub fn expand_include<'cx>(
                     }
                     Ok(Some(item)) => ret.push(item),
                     Ok(None) => {
-                        let token = pprust::token_to_string(&self.p.token);
-                        let msg = format!("expected item, found `{}`", token);
-                        self.p.struct_span_err(self.p.token.span, &msg).emit();
+                        if self.p.token != token::Eof {
+                            let token = pprust::token_to_string(&self.p.token);
+                            let msg = format!("expected item, found `{}`", token);
+                            self.p.struct_span_err(self.p.token.span, &msg).emit();
+                        }
+
                         break;
                     }
                 }

--- a/src/test/ui/parser/attr.rs
+++ b/src/test/ui/parser/attr.rs
@@ -3,5 +3,4 @@
 fn main() {}
 
 #![lang = "foo"] //~ ERROR an inner attribute is not permitted in this context
-                 //~| ERROR definition of an unknown language item: `foo`
 fn foo() {}

--- a/src/test/ui/parser/attr.stderr
+++ b/src/test/ui/parser/attr.stderr
@@ -3,7 +3,6 @@ error: an inner attribute is not permitted in this context
    |
 LL | #![lang = "foo"]
    | ^^^^^^^^^^^^^^^^
-LL |
 LL | fn foo() {}
    | ----------- the inner attribute doesn't annotate this function
    |
@@ -14,12 +13,5 @@ LL - #![lang = "foo"]
 LL + #[lang = "foo"]
    | 
 
-error[E0522]: definition of an unknown language item: `foo`
-  --> $DIR/attr.rs:5:1
-   |
-LL | #![lang = "foo"]
-   | ^^^^^^^^^^^^^^^^ definition of unknown language item `foo`
+error: aborting due to previous error
 
-error: aborting due to 2 previous errors
-
-For more information about this error, try `rustc --explain E0522`.

--- a/src/test/ui/parser/issues/auxiliary/issue-94340-inc.rs
+++ b/src/test/ui/parser/issues/auxiliary/issue-94340-inc.rs
@@ -1,0 +1,3 @@
+// include file for issue-94340.rs
+#![deny(rust_2018_idioms)]
+#![deny(unused_must_use)]

--- a/src/test/ui/parser/issues/issue-94340.rs
+++ b/src/test/ui/parser/issues/issue-94340.rs
@@ -1,0 +1,8 @@
+// Make sure that unexpected inner attributes are not labeled as outer ones in diagnostics when
+// trying to parse an item and that they are subsequently ignored not triggering confusing extra
+// diagnostics like "expected item after attributes" which is not true for `include!` which can
+// include empty files.
+
+include!("auxiliary/issue-94340-inc.rs");
+
+fn main() {}

--- a/src/test/ui/parser/issues/issue-94340.stderr
+++ b/src/test/ui/parser/issues/issue-94340.stderr
@@ -1,0 +1,20 @@
+error: an inner attribute is not permitted in this context
+  --> $DIR/auxiliary/issue-94340-inc.rs:2:1
+   |
+LL | #![deny(rust_2018_idioms)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files
+   = note: outer attributes, like `#[test]`, annotate the item following them
+
+error: an inner attribute is not permitted in this context
+  --> $DIR/auxiliary/issue-94340-inc.rs:3:1
+   |
+LL | #![deny(unused_must_use)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files
+   = note: outer attributes, like `#[test]`, annotate the item following them
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Fixes #94340.

In the issue to-be-fixed I write that the general message _an inner attribute is not permitted in this context_ should be more specific noting that the “context” is the `include` macro. This, however, cannot be achieved without touching a lot of things and passing a flag to the `parse_expr` and `parse_item` calls in `expand_include`. This seems rather hacky to me. That's why I left it as it. `Span::from_expansion` does not apply either AFAIK.

@rustbot label A-diagnostics T-compiler