### PR TITLE
thin_box test: import from std, not alloc

### DIFF
--- a/library/alloc/tests/thin_box.rs
+++ b/library/alloc/tests/thin_box.rs
@@ -1,5 +1,5 @@
-use alloc::boxed::ThinBox;
 use core::mem::size_of;
+use std::boxed::ThinBox;
 
 #[test]
 fn want_niche_optimization() {


### PR DESCRIPTION
Importing from `alloc` makes [Miri fail](https://github.com/rust-lang/miri-test-libstd/runs/5964922742?check_suite_focus=true), probably due to the hack that we used to resolve https://github.com/rust-lang/miri-test-libstd/issues/4. There might be better ways around this, but for now this is the easiest thing to do -- no other alloc integration test is importing from `alloc::`.