### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -7,51 +7,98 @@
 
 Aaron Todd <github@opprobrio.us>
 Abhishek Chanda <abhishek.becs@gmail.com> Abhishek Chanda <abhishek@cloudscaling.com>
+Abhijeet Bhagat <abhijeet.bhagat@gmx.com>
+Abroskin Alexander <arkweid@evilmartians.com>
 Adolfo Ochagavía <aochagavia92@gmail.com>
+Adrian Heine né Lang <mail@adrianheine.de>
 Adrien Tétar <adri-from-59@hotmail.fr>
 Ahmed Charles <ahmedcharles@gmail.com> <acharles@outlook.com>
+Alan Egerton <eggyal@gmail.com>
+Alan Stoate <alan.stoate@gmail.com>
+Alessandro Decina <alessandro.d@gmail.com>
 Alex Burka <durka42+github@gmail.com> Alex Burka <aburka@seas.upenn.edu>
+Alex Hansen <ahansen2@trinity.edu>
 Alex Lyon <arcterus@mail.com> <Arcterus@mail.com>
 Alex Newman <posix4e@gmail.com> Alex HotShot Newman <posix4e@gmail.com>
 Alex Rønne Petersen <alex@lycus.org>
+Alex Vlasov <alex.m.vlasov@gmail.com>
+Alex von Gluck IV <kallisti5@unixzen.com>
 Alexander Light <allight@cs.brown.edu> Alexander Light <scialexlight@gmail.com>
+Alexander Ronald Altman <alexanderaltman@me.com>
+Alexandre Martin <martin.alex32@hotmail.fr>
 Alexis Beingessner <a.beingessner@gmail.com>
 Alfie John <alfie@alfie.wtf> Alfie John <alfiej@fastmail.fm>
+Amos Onn <amosonn@gmail.com>
+Ana-Maria Mihalache <mihalacheana.maria@yahoo.com>
 Anatoly Ikorsky <aikorsky@gmail.com>
 Andre Bogus <bogusandre@gmail.com>
+Andrea Ciliberti <meziu210@icloud.com>
 Andreas Gal <gal@mozilla.com> <andreas.gal@gmail.com>
+Andreas Jonson <andjo403@users.noreply.github.com>
+Andrew Gauger <andygauge@gmail.com>
 Andrew Kuchev <0coming.soon@gmail.com> Andrew <0coming.soon@gmail.com>
+Andrew Lamb <andrew@nerdnetworks.org>
 Andrew Poelstra <asp11@sfu.ca> <apoelstra@wpsoftware.net>
+Anhad Singh <andypythonappdeveloper@gmail.com>
+Antoine Plaskowski <antoine.plaskowski@epitech.eu>
 Anton Löfgren <anton.lofgren@gmail.com> <alofgren@op5.com>
+Araam Borhanian <avborhanian@gmail.com>
+Araam Borhanian <avborhanian@gmail.com> <dobbybabee@gmail.com>
 Areski Belaid <areski@gmail.com> areski <areski@gmail.com>
 Ariel Ben-Yehuda <arielb1@mail.tau.ac.il> Ariel Ben-Yehuda <ariel.byd@gmail.com>
 Ariel Ben-Yehuda <arielb1@mail.tau.ac.il> arielb1 <arielb1@mail.tau.ac.il>
+Artem Chernyak <artemchernyak@gmail.com>
+Arthur Cohen <arthur.cohen@epita.fr>
+Arthur Silva <arthurprs@gmail.com>
+Arthur Woimbée <arthur.woimbee@gmail.com>
+Artyom Pavlov <newpavlov@gmail.com>
 Austin Seipp <mad.one@gmail.com> <as@hacks.yi.org>
+Ayaz Hafiz <ayaz.hafiz.1@gmail.com>
 Aydin Kim <ladinjin@hanmail.net> aydin.kim <aydin.kim@samsung.com>
+Ayush Mishra <ayushmishra2005@gmail.com>
+asrar <aszenz@gmail.com>
+BaoshanPang <pangbw@gmail.com>
 Barosl Lee <vcs@barosl.com> Barosl LEE <github@barosl.com>
+Bastian Kersting <bastian@cmbt.de>
+Bastien Orivel <eijebong@bananium.fr>
 Ben Alpert <ben@benalpert.com> <spicyjalapeno@gmail.com>
-Ben Sago <ogham@users.noreply.github.com> Ben S <ogham@bsago.me>
-Ben Sago <ogham@users.noreply.github.com> Ben S <ogham@users.noreply.github.com>
+Ben Lewis <benlewisj@gmail.com>
+Ben Sago <ogham@users.noreply.github.com>
+Ben Sago <ogham@users.noreply.github.com> <ogham@bsago.me>
+Ben Striegel <ben.striegel@gmail.com>
 Benjamin Jackman <ben@jackman.biz>
+Benoît Cortier <benoit.cortier@fried-world.eu>
 Bheesham Persaud <bheesham123@hotmail.com> Bheesham Persaud <bheesham.persaud@live.ca>
 Björn Steinbrink <bsteinbr@gmail.com> <B.Steinbrink@gmx.de>
 blake2-ppc <ulrik.sverdrup@gmail.com> <blake2-ppc>
+boolean_coercion <booleancoercion@gmail.com>
 Boris Egorov <jightuse@gmail.com> <egorov@linux.com>
+Braden Nelson <moonheart08@users.noreply.github.com>
 Brandon Sanderson <singingboyo@gmail.com> Brandon Sanderson <singingboyo@hotmail.com>
 Brett Cannon <brett@python.org> Brett Cannon <brettcannon@users.noreply.github.com>
 Brian Anderson <banderson@mozilla.com> <andersrb@gmail.com>
 Brian Anderson <banderson@mozilla.com> <banderson@mozilla.org>
+Brian Bowman <seeker14491@gmail.com>
+Brian Cain <brian.cain@gmail.com>
 Brian Dawn <brian.t.dawn@gmail.com>
 Brian Leibig <brian@brianleibig.com> Brian Leibig <brian.leibig@gmail.com>
+Caleb Cartwright <caleb.cartwright@outlook.com>
+Caleb Jones <code@calebjones.net>
 Noah Lev <camelidcamel@gmail.com>
 Noah Lev <camelidcamel@gmail.com> <37223377+camelid@users.noreply.github.com>
+cameron1024 <cameron.studdstreet@gmail.com>
+Camille Gillot <gillot.camille@gmail.com>
 Carl-Anton Ingmarsson <mail@carlanton.se> <ca.ingmarsson@gmail.com>
+Carlo Teubner <carlo.teubner@gmail.com>
 Carol (Nichols || Goulding) <carol.nichols@gmail.com> <193874+carols10cents@users.noreply.github.com>
 Carol (Nichols || Goulding) <carol.nichols@gmail.com> <carol.nichols@gmail.com>
 Carol (Nichols || Goulding) <carol.nichols@gmail.com> <cnichols@thinkthroughmath.com>
 Carol Willing <carolcode@willingconsulting.com>
+Chandler Deng <chandde@microsoft.com>
 Charles Lew <crlf0710@gmail.com> CrLF0710 <crlf0710@gmail.com>
 Chris C Cerami <chrisccerami@users.noreply.github.com> Chris C Cerami <chrisccerami@gmail.com>
+Chris Gregory <czipperz@gmail.com>
+Chris Pardy <chrispardy36@gmail.com>
 Chris Pressey <cpressey@gmail.com>
 Chris Thorn <chris@thorn.co> Chris Thorn <thorn@thoughtbot.com>
 Chris Vittal <christopher.vittal@gmail.com> Christopher Vittal <christopher.vittal@gmail.com>
@@ -62,29 +109,53 @@ Christian Poveda <git@christianpoveda.xyz> <christianpoveda@protonmail.com>
 Christian Poveda <git@christianpoveda.xyz> <cn.poveda.ruiz@gmail.com>
 Christian Poveda <git@christianpoveda.xyz> <z1mvader@protonmail.com>
 Christian Poveda <git@christianpoveda.xyz> <cpovedar@fnal.gov>
+Christian Vallentin <vallentinsource@gmail.com>
+Christoffer Buchholz <chris@chrisbuchholz.me>
+Christopher Durham <cad97@cad97.com>
 Clark Gaebel <cg.wowus.cg@gmail.com> <cgaebel@mozilla.com>
