### PR TITLE
TypeId: use a (v0) mangled type to remain sound in the face of hash collisions.

### DIFF
--- a/compiler/rustc_codegen_gcc/src/builder.rs
+++ b/compiler/rustc_codegen_gcc/src/builder.rs
@@ -783,11 +783,11 @@ impl<'a, 'gcc, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'gcc, 'tcx> {
         // TODO(antoyo)
     }
 
-    fn type_metadata(&mut self, _function: RValue<'gcc>, _typeid: String) {
+    fn llvm_cfi_type_metadata(&mut self, _function: RValue<'gcc>, _typeid: String) {
         // Unsupported.
     }
 
-    fn typeid_metadata(&mut self, _typeid: String) -> RValue<'gcc> {
+    fn llvm_cfi_typeid_metadata(&mut self, _typeid: String) -> RValue<'gcc> {
         // Unsupported.
         self.context.new_rvalue_from_int(self.int_type, 0)
     }

--- a/compiler/rustc_codegen_llvm/src/builder.rs
+++ b/compiler/rustc_codegen_llvm/src/builder.rs
@@ -621,8 +621,9 @@ impl<'a, 'll, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'll, 'tcx> {
         }
     }
 
-    fn type_metadata(&mut self, function: &'ll Value, typeid: String) {
-        let typeid_metadata = self.typeid_metadata(typeid);
+    // FIXME(eddyb) this does not belong in `Builder`, it's global.
+    fn llvm_cfi_type_metadata(&mut self, function: &'ll Value, typeid: String) {
+        let typeid_metadata = self.llvm_cfi_typeid_metadata(typeid);
         let v = [self.const_usize(0), typeid_metadata];
         unsafe {
             llvm::LLVMGlobalSetMetadata(
@@ -637,7 +638,8 @@ impl<'a, 'll, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'll, 'tcx> {
         }
     }
 
-    fn typeid_metadata(&mut self, typeid: String) -> Self::Value {
+    // FIXME(eddyb) this does not belong in `Builder`, it's global.
+    fn llvm_cfi_typeid_metadata(&mut self, typeid: String) -> Self::Value {
         unsafe {
             llvm::LLVMMDStringInContext(
                 self.cx.llcx,

--- a/compiler/rustc_codegen_ssa/src/mir/block.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/block.rs
@@ -20,7 +20,7 @@ use rustc_middle::ty::print::{with_no_trimmed_paths, with_no_visible_paths};
 use rustc_middle::ty::{self, Instance, Ty, TypeFoldable};
 use rustc_span::source_map::Span;
 use rustc_span::{sym, Symbol};
-use rustc_symbol_mangling::typeid_for_fnabi;
+use rustc_symbol_mangling::llvm_cfi_typeid_for_fn_abi;
 use rustc_target::abi::call::{ArgAbi, FnAbi, PassMode};
 use rustc_target::abi::{self, HasDataLayout, WrappingRange};
 use rustc_target::spec::abi::Abi;
@@ -908,8 +908,8 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
             // Emit type metadata and checks.
             // FIXME(rcvalle): Add support for generalized identifiers.
             // FIXME(rcvalle): Create distinct unnamed MDNodes for internal identifiers.
-            let typeid = typeid_for_fnabi(bx.tcx(), fn_abi);
-            let typeid_metadata = bx.typeid_metadata(typeid);
+            let typeid = llvm_cfi_typeid_for_fn_abi(bx.tcx(), fn_abi);
+            let typeid_metadata = bx.llvm_cfi_typeid_metadata(typeid);
 
             // Test whether the function pointer is associated with the type identifier.
             let cond = bx.type_test(fn_ptr, typeid_metadata);

--- a/compiler/rustc_codegen_ssa/src/mir/mod.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/mod.rs
@@ -3,7 +3,7 @@ use rustc_middle::mir;
 use rustc_middle::mir::interpret::ErrorHandled;
 use rustc_middle::ty::layout::{FnAbiOf, HasTyCtxt, TyAndLayout};
 use rustc_middle::ty::{self, Instance, Ty, TypeFoldable};
-use rustc_symbol_mangling::typeid_for_fnabi;
+use rustc_symbol_mangling::llvm_cfi_typeid_for_fn_abi;
 use rustc_target::abi::call::{FnAbi, PassMode};
 
 use std::iter;
@@ -252,8 +252,8 @@ pub fn codegen_mir<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
     // For backends that support CFI using type membership (i.e., testing whether a given  pointer
     // is associated with a type identifier).
     if cx.tcx().sess.is_sanitizer_cfi_enabled() {
-        let typeid = typeid_for_fnabi(cx.tcx(), fn_abi);
-        bx.type_metadata(llfn, typeid);
+        let typeid = llvm_cfi_typeid_for_fn_abi(cx.tcx(), fn_abi);
+        bx.llvm_cfi_type_metadata(llfn, typeid);
     }
 }
 

--- a/compiler/rustc_codegen_ssa/src/traits/builder.rs
+++ b/compiler/rustc_codegen_ssa/src/traits/builder.rs
@@ -160,8 +160,10 @@ pub trait BuilderMethods<'a, 'tcx>:
 
     fn range_metadata(&mut self, load: Self::Value, range: WrappingRange);
     fn nonnull_metadata(&mut self, load: Self::Value);
-    fn type_metadata(&mut self, function: Self::Function, typeid: String);
-    fn typeid_metadata(&mut self, typeid: String) -> Self::Value;
+
+    // FIXME(eddyb) these do not belong in `Builder`, they're global.
+    fn llvm_cfi_type_metadata(&mut self, function: Self::Function, typeid: String);
+    fn llvm_cfi_typeid_metadata(&mut self, typeid: String) -> Self::Value;
 
     fn store(&mut self, val: Self::Value, ptr: Self::Value, align: Align) -> Self::Value;
     fn store_with_flags(

--- a/compiler/rustc_const_eval/src/interpret/intern.rs
+++ b/compiler/rustc_const_eval/src/interpret/intern.rs
@@ -106,7 +106,7 @@ fn intern_shallow<'rt, 'mir, 'tcx, M: CompileTimeMachine<'mir, 'tcx, const_eval:
     match kind {
         MemoryKind::Stack
         | MemoryKind::Machine(const_eval::MemoryKind::Heap)
-        | MemoryKind::CallerLocation => {}
+        | MemoryKind::IntrinsicGlobal => {}
     }
     // Set allocation mutability as appropriate. This is used by LLVM to put things into
     // read-only memory, and also by Miri when evaluating other globals that

--- a/compiler/rustc_const_eval/src/interpret/intrinsics.rs
+++ b/compiler/rustc_const_eval/src/interpret/intrinsics.rs
@@ -5,6 +5,7 @@
 use std::convert::TryFrom;
 
 use rustc_hir::def_id::DefId;
+use rustc_hir::lang_items::LangItem;
 use rustc_middle::mir::{
     self,
     interpret::{ConstValue, GlobalId, InterpResult, Scalar},
@@ -166,7 +167,9 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 let ty = match intrinsic_name {
                     sym::pref_align_of | sym::variant_count => self.tcx.types.usize,
                     sym::needs_drop => self.tcx.types.bool,
-                    sym::type_id => self.tcx.types.u64,
+                    sym::type_id => self
+                        .tcx
+                        .type_of(self.tcx.require_lang_item(LangItem::TypeId, Some(self.tcx.span))),
                     sym::type_name => self.tcx.mk_static_str(),
                     _ => bug!("already checked for nullary intrinsics"),
                 };

--- a/compiler/rustc_const_eval/src/interpret/intrinsics.rs
+++ b/compiler/rustc_const_eval/src/interpret/intrinsics.rs
@@ -70,7 +70,7 @@ crate fn eval_nullary_intrinsic<'tcx>(
         }
         sym::type_id => {
             ensure_monomorphic_enough(tcx, tp_ty)?;
-            ConstValue::from_u64(tcx.type_id_hash(tp_ty))
+            crate::const_eval::const_type_id(tcx, param_env, tp_ty)
         }
         sym::variant_count => match tp_ty.kind() {
             // Correctly handles non-monomorphic calls, so there is no need for ensure_monomorphic_enough.

--- a/compiler/rustc_const_eval/src/interpret/memory.rs
+++ b/compiler/rustc_const_eval/src/interpret/memory.rs
@@ -29,8 +29,8 @@ use super::{
 pub enum MemoryKind<T> {
     /// Stack memory. Error if deallocated except during a stack pop.
     Stack,
-    /// Memory allocated by `caller_location` intrinsic. Error if ever deallocated.
-    CallerLocation,
+    /// Global memory allocated by an intrinsic. Error if ever deallocated.
+    IntrinsicGlobal,
     /// Additional memory kinds a machine wishes to distinguish from the builtin ones.
     Machine(T),
 }
@@ -40,7 +40,7 @@ impl<T: MayLeak> MayLeak for MemoryKind<T> {
     fn may_leak(self) -> bool {
         match self {
             MemoryKind::Stack => false,
-            MemoryKind::CallerLocation => true,
+            MemoryKind::IntrinsicGlobal => true,
             MemoryKind::Machine(k) => k.may_leak(),
         }
     }
@@ -50,7 +50,7 @@ impl<T: fmt::Display> fmt::Display for MemoryKind<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             MemoryKind::Stack => write!(f, "stack variable"),
-            MemoryKind::CallerLocation => write!(f, "caller location"),
+            MemoryKind::IntrinsicGlobal => write!(f, "global memory (from intrinsic)"),
             MemoryKind::Machine(m) => write!(f, "{}", m),
         }
     }

--- a/compiler/rustc_hir/src/lang_items.rs
+++ b/compiler/rustc_hir/src/lang_items.rs
@@ -217,7 +217,7 @@ language_item_table! {
     IndexMut(Op),            sym::index_mut,           index_mut_trait,            Target::Trait,          GenericRequirement::Exact(1);
 
     UnsafeCell,              sym::unsafe_cell,         unsafe_cell_type,           Target::Struct,         GenericRequirement::None;
-    VaList,                  sym::va_list,             va_list,                    Target::Struct,         GenericRequirement::None;
+    VaList,                  sym::va_list,             va_list_type,               Target::Struct,         GenericRequirement::None;
 
     Deref,                   sym::deref,               deref_trait,                Target::Trait,          GenericRequirement::Exact(0);
     DerefMut,                sym::deref_mut,           deref_mut_trait,            Target::Trait,          GenericRequirement::Exact(0);
@@ -326,6 +326,8 @@ language_item_table! {
     Range,                   sym::Range,               range_struct,               Target::Struct,         GenericRequirement::None;
     RangeToInclusive,        sym::RangeToInclusive,    range_to_inclusive_struct,  Target::Struct,         GenericRequirement::None;
     RangeTo,                 sym::RangeTo,             range_to_struct,            Target::Struct,         GenericRequirement::None;
+
+    TypeId,                  sym::TypeId,              type_id_struct,             Target::Struct,         GenericRequirement::Exact(0);
 }
 
 pub enum GenericRequirement {

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -266,6 +266,7 @@ symbols! {
         Ty,
         TyCtxt,
         TyKind,
+        TypeId,
         Unknown,
         UnsafeArg,
         Vec,

--- a/compiler/rustc_symbol_mangling/src/v0.rs
+++ b/compiler/rustc_symbol_mangling/src/v0.rs
@@ -11,7 +11,6 @@ use rustc_middle::ty::print::{Print, Printer};
 use rustc_middle::ty::subst::{GenericArg, GenericArgKind, Subst};
 use rustc_middle::ty::{self, FloatTy, Instance, IntTy, Ty, TyCtxt, TypeFoldable, UintTy};
 use rustc_span::symbol::kw;
-use rustc_target::abi::call::FnAbi;
 use rustc_target::abi::Integer;
 use rustc_target::spec::abi::Abi;
 
@@ -56,41 +55,6 @@ pub(super) fn mangle<'tcx>(
         cx = cx.print_def_path(instantiating_crate.as_def_id(), &[]).unwrap();
     }
     std::mem::take(&mut cx.out)
-}
-
-pub(super) fn mangle_typeid_for_fnabi<'tcx>(
-    _tcx: TyCtxt<'tcx>,
-    fn_abi: &FnAbi<'tcx, Ty<'tcx>>,
-) -> String {
-    // LLVM uses type metadata to allow IR modules to aggregate pointers by their types.[1] This
-    // type metadata is used by LLVM Control Flow Integrity to test whether a given pointer is
-    // associated with a type identifier (i.e., test type membership).
-    //
-    // Clang uses the Itanium C++ ABI's[2] virtual tables and RTTI typeinfo structure name[3] as
-    // type metadata identifiers for function pointers. The typeinfo name encoding is a
-    // two-character code (i.e., “TS”) prefixed to the type encoding for the function.
-    //
-    // For cross-language LLVM CFI support, a compatible encoding must be used by either
-    //
-    //  a. Using a superset of types that encompasses types used by Clang (i.e., Itanium C++ ABI's
-    //     type encodings[4]), or at least types used at the FFI boundary.
-    //  b. Reducing the types to the least common denominator between types used by Clang (or at
-    //     least types used at the FFI boundary) and Rust compilers (if even possible).
-    //  c. Creating a new ABI for cross-language CFI and using it for Clang and Rust compilers (and
-    //     possibly other compilers).
-    //
-    // Option (b) may weaken the protection for Rust-compiled only code, so it should be provided
-    // as an alternative to a Rust-specific encoding for when mixing Rust and C and C++ -compiled
-    // code. Option (c) would require changes to Clang to use the new ABI.
-    //
-    // [1] https://llvm.org/docs/TypeMetadata.html
-    // [2] https://itanium-cxx-abi.github.io/cxx-abi/abi.html
-    // [3] https://itanium-cxx-abi.github.io/cxx-abi/abi.html#mangling-special-vtables
-    // [4] https://itanium-cxx-abi.github.io/cxx-abi/abi.html#mangling-type
-    //
-    // FIXME(rcvalle): See comment above.
-    let arg_count = fn_abi.args.len() + fn_abi.ret.is_indirect() as usize;
-    format!("typeid{}", arg_count)
 }
 
 struct BinderLevel {

--- a/library/core/src/any.rs
+++ b/library/core/src/any.rs
@@ -594,6 +594,7 @@ impl dyn Any + Send + Sync {
 /// While `TypeId` implements `Hash`, `PartialOrd`, and `Ord`, it is worth
 /// noting that the hashes and ordering will vary between Rust releases. Beware
 /// of relying on them inside of your code!
+#[cfg_attr(not(bootstrap), lang = "TypeId")]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub struct TypeId {
@@ -620,7 +621,14 @@ impl TypeId {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_const_unstable(feature = "const_type_id", issue = "77125")]
     pub const fn of<T: ?Sized + 'static>() -> TypeId {
-        TypeId { t: intrinsics::type_id::<T>() }
+        #[cfg(bootstrap)]
+        {
+            TypeId { t: intrinsics::type_id::<T>() }
+        }
+        #[cfg(not(bootstrap))]
+        {
+            intrinsics::type_id::<T>()
+        }
     }
 }
 

--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -848,6 +848,11 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is [`core::any::TypeId::of`].
     #[rustc_const_unstable(feature = "const_type_id", issue = "77125")]
+    #[cfg(not(bootstrap))]
+    pub fn type_id<T: ?Sized + 'static>() -> crate::any::TypeId;
+
+    #[rustc_const_unstable(feature = "const_type_id", issue = "77125")]
+    #[cfg(bootstrap)]
     pub fn type_id<T: ?Sized + 'static>() -> u64;
 
     /// A guard for unsafe functions that cannot ever be executed if `T` is uninhabited:

--- a/src/test/ui/const-generics/issues/issue-90318.stderr
+++ b/src/test/ui/const-generics/issues/issue-90318.stderr
@@ -18,7 +18,7 @@ LL |     If<{ TypeId::of::<T>() != TypeId::of::<()>() }>: True,
 note: impl defined here, but it is not `const`
   --> $SRC_DIR/core/src/any.rs:LL:COL
    |
-LL | #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
+LL | #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
    |                       ^^^^^^^^^
    = note: calls in constants are limited to constant functions, tuple structs and tuple variants
    = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -43,7 +43,7 @@ LL |     If<{ TypeId::of::<T>() != TypeId::of::<()>() }>: True,
 note: impl defined here, but it is not `const`
   --> $SRC_DIR/core/src/any.rs:LL:COL
    |
-LL | #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
+LL | #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
    |                       ^^^^^^^^^
    = note: calls in constants are limited to constant functions, tuple structs and tuple variants
    = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/src/test/ui/consts/issue-73976-monomorphic.rs
+++ b/src/test/ui/consts/issue-73976-monomorphic.rs
@@ -1,9 +1,10 @@
-// check-pass
-//
-// This test is complement to the test in issue-73976-polymorphic.rs.
-// In that test we ensure that polymorphic use of type_id and type_name in patterns
-// will be properly rejected. This test will ensure that monomorphic use of these
-// would not be wrongly rejected in patterns.
+// NOTE(eddyb) this was the original comment before this test started erroring:
+//  > // check-pass
+//  > //
+//  > // This test is complement to the test in issue-73976-polymorphic.rs.
+//  > // In that test we ensure that polymorphic use of type_id and type_name in patterns
+//  > // will be properly rejected. This test will ensure that monomorphic use of these
+//  > // would not be wrongly rejected in patterns.
 
 #![feature(const_type_id)]
 #![feature(const_type_name)]
@@ -18,6 +19,7 @@ impl<T: 'static> GetTypeId<T> {
 
 const fn check_type_id<T: 'static>() -> bool {
     matches!(GetTypeId::<T>::VALUE, GetTypeId::<usize>::VALUE)
+    //~^ ERROR to use a constant of type
 }
 
 pub struct GetTypeNameLen<T>(T);

--- a/src/test/ui/consts/issue-73976-monomorphic.stderr
+++ b/src/test/ui/consts/issue-73976-monomorphic.stderr
@@ -1,0 +1,8 @@
+error: to use a constant of type `any::TypeManglingStr` in a pattern, `any::TypeManglingStr` must be annotated with `#[derive(PartialEq, Eq)]`
+  --> $DIR/issue-73976-monomorphic.rs:21:37
+   |
+LL |     matches!(GetTypeId::<T>::VALUE, GetTypeId::<usize>::VALUE)
+   |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+

--- a/src/test/ui/extern/extern-types-not-sync-send.stderr
+++ b/src/test/ui/extern/extern-types-not-sync-send.stderr
@@ -5,6 +5,7 @@ LL |     assert_sync::<A>();
    |                   ^ `A` cannot be shared between threads safely
    |
    = help: the trait `Sync` is not implemented for `A`
+   = help: the trait `Sync` is implemented for `any::OpaqueStrBytes`
 note: required by a bound in `assert_sync`
   --> $DIR/extern-types-not-sync-send.rs:9:28
    |
@@ -18,6 +19,7 @@ LL |     assert_send::<A>();
    |                   ^ `A` cannot be sent between threads safely
    |
    = help: the trait `Send` is not implemented for `A`
+   = help: the trait `Send` is implemented for `any::OpaqueStrBytes`
 note: required by a bound in `assert_send`
   --> $DIR/extern-types-not-sync-send.rs:10:28
    |

--- a/src/test/ui/fmt/send-sync.stderr
+++ b/src/test/ui/fmt/send-sync.stderr
@@ -5,6 +5,7 @@ LL |     send(format_args!("{:?}", c));
    |     ^^^^ `core::fmt::Opaque` cannot be shared between threads safely
    |
    = help: within `[ArgumentV1<'_>]`, the trait `Sync` is not implemented for `core::fmt::Opaque`
+   = help: the trait `Sync` is implemented for `any::OpaqueStrBytes`
    = note: required because it appears within the type `&core::fmt::Opaque`
    = note: required because it appears within the type `ArgumentV1<'_>`
    = note: required because it appears within the type `[ArgumentV1<'_>]`
@@ -23,6 +24,7 @@ LL |     sync(format_args!("{:?}", c));
    |     ^^^^ `core::fmt::Opaque` cannot be shared between threads safely
    |
    = help: within `Arguments<'_>`, the trait `Sync` is not implemented for `core::fmt::Opaque`
+   = help: the trait `Sync` is implemented for `any::OpaqueStrBytes`
    = note: required because it appears within the type `&core::fmt::Opaque`
    = note: required because it appears within the type `ArgumentV1<'_>`
    = note: required because it appears within the type `[ArgumentV1<'_>]`


### PR DESCRIPTION
This implements the strategy described in https://github.com/rust-lang/rust/issues/77125#issuecomment-894926005, resulting in:
* collision resistance: `TypeId`s become as sound as [v0 symbol names](https://github.com/rust-lang/rust/issues/60705)
  * that is, either can only be subverted by bypassing Cargo and linking together artifacts that share a crate identity (both name and disambiguator hash) but not the same sources
    <sub>on some platforms we may be able to instruct the linker to error based on e.g. different data in a symbol with a name only depends on crate identity, but in which we place the SVH (which depends on the crate's whole source/AST/HIR)</sub>
    <sub>*however*, improving symbol name soundness is not in the scope of this PR, only `TypeId` parity with the best tool we have for serializing Rust identities in the face of separate compilation (i.e. v0 symbol names)</sub>
* breaking code `transmute`-ing `TypeId`s to `u64`
  * you can see some examples in https://github.com/rust-lang/rust/pull/75923#issuecomment-699080944
  * this's why the `(u64, ptr)` layout was used in this PR (instead of a single pointer with the `u64` hash stored behind it) - it's strictly larger *irrespective* of target
* breaking code calling `TypeId::of` at compile-time (still unstable) then either `transmute`-ing it to an integer, or using it in a pattern (turns out we had a test for the latter)
  * effectively unblocks #77125
* (optionally) `TypeId` + `rustc_demangle` (which `std` already depends on) could offer access to the type name at runtime, which has been asked for before:
  * #61533
  * #68379
  * this would be equivalent to [`type_info::name`](https://en.cppreference.com/w/cpp/types/type_info/name) from C++ RTTI (where `type_info` is obtained with the `typeid(T)` operator, which acts like our `TypeId::of::<T>()`)
  * while the type mangling string is not exposed in this PR, it could easily be later - but embedding `rustc_demangle` into `core` would be harder to do (and justify)

<hr/>

This implementation adds a new field to `TypeId`:
```rust
struct TypeId {
    hash: u64,
    mangling: &'static TypeManglingStr,
}
```
The `&TypeManglingStr` type is like `&str` but "thin", with the `usize` length being stored before the `str` data (an optimization to avoid making `TypeId` more than double in size).

To avoid comparing the string contents of the `mangling` field *every* time, `a == b` has:
1. a "fast reject" path for `a.hash != b.hash`
    * i.e. `a` and `b` are definitely different if their `hash`es differ
2. a "fast accept" path for `ptr::eq(a.mangling, b.mangling)`
    * i.e. `a` and `b` are definitely the same if their `mangling`s are the same in memory
    * this is just one address comparison thanks to the use of the "thin" `&TypeManglingStr` type, which its length being stored behind the pointer
3. a fallback path: compare the actual `mangling` string contents

While 1. and 2. could come in either order (as `hash` and `mangling` equalities are intrinsically linked), for simplicity (and being able to rely on `#[derive]` a bit), the order used above is the order they are checked in, in this PR currently.

Ideally, the fallback path won't be hit outside of a hash collision, and this should be the case today if the same crate (or at least CGU) has caused the codegen of both `TypeId::of` which produced the two `TypeId`s in the first place (which will cause their `mangling` fields to point at the same place in read-only static memory).

*However*, to get global deduplication (across all crates/CGUs), we'd have to start using certain linker features (discussed in e.g. #75923), which I've left out of this PR.

As it stands, this implementation is comparable to [the `typeinfo` implementation `libcxx` calls `NonUnique`](https://github.com/llvm/llvm-project/blob/256c6b0ba14e8a7ab6373b61b7193ea8c0a3651c/libcxx/include/typeinfo#L135-L144), which seems [to be used at least on Windows](https://github.com/llvm/llvm-project/blob/256c6b0ba14e8a7ab6373b61b7193ea8c0a3651c/libcxx/include/typeinfo#L177-L179) (and its existence suggest we may never be able to guarantee deduplication, only do it on a best-effort basis).

<hr/>

Fixes #10389

cc @oli-obk @RalfJung @KodrAus @mystor