### PR TITLE
rustdoc doctest: include signal number in exit status

### DIFF
--- a/src/librustdoc/doctest.rs
+++ b/src/librustdoc/doctest.rs
@@ -1069,13 +1069,7 @@ impl Tester for Collector {
                             }
                         }
                         TestFailure::ExecutionFailure(out) => {
-                            let reason = if let Some(code) = out.status.code() {
-                                format!("exit code {code}")
-                            } else {
-                                String::from("terminated by signal")
-                            };
-
-                            eprintln!("Test executable failed ({reason}).");
+                            eprintln!("Test executable failed ({reason}).", reason = out.status);
 
                             // FIXME(#12309): An unfortunate side-effect of capturing the test
                             // executable's output is that the relative ordering between the test's

--- a/src/test/rustdoc-ui/failed-doctest-output-windows.rs
+++ b/src/test/rustdoc-ui/failed-doctest-output-windows.rs
@@ -1,5 +1,5 @@
 // only-windows
-// There's a parallel generic version of this test for POSIXy platforms.
+// There's a parallel generic version of this test for non-windows platforms.
 
 // Issue #51162: A failed doctest was not printing its stdout/stderr
 // FIXME: if/when the output of the test harness can be tested on its own, this test should be

--- a/src/test/rustdoc-ui/failed-doctest-output-windows.rs
+++ b/src/test/rustdoc-ui/failed-doctest-output-windows.rs
@@ -1,5 +1,5 @@
-// ignore-windows
-// There's a parallel version of this test for Windows.
+// only-windows
+// There's a parallel generic version of this test for POSIXy platforms.
 
 // Issue #51162: A failed doctest was not printing its stdout/stderr
 // FIXME: if/when the output of the test harness can be tested on its own, this test should be

--- a/src/test/rustdoc-ui/failed-doctest-output-windows.stdout
+++ b/src/test/rustdoc-ui/failed-doctest-output-windows.stdout
@@ -1,0 +1,39 @@
+
+running 2 tests
+test $DIR/failed-doctest-output.rs - OtherStruct (line 22) ... FAILED
+test $DIR/failed-doctest-output.rs - SomeStruct (line 12) ... FAILED
+
+failures:
+
+---- $DIR/failed-doctest-output.rs - OtherStruct (line 22) stdout ----
+error[E0425]: cannot find value `no` in this scope
+  --> $DIR/failed-doctest-output.rs:23:1
+   |
+LL | no
+   | ^^ not found in this scope
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0425`.
+Couldn't compile the test.
+---- $DIR/failed-doctest-output.rs - SomeStruct (line 12) stdout ----
+Test executable failed (exit code: 101).
+
+stdout:
+stdout 1
+stdout 2
+
+stderr:
+stderr 1
+stderr 2
+thread 'main' panicked at 'oh no', $DIR/failed-doctest-output.rs:7:1
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+
+
+
+failures:
+    $DIR/failed-doctest-output.rs - OtherStruct (line 22)
+    $DIR/failed-doctest-output.rs - SomeStruct (line 12)
+
+test result: FAILED. 0 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
+

--- a/src/test/rustdoc-ui/failed-doctest-output-windows.stdout
+++ b/src/test/rustdoc-ui/failed-doctest-output-windows.stdout
@@ -1,13 +1,13 @@
 
 running 2 tests
-test $DIR/failed-doctest-output.rs - OtherStruct (line 22) ... FAILED
-test $DIR/failed-doctest-output.rs - SomeStruct (line 12) ... FAILED
+test $DIR/failed-doctest-output-windows.rs - OtherStruct (line 25) ... FAILED
+test $DIR/failed-doctest-output-windows.rs - SomeStruct (line 15) ... FAILED
 
 failures:
 
----- $DIR/failed-doctest-output.rs - OtherStruct (line 22) stdout ----
+---- $DIR/failed-doctest-output-windows.rs - OtherStruct (line 25) stdout ----
 error[E0425]: cannot find value `no` in this scope
-  --> $DIR/failed-doctest-output.rs:23:1
+  --> $DIR/failed-doctest-output-windows.rs:26:1
    |
 LL | no
    | ^^ not found in this scope
@@ -16,7 +16,7 @@ error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0425`.
 Couldn't compile the test.
----- $DIR/failed-doctest-output.rs - SomeStruct (line 12) stdout ----
+---- $DIR/failed-doctest-output-windows.rs - SomeStruct (line 15) stdout ----
 Test executable failed (exit code: 101).
 
 stdout:
@@ -26,14 +26,14 @@ stdout 2
 stderr:
 stderr 1
 stderr 2
-thread 'main' panicked at 'oh no', $DIR/failed-doctest-output.rs:7:1
+thread 'main' panicked at 'oh no', $DIR/failed-doctest-output-windows.rs:7:1
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 
 
 
 failures:
-    $DIR/failed-doctest-output.rs - OtherStruct (line 22)
-    $DIR/failed-doctest-output.rs - SomeStruct (line 12)
+    $DIR/failed-doctest-output-windows.rs - OtherStruct (line 25)
+    $DIR/failed-doctest-output-windows.rs - SomeStruct (line 15)
 
 test result: FAILED. 0 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
 

--- a/src/test/rustdoc-ui/failed-doctest-output.stdout
+++ b/src/test/rustdoc-ui/failed-doctest-output.stdout
@@ -1,13 +1,13 @@
 
 running 2 tests
-test $DIR/failed-doctest-output.rs - OtherStruct (line 22) ... FAILED
-test $DIR/failed-doctest-output.rs - SomeStruct (line 12) ... FAILED
+test $DIR/failed-doctest-output.rs - OtherStruct (line 25) ... FAILED
+test $DIR/failed-doctest-output.rs - SomeStruct (line 15) ... FAILED
 
 failures:
 
----- $DIR/failed-doctest-output.rs - OtherStruct (line 22) stdout ----
+---- $DIR/failed-doctest-output.rs - OtherStruct (line 25) stdout ----
 error[E0425]: cannot find value `no` in this scope
-  --> $DIR/failed-doctest-output.rs:23:1
+  --> $DIR/failed-doctest-output.rs:26:1
    |
 LL | no
    | ^^ not found in this scope
@@ -16,7 +16,7 @@ error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0425`.
 Couldn't compile the test.
----- $DIR/failed-doctest-output.rs - SomeStruct (line 12) stdout ----
+---- $DIR/failed-doctest-output.rs - SomeStruct (line 15) stdout ----
 Test executable failed (exit status: 101).
 
 stdout:
@@ -32,8 +32,8 @@ note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 
 
 failures:
-    $DIR/failed-doctest-output.rs - OtherStruct (line 22)
-    $DIR/failed-doctest-output.rs - SomeStruct (line 12)
+    $DIR/failed-doctest-output.rs - OtherStruct (line 25)
+    $DIR/failed-doctest-output.rs - SomeStruct (line 15)
 
 test result: FAILED. 0 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
 

--- a/src/test/rustdoc-ui/failed-doctest-output.stdout
+++ b/src/test/rustdoc-ui/failed-doctest-output.stdout
@@ -17,7 +17,7 @@ error: aborting due to previous error
 For more information about this error, try `rustc --explain E0425`.
 Couldn't compile the test.
 ---- $DIR/failed-doctest-output.rs - SomeStruct (line 12) stdout ----
-Test executable failed (exit code 101).
+Test executable failed (exit status: 101).
 
 stdout:
 stdout 1


### PR DESCRIPTION
Related to #95601