### PR TITLE
[bootstrap] Print the full relative path to failed tests

### DIFF
--- a/src/tools/compiletest/src/main.rs
+++ b/src/tools/compiletest/src/main.rs
@@ -744,12 +744,10 @@ fn make_test_name(
     testpaths: &TestPaths,
     revision: Option<&String>,
 ) -> test::TestName {
-    // Convert a complete path to something like
-    //
-    //    ui/foo/bar/baz.rs
-    let path = PathBuf::from(config.src_base.file_name().unwrap())
-        .join(&testpaths.relative_dir)
-        .join(&testpaths.file.file_name().unwrap());
+    // Print the name of the file, relative to the repository root.
+    // `src_base` looks like `/path/to/rust/src/test/ui`
+    let root_directory = config.src_base.parent().unwrap().parent().unwrap().parent().unwrap();
+    let path = testpaths.file.strip_prefix(root_directory).unwrap();
     let debugger = match config.debugger {
         Some(d) => format!("-{}", d),
         None => String::new(),


### PR DESCRIPTION
Before:
```
failures:
    [ui] rustdoc-ui/intra-doc/feature-gate-intra-doc-pointers.rs

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 163 filtered out; finished in 0.45s
```

After:
```
failures:
    [ui] src/test/rustdoc-ui/intra-doc/feature-gate-intra-doc-pointers.rs

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 163 filtered out; finished in 0.45s
```

This allows copy pasting the path or using Ctrl+Click in IDEs to go directly to the file, instead of having to edit the filename first.