### PR TITLE
Update data layout string for wasm64-unknown-unknown

### DIFF
--- a/compiler/rustc_target/src/spec/wasm64_unknown_unknown.rs
+++ b/compiler/rustc_target/src/spec/wasm64_unknown_unknown.rs
@@ -36,7 +36,7 @@ pub fn target() -> Target {
     Target {
         llvm_target: "wasm64-unknown-unknown".into(),
         pointer_width: 64,
-        data_layout: "e-m:e-p:64:64-i64:64-n32:64-S128-ni:1:10:20".into(),
+        data_layout: "e-m:e-p:64:64-p10:8:8-p20:8:8-i64:64-n32:64-S128-ni:1:10:20".into(),
         arch: "wasm64".into(),
         options,
     }


### PR DESCRIPTION
Looks like this changed in a recent LLVM update but wasm64 isn't built
on CI so it wasn't caught until now.

Closes #96463