### PR TITLE
Fix missing modules because of missing unindent doc comment in early intra-doc pass

### DIFF
--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -1165,6 +1165,10 @@ impl Attributes {
         ret
     }
 
+    crate fn doc_contains(&self, c: char) -> bool {
+        self.doc_strings.iter().any(|s| s.doc.as_str().contains(c))
+    }
+
     /// Finds all `doc` attributes as NameValues and returns their corresponding values, joined
     /// with newlines.
     crate fn collapsed_doc_value(&self) -> Option<String> {

--- a/src/librustdoc/passes/collect_intra_doc_links/early.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links/early.rs
@@ -164,9 +164,14 @@ impl EarlyDocLinkResolver<'_, '_> {
     fn load_links_in_attrs(&mut self, attrs: &[ast::Attribute]) {
         let module_id = self.current_mod.to_def_id();
         let mut need_traits_in_scope = false;
-        for (doc_module, doc) in
-            Attributes::from_ast(attrs, None).collapsed_doc_value_by_module_level()
-        {
+        let mut attrs = Attributes::from_ast(attrs, None);
+        if !attrs.doc_contains('[') {
+            // No need to load anything if there is no link inside this doc comment...
+            return;
+        }
+        // The `unindent_comments` pass hasn't been run yet!
+        attrs.unindent_doc_comments();
+        for (doc_module, doc) in attrs.collapsed_doc_value_by_module_level() {
             assert_eq!(doc_module, None);
             for link in markdown_links(&doc.as_str()) {
                 if let Some(Ok(pinfo)) = preprocess_link(&link) {

--- a/src/test/rustdoc/early-unindent.rs
+++ b/src/test/rustdoc/early-unindent.rs
@@ -1,0 +1,26 @@
+// This is a regression for https://github.com/rust-lang/rust/issues/96079.
+
+#![crate_name = "foo"]
+
+pub mod app {
+    pub struct S;
+
+    impl S {
+        // @has 'foo/app/struct.S.html'
+        // @has - '//a[@href="../enums/enum.Foo.html#method.by_name"]' 'Foo::by_name'
+        /**
+        Doc comment hello! [`Foo::by_name`](`crate::enums::Foo::by_name`).
+        */
+        pub fn whatever(&self) {}
+    }
+}
+
+pub mod enums {
+    pub enum Foo {
+        Bar,
+    }
+
+    impl Foo {
+        pub fn by_name(&self) {}
+    }
+}


### PR DESCRIPTION
Fixes #96079.

Copying/pasting my explanation from #96079:

> Figured the problem: the doc block hasn't been cleaned yet in the early intra doc links pass. Meaning that it interprets the link as a code block (because of the indent) and therefore doesn't load the associated module.

I didn't find a way to be able to run the `unindent` pass before the early intra-doc link pass unfortunately, so instead I check beforehand if there is a point into looking for a link instead the doc comment before doing anything. Hopefully, this shouldn't impact performance too much...

cc @petrochenkov 
r? @notriddle 