### PR TITLE
Rename RWLock to RwLock in std::sys.

### DIFF
--- a/library/std/src/panicking.rs
+++ b/library/std/src/panicking.rs
@@ -20,7 +20,7 @@ use crate::process;
 use crate::sync::atomic::{AtomicBool, Ordering};
 use crate::sys::stdio::panic_output;
 use crate::sys_common::backtrace;
-use crate::sys_common::rwlock::StaticRWLock;
+use crate::sys_common::rwlock::StaticRwLock;
 use crate::sys_common::thread_info;
 use crate::thread;
 
@@ -83,7 +83,7 @@ impl Hook {
     }
 }
 
-static HOOK_LOCK: StaticRWLock = StaticRWLock::new();
+static HOOK_LOCK: StaticRwLock = StaticRwLock::new();
 static mut HOOK: Hook = Hook::Default;
 
 /// Registers a custom panic hook, replacing any that was previously registered.

--- a/library/std/src/sync/rwlock.rs
+++ b/library/std/src/sync/rwlock.rs
@@ -76,7 +76,7 @@ use crate::sys_common::rwlock as sys;
 /// [`Mutex`]: super::Mutex
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct RwLock<T: ?Sized> {
-    inner: sys::MovableRWLock,
+    inner: sys::MovableRwLock,
     poison: poison::Flag,
     data: UnsafeCell<T>,
 }
