### PR TITLE
Windows: Make stdin pipes synchronous

### DIFF
--- a/library/std/src/os/windows/io/handle.rs
+++ b/library/std/src/os/windows/io/handle.rs
@@ -198,6 +198,18 @@ impl OwnedHandle {
         })?;
         unsafe { Ok(Self::from_raw_handle(ret)) }
     }
+
+    /// Allow child processes to inherit the handle.
+    pub(crate) fn set_inheritable(&self) -> io::Result<()> {
+        cvt(unsafe {
+            c::SetHandleInformation(
+                self.as_raw_handle(),
+                c::HANDLE_FLAG_INHERIT,
+                c::HANDLE_FLAG_INHERIT,
+            )
+        })?;
+        Ok(())
+    }
 }
 
 impl TryFrom<HandleOrInvalid> for OwnedHandle {

--- a/library/std/src/sys/windows/c.rs
+++ b/library/std/src/sys/windows/c.rs
@@ -1022,6 +1022,12 @@ extern "system" {
         bWaitAll: BOOL,
         dwMilliseconds: DWORD,
     ) -> DWORD;
+    pub fn CreatePipe(
+        hReadPipe: *mut HANDLE,
+        hWritePipe: *mut HANDLE,
+        lpPipeAttributes: *const SECURITY_ATTRIBUTES,
+        nSize: DWORD,
+    ) -> BOOL;
     pub fn CreateNamedPipeW(
         lpName: LPCWSTR,
         dwOpenMode: DWORD,

--- a/library/std/src/sys/windows/handle.rs
+++ b/library/std/src/sys/windows/handle.rs
@@ -221,6 +221,10 @@ impl Handle {
         Ok(Self(self.0.duplicate(access, inherit, options)?))
     }
 
+    pub(crate) fn set_inheritable(&self) -> io::Result<()> {
+        self.0.set_inheritable()
+    }
+
     /// Performs a synchronous read.
     ///
     /// If the handle is opened for asynchronous I/O then this abort the process.


### PR DESCRIPTION
Stdin pipes do not need to be used asynchronously within the standard library. This is a first step in making pipes mostly synchronous. 

r? @m-ou-se 