### PR TITLE
Don't build the full compiler before running unit tests

### DIFF
--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -1998,7 +1998,6 @@ impl Step for Crate {
                 compile::std_cargo(builder, target, compiler.stage, &mut cargo);
             }
             Mode::Rustc => {
-                builder.ensure(compile::Rustc { compiler, target });
                 compile::rustc_cargo(builder, &mut cargo, target);
             }
             _ => panic!("can only test libraries"),


### PR DESCRIPTION
This has been present since `builder.ensure` was first added in https://github.com/rust-lang/rust/pull/43059.
It's unclear to me why it was added then - I tested these changes locally
with `x test compiler/rustc_data_structures --stage 0` and they worked fine.

Fixes https://github.com/rust-lang/rust/issues/51748.