### PR TITLE
Fix `x test src/tools/error_index_generator --stage {0,1}`

### DIFF
--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -835,6 +835,18 @@ impl<'a> Builder<'a> {
         }
     }
 
+    pub fn rustc_lib_paths(&self, compiler: Compiler) -> Vec<PathBuf> {
+        let mut dylib_dirs = vec![self.rustc_libdir(compiler)];
+
+        // Ensure that the downloaded LLVM libraries can be found.
+        if self.config.llvm_from_ci {
+            let ci_llvm_lib = self.out.join(&*compiler.host.triple).join("ci-llvm").join("lib");
+            dylib_dirs.push(ci_llvm_lib);
+        }
+
+        dylib_dirs
+    }
+
     /// Adds the compiler's directory of dynamic libraries to `cmd`'s dynamic
     /// library lookup path.
     pub fn add_rustc_lib_path(&self, compiler: Compiler, cmd: &mut Command) {
@@ -845,15 +857,7 @@ impl<'a> Builder<'a> {
             return;
         }
 
-        let mut dylib_dirs = vec![self.rustc_libdir(compiler)];
-
-        // Ensure that the downloaded LLVM libraries can be found.
-        if self.config.llvm_from_ci {
-            let ci_llvm_lib = self.out.join(&*compiler.host.triple).join("ci-llvm").join("lib");
-            dylib_dirs.push(ci_llvm_lib);
-        }
-
-        add_dylib_path(dylib_dirs, cmd);
+        add_dylib_path(self.rustc_lib_paths(compiler), cmd);
     }
 
     /// Gets a path to the compiler specified.

--- a/src/bootstrap/tool.rs
+++ b/src/bootstrap/tool.rs
@@ -379,22 +379,14 @@ pub struct ErrorIndex {
 
 impl ErrorIndex {
     pub fn command(builder: &Builder<'_>) -> Command {
-        // This uses stage-1 to match the behavior of building rustdoc.
-        // Error-index-generator links with the rustdoc library, so we want to
-        // use the same librustdoc to avoid building rustdoc twice (and to
-        // avoid building the compiler an extra time). This uses
-        // saturating_sub to deal with building with stage 0. (Using stage 0
-        // isn't recommended, since it will fail if any new error index tests
-        // use new syntax, but it should work otherwise.)
-        let compiler = builder.compiler(builder.top_stage.saturating_sub(1), builder.config.build);
+        // Error-index-generator links with the rustdoc library, so we need to add `rustc_lib_paths`
+        // for rustc_private and libLLVM.so, and `sysroot_lib` for libstd, etc.
+        let host = builder.config.build;
+        let compiler = builder.compiler_for(builder.top_stage, host, host);
         let mut cmd = Command::new(builder.ensure(ErrorIndex { compiler }));
-        add_dylib_path(
-            vec![
-                PathBuf::from(&builder.sysroot_libdir(compiler, compiler.host)),
-                builder.rustc_libdir(compiler),
-            ],
-            &mut cmd,
-        );
+        let mut dylib_paths = builder.rustc_lib_paths(compiler);
+        dylib_paths.push(PathBuf::from(&builder.sysroot_libdir(compiler, compiler.host)));
+        add_dylib_path(dylib_paths, &mut cmd);
         cmd
     }
 }

--- a/src/bootstrap/util.rs
+++ b/src/bootstrap/util.rs
@@ -63,7 +63,7 @@ pub fn libdir(target: TargetSelection) -> &'static str {
 }
 
 /// Adds a list of lookup paths to `cmd`'s dynamic library lookup path.
-/// If The dylib_path_par is already set for this cmd, the old value will be overwritten!
+/// If the dylib_path_var is already set for this cmd, the old value will be overwritten!
 pub fn add_dylib_path(path: Vec<PathBuf>, cmd: &mut Command) {
     let mut list = dylib_path();
     for path in path {

--- a/src/tools/error_index_generator/build.rs
+++ b/src/tools/error_index_generator/build.rs
@@ -7,7 +7,6 @@ fn main() {
     // Note that we could skip one of the .. but this ensures we at least loosely find the right
     // directory.
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
-    let dest = out_dir.join("error_codes.rs");
 
     let error_codes_path = "../../../compiler/rustc_error_codes/src/error_codes.rs";
 
@@ -29,35 +28,4 @@ fn main() {
         let md_content = fs::read_to_string(entry.path()).unwrap();
         fs::write(&out_dir.join(entry.file_name()), &md_content).unwrap();
     }
-
-    let mut all = String::new();
-    all.push_str(
-        r###"
-fn register_all() -> Vec<(&'static str, Option<&'static str>)> {
-    let mut long_codes: Vec<(&'static str, Option<&'static str>)> = Vec::new();
-    macro_rules! register_diagnostics {
-        ($($ecode:ident: $message:expr,)*) => (
-            register_diagnostics!{$($ecode:$message,)* ;}
-        );
-
-        ($($ecode:ident: $message:expr,)* ; $($code:ident,)*) => (
-            $(
-                {long_codes.extend([
-                    (stringify!($ecode), Some($message)),
-                ].iter());}
-            )*
-            $(
-                {long_codes.extend([
-                    stringify!($code),
-                ].iter().cloned().map(|s| (s, None)).collect::<Vec<_>>());}
-            )*
-        )
-    }
-"###,
-    );
-    all.push_str(r#"include!(concat!(env!("OUT_DIR"), "/all_error_codes.rs"));"#);
-    all.push_str("\nlong_codes\n");
-    all.push_str("}\n");
-
-    fs::write(&dest, all).unwrap();
 }

--- a/src/tools/error_index_generator/main.rs
+++ b/src/tools/error_index_generator/main.rs
@@ -277,4 +277,26 @@ fn main() {
     }
 }
 
-include!(concat!(env!("OUT_DIR"), "/error_codes.rs"));
+fn register_all() -> Vec<(&'static str, Option<&'static str>)> {
+    let mut long_codes: Vec<(&'static str, Option<&'static str>)> = Vec::new();
+    macro_rules! register_diagnostics {
+        ($($ecode:ident: $message:expr,)*) => (
+            register_diagnostics!{$($ecode:$message,)* ;}
+        );
+
+        ($($ecode:ident: $message:expr,)* ; $($code:ident,)*) => (
+            $(
+                {long_codes.extend([
+                    (stringify!($ecode), Some($message)),
+                ].iter());}
+            )*
+            $(
+                {long_codes.extend([
+                    stringify!($code),
+                ].iter().cloned().map(|s| (s, None)).collect::<Vec<_>>());}
+            )*
+        )
+    }
+    include!(concat!(env!("OUT_DIR"), "/all_error_codes.rs"));
+    long_codes
+}


### PR DESCRIPTION
There were two fixes needed:
1. Use `top_stage` instead of `top_stage - 1`. There was a long and torturous comment about trying to match rustdoc's version, but it works better without the hard-coding than with (before it gave errors that `libtest.so` couldn't be found).
2. Make sure that `ci-llvm/lib` is added to LD_LIBRARY_PATH. Previously the error index would be unable to load LLVM for stage0 builds.

At some point we should probably have a discussion about how rustdoc stages should be numbered;
confusion between 0/1/2 has come up several times in bootstrap now. cc https://github.com/rust-lang/rust/issues/92538

Note that this is still broken when using `download-rustc = true` and `--stage 1`,
but that's *really* a corner case and should affect almost no one. `--stage {0,2}`
work fine with download-rustc.

Fixes https://github.com/rust-lang/rust/issues/80096.