### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/compiler/rustc_typeck/src/check/demand.rs
+++ b/compiler/rustc_typeck/src/check/demand.rs
@@ -268,10 +268,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         expr_ty: Ty<'tcx>,
     ) {
         if let ty::Adt(expected_adt, substs) = expected.kind() {
-            if !expected_adt.is_enum() {
-                return;
-            }
-
             // If the expression is of type () and it's the return expression of a block,
             // we suggest adding a separate return expression instead.
             // (To avoid things like suggesting `Ok(while .. { .. })`.)

--- a/compiler/rustc_typeck/src/check/demand.rs
+++ b/compiler/rustc_typeck/src/check/demand.rs
@@ -336,7 +336,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             let compatible_variants: Vec<String> = expected_adt
                 .variants()
                 .iter()
-                .filter(|variant| variant.fields.len() == 1)
+                .filter(|variant| {
+                    variant.fields.len() == 1 && variant.ctor_kind == hir::def::CtorKind::Fn
+                })
                 .filter_map(|variant| {
                     let sole_field = &variant.fields[0];
                     let sole_field_ty = sole_field.ty(self.tcx, substs);

--- a/library/std/src/io/error/repr_bitpacked.rs
+++ b/library/std/src/io/error/repr_bitpacked.rs
@@ -120,7 +120,7 @@ const TAG_SIMPLE: usize = 0b11;
 /// See the module docs for more, this is just a way to hack in a check that we
 /// indeed are not unwind-safe.
 ///
-/// ```compile_fail
+/// ```compile_fail,E0277
 /// fn is_unwind_safe<T: core::panic::UnwindSafe>() {}
 /// is_unwind_safe::<std::io::Error>();
 /// ```

--- a/library/std/src/io/error/repr_bitpacked.rs
+++ b/library/std/src/io/error/repr_bitpacked.rs
@@ -115,6 +115,15 @@ const TAG_CUSTOM: usize = 0b01;
 const TAG_OS: usize = 0b10;
 const TAG_SIMPLE: usize = 0b11;
 
+/// The internal representation.
+///
+/// See the module docs for more, this is just a way to hack in a check that we
+/// indeed are not unwind-safe.
+///
+/// ```compile_fail
+/// fn is_unwind_safe<T: core::panic::UnwindSafe>() {}
+/// is_unwind_safe::<std::io::Error>();
+/// ```
 #[repr(transparent)]
 pub(super) struct Repr(NonNull<()>, PhantomData<ErrorData<Box<Custom>>>);
 

--- a/library/std/src/process.rs
+++ b/library/std/src/process.rs
@@ -1648,8 +1648,8 @@ impl crate::error::Error for ExitStatusError {}
 /// This type represents the status code the current process can return
 /// to its parent under normal termination.
 ///
-/// ExitCode is intended to be consumed only by the standard library (via
-/// `Termination::report()`), and intentionally does not provide accessors like
+/// `ExitCode` is intended to be consumed only by the standard library (via
+/// [`Termination::report()`]), and intentionally does not provide accessors like
 /// `PartialEq`, `Eq`, or `Hash`. Instead the standard library provides the
 /// canonical `SUCCESS` and `FAILURE` exit codes as well as `From<u8> for
 /// ExitCode` for constructing other arbitrary exit codes.
@@ -1673,13 +1673,31 @@ impl crate::error::Error for ExitStatusError {}
 /// compatibility differences and their expected usage; it is not generally
 /// possible to exactly reproduce an ExitStatus from a child for the current
 /// process after the fact.
+///
+/// # Examples
+///
+/// `ExitCode` can be returned from the `main` function of a crate, as it implements
+/// [`Termination`]:
+///
+/// ```
+/// use std::process::ExitCode;
+/// # fn check_foo() -> bool { true }
+///
+/// fn main() -> ExitCode {
+///     if !check_foo() {
+///         return ExitCode::from(42);
+///     }
+///
+///     ExitCode::SUCCESS
+/// }
+/// ```
 #[derive(Clone, Copy, Debug)]
 #[stable(feature = "process_exitcode", since = "1.60.0")]
 pub struct ExitCode(imp::ExitCode);
 
 #[stable(feature = "process_exitcode", since = "1.60.0")]
 impl ExitCode {
-    /// The canonical ExitCode for successful termination on this platform.
+    /// The canonical `ExitCode` for successful termination on this platform.
     ///
     /// Note that a `()`-returning `main` implicitly results in a successful
     /// termination, so there's no need to return this from `main` unless
@@ -1687,7 +1705,7 @@ impl ExitCode {
     #[stable(feature = "process_exitcode", since = "1.60.0")]
     pub const SUCCESS: ExitCode = ExitCode(imp::ExitCode::SUCCESS);
 
-    /// The canonical ExitCode for unsuccessful termination on this platform.
+    /// The canonical `ExitCode` for unsuccessful termination on this platform.
     ///
     /// If you're only returning this and `SUCCESS` from `main`, consider
     /// instead returning `Err(_)` and `Ok(())` respectively, which will
@@ -1697,19 +1715,20 @@ impl ExitCode {
 }
 
 impl ExitCode {
-    // This should not be stabilized when stabilizing ExitCode, we don't know that i32 will serve
+    // This is private/perma-unstable because ExitCode is opaque; we don't know that i32 will serve
     // all usecases, for example windows seems to use u32, unix uses the 8-15th bits of an i32, we
     // likely want to isolate users anything that could restrict the platform specific
     // representation of an ExitCode
     //
     // More info: https://internals.rust-lang.org/t/mini-pre-rfc-redesigning-process-exitstatus/5426
-    /// Convert an ExitCode into an i32
+    /// Convert an `ExitCode` into an i32
     #[unstable(
         feature = "process_exitcode_internals",
         reason = "exposed only for libstd",
         issue = "none"
     )]
     #[inline]
+    #[doc(hidden)]
     pub fn to_i32(self) -> i32 {
         self.0.as_i32()
     }
@@ -1717,7 +1736,7 @@ impl ExitCode {
 
 #[stable(feature = "process_exitcode", since = "1.60.0")]
 impl From<u8> for ExitCode {
-    /// Construct an exit code from an arbitrary u8 value.
+    /// Construct an `ExitCode` from an arbitrary u8 value.
     fn from(code: u8) -> Self {
         ExitCode(imp::ExitCode::from(code))
     }

--- a/library/test/src/lib.rs
+++ b/library/test/src/lib.rs
@@ -19,8 +19,7 @@
 #![feature(bench_black_box)]
 #![feature(internal_output_capture)]
 #![feature(staged_api)]
-#![feature(termination_trait_lib)]
-#![feature(process_exitcode_placeholder)]
+#![feature(process_exitcode_internals)]
 #![feature(test)]
 #![feature(total_cmp)]
 

--- a/src/test/ui/did_you_mean/compatible-variants-in-pat.rs
+++ b/src/test/ui/did_you_mean/compatible-variants-in-pat.rs
@@ -1,0 +1,41 @@
+enum Foo {
+    Bar(Bar),
+}
+struct Bar {
+    x: i32,
+}
+
+fn a(f: Foo) {
+    match f {
+        Bar { x } => {
+            //~^ ERROR mismatched types
+            //~| HELP try wrapping
+        }
+    }
+}
+
+struct S;
+
+fn b(s: Option<S>) {
+    match s {
+        S => {
+            //~^ ERROR mismatched types
+            //~| HELP try wrapping
+            //~| HELP introduce a new binding instead
+        }
+        _ => {}
+    }
+}
+
+fn c(s: Result<S, S>) {
+    match s {
+        S => {
+            //~^ ERROR mismatched types
+            //~| HELP try wrapping
+            //~| HELP introduce a new binding instead
+        }
+        _ => {}
+    }
+}
+
+fn main() {}

--- a/src/test/ui/did_you_mean/compatible-variants-in-pat.stderr
+++ b/src/test/ui/did_you_mean/compatible-variants-in-pat.stderr
@@ -1,0 +1,68 @@
+error[E0308]: mismatched types
+  --> $DIR/compatible-variants-in-pat.rs:10:9
+   |
+LL |     match f {
+   |           - this expression has type `Foo`
+LL |         Bar { x } => {
+   |         ^^^^^^^^^ expected enum `Foo`, found struct `Bar`
+   |
+help: try wrapping the pattern in `Foo::Bar`
+   |
+LL |         Foo::Bar(Bar { x }) => {
+   |         +++++++++         +
+
+error[E0308]: mismatched types
+  --> $DIR/compatible-variants-in-pat.rs:21:9
+   |
+LL | struct S;
+   | --------- unit struct defined here
+...
+LL |     match s {
+   |           - this expression has type `Option<S>`
+LL |         S => {
+   |         ^
+   |         |
+   |         expected enum `Option`, found struct `S`
+   |         `S` is interpreted as a unit struct, not a new binding
+   |
+   = note: expected enum `Option<S>`
+            found struct `S`
+help: try wrapping the pattern in `Some`
+   |
+LL |         Some(S) => {
+   |         +++++ +
+help: introduce a new binding instead
+   |
+LL |         other_s => {
+   |         ~~~~~~~
+
+error[E0308]: mismatched types
+  --> $DIR/compatible-variants-in-pat.rs:32:9
+   |
+LL | struct S;
+   | --------- unit struct defined here
+...
+LL |     match s {
+   |           - this expression has type `Result<S, S>`
+LL |         S => {
+   |         ^
+   |         |
+   |         expected enum `Result`, found struct `S`
+   |         `S` is interpreted as a unit struct, not a new binding
+   |
+   = note: expected enum `Result<S, S>`
+            found struct `S`
+help: try wrapping the pattern in a variant of `Result`
+   |
+LL |         Ok(S) => {
+   |         +++ +
+LL |         Err(S) => {
+   |         ++++ +
+help: introduce a new binding instead
+   |
+LL |         other_s => {
+   |         ~~~~~~~
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/did_you_mean/compatible-variants.rs
+++ b/src/test/ui/did_you_mean/compatible-variants.rs
@@ -64,3 +64,18 @@ fn main() {
     //~^ ERROR mismatched types
     //~| HELP try wrapping
 }
+
+enum A {
+    B { b: B},
+}
+
+enum B {
+    Fst,
+    Snd,
+}
+
+fn foo() {
+    // We don't want to suggest `A::B(B::Fst)` here.
+    let a: A = B::Fst;
+    //~^ ERROR mismatched types
+}

--- a/src/test/ui/did_you_mean/compatible-variants.rs
+++ b/src/test/ui/did_you_mean/compatible-variants.rs
@@ -69,6 +69,8 @@ enum A {
     B { b: B},
 }
 
+struct A2(B);
+
 enum B {
     Fst,
     Snd,
@@ -78,4 +80,11 @@ fn foo() {
     // We don't want to suggest `A::B(B::Fst)` here.
     let a: A = B::Fst;
     //~^ ERROR mismatched types
+}
+
+fn bar() {
+    // But we _do_ want to suggest `A2(B::Fst)` here!
+    let a: A2 = B::Fst;
+    //~^ ERROR mismatched types
+    //~| HELP try wrapping
 }

--- a/src/test/ui/did_you_mean/compatible-variants.stderr
+++ b/src/test/ui/did_you_mean/compatible-variants.stderr
@@ -191,13 +191,26 @@ LL |     let _ = Foo { bar: Some(bar) };
    |                   ++++++++++   +
 
 error[E0308]: mismatched types
-  --> $DIR/compatible-variants.rs:79:16
+  --> $DIR/compatible-variants.rs:81:16
    |
 LL |     let a: A = B::Fst;
    |            -   ^^^^^^ expected enum `A`, found enum `B`
    |            |
    |            expected due to this
 
-error: aborting due to 12 previous errors
+error[E0308]: mismatched types
+  --> $DIR/compatible-variants.rs:87:17
+   |
+LL |     let a: A2 = B::Fst;
+   |            --   ^^^^^^ expected struct `A2`, found enum `B`
+   |            |
+   |            expected due to this
+   |
+help: try wrapping the expression in `A2`
+   |
+LL |     let a: A2 = A2(B::Fst);
+   |                 +++      +
+
+error: aborting due to 13 previous errors
 
 For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/did_you_mean/compatible-variants.stderr
+++ b/src/test/ui/did_you_mean/compatible-variants.stderr
@@ -190,6 +190,14 @@ help: try wrapping the expression in `Some`
 LL |     let _ = Foo { bar: Some(bar) };
    |                   ++++++++++   +
 
-error: aborting due to 11 previous errors
+error[E0308]: mismatched types
+  --> $DIR/compatible-variants.rs:79:16
+   |
+LL |     let a: A = B::Fst;
+   |            -   ^^^^^^ expected enum `A`, found enum `B`
+   |            |
+   |            expected due to this
+
+error: aborting due to 12 previous errors
 
 For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/issues/issue-12552.stderr
+++ b/src/test/ui/issues/issue-12552.stderr
@@ -8,6 +8,10 @@ LL |     Some(k) => match k {
    |
    = note: expected enum `Result<_, {integer}>`
               found enum `Option<_>`
+help: try wrapping the pattern in `Ok`
+   |
+LL |     Ok(Some(k)) => match k {
+   |     +++       +
 
 error[E0308]: mismatched types
   --> $DIR/issue-12552.rs:9:5
@@ -20,6 +24,10 @@ LL |     None => ()
    |
    = note: expected enum `Result<_, {integer}>`
               found enum `Option<_>`
+help: try wrapping the pattern in `Ok`
+   |
+LL |     Ok(None) => ()
+   |     +++    +
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-3680.stderr
+++ b/src/test/ui/issues/issue-3680.stderr
@@ -8,6 +8,10 @@ LL |         Err(_) => ()
    |
    = note: expected enum `Option<_>`
               found enum `Result<_, _>`
+help: try wrapping the pattern in `Some`
+   |
+LL |         Some(Err(_)) => ()
+   |         +++++      +
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-5358-1.stderr
+++ b/src/test/ui/issues/issue-5358-1.stderr
@@ -8,6 +8,10 @@ LL |         Either::Right(_) => {}
    |
    = note: expected struct `S`
                 found enum `Either<_, _>`
+help: try wrapping the pattern in `S`
+   |
+LL |         S(Either::Right(_)) => {}
+   |         ++                +
 help: you might have meant to use field `0` whose type is `Either<usize, usize>`
    |
 LL |     match S(Either::Left(5)).0 {

--- a/src/test/ui/rfcs/rfc-1937-termination-trait/termination-trait-for-exitcode.rs
+++ b/src/test/ui/rfcs/rfc-1937-termination-trait/termination-trait-for-exitcode.rs
@@ -1,5 +1,4 @@
 // run-pass
-#![feature(process_exitcode_placeholder)]
 
 use std::process::ExitCode;
 

--- a/src/test/ui/rfcs/rfc-1937-termination-trait/termination-trait-for-impl-termination.rs
+++ b/src/test/ui/rfcs/rfc-1937-termination-trait/termination-trait-for-impl-termination.rs
@@ -1,4 +1,3 @@
 // run-pass
-#![feature(termination_trait_lib)]
 
 fn main() -> impl std::process::Termination { }

--- a/src/test/ui/suggestions/derive-clone-for-eq.fixed
+++ b/src/test/ui/suggestions/derive-clone-for-eq.fixed
@@ -1,0 +1,18 @@
+// run-rustfix
+// https://github.com/rust-lang/rust/issues/79076
+
+use std::cmp::PartialEq;
+
+#[derive(Clone, Eq)] //~ ERROR [E0277]
+pub struct Struct<T: std::clone::Clone>(T);
+
+impl<T: Clone, U> PartialEq<U> for Struct<T>
+where
+    U: Into<Struct<T>> + Clone
+{
+    fn eq(&self, _other: &U) -> bool {
+        todo!()
+    }
+}
+
+fn main() {}

--- a/src/test/ui/suggestions/derive-clone-for-eq.rs
+++ b/src/test/ui/suggestions/derive-clone-for-eq.rs
@@ -1,0 +1,18 @@
+// run-rustfix
+// https://github.com/rust-lang/rust/issues/79076
+
+use std::cmp::PartialEq;
+
+#[derive(Clone, Eq)] //~ ERROR [E0277]
+pub struct Struct<T>(T);
+
+impl<T: Clone, U> PartialEq<U> for Struct<T>
+where
+    U: Into<Struct<T>> + Clone
+{
+    fn eq(&self, _other: &U) -> bool {
+        todo!()
+    }
+}
+
+fn main() {}

--- a/src/test/ui/suggestions/derive-clone-for-eq.stderr
+++ b/src/test/ui/suggestions/derive-clone-for-eq.stderr
@@ -1,0 +1,25 @@
+error[E0277]: the trait bound `T: Clone` is not satisfied
+  --> $DIR/derive-clone-for-eq.rs:6:17
+   |
+LL | #[derive(Clone, Eq)]
+   |                 ^^ the trait `Clone` is not implemented for `T`
+   |
+note: required because of the requirements on the impl of `PartialEq` for `Struct<T>`
+  --> $DIR/derive-clone-for-eq.rs:9:19
+   |
+LL | impl<T: Clone, U> PartialEq<U> for Struct<T>
+   |                   ^^^^^^^^^^^^     ^^^^^^^^^
+note: required by a bound in `Eq`
+  --> $SRC_DIR/core/src/cmp.rs:LL:COL
+   |
+LL | pub trait Eq: PartialEq<Self> {
+   |               ^^^^^^^^^^^^^^^ required by this bound in `Eq`
+   = note: this error originates in the derive macro `Eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider restricting type parameter `T`
+   |
+LL | pub struct Struct<T: std::clone::Clone>(T);
+   |                    +++++++++++++++++++
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
Successful merges:

 - #93840 (Stabilize Termination and ExitCode)
 - #95256 (Ensure io::Error's bitpacked repr doesn't accidentally impl UnwindSafe)
 - #95386 (Suggest wrapping patterns in enum variants)
 - #95437 (diagnostics: regression test for derive bounds)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=93840,95256,95386,95437)
<!-- homu-ignore:end -->