### PR TITLE
Implement Valtree to ConstValue conversion

### DIFF
--- a/compiler/rustc_const_eval/src/const_eval/eval_queries.rs
+++ b/compiler/rustc_const_eval/src/const_eval/eval_queries.rs
@@ -215,16 +215,16 @@ fn turn_into_const_value<'tcx>(
         "the `eval_to_const_value_raw` query should not be used for statics, use `eval_to_allocation` instead"
     );
 
+    // Turn this into a proper constant.
+    let const_val = op_to_const(&ecx, &mplace.into());
+    debug!(?const_val);
+
     if cfg!(debug_assertions) {
         if let Some(valtree) = const_to_valtree(tcx, key.param_env, constant) {
             let const_val = tcx.valtree_to_const_val((constant.ty, valtree));
             debug!(?const_val);
         }
     }
-
-    // Turn this into a proper constant.
-    let const_val = op_to_const(&ecx, &mplace.into());
-    debug!(?const_val);
 
     const_val
 }

--- a/compiler/rustc_const_eval/src/const_eval/eval_queries.rs
+++ b/compiler/rustc_const_eval/src/const_eval/eval_queries.rs
@@ -1,4 +1,4 @@
-use super::{CompileTimeEvalContext, CompileTimeInterpreter, ConstEvalErr};
+use super::{const_to_valtree, CompileTimeEvalContext, CompileTimeInterpreter, ConstEvalErr};
 use crate::interpret::eval_nullary_intrinsic;
 use crate::interpret::{
     intern_const_alloc_recursive, Allocation, ConstAlloc, ConstValue, CtfeValidationMode, GlobalId,
@@ -214,6 +214,13 @@ fn turn_into_const_value<'tcx>(
         !is_static || cid.promoted.is_some(),
         "the `eval_to_const_value_raw` query should not be used for statics, use `eval_to_allocation` instead"
     );
+
+    if cfg!(debug_assertions) {
+        if let Some(valtree) = const_to_valtree(tcx, key.param_env, constant) {
+            let const_val = tcx.valtree_to_const_val((constant.ty, valtree));
+            debug!(?const_val);
+        }
+    }
 
     // Turn this into a proper constant.
     let const_val = op_to_const(&ecx, &mplace.into());

--- a/compiler/rustc_const_eval/src/const_eval/eval_queries.rs
+++ b/compiler/rustc_const_eval/src/const_eval/eval_queries.rs
@@ -1,4 +1,4 @@
-use super::{const_to_valtree, CompileTimeEvalContext, CompileTimeInterpreter, ConstEvalErr};
+use super::{CompileTimeEvalContext, CompileTimeInterpreter, ConstEvalErr};
 use crate::interpret::eval_nullary_intrinsic;
 use crate::interpret::{
     intern_const_alloc_recursive, Allocation, ConstAlloc, ConstValue, CtfeValidationMode, GlobalId,
@@ -218,13 +218,6 @@ fn turn_into_const_value<'tcx>(
     // Turn this into a proper constant.
     let const_val = op_to_const(&ecx, &mplace.into());
     debug!(?const_val);
-
-    if cfg!(debug_assertions) {
-        if let Some(valtree) = const_to_valtree(tcx, key.param_env, constant) {
-            let const_val = tcx.valtree_to_const_val((constant.ty, valtree));
-            debug!(?const_val);
-        }
-    }
 
     const_val
 }

--- a/compiler/rustc_const_eval/src/const_eval/valtrees.rs
+++ b/compiler/rustc_const_eval/src/const_eval/valtrees.rs
@@ -2,16 +2,16 @@ use super::eval_queries::{mk_eval_cx, op_to_const};
 use super::machine::CompileTimeEvalContext;
 use crate::interpret::{
     intern_const_alloc_recursive, ConstValue, ImmTy, Immediate, InternKind, MemoryKind, PlaceTy,
-    Pointer, Scalar, ScalarMaybeUninit,
+    Scalar, ScalarMaybeUninit,
 };
-use rustc_middle::mir::interpret::{ConstAlloc, GlobalAlloc};
+use rustc_middle::mir::interpret::ConstAlloc;
 use rustc_middle::mir::{Field, ProjectionElem};
 use rustc_middle::ty::{self, ScalarInt, Ty, TyCtxt};
 use rustc_span::source_map::DUMMY_SP;
 use rustc_target::abi::VariantIdx;
 
-use crate::interpret::visitor::Value;
 use crate::interpret::MPlaceTy;
+use crate::interpret::Value;
 
 /// Convert an evaluated constant to a type level constant
 #[instrument(skip(tcx), level = "debug")]
@@ -54,6 +54,7 @@ fn branches<'tcx>(
     Some(ty::ValTree::Branch(ecx.tcx.arena.alloc_from_iter(branches.collect::<Option<Vec<_>>>()?)))
 }
 
+#[instrument(skip(ecx), level = "debug")]
 fn slice_branches<'tcx>(
     ecx: &CompileTimeEvalContext<'tcx, 'tcx>,
     place: &MPlaceTy<'tcx>,
@@ -139,13 +140,42 @@ fn const_to_valtree_inner<'tcx>(
 #[instrument(skip(ecx), level = "debug")]
 fn create_mplace_from_layout<'tcx>(
     ecx: &mut CompileTimeEvalContext<'tcx, 'tcx>,
-    param_env_ty: ty::ParamEnvAnd<'tcx, Ty<'tcx>>,
+    ty: Ty<'tcx>,
 ) -> MPlaceTy<'tcx> {
     let tcx = ecx.tcx;
-    let layout = tcx.layout_of(param_env_ty).unwrap();
+    let param_env = ecx.param_env;
+    let layout = tcx.layout_of(param_env.and(ty)).unwrap();
     debug!(?layout);
 
     ecx.allocate(layout, MemoryKind::Stack).unwrap()
+}
+
+#[instrument(skip(ecx), level = "debug")]
+fn create_pointee_place<'tcx>(
+    ecx: &mut CompileTimeEvalContext<'tcx, 'tcx>,
+    ty: Ty<'tcx>,
+    valtree: ty::ValTree<'tcx>,
+) -> MPlaceTy<'tcx> {
+    let tcx = ecx.tcx.tcx;
+
+    match ty.kind() {
+        ty::Slice(_) | ty::Str => {
+            let slice_ty = match ty.kind() {
+                ty::Slice(slice_ty) => *slice_ty,
+                ty::Str => tcx.mk_ty(ty::Uint(ty::UintTy::U8)),
+                _ => bug!("expected ty::Slice | ty::Str"),
+            };
+
+            // Create a place for the underlying array
+            let len = valtree.unwrap_branch().len() as u64;
+            let arr_ty = tcx.mk_array(slice_ty, len as u64);
+            let place = create_mplace_from_layout(ecx, arr_ty);
+            debug!(?place);
+
+            place
+        }
+        _ => create_mplace_from_layout(ecx, ty),
+    }
 }
 
 /// Converts a `ValTree` to a `ConstValue`, which is needed after mir