+Clement Miao <clementmiao@gmail.com>
+Clément Renault <renault.cle@gmail.com>
+Cliff Dyer <jcd@sdf.org>
 Clinton Ryan <clint.ryan3@gmail.com>
 Corey Richardson <corey@octayn.net> Elaine "See More" Nemo <corey@octayn.net>
+Crazycolorz5 <Crazycolorz5@gmail.com>
+csmoe <35686186+csmoe@users.noreply.github.com>
 Cyryl Płotnicki <cyplo@cyplo.net>
 Damien Schoof <damien.schoof@gmail.com>
+Dan Robertson <danlrobertson89@gmail.com>
+Daniel Campoverde <alx741@riseup.net>
 Daniel J Rollins <drollins@financialforce.com>
+Daniel Mueller <deso@posteo.net>
 Daniel Ramos <dan@daramos.com>
+Daniele D'Orazio <d.dorazio96@gmail.com>
+Dante Broggi <34220985+Dante-Broggi@users.noreply.github.com>
+David Carlier <devnexen@gmail.com>
 David Klein <david.klein@baesystemsdetica.com>
 David Manescu <david.manescu@gmail.com> <dman2626@uni.sydney.edu.au>
 David Ross <daboross@daboross.net>
 David Wood <david@davidtw.co> <david.wood@huawei.com>
+Deadbeef <ent3rm4n@gmail.com>
 Deadbeef <ent3rm4n@gmail.com> <fee1-dead-beef@protonmail.com>
 Derek Chiang <derekchiang93@gmail.com> Derek Chiang (Enchi Jiang) <derekchiang93@gmail.com>
+DeveloperC <DeveloperC@protonmail.com>
+Devin Ragotzy <devin.ragotzy@gmail.com>
+Dharma Saputra Wijaya <dswijj@gmail.com>
 Diggory Hardy <diggory.hardy@gmail.com> Diggory Hardy <github@dhardy.name>
+Dileep Bapat <dileepbapat@gmail.com>
 Donough Liu <ldm2993593805@163.com> <donoughliu@gmail.com>
 Donough Liu <ldm2993593805@163.com> DingMing Liu <liudingming@bupt.edu.cn>
 Dustin Bensing <dustin.bensing@googlemail.com>
+DutchGhost <kasper199914@gmail.com>
 Dylan Braithwaite <dylanbraithwaite1@gmail.com> <mail@dylanb.me>
+Dylan DPC <dylan.dpc@gmail.com>
+Dylan MacKenzie <ecstaticmorse@gmail.com>
 Dzmitry Malyshau <kvarkus@gmail.com>
 E. Dunham <edunham@mozilla.com> edunham <edunham@mozilla.com>
+Ed Barnard <eabarnard@gmail.com>
 Eduard-Mihai Burtescu <edy.burt@gmail.com>
 Eduardo Bautista <me@eduardobautista.com> <=>
 Eduardo Bautista <me@eduardobautista.com> <mail@eduardobautista.com>
+Eduardo Broto <ebroto@tutanota.com>
 Elliott Slaughter <elliottslaughter@gmail.com> <eslaughter@mozilla.com>
 Elly Fong-Jones <elly@leptoquark.net>
 Eric Holk <eric.holk@gmail.com> <eholk@cs.indiana.edu>
@@ -92,46 +163,82 @@ Eric Holk <eric.holk@gmail.com> <eholk@mozilla.com>
 Eric Holmes <eric@ejholmes.net>
 Eric Reed <ecreed@cs.washington.edu> <ereed@mozilla.com>
 Erick Tryzelaar <erick.tryzelaar@gmail.com> <etryzelaar@iqt.org>
+Erik Desjardins <erikdesjardins@users.noreply.github.com>
+Erik Jensen <erikjensen@rkjnsn.net>
+Erin Power <xampprocky@gmail.com>
 Erin Power <xampprocky@gmail.com> <theaaronepower@gmail.com>
 Erin Power <xampprocky@gmail.com> <Aaronepower@users.noreply.github.com>
+Esteban Küber <esteban@kuber.com.ar>
 Esteban Küber <esteban@kuber.com.ar> <esteban@commure.com>
 Esteban Küber <esteban@kuber.com.ar> <estebank@users.noreply.github.com>
 Esteban Küber <esteban@kuber.com.ar> <github@kuber.com.ar>
+Ethan Dagner <napen123@gmail.com>
 Evgeny Sologubov
+F001 <changchun.fan@qq.com>
+Fabian Kössel <fkjogu@users.noreply.github.com>
 Falco Hirschenberger <falco.hirschenberger@gmail.com> <hirschen@itwm.fhg.de>
 Felix S. Klock II <pnkfelix@pnkfx.org> Felix S Klock II <pnkfelix@pnkfx.org>
+Félix Saparelli <felix@passcod.name>
 Flaper Fesp <flaper87@gmail.com>
+Florian Berger <fbergr@gmail.com>
 Florian Wilkens <mrfloya_github@outlook.com> Florian Wilkens <floya@live.de>
+François Mockers <mockersf@gmail.com>
 Frank Steffahn <fdsteffahn@gmail.com> <frank.steffahn@stu.uni-kiel.de>
+Fridtjof Stoldt <xFrednet@gmail.com>
+fukatani <nannyakannya@gmail.com>
+Fuqiao Xue <xfq.free@gmail.com>
 Gareth Daniel Smith <garethdanielsmith@gmail.com> gareth <gareth@gareth-N56VM.(none)>
 Gareth Daniel Smith <garethdanielsmith@gmail.com> Gareth Smith <garethdanielsmith@gmail.com>
+Gauri Kholkar <f2013002@goa.bits-pilani.ac.in>
 Georges Dubus <georges.dubus@gmail.com> <georges.dubus@compiletoi.net>
+Giles Cope <gilescope@gmail.com>
+Glen De Cauwsemaecker <decauwsemaecker.glen@gmail.com>
 Graham Fawcett <graham.fawcett@gmail.com> Graham Fawcett <fawcett@uwindsor.ca>
 Graydon Hoare <graydon@pobox.com> Graydon Hoare <graydon@mozilla.com>
+Greg V <greg@unrelenting.technology>
+Gregor Peach <gregorpeach@gmail.com>
+Grzegorz Bartoszek <grzegorz.bartoszek@thaumatec.com>
+Guanqun Lu <guanqun.lu@gmail.com>
 Guillaume Gomez <guillaume1.gomez@gmail.com>
 Guillaume Gomez <guillaume1.gomez@gmail.com> ggomez <ggomez@ggo.ifr.lan>
 Guillaume Gomez <guillaume1.gomez@gmail.com> Guillaume Gomez <ggomez@ggo.ifr.lan>
 Guillaume Gomez <guillaume1.gomez@gmail.com> Guillaume Gomez <guillaume.gomez@huawei.com>
+hamidreza kalbasi <hamidrezakalbasi@protonmail.com>
 Hanna Kruppe <hanna.kruppe@gmail.com> <robin.kruppe@gmail.com>
 Heather <heather@cynede.net> <Cynede@Gentoo.org>
 Heather <heather@cynede.net> <Heather@cynede.net>
 Herman J. Radtke III <herman@hermanradtke.com> Herman J. Radtke III <hermanradtke@gmail.com>
 Hirochika Matsumoto <git@hkmatsumoto.com> <matsujika@gmail.com>
+Hrvoje Nikšić <hniksic@gmail.com>
+Hsiang-Cheng Yang <rick68@users.noreply.github.com>
 Ian Jackson <ijackson@chiark.greenend.org.uk> <ian.jackson@citrix.com>
 Ian Jackson <ijackson@chiark.greenend.org.uk> <ijackson+github@slimy.greenend.org.uk>
 Ian Jackson <ijackson@chiark.greenend.org.uk> <iwj@xenproject.org>
+Ibraheem Ahmed <ibrah1440@gmail.com>
 Ilyong Cho <ilyoan@gmail.com>
 inquisitivecrystal <22333129+inquisitivecrystal@users.noreply.github.com>
+Irina Popa <irinagpopa@gmail.com>
 Ivan Ivaschenko <defuz.net@gmail.com>
+ivan tkachenko <me@ratijas.tk>
 J. J. Weber <jjweber@gmail.com>
+Jack Huey <jack.huey@umassmed.edu>
+Jacob <jacob.macritchie@gmail.com>
+Jacob Greenfield <xales@naveria.com>
 Jacob Pratt <jacob@jhpratt.dev> <the.z.cuber@gmail.com>
