### PR TITLE
fix: Vec leak when capacity is 0

### DIFF
--- a/library/alloc/src/raw_vec.rs
+++ b/library/alloc/src/raw_vec.rs
@@ -170,6 +170,13 @@ impl<T, A: Allocator> RawVec<T, A> {
     fn allocate_in(capacity: usize, init: AllocInit, alloc: A) -> Self {
         if mem::size_of::<T>() == 0 {
             Self::new_in(alloc)
+        } else if capacity == 0 {
+            // Don't allocate here because `Drop` will not deallocate when `capacity` is 0.
+            Self {
+                ptr: unsafe { Unique::new_unchecked(NonNull::dangling().as_ptr()) },
+                cap: capacity,
+                alloc,
+            }
         } else {
             // We avoid `unwrap_or_else` here because it bloats the amount of
             // LLVM IR generated.

--- a/library/alloc/src/raw_vec.rs
+++ b/library/alloc/src/raw_vec.rs
@@ -168,7 +168,7 @@ impl<T, A: Allocator> RawVec<T, A> {
 
     #[cfg(not(no_global_oom_handling))]
     fn allocate_in(capacity: usize, init: AllocInit, alloc: A) -> Self {
-		// Don't allocate here because `Drop` will not deallocate when `capacity` is 0.
+        // Don't allocate here because `Drop` will not deallocate when `capacity` is 0.
         if mem::size_of::<T>() == 0 || capacity == 0 {
             Self::new_in(alloc)
         } else {

--- a/library/alloc/src/raw_vec.rs
+++ b/library/alloc/src/raw_vec.rs
@@ -168,15 +168,9 @@ impl<T, A: Allocator> RawVec<T, A> {
 
     #[cfg(not(no_global_oom_handling))]
     fn allocate_in(capacity: usize, init: AllocInit, alloc: A) -> Self {
-        if mem::size_of::<T>() == 0 {
+		// Don't allocate here because `Drop` will not deallocate when `capacity` is 0.
+        if mem::size_of::<T>() == 0 || capacity == 0 {
             Self::new_in(alloc)
-        } else if capacity == 0 {
-            // Don't allocate here because `Drop` will not deallocate when `capacity` is 0.
-            Self {
-                ptr: unsafe { Unique::new_unchecked(NonNull::dangling().as_ptr()) },
-                cap: capacity,
-                alloc,
-            }
         } else {
             // We avoid `unwrap_or_else` here because it bloats the amount of
             // LLVM IR generated.


### PR DESCRIPTION
When `RawVec::with_capacity_in` is called with capacity 0, an allocation of size 0 is allocated.
However, `<RawVec as Drop>::drop` doesn't deallocate, since it only checks if capacity was 0. Fixed by not allocating when capacity is 0.