@@ -174,96 +204,28 @@ pub fn valtree_to_const_value<'tcx>(
             ),
         },
         ty::Ref(_, inner_ty, _) => {
-            match inner_ty.kind() {
-                ty::Slice(_) | ty::Str => {
-                    let slice_ty = match inner_ty.kind() {
-                        ty::Slice(slice_ty) => *slice_ty,
-                        ty::Str => tcx.mk_ty(ty::Uint(ty::UintTy::U8)),
-                        _ => bug!("expected ty::Slice | ty::Str"),
-                    };
-                    debug!(?slice_ty);
+            // create a place for the pointee
+            let mut pointee_place = create_pointee_place(&mut ecx, *inner_ty, valtree);
+            debug!(?pointee_place);
 
-                    let valtrees = valtree.unwrap_branch();
+            // insert elements of valtree into `place`
+            fill_place_recursively(&mut ecx, &mut pointee_place, valtree);
+            dump_place(&ecx, pointee_place.into());
+            intern_const_alloc_recursive(&mut ecx, InternKind::Constant, &pointee_place).unwrap();
 
-                    // Create a place for the underlying array
-                    let len = valtrees.len();
-                    let arr_ty = tcx.mk_array(slice_ty, len as u64);
-                    let mut place =
-                        create_mplace_from_layout(&mut ecx, ty::ParamEnv::empty().and(arr_ty));
-                    debug!(?place);
+            let ref_place = pointee_place.to_ref(&tcx);
+            let imm = ImmTy::from_immediate(ref_place, tcx.layout_of(param_env_ty).unwrap());
 
-                    // Insert elements of `arr_valtree` into `place`
-                    fill_place_recursively(&mut ecx, &mut place, valtree, arr_ty);
-                    dump_place(&ecx, place.into());
+            let const_val = op_to_const(&ecx, &imm.into());
+            debug!(?const_val);
 
-                    // The allocation behind `place` is local, we need to intern it
-                    intern_const_alloc_recursive(&mut ecx, InternKind::Constant, &place).unwrap();
-
-                    // Now we need to get the Allocation
-                    let alloc_id = place.mplace.ptr.provenance.unwrap();
-                    debug!(?alloc_id);
-
-                    let data = match tcx.get_global_alloc(alloc_id) {
-                        Some(GlobalAlloc::Memory(const_alloc)) => const_alloc,
-                        _ => bug!("expected memory allocation"),
-                    };
-                    debug!(?data);
-
-                    return ConstValue::Slice { data, start: 0, end: len as usize };
-                }
-                _ => {
-                    match valtree {
-                        ty::ValTree::Branch(_) => {
-                            // create a place for the pointee
-                            let mut place = create_mplace_from_layout(
-                                &mut ecx,
-                                ty::ParamEnv::empty().and(*inner_ty),
-                            );
-                            debug!(?place);
-
-                            // insert elements of valtree into `place`
-                            fill_place_recursively(&mut ecx, &mut place, valtree, *inner_ty);
-                            dump_place(&ecx, place.into());
-                            intern_const_alloc_recursive(&mut ecx, InternKind::Constant, &place)
-                                .unwrap();
-
-                            let ref_place = place.mplace.to_ref(&tcx);
-                            let imm = ImmTy::from_immediate(
-                                ref_place,
-                                tcx.layout_of(param_env_ty).unwrap(),
-                            );
-
-                            let const_val = op_to_const(&ecx, &imm.into());
-                            debug!(?const_val);
-
-                            const_val
-                        }
-                        ty::ValTree::Leaf(_) => {
-                            let mut place = create_mplace_from_layout(
-                                &mut ecx,
-                                ty::ParamEnv::empty().and(*inner_ty),
-                            );
-
-                            fill_place_recursively(&mut ecx, &mut place, valtree, *inner_ty);
-                            dump_place(&ecx, place.into());
-
-                            let ref_place = place.mplace.to_ref(&tcx);
-                            let imm = ImmTy::from_immediate(
-                                ref_place,
-                                tcx.layout_of(param_env_ty).unwrap(),
-                            );
-
-                            op_to_const(&ecx, &imm.into())
-                        }
-                    }
-                }
-            }
+            const_val
         }
         ty::Tuple(_) | ty::Array(_, _) | ty::Adt(..) => {
-            let mut place = create_mplace_from_layout(&mut ecx, param_env_ty);
+            let mut place = create_mplace_from_layout(&mut ecx, ty);
             debug!(?place);
 
-            fill_place_recursively(&mut ecx, &mut place, valtree, ty);
+            fill_place_recursively(&mut ecx, &mut place, valtree);
             dump_place(&ecx, place.into());
             intern_const_alloc_recursive(&mut ecx, InternKind::Constant, &place).unwrap();
 
@@ -301,12 +263,12 @@ fn fill_place_recursively<'tcx>(
     ecx: &mut CompileTimeEvalContext<'tcx, 'tcx>,
     place: &mut MPlaceTy<'tcx>,
     valtree: ty::ValTree<'tcx>,
-    ty: Ty<'tcx>,
 ) {
     // This will match on valtree and write the value(s) corresponding to the ValTree
     // inside the place recursively.
 
     let tcx = ecx.tcx.tcx;
+    let ty = place.layout.ty;
 
     match ty.kind() {
         ty::Bool | ty::Int(_) | ty::Uint(_) | ty::Float(_) | ty::Char => {
@@ -319,161 +281,90 @@ fn fill_place_recursively<'tcx>(
             .unwrap();
         }
         ty::Ref(_, inner_ty, _) => {
-            match inner_ty.kind() {
+            let mut pointee_place = create_pointee_place(ecx, *inner_ty, valtree);
+            debug!(?pointee_place);
+
+            fill_place_recursively(ecx, &mut pointee_place, valtree);
+            dump_place(ecx, pointee_place.into());
+            intern_const_alloc_recursive(ecx, InternKind::Constant, &pointee_place).unwrap();
+
+            let imm = match inner_ty.kind() {
                 ty::Slice(_) | ty::Str => {
-                    let slice_ty = match inner_ty.kind() {
-                        ty::Slice(slice_ty) => *slice_ty,
-                        ty::Str => tcx.mk_ty(ty::Uint(ty::UintTy::U8)),
-                        _ => bug!("expected ty::Slice | ty::Str"),
-                    };
-                    debug!(?slice_ty);
-
-                    let valtrees = valtree.unwrap_branch();
-                    debug!(?valtrees);
-                    let len = valtrees.len();
-                    debug!(?len);
-
-                    // create a place for the underlying array
-                    let arr_ty = tcx.mk_array(slice_ty, len as u64);
-                    let mut arr_place =
-                        create_mplace_from_layout(ecx, ty::ParamEnv::empty().and(arr_ty));
-                    debug!(?arr_place);
-
-                    // Insert elements of `arr_valtree` into `place`
-                    fill_place_recursively(ecx, &mut arr_place, valtree, arr_ty);
-                    dump_place(&ecx, arr_place.into());
-
-                    // Now we need to create a `ScalarPair` from the filled `place`
-                    // and write that into `place`
-                    let (alloc_id, offset) = arr_place.mplace.ptr.into_parts();
-                    debug!(?alloc_id, ?offset);
-                    let unwrapped_ptr = Pointer { offset, provenance: alloc_id.unwrap() };
+                    let len = valtree.unwrap_branch().len();
                     let len_scalar = ScalarMaybeUninit::Scalar(Scalar::from_u64(len as u64));
 
-                    let imm = Immediate::ScalarPair(
-                        ScalarMaybeUninit::from_pointer(unwrapped_ptr, &tcx),
+                    Immediate::ScalarPair(
+                        ScalarMaybeUninit::from_maybe_pointer((*pointee_place).ptr, &tcx),
                         len_scalar,
-                    );
-                    debug!(?imm);
-
-                    // Now write the ScalarPair into the original place we wanted to fill
-                    // in this call
-                    let _ = ecx.write_immediate(imm, &(*place).into()).unwrap();
-
-                    dump_place(&ecx, (*place).into());
+                    )
                 }
-                _ => {
-                    let mut pointee_place =
-                        create_mplace_from_layout(ecx, ty::ParamEnv::empty().and(*inner_ty));
-                    debug!(?pointee_place);
-                    fill_place_recursively(ecx, &mut pointee_place, valtree, *inner_ty);
+                _ => pointee_place.to_ref(&tcx),
+            };
+            debug!(?imm);
 
-                    dump_place(ecx, pointee_place.into());
-                    intern_const_alloc_recursive(ecx, InternKind::Constant, &pointee_place)
-                        .unwrap();
-
-                    let imm = pointee_place.mplace.to_ref(&tcx);
-                    debug!(?imm);
-
-                    ecx.write_immediate(imm, &(*place).into()).unwrap();
-                }
-            }
+            ecx.write_immediate(imm, &(*place).into()).unwrap();
         }
-        ty::Tuple(tuple_types) => {
+        ty::Adt(_, _) | ty::Tuple(_) | ty::Array(_, _) | ty::Str => {
             let branches = valtree.unwrap_branch();
-            assert_eq!(tuple_types.len(), branches.len());
 
+            // Need to downcast place for enums
+            let (place_adjusted, branches, variant_idx) = match ty.kind() {
+                ty::Adt(def, _) if def.is_enum() => {
+                    // First element of valtree corresponds to variant
+                    let scalar_int = branches[0].unwrap_leaf();
+                    let variant_idx = VariantIdx::from_u32(scalar_int.try_to_u32().unwrap());
+                    let variant = def.variant(variant_idx);
+                    debug!(?variant);
+
+                    (
+                        place.project_downcast(ecx, variant_idx).unwrap(),
+                        &branches[1..],
+                        Some(variant_idx),
+                    )
+                }
+                _ => (*place, branches, None),
+            };
+            debug!(?place_adjusted, ?branches);
+
+            // Create the places for the fields and fill them recursively
             for (i, inner_valtree) in branches.iter().enumerate() {
                 debug!(?i, ?inner_valtree);
-                let inner_ty = tuple_types.get(i).expect(&format!(
-                    "expected to be able to index at position {} into {:?}",
-                    i, tuple_types
-                ));
-                debug!(?inner_ty);
 
-                // Create the mplace for the tuple element
-                let mut place_inner = ecx.mplace_field(place, i).unwrap();
+                let mut place_inner = match *ty.kind() {
+                    ty::Adt(def, substs) if !def.is_enum() => {
+                        let field = &def.variant(VariantIdx::from_usize(0)).fields[i];
+                        let field_ty = field.ty(tcx, substs);
+                        let projection_elem = ProjectionElem::Field(Field::from_usize(i), field_ty);
+
+                        ecx.mplace_projection(&place_adjusted, projection_elem).unwrap()
+                    }
+                    ty::Adt(_, _) | ty::Tuple(_) => ecx.mplace_field(&place_adjusted, i).unwrap(),
+                    ty::Array(_, _) | ty::Str => {
+                        ecx.mplace_index(&place_adjusted, i as u64).unwrap()
+                    }
+                    _ => bug!(),
+                };
                 debug!(?place_inner);
 
                 // insert valtree corresponding to tuple element into place
-                fill_place_recursively(ecx, &mut place_inner, *inner_valtree, *inner_ty);
-            }
-        }
-        ty::Array(inner_ty, _) => {
-            let inner_valtrees = valtree.unwrap_branch();
-            for (i, inner_valtree) in inner_valtrees.iter().enumerate() {
-                debug!(?i, ?inner_valtree);
-
-                let mut place_inner = ecx.mplace_field(place, i).unwrap();
-                debug!(?place_inner);
-
-                fill_place_recursively(ecx, &mut place_inner, *inner_valtree, *inner_ty)
-            }
-        }
-        ty::Adt(def, substs) if def.is_enum() => {
-            debug!("enum, substs: {:?}", substs);
-            let inner_valtrees = valtree.unwrap_branch();
-
-            // First element of valtree corresponds to variant
-            let scalar_int = inner_valtrees[0].unwrap_leaf();
-            let variant_idx = VariantIdx::from_u32(scalar_int.try_to_u32().unwrap());
-            let variant = def.variant(variant_idx);
-            debug!(?variant);
-
-            // Need to downcast place
-            let place_downcast = place.project_downcast(ecx, variant_idx).unwrap();
-            debug!(?place_downcast);
-
-            // fill `place_downcast` with the valtree elements corresponding to
-            // the fields of the enum
-            let fields = &variant.fields;
-            let inner_valtrees = &inner_valtrees[1..];
-            for (i, field) in fields.iter().enumerate() {
-                debug!(?i, ?field);
-
-                let field_ty = field.ty(tcx, substs);
-                debug!(?field_ty);
-
-                let mut field_mplace = ecx.mplace_field(&place_downcast, i).unwrap();
-                debug!(?field_mplace);
-                let inner_valtree = inner_valtrees[i];
-
-                fill_place_recursively(ecx, &mut field_mplace, inner_valtree, field_ty);
-                dump_place(&ecx, field_mplace.into());
+                fill_place_recursively(ecx, &mut place_inner, *inner_valtree);
+                dump_place(&ecx, place_inner.into());
             }
 
-            debug!("dump of place_downcast");
-            dump_place(ecx, place_downcast.into());
+            debug!("dump of place_adjusted:");
+            dump_place(ecx, place_adjusted.into());
 
-            // don't forget filling the place with the discriminant of the enum
-            ecx.write_discriminant(variant_idx, &(*place).into()).unwrap();
+            if let Some(variant_idx) = variant_idx {
+                // don't forget filling the place with the discriminant of the enum
+                ecx.write_discriminant(variant_idx, &(*place).into()).unwrap();
+            }
+
             dump_place(ecx, (*place).into());
         }
-        ty::Adt(def, substs) => {
-            debug!("Adt def: {:?} with substs: {:?}", def, substs);
-            let inner_valtrees = valtree.unwrap_branch();
-            debug!(?inner_valtrees);
-            let (fields, inner_valtrees) =
-                (&def.variant(VariantIdx::from_usize(0)).fields[..], inner_valtrees);
-
-            debug!("fields: {:?}", fields);
-
-            for (i, field) in fields.iter().enumerate() {
-                let field_ty = field.ty(tcx, substs);
-                debug!(?field_ty);
-                let old_field_ty = tcx.type_of(field.did);
-                debug!(?old_field_ty);
-                let projection_elem = ProjectionElem::Field(Field::from_usize(i), field_ty);
-                let mut field_place = ecx.mplace_projection(place, projection_elem).unwrap();
-                let inner_valtree = inner_valtrees[i];
-
-                fill_place_recursively(ecx, &mut field_place, inner_valtree, field_ty);
-            }
-        }
-        _ => {}
+        _ => bug!("shouldn't have created a ValTree for {:?}", ty),
     }
 }
 
 fn dump_place<'tcx>(ecx: &CompileTimeEvalContext<'tcx, 'tcx>, place: PlaceTy<'tcx>) {
-    trace!("{:?}", ecx.dump_place(place.place));
+    trace!("{:?}", ecx.dump_place(*place));
 }

