### PR TITLE
Fix rustdoc duplicated blanket impls

### DIFF
--- a/src/test/rustdoc/duplicated_impl.rs
+++ b/src/test/rustdoc/duplicated_impl.rs
@@ -1,0 +1,14 @@
+// This test ensures that the same implementation doesn't show more than once.
+// It's a regression test for https://github.com/rust-lang/rust/issues/96036.
+
+#![crate_name = "foo"]
+
+// We check that there is only one "impl<T> Something<Whatever> for T" listed in the
+// blanket implementations.
+
+// @has 'foo/struct.Whatever.html'
+// @count - '//*[@id="blanket-implementations-list"]/section[@class="impl has-srclink"]' 1
+
+pub trait Something<T> { }
+pub struct Whatever;
+impl<T> Something<Whatever> for T {}


### PR DESCRIPTION
Fixes #96036.

I think it'll not be great performance-wise but I couldn't find another way to prevent that unfortunately...

r? @notriddle 