### PR TITLE
DONOTLAND (perf-only): Disable potentially unsound int2ptr/ptr2int optimizations

### DIFF
--- a/compiler/rustc_codegen_llvm/src/llvm_util.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm_util.rs
@@ -120,6 +120,9 @@ unsafe fn configure_llvm(sess: &Session) {
         // Use non-zero `import-instr-limit` multiplier for cold callsites.
         add("-import-cold-multiplier=0.1", false);
 
+        // DONOTLAND: just testing the perf impact of this.
+        add("-disable-i2p-p2i-opt", false);
+
         for arg in sess_args {
             add(&(*arg), true);
         }


### PR DESCRIPTION
See https://rust-lang.zulipchat.com/#narrow/stream/187780-t-compiler.2Fwg-llvm/topic/Set.20flags.20to.20control.20pointer.20provenance.20related.20optimization for justification here. We'd like to measure the performance impact of this for various reasons, one of which being that it would be useful information for upstream.

r? @ghost