### PR TITLE
Fix `x test --doc --stage 0 library/std`

### DIFF
--- a/src/bootstrap/bin/rustdoc.rs
+++ b/src/bootstrap/bin/rustdoc.rs
@@ -31,7 +31,9 @@ fn main() {
 
     let mut cmd = Command::new(rustdoc);
 
-    if target.is_some() {
+    // I am not actually sure why it's necessary to pass the sysroot for `--test`,
+    // but `test --doc --stage 0` is broken without it :(
+    if target.is_some() || args.iter().any(|x| x == "--test") {
         // The stage0 compiler has a special sysroot distinct from what we
         // actually downloaded, so we just always pass the `--sysroot` option,
         // unless one is already set.


### PR DESCRIPTION
I managed to break this in https://github.com/rust-lang/rust/pull/95449.
I am not quite sure why this is the correct fix, but it doesn't break `doc --stage 0`
and is strictly closer to the previous behavior.

Previously, rustdoc would error with strange issues because of the mismatched sysroot:
```
error[E0460]: found possibly newer version of crate `std` which `rustc_span` depends on
  --> /home/jnelson/rust-lang/rust/compiler/rustc_lint_defs/src/lib.rs:14:5
   |
14 | use rustc_span::{sym, symbol::Ident, Span, Symbol};
   |     ^^^^^^^^^^
   |
   = note: perhaps that crate needs to be recompiled?
   = note: the following crate versions were found:
           crate `std`: /home/jnelson/rust-lang/rust/build/x86_64-unknown-linux-gnu/stage0/lib/rustlib/x86_64-unknown-linux-gnu/lib/libstd-ff9290e971253a38.rlib
           crate `std`: /home/jnelson/rust-lang/rust/build/x86_64-unknown-linux-gnu/stage0/lib/rustlib/x86_64-unknown-linux-gnu/lib/libstd-ff9290e971253a38.so
           crate `rustc_span`: /home/jnelson/rust-lang/rust/build/x86_64-unknown-linux-gnu/stage0-rustc/x86_64-unknown-linux-gnu/release/deps/librustc_span-ed11dce30c1766f9.rlib
```