### PR TITLE
Fix handling of `!` in rustdoc search

### DIFF
--- a/src/test/rustdoc-js-std/parser-errors.js
+++ b/src/test/rustdoc-js-std/parser-errors.js
@@ -35,6 +35,8 @@ const QUERY = [
     "a,:",
     "  a<>  :",
     "mod : :",
+    "a!a",
+    "a!!",
 ];
 
 const PARSED = [
@@ -361,5 +363,23 @@ const PARSED = [
         typeFilter: -1,
         userQuery: "mod : :",
         error: 'Unexpected `:`',
+    },
+    {
+        elems: [],
+        foundElems: 0,
+        original: "a!a",
+        returned: [],
+        typeFilter: -1,
+        userQuery: "a!a",
+        error: '`!` can only be at the end of an ident',
+    },
+    {
+        elems: [],
+        foundElems: 0,
+        original: "a!!",
+        returned: [],
+        typeFilter: -1,
+        userQuery: "a!!",
+        error: 'Cannot have more than one `!` in an ident',
     },
 ];

--- a/src/test/rustdoc-js-std/parser-ident.js
+++ b/src/test/rustdoc-js-std/parser-ident.js
@@ -1,0 +1,93 @@
+const QUERY = [
+    "R<!>",
+    "!",
+    "a!",
+    "a!::b",
+    "a!::b!",
+];
+
+const PARSED = [
+    {
+        elems: [{
+            name: "r",
+            fullPath: ["r"],
+            pathWithoutLast: [],
+            pathLast: "r",
+            generics: [
+                {
+                    name: "!",
+                    fullPath: ["!"],
+                    pathWithoutLast: [],
+                    pathLast: "!",
+                    generics: [],
+                },
+            ],
+        }],
+        foundElems: 1,
+        original: "R<!>",
+        returned: [],
+        typeFilter: -1,
+        userQuery: "r<!>",
+        error: null,
+    },
+    {
+        elems: [{
+            name: "!",
+            fullPath: ["!"],
+            pathWithoutLast: [],
+            pathLast: "!",
+            generics: [],
+        }],
+        foundElems: 1,
+        original: "!",
+        returned: [],
+        typeFilter: -1,
+        userQuery: "!",
+        error: null,
+    },
+    {
+        elems: [{
+            name: "a!",
+            fullPath: ["a!"],
+            pathWithoutLast: [],
+            pathLast: "a!",
+            generics: [],
+        }],
+        foundElems: 1,
+        original: "a!",
+        returned: [],
+        typeFilter: -1,
+        userQuery: "a!",
+        error: null,
+    },
+    {
+        elems: [{
+            name: "a!::b",
+            fullPath: ["a!", "b"],
+            pathWithoutLast: ["a!"],
+            pathLast: "b",
+            generics: [],
+        }],
+        foundElems: 1,
+        original: "a!::b",
+        returned: [],
+        typeFilter: -1,
+        userQuery: "a!::b",
+        error: null,
+    },
+    {
+        elems: [{
+            name: "a!::b!",
+            fullPath: ["a!", "b!"],
+            pathWithoutLast: ["a!"],
+            pathLast: "b!",
+            generics: [],
+        }],
+        foundElems: 1,
+        original: "a!::b!",
+        returned: [],
+        typeFilter: -1,
+        userQuery: "a!::b!",
+        error: null,
+    },
+];

--- a/src/test/rustdoc-js-std/parser-returned.js
+++ b/src/test/rustdoc-js-std/parser-returned.js
@@ -1,4 +1,10 @@
-const QUERY = ['-> F<P>', '-> P', '->,a', 'aaaaa->a'];
+const QUERY = [
+    "-> F<P>",
+    "-> P",
+    "->,a",
+    "aaaaa->a",
+    "-> !",
+];
 
 const PARSED = [
     {
@@ -73,6 +79,21 @@ const PARSED = [
         }],
         typeFilter: -1,
         userQuery: "aaaaa->a",
+        error: null,
+    },
+    {
+        elems: [],
+        foundElems: 1,
+        original: "-> !",
+        returned: [{
+            name: "!",
+            fullPath: ["!"],
+            pathWithoutLast: [],
+            pathLast: "!",
+            generics: [],
+        }],
+        typeFilter: -1,
+        userQuery: "-> !",
         error: null,
     },
 ];


### PR DESCRIPTION
Fixes #96399.

I also updated the eBNF.

cc @jsha 
r? @notriddle 