### PR TITLE
(Selectively) turn on validation in const eval

### DIFF
--- a/compiler/rustc_const_eval/src/interpret/machine.rs
+++ b/compiler/rustc_const_eval/src/interpret/machine.rs
@@ -131,7 +131,7 @@ pub trait Machine<'mir, 'tcx>: Sized {
     fn force_int_for_alignment_check(ecx: &InterpCx<'mir, 'tcx, Self>) -> bool;
 
     /// Whether to enforce the validity invariant
-    fn enforce_validity(ecx: &InterpCx<'mir, 'tcx, Self>) -> bool;
+    fn enforce_validity(ecx: &mut InterpCx<'mir, 'tcx, Self>) -> bool;
 
     /// Whether to enforce integers and floats being initialized.
     fn enforce_number_init(ecx: &InterpCx<'mir, 'tcx, Self>) -> bool;
@@ -450,7 +450,7 @@ pub macro compile_time_machine(<$mir: lifetime, $tcx: lifetime>) {
     }
 
     #[inline(always)]
-    fn enforce_validity(_ecx: &InterpCx<$mir, $tcx, Self>) -> bool {
+    fn enforce_validity(_ecx: &mut InterpCx<$mir, $tcx, Self>) -> bool {
         false // for now, we don't enforce validity
     }
 

--- a/compiler/rustc_mir_transform/src/const_prop.rs
+++ b/compiler/rustc_mir_transform/src/const_prop.rs
@@ -184,6 +184,12 @@ impl ConstPropMachine<'_, '_> {
 
 impl<'mir, 'tcx> interpret::Machine<'mir, 'tcx> for ConstPropMachine<'mir, 'tcx> {
     compile_time_machine!(<'mir, 'tcx>);
+
+    #[inline(always)]
+    fn enforce_validity(_ecx: &mut InterpCx<'mir, 'tcx, Self>) -> bool {
+        false
+    }
+
     const PANIC_ON_ALLOC_FAIL: bool = true; // all allocations are small (see `MAX_ALLOC_LIMIT`)
 
     type MemoryKind = !;

--- a/compiler/rustc_mir_transform/src/const_prop_lint.rs
+++ b/compiler/rustc_mir_transform/src/const_prop_lint.rs
@@ -176,6 +176,12 @@ impl ConstPropMachine<'_, '_> {
 
 impl<'mir, 'tcx> interpret::Machine<'mir, 'tcx> for ConstPropMachine<'mir, 'tcx> {
     compile_time_machine!(<'mir, 'tcx>);
+
+    #[inline(always)]
+    fn enforce_validity(_ecx: &mut InterpCx<'mir, 'tcx, Self>) -> bool {
+        false
+    }
+
     const PANIC_ON_ALLOC_FAIL: bool = true; // all allocations are small (see `MAX_ALLOC_LIMIT`)
 
     type MemoryKind = !;

--- a/src/test/ui/const-generics/min_const_generics/invalid-patterns.32bit.stderr
+++ b/src/test/ui/const-generics/min_const_generics/invalid-patterns.32bit.stderr
@@ -22,49 +22,29 @@ error[E0308]: mismatched types
 LL |   get_flag::<42, 0x5ad>();
    |                  ^^^^^ expected `char`, found `u8`
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/invalid-patterns.rs:38:21
+error[E0080]: evaluation of constant value failed
+  --> $DIR/invalid-patterns.rs:38:32
    |
 LL |   get_flag::<false, { unsafe { char_raw.character } }>();
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered uninitialized bytes, but expected a valid unicode scalar value (in `0..=0x10FFFF` but not in `0xD800..=0xDFFF`)
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 4, align: 4) {
-               __ __ __ __                                     │ ░░░░
-           }
+   |                                ^^^^^^^^^^^^^^^^^^ type validation failed: encountered uninitialized bytes, but expected a valid unicode scalar value (in `0..=0x10FFFF` but not in `0xD800..=0xDFFF`)
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/invalid-patterns.rs:40:14
+error[E0080]: evaluation of constant value failed
+  --> $DIR/invalid-patterns.rs:40:25
    |
 LL |   get_flag::<{ unsafe { bool_raw.boolean } }, 'z'>();
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 0x42, but expected a boolean
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 1, align: 1) {
-               42                                              │ B
-           }
+   |                         ^^^^^^^^^^^^^^^^ type validation failed: encountered 0x42, but expected a boolean
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/invalid-patterns.rs:42:14
+error[E0080]: evaluation of constant value failed
+  --> $DIR/invalid-patterns.rs:42:25
    |
 LL |   get_flag::<{ unsafe { bool_raw.boolean } }, { unsafe { char_raw.character } }>();
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 0x42, but expected a boolean
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 1, align: 1) {
-               42                                              │ B
-           }
+   |                         ^^^^^^^^^^^^^^^^ type validation failed: encountered 0x42, but expected a boolean
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/invalid-patterns.rs:42:47
+error[E0080]: evaluation of constant value failed
+  --> $DIR/invalid-patterns.rs:42:58
    |
 LL |   get_flag::<{ unsafe { bool_raw.boolean } }, { unsafe { char_raw.character } }>();
-   |                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered uninitialized bytes, but expected a valid unicode scalar value (in `0..=0x10FFFF` but not in `0xD800..=0xDFFF`)
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 4, align: 4) {
-               __ __ __ __                                     │ ░░░░
-           }
+   |                                                          ^^^^^^^^^^^^^^^^^^ type validation failed: encountered uninitialized bytes, but expected a valid unicode scalar value (in `0..=0x10FFFF` but not in `0xD800..=0xDFFF`)
 
 error: aborting due to 8 previous errors
 

--- a/src/test/ui/const-generics/min_const_generics/invalid-patterns.64bit.stderr
+++ b/src/test/ui/const-generics/min_const_generics/invalid-patterns.64bit.stderr
@@ -22,49 +22,29 @@ error[E0308]: mismatched types
 LL |   get_flag::<42, 0x5ad>();
    |                  ^^^^^ expected `char`, found `u8`
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/invalid-patterns.rs:38:21
+error[E0080]: evaluation of constant value failed
+  --> $DIR/invalid-patterns.rs:38:32
    |
 LL |   get_flag::<false, { unsafe { char_raw.character } }>();
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered uninitialized bytes, but expected a valid unicode scalar value (in `0..=0x10FFFF` but not in `0xD800..=0xDFFF`)
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 4, align: 4) {
-               __ __ __ __                                     │ ░░░░
-           }
+   |                                ^^^^^^^^^^^^^^^^^^ type validation failed: encountered uninitialized bytes, but expected a valid unicode scalar value (in `0..=0x10FFFF` but not in `0xD800..=0xDFFF`)
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/invalid-patterns.rs:40:14
+error[E0080]: evaluation of constant value failed
+  --> $DIR/invalid-patterns.rs:40:25
    |
 LL |   get_flag::<{ unsafe { bool_raw.boolean } }, 'z'>();
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 0x42, but expected a boolean
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 1, align: 1) {
-               42                                              │ B
-           }
+   |                         ^^^^^^^^^^^^^^^^ type validation failed: encountered 0x42, but expected a boolean
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/invalid-patterns.rs:42:14
+error[E0080]: evaluation of constant value failed
+  --> $DIR/invalid-patterns.rs:42:25
    |
 LL |   get_flag::<{ unsafe { bool_raw.boolean } }, { unsafe { char_raw.character } }>();
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 0x42, but expected a boolean
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 1, align: 1) {
-               42                                              │ B
-           }
+   |                         ^^^^^^^^^^^^^^^^ type validation failed: encountered 0x42, but expected a boolean
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/invalid-patterns.rs:42:47
+error[E0080]: evaluation of constant value failed
+  --> $DIR/invalid-patterns.rs:42:58
    |
 LL |   get_flag::<{ unsafe { bool_raw.boolean } }, { unsafe { char_raw.character } }>();
-   |                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered uninitialized bytes, but expected a valid unicode scalar value (in `0..=0x10FFFF` but not in `0xD800..=0xDFFF`)
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 4, align: 4) {
-               __ __ __ __                                     │ ░░░░
-           }
+   |                                                          ^^^^^^^^^^^^^^^^^^ type validation failed: encountered uninitialized bytes, but expected a valid unicode scalar value (in `0..=0x10FFFF` but not in `0xD800..=0xDFFF`)
 
 error: aborting due to 8 previous errors
 

--- a/src/test/ui/const-generics/min_const_generics/invalid-patterns.rs
+++ b/src/test/ui/const-generics/min_const_generics/invalid-patterns.rs
@@ -36,10 +36,10 @@ fn main() {
 
 
   get_flag::<false, { unsafe { char_raw.character } }>();
-  //~^ ERROR it is undefined behavior
+  //~^ ERROR evaluation of constant value failed
   get_flag::<{ unsafe { bool_raw.boolean } }, 'z'>();
-  //~^ ERROR it is undefined behavior
+  //~^ ERROR evaluation of constant value failed
   get_flag::<{ unsafe { bool_raw.boolean } }, { unsafe { char_raw.character } }>();
-  //~^ ERROR it is undefined behavior
-  //~| ERROR it is undefined behavior
+  //~^ ERROR evaluation of constant value failed
+  //~| ERROR evaluation of constant value failed
 }

--- a/src/test/ui/consts/const-err4.32bit.stderr
+++ b/src/test/ui/consts/const-err4.32bit.stderr
@@ -1,13 +1,8 @@
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/const-err4.rs:9:11
+error[E0080]: evaluation of constant value failed
+  --> $DIR/const-err4.rs:9:21
    |
 LL |     Boo = [unsafe { Foo { b: () }.a }; 4][3],
-   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered uninitialized bytes, but expected initialized bytes
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 4, align: 4) {
-               __ __ __ __                                     │ ░░░░
-           }
+   |                     ^^^^^^^^^^^^^^^ type validation failed: encountered uninitialized bytes, but expected initialized bytes
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/const-err4.64bit.stderr
+++ b/src/test/ui/consts/const-err4.64bit.stderr
@@ -1,13 +1,8 @@
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/const-err4.rs:9:11
+error[E0080]: evaluation of constant value failed
+  --> $DIR/const-err4.rs:9:21
    |
 LL |     Boo = [unsafe { Foo { b: () }.a }; 4][3],
-   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered uninitialized bytes, but expected initialized bytes
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 8) {
-               __ __ __ __ __ __ __ __                         │ ░░░░░░░░
-           }
+   |                     ^^^^^^^^^^^^^^^ type validation failed: encountered uninitialized bytes, but expected initialized bytes
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/const-err4.rs
+++ b/src/test/ui/consts/const-err4.rs
@@ -7,7 +7,7 @@ union Foo {
 
 enum Bar {
     Boo = [unsafe { Foo { b: () }.a }; 4][3],
-    //~^ ERROR it is undefined behavior to use this value
+    //~^ ERROR evaluation of constant value failed
 }
 
 fn main() {

--- a/src/test/ui/consts/const-eval/const-pointer-values-in-various-types.64bit.stderr
+++ b/src/test/ui/consts/const-eval/const-pointer-values-in-various-types.64bit.stderr
@@ -1,13 +1,8 @@
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/const-pointer-values-in-various-types.rs:26:5
+error[E0080]: evaluation of constant value failed
+  --> $DIR/const-pointer-values-in-various-types.rs:26:49
    |
 LL |     const I32_REF_USIZE_UNION: usize = unsafe { Nonsense { int_32_ref: &3 }.u };
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc3, but expected plain (non-pointer) bytes
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 8) {
-               ╾───────alloc3────────╼                         │ ╾──────╼
-           }
+   |                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc3, but expected plain (non-pointer) bytes
 
 error: any use of this value will cause an error
   --> $DIR/const-pointer-values-in-various-types.rs:29:43
@@ -43,27 +38,17 @@ LL |     const I32_REF_U32_UNION: u32 = unsafe { Nonsense { int_32_ref: &3 }.uin
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/const-pointer-values-in-various-types.rs:41:5
+error[E0080]: evaluation of constant value failed
+  --> $DIR/const-pointer-values-in-various-types.rs:41:45
    |
 LL |     const I32_REF_U64_UNION: u64 = unsafe { Nonsense { int_32_ref: &3 }.uint_64 };
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc19, but expected plain (non-pointer) bytes
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 8) {
-               ╾───────alloc19───────╼                         │ ╾──────╼
-           }
+   |                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc19, but expected plain (non-pointer) bytes
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/const-pointer-values-in-various-types.rs:44:5
+error[E0080]: evaluation of constant value failed
+  --> $DIR/const-pointer-values-in-various-types.rs:44:47
    |
 LL |     const I32_REF_U128_UNION: u128 = unsafe { Nonsense { int_32_ref: &3 }.uint_128 };
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered uninitialized bytes, but expected initialized bytes
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 16, align: 8) {
-               __ __ __ __ __ __ __ __ __ __ __ __ __ __ __ __ │ ░░░░░░░░░░░░░░░░
-           }
+   |                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered uninitialized bytes, but expected initialized bytes
 
 error: any use of this value will cause an error
   --> $DIR/const-pointer-values-in-various-types.rs:47:43
@@ -98,27 +83,17 @@ LL |     const I32_REF_I32_UNION: i32 = unsafe { Nonsense { int_32_ref: &3 }.int
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/const-pointer-values-in-various-types.rs:59:5
+error[E0080]: evaluation of constant value failed
+  --> $DIR/const-pointer-values-in-various-types.rs:59:45
    |
 LL |     const I32_REF_I64_UNION: i64 = unsafe { Nonsense { int_32_ref: &3 }.int_64 };
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc39, but expected plain (non-pointer) bytes
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 8) {
-               ╾───────alloc39───────╼                         │ ╾──────╼
-           }
+   |                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc39, but expected plain (non-pointer) bytes
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/const-pointer-values-in-various-types.rs:62:5
+error[E0080]: evaluation of constant value failed
+  --> $DIR/const-pointer-values-in-various-types.rs:62:47
    |
 LL |     const I32_REF_I128_UNION: i128 = unsafe { Nonsense { int_32_ref: &3 }.int_128 };
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered uninitialized bytes, but expected initialized bytes
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 16, align: 8) {
-               __ __ __ __ __ __ __ __ __ __ __ __ __ __ __ __ │ ░░░░░░░░░░░░░░░░
-           }
+   |                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered uninitialized bytes, but expected initialized bytes
 
 error: any use of this value will cause an error
   --> $DIR/const-pointer-values-in-various-types.rs:65:45
@@ -131,16 +106,11 @@ LL |     const I32_REF_F32_UNION: f32 = unsafe { Nonsense { int_32_ref: &3 }.flo
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/const-pointer-values-in-various-types.rs:69:5
+error[E0080]: evaluation of constant value failed
+  --> $DIR/const-pointer-values-in-various-types.rs:69:45
    |
 LL |     const I32_REF_F64_UNION: f64 = unsafe { Nonsense { int_32_ref: &3 }.float_64 };
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc51, but expected plain (non-pointer) bytes
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 8) {
-               ╾───────alloc51───────╼                         │ ╾──────╼
-           }
+   |                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc51, but expected plain (non-pointer) bytes
 
 error: any use of this value will cause an error
   --> $DIR/const-pointer-values-in-various-types.rs:72:47
@@ -197,16 +167,11 @@ LL |     const STR_U32_UNION: u32 = unsafe { Nonsense { stringy: "3" }.uint_32 }
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/const-pointer-values-in-various-types.rs:92:5
+error[E0080]: evaluation of constant value failed
+  --> $DIR/const-pointer-values-in-various-types.rs:92:41
    |
 LL |     const STR_U64_UNION: u64 = unsafe { Nonsense { stringy: "3" }.uint_64 };
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc72, but expected plain (non-pointer) bytes
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 8) {
-               ╾───────alloc72───────╼                         │ ╾──────╼
-           }
+   |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc72, but expected plain (non-pointer) bytes
 
 error: any use of this value will cause an error
   --> $DIR/const-pointer-values-in-various-types.rs:95:43
@@ -252,16 +217,11 @@ LL |     const STR_I32_UNION: i32 = unsafe { Nonsense { stringy: "3" }.int_32 };
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/const-pointer-values-in-various-types.rs:111:5
+error[E0080]: evaluation of constant value failed
+  --> $DIR/const-pointer-values-in-various-types.rs:111:41
    |
 LL |     const STR_I64_UNION: i64 = unsafe { Nonsense { stringy: "3" }.int_64 };
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc87, but expected plain (non-pointer) bytes
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 8) {
-               ╾───────alloc87───────╼                         │ ╾──────╼
-           }
+   |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc87, but expected plain (non-pointer) bytes
 
 error: any use of this value will cause an error
   --> $DIR/const-pointer-values-in-various-types.rs:114:43
@@ -285,16 +245,11 @@ LL |     const STR_F32_UNION: f32 = unsafe { Nonsense { stringy: "3" }.float_32 
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/const-pointer-values-in-various-types.rs:122:5
+error[E0080]: evaluation of constant value failed
+  --> $DIR/const-pointer-values-in-various-types.rs:122:41
    |
 LL |     const STR_F64_UNION: f64 = unsafe { Nonsense { stringy: "3" }.float_64 };
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc96, but expected plain (non-pointer) bytes
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 8) {
-               ╾───────alloc96───────╼                         │ ╾──────╼
-           }
+   |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc96, but expected plain (non-pointer) bytes
 
 error: any use of this value will cause an error
   --> $DIR/const-pointer-values-in-various-types.rs:125:43

