### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/mutability_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/mutability_errors.rs
@@ -787,7 +787,12 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
                                                         _,
                                                         [
                                                             Expr {
-                                                                kind: MethodCall(path_segment, ..),
+                                                                kind:
+                                                                    MethodCall(
+                                                                        path_segment,
+                                                                        _args,
+                                                                        span,
+                                                                    ),
                                                                 hir_id,
                                                                 ..
                                                             },
@@ -831,7 +836,7 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, 'tcx> {
                 if let Some(mut suggestions) = opt_suggestions {
                     if suggestions.peek().is_some() {
                         err.span_suggestions(
-                            path_segment.ident.span,
+                            *span,
                             "use mutable method",
                             suggestions,
                             Applicability::MaybeIncorrect,

--- a/compiler/rustc_typeck/src/check/op.rs
+++ b/compiler/rustc_typeck/src/check/op.rs
@@ -299,52 +299,52 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     IsAssign::No => {
                         let (message, missing_trait, use_output) = match op.node {
                             hir::BinOpKind::Add => (
-                                format!("cannot add `{}` to `{}`", rhs_ty, lhs_ty),
+                                format!("cannot add `{rhs_ty}` to `{lhs_ty}`"),
                                 Some("std::ops::Add"),
                                 true,
                             ),
                             hir::BinOpKind::Sub => (
-                                format!("cannot subtract `{}` from `{}`", rhs_ty, lhs_ty),
+                                format!("cannot subtract `{rhs_ty}` from `{lhs_ty}`"),
                                 Some("std::ops::Sub"),
                                 true,
                             ),
                             hir::BinOpKind::Mul => (
-                                format!("cannot multiply `{}` by `{}`", lhs_ty, rhs_ty),
+                                format!("cannot multiply `{lhs_ty}` by `{rhs_ty}`"),
                                 Some("std::ops::Mul"),
                                 true,
                             ),
                             hir::BinOpKind::Div => (
-                                format!("cannot divide `{}` by `{}`", lhs_ty, rhs_ty),
+                                format!("cannot divide `{lhs_ty}` by `{rhs_ty}`"),
                                 Some("std::ops::Div"),
                                 true,
                             ),
                             hir::BinOpKind::Rem => (
-                                format!("cannot mod `{}` by `{}`", lhs_ty, rhs_ty),
+                                format!("cannot mod `{lhs_ty}` by `{rhs_ty}`"),
                                 Some("std::ops::Rem"),
                                 true,
                             ),
                             hir::BinOpKind::BitAnd => (
-                                format!("no implementation for `{} & {}`", lhs_ty, rhs_ty),
+                                format!("no implementation for `{lhs_ty} & {rhs_ty}`"),
                                 Some("std::ops::BitAnd"),
                                 true,
                             ),
                             hir::BinOpKind::BitXor => (
-                                format!("no implementation for `{} ^ {}`", lhs_ty, rhs_ty),
+                                format!("no implementation for `{lhs_ty} ^ {rhs_ty}`"),
                                 Some("std::ops::BitXor"),
                                 true,
                             ),
                             hir::BinOpKind::BitOr => (
-                                format!("no implementation for `{} | {}`", lhs_ty, rhs_ty),
+                                format!("no implementation for `{lhs_ty} | {rhs_ty}`"),
                                 Some("std::ops::BitOr"),
                                 true,
                             ),
                             hir::BinOpKind::Shl => (
-                                format!("no implementation for `{} << {}`", lhs_ty, rhs_ty),
+                                format!("no implementation for `{lhs_ty} << {rhs_ty}`"),
                                 Some("std::ops::Shl"),
                                 true,
                             ),
                             hir::BinOpKind::Shr => (
-                                format!("no implementation for `{} >> {}`", lhs_ty, rhs_ty),
+                                format!("no implementation for `{lhs_ty} >> {rhs_ty}`"),
                                 Some("std::ops::Shr"),
                                 true,
                             ),
@@ -477,8 +477,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                                 // When we know that a missing bound is responsible, we don't show
                                 // this note as it is redundant.
                                 err.note(&format!(
-                                    "the trait `{}` is not implemented for `{}`",
-                                    missing_trait, lhs_ty
+                                    "the trait `{missing_trait}` is not implemented for `{lhs_ty}`"
                                 ));
                             }
                         } else {
@@ -679,19 +678,17 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     };
                     let mut visitor = TypeParamVisitor(vec![]);
                     visitor.visit_ty(operand_ty);
-                    if let [ty] = &visitor.0[..] {
-                        if let ty::Param(p) = *operand_ty.kind() {
-                            suggest_constraining_param(
-                                self.tcx,
-                                self.body_id,
-                                &mut err,
-                                *ty,
-                                operand_ty,
-                                missing_trait,
-                                p,
-                                true,
-                            );
-                        }
+                    if let [ty] = &visitor.0[..] && let ty::Param(p) = *operand_ty.kind() {
+                        suggest_constraining_param(
+                            self.tcx,
+                            self.body_id,
+                            &mut err,
+                            *ty,
+                            operand_ty,
+                            missing_trait,
+                            p,
+                            true,
+                        );
                     }
 
                     let sp = self.tcx.sess.source_map().start_point(ex.span);
@@ -722,10 +719,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                                     err.span_suggestion(
                                         ex.span,
                                         &format!(
-                                            "you may have meant the maximum value of `{}`",
-                                            actual
+                                            "you may have meant the maximum value of `{actual}`",
                                         ),
-                                        format!("{}::MAX", actual),
+                                        format!("{actual}::MAX"),
                                         Applicability::MaybeIncorrect,
                                     );
                                 }
@@ -988,7 +984,7 @@ fn suggest_constraining_param(
     set_output: bool,
 ) {
     let hir = tcx.hir();
-    let msg = &format!("`{}` might need a bound for `{}`", lhs_ty, missing_trait);
+    let msg = &format!("`{lhs_ty}` might need a bound for `{missing_trait}`");
     // Try to find the def-id and details for the parameter p. We have only the index,
     // so we have to find the enclosing function's def-id, then look through its declared
     // generic parameters to get the declaration.
@@ -1002,13 +998,13 @@ fn suggest_constraining_param(
         .as_ref()
         .and_then(|node| node.generics())
     {
-        let output = if set_output { format!("<Output = {}>", rhs_ty) } else { String::new() };
+        let output = if set_output { format!("<Output = {rhs_ty}>") } else { String::new() };
         suggest_constraining_type_param(
             tcx,
             generics,
             &mut err,
-            &format!("{}", lhs_ty),
-            &format!("{}{}", missing_trait, output),
+            &lhs_ty.to_string(),
+            &format!("{missing_trait}{output}"),
             None,
         );
     } else {

--- a/library/test/src/console.rs
+++ b/library/test/src/console.rs
@@ -118,7 +118,7 @@ impl ConsoleTestState {
                     TestResult::TrIgnored => {
                         #[cfg(not(bootstrap))]
                         if let Some(msg) = ignore_message {
-                            format!("ignored, {msg}")
+                            format!("ignored: {msg}")
                         } else {
                             "ignored".to_owned()
                         }

--- a/library/test/src/formatters/json.rs
+++ b/library/test/src/formatters/json.rs
@@ -121,6 +121,27 @@ impl<T: Write> OutputFormatter for JsonFormatter<T> {
             ),
 
             TestResult::TrIgnored => {
+                #[cfg(not(bootstrap))]
+                if let Some(msg) = desc.ignore_message {
+                    self.write_event(
+                        "test",
+                        desc.name.as_slice(),
+                        "ignored",
+                        exec_time,
+                        stdout,
+                        Some(&*format!(r#""message": "{}""#, EscapedString(msg))),
+                    )
+                } else {
+                    self.write_event(
+                        "test",
+                        desc.name.as_slice(),
+                        "ignored",
+                        exec_time,
+                        stdout,
+                        None,
+                    )
+                }
+                #[cfg(bootstrap)]
                 self.write_event("test", desc.name.as_slice(), "ignored", exec_time, stdout, None)
             }
 

--- a/library/test/src/formatters/json.rs
+++ b/library/test/src/formatters/json.rs
@@ -122,25 +122,17 @@ impl<T: Write> OutputFormatter for JsonFormatter<T> {
 
             TestResult::TrIgnored => {
                 #[cfg(not(bootstrap))]
-                if let Some(msg) = desc.ignore_message {
-                    self.write_event(
-                        "test",
-                        desc.name.as_slice(),
-                        "ignored",
-                        exec_time,
-                        stdout,
-                        Some(&*format!(r#""message": "{}""#, EscapedString(msg))),
-                    )
-                } else {
-                    self.write_event(
-                        "test",
-                        desc.name.as_slice(),
-                        "ignored",
-                        exec_time,
-                        stdout,
-                        None,
-                    )
-                }
+                return self.write_event(
+                    "test",
+                    desc.name.as_slice(),
+                    "ignored",
+                    exec_time,
+                    stdout,
+                    desc.ignore_message
+                        .map(|msg| format!(r#""message": "{}""#, EscapedString(msg)))
+                        .as_deref(),
+                );
+
                 #[cfg(bootstrap)]
                 self.write_event("test", desc.name.as_slice(), "ignored", exec_time, stdout, None)
             }

--- a/library/test/src/formatters/pretty.rs
+++ b/library/test/src/formatters/pretty.rs
@@ -66,7 +66,7 @@ impl<T: Write> PrettyFormatter<T> {
         result: &str,
         color: term::color::Color,
     ) -> io::Result<()> {
-        self.write_pretty(result.as_ref(), color)
+        self.write_pretty(result, color)
     }
 
     pub fn write_pretty(&mut self, word: &str, color: term::color::Color) -> io::Result<()> {

--- a/library/test/src/formatters/pretty.rs
+++ b/library/test/src/formatters/pretty.rs
@@ -45,8 +45,8 @@ impl<T: Write> PrettyFormatter<T> {
         self.write_short_result("FAILED", term::color::RED)
     }
 
-    pub fn write_ignored(&mut self, may_message: Option<&'static str>) -> io::Result<()> {
-        if let Some(message) = may_message {
+    pub fn write_ignored(&mut self, message: Option<&'static str>) -> io::Result<()> {
+        if let Some(message) = message {
             self.write_short_result(&format!("ignored, {}", message), term::color::YELLOW)
         } else {
             self.write_short_result("ignored", term::color::YELLOW)
@@ -63,7 +63,7 @@ impl<T: Write> PrettyFormatter<T> {
 
     pub fn write_short_result(
         &mut self,
-        result: impl AsRef<str>,
+        result: &str,
         color: term::color::Color,
     ) -> io::Result<()> {
         self.write_pretty(result.as_ref(), color)

--- a/library/test/src/formatters/pretty.rs
+++ b/library/test/src/formatters/pretty.rs
@@ -45,8 +45,12 @@ impl<T: Write> PrettyFormatter<T> {
         self.write_short_result("FAILED", term::color::RED)
     }
 
-    pub fn write_ignored(&mut self) -> io::Result<()> {
-        self.write_short_result("ignored", term::color::YELLOW)
+    pub fn write_ignored(&mut self, may_message: Option<&'static str>) -> io::Result<()> {
+        if let Some(message) = may_message {
+            self.write_short_result(&format!("ignored, {}", message), term::color::YELLOW)
+        } else {
+            self.write_short_result("ignored", term::color::YELLOW)
+        }
     }
 
     pub fn write_time_failed(&mut self) -> io::Result<()> {
@@ -59,10 +63,10 @@ impl<T: Write> PrettyFormatter<T> {
 
     pub fn write_short_result(
         &mut self,
-        result: &str,
+        result: impl AsRef<str>,
         color: term::color::Color,
     ) -> io::Result<()> {
-        self.write_pretty(result, color)
+        self.write_pretty(result.as_ref(), color)
     }
 
     pub fn write_pretty(&mut self, word: &str, color: term::color::Color) -> io::Result<()> {
@@ -214,7 +218,12 @@ impl<T: Write> OutputFormatter for PrettyFormatter<T> {
         match *result {
             TestResult::TrOk => self.write_ok()?,
             TestResult::TrFailed | TestResult::TrFailedMsg(_) => self.write_failed()?,
-            TestResult::TrIgnored => self.write_ignored()?,
+            TestResult::TrIgnored => {
+                #[cfg(not(bootstrap))]
+                self.write_ignored(desc.ignore_message)?;
+                #[cfg(bootstrap)]
+                self.write_ignored(None)?;
+            }
             TestResult::TrBench(ref bs) => {
                 self.write_bench()?;
                 self.write_plain(&format!(": {}", fmt_bench_samples(bs)))?;

--- a/src/test/run-make-fulldeps/libtest-json/Makefile
+++ b/src/test/run-make-fulldeps/libtest-json/Makefile
@@ -5,7 +5,7 @@
 OUTPUT_FILE_DEFAULT := $(TMPDIR)/libtest-json-output-default.json
 OUTPUT_FILE_STDOUT_SUCCESS := $(TMPDIR)/libtest-json-output-stdout-success.json
 
-all:
+all: f.rs validate_json.py output-default.json output-stdout-success.json
 	$(RUSTC) --test f.rs
 	RUST_BACKTRACE=0 $(call RUN,f) -Z unstable-options --test-threads=1 --format=json > $(OUTPUT_FILE_DEFAULT) || true
 	RUST_BACKTRACE=0 $(call RUN,f) -Z unstable-options --test-threads=1 --format=json --show-output > $(OUTPUT_FILE_STDOUT_SUCCESS) || true

--- a/src/test/run-make-fulldeps/libtest-json/f.rs
+++ b/src/test/run-make-fulldeps/libtest-json/f.rs
@@ -16,7 +16,7 @@ fn c() {
 }
 
 #[test]
-#[ignore]
+#[ignore = "msg"]
 fn d() {
     assert!(false);
 }

--- a/src/test/run-make-fulldeps/libtest-json/output-default.json
+++ b/src/test/run-make-fulldeps/libtest-json/output-default.json
@@ -6,5 +6,5 @@
 { "type": "test", "event": "started", "name": "c" }
 { "type": "test", "name": "c", "event": "ok" }
 { "type": "test", "event": "started", "name": "d" }
-{ "type": "test", "name": "d", "event": "ignored" }
+{ "type": "test", "name": "d", "event": "ignored", "message": "msg" }
 { "type": "suite", "event": "failed", "passed": 2, "failed": 1, "ignored": 1, "measured": 0, "filtered_out": 0, "exec_time": $TIME }

--- a/src/test/run-make-fulldeps/libtest-json/output-stdout-success.json
+++ b/src/test/run-make-fulldeps/libtest-json/output-stdout-success.json
@@ -6,5 +6,5 @@
 { "type": "test", "event": "started", "name": "c" }
 { "type": "test", "name": "c", "event": "ok", "stdout": "thread 'main' panicked at 'assertion failed: false', f.rs:15:5\n" }
 { "type": "test", "event": "started", "name": "d" }
-{ "type": "test", "name": "d", "event": "ignored" }
+{ "type": "test", "name": "d", "event": "ignored", "message": "msg" }
 { "type": "suite", "event": "failed", "passed": 2, "failed": 1, "ignored": 1, "measured": 0, "filtered_out": 0, "exec_time": $TIME }

--- a/src/test/ui/suggestions/suggest-mut-method-for-loop-hashmap.fixed
+++ b/src/test/ui/suggestions/suggest-mut-method-for-loop-hashmap.fixed
@@ -1,0 +1,21 @@
+// run-rustfix
+// https://github.com/rust-lang/rust/issues/82081
+
+use std::collections::HashMap;
+
+struct Test {
+    v: u32,
+}
+
+fn main() {
+    let mut map = HashMap::new();
+    map.insert("a", Test { v: 0 });
+
+    for (_k, mut v) in map.iter_mut() {
+        //~^ HELP use mutable method
+        //~| NOTE this iterator yields `&` references
+        v.v += 1;
+        //~^ ERROR cannot assign to `v.v`
+        //~| NOTE `v` is a `&` reference
+    }
+}

--- a/src/test/ui/suggestions/suggest-mut-method-for-loop-hashmap.rs
+++ b/src/test/ui/suggestions/suggest-mut-method-for-loop-hashmap.rs
@@ -1,0 +1,21 @@
+// run-rustfix
+// https://github.com/rust-lang/rust/issues/82081
+
+use std::collections::HashMap;
+
+struct Test {
+    v: u32,
+}
+
+fn main() {
+    let mut map = HashMap::new();
+    map.insert("a", Test { v: 0 });
+
+    for (_k, mut v) in map.iter() {
+        //~^ HELP use mutable method
+        //~| NOTE this iterator yields `&` references
+        v.v += 1;
+        //~^ ERROR cannot assign to `v.v`
+        //~| NOTE `v` is a `&` reference
+    }
+}

--- a/src/test/ui/suggestions/suggest-mut-method-for-loop-hashmap.stderr
+++ b/src/test/ui/suggestions/suggest-mut-method-for-loop-hashmap.stderr
@@ -1,0 +1,15 @@
+error[E0594]: cannot assign to `v.v`, which is behind a `&` reference
+  --> $DIR/suggest-mut-method-for-loop-hashmap.rs:17:9
+   |
+LL |     for (_k, mut v) in map.iter() {
+   |                        ----------
+   |                        |   |
+   |                        |   help: use mutable method: `iter_mut()`
+   |                        this iterator yields `&` references
+...
+LL |         v.v += 1;
+   |         ^^^^^^^^ `v` is a `&` reference, so the data it refers to cannot be written
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0594`.

--- a/src/test/ui/test-attrs/test-type.rs
+++ b/src/test/ui/test-attrs/test-type.rs
@@ -5,7 +5,6 @@
 // ignore-emscripten no threads support
 // run-pass
 
-
 #[test]
 fn test_ok() {
     let _a = true;
@@ -18,9 +17,9 @@ fn test_panic() {
 }
 
 #[test]
-#[ignore]
+#[ignore = "msg"]
 fn test_no_run() {
-    loop{
+    loop {
         println!("Hello, world");
     }
 }

--- a/src/test/ui/test-attrs/test-type.run.stdout
+++ b/src/test/ui/test-attrs/test-type.run.stdout
@@ -1,6 +1,6 @@
 
 running 3 tests
-test test_no_run ... ignored
+test test_no_run ... ignored, msg
 test test_ok ... ok
 test test_panic - should panic ... ok
 


### PR DESCRIPTION
Successful merges:

 - #94566 (Show ignore message in console and json output)
 - #95415 (diagnostics: regression test for HashMap iter_mut suggestion)
 - #95422 (Refactor: Use `format-args-capture` and remove an unnecessary nested block)
 - #95424 (:arrow_up: rust-analyzer)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=94566,95415,95422,95424)
<!-- homu-ignore:end -->