### PR TITLE
diagnostics: use correct span for const generics

### DIFF
--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -2068,7 +2068,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
         hir::GenericParam {
             hir_id,
             name,
-            span: self.lower_span(param.ident.span),
+            span: self.lower_span(param.span()),
             pure_wrt_drop: self.sess.contains_name(&param.attrs, sym::may_dangle),
             bounds: self.arena.alloc_from_iter(bounds),
             kind,

--- a/src/test/ui/associated-types/trait-with-supertraits-needing-sized-self.stderr
+++ b/src/test/ui/associated-types/trait-with-supertraits-needing-sized-self.stderr
@@ -8,7 +8,7 @@ note: required by a bound in `Add`
   --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
    |
 LL | pub trait Add<Rhs = Self> {
-   |               ^^^ required by this bound in `Add`
+   |               ^^^^^^^^^^ required by this bound in `Add`
 help: consider further restricting `Self`
    |
 LL | trait ArithmeticOps: Add<Output=Self> + Sub<Output=Self> + Mul<Output=Self> + Div<Output=Self> + Sized {}

--- a/src/test/ui/async-await/issues/issue-78654.full.stderr
+++ b/src/test/ui/async-await/issues/issue-78654.full.stderr
@@ -5,10 +5,10 @@ LL | impl<const H: feature> Foo {
    |               ^^^^^^^ not a type
 
 error[E0207]: the const parameter `H` is not constrained by the impl trait, self type, or predicates
-  --> $DIR/issue-78654.rs:9:12
+  --> $DIR/issue-78654.rs:9:6
    |
 LL | impl<const H: feature> Foo {
-   |            ^ unconstrained const parameter
+   |      ^^^^^^^^^^^^^^^^ unconstrained const parameter
    |
    = note: expressions using a const parameter must map each value to a distinct output value
    = note: proving the result of expressions other than the parameter are unique is not supported

--- a/src/test/ui/async-await/issues/issue-78654.min.stderr
+++ b/src/test/ui/async-await/issues/issue-78654.min.stderr
@@ -5,10 +5,10 @@ LL | impl<const H: feature> Foo {
    |               ^^^^^^^ not a type
 
 error[E0207]: the const parameter `H` is not constrained by the impl trait, self type, or predicates
-  --> $DIR/issue-78654.rs:9:12
+  --> $DIR/issue-78654.rs:9:6
    |
 LL | impl<const H: feature> Foo {
-   |            ^ unconstrained const parameter
+   |      ^^^^^^^^^^^^^^^^ unconstrained const parameter
    |
    = note: expressions using a const parameter must map each value to a distinct output value
    = note: proving the result of expressions other than the parameter are unique is not supported

--- a/src/test/ui/const-generics/defaults/default-on-impl.stderr
+++ b/src/test/ui/const-generics/defaults/default-on-impl.stderr
@@ -1,8 +1,8 @@
 error: defaults for const parameters are only allowed in `struct`, `enum`, `type`, or `trait` definitions
-  --> $DIR/default-on-impl.rs:3:12
+  --> $DIR/default-on-impl.rs:3:6
    |
 LL | impl<const N: usize = 1> Foo<N> {}
-   |            ^
+   |      ^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/const-generics/generic_const_exprs/issue-76595.stderr
+++ b/src/test/ui/const-generics/generic_const_exprs/issue-76595.stderr
@@ -10,7 +10,7 @@ note: function defined here, with 2 generic parameters: `T`, `P`
   --> $DIR/issue-76595.rs:10:4
    |
 LL | fn test<T, const P: usize>() where Bool<{core::mem::size_of::<T>() > 4}>: True {
-   |    ^^^^ -        -
+   |    ^^^^ -  --------------
 help: add missing generic argument
    |
 LL |     test::<2, P>();

--- a/src/test/ui/const-generics/incorrect-number-of-const-args.stderr
+++ b/src/test/ui/const-generics/incorrect-number-of-const-args.stderr
@@ -10,7 +10,7 @@ note: function defined here, with 2 generic parameters: `X`, `Y`
   --> $DIR/incorrect-number-of-const-args.rs:1:4
    |
 LL | fn foo<const X: usize, const Y: usize>() -> usize {
-   |    ^^^       -               -
+   |    ^^^ --------------  --------------
 help: add missing generic argument
    |
 LL |     foo::<0, Y>();
@@ -28,7 +28,7 @@ note: function defined here, with 2 generic parameters: `X`, `Y`
   --> $DIR/incorrect-number-of-const-args.rs:1:4
    |
 LL | fn foo<const X: usize, const Y: usize>() -> usize {
-   |    ^^^       -               -
+   |    ^^^ --------------  --------------
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/const-generics/issues/issue-68366.full.stderr
+++ b/src/test/ui/const-generics/issues/issue-68366.full.stderr
@@ -1,17 +1,17 @@
 error[E0207]: the const parameter `N` is not constrained by the impl trait, self type, or predicates
-  --> $DIR/issue-68366.rs:11:13
+  --> $DIR/issue-68366.rs:11:7
    |
 LL | impl <const N: usize> Collatz<{Some(N)}> {}
-   |             ^ unconstrained const parameter
+   |       ^^^^^^^^^^^^^^ unconstrained const parameter
    |
    = note: expressions using a const parameter must map each value to a distinct output value
    = note: proving the result of expressions other than the parameter are unique is not supported
 
 error[E0207]: the const parameter `N` is not constrained by the impl trait, self type, or predicates
-  --> $DIR/issue-68366.rs:17:12
+  --> $DIR/issue-68366.rs:17:6
    |
 LL | impl<const N: usize> Foo {}
-   |            ^ unconstrained const parameter
+   |      ^^^^^^^^^^^^^^ unconstrained const parameter
    |
    = note: expressions using a const parameter must map each value to a distinct output value
    = note: proving the result of expressions other than the parameter are unique is not supported

--- a/src/test/ui/const-generics/issues/issue-68366.min.stderr
+++ b/src/test/ui/const-generics/issues/issue-68366.min.stderr
@@ -8,19 +8,19 @@ LL | impl <const N: usize> Collatz<{Some(N)}> {}
    = help: use `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error[E0207]: the const parameter `N` is not constrained by the impl trait, self type, or predicates
-  --> $DIR/issue-68366.rs:11:13
+  --> $DIR/issue-68366.rs:11:7
    |
 LL | impl <const N: usize> Collatz<{Some(N)}> {}
-   |             ^ unconstrained const parameter
+   |       ^^^^^^^^^^^^^^ unconstrained const parameter
    |
    = note: expressions using a const parameter must map each value to a distinct output value
    = note: proving the result of expressions other than the parameter are unique is not supported
 
 error[E0207]: the const parameter `N` is not constrained by the impl trait, self type, or predicates
-  --> $DIR/issue-68366.rs:17:12
+  --> $DIR/issue-68366.rs:17:6
    |
 LL | impl<const N: usize> Foo {}
-   |            ^ unconstrained const parameter
+   |      ^^^^^^^^^^^^^^ unconstrained const parameter
    |
    = note: expressions using a const parameter must map each value to a distinct output value
    = note: proving the result of expressions other than the parameter are unique is not supported

--- a/src/test/ui/const-generics/issues/issue-86820.stderr
+++ b/src/test/ui/const-generics/issues/issue-86820.stderr
@@ -1,14 +1,14 @@
 error[E0053]: method `bit` has an incompatible const parameter type for trait
-  --> $DIR/issue-86820.rs:17:18
+  --> $DIR/issue-86820.rs:17:12
    |
 LL |     fn bit<const I : usize>(self) -> bool {
-   |                  ^
+   |            ^^^^^^^^^^^^^^^
    |
 note: the const parameter `I` has type `usize`, but the declaration in trait `Bits::bit` has type `u8`
-  --> $DIR/issue-86820.rs:12:18
+  --> $DIR/issue-86820.rs:12:12
    |
 LL |     fn bit<const I : u8>(self) -> bool;
-   |                  ^
+   |            ^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/const-generics/min_const_generics/default_function_param.stderr
+++ b/src/test/ui/const-generics/min_const_generics/default_function_param.stderr
@@ -1,8 +1,8 @@
 error: defaults for const parameters are only allowed in `struct`, `enum`, `type`, or `trait` definitions
-  --> $DIR/default_function_param.rs:3:14
+  --> $DIR/default_function_param.rs:3:8
    |
 LL | fn foo<const SIZE: usize = 5usize>() {}
-   |              ^^^^
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/const-generics/parser-error-recovery/issue-89013-no-kw.stderr
+++ b/src/test/ui/const-generics/parser-error-recovery/issue-89013-no-kw.stderr
@@ -17,7 +17,7 @@ note: trait defined here, with 1 generic parameter: `N`
   --> $DIR/issue-89013-no-kw.rs:1:7
    |
 LL | trait Foo<const N: usize> {
-   |       ^^^       -
+   |       ^^^ --------------
 help: add missing generic argument
    |
 LL | impl Foo<N, N = 3> for Bar {

--- a/src/test/ui/const-generics/parser-error-recovery/issue-89013.stderr
+++ b/src/test/ui/const-generics/parser-error-recovery/issue-89013.stderr
@@ -29,7 +29,7 @@ note: trait defined here, with 1 generic parameter: `N`
   --> $DIR/issue-89013.rs:1:7
    |
 LL | trait Foo<const N: usize> {
-   |       ^^^       -
+   |       ^^^ --------------
 help: add missing generic argument
    |
 LL | impl Foo<N, N = const 3> for Bar {

--- a/src/test/ui/feature-gates/feature-gate-default_type_parameter_fallback.stderr
+++ b/src/test/ui/feature-gates/feature-gate-default_type_parameter_fallback.stderr
@@ -2,7 +2,7 @@ error: defaults for type parameters are only allowed in `struct`, `enum`, `type`
   --> $DIR/feature-gate-default_type_parameter_fallback.rs:3:8
    |
 LL | fn avg<T=i32>(_: T) {}
-   |        ^
+   |        ^^^^^
    |
    = note: `#[deny(invalid_type_param_default)]` on by default
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
@@ -12,7 +12,7 @@ error: defaults for type parameters are only allowed in `struct`, `enum`, `type`
   --> $DIR/feature-gate-default_type_parameter_fallback.rs:8:6
    |
 LL | impl<T=i32> S<T> {}
-   |      ^
+   |      ^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #36887 <https://github.com/rust-lang/rust/issues/36887>

--- a/src/test/ui/generics/generic-impl-more-params-with-defaults.stderr
+++ b/src/test/ui/generics/generic-impl-more-params-with-defaults.stderr
@@ -10,7 +10,7 @@ note: struct defined here, with at most 2 generic parameters: `T`, `A`
   --> $DIR/generic-impl-more-params-with-defaults.rs:5:8
    |
 LL | struct Vec<T, A = Heap>(
-   |        ^^^ -  -
+   |        ^^^ -  --------
 
 error: aborting due to previous error
 

--- a/src/test/ui/generics/generic-type-more-params-with-defaults.stderr
+++ b/src/test/ui/generics/generic-type-more-params-with-defaults.stderr
@@ -10,7 +10,7 @@ note: struct defined here, with at most 2 generic parameters: `T`, `A`
   --> $DIR/generic-type-more-params-with-defaults.rs:5:8
    |
 LL | struct Vec<T, A = Heap>(
-   |        ^^^ -  -
+   |        ^^^ -  --------
 
 error: aborting due to previous error
 

--- a/src/test/ui/generics/issue-61631-default-type-param-can-reference-self-in-trait.stderr
+++ b/src/test/ui/generics/issue-61631-default-type-param-can-reference-self-in-trait.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `Tsized`
   --> $DIR/issue-61631-default-type-param-can-reference-self-in-trait.rs:17:14
    |
 LL | trait Tsized<P: Sized = [Self]> {}
-   |              ^ required by this bound in `Tsized`
+   |              ^^^^^^^^^^^^^^^^^ required by this bound in `Tsized`
 
 error: aborting due to previous error
 

--- a/src/test/ui/generics/wrong-number-of-args.stderr
+++ b/src/test/ui/generics/wrong-number-of-args.stderr
@@ -287,7 +287,7 @@ note: struct defined here, with at most 3 generic parameters: `A`, `B`, `C`
   --> $DIR/wrong-number-of-args.rs:78:12
    |
 LL |     struct Ty<A, B, C = &'static str>;
-   |            ^^ -  -  -
+   |            ^^ -  -  ----------------
 
 error[E0107]: this struct takes at least 2 generic arguments but 0 generic arguments were supplied
   --> $DIR/wrong-number-of-args.rs:96:14
@@ -922,7 +922,7 @@ note: struct defined here, with at most 3 generic parameters: `K`, `V`, `S`
   --> $SRC_DIR/std/src/collections/hash/map.rs:LL:COL
    |
 LL | pub struct HashMap<K, V, S = RandomState> {
-   |            ^^^^^^^ -  -  -
+   |            ^^^^^^^ -  -  ---------------
 
 error[E0107]: this struct takes at least 2 generic arguments but 0 generic arguments were supplied
   --> $DIR/wrong-number-of-args.rs:319:18

--- a/src/test/ui/impl-trait/where-allowed.stderr
+++ b/src/test/ui/impl-trait/where-allowed.stderr
@@ -293,7 +293,7 @@ error: defaults for type parameters are only allowed in `struct`, `enum`, `type`
   --> $DIR/where-allowed.rs:234:7
    |
 LL | impl <T = impl Debug> T {}
-   |       ^
+   |       ^^^^^^^^^^^^^^
    |
    = note: `#[deny(invalid_type_param_default)]` on by default
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
@@ -303,7 +303,7 @@ error: defaults for type parameters are only allowed in `struct`, `enum`, `type`
   --> $DIR/where-allowed.rs:241:36
    |
 LL | fn in_method_generic_param_default<T = impl Debug>(_: T) {}
-   |                                    ^
+   |                                    ^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #36887 <https://github.com/rust-lang/rust/issues/36887>

--- a/src/test/ui/issues/issue-78957.stderr
+++ b/src/test/ui/issues/issue-78957.stderr
@@ -2,13 +2,13 @@ error[E0518]: attribute should be applied to function or closure
   --> $DIR/issue-78957.rs:5:16
    |
 LL | pub struct Foo<#[inline] const N: usize>;
-   |                ^^^^^^^^^       - not a function or closure
+   |                ^^^^^^^^^ -------------- not a function or closure
 
 error: attribute should be applied to a function
   --> $DIR/issue-78957.rs:7:16
    |
 LL | pub struct Bar<#[cold] const N: usize>;
-   |                ^^^^^^^       - not a function
+   |                ^^^^^^^ -------------- not a function
    |
 note: the lint level is defined here
   --> $DIR/issue-78957.rs:1:9
@@ -21,7 +21,7 @@ error[E0517]: attribute should be applied to a struct, enum, or union
   --> $DIR/issue-78957.rs:10:23
    |
 LL | pub struct Baz<#[repr(C)] const N: usize>;
-   |                       ^         - not a struct, enum, or union
+   |                       ^   -------------- not a struct, enum, or union
 
 error[E0518]: attribute should be applied to function or closure
   --> $DIR/issue-78957.rs:13:17

--- a/src/test/ui/mir/thir-constparam-temp.stderr
+++ b/src/test/ui/mir/thir-constparam-temp.stderr
@@ -13,10 +13,10 @@ note: mutable reference created due to call to this method
 LL |     fn mut_self(&mut self) {}
    |     ^^^^^^^^^^^^^^^^^^^^^^
 note: `const` item defined here
-  --> $DIR/thir-constparam-temp.rs:13:14
+  --> $DIR/thir-constparam-temp.rs:13:8
    |
 LL | fn foo<const YIKES: Yikes>() {
-   |              ^^^^^
+   |        ^^^^^^^^^^^^^^^^^^
 
 warning: 1 warning emitted
 

--- a/src/test/ui/missing/missing-items/missing-type-parameter2.stderr
+++ b/src/test/ui/missing/missing-items/missing-type-parameter2.stderr
@@ -99,10 +99,10 @@ LL | impl X<{ N }> {}
    |        +   +
 
 error: defaults for const parameters are only allowed in `struct`, `enum`, `type`, or `trait` definitions
-  --> $DIR/missing-type-parameter2.rs:6:15
+  --> $DIR/missing-type-parameter2.rs:6:9
    |
 LL | impl<T, const A: u8 = 2> X<N> {}
-   |               ^
+   |         ^^^^^^^^^^^^^^^
 
 error[E0747]: unresolved item provided when a constant was expected
   --> $DIR/missing-type-parameter2.rs:6:28

--- a/src/test/ui/polymorphization/const_parameters/closures.stderr
+++ b/src/test/ui/polymorphization/const_parameters/closures.stderr
@@ -11,7 +11,7 @@ error: item has unused generic parameters
   --> $DIR/closures.rs:19:19
    |
 LL | pub fn unused<const T: usize>() -> usize {
-   |                     - generic parameter `T` is unused
+   |               -------------- generic parameter `T` is unused
 LL |
 LL |     let add_one = |x: usize| x + 1;
    |                   ^^^^^^^^^^^^^^^^
@@ -20,13 +20,13 @@ error: item has unused generic parameters
   --> $DIR/closures.rs:17:8
    |
 LL | pub fn unused<const T: usize>() -> usize {
-   |        ^^^^^^       - generic parameter `T` is unused
+   |        ^^^^^^ -------------- generic parameter `T` is unused
 
 error: item has unused generic parameters
   --> $DIR/closures.rs:28:19
    |
 LL | pub fn used_parent<const T: usize>() -> usize {
-   |                          - generic parameter `T` is unused
+   |                    -------------- generic parameter `T` is unused
 LL |     let x: usize = T;
 LL |     let add_one = |x: usize| x + 1;
    |                   ^^^^^^^^^^^^^^^^
@@ -35,7 +35,7 @@ error: item has unused generic parameters
   --> $DIR/closures.rs:48:13
    |
 LL | pub fn unused_upvar<const T: usize>() -> usize {
-   |                           - generic parameter `T` is unused
+   |                     -------------- generic parameter `T` is unused
 LL |     let x: usize = T;
 LL |     let y = || x;
    |             ^^^^

--- a/src/test/ui/polymorphization/const_parameters/functions.stderr
+++ b/src/test/ui/polymorphization/const_parameters/functions.stderr
@@ -11,7 +11,7 @@ error: item has unused generic parameters
   --> $DIR/functions.rs:15:8
    |
 LL | pub fn unused<const T: usize>() {
-   |        ^^^^^^       - generic parameter `T` is unused
+   |        ^^^^^^ -------------- generic parameter `T` is unused
 
 error: aborting due to previous error; 1 warning emitted
 

--- a/src/test/ui/polymorphization/generators.stderr
+++ b/src/test/ui/polymorphization/generators.stderr
@@ -23,7 +23,7 @@ error: item has unused generic parameters
   --> $DIR/generators.rs:60:5
    |
 LL |   pub fn unused_const<const T: u32>() -> impl Generator<(), Yield = u32, Return = u32> + Unpin {
-   |                             - generic parameter `T` is unused
+   |                       ------------ generic parameter `T` is unused
 LL | /     || {
 LL | |
 LL | |         yield 1;

--- a/src/test/ui/save-analysis/issue-89066.stderr
+++ b/src/test/ui/save-analysis/issue-89066.stderr
@@ -31,7 +31,7 @@ note: struct defined here, with 2 generic parameters: `T`, `N`
   --> $DIR/issue-89066.rs:8:8
    |
 LL | struct All<'a, T, const N: usize> {
-   |        ^^^     -        -
+   |        ^^^     -  --------------
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/suggestions/lifetimes/missing-lifetimes-in-signature-before-const.fixed
+++ b/src/test/ui/suggestions/lifetimes/missing-lifetimes-in-signature-before-const.fixed
@@ -1,0 +1,10 @@
+// run-rustfix
+// https://github.com/rust-lang/rust/issues/95616
+
+fn buggy_const<'a, const N: usize>(_a: &'a Option<[u8; N]>, _f: &'a str) -> &'a str { //~ERROR [E0106]
+    return "";
+}
+
+fn main() {
+    buggy_const(&Some([69,69,69,69,0]), "test");
+}

--- a/src/test/ui/suggestions/lifetimes/missing-lifetimes-in-signature-before-const.rs
+++ b/src/test/ui/suggestions/lifetimes/missing-lifetimes-in-signature-before-const.rs
@@ -1,0 +1,10 @@
+// run-rustfix
+// https://github.com/rust-lang/rust/issues/95616
+
+fn buggy_const<const N: usize>(_a: &Option<[u8; N]>, _f: &str) -> &str { //~ERROR [E0106]
+    return "";
+}
+
+fn main() {
+    buggy_const(&Some([69,69,69,69,0]), "test");
+}

--- a/src/test/ui/suggestions/lifetimes/missing-lifetimes-in-signature-before-const.stderr
+++ b/src/test/ui/suggestions/lifetimes/missing-lifetimes-in-signature-before-const.stderr
@@ -1,0 +1,15 @@
+error[E0106]: missing lifetime specifier
+  --> $DIR/missing-lifetimes-in-signature-before-const.rs:4:67
+   |
+LL | fn buggy_const<const N: usize>(_a: &Option<[u8; N]>, _f: &str) -> &str {
+   |                                    ----------------      ----     ^ expected named lifetime parameter
+   |
+   = help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from `_a` or `_f`
+help: consider introducing a named lifetime parameter
+   |
+LL | fn buggy_const<'a, const N: usize>(_a: &'a Option<[u8; N]>, _f: &'a str) -> &'a str {
+   |                +++                      ++                       ++          ++
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0106`.

--- a/src/test/ui/type-alias-impl-trait/generic_duplicate_param_use.stderr
+++ b/src/test/ui/type-alias-impl-trait/generic_duplicate_param_use.stderr
@@ -29,10 +29,10 @@ LL |     t
    |     ^
    |
 note: constant used multiple times
-  --> $DIR/generic_duplicate_param_use.rs:12:22
+  --> $DIR/generic_duplicate_param_use.rs:12:16
    |
 LL | type TwoConsts<const X: usize, const Y: usize> = impl Debug;
-   |                      ^               ^
+   |                ^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/type-alias-impl-trait/generic_nondefining_use.stderr
+++ b/src/test/ui/type-alias-impl-trait/generic_nondefining_use.stderr
@@ -26,10 +26,10 @@ LL |     7u32
    |     ^^^^
    |
 note: used non-generic constant `123_usize` for generic parameter
-  --> $DIR/generic_nondefining_use.rs:11:21
+  --> $DIR/generic_nondefining_use.rs:11:15
    |
 LL | type OneConst<const X: usize> = impl Debug;
-   |                     ^
+   |               ^^^^^^^^^^^^^^
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/type/type-check-defaults.stderr
+++ b/src/test/ui/type/type-check-defaults.stderr
@@ -2,7 +2,7 @@ error[E0277]: a value of type `i32` cannot be built from an iterator over elemen
   --> $DIR/type-check-defaults.rs:6:19
    |
 LL | struct WellFormed<Z = Foo<i32, i32>>(Z);
-   |                   ^ value of type `i32` cannot be built from `std::iter::Iterator<Item=i32>`
+   |                   ^^^^^^^^^^^^^^^^^ value of type `i32` cannot be built from `std::iter::Iterator<Item=i32>`
    |
    = help: the trait `FromIterator<i32>` is not implemented for `i32`
 note: required by a bound in `Foo`
@@ -15,7 +15,7 @@ error[E0277]: a value of type `i32` cannot be built from an iterator over elemen
   --> $DIR/type-check-defaults.rs:8:27
    |
 LL | struct WellFormedNoBounds<Z:?Sized = Foo<i32, i32>>(Z);
-   |                           ^ value of type `i32` cannot be built from `std::iter::Iterator<Item=i32>`
+   |                           ^^^^^^^^^^^^^^^^^^^^^^^^ value of type `i32` cannot be built from `std::iter::Iterator<Item=i32>`
    |
    = help: the trait `FromIterator<i32>` is not implemented for `i32`
 note: required by a bound in `Foo`


### PR DESCRIPTION
Fixes #95616