### PR TITLE
Rustdoc: Use the default size of the Rust logo svg.

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -452,8 +452,8 @@ nav.sub {
 }
 
 .logo-container > img {
-	height: 100px;
-	width: 100px;
+	height: 106px;
+	width: 106px;
 }
 
 .location:empty {


### PR DESCRIPTION
Rustdoc started using [the new logo svg](https://github.com/rust-lang/rust-artwork/pull/9) in  https://github.com/rust-lang/rust/pull/92854, but kept the size in the css at 100 by 100 pixels.

The new svg has natural size of 106px, and is designed to align the straight edges exactly with the pixels at that size. This PR changes the size to match that 106px.

Before:

![image](https://user-images.githubusercontent.com/783247/163877510-6b743f39-2092-436f-8795-03935605f900.png)

After:

![image](https://user-images.githubusercontent.com/783247/163877537-e8bd6410-015e-4235-bd13-7f37f3674429.png)

