### PR TITLE
Add support for LibreSSL 3.4.x

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2502,9 +2502,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.35"
+version = "0.10.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "549430950c79ae24e6d02e0b7404534ecf311d94cc9f861e9e4020187d13d885"
+checksum = "0c7ae222234c30df141154f159066c5093ff73b63204dcda7121eb082fc56a95"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
@@ -2531,9 +2531,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.65"
+version = "0.9.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a7907e3bfa08bb85105209cdfcb6c63d109f8f6c1ed6ca318fff5c1853fbc1d"
+checksum = "7e46109c383602735fa0a2e48dd2b7c892b048e1bf69e5c3b1d804b7d9c203cb"
 dependencies = [
  "autocfg",
  "cc",


### PR DESCRIPTION
This updates the `openssl` and `openssl-sys` crates to support building
the toolchain with system libraries up to LibreSSL 3.4.x.

LibreSSL 3.4.0 has been supported since `openssl-sys` version 0.9.67,
LibreSSL 3.4.x since `openssl-sys` 0.9.72.