### PR TITLE
hide another #[allow] directive from a docs example

### DIFF
--- a/library/alloc/src/rc.rs
+++ b/library/alloc/src/rc.rs
@@ -393,7 +393,7 @@ impl<T> Rc<T> {
     /// # Examples
     ///
     /// ```
-    /// #![allow(dead_code)]
+    /// # #![allow(dead_code)]
     /// use std::rc::{Rc, Weak};
     ///
     /// struct Gadget {


### PR DESCRIPTION
This is a repeat for Rc of e0e64a89304de2b34dbafbc6cb354d2be9e67835,
which cleaned up the same thing for Arc.