### PR TITLE
Revert "Fix intra doc link ICE when trying to get traits in scope for primitive"

### DIFF
--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -771,7 +771,6 @@ fn main_options(options: config::Options) -> MainResult {
     let externs = options.externs.clone();
     let render_options = options.render_options.clone();
     let scrape_examples_options = options.scrape_examples_options.clone();
-    let document_private = options.render_options.document_private;
     let config = core::create_config(options);
 
     interface::create_compiler_and_run(config, |compiler| {
@@ -792,12 +791,7 @@ fn main_options(options: config::Options) -> MainResult {
             let (resolver, resolver_caches) = {
                 let (krate, resolver, _) = &*abort_on_err(queries.expansion(), sess).peek();
                 let resolver_caches = resolver.borrow_mut().access(|resolver| {
-                    collect_intra_doc_links::early_resolve_intra_doc_links(
-                        resolver,
-                        krate,
-                        externs,
-                        document_private,
-                    )
+                    collect_intra_doc_links::early_resolve_intra_doc_links(resolver, krate, externs)
                 });
                 (resolver.clone(), resolver_caches)
             };

--- a/src/librustdoc/passes/collect_intra_doc_links/early.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links/early.rs
@@ -22,7 +22,6 @@ crate fn early_resolve_intra_doc_links(
     resolver: &mut Resolver<'_>,
     krate: &ast::Crate,
     externs: Externs,
-    document_private_items: bool,
 ) -> ResolverCaches {
     let mut loader = IntraLinkCrateLoader {
         resolver,
@@ -31,7 +30,6 @@ crate fn early_resolve_intra_doc_links(
         traits_in_scope: Default::default(),
         all_traits: Default::default(),
         all_trait_impls: Default::default(),
-        document_private_items,
     };
 
     // Overridden `visit_item` below doesn't apply to the crate root,
@@ -63,7 +61,6 @@ struct IntraLinkCrateLoader<'r, 'ra> {
     traits_in_scope: DefIdMap<Vec<TraitCandidate>>,
     all_traits: Vec<DefId>,
     all_trait_impls: Vec<DefId>,
-    document_private_items: bool,
 }
 
 impl IntraLinkCrateLoader<'_, '_> {
@@ -170,7 +167,7 @@ impl IntraLinkCrateLoader<'_, '_> {
         }
 
         for child in self.resolver.module_children_or_reexports(module_id) {
-            if child.vis == Visibility::Public || self.document_private_items {
+            if child.vis == Visibility::Public {
                 if let Some(def_id) = child.res.opt_def_id() {
                     self.add_traits_in_parent_scope(def_id);
                 }

--- a/src/test/rustdoc/issue-95633.rs
+++ b/src/test/rustdoc/issue-95633.rs
@@ -1,7 +1,0 @@
-// compile-flags: --document-private-items
-
-// This ensures that no ICE is triggered when rustdoc is run on this code.
-
-mod stdlib {
-    pub (crate) use std::i8;
-}


### PR DESCRIPTION
Reverts rust-lang/rust#95645

This is only to confirm that the perf drop comes from this PR.

r? @GuillaumeGomez 