### PR TITLE
Optimize `<SourceFile as Decodable>::decode`

### DIFF
--- a/compiler/rustc_span/src/lib.rs
+++ b/compiler/rustc_span/src/lib.rs
@@ -1319,24 +1319,18 @@ impl<D: Decoder> Decodable<D> for SourceFile {
                 lines.push(line_start);
 
                 match bytes_per_diff {
-                    1 => {
-                        for _ in 1..num_lines {
-                            line_start = line_start + BytePos(d.read_u8() as u32);
-                            lines.push(line_start);
-                        }
-                    }
-                    2 => {
-                        for _ in 1..num_lines {
-                            line_start = line_start + BytePos(d.read_u16() as u32);
-                            lines.push(line_start);
-                        }
-                    }
-                    4 => {
-                        for _ in 1..num_lines {
-                            line_start = line_start + BytePos(d.read_u32());
-                            lines.push(line_start);
-                        }
-                    }
+                    1 => lines.extend((1..num_lines).map(|_| {
+                        line_start = line_start + BytePos(d.read_u8() as u32);
+                        line_start
+                    })),
+                    2 => lines.extend((1..num_lines).map(|_| {
+                        line_start = line_start + BytePos(d.read_u16() as u32);
+                        line_start
+                    })),
+                    4 => lines.extend((1..num_lines).map(|_| {
+                        line_start = line_start + BytePos(d.read_u32());
+                        line_start
+                    })),
                     _ => unreachable!(),
                 }
             }

