### PR TITLE
Reduce the amount of unstable features used in libproc_macro

### DIFF
--- a/library/proc_macro/src/bridge/client.rs
+++ b/library/proc_macro/src/bridge/client.rs
@@ -310,7 +310,8 @@ impl Bridge<'_> {
         // NB. the server can't do this because it may use a different libstd.
         static HIDE_PANICS_DURING_EXPANSION: Once = Once::new();
         HIDE_PANICS_DURING_EXPANSION.call_once(|| {
-            panic::update_hook(move |prev, info| {
+            let prev = panic::take_hook();
+            panic::set_hook(Box::new(move |info| {
                 let show = BridgeState::with(|state| match state {
                     BridgeState::NotConnected => true,
                     BridgeState::Connected(_) | BridgeState::InUse => force_show_panics,
@@ -318,7 +319,7 @@ impl Bridge<'_> {
                 if show {
                     prev(info)
                 }
-            });
+            }));
         });
 
         BRIDGE_STATE.with(|state| state.set(BridgeState::Connected(self), f))

--- a/library/proc_macro/src/bridge/closure.rs
+++ b/library/proc_macro/src/bridge/closure.rs
@@ -6,13 +6,11 @@ use std::marker::PhantomData;
 pub struct Closure<'a, A, R> {
     call: unsafe extern "C" fn(*mut Env, A) -> R,
     env: *mut Env,
-    _marker: PhantomData<&'a mut ()>,
+    // Ensure Closure is !Send and !Sync
+    _marker: PhantomData<*mut &'a mut ()>,
 }
 
 struct Env;
-
-impl<'a, A, R> !Sync for Closure<'a, A, R> {}
-impl<'a, A, R> !Send for Closure<'a, A, R> {}
 
 impl<'a, A, R, F: FnMut(A) -> R> From<&'a mut F> for Closure<'a, A, R> {
     fn from(f: &'a mut F) -> Self {

--- a/library/proc_macro/src/bridge/closure.rs
+++ b/library/proc_macro/src/bridge/closure.rs
@@ -1,24 +1,25 @@
 //! Closure type (equivalent to `&mut dyn FnMut(A) -> R`) that's `repr(C)`.
 
+use std::marker::PhantomData;
+
 #[repr(C)]
 pub struct Closure<'a, A, R> {
-    call: unsafe extern "C" fn(&mut Env, A) -> R,
-    env: &'a mut Env,
+    call: unsafe extern "C" fn(*mut Env, A) -> R,
+    env: *mut Env,
+    _marker: PhantomData<&'a mut ()>,
 }
 
-extern "C" {
-    type Env;
-}
+struct Env;
 
 impl<'a, A, R> !Sync for Closure<'a, A, R> {}
 impl<'a, A, R> !Send for Closure<'a, A, R> {}
 
 impl<'a, A, R, F: FnMut(A) -> R> From<&'a mut F> for Closure<'a, A, R> {
     fn from(f: &'a mut F) -> Self {
-        unsafe extern "C" fn call<A, R, F: FnMut(A) -> R>(env: &mut Env, arg: A) -> R {
+        unsafe extern "C" fn call<A, R, F: FnMut(A) -> R>(env: *mut Env, arg: A) -> R {
             (*(env as *mut _ as *mut F))(arg)
         }
-        Closure { call: call::<A, R, F>, env: unsafe { &mut *(f as *mut _ as *mut Env) } }
+        Closure { call: call::<A, R, F>, env: f as *mut _ as *mut Env, _marker: PhantomData }
     }
 }
 

--- a/library/proc_macro/src/bridge/mod.rs
+++ b/library/proc_macro/src/bridge/mod.rs
@@ -220,6 +220,8 @@ use rpc::{Decode, DecodeMut, Encode, Reader, Writer};
 /// then passes it to the client through the function pointer in the `run`
 /// field of `client::Client`. The client holds its copy of the `Bridge`
 /// in TLS during its execution (`Bridge::{enter, with}` in `client.rs`).
+// Note: Bridge is !Send and !Sync due to containg a `Closure`. If this
+// ever changes, make sure to preserve the !Send and !Sync property.
 #[repr(C)]
 pub struct Bridge<'a> {
     /// Reusable buffer (only `clear`-ed, never shrunk), primarily
@@ -232,9 +234,6 @@ pub struct Bridge<'a> {
     /// If 'true', always invoke the default panic hook
     force_show_panics: bool,
 }
