### PR TITLE
Fix running bootstrap tests on a fresh clone

### DIFF
--- a/src/bootstrap/builder/tests.rs
+++ b/src/bootstrap/builder/tests.rs
@@ -7,7 +7,19 @@ fn configure(cmd: &str, host: &[&str], target: &[&str]) -> Config {
     // don't save toolstates
     config.save_toolstates = None;
     config.dry_run = true;
+
+    // Ignore most submodules, since we don't need them for a dry run.
+    // But make sure to check out the `doc` and `rust-analyzer` submodules, since some steps need them
+    // just to know which commands to run.
+    let submodule_build = Build::new(Config {
+        // don't include LLVM, so CI doesn't require ninja/cmake to be installed
+        rust_codegen_backends: vec![],
+        ..Config::parse(&["check".to_owned()])
+    });
+    submodule_build.update_submodule(Path::new("src/doc/book"));
+    submodule_build.update_submodule(Path::new("src/tools/rust-analyzer"));
     config.submodules = Some(false);
+
     config.ninja_in_file = false;
     // try to avoid spurious failures in dist where we create/delete each others file
     // HACK: rather than pull in `tempdir`, use the one that cargo has conveniently created for us


### PR DESCRIPTION
In #96303, I changed the tests not to manage submodules, with the main
goal of avoiding a clone for llvm-project. Unfortunately, there are some tests
which depend on submodules - I didn't notice locally because they were already checked out for me,
and CI doesn't use submodule handling at all. Fresh clones, however, were impacted:
```
failures:

---- builder::tests::defaults::doc_default stdout ----
thread 'main' panicked at 'fs::read_dir(builder.src.join(&relative_path).join("redirects")) failed with No such file or directory (os error 2)', src/bootstrap/doc.rs:232:21
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- builder::tests::dist::dist_only_cross_host stdout ----
thread 'main' panicked at 'fs::read_to_string(&toml_file_name) failed with No such file or directory (os error 2)', src/bootstrap/lib.rs:1314:20
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Try and get the best of both worlds by only checking out the submodules actually used in tests.