### PR TITLE
Mark payload fields of ScalarPair enums as Scalar::Union when they're not always initialized

### DIFF
--- a/src/test/ui/layout/issue-96158-scalarpair-payload-might-be-uninit.rs
+++ b/src/test/ui/layout/issue-96158-scalarpair-payload-might-be-uninit.rs
@@ -1,0 +1,53 @@
+#![crate_type = "lib"]
+#![feature(rustc_attrs)]
+
+use std::mem::MaybeUninit;
+
+enum HasNiche {
+    A,
+    B,
+    C,
+}
+
+// This should result in ScalarPair(Initialized, Union),
+// since the u8 payload will be uninit for `None`.
+#[rustc_layout(debug)]
+pub enum MissingPayloadField { //~ ERROR: layout_of
+    Some(u8),
+    None
+}
+
+// This should result in ScalarPair(Initialized, Initialized),
+// since the u8 field is present in all variants,
+// and hence will always be initialized.
+#[rustc_layout(debug)]
+pub enum CommonPayloadField { //~ ERROR: layout_of
+    A(u8),
+    B(u8),
+}
+
+// This should result in ScalarPair(Initialized, Union),
+// since, though a u8-sized field is present in all variants, it might be uninit.
+#[rustc_layout(debug)]
+pub enum CommonPayloadFieldIsMaybeUninit { //~ ERROR: layout_of
+    A(u8),
+    B(MaybeUninit<u8>),
+}
+
+// This should result in ScalarPair(Initialized, Union),
+// since only the niche field (used for the tag) is guaranteed to be initialized.
+#[rustc_layout(debug)]
+pub enum NicheFirst { //~ ERROR: layout_of
+    A(HasNiche, u8),
+    B,
+    C
+}
+
+// This should result in ScalarPair(Union, Initialized),
+// since only the niche field (used for the tag) is guaranteed to be initialized.
+#[rustc_layout(debug)]
+pub enum NicheSecond { //~ ERROR: layout_of
+    A(u8, HasNiche),
+    B,
+    C,
+}

--- a/src/test/ui/layout/issue-96158-scalarpair-payload-might-be-uninit.rs
+++ b/src/test/ui/layout/issue-96158-scalarpair-payload-might-be-uninit.rs
@@ -1,3 +1,4 @@
+// normalize-stderr-test "pref: Align \{\n *pow2: [1-3],\n *\}" -> "pref: $$PREF_ALIGN"
 #![crate_type = "lib"]
 #![feature(rustc_attrs)]
 