+Jake Vossen <jake@vossen.dev>
+Jakob Degen <jakob@degen.com>
+Jakob Lautrup Nysom <jako3047@gmail.com>
+Jakub Adam Wieczorek <jakub.adam.wieczorek@gmail.com>
 Jakub Adam Wieczorek <jakub.adam.wieczorek@gmail.com> <jakub.bukaj@yahoo.com>
 Jakub Adam Wieczorek <jakub.adam.wieczorek@gmail.com> <jakub@jakub.cc>
 Jakub Adam Wieczorek <jakub.adam.wieczorek@gmail.com> <jakubw@jakubw.net>
+James [Undefined] <tpzker@thepuzzlemaker.info>
 James Deng <cnjamesdeng@gmail.com> <cnJamesDeng@gmail.com>
 James Hinshelwood <jameshinshelwood1@gmail.com> <james.hinshelwood@bigpayme.com>
 James Miller <bladeon@gmail.com> <james@aatch.net>
 James Perry <james.austin.perry@gmail.com>
+James Sanderson <zofrex@gmail.com>
+Jaro Fietz <jaro.fietz@gmx.de>
 Jason Fager <jfager@gmail.com>
 Jason Liquorish <jason@liquori.sh> <Bassetts@users.noreply.github.com>
 Jason Orendorff <jorendorff@mozilla.com> <jason.orendorff@gmail.com>
@@ -140,33 +247,60 @@ Jason Toffaletti <toffaletti@gmail.com> Jason Toffaletti <jason@topsy.com>
 Jauhien Piatlicki <jauhien@gentoo.org> Jauhien Piatlicki <jpiatlicki@zertisa.com>
 Jay True <glacjay@gmail.com>
 Jeremy Letang <letang.jeremy@gmail.com>
+Jeremy Sorensen <jeremy.a.sorensen@gmail.com>
 Jeremy Stucki <dev@jeremystucki.ch> <stucki.jeremy@gmail.com>
 Jeremy Stucki <dev@jeremystucki.ch> <jeremy@myelin.ch>
 Jeremy Stucki <dev@jeremystucki.ch>
+Jerry Hardee <hardeejj9@gmail.com>
+Jesús Rubio <jesusprubio@gmail.com>
 Jethro Beekman <github@jbeekman.nl>
+Jian Zeng <knight42@mail.ustc.edu.cn>
 Jihyun Yu <j.yu@navercorp.com> <yjh0502@gmail.com>
 Jihyun Yu <j.yu@navercorp.com> jihyun <jihyun@nablecomm.com>
 Jihyun Yu <j.yu@navercorp.com> Jihyun Yu <jihyun@nclab.kaist.ac.kr>
 João Oliveira <hello@jxs.pt> joaoxsouls <joaoxsouls@gmail.com>
+joboet <jonasboettiger@icloud.com>
 Johann Hofmann <git@johann-hofmann.com> Johann <git@johann-hofmann.com>
 John Clements <clements@racket-lang.org> <clements@brinckerhoff.org>
 John Hodge <acessdev@gmail.com> John Hodge <tpg@mutabah.net>
+John Hörnvall <trolledwoods@gmail.com>
 John Kåre Alsaker <john.kare.alsaker@gmail.com>
 John Talling <inrustwetrust@users.noreply.github.com>
+John Van Enk <vanenkj@gmail.com>
+Jonas Tepe <jonasprogrammer@gmail.com>
 Jonathan Bailey <jbailey@mozilla.com> <jbailey@jbailey-20809.local>
+Jonathan Chan Kwan Yin <sofe2038@gmail.com>
+Jonathan L <Xmasreturns@users.noreply.github.com>
 Jonathan S <gereeter@gmail.com> Jonathan S <gereeter+code@gmail.com>
+Jonathan Sieber <mail@strfry.org>
 Jonathan Turner <probata@hotmail.com>
 Jorge Aparicio <japaric@linux.com> <japaricious@gmail.com>
+Josef Reinhard Brandl <mail@josefbrandl.de>
+Joseph Dunne <jd@lambda.tech>
 Joseph Martin <pythoner6@gmail.com>
+Joseph Richey <joerichey@google.com>
+Joseph T. Lyons <JosephTLyons@gmail.com>
 Joseph T. Lyons <JosephTLyons@gmail.com> <josephtlyons@gmail.com>
 Joseph T. Lyons <JosephTLyons@gmail.com> <JosephTLyons@users.noreply.github.com>
+Josh Cotton <jcotton42@outlook.com>
+Josh Driver <keeperofdakeys@gmail.com>
+Josh Holmer <jholmer.in@gmail.com>
 Joshua Nelson <jyn514@gmail.com> <joshua@yottadb.com>
+Julian Knodt <julianknodt@gmail.com>
 jumbatm <jumbatm@gmail.com> <30644300+jumbatm@users.noreply.github.com>
 Junyoung Cho <june0.cho@samsung.com>
 Jyun-Yan You <jyyou.tw@gmail.com> <jyyou@cs.nctu.edu.tw>
+Kalita Alexey <kalita.alexey@outlook.com>
+Kampfkarren <boynedmaster@gmail.com>
 Kang Seonghoon <kang.seonghoon@mearie.org> <public+git@mearie.org>
+Karim Snj <karim.snj@gmail.com>
+Katze <binary@benary.org>
 Keegan McAllister <mcallister.keegan@gmail.com> <kmcallister@mozilla.com>
+Kerem Kat <keremkat@gmail.com>
 Kevin Butler <haqkrs@gmail.com>
+Kevin Jiang <kwj2104@columbia.edu>
+Kornel Lesiński <kornel@geekhood.net>
+Krishna Sai Veera Reddy <veerareddy@email.arizona.edu>
 Kyeongwoon Lee <kyeongwoon.lee@samsung.com>
 Kyle J Strand <batmanaod@gmail.com> <BatmanAoD@users.noreply.github.com>
 Kyle J Strand <batmanaod@gmail.com> <kyle.j.strand@gmail.com>
@@ -176,57 +310,102 @@ Laurențiu Nicola <lnicola@dend.ro>
 lcnr <rust@lcnr.de> <bastian_kauschke@hotmail.de>
 Lee Jeffery <leejeffery@gmail.com> Lee Jeffery <lee@leejeffery.co.uk>
 Lee Wondong <wdlee91@gmail.com>
+lengyijun <sjtu5140809011@gmail.com>
 Lennart Kudling <github@kudling.de>
 Léo Lanteri Thauvin <leseulartichaut@gmail.com>
 Léo Lanteri Thauvin <leseulartichaut@gmail.com> <38361244+LeSeulArtichaut@users.noreply.github.com>
 Léo Testard <leo.testard@gmail.com>
+Leonardo Yvens <leoyvens@gmail.com>
+Liigo Zhuang <liigo@qq.com>
 Lily Ballard <lily@ballards.net> <kevin@sb.org>
 Lindsey Kuper <lindsey@composition.al> <lindsey@rockstargirl.org>
 Lindsey Kuper <lindsey@composition.al> <lkuper@mozilla.com>
+Liu Dingming <liudingming@bytedance.com>
+Loo Maclin <loo.maclin@protonmail.com>
+Loïc BRANSTETT <lolo.branstett@numericable.fr>
+Lucy <luxx4x@protonmail.com>
+Lukas H. <lukaramu@users.noreply.github.com>
+Lukas Lueg <lukas.lueg@gmail.com>
 Luke Metz <luke.metz@students.olin.edu>
 Luqman Aden <me@luqman.ca> <laden@csclub.uwaterloo.ca>
 Luqman Aden <me@luqman.ca> <laden@mozilla.com>
+Lzu Tao <taolzu@gmail.com>
+Maik Klein <maikklein@googlemail.com>
+Malo Jaffré <jaffre.malo@gmail.com>
 Manish Goregaokar <manishsmail@gmail.com>
+Mara Bos <m-ou.se@m-ou.se>
 Marcell Pardavi <marcell.pardavi@gmail.com>
+Marcus Klaas de Vries <mail@marcusklaas.nl>
 Margaret Meyerhofer <mmeyerho@andrew.cmu.edu> <mmeyerho@andrew>
+Mark Mansi <markm@cs.wisc.edu>
 Mark Rousskov <mark.simulacrum@gmail.com>
 Mark Sinclair <mark.edward.x@gmail.com>
 Mark Sinclair <mark.edward.x@gmail.com> =Mark Sinclair <=125axel125@gmail.com>
