### PR TITLE
Use `ReEmpty(Universe::MAX)` for trivial outlives constraint

### DIFF
--- a/compiler/rustc_borrowck/src/region_infer/mod.rs
+++ b/compiler/rustc_borrowck/src/region_infer/mod.rs
@@ -490,6 +490,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
                 }
 
                 NllRegionVariableOrigin::RootEmptyRegion
+                | NllRegionVariableOrigin::TopEmptyRegion
                 | NllRegionVariableOrigin::Existential { .. } => {
                     // For existential, regions, nothing to do.
                 }
@@ -1346,6 +1347,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
                 }
 
                 NllRegionVariableOrigin::RootEmptyRegion
+                | NllRegionVariableOrigin::TopEmptyRegion
                 | NllRegionVariableOrigin::Existential { .. } => {
                     // nothing to check here
                 }
@@ -1449,6 +1451,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
                 }
 
                 NllRegionVariableOrigin::RootEmptyRegion
+                | NllRegionVariableOrigin::TopEmptyRegion
                 | NllRegionVariableOrigin::Existential { .. } => {
                     // nothing to check here
                 }
@@ -1722,6 +1725,8 @@ impl<'tcx> RegionInferenceContext<'tcx> {
                 );
                 universe1.cannot_name(placeholder.universe)
             }
+
+            NllRegionVariableOrigin::TopEmptyRegion => true,
 
             NllRegionVariableOrigin::RootEmptyRegion
             | NllRegionVariableOrigin::FreeRegion
@@ -2087,6 +2092,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
             NllRegionVariableOrigin::FreeRegion
             | NllRegionVariableOrigin::Existential { from_forall: false } => true,
             NllRegionVariableOrigin::RootEmptyRegion
+            | NllRegionVariableOrigin::TopEmptyRegion
             | NllRegionVariableOrigin::Placeholder(_)
             | NllRegionVariableOrigin::Existential { from_forall: true } => false,
         };

