### PR TITLE
Use revisions to track NLL test output (part 1)

### DIFF
--- a/src/test/ui/nll/issue-50716.base.stderr
+++ b/src/test/ui/nll/issue-50716.base.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/issue-50716.rs:14:9
+  --> $DIR/issue-50716.rs:18:9
    |
 LL |     let _x = *s;
    |         ^^ lifetime mismatch
@@ -7,7 +7,7 @@ LL |     let _x = *s;
    = note: expected type `<<&'a T as A>::X as Sized>`
               found type `<<&'static T as A>::X as Sized>`
 note: the lifetime `'a` as defined here...
-  --> $DIR/issue-50716.rs:9:8
+  --> $DIR/issue-50716.rs:13:8
    |
 LL | fn foo<'a, T: 'static>(s: Box<<&'a T as A>::X>)
    |        ^^

--- a/src/test/ui/nll/issue-50716.nll.stderr
+++ b/src/test/ui/nll/issue-50716.nll.stderr
@@ -1,5 +1,5 @@
 error: lifetime may not live long enough
-  --> $DIR/issue-50716.rs:14:14
+  --> $DIR/issue-50716.rs:18:14
    |
 LL | fn foo<'a, T: 'static>(s: Box<<&'a T as A>::X>)
    |        -- lifetime `'a` defined here

--- a/src/test/ui/nll/issue-50716.rs
+++ b/src/test/ui/nll/issue-50716.rs
@@ -2,6 +2,10 @@
 // Regression test for the issue #50716: NLL ignores lifetimes bounds
 // derived from `Sized` requirements
 
+// revisions: base nll
+// ignore-compare-mode-nll
+//[nll] compile-flags: -Z borrowck=mir
+
 trait A {
     type X: ?Sized;
 }

--- a/src/test/ui/nll/issue-52742.base.stderr
+++ b/src/test/ui/nll/issue-52742.base.stderr
@@ -1,16 +1,16 @@
 error[E0312]: lifetime of reference outlives lifetime of borrowed content...
-  --> $DIR/issue-52742.rs:12:18
+  --> $DIR/issue-52742.rs:17:18
    |
 LL |         self.y = b.z
    |                  ^^^
    |
 note: ...the reference is valid for the lifetime `'_` as defined here...
-  --> $DIR/issue-52742.rs:10:10
+  --> $DIR/issue-52742.rs:15:10
    |
 LL | impl Foo<'_, '_> {
    |          ^^
 note: ...but the borrowed content is only valid for the anonymous lifetime defined here
-  --> $DIR/issue-52742.rs:11:31
+  --> $DIR/issue-52742.rs:16:31
    |
 LL |     fn take_bar(&mut self, b: Bar<'_>) {
    |                               ^^^^^^^

--- a/src/test/ui/nll/issue-52742.nll.stderr
+++ b/src/test/ui/nll/issue-52742.nll.stderr
@@ -1,5 +1,5 @@
 error: lifetime may not live long enough
-  --> $DIR/issue-52742.rs:12:9
+  --> $DIR/issue-52742.rs:17:9
    |
 LL |     fn take_bar(&mut self, b: Bar<'_>) {
    |                 ---------         -- let's call this `'1`

--- a/src/test/ui/nll/issue-52742.rs
+++ b/src/test/ui/nll/issue-52742.rs
@@ -1,3 +1,8 @@
+// revisions: base nll
+// ignore-compare-mode-nll
+//[nll] compile-flags: -Z borrowck=mir
+
+
 struct Foo<'a, 'b> {
     x: &'a u32,
     y: &'b u32,

--- a/src/test/ui/nll/issue-55394.base.stderr
+++ b/src/test/ui/nll/issue-55394.base.stderr
@@ -1,26 +1,26 @@
 error[E0495]: cannot infer an appropriate lifetime for lifetime parameter `'s` due to conflicting requirements
-  --> $DIR/issue-55394.rs:9:9
+  --> $DIR/issue-55394.rs:13:9
    |
 LL |         Foo { bar }
    |         ^^^
    |
 note: first, the lifetime cannot outlive the anonymous lifetime defined here...
-  --> $DIR/issue-55394.rs:8:17
+  --> $DIR/issue-55394.rs:12:17
    |
 LL |     fn new(bar: &mut Bar) -> Self {
    |                 ^^^^^^^^
 note: ...so that reference does not outlive borrowed content
-  --> $DIR/issue-55394.rs:9:15
+  --> $DIR/issue-55394.rs:13:15
    |
 LL |         Foo { bar }
    |               ^^^
 note: but, the lifetime must be valid for the lifetime `'_` as defined here...
-  --> $DIR/issue-55394.rs:7:10
+  --> $DIR/issue-55394.rs:11:10
    |
 LL | impl Foo<'_> {
    |          ^^
 note: ...so that the types are compatible
-  --> $DIR/issue-55394.rs:9:9
+  --> $DIR/issue-55394.rs:13:9
    |
 LL |         Foo { bar }
    |         ^^^^^^^^^^^

--- a/src/test/ui/nll/issue-55394.nll.stderr
+++ b/src/test/ui/nll/issue-55394.nll.stderr
@@ -1,5 +1,5 @@
 error: lifetime may not live long enough
-  --> $DIR/issue-55394.rs:9:9
+  --> $DIR/issue-55394.rs:13:9
    |
 LL |     fn new(bar: &mut Bar) -> Self {
    |                 -            ---- return type is Foo<'2>

--- a/src/test/ui/nll/issue-55394.rs
+++ b/src/test/ui/nll/issue-55394.rs
@@ -1,3 +1,7 @@
+// revisions: base nll
+// ignore-compare-mode-nll
+//[nll] compile-flags: -Z borrowck=mir
+
 struct Bar;
 
 struct Foo<'s> {

--- a/src/test/ui/nll/issue-55401.base.stderr
+++ b/src/test/ui/nll/issue-55401.base.stderr
@@ -1,15 +1,15 @@
 error[E0312]: lifetime of reference outlives lifetime of borrowed content...
-  --> $DIR/constant-in-expr-trait-item-2.rs:10:5
+  --> $DIR/issue-55401.rs:7:5
    |
-LL |     <T as Foo<'a>>::C
-   |     ^^^^^^^^^^^^^^^^^
+LL |     *y
+   |     ^^
    |
    = note: ...the reference is valid for the static lifetime...
 note: ...but the borrowed content is only valid for the lifetime `'a` as defined here
-  --> $DIR/constant-in-expr-trait-item-2.rs:9:8
+  --> $DIR/issue-55401.rs:5:47
    |
-LL | fn foo<'a, T: Foo<'a>>() -> &'static u32 {
-   |        ^^
+LL | fn static_to_a_to_static_through_ref_in_tuple<'a>(x: &'a u32) -> &'static u32 {
+   |                                               ^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/issue-55401.nll.stderr
+++ b/src/test/ui/nll/issue-55401.nll.stderr
@@ -1,5 +1,5 @@
 error: lifetime may not live long enough
-  --> $DIR/issue-55401.rs:3:5
+  --> $DIR/issue-55401.rs:7:5
    |
 LL | fn static_to_a_to_static_through_ref_in_tuple<'a>(x: &'a u32) -> &'static u32 {
    |                                               -- lifetime `'a` defined here

--- a/src/test/ui/nll/issue-55401.rs
+++ b/src/test/ui/nll/issue-55401.rs
@@ -1,3 +1,7 @@
+// revisions: base nll
+// ignore-compare-mode-nll
+//[nll] compile-flags: -Z borrowck=mir
+
 fn static_to_a_to_static_through_ref_in_tuple<'a>(x: &'a u32) -> &'static u32 {
     let (ref y, _z): (&'a u32, u32) = (&22, 44);
     *y //~ ERROR

--- a/src/test/ui/nll/lub-if.base.stderr
+++ b/src/test/ui/nll/lub-if.base.stderr
@@ -1,25 +1,25 @@
 error[E0312]: lifetime of reference outlives lifetime of borrowed content...
-  --> $DIR/lub-if.rs:28:9
+  --> $DIR/lub-if.rs:32:9
    |
 LL |         s
    |         ^
    |
    = note: ...the reference is valid for the static lifetime...
 note: ...but the borrowed content is only valid for the lifetime `'a` as defined here
-  --> $DIR/lub-if.rs:23:17
+  --> $DIR/lub-if.rs:27:17
    |
 LL | pub fn opt_str2<'a>(maybestr: &'a Option<String>) -> &'static str {
    |                 ^^
 
 error[E0312]: lifetime of reference outlives lifetime of borrowed content...
-  --> $DIR/lub-if.rs:35:9
+  --> $DIR/lub-if.rs:41:9
    |
 LL |         s
    |         ^
    |
    = note: ...the reference is valid for the static lifetime...
 note: ...but the borrowed content is only valid for the lifetime `'a` as defined here
-  --> $DIR/lub-if.rs:32:17
+  --> $DIR/lub-if.rs:38:17
    |
 LL | pub fn opt_str3<'a>(maybestr: &'a Option<String>) -> &'static str {
    |                 ^^

--- a/src/test/ui/nll/lub-if.nll.stderr
+++ b/src/test/ui/nll/lub-if.nll.stderr
@@ -1,5 +1,5 @@
 error: lifetime may not live long enough
-  --> $DIR/lub-if.rs:28:9
+  --> $DIR/lub-if.rs:32:9
    |
 LL | pub fn opt_str2<'a>(maybestr: &'a Option<String>) -> &'static str {
    |                 -- lifetime `'a` defined here
@@ -8,7 +8,7 @@ LL |         s
    |         ^ returning this value requires that `'a` must outlive `'static`
 
 error: lifetime may not live long enough
-  --> $DIR/lub-if.rs:35:9
+  --> $DIR/lub-if.rs:41:9
    |
 LL | pub fn opt_str3<'a>(maybestr: &'a Option<String>) -> &'static str {
    |                 -- lifetime `'a` defined here

--- a/src/test/ui/nll/lub-if.rs
+++ b/src/test/ui/nll/lub-if.rs
@@ -2,6 +2,10 @@
 // of the various arms, particularly in the case where regions are
 // involved.
 
+// revisions: base nll
+// ignore-compare-mode-nll
+//[nll] compile-flags: -Z borrowck=mir
+
 pub fn opt_str0<'a>(maybestr: &'a Option<String>) -> &'a str {
     if maybestr.is_none() {
         "(none)"
@@ -25,14 +29,18 @@ pub fn opt_str2<'a>(maybestr: &'a Option<String>) -> &'static str {
         "(none)"
     } else {
         let s: &'a str = maybestr.as_ref().unwrap();
-        s  //~ ERROR E0312
+        s
+        //[base]~^ ERROR E0312
+        //[nll]~^^ ERROR lifetime may not live long enough
     }
 }
 
 pub fn opt_str3<'a>(maybestr: &'a Option<String>) -> &'static str {
     if maybestr.is_some() {
         let s: &'a str = maybestr.as_ref().unwrap();
-        s  //~ ERROR E0312
+        s
+        //[base]~^ ERROR E0312
+        //[nll]~^^ ERROR lifetime may not live long enough
     } else {
         "(none)"
     }

--- a/src/test/ui/nll/lub-match.base.stderr
+++ b/src/test/ui/nll/lub-match.base.stderr
@@ -1,25 +1,25 @@
 error[E0312]: lifetime of reference outlives lifetime of borrowed content...
-  --> $DIR/lub-match.rs:30:13
+  --> $DIR/lub-match.rs:34:13
    |
 LL |             s
    |             ^
    |
    = note: ...the reference is valid for the static lifetime...
 note: ...but the borrowed content is only valid for the lifetime `'a` as defined here
-  --> $DIR/lub-match.rs:25:17
+  --> $DIR/lub-match.rs:29:17
    |
 LL | pub fn opt_str2<'a>(maybestr: &'a Option<String>) -> &'static str {
    |                 ^^
 
 error[E0312]: lifetime of reference outlives lifetime of borrowed content...
-  --> $DIR/lub-match.rs:39:13
+  --> $DIR/lub-match.rs:45:13
    |
 LL |             s
    |             ^
    |
    = note: ...the reference is valid for the static lifetime...
 note: ...but the borrowed content is only valid for the lifetime `'a` as defined here
-  --> $DIR/lub-match.rs:35:17
+  --> $DIR/lub-match.rs:41:17
    |
 LL | pub fn opt_str3<'a>(maybestr: &'a Option<String>) -> &'static str {
    |                 ^^

--- a/src/test/ui/nll/lub-match.nll.stderr
+++ b/src/test/ui/nll/lub-match.nll.stderr
@@ -1,5 +1,5 @@
 error: lifetime may not live long enough
-  --> $DIR/lub-match.rs:30:13
+  --> $DIR/lub-match.rs:34:13
    |
 LL | pub fn opt_str2<'a>(maybestr: &'a Option<String>) -> &'static str {
    |                 -- lifetime `'a` defined here
@@ -8,7 +8,7 @@ LL |             s
    |             ^ returning this value requires that `'a` must outlive `'static`
 
 error: lifetime may not live long enough
-  --> $DIR/lub-match.rs:39:13
+  --> $DIR/lub-match.rs:45:13
    |
 LL | pub fn opt_str3<'a>(maybestr: &'a Option<String>) -> &'static str {
    |                 -- lifetime `'a` defined here

--- a/src/test/ui/nll/lub-match.rs
+++ b/src/test/ui/nll/lub-match.rs
@@ -2,6 +2,10 @@
 // of the various arms, particularly in the case where regions are
 // involved.
 
+// revisions: base nll
+// ignore-compare-mode-nll
+//[nll] compile-flags: -Z borrowck=mir
+
 pub fn opt_str0<'a>(maybestr: &'a Option<String>) -> &'a str {
     match *maybestr {
         Some(ref s) => {
@@ -27,7 +31,9 @@ pub fn opt_str2<'a>(maybestr: &'a Option<String>) -> &'static str {
         None => "(none)",
         Some(ref s) => {
             let s: &'a str = s;
-            s //~ ERROR E0312
+            s
+            //[base]~^ ERROR E0312
+            //[nll]~^^ ERROR lifetime may not live long enough
         }
     }
 }
@@ -36,7 +42,9 @@ pub fn opt_str3<'a>(maybestr: &'a Option<String>) -> &'static str {
     match *maybestr {
         Some(ref s) => {
             let s: &'a str = s;
-            s //~ ERROR E0312
+            s
+            //[base]~^ ERROR E0312
+            //[nll]~^^ ERROR lifetime may not live long enough
         }
         None => "(none)",
     }

--- a/src/test/ui/nll/type-alias-free-regions.base.stderr
+++ b/src/test/ui/nll/type-alias-free-regions.base.stderr
@@ -1,28 +1,28 @@
 error[E0495]: cannot infer an appropriate lifetime for lifetime parameter `'a` due to conflicting requirements
-  --> $DIR/type-alias-free-regions.rs:17:9
+  --> $DIR/type-alias-free-regions.rs:21:9
    |
 LL |         C { f: b }
    |         ^
    |
 note: first, the lifetime cannot outlive the anonymous lifetime defined here...
-  --> $DIR/type-alias-free-regions.rs:16:24
+  --> $DIR/type-alias-free-regions.rs:20:24
    |
 LL |     fn from_box(b: Box<B>) -> Self {
    |                        ^
 note: ...so that the expression is assignable
-  --> $DIR/type-alias-free-regions.rs:17:16
+  --> $DIR/type-alias-free-regions.rs:21:16
    |
 LL |         C { f: b }
    |                ^
    = note: expected `Box<Box<&isize>>`
               found `Box<Box<&isize>>`
 note: but, the lifetime must be valid for the lifetime `'a` as defined here...
-  --> $DIR/type-alias-free-regions.rs:15:6
+  --> $DIR/type-alias-free-regions.rs:19:6
    |
 LL | impl<'a> FromBox<'a> for C<'a> {
    |      ^^
 note: ...so that the types are compatible
-  --> $DIR/type-alias-free-regions.rs:17:9
+  --> $DIR/type-alias-free-regions.rs:21:9
    |
 LL |         C { f: b }
    |         ^^^^^^^^^^
@@ -30,30 +30,30 @@ LL |         C { f: b }
               found `C<'_>`
 
 error[E0495]: cannot infer an appropriate lifetime due to conflicting requirements
-  --> $DIR/type-alias-free-regions.rs:27:16
+  --> $DIR/type-alias-free-regions.rs:31:16
    |
 LL |         C { f: Box::new(b.0) }
    |                ^^^^^^^^^^^^^
    |
 note: first, the lifetime cannot outlive the anonymous lifetime defined here...
-  --> $DIR/type-alias-free-regions.rs:26:23
+  --> $DIR/type-alias-free-regions.rs:30:23
    |
 LL |     fn from_tuple(b: (B,)) -> Self {
    |                       ^
 note: ...so that the expression is assignable
-  --> $DIR/type-alias-free-regions.rs:27:25
+  --> $DIR/type-alias-free-regions.rs:31:25
    |
 LL |         C { f: Box::new(b.0) }
    |                         ^^^
    = note: expected `Box<&isize>`
               found `Box<&isize>`
 note: but, the lifetime must be valid for the lifetime `'a` as defined here...
-  --> $DIR/type-alias-free-regions.rs:25:6
+  --> $DIR/type-alias-free-regions.rs:29:6
    |
 LL | impl<'a> FromTuple<'a> for C<'a> {
    |      ^^
 note: ...so that the types are compatible
-  --> $DIR/type-alias-free-regions.rs:27:9
+  --> $DIR/type-alias-free-regions.rs:31:9
    |
 LL |         C { f: Box::new(b.0) }
    |         ^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/nll/type-alias-free-regions.nll.stderr
+++ b/src/test/ui/nll/type-alias-free-regions.nll.stderr
@@ -1,5 +1,5 @@
 error: lifetime may not live long enough
-  --> $DIR/type-alias-free-regions.rs:17:9
+  --> $DIR/type-alias-free-regions.rs:21:9
    |
 LL | impl<'a> FromBox<'a> for C<'a> {
    |      -- lifetime `'a` defined here
@@ -9,7 +9,7 @@ LL |         C { f: b }
    |         ^^^^^^^^^^ associated function was supposed to return data with lifetime `'a` but it is returning data with lifetime `'1`
 
 error: lifetime may not live long enough
-  --> $DIR/type-alias-free-regions.rs:27:9
+  --> $DIR/type-alias-free-regions.rs:31:9
    |
 LL | impl<'a> FromTuple<'a> for C<'a> {
    |      -- lifetime `'a` defined here

--- a/src/test/ui/nll/type-alias-free-regions.rs
+++ b/src/test/ui/nll/type-alias-free-regions.rs
@@ -1,6 +1,10 @@
 // Test that we don't assume that type aliases have the same type parameters
 // as the type they alias and then panic when we see this.
 
+// revisions: base nll
+// ignore-compare-mode-nll
+//[nll] compile-flags: -Z borrowck=mir
+
 type A<'a> = &'a isize;
 type B<'a> = Box<A<'a>>;
 

--- a/src/test/ui/nll/user-annotations/constant-in-expr-inherent-1.base.stderr
+++ b/src/test/ui/nll/user-annotations/constant-in-expr-inherent-1.base.stderr
@@ -1,5 +1,5 @@
 error[E0759]: `fn` parameter has lifetime `'a` but it needs to satisfy a `'static` lifetime requirement
-  --> $DIR/constant-in-expr-inherent-1.rs:8:5
+  --> $DIR/constant-in-expr-inherent-1.rs:12:5
    |
 LL | fn foo<'a>(_: &'a u32) -> &'static u32 {
    |               ------- this data with lifetime `'a`...

--- a/src/test/ui/nll/user-annotations/constant-in-expr-inherent-1.nll.stderr
+++ b/src/test/ui/nll/user-annotations/constant-in-expr-inherent-1.nll.stderr
@@ -1,5 +1,5 @@
 error: lifetime may not live long enough
-  --> $DIR/constant-in-expr-inherent-1.rs:8:5
+  --> $DIR/constant-in-expr-inherent-1.rs:12:5
    |
 LL | fn foo<'a>(_: &'a u32) -> &'static u32 {
    |        -- lifetime `'a` defined here

