### PR TITLE
WIP: Document `From` implementations in std::sys::unix::process

### DIFF
--- a/library/std/src/sys/unix/process/process_common.rs
+++ b/library/std/src/sys/unix/process/process_common.rs
@@ -429,12 +429,20 @@ impl Stdio {
 }
 
 impl From<AnonPipe> for Stdio {
+    /// Converts a [`AnonPipe`] into a [`Stdio`].
+    ///
+    /// The conversion consumes the [`AnonPipe`].
+    ///
     fn from(pipe: AnonPipe) -> Stdio {
         Stdio::Fd(pipe.into_inner())
     }
 }
 
 impl From<File> for Stdio {
+    /// Converts a [`File`] into a [`Stdio`].
+    ///
+    /// The conversion consumes the [`File`].
+    ///
     fn from(file: File) -> Stdio {
         Stdio::Fd(file.into_inner())
     }


### PR DESCRIPTION
Document `From` implementations for Stdio, ExitCode

In connection with rust-lang#51430