### PR TITLE
Remove duplicate aliases for `check codegen_{cranelift,gcc}` and fix `build codegen_gcc`

### DIFF
--- a/src/bootstrap/check.rs
+++ b/src/bootstrap/check.rs
@@ -243,12 +243,7 @@ impl Step for CodegenBackend {
     const DEFAULT: bool = true;
 
     fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
-        run.paths(&[
-            "compiler/rustc_codegen_cranelift",
-            "rustc_codegen_cranelift",
-            "compiler/rustc_codegen_gcc",
-            "rustc_codegen_gcc",
-        ])
+        run.paths(&["compiler/rustc_codegen_cranelift", "compiler/rustc_codegen_gcc"])
     }
 
     fn make_run(run: RunConfig<'_>) {

--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -795,7 +795,7 @@ impl Step for CodegenBackend {
     const DEFAULT: bool = true;
 
     fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
-        run.path("compiler/rustc_codegen_cranelift")
+        run.paths(&["compiler/rustc_codegen_cranelift", "compiler/rustc_codegen_gcc"])
     }
 
     fn make_run(run: RunConfig<'_>) {


### PR DESCRIPTION
* Remove duplicate aliases
    Bootstrap already allows selecting these in `PathSet::has`, which allows
    any string that matches the end of a full path.

    I found these by adding `assert!(path.exists())` in `StepDescription::paths`.
    I think ideally we wouldn't have any aliases that aren't paths, but I've held
    off on enforcing that here since it may be controversial, I'll open a separate PR.

* Add `build compiler/rustc_codegen_gcc` as an alias for `CodegenBackend` 

    These paths (`_cranelift` and `_gcc`) are somewhat misleading, since they
    actually tell bootstrap to build *all* codegen backends. But this seems like
    a useful improvement in the meantime.

cc @bjorn3 @antoyo