### PR TITLE
Fix yet another Box<T, A> ICE

### DIFF
--- a/compiler/rustc_codegen_ssa/src/mir/place.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/place.rs
@@ -455,7 +455,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
             cg_base = match elem.clone() {
                 mir::ProjectionElem::Deref => {
                     // a box with a non-zst allocator should not be directly dereferenced
-                    if cg_base.layout.ty.is_box() && !cg_base.layout.field(cx, 0).is_zst() {
+                    if cg_base.layout.ty.is_box() && !cg_base.layout.field(cx, 1).is_zst() {
                         let ptr = cg_base.project_field(bx, 0).project_field(bx, 0);
 
                         bx.load_operand(ptr).deref(bx.cx())

--- a/src/test/ui/box/issue-95036.rs
+++ b/src/test/ui/box/issue-95036.rs
@@ -1,5 +1,5 @@
 // compile-flags: -O
-// compile-pass
+// build-pass
 
 #![feature(allocator_api, bench_black_box)]
 

--- a/src/test/ui/box/issue-95036.rs
+++ b/src/test/ui/box/issue-95036.rs
@@ -3,8 +3,20 @@
 
 #![feature(allocator_api, bench_black_box)]
 
+#[inline(never)]
+pub fn by_ref(node: &mut Box<[u8; 1], &std::alloc::Global>) {
+    node[0] = 9u8;
+}
+
 pub fn main() {
     let mut node = Box::new_in([5u8], &std::alloc::Global);
     node[0] = 7u8;
+
+    std::hint::black_box(node);
+
+    let mut node = Box::new_in([5u8], &std::alloc::Global);
+
+    by_ref(&mut node);
+
     std::hint::black_box(node);
 }

--- a/src/test/ui/box/issue-95036.rs
+++ b/src/test/ui/box/issue-95036.rs
@@ -1,0 +1,10 @@
+// compile-flags: -O
+// compile-pass
+
+#![feature(allocator_api, bench_black_box)]
+
+pub fn main() {
+    let mut node = Box::new_in([5u8], &std::alloc::Global);
+    node[0] = 7u8;
+    std::hint::black_box(node);
+}


### PR DESCRIPTION
Fixes #95036.

This widens the special case from #94414 to make sure that boxes with a custom allocator are never directly dereferenced.