### PR TITLE
Stop emitting E0026 for struct enums with underscores

### DIFF
--- a/compiler/rustc_typeck/src/check/pat.rs
+++ b/compiler/rustc_typeck/src/check/pat.rs
@@ -17,7 +17,7 @@ use rustc_session::lint::builtin::NON_EXHAUSTIVE_OMITTED_PATTERNS;
 use rustc_span::hygiene::DesugaringKind;
 use rustc_span::lev_distance::find_best_match_for_name;
 use rustc_span::source_map::{Span, Spanned};
-use rustc_span::symbol::{sym, Ident};
+use rustc_span::symbol::{kw, sym, Ident};
 use rustc_span::{BytePos, MultiSpan, DUMMY_SP};
 use rustc_trait_selection::autoderef::Autoderef;
 use rustc_trait_selection::traits::{ObligationCause, Pattern};
@@ -1275,7 +1275,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             .filter(|(_, ident)| !used_fields.contains_key(ident))
             .collect::<Vec<_>>();
 
-        let inexistent_fields_err = if !(inexistent_fields.is_empty() || variant.is_recovered()) {
+        let inexistent_fields_err = if !(inexistent_fields.is_empty() || variant.is_recovered())
+            && !inexistent_fields.iter().any(|field| field.name == kw::Underscore)
+        {
             Some(self.error_inexistent_fields(
                 adt.variant_descr(),
                 &inexistent_fields,

--- a/src/test/ui/structs-enums/struct-enum-ignoring-field-with-underscore.rs
+++ b/src/test/ui/structs-enums/struct-enum-ignoring-field-with-underscore.rs
@@ -1,0 +1,12 @@
+enum Foo {
+    Bar { bar: bool },
+    Other,
+}
+
+fn main() {
+    let foo = Some(Foo::Other);
+
+    if let Some(Foo::Bar {_}) = foo {}
+    //~^ ERROR expected identifier, found reserved identifier `_`
+    //~| ERROR pattern does not mention field `bar` [E0027]
+}

--- a/src/test/ui/structs-enums/struct-enum-ignoring-field-with-underscore.stderr
+++ b/src/test/ui/structs-enums/struct-enum-ignoring-field-with-underscore.stderr
@@ -1,0 +1,24 @@
+error: expected identifier, found reserved identifier `_`
+  --> $DIR/struct-enum-ignoring-field-with-underscore.rs:9:27
+   |
+LL |     if let Some(Foo::Bar {_}) = foo {}
+   |                           ^ expected identifier, found reserved identifier
+
+error[E0027]: pattern does not mention field `bar`
+  --> $DIR/struct-enum-ignoring-field-with-underscore.rs:9:17
+   |
+LL |     if let Some(Foo::Bar {_}) = foo {}
+   |                 ^^^^^^^^^^^^ missing field `bar`
+   |
+help: include the missing field in the pattern
+   |
+LL |     if let Some(Foo::Bar {_, bar }) = foo {}
+   |                            ~~~~~~~
+help: if you don't care about this missing field, you can explicitly ignore it
+   |
+LL |     if let Some(Foo::Bar {_, .. }) = foo {}
+   |                            ~~~~~~
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0027`.


### PR DESCRIPTION
This patch resolves a part of #83263;

r? @estebank 