### PR TITLE
Stabilize `$$` in Rust 1.63.0

### DIFF
--- a/compiler/rustc_expand/src/mbe/quoted.rs
+++ b/compiler/rustc_expand/src/mbe/quoted.rs
@@ -234,8 +234,6 @@ fn parse_tree(
                             sess,
                             &Token { kind: token::Dollar, span },
                         );
-                    } else {
-                        maybe_emit_macro_metavar_expr_feature(features, sess, span);
                     }
                     TokenTree::token(token::Dollar, span)
                 }

--- a/src/test/ui/macros/rfc-3086-metavar-expr/allowed-features.rs
+++ b/src/test/ui/macros/rfc-3086-metavar-expr/allowed-features.rs
@@ -1,0 +1,12 @@
+// check-pass
+
+macro_rules! dollar_dollar {
+    () => {
+        macro_rules! bar {
+            ( $$( $$any:tt )* ) => { $$( $$any )* };
+        }
+    };
+}
+
+fn main() {
+}

--- a/src/test/ui/macros/rfc-3086-metavar-expr/required-features.rs
+++ b/src/test/ui/macros/rfc-3086-metavar-expr/required-features.rs
@@ -5,18 +5,6 @@ macro_rules! count {
     };
 }
 
-macro_rules! dollar_dollar {
-    () => {
-        macro_rules! bar {
-            ( $$( $$any:tt )* ) => { $$( $$any )* };
-            //~^ ERROR meta-variable expressions are unstable
-            //~| ERROR meta-variable expressions are unstable
-            //~| ERROR meta-variable expressions are unstable
-            //~| ERROR meta-variable expressions are unstable
-        }
-    };
-}
-
 macro_rules! index {
     ( $( $e:stmt ),* ) => {
         $( ${ignore(e)} ${index()} )*

--- a/src/test/ui/macros/rfc-3086-metavar-expr/required-features.stderr
+++ b/src/test/ui/macros/rfc-3086-metavar-expr/required-features.stderr
@@ -1,5 +1,5 @@
 error[E0658]: meta-variable expressions are unstable
-  --> $DIR/required-feature.rs:3:10
+  --> $DIR/required-features.rs:3:10
    |
 LL |         ${ count(e) }
    |          ^^^^^^^^^^^^
@@ -8,43 +8,7 @@ LL |         ${ count(e) }
    = help: add `#![feature(macro_metavar_expr)]` to the crate attributes to enable
 
 error[E0658]: meta-variable expressions are unstable
-  --> $DIR/required-feature.rs:11:16
-   |
-LL |             ( $$( $$any:tt )* ) => { $$( $$any )* };
-   |                ^
-   |
-   = note: see issue #83527 <https://github.com/rust-lang/rust/issues/83527> for more information
-   = help: add `#![feature(macro_metavar_expr)]` to the crate attributes to enable
-
-error[E0658]: meta-variable expressions are unstable
-  --> $DIR/required-feature.rs:11:20
-   |
-LL |             ( $$( $$any:tt )* ) => { $$( $$any )* };
-   |                    ^
-   |
-   = note: see issue #83527 <https://github.com/rust-lang/rust/issues/83527> for more information
-   = help: add `#![feature(macro_metavar_expr)]` to the crate attributes to enable
-
-error[E0658]: meta-variable expressions are unstable
-  --> $DIR/required-feature.rs:11:39
-   |
-LL |             ( $$( $$any:tt )* ) => { $$( $$any )* };
-   |                                       ^
-   |
-   = note: see issue #83527 <https://github.com/rust-lang/rust/issues/83527> for more information
-   = help: add `#![feature(macro_metavar_expr)]` to the crate attributes to enable
-
-error[E0658]: meta-variable expressions are unstable
-  --> $DIR/required-feature.rs:11:43
-   |
-LL |             ( $$( $$any:tt )* ) => { $$( $$any )* };
-   |                                           ^
-   |
-   = note: see issue #83527 <https://github.com/rust-lang/rust/issues/83527> for more information
-   = help: add `#![feature(macro_metavar_expr)]` to the crate attributes to enable
-
-error[E0658]: meta-variable expressions are unstable
-  --> $DIR/required-feature.rs:22:13
+  --> $DIR/required-features.rs:10:13
    |
 LL |         $( ${ignore(e)} ${index()} )*
    |             ^^^^^^^^^^^
@@ -53,7 +17,7 @@ LL |         $( ${ignore(e)} ${index()} )*
    = help: add `#![feature(macro_metavar_expr)]` to the crate attributes to enable
 
 error[E0658]: meta-variable expressions are unstable
-  --> $DIR/required-feature.rs:22:26
+  --> $DIR/required-features.rs:10:26
    |
 LL |         $( ${ignore(e)} ${index()} )*
    |                          ^^^^^^^^^
@@ -62,7 +26,7 @@ LL |         $( ${ignore(e)} ${index()} )*
    = help: add `#![feature(macro_metavar_expr)]` to the crate attributes to enable
 
 error[E0658]: meta-variable expressions are unstable
-  --> $DIR/required-feature.rs:30:19
+  --> $DIR/required-features.rs:18:19
    |
 LL |         0 $( + 1 ${ignore(i)} )*
    |                   ^^^^^^^^^^^
@@ -71,7 +35,7 @@ LL |         0 $( + 1 ${ignore(i)} )*
    = help: add `#![feature(macro_metavar_expr)]` to the crate attributes to enable
 
 error[E0658]: meta-variable expressions are unstable
-  --> $DIR/required-feature.rs:37:13
+  --> $DIR/required-features.rs:25:13
    |
 LL |         $( ${ignore(e)} ${length()} )*
    |             ^^^^^^^^^^^
@@ -80,7 +44,7 @@ LL |         $( ${ignore(e)} ${length()} )*
    = help: add `#![feature(macro_metavar_expr)]` to the crate attributes to enable
 
 error[E0658]: meta-variable expressions are unstable
-  --> $DIR/required-feature.rs:37:26
+  --> $DIR/required-features.rs:25:26
    |
 LL |         $( ${ignore(e)} ${length()} )*
    |                          ^^^^^^^^^^
@@ -88,6 +52,6 @@ LL |         $( ${ignore(e)} ${length()} )*
    = note: see issue #83527 <https://github.com/rust-lang/rust/issues/83527> for more information
    = help: add `#![feature(macro_metavar_expr)]` to the crate attributes to enable
 
-error: aborting due to 10 previous errors
+error: aborting due to 6 previous errors
 
 For more information about this error, try `rustc --explain E0658`.


### PR DESCRIPTION
# Stabilization proposal

This PR proposes the stabilization of a subset of `#![feature(macro_metavar_expr)]` or more specifically, the stabilization of dollar-dollar (`$$`).

Tracking issue: #83527
Version: 1.63 (2022-06-28 => beta, 2022-08-11 => stable).

## What is stabilized

```rust
macro_rules! foo {
    () => {
        macro_rules! bar {
            ( $$( $$any:tt )* ) => { $$( $$any )* };
        }
    };
}

fn main() {
    foo!();
}
```

## Motivation

For more examples, see the [RFC](https://github.com/markbt/rfcs/blob/macro_metavar_expr/text/0000-macro-metavar-expr.md).

Users must currently resort to a tricky and not so well-known hack to declare nested macros with repetitions.

```rust
macro_rules! foo {
    ($dollar:tt) => {
        macro_rules! bar {
            ( $dollar ( $any:tt )* ) => { $dollar ( $any )* };
        }
    };
}
fn main() {
    foo!($);
}
```

As seen above, such hack is fragile and makes work with declarative macros much more unpleasant. Dollar-dollar (`$$`), on the other hand, makes nested macros more intuitive.

## What isn't stabilized

`count`, `ignore`, `index` and `length` are not being stabilized due to the lack of consensus. 

## History

* 2021-02-22, [RFC: Declarative macro metavariable expressions](https://github.com/rust-lang/rfcs/pull/3086)
* 2021-03-26, [Tracking Issue for RFC 3086: macro metavariable expressions](https://github.com/rust-lang/rust/issues/83527)
* 2022-02-01, [Implement macro meta-variable expressions](https://github.com/rust-lang/rust/pull/93545)
* 2022-02-25, [[1/2] Implement macro meta-variable expressions](https://github.com/rust-lang/rust/pull/94368)
* 2022-03-11, [[2/2] Implement macro meta-variable expressions](https://github.com/rust-lang/rust/pull/94833)
* 2022-03-12, [Fix remaining meta-variable expression TODOs](https://github.com/rust-lang/rust/pull/94884)
* 2019-03-21, [[macro-metavar-expr] Fix generated tokens hygiene](https://github.com/rust-lang/rust/pull/95188)
* 2022-04-07, [Kickstart the inner usage of macro_metavar_expr](https://github.com/rust-lang/rust/pull/95761)
* 2022-04-07, [[macro_metavar_expr] Add tests to ensure the feature requirement](https://github.com/rust-lang/rust/pull/95764)

## Non-stabilized expressions

https://github.com/rust-lang/rust/issues/83527 lists several concerns about some characteristics of `count`, `index` and `length` that effectively make their stabilization unfeasible. `$$` and `ignore`, however, are not part of any discussion and thus are suitable for stabilization.

It is not in the scope of this PR to detail each concern or suggest any possible converging solution. Such thing should be restrained in this tracking issue.

## Tests

This list is a subset of https://github.com/rust-lang/rust/tree/master/src/test/ui/macros/rfc-3086-metavar-expr

* [Ensures that nested macros have correct behavior](https://github.com/rust-lang/rust/blob/master/src/test/ui/macros/rfc-3086-metavar-expr/dollar-dollar-has-correct-behavior.rs)

* [Compares produced tokens to assert expected outputs](https://github.com/rust-lang/rust/blob/master/src/test/ui/macros/rfc-3086-metavar-expr/feature-gate-macro_metavar_expr.rs)

* [Checks the declarations of the features](https://github.com/rust-lang/rust/blob/master/src/test/ui/macros/rfc-3086-metavar-expr/required-features.rs)

* [Verifies all possible errors that can occur due to incorrect user input](https://github.com/rust-lang/rust/blob/master/src/test/ui/macros/rfc-3086-metavar-expr/syntax-errors.rs)

## Possible future work

Once consensus is achieved, other nightly expressions can be stabilized.

Thanks @markbt for creating the RFC and thanks to @petrochenkov and @mark-i-m for reviewing the implementations.
