### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -2068,7 +2068,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
         hir::GenericParam {
             hir_id,
             name,
-            span: self.lower_span(param.ident.span),
+            span: self.lower_span(param.span()),
             pure_wrt_drop: self.sess.contains_name(&param.attrs, sym::may_dangle),
             bounds: self.arena.alloc_from_iter(bounds),
             kind,

--- a/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
@@ -772,14 +772,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
             Some((issued_span, span)),
         );
 
-        self.suggest_using_local_if_applicable(
-            &mut err,
-            location,
-            (place, span),
-            gen_borrow_kind,
-            issued_borrow,
-            explanation,
-        );
+        self.suggest_using_local_if_applicable(&mut err, location, issued_borrow, explanation);
 
         err
     }
@@ -789,8 +782,6 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
         &self,
         err: &mut Diagnostic,
         location: Location,
-        (place, span): (Place<'tcx>, Span),
-        gen_borrow_kind: BorrowKind,
         issued_borrow: &BorrowData<'tcx>,
         explanation: BorrowExplanation,
     ) {
@@ -822,7 +813,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
             return;
         };
         let inner_param_uses = find_all_local_uses::find(self.body, inner_param.local);
-        let Some((inner_call_loc,inner_call_term)) = inner_param_uses.into_iter().find_map(|loc| {
+        let Some((inner_call_loc, inner_call_term)) = inner_param_uses.into_iter().find_map(|loc| {
             let Either::Right(term) = self.body.stmt_at(loc) else {
                 debug!("{:?} is a statement, so it can't be a call", loc);
                 return None;
@@ -833,7 +824,7 @@ impl<'cx, 'tcx> MirBorrowckCtxt<'cx, 'tcx> {
             };
             debug!("checking call args for uses of inner_param: {:?}", args);
             if args.contains(&Operand::Move(inner_param)) {
-                Some((loc,term))
+                Some((loc, term))
             } else {
                 None
             }

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
@@ -536,6 +536,7 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                         );
                         self.note_version_mismatch(&mut err, &trait_ref);
                         self.suggest_remove_await(&obligation, &mut err);
+                        self.suggest_derive(&mut err, trait_predicate);
 
                         if Some(trait_ref.def_id()) == tcx.lang_items().try_trait() {
                             self.suggest_await_before_try(

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
@@ -536,7 +536,7 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                         );
                         self.note_version_mismatch(&mut err, &trait_ref);
                         self.suggest_remove_await(&obligation, &mut err);
-                        self.suggest_derive(&mut err, trait_predicate);
+                        self.suggest_derive(&obligation, &mut err, trait_predicate);
 
                         if Some(trait_ref.def_id()) == tcx.lang_items().try_trait() {
                             self.suggest_await_before_try(

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -189,6 +189,8 @@ pub trait InferCtxtExt<'tcx> {
         err: &mut Diagnostic,
         trait_ref: &ty::PolyTraitRef<'tcx>,
     );
+
+    fn suggest_derive(&self, err: &mut Diagnostic, trait_pred: ty::PolyTraitPredicate<'tcx>);
 }
 
 fn predicate_constraint(generics: &hir::Generics<'_>, pred: String) -> (Span, String) {
@@ -2587,6 +2589,39 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                 );
             }
             _ => {}
+        }
+    }
+
+    fn suggest_derive(&self, err: &mut Diagnostic, trait_pred: ty::PolyTraitPredicate<'tcx>) {
+        if let Some(diagnostic_name) = self.tcx.get_diagnostic_name(trait_pred.def_id()) {
+            let adt = match trait_pred.skip_binder().self_ty().ty_adt_def() {
+                Some(adt) if adt.did().is_local() => adt,
+                _ => return,
+            };
+            let can_derive = match diagnostic_name {
+                sym::Default => !adt.is_enum(),
+                sym::Eq
+                | sym::PartialEq
+                | sym::Ord
+                | sym::PartialOrd
+                | sym::Clone
+                | sym::Copy
+                | sym::Hash
+                | sym::Debug => true,
+                _ => false,
+            };
+            if can_derive {
+                err.span_suggestion_verbose(
+                    self.tcx.def_span(adt.did()).shrink_to_lo(),
+                    &format!(
+                        "consider annotating `{}` with `#[derive({})]`",
+                        trait_pred.skip_binder().self_ty().to_string(),
+                        diagnostic_name.to_string(),
+                    ),
+                    format!("#[derive({})]\n", diagnostic_name.to_string()),
+                    Applicability::MaybeIncorrect,
+                );
+            }
         }
     }
 }

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -190,7 +190,12 @@ pub trait InferCtxtExt<'tcx> {
         trait_ref: &ty::PolyTraitRef<'tcx>,
     );
 
-    fn suggest_derive(&self, err: &mut Diagnostic, trait_pred: ty::PolyTraitPredicate<'tcx>);
+    fn suggest_derive(
+        &self,
+        obligation: &PredicateObligation<'tcx>,
+        err: &mut Diagnostic,
+        trait_pred: ty::PolyTraitPredicate<'tcx>,
+    );
 }
 
 fn predicate_constraint(generics: &hir::Generics<'_>, pred: String) -> (Span, String) {
@@ -2592,33 +2597,60 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
         }
     }
 
