### PR TITLE
Stabilize total_cmp

### DIFF
--- a/library/core/src/num/f32.rs
+++ b/library/core/src/num/f32.rs
@@ -1040,7 +1040,6 @@ impl f32 {
     /// # Example
     ///
     /// ```
-    /// #![feature(total_cmp)]
     /// struct GoodBoy {
     ///     name: String,
     ///     weight: f32,
@@ -1060,7 +1059,7 @@ impl f32 {
     /// #     .zip([-5.0, 0.1, 10.0, 99.0, f32::INFINITY, f32::NAN].iter())
     /// #     .all(|(a, b)| a.to_bits() == b.to_bits()))
     /// ```
-    #[unstable(feature = "total_cmp", issue = "72599")]
+    #[stable(feature = "total_cmp", since = "1.62.0")]
     #[must_use]
     #[inline]
     pub fn total_cmp(&self, other: &Self) -> crate::cmp::Ordering {

--- a/library/core/src/num/f64.rs
+++ b/library/core/src/num/f64.rs
@@ -1056,7 +1056,6 @@ impl f64 {
     /// # Example
     ///
     /// ```
-    /// #![feature(total_cmp)]
     /// struct GoodBoy {
     ///     name: String,
     ///     weight: f64,
@@ -1076,7 +1075,7 @@ impl f64 {
     /// #     .zip([-5.0, 0.1, 10.0, 99.0, f64::INFINITY, f64::NAN].iter())
     /// #     .all(|(a, b)| a.to_bits() == b.to_bits()))
     /// ```
-    #[unstable(feature = "total_cmp", issue = "72599")]
+    #[stable(feature = "total_cmp", since = "1.62.0")]
     #[must_use]
     #[inline]
     pub fn total_cmp(&self, other: &Self) -> crate::cmp::Ordering {

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -285,7 +285,6 @@
 #![feature(std_internals)]
 #![feature(str_internals)]
 #![feature(strict_provenance)]
-#![feature(total_cmp)]
 //
 // Library features (alloc):
 #![feature(alloc_layout_extra)]

--- a/library/test/src/lib.rs
+++ b/library/test/src/lib.rs
@@ -21,7 +21,6 @@
 #![feature(staged_api)]
 #![feature(process_exitcode_internals)]
 #![feature(test)]
-#![feature(total_cmp)]
 
 // Public reexports
 pub use self::bench::{black_box, Bencher};


### PR DESCRIPTION
Stabilises `total_cmp` for <s>Rust 1.61.0</s>. **Didn't make it in time, will be in Rust 1.62.0.** Tracking issue: https://github.com/rust-lang/rust/issues/72599