-
-impl<'a> !Sync for Bridge<'a> {}
-impl<'a> !Send for Bridge<'a> {}
 
 #[forbid(unsafe_code)]
 #[allow(non_camel_case_types)]

--- a/library/proc_macro/src/bridge/mod.rs
+++ b/library/proc_macro/src/bridge/mod.rs
@@ -220,8 +220,6 @@ use rpc::{Decode, DecodeMut, Encode, Reader, Writer};
 /// then passes it to the client through the function pointer in the `run`
 /// field of `client::Client`. The client holds its copy of the `Bridge`
 /// in TLS during its execution (`Bridge::{enter, with}` in `client.rs`).
-// Note: Bridge is !Send and !Sync due to containg a `Closure`. If this
-// ever changes, make sure to preserve the !Send and !Sync property.
 #[repr(C)]
 pub struct Bridge<'a> {
     /// Reusable buffer (only `clear`-ed, never shrunk), primarily
@@ -233,6 +231,9 @@ pub struct Bridge<'a> {
 
     /// If 'true', always invoke the default panic hook
     force_show_panics: bool,
+
+    // Prevent Send and Sync impls
+    _marker: marker::PhantomData<*mut ()>,
 }
 
 #[forbid(unsafe_code)]

--- a/library/proc_macro/src/bridge/server.rs
+++ b/library/proc_macro/src/bridge/server.rs
@@ -153,7 +153,12 @@ impl ExecutionStrategy for SameThread {
         let mut dispatch = |b| dispatcher.dispatch(b);
 
         run_client(
-            Bridge { cached_buffer: input, dispatch: (&mut dispatch).into(), force_show_panics },
+            Bridge {
+                cached_buffer: input,
+                dispatch: (&mut dispatch).into(),
+                force_show_panics,
+                _marker: marker::PhantomData,
+            },
             client_data,
         )
     }
@@ -189,6 +194,7 @@ impl ExecutionStrategy for CrossThread1 {
                     cached_buffer: input,
                     dispatch: (&mut dispatch).into(),
                     force_show_panics,
+                    _marker: marker::PhantomData,
                 },
                 client_data,
             )
@@ -241,6 +247,7 @@ impl ExecutionStrategy for CrossThread2 {
                     cached_buffer: input,
                     dispatch: (&mut dispatch).into(),
                     force_show_panics,
+                    _marker: marker::PhantomData,
                 },
                 client_data,
             );

--- a/library/proc_macro/src/lib.rs
+++ b/library/proc_macro/src/lib.rs
@@ -24,7 +24,6 @@
 #![cfg_attr(bootstrap, feature(const_fn_fn_ptr_basics))]
 #![feature(allow_internal_unstable)]
 #![feature(decl_macro)]
-#![feature(extern_types)]
 #![feature(negative_impls)]
 #![feature(restricted_std)]
 #![feature(rustc_attrs)]

--- a/library/proc_macro/src/lib.rs
+++ b/library/proc_macro/src/lib.rs
@@ -29,7 +29,6 @@
 #![feature(restricted_std)]
 #![feature(rustc_attrs)]
 #![feature(min_specialization)]
-#![feature(panic_update_hook)]
 #![recursion_limit = "256"]
 
 #[unstable(feature = "proc_macro_internals", issue = "27812")]

--- a/library/proc_macro/src/lib.rs
+++ b/library/proc_macro/src/lib.rs
@@ -26,7 +26,6 @@
 #![feature(decl_macro)]
 #![feature(extern_types)]
 #![feature(negative_impls)]
-#![feature(auto_traits)]
 #![feature(restricted_std)]
 #![feature(rustc_attrs)]
 #![feature(min_specialization)]

--- a/library/proc_macro/src/lib.rs
+++ b/library/proc_macro/src/lib.rs
@@ -17,6 +17,9 @@
     test(no_crate_inject, attr(deny(warnings))),
     test(attr(allow(dead_code, deprecated, unused_variables, unused_mut)))
 )]
+// This library is copied into rust-analyzer to allow loading rustc compiled proc macros.
+// Please avoid unstable features where possible to minimize the amount of changes necessary
+// to make it compile with rust-analyzer on stable.
 #![feature(rustc_allow_const_fn_unstable)]
 #![feature(nll)]
 #![feature(staged_api)]


### PR DESCRIPTION
This makes it easier to adapt the source for stable when copying it into rust-analyzer to load rustc compiled proc macros.