### PR TITLE
Use futex locks on emscripten.

### DIFF
--- a/library/std/src/sys/unix/locks/mod.rs
+++ b/library/std/src/sys/unix/locks/mod.rs
@@ -2,6 +2,7 @@ cfg_if::cfg_if! {
     if #[cfg(any(
         target_os = "linux",
         target_os = "android",
+        all(target_os = "emscripten", target_feature = "atomics"),
     ))] {
         mod futex;
         mod futex_rwlock;


### PR DESCRIPTION
This switches Emscripten to the futex-based lock implementations, away from pthread.

Tracking issue: https://github.com/rust-lang/rust/issues/93740