### PR TITLE
[bootstrap] Grab the right FileCheck binary for dist when cross-compiling.

### DIFF
--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -865,8 +865,8 @@ impl Build {
                 }
             }
         } else {
-            let base = self.llvm_out(self.config.build).join("build");
-            let base = if !self.ninja() && self.config.build.contains("msvc") {
+            let base = self.llvm_out(target).join("build");
+            let base = if !self.ninja() && target.contains("msvc") {
                 if self.config.llvm_optimize {
                     if self.config.llvm_release_debuginfo {
                         base.join("RelWithDebInfo")


### PR DESCRIPTION
Fixes #95862

We were using the target dir for all the other LLVM tools (`llvm-config`, `llvm-ar`, etc) but the build target dir for `FileCheck`. This meant for targets which are cross-compiled, we were copying the wrong binary.
