### PR TITLE
hide an #[allow] directive from the Arc::new_cyclic doc example

### DIFF
--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -369,7 +369,7 @@ impl<T> Arc<T> {
     ///
     /// # Example
     /// ```
-    /// #![allow(dead_code)]
+    /// # #![allow(dead_code)]
     /// use std::sync::{Arc, Weak};
     ///
     /// struct Gadget {


### PR DESCRIPTION
A minor docs cleanup.