### PR TITLE
Default to running python3 for x.py

### DIFF
--- a/x.py
+++ b/x.py
@@ -1,24 +1,9 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # This file is only a "symlink" to bootstrap.py, all logic should go there.
 
 import os
 import sys
-
-# If this is python2, check if python3 is available and re-execute with that
-# interpreter.
-if sys.version_info.major < 3:
-    try:
-        # On Windows, `py -3` sometimes works.
-        # Try this first, because 'python3' sometimes tries to launch the app
-        # store on Windows
-        os.execvp("py", ["py", "-3"] + sys.argv)
-    except OSError:
-        try:
-            os.execvp("python3", ["python3"] + sys.argv)
-        except OSError:
-            # Python 3 isn't available, fall back to python 2
-            pass
 
 rust_dir = os.path.dirname(os.path.abspath(__file__))
 sys.path.append(os.path.join(rust_dir, "src", "bootstrap"))


### PR DESCRIPTION
On my macOS machine, there is no python binary on the PATH. In this day
(15 months after Python 2 has gone EOL), it doesn't seem crazy to
default to Python3. Users who don't have python3 available could
supposedly still run `python x.py` manually.

This assumes that any environment where `python` is at version 3,
`python3` is also on the PATH.