### PR TITLE
make unaligned_references lint deny-by-default and make it show up in future-breakage report

### DIFF
--- a/compiler/rustc_data_structures/src/lib.rs
+++ b/compiler/rustc_data_structures/src/lib.rs
@@ -27,7 +27,6 @@
 #![feature(thread_id_value)]
 #![feature(vec_into_raw_parts)]
 #![allow(rustc::default_hash_types)]
-#![deny(unaligned_references)]
 #![allow(rustc::potential_query_instability)]
 
 #[macro_use]

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -1110,8 +1110,6 @@ declare_lint! {
     /// ### Example
     ///
     /// ```rust,compile_fail
-    /// #![deny(unaligned_references)]
-    ///
     /// #[repr(packed)]
     /// pub struct Foo {
     ///     field1: u64,
@@ -1139,7 +1137,7 @@ declare_lint! {
     /// [undefined behavior]: https://doc.rust-lang.org/reference/behavior-considered-undefined.html
     /// [issue #82523]: https://github.com/rust-lang/rust/issues/82523
     pub UNALIGNED_REFERENCES,
-    Warn,
+    Deny,
     "detects unaligned references to fields of packed structs",
     @future_incompatible = FutureIncompatibleInfo {
         reference: "issue #82523 <https://github.com/rust-lang/rust/issues/82523>",

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -1141,6 +1141,7 @@ declare_lint! {
     "detects unaligned references to fields of packed structs",
     @future_incompatible = FutureIncompatibleInfo {
         reference: "issue #82523 <https://github.com/rust-lang/rust/issues/82523>",
+        reason: FutureIncompatibilityReason::FutureReleaseErrorReportNow,
     };
     report_in_external_macro
 }

--- a/src/test/ui/binding/issue-53114-safety-checks.rs
+++ b/src/test/ui/binding/issue-53114-safety-checks.rs
@@ -20,13 +20,13 @@ fn let_wild_gets_unsafe_field() {
     let u1 = U { a: I(0) };
     let u2 = U { a: I(1) };
     let p = P { a: &2, b: &3 };
-    let _ = &p.b;  //~ WARN    reference to packed field
+    let _ = &p.b;  //~ ERROR    reference to packed field
     //~^  WARN will become a hard error
     let _ = u1.a;  // #53114: should eventually signal error as well
     let _ = &u2.a; //~ ERROR  [E0133]
 
     // variation on above with `_` in substructure
-    let (_,) = (&p.b,);  //~ WARN     reference to packed field
+    let (_,) = (&p.b,);  //~ ERROR     reference to packed field
     //~^  WARN will become a hard error
     let (_,) = (u1.a,);  //~ ERROR   [E0133]
     let (_,) = (&u2.a,); //~ ERROR   [E0133]
@@ -36,13 +36,13 @@ fn match_unsafe_field_to_wild() {
     let u1 = U { a: I(0) };
     let u2 = U { a: I(1) };
     let p = P { a: &2, b: &3 };
-    match &p.b  { _ => { } } //~ WARN     reference to packed field
+    match &p.b  { _ => { } } //~ ERROR     reference to packed field
     //~^  WARN will become a hard error
     match u1.a  { _ => { } } //~ ERROR   [E0133]
     match &u2.a { _ => { } } //~ ERROR   [E0133]
 
     // variation on above with `_` in substructure
-    match (&p.b,)  { (_,) => { } } //~ WARN     reference to packed field
+    match (&p.b,)  { (_,) => { } } //~ ERROR     reference to packed field
     //~^  WARN will become a hard error
     match (u1.a,)  { (_,) => { } } //~ ERROR   [E0133]
     match (&u2.a,) { (_,) => { } } //~ ERROR   [E0133]

--- a/src/test/ui/binding/issue-53114-safety-checks.stderr
+++ b/src/test/ui/binding/issue-53114-safety-checks.stderr
@@ -1,16 +1,16 @@
-warning: reference to packed field is unaligned
+error: reference to packed field is unaligned
   --> $DIR/issue-53114-safety-checks.rs:23:13
    |
 LL |     let _ = &p.b;
    |             ^^^^
    |
-   = note: `#[warn(unaligned_references)]` on by default
+   = note: `#[deny(unaligned_references)]` on by default
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #82523 <https://github.com/rust-lang/rust/issues/82523>
    = note: fields of packed structs are not properly aligned, and creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
    = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
 
-warning: reference to packed field is unaligned
+error: reference to packed field is unaligned
   --> $DIR/issue-53114-safety-checks.rs:29:17
    |
 LL |     let (_,) = (&p.b,);
@@ -21,7 +21,7 @@ LL |     let (_,) = (&p.b,);
    = note: fields of packed structs are not properly aligned, and creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
    = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
 
-warning: reference to packed field is unaligned
+error: reference to packed field is unaligned
   --> $DIR/issue-53114-safety-checks.rs:39:11
    |
 LL |     match &p.b  { _ => { } }
@@ -32,7 +32,7 @@ LL |     match &p.b  { _ => { } }
    = note: fields of packed structs are not properly aligned, and creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
    = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
 
-warning: reference to packed field is unaligned
+error: reference to packed field is unaligned
   --> $DIR/issue-53114-safety-checks.rs:45:12
    |
 LL |     match (&p.b,)  { (_,) => { } }
@@ -99,6 +99,6 @@ LL |     match (&u2.a,) { (_,) => { } }
    |
    = note: the field may not be properly initialized: using uninitialized data will cause undefined behavior
 
-error: aborting due to 7 previous errors; 4 warnings emitted
+error: aborting due to 11 previous errors
 
 For more information about this error, try `rustc --explain E0133`.

--- a/src/test/ui/binding/issue-53114-safety-checks.stderr
+++ b/src/test/ui/binding/issue-53114-safety-checks.stderr
@@ -102,3 +102,55 @@ LL |     match (&u2.a,) { (_,) => { } }
 error: aborting due to 11 previous errors
 
 For more information about this error, try `rustc --explain E0133`.
+Future incompatibility report: Future breakage diagnostic:
+error: reference to packed field is unaligned
+  --> $DIR/issue-53114-safety-checks.rs:23:13
+   |
+LL |     let _ = &p.b;
+   |             ^^^^
+   |
+   = note: `#[deny(unaligned_references)]` on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #82523 <https://github.com/rust-lang/rust/issues/82523>
+   = note: fields of packed structs are not properly aligned, and creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
+   = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
+
+Future breakage diagnostic:
+error: reference to packed field is unaligned
+  --> $DIR/issue-53114-safety-checks.rs:29:17
+   |
+LL |     let (_,) = (&p.b,);
+   |                 ^^^^
+   |
+   = note: `#[deny(unaligned_references)]` on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #82523 <https://github.com/rust-lang/rust/issues/82523>
+   = note: fields of packed structs are not properly aligned, and creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
+   = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
+
+Future breakage diagnostic:
+error: reference to packed field is unaligned
+  --> $DIR/issue-53114-safety-checks.rs:39:11
+   |
+LL |     match &p.b  { _ => { } }
+   |           ^^^^
+   |
+   = note: `#[deny(unaligned_references)]` on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #82523 <https://github.com/rust-lang/rust/issues/82523>
+   = note: fields of packed structs are not properly aligned, and creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
+   = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
+
+Future breakage diagnostic:
+error: reference to packed field is unaligned
+  --> $DIR/issue-53114-safety-checks.rs:45:12
+   |
+LL |     match (&p.b,)  { (_,) => { } }
+   |            ^^^^
+   |
+   = note: `#[deny(unaligned_references)]` on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #82523 <https://github.com/rust-lang/rust/issues/82523>
+   = note: fields of packed structs are not properly aligned, and creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
+   = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
+

--- a/src/test/ui/closures/2229_closure_analysis/diagnostics/repr_packed.rs
+++ b/src/test/ui/closures/2229_closure_analysis/diagnostics/repr_packed.rs
@@ -1,7 +1,5 @@
 // edition:2021
 
-// check-pass
-
 // Given how the closure desugaring is implemented (at least at the time of writing this test),
 // we don't need to truncate the captured path to a reference into a packed-struct if the field
 // being referenced will be moved into the closure, since it's safe to move out a field from a
@@ -11,9 +9,8 @@
 // inlined we will truncate the capture to access just the struct regardless of if the field
 // might get moved into the closure.
 //
-// It is possible for someone to try writing the code that relies on the desugaring to access a ref
-// into a packed-struct without explicity using unsafe. Here we test that the compiler warns the
-// user that such an access is still unsafe.
+// It is possible for someone to try writing the code that relies on the desugaring to create a ref
+// into a packed-struct. Here we test that the compiler still detects that case.
 fn test_missing_unsafe_warning_on_repr_packed() {
     #[repr(packed)]
     struct Foo { x: String }
@@ -22,7 +19,7 @@ fn test_missing_unsafe_warning_on_repr_packed() {
 
     let c = || {
         println!("{}", foo.x);
-        //~^ WARNING: reference to packed field is unaligned
+        //~^ ERROR: reference to packed field is unaligned
         //~| WARNING: this was previously accepted by the compiler but is being phased out
         let _z = foo.x;
     };

--- a/src/test/ui/closures/2229_closure_analysis/diagnostics/repr_packed.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/diagnostics/repr_packed.stderr
@@ -13,3 +13,17 @@ LL |         println!("{}", foo.x);
 
 error: aborting due to previous error
 
+Future incompatibility report: Future breakage diagnostic:
+error: reference to packed field is unaligned
+  --> $DIR/repr_packed.rs:21:24
+   |
+LL |         println!("{}", foo.x);
+   |                        ^^^^^
+   |
+   = note: `#[deny(unaligned_references)]` on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #82523 <https://github.com/rust-lang/rust/issues/82523>
+   = note: fields of packed structs are not properly aligned, and creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
+   = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
+   = note: this error originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
+

--- a/src/test/ui/closures/2229_closure_analysis/diagnostics/repr_packed.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/diagnostics/repr_packed.stderr
@@ -1,15 +1,15 @@
-warning: reference to packed field is unaligned
-  --> $DIR/repr_packed.rs:24:24
+error: reference to packed field is unaligned
+  --> $DIR/repr_packed.rs:21:24
    |
 LL |         println!("{}", foo.x);
    |                        ^^^^^
    |
-   = note: `#[warn(unaligned_references)]` on by default
+   = note: `#[deny(unaligned_references)]` on by default
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #82523 <https://github.com/rust-lang/rust/issues/82523>
    = note: fields of packed structs are not properly aligned, and creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
    = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
-   = note: this warning originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-warning: 1 warning emitted
+error: aborting due to previous error
 

--- a/src/test/ui/derives/deriving-with-repr-packed.stderr
+++ b/src/test/ui/derives/deriving-with-repr-packed.stderr
@@ -45,3 +45,67 @@ LL | #[derive(PartialEq)]
 
 error: aborting due to 4 previous errors
 
+Future incompatibility report: Future breakage diagnostic:
+error: `#[derive]` can't be used on a `#[repr(packed)]` struct with type or const parameters (error E0133)
+  --> $DIR/deriving-with-repr-packed.rs:8:16
+   |
+LL | #[derive(Copy, Clone, PartialEq, Eq)]
+   |                ^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/deriving-with-repr-packed.rs:1:9
+   |
+LL | #![deny(unaligned_references)]
+   |         ^^^^^^^^^^^^^^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #82523 <https://github.com/rust-lang/rust/issues/82523>
+   = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+Future breakage diagnostic:
+error: `#[derive]` can't be used on a `#[repr(packed)]` struct with type or const parameters (error E0133)
+  --> $DIR/deriving-with-repr-packed.rs:8:23
+   |
+LL | #[derive(Copy, Clone, PartialEq, Eq)]
+   |                       ^^^^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/deriving-with-repr-packed.rs:1:9
+   |
+LL | #![deny(unaligned_references)]
+   |         ^^^^^^^^^^^^^^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #82523 <https://github.com/rust-lang/rust/issues/82523>
+   = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+Future breakage diagnostic:
+error: `#[derive]` can't be used on a `#[repr(packed)]` struct that does not derive Copy (error E0133)
+  --> $DIR/deriving-with-repr-packed.rs:16:10
+   |
+LL | #[derive(PartialEq, Eq)]
+   |          ^^^^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/deriving-with-repr-packed.rs:1:9
+   |
+LL | #![deny(unaligned_references)]
+   |         ^^^^^^^^^^^^^^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #82523 <https://github.com/rust-lang/rust/issues/82523>
+   = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+Future breakage diagnostic:
+error: `#[derive]` can't be used on a `#[repr(packed)]` struct that does not derive Copy (error E0133)
+  --> $DIR/deriving-with-repr-packed.rs:25:10
+   |
+LL | #[derive(PartialEq)]
+   |          ^^^^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/deriving-with-repr-packed.rs:1:9
+   |
+LL | #![deny(unaligned_references)]
+   |         ^^^^^^^^^^^^^^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #82523 <https://github.com/rust-lang/rust/issues/82523>
+   = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
+

--- a/src/test/ui/lint/unaligned_references.stderr
+++ b/src/test/ui/lint/unaligned_references.stderr
@@ -82,3 +82,122 @@ LL |         let _ = &packed2.x;
 
 error: aborting due to 7 previous errors
 
+Future incompatibility report: Future breakage diagnostic:
+error: reference to packed field is unaligned
+  --> $DIR/unaligned_references.rs:22:17
+   |
+LL |         let _ = &good.ptr;
+   |                 ^^^^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/unaligned_references.rs:1:9
+   |
+LL | #![deny(unaligned_references)]
+   |         ^^^^^^^^^^^^^^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #82523 <https://github.com/rust-lang/rust/issues/82523>
+   = note: fields of packed structs are not properly aligned, and creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
+   = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
+
+Future breakage diagnostic:
+error: reference to packed field is unaligned
+  --> $DIR/unaligned_references.rs:24:17
+   |
+LL |         let _ = &good.data;
+   |                 ^^^^^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/unaligned_references.rs:1:9
+   |
+LL | #![deny(unaligned_references)]
+   |         ^^^^^^^^^^^^^^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #82523 <https://github.com/rust-lang/rust/issues/82523>
+   = note: fields of packed structs are not properly aligned, and creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
+   = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
+
+Future breakage diagnostic:
+error: reference to packed field is unaligned
+  --> $DIR/unaligned_references.rs:27:17
+   |
+LL |         let _ = &good.data as *const _;
+   |                 ^^^^^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/unaligned_references.rs:1:9
+   |
+LL | #![deny(unaligned_references)]
+   |         ^^^^^^^^^^^^^^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #82523 <https://github.com/rust-lang/rust/issues/82523>
+   = note: fields of packed structs are not properly aligned, and creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
+   = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
+
+Future breakage diagnostic:
+error: reference to packed field is unaligned
+  --> $DIR/unaligned_references.rs:29:27
+   |
+LL |         let _: *const _ = &good.data;
+   |                           ^^^^^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/unaligned_references.rs:1:9
+   |
+LL | #![deny(unaligned_references)]
+   |         ^^^^^^^^^^^^^^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #82523 <https://github.com/rust-lang/rust/issues/82523>
+   = note: fields of packed structs are not properly aligned, and creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
+   = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
+
+Future breakage diagnostic:
+error: reference to packed field is unaligned
+  --> $DIR/unaligned_references.rs:32:17
+   |
+LL |         let _ = good.data.clone();
+   |                 ^^^^^^^^^^^^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/unaligned_references.rs:1:9
+   |
+LL | #![deny(unaligned_references)]
+   |         ^^^^^^^^^^^^^^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #82523 <https://github.com/rust-lang/rust/issues/82523>
+   = note: fields of packed structs are not properly aligned, and creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
+   = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
+
+Future breakage diagnostic:
+error: reference to packed field is unaligned
+  --> $DIR/unaligned_references.rs:35:17
+   |
+LL |         let _ = &good.data2[0];
+   |                 ^^^^^^^^^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/unaligned_references.rs:1:9
+   |
+LL | #![deny(unaligned_references)]
+   |         ^^^^^^^^^^^^^^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #82523 <https://github.com/rust-lang/rust/issues/82523>
+   = note: fields of packed structs are not properly aligned, and creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
+   = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
+
+Future breakage diagnostic:
+error: reference to packed field is unaligned
+  --> $DIR/unaligned_references.rs:45:17
+   |
+LL |         let _ = &packed2.x;
+   |                 ^^^^^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/unaligned_references.rs:1:9
+   |
+LL | #![deny(unaligned_references)]
+   |         ^^^^^^^^^^^^^^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #82523 <https://github.com/rust-lang/rust/issues/82523>
+   = note: fields of packed structs are not properly aligned, and creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
+   = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
+

--- a/src/test/ui/lint/unaligned_references_external_macro.stderr
+++ b/src/test/ui/lint/unaligned_references_external_macro.stderr
@@ -29,3 +29,33 @@ LL | | }
 
 error: aborting due to previous error
 
+Future incompatibility report: Future breakage diagnostic:
+error: reference to packed field is unaligned
+  --> $DIR/unaligned_references_external_macro.rs:5:1
+   |
+LL | / unaligned_references_external_crate::mac! {
+LL | |
+LL | |     #[repr(packed)]
+LL | |     pub struct X {
+LL | |         pub field: u16
+LL | |     }
+LL | | }
+   | |_^
+   |
+note: the lint level is defined here
+  --> $DIR/unaligned_references_external_macro.rs:5:1
+   |
+LL | / unaligned_references_external_crate::mac! {
+LL | |
+LL | |     #[repr(packed)]
+LL | |     pub struct X {
+LL | |         pub field: u16
+LL | |     }
+LL | | }
+   | |_^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #82523 <https://github.com/rust-lang/rust/issues/82523>
+   = note: fields of packed structs are not properly aligned, and creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
+   = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
+   = note: this error originates in the macro `unaligned_references_external_crate::mac` (in Nightly builds, run with -Z macro-backtrace for more info)
+

--- a/src/test/ui/packed/issue-27060-rpass.stderr
+++ b/src/test/ui/packed/issue-27060-rpass.stderr
@@ -1,44 +1,15 @@
-warning: reference to packed field is unaligned
-  --> $DIR/packed-struct-borrow-element.rs:26:15
-   |
-LL |     let brw = &foo.baz;
-   |               ^^^^^^^^
-   |
-note: the lint level is defined here
-  --> $DIR/packed-struct-borrow-element.rs:23:8
-   |
-LL | #[warn(unaligned_references)]
-   |        ^^^^^^^^^^^^^^^^^^^^
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #82523 <https://github.com/rust-lang/rust/issues/82523>
-   = note: fields of packed structs are not properly aligned, and creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
-   = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
-
-warning: reference to packed field is unaligned
-  --> $DIR/packed-struct-borrow-element.rs:31:15
-   |
-LL |     let brw = &foo.baz;
-   |               ^^^^^^^^
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #82523 <https://github.com/rust-lang/rust/issues/82523>
-   = note: fields of packed structs are not properly aligned, and creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
-   = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
-
-warning: 2 warnings emitted
-
 Future incompatibility report: Future breakage diagnostic:
 warning: reference to packed field is unaligned
-  --> $DIR/packed-struct-borrow-element.rs:26:15
+  --> $DIR/issue-27060-rpass.rs:15:13
    |
-LL |     let brw = &foo.baz;
-   |               ^^^^^^^^
+LL |     let _ = &good.data; // ok
+   |             ^^^^^^^^^^
    |
 note: the lint level is defined here
-  --> $DIR/packed-struct-borrow-element.rs:23:8
+  --> $DIR/issue-27060-rpass.rs:11:9
    |
-LL | #[warn(unaligned_references)]
-   |        ^^^^^^^^^^^^^^^^^^^^
+LL | #[allow(unaligned_references)]
+   |         ^^^^^^^^^^^^^^^^^^^^
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #82523 <https://github.com/rust-lang/rust/issues/82523>
    = note: fields of packed structs are not properly aligned, and creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
@@ -46,16 +17,50 @@ LL | #[warn(unaligned_references)]
 
 Future breakage diagnostic:
 warning: reference to packed field is unaligned
-  --> $DIR/packed-struct-borrow-element.rs:31:15
+  --> $DIR/issue-27060-rpass.rs:16:13
    |
-LL |     let brw = &foo.baz;
-   |               ^^^^^^^^
+LL |     let _ = &good.data2[0]; // ok
+   |             ^^^^^^^^^^^^^^
    |
 note: the lint level is defined here
-  --> $DIR/packed-struct-borrow-element.rs:23:8
+  --> $DIR/issue-27060-rpass.rs:11:9
    |
-LL | #[warn(unaligned_references)]
-   |        ^^^^^^^^^^^^^^^^^^^^
+LL | #[allow(unaligned_references)]
+   |         ^^^^^^^^^^^^^^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #82523 <https://github.com/rust-lang/rust/issues/82523>
+   = note: fields of packed structs are not properly aligned, and creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
+   = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
+
+Future breakage diagnostic:
+warning: reference to packed field is unaligned
+  --> $DIR/issue-27060-rpass.rs:18:13
+   |
+LL |     let _ = &good.data;
+   |             ^^^^^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/issue-27060-rpass.rs:11:9
+   |
+LL | #[allow(unaligned_references)]
+   |         ^^^^^^^^^^^^^^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #82523 <https://github.com/rust-lang/rust/issues/82523>
+   = note: fields of packed structs are not properly aligned, and creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
+   = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
+
+Future breakage diagnostic:
+warning: reference to packed field is unaligned
+  --> $DIR/issue-27060-rpass.rs:19:13
+   |
+LL |     let _ = &good.data2[0];
+   |             ^^^^^^^^^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/issue-27060-rpass.rs:11:9
+   |
+LL | #[allow(unaligned_references)]
+   |         ^^^^^^^^^^^^^^^^^^^^
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #82523 <https://github.com/rust-lang/rust/issues/82523>
    = note: fields of packed structs are not properly aligned, and creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)

--- a/src/test/ui/packed/issue-27060.rs
+++ b/src/test/ui/packed/issue-27060.rs
@@ -5,7 +5,6 @@ pub struct Good {
     aligned: [u8; 32],
 }
 
-#[deny(unaligned_references)]
 fn main() {
     let good = Good {
         data: &0,

--- a/src/test/ui/packed/issue-27060.stderr
+++ b/src/test/ui/packed/issue-27060.stderr
@@ -1,21 +1,17 @@
 error: reference to packed field is unaligned
-  --> $DIR/issue-27060.rs:16:13
+  --> $DIR/issue-27060.rs:15:13
    |
 LL |     let _ = &good.data;
    |             ^^^^^^^^^^
    |
-note: the lint level is defined here
-  --> $DIR/issue-27060.rs:8:8
-   |
-LL | #[deny(unaligned_references)]
-   |        ^^^^^^^^^^^^^^^^^^^^
+   = note: `#[deny(unaligned_references)]` on by default
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #82523 <https://github.com/rust-lang/rust/issues/82523>
    = note: fields of packed structs are not properly aligned, and creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
    = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
 
 error: reference to packed field is unaligned
-  --> $DIR/issue-27060.rs:18:13
+  --> $DIR/issue-27060.rs:17:13
    |
 LL |     let _ = &good.data2[0];
    |             ^^^^^^^^^^^^^^
@@ -26,7 +22,7 @@ LL |     let _ = &good.data2[0];
    = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
 
 error: reference to packed field is unaligned
-  --> $DIR/issue-27060.rs:21:13
+  --> $DIR/issue-27060.rs:20:13
    |
 LL |     let _ = &good.data;
    |             ^^^^^^^^^^
@@ -37,7 +33,7 @@ LL |     let _ = &good.data;
    = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
 
 error: reference to packed field is unaligned
-  --> $DIR/issue-27060.rs:23:13
+  --> $DIR/issue-27060.rs:22:13
    |
 LL |     let _ = &good.data2[0];
    |             ^^^^^^^^^^^^^^

--- a/src/test/ui/packed/issue-27060.stderr
+++ b/src/test/ui/packed/issue-27060.stderr
@@ -45,3 +45,55 @@ LL |     let _ = &good.data2[0];
 
 error: aborting due to 4 previous errors
 
+Future incompatibility report: Future breakage diagnostic:
+error: reference to packed field is unaligned
+  --> $DIR/issue-27060.rs:15:13
+   |
+LL |     let _ = &good.data;
+   |             ^^^^^^^^^^
+   |
+   = note: `#[deny(unaligned_references)]` on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #82523 <https://github.com/rust-lang/rust/issues/82523>
+   = note: fields of packed structs are not properly aligned, and creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
+   = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
+
+Future breakage diagnostic:
+error: reference to packed field is unaligned
+  --> $DIR/issue-27060.rs:17:13
+   |
+LL |     let _ = &good.data2[0];
+   |             ^^^^^^^^^^^^^^
+   |
+   = note: `#[deny(unaligned_references)]` on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #82523 <https://github.com/rust-lang/rust/issues/82523>
+   = note: fields of packed structs are not properly aligned, and creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
+   = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
+
+Future breakage diagnostic:
+error: reference to packed field is unaligned
+  --> $DIR/issue-27060.rs:20:13
+   |
+LL |     let _ = &good.data;
+   |             ^^^^^^^^^^
+   |
+   = note: `#[deny(unaligned_references)]` on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #82523 <https://github.com/rust-lang/rust/issues/82523>
+   = note: fields of packed structs are not properly aligned, and creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
+   = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
+
+Future breakage diagnostic:
+error: reference to packed field is unaligned
+  --> $DIR/issue-27060.rs:22:13
+   |
+LL |     let _ = &good.data2[0];
+   |             ^^^^^^^^^^^^^^
+   |
+   = note: `#[deny(unaligned_references)]` on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #82523 <https://github.com/rust-lang/rust/issues/82523>
+   = note: fields of packed structs are not properly aligned, and creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
+   = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
+

--- a/src/test/ui/packed/packed-struct-address-of-element.rs
+++ b/src/test/ui/packed/packed-struct-address-of-element.rs
@@ -1,6 +1,5 @@
 // run-pass
 #![allow(dead_code)]
-#![deny(unaligned_references)]
 #![feature(raw_ref_op)]
 // ignore-emscripten weird assertion?
 

--- a/src/test/ui/packed/packed-struct-borrow-element-64bit.rs
+++ b/src/test/ui/packed/packed-struct-borrow-element-64bit.rs
@@ -9,6 +9,7 @@ struct Foo4C {
     baz: usize
 }
 
+#[warn(unaligned_references)]
 pub fn main() {
     let foo = Foo4C { bar: 1, baz: 2 };
     let brw = &foo.baz; //~WARN reference to packed field is unaligned

--- a/src/test/ui/packed/packed-struct-borrow-element-64bit.stderr
+++ b/src/test/ui/packed/packed-struct-borrow-element-64bit.stderr
@@ -16,3 +16,20 @@ LL | #[warn(unaligned_references)]
 
 warning: 1 warning emitted
 
+Future incompatibility report: Future breakage diagnostic:
+warning: reference to packed field is unaligned
+  --> $DIR/packed-struct-borrow-element-64bit.rs:15:15
+   |
+LL |     let brw = &foo.baz;
+   |               ^^^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/packed-struct-borrow-element-64bit.rs:12:8
+   |
+LL | #[warn(unaligned_references)]
+   |        ^^^^^^^^^^^^^^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #82523 <https://github.com/rust-lang/rust/issues/82523>
+   = note: fields of packed structs are not properly aligned, and creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
+   = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
+

--- a/src/test/ui/packed/packed-struct-borrow-element-64bit.stderr
+++ b/src/test/ui/packed/packed-struct-borrow-element-64bit.stderr
@@ -1,10 +1,14 @@
 warning: reference to packed field is unaligned
-  --> $DIR/packed-struct-borrow-element-64bit.rs:14:15
+  --> $DIR/packed-struct-borrow-element-64bit.rs:15:15
    |
 LL |     let brw = &foo.baz;
    |               ^^^^^^^^
    |
-   = note: `#[warn(unaligned_references)]` on by default
+note: the lint level is defined here
+  --> $DIR/packed-struct-borrow-element-64bit.rs:12:8
+   |
+LL | #[warn(unaligned_references)]
+   |        ^^^^^^^^^^^^^^^^^^^^
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #82523 <https://github.com/rust-lang/rust/issues/82523>
    = note: fields of packed structs are not properly aligned, and creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)

--- a/src/test/ui/packed/packed-struct-borrow-element.rs
+++ b/src/test/ui/packed/packed-struct-borrow-element.rs
@@ -20,6 +20,7 @@ struct Foo4C {
     baz: usize
 }
 
+#[warn(unaligned_references)]
 pub fn main() {
     let foo = Foo1 { bar: 1, baz: 2 };
     let brw = &foo.baz; //~WARN reference to packed field is unaligned

--- a/src/test/ui/packed/packed-struct-borrow-element.stderr
+++ b/src/test/ui/packed/packed-struct-borrow-element.stderr
@@ -1,17 +1,21 @@
 warning: reference to packed field is unaligned
-  --> $DIR/packed-struct-borrow-element.rs:25:15
+  --> $DIR/packed-struct-borrow-element.rs:26:15
    |
 LL |     let brw = &foo.baz;
    |               ^^^^^^^^
    |
-   = note: `#[warn(unaligned_references)]` on by default
+note: the lint level is defined here
+  --> $DIR/packed-struct-borrow-element.rs:23:8
+   |
+LL | #[warn(unaligned_references)]
+   |        ^^^^^^^^^^^^^^^^^^^^
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #82523 <https://github.com/rust-lang/rust/issues/82523>
    = note: fields of packed structs are not properly aligned, and creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
    = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
 
 warning: reference to packed field is unaligned
-  --> $DIR/packed-struct-borrow-element.rs:30:15
+  --> $DIR/packed-struct-borrow-element.rs:31:15
    |
 LL |     let brw = &foo.baz;
    |               ^^^^^^^^


### PR DESCRIPTION
This lint has been warn-by-default for a year now (since https://github.com/rust-lang/rust/pull/82525), so I think it is time to crank it up a bit. Code that triggers the lint causes UB (without `unsafe`) when executed, so we really don't want people to write code like this.

Also make it show up in future-breakage report.