### PR TITLE
Fix suggestions in case of `T:` bounds

### DIFF
--- a/src/test/ui/moves/use_of_moved_value_copy_suggestions.fixed
+++ b/src/test/ui/moves/use_of_moved_value_copy_suggestions.fixed
@@ -69,4 +69,18 @@ where
     (t, t) //~ use of moved value: `t`
 }
 
+#[rustfmt::skip]
+fn existing_colon<T: Copy>(t: T) {
+    //~^ HELP consider restricting type parameter `T`
+    [t, t]; //~ use of moved value: `t`
+}
+
+fn existing_colon_in_where<T>(t: T)
+where
+    T: Copy,
+    //~^ HELP consider further restricting this bound
+{
+    [t, t]; //~ use of moved value: `t`
+}
+
 fn main() {}

--- a/src/test/ui/moves/use_of_moved_value_copy_suggestions.rs
+++ b/src/test/ui/moves/use_of_moved_value_copy_suggestions.rs
@@ -69,4 +69,18 @@ where
     (t, t) //~ use of moved value: `t`
 }
 
+#[rustfmt::skip]
+fn existing_colon<T:>(t: T) {
+    //~^ HELP consider restricting type parameter `T`
+    [t, t]; //~ use of moved value: `t`
+}
+
+fn existing_colon_in_where<T>(t: T)
+where
+    T:,
+    //~^ HELP consider further restricting this bound
+{
+    [t, t]; //~ use of moved value: `t`
+}
+
 fn main() {}

--- a/src/test/ui/moves/use_of_moved_value_copy_suggestions.stderr
+++ b/src/test/ui/moves/use_of_moved_value_copy_suggestions.stderr
@@ -142,6 +142,38 @@ help: consider further restricting this bound
 LL |     T: B + Trait + Copy,
    |          ++++++++++++++
 
-error: aborting due to 9 previous errors
+error[E0382]: use of moved value: `t`
+  --> $DIR/use_of_moved_value_copy_suggestions.rs:83:9
+   |
+LL | fn existing_colon_in_where<T>(t: T)
+   |                               - move occurs because `t` has type `T`, which does not implement the `Copy` trait
+...
+LL |     [t, t];
+   |      -  ^ value used here after move
+   |      |
+   |      value moved here
+   |
+help: consider further restricting this bound
+   |
+LL |     T: Copy,
+   |        ++++
+
+error[E0382]: use of moved value: `t`
+  --> $DIR/use_of_moved_value_copy_suggestions.rs:75:9
+   |
+LL | fn existing_colon<T:>(t: T) {
+   |                       - move occurs because `t` has type `T`, which does not implement the `Copy` trait
+LL |
+LL |     [t, t];
+   |      -  ^ value used here after move
+   |      |
+   |      value moved here
+   |
+help: consider restricting type parameter `T`
+   |
+LL | fn existing_colon<T: Copy>(t: T) {
+   |                      ++++
+
+error: aborting due to 11 previous errors
 
 For more information about this error, try `rustc --explain E0382`.


### PR DESCRIPTION
This PR fixes a corner case in `suggest_constraining_type_params` that was causing incorrect suggestions.

For the following functions:
```rust
fn a<T:>(t: T) { [t, t]; }
fn b<T>(t: T) where T: { [t, t]; }
```

We previously suggested the following:
```text
...
help: consider restricting type parameter `T`
  |
1 | fn a<T: Copy:>(t: T) { [t, t]; }
  |       ++++++
...
help: consider further restricting this bound
  |
2 | fn b<T>(t: T) where T: + Copy { [t, t]; }
  |                        ++++++
```

Note that neither `T: Copy:` not `where T: + Copy` is a correct bound.

With this commit the suggestions are correct:
```text
...
help: consider restricting type parameter `T`
  |
1 | fn a<T: Copy>(t: T) { [t, t]; }
  |         ++++
...
help: consider further restricting this bound
  |
2 | fn b<T>(t: T) where T: Copy { [t, t]; }
  |                        ++++
```

r? @compiler-errors

I've tried fixing #95898 here too, but got too confused with how `suggest_traits_to_import` works and what it does :sweat_smile: