### PR TITLE
[bootstrap] Give a hard error when filtering tests for a file that does not exist

### DIFF
--- a/src/bootstrap/util.rs
+++ b/src/bootstrap/util.rs
@@ -308,10 +308,10 @@ pub fn is_valid_test_suite_arg<'a, P: AsRef<Path>>(
     let abs_path = builder.src.join(path);
     let exists = abs_path.is_dir() || abs_path.is_file();
     if !exists {
-        if let Some(p) = abs_path.to_str() {
-            builder.info(&format!("Warning: Skipping \"{}\": not a regular file or directory", p));
-        }
-        return None;
+        panic!(
+            "Invalid test suite filter \"{}\": file or directory does not exist",
+            abs_path.display()
+        );
     }
     // Since test suite paths are themselves directories, if we don't
     // specify a directory or file, we'll get an empty string here


### PR DESCRIPTION
A common issue people run into when running compiletest is that filtering for files that don't exist is only a warning and not an error; running the whole test suite instead.
See for example https://rust-lang.zulipchat.com/#narrow/stream/182449-t-compiler.2Fhelp/topic/Question.20about.20compiletest.
This is especially bad when using `--bless`, which will modify all `.stderr` files.

Change bootstrap to require valid filters instead of discarding invalid filters and continuing.

Before:

```
Warning: Skipping "/home/jnelson/rust-lang/rust/src/test/rustdoc-ui/intra-doc/feature-gate-intra-doc-pointers.r": not a regular file or directory
Check compiletest suite=rustdoc-ui mode=ui (x86_64-unknown-linux-gnu(x86_64-unknown-linux-gnu) -> x86_64-unknown-linux-gnu(x86_64-unknown-linux-gnu))

running 163 tests
iiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiii.......................... 100/163
...............................................................
test result: ok. 89 passed; 0 failed; 74 ignored; 0 measured; 0 filtered out; finished in 7.20s

        finished in 7.248 seconds
Build completed successfully in 0:00:08
```

After:
```
thread 'main' panicked at 'Invalid test suite filter "/home/jnelson/rust-lang/rust/src/test/rustdoc-ui/intra-doc/feature-gate-intra-doc-pointers.r": file or directory does not exist', src/bootstrap/util.rs:311:
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Build completed unsuccessfully in 0:00:08
```