### PR TITLE
Suggest borrowing when trying to coerce unsized type into `dyn Trait`

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
@@ -474,6 +474,12 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                             err.span_label(span, explanation);
                         }
 
+                        if let ObligationCauseCode::ObjectCastObligation(obj_ty) = obligation.cause.code().peel_derives() &&
+                           let Some(self_ty) = trait_predicate.self_ty().no_bound_vars() &&
+                           Some(trait_ref.def_id()) == self.tcx.lang_items().sized_trait() {
+                            self.suggest_borrowing_for_object_cast(&mut err, &obligation, self_ty, *obj_ty);
+                        }
+
                         if trait_predicate.is_const_if_const() && obligation.param_env.is_const() {
                             let non_const_predicate = trait_ref.without_const();
                             let non_const_obligation = Obligation {

--- a/src/test/ui/issues/issue-14366.stderr
+++ b/src/test/ui/issues/issue-14366.stderr
@@ -6,6 +6,10 @@ LL |     let _x = "test" as &dyn (::std::any::Any);
    |
    = help: the trait `Sized` is not implemented for `str`
    = note: required for the cast to the object type `dyn Any`
+help: consider borrowing the value, since `&str` can be coerced into `dyn Any`
+   |
+LL |     let _x = &"test" as &dyn (::std::any::Any);
+   |              +
 
 error: aborting due to previous error
 

--- a/src/test/ui/mismatched_types/cast-rfc0401.stderr
+++ b/src/test/ui/mismatched_types/cast-rfc0401.stderr
@@ -224,6 +224,10 @@ LL |     let _ = fat_v as *const dyn Foo;
    |
    = help: the trait `Sized` is not implemented for `[u8]`
    = note: required for the cast to the object type `dyn Foo`
+help: consider borrowing the value, since `&[u8]` can be coerced into `dyn Foo`
+   |
+LL |     let _ = &fat_v as *const dyn Foo;
+   |             +
 
 error[E0277]: the size for values of type `str` cannot be known at compilation time
   --> $DIR/cast-rfc0401.rs:62:13
@@ -233,6 +237,10 @@ LL |     let _ = a as *const dyn Foo;
    |
    = help: the trait `Sized` is not implemented for `str`
    = note: required for the cast to the object type `dyn Foo`
+help: consider borrowing the value, since `&str` can be coerced into `dyn Foo`
+   |
+LL |     let _ = &a as *const dyn Foo;
+   |             +
 
 error[E0606]: casting `&{float}` as `f32` is invalid
   --> $DIR/cast-rfc0401.rs:71:30

--- a/src/test/ui/unsized/unsized-fn-param.stderr
+++ b/src/test/ui/unsized/unsized-fn-param.stderr
@@ -6,6 +6,10 @@ LL |     foo11("bar", &"baz");
    |
    = help: the trait `Sized` is not implemented for `str`
    = note: required for the cast to the object type `dyn AsRef<Path>`
+help: consider borrowing the value, since `&str` can be coerced into `dyn AsRef<Path>`
+   |
+LL |     foo11(&"bar", &"baz");
+   |           +
 
 error[E0277]: the size for values of type `str` cannot be known at compilation time
   --> $DIR/unsized-fn-param.rs:13:19
@@ -15,6 +19,10 @@ LL |     foo12(&"bar", "baz");
    |
    = help: the trait `Sized` is not implemented for `str`
    = note: required for the cast to the object type `dyn AsRef<Path>`
+help: consider borrowing the value, since `&str` can be coerced into `dyn AsRef<Path>`
+   |
+LL |     foo12(&"bar", &"baz");
+   |                   +
 
 error[E0277]: the size for values of type `str` cannot be known at compilation time
   --> $DIR/unsized-fn-param.rs:16:11
@@ -24,6 +32,10 @@ LL |     foo21("bar", &"baz");
    |
    = help: the trait `Sized` is not implemented for `str`
    = note: required for the cast to the object type `dyn AsRef<str>`
+help: consider borrowing the value, since `&str` can be coerced into `dyn AsRef<str>`
+   |
+LL |     foo21(&"bar", &"baz");
+   |           +
 
 error[E0277]: the size for values of type `str` cannot be known at compilation time
   --> $DIR/unsized-fn-param.rs:18:19
@@ -33,6 +45,10 @@ LL |     foo22(&"bar", "baz");
    |
    = help: the trait `Sized` is not implemented for `str`
    = note: required for the cast to the object type `dyn AsRef<str>`
+help: consider borrowing the value, since `&str` can be coerced into `dyn AsRef<str>`
+   |
+LL |     foo22(&"bar", &"baz");
+   |                   +
 
 error: aborting due to 4 previous errors
 


### PR DESCRIPTION
A helpful error in response to #95598, since we can't coerce e.g. `&str` into `&dyn Display`, but we can coerce `&&str` into `&dyn Display` :)

Not sure if the suggestion message needs some help. Let me know, and I can refine this PR.