### PR TITLE
Memory-map the dep-graph instead of reading it up front

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4371,6 +4371,7 @@ dependencies = [
 name = "rustc_query_system"
 version = "0.0.0"
 dependencies = [
+ "hashbrown",
  "parking_lot 0.11.2",
  "rustc-rayon-core",
  "rustc_arena",

--- a/compiler/rustc_incremental/src/persist/load.rs
+++ b/compiler/rustc_incremental/src/persist/load.rs
@@ -204,7 +204,7 @@ pub fn load_dep_graph(sess: &Session) -> DepGraphFuture {
                     return LoadResult::DataOutOfDate;
                 }
 
-                let dep_graph = SerializedDepGraph::decode(&mut decoder);
+                let dep_graph = SerializedDepGraph::decode(bytes);
 
                 LoadResult::Ok { data: (dep_graph, prev_work_products) }
             }

--- a/compiler/rustc_query_system/Cargo.toml
+++ b/compiler/rustc_query_system/Cargo.toml
@@ -8,6 +8,7 @@ doctest = false
 
 [dependencies]
 rustc_arena = { path = "../rustc_arena" }
+hashbrown = { version = "0.12.0", features = ["raw"] }
 tracing = "0.1"
 rustc-rayon-core = { version = "0.4.0", optional = true }
 rustc_ast = { path = "../rustc_ast" }

--- a/compiler/rustc_query_system/src/dep_graph/dep_node.rs
+++ b/compiler/rustc_query_system/src/dep_graph/dep_node.rs
@@ -50,7 +50,7 @@ use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
 use std::fmt;
 use std::hash::Hash;
 
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Encodable, Decodable)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DepNode<K> {
     pub kind: K,
     pub hash: PackedFingerprint,

--- a/compiler/rustc_query_system/src/dep_graph/graph.rs
+++ b/compiler/rustc_query_system/src/dep_graph/graph.rs
@@ -731,8 +731,7 @@ impl<K: DepKind> DepGraph<K> {
         debug_assert_eq!(data.previous.index_to_node(prev_dep_node_index), *dep_node);
 
         let prev_deps = data.previous.edge_targets_from(prev_dep_node_index);
-
-        for &dep_dep_node_index in prev_deps {
+        for dep_dep_node_index in prev_deps {
             self.try_mark_parent_green(tcx, data, dep_dep_node_index, dep_node)?
         }
 

--- a/compiler/rustc_query_system/src/dep_graph/graph.rs
+++ b/compiler/rustc_query_system/src/dep_graph/graph.rs
@@ -1180,8 +1180,7 @@ impl<K: DepKind> CurrentDepGraph<K> {
                     prev_graph.fingerprint_by_index(prev_index),
                     prev_graph
                         .edge_targets_from(prev_index)
-                        .iter()
-                        .map(|i| prev_index_to_index[*i].unwrap())
+                        .map(|i| prev_index_to_index[i].unwrap())
                         .collect(),
                 );
                 prev_index_to_index[prev_index] = Some(dep_node_index);

--- a/compiler/rustc_query_system/src/dep_graph/mod.rs
+++ b/compiler/rustc_query_system/src/dep_graph/mod.rs
@@ -13,7 +13,7 @@ pub use serialized::{SerializedDepGraph, SerializedDepNodeIndex};
 
 use crate::ich::StableHashingContext;
 use rustc_data_structures::profiling::SelfProfilerRef;
-use rustc_serialize::{opaque::FileEncoder, Encodable};
+use rustc_serialize::MmapSafe;
 use rustc_session::Session;
 
 use std::fmt;
@@ -84,7 +84,7 @@ impl FingerprintStyle {
 }
 
 /// Describe the different families of dependency nodes.
-pub trait DepKind: Copy + fmt::Debug + Eq + Hash + Send + Encodable<FileEncoder> + 'static {
+pub trait DepKind: Copy + fmt::Debug + Eq + Hash + Send + MmapSafe + 'static {
     /// DepKind to use when incr. comp. is turned off.
     const NULL: Self;
 

--- a/compiler/rustc_query_system/src/dep_graph/serialized.rs
+++ b/compiler/rustc_query_system/src/dep_graph/serialized.rs
@@ -258,7 +258,7 @@ impl<K: DepKind> EncoderState<K> {
     }
 }
 
-#[derive(Debug, Encodable, Decodable)]
+#[derive(Debug)]
 pub struct NodeInfo<K: DepKind> {
     node: DepNode<K>,
     fingerprint: Fingerprint,

--- a/compiler/rustc_serialize/src/lib.rs
+++ b/compiler/rustc_serialize/src/lib.rs
@@ -9,12 +9,14 @@ Core encoding and decoding interfaces.
     html_playground_url = "https://play.rust-lang.org/",
     test(attr(allow(unused_variables), deny(warnings)))
 )]
+#![feature(auto_traits)]
 #![feature(never_type)]
 #![feature(associated_type_bounds)]
 #![feature(min_specialization)]
 #![feature(core_intrinsics)]
 #![feature(maybe_uninit_slice)]
 #![feature(let_else)]
+#![feature(negative_impls)]
 #![feature(new_uninit)]
 #![cfg_attr(test, feature(test))]
 #![allow(rustc::internal)]
@@ -26,3 +28,10 @@ mod serialize;
 
 pub mod leb128;
 pub mod opaque;
+
+/// This trait is used to mark datastructures as safe for Mmap.
+pub unsafe auto trait MmapSafe {}
+impl<'a, T> !MmapSafe for &'a T {}
+impl<'a, T> !MmapSafe for &'a mut T {}
+impl<T> !MmapSafe for *const T {}
+impl<T> !MmapSafe for *mut T {}


### PR DESCRIPTION
An incremental compilation session starts by reading the dep-graph from disk. This step allocates a lot of memory to store the whole graph. Most of this memory will be used at most once: a node's dependencies are only checked when before trying to force it, and its fingerprint once it has been re-computed.

This PR proposes to skip reading the fingerprints and dependencies at the beginning of the compilation session, and to only load them when necessary.  To achieve that, the dep-graph file remains accessible through a memmap throughout the compilation session.

In opposition, the list of dep-nodes, along with the in-file positions of the unread fingerprints are pushed to the end of the dep-graph file.  This list is also accessed through the memmap.  This list is still read immediately to construct the inverse index `DepNode -> SerializedDepNodeIndex`, and remains available afterwards.

Along the way, the inverse index is refactored to use a hashbrown `RawTable`. This avoids having to store all the `DepNode`s twice.