### PR TITLE
AddNicheCases MirPass

### DIFF
--- a/compiler/rustc_borrowck/src/invalidation.rs
+++ b/compiler/rustc_borrowck/src/invalidation.rs
@@ -291,10 +291,10 @@ impl<'cx, 'tcx> InvalidationGenerator<'cx, 'tcx> {
                 self.consume_operand(location, operand)
             }
 
-            Rvalue::Len(place) | Rvalue::Discriminant(place) => {
+            Rvalue::Len(place) | Rvalue::Discriminant { place, .. } => {
                 let af = match *rvalue {
                     Rvalue::Len(..) => Some(ArtificialField::ArrayLength),
-                    Rvalue::Discriminant(..) => None,
+                    Rvalue::Discriminant { .. } => None,
                     _ => unreachable!(),
                 };
                 self.access_place(

--- a/compiler/rustc_borrowck/src/lib.rs
+++ b/compiler/rustc_borrowck/src/lib.rs
@@ -1280,10 +1280,10 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
                 self.consume_operand(location, (operand, span), flow_state)
             }
 
-            Rvalue::Len(place) | Rvalue::Discriminant(place) => {
+            Rvalue::Len(place) | Rvalue::Discriminant { place, .. } => {
                 let af = match *rvalue {
                     Rvalue::Len(..) => Some(ArtificialField::ArrayLength),
-                    Rvalue::Discriminant(..) => None,
+                    Rvalue::Discriminant { .. } => None,
                     _ => unreachable!(),
                 };
                 self.access_place(

--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -2260,7 +2260,7 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
             Rvalue::AddressOf(..)
             | Rvalue::ThreadLocalRef(..)
             | Rvalue::Len(..)
-            | Rvalue::Discriminant(..) => {}
+            | Rvalue::Discriminant { .. } => {}
         }
     }
 
@@ -2281,7 +2281,7 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
             | Rvalue::CheckedBinaryOp(..)
             | Rvalue::NullaryOp(..)
             | Rvalue::UnaryOp(..)
-            | Rvalue::Discriminant(..) => None,
+            | Rvalue::Discriminant { .. } => None,
 
             Rvalue::Aggregate(aggregate, _) => match **aggregate {
                 AggregateKind::Adt(_, _, _, user_ty, _) => user_ty,

--- a/compiler/rustc_codegen_cranelift/src/base.rs
+++ b/compiler/rustc_codegen_cranelift/src/base.rs
@@ -634,6 +634,7 @@ fn codegen_stmt<'tcx>(
                             fx,
                             operand,
                             fx.layout_of(operand.layout().ty.discriminant_ty(fx.tcx)),
+                            false,
                         )
                         .load_scalar(fx);
 
@@ -684,11 +685,15 @@ fn codegen_stmt<'tcx>(
                     let operand = codegen_operand(fx, operand);
                     operand.unsize_value(fx, lval);
                 }
-                Rvalue::Discriminant(place) => {
+                Rvalue::Discriminant { place, relative } => {
                     let place = codegen_place(fx, place);
                     let value = place.to_cvalue(fx);
-                    let discr =
-                        crate::discriminant::codegen_get_discriminant(fx, value, dest_layout);
+                    let discr = crate::discriminant::codegen_get_discriminant(
+                        fx,
+                        value,
+                        dest_layout,
+                        relative,
+                    );
                     lval.write_cvalue(fx, discr);
                 }
                 Rvalue::Repeat(ref operand, times) => {

--- a/compiler/rustc_codegen_ssa/src/mir/intrinsic.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/intrinsic.rs
@@ -359,7 +359,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
 
             sym::discriminant_value => {
                 if ret_ty.is_integral() {
-                    args[0].deref(bx.cx()).codegen_get_discr(bx, ret_ty)
+                    args[0].deref(bx.cx()).codegen_get_discr(bx, ret_ty, false)
                 } else {
                     span_bug!(span, "Invalid discriminant type for `{:?}`", arg_tys[0])
                 }

--- a/compiler/rustc_codegen_ssa/src/mir/place.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/place.rs
@@ -204,10 +204,14 @@ impl<'a, 'tcx, V: CodegenObject> PlaceRef<'tcx, V> {
     }
 
     /// Obtain the actual discriminant of a value.
+    ///
+    /// If `relative` is true, instead calculate the *relative* discriminant (see
+    /// `RValue::Discriminant`).
     pub fn codegen_get_discr<Bx: BuilderMethods<'a, 'tcx, Value = V>>(
         self,
         bx: &mut Bx,
         cast_to: Ty<'tcx>,
+        relative: bool,
     ) -> V {
         let cast_to = bx.cx().immediate_backend_type(bx.cx().layout_of(cast_to));
         if self.layout.abi.is_uninhabited() {
@@ -266,44 +270,49 @@ impl<'a, 'tcx, V: CodegenObject> PlaceRef<'tcx, V> {
                 } else {
                     bx.sub(tag, bx.cx().const_uint_big(niche_llty, niche_start))
                 };
-                let relative_max = niche_variants.end().as_u32() - niche_variants.start().as_u32();
-                let is_niche = if relative_max == 0 {
-                    // Avoid calling `const_uint`, which wouldn't work for pointers.
-                    // Also use canonical == 0 instead of non-canonical u<= 0.
-                    // FIXME(eddyb) check the actual primitive type here.
-                    bx.icmp(IntPredicate::IntEQ, relative_discr, bx.cx().const_null(niche_llty))
+                let relative_max = niche_variants.size_hint().1.unwrap() - 1;
+
+                if relative {
+                    bx.intcast(relative_discr, cast_to, false)
                 } else {
-                    let relative_max = bx.cx().const_uint(niche_llty, relative_max as u64);
-                    bx.icmp(IntPredicate::IntULE, relative_discr, relative_max)
-                };
-
-                // NOTE(eddyb) this addition needs to be performed on the final
-                // type, in case the niche itself can't represent all variant
-                // indices (e.g. `u8` niche with more than `256` variants,
-                // but enough uninhabited variants so that the remaining variants
-                // fit in the niche).
-                // In other words, `niche_variants.end - niche_variants.start`
-                // is representable in the niche, but `niche_variants.end`
-                // might not be, in extreme cases.
-                let niche_discr = {
-                    let relative_discr = if relative_max == 0 {
-                        // HACK(eddyb) since we have only one niche, we know which
-                        // one it is, and we can avoid having a dynamic value here.
-                        bx.cx().const_uint(cast_to, 0)
-                    } else {
-                        bx.intcast(relative_discr, cast_to, false)
+                    // NOTE(eddyb) this addition needs to be performed on the final
+                    // type, in case the niche itself can't represent all variant
+                    // indices (e.g. `u8` niche with more than `256` variants,
+                    // but enough uninhabited variants so that the remaining variants
+                    // fit in the niche).
+                    // In other words, `niche_variants.end - niche_variants.start`
+                    // is representable in the niche, but `niche_variants.end`
+                    // might not be, in extreme cases.
+                    let niche_discr = {
+                        let relative_discr = if relative_max == 0 {
+                            // HACK(eddyb) since we have only one niche, we know which
+                            // one it is, and we can avoid having a dynamic value here.
+                            bx.cx().const_uint(cast_to, 0)
+                        } else {
+                            bx.intcast(relative_discr, cast_to, false)
+                        };
+                        bx.add(
+                            relative_discr,
+                            bx.cx().const_uint(cast_to, niche_variants.start().as_u32() as u64),
+                        )
                     };
-                    bx.add(
-                        relative_discr,
-                        bx.cx().const_uint(cast_to, niche_variants.start().as_u32() as u64),
-                    )
-                };
 
-                bx.select(
-                    is_niche,
-                    niche_discr,
-                    bx.cx().const_uint(cast_to, dataful_variant.as_u32() as u64),
-                )
+                    let is_niche = if relative_max == 0 {
+                        // Avoid calling `const_uint`, which wouldn't work for pointers.
+                        // Also use canonical == 0 instead of non-canonical u<= 0.
+                        // FIXME(eddyb) check the actual primitive type here.
+                        bx.icmp(IntPredicate::IntEQ, relative_discr, bx.cx().const_null(niche_llty))
+                    } else {
+                        let relative_max = bx.cx().const_uint(niche_llty, relative_max as u64);
+                        bx.icmp(IntPredicate::IntULE, relative_discr, relative_max)
+                    };
+
+                    bx.select(
+                        is_niche,
+                        niche_discr,
+                        bx.cx().const_uint(cast_to, dataful_variant.as_u32() as u64),
+                    )
+                }
             }
         }
     }

--- a/compiler/rustc_codegen_ssa/src/mir/rvalue.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/rvalue.rs
@@ -469,12 +469,12 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                 (bx, OperandRef { val: OperandValue::Immediate(llval), layout: operand.layout })
             }
 
-            mir::Rvalue::Discriminant(ref place) => {
+            mir::Rvalue::Discriminant { ref place, relative } => {
                 let discr_ty = rvalue.ty(self.mir, bx.tcx());
                 let discr_ty = self.monomorphize(discr_ty);
                 let discr = self
                     .codegen_place(&mut bx, place.as_ref())
-                    .codegen_get_discr(&mut bx, discr_ty);
+                    .codegen_get_discr(&mut bx, discr_ty, relative);
                 (
                     bx,
                     OperandRef {
@@ -751,7 +751,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
             mir::Rvalue::BinaryOp(..) |
             mir::Rvalue::CheckedBinaryOp(..) |
             mir::Rvalue::UnaryOp(..) |
-            mir::Rvalue::Discriminant(..) |
+            mir::Rvalue::Discriminant { .. } |
             mir::Rvalue::NullaryOp(..) |
             mir::Rvalue::ThreadLocalRef(_) |
             mir::Rvalue::Use(..) => // (*)

--- a/compiler/rustc_const_eval/src/const_eval/mod.rs
+++ b/compiler/rustc_const_eval/src/const_eval/mod.rs
@@ -109,7 +109,7 @@ fn const_to_valtree_inner<'tcx>(
                 bug!("uninhabited types should have errored and never gotten converted to valtree")
             }
 
-            let variant = ecx.read_discriminant(&place.into()).unwrap().1;
+            let variant = ecx.read_discriminant(&place.into(), false).unwrap().1;
 
             branches(def.variant(variant).fields.len(), def.is_enum().then_some(variant))
         }
@@ -152,7 +152,7 @@ pub(crate) fn try_destructure_const<'tcx>(
         // index).
         ty::Adt(def, _) if def.variants().is_empty() => throw_ub!(Unreachable),
         ty::Adt(def, _) => {
-            let variant = ecx.read_discriminant(&op)?.1;
+            let variant = ecx.read_discriminant(&op, false)?.1;
             let down = ecx.operand_downcast(&op, variant)?;
             (def.variant(variant).fields.len(), Some(variant), down)
         }

--- a/compiler/rustc_const_eval/src/interpret/intrinsics.rs
+++ b/compiler/rustc_const_eval/src/interpret/intrinsics.rs
@@ -230,7 +230,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
             }
             sym::discriminant_value => {
                 let place = self.deref_operand(&args[0])?;
-                let discr_val = self.read_discriminant(&place.into())?.0;
+                let discr_val = self.read_discriminant(&place.into(), false)?.0;
                 self.write_scalar(discr_val, dest)?;
             }
             sym::unchecked_shl

--- a/compiler/rustc_const_eval/src/interpret/step.rs
+++ b/compiler/rustc_const_eval/src/interpret/step.rs
@@ -297,9 +297,9 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 self.cast(&src, cast_kind, cast_ty, &dest)?;
             }
 
-            Discriminant(place) => {
+            Discriminant { place, relative } => {
                 let op = self.eval_place_to_op(place, None)?;
-                let discr_val = self.read_discriminant(&op)?.0;
+                let discr_val = self.read_discriminant(&op, relative)?.0;
                 self.write_scalar(discr_val, &dest)?;
             }
         }

--- a/compiler/rustc_const_eval/src/interpret/validity.rs
+++ b/compiler/rustc_const_eval/src/interpret/validity.rs
@@ -704,7 +704,7 @@ impl<'rt, 'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> ValueVisitor<'mir, 'tcx, M>
     ) -> InterpResult<'tcx, VariantIdx> {
         self.with_elem(PathElem::EnumTag, move |this| {
             Ok(try_validation!(
-                this.ecx.read_discriminant(op),
+                this.ecx.read_discriminant(op, /*relative*/false),
                 this.path,
                 err_ub!(InvalidTag(val)) =>
                     { "{:x}", val } expected { "a valid enum tag" },

--- a/compiler/rustc_const_eval/src/interpret/visitor.rs
+++ b/compiler/rustc_const_eval/src/interpret/visitor.rs
@@ -135,7 +135,7 @@ macro_rules! make_value_visitor {
                 &mut self,
                 op: &OpTy<'tcx, M::PointerTag>,
             ) -> InterpResult<'tcx, VariantIdx> {
-                Ok(self.ecx().read_discriminant(op)?.1)
+                Ok(self.ecx().read_discriminant(op, /*relative*/ false)?.1)
             }
 
             // Recursive actions, ready to be overloaded.

--- a/compiler/rustc_const_eval/src/transform/check_consts/check.rs
+++ b/compiler/rustc_const_eval/src/transform/check_consts/check.rs
@@ -463,7 +463,7 @@ impl<'tcx> Visitor<'tcx> for Checker<'_, 'tcx> {
 
             Rvalue::Use(_)
             | Rvalue::Repeat(..)
-            | Rvalue::Discriminant(..)
+            | Rvalue::Discriminant { .. }
             | Rvalue::Len(_)
             | Rvalue::Aggregate(..) => {}
 

--- a/compiler/rustc_const_eval/src/transform/check_consts/qualifs.rs
+++ b/compiler/rustc_const_eval/src/transform/check_consts/qualifs.rs
@@ -256,7 +256,7 @@ where
             Q::in_any_value_of_ty(cx, rvalue.ty(cx.body, cx.tcx))
         }
 
-        Rvalue::Discriminant(place) | Rvalue::Len(place) => {
+        Rvalue::Discriminant { place, .. } | Rvalue::Len(place) => {
             in_place::<Q, _>(cx, in_local, place.as_ref())
         }
 

--- a/compiler/rustc_const_eval/src/transform/check_consts/resolver.rs
+++ b/compiler/rustc_const_eval/src/transform/check_consts/resolver.rs
@@ -206,7 +206,7 @@ where
             | mir::Rvalue::CheckedBinaryOp(..)
             | mir::Rvalue::NullaryOp(..)
             | mir::Rvalue::UnaryOp(..)
-            | mir::Rvalue::Discriminant(..)
+            | mir::Rvalue::Discriminant { .. }
             | mir::Rvalue::Aggregate(..) => {}
         }
     }

--- a/compiler/rustc_const_eval/src/transform/promote_consts.rs
+++ b/compiler/rustc_const_eval/src/transform/promote_consts.rs
@@ -486,7 +486,7 @@ impl<'tcx> Validator<'_, 'tcx> {
                 self.validate_operand(operand)?;
             }
 
-            Rvalue::Discriminant(place) | Rvalue::Len(place) => {
+            Rvalue::Discriminant { place, .. } | Rvalue::Len(place) => {
                 self.validate_place(place.as_ref())?
             }
 

--- a/compiler/rustc_middle/src/mir/tcx.rs
+++ b/compiler/rustc_middle/src/mir/tcx.rs
@@ -194,7 +194,9 @@ impl<'tcx> Rvalue<'tcx> {
                 tcx.intern_tup(&[ty, tcx.types.bool])
             }
             Rvalue::UnaryOp(UnOp::Not | UnOp::Neg, ref operand) => operand.ty(local_decls, tcx),
-            Rvalue::Discriminant(ref place) => place.ty(local_decls, tcx).ty.discriminant_ty(tcx),
+            Rvalue::Discriminant { ref place, .. } => {
+                place.ty(local_decls, tcx).ty.discriminant_ty(tcx)
+            }
             Rvalue::NullaryOp(NullOp::SizeOf | NullOp::AlignOf, _) => tcx.types.usize,
             Rvalue::Aggregate(ref ak, ref ops) => match **ak {
                 AggregateKind::Array(ty) => tcx.mk_array(ty, ops.len() as u64),

--- a/compiler/rustc_middle/src/mir/type_foldable.rs
+++ b/compiler/rustc_middle/src/mir/type_foldable.rs
@@ -214,7 +214,9 @@ impl<'tcx> TypeFoldable<'tcx> for Rvalue<'tcx> {
                 Box::new((rhs.try_fold_with(folder)?, lhs.try_fold_with(folder)?)),
             ),
             UnaryOp(op, val) => UnaryOp(op, val.try_fold_with(folder)?),
-            Discriminant(place) => Discriminant(place.try_fold_with(folder)?),
+            Discriminant { place, relative } => {
+                Discriminant { place: place.try_fold_with(folder)?, relative }
+            }
             NullaryOp(op, ty) => NullaryOp(op, ty.try_fold_with(folder)?),
             Aggregate(kind, fields) => {
                 let kind = kind.try_map_id(|kind| {
@@ -265,7 +267,7 @@ impl<'tcx> TypeFoldable<'tcx> for Rvalue<'tcx> {
                 lhs.visit_with(visitor)
             }
             UnaryOp(_, ref val) => val.visit_with(visitor),
-            Discriminant(ref place) => place.visit_with(visitor),
+            Discriminant { ref place, .. } => place.visit_with(visitor),
             NullaryOp(_, ty) => ty.visit_with(visitor),
             Aggregate(ref kind, ref fields) => {
                 match **kind {

--- a/compiler/rustc_middle/src/mir/visit.rs
+++ b/compiler/rustc_middle/src/mir/visit.rs
@@ -698,7 +698,7 @@ macro_rules! make_mir_visitor {
                         self.visit_operand(op, location);
                     }
 
-                    Rvalue::Discriminant(place) => {
+                    Rvalue::Discriminant { place, .. } => {
                         self.visit_place(
                             place,
                             PlaceContext::NonMutatingUse(NonMutatingUseContext::Inspect),

--- a/compiler/rustc_mir_build/src/build/matches/test.rs
+++ b/compiler/rustc_mir_build/src/build/matches/test.rs
@@ -192,7 +192,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                             debug_assert_eq!(
                                 target_blocks[idx.index()],
                                 otherwise_block,
-                                "found canididates for untested discriminant: {:?}",
+                                "found candidates for untested discriminant: {:?}",
                                 discr,
                             );
                             None
@@ -207,7 +207,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     block,
                     self.source_info(scrutinee_span),
                     discr,
-                    Rvalue::Discriminant(place),
+                    Rvalue::Discriminant { place, relative: false },
                 );
                 self.cfg.terminate(
                     block,

--- a/compiler/rustc_mir_dataflow/src/elaborate_drops.rs
+++ b/compiler/rustc_mir_dataflow/src/elaborate_drops.rs
@@ -579,7 +579,7 @@ where
         // way lies only trouble.
         let discr_ty = adt.repr().discr_type().to_ty(self.tcx());
         let discr = Place::from(self.new_temp(discr_ty));
-        let discr_rv = Rvalue::Discriminant(self.place);
+        let discr_rv = Rvalue::Discriminant { place: self.place, relative: false };
         let switch_block = BasicBlockData {
             statements: vec![self.assign(discr, discr_rv)],
             terminator: Some(Terminator {

--- a/compiler/rustc_mir_dataflow/src/impls/borrowed_locals.rs
+++ b/compiler/rustc_mir_dataflow/src/impls/borrowed_locals.rs
@@ -107,7 +107,7 @@ where
             | mir::Rvalue::CheckedBinaryOp(..)
             | mir::Rvalue::NullaryOp(..)
             | mir::Rvalue::UnaryOp(..)
-            | mir::Rvalue::Discriminant(..)
+            | mir::Rvalue::Discriminant { .. }
             | mir::Rvalue::Aggregate(..) => {}
         }
     }

--- a/compiler/rustc_mir_dataflow/src/impls/mod.rs
+++ b/compiler/rustc_mir_dataflow/src/impls/mod.rs
@@ -708,9 +708,10 @@ fn switch_on_enum_discriminant<'mir, 'tcx>(
 ) -> Option<(mir::Place<'tcx>, ty::AdtDef<'tcx>)> {
     for statement in block.statements.iter().rev() {
         match &statement.kind {
-            mir::StatementKind::Assign(box (lhs, mir::Rvalue::Discriminant(discriminated)))
-                if *lhs == switch_on =>
-            {
+            mir::StatementKind::Assign(box (
+                lhs,
+                mir::Rvalue::Discriminant { place: discriminated, relative: false },
+            )) if *lhs == switch_on => {
                 match discriminated.ty(body, tcx).ty.kind() {
                     ty::Adt(def, _) => return Some((*discriminated, *def)),
 

--- a/compiler/rustc_mir_dataflow/src/move_paths/builder.rs
+++ b/compiler/rustc_mir_dataflow/src/move_paths/builder.rs
@@ -330,7 +330,7 @@ impl<'b, 'a, 'tcx> Gatherer<'b, 'a, 'tcx> {
             }
             Rvalue::Ref(..)
             | Rvalue::AddressOf(..)
-            | Rvalue::Discriminant(..)
+            | Rvalue::Discriminant { .. }
             | Rvalue::Len(..)
             | Rvalue::NullaryOp(NullOp::SizeOf | NullOp::AlignOf, _) => {}
         }

--- a/compiler/rustc_mir_transform/src/add_niche_cases.rs
+++ b/compiler/rustc_mir_transform/src/add_niche_cases.rs
@@ -1,0 +1,178 @@
+//! Turn a SwitchInt over a discriminant into a SwitchInt over a
+//! relative discriminant, adding extra cases for the potential values
+//! representing the dataful variant as needed.
+//!
+//! This lets us avoid some arithmetic and a select that would occur
+//! in the usual discriminant calculation.
+
+use crate::MirPass;
+use rustc_middle::mir::*;
+use rustc_middle::ty::TyCtxt;
+use rustc_target::abi::{TagEncoding, Variants};
+
+use std::iter;
+
+// This is arbitrary but seems to work well enough.
+const ALLOWED_EXTRA_BRANCHES: u128 = 20;
+
+pub struct AddNicheCases;
+
+impl<'tcx> MirPass<'tcx> for AddNicheCases {
+    fn is_enabled(&self, sess: &rustc_session::Session) -> bool {
+        sess.mir_opt_level() >= 1
+    }
+
+    fn run_pass(&self, tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
+        if body.generator.is_some() {
+            return;
+        }
+
+        let def_id = body.source.def_id();
+        let param_env = tcx.param_env(def_id);
+
+        let (bbs, local_decls) = body.basic_blocks_and_local_decls_mut();
+
+        for bb_idx in bbs.indices() {
+            let extract_from_switch_int = || {
+                if let TerminatorKind::SwitchInt {
+                    discr: Operand::Copy(ref d) | Operand::Move(ref d),
+                    ref targets,
+                    ..
+                } = bbs[bb_idx].terminator().kind
+                {
+                    if targets.iter().len() <= 1 {
+                        return None;
+                    }
+
+                    let otherwise_is_unreachable = {
+                        match bbs[targets.otherwise()].terminator().kind {
+                            TerminatorKind::Unreachable => true,
+                            _ => false,
+                        }
+                    };
+
+                    if targets.iter().len() == 2 && otherwise_is_unreachable {
+                        // This will be well optimized anyway.
+                        return None;
+                    }
+
+                    if bbs[bb_idx].statements.is_empty() {
+                        return None;
+                    }
+
+                    // If the last statement is assigning a discriminant,
+                    // this is what we're looking for.
+                    if let &StatementKind::Assign(box (ref place, ref rvalue)) =
+                        &bbs[bb_idx].statements.last().unwrap().kind
+                    {
+                        if *place == *d {
+                            if let Rvalue::Discriminant { place, relative: false } = rvalue {
+                                return Some((*d, *place, targets));
+                            }
+                        }
+                    }
+                }
+                None
+            };
+
+            let (d, enum_place, targets) = match extract_from_switch_int() {
+                Some(vals) => vals,
+                None => continue,
+            };
+
+            let enum_ty = enum_place.ty(local_decls, tcx).ty;
+            let d_ty = d.ty(local_decls, tcx).ty;
+            let enum_ty_and_layout = match tcx.layout_of(param_env.and(enum_ty)) {
+                Ok(ty_and_layout) => ty_and_layout,
+                _ => continue,
+            };
+
+            let (tag, tag_encoding) = match enum_ty_and_layout.layout.variants() {
+                Variants::Multiple { tag, ref tag_encoding, .. } => (tag, tag_encoding),
+
+                _ => continue,
+            };
+
+            let (dataful_variant, niche_start, niche_variants) = match tag_encoding {
+                TagEncoding::Niche { dataful_variant, niche_start, niche_variants, .. } => {
+                    (*dataful_variant, *niche_start, niche_variants)
+                }
+
+                _ => continue,
+            };
+
+            let niche_variants_count_m1 =
+                niche_variants.end().as_u32() - niche_variants.start().as_u32();
+
+            let niche_variants_count = niche_variants_count_m1 as u128 + 1;
+
+            let dataful_bb = {
+                let found = targets.iter().find(|(v, _)| *v == dataful_variant.as_u32() as u128);
+                if let Some((_, b)) = found {
+                    b
+                } else {
+                    // The dataful variant doesn't appear in the target blocks anyway.
+                    continue;
+                }
+            };
+
+            let valid_range = tag.valid_range;
+            let max_value = tag.value.size(&tcx).unsigned_int_max();
+            let valid_values_count_m1 = valid_range.end.wrapping_sub(valid_range.start);
+
+            let needed_extra_branches_m1 = valid_values_count_m1
+                .checked_sub(niche_variants_count)
+                .expect("Can't have fewer variants than valid values in a niche");
+            if needed_extra_branches_m1 > ALLOWED_EXTRA_BRANCHES - 1 {
+                continue;
+            }
+
+            let first = if niche_start == valid_range.start {
+                // valid and non-variant values come at the end
+                niche_variants.end().as_u32() as u128 + 1
+            } else {
+                // valid and non-variant values come at the beginning
+                let last = (niche_variants.start().as_u32() as u128).wrapping_sub(1);
+                last.wrapping_sub(needed_extra_branches_m1)
+            };
+
+            let needed_extra_branches = needed_extra_branches_m1 as usize + 1;
+            let new_values = iter::successors(Some(first), |v| Some(v.wrapping_add(1)))
+                .map(|v| v & max_value)
+                .take(needed_extra_branches);
+            let new_targets = iter::repeat(dataful_bb);
+            let new_values_targets = new_values.zip(new_targets);
+
+            let old_iter = targets.iter().filter(|(v, _)| *v != dataful_variant.as_u32() as u128);
+            let all_values_targets = new_values_targets.chain(old_iter).map(|(v, t)| {
+                (v.wrapping_sub(niche_variants.start().as_u32() as u128) & max_value, t)
+            });
+            let otherwise = targets.otherwise();
+
+            let new_targets = SwitchTargets::new(all_values_targets, otherwise);
+            let source_info = bbs[bb_idx].terminator().source_info;
+
+            let span = local_decls[d.local].source_info.span;
+            let fake_d: Place<'_> = local_decls.push(LocalDecl::new(d_ty, span)).into();
+            let assignment = Statement {
+                source_info: bbs[bb_idx].statements.last().unwrap().source_info,
+                kind: StatementKind::Assign(Box::new((
+                    fake_d,
+                    Rvalue::Discriminant { place: enum_place, relative: true },
+                ))),
+            };
+
+            let new_terminator = Terminator {
+                source_info,
+                kind: TerminatorKind::SwitchInt {
+                    discr: Operand::Copy(fake_d),
+                    switch_ty: d_ty,
+                    targets: new_targets,
+                },
+            };
+
+            *bbs[bb_idx].statements.last_mut().unwrap() = assignment;
+            bbs[bb_idx].terminator = Some(new_terminator);
+        }
+    }
+}

--- a/compiler/rustc_mir_transform/src/const_prop.rs
+++ b/compiler/rustc_mir_transform/src/const_prop.rs
@@ -618,7 +618,7 @@ impl<'mir, 'tcx> ConstPropagator<'mir, 'tcx> {
             | Rvalue::Len(..)
             | Rvalue::Cast(..)
             | Rvalue::ShallowInitBox(..)
-            | Rvalue::Discriminant(..)
+            | Rvalue::Discriminant { .. }
             | Rvalue::NullaryOp(..) => {}
         }
 

--- a/compiler/rustc_mir_transform/src/const_prop_lint.rs
+++ b/compiler/rustc_mir_transform/src/const_prop_lint.rs
@@ -684,7 +684,7 @@ impl<'mir, 'tcx> ConstPropagator<'mir, 'tcx> {
             | Rvalue::Len(..)
             | Rvalue::Cast(..)
             | Rvalue::ShallowInitBox(..)
-            | Rvalue::Discriminant(..)
+            | Rvalue::Discriminant { .. }
             | Rvalue::NullaryOp(..) => {}
         }
 

--- a/compiler/rustc_mir_transform/src/dest_prop.rs
+++ b/compiler/rustc_mir_transform/src/dest_prop.rs
@@ -916,7 +916,7 @@ impl<'tcx> Visitor<'tcx> for BorrowCollector {
             | Rvalue::CheckedBinaryOp(..)
             | Rvalue::NullaryOp(..)
             | Rvalue::UnaryOp(..)
-            | Rvalue::Discriminant(..)
+            | Rvalue::Discriminant { .. }
             | Rvalue::Aggregate(..)
             | Rvalue::ThreadLocalRef(..) => {}
         }

--- a/compiler/rustc_mir_transform/src/early_otherwise_branch.rs
+++ b/compiler/rustc_mir_transform/src/early_otherwise_branch.rs
@@ -147,7 +147,7 @@ impl<'tcx> MirPass<'tcx> for EarlyOtherwiseBranch {
             patch.add_assign(
                 parent_end,
                 Place::from(second_discriminant_temp),
-                Rvalue::Discriminant(opt_data.child_place),
+                Rvalue::Discriminant { place: opt_data.child_place, relative: false },
             );
 
             // create temp to store inequality comparison between the two discriminants, `_t` in
@@ -354,7 +354,7 @@ fn evaluate_candidate<'tcx>(
         = &bbs[child].statements.first().map(|x| &x.kind) else {
         return None;
     };
-    let (_, Rvalue::Discriminant(child_place)) = &**boxed else {
+    let (_, Rvalue::Discriminant { place: child_place, relative: false }) = &**boxed else {
         return None;
     };
     let destination = parent_dest.unwrap_or(child_targets.otherwise());
@@ -394,7 +394,7 @@ fn verify_candidate_branch<'tcx>(
     let StatementKind::Assign(boxed) = &branch.statements[0].kind else {
         return false
     };
-    let (discr_place, Rvalue::Discriminant(from_place)) = &**boxed else {
+    let (discr_place, Rvalue::Discriminant { place: from_place, relative: false }) = &**boxed else {
         return false
     };
     if *from_place != place {

--- a/compiler/rustc_mir_transform/src/generator.rs
+++ b/compiler/rustc_mir_transform/src/generator.rs
@@ -289,7 +289,10 @@ impl<'tcx> TransformVisitor<'tcx> {
         let self_place = Place::from(SELF_ARG);
         let assign = Statement {
             source_info: SourceInfo::outermost(body.span),
-            kind: StatementKind::Assign(Box::new((temp, Rvalue::Discriminant(self_place)))),
+            kind: StatementKind::Assign(Box::new((
+                temp,
+                Rvalue::Discriminant { place: self_place, relative: false },
+            ))),
         };
         (assign, temp)
     }

--- a/compiler/rustc_mir_transform/src/lib.rs
+++ b/compiler/rustc_mir_transform/src/lib.rs
@@ -40,6 +40,7 @@ use pass_manager::{self as pm, Lint, MirLint, WithMinOptLevel};
 mod abort_unwinding_calls;
 mod add_call_guards;
 mod add_moves_for_packed_drops;
+mod add_niche_cases;
 mod add_retag;
 mod check_const_item_mutation;
 mod check_packed_ref;
@@ -483,6 +484,7 @@ fn run_optimization_passes<'tcx>(tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
             // Const-prop runs unconditionally, but doesn't mutate the MIR at mir-opt-level=0.
             &o1(simplify_branches::SimplifyConstCondition::new("after-const-prop")),
             &early_otherwise_branch::EarlyOtherwiseBranch,
+            &add_niche_cases::AddNicheCases,
             &simplify_comparison_integral::SimplifyComparisonIntegral,
             &simplify_try::SimplifyArmIdentity,
             &simplify_try::SimplifyBranchSame,

--- a/compiler/rustc_mir_transform/src/lower_intrinsics.rs
+++ b/compiler/rustc_mir_transform/src/lower_intrinsics.rs
@@ -118,7 +118,7 @@ impl<'tcx> MirPass<'tcx> for LowerIntrinsics {
                                 source_info: terminator.source_info,
                                 kind: StatementKind::Assign(Box::new((
                                     destination,
-                                    Rvalue::Discriminant(arg),
+                                    Rvalue::Discriminant { place: arg, relative: false },
                                 ))),
                             });
                             terminator.kind = TerminatorKind::Goto { target };

--- a/compiler/rustc_mir_transform/src/remove_noop_landing_pads.rs
+++ b/compiler/rustc_mir_transform/src/remove_noop_landing_pads.rs
@@ -39,7 +39,10 @@ impl RemoveNoopLandingPads {
                     // These are all noops in a landing pad
                 }
 
-                StatementKind::Assign(box (place, Rvalue::Use(_) | Rvalue::Discriminant(_))) => {
+                StatementKind::Assign(box (
+                    place,
+                    Rvalue::Use(_) | Rvalue::Discriminant { .. },
+                )) => {
                     if place.as_local().is_some() {
                         // Writing to a local (e.g., a drop flag) does not
                         // turn a landing pad to a non-nop

--- a/compiler/rustc_mir_transform/src/separate_const_switch.rs
+++ b/compiler/rustc_mir_transform/src/separate_const_switch.rs
@@ -219,7 +219,7 @@ fn is_likely_const<'tcx>(mut tracked_place: Place<'tcx>, block: &BasicBlockData<
                         Rvalue::Cast(_, Operand::Copy(place) | Operand::Move(place), _)
                         | Rvalue::Use(Operand::Copy(place) | Operand::Move(place))
                         | Rvalue::UnaryOp(_, Operand::Copy(place) | Operand::Move(place))
-                        | Rvalue::Discriminant(place) => tracked_place = place,
+                        | Rvalue::Discriminant { place, .. } => tracked_place = place,
                     }
                 }
             }
@@ -280,7 +280,7 @@ fn find_determining_place<'tcx>(
                     | Rvalue::UnaryOp(_, Operand::Copy(new) | Operand::Move(new))
                     | Rvalue::Cast(_, Operand::Move(new) | Operand::Copy(new), _)
                     | Rvalue::Repeat(Operand::Move(new) | Operand::Copy(new), _)
-                    | Rvalue::Discriminant(new)
+                    | Rvalue::Discriminant { place: new, .. }
                     => switch_place = new,
 
                     // The following rvalues might still make the block

--- a/compiler/rustc_mir_transform/src/simplify_try.rs
+++ b/compiler/rustc_mir_transform/src/simplify_try.rs
@@ -612,7 +612,7 @@ impl<'tcx> SimplifyBranchSameOptimizationFinder<'_, 'tcx> {
                         if Some(*place) == discr_switched_on.place() =>
                     {
                         match rhs {
-                            Rvalue::Discriminant(adt_place) if adt_place.ty(self.body, self.tcx).ty.is_enum() => adt_place,
+                            Rvalue::Discriminant { place, .. } if place.ty(self.body, self.tcx).ty.is_enum() => place,
                             _ => {
                                 trace!("NO: expected a discriminant read of an enum instead of: {:?}", rhs);
                                 return None;

--- a/compiler/rustc_mir_transform/src/uninhabited_enum_branching.rs
+++ b/compiler/rustc_mir_transform/src/uninhabited_enum_branching.rs
@@ -34,7 +34,8 @@ fn get_switched_on_type<'tcx>(
         let stmt_before_term = (!block_data.statements.is_empty())
             .then(|| &block_data.statements[block_data.statements.len() - 1].kind);
 
-        if let Some(StatementKind::Assign(box (l, Rvalue::Discriminant(place)))) = stmt_before_term
+        if let Some(StatementKind::Assign(box (l, Rvalue::Discriminant { place, .. }))) =
+            stmt_before_term
         {
             if l.as_local() == Some(local) {
                 let ty = place.ty(body, tcx).ty;

--- a/src/tools/clippy/clippy_utils/src/qualify_min_const_fn.rs
+++ b/src/tools/clippy/clippy_utils/src/qualify_min_const_fn.rs
@@ -123,9 +123,10 @@ fn check_rvalue<'tcx>(
     match rvalue {
         Rvalue::ThreadLocalRef(_) => Err((span, "cannot access thread local storage in const fn".into())),
         Rvalue::Repeat(operand, _) | Rvalue::Use(operand) => check_operand(tcx, operand, span, body),
-        Rvalue::Len(place) | Rvalue::Discriminant(place) | Rvalue::Ref(_, _, place) | Rvalue::AddressOf(_, place) => {
-            check_place(tcx, *place, span, body)
-        },
+        Rvalue::Len(place)
+        | Rvalue::Discriminant { place, .. }
+        | Rvalue::Ref(_, _, place)
+        | Rvalue::AddressOf(_, place) => check_place(tcx, *place, span, body),
         Rvalue::Cast(CastKind::Misc, operand, cast_ty) => {
             use rustc_middle::ty::cast::CastTy;
             let cast_in = CastTy::from_ty(operand.ty(body, tcx)).expect("bad input type for cast");


### PR DESCRIPTION
This pass optimizes switches on the discriminant of a niche-optimized enum.