### PR TITLE
mark ptr-int-transmute test as no_run

### DIFF
--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -981,7 +981,7 @@ extern "rust-intrinsic" {
     ///
     /// Turning a pointer into a `usize`:
     ///
-    /// ```
+    /// ```no_run
     /// let ptr = &0;
     /// let ptr_num_transmute = unsafe {
     ///     std::mem::transmute::<&i32, usize>(ptr)


### PR DESCRIPTION
This causes [CI failures in Miri](https://github.com/rust-lang/miri-test-libstd/runs/6062500259?check_suite_focus=true) since ptr-int-transmutes are rejected there (when strict provenance is enabled).