### PR TITLE
More improvents to dest prop

### DIFF
--- a/src/test/mir-opt/dest-prop/union.main.DestinationPropagation.diff
+++ b/src/test/mir-opt/dest-prop/union.main.DestinationPropagation.diff
@@ -17,29 +17,23 @@
       }
   
       bb0: {
--         StorageLive(_1);                 // scope 0 at $DIR/union.rs:13:9: 13:11
--         StorageLive(_2);                 // scope 0 at $DIR/union.rs:13:23: 13:28
--         _2 = val() -> bb1;               // scope 0 at $DIR/union.rs:13:23: 13:28
-+         nop;                             // scope 0 at $DIR/union.rs:13:9: 13:11
-+         nop;                             // scope 0 at $DIR/union.rs:13:23: 13:28
-+         (_1.0: u32) = val() -> bb1;      // scope 0 at $DIR/union.rs:13:23: 13:28
+          StorageLive(_1);                 // scope 0 at $DIR/union.rs:13:9: 13:11
+          StorageLive(_2);                 // scope 0 at $DIR/union.rs:13:23: 13:28
+          _2 = val() -> bb1;               // scope 0 at $DIR/union.rs:13:23: 13:28
                                            // mir::Constant
                                            // + span: $DIR/union.rs:13:23: 13:26
                                            // + literal: Const { ty: fn() -> u32 {val}, val: Value(Scalar(<ZST>)) }
       }
   
       bb1: {
--         (_1.0: u32) = move _2;           // scope 0 at $DIR/union.rs:13:14: 13:30
--         StorageDead(_2);                 // scope 0 at $DIR/union.rs:13:29: 13:30
-+         nop;                             // scope 0 at $DIR/union.rs:13:14: 13:30
-+         nop;                             // scope 0 at $DIR/union.rs:13:29: 13:30
+          (_1.0: u32) = move _2;           // scope 0 at $DIR/union.rs:13:14: 13:30
+          StorageDead(_2);                 // scope 0 at $DIR/union.rs:13:29: 13:30
           StorageLive(_3);                 // scope 1 at $DIR/union.rs:15:5: 15:27
           StorageLive(_4);                 // scope 1 at $DIR/union.rs:15:10: 15:26
           _4 = (_1.0: u32);                // scope 2 at $DIR/union.rs:15:19: 15:24
           StorageDead(_4);                 // scope 1 at $DIR/union.rs:15:26: 15:27
           StorageDead(_3);                 // scope 1 at $DIR/union.rs:15:27: 15:28
--         StorageDead(_1);                 // scope 0 at $DIR/union.rs:16:1: 16:2
-+         nop;                             // scope 0 at $DIR/union.rs:16:1: 16:2
+          StorageDead(_1);                 // scope 0 at $DIR/union.rs:16:1: 16:2
           return;                          // scope 0 at $DIR/union.rs:16:2: 16:2
       }
   }

--- a/src/test/mir-opt/dest-prop/union.rs
+++ b/src/test/mir-opt/dest-prop/union.rs
@@ -14,3 +14,6 @@ fn main() {
 
     drop(unsafe { un.us });
 }
+
+// FIXME(JakobDegen): This example is currently broken; it needs a more precise liveness analysis in
+// order to be fixed.

