### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/compiler/rustc_monomorphize/src/collector.rs
+++ b/compiler/rustc_monomorphize/src/collector.rs
@@ -859,6 +859,7 @@ impl<'a, 'tcx> MirVisitor<'tcx> for MirNeighborCollector<'a, 'tcx> {
                     |lint| {
                         let mut err = lint.build(&format!("moving {} bytes", layout.size.bytes()));
                         err.span_label(source_info.span, "value moved from here");
+                        err.note(&format!(r#"The current maximum size is {}, but it can be customized with the move_size_limit attribute: `#![move_size_limit = "..."]`"#, limit.bytes()));
                         err.emit();
                     },
                 );

--- a/library/std/src/sys/unix/thread.rs
+++ b/library/std/src/sys/unix/thread.rs
@@ -522,7 +522,7 @@ pub mod guard {
             // new thread
             stack_ptr.addr() - current_stack.ss_size
         };
-        Some(stack_ptr.with_addr(stack_addr))
+        Some(stack_ptr.with_addr(stackaddr))
     }
 
     #[cfg(any(

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -1998,7 +1998,6 @@ impl Step for Crate {
                 compile::std_cargo(builder, target, compiler.stage, &mut cargo);
             }
             Mode::Rustc => {
-                builder.ensure(compile::Rustc { compiler, target });
                 compile::rustc_cargo(builder, &mut cargo, target);
             }
             _ => panic!("can only test libraries"),

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -465,7 +465,7 @@ fn extra_info_tags(item: &clean::Item, parent: &clean::Item, tcx: TyCtxt<'_>) ->
 fn item_function(w: &mut Buffer, cx: &Context<'_>, it: &clean::Item, f: &clean::Function) {
     let header = it.fn_header(cx.tcx()).expect("printing a function which isn't a function");
     let constness = print_constness_with_space(&header.constness, it.const_stability(cx.tcx()));
-    let unsafety = header.unsafety.print_with_space().to_string();
+    let unsafety = header.unsafety.print_with_space();
     let abi = print_abi_with_space(header.abi).to_string();
     let asyncness = header.asyncness.print_with_space();
     let visibility = it.visibility.print_with_space(it.def_id, cx).to_string();

--- a/src/test/rustdoc-gui/search-result-display.goml
+++ b/src/test/rustdoc-gui/search-result-display.goml
@@ -2,8 +2,7 @@
 goto: file://|DOC_PATH|/test_docs/index.html
 size: (900, 1000)
 write: (".search-input", "test")
-// Waiting for the search results to appear...
-wait-for: "#titles"
+wait-for: "#search-settings"
 // The width is returned by "getComputedStyle" which returns the exact number instead of the
 // CSS rule which is "50%"...
 assert-css: (".search-results div.desc", {"width": "295px"})

--- a/src/test/ui/async-await/large_moves.attribute.stderr
+++ b/src/test/ui/async-await/large_moves.attribute.stderr
@@ -15,24 +15,31 @@ note: the lint level is defined here
    |
 LL | #![deny(large_assignments)]
    |         ^^^^^^^^^^^^^^^^^
+   = note: The current maximum size is 1000, but it can be customized with the move_size_limit attribute: `#![move_size_limit = "..."]`
 
 error: moving 10024 bytes
   --> $DIR/large_moves.rs:18:14
    |
 LL |     let z = (x, 42);
    |              ^ value moved from here
+   |
+   = note: The current maximum size is 1000, but it can be customized with the move_size_limit attribute: `#![move_size_limit = "..."]`
 
 error: moving 10024 bytes
   --> $DIR/large_moves.rs:18:13
    |
 LL |     let z = (x, 42);
    |             ^^^^^^^ value moved from here
+   |
+   = note: The current maximum size is 1000, but it can be customized with the move_size_limit attribute: `#![move_size_limit = "..."]`
 
 error: moving 10024 bytes
   --> $DIR/large_moves.rs:20:13
    |
 LL |     let a = z.0;
    |             ^^^ value moved from here
+   |
+   = note: The current maximum size is 1000, but it can be customized with the move_size_limit attribute: `#![move_size_limit = "..."]`
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/async-await/large_moves.option.stderr
+++ b/src/test/ui/async-await/large_moves.option.stderr
@@ -15,24 +15,31 @@ note: the lint level is defined here
    |
 LL | #![deny(large_assignments)]
    |         ^^^^^^^^^^^^^^^^^
+   = note: The current maximum size is 1000, but it can be customized with the move_size_limit attribute: `#![move_size_limit = "..."]`
 
 error: moving 10024 bytes
   --> $DIR/large_moves.rs:18:14
    |
 LL |     let z = (x, 42);
    |              ^ value moved from here
+   |
+   = note: The current maximum size is 1000, but it can be customized with the move_size_limit attribute: `#![move_size_limit = "..."]`
 
 error: moving 10024 bytes
   --> $DIR/large_moves.rs:18:13
    |
 LL |     let z = (x, 42);
    |             ^^^^^^^ value moved from here
+   |
+   = note: The current maximum size is 1000, but it can be customized with the move_size_limit attribute: `#![move_size_limit = "..."]`
 
 error: moving 10024 bytes
   --> $DIR/large_moves.rs:20:13
    |
 LL |     let a = z.0;
    |             ^^^ value moved from here
+   |
+   = note: The current maximum size is 1000, but it can be customized with the move_size_limit attribute: `#![move_size_limit = "..."]`
 
 error: aborting due to 4 previous errors
 


### PR DESCRIPTION
Successful merges:

 - #95445 (Don't build the full compiler before running unit tests)
 - #95470 (Fix last rustdoc-gui spurious test)
 - #95478 (Add note to the move size diagnostic)
 - #95495 (Remove unneeded `to_string` call)
 - #95505 (Fix library/std compilation on openbsd.)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=95445,95470,95478,95495,95505)
<!-- homu-ignore:end -->