### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/compiler/rustc_expand/src/mbe/macro_parser.rs
+++ b/compiler/rustc_expand/src/mbe/macro_parser.rs
@@ -81,21 +81,11 @@ use rustc_session::parse::ParseSess;
 use rustc_span::symbol::MacroRulesNormalizedIdent;
 use rustc_span::Span;
 
-use smallvec::{smallvec, SmallVec};
-
 use rustc_data_structures::fx::FxHashMap;
 use rustc_data_structures::sync::Lrc;
 use rustc_span::symbol::Ident;
 use std::borrow::Cow;
 use std::collections::hash_map::Entry::{Occupied, Vacant};
-
-// One element is enough to cover 95-99% of vectors for most benchmarks. Also, vectors longer than
-// one frequently have many elements, not just two or three.
-type NamedMatchVec = SmallVec<[NamedMatch; 1]>;
-
-// This type is used a lot. Make sure it doesn't unintentionally get bigger.
-#[cfg(all(target_arch = "x86_64", target_pointer_width = "64"))]
-rustc_data_structures::static_assert_size!(NamedMatchVec, 48);
 
 /// A unit within a matcher that a `MatcherPos` can refer to. Similar to (and derived from)
 /// `mbe::TokenTree`, but designed specifically for fast and easy traversal during matching.
@@ -221,7 +211,7 @@ struct MatcherPos {
     /// with one element per metavar decl in the matcher. Each element records token trees matched
     /// against the relevant metavar by the black box parser. An element will be a `MatchedSeq` if
     /// the corresponding metavar decl is within a sequence.
-    matches: Lrc<NamedMatchVec>,
+    matches: Lrc<Vec<NamedMatch>>,
 }
 
 // This type is used a lot. Make sure it doesn't unintentionally get bigger.
@@ -246,18 +236,12 @@ impl MatcherPos {
                 let mut curr = &mut matches[metavar_idx];
                 for _ in 0..seq_depth - 1 {
                     match curr {
-                        MatchedSeq(seq) => {
-                            let seq = Lrc::make_mut(seq);
-                            curr = seq.last_mut().unwrap();
-                        }
+                        MatchedSeq(seq) => curr = seq.last_mut().unwrap(),
                         _ => unreachable!(),
                     }
                 }
                 match curr {
-                    MatchedSeq(seq) => {
-                        let seq = Lrc::make_mut(seq);
-                        seq.push(m);
-                    }
+                    MatchedSeq(seq) => seq.push(m),
                     _ => unreachable!(),
                 }
             }
