### PR TITLE
Make the debug output for `TargetSelection` less verbose

### DIFF
--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -221,7 +221,7 @@ impl FromStr for LlvmLibunwind {
     }
 }
 
-#[derive(Debug, Copy, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Copy, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct TargetSelection {
     pub triple: Interned<String>,
     file: Option<Interned<String>>,
@@ -273,6 +273,12 @@ impl fmt::Display for TargetSelection {
             write!(f, "({})", file)?;
         }
         Ok(())
+    }
+}
+
+impl fmt::Debug for TargetSelection {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self)
     }
 }
 


### PR DESCRIPTION
In particular, this makes the output of `x build -vv` easier to read.
Before:

```
    c Sysroot { compiler: Compiler { stage: 0, host: TargetSelection { triple: "x86_64-unknown-linux-gnu", file: None } } }
```

After:
```
    c Sysroot { compiler: Compiler { stage: 0, host: x86_64-unknown-linux-gnu } }
```