### PR TITLE
Use specification for BTreeMap::from_iter and BTreeSet::from_iter

### DIFF
--- a/library/alloc/src/collections/btree/map.rs
+++ b/library/alloc/src/collections/btree/map.rs
@@ -1,4 +1,3 @@
-use crate::vec::Vec;
 use core::borrow::Borrow;
 use core::cmp::Ordering;
 use core::fmt::{self, Debug};
@@ -14,6 +13,7 @@ use super::dedup_sorted_iter::DedupSortedIter;
 use super::navigate::{LazyLeafRange, LeafRange};
 use super::node::{self, marker, ForceResult::*, Handle, NodeRef, Root};
 use super::search::SearchResult::*;
+use super::spec_from_iter::SpecFromIter;
 
 mod entry;
 
@@ -1947,16 +1947,9 @@ impl<K, V> FusedIterator for RangeMut<'_, K, V> {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<K: Ord, V> FromIterator<(K, V)> for BTreeMap<K, V> {
-    fn from_iter<T: IntoIterator<Item = (K, V)>>(iter: T) -> BTreeMap<K, V> {
-        let mut inputs: Vec<_> = iter.into_iter().collect();
-
-        if inputs.is_empty() {
-            return BTreeMap::new();
-        }
-
-        // use stable sort to preserve the insertion order.
-        inputs.sort_by(|a, b| a.0.cmp(&b.0));
-        BTreeMap::bulk_build_from_sorted_iter(inputs)
+    #[inline]
+    fn from_iter<I: IntoIterator<Item = (K, V)>>(iter: I) -> BTreeMap<K, V> {
+        <Self as SpecFromIter<(K, V), I::IntoIter>>::spec_from_iter(iter.into_iter())
     }
 }
 

--- a/library/alloc/src/collections/btree/map/tests.rs
+++ b/library/alloc/src/collections/btree/map/tests.rs
@@ -2303,3 +2303,16 @@ fn from_array() {
     let unordered_duplicates = BTreeMap::from([(3, 4), (1, 2), (1, 2)]);
     assert_eq!(map, unordered_duplicates);
 }
+
+#[test]
+fn from_iter() {
+    let expect = BTreeMap::from([(1, 5), (3, 4)]);
+    let actual = BTreeMap::from_iter(vec![(1, 2), (3, 4), (1, 5)]);
+    assert_eq!(expect, actual);
+
+    let mut iter = vec![(6, 5), (4, 3), (2, 1)].into_iter();
+    iter.next();
+    let expect = BTreeMap::from([(2, 1), (4, 3)]);
+    let actual = BTreeMap::from_iter(iter);
+    assert_eq!(expect, actual);
+}

--- a/library/alloc/src/collections/btree/mod.rs
+++ b/library/alloc/src/collections/btree/mod.rs
@@ -10,6 +10,7 @@ mod node;
 mod remove;
 mod search;
 pub mod set;
+mod spec_from_iter;
 mod split;
 
 #[doc(hidden)]

--- a/library/alloc/src/collections/btree/set.rs
+++ b/library/alloc/src/collections/btree/set.rs
@@ -1,7 +1,6 @@
 // This is pretty much entirely stolen from TreeSet, since BTreeMap has an identical interface
 // to TreeMap
 
-use crate::vec::Vec;
 use core::borrow::Borrow;
 use core::cmp::Ordering::{Equal, Greater, Less};
 use core::cmp::{max, min};
@@ -11,6 +10,7 @@ use core::ops::{BitAnd, BitOr, BitXor, RangeBounds, Sub};
 
 use super::map::{BTreeMap, Keys};
 use super::merge_iter::MergeIterInner;
+use super::spec_from_iter::SpecFromIter;
 use super::Recover;
 
 // FIXME(conventions): implement bounded iterators
