### PR TITLE
Make it possible to run `cargo test` for bootstrap

### DIFF
--- a/src/bootstrap/builder/tests.rs
+++ b/src/bootstrap/builder/tests.rs
@@ -8,12 +8,9 @@ fn configure(cmd: &str, host: &[&str], target: &[&str]) -> Config {
     config.save_toolstates = None;
     config.dry_run = true;
     config.ninja_in_file = false;
-    config.out = PathBuf::from(env::var_os("BOOTSTRAP_OUTPUT_DIRECTORY").unwrap());
-    config.initial_rustc = PathBuf::from(env::var_os("RUSTC").unwrap());
-    config.initial_cargo = PathBuf::from(env::var_os("BOOTSTRAP_INITIAL_CARGO").unwrap());
     // try to avoid spurious failures in dist where we create/delete each others file
-    let dir = config
-        .out
+    // HACK: rather than pull in `tempdir`, use the one that cargo has conveniently created for us
+    let dir = Path::new(env!("OUT_DIR"))
         .join("tmp-rustbuild-tests")
         .join(&thread::current().name().unwrap_or("unknown").replace(":", "-"));
     t!(fs::create_dir_all(&dir));

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -442,7 +442,7 @@ impl Build {
                 .map(PathBuf::from)
                 .unwrap_or_else(|_| src.join("target"));
             let bootstrap_out = workspace_target_dir.join("debug");
-            if !bootstrap_out.join("rustc").exists() {
+            if !bootstrap_out.join("rustc").exists() && !cfg!(test) {
                 // this restriction can be lifted whenever https://github.com/rust-lang/rfcs/pull/3028 is implemented
                 panic!("run `cargo build --bins` before `cargo run`")
             }

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -2346,10 +2346,6 @@ impl Step for Bootstrap {
             .current_dir(builder.src.join("src/bootstrap"))
             .env("RUSTFLAGS", "-Cdebuginfo=2")
             .env("CARGO_TARGET_DIR", builder.out.join("bootstrap"))
-            // HACK: bootstrap's tests want to know the output directory, but there's no way to set
-            // it except through config.toml. Set it through an env variable instead.
-            .env("BOOTSTRAP_OUTPUT_DIRECTORY", &builder.config.out)
-            .env("BOOTSTRAP_INITIAL_CARGO", &builder.config.initial_cargo)
             .env("RUSTC_BOOTSTRAP", "1")
             .env("RUSTC", &builder.initial_rustc);
         if let Some(flags) = option_env!("RUSTFLAGS") {


### PR DESCRIPTION
Note that this only runs bootstrap's self-tests, not compiler or library tests.

Helps with https://github.com/rust-lang/rust/issues/94829.