### PR TITLE
Fix typo in default.rs (`derive`d to `derived`)

### DIFF
--- a/library/core/src/default.rs
+++ b/library/core/src/default.rs
@@ -50,7 +50,7 @@
 /// ## Derivable
 ///
 /// This trait can be used with `#[derive]` if all of the type's fields implement
-/// `Default`. When `derive`d, it will use the default value for each field's type.
+/// `Default`. When `derived`, it will use the default value for each field's type.
 ///
 /// ## How can I implement `Default`?
 ///


### PR DESCRIPTION
Changed `derive`d to `derived` in library/core/src/default.rs.