### PR TITLE
Handle `def_ident_span` like `def_span`.

### DIFF
--- a/compiler/rustc_metadata/src/rmeta/decoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder.rs
@@ -774,7 +774,8 @@ impl<'a, 'tcx> CrateMetadataRef<'a> {
 
     fn opt_item_ident(self, item_index: DefIndex, sess: &Session) -> Option<Ident> {
         let name = self.opt_item_name(item_index)?;
-        let span = self.root.tables.def_ident_span.get(self, item_index)?.decode((self, sess));
+        let span =
+            self.root.tables.def_ident_span.get(self, item_index).unwrap().decode((self, sess));
         Some(Ident::new(name, span))
     }
 

--- a/compiler/rustc_metadata/src/rmeta/decoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder.rs
@@ -774,17 +774,7 @@ impl<'a, 'tcx> CrateMetadataRef<'a> {
 
     fn opt_item_ident(self, item_index: DefIndex, sess: &Session) -> Option<Ident> {
         let name = self.opt_item_name(item_index)?;
-        let span = match self.root.tables.def_ident_span.get(self, item_index) {
-            Some(lazy_span) => lazy_span.decode((self, sess)),
-            None => {
-                // FIXME: this weird case of a name with no span is specific to `extern crate`
-                // items, which are supposed to be treated like `use` items and only be encoded
-                // to metadata as `Export`s, return `None` because that's what all the callers
-                // expect in this case.
-                assert_eq!(self.def_kind(item_index), DefKind::ExternCrate);
-                return None;
-            }
-        };
+        let span = self.root.tables.def_ident_span.get(self, item_index)?.decode((self, sess));
         Some(Ident::new(name, span))
     }
 

