### PR TITLE
`impl<T: AsRef<Path>> Div<T> for {Path, PathBuf}`

### DIFF
--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -1742,6 +1742,39 @@ impl Default for PathBuf {
     }
 }
 
+#[stable(feature = "path_div", since = "1.62.0")]
+/// A convenient syntax for creating cross-platform file paths without unnecessary allocation.
+///
+/// Example:
+/// ```
+/// use std::path::{Path, PathBuf};
+/// let path = PathBuf::from(".rustup") / "toolchains" / "stable-x86_64-unknown-linux-gnu";
+/// assert_eq!(path, Path::new(".rustup/toolchains/stable-x86_64-unknown-linux-gnu"));
+/// ```
+impl<T: ?Sized + AsRef<Path>> core::ops::Div<&T> for PathBuf {
+    type Output = PathBuf;
+    fn div(mut self, rhs: &T) -> Self {
+        self.push(rhs);
+        self
+    }
+}
+
+/// A convenient syntax for creating cross-platform file paths without unnecessary allocation.
+///
+/// Example:
+/// ```
+/// use std::path::Path;
+/// let path = Path::new(".rustup") / "toolchains" / "stable-x86_64-unknown-linux-gnu";
+/// assert_eq!(path, Path::new(".rustup/toolchains/stable-x86_64-unknown-linux-gnu"));
+/// ```
+#[stable(feature = "path_div", since = "1.62.0")]
+impl<T: ?Sized + AsRef<Path>> core::ops::Div<&T> for &Path {
+    type Output = PathBuf;
+    fn div(self, rhs: &T) -> PathBuf {
+        self.join(rhs)
+    }
+}
+
 #[stable(feature = "cow_from_path", since = "1.6.0")]
 impl<'a> From<&'a Path> for Cow<'a, Path> {
     /// Creates a clone-on-write pointer from a reference to


### PR DESCRIPTION
This was suggested by @mgattozzi in https://twitter.com/mgattozzi/status/1511150559453229059.
Don't let your memes be dreams!

The serious motivation for this change is that it's currently annoying to do this in a
cross-platform way without unnecessary allocations. The possible options are:
1. (least common): `["x", "y", "z"].into_iter().collect::<PathBuf>().` This works, but is non-trivial to discover and very rare in practice.
2. (more common) `Path::new("x").join("y").join("z")`. This works, but does an unnecessary allocation for each intermediate path.
3. (most common) `Path::new("x/y/z")`. Not cross-platform.

This PR introduces a fourth option, `Path::new("x") / "y" / "z"`, which
is easier to type than both options 1 and 2, while still being cross-platform
and avoiding allocations.