### PR TITLE
when checking pointee metadata, canonicalize the `Sized` check

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/project.rs
+++ b/compiler/rustc_trait_selection/src/traits/project.rs
@@ -19,6 +19,7 @@ use super::{Normalized, NormalizedTy, ProjectionCacheEntry, ProjectionCacheKey};
 use crate::infer::type_variable::{TypeVariableOrigin, TypeVariableOriginKind};
 use crate::infer::{InferCtxt, InferOk, LateBoundRegionConversionTime};
 use crate::traits::error_reporting::InferCtxtExt as _;
+use crate::traits::query::evaluate_obligation::InferCtxtExt as _;
 use crate::traits::select::ProjectionMatchesProjection;
 use rustc_data_structures::sso::SsoHashSet;
 use rustc_data_structures::stack::ensure_sufficient_stack;
@@ -1515,7 +1516,16 @@ fn assemble_candidates_from_impls<'cx, 'tcx>(
                     // type parameters, opaques, and unnormalized projections have pointer
                     // metadata if they're known (e.g. by the param_env) to be sized
                     ty::Param(_) | ty::Projection(..) | ty::Opaque(..)
-                        if tail.is_sized(selcx.tcx().at(obligation.cause.span), obligation.param_env) =>
+                        if selcx.infcx().predicate_must_hold_modulo_regions(
+                            &obligation.with(
+                                ty::Binder::dummy(ty::TraitRef::new(
+                                    selcx.tcx().require_lang_item(LangItem::Sized, None),
+                                    selcx.tcx().mk_substs_trait(self_ty, &[]),
+                                ))
+                                .without_const()
+                                .to_predicate(selcx.tcx()),
+                            ),
+                        ) =>
                     {
                         true
                     }

--- a/src/test/ui/traits/issue-95311.rs
+++ b/src/test/ui/traits/issue-95311.rs
@@ -1,0 +1,19 @@
+// check-pass
+
+// Test to check that pointee trait doesn't let region variables escape into the cache
+
+#![feature(ptr_metadata)]
+
+trait Bar: Sized + 'static {}
+
+struct Foo<B: Bar> {
+    marker: std::marker::PhantomData<B>,
+}
+
+impl<B: Bar> Foo<B> {
+    fn foo<T: ?Sized>(value: &T) {
+        std::ptr::metadata(value);
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
Use `infcx.predicate_must_hold_modulo_regions` with a `Sized` obligation instead of just calling `ty.is_sized`, because the latter does not canonicalize region and type vars (and in the test case I added in this PR, there's a region var in the `ParamEnv`).

Fixes #95311