### PR TITLE
Support arrays of zeros in Vec's __rust_alloc_zeroed optimization

### DIFF
--- a/library/alloc/src/vec/is_zero.rs
+++ b/library/alloc/src/vec/is_zero.rs
@@ -2,7 +2,7 @@ use crate::boxed::Box;
 
 #[rustc_specialization_trait]
 pub(super) unsafe trait IsZero {
-    /// Whether this value is zero
+    /// Whether this value's representation is all zeros
     fn is_zero(&self) -> bool;
 }
 
@@ -46,6 +46,13 @@ unsafe impl<T> IsZero for *mut T {
     #[inline]
     fn is_zero(&self) -> bool {
         (*self).is_null()
+    }
+}
+
+unsafe impl<T: IsZero, const N: usize> IsZero for [T; N] {
+    #[inline]
+    fn is_zero(&self) -> bool {
+        self.iter().all(IsZero::is_zero)
     }
 }
 


### PR DESCRIPTION
I happened to notice in https://users.rust-lang.org/t/any-advantage-of-box-u64-16-16-16-over-vec-u64/73500/3?u=scottmcm that the calloc optimization wasn't applying to vectors-of-arrays, so here's the easy fix for that.