+Markus Legner <markus@legner.ch>
 Markus Westerlind <marwes91@gmail.com> Markus <marwes91@gmail.com>
+Martin Carton <cartonmartin+git@gmail.com>
+Martin Habovštiak <martin.habovstiak@gmail.com>
 Martin Hafskjold Thoresen <martinhath@gmail.com>
 Matej Lach <matej.lach@gmail.com> Matej Ľach <matej.lach@gmail.com>
+Mateusz Mikuła <mati865@gmail.com>
 Mateusz Mikuła <mati865@gmail.com> <mati865@users.noreply.github.com>
 Mateusz Mikuła <mati865@gmail.com> <matti@marinelayer.io>
 Matt Brubeck <mbrubeck@limpet.net> <mbrubeck@cs.hmc.edu>
 Matthew Auld <matthew.auld@intel.com>
+Matthew Jasper <mjjasper1@gmail.com>
 Matthew Kraai <kraai@ftbfs.org>
 Matthew Kraai <kraai@ftbfs.org> <matt.kraai@abbott.com>
 Matthew Kraai <kraai@ftbfs.org> <mkraai@its.jnj.com>
 Matthew McPherrin <matthew@mcpherrin.ca> <matt@mcpherrin.ca>
+Matthew Tran <0e4ef622@gmail.com>
 Matthijs Hofstra <thiezz@gmail.com>
+Max Sharnoff <github@max.sharnoff.org>
+Max Wase <max.vvase@gmail.com>
+Mazdak Farrokhzad <twingoow@gmail.com>
+Meade Kincke <thedarkula2049@gmail.com>
 Melody Horn <melody@boringcactus.com> <mathphreak@gmail.com>
+Mendes <pedro.mendes.26@gmail.com>
+mental <m3nta1@yahoo.com>
+mibac138 <5672750+mibac138@users.noreply.github.com>
 Michael Williams <m.t.williams@live.com>
 Michael Woerister <michaelwoerister@posteo> <michaelwoerister@gmail>
 Michael Woerister <michaelwoerister@posteo> <michaelwoerister@users.noreply.github.com>
 Michael Woerister <michaelwoerister@posteo> <michaelwoerister@posteo.net>
+Michael Zhang <hmperson1@gmail.com>
+Michał Krasnoborski <mkrdln@gmail.com>
+Michiel De Muynck <michieldemuynck@gmail.com>
 Mickaël Raybaud-Roig <raybaudroigm@gmail.com> m-r-r <raybaudroigm@gmail.com>
+Mikhail Babenko <misha-babenko@yandex.ru>
+Milan Landaverde <milanlandaverde@gmail.com>
+mjptree <michael.prantl@hotmail.de>
 Ms2ger <ms2ger@gmail.com> <Ms2ger@gmail.com>
+msizanoen1 <qtmlabs@protonmail.com>
 Mukilan Thiagarajan <mukilanthiagarajan@gmail.com>
+Nadrieril Feneanar <Nadrieril@users.noreply.github.com>
 NAKASHIMA, Makoto <makoto.nksm+github@gmail.com> <makoto.nksm@gmail.com>
 NAKASHIMA, Makoto <makoto.nksm+github@gmail.com> <makoto.nksm+github@gmail.com>
+Nathan Ringo <remexre@gmail.com>
 Nathan West <Lucretiel@gmail.com> <lucretiel@gmail.com>
+Nathan Whitaker <nathan.whitaker01@gmail.com>
 Nathan Wilson <wilnathan@gmail.com>
+Nathaniel Hamovitz <18648574+nhamovitz@users.noreply.github.com>
 Nathaniel Herman <nherman@post.harvard.edu> Nathaniel Herman <nherman@college.harvard.edu>
 Neil Pankey <npankey@gmail.com> <neil@wire.im>
+Ngo Iok Ui (Wu Yu Wei) <wusyong9104@gmail.com>
+Nicholas Baron <nicholas.baron.ten@gmail.com>
 Nick Platt <platt.nicholas@gmail.com>
+Niclas Schwarzlose <15schnic@gmail.com>
+Nicolas Abram <abramlujan@gmail.com>
 Nicole Mazzuca <npmazzuca@gmail.com>
 Nif Ward <nif.ward@gmail.com>
 Nika Layzell <nika@thelayzells.com> <michael@thelayzells.com>
+Nixon Enraght-Moony <nixon.emoony@gmail.com>
+NODA Kai <nodakai@gmail.com>
+oliver <16816606+o752d@users.noreply.github.com>
 Oliver Middleton <olliemail27@gmail.com> <ollie27@users.noreply.github.com>
 Oliver Scherer <oliver.schneider@kit.edu> <git-spam-no-reply9815368754983@oli-obk.de>
 Oliver Scherer <oliver.schneider@kit.edu> <git-spam9815368754983@oli-obk.de>
 Oliver Scherer <oliver.schneider@kit.edu> <github333195615777966@oli-obk.de>
-Oliver Scherer <oliver.schneider@kit.edu> <github6541940@oli-obk.de>
 Oliver Scherer <oliver.schneider@kit.edu> <rust19446194516@oli-obk.de>
 Oliver Scherer <oliver.schneider@kit.edu> <git-no-reply-9879165716479413131@oli-obk.de>
 Oliver Scherer <oliver.schneider@kit.edu> <git1984941651981@oli-obk.de>
@@ -236,76 +415,139 @@ Oliver Scherer <oliver.schneider@kit.edu> <oli-obk@users.noreply.github.com>
 Oliver Scherer <oliver.schneider@kit.edu> <public.oliver.schneider@kit.edu>
 Oliver Scherer <oliver.schneider@kit.edu> <obk8176014uqher834@olio-obk.de>
 Oliver Scherer <oliver.schneider@kit.edu>
+Ömer Sinan Ağacan <omeragacan@gmail.com>
+Ophir LOJKINE <pere.jobs@gmail.com>
 Ožbolt Menegatti <ozbolt.menegatti@gmail.com> gareins <ozbolt.menegatti@gmail.com>
+Pankaj Chaudhary <pankajchaudhary172@gmail.com>
 Paul Faria <paul_faria@ultimatesoftware.com> Paul Faria <Nashenas88@gmail.com>
 Peer Aramillo Irizar <peer.aramillo.irizar@gmail.com> parir <peer.aramillo.irizar@gmail.com>
 Peter Elmers <peter.elmers@yahoo.com> <peter.elmers@rice.edu>
 Peter Liniker <peter.liniker+github@gmail.com>
 Phil Dawes <phil@phildawes.net> Phil Dawes <pdawes@drw.com>
+Phil Hansch <dev@phansch.net>
 Philipp Brüschweiler <blei42@gmail.com> <blei42@gmail.com>
 Philipp Brüschweiler <blei42@gmail.com> <bruphili@student.ethz.ch>
-Philipp Krones <hello@philkrones.com> flip1995 <hello@philkrones.com>
+Philipp Krones <hello@philkrones.com>
+Philipp Krones <hello@philkrones.com> <9744647+flip1995@users.noreply.github.com>
 Philipp Krones <hello@philkrones.com> <philipp.krones@embecosm.com>
+Philipp Krones <hello@philkrones.com> <uwdkn@student.kit.edu>
 Philipp Matthias Schäfer <philipp.matthias.schaefer@posteo.de>
+phosphorus <steepout@qq.com>
+Pierre Krieger <pierre.krieger1708@gmail.com>
 pierwill <pierwill@users.noreply.github.com> <19642016+pierwill@users.noreply.github.com>
+Pradyumna Rahul <prkinformed@gmail.com>
 Przemysław Wesołek <jest@go.art.pl> Przemek Wesołek <jest@go.art.pl>
+r00ster <r00ster91@protonmail.com>
 Rafael Ávila de Espíndola <respindola@mozilla.com> Rafael Avila de Espindola <espindola@dream.(none)>
+rail <12975677+rail-rain@users.noreply.github.com>
 Ralph Giles <giles@thaumas.net> Ralph Giles <giles@mozilla.com>
 Ramkumar Ramachandra <r@artagnon.com> <artagnon@gmail.com>
+Raphaël Huchet <rap2hpoutre@users.noreply.github.com>
+rChaser53 <tayoshizawa29@gmail.com>
+Rémy Rakic <remy.rakic@gmail.com>
+Rémy Rakic <remy.rakic@gmail.com> <remy.rakic+github@gmail.com>
 Renato Riccieri Santos Zannon <renato@rrsz.com.br>
 Richard Diamond <wichard@vitalitystudios.com> <wichard@hahbee.co>
