### PR TITLE
Ignore "format the world" commit in git blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,6 @@
+# format the world
+a06baa56b95674fc626b3c3fd680d6a65357fe60
+# format libcore
+95e00bfed801e264e9c4ac817004153ca0f19eb6
+# reformat with new rustfmt
+971c549ca334b7b7406e61e958efcca9c4152822


### PR DESCRIPTION
This tells github to hide it in its blame view: https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view
It can also be used locally by running `git config blame.ignorerevsfile .git-blame-ignore-revs` (although it's advised to avoid `--global` since git gives a hard error when the file doesn't exist).

We may want to add more commits in later PRs, but this should be a good start.

Before: ![image](https://user-images.githubusercontent.com/23638587/160255130-d7283cc4-4d33-4a7d-bc70-f9ce6820293c.png)
After: ![image](https://user-images.githubusercontent.com/23638587/160255138-90d0325a-e063-4e0e-8cfb-732724bf6c60.png)
cc https://rust-lang.zulipchat.com/#narrow/stream/122651-general/topic/Hide.20some.20commits.20in.20GitHub.20blame