### PR TITLE
Prepare 1.60.0 stable release

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,342 @@
+Version 1.60.0 (2022-04-07)
+==========================
+
+Language
+--------
+- [Stabilize `#[cfg(panic = "...")]` for either `"unwind"` or `"abort"`.][93658]
+- [Stabilize `#[cfg(target_has_atomic = "...")]` for each integer size and `"ptr"`.][93824]
+
+Compiler
+--------
+- [Enable combining `+crt-static` and `relocation-model=pic` on `x86_64-unknown-linux-gnu`][86374]
+- [Fixes wrong `unreachable_pub` lints on nested and glob public reexport][87487]
+- [Stabilize `-Z instrument-coverage` as `-C instrument-coverage`][90132]
+- [Stabilize `-Z print-link-args` as `--print link-args`][91606]
+- [Add new Tier 3 target `mips64-openwrt-linux-musl`\*][92300]
+- [Add new Tier 3 target `armv7-unknown-linux-uclibceabi` (softfloat)\*][92383]
+- [Fix invalid removal of newlines from doc comments][92357]
+- [Add kernel target for RustyHermit][92670]
+- [Deny mixing bin crate type with lib crate types][92933]
+- [Make rustc use `RUST_BACKTRACE=full` by default][93566]
+- [Upgrade to LLVM 14][93577]
+
+\* Refer to Rust's [platform support page][platform-support-doc] for more
+   information on Rust's tiered platform support.
+
+Libraries
+---------
+- [Guarantee call order for `sort_by_cached_key`][89621]
+- [Improve `Duration::try_from_secs_f32`/`f64` accuracy by directly processing exponent and mantissa][90247]
+- [Make `Instant::{duration_since, elapsed, sub}` saturating][89926]
+- [Remove non-monotonic clocks workarounds in `Instant::now`][89926]
+- [Make `BuildHasherDefault`, `iter::Empty` and `future::Pending` covariant][92630]
+
+Stabilized APIs
+---------------
+- [`Arc::new_cyclic`][arc_new_cyclic]
+- [`Rc::new_cyclic`][rc_new_cyclic]
+- [`slice::EscapeAscii`][slice_escape_ascii]
+- [`<[u8]>::escape_ascii`][slice_u8_escape_ascii]
+- [`u8::escape_ascii`][u8_escape_ascii]
+- [`Vec::spare_capacity_mut`][vec_spare_capacity_mut]
+- [`MaybeUninit::assume_init_drop`][assume_init_drop]
+- [`MaybeUninit::assume_init_read`][assume_init_read]
+- [`i8::abs_diff`][i8_abs_diff]
+- [`i16::abs_diff`][i16_abs_diff]
+- [`i32::abs_diff`][i32_abs_diff]
+- [`i64::abs_diff`][i64_abs_diff]
+- [`i128::abs_diff`][i128_abs_diff]
+- [`isize::abs_diff`][isize_abs_diff]
+- [`u8::abs_diff`][u8_abs_diff]
+- [`u16::abs_diff`][u16_abs_diff]
+- [`u32::abs_diff`][u32_abs_diff]
+- [`u64::abs_diff`][u64_abs_diff]
+- [`u128::abs_diff`][u128_abs_diff]
+- [`usize::abs_diff`][usize_abs_diff]
+- [`Display for io::ErrorKind`][display_error_kind]
+- [`From<u8> for ExitCode`][from_u8_exit_code]
+- [`Not for !` (the "never" type)][not_never]
+- [_Op_`Assign<$t> for Wrapping<$t>`][wrapping_assign_ops]
+- [`arch::is_aarch64_feature_detected!`][is_aarch64_feature_detected]
+
+Cargo
+-----
+- [Port cargo from `toml-rs` to `toml_edit`][cargo/10086]
+- [Stabilize `-Ztimings` as `--timings`][cargo/10245]
+- [Stabilize namespaced and weak dependency features.][cargo/10269]
+- [Accept more `cargo:rustc-link-arg-*` types from build script output.][cargo/10274]
+- [cargo-new should not add ignore rule on Cargo.lock inside subdirs][cargo/10379]
+
+Misc
+----
+- [Ship docs on Tier 2 platforms by reusing the closest Tier 1 platform docs][92800]
+- [Drop rustc-docs from complete profile][93742]
+- [bootstrap: tidy up flag handling for llvm build][93918]
+
+Compatibility Notes
+-------------------
+- [Remove compiler-rt linking hack on Android][83822]
+- [Mitigations for platforms with non-monotonic clocks have been removed from
+  `Instant::now`][89926]. On platforms that don't provide monotonic clocks, an
+  instant is not guaranteed to be greater than an earlier instant anymore.
+- [`Instant::{duration_since, elapsed, sub}` do not panic anymore on underflow,
+  saturating to `0` instead][89926]. In the real world the panic happened mostly
+  on platforms with buggy monotonic clock implementations rather than catching
+  programming errors like reversing the start and end times. Such programming
+  errors will now results in `0` rather than a panic.
+- In a future release we're planning to increase the baseline requirements for
+  the Linux kernel to version 3.2, and for glibc to version 2.17. We'd love
+  your feedback in [PR #95026][95026].
+
+Internal Changes
+----------------
+
+These changes provide no direct user facing benefits, but represent significant
+improvements to the internals and overall performance of rustc
+and related tools.
+
+- [Switch all libraries to the 2021 edition][92068]
+
+[83822]: https://github.com/rust-lang/rust/pull/83822
+[86374]: https://github.com/rust-lang/rust/pull/86374
+[87487]: https://github.com/rust-lang/rust/pull/87487
+[89621]: https://github.com/rust-lang/rust/pull/89621
+[89926]: https://github.com/rust-lang/rust/pull/89926
+[90132]: https://github.com/rust-lang/rust/pull/90132
+[90247]: https://github.com/rust-lang/rust/pull/90247
+[91606]: https://github.com/rust-lang/rust/pull/91606
+[92068]: https://github.com/rust-lang/rust/pull/92068
+[92300]: https://github.com/rust-lang/rust/pull/92300
+[92357]: https://github.com/rust-lang/rust/pull/92357
+[92383]: https://github.com/rust-lang/rust/pull/92383
+[92630]: https://github.com/rust-lang/rust/pull/92630
+[92670]: https://github.com/rust-lang/rust/pull/92670
+[92800]: https://github.com/rust-lang/rust/pull/92800
+[92933]: https://github.com/rust-lang/rust/pull/92933
+[93566]: https://github.com/rust-lang/rust/pull/93566
+[93577]: https://github.com/rust-lang/rust/pull/93577
+[93658]: https://github.com/rust-lang/rust/pull/93658
+[93742]: https://github.com/rust-lang/rust/pull/93742
+[93824]: https://github.com/rust-lang/rust/pull/93824
+[93918]: https://github.com/rust-lang/rust/pull/93918
+[95026]: https://github.com/rust-lang/rust/pull/95026
+
+[cargo/10086]: https://github.com/rust-lang/cargo/pull/10086
+[cargo/10245]: https://github.com/rust-lang/cargo/pull/10245
+[cargo/10269]: https://github.com/rust-lang/cargo/pull/10269
+[cargo/10274]: https://github.com/rust-lang/cargo/pull/10274
+[cargo/10379]: https://github.com/rust-lang/cargo/pull/10379
+
+[arc_new_cyclic]: https://doc.rust-lang.org/stable/std/sync/struct.Arc.html#method.new_cyclic
+[rc_new_cyclic]: https://doc.rust-lang.org/stable/std/rc/struct.Rc.html#method.new_cyclic
+[slice_escape_ascii]: https://doc.rust-lang.org/stable/std/slice/struct.EscapeAscii.html
+[slice_u8_escape_ascii]: https://doc.rust-lang.org/stable/std/primitive.slice.html#method.escape_ascii
+[u8_escape_ascii]: https://doc.rust-lang.org/stable/std/primitive.u8.html#method.escape_ascii
+[vec_spare_capacity_mut]: https://doc.rust-lang.org/stable/std/vec/struct.Vec.html#method.spare_capacity_mut
+[assume_init_drop]: https://doc.rust-lang.org/stable/std/mem/union.MaybeUninit.html#method.assume_init_drop
+[assume_init_read]: https://doc.rust-lang.org/stable/std/mem/union.MaybeUninit.html#method.assume_init_read
+[i8_abs_diff]: https://doc.rust-lang.org/stable/std/primitive.i8.html#method.abs_diff
+[i16_abs_diff]: https://doc.rust-lang.org/stable/std/primitive.i16.html#method.abs_diff
+[i32_abs_diff]: https://doc.rust-lang.org/stable/std/primitive.i32.html#method.abs_diff
+[i64_abs_diff]: https://doc.rust-lang.org/stable/std/primitive.i64.html#method.abs_diff
+[i128_abs_diff]: https://doc.rust-lang.org/stable/std/primitive.i128.html#method.abs_diff
+[isize_abs_diff]: https://doc.rust-lang.org/stable/std/primitive.isize.html#method.abs_diff
+[u8_abs_diff]: https://doc.rust-lang.org/stable/std/primitive.u8.html#method.abs_diff
+[u16_abs_diff]: https://doc.rust-lang.org/stable/std/primitive.u16.html#method.abs_diff
+[u32_abs_diff]: https://doc.rust-lang.org/stable/std/primitive.u32.html#method.abs_diff
+[u64_abs_diff]: https://doc.rust-lang.org/stable/std/primitive.u64.html#method.abs_diff
+[u128_abs_diff]: https://doc.rust-lang.org/stable/std/primitive.u128.html#method.abs_diff
+[usize_abs_diff]: https://doc.rust-lang.org/stable/std/primitive.usize.html#method.abs_diff
+[display_error_kind]: https://doc.rust-lang.org/stable/std/io/enum.ErrorKind.html#impl-Display
+[from_u8_exit_code]: https://doc.rust-lang.org/stable/std/process/struct.ExitCode.html#impl-From%3Cu8%3E
+[not_never]: https://doc.rust-lang.org/stable/std/primitive.never.html#impl-Not
+[wrapping_assign_ops]: https://doc.rust-lang.org/stable/std/num/struct.Wrapping.html#trait-implementations
+[is_aarch64_feature_detected]: https://doc.rust-lang.org/stable/std/arch/macro.is_aarch64_feature_detected.html
+
+Version 1.59.0 (2022-02-24)
+==========================
+
+Language
+--------
+
+- [Stabilize default arguments for const parameters and remove the ordering restriction for type and const parameters][90207]
+- [Stabilize destructuring assignment][90521]
+- [Relax private in public lint on generic bounds and where clauses of trait impls][90586]
+- [Stabilize asm! and global_asm! for x86, x86_64, ARM, Aarch64, and RISC-V][91728]
+
+Compiler
+--------
+
+- [Stabilize new symbol mangling format, leaving it opt-in (-Csymbol-mangling-version=v0)][90128]
+- [Emit LLVM optimization remarks when enabled with `-Cremark`][90833]
+- [Fix sparc64 ABI for aggregates with floating point members][91003]
+- [Warn when a `#[test]`-like built-in attribute macro is present multiple times.][91172]
+- [Add support for riscv64gc-unknown-freebsd][91284]
+- [Stabilize `-Z emit-future-incompat` as `--json future-incompat`][91535]
+- [Soft disable incremental compilation][94124]
+
+This release disables incremental compilation, unless the user has explicitly
+opted in via the newly added RUSTC_FORCE_INCREMENTAL=1 environment variable.
+This is due to a known and relatively frequently occurring bug in incremental
+compilation, which causes builds to issue internal compiler errors. This
+particular bug is already fixed on nightly, but that fix has not yet rolled out
+to stable and is deemed too risky for a direct stable backport.
+
+As always, we encourage users to test with nightly and report bugs so that we
+can track failures and fix issues earlier.
+
+See [94124] for more details.
+
+[94124]: https://github.com/rust-lang/rust/issues/94124
+
+Libraries
+---------
+
+- [Remove unnecessary bounds for some Hash{Map,Set} methods][91593]
+
+Stabilized APIs
+---------------
+
+- [`std::thread::available_parallelism`][available_parallelism]
+- [`Result::copied`][result-copied]
+- [`Result::cloned`][result-cloned]
+- [`arch::asm!`][asm]
+- [`arch::global_asm!`][global_asm]
+- [`ops::ControlFlow::is_break`][is_break]
+- [`ops::ControlFlow::is_continue`][is_continue]
+- [`TryFrom<char> for u8`][try_from_char_u8]
+- [`char::TryFromCharError`][try_from_char_err]
+  implementing `Clone`, `Debug`, `Display`, `PartialEq`, `Copy`, `Eq`, `Error`
+- [`iter::zip`][zip]
+- [`NonZeroU8::is_power_of_two`][is_power_of_two8]
+- [`NonZeroU16::is_power_of_two`][is_power_of_two16]
+- [`NonZeroU32::is_power_of_two`][is_power_of_two32]
+- [`NonZeroU64::is_power_of_two`][is_power_of_two64]
+- [`NonZeroU128::is_power_of_two`][is_power_of_two128]
+- [`NonZeroUsize::is_power_of_two`][is_power_of_two_usize]
+- [`DoubleEndedIterator for ToLowercase`][lowercase]
+- [`DoubleEndedIterator for ToUppercase`][uppercase]
+- [`TryFrom<&mut [T]> for [T; N]`][tryfrom_ref_arr]
+- [`UnwindSafe for Once`][unwindsafe_once]
+- [`RefUnwindSafe for Once`][refunwindsafe_once]
+- [armv8 neon intrinsics for aarch64][stdarch/1266]
+
+Const-stable:
+
+- [`mem::MaybeUninit::as_ptr`][muninit_ptr]
+- [`mem::MaybeUninit::assume_init`][muninit_init]
+- [`mem::MaybeUninit::assume_init_ref`][muninit_init_ref]
+- [`ffi::CStr::from_bytes_with_nul_unchecked`][cstr_from_bytes]
+
+Cargo
+-----
+
+- [Stabilize the `strip` profile option][cargo/10088]
+- [Stabilize future-incompat-report][cargo/10165]
+- [Support abbreviating `--release` as `-r`][cargo/10133]
+- [Support `term.quiet` configuration][cargo/10152]
+- [Remove `--host` from cargo {publish,search,login}][cargo/10145]
+
+Compatibility Notes
+-------------------
+
+- [Refactor weak symbols in std::sys::unix][90846]
+  This may add new, versioned, symbols when building with a newer glibc, as the
+  standard library uses weak linkage rather than dynamically attempting to load
+  certain symbols at runtime.
+- [Deprecate crate_type and crate_name nested inside `#![cfg_attr]`][83744]
+  This adds a future compatibility lint to supporting the use of cfg_attr
+  wrapping either crate_type or crate_name specification within Rust files;
+  it is recommended that users migrate to setting the equivalent command line
+  flags.
+- [Remove effect of `#[no_link]` attribute on name resolution][92034]
+  This may expose new names, leading to conflicts with preexisting names in a
+  given namespace and a compilation failure.
+- [Cargo will document libraries before binaries.][cargo/10172]
+- [Respect doc=false in dependencies, not just the root crate][cargo/10201]
+- [Weaken guarantee around advancing underlying iterators in zip][83791]
+- [Make split_inclusive() on an empty slice yield an empty output][89825]
+- [Update std::env::temp_dir to use GetTempPath2 on Windows when available.][89999]
+- [unreachable! was updated to match other formatting macro behavior on Rust 2021][92137]
+
+Internal Changes
+----------------
+
+These changes provide no direct user facing benefits, but represent significant
+improvements to the internals and overall performance of rustc
+and related tools.
+
+- [Fix many cases of normalization-related ICEs][91255]
+- [Replace dominators algorithm with simple Lengauer-Tarjan][85013]
+- [Store liveness in interval sets for region inference][90637]
+
+- [Remove `in_band_lifetimes` from the compiler and standard library, in preparation for removing this
+  unstable feature.][91867]
+
+[91867]: https://github.com/rust-lang/rust/issues/91867
+[83744]: https://github.com/rust-lang/rust/pull/83744/
+[83791]: https://github.com/rust-lang/rust/pull/83791/
+[85013]: https://github.com/rust-lang/rust/pull/85013/
+[89825]: https://github.com/rust-lang/rust/pull/89825/
+[89999]: https://github.com/rust-lang/rust/pull/89999/
+[90128]: https://github.com/rust-lang/rust/pull/90128/
+[90207]: https://github.com/rust-lang/rust/pull/90207/
+[90521]: https://github.com/rust-lang/rust/pull/90521/
+[90586]: https://github.com/rust-lang/rust/pull/90586/
+[90637]: https://github.com/rust-lang/rust/pull/90637/
+[90833]: https://github.com/rust-lang/rust/pull/90833/
+[90846]: https://github.com/rust-lang/rust/pull/90846/
+[91003]: https://github.com/rust-lang/rust/pull/91003/
+[91172]: https://github.com/rust-lang/rust/pull/91172/
+[91255]: https://github.com/rust-lang/rust/pull/91255/
+[91284]: https://github.com/rust-lang/rust/pull/91284/
+[91535]: https://github.com/rust-lang/rust/pull/91535/
+[91593]: https://github.com/rust-lang/rust/pull/91593/
+[91728]: https://github.com/rust-lang/rust/pull/91728/
+[91878]: https://github.com/rust-lang/rust/pull/91878/
+[91896]: https://github.com/rust-lang/rust/pull/91896/
+[91926]: https://github.com/rust-lang/rust/pull/91926/
+[91984]: https://github.com/rust-lang/rust/pull/91984/
+[92020]: https://github.com/rust-lang/rust/pull/92020/
+[92034]: https://github.com/rust-lang/rust/pull/92034/
+[92137]: https://github.com/rust-lang/rust/pull/92137/
+[92483]: https://github.com/rust-lang/rust/pull/92483/
+[cargo/10088]: https://github.com/rust-lang/cargo/pull/10088/
+[cargo/10133]: https://github.com/rust-lang/cargo/pull/10133/
+[cargo/10145]: https://github.com/rust-lang/cargo/pull/10145/
+[cargo/10152]: https://github.com/rust-lang/cargo/pull/10152/
+[cargo/10165]: https://github.com/rust-lang/cargo/pull/10165/
+[cargo/10172]: https://github.com/rust-lang/cargo/pull/10172/
+[cargo/10201]: https://github.com/rust-lang/cargo/pull/10201/
+[cargo/10269]: https://github.com/rust-lang/cargo/pull/10269/
+
+[cstr_from_bytes]: https://doc.rust-lang.org/stable/std/ffi/struct.CStr.html#method.from_bytes_with_nul_unchecked
+[muninit_ptr]: https://doc.rust-lang.org/stable/std/mem/union.MaybeUninit.html#method.as_ptr
+[muninit_init]: https://doc.rust-lang.org/stable/std/mem/union.MaybeUninit.html#method.assume_init
+[muninit_init_ref]: https://doc.rust-lang.org/stable/std/mem/union.MaybeUninit.html#method.assume_init_ref
+[unwindsafe_once]: https://doc.rust-lang.org/stable/std/sync/struct.Once.html#impl-UnwindSafe
+[refunwindsafe_once]: https://doc.rust-lang.org/stable/std/sync/struct.Once.html#impl-RefUnwindSafe
+[tryfrom_ref_arr]: https://doc.rust-lang.org/stable/std/convert/trait.TryFrom.html#impl-TryFrom%3C%26%27_%20mut%20%5BT%5D%3E
+[lowercase]: https://doc.rust-lang.org/stable/std/char/struct.ToLowercase.html#impl-DoubleEndedIterator
+[uppercase]: https://doc.rust-lang.org/stable/std/char/struct.ToUppercase.html#impl-DoubleEndedIterator
+[try_from_char_err]: https://doc.rust-lang.org/stable/std/char/struct.TryFromCharError.html
+[available_parallelism]: https://doc.rust-lang.org/stable/std/thread/fn.available_parallelism.html
+[result-copied]: https://doc.rust-lang.org/stable/std/result/enum.Result.html#method.copied
+[result-cloned]: https://doc.rust-lang.org/stable/std/result/enum.Result.html#method.cloned
+[asm]: https://doc.rust-lang.org/stable/core/arch/macro.asm.html
+[global_asm]: https://doc.rust-lang.org/stable/core/arch/macro.global_asm.html
+[is_break]: https://doc.rust-lang.org/stable/std/ops/enum.ControlFlow.html#method.is_break
+[is_continue]: https://doc.rust-lang.org/stable/std/ops/enum.ControlFlow.html#method.is_continue
+[try_from_char_u8]: https://doc.rust-lang.org/stable/std/primitive.char.html#impl-TryFrom%3Cchar%3E
+[zip]: https://doc.rust-lang.org/stable/std/iter/fn.zip.html
+[is_power_of_two8]: https://doc.rust-lang.org/stable/core/num/struct.NonZeroU8.html#method.is_power_of_two
+[is_power_of_two16]: https://doc.rust-lang.org/stable/core/num/struct.NonZeroU16.html#method.is_power_of_two
+[is_power_of_two32]: https://doc.rust-lang.org/stable/core/num/struct.NonZeroU32.html#method.is_power_of_two
+[is_power_of_two64]: https://doc.rust-lang.org/stable/core/num/struct.NonZeroU64.html#method.is_power_of_two
+[is_power_of_two128]: https://doc.rust-lang.org/stable/core/num/struct.NonZeroU128.html#method.is_power_of_two
+[is_power_of_two_usize]: https://doc.rust-lang.org/stable/core/num/struct.NonZeroUsize.html#method.is_power_of_two
+[stdarch/1266]: https://github.com/rust-lang/stdarch/pull/1266
+
 Version 1.58.1 (2022-01-19)
 ===========================
 
@@ -876,7 +1215,7 @@ Version 1.52.1 (2021-05-10)
 This release disables incremental compilation, unless the user has explicitly
 opted in via the newly added RUSTC_FORCE_INCREMENTAL=1 environment variable.
 
-This is due to the widespread, and frequently occuring, breakage encountered by
+This is due to the widespread, and frequently occurring, breakage encountered by
 Rust users due to newly enabled incremental verification in 1.52.0. Notably,
 Rust users **should** upgrade to 1.52.0 or 1.52.1: the bugs that are detected by
 newly added incremental verification are still present in past stable versions,

--- a/library/std/src/io/error/repr_bitpacked.rs
+++ b/library/std/src/io/error/repr_bitpacked.rs
@@ -120,7 +120,7 @@ const TAG_SIMPLE: usize = 0b11;
 /// See the module docs for more, this is just a way to hack in a check that we
 /// indeed are not unwind-safe.
 ///
-/// ```compile_fail
+/// ```compile_fail,E0277
 /// fn is_unwind_safe<T: core::panic::UnwindSafe>() {}
 /// is_unwind_safe::<std::io::Error>();
 /// ```

--- a/library/std/src/io/error/repr_bitpacked.rs
+++ b/library/std/src/io/error/repr_bitpacked.rs
@@ -115,6 +115,15 @@ const TAG_CUSTOM: usize = 0b01;
 const TAG_OS: usize = 0b10;
 const TAG_SIMPLE: usize = 0b11;
 
+/// The internal representation.
+///
+/// See the module docs for more, this is just a way to hack in a check that we
+/// indeed are not unwind-safe.
+///
+/// ```compile_fail
+/// fn is_unwind_safe<T: core::panic::UnwindSafe>() {}
+/// is_unwind_safe::<std::io::Error>();
+/// ```
 #[repr(transparent)]
 pub(super) struct Repr(NonNull<()>, PhantomData<ErrorData<Box<Custom>>>);
 

--- a/library/std/src/io/error/repr_bitpacked.rs
+++ b/library/std/src/io/error/repr_bitpacked.rs
@@ -104,6 +104,7 @@
 
 use super::{Custom, ErrorData, ErrorKind, SimpleMessage};
 use alloc::boxed::Box;
+use core::marker::PhantomData;
 use core::mem::{align_of, size_of};
 use core::ptr::NonNull;
 
@@ -115,7 +116,7 @@ const TAG_OS: usize = 0b10;
 const TAG_SIMPLE: usize = 0b11;
 
 #[repr(transparent)]
-pub(super) struct Repr(NonNull<()>);
+pub(super) struct Repr(NonNull<()>, PhantomData<ErrorData<Box<Custom>>>);
 
 // All the types `Repr` stores internally are Send + Sync, and so is it.
 unsafe impl Send for Repr {}
@@ -145,7 +146,7 @@ impl Repr {
         // box, and `TAG_CUSTOM` just... isn't zero -- it's `0b01`). Therefore,
         // `TAG_CUSTOM + p` isn't zero and so `tagged` can't be, and the
         // `new_unchecked` is safe.
-        let res = Self(unsafe { NonNull::new_unchecked(tagged) });
+        let res = Self(unsafe { NonNull::new_unchecked(tagged) }, PhantomData);
         // quickly smoke-check we encoded the right thing (This generally will
         // only run in libstd's tests, unless the user uses -Zbuild-std)
         debug_assert!(matches!(res.data(), ErrorData::Custom(_)), "repr(custom) encoding failed");
@@ -156,7 +157,7 @@ impl Repr {
     pub(super) fn new_os(code: i32) -> Self {
         let utagged = ((code as usize) << 32) | TAG_OS;
         // Safety: `TAG_OS` is not zero, so the result of the `|` is not 0.
-        let res = Self(unsafe { NonNull::new_unchecked(utagged as *mut ()) });
+        let res = Self(unsafe { NonNull::new_unchecked(utagged as *mut ()) }, PhantomData);
         // quickly smoke-check we encoded the right thing (This generally will
         // only run in libstd's tests, unless the user uses -Zbuild-std)
         debug_assert!(
@@ -171,7 +172,7 @@ impl Repr {
     pub(super) fn new_simple(kind: ErrorKind) -> Self {
         let utagged = ((kind as usize) << 32) | TAG_SIMPLE;
         // Safety: `TAG_SIMPLE` is not zero, so the result of the `|` is not 0.
-        let res = Self(unsafe { NonNull::new_unchecked(utagged as *mut ()) });
+        let res = Self(unsafe { NonNull::new_unchecked(utagged as *mut ()) }, PhantomData);
         // quickly smoke-check we encoded the right thing (This generally will
         // only run in libstd's tests, unless the user uses -Zbuild-std)
         debug_assert!(
@@ -185,7 +186,7 @@ impl Repr {
     #[inline]
     pub(super) const fn new_simple_message(m: &'static SimpleMessage) -> Self {
         // Safety: References are never null.
-        Self(unsafe { NonNull::new_unchecked(m as *const _ as *mut ()) })
+        Self(unsafe { NonNull::new_unchecked(m as *const _ as *mut ()) }, PhantomData)
     }
 
     #[inline]

--- a/src/ci/channel
+++ b/src/ci/channel
@@ -1,1 +1,1 @@
-beta
+stable


### PR DESCRIPTION
This PR bumps the channel to stable, and backports the following PRs:

* Miscellaneous release notes updates.
* https://github.com/rust-lang/rust/pull/94817
* https://github.com/rust-lang/rust/pull/95256

r? @ghost