### PR TITLE
Revert "Mark Location::caller() as #[inline]"

### DIFF
--- a/library/core/src/panic/location.rs
+++ b/library/core/src/panic/location.rs
@@ -83,7 +83,6 @@ impl<'a> Location<'a> {
     #[stable(feature = "track_caller", since = "1.46.0")]
     #[rustc_const_unstable(feature = "const_caller_location", issue = "76156")]
     #[track_caller]
-    #[inline]
     pub const fn caller() -> &'static Location<'static> {
         crate::intrinsics::caller_location()
     }


### PR DESCRIPTION
This reverts https://github.com/rust-lang/rust/pull/95619. As noted in https://github.com/rust-lang/rust/pull/95619#issuecomment-1088548140 this seems to break several tests with cg_clif.