### PR TITLE
Fix library/std compilation on openbsd.

### DIFF
--- a/library/std/src/sys/unix/thread.rs
+++ b/library/std/src/sys/unix/thread.rs
@@ -522,7 +522,7 @@ pub mod guard {
             // new thread
             stack_ptr.addr() - current_stack.ss_size
         };
-        Some(stack_ptr.with_addr(stack_addr))
+        Some(stack_ptr.with_addr(stackaddr))
     }
 
     #[cfg(any(


### PR DESCRIPTION
Fix a minor typo from #95241 which prevented compilation on x86_64-unknown-openbsd.