--- a/src/test/ui/consts/const-eval/const-pointer-values-in-various-types.rs
+++ b/src/test/ui/consts/const-eval/const-pointer-values-in-various-types.rs
@@ -24,7 +24,7 @@ union Nonsense {
 
 fn main() {
     const I32_REF_USIZE_UNION: usize = unsafe { Nonsense { int_32_ref: &3 }.u };
-    //~^ ERROR it is undefined behavior to use this value
+    //~^ ERROR evaluation of constant value failed
 
     const I32_REF_U8_UNION: u8 = unsafe { Nonsense { int_32_ref: &3 }.uint_8 };
     //~^ ERROR any use of this value will cause an error
@@ -39,10 +39,10 @@ fn main() {
     //~| WARN this was previously accepted by the compiler but is being phased out
 
     const I32_REF_U64_UNION: u64 = unsafe { Nonsense { int_32_ref: &3 }.uint_64 };
-    //~^ ERROR it is undefined behavior to use this value
+    //~^ ERROR evaluation of constant value failed
 
     const I32_REF_U128_UNION: u128 = unsafe { Nonsense { int_32_ref: &3 }.uint_128 };
-    //~^ ERROR it is undefined behavior to use this value
+    //~^ ERROR evaluation of constant value failed
 
     const I32_REF_I8_UNION: i8 = unsafe { Nonsense { int_32_ref: &3 }.int_8 };
     //~^ ERROR any use of this value will cause an error
@@ -57,17 +57,17 @@ fn main() {
     //~| WARN this was previously accepted by the compiler but is being phased out
 
     const I32_REF_I64_UNION: i64 = unsafe { Nonsense { int_32_ref: &3 }.int_64 };
-    //~^ ERROR it is undefined behavior to use this value
+    //~^ ERROR evaluation of constant value failed
 
     const I32_REF_I128_UNION: i128 = unsafe { Nonsense { int_32_ref: &3 }.int_128 };
-    //~^ ERROR it is undefined behavior to use this value
+    //~^ ERROR evaluation of constant value failed
 
     const I32_REF_F32_UNION: f32 = unsafe { Nonsense { int_32_ref: &3 }.float_32 };
     //~^ ERROR any use of this value will cause an error
     //~| WARN this was previously accepted by the compiler but is being phased out
 
     const I32_REF_F64_UNION: f64 = unsafe { Nonsense { int_32_ref: &3 }.float_64 };
-    //~^ ERROR it is undefined behavior to use this value
+    //~^ ERROR evaluation of constant value failed
 
     const I32_REF_BOOL_UNION: bool = unsafe { Nonsense { int_32_ref: &3 }.truthy_falsey };
     //~^ ERROR any use of this value will cause an error
@@ -90,7 +90,7 @@ fn main() {
     //~| WARN this was previously accepted by the compiler but is being phased out
 
     const STR_U64_UNION: u64 = unsafe { Nonsense { stringy: "3" }.uint_64 };
-    //~^ ERROR it is undefined behavior to use this value
+    //~^ ERROR evaluation of constant value failed
 
     const STR_U128_UNION: u128 = unsafe { Nonsense { stringy: "3" }.uint_128 };
     //~^ ERROR any use of this value will cause an error
@@ -109,7 +109,7 @@ fn main() {
     //~| WARN this was previously accepted by the compiler but is being phased out
 
     const STR_I64_UNION: i64 = unsafe { Nonsense { stringy: "3" }.int_64 };
-    //~^ ERROR it is undefined behavior to use this value
+    //~^ ERROR evaluation of constant value failed
 
     const STR_I128_UNION: i128 = unsafe { Nonsense { stringy: "3" }.int_128 };
     //~^ ERROR any use of this value will cause an error
@@ -120,7 +120,7 @@ fn main() {
     //~| WARN this was previously accepted by the compiler but is being phased out
 
     const STR_F64_UNION: f64 = unsafe { Nonsense { stringy: "3" }.float_64 };
-    //~^ ERROR it is undefined behavior to use this value
+    //~^ ERROR evaluation of constant value failed
 
     const STR_BOOL_UNION: bool = unsafe { Nonsense { stringy: "3" }.truthy_falsey };
     //~^ ERROR any use of this value will cause an error

--- a/src/test/ui/consts/const-eval/ref_to_int_match.32bit.stderr
+++ b/src/test/ui/consts/const-eval/ref_to_int_match.32bit.stderr
@@ -1,13 +1,8 @@
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ref_to_int_match.rs:25:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ref_to_int_match.rs:25:27
    |
 LL | const BAR: Int = unsafe { Foo { r: &42 }.f };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc3, but expected plain (non-pointer) bytes
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 4, align: 4) {
-               ╾─alloc3──╼                                     │ ╾──╼
-           }
+   |                           ^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc3, but expected plain (non-pointer) bytes
 
 error: could not evaluate constant pattern
   --> $DIR/ref_to_int_match.rs:7:14

--- a/src/test/ui/consts/const-eval/ref_to_int_match.64bit.stderr
+++ b/src/test/ui/consts/const-eval/ref_to_int_match.64bit.stderr
@@ -1,13 +1,8 @@
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ref_to_int_match.rs:25:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ref_to_int_match.rs:25:27
    |
 LL | const BAR: Int = unsafe { Foo { r: &42 }.f };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc3, but expected plain (non-pointer) bytes
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 8) {
-               ╾───────alloc3────────╼                         │ ╾──────╼
-           }
+   |                           ^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc3, but expected plain (non-pointer) bytes
 
 error: could not evaluate constant pattern
   --> $DIR/ref_to_int_match.rs:7:14

--- a/src/test/ui/consts/const-eval/ref_to_int_match.rs
+++ b/src/test/ui/consts/const-eval/ref_to_int_match.rs
@@ -22,4 +22,4 @@ type Int = u64;
 #[cfg(target_pointer_width="32")]
 type Int = u32;
 
-const BAR: Int = unsafe { Foo { r: &42 }.f }; //~ ERROR it is undefined behavior to use this value
+const BAR: Int = unsafe { Foo { r: &42 }.f }; //~ ERROR evaluation of constant value failed

--- a/src/test/ui/consts/const-eval/transmute-const.32bit.stderr
+++ b/src/test/ui/consts/const-eval/transmute-const.32bit.stderr
@@ -1,13 +1,8 @@
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/transmute-const.rs:4:1
+error[E0080]: could not evaluate static initializer
+  --> $DIR/transmute-const.rs:4:29
    |
 LL | static FOO: bool = unsafe { mem::transmute(3u8) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 0x03, but expected a boolean
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 1, align: 1) {
-               03                                              │ .
-           }
+   |                             ^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 0x03, but expected a boolean
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/const-eval/transmute-const.64bit.stderr
+++ b/src/test/ui/consts/const-eval/transmute-const.64bit.stderr
@@ -1,13 +1,8 @@
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/transmute-const.rs:4:1
+error[E0080]: could not evaluate static initializer
+  --> $DIR/transmute-const.rs:4:29
    |
 LL | static FOO: bool = unsafe { mem::transmute(3u8) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 0x03, but expected a boolean
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 1, align: 1) {
-               03                                              │ .
-           }
+   |                             ^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 0x03, but expected a boolean
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/const-eval/transmute-const.rs
+++ b/src/test/ui/consts/const-eval/transmute-const.rs
@@ -2,6 +2,6 @@
 use std::mem;
 
 static FOO: bool = unsafe { mem::transmute(3u8) };
-//~^ ERROR it is undefined behavior to use this value
+//~^ ERROR could not evaluate static initializer
 
 fn main() {}

--- a/src/test/ui/consts/const-eval/ub-enum-overwrite.rs
+++ b/src/test/ui/consts/const-eval/ub-enum-overwrite.rs
@@ -6,12 +6,12 @@ enum E {
 }
 
 const _: u8 = {
-    //~^ ERROR is undefined behavior
     let mut e = E::A(1);
     let p = if let E::A(x) = &mut e { x as *mut u8 } else { unreachable!() };
     // Make sure overwriting `e` uninitializes other bytes
     e = E::B;
     unsafe { *p }
+    //~^ ERROR evaluation of constant value failed
 };
 
 fn main() {}

--- a/src/test/ui/consts/const-eval/ub-enum-overwrite.stderr
+++ b/src/test/ui/consts/const-eval/ub-enum-overwrite.stderr
@@ -1,19 +1,8 @@
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-enum-overwrite.rs:8:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-enum-overwrite.rs:13:14
    |
-LL | / const _: u8 = {
-LL | |
-LL | |     let mut e = E::A(1);
-LL | |     let p = if let E::A(x) = &mut e { x as *mut u8 } else { unreachable!() };
-...  |
-LL | |     unsafe { *p }
-LL | | };
-   | |__^ type validation failed: encountered uninitialized bytes, but expected initialized bytes
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 1, align: 1) {
-               __                                              │ ░
-           }
+LL |     unsafe { *p }
+   |              ^^ type validation failed: encountered uninitialized bytes, but expected initialized bytes
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/const-eval/ub-enum.32bit.stderr
+++ b/src/test/ui/consts/const-eval/ub-enum.32bit.stderr
@@ -1,123 +1,68 @@
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-enum.rs:24:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-enum.rs:24:33
    |
 LL | const BAD_ENUM: Enum = unsafe { mem::transmute(1usize) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .<enum-tag>: encountered 0x00000001, but expected a valid enum tag
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 4, align: 4) {
-               01 00 00 00                                     │ ....
-           }
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .<enum-tag>: encountered 0x00000001, but expected a valid enum tag
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-enum.rs:27:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-enum.rs:27:37
    |
 LL | const BAD_ENUM_PTR: Enum = unsafe { mem::transmute(&1) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .<enum-tag>: encountered pointer to alloc9, but expected plain (non-pointer) bytes
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 4, align: 4) {
-               ╾─alloc9──╼                                     │ ╾──╼
-           }
+   |                                     ^^^^^^^^^^^^^^^^^^ type validation failed at .<enum-tag>: encountered pointer to alloc9, but expected plain (non-pointer) bytes
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-enum.rs:30:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-enum.rs:30:47
    |
 LL | const BAD_ENUM_WRAPPED: Wrap<Enum> = unsafe { mem::transmute(&1) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .0.<enum-tag>: encountered pointer to alloc13, but expected plain (non-pointer) bytes
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 4, align: 4) {
-               ╾─alloc13─╼                                     │ ╾──╼
-           }
+   |                                               ^^^^^^^^^^^^^^^^^^ type validation failed at .0.<enum-tag>: encountered pointer to alloc13, but expected plain (non-pointer) bytes
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-enum.rs:42:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-enum.rs:42:35
    |
 LL | const BAD_ENUM2: Enum2 = unsafe { mem::transmute(0usize) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .<enum-tag>: encountered 0x00000000, but expected a valid enum tag
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 4, align: 4) {
-               00 00 00 00                                     │ ....
-           }
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .<enum-tag>: encountered 0x00000000, but expected a valid enum tag
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-enum.rs:44:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-enum.rs:44:39
    |
 LL | const BAD_ENUM2_PTR: Enum2 = unsafe { mem::transmute(&0) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .<enum-tag>: encountered pointer to alloc19, but expected plain (non-pointer) bytes
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 4, align: 4) {
-               ╾─alloc19─╼                                     │ ╾──╼
-           }
+   |                                       ^^^^^^^^^^^^^^^^^^ type validation failed at .<enum-tag>: encountered pointer to alloc19, but expected plain (non-pointer) bytes
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-enum.rs:47:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-enum.rs:47:49
    |
 LL | const BAD_ENUM2_WRAPPED: Wrap<Enum2> = unsafe { mem::transmute(&0) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .0.<enum-tag>: encountered pointer to alloc23, but expected plain (non-pointer) bytes
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 4, align: 4) {
-               ╾─alloc23─╼                                     │ ╾──╼
-           }
+   |                                                 ^^^^^^^^^^^^^^^^^^ type validation failed at .0.<enum-tag>: encountered pointer to alloc23, but expected plain (non-pointer) bytes
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-enum.rs:56:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-enum.rs:56:42
    |
 LL | const BAD_ENUM2_UNDEF : Enum2 = unsafe { MaybeUninit { uninit: () }.init };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .<enum-tag>: encountered uninitialized bytes, but expected initialized bytes
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 4, align: 4) {
-               __ __ __ __                                     │ ░░░░
-           }
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .<enum-tag>: encountered uninitialized bytes, but expected initialized bytes
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-enum.rs:60:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-enum.rs:60:54
    |
 LL | const BAD_ENUM2_OPTION_PTR: Option<Enum2> = unsafe { mem::transmute(&0) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .<enum-tag>: encountered pointer to alloc30, but expected plain (non-pointer) bytes
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 4, align: 4) {
-               ╾─alloc30─╼                                     │ ╾──╼
-           }
+   |                                                      ^^^^^^^^^^^^^^^^^^ type validation failed at .<enum-tag>: encountered pointer to alloc30, but expected plain (non-pointer) bytes
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-enum.rs:77:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-enum.rs:77:62
    |
 LL | const BAD_UNINHABITED_VARIANT1: UninhDiscriminant = unsafe { mem::transmute(1u8) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .<enum-variant(B)>.0: encountered a value of the never type `!`
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 1, align: 1) {
-               01                                              │ .
-           }
+   |                                                              ^^^^^^^^^^^^^^^^^^^ type validation failed at .<enum-variant(B)>.0: encountered a value of the never type `!`
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-enum.rs:79:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-enum.rs:79:62
    |
 LL | const BAD_UNINHABITED_VARIANT2: UninhDiscriminant = unsafe { mem::transmute(3u8) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .<enum-variant(D)>.0: encountered a value of uninhabited type Never
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 1, align: 1) {
-               03                                              │ .
-           }
+   |                                                              ^^^^^^^^^^^^^^^^^^^ type validation failed at .<enum-variant(D)>.0: encountered a value of uninhabited type Never
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-enum.rs:87:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-enum.rs:87:67
    |
 LL | const BAD_OPTION_CHAR: Option<(char, char)> = Some(('x', unsafe { mem::transmute(!0u32) }));
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .<enum-variant(Some)>.0.1: encountered 0xffffffff, but expected a valid unicode scalar value (in `0..=0x10FFFF` but not in `0xD800..=0xDFFF`)
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 4) {
-               78 00 00 00 ff ff ff ff                         │ x.......
-           }
+   |                                                                   ^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 0xffffffff, but expected a valid unicode scalar value (in `0..=0x10FFFF` but not in `0xD800..=0xDFFF`)
 
 error[E0080]: evaluation of constant value failed
   --> $DIR/ub-enum.rs:92:77

--- a/src/test/ui/consts/const-eval/ub-enum.64bit.stderr
+++ b/src/test/ui/consts/const-eval/ub-enum.64bit.stderr
@@ -1,123 +1,68 @@
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-enum.rs:24:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-enum.rs:24:33
    |
 LL | const BAD_ENUM: Enum = unsafe { mem::transmute(1usize) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .<enum-tag>: encountered 0x0000000000000001, but expected a valid enum tag
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 8) {
-               01 00 00 00 00 00 00 00                         │ ........
-           }
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .<enum-tag>: encountered 0x0000000000000001, but expected a valid enum tag
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-enum.rs:27:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-enum.rs:27:37
    |
 LL | const BAD_ENUM_PTR: Enum = unsafe { mem::transmute(&1) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .<enum-tag>: encountered pointer to alloc9, but expected plain (non-pointer) bytes
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 8) {
-               ╾───────alloc9────────╼                         │ ╾──────╼
-           }
+   |                                     ^^^^^^^^^^^^^^^^^^ type validation failed at .<enum-tag>: encountered pointer to alloc9, but expected plain (non-pointer) bytes
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-enum.rs:30:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-enum.rs:30:47
    |
 LL | const BAD_ENUM_WRAPPED: Wrap<Enum> = unsafe { mem::transmute(&1) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .0.<enum-tag>: encountered pointer to alloc13, but expected plain (non-pointer) bytes
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 8) {
-               ╾───────alloc13───────╼                         │ ╾──────╼
-           }
+   |                                               ^^^^^^^^^^^^^^^^^^ type validation failed at .0.<enum-tag>: encountered pointer to alloc13, but expected plain (non-pointer) bytes
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-enum.rs:42:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-enum.rs:42:35
    |
 LL | const BAD_ENUM2: Enum2 = unsafe { mem::transmute(0usize) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .<enum-tag>: encountered 0x0000000000000000, but expected a valid enum tag
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 8) {
-               00 00 00 00 00 00 00 00                         │ ........
-           }
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .<enum-tag>: encountered 0x0000000000000000, but expected a valid enum tag
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-enum.rs:44:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-enum.rs:44:39
    |
 LL | const BAD_ENUM2_PTR: Enum2 = unsafe { mem::transmute(&0) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .<enum-tag>: encountered pointer to alloc19, but expected plain (non-pointer) bytes
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 8) {
-               ╾───────alloc19───────╼                         │ ╾──────╼
-           }
+   |                                       ^^^^^^^^^^^^^^^^^^ type validation failed at .<enum-tag>: encountered pointer to alloc19, but expected plain (non-pointer) bytes
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-enum.rs:47:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-enum.rs:47:49
    |
 LL | const BAD_ENUM2_WRAPPED: Wrap<Enum2> = unsafe { mem::transmute(&0) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .0.<enum-tag>: encountered pointer to alloc23, but expected plain (non-pointer) bytes
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 8) {
-               ╾───────alloc23───────╼                         │ ╾──────╼
-           }
+   |                                                 ^^^^^^^^^^^^^^^^^^ type validation failed at .0.<enum-tag>: encountered pointer to alloc23, but expected plain (non-pointer) bytes
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-enum.rs:56:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-enum.rs:56:42
    |
 LL | const BAD_ENUM2_UNDEF : Enum2 = unsafe { MaybeUninit { uninit: () }.init };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .<enum-tag>: encountered uninitialized bytes, but expected initialized bytes
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 8) {
-               __ __ __ __ __ __ __ __                         │ ░░░░░░░░
-           }
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .<enum-tag>: encountered uninitialized bytes, but expected initialized bytes
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-enum.rs:60:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-enum.rs:60:54
    |
 LL | const BAD_ENUM2_OPTION_PTR: Option<Enum2> = unsafe { mem::transmute(&0) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .<enum-tag>: encountered pointer to alloc30, but expected plain (non-pointer) bytes
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 8) {
-               ╾───────alloc30───────╼                         │ ╾──────╼
-           }
+   |                                                      ^^^^^^^^^^^^^^^^^^ type validation failed at .<enum-tag>: encountered pointer to alloc30, but expected plain (non-pointer) bytes
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-enum.rs:77:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-enum.rs:77:62
    |
 LL | const BAD_UNINHABITED_VARIANT1: UninhDiscriminant = unsafe { mem::transmute(1u8) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .<enum-variant(B)>.0: encountered a value of the never type `!`
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 1, align: 1) {
-               01                                              │ .
-           }
+   |                                                              ^^^^^^^^^^^^^^^^^^^ type validation failed at .<enum-variant(B)>.0: encountered a value of the never type `!`
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-enum.rs:79:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-enum.rs:79:62
    |
 LL | const BAD_UNINHABITED_VARIANT2: UninhDiscriminant = unsafe { mem::transmute(3u8) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .<enum-variant(D)>.0: encountered a value of uninhabited type Never
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 1, align: 1) {
-               03                                              │ .
-           }
+   |                                                              ^^^^^^^^^^^^^^^^^^^ type validation failed at .<enum-variant(D)>.0: encountered a value of uninhabited type Never
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-enum.rs:87:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-enum.rs:87:67
    |
 LL | const BAD_OPTION_CHAR: Option<(char, char)> = Some(('x', unsafe { mem::transmute(!0u32) }));
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .<enum-variant(Some)>.0.1: encountered 0xffffffff, but expected a valid unicode scalar value (in `0..=0x10FFFF` but not in `0xD800..=0xDFFF`)
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 4) {
-               78 00 00 00 ff ff ff ff                         │ x.......
-           }
+   |                                                                   ^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 0xffffffff, but expected a valid unicode scalar value (in `0..=0x10FFFF` but not in `0xD800..=0xDFFF`)
 
 error[E0080]: evaluation of constant value failed
   --> $DIR/ub-enum.rs:92:77

