### PR TITLE
llvm-wrapper: add an include for Mangler

### DIFF
--- a/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
@@ -6,6 +6,7 @@
 #include "llvm/IR/GlobalVariable.h"
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/Intrinsics.h"
+#include "llvm/IR/Mangler.h"
 #include "llvm/Object/Archive.h"
 #include "llvm/Object/COFFImportFile.h"
 #include "llvm/Object/ObjectFile.h"


### PR DESCRIPTION
No functional changes intended.

Add an explicit #include for a new Mangler usage from
https://github.com/rust-lang/rust/commit/547405e80120117f3299d7271c839455bb670ad6#diff-b9d202534dd2844b76444d5ecca2536e97ff29913a69be05d4585c9f98bac797R1842.

Fixes a compilation error in our rust + head LLVM experimental CL:
https://buildkite.com/llvm-project/rust-llvm-integrate-prototype/builds/9819#9b3b87ab-5304-4d66-8576-f12a2f8221f2/209-506