### PR TITLE
rustdoc: do not show primitives and keywords as private

### DIFF
--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -471,14 +471,17 @@ impl Item {
     ) -> Item {
         trace!("name={:?}, def_id={:?}", name, def_id);
 
-        Item {
-            def_id: def_id.into(),
-            kind: box kind,
-            name,
-            attrs,
-            visibility: cx.tcx.visibility(def_id).clean(cx),
-            cfg,
-        }
+        // Primitives and Keywords are written in the source code as private modules.
+        // The modules need to be private so that nobody actually uses them, but the
+        // keywords and primitives that they are documenting are public.
+        let visibility = if matches!(&kind, ItemKind::KeywordItem(..) | ItemKind::PrimitiveItem(..))
+        {
+            Visibility::Public
+        } else {
+            cx.tcx.visibility(def_id).clean(cx)
+        };
+
+        Item { def_id: def_id.into(), kind: box kind, name, attrs, visibility, cfg }
     }
 
     /// Finds all `doc` attributes as NameValues and returns their corresponding values, joined

--- a/src/test/rustdoc/keyword.rs
+++ b/src/test/rustdoc/keyword.rs
@@ -12,6 +12,7 @@
 // @has foo/index.html '//a/@href' '../foo/index.html'
 // @!has foo/foo/index.html
 // @!has-dir foo/foo
+// @!has foo/index.html '//span' '🔒'
 #[doc(keyword = "match")]
 /// this is a test!
 mod foo{}

--- a/src/test/rustdoc/primitive.rs
+++ b/src/test/rustdoc/primitive.rs
@@ -1,0 +1,21 @@
+#![crate_name = "foo"]
+
+#![feature(rustdoc_internals)]
+
+// @has foo/index.html '//h2[@id="primitives"]' 'Primitive Types'
+// @has foo/index.html '//a[@href="primitive.i32.html"]' 'i32'
+// @has foo/index.html '//div[@class="sidebar-elems"]//li/a' 'Primitive Types'
+// @has foo/index.html '//div[@class="sidebar-elems"]//li/a/@href' '#primitives'
+// @has foo/primitive.i32.html '//a[@class="primitive"]' 'i32'
+// @has foo/primitive.i32.html '//span[@class="in-band"]' 'Primitive Type i32'
+// @has foo/primitive.i32.html '//section[@id="main-content"]//div[@class="docblock"]//p' 'this is a test!'
+// @has foo/index.html '//a/@href' '../foo/index.html'
+// @!has foo/index.html '//span' '🔒'
+#[doc(primitive = "i32")]
+/// this is a test!
+mod i32{}
+
+// @has foo/primitive.bool.html '//section[@id="main-content"]//div[@class="docblock"]//p' 'hello'
+#[doc(primitive = "bool")]
+/// hello
+mod bool {}


### PR DESCRIPTION
Fixes this:

![image](https://user-images.githubusercontent.com/1593513/161102430-f1f0301e-3e7f-453f-9c0a-bc87a12b893d.png)