@@ -350,7 +334,7 @@ pub(super) fn count_metavar_decls(matcher: &[TokenTree]) -> usize {
 /// ```
 #[derive(Debug, Clone)]
 crate enum NamedMatch {
-    MatchedSeq(Lrc<NamedMatchVec>),
+    MatchedSeq(Vec<NamedMatch>),
 
     // A metavar match of type `tt`.
     MatchedTokenTree(rustc_ast::tokenstream::TokenTree),
@@ -388,7 +372,7 @@ pub struct TtParser {
 
     /// Pre-allocate an empty match array, so it can be cloned cheaply for macros with many rules
     /// that have no metavars.
-    empty_matches: Lrc<NamedMatchVec>,
+    empty_matches: Lrc<Vec<NamedMatch>>,
 }
 
 impl TtParser {
@@ -398,7 +382,7 @@ impl TtParser {
             cur_mps: vec![],
             next_mps: vec![],
             bb_mps: vec![],
-            empty_matches: Lrc::new(smallvec![]),
+            empty_matches: Lrc::new(vec![]),
         }
     }
 
@@ -452,11 +436,7 @@ impl TtParser {
                 } => {
                     // Install an empty vec for each metavar within the sequence.
                     for metavar_idx in next_metavar..next_metavar + num_metavar_decls {
-                        mp.push_match(
-                            metavar_idx,
-                            seq_depth,
-                            MatchedSeq(self.empty_matches.clone()),
-                        );
+                        mp.push_match(metavar_idx, seq_depth, MatchedSeq(vec![]));
                     }
 
                     if op == KleeneOp::ZeroOrMore || op == KleeneOp::ZeroOrOne {

--- a/compiler/rustc_expand/src/mbe/macro_parser.rs
+++ b/compiler/rustc_expand/src/mbe/macro_parser.rs
@@ -211,6 +211,10 @@ struct MatcherPos {
     /// with one element per metavar decl in the matcher. Each element records token trees matched
     /// against the relevant metavar by the black box parser. An element will be a `MatchedSeq` if
     /// the corresponding metavar decl is within a sequence.
+    ///
+    /// It is critical to performance that this is an `Lrc`, because it gets cloned frequently when
+    /// processing sequences. Mostly for sequence-ending possibilities that must be tried but end
+    /// up failing.
     matches: Lrc<Vec<NamedMatch>>,
 }
 

--- a/compiler/rustc_expand/src/mbe/macro_rules.rs
+++ b/compiler/rustc_expand/src/mbe/macro_rules.rs
@@ -439,7 +439,8 @@ pub fn compile_declarative_macro(
     let argument_gram = mbe::macro_parser::compute_locs(&sess.parse_sess, &argument_gram);
 
     let parser = Parser::new(&sess.parse_sess, body, true, rustc_parse::MACRO_ARGUMENTS);
-    let mut tt_parser = TtParser::new(def.ident);
+    let mut tt_parser =
+        TtParser::new(Ident::with_dummy_span(if macro_rules { kw::MacroRules } else { kw::Macro }));
     let argument_map = match tt_parser.parse_tt(&mut Cow::Borrowed(&parser), &argument_gram) {
         Success(m) => m,
         Failure(token, msg) => {

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -865,8 +865,8 @@ impl Build {
                 }
             }
         } else {
-            let base = self.llvm_out(self.config.build).join("build");
-            let base = if !self.ninja() && self.config.build.contains("msvc") {
+            let base = self.llvm_out(target).join("build");
+            let base = if !self.ninja() && target.contains("msvc") {
                 if self.config.llvm_optimize {
                     if self.config.llvm_release_debuginfo {
                         base.join("RelWithDebInfo")

--- a/src/librustdoc/doctest.rs
+++ b/src/librustdoc/doctest.rs
@@ -1069,13 +1069,7 @@ impl Tester for Collector {
                             }
                         }
                         TestFailure::ExecutionFailure(out) => {
-                            let reason = if let Some(code) = out.status.code() {
-                                format!("exit code {code}")
-                            } else {
-                                String::from("terminated by signal")
-                            };
-
-                            eprintln!("Test executable failed ({reason}).");
+                            eprintln!("Test executable failed ({reason}).", reason = out.status);
 
                             // FIXME(#12309): An unfortunate side-effect of capturing the test
                             // executable's output is that the relative ordering between the test's

--- a/src/test/rustdoc-ui/failed-doctest-output-windows.rs
+++ b/src/test/rustdoc-ui/failed-doctest-output-windows.rs
@@ -1,5 +1,5 @@
 // only-windows
-// There's a parallel generic version of this test for POSIXy platforms.
+// There's a parallel generic version of this test for non-windows platforms.
 
 // Issue #51162: A failed doctest was not printing its stdout/stderr
 // FIXME: if/when the output of the test harness can be tested on its own, this test should be

--- a/src/test/rustdoc-ui/failed-doctest-output-windows.rs
+++ b/src/test/rustdoc-ui/failed-doctest-output-windows.rs
@@ -1,5 +1,5 @@
-// ignore-windows
-// There's a parallel version of this test for Windows.
+// only-windows
+// There's a parallel generic version of this test for POSIXy platforms.
 
 // Issue #51162: A failed doctest was not printing its stdout/stderr
 // FIXME: if/when the output of the test harness can be tested on its own, this test should be

--- a/src/test/rustdoc-ui/failed-doctest-output-windows.stdout
+++ b/src/test/rustdoc-ui/failed-doctest-output-windows.stdout
@@ -1,0 +1,39 @@
+
+running 2 tests
+test $DIR/failed-doctest-output.rs - OtherStruct (line 22) ... FAILED
+test $DIR/failed-doctest-output.rs - SomeStruct (line 12) ... FAILED
+
+failures:
+
+---- $DIR/failed-doctest-output.rs - OtherStruct (line 22) stdout ----
+error[E0425]: cannot find value `no` in this scope
+  --> $DIR/failed-doctest-output.rs:23:1
+   |
+LL | no
+   | ^^ not found in this scope
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0425`.
+Couldn't compile the test.
+---- $DIR/failed-doctest-output.rs - SomeStruct (line 12) stdout ----
+Test executable failed (exit code: 101).
+
+stdout:
+stdout 1
+stdout 2
+
+stderr:
+stderr 1
+stderr 2
+thread 'main' panicked at 'oh no', $DIR/failed-doctest-output.rs:7:1
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+
+
+
+failures:
+    $DIR/failed-doctest-output.rs - OtherStruct (line 22)
+    $DIR/failed-doctest-output.rs - SomeStruct (line 12)
+
+test result: FAILED. 0 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
+

--- a/src/test/rustdoc-ui/failed-doctest-output-windows.stdout
+++ b/src/test/rustdoc-ui/failed-doctest-output-windows.stdout
@@ -1,13 +1,13 @@
 
 running 2 tests
-test $DIR/failed-doctest-output.rs - OtherStruct (line 22) ... FAILED
-test $DIR/failed-doctest-output.rs - SomeStruct (line 12) ... FAILED
+test $DIR/failed-doctest-output-windows.rs - OtherStruct (line 25) ... FAILED
+test $DIR/failed-doctest-output-windows.rs - SomeStruct (line 15) ... FAILED
 
 failures:
 
----- $DIR/failed-doctest-output.rs - OtherStruct (line 22) stdout ----
+---- $DIR/failed-doctest-output-windows.rs - OtherStruct (line 25) stdout ----
 error[E0425]: cannot find value `no` in this scope
-  --> $DIR/failed-doctest-output.rs:23:1
+  --> $DIR/failed-doctest-output-windows.rs:26:1
    |
 LL | no
    | ^^ not found in this scope
@@ -16,7 +16,7 @@ error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0425`.
 Couldn't compile the test.
----- $DIR/failed-doctest-output.rs - SomeStruct (line 12) stdout ----
+---- $DIR/failed-doctest-output-windows.rs - SomeStruct (line 15) stdout ----
 Test executable failed (exit code: 101).
 
 stdout:
@@ -26,14 +26,14 @@ stdout 2
 stderr:
 stderr 1
 stderr 2
-thread 'main' panicked at 'oh no', $DIR/failed-doctest-output.rs:7:1
+thread 'main' panicked at 'oh no', $DIR/failed-doctest-output-windows.rs:7:1
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 
 
 
 failures:
-    $DIR/failed-doctest-output.rs - OtherStruct (line 22)
-    $DIR/failed-doctest-output.rs - SomeStruct (line 12)
+    $DIR/failed-doctest-output-windows.rs - OtherStruct (line 25)
+    $DIR/failed-doctest-output-windows.rs - SomeStruct (line 15)
 
 test result: FAILED. 0 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
 

--- a/src/test/rustdoc-ui/failed-doctest-output.stdout
+++ b/src/test/rustdoc-ui/failed-doctest-output.stdout
@@ -1,13 +1,13 @@
 
 running 2 tests
-test $DIR/failed-doctest-output.rs - OtherStruct (line 22) ... FAILED
-test $DIR/failed-doctest-output.rs - SomeStruct (line 12) ... FAILED
+test $DIR/failed-doctest-output.rs - OtherStruct (line 25) ... FAILED
+test $DIR/failed-doctest-output.rs - SomeStruct (line 15) ... FAILED
 
 failures:
 
----- $DIR/failed-doctest-output.rs - OtherStruct (line 22) stdout ----
+---- $DIR/failed-doctest-output.rs - OtherStruct (line 25) stdout ----
 error[E0425]: cannot find value `no` in this scope
-  --> $DIR/failed-doctest-output.rs:23:1
+  --> $DIR/failed-doctest-output.rs:26:1
    |
 LL | no
    | ^^ not found in this scope
@@ -16,7 +16,7 @@ error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0425`.
 Couldn't compile the test.
----- $DIR/failed-doctest-output.rs - SomeStruct (line 12) stdout ----
+---- $DIR/failed-doctest-output.rs - SomeStruct (line 15) stdout ----
 Test executable failed (exit status: 101).
 
 stdout:
@@ -32,8 +32,8 @@ note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 
 
 failures:
-    $DIR/failed-doctest-output.rs - OtherStruct (line 22)
-    $DIR/failed-doctest-output.rs - SomeStruct (line 12)
+    $DIR/failed-doctest-output.rs - OtherStruct (line 25)
+    $DIR/failed-doctest-output.rs - SomeStruct (line 15)
 
 test result: FAILED. 0 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
 

--- a/src/test/rustdoc-ui/failed-doctest-output.stdout
+++ b/src/test/rustdoc-ui/failed-doctest-output.stdout
@@ -17,7 +17,7 @@ error: aborting due to previous error
 For more information about this error, try `rustc --explain E0425`.
 Couldn't compile the test.
 ---- $DIR/failed-doctest-output.rs - SomeStruct (line 12) stdout ----
-Test executable failed (exit code 101).
+Test executable failed (exit status: 101).
 
 stdout:
 stdout 1

--- a/src/test/ui/issues/issue-70093.rs
+++ b/src/test/ui/issues/issue-70093.rs
@@ -2,6 +2,7 @@
 // compile-flags: -Zlink-native-libraries=no -Cdefault-linker-libraries=yes
 // ignore-windows - this will probably only work on unixish systems
 // ignore-fuchsia - missing __libc_start_main for some reason (#84733)
+// ignore-cross-compile - default-linker-libraries=yes doesn't play well with cross compiling
 
 #[link(name = "some-random-non-existent-library", kind = "static")]
 extern "C" {}


### PR DESCRIPTION
Successful merges:

 - #95783 (rustdoc doctest: include signal number in exit status)
 - #95794 (`parse_tt`: a few more tweaks)
 - #95963 ([bootstrap] Grab the right FileCheck binary for dist when cross-compiling.)
 - #95975 (Don't test -Cdefault-linker-libraries=yes when cross compiling.)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=95783,95794,95963,95975)
<!-- homu-ignore:end -->