### PR TITLE
Allow dynamic linking on ios.

### DIFF
--- a/compiler/rustc_target/src/spec/apple_sdk_base.rs
+++ b/compiler/rustc_target/src/spec/apple_sdk_base.rs
@@ -49,8 +49,6 @@ pub fn opts(os: &'static str, arch: Arch) -> TargetOptions {
     TargetOptions {
         abi: target_abi(arch).into(),
         cpu: target_cpu(arch).into(),
-        dynamic_linking: false,
-        executables: true,
         link_env_remove: link_env_remove(arch),
         has_thread_local: false,
         ..super::apple_base::opts(os)


### PR DESCRIPTION
dynamic linking is supported on ios. this was enabled previously but then reverted due to backwards compatibility concerns. now that `cargo rustc` has a `--crate-type` flag these concerns aren't warrented any more, with new evidence presented in [0]. Given this new evidence I'm reenabling dynamic linking on ios.

- [0] https://github.com/rust-lang/rust/pull/88130