### PR TITLE
Ensure existance of dist directory when creating tarball

### DIFF
--- a/src/bootstrap/tarball.rs
+++ b/src/bootstrap/tarball.rs
@@ -262,11 +262,13 @@ impl<'a> Tarball<'a> {
         t!(std::fs::rename(&self.image_dir, &dest));
 
         self.run(|this, cmd| {
+            let distdir = crate::dist::distdir(this.builder);
+            t!(std::fs::create_dir_all(&distdir));
             cmd.arg("tarball")
                 .arg("--input")
                 .arg(&dest)
                 .arg("--output")
-                .arg(crate::dist::distdir(this.builder).join(this.package_name()));
+                .arg(distdir.join(this.package_name()));
         })
     }
 


### PR DESCRIPTION
I'm not sure why this works in CI, but this is necessary to make distcheck (including the `x86_64-linux-distcheck` image) run on Fedora 35.