### PR TITLE
Add Finalize statement to make deaggregation "reversible" by storing all information in MIR

### DIFF
--- a/compiler/rustc_borrowck/src/dataflow.rs
+++ b/compiler/rustc_borrowck/src/dataflow.rs
@@ -387,6 +387,7 @@ impl<'tcx> rustc_mir_dataflow::GenKillAnalysis<'tcx> for Borrows<'_, 'tcx> {
             mir::StatementKind::FakeRead(..)
             | mir::StatementKind::SetDiscriminant { .. }
             | mir::StatementKind::Deinit(..)
+            | mir::StatementKind::Finalize(..)
             | mir::StatementKind::StorageLive(..)
             | mir::StatementKind::Retag { .. }
             | mir::StatementKind::AscribeUserType(..)

--- a/compiler/rustc_borrowck/src/invalidation.rs
+++ b/compiler/rustc_borrowck/src/invalidation.rs
@@ -88,7 +88,9 @@ impl<'cx, 'tcx> Visitor<'tcx> for InvalidationGenerator<'cx, 'tcx> {
                     LocalMutationIsAllowed::Yes,
                 );
             }
-            StatementKind::Deinit(..) | StatementKind::SetDiscriminant { .. } => {
+            StatementKind::Finalize(..)
+            | StatementKind::Deinit(..)
+            | StatementKind::SetDiscriminant { .. } => {
                 bug!("Statement not allowed in this MIR phase")
             }
         }

--- a/compiler/rustc_borrowck/src/lib.rs
+++ b/compiler/rustc_borrowck/src/lib.rs
@@ -651,7 +651,9 @@ impl<'cx, 'tcx> rustc_mir_dataflow::ResultsVisitor<'cx, 'tcx> for MirBorrowckCtx
                     flow_state,
                 );
             }
-            StatementKind::Deinit(..) | StatementKind::SetDiscriminant { .. } => {
+            StatementKind::Finalize(..)
+            | StatementKind::Deinit(..)
+            | StatementKind::SetDiscriminant { .. } => {
                 bug!("Statement not allowed in this MIR phase")
             }
         }

--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -1337,7 +1337,9 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
             | StatementKind::Retag { .. }
             | StatementKind::Coverage(..)
             | StatementKind::Nop => {}
-            StatementKind::Deinit(..) | StatementKind::SetDiscriminant { .. } => {
+            StatementKind::Finalize(..)
+            | StatementKind::Deinit(..)
+            | StatementKind::SetDiscriminant { .. } => {
                 bug!("Statement not allowed in this MIR phase")
             }
         }

--- a/compiler/rustc_codegen_cranelift/src/base.rs
+++ b/compiler/rustc_codegen_cranelift/src/base.rs
@@ -772,6 +772,7 @@ fn codegen_stmt<'tcx>(
         }
         StatementKind::StorageLive(_)
         | StatementKind::StorageDead(_)
+        | StatementKind::Finalize(..)
         | StatementKind::Deinit(_)
         | StatementKind::Nop
         | StatementKind::FakeRead(..)

--- a/compiler/rustc_codegen_cranelift/src/constant.rs
+++ b/compiler/rustc_codegen_cranelift/src/constant.rs
@@ -519,6 +519,7 @@ pub(crate) fn mir_operand_get_const_val<'tcx>(
                         | StatementKind::FakeRead(_)
                         | StatementKind::SetDiscriminant { .. }
                         | StatementKind::Deinit(_)
+                        | StatementKind::Finalize(..)
                         | StatementKind::StorageLive(_)
                         | StatementKind::StorageDead(_)
                         | StatementKind::Retag(_, _)

--- a/compiler/rustc_codegen_ssa/src/mir/statement.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/statement.rs
@@ -48,7 +48,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                     .codegen_set_discr(&mut bx, variant_index);
                 bx
             }
-            mir::StatementKind::Deinit(..) => {
+            mir::StatementKind::Finalize(..) | mir::StatementKind::Deinit(..) => {
                 // For now, don't codegen this to anything. In the future it may be worth
                 // experimenting with what kind of information we can emit to LLVM without hurting
                 // perf here

--- a/compiler/rustc_const_eval/src/interpret/step.rs
+++ b/compiler/rustc_const_eval/src/interpret/step.rs
@@ -90,6 +90,14 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 self.write_discriminant(*variant_index, &dest)?;
             }
 
+            Finalize(place) => {
+                if M::enforce_validity(self) {
+                    let place = self.eval_place(**place)?;
+                    // Invariant: when `Finalize` is invoked on a place, that place is fully valid
+                    self.validate_operand(&self.place_to_op(&place)?)?;
+                }
+            }
+
             Deinit(place) => {
                 let dest = self.eval_place(**place)?;
                 self.write_uninit(&dest)?;

--- a/compiler/rustc_const_eval/src/transform/check_consts/check.rs
+++ b/compiler/rustc_const_eval/src/transform/check_consts/check.rs
@@ -693,6 +693,7 @@ impl<'tcx> Visitor<'tcx> for Checker<'_, 'tcx> {
             StatementKind::Assign(..)
             | StatementKind::SetDiscriminant { .. }
             | StatementKind::Deinit(..)
+            | StatementKind::Finalize(..)
             | StatementKind::FakeRead(..)
             | StatementKind::StorageLive(_)
             | StatementKind::StorageDead(_)

--- a/compiler/rustc_const_eval/src/transform/validate.rs
+++ b/compiler/rustc_const_eval/src/transform/validate.rs
@@ -488,9 +488,12 @@ impl<'a, 'tcx> Visitor<'tcx> for TypeChecker<'a, 'tcx> {
                     );
                 }
             }
-            StatementKind::Deinit(..) => {
+            StatementKind::Finalize(..) | StatementKind::Deinit(..) => {
                 if self.mir_phase < MirPhase::Deaggregated {
-                    self.fail(location, "`Deinit`is not allowed until deaggregation");
+                    self.fail(
+                        location,
+                        format!("`{:?}`is not allowed until deaggregation", statement.kind),
+                    );
                 }
             }
             StatementKind::Retag(_, _) => {

--- a/compiler/rustc_const_eval/src/util/aggregate.rs
+++ b/compiler/rustc_const_eval/src/util/aggregate.rs
@@ -70,8 +70,7 @@ pub fn expand_aggregate<'tcx>(
             kind: StatementKind::Assign(Box::new((lhs_field, Rvalue::Use(op)))),
         }
     });
-    [Statement { source_info, kind: StatementKind::Deinit(Box::new(orig_lhs)) }]
-        .into_iter()
-        .chain(operands)
-        .chain(set_discriminant)
+    let deinit = Statement { source_info, kind: StatementKind::Deinit(Box::new(orig_lhs)) };
+    let finalize = Statement { source_info, kind: StatementKind::Finalize(Box::new(orig_lhs)) };
+    [deinit].into_iter().chain(operands).chain(set_discriminant).chain(Some(finalize))
 }

