### PR TITLE
Promote x86_64-unknown-none target to Tier 2 and distribute build artifacts

### DIFF
--- a/src/ci/docker/host-x86_64/dist-various-2/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-various-2/Dockerfile
@@ -111,6 +111,7 @@ ENV TARGETS=$TARGETS,nvptx64-nvidia-cuda
 ENV TARGETS=$TARGETS,armv7-unknown-linux-gnueabi
 ENV TARGETS=$TARGETS,armv7-unknown-linux-musleabi
 ENV TARGETS=$TARGETS,i686-unknown-freebsd
+ENV TARGETS=$TARGETS,x86_64-unknown-none
 
 # As per https://bugs.launchpad.net/ubuntu/+source/gcc-defaults/+bug/1300211
 # we need asm in the search path for gcc-8 (for gnux32) but not in the search path of the

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -177,6 +177,7 @@ target | std | notes
 `x86_64-linux-android` | ✓ | 64-bit x86 Android
 `x86_64-pc-solaris` | ✓ | 64-bit Solaris 10/11, illumos
 `x86_64-unknown-linux-gnux32` | ✓ | 64-bit Linux (x32 ABI) (kernel 4.15, glibc 2.27)
+[`x86_64-unknown-none`](platform-support/x86_64-unknown-none.md) | * | Freestanding/bare-metal x86_64, softfloat
 `x86_64-unknown-redox` | ✓ | Redox OS
 
 [Fortanix ABI]: https://edp.fortanix.com/
@@ -291,7 +292,6 @@ target | std | host | notes
 `x86_64-unknown-haiku` | ✓ | ✓ | 64-bit Haiku
 `x86_64-unknown-hermit` | ✓ |  | HermitCore
 `x86_64-unknown-l4re-uclibc` | ? |  |
-[`x86_64-unknown-none`](platform-support/x86_64-unknown-none.md) | * |  | Freestanding/bare-metal x86_64, softfloat
 `x86_64-unknown-none-linuxkernel` | * |  | Linux kernel modules
 [`x86_64-unknown-openbsd`](platform-support/openbsd.md) | ✓ | ✓ | 64-bit OpenBSD
 `x86_64-unknown-uefi` | * |  | 64-bit UEFI

--- a/src/doc/rustc/src/platform-support/x86_64-unknown-none.md
+++ b/src/doc/rustc/src/platform-support/x86_64-unknown-none.md
@@ -1,6 +1,6 @@
 # `x86_64-unknown-none`
 
-**Tier: 3**
+**Tier: 2**
 
 Freestanding/bare-metal x86-64 binaries in ELF format: firmware, kernels, etc.
 
@@ -32,7 +32,7 @@ You can change this using the `-C code-model=` option to rustc.
 On `x86_64-unknown-none`, `extern "C"` uses the [standard System V calling
 convention](https://gitlab.com/x86-psABIs/x86-64-ABI), without red zones.
 
-This target generated binaries in the ELF format. Any alternate formats or
+This target generates binaries in the ELF format. Any alternate formats or
 special considerations for binary layout will require linker options or linker
 scripts.
 
@@ -49,15 +49,19 @@ target = ["x86_64-unknown-none"]
 
 ## Building Rust programs
 
-Rust does not yet ship pre-compiled artifacts for this target. To compile for
-this target, you will either need to build Rust with the target enabled (see
-"Building the target" above), or build your own copy of `core` by using
-`build-std` or similar.
+Starting with Rust 1.62, precompiled artifacts are provided via `rustup`:
+
+```text
+# install cross-compile toolchain
+rustup target add x86_64-unknown-none
+# target flag may be used with any cargo or rustc command
+cargo build --target x86_64-unknown-none
+```
 
 ## Testing
 
 As `x86_64-unknown-none` supports a variety of different environments and does
-not support `std`, this target does not support running the Rust testsuite.
+not support `std`, this target does not support running the Rust test suite.
 
 ## Cross-compilation toolchains and C code
 

--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -152,6 +152,7 @@ static TARGETS: &[&str] = &[
     "x86_64-unknown-linux-gnux32",
     "x86_64-unknown-linux-musl",
     "x86_64-unknown-netbsd",
+    "x86_64-unknown-none",
     "x86_64-unknown-redox",
     "x86_64-unknown-hermit",
 ];


### PR DESCRIPTION
This implements https://github.com/rust-lang/compiler-team/issues/499 , in which the compiler team accepted the x86_64-unknown-none target for promotion to a Tier 2 platform.