### PR TITLE
Ignore doc comments in a declarative macro matcher.

### DIFF
--- a/compiler/rustc_expand/src/mbe/macro_parser.rs
+++ b/compiler/rustc_expand/src/mbe/macro_parser.rs
@@ -519,13 +519,14 @@ impl<'tt> TtParser<'tt> {
                     }
 
                     TokenTree::Token(t) => {
-                        // Doc comments cannot appear in a matcher.
-                        debug_assert!(!matches!(t, Token { kind: DocComment(..), .. }));
-
-                        // If the token matches, we can just advance the parser. Otherwise, this
-                        // match hash failed, there is nothing to do, and hopefully another item in
-                        // `cur_items` will match.
-                        if token_name_eq(&t, token) {
+                        // If it's a doc comment, we just ignore it and move on to the next tt in
+                        // the matcher. If the token matches, we can just advance the parser.
+                        // Otherwise, this match has failed, there is nothing to do, and hopefully
+                        // another item in `cur_items` will match.
+                        if matches!(t, Token { kind: DocComment(..), .. }) {
+                            item.idx += 1;
+                            self.cur_items.push(item);
+                        } else if token_name_eq(&t, token) {
                             item.idx += 1;
                             self.next_items.push(item);
                         }

--- a/src/test/ui/macros/issue-95267.rs
+++ b/src/test/ui/macros/issue-95267.rs
@@ -1,0 +1,13 @@
+// check-pass
+
+// This is a valid macro. Commit 4 in #95159 broke things such that it failed
+// with a "missing tokens in macro arguments" error, as reported in #95267.
+macro_rules! f {
+    (
+        /// ab
+    ) => {};
+}
+
+fn main() {
+    f!();
+}


### PR DESCRIPTION
Fixes #95267. Reverts to the old behaviour before #95159 introduced a
regression.

r? @petrochenkov 