### PR TITLE
Reenable debuginfo tests

### DIFF
--- a/compiler/rustc_codegen_llvm/src/back/lto.rs
+++ b/compiler/rustc_codegen_llvm/src/back/lto.rs
@@ -325,20 +325,6 @@ fn fat_lto(
         drop(linker);
         save_temp_bitcode(cgcx, &module, "lto.input");
 
-        // Fat LTO also suffers from the invalid DWARF issue similar to Thin LTO.
-        // Here we rewrite all `DICompileUnit` pointers if there is only one `DICompileUnit`.
-        // This only works around the problem when codegen-units = 1.
-        // Refer to the comments in the `optimize_thin_module` function for more details.
-        let mut cu1 = ptr::null_mut();
-        let mut cu2 = ptr::null_mut();
-        unsafe { llvm::LLVMRustLTOGetDICompileUnit(llmod, &mut cu1, &mut cu2) };
-        if !cu2.is_null() {
-            let _timer =
-                cgcx.prof.generic_activity_with_arg("LLVM_fat_lto_patch_debuginfo", &*module.name);
-            unsafe { llvm::LLVMRustLTOPatchDICompileUnit(llmod, cu1) };
-            save_temp_bitcode(cgcx, &module, "fat-lto-after-patch");
-        }
-
         // Internalize everything below threshold to help strip out more modules and such.
         unsafe {
             let ptr = symbols_below_threshold.as_ptr();
@@ -757,7 +743,7 @@ pub unsafe fn optimize_thin_module(
         // an error.
         let mut cu1 = ptr::null_mut();
         let mut cu2 = ptr::null_mut();
-        llvm::LLVMRustLTOGetDICompileUnit(llmod, &mut cu1, &mut cu2);
+        llvm::LLVMRustThinLTOGetDICompileUnit(llmod, &mut cu1, &mut cu2);
         if !cu2.is_null() {
             let msg = "multiple source DICompileUnits found";
             return Err(write::llvm_err(&diag_handler, msg));
@@ -846,7 +832,7 @@ pub unsafe fn optimize_thin_module(
             let _timer = cgcx
                 .prof
                 .generic_activity_with_arg("LLVM_thin_lto_patch_debuginfo", thin_module.name());
-            llvm::LLVMRustLTOPatchDICompileUnit(llmod, cu1);
+            llvm::LLVMRustThinLTOPatchDICompileUnit(llmod, cu1);
             save_temp_bitcode(cgcx, &module, "thin-lto-after-patch");
         }
 

--- a/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
@@ -2506,8 +2506,12 @@ extern "C" {
         len: usize,
         out_len: &mut usize,
     ) -> *const u8;
-    pub fn LLVMRustLTOGetDICompileUnit(M: &Module, CU1: &mut *mut c_void, CU2: &mut *mut c_void);
-    pub fn LLVMRustLTOPatchDICompileUnit(M: &Module, CU: *mut c_void);
+    pub fn LLVMRustThinLTOGetDICompileUnit(
+        M: &Module,
+        CU1: &mut *mut c_void,
+        CU2: &mut *mut c_void,
+    );
+    pub fn LLVMRustThinLTOPatchDICompileUnit(M: &Module, CU: *mut c_void);
 
     pub fn LLVMRustLinkerNew(M: &Module) -> &mut Linker<'_>;
     pub fn LLVMRustLinkerAdd(

--- a/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
@@ -1611,7 +1611,7 @@ LLVMRustGetBitcodeSliceFromObjectData(const char *data,
 // Rewrite all `DICompileUnit` pointers to the `DICompileUnit` specified. See
 // the comment in `back/lto.rs` for why this exists.
 extern "C" void
-LLVMRustLTOGetDICompileUnit(LLVMModuleRef Mod,
+LLVMRustThinLTOGetDICompileUnit(LLVMModuleRef Mod,
                                 DICompileUnit **A,
                                 DICompileUnit **B) {
   Module *M = unwrap(Mod);
@@ -1629,7 +1629,7 @@ LLVMRustLTOGetDICompileUnit(LLVMModuleRef Mod,
 // Rewrite all `DICompileUnit` pointers to the `DICompileUnit` specified. See
 // the comment in `back/lto.rs` for why this exists.
 extern "C" void
-LLVMRustLTOPatchDICompileUnit(LLVMModuleRef Mod, DICompileUnit *Unit) {
+LLVMRustThinLTOPatchDICompileUnit(LLVMModuleRef Mod, DICompileUnit *Unit) {
   Module *M = unwrap(Mod);
 
   // If the original source module didn't have a `DICompileUnit` then try to

--- a/src/test/debuginfo/basic-types-globals-lto.rs
+++ b/src/test/debuginfo/basic-types-globals-lto.rs
@@ -3,7 +3,8 @@
 
 // min-lldb-version: 310
 
-// compile-flags:-g
+// no-prefer-dynamic
+// compile-flags:-g -C lto
 // gdb-command:run
 // gdbg-command:print 'basic_types_globals::B'
 // gdbr-command:print B

--- a/src/test/debuginfo/basic-types-globals-metadata.rs
+++ b/src/test/debuginfo/basic-types-globals-metadata.rs
@@ -1,5 +1,4 @@
 // min-lldb-version: 310
-// ignore-gdb // Test temporarily ignored due to debuginfo tests being disabled, see PR 47155
 
 // compile-flags:-g
 // gdb-command:run
@@ -11,7 +10,7 @@
 // gdb-check:type = isize
 // gdbg-command:whatis 'basic_types_globals_metadata::C'
 // gdbr-command:whatis basic_types_globals_metadata::C
-// gdb-check:type = char
+// gdb-check:type = char32_t
 // gdbg-command:whatis 'basic_types_globals_metadata::I8'
 // gdbr-command:whatis basic_types_globals_metadata::I8
 // gdb-check:type = i8

--- a/src/test/debuginfo/basic-types-metadata.rs
+++ b/src/test/debuginfo/basic-types-metadata.rs
@@ -1,5 +1,4 @@
 // min-lldb-version: 310
-// ignore-gdb // Test temporarily ignored due to debuginfo tests being disabled, see PR 47155
 
 // compile-flags:-g
 // gdb-command:run
@@ -10,7 +9,7 @@
 // gdb-command:whatis i
 // gdb-check:type = isize
 // gdb-command:whatis c
-// gdb-check:type = char
+// gdb-check:type = char32_t
 // gdb-command:whatis i8
 // gdb-check:type = i8
 // gdb-command:whatis i16
@@ -34,12 +33,12 @@
 // gdb-command:whatis f64
 // gdb-check:type = f64
 // gdb-command:whatis fnptr
-// gdb-check:type = [...] (*)([...])
+// gdb-check:type = *mut fn ()
 // gdb-command:info functions _yyy
 // gdbg-check:[...]![...]_yyy([...]);
-// gdbr-check:static fn basic_types_metadata::_yyy() -> !;
+// gdbr-check:static fn basic_types_metadata::_yyy();
 // gdb-command:ptype closure_0
-// gdbr-check: type = struct closure
+// gdbr-check: type = struct basic_types_metadata::main::{closure_env#0}
 // gdbg-check: type = struct closure {
 // gdbg-check:     <no data fields>
 // gdbg-check: }
@@ -47,18 +46,18 @@
 // gdbg-check: type = struct closure {
 // gdbg-check:     bool *__0;
 // gdbg-check: }
-// gdbr-check: type = struct closure (
-// gdbr-check:     bool *,
-// gdbr-check: )
+// gdbr-check: type = struct basic_types_metadata::main::{closure_env#1} {
+// gdbr-check:     _ref__b: *mut bool,
+// gdbr-check: }
 // gdb-command:ptype closure_2
 // gdbg-check: type = struct closure {
 // gdbg-check:     bool *__0;
 // gdbg-check:     isize *__1;
 // gdbg-check: }
-// gdbr-check: type = struct closure (
-// gdbr-check:     bool *,
-// gdbr-check:     isize *,
-// gdbr-check: )
+// gdbr-check: type = struct basic_types_metadata::main::{closure_env#2} {
+// gdbr-check:     _ref__b: *mut bool,
+// gdbr-check:     _ref__i: *mut isize,
+// gdbr-check: }
 
 //
 // gdb-command:continue

--- a/src/test/debuginfo/basic-types-mut-globals.rs
+++ b/src/test/debuginfo/basic-types-mut-globals.rs
@@ -5,7 +5,6 @@
 // its numerical value.
 
 // min-lldb-version: 310
-// ignore-gdb // Test temporarily ignored due to debuginfo tests being disabled, see PR 47155
 
 // compile-flags:-g
 
@@ -21,7 +20,7 @@
 // gdbg-command:print/d 'basic_types_mut_globals::C'
 // gdbr-command:print C
 // gdbg-check:$3 = 97
-// gdbr-check:$3 = 97 'a'
+// gdbr-check:$3 = 97
 // gdbg-command:print/d 'basic_types_mut_globals::I8'
 // gdbr-command:print I8
 // gdb-check:$4 = 68
@@ -67,7 +66,7 @@
 // gdbg-command:print/d 'basic_types_mut_globals'::C
 // gdbr-command:print C
 // gdbg-check:$17 = 102
-// gdbr-check:$17 = 102 'f'
+// gdbr-check:$17 = 102
 // gdbg-command:print/d 'basic_types_mut_globals'::I8
 // gdbr-command:print/d I8
 // gdb-check:$18 = 78

--- a/src/test/debuginfo/by-value-non-immediate-argument.rs
+++ b/src/test/debuginfo/by-value-non-immediate-argument.rs
@@ -1,5 +1,5 @@
-// ignore-test // Test temporarily ignored due to debuginfo tests being disabled, see PR 47155
 // min-lldb-version: 310
+// ignore-lldb
 
 // compile-flags:-g
 

--- a/src/test/debuginfo/c-style-enum.rs
+++ b/src/test/debuginfo/c-style-enum.rs
@@ -1,5 +1,4 @@
 // ignore-aarch64
-// ignore-gdb // Test temporarily ignored due to debuginfo tests being disabled, see PR 47155
 // min-lldb-version: 310
 
 // compile-flags:-g

--- a/src/test/debuginfo/function-arg-initialization.rs
+++ b/src/test/debuginfo/function-arg-initialization.rs
@@ -1,5 +1,5 @@
-// ignore-test // Test temporarily ignored due to debuginfo tests being disabled, see PR 47155
 // min-lldb-version: 310
+// ignore-lldb
 
 // This test case checks if function arguments already have the correct value
 // when breaking at the first line of the function, that is if the function

--- a/src/test/debuginfo/function-prologue-stepping-regular.rs
+++ b/src/test/debuginfo/function-prologue-stepping-regular.rs
@@ -1,9 +1,9 @@
 // This test case checks if function arguments already have the correct value when breaking at the
 // beginning of a function.
 
+// ignore-lldb
+
 // min-lldb-version: 310
-// ignore-gdb
-// ignore-test // Test temporarily ignored due to debuginfo tests being disabled, see PR 47155
 // compile-flags:-g
 
 // lldb-command:breakpoint set --name immediate_args

--- a/src/test/debuginfo/lexical-scopes-in-block-expression.rs
+++ b/src/test/debuginfo/lexical-scopes-in-block-expression.rs
@@ -1,5 +1,4 @@
 // min-lldb-version: 310
-// ignore-gdb // Test temporarily ignored due to debuginfo tests being disabled, see PR 47155
 
 // compile-flags:-g
 

--- a/src/test/debuginfo/limited-debuginfo.rs
+++ b/src/test/debuginfo/limited-debuginfo.rs
@@ -1,5 +1,4 @@
 // ignore-lldb
-// ignore-gdb // Test temporarily ignored due to debuginfo tests being disabled, see PR 47155
 
 // compile-flags:-C debuginfo=1
 

--- a/src/test/debuginfo/option-like-enum.rs
+++ b/src/test/debuginfo/option-like-enum.rs
@@ -1,6 +1,5 @@
-// ignore-test // Test temporarily ignored due to debuginfo tests being disabled, see PR 47155
-
 // min-lldb-version: 310
+// ignore-lldb
 
 // compile-flags:-g
 
@@ -22,7 +21,8 @@
 
 // gdbg-command:print empty_gdb->discr
 // gdbr-command:print empty_gdb.discr
-// gdb-check:$4 = (isize *) 0x0
+// gdbg-check:$4 = (isize *) 0x1
+// gdbr-check:$4 = (*mut isize) 0x1
 
 // gdb-command:print droid
 // gdbg-check:$5 = {RUST$ENCODED$ENUM$2$Void = {id = 675675, range = 10000001, internals = 0x43218765}}
@@ -30,11 +30,12 @@
 
 // gdbg-command:print void_droid_gdb->internals
 // gdbr-command:print void_droid_gdb.internals
-// gdb-check:$6 = (isize *) 0x0
+// gdbg-check:$6 = (isize *) 0x0
+// gdbr-check:$6 = (*mut isize) 0x0
 
 // gdb-command:print nested_non_zero_yep
 // gdbg-check:$7 = {RUST$ENCODED$ENUM$1$2$Nope = {__0 = 10.5, __1 = {a = 10, b = 20, c = [...]}}}
-// gdbr-check:$7 = option_like_enum::NestedNonZero::Yep(10.5, option_like_enum::NestedNonZeroField {a: 10, b: 20, c: 0x[...] "x[...]"})
+// gdbr-check:$7 = option_like_enum::NestedNonZero::Yep(10.5, option_like_enum::NestedNonZeroField {a: 10, b: 20, c: 0x[...]})
 
 // gdb-command:print nested_non_zero_nope
 // gdbg-check:$8 = {RUST$ENCODED$ENUM$1$2$Nope = {__0 = [...], __1 = {a = [...], b = [...], c = 0x0}}}

--- a/src/test/debuginfo/simple-struct.rs
+++ b/src/test/debuginfo/simple-struct.rs
@@ -1,5 +1,4 @@
 // min-lldb-version: 310
-// ignore-gdb // Test temporarily ignored due to debuginfo tests being disabled, see PR 47155
 
 // compile-flags:-g
 

--- a/src/test/debuginfo/simple-tuple.rs
+++ b/src/test/debuginfo/simple-tuple.rs
@@ -1,5 +1,4 @@
 // min-lldb-version: 310
-// ignore-gdb // Test temporarily ignored due to debuginfo tests being disabled, see PR 47155
 
 // compile-flags:-g
 

--- a/src/test/debuginfo/struct-in-enum.rs
+++ b/src/test/debuginfo/struct-in-enum.rs
@@ -1,6 +1,6 @@
 // min-lldb-version: 310
 // ignore-gdb-version: 7.11.90 - 7.12.9
-// ignore-test // Test temporarily ignored due to debuginfo tests being disabled, see PR 47155
+// ignore-lldb
 
 // compile-flags:-g
 

--- a/src/test/debuginfo/union-smoke.rs
+++ b/src/test/debuginfo/union-smoke.rs
@@ -1,5 +1,4 @@
 // min-lldb-version: 310
-// ignore-gdb // Test temporarily ignored due to debuginfo tests being disabled, see PR 47155
 
 // ignore-gdb-version: 7.11.90 - 7.12.9
 

--- a/src/test/debuginfo/vec.rs
+++ b/src/test/debuginfo/vec.rs
@@ -1,5 +1,4 @@
 // min-lldb-version: 310
-// ignore-gdb // Test temporarily ignored due to debuginfo tests being disabled, see PR 47155
 
 // compile-flags:-g
 


### PR DESCRIPTION
These tests were disabled four years ago; it appears that it was
intended to be temporary.

In that time their assertions have rotted. I've gone through and fixed
the assertions where necessary and rehabilitated them. In several cases
I've had to leave lldb disabled, because the lldb output has changed in
ways that I don't understand. I figured gdb coverage was better than no
coverage.

It's worth noting that these tests being enabled would probably have
caught the regression observed in https://github.com/rust-lang/rust/issues/90357.