@@ -146,7 +146,7 @@ impl<T> RwLock<T> {
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn new(t: T) -> RwLock<T> {
         RwLock {
-            inner: sys::MovableRWLock::new(),
+            inner: sys::MovableRwLock::new(),
             poison: poison::Flag::new(),
             data: UnsafeCell::new(t),
         }

--- a/library/std/src/sys/hermit/rwlock.rs
+++ b/library/std/src/sys/hermit/rwlock.rs
@@ -1,13 +1,13 @@
 use crate::cell::UnsafeCell;
 use crate::sys::locks::{Condvar, Mutex};
 
-pub struct RWLock {
+pub struct RwLock {
     lock: Mutex,
     cond: Condvar,
     state: UnsafeCell<State>,
 }
 
-pub type MovableRWLock = RWLock;
+pub type MovableRwLock = RwLock;
 
 enum State {
     Unlocked,
@@ -15,8 +15,8 @@ enum State {
     Writing,
 }
 
-unsafe impl Send for RWLock {}
-unsafe impl Sync for RWLock {}
+unsafe impl Send for RwLock {}
+unsafe impl Sync for RwLock {}
 
 // This rwlock implementation is a relatively simple implementation which has a
 // condition variable for readers/writers as well as a mutex protecting the
@@ -26,9 +26,9 @@ unsafe impl Sync for RWLock {}
 // hopefully correct this implementation is very likely to want to be changed in
 // the future.
 
-impl RWLock {
-    pub const fn new() -> RWLock {
-        RWLock { lock: Mutex::new(), cond: Condvar::new(), state: UnsafeCell::new(State::Unlocked) }
+impl RwLock {
+    pub const fn new() -> RwLock {
+        RwLock { lock: Mutex::new(), cond: Condvar::new(), state: UnsafeCell::new(State::Unlocked) }
     }
 
     #[inline]

--- a/library/std/src/sys/sgx/rwlock.rs
+++ b/library/std/src/sys/sgx/rwlock.rs
@@ -8,25 +8,25 @@ use super::waitqueue::{
 };
 use crate::mem;
 
-pub struct RWLock {
+pub struct RwLock {
     readers: SpinMutex<WaitVariable<Option<NonZeroUsize>>>,
     writer: SpinMutex<WaitVariable<bool>>,
 }
 
-pub type MovableRWLock = Box<RWLock>;
+pub type MovableRwLock = Box<RwLock>;
 
-// Check at compile time that RWLock size matches C definition (see test_c_rwlock_initializer below)
+// Check at compile time that RwLock size matches C definition (see test_c_rwlock_initializer below)
 //
 // # Safety
 // Never called, as it is a compile time check.
 #[allow(dead_code)]
-unsafe fn rw_lock_size_assert(r: RWLock) {
-    unsafe { mem::transmute::<RWLock, [u8; 144]>(r) };
+unsafe fn rw_lock_size_assert(r: RwLock) {
+    unsafe { mem::transmute::<RwLock, [u8; 144]>(r) };
 }
 
-impl RWLock {
-    pub const fn new() -> RWLock {
-        RWLock {
+impl RwLock {
+    pub const fn new() -> RwLock {
+        RwLock {
             readers: SpinMutex::new(WaitVariable::new(None)),
             writer: SpinMutex::new(WaitVariable::new(false)),
         }
@@ -180,7 +180,7 @@ const EINVAL: i32 = 22;
 
 #[cfg(not(test))]
 #[no_mangle]
-pub unsafe extern "C" fn __rust_rwlock_rdlock(p: *mut RWLock) -> i32 {
+pub unsafe extern "C" fn __rust_rwlock_rdlock(p: *mut RwLock) -> i32 {
     if p.is_null() {
         return EINVAL;
     }
@@ -190,7 +190,7 @@ pub unsafe extern "C" fn __rust_rwlock_rdlock(p: *mut RWLock) -> i32 {
 
 #[cfg(not(test))]
 #[no_mangle]
-pub unsafe extern "C" fn __rust_rwlock_wrlock(p: *mut RWLock) -> i32 {
+pub unsafe extern "C" fn __rust_rwlock_wrlock(p: *mut RwLock) -> i32 {
     if p.is_null() {
         return EINVAL;
     }
@@ -199,7 +199,7 @@ pub unsafe extern "C" fn __rust_rwlock_wrlock(p: *mut RWLock) -> i32 {
 }
 #[cfg(not(test))]
 #[no_mangle]
-pub unsafe extern "C" fn __rust_rwlock_unlock(p: *mut RWLock) -> i32 {
+pub unsafe extern "C" fn __rust_rwlock_unlock(p: *mut RwLock) -> i32 {
     if p.is_null() {
         return EINVAL;
     }

--- a/library/std/src/sys/sgx/rwlock/tests.rs
+++ b/library/std/src/sys/sgx/rwlock/tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 
-// Verify that the byte pattern libunwind uses to initialize an RWLock is
-// equivalent to the value of RWLock::new(). If the value changes,
+// Verify that the byte pattern libunwind uses to initialize an RwLock is
+// equivalent to the value of RwLock::new(). If the value changes,
 // `src/UnwindRustSgx.h` in libunwind needs to be changed too.
 #[test]
 fn test_c_rwlock_initializer() {
@@ -18,9 +18,9 @@ fn test_c_rwlock_initializer() {
         /* 0x80 */ 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
     ];
 
-    // For the test to work, we need the padding/unused bytes in RWLock to be
+    // For the test to work, we need the padding/unused bytes in RwLock to be
     // initialized as 0. In practice, this is the case with statics.
-    static RUST_RWLOCK_INIT: RWLock = RWLock::new();
+    static RUST_RWLOCK_INIT: RwLock = RwLock::new();
 
     unsafe {
         // If the assertion fails, that not necessarily an issue with the value

--- a/library/std/src/sys/solid/os.rs
+++ b/library/std/src/sys/solid/os.rs
@@ -8,7 +8,7 @@ use crate::os::{
     solid::ffi::{OsStrExt, OsStringExt},
 };
 use crate::path::{self, PathBuf};
-use crate::sys_common::rwlock::StaticRWLock;
+use crate::sys_common::rwlock::StaticRwLock;
 use crate::vec;
 
 use super::{abi, error, itron, memchr};
@@ -78,7 +78,7 @@ pub fn current_exe() -> io::Result<PathBuf> {
     unsupported()
 }
 
-static ENV_LOCK: StaticRWLock = StaticRWLock::new();
+static ENV_LOCK: StaticRwLock = StaticRwLock::new();
 
 pub struct Env {
     iter: vec::IntoIter<(OsString, OsString)>,

--- a/library/std/src/sys/solid/rwlock.rs
+++ b/library/std/src/sys/solid/rwlock.rs
@@ -7,24 +7,24 @@ use super::{
     },
 };
 
-pub struct RWLock {
+pub struct RwLock {
     /// The ID of the underlying mutex object
     rwl: SpinIdOnceCell<()>,
 }
 
-pub type MovableRWLock = RWLock;
+pub type MovableRwLock = RwLock;
 
 // Safety: `num_readers` is protected by `mtx_num_readers`
-unsafe impl Send for RWLock {}
-unsafe impl Sync for RWLock {}
+unsafe impl Send for RwLock {}
+unsafe impl Sync for RwLock {}
 
 fn new_rwl() -> Result<abi::ID, ItronError> {
     ItronError::err_if_negative(unsafe { abi::rwl_acre_rwl() })
 }
 
-impl RWLock {
-    pub const fn new() -> RWLock {
-        RWLock { rwl: SpinIdOnceCell::new() }
+impl RwLock {
+    pub const fn new() -> RwLock {
+        RwLock { rwl: SpinIdOnceCell::new() }
     }
 
     /// Get the inner mutex's ID, which is lazily created.

--- a/library/std/src/sys/unix/locks/mod.rs
+++ b/library/std/src/sys/unix/locks/mod.rs
@@ -10,7 +10,7 @@ cfg_if::cfg_if! {
         mod pthread_rwlock; // FIXME: Implement this using a futex
         pub use futex::{Mutex, MovableMutex, Condvar, MovableCondvar};
         pub use pthread_remutex::ReentrantMutex;
-        pub use pthread_rwlock::{RWLock, MovableRWLock};
+        pub use pthread_rwlock::{RwLock, MovableRwLock};
     } else {
         mod pthread_mutex;
         mod pthread_remutex;
@@ -18,7 +18,7 @@ cfg_if::cfg_if! {
         mod pthread_condvar;
         pub use pthread_mutex::{Mutex, MovableMutex};
         pub use pthread_remutex::ReentrantMutex;
-        pub use pthread_rwlock::{RWLock, MovableRWLock};
+        pub use pthread_rwlock::{RwLock, MovableRwLock};
         pub use pthread_condvar::{Condvar, MovableCondvar};
     }
 }

--- a/library/std/src/sys/unix/locks/pthread_rwlock.rs
+++ b/library/std/src/sys/unix/locks/pthread_rwlock.rs
@@ -1,20 +1,20 @@
 use crate::cell::UnsafeCell;
 use crate::sync::atomic::{AtomicUsize, Ordering};
 
-pub struct RWLock {
+pub struct RwLock {
     inner: UnsafeCell<libc::pthread_rwlock_t>,
     write_locked: UnsafeCell<bool>, // guarded by the `inner` RwLock
     num_readers: AtomicUsize,
 }
 
-pub type MovableRWLock = Box<RWLock>;
+pub type MovableRwLock = Box<RwLock>;
 
-unsafe impl Send for RWLock {}
-unsafe impl Sync for RWLock {}
+unsafe impl Send for RwLock {}
+unsafe impl Sync for RwLock {}
 
-impl RWLock {
-    pub const fn new() -> RWLock {
-        RWLock {
+impl RwLock {
+    pub const fn new() -> RwLock {
+        RwLock {
             inner: UnsafeCell::new(libc::PTHREAD_RWLOCK_INITIALIZER),
             write_locked: UnsafeCell::new(false),
             num_readers: AtomicUsize::new(0),

--- a/library/std/src/sys/unix/os.rs
+++ b/library/std/src/sys/unix/os.rs
@@ -20,7 +20,7 @@ use crate::str;
 use crate::sys::cvt;
 use crate::sys::fd;
 use crate::sys::memchr;
-use crate::sys_common::rwlock::{StaticRWLock, StaticRWLockReadGuard};
+use crate::sys_common::rwlock::{StaticRwLock, StaticRwLockReadGuard};
 use crate::vec;
 
 #[cfg(all(target_env = "gnu", not(target_os = "vxworks")))]
@@ -481,9 +481,9 @@ pub unsafe fn environ() -> *mut *const *const c_char {
     ptr::addr_of_mut!(environ)
 }
 
-static ENV_LOCK: StaticRWLock = StaticRWLock::new();
+static ENV_LOCK: StaticRwLock = StaticRwLock::new();
 
-pub fn env_read_lock() -> StaticRWLockReadGuard {
+pub fn env_read_lock() -> StaticRwLockReadGuard {
     ENV_LOCK.read()
 }
 

--- a/library/std/src/sys/unsupported/locks/mod.rs
+++ b/library/std/src/sys/unsupported/locks/mod.rs
@@ -3,4 +3,4 @@ mod mutex;
 mod rwlock;
 pub use condvar::{Condvar, MovableCondvar};
 pub use mutex::{MovableMutex, Mutex, ReentrantMutex};
-pub use rwlock::{MovableRWLock, RWLock};
+pub use rwlock::{MovableRwLock, RwLock};

--- a/library/std/src/sys/unsupported/locks/rwlock.rs
+++ b/library/std/src/sys/unsupported/locks/rwlock.rs
@@ -1,18 +1,18 @@
 use crate::cell::Cell;
 
-pub struct RWLock {
+pub struct RwLock {
     // This platform has no threads, so we can use a Cell here.
     mode: Cell<isize>,
 }
 
-pub type MovableRWLock = RWLock;
+pub type MovableRwLock = RwLock;
 
-unsafe impl Send for RWLock {}
-unsafe impl Sync for RWLock {} // no threads on this platform
+unsafe impl Send for RwLock {}
+unsafe impl Sync for RwLock {} // no threads on this platform
 
-impl RWLock {
-    pub const fn new() -> RWLock {
-        RWLock { mode: Cell::new(0) }
+impl RwLock {
+    pub const fn new() -> RwLock {
+        RwLock { mode: Cell::new(0) }
     }
 
     #[inline]

--- a/library/std/src/sys/wasm/atomics/rwlock.rs
+++ b/library/std/src/sys/wasm/atomics/rwlock.rs
@@ -1,13 +1,13 @@
 use crate::cell::UnsafeCell;
 use crate::sys::locks::{Condvar, Mutex};
 
-pub struct RWLock {
+pub struct RwLock {
     lock: Mutex,
     cond: Condvar,
     state: UnsafeCell<State>,
 }
 
-pub type MovableRWLock = RWLock;
+pub type MovableRwLock = RwLock;
 
 enum State {
     Unlocked,
@@ -15,8 +15,8 @@ enum State {
     Writing,
 }
 
-unsafe impl Send for RWLock {}
-unsafe impl Sync for RWLock {}
+unsafe impl Send for RwLock {}
+unsafe impl Sync for RwLock {}
 
 // This rwlock implementation is a relatively simple implementation which has a
 // condition variable for readers/writers as well as a mutex protecting the
@@ -26,9 +26,9 @@ unsafe impl Sync for RWLock {}
 // hopefully correct this implementation is very likely to want to be changed in
 // the future.
 
-impl RWLock {
-    pub const fn new() -> RWLock {
-        RWLock { lock: Mutex::new(), cond: Condvar::new(), state: UnsafeCell::new(State::Unlocked) }
+impl RwLock {
+    pub const fn new() -> RwLock {
+        RwLock { lock: Mutex::new(), cond: Condvar::new(), state: UnsafeCell::new(State::Unlocked) }
     }
 
     #[inline]

--- a/library/std/src/sys/windows/locks/mod.rs
+++ b/library/std/src/sys/windows/locks/mod.rs
@@ -3,4 +3,4 @@ mod mutex;
 mod rwlock;
 pub use condvar::{Condvar, MovableCondvar};
 pub use mutex::{MovableMutex, Mutex, ReentrantMutex};
-pub use rwlock::{MovableRWLock, RWLock};
+pub use rwlock::{MovableRwLock, RwLock};

--- a/library/std/src/sys/windows/locks/rwlock.rs
+++ b/library/std/src/sys/windows/locks/rwlock.rs
@@ -1,18 +1,18 @@
 use crate::cell::UnsafeCell;
 use crate::sys::c;
 
-pub struct RWLock {
+pub struct RwLock {
     inner: UnsafeCell<c::SRWLOCK>,
 }
 
-pub type MovableRWLock = RWLock;
+pub type MovableRwLock = RwLock;
 
-unsafe impl Send for RWLock {}
-unsafe impl Sync for RWLock {}
+unsafe impl Send for RwLock {}
+unsafe impl Sync for RwLock {}
 
-impl RWLock {
-    pub const fn new() -> RWLock {
-        RWLock { inner: UnsafeCell::new(c::SRWLOCK_INIT) }
+impl RwLock {
+    pub const fn new() -> RwLock {
+        RwLock { inner: UnsafeCell::new(c::SRWLOCK_INIT) }
     }
     #[inline]
     pub unsafe fn read(&self) {

--- a/library/std/src/sys_common/rwlock.rs
+++ b/library/std/src/sys_common/rwlock.rs
@@ -4,14 +4,14 @@ use crate::sys::locks as imp;
 ///
 /// This rwlock does not implement poisoning.
 ///
-/// This rwlock has a const constructor ([`StaticRWLock::new`]), does not
+/// This rwlock has a const constructor ([`StaticRwLock::new`]), does not
 /// implement `Drop` to cleanup resources.
-pub struct StaticRWLock(imp::RWLock);
+pub struct StaticRwLock(imp::RwLock);
 
-impl StaticRWLock {
+impl StaticRwLock {
     /// Creates a new rwlock for use.
     pub const fn new() -> Self {
-        Self(imp::RWLock::new())
+        Self(imp::RwLock::new())
     }
 
     /// Acquires shared access to the underlying lock, blocking the current
@@ -19,9 +19,9 @@ impl StaticRWLock {
     ///
     /// The lock is automatically unlocked when the returned guard is dropped.
     #[inline]
-    pub fn read(&'static self) -> StaticRWLockReadGuard {
+    pub fn read(&'static self) -> StaticRwLockReadGuard {
         unsafe { self.0.read() };
-        StaticRWLockReadGuard(&self.0)
+        StaticRwLockReadGuard(&self.0)
     }
 
     /// Acquires write access to the underlying lock, blocking the current thread
@@ -29,16 +29,16 @@ impl StaticRWLock {
     ///
     /// The lock is automatically unlocked when the returned guard is dropped.
     #[inline]
-    pub fn write(&'static self) -> StaticRWLockWriteGuard {
+    pub fn write(&'static self) -> StaticRwLockWriteGuard {
         unsafe { self.0.write() };
-        StaticRWLockWriteGuard(&self.0)
+        StaticRwLockWriteGuard(&self.0)
     }
 }
 
 #[must_use]
-pub struct StaticRWLockReadGuard(&'static imp::RWLock);
+pub struct StaticRwLockReadGuard(&'static imp::RwLock);
 
-impl Drop for StaticRWLockReadGuard {
+impl Drop for StaticRwLockReadGuard {
     #[inline]
     fn drop(&mut self) {
         unsafe {
@@ -48,9 +48,9 @@ impl Drop for StaticRWLockReadGuard {
 }
 
 #[must_use]
-pub struct StaticRWLockWriteGuard(&'static imp::RWLock);
+pub struct StaticRwLockWriteGuard(&'static imp::RwLock);
 
-impl Drop for StaticRWLockWriteGuard {
+impl Drop for StaticRwLockWriteGuard {
     #[inline]
     fn drop(&mut self) {
         unsafe {
@@ -66,15 +66,15 @@ impl Drop for StaticRWLockWriteGuard {
 ///
 /// This rwlock does not implement poisoning.
 ///
-/// This is either a wrapper around `Box<imp::RWLock>` or `imp::RWLock`,
-/// depending on the platform. It is boxed on platforms where `imp::RWLock` may
+/// This is either a wrapper around `Box<imp::RwLock>` or `imp::RwLock`,
+/// depending on the platform. It is boxed on platforms where `imp::RwLock` may
 /// not be moved.
-pub struct MovableRWLock(imp::MovableRWLock);
+pub struct MovableRwLock(imp::MovableRwLock);
 
-impl MovableRWLock {
+impl MovableRwLock {
     /// Creates a new reader-writer lock for use.
     pub fn new() -> Self {
-        Self(imp::MovableRWLock::from(imp::RWLock::new()))
+        Self(imp::MovableRwLock::from(imp::RwLock::new()))
     }
 
     /// Acquires shared access to the underlying lock, blocking the current
@@ -127,7 +127,7 @@ impl MovableRWLock {
     }
 }
 
-impl Drop for MovableRWLock {
+impl Drop for MovableRwLock {
     fn drop(&mut self) {
         unsafe { self.0.destroy() };
     }


### PR DESCRIPTION
std::sync::RwLock is spelled with two capital letters, but std::sys's RWLock was spelled with three capital letters. This cleans that up and uses `RwLock` everywhere.