### PR TITLE
[DO NOT MERGE] experiment: add `#[inline]` annotation to blanket `IntoFuture` impl

### DIFF
--- a/library/core/src/future/into_future.rs
+++ b/library/core/src/future/into_future.rs
@@ -22,6 +22,7 @@ impl<F: Future> IntoFuture for F {
     type Output = F::Output;
     type IntoFuture = F;
 
+    #[inline]
     fn into_future(self) -> Self::IntoFuture {
         self
     }


### PR DESCRIPTION
`IntoIterator` does this, so try and see if it can impact stack sizes in debug builds. We don't have an MCVE for this issue, and this PR is to have try artifacts for people to compare on their own projects.

r? @ghost