### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/library/core/src/panic/location.rs
+++ b/library/core/src/panic/location.rs
@@ -83,7 +83,6 @@ impl<'a> Location<'a> {
     #[stable(feature = "track_caller", since = "1.46.0")]
     #[rustc_const_unstable(feature = "const_caller_location", issue = "76156")]
     #[track_caller]
-    #[inline]
     pub const fn caller() -> &'static Location<'static> {
         crate::intrinsics::caller_location()
     }

--- a/library/std/src/io/stdio.rs
+++ b/library/std/src/io/stdio.rs
@@ -394,7 +394,6 @@ impl Stdin {
     /// # Examples
     ///
     /// ```no_run
-    /// #![feature(stdin_forwarders)]
     /// use std::io;
     ///
     /// let lines = io::stdin().lines();
@@ -403,7 +402,7 @@ impl Stdin {
     /// }
     /// ```
     #[must_use = "`self` will be dropped if the result is not used"]
-    #[unstable(feature = "stdin_forwarders", issue = "87096")]
+    #[stable(feature = "stdin_forwarders", since = "1.61.0")]
     pub fn lines(self) -> Lines<StdinLock<'static>> {
         self.lock().lines()
     }

--- a/library/std/src/io/stdio.rs
+++ b/library/std/src/io/stdio.rs
@@ -402,7 +402,7 @@ impl Stdin {
     /// }
     /// ```
     #[must_use = "`self` will be dropped if the result is not used"]
-    #[stable(feature = "stdin_forwarders", since = "1.61.0")]
+    #[stable(feature = "stdin_forwarders", since = "1.62.0")]
     pub fn lines(self) -> Lines<StdinLock<'static>> {
         self.lock().lines()
     }

--- a/library/std/src/sys/unix/thread.rs
+++ b/library/std/src/sys/unix/thread.rs
@@ -122,7 +122,7 @@ impl Thread {
         // pthread wrapper only appeared in glibc 2.12, so we use syscall
         // directly.
         unsafe {
-            libc::prctl(PR_SET_NAME, name.as_ptr() as libc::c_ulong, 0, 0, 0);
+            libc::prctl(PR_SET_NAME, name.as_ptr(), 0, 0, 0);
         }
     }
 

--- a/library/std/src/sys/unix/thread.rs
+++ b/library/std/src/sys/unix/thread.rs
@@ -122,7 +122,13 @@ impl Thread {
         // pthread wrapper only appeared in glibc 2.12, so we use syscall
         // directly.
         unsafe {
-            libc::prctl(PR_SET_NAME, name.as_ptr(), 0, 0, 0);
+            libc::prctl(
+                PR_SET_NAME,
+                name.as_ptr(),
+                0 as libc::c_ulong,
+                0 as libc::c_ulong,
+                0 as libc::c_ulong,
+            );
         }
     }
 

--- a/library/test/src/formatters/terse.rs
+++ b/library/test/src/formatters/terse.rs
@@ -11,8 +11,9 @@ use crate::{
     types::TestDesc,
 };
 
-// insert a '\n' after 100 tests in quiet mode
-const QUIET_MODE_MAX_COLUMN: usize = 100;
+// We insert a '\n' when the output hits 100 columns in quiet mode. 88 test
+// result chars leaves 12 chars for a progress count like " 11704/12853".
+const QUIET_MODE_MAX_COLUMN: usize = 88;
 
 pub(crate) struct TerseFormatter<T> {
     out: OutputLocation<T>,
@@ -65,7 +66,7 @@ impl<T: Write> TerseFormatter<T> {
     ) -> io::Result<()> {
         self.write_pretty(result, color)?;
         if self.test_count % QUIET_MODE_MAX_COLUMN == QUIET_MODE_MAX_COLUMN - 1 {
-            // we insert a new line every 100 dots in order to flush the
+            // We insert a new line regularly in order to flush the
             // screen when dealing with line-buffered output (e.g., piping to
             // `stamp` in the rust CI).
             let out = format!(" {}/{}\n", self.test_count + 1, self.total_test_count);

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -597,11 +597,11 @@ fn document_item_info(
 ) {
     let item_infos = short_item_info(item, cx, parent);
     if !item_infos.is_empty() {
-        w.write_str("<div class=\"item-info\">");
+        w.write_str("<span class=\"item-info\">");
         for info in item_infos {
             w.write_str(&info);
         }
-        w.write_str("</div>");
+        w.write_str("</span>");
     }
 }
 
@@ -1772,7 +1772,7 @@ pub(crate) fn render_impl_summary(
     let is_trait = i.inner_impl().trait_.is_some();
     if is_trait {
         if let Some(portability) = portability(&i.impl_item, Some(parent)) {
-            write!(w, "<div class=\"item-info\">{}</div>", portability);
+            write!(w, "<span class=\"item-info\">{}</span>", portability);
         }
     }
 

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -737,6 +737,10 @@ h2.location a {
 	border: none;
 }
 
+.item-info {
+	display: block;
+}
+
 .content .item-info code {
 	font-size: 0.875rem;
 }

--- a/src/test/rustdoc/stability.rs
+++ b/src/test/rustdoc/stability.rs
@@ -4,7 +4,7 @@
 
 pub struct Unstable {
     // @has stability/struct.Unstable.html \
-    //      '//div[@class="item-info"]//div[@class="stab unstable"]' \
+    //      '//span[@class="item-info"]//div[@class="stab unstable"]' \
     //      'This is a nightly-only experimental API'
     // @count stability/struct.Unstable.html '//span[@class="stab unstable"]' 0
     pub foo: u32,


### PR DESCRIPTION
Successful merges:

 - #95185 (Stabilize Stdin::lines.)
 - #95626 (Don't cast thread name to an integer for prctl)
 - #95709 (Improve terse test output.)
 - #95735 (Revert "Mark Location::caller() as #[inline]")
 - #95738 (Switch item-info from div to span)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=95185,95626,95709,95735,95738)
<!-- homu-ignore:end -->