+Ricky Hosfelt <ricky@hosfelt.io>
+Ritiek Malhotra <ritiekmalhotra123@gmail.com>
 Rob Arnold <robarnold@cs.cmu.edu>
 Rob Arnold <robarnold@cs.cmu.edu> Rob Arnold <robarnold@68-26-94-7.pools.spcsdns.net>
 Robert Foss <dev@robertfoss.se> robertfoss <dev@robertfoss.se>
 Robert Gawdzik <rgawdzik@hotmail.com> Robert Gawdzik ☢ <rgawdzik@hotmail.com>
+Robert Habermeier <rphmeier@gmail.com>
 Robert Millar <robert.millar@cantab.net>
+Roc Yu <rocyu@protonmail.com>
 Rohit Joshi <rohitjoshi@users.noreply.github.com> Rohit Joshi <rohit.joshi@capitalone.com>
+Roxane Fruytier <roxane.fruytier@hotmail.com>
+Rui <xiongmao86dev@sina.com>
 Russell Johnston <rpjohnst@gmail.com>
+Rustin-Liu <rustin.liu@gmail.com>
+Rusty Blitzerr <rusty.blitzerr@gmail.com>
+RustyYato <krishna.sd.2012@gmail.com>
 Ruud van Asseldonk <dev@veniogames.com> Ruud van Asseldonk <ruuda@google.com>
+Ryan Leung <rleungx@gmail.com>
 Ryan Scheel <ryan.havvy@gmail.com>
+Ryan Sullivant <rsulli55@gmail.com>
+Ryan Wiedemann <Ryan1729@gmail.com>
 S Pradeep Kumar <gohanpra@gmail.com>
+Sam Radhakrishnan <sk09idm@gmail.com>
+Scott McMurray <scottmcm@users.noreply.github.com>
 Scott Olson <scott@solson.me> Scott Olson <scott@scott-olson.org>
 Sean Gillespie <sean.william.g@gmail.com> swgillespie <sean.william.g@gmail.com>
+Seiichi Uchida <seuchida@gmail.com>
 Seonghyun Kim <sh8281.kim@samsung.com>
+Shohei Wada <pc@wada314.jp>
+Shotaro Yamada <sinkuu@sinkuu.xyz>
+Shotaro Yamada <sinkuu@sinkuu.xyz> <sinkuu@users.noreply.github.com>
 Shyam Sundar B <shyambaskaran@outlook.com>
 Simon Barber-Dueck <sbarberdueck@gmail.com> Simon BD <simon@server>
 Simon Sapin <simon@exyr.org> <simon.sapin@exyr.org>
 Simonas Kazlauskas <git@kazlauskas.me> Simonas Kazlauskas <github@kazlauskas.me>
+Siva Prasad <sivaauturic@gmail.com>
+Smittyvb <me@smitop.com>
+Srinivas Reddy Thatiparthy <thatiparthysreenivas@gmail.com>
+Stanislav Tkach <stanislav.tkach@gmail.com>
 startling <tdixon51793@gmail.com>
 Stepan Koltsov <stepan.koltsov@gmail.com> Stepan Koltsov <nga@yandex-team.ru>
 Steve Klabnik <steve@steveklabnik.com>
 Steven Fackler <sfackler@gmail.com> <sfackler@palantir.com>
+Steven Malis <smmalis37@gmail.com>
 Steven Stewart-Gallus <sstewartgallus00@langara.bc.ca> <sstewartgallus00@mylangara.bc.ca>
 Stuart Pernsteiner <stuart@pernsteiner.org> Stuart Pernsteiner <spernsteiner@mozilla.com>
+Suyash458 <suyash.behera458@gmail.com>
+Sébastien Marie <semarie@online.fr>
+Takashi Idobe <idobetakashi@gmail.com>
+Takayuki Maeda <takoyaki0316@gmail.com>
 Tamir Duberstein <tamird@gmail.com> Tamir Duberstein <tamird@squareup.com>
+Tatsuyuki Ishi <ishitatsuyuki@gmail.com>
 Tero Hänninen <lgvz@users.noreply.github.com> Tero Hänninen <tejohann@kapsi.fi>
+The8472 <git@infinite-source.de>
 Theo Belaire <theo.belaire@gmail.com> Theo Belaire <tyr.god.of.war.42@gmail.com>
+Theodore Luo Wang <wangtheo662@gmail.com>
 Thiago Pontes <email@thiago.me> thiagopnts <thiagopnts@gmail.com>
 Thomas Bracht Laumann Jespersen <laumann.thomas@gmail.com>
+Tibo Delor <delor.thibault@gmail.com>
 Ticki <Ticki@users.noreply.github.com> Ticki <@>
 Tim Brooks <brooks@cern.ch> Tim Brooks <tim.brooks@staples.com>
 Tim Chevalier <chevalier@alum.wellesley.edu> <catamorphism@gmail.com>
+Tim Diekmann <t.diekmann.3dv@gmail.com>
+Tim Hutt <tdhutt@gmail.com>
 Tim JIANG <p90eri@gmail.com>
 Tim Joseph Dumol <tim@timdumol.com>
+Timothy Maloney <tmaloney@pdx.edu>
+Tomas Koutsky <tomas@stepnivlk.net>
+Torsten Weber <TorstenWeber12@gmail.com>
 Torsten Weber <TorstenWeber12@gmail.com> <torstenweber12@gmail.com>
 Trevor Spiteri <tspiteri@ieee.org> <trevor.spiteri@um.edu.mt>
 Ty Overby <ty@pre-alpha.com>
 Tyler Mandry <tmandry@gmail.com> <tmandry@google.com>
+Tyler Ruckinger <t.ruckinger@gmail.com>
 Ulrik Sverdrup <bluss@users.noreply.github.com> bluss <bluss@users.noreply.github.com>
 Ulrik Sverdrup <bluss@users.noreply.github.com> bluss <bluss>
 Ulrik Sverdrup <bluss@users.noreply.github.com> Ulrik Sverdrup <root@localhost>
 Vadim Petrochenkov <vadim.petrochenkov@gmail.com>
 Vadim Petrochenkov <vadim.petrochenkov@gmail.com> petrochenkov <vadim.petrochenkov@gmail.com>
+Val Markovic <val@markovic.io>
+Valerii Lashmanov <vflashm@gmail.com>
 Vitali Haravy <HumaneProgrammer@gmail.com> Vitali Haravy <humaneprogrammer@gmail.com>
+Vitaly Shukela <vi0oss@gmail.com>
+Waffle Maybe <waffle.lapkin@gmail.com>
 Wesley Wiser <wwiser@gmail.com> <wesleywiser@microsoft.com>
 whitequark <whitequark@whitequark.org>
 William Ting <io@williamting.com> <william.h.ting@gmail.com>
+Wim Looman <wim@nemo157.com>
+Without Boats <woboats@gmail.com>
+Without Boats <woboats@gmail.com> <boats@mozilla.com>
+Xinye Tao <xy.tao@outlook.com>
 Xuefeng Wu <benewu@gmail.com> Xuefeng Wu <xfwu@thoughtworks.com>
 Xuefeng Wu <benewu@gmail.com> XuefengWu <benewu@gmail.com>
 York Xiang <bombless@126.com>
 Youngsoo Son <ysson83@gmail.com> <ysoo.son@samsung.com>
+Youngsuk Kim <joseph942010@gmail.com>
+Yuki Okushi <jtitor@2k36.org>
 Yuki Okushi <jtitor@2k36.org> <huyuumi.dev@gmail.com>
 Yuki Okushi <jtitor@2k36.org> <yuki.okushi@huawei.com>
+Yuning Zhang <codeworm96@outlook.com>
 Zach Pomerantz <zmp@umich.edu>
 Zack Corr <zack@z0w0.me> <zackcorr95@gmail.com>
 Zack Slayton <zack.slayton@gmail.com>

