### PR TITLE
Bump the ripgrep commit exercised by cargotest

### DIFF
--- a/src/tools/cargotest/main.rs
+++ b/src/tools/cargotest/main.rs
@@ -26,7 +26,7 @@ const TEST_REPOS: &[Test] = &[
     Test {
         name: "ripgrep",
         repo: "https://github.com/BurntSushi/ripgrep",
-        sha: "3de31f752729525d85a3d1575ac1978733b3f7e7",
+        sha: "ced5b92aa93eb47e892bd2fd26ab454008721730",
         lock: None,
         packages: &[],
         features: None,


### PR DESCRIPTION
This update goes from https://github.com/BurntSushi/ripgrep/commit/3de31f752729525d85a3d1575ac1978733b3f7e7 (Aug 1, 2019) to current master, https://github.com/BurntSushi/ripgrep/commit/ced5b92aa93eb47e892bd2fd26ab454008721730 (March 21, 2022).

I need this in order to pick up https://github.com/BurntSushi/ripgrep/pull/1722, which picked up https://github.com/BurntSushi/bstr/pull/58, which unblocks https://github.com/rust-lang/rust/pull/95345. Ripgrep uses the Debug representation of a `BStr` in some of its tests. In old versions of bstr, that used to just use the standard library's `escape_debug()` implementation, so the output ends up being sensitive to whether the standard library renders character 0 as `\u{0}` or as `\0`. The newer bstr always renders character 0 as `\0` and ripgrep's test suite has been correspondingly updated.