### PR TITLE
Fix erased region escaping into wfcheck due to #95395

### DIFF
--- a/compiler/rustc_typeck/src/astconv/mod.rs
+++ b/compiler/rustc_typeck/src/astconv/mod.rs
@@ -2681,21 +2681,21 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
         let trait_ref =
             self.instantiate_mono_trait_ref(i.of_trait.as_ref()?, self.ast_ty_to_ty(i.self_ty));
 
-        let x: &ty::AssocItem = tcx.associated_items(trait_ref.def_id).find_by_name_and_kind(
+        let assoc = tcx.associated_items(trait_ref.def_id).find_by_name_and_kind(
             tcx,
             *ident,
             ty::AssocKind::Fn,
             trait_ref.def_id,
         )?;
 
-        let fn_sig = tcx.fn_sig(x.def_id).subst(
+        let fn_sig = tcx.fn_sig(assoc.def_id).subst(
             tcx,
-            trait_ref.substs.extend_to(tcx, x.def_id, |param, _| tcx.mk_param_from_def(param)),
+            trait_ref.substs.extend_to(tcx, assoc.def_id, |param, _| tcx.mk_param_from_def(param)),
         );
 
         let ty = if let Some(arg_idx) = arg_idx { fn_sig.input(arg_idx) } else { fn_sig.output() };
 
-        Some(tcx.erase_late_bound_regions(ty))
+        Some(tcx.liberate_late_bound_regions(fn_hir_id.expect_owner().to_def_id(), ty))
     }
 
     fn validate_late_bound_regions(

--- a/src/test/rustdoc/issue-96381.rs
+++ b/src/test/rustdoc/issue-96381.rs
@@ -1,0 +1,16 @@
+// should-fail
+
+#![allow(unused)]
+
+trait Foo<T>: Sized {
+    fn bar(i: i32, t: T, s: &Self) -> (T, i32);
+}
+
+impl Foo<usize> for () {
+    fn bar(i: _, t: _, s: _) -> _ {
+        //~^ ERROR the placeholder `_` is not allowed within types on item signatures for functions
+        (1, 2)
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
We can just use `liberate_late_bound_regions` instead of `erase_late_bound_regions`... This gives us `ReEarlyBound` instead of `ReErased`, the former being something typeck actually knows how to deal with...

Fixes #96381

Side-note: We only actually get far enough in the compiler pipeline to cause this ICE when we're invoking rustdoc. We actually abort rustc right before wfcheck because of the error that we emit (having `_` in the type signature). Why does rustdoc keep going even though we raise an error?