### PR TITLE
Implement Deref and DerefMut for arrays

### DIFF
--- a/library/core/src/array/mod.rs
+++ b/library/core/src/array/mod.rs
@@ -12,7 +12,8 @@ use crate::hash::{self, Hash};
 use crate::iter::TrustedLen;
 use crate::mem::{self, MaybeUninit};
 use crate::ops::{
-    ChangeOutputType, ControlFlow, FromResidual, Index, IndexMut, NeverShortCircuit, Residual, Try,
+    ChangeOutputType, ControlFlow, Deref, DerefMut, FromResidual, Index, IndexMut,
+    NeverShortCircuit, Residual, Try,
 };
 use crate::slice::{Iter, IterMut};
 
@@ -172,6 +173,24 @@ impl<T, const N: usize> const Borrow<[T]> for [T; N] {
 impl<T, const N: usize> const BorrowMut<[T]> for [T; N] {
     fn borrow_mut(&mut self) -> &mut [T] {
         self
+    }
+}
+
+#[stable(feature = "array_deref", since = "1.61.0")]
+#[rustc_const_unstable(feature = "const_array_deref", issue = "none")]
+impl<T, const N: usize> const Deref for [T; N] {
+    type Target = [T];
+
+    fn deref(&self) -> &[T] {
+        self as &[T]
+    }
+}
+
+#[stable(feature = "array_deref", since = "1.61.0")]
+#[rustc_const_unstable(feature = "const_array_deref", issue = "none")]
+impl<T, const N: usize> const DerefMut for [T; N] {
+    fn deref_mut(&mut self) -> &mut [T] {
+        self as &mut [T]
     }
 }
 


### PR DESCRIPTION
I recently noticed that arrays don't actually implement `Deref` and `DerefMut` (the slice coercion works through compiler magic, presumably: `CoerceUnsized` is also not implemented AFAICT).

With this PR, I want to expose the idea of adding these impls to more people. I already noticed that this will be blocked on `const` trait implementations (#67792) unless there is a way to bypass the error when `#[rustc_const_unstable(…)]` is omitted.