--- a/src/test/ui/consts/const-eval/ub-enum.rs
+++ b/src/test/ui/consts/const-eval/ub-enum.rs
@@ -22,13 +22,13 @@ enum Enum {
 const GOOD_ENUM: Enum = unsafe { mem::transmute(0usize) };
 
 const BAD_ENUM: Enum = unsafe { mem::transmute(1usize) };
-//~^ ERROR is undefined behavior
+//~^ ERROR evaluation of constant value failed
 
 const BAD_ENUM_PTR: Enum = unsafe { mem::transmute(&1) };
-//~^ ERROR is undefined behavior
+//~^ ERROR evaluation of constant value failed
 
 const BAD_ENUM_WRAPPED: Wrap<Enum> = unsafe { mem::transmute(&1) };
-//~^ ERROR is undefined behavior
+//~^ ERROR evaluation of constant value failed
 
 // # simple enum with discriminant 2
 
@@ -40,12 +40,12 @@ enum Enum2 {
 }
 
 const BAD_ENUM2: Enum2 = unsafe { mem::transmute(0usize) };
-//~^ ERROR is undefined behavior
+//~^ ERROR evaluation of constant value failed
 const BAD_ENUM2_PTR: Enum2 = unsafe { mem::transmute(&0) };
-//~^ ERROR is undefined behavior
+//~^ ERROR evaluation of constant value failed
 // something wrapping the enum so that we test layout first, not enum
 const BAD_ENUM2_WRAPPED: Wrap<Enum2> = unsafe { mem::transmute(&0) };
-//~^ ERROR is undefined behavior
+//~^ ERROR evaluation of constant value failed
 
 // Undef enum discriminant.
 #[repr(C)]
@@ -54,11 +54,11 @@ union MaybeUninit<T: Copy> {
     init: T,
 }
 const BAD_ENUM2_UNDEF : Enum2 = unsafe { MaybeUninit { uninit: () }.init };
-//~^ ERROR is undefined behavior
+//~^ ERROR evaluation of constant value failed
 
 // Pointer value in an enum with a niche that is not just 0.
 const BAD_ENUM2_OPTION_PTR: Option<Enum2> = unsafe { mem::transmute(&0) };
-//~^ ERROR is undefined behavior
+//~^ ERROR evaluation of constant value failed
 
 // # valid discriminant for uninhabited variant
 
@@ -75,9 +75,9 @@ const GOOD_INHABITED_VARIANT1: UninhDiscriminant = unsafe { mem::transmute(0u8) 
 const GOOD_INHABITED_VARIANT2: UninhDiscriminant = unsafe { mem::transmute(2u8) }; // variant C
 
 const BAD_UNINHABITED_VARIANT1: UninhDiscriminant = unsafe { mem::transmute(1u8) };
-//~^ ERROR is undefined behavior
+//~^ ERROR evaluation of constant value failed
 const BAD_UNINHABITED_VARIANT2: UninhDiscriminant = unsafe { mem::transmute(3u8) };
-//~^ ERROR is undefined behavior
+//~^ ERROR evaluation of constant value failed
 
 // # other
 
@@ -85,7 +85,7 @@ const BAD_UNINHABITED_VARIANT2: UninhDiscriminant = unsafe { mem::transmute(3u8)
 // variants and tuples).
 // Need to create something which does not clash with enum layout optimizations.
 const BAD_OPTION_CHAR: Option<(char, char)> = Some(('x', unsafe { mem::transmute(!0u32) }));
-//~^ ERROR is undefined behavior
+//~^ ERROR evaluation of constant value failed
 
 // All variants are uninhabited but also have data.
 // Use `0` as constant to make behavior endianess-independent.

--- a/src/test/ui/consts/const-eval/ub-incorrect-vtable.32bit.stderr
+++ b/src/test/ui/consts/const-eval/ub-incorrect-vtable.32bit.stderr
@@ -2,37 +2,25 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/ub-incorrect-vtable.rs:19:14
    |
 LL |     unsafe { std::mem::transmute((&92u8, &[0usize, 1usize, 1000usize])) };
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ invalid vtable: alignment `1000` is not a power of 2
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered invalid drop function pointer in vtable (not pointing to a function)
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/ub-incorrect-vtable.rs:24:14
+  --> $DIR/ub-incorrect-vtable.rs:23:14
    |
 LL |     unsafe { std::mem::transmute((&92u8, &[1usize, usize::MAX, 1usize])) };
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ invalid vtable: size is bigger than largest supported object
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered invalid drop function pointer in vtable (not pointing to a function)
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-incorrect-vtable.rs:34:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-incorrect-vtable.rs:33:14
    |
-LL | / const INVALID_VTABLE_ALIGNMENT_UB: W<&dyn Trait> =
-LL | |     unsafe { std::mem::transmute((&92u8, &(drop_me as fn(*mut usize), 1usize, 1000usize))) };
-   | |_____________________________________________________________________________________________^ type validation failed at .0: encountered invalid vtable: alignment `1000` is not a power of 2
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾─allocN─╼ ╾─allocN─╼                         │ ╾──╼╾──╼
-           }
+LL |     unsafe { std::mem::transmute((&92u8, &(drop_me as fn(*mut usize), 1usize, 1000usize))) };
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .0: encountered invalid vtable: alignment `1000` is not a power of 2
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-incorrect-vtable.rs:39:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-incorrect-vtable.rs:37:14
    |
-LL | / const INVALID_VTABLE_SIZE_UB: W<&dyn Trait> =
-LL | |     unsafe { std::mem::transmute((&92u8, &(drop_me as fn(*mut usize), usize::MAX, 1usize))) };
-   | |______________________________________________________________________________________________^ type validation failed at .0: encountered invalid vtable: size is bigger than largest supported object
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾─allocN─╼ ╾─allocN─╼                         │ ╾──╼╾──╼
-           }
+LL |     unsafe { std::mem::transmute((&92u8, &(drop_me as fn(*mut usize), usize::MAX, 1usize))) };
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .0: encountered invalid vtable: size is bigger than largest supported object
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/consts/const-eval/ub-incorrect-vtable.64bit.stderr
+++ b/src/test/ui/consts/const-eval/ub-incorrect-vtable.64bit.stderr
@@ -2,37 +2,25 @@ error[E0080]: evaluation of constant value failed
   --> $DIR/ub-incorrect-vtable.rs:19:14
    |
 LL |     unsafe { std::mem::transmute((&92u8, &[0usize, 1usize, 1000usize])) };
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ invalid vtable: alignment `1000` is not a power of 2
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered invalid drop function pointer in vtable (not pointing to a function)
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/ub-incorrect-vtable.rs:24:14
+  --> $DIR/ub-incorrect-vtable.rs:23:14
    |
 LL |     unsafe { std::mem::transmute((&92u8, &[1usize, usize::MAX, 1usize])) };
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ invalid vtable: size is bigger than largest supported object
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered invalid drop function pointer in vtable (not pointing to a function)
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-incorrect-vtable.rs:34:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-incorrect-vtable.rs:33:14
    |
-LL | / const INVALID_VTABLE_ALIGNMENT_UB: W<&dyn Trait> =
-LL | |     unsafe { std::mem::transmute((&92u8, &(drop_me as fn(*mut usize), 1usize, 1000usize))) };
-   | |_____________________________________________________________________________________________^ type validation failed at .0: encountered invalid vtable: alignment `1000` is not a power of 2
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾───────allocN───────╼ ╾───────allocN───────╼ │ ╾──────╼╾──────╼
-           }
+LL |     unsafe { std::mem::transmute((&92u8, &(drop_me as fn(*mut usize), 1usize, 1000usize))) };
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .0: encountered invalid vtable: alignment `1000` is not a power of 2
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-incorrect-vtable.rs:39:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-incorrect-vtable.rs:37:14
    |
-LL | / const INVALID_VTABLE_SIZE_UB: W<&dyn Trait> =
-LL | |     unsafe { std::mem::transmute((&92u8, &(drop_me as fn(*mut usize), usize::MAX, 1usize))) };
-   | |______________________________________________________________________________________________^ type validation failed at .0: encountered invalid vtable: size is bigger than largest supported object
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾───────allocN───────╼ ╾───────allocN───────╼ │ ╾──────╼╾──────╼
-           }
+LL |     unsafe { std::mem::transmute((&92u8, &(drop_me as fn(*mut usize), usize::MAX, 1usize))) };
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .0: encountered invalid vtable: size is bigger than largest supported object
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/consts/const-eval/ub-incorrect-vtable.rs
+++ b/src/test/ui/consts/const-eval/ub-incorrect-vtable.rs
@@ -18,12 +18,10 @@ trait Trait {}
 const INVALID_VTABLE_ALIGNMENT: &dyn Trait =
     unsafe { std::mem::transmute((&92u8, &[0usize, 1usize, 1000usize])) };
 //~^ ERROR evaluation of constant value failed
-//~| invalid vtable: alignment `1000` is not a power of 2
 
 const INVALID_VTABLE_SIZE: &dyn Trait =
     unsafe { std::mem::transmute((&92u8, &[1usize, usize::MAX, 1usize])) };
 //~^ ERROR evaluation of constant value failed
-//~| invalid vtable: size is bigger than largest supported object
 
 #[repr(transparent)]
 struct W<T>(T);
@@ -33,12 +31,10 @@ fn drop_me(_: *mut usize) {}
 
 const INVALID_VTABLE_ALIGNMENT_UB: W<&dyn Trait> =
     unsafe { std::mem::transmute((&92u8, &(drop_me as fn(*mut usize), 1usize, 1000usize))) };
-//~^^ ERROR it is undefined behavior to use this value
-//~| invalid vtable: alignment `1000` is not a power of 2
+//~^ ERROR evaluation of constant value failed
 
 const INVALID_VTABLE_SIZE_UB: W<&dyn Trait> =
     unsafe { std::mem::transmute((&92u8, &(drop_me as fn(*mut usize), usize::MAX, 1usize))) };
-//~^^ ERROR it is undefined behavior to use this value
-//~| invalid vtable: size is bigger than largest supported object
+//~^ ERROR evaluation of constant value failed
 
 fn main() {}

--- a/src/test/ui/consts/const-eval/ub-int-array.32bit.stderr
+++ b/src/test/ui/consts/const-eval/ub-int-array.32bit.stderr
@@ -1,53 +1,20 @@
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-int-array.rs:14:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-int-array.rs:16:9
    |
-LL | / const UNINIT_INT_0: [u32; 3] = unsafe {
-LL | |
-LL | |
-LL | |     [
-...  |
-LL | |     ]
-LL | | };
-   | |__^ type validation failed at [0]: encountered uninitialized bytes
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 12, align: 4) {
-               __ __ __ __ 01 00 00 00 02 00 00 00             │ ░░░░........
-           }
+LL |         MaybeUninit { uninit: () }.init,
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered uninitialized bytes, but expected initialized bytes
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-int-array.rs:23:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-int-array.rs:29:13
    |
-LL | / const UNINIT_INT_1: [u32; 3] = unsafe {
-LL | |
-LL | |
-LL | |     mem::transmute(
-...  |
-LL | |     )
-LL | | };
-   | |__^ type validation failed at [1]: encountered uninitialized bytes
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 12, align: 4) {
-               00 00 00 00 01 __ 01 01 02 02 __ 02             │ .....░....░.
-           }
+LL |             MaybeUninit { uninit: () }.init,
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered uninitialized bytes, but expected initialized bytes
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-int-array.rs:43:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-int-array.rs:53:13
    |
-LL | / const UNINIT_INT_2: [u32; 3] = unsafe {
-LL | |
-LL | |
-LL | |     mem::transmute(
-...  |
-LL | |     )
-LL | | };
-   | |__^ type validation failed at [2]: encountered uninitialized bytes
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 12, align: 4) {
-               00 00 00 00 01 01 01 01 02 02 02 __             │ ...........░
-           }
+LL |             MaybeUninit { uninit: () }.init,
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered uninitialized bytes, but expected initialized bytes
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/consts/const-eval/ub-int-array.64bit.stderr
+++ b/src/test/ui/consts/const-eval/ub-int-array.64bit.stderr
@@ -1,53 +1,20 @@
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-int-array.rs:14:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-int-array.rs:16:9
    |
-LL | / const UNINIT_INT_0: [u32; 3] = unsafe {
-LL | |
-LL | |
-LL | |     [
-...  |
-LL | |     ]
-LL | | };
-   | |__^ type validation failed at [0]: encountered uninitialized bytes
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 12, align: 4) {
-               __ __ __ __ 01 00 00 00 02 00 00 00             │ ░░░░........
-           }
+LL |         MaybeUninit { uninit: () }.init,
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered uninitialized bytes, but expected initialized bytes
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-int-array.rs:23:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-int-array.rs:29:13
    |
-LL | / const UNINIT_INT_1: [u32; 3] = unsafe {
-LL | |
-LL | |
-LL | |     mem::transmute(
-...  |
-LL | |     )
-LL | | };
-   | |__^ type validation failed at [1]: encountered uninitialized bytes
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 12, align: 4) {
-               00 00 00 00 01 __ 01 01 02 02 __ 02             │ .....░....░.
-           }
+LL |             MaybeUninit { uninit: () }.init,
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered uninitialized bytes, but expected initialized bytes
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-int-array.rs:43:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-int-array.rs:53:13
    |
