### PR TITLE
Refer to u8 by absolute path in expansion of thread_local

### DIFF
--- a/library/std/src/thread/local.rs
+++ b/library/std/src/thread/local.rs
@@ -217,9 +217,9 @@ macro_rules! __thread_local_inner {
                 // 1 == dtor registered, dtor not run
                 // 2 == dtor registered and is running or has run
                 #[thread_local]
-                static mut STATE: u8 = 0;
+                static mut STATE: $crate::primitive::u8 = 0;
 
-                unsafe extern "C" fn destroy(ptr: *mut u8) {
+                unsafe extern "C" fn destroy(ptr: *mut $crate::primitive::u8) {
                     let ptr = ptr as *mut $t;
 
                     unsafe {
@@ -235,7 +235,7 @@ macro_rules! __thread_local_inner {
                         //   so now.
                         0 => {
                             $crate::thread::__FastLocalKeyInner::<$t>::register_dtor(
-                                $crate::ptr::addr_of_mut!(VAL) as *mut u8,
+                                $crate::ptr::addr_of_mut!(VAL) as *mut $crate::primitive::u8,
                                 destroy,
                             );
                             STATE = 1;

--- a/src/test/ui/thread-local/name-collision.rs
+++ b/src/test/ui/thread-local/name-collision.rs
@@ -1,0 +1,15 @@
+// check-pass
+
+#[allow(non_camel_case_types)]
+struct u8;
+
+std::thread_local! {
+    pub static A: i32 = f();
+    pub static B: i32 = const { 0 };
+}
+
+fn f() -> i32 {
+    0
+}
+
+fn main() {}


### PR DESCRIPTION
The standard library's `thread_local!` macro previously referred to `u8` just as `u8`, resolving to whatever `u8` existed in the type namespace at the call site. This PR replaces those with `$crate::primitive::u8` which always refers to `std::primitive::u8` regardless of what's in scope at the call site. Unambiguously naming primitives inside macro-generated code is the reason that std::primitive was introduced in the first place.

<details>
<summary>Here is the error message prior to this PR ⬇️</summary>

```console
error[E0308]: mismatched types
 --> src/main.rs:6:1
  |
6 | / std::thread_local! {
7 | |     pub static A: i32 = f();
8 | |     pub static B: i32 = const { 0 };
9 | | }
  | |_^ expected struct `u8`, found integer
  |
  = note: this error originates in the macro `$crate::__thread_local_inner` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0308]: mismatched types
 --> src/main.rs:6:1
  |
6 | / std::thread_local! {
7 | |     pub static A: i32 = f();
8 | |     pub static B: i32 = const { 0 };
9 | | }
  | | ^
  | | |
  | |_expected struct `u8`, found integer
  |   this expression has type `u8`
  |
  = note: this error originates in the macro `$crate::__thread_local_inner` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0308]: mismatched types
 --> src/main.rs:6:1
  |
6 | / std::thread_local! {
7 | |     pub static A: i32 = f();
8 | |     pub static B: i32 = const { 0 };
9 | | }
  | |_^ expected `u8`, found struct `u8`
  |
  = note: expected raw pointer `*mut u8` (`u8`)
             found raw pointer `*mut u8` (struct `u8`)
  = note: this error originates in the macro `$crate::__thread_local_inner` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0308]: mismatched types
 --> src/main.rs:6:1
  |
6 | / std::thread_local! {
7 | |     pub static A: i32 = f();
8 | |     pub static B: i32 = const { 0 };
9 | | }
  | |_^ expected `u8`, found struct `u8`
  |
  = note: expected fn pointer `unsafe extern "C" fn(*mut u8)`
                found fn item `unsafe extern "C" fn(*mut u8) {destroy}`
  = note: this error originates in the macro `$crate::__thread_local_inner` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0308]: mismatched types
 --> src/main.rs:6:1
  |
6 | / std::thread_local! {
7 | |     pub static A: i32 = f();
8 | |     pub static B: i32 = const { 0 };
9 | | }
  | | ^
  | | |
  | |_expected struct `u8`, found integer
  |   expected due to this type
  |
  = note: this error originates in the macro `$crate::__thread_local_inner` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0369]: binary operation `==` cannot be applied to type `u8`
 --> src/main.rs:6:1
  |
6 | / std::thread_local! {
7 | |     pub static A: i32 = f();
8 | |     pub static B: i32 = const { 0 };
9 | | }
  | | ^
  | | |
  | |_u8
  |   {integer}
  |
note: an implementation of `PartialEq<_>` might be missing for `u8`
 --> src/main.rs:4:1
  |
4 | struct u8;
  | ^^^^^^^^^^ must implement `PartialEq<_>`
  = note: this error originates in the macro `$crate::assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
help: consider annotating `u8` with `#[derive(PartialEq)]`
  |
4 | #[derive(PartialEq)]
  |

error[E0277]: `u8` doesn't implement `Debug`
 --> src/main.rs:6:1
  |
6 | / std::thread_local! {
7 | |     pub static A: i32 = f();
8 | |     pub static B: i32 = const { 0 };
9 | | }
  | |_^ `u8` cannot be formatted using `{:?}`
  |
  = help: the trait `Debug` is not implemented for `u8`
  = note: add `#[derive(Debug)]` to `u8` or manually `impl Debug for u8`
  = note: this error originates in the macro `$crate::assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
```
</details>