### PR TITLE
only downgrade selection Error -> Ambiguous if type error is in predicate

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/select/candidate_assembly.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/candidate_assembly.rs
@@ -231,8 +231,8 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             // `Err(Unimplemented)` to `Ok(None)`. This helps us avoid
             // emitting additional spurious errors, since we're guaranteed
             // to have emitted at least one.
-            if stack.obligation.references_error() {
-                debug!("no results for error type, treating as ambiguous");
+            if stack.obligation.predicate.references_error() {
+                debug!(?stack.obligation.predicate, "found error type in predicate, treating as ambiguous");
                 return Ok(None);
             }
             return Err(Unimplemented);

--- a/src/test/ui/functions-closures/fn-help-with-err-generic-is-not-function.rs
+++ b/src/test/ui/functions-closures/fn-help-with-err-generic-is-not-function.rs
@@ -8,15 +8,7 @@ where
     //~^ ERROR cannot find type `T` in this scope
     //~| NOTE not found in this scope
 {
-    // The part where it claims that there is no method named `len` is a bug. Feel free to fix it.
-    // This test is intended to ensure that a different bug, where it claimed
-    // that `v` was a function, does not regress.
     fn method(v: Vec<u8>) { v.len(); }
-    //~^ ERROR type annotations needed
-    //~| NOTE cannot infer type
-    //~| NOTE type must be known at this point
-    //~| ERROR no method named `len`
-    //~| NOTE private field, not a method
 }
 
 fn main() {}

--- a/src/test/ui/functions-closures/fn-help-with-err-generic-is-not-function.stderr
+++ b/src/test/ui/functions-closures/fn-help-with-err-generic-is-not-function.stderr
@@ -12,21 +12,6 @@ error[E0412]: cannot find type `T` in this scope
 LL |     T: Copy,
    |     ^ not found in this scope
 
-error[E0282]: type annotations needed
-  --> $DIR/fn-help-with-err-generic-is-not-function.rs:14:31
-   |
-LL |     fn method(v: Vec<u8>) { v.len(); }
-   |                               ^^^ cannot infer type
-   |
-   = note: type must be known at this point
+error: aborting due to 2 previous errors
 
-error[E0599]: no method named `len` found for struct `Vec<u8>` in the current scope
-  --> $DIR/fn-help-with-err-generic-is-not-function.rs:14:31
-   |
-LL |     fn method(v: Vec<u8>) { v.len(); }
-   |                               ^^^ private field, not a method
-
-error: aborting due to 4 previous errors
-
-Some errors have detailed explanations: E0282, E0412, E0599.
-For more information about an error, try `rustc --explain E0282`.
+For more information about this error, try `rustc --explain E0412`.

--- a/src/test/ui/typeck/autoderef-with-param-env-error.rs
+++ b/src/test/ui/typeck/autoderef-with-param-env-error.rs
@@ -1,0 +1,9 @@
+fn foo()
+where
+    T: Send,
+    //~^ cannot find type `T` in this scope
+{
+    let s = "abc".to_string();
+}
+
+fn main() {}

--- a/src/test/ui/typeck/autoderef-with-param-env-error.stderr
+++ b/src/test/ui/typeck/autoderef-with-param-env-error.stderr
@@ -1,0 +1,12 @@
+error[E0412]: cannot find type `T` in this scope
+  --> $DIR/autoderef-with-param-env-error.rs:3:5
+   |
+LL | fn foo()
+   |       - help: you might be missing a type parameter: `<T>`
+LL | where
+LL |     T: Send,
+   |     ^ not found in this scope
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0412`.


### PR DESCRIPTION
That is, we don't care if there's a TypeError type in the ParamEnv.

Fixes #95408