### PR TITLE
Suggest constraining param for unary ops when missing trait impl

### DIFF
--- a/src/test/ui/type/type-check/missing_trait_impl.rs
+++ b/src/test/ui/type/type-check/missing_trait_impl.rs
@@ -8,3 +8,9 @@ fn foo<T>(x: T, y: T) {
 fn bar<T>(x: T) {
     x += x; //~ ERROR binary assignment operation `+=` cannot be applied to type `T`
 }
+
+fn baz<T>(x: T) {
+    let y = -x; //~ ERROR cannot apply unary operator `-` to type `T`
+    let y = !x; //~ ERROR cannot apply unary operator `!` to type `T`
+    let y = *x; //~ ERROR type `T` cannot be dereferenced
+}

--- a/src/test/ui/type/type-check/missing_trait_impl.stderr
+++ b/src/test/ui/type/type-check/missing_trait_impl.stderr
@@ -24,7 +24,35 @@ help: consider restricting type parameter `T`
 LL | fn bar<T: std::ops::AddAssign>(x: T) {
    |         +++++++++++++++++++++
 
-error: aborting due to 2 previous errors
+error[E0600]: cannot apply unary operator `-` to type `T`
+  --> $DIR/missing_trait_impl.rs:13:13
+   |
+LL |     let y = -x;
+   |             ^^ cannot apply unary operator `-`
+   |
+help: consider restricting type parameter `T`
+   |
+LL | fn baz<T: std::ops::Neg<Output = T>>(x: T) {
+   |         +++++++++++++++++++++++++++
 
-Some errors have detailed explanations: E0368, E0369.
+error[E0600]: cannot apply unary operator `!` to type `T`
+  --> $DIR/missing_trait_impl.rs:14:13
+   |
+LL |     let y = !x;
+   |             ^^ cannot apply unary operator `!`
+   |
+help: consider restricting type parameter `T`
+   |
+LL | fn baz<T: std::ops::Not<Output = T>>(x: T) {
+   |         +++++++++++++++++++++++++++
+
+error[E0614]: type `T` cannot be dereferenced
+  --> $DIR/missing_trait_impl.rs:15:13
+   |
+LL |     let y = *x;
+   |             ^^
+
+error: aborting due to 5 previous errors
+
+Some errors have detailed explanations: E0368, E0369, E0600, E0614.
 For more information about an error, try `rustc --explain E0368`.


### PR DESCRIPTION
This PR adds a suggestion of constraining param for unary ops `-` and `!` when the corresponding trait implementation 
is missing.

Fixs #94543.

BTW, this is my first time to touch rustc, please correct me if I did anything wrong.