### PR TITLE
rustdoc: Fix resolution of `crate`-relative paths in doc links

### DIFF
--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -3285,12 +3285,21 @@ impl<'a> Resolver<'a> {
         &mut self,
         path_str: &str,
         ns: Namespace,
-        module_id: DefId,
+        mut module_id: DefId,
     ) -> Option<Res> {
         let mut segments =
             Vec::from_iter(path_str.split("::").map(Ident::from_str).map(Segment::from_ident));
-        if path_str.starts_with("::") {
-            segments[0].ident.name = kw::PathRoot;
+        if let Some(segment) = segments.first_mut() {
+            if segment.ident.name == kw::Crate {
+                // FIXME: `resolve_path` always resolves `crate` to the current crate root, but
+                // rustdoc wants it to resolve to the `module_id`'s crate root. This trick of
+                // replacing `crate` with `self` and changing the current module should achieve
+                // the same effect.
+                segment.ident.name = kw::SelfLower;
+                module_id = module_id.krate.as_def_id();
+            } else if segment.ident.name == kw::Empty {
+                segment.ident.name = kw::PathRoot;
+            }
         }
 
         let module = self.expect_module(module_id);

--- a/src/librustdoc/passes/collect_intra_doc_links/early.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links/early.rs
@@ -32,11 +32,6 @@ crate fn early_resolve_intra_doc_links(
         all_trait_impls: Default::default(),
     };
 
-    // Because of the `crate::` prefix, any doc comment can reference
-    // the crate root's set of in-scope traits. This line makes sure
-    // it's available.
-    loader.add_traits_in_scope(CRATE_DEF_ID.to_def_id());
-
     // Overridden `visit_item` below doesn't apply to the crate root,
     // so we have to visit its attributes and reexports separately.
     loader.load_links_in_attrs(&krate.attrs);
@@ -105,9 +100,6 @@ impl IntraLinkCrateLoader<'_, '_> {
     /// having impls in them.
     fn add_foreign_traits_in_scope(&mut self) {
         for cnum in Vec::from_iter(self.resolver.cstore().crates_untracked()) {
-            // FIXME: Due to #78696 rustdoc can query traits in scope for any crate root.
-            self.add_traits_in_scope(cnum.as_def_id());
-
             let all_traits = Vec::from_iter(self.resolver.cstore().traits_in_crate_untracked(cnum));
             let all_trait_impls =
                 Vec::from_iter(self.resolver.cstore().trait_impls_in_crate_untracked(cnum));

--- a/src/test/rustdoc-ui/intra-doc/crate-nonexistent.rs
+++ b/src/test/rustdoc-ui/intra-doc/crate-nonexistent.rs
@@ -1,0 +1,5 @@
+#![deny(rustdoc::broken_intra_doc_links)]
+
+/// [crate::DoesNotExist]
+//~^ ERROR unresolved link to `crate::DoesNotExist`
+pub struct Item;

--- a/src/test/rustdoc-ui/intra-doc/crate-nonexistent.stderr
+++ b/src/test/rustdoc-ui/intra-doc/crate-nonexistent.stderr
@@ -1,0 +1,14 @@
+error: unresolved link to `crate::DoesNotExist`
+  --> $DIR/crate-nonexistent.rs:3:6
+   |
+LL | /// [crate::DoesNotExist]
+   |      ^^^^^^^^^^^^^^^^^^^ no item named `DoesNotExist` in module `crate_nonexistent`
+   |
+note: the lint level is defined here
+  --> $DIR/crate-nonexistent.rs:1:9
+   |
+LL | #![deny(rustdoc::broken_intra_doc_links)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+

--- a/src/test/rustdoc/intra-doc/crate-relative-assoc.rs
+++ b/src/test/rustdoc/intra-doc/crate-relative-assoc.rs
@@ -1,0 +1,17 @@
+pub mod io {
+    pub trait Read {
+        fn read(&mut self);
+    }
+}
+
+pub mod bufreader {
+    // @has crate_relative_assoc/bufreader/index.html '//a/@href' 'struct.TcpStream.html#method.read'
+    //! [`crate::TcpStream::read`]
+    use crate::io::Read;
+}
+
+pub struct TcpStream;
+
+impl crate::io::Read for TcpStream {
+    fn read(&mut self) {}
+}


### PR DESCRIPTION
Resolve `crate::foo` paths transparently to rustdoc, so their resolution no longer affects diagnostics and modules used for determining traits in scope.

The proper solution is to account for the current `module_id`/`parent_scope` in `fn resolve_crate_root`, but it's a slightly larger compiler changes. This PR moves the code closer to it, but keeps it rustdoc-specific.

Fixes https://github.com/rust-lang/rust/issues/78696
Fixes https://github.com/rust-lang/rust/issues/94924