### PR TITLE
Fix incremental perf regression unsafety checking

### DIFF
--- a/src/test/ui/async-await/async-unsafe-fn-call-in-safe.mir.stderr
+++ b/src/test/ui/async-await/async-unsafe-fn-call-in-safe.mir.stderr
@@ -1,4 +1,4 @@
-error[E0133]: call to unsafe function `S::f` is unsafe and requires unsafe function or block
+error[E0133]: call to unsafe function is unsafe and requires unsafe function or block
   --> $DIR/async-unsafe-fn-call-in-safe.rs:14:5
    |
 LL |     S::f();
@@ -6,24 +6,24 @@ LL |     S::f();
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 
-error[E0133]: call to unsafe function `f` is unsafe and requires unsafe function or block
-  --> $DIR/async-unsafe-fn-call-in-safe.rs:15:5
+error[E0133]: call to unsafe function is unsafe and requires unsafe function or block
+  --> $DIR/async-unsafe-fn-call-in-safe.rs:17:5
    |
 LL |     f();
    |     ^^^ call to unsafe function
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 
-error[E0133]: call to unsafe function `S::f` is unsafe and requires unsafe function or block
-  --> $DIR/async-unsafe-fn-call-in-safe.rs:19:5
+error[E0133]: call to unsafe function is unsafe and requires unsafe function or block
+  --> $DIR/async-unsafe-fn-call-in-safe.rs:23:5
    |
 LL |     S::f();
    |     ^^^^^^ call to unsafe function
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 
-error[E0133]: call to unsafe function `f` is unsafe and requires unsafe function or block
-  --> $DIR/async-unsafe-fn-call-in-safe.rs:20:5
+error[E0133]: call to unsafe function is unsafe and requires unsafe function or block
+  --> $DIR/async-unsafe-fn-call-in-safe.rs:24:5
    |
 LL |     f();
    |     ^^^ call to unsafe function

