### PR TITLE
linker: Implicitly link native libs as whole-archive in some more cases

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -2079,9 +2079,14 @@ fn add_local_native_libraries(
             NativeLibKind::Framework { as_needed } => {
                 cmd.link_framework(name, as_needed.unwrap_or(true))
             }
-            NativeLibKind::Static { whole_archive, .. } => {
+            NativeLibKind::Static { whole_archive, bundle, .. } => {
                 if whole_archive == Some(true)
                     || (whole_archive == None && default_to_whole_archive(sess, crate_type, cmd))
+                    // Backward compatibility case: this can be a rlib (so `+whole-archive` cannot
+                    // be added explicitly if necessary, see the error in `fn link_rlib`) compiled
+                    // as an executable due to `--test`. Use whole-archive implicitly, like before
+                    // the introduction of native lib modifiers.
+                    || (bundle != Some(false) && sess.opts.test)
                 {
                     cmd.link_whole_staticlib(
                         name,


### PR DESCRIPTION
Partially revert changes from https://github.com/rust-lang/rust/pull/93901 to address regressions like https://github.com/rust-lang/rust/issues/95561.

Fixes https://github.com/rust-lang/rust/issues/95561
r? @wesleywiser 