### PR TITLE
Use bitwise XOR in to_ascii_uppercase

### DIFF
--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -299,8 +299,8 @@ impl u8 {
     #[rustc_const_stable(feature = "const_ascii_methods_on_intrinsics", since = "1.52.0")]
     #[inline]
     pub const fn to_ascii_uppercase(&self) -> u8 {
-        // Unset the fifth bit if this is a lowercase letter
-        *self & !((self.is_ascii_lowercase() as u8) * ASCII_CASE_MASK)
+        // Toggle the fifth bit if this is a lowercase letter
+        *self ^ ((self.is_ascii_lowercase() as u8) * ASCII_CASE_MASK)
     }
 
     /// Makes a copy of the value in its ASCII lower case equivalent.


### PR DESCRIPTION
This saves an instruction compared to the previous approach, which
was to unset the fifth bit with bitwise OR.

Comparison of generated assembly on x86: https://godbolt.org/z/GdfvdGs39

This can also affect autovectorization, saving SIMD instructions as well: https://godbolt.org/z/cnPcz75T9

Not sure if `u8::to_ascii_lowercase` should also be changed, since using bitwise OR for that function does not require an extra bitwise negate since the code is setting a bit rather than unsetting a bit. `char::to_ascii_uppercase` already uses XOR, so no change seems to be required there.