### PR TITLE
more efficient is_ascii methods

### DIFF
--- a/library/core/src/char/methods.rs
+++ b/library/core/src/char/methods.rs
@@ -1275,7 +1275,7 @@ impl char {
     #[rustc_const_stable(feature = "const_ascii_ctype_on_intrinsics", since = "1.47.0")]
     #[inline]
     pub const fn is_ascii_alphabetic(&self) -> bool {
-        (*self as u32 | 0b10_0000).wrapping_sub('a' as u32) < 26 
+        (*self as u32 | 0b10_0000).wrapping_sub('a' as u32) < 26
     }
 
     /// Checks if the value is an ASCII uppercase character:

--- a/library/core/src/char/methods.rs
+++ b/library/core/src/char/methods.rs
@@ -1275,7 +1275,8 @@ impl char {
     #[rustc_const_stable(feature = "const_ascii_ctype_on_intrinsics", since = "1.47.0")]
     #[inline]
     pub const fn is_ascii_alphabetic(&self) -> bool {
-        matches!(*self, 'A'..='Z' | 'a'..='z')
+        //Godbolt: https://rust.godbolt.org/z/nMdjWz4aG
+        (*self as u32 | 0b10_0000).wrapping_sub('a' as u32) < 26 
     }
 
     /// Checks if the value is an ASCII uppercase character:
@@ -1380,7 +1381,8 @@ impl char {
     #[rustc_const_stable(feature = "const_ascii_ctype_on_intrinsics", since = "1.47.0")]
     #[inline]
     pub const fn is_ascii_alphanumeric(&self) -> bool {
-        matches!(*self, '0'..='9' | 'A'..='Z' | 'a'..='z')
+        //Godbolt: https://rust.godbolt.org/z/dejn8P9q5
+        self.is_ascii_digit() || self.is_ascii_alphabetic()
     }
 
     /// Checks if the value is an ASCII decimal digit:
@@ -1451,7 +1453,8 @@ impl char {
     #[rustc_const_stable(feature = "const_ascii_ctype_on_intrinsics", since = "1.47.0")]
     #[inline]
     pub const fn is_ascii_hexdigit(&self) -> bool {
-        matches!(*self, '0'..='9' | 'A'..='F' | 'a'..='f')
+        // Godbolt: https://rust.godbolt.org/z/nYsdEPj4e
+        self.is_ascii_digit() || (*self as u32 | 0b10_0000).wrapping_sub('a' as u32) <= 6
     }
 
     /// Checks if the value is an ASCII punctuation character:

--- a/library/core/src/char/methods.rs
+++ b/library/core/src/char/methods.rs
@@ -1451,7 +1451,7 @@ impl char {
     #[rustc_const_stable(feature = "const_ascii_ctype_on_intrinsics", since = "1.47.0")]
     #[inline]
     pub const fn is_ascii_hexdigit(&self) -> bool {
-        self.is_ascii_digit() || (*self as u32 | 0b10_0000).wrapping_sub('a' as u32) <= 6
+        self.is_ascii_digit() || (*self as u32 | 0b10_0000).wrapping_sub('a' as u32) < 6
     }
 
     /// Checks if the value is an ASCII punctuation character:

--- a/library/core/src/char/methods.rs
+++ b/library/core/src/char/methods.rs
@@ -1275,7 +1275,6 @@ impl char {
     #[rustc_const_stable(feature = "const_ascii_ctype_on_intrinsics", since = "1.47.0")]
     #[inline]
     pub const fn is_ascii_alphabetic(&self) -> bool {
-        //Godbolt: https://rust.godbolt.org/z/nMdjWz4aG
         (*self as u32 | 0b10_0000).wrapping_sub('a' as u32) < 26 
     }
 
@@ -1381,7 +1380,6 @@ impl char {
     #[rustc_const_stable(feature = "const_ascii_ctype_on_intrinsics", since = "1.47.0")]
     #[inline]
     pub const fn is_ascii_alphanumeric(&self) -> bool {
-        //Godbolt: https://rust.godbolt.org/z/dejn8P9q5
         self.is_ascii_digit() || self.is_ascii_alphabetic()
     }
 
@@ -1453,7 +1451,6 @@ impl char {
     #[rustc_const_stable(feature = "const_ascii_ctype_on_intrinsics", since = "1.47.0")]
     #[inline]
     pub const fn is_ascii_hexdigit(&self) -> bool {
-        // Godbolt: https://rust.godbolt.org/z/nYsdEPj4e
         self.is_ascii_digit() || (*self as u32 | 0b10_0000).wrapping_sub('a' as u32) <= 6
     }
 


### PR DESCRIPTION
These formulations seem to compile down to less (optimised) machine code. (The 0b10_0000 is making it lower case like in to_digit here https://github.com/rust-lang/rust/blob/ac8b11810f4a0def3596ee401feb9ef00015b555/library/core/src/char/methods.rs#L354 )

is_ascii_alphabetic
https://rust.godbolt.org/z/nMdjWz4aG

is_ascii_alphanumeric
https://rust.godbolt.org/z/dejn8P9q5

is_ascii_hexdigit
https://rust.godbolt.org/z/nYsdEPj4e