### PR TITLE
Improve parser diagnostics

### DIFF
--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -29,6 +29,7 @@ use std::ops::{Deref, DerefMut};
 
 use std::mem::take;
 
+use crate::parser;
 use tracing::{debug, trace};
 
 const TURBOFISH_SUGGESTION_STR: &str =
@@ -400,6 +401,35 @@ impl<'a> Parser<'a> {
             .map(|x| TokenType::Token(x.clone()))
             .chain(inedible.iter().map(|x| TokenType::Token(x.clone())))
             .chain(self.expected_tokens.iter().cloned())
+            .filter_map(|token| {
+                // filter out suggestions which suggest the same token which was found and deemed incorrect
+                fn is_ident_eq_keyword(found: &TokenKind, expected: &TokenType) -> bool {
+                    if let TokenKind::Ident(current_sym, _) = found {
+                        if let TokenType::Keyword(suggested_sym) = expected {
+                            return current_sym == suggested_sym;
+                        }
+                    }
+                    false
+                }
+                if token != parser::TokenType::Token(self.token.kind.clone()) {
+                    let eq = is_ident_eq_keyword(&self.token.kind, &token);
+                    // if the suggestion is a keyword and the found token is an ident,
+                    // the content of which are equal to the suggestion's content,
+                    // we can remove that suggestion (see the return None statement below)
+
+                    // if this isn't the case however, and the suggestion is a token the
+                    // content of which is the same as the found token's, we remove it as well
+                    if !eq {
+                        if let TokenType::Token(kind) = &token {
+                            if kind == &self.token.kind {
+                                return None;
+                            }
+                        }
+                        return Some(token);
+                    }
+                }
+                return None;
+            })
             .collect::<Vec<_>>();
         expected.sort_by_cached_key(|x| x.to_string());
         expected.dedup();

--- a/compiler/rustc_parse/src/parser/mod.rs
+++ b/compiler/rustc_parse/src/parser/mod.rs
@@ -548,6 +548,22 @@ impl<'a> Parser<'a> {
         is_present
     }
 
+    fn check_noexpect(&self, tok: &TokenKind) -> bool {
+        self.token == *tok
+    }
+
+    /// Consumes a token 'tok' if it exists. Returns whether the given token was present.
+    ///
+    /// the main purpose of this function is to reduce the cluttering of the suggestions list
+    /// which using the normal eat method could introduce in some cases.
+    pub fn eat_noexpect(&mut self, tok: &TokenKind) -> bool {
+        let is_present = self.check_noexpect(tok);
+        if is_present {
+            self.bump()
+        }
+        is_present
+    }
+
     /// Consumes a token 'tok' if it exists. Returns whether the given token was present.
     pub fn eat(&mut self, tok: &TokenKind) -> bool {
         let is_present = self.check(tok);

--- a/compiler/rustc_parse/src/parser/stmt.rs
+++ b/compiler/rustc_parse/src/parser/stmt.rs
@@ -262,7 +262,10 @@ impl<'a> Parser<'a> {
                     if let Ok(snip) = self.span_to_snippet(pat.span) {
                         err.span_label(pat.span, format!("while parsing the type for `{}`", snip));
                     }
-                    let err = if self.check(&token::Eq) {
+                    // we use noexpect here because we don't actually expect Eq to be here
+                    // but we are still checking for it in order to be able to handle it if
+                    // it is there
+                    let err = if self.check_noexpect(&token::Eq) {
                         err.emit();
                         None
                     } else {

--- a/src/test/ui/parser/can-begin-expr-check.rs
+++ b/src/test/ui/parser/can-begin-expr-check.rs
@@ -16,5 +16,5 @@ pub fn main() {
         return break as ();
     }
 
-    return enum; //~ ERROR expected one of `.`, `;`, `?`, `}`, or an operator, found keyword `enum`
+    return enum; //~ ERROR expected one of `;`, `}`, or an operator, found keyword `enum`
 }

--- a/src/test/ui/parser/can-begin-expr-check.stderr
+++ b/src/test/ui/parser/can-begin-expr-check.stderr
@@ -1,8 +1,8 @@
-error: expected one of `.`, `;`, `?`, `}`, or an operator, found keyword `enum`
+error: expected one of `;`, `}`, or an operator, found keyword `enum`
   --> $DIR/can-begin-expr-check.rs:19:12
    |
 LL |     return enum;
-   |            ^^^^ expected one of `.`, `;`, `?`, `}`, or an operator
+   |            ^^^^ expected one of `;`, `}`, or an operator
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/duplicate-visibility.rs
+++ b/src/test/ui/parser/duplicate-visibility.rs
@@ -2,8 +2,8 @@ fn main() {}
 
 extern "C" { //~ NOTE while parsing this item list starting here
     pub pub fn foo();
-    //~^ ERROR expected one of `(`, `async`, `const`, `default`, `extern`, `fn`, `pub`, `unsafe`, or `use`, found keyword `pub`
-    //~| NOTE expected one of 9 possible tokens
+    //~^ ERROR expected one of `(`, `async`, `const`, `default`, `extern`, `fn`, `unsafe`, or `use`, found keyword `pub`
+    //~| NOTE expected one of 8 possible tokens
     //~| HELP there is already a visibility modifier, remove one
     //~| NOTE explicit visibility first seen here
 } //~ NOTE the item list ends here

--- a/src/test/ui/parser/duplicate-visibility.stderr
+++ b/src/test/ui/parser/duplicate-visibility.stderr
@@ -1,4 +1,4 @@
-error: expected one of `(`, `async`, `const`, `default`, `extern`, `fn`, `pub`, `unsafe`, or `use`, found keyword `pub`
+error: expected one of `(`, `async`, `const`, `default`, `extern`, `fn`, `unsafe`, or `use`, found keyword `pub`
   --> $DIR/duplicate-visibility.rs:4:9
    |
 LL | extern "C" {
@@ -6,7 +6,7 @@ LL | extern "C" {
 LL |     pub pub fn foo();
    |         ^^^
    |         |
-   |         expected one of 9 possible tokens
+   |         expected one of 8 possible tokens
    |         help: there is already a visibility modifier, remove one
 ...
 LL | }

--- a/src/test/ui/parser/issues/issue-20616-2.rs
+++ b/src/test/ui/parser/issues/issue-20616-2.rs
@@ -9,7 +9,7 @@ type Type_1_<'a, T> = &'a T;
 //type Type_1<'a T> = &'a T; // error: expected `,` or `>` after lifetime name, found `T`
 
 
-type Type_2 = Type_1_<'static ()>; //~ error: expected one of `,`, `:`, `=`, or `>`, found `(`
+type Type_2 = Type_1_<'static ()>; //~ error: expected one of `,` or `>`, found `(`
 
 
 //type Type_3<T> = Box<T,,>; // error: expected type, found `,`

--- a/src/test/ui/parser/issues/issue-20616-2.stderr
+++ b/src/test/ui/parser/issues/issue-20616-2.stderr
@@ -1,8 +1,8 @@
-error: expected one of `,`, `:`, `=`, or `>`, found `(`
+error: expected one of `,` or `>`, found `(`
   --> $DIR/issue-20616-2.rs:12:31
    |
 LL | type Type_2 = Type_1_<'static ()>;
-   |                               ^ expected one of `,`, `:`, `=`, or `>`
+   |                               ^ expected one of `,` or `>`
    |
 help: you might have meant to end the type parameters here
    |

--- a/src/test/ui/parser/issues/issue-62660.rs
+++ b/src/test/ui/parser/issues/issue-62660.rs
@@ -5,7 +5,7 @@ struct Foo;
 
 impl Foo {
     pub fn foo(_: i32, self: Box<Self) {}
-    //~^ ERROR expected one of `!`, `(`, `+`, `,`, `::`, `:`, `<`, `=`, or `>`, found `)`
+    //~^ ERROR expected one of `!`, `(`, `+`, `,`, `::`, `<`, or `>`, found `)`
 }
 
 fn main() {}

--- a/src/test/ui/parser/issues/issue-62660.stderr
+++ b/src/test/ui/parser/issues/issue-62660.stderr
@@ -1,8 +1,8 @@
-error: expected one of `!`, `(`, `+`, `,`, `::`, `:`, `<`, `=`, or `>`, found `)`
+error: expected one of `!`, `(`, `+`, `,`, `::`, `<`, or `>`, found `)`
   --> $DIR/issue-62660.rs:7:38
    |
 LL |     pub fn foo(_: i32, self: Box<Self) {}
-   |                                      ^ expected one of 9 possible tokens
+   |                                      ^ expected one of 7 possible tokens
    |
 help: you might have meant to end the type parameters here
    |

--- a/src/test/ui/parser/issues/issue-84117.rs
+++ b/src/test/ui/parser/issues/issue-84117.rs
@@ -6,4 +6,4 @@ fn main() {
     //~| ERROR expected one of `!`, `.`, `::`, `;`, `?`, `else`, `{`, or an operator, found `,`
     //~| ERROR expected one of `!`, `.`, `::`, `;`, `?`, `else`, `{`, or an operator, found `,`
 }
-//~^ ERROR expected one of `,`, `:`, `=`, or `>`, found `}`
+//~^ ERROR expected one of `,` or `>`, found `}`

--- a/src/test/ui/parser/issues/issue-84117.stderr
+++ b/src/test/ui/parser/issues/issue-84117.stderr
@@ -21,11 +21,11 @@ error: expected one of `!`, `.`, `::`, `;`, `?`, `else`, `{`, or an operator, fo
 LL |     let outer_local:e_outer<&str, { let inner_local:e_inner<&str, }
    |                                                                 ^ expected one of 8 possible tokens
 
-error: expected one of `,`, `:`, `=`, or `>`, found `}`
+error: expected one of `,` or `>`, found `}`
   --> $DIR/issue-84117.rs:8:1
    |
 LL |     let outer_local:e_outer<&str, { let inner_local:e_inner<&str, }
-   |         ----------- while parsing the type for `outer_local`       - expected one of `,`, `:`, `=`, or `>`
+   |         ----------- while parsing the type for `outer_local`       - expected one of `,` or `>`
 ...
 LL | }
    | ^ unexpected token

--- a/src/test/ui/parser/issues/issue-93282.stderr
+++ b/src/test/ui/parser/issues/issue-93282.stderr
@@ -4,11 +4,11 @@ error: expected `while`, `for`, `loop` or `{` after a label
 LL |     f<'a,>
    |         ^ expected `while`, `for`, `loop` or `{` after a label
 
-error: expected one of `.`, `:`, `;`, `?`, `for`, `loop`, `while`, `{`, `}`, or an operator, found `,`
+error: expected one of `.`, `:`, `;`, `?`, `for`, `loop`, `while`, `}`, or an operator, found `,`
   --> $DIR/issue-93282.rs:2:9
    |
 LL |     f<'a,>
-   |         ^ expected one of 10 possible tokens
+   |         ^ expected one of 9 possible tokens
    |
 help: use `::<...>` instead of `<...>` to specify lifetime, type, or const arguments
    |

--- a/src/test/ui/parser/issues/issue-93867.rs
+++ b/src/test/ui/parser/issues/issue-93867.rs
@@ -1,0 +1,10 @@
+pub struct Entry<'a, K, V> {
+    k: &'a mut K,
+    v: V,
+}
+
+pub fn entry<'a, K, V>() -> Entry<'a K, V> {
+//                                  ^ missing comma
+//~^^ expected one of `,` or `>`, found `K`
+    unimplemented!()
+}

--- a/src/test/ui/parser/issues/issue-93867.stderr
+++ b/src/test/ui/parser/issues/issue-93867.stderr
@@ -1,0 +1,13 @@
+error: expected one of `,` or `>`, found `K`
+  --> $DIR/issue-93867.rs:6:38
+   |
+LL | pub fn entry<'a, K, V>() -> Entry<'a K, V> {
+   |                                      ^ expected one of `,` or `>`
+   |
+help: you might have meant to end the type parameters here
+   |
+LL | pub fn entry<'a, K, V>() -> Entry<'a> K, V> {
+   |                                     +
+
+error: aborting due to previous error
+

--- a/src/test/ui/parser/lifetime-semicolon.fixed
+++ b/src/test/ui/parser/lifetime-semicolon.fixed
@@ -5,6 +5,6 @@ struct Foo<'a, 'b> {
 }
 
 fn foo<'a, 'b>(_x: &mut Foo<'a, 'b>) {}
-//~^ ERROR expected one of `,`, `:`, `=`, or `>`, found `;`
+//~^ ERROR expected one of `,` or `>`, found `;`
 
 fn main() {}

--- a/src/test/ui/parser/lifetime-semicolon.rs
+++ b/src/test/ui/parser/lifetime-semicolon.rs
@@ -5,6 +5,6 @@ struct Foo<'a, 'b> {
 }
 
 fn foo<'a, 'b>(_x: &mut Foo<'a; 'b>) {}
-//~^ ERROR expected one of `,`, `:`, `=`, or `>`, found `;`
+//~^ ERROR expected one of `,` or `>`, found `;`
 
 fn main() {}

--- a/src/test/ui/parser/lifetime-semicolon.stderr
+++ b/src/test/ui/parser/lifetime-semicolon.stderr
@@ -1,8 +1,8 @@
-error: expected one of `,`, `:`, `=`, or `>`, found `;`
+error: expected one of `,` or `>`, found `;`
   --> $DIR/lifetime-semicolon.rs:7:31
    |
 LL | fn foo<'a, 'b>(_x: &mut Foo<'a; 'b>) {}
-   |                               ^ expected one of `,`, `:`, `=`, or `>`
+   |                               ^ expected one of `,` or `>`
    |
 help: use a comma to separate type parameters
    |

--- a/src/test/ui/parser/require-parens-for-chained-comparison.stderr
+++ b/src/test/ui/parser/require-parens-for-chained-comparison.stderr
@@ -59,11 +59,11 @@ error: expected `while`, `for`, `loop` or `{` after a label
 LL |     let _ = f<'_, i8>();
    |                 ^ expected `while`, `for`, `loop` or `{` after a label
 
-error: expected one of `.`, `:`, `;`, `?`, `else`, `for`, `loop`, `while`, `{`, or an operator, found `,`
+error: expected one of `.`, `:`, `;`, `?`, `else`, `for`, `loop`, `while`, or an operator, found `,`
   --> $DIR/require-parens-for-chained-comparison.rs:22:17
    |
 LL |     let _ = f<'_, i8>();
-   |                 ^ expected one of 10 possible tokens
+   |                 ^ expected one of 9 possible tokens
    |
 help: use `::<...>` instead of `<...>` to specify lifetime, type, or const arguments
    |


### PR DESCRIPTION
This pr fixes https://github.com/rust-lang/rust/issues/93867 and contains a couple of diagnostics related changes to the parser.
Here is a short list with some of the changes:
- don't suggest the same thing that is the current token
- suggest removing the current token if the following token is one of the suggestions (maybe incorrect)
- tell the user to put a type or lifetime after where if there is none (as a warning)
- reduce the amount of tokens suggested (via the new eat_noexpect and check_noexpect methods)

If any of these changes are undesirable, i can remove them, thanks!