--- a/src/test/ui/layout/issue-96158-scalarpair-payload-might-be-uninit.stderr
+++ b/src/test/ui/layout/issue-96158-scalarpair-payload-might-be-uninit.stderr
@@ -1,0 +1,754 @@
+error: layout_of(MissingPayloadField) = Layout {
+           fields: Arbitrary {
+               offsets: [
+                   Size {
+                       raw: 0,
+                   },
+               ],
+               memory_index: [
+                   0,
+               ],
+           },
+           variants: Multiple {
+               tag: Initialized {
+                   value: Int(
+                       I8,
+                       false,
+                   ),
+                   valid_range: 0..=1,
+               },
+               tag_encoding: Direct,
+               tag_field: 0,
+               variants: [
+                   Layout {
+                       fields: Arbitrary {
+                           offsets: [
+                               Size {
+                                   raw: 1,
+                               },
+                           ],
+                           memory_index: [
+                               0,
+                           ],
+                       },
+                       variants: Single {
+                           index: 0,
+                       },
+                       abi: Aggregate {
+                           sized: true,
+                       },
+                       largest_niche: None,
+                       align: AbiAndPrefAlign {
+                           abi: Align {
+                               pow2: 0,
+                           },
+                           pref: Align {
+                               pow2: 3,
+                           },
+                       },
+                       size: Size {
+                           raw: 2,
+                       },
+                   },
+                   Layout {
+                       fields: Arbitrary {
+                           offsets: [],
+                           memory_index: [],
+                       },
+                       variants: Single {
+                           index: 1,
+                       },
+                       abi: Aggregate {
+                           sized: true,
+                       },
+                       largest_niche: None,
+                       align: AbiAndPrefAlign {
+                           abi: Align {
+                               pow2: 0,
+                           },
+                           pref: Align {
+                               pow2: 3,
+                           },
+                       },
+                       size: Size {
+                           raw: 1,
+                       },
+                   },
+               ],
+           },
+           abi: ScalarPair(
+               Initialized {
+                   value: Int(
+                       I8,
+                       false,
+                   ),
+                   valid_range: 0..=1,
+               },
+               Union {
+                   value: Int(
+                       I8,
+                       false,
+                   ),
+               },
+           ),
+           largest_niche: Some(
+               Niche {
+                   offset: Size {
+                       raw: 0,
+                   },
+                   value: Int(
+                       I8,
+                       false,
+                   ),
+                   valid_range: 0..=1,
+               },
+           ),
+           align: AbiAndPrefAlign {
+               abi: Align {
+                   pow2: 0,
+               },
+               pref: Align {
+                   pow2: 3,
+               },
+           },
+           size: Size {
+               raw: 2,
+           },
+       }
+  --> $DIR/issue-96158-scalarpair-payload-might-be-uninit.rs:15:1
+   |
+LL | / pub enum MissingPayloadField {
+LL | |     Some(u8),
+LL | |     None
+LL | | }
+   | |_^
+
+error: layout_of(CommonPayloadField) = Layout {
+           fields: Arbitrary {
+               offsets: [
+                   Size {
+                       raw: 0,
+                   },
+               ],
+               memory_index: [
+                   0,
+               ],
+           },
+           variants: Multiple {
+               tag: Initialized {
+                   value: Int(
+                       I8,
+                       false,
+                   ),
+                   valid_range: 0..=1,
+               },
+               tag_encoding: Direct,
+               tag_field: 0,
+               variants: [
+                   Layout {
+                       fields: Arbitrary {
+                           offsets: [
+                               Size {
+                                   raw: 1,
+                               },
+                           ],
+                           memory_index: [
+                               0,
+                           ],
+                       },
+                       variants: Single {
+                           index: 0,
+                       },
+                       abi: Aggregate {
+                           sized: true,
+                       },
+                       largest_niche: None,
+                       align: AbiAndPrefAlign {
+                           abi: Align {
+                               pow2: 0,
+                           },
+                           pref: Align {
+                               pow2: 3,
+                           },
+                       },
+                       size: Size {
+                           raw: 2,
+                       },
+                   },
+                   Layout {
+                       fields: Arbitrary {
+                           offsets: [
+                               Size {
+                                   raw: 1,
+                               },
+                           ],
+                           memory_index: [
+                               0,
+                           ],
+                       },
+                       variants: Single {
+                           index: 1,
+                       },
+                       abi: Aggregate {
+                           sized: true,
+                       },
+                       largest_niche: None,
+                       align: AbiAndPrefAlign {
+                           abi: Align {
+                               pow2: 0,
+                           },
+                           pref: Align {
+                               pow2: 3,
+                           },
+                       },
+                       size: Size {
+                           raw: 2,
+                       },
+                   },
+               ],
+           },
+           abi: ScalarPair(
+               Initialized {
+                   value: Int(
+                       I8,
+                       false,
+                   ),
+                   valid_range: 0..=1,
+               },
+               Initialized {
+                   value: Int(
+                       I8,
+                       false,
+                   ),
+                   valid_range: 0..=255,
+               },
+           ),
+           largest_niche: Some(
+               Niche {
+                   offset: Size {
+                       raw: 0,
+                   },
+                   value: Int(
+                       I8,
+                       false,
+                   ),
+                   valid_range: 0..=1,
+               },
+           ),
+           align: AbiAndPrefAlign {
+               abi: Align {
+                   pow2: 0,
+               },
+               pref: Align {
+                   pow2: 3,
+               },
+           },
+           size: Size {
+               raw: 2,
+           },
+       }
+  --> $DIR/issue-96158-scalarpair-payload-might-be-uninit.rs:24:1
+   |
+LL | / pub enum CommonPayloadField {
+LL | |     A(u8),
+LL | |     B(u8),
+LL | | }
+   | |_^
+
+error: layout_of(CommonPayloadFieldIsMaybeUninit) = Layout {
+           fields: Arbitrary {
+               offsets: [
+                   Size {
+                       raw: 0,
+                   },
+               ],
+               memory_index: [
+                   0,
+               ],
+           },
+           variants: Multiple {
+               tag: Initialized {
+                   value: Int(
+                       I8,
+                       false,
+                   ),
+                   valid_range: 0..=1,
+               },
+               tag_encoding: Direct,
+               tag_field: 0,
+               variants: [
+                   Layout {
+                       fields: Arbitrary {
+                           offsets: [
+                               Size {
+                                   raw: 1,
+                               },
+                           ],
+                           memory_index: [
+                               0,
+                           ],
+                       },
+                       variants: Single {
+                           index: 0,
+                       },
+                       abi: Aggregate {
+                           sized: true,
+                       },
+                       largest_niche: None,
+                       align: AbiAndPrefAlign {
+                           abi: Align {
+                               pow2: 0,
+                           },
+                           pref: Align {
+                               pow2: 3,
+                           },
+                       },
+                       size: Size {
+                           raw: 2,
+                       },
+                   },
+                   Layout {
+                       fields: Arbitrary {
+                           offsets: [
+                               Size {
+                                   raw: 1,
+                               },
+                           ],
+                           memory_index: [
+                               0,
+                           ],
+                       },
+                       variants: Single {
+                           index: 1,
+                       },
+                       abi: Aggregate {
+                           sized: true,
+                       },
+                       largest_niche: None,
+                       align: AbiAndPrefAlign {
+                           abi: Align {
+                               pow2: 0,
+                           },
+                           pref: Align {
+                               pow2: 3,
+                           },
+                       },
+                       size: Size {
+                           raw: 2,
+                       },
+                   },
+               ],
+           },
+           abi: ScalarPair(
+               Initialized {
+                   value: Int(
+                       I8,
+                       false,
+                   ),
+                   valid_range: 0..=1,
+               },
+               Union {
+                   value: Int(
+                       I8,
+                       false,
+                   ),
+               },
+           ),
+           largest_niche: Some(
+               Niche {
+                   offset: Size {
+                       raw: 0,
+                   },
+                   value: Int(
+                       I8,
+                       false,
+                   ),
+                   valid_range: 0..=1,
+               },
+           ),
+           align: AbiAndPrefAlign {
+               abi: Align {
+                   pow2: 0,
+               },
+               pref: Align {
+                   pow2: 3,
+               },
+           },
+           size: Size {
+               raw: 2,
+           },
+       }
+  --> $DIR/issue-96158-scalarpair-payload-might-be-uninit.rs:32:1
+   |
+LL | / pub enum CommonPayloadFieldIsMaybeUninit {
+LL | |     A(u8),
+LL | |     B(MaybeUninit<u8>),
+LL | | }
+   | |_^
+
+error: layout_of(NicheFirst) = Layout {
+           fields: Arbitrary {
+               offsets: [
+                   Size {
+                       raw: 0,
+                   },
+               ],
+               memory_index: [
+                   0,
+               ],
+           },
+           variants: Multiple {
+               tag: Initialized {
+                   value: Int(
+                       I8,
+                       false,
+                   ),
+                   valid_range: 0..=4,
+               },
+               tag_encoding: Niche {
+                   dataful_variant: 0,
+                   niche_variants: 1..=2,
+                   niche_start: 3,
+               },
+               tag_field: 0,
+               variants: [
+                   Layout {
+                       fields: Arbitrary {
+                           offsets: [
+                               Size {
+                                   raw: 0,
+                               },
+                               Size {
+                                   raw: 1,
+                               },
+                           ],
+                           memory_index: [
+                               0,
+                               1,
+                           ],
+                       },
+                       variants: Single {
+                           index: 0,
+                       },
+                       abi: ScalarPair(
+                           Initialized {
+                               value: Int(
+                                   I8,
+                                   false,
+                               ),
+                               valid_range: 0..=2,
+                           },
+                           Initialized {
+                               value: Int(
+                                   I8,
+                                   false,
+                               ),
+                               valid_range: 0..=255,
+                           },
+                       ),
+                       largest_niche: Some(
+                           Niche {
+                               offset: Size {
+                                   raw: 0,
+                               },
+                               value: Int(
+                                   I8,
+                                   false,
+                               ),
+                               valid_range: 0..=2,
+                           },
+                       ),
+                       align: AbiAndPrefAlign {
+                           abi: Align {
+                               pow2: 0,
+                           },
+                           pref: Align {
+                               pow2: 3,
+                           },
+                       },
+                       size: Size {
+                           raw: 2,
+                       },
+                   },
+                   Layout {
+                       fields: Arbitrary {
+                           offsets: [],
+                           memory_index: [],
+                       },
+                       variants: Single {
+                           index: 1,
+                       },
+                       abi: Aggregate {
+                           sized: true,
+                       },
+                       largest_niche: None,
+                       align: AbiAndPrefAlign {
+                           abi: Align {
+                               pow2: 0,
+                           },
+                           pref: Align {
+                               pow2: 3,
+                           },
+                       },
+                       size: Size {
+                           raw: 0,
+                       },
+                   },
+                   Layout {
+                       fields: Arbitrary {
+                           offsets: [],
+                           memory_index: [],
+                       },
+                       variants: Single {
+                           index: 2,
+                       },
+                       abi: Aggregate {
+                           sized: true,
+                       },
+                       largest_niche: None,
+                       align: AbiAndPrefAlign {
+                           abi: Align {
+                               pow2: 0,
+                           },
+                           pref: Align {
+                               pow2: 3,
+                           },
+                       },
+                       size: Size {
+                           raw: 0,
+                       },
+                   },
+               ],
+           },
+           abi: ScalarPair(
+               Initialized {
+                   value: Int(
+                       I8,
+                       false,
+                   ),
+                   valid_range: 0..=4,
+               },
+               Union {
+                   value: Int(
+                       I8,
+                       false,
+                   ),
+               },
+           ),
+           largest_niche: Some(
+               Niche {
+                   offset: Size {
+                       raw: 0,
+                   },
+                   value: Int(
+                       I8,
+                       false,
+                   ),
+                   valid_range: 0..=4,
+               },
+           ),
+           align: AbiAndPrefAlign {
+               abi: Align {
+                   pow2: 0,
+               },
+               pref: Align {
+                   pow2: 3,
+               },
+           },
+           size: Size {
+               raw: 2,
+           },
+       }
+  --> $DIR/issue-96158-scalarpair-payload-might-be-uninit.rs:40:1
+   |
+LL | / pub enum NicheFirst {
+LL | |     A(HasNiche, u8),
+LL | |     B,
+LL | |     C
+LL | | }
+   | |_^
+
+error: layout_of(NicheSecond) = Layout {
+           fields: Arbitrary {
+               offsets: [
+                   Size {
+                       raw: 1,
+                   },
+               ],
+               memory_index: [
+                   0,
+               ],
+           },
+           variants: Multiple {
+               tag: Initialized {
+                   value: Int(
+                       I8,
+                       false,
+                   ),
+                   valid_range: 0..=4,
+               },
+               tag_encoding: Niche {
+                   dataful_variant: 0,
+                   niche_variants: 1..=2,
+                   niche_start: 3,
+               },
+               tag_field: 0,
+               variants: [
+                   Layout {
+                       fields: Arbitrary {
+                           offsets: [
+                               Size {
+                                   raw: 0,
+                               },
+                               Size {
+                                   raw: 1,
+                               },
+                           ],
+                           memory_index: [
+                               0,
+                               1,
+                           ],
+                       },
+                       variants: Single {
+                           index: 0,
+                       },
+                       abi: ScalarPair(
+                           Initialized {
+                               value: Int(
+                                   I8,
+                                   false,
+                               ),
+                               valid_range: 0..=255,
+                           },
+                           Initialized {
+                               value: Int(
+                                   I8,
+                                   false,
+                               ),
+                               valid_range: 0..=2,
+                           },
+                       ),
+                       largest_niche: Some(
+                           Niche {
+                               offset: Size {
+                                   raw: 1,
+                               },
+                               value: Int(
+                                   I8,
+                                   false,
+                               ),
+                               valid_range: 0..=2,
+                           },
+                       ),
+                       align: AbiAndPrefAlign {
+                           abi: Align {
+                               pow2: 0,
+                           },
+                           pref: Align {
+                               pow2: 3,
+                           },
+                       },
+                       size: Size {
+                           raw: 2,
+                       },
+                   },
+                   Layout {
+                       fields: Arbitrary {
+                           offsets: [],
+                           memory_index: [],
+                       },
+                       variants: Single {
+                           index: 1,
+                       },
+                       abi: Aggregate {
+                           sized: true,
+                       },
+                       largest_niche: None,
+                       align: AbiAndPrefAlign {
+                           abi: Align {
+                               pow2: 0,
+                           },
+                           pref: Align {
+                               pow2: 3,
+                           },
+                       },
+                       size: Size {
+                           raw: 0,
+                       },
+                   },
+                   Layout {
+                       fields: Arbitrary {
+                           offsets: [],
+                           memory_index: [],
+                       },
+                       variants: Single {
+                           index: 2,
+                       },
+                       abi: Aggregate {
+                           sized: true,
+                       },
+                       largest_niche: None,
+                       align: AbiAndPrefAlign {
+                           abi: Align {
+                               pow2: 0,
+                           },
+                           pref: Align {
+                               pow2: 3,
+                           },
+                       },
+                       size: Size {
+                           raw: 0,
+                       },
+                   },
+               ],
+           },
+           abi: ScalarPair(
+               Union {
+                   value: Int(
+                       I8,
+                       false,
+                   ),
+               },
+               Initialized {
+                   value: Int(
+                       I8,
+                       false,
+                   ),
+                   valid_range: 0..=4,
+               },
+           ),
+           largest_niche: Some(
+               Niche {
+                   offset: Size {
+                       raw: 1,
+                   },
+                   value: Int(
+                       I8,
+                       false,
+                   ),
+                   valid_range: 0..=4,
+               },
+           ),
+           align: AbiAndPrefAlign {
+               abi: Align {
+                   pow2: 0,
+               },
+               pref: Align {
+                   pow2: 3,
+               },
+           },
+           size: Size {
+               raw: 2,
+           },
+       }
+  --> $DIR/issue-96158-scalarpair-payload-might-be-uninit.rs:49:1
+   |
+LL | / pub enum NicheSecond {
+LL | |     A(u8, HasNiche),
+LL | |     B,
+LL | |     C,
+LL | | }
+   | |_^
+
+error: aborting due to 5 previous errors
+

