### PR TITLE
Update `int_roundings` methods from feedback

### DIFF
--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -2015,7 +2015,12 @@ macro_rules! int_impl {
         ///
         /// # Panics
         ///
-        /// This function will panic if `rhs` is 0 or the division results in overflow.
+        /// This function will panic if `rhs` is zero.
+        ///
+        /// ## Overflow behavior
+        ///
+        /// On overflow, this function will panic if overflow checks are enabled (default in debug
+        /// mode) and wrap if overflow checks are disabled (default in release mode).
         ///
         /// # Examples
         ///
@@ -2050,7 +2055,12 @@ macro_rules! int_impl {
         ///
         /// # Panics
         ///
-        /// This function will panic if `rhs` is 0 or the division results in overflow.
+        /// This function will panic if `rhs` is zero.
+        ///
+        /// ## Overflow behavior
+        ///
+        /// On overflow, this function will panic if overflow checks are enabled (default in debug
+        /// mode) and wrap if overflow checks are disabled (default in release mode).
         ///
         /// # Examples
         ///
@@ -2088,7 +2098,12 @@ macro_rules! int_impl {
         ///
         /// # Panics
         ///
-        /// This function will panic if `rhs` is 0 or the operation results in overflow.
+        /// This function will panic if `rhs` is zero.
+        ///
+        /// ## Overflow behavior
+        ///
+        /// On overflow, this function will panic if overflow checks are enabled (default in debug
+        /// mode) and wrap if overflow checks are disabled (default in release mode).
         ///
         /// # Examples
         ///
@@ -2157,7 +2172,6 @@ macro_rules! int_impl {
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]
-        #[rustc_inherit_overflow_checks]
         pub const fn checked_next_multiple_of(self, rhs: Self) -> Option<Self> {
             // This would otherwise fail when calculating `r` when self == T::MIN.
             if rhs == -1 {

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -2020,7 +2020,7 @@ macro_rules! uint_impl {
         ///
         /// # Panics
         ///
-        /// This function will panic if `rhs` is 0.
+        /// This function will panic if `rhs` is zero.
         ///
         /// # Examples
         ///
@@ -2034,7 +2034,6 @@ macro_rules! uint_impl {
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline(always)]
-        #[rustc_inherit_overflow_checks]
         pub const fn div_floor(self, rhs: Self) -> Self {
             self / rhs
         }
@@ -2043,7 +2042,12 @@ macro_rules! uint_impl {
         ///
         /// # Panics
         ///
-        /// This function will panic if `rhs` is 0.
+        /// This function will panic if `rhs` is zero.
+        ///
+        /// ## Overflow behavior
+        ///
+        /// On overflow, this function will panic if overflow checks are enabled (default in debug
+        /// mode) and wrap if overflow checks are disabled (default in release mode).
         ///
         /// # Examples
         ///
@@ -2073,7 +2077,12 @@ macro_rules! uint_impl {
         ///
         /// # Panics
         ///
-        /// This function will panic if `rhs` is 0 or the operation results in overflow.
+        /// This function will panic if `rhs` is zero.
+        ///
+        /// ## Overflow behavior
+        ///
+        /// On overflow, this function will panic if overflow checks are enabled (default in debug
+        /// mode) and wrap if overflow checks are disabled (default in release mode).
         ///
         /// # Examples
         ///
@@ -2097,7 +2106,7 @@ macro_rules! uint_impl {
         }
 
         /// Calculates the smallest value greater than or equal to `self` that
-        /// is a multiple of `rhs`. Returns `None` is `rhs` is zero or the
+        /// is a multiple of `rhs`. Returns `None` if `rhs` is zero or the
         /// operation would result in overflow.
         ///
         /// # Examples
@@ -2115,7 +2124,6 @@ macro_rules! uint_impl {
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]
-        #[rustc_inherit_overflow_checks]
         pub const fn checked_next_multiple_of(self, rhs: Self) -> Option<Self> {
             match try_opt!(self.checked_rem(rhs)) {
                 0 => Some(self),

--- a/library/core/tests/num/i128.rs
+++ b/library/core/tests/num/i128.rs
@@ -1,1 +1,1 @@
-int_module!(i128, i128);
+int_module!(i128);

--- a/library/core/tests/num/i16.rs
+++ b/library/core/tests/num/i16.rs
@@ -1,1 +1,1 @@
-int_module!(i16, i16);
+int_module!(i16);

--- a/library/core/tests/num/i32.rs
+++ b/library/core/tests/num/i32.rs
@@ -1,4 +1,4 @@
-int_module!(i32, i32);
+int_module!(i32);
 
 #[test]
 fn test_arith_operation() {

--- a/library/core/tests/num/i64.rs
+++ b/library/core/tests/num/i64.rs
@@ -1,1 +1,1 @@
-int_module!(i64, i64);
+int_module!(i64);

--- a/library/core/tests/num/i8.rs
+++ b/library/core/tests/num/i8.rs
@@ -1,1 +1,1 @@
-int_module!(i8, i8);
+int_module!(i8);

--- a/library/core/tests/num/int_macros.rs
+++ b/library/core/tests/num/int_macros.rs
@@ -1,9 +1,9 @@
 macro_rules! int_module {
-    ($T:ident, $T_i:ident) => {
+    ($T:ident) => {
         #[cfg(test)]
         mod tests {
             use core::ops::{BitAnd, BitOr, BitXor, Not, Shl, Shr};
-            use core::$T_i::*;
+            use core::$T::*;
 
             use crate::num;
 

--- a/library/core/tests/num/u128.rs
+++ b/library/core/tests/num/u128.rs
@@ -1,1 +1,1 @@
-uint_module!(u128, u128);
+uint_module!(u128);

--- a/library/core/tests/num/u16.rs
+++ b/library/core/tests/num/u16.rs
@@ -1,1 +1,1 @@
-uint_module!(u16, u16);
+uint_module!(u16);

--- a/library/core/tests/num/u32.rs
+++ b/library/core/tests/num/u32.rs
@@ -1,1 +1,1 @@
-uint_module!(u32, u32);
+uint_module!(u32);

--- a/library/core/tests/num/u64.rs
+++ b/library/core/tests/num/u64.rs
@@ -1,1 +1,1 @@
-uint_module!(u64, u64);
+uint_module!(u64);

--- a/library/core/tests/num/u8.rs
+++ b/library/core/tests/num/u8.rs
@@ -1,1 +1,1 @@
-uint_module!(u8, u8);
+uint_module!(u8);

--- a/library/core/tests/num/uint_macros.rs
+++ b/library/core/tests/num/uint_macros.rs
@@ -1,9 +1,9 @@
 macro_rules! uint_module {
-    ($T:ident, $T_i:ident) => {
+    ($T:ident) => {
         #[cfg(test)]
         mod tests {
             use core::ops::{BitAnd, BitOr, BitXor, Not, Shl, Shr};
-            use core::$T_i::*;
+            use core::$T::*;
             use std::str::FromStr;
 
             use crate::num;


### PR DESCRIPTION
This updates `#![feature(int_roundings)]` (#88581) from feedback. All methods now take `NonZeroX`. The documentation makes clear that they panic in debug mode and wrap in release mode.

r? @joshtriplett 

@rustbot label +T-libs +T-libs-api +S-waiting-on-review