### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/compiler/rustc_codegen_ssa/src/lib.rs
+++ b/compiler/rustc_codegen_ssa/src/lib.rs
@@ -29,12 +29,12 @@ use rustc_hir::LangItem;
 use rustc_middle::dep_graph::WorkProduct;
 use rustc_middle::middle::dependency_format::Dependencies;
 use rustc_middle::ty::query::{ExternProviders, Providers};
+use rustc_serialize::{opaque, Decodable, Decoder, Encoder};
 use rustc_session::config::{CrateType, OutputFilenames, OutputType, RUST_CGU_EXT};
 use rustc_session::cstore::{self, CrateSource};
 use rustc_session::utils::NativeLibKind;
 use rustc_span::symbol::Symbol;
 use std::path::{Path, PathBuf};
-use rustc_serialize::{Decodable, Decoder, Encoder, opaque};
 
 pub mod back;
 pub mod base;
@@ -192,13 +192,18 @@ pub fn looks_like_rust_object_file(filename: &str) -> bool {
     ext2 == Some(RUST_CGU_EXT)
 }
 
-const RLINK_MAGIC: &'static [u8; 5] = b"rlink";
+const RLINK_VERSION: u32 = 1;
+const RLINK_MAGIC: &[u8] = b"rustlink";
+
 const RUSTC_VERSION: Option<&str> = option_env!("CFG_VERSION");
 
 impl CodegenResults {
     pub fn serialize_rlink(codegen_results: &CodegenResults) -> Vec<u8> {
         let mut encoder = opaque::Encoder::new(vec![]);
         encoder.emit_raw_bytes(RLINK_MAGIC).unwrap();
+        // `emit_raw_bytes` is used to make sure that the version representation does not depend on
+        // Encoder's inner representation of `u32`.
+        encoder.emit_raw_bytes(&RLINK_VERSION.to_be_bytes()).unwrap();
         encoder.emit_str(RUSTC_VERSION.unwrap()).unwrap();
 
         let mut encoder = rustc_serialize::opaque::Encoder::new(encoder.into_inner());
@@ -207,14 +212,29 @@ impl CodegenResults {
     }
 
     pub fn deserialize_rlink(data: Vec<u8>) -> Result<Self, String> {
+        // The Decodable machinery is not used here because it panics if the input data is invalid
+        // and because its internal representation may change.
         if !data.starts_with(RLINK_MAGIC) {
             return Err("The input does not look like a .rlink file".to_string());
         }
-        let mut decoder = opaque::Decoder::new(&data[RLINK_MAGIC.len()..], 0);
+        let data = &data[RLINK_MAGIC.len()..];
+        if data.len() < 4 {
+            return Err("The input does not contain version number".to_string());
+        }
+
+        let mut version_array: [u8; 4] = Default::default();
+        version_array.copy_from_slice(&data[..4]);
+        if u32::from_be_bytes(version_array) != RLINK_VERSION {
+            return Err(".rlink file was produced with encoding version {version_array}, but the current version is {RLINK_VERSION}".to_string());
+        }
+
+        let mut decoder = opaque::Decoder::new(&data[4..], 0);
         let rustc_version = decoder.read_str();
         let current_version = RUSTC_VERSION.unwrap();
         if rustc_version != current_version {
-            return Err(format!(".rlink file was produced by rustc version {rustc_version}, but the current version is {current_version}."));
+            return Err(format!(
+                ".rlink file was produced by rustc version {rustc_version}, but the current version is {current_version}."
+            ));
         }
 
         let codegen_results = CodegenResults::decode(&mut decoder);

--- a/compiler/rustc_driver/src/lib.rs
+++ b/compiler/rustc_driver/src/lib.rs
@@ -588,8 +588,12 @@ pub fn try_process_rlink(sess: &Session, compiler: &interface::Compiler) -> Comp
             let rlink_data = fs::read(file).unwrap_or_else(|err| {
                 sess.fatal(&format!("failed to read rlink file: {}", err));
             });
-            let codegen_results = CodegenResults::deserialize_rlink(rlink_data)
-                .expect("Could not deserialize .rlink file");
+            let codegen_results = match CodegenResults::deserialize_rlink(rlink_data) {
+                Ok(codegen) => codegen,
+                Err(error) => {
+                    sess.fatal(&format!("Could not deserialize .rlink file: {error}"));
+                }
+            };
             let result = compiler.codegen_backend().link(sess, codegen_results, &outputs);
             abort_on_err(result, sess);
         } else {

--- a/compiler/rustc_driver/src/lib.rs
+++ b/compiler/rustc_driver/src/lib.rs
@@ -588,8 +588,8 @@ pub fn try_process_rlink(sess: &Session, compiler: &interface::Compiler) -> Comp
             let rlink_data = fs::read(file).unwrap_or_else(|err| {
                 sess.fatal(&format!("failed to read rlink file: {}", err));
             });
-            let mut decoder = rustc_serialize::opaque::Decoder::new(&rlink_data, 0);
-            let codegen_results: CodegenResults = rustc_serialize::Decodable::decode(&mut decoder);
+            let codegen_results = CodegenResults::deserialize_rlink(rlink_data)
+                .expect("Could not deserialize .rlink file");
             let result = compiler.codegen_backend().link(sess, codegen_results, &outputs);
             abort_on_err(result, sess);
         } else {

--- a/compiler/rustc_interface/src/queries.rs
+++ b/compiler/rustc_interface/src/queries.rs
@@ -3,6 +3,7 @@ use crate::passes::{self, BoxedResolver, QueryContext};
 
 use rustc_ast as ast;
 use rustc_codegen_ssa::traits::CodegenBackend;
+use rustc_codegen_ssa::CodegenResults;
 use rustc_data_structures::svh::Svh;
 use rustc_data_structures::sync::{Lrc, OnceCell, WorkerLocal};
 use rustc_hir::def_id::LOCAL_CRATE;
@@ -18,7 +19,6 @@ use rustc_span::symbol::sym;
 use std::any::Any;
 use std::cell::{Ref, RefCell, RefMut};
 use std::rc::Rc;
-use rustc_codegen_ssa::CodegenResults;
 
 /// Represent the result of a query.
 ///

--- a/compiler/rustc_interface/src/queries.rs
+++ b/compiler/rustc_interface/src/queries.rs
@@ -18,6 +18,7 @@ use rustc_span::symbol::sym;
 use std::any::Any;
 use std::cell::{Ref, RefCell, RefMut};
 use std::rc::Rc;
+use rustc_codegen_ssa::CodegenResults;
 
 /// Represent the result of a query.
 ///
@@ -360,10 +361,9 @@ impl Linker {
         }
 
         if sess.opts.debugging_opts.no_link {
-            let mut encoder = rustc_serialize::opaque::Encoder::new(Vec::new());
-            rustc_serialize::Encodable::encode(&codegen_results, &mut encoder).unwrap();
+            let encoded = CodegenResults::serialize_rlink(&codegen_results);
             let rlink_file = self.prepare_outputs.with_extension(config::RLINK_EXT);
-            std::fs::write(&rlink_file, encoder.into_inner()).map_err(|err| {
+            std::fs::write(&rlink_file, encoded).map_err(|err| {
                 sess.fatal(&format!("failed to write file {}: {}", rlink_file.display(), err));
             })?;
             return Ok(());

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -224,7 +224,6 @@
 #![feature(allocator_internals)]
 #![feature(allow_internal_unsafe)]
 #![feature(allow_internal_unstable)]
-#![feature(associated_type_bounds)]
 #![feature(box_syntax)]
 #![feature(c_unwind)]
 #![feature(cfg_target_thread_local)]

--- a/library/std/src/sys/sgx/abi/usercalls/alloc.rs
+++ b/library/std/src/sys/sgx/abi/usercalls/alloc.rs
@@ -571,7 +571,8 @@ impl<T: CoerceUnsized<U>, U> CoerceUnsized<UserRef<U>> for UserRef<T> {}
 impl<T, I> Index<I> for UserRef<[T]>
 where
     [T]: UserSafe,
-    I: SliceIndex<[T], Output: UserSafe>,
+    I: SliceIndex<[T]>,
+    I::Output: UserSafe,
 {
     type Output = UserRef<I::Output>;
 
@@ -591,7 +592,8 @@ where
 impl<T, I> IndexMut<I> for UserRef<[T]>
 where
     [T]: UserSafe,
-    I: SliceIndex<[T], Output: UserSafe>,
+    I: SliceIndex<[T]>,
+    I::Output: UserSafe,
 {
     #[inline]
     fn index_mut(&mut self, index: I) -> &mut UserRef<I::Output> {

--- a/library/std/src/thread/local.rs
+++ b/library/std/src/thread/local.rs
@@ -217,9 +217,9 @@ macro_rules! __thread_local_inner {
                 // 1 == dtor registered, dtor not run
                 // 2 == dtor registered and is running or has run
                 #[thread_local]
-                static mut STATE: u8 = 0;
+                static mut STATE: $crate::primitive::u8 = 0;
 
-                unsafe extern "C" fn destroy(ptr: *mut u8) {
+                unsafe extern "C" fn destroy(ptr: *mut $crate::primitive::u8) {
                     let ptr = ptr as *mut $t;
 
                     unsafe {
@@ -235,7 +235,7 @@ macro_rules! __thread_local_inner {
                         //   so now.
                         0 => {
                             $crate::thread::__FastLocalKeyInner::<$t>::register_dtor(
-                                $crate::ptr::addr_of_mut!(VAL) as *mut u8,
+                                $crate::ptr::addr_of_mut!(VAL) as *mut $crate::primitive::u8,
                                 destroy,
                             );
                             STATE = 1;

--- a/src/test/run-make-fulldeps/separate-link-fail/Makefile
+++ b/src/test/run-make-fulldeps/separate-link-fail/Makefile
@@ -1,0 +1,7 @@
+-include ../tools.mk
+
+all:
+	echo 'fn main(){}' > $(TMPDIR)/main.rs
+	# Make sure that this fails
+	! $(RUSTC) -Z link-only $(TMPDIR)/main.rs 2> $(TMPDIR)/stderr.txt
+	$(CGREP) "The input does not look like a .rlink file" < $(TMPDIR)/stderr.txt

--- a/src/test/ui/consts/const-eval/size-of-t.rs
+++ b/src/test/ui/consts/const-eval/size-of-t.rs
@@ -1,0 +1,13 @@
+// https://github.com/rust-lang/rust/issues/69228
+// Used to give bogus suggestion about T not being Sized.
+
+use std::mem::size_of;
+
+fn foo<T>() {
+    let _arr: [u8; size_of::<T>()];
+    //~^ ERROR generic parameters may not be used in const operations
+    //~| NOTE cannot perform const operation
+    //~| NOTE type parameters may not be used in const expressions
+}
+
+fn main() {}

--- a/src/test/ui/consts/const-eval/size-of-t.stderr
+++ b/src/test/ui/consts/const-eval/size-of-t.stderr
@@ -1,0 +1,11 @@
+error: generic parameters may not be used in const operations
+  --> $DIR/size-of-t.rs:7:30
+   |
+LL |     let _arr: [u8; size_of::<T>()];
+   |                              ^ cannot perform const operation using `T`
+   |
+   = note: type parameters may not be used in const expressions
+   = help: use `#![feature(generic_const_exprs)]` to allow generic const expressions
+
+error: aborting due to previous error
+

--- a/src/test/ui/thread-local/name-collision.rs
+++ b/src/test/ui/thread-local/name-collision.rs
@@ -1,0 +1,15 @@
+// check-pass
+
+#[allow(non_camel_case_types)]
+struct u8;
+
+std::thread_local! {
+    pub static A: i32 = f();
+    pub static B: i32 = const { 0 };
+}
+
+fn f() -> i32 {
+    0
+}
+
+fn main() {}


### PR DESCRIPTION
Successful merges:

 - #95587 (Remove need for associated_type_bounds in std.)
 - #95589 (Include a header in .rlink files)
 - #95593 (diagnostics: add test case for bogus T:Sized suggestion)
 - #95597 (Refer to u8 by absolute path in expansion of thread_local)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=95587,95589,95593,95597)
<!-- homu-ignore:end -->