### PR TITLE
Ensure that `'_` and GAT yields errors

### DIFF
--- a/src/test/ui/generic-associated-types/issue-95305.rs
+++ b/src/test/ui/generic-associated-types/issue-95305.rs
@@ -1,0 +1,17 @@
+// It's not yet clear how '_ and GATs should interact.
+// Forbid it for now but proper support might be added
+// at some point in the future.
+
+#![feature(generic_associated_types)]
+
+trait Foo {
+    type Item<'a>;
+}
+
+fn foo(x: &impl Foo<Item<'_> = u32>) { }
+                       //~^ ERROR missing lifetime specifier
+
+fn bar(x: &impl for<'a> Foo<Item<'a> = &'_ u32>) { }
+                                      //~^ ERROR missing lifetime specifier
+
+fn main() {}

--- a/src/test/ui/generic-associated-types/issue-95305.stderr
+++ b/src/test/ui/generic-associated-types/issue-95305.stderr
@@ -1,0 +1,25 @@
+error[E0106]: missing lifetime specifier
+  --> $DIR/issue-95305.rs:11:26
+   |
+LL | fn foo(x: &impl Foo<Item<'_> = u32>) { }
+   |                          ^^ expected named lifetime parameter
+   |
+help: consider introducing a named lifetime parameter
+   |
+LL | fn foo<'a>(x: &impl Foo<Item<'a> = u32>) { }
+   |       ++++                   ~~
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/issue-95305.rs:14:41
+   |
+LL | fn bar(x: &impl for<'a> Foo<Item<'a> = &'_ u32>) { }
+   |                                         ^^ expected named lifetime parameter
+   |
+help: consider using the `'a` lifetime
+   |
+LL | fn bar(x: &impl for<'a> Foo<Item<'a> = &'a u32>) { }
+   |                                         ~~
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0106`.


### PR DESCRIPTION
Fixes #95305 

@bors r? @jackh726 