--- a/src/test/ui/nll/user-annotations/constant-in-expr-inherent-1.rs
+++ b/src/test/ui/nll/user-annotations/constant-in-expr-inherent-1.rs
@@ -1,3 +1,7 @@
+// revisions: base nll
+// ignore-compare-mode-nll
+//[nll] compile-flags: -Z borrowck=mir
+
 struct Foo<'a> { x: &'a u32 }
 
 impl<'a> Foo<'a> {

--- a/src/test/ui/nll/user-annotations/constant-in-expr-normalize.base.stderr
+++ b/src/test/ui/nll/user-annotations/constant-in-expr-normalize.base.stderr
@@ -1,12 +1,12 @@
 error[E0312]: lifetime of reference outlives lifetime of borrowed content...
-  --> $DIR/constant-in-expr-trait-item-1.rs:10:5
+  --> $DIR/constant-in-expr-normalize.rs:22:5
    |
 LL |     <() as Foo<'a>>::C
    |     ^^^^^^^^^^^^^^^^^^
    |
    = note: ...the reference is valid for the static lifetime...
 note: ...but the borrowed content is only valid for the lifetime `'a` as defined here
-  --> $DIR/constant-in-expr-trait-item-1.rs:9:8
+  --> $DIR/constant-in-expr-normalize.rs:21:8
    |
 LL | fn foo<'a>(_: &'a u32) -> &'static u32 {
    |        ^^

--- a/src/test/ui/nll/user-annotations/constant-in-expr-normalize.nll.stderr
+++ b/src/test/ui/nll/user-annotations/constant-in-expr-normalize.nll.stderr
@@ -1,5 +1,5 @@
 error: lifetime may not live long enough
-  --> $DIR/constant-in-expr-normalize.rs:18:5
+  --> $DIR/constant-in-expr-normalize.rs:22:5
    |
 LL | fn foo<'a>(_: &'a u32) -> &'static u32 {
    |        -- lifetime `'a` defined here

--- a/src/test/ui/nll/user-annotations/constant-in-expr-normalize.rs
+++ b/src/test/ui/nll/user-annotations/constant-in-expr-normalize.rs
@@ -1,3 +1,7 @@
+// revisions: base nll
+// ignore-compare-mode-nll
+//[nll] compile-flags: -Z borrowck=mir
+
 trait Mirror {
     type Me;
 }

--- a/src/test/ui/nll/user-annotations/constant-in-expr-trait-item-1.base.stderr
+++ b/src/test/ui/nll/user-annotations/constant-in-expr-trait-item-1.base.stderr
@@ -1,15 +1,15 @@
 error[E0312]: lifetime of reference outlives lifetime of borrowed content...
-  --> $DIR/issue-55401.rs:3:5
+  --> $DIR/constant-in-expr-trait-item-1.rs:14:5
    |
-LL |     *y
-   |     ^^
+LL |     <() as Foo<'a>>::C
+   |     ^^^^^^^^^^^^^^^^^^
    |
    = note: ...the reference is valid for the static lifetime...
 note: ...but the borrowed content is only valid for the lifetime `'a` as defined here
-  --> $DIR/issue-55401.rs:1:47
+  --> $DIR/constant-in-expr-trait-item-1.rs:13:8
    |
-LL | fn static_to_a_to_static_through_ref_in_tuple<'a>(x: &'a u32) -> &'static u32 {
-   |                                               ^^
+LL | fn foo<'a>(_: &'a u32) -> &'static u32 {
+   |        ^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/nll/user-annotations/constant-in-expr-trait-item-1.nll.stderr
+++ b/src/test/ui/nll/user-annotations/constant-in-expr-trait-item-1.nll.stderr
@@ -1,5 +1,5 @@
 error: lifetime may not live long enough
-  --> $DIR/constant-in-expr-trait-item-1.rs:10:5
+  --> $DIR/constant-in-expr-trait-item-1.rs:14:5
    |
 LL | fn foo<'a>(_: &'a u32) -> &'static u32 {
    |        -- lifetime `'a` defined here

--- a/src/test/ui/nll/user-annotations/constant-in-expr-trait-item-1.rs
+++ b/src/test/ui/nll/user-annotations/constant-in-expr-trait-item-1.rs
@@ -1,3 +1,7 @@
+// revisions: base nll
+// ignore-compare-mode-nll
+//[nll] compile-flags: -Z borrowck=mir
+
 trait Foo<'a> {
     const C: &'a u32;
 }

--- a/src/test/ui/nll/user-annotations/constant-in-expr-trait-item-2.base.stderr
+++ b/src/test/ui/nll/user-annotations/constant-in-expr-trait-item-2.base.stderr
@@ -1,14 +1,14 @@
 error[E0312]: lifetime of reference outlives lifetime of borrowed content...
-  --> $DIR/constant-in-expr-normalize.rs:18:5
+  --> $DIR/constant-in-expr-trait-item-2.rs:14:5
    |
-LL |     <() as Foo<'a>>::C
-   |     ^^^^^^^^^^^^^^^^^^
+LL |     <T as Foo<'a>>::C
+   |     ^^^^^^^^^^^^^^^^^
    |
    = note: ...the reference is valid for the static lifetime...
 note: ...but the borrowed content is only valid for the lifetime `'a` as defined here
-  --> $DIR/constant-in-expr-normalize.rs:17:8
+  --> $DIR/constant-in-expr-trait-item-2.rs:13:8
    |
-LL | fn foo<'a>(_: &'a u32) -> &'static u32 {
+LL | fn foo<'a, T: Foo<'a>>() -> &'static u32 {
    |        ^^
 
 error: aborting due to previous error

--- a/src/test/ui/nll/user-annotations/constant-in-expr-trait-item-2.nll.stderr
+++ b/src/test/ui/nll/user-annotations/constant-in-expr-trait-item-2.nll.stderr
@@ -1,5 +1,5 @@
 error: lifetime may not live long enough
-  --> $DIR/constant-in-expr-trait-item-2.rs:10:5
+  --> $DIR/constant-in-expr-trait-item-2.rs:14:5
    |
 LL | fn foo<'a, T: Foo<'a>>() -> &'static u32 {
    |        -- lifetime `'a` defined here

--- a/src/test/ui/nll/user-annotations/constant-in-expr-trait-item-2.rs
+++ b/src/test/ui/nll/user-annotations/constant-in-expr-trait-item-2.rs
@@ -1,3 +1,7 @@
+// revisions: base nll
+// ignore-compare-mode-nll
+//[nll] compile-flags: -Z borrowck=mir
+
 trait Foo<'a> {
     const C: &'a u32;
 }

--- a/src/test/ui/nll/user-annotations/constant-in-expr-trait-item-3.base.stderr
+++ b/src/test/ui/nll/user-annotations/constant-in-expr-trait-item-3.base.stderr
@@ -1,16 +1,16 @@
 error[E0495]: cannot infer an appropriate lifetime for lifetime parameter `'a` due to conflicting requirements
-  --> $DIR/constant-in-expr-trait-item-3.rs:10:5
+  --> $DIR/constant-in-expr-trait-item-3.rs:14:5
    |
 LL |     T::C
    |     ^^^^
    |
 note: first, the lifetime cannot outlive the lifetime `'a` as defined here...
-  --> $DIR/constant-in-expr-trait-item-3.rs:9:8
+  --> $DIR/constant-in-expr-trait-item-3.rs:13:8
    |
 LL | fn foo<'a, T: Foo<'a>>() -> &'static u32 {
    |        ^^
 note: ...so that the types are compatible
-  --> $DIR/constant-in-expr-trait-item-3.rs:10:5
+  --> $DIR/constant-in-expr-trait-item-3.rs:14:5
    |
 LL |     T::C
    |     ^^^^
@@ -18,7 +18,7 @@ LL |     T::C
               found `Foo<'a>`
    = note: but, the lifetime must be valid for the static lifetime...
 note: ...so that reference does not outlive borrowed content
-  --> $DIR/constant-in-expr-trait-item-3.rs:10:5
+  --> $DIR/constant-in-expr-trait-item-3.rs:14:5
    |
 LL |     T::C
    |     ^^^^

--- a/src/test/ui/nll/user-annotations/constant-in-expr-trait-item-3.nll.stderr
+++ b/src/test/ui/nll/user-annotations/constant-in-expr-trait-item-3.nll.stderr
@@ -1,5 +1,5 @@
 error: lifetime may not live long enough
-  --> $DIR/constant-in-expr-trait-item-3.rs:10:5
+  --> $DIR/constant-in-expr-trait-item-3.rs:14:5
    |
 LL | fn foo<'a, T: Foo<'a>>() -> &'static u32 {
    |        -- lifetime `'a` defined here

--- a/src/test/ui/nll/user-annotations/constant-in-expr-trait-item-3.rs
+++ b/src/test/ui/nll/user-annotations/constant-in-expr-trait-item-3.rs
@@ -1,3 +1,7 @@
+// revisions: base nll
+// ignore-compare-mode-nll
+//[nll] compile-flags: -Z borrowck=mir
+
 trait Foo<'a> {
     const C: &'a u32;
 }

--- a/src/test/ui/rfc1623.base.stderr
+++ b/src/test/ui/rfc1623.base.stderr
@@ -1,5 +1,5 @@
 error: implementation of `FnOnce` is not general enough
-  --> $DIR/rfc1623.rs:28:8
+  --> $DIR/rfc1623.rs:36:8
    |
 LL |     f: &id,
    |        ^^^ implementation of `FnOnce` is not general enough

--- a/src/test/ui/rfc1623.nll.stderr
+++ b/src/test/ui/rfc1623.nll.stderr
@@ -1,11 +1,12 @@
 error[E0308]: mismatched types
-  --> $DIR/rfc1623.rs:25:35
+  --> $DIR/rfc1623.rs:29:35
    |
 LL |   static SOME_STRUCT: &SomeStruct = &SomeStruct {
    |  ___________________________________^
-LL | |     foo: &Foo { bools: &[false, true] },
-LL | |     bar: &Bar { bools: &[true, true] },
-LL | |     f: &id,
+LL | |
+LL | |
+LL | |
+...  |
 LL | |
 LL | | };
    | |_^ one type is more general than the other
@@ -14,13 +15,14 @@ LL | | };
               found type `Fn<(&Foo<'_>,)>`
 
 error[E0308]: mismatched types
-  --> $DIR/rfc1623.rs:25:35
+  --> $DIR/rfc1623.rs:29:35
    |
 LL |   static SOME_STRUCT: &SomeStruct = &SomeStruct {
    |  ___________________________________^
-LL | |     foo: &Foo { bools: &[false, true] },
-LL | |     bar: &Bar { bools: &[true, true] },
-LL | |     f: &id,
+LL | |
+LL | |
+LL | |
+...  |
 LL | |
 LL | | };
    | |_^ one type is more general than the other
@@ -29,13 +31,14 @@ LL | | };
               found type `Fn<(&Foo<'_>,)>`
 
 error: implementation of `FnOnce` is not general enough
-  --> $DIR/rfc1623.rs:25:35
+  --> $DIR/rfc1623.rs:29:35
    |
 LL |   static SOME_STRUCT: &SomeStruct = &SomeStruct {
    |  ___________________________________^
-LL | |     foo: &Foo { bools: &[false, true] },
-LL | |     bar: &Bar { bools: &[true, true] },
-LL | |     f: &id,
+LL | |
+LL | |
+LL | |
+...  |
 LL | |
 LL | | };
    | |_^ implementation of `FnOnce` is not general enough
@@ -44,13 +47,14 @@ LL | | };
    = note: ...but it actually implements `FnOnce<(&'2 Foo<'_>,)>`, for some specific lifetime `'2`
 
 error: implementation of `FnOnce` is not general enough
-  --> $DIR/rfc1623.rs:25:35
+  --> $DIR/rfc1623.rs:29:35
    |
 LL |   static SOME_STRUCT: &SomeStruct = &SomeStruct {
    |  ___________________________________^
-LL | |     foo: &Foo { bools: &[false, true] },
-LL | |     bar: &Bar { bools: &[true, true] },
-LL | |     f: &id,
+LL | |
+LL | |
+LL | |
+...  |
 LL | |
 LL | | };
    | |_^ implementation of `FnOnce` is not general enough

--- a/src/test/ui/rfc1623.rs
+++ b/src/test/ui/rfc1623.rs
@@ -1,3 +1,7 @@
+// revisions: base nll
+// ignore-compare-mode-nll
+//[nll] compile-flags: -Z borrowck=mir
+
 #![allow(dead_code)]
 
 fn non_elidable<'a, 'b>(a: &'a u8, b: &'b u8) -> &'a u8 {
@@ -23,10 +27,14 @@ fn id<T>(t: T) -> T {
 }
 
 static SOME_STRUCT: &SomeStruct = &SomeStruct {
+    //[nll]~^ ERROR mismatched types
+    //[nll]~| ERROR mismatched types
+    //[nll]~| ERROR implementation of `FnOnce` is not general enough
+    //[nll]~| ERROR implementation of `FnOnce` is not general enough
     foo: &Foo { bools: &[false, true] },
     bar: &Bar { bools: &[true, true] },
     f: &id,
-    //~^ ERROR implementation of `FnOnce` is not general enough
+    //[base]~^ ERROR implementation of `FnOnce` is not general enough
 };
 
 // very simple test for a 'static static with default lifetime

--- a/src/test/ui/type-alias-impl-trait/generic_type_does_not_live_long_enough.base.stderr
+++ b/src/test/ui/type-alias-impl-trait/generic_type_does_not_live_long_enough.base.stderr
@@ -1,23 +1,23 @@
 error: at least one trait must be specified
-  --> $DIR/generic_type_does_not_live_long_enough.rs:10:24
+  --> $DIR/generic_type_does_not_live_long_enough.rs:14:24
    |
 LL | type WrongGeneric<T> = impl 'static;
    |                        ^^^^^^^^^^^^
 
 error: non-defining opaque type use in defining scope
-  --> $DIR/generic_type_does_not_live_long_enough.rs:6:18
+  --> $DIR/generic_type_does_not_live_long_enough.rs:10:18
    |
 LL |     let z: i32 = x;
    |                  ^
    |
 note: used non-generic type `&'static i32` for generic parameter
-  --> $DIR/generic_type_does_not_live_long_enough.rs:10:19
+  --> $DIR/generic_type_does_not_live_long_enough.rs:14:19
    |
 LL | type WrongGeneric<T> = impl 'static;
    |                   ^
 
 error[E0310]: the parameter type `T` may not live long enough
