### PR TITLE
Fix `x doc compiler/rustc`

### DIFF
--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -618,20 +618,13 @@ impl Step for Rustc {
             }
         } else {
             for root_crate_path in paths {
-                if !root_crate_path.exists() {
-                    builder.info(&format!(
-                        "\tskipping - {} (unknown compiler crate)",
-                        root_crate_path.display()
-                    ));
-                } else {
-                    let root_crate = builder.crate_paths[root_crate_path];
-                    compiler_crates.extend(
-                        builder
-                            .in_tree_crates(&root_crate, Some(target))
-                            .into_iter()
-                            .map(|krate| krate.name),
-                    );
-                }
+                let root_crate = builder.crate_paths[root_crate_path];
+                compiler_crates.extend(
+                    builder
+                        .in_tree_crates(&root_crate, Some(target))
+                        .into_iter()
+                        .map(|krate| krate.name),
+                );
             }
         }
 

--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -7,7 +7,6 @@
 //! Everything here is basically just a shim around calling either `rustbook` or
 //! `rustdoc`.
 
-use std::collections::HashSet;
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
@@ -604,32 +603,22 @@ impl Step for Rustc {
         cargo.rustdocflag("--extern-html-root-url");
         cargo.rustdocflag("ena=https://docs.rs/ena/latest/");
 
-        let mut compiler_crates = HashSet::new();
-
-        if paths.is_empty() {
-            // Find dependencies for top level crates.
-            for root_crate in &["rustc_driver", "rustc_codegen_llvm", "rustc_codegen_ssa"] {
-                compiler_crates.extend(
-                    builder
-                        .in_tree_crates(root_crate, Some(target))
-                        .into_iter()
-                        .map(|krate| krate.name),
-                );
-            }
+        let root_crates = if paths.is_empty() {
+            vec![
+                INTERNER.intern_str("rustc_driver"),
+                INTERNER.intern_str("rustc_codegen_llvm"),
+                INTERNER.intern_str("rustc_codegen_ssa"),
+            ]
         } else {
-            for root_crate_path in paths {
-                let root_crate = builder.crate_paths[root_crate_path];
-                compiler_crates.extend(
-                    builder
-                        .in_tree_crates(&root_crate, Some(target))
-                        .into_iter()
-                        .map(|krate| krate.name),
-                );
-            }
-        }
+            paths.into_iter().map(|p| builder.crate_paths[p]).collect()
+        };
+        // Find dependencies for top level crates.
+        let compiler_crates = root_crates.iter().flat_map(|krate| {
+            builder.in_tree_crates(krate, Some(target)).into_iter().map(|krate| krate.name)
+        });
 
         let mut to_open = None;
-        for krate in &compiler_crates {
+        for krate in compiler_crates {
             // Create all crate output directories first to make sure rustdoc uses
             // relative links.
             // FIXME: Cargo should probably do this itself.

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -301,7 +301,9 @@ pub struct Build {
     ar: HashMap<TargetSelection, PathBuf>,
     ranlib: HashMap<TargetSelection, PathBuf>,
     // Miscellaneous
+    // allow bidirectional lookups: both name -> path and path -> name
     crates: HashMap<Interned<String>, Crate>,
+    crate_paths: HashMap<PathBuf, Interned<String>>,
     is_sudo: bool,
     ci_env: CiEnv,
     delayed_failures: RefCell<Vec<String>>,
@@ -491,6 +493,7 @@ impl Build {
             ar: HashMap::new(),
             ranlib: HashMap::new(),
             crates: HashMap::new(),
+            crate_paths: HashMap::new(),
             is_sudo,
             ci_env: CiEnv::current(),
             delayed_failures: RefCell::new(Vec::new()),

--- a/src/bootstrap/metadata.rs
+++ b/src/bootstrap/metadata.rs
@@ -49,7 +49,11 @@ pub fn build(build: &mut Build) {
                 .filter(|dep| dep.source.is_none())
                 .map(|dep| INTERNER.intern_string(dep.name))
                 .collect();
-            build.crates.insert(name, Crate { name, deps, path });
+            let krate = Crate { name, deps, path };
+            let relative_path = krate.local_path(build);
+            build.crates.insert(name, krate);
+            let existing_path = build.crate_paths.insert(relative_path, name);
+            assert!(existing_path.is_none(), "multiple crates with the same path");
         }
     }
 }


### PR DESCRIPTION
This also has a few cleanups to `doc.rs`. The last two commits I don't care about, but the first commit I'd like to keep - it will be very useful for https://github.com/rust-lang/rust/issues/44293.

Fixes https://github.com/rust-lang/rust/issues/95447.