### PR TITLE
MaybeUninit array cleanup

### DIFF
--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -117,6 +117,7 @@
 #![feature(const_intrinsic_copy)]
 #![feature(const_intrinsic_forget)]
 #![feature(const_likely)]
+#![feature(const_maybe_uninit_uninit_array)]
 #![feature(const_maybe_uninit_as_mut_ptr)]
 #![feature(const_maybe_uninit_assume_init)]
 #![feature(const_num_from_num)]


### PR DESCRIPTION
* Links `MaybeUninit::uninit_array` to meta-tracking issue
* Links `MaybeUninit::array_assume_init` to meta-tracking issue
* Unstably constifies `MaybeUninit::array_assume_init`

Another thing worth mentioning: this splits the const feature flag for `maybe_uninit_uninit_array` into `const_maybe_uninit_uninit_array` to avoid weird cases where only one gets stabilised.

Note that it may be desired to keep the `array_assume_init` method linked to its dedicated issue, but at least for now, I decided to link to the meta-tracking issue so that all of the methods lead users to the same place. But I can revert that bit if desired.

The meta-tracking issue that I filed is #96097.