### PR TITLE
Use `rust_out{exe_suffix}` for doctests

### DIFF
--- a/src/test/run-make/coverage-reports/Makefile
+++ b/src/test/run-make/coverage-reports/Makefile
@@ -132,7 +132,7 @@ include clear_expected_if_blessed
 			--instr-profile="$(TMPDIR)"/$@.profdata \
 			$(call BIN,"$(TMPDIR)"/$@) \
 			$$( \
-				for file in $(TMPDIR)/rustdoc-$@/*/rust_out; do \
+				for file in $(TMPDIR)/rustdoc-$@/*/rust_out*; do \
 				[ -x "$$file" ] && printf "%s %s " -object $$file; \
 				done \
 			) \


### PR DESCRIPTION
This was mentioned as an issue to me by @bruxisma. There are 3 separate instances where "rust_out" can become part of the name of a Rust executable, so I am mostly just hoping that this fixes the problem, given that the other sites which it can slip in seem to be well-behaved.