--- a/compiler/rustc_middle/src/hir/map/mod.rs
+++ b/compiler/rustc_middle/src/hir/map/mod.rs
@@ -1012,7 +1012,7 @@ impl<'hir> Map<'hir> {
     }
 
     pub fn span_if_local(self, id: DefId) -> Option<Span> {
-        id.as_local().and_then(|id| self.opt_span(self.local_def_id_to_hir_id(id)))
+        if id.is_local() { Some(self.tcx.def_span(id)) } else { None }
     }
 
     pub fn res_span(self, res: Res) -> Option<Span> {

--- a/compiler/rustc_middle/src/hir/mod.rs
+++ b/compiler/rustc_middle/src/hir/mod.rs
@@ -122,6 +122,11 @@ pub fn provide(providers: &mut Providers) {
         |tcx, id| tcx.hir_crate(()).owners[id].as_owner().map_or(AttributeMap::EMPTY, |o| &o.attrs);
     providers.source_span = |tcx, def_id| tcx.resolutions(()).definitions.def_span(def_id);
     providers.def_span = |tcx, def_id| tcx.hir().span_if_local(def_id).unwrap_or(DUMMY_SP);
+    providers.def_ident_span = |tcx, def_id| {
+        let def_id = def_id.expect_local();
+        let hir_id = tcx.hir().local_def_id_to_hir_id(def_id);
+        tcx.hir().opt_ident_span(hir_id)
+    };
     providers.fn_arg_names = |tcx, id| {
         let hir = tcx.hir();
         let hir_id = hir.local_def_id_to_hir_id(id.expect_local());

--- a/compiler/rustc_middle/src/hir/mod.rs
+++ b/compiler/rustc_middle/src/hir/mod.rs
@@ -121,7 +121,11 @@ pub fn provide(providers: &mut Providers) {
     providers.hir_attrs =
         |tcx, id| tcx.hir_crate(()).owners[id].as_owner().map_or(AttributeMap::EMPTY, |o| &o.attrs);
     providers.source_span = |tcx, def_id| tcx.resolutions(()).definitions.def_span(def_id);
-    providers.def_span = |tcx, def_id| tcx.hir().span_if_local(def_id).unwrap_or(DUMMY_SP);
+    providers.def_span = |tcx, def_id| {
+        let def_id = def_id.expect_local();
+        let hir_id = tcx.hir().local_def_id_to_hir_id(def_id);
+        tcx.hir().opt_span(hir_id).unwrap_or(DUMMY_SP)
+    };
     providers.def_ident_span = |tcx, def_id| {
         let def_id = def_id.expect_local();
         let hir_id = tcx.hir().local_def_id_to_hir_id(def_id);

--- a/compiler/rustc_ty_utils/src/ty.rs
+++ b/compiler/rustc_ty_utils/src/ty.rs
@@ -5,7 +5,6 @@ use rustc_middle::ty::subst::Subst;
 use rustc_middle::ty::{
     self, Binder, EarlyBinder, Predicate, PredicateKind, ToPredicate, Ty, TyCtxt,
 };
-use rustc_span::Span;
 use rustc_trait_selection::traits;
 
 fn sized_constraint_for_ty<'tcx>(
@@ -101,21 +100,6 @@ fn adt_sized_constraint(tcx: TyCtxt<'_>, def_id: DefId) -> ty::AdtSizedConstrain
     debug!("adt_sized_constraint: {:?} => {:?}", def, result);
 
     ty::AdtSizedConstraint(result)
-}
-
-fn def_ident_span(tcx: TyCtxt<'_>, def_id: DefId) -> Option<Span> {
-    tcx.hir()
-        .get_if_local(def_id)
-        .and_then(|node| match node {
-            // A `Ctor` doesn't have an identifier itself, but its parent
-            // struct/variant does. Compare with `hir::Map::opt_span`.
-            hir::Node::Ctor(ctor) => ctor
-                .ctor_hir_id()
-                .and_then(|ctor_id| tcx.hir().find(tcx.hir().get_parent_node(ctor_id)))
-                .and_then(|parent| parent.ident()),
-            _ => node.ident(),
-        })
-        .map(|ident| ident.span)
 }
 
 /// See `ParamEnv` struct definition for details.
@@ -480,7 +464,6 @@ pub fn provide(providers: &mut ty::query::Providers) {
     *providers = ty::query::Providers {
         asyncness,
         adt_sized_constraint,
-        def_ident_span,
         param_env,
         param_env_reveal_all_normalized,
         instance_def_size_estimate,

--- a/src/test/ui/closures/issue-87461.stderr
+++ b/src/test/ui/closures/issue-87461.stderr
@@ -5,6 +5,12 @@ LL |     Ok(())
    |     -- ^^ expected `u16`, found `()`
    |     |
    |     arguments to this enum variant are incorrect
+   |
+note: tuple variant defined here
+  --> $SRC_DIR/core/src/result.rs:LL:COL
+   |
+LL |     Ok(#[stable(feature = "rust1", since = "1.0.0")] T),
+   |     ^^
 
 error[E0308]: mismatched types
   --> $DIR/issue-87461.rs:17:8
@@ -13,6 +19,12 @@ LL |     Ok(())
    |     -- ^^ expected `u16`, found `()`
    |     |
    |     arguments to this enum variant are incorrect
+   |
+note: tuple variant defined here
+  --> $SRC_DIR/core/src/result.rs:LL:COL
+   |
+LL |     Ok(#[stable(feature = "rust1", since = "1.0.0")] T),
+   |     ^^
 
 error[E0308]: mismatched types
   --> $DIR/issue-87461.rs:26:12
@@ -21,6 +33,12 @@ LL |         Ok(())
    |         -- ^^ expected `u16`, found `()`
    |         |
    |         arguments to this enum variant are incorrect
+   |
+note: tuple variant defined here
+  --> $SRC_DIR/core/src/result.rs:LL:COL
+   |
+LL |     Ok(#[stable(feature = "rust1", since = "1.0.0")] T),
+   |     ^^
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/const-generics/const-argument-cross-crate-mismatch.stderr
+++ b/src/test/ui/const-generics/const-argument-cross-crate-mismatch.stderr
@@ -5,6 +5,12 @@ LL |     let _ = const_generic_lib::function(const_generic_lib::Struct([0u8, 1u8
    |                                         ------------------------- ^^^^^^^^^^ expected an array with a fixed size of 3 elements, found one with 2 elements
    |                                         |
    |                                         arguments to this struct are incorrect
+   |
+note: tuple struct defined here
+  --> $DIR/auxiliary/const_generic_lib.rs:1:12
+   |
+LL | pub struct Struct<const N: usize>(pub [u8; N]);
+   |            ^^^^^^
 
 error[E0308]: mismatched types
   --> $DIR/const-argument-cross-crate-mismatch.rs:8:65
@@ -13,6 +19,12 @@ LL |     let _: const_generic_lib::Alias = const_generic_lib::Struct([0u8, 1u8, 
    |                                       ------------------------- ^^^^^^^^^^^^^^^ expected an array with a fixed size of 2 elements, found one with 3 elements
    |                                       |
    |                                       arguments to this struct are incorrect
+   |
+note: tuple struct defined here
+  --> $DIR/auxiliary/const_generic_lib.rs:1:12
+   |
+LL | pub struct Struct<const N: usize>(pub [u8; N]);
+   |            ^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/mismatched_types/issue-35030.stderr
+++ b/src/test/ui/mismatched_types/issue-35030.stderr
@@ -11,6 +11,11 @@ LL |         Some(true)
    |
    = note: expected type parameter `bool` (type parameter `bool`)
                         found type `bool` (`bool`)
+note: tuple variant defined here
+  --> $SRC_DIR/core/src/option.rs:LL:COL
+   |
+LL |     Some(#[stable(feature = "rust1", since = "1.0.0")] T),
+   |     ^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/pattern/pat-tuple-field-count-cross.stderr
+++ b/src/test/ui/pattern/pat-tuple-field-count-cross.stderr
@@ -198,20 +198,19 @@ LL | pub struct S(pub u8, pub u8, pub u8);
 error[E0023]: this pattern has 0 fields, but the corresponding tuple struct has 3 fields
   --> $DIR/pat-tuple-field-count-cross.rs:24:9
    |
-LL |           M() => {}
-   |           ^^^ expected 3 fields, found 0
+LL |         M() => {}
+   |         ^^^ expected 3 fields, found 0
    |
-  ::: $DIR/auxiliary/declarations-for-tuple-field-count-errors.rs:5:1
+  ::: $DIR/auxiliary/declarations-for-tuple-field-count-errors.rs:5:12
    |
-LL | / pub struct M(
-LL | |     pub u8,
-   | |     ------
-LL | |     pub u8,
-   | |     ------
-LL | |     pub u8,
-   | |     ------ tuple struct has 3 fields
-LL | | );
-   | |__- tuple struct defined here
+LL | pub struct M(
+   |            - tuple struct defined here
+LL |     pub u8,
+   |     ------
+LL |     pub u8,
+   |     ------
+LL |     pub u8,
+   |     ------ tuple struct has 3 fields
    |
 help: use `_` to explicitly ignore each field
    |
@@ -225,20 +224,19 @@ LL |         M(..) => {}
 error[E0023]: this pattern has 1 field, but the corresponding tuple struct has 3 fields
   --> $DIR/pat-tuple-field-count-cross.rs:25:11
    |
-LL |           M(1) => {}
-   |             ^ expected 3 fields, found 1
+LL |         M(1) => {}
+   |           ^ expected 3 fields, found 1
    |
-  ::: $DIR/auxiliary/declarations-for-tuple-field-count-errors.rs:5:1
+  ::: $DIR/auxiliary/declarations-for-tuple-field-count-errors.rs:5:12
    |
-LL | / pub struct M(
-LL | |     pub u8,
-   | |     ------
-LL | |     pub u8,
-   | |     ------
-LL | |     pub u8,
-   | |     ------ tuple struct has 3 fields
-LL | | );
-   | |__- tuple struct defined here
+LL | pub struct M(
+   |            - tuple struct defined here
+LL |     pub u8,
+   |     ------
+LL |     pub u8,
+   |     ------
+LL |     pub u8,
+   |     ------ tuple struct has 3 fields
    |
 help: use `_` to explicitly ignore each field
    |
@@ -252,20 +250,19 @@ LL |         M(1, ..) => {}
 error[E0023]: this pattern has 2 fields, but the corresponding tuple struct has 3 fields
   --> $DIR/pat-tuple-field-count-cross.rs:26:11
    |
-LL |           M(xyz, abc) => {}
-   |             ^^^  ^^^ expected 3 fields, found 2
+LL |         M(xyz, abc) => {}
+   |           ^^^  ^^^ expected 3 fields, found 2
    |
-  ::: $DIR/auxiliary/declarations-for-tuple-field-count-errors.rs:5:1
+  ::: $DIR/auxiliary/declarations-for-tuple-field-count-errors.rs:5:12
    |
-LL | / pub struct M(
-LL | |     pub u8,
-   | |     ------
-LL | |     pub u8,
-   | |     ------
-LL | |     pub u8,
-   | |     ------ tuple struct has 3 fields
-LL | | );
-   | |__- tuple struct defined here
+LL | pub struct M(
+   |            - tuple struct defined here
+LL |     pub u8,
+   |     ------
+LL |     pub u8,
+   |     ------
+LL |     pub u8,
+   |     ------ tuple struct has 3 fields
    |
 help: use `_` to explicitly ignore each field
    |
@@ -275,20 +272,19 @@ LL |         M(xyz, abc, _) => {}
 error[E0023]: this pattern has 4 fields, but the corresponding tuple struct has 3 fields
   --> $DIR/pat-tuple-field-count-cross.rs:27:11
    |
-LL |           M(1, 2, 3, 4) => {}
-   |             ^  ^  ^  ^ expected 3 fields, found 4
+LL |         M(1, 2, 3, 4) => {}
+   |           ^  ^  ^  ^ expected 3 fields, found 4
    |
-  ::: $DIR/auxiliary/declarations-for-tuple-field-count-errors.rs:5:1
+  ::: $DIR/auxiliary/declarations-for-tuple-field-count-errors.rs:5:12
    |
-LL | / pub struct M(
-LL | |     pub u8,
-   | |     ------
-LL | |     pub u8,
-   | |     ------
-LL | |     pub u8,
-   | |     ------ tuple struct has 3 fields
-LL | | );
-   | |__- tuple struct defined here
+LL | pub struct M(
+   |            - tuple struct defined here
+LL |     pub u8,
+   |     ------
+LL |     pub u8,
+   |     ------
+LL |     pub u8,
+   |     ------ tuple struct has 3 fields
 
 error[E0023]: this pattern has 1 field, but the corresponding tuple variant has 0 fields
   --> $DIR/pat-tuple-field-count-cross.rs:36:16
@@ -438,20 +434,19 @@ LL |     S(u8, u8, u8),
 error[E0023]: this pattern has 0 fields, but the corresponding tuple variant has 3 fields
   --> $DIR/pat-tuple-field-count-cross.rs:52:9
    |
-LL |           E2::M() => {}
-   |           ^^^^^^^ expected 3 fields, found 0
+LL |         E2::M() => {}
+   |         ^^^^^^^ expected 3 fields, found 0
    |
   ::: $DIR/auxiliary/declarations-for-tuple-field-count-errors.rs:15:5
    |
-LL | /     M(
-LL | |         u8,
-   | |         --
-LL | |         u8,
-   | |         --
-LL | |         u8,
-   | |         -- tuple variant has 3 fields
-LL | |     ),
-   | |_____- tuple variant defined here
+LL |     M(
+   |     - tuple variant defined here
+LL |         u8,
+   |         --
+LL |         u8,
+   |         --
+LL |         u8,
+   |         -- tuple variant has 3 fields
    |
 help: use `_` to explicitly ignore each field
    |
@@ -465,20 +460,19 @@ LL |         E2::M(..) => {}
 error[E0023]: this pattern has 1 field, but the corresponding tuple variant has 3 fields
   --> $DIR/pat-tuple-field-count-cross.rs:53:15
    |
-LL |           E2::M(1) => {}
-   |                 ^ expected 3 fields, found 1
+LL |         E2::M(1) => {}
+   |               ^ expected 3 fields, found 1
    |
   ::: $DIR/auxiliary/declarations-for-tuple-field-count-errors.rs:15:5
    |
-LL | /     M(
-LL | |         u8,
-   | |         --
-LL | |         u8,
-   | |         --
-LL | |         u8,
-   | |         -- tuple variant has 3 fields
-LL | |     ),
-   | |_____- tuple variant defined here
+LL |     M(
+   |     - tuple variant defined here
+LL |         u8,
+   |         --
+LL |         u8,
+   |         --
+LL |         u8,
+   |         -- tuple variant has 3 fields
    |
 help: use `_` to explicitly ignore each field
    |
@@ -492,20 +486,19 @@ LL |         E2::M(1, ..) => {}
 error[E0023]: this pattern has 2 fields, but the corresponding tuple variant has 3 fields
   --> $DIR/pat-tuple-field-count-cross.rs:54:15
    |
-LL |           E2::M(xyz, abc) => {}
-   |                 ^^^  ^^^ expected 3 fields, found 2
+LL |         E2::M(xyz, abc) => {}
+   |               ^^^  ^^^ expected 3 fields, found 2
    |
   ::: $DIR/auxiliary/declarations-for-tuple-field-count-errors.rs:15:5
    |
-LL | /     M(
-LL | |         u8,
-   | |         --
-LL | |         u8,
-   | |         --
-LL | |         u8,
-   | |         -- tuple variant has 3 fields
-LL | |     ),
-   | |_____- tuple variant defined here
+LL |     M(
+   |     - tuple variant defined here
+LL |         u8,
+   |         --
+LL |         u8,
+   |         --
+LL |         u8,
+   |         -- tuple variant has 3 fields
    |
 help: use `_` to explicitly ignore each field
    |
@@ -515,20 +508,19 @@ LL |         E2::M(xyz, abc, _) => {}
 error[E0023]: this pattern has 4 fields, but the corresponding tuple variant has 3 fields
   --> $DIR/pat-tuple-field-count-cross.rs:55:15
    |
-LL |           E2::M(1, 2, 3, 4) => {}
-   |                 ^  ^  ^  ^ expected 3 fields, found 4
+LL |         E2::M(1, 2, 3, 4) => {}
+   |               ^  ^  ^  ^ expected 3 fields, found 4
    |
   ::: $DIR/auxiliary/declarations-for-tuple-field-count-errors.rs:15:5
    |
-LL | /     M(
-LL | |         u8,
-   | |         --
-LL | |         u8,
-   | |         --
-LL | |         u8,
-   | |         -- tuple variant has 3 fields
-LL | |     ),
-   | |_____- tuple variant defined here
+LL |     M(
+   |     - tuple variant defined here
+LL |         u8,
+   |         --
+LL |         u8,
+   |         --
+LL |         u8,
+   |         -- tuple variant has 3 fields
 
 error: aborting due to 28 previous errors
 

--- a/src/test/ui/span/missing-unit-argument.stderr
+++ b/src/test/ui/span/missing-unit-argument.stderr
@@ -4,6 +4,11 @@ error[E0061]: this enum variant takes 1 argument but 0 arguments were supplied
 LL |     let _: Result<(), String> = Ok();
    |                                 ^^-- an argument of type `()` is missing
    |
+note: tuple variant defined here
+  --> $SRC_DIR/core/src/result.rs:LL:COL
+   |
+LL |     Ok(#[stable(feature = "rust1", since = "1.0.0")] T),
+   |     ^^
 help: provide the argument
    |
 LL |     let _: Result<(), String> = Ok(());

--- a/src/test/ui/suggestions/args-instead-of-tuple-errors.stderr
+++ b/src/test/ui/suggestions/args-instead-of-tuple-errors.stderr
@@ -8,6 +8,11 @@ LL |     let _: Option<(i32, bool)> = Some(1, 2);
    |
    = note: expected tuple `(i32, bool)`
                found type `{integer}`
+note: tuple variant defined here
+  --> $SRC_DIR/core/src/option.rs:LL:COL
+   |
+LL |     Some(#[stable(feature = "rust1", since = "1.0.0")] T),
+   |     ^^^^
 help: remove the extra argument
    |
 LL |     let _: Option<(i32, bool)> = Some({(i32, bool)});
@@ -39,6 +44,11 @@ error[E0061]: this enum variant takes 1 argument but 0 arguments were supplied
 LL |     let _: Option<(i8,)> = Some();
    |                            ^^^^-- an argument of type `(i8,)` is missing
    |
+note: tuple variant defined here
+  --> $SRC_DIR/core/src/option.rs:LL:COL
+   |
+LL |     Some(#[stable(feature = "rust1", since = "1.0.0")] T),
+   |     ^^^^
 help: provide the argument
    |
 LL |     let _: Option<(i8,)> = Some({(i8,)});
@@ -54,6 +64,11 @@ LL |     let _: Option<(i32,)> = Some(5_usize);
    |
    = note: expected tuple `(i32,)`
                found type `usize`
+note: tuple variant defined here
+  --> $SRC_DIR/core/src/option.rs:LL:COL
+   |
+LL |     Some(#[stable(feature = "rust1", since = "1.0.0")] T),
+   |     ^^^^
 
 error[E0308]: mismatched types
   --> $DIR/args-instead-of-tuple-errors.rs:17:34
@@ -65,6 +80,11 @@ LL |     let _: Option<(i32,)> = Some((5_usize));
    |
    = note: expected tuple `(i32,)`
                found type `usize`
+note: tuple variant defined here
+  --> $SRC_DIR/core/src/option.rs:LL:COL
+   |
+LL |     Some(#[stable(feature = "rust1", since = "1.0.0")] T),
+   |     ^^^^
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/suggestions/args-instead-of-tuple.stderr
+++ b/src/test/ui/suggestions/args-instead-of-tuple.stderr
@@ -4,6 +4,11 @@ error[E0061]: this enum variant takes 1 argument but 2 arguments were supplied
 LL |     let _: Result<(i32, i8), ()> = Ok(1, 2);
    |                                    ^^
    |
+note: tuple variant defined here
+  --> $SRC_DIR/core/src/result.rs:LL:COL
+   |
+LL |     Ok(#[stable(feature = "rust1", since = "1.0.0")] T),
+   |     ^^
 help: use parentheses to construct a tuple
    |
 LL |     let _: Result<(i32, i8), ()> = Ok((1, 2));
@@ -15,6 +20,11 @@ error[E0061]: this enum variant takes 1 argument but 3 arguments were supplied
 LL |     let _: Option<(i32, i8, &'static str)> = Some(1, 2, "hi");
    |                                              ^^^^
    |
+note: tuple variant defined here
+  --> $SRC_DIR/core/src/option.rs:LL:COL
+   |
+LL |     Some(#[stable(feature = "rust1", since = "1.0.0")] T),
+   |     ^^^^
 help: use parentheses to construct a tuple
    |
 LL |     let _: Option<(i32, i8, &'static str)> = Some((1, 2, "hi"));
@@ -26,6 +36,11 @@ error[E0061]: this enum variant takes 1 argument but 0 arguments were supplied
 LL |     let _: Option<()> = Some();
    |                         ^^^^-- an argument of type `()` is missing
    |
+note: tuple variant defined here
+  --> $SRC_DIR/core/src/option.rs:LL:COL
+   |
+LL |     Some(#[stable(feature = "rust1", since = "1.0.0")] T),
+   |     ^^^^
 help: provide the argument
    |
 LL |     let _: Option<()> = Some(());
@@ -41,6 +56,11 @@ LL |     let _: Option<(i32,)> = Some(3);
    |
    = note: expected tuple `(i32,)`
                found type `{integer}`
+note: tuple variant defined here
+  --> $SRC_DIR/core/src/option.rs:LL:COL
+   |
+LL |     Some(#[stable(feature = "rust1", since = "1.0.0")] T),
+   |     ^^^^
 help: use a trailing comma to create a tuple with one element
    |
 LL |     let _: Option<(i32,)> = Some((3,));
@@ -56,6 +76,11 @@ LL |     let _: Option<(i32,)> = Some((3));
    |
    = note: expected tuple `(i32,)`
                found type `{integer}`
+note: tuple variant defined here
+  --> $SRC_DIR/core/src/option.rs:LL:COL
+   |
+LL |     Some(#[stable(feature = "rust1", since = "1.0.0")] T),
+   |     ^^^^
 help: use a trailing comma to create a tuple with one element
    |
 LL |     let _: Option<(i32,)> = Some((3,));

--- a/src/test/ui/typeck/issue-46112.stderr
+++ b/src/test/ui/typeck/issue-46112.stderr
@@ -8,6 +8,11 @@ LL | fn main() { test(Ok(())); }
    |
    = note:   expected enum `Option<()>`
            found unit type `()`
+note: tuple variant defined here
+  --> $SRC_DIR/core/src/result.rs:LL:COL
+   |
+LL |     Ok(#[stable(feature = "rust1", since = "1.0.0")] T),
+   |     ^^
 help: try wrapping the expression in `Some`
    |
 LL | fn main() { test(Ok(Some(()))); }

--- a/src/test/ui/typeck/struct-enum-wrong-args.stderr
+++ b/src/test/ui/typeck/struct-enum-wrong-args.stderr
@@ -4,6 +4,11 @@ error[E0061]: this enum variant takes 1 argument but 2 arguments were supplied
 LL |     let _ = Some(3, 2);
    |             ^^^^    - argument unexpected
    |
+note: tuple variant defined here
+  --> $SRC_DIR/core/src/option.rs:LL:COL
+   |
+LL |     Some(#[stable(feature = "rust1", since = "1.0.0")] T),
+   |     ^^^^
 help: remove the extra argument
    |
 LL |     let _ = Some(3);
@@ -17,6 +22,11 @@ LL |     let _ = Ok(3, 6, 2);
    |                   |
    |                   argument unexpected
    |
+note: tuple variant defined here
+  --> $SRC_DIR/core/src/result.rs:LL:COL
+   |
+LL |     Ok(#[stable(feature = "rust1", since = "1.0.0")] T),
+   |     ^^
 help: remove the extra arguments
    |
 LL |     let _ = Ok(3);
@@ -28,6 +38,11 @@ error[E0061]: this enum variant takes 1 argument but 0 arguments were supplied
 LL |     let _ = Ok();
    |             ^^-- an argument is missing
    |
+note: tuple variant defined here
+  --> $SRC_DIR/core/src/result.rs:LL:COL
+   |
+LL |     Ok(#[stable(feature = "rust1", since = "1.0.0")] T),
+   |     ^^
 help: provide the argument
    |
 LL |     let _ = Ok({_});


### PR DESCRIPTION
`def_ident_span` had an ad-hoc status in the compiler.

This PR refactors it to be a first-class citizen like `def_span`:
- it gets encoded in the main metadata loop, instead of the visitor;
- its implementation is updated to mirror the one of `def_span`.

We do not remove the `Option` in the return type, since some items do not have an ident, AnonConsts for instance.