### PR TITLE
Display function path in unsafety violations - E0133 

### DIFF
--- a/compiler/rustc_middle/src/mir/query.rs
+++ b/compiler/rustc_middle/src/mir/query.rs
@@ -44,6 +44,27 @@ pub enum UnsafetyViolationDetails {
 }
 
 impl UnsafetyViolationDetails {
+    pub fn simple_description(&self) -> &'static str {
+        use UnsafetyViolationDetails::*;
+
+        match self {
+            CallToUnsafeFunction(..) => "call to unsafe function",
+            UseOfInlineAssembly => "use of inline assembly",
+            InitializingTypeWith => "initializing type with `rustc_layout_scalar_valid_range` attr",
+            CastOfPointerToInt => "cast of pointer to int",
+            UseOfMutableStatic => "use of mutable static",
+            UseOfExternStatic => "use of extern static",
+            DerefOfRawPointer => "dereference of raw pointer",
+            AssignToDroppingUnionField => "assignment to union field that might need dropping",
+            AccessToUnionField => "access to union field",
+            MutationOfLayoutConstrainedField => "mutation of layout constrained field",
+            BorrowOfLayoutConstrainedField => {
+                "borrow of layout constrained field with interior mutability"
+            }
+            CallToFunctionWith(..) => "call to function with `#[target_feature]`",
+        }
+    }
+
     pub fn description_and_note(&self, tcx: TyCtxt<'_>) -> (Cow<'static, str>, &'static str) {
         use UnsafetyViolationDetails::*;
         match self {
@@ -51,55 +72,55 @@ impl UnsafetyViolationDetails {
                 if let Some(did) = did {
                     Cow::from(format!("call to unsafe function `{}`", tcx.def_path_str(*did)))
                 } else {
-                    Cow::Borrowed("call to unsafe function")
+                    Cow::Borrowed(self.simple_description())
                 },
                 "consult the function's documentation for information on how to avoid undefined \
                  behavior",
             ),
             UseOfInlineAssembly => (
-                Cow::Borrowed("use of inline assembly"),
+                Cow::Borrowed(self.simple_description()),
                 "inline assembly is entirely unchecked and can cause undefined behavior",
             ),
             InitializingTypeWith => (
-                Cow::Borrowed("initializing type with `rustc_layout_scalar_valid_range` attr"),
+                Cow::Borrowed(self.simple_description()),
                 "initializing a layout restricted type's field with a value outside the valid \
                  range is undefined behavior",
             ),
             CastOfPointerToInt => (
-                Cow::Borrowed("cast of pointer to int"),
+                Cow::Borrowed(self.simple_description()),
                 "casting pointers to integers in constants",
             ),
             UseOfMutableStatic => (
-                Cow::Borrowed("use of mutable static"),
+                Cow::Borrowed(self.simple_description()),
                 "mutable statics can be mutated by multiple threads: aliasing violations or data \
                  races will cause undefined behavior",
             ),
             UseOfExternStatic => (
-                Cow::Borrowed("use of extern static"),
+                Cow::Borrowed(self.simple_description()),
                 "extern statics are not controlled by the Rust type system: invalid data, \
                  aliasing violations or data races will cause undefined behavior",
             ),
             DerefOfRawPointer => (
-                Cow::Borrowed("dereference of raw pointer"),
+                Cow::Borrowed(self.simple_description()),
                 "raw pointers may be null, dangling or unaligned; they can violate aliasing rules \
                  and cause data races: all of these are undefined behavior",
             ),
             AssignToDroppingUnionField => (
-                Cow::Borrowed("assignment to union field that might need dropping"),
+                Cow::Borrowed(self.simple_description()),
                 "the previous content of the field will be dropped, which causes undefined \
                  behavior if the field was not properly initialized",
             ),
             AccessToUnionField => (
-                Cow::Borrowed("access to union field"),
+                Cow::Borrowed(self.simple_description()),
                 "the field may not be properly initialized: using uninitialized data will cause \
                  undefined behavior",
             ),
             MutationOfLayoutConstrainedField => (
-                Cow::Borrowed("mutation of layout constrained field"),
+                Cow::Borrowed(self.simple_description()),
                 "mutating layout constrained fields cannot statically be checked for valid values",
             ),
             BorrowOfLayoutConstrainedField => (
-                Cow::Borrowed("borrow of layout constrained field with interior mutability"),
+                Cow::Borrowed(self.simple_description()),
                 "references to fields of layout constrained fields lose the constraints. Coupled \
                  with interior mutability, the field can be changed to invalid values",
             ),

--- a/compiler/rustc_mir_build/src/check_unsafety.rs
+++ b/compiler/rustc_mir_build/src/check_unsafety.rs
@@ -12,6 +12,7 @@ use rustc_span::def_id::{DefId, LocalDefId};
 use rustc_span::symbol::Symbol;
 use rustc_span::Span;
 
+use std::borrow::Cow;
 use std::ops::Bound;
 
 struct UnsafetyVisitor<'a, 'tcx> {
@@ -70,7 +71,6 @@ impl<'tcx> UnsafetyVisitor<'_, 'tcx> {
     }
 
     fn requires_unsafe(&mut self, span: Span, kind: UnsafeOpKind) {
-        let (description, note) = kind.description_and_note();
         let unsafe_op_in_unsafe_fn_allowed = self.unsafe_op_in_unsafe_fn_allowed();
         match self.safety_context {
             SafetyContext::BuiltinUnsafeBlock => {}
@@ -82,6 +82,7 @@ impl<'tcx> UnsafetyVisitor<'_, 'tcx> {
             }
             SafetyContext::UnsafeFn if unsafe_op_in_unsafe_fn_allowed => {}
             SafetyContext::UnsafeFn => {
+                let (description, note) = kind.description_and_note(self.tcx);
                 // unsafe_op_in_unsafe_fn is disallowed
                 self.tcx.struct_span_lint_hir(
                     UNSAFE_OP_IN_UNSAFE_FN,
@@ -99,6 +100,7 @@ impl<'tcx> UnsafetyVisitor<'_, 'tcx> {
                 )
             }
             SafetyContext::Safe => {
+                let (description, note) = kind.description_and_note(self.tcx);
                 let fn_sugg = if unsafe_op_in_unsafe_fn_allowed { " function or" } else { "" };
                 struct_span_err!(
                     self.tcx.sess,
@@ -350,7 +352,12 @@ impl<'a, 'tcx> Visitor<'a, 'tcx> for UnsafetyVisitor<'a, 'tcx> {
             }
             ExprKind::Call { fun, ty: _, args: _, from_hir_call: _, fn_span: _ } => {
                 if self.thir[fun].ty.fn_sig(self.tcx).unsafety() == hir::Unsafety::Unsafe {
-                    self.requires_unsafe(expr.span, CallToUnsafeFunction);
+                    let func_id = if let ty::FnDef(func_id, _) = self.thir[fun].ty.kind() {
+                        Some(*func_id)
+                    } else {
+                        None
+                    };
+                    self.requires_unsafe(expr.span, CallToUnsafeFunction(func_id));
                 } else if let &ty::FnDef(func_did, _) = self.thir[fun].ty.kind() {
                     // If the called function has target features the calling function hasn't,
                     // the call requires `unsafe`. Don't check this on wasm
@@ -364,7 +371,7 @@ impl<'a, 'tcx> Visitor<'a, 'tcx> for UnsafetyVisitor<'a, 'tcx> {
                             .iter()
                             .all(|feature| self.body_target_features.contains(feature))
                     {
-                        self.requires_unsafe(expr.span, CallToFunctionWith);
+                        self.requires_unsafe(expr.span, CallToFunctionWith(func_did));
                     }
                 }
             }
@@ -523,7 +530,7 @@ impl BodyUnsafety {
 
 #[derive(Clone, Copy, PartialEq)]
 enum UnsafeOpKind {
-    CallToUnsafeFunction,
+    CallToUnsafeFunction(Option<DefId>),
     UseOfInlineAssembly,
     InitializingTypeWith,
     UseOfMutableStatic,
@@ -533,64 +540,71 @@ enum UnsafeOpKind {
     AccessToUnionField,
     MutationOfLayoutConstrainedField,
     BorrowOfLayoutConstrainedField,
-    CallToFunctionWith,
+    CallToFunctionWith(DefId),
 }
 
 use UnsafeOpKind::*;
 
 impl UnsafeOpKind {
-    pub fn description_and_note(&self) -> (&'static str, &'static str) {
+    pub fn description_and_note(&self, tcx: TyCtxt<'_>) -> (Cow<'static, str>, &'static str) {
         match self {
-            CallToUnsafeFunction => (
-                "call to unsafe function",
+            CallToUnsafeFunction(did) => (
+                if let Some(did) = did {
+                    Cow::from(format!("call to unsafe function `{}`", tcx.def_path_str(*did)))
+                } else {
+                    Cow::Borrowed("call to unsafe function")
+                },
                 "consult the function's documentation for information on how to avoid undefined \
                  behavior",
             ),
             UseOfInlineAssembly => (
-                "use of inline assembly",
+                Cow::Borrowed("use of inline assembly"),
                 "inline assembly is entirely unchecked and can cause undefined behavior",
             ),
             InitializingTypeWith => (
-                "initializing type with `rustc_layout_scalar_valid_range` attr",
+                Cow::Borrowed("initializing type with `rustc_layout_scalar_valid_range` attr"),
                 "initializing a layout restricted type's field with a value outside the valid \
                  range is undefined behavior",
             ),
             UseOfMutableStatic => (
-                "use of mutable static",
+                Cow::Borrowed("use of mutable static"),
                 "mutable statics can be mutated by multiple threads: aliasing violations or data \
                  races will cause undefined behavior",
             ),
             UseOfExternStatic => (
-                "use of extern static",
+                Cow::Borrowed("use of extern static"),
                 "extern statics are not controlled by the Rust type system: invalid data, \
                  aliasing violations or data races will cause undefined behavior",
             ),
             DerefOfRawPointer => (
-                "dereference of raw pointer",
+                Cow::Borrowed("dereference of raw pointer"),
                 "raw pointers may be null, dangling or unaligned; they can violate aliasing rules \
                  and cause data races: all of these are undefined behavior",
             ),
             AssignToDroppingUnionField => (
-                "assignment to union field that might need dropping",
+                Cow::Borrowed("assignment to union field that might need dropping"),
                 "the previous content of the field will be dropped, which causes undefined \
                  behavior if the field was not properly initialized",
             ),
             AccessToUnionField => (
-                "access to union field",
+                Cow::Borrowed("access to union field"),
                 "the field may not be properly initialized: using uninitialized data will cause \
                  undefined behavior",
             ),
             MutationOfLayoutConstrainedField => (
-                "mutation of layout constrained field",
+                Cow::Borrowed("mutation of layout constrained field"),
                 "mutating layout constrained fields cannot statically be checked for valid values",
             ),
             BorrowOfLayoutConstrainedField => (
-                "borrow of layout constrained field with interior mutability",
+                Cow::Borrowed("borrow of layout constrained field with interior mutability"),
                 "references to fields of layout constrained fields lose the constraints. Coupled \
                  with interior mutability, the field can be changed to invalid values",
             ),
-            CallToFunctionWith => (
-                "call to function with `#[target_feature]`",
+            CallToFunctionWith(did) => (
+                Cow::from(format!(
+                    "call to function `{}` with `#[target_feature]`",
+                    tcx.def_path_str(*did)
+                )),
                 "can only be called if the required target features are available",
             ),
         }

--- a/compiler/rustc_mir_transform/src/check_unsafety.rs
+++ b/compiler/rustc_mir_transform/src/check_unsafety.rs
@@ -598,7 +598,7 @@ pub fn check_unsafety(tcx: TyCtxt<'_>, def_id: LocalDefId) {
                     description,
                     unsafe_fn_msg,
                 )
-                .span_label(source_info.span, description)
+                .span_label(source_info.span, details.simple_description())
                 .note(note)
                 .emit();
             }

--- a/compiler/rustc_mir_transform/src/check_unsafety.rs
+++ b/compiler/rustc_mir_transform/src/check_unsafety.rs
@@ -70,15 +70,17 @@ impl<'tcx> Visitor<'tcx> for UnsafetyChecker<'_, 'tcx> {
 
             TerminatorKind::Call { ref func, .. } => {
                 let func_ty = func.ty(self.body, self.tcx);
+                let func_id =
+                    if let ty::FnDef(func_id, _) = func_ty.kind() { Some(func_id) } else { None };
                 let sig = func_ty.fn_sig(self.tcx);
                 if let hir::Unsafety::Unsafe = sig.unsafety() {
                     self.require_unsafe(
                         UnsafetyViolationKind::General,
-                        UnsafetyViolationDetails::CallToUnsafeFunction,
+                        UnsafetyViolationDetails::CallToUnsafeFunction(func_id.copied()),
                     )
                 }
 
-                if let ty::FnDef(func_id, _) = func_ty.kind() {
+                if let Some(func_id) = func_id {
                     self.check_target_features(*func_id);
                 }
             }
@@ -379,7 +381,7 @@ impl<'tcx> UnsafetyChecker<'_, 'tcx> {
         if !callee_features.iter().all(|feature| self_features.contains(feature)) {
             self.require_unsafe(
                 UnsafetyViolationKind::General,
-                UnsafetyViolationDetails::CallToFunctionWith,
+                UnsafetyViolationDetails::CallToFunctionWith(func_did),
             )
         }
     }
@@ -578,7 +580,8 @@ pub fn check_unsafety(tcx: TyCtxt<'_>, def_id: LocalDefId) {
     let UnsafetyCheckResult { violations, unused_unsafes, .. } = tcx.unsafety_check_result(def_id);
 
     for &UnsafetyViolation { source_info, lint_root, kind, details } in violations.iter() {
-        let (description, note) = details.description_and_note();
+        let (description, note) =
+            ty::print::with_no_trimmed_paths!(details.description_and_note(tcx));
 
         // Report an error.
         let unsafe_fn_msg =

--- a/src/test/ui/async-await/async-unsafe-fn-call-in-safe.mir.stderr
+++ b/src/test/ui/async-await/async-unsafe-fn-call-in-safe.mir.stderr
@@ -2,7 +2,7 @@ error[E0133]: call to unsafe function `S::f` is unsafe and requires unsafe funct
   --> $DIR/async-unsafe-fn-call-in-safe.rs:14:5
    |
 LL |     S::f();
-   |     ^^^^^^ call to unsafe function `S::f`
+   |     ^^^^^^ call to unsafe function
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 
@@ -10,7 +10,7 @@ error[E0133]: call to unsafe function `f` is unsafe and requires unsafe function
   --> $DIR/async-unsafe-fn-call-in-safe.rs:15:5
    |
 LL |     f();
-   |     ^^^ call to unsafe function `f`
+   |     ^^^ call to unsafe function
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 
@@ -18,7 +18,7 @@ error[E0133]: call to unsafe function `S::f` is unsafe and requires unsafe funct
   --> $DIR/async-unsafe-fn-call-in-safe.rs:19:5
    |
 LL |     S::f();
-   |     ^^^^^^ call to unsafe function `S::f`
+   |     ^^^^^^ call to unsafe function
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 
@@ -26,7 +26,7 @@ error[E0133]: call to unsafe function `f` is unsafe and requires unsafe function
   --> $DIR/async-unsafe-fn-call-in-safe.rs:20:5
    |
 LL |     f();
-   |     ^^^ call to unsafe function `f`
+   |     ^^^ call to unsafe function
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 

--- a/src/test/ui/async-await/async-unsafe-fn-call-in-safe.mir.stderr
+++ b/src/test/ui/async-await/async-unsafe-fn-call-in-safe.mir.stderr
@@ -1,32 +1,32 @@
-error[E0133]: call to unsafe function is unsafe and requires unsafe function or block
+error[E0133]: call to unsafe function `S::f` is unsafe and requires unsafe function or block
   --> $DIR/async-unsafe-fn-call-in-safe.rs:14:5
    |
 LL |     S::f();
-   |     ^^^^^^ call to unsafe function
+   |     ^^^^^^ call to unsafe function `S::f`
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 
-error[E0133]: call to unsafe function is unsafe and requires unsafe function or block
+error[E0133]: call to unsafe function `f` is unsafe and requires unsafe function or block
   --> $DIR/async-unsafe-fn-call-in-safe.rs:15:5
    |
 LL |     f();
-   |     ^^^ call to unsafe function
+   |     ^^^ call to unsafe function `f`
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 
-error[E0133]: call to unsafe function is unsafe and requires unsafe function or block
+error[E0133]: call to unsafe function `S::f` is unsafe and requires unsafe function or block
   --> $DIR/async-unsafe-fn-call-in-safe.rs:19:5
    |
 LL |     S::f();
-   |     ^^^^^^ call to unsafe function
+   |     ^^^^^^ call to unsafe function `S::f`
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 
-error[E0133]: call to unsafe function is unsafe and requires unsafe function or block
+error[E0133]: call to unsafe function `f` is unsafe and requires unsafe function or block
   --> $DIR/async-unsafe-fn-call-in-safe.rs:20:5
    |
 LL |     f();
-   |     ^^^ call to unsafe function
+   |     ^^^ call to unsafe function `f`
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 

--- a/src/test/ui/async-await/async-unsafe-fn-call-in-safe.rs
+++ b/src/test/ui/async-await/async-unsafe-fn-call-in-safe.rs
@@ -11,11 +11,11 @@ impl S {
 async unsafe fn f() {}
 
 async fn g() {
-    S::f(); //~ ERROR call to unsafe function is unsafe
-    f(); //~ ERROR call to unsafe function is unsafe
+    S::f(); //~ ERROR call to unsafe function `S::f` is unsafe
+    f(); //~ ERROR call to unsafe function `f` is unsafe
 }
 
 fn main() {
-    S::f(); //[mir]~ ERROR call to unsafe function is unsafe
-    f(); //[mir]~ ERROR call to unsafe function is unsafe
+    S::f(); //[mir]~ ERROR call to unsafe function `S::f` is unsafe
+    f(); //[mir]~ ERROR call to unsafe function `f` is unsafe
 }

--- a/src/test/ui/async-await/async-unsafe-fn-call-in-safe.thir.stderr
+++ b/src/test/ui/async-await/async-unsafe-fn-call-in-safe.thir.stderr
@@ -2,7 +2,7 @@ error[E0133]: call to unsafe function `S::f` is unsafe and requires unsafe funct
   --> $DIR/async-unsafe-fn-call-in-safe.rs:14:5
    |
 LL |     S::f();
-   |     ^^^^^^ call to unsafe function `S::f`
+   |     ^^^^^^ call to unsafe function
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 
@@ -10,7 +10,7 @@ error[E0133]: call to unsafe function `f` is unsafe and requires unsafe function
   --> $DIR/async-unsafe-fn-call-in-safe.rs:15:5
    |
 LL |     f();
-   |     ^^^ call to unsafe function `f`
+   |     ^^^ call to unsafe function
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 

--- a/src/test/ui/async-await/async-unsafe-fn-call-in-safe.thir.stderr
+++ b/src/test/ui/async-await/async-unsafe-fn-call-in-safe.thir.stderr
@@ -1,16 +1,16 @@
-error[E0133]: call to unsafe function is unsafe and requires unsafe function or block
+error[E0133]: call to unsafe function `S::f` is unsafe and requires unsafe function or block
   --> $DIR/async-unsafe-fn-call-in-safe.rs:14:5
    |
 LL |     S::f();
-   |     ^^^^^^ call to unsafe function
+   |     ^^^^^^ call to unsafe function `S::f`
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 
-error[E0133]: call to unsafe function is unsafe and requires unsafe function or block
+error[E0133]: call to unsafe function `f` is unsafe and requires unsafe function or block
   --> $DIR/async-unsafe-fn-call-in-safe.rs:15:5
    |
 LL |     f();
-   |     ^^^ call to unsafe function
+   |     ^^^ call to unsafe function `f`
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 

--- a/src/test/ui/closures/coerce-unsafe-closure-to-unsafe-fn-ptr.mir.stderr
+++ b/src/test/ui/closures/coerce-unsafe-closure-to-unsafe-fn-ptr.mir.stderr
@@ -1,8 +1,8 @@
-error[E0133]: call to unsafe function is unsafe and requires unsafe function or block
+error[E0133]: call to unsafe function `std::pin::Pin::<P>::new_unchecked` is unsafe and requires unsafe function or block
   --> $DIR/coerce-unsafe-closure-to-unsafe-fn-ptr.rs:5:31
    |
 LL |     let _: unsafe fn() = || { ::std::pin::Pin::new_unchecked(&0_u8); };
-   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function `std::pin::Pin::<P>::new_unchecked`
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 

--- a/src/test/ui/closures/coerce-unsafe-closure-to-unsafe-fn-ptr.mir.stderr
+++ b/src/test/ui/closures/coerce-unsafe-closure-to-unsafe-fn-ptr.mir.stderr
@@ -2,7 +2,7 @@ error[E0133]: call to unsafe function `std::pin::Pin::<P>::new_unchecked` is uns
   --> $DIR/coerce-unsafe-closure-to-unsafe-fn-ptr.rs:5:31
    |
 LL |     let _: unsafe fn() = || { ::std::pin::Pin::new_unchecked(&0_u8); };
-   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function `std::pin::Pin::<P>::new_unchecked`
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 

--- a/src/test/ui/closures/coerce-unsafe-closure-to-unsafe-fn-ptr.thir.stderr
+++ b/src/test/ui/closures/coerce-unsafe-closure-to-unsafe-fn-ptr.thir.stderr
@@ -2,7 +2,7 @@ error[E0133]: call to unsafe function `Pin::<P>::new_unchecked` is unsafe and re
   --> $DIR/coerce-unsafe-closure-to-unsafe-fn-ptr.rs:5:31
    |
 LL |     let _: unsafe fn() = || { ::std::pin::Pin::new_unchecked(&0_u8); };
-   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function `Pin::<P>::new_unchecked`
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 

--- a/src/test/ui/closures/coerce-unsafe-closure-to-unsafe-fn-ptr.thir.stderr
+++ b/src/test/ui/closures/coerce-unsafe-closure-to-unsafe-fn-ptr.thir.stderr
@@ -1,8 +1,8 @@
-error[E0133]: call to unsafe function is unsafe and requires unsafe function or block
+error[E0133]: call to unsafe function `Pin::<P>::new_unchecked` is unsafe and requires unsafe function or block
   --> $DIR/coerce-unsafe-closure-to-unsafe-fn-ptr.rs:5:31
    |
 LL |     let _: unsafe fn() = || { ::std::pin::Pin::new_unchecked(&0_u8); };
-   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function `Pin::<P>::new_unchecked`
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 

--- a/src/test/ui/consts/const-extern-fn/const-extern-fn-requires-unsafe.mir.stderr
+++ b/src/test/ui/consts/const-extern-fn/const-extern-fn-requires-unsafe.mir.stderr
@@ -2,7 +2,7 @@ error[E0133]: call to unsafe function `foo` is unsafe and requires unsafe functi
   --> $DIR/const-extern-fn-requires-unsafe.rs:9:17
    |
 LL |     let a: [u8; foo()];
-   |                 ^^^^^ call to unsafe function `foo`
+   |                 ^^^^^ call to unsafe function
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 
@@ -10,7 +10,7 @@ error[E0133]: call to unsafe function `foo` is unsafe and requires unsafe functi
   --> $DIR/const-extern-fn-requires-unsafe.rs:11:5
    |
 LL |     foo();
-   |     ^^^^^ call to unsafe function `foo`
+   |     ^^^^^ call to unsafe function
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 

--- a/src/test/ui/consts/const-extern-fn/const-extern-fn-requires-unsafe.mir.stderr
+++ b/src/test/ui/consts/const-extern-fn/const-extern-fn-requires-unsafe.mir.stderr
@@ -1,16 +1,16 @@
-error[E0133]: call to unsafe function is unsafe and requires unsafe function or block
+error[E0133]: call to unsafe function `foo` is unsafe and requires unsafe function or block
   --> $DIR/const-extern-fn-requires-unsafe.rs:9:17
    |
 LL |     let a: [u8; foo()];
-   |                 ^^^^^ call to unsafe function
+   |                 ^^^^^ call to unsafe function `foo`
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 
-error[E0133]: call to unsafe function is unsafe and requires unsafe function or block
+error[E0133]: call to unsafe function `foo` is unsafe and requires unsafe function or block
   --> $DIR/const-extern-fn-requires-unsafe.rs:11:5
    |
 LL |     foo();
-   |     ^^^^^ call to unsafe function
+   |     ^^^^^ call to unsafe function `foo`
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 

--- a/src/test/ui/consts/const-extern-fn/const-extern-fn-requires-unsafe.rs
+++ b/src/test/ui/consts/const-extern-fn/const-extern-fn-requires-unsafe.rs
@@ -7,7 +7,7 @@ const unsafe extern "C" fn foo() -> usize { 5 }
 
 fn main() {
     let a: [u8; foo()];
-    //~^ ERROR call to unsafe function is unsafe and requires unsafe function or block
+    //~^ ERROR call to unsafe function `foo` is unsafe and requires unsafe function or block
     foo();
-    //[mir]~^ ERROR call to unsafe function is unsafe and requires unsafe function or block
+    //[mir]~^ ERROR call to unsafe function `foo` is unsafe and requires unsafe function or block
 }

--- a/src/test/ui/consts/const-extern-fn/const-extern-fn-requires-unsafe.thir.stderr
+++ b/src/test/ui/consts/const-extern-fn/const-extern-fn-requires-unsafe.thir.stderr
@@ -2,7 +2,7 @@ error[E0133]: call to unsafe function `foo` is unsafe and requires unsafe functi
   --> $DIR/const-extern-fn-requires-unsafe.rs:9:17
    |
 LL |     let a: [u8; foo()];
-   |                 ^^^^^ call to unsafe function `foo`
+   |                 ^^^^^ call to unsafe function
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 

--- a/src/test/ui/consts/const-extern-fn/const-extern-fn-requires-unsafe.thir.stderr
+++ b/src/test/ui/consts/const-extern-fn/const-extern-fn-requires-unsafe.thir.stderr
@@ -1,8 +1,8 @@
-error[E0133]: call to unsafe function is unsafe and requires unsafe function or block
+error[E0133]: call to unsafe function `foo` is unsafe and requires unsafe function or block
   --> $DIR/const-extern-fn-requires-unsafe.rs:9:17
    |
 LL |     let a: [u8; foo()];
-   |                 ^^^^^ call to unsafe function
+   |                 ^^^^^ call to unsafe function `foo`
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 

--- a/src/test/ui/error-codes/E0133.mir.stderr
+++ b/src/test/ui/error-codes/E0133.mir.stderr
@@ -1,8 +1,8 @@
-error[E0133]: call to unsafe function is unsafe and requires unsafe function or block
+error[E0133]: call to unsafe function `f` is unsafe and requires unsafe function or block
   --> $DIR/E0133.rs:7:5
    |
 LL |     f();
-   |     ^^^ call to unsafe function
+   |     ^^^ call to unsafe function `f`
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 

--- a/src/test/ui/error-codes/E0133.mir.stderr
+++ b/src/test/ui/error-codes/E0133.mir.stderr
@@ -2,7 +2,7 @@ error[E0133]: call to unsafe function `f` is unsafe and requires unsafe function
   --> $DIR/E0133.rs:7:5
    |
 LL |     f();
-   |     ^^^ call to unsafe function `f`
+   |     ^^^ call to unsafe function
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 

--- a/src/test/ui/error-codes/E0133.thir.stderr
+++ b/src/test/ui/error-codes/E0133.thir.stderr
@@ -1,8 +1,8 @@
-error[E0133]: call to unsafe function is unsafe and requires unsafe function or block
+error[E0133]: call to unsafe function `f` is unsafe and requires unsafe function or block
   --> $DIR/E0133.rs:7:5
    |
 LL |     f();
-   |     ^^^ call to unsafe function
+   |     ^^^ call to unsafe function `f`
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 

--- a/src/test/ui/error-codes/E0133.thir.stderr
+++ b/src/test/ui/error-codes/E0133.thir.stderr
@@ -2,7 +2,7 @@ error[E0133]: call to unsafe function `f` is unsafe and requires unsafe function
   --> $DIR/E0133.rs:7:5
    |
 LL |     f();
-   |     ^^^ call to unsafe function `f`
+   |     ^^^ call to unsafe function
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 

--- a/src/test/ui/foreign-unsafe-fn-called.mir.stderr
+++ b/src/test/ui/foreign-unsafe-fn-called.mir.stderr
@@ -1,8 +1,8 @@
-error[E0133]: call to unsafe function is unsafe and requires unsafe function or block
+error[E0133]: call to unsafe function `test::free` is unsafe and requires unsafe function or block
   --> $DIR/foreign-unsafe-fn-called.rs:11:5
    |
 LL |     test::free();
-   |     ^^^^^^^^^^^^ call to unsafe function
+   |     ^^^^^^^^^^^^ call to unsafe function `test::free`
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 

--- a/src/test/ui/foreign-unsafe-fn-called.mir.stderr
+++ b/src/test/ui/foreign-unsafe-fn-called.mir.stderr
@@ -2,7 +2,7 @@ error[E0133]: call to unsafe function `test::free` is unsafe and requires unsafe
   --> $DIR/foreign-unsafe-fn-called.rs:11:5
    |
 LL |     test::free();
-   |     ^^^^^^^^^^^^ call to unsafe function `test::free`
+   |     ^^^^^^^^^^^^ call to unsafe function
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 

--- a/src/test/ui/foreign-unsafe-fn-called.rs
+++ b/src/test/ui/foreign-unsafe-fn-called.rs
@@ -9,5 +9,5 @@ mod test {
 
 fn main() {
     test::free();
-    //~^ ERROR call to unsafe function is unsafe
+    //~^ ERROR call to unsafe function `test::free` is unsafe
 }

--- a/src/test/ui/foreign-unsafe-fn-called.thir.stderr
+++ b/src/test/ui/foreign-unsafe-fn-called.thir.stderr
@@ -1,8 +1,8 @@
-error[E0133]: call to unsafe function is unsafe and requires unsafe function or block
+error[E0133]: call to unsafe function `test::free` is unsafe and requires unsafe function or block
   --> $DIR/foreign-unsafe-fn-called.rs:11:5
    |
 LL |     test::free();
-   |     ^^^^^^^^^^^^ call to unsafe function
+   |     ^^^^^^^^^^^^ call to unsafe function `test::free`
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 

--- a/src/test/ui/foreign-unsafe-fn-called.thir.stderr
+++ b/src/test/ui/foreign-unsafe-fn-called.thir.stderr
@@ -2,7 +2,7 @@ error[E0133]: call to unsafe function `test::free` is unsafe and requires unsafe
   --> $DIR/foreign-unsafe-fn-called.rs:11:5
    |
 LL |     test::free();
-   |     ^^^^^^^^^^^^ call to unsafe function `test::free`
+   |     ^^^^^^^^^^^^ call to unsafe function
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 

--- a/src/test/ui/intrinsics/unchecked_math_unsafe.mir.stderr
+++ b/src/test/ui/intrinsics/unchecked_math_unsafe.mir.stderr
@@ -1,24 +1,24 @@
-error[E0133]: call to unsafe function is unsafe and requires unsafe function or block
+error[E0133]: call to unsafe function `std::intrinsics::unchecked_add` is unsafe and requires unsafe function or block
   --> $DIR/unchecked_math_unsafe.rs:8:15
    |
 LL |     let add = std::intrinsics::unchecked_add(x, y);
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function `std::intrinsics::unchecked_add`
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 
-error[E0133]: call to unsafe function is unsafe and requires unsafe function or block
+error[E0133]: call to unsafe function `std::intrinsics::unchecked_sub` is unsafe and requires unsafe function or block
   --> $DIR/unchecked_math_unsafe.rs:9:15
    |
 LL |     let sub = std::intrinsics::unchecked_sub(x, y);
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function `std::intrinsics::unchecked_sub`
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 
-error[E0133]: call to unsafe function is unsafe and requires unsafe function or block
+error[E0133]: call to unsafe function `std::intrinsics::unchecked_mul` is unsafe and requires unsafe function or block
   --> $DIR/unchecked_math_unsafe.rs:10:15
    |
 LL |     let mul = std::intrinsics::unchecked_mul(x, y);
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function `std::intrinsics::unchecked_mul`
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 

--- a/src/test/ui/intrinsics/unchecked_math_unsafe.mir.stderr
+++ b/src/test/ui/intrinsics/unchecked_math_unsafe.mir.stderr
@@ -2,7 +2,7 @@ error[E0133]: call to unsafe function `std::intrinsics::unchecked_add` is unsafe
   --> $DIR/unchecked_math_unsafe.rs:8:15
    |
 LL |     let add = std::intrinsics::unchecked_add(x, y);
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function `std::intrinsics::unchecked_add`
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 
@@ -10,7 +10,7 @@ error[E0133]: call to unsafe function `std::intrinsics::unchecked_sub` is unsafe
   --> $DIR/unchecked_math_unsafe.rs:9:15
    |
 LL |     let sub = std::intrinsics::unchecked_sub(x, y);
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function `std::intrinsics::unchecked_sub`
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 
@@ -18,7 +18,7 @@ error[E0133]: call to unsafe function `std::intrinsics::unchecked_mul` is unsafe
   --> $DIR/unchecked_math_unsafe.rs:10:15
    |
 LL |     let mul = std::intrinsics::unchecked_mul(x, y);
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function `std::intrinsics::unchecked_mul`
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 

--- a/src/test/ui/intrinsics/unchecked_math_unsafe.thir.stderr
+++ b/src/test/ui/intrinsics/unchecked_math_unsafe.thir.stderr
@@ -2,7 +2,7 @@ error[E0133]: call to unsafe function `unchecked_add` is unsafe and requires uns
   --> $DIR/unchecked_math_unsafe.rs:8:15
    |
 LL |     let add = std::intrinsics::unchecked_add(x, y);
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function `unchecked_add`
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 
@@ -10,7 +10,7 @@ error[E0133]: call to unsafe function `unchecked_sub` is unsafe and requires uns
   --> $DIR/unchecked_math_unsafe.rs:9:15
    |
 LL |     let sub = std::intrinsics::unchecked_sub(x, y);
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function `unchecked_sub`
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 
@@ -18,7 +18,7 @@ error[E0133]: call to unsafe function `unchecked_mul` is unsafe and requires uns
   --> $DIR/unchecked_math_unsafe.rs:10:15
    |
 LL |     let mul = std::intrinsics::unchecked_mul(x, y);
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function `unchecked_mul`
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 

--- a/src/test/ui/intrinsics/unchecked_math_unsafe.thir.stderr
+++ b/src/test/ui/intrinsics/unchecked_math_unsafe.thir.stderr
@@ -1,24 +1,24 @@
-error[E0133]: call to unsafe function is unsafe and requires unsafe function or block
+error[E0133]: call to unsafe function `unchecked_add` is unsafe and requires unsafe function or block
   --> $DIR/unchecked_math_unsafe.rs:8:15
    |
 LL |     let add = std::intrinsics::unchecked_add(x, y);
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function `unchecked_add`
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 
-error[E0133]: call to unsafe function is unsafe and requires unsafe function or block
+error[E0133]: call to unsafe function `unchecked_sub` is unsafe and requires unsafe function or block
   --> $DIR/unchecked_math_unsafe.rs:9:15
    |
 LL |     let sub = std::intrinsics::unchecked_sub(x, y);
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function `unchecked_sub`
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 
-error[E0133]: call to unsafe function is unsafe and requires unsafe function or block
+error[E0133]: call to unsafe function `unchecked_mul` is unsafe and requires unsafe function or block
   --> $DIR/unchecked_math_unsafe.rs:10:15
    |
 LL |     let mul = std::intrinsics::unchecked_mul(x, y);
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function `unchecked_mul`
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 

--- a/src/test/ui/issues/issue-28776.mir.stderr
+++ b/src/test/ui/issues/issue-28776.mir.stderr
@@ -2,7 +2,7 @@ error[E0133]: call to unsafe function `std::ptr::write` is unsafe and requires u
   --> $DIR/issue-28776.rs:7:5
    |
 LL |     (&ptr::write)(1 as *mut _, 42);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function `std::ptr::write`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 

--- a/src/test/ui/issues/issue-28776.mir.stderr
+++ b/src/test/ui/issues/issue-28776.mir.stderr
@@ -1,8 +1,8 @@
-error[E0133]: call to unsafe function is unsafe and requires unsafe function or block
+error[E0133]: call to unsafe function `std::ptr::write` is unsafe and requires unsafe function or block
   --> $DIR/issue-28776.rs:7:5
    |
 LL |     (&ptr::write)(1 as *mut _, 42);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function `std::ptr::write`
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 

--- a/src/test/ui/issues/issue-28776.thir.stderr
+++ b/src/test/ui/issues/issue-28776.thir.stderr
@@ -2,7 +2,7 @@ error[E0133]: call to unsafe function `std::ptr::write` is unsafe and requires u
   --> $DIR/issue-28776.rs:7:5
    |
 LL |     (&ptr::write)(1 as *mut _, 42);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function `std::ptr::write`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 

--- a/src/test/ui/issues/issue-28776.thir.stderr
+++ b/src/test/ui/issues/issue-28776.thir.stderr
@@ -1,8 +1,8 @@
-error[E0133]: call to unsafe function is unsafe and requires unsafe function or block
+error[E0133]: call to unsafe function `std::ptr::write` is unsafe and requires unsafe function or block
   --> $DIR/issue-28776.rs:7:5
    |
 LL |     (&ptr::write)(1 as *mut _, 42);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function `std::ptr::write`
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 

--- a/src/test/ui/issues/issue-3080.mir.stderr
+++ b/src/test/ui/issues/issue-3080.mir.stderr
@@ -2,7 +2,7 @@ error[E0133]: call to unsafe function `X::with` is unsafe and requires unsafe fu
   --> $DIR/issue-3080.rs:10:5
    |
 LL |     X(()).with();
-   |     ^^^^^^^^^^^^ call to unsafe function `X::with`
+   |     ^^^^^^^^^^^^ call to unsafe function
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 

--- a/src/test/ui/issues/issue-3080.mir.stderr
+++ b/src/test/ui/issues/issue-3080.mir.stderr
@@ -1,8 +1,8 @@
-error[E0133]: call to unsafe function is unsafe and requires unsafe function or block
+error[E0133]: call to unsafe function `X::with` is unsafe and requires unsafe function or block
   --> $DIR/issue-3080.rs:10:5
    |
 LL |     X(()).with();
-   |     ^^^^^^^^^^^^ call to unsafe function
+   |     ^^^^^^^^^^^^ call to unsafe function `X::with`
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 

--- a/src/test/ui/issues/issue-3080.thir.stderr
+++ b/src/test/ui/issues/issue-3080.thir.stderr
@@ -2,7 +2,7 @@ error[E0133]: call to unsafe function `X::with` is unsafe and requires unsafe fu
   --> $DIR/issue-3080.rs:10:5
    |
 LL |     X(()).with();
-   |     ^^^^^^^^^^^^ call to unsafe function `X::with`
+   |     ^^^^^^^^^^^^ call to unsafe function
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 

--- a/src/test/ui/issues/issue-3080.thir.stderr
+++ b/src/test/ui/issues/issue-3080.thir.stderr
@@ -1,8 +1,8 @@
-error[E0133]: call to unsafe function is unsafe and requires unsafe function or block
+error[E0133]: call to unsafe function `X::with` is unsafe and requires unsafe function or block
   --> $DIR/issue-3080.rs:10:5
    |
 LL |     X(()).with();
-   |     ^^^^^^^^^^^^ call to unsafe function
+   |     ^^^^^^^^^^^^ call to unsafe function `X::with`
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 

--- a/src/test/ui/issues/issue-5844.mir.stderr
+++ b/src/test/ui/issues/issue-5844.mir.stderr
@@ -2,7 +2,7 @@ error[E0133]: call to unsafe function `issue_5844_aux::rand` is unsafe and requi
   --> $DIR/issue-5844.rs:8:5
    |
 LL |     issue_5844_aux::rand();
-   |     ^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function `issue_5844_aux::rand`
+   |     ^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 

--- a/src/test/ui/issues/issue-5844.mir.stderr
+++ b/src/test/ui/issues/issue-5844.mir.stderr
@@ -1,8 +1,8 @@
-error[E0133]: call to unsafe function is unsafe and requires unsafe function or block
+error[E0133]: call to unsafe function `issue_5844_aux::rand` is unsafe and requires unsafe function or block
   --> $DIR/issue-5844.rs:8:5
    |
 LL |     issue_5844_aux::rand();
-   |     ^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function
+   |     ^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function `issue_5844_aux::rand`
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 

--- a/src/test/ui/issues/issue-5844.thir.stderr
+++ b/src/test/ui/issues/issue-5844.thir.stderr
@@ -2,7 +2,7 @@ error[E0133]: call to unsafe function `rand` is unsafe and requires unsafe funct
   --> $DIR/issue-5844.rs:8:5
    |
 LL |     issue_5844_aux::rand();
-   |     ^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function `rand`
+   |     ^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 

--- a/src/test/ui/issues/issue-5844.thir.stderr
+++ b/src/test/ui/issues/issue-5844.thir.stderr
@@ -1,8 +1,8 @@
-error[E0133]: call to unsafe function is unsafe and requires unsafe function or block
+error[E0133]: call to unsafe function `rand` is unsafe and requires unsafe function or block
   --> $DIR/issue-5844.rs:8:5
    |
 LL |     issue_5844_aux::rand();
-   |     ^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function
+   |     ^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function `rand`
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 

--- a/src/test/ui/rfcs/rfc-2396-target_feature-11/safe-calls.mir.stderr
+++ b/src/test/ui/rfcs/rfc-2396-target_feature-11/safe-calls.mir.stderr
@@ -1,80 +1,80 @@
-error[E0133]: call to function with `#[target_feature]` is unsafe and requires unsafe function or block
+error[E0133]: call to function `sse2` with `#[target_feature]` is unsafe and requires unsafe function or block
   --> $DIR/safe-calls.rs:23:5
    |
 LL |     sse2();
-   |     ^^^^^^ call to function with `#[target_feature]`
+   |     ^^^^^^ call to function `sse2` with `#[target_feature]`
    |
    = note: can only be called if the required target features are available
 
-error[E0133]: call to function with `#[target_feature]` is unsafe and requires unsafe function or block
+error[E0133]: call to function `avx_bmi2` with `#[target_feature]` is unsafe and requires unsafe function or block
   --> $DIR/safe-calls.rs:24:5
    |
 LL |     avx_bmi2();
-   |     ^^^^^^^^^^ call to function with `#[target_feature]`
+   |     ^^^^^^^^^^ call to function `avx_bmi2` with `#[target_feature]`
    |
    = note: can only be called if the required target features are available
 
-error[E0133]: call to function with `#[target_feature]` is unsafe and requires unsafe function or block
+error[E0133]: call to function `Quux::avx_bmi2` with `#[target_feature]` is unsafe and requires unsafe function or block
   --> $DIR/safe-calls.rs:25:5
    |
 LL |     Quux.avx_bmi2();
-   |     ^^^^^^^^^^^^^^^ call to function with `#[target_feature]`
+   |     ^^^^^^^^^^^^^^^ call to function `Quux::avx_bmi2` with `#[target_feature]`
    |
    = note: can only be called if the required target features are available
 
-error[E0133]: call to function with `#[target_feature]` is unsafe and requires unsafe function or block
+error[E0133]: call to function `avx_bmi2` with `#[target_feature]` is unsafe and requires unsafe function or block
   --> $DIR/safe-calls.rs:30:5
    |
 LL |     avx_bmi2();
-   |     ^^^^^^^^^^ call to function with `#[target_feature]`
+   |     ^^^^^^^^^^ call to function `avx_bmi2` with `#[target_feature]`
    |
    = note: can only be called if the required target features are available
 
-error[E0133]: call to function with `#[target_feature]` is unsafe and requires unsafe function or block
+error[E0133]: call to function `Quux::avx_bmi2` with `#[target_feature]` is unsafe and requires unsafe function or block
   --> $DIR/safe-calls.rs:31:5
    |
 LL |     Quux.avx_bmi2();
-   |     ^^^^^^^^^^^^^^^ call to function with `#[target_feature]`
+   |     ^^^^^^^^^^^^^^^ call to function `Quux::avx_bmi2` with `#[target_feature]`
    |
    = note: can only be called if the required target features are available
 
-error[E0133]: call to function with `#[target_feature]` is unsafe and requires unsafe function or block
+error[E0133]: call to function `sse2` with `#[target_feature]` is unsafe and requires unsafe function or block
   --> $DIR/safe-calls.rs:36:5
    |
 LL |     sse2();
-   |     ^^^^^^ call to function with `#[target_feature]`
+   |     ^^^^^^ call to function `sse2` with `#[target_feature]`
    |
    = note: can only be called if the required target features are available
 
-error[E0133]: call to function with `#[target_feature]` is unsafe and requires unsafe function or block
+error[E0133]: call to function `avx_bmi2` with `#[target_feature]` is unsafe and requires unsafe function or block
   --> $DIR/safe-calls.rs:37:5
    |
 LL |     avx_bmi2();
-   |     ^^^^^^^^^^ call to function with `#[target_feature]`
+   |     ^^^^^^^^^^ call to function `avx_bmi2` with `#[target_feature]`
    |
    = note: can only be called if the required target features are available
 
-error[E0133]: call to function with `#[target_feature]` is unsafe and requires unsafe function or block
+error[E0133]: call to function `Quux::avx_bmi2` with `#[target_feature]` is unsafe and requires unsafe function or block
   --> $DIR/safe-calls.rs:38:5
    |
 LL |     Quux.avx_bmi2();
-   |     ^^^^^^^^^^^^^^^ call to function with `#[target_feature]`
+   |     ^^^^^^^^^^^^^^^ call to function `Quux::avx_bmi2` with `#[target_feature]`
    |
    = note: can only be called if the required target features are available
 
-error[E0133]: call to function with `#[target_feature]` is unsafe and requires unsafe function or block
+error[E0133]: call to function `sse2` with `#[target_feature]` is unsafe and requires unsafe function or block
   --> $DIR/safe-calls.rs:44:5
    |
 LL |     sse2();
-   |     ^^^^^^ call to function with `#[target_feature]`
+   |     ^^^^^^ call to function `sse2` with `#[target_feature]`
    |
    = note: can only be called if the required target features are available
 
-error[E0133]: call to function with `#[target_feature]` is unsafe and requires unsafe function or block
+error[E0133]: call to function `sse2` with `#[target_feature]` is unsafe and requires unsafe function or block
   --> $DIR/safe-calls.rs:47:18
    |
 LL | const name: () = sse2();
-   |                  ^^^^^^ call to function with `#[target_feature]`
+   |                  ^^^^^^ call to function `sse2` with `#[target_feature]`
    |
    = note: can only be called if the required target features are available
 

--- a/src/test/ui/rfcs/rfc-2396-target_feature-11/safe-calls.mir.stderr
+++ b/src/test/ui/rfcs/rfc-2396-target_feature-11/safe-calls.mir.stderr
@@ -2,7 +2,7 @@ error[E0133]: call to function `sse2` with `#[target_feature]` is unsafe and req
   --> $DIR/safe-calls.rs:23:5
    |
 LL |     sse2();
-   |     ^^^^^^ call to function `sse2` with `#[target_feature]`
+   |     ^^^^^^ call to function with `#[target_feature]`
    |
    = note: can only be called if the required target features are available
 
@@ -10,7 +10,7 @@ error[E0133]: call to function `avx_bmi2` with `#[target_feature]` is unsafe and
   --> $DIR/safe-calls.rs:24:5
    |
 LL |     avx_bmi2();
-   |     ^^^^^^^^^^ call to function `avx_bmi2` with `#[target_feature]`
+   |     ^^^^^^^^^^ call to function with `#[target_feature]`
    |
    = note: can only be called if the required target features are available
 
@@ -18,7 +18,7 @@ error[E0133]: call to function `Quux::avx_bmi2` with `#[target_feature]` is unsa
   --> $DIR/safe-calls.rs:25:5
    |
 LL |     Quux.avx_bmi2();
-   |     ^^^^^^^^^^^^^^^ call to function `Quux::avx_bmi2` with `#[target_feature]`
+   |     ^^^^^^^^^^^^^^^ call to function with `#[target_feature]`
    |
    = note: can only be called if the required target features are available
 
@@ -26,7 +26,7 @@ error[E0133]: call to function `avx_bmi2` with `#[target_feature]` is unsafe and
   --> $DIR/safe-calls.rs:30:5
    |
 LL |     avx_bmi2();
-   |     ^^^^^^^^^^ call to function `avx_bmi2` with `#[target_feature]`
+   |     ^^^^^^^^^^ call to function with `#[target_feature]`
    |
    = note: can only be called if the required target features are available
 
@@ -34,7 +34,7 @@ error[E0133]: call to function `Quux::avx_bmi2` with `#[target_feature]` is unsa
   --> $DIR/safe-calls.rs:31:5
    |
 LL |     Quux.avx_bmi2();
-   |     ^^^^^^^^^^^^^^^ call to function `Quux::avx_bmi2` with `#[target_feature]`
+   |     ^^^^^^^^^^^^^^^ call to function with `#[target_feature]`
    |
    = note: can only be called if the required target features are available
 
@@ -42,7 +42,7 @@ error[E0133]: call to function `sse2` with `#[target_feature]` is unsafe and req
   --> $DIR/safe-calls.rs:36:5
    |
 LL |     sse2();
-   |     ^^^^^^ call to function `sse2` with `#[target_feature]`
+   |     ^^^^^^ call to function with `#[target_feature]`
    |
    = note: can only be called if the required target features are available
 
@@ -50,7 +50,7 @@ error[E0133]: call to function `avx_bmi2` with `#[target_feature]` is unsafe and
   --> $DIR/safe-calls.rs:37:5
    |
 LL |     avx_bmi2();
-   |     ^^^^^^^^^^ call to function `avx_bmi2` with `#[target_feature]`
+   |     ^^^^^^^^^^ call to function with `#[target_feature]`
    |
    = note: can only be called if the required target features are available
 
@@ -58,7 +58,7 @@ error[E0133]: call to function `Quux::avx_bmi2` with `#[target_feature]` is unsa
   --> $DIR/safe-calls.rs:38:5
    |
 LL |     Quux.avx_bmi2();
-   |     ^^^^^^^^^^^^^^^ call to function `Quux::avx_bmi2` with `#[target_feature]`
+   |     ^^^^^^^^^^^^^^^ call to function with `#[target_feature]`
    |
    = note: can only be called if the required target features are available
 
@@ -66,7 +66,7 @@ error[E0133]: call to function `sse2` with `#[target_feature]` is unsafe and req
   --> $DIR/safe-calls.rs:44:5
    |
 LL |     sse2();
-   |     ^^^^^^ call to function `sse2` with `#[target_feature]`
+   |     ^^^^^^ call to function with `#[target_feature]`
    |
    = note: can only be called if the required target features are available
 
@@ -74,7 +74,7 @@ error[E0133]: call to function `sse2` with `#[target_feature]` is unsafe and req
   --> $DIR/safe-calls.rs:47:18
    |
 LL | const name: () = sse2();
-   |                  ^^^^^^ call to function `sse2` with `#[target_feature]`
+   |                  ^^^^^^ call to function with `#[target_feature]`
    |
    = note: can only be called if the required target features are available
 

--- a/src/test/ui/rfcs/rfc-2396-target_feature-11/safe-calls.rs
+++ b/src/test/ui/rfcs/rfc-2396-target_feature-11/safe-calls.rs
@@ -20,30 +20,30 @@ impl Quux {
 }
 
 fn foo() {
-    sse2();              //~ ERROR call to function with `#[target_feature]` is unsafe
-    avx_bmi2();          //~ ERROR call to function with `#[target_feature]` is unsafe
-    Quux.avx_bmi2();     //~ ERROR call to function with `#[target_feature]` is unsafe
+    sse2();              //~ ERROR call to function `sse2` with `#[target_feature]` is unsafe
+    avx_bmi2();          //~ ERROR call to function `avx_bmi2` with `#[target_feature]` is unsafe
+    Quux.avx_bmi2();     //~ ERROR call to function `Quux::avx_bmi2` with `#[target_feature]` is unsafe
 }
 
 #[target_feature(enable = "sse2")]
 fn bar() {
-    avx_bmi2();          //~ ERROR call to function with `#[target_feature]` is unsafe
-    Quux.avx_bmi2();     //~ ERROR call to function with `#[target_feature]` is unsafe
+    avx_bmi2();          //~ ERROR call to function `avx_bmi2` with `#[target_feature]` is unsafe
+    Quux.avx_bmi2();     //~ ERROR call to function `Quux::avx_bmi2` with `#[target_feature]` is unsafe
 }
 
 #[target_feature(enable = "avx")]
 fn baz() {
-    sse2();              //~ ERROR call to function with `#[target_feature]` is unsafe
-    avx_bmi2();          //~ ERROR call to function with `#[target_feature]` is unsafe
-    Quux.avx_bmi2();     //~ ERROR call to function with `#[target_feature]` is unsafe
+    sse2();              //~ ERROR call to function `sse2` with `#[target_feature]` is unsafe
+    avx_bmi2();          //~ ERROR call to function `avx_bmi2` with `#[target_feature]` is unsafe
+    Quux.avx_bmi2();     //~ ERROR call to function `Quux::avx_bmi2` with `#[target_feature]` is unsafe
 }
 
 #[target_feature(enable = "avx")]
 #[target_feature(enable = "bmi2")]
 fn qux() {
-    sse2();              //~ ERROR call to function with `#[target_feature]` is unsafe
+    sse2();              //~ ERROR call to function `sse2` with `#[target_feature]` is unsafe
 }
 
-const name: () = sse2(); //~ ERROR call to function with `#[target_feature]` is unsafe
+const name: () = sse2(); //~ ERROR call to function `sse2` with `#[target_feature]` is unsafe
 
 fn main() {}

--- a/src/test/ui/rfcs/rfc-2396-target_feature-11/safe-calls.thir.stderr
+++ b/src/test/ui/rfcs/rfc-2396-target_feature-11/safe-calls.thir.stderr
@@ -1,80 +1,80 @@
-error[E0133]: call to function with `#[target_feature]` is unsafe and requires unsafe function or block
+error[E0133]: call to function `sse2` with `#[target_feature]` is unsafe and requires unsafe function or block
   --> $DIR/safe-calls.rs:23:5
    |
 LL |     sse2();
-   |     ^^^^^^ call to function with `#[target_feature]`
+   |     ^^^^^^ call to function `sse2` with `#[target_feature]`
    |
    = note: can only be called if the required target features are available
 
-error[E0133]: call to function with `#[target_feature]` is unsafe and requires unsafe function or block
+error[E0133]: call to function `avx_bmi2` with `#[target_feature]` is unsafe and requires unsafe function or block
   --> $DIR/safe-calls.rs:24:5
    |
 LL |     avx_bmi2();
-   |     ^^^^^^^^^^ call to function with `#[target_feature]`
+   |     ^^^^^^^^^^ call to function `avx_bmi2` with `#[target_feature]`
    |
    = note: can only be called if the required target features are available
 
-error[E0133]: call to function with `#[target_feature]` is unsafe and requires unsafe function or block
+error[E0133]: call to function `Quux::avx_bmi2` with `#[target_feature]` is unsafe and requires unsafe function or block
   --> $DIR/safe-calls.rs:25:5
    |
 LL |     Quux.avx_bmi2();
-   |     ^^^^^^^^^^^^^^^ call to function with `#[target_feature]`
+   |     ^^^^^^^^^^^^^^^ call to function `Quux::avx_bmi2` with `#[target_feature]`
    |
    = note: can only be called if the required target features are available
 
-error[E0133]: call to function with `#[target_feature]` is unsafe and requires unsafe function or block
+error[E0133]: call to function `avx_bmi2` with `#[target_feature]` is unsafe and requires unsafe function or block
   --> $DIR/safe-calls.rs:30:5
    |
 LL |     avx_bmi2();
-   |     ^^^^^^^^^^ call to function with `#[target_feature]`
+   |     ^^^^^^^^^^ call to function `avx_bmi2` with `#[target_feature]`
    |
    = note: can only be called if the required target features are available
 
-error[E0133]: call to function with `#[target_feature]` is unsafe and requires unsafe function or block
+error[E0133]: call to function `Quux::avx_bmi2` with `#[target_feature]` is unsafe and requires unsafe function or block
   --> $DIR/safe-calls.rs:31:5
    |
 LL |     Quux.avx_bmi2();
-   |     ^^^^^^^^^^^^^^^ call to function with `#[target_feature]`
+   |     ^^^^^^^^^^^^^^^ call to function `Quux::avx_bmi2` with `#[target_feature]`
    |
    = note: can only be called if the required target features are available
 
-error[E0133]: call to function with `#[target_feature]` is unsafe and requires unsafe function or block
+error[E0133]: call to function `sse2` with `#[target_feature]` is unsafe and requires unsafe function or block
   --> $DIR/safe-calls.rs:36:5
    |
 LL |     sse2();
-   |     ^^^^^^ call to function with `#[target_feature]`
+   |     ^^^^^^ call to function `sse2` with `#[target_feature]`
    |
    = note: can only be called if the required target features are available
 
-error[E0133]: call to function with `#[target_feature]` is unsafe and requires unsafe function or block
+error[E0133]: call to function `avx_bmi2` with `#[target_feature]` is unsafe and requires unsafe function or block
   --> $DIR/safe-calls.rs:37:5
    |
 LL |     avx_bmi2();
-   |     ^^^^^^^^^^ call to function with `#[target_feature]`
+   |     ^^^^^^^^^^ call to function `avx_bmi2` with `#[target_feature]`
    |
    = note: can only be called if the required target features are available
 
-error[E0133]: call to function with `#[target_feature]` is unsafe and requires unsafe function or block
+error[E0133]: call to function `Quux::avx_bmi2` with `#[target_feature]` is unsafe and requires unsafe function or block
   --> $DIR/safe-calls.rs:38:5
    |
 LL |     Quux.avx_bmi2();
-   |     ^^^^^^^^^^^^^^^ call to function with `#[target_feature]`
+   |     ^^^^^^^^^^^^^^^ call to function `Quux::avx_bmi2` with `#[target_feature]`
    |
    = note: can only be called if the required target features are available
 
-error[E0133]: call to function with `#[target_feature]` is unsafe and requires unsafe function or block
+error[E0133]: call to function `sse2` with `#[target_feature]` is unsafe and requires unsafe function or block
   --> $DIR/safe-calls.rs:44:5
    |
 LL |     sse2();
-   |     ^^^^^^ call to function with `#[target_feature]`
+   |     ^^^^^^ call to function `sse2` with `#[target_feature]`
    |
    = note: can only be called if the required target features are available
 
-error[E0133]: call to function with `#[target_feature]` is unsafe and requires unsafe function or block
+error[E0133]: call to function `sse2` with `#[target_feature]` is unsafe and requires unsafe function or block
   --> $DIR/safe-calls.rs:47:18
    |
 LL | const name: () = sse2();
-   |                  ^^^^^^ call to function with `#[target_feature]`
+   |                  ^^^^^^ call to function `sse2` with `#[target_feature]`
    |
    = note: can only be called if the required target features are available
 

--- a/src/test/ui/rfcs/rfc-2396-target_feature-11/safe-calls.thir.stderr
+++ b/src/test/ui/rfcs/rfc-2396-target_feature-11/safe-calls.thir.stderr
@@ -2,7 +2,7 @@ error[E0133]: call to function `sse2` with `#[target_feature]` is unsafe and req
   --> $DIR/safe-calls.rs:23:5
    |
 LL |     sse2();
-   |     ^^^^^^ call to function `sse2` with `#[target_feature]`
+   |     ^^^^^^ call to function with `#[target_feature]`
    |
    = note: can only be called if the required target features are available
 
@@ -10,7 +10,7 @@ error[E0133]: call to function `avx_bmi2` with `#[target_feature]` is unsafe and
   --> $DIR/safe-calls.rs:24:5
    |
 LL |     avx_bmi2();
-   |     ^^^^^^^^^^ call to function `avx_bmi2` with `#[target_feature]`
+   |     ^^^^^^^^^^ call to function with `#[target_feature]`
    |
    = note: can only be called if the required target features are available
 
@@ -18,7 +18,7 @@ error[E0133]: call to function `Quux::avx_bmi2` with `#[target_feature]` is unsa
   --> $DIR/safe-calls.rs:25:5
    |
 LL |     Quux.avx_bmi2();
-   |     ^^^^^^^^^^^^^^^ call to function `Quux::avx_bmi2` with `#[target_feature]`
+   |     ^^^^^^^^^^^^^^^ call to function with `#[target_feature]`
    |
    = note: can only be called if the required target features are available
 
@@ -26,7 +26,7 @@ error[E0133]: call to function `avx_bmi2` with `#[target_feature]` is unsafe and
   --> $DIR/safe-calls.rs:30:5
    |
 LL |     avx_bmi2();
-   |     ^^^^^^^^^^ call to function `avx_bmi2` with `#[target_feature]`
+   |     ^^^^^^^^^^ call to function with `#[target_feature]`
    |
    = note: can only be called if the required target features are available
 
@@ -34,7 +34,7 @@ error[E0133]: call to function `Quux::avx_bmi2` with `#[target_feature]` is unsa
   --> $DIR/safe-calls.rs:31:5
    |
 LL |     Quux.avx_bmi2();
-   |     ^^^^^^^^^^^^^^^ call to function `Quux::avx_bmi2` with `#[target_feature]`
+   |     ^^^^^^^^^^^^^^^ call to function with `#[target_feature]`
    |
    = note: can only be called if the required target features are available
 
@@ -42,7 +42,7 @@ error[E0133]: call to function `sse2` with `#[target_feature]` is unsafe and req
   --> $DIR/safe-calls.rs:36:5
    |
 LL |     sse2();
-   |     ^^^^^^ call to function `sse2` with `#[target_feature]`
+   |     ^^^^^^ call to function with `#[target_feature]`
    |
    = note: can only be called if the required target features are available
 
@@ -50,7 +50,7 @@ error[E0133]: call to function `avx_bmi2` with `#[target_feature]` is unsafe and
   --> $DIR/safe-calls.rs:37:5
    |
 LL |     avx_bmi2();
-   |     ^^^^^^^^^^ call to function `avx_bmi2` with `#[target_feature]`
+   |     ^^^^^^^^^^ call to function with `#[target_feature]`
    |
    = note: can only be called if the required target features are available
 
@@ -58,7 +58,7 @@ error[E0133]: call to function `Quux::avx_bmi2` with `#[target_feature]` is unsa
   --> $DIR/safe-calls.rs:38:5
    |
 LL |     Quux.avx_bmi2();
-   |     ^^^^^^^^^^^^^^^ call to function `Quux::avx_bmi2` with `#[target_feature]`
+   |     ^^^^^^^^^^^^^^^ call to function with `#[target_feature]`
    |
    = note: can only be called if the required target features are available
 
@@ -66,7 +66,7 @@ error[E0133]: call to function `sse2` with `#[target_feature]` is unsafe and req
   --> $DIR/safe-calls.rs:44:5
    |
 LL |     sse2();
-   |     ^^^^^^ call to function `sse2` with `#[target_feature]`
+   |     ^^^^^^ call to function with `#[target_feature]`
    |
    = note: can only be called if the required target features are available
 
@@ -74,7 +74,7 @@ error[E0133]: call to function `sse2` with `#[target_feature]` is unsafe and req
   --> $DIR/safe-calls.rs:47:18
    |
 LL | const name: () = sse2();
-   |                  ^^^^^^ call to function `sse2` with `#[target_feature]`
+   |                  ^^^^^^ call to function with `#[target_feature]`
    |
    = note: can only be called if the required target features are available
 

--- a/src/test/ui/threads-sendsync/issue-43733.mir.stderr
+++ b/src/test/ui/threads-sendsync/issue-43733.mir.stderr
@@ -1,16 +1,16 @@
-error[E0133]: call to unsafe function is unsafe and requires unsafe function or block
+error[E0133]: call to unsafe function `std::thread::__FastLocalKeyInner::<T>::get` is unsafe and requires unsafe function or block
   --> $DIR/issue-43733.rs:19:5
    |
 LL |     __KEY.get(Default::default)
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function `std::thread::__FastLocalKeyInner::<T>::get`
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 
-error[E0133]: call to unsafe function is unsafe and requires unsafe function or block
-  --> $DIR/issue-43733.rs:22:42
+error[E0133]: call to unsafe function `std::thread::LocalKey::<T>::new` is unsafe and requires unsafe function or block
+  --> $DIR/issue-43733.rs:24:42
    |
 LL | static FOO: std::thread::LocalKey<Foo> = std::thread::LocalKey::new(__getit);
-   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function `std::thread::LocalKey::<T>::new`
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 

--- a/src/test/ui/threads-sendsync/issue-43733.mir.stderr
+++ b/src/test/ui/threads-sendsync/issue-43733.mir.stderr
@@ -2,7 +2,7 @@ error[E0133]: call to unsafe function `std::thread::__FastLocalKeyInner::<T>::ge
   --> $DIR/issue-43733.rs:19:5
    |
 LL |     __KEY.get(Default::default)
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function `std::thread::__FastLocalKeyInner::<T>::get`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 
@@ -10,7 +10,7 @@ error[E0133]: call to unsafe function `std::thread::LocalKey::<T>::new` is unsaf
   --> $DIR/issue-43733.rs:24:42
    |
 LL | static FOO: std::thread::LocalKey<Foo> = std::thread::LocalKey::new(__getit);
-   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function `std::thread::LocalKey::<T>::new`
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 

--- a/src/test/ui/threads-sendsync/issue-43733.mir.stderr
+++ b/src/test/ui/threads-sendsync/issue-43733.mir.stderr
@@ -1,5 +1,5 @@
-error[E0133]: call to unsafe function `std::thread::__FastLocalKeyInner::<T>::get` is unsafe and requires unsafe function or block
-  --> $DIR/issue-43733.rs:19:5
+error[E0133]: call to unsafe function `std::thread::$LOCALKEYINNER::<T>::get` is unsafe and requires unsafe function or block
+  --> $DIR/issue-43733.rs:21:5
    |
 LL |     __KEY.get(Default::default)
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function
@@ -7,7 +7,7 @@ LL |     __KEY.get(Default::default)
    = note: consult the function's documentation for information on how to avoid undefined behavior
 
 error[E0133]: call to unsafe function `std::thread::LocalKey::<T>::new` is unsafe and requires unsafe function or block
-  --> $DIR/issue-43733.rs:24:42
+  --> $DIR/issue-43733.rs:26:42
    |
 LL | static FOO: std::thread::LocalKey<Foo> = std::thread::LocalKey::new(__getit);
    |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function

--- a/src/test/ui/threads-sendsync/issue-43733.rs
+++ b/src/test/ui/threads-sendsync/issue-43733.rs
@@ -16,11 +16,14 @@ static __KEY: std::thread::__FastLocalKeyInner<Foo> = std::thread::__FastLocalKe
 static __KEY: std::thread::__OsLocalKeyInner<Foo> = std::thread::__OsLocalKeyInner::new();
 
 fn __getit(_: Option<&mut Option<RefCell<String>>>) -> std::option::Option<&'static Foo> {
-    __KEY.get(Default::default) //~ ERROR call to unsafe function is unsafe
+    __KEY.get(Default::default)
+    //[mir]~^ ERROR call to unsafe function `std::thread::__FastLocalKeyInner::<T>::get` is unsafe
+    //[thir]~^^ ERROR call to unsafe function `__FastLocalKeyInner::<T>::get` is unsafe
 }
 
 static FOO: std::thread::LocalKey<Foo> = std::thread::LocalKey::new(__getit);
-//~^ ERROR call to unsafe function is unsafe
+//[mir]~^ ERROR call to unsafe function `std::thread::LocalKey::<T>::new` is unsafe
+//[thir]~^^ ERROR call to unsafe function `LocalKey::<T>::new` is unsafe
 
 fn main() {
     FOO.with(|foo| println!("{}", foo.borrow()));

--- a/src/test/ui/threads-sendsync/issue-43733.rs
+++ b/src/test/ui/threads-sendsync/issue-43733.rs
@@ -1,5 +1,7 @@
 // revisions: mir thir
 // [thir]compile-flags: -Z thir-unsafeck
+// normalize-stderr-test: "__FastLocalKeyInner::<T>::get" -> "$$LOCALKEYINNER::<T>::get"
+// normalize-stderr-test: "__OsLocalKeyInner::<T>::get" -> "$$LOCALKEYINNER::<T>::get"
 
 #![feature(thread_local)]
 #![feature(cfg_target_thread_local, thread_local_internals)]
@@ -17,8 +19,8 @@ static __KEY: std::thread::__OsLocalKeyInner<Foo> = std::thread::__OsLocalKeyInn
 
 fn __getit(_: Option<&mut Option<RefCell<String>>>) -> std::option::Option<&'static Foo> {
     __KEY.get(Default::default)
-    //[mir]~^ ERROR call to unsafe function `std::thread::__FastLocalKeyInner::<T>::get` is unsafe
-    //[thir]~^^ ERROR call to unsafe function `__FastLocalKeyInner::<T>::get` is unsafe
+    //[mir]~^ ERROR call to unsafe function `std::thread::
+    //[thir]~^^ ERROR call to unsafe function `__
 }
 
 static FOO: std::thread::LocalKey<Foo> = std::thread::LocalKey::new(__getit);

--- a/src/test/ui/threads-sendsync/issue-43733.thir.stderr
+++ b/src/test/ui/threads-sendsync/issue-43733.thir.stderr
@@ -1,5 +1,5 @@
-error[E0133]: call to unsafe function `__FastLocalKeyInner::<T>::get` is unsafe and requires unsafe function or block
-  --> $DIR/issue-43733.rs:19:5
+error[E0133]: call to unsafe function `$LOCALKEYINNER::<T>::get` is unsafe and requires unsafe function or block
+  --> $DIR/issue-43733.rs:21:5
    |
 LL |     __KEY.get(Default::default)
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function
@@ -7,7 +7,7 @@ LL |     __KEY.get(Default::default)
    = note: consult the function's documentation for information on how to avoid undefined behavior
 
 error[E0133]: call to unsafe function `LocalKey::<T>::new` is unsafe and requires unsafe function or block
-  --> $DIR/issue-43733.rs:24:42
+  --> $DIR/issue-43733.rs:26:42
    |
 LL | static FOO: std::thread::LocalKey<Foo> = std::thread::LocalKey::new(__getit);
    |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function

--- a/src/test/ui/threads-sendsync/issue-43733.thir.stderr
+++ b/src/test/ui/threads-sendsync/issue-43733.thir.stderr
@@ -1,16 +1,16 @@
-error[E0133]: call to unsafe function is unsafe and requires unsafe function or block
+error[E0133]: call to unsafe function `__FastLocalKeyInner::<T>::get` is unsafe and requires unsafe function or block
   --> $DIR/issue-43733.rs:19:5
    |
 LL |     __KEY.get(Default::default)
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function `__FastLocalKeyInner::<T>::get`
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 
-error[E0133]: call to unsafe function is unsafe and requires unsafe function or block
-  --> $DIR/issue-43733.rs:22:42
+error[E0133]: call to unsafe function `LocalKey::<T>::new` is unsafe and requires unsafe function or block
+  --> $DIR/issue-43733.rs:24:42
    |
 LL | static FOO: std::thread::LocalKey<Foo> = std::thread::LocalKey::new(__getit);
-   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function `LocalKey::<T>::new`
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 

--- a/src/test/ui/threads-sendsync/issue-43733.thir.stderr
+++ b/src/test/ui/threads-sendsync/issue-43733.thir.stderr
@@ -2,7 +2,7 @@ error[E0133]: call to unsafe function `__FastLocalKeyInner::<T>::get` is unsafe 
   --> $DIR/issue-43733.rs:19:5
    |
 LL |     __KEY.get(Default::default)
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function `__FastLocalKeyInner::<T>::get`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 
@@ -10,7 +10,7 @@ error[E0133]: call to unsafe function `LocalKey::<T>::new` is unsafe and require
   --> $DIR/issue-43733.rs:24:42
    |
 LL | static FOO: std::thread::LocalKey<Foo> = std::thread::LocalKey::new(__getit);
-   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function `LocalKey::<T>::new`
+   |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 

--- a/src/test/ui/threads-sendsync/tls-dtors-are-run-in-a-static-binary.rs
+++ b/src/test/ui/threads-sendsync/tls-dtors-are-run-in-a-static-binary.rs
@@ -1,7 +1,6 @@
 // run-pass
 // no-prefer-dynamic
 // ignore-emscripten no threads support
-
 static mut HIT: bool = false;
 
 struct Foo;

--- a/src/test/ui/unsafe/rfc-2585-unsafe_op_in_unsafe_fn.mir.stderr
+++ b/src/test/ui/unsafe/rfc-2585-unsafe_op_in_unsafe_fn.mir.stderr
@@ -117,7 +117,7 @@ error[E0133]: call to unsafe function `unsf` is unsafe and requires unsafe block
   --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:76:5
    |
 LL |     unsf();
-   |     ^^^^^^ call to unsafe function `unsf`
+   |     ^^^^^^ call to unsafe function
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 
@@ -125,7 +125,7 @@ error[E0133]: call to unsafe function `unsf` is unsafe and requires unsafe funct
   --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:80:9
    |
 LL |         unsf();
-   |         ^^^^^^ call to unsafe function `unsf`
+   |         ^^^^^^ call to unsafe function
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 

--- a/src/test/ui/unsafe/rfc-2585-unsafe_op_in_unsafe_fn.mir.stderr
+++ b/src/test/ui/unsafe/rfc-2585-unsafe_op_in_unsafe_fn.mir.stderr
@@ -1,8 +1,8 @@
-error: call to unsafe function is unsafe and requires unsafe block (error E0133)
+error: call to unsafe function `unsf` is unsafe and requires unsafe block (error E0133)
   --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:12:5
    |
 LL |     unsf();
-   |     ^^^^^^ call to unsafe function
+   |     ^^^^^^ call to unsafe function `unsf`
    |
 note: the lint level is defined here
   --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:4:9
@@ -39,11 +39,11 @@ note: the lint level is defined here
 LL | #![deny(unused_unsafe)]
    |         ^^^^^^^^^^^^^
 
-error: call to unsafe function is unsafe and requires unsafe block (error E0133)
+error: call to unsafe function `unsf` is unsafe and requires unsafe block (error E0133)
   --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:27:5
    |
 LL |     unsf();
-   |     ^^^^^^ call to unsafe function
+   |     ^^^^^^ call to unsafe function `unsf`
    |
 note: the lint level is defined here
   --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:25:8
@@ -113,19 +113,19 @@ note: the lint level is defined here
 LL |     #[allow(unsafe_op_in_unsafe_fn)]
    |             ^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0133]: call to unsafe function is unsafe and requires unsafe block
+error[E0133]: call to unsafe function `unsf` is unsafe and requires unsafe block
   --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:76:5
    |
 LL |     unsf();
-   |     ^^^^^^ call to unsafe function
+   |     ^^^^^^ call to unsafe function `unsf`
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 
-error[E0133]: call to unsafe function is unsafe and requires unsafe function or block
+error[E0133]: call to unsafe function `unsf` is unsafe and requires unsafe function or block
   --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:80:9
    |
 LL |         unsf();
-   |         ^^^^^^ call to unsafe function
+   |         ^^^^^^ call to unsafe function `unsf`
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 

--- a/src/test/ui/unsafe/rfc-2585-unsafe_op_in_unsafe_fn.rs
+++ b/src/test/ui/unsafe/rfc-2585-unsafe_op_in_unsafe_fn.rs
@@ -10,7 +10,7 @@ static mut VOID: () = ();
 
 unsafe fn deny_level() {
     unsf();
-    //~^ ERROR call to unsafe function is unsafe and requires unsafe block
+    //~^ ERROR call to unsafe function `unsf` is unsafe and requires unsafe block
     *PTR;
     //~^ ERROR dereference of raw pointer is unsafe and requires unsafe block
     VOID = ();
@@ -25,7 +25,7 @@ unsafe fn deny_level() {
 #[deny(warnings)]
 unsafe fn warning_level() {
     unsf();
-    //~^ ERROR call to unsafe function is unsafe and requires unsafe block
+    //~^ ERROR call to unsafe function `unsf` is unsafe and requires unsafe block
     *PTR;
     //~^ ERROR dereference of raw pointer is unsafe and requires unsafe block
     VOID = ();
@@ -74,10 +74,10 @@ unsafe fn nested_allow_level() {
 
 fn main() {
     unsf();
-    //~^ ERROR call to unsafe function is unsafe and requires unsafe block
+    //~^ ERROR call to unsafe function `unsf` is unsafe and requires unsafe block
     #[allow(unsafe_op_in_unsafe_fn)]
     {
         unsf();
-        //~^ ERROR call to unsafe function is unsafe and requires unsafe function or block
+        //~^ ERROR call to unsafe function `unsf` is unsafe and requires unsafe function or block
     }
 }

--- a/src/test/ui/unsafe/rfc-2585-unsafe_op_in_unsafe_fn.thir.stderr
+++ b/src/test/ui/unsafe/rfc-2585-unsafe_op_in_unsafe_fn.thir.stderr
@@ -2,7 +2,7 @@ error: call to unsafe function `unsf` is unsafe and requires unsafe block (error
   --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:12:5
    |
 LL |     unsf();
-   |     ^^^^^^ call to unsafe function `unsf`
+   |     ^^^^^^ call to unsafe function
    |
 note: the lint level is defined here
   --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:4:9
@@ -43,7 +43,7 @@ error: call to unsafe function `unsf` is unsafe and requires unsafe block (error
   --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:27:5
    |
 LL |     unsf();
-   |     ^^^^^^ call to unsafe function `unsf`
+   |     ^^^^^^ call to unsafe function
    |
 note: the lint level is defined here
   --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:25:8
@@ -105,7 +105,7 @@ error[E0133]: call to unsafe function `unsf` is unsafe and requires unsafe block
   --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:76:5
    |
 LL |     unsf();
-   |     ^^^^^^ call to unsafe function `unsf`
+   |     ^^^^^^ call to unsafe function
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 
@@ -113,7 +113,7 @@ error[E0133]: call to unsafe function `unsf` is unsafe and requires unsafe funct
   --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:80:9
    |
 LL |         unsf();
-   |         ^^^^^^ call to unsafe function `unsf`
+   |         ^^^^^^ call to unsafe function
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 

--- a/src/test/ui/unsafe/rfc-2585-unsafe_op_in_unsafe_fn.thir.stderr
+++ b/src/test/ui/unsafe/rfc-2585-unsafe_op_in_unsafe_fn.thir.stderr
@@ -1,8 +1,8 @@
-error: call to unsafe function is unsafe and requires unsafe block (error E0133)
+error: call to unsafe function `unsf` is unsafe and requires unsafe block (error E0133)
   --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:12:5
    |
 LL |     unsf();
-   |     ^^^^^^ call to unsafe function
+   |     ^^^^^^ call to unsafe function `unsf`
    |
 note: the lint level is defined here
   --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:4:9
@@ -39,11 +39,11 @@ note: the lint level is defined here
 LL | #![deny(unused_unsafe)]
    |         ^^^^^^^^^^^^^
 
-error: call to unsafe function is unsafe and requires unsafe block (error E0133)
+error: call to unsafe function `unsf` is unsafe and requires unsafe block (error E0133)
   --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:27:5
    |
 LL |     unsf();
-   |     ^^^^^^ call to unsafe function
+   |     ^^^^^^ call to unsafe function `unsf`
    |
 note: the lint level is defined here
   --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:25:8
@@ -101,19 +101,19 @@ LL | unsafe fn nested_allow_level() {
 LL |         unsafe { unsf() }
    |         ^^^^^^ unnecessary `unsafe` block
 
-error[E0133]: call to unsafe function is unsafe and requires unsafe block
+error[E0133]: call to unsafe function `unsf` is unsafe and requires unsafe block
   --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:76:5
    |
 LL |     unsf();
-   |     ^^^^^^ call to unsafe function
+   |     ^^^^^^ call to unsafe function `unsf`
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 
-error[E0133]: call to unsafe function is unsafe and requires unsafe function or block
+error[E0133]: call to unsafe function `unsf` is unsafe and requires unsafe function or block
   --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:80:9
    |
 LL |         unsf();
-   |         ^^^^^^ call to unsafe function
+   |         ^^^^^^ call to unsafe function `unsf`
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 

--- a/src/test/ui/unsafe/unsafe-const-fn.mir.stderr
+++ b/src/test/ui/unsafe/unsafe-const-fn.mir.stderr
@@ -1,8 +1,8 @@
-error[E0133]: call to unsafe function is unsafe and requires unsafe function or block
+error[E0133]: call to unsafe function `dummy` is unsafe and requires unsafe function or block
   --> $DIR/unsafe-const-fn.rs:10:18
    |
 LL | const VAL: u32 = dummy(0xFFFF);
-   |                  ^^^^^^^^^^^^^ call to unsafe function
+   |                  ^^^^^^^^^^^^^ call to unsafe function `dummy`
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 

--- a/src/test/ui/unsafe/unsafe-const-fn.mir.stderr
+++ b/src/test/ui/unsafe/unsafe-const-fn.mir.stderr
@@ -2,7 +2,7 @@ error[E0133]: call to unsafe function `dummy` is unsafe and requires unsafe func
   --> $DIR/unsafe-const-fn.rs:10:18
    |
 LL | const VAL: u32 = dummy(0xFFFF);
-   |                  ^^^^^^^^^^^^^ call to unsafe function `dummy`
+   |                  ^^^^^^^^^^^^^ call to unsafe function
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 

--- a/src/test/ui/unsafe/unsafe-const-fn.thir.stderr
+++ b/src/test/ui/unsafe/unsafe-const-fn.thir.stderr
@@ -1,8 +1,8 @@
-error[E0133]: call to unsafe function is unsafe and requires unsafe function or block
+error[E0133]: call to unsafe function `dummy` is unsafe and requires unsafe function or block
   --> $DIR/unsafe-const-fn.rs:10:18
    |
 LL | const VAL: u32 = dummy(0xFFFF);
-   |                  ^^^^^^^^^^^^^ call to unsafe function
+   |                  ^^^^^^^^^^^^^ call to unsafe function `dummy`
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 

--- a/src/test/ui/unsafe/unsafe-const-fn.thir.stderr
+++ b/src/test/ui/unsafe/unsafe-const-fn.thir.stderr
@@ -2,7 +2,7 @@ error[E0133]: call to unsafe function `dummy` is unsafe and requires unsafe func
   --> $DIR/unsafe-const-fn.rs:10:18
    |
 LL | const VAL: u32 = dummy(0xFFFF);
-   |                  ^^^^^^^^^^^^^ call to unsafe function `dummy`
+   |                  ^^^^^^^^^^^^^ call to unsafe function
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 

--- a/src/test/ui/unsafe/unsafe-fn-called-from-safe.mir.stderr
+++ b/src/test/ui/unsafe/unsafe-fn-called-from-safe.mir.stderr
@@ -2,7 +2,7 @@ error[E0133]: call to unsafe function `f` is unsafe and requires unsafe function
   --> $DIR/unsafe-fn-called-from-safe.rs:7:5
    |
 LL |     f();
-   |     ^^^ call to unsafe function `f`
+   |     ^^^ call to unsafe function
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 

--- a/src/test/ui/unsafe/unsafe-fn-called-from-safe.mir.stderr
+++ b/src/test/ui/unsafe/unsafe-fn-called-from-safe.mir.stderr
@@ -1,8 +1,8 @@
-error[E0133]: call to unsafe function is unsafe and requires unsafe function or block
+error[E0133]: call to unsafe function `f` is unsafe and requires unsafe function or block
   --> $DIR/unsafe-fn-called-from-safe.rs:7:5
    |
 LL |     f();
-   |     ^^^ call to unsafe function
+   |     ^^^ call to unsafe function `f`
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 

--- a/src/test/ui/unsafe/unsafe-fn-called-from-safe.rs
+++ b/src/test/ui/unsafe/unsafe-fn-called-from-safe.rs
@@ -4,5 +4,5 @@
 unsafe fn f() { return; }
 
 fn main() {
-    f(); //~ ERROR call to unsafe function is unsafe
+    f(); //~ ERROR call to unsafe function `f` is unsafe
 }

--- a/src/test/ui/unsafe/unsafe-fn-called-from-safe.thir.stderr
+++ b/src/test/ui/unsafe/unsafe-fn-called-from-safe.thir.stderr
@@ -2,7 +2,7 @@ error[E0133]: call to unsafe function `f` is unsafe and requires unsafe function
   --> $DIR/unsafe-fn-called-from-safe.rs:7:5
    |
 LL |     f();
-   |     ^^^ call to unsafe function `f`
+   |     ^^^ call to unsafe function
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 

--- a/src/test/ui/unsafe/unsafe-fn-called-from-safe.thir.stderr
+++ b/src/test/ui/unsafe/unsafe-fn-called-from-safe.thir.stderr
@@ -1,8 +1,8 @@
-error[E0133]: call to unsafe function is unsafe and requires unsafe function or block
+error[E0133]: call to unsafe function `f` is unsafe and requires unsafe function or block
   --> $DIR/unsafe-fn-called-from-safe.rs:7:5
    |
 LL |     f();
-   |     ^^^ call to unsafe function
+   |     ^^^ call to unsafe function `f`
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 

--- a/src/test/ui/unsafe/unsafe-fn-used-as-value.mir.stderr
+++ b/src/test/ui/unsafe/unsafe-fn-used-as-value.mir.stderr
@@ -1,8 +1,8 @@
-error[E0133]: call to unsafe function is unsafe and requires unsafe function or block
+error[E0133]: call to unsafe function `f` is unsafe and requires unsafe function or block
   --> $DIR/unsafe-fn-used-as-value.rs:8:5
    |
 LL |     x();
-   |     ^^^ call to unsafe function
+   |     ^^^ call to unsafe function `f`
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 

--- a/src/test/ui/unsafe/unsafe-fn-used-as-value.mir.stderr
+++ b/src/test/ui/unsafe/unsafe-fn-used-as-value.mir.stderr
@@ -2,7 +2,7 @@ error[E0133]: call to unsafe function `f` is unsafe and requires unsafe function
   --> $DIR/unsafe-fn-used-as-value.rs:8:5
    |
 LL |     x();
-   |     ^^^ call to unsafe function `f`
+   |     ^^^ call to unsafe function
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 

--- a/src/test/ui/unsafe/unsafe-fn-used-as-value.rs
+++ b/src/test/ui/unsafe/unsafe-fn-used-as-value.rs
@@ -5,5 +5,5 @@ unsafe fn f() { return; }
 
 fn main() {
     let x = f;
-    x();    //~ ERROR call to unsafe function is unsafe
+    x(); //~ ERROR call to unsafe function `f` is unsafe
 }

--- a/src/test/ui/unsafe/unsafe-fn-used-as-value.thir.stderr
+++ b/src/test/ui/unsafe/unsafe-fn-used-as-value.thir.stderr
@@ -1,8 +1,8 @@
-error[E0133]: call to unsafe function is unsafe and requires unsafe function or block
+error[E0133]: call to unsafe function `f` is unsafe and requires unsafe function or block
   --> $DIR/unsafe-fn-used-as-value.rs:8:5
    |
 LL |     x();
-   |     ^^^ call to unsafe function
+   |     ^^^ call to unsafe function `f`
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 

--- a/src/test/ui/unsafe/unsafe-fn-used-as-value.thir.stderr
+++ b/src/test/ui/unsafe/unsafe-fn-used-as-value.thir.stderr
@@ -2,7 +2,7 @@ error[E0133]: call to unsafe function `f` is unsafe and requires unsafe function
   --> $DIR/unsafe-fn-used-as-value.rs:8:5
    |
 LL |     x();
-   |     ^^^ call to unsafe function `f`
+   |     ^^^ call to unsafe function
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 


### PR DESCRIPTION
adds `DefId` to `UnsafetyViolationDetails`

this enables consumers to access the function definition that was reported to be unsafe and also changes the output for some E0133 diagnostics