--- a/compiler/rustc_infer/src/infer/canonical/canonicalizer.rs
+++ b/compiler/rustc_infer/src/infer/canonical/canonicalizer.rs
@@ -184,6 +184,7 @@ impl CanonicalizeMode for CanonicalizeQueryResponse {
             | ty::ReErased
             | ty::ReStatic
             | ty::ReEmpty(ty::UniverseIndex::ROOT)
+            | ty::ReEmpty(ty::UniverseIndex::MAX)
             | ty::ReEarlyBound(..) => r,
 
             ty::RePlaceholder(placeholder) => canonicalizer.canonical_var_for_region(

--- a/compiler/rustc_infer/src/infer/mod.rs
+++ b/compiler/rustc_infer/src/infer/mod.rs
@@ -513,6 +513,9 @@ pub enum NllRegionVariableOrigin {
     /// The variable we create to represent `'empty(U0)`.
     RootEmptyRegion,
 
+    /// The variable we create to represent `'empty(U::MAX)`
+    TopEmptyRegion,
+
     Existential {
         /// If this is true, then this variable was created to represent a lifetime
         /// bound in a `for` binder. For example, it might have been created to

--- a/compiler/rustc_typeck/src/collect.rs
+++ b/compiler/rustc_typeck/src/collect.rs
@@ -2299,11 +2299,10 @@ fn gather_explicit_predicates_of(tcx: TyCtxt<'_>, def_id: DefId) -> ty::GenericP
                         // compiler/tooling bugs from not handling WF predicates.
                     } else {
                         let span = bound_pred.bounded_ty.span;
-                        let re_root_empty = tcx.lifetimes.re_root_empty;
                         let predicate = ty::Binder::bind_with_vars(
                             ty::PredicateKind::TypeOutlives(ty::OutlivesPredicate(
                                 ty,
-                                re_root_empty,
+                                tcx.mk_region(ty::RegionKind::ReEmpty(ty::UniverseIndex::MAX)),
                             )),
                             bound_vars,
                         );

--- a/src/test/mir-opt/nll/named_lifetimes_basic.use_x.nll.0.mir
+++ b/src/test/mir-opt/nll/named_lifetimes_basic.use_x.nll.0.mir
@@ -14,10 +14,11 @@
 | '_#3r | U0 | {bb0[0..=1], '_#3r}
 | '_#4r | U0 | {bb0[0..=1], '_#4r}
 | '_#5r | U0 | {}
-| '_#6r | U0 | {bb0[0..=1], '_#1r}
-| '_#7r | U0 | {bb0[0..=1], '_#2r}
-| '_#8r | U0 | {bb0[0..=1], '_#1r}
-| '_#9r | U0 | {bb0[0..=1], '_#3r}
+| '_#6r | U4294967040 | {}
+| '_#7r | U0 | {bb0[0..=1], '_#1r}
+| '_#8r | U0 | {bb0[0..=1], '_#2r}
+| '_#9r | U0 | {bb0[0..=1], '_#1r}
+| '_#10r | U0 | {bb0[0..=1], '_#3r}
 |
 | Inference Constraints
 | '_#0r live at {bb0[0..=1]}
@@ -25,16 +26,16 @@
 | '_#2r live at {bb0[0..=1]}
 | '_#3r live at {bb0[0..=1]}
 | '_#4r live at {bb0[0..=1]}
-| '_#1r: '_#6r due to BoringNoLocation at All($DIR/named-lifetimes-basic.rs:12:26: 12:27)
-| '_#1r: '_#8r due to BoringNoLocation at All($DIR/named-lifetimes-basic.rs:12:54: 12:55)
-| '_#2r: '_#7r due to BoringNoLocation at All($DIR/named-lifetimes-basic.rs:12:42: 12:43)
-| '_#3r: '_#9r due to BoringNoLocation at All($DIR/named-lifetimes-basic.rs:12:66: 12:67)
-| '_#6r: '_#1r due to BoringNoLocation at All($DIR/named-lifetimes-basic.rs:12:26: 12:27)
-| '_#7r: '_#2r due to BoringNoLocation at All($DIR/named-lifetimes-basic.rs:12:42: 12:43)
-| '_#8r: '_#1r due to BoringNoLocation at All($DIR/named-lifetimes-basic.rs:12:54: 12:55)
-| '_#9r: '_#3r due to BoringNoLocation at All($DIR/named-lifetimes-basic.rs:12:66: 12:67)
+| '_#1r: '_#7r due to BoringNoLocation at All($DIR/named-lifetimes-basic.rs:12:26: 12:27)
+| '_#1r: '_#9r due to BoringNoLocation at All($DIR/named-lifetimes-basic.rs:12:54: 12:55)
+| '_#2r: '_#8r due to BoringNoLocation at All($DIR/named-lifetimes-basic.rs:12:42: 12:43)
+| '_#3r: '_#10r due to BoringNoLocation at All($DIR/named-lifetimes-basic.rs:12:66: 12:67)
+| '_#7r: '_#1r due to BoringNoLocation at All($DIR/named-lifetimes-basic.rs:12:26: 12:27)
+| '_#8r: '_#2r due to BoringNoLocation at All($DIR/named-lifetimes-basic.rs:12:42: 12:43)
+| '_#9r: '_#1r due to BoringNoLocation at All($DIR/named-lifetimes-basic.rs:12:54: 12:55)
+| '_#10r: '_#3r due to BoringNoLocation at All($DIR/named-lifetimes-basic.rs:12:66: 12:67)
 |
-fn use_x(_1: &'_#6r mut i32, _2: &'_#7r u32, _3: &'_#8r u32, _4: &'_#9r u32) -> bool {
+fn use_x(_1: &'_#7r mut i32, _2: &'_#8r u32, _3: &'_#9r u32, _4: &'_#10r u32) -> bool {
     debug w => _1;                       // in scope 0 at $DIR/named-lifetimes-basic.rs:12:26: 12:27
     debug x => _2;                       // in scope 0 at $DIR/named-lifetimes-basic.rs:12:42: 12:43
     debug y => _3;                       // in scope 0 at $DIR/named-lifetimes-basic.rs:12:54: 12:55

--- a/src/test/mir-opt/nll/region_subtyping_basic.main.nll.0.64bit.mir
+++ b/src/test/mir-opt/nll/region_subtyping_basic.main.nll.0.64bit.mir
@@ -8,18 +8,19 @@
 | '_#0r | U0 | {bb0[0..=8], bb1[0..=7], bb2[0..=3], bb3[0..=3], bb4[0..=1], bb5[0..=2], bb6[0..=5], bb7[0], '_#0r, '_#1r}
 | '_#1r | U0 | {bb0[0..=8], bb1[0..=7], bb2[0..=3], bb3[0..=3], bb4[0..=1], bb5[0..=2], bb6[0..=5], bb7[0], '_#1r}
 | '_#2r | U0 | {}
-| '_#3r | U0 | {bb1[0..=7], bb2[0..=2]}
-| '_#4r | U0 | {bb1[1..=7], bb2[0..=2]}
-| '_#5r | U0 | {bb1[4..=7], bb2[0..=2]}
+| '_#3r | U4294967040 | {}
+| '_#4r | U0 | {bb1[0..=7], bb2[0..=2]}
+| '_#5r | U0 | {bb1[1..=7], bb2[0..=2]}
+| '_#6r | U0 | {bb1[4..=7], bb2[0..=2]}
 |
 | Inference Constraints
 | '_#0r live at {bb0[0..=8], bb1[0..=7], bb2[0..=3], bb3[0..=3], bb4[0..=1], bb5[0..=2], bb6[0..=5], bb7[0]}
 | '_#1r live at {bb0[0..=8], bb1[0..=7], bb2[0..=3], bb3[0..=3], bb4[0..=1], bb5[0..=2], bb6[0..=5], bb7[0]}
-| '_#3r live at {bb1[0]}
-| '_#4r live at {bb1[1..=3]}
-| '_#5r live at {bb1[4..=7], bb2[0..=2]}
-| '_#3r: '_#4r due to Assignment at Single(bb1[0])
-| '_#4r: '_#5r due to Assignment at Single(bb1[3])
+| '_#4r live at {bb1[0]}
+| '_#5r live at {bb1[1..=3]}
+| '_#6r live at {bb1[4..=7], bb2[0..=2]}
+| '_#4r: '_#5r due to Assignment at Single(bb1[0])
+| '_#5r: '_#6r due to Assignment at Single(bb1[3])
 |
 fn main() -> () {
     let mut _0: ();                      // return place in scope 0 at $DIR/region-subtyping-basic.rs:16:11: 16:11
@@ -33,10 +34,10 @@ fn main() -> () {
     let _10: bool;                       // in scope 0 at $DIR/region-subtyping-basic.rs:23:9: 23:18
     scope 1 {
         debug v => _1;                   // in scope 1 at $DIR/region-subtyping-basic.rs:17:9: 17:14
-        let _2: &'_#4r usize;            // in scope 1 at $DIR/region-subtyping-basic.rs:18:9: 18:10
+        let _2: &'_#5r usize;            // in scope 1 at $DIR/region-subtyping-basic.rs:18:9: 18:10
         scope 2 {
             debug p => _2;               // in scope 2 at $DIR/region-subtyping-basic.rs:18:9: 18:10
-            let _6: &'_#5r usize;        // in scope 2 at $DIR/region-subtyping-basic.rs:19:9: 19:10
+            let _6: &'_#6r usize;        // in scope 2 at $DIR/region-subtyping-basic.rs:19:9: 19:10
             scope 3 {
                 debug q => _6;           // in scope 3 at $DIR/region-subtyping-basic.rs:19:9: 19:10
             }
@@ -56,7 +57,7 @@ fn main() -> () {
     }
 
     bb1: {
-        _2 = &'_#3r _1[_3];              // bb1[0]: scope 1 at $DIR/region-subtyping-basic.rs:18:13: 18:18
+        _2 = &'_#4r _1[_3];              // bb1[0]: scope 1 at $DIR/region-subtyping-basic.rs:18:13: 18:18
         FakeRead(ForLet(None), _2);      // bb1[1]: scope 1 at $DIR/region-subtyping-basic.rs:18:9: 18:10
         StorageLive(_6);                 // bb1[2]: scope 2 at $DIR/region-subtyping-basic.rs:19:9: 19:10
         _6 = _2;                         // bb1[3]: scope 2 at $DIR/region-subtyping-basic.rs:19:13: 19:14

--- a/src/test/mir-opt/storage_ranges.main.nll.0.mir
+++ b/src/test/mir-opt/storage_ranges.main.nll.0.mir
@@ -8,15 +8,16 @@
 | '_#0r | U0 | {bb0[0..=22], '_#0r, '_#1r}
 | '_#1r | U0 | {bb0[0..=22], '_#1r}
 | '_#2r | U0 | {}
-| '_#3r | U0 | {bb0[10..=11]}
-| '_#4r | U0 | {bb0[11]}
+| '_#3r | U4294967040 | {}
+| '_#4r | U0 | {bb0[10..=11]}
+| '_#5r | U0 | {bb0[11]}
 |
 | Inference Constraints
 | '_#0r live at {bb0[0..=22]}
 | '_#1r live at {bb0[0..=22]}
-| '_#3r live at {bb0[10]}
-| '_#4r live at {bb0[11]}
-| '_#3r: '_#4r due to Assignment at Single(bb0[10])
+| '_#4r live at {bb0[10]}
+| '_#5r live at {bb0[11]}
+| '_#4r: '_#5r due to Assignment at Single(bb0[10])
 |
 fn main() -> () {
     let mut _0: ();                      // return place in scope 0 at $DIR/storage_ranges.rs:3:11: 3:11

--- a/src/test/ui/chalkify/lower_trait_where_clause.rs
+++ b/src/test/ui/chalkify/lower_trait_where_clause.rs
@@ -8,7 +8,8 @@ where
     T: Borrow<U> + ?Sized,
     U: ?Sized + 'b,
     'a: 'b,
-    Box<T>:, // NOTE(#53696) this checks an empty list of bounds.
+//    Box<T>:, // NOTE(#53696) this checks an empty list of bounds.
+// FIXME(compiler-errors): Add the above bound back once chalk knows `ReFree(U::MAX)`
 {
 }
 

--- a/src/test/ui/closures/print/closure-print-generic-verbose-1.stderr
+++ b/src/test/ui/closures/print/closure-print-generic-verbose-1.stderr
@@ -2,7 +2,7 @@ error[E0382]: use of moved value: `c`
   --> $DIR/closure-print-generic-verbose-1.rs:17:5
    |
 LL |     let c = to_fn_once(move|| {
-   |         - move occurs because `c` has type `[f<T>::{closure#0} closure_kind_ty=i32 closure_sig_as_fn_ptr_ty=extern "rust-call" fn(()) upvar_tys=(Foo<&'_#10r str>, T)]`, which does not implement the `Copy` trait
+   |         - move occurs because `c` has type `[f<T>::{closure#0} closure_kind_ty=i32 closure_sig_as_fn_ptr_ty=extern "rust-call" fn(()) upvar_tys=(Foo<&'_#11r str>, T)]`, which does not implement the `Copy` trait
 ...
 LL |     c();
    |     --- `c` moved due to this call

--- a/src/test/ui/generic-associated-types/issue-87258_a.stderr
+++ b/src/test/ui/generic-associated-types/issue-87258_a.stderr
@@ -4,7 +4,7 @@ error[E0700]: hidden type for `impl Trait` captures lifetime that does not appea
 LL |     fn foo<'a>() -> Self::FooFuture<'a> {
    |                     ^^^^^^^^^^^^^^^^^^^
    |
-   = note: hidden type `Struct<'_>` captures lifetime '_#7r
+   = note: hidden type `Struct<'_>` captures lifetime '_#8r
 
 error: aborting due to previous error
 

--- a/src/test/ui/generic-associated-types/issue-87258_b.stderr
+++ b/src/test/ui/generic-associated-types/issue-87258_b.stderr
@@ -4,7 +4,7 @@ error[E0700]: hidden type for `impl Trait` captures lifetime that does not appea
 LL |     fn foo<'a>() -> Self::FooFuture<'a> {
    |                     ^^^^^^^^^^^^^^^^^^^
    |
-   = note: hidden type `Struct<'_>` captures lifetime '_#7r
+   = note: hidden type `Struct<'_>` captures lifetime '_#8r
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-no-bound.stderr
+++ b/src/test/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-no-bound.stderr
@@ -52,7 +52,7 @@ LL | |     });
    | |______`cell_a` escapes the function body here
    |        argument requires that `'a` must outlive `'static`
    |
-   = note: requirement occurs because of the type Cell<&'_#10r u32>, which makes the generic argument &'_#10r u32 invariant
+   = note: requirement occurs because of the type Cell<&'_#11r u32>, which makes the generic argument &'_#11r u32 invariant
    = note: the struct Cell<T> is invariant over the parameter T
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 

--- a/src/test/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-wrong-bound.stderr
+++ b/src/test/ui/nll/closure-requirements/propagate-approximated-shorter-to-static-wrong-bound.stderr
@@ -52,7 +52,7 @@ LL | |     });
    | |______`cell_a` escapes the function body here
    |        argument requires that `'a` must outlive `'static`
    |
-   = note: requirement occurs because of the type Cell<&'_#11r u32>, which makes the generic argument &'_#11r u32 invariant
+   = note: requirement occurs because of the type Cell<&'_#12r u32>, which makes the generic argument &'_#12r u32 invariant
    = note: the struct Cell<T> is invariant over the parameter T
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 

--- a/src/test/ui/regions/empty-where-clause.rs
+++ b/src/test/ui/regions/empty-where-clause.rs
@@ -1,0 +1,7 @@
+// check-pass
+
+pub struct Bar
+where
+    for<'a> &'a mut Self:;
+
+fn main() {}


### PR DESCRIPTION
Another bad idea I came up with in https://github.com/rust-lang/rust/pull/95231#issuecomment-1076842195. 

I will also probably also will test what adding a `WellFormed` predicate does as the trivial predicate for things like `where Ty:,`.

r? @jackh726 (or feel free to reassign, perhaps to Niko?)