### PR TITLE
Correct documentation for `Rvalue::ShallowInitBox`

### DIFF
--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -2581,8 +2581,6 @@ pub enum Rvalue<'tcx> {
     /// This is different from a normal transmute because dataflow analysis will treat the box as
     /// initialized but its content as uninitialized. Like other pointer casts, this in general
     /// affects alias analysis.
-    ///
-    /// Disallowed after drop elaboration.
     ShallowInitBox(Operand<'tcx>, Ty<'tcx>),
 }
 


### PR DESCRIPTION
As a part of the big MIR docs PR, I had added a comment indicating that `Rvalue::ShallowInitBox` is disallowed after drop elaboration, but this is not true (no idea why I thought it was). Codegen has support for it, and trying to enforce this rule in the validator causes compiling core to ICE on the very first `box` statement.

That being said, this `Rvalue` probably *should* be banned after drop elaboration - it doesn't seem like it's still useful for much. However, I do not have time right now to actually go investigate how difficult a change that is to make, so in the meantime fixing the docs to reflect the current situation seems like the right step.

r? rust-lang/mir-opt