--- a/compiler/rustc_expand/src/expand.rs
+++ b/compiler/rustc_expand/src/expand.rs
@@ -83,9 +83,7 @@ macro_rules! ast_fragments {
                 }
                 match self {
                     $($(AstFragment::$Kind(ast) => ast.extend(placeholders.iter().flat_map(|id| {
-                        // We are repeating through arguments with `many`, to do that we have to
-                        // mention some macro variable from those arguments even if it's not used.
-                        macro _repeating($flat_map_ast_elt) {}
+                        ${ignore(flat_map_ast_elt)}
                         placeholder(AstFragmentKind::$Kind, *id, None).$make_ast()
                     })),)?)*
                     _ => panic!("unexpected AST fragment kind")

--- a/compiler/rustc_expand/src/lib.rs
+++ b/compiler/rustc_expand/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(rustc::potential_query_instability)]
 #![feature(associated_type_bounds)]
 #![feature(associated_type_defaults)]
 #![feature(crate_visibility_modifier)]
@@ -5,12 +6,12 @@
 #![feature(if_let_guard)]
 #![feature(let_chains)]
 #![feature(let_else)]
+#![feature(macro_metavar_expr)]
 #![feature(proc_macro_diagnostic)]
 #![feature(proc_macro_internals)]
 #![feature(proc_macro_span)]
 #![feature(try_blocks)]
 #![recursion_limit = "256"]
-#![allow(rustc::potential_query_instability)]
 
 #[macro_use]
 extern crate rustc_macros;

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -181,6 +181,7 @@
 #![feature(intrinsics)]
 #![feature(lang_items)]
 #![feature(link_llvm_intrinsics)]
+#![feature(macro_metavar_expr)]
 #![feature(min_specialization)]
 #![feature(mixed_integer_ops)]
 #![feature(must_not_suspend)]

