### PR TITLE
Deprecate the unstable `ptr_to_from_bits` feature

### DIFF
--- a/library/core/src/ptr/const_ptr.rs
+++ b/library/core/src/ptr/const_ptr.rs
@@ -119,6 +119,7 @@ impl<T: ?Sized> *const T {
     /// assert_eq!(p1.to_bits() - p0.to_bits(), 4);
     /// ```
     #[unstable(feature = "ptr_to_from_bits", issue = "91126")]
+    #[rustc_deprecated(since = "1.62", reason = "replaced by the `addr` method")]
     pub fn to_bits(self) -> usize
     where
         T: Sized,
@@ -140,6 +141,10 @@ impl<T: ?Sized> *const T {
     /// assert_eq!(<*const u8>::from_bits(1), dangling);
     /// ```
     #[unstable(feature = "ptr_to_from_bits", issue = "91126")]
+    #[rustc_deprecated(
+        since = "1.62",
+        reason = "replaced by the `with_addr` method or the `ptr::invalid` function"
+    )]
     #[allow(fuzzy_provenance_casts)] // this is an unstable and semi-deprecated cast function
     pub fn from_bits(bits: usize) -> Self
     where

--- a/library/core/src/ptr/const_ptr.rs
+++ b/library/core/src/ptr/const_ptr.rs
@@ -119,7 +119,11 @@ impl<T: ?Sized> *const T {
     /// assert_eq!(p1.to_bits() - p0.to_bits(), 4);
     /// ```
     #[unstable(feature = "ptr_to_from_bits", issue = "91126")]
-    #[rustc_deprecated(since = "1.62", reason = "replaced by the `addr` method")]
+    #[rustc_deprecated(
+        since = "1.62",
+        reason = "replaced by the `exposed_addr` method, or update your code \
+            to follow the strict provenance rules using its APIs"
+    )]
     pub fn to_bits(self) -> usize
     where
         T: Sized,
@@ -143,7 +147,8 @@ impl<T: ?Sized> *const T {
     #[unstable(feature = "ptr_to_from_bits", issue = "91126")]
     #[rustc_deprecated(
         since = "1.62",
-        reason = "replaced by the `with_addr` method or the `ptr::invalid` function"
+        reason = "replaced by the `ptr::from_exposed_addr` function, or update \
+            your code to follow the strict provenance rules using its APIs"
     )]
     #[allow(fuzzy_provenance_casts)] // this is an unstable and semi-deprecated cast function
     pub fn from_bits(bits: usize) -> Self

--- a/library/core/src/ptr/const_ptr.rs
+++ b/library/core/src/ptr/const_ptr.rs
@@ -120,7 +120,7 @@ impl<T: ?Sized> *const T {
     /// ```
     #[unstable(feature = "ptr_to_from_bits", issue = "91126")]
     #[rustc_deprecated(
-        since = "1.62",
+        since = "1.67",
         reason = "replaced by the `exposed_addr` method, or update your code \
             to follow the strict provenance rules using its APIs"
     )]
@@ -146,7 +146,7 @@ impl<T: ?Sized> *const T {
     /// ```
     #[unstable(feature = "ptr_to_from_bits", issue = "91126")]
     #[rustc_deprecated(
-        since = "1.62",
+        since = "1.67",
         reason = "replaced by the `ptr::from_exposed_addr` function, or update \
             your code to follow the strict provenance rules using its APIs"
     )]

--- a/library/core/src/ptr/const_ptr.rs
+++ b/library/core/src/ptr/const_ptr.rs
@@ -119,9 +119,9 @@ impl<T: ?Sized> *const T {
     /// assert_eq!(p1.to_bits() - p0.to_bits(), 4);
     /// ```
     #[unstable(feature = "ptr_to_from_bits", issue = "91126")]
-    #[rustc_deprecated(
+    #[deprecated(
         since = "1.67",
-        reason = "replaced by the `exposed_addr` method, or update your code \
+        note = "replaced by the `exposed_addr` method, or update your code \
             to follow the strict provenance rules using its APIs"
     )]
     pub fn to_bits(self) -> usize
@@ -145,9 +145,9 @@ impl<T: ?Sized> *const T {
     /// assert_eq!(<*const u8>::from_bits(1), dangling);
     /// ```
     #[unstable(feature = "ptr_to_from_bits", issue = "91126")]
-    #[rustc_deprecated(
+    #[deprecated(
         since = "1.67",
-        reason = "replaced by the `ptr::from_exposed_addr` function, or update \
+        note = "replaced by the `ptr::from_exposed_addr` function, or update \
             your code to follow the strict provenance rules using its APIs"
     )]
     #[allow(fuzzy_provenance_casts)] // this is an unstable and semi-deprecated cast function

--- a/library/core/src/ptr/mut_ptr.rs
+++ b/library/core/src/ptr/mut_ptr.rs
@@ -125,7 +125,11 @@ impl<T: ?Sized> *mut T {
     /// assert_eq!(p1.to_bits() - p0.to_bits(), 4);
     /// ```
     #[unstable(feature = "ptr_to_from_bits", issue = "91126")]
-    #[rustc_deprecated(since = "1.62", reason = "replaced by the `addr` method")]
+    #[rustc_deprecated(
+        since = "1.62",
+        reason = "replaced by the `exposed_addr` method, or update your code \
+            to follow the strict provenance rules using its APIs"
+    )]
     pub fn to_bits(self) -> usize
     where
         T: Sized,
