### PR TITLE
Update `validate_uninhabited_zsts.rs` test after MIR building changes

### DIFF
--- a/src/test/ui/consts/const-eval/validate_uninhabited_zsts.32bit.stderr
+++ b/src/test/ui/consts/const-eval/validate_uninhabited_zsts.32bit.stderr
@@ -7,14 +7,17 @@ LL |     unsafe { std::mem::transmute(()) }
    |              transmuting to uninhabited type
    |              inside `foo` at $DIR/validate_uninhabited_zsts.rs:4:14
 ...
-LL | const FOO: [Empty; 3] = [foo(); 3];
-   |                          ----- inside `FOO` at $DIR/validate_uninhabited_zsts.rs:13:26
+LL | const FOO: [empty::Empty; 3] = [foo(); 3];
+   |                                 ----- inside `FOO` at $DIR/validate_uninhabited_zsts.rs:20:33
 
-error[E0080]: evaluation of constant value failed
-  --> $DIR/validate_uninhabited_zsts.rs:16:35
+error[E0080]: it is undefined behavior to use this value
+  --> $DIR/validate_uninhabited_zsts.rs:23:1
    |
-LL | const BAR: [Empty; 3] = [unsafe { std::mem::transmute(()) }; 3];
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^ transmuting to uninhabited type
+LL | const BAR: [empty::Empty; 3] = [unsafe { std::mem::transmute(()) }; 3];
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at [0].0: encountered a value of uninhabited type empty::Void
+   |
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
+   = note: the raw bytes of the constant (size: 0, align: 1) {}
 
 warning: the type `!` does not permit zero-initialization
   --> $DIR/validate_uninhabited_zsts.rs:4:14
@@ -28,16 +31,20 @@ LL |     unsafe { std::mem::transmute(()) }
    = note: `#[warn(invalid_value)]` on by default
    = note: the `!` type has no valid value
 
-warning: the type `Empty` does not permit zero-initialization
-  --> $DIR/validate_uninhabited_zsts.rs:16:35
+warning: the type `empty::Empty` does not permit zero-initialization
+  --> $DIR/validate_uninhabited_zsts.rs:23:42
    |
-LL | const BAR: [Empty; 3] = [unsafe { std::mem::transmute(()) }; 3];
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^
-   |                                   |
-   |                                   this code causes undefined behavior when executed
-   |                                   help: use `MaybeUninit<T>` instead, and only call `assume_init` after initialization is done
+LL | const BAR: [empty::Empty; 3] = [unsafe { std::mem::transmute(()) }; 3];
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^
+   |                                          |
+   |                                          this code causes undefined behavior when executed
+   |                                          help: use `MaybeUninit<T>` instead, and only call `assume_init` after initialization is done
    |
-   = note: enums with no variants have no valid value
+note: enums with no variants have no valid value (in this struct field)
+  --> $DIR/validate_uninhabited_zsts.rs:16:22
+   |
+LL |     pub struct Empty(Void);
+   |                      ^^^^
 
 error: aborting due to 2 previous errors; 2 warnings emitted
 

--- a/src/test/ui/consts/const-eval/validate_uninhabited_zsts.64bit.stderr
+++ b/src/test/ui/consts/const-eval/validate_uninhabited_zsts.64bit.stderr
@@ -7,14 +7,17 @@ LL |     unsafe { std::mem::transmute(()) }
    |              transmuting to uninhabited type
    |              inside `foo` at $DIR/validate_uninhabited_zsts.rs:4:14
 ...
-LL | const FOO: [Empty; 3] = [foo(); 3];
-   |                          ----- inside `FOO` at $DIR/validate_uninhabited_zsts.rs:13:26
+LL | const FOO: [empty::Empty; 3] = [foo(); 3];
+   |                                 ----- inside `FOO` at $DIR/validate_uninhabited_zsts.rs:20:33
 
-error[E0080]: evaluation of constant value failed
-  --> $DIR/validate_uninhabited_zsts.rs:16:35
+error[E0080]: it is undefined behavior to use this value
+  --> $DIR/validate_uninhabited_zsts.rs:23:1
    |
-LL | const BAR: [Empty; 3] = [unsafe { std::mem::transmute(()) }; 3];
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^ transmuting to uninhabited type
+LL | const BAR: [empty::Empty; 3] = [unsafe { std::mem::transmute(()) }; 3];
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at [0].0: encountered a value of uninhabited type empty::Void
+   |
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
+   = note: the raw bytes of the constant (size: 0, align: 1) {}
 
 warning: the type `!` does not permit zero-initialization
   --> $DIR/validate_uninhabited_zsts.rs:4:14
@@ -28,16 +31,20 @@ LL |     unsafe { std::mem::transmute(()) }
    = note: `#[warn(invalid_value)]` on by default
    = note: the `!` type has no valid value
 
-warning: the type `Empty` does not permit zero-initialization
-  --> $DIR/validate_uninhabited_zsts.rs:16:35
+warning: the type `empty::Empty` does not permit zero-initialization
+  --> $DIR/validate_uninhabited_zsts.rs:23:42
    |
-LL | const BAR: [Empty; 3] = [unsafe { std::mem::transmute(()) }; 3];
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^
-   |                                   |
-   |                                   this code causes undefined behavior when executed
-   |                                   help: use `MaybeUninit<T>` instead, and only call `assume_init` after initialization is done
+LL | const BAR: [empty::Empty; 3] = [unsafe { std::mem::transmute(()) }; 3];
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^
+   |                                          |
+   |                                          this code causes undefined behavior when executed
+   |                                          help: use `MaybeUninit<T>` instead, and only call `assume_init` after initialization is done
    |
-   = note: enums with no variants have no valid value
+note: enums with no variants have no valid value (in this struct field)
+  --> $DIR/validate_uninhabited_zsts.rs:16:22
+   |
+LL |     pub struct Empty(Void);
+   |                      ^^^^
 
 error: aborting due to 2 previous errors; 2 warnings emitted
 

--- a/src/test/ui/consts/const-eval/validate_uninhabited_zsts.rs
+++ b/src/test/ui/consts/const-eval/validate_uninhabited_zsts.rs
@@ -6,16 +6,23 @@ const fn foo() -> ! {
     //~| WARN the type `!` does not permit zero-initialization [invalid_value]
 }
 
-#[derive(Clone, Copy)]
-enum Empty { }
+// Type defined in a submodule, so that it is not "visibly"
+// uninhabited (which would change interpreter behavior).
+pub mod empty {
+    #[derive(Clone, Copy)]
+    enum Void {}
+
+    #[derive(Clone, Copy)]
+    pub struct Empty(Void);
+}
 
 #[warn(const_err)]
-const FOO: [Empty; 3] = [foo(); 3];
+const FOO: [empty::Empty; 3] = [foo(); 3];
 
 #[warn(const_err)]
-const BAR: [Empty; 3] = [unsafe { std::mem::transmute(()) }; 3];
-//~^ ERROR evaluation of constant value failed
-//~| WARN the type `Empty` does not permit zero-initialization
+const BAR: [empty::Empty; 3] = [unsafe { std::mem::transmute(()) }; 3];
+//~^ ERROR it is undefined behavior to use this value
+//~| WARN the type `empty::Empty` does not permit zero-initialization
 
 fn main() {
     FOO;


### PR DESCRIPTION
to ensure that it still tests validation, instead of failing earlier on
during evaluation.

r? @RalfJung 