### PR TITLE
Fix `cargo run` on Windows

### DIFF
--- a/src/bootstrap/build.rs
+++ b/src/bootstrap/build.rs
@@ -1,10 +1,25 @@
+use env::consts::{EXE_EXTENSION, EXE_SUFFIX};
 use std::env;
+use std::ffi::OsString;
 use std::path::PathBuf;
 
+/// Given an executable called `name`, return the filename for the
+/// executable for a particular target.
+pub fn exe(name: &PathBuf) -> PathBuf {
+    if EXE_EXTENSION != "" && name.extension() != Some(EXE_EXTENSION.as_ref()) {
+        let mut name: OsString = name.clone().into();
+        name.push(EXE_SUFFIX);
+        name.into()
+    } else {
+        name.clone()
+    }
+}
+
 fn main() {
+    let host = env::var("HOST").unwrap();
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-env-changed=RUSTC");
-    println!("cargo:rustc-env=BUILD_TRIPLE={}", env::var("HOST").unwrap());
+    println!("cargo:rustc-env=BUILD_TRIPLE={}", host);
 
     // This may not be a canonicalized path.
     let mut rustc = PathBuf::from(env::var_os("RUSTC").unwrap());
@@ -12,7 +27,7 @@ fn main() {
     if rustc.is_relative() {
         println!("cargo:rerun-if-env-changed=PATH");
         for dir in env::split_paths(&env::var_os("PATH").unwrap_or_default()) {
-            let absolute = dir.join(&rustc);
+            let absolute = dir.join(&exe(&rustc));
             if absolute.exists() {
                 rustc = absolute;
                 break;


### PR DESCRIPTION
Fixes the following error:
```
error: failed to run custom build command for `bootstrap v0.0.0 (C:\Users\Walther\git\rust\src\bootstrap)`

Caused by:
  process didn't exit successfully: `C:\Users\Walther\git\rust\target\debug\build\bootstrap-7757a4777dec0f86\build-script-build` (exit code: 101)
  --- stdout
  cargo:rerun-if-changed=build.rs
  cargo:rerun-if-env-changed=RUSTC
  cargo:rustc-env=BUILD_TRIPLE=x86_64-pc-windows-msvc
  cargo:rerun-if-env-changed=PATH

  --- stderr
  thread 'main' panicked at 'assertion failed: rustc.is_absolute()', src\bootstrap\build.rs:22:5
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
warning: build failed, waiting for other jobs to finish...
error: build failed
```

The problem was that the `dir.join` check only works with `rustc.exe`, not `rustc`.

Thanks @Walther for the help testing the fix!

Helps with https://github.com/rust-lang/rust/issues/94829.