### PR TITLE
track individual proc-macro expansions in the self-profiler

### DIFF
--- a/compiler/rustc_expand/src/base.rs
+++ b/compiler/rustc_expand/src/base.rs
@@ -1047,6 +1047,12 @@ impl<'a> ExtCtxt<'a> {
         self.current_expansion.id.expn_data().call_site
     }
 
+    /// Returns the current expansion kind's description.
+    pub(crate) fn expansion_descr(&self) -> String {
+        let expn_data = self.current_expansion.id.expn_data();
+        expn_data.kind.descr()
+    }
+
     /// Equivalent of `Span::def_site` from the proc macro API,
     /// except that the location is taken from the span passed as an argument.
     pub fn with_def_site_ctxt(&self, span: Span) -> Span {


### PR DESCRIPTION
As described in [this zulip thread](https://rust-lang.zulipchat.com/#narrow/stream/131828-t-compiler/topic/Macro.20expansion.20performance.20on.20complex.20macros/near/275063190), users don't currently have a lot of information to diagnose macro expansion performance issues. That comment suggests using the macro names to add further timing information.

This PR starts to do this for proc-macros which have the same issue, and performance problems happening in the wild in [this other zulip thread](https://rust-lang.zulipchat.com/#narrow/stream/247081-t-compiler.2Fperformance/topic/Identifying.20proc-macro.20slowdowns) could be helped by such information.

It uses the available proc-macro name to track their individual expansions with self-profiling events. 

r? @Aaron1011 who mentioned this idea originally