### PR TITLE
Suggest wrapping patterns in enum variants

### DIFF
--- a/compiler/rustc_typeck/src/check/demand.rs
+++ b/compiler/rustc_typeck/src/check/demand.rs
@@ -268,10 +268,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         expr_ty: Ty<'tcx>,
     ) {
         if let ty::Adt(expected_adt, substs) = expected.kind() {
-            if !expected_adt.is_enum() {
-                return;
-            }
-
             // If the expression is of type () and it's the return expression of a block,
             // we suggest adding a separate return expression instead.
             // (To avoid things like suggesting `Ok(while .. { .. })`.)

--- a/compiler/rustc_typeck/src/check/demand.rs
+++ b/compiler/rustc_typeck/src/check/demand.rs
@@ -336,7 +336,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             let compatible_variants: Vec<String> = expected_adt
                 .variants()
                 .iter()
-                .filter(|variant| variant.fields.len() == 1)
+                .filter(|variant| {
+                    variant.fields.len() == 1 && variant.ctor_kind == hir::def::CtorKind::Fn
+                })
                 .filter_map(|variant| {
                     let sole_field = &variant.fields[0];
                     let sole_field_ty = sole_field.ty(self.tcx, substs);

--- a/src/test/ui/did_you_mean/compatible-variants-in-pat.rs
+++ b/src/test/ui/did_you_mean/compatible-variants-in-pat.rs
@@ -1,0 +1,41 @@
+enum Foo {
+    Bar(Bar),
+}
+struct Bar {
+    x: i32,
+}
+
+fn a(f: Foo) {
+    match f {
+        Bar { x } => {
+            //~^ ERROR mismatched types
+            //~| HELP try wrapping
+        }
+    }
+}
+
+struct S;
+
+fn b(s: Option<S>) {
+    match s {
+        S => {
+            //~^ ERROR mismatched types
+            //~| HELP try wrapping
+            //~| HELP introduce a new binding instead
+        }
+        _ => {}
+    }
+}
+
+fn c(s: Result<S, S>) {
+    match s {
+        S => {
+            //~^ ERROR mismatched types
+            //~| HELP try wrapping
+            //~| HELP introduce a new binding instead
+        }
+        _ => {}
+    }
+}
+
+fn main() {}

--- a/src/test/ui/did_you_mean/compatible-variants-in-pat.stderr
+++ b/src/test/ui/did_you_mean/compatible-variants-in-pat.stderr
@@ -1,0 +1,68 @@
+error[E0308]: mismatched types
+  --> $DIR/compatible-variants-in-pat.rs:10:9
+   |
+LL |     match f {
+   |           - this expression has type `Foo`
+LL |         Bar { x } => {
+   |         ^^^^^^^^^ expected enum `Foo`, found struct `Bar`
+   |
+help: try wrapping the pattern in `Foo::Bar`
+   |
+LL |         Foo::Bar(Bar { x }) => {
+   |         +++++++++         +
+
+error[E0308]: mismatched types
+  --> $DIR/compatible-variants-in-pat.rs:21:9
+   |
+LL | struct S;
+   | --------- unit struct defined here
+...
+LL |     match s {
+   |           - this expression has type `Option<S>`
+LL |         S => {
+   |         ^
+   |         |
+   |         expected enum `Option`, found struct `S`
+   |         `S` is interpreted as a unit struct, not a new binding
+   |
+   = note: expected enum `Option<S>`
+            found struct `S`
+help: try wrapping the pattern in `Some`
+   |
+LL |         Some(S) => {
+   |         +++++ +
+help: introduce a new binding instead
+   |
+LL |         other_s => {
+   |         ~~~~~~~
+
+error[E0308]: mismatched types
+  --> $DIR/compatible-variants-in-pat.rs:32:9
+   |
+LL | struct S;
+   | --------- unit struct defined here
+...
+LL |     match s {
+   |           - this expression has type `Result<S, S>`
+LL |         S => {
+   |         ^
+   |         |
+   |         expected enum `Result`, found struct `S`
+   |         `S` is interpreted as a unit struct, not a new binding
+   |
+   = note: expected enum `Result<S, S>`
+            found struct `S`
+help: try wrapping the pattern in a variant of `Result`
+   |
+LL |         Ok(S) => {
+   |         +++ +
+LL |         Err(S) => {
+   |         ++++ +
+help: introduce a new binding instead
+   |
+LL |         other_s => {
+   |         ~~~~~~~
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/did_you_mean/compatible-variants.rs
+++ b/src/test/ui/did_you_mean/compatible-variants.rs
@@ -64,3 +64,18 @@ fn main() {
     //~^ ERROR mismatched types
     //~| HELP try wrapping
 }
+
+enum A {
+    B { b: B},
+}
+
+enum B {
+    Fst,
+    Snd,
+}
+
+fn foo() {
+    // We don't want to suggest `A::B(B::Fst)` here.
+    let a: A = B::Fst;
+    //~^ ERROR mismatched types
+}

--- a/src/test/ui/did_you_mean/compatible-variants.rs
+++ b/src/test/ui/did_you_mean/compatible-variants.rs
@@ -69,6 +69,8 @@ enum A {
     B { b: B},
 }
 
+struct A2(B);
+
 enum B {
     Fst,
     Snd,
@@ -78,4 +80,11 @@ fn foo() {
     // We don't want to suggest `A::B(B::Fst)` here.
     let a: A = B::Fst;
     //~^ ERROR mismatched types
+}
+
+fn bar() {
+    // But we _do_ want to suggest `A2(B::Fst)` here!
+    let a: A2 = B::Fst;
+    //~^ ERROR mismatched types
+    //~| HELP try wrapping
 }

--- a/src/test/ui/did_you_mean/compatible-variants.stderr
+++ b/src/test/ui/did_you_mean/compatible-variants.stderr
@@ -191,13 +191,26 @@ LL |     let _ = Foo { bar: Some(bar) };
    |                   ++++++++++   +
 
 error[E0308]: mismatched types
-  --> $DIR/compatible-variants.rs:79:16
+  --> $DIR/compatible-variants.rs:81:16
    |
 LL |     let a: A = B::Fst;
    |            -   ^^^^^^ expected enum `A`, found enum `B`
    |            |
    |            expected due to this
 
-error: aborting due to 12 previous errors
+error[E0308]: mismatched types
+  --> $DIR/compatible-variants.rs:87:17
+   |
+LL |     let a: A2 = B::Fst;
+   |            --   ^^^^^^ expected struct `A2`, found enum `B`
+   |            |
+   |            expected due to this
+   |
+help: try wrapping the expression in `A2`
+   |
+LL |     let a: A2 = A2(B::Fst);
+   |                 +++      +
+
+error: aborting due to 13 previous errors
 
 For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/did_you_mean/compatible-variants.stderr
+++ b/src/test/ui/did_you_mean/compatible-variants.stderr
@@ -190,6 +190,14 @@ help: try wrapping the expression in `Some`
 LL |     let _ = Foo { bar: Some(bar) };
    |                   ++++++++++   +
 
-error: aborting due to 11 previous errors
+error[E0308]: mismatched types
+  --> $DIR/compatible-variants.rs:79:16
+   |
+LL |     let a: A = B::Fst;
+   |            -   ^^^^^^ expected enum `A`, found enum `B`
+   |            |
+   |            expected due to this
+
+error: aborting due to 12 previous errors
 
 For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/issues/issue-12552.stderr
+++ b/src/test/ui/issues/issue-12552.stderr
@@ -8,6 +8,10 @@ LL |     Some(k) => match k {
    |
    = note: expected enum `Result<_, {integer}>`
               found enum `Option<_>`
+help: try wrapping the pattern in `Ok`
+   |
+LL |     Ok(Some(k)) => match k {
+   |     +++       +
 
 error[E0308]: mismatched types
   --> $DIR/issue-12552.rs:9:5
@@ -20,6 +24,10 @@ LL |     None => ()
    |
    = note: expected enum `Result<_, {integer}>`
               found enum `Option<_>`
+help: try wrapping the pattern in `Ok`
+   |
+LL |     Ok(None) => ()
+   |     +++    +
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-3680.stderr
+++ b/src/test/ui/issues/issue-3680.stderr
@@ -8,6 +8,10 @@ LL |         Err(_) => ()
    |
    = note: expected enum `Option<_>`
               found enum `Result<_, _>`
+help: try wrapping the pattern in `Some`
+   |
+LL |         Some(Err(_)) => ()
+   |         +++++      +
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-5358-1.stderr
+++ b/src/test/ui/issues/issue-5358-1.stderr
@@ -8,6 +8,10 @@ LL |         Either::Right(_) => {}
    |
    = note: expected struct `S`
                 found enum `Either<_, _>`
+help: try wrapping the pattern in `S`
+   |
+LL |         S(Either::Right(_)) => {}
+   |         ++                +
 help: you might have meant to use field `0` whose type is `Either<usize, usize>`
    |
 LL |     match S(Either::Left(5)).0 {


### PR DESCRIPTION
Structured suggestion to wrap a pattern in a single-field enum or struct:

```diff
 struct A;

 enum B {
   A(A),
 }

 fn main(b: B) {
   match b {
-    A => {}
+    B::A(A) => {}
   }
 }
```

Half of #94942, the other half I'm not exactly sure how to fix.

Also includes two drive-by changes (that I am open to splitting out into another PR, but thought they could be rolled up into this one):
- 07776c111f07b887cd46b752870cd3fd76b2ba7c: Makes sure not to suggest wrapping if it doesn't have tuple field constructor (i.e. has named fields)
- 8f2bbb18fd53e5008bb488302dbd354577698ede: Also suggest wrapping expressions in a tuple struct (not just enum variants)