### PR TITLE
Fix rustdoc attribute display (removing unneeded backslash)

### DIFF
--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -1002,7 +1002,12 @@ fn attributes(it: &clean::Item) -> Vec<String> {
         .iter()
         .filter_map(|attr| {
             if ALLOWED_ATTRIBUTES.contains(&attr.name_or_empty()) {
-                Some(pprust::attribute_to_string(attr).replace('\n', "").replace("  ", " "))
+                Some(
+                    pprust::attribute_to_string(attr)
+                        .replace("\\\n", "")
+                        .replace('\n', "")
+                        .replace("  ", " "),
+                )
             } else {
                 None
             }

--- a/src/test/rustdoc/attribute-rendering.rs
+++ b/src/test/rustdoc/attribute-rendering.rs
@@ -1,0 +1,7 @@
+#![crate_name = "foo"]
+
+// @has 'foo/fn.f.html'
+// @has - //*[@'class="docblock item-decl"]' '#[export_name = "f"] pub fn f()'
+#[export_name = "\
+f"]
+pub fn f() {}


### PR DESCRIPTION
Fixes #81482.

r? @notriddle 