### PR TITLE
Ensure io::Error's bitpacked repr doesn't accidentally impl UnwindSafe

### DIFF
--- a/library/std/src/io/error/repr_bitpacked.rs
+++ b/library/std/src/io/error/repr_bitpacked.rs
@@ -120,7 +120,7 @@ const TAG_SIMPLE: usize = 0b11;
 /// See the module docs for more, this is just a way to hack in a check that we
 /// indeed are not unwind-safe.
 ///
-/// ```compile_fail
+/// ```compile_fail,E0277
 /// fn is_unwind_safe<T: core::panic::UnwindSafe>() {}
 /// is_unwind_safe::<std::io::Error>();
 /// ```

--- a/library/std/src/io/error/repr_bitpacked.rs
+++ b/library/std/src/io/error/repr_bitpacked.rs
@@ -115,6 +115,15 @@ const TAG_CUSTOM: usize = 0b01;
 const TAG_OS: usize = 0b10;
 const TAG_SIMPLE: usize = 0b11;
 
+/// The internal representation.
+///
+/// See the module docs for more, this is just a way to hack in a check that we
+/// indeed are not unwind-safe.
+///
+/// ```compile_fail
+/// fn is_unwind_safe<T: core::panic::UnwindSafe>() {}
+/// is_unwind_safe::<std::io::Error>();
+/// ```
 #[repr(transparent)]
 pub(super) struct Repr(NonNull<()>, PhantomData<ErrorData<Box<Custom>>>);
 


### PR DESCRIPTION
Sadly, I'm not sure how to easily test that we don't impl a trait, though (or can libstd use `where io::Error: !UnwindSafe` or something).

Fixes #95203