### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/compiler/rustc_expand/src/mbe/macro_parser.rs
+++ b/compiler/rustc_expand/src/mbe/macro_parser.rs
@@ -263,18 +263,12 @@ crate type NamedParseResult = ParseResult<FxHashMap<MacroRulesNormalizedIdent, N
 pub(super) fn count_metavar_decls(matcher: &[TokenTree]) -> usize {
     matcher
         .iter()
-        .map(|tt| {
-            match tt {
-                TokenTree::Delimited(_, delim) => count_metavar_decls(delim.inner_tts()),
-                TokenTree::MetaVar(..) => 0,
-                TokenTree::MetaVarDecl(..) => 1,
-                // RHS meta-variable expressions eventually end-up here. `0` is returned to inform
-                // that no meta-variable was found, because "meta-variables" != "meta-variable
-                // expressions".
-                TokenTree::MetaVarExpr(..) => 0,
-                TokenTree::Sequence(_, seq) => seq.num_captures,
-                TokenTree::Token(..) => 0,
-            }
+        .map(|tt| match tt {
+            TokenTree::MetaVarDecl(..) => 1,
+            TokenTree::Sequence(_, seq) => seq.num_captures,
+            TokenTree::Delimited(_, delim) => count_metavar_decls(delim.inner_tts()),
+            TokenTree::Token(..) => 0,
+            TokenTree::MetaVar(..) | TokenTree::MetaVarExpr(..) => unreachable!(),
         })
         .sum()
 }

--- a/compiler/rustc_expand/src/mbe/quoted.rs
+++ b/compiler/rustc_expand/src/mbe/quoted.rs
@@ -1,4 +1,4 @@
-use crate::mbe::macro_parser;
+use crate::mbe::macro_parser::count_metavar_decls;
 use crate::mbe::{Delimited, KleeneOp, KleeneToken, MetaVarExpr, SequenceRepetition, TokenTree};
 
 use rustc_ast::token::{self, Token};
@@ -211,14 +211,15 @@ fn parse_tree(
                     let (separator, kleene) =
                         parse_sep_and_kleene_op(&mut trees, delim_span.entire(), sess);
                     // Count the number of captured "names" (i.e., named metavars)
-                    let name_captures = macro_parser::count_metavar_decls(&sequence);
+                    let num_captures =
+                        if parsing_patterns { count_metavar_decls(&sequence) } else { 0 };
                     TokenTree::Sequence(
                         delim_span,
                         Lrc::new(SequenceRepetition {
                             tts: sequence,
                             separator,
                             kleene,
-                            num_captures: name_captures,
+                            num_captures,
                         }),
                     )
                 }

--- a/library/alloc/tests/str.rs
+++ b/library/alloc/tests/str.rs
@@ -2234,11 +2234,14 @@ fn utf8_chars() {
 #[test]
 fn utf8_char_counts() {
     let strs = [("e", 1), ("é", 1), ("€", 1), ("\u{10000}", 1), ("eé€\u{10000}", 4)];
-    let mut reps =
-        [8, 64, 256, 512, 1024].iter().copied().flat_map(|n| n - 8..=n + 8).collect::<Vec<usize>>();
+    let spread = if cfg!(miri) { 4 } else { 8 };
+    let mut reps = [8, 64, 256, 512]
+        .iter()
+        .copied()
+        .flat_map(|n| n - spread..=n + spread)
+        .collect::<Vec<usize>>();
     if cfg!(not(miri)) {
-        let big = 1 << 16;
-        reps.extend(big - 8..=big + 8);
+        reps.extend([1024, 1 << 16].iter().copied().flat_map(|n| n - spread..=n + spread));
     }
     let counts = if cfg!(miri) { 0..1 } else { 0..8 };
     let padding = counts.map(|len| " ".repeat(len)).collect::<Vec<String>>();

--- a/library/core/src/alloc/mod.rs
+++ b/library/core/src/alloc/mod.rs
@@ -173,6 +173,8 @@ pub unsafe trait Allocator {
     /// * `old_layout` must [*fit*] that block of memory (The `new_layout` argument need not fit it.).
     /// * `new_layout.size()` must be greater than or equal to `old_layout.size()`.
     ///
+    /// Note that `new_layout.align()` need not be the same as `old_layout.align()`.
+    ///
     /// [*currently allocated*]: #currently-allocated-memory
     /// [*fit*]: #memory-fitting
     ///
@@ -233,6 +235,8 @@ pub unsafe trait Allocator {
     /// * `ptr` must denote a block of memory [*currently allocated*] via this allocator.
     /// * `old_layout` must [*fit*] that block of memory (The `new_layout` argument need not fit it.).
     /// * `new_layout.size()` must be greater than or equal to `old_layout.size()`.
+    ///
+    /// Note that `new_layout.align()` need not be the same as `old_layout.align()`.
     ///
     /// [*currently allocated*]: #currently-allocated-memory
     /// [*fit*]: #memory-fitting
@@ -295,6 +299,8 @@ pub unsafe trait Allocator {
     /// * `ptr` must denote a block of memory [*currently allocated*] via this allocator.
     /// * `old_layout` must [*fit*] that block of memory (The `new_layout` argument need not fit it.).
     /// * `new_layout.size()` must be smaller than or equal to `old_layout.size()`.
+    ///
+    /// Note that `new_layout.align()` need not be the same as `old_layout.align()`.
     ///
     /// [*currently allocated*]: #currently-allocated-memory
     /// [*fit*]: #memory-fitting

--- a/library/core/tests/num/int_log.rs
+++ b/library/core/tests/num/int_log.rs
@@ -22,12 +22,15 @@ fn checked_log() {
     assert_eq!(0i8.checked_log(4), None);
     assert_eq!(0i16.checked_log(4), None);
 
+    #[cfg(not(miri))] // Miri is too slow
     for i in i16::MIN..=0 {
         assert_eq!(i.checked_log(4), None);
     }
+    #[cfg(not(miri))] // Miri is too slow
     for i in 1..=i16::MAX {
         assert_eq!(i.checked_log(13), Some((i as f32).log(13.0) as u32));
     }
+    #[cfg(not(miri))] // Miri is too slow
     for i in 1..=u16::MAX {
         assert_eq!(i.checked_log(13), Some((i as f32).log(13.0) as u32));
     }
@@ -48,6 +51,7 @@ fn checked_log2() {
     for i in 1..=u8::MAX {
         assert_eq!(i.checked_log2(), Some((i as f32).log2() as u32));
     }
+    #[cfg(not(miri))] // Miri is too slow
     for i in 1..=u16::MAX {
         // Guard against Android's imprecise f32::log2 implementation.
         if i != 8192 && i != 32768 {
@@ -60,9 +64,11 @@ fn checked_log2() {
     for i in 1..=i8::MAX {
         assert_eq!(i.checked_log2(), Some((i as f32).log2() as u32));
     }
+    #[cfg(not(miri))] // Miri is too slow
     for i in i16::MIN..=0 {
         assert_eq!(i.checked_log2(), None);
     }
+    #[cfg(not(miri))] // Miri is too slow
     for i in 1..=i16::MAX {
         // Guard against Android's imprecise f32::log2 implementation.
         if i != 8192 {
@@ -87,15 +93,19 @@ fn checked_log10() {
     assert_eq!(0i8.checked_log10(), None);
     assert_eq!(0i16.checked_log10(), None);
 
+    #[cfg(not(miri))] // Miri is too slow
     for i in i16::MIN..=0 {
         assert_eq!(i.checked_log10(), None);
     }
+    #[cfg(not(miri))] // Miri is too slow
     for i in 1..=i16::MAX {
         assert_eq!(i.checked_log10(), Some((i as f32).log10() as u32));
     }
+    #[cfg(not(miri))] // Miri is too slow
     for i in 1..=u16::MAX {
         assert_eq!(i.checked_log10(), Some((i as f32).log10() as u32));
     }
+    #[cfg(not(miri))] // Miri is too slow
     for i in 1..=100_000u32 {
         assert_eq!(i.checked_log10(), Some((i as f32).log10() as u32));
     }

--- a/library/core/tests/ptr.rs
+++ b/library/core/tests/ptr.rs
@@ -490,11 +490,11 @@ fn ptr_metadata() {
     let vtable_5: DynMetadata<dyn Display> =
         metadata(&Pair(true, 7_u32) as &Pair<bool, dyn Display>);
     unsafe {
-        let address_1: usize = std::mem::transmute(vtable_1);
-        let address_2: usize = std::mem::transmute(vtable_2);
-        let address_3: usize = std::mem::transmute(vtable_3);
-        let address_4: usize = std::mem::transmute(vtable_4);
-        let address_5: usize = std::mem::transmute(vtable_5);
+        let address_1: *const () = std::mem::transmute(vtable_1);
+        let address_2: *const () = std::mem::transmute(vtable_2);
+        let address_3: *const () = std::mem::transmute(vtable_3);
+        let address_4: *const () = std::mem::transmute(vtable_4);
+        let address_5: *const () = std::mem::transmute(vtable_5);
         // Different trait => different vtable pointer
         assert_ne!(address_1, address_2);
         // Different erased type => different vtable pointer

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -1987,6 +1987,7 @@ fn sidebar_assoc_items(cx: &Context<'_>, out: &mut Buffer, it: &clean::Item) {
             let used_links_bor = &mut used_links;
             let mut assoc_consts = v
                 .iter()
+                .filter(|i| i.inner_impl().trait_.is_none())
                 .flat_map(|i| get_associated_constants(i.inner_impl(), used_links_bor))
                 .collect::<Vec<_>>();
             if !assoc_consts.is_empty() {

--- a/src/test/rustdoc/associated-consts.rs
+++ b/src/test/rustdoc/associated-consts.rs
@@ -9,8 +9,8 @@ pub trait Trait {
 pub struct Bar;
 
 // @has 'foo/struct.Bar.html'
-// @has - '//h3[@class="sidebar-title"]' 'Associated Constants'
-// @has - '//div[@class="sidebar-elems"]//a' 'FOO'
+// @!has - '//h3[@class="sidebar-title"]' 'Associated Constants'
+// @!has - '//div[@class="sidebar-elems"]//a' 'FOO'
 impl Trait for Bar {
     const FOO: u32 = 1;
 
@@ -22,10 +22,30 @@ pub enum Foo {
 }
 
 // @has 'foo/enum.Foo.html'
-// @has - '//h3[@class="sidebar-title"]' 'Associated Constants'
-// @has - '//div[@class="sidebar-elems"]//a' 'FOO'
+// @!has - '//h3[@class="sidebar-title"]' 'Associated Constants'
+// @!has - '//div[@class="sidebar-elems"]//a' 'FOO'
 impl Trait for Foo {
     const FOO: u32 = 1;
 
     fn foo() {}
+}
+
+pub struct Baz;
+
+// @has 'foo/struct.Baz.html'
+// @has - '//h3[@class="sidebar-title"]' 'Associated Constants'
+// @has - '//div[@class="sidebar-elems"]//a' 'FOO'
+impl Baz {
+    pub const FOO: u32 = 42;
+}
+
+pub enum Quux {
+    B,
+}
+
+// @has 'foo/enum.Quux.html'
+// @has - '//h3[@class="sidebar-title"]' 'Associated Constants'
+// @has - '//div[@class="sidebar-elems"]//a' 'FOO'
+impl Quux {
+    pub const FOO: u32 = 42;
 }


### PR DESCRIPTION
Successful merges:

 - #95475 (rustdoc: Only show associated consts from inherent impls in sidebar)
 - #95516 (ptr_metadata test: avoid ptr-to-int transmutes)
 - #95528 (skip slow int_log tests in Miri)
 - #95531 (expand: Do not count metavar declarations on RHS of `macro_rules`)
 - #95532 (make utf8_char_counts test faster in Miri)
 - #95546 (add notes about alignment-altering reallocations to Allocator docs)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=95475,95516,95528,95531,95532,95546)
<!-- homu-ignore:end -->