### PR TITLE
ast_lowering: Stop wrapping `ident` matchers into groups

### DIFF
--- a/compiler/rustc_session/src/lib.rs
+++ b/compiler/rustc_session/src/lib.rs
@@ -1,5 +1,6 @@
 #![feature(crate_visibility_modifier)]
 #![feature(derive_default_enum)]
+#![feature(if_let_guard)]
 #![feature(let_chains)]
 #![feature(let_else)]
 #![feature(min_specialization)]

--- a/compiler/rustc_session/src/utils.rs
+++ b/compiler/rustc_session/src/utils.rs
@@ -132,6 +132,9 @@ impl<'a> FlattenNonterminals<'a> {
 
     pub fn process_token(&mut self, token: Token) -> TokenStream {
         match token.kind {
+            token::Interpolated(nt) if let token::NtIdent(ident, is_raw) = *nt => {
+                TokenTree::Token(Token::new(token::Ident(ident.name, is_raw), ident.span)).into()
+            }
             token::Interpolated(nt) => {
                 let tts = (self.nt_to_tokenstream)(&nt, self.parse_sess, self.synthesize_tokens);
                 TokenTree::Delimited(

--- a/src/test/ui/proc-macro/nested-macro-rules.stdout
+++ b/src/test/ui/proc-macro/nested-macro-rules.stdout
@@ -1,14 +1,8 @@
 PRINT-BANG INPUT (DISPLAY): FirstStruct
 PRINT-BANG INPUT (DEBUG): TokenStream [
-    Group {
-        delimiter: None,
-        stream: TokenStream [
-            Ident {
-                ident: "FirstStruct",
-                span: $DIR/auxiliary/nested-macro-rules.rs:16:14: 16:25 (#7),
-            },
-        ],
-        span: $DIR/auxiliary/nested-macro-rules.rs:9:30: 9:35 (#6),
+    Ident {
+        ident: "FirstStruct",
+        span: $DIR/auxiliary/nested-macro-rules.rs:16:14: 16:25 (#7),
     },
 ]
 PRINT-ATTR INPUT (DISPLAY): struct FirstAttrStruct {}
@@ -17,15 +11,9 @@ PRINT-ATTR INPUT (DEBUG): TokenStream [
         ident: "struct",
         span: $DIR/auxiliary/nested-macro-rules.rs:10:32: 10:38 (#6),
     },
-    Group {
-        delimiter: None,
-        stream: TokenStream [
-            Ident {
-                ident: "FirstAttrStruct",
-                span: $DIR/auxiliary/nested-macro-rules.rs:16:27: 16:42 (#7),
-            },
-        ],
-        span: $DIR/auxiliary/nested-macro-rules.rs:10:39: 10:56 (#6),
+    Ident {
+        ident: "FirstAttrStruct",
+        span: $DIR/auxiliary/nested-macro-rules.rs:16:27: 16:42 (#7),
     },
     Group {
         delimiter: Brace,


### PR DESCRIPTION
The lowered forms goes to metadata, for example during encoding of macro definitions.
This is a missing part of https://github.com/rust-lang/rust/pull/92472.

Fixes https://github.com/rust-lang/rust/issues/95569
r? @Aaron1011 