### PR TITLE
Reduce allocations for path conversions on Windows

### DIFF
--- a/library/std/src/sys/windows/mod.rs
+++ b/library/std/src/sys/windows/mod.rs
@@ -160,7 +160,7 @@ pub fn to_u16s<S: AsRef<OsStr>>(s: S) -> crate::io::Result<Vec<u16>> {
         // in the OsStr plus one for the null-terminating character. We are not
         // wasting bytes here as paths created by this function are primarily used
         // in an ephemeral fashion.
-        let mut maybe_result: Vec<u16> = Vec::with_capacity(s.len() + 1);
+        let mut maybe_result = Vec::with_capacity(s.len() + 1);
         maybe_result.extend(s.encode_wide());
 
         if unrolled_find_u16s(0, &maybe_result).is_some() {


### PR DESCRIPTION
Fixes #96297. Previously, UTF-8 to UTF-16 Path conversions on Windows unnecessarily allocate twice, as described in #96297. This commit fixes that issue.