### PR TITLE
pre-push.sh: Use python3 if python is not found

### DIFF
--- a/src/etc/pre-push.sh
+++ b/src/etc/pre-push.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Call `tidy --bless` before each commit
+# Call `tidy --bless` before git push
 # Copy this script to .git/hooks to activate,
 # and remove it from .git/hooks to deactivate.
 #
@@ -14,6 +14,8 @@ COMMAND="$ROOT_DIR/x.py test tidy --bless"
 
 if [[ "$OSTYPE" == "msys" || "$OSTYPE" == "win32" ]]; then
   COMMAND="python $COMMAND"
+elif ! command -v python &> /dev/null; then
+  COMMAND="python3 $COMMAND"
 fi
 
 echo "Running pre-push script '$COMMAND'"


### PR DESCRIPTION
Since Python 2 has reached EOL, `python` may not be available in certain systems (e.g., recent macOS). We should use `python3` in this case to avoid error like `python: No such file or directory`.