--- a/src/test/ui/async-await/async-unsafe-fn-call-in-safe.rs
+++ b/src/test/ui/async-await/async-unsafe-fn-call-in-safe.rs
@@ -11,11 +11,15 @@ impl S {
 async unsafe fn f() {}
 
 async fn g() {
-    S::f(); //~ ERROR call to unsafe function `S::f` is unsafe
-    f(); //~ ERROR call to unsafe function `f` is unsafe
+    S::f();
+    //[mir]~^ ERROR call to unsafe function is unsafe
+    //[thir]~^^ ERROR call to unsafe function `S::f` is unsafe
+    f();
+    //[mir]~^ ERROR call to unsafe function is unsafe
+    //[thir]~^^ ERROR call to unsafe function `f` is unsafe
 }
 
 fn main() {
-    S::f(); //[mir]~ ERROR call to unsafe function `S::f` is unsafe
-    f(); //[mir]~ ERROR call to unsafe function `f` is unsafe
+    S::f(); //[mir]~ ERROR call to unsafe function is unsafe
+    f(); //[mir]~ ERROR call to unsafe function is unsafe
 }

--- a/src/test/ui/async-await/async-unsafe-fn-call-in-safe.thir.stderr
+++ b/src/test/ui/async-await/async-unsafe-fn-call-in-safe.thir.stderr
@@ -7,7 +7,7 @@ LL |     S::f();
    = note: consult the function's documentation for information on how to avoid undefined behavior
 
 error[E0133]: call to unsafe function `f` is unsafe and requires unsafe function or block
-  --> $DIR/async-unsafe-fn-call-in-safe.rs:15:5
+  --> $DIR/async-unsafe-fn-call-in-safe.rs:17:5
    |
 LL |     f();
    |     ^^^ call to unsafe function

--- a/src/test/ui/closures/coerce-unsafe-closure-to-unsafe-fn-ptr.mir.stderr
+++ b/src/test/ui/closures/coerce-unsafe-closure-to-unsafe-fn-ptr.mir.stderr
@@ -1,4 +1,4 @@
-error[E0133]: call to unsafe function `std::pin::Pin::<P>::new_unchecked` is unsafe and requires unsafe function or block
+error[E0133]: call to unsafe function is unsafe and requires unsafe function or block
   --> $DIR/coerce-unsafe-closure-to-unsafe-fn-ptr.rs:5:31
    |
 LL |     let _: unsafe fn() = || { ::std::pin::Pin::new_unchecked(&0_u8); };

--- a/src/test/ui/consts/const-extern-fn/const-extern-fn-requires-unsafe.mir.stderr
+++ b/src/test/ui/consts/const-extern-fn/const-extern-fn-requires-unsafe.mir.stderr
@@ -1,4 +1,4 @@
-error[E0133]: call to unsafe function `foo` is unsafe and requires unsafe function or block
+error[E0133]: call to unsafe function is unsafe and requires unsafe function or block
   --> $DIR/const-extern-fn-requires-unsafe.rs:9:17
    |
 LL |     let a: [u8; foo()];
@@ -6,8 +6,8 @@ LL |     let a: [u8; foo()];
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 
-error[E0133]: call to unsafe function `foo` is unsafe and requires unsafe function or block
-  --> $DIR/const-extern-fn-requires-unsafe.rs:11:5
+error[E0133]: call to unsafe function is unsafe and requires unsafe function or block
+  --> $DIR/const-extern-fn-requires-unsafe.rs:12:5
    |
 LL |     foo();
    |     ^^^^^ call to unsafe function

--- a/src/test/ui/consts/const-extern-fn/const-extern-fn-requires-unsafe.rs
+++ b/src/test/ui/consts/const-extern-fn/const-extern-fn-requires-unsafe.rs
@@ -7,7 +7,8 @@ const unsafe extern "C" fn foo() -> usize { 5 }
 
 fn main() {
     let a: [u8; foo()];
-    //~^ ERROR call to unsafe function `foo` is unsafe and requires unsafe function or block
+    //[mir]~^ call to unsafe function is unsafe and requires unsafe function or block
+    //[thir]~^^ call to unsafe function `foo` is unsafe and requires unsafe function or block
     foo();
-    //[mir]~^ ERROR call to unsafe function `foo` is unsafe and requires unsafe function or block
+    //[mir]~^ ERROR call to unsafe function is unsafe and requires unsafe function or block
 }

--- a/src/test/ui/error-codes/E0133.mir.stderr
+++ b/src/test/ui/error-codes/E0133.mir.stderr
@@ -1,4 +1,4 @@
-error[E0133]: call to unsafe function `f` is unsafe and requires unsafe function or block
+error[E0133]: call to unsafe function is unsafe and requires unsafe function or block
   --> $DIR/E0133.rs:7:5
    |
 LL |     f();

--- a/src/test/ui/foreign-unsafe-fn-called.mir.stderr
+++ b/src/test/ui/foreign-unsafe-fn-called.mir.stderr
@@ -1,4 +1,4 @@
-error[E0133]: call to unsafe function `test::free` is unsafe and requires unsafe function or block
+error[E0133]: call to unsafe function is unsafe and requires unsafe function or block
   --> $DIR/foreign-unsafe-fn-called.rs:11:5
    |
 LL |     test::free();

--- a/src/test/ui/foreign-unsafe-fn-called.rs
+++ b/src/test/ui/foreign-unsafe-fn-called.rs
@@ -9,5 +9,6 @@ mod test {
 
 fn main() {
     test::free();
-    //~^ ERROR call to unsafe function `test::free` is unsafe
+    //[mir]~^ ERROR call to unsafe function is unsafe
+    //[thir]~^^ ERROR call to unsafe function `test::free` is unsafe
 }

--- a/src/test/ui/intrinsics/unchecked_math_unsafe.mir.stderr
+++ b/src/test/ui/intrinsics/unchecked_math_unsafe.mir.stderr
@@ -1,4 +1,4 @@
-error[E0133]: call to unsafe function `std::intrinsics::unchecked_add` is unsafe and requires unsafe function or block
+error[E0133]: call to unsafe function is unsafe and requires unsafe function or block
   --> $DIR/unchecked_math_unsafe.rs:8:15
    |
 LL |     let add = std::intrinsics::unchecked_add(x, y);
@@ -6,7 +6,7 @@ LL |     let add = std::intrinsics::unchecked_add(x, y);
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 
-error[E0133]: call to unsafe function `std::intrinsics::unchecked_sub` is unsafe and requires unsafe function or block
+error[E0133]: call to unsafe function is unsafe and requires unsafe function or block
   --> $DIR/unchecked_math_unsafe.rs:9:15
    |
 LL |     let sub = std::intrinsics::unchecked_sub(x, y);
@@ -14,7 +14,7 @@ LL |     let sub = std::intrinsics::unchecked_sub(x, y);
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 
-error[E0133]: call to unsafe function `std::intrinsics::unchecked_mul` is unsafe and requires unsafe function or block
+error[E0133]: call to unsafe function is unsafe and requires unsafe function or block
   --> $DIR/unchecked_math_unsafe.rs:10:15
    |
 LL |     let mul = std::intrinsics::unchecked_mul(x, y);

--- a/src/test/ui/issues/issue-28776.mir.stderr
+++ b/src/test/ui/issues/issue-28776.mir.stderr
@@ -1,4 +1,4 @@
-error[E0133]: call to unsafe function `std::ptr::write` is unsafe and requires unsafe function or block
+error[E0133]: call to unsafe function is unsafe and requires unsafe function or block
   --> $DIR/issue-28776.rs:7:5
    |
 LL |     (&ptr::write)(1 as *mut _, 42);

--- a/src/test/ui/issues/issue-3080.mir.stderr
+++ b/src/test/ui/issues/issue-3080.mir.stderr
@@ -1,4 +1,4 @@
-error[E0133]: call to unsafe function `X::with` is unsafe and requires unsafe function or block
+error[E0133]: call to unsafe function is unsafe and requires unsafe function or block
   --> $DIR/issue-3080.rs:10:5
    |
 LL |     X(()).with();

--- a/src/test/ui/issues/issue-5844.mir.stderr
+++ b/src/test/ui/issues/issue-5844.mir.stderr
@@ -1,4 +1,4 @@
-error[E0133]: call to unsafe function `issue_5844_aux::rand` is unsafe and requires unsafe function or block
+error[E0133]: call to unsafe function is unsafe and requires unsafe function or block
   --> $DIR/issue-5844.rs:8:5
    |
 LL |     issue_5844_aux::rand();

--- a/src/test/ui/rfcs/rfc-2396-target_feature-11/safe-calls.mir.stderr
+++ b/src/test/ui/rfcs/rfc-2396-target_feature-11/safe-calls.mir.stderr
@@ -1,4 +1,4 @@
-error[E0133]: call to function `sse2` with `#[target_feature]` is unsafe and requires unsafe function or block
+error[E0133]: call to function with `#[target_feature]` is unsafe and requires unsafe function or block
   --> $DIR/safe-calls.rs:23:5
    |
 LL |     sse2();
@@ -6,72 +6,72 @@ LL |     sse2();
    |
    = note: can only be called if the required target features are available
 
-error[E0133]: call to function `avx_bmi2` with `#[target_feature]` is unsafe and requires unsafe function or block
-  --> $DIR/safe-calls.rs:24:5
+error[E0133]: call to function with `#[target_feature]` is unsafe and requires unsafe function or block
+  --> $DIR/safe-calls.rs:26:5
    |
 LL |     avx_bmi2();
    |     ^^^^^^^^^^ call to function with `#[target_feature]`
    |
    = note: can only be called if the required target features are available
 
-error[E0133]: call to function `Quux::avx_bmi2` with `#[target_feature]` is unsafe and requires unsafe function or block
-  --> $DIR/safe-calls.rs:25:5
+error[E0133]: call to function with `#[target_feature]` is unsafe and requires unsafe function or block
+  --> $DIR/safe-calls.rs:29:5
    |
 LL |     Quux.avx_bmi2();
    |     ^^^^^^^^^^^^^^^ call to function with `#[target_feature]`
    |
    = note: can only be called if the required target features are available
 
-error[E0133]: call to function `avx_bmi2` with `#[target_feature]` is unsafe and requires unsafe function or block
-  --> $DIR/safe-calls.rs:30:5
-   |
-LL |     avx_bmi2();
-   |     ^^^^^^^^^^ call to function with `#[target_feature]`
-   |
-   = note: can only be called if the required target features are available
-
-error[E0133]: call to function `Quux::avx_bmi2` with `#[target_feature]` is unsafe and requires unsafe function or block
-  --> $DIR/safe-calls.rs:31:5
-   |
-LL |     Quux.avx_bmi2();
-   |     ^^^^^^^^^^^^^^^ call to function with `#[target_feature]`
-   |
-   = note: can only be called if the required target features are available
-
-error[E0133]: call to function `sse2` with `#[target_feature]` is unsafe and requires unsafe function or block
+error[E0133]: call to function with `#[target_feature]` is unsafe and requires unsafe function or block
   --> $DIR/safe-calls.rs:36:5
    |
-LL |     sse2();
-   |     ^^^^^^ call to function with `#[target_feature]`
-   |
-   = note: can only be called if the required target features are available
-
-error[E0133]: call to function `avx_bmi2` with `#[target_feature]` is unsafe and requires unsafe function or block
-  --> $DIR/safe-calls.rs:37:5
-   |
 LL |     avx_bmi2();
    |     ^^^^^^^^^^ call to function with `#[target_feature]`
    |
    = note: can only be called if the required target features are available
 
-error[E0133]: call to function `Quux::avx_bmi2` with `#[target_feature]` is unsafe and requires unsafe function or block
-  --> $DIR/safe-calls.rs:38:5
+error[E0133]: call to function with `#[target_feature]` is unsafe and requires unsafe function or block
+  --> $DIR/safe-calls.rs:39:5
    |
 LL |     Quux.avx_bmi2();
    |     ^^^^^^^^^^^^^^^ call to function with `#[target_feature]`
    |
    = note: can only be called if the required target features are available
 
-error[E0133]: call to function `sse2` with `#[target_feature]` is unsafe and requires unsafe function or block
-  --> $DIR/safe-calls.rs:44:5
+error[E0133]: call to function with `#[target_feature]` is unsafe and requires unsafe function or block
+  --> $DIR/safe-calls.rs:46:5
    |
 LL |     sse2();
    |     ^^^^^^ call to function with `#[target_feature]`
    |
    = note: can only be called if the required target features are available
 
-error[E0133]: call to function `sse2` with `#[target_feature]` is unsafe and requires unsafe function or block
-  --> $DIR/safe-calls.rs:47:18
+error[E0133]: call to function with `#[target_feature]` is unsafe and requires unsafe function or block
+  --> $DIR/safe-calls.rs:49:5
+   |
+LL |     avx_bmi2();
+   |     ^^^^^^^^^^ call to function with `#[target_feature]`
+   |
+   = note: can only be called if the required target features are available
+
+error[E0133]: call to function with `#[target_feature]` is unsafe and requires unsafe function or block
+  --> $DIR/safe-calls.rs:52:5
+   |
+LL |     Quux.avx_bmi2();
+   |     ^^^^^^^^^^^^^^^ call to function with `#[target_feature]`
+   |
+   = note: can only be called if the required target features are available
+
+error[E0133]: call to function with `#[target_feature]` is unsafe and requires unsafe function or block
+  --> $DIR/safe-calls.rs:60:5
+   |
+LL |     sse2();
+   |     ^^^^^^ call to function with `#[target_feature]`
+   |
+   = note: can only be called if the required target features are available
+
+error[E0133]: call to function with `#[target_feature]` is unsafe and requires unsafe function or block
+  --> $DIR/safe-calls.rs:65:18
    |
 LL | const name: () = sse2();
    |                  ^^^^^^ call to function with `#[target_feature]`

--- a/src/test/ui/rfcs/rfc-2396-target_feature-11/safe-calls.rs
+++ b/src/test/ui/rfcs/rfc-2396-target_feature-11/safe-calls.rs
@@ -20,30 +20,50 @@ impl Quux {
 }
 
 fn foo() {
-    sse2();              //~ ERROR call to function `sse2` with `#[target_feature]` is unsafe
-    avx_bmi2();          //~ ERROR call to function `avx_bmi2` with `#[target_feature]` is unsafe
-    Quux.avx_bmi2();     //~ ERROR call to function `Quux::avx_bmi2` with `#[target_feature]` is unsafe
+    sse2();
+    //[mir]~^ ERROR call to function with `#[target_feature]` is unsafe
+    //[thir]~^^ ERROR call to function `sse2` with `#[target_feature]` is unsafe
+    avx_bmi2();
+    //[mir]~^ ERROR call to function with `#[target_feature]` is unsafe
+    //[thir]~^^ ERROR call to function `avx_bmi2` with `#[target_feature]` is unsafe
+    Quux.avx_bmi2();
+    //[mir]~^ ERROR call to function with `#[target_feature]` is unsafe
+    //[thir]~^^ ERROR call to function `Quux::avx_bmi2` with `#[target_feature]` is unsafe
 }
 
 #[target_feature(enable = "sse2")]
 fn bar() {
-    avx_bmi2();          //~ ERROR call to function `avx_bmi2` with `#[target_feature]` is unsafe
-    Quux.avx_bmi2();     //~ ERROR call to function `Quux::avx_bmi2` with `#[target_feature]` is unsafe
+    avx_bmi2();
+    //[mir]~^ ERROR call to function with `#[target_feature]` is unsafe
+    //[thir]~^^ ERROR call to function `avx_bmi2` with `#[target_feature]` is unsafe
+    Quux.avx_bmi2();
+    //[mir]~^ ERROR call to function with `#[target_feature]` is unsafe
+    //[thir]~^^ ERROR call to function `Quux::avx_bmi2` with `#[target_feature]` is unsafe
 }
 
 #[target_feature(enable = "avx")]
 fn baz() {
-    sse2();              //~ ERROR call to function `sse2` with `#[target_feature]` is unsafe
-    avx_bmi2();          //~ ERROR call to function `avx_bmi2` with `#[target_feature]` is unsafe
-    Quux.avx_bmi2();     //~ ERROR call to function `Quux::avx_bmi2` with `#[target_feature]` is unsafe
+    sse2();
+    //[mir]~^ ERROR call to function with `#[target_feature]` is unsafe
+    //[thir]~^^ ERROR call to function `sse2` with `#[target_feature]` is unsafe
+    avx_bmi2();
+    //[mir]~^ ERROR call to function with `#[target_feature]` is unsafe
+    //[thir]~^^ ERROR call to function `avx_bmi2` with `#[target_feature]` is unsafe
+    Quux.avx_bmi2();
+    //[mir]~^ ERROR call to function with `#[target_feature]` is unsafe
+    //[thir]~^^ ERROR call to function `Quux::avx_bmi2` with `#[target_feature]` is unsafe
 }
 
 #[target_feature(enable = "avx")]
 #[target_feature(enable = "bmi2")]
 fn qux() {
-    sse2();              //~ ERROR call to function `sse2` with `#[target_feature]` is unsafe
+    sse2();
+    //[mir]~^ ERROR call to function with `#[target_feature]` is unsafe
+    //[thir]~^^ ERROR call to function `sse2` with `#[target_feature]` is unsafe
 }
 
-const name: () = sse2(); //~ ERROR call to function `sse2` with `#[target_feature]` is unsafe
+const name: () = sse2();
+//[mir]~^ ERROR call to function with `#[target_feature]` is unsafe
+//[thir]~^^ ERROR call to function `sse2` with `#[target_feature]` is unsafe
 
 fn main() {}

--- a/src/test/ui/rfcs/rfc-2396-target_feature-11/safe-calls.thir.stderr
+++ b/src/test/ui/rfcs/rfc-2396-target_feature-11/safe-calls.thir.stderr
@@ -7,7 +7,7 @@ LL |     sse2();
    = note: can only be called if the required target features are available
 
 error[E0133]: call to function `avx_bmi2` with `#[target_feature]` is unsafe and requires unsafe function or block
-  --> $DIR/safe-calls.rs:24:5
+  --> $DIR/safe-calls.rs:26:5
    |
 LL |     avx_bmi2();
    |     ^^^^^^^^^^ call to function with `#[target_feature]`
@@ -15,7 +15,7 @@ LL |     avx_bmi2();
    = note: can only be called if the required target features are available
 
 error[E0133]: call to function `Quux::avx_bmi2` with `#[target_feature]` is unsafe and requires unsafe function or block
-  --> $DIR/safe-calls.rs:25:5
+  --> $DIR/safe-calls.rs:29:5
    |
 LL |     Quux.avx_bmi2();
    |     ^^^^^^^^^^^^^^^ call to function with `#[target_feature]`
@@ -23,39 +23,15 @@ LL |     Quux.avx_bmi2();
    = note: can only be called if the required target features are available
 
 error[E0133]: call to function `avx_bmi2` with `#[target_feature]` is unsafe and requires unsafe function or block
-  --> $DIR/safe-calls.rs:30:5
-   |
-LL |     avx_bmi2();
-   |     ^^^^^^^^^^ call to function with `#[target_feature]`
-   |
-   = note: can only be called if the required target features are available
-
-error[E0133]: call to function `Quux::avx_bmi2` with `#[target_feature]` is unsafe and requires unsafe function or block
-  --> $DIR/safe-calls.rs:31:5
-   |
-LL |     Quux.avx_bmi2();
-   |     ^^^^^^^^^^^^^^^ call to function with `#[target_feature]`
-   |
-   = note: can only be called if the required target features are available
-
-error[E0133]: call to function `sse2` with `#[target_feature]` is unsafe and requires unsafe function or block
   --> $DIR/safe-calls.rs:36:5
    |
-LL |     sse2();
-   |     ^^^^^^ call to function with `#[target_feature]`
-   |
-   = note: can only be called if the required target features are available
-
-error[E0133]: call to function `avx_bmi2` with `#[target_feature]` is unsafe and requires unsafe function or block
-  --> $DIR/safe-calls.rs:37:5
-   |
 LL |     avx_bmi2();
    |     ^^^^^^^^^^ call to function with `#[target_feature]`
    |
    = note: can only be called if the required target features are available
 
 error[E0133]: call to function `Quux::avx_bmi2` with `#[target_feature]` is unsafe and requires unsafe function or block
-  --> $DIR/safe-calls.rs:38:5
+  --> $DIR/safe-calls.rs:39:5
    |
 LL |     Quux.avx_bmi2();
    |     ^^^^^^^^^^^^^^^ call to function with `#[target_feature]`
@@ -63,7 +39,31 @@ LL |     Quux.avx_bmi2();
    = note: can only be called if the required target features are available
 
 error[E0133]: call to function `sse2` with `#[target_feature]` is unsafe and requires unsafe function or block
-  --> $DIR/safe-calls.rs:44:5
+  --> $DIR/safe-calls.rs:46:5
+   |
+LL |     sse2();
+   |     ^^^^^^ call to function with `#[target_feature]`
+   |
+   = note: can only be called if the required target features are available
+
+error[E0133]: call to function `avx_bmi2` with `#[target_feature]` is unsafe and requires unsafe function or block
+  --> $DIR/safe-calls.rs:49:5
+   |
+LL |     avx_bmi2();
+   |     ^^^^^^^^^^ call to function with `#[target_feature]`
+   |
+   = note: can only be called if the required target features are available
+
+error[E0133]: call to function `Quux::avx_bmi2` with `#[target_feature]` is unsafe and requires unsafe function or block
+  --> $DIR/safe-calls.rs:52:5
+   |
+LL |     Quux.avx_bmi2();
+   |     ^^^^^^^^^^^^^^^ call to function with `#[target_feature]`
+   |
+   = note: can only be called if the required target features are available
+
+error[E0133]: call to function `sse2` with `#[target_feature]` is unsafe and requires unsafe function or block
+  --> $DIR/safe-calls.rs:60:5
    |
 LL |     sse2();
    |     ^^^^^^ call to function with `#[target_feature]`
@@ -71,7 +71,7 @@ LL |     sse2();
    = note: can only be called if the required target features are available
 
 error[E0133]: call to function `sse2` with `#[target_feature]` is unsafe and requires unsafe function or block
-  --> $DIR/safe-calls.rs:47:18
+  --> $DIR/safe-calls.rs:65:18
    |
 LL | const name: () = sse2();
    |                  ^^^^^^ call to function with `#[target_feature]`

--- a/src/test/ui/threads-sendsync/issue-43733.mir.stderr
+++ b/src/test/ui/threads-sendsync/issue-43733.mir.stderr
@@ -1,4 +1,4 @@
-error[E0133]: call to unsafe function `std::thread::$LOCALKEYINNER::<T>::get` is unsafe and requires unsafe function or block
+error[E0133]: call to unsafe function is unsafe and requires unsafe function or block
   --> $DIR/issue-43733.rs:21:5
    |
 LL |     __KEY.get(Default::default)
@@ -6,7 +6,7 @@ LL |     __KEY.get(Default::default)
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 
-error[E0133]: call to unsafe function `std::thread::LocalKey::<T>::new` is unsafe and requires unsafe function or block
+error[E0133]: call to unsafe function is unsafe and requires unsafe function or block
   --> $DIR/issue-43733.rs:26:42
    |
 LL | static FOO: std::thread::LocalKey<Foo> = std::thread::LocalKey::new(__getit);

--- a/src/test/ui/threads-sendsync/issue-43733.rs
+++ b/src/test/ui/threads-sendsync/issue-43733.rs
@@ -19,13 +19,13 @@ static __KEY: std::thread::__OsLocalKeyInner<Foo> = std::thread::__OsLocalKeyInn
 
 fn __getit(_: Option<&mut Option<RefCell<String>>>) -> std::option::Option<&'static Foo> {
     __KEY.get(Default::default)
-    //[mir]~^ ERROR call to unsafe function `std::thread::
+    //[mir]~^ ERROR call to unsafe function is unsafe
     //[thir]~^^ ERROR call to unsafe function `__
 }
 
 static FOO: std::thread::LocalKey<Foo> = std::thread::LocalKey::new(__getit);
-//[mir]~^ ERROR call to unsafe function `std::thread::LocalKey::<T>::new` is unsafe
-//[thir]~^^ ERROR call to unsafe function `LocalKey::<T>::new` is unsafe
+//[mir]~^ ERROR call to unsafe function is unsafe
+//[thir]~^^ ERROR call to unsafe function `LocalKey::<T>::new`
 
 fn main() {
     FOO.with(|foo| println!("{}", foo.borrow()));

--- a/src/test/ui/threads-sendsync/tls-dtors-are-run-in-a-static-binary.rs
+++ b/src/test/ui/threads-sendsync/tls-dtors-are-run-in-a-static-binary.rs
@@ -1,6 +1,7 @@
 // run-pass
 // no-prefer-dynamic
 // ignore-emscripten no threads support
+
 static mut HIT: bool = false;
 
 struct Foo;

--- a/src/test/ui/unsafe/rfc-2585-unsafe_op_in_unsafe_fn.mir.stderr
+++ b/src/test/ui/unsafe/rfc-2585-unsafe_op_in_unsafe_fn.mir.stderr
@@ -1,8 +1,8 @@
-error: call to unsafe function `unsf` is unsafe and requires unsafe block (error E0133)
+error: call to unsafe function is unsafe and requires unsafe block (error E0133)
   --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:12:5
    |
 LL |     unsf();
-   |     ^^^^^^ call to unsafe function `unsf`
+   |     ^^^^^^ call to unsafe function
    |
 note: the lint level is defined here
   --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:4:9
@@ -12,7 +12,7 @@ LL | #![deny(unsafe_op_in_unsafe_fn)]
    = note: consult the function's documentation for information on how to avoid undefined behavior
 
 error: dereference of raw pointer is unsafe and requires unsafe block (error E0133)
-  --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:14:5
+  --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:15:5
    |
 LL |     *PTR;
    |     ^^^^ dereference of raw pointer
@@ -20,7 +20,7 @@ LL |     *PTR;
    = note: raw pointers may be null, dangling or unaligned; they can violate aliasing rules and cause data races: all of these are undefined behavior
 
 error: use of mutable static is unsafe and requires unsafe block (error E0133)
-  --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:16:5
+  --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:17:5
    |
 LL |     VOID = ();
    |     ^^^^^^^^^ use of mutable static
@@ -28,7 +28,7 @@ LL |     VOID = ();
    = note: mutable statics can be mutated by multiple threads: aliasing violations or data races will cause undefined behavior
 
 error: unnecessary `unsafe` block
-  --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:19:5
+  --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:20:5
    |
 LL |     unsafe {}
    |     ^^^^^^ unnecessary `unsafe` block
@@ -39,14 +39,14 @@ note: the lint level is defined here
 LL | #![deny(unused_unsafe)]
    |         ^^^^^^^^^^^^^
 
-error: call to unsafe function `unsf` is unsafe and requires unsafe block (error E0133)
-  --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:27:5
+error: call to unsafe function is unsafe and requires unsafe block (error E0133)
+  --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:28:5
    |
 LL |     unsf();
-   |     ^^^^^^ call to unsafe function `unsf`
+   |     ^^^^^^ call to unsafe function
    |
 note: the lint level is defined here
-  --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:25:8
+  --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:26:8
    |
 LL | #[deny(warnings)]
    |        ^^^^^^^^
@@ -54,7 +54,7 @@ LL | #[deny(warnings)]
    = note: consult the function's documentation for information on how to avoid undefined behavior
 
 error: dereference of raw pointer is unsafe and requires unsafe block (error E0133)
-  --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:29:5
+  --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:31:5
    |
 LL |     *PTR;
    |     ^^^^ dereference of raw pointer
@@ -62,7 +62,7 @@ LL |     *PTR;
    = note: raw pointers may be null, dangling or unaligned; they can violate aliasing rules and cause data races: all of these are undefined behavior
 
 error: use of mutable static is unsafe and requires unsafe block (error E0133)
-  --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:31:5
+  --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:33:5
    |
 LL |     VOID = ();
    |     ^^^^^^^^^ use of mutable static
@@ -70,19 +70,19 @@ LL |     VOID = ();
    = note: mutable statics can be mutated by multiple threads: aliasing violations or data races will cause undefined behavior
 
 error: unnecessary `unsafe` block
-  --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:33:5
+  --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:35:5
    |
 LL |     unsafe {}
    |     ^^^^^^ unnecessary `unsafe` block
 
 error: unnecessary `unsafe` block
-  --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:47:5
+  --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:49:5
    |
 LL |     unsafe { unsafe { unsf() } }
    |     ^^^^^^ unnecessary `unsafe` block
 
 error: unnecessary `unsafe` block
-  --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:58:5
+  --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:60:5
    |
 LL | unsafe fn allow_level() {
    | ----------------------- because it's nested under this `unsafe` fn
@@ -92,13 +92,13 @@ LL |     unsafe { unsf() }
    |
    = note: this `unsafe` block does contain unsafe operations, but those are already allowed in an `unsafe fn`
 note: the lint level is defined here
-  --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:51:9
+  --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:53:9
    |
 LL | #[allow(unsafe_op_in_unsafe_fn)]
    |         ^^^^^^^^^^^^^^^^^^^^^^
 
 error: unnecessary `unsafe` block
-  --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:70:9
+  --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:72:9
    |
 LL | unsafe fn nested_allow_level() {
    | ------------------------------ because it's nested under this `unsafe` fn
@@ -108,21 +108,21 @@ LL |         unsafe { unsf() }
    |
    = note: this `unsafe` block does contain unsafe operations, but those are already allowed in an `unsafe fn`
 note: the lint level is defined here
-  --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:63:13
+  --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:65:13
    |
 LL |     #[allow(unsafe_op_in_unsafe_fn)]
    |             ^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0133]: call to unsafe function `unsf` is unsafe and requires unsafe block
-  --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:76:5
+error[E0133]: call to unsafe function is unsafe and requires unsafe block
+  --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:78:5
    |
 LL |     unsf();
    |     ^^^^^^ call to unsafe function
    |
    = note: consult the function's documentation for information on how to avoid undefined behavior
 
-error[E0133]: call to unsafe function `unsf` is unsafe and requires unsafe function or block
-  --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:80:9
+error[E0133]: call to unsafe function is unsafe and requires unsafe function or block
+  --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:83:9
    |
 LL |         unsf();
    |         ^^^^^^ call to unsafe function

--- a/src/test/ui/unsafe/rfc-2585-unsafe_op_in_unsafe_fn.rs
+++ b/src/test/ui/unsafe/rfc-2585-unsafe_op_in_unsafe_fn.rs
@@ -10,7 +10,8 @@ static mut VOID: () = ();
 
 unsafe fn deny_level() {
     unsf();
-    //~^ ERROR call to unsafe function `unsf` is unsafe and requires unsafe block
+    //[mir]~^ ERROR call to unsafe function is unsafe and requires unsafe block
+    //[thir]~^^ ERROR call to unsafe function `unsf` is unsafe and requires unsafe block
     *PTR;
     //~^ ERROR dereference of raw pointer is unsafe and requires unsafe block
     VOID = ();
@@ -25,7 +26,8 @@ unsafe fn deny_level() {
 #[deny(warnings)]
 unsafe fn warning_level() {
     unsf();
-    //~^ ERROR call to unsafe function `unsf` is unsafe and requires unsafe block
+    //[mir]~^ ERROR call to unsafe function is unsafe and requires unsafe block
+    //[thir]~^^ ERROR call to unsafe function `unsf` is unsafe and requires unsafe block
     *PTR;
     //~^ ERROR dereference of raw pointer is unsafe and requires unsafe block
     VOID = ();
@@ -74,10 +76,12 @@ unsafe fn nested_allow_level() {
 
 fn main() {
     unsf();
-    //~^ ERROR call to unsafe function `unsf` is unsafe and requires unsafe block
+    //[mir]~^ ERROR call to unsafe function is unsafe and requires unsafe block
+    //[thir]~^^ ERROR call to unsafe function `unsf` is unsafe and requires unsafe block
     #[allow(unsafe_op_in_unsafe_fn)]
     {
         unsf();
-        //~^ ERROR call to unsafe function `unsf` is unsafe and requires unsafe function or block
+        //[mir]~^ ERROR call to unsafe function is unsafe and requires unsafe function or block
+        //[thir]~^^ ERROR call to unsafe function `unsf` is unsafe and requires unsafe function or block
     }
 }

--- a/src/test/ui/unsafe/rfc-2585-unsafe_op_in_unsafe_fn.thir.stderr
+++ b/src/test/ui/unsafe/rfc-2585-unsafe_op_in_unsafe_fn.thir.stderr
@@ -12,7 +12,7 @@ LL | #![deny(unsafe_op_in_unsafe_fn)]
    = note: consult the function's documentation for information on how to avoid undefined behavior
 
 error: dereference of raw pointer is unsafe and requires unsafe block (error E0133)
-  --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:14:5
+  --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:15:5
    |
 LL |     *PTR;
    |     ^^^^ dereference of raw pointer
@@ -20,7 +20,7 @@ LL |     *PTR;
    = note: raw pointers may be null, dangling or unaligned; they can violate aliasing rules and cause data races: all of these are undefined behavior
 
 error: use of mutable static is unsafe and requires unsafe block (error E0133)
-  --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:16:5
+  --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:17:5
    |
 LL |     VOID = ();
    |     ^^^^ use of mutable static
@@ -28,7 +28,7 @@ LL |     VOID = ();
    = note: mutable statics can be mutated by multiple threads: aliasing violations or data races will cause undefined behavior
 
 error: unnecessary `unsafe` block
-  --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:19:5
+  --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:20:5
    |
 LL |     unsafe {}
    |     ^^^^^^ unnecessary `unsafe` block
@@ -40,13 +40,13 @@ LL | #![deny(unused_unsafe)]
    |         ^^^^^^^^^^^^^
 
 error: call to unsafe function `unsf` is unsafe and requires unsafe block (error E0133)
-  --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:27:5
+  --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:28:5
    |
 LL |     unsf();
    |     ^^^^^^ call to unsafe function
    |
 note: the lint level is defined here
-  --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:25:8
+  --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:26:8
    |
 LL | #[deny(warnings)]
    |        ^^^^^^^^
@@ -54,7 +54,7 @@ LL | #[deny(warnings)]
    = note: consult the function's documentation for information on how to avoid undefined behavior
 
 error: dereference of raw pointer is unsafe and requires unsafe block (error E0133)
-  --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:29:5
+  --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:31:5
    |
 LL |     *PTR;
    |     ^^^^ dereference of raw pointer
@@ -62,7 +62,7 @@ LL |     *PTR;
    = note: raw pointers may be null, dangling or unaligned; they can violate aliasing rules and cause data races: all of these are undefined behavior
 
 error: use of mutable static is unsafe and requires unsafe block (error E0133)
-  --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:31:5
+  --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:33:5
    |
 LL |     VOID = ();
    |     ^^^^ use of mutable static
@@ -70,13 +70,13 @@ LL |     VOID = ();
    = note: mutable statics can be mutated by multiple threads: aliasing violations or data races will cause undefined behavior
 
 error: unnecessary `unsafe` block
-  --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:33:5
+  --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:35:5
    |
 LL |     unsafe {}
    |     ^^^^^^ unnecessary `unsafe` block
 
 error: unnecessary `unsafe` block
-  --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:47:14
+  --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:49:14
    |
 LL |     unsafe { unsafe { unsf() } }
    |     ------   ^^^^^^ unnecessary `unsafe` block
@@ -84,7 +84,7 @@ LL |     unsafe { unsafe { unsf() } }
    |     because it's nested under this `unsafe` block
 
 error: unnecessary `unsafe` block
-  --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:58:5
+  --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:60:5
    |
 LL | unsafe fn allow_level() {
    | ----------------------- because it's nested under this `unsafe` fn
@@ -93,7 +93,7 @@ LL |     unsafe { unsf() }
    |     ^^^^^^ unnecessary `unsafe` block
 
 error: unnecessary `unsafe` block
-  --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:70:9
+  --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:72:9
    |
 LL | unsafe fn nested_allow_level() {
    | ------------------------------ because it's nested under this `unsafe` fn
@@ -102,7 +102,7 @@ LL |         unsafe { unsf() }
    |         ^^^^^^ unnecessary `unsafe` block
 
 error[E0133]: call to unsafe function `unsf` is unsafe and requires unsafe block
-  --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:76:5
+  --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:78:5
    |
 LL |     unsf();
    |     ^^^^^^ call to unsafe function
@@ -110,7 +110,7 @@ LL |     unsf();
    = note: consult the function's documentation for information on how to avoid undefined behavior
 
 error[E0133]: call to unsafe function `unsf` is unsafe and requires unsafe function or block
-  --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:80:9
+  --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:83:9
    |
 LL |         unsf();
    |         ^^^^^^ call to unsafe function

--- a/src/test/ui/unsafe/unsafe-const-fn.mir.stderr
+++ b/src/test/ui/unsafe/unsafe-const-fn.mir.stderr
@@ -1,4 +1,4 @@
-error[E0133]: call to unsafe function `dummy` is unsafe and requires unsafe function or block
+error[E0133]: call to unsafe function is unsafe and requires unsafe function or block
   --> $DIR/unsafe-const-fn.rs:10:18
    |
 LL | const VAL: u32 = dummy(0xFFFF);

--- a/src/test/ui/unsafe/unsafe-fn-called-from-safe.mir.stderr
+++ b/src/test/ui/unsafe/unsafe-fn-called-from-safe.mir.stderr
@@ -1,4 +1,4 @@
-error[E0133]: call to unsafe function `f` is unsafe and requires unsafe function or block
+error[E0133]: call to unsafe function is unsafe and requires unsafe function or block
   --> $DIR/unsafe-fn-called-from-safe.rs:7:5
    |
 LL |     f();

--- a/src/test/ui/unsafe/unsafe-fn-called-from-safe.rs
+++ b/src/test/ui/unsafe/unsafe-fn-called-from-safe.rs
@@ -4,5 +4,7 @@
 unsafe fn f() { return; }
 
 fn main() {
-    f(); //~ ERROR call to unsafe function `f` is unsafe
+    f();
+    //[mir]~^ ERROR call to unsafe function is unsafe
+    //[thir]~^^ ERROR call to unsafe function `f` is unsafe
 }

--- a/src/test/ui/unsafe/unsafe-fn-used-as-value.mir.stderr
+++ b/src/test/ui/unsafe/unsafe-fn-used-as-value.mir.stderr
@@ -1,4 +1,4 @@
-error[E0133]: call to unsafe function `f` is unsafe and requires unsafe function or block
+error[E0133]: call to unsafe function is unsafe and requires unsafe function or block
   --> $DIR/unsafe-fn-used-as-value.rs:8:5
    |
 LL |     x();

--- a/src/test/ui/unsafe/unsafe-fn-used-as-value.rs
+++ b/src/test/ui/unsafe/unsafe-fn-used-as-value.rs
@@ -5,5 +5,7 @@ unsafe fn f() { return; }
 
 fn main() {
     let x = f;
-    x(); //~ ERROR call to unsafe function `f` is unsafe
+    x();
+    //[mir]~^ ERROR call to unsafe function is unsafe
+    //[thir]~^^ ERROR call to unsafe function `f` is unsafe
 }


### PR DESCRIPTION
Perf regression introduced in #96294

We will simply avoid emitting the name of the unsafe function in MIR unsafeck, since we're moving to THIR unsafeck anyway.