### PR TITLE
Remove impossible panic note from `Vec::append`

### DIFF
--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -1767,7 +1767,7 @@ impl<T, A: Allocator> Vec<T, A> {
     ///
     /// # Panics
     ///
-    /// Panics if the number of elements in the vector overflows a `usize`.
+    /// Panics if the new capacity exceeds `isize::MAX` bytes.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
Neither the number of elements in a vector can overflow a `usize`, nor
can the amount of elements in two vectors.