### PR TITLE
Modernize `alloc-no-oom-handling` test

### DIFF
--- a/src/test/run-make-fulldeps/alloc-no-oom-handling/Makefile
+++ b/src/test/run-make-fulldeps/alloc-no-oom-handling/Makefile
@@ -1,4 +1,4 @@
 -include ../tools.mk
 
 all:
-	$(RUSTC) --edition=2018 --crate-type=rlib ../../../../library/alloc/src/lib.rs --cfg feature=\"external_crate\" --cfg no_global_oom_handling
+	$(RUSTC) --edition=2021 --crate-type=rlib ../../../../library/alloc/src/lib.rs --cfg no_global_oom_handling


### PR DESCRIPTION
  - The edition should be 2021 to avoid warnings.

  - The `external_crate` feature was removed in commit 45bf1ed1a112 ("rustc: Allow changing the default allocator").

    Note that commit d620ae10709c ("Auto merge of #84266") removed the old test, but the new one introduced passed the `--cfg` like in the old one.

Signed-off-by: Miguel Ojeda <ojeda@kernel.org>

---

This is intended to align this test to the new `no_rc` and `no_sync` ones being added in https://github.com/rust-lang/rust/pull/89891, but it makes sense on its own too.