-LL | / const UNINIT_INT_2: [u32; 3] = unsafe {
-LL | |
-LL | |
-LL | |     mem::transmute(
-...  |
-LL | |     )
-LL | | };
-   | |__^ type validation failed at [2]: encountered uninitialized bytes
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 12, align: 4) {
-               00 00 00 00 01 01 01 01 02 02 02 __             │ ...........░
-           }
+LL |             MaybeUninit { uninit: () }.init,
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered uninitialized bytes, but expected initialized bytes
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/consts/const-eval/ub-int-array.rs
+++ b/src/test/ui/consts/const-eval/ub-int-array.rs
@@ -12,17 +12,13 @@ union MaybeUninit<T: Copy> {
 }
 
 const UNINIT_INT_0: [u32; 3] = unsafe {
-//~^ ERROR it is undefined behavior to use this value
-//~| type validation failed at [0]: encountered uninitialized bytes
     [
-        MaybeUninit { uninit: () }.init,
+        MaybeUninit { uninit: () }.init, //~ ERROR evaluation of constant value failed
         1,
         2,
     ]
 };
 const UNINIT_INT_1: [u32; 3] = unsafe {
-//~^ ERROR it is undefined behavior to use this value
-//~| type validation failed at [1]: encountered uninitialized bytes
     mem::transmute(
         [
             0u8,
@@ -30,7 +26,7 @@ const UNINIT_INT_1: [u32; 3] = unsafe {
             0u8,
             0u8,
             1u8,
-            MaybeUninit { uninit: () }.init,
+            MaybeUninit { uninit: () }.init, //~ ERROR evaluation of constant value failed
             1u8,
             1u8,
             2u8,
@@ -41,8 +37,6 @@ const UNINIT_INT_1: [u32; 3] = unsafe {
     )
 };
 const UNINIT_INT_2: [u32; 3] = unsafe {
-//~^ ERROR it is undefined behavior to use this value
-//~| type validation failed at [2]: encountered uninitialized bytes
     mem::transmute(
         [
             0u8,
@@ -56,7 +50,7 @@ const UNINIT_INT_2: [u32; 3] = unsafe {
             2u8,
             2u8,
             2u8,
-            MaybeUninit { uninit: () }.init,
+            MaybeUninit { uninit: () }.init, //~ ERROR evaluation of constant value failed
         ]
     )
 };

--- a/src/test/ui/consts/const-eval/ub-nonnull.32bit.stderr
+++ b/src/test/ui/consts/const-eval/ub-nonnull.32bit.stderr
@@ -1,74 +1,44 @@
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-nonnull.rs:12:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-nonnull.rs:12:40
    |
 LL | const NULL_PTR: NonNull<u8> = unsafe { mem::transmute(0usize) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 0, but expected something greater or equal to 1
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 4, align: 4) {
-               00 00 00 00                                     │ ....
-           }
+   |                                        ^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 0, but expected something greater or equal to 1
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/ub-nonnull.rs:19:30
+  --> $DIR/ub-nonnull.rs:17:27
    |
-LL |     let out_of_bounds_ptr = &ptr[255];
-   |                              ^^^^^^^^ dereferencing pointer failed: alloc11 has size 1, so pointer to 256 bytes starting at offset 0 is out-of-bounds
+LL |     let ptr: &[u8; 256] = mem::transmute(&0u8); // &0 gets promoted so it does not dangle
+   |                           ^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a dangling reference (going beyond the bounds of its allocation)
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-nonnull.rs:23:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-nonnull.rs:24:37
    |
 LL | const NULL_U8: NonZeroU8 = unsafe { mem::transmute(0u8) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 0, but expected something greater or equal to 1
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 1, align: 1) {
-               00                                              │ .
-           }
+   |                                     ^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 0, but expected something greater or equal to 1
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-nonnull.rs:25:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-nonnull.rs:26:43
    |
 LL | const NULL_USIZE: NonZeroUsize = unsafe { mem::transmute(0usize) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 0, but expected something greater or equal to 1
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 4, align: 4) {
-               00 00 00 00                                     │ ....
-           }
+   |                                           ^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 0, but expected something greater or equal to 1
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-nonnull.rs:33:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-nonnull.rs:34:36
    |
 LL | const UNINIT: NonZeroU8 = unsafe { MaybeUninit { uninit: () }.init };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .0: encountered uninitialized bytes, but expected initialized bytes
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 1, align: 1) {
-               __                                              │ ░
-           }
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .0: encountered uninitialized bytes, but expected initialized bytes
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-nonnull.rs:41:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-nonnull.rs:42:1
    |
 LL | const BAD_RANGE1: RestrictedRange1 = unsafe { RestrictedRange1(42) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 42, but expected something in the range 10..=30
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 4, align: 4) {
-               2a 00 00 00                                     │ *...
-           }
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-nonnull.rs:47:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-nonnull.rs:48:1
    |
 LL | const BAD_RANGE2: RestrictedRange2 = unsafe { RestrictedRange2(20) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 20, but expected something less or equal to 10, or greater or equal to 30
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 4, align: 4) {
-               14 00 00 00                                     │ ....
-           }
 
 error: aborting due to 7 previous errors
 

--- a/src/test/ui/consts/const-eval/ub-nonnull.64bit.stderr
+++ b/src/test/ui/consts/const-eval/ub-nonnull.64bit.stderr
@@ -1,74 +1,44 @@
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-nonnull.rs:12:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-nonnull.rs:12:40
    |
 LL | const NULL_PTR: NonNull<u8> = unsafe { mem::transmute(0usize) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 0, but expected something greater or equal to 1
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 8) {
-               00 00 00 00 00 00 00 00                         │ ........
-           }
+   |                                        ^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 0, but expected something greater or equal to 1
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/ub-nonnull.rs:19:30
+  --> $DIR/ub-nonnull.rs:17:27
    |
-LL |     let out_of_bounds_ptr = &ptr[255];
-   |                              ^^^^^^^^ dereferencing pointer failed: alloc11 has size 1, so pointer to 256 bytes starting at offset 0 is out-of-bounds
+LL |     let ptr: &[u8; 256] = mem::transmute(&0u8); // &0 gets promoted so it does not dangle
+   |                           ^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a dangling reference (going beyond the bounds of its allocation)
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-nonnull.rs:23:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-nonnull.rs:24:37
    |
 LL | const NULL_U8: NonZeroU8 = unsafe { mem::transmute(0u8) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 0, but expected something greater or equal to 1
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 1, align: 1) {
-               00                                              │ .
-           }
+   |                                     ^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 0, but expected something greater or equal to 1
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-nonnull.rs:25:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-nonnull.rs:26:43
    |
 LL | const NULL_USIZE: NonZeroUsize = unsafe { mem::transmute(0usize) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 0, but expected something greater or equal to 1
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 8) {
-               00 00 00 00 00 00 00 00                         │ ........
-           }
+   |                                           ^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 0, but expected something greater or equal to 1
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-nonnull.rs:33:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-nonnull.rs:34:36
    |
 LL | const UNINIT: NonZeroU8 = unsafe { MaybeUninit { uninit: () }.init };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .0: encountered uninitialized bytes, but expected initialized bytes
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 1, align: 1) {
-               __                                              │ ░
-           }
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .0: encountered uninitialized bytes, but expected initialized bytes
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-nonnull.rs:41:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-nonnull.rs:42:1
    |
 LL | const BAD_RANGE1: RestrictedRange1 = unsafe { RestrictedRange1(42) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 42, but expected something in the range 10..=30
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 4, align: 4) {
-               2a 00 00 00                                     │ *...
-           }
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-nonnull.rs:47:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-nonnull.rs:48:1
    |
 LL | const BAD_RANGE2: RestrictedRange2 = unsafe { RestrictedRange2(20) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 20, but expected something less or equal to 10, or greater or equal to 30
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 4, align: 4) {
-               14 00 00 00                                     │ ....
-           }
 
 error: aborting due to 7 previous errors
 

--- a/src/test/ui/consts/const-eval/ub-nonnull.rs
+++ b/src/test/ui/consts/const-eval/ub-nonnull.rs
@@ -10,20 +10,21 @@ const NON_NULL: NonNull<u8> = unsafe { mem::transmute(1usize) };
 const NON_NULL_PTR: NonNull<u8> = unsafe { mem::transmute(&1) };
 
 const NULL_PTR: NonNull<u8> = unsafe { mem::transmute(0usize) };
-//~^ ERROR it is undefined behavior to use this value
+//~^ ERROR evaluation of constant value failed
 
 #[deny(const_err)] // this triggers a `const_err` so validation does not even happen
 const OUT_OF_BOUNDS_PTR: NonNull<u8> = { unsafe {
     let ptr: &[u8; 256] = mem::transmute(&0u8); // &0 gets promoted so it does not dangle
+    //~^ ERROR evaluation of constant value failed
     // Use address-of-element for pointer arithmetic. This could wrap around to null!
-    let out_of_bounds_ptr = &ptr[255]; //~ ERROR evaluation of constant value failed
+    let out_of_bounds_ptr = &ptr[255];
     mem::transmute(out_of_bounds_ptr)
 } };
 
 const NULL_U8: NonZeroU8 = unsafe { mem::transmute(0u8) };
-//~^ ERROR it is undefined behavior to use this value
+//~^ ERROR evaluation of constant value failed
 const NULL_USIZE: NonZeroUsize = unsafe { mem::transmute(0usize) };
-//~^ ERROR it is undefined behavior to use this value
+//~^ ERROR evaluation of constant value failed
 
 #[repr(C)]
 union MaybeUninit<T: Copy> {
@@ -31,7 +32,7 @@ union MaybeUninit<T: Copy> {
     init: T,
 }
 const UNINIT: NonZeroU8 = unsafe { MaybeUninit { uninit: () }.init };
-//~^ ERROR it is undefined behavior to use this value
+//~^ ERROR evaluation of constant value failed
 
 // Also test other uses of rustc_layout_scalar_valid_range_start
 
@@ -39,12 +40,12 @@ const UNINIT: NonZeroU8 = unsafe { MaybeUninit { uninit: () }.init };
 #[rustc_layout_scalar_valid_range_end(30)]
 struct RestrictedRange1(u32);
 const BAD_RANGE1: RestrictedRange1 = unsafe { RestrictedRange1(42) };
-//~^ ERROR it is undefined behavior to use this value
+//~^ ERROR evaluation of constant value failed
 
 #[rustc_layout_scalar_valid_range_start(30)]
 #[rustc_layout_scalar_valid_range_end(10)]
 struct RestrictedRange2(u32);
 const BAD_RANGE2: RestrictedRange2 = unsafe { RestrictedRange2(20) };
-//~^ ERROR it is undefined behavior to use this value
+//~^ ERROR evaluation of constant value failed
 
 fn main() {}

--- a/src/test/ui/consts/const-eval/ub-ref-ptr.32bit.stderr
+++ b/src/test/ui/consts/const-eval/ub-ref-ptr.32bit.stderr
@@ -1,134 +1,74 @@
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-ref-ptr.rs:13:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-ref-ptr.rs:13:34
    |
 LL | const UNALIGNED: &u16 = unsafe { mem::transmute(&[0u8; 4]) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered an unaligned reference (required 2 byte alignment but found 1)
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 4, align: 4) {
-               ╾─alloc3──╼                                     │ ╾──╼
-           }
+   |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered an unaligned reference (required 2 byte alignment but found 1)
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-ref-ptr.rs:17:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-ref-ptr.rs:17:42
    |
 LL | const UNALIGNED_BOX: Box<u16> = unsafe { mem::transmute(&[0u8; 4]) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered an unaligned box (required 2 byte alignment but found 1)
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 4, align: 4) {
-               ╾─alloc7──╼                                     │ ╾──╼
-           }
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered an unaligned box (required 2 byte alignment but found 1)
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-ref-ptr.rs:21:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-ref-ptr.rs:21:29
    |
 LL | const NULL: &u16 = unsafe { mem::transmute(0usize) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a null reference
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 4, align: 4) {
-               00 00 00 00                                     │ ....
-           }
+   |                             ^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a null reference
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-ref-ptr.rs:24:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-ref-ptr.rs:24:37
    |
 LL | const NULL_BOX: Box<u16> = unsafe { mem::transmute(0usize) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a null box
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 4, align: 4) {
-               00 00 00 00                                     │ ....
-           }
+   |                                     ^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a null box
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-ref-ptr.rs:31:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-ref-ptr.rs:31:38
    |
 LL | const REF_AS_USIZE: usize = unsafe { mem::transmute(&0) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc15, but expected plain (non-pointer) bytes
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 4, align: 4) {
-               ╾─alloc15─╼                                     │ ╾──╼
-           }
+   |                                      ^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc15, but expected plain (non-pointer) bytes
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-ref-ptr.rs:34:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-ref-ptr.rs:34:49
    |
 LL | const REF_AS_USIZE_SLICE: &[usize] = &[unsafe { mem::transmute(&0) }];
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .<deref>: encountered a pointer, but expected plain (non-pointer) bytes
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 4, align: 4) {
-               ╾─alloc21─╼                                     │ ╾──╼
-           }
+   |                                                 ^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc19, but expected plain (non-pointer) bytes
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-ref-ptr.rs:37:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-ref-ptr.rs:37:87
    |
 LL | const REF_AS_USIZE_BOX_SLICE: Box<[usize]> = unsafe { mem::transmute::<&[usize], _>(&[mem::transmute(&0)]) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .<deref>: encountered a pointer, but expected plain (non-pointer) bytes
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 4, align: 4) {
-               ╾─alloc26─╼                                     │ ╾──╼
-           }
+   |                                                                                       ^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc23, but expected plain (non-pointer) bytes
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-ref-ptr.rs:40:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-ref-ptr.rs:40:44
    |
 LL | const USIZE_AS_REF: &'static u8 = unsafe { mem::transmute(1337usize) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a dangling reference (address 0x539 is unallocated)
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 4, align: 4) {
-               39 05 00 00                                     │ 9...
-           }
+   |                                            ^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a dangling reference (address 0x539 is unallocated)
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-ref-ptr.rs:43:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-ref-ptr.rs:43:40
    |
 LL | const USIZE_AS_BOX: Box<u8> = unsafe { mem::transmute(1337usize) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a dangling box (address 0x539 is unallocated)
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 4, align: 4) {
-               39 05 00 00                                     │ 9...
-           }
+   |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a dangling box (address 0x539 is unallocated)
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-ref-ptr.rs:46:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-ref-ptr.rs:46:41
    |
 LL | const UNINIT_PTR: *const i32 = unsafe { MaybeUninit { uninit: () }.init };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered uninitialized raw pointer
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 4, align: 4) {
-               __ __ __ __                                     │ ░░░░
-           }
+   |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered uninitialized raw pointer
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-ref-ptr.rs:49:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-ref-ptr.rs:49:36
    |
 LL | const NULL_FN_PTR: fn() = unsafe { mem::transmute(0usize) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a null function pointer
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 4, align: 4) {
-               00 00 00 00                                     │ ....
-           }
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a null function pointer
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-ref-ptr.rs:51:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-ref-ptr.rs:51:38
    |
 LL | const UNINIT_FN_PTR: fn() = unsafe { MaybeUninit { uninit: () }.init };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered uninitialized bytes, but expected a proper pointer or integer value
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 4, align: 4) {
-               __ __ __ __                                     │ ░░░░
-           }
+   |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered uninitialized bytes, but expected a proper pointer or integer value
 
 error[E0080]: it is undefined behavior to use this value
   --> $DIR/ub-ref-ptr.rs:53:1
@@ -145,11 +85,11 @@ error[E0080]: it is undefined behavior to use this value
   --> $DIR/ub-ref-ptr.rs:55:1
    |
 LL | const DATA_FN_PTR: fn() = unsafe { mem::transmute(&13) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc43, but expected a function pointer
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc41, but expected a function pointer
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 4, align: 4) {
-               ╾─alloc43─╼                                     │ ╾──╼
+               ╾─alloc41─╼                                     │ ╾──╼
            }
 
 error: aborting due to 14 previous errors

--- a/src/test/ui/consts/const-eval/ub-ref-ptr.64bit.stderr
+++ b/src/test/ui/consts/const-eval/ub-ref-ptr.64bit.stderr
@@ -1,134 +1,74 @@
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-ref-ptr.rs:13:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-ref-ptr.rs:13:34
    |
 LL | const UNALIGNED: &u16 = unsafe { mem::transmute(&[0u8; 4]) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered an unaligned reference (required 2 byte alignment but found 1)
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 8) {
-               ╾───────alloc3────────╼                         │ ╾──────╼
-           }
+   |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered an unaligned reference (required 2 byte alignment but found 1)
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-ref-ptr.rs:17:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-ref-ptr.rs:17:42
    |
 LL | const UNALIGNED_BOX: Box<u16> = unsafe { mem::transmute(&[0u8; 4]) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered an unaligned box (required 2 byte alignment but found 1)
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 8) {
-               ╾───────alloc7────────╼                         │ ╾──────╼
-           }
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered an unaligned box (required 2 byte alignment but found 1)
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-ref-ptr.rs:21:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-ref-ptr.rs:21:29
    |
 LL | const NULL: &u16 = unsafe { mem::transmute(0usize) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a null reference
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 8) {
-               00 00 00 00 00 00 00 00                         │ ........
-           }
+   |                             ^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a null reference
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-ref-ptr.rs:24:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-ref-ptr.rs:24:37
    |
 LL | const NULL_BOX: Box<u16> = unsafe { mem::transmute(0usize) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a null box
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 8) {
-               00 00 00 00 00 00 00 00                         │ ........
-           }
+   |                                     ^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a null box
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-ref-ptr.rs:31:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-ref-ptr.rs:31:38
    |
 LL | const REF_AS_USIZE: usize = unsafe { mem::transmute(&0) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc15, but expected plain (non-pointer) bytes
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 8) {
-               ╾───────alloc15───────╼                         │ ╾──────╼
-           }
+   |                                      ^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc15, but expected plain (non-pointer) bytes
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-ref-ptr.rs:34:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-ref-ptr.rs:34:49
    |
 LL | const REF_AS_USIZE_SLICE: &[usize] = &[unsafe { mem::transmute(&0) }];
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .<deref>: encountered a pointer, but expected plain (non-pointer) bytes
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 8) {
-               ╾───────alloc21───────╼                         │ ╾──────╼
-           }
+   |                                                 ^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc19, but expected plain (non-pointer) bytes
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-ref-ptr.rs:37:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-ref-ptr.rs:37:87
    |
 LL | const REF_AS_USIZE_BOX_SLICE: Box<[usize]> = unsafe { mem::transmute::<&[usize], _>(&[mem::transmute(&0)]) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .<deref>: encountered a pointer, but expected plain (non-pointer) bytes
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 8) {
-               ╾───────alloc26───────╼                         │ ╾──────╼
-           }
+   |                                                                                       ^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc23, but expected plain (non-pointer) bytes
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-ref-ptr.rs:40:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-ref-ptr.rs:40:44
    |
 LL | const USIZE_AS_REF: &'static u8 = unsafe { mem::transmute(1337usize) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a dangling reference (address 0x539 is unallocated)
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 8) {
-               39 05 00 00 00 00 00 00                         │ 9.......
-           }
+   |                                            ^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a dangling reference (address 0x539 is unallocated)
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-ref-ptr.rs:43:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-ref-ptr.rs:43:40
    |
 LL | const USIZE_AS_BOX: Box<u8> = unsafe { mem::transmute(1337usize) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a dangling box (address 0x539 is unallocated)
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 8) {
-               39 05 00 00 00 00 00 00                         │ 9.......
-           }
+   |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a dangling box (address 0x539 is unallocated)
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-ref-ptr.rs:46:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-ref-ptr.rs:46:41
    |
 LL | const UNINIT_PTR: *const i32 = unsafe { MaybeUninit { uninit: () }.init };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered uninitialized raw pointer
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 8) {
-               __ __ __ __ __ __ __ __                         │ ░░░░░░░░
-           }
+   |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered uninitialized raw pointer
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-ref-ptr.rs:49:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-ref-ptr.rs:49:36
    |
 LL | const NULL_FN_PTR: fn() = unsafe { mem::transmute(0usize) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a null function pointer
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 8) {
-               00 00 00 00 00 00 00 00                         │ ........
-           }
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a null function pointer
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-ref-ptr.rs:51:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-ref-ptr.rs:51:38
    |
 LL | const UNINIT_FN_PTR: fn() = unsafe { MaybeUninit { uninit: () }.init };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered uninitialized bytes, but expected a proper pointer or integer value
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 8) {
-               __ __ __ __ __ __ __ __                         │ ░░░░░░░░
-           }
+   |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered uninitialized bytes, but expected a proper pointer or integer value
 
 error[E0080]: it is undefined behavior to use this value
   --> $DIR/ub-ref-ptr.rs:53:1
@@ -145,11 +85,11 @@ error[E0080]: it is undefined behavior to use this value
   --> $DIR/ub-ref-ptr.rs:55:1
    |
 LL | const DATA_FN_PTR: fn() = unsafe { mem::transmute(&13) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc43, but expected a function pointer
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc41, but expected a function pointer
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 8, align: 8) {
-               ╾───────alloc43───────╼                         │ ╾──────╼
+               ╾───────alloc41───────╼                         │ ╾──────╼
            }
 
 error: aborting due to 14 previous errors

--- a/src/test/ui/consts/const-eval/ub-ref-ptr.rs
+++ b/src/test/ui/consts/const-eval/ub-ref-ptr.rs
@@ -11,45 +11,45 @@ union MaybeUninit<T: Copy> {
 }
 
 const UNALIGNED: &u16 = unsafe { mem::transmute(&[0u8; 4]) };
-//~^ ERROR it is undefined behavior to use this value
+//~^ ERROR evaluation of constant value failed
 //~| type validation failed: encountered an unaligned reference (required 2 byte alignment but found 1)
 
 const UNALIGNED_BOX: Box<u16> = unsafe { mem::transmute(&[0u8; 4]) };
-//~^ ERROR it is undefined behavior to use this value
+//~^ ERROR evaluation of constant value failed
 //~| type validation failed: encountered an unaligned box (required 2 byte alignment but found 1)
 
 const NULL: &u16 = unsafe { mem::transmute(0usize) };
-//~^ ERROR it is undefined behavior to use this value
+//~^ ERROR evaluation of constant value failed
 
 const NULL_BOX: Box<u16> = unsafe { mem::transmute(0usize) };
-//~^ ERROR it is undefined behavior to use this value
+//~^ ERROR evaluation of constant value failed
 
 
 // It is very important that we reject this: We do promote `&(4 * REF_AS_USIZE)`,
 // but that would fail to compile; so we ended up breaking user code that would
 // have worked fine had we not promoted.
 const REF_AS_USIZE: usize = unsafe { mem::transmute(&0) };
-//~^ ERROR it is undefined behavior to use this value
+//~^ ERROR evaluation of constant value failed
 
 const REF_AS_USIZE_SLICE: &[usize] = &[unsafe { mem::transmute(&0) }];
-//~^ ERROR it is undefined behavior to use this value
+//~^ ERROR evaluation of constant value failed
 
 const REF_AS_USIZE_BOX_SLICE: Box<[usize]> = unsafe { mem::transmute::<&[usize], _>(&[mem::transmute(&0)]) };
