### PR TITLE
Build LLVM with support for compression

### DIFF
--- a/src/ci/docker/host-aarch64/aarch64-gnu/Dockerfile
+++ b/src/ci/docker/host-aarch64/aarch64-gnu/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
   sudo \
   gdb \
   libssl-dev \
+  zlib1g-dev \
   pkg-config \
   xz-utils
 

--- a/src/ci/docker/host-x86_64/dist-aarch64-linux/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-aarch64-linux/Dockerfile
@@ -21,6 +21,10 @@ RUN sh /scripts/cross-apt-packages.sh
 COPY scripts/make3.sh /scripts/
 RUN sh /scripts/make3.sh
 
+# We need an aarch64 build of zlib for parity with x86_64.
+# See https://github.com/rust-lang/rust/pull/95545.
+RUN dpkg --add-architecture arm64 && apt-get update && apt-get install zlib1g-dev:arm64
+
 COPY scripts/crosstool-ng.sh /scripts/
 RUN sh /scripts/crosstool-ng.sh
 


### PR DESCRIPTION
Through what seems to be an oversight we don't install libz in the
aarch64 Docker image, which causes LLVM, and in turn both rustc and
llvm-tools, to be built without support for compressing PGO and coverage
files (and probably other things too). This patch rectifies that
oversight so that aarch64 joins x86_64 in having compression support.

Since we do this for both what writes and what reads these things, it
doesn't usually manifest as an issue (beyond larger-than-necessary
files). But it does mean that a profraw file written by rustc on x86_64
cannot be read by Rust's llvm-profdata on aarch64. It shows up in other
situations too, such as if someone built rustc from source with zlib
available on aarch64, but is using llvm-tools from rustup. So it feels
worthwhile to fix.

And for Google-ability, this tends to manifest with errors like:

```
profile uses zlib compression but the profile reader was built without zlib support
```

Note that we install `zlib1g-dev`, not `lib32z1-dev` as in the x86_64
image, since we're only building for 64-bit on aarch anyway.