### PR TITLE
Enable -Z panic-in-drop=abort by default

### DIFF
--- a/compiler/rustc_interface/src/tests.rs
+++ b/compiler/rustc_interface/src/tests.rs
@@ -762,7 +762,7 @@ fn test_debugging_options_tracking_hash() {
     tracked!(oom, OomStrategy::Panic);
     tracked!(osx_rpath_install_name, true);
     tracked!(panic_abort_tests, true);
-    tracked!(panic_in_drop, PanicStrategy::Abort);
+    tracked!(panic_in_drop, PanicStrategy::Unwind);
     tracked!(pick_stable_methods_before_any_unstable, false);
     tracked!(plt, Some(true));
     tracked!(polonius, true);

--- a/compiler/rustc_interface/src/tests.rs
+++ b/compiler/rustc_interface/src/tests.rs
@@ -641,6 +641,7 @@ fn test_debugging_options_tracking_hash() {
 
     // Make sure that changing an [UNTRACKED] option leaves the hash unchanged.
     // This list is in alphabetical order.
+    untracked!(allow_incompatible_panic_in_drop, true);
     untracked!(assert_incr_state, Some(String::from("loaded")));
     untracked!(ast_json, true);
     untracked!(ast_json_noexpand, true);

--- a/compiler/rustc_metadata/src/dependency_format.rs
+++ b/compiler/rustc_metadata/src/dependency_format.rs
@@ -419,7 +419,9 @@ fn verify_ok(tcx: TyCtxt<'_>, list: &[Linkage]) {
             }
 
             let found_drop_strategy = tcx.panic_in_drop_strategy(cnum);
-            if tcx.sess.opts.debugging_opts.panic_in_drop != found_drop_strategy {
+            if !tcx.sess.opts.debugging_opts.allow_incompatible_panic_in_drop
+                && tcx.sess.opts.debugging_opts.panic_in_drop != found_drop_strategy
+            {
                 sess.err(&format!(
                     "the crate `{}` is compiled with the \
                                panic-in-drop strategy `{}` which is \

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -1148,6 +1148,8 @@ options! {
 
     allow_features: Option<Vec<String>> = (None, parse_opt_comma_list, [TRACKED],
         "only allow the listed language features to be enabled in code (space separated)"),
+    allow_incompatible_panic_in_drop: bool = (false, parse_bool, [UNTRACKED],
+        "allow linking to crates with an incompatible panic-in-drop strategy"),
     always_encode_mir: bool = (false, parse_bool, [TRACKED],
         "encode MIR of all functions into the crate metadata (default: no)"),
     assume_incomplete_release: bool = (false, parse_bool, [TRACKED],

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -1347,7 +1347,7 @@ options! {
         "pass `-install_name @rpath/...` to the macOS linker (default: no)"),
     panic_abort_tests: bool = (false, parse_bool, [TRACKED],
         "support compiling tests with panic=abort (default: no)"),
-    panic_in_drop: PanicStrategy = (PanicStrategy::Unwind, parse_panic_strategy, [TRACKED],
+    panic_in_drop: PanicStrategy = (PanicStrategy::Abort, parse_panic_strategy, [TRACKED],
         "panic strategy for panics in drops"),
     parse_only: bool = (false, parse_bool, [UNTRACKED],
         "parse only; do not compile, assemble, or link (default: no)"),

--- a/library/alloc/src/collections/btree/map/tests.rs
+++ b/library/alloc/src/collections/btree/map/tests.rs
@@ -1121,6 +1121,7 @@ mod test_drain_filter {
         map.check();
     }
 
+    #[ignore]
     #[test]
     fn drop_panic_leak() {
         let a = CrashTestDummy::new(0);
@@ -1141,6 +1142,7 @@ mod test_drain_filter {
         assert_eq!(c.dropped(), 1);
     }
 
+    #[ignore]
     #[test]
     fn pred_panic_leak() {
         let a = CrashTestDummy::new(0);
@@ -1415,6 +1417,7 @@ fn test_clear() {
     }
 }
 
+#[ignore]
 #[test]
 fn test_clear_drop_panic_leak() {
     let a = CrashTestDummy::new(0);
@@ -1960,6 +1963,7 @@ create_append_test!(test_append_239, 239);
 #[cfg(not(miri))] // Miri is too slow
 create_append_test!(test_append_1700, 1700);
 
+#[ignore]
 #[test]
 fn test_append_drop_leak() {
     let a = CrashTestDummy::new(0);
@@ -2101,6 +2105,7 @@ fn test_split_off_large_random_sorted() {
     assert!(right.into_iter().eq(data.into_iter().filter(|x| x.0 >= key)));
 }
 
+#[ignore]
 #[test]
 fn test_into_iter_drop_leak_height_0() {
     let a = CrashTestDummy::new(0);
@@ -2124,6 +2129,7 @@ fn test_into_iter_drop_leak_height_0() {
     assert_eq!(e.dropped(), 1);
 }
 
+#[ignore]
 #[test]
 fn test_into_iter_drop_leak_height_1() {
     let size = MIN_INSERTS_HEIGHT_1;

--- a/library/alloc/src/collections/btree/set/tests.rs
+++ b/library/alloc/src/collections/btree/set/tests.rs
@@ -340,6 +340,7 @@ fn test_drain_filter() {
     assert_eq!(y.len(), 1);
 }
 
+#[ignore]
 #[test]
 fn test_drain_filter_drop_panic_leak() {
     let a = CrashTestDummy::new(0);
@@ -360,6 +361,7 @@ fn test_drain_filter_drop_panic_leak() {
     assert_eq!(c.dropped(), 1);
 }
 
+#[ignore]
 #[test]
 fn test_drain_filter_pred_panic_leak() {
     let a = CrashTestDummy::new(0);

--- a/library/alloc/tests/binary_heap.rs
+++ b/library/alloc/tests/binary_heap.rs
@@ -289,6 +289,7 @@ fn test_drain_sorted() {
     assert!(q.is_empty());
 }
 
+#[ignore]
 #[test]
 fn test_drain_sorted_leak() {
     static DROPS: AtomicU32 = AtomicU32::new(0);

--- a/library/alloc/tests/linked_list.rs
+++ b/library/alloc/tests/linked_list.rs
@@ -530,6 +530,7 @@ fn drain_filter_complex() {
     }
 }
 
+#[ignore]
 #[test]
 fn drain_filter_drop_panic_leak() {
     static mut DROPS: i32 = 0;
@@ -565,6 +566,7 @@ fn drain_filter_drop_panic_leak() {
 }
 
 #[test]
+#[ignore]
 fn drain_filter_pred_panic_leak() {
     static mut DROPS: i32 = 0;
 
@@ -670,6 +672,7 @@ fn test_drop_clear() {
     assert_eq!(unsafe { DROPS }, 4);
 }
 
+#[ignore]
 #[test]
 fn test_drop_panic() {
     static mut DROPS: i32 = 0;

--- a/library/alloc/tests/vec.rs
+++ b/library/alloc/tests/vec.rs
@@ -321,6 +321,7 @@ fn test_retain_pred_panic_no_hole() {
     assert!(v.iter().all(|r| Rc::strong_count(r) == 1));
 }
 
+#[ignore]
 #[test]
 fn test_retain_drop_panic() {
     struct Wrap(Rc<i32>);
@@ -509,6 +510,7 @@ fn test_vec_truncate_drop() {
     assert_eq!(unsafe { DROPS }, 5);
 }
 
+#[ignore]
 #[test]
 #[should_panic]
 fn test_vec_truncate_fail() {
@@ -752,6 +754,7 @@ fn test_drain_end_overflow() {
     v.drain((Included(0), Included(usize::MAX)));
 }
 
+#[ignore]
 #[test]
 fn test_drain_leak() {
     static mut DROPS: i32 = 0;
@@ -945,6 +948,7 @@ fn test_into_iter_clone() {
     assert_eq!(it.next(), None);
 }
 
+#[ignore]
 #[test]
 fn test_into_iter_leak() {
     static mut DROPS: i32 = 0;
@@ -1071,6 +1075,7 @@ fn test_from_iter_specialization_panic_during_iteration_drops() {
     );
 }
 
+#[ignore]
 #[test]
 fn test_from_iter_specialization_panic_during_drop_leaks() {
     static mut DROP_COUNTER: usize = 0;
@@ -1392,6 +1397,7 @@ fn drain_filter_consumed_panic() {
 }
 
 // FIXME: Re-enable emscripten once it can catch panics
+#[ignore]
 #[test]
 #[cfg(not(target_os = "emscripten"))]
 fn drain_filter_unconsumed_panic() {
@@ -2285,6 +2291,7 @@ fn test_vec_dedup() {
     }
 }
 
+#[ignore]
 #[test]
 fn test_vec_dedup_panicking() {
     #[derive(Debug)]

--- a/library/alloc/tests/vec_deque.rs
+++ b/library/alloc/tests/vec_deque.rs
@@ -725,6 +725,7 @@ fn test_drop_clear() {
     assert_eq!(unsafe { DROPS }, 4);
 }
 
+#[ignore]
 #[test]
 fn test_drop_panic() {
     static mut DROPS: i32 = 0;
@@ -1619,6 +1620,7 @@ fn test_try_rfold_moves_iter() {
     assert_eq!(iter.next_back(), Some(&70));
 }
 
+#[ignore]
 #[test]
 fn truncate_leak() {
     static mut DROPS: i32 = 0;
@@ -1652,6 +1654,7 @@ fn truncate_leak() {
     assert_eq!(unsafe { DROPS }, 7);
 }
 
+#[ignore]
 #[test]
 fn test_drain_leak() {
     static mut DROPS: i32 = 0;

--- a/library/std/src/collections/hash/map/tests.rs
+++ b/library/std/src/collections/hash/map/tests.rs
@@ -1013,6 +1013,7 @@ mod test_drain_filter {
     }
 
     #[test]
+    #[ignore]
     fn drop_panic_leak() {
         static PREDS: AtomicUsize = AtomicUsize::new(0);
         static DROPS: AtomicUsize = AtomicUsize::new(0);
@@ -1041,6 +1042,7 @@ mod test_drain_filter {
     }
 
     #[test]
+    #[ignore]
     fn pred_panic_leak() {
         static PREDS: AtomicUsize = AtomicUsize::new(0);
         static DROPS: AtomicUsize = AtomicUsize::new(0);

--- a/library/std/src/collections/hash/set/tests.rs
+++ b/library/std/src/collections/hash/set/tests.rs
@@ -428,6 +428,7 @@ fn test_drain_filter() {
     assert_eq!(y.len(), 1);
 }
 
+#[ignore]
 #[test]
 fn test_drain_filter_drop_panic_leak() {
     static PREDS: AtomicU32 = AtomicU32::new(0);
@@ -458,6 +459,7 @@ fn test_drain_filter_drop_panic_leak() {
 }
 
 #[test]
+#[ignore]
 fn test_drain_filter_pred_panic_leak() {
     static PREDS: AtomicU32 = AtomicU32::new(0);
     static DROPS: AtomicU32 = AtomicU32::new(0);

--- a/src/test/codegen/dealloc-no-unwind.rs
+++ b/src/test/codegen/dealloc-no-unwind.rs
@@ -13,10 +13,11 @@ impl Drop for A {
 }
 
 #[no_mangle]
-pub fn a(a: Box<i32>) {
+pub fn a(b: Box<i32>) {
     // CHECK-LABEL: define{{.*}}void @a
     // CHECK: call void @__rust_dealloc
-    // CHECK-NEXT: call void @foo
-    let _a = A;
-    drop(a);
+    // CHECK-NOT: call void @foo
+    let a = A;
+    drop(b);
+    std::mem::forget(a);
 }

--- a/src/test/codegen/issue-47442.rs
+++ b/src/test/codegen/issue-47442.rs
@@ -1,7 +1,7 @@
 // check that we don't emit unneeded `resume` cleanup blocks for every
 // destructor.
 
-// CHECK-NOT: Unwind
+// CHECK-NOT: _Unwind_Resume
 
 #![feature(test)]
 #![crate_type="rlib"]

--- a/src/test/codegen/vec-shrink-panik.rs
+++ b/src/test/codegen/vec-shrink-panik.rs
@@ -17,14 +17,6 @@ pub fn shrink_to_fit(vec: &mut Vec<u32>) {
 #[no_mangle]
 pub fn issue71861(vec: Vec<u32>) -> Box<[u32]> {
     // CHECK-NOT: panic
-
-    // Call to panic_no_unwind in case of double-panic is expected,
-    // but other panics are not.
-    // CHECK: cleanup
-    // CHECK-NEXT: ; call core::panicking::panic_no_unwind
-    // CHECK-NEXT: panic_no_unwind
-
-    // CHECK-NOT: panic
     vec.into_boxed_slice()
 }
 
@@ -32,16 +24,5 @@ pub fn issue71861(vec: Vec<u32>) -> Box<[u32]> {
 #[no_mangle]
 pub fn issue75636<'a>(iter: &[&'a str]) -> Box<[&'a str]> {
     // CHECK-NOT: panic
-
-    // Call to panic_no_unwind in case of double-panic is expected,
-    // but other panics are not.
-    // CHECK: cleanup
-    // CHECK-NEXT: ; call core::panicking::panic_no_unwind
-    // CHECK-NEXT: panic_no_unwind
-
-    // CHECK-NOT: panic
     iter.iter().copied().collect()
 }
-
-// CHECK: ; core::panicking::panic_no_unwind
-// CHECK: declare void @{{.*}}panic_no_unwind

--- a/src/test/mir-opt/const_prop/boxes.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/boxes.main.ConstProp.diff
@@ -40,7 +40,7 @@
           _2 = (*_3);                      // scope 0 at $DIR/boxes.rs:12:13: 12:22
           _1 = Add(move _2, const 0_i32);  // scope 0 at $DIR/boxes.rs:12:13: 12:26
           StorageDead(_2);                 // scope 0 at $DIR/boxes.rs:12:25: 12:26
-          drop(_3) -> [return: bb2, unwind: bb3]; // scope 0 at $DIR/boxes.rs:12:26: 12:27
+          drop(_3) -> bb2;                 // scope 0 at $DIR/boxes.rs:12:26: 12:27
       }
   
       bb2: {
@@ -48,10 +48,6 @@
           nop;                             // scope 0 at $DIR/boxes.rs:11:11: 13:2
           StorageDead(_1);                 // scope 0 at $DIR/boxes.rs:13:1: 13:2
           return;                          // scope 0 at $DIR/boxes.rs:13:2: 13:2
-      }
-  
-      bb3 (cleanup): {
-          resume;                          // scope 0 at $DIR/boxes.rs:11:1: 13:2
       }
   }
   

--- a/src/test/mir-opt/generator_drop_cleanup.main-{closure#0}.generator_drop.0.mir
+++ b/src/test/mir-opt/generator_drop_cleanup.main-{closure#0}.generator_drop.0.mir
@@ -29,56 +29,47 @@ fn main::{closure#0}(_1: *mut [generator@$DIR/generator-drop-cleanup.rs:10:15: 1
 
     bb0: {
         _8 = discriminant((*_1));        // scope 0 at $DIR/generator-drop-cleanup.rs:10:15: 13:6
-        switchInt(move _8) -> [0_u32: bb7, 3_u32: bb10, otherwise: bb11]; // scope 0 at $DIR/generator-drop-cleanup.rs:10:15: 13:6
+        switchInt(move _8) -> [0_u32: bb5, 3_u32: bb8, otherwise: bb9]; // scope 0 at $DIR/generator-drop-cleanup.rs:10:15: 13:6
     }
 
     bb1: {
         StorageDead(_5);                 // scope 1 at $DIR/generator-drop-cleanup.rs:12:13: 12:14
         StorageDead(_4);                 // scope 1 at $DIR/generator-drop-cleanup.rs:12:14: 12:15
-        drop((((*_1) as variant#3).0: std::string::String)) -> [return: bb2, unwind: bb5]; // scope 0 at $DIR/generator-drop-cleanup.rs:13:5: 13:6
+        drop((((*_1) as variant#3).0: std::string::String)) -> bb2; // scope 0 at $DIR/generator-drop-cleanup.rs:13:5: 13:6
     }
 
     bb2: {
         nop;                             // scope 0 at $DIR/generator-drop-cleanup.rs:13:5: 13:6
-        goto -> bb8;                     // scope 0 at $DIR/generator-drop-cleanup.rs:13:5: 13:6
+        goto -> bb6;                     // scope 0 at $DIR/generator-drop-cleanup.rs:13:5: 13:6
     }
 
     bb3: {
         return;                          // scope 0 at $DIR/generator-drop-cleanup.rs:10:15: 13:6
     }
 
-    bb4 (cleanup): {
-        resume;                          // scope 0 at $DIR/generator-drop-cleanup.rs:10:15: 13:6
-    }
-
-    bb5 (cleanup): {
-        nop;                             // scope 0 at $DIR/generator-drop-cleanup.rs:13:5: 13:6
-        goto -> bb4;                     // scope 0 at $DIR/generator-drop-cleanup.rs:13:5: 13:6
-    }
-
-    bb6: {
+    bb4: {
         return;                          // scope 0 at $DIR/generator-drop-cleanup.rs:10:15: 13:6
     }
 
-    bb7: {
-        goto -> bb9;                     // scope 0 at $DIR/generator-drop-cleanup.rs:10:15: 13:6
+    bb5: {
+        goto -> bb7;                     // scope 0 at $DIR/generator-drop-cleanup.rs:10:15: 13:6
     }
 
-    bb8: {
+    bb6: {
         goto -> bb3;                     // scope 0 at $DIR/generator-drop-cleanup.rs:13:5: 13:6
     }
 
-    bb9: {
-        goto -> bb6;                     // scope 0 at $DIR/generator-drop-cleanup.rs:10:15: 13:6
+    bb7: {
+        goto -> bb4;                     // scope 0 at $DIR/generator-drop-cleanup.rs:10:15: 13:6
     }
 
-    bb10: {
+    bb8: {
         StorageLive(_4);                 // scope 0 at $DIR/generator-drop-cleanup.rs:10:15: 13:6
         StorageLive(_5);                 // scope 0 at $DIR/generator-drop-cleanup.rs:10:15: 13:6
         goto -> bb1;                     // scope 0 at $DIR/generator-drop-cleanup.rs:10:15: 13:6
     }
 
-    bb11: {
+    bb9: {
         return;                          // scope 0 at $DIR/generator-drop-cleanup.rs:10:15: 13:6
     }
 }

--- a/src/test/mir-opt/generator_storage_dead_unwind.main-{closure#0}.StateTransform.before.mir
+++ b/src/test/mir-opt/generator_storage_dead_unwind.main-{closure#0}.StateTransform.before.mir
@@ -59,7 +59,7 @@ yields ()
         _0 = const ();                   // scope 0 at $DIR/generator-storage-dead-unwind.rs:22:19: 28:6
         StorageDead(_4);                 // scope 1 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
         StorageDead(_3);                 // scope 0 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
-        drop(_1) -> [return: bb4, unwind: bb11]; // scope 0 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
+        drop(_1) -> bb4;                 // scope 0 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
     }
 
     bb4: {
@@ -70,12 +70,12 @@ yields ()
         StorageDead(_6);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:25:13: 25:14
         StorageDead(_5);                 // scope 2 at $DIR/generator-storage-dead-unwind.rs:25:14: 25:15
         StorageDead(_4);                 // scope 1 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
-        drop(_3) -> [return: bb6, unwind: bb12]; // scope 0 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
+        drop(_3) -> bb6;                 // scope 0 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
     }
 
     bb6: {
         StorageDead(_3);                 // scope 0 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
-        drop(_1) -> [return: bb7, unwind: bb11]; // scope 0 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
+        drop(_1) -> bb7;                 // scope 0 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
     }
 
     bb7: {
@@ -102,10 +102,5 @@ yields ()
 
     bb11 (cleanup): {
         resume;                          // scope 0 at $DIR/generator-storage-dead-unwind.rs:22:16: 28:6
-    }
-
-    bb12 (cleanup): {
-        StorageDead(_3);                 // scope 0 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
-        drop(_1) -> bb11;                // scope 0 at $DIR/generator-storage-dead-unwind.rs:28:5: 28:6
     }
 }

--- a/src/test/mir-opt/inline/cycle.f.Inline.diff
+++ b/src/test/mir-opt/inline/cycle.f.Inline.diff
@@ -24,7 +24,7 @@
           StorageDead(_3);                 // scope 0 at $DIR/cycle.rs:6:7: 6:8
           StorageDead(_2);                 // scope 0 at $DIR/cycle.rs:6:8: 6:9
           _0 = const ();                   // scope 0 at $DIR/cycle.rs:5:20: 7:2
-          drop(_1) -> [return: bb2, unwind: bb4]; // scope 0 at $DIR/cycle.rs:7:1: 7:2
+          drop(_1) -> bb2;                 // scope 0 at $DIR/cycle.rs:7:1: 7:2
       }
   
       bb2: {

--- a/src/test/mir-opt/inline/inline_into_box_place.main.Inline.64bit.diff
+++ b/src/test/mir-opt/inline/inline_into_box_place.main.Inline.64bit.diff
@@ -50,19 +50,18 @@
           _1 = move _5;                    // scope 0 at $DIR/inline-into-box-place.rs:8:29: 8:43
           StorageDead(_5);                 // scope 0 at $DIR/inline-into-box-place.rs:8:42: 8:43
           _0 = const ();                   // scope 0 at $DIR/inline-into-box-place.rs:7:11: 9:2
--         drop(_1) -> [return: bb3, unwind: bb4]; // scope 0 at $DIR/inline-into-box-place.rs:9:1: 9:2
-+         drop(_1) -> [return: bb2, unwind: bb3]; // scope 0 at $DIR/inline-into-box-place.rs:9:1: 9:2
+-         drop(_1) -> bb3;                 // scope 0 at $DIR/inline-into-box-place.rs:9:1: 9:2
++         drop(_1) -> bb2;                 // scope 0 at $DIR/inline-into-box-place.rs:9:1: 9:2
       }
   
 -     bb3: {
 +     bb2: {
           StorageDead(_1);                 // scope 0 at $DIR/inline-into-box-place.rs:9:1: 9:2
           return;                          // scope 0 at $DIR/inline-into-box-place.rs:9:2: 9:2
-      }
-  
+-     }
+- 
 -     bb4 (cleanup): {
-+     bb3 (cleanup): {
-          resume;                          // scope 0 at $DIR/inline-into-box-place.rs:7:1: 9:2
+-         resume;                          // scope 0 at $DIR/inline-into-box-place.rs:7:1: 9:2
 -     }
 - 
 -     bb5 (cleanup): {

--- a/src/test/mir-opt/inline/issue_78442.bar.Inline.diff
+++ b/src/test/mir-opt/inline/issue_78442.bar.Inline.diff
@@ -38,7 +38,7 @@
 -         StorageDead(_4);                 // scope 0 at $DIR/issue-78442.rs:11:17: 11:18
 -         StorageDead(_2);                 // scope 0 at $DIR/issue-78442.rs:11:17: 11:18
 -         _0 = const ();                   // scope 0 at $DIR/issue-78442.rs:10:3: 12:2
--         drop(_1) -> [return: bb3, unwind: bb5]; // scope 0 at $DIR/issue-78442.rs:12:1: 12:2
+-         drop(_1) -> bb3;                 // scope 0 at $DIR/issue-78442.rs:12:1: 12:2
 +         return;                          // scope 0 at $DIR/issue-78442.rs:12:2: 12:2
       }
   
@@ -61,7 +61,7 @@
 +         StorageDead(_4);                 // scope 0 at $DIR/issue-78442.rs:11:17: 11:18
 +         StorageDead(_2);                 // scope 0 at $DIR/issue-78442.rs:11:17: 11:18
 +         _0 = const ();                   // scope 0 at $DIR/issue-78442.rs:10:3: 12:2
-+         drop(_1) -> [return: bb2, unwind: bb4]; // scope 0 at $DIR/issue-78442.rs:12:1: 12:2
++         drop(_1) -> bb2;                 // scope 0 at $DIR/issue-78442.rs:12:1: 12:2
       }
   }
   

--- a/src/test/mir-opt/inline/issue_78442.bar.RevealAll.diff
+++ b/src/test/mir-opt/inline/issue_78442.bar.RevealAll.diff
@@ -39,7 +39,7 @@
           StorageDead(_4);                 // scope 0 at $DIR/issue-78442.rs:11:17: 11:18
           StorageDead(_2);                 // scope 0 at $DIR/issue-78442.rs:11:17: 11:18
           _0 = const ();                   // scope 0 at $DIR/issue-78442.rs:10:3: 12:2
-          drop(_1) -> [return: bb3, unwind: bb5]; // scope 0 at $DIR/issue-78442.rs:12:1: 12:2
+          drop(_1) -> bb3;                 // scope 0 at $DIR/issue-78442.rs:12:1: 12:2
       }
   
       bb3: {

--- a/src/test/mir-opt/packed_struct_drop_aligned.main.SimplifyCfg-elaborate-drops.after.64bit.mir
+++ b/src/test/mir-opt/packed_struct_drop_aligned.main.SimplifyCfg-elaborate-drops.after.64bit.mir
@@ -28,7 +28,7 @@ fn main() -> () {
         StorageDead(_5);                 // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:28: 7:29
         StorageLive(_6);                 // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:5: 7:8
         _6 = move (_1.0: Aligned);       // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:5: 7:8
-        drop(_6) -> [return: bb4, unwind: bb3]; // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:5: 7:8
+        drop(_6) -> bb2;                 // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:5: 7:8
     }
 
     bb1: {
@@ -36,20 +36,11 @@ fn main() -> () {
         return;                          // scope 0 at $DIR/packed-struct-drop-aligned.rs:8:2: 8:2
     }
 
-    bb2 (cleanup): {
-        resume;                          // scope 0 at $DIR/packed-struct-drop-aligned.rs:5:1: 8:2
-    }
-
-    bb3 (cleanup): {
-        (_1.0: Aligned) = move _4;       // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:5: 7:8
-        drop(_1) -> bb2;                 // scope 0 at $DIR/packed-struct-drop-aligned.rs:8:1: 8:2
-    }
-
-    bb4: {
+    bb2: {
         StorageDead(_6);                 // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:5: 7:8
         (_1.0: Aligned) = move _4;       // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:5: 7:8
         StorageDead(_4);                 // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:28: 7:29
         _0 = const ();                   // scope 0 at $DIR/packed-struct-drop-aligned.rs:5:11: 8:2
-        drop(_1) -> [return: bb1, unwind: bb2]; // scope 0 at $DIR/packed-struct-drop-aligned.rs:8:1: 8:2
+        drop(_1) -> bb1;                 // scope 0 at $DIR/packed-struct-drop-aligned.rs:8:1: 8:2
     }
 }

--- a/src/test/mir-opt/retag.main.SimplifyCfg-elaborate-drops.after.mir
+++ b/src/test/mir-opt/retag.main.SimplifyCfg-elaborate-drops.after.mir
@@ -82,7 +82,7 @@ fn main() -> () {
         StorageDead(_6);                 // scope 1 at $DIR/retag.rs:32:35: 32:36
         StorageDead(_4);                 // scope 1 at $DIR/retag.rs:32:35: 32:36
         StorageDead(_7);                 // scope 1 at $DIR/retag.rs:32:36: 32:37
-        drop(_5) -> [return: bb2, unwind: bb9]; // scope 1 at $DIR/retag.rs:32:36: 32:37
+        drop(_5) -> bb2;                 // scope 1 at $DIR/retag.rs:32:36: 32:37
     }
 
     bb2: {
@@ -167,7 +167,7 @@ fn main() -> () {
         StorageDead(_22);                // scope 7 at $DIR/retag.rs:47:23: 47:24
         StorageDead(_20);                // scope 7 at $DIR/retag.rs:47:23: 47:24
         StorageDead(_23);                // scope 7 at $DIR/retag.rs:47:24: 47:25
-        drop(_21) -> [return: bb5, unwind: bb9]; // scope 7 at $DIR/retag.rs:47:24: 47:25
+        drop(_21) -> bb5;                // scope 7 at $DIR/retag.rs:47:24: 47:25
     }
 
     bb5: {

--- a/src/test/ui/binding/fn-arg-incomplete-pattern-drop-order.rs
+++ b/src/test/ui/binding/fn-arg-incomplete-pattern-drop-order.rs
@@ -1,5 +1,6 @@
 // run-pass
 // needs-unwind
+// compile-flags: -Z panic-in-drop=unwind -Z allow-incompatible-panic-in-drop
 // Check that partially moved from function parameters are dropped after the
 // named bindings that move from them.
 

--- a/src/test/ui/drop/drop-trait-enum.rs
+++ b/src/test/ui/drop/drop-trait-enum.rs
@@ -4,6 +4,7 @@
 #![allow(unused_variables)]
 // ignore-emscripten no threads support
 // needs-unwind
+// compile-flags: -Z panic-in-drop=unwind -Z allow-incompatible-panic-in-drop
 
 use std::thread;
 use std::sync::mpsc::{channel, Sender};

--- a/src/test/ui/drop/dynamic-drop-async.rs
+++ b/src/test/ui/drop/dynamic-drop-async.rs
@@ -5,6 +5,7 @@
 
 // run-pass
 // needs-unwind
+// compile-flags: -Z panic-in-drop=unwind -Z allow-incompatible-panic-in-drop
 // edition:2018
 // ignore-wasm32-bare compiled with panic=abort by default
 

--- a/src/test/ui/drop/dynamic-drop.rs
+++ b/src/test/ui/drop/dynamic-drop.rs
@@ -1,5 +1,6 @@
 // run-pass
 // needs-unwind
+// compile-flags: -Z panic-in-drop=unwind -Z allow-incompatible-panic-in-drop
 // ignore-wasm32-bare compiled with panic=abort by default
 
 #![feature(generators, generator_trait)]

--- a/src/test/ui/generator/size-moved-locals.rs
+++ b/src/test/ui/generator/size-moved-locals.rs
@@ -71,7 +71,7 @@ fn overlap_x_and_y() -> impl Generator<Yield = (), Return = ()> {
 
 fn main() {
     assert_eq!(1025, std::mem::size_of_val(&move_before_yield()));
-    assert_eq!(1026, std::mem::size_of_val(&move_before_yield_with_noop()));
+    assert_eq!(1025, std::mem::size_of_val(&move_before_yield_with_noop()));
     assert_eq!(2051, std::mem::size_of_val(&overlap_move_points()));
     assert_eq!(1026, std::mem::size_of_val(&overlap_x_and_y()));
 }

--- a/src/test/ui/issues/issue-14875.rs
+++ b/src/test/ui/issues/issue-14875.rs
@@ -1,5 +1,6 @@
 // run-pass
 // needs-unwind
+// compile-flags: -Z panic-in-drop=unwind -Z allow-incompatible-panic-in-drop
 // ignore-wasm32-bare compiled with panic=abort by default
 
 // Check that values are not leaked when a dtor panics (#14875)

--- a/src/test/ui/mir/mir_drop_panics.rs
+++ b/src/test/ui/mir/mir_drop_panics.rs
@@ -1,5 +1,6 @@
 // run-fail
 // needs-unwind
+// compile-flags: -Z panic-in-drop=unwind -Z allow-incompatible-panic-in-drop
 // error-pattern:panic 1
 // error-pattern:drop 2
 // ignore-emscripten no processes

--- a/src/test/ui/panics/panic-in-dtor-drops-fields.rs
+++ b/src/test/ui/panics/panic-in-dtor-drops-fields.rs
@@ -1,5 +1,6 @@
 // run-pass
 // needs-unwind
+// compile-flags: -Z panic-in-drop=unwind -Z allow-incompatible-panic-in-drop
 #![allow(dead_code)]
 #![allow(non_upper_case_globals)]
 

--- a/src/test/ui/runtime/rt-explody-panic-payloads.rs
+++ b/src/test/ui/runtime/rt-explody-panic-payloads.rs
@@ -22,10 +22,22 @@ fn main() {
     let output = match &args[..] {
         [me] => Command::new(&me).arg("plant the").output(),
         [..] => std::panic::panic_any(Bomb),
-    }.expect("running the command should have succeeded");
+    }
+    .expect("running the command should have succeeded");
     println!("{:#?}", output);
     let stderr = std::str::from_utf8(&output.stderr);
-    assert!(stderr.map(|v| {
-        v.ends_with("fatal runtime error: drop of the panic payload panicked\n")
-    }).unwrap_or(false));
+
+    // The standard library used in tests is built with -Z panic-in-drop=abort
+    // which causes the unwind to fail immediately since the catch_unwind in
+    // the standard library has been optimized away as unreachable. Even if it
+    // weren't optimized away the unwind would still be forcibly stopped in
+    // drop_in_place which cannot unwind.
+    //
+    // When the standard library is built with -Z panic-in-drop=unwind this
+    // fails with a specific error message: "drop of the panic payload panicked"
+    assert!(
+        stderr
+            .map(|v| { v.contains("fatal runtime error: failed to initiate panic") })
+            .unwrap_or(false)
+    );
 }

--- a/src/test/ui/structs-enums/unit-like-struct-drop-run.rs
+++ b/src/test/ui/structs-enums/unit-like-struct-drop-run.rs
@@ -1,5 +1,6 @@
 // run-pass
 // needs-unwind
+// compile-flags: -Z panic-in-drop=unwind -Z allow-incompatible-panic-in-drop
 // ignore-emscripten no threads support
 
 // Make sure the destructor is run for unit-like structs.


### PR DESCRIPTION
This PR switches the default value of `-Z panic-in-drop` to `abort`. This causes Rust programs to abort if a panic escapes from a `Drop` impl (it is not caught by `catch_unwind`).

See https://github.com/rust-lang/lang-team/issues/97 for a more detailed rationale on this change.

Most of the changes in this PR involve fixing tests to work with the new behavior. For now, stdlib tests which rely on panics in drop are simply disabled with `#[ignore]`. However, if in the future we decide to make this change permanent and remove the `-Z panic-in-drop=unwind` option then we can simplify the implementation of the collections, especially with regards to `drain_filter`.

r? @joshtriplett 