### PR TITLE
rustdoc: do not write `{{root}}` in `pub use ::foo` docs

### DIFF
--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -18,6 +18,7 @@ use rustc_hir::def_id::DefId;
 use rustc_middle::ty;
 use rustc_middle::ty::DefIdTree;
 use rustc_middle::ty::TyCtxt;
+use rustc_span::symbol::kw;
 use rustc_span::{sym, Symbol};
 use rustc_target::spec::abi::Abi;
 
@@ -679,7 +680,7 @@ fn resolved_path<'cx>(
 
     if print_all {
         for seg in &path.segments[..path.segments.len() - 1] {
-            write!(w, "{}::", seg.name)?;
+            write!(w, "{}::", if seg.name == kw::PathRoot { "" } else { seg.name.as_str() })?;
         }
     }
     if w.alternate() {

--- a/src/test/rustdoc/issue-95873.rs
+++ b/src/test/rustdoc/issue-95873.rs
@@ -1,2 +1,2 @@
-// @!has issue_95873/index.html '{{root}}'
+// @has issue_95873/index.html "//*[@class='item-left import-item']" "pub use ::std as x;"
 pub use ::std as x;

--- a/src/test/rustdoc/issue-95873.rs
+++ b/src/test/rustdoc/issue-95873.rs
@@ -1,0 +1,2 @@
+// @!has issue_95873/index.html '{{root}}'
+pub use ::std as x;


### PR DESCRIPTION
Fixes #95873