--- a/src/test/ui/layout/issue-96158-scalarpair-payload-might-be-uninit.stderr
+++ b/src/test/ui/layout/issue-96158-scalarpair-payload-might-be-uninit.stderr
@@ -42,9 +42,7 @@ error: layout_of(MissingPayloadField) = Layout {
                            abi: Align {
                                pow2: 0,
                            },
-                           pref: Align {
-                               pow2: 3,
-                           },
+                           pref: $PREF_ALIGN,
                        },
                        size: Size {
                            raw: 2,
@@ -66,9 +64,7 @@ error: layout_of(MissingPayloadField) = Layout {
                            abi: Align {
                                pow2: 0,
                            },
-                           pref: Align {
-                               pow2: 3,
-                           },
+                           pref: $PREF_ALIGN,
                        },
                        size: Size {
                            raw: 1,
@@ -107,15 +103,13 @@ error: layout_of(MissingPayloadField) = Layout {
                abi: Align {
                    pow2: 0,
                },
-               pref: Align {
-                   pow2: 3,
-               },
+               pref: $PREF_ALIGN,
            },
            size: Size {
                raw: 2,
            },
        }
-  --> $DIR/issue-96158-scalarpair-payload-might-be-uninit.rs:15:1
+  --> $DIR/issue-96158-scalarpair-payload-might-be-uninit.rs:16:1
    |
 LL | / pub enum MissingPayloadField {
 LL | |     Some(u8),
@@ -167,9 +161,7 @@ error: layout_of(CommonPayloadField) = Layout {
                            abi: Align {
                                pow2: 0,
                            },
-                           pref: Align {
-                               pow2: 3,
-                           },
+                           pref: $PREF_ALIGN,
                        },
                        size: Size {
                            raw: 2,
@@ -197,9 +189,7 @@ error: layout_of(CommonPayloadField) = Layout {
                            abi: Align {
                                pow2: 0,
                            },
-                           pref: Align {
-                               pow2: 3,
-                           },
+                           pref: $PREF_ALIGN,
                        },
                        size: Size {
                            raw: 2,
@@ -239,15 +229,13 @@ error: layout_of(CommonPayloadField) = Layout {
                abi: Align {
                    pow2: 0,
                },
-               pref: Align {
-                   pow2: 3,
-               },
+               pref: $PREF_ALIGN,
            },
            size: Size {
                raw: 2,
            },
        }
-  --> $DIR/issue-96158-scalarpair-payload-might-be-uninit.rs:24:1
+  --> $DIR/issue-96158-scalarpair-payload-might-be-uninit.rs:25:1
    |
 LL | / pub enum CommonPayloadField {
 LL | |     A(u8),
@@ -299,9 +287,7 @@ error: layout_of(CommonPayloadFieldIsMaybeUninit) = Layout {
                            abi: Align {
                                pow2: 0,
                            },
-                           pref: Align {
-                               pow2: 3,
-                           },
+                           pref: $PREF_ALIGN,
                        },
                        size: Size {
                            raw: 2,
@@ -329,9 +315,7 @@ error: layout_of(CommonPayloadFieldIsMaybeUninit) = Layout {
                            abi: Align {
                                pow2: 0,
                            },
-                           pref: Align {
-                               pow2: 3,
-                           },
+                           pref: $PREF_ALIGN,
                        },
                        size: Size {
                            raw: 2,
@@ -370,15 +354,13 @@ error: layout_of(CommonPayloadFieldIsMaybeUninit) = Layout {
                abi: Align {
                    pow2: 0,
                },
-               pref: Align {
-                   pow2: 3,
-               },
+               pref: $PREF_ALIGN,
            },
            size: Size {
                raw: 2,
            },
        }
-  --> $DIR/issue-96158-scalarpair-payload-might-be-uninit.rs:32:1
+  --> $DIR/issue-96158-scalarpair-payload-might-be-uninit.rs:33:1
    |
 LL | / pub enum CommonPayloadFieldIsMaybeUninit {
 LL | |     A(u8),
@@ -462,9 +444,7 @@ error: layout_of(NicheFirst) = Layout {
                            abi: Align {
                                pow2: 0,
                            },
-                           pref: Align {
-                               pow2: 3,
-                           },
+                           pref: $PREF_ALIGN,
                        },
                        size: Size {
                            raw: 2,
@@ -486,9 +466,7 @@ error: layout_of(NicheFirst) = Layout {
                            abi: Align {
                                pow2: 0,
                            },
-                           pref: Align {
-                               pow2: 3,
-                           },
+                           pref: $PREF_ALIGN,
                        },
                        size: Size {
                            raw: 0,
@@ -510,9 +488,7 @@ error: layout_of(NicheFirst) = Layout {
                            abi: Align {
                                pow2: 0,
                            },
-                           pref: Align {
-                               pow2: 3,
-                           },
+                           pref: $PREF_ALIGN,
                        },
                        size: Size {
                            raw: 0,
@@ -551,15 +527,13 @@ error: layout_of(NicheFirst) = Layout {
                abi: Align {
                    pow2: 0,
                },
-               pref: Align {
-                   pow2: 3,
-               },
+               pref: $PREF_ALIGN,
            },
            size: Size {
                raw: 2,
            },
        }
-  --> $DIR/issue-96158-scalarpair-payload-might-be-uninit.rs:40:1
+  --> $DIR/issue-96158-scalarpair-payload-might-be-uninit.rs:41:1
    |
 LL | / pub enum NicheFirst {
 LL | |     A(HasNiche, u8),
@@ -644,9 +618,7 @@ error: layout_of(NicheSecond) = Layout {
                            abi: Align {
                                pow2: 0,
                            },
-                           pref: Align {
-                               pow2: 3,
-                           },
+                           pref: $PREF_ALIGN,
                        },
                        size: Size {
                            raw: 2,
@@ -668,9 +640,7 @@ error: layout_of(NicheSecond) = Layout {
                            abi: Align {
                                pow2: 0,
                            },
-                           pref: Align {
-                               pow2: 3,
-                           },
+                           pref: $PREF_ALIGN,
                        },
                        size: Size {
                            raw: 0,
@@ -692,9 +662,7 @@ error: layout_of(NicheSecond) = Layout {
                            abi: Align {
                                pow2: 0,
                            },
-                           pref: Align {
-                               pow2: 3,
-                           },
+                           pref: $PREF_ALIGN,
                        },
                        size: Size {
                            raw: 0,
@@ -733,15 +701,13 @@ error: layout_of(NicheSecond) = Layout {
                abi: Align {
                    pow2: 0,
                },
-               pref: Align {
-                   pow2: 3,
-               },
+               pref: $PREF_ALIGN,
            },
            size: Size {
                raw: 2,
            },
        }
-  --> $DIR/issue-96158-scalarpair-payload-might-be-uninit.rs:49:1
+  --> $DIR/issue-96158-scalarpair-payload-might-be-uninit.rs:50:1
    |
 LL | / pub enum NicheSecond {
 LL | |     A(u8, HasNiche),


### PR DESCRIPTION
Fixes #96158

r? @RalfJung

