### PR TITLE
Use `P<ast::Stmt>` in many places.

### DIFF
--- a/compiler/rustc_ast_lowering/src/block.rs
+++ b/compiler/rustc_ast_lowering/src/block.rs
@@ -1,4 +1,5 @@
 use crate::{ImplTraitContext, ImplTraitPosition, LoweringContext};
+use rustc_ast::ptr::P;
 use rustc_ast::{AttrVec, Block, BlockCheckMode, Expr, Local, LocalKind, Stmt, StmtKind};
 use rustc_hir as hir;
 use rustc_session::parse::feature_err;
@@ -28,7 +29,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
 
     fn lower_stmts(
         &mut self,
-        mut ast_stmts: &[Stmt],
+        mut ast_stmts: &[P<Stmt>],
     ) -> (&'hir [hir::Stmt<'hir>], Option<&'hir hir::Expr<'hir>>) {
         let mut stmts = SmallVec::<[hir::Stmt<'hir>; 8]>::new();
         let mut expr = None;
@@ -122,7 +123,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
         local: &Local,
         init: &Expr,
         els: &Block,
-        tail: &[Stmt],
+        tail: &[P<Stmt>],
     ) -> &'hir hir::Expr<'hir> {
         let ty = local
             .ty

--- a/compiler/rustc_builtin_macros/src/cfg_eval.rs
+++ b/compiler/rustc_builtin_macros/src/cfg_eval.rs
@@ -62,9 +62,7 @@ fn flat_map_annotatable(
         Annotatable::ForeignItem(item) => {
             vis.flat_map_foreign_item(item).pop().map(Annotatable::ForeignItem)
         }
-        Annotatable::Stmt(stmt) => {
-            vis.flat_map_stmt(stmt.into_inner()).pop().map(P).map(Annotatable::Stmt)
-        }
+        Annotatable::Stmt(stmt) => vis.flat_map_stmt(stmt).pop().map(Annotatable::Stmt),
         Annotatable::Expr(mut expr) => {
             vis.visit_expr(&mut expr);
             Some(Annotatable::Expr(expr))
@@ -165,9 +163,9 @@ impl CfgEval<'_, '_> {
                     parser.parse_foreign_item(ForceCollect::Yes).unwrap().unwrap().unwrap(),
                 )
             },
-            Annotatable::Stmt(_) => |parser| {
-                Annotatable::Stmt(P(parser.parse_stmt(ForceCollect::Yes).unwrap().unwrap()))
-            },
+            Annotatable::Stmt(_) => {
+                |parser| Annotatable::Stmt(parser.parse_stmt(ForceCollect::Yes).unwrap().unwrap())
+            }
             Annotatable::Expr(_) => {
                 |parser| Annotatable::Expr(parser.parse_expr_force_collect().unwrap())
             }
@@ -234,7 +232,7 @@ impl MutVisitor for CfgEval<'_, '_> {
         mut_visit::noop_flat_map_generic_param(configure!(self, param), self)
     }
 
-    fn flat_map_stmt(&mut self, stmt: ast::Stmt) -> SmallVec<[ast::Stmt; 1]> {
+    fn flat_map_stmt(&mut self, stmt: P<ast::Stmt>) -> SmallVec<[P<ast::Stmt>; 1]> {
         mut_visit::noop_flat_map_stmt(configure!(self, stmt), self)
     }
 

--- a/compiler/rustc_builtin_macros/src/deriving/clone.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/clone.rs
@@ -109,7 +109,7 @@ fn cs_clone_shallow(
 ) -> P<Expr> {
     fn assert_ty_bounds(
         cx: &mut ExtCtxt<'_>,
-        stmts: &mut Vec<ast::Stmt>,
+        stmts: &mut Vec<P<ast::Stmt>>,
         ty: P<ast::Ty>,
         span: Span,
         helper_name: &str,
@@ -125,7 +125,7 @@ fn cs_clone_shallow(
         );
         stmts.push(cx.stmt_let_type_only(span, cx.ty_path(assert_path)));
     }
-    fn process_variant(cx: &mut ExtCtxt<'_>, stmts: &mut Vec<ast::Stmt>, variant: &VariantData) {
+    fn process_variant(cx: &mut ExtCtxt<'_>, stmts: &mut Vec<P<ast::Stmt>>, variant: &VariantData) {
         for field in variant.fields() {
             // let _: AssertParamIsClone<FieldTy>;
             assert_ty_bounds(cx, stmts, field.ty.clone(), field.span, "AssertParamIsClone");

--- a/compiler/rustc_builtin_macros/src/deriving/cmp/eq.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/cmp/eq.rs
@@ -57,7 +57,7 @@ fn cs_total_eq_assert(
 ) -> P<Expr> {
     fn assert_ty_bounds(
         cx: &mut ExtCtxt<'_>,
-        stmts: &mut Vec<ast::Stmt>,
+        stmts: &mut Vec<P<ast::Stmt>>,
         ty: P<ast::Ty>,
         span: Span,
         helper_name: &str,
@@ -75,7 +75,7 @@ fn cs_total_eq_assert(
     }
     fn process_variant(
         cx: &mut ExtCtxt<'_>,
-        stmts: &mut Vec<ast::Stmt>,
+        stmts: &mut Vec<P<ast::Stmt>>,
         variant: &ast::VariantData,
     ) {
         for field in variant.fields() {

--- a/compiler/rustc_builtin_macros/src/deriving/debug.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/debug.rs
@@ -145,7 +145,7 @@ fn show_substructure(cx: &mut ExtCtxt<'_>, span: Span, substr: &Substructure<'_>
     cx.expr_block(block)
 }
 
-fn stmt_let_underscore(cx: &mut ExtCtxt<'_>, sp: Span, expr: P<ast::Expr>) -> ast::Stmt {
+fn stmt_let_underscore(cx: &mut ExtCtxt<'_>, sp: Span, expr: P<ast::Expr>) -> P<ast::Stmt> {
     let local = P(ast::Local {
         pat: cx.pat_wild(sp),
         ty: None,
@@ -155,5 +155,5 @@ fn stmt_let_underscore(cx: &mut ExtCtxt<'_>, sp: Span, expr: P<ast::Expr>) -> as
         attrs: ast::AttrVec::new(),
         tokens: None,
     });
-    ast::Stmt { id: ast::DUMMY_NODE_ID, kind: ast::StmtKind::Local(local), span: sp }
+    P(ast::Stmt { id: ast::DUMMY_NODE_ID, kind: ast::StmtKind::Local(local), span: sp })
 }

--- a/compiler/rustc_builtin_macros/src/deriving/generic/mod.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/generic/mod.rs
@@ -1393,7 +1393,7 @@ impl<'a> MethodDef<'a> {
             // let __self1_vi = std::intrinsics::discriminant_value(&arg1);
             // let __self2_vi = std::intrinsics::discriminant_value(&arg2);
             // ```
-            let mut index_let_stmts: Vec<ast::Stmt> = Vec::with_capacity(vi_idents.len() + 1);
+            let mut index_let_stmts: Vec<P<ast::Stmt>> = Vec::with_capacity(vi_idents.len() + 1);
 
             // We also build an expression which checks whether all discriminants are equal
             // discriminant_test = __self0_vi == __self1_vi && __self0_vi == __self2_vi && ...

--- a/compiler/rustc_builtin_macros/src/global_allocator.rs
+++ b/compiler/rustc_builtin_macros/src/global_allocator.rs
@@ -54,7 +54,7 @@ pub fn expand(
     let const_body = ecx.expr_block(ecx.block(span, stmts));
     let const_item = ecx.item_const(span, Ident::new(kw::Underscore, span), const_ty, const_body);
     let const_item = if is_stmt {
-        Annotatable::Stmt(P(ecx.stmt_item(span, const_item)))
+        Annotatable::Stmt(ecx.stmt_item(span, const_item))
     } else {
         Annotatable::Item(const_item)
     };
@@ -72,7 +72,7 @@ struct AllocFnFactory<'a, 'b> {
 }
 
 impl AllocFnFactory<'_, '_> {
-    fn allocator_fn(&self, method: &AllocatorMethod) -> Stmt {
+    fn allocator_fn(&self, method: &AllocatorMethod) -> P<Stmt> {
         let mut abi_args = Vec::new();
         let mut i = 0;
         let mut mk = || {

--- a/compiler/rustc_builtin_macros/src/test.rs
+++ b/compiler/rustc_builtin_macros/src/test.rs
@@ -4,7 +4,6 @@ use crate::util::{check_builtin_macro_attribute, warn_on_duplicate_attribute};
 
 use rustc_ast as ast;
 use rustc_ast::attr;
-use rustc_ast::ptr::P;
 use rustc_ast_pretty::pprust;
 use rustc_errors::Applicability;
 use rustc_expand::base::*;
@@ -341,11 +340,11 @@ pub fn expand_test_or_bench(
     if is_stmt {
         vec![
             // Access to libtest under a hygienic name
-            Annotatable::Stmt(P(cx.stmt_item(sp, test_extern))),
+            Annotatable::Stmt(cx.stmt_item(sp, test_extern)),
             // The generated test case
-            Annotatable::Stmt(P(cx.stmt_item(sp, test_const))),
+            Annotatable::Stmt(cx.stmt_item(sp, test_const)),
             // The original item
-            Annotatable::Stmt(P(cx.stmt_item(sp, item))),
+            Annotatable::Stmt(cx.stmt_item(sp, item)),
         ]
     } else {
         vec![

--- a/compiler/rustc_expand/src/base.rs
+++ b/compiler/rustc_expand/src/base.rs
@@ -163,9 +163,9 @@ impl Annotatable {
         }
     }
 
-    pub fn expect_stmt(self) -> ast::Stmt {
+    pub fn expect_stmt(self) -> P<ast::Stmt> {
         match self {
-            Annotatable::Stmt(stmt) => stmt.into_inner(),
+            Annotatable::Stmt(stmt) => stmt,
             _ => panic!("expected statement"),
         }
     }
@@ -350,11 +350,11 @@ where
 macro_rules! make_stmts_default {
     ($me:expr) => {
         $me.make_expr().map(|e| {
-            smallvec![ast::Stmt {
+            smallvec![P(ast::Stmt {
                 id: ast::DUMMY_NODE_ID,
                 span: e.span,
                 kind: ast::StmtKind::Expr(e),
-            }]
+            })]
         })
     };
 }
@@ -396,7 +396,7 @@ pub trait MacResult {
     ///
     /// By default this attempts to create an expression statement,
     /// returning None if that fails.
-    fn make_stmts(self: Box<Self>) -> Option<SmallVec<[ast::Stmt; 1]>> {
+    fn make_stmts(self: Box<Self>) -> Option<SmallVec<[P<ast::Stmt>; 1]>> {
         make_stmts_default!(self)
     }
 
@@ -469,7 +469,7 @@ make_MacEager! {
     impl_items: SmallVec<[P<ast::AssocItem>; 1]>,
     trait_items: SmallVec<[P<ast::AssocItem>; 1]>,
     foreign_items: SmallVec<[P<ast::ForeignItem>; 1]>,
-    stmts: SmallVec<[ast::Stmt; 1]>,
+    stmts: SmallVec<[P<ast::Stmt>; 1]>,
     ty: P<ast::Ty>,
 }
 
@@ -494,7 +494,7 @@ impl MacResult for MacEager {
         self.foreign_items
     }
 
-    fn make_stmts(self: Box<Self>) -> Option<SmallVec<[ast::Stmt; 1]>> {
+    fn make_stmts(self: Box<Self>) -> Option<SmallVec<[P<ast::Stmt>; 1]>> {
         match self.stmts.as_ref().map_or(0, |s| s.len()) {
             0 => make_stmts_default!(self),
             _ => self.stmts,
@@ -597,12 +597,12 @@ impl MacResult for DummyResult {
         Some(SmallVec::new())
     }
 
-    fn make_stmts(self: Box<DummyResult>) -> Option<SmallVec<[ast::Stmt; 1]>> {
-        Some(smallvec![ast::Stmt {
+    fn make_stmts(self: Box<DummyResult>) -> Option<SmallVec<[P<ast::Stmt>; 1]>> {
+        Some(smallvec![P(ast::Stmt {
             id: ast::DUMMY_NODE_ID,
             kind: ast::StmtKind::Expr(DummyResult::raw_expr(self.span, self.is_error)),
             span: self.span,
-        }])
+        })])
     }
 
     fn make_ty(self: Box<DummyResult>) -> Option<P<ast::Ty>> {

--- a/compiler/rustc_expand/src/build.rs
+++ b/compiler/rustc_expand/src/build.rs
@@ -139,11 +139,11 @@ impl<'a> ExtCtxt<'a> {
         ast::Lifetime { id: ast::DUMMY_NODE_ID, ident: ident.with_span_pos(span) }
     }
 
-    pub fn stmt_expr(&self, expr: P<ast::Expr>) -> ast::Stmt {
-        ast::Stmt { id: ast::DUMMY_NODE_ID, span: expr.span, kind: ast::StmtKind::Expr(expr) }
+    pub fn stmt_expr(&self, expr: P<ast::Expr>) -> P<ast::Stmt> {
+        P(ast::Stmt { id: ast::DUMMY_NODE_ID, span: expr.span, kind: ast::StmtKind::Expr(expr) })
     }
 
-    pub fn stmt_let(&self, sp: Span, mutbl: bool, ident: Ident, ex: P<ast::Expr>) -> ast::Stmt {
+    pub fn stmt_let(&self, sp: Span, mutbl: bool, ident: Ident, ex: P<ast::Expr>) -> P<ast::Stmt> {
         let pat = if mutbl {
             let binding_mode = ast::BindingMode::ByValue(ast::Mutability::Mut);
             self.pat_ident_binding_mode(sp, ident, binding_mode)
@@ -159,11 +159,11 @@ impl<'a> ExtCtxt<'a> {
             attrs: AttrVec::new(),
             tokens: None,
         });
-        ast::Stmt { id: ast::DUMMY_NODE_ID, kind: ast::StmtKind::Local(local), span: sp }
+        P(ast::Stmt { id: ast::DUMMY_NODE_ID, kind: ast::StmtKind::Local(local), span: sp })
     }
 
     // Generates `let _: Type;`, which is usually used for type assertions.
-    pub fn stmt_let_type_only(&self, span: Span, ty: P<ast::Ty>) -> ast::Stmt {
+    pub fn stmt_let_type_only(&self, span: Span, ty: P<ast::Ty>) -> P<ast::Stmt> {
         let local = P(ast::Local {
             pat: self.pat_wild(span),
             ty: Some(ty),
@@ -173,24 +173,24 @@ impl<'a> ExtCtxt<'a> {
             attrs: AttrVec::new(),
             tokens: None,
         });
-        ast::Stmt { id: ast::DUMMY_NODE_ID, kind: ast::StmtKind::Local(local), span }
+        P(ast::Stmt { id: ast::DUMMY_NODE_ID, kind: ast::StmtKind::Local(local), span })
     }
 
-    pub fn stmt_item(&self, sp: Span, item: P<ast::Item>) -> ast::Stmt {
-        ast::Stmt { id: ast::DUMMY_NODE_ID, kind: ast::StmtKind::Item(item), span: sp }
+    pub fn stmt_item(&self, sp: Span, item: P<ast::Item>) -> P<ast::Stmt> {
+        P(ast::Stmt { id: ast::DUMMY_NODE_ID, kind: ast::StmtKind::Item(item), span: sp })
     }
 
     pub fn block_expr(&self, expr: P<ast::Expr>) -> P<ast::Block> {
         self.block(
             expr.span,
-            vec![ast::Stmt {
+            vec![P(ast::Stmt {
                 id: ast::DUMMY_NODE_ID,
                 span: expr.span,
                 kind: ast::StmtKind::Expr(expr),
-            }],
+            })],
         )
     }
-    pub fn block(&self, span: Span, stmts: Vec<ast::Stmt>) -> P<ast::Block> {
+    pub fn block(&self, span: Span, stmts: Vec<P<ast::Stmt>>) -> P<ast::Block> {
         P(ast::Block {
             stmts,
             id: ast::DUMMY_NODE_ID,
@@ -497,7 +497,12 @@ impl<'a> ExtCtxt<'a> {
         self.lambda(span, vec![ident], body)
     }
 
-    pub fn lambda_stmts_1(&self, span: Span, stmts: Vec<ast::Stmt>, ident: Ident) -> P<ast::Expr> {
+    pub fn lambda_stmts_1(
+        &self,
+        span: Span,
+        stmts: Vec<P<ast::Stmt>>,
+        ident: Ident,
+    ) -> P<ast::Expr> {
         self.lambda1(span, self.expr_block(self.block(span, stmts)), ident)
     }
 

--- a/compiler/rustc_expand/src/placeholders.rs
+++ b/compiler/rustc_expand/src/placeholders.rs
@@ -112,7 +112,7 @@ pub fn placeholder(
                 attrs: ast::AttrVec::new(),
                 tokens: None,
             });
-            ast::Stmt { id, span, kind: ast::StmtKind::MacCall(mac) }
+            P(ast::Stmt { id, span, kind: ast::StmtKind::MacCall(mac) })
         }]),
         AstFragmentKind::Arms => AstFragment::Arms(smallvec![ast::Arm {
             attrs: Default::default(),
@@ -302,8 +302,8 @@ impl MutVisitor for PlaceholderExpander {
         }
     }
 
-    fn flat_map_stmt(&mut self, stmt: ast::Stmt) -> SmallVec<[ast::Stmt; 1]> {
-        let (style, mut stmts) = match stmt.kind {
+    fn flat_map_stmt(&mut self, stmt: P<ast::Stmt>) -> SmallVec<[P<ast::Stmt>; 1]> {
+        let (style, mut stmts) = match &stmt.kind {
             ast::StmtKind::MacCall(mac) => (mac.style, self.remove(stmt.id).make_stmts()),
             _ => return noop_flat_map_stmt(stmt, self),
         };
@@ -331,7 +331,7 @@ impl MutVisitor for PlaceholderExpander {
             // FIXME: We will need to preserve the original semicolon token and
             // span as part of #15701
             let empty_stmt =
-                ast::Stmt { id: ast::DUMMY_NODE_ID, kind: ast::StmtKind::Empty, span: DUMMY_SP };
+                P(ast::Stmt { id: ast::DUMMY_NODE_ID, kind: ast::StmtKind::Empty, span: DUMMY_SP });
 
             if let Some(stmt) = stmts.pop() {
                 if stmt.has_trailing_semicolon() {

--- a/compiler/rustc_expand/src/proc_macro.rs
+++ b/compiler/rustc_expand/src/proc_macro.rs
@@ -2,7 +2,6 @@ use crate::base::{self, *};
 use crate::proc_macro_server;
 
 use rustc_ast as ast;
-use rustc_ast::ptr::P;
 use rustc_ast::token;
 use rustc_ast::tokenstream::{CanSynthesizeMissingTokens, TokenStream, TokenTree};
 use rustc_data_structures::sync::Lrc;
@@ -129,7 +128,7 @@ impl MultiItemModifier for ProcMacroDerive {
                 Ok(None) => break,
                 Ok(Some(item)) => {
                     if is_stmt {
-                        items.push(Annotatable::Stmt(P(ecx.stmt_item(span, item))));
+                        items.push(Annotatable::Stmt(ecx.stmt_item(span, item)));
                     } else {
                         items.push(Annotatable::Item(item));
                     }

--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -2424,7 +2424,7 @@ impl<'a> Parser<'a> {
         self.bump(); // `;`
         let mut stmts =
             vec![self.mk_stmt(first_expr.span, ast::StmtKind::Expr(first_expr.clone()))];
-        let err = |this: &mut Parser<'_>, stmts: Vec<ast::Stmt>| {
+        let err = |this: &mut Parser<'_>, stmts: Vec<P<ast::Stmt>>| {
             let span = stmts[0].span.to(stmts[stmts.len() - 1].span);
             let mut err = this.struct_span_err(span, "`match` arm body without braces");
             let (these, s, are) =

--- a/compiler/rustc_parse/src/parser/nonterminal.rs
+++ b/compiler/rustc_parse/src/parser/nonterminal.rs
@@ -118,7 +118,7 @@ impl<'a> Parser<'a> {
                 token::NtBlock(self.collect_tokens_no_attrs(|this| this.parse_block())?)
             }
             NonterminalKind::Stmt => match self.parse_stmt(ForceCollect::Yes)? {
-                Some(s) => token::NtStmt(P(s)),
+                Some(s) => token::NtStmt(s),
                 None => {
                     return Err(self.struct_span_err(self.token.span, "expected a statement"));
                 }

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -2295,12 +2295,11 @@ impl<'a: 'ast, 'b, 'ast> LateResolutionVisitor<'a, 'b, 'ast> {
         }
 
         let prev = self.diagnostic_metadata.current_block_could_be_bare_struct_literal.take();
-        if let (true, [Stmt { kind: StmtKind::Expr(expr), .. }]) =
-            (block.could_be_bare_literal, &block.stmts[..])
-            && let ExprKind::Type(..) = expr.kind
-        {
+        if let (true, [stmt]) = (block.could_be_bare_literal, &block.stmts[..])
+            && let Stmt { kind: StmtKind::Expr(ref expr), .. } = **stmt
+            && let ExprKind::Type(..) = expr.kind {
             self.diagnostic_metadata.current_block_could_be_bare_struct_literal =
-            Some(block.span);
+                Some(block.span);
         }
         // Descend into the block.
         for stmt in &block.stmts {

--- a/src/tools/clippy/clippy_utils/src/ast_utils.rs
+++ b/src/tools/clippy/clippy_utils/src/ast_utils.rs
@@ -209,7 +209,7 @@ pub fn eq_block(l: &Block, r: &Block) -> bool {
     l.rules == r.rules && over(&l.stmts, &r.stmts, eq_stmt)
 }
 
-pub fn eq_stmt(l: &Stmt, r: &Stmt) -> bool {
+pub fn eq_stmt(l: &P<Stmt>, r: &P<Stmt>) -> bool {
     use StmtKind::*;
     match (&l.kind, &r.kind) {
         (Local(l), Local(r)) => {

--- a/src/tools/rustfmt/src/closures.rs
+++ b/src/tools/rustfmt/src/closures.rs
@@ -147,11 +147,11 @@ fn rewrite_closure_with_block(
     }
 
     let block = ast::Block {
-        stmts: vec![ast::Stmt {
+        stmts: vec![ptr::P(ast::Stmt {
             id: ast::NodeId::root(),
             kind: ast::StmtKind::Expr(ptr::P(body.clone())),
             span: body.span,
-        }],
+        })],
         id: ast::NodeId::root(),
         rules: ast::BlockCheckMode::Default,
         tokens: None,

--- a/src/tools/rustfmt/src/stmt.rs
+++ b/src/tools/rustfmt/src/stmt.rs
@@ -39,7 +39,7 @@ impl<'a> Stmt<'a> {
 
     pub(crate) fn from_ast_nodes<I>(iter: I) -> Vec<Self>
     where
-        I: Iterator<Item = &'a ast::Stmt>,
+        I: Iterator<Item = &'a rustc_ast::ptr::P<ast::Stmt>>,
     {
         let mut result = vec![];
         let mut iter = iter.peekable();

--- a/src/tools/rustfmt/src/utils.rs
+++ b/src/tools/rustfmt/src/utils.rs
@@ -319,7 +319,7 @@ pub(crate) fn semicolon_for_stmt(context: &RewriteContext<'_>, stmt: &ast::Stmt)
 }
 
 #[inline]
-pub(crate) fn stmt_expr(stmt: &ast::Stmt) -> Option<&ast::Expr> {
+pub(crate) fn stmt_expr(stmt: &ptr::P<ast::Stmt>) -> Option<&ast::Expr> {
     match stmt.kind {
         ast::StmtKind::Expr(ref expr) => Some(expr),
         _ => None,


### PR DESCRIPTION
This is for consistency with things like `P<ast::Item>`.
Performance-wise, it's a tradeoff: more allocations, but `Vec<P<Stmt>>`
manipulations involve fewer `memcpy` calls than `Vec<Stmt>`
manipulations.

r? @ghost