### PR TITLE
Don't consider predicates with HRTBs to be global during winnowing

### DIFF
--- a/src/test/ui/mir/issue-95640.rs
+++ b/src/test/ui/mir/issue-95640.rs
@@ -1,0 +1,31 @@
+// build-pass
+// compile-flags:-Zmir-opt-level=3
+
+struct D;
+
+trait Tr {
+    type It;
+    fn foo(self) -> Option<Self::It>;
+}
+
+impl<'a> Tr for &'a D {
+    type It = ();
+    fn foo(self) -> Option<()> {
+        None
+    }
+}
+
+fn run<F>(f: F)
+where
+    for<'a> &'a D: Tr,
+    F: Fn(<&D as Tr>::It),
+{
+    let d = &D;
+    while let Some(i) = d.foo() {
+        f(i);
+    }
+}
+
+fn main() {
+    run(|_| {});
+}


### PR DESCRIPTION
Kinda along the same lines as #95611, predicates with `for<'a>` in them shouldn't be treated specially, and are (or should be treated) as "global" as predicates without bound variables.

Fixes #95640