-//~^ ERROR it is undefined behavior to use this value
+//~^ ERROR evaluation of constant value failed
 
 const USIZE_AS_REF: &'static u8 = unsafe { mem::transmute(1337usize) };
-//~^ ERROR it is undefined behavior to use this value
+//~^ ERROR evaluation of constant value failed
 
 const USIZE_AS_BOX: Box<u8> = unsafe { mem::transmute(1337usize) };
-//~^ ERROR it is undefined behavior to use this value
+//~^ ERROR evaluation of constant value failed
 
 const UNINIT_PTR: *const i32 = unsafe { MaybeUninit { uninit: () }.init };
-//~^ ERROR it is undefined behavior to use this value
+//~^ ERROR evaluation of constant value failed
 
 const NULL_FN_PTR: fn() = unsafe { mem::transmute(0usize) };
-//~^ ERROR it is undefined behavior to use this value
+//~^ ERROR evaluation of constant value failed
 const UNINIT_FN_PTR: fn() = unsafe { MaybeUninit { uninit: () }.init };
-//~^ ERROR it is undefined behavior to use this value
+//~^ ERROR evaluation of constant value failed
 const DANGLING_FN_PTR: fn() = unsafe { mem::transmute(13usize) };
 //~^ ERROR it is undefined behavior to use this value
 const DATA_FN_PTR: fn() = unsafe { mem::transmute(&13) };

--- a/src/test/ui/consts/const-eval/ub-uninhabit.32bit.stderr
+++ b/src/test/ui/consts/const-eval/ub-uninhabit.32bit.stderr
@@ -1,31 +1,20 @@
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-uninhabit.rs:15:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-uninhabit.rs:15:35
    |
 LL | const BAD_BAD_BAD: Bar = unsafe { MaybeUninit { uninit: () }.init };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a value of uninhabited type Bar
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 0, align: 1) {}
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a value of uninhabited type Bar
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-uninhabit.rs:18:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-uninhabit.rs:18:36
    |
 LL | const BAD_BAD_REF: &Bar = unsafe { mem::transmute(1usize) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a reference pointing to uninhabited type Bar
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 4, align: 4) {
-               01 00 00 00                                     │ ....
-           }
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a reference pointing to uninhabited type Bar
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-uninhabit.rs:21:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-uninhabit.rs:21:42
    |
 LL | const BAD_BAD_ARRAY: [Bar; 1] = unsafe { MaybeUninit { uninit: () }.init };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at [0]: encountered a value of uninhabited type Bar
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 0, align: 1) {}
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at [0]: encountered a value of uninhabited type Bar
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/consts/const-eval/ub-uninhabit.64bit.stderr
+++ b/src/test/ui/consts/const-eval/ub-uninhabit.64bit.stderr
@@ -1,31 +1,20 @@
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-uninhabit.rs:15:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-uninhabit.rs:15:35
    |
 LL | const BAD_BAD_BAD: Bar = unsafe { MaybeUninit { uninit: () }.init };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a value of uninhabited type Bar
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 0, align: 1) {}
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a value of uninhabited type Bar
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-uninhabit.rs:18:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-uninhabit.rs:18:36
    |
 LL | const BAD_BAD_REF: &Bar = unsafe { mem::transmute(1usize) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a reference pointing to uninhabited type Bar
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 8) {
-               01 00 00 00 00 00 00 00                         │ ........
-           }
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a reference pointing to uninhabited type Bar
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-uninhabit.rs:21:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-uninhabit.rs:21:42
    |
 LL | const BAD_BAD_ARRAY: [Bar; 1] = unsafe { MaybeUninit { uninit: () }.init };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at [0]: encountered a value of uninhabited type Bar
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 0, align: 1) {}
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at [0]: encountered a value of uninhabited type Bar
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/consts/const-eval/ub-uninhabit.rs
+++ b/src/test/ui/consts/const-eval/ub-uninhabit.rs
@@ -13,12 +13,12 @@ union MaybeUninit<T: Copy> {
 }
 
 const BAD_BAD_BAD: Bar = unsafe { MaybeUninit { uninit: () }.init };
-//~^ ERROR it is undefined behavior to use this value
+//~^ ERROR evaluation of constant value failed
 
 const BAD_BAD_REF: &Bar = unsafe { mem::transmute(1usize) };
-//~^ ERROR it is undefined behavior to use this value
+//~^ ERROR evaluation of constant value failed
 
 const BAD_BAD_ARRAY: [Bar; 1] = unsafe { MaybeUninit { uninit: () }.init };
-//~^ ERROR it is undefined behavior to use this value
+//~^ ERROR evaluation of constant value failed
 
 fn main() {}

--- a/src/test/ui/consts/const-eval/ub-upvars.32bit.stderr
+++ b/src/test/ui/consts/const-eval/ub-upvars.32bit.stderr
@@ -1,17 +1,8 @@
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-upvars.rs:6:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-upvars.rs:7:42
    |
-LL | / const BAD_UPVAR: &dyn FnOnce() = &{
-LL | |     let bad_ref: &'static u16 = unsafe { mem::transmute(0usize) };
-LL | |     let another_var = 13;
-LL | |     move || { let _ = bad_ref; let _ = another_var; }
-LL | | };
-   | |__^ type validation failed at .<deref>.<dyn-downcast>.<captured-var(bad_ref)>: encountered a null reference
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾─alloc3──╼ ╾─alloc6──╼                         │ ╾──╼╾──╼
-           }
+LL |     let bad_ref: &'static u16 = unsafe { mem::transmute(0usize) };
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a null reference
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/const-eval/ub-upvars.64bit.stderr
+++ b/src/test/ui/consts/const-eval/ub-upvars.64bit.stderr
@@ -1,17 +1,8 @@
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-upvars.rs:6:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-upvars.rs:7:42
    |
-LL | / const BAD_UPVAR: &dyn FnOnce() = &{
-LL | |     let bad_ref: &'static u16 = unsafe { mem::transmute(0usize) };
-LL | |     let another_var = 13;
-LL | |     move || { let _ = bad_ref; let _ = another_var; }
-LL | | };
-   | |__^ type validation failed at .<deref>.<dyn-downcast>.<captured-var(bad_ref)>: encountered a null reference
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾───────alloc3────────╼ ╾───────alloc6────────╼ │ ╾──────╼╾──────╼
-           }
+LL |     let bad_ref: &'static u16 = unsafe { mem::transmute(0usize) };
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a null reference
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/const-eval/ub-upvars.rs
+++ b/src/test/ui/consts/const-eval/ub-upvars.rs
@@ -3,8 +3,9 @@
 
 use std::mem;
 
-const BAD_UPVAR: &dyn FnOnce() = &{ //~ ERROR it is undefined behavior to use this value
+const BAD_UPVAR: &dyn FnOnce() = &{
     let bad_ref: &'static u16 = unsafe { mem::transmute(0usize) };
+    //~^ ERROR evaluation of constant value failed
     let another_var = 13;
     move || { let _ = bad_ref; let _ = another_var; }
 };

--- a/src/test/ui/consts/const-eval/ub-wide-ptr.32bit.stderr
+++ b/src/test/ui/consts/const-eval/ub-wide-ptr.32bit.stderr
@@ -1,57 +1,32 @@
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-wide-ptr.rs:38:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-wide-ptr.rs:38:37
    |
 LL | const STR_TOO_LONG: &str = unsafe { mem::transmute((&42u8, 999usize)) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a dangling reference (going beyond the bounds of its allocation)
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾─allocN──╼ e7 03 00 00                         │ ╾──╼....
-           }
+   |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a dangling reference (going beyond the bounds of its allocation)
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-wide-ptr.rs:40:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-wide-ptr.rs:40:53
    |
 LL | const NESTED_STR_MUCH_TOO_LONG: (&str,) = (unsafe { mem::transmute((&42, usize::MAX)) },);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .0: encountered invalid reference metadata: slice is bigger than largest supported object
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾─allocN─╼ ff ff ff ff                         │ ╾──╼....
-           }
+   |                                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered invalid reference metadata: slice is bigger than largest supported object
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-wide-ptr.rs:43:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-wide-ptr.rs:43:39
    |
 LL | const STR_LENGTH_PTR: &str = unsafe { mem::transmute((&42u8, &3)) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered non-integer slice length in wide pointer
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾─allocN─╼ ╾─allocN─╼                         │ ╾──╼╾──╼
-           }
+   |                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered non-integer slice length in wide pointer
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-wide-ptr.rs:46:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-wide-ptr.rs:46:44
    |
 LL | const MY_STR_LENGTH_PTR: &MyStr = unsafe { mem::transmute((&42u8, &3)) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered non-integer slice length in wide pointer
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾─allocN─╼ ╾─allocN─╼                         │ ╾──╼╾──╼
-           }
+   |                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered non-integer slice length in wide pointer
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-wide-ptr.rs:48:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-wide-ptr.rs:48:47
    |
 LL | const MY_STR_MUCH_TOO_LONG: &MyStr = unsafe { mem::transmute((&42u8, usize::MAX)) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered invalid reference metadata: slice is bigger than largest supported object
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾─allocN─╼ ff ff ff ff                         │ ╾──╼....
-           }
+   |                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered invalid reference metadata: slice is bigger than largest supported object
 
 error[E0080]: it is undefined behavior to use this value
   --> $DIR/ub-wide-ptr.rs:52:1
@@ -75,203 +50,110 @@ LL | const MYSTR_NO_INIT: &MyStr = unsafe { mem::transmute::<&[_], _>(&[MaybeUni
                ╾─allocN─╼ 01 00 00 00                         │ ╾──╼....
            }
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-wide-ptr.rs:62:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-wide-ptr.rs:64:5
    |
-LL | / const SLICE_LENGTH_UNINIT: &[u8] = unsafe {
-LL | |
-LL | |     let uninit_len = MaybeUninit::<usize> { uninit: () };
-LL | |     mem::transmute((42, uninit_len))
-LL | | };
-   | |__^ type validation failed: encountered uninitialized reference
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 4) {
-               2a 00 00 00 __ __ __ __                         │ *...░░░░
-           }
+LL |     mem::transmute((42, uninit_len))
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered uninitialized reference
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-wide-ptr.rs:68:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-wide-ptr.rs:68:40
    |
 LL | const SLICE_TOO_LONG: &[u8] = unsafe { mem::transmute((&42u8, 999usize)) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a dangling reference (going beyond the bounds of its allocation)
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾─allocN─╼ e7 03 00 00                         │ ╾──╼....
-           }
+   |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a dangling reference (going beyond the bounds of its allocation)
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-wide-ptr.rs:71:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-wide-ptr.rs:71:50
    |
 LL | const SLICE_TOO_LONG_OVERFLOW: &[u32] = unsafe { mem::transmute((&42u32, isize::MAX)) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered invalid reference metadata: slice is bigger than largest supported object
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾─allocN─╼ ff ff ff 7f                         │ ╾──╼....
-           }
+   |                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered invalid reference metadata: slice is bigger than largest supported object
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-wide-ptr.rs:74:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-wide-ptr.rs:74:42
    |
 LL | const SLICE_LENGTH_PTR: &[u8] = unsafe { mem::transmute((&42u8, &3)) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered non-integer slice length in wide pointer
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾─allocN─╼ ╾─allocN─╼                         │ ╾──╼╾──╼
-           }
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered non-integer slice length in wide pointer
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-wide-ptr.rs:77:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-wide-ptr.rs:77:48
    |
 LL | const SLICE_TOO_LONG_BOX: Box<[u8]> = unsafe { mem::transmute((&42u8, 999usize)) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a dangling box (going beyond the bounds of its allocation)
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾─allocN─╼ e7 03 00 00                         │ ╾──╼....
-           }
+   |                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a dangling box (going beyond the bounds of its allocation)
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-wide-ptr.rs:80:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-wide-ptr.rs:80:50
    |
 LL | const SLICE_LENGTH_PTR_BOX: Box<[u8]> = unsafe { mem::transmute((&42u8, &3)) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered non-integer slice length in wide pointer
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾─allocN─╼ ╾─allocN─╼                         │ ╾──╼╾──╼
-           }
+   |                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered non-integer slice length in wide pointer
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-wide-ptr.rs:84:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-wide-ptr.rs:84:51
    |
 LL | const SLICE_CONTENT_INVALID: &[bool] = &[unsafe { mem::transmute(3u8) }];
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .<deref>[0]: encountered 0x03, but expected a boolean
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 4, align: 4) {
-               ╾─allocN─╼                                     │ ╾──╼
-           }
+   |                                                   ^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 0x03, but expected a boolean
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-wide-ptr.rs:90:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-wide-ptr.rs:90:60
    |
 LL | const MYSLICE_PREFIX_BAD: &MySliceBool = &MySlice(unsafe { mem::transmute(3u8) }, [false]);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .<deref>.0: encountered 0x03, but expected a boolean
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 4, align: 4) {
-               ╾allocN─╼                                     │ ╾──╼
-           }
+   |                                                            ^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 0x03, but expected a boolean
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-wide-ptr.rs:93:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-wide-ptr.rs:93:67
    |
 LL | const MYSLICE_SUFFIX_BAD: &MySliceBool = &MySlice(true, [unsafe { mem::transmute(3u8) }]);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .<deref>.1[0]: encountered 0x03, but expected a boolean
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 4, align: 4) {
-               ╾allocN─╼                                     │ ╾──╼
-           }
+   |                                                                   ^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 0x03, but expected a boolean
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-wide-ptr.rs:100:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-wide-ptr.rs:102:5
    |
-LL | / const RAW_SLICE_LENGTH_UNINIT: *const [u8] = unsafe {
-LL | |
-LL | |     let uninit_len = MaybeUninit::<usize> { uninit: () };
-LL | |     mem::transmute((42, uninit_len))
-LL | | };
-   | |__^ type validation failed: encountered uninitialized raw pointer
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 4) {
-               2a 00 00 00 __ __ __ __                         │ *...░░░░
-           }
+LL |     mem::transmute((42, uninit_len))
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered uninitialized raw pointer
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-wide-ptr.rs:108:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-wide-ptr.rs:108:58
    |
 LL | const TRAIT_OBJ_SHORT_VTABLE_1: W<&dyn Trait> = unsafe { mem::transmute(W((&92u8, &3u8))) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .0: encountered too small vtable
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾allocN─╼ ╾allocN─╼                         │ ╾──╼╾──╼
-           }
+   |                                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .0: encountered too small vtable
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-wide-ptr.rs:111:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-wide-ptr.rs:111:58
    |
 LL | const TRAIT_OBJ_SHORT_VTABLE_2: W<&dyn Trait> = unsafe { mem::transmute(W((&92u8, &3u64))) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .0: encountered too small vtable
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾allocN─╼ ╾allocN─╼                         │ ╾──╼╾──╼
-           }
+   |                                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .0: encountered too small vtable
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-wide-ptr.rs:114:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-wide-ptr.rs:114:54
    |
 LL | const TRAIT_OBJ_INT_VTABLE: W<&dyn Trait> = unsafe { mem::transmute(W((&92u8, 4usize))) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .0: encountered dangling vtable pointer in wide pointer
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾allocN─╼ 04 00 00 00                         │ ╾──╼....
-           }
+   |                                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .0: encountered dangling vtable pointer in wide pointer
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-wide-ptr.rs:116:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-wide-ptr.rs:116:57
    |
 LL | const TRAIT_OBJ_UNALIGNED_VTABLE: &dyn Trait = unsafe { mem::transmute((&92u8, &[0u8; 128])) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered unaligned vtable pointer in wide pointer
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾allocN─╼ ╾allocN─╼                         │ ╾──╼╾──╼
-           }
+   |                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered unaligned vtable pointer in wide pointer
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-wide-ptr.rs:118:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-wide-ptr.rs:118:57
    |
 LL | const TRAIT_OBJ_BAD_DROP_FN_NULL: &dyn Trait = unsafe { mem::transmute((&92u8, &[0usize; 8])) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered invalid drop function pointer in vtable (not pointing to a function)
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾allocN─╼ ╾allocN─╼                         │ ╾──╼╾──╼
-           }
+   |                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered invalid drop function pointer in vtable (not pointing to a function)
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-wide-ptr.rs:120:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-wide-ptr.rs:120:56
    |
 LL | const TRAIT_OBJ_BAD_DROP_FN_INT: &dyn Trait = unsafe { mem::transmute((&92u8, &[1usize; 8])) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered invalid drop function pointer in vtable (not pointing to a function)
+   |                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered invalid drop function pointer in vtable (not pointing to a function)
+
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-wide-ptr.rs:123:14
    |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾allocN─╼ ╾allocN─╼                         │ ╾──╼╾──╼
-           }
+LL |     unsafe { mem::transmute(W((&92u8, &[&42u8; 8]))) };
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .0: encountered invalid drop function pointer in vtable (not pointing to a function)
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-wide-ptr.rs:122:1
-   |
-LL | const TRAIT_OBJ_BAD_DROP_FN_NOT_FN_PTR: W<&dyn Trait> = unsafe { mem::transmute(W((&92u8, &[&42u8; 8]))) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .0: encountered invalid drop function pointer in vtable (not pointing to a function)
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾allocN─╼ ╾allocN─╼                         │ ╾──╼╾──╼
-           }
-
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-wide-ptr.rs:126:1
+  --> $DIR/ub-wide-ptr.rs:127:1
    |
 LL | const TRAIT_OBJ_CONTENT_INVALID: &dyn Trait = unsafe { mem::transmute::<_, &bool>(&3u8) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .<deref>.<dyn-downcast>: encountered 0x03, but expected a boolean
@@ -281,39 +163,29 @@ LL | const TRAIT_OBJ_CONTENT_INVALID: &dyn Trait = unsafe { mem::transmute::<_, 
                ╾allocN─╼ ╾allocN─╼                         │ ╾──╼╾──╼
            }
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-wide-ptr.rs:130:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-wide-ptr.rs:131:62
    |
 LL | const RAW_TRAIT_OBJ_VTABLE_NULL: *const dyn Trait = unsafe { mem::transmute((&92u8, 0usize)) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered dangling vtable pointer in wide pointer
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾allocN─╼ 00 00 00 00                         │ ╾──╼....
-           }
+   |                                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered dangling vtable pointer in wide pointer
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-wide-ptr.rs:132:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-wide-ptr.rs:133:65
    |
 LL | const RAW_TRAIT_OBJ_VTABLE_INVALID: *const dyn Trait = unsafe { mem::transmute((&92u8, &3u64)) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered too small vtable
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾allocN─╼ ╾allocN─╼                         │ ╾──╼╾──╼
-           }
+   |                                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered too small vtable
 
 error[E0080]: could not evaluate static initializer
-  --> $DIR/ub-wide-ptr.rs:138:5
+  --> $DIR/ub-wide-ptr.rs:140:5
    |
 LL |     mem::transmute::<_, &dyn Trait>((&92u8, 0usize))
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ memory access failed: null pointer is not a valid pointer
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered dangling vtable pointer in wide pointer
 
 error[E0080]: could not evaluate static initializer
-  --> $DIR/ub-wide-ptr.rs:142:5
+  --> $DIR/ub-wide-ptr.rs:144:5
    |
 LL |     mem::transmute::<_, &dyn Trait>((&92u8, &3u64))
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ memory access failed: allocN has size N, so pointer to 12 bytes starting at offset N is out-of-bounds
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered too small vtable
 
 error: aborting due to 29 previous errors
 

--- a/src/test/ui/consts/const-eval/ub-wide-ptr.64bit.stderr
+++ b/src/test/ui/consts/const-eval/ub-wide-ptr.64bit.stderr
@@ -1,57 +1,32 @@
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-wide-ptr.rs:38:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-wide-ptr.rs:38:37
    |
 LL | const STR_TOO_LONG: &str = unsafe { mem::transmute((&42u8, 999usize)) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a dangling reference (going beyond the bounds of its allocation)
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾───────allocN────────╼ e7 03 00 00 00 00 00 00 │ ╾──────╼........
-           }
+   |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a dangling reference (going beyond the bounds of its allocation)
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-wide-ptr.rs:40:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-wide-ptr.rs:40:53
    |
 LL | const NESTED_STR_MUCH_TOO_LONG: (&str,) = (unsafe { mem::transmute((&42, usize::MAX)) },);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .0: encountered invalid reference metadata: slice is bigger than largest supported object
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾───────allocN───────╼ ff ff ff ff ff ff ff ff │ ╾──────╼........
-           }
+   |                                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered invalid reference metadata: slice is bigger than largest supported object
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-wide-ptr.rs:43:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-wide-ptr.rs:43:39
    |
 LL | const STR_LENGTH_PTR: &str = unsafe { mem::transmute((&42u8, &3)) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered non-integer slice length in wide pointer
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾───────allocN───────╼ ╾───────allocN───────╼ │ ╾──────╼╾──────╼
-           }
+   |                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered non-integer slice length in wide pointer
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-wide-ptr.rs:46:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-wide-ptr.rs:46:44
    |
 LL | const MY_STR_LENGTH_PTR: &MyStr = unsafe { mem::transmute((&42u8, &3)) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered non-integer slice length in wide pointer
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾───────allocN───────╼ ╾───────allocN───────╼ │ ╾──────╼╾──────╼
-           }
+   |                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered non-integer slice length in wide pointer
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-wide-ptr.rs:48:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-wide-ptr.rs:48:47
    |
 LL | const MY_STR_MUCH_TOO_LONG: &MyStr = unsafe { mem::transmute((&42u8, usize::MAX)) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered invalid reference metadata: slice is bigger than largest supported object
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾───────allocN───────╼ ff ff ff ff ff ff ff ff │ ╾──────╼........
-           }
+   |                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered invalid reference metadata: slice is bigger than largest supported object
 
 error[E0080]: it is undefined behavior to use this value
   --> $DIR/ub-wide-ptr.rs:52:1
