### PR TITLE
Use u32 instead of i32 for futexes.

### DIFF
--- a/library/std/src/sys/unix/locks/futex.rs
+++ b/library/std/src/sys/unix/locks/futex.rs
@@ -1,6 +1,6 @@
 use crate::cell::UnsafeCell;
 use crate::sync::atomic::{
-    AtomicI32, AtomicUsize,
+    AtomicU32, AtomicUsize,
     Ordering::{Acquire, Relaxed, Release},
 };
 use crate::sys::futex::{futex_wait, futex_wake, futex_wake_all};
@@ -13,13 +13,13 @@ pub struct Mutex {
     /// 0: unlocked
     /// 1: locked, no other threads waiting
     /// 2: locked, and other threads waiting (contended)
-    futex: AtomicI32,
+    futex: AtomicU32,
 }
 
 impl Mutex {
     #[inline]
     pub const fn new() -> Self {
-        Self { futex: AtomicI32::new(0) }
+        Self { futex: AtomicU32::new(0) }
     }
 
     #[inline]
@@ -71,7 +71,7 @@ impl Mutex {
         }
     }
 
-    fn spin(&self) -> i32 {
+    fn spin(&self) -> u32 {
         let mut spin = 100;
         loop {
             // We only use `load` (and not `swap` or `compare_exchange`)
@@ -110,13 +110,13 @@ pub struct Condvar {
     // The value of this atomic is simply incremented on every notification.
     // This is used by `.wait()` to not miss any notifications after
     // unlocking the mutex and before waiting for notifications.
-    futex: AtomicI32,
+    futex: AtomicU32,
 }
 
 impl Condvar {
     #[inline]
     pub const fn new() -> Self {
-        Self { futex: AtomicI32::new(0) }
+        Self { futex: AtomicU32::new(0) }
     }
 
     #[inline]

--- a/library/std/src/sys/wasm/atomics/futex.rs
+++ b/library/std/src/sys/wasm/atomics/futex.rs
@@ -1,17 +1,21 @@
 use crate::arch::wasm32;
 use crate::convert::TryInto;
-use crate::sync::atomic::AtomicI32;
+use crate::sync::atomic::AtomicU32;
 use crate::time::Duration;
 
-pub fn futex_wait(futex: &AtomicI32, expected: i32, timeout: Option<Duration>) {
+pub fn futex_wait(futex: &AtomicU32, expected: u32, timeout: Option<Duration>) {
     let timeout = timeout.and_then(|t| t.as_nanos().try_into().ok()).unwrap_or(-1);
     unsafe {
-        wasm32::memory_atomic_wait32(futex as *const AtomicI32 as *mut i32, expected, timeout);
+        wasm32::memory_atomic_wait32(
+            futex as *const AtomicU32 as *mut i32,
+            expected as i32,
+            timeout,
+        );
     }
 }
 
-pub fn futex_wake(futex: &AtomicI32) {
+pub fn futex_wake(futex: &AtomicU32) {
     unsafe {
-        wasm32::memory_atomic_notify(futex as *const AtomicI32 as *mut i32, 1);
+        wasm32::memory_atomic_notify(futex as *const AtomicU32 as *mut i32, 1);
     }
 }

--- a/library/std/src/sys_common/thread_parker/futex.rs
+++ b/library/std/src/sys_common/thread_parker/futex.rs
@@ -1,14 +1,14 @@
-use crate::sync::atomic::AtomicI32;
+use crate::sync::atomic::AtomicU32;
 use crate::sync::atomic::Ordering::{Acquire, Release};
 use crate::sys::futex::{futex_wait, futex_wake};
 use crate::time::Duration;
 
-const PARKED: i32 = -1;
-const EMPTY: i32 = 0;
-const NOTIFIED: i32 = 1;
+const PARKED: u32 = u32::MAX;
+const EMPTY: u32 = 0;
+const NOTIFIED: u32 = 1;
 
 pub struct Parker {
-    state: AtomicI32,
+    state: AtomicU32,
 }
 
 // Notes about memory ordering:
@@ -34,7 +34,7 @@ pub struct Parker {
 impl Parker {
     #[inline]
     pub const fn new() -> Self {
-        Parker { state: AtomicI32::new(EMPTY) }
+        Parker { state: AtomicU32::new(EMPTY) }
     }
 
     // Assumes this is only called by the thread that owns the Parker,


### PR DESCRIPTION
This changes futexes from i32 to u32. The [Linux man page](https://man7.org/linux/man-pages/man2/futex.2.html) uses `uint32_t` for them, so I'm not sure why I used i32 for them. Maybe because I first used them for thread parkers, where I used -1, 0, and 1 as the states.

(Wasm's `memory.atomic.wait32` does use `i32`, because wasm doesn't support `u32`.)

It doesn't matter much, but using the unsigned type probably results in fewer surprises when shifting bits around or using comparison operators.

r? @Amanieu