### PR TITLE
Autolabel library PRs with T-libs

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -136,6 +136,21 @@ exclude_labels = [
     "T-*",
 ]
 
+[autolabel."T-libs"]
+trigger_files = [
+    "library/alloc",
+    "library/core",
+    "library/panic_abort",
+    "library/panic_unwind",
+    "library/std",
+    "library/stdarch",
+    "library/term",
+    "library/test",
+]
+exclude_labels = [
+    "T-*",
+]
+
 [notify-zulip."I-prioritize"]
 zulip_stream = 245100 # #t-compiler/wg-prioritization/alerts
 topic = "#{number} {title}"


### PR DESCRIPTION
Continuation of https://github.com/rust-lang/highfive/pull/389

We're trying to improve the libs team review structure and part of that is defaulting PRs to the T-libs team to act as a mini-triage team for all the libs teams / project groups. Highfive doesn't do issue tagging so we will rely on triagebot to pre-triage for t-libs to post-triage :)