### PR TITLE
diagnostics: do not suggest `fn foo({ <body> }`

### DIFF
--- a/compiler/rustc_ast_passes/src/ast_validation.rs
+++ b/compiler/rustc_ast_passes/src/ast_validation.rs
@@ -471,10 +471,17 @@ impl<'a> AstValidator<'a> {
     }
 
     fn error_item_without_body(&self, sp: Span, ctx: &str, msg: &str, sugg: &str) {
+        let source_map = self.session.source_map();
+        let end = source_map.end_point(sp);
+        let replace_span = if source_map.span_to_snippet(end).map(|s| s == ";").unwrap_or(false) {
+            end
+        } else {
+            sp.shrink_to_hi()
+        };
         self.err_handler()
             .struct_span_err(sp, msg)
             .span_suggestion(
-                self.session.source_map().end_point(sp),
+                replace_span,
                 &format!("provide a definition for the {}", ctx),
                 sugg.to_string(),
                 Applicability::HasPlaceholders,

--- a/src/test/ui/parser/issues/issue-87635.stderr
+++ b/src/test/ui/parser/issues/issue-87635.stderr
@@ -13,9 +13,7 @@ error: associated function in `impl` without body
   --> $DIR/issue-87635.rs:4:5
    |
 LL |     pub fn bar()
-   |     ^^^^^^^^^^^-
-   |                |
-   |                help: provide a definition for the function: `{ <body> }`
+   |     ^^^^^^^^^^^^- help: provide a definition for the function: `{ <body> }`
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION
Instead of suggesting that the body always replace the last character on the line, presuming it must be a semicolon, the parser should instead check what the last character is, and append the body if it is anything else.

Fixes #83104