### PR TITLE
Special case inference around `AsRef<Vec<T>>` to support existing code without reverting #95098

### DIFF
--- a/src/test/ui/inference/vec-from-array-ref-impl.rs
+++ b/src/test/ui/inference/vec-from-array-ref-impl.rs
@@ -1,0 +1,14 @@
+// check-pass
+
+#[derive(Clone)]
+struct Constraint;
+
+fn constraints<C>(constraints: C)
+where C: Into<Vec<Constraint>>
+{
+    let _: Vec<Constraint> = constraints.into();
+}
+
+fn main() {
+    constraints(vec![Constraint].as_ref());
+}


### PR DESCRIPTION
 #95098 introduces new `From` impls for `Vec`, which can break existing
 code that relies on inference when calling `.as_ref()`. This change
 explicitly carves out a bias in the inference machinery to keep
 existing code compiling, while still maintaining the new `From` impls.

 Reported in #96074.