--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -1649,6 +1649,14 @@ pub enum StatementKind<'tcx> {
     /// This writes `uninit` bytes to the entire place.
     Deinit(Box<Place<'tcx>>),
 
+    /// Marks the place as fully initialized.
+    ///
+    /// This allows assigning the components of the place incrementally,
+    /// while still treating it just like a full assignment to the place *after* this statment.
+    /// It is not semantically the same as assigning to the place, because that would allow
+    /// marking all preceding partial writes to the place as dead.
+    Finalize(Box<Place<'tcx>>),
+
     /// `StorageLive` and `StorageDead` statements mark the live range of a local.
     ///
     /// Using a local before a `StorageLive` or after a `StorageDead` is not well-formed. These
@@ -1831,6 +1839,7 @@ impl Debug for Statement<'_> {
                 write!(fmt, "discriminant({:?}) = {:?}", place, variant_index)
             }
             Deinit(ref place) => write!(fmt, "Deinit({:?})", place),
+            Finalize(ref place) => write!(fmt, "Finalize({:?})", place),
             AscribeUserType(box (ref place, ref c_ty), ref variance) => {
                 write!(fmt, "AscribeUserType({:?}, {:?}, {:?})", place, variance, c_ty)
             }

--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -168,13 +168,13 @@ pub enum MirPhase {
     /// Furthermore, `Drop` now uses explicit drop flags visible in the MIR and reaching a `Drop`
     /// terminator means that the auto-generated drop glue will be invoked. Also, `Copy` operands
     /// are allowed for non-`Copy` types.
-    DropsLowered = 3,
+    DropsLowered = 4,
     /// Beginning with this phase, the following variant is disallowed:
     /// * [`Rvalue::Aggregate`] for any `AggregateKind` except `Array`
     ///
     /// And the following variant is allowed:
     /// * [`StatementKind::SetDiscriminant`]
-    Deaggregated = 4,
+    Deaggregated = 3,
     /// Before this phase, generators are in the "source code" form, featuring `yield` statements
     /// and such. With this phase change, they are transformed into a proper state machine. Running
     /// optimizations before this change can be potentially dangerous because the source code is to

--- a/compiler/rustc_middle/src/mir/spanview.rs
+++ b/compiler/rustc_middle/src/mir/spanview.rs
@@ -244,6 +244,7 @@ pub fn statement_kind_name(statement: &Statement<'_>) -> &'static str {
         FakeRead(..) => "FakeRead",
         SetDiscriminant { .. } => "SetDiscriminant",
         Deinit(..) => "Deinit",
+        Finalize(..) => "Finalize",
         StorageLive(..) => "StorageLive",
         StorageDead(..) => "StorageDead",
         Retag(..) => "Retag",

--- a/compiler/rustc_middle/src/mir/visit.rs
+++ b/compiler/rustc_middle/src/mir/visit.rs
@@ -406,6 +406,13 @@ macro_rules! make_mir_visitor {
                             location
                         )
                     }
+                    StatementKind::Finalize(place) => {
+                        self.visit_place(
+                            place,
+                            PlaceContext::MutatingUse(MutatingUseContext::Store),
+                            location
+                        )
+                    }
                     StatementKind::StorageLive(local) => {
                         self.visit_local(
                             local,

--- a/compiler/rustc_mir_dataflow/src/impls/storage_liveness.rs
+++ b/compiler/rustc_mir_dataflow/src/impls/storage_liveness.rs
@@ -132,6 +132,7 @@ impl<'mir, 'tcx> crate::GenKillAnalysis<'tcx> for MaybeRequiresStorage<'mir, 'tc
             // If a place is assigned to in a statement, it needs storage for that statement.
             StatementKind::Assign(box (place, _))
             | StatementKind::SetDiscriminant { box place, .. }
+            | StatementKind::Finalize(box place)
             | StatementKind::Deinit(box place) => {
                 trans.gen(place.local);
             }

--- a/compiler/rustc_mir_dataflow/src/move_paths/builder.rs
+++ b/compiler/rustc_mir_dataflow/src/move_paths/builder.rs
@@ -296,7 +296,9 @@ impl<'b, 'a, 'tcx> Gatherer<'b, 'a, 'tcx> {
             StatementKind::StorageDead(local) => {
                 self.gather_move(Place::from(*local));
             }
-            StatementKind::SetDiscriminant { .. } | StatementKind::Deinit(..) => {
+            StatementKind::SetDiscriminant { .. }
+            | StatementKind::Deinit(..)
+            | StatementKind::Finalize(..) => {
                 span_bug!(
                     stmt.source_info.span,
                     "SetDiscriminant/Deinit should not exist during borrowck"

--- a/compiler/rustc_mir_dataflow/src/move_paths/builder.rs
+++ b/compiler/rustc_mir_dataflow/src/move_paths/builder.rs
@@ -296,13 +296,10 @@ impl<'b, 'a, 'tcx> Gatherer<'b, 'a, 'tcx> {
             StatementKind::StorageDead(local) => {
                 self.gather_move(Place::from(*local));
             }
-            StatementKind::SetDiscriminant { .. }
-            | StatementKind::Deinit(..)
-            | StatementKind::Finalize(..) => {
-                span_bug!(
-                    stmt.source_info.span,
-                    "SetDiscriminant/Deinit should not exist during borrowck"
-                );
+            StatementKind::SetDiscriminant { .. } => {}
+            StatementKind::Deinit(..) => {}
+            StatementKind::Finalize(box place) => {
+                self.gather_init(place.as_ref(), InitKind::Deep);
             }
             StatementKind::Retag { .. }
             | StatementKind::AscribeUserType(..)

--- a/compiler/rustc_mir_transform/src/check_unsafety.rs
+++ b/compiler/rustc_mir_transform/src/check_unsafety.rs
@@ -98,6 +98,7 @@ impl<'tcx> Visitor<'tcx> for UnsafetyChecker<'_, 'tcx> {
             | StatementKind::FakeRead(..)
             | StatementKind::SetDiscriminant { .. }
             | StatementKind::Deinit(..)
+            | StatementKind::Finalize(..)
             | StatementKind::StorageLive(..)
             | StatementKind::StorageDead(..)
             | StatementKind::Retag { .. }

--- a/compiler/rustc_mir_transform/src/coverage/spans.rs
+++ b/compiler/rustc_mir_transform/src/coverage/spans.rs
@@ -828,6 +828,7 @@ pub(super) fn filtered_statement_span(statement: &Statement<'_>) -> Option<Span>
         | StatementKind::Assign(_)
         | StatementKind::SetDiscriminant { .. }
         | StatementKind::Deinit(..)
+        | StatementKind::Finalize(..)
         | StatementKind::Retag(_, _)
         | StatementKind::AscribeUserType(_, _) => {
             Some(statement.source_info.span)

--- a/compiler/rustc_mir_transform/src/dest_prop.rs
+++ b/compiler/rustc_mir_transform/src/dest_prop.rs
@@ -531,6 +531,7 @@ impl<'a> Conflicts<'a> {
 
             StatementKind::SetDiscriminant { .. }
             | StatementKind::Deinit(..)
+            | StatementKind::Finalize(..)
             | StatementKind::StorageLive(..)
             | StatementKind::StorageDead(..)
             | StatementKind::Retag(..)

--- a/compiler/rustc_mir_transform/src/generator.rs
+++ b/compiler/rustc_mir_transform/src/generator.rs
@@ -1442,6 +1442,7 @@ impl<'tcx> Visitor<'tcx> for EnsureGeneratorFieldAssignmentsNeverAlias<'_> {
             StatementKind::FakeRead(..)
             | StatementKind::SetDiscriminant { .. }
             | StatementKind::Deinit(..)
+            | StatementKind::Finalize(..)
             | StatementKind::StorageLive(_)
             | StatementKind::StorageDead(_)
             | StatementKind::Retag(..)

--- a/compiler/rustc_mir_transform/src/lib.rs
+++ b/compiler/rustc_mir_transform/src/lib.rs
@@ -71,6 +71,7 @@ mod normalize_array_len;
 mod nrvo;
 // This pass is public to allow external drivers to perform MIR cleanup
 pub mod remove_false_edges;
+mod remove_finalize;
 mod remove_noop_landing_pads;
 mod remove_storage_markers;
 mod remove_uninit_drops;
@@ -434,6 +435,7 @@ fn run_post_borrowck_cleanup_passes<'tcx>(tcx: TyCtxt<'tcx>, body: &mut Body<'tc
         &deaggregator::Deaggregator,
         &deref_separator::Derefer,
         &Lint(const_prop_lint::ConstProp),
+        &remove_finalize::RemoveFinalize,
     ];
 
     pm::run_passes(tcx, body, post_borrowck_cleanup);

--- a/compiler/rustc_mir_transform/src/remove_finalize.rs
+++ b/compiler/rustc_mir_transform/src/remove_finalize.rs
@@ -1,0 +1,21 @@
+//! Removes assignments to ZST places.
+
+use crate::MirPass;
+use rustc_middle::mir::{Body, StatementKind};
+use rustc_middle::ty::TyCtxt;
+
+pub struct RemoveFinalize;
+
+impl<'tcx> MirPass<'tcx> for RemoveFinalize {
+    fn is_enabled(&self, sess: &rustc_session::Session) -> bool {
+        sess.mir_opt_level() > 0
+    }
+
+    fn run_pass(&self, _tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
+        for block in body.basic_blocks_mut() {
+            block
+                .statements
+                .retain(|statement| !matches!(statement.kind, StatementKind::Finalize(..)));
+        }
+    }
+}

--- a/compiler/rustc_mir_transform/src/remove_finalize.rs
+++ b/compiler/rustc_mir_transform/src/remove_finalize.rs
@@ -1,4 +1,4 @@
-//! Removes assignments to ZST places.
+//! Removes Finalize statements, as they have no codegen impact
 
 use crate::MirPass;
 use rustc_middle::mir::{Body, StatementKind};
@@ -7,10 +7,6 @@ use rustc_middle::ty::TyCtxt;
 pub struct RemoveFinalize;
 
 impl<'tcx> MirPass<'tcx> for RemoveFinalize {
-    fn is_enabled(&self, sess: &rustc_session::Session) -> bool {
-        sess.mir_opt_level() > 0
-    }
-
     fn run_pass(&self, _tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
         for block in body.basic_blocks_mut() {
             block

--- a/compiler/rustc_mir_transform/src/remove_noop_landing_pads.rs
+++ b/compiler/rustc_mir_transform/src/remove_noop_landing_pads.rs
@@ -51,6 +51,7 @@ impl RemoveNoopLandingPads {
                 StatementKind::Assign { .. }
                 | StatementKind::SetDiscriminant { .. }
                 | StatementKind::Deinit(..)
+                | StatementKind::Finalize(..)
                 | StatementKind::CopyNonOverlapping(..)
                 | StatementKind::Retag { .. } => {
                     return false;

--- a/compiler/rustc_mir_transform/src/remove_zsts.rs
+++ b/compiler/rustc_mir_transform/src/remove_zsts.rs
@@ -21,8 +21,9 @@ impl<'tcx> MirPass<'tcx> for RemoveZsts {
         let (basic_blocks, local_decls) = body.basic_blocks_and_local_decls_mut();
         for block in basic_blocks.iter_mut() {
             for statement in block.statements.iter_mut() {
-                if let StatementKind::Assign(box (place, _)) | StatementKind::Deinit(box place) =
-                    statement.kind
+                if let StatementKind::Assign(box (place, _))
+                | StatementKind::Deinit(box place)
+                | StatementKind::Finalize(box place) = statement.kind
                 {
                     let place_ty = place.ty(local_decls, tcx).ty;
                     if !maybe_zst(place_ty) {

--- a/compiler/rustc_mir_transform/src/separate_const_switch.rs
+++ b/compiler/rustc_mir_transform/src/separate_const_switch.rs
@@ -243,6 +243,7 @@ fn is_likely_const<'tcx>(mut tracked_place: Place<'tcx>, block: &BasicBlockData<
             // we are interested in
             StatementKind::FakeRead(_)
             | StatementKind::Deinit(_)
+            | StatementKind::Finalize(_)
             | StatementKind::StorageLive(_)
             | StatementKind::Retag(_, _)
             | StatementKind::AscribeUserType(_, _)
@@ -310,6 +311,7 @@ fn find_determining_place<'tcx>(
             // we are interested in
             StatementKind::FakeRead(_)
             | StatementKind::Deinit(_)
+            | StatementKind::Finalize(_)
             | StatementKind::StorageLive(_)
             | StatementKind::StorageDead(_)
             | StatementKind::Retag(_, _)

--- a/src/test/mir-opt/deaggregator_test.bar.Deaggregator.diff
+++ b/src/test/mir-opt/deaggregator_test.bar.Deaggregator.diff
@@ -14,6 +14,7 @@
 +         (_0.0: usize) = move _2;         // scope 0 at $DIR/deaggregator_test.rs:9:5: 9:35
 +         (_0.1: f32) = const 0f32;        // scope 0 at $DIR/deaggregator_test.rs:9:5: 9:35
 +         (_0.2: bool) = const false;      // scope 0 at $DIR/deaggregator_test.rs:9:5: 9:35
++         Finalize(_0);                    // scope 0 at $DIR/deaggregator_test.rs:9:5: 9:35
           StorageDead(_2);                 // scope 0 at $DIR/deaggregator_test.rs:9:34: 9:35
           return;                          // scope 0 at $DIR/deaggregator_test.rs:10:2: 10:2
       }

--- a/src/test/mir-opt/deaggregator_test_enum.bar.Deaggregator.diff
+++ b/src/test/mir-opt/deaggregator_test_enum.bar.Deaggregator.diff
@@ -13,6 +13,7 @@
 +         Deinit(_0);                      // scope 0 at $DIR/deaggregator_test_enum.rs:8:5: 8:22
 +         ((_0 as Foo).0: usize) = move _2; // scope 0 at $DIR/deaggregator_test_enum.rs:8:5: 8:22
 +         discriminant(_0) = 1;            // scope 0 at $DIR/deaggregator_test_enum.rs:8:5: 8:22
++         Finalize(_0);                    // scope 0 at $DIR/deaggregator_test_enum.rs:8:5: 8:22
           StorageDead(_2);                 // scope 0 at $DIR/deaggregator_test_enum.rs:8:21: 8:22
           return;                          // scope 0 at $DIR/deaggregator_test_enum.rs:9:2: 9:2
       }

--- a/src/test/mir-opt/deaggregator_test_enum_2.test1.Deaggregator.diff
+++ b/src/test/mir-opt/deaggregator_test_enum_2.test1.Deaggregator.diff
@@ -22,6 +22,7 @@
 +         Deinit(_0);                      // scope 0 at $DIR/deaggregator_test_enum_2.rs:11:9: 11:18
 +         ((_0 as A).0: i32) = move _4;    // scope 0 at $DIR/deaggregator_test_enum_2.rs:11:9: 11:18
 +         discriminant(_0) = 0;            // scope 0 at $DIR/deaggregator_test_enum_2.rs:11:9: 11:18
++         Finalize(_0);                    // scope 0 at $DIR/deaggregator_test_enum_2.rs:11:9: 11:18
           StorageDead(_4);                 // scope 0 at $DIR/deaggregator_test_enum_2.rs:11:17: 11:18
           goto -> bb3;                     // scope 0 at $DIR/deaggregator_test_enum_2.rs:10:5: 14:6
       }
@@ -33,6 +34,7 @@
 +         Deinit(_0);                      // scope 0 at $DIR/deaggregator_test_enum_2.rs:13:9: 13:18
 +         ((_0 as B).0: i32) = move _5;    // scope 0 at $DIR/deaggregator_test_enum_2.rs:13:9: 13:18
 +         discriminant(_0) = 1;            // scope 0 at $DIR/deaggregator_test_enum_2.rs:13:9: 13:18
++         Finalize(_0);                    // scope 0 at $DIR/deaggregator_test_enum_2.rs:13:9: 13:18
           StorageDead(_5);                 // scope 0 at $DIR/deaggregator_test_enum_2.rs:13:17: 13:18
           goto -> bb3;                     // scope 0 at $DIR/deaggregator_test_enum_2.rs:10:5: 14:6
       }

--- a/src/test/mir-opt/deaggregator_test_multiple.test.Deaggregator.diff
+++ b/src/test/mir-opt/deaggregator_test_multiple.test.Deaggregator.diff
@@ -17,6 +17,7 @@
 +         Deinit(_2);                      // scope 0 at $DIR/deaggregator_test_multiple.rs:10:6: 10:15
 +         ((_2 as A).0: i32) = move _3;    // scope 0 at $DIR/deaggregator_test_multiple.rs:10:6: 10:15
 +         discriminant(_2) = 0;            // scope 0 at $DIR/deaggregator_test_multiple.rs:10:6: 10:15
++         Finalize(_2);                    // scope 0 at $DIR/deaggregator_test_multiple.rs:10:6: 10:15
           StorageDead(_3);                 // scope 0 at $DIR/deaggregator_test_multiple.rs:10:14: 10:15
           StorageLive(_4);                 // scope 0 at $DIR/deaggregator_test_multiple.rs:10:17: 10:26
           StorageLive(_5);                 // scope 0 at $DIR/deaggregator_test_multiple.rs:10:24: 10:25
@@ -25,6 +26,7 @@
 +         Deinit(_4);                      // scope 0 at $DIR/deaggregator_test_multiple.rs:10:17: 10:26
 +         ((_4 as A).0: i32) = move _5;    // scope 0 at $DIR/deaggregator_test_multiple.rs:10:17: 10:26
 +         discriminant(_4) = 0;            // scope 0 at $DIR/deaggregator_test_multiple.rs:10:17: 10:26
++         Finalize(_4);                    // scope 0 at $DIR/deaggregator_test_multiple.rs:10:17: 10:26
           StorageDead(_5);                 // scope 0 at $DIR/deaggregator_test_multiple.rs:10:25: 10:26
           _0 = [move _2, move _4];         // scope 0 at $DIR/deaggregator_test_multiple.rs:10:5: 10:27
           StorageDead(_4);                 // scope 0 at $DIR/deaggregator_test_multiple.rs:10:26: 10:27

--- a/src/test/mir-opt/derefer_test.main.Derefer.diff
+++ b/src/test/mir-opt/derefer_test.main.Derefer.diff
@@ -28,12 +28,14 @@
           Deinit(_1);                      // scope 0 at $DIR/derefer_test.rs:3:17: 3:24
           (_1.0: i32) = const 42_i32;      // scope 0 at $DIR/derefer_test.rs:3:17: 3:24
           (_1.1: i32) = const 43_i32;      // scope 0 at $DIR/derefer_test.rs:3:17: 3:24
+          Finalize(_1);                    // scope 0 at $DIR/derefer_test.rs:3:17: 3:24
           StorageLive(_2);                 // scope 1 at $DIR/derefer_test.rs:4:9: 4:14
           StorageLive(_3);                 // scope 1 at $DIR/derefer_test.rs:4:22: 4:28
           _3 = &mut _1;                    // scope 1 at $DIR/derefer_test.rs:4:22: 4:28
           Deinit(_2);                      // scope 1 at $DIR/derefer_test.rs:4:17: 4:29
           (_2.0: i32) = const 99_i32;      // scope 1 at $DIR/derefer_test.rs:4:17: 4:29
           (_2.1: &mut (i32, i32)) = move _3; // scope 1 at $DIR/derefer_test.rs:4:17: 4:29
+          Finalize(_2);                    // scope 1 at $DIR/derefer_test.rs:4:17: 4:29
           StorageDead(_3);                 // scope 1 at $DIR/derefer_test.rs:4:28: 4:29
           StorageLive(_4);                 // scope 2 at $DIR/derefer_test.rs:5:9: 5:10
 -         _4 = &mut ((*(_2.1: &mut (i32, i32))).0: i32); // scope 2 at $DIR/derefer_test.rs:5:13: 5:26

--- a/src/test/mir-opt/derefer_test_multiple.main.Derefer.diff
+++ b/src/test/mir-opt/derefer_test_multiple.main.Derefer.diff
@@ -42,12 +42,14 @@
           Deinit(_1);                      // scope 0 at $DIR/derefer_test_multiple.rs:3:17: 3:25
           (_1.0: i32) = const 42_i32;      // scope 0 at $DIR/derefer_test_multiple.rs:3:17: 3:25
           (_1.1: i32) = const 43_i32;      // scope 0 at $DIR/derefer_test_multiple.rs:3:17: 3:25
+          Finalize(_1);                    // scope 0 at $DIR/derefer_test_multiple.rs:3:17: 3:25
           StorageLive(_2);                 // scope 1 at $DIR/derefer_test_multiple.rs:4:9: 4:14
           StorageLive(_3);                 // scope 1 at $DIR/derefer_test_multiple.rs:4:22: 4:28
           _3 = &mut _1;                    // scope 1 at $DIR/derefer_test_multiple.rs:4:22: 4:28
           Deinit(_2);                      // scope 1 at $DIR/derefer_test_multiple.rs:4:17: 4:29
           (_2.0: i32) = const 99_i32;      // scope 1 at $DIR/derefer_test_multiple.rs:4:17: 4:29
           (_2.1: &mut (i32, i32)) = move _3; // scope 1 at $DIR/derefer_test_multiple.rs:4:17: 4:29
+          Finalize(_2);                    // scope 1 at $DIR/derefer_test_multiple.rs:4:17: 4:29
           StorageDead(_3);                 // scope 1 at $DIR/derefer_test_multiple.rs:4:28: 4:29
           StorageLive(_4);                 // scope 2 at $DIR/derefer_test_multiple.rs:5:9: 5:14
           StorageLive(_5);                 // scope 2 at $DIR/derefer_test_multiple.rs:5:22: 5:28
@@ -55,6 +57,7 @@
           Deinit(_4);                      // scope 2 at $DIR/derefer_test_multiple.rs:5:17: 5:29
           (_4.0: i32) = const 11_i32;      // scope 2 at $DIR/derefer_test_multiple.rs:5:17: 5:29
           (_4.1: &mut (i32, &mut (i32, i32))) = move _5; // scope 2 at $DIR/derefer_test_multiple.rs:5:17: 5:29
+          Finalize(_4);                    // scope 2 at $DIR/derefer_test_multiple.rs:5:17: 5:29
           StorageDead(_5);                 // scope 2 at $DIR/derefer_test_multiple.rs:5:28: 5:29
           StorageLive(_6);                 // scope 3 at $DIR/derefer_test_multiple.rs:6:9: 6:14
           StorageLive(_7);                 // scope 3 at $DIR/derefer_test_multiple.rs:6:22: 6:28
@@ -62,6 +65,7 @@
           Deinit(_6);                      // scope 3 at $DIR/derefer_test_multiple.rs:6:17: 6:29
           (_6.0: i32) = const 13_i32;      // scope 3 at $DIR/derefer_test_multiple.rs:6:17: 6:29
           (_6.1: &mut (i32, &mut (i32, &mut (i32, i32)))) = move _7; // scope 3 at $DIR/derefer_test_multiple.rs:6:17: 6:29
+          Finalize(_6);                    // scope 3 at $DIR/derefer_test_multiple.rs:6:17: 6:29
           StorageDead(_7);                 // scope 3 at $DIR/derefer_test_multiple.rs:6:28: 6:29
           StorageLive(_8);                 // scope 4 at $DIR/derefer_test_multiple.rs:7:9: 7:10
 -         _8 = &mut ((*((*((*(_6.1: &mut (i32, &mut (i32, &mut (i32, i32))))).1: &mut (i32, &mut (i32, i32)))).1: &mut (i32, i32))).1: i32); // scope 4 at $DIR/derefer_test_multiple.rs:7:13: 7:30

--- a/src/test/mir-opt/generator_tiny.main-{closure#0}.generator_resume.0.mir
+++ b/src/test/mir-opt/generator_tiny.main-{closure#0}.generator_resume.0.mir
@@ -50,6 +50,7 @@ fn main::{closure#0}(_1: Pin<&mut [generator@$DIR/generator-tiny.rs:19:16: 25:6]
         Deinit(_0);                      // scope 1 at $DIR/generator-tiny.rs:22:13: 22:18
         ((_0 as Yielded).0: ()) = move _7; // scope 1 at $DIR/generator-tiny.rs:22:13: 22:18
         discriminant(_0) = 0;            // scope 1 at $DIR/generator-tiny.rs:22:13: 22:18
+        Finalize(_0);                    // scope 1 at $DIR/generator-tiny.rs:22:13: 22:18
         discriminant((*(_1.0: &mut [generator@$DIR/generator-tiny.rs:19:16: 25:6]))) = 3; // scope 1 at $DIR/generator-tiny.rs:22:13: 22:18
         return;                          // scope 1 at $DIR/generator-tiny.rs:22:13: 22:18
     }

--- a/src/test/mir-opt/inline/inline_generator.main.Inline.diff
+++ b/src/test/mir-opt/inline/inline_generator.main.Inline.diff
@@ -118,6 +118,7 @@
 +         Deinit(_1);                      // scope 6 at $DIR/inline-generator.rs:15:11: 15:39
 +         ((_1 as Yielded).0: i32) = move _8; // scope 6 at $DIR/inline-generator.rs:15:11: 15:39
 +         discriminant(_1) = 0;            // scope 6 at $DIR/inline-generator.rs:15:11: 15:39
++         Finalize(_1);                    // scope 6 at $DIR/inline-generator.rs:15:11: 15:39
 +         discriminant((*(_2.0: &mut [generator@$DIR/inline-generator.rs:15:5: 15:41]))) = 3; // scope 6 at $DIR/inline-generator.rs:15:11: 15:39
 +         goto -> bb1;                     // scope 0 at $DIR/inline-generator.rs:15:11: 15:39
 +     }
@@ -129,6 +130,7 @@
 +         Deinit(_1);                      // scope 6 at $DIR/inline-generator.rs:15:41: 15:41
 +         ((_1 as Complete).0: bool) = move _10; // scope 6 at $DIR/inline-generator.rs:15:41: 15:41
 +         discriminant(_1) = 1;            // scope 6 at $DIR/inline-generator.rs:15:41: 15:41
++         Finalize(_1);                    // scope 6 at $DIR/inline-generator.rs:15:41: 15:41
 +         discriminant((*(_2.0: &mut [generator@$DIR/inline-generator.rs:15:5: 15:41]))) = 1; // scope 6 at $DIR/inline-generator.rs:15:41: 15:41
 +         goto -> bb1;                     // scope 0 at $DIR/inline-generator.rs:15:41: 15:41
 +     }

--- a/src/test/mir-opt/issue_41110.main.ElaborateDrops.after.mir
+++ b/src/test/mir-opt/issue_41110.main.ElaborateDrops.after.mir
@@ -15,11 +15,13 @@ fn main() -> () {
         _5 = const false;                // scope 0 at $DIR/issue-41110.rs:8:9: 8:10
         StorageLive(_1);                 // scope 0 at $DIR/issue-41110.rs:8:9: 8:10
         StorageLive(_2);                 // scope 0 at $DIR/issue-41110.rs:8:13: 8:14
+        Deinit(_2);                      // scope 0 at $DIR/issue-41110.rs:8:13: 8:14
         _5 = const true;                 // scope 0 at $DIR/issue-41110.rs:8:13: 8:14
-        _2 = S;                          // scope 0 at $DIR/issue-41110.rs:8:13: 8:14
+        Finalize(_2);                    // scope 0 at $DIR/issue-41110.rs:8:13: 8:14
         StorageLive(_3);                 // scope 0 at $DIR/issue-41110.rs:8:21: 8:27
         StorageLive(_4);                 // scope 0 at $DIR/issue-41110.rs:8:21: 8:22
-        _4 = S;                          // scope 0 at $DIR/issue-41110.rs:8:21: 8:22
+        Deinit(_4);                      // scope 0 at $DIR/issue-41110.rs:8:21: 8:22
+        Finalize(_4);                    // scope 0 at $DIR/issue-41110.rs:8:21: 8:22
         _3 = S::id(move _4) -> [return: bb1, unwind: bb4]; // scope 0 at $DIR/issue-41110.rs:8:21: 8:27
                                          // mir::Constant
                                          // + span: $DIR/issue-41110.rs:8:23: 8:25

--- a/src/test/mir-opt/issue_41110.test.ElaborateDrops.after.mir
+++ b/src/test/mir-opt/issue_41110.test.ElaborateDrops.after.mir
@@ -18,10 +18,12 @@ fn test() -> () {
     bb0: {
         _6 = const false;                // scope 0 at $DIR/issue-41110.rs:15:9: 15:10
         StorageLive(_1);                 // scope 0 at $DIR/issue-41110.rs:15:9: 15:10
+        Deinit(_1);                      // scope 0 at $DIR/issue-41110.rs:15:13: 15:14
         _6 = const true;                 // scope 0 at $DIR/issue-41110.rs:15:13: 15:14
-        _1 = S;                          // scope 0 at $DIR/issue-41110.rs:15:13: 15:14
+        Finalize(_1);                    // scope 0 at $DIR/issue-41110.rs:15:13: 15:14
         StorageLive(_2);                 // scope 1 at $DIR/issue-41110.rs:16:9: 16:14
-        _2 = S;                          // scope 1 at $DIR/issue-41110.rs:16:17: 16:18
+        Deinit(_2);                      // scope 1 at $DIR/issue-41110.rs:16:17: 16:18
+        Finalize(_2);                    // scope 1 at $DIR/issue-41110.rs:16:17: 16:18
         StorageLive(_3);                 // scope 2 at $DIR/issue-41110.rs:17:5: 17:12
         StorageLive(_4);                 // scope 2 at $DIR/issue-41110.rs:17:10: 17:11
         _4 = move _2;                    // scope 2 at $DIR/issue-41110.rs:17:10: 17:11

--- a/src/test/mir-opt/issue_41888.main.ElaborateDrops.after.mir
+++ b/src/test/mir-opt/issue_41888.main.ElaborateDrops.after.mir
@@ -21,9 +21,9 @@ fn main() -> () {
     }
 
     bb0: {
-        _9 = const false;                // scope 0 at $DIR/issue-41888.rs:7:9: 7:10
         _7 = const false;                // scope 0 at $DIR/issue-41888.rs:7:9: 7:10
         _8 = const false;                // scope 0 at $DIR/issue-41888.rs:7:9: 7:10
+        _9 = const false;                // scope 0 at $DIR/issue-41888.rs:7:9: 7:10
         StorageLive(_1);                 // scope 0 at $DIR/issue-41888.rs:7:9: 7:10
         StorageLive(_2);                 // scope 1 at $DIR/issue-41888.rs:8:8: 8:14
         _2 = cond() -> [return: bb1, unwind: bb11]; // scope 1 at $DIR/issue-41888.rs:8:8: 8:14
@@ -39,8 +39,12 @@ fn main() -> () {
     bb2: {
         StorageLive(_3);                 // scope 1 at $DIR/issue-41888.rs:9:13: 9:20
         StorageLive(_4);                 // scope 1 at $DIR/issue-41888.rs:9:18: 9:19
-        _4 = K;                          // scope 1 at $DIR/issue-41888.rs:9:18: 9:19
-        _3 = E::F(move _4);              // scope 1 at $DIR/issue-41888.rs:9:13: 9:20
+        Deinit(_4);                      // scope 1 at $DIR/issue-41888.rs:9:18: 9:19
+        Finalize(_4);                    // scope 1 at $DIR/issue-41888.rs:9:18: 9:19
+        Deinit(_3);                      // scope 1 at $DIR/issue-41888.rs:9:13: 9:20
+        ((_3 as F).0: K) = move _4;      // scope 1 at $DIR/issue-41888.rs:9:13: 9:20
+        discriminant(_3) = 0;            // scope 1 at $DIR/issue-41888.rs:9:13: 9:20
+        Finalize(_3);                    // scope 1 at $DIR/issue-41888.rs:9:13: 9:20
         StorageDead(_4);                 // scope 1 at $DIR/issue-41888.rs:9:19: 9:20
         goto -> bb14;                    // scope 1 at $DIR/issue-41888.rs:9:9: 9:10
     }

--- a/src/test/mir-opt/issue_62289.test.ElaborateDrops.before.mir
+++ b/src/test/mir-opt/issue_62289.test.ElaborateDrops.before.mir
@@ -42,7 +42,9 @@ fn test() -> Option<Box<u32>> {
         _5 = ShallowInitBox(move _4, u32); // scope 0 at $DIR/issue-62289.rs:9:10: 9:21
         StorageLive(_6);                 // scope 0 at $DIR/issue-62289.rs:9:15: 9:20
         StorageLive(_7);                 // scope 0 at $DIR/issue-62289.rs:9:15: 9:19
-        _7 = Option::<u32>::None;        // scope 0 at $DIR/issue-62289.rs:9:15: 9:19
+        Deinit(_7);                      // scope 0 at $DIR/issue-62289.rs:9:15: 9:19
+        discriminant(_7) = 0;            // scope 0 at $DIR/issue-62289.rs:9:15: 9:19
+        Finalize(_7);                    // scope 0 at $DIR/issue-62289.rs:9:15: 9:19
         _6 = <Option<u32> as Try>::branch(move _7) -> [return: bb2, unwind: bb12]; // scope 0 at $DIR/issue-62289.rs:9:15: 9:20
                                          // mir::Constant
                                          // + span: $DIR/issue-62289.rs:9:15: 9:20
@@ -87,7 +89,10 @@ fn test() -> Option<Box<u32>> {
 
     bb7: {
         StorageDead(_5);                 // scope 0 at $DIR/issue-62289.rs:9:20: 9:21
-        _0 = Option::<Box<u32>>::Some(move _1); // scope 0 at $DIR/issue-62289.rs:9:5: 9:22
+        Deinit(_0);                      // scope 0 at $DIR/issue-62289.rs:9:5: 9:22
+        ((_0 as Some).0: std::boxed::Box<u32>) = move _1; // scope 0 at $DIR/issue-62289.rs:9:5: 9:22
+        discriminant(_0) = 1;            // scope 0 at $DIR/issue-62289.rs:9:5: 9:22
+        Finalize(_0);                    // scope 0 at $DIR/issue-62289.rs:9:5: 9:22
         drop(_1) -> bb8;                 // scope 0 at $DIR/issue-62289.rs:9:21: 9:22
     }
 

--- a/src/test/mir-opt/packed_struct_drop_aligned.main.SimplifyCfg-elaborate-drops.after.32bit.mir
+++ b/src/test/mir-opt/packed_struct_drop_aligned.main.SimplifyCfg-elaborate-drops.after.32bit.mir
@@ -16,15 +16,25 @@ fn main() -> () {
         StorageLive(_1);                 // scope 0 at $DIR/packed-struct-drop-aligned.rs:6:9: 6:14
         StorageLive(_2);                 // scope 0 at $DIR/packed-struct-drop-aligned.rs:6:24: 6:42
         StorageLive(_3);                 // scope 0 at $DIR/packed-struct-drop-aligned.rs:6:32: 6:41
-        _3 = Droppy(const 0_usize);      // scope 0 at $DIR/packed-struct-drop-aligned.rs:6:32: 6:41
-        _2 = Aligned(move _3);           // scope 0 at $DIR/packed-struct-drop-aligned.rs:6:24: 6:42
+        Deinit(_3);                      // scope 0 at $DIR/packed-struct-drop-aligned.rs:6:32: 6:41
+        (_3.0: usize) = const 0_usize;   // scope 0 at $DIR/packed-struct-drop-aligned.rs:6:32: 6:41
+        Finalize(_3);                    // scope 0 at $DIR/packed-struct-drop-aligned.rs:6:32: 6:41
+        Deinit(_2);                      // scope 0 at $DIR/packed-struct-drop-aligned.rs:6:24: 6:42
+        (_2.0: Droppy) = move _3;        // scope 0 at $DIR/packed-struct-drop-aligned.rs:6:24: 6:42
+        Finalize(_2);                    // scope 0 at $DIR/packed-struct-drop-aligned.rs:6:24: 6:42
         StorageDead(_3);                 // scope 0 at $DIR/packed-struct-drop-aligned.rs:6:41: 6:42
-        _1 = Packed(move _2);            // scope 0 at $DIR/packed-struct-drop-aligned.rs:6:17: 6:43
+        Deinit(_1);                      // scope 0 at $DIR/packed-struct-drop-aligned.rs:6:17: 6:43
+        (_1.0: Aligned) = move _2;       // scope 0 at $DIR/packed-struct-drop-aligned.rs:6:17: 6:43
+        Finalize(_1);                    // scope 0 at $DIR/packed-struct-drop-aligned.rs:6:17: 6:43
         StorageDead(_2);                 // scope 0 at $DIR/packed-struct-drop-aligned.rs:6:42: 6:43
         StorageLive(_4);                 // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:11: 7:29
         StorageLive(_5);                 // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:19: 7:28
-        _5 = Droppy(const 0_usize);      // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:19: 7:28
-        _4 = Aligned(move _5);           // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:11: 7:29
+        Deinit(_5);                      // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:19: 7:28
+        (_5.0: usize) = const 0_usize;   // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:19: 7:28
+        Finalize(_5);                    // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:19: 7:28
+        Deinit(_4);                      // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:11: 7:29
+        (_4.0: Droppy) = move _5;        // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:11: 7:29
+        Finalize(_4);                    // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:11: 7:29
         StorageDead(_5);                 // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:28: 7:29
         StorageLive(_6);                 // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:5: 7:8
         _6 = move (_1.0: Aligned);       // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:5: 7:8

--- a/src/test/mir-opt/packed_struct_drop_aligned.main.SimplifyCfg-elaborate-drops.after.64bit.mir
+++ b/src/test/mir-opt/packed_struct_drop_aligned.main.SimplifyCfg-elaborate-drops.after.64bit.mir
@@ -16,15 +16,25 @@ fn main() -> () {
         StorageLive(_1);                 // scope 0 at $DIR/packed-struct-drop-aligned.rs:6:9: 6:14
         StorageLive(_2);                 // scope 0 at $DIR/packed-struct-drop-aligned.rs:6:24: 6:42
         StorageLive(_3);                 // scope 0 at $DIR/packed-struct-drop-aligned.rs:6:32: 6:41
-        _3 = Droppy(const 0_usize);      // scope 0 at $DIR/packed-struct-drop-aligned.rs:6:32: 6:41
-        _2 = Aligned(move _3);           // scope 0 at $DIR/packed-struct-drop-aligned.rs:6:24: 6:42
+        Deinit(_3);                      // scope 0 at $DIR/packed-struct-drop-aligned.rs:6:32: 6:41
+        (_3.0: usize) = const 0_usize;   // scope 0 at $DIR/packed-struct-drop-aligned.rs:6:32: 6:41
+        Finalize(_3);                    // scope 0 at $DIR/packed-struct-drop-aligned.rs:6:32: 6:41
+        Deinit(_2);                      // scope 0 at $DIR/packed-struct-drop-aligned.rs:6:24: 6:42
+        (_2.0: Droppy) = move _3;        // scope 0 at $DIR/packed-struct-drop-aligned.rs:6:24: 6:42
+        Finalize(_2);                    // scope 0 at $DIR/packed-struct-drop-aligned.rs:6:24: 6:42
         StorageDead(_3);                 // scope 0 at $DIR/packed-struct-drop-aligned.rs:6:41: 6:42
-        _1 = Packed(move _2);            // scope 0 at $DIR/packed-struct-drop-aligned.rs:6:17: 6:43
+        Deinit(_1);                      // scope 0 at $DIR/packed-struct-drop-aligned.rs:6:17: 6:43
+        (_1.0: Aligned) = move _2;       // scope 0 at $DIR/packed-struct-drop-aligned.rs:6:17: 6:43
+        Finalize(_1);                    // scope 0 at $DIR/packed-struct-drop-aligned.rs:6:17: 6:43
         StorageDead(_2);                 // scope 0 at $DIR/packed-struct-drop-aligned.rs:6:42: 6:43
         StorageLive(_4);                 // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:11: 7:29
         StorageLive(_5);                 // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:19: 7:28
-        _5 = Droppy(const 0_usize);      // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:19: 7:28
-        _4 = Aligned(move _5);           // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:11: 7:29
+        Deinit(_5);                      // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:19: 7:28
+        (_5.0: usize) = const 0_usize;   // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:19: 7:28
+        Finalize(_5);                    // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:19: 7:28
+        Deinit(_4);                      // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:11: 7:29
+        (_4.0: Droppy) = move _5;        // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:11: 7:29
+        Finalize(_4);                    // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:11: 7:29
         StorageDead(_5);                 // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:28: 7:29
         StorageLive(_6);                 // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:5: 7:8
         _6 = move (_1.0: Aligned);       // scope 1 at $DIR/packed-struct-drop-aligned.rs:7:5: 7:8

--- a/src/test/mir-opt/retag.array_casts.SimplifyCfg-elaborate-drops.after.mir
+++ b/src/test/mir-opt/retag.array_casts.SimplifyCfg-elaborate-drops.after.mir
@@ -128,7 +128,12 @@ fn array_casts() -> () {
         Retag(_35);                      // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         _18 = &(*_35);                   // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         Retag(_18);                      // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _13 = (move _14, move _18);      // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        Deinit(_13);                     // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        (_13.0: &usize) = move _14;      // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        Retag((_13.0: &usize));          // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        (_13.1: &usize) = move _18;      // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        Retag((_13.1: &usize));          // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        Finalize(_13);                   // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         StorageDead(_18);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         StorageDead(_14);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         StorageLive(_20);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
@@ -153,7 +158,9 @@ fn array_casts() -> () {
 
     bb3: {
         StorageLive(_27);                // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _27 = core::panicking::AssertKind::Eq; // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        Deinit(_27);                     // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        discriminant(_27) = 0;           // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        Finalize(_27);                   // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         StorageLive(_28);                // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         StorageLive(_29);                // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         _29 = move _27;                  // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
@@ -170,7 +177,9 @@ fn array_casts() -> () {
         _32 = &(*_33);                   // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         Retag(_32);                      // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         StorageLive(_34);                // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-        _34 = Option::<Arguments>::None; // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        Deinit(_34);                     // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        discriminant(_34) = 0;           // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+        Finalize(_34);                   // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
         core::panicking::assert_failed::<usize, usize>(move _29, move _30, move _32, move _34); // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                          // mir::Constant
                                          // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL

--- a/src/test/mir-opt/retag.main.SimplifyCfg-elaborate-drops.after.mir
+++ b/src/test/mir-opt/retag.main.SimplifyCfg-elaborate-drops.after.mir
@@ -62,7 +62,9 @@ fn main() -> () {
         StorageLive(_3);                 // scope 1 at $DIR/retag.rs:32:13: 32:14
         StorageLive(_4);                 // scope 1 at $DIR/retag.rs:32:17: 32:36
         StorageLive(_5);                 // scope 1 at $DIR/retag.rs:32:17: 32:24
-        _5 = Test(const 0_i32);          // scope 1 at $DIR/retag.rs:32:17: 32:24
+        Deinit(_5);                      // scope 1 at $DIR/retag.rs:32:17: 32:24
+        (_5.0: i32) = const 0_i32;       // scope 1 at $DIR/retag.rs:32:17: 32:24
+        Finalize(_5);                    // scope 1 at $DIR/retag.rs:32:17: 32:24
         _4 = &_5;                        // scope 1 at $DIR/retag.rs:32:17: 32:36
         Retag(_4);                       // scope 1 at $DIR/retag.rs:32:17: 32:36
         StorageLive(_6);                 // scope 1 at $DIR/retag.rs:32:29: 32:35
@@ -111,15 +113,8 @@ fn main() -> () {
         StorageDead(_2);                 // scope 1 at $DIR/retag.rs:37:5: 37:6
         StorageLive(_13);                // scope 1 at $DIR/retag.rs:40:9: 40:10
         StorageLive(_14);                // scope 1 at $DIR/retag.rs:40:31: 43:6
-        _14 = [closure@main::{closure#0}]; // scope 1 at $DIR/retag.rs:40:31: 43:6
-                                         // closure
-                                         // + def_id: DefId(0:14 ~ retag[4622]::main::{closure#0})
-                                         // + substs: [
-                                         //     i8,
-                                         //     for<'r> extern "rust-call" fn((&'r i32,)) -> &'r i32,
-                                         //     (),
-                                         // ]
-        Retag(_14);                      // scope 1 at $DIR/retag.rs:40:31: 43:6
+        Deinit(_14);                     // scope 1 at $DIR/retag.rs:40:31: 43:6
+        Finalize(_14);                   // scope 1 at $DIR/retag.rs:40:31: 43:6
         _13 = move _14 as for<'r> fn(&'r i32) -> &'r i32 (Pointer(ClosureFnPointer(Normal))); // scope 1 at $DIR/retag.rs:40:31: 43:6
         StorageDead(_14);                // scope 1 at $DIR/retag.rs:43:5: 43:6
         StorageLive(_15);                // scope 6 at $DIR/retag.rs:44:9: 44:11
@@ -142,7 +137,9 @@ fn main() -> () {
         StorageLive(_19);                // scope 7 at $DIR/retag.rs:47:5: 47:24
         StorageLive(_20);                // scope 7 at $DIR/retag.rs:47:5: 47:24
         StorageLive(_21);                // scope 7 at $DIR/retag.rs:47:5: 47:12
-        _21 = Test(const 0_i32);         // scope 7 at $DIR/retag.rs:47:5: 47:12
+        Deinit(_21);                     // scope 7 at $DIR/retag.rs:47:5: 47:12
+        (_21.0: i32) = const 0_i32;      // scope 7 at $DIR/retag.rs:47:5: 47:12
+        Finalize(_21);                   // scope 7 at $DIR/retag.rs:47:5: 47:12
         _20 = &_21;                      // scope 7 at $DIR/retag.rs:47:5: 47:24
         Retag(_20);                      // scope 7 at $DIR/retag.rs:47:5: 47:24
         StorageLive(_22);                // scope 7 at $DIR/retag.rs:47:21: 47:23

--- a/src/test/mir-opt/unusual_item_types.Test-X-{constructor#0}.mir_map.0.32bit.mir
+++ b/src/test/mir-opt/unusual_item_types.Test-X-{constructor#0}.mir_map.0.32bit.mir
@@ -7,6 +7,7 @@ fn Test::X(_1: usize) -> Test {
         Deinit(_0);                      // scope 0 at $DIR/unusual-item-types.rs:16:5: 16:13
         ((_0 as X).0: usize) = move _1;  // scope 0 at $DIR/unusual-item-types.rs:16:5: 16:13
         discriminant(_0) = 0;            // scope 0 at $DIR/unusual-item-types.rs:16:5: 16:13
+        Finalize(_0);                    // scope 0 at $DIR/unusual-item-types.rs:16:5: 16:13
         return;                          // scope 0 at $DIR/unusual-item-types.rs:16:5: 16:13
     }
 }

--- a/src/test/mir-opt/unusual_item_types.Test-X-{constructor#0}.mir_map.0.64bit.mir
+++ b/src/test/mir-opt/unusual_item_types.Test-X-{constructor#0}.mir_map.0.64bit.mir
@@ -7,6 +7,7 @@ fn Test::X(_1: usize) -> Test {
         Deinit(_0);                      // scope 0 at $DIR/unusual-item-types.rs:16:5: 16:13
         ((_0 as X).0: usize) = move _1;  // scope 0 at $DIR/unusual-item-types.rs:16:5: 16:13
         discriminant(_0) = 0;            // scope 0 at $DIR/unusual-item-types.rs:16:5: 16:13
+        Finalize(_0);                    // scope 0 at $DIR/unusual-item-types.rs:16:5: 16:13
         return;                          // scope 0 at $DIR/unusual-item-types.rs:16:5: 16:13
     }
 }

--- a/src/test/ui/async-await/async-fn-size-moved-locals.rs
+++ b/src/test/ui/async-await/async-fn-size-moved-locals.rs
@@ -114,5 +114,5 @@ fn main() {
     assert_eq!(1026, std::mem::size_of_val(&single_with_noop()));
     assert_eq!(3076, std::mem::size_of_val(&joined()));
     assert_eq!(3076, std::mem::size_of_val(&joined_with_noop()));
-    assert_eq!(6157, std::mem::size_of_val(&mixed_sizes()));
+    assert_eq!(6159, std::mem::size_of_val(&mixed_sizes()));
 }

--- a/src/test/ui/type-alias-impl-trait/issue-53678-generator-and-const-fn.rs
+++ b/src/test/ui/type-alias-impl-trait/issue-53678-generator-and-const-fn.rs
@@ -1,5 +1,7 @@
-#![feature(generators, generator_trait, rustc_attrs)]
+#![feature(generators, generator_trait)]
 #![feature(type_alias_impl_trait)]
+
+// build-pass
 
 use std::ops::Generator;
 
@@ -15,5 +17,4 @@ const fn const_generator<Y, R>(yielding: Y, returning: R) -> GenOnce<Y, R> {
 
 const FOO: GenOnce<usize, usize> = const_generator(10, 100);
 
-#[rustc_error]
-fn main() {} //~ ERROR
+fn main() {}

--- a/src/test/ui/type-alias-impl-trait/issue-53678-generator-and-const-fn.stderr
+++ b/src/test/ui/type-alias-impl-trait/issue-53678-generator-and-const-fn.stderr
@@ -1,8 +1,0 @@
-error: fatal error triggered by #[rustc_error]
-  --> $DIR/issue-53678-generator-and-const-fn.rs:19:1
-   |
-LL | fn main() {}
-   | ^^^^^^^^^
-
-error: aborting due to previous error
-

--- a/src/tools/clippy/clippy_utils/src/qualify_min_const_fn.rs
+++ b/src/tools/clippy/clippy_utils/src/qualify_min_const_fn.rs
@@ -211,6 +211,7 @@ fn check_statement<'tcx>(
 
         StatementKind::FakeRead(box (_, place)) => check_place(tcx, *place, span, body),
         // just an assignment
+        StatementKind::Finalize(place) |
         StatementKind::SetDiscriminant { place, .. } | StatementKind::Deinit(place) => 
             check_place(tcx, **place, span, body),
 


### PR DESCRIPTION
cc @JakobDegen 

cc @compiler-errors (Due to the additional information encodable for temporaries, once we stop emitting aggregates during mir building, this should improve diagnostics in borrowck, and especially around opaque types)

This PR can stand on its own, but I'm not sure its valuable on its own. I'm planning to continue moving the deaggregation pass earlier, until it runs right after mir building. Then I will remove it and make mir building generate deaggregated MIR