### PR TITLE
Spellchecking compiler literals

### DIFF
--- a/compiler/rustc_infer/src/infer/freshen.rs
+++ b/compiler/rustc_infer/src/infer/freshen.rs
@@ -183,7 +183,7 @@ impl<'a, 'tcx> TypeFolder<'tcx> for TypeFreshener<'a, 'tcx> {
             ty::Infer(ty::FreshTy(ct) | ty::FreshIntTy(ct) | ty::FreshFloatTy(ct)) => {
                 if ct >= self.ty_freshen_count {
                     bug!(
-                        "Encountered a freshend type with id {} \
+                        "Encountered a freshened type with id {} \
                           but our counter is only at {}",
                         ct,
                         self.ty_freshen_count
@@ -242,7 +242,7 @@ impl<'a, 'tcx> TypeFolder<'tcx> for TypeFreshener<'a, 'tcx> {
             ty::ConstKind::Infer(ty::InferConst::Fresh(i)) => {
                 if i >= self.const_freshen_count {
                     bug!(
-                        "Encountered a freshend const with id {} \
+                        "Encountered a freshened const with id {} \
                             but our counter is only at {}",
                         i,
                         self.const_freshen_count,

--- a/compiler/rustc_infer/src/infer/nll_relate/mod.rs
+++ b/compiler/rustc_infer/src/infer/nll_relate/mod.rs
@@ -983,7 +983,7 @@ where
             ty::Placeholder(placeholder) => {
                 if self.universe.cannot_name(placeholder.universe) {
                     debug!(
-                        "TypeGeneralizer::tys: root universe {:?} cannot name\
+                        "TypeGeneralizer::tys: root universe {:?} cannot name \
                          placeholder in universe {:?}",
                         self.universe, placeholder.universe
                     );

--- a/compiler/rustc_interface/src/interface.rs
+++ b/compiler/rustc_interface/src/interface.rs
@@ -176,7 +176,7 @@ pub fn parse_check_cfg(specs: Vec<String>) -> CheckCfg {
                                         let ident = arg.ident().expect("multi-segment cfg key");
                                         names_valid.insert(ident.name.to_string());
                                     } else {
-                                        error!("`names()` arguments must be simple identifers");
+                                        error!("`names()` arguments must be simple identifiers");
                                     }
                                 }
                                 continue 'specs;
@@ -204,7 +204,7 @@ pub fn parse_check_cfg(specs: Vec<String>) -> CheckCfg {
                                         continue 'specs;
                                     } else {
                                         error!(
-                                            "`values()` first argument must be a simple identifer"
+                                            "`values()` first argument must be a simple identifier"
                                         );
                                     }
                                 } else if args.is_empty() {

--- a/compiler/rustc_lint/src/builtin.rs
+++ b/compiler/rustc_lint/src/builtin.rs
@@ -332,7 +332,7 @@ impl UnsafeCode {
         self.report_unsafe(cx, span, |lint| {
             lint.build(msg)
                 .note(
-                    "the linker's behavior with multiple libraries exporting duplicate symbol \
+                    "the linker behavior with multiple libraries exporting duplicate symbol \
                     names is undefined and Rust cannot provide guarantees when you manually \
                     override them",
                 )

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -874,7 +874,7 @@ rustc_queries! {
     /// which impls fail it. If all impls are correct, the returned slice is empty.
     query orphan_check_crate(_: ()) -> &'tcx [LocalDefId] {
         desc {
-            "checking whether the immpl in the this crate follow the orphan rules",
+            "checking whether the impl in the this crate follow the orphan rules",
         }
     }
 
@@ -1070,7 +1070,7 @@ rustc_queries! {
     /// Used by rustdoc.
     query rendered_const(def_id: DefId) -> String {
         storage(ArenaCacheSelector<'tcx>)
-        desc { |tcx| "rendering constant intializer of `{}`", tcx.def_path_str(def_id) }
+        desc { |tcx| "rendering constant initializer of `{}`", tcx.def_path_str(def_id) }
         separate_provide_extern
     }
     query impl_parent(def_id: DefId) -> Option<DefId> {

--- a/compiler/rustc_mir_build/src/build/matches/test.rs
+++ b/compiler/rustc_mir_build/src/build/matches/test.rs
@@ -184,7 +184,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                             debug_assert_ne!(
                                 target_blocks[idx.index()],
                                 otherwise_block,
-                                "no canididates for tested discriminant: {:?}",
+                                "no candidates for tested discriminant: {:?}",
                                 discr,
                             );
                             Some((discr.val, target_blocks[idx.index()]))
@@ -192,7 +192,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                             debug_assert_eq!(
                                 target_blocks[idx.index()],
                                 otherwise_block,
-                                "found canididates for untested discriminant: {:?}",
+                                "found candidates for untested discriminant: {:?}",
                                 discr,
                             );
                             None
@@ -757,7 +757,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
     }
 
     fn error_simplifyable<'pat>(&mut self, match_pair: &MatchPair<'pat, 'tcx>) -> ! {
-        span_bug!(match_pair.pattern.span, "simplifyable pattern found: {:?}", match_pair.pattern)
+        span_bug!(match_pair.pattern.span, "simplifiable pattern found: {:?}", match_pair.pattern)
     }
 
     fn const_range_contains(&self, range: PatRange<'tcx>, value: ty::Const<'tcx>) -> Option<bool> {

--- a/compiler/rustc_mir_build/src/thir/util.rs
+++ b/compiler/rustc_mir_build/src/thir/util.rs
@@ -15,7 +15,7 @@ crate trait UserAnnotatedTyHelpers<'tcx> {
     ) -> Option<CanonicalUserType<'tcx>> {
         let user_provided_types = self.typeck_results().user_provided_types();
         let mut user_ty = *user_provided_types.get(hir_id)?;
-        debug!("user_subts_applied_to_ty_of_hir_id: user_ty={:?}", user_ty);
+        debug!("user_substs_applied_to_ty_of_hir_id: user_ty={:?}", user_ty);
         let ty = self.typeck_results().node_type(hir_id);
         match ty.kind() {
             ty::Adt(adt_def, ..) => {

--- a/compiler/rustc_mir_transform/src/const_prop.rs
+++ b/compiler/rustc_mir_transform/src/const_prop.rs
@@ -939,7 +939,7 @@ impl Visitor<'_> for CanConstProp {
             | NonMutatingUse(NonMutatingUseContext::AddressOf)
             | MutatingUse(MutatingUseContext::Borrow)
             | MutatingUse(MutatingUseContext::AddressOf) => {
-                trace!("local {:?} can't be propagaged because it's used: {:?}", local, context);
+                trace!("local {:?} can't be propagated because it's used: {:?}", local, context);
                 self.can_const_prop[local] = ConstPropMode::NoPropagation;
             }
         }

--- a/compiler/rustc_mir_transform/src/const_prop_lint.rs
+++ b/compiler/rustc_mir_transform/src/const_prop_lint.rs
@@ -821,7 +821,7 @@ impl Visitor<'_> for CanConstProp {
             | NonMutatingUse(NonMutatingUseContext::AddressOf)
             | MutatingUse(MutatingUseContext::Borrow)
             | MutatingUse(MutatingUseContext::AddressOf) => {
-                trace!("local {:?} can't be propagaged because it's used: {:?}", local, context);
+                trace!("local {:?} can't be propagated because it's used: {:?}", local, context);
                 self.can_const_prop[local] = ConstPropMode::NoPropagation;
             }
         }

--- a/compiler/rustc_mir_transform/src/coverage/graph.rs
+++ b/compiler/rustc_mir_transform/src/coverage/graph.rs
@@ -112,7 +112,7 @@ impl CoverageGraph {
                         if predecessors.len() > 1 {
                             "predecessors.len() > 1".to_owned()
                         } else {
-                            format!("bb {} is not in precessors: {:?}", bb.index(), predecessors)
+                            format!("bb {} is not in predecessors: {:?}", bb.index(), predecessors)
                         }
                     );
                 }

--- a/compiler/rustc_monomorphize/src/util.rs
+++ b/compiler/rustc_monomorphize/src/util.rs
@@ -13,7 +13,7 @@ crate fn dump_closure_profile<'tcx>(tcx: TyCtxt<'tcx>, closure_instance: Instanc
         .append(true)
         .open(&format!("closure_profile_{}.csv", std::process::id()))
     else {
-        eprintln!("Cound't open file for writing closure profile");
+        eprintln!("Couldn't open file for writing closure profile");
         return;
     };
 

--- a/compiler/rustc_passes/src/hir_id_validator.rs
+++ b/compiler/rustc_passes/src/hir_id_validator.rs
@@ -124,7 +124,7 @@ impl<'a, 'hir> HirIdValidator<'a, 'hir> {
             self.error(|| {
                 format!(
                     "ItemLocalIds not assigned densely in {}. \
-                Max ItemLocalId = {}, missing IDs = {:?}; seens IDs = {:?}",
+                Max ItemLocalId = {}, missing IDs = {:?}; seen IDs = {:?}",
                     self.hir_map.def_path(owner).to_string_no_crate_verbose(),
                     max,
                     missing_items,

--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -2145,7 +2145,7 @@ impl Target {
                 load_builtin(target_triple).expect("built-in target")
             }
             TargetTriple::TargetPath(..) => {
-                panic!("built-in targets doens't support target-paths")
+                panic!("built-in targets do not support target-paths")
             }
         }
     }

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
@@ -191,7 +191,7 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
             }
         }
 
-        self.tcx.sess.delay_span_bug(DUMMY_SP, "expected fullfillment errors")
+        self.tcx.sess.delay_span_bug(DUMMY_SP, "expected fulfillment errors")
     }
 
     /// Reports that an overflow has occurred and halts compilation. We

--- a/compiler/rustc_trait_selection/src/traits/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/mod.rs
@@ -236,7 +236,7 @@ fn do_normalize_predicates<'tcx>(
                 }
             };
 
-        debug!("do_normalize_predictes: normalized predicates = {:?}", predicates);
+        debug!("do_normalize_predicates: normalized predicates = {:?}", predicates);
 
         // We can use the `elaborated_env` here; the region code only
         // cares about declarations like `'a: 'b`.

--- a/compiler/rustc_ty_utils/src/needs_drop.rs
+++ b/compiler/rustc_ty_utils/src/needs_drop.rs
@@ -238,7 +238,7 @@ fn drop_tys_helper<'tcx>(
         } else {
             let field_tys = adt_def.all_fields().map(|field| {
                 let r = tcx.type_of(field.did).subst(tcx, substs);
-                debug!("drop_tys_helper: Subst into {:?} with {:?} gettng {:?}", field, substs, r);
+                debug!("drop_tys_helper: Subst into {:?} with {:?} getting {:?}", field, substs, r);
                 r
             });
             if only_significant {

--- a/compiler/rustc_typeck/src/check/regionck.rs
+++ b/compiler/rustc_typeck/src/check/regionck.rs
@@ -834,7 +834,7 @@ impl<'a, 'tcx> RegionCtxt<'a, 'tcx> {
         borrow_region: ty::Region<'tcx>,
         upvar_id: ty::UpvarId,
     ) {
-        debug!("link_upvar_region(borrorw_region={:?}, upvar_id={:?}", borrow_region, upvar_id);
+        debug!("link_upvar_region(borrow_region={:?}, upvar_id={:?}", borrow_region, upvar_id);
         // A by-reference upvar can't be borrowed for longer than the
         // upvar is borrowed from the environment.
         let closure_local_def_id = upvar_id.closure_expr_id;

--- a/src/test/ui/check-cfg/invalid-arguments.names_simple_ident.stderr
+++ b/src/test/ui/check-cfg/invalid-arguments.names_simple_ident.stderr
@@ -1,2 +1,2 @@
-error: invalid `--check-cfg` argument: `names("NOT_IDENT")` (`names()` arguments must be simple identifers)
+error: invalid `--check-cfg` argument: `names("NOT_IDENT")` (`names()` arguments must be simple identifiers)
 

--- a/src/test/ui/check-cfg/invalid-arguments.values_simple_ident.stderr
+++ b/src/test/ui/check-cfg/invalid-arguments.values_simple_ident.stderr
@@ -1,2 +1,2 @@
-error: invalid `--check-cfg` argument: `values("NOT_IDENT")` (`values()` first argument must be a simple identifer)
+error: invalid `--check-cfg` argument: `values("NOT_IDENT")` (`values()` first argument must be a simple identifier)
 

--- a/src/test/ui/lint/lint-unsafe-code.stderr
+++ b/src/test/ui/lint/lint-unsafe-code.stderr
@@ -9,7 +9,7 @@ note: the lint level is defined here
    |
 LL | #![deny(unsafe_code)]
    |         ^^^^^^^^^^^
-   = note: the linker's behavior with multiple libraries exporting duplicate symbol names is undefined and Rust cannot provide guarantees when you manually override them
+   = note: the linker behavior with multiple libraries exporting duplicate symbol names is undefined and Rust cannot provide guarantees when you manually override them
 
 error: declaration of a `no_mangle` static
   --> $DIR/lint-unsafe-code.rs:32:1
@@ -17,7 +17,7 @@ error: declaration of a `no_mangle` static
 LL | #[no_mangle] static FOO: u32 = 5;
    | ^^^^^^^^^^^^
    |
-   = note: the linker's behavior with multiple libraries exporting duplicate symbol names is undefined and Rust cannot provide guarantees when you manually override them
+   = note: the linker behavior with multiple libraries exporting duplicate symbol names is undefined and Rust cannot provide guarantees when you manually override them
 
 error: declaration of a `no_mangle` method
   --> $DIR/lint-unsafe-code.rs:41:5
@@ -25,7 +25,7 @@ error: declaration of a `no_mangle` method
 LL |     #[no_mangle] fn foo() {}
    |     ^^^^^^^^^^^^
    |
-   = note: the linker's behavior with multiple libraries exporting duplicate symbol names is undefined and Rust cannot provide guarantees when you manually override them
+   = note: the linker behavior with multiple libraries exporting duplicate symbol names is undefined and Rust cannot provide guarantees when you manually override them
 
 error: declaration of a `no_mangle` method
   --> $DIR/lint-unsafe-code.rs:45:5
@@ -33,7 +33,7 @@ error: declaration of a `no_mangle` method
 LL |     #[no_mangle] fn foo() {}
    |     ^^^^^^^^^^^^
    |
-   = note: the linker's behavior with multiple libraries exporting duplicate symbol names is undefined and Rust cannot provide guarantees when you manually override them
+   = note: the linker behavior with multiple libraries exporting duplicate symbol names is undefined and Rust cannot provide guarantees when you manually override them
 
 error: declaration of a function with `export_name`
   --> $DIR/lint-unsafe-code.rs:48:1
@@ -41,7 +41,7 @@ error: declaration of a function with `export_name`
 LL | #[export_name = "bar"] fn bar() {}
    | ^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: the linker's behavior with multiple libraries exporting duplicate symbol names is undefined and Rust cannot provide guarantees when you manually override them
+   = note: the linker behavior with multiple libraries exporting duplicate symbol names is undefined and Rust cannot provide guarantees when you manually override them
 
 error: declaration of a static with `export_name`
   --> $DIR/lint-unsafe-code.rs:49:1
@@ -49,7 +49,7 @@ error: declaration of a static with `export_name`
 LL | #[export_name = "BAR"] static BAR: u32 = 5;
    | ^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: the linker's behavior with multiple libraries exporting duplicate symbol names is undefined and Rust cannot provide guarantees when you manually override them
+   = note: the linker behavior with multiple libraries exporting duplicate symbol names is undefined and Rust cannot provide guarantees when you manually override them
 
 error: declaration of a method with `export_name`
   --> $DIR/lint-unsafe-code.rs:54:5
@@ -57,7 +57,7 @@ error: declaration of a method with `export_name`
 LL |     #[export_name = "bar"] fn bar() {}
    |     ^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: the linker's behavior with multiple libraries exporting duplicate symbol names is undefined and Rust cannot provide guarantees when you manually override them
+   = note: the linker behavior with multiple libraries exporting duplicate symbol names is undefined and Rust cannot provide guarantees when you manually override them
 
 error: declaration of a method with `export_name`
   --> $DIR/lint-unsafe-code.rs:58:5
@@ -65,7 +65,7 @@ error: declaration of a method with `export_name`
 LL |     #[export_name = "bar"] fn foo() {}
    |     ^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: the linker's behavior with multiple libraries exporting duplicate symbol names is undefined and Rust cannot provide guarantees when you manually override them
+   = note: the linker behavior with multiple libraries exporting duplicate symbol names is undefined and Rust cannot provide guarantees when you manually override them
 
 error: declaration of an `unsafe` function
   --> $DIR/lint-unsafe-code.rs:61:1
@@ -154,7 +154,7 @@ LL |         #[no_mangle] fn foo() {}
 LL |     unsafe_in_macro!()
    |     ------------------ in this macro invocation
    |
-   = note: the linker's behavior with multiple libraries exporting duplicate symbol names is undefined and Rust cannot provide guarantees when you manually override them
+   = note: the linker behavior with multiple libraries exporting duplicate symbol names is undefined and Rust cannot provide guarantees when you manually override them
    = note: this error originates in the macro `unsafe_in_macro` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: declaration of a `no_mangle` static
@@ -166,7 +166,7 @@ LL |         #[no_mangle] static FOO: u32 = 5;
 LL |     unsafe_in_macro!()
    |     ------------------ in this macro invocation
    |
-   = note: the linker's behavior with multiple libraries exporting duplicate symbol names is undefined and Rust cannot provide guarantees when you manually override them
+   = note: the linker behavior with multiple libraries exporting duplicate symbol names is undefined and Rust cannot provide guarantees when you manually override them
    = note: this error originates in the macro `unsafe_in_macro` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: declaration of a function with `export_name`
@@ -178,7 +178,7 @@ LL |         #[export_name = "bar"] fn bar() {}
 LL |     unsafe_in_macro!()
    |     ------------------ in this macro invocation
    |
-   = note: the linker's behavior with multiple libraries exporting duplicate symbol names is undefined and Rust cannot provide guarantees when you manually override them
+   = note: the linker behavior with multiple libraries exporting duplicate symbol names is undefined and Rust cannot provide guarantees when you manually override them
    = note: this error originates in the macro `unsafe_in_macro` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: declaration of a static with `export_name`
@@ -190,7 +190,7 @@ LL |         #[export_name = "BAR"] static BAR: u32 = 5;
 LL |     unsafe_in_macro!()
    |     ------------------ in this macro invocation
    |
-   = note: the linker's behavior with multiple libraries exporting duplicate symbol names is undefined and Rust cannot provide guarantees when you manually override them
+   = note: the linker behavior with multiple libraries exporting duplicate symbol names is undefined and Rust cannot provide guarantees when you manually override them
    = note: this error originates in the macro `unsafe_in_macro` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: usage of an `unsafe` block


### PR DESCRIPTION
This PR cleans up the spelling mistakes in the compiler literals.