### PR TITLE
rustdoc: Rename `def_id` into `item_id` when the type is `ItemId` for readability

### DIFF
--- a/src/librustdoc/clean/auto_trait.rs
+++ b/src/librustdoc/clean/auto_trait.rs
@@ -116,7 +116,7 @@ impl<'a, 'tcx> AutoTraitFinder<'a, 'tcx> {
             name: None,
             attrs: Default::default(),
             visibility: Inherited,
-            def_id: ItemId::Auto { trait_: trait_def_id, for_: item_def_id },
+            item_id: ItemId::Auto { trait_: trait_def_id, for_: item_def_id },
             kind: box ImplItem(Impl {
                 unsafety: hir::Unsafety::Normal,
                 generics: new_generics,

--- a/src/librustdoc/clean/blanket_impl.rs
+++ b/src/librustdoc/clean/blanket_impl.rs
@@ -105,7 +105,7 @@ impl<'a, 'tcx> BlanketImplFinder<'a, 'tcx> {
                         name: None,
                         attrs: Default::default(),
                         visibility: Inherited,
-                        def_id: ItemId::Blanket { impl_id: impl_def_id, for_: item_def_id },
+                        item_id: ItemId::Blanket { impl_id: impl_def_id, for_: item_def_id },
                         kind: box ImplItem(Impl {
                             unsafety: hir::Unsafety::Normal,
                             generics: clean_ty_generics(

--- a/src/librustdoc/clean/inline.rs
+++ b/src/librustdoc/clean/inline.rs
@@ -534,7 +534,7 @@ fn build_module(
                 items.push(clean::Item {
                     name: None,
                     attrs: box clean::Attributes::default(),
-                    def_id: ItemId::Primitive(prim_ty, did.krate),
+                    item_id: ItemId::Primitive(prim_ty, did.krate),
                     visibility: clean::Public,
                     kind: box clean::ImportItem(clean::Import::new_simple(
                         item.ident.name,

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -2009,7 +2009,7 @@ fn clean_extern_crate(
     vec![Item {
         name: Some(name),
         attrs: box attrs.clean(cx),
-        def_id: crate_def_id.into(),
+        item_id: crate_def_id.into(),
         visibility: ty_vis.clean(cx),
         kind: box ExternCrateItem { src: orig_name },
         cfg: attrs.cfg(cx.tcx, &cx.cache.hidden_cfg),

--- a/src/librustdoc/clean/utils.rs
+++ b/src/librustdoc/clean/utils.rs
@@ -44,9 +44,9 @@ crate fn krate(cx: &mut DocContext<'_>) -> Crate {
                 // `#[doc(masked)]` to the injected `extern crate` because it's unstable.
                 if it.is_extern_crate()
                     && (it.attrs.has_doc_flag(sym::masked)
-                        || cx.tcx.is_compiler_builtins(it.def_id.krate()))
+                        || cx.tcx.is_compiler_builtins(it.item_id.krate()))
                 {
-                    cx.cache.masked_crates.insert(it.def_id.krate());
+                    cx.cache.masked_crates.insert(it.item_id.krate());
                 }
             }
         }

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -113,8 +113,8 @@ impl<'tcx> DocContext<'tcx> {
 
     /// Like `hir().local_def_id_to_hir_id()`, but skips calling it on fake DefIds.
     /// (This avoids a slice-index-out-of-bounds panic.)
-    crate fn as_local_hir_id(tcx: TyCtxt<'_>, def_id: ItemId) -> Option<HirId> {
-        match def_id {
+    crate fn as_local_hir_id(tcx: TyCtxt<'_>, item_id: ItemId) -> Option<HirId> {
+        match item_id {
             ItemId::DefId(real_id) => {
                 real_id.as_local().map(|def_id| tcx.hir().local_def_id_to_hir_id(def_id))
             }
@@ -390,7 +390,7 @@ crate fn run_global_ctxt(
         );
         tcx.struct_lint_node(
             crate::lint::MISSING_CRATE_LEVEL_DOCS,
-            DocContext::as_local_hir_id(tcx, krate.module.def_id).unwrap(),
+            DocContext::as_local_hir_id(tcx, krate.module.item_id).unwrap(),
             |lint| {
                 let mut diag =
                     lint.build("no documentation found for this crate's top-level module");

--- a/src/librustdoc/html/render/context.rs
+++ b/src/librustdoc/html/render/context.rs
@@ -222,7 +222,7 @@ impl<'tcx> Context<'tcx> {
                 &self.shared.style_files,
             )
         } else {
-            if let Some(&(ref names, ty)) = self.cache().paths.get(&it.def_id.expect_def_id()) {
+            if let Some(&(ref names, ty)) = self.cache().paths.get(&it.item_id.expect_def_id()) {
                 if self.current.len() + 1 != names.len()
                     || self.current.iter().zip(names.iter()).any(|(a, b)| a != b)
                 {

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -830,7 +830,7 @@ fn assoc_const(
         w,
         "{extra}{vis}const <a{href} class=\"constant\">{name}</a>: {ty}",
         extra = extra,
-        vis = it.visibility.print_with_space(it.def_id, cx),
+        vis = it.visibility.print_with_space(it.item_id, cx),
         href = assoc_href_attr(it, link, cx),
         name = it.name.as_ref().unwrap(),
         ty = ty.print(cx),
@@ -884,7 +884,7 @@ fn assoc_method(
 ) {
     let header = meth.fn_header(cx.tcx()).expect("Trying to get header from a non-function item");
     let name = meth.name.as_ref().unwrap();
-    let vis = meth.visibility.print_with_space(meth.def_id, cx).to_string();
+    let vis = meth.visibility.print_with_space(meth.item_id, cx).to_string();
     // FIXME: Once https://github.com/rust-lang/rust/issues/67792 is implemented, we can remove
     // this condition.
     let constness = match render_mode {
@@ -2060,7 +2060,7 @@ fn small_url_encode(s: String) -> String {
 }
 
 fn sidebar_assoc_items(cx: &Context<'_>, out: &mut Buffer, it: &clean::Item) {
-    let did = it.def_id.expect_def_id();
+    let did = it.item_id.expect_def_id();
     let cache = cx.cache();
 
     if let Some(v) = cache.impls.get(&did) {
@@ -2412,7 +2412,7 @@ fn sidebar_trait(cx: &Context<'_>, buf: &mut Buffer, it: &clean::Item, t: &clean
     );
 
     let cache = cx.cache();
-    if let Some(implementors) = cache.implementors.get(&it.def_id.expect_def_id()) {
+    if let Some(implementors) = cache.implementors.get(&it.item_id.expect_def_id()) {
         let mut res = implementors
             .iter()
             .filter(|i| {
@@ -2761,7 +2761,7 @@ const NUM_VISIBLE_LINES: usize = 10;
 /// Generates the HTML for example call locations generated via the --scrape-examples flag.
 fn render_call_locations(w: &mut Buffer, cx: &Context<'_>, item: &clean::Item) {
     let tcx = cx.tcx();
-    let def_id = item.def_id.expect_def_id();
+    let def_id = item.item_id.expect_def_id();
     let key = tcx.def_path_hash(def_id);
     let Some(call_locations) = cx.shared.call_locations.get(&key) else { return };
 

--- a/src/librustdoc/html/render/write_shared.rs
+++ b/src/librustdoc/html/render/write_shared.rs
@@ -535,7 +535,7 @@ pub(super) fn write_shared(
                 //
                 // If the implementation is from another crate then that crate
                 // should add it.
-                if imp.impl_item.def_id.krate() == did.krate || !imp.impl_item.def_id.is_local() {
+                if imp.impl_item.item_id.krate() == did.krate || !imp.impl_item.item_id.is_local() {
                     None
                 } else {
                     Some(Implementor {

--- a/src/librustdoc/json/mod.rs
+++ b/src/librustdoc/json/mod.rs
@@ -54,7 +54,7 @@ impl<'tcx> JsonRenderer<'tcx> {
                     .map(|i| {
                         let item = &i.impl_item;
                         self.item(item.clone()).unwrap();
-                        from_item_id(item.def_id)
+                        from_item_id(item.item_id)
                     })
                     .collect()
             })
@@ -84,9 +84,9 @@ impl<'tcx> JsonRenderer<'tcx> {
                             }
                         }
 
-                        if item.def_id.is_local() || is_primitive_impl {
+                        if item.item_id.is_local() || is_primitive_impl {
                             self.item(item.clone()).unwrap();
-                            Some(from_item_id(item.def_id))
+                            Some(from_item_id(item.item_id))
                         } else {
                             None
                         }
@@ -176,18 +176,18 @@ impl<'tcx> FormatRenderer<'tcx> for JsonRenderer<'tcx> {
         // Flatten items that recursively store other items
         item.kind.inner_items().for_each(|i| self.item(i.clone()).unwrap());
 
-        let id = item.def_id;
+        let item_id = item.item_id;
         if let Some(mut new_item) = self.convert_item(item) {
             if let types::ItemEnum::Trait(ref mut t) = new_item.inner {
-                t.implementations = self.get_trait_implementors(id.expect_def_id())
+                t.implementations = self.get_trait_implementors(item_id.expect_def_id())
             } else if let types::ItemEnum::Struct(ref mut s) = new_item.inner {
-                s.impls = self.get_impls(id.expect_def_id())
+                s.impls = self.get_impls(item_id.expect_def_id())
             } else if let types::ItemEnum::Enum(ref mut e) = new_item.inner {
-                e.impls = self.get_impls(id.expect_def_id())
+                e.impls = self.get_impls(item_id.expect_def_id())
             } else if let types::ItemEnum::Union(ref mut u) = new_item.inner {
-                u.impls = self.get_impls(id.expect_def_id())
+                u.impls = self.get_impls(item_id.expect_def_id())
             }
-            let removed = self.index.borrow_mut().insert(from_item_id(id), new_item.clone());
+            let removed = self.index.borrow_mut().insert(from_item_id(item_id), new_item.clone());
 
             // FIXME(adotinthevoid): Currently, the index is duplicated. This is a sanity check
             // to make sure the items are unique. The main place this happens is when an item, is

--- a/src/librustdoc/passes/bare_urls.rs
+++ b/src/librustdoc/passes/bare_urls.rs
@@ -61,7 +61,7 @@ crate fn check_bare_urls(krate: Crate, cx: &mut DocContext<'_>) -> Crate {
 
 impl<'a, 'tcx> DocVisitor for BareUrlsLinter<'a, 'tcx> {
     fn visit_item(&mut self, item: &Item) {
-        let Some(hir_id) = DocContext::as_local_hir_id(self.cx.tcx, item.def_id)
+        let Some(hir_id) = DocContext::as_local_hir_id(self.cx.tcx, item.item_id)
         else {
             // If non-local, no need to check anything.
             return;

--- a/src/librustdoc/passes/calculate_doc_coverage.rs
+++ b/src/librustdoc/passes/calculate_doc_coverage.rs
@@ -185,7 +185,7 @@ impl<'a, 'b> CoverageCalculator<'a, 'b> {
 
 impl<'a, 'b> DocVisitor for CoverageCalculator<'a, 'b> {
     fn visit_item(&mut self, i: &clean::Item) {
-        if !i.def_id.is_local() {
+        if !i.item_id.is_local() {
             // non-local items are skipped because they can be out of the users control,
             // especially in the case of trait impls, which rustdoc eagerly inlines
             return;
@@ -223,7 +223,7 @@ impl<'a, 'b> DocVisitor for CoverageCalculator<'a, 'b> {
                     .ctx
                     .tcx
                     .hir()
-                    .local_def_id_to_hir_id(i.def_id.expect_def_id().expect_local());
+                    .local_def_id_to_hir_id(i.item_id.expect_def_id().expect_local());
                 let (level, source) = self.ctx.tcx.lint_level_at_node(MISSING_DOCS, hir_id);
 
                 // In case we have:
@@ -237,7 +237,7 @@ impl<'a, 'b> DocVisitor for CoverageCalculator<'a, 'b> {
                 // there is no need to require documentation on the fields of tuple variants and
                 // tuple structs.
                 let should_be_ignored = i
-                    .def_id
+                    .item_id
                     .as_def_id()
                     .and_then(|def_id| self.ctx.tcx.parent(def_id))
                     .and_then(|def_id| self.ctx.tcx.hir().get_if_local(def_id))

--- a/src/librustdoc/passes/check_code_block_syntax.rs
+++ b/src/librustdoc/passes/check_code_block_syntax.rs
@@ -69,7 +69,7 @@ impl<'a, 'tcx> SyntaxChecker<'a, 'tcx> {
             return;
         }
 
-        let Some(local_id) = item.def_id.as_def_id().and_then(|x| x.as_local())
+        let Some(local_id) = item.item_id.as_def_id().and_then(|x| x.as_local())
         else {
             // We don't need to check the syntax for other crates so returning
             // without doing anything should not be a problem.
@@ -153,7 +153,7 @@ impl<'a, 'tcx> DocVisitor for SyntaxChecker<'a, 'tcx> {
             let sp = item.attr_span(self.cx.tcx);
             let extra = crate::html::markdown::ExtraInfo::new_did(
                 self.cx.tcx,
-                item.def_id.expect_def_id(),
+                item.item_id.expect_def_id(),
                 sp,
             );
             for code_block in markdown::rust_code_blocks(dox, &extra) {

--- a/src/librustdoc/passes/check_doc_test_visibility.rs
+++ b/src/librustdoc/passes/check_doc_test_visibility.rs
@@ -56,7 +56,7 @@ impl crate::doctest::Tester for Tests {
 }
 
 crate fn should_have_doc_example(cx: &DocContext<'_>, item: &clean::Item) -> bool {
-    if !cx.cache.access_levels.is_public(item.def_id.expect_def_id())
+    if !cx.cache.access_levels.is_public(item.item_id.expect_def_id())
         || matches!(
             *item.kind,
             clean::StructFieldItem(_)
@@ -79,7 +79,7 @@ crate fn should_have_doc_example(cx: &DocContext<'_>, item: &clean::Item) -> boo
 
     // The `expect_def_id()` should be okay because `local_def_id_to_hir_id`
     // would presumably panic if a fake `DefIndex` were passed.
-    let hir_id = cx.tcx.hir().local_def_id_to_hir_id(item.def_id.expect_def_id().expect_local());
+    let hir_id = cx.tcx.hir().local_def_id_to_hir_id(item.item_id.expect_def_id().expect_local());
 
     // check if parent is trait impl
     if let Some(parent_hir_id) = cx.tcx.hir().find_parent_node(hir_id) {
@@ -107,7 +107,7 @@ crate fn should_have_doc_example(cx: &DocContext<'_>, item: &clean::Item) -> boo
 }
 
 crate fn look_for_tests<'tcx>(cx: &DocContext<'tcx>, dox: &str, item: &Item) {
-    let Some(hir_id) = DocContext::as_local_hir_id(cx.tcx, item.def_id)
+    let Some(hir_id) = DocContext::as_local_hir_id(cx.tcx, item.item_id)
     else {
         // If non-local, no need to check anything.
         return;
@@ -131,7 +131,7 @@ crate fn look_for_tests<'tcx>(cx: &DocContext<'tcx>, dox: &str, item: &Item) {
             );
         }
     } else if tests.found_tests > 0
-        && !cx.cache.access_levels.is_exported(item.def_id.expect_def_id())
+        && !cx.cache.access_levels.is_exported(item.item_id.expect_def_id())
     {
         cx.tcx.struct_span_lint_hir(
             crate::lint::PRIVATE_DOC_TESTS,

--- a/src/librustdoc/passes/collect_trait_impls.rs
+++ b/src/librustdoc/passes/collect_trait_impls.rs
@@ -52,7 +52,7 @@ crate fn collect_trait_impls(mut krate: Crate, cx: &mut DocContext<'_>) -> Crate
                 // FIXME(eddyb) is this `doc(hidden)` check needed?
                 if !cx.tcx.is_doc_hidden(def_id) {
                     let impls = get_auto_trait_and_blanket_impls(cx, def_id);
-                    new_items.extend(impls.filter(|i| cx.inlined.insert(i.def_id)));
+                    new_items.extend(impls.filter(|i| cx.inlined.insert(i.item_id)));
                 }
             }
         }
@@ -176,9 +176,9 @@ impl<'a, 'tcx> DocVisitor for SyntheticImplCollector<'a, 'tcx> {
     fn visit_item(&mut self, i: &Item) {
         if i.is_struct() || i.is_enum() || i.is_union() {
             // FIXME(eddyb) is this `doc(hidden)` check needed?
-            if !self.cx.tcx.is_doc_hidden(i.def_id.expect_def_id()) {
+            if !self.cx.tcx.is_doc_hidden(i.item_id.expect_def_id()) {
                 self.impls
-                    .extend(get_auto_trait_and_blanket_impls(self.cx, i.def_id.expect_def_id()));
+                    .extend(get_auto_trait_and_blanket_impls(self.cx, i.item_id.expect_def_id()));
             }
         }
 
@@ -199,7 +199,7 @@ impl ItemCollector {
 
 impl DocVisitor for ItemCollector {
     fn visit_item(&mut self, i: &Item) {
-        self.items.insert(i.def_id);
+        self.items.insert(i.item_id);
 
         self.visit_item_recur(i)
     }
@@ -225,7 +225,7 @@ impl<'a> BadImplStripper<'a> {
         }
     }
 
-    fn keep_impl_with_def_id(&self, did: ItemId) -> bool {
-        self.items.contains(&did)
+    fn keep_impl_with_def_id(&self, item_id: ItemId) -> bool {
+        self.items.contains(&item_id)
     }
 }

--- a/src/librustdoc/passes/html_tags.rs
+++ b/src/librustdoc/passes/html_tags.rs
@@ -197,7 +197,7 @@ fn extract_tags(
 impl<'a, 'tcx> DocVisitor for InvalidHtmlTagsLinter<'a, 'tcx> {
     fn visit_item(&mut self, item: &Item) {
         let tcx = self.cx.tcx;
-        let Some(hir_id) = DocContext::as_local_hir_id(tcx, item.def_id)
+        let Some(hir_id) = DocContext::as_local_hir_id(tcx, item.item_id)
         // If non-local, no need to check anything.
         else { return };
         let dox = item.attrs.collapsed_doc_value().unwrap_or_default();

--- a/src/librustdoc/passes/strip_hidden.rs
+++ b/src/librustdoc/passes/strip_hidden.rs
@@ -53,7 +53,7 @@ impl<'a> DocFolder for Stripper<'a> {
             }
         } else {
             if self.update_retained {
-                self.retained.insert(i.def_id);
+                self.retained.insert(i.item_id);
             }
         }
         Some(self.fold_item_recur(i))

--- a/src/librustdoc/passes/stripper.rs
+++ b/src/librustdoc/passes/stripper.rs
@@ -45,7 +45,8 @@ impl<'a> DocFolder for Stripper<'a> {
             | clean::TraitAliasItem(..)
             | clean::MacroItem(..)
             | clean::ForeignTypeItem => {
-                if i.def_id.is_local() && !self.access_levels.is_exported(i.def_id.expect_def_id())
+                if i.item_id.is_local()
+                    && !self.access_levels.is_exported(i.item_id.expect_def_id())
                 {
                     debug!("Stripper: stripping {:?} {:?}", i.type_(), i.name);
                     return None;
@@ -59,7 +60,7 @@ impl<'a> DocFolder for Stripper<'a> {
             }
 
             clean::ModuleItem(..) => {
-                if i.def_id.is_local() && !i.visibility.is_public() {
+                if i.item_id.is_local() && !i.visibility.is_public() {
                     debug!("Stripper: stripping module {:?}", i.name);
                     let old = mem::replace(&mut self.update_retained, false);
                     let ret = strip_item(self.fold_item_recur(i));
@@ -100,7 +101,7 @@ impl<'a> DocFolder for Stripper<'a> {
 
         let i = if fastreturn {
             if self.update_retained {
-                self.retained.insert(i.def_id);
+                self.retained.insert(i.item_id);
             }
             return Some(i);
         } else {
@@ -108,7 +109,7 @@ impl<'a> DocFolder for Stripper<'a> {
         };
 
         if self.update_retained {
-            self.retained.insert(i.def_id);
+            self.retained.insert(i.item_id);
         }
         Some(i)
     }


### PR DESCRIPTION
As @notriddle mentioned in https://github.com/rust-lang/rust/pull/96091, the field name is inaccurate. This PR fixes it by renaming it accordingly to its real type.

r? @notriddle 