### PR TITLE
Implement str to [u8] conversion for refcounted containers

### DIFF
--- a/library/alloc/src/rc.rs
+++ b/library/alloc/src/rc.rs
@@ -1956,6 +1956,25 @@ where
     }
 }
 
+#[stable(feature = "shared_from_str", since = "1.61.0")]
+impl From<Rc<str>> for Rc<[u8]> {
+    /// Converts a reference-counted string slice into a byte slice.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use std::rc::Rc;
+    /// let string: Rc<str> = Rc::from("eggplant");
+    /// let bytes: Rc<[u8]> = Rc::from(string);
+    /// assert_eq!("eggplant".as_bytes(), bytes.as_ref());
+    /// ```
+    #[inline]
+    fn from(rc: Rc<str>) -> Self {
+        // SAFETY: `str` has the same layout as `[u8]`.
+        unsafe { Rc::from_raw(Rc::into_raw(rc) as *const [u8]) }
+    }
+}
+
 #[stable(feature = "boxed_slice_try_from", since = "1.43.0")]
 impl<T, const N: usize> TryFrom<Rc<[T]>> for Rc<[T; N]> {
     type Error = Rc<[T]>;

--- a/library/alloc/src/rc.rs
+++ b/library/alloc/src/rc.rs
@@ -1956,7 +1956,7 @@ where
     }
 }
 
-#[stable(feature = "shared_from_str", since = "1.61.0")]
+#[stable(feature = "shared_from_str", since = "1.62.0")]
 impl From<Rc<str>> for Rc<[u8]> {
     /// Converts a reference-counted string slice into a byte slice.
     ///

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -2556,6 +2556,25 @@ where
     }
 }
 
+#[stable(feature = "shared_from_str", since = "1.61.0")]
+impl From<Arc<str>> for Arc<[u8]> {
+    /// Converts an atomically reference-counted string slice into a byte slice.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use std::sync::Arc;
+    /// let string: Arc<str> = Arc::from("eggplant");
+    /// let bytes: Arc<[u8]> = Arc::from(string);
+    /// assert_eq!("eggplant".as_bytes(), bytes.as_ref());
+    /// ```
+    #[inline]
+    fn from(rc: Arc<str>) -> Self {
+        // SAFETY: `str` has the same layout as `[u8]`.
+        unsafe { Arc::from_raw(Arc::into_raw(rc) as *const [u8]) }
+    }
+}
+
 #[stable(feature = "boxed_slice_try_from", since = "1.43.0")]
 impl<T, const N: usize> TryFrom<Arc<[T]>> for Arc<[T; N]> {
     type Error = Arc<[T]>;

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -2556,7 +2556,7 @@ where
     }
 }
 
-#[stable(feature = "shared_from_str", since = "1.61.0")]
+#[stable(feature = "shared_from_str", since = "1.62.0")]
 impl From<Arc<str>> for Arc<[u8]> {
     /// Converts an atomically reference-counted string slice into a byte slice.
     ///


### PR DESCRIPTION
This seems motivated to complete the APIs for shared containers since we already have similar allocation-free conversions for strings like `From<Box<[u8]>> for Box<str>`.

Insta-stable since it's a new trait impl?