### PR TITLE
Add support for `sysroot` --extern flag

### DIFF
--- a/compiler/rustc_interface/src/tests.rs
+++ b/compiler/rustc_interface/src/tests.rs
@@ -66,6 +66,7 @@ where
         location: ExternLocation::ExactPaths(locations),
         is_private_dep: false,
         add_prelude: true,
+        sysroot_dep: false,
     }
 }
 

--- a/compiler/rustc_metadata/src/creader.rs
+++ b/compiler/rustc_metadata/src/creader.rs
@@ -908,6 +908,10 @@ impl<'a> CrateLoader<'a> {
                 // Don't worry about pathless `--extern foo` sysroot references
                 continue;
             }
+            if entry.sysroot_dep {
+                // If it's an explicit sysroot dependency, let it slide
+                continue;
+            }
             let name_interned = Symbol::intern(name);
             if self.used_extern_options.contains(&name_interned) {
                 continue;

--- a/src/test/ui/extern-flag/no-sysroot.rs
+++ b/src/test/ui/extern-flag/no-sysroot.rs
@@ -1,0 +1,6 @@
+// aux-crate:somedep=somedep.rs
+// compile-flags: -Zunstable-options -Dunused-crate-dependencies
+// edition:2018
+
+fn main() { //~ ERROR external crate `somedep` unused in `no_sysroot`
+}

--- a/src/test/ui/extern-flag/no-sysroot.stderr
+++ b/src/test/ui/extern-flag/no-sysroot.stderr
@@ -1,0 +1,11 @@
+error: external crate `somedep` unused in `no_sysroot`: remove the dependency or add `use somedep as _;`
+  --> $DIR/no-sysroot.rs:5:1
+   |
+LL | fn main() {
+   | ^
+   |
+   = note: requested on the command line with `-D unused-crate-dependencies`
+   = help: remove unnecessary dependency `somedep`
+
+error: aborting due to previous error
+

--- a/src/test/ui/extern-flag/sysroot.rs
+++ b/src/test/ui/extern-flag/sysroot.rs
@@ -1,0 +1,7 @@
+// check-pass
+// aux-crate:sysroot:somedep=somedep.rs
+// compile-flags: -Zunstable-options -Dunused-crate-dependencies
+// edition:2018
+
+fn main() {
+}


### PR DESCRIPTION
This adds `sysroot` to the set of extern flags:
`--extern sysroot:core=/path/to/core/libcore.rlib`.

The primary effect of this flag is to suppress `unused-crate-dependencies`
warnings relating to the crate.

It's used for build environments where it's desirable for the build
system to explicitly specify dependencies on sysroot crates rather than
letting rustc find them implicitly. In such cases, these dependencies
are likely to be added unconditionally, so there's no way that a user
could act on an unused dependency warning.

Alternatively, I'd be fine with making this flag more explicitly about
suppressing the warning - e.g. `nounused`.