### PR TITLE
bootstrap: better error message for no_std docs

### DIFF
--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -432,6 +432,12 @@ impl Step for Std {
         let stage = self.stage;
         let target = self.target;
         builder.info(&format!("Documenting stage{} std ({})", stage, target));
+        if builder.no_std(target) == Some(true) {
+            panic!(
+                "building std documentation for no_std target {target} is not supported\n\
+                 Set `docs = false` in the config to disable documentation."
+            );
+        }
         let out = builder.doc_out(target);
         t!(fs::create_dir_all(&out));
         let compiler = builder.compiler(stage, builder.config.build);


### PR DESCRIPTION
Currently if one tries to build std documentation for a no_std target, you get a confusing error message:

`error: The argument '--package [<SPEC>...]' was provided more than once, but cannot be used multiple times`

This is because [`std_cargo`](https://github.com/rust-lang/rust/blob/600ec284838c52d1f6657c2cf0097b58970b133b/src/bootstrap/compile.rs#L299-L305) has a built-in `-p alloc` argument that conflicts with the `cargo rustdoc` command used in the Std doc step.

This just adds a better error message in this scenario. It may be possible to fix this correctly, but that would likely be a bit more of an invasive change that I don't have time for right now.
