### PR TITLE
Update RLS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2950,9 +2950,9 @@ dependencies = [
 
 [[package]]
 name = "racer"
-version = "2.2.0"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0b4b5faaf07040474e8af74a9e19ff167d5d204df5db5c5c765edecfb900358"
+checksum = "64954e44fc0d1dcc64e0b9f2b155249ad62849eba25354b76ae1598d1e8f0fa0"
 dependencies = [
  "bitflags",
  "clap 2.34.0",


### PR DESCRIPTION
This PR updates RLS to include the following PRs:

* https://github.com/rust-lang/rls/pull/1766
* https://github.com/rust-lang/rls/pull/1767
* https://github.com/rust-lang/rls/pull/1771
* https://github.com/rust-lang/rls/pull/1772

It also updates racer to fix RLS compilation with the parallel compiler enabled.