### PR TITLE
Fix &mut invalidation in ptr::swap doctest

### DIFF
--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -637,8 +637,9 @@ pub const fn slice_from_raw_parts_mut<T>(data: *mut T, len: usize) -> *mut [T] {
 ///
 /// let mut array = [0, 1, 2, 3];
 ///
-/// let x = array[0..].as_mut_ptr() as *mut [u32; 2]; // this is `array[0..2]`
-/// let y = array[2..].as_mut_ptr() as *mut [u32; 2]; // this is `array[2..4]`
+/// let (x, y) = array.split_at_mut(2);
+/// let x = x.as_mut_ptr().cast::<[u32; 2]>(); // this is `array[0..2]`
+/// let y = y.as_mut_ptr().cast::<[u32; 2]>(); // this is `array[2..4]`
 ///
 /// unsafe {
 ///     ptr::swap(x, y);


### PR DESCRIPTION
Under Stacked Borrows with raw pointer tagging, the previous code was UB
because the code which creates the the second pointer borrows the array
through a tag in the borrow stacks below the Unique tag that our first
pointer is based on, thus invalidating the first pointer.

This is not definitely a bug and may never be real UB, but I desperately
want people to write code that conforms to SB with raw pointer tagging
so that I can write good diagnostics. The alternative aliasing models
aren't possible to diagnose well due to state space explosion.
Therefore, it would be super cool if the standard library nudged people
towards writing code that is valid with respect to SB with raw pointer
tagging.

The diagnostics that I want to write are implemented in a branch of Miri and the one for this case is below:
```
error: Undefined Behavior: attempting a read access using <2170> at alloc1068[0x0], but that tag does not exist in the borrow stack for this location
    --> /home/ben/rust/library/core/src/intrinsics.rs:2103:14
     |
2103 |     unsafe { copy_nonoverlapping(src, dst, count) }
     |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     |              |
     |              attempting a read access using <2170> at alloc1068[0x0], but that tag does not exist in the borrow stack for this location
     |              this error occurs as part of an access at alloc1068[0x0..0x8]
     |
     = help: this indicates a potential bug in the program: it performed an invalid operation, but the rules it violated are still experimental
     = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information
help: <2170> was created due to a retag at offsets [0x0..0x10]
    --> ../libcore/src/ptr/mod.rs:640:9
     |
8    | let x = array[0..].as_mut_ptr() as *mut [u32; 2]; // this is `array[0..2]`
     |         ^^^^^^^^^^^^^^^^^^^^^^^
help: <2170> was later invalidated due to a retag at offsets [0x0..0x10]
    --> ../libcore/src/ptr/mod.rs:641:9
     |
9    | let y = array[2..].as_mut_ptr() as *mut [u32; 2]; // this is `array[2..4]`
     |         ^^^^^
     = note: inside `std::intrinsics::copy_nonoverlapping::<[u32; 2]>` at /home/ben/rust/library/core/src/intrinsics.rs:2103:14
     = note: inside `std::ptr::swap::<[u32; 2]>` at /home/ben/rust/library/core/src/ptr/mod.rs:685:9
note: inside `main::_doctest_main____libcore_src_ptr_mod_rs_635_0` at ../libcore/src/ptr/mod.rs:12:5
    --> ../libcore/src/ptr/mod.rs:644:5
     |
12   |     ptr::swap(x, y);
     |     ^^^^^^^^^^^^^^^
note: inside `main` at ../libcore/src/ptr/mod.rs:15:3
    --> ../libcore/src/ptr/mod.rs:647:3
     |
15   | } _doctest_main____libcore_src_ptr_mod_rs_635_0() }
     |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

error: aborting due to previous error
```