### PR TITLE
Make libtest logfile respect --format

### DIFF
--- a/library/test/src/tests.rs
+++ b/library/test/src/tests.rs
@@ -778,7 +778,6 @@ fn should_sort_failures_before_printing_them() {
     let mut out = PrettyFormatter::new(OutputLocation::Raw(Vec::new()), false, 10, false, None);
 
     let st = console::ConsoleTestState {
-        log_out: None,
         total: 0,
         passed: 0,
         failed: 0,


### PR DESCRIPTION
I recently ran into an issue caused by the libtest output in logfile not respecting the --format flag. I've seen that a bug has been filed (#57147) but no PR was ever sent.

This PR makes the logfile follow the same format used for STDOUT printing. It removes the log_out field from ConsoleTestState and inlines its creation where needed, wrapping the logfile in an OutputFormatter. I've also deleted a couple of (now unused) methods in ConsoleTestState.

Let me know if you think there is a cleaner solution than the direction I've followed. Thanks!

closes #57147