### PR TITLE
Respect ranlib specified for target during LLVM build

### DIFF
--- a/src/bootstrap/cc_detect.rs
+++ b/src/bootstrap/cc_detect.rs
@@ -149,6 +149,10 @@ pub fn find(build: &mut Build) {
             build.verbose(&format!("AR_{} = {:?}", &target.triple, ar));
             build.ar.insert(target, ar);
         }
+
+        if let Some(ranlib) = config.and_then(|c| c.ranlib.clone()) {
+            build.ranlib.insert(target, ranlib);
+        }
     }
 }
 


### PR DESCRIPTION
The ranlib specified for the target was never actually transferred
into the builder configuration. In the dist-x86_64-linux build we
ended up using ranlib instead of llvm-ranlib.

Found this investigating a build failure in #94214.