-    fn suggest_derive(&self, err: &mut Diagnostic, trait_pred: ty::PolyTraitPredicate<'tcx>) {
+    fn suggest_derive(
+        &self,
+        obligation: &PredicateObligation<'tcx>,
+        err: &mut Diagnostic,
+        trait_pred: ty::PolyTraitPredicate<'tcx>,
+    ) {
         let Some(diagnostic_name) = self.tcx.get_diagnostic_name(trait_pred.def_id()) else {
             return;
         };
-        let Some(self_ty) = trait_pred.self_ty().no_bound_vars() else {
-            return;
-        };
-
-        let adt = match self_ty.ty_adt_def() {
-            Some(adt) if adt.did().is_local() => adt,
+        let (adt, substs) = match trait_pred.skip_binder().self_ty().kind() {
+            ty::Adt(adt, substs) if adt.did().is_local() => (adt, substs),
             _ => return,
         };
-        let can_derive = match diagnostic_name {
-            sym::Default => !adt.is_enum(),
-            sym::PartialEq | sym::PartialOrd => {
-                let rhs_ty = trait_pred.skip_binder().trait_ref.substs.type_at(1);
-                self_ty == rhs_ty
-            }
-            sym::Eq | sym::Ord | sym::Clone | sym::Copy | sym::Hash | sym::Debug => true,
-            _ => false,
+        let can_derive = {
+            let is_derivable_trait = match diagnostic_name {
+                sym::Default => !adt.is_enum(),
+                sym::PartialEq | sym::PartialOrd => {
+                    let rhs_ty = trait_pred.skip_binder().trait_ref.substs.type_at(1);
+                    trait_pred.skip_binder().self_ty() == rhs_ty
+                }
+                sym::Eq | sym::Ord | sym::Clone | sym::Copy | sym::Hash | sym::Debug => true,
+                _ => false,
+            };
+            is_derivable_trait &&
+                // Ensure all fields impl the trait.
+                adt.all_fields().all(|field| {
+                    let field_ty = field.ty(self.tcx, substs);
+                    let trait_substs = match diagnostic_name {
+                        sym::PartialEq | sym::PartialOrd => {
+                            self.tcx.mk_substs_trait(field_ty, &[field_ty.into()])
+                        }
+                        _ => self.tcx.mk_substs_trait(field_ty, &[]),
+                    };
+                    let trait_pred = trait_pred.map_bound_ref(|tr| ty::TraitPredicate {
+                        trait_ref: ty::TraitRef {
+                            substs: trait_substs,
+                            ..trait_pred.skip_binder().trait_ref
+                        },
+                        ..*tr
+                    });
+                    let field_obl = Obligation::new(
+                        obligation.cause.clone(),
+                        obligation.param_env,
+                        trait_pred.to_predicate(self.tcx),
+                    );
+                    self.predicate_must_hold_modulo_regions(&field_obl)
+                })
         };
         if can_derive {
             err.span_suggestion_verbose(
                 self.tcx.def_span(adt.did()).shrink_to_lo(),
                 &format!(
                     "consider annotating `{}` with `#[derive({})]`",
-                    trait_pred.skip_binder().self_ty().to_string(),
+                    trait_pred.skip_binder().self_ty(),
                     diagnostic_name.to_string(),
                 ),
                 format!("#[derive({})]\n", diagnostic_name.to_string()),

--- a/library/core/src/macros/panic.md
+++ b/library/core/src/macros/panic.md
@@ -1,8 +1,7 @@
 Panics the current thread.
 
 This allows a program to terminate immediately and provide feedback
-to the caller of the program. `panic!` should be used when a program reaches
-an unrecoverable state.
+to the caller of the program.
 
 This macro is the perfect way to assert conditions in example code and in
 tests. `panic!` is closely tied with the `unwrap` method of both
@@ -21,12 +20,24 @@ Inside the hook a panic can be accessed as a `&dyn Any + Send`,
 which contains either a `&str` or `String` for regular `panic!()` invocations.
 To panic with a value of another other type, [`panic_any`] can be used.
 
-[`Result`] enum is often a better solution for recovering from errors than
-using the `panic!` macro. This macro should be used to avoid proceeding using
-incorrect values, such as from external sources. Detailed information about
-error handling is found in the [book].
-
 See also the macro [`compile_error!`], for raising errors during compilation.
+
+# When to use `panic!` vs `Result`
+
+The Rust model of error handling groups errors into two major categories:
+recoverable and unrecoverable errors. For a recoverable error, such as a file
+not found error, it’s reasonable to report the problem to the user and retry
+the operation. Unrecoverable errors are always symptoms of bugs, like trying to
+access a location beyond the end of an array.
+
+The Rust language and standard library provides `Result` and `panic!` as parts
+of two complementary systems for representing, reporting, propagating, reacting
+to, and discarding errors for in these two categories.
+
+The `panic!` macro is provided to represent unrecoverable errors, whereas the
+`Result` enum is provided to represent recoverable errors. For more detailed
+information about error handling check out the [book] or the [`std::result`]
+module docs.
 
 [ounwrap]: Option::unwrap
 [runwrap]: Result::unwrap
@@ -36,6 +47,7 @@ See also the macro [`compile_error!`], for raising errors during compilation.
 [`Any`]: crate::any::Any
 [`format!`]: ../std/macro.format.html
 [book]: ../book/ch09-00-error-handling.html
+[`std::result`]: ../std/result/index.html
 
 # Current implementation
 

--- a/src/test/ui/array-slice-vec/repeat_empty_ok.stderr
+++ b/src/test/ui/array-slice-vec/repeat_empty_ok.stderr
@@ -5,6 +5,10 @@ LL |     let headers = [Header{value: &[]}; 128];
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `Header<'_>`
    |
    = note: the `Copy` trait is required because the repeated element will be copied
+help: consider annotating `Header<'_>` with `#[derive(Copy)]`
+   |
+LL | #[derive(Copy)]
+   |
 
 error[E0277]: the trait bound `Header<'_>: Copy` is not satisfied
   --> $DIR/repeat_empty_ok.rs:13:19
@@ -13,6 +17,10 @@ LL |     let headers = [Header{value: &[0]}; 128];
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `Header<'_>`
    |
    = note: the `Copy` trait is required because the repeated element will be copied
+help: consider annotating `Header<'_>` with `#[derive(Copy)]`
+   |
+LL | #[derive(Copy)]
+   |
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/associated-types/defaults-suitability.stderr
+++ b/src/test/ui/associated-types/defaults-suitability.stderr
@@ -9,6 +9,10 @@ note: required by a bound in `Tr::Ty`
    |
 LL |     type Ty: Clone = NotClone;
    |              ^^^^^ required by this bound in `Tr::Ty`
+help: consider annotating `NotClone` with `#[derive(Clone)]`
+   |
+LL | #[derive(Clone)]
+   |
 
 error[E0277]: the trait bound `NotClone: Clone` is not satisfied
   --> $DIR/defaults-suitability.rs:22:15
@@ -24,6 +28,10 @@ LL |     Self::Ty: Clone,
 LL | {
 LL |     type Ty = NotClone;
    |          -- required by a bound in this
+help: consider annotating `NotClone` with `#[derive(Clone)]`
+   |
+LL | #[derive(Clone)]
+   |
 
 error[E0277]: the trait bound `T: Clone` is not satisfied
   --> $DIR/defaults-suitability.rs:28:23

--- a/src/test/ui/associated-types/trait-with-supertraits-needing-sized-self.stderr
+++ b/src/test/ui/associated-types/trait-with-supertraits-needing-sized-self.stderr
@@ -8,7 +8,7 @@ note: required by a bound in `Add`
   --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
    |
 LL | pub trait Add<Rhs = Self> {
-   |               ^^^ required by this bound in `Add`
+   |               ^^^^^^^^^^ required by this bound in `Add`
 help: consider further restricting `Self`
    |
 LL | trait ArithmeticOps: Add<Output=Self> + Sub<Output=Self> + Mul<Output=Self> + Div<Output=Self> + Sized {}

--- a/src/test/ui/async-await/issues/issue-78654.full.stderr
+++ b/src/test/ui/async-await/issues/issue-78654.full.stderr
@@ -5,10 +5,10 @@ LL | impl<const H: feature> Foo {
    |               ^^^^^^^ not a type
 
 error[E0207]: the const parameter `H` is not constrained by the impl trait, self type, or predicates
-  --> $DIR/issue-78654.rs:9:12
+  --> $DIR/issue-78654.rs:9:6
    |
 LL | impl<const H: feature> Foo {
-   |            ^ unconstrained const parameter
+   |      ^^^^^^^^^^^^^^^^ unconstrained const parameter
    |
    = note: expressions using a const parameter must map each value to a distinct output value
    = note: proving the result of expressions other than the parameter are unique is not supported

--- a/src/test/ui/async-await/issues/issue-78654.min.stderr
+++ b/src/test/ui/async-await/issues/issue-78654.min.stderr
@@ -5,10 +5,10 @@ LL | impl<const H: feature> Foo {
    |               ^^^^^^^ not a type
 
 error[E0207]: the const parameter `H` is not constrained by the impl trait, self type, or predicates
-  --> $DIR/issue-78654.rs:9:12
+  --> $DIR/issue-78654.rs:9:6
    |
 LL | impl<const H: feature> Foo {
-   |            ^ unconstrained const parameter
+   |      ^^^^^^^^^^^^^^^^ unconstrained const parameter
    |
    = note: expressions using a const parameter must map each value to a distinct output value
    = note: proving the result of expressions other than the parameter are unique is not supported

--- a/src/test/ui/const-generics/defaults/default-on-impl.stderr
+++ b/src/test/ui/const-generics/defaults/default-on-impl.stderr
@@ -1,8 +1,8 @@
 error: defaults for const parameters are only allowed in `struct`, `enum`, `type`, or `trait` definitions
-  --> $DIR/default-on-impl.rs:3:12
+  --> $DIR/default-on-impl.rs:3:6
    |
 LL | impl<const N: usize = 1> Foo<N> {}
-   |            ^
+   |      ^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/const-generics/generic_const_exprs/issue-76595.stderr
+++ b/src/test/ui/const-generics/generic_const_exprs/issue-76595.stderr
@@ -10,7 +10,7 @@ note: function defined here, with 2 generic parameters: `T`, `P`
   --> $DIR/issue-76595.rs:10:4
    |
 LL | fn test<T, const P: usize>() where Bool<{core::mem::size_of::<T>() > 4}>: True {
-   |    ^^^^ -        -
+   |    ^^^^ -  --------------
 help: add missing generic argument
    |
 LL |     test::<2, P>();

--- a/src/test/ui/const-generics/incorrect-number-of-const-args.stderr
+++ b/src/test/ui/const-generics/incorrect-number-of-const-args.stderr
@@ -10,7 +10,7 @@ note: function defined here, with 2 generic parameters: `X`, `Y`
   --> $DIR/incorrect-number-of-const-args.rs:1:4
    |
 LL | fn foo<const X: usize, const Y: usize>() -> usize {
-   |    ^^^       -               -
+   |    ^^^ --------------  --------------
 help: add missing generic argument
    |
 LL |     foo::<0, Y>();
@@ -28,7 +28,7 @@ note: function defined here, with 2 generic parameters: `X`, `Y`
   --> $DIR/incorrect-number-of-const-args.rs:1:4
    |
 LL | fn foo<const X: usize, const Y: usize>() -> usize {
-   |    ^^^       -               -
+   |    ^^^ --------------  --------------
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/const-generics/issues/issue-68366.full.stderr
+++ b/src/test/ui/const-generics/issues/issue-68366.full.stderr
@@ -1,17 +1,17 @@
 error[E0207]: the const parameter `N` is not constrained by the impl trait, self type, or predicates
-  --> $DIR/issue-68366.rs:11:13
+  --> $DIR/issue-68366.rs:11:7
    |
 LL | impl <const N: usize> Collatz<{Some(N)}> {}
-   |             ^ unconstrained const parameter
+   |       ^^^^^^^^^^^^^^ unconstrained const parameter
    |
    = note: expressions using a const parameter must map each value to a distinct output value
    = note: proving the result of expressions other than the parameter are unique is not supported
 
 error[E0207]: the const parameter `N` is not constrained by the impl trait, self type, or predicates
-  --> $DIR/issue-68366.rs:17:12
+  --> $DIR/issue-68366.rs:17:6
    |
 LL | impl<const N: usize> Foo {}
-   |            ^ unconstrained const parameter
+   |      ^^^^^^^^^^^^^^ unconstrained const parameter
    |
    = note: expressions using a const parameter must map each value to a distinct output value
    = note: proving the result of expressions other than the parameter are unique is not supported

--- a/src/test/ui/const-generics/issues/issue-68366.min.stderr
+++ b/src/test/ui/const-generics/issues/issue-68366.min.stderr
@@ -8,19 +8,19 @@ LL | impl <const N: usize> Collatz<{Some(N)}> {}
    = help: use `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error[E0207]: the const parameter `N` is not constrained by the impl trait, self type, or predicates
-  --> $DIR/issue-68366.rs:11:13
+  --> $DIR/issue-68366.rs:11:7
    |
 LL | impl <const N: usize> Collatz<{Some(N)}> {}
-   |             ^ unconstrained const parameter
+   |       ^^^^^^^^^^^^^^ unconstrained const parameter
    |
    = note: expressions using a const parameter must map each value to a distinct output value
    = note: proving the result of expressions other than the parameter are unique is not supported
 
 error[E0207]: the const parameter `N` is not constrained by the impl trait, self type, or predicates
-  --> $DIR/issue-68366.rs:17:12
+  --> $DIR/issue-68366.rs:17:6
    |
 LL | impl<const N: usize> Foo {}
-   |            ^ unconstrained const parameter
+   |      ^^^^^^^^^^^^^^ unconstrained const parameter
    |
    = note: expressions using a const parameter must map each value to a distinct output value
    = note: proving the result of expressions other than the parameter are unique is not supported

--- a/src/test/ui/const-generics/issues/issue-86820.stderr
+++ b/src/test/ui/const-generics/issues/issue-86820.stderr
@@ -1,14 +1,14 @@
 error[E0053]: method `bit` has an incompatible const parameter type for trait
-  --> $DIR/issue-86820.rs:17:18
+  --> $DIR/issue-86820.rs:17:12
    |
 LL |     fn bit<const I : usize>(self) -> bool {
-   |                  ^
+   |            ^^^^^^^^^^^^^^^
    |
 note: the const parameter `I` has type `usize`, but the declaration in trait `Bits::bit` has type `u8`
-  --> $DIR/issue-86820.rs:12:18
+  --> $DIR/issue-86820.rs:12:12
    |
 LL |     fn bit<const I : u8>(self) -> bool;
-   |                  ^
+   |            ^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/const-generics/min_const_generics/default_function_param.stderr
+++ b/src/test/ui/const-generics/min_const_generics/default_function_param.stderr
@@ -1,8 +1,8 @@
 error: defaults for const parameters are only allowed in `struct`, `enum`, `type`, or `trait` definitions
-  --> $DIR/default_function_param.rs:3:14
+  --> $DIR/default_function_param.rs:3:8
    |
 LL | fn foo<const SIZE: usize = 5usize>() {}
-   |              ^^^^
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/const-generics/parser-error-recovery/issue-89013-no-kw.stderr
+++ b/src/test/ui/const-generics/parser-error-recovery/issue-89013-no-kw.stderr
@@ -17,7 +17,7 @@ note: trait defined here, with 1 generic parameter: `N`
   --> $DIR/issue-89013-no-kw.rs:1:7
    |
 LL | trait Foo<const N: usize> {
-   |       ^^^       -
+   |       ^^^ --------------
 help: add missing generic argument
    |
 LL | impl Foo<N, N = 3> for Bar {

--- a/src/test/ui/const-generics/parser-error-recovery/issue-89013.stderr
+++ b/src/test/ui/const-generics/parser-error-recovery/issue-89013.stderr
@@ -29,7 +29,7 @@ note: trait defined here, with 1 generic parameter: `N`
   --> $DIR/issue-89013.rs:1:7
    |
 LL | trait Foo<const N: usize> {
-   |       ^^^       -
+   |       ^^^ --------------
 help: add missing generic argument
    |
 LL | impl Foo<N, N = const 3> for Bar {

--- a/src/test/ui/consts/const-blocks/trait-error.stderr
+++ b/src/test/ui/consts/const-blocks/trait-error.stderr
@@ -7,6 +7,10 @@ LL |     [Foo(String::new()); 4];
    = help: the following implementations were found:
              <Foo<T> as Copy>
    = note: the `Copy` trait is required because the repeated element will be copied
+help: consider annotating `Foo<String>` with `#[derive(Copy)]`
+   |
+LL | #[derive(Copy)]
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/const-blocks/trait-error.stderr
+++ b/src/test/ui/consts/const-blocks/trait-error.stderr
@@ -7,10 +7,6 @@ LL |     [Foo(String::new()); 4];
    = help: the following implementations were found:
              <Foo<T> as Copy>
    = note: the `Copy` trait is required because the repeated element will be copied
-help: consider annotating `Foo<String>` with `#[derive(Copy)]`
-   |
-LL | #[derive(Copy)]
-   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/derives/derives-span-Clone-enum-struct-variant.stderr
+++ b/src/test/ui/derives/derives-span-Clone-enum-struct-variant.stderr
@@ -8,6 +8,10 @@ LL |      x: Error
    |      ^^^^^^^^ the trait `Clone` is not implemented for `Error`
    |
    = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider annotating `Error` with `#[derive(Clone)]`
+   |
+LL | #[derive(Clone)]
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/derives/derives-span-Clone-enum.stderr
+++ b/src/test/ui/derives/derives-span-Clone-enum.stderr
@@ -8,6 +8,10 @@ LL |      Error
    |      ^^^^^ the trait `Clone` is not implemented for `Error`
    |
    = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider annotating `Error` with `#[derive(Clone)]`
+   |
+LL | #[derive(Clone)]
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/derives/derives-span-Clone-struct.stderr
+++ b/src/test/ui/derives/derives-span-Clone-struct.stderr
@@ -8,6 +8,10 @@ LL |     x: Error
    |     ^^^^^^^^ the trait `Clone` is not implemented for `Error`
    |
    = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider annotating `Error` with `#[derive(Clone)]`
+   |
+LL | #[derive(Clone)]
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/derives/derives-span-Clone-tuple-struct.stderr
+++ b/src/test/ui/derives/derives-span-Clone-tuple-struct.stderr
@@ -8,6 +8,10 @@ LL |     Error
    |     ^^^^^ the trait `Clone` is not implemented for `Error`
    |
    = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider annotating `Error` with `#[derive(Clone)]`
+   |
+LL | #[derive(Clone)]
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/derives/derives-span-Debug-enum-struct-variant.stderr
+++ b/src/test/ui/derives/derives-span-Debug-enum-struct-variant.stderr
@@ -10,6 +10,10 @@ LL |      x: Error
    = help: the trait `Debug` is not implemented for `Error`
    = note: add `#[derive(Debug)]` to `Error` or manually `impl Debug for Error`
    = note: this error originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider annotating `Error` with `#[derive(Debug)]`
+   |
+LL | #[derive(Debug)]
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/derives/derives-span-Debug-enum.stderr
+++ b/src/test/ui/derives/derives-span-Debug-enum.stderr
@@ -10,6 +10,10 @@ LL |      Error
    = help: the trait `Debug` is not implemented for `Error`
    = note: add `#[derive(Debug)]` to `Error` or manually `impl Debug for Error`
    = note: this error originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider annotating `Error` with `#[derive(Debug)]`
+   |
+LL | #[derive(Debug)]
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/derives/derives-span-Debug-struct.stderr
+++ b/src/test/ui/derives/derives-span-Debug-struct.stderr
@@ -10,6 +10,10 @@ LL |     x: Error
    = help: the trait `Debug` is not implemented for `Error`
    = note: add `#[derive(Debug)]` to `Error` or manually `impl Debug for Error`
    = note: this error originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider annotating `Error` with `#[derive(Debug)]`
+   |
+LL | #[derive(Debug)]
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/derives/derives-span-Debug-tuple-struct.stderr
+++ b/src/test/ui/derives/derives-span-Debug-tuple-struct.stderr
@@ -10,6 +10,10 @@ LL |     Error
    = help: the trait `Debug` is not implemented for `Error`
    = note: add `#[derive(Debug)]` to `Error` or manually `impl Debug for Error`
    = note: this error originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider annotating `Error` with `#[derive(Debug)]`
+   |
+LL | #[derive(Debug)]
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/derives/derives-span-Default-struct.stderr
+++ b/src/test/ui/derives/derives-span-Default-struct.stderr
@@ -8,6 +8,10 @@ LL |     x: Error
    |     ^^^^^^^^ the trait `Default` is not implemented for `Error`
    |
    = note: this error originates in the derive macro `Default` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider annotating `Error` with `#[derive(Default)]`
+   |
+LL | #[derive(Default)]
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/derives/derives-span-Default-tuple-struct.stderr
+++ b/src/test/ui/derives/derives-span-Default-tuple-struct.stderr
@@ -8,6 +8,10 @@ LL |     Error
    |     ^^^^^ the trait `Default` is not implemented for `Error`
    |
    = note: this error originates in the derive macro `Default` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider annotating `Error` with `#[derive(Default)]`
+   |
+LL | #[derive(Default)]
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/derives/derives-span-Eq-enum-struct-variant.stderr
+++ b/src/test/ui/derives/derives-span-Eq-enum-struct-variant.stderr
@@ -13,6 +13,10 @@ note: required by a bound in `AssertParamIsEq`
 LL | pub struct AssertParamIsEq<T: Eq + ?Sized> {
    |                               ^^ required by this bound in `AssertParamIsEq`
    = note: this error originates in the derive macro `Eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider annotating `Error` with `#[derive(Eq)]`
+   |
+LL | #[derive(Eq)]
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/derives/derives-span-Eq-enum.stderr
+++ b/src/test/ui/derives/derives-span-Eq-enum.stderr
@@ -13,6 +13,10 @@ note: required by a bound in `AssertParamIsEq`
 LL | pub struct AssertParamIsEq<T: Eq + ?Sized> {
    |                               ^^ required by this bound in `AssertParamIsEq`
    = note: this error originates in the derive macro `Eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider annotating `Error` with `#[derive(Eq)]`
+   |
+LL | #[derive(Eq)]
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/derives/derives-span-Eq-struct.stderr
+++ b/src/test/ui/derives/derives-span-Eq-struct.stderr
@@ -13,6 +13,10 @@ note: required by a bound in `AssertParamIsEq`
 LL | pub struct AssertParamIsEq<T: Eq + ?Sized> {
    |                               ^^ required by this bound in `AssertParamIsEq`
    = note: this error originates in the derive macro `Eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider annotating `Error` with `#[derive(Eq)]`
+   |
+LL | #[derive(Eq)]
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/derives/derives-span-Eq-tuple-struct.stderr
+++ b/src/test/ui/derives/derives-span-Eq-tuple-struct.stderr
@@ -13,6 +13,10 @@ note: required by a bound in `AssertParamIsEq`
 LL | pub struct AssertParamIsEq<T: Eq + ?Sized> {
    |                               ^^ required by this bound in `AssertParamIsEq`
    = note: this error originates in the derive macro `Eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider annotating `Error` with `#[derive(Eq)]`
+   |
+LL | #[derive(Eq)]
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/derives/derives-span-Hash-enum-struct-variant.stderr
+++ b/src/test/ui/derives/derives-span-Hash-enum-struct-variant.stderr
@@ -8,6 +8,10 @@ LL |      x: Error
    |      ^^^^^^^^ the trait `Hash` is not implemented for `Error`
    |
    = note: this error originates in the derive macro `Hash` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider annotating `Error` with `#[derive(Hash)]`
+   |
+LL | #[derive(Hash)]
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/derives/derives-span-Hash-enum.stderr
+++ b/src/test/ui/derives/derives-span-Hash-enum.stderr
@@ -8,6 +8,10 @@ LL |      Error
    |      ^^^^^ the trait `Hash` is not implemented for `Error`
    |
    = note: this error originates in the derive macro `Hash` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider annotating `Error` with `#[derive(Hash)]`
+   |
+LL | #[derive(Hash)]
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/derives/derives-span-Hash-struct.stderr
+++ b/src/test/ui/derives/derives-span-Hash-struct.stderr
@@ -8,6 +8,10 @@ LL |     x: Error
    |     ^^^^^^^^ the trait `Hash` is not implemented for `Error`
    |
    = note: this error originates in the derive macro `Hash` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider annotating `Error` with `#[derive(Hash)]`
+   |
+LL | #[derive(Hash)]
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/derives/derives-span-Hash-tuple-struct.stderr
+++ b/src/test/ui/derives/derives-span-Hash-tuple-struct.stderr
@@ -8,6 +8,10 @@ LL |     Error
    |     ^^^^^ the trait `Hash` is not implemented for `Error`
    |
    = note: this error originates in the derive macro `Hash` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider annotating `Error` with `#[derive(Hash)]`
+   |
+LL | #[derive(Hash)]
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/derives/derives-span-Ord-enum-struct-variant.stderr
+++ b/src/test/ui/derives/derives-span-Ord-enum-struct-variant.stderr
@@ -8,6 +8,10 @@ LL |      x: Error
    |      ^^^^^^^^ the trait `Ord` is not implemented for `Error`
    |
    = note: this error originates in the derive macro `Ord` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider annotating `Error` with `#[derive(Ord)]`
+   |
+LL | #[derive(Ord)]
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/derives/derives-span-Ord-enum.stderr
+++ b/src/test/ui/derives/derives-span-Ord-enum.stderr
@@ -8,6 +8,10 @@ LL |      Error
    |      ^^^^^ the trait `Ord` is not implemented for `Error`
    |
    = note: this error originates in the derive macro `Ord` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider annotating `Error` with `#[derive(Ord)]`
+   |
+LL | #[derive(Ord)]
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/derives/derives-span-Ord-struct.stderr
+++ b/src/test/ui/derives/derives-span-Ord-struct.stderr
@@ -8,6 +8,10 @@ LL |     x: Error
    |     ^^^^^^^^ the trait `Ord` is not implemented for `Error`
    |
    = note: this error originates in the derive macro `Ord` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider annotating `Error` with `#[derive(Ord)]`
+   |
+LL | #[derive(Ord)]
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/derives/derives-span-Ord-tuple-struct.stderr
+++ b/src/test/ui/derives/derives-span-Ord-tuple-struct.stderr
@@ -8,6 +8,10 @@ LL |     Error
    |     ^^^^^ the trait `Ord` is not implemented for `Error`
    |
    = note: this error originates in the derive macro `Ord` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider annotating `Error` with `#[derive(Ord)]`
+   |
+LL | #[derive(Ord)]
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/derives/derives-span-PartialOrd-enum-struct-variant.stderr
+++ b/src/test/ui/derives/derives-span-PartialOrd-enum-struct-variant.stderr
@@ -9,6 +9,10 @@ LL |      x: Error
    |
    = help: the trait `PartialOrd` is not implemented for `Error`
    = note: this error originates in the derive macro `PartialOrd` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider annotating `Error` with `#[derive(PartialOrd)]`
+   |
+LL | #[derive(PartialOrd)]
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/derives/derives-span-PartialOrd-enum.stderr
+++ b/src/test/ui/derives/derives-span-PartialOrd-enum.stderr
@@ -9,6 +9,10 @@ LL |      Error
    |
    = help: the trait `PartialOrd` is not implemented for `Error`
    = note: this error originates in the derive macro `PartialOrd` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider annotating `Error` with `#[derive(PartialOrd)]`
+   |
+LL | #[derive(PartialOrd)]
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/derives/derives-span-PartialOrd-struct.stderr
+++ b/src/test/ui/derives/derives-span-PartialOrd-struct.stderr
@@ -9,6 +9,10 @@ LL |     x: Error
    |
    = help: the trait `PartialOrd` is not implemented for `Error`
    = note: this error originates in the derive macro `PartialOrd` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider annotating `Error` with `#[derive(PartialOrd)]`
+   |
+LL | #[derive(PartialOrd)]
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/derives/derives-span-PartialOrd-tuple-struct.stderr
+++ b/src/test/ui/derives/derives-span-PartialOrd-tuple-struct.stderr
@@ -9,6 +9,10 @@ LL |     Error
    |
    = help: the trait `PartialOrd` is not implemented for `Error`
    = note: this error originates in the derive macro `PartialOrd` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider annotating `Error` with `#[derive(PartialOrd)]`
+   |
+LL | #[derive(PartialOrd)]
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/derives/deriving-no-inner-impl-error-message.stderr
+++ b/src/test/ui/derives/deriving-no-inner-impl-error-message.stderr
@@ -48,6 +48,10 @@ LL |     x: NoCloneOrEq
    |     ^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `NoCloneOrEq`
    |
    = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider annotating `NoCloneOrEq` with `#[derive(Clone)]`
+   |
+LL | #[derive(Clone)]
+   |
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/error-codes/E0277-3.rs
+++ b/src/test/ui/error-codes/E0277-3.rs
@@ -1,0 +1,8 @@
+fn foo<T: PartialEq>(_: T) {}
+
+struct S;
+
+fn main() {
+    foo(S);
+    //~^ ERROR can't compare `S` with `S`
+}

--- a/src/test/ui/error-codes/E0277-3.stderr
+++ b/src/test/ui/error-codes/E0277-3.stderr
@@ -1,0 +1,22 @@
+error[E0277]: can't compare `S` with `S`
+  --> $DIR/E0277-3.rs:6:9
+   |
+LL |     foo(S);
+   |     --- ^ no implementation for `S == S`
+   |     |
+   |     required by a bound introduced by this call
+   |
+   = help: the trait `PartialEq` is not implemented for `S`
+note: required by a bound in `foo`
+  --> $DIR/E0277-3.rs:1:11
+   |
+LL | fn foo<T: PartialEq>(_: T) {}
+   |           ^^^^^^^^^ required by this bound in `foo`
+help: consider annotating `S` with `#[derive(PartialEq)]`
+   |
+LL | #[derive(PartialEq)]
+   |
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/feature-gates/feature-gate-default_type_parameter_fallback.stderr
+++ b/src/test/ui/feature-gates/feature-gate-default_type_parameter_fallback.stderr
@@ -2,7 +2,7 @@ error: defaults for type parameters are only allowed in `struct`, `enum`, `type`
   --> $DIR/feature-gate-default_type_parameter_fallback.rs:3:8
    |
 LL | fn avg<T=i32>(_: T) {}
-   |        ^
+   |        ^^^^^
    |
    = note: `#[deny(invalid_type_param_default)]` on by default
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
@@ -12,7 +12,7 @@ error: defaults for type parameters are only allowed in `struct`, `enum`, `type`
   --> $DIR/feature-gate-default_type_parameter_fallback.rs:8:6
    |
 LL | impl<T=i32> S<T> {}
-   |      ^
+   |      ^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #36887 <https://github.com/rust-lang/rust/issues/36887>

--- a/src/test/ui/generic-associated-types/issue-87429-associated-type-default.stderr
+++ b/src/test/ui/generic-associated-types/issue-87429-associated-type-default.stderr
@@ -10,6 +10,10 @@ note: required by a bound in `Family2::Member`
    |
 LL |     type Member<'a>: for<'b> PartialEq<Self::Member<'b>> = Foo;
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `Family2::Member`
+help: consider annotating `Foo` with `#[derive(PartialEq)]`
+   |
+LL | #[derive(PartialEq)]
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/generic-associated-types/issue-87429-specialization.stderr
+++ b/src/test/ui/generic-associated-types/issue-87429-specialization.stderr
@@ -20,6 +20,10 @@ note: required by a bound in `Family::Member`
    |
 LL |     type Member<'a>: for<'b> PartialEq<Self::Member<'b>>;
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `Family::Member`
+help: consider annotating `Foo` with `#[derive(PartialEq)]`
+   |
+LL | #[derive(PartialEq)]
+   |
 
 error: aborting due to previous error; 1 warning emitted
 

--- a/src/test/ui/generics/generic-impl-more-params-with-defaults.stderr
+++ b/src/test/ui/generics/generic-impl-more-params-with-defaults.stderr
@@ -10,7 +10,7 @@ note: struct defined here, with at most 2 generic parameters: `T`, `A`
   --> $DIR/generic-impl-more-params-with-defaults.rs:5:8
    |
 LL | struct Vec<T, A = Heap>(
-   |        ^^^ -  -
+   |        ^^^ -  --------
 
 error: aborting due to previous error
 

--- a/src/test/ui/generics/generic-type-more-params-with-defaults.stderr
+++ b/src/test/ui/generics/generic-type-more-params-with-defaults.stderr
@@ -10,7 +10,7 @@ note: struct defined here, with at most 2 generic parameters: `T`, `A`
   --> $DIR/generic-type-more-params-with-defaults.rs:5:8
    |
 LL | struct Vec<T, A = Heap>(
-   |        ^^^ -  -
+   |        ^^^ -  --------
 
 error: aborting due to previous error
 

--- a/src/test/ui/generics/issue-61631-default-type-param-can-reference-self-in-trait.stderr
+++ b/src/test/ui/generics/issue-61631-default-type-param-can-reference-self-in-trait.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `Tsized`
   --> $DIR/issue-61631-default-type-param-can-reference-self-in-trait.rs:17:14
    |
 LL | trait Tsized<P: Sized = [Self]> {}
-   |              ^ required by this bound in `Tsized`
+   |              ^^^^^^^^^^^^^^^^^ required by this bound in `Tsized`
 
 error: aborting due to previous error
 

--- a/src/test/ui/generics/wrong-number-of-args.stderr
+++ b/src/test/ui/generics/wrong-number-of-args.stderr
@@ -287,7 +287,7 @@ note: struct defined here, with at most 3 generic parameters: `A`, `B`, `C`
   --> $DIR/wrong-number-of-args.rs:78:12
    |
 LL |     struct Ty<A, B, C = &'static str>;
-   |            ^^ -  -  -
+   |            ^^ -  -  ----------------
 
 error[E0107]: this struct takes at least 2 generic arguments but 0 generic arguments were supplied
   --> $DIR/wrong-number-of-args.rs:96:14
@@ -922,7 +922,7 @@ note: struct defined here, with at most 3 generic parameters: `K`, `V`, `S`
   --> $SRC_DIR/std/src/collections/hash/map.rs:LL:COL
    |
 LL | pub struct HashMap<K, V, S = RandomState> {
-   |            ^^^^^^^ -  -  -
+   |            ^^^^^^^ -  -  ---------------
 
 error[E0107]: this struct takes at least 2 generic arguments but 0 generic arguments were supplied
   --> $DIR/wrong-number-of-args.rs:319:18

--- a/src/test/ui/impl-trait/where-allowed.stderr
+++ b/src/test/ui/impl-trait/where-allowed.stderr
@@ -293,7 +293,7 @@ error: defaults for type parameters are only allowed in `struct`, `enum`, `type`
   --> $DIR/where-allowed.rs:234:7
    |
 LL | impl <T = impl Debug> T {}
-   |       ^
+   |       ^^^^^^^^^^^^^^
    |
    = note: `#[deny(invalid_type_param_default)]` on by default
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
@@ -303,7 +303,7 @@ error: defaults for type parameters are only allowed in `struct`, `enum`, `type`
   --> $DIR/where-allowed.rs:241:36
    |
 LL | fn in_method_generic_param_default<T = impl Debug>(_: T) {}
-   |                                    ^
+   |                                    ^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #36887 <https://github.com/rust-lang/rust/issues/36887>

--- a/src/test/ui/issues/issue-20162.stderr
+++ b/src/test/ui/issues/issue-20162.stderr
@@ -9,6 +9,10 @@ note: required by a bound in `slice::<impl [T]>::sort`
    |
 LL |         T: Ord,
    |            ^^^ required by this bound in `slice::<impl [T]>::sort`
+help: consider annotating `X` with `#[derive(Ord)]`
+   |
+LL | #[derive(Ord)]
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-21160.stderr
+++ b/src/test/ui/issues/issue-21160.stderr
@@ -7,6 +7,10 @@ LL | struct Foo(Bar);
    |            ^^^ the trait `Hash` is not implemented for `Bar`
    |
    = note: this error originates in the derive macro `Hash` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider annotating `Bar` with `#[derive(Hash)]`
+   |
+LL | #[derive(Hash)]
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-34229.stderr
+++ b/src/test/ui/issues/issue-34229.stderr
@@ -8,6 +8,10 @@ LL | #[derive(PartialEq, PartialOrd)] struct Nope(Comparable);
    |
    = help: the trait `PartialOrd` is not implemented for `Comparable`
    = note: this error originates in the derive macro `PartialOrd` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider annotating `Comparable` with `#[derive(PartialOrd)]`
+   |
+LL | #[derive(PartialEq)] #[derive(PartialOrd)]
+   |                      +++++++++++++++++++++
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-78957.stderr
+++ b/src/test/ui/issues/issue-78957.stderr
@@ -2,13 +2,13 @@ error[E0518]: attribute should be applied to function or closure
   --> $DIR/issue-78957.rs:5:16
    |
 LL | pub struct Foo<#[inline] const N: usize>;
-   |                ^^^^^^^^^       - not a function or closure
+   |                ^^^^^^^^^ -------------- not a function or closure
 
 error: attribute should be applied to a function
   --> $DIR/issue-78957.rs:7:16
    |
 LL | pub struct Bar<#[cold] const N: usize>;
-   |                ^^^^^^^       - not a function
+   |                ^^^^^^^ -------------- not a function
    |
 note: the lint level is defined here
   --> $DIR/issue-78957.rs:1:9
@@ -21,7 +21,7 @@ error[E0517]: attribute should be applied to a struct, enum, or union
   --> $DIR/issue-78957.rs:10:23
    |
 LL | pub struct Baz<#[repr(C)] const N: usize>;
-   |                       ^         - not a struct, enum, or union
+   |                       ^   -------------- not a struct, enum, or union
 
 error[E0518]: attribute should be applied to function or closure
   --> $DIR/issue-78957.rs:13:17

--- a/src/test/ui/kindck/kindck-copy.stderr
+++ b/src/test/ui/kindck/kindck-copy.stderr
@@ -129,10 +129,6 @@ note: required by a bound in `assert_copy`
    |
 LL | fn assert_copy<T:Copy>() { }
    |                  ^^^^ required by this bound in `assert_copy`
-help: consider annotating `MyNoncopyStruct` with `#[derive(Copy)]`
-   |
-LL | #[derive(Copy)]
-   |
 
 error[E0277]: the trait bound `Rc<isize>: Copy` is not satisfied
   --> $DIR/kindck-copy.rs:67:19

--- a/src/test/ui/kindck/kindck-copy.stderr
+++ b/src/test/ui/kindck/kindck-copy.stderr
@@ -129,6 +129,10 @@ note: required by a bound in `assert_copy`
    |
 LL | fn assert_copy<T:Copy>() { }
    |                  ^^^^ required by this bound in `assert_copy`
+help: consider annotating `MyNoncopyStruct` with `#[derive(Copy)]`
+   |
+LL | #[derive(Copy)]
+   |
 
 error[E0277]: the trait bound `Rc<isize>: Copy` is not satisfied
   --> $DIR/kindck-copy.rs:67:19

--- a/src/test/ui/kindck/kindck-impl-type-params.nll.stderr
+++ b/src/test/ui/kindck/kindck-impl-type-params.nll.stderr
@@ -91,6 +91,10 @@ note: required because of the requirements on the impl of `Gettable<Foo>` for `S
 LL | impl<T: Send + Copy + 'static> Gettable<T> for S<T> {}
    |                                ^^^^^^^^^^^     ^^^^
    = note: required for the cast to the object type `dyn Gettable<Foo>`
+help: consider annotating `Foo` with `#[derive(Copy)]`
+   |
+LL |     #[derive(Copy)]
+   |
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/kindck/kindck-impl-type-params.stderr
+++ b/src/test/ui/kindck/kindck-impl-type-params.stderr
@@ -99,6 +99,10 @@ note: required because of the requirements on the impl of `Gettable<Foo>` for `S
 LL | impl<T: Send + Copy + 'static> Gettable<T> for S<T> {}
    |                                ^^^^^^^^^^^     ^^^^
    = note: required for the cast to the object type `dyn Gettable<Foo>`
+help: consider annotating `Foo` with `#[derive(Copy)]`
+   |
+LL |     #[derive(Copy)]
+   |
 
 error: aborting due to 7 previous errors
 

--- a/src/test/ui/malformed/malformed-derive-entry.stderr
+++ b/src/test/ui/malformed/malformed-derive-entry.stderr
@@ -28,6 +28,10 @@ note: required by a bound in `Copy`
 LL | pub trait Copy: Clone {
    |                 ^^^^^ required by this bound in `Copy`
    = note: this error originates in the derive macro `Copy` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider annotating `Test1` with `#[derive(Clone)]`
+   |
+LL | #[derive(Clone)]
+   |
 
 error[E0277]: the trait bound `Test2: Clone` is not satisfied
   --> $DIR/malformed-derive-entry.rs:6:10
@@ -41,6 +45,10 @@ note: required by a bound in `Copy`
 LL | pub trait Copy: Clone {
    |                 ^^^^^ required by this bound in `Copy`
    = note: this error originates in the derive macro `Copy` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider annotating `Test2` with `#[derive(Clone)]`
+   |
+LL | #[derive(Clone)]
+   |
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/mir/thir-constparam-temp.stderr
+++ b/src/test/ui/mir/thir-constparam-temp.stderr
@@ -13,10 +13,10 @@ note: mutable reference created due to call to this method
 LL |     fn mut_self(&mut self) {}
    |     ^^^^^^^^^^^^^^^^^^^^^^
 note: `const` item defined here
-  --> $DIR/thir-constparam-temp.rs:13:14
+  --> $DIR/thir-constparam-temp.rs:13:8
    |
 LL | fn foo<const YIKES: Yikes>() {
-   |              ^^^^^
+   |        ^^^^^^^^^^^^^^^^^^
 
 warning: 1 warning emitted
 

--- a/src/test/ui/mismatched_types/method-help-unsatisfied-bound.stderr
+++ b/src/test/ui/mismatched_types/method-help-unsatisfied-bound.stderr
@@ -11,6 +11,10 @@ note: required by a bound in `Result::<T, E>::unwrap`
    |
 LL |         E: fmt::Debug,
    |            ^^^^^^^^^^ required by this bound in `Result::<T, E>::unwrap`
+help: consider annotating `Foo` with `#[derive(Debug)]`
+   |
+LL | #[derive(Debug)]
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/missing/missing-items/missing-type-parameter2.stderr
+++ b/src/test/ui/missing/missing-items/missing-type-parameter2.stderr
@@ -99,10 +99,10 @@ LL | impl X<{ N }> {}
    |        +   +
 
 error: defaults for const parameters are only allowed in `struct`, `enum`, `type`, or `trait` definitions
-  --> $DIR/missing-type-parameter2.rs:6:15
+  --> $DIR/missing-type-parameter2.rs:6:9
    |
 LL | impl<T, const A: u8 = 2> X<N> {}
-   |               ^
+   |         ^^^^^^^^^^^^^^^
 
 error[E0747]: unresolved item provided when a constant was expected
   --> $DIR/missing-type-parameter2.rs:6:28

--- a/src/test/ui/not-clone-closure.stderr
+++ b/src/test/ui/not-clone-closure.stderr
@@ -11,6 +11,10 @@ LL |       let hello = hello.clone();
    |                         ^^^^^ within `[closure@$DIR/not-clone-closure.rs:7:17: 9:6]`, the trait `Clone` is not implemented for `S`
    |
    = note: required because it appears within the type `[closure@$DIR/not-clone-closure.rs:7:17: 9:6]`
+help: consider annotating `S` with `#[derive(Clone)]`
+   |
+LL | #[derive(Clone)]
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/on-unimplemented/no-debug.stderr
+++ b/src/test/ui/on-unimplemented/no-debug.stderr
@@ -7,6 +7,10 @@ LL |     println!("{:?} {:?}", Foo, Bar);
    = help: the trait `Debug` is not implemented for `Foo`
    = note: add `#[derive(Debug)]` to `Foo` or manually `impl Debug for Foo`
    = note: this error originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider annotating `Foo` with `#[derive(Debug)]`
+   |
+LL | #[derive(Debug)]
+   |
 
 error[E0277]: `Bar` doesn't implement `Debug`
   --> $DIR/no-debug.rs:10:32

--- a/src/test/ui/polymorphization/const_parameters/closures.stderr
+++ b/src/test/ui/polymorphization/const_parameters/closures.stderr
@@ -11,7 +11,7 @@ error: item has unused generic parameters
   --> $DIR/closures.rs:19:19
    |
 LL | pub fn unused<const T: usize>() -> usize {
-   |                     - generic parameter `T` is unused
+   |               -------------- generic parameter `T` is unused
 LL |
 LL |     let add_one = |x: usize| x + 1;
    |                   ^^^^^^^^^^^^^^^^
@@ -20,13 +20,13 @@ error: item has unused generic parameters
   --> $DIR/closures.rs:17:8
    |
 LL | pub fn unused<const T: usize>() -> usize {
-   |        ^^^^^^       - generic parameter `T` is unused
+   |        ^^^^^^ -------------- generic parameter `T` is unused
 
 error: item has unused generic parameters
   --> $DIR/closures.rs:28:19
    |
 LL | pub fn used_parent<const T: usize>() -> usize {
-   |                          - generic parameter `T` is unused
+   |                    -------------- generic parameter `T` is unused
 LL |     let x: usize = T;
 LL |     let add_one = |x: usize| x + 1;
    |                   ^^^^^^^^^^^^^^^^
@@ -35,7 +35,7 @@ error: item has unused generic parameters
   --> $DIR/closures.rs:48:13
    |
 LL | pub fn unused_upvar<const T: usize>() -> usize {
-   |                           - generic parameter `T` is unused
+   |                     -------------- generic parameter `T` is unused
 LL |     let x: usize = T;
 LL |     let y = || x;
    |             ^^^^

--- a/src/test/ui/polymorphization/const_parameters/functions.stderr
+++ b/src/test/ui/polymorphization/const_parameters/functions.stderr
@@ -11,7 +11,7 @@ error: item has unused generic parameters
   --> $DIR/functions.rs:15:8
    |
 LL | pub fn unused<const T: usize>() {
-   |        ^^^^^^       - generic parameter `T` is unused
+   |        ^^^^^^ -------------- generic parameter `T` is unused
 
 error: aborting due to previous error; 1 warning emitted
 

--- a/src/test/ui/polymorphization/generators.stderr
+++ b/src/test/ui/polymorphization/generators.stderr
@@ -23,7 +23,7 @@ error: item has unused generic parameters
   --> $DIR/generators.rs:60:5
    |
 LL |   pub fn unused_const<const T: u32>() -> impl Generator<(), Yield = u32, Return = u32> + Unpin {
-   |                             - generic parameter `T` is unused
+   |                       ------------ generic parameter `T` is unused
 LL | /     || {
 LL | |
 LL | |         yield 1;

--- a/src/test/ui/repeat-to-run-dtor-twice.stderr
+++ b/src/test/ui/repeat-to-run-dtor-twice.stderr
@@ -5,6 +5,10 @@ LL |     let _ = [ a; 5 ];
    |             ^^^^^^^^ the trait `Copy` is not implemented for `Foo`
    |
    = note: the `Copy` trait is required because the repeated element will be copied
+help: consider annotating `Foo` with `#[derive(Copy)]`
+   |
+LL | #[derive(Copy)]
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/rfc-2361-dbg-macro/dbg-macro-requires-debug.stderr
+++ b/src/test/ui/rfc-2361-dbg-macro/dbg-macro-requires-debug.stderr
@@ -7,6 +7,10 @@ LL |     let _: NotDebug = dbg!(NotDebug);
    = help: the trait `Debug` is not implemented for `NotDebug`
    = note: add `#[derive(Debug)]` to `NotDebug` or manually `impl Debug for NotDebug`
    = note: this error originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider annotating `NotDebug` with `#[derive(Debug)]`
+   |
+LL | #[derive(Debug)]
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/rfc-2632-const-trait-impl/call-generic-method-nonconst.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/call-generic-method-nonconst.stderr
@@ -17,6 +17,10 @@ note: required by a bound in `equals_self`
    |
 LL | const fn equals_self<T: ~const PartialEq>(t: &T) -> bool {
    |                         ^^^^^^^^^^^^^^^^ required by this bound in `equals_self`
+help: consider annotating `S` with `#[derive(PartialEq)]`
+   |
+LL | #[derive(PartialEq)]
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/save-analysis/issue-89066.stderr
+++ b/src/test/ui/save-analysis/issue-89066.stderr
@@ -31,7 +31,7 @@ note: struct defined here, with 2 generic parameters: `T`, `N`
   --> $DIR/issue-89066.rs:8:8
    |
 LL | struct All<'a, T, const N: usize> {
-   |        ^^^     -        -
+   |        ^^^     -  --------------
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/specialization/issue-59435.stderr
+++ b/src/test/ui/specialization/issue-59435.stderr
@@ -9,6 +9,10 @@ note: required by a bound in `MyTrait::MyType`
    |
 LL |     type MyType: Default;
    |                  ^^^^^^^ required by this bound in `MyTrait::MyType`
+help: consider annotating `MyStruct` with `#[derive(Default)]`
+   |
+LL | #[derive(Default)]
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/structs/struct-path-alias-bounds.stderr
+++ b/src/test/ui/structs/struct-path-alias-bounds.stderr
@@ -9,6 +9,10 @@ note: required by a bound in `S`
    |
 LL | struct S<T: Clone> { a: T }
    |             ^^^^^ required by this bound in `S`
+help: consider annotating `NoClone` with `#[derive(Clone)]`
+   |
+LL | #[derive(Clone)]
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/suggestions/derive-macro-missing-bounds.stderr
+++ b/src/test/ui/suggestions/derive-macro-missing-bounds.stderr
@@ -9,6 +9,10 @@ LL |     struct Outer<T>(Inner<T>);
    = help: the trait `Debug` is not implemented for `a::Inner<T>`
    = note: add `#[derive(Debug)]` to `a::Inner<T>` or manually `impl Debug for a::Inner<T>`
    = note: this error originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider annotating `a::Inner<T>` with `#[derive(Debug)]`
+   |
+LL |     #[derive(Debug)]
+   |
 help: consider introducing a `where` bound, but there might be an alternative better way to express this requirement
    |
 LL |     struct Outer<T>(Inner<T>) where a::Inner<T>: Debug;

--- a/src/test/ui/suggestions/issue-84973-blacklist.stderr
+++ b/src/test/ui/suggestions/issue-84973-blacklist.stderr
@@ -25,6 +25,10 @@ note: required by a bound in `f_clone`
    |
 LL | fn f_clone<T: Clone>(t: T) {}
    |               ^^^^^ required by this bound in `f_clone`
+help: consider annotating `S` with `#[derive(Clone)]`
+   |
+LL | #[derive(Clone)]
+   |
 
 error[E0277]: `[static generator@$DIR/issue-84973-blacklist.rs:17:13: 17:33]` cannot be unpinned
   --> $DIR/issue-84973-blacklist.rs:17:5

--- a/src/test/ui/suggestions/lifetimes/missing-lifetimes-in-signature-before-const.fixed
+++ b/src/test/ui/suggestions/lifetimes/missing-lifetimes-in-signature-before-const.fixed
@@ -1,0 +1,10 @@
+// run-rustfix
+// https://github.com/rust-lang/rust/issues/95616
+
+fn buggy_const<'a, const N: usize>(_a: &'a Option<[u8; N]>, _f: &'a str) -> &'a str { //~ERROR [E0106]
+    return "";
+}
+
+fn main() {
+    buggy_const(&Some([69,69,69,69,0]), "test");
+}

--- a/src/test/ui/suggestions/lifetimes/missing-lifetimes-in-signature-before-const.rs
+++ b/src/test/ui/suggestions/lifetimes/missing-lifetimes-in-signature-before-const.rs
@@ -1,0 +1,10 @@
+// run-rustfix
+// https://github.com/rust-lang/rust/issues/95616
+
+fn buggy_const<const N: usize>(_a: &Option<[u8; N]>, _f: &str) -> &str { //~ERROR [E0106]
+    return "";
+}
+
+fn main() {
+    buggy_const(&Some([69,69,69,69,0]), "test");
+}

--- a/src/test/ui/suggestions/lifetimes/missing-lifetimes-in-signature-before-const.stderr
+++ b/src/test/ui/suggestions/lifetimes/missing-lifetimes-in-signature-before-const.stderr
@@ -1,0 +1,15 @@
+error[E0106]: missing lifetime specifier
+  --> $DIR/missing-lifetimes-in-signature-before-const.rs:4:67
+   |
+LL | fn buggy_const<const N: usize>(_a: &Option<[u8; N]>, _f: &str) -> &str {
+   |                                    ----------------      ----     ^ expected named lifetime parameter
+   |
+   = help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from `_a` or `_f`
+help: consider introducing a named lifetime parameter
+   |
+LL | fn buggy_const<'a, const N: usize>(_a: &'a Option<[u8; N]>, _f: &'a str) -> &'a str {
+   |                +++                      ++                       ++          ++
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0106`.

--- a/src/test/ui/traits/inductive-overflow/supertrait-auto-trait.stderr
+++ b/src/test/ui/traits/inductive-overflow/supertrait-auto-trait.stderr
@@ -24,6 +24,10 @@ note: required by a bound in `copy`
    |
 LL | fn copy<T: Magic>(x: T) -> (T, T) { (x, x) }
    |            ^^^^^ required by this bound in `copy`
+help: consider annotating `NoClone` with `#[derive(Copy)]`
+   |
+LL | #[derive(Copy)]
+   |
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/traits/issue-71136.stderr
+++ b/src/test/ui/traits/issue-71136.stderr
@@ -9,6 +9,10 @@ LL |     the_foos: Vec<Foo>,
    |
    = note: required because of the requirements on the impl of `Clone` for `Vec<Foo>`
    = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider annotating `Foo` with `#[derive(Clone)]`
+   |
+LL | #[derive(Clone)]
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/type-alias-impl-trait/generic_duplicate_param_use.stderr
+++ b/src/test/ui/type-alias-impl-trait/generic_duplicate_param_use.stderr
@@ -29,10 +29,10 @@ LL |     t
    |     ^
    |
 note: constant used multiple times
-  --> $DIR/generic_duplicate_param_use.rs:12:22
+  --> $DIR/generic_duplicate_param_use.rs:12:16
    |
 LL | type TwoConsts<const X: usize, const Y: usize> = impl Debug;
-   |                      ^               ^
+   |                ^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/type-alias-impl-trait/generic_nondefining_use.stderr
+++ b/src/test/ui/type-alias-impl-trait/generic_nondefining_use.stderr
@@ -26,10 +26,10 @@ LL |     7u32
    |     ^^^^
    |
 note: used non-generic constant `123_usize` for generic parameter
-  --> $DIR/generic_nondefining_use.rs:11:21
+  --> $DIR/generic_nondefining_use.rs:11:15
    |
 LL | type OneConst<const X: usize> = impl Debug;
-   |                     ^
+   |               ^^^^^^^^^^^^^^
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/type/type-check-defaults.stderr
+++ b/src/test/ui/type/type-check-defaults.stderr
@@ -2,7 +2,7 @@ error[E0277]: a value of type `i32` cannot be built from an iterator over elemen
   --> $DIR/type-check-defaults.rs:6:19
    |
 LL | struct WellFormed<Z = Foo<i32, i32>>(Z);
-   |                   ^ value of type `i32` cannot be built from `std::iter::Iterator<Item=i32>`
+   |                   ^^^^^^^^^^^^^^^^^ value of type `i32` cannot be built from `std::iter::Iterator<Item=i32>`
    |
    = help: the trait `FromIterator<i32>` is not implemented for `i32`
 note: required by a bound in `Foo`
@@ -15,7 +15,7 @@ error[E0277]: a value of type `i32` cannot be built from an iterator over elemen
   --> $DIR/type-check-defaults.rs:8:27
    |
 LL | struct WellFormedNoBounds<Z:?Sized = Foo<i32, i32>>(Z);
-   |                           ^ value of type `i32` cannot be built from `std::iter::Iterator<Item=i32>`
+   |                           ^^^^^^^^^^^^^^^^^^^^^^^^ value of type `i32` cannot be built from `std::iter::Iterator<Item=i32>`
    |
    = help: the trait `FromIterator<i32>` is not implemented for `i32`
 note: required by a bound in `Foo`

--- a/src/test/ui/union/union-derive-clone.mirunsafeck.stderr
+++ b/src/test/ui/union/union-derive-clone.mirunsafeck.stderr
@@ -38,6 +38,10 @@ note: required by a bound in `AssertParamIsCopy`
 LL | pub struct AssertParamIsCopy<T: Copy + ?Sized> {
    |                                 ^^^^ required by this bound in `AssertParamIsCopy`
    = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider annotating `U1` with `#[derive(Copy)]`
+   |
+LL | #[derive(Copy)]
+   |
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/union/union-derive-clone.thirunsafeck.stderr
+++ b/src/test/ui/union/union-derive-clone.thirunsafeck.stderr
@@ -38,6 +38,10 @@ note: required by a bound in `AssertParamIsCopy`
 LL | pub struct AssertParamIsCopy<T: Copy + ?Sized> {
    |                                 ^^^^ required by this bound in `AssertParamIsCopy`
    = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider annotating `U1` with `#[derive(Copy)]`
+   |
+LL | #[derive(Copy)]
+   |
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/union/union-derive-eq.mirunsafeck.stderr
+++ b/src/test/ui/union/union-derive-eq.mirunsafeck.stderr
@@ -13,6 +13,10 @@ note: required by a bound in `AssertParamIsEq`
 LL | pub struct AssertParamIsEq<T: Eq + ?Sized> {
    |                               ^^ required by this bound in `AssertParamIsEq`
    = note: this error originates in the derive macro `Eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider annotating `PartialEqNotEq` with `#[derive(Eq)]`
+   |
+LL | #[derive(Eq)]
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/union/union-derive-eq.thirunsafeck.stderr
+++ b/src/test/ui/union/union-derive-eq.thirunsafeck.stderr
@@ -13,6 +13,10 @@ note: required by a bound in `AssertParamIsEq`
 LL | pub struct AssertParamIsEq<T: Eq + ?Sized> {
    |                               ^^ required by this bound in `AssertParamIsEq`
    = note: this error originates in the derive macro `Eq` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider annotating `PartialEqNotEq` with `#[derive(Eq)]`
+   |
+LL | #[derive(Eq)]
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-const-type.stderr
+++ b/src/test/ui/wf/wf-const-type.stderr
@@ -10,6 +10,10 @@ note: required by a bound in `IsCopy`
    |
 LL | struct IsCopy<T:Copy> { t: T }
    |                 ^^^^ required by this bound in `IsCopy`
+help: consider annotating `NotCopy` with `#[derive(Copy)]`
+   |
+LL | #[derive(Copy)]
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-static-type.stderr
+++ b/src/test/ui/wf/wf-static-type.stderr
@@ -10,6 +10,10 @@ note: required by a bound in `IsCopy`
    |
 LL | struct IsCopy<T:Copy> { t: T }
    |                 ^^^^ required by this bound in `IsCopy`
+help: consider annotating `NotCopy` with `#[derive(Copy)]`
+   |
+LL | #[derive(Copy)]
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/where-clauses/where-clauses-method-unsatisfied.stderr
+++ b/src/test/ui/where-clauses/where-clauses-method-unsatisfied.stderr
@@ -11,6 +11,10 @@ note: required by a bound in `Foo::<T>::equals`
    |
 LL |     fn equals(&self, u: &Foo<T>) -> bool where T : Eq {
    |                                                    ^^ required by this bound in `Foo::<T>::equals`
+help: consider annotating `Bar` with `#[derive(Eq)]`
+   |
+LL | #[derive(Eq)]
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/where-clauses/where-clauses-unsatisfied.stderr
+++ b/src/test/ui/where-clauses/where-clauses-unsatisfied.stderr
@@ -9,6 +9,10 @@ note: required by a bound in `equal`
    |
 LL | fn equal<T>(a: &T, b: &T) -> bool where T : Eq { a == b }
    |                                             ^^ required by this bound in `equal`
+help: consider annotating `Struct` with `#[derive(Eq)]`
+   |
+LL | #[derive(Eq)]
+   |
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Successful merges:

 - #95525 (Suggest derivable trait on E0277 error)
 - #95654 (diagnostics: use correct span for const generics)
 - #95660 (Update panic docs to make it clearer when to use panic vs Result)
 - #95670 (Refactor: remove unused function parameters)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=95525,95654,95660,95670)
<!-- homu-ignore:end -->