### PR TITLE
Fix (A)Rc<[T]> slices larger than isize::MAX bytes when collecting from a TrustedLen iter

### DIFF
--- a/library/alloc/src/raw_vec.rs
+++ b/library/alloc/src/raw_vec.rs
@@ -513,6 +513,6 @@ fn alloc_guard(alloc_size: usize) -> Result<(), TryReserveError> {
 // ensure that the code generation related to these panics is minimal as there's
 // only one location which panics rather than a bunch throughout the module.
 #[cfg(not(no_global_oom_handling))]
-fn capacity_overflow() -> ! {
+pub(crate) fn capacity_overflow() -> ! {
     panic!("capacity overflow");
 }

--- a/library/alloc/src/rc/tests.rs
+++ b/library/alloc/src/rc/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use core::mem::MaybeUninit;
 
 use std::boxed::Box;
 use std::cell::RefCell;
@@ -460,6 +461,21 @@ fn test_from_vec() {
     let r: Rc<[u32]> = Rc::from(v);
 
     assert_eq!(&r[..], [1, 2, 3]);
+}
+
+#[test]
+#[should_panic]
+fn test_uninit_slice_max_allocation() {
+    let _: Rc<[MaybeUninit<u8>]> = Rc::new_uninit_slice(isize::MAX as usize);
+}
+
+#[test]
+#[should_panic]
+fn test_from_iter_max_allocation() {
+    // isize::MAX is the max allocation size
+    // but due to the internal RcBox overhead the actual allocation will be larger and thus panic
+    let len = isize::MAX as usize;
+    let _ = (0..len).map(|_| MaybeUninit::<u8>::uninit()).collect::<Rc<[_]>>();
 }
 
 #[test]


### PR DESCRIPTION
Due to ptr::add restrictions allocations must be <= isize::MAX bytes ([see UCG](https://rust-lang.github.io/unsafe-code-guidelines/layout/scalars.html#isize-and-usize)). Since (A)RcBox is 2 words larger than the slice even when `Vec` ensures that the allocation is small enough the internal layout calculation of (A)Rc can still exceed isize::MAX, so we have to check it directly.

Affected methods:

* `Arc::new_uninit_slice`
* `Arc::from_iter`
* `Rc::new_uninit_slice`
* `Rc::from_iter`


[Zulip discussion](https://rust-lang.zulipchat.com/#narrow/stream/219381-t-libs/topic/Layout.20Isn't.20Enforcing.20The.20isize.3A.3AMAX.20Rule)
Fixes https://github.com/rust-lang/rust/issues/95334