### PR TITLE
Add EntryExistInstrumenterPass for -Z instrument-mcount to the pipeline manually for LLVM >= 13.

### DIFF
--- a/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
@@ -2253,7 +2253,13 @@ extern "C" {
     ) -> &'static mut Pass;
     pub fn LLVMRustCreateThreadSanitizerPass() -> &'static mut Pass;
     pub fn LLVMRustCreateHWAddressSanitizerPass(Recover: bool) -> &'static mut Pass;
+    pub fn LLVMRustCreateEntryExitInstrumenterPass(PostInlining: bool) -> &'static mut Pass;
     pub fn LLVMRustAddPass(PM: &PassManager<'_>, Pass: &'static mut Pass);
+    pub fn LLVMRustAddEarlyExtensionPasses(
+        PMB: &PassManagerBuilder,
+        Passes: *const &'static mut Pass,
+        NumPasses: size_t,
+    );
     pub fn LLVMRustAddLastExtensionPasses(
         PMB: &PassManagerBuilder,
         Passes: *const &'static mut Pass,
@@ -2342,6 +2348,7 @@ extern "C" {
         PGOUsePath: *const c_char,
         InstrumentCoverage: bool,
         InstrumentGCOV: bool,
+        InstrumentMcount: bool,
         PGOSampleUsePath: *const c_char,
         DebugInfoForProfiling: bool,
         llvm_selfprofiler: *mut c_void,

--- a/compiler/rustc_codegen_ssa/src/back/write.rs
+++ b/compiler/rustc_codegen_ssa/src/back/write.rs
@@ -87,6 +87,7 @@ pub struct ModuleConfig {
     pub debug_info_for_profiling: bool,
     pub instrument_coverage: bool,
     pub instrument_gcov: bool,
+    pub instrument_mcount: bool,
 
     pub sanitizer: SanitizerSet,
     pub sanitizer_recover: SanitizerSet,
@@ -189,6 +190,7 @@ impl ModuleConfig {
                 sess.opts.debugging_opts.profile && !is_compiler_builtins,
                 false
             ),
+            instrument_mcount: if_regular!(sess.instrument_mcount(), false),
 
             sanitizer: if_regular!(sess.opts.debugging_opts.sanitizer, SanitizerSet::empty()),
             sanitizer_recover: if_regular!(

--- a/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
@@ -149,11 +149,15 @@ extern "C" LLVMPassRef LLVMRustCreateHWAddressSanitizerPass(bool Recover) {
 }
 
 extern "C" LLVMPassRef LLVMRustCreateEntryExitInstrumenterPass(bool PostInlining) {
+#if LLVM_VERSION_LT(15, 0)
   if (PostInlining) {
     return wrap(createPostInlineEntryExitInstrumenterPass());
   } else {
     return wrap(createEntryExitInstrumenterPass());
   }
+#else
+  report_fatal_error("Legacy PM not supported with LLVM 15");
+#endif
 }
 
 extern "C" LLVMRustPassKind LLVMRustPassKind(LLVMPassRef RustPass) {
@@ -180,6 +184,7 @@ void LLVMRustPassManagerBuilderPopulateThinLTOPassManager(
 extern "C"
 void LLVMRustAddEarlyExtensionPasses(
     LLVMPassManagerBuilderRef PMBR, LLVMPassRef *Passes, size_t NumPasses) {
+#if LLVM_VERSION_LT(15, 0)
   auto AddExtensionPasses = [Passes, NumPasses](
       const PassManagerBuilder &Builder, PassManagerBase &PM) {
     for (size_t I = 0; I < NumPasses; I++) {
@@ -190,6 +195,9 @@ void LLVMRustAddEarlyExtensionPasses(
                              AddExtensionPasses);
   unwrap(PMBR)->addExtension(PassManagerBuilder::EP_EnabledOnOptLevel0,
                              AddExtensionPasses);
+#else
+  report_fatal_error("Legacy PM not supported with LLVM 15");
+#endif
 }
 
 extern "C"

--- a/src/test/codegen/instrument-mcount-legacy.rs
+++ b/src/test/codegen/instrument-mcount-legacy.rs
@@ -1,0 +1,9 @@
+// ignore-llvm-version: 13.0.0 - 99.99.99
+// revisions: opt noopt
+// compile-flags: -Z instrument-mcount
+// [opt]compile-flags: -O
+
+#![crate_type = "lib"]
+
+// CHECK: attributes #{{.*}} "frame-pointer"="all" "instrument-function-entry-inlined"="{{.*}}mcount{{.*}}"
+pub fn foo() {}

--- a/src/test/codegen/instrument-mcount.rs
+++ b/src/test/codegen/instrument-mcount.rs
@@ -1,3 +1,4 @@
+// min-llvm-version: 13.0.0
 // revisions: opt noopt
 // compile-flags: -Z instrument-mcount
 // [opt]compile-flags: -O

--- a/src/test/codegen/instrument-mcount.rs
+++ b/src/test/codegen/instrument-mcount.rs
@@ -1,7 +1,8 @@
-//
+// revisions: opt noopt
 // compile-flags: -Z instrument-mcount
+// [opt]compile-flags: -O
 
 #![crate_type = "lib"]
 
-// CHECK: attributes #{{.*}} "frame-pointer"="all" "instrument-function-entry-inlined"="{{.*}}mcount{{.*}}"
+// CHECK: call void @{{.*}}mcount
 pub fn foo() {}


### PR DESCRIPTION
Fixes #92109