@@ -75,203 +50,110 @@ LL | const MYSTR_NO_INIT: &MyStr = unsafe { mem::transmute::<&[_], _>(&[MaybeUni
                ╾───────allocN───────╼ 01 00 00 00 00 00 00 00 │ ╾──────╼........
            }
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-wide-ptr.rs:62:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-wide-ptr.rs:64:5
    |
-LL | / const SLICE_LENGTH_UNINIT: &[u8] = unsafe {
-LL | |
-LL | |     let uninit_len = MaybeUninit::<usize> { uninit: () };
-LL | |     mem::transmute((42, uninit_len))
-LL | | };
-   | |__^ type validation failed: encountered uninitialized reference
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 16, align: 8) {
-               __ __ __ __ __ __ __ __ __ __ __ __ __ __ __ __ │ ░░░░░░░░░░░░░░░░
-           }
+LL |     mem::transmute((42, uninit_len))
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered uninitialized reference
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-wide-ptr.rs:68:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-wide-ptr.rs:68:40
    |
 LL | const SLICE_TOO_LONG: &[u8] = unsafe { mem::transmute((&42u8, 999usize)) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a dangling reference (going beyond the bounds of its allocation)
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾───────allocN───────╼ e7 03 00 00 00 00 00 00 │ ╾──────╼........
-           }
+   |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a dangling reference (going beyond the bounds of its allocation)
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-wide-ptr.rs:71:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-wide-ptr.rs:71:50
    |
 LL | const SLICE_TOO_LONG_OVERFLOW: &[u32] = unsafe { mem::transmute((&42u32, isize::MAX)) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered invalid reference metadata: slice is bigger than largest supported object
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾───────allocN───────╼ ff ff ff ff ff ff ff 7f │ ╾──────╼........
-           }
+   |                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered invalid reference metadata: slice is bigger than largest supported object
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-wide-ptr.rs:74:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-wide-ptr.rs:74:42
    |
 LL | const SLICE_LENGTH_PTR: &[u8] = unsafe { mem::transmute((&42u8, &3)) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered non-integer slice length in wide pointer
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾───────allocN───────╼ ╾───────allocN───────╼ │ ╾──────╼╾──────╼
-           }
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered non-integer slice length in wide pointer
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-wide-ptr.rs:77:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-wide-ptr.rs:77:48
    |
 LL | const SLICE_TOO_LONG_BOX: Box<[u8]> = unsafe { mem::transmute((&42u8, 999usize)) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a dangling box (going beyond the bounds of its allocation)
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾───────allocN───────╼ e7 03 00 00 00 00 00 00 │ ╾──────╼........
-           }
+   |                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a dangling box (going beyond the bounds of its allocation)
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-wide-ptr.rs:80:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-wide-ptr.rs:80:50
    |
 LL | const SLICE_LENGTH_PTR_BOX: Box<[u8]> = unsafe { mem::transmute((&42u8, &3)) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered non-integer slice length in wide pointer
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾───────allocN───────╼ ╾───────allocN───────╼ │ ╾──────╼╾──────╼
-           }
+   |                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered non-integer slice length in wide pointer
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-wide-ptr.rs:84:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-wide-ptr.rs:84:51
    |
 LL | const SLICE_CONTENT_INVALID: &[bool] = &[unsafe { mem::transmute(3u8) }];
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .<deref>[0]: encountered 0x03, but expected a boolean
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 8) {
-               ╾───────allocN───────╼                         │ ╾──────╼
-           }
+   |                                                   ^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 0x03, but expected a boolean
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-wide-ptr.rs:90:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-wide-ptr.rs:90:60
    |
 LL | const MYSLICE_PREFIX_BAD: &MySliceBool = &MySlice(unsafe { mem::transmute(3u8) }, [false]);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .<deref>.0: encountered 0x03, but expected a boolean
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 8) {
-               ╾──────allocN───────╼                         │ ╾──────╼
-           }
+   |                                                            ^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 0x03, but expected a boolean
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-wide-ptr.rs:93:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-wide-ptr.rs:93:67
    |
 LL | const MYSLICE_SUFFIX_BAD: &MySliceBool = &MySlice(true, [unsafe { mem::transmute(3u8) }]);
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .<deref>.1[0]: encountered 0x03, but expected a boolean
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 8) {
-               ╾──────allocN───────╼                         │ ╾──────╼
-           }
+   |                                                                   ^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 0x03, but expected a boolean
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-wide-ptr.rs:100:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-wide-ptr.rs:102:5
    |
