### PR TITLE
Add `mem::conjure_zst` for creating ZSTs out of nothing

### DIFF
--- a/tests/ui/consts/std/conjure_uninhabited_zst.rs
+++ b/tests/ui/consts/std/conjure_uninhabited_zst.rs
@@ -1,0 +1,11 @@
+#![feature(mem_conjure_zst)]
+
+use std::convert::Infallible;
+use std::mem::conjure_zst;
+
+// not ok, since the type needs to be inhabited
+const CONJURE_INVALID: Infallible = unsafe { conjure_zst() };
+//~^ ERROR any use of this value will cause an error
+//~^^ WARN will become a hard error in a future release
+
+fn main() {}

--- a/tests/ui/consts/std/conjure_uninhabited_zst.stderr
+++ b/tests/ui/consts/std/conjure_uninhabited_zst.stderr
@@ -1,0 +1,14 @@
+error: any use of this value will cause an error
+  --> $DIR/conjure_uninhabited_zst.rs:7:46
+   |
+LL | const CONJURE_INVALID: Infallible = unsafe { conjure_zst() };
+   | ---------------------------------------------^^^^^^^^^^^^^---
+   |                                              |
+   |                                              aborted execution: attempted to instantiate uninhabited type `Infallible`
+   |
+   = note: `#[deny(const_err)]` on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+
+error: aborting due to previous error
+


### PR DESCRIPTION
This adds a new `unsafe fn` to `mem` which can create instances of ZSTs (and *only* ZSTs).

I think this is valuable for a few reasons:

1) It avoids wondering whether it's best to do this with `zeroed()` or `uninitialized()` or `new_uninit().assume_init()` or `transmute_copy` or ... when you're writing code.  (See, for example, this PR conversation https://github.com/rust-lang/rust/pull/82098#discussion_r575814738 )
2) It makes it clearer to the reader of the code what's happening, rather than making them get distracted wondering "wait, why is zero-init okay here?" or similar.
3) It gives a good place to describe the soundness restrictions on this operation, since it's easy to mistakenly think "oh, it's a ZST, I'm sure it's sound to just create one no matter what".  (cc @RalfJung , in case you'd like to check whether what I wrote is sufficient.)

TL/DR: I think this is a useful piece of ["good evil"](https://rust-lang.zulipchat.com/#narrow/stream/136281-t-lang.2Fwg-unsafe-code-guidelines/topic/strict.20provenance.20std.20compat.20notes/near/276143230).

The PR also uses it in a few places in the library I quickly spotted where we need to create instances after `size_of::<T>() == 0` runtime checks, if you'd like to see usage examples.

### Naming

To conjure is [to summon by or as if by invocation or incantation](https://www.merriam-webster.com/dictionary/conjure).

Given that we have [transmutation](https://harrypotter.fandom.com/wiki/Transmutation) already, I thought that [conjuration](https://harrypotter.fandom.com/wiki/Conjuration) fit well for this operation -- the method is creating it "from nothing", as opposed to the "from something else" of `mem::transmute`.  (This seems a pretty pervasive use, here's a [game example of conjuration](https://skyrim.fandom.com/wiki/Conjuration) to add to the previous book one.)
