### PR TITLE
Fix inaccurate function name in `rustc_const_eval` docs

### DIFF
--- a/compiler/rustc_const_eval/src/interpret/operand.rs
+++ b/compiler/rustc_const_eval/src/interpret/operand.rs
@@ -520,8 +520,8 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
         Ok(OpTy { op, layout: place.layout })
     }
 
-    // Evaluate a place with the goal of reading from it.  This lets us sometimes
-    // avoid allocations.
+    /// Evaluate a place with the goal of reading from it.  This lets us sometimes
+    /// avoid allocations.
     pub fn eval_place_to_op(
         &self,
         place: mir::Place<'tcx>,

--- a/compiler/rustc_const_eval/src/interpret/place.rs
+++ b/compiler/rustc_const_eval/src/interpret/place.rs
@@ -625,7 +625,7 @@ where
     }
 
     /// Computes a place. You should only use this if you intend to write into this
-    /// place; for reading, a more efficient alternative is `eval_place_for_read`.
+    /// place; for reading, a more efficient alternative is `eval_place_to_op`.
     #[instrument(skip(self), level = "debug")]
     pub fn eval_place(
         &mut self,


### PR DESCRIPTION
Looks to me like this fixes #85513. I had trouble making a intra-docs link to `eval_place_to_op` work, though...