### PR TITLE
Remove explicit delimiter token trees from `Delimited`.

### DIFF
--- a/compiler/rustc_expand/src/mbe/macro_check.rs
+++ b/compiler/rustc_expand/src/mbe/macro_check.rs
@@ -282,7 +282,7 @@ fn check_binders(
         // `MetaVarExpr` can not appear in the LHS of a macro arm
         TokenTree::MetaVarExpr(..) => {}
         TokenTree::Delimited(_, ref del) => {
-            for tt in del.inner_tts() {
+            for tt in &del.tts {
                 check_binders(sess, node_id, tt, macros, binders, ops, valid);
             }
         }
@@ -345,7 +345,7 @@ fn check_occurrences(
             check_ops_is_prefix(sess, node_id, macros, binders, ops, dl.entire(), name);
         }
         TokenTree::Delimited(_, ref del) => {
-            check_nested_occurrences(sess, node_id, del.inner_tts(), macros, binders, ops, valid);
+            check_nested_occurrences(sess, node_id, &del.tts, macros, binders, ops, valid);
         }
         TokenTree::Sequence(_, ref seq) => {
             let ops = ops.push(seq.kleene);
@@ -432,20 +432,14 @@ fn check_nested_occurrences(
             {
                 let macro_rules = state == NestedMacroState::MacroRulesNotName;
                 state = NestedMacroState::Empty;
-                let rest = check_nested_macro(
-                    sess,
-                    node_id,
-                    macro_rules,
-                    del.inner_tts(),
-                    &nested_macros,
-                    valid,
-                );
+                let rest =
+                    check_nested_macro(sess, node_id, macro_rules, &del.tts, &nested_macros, valid);
                 // If we did not check the whole macro definition, then check the rest as if outside
                 // the macro definition.
                 check_nested_occurrences(
                     sess,
                     node_id,
-                    &del.inner_tts()[rest..],
+                    &del.tts[rest..],
                     macros,
                     binders,
                     ops,

--- a/compiler/rustc_expand/src/mbe/quoted.rs
+++ b/compiler/rustc_expand/src/mbe/quoted.rs
@@ -45,8 +45,10 @@ pub(super) fn parse(
     node_id: NodeId,
     features: &Features,
     edition: Edition,
-    result: &mut Vec<TokenTree>,
-) {
+) -> Vec<TokenTree> {
+    // Will contain the final collection of `self::TokenTree`
+    let mut result = Vec::new();
+
     // For each token tree in `input`, parse the token into a `self::TokenTree`, consuming
     // additional trees if need be.
     let mut trees = input.trees();
@@ -113,6 +115,7 @@ pub(super) fn parse(
             _ => result.push(tree),
         }
     }
+    result
 }
 
 /// Asks for the `macro_metavar_expr` feature if it is not already declared
@@ -205,8 +208,7 @@ fn parse_tree(
                     // If we didn't find a metavar expression above, then we must have a
                     // repetition sequence in the macro (e.g. `$(pat)*`).  Parse the
                     // contents of the sequence itself
-                    let mut sequence = vec![];
-                    parse(tts, parsing_patterns, sess, node_id, features, edition, &mut sequence);
+                    let sequence = parse(tts, parsing_patterns, sess, node_id, features, edition);
                     // Get the Kleene operator and optional separator
                     let (separator, kleene) =
                         parse_sep_and_kleene_op(&mut trees, delim_span.entire(), sess);
@@ -269,15 +271,13 @@ fn parse_tree(
 
         // `tree` is the beginning of a delimited set of tokens (e.g., `(` or `{`). We need to
         // descend into the delimited set and further parse it.
-        tokenstream::TokenTree::Delimited(span, delim, tts) => {
-            let mut all_tts = vec![];
-            // Add the explicit open and close delimiters, which
-            // `tokenstream::TokenTree::Delimited` lacks.
-            all_tts.push(TokenTree::token(token::OpenDelim(delim), span.open));
-            parse(tts, parsing_patterns, sess, node_id, features, edition, &mut all_tts);
-            all_tts.push(TokenTree::token(token::CloseDelim(delim), span.close));
-            TokenTree::Delimited(span, Lrc::new(Delimited { delim, all_tts }))
-        }
+        tokenstream::TokenTree::Delimited(span, delim, tts) => TokenTree::Delimited(
+            span,
+            Lrc::new(Delimited {
+                delim,
+                tts: parse(tts, parsing_patterns, sess, node_id, features, edition),
+            }),
+        ),
     }
 }
 


### PR DESCRIPTION
They were introduced by the final commit in #95159 and gave a
performance win. But since the introduction of `MatcherLoc` they are no
longer needed. This commit reverts that change, making the code a bit
simpler.

r? @petrochenkov 