### PR TITLE
Experiment: Make intrinsic::size_of(slice) saturate

### DIFF
--- a/compiler/rustc_codegen_ssa/src/glue.rs
+++ b/compiler/rustc_codegen_ssa/src/glue.rs
@@ -44,8 +44,9 @@ pub fn size_and_align_of_dst<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
                 bx.const_usize(unit.size.bytes()),
                 info.unwrap(),
             );
+            let ptr_max = bx.data_layout().pointer_size.truncate(u128::MAX) as u64;
             (
-                bx.select(overflow, bx.const_usize(u64::MAX), size),
+                bx.select(overflow, bx.const_usize(ptr_max), size),
                 bx.const_usize(unit.align.abi.bytes()),
             )
         }

--- a/compiler/rustc_codegen_ssa/src/glue.rs
+++ b/compiler/rustc_codegen_ssa/src/glue.rs
@@ -5,7 +5,7 @@
 use crate::common::IntPredicate;
 use crate::meth;
 use crate::traits::*;
-use rustc_middle::ty::{self, Ty};
+use rustc_middle::ty::{self, Ty, UintTy};
 use rustc_target::abi::WrappingRange;
 
 pub fn size_and_align_of_dst<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
@@ -41,11 +41,11 @@ pub fn size_and_align_of_dst<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
             let (size, overflow) = bx.checked_binop(
                 OverflowOp::Mul,
                 bx.tcx().mk_mach_uint(UintTy::Usize),
-                unit.size.bytes(),
+                bx.const_usize(unit.size.bytes()),
                 info.unwrap(),
             );
             (
-                bx.select(overflow, bx.const_usize(usize::MAX), size),
+                bx.select(overflow, bx.const_usize(u64::MAX), size),
                 bx.const_usize(unit.align.abi.bytes()),
             )
         }

--- a/compiler/rustc_codegen_ssa/src/glue.rs
+++ b/compiler/rustc_codegen_ssa/src/glue.rs
@@ -38,8 +38,14 @@ pub fn size_and_align_of_dst<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
             let unit = layout.field(bx, 0);
             // The info in this case is the length of the str, so the size is that
             // times the unit size.
+            let (size, overflow) = bx.checked_binop(
+                OverflowOp::Mul,
+                bx.tcx().mk_mach_uint(UintTy::Usize),
+                unit.size.bytes(),
+                info.unwrap(),
+            );
             (
-                bx.mul(info.unwrap(), bx.const_usize(unit.size.bytes())),
+                bx.select(overflow, bx.const_usize(usize::MAX), size),
                 bx.const_usize(unit.align.abi.bytes()),
             )
         }


### PR DESCRIPTION
Experiment to see how much of a perf impact this is.

Currently, `size_of_val` will wrap for a slice that is larger than `usize::MAX`. Constructing a pointer to such is stably safe via [`ptr::slice_from_raw_parts[_mut]`](https://doc.rust-lang.org/std/ptr/fn.slice_from_raw_parts_mut.html).

I would like it to be possible to have a safe/checked version of `size_of_val_raw`, which returns roughly `Option<#[rustc_valid_scalar_range_start(0)] isize>`. The simple way to do so is to have `intrinsic::size_of` saturate, and then the safe wrapper can check for `> isize::MAX` as the error condition.

This PR is to check how expensive it would be to just always saturate the computation of a slice's size.

This PR does not address any of the other kinds of unsized types. Aggregate types will still potentially overflow, and it is still (AIUI) undecided whether the vtable part of pointer-to-dyn-trait is required to point to a valid vtable.