--- a/compiler/rustc_span/src/lib.rs
+++ b/compiler/rustc_span/src/lib.rs
@@ -1318,17 +1318,26 @@ impl<D: Decoder> Decodable<D> for SourceFile {
                 let mut line_start: BytePos = Decodable::decode(d);
                 lines.push(line_start);
 
-                for _ in 1..num_lines {
-                    let diff = match bytes_per_diff {
-                        1 => d.read_u8() as u32,
-                        2 => d.read_u16() as u32,
-                        4 => d.read_u32(),
-                        _ => unreachable!(),
-                    };
-
-                    line_start = line_start + BytePos(diff);
-
-                    lines.push(line_start);
+                match bytes_per_diff {
+                    1 => {
+                        for _ in 1..num_lines {
+                            line_start = line_start + BytePos(d.read_u8() as u32);
+                            lines.push(line_start);
+                        }
+                    }
+                    2 => {
+                        for _ in 1..num_lines {
+                            line_start = line_start + BytePos(d.read_u16() as u32);
+                            lines.push(line_start);
+                        }
+                    }
+                    4 => {
+                        for _ in 1..num_lines {
+                            line_start = line_start + BytePos(d.read_u32());
+                            lines.push(line_start);
+                        }
+                    }
+                    _ => unreachable!(),
                 }
             }
 


### PR DESCRIPTION
It showed up as a hot-ish function in a callgrind profile of the `await-call-tree` benchmark crate.

Provides some moderate speedups to compilation of some of the smaller benchmarks:

#### Primary benchmarks

Benchmark | Profile | Scenario | % Change | Significance Factor?
-- | -- | -- | -- | --
helloworld | check | full | -1.81% | 9.03x
helloworld | check | incr-unchanged | -1.80% | 8.99x
helloworld | check | incr-full | -1.59% | 7.97x
helloworld | check | incr-patched: println | -1.57% | 7.86x


#### Secondary benchmarks
<div class="category-title"></div>

Benchmark | Profile | Scenario | % Change | Significance Factor?
-- | -- | -- | -- | --
unify-linearly | check | incr-unchanged | -1.55% | 7.74x
unify-linearly | check | incr-patched: dummy fn | -1.42% | 7.08x
await-call-tree | check | incr-unchanged | -1.27% | 6.35x
await-call-tree | debug | incr-unchanged | -1.19% | 5.95x
await-call-tree | opt | incr-unchanged | -1.19% | 5.94x
issue-46449 | check | incr-unchanged | -1.08% | 5.39x
issue-46449 | check | incr-patched: u8 3072 | -1.00% | 5.00x
structopt-0.3.26 | check | incr-unchanged | -0.94% | 4.72x
structopt-0.3.26 | opt | incr-unchanged | -0.92% | 4.60x
structopt-0.3.26 | debug | incr-unchanged | -0.92% | 4.59x
issue-46449 | check | full | -0.89% | 4.46x
structopt-0.3.26 | check | full | -0.83% | 4.17x
structopt-0.3.26 | debug | full | -0.78% | 3.88x
structopt-0.3.26 | opt | full | -0.76% | 3.81x
unify-linearly | check | full | -0.75% | 3.74x
projection-caching | check | incr-unchanged | -0.74% | 3.70x
issue-46449 | check | incr-patched: u32 3072 | -0.70% | 3.50x
issue-46449 | check | incr-patched: empty 3072 | -0.68% | 3.41x
structopt-0.3.26 | check | incr-full | -0.68% | 3.40x
wf-projection-stress-65510 | check | incr-unchanged | -0.68% | 3.39x
issue-46449 | check | incr-patched: static str 6144 | -0.67% | 3.37x
wf-projection-stress-65510 | debug | incr-unchanged | -0.67% | 3.33x
wf-projection-stress-65510 | opt | incr-unchanged | -0.66% | 3.31x
issue-46449 | check | incr-patched: io error 6144 | -0.66% | 3.29x
unify-linearly | check | incr-full | -0.65% | 3.26x
issue-46449 | check | incr-full | -0.65% | 3.25x
structopt-0.3.26 | debug | incr-full | -0.64% | 3.18x
structopt-0.3.26 | opt | incr-full | -0.63% | 3.17x
issue-46449 | debug | incr-unchanged | -0.61% | 3.06x
issue-46449 | opt | incr-unchanged | -0.61% | 3.03x
await-call-tree | check | full | -0.60% | 2.99x
issue-88862 | check | incr-unchanged | -0.58% | 2.91x
deep-vector | debug | full | 0.57% | 2.83x
await-call-tree | check | incr-full | -0.52% | 2.59x
tt-muncher | opt | full | -0.52% | 2.58x
issue-58319 | check | incr-unchanged | -0.50% | 2.52x
await-call-tree | debug | full | -0.50% | 2.49x
await-call-tree | opt | full | -0.49% | 2.45x
deep-vector | debug | incr-patched: println | 0.47% | 2.37x
await-call-tree | debug | incr-full | -0.45% | 2.26x
await-call-tree | opt | incr-full | -0.44% | 2.18x
issue-88862 | check | full | -0.41% | 2.06x
mockall-0.11.0 | check | incr-unchanged | -0.38% | 1.90x
regression-31157 | check | incr-unchanged | -0.37% | 1.86x
wf-projection-stress-65510 | opt | full | -0.36% | 1.80x
deunicode-1.3.1 | check | incr-unchanged | -0.35% | 1.76x
unify-linearly | debug | incr-patched: dummy fn | -0.35% | 1.74x
mockall-0.11.0 | check | full | -0.35% | 1.73x
unify-linearly | debug | incr-unchanged | -0.34% | 1.69x
deunicode-1.3.1 | check | full | -0.33% | 1.63x
token-stream-stress | check | full | -0.32% | 1.62x
token-stream-stress | check | incr-full | -0.32% | 1.59x
token-stream-stress | check | incr-unchanged | -0.32% | 1.59x
regression-31157 | check | incr-patched: println | -0.31% | 1.57x
wf-projection-stress-65510 | check | full | -0.31% | 1.54x
deeply-nested-multi | check | incr-unchanged | -0.31% | 1.53x
mockall-0.11.0 | opt | incr-unchanged | -0.30% | 1.50x

r? @nnethercote 