### PR TITLE
Mark Location::caller() as #[inline]

### DIFF
--- a/library/core/src/panic/location.rs
+++ b/library/core/src/panic/location.rs
@@ -83,6 +83,7 @@ impl<'a> Location<'a> {
     #[stable(feature = "track_caller", since = "1.46.0")]
     #[rustc_const_unstable(feature = "const_caller_location", issue = "76156")]
     #[track_caller]
+    #[inline]
     pub const fn caller() -> &'static Location<'static> {
         crate::intrinsics::caller_location()
     }


### PR DESCRIPTION
This function gets compiled to a single register move as it actually gets it's return value passed in as argument.