### PR TITLE
fix: wrong trait import suggestion for T:

### DIFF
--- a/compiler/rustc_typeck/src/check/method/suggest.rs
+++ b/compiler/rustc_typeck/src/check/method/suggest.rs
@@ -1880,9 +1880,15 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                                 };
                             let sp = hir.span(id);
                             let sp = if let Some(first_bound) = has_bounds {
-                                // `sp` only covers `T`, change it so that it covers
-                                // `T:` when appropriate
                                 sp.until(first_bound.span())
+                            } else if let Some(colon_sp) =
+                                // If the generic param is declared with a colon but without bounds:
+                                // fn foo<T:>(t: T) { ... }
+                                param.colon_span_for_suggestions(
+                                    self.inh.tcx.sess.source_map(),
+                                )
+                            {
+                                sp.to(colon_sp)
                             } else {
                                 sp
                             };

--- a/src/test/ui/traits/issue-95898.rs
+++ b/src/test/ui/traits/issue-95898.rs
@@ -1,0 +1,9 @@
+// Test for #95898: The trait suggestion had an extra `:` after the trait.
+// edition:2021
+
+fn foo<T:>(t: T) {
+    t.clone();
+    //~^ ERROR no method named `clone` found for type parameter `T` in the current scope
+}
+
+fn main() {}

--- a/src/test/ui/traits/issue-95898.stderr
+++ b/src/test/ui/traits/issue-95898.stderr
@@ -1,0 +1,15 @@
+error[E0599]: no method named `clone` found for type parameter `T` in the current scope
+  --> $DIR/issue-95898.rs:5:7
+   |
+LL |     t.clone();
+   |       ^^^^^ method not found in `T`
+   |
+   = help: items from traits can only be used if the type parameter is bounded by the trait
+help: the following trait defines an item `clone`, perhaps you need to restrict type parameter `T` with it:
+   |
+LL | fn foo<T: Clone>(t: T) {
+   |        ~~~~~~~~
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0599`.


### PR DESCRIPTION
The suggestion to bound `T` had an extra `:`.

```rust
fn foo<T:>(t: T) {
  t.clone();
}
```

```
error[E0599]: no method named `clone` found for type parameter `T` in the current scope
 --> src/lib.rs:2:7
  |
2 |     t.clone();
  |       ^^^^^ method not found in `T`
  |
  = help: items from traits can only be used if the type parameter is bounded by the trait
help: the following trait defines an item `clone`, perhaps you need to restrict type parameter `T` with it:
  |
1 | fn foo<T: Clone:>(t: T) {
  |        ~~~~~~~~
 ```

Fixes: #95898