--- a/library/core/src/tuple.rs
+++ b/library/core/src/tuple.rs
@@ -5,21 +5,17 @@ use crate::cmp::*;
 
 // macro for implementing n-ary tuple functions and operations
 macro_rules! tuple_impls {
-    ($(
-        $Tuple:ident {
-            $(($idx:tt) -> $T:ident)+
-        }
-    )+) => {
+    ( $( $Tuple:ident( $( $T:ident )+ ) )+ ) => {
         $(
             #[stable(feature = "rust1", since = "1.0.0")]
             impl<$($T:PartialEq),+> PartialEq for ($($T,)+) where last_type!($($T,)+): ?Sized {
                 #[inline]
                 fn eq(&self, other: &($($T,)+)) -> bool {
-                    $(self.$idx == other.$idx)&&+
+                    $( ${ignore(T)} self.${index()} == other.${index()} )&&+
                 }
                 #[inline]
                 fn ne(&self, other: &($($T,)+)) -> bool {
-                    $(self.$idx != other.$idx)||+
+                    $( ${ignore(T)} self.${index()} != other.${index()} )||+
                 }
             }
 
@@ -28,26 +24,28 @@ macro_rules! tuple_impls {
 
             #[stable(feature = "rust1", since = "1.0.0")]
             impl<$($T:PartialOrd + PartialEq),+> PartialOrd for ($($T,)+)
-                    where last_type!($($T,)+): ?Sized {
+            where
+                last_type!($($T,)+): ?Sized
+            {
                 #[inline]
                 fn partial_cmp(&self, other: &($($T,)+)) -> Option<Ordering> {
-                    lexical_partial_cmp!($(self.$idx, other.$idx),+)
+                    lexical_partial_cmp!($( ${ignore(T)} self.${index()}, other.${index()} ),+)
                 }
                 #[inline]
                 fn lt(&self, other: &($($T,)+)) -> bool {
-                    lexical_ord!(lt, $(self.$idx, other.$idx),+)
+                    lexical_ord!(lt, $( ${ignore(T)} self.${index()}, other.${index()} ),+)
                 }
                 #[inline]
                 fn le(&self, other: &($($T,)+)) -> bool {
-                    lexical_ord!(le, $(self.$idx, other.$idx),+)
+                    lexical_ord!(le, $( ${ignore(T)} self.${index()}, other.${index()} ),+)
                 }
                 #[inline]
                 fn ge(&self, other: &($($T,)+)) -> bool {
-                    lexical_ord!(ge, $(self.$idx, other.$idx),+)
+                    lexical_ord!(ge, $( ${ignore(T)} self.${index()}, other.${index()} ),+)
                 }
                 #[inline]
                 fn gt(&self, other: &($($T,)+)) -> bool {
-                    lexical_ord!(gt, $(self.$idx, other.$idx),+)
+                    lexical_ord!(gt, $( ${ignore(T)} self.${index()}, other.${index()} ),+)
                 }
             }
 
@@ -55,7 +53,7 @@ macro_rules! tuple_impls {
             impl<$($T:Ord),+> Ord for ($($T,)+) where last_type!($($T,)+): ?Sized {
                 #[inline]
                 fn cmp(&self, other: &($($T,)+)) -> Ordering {
-                    lexical_cmp!($(self.$idx, other.$idx),+)
+                    lexical_cmp!($( ${ignore(T)} self.${index()}, other.${index()} ),+)
                 }
             }
 
@@ -108,106 +106,16 @@ macro_rules! last_type {
 }
 
 tuple_impls! {
-    Tuple1 {
-        (0) -> A
-    }
-    Tuple2 {
-        (0) -> A
-        (1) -> B
-    }
-    Tuple3 {
-        (0) -> A
-        (1) -> B
-        (2) -> C
-    }
-    Tuple4 {
-        (0) -> A
-        (1) -> B
-        (2) -> C
-        (3) -> D
-    }
-    Tuple5 {
-        (0) -> A
-        (1) -> B
-        (2) -> C
-        (3) -> D
-        (4) -> E
-    }
-    Tuple6 {
-        (0) -> A
-        (1) -> B
-        (2) -> C
-        (3) -> D
-        (4) -> E
-        (5) -> F
-    }
-    Tuple7 {
-        (0) -> A
-        (1) -> B
-        (2) -> C
-        (3) -> D
-        (4) -> E
-        (5) -> F
-        (6) -> G
-    }
-    Tuple8 {
-        (0) -> A
-        (1) -> B
-        (2) -> C
-        (3) -> D
-        (4) -> E
-        (5) -> F
-        (6) -> G
-        (7) -> H
-    }
-    Tuple9 {
-        (0) -> A
-        (1) -> B
-        (2) -> C
-        (3) -> D
-        (4) -> E
-        (5) -> F
-        (6) -> G
-        (7) -> H
-        (8) -> I
-    }
-    Tuple10 {
-        (0) -> A
-        (1) -> B
-        (2) -> C
-        (3) -> D
-        (4) -> E
-        (5) -> F
-        (6) -> G
-        (7) -> H
-        (8) -> I
-        (9) -> J
-    }
-    Tuple11 {
-        (0) -> A
-        (1) -> B
-        (2) -> C
-        (3) -> D
-        (4) -> E
-        (5) -> F
-        (6) -> G
-        (7) -> H
-        (8) -> I
-        (9) -> J
-        (10) -> K
-    }
-    Tuple12 {
-        (0) -> A
-        (1) -> B
-        (2) -> C
-        (3) -> D
-        (4) -> E
-        (5) -> F
-        (6) -> G
-        (7) -> H
-        (8) -> I
-        (9) -> J
-        (10) -> K
-        (11) -> L
-    }
+    Tuple1(A)
+    Tuple2(A B)
+    Tuple3(A B C)
+    Tuple4(A B C D)
+    Tuple5(A B C D E)
+    Tuple6(A B C D E F)
+    Tuple7(A B C D E F G)
+    Tuple8(A B C D E F G H)
+    Tuple9(A B C D E F G H I)
+    Tuple10(A B C D E F G H I J)
+    Tuple11(A B C D E F G H I J K)
+    Tuple12(A B C D E F G H I J K L)
 }

--- a/src/ci/docker/host-x86_64/dist-various-2/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-various-2/Dockerfile
@@ -111,6 +111,7 @@ ENV TARGETS=$TARGETS,nvptx64-nvidia-cuda
 ENV TARGETS=$TARGETS,armv7-unknown-linux-gnueabi
 ENV TARGETS=$TARGETS,armv7-unknown-linux-musleabi
 ENV TARGETS=$TARGETS,i686-unknown-freebsd
+ENV TARGETS=$TARGETS,x86_64-unknown-none
 
 # As per https://bugs.launchpad.net/ubuntu/+source/gcc-defaults/+bug/1300211
 # we need asm in the search path for gcc-8 (for gnux32) but not in the search path of the

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -177,6 +177,7 @@ target | std | notes
 `x86_64-linux-android` | ✓ | 64-bit x86 Android
 `x86_64-pc-solaris` | ✓ | 64-bit Solaris 10/11, illumos
 `x86_64-unknown-linux-gnux32` | ✓ | 64-bit Linux (x32 ABI) (kernel 4.15, glibc 2.27)
+[`x86_64-unknown-none`](platform-support/x86_64-unknown-none.md) | * | Freestanding/bare-metal x86_64, softfloat
 `x86_64-unknown-redox` | ✓ | Redox OS
 
 [Fortanix ABI]: https://edp.fortanix.com/
@@ -291,7 +292,6 @@ target | std | host | notes
 `x86_64-unknown-haiku` | ✓ | ✓ | 64-bit Haiku
 `x86_64-unknown-hermit` | ✓ |  | HermitCore
 `x86_64-unknown-l4re-uclibc` | ? |  |
-[`x86_64-unknown-none`](platform-support/x86_64-unknown-none.md) | * |  | Freestanding/bare-metal x86_64, softfloat
 `x86_64-unknown-none-linuxkernel` | * |  | Linux kernel modules
 [`x86_64-unknown-openbsd`](platform-support/openbsd.md) | ✓ | ✓ | 64-bit OpenBSD
 `x86_64-unknown-uefi` | * |  | 64-bit UEFI

--- a/src/doc/rustc/src/platform-support/x86_64-unknown-none.md
+++ b/src/doc/rustc/src/platform-support/x86_64-unknown-none.md
@@ -1,6 +1,6 @@
 # `x86_64-unknown-none`
 
-**Tier: 3**
+**Tier: 2**
 
 Freestanding/bare-metal x86-64 binaries in ELF format: firmware, kernels, etc.
 
@@ -32,7 +32,7 @@ You can change this using the `-C code-model=` option to rustc.
 On `x86_64-unknown-none`, `extern "C"` uses the [standard System V calling
 convention](https://gitlab.com/x86-psABIs/x86-64-ABI), without red zones.
 
-This target generated binaries in the ELF format. Any alternate formats or
+This target generates binaries in the ELF format. Any alternate formats or
 special considerations for binary layout will require linker options or linker
 scripts.
 
@@ -49,15 +49,19 @@ target = ["x86_64-unknown-none"]
 
 ## Building Rust programs
 
-Rust does not yet ship pre-compiled artifacts for this target. To compile for
-this target, you will either need to build Rust with the target enabled (see
-"Building the target" above), or build your own copy of `core` by using
-`build-std` or similar.
+Starting with Rust 1.62, precompiled artifacts are provided via `rustup`:
+
+```text
+# install cross-compile toolchain
+rustup target add x86_64-unknown-none
+# target flag may be used with any cargo or rustc command
+cargo build --target x86_64-unknown-none
+```
 
 ## Testing
 
 As `x86_64-unknown-none` supports a variety of different environments and does
-not support `std`, this target does not support running the Rust testsuite.
+not support `std`, this target does not support running the Rust test suite.
 
 ## Cross-compilation toolchains and C code
 

--- a/src/test/ui/hrtb/issue-94034.rs
+++ b/src/test/ui/hrtb/issue-94034.rs
@@ -1,0 +1,96 @@
+// known-bug
+// failure-status: 101
+// compile-flags: --edition=2021 --crate-type=lib
+// rustc-env:RUST_BACKTRACE=0
+
+// normalize-stderr-test "thread 'rustc' panicked.*" -> "thread 'rustc' panicked"
+// normalize-stderr-test "note:.*RUST_BACKTRACE=1.*\n" -> ""
+// normalize-stderr-test "\nerror: internal compiler error.*\n\n" -> ""
+// normalize-stderr-test "note:.*unexpectedly panicked.*\n\n" -> ""
+// normalize-stderr-test "note: we would appreciate a bug report.*\n\n" -> ""
+// normalize-stderr-test "note: compiler flags.*\n\n" -> ""
+// normalize-stderr-test "note: rustc.*running on.*\n\n" -> ""
+// normalize-stderr-test "query stack during panic:\n" -> ""
+// normalize-stderr-test "we're just showing a limited slice of the query stack\n" -> ""
+// normalize-stderr-test "end of query stack\n" -> ""
+// normalize-stderr-test "#.*\n" -> ""
+
+// This should not ICE.
+
+use std::{
+    future::Future,
+    marker::PhantomData,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+mod object {
+    use super::*;
+
+    pub trait Object<'a> {
+        type Error;
+        type Future: Future<Output = Self>;
+        fn create() -> Self::Future;
+    }
+
+    impl<'a> Object<'a> for u8 {
+        type Error = ();
+        type Future = Pin<Box<dyn Future<Output = Self>>>;
+        fn create() -> Self::Future {
+            unimplemented!()
+        }
+    }
+
+    impl<'a, E, A: Object<'a, Error = E>> Object<'a> for (A,) {
+        type Error = ();
+        type Future = CustomFut<'a, E, A>;
+        fn create() -> Self::Future {
+            unimplemented!()
+        }
+    }
+
+    pub struct CustomFut<'f, E, A: Object<'f, Error = E>> {
+        ph: PhantomData<(A::Future,)>,
+    }
+
+    impl<'f, E, A: Object<'f, Error = E>> Future for CustomFut<'f, E, A> {
+        type Output = (A,);
+        fn poll(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Self::Output> {
+            unimplemented!()
+        }
+    }
+}
+
+mod async_fn {
+    use super::*;
+
+    pub trait AsyncFn {
+        type Future: Future<Output = ()>;
+        fn call(&self) -> Self::Future;
+    }
+
+    impl<F, Fut> AsyncFn for F
+    where
+        F: Fn() -> Fut,
+        Fut: Future<Output = ()>,
+    {
+        type Future = Fut;
+        fn call(&self) -> Self::Future {
+            (self)()
+        }
+    }
+}
+
+pub async fn test() {
+    use self::{async_fn::AsyncFn, object::Object};
+
+    async fn create<T: Object<'static>>() {
+        T::create().await;
+    }
+
+    async fn call_async_fn(inner: impl AsyncFn) {
+        inner.call().await;
+    }
+
+    call_async_fn(create::<(u8,)>).await;
+}

--- a/src/test/ui/hrtb/issue-94034.stderr
+++ b/src/test/ui/hrtb/issue-94034.stderr
@@ -1,0 +1,1 @@
+thread 'rustc' panicked

--- a/src/test/ui/macros/rfc-3086-metavar-expr/required-feature.rs
+++ b/src/test/ui/macros/rfc-3086-metavar-expr/required-feature.rs
@@ -5,5 +5,40 @@ macro_rules! count {
     };
 }
 
+macro_rules! dollar_dollar {
+    () => {
+        macro_rules! bar {
+            ( $$( $$any:tt )* ) => { $$( $$any )* };
+            //~^ ERROR meta-variable expressions are unstable
+            //~| ERROR meta-variable expressions are unstable
+            //~| ERROR meta-variable expressions are unstable
+            //~| ERROR meta-variable expressions are unstable
+        }
+    };
+}
+
+macro_rules! index {
+    ( $( $e:stmt ),* ) => {
+        $( ${ignore(e)} ${index()} )*
+        //~^ ERROR meta-variable expressions are unstable
+        //~| ERROR meta-variable expressions are unstable
+    };
+}
+
+macro_rules! ignore {
+    ( $( $i:stmt ),* ) => {{
+        0 $( + 1 ${ignore(i)} )*
+        //~^ ERROR meta-variable expressions are unstable
+    }};
+}
+
+macro_rules! length {
+    ( $( $e:stmt ),* ) => {
+        $( ${ignore(e)} ${length()} )*
+        //~^ ERROR meta-variable expressions are unstable
+        //~| ERROR meta-variable expressions are unstable
+    };
+}
+
 fn main() {
 }

--- a/src/test/ui/macros/rfc-3086-metavar-expr/required-feature.stderr
+++ b/src/test/ui/macros/rfc-3086-metavar-expr/required-feature.stderr
@@ -7,6 +7,87 @@ LL |         ${ count(e) }
    = note: see issue #83527 <https://github.com/rust-lang/rust/issues/83527> for more information
    = help: add `#![feature(macro_metavar_expr)]` to the crate attributes to enable
 
-error: aborting due to previous error
+error[E0658]: meta-variable expressions are unstable
+  --> $DIR/required-feature.rs:11:16
+   |
+LL |             ( $$( $$any:tt )* ) => { $$( $$any )* };
+   |                ^
+   |
+   = note: see issue #83527 <https://github.com/rust-lang/rust/issues/83527> for more information
+   = help: add `#![feature(macro_metavar_expr)]` to the crate attributes to enable
+
+error[E0658]: meta-variable expressions are unstable
+  --> $DIR/required-feature.rs:11:20
+   |
+LL |             ( $$( $$any:tt )* ) => { $$( $$any )* };
+   |                    ^
+   |
+   = note: see issue #83527 <https://github.com/rust-lang/rust/issues/83527> for more information
+   = help: add `#![feature(macro_metavar_expr)]` to the crate attributes to enable
+
+error[E0658]: meta-variable expressions are unstable
+  --> $DIR/required-feature.rs:11:39
+   |
+LL |             ( $$( $$any:tt )* ) => { $$( $$any )* };
+   |                                       ^
+   |
+   = note: see issue #83527 <https://github.com/rust-lang/rust/issues/83527> for more information
+   = help: add `#![feature(macro_metavar_expr)]` to the crate attributes to enable
+
+error[E0658]: meta-variable expressions are unstable
+  --> $DIR/required-feature.rs:11:43
+   |
+LL |             ( $$( $$any:tt )* ) => { $$( $$any )* };
+   |                                           ^
+   |
+   = note: see issue #83527 <https://github.com/rust-lang/rust/issues/83527> for more information
+   = help: add `#![feature(macro_metavar_expr)]` to the crate attributes to enable
+
+error[E0658]: meta-variable expressions are unstable
+  --> $DIR/required-feature.rs:22:13
+   |
+LL |         $( ${ignore(e)} ${index()} )*
+   |             ^^^^^^^^^^^
+   |
+   = note: see issue #83527 <https://github.com/rust-lang/rust/issues/83527> for more information
+   = help: add `#![feature(macro_metavar_expr)]` to the crate attributes to enable
+
+error[E0658]: meta-variable expressions are unstable
+  --> $DIR/required-feature.rs:22:26
+   |
+LL |         $( ${ignore(e)} ${index()} )*
+   |                          ^^^^^^^^^
+   |
+   = note: see issue #83527 <https://github.com/rust-lang/rust/issues/83527> for more information
+   = help: add `#![feature(macro_metavar_expr)]` to the crate attributes to enable
+
+error[E0658]: meta-variable expressions are unstable
+  --> $DIR/required-feature.rs:30:19
+   |
+LL |         0 $( + 1 ${ignore(i)} )*
+   |                   ^^^^^^^^^^^
+   |
+   = note: see issue #83527 <https://github.com/rust-lang/rust/issues/83527> for more information
+   = help: add `#![feature(macro_metavar_expr)]` to the crate attributes to enable
+
+error[E0658]: meta-variable expressions are unstable
+  --> $DIR/required-feature.rs:37:13
+   |
+LL |         $( ${ignore(e)} ${length()} )*
+   |             ^^^^^^^^^^^
+   |
+   = note: see issue #83527 <https://github.com/rust-lang/rust/issues/83527> for more information
+   = help: add `#![feature(macro_metavar_expr)]` to the crate attributes to enable
+
+error[E0658]: meta-variable expressions are unstable
+  --> $DIR/required-feature.rs:37:26
+   |
+LL |         $( ${ignore(e)} ${length()} )*
+   |                          ^^^^^^^^^^
+   |
+   = note: see issue #83527 <https://github.com/rust-lang/rust/issues/83527> for more information
+   = help: add `#![feature(macro_metavar_expr)]` to the crate attributes to enable
+
+error: aborting due to 10 previous errors
 
 For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/traits/no-fallback-multiple-impls.rs
+++ b/src/test/ui/traits/no-fallback-multiple-impls.rs
@@ -1,0 +1,16 @@
+trait Fallback {
+    fn foo(&self) {}
+}
+
+impl Fallback for i32 {}
+
+impl Fallback for u64 {}
+
+impl Fallback for usize {}
+
+fn main() {
+    missing();
+    //~^ ERROR cannot find function `missing` in this scope
+    0.foo();
+    // But then we shouldn't report an inference ambiguity here...
+}

--- a/src/test/ui/traits/no-fallback-multiple-impls.stderr
+++ b/src/test/ui/traits/no-fallback-multiple-impls.stderr
@@ -1,0 +1,9 @@
+error[E0425]: cannot find function `missing` in this scope
+  --> $DIR/no-fallback-multiple-impls.rs:12:5
+   |
+LL |     missing();
+   |     ^^^^^^^ not found in this scope
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0425`.

--- a/src/test/ui/traits/test-2.rs
+++ b/src/test/ui/traits/test-2.rs
@@ -6,9 +6,9 @@ impl bar for i32 { fn dup(&self) -> i32 { *self } fn blah<X>(&self) {} }
 impl bar for u32 { fn dup(&self) -> u32 { *self } fn blah<X>(&self) {} }
 
 fn main() {
-    10.dup::<i32>(); //~ ERROR type annotations needed
+    10.dup::<i32>();
     //~^ ERROR this associated function takes 0 generic arguments but 1
-    10.blah::<i32, i32>(); //~ ERROR type annotations needed
+    10.blah::<i32, i32>();
     //~^ ERROR this associated function takes 1 generic argument but 2
     (Box::new(10) as Box<dyn bar>).dup();
     //~^ ERROR E0038

--- a/src/test/ui/traits/test-2.stderr
+++ b/src/test/ui/traits/test-2.stderr
@@ -79,35 +79,7 @@ LL | trait bar { fn dup(&self) -> Self; fn blah<X>(&self); }
    = note: required because of the requirements on the impl of `CoerceUnsized<Box<dyn bar>>` for `Box<{integer}>`
    = note: required by cast to type `Box<dyn bar>`
 
-error[E0283]: type annotations needed
-  --> $DIR/test-2.rs:9:8
-   |
-LL |     10.dup::<i32>();
-   |        ^^^ cannot infer type for type `{integer}`
-   |
-note: multiple `impl`s satisfying `{integer}: bar` found
-  --> $DIR/test-2.rs:5:1
-   |
-LL | impl bar for i32 { fn dup(&self) -> i32 { *self } fn blah<X>(&self) {} }
-   | ^^^^^^^^^^^^^^^^
-LL | impl bar for u32 { fn dup(&self) -> u32 { *self } fn blah<X>(&self) {} }
-   | ^^^^^^^^^^^^^^^^
+error: aborting due to 5 previous errors
 
-error[E0283]: type annotations needed
-  --> $DIR/test-2.rs:11:8
-   |
-LL |     10.blah::<i32, i32>();
-   |        ^^^^ cannot infer type for type `{integer}`
-   |
-note: multiple `impl`s satisfying `{integer}: bar` found
-  --> $DIR/test-2.rs:5:1
-   |
-LL | impl bar for i32 { fn dup(&self) -> i32 { *self } fn blah<X>(&self) {} }
-   | ^^^^^^^^^^^^^^^^
-LL | impl bar for u32 { fn dup(&self) -> u32 { *self } fn blah<X>(&self) {} }
-   | ^^^^^^^^^^^^^^^^
-
-error: aborting due to 7 previous errors
-
-Some errors have detailed explanations: E0038, E0107, E0283.
+Some errors have detailed explanations: E0038, E0107.
 For more information about an error, try `rustc --explain E0038`.

--- a/src/tools/build-manifest/src/main.rs
+++ b/src/tools/build-manifest/src/main.rs
@@ -152,6 +152,7 @@ static TARGETS: &[&str] = &[
     "x86_64-unknown-linux-gnux32",
     "x86_64-unknown-linux-musl",
     "x86_64-unknown-netbsd",
+    "x86_64-unknown-none",
     "x86_64-unknown-redox",
     "x86_64-unknown-hermit",
 ];


### PR DESCRIPTION
Successful merges:

 - #95102 (Add known-bug for #95034)
 - #95634 (Mailmap update)
 - #95705 (Promote x86_64-unknown-none target to Tier 2 and distribute build artifacts)
 - #95751 (Don't report numeric inference ambiguity when we have previous errors)
 - #95761 (Kickstart the inner usage of `macro_metavar_expr`)
 - #95764 ([macro_metavar_expr] Add tests to ensure the feature requirement)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=95102,95634,95705,95751,95761,95764)
<!-- homu-ignore:end -->