### PR TITLE
Additional `*mut [T]` methods

### DIFF
--- a/library/core/src/ptr/mut_ptr.rs
+++ b/library/core/src/ptr/mut_ptr.rs
@@ -1382,7 +1382,7 @@ impl<T> *mut [T] {
     /// ```
     #[inline(always)]
     #[track_caller]
-    #[unstable(feature = "raw_slice_split", issue = "71146")]
+    #[unstable(feature = "raw_slice_split", issue = "95595")]
     pub fn split_at_mut(self, mid: usize) -> (*mut [T], *mut [T]) {
         assert!(mid <= self.len());
         // SAFETY: `[ptr; mid]` and `[mid; len]` are inside `self`, which
@@ -1426,7 +1426,7 @@ impl<T> *mut [T] {
     /// assert_eq!(v, [1, 2, 3, 4, 5, 6]);
     /// ```
     #[inline(always)]
-    #[unstable(feature = "raw_slice_split", issue = "71146")]
+    #[unstable(feature = "raw_slice_split", issue = "95595")]
     pub unsafe fn split_at_mut_unchecked(self, mid: usize) -> (*mut [T], *mut [T]) {
         let len = self.len();
         let ptr = self.as_mut_ptr();


### PR DESCRIPTION
Split out from #94247

This adds the following methods to raw slices that already exist on regular slices

* `*mut [T]::is_empty`
* `*mut [T]::split_at_mut`
* `*mut [T]::split_at_mut_unchecked`

These methods reduce the amount of unsafe code needed to migrate `ChunksMut` and related iterators
to raw slices (#94247)

r? @m-ou-se 