### PR TITLE
Don't test -Cdefault-linker-libraries=yes when cross compiling.

### DIFF
--- a/src/test/ui/issues/issue-70093.rs
+++ b/src/test/ui/issues/issue-70093.rs
@@ -2,6 +2,7 @@
 // compile-flags: -Zlink-native-libraries=no -Cdefault-linker-libraries=yes
 // ignore-windows - this will probably only work on unixish systems
 // ignore-fuchsia - missing __libc_start_main for some reason (#84733)
+// ignore-cross-compile - default-linker-libraries=yes doesn't play well with cross compiling
 
 #[link(name = "some-random-non-existent-library", kind = "static")]
 extern "C" {}


### PR DESCRIPTION
See https://github.com/rust-lang/rust/pull/95727#issuecomment-1096603163 and the five comments below that.

Unblocks #95727.