### PR TITLE
rustc_metadata: Do not encode unnecessary module children

### DIFF
--- a/compiler/rustc_data_structures/src/lib.rs
+++ b/compiler/rustc_data_structures/src/lib.rs
@@ -14,6 +14,8 @@
 #![feature(control_flow_enum)]
 #![feature(core_intrinsics)]
 #![feature(extend_one)]
+#![feature(generator_trait)]
+#![feature(generators)]
 #![feature(let_else)]
 #![feature(hash_raw_entry)]
 #![feature(maybe_uninit_uninit_array)]
@@ -113,6 +115,9 @@ pub mod unhash;
 pub use ena::undo_log;
 pub use ena::unify;
 
+use std::ops::{Generator, GeneratorState};
+use std::pin::Pin;
+
 pub struct OnDrop<F: Fn()>(pub F);
 
 impl<F: Fn()> OnDrop<F> {
@@ -129,6 +134,26 @@ impl<F: Fn()> Drop for OnDrop<F> {
     fn drop(&mut self) {
         (self.0)();
     }
+}
+
+struct IterFromGenerator<G>(G);
+
+impl<G: Generator<Return = ()> + Unpin> Iterator for IterFromGenerator<G> {
+    type Item = G::Yield;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match Pin::new(&mut self.0).resume(()) {
+            GeneratorState::Yielded(n) => Some(n),
+            GeneratorState::Complete(_) => None,
+        }
+    }
+}
+
+/// An adapter for turning a generator closure into an iterator, similar to `iter::from_fn`.
+pub fn iter_from_generator<G: Generator<Return = ()> + Unpin>(
+    generator: G,
+) -> impl Iterator<Item = G::Yield> {
+    IterFromGenerator(generator)
 }
 
 // See comments in src/librustc_middle/lib.rs

--- a/compiler/rustc_metadata/src/lib.rs
+++ b/compiler/rustc_metadata/src/lib.rs
@@ -1,6 +1,7 @@
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
 #![feature(crate_visibility_modifier)]
 #![feature(drain_filter)]
+#![feature(generators)]
 #![feature(let_else)]
 #![feature(nll)]
 #![feature(once_cell)]


### PR DESCRIPTION
This should remove the syntax context shift and the special case for `ExternCrate` in decoder in https://github.com/rust-lang/rust/pull/95880.

This PR also shifts some work from decoding to encoding, which is typically useful for performance (but probably not much in this case).
r? @cjgillot 