-  --> $DIR/generic_type_does_not_live_long_enough.rs:14:5
+  --> $DIR/generic_type_does_not_live_long_enough.rs:18:5
    |
 LL | fn wrong_generic<T>(t: T) -> WrongGeneric<T> {
    |                  - help: consider adding an explicit lifetime bound...: `T: 'static`

--- a/src/test/ui/type-alias-impl-trait/generic_type_does_not_live_long_enough.nll.stderr
+++ b/src/test/ui/type-alias-impl-trait/generic_type_does_not_live_long_enough.nll.stderr
@@ -1,23 +1,23 @@
 error: at least one trait must be specified
-  --> $DIR/generic_type_does_not_live_long_enough.rs:10:24
+  --> $DIR/generic_type_does_not_live_long_enough.rs:14:24
    |
 LL | type WrongGeneric<T> = impl 'static;
    |                        ^^^^^^^^^^^^
 
 error: non-defining opaque type use in defining scope
-  --> $DIR/generic_type_does_not_live_long_enough.rs:6:18
+  --> $DIR/generic_type_does_not_live_long_enough.rs:10:18
    |
 LL |     let z: i32 = x;
    |                  ^
    |
 note: used non-generic type `&'static i32` for generic parameter
-  --> $DIR/generic_type_does_not_live_long_enough.rs:10:19
+  --> $DIR/generic_type_does_not_live_long_enough.rs:14:19
    |
 LL | type WrongGeneric<T> = impl 'static;
    |                   ^
 
 error[E0310]: the parameter type `T` may not live long enough
-  --> $DIR/generic_type_does_not_live_long_enough.rs:14:5
+  --> $DIR/generic_type_does_not_live_long_enough.rs:18:5
    |
 LL |     t
    |     ^

--- a/src/test/ui/type-alias-impl-trait/generic_type_does_not_live_long_enough.rs
+++ b/src/test/ui/type-alias-impl-trait/generic_type_does_not_live_long_enough.rs
@@ -1,5 +1,9 @@
 #![feature(type_alias_impl_trait)]
 
+// revisions: base nll
+// ignore-compare-mode-nll
+//[nll] compile-flags: -Z borrowck=mir
+
 fn main() {
     let y = 42;
     let x = wrong_generic(&y);

--- a/src/test/ui/type-alias-impl-trait/issue-57611-trait-alias.base.stderr
+++ b/src/test/ui/type-alias-impl-trait/issue-57611-trait-alias.base.stderr
@@ -1,5 +1,5 @@
 error: implementation of `FnOnce` is not general enough
-  --> $DIR/issue-57611-trait-alias.rs:20:9
+  --> $DIR/issue-57611-trait-alias.rs:25:9
    |
 LL |         |x| x
    |         ^^^^^ implementation of `FnOnce` is not general enough

--- a/src/test/ui/type-alias-impl-trait/issue-57611-trait-alias.nll.stderr
+++ b/src/test/ui/type-alias-impl-trait/issue-57611-trait-alias.nll.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/issue-57611-trait-alias.rs:20:9
+  --> $DIR/issue-57611-trait-alias.rs:25:9
    |
 LL |         |x| x
    |         ^^^^^ one type is more general than the other
@@ -7,13 +7,13 @@ LL |         |x| x
    = note: expected type `for<'r> Fn<(&'r X,)>`
               found type `Fn<(&X,)>`
 note: this closure does not fulfill the lifetime requirements
-  --> $DIR/issue-57611-trait-alias.rs:20:9
+  --> $DIR/issue-57611-trait-alias.rs:25:9
    |
 LL |         |x| x
    |         ^^^^^
 
 error: implementation of `FnOnce` is not general enough
-  --> $DIR/issue-57611-trait-alias.rs:20:9
+  --> $DIR/issue-57611-trait-alias.rs:25:9
    |
 LL |         |x| x
    |         ^^^^^ implementation of `FnOnce` is not general enough

--- a/src/test/ui/type-alias-impl-trait/issue-57611-trait-alias.rs
+++ b/src/test/ui/type-alias-impl-trait/issue-57611-trait-alias.rs
@@ -1,6 +1,11 @@
 // Regression test for issue #57611
 // Ensures that we don't ICE
 // FIXME: This should compile, but it currently doesn't
+// known-bug
+
+// revisions: base nll
+// ignore-compare-mode-nll
+//[nll] compile-flags: -Z borrowck=mir
 
 #![feature(trait_alias)]
 #![feature(type_alias_impl_trait)]
@@ -18,7 +23,6 @@ impl Foo for X {
 
     fn bar(&self) -> Self::Bar {
         |x| x
-        //~^ ERROR implementation of `FnOnce` is not general enough
     }
 }
 

--- a/src/test/ui/unboxed-closures/issue-30906.base.stderr
+++ b/src/test/ui/unboxed-closures/issue-30906.base.stderr
@@ -1,5 +1,5 @@
 error: implementation of `FnOnce` is not general enough
-  --> $DIR/issue-30906.rs:18:5
+  --> $DIR/issue-30906.rs:22:5
    |
 LL |     test(Compose(f, |_| {}));
    |     ^^^^ implementation of `FnOnce` is not general enough

--- a/src/test/ui/unboxed-closures/issue-30906.nll.stderr
+++ b/src/test/ui/unboxed-closures/issue-30906.nll.stderr
@@ -1,5 +1,5 @@
 error: implementation of `FnOnce` is not general enough
-  --> $DIR/issue-30906.rs:18:5
+  --> $DIR/issue-30906.rs:22:5
    |
 LL |     test(Compose(f, |_| {}));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^ implementation of `FnOnce` is not general enough

--- a/src/test/ui/unboxed-closures/issue-30906.rs
+++ b/src/test/ui/unboxed-closures/issue-30906.rs
@@ -1,5 +1,9 @@
 #![feature(fn_traits, unboxed_closures)]
 
+// revisions: base nll
+// ignore-compare-mode-nll
+//[nll] compile-flags: -Z borrowck=mir
+
 fn test<F: for<'x> FnOnce<(&'x str,)>>(_: F) {}
 
 struct Compose<F, G>(F, G);

--- a/src/test/ui/unboxed-closures/unboxed-closures-infer-argument-types-two-region-pointers.base.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closures-infer-argument-types-two-region-pointers.base.stderr
@@ -1,23 +1,27 @@
 error[E0312]: lifetime of reference outlives lifetime of borrowed content...
-  --> $DIR/unboxed-closures-infer-argument-types-two-region-pointers.rs:17:15
+  --> $DIR/unboxed-closures-infer-argument-types-two-region-pointers.rs:21:15
    |
 LL |         x.set(y);
    |               ^
    |
 note: ...the reference is valid for the anonymous lifetime #2 defined here...
-  --> $DIR/unboxed-closures-infer-argument-types-two-region-pointers.rs:16:14
+  --> $DIR/unboxed-closures-infer-argument-types-two-region-pointers.rs:20:14
    |
 LL |       doit(0, &|x, y| {
    |  ______________^
 LL | |         x.set(y);
+LL | |
+LL | |
 LL | |     });
    | |_____^
 note: ...but the borrowed content is only valid for the anonymous lifetime #3 defined here
-  --> $DIR/unboxed-closures-infer-argument-types-two-region-pointers.rs:16:14
+  --> $DIR/unboxed-closures-infer-argument-types-two-region-pointers.rs:20:14
    |
 LL |       doit(0, &|x, y| {
    |  ______________^
 LL | |         x.set(y);
+LL | |
+LL | |
 LL | |     });
    | |_____^
 

--- a/src/test/ui/unboxed-closures/unboxed-closures-infer-argument-types-two-region-pointers.nll.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closures-infer-argument-types-two-region-pointers.nll.stderr
@@ -1,5 +1,5 @@
 error: lifetime may not live long enough
-  --> $DIR/unboxed-closures-infer-argument-types-two-region-pointers.rs:17:9
+  --> $DIR/unboxed-closures-infer-argument-types-two-region-pointers.rs:21:9
    |
 LL |     doit(0, &|x, y| {
    |               -  - has type `&'1 i32`

--- a/src/test/ui/unboxed-closures/unboxed-closures-infer-argument-types-two-region-pointers.rs
+++ b/src/test/ui/unboxed-closures/unboxed-closures-infer-argument-types-two-region-pointers.rs
@@ -3,6 +3,10 @@
 // That a closure whose expected argument types include two distinct
 // bound regions.
 
+// revisions: base nll
+// ignore-compare-mode-nll
+//[nll] compile-flags: -Z borrowck=mir
+
 use std::cell::Cell;
 
 fn doit<T,F>(val: T, f: &F)
@@ -14,6 +18,8 @@ fn doit<T,F>(val: T, f: &F)
 
 pub fn main() {
     doit(0, &|x, y| {
-        x.set(y); //~ ERROR E0312
+        x.set(y);
+        //[base]~^ ERROR E0312
+        //[nll]~^^ lifetime may not live long enough
     });
 }

--- a/src/test/ui/underscore-lifetime/dyn-trait-underscore.base.stderr
+++ b/src/test/ui/underscore-lifetime/dyn-trait-underscore.base.stderr
@@ -1,5 +1,5 @@
 error[E0759]: `items` has an anonymous lifetime `'_` but it needs to satisfy a `'static` lifetime requirement
-  --> $DIR/dyn-trait-underscore.rs:8:20
+  --> $DIR/dyn-trait-underscore.rs:12:20
    |
 LL | fn a<T>(items: &[T]) -> Box<dyn Iterator<Item=&T>> {
    |                ---- this data with an anonymous lifetime `'_`...
@@ -10,7 +10,7 @@ LL |     Box::new(items.iter())
    |              ...is used and required to live as long as `'static` here
    |
 note: `'static` lifetime requirement introduced by the return type
-  --> $DIR/dyn-trait-underscore.rs:6:29
+  --> $DIR/dyn-trait-underscore.rs:10:29
    |
 LL | fn a<T>(items: &[T]) -> Box<dyn Iterator<Item=&T>> {
    |                             ^^^^^^^^^^^^^^^^^^^^^ `'static` requirement introduced here

--- a/src/test/ui/underscore-lifetime/dyn-trait-underscore.nll.stderr
+++ b/src/test/ui/underscore-lifetime/dyn-trait-underscore.nll.stderr
@@ -1,5 +1,5 @@
 error: lifetime may not live long enough
-  --> $DIR/dyn-trait-underscore.rs:8:5
+  --> $DIR/dyn-trait-underscore.rs:12:5
    |
 LL | fn a<T>(items: &[T]) -> Box<dyn Iterator<Item=&T>> {
    |                - let's call the lifetime of this reference `'1`

--- a/src/test/ui/underscore-lifetime/dyn-trait-underscore.rs
+++ b/src/test/ui/underscore-lifetime/dyn-trait-underscore.rs
@@ -3,9 +3,15 @@
 //
 // cc #48468
 
+// revisions: base nll
+// ignore-compare-mode-nll
+//[nll] compile-flags: -Z borrowck=mir
+
 fn a<T>(items: &[T]) -> Box<dyn Iterator<Item=&T>> {
     //                      ^^^^^^^^^^^^^^^^^^^^^ bound *here* defaults to `'static`
-    Box::new(items.iter()) //~ ERROR E0759
+    Box::new(items.iter())
+    //[base]~^ ERROR E0759
+    //[nll]~^^ ERROR lifetime may not live long enough
 }
 
 fn b<T>(items: &[T]) -> Box<dyn Iterator<Item=&T> + '_> {

--- a/src/test/ui/underscore-lifetime/underscore-lifetime-elison-mismatch.base.stderr
+++ b/src/test/ui/underscore-lifetime/underscore-lifetime-elison-mismatch.base.stderr
@@ -1,5 +1,5 @@
 error[E0623]: lifetime mismatch
-  --> $DIR/underscore-lifetime-elison-mismatch.rs:1:49
+  --> $DIR/underscore-lifetime-elison-mismatch.rs:5:49
    |
 LL | fn foo(x: &mut Vec<&'_ u8>, y: &'_ u8) { x.push(y); }
    |                    ------      ------           ^ ...but data from `y` flows into `x` here

--- a/src/test/ui/underscore-lifetime/underscore-lifetime-elison-mismatch.nll.stderr
+++ b/src/test/ui/underscore-lifetime/underscore-lifetime-elison-mismatch.nll.stderr
@@ -1,5 +1,5 @@
 error: lifetime may not live long enough
-  --> $DIR/underscore-lifetime-elison-mismatch.rs:1:42
+  --> $DIR/underscore-lifetime-elison-mismatch.rs:5:42
    |
 LL | fn foo(x: &mut Vec<&'_ u8>, y: &'_ u8) { x.push(y); }
    |                    -           -         ^^^^^^^^^ argument requires that `'1` must outlive `'2`

--- a/src/test/ui/underscore-lifetime/underscore-lifetime-elison-mismatch.rs
+++ b/src/test/ui/underscore-lifetime/underscore-lifetime-elison-mismatch.rs
@@ -1,3 +1,9 @@
-fn foo(x: &mut Vec<&'_ u8>, y: &'_ u8) { x.push(y); } //~ ERROR lifetime mismatch
+// revisions: base nll
+// ignore-compare-mode-nll
+//[nll] compile-flags: -Z borrowck=mir
+
+fn foo(x: &mut Vec<&'_ u8>, y: &'_ u8) { x.push(y); }
+//[base]~^ ERROR lifetime mismatch
+//[nll]~^^ ERROR lifetime may not live long enough
 
 fn main() {}

--- a/src/test/ui/variance/variance-associated-types2.base.stderr
+++ b/src/test/ui/variance/variance-associated-types2.base.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/variance-associated-types2.rs:13:42
+  --> $DIR/variance-associated-types2.rs:17:42
    |
 LL |     let _: Box<dyn Foo<Bar = &'a u32>> = make();
    |                                          ^^^^^^ lifetime mismatch
@@ -7,7 +7,7 @@ LL |     let _: Box<dyn Foo<Bar = &'a u32>> = make();
    = note: expected trait object `dyn Foo<Bar = &'a u32>`
               found trait object `dyn Foo<Bar = &'static u32>`
 note: the lifetime `'a` as defined here...
-  --> $DIR/variance-associated-types2.rs:12:9
+  --> $DIR/variance-associated-types2.rs:16:9
    |
 LL | fn take<'a>(_: &'a u32) {
    |         ^^

--- a/src/test/ui/variance/variance-associated-types2.nll.stderr
+++ b/src/test/ui/variance/variance-associated-types2.nll.stderr
@@ -1,5 +1,5 @@
 error: lifetime may not live long enough
-  --> $DIR/variance-associated-types2.rs:13:12
+  --> $DIR/variance-associated-types2.rs:17:12
    |
 LL | fn take<'a>(_: &'a u32) {
    |         -- lifetime `'a` defined here

--- a/src/test/ui/variance/variance-associated-types2.rs
+++ b/src/test/ui/variance/variance-associated-types2.rs
@@ -1,6 +1,10 @@
 // Test that dyn Foo<Bar = T> is invariant with respect to T.
 // Failure to enforce invariance here can be weaponized, see #71550 for details.
 
+// revisions: base nll
+// ignore-compare-mode-nll
+//[nll] compile-flags: -Z borrowck=mir
+
 trait Foo {
     type Bar;
 }
@@ -11,7 +15,8 @@ fn make() -> Box<dyn Foo<Bar = &'static u32>> {
 
 fn take<'a>(_: &'a u32) {
     let _: Box<dyn Foo<Bar = &'a u32>> = make();
-    //~^ ERROR mismatched types [E0308]
+    //[base]~^ ERROR mismatched types [E0308]
+    //[nll]~^^ ERROR lifetime may not live long enough
 }
 
 fn main() {}

--- a/src/test/ui/variance/variance-btree-invariant-types.base.stderr
+++ b/src/test/ui/variance/variance-btree-invariant-types.base.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/variance-btree-invariant-types.rs:4:5
+  --> $DIR/variance-btree-invariant-types.rs:8:5
    |
 LL |     v
    |     ^ lifetime mismatch
@@ -7,40 +7,10 @@ LL |     v
    = note: expected struct `std::collections::btree_map::IterMut<'_, &'new (), _>`
               found struct `std::collections::btree_map::IterMut<'_, &'static (), _>`
 note: the lifetime `'new` as defined here...
-  --> $DIR/variance-btree-invariant-types.rs:3:21
+  --> $DIR/variance-btree-invariant-types.rs:7:21
    |
 LL | fn iter_cov_key<'a, 'new>(v: IterMut<'a, &'static (), ()>) -> IterMut<'a, &'new (), ()> {
    |                     ^^^^
-   = note: ...does not necessarily outlive the static lifetime
-
-error[E0308]: mismatched types
-  --> $DIR/variance-btree-invariant-types.rs:7:5
-   |
-LL |     v
-   |     ^ lifetime mismatch
-   |
-   = note: expected struct `std::collections::btree_map::IterMut<'_, _, &'new ()>`
-              found struct `std::collections::btree_map::IterMut<'_, _, &'static ()>`
-note: the lifetime `'new` as defined here...
-  --> $DIR/variance-btree-invariant-types.rs:6:21
-   |
-LL | fn iter_cov_val<'a, 'new>(v: IterMut<'a, (), &'static ()>) -> IterMut<'a, (), &'new ()> {
-   |                     ^^^^
-   = note: ...does not necessarily outlive the static lifetime
-
-error[E0308]: mismatched types
-  --> $DIR/variance-btree-invariant-types.rs:10:5
-   |
-LL |     v
-   |     ^ lifetime mismatch
-   |
-   = note: expected struct `std::collections::btree_map::IterMut<'_, &'static (), _>`
-              found struct `std::collections::btree_map::IterMut<'_, &'new (), _>`
-note: the lifetime `'new` as defined here...
-  --> $DIR/variance-btree-invariant-types.rs:9:24
-   |
-LL | fn iter_contra_key<'a, 'new>(v: IterMut<'a, &'new (), ()>) -> IterMut<'a, &'static (), ()> {
-   |                        ^^^^
    = note: ...does not necessarily outlive the static lifetime
 
 error[E0308]: mismatched types
@@ -49,43 +19,28 @@ error[E0308]: mismatched types
 LL |     v
    |     ^ lifetime mismatch
    |
-   = note: expected struct `std::collections::btree_map::IterMut<'_, _, &'static ()>`
-              found struct `std::collections::btree_map::IterMut<'_, _, &'new ()>`
+   = note: expected struct `std::collections::btree_map::IterMut<'_, _, &'new ()>`
+              found struct `std::collections::btree_map::IterMut<'_, _, &'static ()>`
 note: the lifetime `'new` as defined here...
-  --> $DIR/variance-btree-invariant-types.rs:12:24
+  --> $DIR/variance-btree-invariant-types.rs:12:21
    |
-LL | fn iter_contra_val<'a, 'new>(v: IterMut<'a, (), &'new ()>) -> IterMut<'a, (), &'static ()> {
+LL | fn iter_cov_val<'a, 'new>(v: IterMut<'a, (), &'static ()>) -> IterMut<'a, (), &'new ()> {
+   |                     ^^^^
+   = note: ...does not necessarily outlive the static lifetime
+
+error[E0308]: mismatched types
+  --> $DIR/variance-btree-invariant-types.rs:18:5
+   |
+LL |     v
+   |     ^ lifetime mismatch
+   |
+   = note: expected struct `std::collections::btree_map::IterMut<'_, &'static (), _>`
+              found struct `std::collections::btree_map::IterMut<'_, &'new (), _>`
+note: the lifetime `'new` as defined here...
+  --> $DIR/variance-btree-invariant-types.rs:17:24
+   |
+LL | fn iter_contra_key<'a, 'new>(v: IterMut<'a, &'new (), ()>) -> IterMut<'a, &'static (), ()> {
    |                        ^^^^
-   = note: ...does not necessarily outlive the static lifetime
-
-error[E0308]: mismatched types
-  --> $DIR/variance-btree-invariant-types.rs:17:5
-   |
-LL |     v
-   |     ^ lifetime mismatch
-   |
-   = note: expected struct `RangeMut<'_, &'new (), _>`
-              found struct `RangeMut<'_, &'static (), _>`
-note: the lifetime `'new` as defined here...
-  --> $DIR/variance-btree-invariant-types.rs:16:22
-   |
-LL | fn range_cov_key<'a, 'new>(v: RangeMut<'a, &'static (), ()>) -> RangeMut<'a, &'new (), ()> {
-   |                      ^^^^
-   = note: ...does not necessarily outlive the static lifetime
-
-error[E0308]: mismatched types
-  --> $DIR/variance-btree-invariant-types.rs:20:5
-   |
-LL |     v
-   |     ^ lifetime mismatch
-   |
-   = note: expected struct `RangeMut<'_, _, &'new ()>`
-              found struct `RangeMut<'_, _, &'static ()>`
-note: the lifetime `'new` as defined here...
-  --> $DIR/variance-btree-invariant-types.rs:19:22
-   |
-LL | fn range_cov_val<'a, 'new>(v: RangeMut<'a, (), &'static ()>) -> RangeMut<'a, (), &'new ()> {
-   |                      ^^^^
    = note: ...does not necessarily outlive the static lifetime
 
 error[E0308]: mismatched types
@@ -94,58 +49,43 @@ error[E0308]: mismatched types
 LL |     v
    |     ^ lifetime mismatch
    |
-   = note: expected struct `RangeMut<'_, &'static (), _>`
-              found struct `RangeMut<'_, &'new (), _>`
+   = note: expected struct `std::collections::btree_map::IterMut<'_, _, &'static ()>`
+              found struct `std::collections::btree_map::IterMut<'_, _, &'new ()>`
 note: the lifetime `'new` as defined here...
-  --> $DIR/variance-btree-invariant-types.rs:22:25
+  --> $DIR/variance-btree-invariant-types.rs:22:24
    |
-LL | fn range_contra_key<'a, 'new>(v: RangeMut<'a, &'new (), ()>) -> RangeMut<'a, &'static (), ()> {
-   |                         ^^^^
+LL | fn iter_contra_val<'a, 'new>(v: IterMut<'a, (), &'new ()>) -> IterMut<'a, (), &'static ()> {
+   |                        ^^^^
    = note: ...does not necessarily outlive the static lifetime
 
 error[E0308]: mismatched types
-  --> $DIR/variance-btree-invariant-types.rs:26:5
+  --> $DIR/variance-btree-invariant-types.rs:29:5
    |
 LL |     v
    |     ^ lifetime mismatch
    |
-   = note: expected struct `RangeMut<'_, _, &'static ()>`
-              found struct `RangeMut<'_, _, &'new ()>`
+   = note: expected struct `RangeMut<'_, &'new (), _>`
+              found struct `RangeMut<'_, &'static (), _>`
 note: the lifetime `'new` as defined here...
-  --> $DIR/variance-btree-invariant-types.rs:25:25
+  --> $DIR/variance-btree-invariant-types.rs:28:22
    |
-LL | fn range_contra_val<'a, 'new>(v: RangeMut<'a, (), &'new ()>) -> RangeMut<'a, (), &'static ()> {
-   |                         ^^^^
+LL | fn range_cov_key<'a, 'new>(v: RangeMut<'a, &'static (), ()>) -> RangeMut<'a, &'new (), ()> {
+   |                      ^^^^
    = note: ...does not necessarily outlive the static lifetime
 
 error[E0308]: mismatched types
-  --> $DIR/variance-btree-invariant-types.rs:31:5
+  --> $DIR/variance-btree-invariant-types.rs:34:5
    |
 LL |     v
    |     ^ lifetime mismatch
    |
-   = note: expected struct `std::collections::btree_map::OccupiedEntry<'_, &'new (), _>`
-              found struct `std::collections::btree_map::OccupiedEntry<'_, &'static (), _>`
+   = note: expected struct `RangeMut<'_, _, &'new ()>`
+              found struct `RangeMut<'_, _, &'static ()>`
 note: the lifetime `'new` as defined here...
-  --> $DIR/variance-btree-invariant-types.rs:29:20
+  --> $DIR/variance-btree-invariant-types.rs:33:22
    |
-LL | fn occ_cov_key<'a, 'new>(v: OccupiedEntry<'a, &'static (), ()>)
-   |                    ^^^^
-   = note: ...does not necessarily outlive the static lifetime
-
-error[E0308]: mismatched types
-  --> $DIR/variance-btree-invariant-types.rs:35:5
-   |
-LL |     v
-   |     ^ lifetime mismatch
-   |
-   = note: expected struct `std::collections::btree_map::OccupiedEntry<'_, _, &'new ()>`
-              found struct `std::collections::btree_map::OccupiedEntry<'_, _, &'static ()>`
-note: the lifetime `'new` as defined here...
-  --> $DIR/variance-btree-invariant-types.rs:33:20
-   |
-LL | fn occ_cov_val<'a, 'new>(v: OccupiedEntry<'a, (), &'static ()>)
-   |                    ^^^^
+LL | fn range_cov_val<'a, 'new>(v: RangeMut<'a, (), &'static ()>) -> RangeMut<'a, (), &'new ()> {
+   |                      ^^^^
    = note: ...does not necessarily outlive the static lifetime
 
 error[E0308]: mismatched types
@@ -154,17 +94,77 @@ error[E0308]: mismatched types
 LL |     v
    |     ^ lifetime mismatch
    |
+   = note: expected struct `RangeMut<'_, &'static (), _>`
+              found struct `RangeMut<'_, &'new (), _>`
+note: the lifetime `'new` as defined here...
+  --> $DIR/variance-btree-invariant-types.rs:38:25
+   |
+LL | fn range_contra_key<'a, 'new>(v: RangeMut<'a, &'new (), ()>) -> RangeMut<'a, &'static (), ()> {
+   |                         ^^^^
+   = note: ...does not necessarily outlive the static lifetime
+
+error[E0308]: mismatched types
+  --> $DIR/variance-btree-invariant-types.rs:44:5
+   |
+LL |     v
+   |     ^ lifetime mismatch
+   |
+   = note: expected struct `RangeMut<'_, _, &'static ()>`
+              found struct `RangeMut<'_, _, &'new ()>`
+note: the lifetime `'new` as defined here...
+  --> $DIR/variance-btree-invariant-types.rs:43:25
+   |
+LL | fn range_contra_val<'a, 'new>(v: RangeMut<'a, (), &'new ()>) -> RangeMut<'a, (), &'static ()> {
+   |                         ^^^^
+   = note: ...does not necessarily outlive the static lifetime
+
+error[E0308]: mismatched types
+  --> $DIR/variance-btree-invariant-types.rs:51:5
+   |
+LL |     v
+   |     ^ lifetime mismatch
+   |
+   = note: expected struct `std::collections::btree_map::OccupiedEntry<'_, &'new (), _>`
+              found struct `std::collections::btree_map::OccupiedEntry<'_, &'static (), _>`
+note: the lifetime `'new` as defined here...
+  --> $DIR/variance-btree-invariant-types.rs:49:20
+   |
+LL | fn occ_cov_key<'a, 'new>(v: OccupiedEntry<'a, &'static (), ()>)
+   |                    ^^^^
+   = note: ...does not necessarily outlive the static lifetime
+
+error[E0308]: mismatched types
+  --> $DIR/variance-btree-invariant-types.rs:57:5
+   |
+LL |     v
+   |     ^ lifetime mismatch
+   |
+   = note: expected struct `std::collections::btree_map::OccupiedEntry<'_, _, &'new ()>`
+              found struct `std::collections::btree_map::OccupiedEntry<'_, _, &'static ()>`
+note: the lifetime `'new` as defined here...
+  --> $DIR/variance-btree-invariant-types.rs:55:20
+   |
+LL | fn occ_cov_val<'a, 'new>(v: OccupiedEntry<'a, (), &'static ()>)
+   |                    ^^^^
+   = note: ...does not necessarily outlive the static lifetime
+
+error[E0308]: mismatched types
+  --> $DIR/variance-btree-invariant-types.rs:63:5
+   |
+LL |     v
+   |     ^ lifetime mismatch
+   |
    = note: expected struct `std::collections::btree_map::OccupiedEntry<'_, &'static (), _>`
               found struct `std::collections::btree_map::OccupiedEntry<'_, &'new (), _>`
 note: the lifetime `'new` as defined here...
-  --> $DIR/variance-btree-invariant-types.rs:37:23
+  --> $DIR/variance-btree-invariant-types.rs:61:23
    |
 LL | fn occ_contra_key<'a, 'new>(v: OccupiedEntry<'a, &'new (), ()>)
    |                       ^^^^
    = note: ...does not necessarily outlive the static lifetime
 
 error[E0308]: mismatched types
-  --> $DIR/variance-btree-invariant-types.rs:43:5
+  --> $DIR/variance-btree-invariant-types.rs:69:5
    |
 LL |     v
    |     ^ lifetime mismatch
@@ -172,14 +172,14 @@ LL |     v
    = note: expected struct `std::collections::btree_map::OccupiedEntry<'_, _, &'static ()>`
               found struct `std::collections::btree_map::OccupiedEntry<'_, _, &'new ()>`
 note: the lifetime `'new` as defined here...
-  --> $DIR/variance-btree-invariant-types.rs:41:23
+  --> $DIR/variance-btree-invariant-types.rs:67:23
    |
 LL | fn occ_contra_val<'a, 'new>(v: OccupiedEntry<'a, (), &'new ()>)
    |                       ^^^^
    = note: ...does not necessarily outlive the static lifetime
 
 error[E0308]: mismatched types
-  --> $DIR/variance-btree-invariant-types.rs:48:5
+  --> $DIR/variance-btree-invariant-types.rs:76:5
    |
 LL |     v
    |     ^ lifetime mismatch
@@ -187,14 +187,14 @@ LL |     v
    = note: expected struct `std::collections::btree_map::VacantEntry<'_, &'new (), _>`
               found struct `std::collections::btree_map::VacantEntry<'_, &'static (), _>`
 note: the lifetime `'new` as defined here...
-  --> $DIR/variance-btree-invariant-types.rs:46:20
+  --> $DIR/variance-btree-invariant-types.rs:74:20
    |
 LL | fn vac_cov_key<'a, 'new>(v: VacantEntry<'a, &'static (), ()>)
    |                    ^^^^
    = note: ...does not necessarily outlive the static lifetime
 
 error[E0308]: mismatched types
-  --> $DIR/variance-btree-invariant-types.rs:52:5
+  --> $DIR/variance-btree-invariant-types.rs:82:5
    |
 LL |     v
    |     ^ lifetime mismatch
@@ -202,14 +202,14 @@ LL |     v
    = note: expected struct `std::collections::btree_map::VacantEntry<'_, _, &'new ()>`
               found struct `std::collections::btree_map::VacantEntry<'_, _, &'static ()>`
 note: the lifetime `'new` as defined here...
-  --> $DIR/variance-btree-invariant-types.rs:50:20
+  --> $DIR/variance-btree-invariant-types.rs:80:20
    |
 LL | fn vac_cov_val<'a, 'new>(v: VacantEntry<'a, (), &'static ()>)
    |                    ^^^^
    = note: ...does not necessarily outlive the static lifetime
 
 error[E0308]: mismatched types
-  --> $DIR/variance-btree-invariant-types.rs:56:5
+  --> $DIR/variance-btree-invariant-types.rs:88:5
    |
 LL |     v
    |     ^ lifetime mismatch
@@ -217,14 +217,14 @@ LL |     v
    = note: expected struct `std::collections::btree_map::VacantEntry<'_, &'static (), _>`
               found struct `std::collections::btree_map::VacantEntry<'_, &'new (), _>`
 note: the lifetime `'new` as defined here...
-  --> $DIR/variance-btree-invariant-types.rs:54:23
+  --> $DIR/variance-btree-invariant-types.rs:86:23
    |
 LL | fn vac_contra_key<'a, 'new>(v: VacantEntry<'a, &'new (), ()>)
    |                       ^^^^
    = note: ...does not necessarily outlive the static lifetime
 
 error[E0308]: mismatched types
-  --> $DIR/variance-btree-invariant-types.rs:60:5
+  --> $DIR/variance-btree-invariant-types.rs:94:5
    |
 LL |     v
    |     ^ lifetime mismatch
@@ -232,7 +232,7 @@ LL |     v
    = note: expected struct `std::collections::btree_map::VacantEntry<'_, _, &'static ()>`
               found struct `std::collections::btree_map::VacantEntry<'_, _, &'new ()>`
 note: the lifetime `'new` as defined here...
-  --> $DIR/variance-btree-invariant-types.rs:58:23
+  --> $DIR/variance-btree-invariant-types.rs:92:23
    |
 LL | fn vac_contra_val<'a, 'new>(v: VacantEntry<'a, (), &'new ()>)
    |                       ^^^^

--- a/src/test/ui/variance/variance-btree-invariant-types.nll.stderr
+++ b/src/test/ui/variance/variance-btree-invariant-types.nll.stderr
@@ -1,5 +1,5 @@
 error: lifetime may not live long enough
-  --> $DIR/variance-btree-invariant-types.rs:4:5
+  --> $DIR/variance-btree-invariant-types.rs:8:5
    |
 LL | fn iter_cov_key<'a, 'new>(v: IterMut<'a, &'static (), ()>) -> IterMut<'a, &'new (), ()> {
    |                     ---- lifetime `'new` defined here
@@ -11,7 +11,7 @@ LL |     v
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
 error: lifetime may not live long enough
-  --> $DIR/variance-btree-invariant-types.rs:7:5
+  --> $DIR/variance-btree-invariant-types.rs:13:5
    |
 LL | fn iter_cov_val<'a, 'new>(v: IterMut<'a, (), &'static ()>) -> IterMut<'a, (), &'new ()> {
    |                     ---- lifetime `'new` defined here
@@ -23,7 +23,7 @@ LL |     v
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
 error: lifetime may not live long enough
-  --> $DIR/variance-btree-invariant-types.rs:10:5
+  --> $DIR/variance-btree-invariant-types.rs:18:5
    |
 LL | fn iter_contra_key<'a, 'new>(v: IterMut<'a, &'new (), ()>) -> IterMut<'a, &'static (), ()> {
    |                        ---- lifetime `'new` defined here
@@ -35,7 +35,7 @@ LL |     v
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
 error: lifetime may not live long enough
-  --> $DIR/variance-btree-invariant-types.rs:13:5
+  --> $DIR/variance-btree-invariant-types.rs:23:5
    |
 LL | fn iter_contra_val<'a, 'new>(v: IterMut<'a, (), &'new ()>) -> IterMut<'a, (), &'static ()> {
    |                        ---- lifetime `'new` defined here
@@ -47,7 +47,7 @@ LL |     v
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
 error: lifetime may not live long enough
-  --> $DIR/variance-btree-invariant-types.rs:17:5
+  --> $DIR/variance-btree-invariant-types.rs:29:5
    |
 LL | fn range_cov_key<'a, 'new>(v: RangeMut<'a, &'static (), ()>) -> RangeMut<'a, &'new (), ()> {
    |                      ---- lifetime `'new` defined here
@@ -59,7 +59,7 @@ LL |     v
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
 error: lifetime may not live long enough
-  --> $DIR/variance-btree-invariant-types.rs:20:5
+  --> $DIR/variance-btree-invariant-types.rs:34:5
    |
 LL | fn range_cov_val<'a, 'new>(v: RangeMut<'a, (), &'static ()>) -> RangeMut<'a, (), &'new ()> {
    |                      ---- lifetime `'new` defined here
@@ -71,7 +71,7 @@ LL |     v
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
 error: lifetime may not live long enough
-  --> $DIR/variance-btree-invariant-types.rs:23:5
+  --> $DIR/variance-btree-invariant-types.rs:39:5
    |
 LL | fn range_contra_key<'a, 'new>(v: RangeMut<'a, &'new (), ()>) -> RangeMut<'a, &'static (), ()> {
    |                         ---- lifetime `'new` defined here
@@ -83,7 +83,7 @@ LL |     v
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
 error: lifetime may not live long enough
-  --> $DIR/variance-btree-invariant-types.rs:26:5
+  --> $DIR/variance-btree-invariant-types.rs:44:5
    |
 LL | fn range_contra_val<'a, 'new>(v: RangeMut<'a, (), &'new ()>) -> RangeMut<'a, (), &'static ()> {
    |                         ---- lifetime `'new` defined here
@@ -95,7 +95,7 @@ LL |     v
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
 error: lifetime may not live long enough
-  --> $DIR/variance-btree-invariant-types.rs:31:5
+  --> $DIR/variance-btree-invariant-types.rs:51:5
    |
 LL | fn occ_cov_key<'a, 'new>(v: OccupiedEntry<'a, &'static (), ()>)
    |                    ---- lifetime `'new` defined here
@@ -108,7 +108,7 @@ LL |     v
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
 error: lifetime may not live long enough
-  --> $DIR/variance-btree-invariant-types.rs:35:5
+  --> $DIR/variance-btree-invariant-types.rs:57:5
    |
 LL | fn occ_cov_val<'a, 'new>(v: OccupiedEntry<'a, (), &'static ()>)
    |                    ---- lifetime `'new` defined here
@@ -121,7 +121,7 @@ LL |     v
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
 error: lifetime may not live long enough
-  --> $DIR/variance-btree-invariant-types.rs:39:5
+  --> $DIR/variance-btree-invariant-types.rs:63:5
    |
 LL | fn occ_contra_key<'a, 'new>(v: OccupiedEntry<'a, &'new (), ()>)
    |                       ---- lifetime `'new` defined here
@@ -134,7 +134,7 @@ LL |     v
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
 error: lifetime may not live long enough
-  --> $DIR/variance-btree-invariant-types.rs:43:5
+  --> $DIR/variance-btree-invariant-types.rs:69:5
    |
 LL | fn occ_contra_val<'a, 'new>(v: OccupiedEntry<'a, (), &'new ()>)
    |                       ---- lifetime `'new` defined here
@@ -147,7 +147,7 @@ LL |     v
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
 error: lifetime may not live long enough
-  --> $DIR/variance-btree-invariant-types.rs:48:5
+  --> $DIR/variance-btree-invariant-types.rs:76:5
    |
 LL | fn vac_cov_key<'a, 'new>(v: VacantEntry<'a, &'static (), ()>)
    |                    ---- lifetime `'new` defined here
@@ -160,7 +160,7 @@ LL |     v
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
 error: lifetime may not live long enough
-  --> $DIR/variance-btree-invariant-types.rs:52:5
+  --> $DIR/variance-btree-invariant-types.rs:82:5
    |
 LL | fn vac_cov_val<'a, 'new>(v: VacantEntry<'a, (), &'static ()>)
    |                    ---- lifetime `'new` defined here
@@ -173,7 +173,7 @@ LL |     v
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
 error: lifetime may not live long enough
-  --> $DIR/variance-btree-invariant-types.rs:56:5
+  --> $DIR/variance-btree-invariant-types.rs:88:5
    |
 LL | fn vac_contra_key<'a, 'new>(v: VacantEntry<'a, &'new (), ()>)
    |                       ---- lifetime `'new` defined here
@@ -186,7 +186,7 @@ LL |     v
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
 error: lifetime may not live long enough
-  --> $DIR/variance-btree-invariant-types.rs:60:5
+  --> $DIR/variance-btree-invariant-types.rs:94:5
    |
 LL | fn vac_contra_val<'a, 'new>(v: VacantEntry<'a, (), &'new ()>)
    |                       ---- lifetime `'new` defined here

--- a/src/test/ui/variance/variance-btree-invariant-types.rs
+++ b/src/test/ui/variance/variance-btree-invariant-types.rs
@@ -1,63 +1,99 @@
 use std::collections::btree_map::{IterMut, OccupiedEntry, RangeMut, VacantEntry};
 
+// revisions: base nll
+// ignore-compare-mode-nll
+//[nll] compile-flags: -Z borrowck=mir
+
 fn iter_cov_key<'a, 'new>(v: IterMut<'a, &'static (), ()>) -> IterMut<'a, &'new (), ()> {
-    v //~ ERROR mismatched types
+    v
+    //[base]~^ ERROR mismatched types
+    //[nll]~^^ lifetime may not live long enough
 }
 fn iter_cov_val<'a, 'new>(v: IterMut<'a, (), &'static ()>) -> IterMut<'a, (), &'new ()> {
-    v //~ ERROR mismatched types
+    v
+    //[base]~^ ERROR mismatched types
+    //[nll]~^^ lifetime may not live long enough
 }
 fn iter_contra_key<'a, 'new>(v: IterMut<'a, &'new (), ()>) -> IterMut<'a, &'static (), ()> {
-    v //~ ERROR mismatched types
+    v
+    //[base]~^ ERROR mismatched types
+    //[nll]~^^ lifetime may not live long enough
 }
 fn iter_contra_val<'a, 'new>(v: IterMut<'a, (), &'new ()>) -> IterMut<'a, (), &'static ()> {
-    v //~ ERROR mismatched types
+    v
+    //[base]~^ ERROR mismatched types
+    //[nll]~^^ lifetime may not live long enough
 }
 
 fn range_cov_key<'a, 'new>(v: RangeMut<'a, &'static (), ()>) -> RangeMut<'a, &'new (), ()> {
-    v //~ ERROR mismatched types
+    v
+    //[base]~^ ERROR mismatched types
+    //[nll]~^^ lifetime may not live long enough
 }
 fn range_cov_val<'a, 'new>(v: RangeMut<'a, (), &'static ()>) -> RangeMut<'a, (), &'new ()> {
-    v //~ ERROR mismatched types
+    v
+    //[base]~^ ERROR mismatched types
+    //[nll]~^^ lifetime may not live long enough
 }
 fn range_contra_key<'a, 'new>(v: RangeMut<'a, &'new (), ()>) -> RangeMut<'a, &'static (), ()> {
-    v //~ ERROR mismatched types
+    v
+    //[base]~^ ERROR mismatched types
+    //[nll]~^^ lifetime may not live long enough
 }
 fn range_contra_val<'a, 'new>(v: RangeMut<'a, (), &'new ()>) -> RangeMut<'a, (), &'static ()> {
-    v //~ ERROR mismatched types
+    v
+    //[base]~^ ERROR mismatched types
+    //[nll]~^^ lifetime may not live long enough
 }
 
 fn occ_cov_key<'a, 'new>(v: OccupiedEntry<'a, &'static (), ()>)
                          -> OccupiedEntry<'a, &'new (), ()> {
-    v //~ ERROR mismatched types
+    v
+    //[base]~^ ERROR mismatched types
+    //[nll]~^^ lifetime may not live long enough
 }
 fn occ_cov_val<'a, 'new>(v: OccupiedEntry<'a, (), &'static ()>)
                          -> OccupiedEntry<'a, (), &'new ()> {
-    v //~ ERROR mismatched types
+    v
+    //[base]~^ ERROR mismatched types
+    //[nll]~^^ lifetime may not live long enough
 }
 fn occ_contra_key<'a, 'new>(v: OccupiedEntry<'a, &'new (), ()>)
                             -> OccupiedEntry<'a, &'static (), ()> {
-    v //~ ERROR mismatched types
+    v
+    //[base]~^ ERROR mismatched types
+    //[nll]~^^ lifetime may not live long enough
 }
 fn occ_contra_val<'a, 'new>(v: OccupiedEntry<'a, (), &'new ()>)
                             -> OccupiedEntry<'a, (), &'static ()> {
-    v //~ ERROR mismatched types
+    v
+    //[base]~^ ERROR mismatched types
+    //[nll]~^^ lifetime may not live long enough
 }
 
 fn vac_cov_key<'a, 'new>(v: VacantEntry<'a, &'static (), ()>)
                          -> VacantEntry<'a, &'new (), ()> {
-    v //~ ERROR mismatched types
+    v
+    //[base]~^ ERROR mismatched types
+    //[nll]~^^ lifetime may not live long enough
 }
 fn vac_cov_val<'a, 'new>(v: VacantEntry<'a, (), &'static ()>)
                          -> VacantEntry<'a, (), &'new ()> {
-    v //~ ERROR mismatched types
+    v
+    //[base]~^ ERROR mismatched types
+    //[nll]~^^ lifetime may not live long enough
 }
 fn vac_contra_key<'a, 'new>(v: VacantEntry<'a, &'new (), ()>)
                             -> VacantEntry<'a, &'static (), ()> {
-    v //~ ERROR mismatched types
+    v
+    //[base]~^ ERROR mismatched types
+    //[nll]~^^ lifetime may not live long enough
 }
 fn vac_contra_val<'a, 'new>(v: VacantEntry<'a, (), &'new ()>)
                             -> VacantEntry<'a, (), &'static ()> {
-    v //~ ERROR mismatched types
+    v
+    //[base]~^ ERROR mismatched types
+    //[nll]~^^ lifetime may not live long enough
 }
 
 

--- a/src/test/ui/variance/variance-cell-is-invariant.base.stderr
+++ b/src/test/ui/variance/variance-cell-is-invariant.base.stderr
@@ -1,5 +1,5 @@
 error[E0623]: lifetime mismatch
-  --> $DIR/variance-cell-is-invariant.rs:14:25
+  --> $DIR/variance-cell-is-invariant.rs:18:25
    |
 LL | fn use_<'short,'long>(c: Foo<'short>,
    |                          ----------- these two types are declared with different lifetimes...

--- a/src/test/ui/variance/variance-cell-is-invariant.nll.stderr
+++ b/src/test/ui/variance/variance-cell-is-invariant.nll.stderr
@@ -1,5 +1,5 @@
 error: lifetime may not live long enough
-  --> $DIR/variance-cell-is-invariant.rs:14:12
+  --> $DIR/variance-cell-is-invariant.rs:18:12
    |
 LL | fn use_<'short,'long>(c: Foo<'short>,
    |         ------ ----- lifetime `'long` defined here

--- a/src/test/ui/variance/variance-cell-is-invariant.rs
+++ b/src/test/ui/variance/variance-cell-is-invariant.rs
@@ -1,6 +1,10 @@
 // Test that Cell is considered invariant with respect to its
 // type.
 
+// revisions: base nll
+// ignore-compare-mode-nll
+//[nll] compile-flags: -Z borrowck=mir
+
 use std::cell::Cell;
 
 struct Foo<'a> {
@@ -11,7 +15,9 @@ fn use_<'short,'long>(c: Foo<'short>,
                       s: &'short isize,
                       l: &'long isize,
                       _where:Option<&'short &'long ()>) {
-    let _: Foo<'long> = c; //~ ERROR E0623
+    let _: Foo<'long> = c;
+    //[base]~^ ERROR E0623
+    //[nll]~^^ ERROR lifetime may not live long enough
 }
 
 fn main() {

--- a/src/test/ui/variance/variance-contravariant-arg-object.base.stderr
+++ b/src/test/ui/variance/variance-contravariant-arg-object.base.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/variance-contravariant-arg-object.rs:14:5
+  --> $DIR/variance-contravariant-arg-object.rs:18:5
    |
 LL |     v
    |     ^ lifetime mismatch
@@ -7,18 +7,18 @@ LL |     v
    = note: expected trait object `dyn Get<&'min i32>`
               found trait object `dyn Get<&'max i32>`
 note: the lifetime `'min` as defined here...
-  --> $DIR/variance-contravariant-arg-object.rs:10:21
+  --> $DIR/variance-contravariant-arg-object.rs:14:21
    |
 LL | fn get_min_from_max<'min, 'max>(v: Box<dyn Get<&'max i32>>)
    |                     ^^^^
 note: ...does not necessarily outlive the lifetime `'max` as defined here
-  --> $DIR/variance-contravariant-arg-object.rs:10:27
+  --> $DIR/variance-contravariant-arg-object.rs:14:27
    |
 LL | fn get_min_from_max<'min, 'max>(v: Box<dyn Get<&'max i32>>)
    |                           ^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/variance-contravariant-arg-object.rs:22:5
+  --> $DIR/variance-contravariant-arg-object.rs:28:5
    |
 LL |     v
    |     ^ lifetime mismatch
@@ -26,12 +26,12 @@ LL |     v
    = note: expected trait object `dyn Get<&'max i32>`
               found trait object `dyn Get<&'min i32>`
 note: the lifetime `'min` as defined here...
-  --> $DIR/variance-contravariant-arg-object.rs:17:21
+  --> $DIR/variance-contravariant-arg-object.rs:23:21
    |
 LL | fn get_max_from_min<'min, 'max, G>(v: Box<dyn Get<&'min i32>>)
    |                     ^^^^
 note: ...does not necessarily outlive the lifetime `'max` as defined here
-  --> $DIR/variance-contravariant-arg-object.rs:17:27
+  --> $DIR/variance-contravariant-arg-object.rs:23:27
    |
 LL | fn get_max_from_min<'min, 'max, G>(v: Box<dyn Get<&'min i32>>)
    |                           ^^^^

--- a/src/test/ui/variance/variance-contravariant-arg-object.nll.stderr
+++ b/src/test/ui/variance/variance-contravariant-arg-object.nll.stderr
@@ -1,5 +1,5 @@
 error: lifetime may not live long enough
-  --> $DIR/variance-contravariant-arg-object.rs:14:5
+  --> $DIR/variance-contravariant-arg-object.rs:18:5
    |
 LL | fn get_min_from_max<'min, 'max>(v: Box<dyn Get<&'max i32>>)
    |                     ----  ---- lifetime `'max` defined here
@@ -12,7 +12,7 @@ LL |     v
    = help: consider adding the following bound: `'min: 'max`
 
 error: lifetime may not live long enough
-  --> $DIR/variance-contravariant-arg-object.rs:22:5
+  --> $DIR/variance-contravariant-arg-object.rs:28:5
    |
 LL | fn get_max_from_min<'min, 'max, G>(v: Box<dyn Get<&'min i32>>)
    |                     ----  ---- lifetime `'max` defined here

--- a/src/test/ui/variance/variance-contravariant-arg-object.rs
+++ b/src/test/ui/variance/variance-contravariant-arg-object.rs
@@ -3,6 +3,10 @@
 // Test that even when `T` is only used in contravariant position, it
 // is treated as invariant.
 
+// revisions: base nll
+// ignore-compare-mode-nll
+//[nll] compile-flags: -Z borrowck=mir
+
 trait Get<T> : 'static {
     fn get(&self, t: T);
 }
@@ -11,7 +15,9 @@ fn get_min_from_max<'min, 'max>(v: Box<dyn Get<&'max i32>>)
                                 -> Box<dyn Get<&'min i32>>
     where 'max : 'min
 {
-    v //~ ERROR mismatched types
+    v
+    //[base]~^ ERROR mismatched types
+    //[nll]~^^ ERROR lifetime may not live long enough
 }
 
 fn get_max_from_min<'min, 'max, G>(v: Box<dyn Get<&'min i32>>)
@@ -19,7 +25,9 @@ fn get_max_from_min<'min, 'max, G>(v: Box<dyn Get<&'min i32>>)
     where 'max : 'min
 {
     // Previously OK:
-    v //~ ERROR mismatched types
+    v
+    //[base]~^ ERROR mismatched types
+    //[nll]~^^ ERROR lifetime may not live long enough
 }
 
 fn main() { }

--- a/src/test/ui/variance/variance-contravariant-arg-trait-match.base.stderr
+++ b/src/test/ui/variance/variance-contravariant-arg-trait-match.base.stderr
@@ -1,37 +1,37 @@
 error[E0308]: mismatched types
-  --> $DIR/variance-contravariant-self-trait-match.rs:13:5
+  --> $DIR/variance-contravariant-arg-trait-match.rs:17:5
    |
-LL |     impls_get::<&'min G>();
-   |     ^^^^^^^^^^^^^^^^^^^^ lifetime mismatch
+LL |     impls_get::<G,&'min i32>()
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^ lifetime mismatch
    |
-   = note: expected type `<&'min G as Get>`
-              found type `<&'max G as Get>`
+   = note: expected type `Get<&'min i32>`
+              found type `Get<&'max i32>`
 note: the lifetime `'min` as defined here...
-  --> $DIR/variance-contravariant-self-trait-match.rs:10:21
+  --> $DIR/variance-contravariant-arg-trait-match.rs:14:21
    |
 LL | fn get_min_from_max<'min, 'max, G>()
    |                     ^^^^
 note: ...does not necessarily outlive the lifetime `'max` as defined here
-  --> $DIR/variance-contravariant-self-trait-match.rs:10:27
+  --> $DIR/variance-contravariant-arg-trait-match.rs:14:27
    |
 LL | fn get_min_from_max<'min, 'max, G>()
    |                           ^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/variance-contravariant-self-trait-match.rs:22:5
+  --> $DIR/variance-contravariant-arg-trait-match.rs:27:5
    |
-LL |     impls_get::<&'max G>();
-   |     ^^^^^^^^^^^^^^^^^^^^ lifetime mismatch
+LL |     impls_get::<G,&'max i32>()
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^ lifetime mismatch
    |
-   = note: expected type `<&'max G as Get>`
-              found type `<&'min G as Get>`
+   = note: expected type `Get<&'max i32>`
+              found type `Get<&'min i32>`
 note: the lifetime `'min` as defined here...
-  --> $DIR/variance-contravariant-self-trait-match.rs:16:21
+  --> $DIR/variance-contravariant-arg-trait-match.rs:22:21
    |
 LL | fn get_max_from_min<'min, 'max, G>()
    |                     ^^^^
 note: ...does not necessarily outlive the lifetime `'max` as defined here
-  --> $DIR/variance-contravariant-self-trait-match.rs:16:27
+  --> $DIR/variance-contravariant-arg-trait-match.rs:22:27
    |
 LL | fn get_max_from_min<'min, 'max, G>()
    |                           ^^^^

--- a/src/test/ui/variance/variance-contravariant-arg-trait-match.nll.stderr
+++ b/src/test/ui/variance/variance-contravariant-arg-trait-match.nll.stderr
@@ -1,5 +1,5 @@
 error: lifetime may not live long enough
-  --> $DIR/variance-contravariant-arg-trait-match.rs:13:5
+  --> $DIR/variance-contravariant-arg-trait-match.rs:17:5
    |
 LL | fn get_min_from_max<'min, 'max, G>()
    |                     ----  ---- lifetime `'max` defined here
@@ -12,7 +12,7 @@ LL |     impls_get::<G,&'min i32>()
    = help: consider adding the following bound: `'min: 'max`
 
 error: lifetime may not live long enough
-  --> $DIR/variance-contravariant-arg-trait-match.rs:21:5
+  --> $DIR/variance-contravariant-arg-trait-match.rs:27:5
    |
 LL | fn get_max_from_min<'min, 'max, G>()
    |                     ----  ---- lifetime `'max` defined here

--- a/src/test/ui/variance/variance-contravariant-arg-trait-match.rs
+++ b/src/test/ui/variance/variance-contravariant-arg-trait-match.rs
@@ -3,6 +3,10 @@
 // Test that even when `T` is only used in contravariant position, it
 // is treated as invariant.
 
+// revisions: base nll
+// ignore-compare-mode-nll
+//[nll] compile-flags: -Z borrowck=mir
+
 trait Get<T> {
     fn get(&self, t: T);
 }
@@ -10,7 +14,9 @@ trait Get<T> {
 fn get_min_from_max<'min, 'max, G>()
     where 'max : 'min, G : Get<&'max i32>
 {
-    impls_get::<G,&'min i32>() //~ ERROR mismatched types
+    impls_get::<G,&'min i32>()
+    //[base]~^ ERROR mismatched types
+    //[nll]~^^ ERROR lifetime may not live long enough
 }
 
 fn get_max_from_min<'min, 'max, G>()
@@ -18,7 +24,9 @@ fn get_max_from_min<'min, 'max, G>()
 {
     // Previously OK, but now an error because traits are invariant:
 
-    impls_get::<G,&'max i32>() //~ ERROR mismatched types
+    impls_get::<G,&'max i32>()
+    //[base]~^ ERROR mismatched types
+    //[nll]~^^ ERROR lifetime may not live long enough
 }
 
 fn impls_get<G,T>() where G : Get<T> { }

--- a/src/test/ui/variance/variance-contravariant-self-trait-match.base.stderr
+++ b/src/test/ui/variance/variance-contravariant-self-trait-match.base.stderr
@@ -1,37 +1,37 @@
 error[E0308]: mismatched types
-  --> $DIR/variance-contravariant-arg-trait-match.rs:13:5
+  --> $DIR/variance-contravariant-self-trait-match.rs:17:5
    |
-LL |     impls_get::<G,&'min i32>()
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^ lifetime mismatch
+LL |     impls_get::<&'min G>();
+   |     ^^^^^^^^^^^^^^^^^^^^ lifetime mismatch
    |
-   = note: expected type `Get<&'min i32>`
-              found type `Get<&'max i32>`
+   = note: expected type `<&'min G as Get>`
+              found type `<&'max G as Get>`
 note: the lifetime `'min` as defined here...
-  --> $DIR/variance-contravariant-arg-trait-match.rs:10:21
+  --> $DIR/variance-contravariant-self-trait-match.rs:14:21
    |
 LL | fn get_min_from_max<'min, 'max, G>()
    |                     ^^^^
 note: ...does not necessarily outlive the lifetime `'max` as defined here
-  --> $DIR/variance-contravariant-arg-trait-match.rs:10:27
+  --> $DIR/variance-contravariant-self-trait-match.rs:14:27
    |
 LL | fn get_min_from_max<'min, 'max, G>()
    |                           ^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/variance-contravariant-arg-trait-match.rs:21:5
+  --> $DIR/variance-contravariant-self-trait-match.rs:28:5
    |
-LL |     impls_get::<G,&'max i32>()
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^ lifetime mismatch
+LL |     impls_get::<&'max G>();
+   |     ^^^^^^^^^^^^^^^^^^^^ lifetime mismatch
    |
-   = note: expected type `Get<&'max i32>`
-              found type `Get<&'min i32>`
+   = note: expected type `<&'max G as Get>`
+              found type `<&'min G as Get>`
 note: the lifetime `'min` as defined here...
-  --> $DIR/variance-contravariant-arg-trait-match.rs:16:21
+  --> $DIR/variance-contravariant-self-trait-match.rs:22:21
    |
 LL | fn get_max_from_min<'min, 'max, G>()
    |                     ^^^^
 note: ...does not necessarily outlive the lifetime `'max` as defined here
-  --> $DIR/variance-contravariant-arg-trait-match.rs:16:27
+  --> $DIR/variance-contravariant-self-trait-match.rs:22:27
    |
 LL | fn get_max_from_min<'min, 'max, G>()
    |                           ^^^^

--- a/src/test/ui/variance/variance-contravariant-self-trait-match.nll.stderr
+++ b/src/test/ui/variance/variance-contravariant-self-trait-match.nll.stderr
@@ -1,5 +1,5 @@
 error: lifetime may not live long enough
-  --> $DIR/variance-contravariant-self-trait-match.rs:13:5
+  --> $DIR/variance-contravariant-self-trait-match.rs:17:5
    |
 LL | fn get_min_from_max<'min, 'max, G>()
    |                     ----  ---- lifetime `'max` defined here
@@ -12,7 +12,7 @@ LL |     impls_get::<&'min G>();
    = help: consider adding the following bound: `'min: 'max`
 
 error: lifetime may not live long enough
-  --> $DIR/variance-contravariant-self-trait-match.rs:22:5
+  --> $DIR/variance-contravariant-self-trait-match.rs:28:5
    |
 LL | fn get_max_from_min<'min, 'max, G>()
    |                     ----  ---- lifetime `'max` defined here

--- a/src/test/ui/variance/variance-contravariant-self-trait-match.rs
+++ b/src/test/ui/variance/variance-contravariant-self-trait-match.rs
@@ -3,6 +3,10 @@
 // Test that even when `Self` is only used in contravariant position, it
 // is treated as invariant.
 
+// revisions: base nll
+// ignore-compare-mode-nll
+//[nll] compile-flags: -Z borrowck=mir
+
 trait Get {
     fn get(&self);
 }
@@ -10,7 +14,9 @@ trait Get {
 fn get_min_from_max<'min, 'max, G>()
     where 'max : 'min, G : 'max, &'max G : Get
 {
-    impls_get::<&'min G>(); //~ ERROR mismatched types
+    impls_get::<&'min G>();
+    //[base]~^ ERROR mismatched types
+    //[nll]~^^ ERROR lifetime may not live long enough
 }
 
 fn get_max_from_min<'min, 'max, G>()
@@ -19,7 +25,9 @@ fn get_max_from_min<'min, 'max, G>()
     // Previously OK, but now error because traits are invariant with
     // respect to all inputs.
 
-    impls_get::<&'max G>(); //~ ERROR mismatched types
+    impls_get::<&'max G>();
+    //[base]~^ ERROR mismatched types
+    //[nll]~^^ ERROR lifetime may not live long enough
 }
 
 fn impls_get<G>() where G : Get { }

--- a/src/test/ui/variance/variance-covariant-arg-object.base.stderr
+++ b/src/test/ui/variance/variance-covariant-arg-object.base.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/variance-invariant-arg-object.rs:11:5
+  --> $DIR/variance-covariant-arg-object.rs:19:5
    |
 LL |     v
    |     ^ lifetime mismatch
@@ -7,18 +7,18 @@ LL |     v
    = note: expected trait object `dyn Get<&'min i32>`
               found trait object `dyn Get<&'max i32>`
 note: the lifetime `'min` as defined here...
-  --> $DIR/variance-invariant-arg-object.rs:7:21
+  --> $DIR/variance-covariant-arg-object.rs:14:21
    |
 LL | fn get_min_from_max<'min, 'max>(v: Box<dyn Get<&'max i32>>)
    |                     ^^^^
 note: ...does not necessarily outlive the lifetime `'max` as defined here
-  --> $DIR/variance-invariant-arg-object.rs:7:27
+  --> $DIR/variance-covariant-arg-object.rs:14:27
    |
 LL | fn get_min_from_max<'min, 'max>(v: Box<dyn Get<&'max i32>>)
    |                           ^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/variance-invariant-arg-object.rs:18:5
+  --> $DIR/variance-covariant-arg-object.rs:28:5
    |
 LL |     v
    |     ^ lifetime mismatch
@@ -26,12 +26,12 @@ LL |     v
    = note: expected trait object `dyn Get<&'max i32>`
               found trait object `dyn Get<&'min i32>`
 note: the lifetime `'min` as defined here...
-  --> $DIR/variance-invariant-arg-object.rs:14:21
+  --> $DIR/variance-covariant-arg-object.rs:24:21
    |
 LL | fn get_max_from_min<'min, 'max, G>(v: Box<dyn Get<&'min i32>>)
    |                     ^^^^
 note: ...does not necessarily outlive the lifetime `'max` as defined here
-  --> $DIR/variance-invariant-arg-object.rs:14:27
+  --> $DIR/variance-covariant-arg-object.rs:24:27
    |
 LL | fn get_max_from_min<'min, 'max, G>(v: Box<dyn Get<&'min i32>>)
    |                           ^^^^

--- a/src/test/ui/variance/variance-covariant-arg-object.nll.stderr
+++ b/src/test/ui/variance/variance-covariant-arg-object.nll.stderr
@@ -1,5 +1,5 @@
 error: lifetime may not live long enough
-  --> $DIR/variance-covariant-arg-object.rs:15:5
+  --> $DIR/variance-covariant-arg-object.rs:19:5
    |
 LL | fn get_min_from_max<'min, 'max>(v: Box<dyn Get<&'max i32>>)
    |                     ----  ---- lifetime `'max` defined here
@@ -12,7 +12,7 @@ LL |     v
    = help: consider adding the following bound: `'min: 'max`
 
 error: lifetime may not live long enough
-  --> $DIR/variance-covariant-arg-object.rs:22:5
+  --> $DIR/variance-covariant-arg-object.rs:28:5
    |
 LL | fn get_max_from_min<'min, 'max, G>(v: Box<dyn Get<&'min i32>>)
    |                     ----  ---- lifetime `'max` defined here

--- a/src/test/ui/variance/variance-covariant-arg-object.rs
+++ b/src/test/ui/variance/variance-covariant-arg-object.rs
@@ -3,6 +3,10 @@
 // Test that even when `T` is only used in covariant position, it
 // is treated as invariant.
 
+// revisions: base nll
+// ignore-compare-mode-nll
+//[nll] compile-flags: -Z borrowck=mir
+
 trait Get<T> : 'static {
     fn get(&self) -> T;
 }
@@ -12,14 +16,18 @@ fn get_min_from_max<'min, 'max>(v: Box<dyn Get<&'max i32>>)
     where 'max : 'min
 {
     // Previously OK, now an error as traits are invariant.
-    v //~ ERROR mismatched types
+    v
+    //[base]~^ ERROR mismatched types
+    //[nll]~^^ ERROR lifetime may not live long enough
 }
 
 fn get_max_from_min<'min, 'max, G>(v: Box<dyn Get<&'min i32>>)
                                    -> Box<dyn Get<&'max i32>>
     where 'max : 'min
 {
-    v //~ ERROR mismatched types
+    v
+    //[base]~^ ERROR mismatched types
+    //[nll]~^^ ERROR lifetime may not live long enough
 }
 
 fn main() { }

--- a/src/test/ui/variance/variance-covariant-arg-trait-match.base.stderr
+++ b/src/test/ui/variance/variance-covariant-arg-trait-match.base.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/variance-invariant-arg-trait-match.rs:10:5
+  --> $DIR/variance-covariant-arg-trait-match.rs:18:5
    |
 LL |     impls_get::<G,&'min i32>()
    |     ^^^^^^^^^^^^^^^^^^^^^^^^ lifetime mismatch
@@ -7,18 +7,18 @@ LL |     impls_get::<G,&'min i32>()
    = note: expected type `Get<&'min i32>`
               found type `Get<&'max i32>`
 note: the lifetime `'min` as defined here...
-  --> $DIR/variance-invariant-arg-trait-match.rs:7:21
+  --> $DIR/variance-covariant-arg-trait-match.rs:14:21
    |
 LL | fn get_min_from_max<'min, 'max, G>()
    |                     ^^^^
 note: ...does not necessarily outlive the lifetime `'max` as defined here
-  --> $DIR/variance-invariant-arg-trait-match.rs:7:27
+  --> $DIR/variance-covariant-arg-trait-match.rs:14:27
    |
 LL | fn get_min_from_max<'min, 'max, G>()
    |                           ^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/variance-invariant-arg-trait-match.rs:16:5
+  --> $DIR/variance-covariant-arg-trait-match.rs:26:5
    |
 LL |     impls_get::<G,&'max i32>()
    |     ^^^^^^^^^^^^^^^^^^^^^^^^ lifetime mismatch
@@ -26,12 +26,12 @@ LL |     impls_get::<G,&'max i32>()
    = note: expected type `Get<&'max i32>`
               found type `Get<&'min i32>`
 note: the lifetime `'min` as defined here...
-  --> $DIR/variance-invariant-arg-trait-match.rs:13:21
+  --> $DIR/variance-covariant-arg-trait-match.rs:23:21
    |
 LL | fn get_max_from_min<'min, 'max, G>()
    |                     ^^^^
 note: ...does not necessarily outlive the lifetime `'max` as defined here
-  --> $DIR/variance-invariant-arg-trait-match.rs:13:27
+  --> $DIR/variance-covariant-arg-trait-match.rs:23:27
    |
 LL | fn get_max_from_min<'min, 'max, G>()
    |                           ^^^^

--- a/src/test/ui/variance/variance-covariant-arg-trait-match.nll.stderr
+++ b/src/test/ui/variance/variance-covariant-arg-trait-match.nll.stderr
@@ -1,5 +1,5 @@
 error: lifetime may not live long enough
-  --> $DIR/variance-covariant-arg-trait-match.rs:14:5
+  --> $DIR/variance-covariant-arg-trait-match.rs:18:5
    |
 LL | fn get_min_from_max<'min, 'max, G>()
    |                     ----  ---- lifetime `'max` defined here
@@ -12,7 +12,7 @@ LL |     impls_get::<G,&'min i32>()
    = help: consider adding the following bound: `'min: 'max`
 
 error: lifetime may not live long enough
-  --> $DIR/variance-covariant-arg-trait-match.rs:20:5
+  --> $DIR/variance-covariant-arg-trait-match.rs:26:5
    |
 LL | fn get_max_from_min<'min, 'max, G>()
    |                     ----  ---- lifetime `'max` defined here

--- a/src/test/ui/variance/variance-covariant-arg-trait-match.rs
+++ b/src/test/ui/variance/variance-covariant-arg-trait-match.rs
@@ -3,6 +3,10 @@
 // Test that even when `T` is only used in covariant position, it
 // is treated as invariant.
 
+// revisions: base nll
+// ignore-compare-mode-nll
+//[nll] compile-flags: -Z borrowck=mir
+
 trait Get<T> {
     fn get(&self) -> T;
 }
@@ -11,13 +15,17 @@ fn get_min_from_max<'min, 'max, G>()
     where 'max : 'min, G : Get<&'max i32>
 {
     // Previously OK, now an error as traits are invariant.
-    impls_get::<G,&'min i32>() //~ ERROR mismatched types
+    impls_get::<G,&'min i32>()
+    //[base]~^ ERROR mismatched types
+    //[nll]~^^ ERROR lifetime may not live long enough
 }
 
 fn get_max_from_min<'min, 'max, G>()
     where 'max : 'min, G : Get<&'min i32>
 {
-    impls_get::<G,&'max i32>() //~ ERROR mismatched types
+    impls_get::<G,&'max i32>()
+    //[base]~^ ERROR mismatched types
+    //[nll]~^^ ERROR lifetime may not live long enough
 }
 
 fn impls_get<G,T>() where G : Get<T> { }

--- a/src/test/ui/variance/variance-covariant-self-trait-match.base.stderr
+++ b/src/test/ui/variance/variance-covariant-self-trait-match.base.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/variance-covariant-self-trait-match.rs:14:5
+  --> $DIR/variance-covariant-self-trait-match.rs:18:5
    |
 LL |     impls_get::<&'min G>();
    |     ^^^^^^^^^^^^^^^^^^^^ lifetime mismatch
@@ -7,18 +7,18 @@ LL |     impls_get::<&'min G>();
    = note: expected type `<&'min G as Get>`
               found type `<&'max G as Get>`
 note: the lifetime `'min` as defined here...
-  --> $DIR/variance-covariant-self-trait-match.rs:10:21
+  --> $DIR/variance-covariant-self-trait-match.rs:14:21
    |
 LL | fn get_min_from_max<'min, 'max, G>()
    |                     ^^^^
 note: ...does not necessarily outlive the lifetime `'max` as defined here
-  --> $DIR/variance-covariant-self-trait-match.rs:10:27
+  --> $DIR/variance-covariant-self-trait-match.rs:14:27
    |
 LL | fn get_min_from_max<'min, 'max, G>()
    |                           ^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/variance-covariant-self-trait-match.rs:20:5
+  --> $DIR/variance-covariant-self-trait-match.rs:26:5
    |
 LL |     impls_get::<&'max G>();
    |     ^^^^^^^^^^^^^^^^^^^^ lifetime mismatch
@@ -26,12 +26,12 @@ LL |     impls_get::<&'max G>();
    = note: expected type `<&'max G as Get>`
               found type `<&'min G as Get>`
 note: the lifetime `'min` as defined here...
-  --> $DIR/variance-covariant-self-trait-match.rs:17:21
+  --> $DIR/variance-covariant-self-trait-match.rs:23:21
    |
 LL | fn get_max_from_min<'min, 'max, G>()
    |                     ^^^^
 note: ...does not necessarily outlive the lifetime `'max` as defined here
-  --> $DIR/variance-covariant-self-trait-match.rs:17:27
+  --> $DIR/variance-covariant-self-trait-match.rs:23:27
    |
 LL | fn get_max_from_min<'min, 'max, G>()
    |                           ^^^^

--- a/src/test/ui/variance/variance-covariant-self-trait-match.nll.stderr
+++ b/src/test/ui/variance/variance-covariant-self-trait-match.nll.stderr
@@ -1,5 +1,5 @@
 error: lifetime may not live long enough
-  --> $DIR/variance-covariant-self-trait-match.rs:14:5
+  --> $DIR/variance-covariant-self-trait-match.rs:18:5
    |
 LL | fn get_min_from_max<'min, 'max, G>()
    |                     ----  ---- lifetime `'max` defined here
@@ -12,7 +12,7 @@ LL |     impls_get::<&'min G>();
    = help: consider adding the following bound: `'min: 'max`
 
 error: lifetime may not live long enough
-  --> $DIR/variance-covariant-self-trait-match.rs:20:5
+  --> $DIR/variance-covariant-self-trait-match.rs:26:5
    |
 LL | fn get_max_from_min<'min, 'max, G>()
    |                     ----  ---- lifetime `'max` defined here

--- a/src/test/ui/variance/variance-covariant-self-trait-match.rs
+++ b/src/test/ui/variance/variance-covariant-self-trait-match.rs
@@ -3,6 +3,10 @@
 // Test that even when `Self` is only used in covariant position, it
 // is treated as invariant.
 
+// revisions: base nll
+// ignore-compare-mode-nll
+//[nll] compile-flags: -Z borrowck=mir
+
 trait Get {
     fn get() -> Self;
 }
@@ -11,13 +15,17 @@ fn get_min_from_max<'min, 'max, G>()
     where 'max : 'min, G : 'max, &'max G : Get
 {
     // Previously OK, now an error as traits are invariant.
-    impls_get::<&'min G>(); //~ ERROR mismatched types
+    impls_get::<&'min G>();
+    //[base]~^ ERROR mismatched types
+    //[nll]~^^ ERROR lifetime may not live long enough
 }
 
 fn get_max_from_min<'min, 'max, G>()
     where 'max : 'min, G : 'max, &'min G : Get
 {
-    impls_get::<&'max G>(); //~ ERROR mismatched types
+    impls_get::<&'max G>();
+    //[base]~^ ERROR mismatched types
+    //[nll]~^^ ERROR lifetime may not live long enough
 }
 
 fn impls_get<G>() where G : Get { }

--- a/src/test/ui/variance/variance-invariant-arg-object.base.stderr
+++ b/src/test/ui/variance/variance-invariant-arg-object.base.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/variance-covariant-arg-object.rs:15:5
+  --> $DIR/variance-invariant-arg-object.rs:15:5
    |
 LL |     v
    |     ^ lifetime mismatch
@@ -7,18 +7,18 @@ LL |     v
    = note: expected trait object `dyn Get<&'min i32>`
               found trait object `dyn Get<&'max i32>`
 note: the lifetime `'min` as defined here...
-  --> $DIR/variance-covariant-arg-object.rs:10:21
+  --> $DIR/variance-invariant-arg-object.rs:11:21
    |
 LL | fn get_min_from_max<'min, 'max>(v: Box<dyn Get<&'max i32>>)
    |                     ^^^^
 note: ...does not necessarily outlive the lifetime `'max` as defined here
-  --> $DIR/variance-covariant-arg-object.rs:10:27
+  --> $DIR/variance-invariant-arg-object.rs:11:27
    |
 LL | fn get_min_from_max<'min, 'max>(v: Box<dyn Get<&'max i32>>)
    |                           ^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/variance-covariant-arg-object.rs:22:5
+  --> $DIR/variance-invariant-arg-object.rs:24:5
    |
 LL |     v
    |     ^ lifetime mismatch
@@ -26,12 +26,12 @@ LL |     v
    = note: expected trait object `dyn Get<&'max i32>`
               found trait object `dyn Get<&'min i32>`
 note: the lifetime `'min` as defined here...
-  --> $DIR/variance-covariant-arg-object.rs:18:21
+  --> $DIR/variance-invariant-arg-object.rs:20:21
    |
 LL | fn get_max_from_min<'min, 'max, G>(v: Box<dyn Get<&'min i32>>)
    |                     ^^^^
 note: ...does not necessarily outlive the lifetime `'max` as defined here
-  --> $DIR/variance-covariant-arg-object.rs:18:27
+  --> $DIR/variance-invariant-arg-object.rs:20:27
    |
 LL | fn get_max_from_min<'min, 'max, G>(v: Box<dyn Get<&'min i32>>)
    |                           ^^^^

--- a/src/test/ui/variance/variance-invariant-arg-object.nll.stderr
+++ b/src/test/ui/variance/variance-invariant-arg-object.nll.stderr
@@ -1,5 +1,5 @@
 error: lifetime may not live long enough
-  --> $DIR/variance-invariant-arg-object.rs:11:5
+  --> $DIR/variance-invariant-arg-object.rs:15:5
    |
 LL | fn get_min_from_max<'min, 'max>(v: Box<dyn Get<&'max i32>>)
    |                     ----  ---- lifetime `'max` defined here
@@ -12,7 +12,7 @@ LL |     v
    = help: consider adding the following bound: `'min: 'max`
 
 error: lifetime may not live long enough
-  --> $DIR/variance-invariant-arg-object.rs:18:5
+  --> $DIR/variance-invariant-arg-object.rs:24:5
    |
 LL | fn get_max_from_min<'min, 'max, G>(v: Box<dyn Get<&'min i32>>)
    |                     ----  ---- lifetime `'max` defined here

--- a/src/test/ui/variance/variance-invariant-arg-object.rs
+++ b/src/test/ui/variance/variance-invariant-arg-object.rs
@@ -1,5 +1,9 @@
 #![allow(dead_code)]
 
+// revisions: base nll
+// ignore-compare-mode-nll
+//[nll] compile-flags: -Z borrowck=mir
+
 trait Get<T> : 'static {
     fn get(&self, t: T) -> T;
 }
@@ -8,14 +12,18 @@ fn get_min_from_max<'min, 'max>(v: Box<dyn Get<&'max i32>>)
                                 -> Box<dyn Get<&'min i32>>
     where 'max : 'min
 {
-    v //~ ERROR mismatched types
+    v
+    //[base]~^ ERROR mismatched types
+    //[nll]~^^ ERROR lifetime may not live long enough
 }
 
 fn get_max_from_min<'min, 'max, G>(v: Box<dyn Get<&'min i32>>)
                                    -> Box<dyn Get<&'max i32>>
     where 'max : 'min
 {
-    v //~ ERROR mismatched types
+    v
+    //[base]~^ ERROR mismatched types
+    //[nll]~^^ ERROR lifetime may not live long enough
 }
 
 fn main() { }

--- a/src/test/ui/variance/variance-invariant-arg-trait-match.base.stderr
+++ b/src/test/ui/variance/variance-invariant-arg-trait-match.base.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/variance-covariant-arg-trait-match.rs:14:5
+  --> $DIR/variance-invariant-arg-trait-match.rs:14:5
    |
 LL |     impls_get::<G,&'min i32>()
    |     ^^^^^^^^^^^^^^^^^^^^^^^^ lifetime mismatch
@@ -7,18 +7,18 @@ LL |     impls_get::<G,&'min i32>()
    = note: expected type `Get<&'min i32>`
               found type `Get<&'max i32>`
 note: the lifetime `'min` as defined here...
-  --> $DIR/variance-covariant-arg-trait-match.rs:10:21
+  --> $DIR/variance-invariant-arg-trait-match.rs:11:21
    |
 LL | fn get_min_from_max<'min, 'max, G>()
    |                     ^^^^
 note: ...does not necessarily outlive the lifetime `'max` as defined here
-  --> $DIR/variance-covariant-arg-trait-match.rs:10:27
+  --> $DIR/variance-invariant-arg-trait-match.rs:11:27
    |
 LL | fn get_min_from_max<'min, 'max, G>()
    |                           ^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/variance-covariant-arg-trait-match.rs:20:5
+  --> $DIR/variance-invariant-arg-trait-match.rs:22:5
    |
 LL |     impls_get::<G,&'max i32>()
    |     ^^^^^^^^^^^^^^^^^^^^^^^^ lifetime mismatch
@@ -26,12 +26,12 @@ LL |     impls_get::<G,&'max i32>()
    = note: expected type `Get<&'max i32>`
               found type `Get<&'min i32>`
 note: the lifetime `'min` as defined here...
-  --> $DIR/variance-covariant-arg-trait-match.rs:17:21
+  --> $DIR/variance-invariant-arg-trait-match.rs:19:21
    |
 LL | fn get_max_from_min<'min, 'max, G>()
    |                     ^^^^
 note: ...does not necessarily outlive the lifetime `'max` as defined here
-  --> $DIR/variance-covariant-arg-trait-match.rs:17:27
+  --> $DIR/variance-invariant-arg-trait-match.rs:19:27
    |
 LL | fn get_max_from_min<'min, 'max, G>()
    |                           ^^^^

--- a/src/test/ui/variance/variance-invariant-arg-trait-match.nll.stderr
+++ b/src/test/ui/variance/variance-invariant-arg-trait-match.nll.stderr
@@ -1,5 +1,5 @@
 error: lifetime may not live long enough
-  --> $DIR/variance-invariant-arg-trait-match.rs:10:5
+  --> $DIR/variance-invariant-arg-trait-match.rs:14:5
    |
 LL | fn get_min_from_max<'min, 'max, G>()
    |                     ----  ---- lifetime `'max` defined here
@@ -12,7 +12,7 @@ LL |     impls_get::<G,&'min i32>()
    = help: consider adding the following bound: `'min: 'max`
 
 error: lifetime may not live long enough
-  --> $DIR/variance-invariant-arg-trait-match.rs:16:5
+  --> $DIR/variance-invariant-arg-trait-match.rs:22:5
    |
 LL | fn get_max_from_min<'min, 'max, G>()
    |                     ----  ---- lifetime `'max` defined here

--- a/src/test/ui/variance/variance-invariant-arg-trait-match.rs
+++ b/src/test/ui/variance/variance-invariant-arg-trait-match.rs
@@ -1,5 +1,9 @@
 #![allow(dead_code)]
 
+// revisions: base nll
+// ignore-compare-mode-nll
+//[nll] compile-flags: -Z borrowck=mir
+
 trait Get<T> {
     fn get(&self, t: T) -> T;
 }
@@ -7,13 +11,17 @@ trait Get<T> {
 fn get_min_from_max<'min, 'max, G>()
     where 'max : 'min, G : Get<&'max i32>
 {
-    impls_get::<G,&'min i32>() //~ ERROR mismatched types
+    impls_get::<G,&'min i32>()
+    //[base]~^ ERROR mismatched types
+    //[nll]~^^ ERROR lifetime may not live long enough
 }
 
 fn get_max_from_min<'min, 'max, G>()
     where 'max : 'min, G : Get<&'min i32>
 {
-    impls_get::<G,&'max i32>() //~ ERROR mismatched types
+    impls_get::<G,&'max i32>()
+    //[base]~^ ERROR mismatched types
+    //[nll]~^^ ERROR lifetime may not live long enough
 }
 
 fn impls_get<G,T>() where G : Get<T> { }

--- a/src/test/ui/variance/variance-invariant-self-trait-match.base.stderr
+++ b/src/test/ui/variance/variance-invariant-self-trait-match.base.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/variance-invariant-self-trait-match.rs:10:5
+  --> $DIR/variance-invariant-self-trait-match.rs:14:5
    |
 LL |     impls_get::<&'min G>();
    |     ^^^^^^^^^^^^^^^^^^^^ lifetime mismatch
@@ -7,18 +7,18 @@ LL |     impls_get::<&'min G>();
    = note: expected type `<&'min G as Get>`
               found type `<&'max G as Get>`
 note: the lifetime `'min` as defined here...
-  --> $DIR/variance-invariant-self-trait-match.rs:7:21
+  --> $DIR/variance-invariant-self-trait-match.rs:11:21
    |
 LL | fn get_min_from_max<'min, 'max, G>()
    |                     ^^^^
 note: ...does not necessarily outlive the lifetime `'max` as defined here
-  --> $DIR/variance-invariant-self-trait-match.rs:7:27
+  --> $DIR/variance-invariant-self-trait-match.rs:11:27
    |
 LL | fn get_min_from_max<'min, 'max, G>()
    |                           ^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/variance-invariant-self-trait-match.rs:16:5
+  --> $DIR/variance-invariant-self-trait-match.rs:22:5
    |
 LL |     impls_get::<&'max G>();
    |     ^^^^^^^^^^^^^^^^^^^^ lifetime mismatch
@@ -26,12 +26,12 @@ LL |     impls_get::<&'max G>();
    = note: expected type `<&'max G as Get>`
               found type `<&'min G as Get>`
 note: the lifetime `'min` as defined here...
-  --> $DIR/variance-invariant-self-trait-match.rs:13:21
+  --> $DIR/variance-invariant-self-trait-match.rs:19:21
    |
 LL | fn get_max_from_min<'min, 'max, G>()
    |                     ^^^^
 note: ...does not necessarily outlive the lifetime `'max` as defined here
-  --> $DIR/variance-invariant-self-trait-match.rs:13:27
+  --> $DIR/variance-invariant-self-trait-match.rs:19:27
    |
 LL | fn get_max_from_min<'min, 'max, G>()
    |                           ^^^^

--- a/src/test/ui/variance/variance-invariant-self-trait-match.nll.stderr
+++ b/src/test/ui/variance/variance-invariant-self-trait-match.nll.stderr
@@ -1,5 +1,5 @@
 error: lifetime may not live long enough
-  --> $DIR/variance-invariant-self-trait-match.rs:10:5
+  --> $DIR/variance-invariant-self-trait-match.rs:14:5
    |
 LL | fn get_min_from_max<'min, 'max, G>()
    |                     ----  ---- lifetime `'max` defined here
@@ -12,7 +12,7 @@ LL |     impls_get::<&'min G>();
    = help: consider adding the following bound: `'min: 'max`
 
 error: lifetime may not live long enough
-  --> $DIR/variance-invariant-self-trait-match.rs:16:5
+  --> $DIR/variance-invariant-self-trait-match.rs:22:5
    |
 LL | fn get_max_from_min<'min, 'max, G>()
    |                     ----  ---- lifetime `'max` defined here

--- a/src/test/ui/variance/variance-invariant-self-trait-match.rs
+++ b/src/test/ui/variance/variance-invariant-self-trait-match.rs
@@ -1,5 +1,9 @@
 #![allow(dead_code)]
 
+// revisions: base nll
+// ignore-compare-mode-nll
+//[nll] compile-flags: -Z borrowck=mir
+
 trait Get {
     fn get(&self) -> Self;
 }
@@ -7,13 +11,17 @@ trait Get {
 fn get_min_from_max<'min, 'max, G>()
     where 'max : 'min, &'max G : Get, G : 'max
 {
-    impls_get::<&'min G>(); //~ ERROR mismatched types
+    impls_get::<&'min G>();
+    //[base]~^ ERROR mismatched types
+    //[nll]~^^ ERROR lifetime may not live long enough
 }
 
 fn get_max_from_min<'min, 'max, G>()
     where 'max : 'min, &'min G : Get, G : 'min
 {
-    impls_get::<&'max G>(); //~ ERROR mismatched types
+    impls_get::<&'max G>();
+    //[base]~^ ERROR mismatched types
+    //[nll]~^^ ERROR lifetime may not live long enough
 }
 
 fn impls_get<G>() where G : Get { }

--- a/src/test/ui/variance/variance-trait-matching.base.stderr
+++ b/src/test/ui/variance/variance-trait-matching.base.stderr
@@ -1,5 +1,5 @@
 error[E0621]: explicit lifetime required in the type of `get`
-  --> $DIR/variance-trait-matching.rs:24:5
+  --> $DIR/variance-trait-matching.rs:28:5
    |
 LL | fn get<'a, G>(get: &G) -> i32
    |                    -- help: add explicit lifetime `'a` to the type of `get`: `&'a G`

--- a/src/test/ui/variance/variance-trait-matching.nll.stderr
+++ b/src/test/ui/variance/variance-trait-matching.nll.stderr
@@ -1,5 +1,5 @@
 error[E0621]: explicit lifetime required in the type of `get`
-  --> $DIR/variance-trait-matching.rs:24:5
+  --> $DIR/variance-trait-matching.rs:28:5
    |
 LL | fn get<'a, G>(get: &G) -> i32
    |                    -- help: add explicit lifetime `'a` to the type of `get`: `&'a G`

--- a/src/test/ui/variance/variance-trait-matching.rs
+++ b/src/test/ui/variance/variance-trait-matching.rs
@@ -1,5 +1,9 @@
 #![allow(dead_code)]
 
+// revisions: base nll
+// ignore-compare-mode-nll
+//[nll] compile-flags: -Z borrowck=mir
+
 // Get<T> is covariant in T
 trait Get<T> {
     fn get(&self) -> T;

--- a/src/test/ui/variance/variance-use-contravariant-struct-1.base.stderr
+++ b/src/test/ui/variance/variance-use-contravariant-struct-1.base.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/variance-use-contravariant-struct-1.rs:12:5
+  --> $DIR/variance-use-contravariant-struct-1.rs:14:5
    |
 LL |     v
    |     ^ lifetime mismatch
@@ -7,12 +7,12 @@ LL |     v
    = note: expected struct `SomeStruct<&'min ()>`
               found struct `SomeStruct<&'max ()>`
 note: the lifetime `'min` as defined here...
-  --> $DIR/variance-use-contravariant-struct-1.rs:8:8
+  --> $DIR/variance-use-contravariant-struct-1.rs:10:8
    |
 LL | fn foo<'min,'max>(v: SomeStruct<&'max ()>)
    |        ^^^^
 note: ...does not necessarily outlive the lifetime `'max` as defined here
-  --> $DIR/variance-use-contravariant-struct-1.rs:8:13
+  --> $DIR/variance-use-contravariant-struct-1.rs:10:13
    |
 LL | fn foo<'min,'max>(v: SomeStruct<&'max ()>)
    |             ^^^^

--- a/src/test/ui/variance/variance-use-contravariant-struct-1.nll.stderr
+++ b/src/test/ui/variance/variance-use-contravariant-struct-1.nll.stderr
@@ -1,5 +1,5 @@
 error: lifetime may not live long enough
-  --> $DIR/variance-use-contravariant-struct-1.rs:12:5
+  --> $DIR/variance-use-contravariant-struct-1.rs:14:5
    |
 LL | fn foo<'min,'max>(v: SomeStruct<&'max ()>)
    |        ---- ---- lifetime `'max` defined here

--- a/src/test/ui/variance/variance-use-contravariant-struct-1.rs
+++ b/src/test/ui/variance/variance-use-contravariant-struct-1.rs
@@ -1,7 +1,9 @@
 // Test various uses of structs with distint variances to make sure
 // they permit lifetimes to be approximated as expected.
 
-
+// revisions: base nll
+// ignore-compare-mode-nll
+//[nll] compile-flags: -Z borrowck=mir
 
 struct SomeStruct<T>(fn(T));
 
@@ -9,7 +11,9 @@ fn foo<'min,'max>(v: SomeStruct<&'max ()>)
                   -> SomeStruct<&'min ()>
     where 'max : 'min
 {
-    v //~ ERROR mismatched types
+    v
+    //[base]~^ ERROR mismatched types
+    //[nll]~^^ ERROR lifetime may not live long enough
 }
 
 

--- a/src/test/ui/variance/variance-use-covariant-struct-1.base.stderr
+++ b/src/test/ui/variance/variance-use-covariant-struct-1.base.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/variance-use-covariant-struct-1.rs:10:5
+  --> $DIR/variance-use-covariant-struct-1.rs:14:5
    |
 LL |     v
    |     ^ lifetime mismatch
@@ -7,12 +7,12 @@ LL |     v
    = note: expected struct `SomeStruct<&'max ()>`
               found struct `SomeStruct<&'min ()>`
 note: the lifetime `'min` as defined here...
-  --> $DIR/variance-use-covariant-struct-1.rs:6:8
+  --> $DIR/variance-use-covariant-struct-1.rs:10:8
    |
 LL | fn foo<'min,'max>(v: SomeStruct<&'min ()>)
    |        ^^^^
 note: ...does not necessarily outlive the lifetime `'max` as defined here
-  --> $DIR/variance-use-covariant-struct-1.rs:6:13
+  --> $DIR/variance-use-covariant-struct-1.rs:10:13
    |
 LL | fn foo<'min,'max>(v: SomeStruct<&'min ()>)
    |             ^^^^

--- a/src/test/ui/variance/variance-use-covariant-struct-1.nll.stderr
+++ b/src/test/ui/variance/variance-use-covariant-struct-1.nll.stderr
@@ -1,5 +1,5 @@
 error: lifetime may not live long enough
-  --> $DIR/variance-use-covariant-struct-1.rs:10:5
+  --> $DIR/variance-use-covariant-struct-1.rs:14:5
    |
 LL | fn foo<'min,'max>(v: SomeStruct<&'min ()>)
    |        ---- ---- lifetime `'max` defined here

--- a/src/test/ui/variance/variance-use-covariant-struct-1.rs
+++ b/src/test/ui/variance/variance-use-covariant-struct-1.rs
@@ -1,13 +1,19 @@
 // Test that a covariant struct does not permit the lifetime of a
 // reference to be enlarged.
 
+// revisions: base nll
+// ignore-compare-mode-nll
+//[nll] compile-flags: -Z borrowck=mir
+
 struct SomeStruct<T>(T);
 
 fn foo<'min,'max>(v: SomeStruct<&'min ()>)
                   -> SomeStruct<&'max ()>
     where 'max : 'min
 {
-    v //~ ERROR mismatched types
+    v
+    //[base]~^ ERROR mismatched types
+    //[nll]~^^ ERROR lifetime may not live long enough
 }
 
 fn main() { }

--- a/src/test/ui/variance/variance-use-invariant-struct-1.base.stderr
+++ b/src/test/ui/variance/variance-use-invariant-struct-1.base.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/variance-use-invariant-struct-1.rs:12:5
+  --> $DIR/variance-use-invariant-struct-1.rs:14:5
    |
 LL |     v
    |     ^ lifetime mismatch
@@ -7,18 +7,18 @@ LL |     v
    = note: expected struct `SomeStruct<&'min ()>`
               found struct `SomeStruct<&'max ()>`
 note: the lifetime `'min` as defined here...
-  --> $DIR/variance-use-invariant-struct-1.rs:8:8
+  --> $DIR/variance-use-invariant-struct-1.rs:10:8
    |
 LL | fn foo<'min,'max>(v: SomeStruct<&'max ()>)
    |        ^^^^
 note: ...does not necessarily outlive the lifetime `'max` as defined here
-  --> $DIR/variance-use-invariant-struct-1.rs:8:13
+  --> $DIR/variance-use-invariant-struct-1.rs:10:13
    |
 LL | fn foo<'min,'max>(v: SomeStruct<&'max ()>)
    |             ^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/variance-use-invariant-struct-1.rs:19:5
+  --> $DIR/variance-use-invariant-struct-1.rs:23:5
    |
 LL |     v
    |     ^ lifetime mismatch
@@ -26,12 +26,12 @@ LL |     v
    = note: expected struct `SomeStruct<&'max ()>`
               found struct `SomeStruct<&'min ()>`
 note: the lifetime `'min` as defined here...
-  --> $DIR/variance-use-invariant-struct-1.rs:15:8
+  --> $DIR/variance-use-invariant-struct-1.rs:19:8
    |
 LL | fn bar<'min,'max>(v: SomeStruct<&'min ()>)
    |        ^^^^
 note: ...does not necessarily outlive the lifetime `'max` as defined here
-  --> $DIR/variance-use-invariant-struct-1.rs:15:13
+  --> $DIR/variance-use-invariant-struct-1.rs:19:13
    |
 LL | fn bar<'min,'max>(v: SomeStruct<&'min ()>)
    |             ^^^^

--- a/src/test/ui/variance/variance-use-invariant-struct-1.nll.stderr
+++ b/src/test/ui/variance/variance-use-invariant-struct-1.nll.stderr
@@ -1,5 +1,5 @@
 error: lifetime may not live long enough
-  --> $DIR/variance-use-invariant-struct-1.rs:12:5
+  --> $DIR/variance-use-invariant-struct-1.rs:14:5
    |
 LL | fn foo<'min,'max>(v: SomeStruct<&'max ()>)
    |        ---- ---- lifetime `'max` defined here
@@ -15,7 +15,7 @@ LL |     v
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
 error: lifetime may not live long enough
-  --> $DIR/variance-use-invariant-struct-1.rs:19:5
+  --> $DIR/variance-use-invariant-struct-1.rs:23:5
    |
 LL | fn bar<'min,'max>(v: SomeStruct<&'min ()>)
    |        ---- ---- lifetime `'max` defined here

--- a/src/test/ui/variance/variance-use-invariant-struct-1.rs
+++ b/src/test/ui/variance/variance-use-invariant-struct-1.rs
@@ -1,7 +1,9 @@
 // Test various uses of structs with distint variances to make sure
 // they permit lifetimes to be approximated as expected.
 
-
+// revisions: base nll
+// ignore-compare-mode-nll
+//[nll] compile-flags: -Z borrowck=mir
 
 struct SomeStruct<T>(*mut T);
 
@@ -9,14 +11,18 @@ fn foo<'min,'max>(v: SomeStruct<&'max ()>)
                   -> SomeStruct<&'min ()>
     where 'max : 'min
 {
-    v //~ ERROR mismatched types
+    v
+    //[base]~^ ERROR mismatched types
+    //[nll]~^^ ERROR lifetime may not live long enough
 }
 
 fn bar<'min,'max>(v: SomeStruct<&'min ()>)
                   -> SomeStruct<&'max ()>
     where 'max : 'min
 {
-    v //~ ERROR mismatched types
+    v
+    //[base]~^ ERROR mismatched types
+    //[nll]~^^ ERROR lifetime may not live long enough
 }
 
 

--- a/src/test/ui/wf/wf-static-method.base.stderr
+++ b/src/test/ui/wf/wf-static-method.base.stderr
@@ -1,131 +1,131 @@
 error[E0312]: lifetime of reference outlives lifetime of borrowed content...
-  --> $DIR/wf-static-method.rs:17:9
+  --> $DIR/wf-static-method.rs:21:9
    |
 LL |         u
    |         ^
    |
 note: ...the reference is valid for the lifetime `'a` as defined here...
-  --> $DIR/wf-static-method.rs:14:6
+  --> $DIR/wf-static-method.rs:18:6
    |
 LL | impl<'a, 'b> Foo<'a, 'b, Evil<'a, 'b>> for () {
    |      ^^
 note: ...but the borrowed content is only valid for the lifetime `'b` as defined here
-  --> $DIR/wf-static-method.rs:14:10
+  --> $DIR/wf-static-method.rs:18:10
    |
 LL | impl<'a, 'b> Foo<'a, 'b, Evil<'a, 'b>> for () {
    |          ^^
 
 error[E0478]: lifetime bound not satisfied
-  --> $DIR/wf-static-method.rs:26:18
+  --> $DIR/wf-static-method.rs:32:18
    |
 LL |         let me = Self::make_me();
    |                  ^^^^
    |
 note: lifetime parameter instantiated with the lifetime `'b` as defined here
-  --> $DIR/wf-static-method.rs:23:10
+  --> $DIR/wf-static-method.rs:29:10
    |
 LL | impl<'a, 'b> Foo<'a, 'b, ()> for IndirectEvil<'a, 'b> {
    |          ^^
 note: but lifetime parameter must outlive the lifetime `'a` as defined here
-  --> $DIR/wf-static-method.rs:23:6
+  --> $DIR/wf-static-method.rs:29:6
    |
 LL | impl<'a, 'b> Foo<'a, 'b, ()> for IndirectEvil<'a, 'b> {
    |      ^^
 
 error[E0312]: lifetime of reference outlives lifetime of borrowed content...
-  --> $DIR/wf-static-method.rs:33:9
+  --> $DIR/wf-static-method.rs:41:9
    |
 LL |         u
    |         ^
    |
 note: ...the reference is valid for the lifetime `'a` as defined here...
-  --> $DIR/wf-static-method.rs:31:6
+  --> $DIR/wf-static-method.rs:39:6
    |
 LL | impl<'a, 'b> Evil<'a, 'b> {
    |      ^^
 note: ...but the borrowed content is only valid for the lifetime `'b` as defined here
-  --> $DIR/wf-static-method.rs:31:10
+  --> $DIR/wf-static-method.rs:39:10
    |
 LL | impl<'a, 'b> Evil<'a, 'b> {
    |          ^^
 
 error[E0495]: cannot infer an appropriate lifetime for lifetime parameter `'b` due to conflicting requirements
-  --> $DIR/wf-static-method.rs:41:5
+  --> $DIR/wf-static-method.rs:51:5
    |
 LL |     <()>::static_evil(b)
    |     ^^^^^^^^^^^^^^^^^
    |
 note: first, the lifetime cannot outlive the lifetime `'b` as defined here...
-  --> $DIR/wf-static-method.rs:40:13
+  --> $DIR/wf-static-method.rs:50:13
    |
 LL | fn evil<'a, 'b>(b: &'b u32) -> &'a u32 {
    |             ^^
 note: ...so that reference does not outlive borrowed content
-  --> $DIR/wf-static-method.rs:41:23
+  --> $DIR/wf-static-method.rs:51:23
    |
 LL |     <()>::static_evil(b)
    |                       ^
 note: but, the lifetime must be valid for the lifetime `'a` as defined here...
-  --> $DIR/wf-static-method.rs:40:9
+  --> $DIR/wf-static-method.rs:50:9
    |
 LL | fn evil<'a, 'b>(b: &'b u32) -> &'a u32 {
    |         ^^
 note: ...so that reference does not outlive borrowed content
-  --> $DIR/wf-static-method.rs:41:5
+  --> $DIR/wf-static-method.rs:51:5
    |
 LL |     <()>::static_evil(b)
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error[E0495]: cannot infer an appropriate lifetime for lifetime parameter `'b` due to conflicting requirements
-  --> $DIR/wf-static-method.rs:45:5
+  --> $DIR/wf-static-method.rs:57:5
    |
 LL |     <IndirectEvil>::static_evil(b)
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: first, the lifetime cannot outlive the lifetime `'b` as defined here...
-  --> $DIR/wf-static-method.rs:44:22
+  --> $DIR/wf-static-method.rs:56:22
    |
 LL | fn indirect_evil<'a, 'b>(b: &'b u32) -> &'a u32 {
    |                      ^^
 note: ...so that reference does not outlive borrowed content
-  --> $DIR/wf-static-method.rs:45:33
+  --> $DIR/wf-static-method.rs:57:33
    |
 LL |     <IndirectEvil>::static_evil(b)
    |                                 ^
 note: but, the lifetime must be valid for the lifetime `'a` as defined here...
-  --> $DIR/wf-static-method.rs:44:18
+  --> $DIR/wf-static-method.rs:56:18
    |
 LL | fn indirect_evil<'a, 'b>(b: &'b u32) -> &'a u32 {
    |                  ^^
 note: ...so that reference does not outlive borrowed content
-  --> $DIR/wf-static-method.rs:45:5
+  --> $DIR/wf-static-method.rs:57:5
    |
 LL |     <IndirectEvil>::static_evil(b)
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0495]: cannot infer an appropriate lifetime for lifetime parameter `'b` due to conflicting requirements
-  --> $DIR/wf-static-method.rs:50:5
+  --> $DIR/wf-static-method.rs:63:5
    |
 LL |     <Evil>::inherent_evil(b)
    |     ^^^^^^^^^^^^^^^^^^^^^
    |
 note: first, the lifetime cannot outlive the lifetime `'b` as defined here...
-  --> $DIR/wf-static-method.rs:49:22
+  --> $DIR/wf-static-method.rs:62:22
    |
 LL | fn inherent_evil<'a, 'b>(b: &'b u32) -> &'a u32 {
    |                      ^^
 note: ...so that reference does not outlive borrowed content
-  --> $DIR/wf-static-method.rs:50:27
+  --> $DIR/wf-static-method.rs:63:27
    |
 LL |     <Evil>::inherent_evil(b)
    |                           ^
 note: but, the lifetime must be valid for the lifetime `'a` as defined here...
-  --> $DIR/wf-static-method.rs:49:18
+  --> $DIR/wf-static-method.rs:62:18
    |
 LL | fn inherent_evil<'a, 'b>(b: &'b u32) -> &'a u32 {
    |                  ^^
 note: ...so that reference does not outlive borrowed content
-  --> $DIR/wf-static-method.rs:50:5
+  --> $DIR/wf-static-method.rs:63:5
    |
 LL |     <Evil>::inherent_evil(b)
    |     ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/wf/wf-static-method.nll.stderr
+++ b/src/test/ui/wf/wf-static-method.nll.stderr
@@ -1,5 +1,5 @@
 error: lifetime may not live long enough
-  --> $DIR/wf-static-method.rs:17:9
+  --> $DIR/wf-static-method.rs:21:9
    |
 LL | impl<'a, 'b> Foo<'a, 'b, Evil<'a, 'b>> for () {
    |      --  -- lifetime `'b` defined here
@@ -12,7 +12,7 @@ LL |         u
    = help: consider adding the following bound: `'b: 'a`
 
 error: lifetime may not live long enough
-  --> $DIR/wf-static-method.rs:26:18
+  --> $DIR/wf-static-method.rs:32:18
    |
 LL | impl<'a, 'b> Foo<'a, 'b, ()> for IndirectEvil<'a, 'b> {
    |      --  -- lifetime `'b` defined here
@@ -25,7 +25,7 @@ LL |         let me = Self::make_me();
    = help: consider adding the following bound: `'b: 'a`
 
 error: lifetime may not live long enough
-  --> $DIR/wf-static-method.rs:33:9
+  --> $DIR/wf-static-method.rs:41:9
    |
 LL | impl<'a, 'b> Evil<'a, 'b> {
    |      --  -- lifetime `'b` defined here
@@ -38,7 +38,7 @@ LL |         u
    = help: consider adding the following bound: `'b: 'a`
 
 error: lifetime may not live long enough
-  --> $DIR/wf-static-method.rs:41:5
+  --> $DIR/wf-static-method.rs:51:5
    |
 LL | fn evil<'a, 'b>(b: &'b u32) -> &'a u32 {
    |         --  -- lifetime `'b` defined here
@@ -50,7 +50,7 @@ LL |     <()>::static_evil(b)
    = help: consider adding the following bound: `'b: 'a`
 
 error: lifetime may not live long enough
-  --> $DIR/wf-static-method.rs:45:5
+  --> $DIR/wf-static-method.rs:57:5
    |
 LL | fn indirect_evil<'a, 'b>(b: &'b u32) -> &'a u32 {
    |                  --  -- lifetime `'b` defined here
@@ -62,7 +62,7 @@ LL |     <IndirectEvil>::static_evil(b)
    = help: consider adding the following bound: `'b: 'a`
 
 error: lifetime may not live long enough
-  --> $DIR/wf-static-method.rs:50:5
+  --> $DIR/wf-static-method.rs:63:5
    |
 LL | fn inherent_evil<'a, 'b>(b: &'b u32) -> &'a u32 {
    |                  --  -- lifetime `'b` defined here

--- a/src/test/ui/wf/wf-static-method.rs
+++ b/src/test/ui/wf/wf-static-method.rs
@@ -4,6 +4,10 @@
 // static inherent methods isn't quite working - need to
 // fix that before removing the check.
 
+// revisions: base nll
+// ignore-compare-mode-nll
+//[nll] compile-flags: -Z borrowck=mir
+
 trait Foo<'a, 'b, T>: Sized {
     fn make_me() -> Self { loop {} }
     fn static_evil(u: &'b u32) -> &'a u32;
@@ -14,7 +18,9 @@ struct Evil<'a, 'b: 'a>(Option<&'a &'b ()>);
 impl<'a, 'b> Foo<'a, 'b, Evil<'a, 'b>> for () {
     fn make_me() -> Self { }
     fn static_evil(u: &'b u32) -> &'a u32 {
-        u //~ ERROR E0312
+        u
+        //[base]~^ ERROR E0312
+        //[nll]~^^ ERROR lifetime may not live long enough
     }
 }
 
@@ -23,14 +29,18 @@ struct IndirectEvil<'a, 'b: 'a>(Option<&'a &'b ()>);
 impl<'a, 'b> Foo<'a, 'b, ()> for IndirectEvil<'a, 'b> {
     fn make_me() -> Self { IndirectEvil(None) }
     fn static_evil(u: &'b u32) -> &'a u32 {
-        let me = Self::make_me(); //~ ERROR lifetime bound not satisfied
+        let me = Self::make_me();
+        //[base]~^ ERROR lifetime bound not satisfied
+        //[nll]~^^ ERROR lifetime may not live long enough
         loop {} // (`me` could be used for the lifetime transmute).
     }
 }
 
 impl<'a, 'b> Evil<'a, 'b> {
     fn inherent_evil(u: &'b u32) -> &'a u32 {
-        u //~ ERROR E0312
+        u
+        //[base]~^ ERROR E0312
+        //[nll]~^^ ERROR lifetime may not live long enough
     }
 }
 
@@ -38,17 +48,21 @@ impl<'a, 'b> Evil<'a, 'b> {
 // *check* that they hold.
 
 fn evil<'a, 'b>(b: &'b u32) -> &'a u32 {
-    <()>::static_evil(b) //~ ERROR cannot infer an appropriate lifetime
+    <()>::static_evil(b)
+    //[base]~^ ERROR cannot infer an appropriate lifetime
+    //[nll]~^^ ERROR lifetime may not live long enough
 }
 
 fn indirect_evil<'a, 'b>(b: &'b u32) -> &'a u32 {
     <IndirectEvil>::static_evil(b)
-    //~^ ERROR cannot infer an appropriate lifetime
+    //[base]~^ ERROR cannot infer an appropriate lifetime
+    //[nll]~^^ ERROR lifetime may not live long enough
 }
 
 fn inherent_evil<'a, 'b>(b: &'b u32) -> &'a u32 {
     <Evil>::inherent_evil(b)
-    //~^ ERROR cannot infer an appropriate lifetime
+    //[base]~^ ERROR cannot infer an appropriate lifetime
+    //[nll]~^^ ERROR lifetime may not live long enough
 }
 
 

--- a/src/test/ui/where-clauses/where-for-self-2.base.stderr
+++ b/src/test/ui/where-clauses/where-for-self-2.base.stderr
@@ -1,5 +1,5 @@
 error: implementation of `Bar` is not general enough
-  --> $DIR/where-for-self-2.rs:23:5
+  --> $DIR/where-for-self-2.rs:27:5
    |
 LL |     foo(&X);
    |     ^^^ implementation of `Bar` is not general enough

--- a/src/test/ui/where-clauses/where-for-self-2.nll.stderr
+++ b/src/test/ui/where-clauses/where-for-self-2.nll.stderr
@@ -1,5 +1,5 @@
 error: implementation of `Bar` is not general enough
-  --> $DIR/where-for-self-2.rs:23:5
+  --> $DIR/where-for-self-2.rs:27:5
    |
 LL |     foo(&X);
    |     ^^^^^^^ implementation of `Bar` is not general enough

--- a/src/test/ui/where-clauses/where-for-self-2.rs
+++ b/src/test/ui/where-clauses/where-for-self-2.rs
@@ -3,6 +3,10 @@
 // specific lifetime is not enough to satisfy the `for<'a> ...` constraint, which
 // should require *all* lifetimes.
 
+// revisions: base nll
+// ignore-compare-mode-nll
+//[nll] compile-flags: -Z borrowck=mir
+
 static X: &'static u32 = &42;
 
 trait Bar {


### PR DESCRIPTION
The idea here is 2 fold: 1) When we eventually do make NLL default on, that PR should be systematic in "delete revisions and corresponding error annotations" 2) This allows us to look at test NLL outputs in chunks. (Though, I've opted here not to "mark" these tests. There are some tests with NLL revisions *now* that will be missed. I expect we do a second pass once we have all the tests with NLL revisions; these tests should be easy enough to eyeball.)

The actual review here should be "easy", but a bit tedious. I expect we should manually go through each test output and confirm it's okay. 

The majority of these are either: 1) Only span change (the one I see most common is highlighting an entire function call, rather than just the function name in that call) 2) "E0308 mismatched types" -> "lifetime does not live long enough" 3) "E0495 cannot infer an appropriate lifetime for lifetime parameter" -> "lifetime does not live long enough" 4) "E0312 lifetime of reference outlives lifetime of borrowed content" -> "lifetime does not live long enough" 5) "E0759 `XXX` has an anonymous lifetime `'_` but it needs to satisfy a `'static` lifetime requirement" -> "lifetime does not live long enough" 6) "E0623 lifetime mismatch" -> "lifetime does not live long enough"

Other than the now lack of an error code, most of these look fine (with most giving more helpful suggestions now).

`rfc1623` output isn't great.

cc @marmeladema if you want to look through these

Let's r? @oli-obk since you've commented on the Zulip thread ;)