### PR TITLE
Modify MIR building to drop repeat expressions with length zero

### DIFF
--- a/src/test/ui/drop/repeat-drop-2.rs
+++ b/src/test/ui/drop/repeat-drop-2.rs
@@ -1,0 +1,5 @@
+fn main() {
+    let foo = String::new();
+    let _bar = foo;
+    let _baz = [foo; 0]; //~ ERROR use of moved value: `foo` [E0382]
+}

--- a/src/test/ui/drop/repeat-drop-2.stderr
+++ b/src/test/ui/drop/repeat-drop-2.stderr
@@ -1,0 +1,13 @@
+error[E0382]: use of moved value: `foo`
+  --> $DIR/repeat-drop-2.rs:4:17
+   |
+LL |     let foo = String::new();
+   |         --- move occurs because `foo` has type `String`, which does not implement the `Copy` trait
+LL |     let _bar = foo;
+   |                --- value moved here
+LL |     let _baz = [foo; 0];
+   |                 ^^^ value used here after move
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0382`.

--- a/src/test/ui/drop/repeat-drop.rs
+++ b/src/test/ui/drop/repeat-drop.rs
@@ -1,0 +1,36 @@
+// run-pass
+
+static mut COUNT: usize = 0;
+
+struct Foo;
+
+impl Drop for Foo {
+    fn drop(&mut self) {
+        unsafe {
+            COUNT += 1;
+        }
+    }
+}
+
+fn a() {
+    let foo = Foo;
+    let v: [Foo; 0] = [foo; 0];
+    unsafe { assert_eq!(COUNT, 1) }
+    std::mem::drop(v);
+}
+
+fn b() {
+    let foo = Foo;
+    let v: [Foo; 1] = [foo; 1];
+    unsafe { assert_eq!(COUNT, 0) }
+    std::mem::drop(v);
+    unsafe { assert_eq!(COUNT, 1) }
+}
+
+fn main() {
+    a();
+    unsafe {
+        COUNT = 0;
+    }
+    b();
+}


### PR DESCRIPTION
Closes #74836 .

This version of things was sort of discussed in the issue, but decided against for a reason I don't quite understand. I'm putting this PR up to demonstrate the intended fix, and I've [asked on Zulip](https://rust-lang.zulipchat.com/#narrow/stream/213817-t-lang/topic/Fixing.20zero.20length.20array.20leak) for clarification over why this is considered problematic.