### PR TITLE
remove unused field from `infcx`

### DIFF
--- a/compiler/rustc_infer/src/infer/at.rs
+++ b/compiler/rustc_infer/src/infer/at.rs
@@ -65,7 +65,6 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
         Self {
             tcx: self.tcx.clone(),
             defining_use_anchor: self.defining_use_anchor.clone(),
-            reveal_defining_opaque_types: self.reveal_defining_opaque_types.clone(),
             in_progress_typeck_results: self.in_progress_typeck_results.clone(),
             inner: self.inner.clone(),
             skip_leak_check: self.skip_leak_check.clone(),

--- a/compiler/rustc_typeck/src/check/inherited.rs
+++ b/compiler/rustc_typeck/src/check/inherited.rs
@@ -95,13 +95,6 @@ impl<'tcx> InheritedBuilder<'tcx> {
         let def_id = self.def_id;
         self.infcx.enter(|infcx| f(Inherited::new(infcx, def_id)))
     }
-
-    /// WF-checking doesn't need to recompute opaque types and can instead use
-    /// the type_of query to get them from typeck.
-    pub fn reveal_defining_opaque_types(mut self) -> Self {
-        self.infcx = self.infcx.reveal_defining_opaque_types();
-        self
-    }
 }
 
 impl<'a, 'tcx> Inherited<'a, 'tcx> {

--- a/compiler/rustc_typeck/src/check/wfcheck.rs
+++ b/compiler/rustc_typeck/src/check/wfcheck.rs
@@ -968,7 +968,7 @@ fn for_item<'tcx>(tcx: TyCtxt<'tcx>, item: &hir::Item<'_>) -> CheckWfFcxBuilder<
 
 fn for_id(tcx: TyCtxt<'_>, def_id: LocalDefId, span: Span) -> CheckWfFcxBuilder<'_> {
     CheckWfFcxBuilder {
-        inherited: Inherited::build(tcx, def_id).reveal_defining_opaque_types(),
+        inherited: Inherited::build(tcx, def_id),
         id: hir::HirId::make_owner(def_id),
         span,
         param_env: tcx.param_env(def_id),


### PR DESCRIPTION
r? @oli-obk did we stop needing that for opaque types?