### PR TITLE
[wip] Update Mac Catalyst support for Clang 13

### DIFF
--- a/compiler/rustc_target/src/spec/apple_base.rs
+++ b/compiler/rustc_target/src/spec/apple_base.rs
@@ -114,3 +114,8 @@ pub fn ios_sim_llvm_target(arch: &str) -> String {
     let (major, minor) = ios_deployment_target();
     format!("{}-apple-ios{}.{}.0-simulator", arch, major, minor)
 }
+
+pub fn macabi_llvm_target(arch: &str) -> String {
+    let (major, minor) = ios_deployment_target();
+    format!("{}-apple-ios{}.{}.0-macabi", arch, major, minor)
+}

--- a/compiler/rustc_target/src/spec/x86_64_apple_ios_macabi.rs
+++ b/compiler/rustc_target/src/spec/x86_64_apple_ios_macabi.rs
@@ -3,8 +3,10 @@ use crate::spec::{StackProbeType, Target, TargetOptions};
 
 pub fn target() -> Target {
     let base = opts("ios", Arch::X86_64_macabi);
+    let arch = "x86_64";
+    let llvm_target = super::apple_base::macabi_llvm_target(arch);
     Target {
-        llvm_target: "x86_64-apple-ios13.0-macabi".into(),
+        llvm_target: llvm_target.into(),
         pointer_width: 64,
         data_layout: "e-m:o-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
             .into(),


### PR DESCRIPTION
LLVM 13 (bundled in Xcode 13.3+) bumped the minimal x86_64 Catalyst version. 

```shell
➜  temp clang -target x86_64-apple-ios13.1-macabi i.c
➜  temp clang -target x86_64-apple-ios13.0-macabi i.c
clang-13: error: invalid version number in '-target x86_64-apple-ios13.0-macabi'
➜  temp clang --version
Homebrew clang version 13.0.1
Target: arm64-apple-darwin21.4.0
Thread model: posix
InstalledDir: /opt/homebrew/bin
➜  temp cat i.c

int main() {
	return 0;
}
➜  temp
```

In this case, we'd better provide a way to change the minimal version number.

This would also work:

```shell
$ clang -target x86_64-apple-ios-macabi -miphoneos-version-min=13.1 i.c
```

Similar PR: https://github.com/conan-io/conan/pull/10880