-LL | / const RAW_SLICE_LENGTH_UNINIT: *const [u8] = unsafe {
-LL | |
-LL | |     let uninit_len = MaybeUninit::<usize> { uninit: () };
-LL | |     mem::transmute((42, uninit_len))
-LL | | };
-   | |__^ type validation failed: encountered uninitialized raw pointer
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 16, align: 8) {
-               __ __ __ __ __ __ __ __ __ __ __ __ __ __ __ __ │ ░░░░░░░░░░░░░░░░
-           }
+LL |     mem::transmute((42, uninit_len))
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered uninitialized raw pointer
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-wide-ptr.rs:108:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-wide-ptr.rs:108:58
    |
 LL | const TRAIT_OBJ_SHORT_VTABLE_1: W<&dyn Trait> = unsafe { mem::transmute(W((&92u8, &3u8))) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .0: encountered too small vtable
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾──────allocN───────╼ ╾──────allocN───────╼ │ ╾──────╼╾──────╼
-           }
+   |                                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .0: encountered too small vtable
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-wide-ptr.rs:111:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-wide-ptr.rs:111:58
    |
 LL | const TRAIT_OBJ_SHORT_VTABLE_2: W<&dyn Trait> = unsafe { mem::transmute(W((&92u8, &3u64))) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .0: encountered too small vtable
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾──────allocN───────╼ ╾──────allocN───────╼ │ ╾──────╼╾──────╼
-           }
+   |                                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .0: encountered too small vtable
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-wide-ptr.rs:114:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-wide-ptr.rs:114:54
    |
 LL | const TRAIT_OBJ_INT_VTABLE: W<&dyn Trait> = unsafe { mem::transmute(W((&92u8, 4usize))) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .0: encountered dangling vtable pointer in wide pointer
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾──────allocN───────╼ 04 00 00 00 00 00 00 00 │ ╾──────╼........
-           }
+   |                                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .0: encountered dangling vtable pointer in wide pointer
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-wide-ptr.rs:116:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-wide-ptr.rs:116:57
    |
 LL | const TRAIT_OBJ_UNALIGNED_VTABLE: &dyn Trait = unsafe { mem::transmute((&92u8, &[0u8; 128])) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered unaligned vtable pointer in wide pointer
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾──────allocN───────╼ ╾──────allocN───────╼ │ ╾──────╼╾──────╼
-           }
+   |                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered unaligned vtable pointer in wide pointer
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-wide-ptr.rs:118:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-wide-ptr.rs:118:57
    |
 LL | const TRAIT_OBJ_BAD_DROP_FN_NULL: &dyn Trait = unsafe { mem::transmute((&92u8, &[0usize; 8])) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered invalid drop function pointer in vtable (not pointing to a function)
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾──────allocN───────╼ ╾──────allocN───────╼ │ ╾──────╼╾──────╼
-           }
+   |                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered invalid drop function pointer in vtable (not pointing to a function)
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-wide-ptr.rs:120:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-wide-ptr.rs:120:56
    |
 LL | const TRAIT_OBJ_BAD_DROP_FN_INT: &dyn Trait = unsafe { mem::transmute((&92u8, &[1usize; 8])) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered invalid drop function pointer in vtable (not pointing to a function)
+   |                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered invalid drop function pointer in vtable (not pointing to a function)
+
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-wide-ptr.rs:123:14
    |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾──────allocN───────╼ ╾──────allocN───────╼ │ ╾──────╼╾──────╼
-           }
+LL |     unsafe { mem::transmute(W((&92u8, &[&42u8; 8]))) };
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .0: encountered invalid drop function pointer in vtable (not pointing to a function)
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-wide-ptr.rs:122:1
-   |
-LL | const TRAIT_OBJ_BAD_DROP_FN_NOT_FN_PTR: W<&dyn Trait> = unsafe { mem::transmute(W((&92u8, &[&42u8; 8]))) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .0: encountered invalid drop function pointer in vtable (not pointing to a function)
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾──────allocN───────╼ ╾──────allocN───────╼ │ ╾──────╼╾──────╼
-           }
-
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-wide-ptr.rs:126:1
+  --> $DIR/ub-wide-ptr.rs:127:1
    |
 LL | const TRAIT_OBJ_CONTENT_INVALID: &dyn Trait = unsafe { mem::transmute::<_, &bool>(&3u8) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .<deref>.<dyn-downcast>: encountered 0x03, but expected a boolean
@@ -281,39 +163,29 @@ LL | const TRAIT_OBJ_CONTENT_INVALID: &dyn Trait = unsafe { mem::transmute::<_, 
                ╾──────allocN───────╼ ╾──────allocN───────╼ │ ╾──────╼╾──────╼
            }
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-wide-ptr.rs:130:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-wide-ptr.rs:131:62
    |
 LL | const RAW_TRAIT_OBJ_VTABLE_NULL: *const dyn Trait = unsafe { mem::transmute((&92u8, 0usize)) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered dangling vtable pointer in wide pointer
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾──────allocN───────╼ 00 00 00 00 00 00 00 00 │ ╾──────╼........
-           }
+   |                                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered dangling vtable pointer in wide pointer
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/ub-wide-ptr.rs:132:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-wide-ptr.rs:133:65
    |
 LL | const RAW_TRAIT_OBJ_VTABLE_INVALID: *const dyn Trait = unsafe { mem::transmute((&92u8, &3u64)) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered too small vtable
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾──────allocN───────╼ ╾──────allocN───────╼ │ ╾──────╼╾──────╼
-           }
+   |                                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered too small vtable
 
 error[E0080]: could not evaluate static initializer
-  --> $DIR/ub-wide-ptr.rs:138:5
+  --> $DIR/ub-wide-ptr.rs:140:5
    |
 LL |     mem::transmute::<_, &dyn Trait>((&92u8, 0usize))
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ memory access failed: null pointer is not a valid pointer
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered dangling vtable pointer in wide pointer
 
 error[E0080]: could not evaluate static initializer
-  --> $DIR/ub-wide-ptr.rs:142:5
+  --> $DIR/ub-wide-ptr.rs:144:5
    |
 LL |     mem::transmute::<_, &dyn Trait>((&92u8, &3u64))
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ memory access failed: allocN has size N, so pointer to 24 bytes starting at offset N is out-of-bounds
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered too small vtable
 
 error: aborting due to 29 previous errors
 

--- a/src/test/ui/consts/const-eval/ub-wide-ptr.rs
+++ b/src/test/ui/consts/const-eval/ub-wide-ptr.rs
@@ -11,7 +11,7 @@ use std::mem;
 
 /// A newtype wrapper to prevent MIR generation from inserting reborrows that would affect the error
 /// message. Use this whenever the message is "any use of this value will cause an error" instead of
-/// "it is undefined behavior to use this value".
+/// "evaluation of constant value failed".
 #[repr(transparent)]
 struct W<T>(T);
 
@@ -36,17 +36,17 @@ type MySliceBool = MySlice<[bool]>;
 const STR_VALID: &str = unsafe { mem::transmute((&42u8, 1usize)) };
 // bad str
 const STR_TOO_LONG: &str = unsafe { mem::transmute((&42u8, 999usize)) };
-//~^ ERROR it is undefined behavior to use this value
+//~^ ERROR evaluation of constant value failed
 const NESTED_STR_MUCH_TOO_LONG: (&str,) = (unsafe { mem::transmute((&42, usize::MAX)) },);
-//~^ ERROR it is undefined behavior to use this value
+//~^ ERROR evaluation of constant value failed
 // bad str
 const STR_LENGTH_PTR: &str = unsafe { mem::transmute((&42u8, &3)) };
-//~^ ERROR it is undefined behavior to use this value
+//~^ ERROR evaluation of constant value failed
 // bad str in user-defined unsized type
 const MY_STR_LENGTH_PTR: &MyStr = unsafe { mem::transmute((&42u8, &3)) };
-//~^ ERROR it is undefined behavior to use this value
+//~^ ERROR evaluation of constant value failed
 const MY_STR_MUCH_TOO_LONG: &MyStr = unsafe { mem::transmute((&42u8, usize::MAX)) };
-//~^ ERROR it is undefined behavior to use this value
+//~^ ERROR evaluation of constant value failed
 
 // uninitialized byte
 const STR_NO_INIT: &str = unsafe { mem::transmute::<&[_], _>(&[MaybeUninit::<u8> { uninit: () }]) };
@@ -60,67 +60,68 @@ const MYSTR_NO_INIT: &MyStr = unsafe { mem::transmute::<&[_], _>(&[MaybeUninit::
 const SLICE_VALID: &[u8] = unsafe { mem::transmute((&42u8, 1usize)) };
 // bad slice: length uninit
 const SLICE_LENGTH_UNINIT: &[u8] = unsafe {
-//~^ ERROR it is undefined behavior to use this value
     let uninit_len = MaybeUninit::<usize> { uninit: () };
     mem::transmute((42, uninit_len))
+    //~^ ERROR evaluation of constant value failed
 };
 // bad slice: length too big
 const SLICE_TOO_LONG: &[u8] = unsafe { mem::transmute((&42u8, 999usize)) };
-//~^ ERROR it is undefined behavior to use this value
+//~^ ERROR evaluation of constant value failed
 // bad slice: length computation overflows
 const SLICE_TOO_LONG_OVERFLOW: &[u32] = unsafe { mem::transmute((&42u32, isize::MAX)) };
-//~^ ERROR it is undefined behavior to use this value
+//~^ ERROR evaluation of constant value failed
 // bad slice: length not an int
 const SLICE_LENGTH_PTR: &[u8] = unsafe { mem::transmute((&42u8, &3)) };
-//~^ ERROR it is undefined behavior to use this value
+//~^ ERROR evaluation of constant value failed
 // bad slice box: length too big
 const SLICE_TOO_LONG_BOX: Box<[u8]> = unsafe { mem::transmute((&42u8, 999usize)) };
-//~^ ERROR it is undefined behavior to use this value
+//~^ ERROR evaluation of constant value failed
 // bad slice box: length not an int
 const SLICE_LENGTH_PTR_BOX: Box<[u8]> = unsafe { mem::transmute((&42u8, &3)) };
-//~^ ERROR it is undefined behavior to use this value
+//~^ ERROR evaluation of constant value failed
 
 // bad data *inside* the slice
 const SLICE_CONTENT_INVALID: &[bool] = &[unsafe { mem::transmute(3u8) }];
-//~^ ERROR it is undefined behavior to use this value
+//~^ ERROR evaluation of constant value failed
 
 // good MySliceBool
 const MYSLICE_GOOD: &MySliceBool = &MySlice(true, [false]);
 // bad: sized field is not okay
 const MYSLICE_PREFIX_BAD: &MySliceBool = &MySlice(unsafe { mem::transmute(3u8) }, [false]);
-//~^ ERROR it is undefined behavior to use this value
+//~^ ERROR evaluation of constant value failed
 // bad: unsized part is not okay
 const MYSLICE_SUFFIX_BAD: &MySliceBool = &MySlice(true, [unsafe { mem::transmute(3u8) }]);
-//~^ ERROR it is undefined behavior to use this value
+//~^ ERROR evaluation of constant value failed
 
 // # raw slice
 const RAW_SLICE_VALID: *const [u8] = unsafe { mem::transmute((&42u8, 1usize)) }; // ok
 const RAW_SLICE_TOO_LONG: *const [u8] = unsafe { mem::transmute((&42u8, 999usize)) }; // ok because raw
 const RAW_SLICE_MUCH_TOO_LONG: *const [u8] = unsafe { mem::transmute((&42u8, usize::MAX)) }; // ok because raw
 const RAW_SLICE_LENGTH_UNINIT: *const [u8] = unsafe {
-//~^ ERROR it is undefined behavior to use this value
     let uninit_len = MaybeUninit::<usize> { uninit: () };
     mem::transmute((42, uninit_len))
+    //~^ ERROR evaluation of constant value failed
 };
 
 // # trait object
 // bad trait object
 const TRAIT_OBJ_SHORT_VTABLE_1: W<&dyn Trait> = unsafe { mem::transmute(W((&92u8, &3u8))) };
-//~^ ERROR it is undefined behavior to use this value
+//~^ ERROR evaluation of constant value failed
 // bad trait object
 const TRAIT_OBJ_SHORT_VTABLE_2: W<&dyn Trait> = unsafe { mem::transmute(W((&92u8, &3u64))) };
-//~^ ERROR it is undefined behavior to use this value
+//~^ ERROR evaluation of constant value failed
 // bad trait object
 const TRAIT_OBJ_INT_VTABLE: W<&dyn Trait> = unsafe { mem::transmute(W((&92u8, 4usize))) };
-//~^ ERROR it is undefined behavior to use this value
+//~^ ERROR evaluation of constant value failed
 const TRAIT_OBJ_UNALIGNED_VTABLE: &dyn Trait = unsafe { mem::transmute((&92u8, &[0u8; 128])) };
-//~^ ERROR it is undefined behavior to use this value
+//~^ ERROR evaluation of constant value failed
 const TRAIT_OBJ_BAD_DROP_FN_NULL: &dyn Trait = unsafe { mem::transmute((&92u8, &[0usize; 8])) };
-//~^ ERROR it is undefined behavior to use this value
+//~^ ERROR evaluation of constant value failed
 const TRAIT_OBJ_BAD_DROP_FN_INT: &dyn Trait = unsafe { mem::transmute((&92u8, &[1usize; 8])) };
-//~^ ERROR it is undefined behavior to use this value
-const TRAIT_OBJ_BAD_DROP_FN_NOT_FN_PTR: W<&dyn Trait> = unsafe { mem::transmute(W((&92u8, &[&42u8; 8]))) };
-//~^ ERROR it is undefined behavior to use this value
+//~^ ERROR evaluation of constant value failed
+const TRAIT_OBJ_BAD_DROP_FN_NOT_FN_PTR: W<&dyn Trait> =
+    unsafe { mem::transmute(W((&92u8, &[&42u8; 8]))) };
+//~^ ERROR evaluation of constant value failed
 
 // bad data *inside* the trait object
 const TRAIT_OBJ_CONTENT_INVALID: &dyn Trait = unsafe { mem::transmute::<_, &bool>(&3u8) };
@@ -128,10 +129,11 @@ const TRAIT_OBJ_CONTENT_INVALID: &dyn Trait = unsafe { mem::transmute::<_, &bool
 
 // # raw trait object
 const RAW_TRAIT_OBJ_VTABLE_NULL: *const dyn Trait = unsafe { mem::transmute((&92u8, 0usize)) };
-//~^ ERROR it is undefined behavior to use this value
+//~^ ERROR evaluation of constant value failed
 const RAW_TRAIT_OBJ_VTABLE_INVALID: *const dyn Trait = unsafe { mem::transmute((&92u8, &3u64)) };
-//~^ ERROR it is undefined behavior to use this value
-const RAW_TRAIT_OBJ_CONTENT_INVALID: *const dyn Trait = unsafe { mem::transmute::<_, &bool>(&3u8) } as *const dyn Trait; // ok because raw
+//~^ ERROR evaluation of constant value failed
+const RAW_TRAIT_OBJ_CONTENT_INVALID: *const dyn Trait =
+    unsafe { mem::transmute::<_, &bool>(&3u8) } as *const dyn Trait; // ok because raw
 
 // Const eval fails for these, so they need to be statics to error.
 static mut RAW_TRAIT_OBJ_VTABLE_NULL_THROUGH_REF: *const dyn Trait = unsafe {

--- a/src/test/ui/consts/const-eval/union-const-eval-field.rs
+++ b/src/test/ui/consts/const-eval/union-const-eval-field.rs
@@ -26,7 +26,7 @@ const fn read_field2() -> Field2 {
 
 const fn read_field3() -> Field3 {
     const FIELD3: Field3 = unsafe { UNION.field3 };
-    //~^ ERROR it is undefined behavior to use this value
+    //~^ ERROR evaluation of constant value failed
     FIELD3
     //~^ ERROR erroneous constant used [E0080]
 }

--- a/src/test/ui/consts/const-eval/union-const-eval-field.stderr
+++ b/src/test/ui/consts/const-eval/union-const-eval-field.stderr
@@ -1,13 +1,8 @@
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/union-const-eval-field.rs:28:5
+error[E0080]: evaluation of constant value failed
+  --> $DIR/union-const-eval-field.rs:28:37
    |
 LL |     const FIELD3: Field3 = unsafe { UNION.field3 };
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered uninitialized bytes, but expected initialized bytes
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 8) {
-               __ __ __ __ __ __ __ __                         │ ░░░░░░░░
-           }
+   |                                     ^^^^^^^^^^^^ type validation failed: encountered uninitialized bytes, but expected initialized bytes
 
 error[E0080]: erroneous constant used
   --> $DIR/union-const-eval-field.rs:30:5

--- a/src/test/ui/consts/const-eval/union-ice.rs
+++ b/src/test/ui/consts/const-eval/union-ice.rs
@@ -11,11 +11,11 @@ union DummyUnion {
 
 const UNION: DummyUnion = DummyUnion { field1: 1065353216 };
 
-const FIELD3: Field3 = unsafe { UNION.field3 }; //~ ERROR it is undefined behavior to use this value
+const FIELD3: Field3 = unsafe { UNION.field3 }; //~ ERROR evaluation of constant value failed
 
-const FIELD_PATH: Struct = Struct { //~ ERROR it is undefined behavior to use this value
+const FIELD_PATH: Struct = Struct {
     a: 42,
-    b: unsafe { UNION.field3 },
+    b: unsafe { UNION.field3 }, //~ ERROR evaluation of constant value failed
 };
 
 struct Struct {
@@ -23,10 +23,10 @@ struct Struct {
     b: Field3,
 }
 
-const FIELD_PATH2: Struct2 = Struct2 { //~ ERROR it is undefined behavior to use this value
+const FIELD_PATH2: Struct2 = Struct2 {
     b: [
         21,
-        unsafe { UNION.field3 },
+        unsafe { UNION.field3 }, //~ ERROR evaluation of constant value failed
         23,
         24,
     ],

--- a/src/test/ui/consts/const-eval/union-ice.stderr
+++ b/src/test/ui/consts/const-eval/union-ice.stderr
@@ -1,46 +1,20 @@
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/union-ice.rs:14:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/union-ice.rs:14:33
    |
 LL | const FIELD3: Field3 = unsafe { UNION.field3 };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered uninitialized bytes, but expected initialized bytes
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 8) {
-               __ __ __ __ __ __ __ __                         │ ░░░░░░░░
-           }
+   |                                 ^^^^^^^^^^^^ type validation failed: encountered uninitialized bytes, but expected initialized bytes
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/union-ice.rs:16:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/union-ice.rs:18:17
    |
-LL | / const FIELD_PATH: Struct = Struct {
-LL | |     a: 42,
-LL | |     b: unsafe { UNION.field3 },
-LL | | };
-   | |__^ type validation failed at .b: encountered uninitialized bytes, but expected initialized bytes
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 16, align: 8) {
-               __ __ __ __ __ __ __ __ 2a __ __ __ __ __ __ __ │ ░░░░░░░░*░░░░░░░
-           }
+LL |     b: unsafe { UNION.field3 },
+   |                 ^^^^^^^^^^^^ type validation failed: encountered uninitialized bytes, but expected initialized bytes
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/union-ice.rs:26:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/union-ice.rs:29:18
    |
-LL | / const FIELD_PATH2: Struct2 = Struct2 {
-LL | |     b: [
-LL | |         21,
-LL | |         unsafe { UNION.field3 },
-...  |
-LL | |     a: 42,
-LL | | };
-   | |__^ type validation failed at .b[1]: encountered uninitialized bytes
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 40, align: 8) {
-               0x00 │ 15 00 00 00 00 00 00 00 __ __ __ __ __ __ __ __ │ ........░░░░░░░░
-               0x10 │ 17 00 00 00 00 00 00 00 18 00 00 00 00 00 00 00 │ ................
-               0x20 │ 2a __ __ __ __ __ __ __                         │ *░░░░░░░
-           }
+LL |         unsafe { UNION.field3 },
+   |                  ^^^^^^^^^^^^ type validation failed: encountered uninitialized bytes, but expected initialized bytes
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/consts/const-eval/union-ub.32bit.stderr
+++ b/src/test/ui/consts/const-eval/union-ub.32bit.stderr
@@ -1,24 +1,14 @@
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/union-ub.rs:33:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/union-ub.rs:33:33
    |
 LL | const BAD_BOOL: bool = unsafe { DummyUnion { u8: 42 }.bool};
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 0x2a, but expected a boolean
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 1, align: 1) {
-               2a                                              │ *
-           }
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 0x2a, but expected a boolean
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/union-ub.rs:35:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/union-ub.rs:35:36
    |
 LL | const UNINIT_BOOL: bool = unsafe { DummyUnion { unit: () }.bool};
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered uninitialized bytes, but expected a boolean
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 1, align: 1) {
-               __                                              │ ░
-           }
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered uninitialized bytes, but expected a boolean
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/consts/const-eval/union-ub.64bit.stderr
+++ b/src/test/ui/consts/const-eval/union-ub.64bit.stderr
@@ -1,24 +1,14 @@
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/union-ub.rs:33:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/union-ub.rs:33:33
    |
 LL | const BAD_BOOL: bool = unsafe { DummyUnion { u8: 42 }.bool};
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 0x2a, but expected a boolean
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 1, align: 1) {
-               2a                                              │ *
-           }
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 0x2a, but expected a boolean
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/union-ub.rs:35:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/union-ub.rs:35:36
    |
 LL | const UNINIT_BOOL: bool = unsafe { DummyUnion { unit: () }.bool};
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered uninitialized bytes, but expected a boolean
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 1, align: 1) {
-               __                                              │ ░
-           }
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered uninitialized bytes, but expected a boolean
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/consts/const-eval/union-ub.rs
+++ b/src/test/ui/consts/const-eval/union-ub.rs
@@ -31,9 +31,9 @@ union Bar {
 
 // the value is not valid for bools
 const BAD_BOOL: bool = unsafe { DummyUnion { u8: 42 }.bool};
-//~^ ERROR it is undefined behavior to use this value
+//~^ ERROR evaluation of constant value failed
 const UNINIT_BOOL: bool = unsafe { DummyUnion { unit: () }.bool};
-//~^ ERROR it is undefined behavior to use this value
+//~^ ERROR evaluation of constant value failed
 
 // The value is not valid for any union variant, but that's fine
 // unions are just a convenient way to transmute bits around

--- a/src/test/ui/consts/const-eval/validate_uninhabited_zsts.32bit.stderr
+++ b/src/test/ui/consts/const-eval/validate_uninhabited_zsts.32bit.stderr
@@ -10,14 +10,11 @@ LL |     unsafe { std::mem::transmute(()) }
 LL | const FOO: [empty::Empty; 3] = [foo(); 3];
    |                                 ----- inside `FOO` at $DIR/validate_uninhabited_zsts.rs:20:33
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/validate_uninhabited_zsts.rs:23:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/validate_uninhabited_zsts.rs:23:42
    |
 LL | const BAR: [empty::Empty; 3] = [unsafe { std::mem::transmute(()) }; 3];
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at [0].0: encountered a value of uninhabited type empty::Void
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 0, align: 1) {}
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .0: encountered a value of uninhabited type empty::Void
 
 warning: the type `!` does not permit zero-initialization
   --> $DIR/validate_uninhabited_zsts.rs:4:14

--- a/src/test/ui/consts/const-eval/validate_uninhabited_zsts.64bit.stderr
+++ b/src/test/ui/consts/const-eval/validate_uninhabited_zsts.64bit.stderr
@@ -10,14 +10,11 @@ LL |     unsafe { std::mem::transmute(()) }
 LL | const FOO: [empty::Empty; 3] = [foo(); 3];
    |                                 ----- inside `FOO` at $DIR/validate_uninhabited_zsts.rs:20:33
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/validate_uninhabited_zsts.rs:23:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/validate_uninhabited_zsts.rs:23:42
    |
 LL | const BAR: [empty::Empty; 3] = [unsafe { std::mem::transmute(()) }; 3];
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at [0].0: encountered a value of uninhabited type empty::Void
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 0, align: 1) {}
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .0: encountered a value of uninhabited type empty::Void
 
 warning: the type `!` does not permit zero-initialization
   --> $DIR/validate_uninhabited_zsts.rs:4:14

--- a/src/test/ui/consts/const-eval/validate_uninhabited_zsts.rs
+++ b/src/test/ui/consts/const-eval/validate_uninhabited_zsts.rs
@@ -21,7 +21,7 @@ const FOO: [empty::Empty; 3] = [foo(); 3];
 
 #[warn(const_err)]
 const BAR: [empty::Empty; 3] = [unsafe { std::mem::transmute(()) }; 3];
-//~^ ERROR it is undefined behavior to use this value
+//~^ ERROR evaluation of constant value failed
 //~| WARN the type `empty::Empty` does not permit zero-initialization
 
 fn main() {

--- a/src/test/ui/consts/const-mut-refs/mut_ref_in_final_dynamic_check.rs
+++ b/src/test/ui/consts/const-mut-refs/mut_ref_in_final_dynamic_check.rs
@@ -22,6 +22,6 @@ const fn helper2() -> Option<&'static mut i32> { unsafe {
     // This code never gets executed, because the static checks fail before that.
     Some(&mut *(&mut 42 as *mut i32))
 } }
-const B: Option<&mut i32> = helper2(); //~ ERROR encountered dangling pointer in final constant
+const B: Option<&mut i32> = helper2(); //~ ERROR evaluation of constant value failed
 
 fn main() {}

--- a/src/test/ui/consts/const-mut-refs/mut_ref_in_final_dynamic_check.stderr
+++ b/src/test/ui/consts/const-mut-refs/mut_ref_in_final_dynamic_check.stderr
@@ -10,11 +10,11 @@ LL |     Some(&mut *(42 as *mut i32))
 LL | const A: Option<&mut i32> = helper();
    |                             -------- inside `A` at $DIR/mut_ref_in_final_dynamic_check.rs:18:29
 
-error: encountered dangling pointer in final constant
-  --> $DIR/mut_ref_in_final_dynamic_check.rs:25:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/mut_ref_in_final_dynamic_check.rs:25:29
    |
 LL | const B: Option<&mut i32> = helper2();
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                             ^^^^^^^^^ type validation failed at .<enum-variant(Some)>.0: encountered a dangling reference (use-after-free)
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/consts/const_discriminant.rs
+++ b/src/test/ui/consts/const_discriminant.rs
@@ -1,10 +1,9 @@
-// run-pass
 #![feature(const_discriminant)]
 #![feature(bench_black_box)]
 #![allow(dead_code)]
 
-use std::mem::{discriminant, Discriminant};
 use std::hint::black_box;
+use std::mem::{discriminant, Discriminant};
 
 enum Test {
     A(u8),
@@ -28,9 +27,11 @@ const TEST_V: Discriminant<SingleVariant> = discriminant(&SingleVariant::V);
 pub const TEST_VOID: () = {
     // This is UB, but CTFE does not check validity so it does not detect this.
     // This is a regression test for https://github.com/rust-lang/rust/issues/89765.
-    unsafe { std::mem::discriminant(&*(&() as *const () as *const Void)); };
+    unsafe {
+        std::mem::discriminant(&*(&() as *const () as *const Void));
+        //~^ ERROR evaluation of constant value failed
+    };
 };
-
 
 fn main() {
     assert_eq!(TEST_A, TEST_A_OTHER);

--- a/src/test/ui/consts/const_discriminant.stderr
+++ b/src/test/ui/consts/const_discriminant.stderr
@@ -1,0 +1,9 @@
+error[E0080]: evaluation of constant value failed
+  --> $DIR/const_discriminant.rs:31:32
+   |
+LL |         std::mem::discriminant(&*(&() as *const () as *const Void));
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a reference pointing to uninhabited type Void
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/dangling-alloc-id-ice.rs
+++ b/src/test/ui/consts/dangling-alloc-id-ice.rs
@@ -7,7 +7,7 @@ union Foo<'a> {
 }
 
 const FOO: &() = {
-//~^ ERROR encountered dangling pointer in final constant
+//~^ ERROR evaluation of constant value failed
     let y = ();
     unsafe { Foo { y: &y }.long_live_the_unit }
 };

--- a/src/test/ui/consts/dangling-alloc-id-ice.stderr
+++ b/src/test/ui/consts/dangling-alloc-id-ice.stderr
@@ -1,4 +1,4 @@
-error: encountered dangling pointer in final constant
+error[E0080]: evaluation of constant value failed
   --> $DIR/dangling-alloc-id-ice.rs:9:1
    |
 LL | / const FOO: &() = {
@@ -6,7 +6,8 @@ LL | |
 LL | |     let y = ();
 LL | |     unsafe { Foo { y: &y }.long_live_the_unit }
 LL | | };
-   | |__^
+   | |__^ type validation failed: encountered a dangling reference (use-after-free)
 
 error: aborting due to previous error
 
+For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/issue-63952.32bit.stderr
+++ b/src/test/ui/consts/issue-63952.32bit.stderr
@@ -1,19 +1,14 @@
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/issue-63952.rs:17:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/issue-63952.rs:18:5
    |
-LL | / const SLICE_WAY_TOO_LONG: &[u8] = unsafe {
-LL | |     SliceTransmute {
+LL | /     SliceTransmute {
 LL | |         repr: SliceRepr {
 LL | |             ptr: &42,
-...  |
+LL | |             len: usize::MAX,
+LL | |         },
+LL | |     }
 LL | |     .slice
-LL | | };
-   | |__^ type validation failed: encountered invalid reference metadata: slice is bigger than largest supported object
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾─alloc4──╼ ff ff ff ff                         │ ╾──╼....
-           }
+   | |__________^ type validation failed: encountered invalid reference metadata: slice is bigger than largest supported object
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/issue-63952.64bit.stderr
+++ b/src/test/ui/consts/issue-63952.64bit.stderr
@@ -1,19 +1,14 @@
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/issue-63952.rs:17:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/issue-63952.rs:18:5
    |
-LL | / const SLICE_WAY_TOO_LONG: &[u8] = unsafe {
-LL | |     SliceTransmute {
+LL | /     SliceTransmute {
 LL | |         repr: SliceRepr {
 LL | |             ptr: &42,
-...  |
+LL | |             len: usize::MAX,
+LL | |         },
+LL | |     }
 LL | |     .slice
-LL | | };
-   | |__^ type validation failed: encountered invalid reference metadata: slice is bigger than largest supported object
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾───────alloc4────────╼ ff ff ff ff ff ff ff ff │ ╾──────╼........
-           }
+   | |__________^ type validation failed: encountered invalid reference metadata: slice is bigger than largest supported object
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/issue-63952.rs
+++ b/src/test/ui/consts/issue-63952.rs
@@ -14,8 +14,8 @@ union SliceTransmute {
 }
 
 // bad slice: length too big to even exist anywhere
-const SLICE_WAY_TOO_LONG: &[u8] = unsafe { //~ ERROR: it is undefined behavior to use this value
-    SliceTransmute {
+const SLICE_WAY_TOO_LONG: &[u8] = unsafe {
+    SliceTransmute { //~ ERROR evaluation of constant value failed
         repr: SliceRepr {
             ptr: &42,
             len: usize::MAX,

--- a/src/test/ui/consts/issue-64506.rs
+++ b/src/test/ui/consts/issue-64506.rs
@@ -1,5 +1,3 @@
-// check-pass
-
 #[derive(Copy, Clone)]
 pub struct ChildStdin {
     inner: AnonPipe,
@@ -14,6 +12,7 @@ const FOO: () = {
         b: (),
     }
     let x = unsafe { Foo { b: () }.a };
+    //~^ ERROR evaluation of constant value failed
     let x = &x.inner;
 };
 

--- a/src/test/ui/consts/issue-64506.stderr
+++ b/src/test/ui/consts/issue-64506.stderr
@@ -1,0 +1,9 @@
+error[E0080]: evaluation of constant value failed
+  --> $DIR/issue-64506.rs:14:22
+   |
+LL |     let x = unsafe { Foo { b: () }.a };
+   |                      ^^^^^^^^^^^^^^^ type validation failed at .inner: encountered a value of uninhabited type AnonPipe
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/miri_unleashed/ptr_arith.rs
+++ b/src/test/ui/consts/miri_unleashed/ptr_arith.rs
@@ -20,9 +20,8 @@ static PTR_INT_CAST: () = {
 
 static PTR_INT_TRANSMUTE: () = unsafe {
     let x: usize = std::mem::transmute(&0);
-    let _v = x + 0;
     //~^ ERROR could not evaluate static initializer
-    //~| unable to turn pointer into raw bytes
+    let _v = x + 0;
 };
 
 fn main() {}

--- a/src/test/ui/consts/miri_unleashed/ptr_arith.stderr
+++ b/src/test/ui/consts/miri_unleashed/ptr_arith.stderr
@@ -11,10 +11,10 @@ LL |     let x = &0 as *const _ as usize;
    |             ^^^^^^^^^^^^^^^^^^^^^^^ "exposing pointers" needs an rfc before being allowed inside constants
 
 error[E0080]: could not evaluate static initializer
-  --> $DIR/ptr_arith.rs:23:14
+  --> $DIR/ptr_arith.rs:22:20
    |
-LL |     let _v = x + 0;
-   |              ^^^^^ unable to turn pointer into raw bytes
+LL |     let x: usize = std::mem::transmute(&0);
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc9, but expected plain (non-pointer) bytes
 
 warning: skipping const checks
    |

--- a/src/test/ui/consts/ptr_comparisons.rs
+++ b/src/test/ui/consts/ptr_comparisons.rs
@@ -63,11 +63,7 @@ const _: *const u8 =
 //~| out-of-bounds
 
 const _: usize = unsafe { std::mem::transmute::<*const usize, usize>(FOO) + 4 };
-//~^ ERROR any use of this value will cause an error
-//~| unable to turn pointer into raw bytes
-//~| WARN this was previously accepted by the compiler but is being phased out
+//~^ ERROR evaluation of constant value failed
 
 const _: usize = unsafe { *std::mem::transmute::<&&usize, &usize>(&FOO) + 4 };
-//~^ ERROR any use of this value will cause an error
-//~| unable to turn pointer into raw bytes
-//~| WARN this was previously accepted by the compiler but is being phased out
+//~^ ERROR evaluation of constant value failed

--- a/src/test/ui/consts/ptr_comparisons.stderr
+++ b/src/test/ui/consts/ptr_comparisons.stderr
@@ -18,28 +18,17 @@ error[E0080]: evaluation of constant value failed
 LL |     unsafe { std::ptr::addr_of!((*(FOO as *const usize as *const [u8; 1000]))[999]) };
    |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ dereferencing pointer failed: alloc3 has size $WORD, so pointer to 1000 bytes starting at offset 0 is out-of-bounds
 
-error: any use of this value will cause an error
+error[E0080]: evaluation of constant value failed
   --> $DIR/ptr_comparisons.rs:65:27
    |
 LL | const _: usize = unsafe { std::mem::transmute::<*const usize, usize>(FOO) + 4 };
-   | --------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
-   |                           |
-   |                           unable to turn pointer into raw bytes
-   |
-   = note: `#[deny(const_err)]` on by default
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+   |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc3, but expected plain (non-pointer) bytes
 
-error: any use of this value will cause an error
-  --> $DIR/ptr_comparisons.rs:70:27
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ptr_comparisons.rs:68:27
    |
 LL | const _: usize = unsafe { *std::mem::transmute::<&&usize, &usize>(&FOO) + 4 };
-   | --------------------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---
-   |                           |
-   |                           unable to turn pointer into raw bytes
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+   |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered pointer to alloc3, but expected plain (non-pointer) bytes
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/consts/std/alloc.32bit.stderr
+++ b/src/test/ui/consts/std/alloc.32bit.stderr
@@ -1,24 +1,40 @@
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/alloc.rs:9:1
+error[E0080]: evaluation of constant value failed
+  --> $SRC_DIR/core/src/mem/valid_align.rs:LL:COL
+   |
+LL |         unsafe { mem::transmute::<usize, ValidAlign>(align) }
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                  |
+   |                  type validation failed at .0.<enum-tag>: encountered 0x00000000, but expected a valid enum tag
+   |                  inside `mem::valid_align::ValidAlign::new_unchecked` at $SRC_DIR/core/src/mem/valid_align.rs:LL:COL
+   |
+  ::: $SRC_DIR/core/src/alloc/layout.rs:LL:COL
+   |
+LL |         Layout { size, align: unsafe { ValidAlign::new_unchecked(align) } }
+   |                                        -------------------------------- inside `Layout::from_size_align_unchecked` at $SRC_DIR/core/src/alloc/layout.rs:LL:COL
+   |
+  ::: $DIR/alloc.rs:9:46
    |
 LL | const LAYOUT_INVALID_ZERO: Layout = unsafe { Layout::from_size_align_unchecked(0x1000, 0x00) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .align.0.<enum-tag>: encountered 0x00000000, but expected a valid enum tag
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 4) {
-               00 10 00 00 00 00 00 00                         │ ........
-           }
+   |                                              ----------------------------------------------- inside `LAYOUT_INVALID_ZERO` at $DIR/alloc.rs:9:46
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/alloc.rs:13:1
+error[E0080]: evaluation of constant value failed
+  --> $SRC_DIR/core/src/mem/valid_align.rs:LL:COL
+   |
+LL |         unsafe { mem::transmute::<usize, ValidAlign>(align) }
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                  |
+   |                  type validation failed at .0.<enum-tag>: encountered 0x00000003, but expected a valid enum tag
+   |                  inside `mem::valid_align::ValidAlign::new_unchecked` at $SRC_DIR/core/src/mem/valid_align.rs:LL:COL
+   |
+  ::: $SRC_DIR/core/src/alloc/layout.rs:LL:COL
+   |
+LL |         Layout { size, align: unsafe { ValidAlign::new_unchecked(align) } }
+   |                                        -------------------------------- inside `Layout::from_size_align_unchecked` at $SRC_DIR/core/src/alloc/layout.rs:LL:COL
+   |
+  ::: $DIR/alloc.rs:12:47
    |
 LL | const LAYOUT_INVALID_THREE: Layout = unsafe { Layout::from_size_align_unchecked(9, 3) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .align.0.<enum-tag>: encountered 0x00000003, but expected a valid enum tag
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 4) {
-               09 00 00 00 03 00 00 00                         │ ........
-           }
+   |                                               --------------------------------------- inside `LAYOUT_INVALID_THREE` at $DIR/alloc.rs:12:47
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/consts/std/alloc.64bit.stderr
+++ b/src/test/ui/consts/std/alloc.64bit.stderr
@@ -1,24 +1,40 @@
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/alloc.rs:9:1
+error[E0080]: evaluation of constant value failed
+  --> $SRC_DIR/core/src/mem/valid_align.rs:LL:COL
+   |
+LL |         unsafe { mem::transmute::<usize, ValidAlign>(align) }
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                  |
+   |                  type validation failed at .0.<enum-tag>: encountered 0x0000000000000000, but expected a valid enum tag
+   |                  inside `mem::valid_align::ValidAlign::new_unchecked` at $SRC_DIR/core/src/mem/valid_align.rs:LL:COL
+   |
+  ::: $SRC_DIR/core/src/alloc/layout.rs:LL:COL
+   |
+LL |         Layout { size, align: unsafe { ValidAlign::new_unchecked(align) } }
+   |                                        -------------------------------- inside `Layout::from_size_align_unchecked` at $SRC_DIR/core/src/alloc/layout.rs:LL:COL
+   |
+  ::: $DIR/alloc.rs:9:46
    |
 LL | const LAYOUT_INVALID_ZERO: Layout = unsafe { Layout::from_size_align_unchecked(0x1000, 0x00) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .align.0.<enum-tag>: encountered 0x0000000000000000, but expected a valid enum tag
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 16, align: 8) {
-               00 10 00 00 00 00 00 00 00 00 00 00 00 00 00 00 │ ................
-           }
+   |                                              ----------------------------------------------- inside `LAYOUT_INVALID_ZERO` at $DIR/alloc.rs:9:46
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/alloc.rs:13:1
+error[E0080]: evaluation of constant value failed
+  --> $SRC_DIR/core/src/mem/valid_align.rs:LL:COL
+   |
+LL |         unsafe { mem::transmute::<usize, ValidAlign>(align) }
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                  |
+   |                  type validation failed at .0.<enum-tag>: encountered 0x0000000000000003, but expected a valid enum tag
+   |                  inside `mem::valid_align::ValidAlign::new_unchecked` at $SRC_DIR/core/src/mem/valid_align.rs:LL:COL
+   |
+  ::: $SRC_DIR/core/src/alloc/layout.rs:LL:COL
+   |
+LL |         Layout { size, align: unsafe { ValidAlign::new_unchecked(align) } }
+   |                                        -------------------------------- inside `Layout::from_size_align_unchecked` at $SRC_DIR/core/src/alloc/layout.rs:LL:COL
+   |
+  ::: $DIR/alloc.rs:12:47
    |
 LL | const LAYOUT_INVALID_THREE: Layout = unsafe { Layout::from_size_align_unchecked(9, 3) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .align.0.<enum-tag>: encountered 0x0000000000000003, but expected a valid enum tag
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 16, align: 8) {
-               09 00 00 00 00 00 00 00 03 00 00 00 00 00 00 00 │ ................
-           }
+   |                                               --------------------------------------- inside `LAYOUT_INVALID_THREE` at $DIR/alloc.rs:12:47
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/consts/std/alloc.rs
+++ b/src/test/ui/consts/std/alloc.rs
@@ -7,10 +7,8 @@ const LAYOUT_VALID: Layout = unsafe { Layout::from_size_align_unchecked(0x1000, 
 
 // not ok, since alignment needs to be non-zero.
 const LAYOUT_INVALID_ZERO: Layout = unsafe { Layout::from_size_align_unchecked(0x1000, 0x00) };
-//~^ ERROR it is undefined behavior to use this value
 
 // not ok, since alignment needs to be a power of two.
 const LAYOUT_INVALID_THREE: Layout = unsafe { Layout::from_size_align_unchecked(9, 3) };
-//~^ ERROR it is undefined behavior to use this value
 
 fn main() {}

--- a/src/test/ui/consts/validate_never_arrays.32bit.stderr
+++ b/src/test/ui/consts/validate_never_arrays.32bit.stderr
@@ -1,35 +1,20 @@
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/validate_never_arrays.rs:4:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/validate_never_arrays.rs:4:29
    |
 LL | const _: &[!; 1] = unsafe { &*(1_usize as *const [!; 1]) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a reference pointing to uninhabited type [!; 1]
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 4, align: 4) {
-               01 00 00 00                                     │ ....
-           }
+   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a reference pointing to uninhabited type [!; 1]
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/validate_never_arrays.rs:7:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/validate_never_arrays.rs:8:26
    |
 LL | const _: &[!] = unsafe { &*(1_usize as *const [!; 1]) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .<deref>[0]: encountered a value of the never type `!`
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 4) {
-               01 00 00 00 01 00 00 00                         │ ........
-           }
+   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a reference pointing to uninhabited type [!; 1]
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/validate_never_arrays.rs:8:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/validate_never_arrays.rs:10:26
    |
 LL | const _: &[!] = unsafe { &*(1_usize as *const [!; 42]) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .<deref>[0]: encountered a value of the never type `!`
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 4) {
-               01 00 00 00 2a 00 00 00                         │ ....*...
-           }
+   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a reference pointing to uninhabited type [!; 42]
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/consts/validate_never_arrays.64bit.stderr
+++ b/src/test/ui/consts/validate_never_arrays.64bit.stderr
@@ -1,35 +1,20 @@
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/validate_never_arrays.rs:4:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/validate_never_arrays.rs:4:29
    |
 LL | const _: &[!; 1] = unsafe { &*(1_usize as *const [!; 1]) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a reference pointing to uninhabited type [!; 1]
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 8, align: 8) {
-               01 00 00 00 00 00 00 00                         │ ........
-           }
+   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a reference pointing to uninhabited type [!; 1]
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/validate_never_arrays.rs:7:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/validate_never_arrays.rs:8:26
    |
 LL | const _: &[!] = unsafe { &*(1_usize as *const [!; 1]) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .<deref>[0]: encountered a value of the never type `!`
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 16, align: 8) {
-               01 00 00 00 00 00 00 00 01 00 00 00 00 00 00 00 │ ................
-           }
+   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a reference pointing to uninhabited type [!; 1]
 
-error[E0080]: it is undefined behavior to use this value
-  --> $DIR/validate_never_arrays.rs:8:1
+error[E0080]: evaluation of constant value failed
+  --> $DIR/validate_never_arrays.rs:10:26
    |
 LL | const _: &[!] = unsafe { &*(1_usize as *const [!; 42]) };
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .<deref>[0]: encountered a value of the never type `!`
-   |
-   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
-   = note: the raw bytes of the constant (size: 16, align: 8) {
-               01 00 00 00 00 00 00 00 2a 00 00 00 00 00 00 00 │ ........*.......
-           }
+   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a reference pointing to uninhabited type [!; 42]
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/consts/validate_never_arrays.rs
+++ b/src/test/ui/consts/validate_never_arrays.rs
@@ -1,10 +1,13 @@
 // stderr-per-bitwidth
 #![feature(never_type)]
 
-const _: &[!; 1] = unsafe { &*(1_usize as *const [!; 1]) }; //~ ERROR undefined behavior
+const _: &[!; 1] = unsafe { &*(1_usize as *const [!; 1]) };
+//~^ ERROR evaluation of constant value failed
 const _: &[!; 0] = unsafe { &*(1_usize as *const [!; 0]) }; // ok
 const _: &[!] = unsafe { &*(1_usize as *const [!; 0]) }; // ok
-const _: &[!] = unsafe { &*(1_usize as *const [!; 1]) }; //~ ERROR undefined behavior
-const _: &[!] = unsafe { &*(1_usize as *const [!; 42]) }; //~ ERROR undefined behavior
+const _: &[!] = unsafe { &*(1_usize as *const [!; 1]) };
+//~^ ERROR evaluation of constant value failed
+const _: &[!] = unsafe { &*(1_usize as *const [!; 42]) };
+//~^ ERROR evaluation of constant value failed
 
 fn main() {}


### PR DESCRIPTION
Normally we tell people that CTFE _may_ detect UB, but it doesn't have to. RFC 3016 documents this explicitly: https://rust-lang.github.io/rfcs/3016-const-ub.html. But until I dug into #95332 I didn't realize how limited the UB checks in CTFE actually are: Invalid bit patterns are not checked for until we create an actual `const`. Thus, this code (from the linked issue) is not detected as UB:
```rust
use std::num::NonZeroU8;
pub const UNDEFINED: Option<NonZeroU8> = Some(unsafe { NonZeroU8::new_unchecked(0) });
```
and that is because in the `Machine` that rustc uses for CTFE, we have this:
```rust
    #[inline(always)]
    fn enforce_validity(_ecx: &InterpCx<'mir, 'tcx, Self>) -> bool {
        false // for now, we don't enforce validity
    }
```

The general idea of this PR is to add some state to `Machine` which indicates whether or not we may be executing `unsafe` code, and if we are, return `true`.

Since there is no `unsafe` in MIR, we're left analyzing HIR which is only available for the current crate. So currently this makes the defensive assumption that any MIR loaded from a non-local crate contains `unsafe`. This assumption could be inverted, I'm preferring the closer-to-sound option here but of course we have no obligation to detect UB here.

In this PR, the `Machine` used for CTFE detects `unsafe` in one of two ways. If there is a call to `load_mir`, we walk all the MIR looking for any unsafe blocks. But if the `Machine` sees a call to `enforce_validity` without a previous call to `load_mir`, it runs the same search but only on the current stack frame. This second case is very common when we are evaluating a trivial `const`. Each `Machine` instance will only search for unsafe blocks once.

r? @oli-obk 