### PR TITLE
Optimize RcInnerPtr::inc_strong()/inc_weak() instruction count

### DIFF
--- a/library/alloc/src/rc.rs
+++ b/library/alloc/src/rc.rs
@@ -2524,8 +2524,8 @@ trait RcInnerPtr {
         self.strong_ref().set(strong);
 
         // We want to abort on overflow instead of dropping the value.
-        // Checking after the store instead of before allows for
-        // slightly better code generation.
+        // Checking for overflow after the store instead of before
+        // allows for slightly better code generation.
         if core::intrinsics::unlikely(strong == 0) {
             abort();
         }
@@ -2557,8 +2557,8 @@ trait RcInnerPtr {
         self.weak_ref().set(weak);
 
         // We want to abort on overflow instead of dropping the value.
-        // Checking after the store instead of before allows for
-        // slightly better code generation.
+        // Checking for overflow after the store instead of before
+        // allows for slightly better code generation.
         if core::intrinsics::unlikely(weak == 0) {
             abort();
         }

--- a/library/alloc/src/rc.rs
+++ b/library/alloc/src/rc.rs
@@ -2516,7 +2516,9 @@ trait RcInnerPtr {
         // missed optimization.
         // SAFETY: The reference count will never be zero when this is
         // called.
-        unsafe { core::intrinsics::assume(strong != 0); }
+        unsafe {
+            core::intrinsics::assume(strong != 0);
+        }
 
         let strong = strong.wrapping_add(1);
         self.strong_ref().set(strong);
@@ -2547,7 +2549,9 @@ trait RcInnerPtr {
         // missed optimization.
         // SAFETY: The reference count will never be zero when this is
         // called.
-        unsafe { core::intrinsics::assume(weak != 0); }
+        unsafe {
+            core::intrinsics::assume(weak != 0);
+        }
 
         let weak = weak.wrapping_add(1);
         self.weak_ref().set(weak);


### PR DESCRIPTION
Inspired by this internals thread: https://internals.rust-lang.org/t/rc-optimization-on-64-bit-targets/16362

[The generated assembly is a bit smaller](https://rust.godbolt.org/z/TeTnf6144) and is a more efficient usage of the CPU's instruction cache. `unlikely` doesn't impact any of the small artificial tests I've done, but I've included it in case it might help more complex scenarios when this is inlined.