### PR TITLE
[crater] Try enabling `-Zgcc-ld=lld`

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -2607,8 +2607,6 @@ fn add_gcc_ld_path(cmd: &mut dyn Linker, sess: &Session, flavor: LinkerFlavor) {
                     }
                 }
             }
-        } else {
-            sess.fatal("option `-Z gcc-ld` is used even though linker flavor is not gcc");
         }
     }
 }

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -1253,7 +1253,7 @@ options! {
         "whether each function should go in its own section"),
     future_incompat_test: bool = (false, parse_bool, [UNTRACKED],
         "forces all lints to be future incompatible, used for internal testing (default: no)"),
-    gcc_ld: Option<LdImpl> = (None, parse_gcc_ld, [TRACKED], "implementation of ld used by cc"),
+    gcc_ld: Option<LdImpl> = (Some(LdImpl::Lld), parse_gcc_ld, [TRACKED], "implementation of ld used by cc"),
     graphviz_dark_mode: bool = (false, parse_bool, [UNTRACKED],
         "use dark-themed colors in graphviz output (default: no)"),
     graphviz_font: String = ("Courier, monospace".to_string(), parse_string, [UNTRACKED],


### PR DESCRIPTION
To make progress towards using `lld`, this PR will test a `build-and-test` crater run enabling `-Zgcc-ld`, to see if it would cause issues on `x86_64-unknown-linux-gnu`. 