### PR TITLE
Inline `ty::Const::ty()` and `ty::Const::val()` getters

### DIFF
--- a/compiler/rustc_middle/src/ty/consts.rs
+++ b/compiler/rustc_middle/src/ty/consts.rs
@@ -44,10 +44,12 @@ pub struct ConstS<'tcx> {
 static_assert_size!(ConstS<'_>, 48);
 
 impl<'tcx> Const<'tcx> {
+    #[inline]
     pub fn ty(self) -> Ty<'tcx> {
         self.0.ty
     }
 
+    #[inline]
     pub fn val(self) -> ConstKind<'tcx> {
         self.0.val
     }


### PR DESCRIPTION
These were not inlined into `super_relate_consts`, which is one of the hottest functions in a callgrind profile of compiling `bitmaps-3.1.0`.

Yields some small speedups across various benchmarks locally:

#### Primary benchmarks

Benchmark | Profile | Scenario | % Change | Significance Factor?
-- | -- | -- | -- | --
unicode-normalization-0.1.19 | check | full | -0.56% | 2.78x
unicode-normalization-0.1.19 | check | incr-full | -0.43% | 2.15x
unicode-normalization-0.1.19 | opt | full | -0.35% | 1.77x
unicode-normalization-0.1.19 | debug | incr-full | -0.31% | 1.56x
unicode-normalization-0.1.19 | debug | full | -0.30% | 1.51x

#### Secondary benchmarks

Benchmark | Profile | Scenario | % Change | Significance Factor?
-- | -- | -- | -- | --
bitmaps-3.1.0 | check | full | -1.88% | 9.39x
bitmaps-3.1.0 | debug | full | -1.79% | 8.96x
bitmaps-3.1.0 | opt | full | -1.69% | 8.43x
bitmaps-3.1.0 | check | incr-full | -1.54% | 7.68x
bitmaps-3.1.0 | debug | incr-full | -1.45% | 7.27x
bitmaps-3.1.0 | opt | incr-full | -1.39% | 6.96x
tt-muncher | opt | full | 1.28% | 6.38x
nalgebra-0.30.1 | check | full | -0.96% | 4.81x
nalgebra-0.30.1 | debug | full | -0.91% | 4.54x
nalgebra-0.30.1 | opt | full | -0.90% | 4.52x
nalgebra-0.30.1 | check | incr-full | -0.77% | 3.86x
nalgebra-0.30.1 | opt | incr-full | -0.76% | 3.79x
nalgebra-0.30.1 | debug | incr-full | -0.74% | 3.72x
hex-0.4.3 | check | full | -0.70% | 3.50x
hex-0.4.3 | debug | full | -0.59% | 2.95x
hex-0.4.3 | check | incr-full | -0.56% | 2.80x
hex-0.4.3 | opt | full | -0.56% | 2.78x
wf-projection-stress-65510 | opt | full | -0.48% | 2.42x
hex-0.4.3 | opt | incr-full | -0.48% | 2.40x
hex-0.4.3 | debug | incr-full | -0.45% | 2.24x
wf-projection-stress-65510 | check | full | -0.44% | 2.18x
wf-projection-stress-65510 | debug | full | -0.42% | 2.08x
wf-projection-stress-65510 | check | incr-full | -0.40% | 2.01x
deep-vector | debug | incr-patched: add vec item | -0.38% | 1.88x
wf-projection-stress-65510 | debug | incr-full | -0.37% | 1.86x
wf-projection-stress-65510 | opt | incr-full | -0.36% | 1.81x
deep-vector | debug | incr-patched: println | 0.33% | 1.63x

r? @nnethercote 