### PR TITLE
rustdoc: Resolve doc links on fields during early resolution

### DIFF
--- a/src/librustdoc/passes/collect_intra_doc_links/early.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links/early.rs
@@ -260,9 +260,21 @@ impl EarlyDocLinkResolver<'_, '_> {
                     if let Res::Def(DefKind::Mod, ..) = child.res {
                         self.resolve_doc_links_extern_inner(def_id); // Inner attribute scope
                     }
-                    // Traits are processed in `add_extern_traits_in_scope`.
+                    // `DefKind::Trait`s are processed in `process_extern_impls`.
                     if let Res::Def(DefKind::Mod | DefKind::Enum, ..) = child.res {
                         self.process_module_children_or_reexports(def_id);
+                    }
+                    if let Res::Def(DefKind::Struct | DefKind::Union | DefKind::Variant, _) =
+                        child.res
+                    {
+                        let field_def_ids = Vec::from_iter(
+                            self.resolver
+                                .cstore()
+                                .associated_item_def_ids_untracked(def_id, self.sess),
+                        );
+                        for field_def_id in field_def_ids {
+                            self.resolve_doc_links_extern_outer(field_def_id, scope_id);
+                        }
                     }
                 }
             }

--- a/src/test/rustdoc-ui/intra-doc/assoc-field.rs
+++ b/src/test/rustdoc-ui/intra-doc/assoc-field.rs
@@ -1,0 +1,26 @@
+// Traits in scope are collected for doc links in field attributes.
+
+// check-pass
+// aux-build: assoc-field-dep.rs
+
+extern crate assoc_field_dep;
+pub use assoc_field_dep::*;
+
+#[derive(Clone)]
+pub struct Struct;
+
+pub mod mod1 {
+    pub struct Fields {
+        /// [crate::Struct::clone]
+        pub field: u8,
+    }
+}
+
+pub mod mod2 {
+    pub enum Fields {
+        V {
+            /// [crate::Struct::clone]
+            field: u8,
+        },
+    }
+}

--- a/src/test/rustdoc-ui/intra-doc/auxiliary/assoc-field-dep.rs
+++ b/src/test/rustdoc-ui/intra-doc/auxiliary/assoc-field-dep.rs
@@ -1,0 +1,18 @@
+#[derive(Clone)]
+pub struct Struct;
+
+pub mod dep_mod1 {
+    pub struct Fields {
+        /// [crate::Struct::clone]
+        pub field: u8,
+    }
+}
+
+pub mod dep_mod2 {
+    pub enum Fields {
+        V {
+            /// [crate::Struct::clone]
+            field: u8,
+        },
+    }
+}


### PR DESCRIPTION
Another subset of https://github.com/rust-lang/rust/pull/94857 which fixes https://github.com/rust-lang/rust/issues/96429.

This case regressed in https://github.com/rust-lang/rust/pull/96135 when `may_have_doc_links`-based filtering was introduced.
Before that filtering structs could collect traits in scope for their fields, but after the filtering structs won't collect anything if they don't have doc comments on them, so we have to visit fields too.