### PR TITLE
expand: Do not count metavar declarations on RHS of `macro_rules`

### DIFF
--- a/compiler/rustc_expand/src/mbe/macro_parser.rs
+++ b/compiler/rustc_expand/src/mbe/macro_parser.rs
@@ -263,18 +263,12 @@ crate type NamedParseResult = ParseResult<FxHashMap<MacroRulesNormalizedIdent, N
 pub(super) fn count_metavar_decls(matcher: &[TokenTree]) -> usize {
     matcher
         .iter()
-        .map(|tt| {
-            match tt {
-                TokenTree::Delimited(_, delim) => count_metavar_decls(delim.inner_tts()),
-                TokenTree::MetaVar(..) => 0,
-                TokenTree::MetaVarDecl(..) => 1,
-                // RHS meta-variable expressions eventually end-up here. `0` is returned to inform
-                // that no meta-variable was found, because "meta-variables" != "meta-variable
-                // expressions".
-                TokenTree::MetaVarExpr(..) => 0,
-                TokenTree::Sequence(_, seq) => seq.num_captures,
-                TokenTree::Token(..) => 0,
-            }
+        .map(|tt| match tt {
+            TokenTree::MetaVarDecl(..) => 1,
+            TokenTree::Sequence(_, seq) => seq.num_captures,
+            TokenTree::Delimited(_, delim) => count_metavar_decls(delim.inner_tts()),
+            TokenTree::Token(..) => 0,
+            TokenTree::MetaVar(..) | TokenTree::MetaVarExpr(..) => unreachable!(),
         })
         .sum()
 }

--- a/compiler/rustc_expand/src/mbe/quoted.rs
+++ b/compiler/rustc_expand/src/mbe/quoted.rs
@@ -1,4 +1,4 @@
-use crate::mbe::macro_parser;
+use crate::mbe::macro_parser::count_metavar_decls;
 use crate::mbe::{Delimited, KleeneOp, KleeneToken, MetaVarExpr, SequenceRepetition, TokenTree};
 
 use rustc_ast::token::{self, Token};
@@ -211,14 +211,15 @@ fn parse_tree(
                     let (separator, kleene) =
                         parse_sep_and_kleene_op(&mut trees, delim_span.entire(), sess);
                     // Count the number of captured "names" (i.e., named metavars)
-                    let name_captures = macro_parser::count_metavar_decls(&sequence);
+                    let num_captures =
+                        if parsing_patterns { count_metavar_decls(&sequence) } else { 0 };
                     TokenTree::Sequence(
                         delim_span,
                         Lrc::new(SequenceRepetition {
                             tts: sequence,
                             separator,
                             kleene,
-                            num_captures: name_captures,
+                            num_captures,
                         }),
                     )
                 }


### PR DESCRIPTION
They are 0 by definition there.

Addresses https://github.com/rust-lang/rust/pull/95425#discussion_r837410476
r? @nnethercote 