### PR TITLE
Inline core::panic::Location methods

### DIFF
--- a/library/core/src/panic/location.rs
+++ b/library/core/src/panic/location.rs
@@ -83,6 +83,7 @@ impl<'a> Location<'a> {
     #[stable(feature = "track_caller", since = "1.46.0")]
     #[rustc_const_unstable(feature = "const_caller_location", issue = "76156")]
     #[track_caller]
+    #[inline]
     pub const fn caller() -> &'static Location<'static> {
         crate::intrinsics::caller_location()
     }
@@ -122,6 +123,7 @@ impl<'a> Location<'a> {
     /// ```
     #[must_use]
     #[stable(feature = "panic_hooks", since = "1.10.0")]
+    #[inline]
     pub fn file(&self) -> &str {
         self.file
     }
@@ -145,6 +147,7 @@ impl<'a> Location<'a> {
     /// ```
     #[must_use]
     #[stable(feature = "panic_hooks", since = "1.10.0")]
+    #[inline]
     pub fn line(&self) -> u32 {
         self.line
     }
@@ -168,6 +171,7 @@ impl<'a> Location<'a> {
     /// ```
     #[must_use]
     #[stable(feature = "panic_col", since = "1.25.0")]
+    #[inline]
     pub fn column(&self) -> u32 {
         self.col
     }


### PR DESCRIPTION
This avoids the overhead of a function call when used.