### PR TITLE
fix std lib build for uclibc

### DIFF
--- a/library/std/src/sys/unix/stack_overflow.rs
+++ b/library/std/src/sys/unix/stack_overflow.rs
@@ -54,6 +54,22 @@ mod imp {
     use crate::sys::unix::os::page_size;
     use crate::sys_common::thread_info;
 
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    unsafe fn siginfo_si_addr(info: *mut libc::siginfo_t) -> usize {
+        #[repr(C)]
+        struct siginfo_t {
+            a: [libc::c_int; 3], // si_signo, si_errno, si_code
+            si_addr: *mut libc::c_void,
+        }
+
+        (*(info as *const siginfo_t)).si_addr as usize
+    }
+
+    #[cfg(not(any(target_os = "linux", target_os = "android")))]
+    unsafe fn siginfo_si_addr(info: *mut libc::siginfo_t) -> usize {
+        (*info).si_addr as usize
+    }
+
     // Signal handler for the SIGSEGV and SIGBUS handlers. We've got guard pages
     // (unmapped pages) at the end of every thread's stack, so if a thread ends
     // up running into the guard page it'll trigger this handler. We want to
@@ -81,7 +97,7 @@ mod imp {
         _data: *mut libc::c_void,
     ) {
         let guard = thread_info::stack_guard().unwrap_or(0..0);
-        let addr = (*info).si_addr() as usize;
+        let addr = siginfo_si_addr(info);
 
         // If the faulting address is within the guard page, then we print a
         // message saying so and abort.


### PR DESCRIPTION
close #95866 

It seems that `libc` doesn't implement `fn si_addr` in `siginfo_t` for uclibc, which causes the build broken. This PR partially revert #95688 to fix the problem.