--- a/compiler/rustc_const_eval/src/const_eval/valtrees.rs
+++ b/compiler/rustc_const_eval/src/const_eval/valtrees.rs
@@ -1,0 +1,479 @@
+use super::eval_queries::{mk_eval_cx, op_to_const};
+use super::machine::CompileTimeEvalContext;
+use crate::interpret::{
+    intern_const_alloc_recursive, ConstValue, ImmTy, Immediate, InternKind, MemoryKind, PlaceTy,
+    Pointer, Scalar, ScalarMaybeUninit,
+};
+use rustc_middle::mir::interpret::{ConstAlloc, GlobalAlloc};
+use rustc_middle::mir::{Field, ProjectionElem};
+use rustc_middle::ty::{self, ScalarInt, Ty, TyCtxt};
+use rustc_span::source_map::DUMMY_SP;
+use rustc_target::abi::VariantIdx;
+
+use crate::interpret::visitor::Value;
+use crate::interpret::MPlaceTy;
+
+/// Convert an evaluated constant to a type level constant
+#[instrument(skip(tcx), level = "debug")]
+pub(crate) fn const_to_valtree<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    param_env: ty::ParamEnv<'tcx>,
+    raw: ConstAlloc<'tcx>,
+) -> Option<ty::ValTree<'tcx>> {
+    let ecx = mk_eval_cx(
+        tcx, DUMMY_SP, param_env,
+        // It is absolutely crucial for soundness that
+        // we do not read from static items or other mutable memory.
+        false,
+    );
+    let place = ecx.raw_const_to_mplace(raw).unwrap();
+    const_to_valtree_inner(&ecx, &place)
+}
+
+#[instrument(skip(ecx), level = "debug")]
+fn branches<'tcx>(
+    ecx: &CompileTimeEvalContext<'tcx, 'tcx>,
+    place: &MPlaceTy<'tcx>,
+    n: usize,
+    variant: Option<VariantIdx>,
+) -> Option<ty::ValTree<'tcx>> {
+    let place = match variant {
+        Some(variant) => ecx.mplace_downcast(&place, variant).unwrap(),
+        None => *place,
+    };
+    let variant = variant.map(|variant| Some(ty::ValTree::Leaf(ScalarInt::from(variant.as_u32()))));
+    debug!(?place, ?variant);
+
+    let fields = (0..n).map(|i| {
+        let field = ecx.mplace_field(&place, i).unwrap();
+        const_to_valtree_inner(ecx, &field)
+    });
+    // For enums, we preped their variant index before the variant's fields so we can figure out
+    // the variant again when just seeing a valtree.
+    let branches = variant.into_iter().chain(fields);
+    Some(ty::ValTree::Branch(ecx.tcx.arena.alloc_from_iter(branches.collect::<Option<Vec<_>>>()?)))
+}
+
+fn slice_branches<'tcx>(
+    ecx: &CompileTimeEvalContext<'tcx, 'tcx>,
+    place: &MPlaceTy<'tcx>,
+) -> Option<ty::ValTree<'tcx>> {
+    let n = place.len(&ecx.tcx.tcx).expect(&format!("expected to use len of place {:?}", place));
+    let branches = (0..n).map(|i| {
+        let place_elem = ecx.mplace_index(place, i).unwrap();
+        const_to_valtree_inner(ecx, &place_elem)
+    });
+
+    Some(ty::ValTree::Branch(ecx.tcx.arena.alloc_from_iter(branches.collect::<Option<Vec<_>>>()?)))
+}
+
+#[instrument(skip(ecx), level = "debug")]
+fn const_to_valtree_inner<'tcx>(
+    ecx: &CompileTimeEvalContext<'tcx, 'tcx>,
+    place: &MPlaceTy<'tcx>,
+) -> Option<ty::ValTree<'tcx>> {
+    match place.layout.ty.kind() {
+        ty::FnDef(..) => Some(ty::ValTree::zst()),
+        ty::Bool | ty::Int(_) | ty::Uint(_) | ty::Float(_) | ty::Char => {
+            let val = ecx.read_immediate(&place.into()).unwrap();
+            let val = val.to_scalar().unwrap();
+            Some(ty::ValTree::Leaf(val.assert_int()))
+        }
+
+        // Raw pointers are not allowed in type level constants, as we cannot properly test them for
+        // equality at compile-time (see `ptr_guaranteed_eq`/`_ne`).
+        // Technically we could allow function pointers (represented as `ty::Instance`), but this is not guaranteed to
+        // agree with runtime equality tests.
+        ty::FnPtr(_) | ty::RawPtr(_) => None,
+
+        ty::Ref(_, _, _)  => {
+            let derefd_place = ecx.deref_operand(&place.into()).unwrap_or_else(|e| bug!("couldn't deref {:?}, error: {:?}", place, e));
+            debug!(?derefd_place);
+
+            const_to_valtree_inner(ecx, &derefd_place)
+        }
+
+        ty::Str | ty::Slice(_) | ty::Array(_, _) => {
+            let valtree = slice_branches(ecx, place);
+            debug!(?valtree);
+
+            valtree
+        }
+        // Trait objects are not allowed in type level constants, as we have no concept for
+        // resolving their backing type, even if we can do that at const eval time. We may
+        // hypothetically be able to allow `dyn StructuralEq` trait objects in the future,
+        // but it is unclear if this is useful.
+        ty::Dynamic(..) => None,
+
+        ty::Tuple(substs) => branches(ecx, place, substs.len(), None),
+
+        ty::Adt(def, _) => {
+            if def.variants().is_empty() {
+                bug!("uninhabited types should have errored and never gotten converted to valtree")
+            }
+
+            let variant = ecx.read_discriminant(&place.into()).unwrap().1;
+
+            branches(ecx, place, def.variant(variant).fields.len(), def.is_enum().then_some(variant))
+        }
+
+        ty::Never
+        | ty::Error(_)
+        | ty::Foreign(..)
+        | ty::Infer(ty::FreshIntTy(_))
+        | ty::Infer(ty::FreshFloatTy(_))
+        | ty::Projection(..)
+        | ty::Param(_)
+        | ty::Bound(..)
+        | ty::Placeholder(..)
+        // FIXME(oli-obk): we could look behind opaque types
+        | ty::Opaque(..)
+        | ty::Infer(_)
+        // FIXME(oli-obk): we can probably encode closures just like structs
+        | ty::Closure(..)
+        | ty::Generator(..)
+        | ty::GeneratorWitness(..) => None,
+    }
+}
+
+#[instrument(skip(ecx), level = "debug")]
+fn create_mplace_from_layout<'tcx>(
+    ecx: &mut CompileTimeEvalContext<'tcx, 'tcx>,
+    param_env_ty: ty::ParamEnvAnd<'tcx, Ty<'tcx>>,
+) -> MPlaceTy<'tcx> {
+    let tcx = ecx.tcx;
+    let layout = tcx.layout_of(param_env_ty).unwrap();
+    debug!(?layout);
+
+    ecx.allocate(layout, MemoryKind::Stack).unwrap()
+}
+
+/// Converts a `ValTree` to a `ConstValue`, which is needed after mir
+/// construction has finished.
+#[instrument(skip(tcx), level = "debug")]
+pub fn valtree_to_const_value<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    param_env_ty: ty::ParamEnvAnd<'tcx, Ty<'tcx>>,
+    valtree: ty::ValTree<'tcx>,
+) -> ConstValue<'tcx> {
+    // Basic idea: We directly construct `Scalar` values from trivial `ValTree`s
+    // (those for constants with type bool, int, uint, float or char).
+    // For all other types we create an `MPlace` and fill that by walking
+    // the `ValTree` and using `place_projection` and `place_field` to
+    // create inner `MPlace`s which are filled recursively.
+    // FIXME Does this need an example?
+
+    let (param_env, ty) = param_env_ty.into_parts();
+    let mut ecx = mk_eval_cx(tcx, DUMMY_SP, param_env, false);
+
+    match ty.kind() {
+        ty::Bool | ty::Int(_) | ty::Uint(_) | ty::Float(_) | ty::Char => match valtree {
+            ty::ValTree::Leaf(scalar_int) => ConstValue::Scalar(Scalar::Int(scalar_int)),
+            ty::ValTree::Branch(_) => bug!(
+                "ValTrees for Bool, Int, Uint, Float or Char should have the form ValTree::Leaf"
+            ),
+        },
+        ty::Ref(_, inner_ty, _) => {
+            match inner_ty.kind() {
+                ty::Slice(_) | ty::Str => {
+                    let slice_ty = match inner_ty.kind() {
+                        ty::Slice(slice_ty) => *slice_ty,
+                        ty::Str => tcx.mk_ty(ty::Uint(ty::UintTy::U8)),
+                        _ => bug!("expected ty::Slice | ty::Str"),
+                    };
+                    debug!(?slice_ty);
+
+                    let valtrees = valtree.unwrap_branch();
+
+                    // Create a place for the underlying array
+                    let len = valtrees.len();
+                    let arr_ty = tcx.mk_array(slice_ty, len as u64);
+                    let mut place =
+                        create_mplace_from_layout(&mut ecx, ty::ParamEnv::empty().and(arr_ty));
+                    debug!(?place);
+
+                    // Insert elements of `arr_valtree` into `place`
+                    fill_place_recursively(&mut ecx, &mut place, valtree, arr_ty);
+                    dump_place(&ecx, place.into());
+
+                    // The allocation behind `place` is local, we need to intern it
+                    intern_const_alloc_recursive(&mut ecx, InternKind::Constant, &place).unwrap();
+
+                    // Now we need to get the Allocation
+                    let alloc_id = place.mplace.ptr.provenance.unwrap();
+                    debug!(?alloc_id);
+
+                    let data = match tcx.get_global_alloc(alloc_id) {
+                        Some(GlobalAlloc::Memory(const_alloc)) => const_alloc,
+                        _ => bug!("expected memory allocation"),
+                    };
+                    debug!(?data);
+
+                    return ConstValue::Slice { data, start: 0, end: len as usize };
+                }
+                _ => {
+                    match valtree {
+                        ty::ValTree::Branch(_) => {
+                            // create a place for the pointee
+                            let mut place = create_mplace_from_layout(
+                                &mut ecx,
+                                ty::ParamEnv::empty().and(*inner_ty),
+                            );
+                            debug!(?place);
+
+                            // insert elements of valtree into `place`
+                            fill_place_recursively(&mut ecx, &mut place, valtree, *inner_ty);
+                            dump_place(&ecx, place.into());
+                            intern_const_alloc_recursive(&mut ecx, InternKind::Constant, &place)
+                                .unwrap();
+
+                            let ref_place = place.mplace.to_ref(&tcx);
+                            let imm = ImmTy::from_immediate(
+                                ref_place,
+                                tcx.layout_of(param_env_ty).unwrap(),
+                            );
+
+                            let const_val = op_to_const(&ecx, &imm.into());
+                            debug!(?const_val);
+
+                            const_val
+                        }
+                        ty::ValTree::Leaf(_) => {
+                            let mut place = create_mplace_from_layout(
+                                &mut ecx,
+                                ty::ParamEnv::empty().and(*inner_ty),
+                            );
+
+                            fill_place_recursively(&mut ecx, &mut place, valtree, *inner_ty);
+                            dump_place(&ecx, place.into());
+
+                            let ref_place = place.mplace.to_ref(&tcx);
+                            let imm = ImmTy::from_immediate(
+                                ref_place,
+                                tcx.layout_of(param_env_ty).unwrap(),
+                            );
+
+                            op_to_const(&ecx, &imm.into())
+                        }
+                    }
+                }
+            }
+        }
+        ty::Tuple(_) | ty::Array(_, _) | ty::Adt(..) => {
+            let mut place = create_mplace_from_layout(&mut ecx, param_env_ty);
+            debug!(?place);
+
+            fill_place_recursively(&mut ecx, &mut place, valtree, ty);
+            dump_place(&ecx, place.into());
+            intern_const_alloc_recursive(&mut ecx, InternKind::Constant, &place).unwrap();
+
+            let const_val = op_to_const(&ecx, &place.into());
+            debug!(?const_val);
+
+            const_val
+        }
+        ty::Never
+        | ty::FnDef(..)
+        | ty::Error(_)
+        | ty::Foreign(..)
+        | ty::Infer(ty::FreshIntTy(_))
+        | ty::Infer(ty::FreshFloatTy(_))
+        | ty::Projection(..)
+        | ty::Param(_)
+        | ty::Bound(..)
+        | ty::Placeholder(..)
+        | ty::Opaque(..)
+        | ty::Infer(_)
+        | ty::Closure(..)
+        | ty::Generator(..)
+        | ty::GeneratorWitness(..)
+        | ty::FnPtr(_)
+        | ty::RawPtr(_)
+        | ty::Str
+        | ty::Slice(_)
+        | ty::Dynamic(..) => bug!("no ValTree should have been created for type {:?}", ty.kind()),
+    }
+}
+
+// FIXME Needs a better/correct name
+#[instrument(skip(ecx), level = "debug")]
+fn fill_place_recursively<'tcx>(
+    ecx: &mut CompileTimeEvalContext<'tcx, 'tcx>,
+    place: &mut MPlaceTy<'tcx>,
+    valtree: ty::ValTree<'tcx>,
+    ty: Ty<'tcx>,
+) {
+    // This will match on valtree and write the value(s) corresponding to the ValTree
+    // inside the place recursively.
+
+    let tcx = ecx.tcx.tcx;
+
+    match ty.kind() {
+        ty::Bool | ty::Int(_) | ty::Uint(_) | ty::Float(_) | ty::Char => {
+            let scalar_int = valtree.unwrap_leaf();
+            debug!("writing trivial valtree {:?} to place {:?}", scalar_int, place);
+            ecx.write_immediate(
+                Immediate::Scalar(ScalarMaybeUninit::Scalar(scalar_int.into())),
+                &(*place).into(),
+            )
+            .unwrap();
+        }
+        ty::Ref(_, inner_ty, _) => {
+            match inner_ty.kind() {
+                ty::Slice(_) | ty::Str => {
+                    let slice_ty = match inner_ty.kind() {
+                        ty::Slice(slice_ty) => *slice_ty,
+                        ty::Str => tcx.mk_ty(ty::Uint(ty::UintTy::U8)),
+                        _ => bug!("expected ty::Slice | ty::Str"),
+                    };
+                    debug!(?slice_ty);
+
+                    let valtrees = valtree.unwrap_branch();
+                    debug!(?valtrees);
+                    let len = valtrees.len();
+                    debug!(?len);
+
+                    // create a place for the underlying array
+                    let arr_ty = tcx.mk_array(slice_ty, len as u64);
+                    let mut arr_place =
+                        create_mplace_from_layout(ecx, ty::ParamEnv::empty().and(arr_ty));
+                    debug!(?arr_place);
+
+                    // Insert elements of `arr_valtree` into `place`
+                    fill_place_recursively(ecx, &mut arr_place, valtree, arr_ty);
+                    dump_place(&ecx, arr_place.into());
+
+                    // Now we need to create a `ScalarPair` from the filled `place`
+                    // and write that into `place`
+                    let (alloc_id, offset) = arr_place.mplace.ptr.into_parts();
+                    debug!(?alloc_id, ?offset);
+                    let unwrapped_ptr = Pointer { offset, provenance: alloc_id.unwrap() };
+                    let len_scalar = ScalarMaybeUninit::Scalar(Scalar::from_u64(len as u64));
+
+                    let imm = Immediate::ScalarPair(
+                        ScalarMaybeUninit::from_pointer(unwrapped_ptr, &tcx),
+                        len_scalar,
+                    );
+                    debug!(?imm);
+
+                    // Now write the ScalarPair into the original place we wanted to fill
+                    // in this call
+                    let _ = ecx.write_immediate(imm, &(*place).into()).unwrap();
+
+                    dump_place(&ecx, (*place).into());
+                }
+                _ => {
+                    let mut pointee_place =
+                        create_mplace_from_layout(ecx, ty::ParamEnv::empty().and(*inner_ty));
+                    debug!(?pointee_place);
+                    fill_place_recursively(ecx, &mut pointee_place, valtree, *inner_ty);
+
+                    dump_place(ecx, pointee_place.into());
+                    intern_const_alloc_recursive(ecx, InternKind::Constant, &pointee_place)
+                        .unwrap();
+
+                    let imm = pointee_place.mplace.to_ref(&tcx);
+                    debug!(?imm);
+
+                    ecx.write_immediate(imm, &(*place).into()).unwrap();
+                }
+            }
+        }
+        ty::Tuple(tuple_types) => {
+            let branches = valtree.unwrap_branch();
+            assert_eq!(tuple_types.len(), branches.len());
+
+            for (i, inner_valtree) in branches.iter().enumerate() {
+                debug!(?i, ?inner_valtree);
+                let inner_ty = tuple_types.get(i).expect(&format!(
+                    "expected to be able to index at position {} into {:?}",
+                    i, tuple_types
+                ));
+                debug!(?inner_ty);
+
+                // Create the mplace for the tuple element
+                let mut place_inner = ecx.mplace_field(place, i).unwrap();
+                debug!(?place_inner);
+
+                // insert valtree corresponding to tuple element into place
+                fill_place_recursively(ecx, &mut place_inner, *inner_valtree, *inner_ty);
+            }
+        }
+        ty::Array(inner_ty, _) => {
+            let inner_valtrees = valtree.unwrap_branch();
+            for (i, inner_valtree) in inner_valtrees.iter().enumerate() {
+                debug!(?i, ?inner_valtree);
+
+                let mut place_inner = ecx.mplace_field(place, i).unwrap();
+                debug!(?place_inner);
+
+                fill_place_recursively(ecx, &mut place_inner, *inner_valtree, *inner_ty)
+            }
+        }
+        ty::Adt(def, substs) if def.is_enum() => {
+            debug!("enum, substs: {:?}", substs);
+            let inner_valtrees = valtree.unwrap_branch();
+
+            // First element of valtree corresponds to variant
+            let scalar_int = inner_valtrees[0].unwrap_leaf();
+            let variant_idx = VariantIdx::from_u32(scalar_int.try_to_u32().unwrap());
+            let variant = def.variant(variant_idx);
+            debug!(?variant);
+
+            // Need to downcast place
+            let place_downcast = place.project_downcast(ecx, variant_idx).unwrap();
+            debug!(?place_downcast);
+
+            // fill `place_downcast` with the valtree elements corresponding to
+            // the fields of the enum
+            let fields = &variant.fields;
+            let inner_valtrees = &inner_valtrees[1..];
+            for (i, field) in fields.iter().enumerate() {
+                debug!(?i, ?field);
+
+                let field_ty = field.ty(tcx, substs);
+                debug!(?field_ty);
+
+                let mut field_mplace = ecx.mplace_field(&place_downcast, i).unwrap();
+                debug!(?field_mplace);
+                let inner_valtree = inner_valtrees[i];
+
+                fill_place_recursively(ecx, &mut field_mplace, inner_valtree, field_ty);
+                dump_place(&ecx, field_mplace.into());
+            }
+
+            debug!("dump of place_downcast");
+            dump_place(ecx, place_downcast.into());
+
+            // don't forget filling the place with the discriminant of the enum
+            ecx.write_discriminant(variant_idx, &(*place).into()).unwrap();
+            dump_place(ecx, (*place).into());
+        }
+        ty::Adt(def, substs) => {
+            debug!("Adt def: {:?} with substs: {:?}", def, substs);
+            let inner_valtrees = valtree.unwrap_branch();
+            debug!(?inner_valtrees);
+            let (fields, inner_valtrees) =
+                (&def.variant(VariantIdx::from_usize(0)).fields[..], inner_valtrees);
+
+            debug!("fields: {:?}", fields);
+
+            for (i, field) in fields.iter().enumerate() {
+                let field_ty = field.ty(tcx, substs);
+                debug!(?field_ty);
+                let old_field_ty = tcx.type_of(field.did);
+                debug!(?old_field_ty);
+                let projection_elem = ProjectionElem::Field(Field::from_usize(i), field_ty);
+                let mut field_place = ecx.mplace_projection(place, projection_elem).unwrap();
+                let inner_valtree = inner_valtrees[i];
+
+                fill_place_recursively(ecx, &mut field_place, inner_valtree, field_ty);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn dump_place<'tcx>(ecx: &CompileTimeEvalContext<'tcx, 'tcx>, place: PlaceTy<'tcx>) {
+    trace!("{:?}", ecx.dump_place(place.place));
+}

--- a/compiler/rustc_const_eval/src/interpret/mod.rs
+++ b/compiler/rustc_const_eval/src/interpret/mod.rs
@@ -14,7 +14,7 @@ mod terminator;
 mod traits;
 mod util;
 mod validity;
-mod visitor;
+pub(crate) mod visitor;
 
 pub use rustc_middle::mir::interpret::*; // have all the `interpret` symbols in one place: here
 

--- a/compiler/rustc_const_eval/src/interpret/mod.rs
+++ b/compiler/rustc_const_eval/src/interpret/mod.rs
@@ -14,7 +14,7 @@ mod terminator;
 mod traits;
 mod util;
 mod validity;
-pub(crate) mod visitor;
+mod visitor;
 
 pub use rustc_middle::mir::interpret::*; // have all the `interpret` symbols in one place: here
 
@@ -27,7 +27,7 @@ pub use self::memory::{AllocCheck, AllocRef, AllocRefMut, FnVal, Memory, MemoryK
 pub use self::operand::{ImmTy, Immediate, OpTy, Operand};
 pub use self::place::{MPlaceTy, MemPlace, MemPlaceMeta, Place, PlaceTy};
 pub use self::validity::{CtfeValidationMode, RefTracking};
-pub use self::visitor::{MutValueVisitor, ValueVisitor};
+pub use self::visitor::{MutValueVisitor, Value, ValueVisitor};
 
 crate use self::intrinsics::eval_nullary_intrinsic;
 use eval_context::{from_known_layout, mir_assign_valid_types};

--- a/compiler/rustc_const_eval/src/interpret/operand.rs
+++ b/compiler/rustc_const_eval/src/interpret/operand.rs
@@ -98,7 +98,7 @@ impl<'tcx, Tag: Provenance> Immediate<Tag> {
 // as input for binary and cast operations.
 #[derive(Copy, Clone, Debug)]
 pub struct ImmTy<'tcx, Tag: Provenance = AllocId> {
-    imm: Immediate<Tag>,
+    pub imm: Immediate<Tag>,
     pub layout: TyAndLayout<'tcx>,
 }
 
@@ -248,7 +248,7 @@ impl<'tcx, Tag: Provenance> ImmTy<'tcx, Tag> {
 impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
     /// Try reading an immediate in memory; this is interesting particularly for `ScalarPair`.
     /// Returns `None` if the layout does not permit loading this as a value.
-    fn try_read_immediate_from_mplace(
+    pub(crate) fn try_read_immediate_from_mplace(
         &self,
         mplace: &MPlaceTy<'tcx, M::PointerTag>,
     ) -> InterpResult<'tcx, Option<ImmTy<'tcx, M::PointerTag>>> {
@@ -424,6 +424,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
         })
     }
 
+    #[instrument(skip(self), level = "debug")]
     pub fn operand_projection(
         &self,
         base: &OpTy<'tcx, M::PointerTag>,

--- a/compiler/rustc_const_eval/src/interpret/operand.rs
+++ b/compiler/rustc_const_eval/src/interpret/operand.rs
@@ -98,7 +98,7 @@ impl<'tcx, Tag: Provenance> Immediate<Tag> {
 // as input for binary and cast operations.
 #[derive(Copy, Clone, Debug)]
 pub struct ImmTy<'tcx, Tag: Provenance = AllocId> {
-    pub imm: Immediate<Tag>,
+    imm: Immediate<Tag>,
     pub layout: TyAndLayout<'tcx>,
 }
 
@@ -248,7 +248,7 @@ impl<'tcx, Tag: Provenance> ImmTy<'tcx, Tag> {
 impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
     /// Try reading an immediate in memory; this is interesting particularly for `ScalarPair`.
     /// Returns `None` if the layout does not permit loading this as a value.
-    pub(crate) fn try_read_immediate_from_mplace(
+    fn try_read_immediate_from_mplace(
         &self,
         mplace: &MPlaceTy<'tcx, M::PointerTag>,
     ) -> InterpResult<'tcx, Option<ImmTy<'tcx, M::PointerTag>>> {

--- a/compiler/rustc_const_eval/src/interpret/place.rs
+++ b/compiler/rustc_const_eval/src/interpret/place.rs
@@ -115,6 +115,12 @@ impl<'tcx, Tag: Provenance> std::ops::Deref for MPlaceTy<'tcx, Tag> {
     }
 }
 
+impl<'tcx, Tag: Provenance> std::ops::DerefMut for MPlaceTy<'tcx, Tag> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.mplace
+    }
+}
+
 impl<'tcx, Tag: Provenance> From<MPlaceTy<'tcx, Tag>> for PlaceTy<'tcx, Tag> {
     #[inline(always)]
     fn from(mplace: MPlaceTy<'tcx, Tag>) -> Self {

--- a/compiler/rustc_const_eval/src/lib.rs
+++ b/compiler/rustc_const_eval/src/lib.rs
@@ -35,6 +35,7 @@ pub mod transform;
 pub mod util;
 
 use rustc_middle::ty::query::Providers;
+use rustc_middle::ty::ParamEnv;
 
 pub fn provide(providers: &mut Providers) {
     const_eval::provide(providers);
@@ -48,6 +49,9 @@ pub fn provide(providers: &mut Providers) {
     providers.const_to_valtree = |tcx, param_env_and_value| {
         let (param_env, raw) = param_env_and_value.into_parts();
         const_eval::const_to_valtree(tcx, param_env, raw)
+    };
+    providers.valtree_to_const_val = |tcx, (ty, valtree)| {
+        const_eval::valtree_to_const_value(tcx, ParamEnv::empty().and(ty), valtree)
     };
     providers.deref_const = |tcx, param_env_and_value| {
         let (param_env, value) = param_env_and_value.into_parts();

--- a/compiler/rustc_middle/src/mir/interpret/allocation.rs
+++ b/compiler/rustc_middle/src/mir/interpret/allocation.rs
@@ -433,7 +433,6 @@ impl<Tag: Provenance, Extra> Allocation<Tag, Extra> {
                 return self.write_uninit(cx, range);
             }
         };
-        debug!(?val);
 
         // `to_bits_or_ptr_internal` is the right method because we just want to store this data
         // as-is into memory.
@@ -444,16 +443,13 @@ impl<Tag: Provenance, Extra> Allocation<Tag, Extra> {
             }
             Ok(data) => (data, None),
         };
-        debug!(?bytes, ?provenance);
 
         let endian = cx.data_layout().endian;
         let dst = self.get_bytes_mut(cx, range)?;
-        debug!(?dst);
         write_target_uint(endian, dst, bytes).unwrap();
 
         // See if we have to also write a relocation.
         if let Some(provenance) = provenance {
-            debug!("insert relocation for {:?}", provenance);
             self.relocations.0.insert(range.start, provenance);
         }
 

--- a/compiler/rustc_middle/src/mir/interpret/allocation.rs
+++ b/compiler/rustc_middle/src/mir/interpret/allocation.rs
@@ -418,6 +418,7 @@ impl<Tag: Provenance, Extra> Allocation<Tag, Extra> {
     ///
     /// It is the caller's responsibility to check bounds and alignment beforehand.
     /// Most likely, you want to call `InterpCx::write_scalar` instead of this method.
+    #[instrument(skip(self, cx), level = "debug")]
     pub fn write_scalar(
         &mut self,
         cx: &impl HasDataLayout,
@@ -432,6 +433,7 @@ impl<Tag: Provenance, Extra> Allocation<Tag, Extra> {
                 return self.write_uninit(cx, range);
             }
         };
+        debug!(?val);
 
         // `to_bits_or_ptr_internal` is the right method because we just want to store this data
         // as-is into memory.
@@ -442,13 +444,16 @@ impl<Tag: Provenance, Extra> Allocation<Tag, Extra> {
             }
             Ok(data) => (data, None),
         };
+        debug!(?bytes, ?provenance);
 
         let endian = cx.data_layout().endian;
         let dst = self.get_bytes_mut(cx, range)?;
+        debug!(?dst);
         write_target_uint(endian, dst, bytes).unwrap();
 
         // See if we have to also write a relocation.
         if let Some(provenance) = provenance {
+            debug!("insert relocation for {:?}", provenance);
             self.relocations.0.insert(range.start, provenance);
         }
 

--- a/compiler/rustc_middle/src/mir/interpret/pointer.rs
+++ b/compiler/rustc_middle/src/mir/interpret/pointer.rs
@@ -158,7 +158,7 @@ impl Provenance for AllocId {
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, TyEncodable, TyDecodable, Hash)]
 #[derive(HashStable)]
 pub struct Pointer<Tag = AllocId> {
-    pub(super) offset: Size, // kept private to avoid accidental misinterpretation (meaning depends on `Tag` type)
+    pub offset: Size, // FIXME This should probably be private
     pub provenance: Tag,
 }
 

--- a/compiler/rustc_middle/src/mir/interpret/pointer.rs
+++ b/compiler/rustc_middle/src/mir/interpret/pointer.rs
@@ -158,7 +158,7 @@ impl Provenance for AllocId {
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, TyEncodable, TyDecodable, Hash)]
 #[derive(HashStable)]
 pub struct Pointer<Tag = AllocId> {
-    pub offset: Size, // FIXME This should probably be private
+    pub(super) offset: Size, // kept private to avoid accidental misinterpretation (meaning depends on `Tag` type)
     pub provenance: Tag,
 }
 

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -936,6 +936,11 @@ rustc_queries! {
         remap_env_constness
     }
 
+    /// Converts a type level constant value into `ConstValue`
+    query valtree_to_const_val(key: (Ty<'tcx>, ty::ValTree<'tcx>)) -> ConstValue<'tcx> {
+        desc { "convert type-level constant value to mir constant value"}
+    }
+
     /// Destructure a constant ADT or array into its variant index and its
     /// field values or return `None` if constant is invalid.
     ///

--- a/compiler/rustc_middle/src/ty/consts/int.rs
+++ b/compiler/rustc_middle/src/ty/consts/int.rs
@@ -237,6 +237,98 @@ impl ScalarInt {
     pub fn try_to_machine_usize<'tcx>(&self, tcx: TyCtxt<'tcx>) -> Result<u64, Size> {
         Ok(self.to_bits(tcx.data_layout.pointer_size)? as u64)
     }
+
+    /// Tries to convert the `ScalarInt` to an unsigned integer of the given size.
+    /// Fails if the size of the `ScalarInt` is unequal to `size` and returns the
+    /// `ScalarInt`s size in that case.
+    #[inline]
+    pub fn try_to_uint(self, size: Size) -> Result<u128, Size> {
+        self.to_bits(size)
+    }
+
+    // Tries to convert the `ScalarInt` to `u8`. Fails if the `size` of the `ScalarInt`
+    // in not equal to `Size { raw: 1 }` and returns the `size` value of the `ScalarInt` in
+    // that case.
+    #[inline]
+    pub fn try_to_u8(self) -> Result<u8, Size> {
+        self.to_bits(Size::from_bits(8)).map(|v| u8::try_from(v).unwrap())
+    }
+
+    /// Tries to convert the `ScalarInt` to `u16`. Fails if the size of the `ScalarInt`
+    /// in not equal to `Size { raw: 2 }` and returns the `size` value of the `ScalarInt` in
+    /// that case.
+    #[inline]
+    pub fn try_to_u16(self) -> Result<u16, Size> {
+        self.to_bits(Size::from_bits(16)).map(|v| u16::try_from(v).unwrap())
+    }
+
+    /// Tries to convert the `ScalarInt` to `u32`. Fails if the `size` of the `ScalarInt`
+    /// in not equal to `Size { raw: 4 }` and returns the `size` value of the `ScalarInt` in
+    /// that case.
+    #[inline]
+    pub fn try_to_u32(self) -> Result<u32, Size> {
+        self.to_bits(Size::from_bits(32)).map(|v| u32::try_from(v).unwrap())
+    }
+
+    /// Tries to convert the `ScalarInt` to `u64`. Fails if the `size` of the `ScalarInt`
+    /// in not equal to `Size { raw: 8 }` and returns the `size` value of the `ScalarInt` in
+    /// that case.
+    #[inline]
+    pub fn try_to_u64(self) -> Result<u64, Size> {
+        self.to_bits(Size::from_bits(64)).map(|v| u64::try_from(v).unwrap())
+    }
+
+    /// Tries to convert the `ScalarInt` to `u128`. Fails if the `size` of the `ScalarInt`
+    /// in not equal to `Size { raw: 16 }` and returns the `size` value of the `ScalarInt` in
+    /// that case.
+    #[inline]
+    pub fn try_to_u128(self) -> Result<u128, Size> {
+        self.to_bits(Size::from_bits(128))
+    }
+
+    /// Tries to convert the `ScalarInt` to a signed integer of the given size.
+    /// Fails if the size of the `ScalarInt` is unequal to `size` and returns the
+    /// `ScalarInt`s size in that case.
+    #[inline]
+    pub fn try_to_int(self, size: Size) -> Result<i128, Size> {
+        let b = self.to_bits(size)?;
+        Ok(size.sign_extend(b) as i128)
+    }
+
+    /// Tries to convert the `ScalarInt` to i8.
+    /// Fails if the size of the `ScalarInt` is unequal to `Size { raw: 1 }`
+    /// and returns the `ScalarInt`s size in that case.
+    pub fn try_to_i8(self) -> Result<i8, Size> {
+        self.try_to_int(Size::from_bits(8)).map(|v| i8::try_from(v).unwrap())
+    }
+
+    /// Tries to convert the `ScalarInt` to i16.
+    /// Fails if the size of the `ScalarInt` is unequal to `Size { raw: 2 }`
+    /// and returns the `ScalarInt`s size in that case.
+    pub fn try_to_i16(self) -> Result<i16, Size> {
+        self.try_to_int(Size::from_bits(16)).map(|v| i16::try_from(v).unwrap())
+    }
+
+    /// Tries to convert the `ScalarInt` to i32.
+    /// Fails if the size of the `ScalarInt` is unequal to `Size { raw: 4 }`
+    /// and returns the `ScalarInt`s size in that case.
+    pub fn try_to_i32(self) -> Result<i32, Size> {
+        self.try_to_int(Size::from_bits(32)).map(|v| i32::try_from(v).unwrap())
+    }
+
+    /// Tries to convert the `ScalarInt` to i64.
+    /// Fails if the size of the `ScalarInt` is unequal to `Size { raw: 8 }`
+    /// and returns the `ScalarInt`s size in that case.
+    pub fn try_to_i64(self) -> Result<i64, Size> {
+        self.try_to_int(Size::from_bits(64)).map(|v| i64::try_from(v).unwrap())
+    }
+
+    /// Tries to convert the `ScalarInt` to i128.
+    /// Fails if the size of the `ScalarInt` is unequal to `Size { raw: 16 }`
+    /// and returns the `ScalarInt`s size in that case.
+    pub fn try_to_i128(self) -> Result<i128, Size> {
+        self.try_to_int(Size::from_bits(128)).map(|v| i128::try_from(v).unwrap())
+    }
 }
 
 macro_rules! from {

--- a/compiler/rustc_middle/src/ty/consts/valtree.rs
+++ b/compiler/rustc_middle/src/ty/consts/valtree.rs
@@ -31,4 +31,20 @@ impl<'tcx> ValTree<'tcx> {
     pub fn zst() -> Self {
         Self::Branch(&[])
     }
+
+    #[inline]
+    pub fn unwrap_leaf(self) -> ScalarInt {
+        match self {
+            Self::Leaf(s) => s,
+            _ => bug!("expected leaf, got {:?}", self),
+        }
+    }
+
+    #[inline]
+    pub fn unwrap_branch(self) -> &'tcx [Self] {
+        match self {
+            Self::Branch(branch) => branch,
+            _ => bug!("expected branch, got {:?}", self),
+        }
+    }
 }

--- a/compiler/rustc_middle/src/ty/consts/valtree.rs
+++ b/compiler/rustc_middle/src/ty/consts/valtree.rs
@@ -20,6 +20,9 @@ pub enum ValTree<'tcx> {
     /// See the `ScalarInt` documentation for how `ScalarInt` guarantees that equal values
     /// of these types have the same representation.
     Leaf(ScalarInt),
+
+    //SliceOrStr(ValSlice<'tcx>),
+    // dont use SliceOrStr for now
     /// The fields of any kind of aggregate. Structs, tuples and arrays are represented by
     /// listing their fields' values in order.
     /// Enums are represented by storing their discriminant as a field, followed by all

--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -2273,7 +2273,7 @@ impl<'tcx> Ty<'tcx> {
         tcx: TyCtxt<'tcx>,
         normalize: impl FnMut(Ty<'tcx>) -> Ty<'tcx>,
     ) -> (Ty<'tcx>, bool) {
-        let tail = tcx.struct_tail_with_normalize(self, normalize);
+        let tail = tcx.struct_tail_with_normalize(self, normalize, || {});
         match tail.kind() {
             // Sized types
             ty::Infer(ty::IntVar(_) | ty::FloatVar(_))

--- a/compiler/rustc_middle/src/ty/util.rs
+++ b/compiler/rustc_middle/src/ty/util.rs
@@ -220,7 +220,7 @@ impl<'tcx> TyCtxt<'tcx> {
         self,
         mut ty: Ty<'tcx>,
         mut normalize: impl FnMut(Ty<'tcx>) -> Ty<'tcx>,
-        // This is a hack that is currently used to allow us to walk a ValTree
+        // This is currently used to allow us to walk a ValTree
         // in lockstep with the type in order to get the ValTree branch that
         // corresponds to an unsized field.
         mut f: impl FnMut() -> (),

--- a/compiler/rustc_middle/src/ty/util.rs
+++ b/compiler/rustc_middle/src/ty/util.rs
@@ -187,7 +187,7 @@ impl<'tcx> TyCtxt<'tcx> {
     /// if input `ty` is not a structure at all.
     pub fn struct_tail_without_normalization(self, ty: Ty<'tcx>) -> Ty<'tcx> {
         let tcx = self;
-        tcx.struct_tail_with_normalize(ty, |ty| ty)
+        tcx.struct_tail_with_normalize(ty, |ty| ty, || {})
     }
 
     /// Returns the deeply last field of nested structures, or the same type if
@@ -203,7 +203,7 @@ impl<'tcx> TyCtxt<'tcx> {
         param_env: ty::ParamEnv<'tcx>,
     ) -> Ty<'tcx> {
         let tcx = self;
-        tcx.struct_tail_with_normalize(ty, |ty| tcx.normalize_erasing_regions(param_env, ty))
+        tcx.struct_tail_with_normalize(ty, |ty| tcx.normalize_erasing_regions(param_env, ty), || {})
     }
 
     /// Returns the deeply last field of nested structures, or the same type if
@@ -220,6 +220,10 @@ impl<'tcx> TyCtxt<'tcx> {
         self,
         mut ty: Ty<'tcx>,
         mut normalize: impl FnMut(Ty<'tcx>) -> Ty<'tcx>,
+        // This is a hack that is currently used to allow us to walk a ValTree
+        // in lockstep with the type in order to get the ValTree branch that
+        // corresponds to an unsized field.
+        mut f: impl FnMut() -> (),
     ) -> Ty<'tcx> {
         let recursion_limit = self.recursion_limit();
         for iteration in 0.. {
@@ -235,12 +239,16 @@ impl<'tcx> TyCtxt<'tcx> {
                         break;
                     }
                     match def.non_enum_variant().fields.last() {
-                        Some(f) => ty = f.ty(self, substs),
+                        Some(field) => {
+                            f();
+                            ty = field.ty(self, substs);
+                        }
                         None => break,
                     }
                 }
 
                 ty::Tuple(tys) if let Some((&last_ty, _)) = tys.split_last() => {
+                    f();
                     ty = last_ty;
                 }
 

--- a/compiler/rustc_query_impl/src/keys.rs
+++ b/compiler/rustc_query_impl/src/keys.rs
@@ -502,3 +502,14 @@ impl<'tcx> Key for (ty::Instance<'tcx>, &'tcx ty::List<Ty<'tcx>>) {
         self.0.default_span(tcx)
     }
 }
+
+impl<'tcx> Key for (Ty<'tcx>, ty::ValTree<'tcx>) {
+    #[inline(always)]
+    fn query_crate_is_local(&self) -> bool {
+        true
+    }
+
+    fn default_span(&self, _: TyCtxt<'_>) -> Span {
+        DUMMY_SP
+    }
+}

--- a/compiler/rustc_trait_selection/src/traits/project.rs
+++ b/compiler/rustc_trait_selection/src/traits/project.rs
@@ -1519,18 +1519,22 @@ fn assemble_candidates_from_impls<'cx, 'tcx>(
                 // Any type with multiple potential metadata types is therefore not eligible.
                 let self_ty = selcx.infcx().shallow_resolve(obligation.predicate.self_ty());
 
-                let tail = selcx.tcx().struct_tail_with_normalize(self_ty, |ty| {
-                    // We throw away any obligations we get from this, since we normalize
-                    // and confirm these obligations once again during confirmation
-                    normalize_with_depth(
-                        selcx,
-                        obligation.param_env,
-                        obligation.cause.clone(),
-                        obligation.recursion_depth + 1,
-                        ty,
-                    )
-                    .value
-                });
+                let tail = selcx.tcx().struct_tail_with_normalize(
+                    self_ty,
+                    |ty| {
+                        // We throw away any obligations we get from this, since we normalize
+                        // and confirm these obligations once again during confirmation
+                        normalize_with_depth(
+                            selcx,
+                            obligation.param_env,
+                            obligation.cause.clone(),
+                            obligation.recursion_depth + 1,
+                            ty,
+                        )
+                        .value
+                    },
+                    || {},
+                );
 
                 match tail.kind() {
                     ty::Bool


### PR DESCRIPTION
Once we start to use `ValTree`s in the type system we will need to be able to convert them into `ConstValue` instances, which we want to continue to use after MIR construction.

r? @oli-obk 

cc @RalfJung 