### PR TITLE
delay bug when adjusting `NeverToAny` twice during diagnostic code

### DIFF
--- a/src/test/ui/never_type/issue-96335.rs
+++ b/src/test/ui/never_type/issue-96335.rs
@@ -1,0 +1,5 @@
+fn main() {
+    0.....{loop{}1};
+    //~^ ERROR unexpected token
+    //~| ERROR mismatched types
+}

--- a/src/test/ui/never_type/issue-96335.stderr
+++ b/src/test/ui/never_type/issue-96335.stderr
@@ -1,0 +1,35 @@
+error: unexpected token: `...`
+  --> $DIR/issue-96335.rs:2:6
+   |
+LL |     0.....{loop{}1};
+   |      ^^^
+   |
+help: use `..` for an exclusive range
+   |
+LL |     0....{loop{}1};
+   |      ~~
+help: or `..=` for an inclusive range
+   |
+LL |     0..=..{loop{}1};
+   |      ~~~
+
+error[E0308]: mismatched types
+  --> $DIR/issue-96335.rs:2:9
+   |
+LL |     0.....{loop{}1};
+   |     ----^^^^^^^^^^^
+   |     |   |
+   |     |   expected integer, found struct `RangeTo`
+   |     arguments to this function are incorrect
+   |
+   = note: expected type `{integer}`
+            found struct `RangeTo<{integer}>`
+note: associated function defined here
+  --> $SRC_DIR/core/src/ops/range.rs:LL:COL
+   |
+LL |     pub const fn new(start: Idx, end: Idx) -> Self {
+   |                  ^^^
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Addresses Issue 96335 (https://github.com/rust-lang/rust/issues/96335) by using `delay_span_bug` instead of an assert and returning an error type from `check_expr_meets_expectation_or_error`. 

Fixes #96335