### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/compiler/rustc_mir_transform/src/const_prop.rs
+++ b/compiler/rustc_mir_transform/src/const_prop.rs
@@ -244,8 +244,8 @@ impl<'mir, 'tcx> interpret::Machine<'mir, 'tcx> for ConstPropMachine<'mir, 'tcx>
     ) -> InterpResult<'tcx, InterpOperand<Self::PointerTag>> {
         let l = &frame.locals[local];
 
-        if l.value == LocalValue::Uninitialized {
-            throw_machine_stop_str!("tried to access an uninitialized local")
+        if l.value == LocalValue::Unallocated {
+            throw_machine_stop_str!("tried to access an unallocated local")
         }
 
         l.access()
@@ -442,7 +442,7 @@ impl<'mir, 'tcx> ConstPropagator<'mir, 'tcx> {
     /// but not reading from them anymore.
     fn remove_const(ecx: &mut InterpCx<'mir, 'tcx, ConstPropMachine<'mir, 'tcx>>, local: Local) {
         ecx.frame_mut().locals[local] =
-            LocalState { value: LocalValue::Uninitialized, layout: Cell::new(None) };
+            LocalState { value: LocalValue::Unallocated, layout: Cell::new(None) };
     }
 
     fn lint_root(&self, source_info: SourceInfo) -> Option<HirId> {
@@ -1147,7 +1147,7 @@ impl<'tcx> MutVisitor<'tcx> for ConstPropagator<'_, 'tcx> {
                     let frame = self.ecx.frame_mut();
                     frame.locals[local].value =
                         if let StatementKind::StorageLive(_) = statement.kind {
-                            LocalValue::Uninitialized
+                            LocalValue::Unallocated
                         } else {
                             LocalValue::Dead
                         };

--- a/compiler/rustc_parse/src/parser/path.rs
+++ b/compiler/rustc_parse/src/parser/path.rs
@@ -630,10 +630,14 @@ impl<'a> Parser<'a> {
                 Ok(ty) => GenericArg::Type(ty),
                 Err(err) => {
                     if is_const_fn {
-                        if let Ok(expr) = (*snapshot).parse_expr_res(Restrictions::CONST_EXPR, None)
-                        {
-                            self.restore_snapshot(snapshot);
-                            return Ok(Some(self.dummy_const_arg_needs_braces(err, expr.span)));
+                        match (*snapshot).parse_expr_res(Restrictions::CONST_EXPR, None) {
+                            Ok(expr) => {
+                                self.restore_snapshot(snapshot);
+                                return Ok(Some(self.dummy_const_arg_needs_braces(err, expr.span)));
+                            }
+                            Err(err) => {
+                                err.cancel();
+                            }
                         }
                     }
                     // Try to recover from possible `const` arg without braces.

--- a/library/std/src/process.rs
+++ b/library/std/src/process.rs
@@ -2030,6 +2030,10 @@ pub fn id() -> u32 {
 ///
 /// The default implementations are returning `libc::EXIT_SUCCESS` to indicate
 /// a successful execution. In case of a failure, `libc::EXIT_FAILURE` is returned.
+///
+/// For the reason that different runtimes have diffrent specificatons on the
+/// return value of the `main` function, this trait is likely to be available 
+/// only on standard library's runtime for type convenience.
 #[cfg_attr(not(test), lang = "termination")]
 #[unstable(feature = "termination_trait_lib", issue = "43301")]
 #[rustc_on_unimplemented(

--- a/library/std/src/process.rs
+++ b/library/std/src/process.rs
@@ -2032,7 +2032,7 @@ pub fn id() -> u32 {
 /// a successful execution. In case of a failure, `libc::EXIT_FAILURE` is returned.
 ///
 /// For the reason that different runtimes have diffrent specificatons on the
-/// return value of the `main` function, this trait is likely to be available 
+/// return value of the `main` function, this trait is likely to be available
 /// only on standard library's runtime for type convenience.
 #[cfg_attr(not(test), lang = "termination")]
 #[unstable(feature = "termination_trait_lib", issue = "43301")]

--- a/library/std/src/process.rs
+++ b/library/std/src/process.rs
@@ -2031,9 +2031,10 @@ pub fn id() -> u32 {
 /// The default implementations are returning `libc::EXIT_SUCCESS` to indicate
 /// a successful execution. In case of a failure, `libc::EXIT_FAILURE` is returned.
 ///
-/// For the reason that different runtimes have diffrent specificatons on the
-/// return value of the `main` function, this trait is likely to be available
-/// only on standard library's runtime for type convenience.
+/// Because different runtimes have different specifications on the return value
+/// of the `main` function, this trait is likely to be available only on
+/// standard library's runtime for convenience. Other runtimes are not required
+/// to provide similar functionality.
 #[cfg_attr(not(test), lang = "termination")]
 #[unstable(feature = "termination_trait_lib", issue = "43301")]
 #[rustc_on_unimplemented(

--- a/src/test/ui/const-generics/ice-const-generic-function-return-ty.rs
+++ b/src/test/ui/const-generics/ice-const-generic-function-return-ty.rs
@@ -1,0 +1,5 @@
+// #95163
+fn return_ty() -> impl Into<<() as Reexported;
+//~^ ERROR expected one of `(`, `::`, `<`, or `>`, found `;`
+
+fn main() {}

--- a/src/test/ui/const-generics/ice-const-generic-function-return-ty.stderr
+++ b/src/test/ui/const-generics/ice-const-generic-function-return-ty.stderr
@@ -1,0 +1,8 @@
+error: expected one of `(`, `::`, `<`, or `>`, found `;`
+  --> $DIR/ice-const-generic-function-return-ty.rs:2:46
+   |
+LL | fn return_ty() -> impl Into<<() as Reexported;
+   |                                              ^ expected one of `(`, `::`, `<`, or `>`
+
+error: aborting due to previous error
+

--- a/src/test/ui/type/type-check/missing_trait_impl.rs
+++ b/src/test/ui/type/type-check/missing_trait_impl.rs
@@ -8,3 +8,9 @@ fn foo<T>(x: T, y: T) {
 fn bar<T>(x: T) {
     x += x; //~ ERROR binary assignment operation `+=` cannot be applied to type `T`
 }
+
+fn baz<T>(x: T) {
+    let y = -x; //~ ERROR cannot apply unary operator `-` to type `T`
+    let y = !x; //~ ERROR cannot apply unary operator `!` to type `T`
+    let y = *x; //~ ERROR type `T` cannot be dereferenced
+}

--- a/src/test/ui/type/type-check/missing_trait_impl.stderr
+++ b/src/test/ui/type/type-check/missing_trait_impl.stderr
@@ -24,7 +24,35 @@ help: consider restricting type parameter `T`
 LL | fn bar<T: std::ops::AddAssign>(x: T) {
    |         +++++++++++++++++++++
 
-error: aborting due to 2 previous errors
+error[E0600]: cannot apply unary operator `-` to type `T`
+  --> $DIR/missing_trait_impl.rs:13:13
+   |
+LL |     let y = -x;
+   |             ^^ cannot apply unary operator `-`
+   |
+help: consider restricting type parameter `T`
+   |
+LL | fn baz<T: std::ops::Neg<Output = T>>(x: T) {
+   |         +++++++++++++++++++++++++++
 
-Some errors have detailed explanations: E0368, E0369.
+error[E0600]: cannot apply unary operator `!` to type `T`
+  --> $DIR/missing_trait_impl.rs:14:13
+   |
+LL |     let y = !x;
+   |             ^^ cannot apply unary operator `!`
+   |
+help: consider restricting type parameter `T`
+   |
+LL | fn baz<T: std::ops::Not<Output = T>>(x: T) {
+   |         +++++++++++++++++++++++++++
+
+error[E0614]: type `T` cannot be dereferenced
+  --> $DIR/missing_trait_impl.rs:15:13
+   |
+LL |     let y = *x;
+   |             ^^
+
+error: aborting due to 5 previous errors
+
+Some errors have detailed explanations: E0368, E0369, E0600, E0614.
 For more information about an error, try `rustc --explain E0368`.


### PR DESCRIPTION
Successful merges:

 - #95188 ([`macro-metavar-expr`] Fix generated tokens hygiene)
 - #95196 (rename LocalState::Uninitialized to Unallocated)
 - #95197 (Suggest constraining param for unary ops when missing trait impl)
 - #95200 (Cancel a not emitted error after parsing const generic args)
 - #95207 (update Termination trait docs)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=95188,95196,95197,95200,95207)
<!-- homu-ignore:end -->