### PR TITLE
Stabilize const-weak-new

### DIFF
--- a/library/alloc/src/rc.rs
+++ b/library/alloc/src/rc.rs
@@ -2112,7 +2112,7 @@ impl<T> Weak<T> {
     /// assert!(empty.upgrade().is_none());
     /// ```
     #[stable(feature = "downgraded_weak", since = "1.10.0")]
-    #[rustc_const_unstable(feature = "const_weak_new", issue = "95091", reason = "recently added")]
+    #[rustc_const_stable(feature = "const_weak_new", since = "CURRENT_RUSTC_VERSION")]
     #[must_use]
     pub const fn new() -> Weak<T> {
         Weak { ptr: unsafe { NonNull::new_unchecked(ptr::invalid_mut::<RcBox<T>>(usize::MAX)) } }

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -1743,7 +1743,7 @@ impl<T> Weak<T> {
     /// assert!(empty.upgrade().is_none());
     /// ```
     #[stable(feature = "downgraded_weak", since = "1.10.0")]
-    #[rustc_const_unstable(feature = "const_weak_new", issue = "95091", reason = "recently added")]
+    #[rustc_const_stable(feature = "const_weak_new", since = "CURRENT_RUSTC_VERSION")]
     #[must_use]
     pub const fn new() -> Weak<T> {
         Weak { ptr: unsafe { NonNull::new_unchecked(ptr::invalid_mut::<ArcInner<T>>(usize::MAX)) } }


### PR DESCRIPTION
This is a fairly uncontroversial library stabilization, so I'm going ahead and proposing it to ride the trains to stable.

This stabilizes the following APIs, which are defined to be non-allocating constructors.

```rust
// alloc::rc
impl<T> Weak<T> {
    pub const fn new() -> Weak<T>;
}

// alloc::sync
impl<T> Weak<T> {
    pub const fn new() -> Weak<T>;
}
```

Closes #95091

@rustbot modify labels: +needs-fcp