### PR TITLE
Document that `OsString` and `OsStr` are bytes; provide conversions to bytes

### DIFF
--- a/compiler/rustc_codegen_cranelift/src/debuginfo/line_info.rs
+++ b/compiler/rustc_codegen_cranelift/src/debuginfo/line_info.rs
@@ -39,7 +39,7 @@ fn osstr_as_utf8_bytes(path: &OsStr) -> &[u8] {
     #[cfg(unix)]
     {
         use std::os::unix::ffi::OsStrExt;
-        path.as_bytes()
+        OsStrExt::as_bytes(path)
     }
     #[cfg(not(unix))]
     {

--- a/compiler/rustc_fs_util/src/lib.rs
+++ b/compiler/rustc_fs_util/src/lib.rs
@@ -82,7 +82,7 @@ pub fn path_to_c_string(p: &Path) -> CString {
     use std::ffi::OsStr;
     use std::os::unix::ffi::OsStrExt;
     let p: &OsStr = p.as_ref();
-    CString::new(p.as_bytes()).unwrap()
+    CString::new(OsStrExt::as_bytes(p)).unwrap()
 }
 #[cfg(windows)]
 pub fn path_to_c_string(p: &Path) -> CString {

--- a/library/std/src/ffi/mod.rs
+++ b/library/std/src/ffi/mod.rs
@@ -90,7 +90,8 @@
 //! exists you will get a <code>[Some]\(os_string)</code>, which you can
 //! *then* try to convert to a Rust string. This yields a [`Result`], so that
 //! your code can detect errors in case the environment variable did
-//! not in fact contain valid Unicode data.
+//! not in fact contain valid Unicode data. You can also process the `OsString` directly, such as
+//! by using it as a filename.
 //!
 //! * [`OsStr`] losslessly represents a borrowed reference to a platform string.
 //! However, this representation is not necessarily in a form native to the platform.
@@ -99,17 +100,28 @@
 //!
 //! # Conversions
 //!
+//! ## On all platforms
+//!
+//! On all platforms, `OsStr` and `OsString` consist of a sequence of bytes; see [`OsString`] for
+//! more details on its encoding on different platforms.
+//!
+//! `OsStr` provides the method [`OsStr::as_bytes`], which provides a zero-cost conversion to a
+//! byte slice. (`OsString` provides this method as well, along with all other `OsStr` methods, via
+//! `Deref`.)
+//!
+//! `OsString` provides the method [`OsString::into_vec`], which provides a zero-cost conversion to
+//! `Vec<u8>`.
+//!
 //! ## On Unix
 //!
 //! On Unix, [`OsStr`] implements the
 //! <code>std::os::unix::ffi::[OsStrExt][unix.OsStrExt]</code> trait, which
-//! augments it with two methods, [`from_bytes`] and [`as_bytes`].
-//! These do inexpensive conversions from and to UTF-8 byte slices.
+//! augments it with an additional method [`from_bytes`], providing a zero-cost conversion from a
+//! byte slice.
 //!
 //! Additionally, on Unix [`OsString`] implements the
-//! <code>std::os::unix::ffi::[OsStringExt][unix.OsStringExt]</code> trait,
-//! which provides [`from_vec`] and [`into_vec`] methods that consume
-//! their arguments, and take or produce vectors of [`u8`].
+//! <code>std::os::unix::ffi::[OsStringExt][unix.OsStringExt]</code> trait, which provides the
+//! [`from_vec`] method that consumes a `Vec<u8>` and produces an `OsString`.
 //!
 //! ## On Windows
 //!
@@ -119,8 +131,8 @@
 //! On Windows, [`OsStr`] implements the
 //! <code>std::os::windows::ffi::[OsStrExt][windows.OsStrExt]</code> trait,
 //! which provides an [`encode_wide`] method. This provides an
-//! iterator that can be [`collect`]ed into a vector of [`u16`]. After a nul
-//! characters is appended, this is the same as a native Windows string.
+//! iterator that can be [`collect`]ed into a vector of [`u16`]. After a 16-bit nul
+//! character is appended, this is the same as a native Windows string.
 //!
 //! Additionally, on Windows [`OsString`] implements the
 //! <code>std::os::windows:ffi::[OsStringExt][windows.OsStringExt]</code>
@@ -133,10 +145,8 @@
 //! [`env::var_os()`]: crate::env::var_os "env::var_os"
 //! [unix.OsStringExt]: crate::os::unix::ffi::OsStringExt "os::unix::ffi::OsStringExt"
 //! [`from_vec`]: crate::os::unix::ffi::OsStringExt::from_vec "os::unix::ffi::OsStringExt::from_vec"
-//! [`into_vec`]: crate::os::unix::ffi::OsStringExt::into_vec "os::unix::ffi::OsStringExt::into_vec"
 //! [unix.OsStrExt]: crate::os::unix::ffi::OsStrExt "os::unix::ffi::OsStrExt"
 //! [`from_bytes`]: crate::os::unix::ffi::OsStrExt::from_bytes "os::unix::ffi::OsStrExt::from_bytes"
-//! [`as_bytes`]: crate::os::unix::ffi::OsStrExt::as_bytes "os::unix::ffi::OsStrExt::as_bytes"
 //! [`OsStrExt`]: crate::os::unix::ffi::OsStrExt "os::unix::ffi::OsStrExt"
 //! [windows.OsStrExt]: crate::os::windows::ffi::OsStrExt "os::windows::ffi::OsStrExt"
 //! [`encode_wide`]: crate::os::windows::ffi::OsStrExt::encode_wide "os::windows::ffi::OsStrExt::encode_wide"

--- a/library/std/src/ffi/mod.rs
+++ b/library/std/src/ffi/mod.rs
@@ -105,11 +105,11 @@
 //! On all platforms, `OsStr` and `OsString` consist of a sequence of bytes; see [`OsString`] for
 //! more details on its encoding on different platforms.
 //!
-//! `OsStr` provides the method [`OsStr::as_bytes`], which provides a zero-cost conversion to a
-//! byte slice. (`OsString` provides this method as well, along with all other `OsStr` methods, via
+//! `OsStr` provides the method `OsStr::as_bytes`, which provides a zero-cost conversion to a byte
+//! slice. (`OsString` provides this method as well, along with all other `OsStr` methods, via
 //! `Deref`.)
 //!
-//! `OsString` provides the method [`OsString::into_vec`], which provides a zero-cost conversion to
+//! `OsString` provides the method `OsString::into_vec`, which provides a zero-cost conversion to
 //! `Vec<u8>`.
 //!
 //! ## On Unix

--- a/library/std/src/ffi/os_str.rs
+++ b/library/std/src/ffi/os_str.rs
@@ -72,11 +72,11 @@ use crate::sys_common::{AsInner, FromInner, IntoInner};
 ///
 /// # Conversions
 ///
-/// `OsStr` provides the method [`OsStr::as_bytes`], which provides a zero-cost conversion to a
-/// byte slice. (`OsString` provides this method as well, along with all other `OsStr` methods, via
+/// `OsStr` provides the method `OsStr::as_bytes`, which provides a zero-cost conversion to a byte
+/// slice. (`OsString` provides this method as well, along with all other `OsStr` methods, via
 /// `Deref`.)
 ///
-/// `OsString` provides the method [`OsString::into_vec`], which provides a zero-cost conversion to
+/// `OsString` provides the method `OsString::into_vec`, which provides a zero-cost conversion to
 /// `Vec<u8>`.
 ///
 /// See the [module's toplevel documentation about conversions][conversions] for a discussion on

--- a/library/std/src/os/unix/ffi/mod.rs
+++ b/library/std/src/os/unix/ffi/mod.rs
@@ -11,10 +11,6 @@
 //! // OsStringExt::from_vec
 //! let os_string = OsString::from_vec(bytes);
 //! assert_eq!(os_string.to_str(), Some("foo"));
-//!
-//! // OsStringExt::into_vec
-//! let bytes = os_string.into_vec();
-//! assert_eq!(bytes, b"foo");
 //! ```
 //!
 //! ```
@@ -26,10 +22,6 @@
 //! // OsStrExt::from_bytes
 //! let os_str = OsStr::from_bytes(bytes);
 //! assert_eq!(os_str.to_str(), Some("foo"));
-//!
-//! // OsStrExt::as_bytes
-//! let bytes = os_str.as_bytes();
-//! assert_eq!(bytes, b"foo");
 //! ```
 //!
 //! [`std::ffi`]: crate::ffi

--- a/library/std/src/sys/unix/os_str.rs
+++ b/library/std/src/sys/unix/os_str.rs
@@ -182,12 +182,22 @@ impl Buf {
     pub fn into_rc(&self) -> Rc<Slice> {
         self.as_slice().into_rc()
     }
+
+    #[inline]
+    pub fn into_vec(self) -> Vec<u8> {
+        self.inner
+    }
 }
 
 impl Slice {
     #[inline]
     fn from_u8_slice(s: &[u8]) -> &Slice {
         unsafe { mem::transmute(s) }
+    }
+
+    #[inline]
+    pub fn as_u8_slice(&self) -> &[u8] {
+        unsafe { mem::transmute(self) }
     }
 
     #[inline]

--- a/library/std/src/sys/windows/os_str.rs
+++ b/library/std/src/sys/windows/os_str.rs
@@ -146,6 +146,11 @@ impl Buf {
     pub fn into_rc(&self) -> Rc<Slice> {
         self.as_slice().into_rc()
     }
+
+    #[inline]
+    pub fn into_vec(self) -> Vec<u8> {
+        self.inner.into_vec()
+    }
 }
 
 impl Slice {
@@ -191,6 +196,11 @@ impl Slice {
     pub fn into_rc(&self) -> Rc<Slice> {
         let rc = self.inner.into_rc();
         unsafe { Rc::from_raw(Rc::into_raw(rc) as *const Slice) }
+    }
+
+    #[inline]
+    pub fn as_u8_slice(&self) -> &[u8] {
+        self.inner.as_inner()
     }
 
     #[inline]

--- a/library/std/src/sys_common/wtf8.rs
+++ b/library/std/src/sys_common/wtf8.rs
@@ -3,13 +3,6 @@
 //! This library uses Rust’s type system to maintain
 //! [well-formedness](https://simonsapin.github.io/wtf-8/#well-formed),
 //! like the `String` and `&str` types do for UTF-8.
-//!
-//! Since [WTF-8 must not be used
-//! for interchange](https://simonsapin.github.io/wtf-8/#intended-audience),
-//! this library deliberately does not provide access to the underlying bytes
-//! of WTF-8 strings,
-//! nor can it decode WTF-8 from arbitrary bytes.
-//! WTF-8 strings can be obtained from UTF-8, UTF-16, or code points.
 
 // this module is imported from @SimonSapin's repo and has tons of dead code on
 // unix (it's mostly used on windows), so don't worry about dead code here.
@@ -398,6 +391,12 @@ impl Wtf8Buf {
     pub fn from_box(boxed: Box<Wtf8>) -> Wtf8Buf {
         let bytes: Box<[u8]> = unsafe { mem::transmute(boxed) };
         Wtf8Buf { bytes: bytes.into_vec() }
+    }
+
+    /// Converts this `Wtf8Buf` into a `Vec<u8>`.
+    #[inline]
+    pub fn into_vec(self) -> Vec<u8> {
+        self.bytes
     }
 }
 

--- a/src/test/ui/env-funky-keys.rs
+++ b/src/test/ui/env-funky-keys.rs
@@ -9,6 +9,7 @@
 // no-prefer-dynamic
 
 #![feature(rustc_private)]
+#![feature(osstr_bytes)]
 
 extern crate libc;
 
@@ -16,7 +17,6 @@ use libc::c_char;
 use libc::execve;
 use std::env;
 use std::ffi::CString;
-use std::os::unix::prelude::*;
 use std::ptr;
 
 fn main() {


### PR DESCRIPTION
The `OsString` and `OsStr` types are wrappers around bytes, and are *required* by existing stable APIs to be byte-based encodings that are supersets of UTF-8 (since a `&str` can become an `&OsStr` without allocation). However, both types are opaque, and do not provide access to raw bytes, primarily because on Windows they use the WTF-8 encoding, the standard for which recommends against exposing it.

Nonetheless, many crates *do* rely on `OsStr` and `OsString` being bytes. We already provide the `OsStrExt` and `OsStringExt` extension traits, [which get used reasonably widely](https://cs.github.com/?scopeName=All+repos&scope=&q=language%3Arust+%2Fuse+std%3A%3Aos%3A%3Aunix.*OsStrExt%2F) despite being non-portable. And the [`os_str_bytes`](https://crates.io/crates/os_str_bytes) crate has millions of downloads, and tens of thousands of new downloads everyday.

This PR is an effort to seek consensus for making the contents of an `OsStr` or `OsString` available as bytes, inspired by recent discussions within the libs-api team.

This is a *minimal* PR to acheive that goal. This PR consists almost entirely of documentation, updating the module documentation in `std::ffi` and the type documentation on `OsString`. This PR only adds two methods: `OsStr::as_bytes` and `OsString::into_vec`, and plumbs those methods down to the existing implementations for both UNIX and Windows. Both methods are unstable (and I'll file a tracking issue for them as soon as I take this PR out of draft status).

In particular, this PR does *not* add any new `From` or `TryFrom` or `Into` or `TryInto` impls, nor does it add methods to construct `OsStr` or `OsString` from bytes (which would require error handling), nor does it attempt to do any further unification of implementations between Windows and UNIX, nor does it extend these types to have more of the functionality of [bstr](https://docs.rs/bstr/latest/bstr/). All of those things could happen in potential future changes, and I'd be happy to make some of those changes myself, but I'd like to focus on the initial consensus for making the change before further work that depends on the change.

As one further note of the implications of this change: there has been a proposal to change OsStr/OsString on Windows from WTF-8 to a more complex encoding that can potentially speed up matching for use with the Pattern API. Since that proposal, we've decided to seal the Pattern API and avoid stabilizing it. I would propose that we not switch the encoding of OsStr/OsString, and proceed with exposing bytes using the current encoding. Another option would be to expose bytes but not specify the exact encoding beyond "superset of UTF-8".

r? @ghost