### PR TITLE
set has_thread_local=true for android 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -741,9 +741,9 @@ dependencies = [
 
 [[package]]
 name = "compiler_builtins"
-version = "0.1.71"
+version = "0.1.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "163437f05ca8f29d7e9128ea728dedf5eb620e445fbca273641d3a3050305f23"
+checksum = "afdbb35d279238cf77f0c9e8d90ad50d6c7bff476ab342baafa29440f0f10bff"
 dependencies = [
  "cc",
  "rustc-std-workspace-core",

--- a/compiler/rustc_target/src/spec/android_base.rs
+++ b/compiler/rustc_target/src/spec/android_base.rs
@@ -5,7 +5,7 @@ pub fn opts() -> TargetOptions {
     base.os = "android".into();
     base.dwarf_version = Some(2);
     base.position_independent_executables = true;
-    base.has_thread_local = false;
+    base.has_thread_local = true;
     // This is for backward compatibility, see https://github.com/rust-lang/rust/issues/49867
     // for context. (At that time, there was no `-C force-unwind-tables`, so the only solution
     // was to always emit `uwtable`).

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -16,7 +16,7 @@ panic_unwind = { path = "../panic_unwind", optional = true }
 panic_abort = { path = "../panic_abort" }
 core = { path = "../core" }
 libc = { version = "0.2.116", default-features = false, features = ['rustc-dep-of-std'] }
-compiler_builtins = { version = "0.1.71" }
+compiler_builtins = { version = "0.1.72" }
 profiler_builtins = { path = "../profiler_builtins", optional = true }
 unwind = { path = "../unwind" }
 hashbrown = { version = "0.12", default-features = false, features = ['rustc-dep-of-std'] }

--- a/library/std/src/sys/unix/thread_local_dtor.rs
+++ b/library/std/src/sys/unix/thread_local_dtor.rs
@@ -13,6 +13,7 @@
 // fallback implementation to use as well.
 #[cfg(any(
     target_os = "linux",
+    target_os = "android",
     target_os = "fuchsia",
     target_os = "redox",
     target_os = "emscripten"


### PR DESCRIPTION
It seems that llvm uses emulated tls on android by default since [this commit](https://reviews.llvm.org/D42999). Which uses a `pthread_key` to emulate various tls objects at runtime([code](https://github.com/llvm-mirror/compiler-rt/blob/master/lib/builtins/emutls.c)). 

I've built a demo with a custom android target setting `has_thread_local=true` and a slightly modified `std` as what this PR does, and it works fine. The generated function symbol `__emutls_get_address`  would link to an implementation in `libgcc.a` , which is also [required by std](https://github.com/rust-lang/rust/blob/master/library/unwind/build.rs#L18) for now.

By enable `has_thread_local`, we can reduce the number of `pthread_key`s used by rust libraries on android, which are quite limited resources(128 per process). I've been investgating some crashes caused by unable to create more pthread_key in our project with about 80 `pthread_key`s used by rust part.

cc #96145  [rust-lang/compiler-builtins#458](https://github.com/rust-lang/compiler-builtins/pull/458)