### PR TITLE
Change an instance of `.collect::<Vec<_>>().join("")` to `.collect::<String>()`

### DIFF
--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -1021,8 +1021,7 @@ impl<'a: 'ast, 'ast> LateResolutionVisitor<'a, '_, 'ast> {
             (Res::Def(DefKind::TyAlias, def_id), PathSource::Trait(_)) => {
                 err.span_label(span, "type aliases cannot be used as traits");
                 if self.r.session.is_nightly_build() {
-                    let msg =
-                        "you might have meant to use `#![feature(trait_alias)]` instead of a \
+                    let msg = "you might have meant to use `#![feature(trait_alias)]` instead of a \
                                `type` alias";
                     if let Some(span) = self.def_span(def_id) {
                         if let Ok(snip) = self.r.session.source_map().span_to_snippet(span) {

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -1021,7 +1021,8 @@ impl<'a: 'ast, 'ast> LateResolutionVisitor<'a, '_, 'ast> {
             (Res::Def(DefKind::TyAlias, def_id), PathSource::Trait(_)) => {
                 err.span_label(span, "type aliases cannot be used as traits");
                 if self.r.session.is_nightly_build() {
-                    let msg = "you might have meant to use `#![feature(trait_alias)]` instead of a \
+                    let msg =
+                        "you might have meant to use `#![feature(trait_alias)]` instead of a \
                                `type` alias";
                     if let Some(span) = self.def_span(def_id) {
                         if let Ok(snip) = self.r.session.source_map().span_to_snippet(span) {
@@ -2379,9 +2380,7 @@ impl<'tcx> LifetimeContext<'_, 'tcx> {
                     suggs.push(match snippet.as_deref() {
                         Some("&") => Some("&'a ".to_string()),
                         Some("'_") => Some("'a".to_string()),
-                        Some("") => {
-                            Some(std::iter::repeat("'a, ").take(count).collect::<Vec<_>>().join(""))
-                        }
+                        Some("") => Some(std::iter::repeat("'a, ").take(count).collect::<String>()),
                         Some("<") => {
                             Some(std::iter::repeat("'a").take(count).collect::<Vec<_>>().join(", "))
                         }


### PR DESCRIPTION
Hey,
I've noticed that `compiler/rustc_resolve/src/late/diagnostics.rs` uses `.collect::<Vec<_>>().join("");` over `.collect::<String>();`, the latter being shorter, clearer and more performant:

```rs
    criterion.bench_function("bench 1", |bencher| {
        bencher.iter(|| {
            std::iter::repeat("'a, ")
                .take(10)
                .collect::<Vec<_>>()
                .join("");
        })
    });

    criterion.bench_function("bench 2", |bencher| {
        bencher.iter(|| {
            std::iter::repeat("'a, ").take(10).collect::<String>();
        })
    });
```

```
bench 1                 time:   [88.355 ns 88.526 ns 88.704 ns]                         
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) low mild
  1 (1.00%) high mild
slope  [88.355 ns 88.704 ns] R^2            [0.9910173 0.9909753]
mean   [88.312 ns 88.623 ns] std. dev.      [640.43 ps 940.42 ps]
median [88.168 ns 88.576 ns] med. abs. dev. [587.33 ps 932.58 ps]

bench 2                 time:   [110.31 ns 110.50 ns 110.77 ns]                         
Found 5 outliers among 100 measurements (5.00%)
  5 (5.00%) high mild
slope  [110.31 ns 110.77 ns] R^2            [0.9907452 0.9903230]
mean   [110.85 ns 111.38 ns] std. dev.      [1.1039 ns 1.5752 ns]
median [110.25 ns 110.91 ns] med. abs. dev. [395.71 ps 1.1579 ns]
```

I'm currently working on a [clippy PR](https://github.com/rust-lang/rust-clippy/pull/8573) to lint this issue but thought to create a manual PR for Deno

Thanks for your consideration!