### PR TITLE
Link to correct `as_mut` in docs for `pointer::as_ref`

### DIFF
--- a/library/core/src/ptr/mut_ptr.rs
+++ b/library/core/src/ptr/mut_ptr.rs
@@ -287,7 +287,7 @@ impl<T: ?Sized> *mut T {
     /// For the mutable counterpart see [`as_mut`].
     ///
     /// [`as_uninit_ref`]: #method.as_uninit_ref-1
-    /// [`as_mut`]: #method.as_mut
+    /// [`as_mut`]: #method.as_mut-1
     ///
     /// # Safety
     ///


### PR DESCRIPTION
It previously linked to the unstable const-mut-cast method instead of
the `mut` counterpart for `as_ref`.

Closes #96327