### PR TITLE
Add convenience byte offset/check align functions to pointers

### DIFF
--- a/library/core/src/ptr/const_ptr.rs
+++ b/library/core/src/ptr/const_ptr.rs
@@ -462,16 +462,17 @@ impl<T: ?Sized> *const T {
     /// This is purely a convenience for casting to a `u8` pointer and
     /// using [offset][pointer::offset] on it. See that method for documentation
     /// and safety requirements.
+    ///
+    /// For non-`Sized` pointees this operation changes only the data pointer,
+    /// leaving the metadata untouched.
     #[must_use]
     #[inline(always)]
     #[unstable(feature = "pointer_byte_offsets", issue = "none")]
     #[rustc_const_unstable(feature = "const_pointer_byte_offsets", issue = "none")]
-    pub const unsafe fn byte_offset(self, count: isize) -> Self
-    where
-        T: Sized,
-    {
+    pub const unsafe fn byte_offset(self, count: isize) -> Self {
         // SAFETY: the caller must uphold the safety contract for `offset`.
-        unsafe { self.cast::<u8>().offset(count).cast::<T>() }
+        let this = unsafe { self.cast::<u8>().offset(count).cast::<()>() };
+        from_raw_parts::<T>(this, metadata(self))
     }
 
     /// Calculates the offset from a pointer using wrapping arithmetic.
@@ -543,15 +544,15 @@ impl<T: ?Sized> *const T {
     /// This is purely a convenience for casting to a `u8` pointer and
     /// using [wrapping_offset][pointer::wrapping_offset] on it. See that method
     /// for documentation.
+    ///
+    /// For non-`Sized` pointees this operation changes only the data pointer,
+    /// leaving the metadata untouched.
     #[must_use]
     #[inline(always)]
     #[unstable(feature = "pointer_byte_offsets", issue = "none")]
     #[rustc_const_unstable(feature = "const_pointer_byte_offsets", issue = "none")]
-    pub const fn wrapping_byte_offset(self, count: isize) -> Self
-    where
-        T: Sized,
-    {
-        self.cast::<u8>().wrapping_offset(count).cast::<T>()
+    pub const fn wrapping_byte_offset(self, count: isize) -> Self {
+        from_raw_parts::<T>(self.cast::<u8>().wrapping_offset(count).cast::<()>(), metadata(self))
     }
 
     /// Calculates the distance between two pointers. The returned value is in
@@ -654,13 +655,13 @@ impl<T: ?Sized> *const T {
     /// This is purely a convenience for casting to a `u8` pointer and
     /// using [offset_from][pointer::offset_from] on it. See that method for
     /// documentation and safety requirements.
+    ///
+    /// For non-`Sized` pointees this operation considers only the data pointers,
+    /// ignoring the metadata.
     #[inline(always)]
     #[unstable(feature = "pointer_byte_offsets", issue = "none")]
     #[rustc_const_unstable(feature = "const_pointer_byte_offsets", issue = "none")]
-    pub const unsafe fn byte_offset_from(self, origin: *const T) -> isize
-    where
-        T: Sized,
-    {
+    pub const unsafe fn byte_offset_from(self, origin: *const T) -> isize {
         // SAFETY: the caller must uphold the safety contract for `offset_from`.
         unsafe { self.cast::<u8>().offset_from(origin.cast::<u8>()) }
     }
@@ -874,16 +875,17 @@ impl<T: ?Sized> *const T {
     /// This is purely a convenience for casting to a `u8` pointer and
     /// using [add][pointer::add] on it. See that method for documentation
     /// and safety requirements.
+    ///
+    /// For non-`Sized` pointees this operation changes only the data pointer,
+    /// leaving the metadata untouched.
     #[must_use]
     #[inline(always)]
     #[unstable(feature = "pointer_byte_offsets", issue = "none")]
     #[rustc_const_unstable(feature = "const_pointer_byte_offsets", issue = "none")]
-    pub const unsafe fn byte_add(self, count: usize) -> Self
-    where
-        T: Sized,
-    {
+    pub const unsafe fn byte_add(self, count: usize) -> Self {
         // SAFETY: the caller must uphold the safety contract for `add`.
-        unsafe { self.cast::<u8>().add(count).cast::<T>() }
+        let this = unsafe { self.cast::<u8>().add(count).cast::<()>() };
+        from_raw_parts::<T>(this, metadata(self))
     }
 
     /// Calculates the offset from a pointer (convenience for
@@ -958,16 +960,17 @@ impl<T: ?Sized> *const T {
     /// This is purely a convenience for casting to a `u8` pointer and
     /// using [sub][pointer::sub] on it. See that method for documentation
     /// and safety requirements.
+    ///
+    /// For non-`Sized` pointees this operation changes only the data pointer,
+    /// leaving the metadata untouched.
     #[must_use]
     #[inline(always)]
     #[unstable(feature = "pointer_byte_offsets", issue = "none")]
     #[rustc_const_unstable(feature = "const_pointer_byte_offsets", issue = "none")]
-    pub const unsafe fn byte_sub(self, count: usize) -> Self
-    where
-        T: Sized,
-    {
+    pub const unsafe fn byte_sub(self, count: usize) -> Self {
         // SAFETY: the caller must uphold the safety contract for `sub`.
-        unsafe { self.cast::<u8>().sub(count).cast::<T>() }
+        let this = unsafe { self.cast::<u8>().sub(count).cast::<()>() };
+        from_raw_parts::<T>(this, metadata(self))
     }
 
     /// Calculates the offset from a pointer using wrapping arithmetic.
@@ -1039,15 +1042,15 @@ impl<T: ?Sized> *const T {
     ///
     /// This is purely a convenience for casting to a `u8` pointer and
     /// using [wrapping_add][pointer::wrapping_add] on it. See that method for documentation.
+    ///
+    /// For non-`Sized` pointees this operation changes only the data pointer,
+    /// leaving the metadata untouched.
     #[must_use]
     #[inline(always)]
     #[unstable(feature = "pointer_byte_offsets", issue = "none")]
     #[rustc_const_unstable(feature = "const_pointer_byte_offsets", issue = "none")]
-    pub const fn wrapping_byte_add(self, count: usize) -> Self
-    where
-        T: Sized,
-    {
-        self.cast::<u8>().wrapping_add(count).cast::<T>()
+    pub const fn wrapping_byte_add(self, count: usize) -> Self {
+        from_raw_parts::<T>(self.cast::<u8>().wrapping_add(count).cast::<()>(), metadata(self))
     }
 
     /// Calculates the offset from a pointer using wrapping arithmetic.
@@ -1119,15 +1122,15 @@ impl<T: ?Sized> *const T {
     ///
     /// This is purely a convenience for casting to a `u8` pointer and
     /// using [wrapping_sub][pointer::wrapping_sub] on it. See that method for documentation.
+    ///
+    /// For non-`Sized` pointees this operation changes only the data pointer,
+    /// leaving the metadata untouched.
     #[must_use]
     #[inline(always)]
     #[unstable(feature = "pointer_byte_offsets", issue = "none")]
     #[rustc_const_unstable(feature = "const_pointer_byte_offsets", issue = "none")]
-    pub const fn wrapping_byte_sub(self, count: usize) -> Self
-    where
-        T: Sized,
-    {
-        self.cast::<u8>().wrapping_sub(count).cast::<T>()
+    pub const fn wrapping_byte_sub(self, count: usize) -> Self {
+        from_raw_parts::<T>(self.cast::<u8>().wrapping_sub(count).cast::<()>(), metadata(self))
     }
 
     /// Reads the value from `self` without moving it. This leaves the
@@ -1303,21 +1306,22 @@ impl<T: ?Sized> *const T {
 
     /// Returns whether the pointer is aligned to `align`.
     ///
+    /// For non-`Sized` pointees this operation considers only the data pointer,
+    /// ignoring the metadata.
+    ///
     /// # Panics
     ///
     /// The function panics if `align` is not a power-of-two (this includes 0).
     #[must_use]
     #[inline]
     #[unstable(feature = "pointer_is_aligned", issue = "none")]
-    pub fn is_aligned_to(self, align: usize) -> bool
-    where
-        T: Sized,
-    {
+    pub fn is_aligned_to(self, align: usize) -> bool {
         if !align.is_power_of_two() {
             panic!("is_aligned_to: align is not a power-of-two");
         }
 
-        self.addr() % align == 0
+        // Cast is needed for `T: !Sized`
+        self.cast::<u8>().addr() % align == 0
     }
 }
 

--- a/library/core/src/ptr/const_ptr.rs
+++ b/library/core/src/ptr/const_ptr.rs
@@ -1320,6 +1320,9 @@ impl<T: ?Sized> *const T {
             panic!("is_aligned_to: align is not a power-of-two");
         }
 
+        // SAFETY: `is_power_of_two()` will return `false` for zero.
+        unsafe { core::intrinsics::assume(align != 0) };
+
         // Cast is needed for `T: !Sized`
         self.cast::<u8>().addr() % align == 0
     }

--- a/library/core/src/ptr/const_ptr.rs
+++ b/library/core/src/ptr/const_ptr.rs
@@ -467,8 +467,8 @@ impl<T: ?Sized> *const T {
     /// leaving the metadata untouched.
     #[must_use]
     #[inline(always)]
-    #[unstable(feature = "pointer_byte_offsets", issue = "none")]
-    #[rustc_const_unstable(feature = "const_pointer_byte_offsets", issue = "none")]
+    #[unstable(feature = "pointer_byte_offsets", issue = "96283")]
+    #[rustc_const_unstable(feature = "const_pointer_byte_offsets", issue = "96283")]
     pub const unsafe fn byte_offset(self, count: isize) -> Self {
         // SAFETY: the caller must uphold the safety contract for `offset`.
         let this = unsafe { self.cast::<u8>().offset(count).cast::<()>() };
@@ -549,8 +549,8 @@ impl<T: ?Sized> *const T {
     /// leaving the metadata untouched.
     #[must_use]
     #[inline(always)]
-    #[unstable(feature = "pointer_byte_offsets", issue = "none")]
-    #[rustc_const_unstable(feature = "const_pointer_byte_offsets", issue = "none")]
+    #[unstable(feature = "pointer_byte_offsets", issue = "96283")]
+    #[rustc_const_unstable(feature = "const_pointer_byte_offsets", issue = "96283")]
     pub const fn wrapping_byte_offset(self, count: isize) -> Self {
         from_raw_parts::<T>(self.cast::<u8>().wrapping_offset(count).cast::<()>(), metadata(self))
     }
@@ -659,8 +659,8 @@ impl<T: ?Sized> *const T {
     /// For non-`Sized` pointees this operation considers only the data pointers,
     /// ignoring the metadata.
     #[inline(always)]
-    #[unstable(feature = "pointer_byte_offsets", issue = "none")]
-    #[rustc_const_unstable(feature = "const_pointer_byte_offsets", issue = "none")]
+    #[unstable(feature = "pointer_byte_offsets", issue = "96283")]
+    #[rustc_const_unstable(feature = "const_pointer_byte_offsets", issue = "96283")]
     pub const unsafe fn byte_offset_from(self, origin: *const T) -> isize {
         // SAFETY: the caller must uphold the safety contract for `offset_from`.
         unsafe { self.cast::<u8>().offset_from(origin.cast::<u8>()) }
@@ -880,8 +880,8 @@ impl<T: ?Sized> *const T {
     /// leaving the metadata untouched.
     #[must_use]
     #[inline(always)]
-    #[unstable(feature = "pointer_byte_offsets", issue = "none")]
-    #[rustc_const_unstable(feature = "const_pointer_byte_offsets", issue = "none")]
+    #[unstable(feature = "pointer_byte_offsets", issue = "96283")]
+    #[rustc_const_unstable(feature = "const_pointer_byte_offsets", issue = "96283")]
     pub const unsafe fn byte_add(self, count: usize) -> Self {
         // SAFETY: the caller must uphold the safety contract for `add`.
         let this = unsafe { self.cast::<u8>().add(count).cast::<()>() };
@@ -965,8 +965,8 @@ impl<T: ?Sized> *const T {
     /// leaving the metadata untouched.
     #[must_use]
     #[inline(always)]
-    #[unstable(feature = "pointer_byte_offsets", issue = "none")]
-    #[rustc_const_unstable(feature = "const_pointer_byte_offsets", issue = "none")]
+    #[unstable(feature = "pointer_byte_offsets", issue = "96283")]
+    #[rustc_const_unstable(feature = "const_pointer_byte_offsets", issue = "96283")]
     pub const unsafe fn byte_sub(self, count: usize) -> Self {
         // SAFETY: the caller must uphold the safety contract for `sub`.
         let this = unsafe { self.cast::<u8>().sub(count).cast::<()>() };
@@ -1047,8 +1047,8 @@ impl<T: ?Sized> *const T {
     /// leaving the metadata untouched.
     #[must_use]
     #[inline(always)]
-    #[unstable(feature = "pointer_byte_offsets", issue = "none")]
-    #[rustc_const_unstable(feature = "const_pointer_byte_offsets", issue = "none")]
+    #[unstable(feature = "pointer_byte_offsets", issue = "96283")]
+    #[rustc_const_unstable(feature = "const_pointer_byte_offsets", issue = "96283")]
     pub const fn wrapping_byte_add(self, count: usize) -> Self {
         from_raw_parts::<T>(self.cast::<u8>().wrapping_add(count).cast::<()>(), metadata(self))
     }
@@ -1127,8 +1127,8 @@ impl<T: ?Sized> *const T {
     /// leaving the metadata untouched.
     #[must_use]
     #[inline(always)]
-    #[unstable(feature = "pointer_byte_offsets", issue = "none")]
-    #[rustc_const_unstable(feature = "const_pointer_byte_offsets", issue = "none")]
+    #[unstable(feature = "pointer_byte_offsets", issue = "96283")]
+    #[rustc_const_unstable(feature = "const_pointer_byte_offsets", issue = "96283")]
     pub const fn wrapping_byte_sub(self, count: usize) -> Self {
         from_raw_parts::<T>(self.cast::<u8>().wrapping_sub(count).cast::<()>(), metadata(self))
     }
@@ -1296,7 +1296,7 @@ impl<T: ?Sized> *const T {
     /// Returns whether the pointer is properly aligned for `T`.
     #[must_use]
     #[inline]
-    #[unstable(feature = "pointer_is_aligned", issue = "none")]
+    #[unstable(feature = "pointer_is_aligned", issue = "96284")]
     pub fn is_aligned(self) -> bool
     where
         T: Sized,
@@ -1314,7 +1314,7 @@ impl<T: ?Sized> *const T {
     /// The function panics if `align` is not a power-of-two (this includes 0).
     #[must_use]
     #[inline]
-    #[unstable(feature = "pointer_is_aligned", issue = "none")]
+    #[unstable(feature = "pointer_is_aligned", issue = "96284")]
     pub fn is_aligned_to(self, align: usize) -> bool {
         if !align.is_power_of_two() {
             panic!("is_aligned_to: align is not a power-of-two");

--- a/library/core/src/ptr/const_ptr.rs
+++ b/library/core/src/ptr/const_ptr.rs
@@ -455,6 +455,25 @@ impl<T: ?Sized> *const T {
         unsafe { intrinsics::offset(self, count) }
     }
 
+    /// Calculates the offset from a pointer in bytes.
+    ///
+    /// `count` is in units of **bytes**.
+    ///
+    /// This is purely a convenience for casting to a `u8` pointer and
+    /// using [offset][pointer::offset] on it. See that method for documentation
+    /// and safety requirements.
+    #[must_use]
+    #[inline(always)]
+    #[unstable(feature = "pointer_byte_offsets", issue = "none")]
+    #[rustc_const_unstable(feature = "const_pointer_byte_offsets", issue = "none")]
+    pub const unsafe fn byte_offset(self, count: isize) -> Self
+    where
+        T: Sized,
+    {
+        // SAFETY: the caller must uphold the safety contract for `offset`.
+        unsafe { self.cast::<u8>().offset(count).cast::<T>() }
+    }
+
     /// Calculates the offset from a pointer using wrapping arithmetic.
     ///
     /// `count` is in units of T; e.g., a `count` of 3 represents a pointer
@@ -515,6 +534,24 @@ impl<T: ?Sized> *const T {
     {
         // SAFETY: the `arith_offset` intrinsic has no prerequisites to be called.
         unsafe { intrinsics::arith_offset(self, count) }
+    }
+
+    /// Calculates the offset from a pointer in bytes using wrapping arithmetic.
+    ///
+    /// `count` is in units of **bytes**.
+    ///
+    /// This is purely a convenience for casting to a `u8` pointer and
+    /// using [wrapping_offset][pointer::wrapping_offset] on it. See that method
+    /// for documentation.
+    #[must_use]
+    #[inline(always)]
+    #[unstable(feature = "pointer_byte_offsets", issue = "none")]
+    #[rustc_const_unstable(feature = "const_pointer_byte_offsets", issue = "none")]
+    pub const fn wrapping_byte_offset(self, count: isize) -> Self
+    where
+        T: Sized,
+    {
+        self.cast::<u8>().wrapping_offset(count).cast::<T>()
     }
 
     /// Calculates the distance between two pointers. The returned value is in
@@ -609,6 +646,23 @@ impl<T: ?Sized> *const T {
         assert!(0 < pointee_size && pointee_size <= isize::MAX as usize);
         // SAFETY: the caller must uphold the safety contract for `ptr_offset_from`.
         unsafe { intrinsics::ptr_offset_from(self, origin) }
+    }
+
+    /// Calculates the distance between two pointers. The returned value is in
+    /// units of **bytes**.
+    ///
+    /// This is purely a convenience for casting to a `u8` pointer and
+    /// using [offset_from][pointer::offset_from] on it. See that method for
+    /// documentation and safety requirements.
+    #[inline(always)]
+    #[unstable(feature = "pointer_byte_offsets", issue = "none")]
+    #[rustc_const_unstable(feature = "const_pointer_byte_offsets", issue = "none")]
+    pub const unsafe fn byte_offset_from(self, origin: *const T) -> isize
+    where
+        T: Sized,
+    {
+        // SAFETY: the caller must uphold the safety contract for `offset_from`.
+        unsafe { self.cast::<u8>().offset_from(origin.cast::<u8>()) }
     }
 
     /// Calculates the distance between two pointers, *where it's known that
@@ -813,6 +867,25 @@ impl<T: ?Sized> *const T {
         unsafe { self.offset(count as isize) }
     }
 
+    /// Calculates the offset from a pointer in bytes (convenience for `.byte_offset(count as isize)`).
+    ///
+    /// `count` is in units of bytes.
+    ///
+    /// This is purely a convenience for casting to a `u8` pointer and
+    /// using [add][pointer::add] on it. See that method for documentation
+    /// and safety requirements.
+    #[must_use]
+    #[inline(always)]
+    #[unstable(feature = "pointer_byte_offsets", issue = "none")]
+    #[rustc_const_unstable(feature = "const_pointer_byte_offsets", issue = "none")]
+    pub const unsafe fn byte_add(self, count: usize) -> Self
+    where
+        T: Sized,
+    {
+        // SAFETY: the caller must uphold the safety contract for `add`.
+        unsafe { self.cast::<u8>().add(count).cast::<T>() }
+    }
+
     /// Calculates the offset from a pointer (convenience for
     /// `.offset((count as isize).wrapping_neg())`).
     ///
@@ -877,6 +950,26 @@ impl<T: ?Sized> *const T {
         unsafe { self.offset((count as isize).wrapping_neg()) }
     }
 
+    /// Calculates the offset from a pointer in bytes (convenience for
+    /// `.byte_offset((count as isize).wrapping_neg())`).
+    ///
+    /// `count` is in units of bytes.
+    ///
+    /// This is purely a convenience for casting to a `u8` pointer and
+    /// using [sub][pointer::sub] on it. See that method for documentation
+    /// and safety requirements.
+    #[must_use]
+    #[inline(always)]
+    #[unstable(feature = "pointer_byte_offsets", issue = "none")]
+    #[rustc_const_unstable(feature = "const_pointer_byte_offsets", issue = "none")]
+    pub const unsafe fn byte_sub(self, count: usize) -> Self
+    where
+        T: Sized,
+    {
+        // SAFETY: the caller must uphold the safety contract for `sub`.
+        unsafe { self.cast::<u8>().sub(count).cast::<T>() }
+    }
+
     /// Calculates the offset from a pointer using wrapping arithmetic.
     /// (convenience for `.wrapping_offset(count as isize)`)
     ///
@@ -939,6 +1032,24 @@ impl<T: ?Sized> *const T {
         self.wrapping_offset(count as isize)
     }
 
+    /// Calculates the offset from a pointer in bytes using wrapping arithmetic.
+    /// (convenience for `.wrapping_byte_offset(count as isize)`)
+    ///
+    /// `count` is in units of bytes.
+    ///
+    /// This is purely a convenience for casting to a `u8` pointer and
+    /// using [wrapping_add][pointer::wrapping_add] on it. See that method for documentation.
+    #[must_use]
+    #[inline(always)]
+    #[unstable(feature = "pointer_byte_offsets", issue = "none")]
+    #[rustc_const_unstable(feature = "const_pointer_byte_offsets", issue = "none")]
+    pub const fn wrapping_byte_add(self, count: usize) -> Self
+    where
+        T: Sized,
+    {
+        self.cast::<u8>().wrapping_add(count).cast::<T>()
+    }
+
     /// Calculates the offset from a pointer using wrapping arithmetic.
     /// (convenience for `.wrapping_offset((count as isize).wrapping_neg())`)
     ///
@@ -999,6 +1110,24 @@ impl<T: ?Sized> *const T {
         T: Sized,
     {
         self.wrapping_offset((count as isize).wrapping_neg())
+    }
+
+    /// Calculates the offset from a pointer in bytes using wrapping arithmetic.
+    /// (convenience for `.wrapping_offset((count as isize).wrapping_neg())`)
+    ///
+    /// `count` is in units of bytes.
+    ///
+    /// This is purely a convenience for casting to a `u8` pointer and
+    /// using [wrapping_sub][pointer::wrapping_sub] on it. See that method for documentation.
+    #[must_use]
+    #[inline(always)]
+    #[unstable(feature = "pointer_byte_offsets", issue = "none")]
+    #[rustc_const_unstable(feature = "const_pointer_byte_offsets", issue = "none")]
+    pub const fn wrapping_byte_sub(self, count: usize) -> Self
+    where
+        T: Sized,
+    {
+        self.cast::<u8>().wrapping_sub(count).cast::<T>()
     }
 
     /// Reads the value from `self` without moving it. This leaves the
@@ -1154,11 +1283,41 @@ impl<T: ?Sized> *const T {
         }
 
         // SAFETY:
-        // It is permisseble for `align_offset` to always return `usize::MAX`,
+        // It is permissible for `align_offset` to always return `usize::MAX`,
         // algorithm correctness can not depend on `align_offset` returning non-max values.
         //
         // As such the behaviour can't change after replacing `align_offset` with `usize::MAX`, only performance can.
         unsafe { intrinsics::const_eval_select((self, align), ctfe_impl, rt_impl) }
+    }
+
+    /// Returns whether the pointer is properly aligned for `T`.
+    #[must_use]
+    #[inline]
+    #[unstable(feature = "pointer_is_aligned", issue = "none")]
+    pub fn is_aligned(self) -> bool
+    where
+        T: Sized,
+    {
+        self.addr() % core::mem::align_of::<T>() == 0
+    }
+
+    /// Returns whether the pointer is aligned to `align`.
+    ///
+    /// # Panics
+    ///
+    /// The function panics if `align` is not a power-of-two (this includes 0).
+    #[must_use]
+    #[inline]
+    #[unstable(feature = "pointer_is_aligned", issue = "none")]
+    pub fn is_aligned_to(self, align: usize) -> bool
+    where
+        T: Sized,
+    {
+        if !align.is_power_of_two() {
+            panic!("is_aligned_to: align is not a power-of-two");
+        }
+
+        self.addr() % align == 0
     }
 }
 

--- a/library/core/src/ptr/const_ptr.rs
+++ b/library/core/src/ptr/const_ptr.rs
@@ -1301,7 +1301,7 @@ impl<T: ?Sized> *const T {
     where
         T: Sized,
     {
-        self.addr() % core::mem::align_of::<T>() == 0
+        self.is_aligned_to(core::mem::align_of::<T>())
     }
 
     /// Returns whether the pointer is aligned to `align`.

--- a/library/core/src/ptr/mut_ptr.rs
+++ b/library/core/src/ptr/mut_ptr.rs
@@ -1589,6 +1589,9 @@ impl<T: ?Sized> *mut T {
             panic!("is_aligned_to: align is not a power-of-two");
         }
 
+        // SAFETY: `is_power_of_two()` will return `false` for zero.
+        unsafe { core::intrinsics::assume(align != 0) };
+
         // Cast is needed for `T: !Sized`
         self.cast::<u8>().addr() % align == 0
     }

--- a/library/core/src/ptr/mut_ptr.rs
+++ b/library/core/src/ptr/mut_ptr.rs
@@ -479,8 +479,8 @@ impl<T: ?Sized> *mut T {
     /// leaving the metadata untouched.
     #[must_use]
     #[inline(always)]
-    #[unstable(feature = "pointer_byte_offsets", issue = "none")]
-    #[rustc_const_unstable(feature = "const_pointer_byte_offsets", issue = "none")]
+    #[unstable(feature = "pointer_byte_offsets", issue = "96283")]
+    #[rustc_const_unstable(feature = "const_pointer_byte_offsets", issue = "96283")]
     pub const unsafe fn byte_offset(self, count: isize) -> Self {
         // SAFETY: the caller must uphold the safety contract for `offset`.
         let this = unsafe { self.cast::<u8>().offset(count).cast::<()>() };
@@ -560,8 +560,8 @@ impl<T: ?Sized> *mut T {
     /// leaving the metadata untouched.
     #[must_use]
     #[inline(always)]
-    #[unstable(feature = "pointer_byte_offsets", issue = "none")]
-    #[rustc_const_unstable(feature = "const_pointer_byte_offsets", issue = "none")]
+    #[unstable(feature = "pointer_byte_offsets", issue = "96283")]
+    #[rustc_const_unstable(feature = "const_pointer_byte_offsets", issue = "96283")]
     pub const fn wrapping_byte_offset(self, count: isize) -> Self {
         from_raw_parts_mut::<T>(
             self.cast::<u8>().wrapping_offset(count).cast::<()>(),
@@ -838,8 +838,8 @@ impl<T: ?Sized> *mut T {
     /// For non-`Sized` pointees this operation considers only the data pointers,
     /// ignoring the metadata.
     #[inline(always)]
-    #[unstable(feature = "pointer_byte_offsets", issue = "none")]
-    #[rustc_const_unstable(feature = "const_pointer_byte_offsets", issue = "none")]
+    #[unstable(feature = "pointer_byte_offsets", issue = "96283")]
+    #[rustc_const_unstable(feature = "const_pointer_byte_offsets", issue = "96283")]
     pub const unsafe fn byte_offset_from(self, origin: *const T) -> isize {
         // SAFETY: the caller must uphold the safety contract for `offset_from`.
         unsafe { self.cast::<u8>().offset_from(origin.cast::<u8>()) }
@@ -992,8 +992,8 @@ impl<T: ?Sized> *mut T {
     /// leaving the metadata untouched.
     #[must_use]
     #[inline(always)]
-    #[unstable(feature = "pointer_byte_offsets", issue = "none")]
-    #[rustc_const_unstable(feature = "const_pointer_byte_offsets", issue = "none")]
+    #[unstable(feature = "pointer_byte_offsets", issue = "96283")]
+    #[rustc_const_unstable(feature = "const_pointer_byte_offsets", issue = "96283")]
     pub const unsafe fn byte_add(self, count: usize) -> Self {
         // SAFETY: the caller must uphold the safety contract for `add`.
         let this = unsafe { self.cast::<u8>().add(count).cast::<()>() };
@@ -1077,8 +1077,8 @@ impl<T: ?Sized> *mut T {
     /// leaving the metadata untouched.
     #[must_use]
     #[inline(always)]
-    #[unstable(feature = "pointer_byte_offsets", issue = "none")]
-    #[rustc_const_unstable(feature = "const_pointer_byte_offsets", issue = "none")]
+    #[unstable(feature = "pointer_byte_offsets", issue = "96283")]
+    #[rustc_const_unstable(feature = "const_pointer_byte_offsets", issue = "96283")]
     pub const unsafe fn byte_sub(self, count: usize) -> Self {
         // SAFETY: the caller must uphold the safety contract for `sub`.
         let this = unsafe { self.cast::<u8>().sub(count).cast::<()>() };
@@ -1159,8 +1159,8 @@ impl<T: ?Sized> *mut T {
     /// leaving the metadata untouched.
     #[must_use]
     #[inline(always)]
-    #[unstable(feature = "pointer_byte_offsets", issue = "none")]
-    #[rustc_const_unstable(feature = "const_pointer_byte_offsets", issue = "none")]
+    #[unstable(feature = "pointer_byte_offsets", issue = "96283")]
+    #[rustc_const_unstable(feature = "const_pointer_byte_offsets", issue = "96283")]
     pub const fn wrapping_byte_add(self, count: usize) -> Self {
         from_raw_parts_mut::<T>(self.cast::<u8>().wrapping_add(count).cast::<()>(), metadata(self))
     }
@@ -1239,8 +1239,8 @@ impl<T: ?Sized> *mut T {
     /// leaving the metadata untouched.
     #[must_use]
     #[inline(always)]
-    #[unstable(feature = "pointer_byte_offsets", issue = "none")]
-    #[rustc_const_unstable(feature = "const_pointer_byte_offsets", issue = "none")]
+    #[unstable(feature = "pointer_byte_offsets", issue = "96283")]
+    #[rustc_const_unstable(feature = "const_pointer_byte_offsets", issue = "96283")]
     pub const fn wrapping_byte_sub(self, count: usize) -> Self {
         from_raw_parts_mut::<T>(self.cast::<u8>().wrapping_sub(count).cast::<()>(), metadata(self))
     }
@@ -1565,7 +1565,7 @@ impl<T: ?Sized> *mut T {
     /// Returns whether the pointer is properly aligned for `T`.
     #[must_use]
     #[inline]
-    #[unstable(feature = "pointer_is_aligned", issue = "none")]
+    #[unstable(feature = "pointer_is_aligned", issue = "96284")]
     pub fn is_aligned(self) -> bool
     where
         T: Sized,
@@ -1583,7 +1583,7 @@ impl<T: ?Sized> *mut T {
     /// The function panics if `align` is not a power-of-two (this includes 0).
     #[must_use]
     #[inline]
-    #[unstable(feature = "pointer_is_aligned", issue = "none")]
+    #[unstable(feature = "pointer_is_aligned", issue = "96284")]
     pub fn is_aligned_to(self, align: usize) -> bool {
         if !align.is_power_of_two() {
             panic!("is_aligned_to: align is not a power-of-two");

--- a/library/core/src/ptr/mut_ptr.rs
+++ b/library/core/src/ptr/mut_ptr.rs
@@ -467,6 +467,25 @@ impl<T: ?Sized> *mut T {
         unsafe { intrinsics::offset(self, count) as *mut T }
     }
 
+    /// Calculates the offset from a pointer in bytes.
+    ///
+    /// `count` is in units of **bytes**.
+    ///
+    /// This is purely a convenience for casting to a `u8` pointer and
+    /// using [offset][pointer::offset] on it. See that method for documentation
+    /// and safety requirements.
+    #[must_use]
+    #[inline(always)]
+    #[unstable(feature = "pointer_byte_offsets", issue = "none")]
+    #[rustc_const_unstable(feature = "const_pointer_byte_offsets", issue = "none")]
+    pub const unsafe fn byte_offset(self, count: isize) -> Self
+    where
+        T: Sized,
+    {
+        // SAFETY: the caller must uphold the safety contract for `offset`.
+        unsafe { self.cast::<u8>().offset(count).cast::<T>() }
+    }
+
     /// Calculates the offset from a pointer using wrapping arithmetic.
     /// `count` is in units of T; e.g., a `count` of 3 represents a pointer
     /// offset of `3 * size_of::<T>()` bytes.
@@ -526,6 +545,24 @@ impl<T: ?Sized> *mut T {
     {
         // SAFETY: the `arith_offset` intrinsic has no prerequisites to be called.
         unsafe { intrinsics::arith_offset(self, count) as *mut T }
+    }
+
+    /// Calculates the offset from a pointer in bytes using wrapping arithmetic.
+    ///
+    /// `count` is in units of **bytes**.
+    ///
+    /// This is purely a convenience for casting to a `u8` pointer and
+    /// using [wrapping_offset][pointer::wrapping_offset] on it. See that method
+    /// for documentation.
+    #[must_use]
+    #[inline(always)]
+    #[unstable(feature = "pointer_byte_offsets", issue = "none")]
+    #[rustc_const_unstable(feature = "const_pointer_byte_offsets", issue = "none")]
+    pub const fn wrapping_byte_offset(self, count: isize) -> Self
+    where
+        T: Sized,
+    {
+        self.cast::<u8>().wrapping_offset(count).cast::<T>()
     }
 
     /// Returns `None` if the pointer is null, or else returns a unique reference to
@@ -787,6 +824,23 @@ impl<T: ?Sized> *mut T {
         unsafe { (self as *const T).offset_from(origin) }
     }
 
+    /// Calculates the distance between two pointers. The returned value is in
+    /// units of **bytes**.
+    ///
+    /// This is purely a convenience for casting to a `u8` pointer and
+    /// using [offset_from][pointer::offset_from] on it. See that method for
+    /// documentation and safety requirements.
+    #[inline(always)]
+    #[unstable(feature = "pointer_byte_offsets", issue = "none")]
+    #[rustc_const_unstable(feature = "const_pointer_byte_offsets", issue = "none")]
+    pub const unsafe fn byte_offset_from(self, origin: *const T) -> isize
+    where
+        T: Sized,
+    {
+        // SAFETY: the caller must uphold the safety contract for `offset_from`.
+        unsafe { self.cast::<u8>().offset_from(origin.cast::<u8>()) }
+    }
+
     /// Calculates the distance between two pointers, *where it's known that
     /// `self` is equal to or greater than `origin`*. The returned value is in
     /// units of T: the distance in bytes is divided by `mem::size_of::<T>()`.
@@ -922,6 +976,25 @@ impl<T: ?Sized> *mut T {
         unsafe { self.offset(count as isize) }
     }
 
+    /// Calculates the offset from a pointer in bytes (convenience for `.byte_offset(count as isize)`).
+    ///
+    /// `count` is in units of bytes.
+    ///
+    /// This is purely a convenience for casting to a `u8` pointer and
+    /// using [add][pointer::add] on it. See that method for documentation
+    /// and safety requirements.
+    #[must_use]
+    #[inline(always)]
+    #[unstable(feature = "pointer_byte_offsets", issue = "none")]
+    #[rustc_const_unstable(feature = "const_pointer_byte_offsets", issue = "none")]
+    pub const unsafe fn byte_add(self, count: usize) -> Self
+    where
+        T: Sized,
+    {
+        // SAFETY: the caller must uphold the safety contract for `add`.
+        unsafe { self.cast::<u8>().add(count).cast::<T>() }
+    }
+
     /// Calculates the offset from a pointer (convenience for
     /// `.offset((count as isize).wrapping_neg())`).
     ///
@@ -986,6 +1059,26 @@ impl<T: ?Sized> *mut T {
         unsafe { self.offset((count as isize).wrapping_neg()) }
     }
 
+    /// Calculates the offset from a pointer in bytes (convenience for
+    /// `.byte_offset((count as isize).wrapping_neg())`).
+    ///
+    /// `count` is in units of bytes.
+    ///
+    /// This is purely a convenience for casting to a `u8` pointer and
+    /// using [sub][pointer::sub] on it. See that method for documentation
+    /// and safety requirements.
+    #[must_use]
+    #[inline(always)]
+    #[unstable(feature = "pointer_byte_offsets", issue = "none")]
+    #[rustc_const_unstable(feature = "const_pointer_byte_offsets", issue = "none")]
+    pub const unsafe fn byte_sub(self, count: usize) -> Self
+    where
+        T: Sized,
+    {
+        // SAFETY: the caller must uphold the safety contract for `sub`.
+        unsafe { self.cast::<u8>().sub(count).cast::<T>() }
+    }
+
     /// Calculates the offset from a pointer using wrapping arithmetic.
     /// (convenience for `.wrapping_offset(count as isize)`)
     ///
@@ -1048,6 +1141,24 @@ impl<T: ?Sized> *mut T {
         self.wrapping_offset(count as isize)
     }
 
+    /// Calculates the offset from a pointer in bytes using wrapping arithmetic.
+    /// (convenience for `.wrapping_byte_offset(count as isize)`)
+    ///
+    /// `count` is in units of bytes.
+    ///
+    /// This is purely a convenience for casting to a `u8` pointer and
+    /// using [wrapping_add][pointer::wrapping_add] on it. See that method for documentation.
+    #[must_use]
+    #[inline(always)]
+    #[unstable(feature = "pointer_byte_offsets", issue = "none")]
+    #[rustc_const_unstable(feature = "const_pointer_byte_offsets", issue = "none")]
+    pub const fn wrapping_byte_add(self, count: usize) -> Self
+    where
+        T: Sized,
+    {
+        self.cast::<u8>().wrapping_add(count).cast::<T>()
+    }
+
     /// Calculates the offset from a pointer using wrapping arithmetic.
     /// (convenience for `.wrapping_offset((count as isize).wrapping_neg())`)
     ///
@@ -1108,6 +1219,24 @@ impl<T: ?Sized> *mut T {
         T: Sized,
     {
         self.wrapping_offset((count as isize).wrapping_neg())
+    }
+
+    /// Calculates the offset from a pointer in bytes using wrapping arithmetic.
+    /// (convenience for `.wrapping_offset((count as isize).wrapping_neg())`)
+    ///
+    /// `count` is in units of bytes.
+    ///
+    /// This is purely a convenience for casting to a `u8` pointer and
+    /// using [wrapping_sub][pointer::wrapping_sub] on it. See that method for documentation.
+    #[must_use]
+    #[inline(always)]
+    #[unstable(feature = "pointer_byte_offsets", issue = "none")]
+    #[rustc_const_unstable(feature = "const_pointer_byte_offsets", issue = "none")]
+    pub const fn wrapping_byte_sub(self, count: usize) -> Self
+    where
+        T: Sized,
+    {
+        self.cast::<u8>().wrapping_sub(count).cast::<T>()
     }
 
     /// Reads the value from `self` without moving it. This leaves the
@@ -1420,11 +1549,41 @@ impl<T: ?Sized> *mut T {
         }
 
         // SAFETY:
-        // It is permisseble for `align_offset` to always return `usize::MAX`,
+        // It is permissible for `align_offset` to always return `usize::MAX`,
         // algorithm correctness can not depend on `align_offset` returning non-max values.
         //
         // As such the behaviour can't change after replacing `align_offset` with `usize::MAX`, only performance can.
         unsafe { intrinsics::const_eval_select((self, align), ctfe_impl, rt_impl) }
+    }
+
+    /// Returns whether the pointer is properly aligned for `T`.
+    #[must_use]
+    #[inline]
+    #[unstable(feature = "pointer_is_aligned", issue = "none")]
+    pub fn is_aligned(self) -> bool
+    where
+        T: Sized,
+    {
+        self.addr() % core::mem::align_of::<T>() == 0
+    }
+
+    /// Returns whether the pointer is aligned to `align`.
+    ///
+    /// # Panics
+    ///
+    /// The function panics if `align` is not a power-of-two (this includes 0).
+    #[must_use]
+    #[inline]
+    #[unstable(feature = "pointer_is_aligned", issue = "none")]
+    pub fn is_aligned_to(self, align: usize) -> bool
+    where
+        T: Sized,
+    {
+        if !align.is_power_of_two() {
+            panic!("is_aligned_to: align is not a power-of-two");
+        }
+
+        self.addr() % align == 0
     }
 }
 

--- a/library/core/src/ptr/mut_ptr.rs
+++ b/library/core/src/ptr/mut_ptr.rs
@@ -474,16 +474,17 @@ impl<T: ?Sized> *mut T {
     /// This is purely a convenience for casting to a `u8` pointer and
     /// using [offset][pointer::offset] on it. See that method for documentation
     /// and safety requirements.
+    ///
+    /// For non-`Sized` pointees this operation changes only the data pointer,
+    /// leaving the metadata untouched.
     #[must_use]
     #[inline(always)]
     #[unstable(feature = "pointer_byte_offsets", issue = "none")]
     #[rustc_const_unstable(feature = "const_pointer_byte_offsets", issue = "none")]
-    pub const unsafe fn byte_offset(self, count: isize) -> Self
-    where
-        T: Sized,
-    {
+    pub const unsafe fn byte_offset(self, count: isize) -> Self {
         // SAFETY: the caller must uphold the safety contract for `offset`.
-        unsafe { self.cast::<u8>().offset(count).cast::<T>() }
+        let this = unsafe { self.cast::<u8>().offset(count).cast::<()>() };
+        from_raw_parts_mut::<T>(this, metadata(self))
     }
 
     /// Calculates the offset from a pointer using wrapping arithmetic.
@@ -554,15 +555,18 @@ impl<T: ?Sized> *mut T {
     /// This is purely a convenience for casting to a `u8` pointer and
     /// using [wrapping_offset][pointer::wrapping_offset] on it. See that method
     /// for documentation.
+    ///
+    /// For non-`Sized` pointees this operation changes only the data pointer,
+    /// leaving the metadata untouched.
     #[must_use]
     #[inline(always)]
     #[unstable(feature = "pointer_byte_offsets", issue = "none")]
     #[rustc_const_unstable(feature = "const_pointer_byte_offsets", issue = "none")]
-    pub const fn wrapping_byte_offset(self, count: isize) -> Self
-    where
-        T: Sized,
-    {
-        self.cast::<u8>().wrapping_offset(count).cast::<T>()
+    pub const fn wrapping_byte_offset(self, count: isize) -> Self {
+        from_raw_parts_mut::<T>(
+            self.cast::<u8>().wrapping_offset(count).cast::<()>(),
+            metadata(self),
+        )
     }
 
     /// Returns `None` if the pointer is null, or else returns a unique reference to
@@ -830,13 +834,13 @@ impl<T: ?Sized> *mut T {
     /// This is purely a convenience for casting to a `u8` pointer and
     /// using [offset_from][pointer::offset_from] on it. See that method for
     /// documentation and safety requirements.
+    ///
+    /// For non-`Sized` pointees this operation considers only the data pointers,
+    /// ignoring the metadata.
     #[inline(always)]
     #[unstable(feature = "pointer_byte_offsets", issue = "none")]
     #[rustc_const_unstable(feature = "const_pointer_byte_offsets", issue = "none")]
-    pub const unsafe fn byte_offset_from(self, origin: *const T) -> isize
-    where
-        T: Sized,
-    {
+    pub const unsafe fn byte_offset_from(self, origin: *const T) -> isize {
         // SAFETY: the caller must uphold the safety contract for `offset_from`.
         unsafe { self.cast::<u8>().offset_from(origin.cast::<u8>()) }
     }
@@ -983,16 +987,17 @@ impl<T: ?Sized> *mut T {
     /// This is purely a convenience for casting to a `u8` pointer and
     /// using [add][pointer::add] on it. See that method for documentation
     /// and safety requirements.
+    ///
+    /// For non-`Sized` pointees this operation changes only the data pointer,
+    /// leaving the metadata untouched.
     #[must_use]
     #[inline(always)]
     #[unstable(feature = "pointer_byte_offsets", issue = "none")]
     #[rustc_const_unstable(feature = "const_pointer_byte_offsets", issue = "none")]
-    pub const unsafe fn byte_add(self, count: usize) -> Self
-    where
-        T: Sized,
-    {
+    pub const unsafe fn byte_add(self, count: usize) -> Self {
         // SAFETY: the caller must uphold the safety contract for `add`.
-        unsafe { self.cast::<u8>().add(count).cast::<T>() }
+        let this = unsafe { self.cast::<u8>().add(count).cast::<()>() };
+        from_raw_parts_mut::<T>(this, metadata(self))
     }
 
     /// Calculates the offset from a pointer (convenience for
@@ -1067,16 +1072,17 @@ impl<T: ?Sized> *mut T {
     /// This is purely a convenience for casting to a `u8` pointer and
     /// using [sub][pointer::sub] on it. See that method for documentation
     /// and safety requirements.
+    ///
+    /// For non-`Sized` pointees this operation changes only the data pointer,
+    /// leaving the metadata untouched.
     #[must_use]
     #[inline(always)]
     #[unstable(feature = "pointer_byte_offsets", issue = "none")]
     #[rustc_const_unstable(feature = "const_pointer_byte_offsets", issue = "none")]
-    pub const unsafe fn byte_sub(self, count: usize) -> Self
-    where
-        T: Sized,
-    {
+    pub const unsafe fn byte_sub(self, count: usize) -> Self {
         // SAFETY: the caller must uphold the safety contract for `sub`.
-        unsafe { self.cast::<u8>().sub(count).cast::<T>() }
+        let this = unsafe { self.cast::<u8>().sub(count).cast::<()>() };
+        from_raw_parts_mut::<T>(this, metadata(self))
     }
 
     /// Calculates the offset from a pointer using wrapping arithmetic.
@@ -1148,15 +1154,15 @@ impl<T: ?Sized> *mut T {
     ///
     /// This is purely a convenience for casting to a `u8` pointer and
     /// using [wrapping_add][pointer::wrapping_add] on it. See that method for documentation.
+    ///
+    /// For non-`Sized` pointees this operation changes only the data pointer,
+    /// leaving the metadata untouched.
     #[must_use]
     #[inline(always)]
     #[unstable(feature = "pointer_byte_offsets", issue = "none")]
     #[rustc_const_unstable(feature = "const_pointer_byte_offsets", issue = "none")]
-    pub const fn wrapping_byte_add(self, count: usize) -> Self
-    where
-        T: Sized,
-    {
-        self.cast::<u8>().wrapping_add(count).cast::<T>()
+    pub const fn wrapping_byte_add(self, count: usize) -> Self {
+        from_raw_parts_mut::<T>(self.cast::<u8>().wrapping_add(count).cast::<()>(), metadata(self))
     }
 
     /// Calculates the offset from a pointer using wrapping arithmetic.
@@ -1228,15 +1234,15 @@ impl<T: ?Sized> *mut T {
     ///
     /// This is purely a convenience for casting to a `u8` pointer and
     /// using [wrapping_sub][pointer::wrapping_sub] on it. See that method for documentation.
+    ///
+    /// For non-`Sized` pointees this operation changes only the data pointer,
+    /// leaving the metadata untouched.
     #[must_use]
     #[inline(always)]
     #[unstable(feature = "pointer_byte_offsets", issue = "none")]
     #[rustc_const_unstable(feature = "const_pointer_byte_offsets", issue = "none")]
-    pub const fn wrapping_byte_sub(self, count: usize) -> Self
-    where
-        T: Sized,
-    {
-        self.cast::<u8>().wrapping_sub(count).cast::<T>()
+    pub const fn wrapping_byte_sub(self, count: usize) -> Self {
+        from_raw_parts_mut::<T>(self.cast::<u8>().wrapping_sub(count).cast::<()>(), metadata(self))
     }
 
     /// Reads the value from `self` without moving it. This leaves the
@@ -1569,21 +1575,22 @@ impl<T: ?Sized> *mut T {
 
     /// Returns whether the pointer is aligned to `align`.
     ///
+    /// For non-`Sized` pointees this operation considers only the data pointer,
+    /// ignoring the metadata.
+    ///
     /// # Panics
     ///
     /// The function panics if `align` is not a power-of-two (this includes 0).
     #[must_use]
     #[inline]
     #[unstable(feature = "pointer_is_aligned", issue = "none")]
-    pub fn is_aligned_to(self, align: usize) -> bool
-    where
-        T: Sized,
-    {
+    pub fn is_aligned_to(self, align: usize) -> bool {
         if !align.is_power_of_two() {
             panic!("is_aligned_to: align is not a power-of-two");
         }
 
-        self.addr() % align == 0
+        // Cast is needed for `T: !Sized`
+        self.cast::<u8>().addr() % align == 0
     }
 }
 

--- a/library/core/src/ptr/mut_ptr.rs
+++ b/library/core/src/ptr/mut_ptr.rs
@@ -1570,7 +1570,7 @@ impl<T: ?Sized> *mut T {
     where
         T: Sized,
     {
-        self.addr() % core::mem::align_of::<T>() == 0
+        self.is_aligned_to(core::mem::align_of::<T>())
     }
 
     /// Returns whether the pointer is aligned to `align`.


### PR DESCRIPTION
This PR adds the following APIs:
```rust
impl *const T {
    // feature gates `pointer_byte_offsets` and `const_pointer_byte_offsets
    pub const unsafe fn byte_offset(self, count: isize) -> Self;
    pub const fn wrapping_byte_offset(self, count: isize) -> Self;
    pub const unsafe fn byte_offset_from(self, origin: *const T) -> isize;
    pub const unsafe fn byte_add(self, count: usize) -> Self;
    pub const unsafe fn byte_sub(self, count: usize) -> Self;
    pub const fn wrapping_byte_add(self, count: usize) -> Self;
    pub const fn wrapping_byte_sub(self, count: usize) -> Self;

    // feature gate `pointer_is_aligned`
    pub fn is_aligned(self) -> bool where T: Sized;
    pub fn is_aligned_to(self, align: usize) -> bool;
}
// ... and the same for` *mut T`
```

Note that all functions except `is_aligned` do **not** require `T: Sized` as their pointee-sized-offset counterparts.

cc @oli-obk (you may want to check that I've correctly placed `const`s)
cc @RalfJung 