### PR TITLE
Strict provenance lints

### DIFF
--- a/compiler/rustc_feature/src/active.rs
+++ b/compiler/rustc_feature/src/active.rs
@@ -505,6 +505,8 @@ declare_features! (
     (active, static_nobundle, "1.16.0", Some(37403), None),
     /// Allows attributes on expressions and non-item statements.
     (active, stmt_expr_attributes, "1.6.0", Some(15701), None),
+    /// Allows lints part of the strict provenance effort.
+    (active, strict_provenance, "1.61.0", Some(95228), None),
     /// Allows the use of `#[target_feature]` on safe functions.
     (active, target_feature_11, "1.45.0", Some(69098), None),
     /// Allows using `#[thread_local]` on `static` items.

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -2649,6 +2649,41 @@ declare_lint! {
 }
 
 declare_lint! {
+    /// The `fuzzy_provenance_casts` lint detects an `as` cast between an integer
+    /// and a pointer.
+    ///
+    /// ### Example
+    ///
+    /// fn main() {
+    ///     let my_ref = &0;
+    ///     let my_addr = my_ref as usize;
+    /// }
+    /// ```
+    ///
+    /// {{produces}}
+    ///
+    /// ### Explanation
+    ///
+    /// Casting a pointer to an integer or an integer to a pointer is a lossy operation,
+    /// because beyond just an *address* a pointer may be associated with a particular
+    /// *provenance* and *segment*. This information is required by both the compiler
+    /// and the hardware to correctly execute your code. If you need to do this kind
+    /// of operation, use ptr::addr and ptr::with_addr.
+    ///
+    /// This is a [future-incompatible] lint to transition this to a hard error
+    /// in the future. See [issue #9999999] for more details.
+    ///
+    /// [future-incompatible]: ../index.md#future-incompatible-lints
+    /// [issue #9999999]: https://github.com/rust-lang/rust/issues/9999999
+    pub FUZZY_PROVENANCE_CASTS,
+    Warn,
+    "A lossy pointer-integer integer cast is used",
+    @future_incompatible = FutureIncompatibleInfo {
+        reference: "issue #9999999 <https://github.com/rust-lang/rust/issues/9999999>",
+    };
+}
+
+declare_lint! {
     /// The `const_evaluatable_unchecked` lint detects a generic constant used
     /// in a type.
     ///
@@ -3101,6 +3136,7 @@ declare_lint_pass! {
         UNSAFE_OP_IN_UNSAFE_FN,
         INCOMPLETE_INCLUDE,
         CENUM_IMPL_DROP_CAST,
+        FUZZY_PROVENANCE_CASTS,
         CONST_EVALUATABLE_UNCHECKED,
         INEFFECTIVE_UNSTABLE_TRAIT_IMPL,
         MUST_NOT_SUSPEND,

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1348,6 +1348,7 @@ symbols! {
         str_trim,
         str_trim_end,
         str_trim_start,
+        strict_provenance,
         stringify,
         stringify_macro,
         struct_field_attributes,

--- a/src/doc/unstable-book/src/language-features/strict-provenance.md
+++ b/src/doc/unstable-book/src/language-features/strict-provenance.md
@@ -1,0 +1,22 @@
+# `strict_provenance`
+
+The tracking issue for this feature is: [#95228]
+
+[#95228]: https://github.com/rust-lang/rust/issues/95228
+-----
+
+The `strict_provenance` feature allows to enable the `fuzzy_provenance_casts` and `lossy_provenance_casts` lints.
+These lint on casts between integers and pointers, that are recommended against or invalid in the strict provenance model.
+The same feature gate is also used for the experimental strict provenance API in `std` (actually `core`).
+
+## Example
+
+```rust
+#![feature(strict_provenance)]
+#![warn(fuzzy_provenance_casts)]
+
+fn main() {
+    let _dangling = 16_usize as *const u8;
+    //~^ WARNING: strict provenance disallows casting integer `usize` to pointer `*const u8`
+}
+```

--- a/src/test/ui/feature-gates/feature-gate-strict_provenance.rs
+++ b/src/test/ui/feature-gates/feature-gate-strict_provenance.rs
@@ -1,0 +1,19 @@
+// check-pass
+
+#![deny(fuzzy_provenance_casts)]
+//~^ WARNING unknown lint: `fuzzy_provenance_casts`
+//~| WARNING unknown lint: `fuzzy_provenance_casts`
+//~| WARNING unknown lint: `fuzzy_provenance_casts`
+#![deny(lossy_provenance_casts)]
+//~^ WARNING unknown lint: `lossy_provenance_casts`
+//~| WARNING unknown lint: `lossy_provenance_casts`
+//~| WARNING unknown lint: `lossy_provenance_casts`
+
+fn main() {
+    // no warnings emitted since the lints are not activated
+
+    let _dangling = 16_usize as *const u8;
+
+    let x: u8 = 37;
+    let _addr: usize = &x as *const u8 as usize;
+}

--- a/src/test/ui/feature-gates/feature-gate-strict_provenance.stderr
+++ b/src/test/ui/feature-gates/feature-gate-strict_provenance.stderr
@@ -1,0 +1,63 @@
+warning: unknown lint: `fuzzy_provenance_casts`
+  --> $DIR/feature-gate-strict_provenance.rs:3:1
+   |
+LL | #![deny(fuzzy_provenance_casts)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(unknown_lints)]` on by default
+   = note: the `fuzzy_provenance_casts` lint is unstable
+   = note: see issue #95228 <https://github.com/rust-lang/rust/issues/95228> for more information
+   = help: add `#![feature(strict_provenance)]` to the crate attributes to enable
+
+warning: unknown lint: `lossy_provenance_casts`
+  --> $DIR/feature-gate-strict_provenance.rs:7:1
+   |
+LL | #![deny(lossy_provenance_casts)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: the `lossy_provenance_casts` lint is unstable
+   = note: see issue #95228 <https://github.com/rust-lang/rust/issues/95228> for more information
+   = help: add `#![feature(strict_provenance)]` to the crate attributes to enable
+
+warning: unknown lint: `fuzzy_provenance_casts`
+  --> $DIR/feature-gate-strict_provenance.rs:3:1
+   |
+LL | #![deny(fuzzy_provenance_casts)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: the `fuzzy_provenance_casts` lint is unstable
+   = note: see issue #95228 <https://github.com/rust-lang/rust/issues/95228> for more information
+   = help: add `#![feature(strict_provenance)]` to the crate attributes to enable
+
+warning: unknown lint: `lossy_provenance_casts`
+  --> $DIR/feature-gate-strict_provenance.rs:7:1
+   |
+LL | #![deny(lossy_provenance_casts)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: the `lossy_provenance_casts` lint is unstable
+   = note: see issue #95228 <https://github.com/rust-lang/rust/issues/95228> for more information
+   = help: add `#![feature(strict_provenance)]` to the crate attributes to enable
+
+warning: unknown lint: `fuzzy_provenance_casts`
+  --> $DIR/feature-gate-strict_provenance.rs:3:1
+   |
+LL | #![deny(fuzzy_provenance_casts)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: the `fuzzy_provenance_casts` lint is unstable
+   = note: see issue #95228 <https://github.com/rust-lang/rust/issues/95228> for more information
+   = help: add `#![feature(strict_provenance)]` to the crate attributes to enable
+
+warning: unknown lint: `lossy_provenance_casts`
+  --> $DIR/feature-gate-strict_provenance.rs:7:1
+   |
+LL | #![deny(lossy_provenance_casts)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: the `lossy_provenance_casts` lint is unstable
+   = note: see issue #95228 <https://github.com/rust-lang/rust/issues/95228> for more information
+   = help: add `#![feature(strict_provenance)]` to the crate attributes to enable
+
+warning: 6 warnings emitted
+

--- a/src/test/ui/lint/lint-strict-provenance-fuzzy-casts.rs
+++ b/src/test/ui/lint/lint-strict-provenance-fuzzy-casts.rs
@@ -1,0 +1,7 @@
+#![feature(strict_provenance)]
+#![deny(fuzzy_provenance_casts)]
+
+fn main() {
+    let dangling = 16_usize as *const u8;
+    //~^ ERROR strict provenance disallows casting integer `usize` to pointer `*const u8`
+}

--- a/src/test/ui/lint/lint-strict-provenance-fuzzy-casts.stderr
+++ b/src/test/ui/lint/lint-strict-provenance-fuzzy-casts.stderr
@@ -1,0 +1,19 @@
+error: strict provenance disallows casting integer `usize` to pointer `*const u8`
+  --> $DIR/lint-strict-provenance-fuzzy-casts.rs:5:20
+   |
+LL |     let dangling = 16_usize as *const u8;
+   |                    ^^^^^^^^^^^^^^^^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/lint-strict-provenance-fuzzy-casts.rs:2:9
+   |
+LL | #![deny(fuzzy_provenance_casts)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^
+   = help: if you can't comply with strict provenance and don't have a pointer with the correct provenance you can use `std::ptr::from_exposed_addr()` instead
+help: use `.with_addr()` to adjust a valid pointer in the same allocation, to this address
+   |
+LL |     let dangling = (...).with_addr(16_usize);
+   |                    ~~~~~~~~~~~~~~~~~~~~~~~~~
+
+error: aborting due to previous error
+

--- a/src/test/ui/lint/lint-strict-provenance-lossy-casts.rs
+++ b/src/test/ui/lint/lint-strict-provenance-lossy-casts.rs
@@ -1,0 +1,11 @@
+#![feature(strict_provenance)]
+#![deny(lossy_provenance_casts)]
+
+fn main() {
+    let x: u8 = 37;
+    let addr: usize = &x as *const u8 as usize;
+    //~^ ERROR under strict provenance it is considered bad style to cast pointer `*const u8` to integer `usize`
+
+    let addr_32bit = &x as *const u8 as u32;
+    //~^ ERROR under strict provenance it is considered bad style to cast pointer `*const u8` to integer `u32`
+}

--- a/src/test/ui/lint/lint-strict-provenance-lossy-casts.stderr
+++ b/src/test/ui/lint/lint-strict-provenance-lossy-casts.stderr
@@ -1,0 +1,23 @@
+error: under strict provenance it is considered bad style to cast pointer `*const u8` to integer `usize`
+  --> $DIR/lint-strict-provenance-lossy-casts.rs:6:23
+   |
+LL |     let addr: usize = &x as *const u8 as usize;
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^^ help: use `.addr()` to obtain the address of a pointer: `(&x as *const u8).addr()`
+   |
+note: the lint level is defined here
+  --> $DIR/lint-strict-provenance-lossy-casts.rs:2:9
+   |
+LL | #![deny(lossy_provenance_casts)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^
+   = help: if you can't comply with strict provenance and need to expose the pointerprovenance you can use `.expose_addr()` instead
+
+error: under strict provenance it is considered bad style to cast pointer `*const u8` to integer `u32`
+  --> $DIR/lint-strict-provenance-lossy-casts.rs:9:22
+   |
+LL |     let addr_32bit = &x as *const u8 as u32;
+   |                      ^^^^^^^^^^^^^^^^^^^^^^ help: use `.addr()` to obtain the address of a pointer: `(&x as *const u8).addr() as u32`
+   |
+   = help: if you can't comply with strict provenance and need to expose the pointerprovenance you can use `.expose_addr()` instead
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
See #95488.
This PR introduces two unstable (allow by default) lints to which lint on int2ptr and ptr2int casts, as the former is not possible in the strict provenance model and the latter can be written nicer using the `.addr()` API.
Based on an initial version of the lint by @Gankra in #95199.