### PR TITLE
Add SyncUnsafeCell.

### DIFF
--- a/library/core/src/cell.rs
+++ b/library/core/src/cell.rs
@@ -2002,16 +2002,16 @@ impl<T: CoerceUnsized<U>, U> CoerceUnsized<UnsafeCell<U>> for UnsafeCell<T> {}
 /// making this type just as unsafe to use.
 ///
 /// See [`UnsafeCell`] for details.
-#[unstable(feature = "sync_unsafe_cell", issue = "none")]
+#[unstable(feature = "sync_unsafe_cell", issue = "95439")]
 #[repr(transparent)]
 pub struct SyncUnsafeCell<T: ?Sized> {
     value: UnsafeCell<T>,
 }
 
-#[unstable(feature = "sync_unsafe_cell", issue = "none")]
+#[unstable(feature = "sync_unsafe_cell", issue = "95439")]
 unsafe impl<T: ?Sized + Sync> Sync for SyncUnsafeCell<T> {}
 
-#[unstable(feature = "sync_unsafe_cell", issue = "none")]
+#[unstable(feature = "sync_unsafe_cell", issue = "95439")]
 impl<T> SyncUnsafeCell<T> {
     /// Constructs a new instance of `SyncUnsafeCell` which will wrap the specified value.
     #[inline]
@@ -2026,7 +2026,7 @@ impl<T> SyncUnsafeCell<T> {
     }
 }
 
-#[unstable(feature = "sync_unsafe_cell", issue = "none")]
+#[unstable(feature = "sync_unsafe_cell", issue = "95439")]
 impl<T: ?Sized> SyncUnsafeCell<T> {
     /// Gets a mutable pointer to the wrapped value.
     ///
@@ -2060,7 +2060,7 @@ impl<T: ?Sized> SyncUnsafeCell<T> {
     }
 }
 
-#[unstable(feature = "sync_unsafe_cell", issue = "none")]
+#[unstable(feature = "sync_unsafe_cell", issue = "95439")]
 impl<T: Default> Default for SyncUnsafeCell<T> {
     /// Creates an `SyncUnsafeCell`, with the `Default` value for T.
     fn default() -> SyncUnsafeCell<T> {
@@ -2068,7 +2068,7 @@ impl<T: Default> Default for SyncUnsafeCell<T> {
     }
 }
 
-#[unstable(feature = "sync_unsafe_cell", issue = "none")]
+#[unstable(feature = "sync_unsafe_cell", issue = "95439")]
 #[rustc_const_unstable(feature = "const_convert", issue = "88674")]
 impl<T> const From<T> for SyncUnsafeCell<T> {
     /// Creates a new `SyncUnsafeCell<T>` containing the given value.
@@ -2078,7 +2078,7 @@ impl<T> const From<T> for SyncUnsafeCell<T> {
 }
 
 #[unstable(feature = "coerce_unsized", issue = "27732")]
-//#[unstable(feature = "sync_unsafe_cell", issue = "none")]
+//#[unstable(feature = "sync_unsafe_cell", issue = "95439")]
 impl<T: CoerceUnsized<U>, U> CoerceUnsized<SyncUnsafeCell<U>> for SyncUnsafeCell<T> {}
 
 #[allow(unused)]

--- a/library/core/src/fmt/mod.rs
+++ b/library/core/src/fmt/mod.rs
@@ -2396,7 +2396,7 @@ impl<T: ?Sized> Debug for UnsafeCell<T> {
     }
 }
 
-#[unstable(feature = "sync_unsafe_cell", issue = "none")]
+#[unstable(feature = "sync_unsafe_cell", issue = "95439")]
 impl<T: ?Sized> Debug for SyncUnsafeCell<T> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         f.debug_struct("SyncUnsafeCell").finish_non_exhaustive()

--- a/library/core/src/fmt/mod.rs
+++ b/library/core/src/fmt/mod.rs
@@ -2,7 +2,7 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
-use crate::cell::{Cell, Ref, RefCell, RefMut, UnsafeCell};
+use crate::cell::{Cell, Ref, RefCell, RefMut, SyncUnsafeCell, UnsafeCell};
 use crate::char::EscapeDebugExtArgs;
 use crate::marker::PhantomData;
 use crate::mem;
@@ -2393,6 +2393,13 @@ impl<T: ?Sized + Debug> Debug for RefMut<'_, T> {
 impl<T: ?Sized> Debug for UnsafeCell<T> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         f.debug_struct("UnsafeCell").finish_non_exhaustive()
+    }
+}
+
+#[unstable(feature = "sync_unsafe_cell", issue = "none")]
+impl<T: ?Sized> Debug for SyncUnsafeCell<T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        f.debug_struct("SyncUnsafeCell").finish_non_exhaustive()
     }
 }
 

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -139,6 +139,7 @@
 #![feature(const_type_id)]
 #![feature(const_type_name)]
 #![feature(const_default_impls)]
+#![feature(const_unsafecell_get_mut)]
 #![feature(core_panic)]
 #![feature(duration_consts_float)]
 #![feature(maybe_uninit_uninit_array)]


### PR DESCRIPTION
This adds `SyncUnsafeCell`, which is just `UnsafeCell` except it implements `Sync`.

This was first proposed under the name `RacyUnsafeCell` here: https://github.com/rust-lang/rust/issues/53639#issuecomment-415515748 and here: https://github.com/rust-lang/rust/issues/53639#issuecomment-432741659 and here: https://github.com/rust-lang/rust/issues/53639#issuecomment-888435728

It allows you to create an UnsafeCell that is Sync without having to wrap it in a struct first (and then implement Sync for that struct).

E.g. `static X: SyncUnsafeCell<i32>`. Using a regular `UnsafeCell` as `static` is not possible, because it isn't `Sync`. We have a language workaround for it called `static mut`, but it's nice to be able to use the proper type for such unsafety instead.

It also makes implementing synchronization primitives based on unsafe cells slightly less verbose, because by using `SyncUnsafeCell` for `UnsafeCell`s that are shared between threads, you don't need a separate `impl<..> Sync for ..`. Using this type also clearly documents that the cell is expected to be accessed from multiple threads.