@@ -75,7 +75,7 @@ use super::Recover;
 #[stable(feature = "rust1", since = "1.0.0")]
 #[cfg_attr(not(test), rustc_diagnostic_item = "BTreeSet")]
 pub struct BTreeSet<T> {
-    map: BTreeMap<T, ()>,
+    pub(super) map: BTreeMap<T, ()>,
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -1080,18 +1080,9 @@ impl<T> BTreeSet<T> {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: Ord> FromIterator<T> for BTreeSet<T> {
+    #[inline]
     fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> BTreeSet<T> {
-        let mut inputs: Vec<_> = iter.into_iter().collect();
-
-        if inputs.is_empty() {
-            return BTreeSet::new();
-        }
-
-        // use stable sort to preserve the insertion order.
-        inputs.sort();
-        let iter = inputs.into_iter().map(|k| (k, ()));
-        let map = BTreeMap::bulk_build_from_sorted_iter(iter);
-        BTreeSet { map }
+        <Self as SpecFromIter<T, I::IntoIter>>::spec_from_iter(iter.into_iter())
     }
 }
 

--- a/library/alloc/src/collections/btree/set.rs
+++ b/library/alloc/src/collections/btree/set.rs
@@ -75,7 +75,7 @@ use super::Recover;
 #[stable(feature = "rust1", since = "1.0.0")]
 #[cfg_attr(not(test), rustc_diagnostic_item = "BTreeSet")]
 pub struct BTreeSet<T> {
-    pub(super) map: BTreeMap<T, ()>,
+    map: BTreeMap<T, ()>,
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -1076,6 +1076,17 @@ impl<T> BTreeSet<T> {
     pub const fn is_empty(&self) -> bool {
         self.len() == 0
     }
+
+    /// Makes a `BTreeSet` from a sorted iterator.
+    pub(crate) fn bulk_build_from_sorted_iter<I>(iter: I) -> Self
+    where
+        T: Ord,
+        I: IntoIterator<Item = T>,
+    {
+        let iter = iter.into_iter().map(|k| (k, ()));
+        let map = BTreeMap::bulk_build_from_sorted_iter(iter);
+        BTreeSet { map }
+    }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -1104,9 +1115,7 @@ impl<T: Ord, const N: usize> From<[T; N]> for BTreeSet<T> {
 
         // use stable sort to preserve the insertion order.
         arr.sort();
-        let iter = IntoIterator::into_iter(arr).map(|k| (k, ()));
-        let map = BTreeMap::bulk_build_from_sorted_iter(iter);
-        BTreeSet { map }
+        BTreeSet::bulk_build_from_sorted_iter(arr)
     }
 }
 

--- a/library/alloc/src/collections/btree/set/tests.rs
+++ b/library/alloc/src/collections/btree/set/tests.rs
@@ -831,3 +831,16 @@ fn from_array() {
     let unordered_duplicates = BTreeSet::from([4, 1, 4, 3, 2]);
     assert_eq!(set, unordered_duplicates);
 }
+
+#[test]
+fn from_iter() {
+    let expect = BTreeSet::from([1, 2, 3, 4]);
+    let actual = BTreeSet::from_iter(vec![4, 1, 4, 3, 2]);
+    assert_eq!(expect, actual);
+
+    let mut iter = vec![1, 2, 3, 4].into_iter();
+    iter.next();
+    let expect = BTreeSet::from([2, 3, 4]);
+    let actual = BTreeSet::from_iter(iter);
+    assert_eq!(expect, actual);
+}

--- a/library/alloc/src/collections/btree/spec_from_iter.rs
+++ b/library/alloc/src/collections/btree/spec_from_iter.rs
@@ -1,0 +1,78 @@
+use super::map::BTreeMap;
+use super::set::BTreeSet;
+use crate::vec::{IntoIter, Vec};
+
+/// Specialization trait used for `BTreeMap::from_iter` and `BTreeSet::from_iter`.
+pub(super) trait SpecFromIter<T, I> {
+    fn spec_from_iter(iter: I) -> Self;
+}
+
+impl<K, V, I> SpecFromIter<(K, V), I> for BTreeMap<K, V>
+where
+    K: Ord,
+    I: Iterator<Item = (K, V)>,
+{
+    default fn spec_from_iter(iterator: I) -> Self {
+        let mut inputs: Vec<_> = iterator.collect();
+
+        if inputs.is_empty() {
+            return BTreeMap::new();
+        }
+
+        // use stable sort to preserve the insertion order.
+        inputs.sort_by(|a, b| a.0.cmp(&b.0));
+        BTreeMap::bulk_build_from_sorted_iter(inputs)
+    }
+}
+
+impl<K, V> SpecFromIter<(K, V), IntoIter<(K, V)>> for BTreeMap<K, V>
+where
+    K: Ord,
+{
+    fn spec_from_iter(mut iterator: IntoIter<(K, V)>) -> Self {
+        if iterator.is_empty() {
+            return BTreeMap::new();
+        }
+
+        // use stable sort to preserve the insertion order.
+        iterator.as_mut_slice().sort_by(|a, b| a.0.cmp(&b.0));
+        BTreeMap::bulk_build_from_sorted_iter(iterator)
+    }
+}
+
+impl<T, I> SpecFromIter<T, I> for BTreeSet<T>
+where
+    T: Ord,
+    I: Iterator<Item = T>,
+{
+    default fn spec_from_iter(iterator: I) -> Self {
+        let mut inputs: Vec<_> = iterator.collect();
+
+        if inputs.is_empty() {
+            return BTreeSet::new();
+        }
+
+        // use stable sort to preserve the insertion order.
+        inputs.sort();
+        let iter = inputs.into_iter().map(|k| (k, ()));
+        let map = BTreeMap::bulk_build_from_sorted_iter(iter);
+        BTreeSet { map }
+    }
+}
+
+impl<T> SpecFromIter<T, IntoIter<T>> for BTreeSet<T>
+where
+    T: Ord,
+{
+    fn spec_from_iter(mut iterator: IntoIter<T>) -> Self {
+        if iterator.is_empty() {
+            return BTreeSet::new();
+        }
+
+        // use stable sort to preserve the insertion order.
+        iterator.as_mut_slice().sort();
+        let iter = iterator.map(|k| (k, ()));
+        let map = BTreeMap::bulk_build_from_sorted_iter(iter);
+        BTreeSet { map }
+    }
+}

--- a/library/alloc/src/collections/btree/spec_from_iter.rs
+++ b/library/alloc/src/collections/btree/spec_from_iter.rs
@@ -54,9 +54,7 @@ where
 
         // use stable sort to preserve the insertion order.
         inputs.sort();
-        let iter = inputs.into_iter().map(|k| (k, ()));
-        let map = BTreeMap::bulk_build_from_sorted_iter(iter);
-        BTreeSet { map }
+        BTreeSet::bulk_build_from_sorted_iter(inputs)
     }
 }
 
@@ -71,8 +69,6 @@ where
 
         // use stable sort to preserve the insertion order.
         iterator.as_mut_slice().sort();
-        let iter = iterator.map(|k| (k, ()));
-        let map = BTreeMap::bulk_build_from_sorted_iter(iter);
-        BTreeSet { map }
+        BTreeSet::bulk_build_from_sorted_iter(iterator)
     }
 }


### PR DESCRIPTION
~~Similar to `std_collections_from_array`, this added `From<Vec<_>>` implementation to all collections for better consistency. Prior to this, `From<Vec<_>>` already exists for `VecDeque` and `BinaryHeap`.~~

~~In addition, this also avoids one unnecessary allocation when converting `Vec<_>` to `BTreeMap`/`BTreeSet`.~~

~~I mark all new implementations `stable` as new trait impls are instant stable.~~