### PR TITLE
smol mistake on `dedup_by` documentation

### DIFF
--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -1599,7 +1599,7 @@ impl<T, A: Allocator> Vec<T, A> {
     ///
     /// The `same_bucket` function is passed references to two elements from the vector and
     /// must determine if the elements compare equal. The elements are passed in opposite order
-    /// from their order in the slice, so if `same_bucket(a, b)` returns `true`, `a` is removed.
+    /// from their order in the slice, so if `same_bucket(a, b)` returns `true`, `b` is removed.
     ///
     /// If the vector is sorted, this removes all duplicates.
     ///


### PR DESCRIPTION
As said in the first line of the documentation and as shown in the example.
If |a, b| returns `true` then `a` is kept and `b` is removed.