### PR TITLE
[WIP] reject more impossible trivial bounds (HRTBs and trivial after normalization)

### DIFF
--- a/src/test/ui/associated-types/bound-lifetime-in-binding-only.ok.stderr
+++ b/src/test/ui/associated-types/bound-lifetime-in-binding-only.ok.stderr
@@ -1,5 +1,5 @@
 error: fatal error triggered by #[rustc_error]
-  --> $DIR/bound-lifetime-in-binding-only.rs:71:1
+  --> $DIR/bound-lifetime-in-binding-only.rs:75:1
    |
 LL | fn main() { }
    | ^^^^^^^^^

--- a/src/test/ui/associated-types/bound-lifetime-in-binding-only.rs
+++ b/src/test/ui/associated-types/bound-lifetime-in-binding-only.rs
@@ -55,6 +55,10 @@ fn elision<T: Fn() -> &i32>() {
 
 struct Parameterized<'a> { x: &'a str }
 
+impl<'a> Foo for Parameterized<'a> {
+    type Item = &'a i32;
+}
+
 #[cfg(ok)]
 fn ok1<T: for<'a> Fn(&Parameterized<'a>) -> &'a i32>() {
 }

--- a/src/test/ui/associated-types/issue-69398.rs
+++ b/src/test/ui/associated-types/issue-69398.rs
@@ -12,6 +12,7 @@ pub trait Broken {
 impl<T> Broken for T {
     type Assoc = ();
     fn broken(&self) where Self::Assoc: Foo {
+        //~^ WARN where-clause bound is impossible to satisfy
         let _x: <Self::Assoc as Foo>::Bar;
     }
 }

--- a/src/test/ui/associated-types/issue-69398.stderr
+++ b/src/test/ui/associated-types/issue-69398.stderr
@@ -1,0 +1,11 @@
+warning: where-clause bound is impossible to satisfy
+  --> $DIR/issue-69398.rs:14:28
+   |
+LL |     fn broken(&self) where Self::Assoc: Foo {
+   |                            ^^^^^^^^^^^^^^^^
+   |
+   = note: the bound `<T as Broken>::Assoc: Foo` was previously accepted, but it may become a hard error in a future release
+   = help: add `#![feature(trivial_bounds)]` to the crate attributes to allow it
+
+warning: 1 warning emitted
+

--- a/src/test/ui/consts/issue-67696-const-prop-ice.rs
+++ b/src/test/ui/consts/issue-67696-const-prop-ice.rs
@@ -10,11 +10,18 @@ trait A {
 }
 
 impl A for [fn(&())] {
-    fn foo(&self) -> Self where Self: Copy { *(&[] as &[_]) }
+    fn foo(&self) -> Self where Self: Copy {
+        //~^ WARN where-clause bound is impossible to satisfy
+        //~| WARN where-clause bound is impossible to satisfy
+        //~| WARN where-clause bound is impossible to satisfy
+        *(&[] as &[_])
+    }
 }
 
 impl A for i32 {
-    fn foo(&self) -> Self { 3 }
+    fn foo(&self) -> Self {
+        3
+    }
 }
 
 fn main() {}

--- a/src/test/ui/consts/issue-67696-const-prop-ice.stderr
+++ b/src/test/ui/consts/issue-67696-const-prop-ice.stderr
@@ -1,0 +1,29 @@
+warning: where-clause bound is impossible to satisfy
+  --> $DIR/issue-67696-const-prop-ice.rs:13:33
+   |
+LL |     fn foo(&self) -> Self where Self: Copy {
+   |                                 ^^^^^^^^^^
+   |
+   = note: the bound `[for<'r> fn(&'r ())]: Copy` was previously accepted, but it may become a hard error in a future release
+   = help: add `#![feature(trivial_bounds)]` to the crate attributes to allow it
+
+warning: where-clause bound is impossible to satisfy
+  --> $DIR/issue-67696-const-prop-ice.rs:13:33
+   |
+LL |     fn foo(&self) -> Self where Self: Copy {
+   |                                 ^^^^^^^^^^
+   |
+   = note: the bound `[for<'r> fn(&'r ())]: Clone` was previously accepted, but it may become a hard error in a future release
+   = help: add `#![feature(trivial_bounds)]` to the crate attributes to allow it
+
+warning: where-clause bound is impossible to satisfy
+  --> $DIR/issue-67696-const-prop-ice.rs:13:33
+   |
+LL |     fn foo(&self) -> Self where Self: Copy {
+   |                                 ^^^^^^^^^^
+   |
+   = note: the bound `[for<'r> fn(&'r ())]: Sized` was previously accepted, but it may become a hard error in a future release
+   = help: add `#![feature(trivial_bounds)]` to the crate attributes to allow it
+
+warning: 3 warnings emitted
+

--- a/src/test/ui/feature-gates/feature-gate-trivial_bounds.rs
+++ b/src/test/ui/feature-gates/feature-gate-trivial_bounds.rs
@@ -62,7 +62,9 @@ fn return_str() -> str where str: Sized { //~ ERROR
 
 // This is currently accepted because the function pointer isn't
 // considered global.
+// FIXME(compiler-errors): Not for long..
 fn global_hr(x: fn(&())) where fn(&()): Foo { // OK
+    //~^ WARN where-clause bound is impossible to satisfy
     x.test();
 }
 

--- a/src/test/ui/feature-gates/feature-gate-trivial_bounds.stderr
+++ b/src/test/ui/feature-gates/feature-gate-trivial_bounds.stderr
@@ -113,6 +113,15 @@ LL | fn return_str() -> str where str: Sized {
    = help: see issue #48214
    = help: add `#![feature(trivial_bounds)]` to the crate attributes to enable
 
-error: aborting due to 11 previous errors
+warning: where-clause bound is impossible to satisfy
+  --> $DIR/feature-gate-trivial_bounds.rs:66:32
+   |
+LL | fn global_hr(x: fn(&())) where fn(&()): Foo { // OK
+   |                                ^^^^^^^^^^^^
+   |
+   = note: the bound `for<'r> fn(&'r ()): Foo` was previously accepted, but it may become a hard error in a future release
+   = help: add `#![feature(trivial_bounds)]` to the crate attributes to allow it
+
+error: aborting due to 11 previous errors; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/higher-rank-trait-bounds/normalize-under-binder/issue-89118.rs
+++ b/src/test/ui/higher-rank-trait-bounds/normalize-under-binder/issue-89118.rs
@@ -7,6 +7,7 @@ impl<B: BufferMut, C> BufferUdpStateContext<B> for C {}
 trait StackContext
 where
     Ctx<()>: for<'a> BufferUdpStateContext<&'a ()>,
+    //~^ WARN where-clause bound is impossible to satisfy
 {
     type Dispatcher;
 }
@@ -26,6 +27,8 @@ where
 struct EthernetWorker<C>(C)
 where
     Ctx<()>: for<'a> BufferUdpStateContext<&'a ()>;
+    //~^ WARN where-clause bound is impossible to satisfy
+
 impl<C> EthernetWorker<C> {}
 //~^ ERROR: is not satisfied [E0277]
 

--- a/src/test/ui/higher-rank-trait-bounds/normalize-under-binder/issue-89118.stderr
+++ b/src/test/ui/higher-rank-trait-bounds/normalize-under-binder/issue-89118.stderr
@@ -1,5 +1,14 @@
+warning: where-clause bound is impossible to satisfy
+  --> $DIR/issue-89118.rs:9:5
+   |
+LL |     Ctx<()>: for<'a> BufferUdpStateContext<&'a ()>,
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: the bound `for<'a> Ctx<()>: BufferUdpStateContext<&'a ()>` was previously accepted, but it may become a hard error in a future release
+   = help: add `#![feature(trivial_bounds)]` to the crate attributes to allow it
+
 error[E0277]: the trait bound `for<'a> &'a (): BufferMut` is not satisfied
-  --> $DIR/issue-89118.rs:19:8
+  --> $DIR/issue-89118.rs:20:8
    |
 LL |     C: StackContext,
    |        ^^^^^^^^^^^^ the trait `for<'a> BufferMut` is not implemented for `&'a ()`
@@ -19,7 +28,7 @@ LL |     Ctx<()>: for<'a> BufferUdpStateContext<&'a ()>,
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `StackContext`
 
 error[E0277]: the trait bound `for<'a> &'a (): BufferMut` is not satisfied
-  --> $DIR/issue-89118.rs:22:20
+  --> $DIR/issue-89118.rs:23:20
    |
 LL |     type Handler = Ctx<C::Dispatcher>;
    |                    ^^^^^^^^^^^^^^^^^^ the trait `for<'a> BufferMut` is not implemented for `&'a ()`
@@ -38,8 +47,17 @@ LL | where
 LL |     Ctx<()>: for<'a> BufferUdpStateContext<&'a ()>,
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `StackContext`
 
+warning: where-clause bound is impossible to satisfy
+  --> $DIR/issue-89118.rs:29:5
+   |
+LL |     Ctx<()>: for<'a> BufferUdpStateContext<&'a ()>;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: the bound `for<'a> Ctx<()>: BufferUdpStateContext<&'a ()>` was previously accepted, but it may become a hard error in a future release
+   = help: add `#![feature(trivial_bounds)]` to the crate attributes to allow it
+
 error[E0277]: the trait bound `for<'a> &'a (): BufferMut` is not satisfied
-  --> $DIR/issue-89118.rs:29:9
+  --> $DIR/issue-89118.rs:32:9
    |
 LL | impl<C> EthernetWorker<C> {}
    |         ^^^^^^^^^^^^^^^^^ the trait `for<'a> BufferMut` is not implemented for `&'a ()`
@@ -50,7 +68,7 @@ note: required because of the requirements on the impl of `for<'a> BufferUdpStat
 LL | impl<B: BufferMut, C> BufferUdpStateContext<B> for C {}
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^     ^
 note: required by a bound in `EthernetWorker`
-  --> $DIR/issue-89118.rs:28:14
+  --> $DIR/issue-89118.rs:29:14
    |
 LL | struct EthernetWorker<C>(C)
    |        -------------- required by a bound in this
@@ -58,6 +76,6 @@ LL | where
 LL |     Ctx<()>: for<'a> BufferUdpStateContext<&'a ()>;
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `EthernetWorker`
 
-error: aborting due to 3 previous errors
+error: aborting due to 3 previous errors; 2 warnings emitted
 
 For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/issues/issue-36839.rs
+++ b/src/test/ui/issues/issue-36839.rs
@@ -12,6 +12,7 @@ pub trait Broken {
 impl<T> Broken for T {
     type Assoc = ();
     fn broken(&self) where Self::Assoc: Foo {
+        //~^ WARN where-clause bound is impossible to satisfy
         let _x: <Self::Assoc as Foo>::Bar;
     }
 }

--- a/src/test/ui/issues/issue-36839.stderr
+++ b/src/test/ui/issues/issue-36839.stderr
@@ -1,0 +1,11 @@
+warning: where-clause bound is impossible to satisfy
+  --> $DIR/issue-36839.rs:14:28
+   |
+LL |     fn broken(&self) where Self::Assoc: Foo {
+   |                            ^^^^^^^^^^^^^^^^
+   |
+   = note: the bound `<T as Broken>::Assoc: Foo` was previously accepted, but it may become a hard error in a future release
+   = help: add `#![feature(trivial_bounds)]` to the crate attributes to allow it
+
+warning: 1 warning emitted
+

--- a/src/test/ui/issues/issue-39970.rs
+++ b/src/test/ui/issues/issue-39970.rs
@@ -13,6 +13,7 @@ impl<'a> Array<'a> for () {
 impl Visit for () where
     //(): for<'a> Array<'a, Element=&'a ()>, // No ICE
     (): for<'a> Array<'a, Element=()>, // ICE
+    //~^ WARN where-clause bound is impossible to satisfy
 {}
 
 fn main() {

--- a/src/test/ui/issues/issue-39970.stderr
+++ b/src/test/ui/issues/issue-39970.stderr
@@ -1,5 +1,14 @@
+warning: where-clause bound is impossible to satisfy
+  --> $DIR/issue-39970.rs:15:5
+   |
+LL |     (): for<'a> Array<'a, Element=()>, // ICE
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: the bound `for<'a> <() as Array<'a>>::Element == ()` was previously accepted, but it may become a hard error in a future release
+   = help: add `#![feature(trivial_bounds)]` to the crate attributes to allow it
+
 error[E0271]: type mismatch resolving `for<'a> <() as Array<'a>>::Element == ()`
-  --> $DIR/issue-39970.rs:19:5
+  --> $DIR/issue-39970.rs:20:5
    |
 LL |     <() as Visit>::visit();
    |     ^^^^^^^^^^^^^^^^^^^^ type mismatch resolving `for<'a> <() as Array<'a>>::Element == ()`
@@ -15,6 +24,6 @@ note: required because of the requirements on the impl of `Visit` for `()`
 LL | impl Visit for () where
    |      ^^^^^     ^^
 
-error: aborting due to previous error
+error: aborting due to previous error; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0271`.

--- a/src/test/ui/issues/issue-42796.rs
+++ b/src/test/ui/issues/issue-42796.rs
@@ -7,6 +7,7 @@ impl<T, Smoke> Mirror<Smoke> for T {
 }
 
 pub fn poison<S>(victim: String) where <String as Mirror<S>>::Image: Copy {
+    //~^ WARN where-clause bound is impossible to satisfy
     loop { drop(victim); }
 }
 

--- a/src/test/ui/issues/issue-42796.stderr
+++ b/src/test/ui/issues/issue-42796.stderr
@@ -1,5 +1,14 @@
+warning: where-clause bound is impossible to satisfy
+  --> $DIR/issue-42796.rs:9:40
+   |
+LL | pub fn poison<S>(victim: String) where <String as Mirror<S>>::Image: Copy {
+   |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: the bound `<String as Mirror<S>>::Image: Copy` was previously accepted, but it may become a hard error in a future release
+   = help: add `#![feature(trivial_bounds)]` to the crate attributes to allow it
+
 error[E0382]: borrow of moved value: `s`
-  --> $DIR/issue-42796.rs:18:20
+  --> $DIR/issue-42796.rs:19:20
    |
 LL |     let s = "Hello!".to_owned();
    |         - move occurs because `s` has type `String`, which does not implement the `Copy` trait
@@ -11,6 +20,6 @@ LL |     println!("{}", s);
    |
    = note: this error originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to previous error
+error: aborting due to previous error; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0382`.

--- a/src/test/ui/mir/issue-91745.rs
+++ b/src/test/ui/mir/issue-91745.rs
@@ -12,6 +12,7 @@ pub trait Broken {
 impl<T> Broken for T {
     type Assoc = ();
     fn broken(&self) where Self::Assoc: Foo {
+        //~^ WARN where-clause bound is impossible to satisfy
         let _x: <Self::Assoc as Foo>::Bar;
     }
 }

--- a/src/test/ui/mir/issue-91745.stderr
+++ b/src/test/ui/mir/issue-91745.stderr
@@ -1,0 +1,11 @@
+warning: where-clause bound is impossible to satisfy
+  --> $DIR/issue-91745.rs:14:28
+   |
+LL |     fn broken(&self) where Self::Assoc: Foo {
+   |                            ^^^^^^^^^^^^^^^^
+   |
+   = note: the bound `<T as Broken>::Assoc: Foo` was previously accepted, but it may become a hard error in a future release
+   = help: add `#![feature(trivial_bounds)]` to the crate attributes to allow it
+
+warning: 1 warning emitted
+

--- a/src/test/ui/regions/regions-normalize-in-where-clause-list.rs
+++ b/src/test/ui/regions/regions-normalize-in-where-clause-list.rs
@@ -23,9 +23,9 @@ where
 // Here we get an error: we need `'a: 'b`.
 fn bar<'a, 'b>()
 //~^ ERROR cannot infer
-//~| ERROR cannot infer
 where
     <() as Project<'a, 'b>>::Item: Eq,
+    //~^ ERROR cannot infer
 {
 }
 

--- a/src/test/ui/regions/regions-normalize-in-where-clause-list.stderr
+++ b/src/test/ui/regions/regions-normalize-in-where-clause-list.stderr
@@ -3,7 +3,6 @@ error[E0495]: cannot infer an appropriate lifetime for lifetime parameter `'a` d
    |
 LL | / fn bar<'a, 'b>()
 LL | |
-LL | |
 LL | | where
 LL | |     <() as Project<'a, 'b>>::Item: Eq,
    | |______________________________________^
@@ -23,7 +22,6 @@ note: ...so that the types are compatible
    |
 LL | / fn bar<'a, 'b>()
 LL | |
-LL | |
 LL | | where
 LL | |     <() as Project<'a, 'b>>::Item: Eq,
    | |______________________________________^
@@ -31,10 +29,10 @@ LL | |     <() as Project<'a, 'b>>::Item: Eq,
               found `Project<'_, '_>`
 
 error[E0495]: cannot infer an appropriate lifetime for lifetime parameter `'a` due to conflicting requirements
-  --> $DIR/regions-normalize-in-where-clause-list.rs:24:4
+  --> $DIR/regions-normalize-in-where-clause-list.rs:27:5
    |
-LL | fn bar<'a, 'b>()
-   |    ^^^
+LL |     <() as Project<'a, 'b>>::Item: Eq,
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: first, the lifetime cannot outlive the lifetime `'a` as defined here...
   --> $DIR/regions-normalize-in-where-clause-list.rs:24:8
@@ -47,10 +45,10 @@ note: ...but the lifetime must also be valid for the lifetime `'b` as defined he
 LL | fn bar<'a, 'b>()
    |            ^^
 note: ...so that the types are compatible
-  --> $DIR/regions-normalize-in-where-clause-list.rs:24:4
+  --> $DIR/regions-normalize-in-where-clause-list.rs:27:5
    |
-LL | fn bar<'a, 'b>()
-   |    ^^^
+LL |     <() as Project<'a, 'b>>::Item: Eq,
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: expected `Project<'a, 'b>`
               found `Project<'_, '_>`
 


### PR DESCRIPTION
We really should be rejecting bounds that are global, even if they have higher-ranked lifetimes. We have the ability to prove whether `for<'a> &'a mut String: Clone` is true or not, so there's no reason to silently allow this to typecheck, especially because it's inconsistent with a non-HRTB like `&'static mut String: Clone` and is the source of ICEs 

For now, though, just add a warning that it may be denied in the future.