### PR TITLE
Windows: Increase a pipe's buffer capacity to 64kb

### DIFF
--- a/library/std/src/sys/windows/pipe.rs
+++ b/library/std/src/sys/windows/pipe.rs
@@ -53,6 +53,9 @@ pub struct Pipes {
 /// with `OVERLAPPED` instances, but also works out ok if it's only ever used
 /// once at a time (which we do indeed guarantee).
 pub fn anon_pipe(ours_readable: bool, their_handle_inheritable: bool) -> io::Result<Pipes> {
+    // A 64kb pipe capacity is the same as a typical Linux default.
+    const PIPE_BUFFER_CAPACITY: u32 = 64 * 1024;
+
     // Note that we specifically do *not* use `CreatePipe` here because
     // unfortunately the anonymous pipes returned do not support overlapped
     // operations. Instead, we create a "hopefully unique" name and create a
@@ -91,8 +94,8 @@ pub fn anon_pipe(ours_readable: bool, their_handle_inheritable: bool) -> io::Res
                     | c::PIPE_WAIT
                     | reject_remote_clients_flag,
                 1,
-                4096,
-                4096,
+                PIPE_BUFFER_CAPACITY,
+                PIPE_BUFFER_CAPACITY,
                 0,
                 ptr::null_mut(),
             );


### PR DESCRIPTION
This brings it inline with typical Linux defaults: https://www.man7.org/linux/man-pages/man7/pipe.7.html

> Since Linux 2.6.11, the pipe capacity is 16 pages (i.e., 65,536 bytes in a system with a page size of 4096 bytes).

This may also help with #45572 and #95759 but does not fix either issue. It simply makes them much less likely to be encountered.