### PR TITLE
modify next_code_point() to accept an Iterator<u8> instead of Iterator<&u8>.  Old code that calls it invokes .copied()

### DIFF
--- a/library/alloc/tests/lib.rs
+++ b/library/alloc/tests/lib.rs
@@ -40,6 +40,7 @@
 #![feature(panic_update_hook)]
 #![feature(slice_flatten)]
 #![feature(thin_box)]
+#![feature(str_internals)]
 
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};

--- a/library/core/src/str/iter.rs
+++ b/library/core/src/str/iter.rs
@@ -41,7 +41,9 @@ impl<'a> Iterator for Chars<'a> {
     fn next(&mut self) -> Option<char> {
         // SAFETY: `str` invariant says `self.iter` is a valid UTF-8 string and
         // the resulting `ch` is a valid Unicode Scalar Value.
-        unsafe { next_code_point(&mut self.iter).map(|ch| char::from_u32_unchecked(ch)) }
+        unsafe {
+            next_code_point(&mut (&mut self.iter).copied()).map(|ch| char::from_u32_unchecked(ch))
+        }
     }
 
     #[inline]
@@ -81,7 +83,10 @@ impl<'a> DoubleEndedIterator for Chars<'a> {
     fn next_back(&mut self) -> Option<char> {
         // SAFETY: `str` invariant says `self.iter` is a valid UTF-8 string and
         // the resulting `ch` is a valid Unicode Scalar Value.
-        unsafe { next_code_point_reverse(&mut self.iter).map(|ch| char::from_u32_unchecked(ch)) }
+        unsafe {
+            next_code_point_reverse(&mut (&mut self.iter).copied())
+                .map(|ch| char::from_u32_unchecked(ch))
+        }
     }
 }
 

--- a/library/std/src/sys_common/wtf8.rs
+++ b/library/std/src/sys_common/wtf8.rs
@@ -847,7 +847,7 @@ impl<'a> Iterator for Wtf8CodePoints<'a> {
     #[inline]
     fn next(&mut self) -> Option<CodePoint> {
         // SAFETY: `self.bytes` has been created from a WTF-8 string
-        unsafe { next_code_point(&mut self.bytes).map(|c| CodePoint { value: c }) }
+        unsafe { next_code_point(&mut (&mut self.bytes).copied()).map(|c| CodePoint { value: c }) }
     }
 
     #[inline]


### PR DESCRIPTION
next_code_point() required an Iterator<Item=&u8> and I only have an Iterator<Item=u8> ; so I have modified next_code_point() to accept an Iterator<Item=u8>.  Code that used the old next_code_point() gets modified to call (&mut self.iter).copied(). 
I threw in some unit tests because I want some confidence that I didn't break anything.
This pull request is an alternate to https://github.com/rust-lang/rust/pull/95788 .  This one is a little less architecturally messy, but will break any external code that was invoking next_code_point().