### PR TITLE
Improve doc example of DerefMut

### DIFF
--- a/library/core/src/ops/deref.rs
+++ b/library/core/src/ops/deref.rs
@@ -164,7 +164,7 @@ impl<T: ?Sized> const Deref for &mut T {
 ///
 /// let mut x = DerefMutExample { value: 'a' };
 /// *x = 'b';
-/// assert_eq!('b', *x);
+/// assert_eq!('b', x.value);
 /// ```
 #[lang = "deref_mut"]
 #[doc(alias = "*")]


### PR DESCRIPTION
It is more illustrative, after using `*x` to modify the field, to show
in the assertion that the field has indeed been modified.