### PR TITLE
Always use system `python3` on MacOS

### DIFF
--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -1167,7 +1167,17 @@ impl Build {
 
     /// Path to the python interpreter to use
     fn python(&self) -> &Path {
-        self.config.python.as_ref().unwrap()
+        if self.config.build.ends_with("apple-darwin") {
+            // Force /usr/bin/python3 on macOS for LLDB tests because we're loading the
+            // LLDB plugin's compiled module which only works with the system python
+            // (namely not Homebrew-installed python)
+            Path::new("/usr/bin/python3")
+        } else {
+            self.config
+                .python
+                .as_ref()
+                .expect("python is required for running LLDB or rustdoc tests")
+        }
     }
 
     /// Temporary directory that extended error information is emitted to.

--- a/src/bootstrap/sanity.rs
+++ b/src/bootstrap/sanity.rs
@@ -103,7 +103,9 @@ pub fn check(build: &mut Build) {
         .take()
         .map(|p| cmd_finder.must_have(p))
         .or_else(|| env::var_os("BOOTSTRAP_PYTHON").map(PathBuf::from)) // set by bootstrap.py
-        .or_else(|| Some(cmd_finder.must_have("python")));
+        .or_else(|| cmd_finder.maybe_have("python"))
+        .or_else(|| cmd_finder.maybe_have("python3"))
+        .or_else(|| cmd_finder.maybe_have("python2"));
 
     build.config.nodejs = build
         .config

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -1403,14 +1403,7 @@ note: if you're sure you want to do this, please open an issue as to why. In the
 
         cmd.arg("--docck-python").arg(builder.python());
 
-        if builder.config.build.ends_with("apple-darwin") {
-            // Force /usr/bin/python3 on macOS for LLDB tests because we're loading the
-            // LLDB plugin's compiled module which only works with the system python
-            // (namely not Homebrew-installed python)
-            cmd.arg("--lldb-python").arg("/usr/bin/python3");
-        } else {
-            cmd.arg("--lldb-python").arg(builder.python());
-        }
+        cmd.arg("--lldb-python").arg(builder.python());
 
         if let Some(ref gdb) = builder.config.gdb {
             cmd.arg("--gdb").arg(gdb);


### PR DESCRIPTION
This PR includes 2 changes:

1. Always use the system Python found at `/usr/bin/python3` on MacOS
2. Removes the hard requirement on having `python` in your system path if you didn't specify alternatives. The proposed change will instead attempt to find and use in order: `python` -> `python3` -> `python2`. This change isn't strictly necessary but without any change to this check, the original issue inspiring this change will still exist.

Fixes #95204 
r? @jyn514