@@ -149,7 +153,8 @@ impl<T: ?Sized> *mut T {
     #[unstable(feature = "ptr_to_from_bits", issue = "91126")]
     #[rustc_deprecated(
         since = "1.62",
-        reason = "replaced by the `with_addr` method or the `ptr::invalid_mut` function"
+        reason = "replaced by the `ptr::from_exposed_addr_mut` function, or \
+            update your code to follow the strict provenance rules using its APIs"
     )]
     #[allow(fuzzy_provenance_casts)] // this is an unstable and semi-deprecated cast function
     pub fn from_bits(bits: usize) -> Self

--- a/library/core/src/ptr/mut_ptr.rs
+++ b/library/core/src/ptr/mut_ptr.rs
@@ -125,6 +125,7 @@ impl<T: ?Sized> *mut T {
     /// assert_eq!(p1.to_bits() - p0.to_bits(), 4);
     /// ```
     #[unstable(feature = "ptr_to_from_bits", issue = "91126")]
+    #[rustc_deprecated(since = "1.62", reason = "replaced by the `addr` method")]
     pub fn to_bits(self) -> usize
     where
         T: Sized,
@@ -146,6 +147,10 @@ impl<T: ?Sized> *mut T {
     /// assert_eq!(<*mut u8>::from_bits(1), dangling);
     /// ```
     #[unstable(feature = "ptr_to_from_bits", issue = "91126")]
+    #[rustc_deprecated(
+        since = "1.62",
+        reason = "replaced by the `with_addr` method or the `ptr::invalid_mut` function"
+    )]
     #[allow(fuzzy_provenance_casts)] // this is an unstable and semi-deprecated cast function
     pub fn from_bits(bits: usize) -> Self
     where

--- a/library/core/src/ptr/mut_ptr.rs
+++ b/library/core/src/ptr/mut_ptr.rs
@@ -126,7 +126,7 @@ impl<T: ?Sized> *mut T {
     /// ```
     #[unstable(feature = "ptr_to_from_bits", issue = "91126")]
     #[rustc_deprecated(
-        since = "1.62",
+        since = "1.67",
         reason = "replaced by the `exposed_addr` method, or update your code \
             to follow the strict provenance rules using its APIs"
     )]
@@ -152,7 +152,7 @@ impl<T: ?Sized> *mut T {
     /// ```
     #[unstable(feature = "ptr_to_from_bits", issue = "91126")]
     #[rustc_deprecated(
-        since = "1.62",
+        since = "1.67",
         reason = "replaced by the `ptr::from_exposed_addr_mut` function, or \
             update your code to follow the strict provenance rules using its APIs"
     )]

--- a/library/core/src/ptr/mut_ptr.rs
+++ b/library/core/src/ptr/mut_ptr.rs
@@ -125,9 +125,9 @@ impl<T: ?Sized> *mut T {
     /// assert_eq!(p1.to_bits() - p0.to_bits(), 4);
     /// ```
     #[unstable(feature = "ptr_to_from_bits", issue = "91126")]
-    #[rustc_deprecated(
+    #[deprecated(
         since = "1.67",
-        reason = "replaced by the `exposed_addr` method, or update your code \
+        note = "replaced by the `exposed_addr` method, or update your code \
             to follow the strict provenance rules using its APIs"
     )]
     pub fn to_bits(self) -> usize
@@ -151,9 +151,9 @@ impl<T: ?Sized> *mut T {
     /// assert_eq!(<*mut u8>::from_bits(1), dangling);
     /// ```
     #[unstable(feature = "ptr_to_from_bits", issue = "91126")]
-    #[rustc_deprecated(
+    #[deprecated(
         since = "1.67",
-        reason = "replaced by the `ptr::from_exposed_addr_mut` function, or \
+        note = "replaced by the `ptr::from_exposed_addr_mut` function, or \
             update your code to follow the strict provenance rules using its APIs"
     )]
     #[allow(fuzzy_provenance_casts)] // this is an unstable and semi-deprecated cast function


### PR DESCRIPTION
I propose that we deprecate the (unstable!) `to_bits` and `from_bits` methods on raw pointers.  (With the intent to ~~remove them once `addr` has been around long enough to make the transition easy on people -- maybe another 6 weeks~~ remove them fairly soon after, as the strict and expose versions have been around for a while already.)

The APIs that came from the strict provenance explorations (#95228) are a more holistic version of these, and things like `.expose_addr()` work for the "that cast looks sketchy" case even if the full strict provenance stuff never happens.  (As a bonus, `addr` is even shorter than `to_bits`, though it is only applicable if people can use full strict provenance! `addr` is *not* a direct replacement for `to_bits`.)  So I think it's fine to move away from the `{to|from}_bits` methods, and encourage the others instead.

That also resolves the worry that was brought up (I forget where) that `q.to_bits()` and `(*q).to_bits()` both work if `q` is a pointer-to-floating-point, as they also have a `to_bits` method.

Tracking issue #91126
Code search: https://github.com/search?l=Rust&p=1&q=ptr_to_from_bits&type=Code

For potential pushback, some users in case they want to chime in
- @RSSchermer https://github.com/RSSchermer/ARWA/blob/365bb68541447453fc44f6fbcc5d394bb94c14e9/arwa/src/html/custom_element.rs#L105
- @strax https://github.com/strax/pbr/blob/99616d1dbf42f93ec8dd668d05b3180649558180/openexr/src/core/alloc.rs#L36
- @MiSawa https://github.com/MiSawa/pomelo/blob/577c6223588d539295a71ff125d8f249e59f4146/crates/kernel/src/timer.rs#L50
