### PR TITLE
Make `Cow` covariant w.r.t `ToOwned::Owned`

### DIFF
--- a/library/alloc/src/borrow.rs
+++ b/library/alloc/src/borrow.rs
@@ -178,7 +178,7 @@ where
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 #[cfg_attr(not(test), rustc_diagnostic_item = "Cow")]
-pub enum Cow<'a, B: ?Sized + 'a>
+pub enum Cow<'a, B: ?Sized + 'a, O = <B as ToOwned>::Owned>
 where
     B: ToOwned,
 {
@@ -188,7 +188,7 @@ where
 
     /// Owned data.
     #[stable(feature = "rust1", since = "1.0.0")]
-    Owned(#[stable(feature = "rust1", since = "1.0.0")] <B as ToOwned>::Owned),
+    Owned(#[stable(feature = "rust1", since = "1.0.0")] O),
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/library/alloc/tests/borrow.rs
+++ b/library/alloc/tests/borrow.rs
@@ -58,3 +58,14 @@ fn cow_const() {
     const IS_OWNED: bool = COW.is_owned();
     assert!(!IS_OWNED);
 }
+
+#[allow(dead_code)]
+fn assert_covariance() {
+    fn cow<'new>(c: Cow<'static, str>) -> Cow<'new, str> {
+        c
+    }
+
+    fn cow_cow<'new>(c: Cow<'static, Cow<'static, str>>) -> Cow<'new, Cow<'new, str>> {
+        c
+    }
+}


### PR DESCRIPTION
This PR makes `Cow` covariant w.r.t `ToOwned::Owned`, by using the trick from https://github.com/rust-lang/rust/issues/57440 (moving the associated type to parameter with a default):

```
// Before:
pub enum Cow<'a, B: ?Sized + 'a>
where B: ToOwned { ... }

// After:                        ........... new .........
pub enum Cow<'a, B: ?Sized + 'a, O = <B as ToOwned>::Owned>
where B: ToOwned { ... }
```

So, for example, this will now compile:
```rust
fn cow_cow<'new>(c: Cow<'static, Cow<'static, str>>) -> Cow<'new, Cow<'new, str>> { c }
```


I'm not really sure this is a good idea: it makes `Cow`'s definition more complex,
it's a terrible hack, and it's not really clear to me if bad things can happen if someone tries to "use" the new generic parameter, and it's possible someone is relying on the fact that `Cow` is invariant w.r.t `Owned`.

However, I ran into this years ago when working on a crate which tries to minimize copying,
and got super confused by scary lifetimes errors.
This is usually caused by something like `struct S1<'a> { c: Cow<'a, str> }; struct S2<'a> { c: Cow<'a, S1<'a>> }` ([Link to playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=e73cca532f6dd7c4d62257cfe874931c)).


(This was previously impossible because of https://github.com/rust-lang/rust/issues/79224)

PS
See https://github.com/rust-lang/rust/issues/21726#issuecomment-71949910 and https://github.com/rust-lang/rust/issues/59875#issuecomment-907433958 on why this is probably not true in the general case for associated types.