### PR TITLE
Check that all hidden types are the same and then deduplicate them.

### DIFF
--- a/src/test/ui/type-alias-impl-trait/multiple_definitions.rs
+++ b/src/test/ui/type-alias-impl-trait/multiple_definitions.rs
@@ -1,0 +1,30 @@
+// check-pass
+
+use std::marker::PhantomData;
+
+pub struct ConcreteError {}
+pub trait IoBase {}
+struct X {}
+impl IoBase for X {}
+
+pub struct ClusterIterator<B, E, S = B> {
+    pub fat: B,
+    phantom_s: PhantomData<S>,
+    phantom_e: PhantomData<E>,
+}
+
+pub struct FileSystem<IO: IoBase> {
+    pub disk: IO,
+}
+
+impl<IO: IoBase> FileSystem<IO> {
+    pub fn cluster_iter(&self) -> ClusterIterator<impl IoBase + '_, ConcreteError> {
+        ClusterIterator {
+            fat: X {},
+            phantom_s: PhantomData::default(),
+            phantom_e: PhantomData::default(),
+        }
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
fixes #95538

This used to trigger a sanity check. Now we accept that there may be multiple places where a hidden type is constrained and we merge all of these at the end.

Ideally we'd merge eagerly, but that is a larger refactoring that I don't want to put into a backport