### PR TITLE
Add error message suggestion for missing noreturn in naked function

### DIFF
--- a/compiler/rustc_passes/src/naked_functions.rs
+++ b/compiler/rustc_passes/src/naked_functions.rs
@@ -1,7 +1,7 @@
 //! Checks validity of naked functions.
 
 use rustc_ast::{Attribute, InlineAsmOptions};
-use rustc_errors::struct_span_err;
+use rustc_errors::{struct_span_err, Applicability};
 use rustc_hir as hir;
 use rustc_hir::def_id::LocalDefId;
 use rustc_hir::intravisit::{FnKind, Visitor};
@@ -274,11 +274,24 @@ impl<'tcx> CheckInlineAssembly<'tcx> {
         }
 
         if !asm.options.contains(InlineAsmOptions::NORETURN) {
+            let last_span = asm
+                .operands
+                .last()
+                .map_or_else(|| asm.template_strs.last().unwrap().2, |op| op.1)
+                .shrink_to_hi();
+
             struct_span_err!(
                 self.tcx.sess,
                 span,
                 E0787,
                 "asm in naked functions must use `noreturn` option"
+            )
+            .span_suggestion(
+                last_span,
+                "consider specifying that the asm block is responsible \
+                for returning, if desired",
+                String::from(", options(noreturn)"),
+                Applicability::MachineApplicable,
             )
             .emit();
         }

--- a/compiler/rustc_passes/src/naked_functions.rs
+++ b/compiler/rustc_passes/src/naked_functions.rs
@@ -289,7 +289,7 @@ impl<'tcx> CheckInlineAssembly<'tcx> {
             .span_suggestion(
                 last_span,
                 "consider specifying that the asm block is responsible \
-                for returning, if desired",
+                for returning from the function",
                 String::from(", options(noreturn)"),
                 Applicability::MachineApplicable,
             )

--- a/src/test/ui/asm/naked-functions.stderr
+++ b/src/test/ui/asm/naked-functions.stderr
@@ -97,6 +97,11 @@ LL | |
 LL | |          sym G,
 LL | |     );
    | |_____^
+   |
+help: consider specifying that the asm block is responsible for returning, if desired
+   |
+LL |          sym G, options(noreturn),
+   |               +++++++++++++++++++
 
 error[E0787]: naked functions must contain a single asm block
   --> $DIR/naked-functions.rs:53:1
@@ -131,18 +136,33 @@ error[E0787]: asm in naked functions must use `noreturn` option
    |
 LL |     asm!("");
    |     ^^^^^^^^
+   |
+help: consider specifying that the asm block is responsible for returning, if desired
+   |
+LL |     asm!("", options(noreturn));
+   |            +++++++++++++++++++
 
 error[E0787]: asm in naked functions must use `noreturn` option
   --> $DIR/naked-functions.rs:85:5
    |
 LL |     asm!("");
    |     ^^^^^^^^
+   |
+help: consider specifying that the asm block is responsible for returning, if desired
+   |
+LL |     asm!("", options(noreturn));
+   |            +++++++++++++++++++
 
 error[E0787]: asm in naked functions must use `noreturn` option
   --> $DIR/naked-functions.rs:87:5
    |
 LL |     asm!("");
    |     ^^^^^^^^
+   |
+help: consider specifying that the asm block is responsible for returning, if desired
+   |
+LL |     asm!("", options(noreturn));
+   |            +++++++++++++++++++
 
 error[E0787]: naked functions must contain a single asm block
   --> $DIR/naked-functions.rs:81:1
@@ -198,6 +218,11 @@ error[E0787]: asm in naked functions must use `noreturn` option
    |
 LL |     asm!("", options(readonly, nostack), options(pure));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: consider specifying that the asm block is responsible for returning, if desired
+   |
+LL |     asm!("", options(noreturn), options(readonly, nostack), options(pure));
+   |            +++++++++++++++++++
 
 error[E0787]: asm options unsupported in naked functions: `may_unwind`
   --> $DIR/naked-functions.rs:118:5

--- a/src/test/ui/asm/naked-functions.stderr
+++ b/src/test/ui/asm/naked-functions.stderr
@@ -98,7 +98,7 @@ LL | |          sym G,
 LL | |     );
    | |_____^
    |
-help: consider specifying that the asm block is responsible for returning, if desired
+help: consider specifying that the asm block is responsible for returning from the function
    |
 LL |          sym G, options(noreturn),
    |               +++++++++++++++++++
@@ -137,7 +137,7 @@ error[E0787]: asm in naked functions must use `noreturn` option
 LL |     asm!("");
    |     ^^^^^^^^
    |
-help: consider specifying that the asm block is responsible for returning, if desired
+help: consider specifying that the asm block is responsible for returning from the function
    |
 LL |     asm!("", options(noreturn));
    |            +++++++++++++++++++
@@ -148,7 +148,7 @@ error[E0787]: asm in naked functions must use `noreturn` option
 LL |     asm!("");
    |     ^^^^^^^^
    |
-help: consider specifying that the asm block is responsible for returning, if desired
+help: consider specifying that the asm block is responsible for returning from the function
    |
 LL |     asm!("", options(noreturn));
    |            +++++++++++++++++++
@@ -159,7 +159,7 @@ error[E0787]: asm in naked functions must use `noreturn` option
 LL |     asm!("");
    |     ^^^^^^^^
    |
-help: consider specifying that the asm block is responsible for returning, if desired
+help: consider specifying that the asm block is responsible for returning from the function
    |
 LL |     asm!("", options(noreturn));
    |            +++++++++++++++++++
@@ -219,7 +219,7 @@ error[E0787]: asm in naked functions must use `noreturn` option
 LL |     asm!("", options(readonly, nostack), options(pure));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-help: consider specifying that the asm block is responsible for returning, if desired
+help: consider specifying that the asm block is responsible for returning from the function
    |
 LL |     asm!("", options(noreturn), options(readonly, nostack), options(pure));
    |            +++++++++++++++++++


### PR DESCRIPTION
I had to google the syntax for inline asm's `noreturn` option when I got this error earlier today, so I figured I'd save others the trouble and add the syntax/fix as a suggestion in the error.