### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/compiler/rustc_builtin_macros/src/source_util.rs
+++ b/compiler/rustc_builtin_macros/src/source_util.rs
@@ -141,7 +141,7 @@ pub fn expand_include<'cx>(
 
         fn make_items(mut self: Box<ExpandResult<'a>>) -> Option<SmallVec<[P<ast::Item>; 1]>> {
             let mut ret = SmallVec::new();
-            while self.p.token != token::Eof {
+            loop {
                 match self.p.parse_item(ForceCollect::No) {
                     Err(mut err) => {
                         err.emit();
@@ -149,9 +149,12 @@ pub fn expand_include<'cx>(
                     }
                     Ok(Some(item)) => ret.push(item),
                     Ok(None) => {
-                        let token = pprust::token_to_string(&self.p.token);
-                        let msg = format!("expected item, found `{}`", token);
-                        self.p.struct_span_err(self.p.token.span, &msg).emit();
+                        if self.p.token != token::Eof {
+                            let token = pprust::token_to_string(&self.p.token);
+                            let msg = format!("expected item, found `{}`", token);
+                            self.p.struct_span_err(self.p.token.span, &msg).emit();
+                        }
+
                         break;
                     }
                 }

--- a/compiler/rustc_expand/src/mbe/macro_parser.rs
+++ b/compiler/rustc_expand/src/mbe/macro_parser.rs
@@ -315,7 +315,7 @@ pub(super) fn count_metavar_decls(matcher: &[TokenTree]) -> usize {
 /// only on the nesting depth of repetitions in the originating token tree it
 /// was derived from.
 ///
-/// In layman's terms: `NamedMatch` will form a tree representing nested matches of a particular
+/// In layperson's terms: `NamedMatch` will form a tree representing nested matches of a particular
 /// meta variable. For example, if we are matching the following macro against the following
 /// invocation...
 ///

--- a/compiler/rustc_typeck/src/check/wfcheck.rs
+++ b/compiler/rustc_typeck/src/check/wfcheck.rs
@@ -1657,7 +1657,7 @@ fn receiver_is_valid<'fcx, 'tcx>(
             }
         } else {
             debug!("receiver_is_valid: type `{:?}` does not deref to `{:?}`", receiver_ty, self_ty);
-            // If he receiver already has errors reported due to it, consider it valid to avoid
+            // If the receiver already has errors reported due to it, consider it valid to avoid
             // unnecessary errors (#58712).
             return receiver_ty.references_error();
         }

--- a/compiler/rustc_typeck/src/collect.rs
+++ b/compiler/rustc_typeck/src/collect.rs
@@ -2700,7 +2700,7 @@ fn linkage_by_name(tcx: TyCtxt<'_>, def_id: DefId, name: &str) -> Linkage {
     // Use the names from src/llvm/docs/LangRef.rst here. Most types are only
     // applicable to variable declarations and may not really make sense for
     // Rust code in the first place but allow them anyway and trust that the
-    // user knows what s/he's doing. Who knows, unanticipated use cases may pop
+    // user knows what they're doing. Who knows, unanticipated use cases may pop
     // up in the future.
     //
     // ghost, dllimport, dllexport and linkonce_odr_autohide are not supported

--- a/library/core/src/str/mod.rs
+++ b/library/core/src/str/mod.rs
@@ -2407,7 +2407,7 @@ impl str {
     #[stable(feature = "ascii_methods_on_intrinsics", since = "1.23.0")]
     #[inline]
     pub fn make_ascii_uppercase(&mut self) {
-        // SAFETY: safe because we transmute two types with the same layout.
+        // SAFETY: changing ASCII letters only does not invalidate UTF-8.
         let me = unsafe { self.as_bytes_mut() };
         me.make_ascii_uppercase()
     }
@@ -2434,7 +2434,7 @@ impl str {
     #[stable(feature = "ascii_methods_on_intrinsics", since = "1.23.0")]
     #[inline]
     pub fn make_ascii_lowercase(&mut self) {
-        // SAFETY: safe because we transmute two types with the same layout.
+        // SAFETY: changing ASCII letters only does not invalidate UTF-8.
         let me = unsafe { self.as_bytes_mut() };
         me.make_ascii_lowercase()
     }

--- a/library/std/src/fs/tests.rs
+++ b/library/std/src/fs/tests.rs
@@ -644,9 +644,9 @@ fn recursive_rmdir_toctou() {
     // Test for time-of-check to time-of-use issues.
     //
     // Scenario:
-    // The attacker wants to get directory contents deleted, to which he does not have access.
-    // He has a way to get a privileged Rust binary call `std::fs::remove_dir_all()` on a
-    // directory he controls, e.g. in his home directory.
+    // The attacker wants to get directory contents deleted, to which they do not have access.
+    // They have a way to get a privileged Rust binary call `std::fs::remove_dir_all()` on a
+    // directory they control, e.g. in their home directory.
     //
     // The POC sets up the `attack_dest/attack_file` which the attacker wants to have deleted.
     // The attacker repeatedly creates a directory and replaces it with a symlink from

--- a/library/std/src/thread/local.rs
+++ b/library/std/src/thread/local.rs
@@ -980,7 +980,7 @@ pub mod fast {
         unsafe fn try_initialize<F: FnOnce() -> T>(&self, init: F) -> Option<&'static T> {
             // SAFETY: See comment above (this function doc).
             if !mem::needs_drop::<T>() || unsafe { self.try_register_dtor() } {
-                // SAFETY: See comment above (his function doc).
+                // SAFETY: See comment above (this function doc).
                 Some(unsafe { self.inner.initialize(init) })
             } else {
                 None

--- a/src/test/ui/match/issue-82866.rs
+++ b/src/test/ui/match/issue-82866.rs
@@ -1,0 +1,7 @@
+fn main() {
+    match x {
+        //~^ ERROR cannot find value `x` in this scope
+        Some::<v>(v) => (),
+        //~^ ERROR cannot find type `v` in this scope
+    }
+}

--- a/src/test/ui/match/issue-82866.stderr
+++ b/src/test/ui/match/issue-82866.stderr
@@ -1,0 +1,16 @@
+error[E0425]: cannot find value `x` in this scope
+  --> $DIR/issue-82866.rs:2:11
+   |
+LL |     match x {
+   |           ^ not found in this scope
+
+error[E0412]: cannot find type `v` in this scope
+  --> $DIR/issue-82866.rs:4:16
+   |
+LL |         Some::<v>(v) => (),
+   |                ^ not found in this scope
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0412, E0425.
+For more information about an error, try `rustc --explain E0412`.

--- a/src/test/ui/parser/attr.rs
+++ b/src/test/ui/parser/attr.rs
@@ -3,5 +3,4 @@
 fn main() {}
 
 #![lang = "foo"] //~ ERROR an inner attribute is not permitted in this context
-                 //~| ERROR definition of an unknown language item: `foo`
 fn foo() {}

--- a/src/test/ui/parser/attr.stderr
+++ b/src/test/ui/parser/attr.stderr
@@ -3,7 +3,6 @@ error: an inner attribute is not permitted in this context
    |
 LL | #![lang = "foo"]
    | ^^^^^^^^^^^^^^^^
-LL |
 LL | fn foo() {}
    | ----------- the inner attribute doesn't annotate this function
    |
@@ -14,12 +13,5 @@ LL - #![lang = "foo"]
 LL + #[lang = "foo"]
    | 
 
-error[E0522]: definition of an unknown language item: `foo`
-  --> $DIR/attr.rs:5:1
-   |
-LL | #![lang = "foo"]
-   | ^^^^^^^^^^^^^^^^ definition of unknown language item `foo`
+error: aborting due to previous error
 
-error: aborting due to 2 previous errors
-
-For more information about this error, try `rustc --explain E0522`.

--- a/src/test/ui/parser/issues/auxiliary/issue-94340-inc.rs
+++ b/src/test/ui/parser/issues/auxiliary/issue-94340-inc.rs
@@ -1,0 +1,3 @@
+// include file for issue-94340.rs
+#![deny(rust_2018_idioms)]
+#![deny(unused_must_use)]

--- a/src/test/ui/parser/issues/issue-94340.rs
+++ b/src/test/ui/parser/issues/issue-94340.rs
@@ -1,0 +1,8 @@
+// Make sure that unexpected inner attributes are not labeled as outer ones in diagnostics when
+// trying to parse an item and that they are subsequently ignored not triggering confusing extra
+// diagnostics like "expected item after attributes" which is not true for `include!` which can
+// include empty files.
+
+include!("auxiliary/issue-94340-inc.rs");
+
+fn main() {}

--- a/src/test/ui/parser/issues/issue-94340.stderr
+++ b/src/test/ui/parser/issues/issue-94340.stderr
@@ -1,0 +1,20 @@
+error: an inner attribute is not permitted in this context
+  --> $DIR/auxiliary/issue-94340-inc.rs:2:1
+   |
+LL | #![deny(rust_2018_idioms)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files
+   = note: outer attributes, like `#[test]`, annotate the item following them
+
+error: an inner attribute is not permitted in this context
+  --> $DIR/auxiliary/issue-94340-inc.rs:3:1
+   |
+LL | #![deny(unused_must_use)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files
+   = note: outer attributes, like `#[test]`, annotate the item following them
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Successful merges:

 - #95189 (Stop flagging unexpected inner attributes as outer ones in certain diagnostics)
 - #95752 (Regression test for #82866)
 - #95753 (Correct safety reasoning in `str::make_ascii_{lower,upper}case()`)
 - #95757 (Use gender neutral terms)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=95189,95752,95753,95757)
<!-- homu-ignore:end -->