--- a/src/test/mir-opt/early_otherwise_branch_68867.try_sum.EarlyOtherwiseBranch.before-SimplifyConstCondition-final.after.diff
+++ b/src/test/mir-opt/early_otherwise_branch_68867.try_sum.EarlyOtherwiseBranch.before-SimplifyConstCondition-final.after.diff
@@ -65,21 +65,16 @@
   
       bb0: {
 -         StorageLive(_3);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 27:6
--         StorageLive(_4);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
--         StorageLive(_5);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:15: 21:16
--         _5 = _1;                         // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:15: 21:16
 +         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 27:6
-+         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
-+         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:15: 21:16
-+         (_4.0: &ViewportPercentageLength) = _1; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:15: 21:16
+          StorageLive(_4);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
+          StorageLive(_5);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:15: 21:16
+          _5 = _1;                         // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:15: 21:16
           StorageLive(_6);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:18: 21:23
           _6 = _2;                         // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:18: 21:23
--         (_4.0: &ViewportPercentageLength) = move _5; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
-+         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
+          (_4.0: &ViewportPercentageLength) = move _5; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
           (_4.1: &ViewportPercentageLength) = move _6; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
           StorageDead(_6);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:23: 21:24
--         StorageDead(_5);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:23: 21:24
-+         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:23: 21:24
+          StorageDead(_5);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:23: 21:24
           _11 = discriminant((*(_4.0: &ViewportPercentageLength))); // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:14: 21:24
 -         switchInt(move _11) -> [0_isize: bb1, 1_isize: bb3, 2_isize: bb4, 3_isize: bb5, otherwise: bb11]; // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
 +         StorageLive(_34);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:8: 21:24
@@ -102,9 +97,8 @@
           discriminant(_0) = 1;            // scope 0 at $DIR/early_otherwise_branch_68867.rs:26:21: 26:28
           StorageDead(_33);                // scope 0 at $DIR/early_otherwise_branch_68867.rs:26:27: 26:28
 -         StorageDead(_3);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:27:6: 27:7
--         StorageDead(_4);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:28:1: 28:2
 +         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:27:6: 27:7
-+         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:28:1: 28:2
+          StorageDead(_4);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:28:1: 28:2
           return;                          // scope 0 at $DIR/early_otherwise_branch_68867.rs:28:2: 28:2
       }
   
@@ -287,9 +281,8 @@
 +         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:5: 27:7
           discriminant(_0) = 0;            // scope 0 at $DIR/early_otherwise_branch_68867.rs:21:5: 27:7
 -         StorageDead(_3);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:27:6: 27:7
--         StorageDead(_4);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:28:1: 28:2
 +         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:27:6: 27:7
-+         nop;                             // scope 0 at $DIR/early_otherwise_branch_68867.rs:28:1: 28:2
+          StorageDead(_4);                 // scope 0 at $DIR/early_otherwise_branch_68867.rs:28:1: 28:2
           return;                          // scope 0 at $DIR/early_otherwise_branch_68867.rs:28:2: 28:2
       }
   


### PR DESCRIPTION
The code changes here are not actually that significant, I'm mostly using this PR as a way to document my plans for fixing this opt.

Three commits:
 1. Remove usage of initialization analysis. I believe this was technically sound because `MaybeInitializedLocals` returns true even if the local is only partially initialized, but it still seems extremely sketchy to me (and likely to break if the analysis ever gets more precise). I also don't think there's a need for it in any case. Uninitialized places should, in general, also be dead. This does break one test, but that test was somewhat flakey already. Essentially what happens there is something like this:
    ```rust
    (_1.0) = _2
    _4 = (_1.0)
    ```
    The pass was dest propping `_2` into `_1.0`; however, it did not actually know that `_1.0` was dead; instead it knew that it was uninit, and concluded soundness from that. This means that if the place happened to be initialized but dead for whatever unrelated reason, this would not have fired. The way to get this and many other similar examples back is to use a more precise version of liveness analysis.

    This also has the benefit of simplifying the expensive conflict building, and should get us some performance back. This will also make the performance improvements (see below) easier later on.

 2. Previously, we did not check for any of the intra statement conflicts in assignments. The justification for this was that self assignments get removed, but this is only the case for `Rvalue::Use`, not all the other rvalues. This commit adds in conflict tracking for assignments with all the other types of rvalues. Unfortunately, the handling of the locals used for indexing places is fundamentally sketchy, both here and elsewhere in this pass. It will probably be fairly difficult to land this without a decision for #68364 (for MIR semantics, not for Rust semantics). If/when we make that decision, and if that decision looks like [Ralf's suggestion](https://github.com/rust-lang/rust/issues/68364#issuecomment-614862820), then I think the real issue here is that there is a missing dataflow state: The one after the place gets retagged and before the RHS is evaluated. Adding in this dataflow state when it exists would completely remove the need for custom behavior around intra-statement conflicts, and seems much more robust in general.
 3. Just documents the outstanding problems

r? @jonas-schievink (feel free to reassign, I have no idea if you have review capacity these days)