### PR TITLE
Implement `#[rustc_default_body_unstable]`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4616,6 +4616,7 @@ dependencies = [
  "rustc_attr",
  "rustc_data_structures",
  "rustc_errors",
+ "rustc_feature",
  "rustc_graphviz",
  "rustc_hir",
  "rustc_hir_pretty",

--- a/compiler/rustc_ast_passes/src/feature_gate.rs
+++ b/compiler/rustc_ast_passes/src/feature_gate.rs
@@ -417,6 +417,7 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
                 || attr.has_name(sym::stable)
                 || attr.has_name(sym::rustc_const_unstable)
                 || attr.has_name(sym::rustc_const_stable)
+                || attr.has_name(sym::rustc_default_body_unstable)
             {
                 struct_span_err!(
                     self.sess,

--- a/compiler/rustc_attr/src/builtin.rs
+++ b/compiler/rustc_attr/src/builtin.rs
@@ -428,9 +428,11 @@ where
                                     ConstStability { level, feature, promotable: false },
                                     attr.span,
                                 ));
-                            } else {
+                            } else if sym::rustc_default_body_unstable == meta_name {
                                 body_stab =
                                     Some((DefaultBodyStability { level, feature }, attr.span));
+                            } else {
+                                unreachable!("Unknown stability attribute {meta_name}");
                             }
                         }
                         (None, _, _) => {

--- a/compiler/rustc_attr/src/builtin.rs
+++ b/compiler/rustc_attr/src/builtin.rs
@@ -131,6 +131,14 @@ impl ConstStability {
     }
 }
 
+/// Represents the `#[rustc_default_body_unstable]` attribute.
+#[derive(Encodable, Decodable, Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(HashStable_Generic)]
+pub struct DefaultBodyStability {
+    pub level: StabilityLevel,
+    pub feature: Symbol,
+}
+
 /// The available stability levels.
 #[derive(Encodable, Decodable, PartialEq, Copy, Clone, Debug, Eq, Hash)]
 #[derive(HashStable_Generic)]
@@ -214,7 +222,8 @@ pub fn find_stability(
     sess: &Session,
     attrs: &[Attribute],
     item_sp: Span,
-) -> (Option<(Stability, Span)>, Option<(ConstStability, Span)>) {
+) -> (Option<(Stability, Span)>, Option<(ConstStability, Span)>, Option<(DefaultBodyStability, Span)>)
+{
     find_stability_generic(sess, attrs.iter(), item_sp)
 }
 
@@ -222,7 +231,7 @@ fn find_stability_generic<'a, I>(
     sess: &Session,
     attrs_iter: I,
     item_sp: Span,
-) -> (Option<(Stability, Span)>, Option<(ConstStability, Span)>)
+) -> (Option<(Stability, Span)>, Option<(ConstStability, Span)>, Option<(DefaultBodyStability, Span)>)
 where
     I: Iterator<Item = &'a Attribute>,
 {
@@ -230,6 +239,7 @@ where
 
     let mut stab: Option<(Stability, Span)> = None;
     let mut const_stab: Option<(ConstStability, Span)> = None;
+    let mut body_stab: Option<(DefaultBodyStability, Span)> = None;
     let mut promotable = false;
     let mut allowed_through_unstable_modules = false;
 
@@ -243,6 +253,7 @@ where
             sym::stable,
             sym::rustc_promotable,
             sym::rustc_allowed_through_unstable_modules,
+            sym::rustc_default_body_unstable,
         ]
         .iter()
         .any(|&s| attr.has_name(s))
@@ -280,7 +291,7 @@ where
 
             let meta_name = meta.name_or_empty();
             match meta_name {
-                sym::rustc_const_unstable | sym::unstable => {
+                sym::rustc_const_unstable | sym::rustc_default_body_unstable | sym::unstable => {
                     if meta_name == sym::unstable && stab.is_some() {
                         handle_errors(
                             &sess.parse_sess,
@@ -289,6 +300,13 @@ where
                         );
                         break;
                     } else if meta_name == sym::rustc_const_unstable && const_stab.is_some() {
+                        handle_errors(
+                            &sess.parse_sess,
+                            attr.span,
+                            AttrError::MultipleStabilityLevels,
+                        );
+                        break;
+                    } else if meta_name == sym::rustc_default_body_unstable && body_stab.is_some() {
                         handle_errors(
                             &sess.parse_sess,
                             attr.span,
@@ -405,11 +423,14 @@ where
                             };
                             if sym::unstable == meta_name {
                                 stab = Some((Stability { level, feature }, attr.span));
-                            } else {
+                            } else if sym::rustc_const_unstable == meta_name {
                                 const_stab = Some((
                                     ConstStability { level, feature, promotable: false },
                                     attr.span,
                                 ));
+                            } else {
+                                body_stab =
+                                    Some((DefaultBodyStability { level, feature }, attr.span));
                             }
                         }
                         (None, _, _) => {
@@ -542,7 +563,7 @@ where
         }
     }
 
-    (stab, const_stab)
+    (stab, const_stab, body_stab)
 }
 
 pub fn find_crate_name(sess: &Session, attrs: &[Attribute]) -> Option<Symbol> {

--- a/compiler/rustc_expand/src/base.rs
+++ b/compiler/rustc_expand/src/base.rs
@@ -772,7 +772,7 @@ impl SyntaxExtension {
                 )
             })
             .unwrap_or_else(|| (None, helper_attrs));
-        let (stability, const_stability) = attr::find_stability(&sess, attrs, span);
+        let (stability, const_stability, body_stability) = attr::find_stability(&sess, attrs, span);
         if let Some((_, sp)) = const_stability {
             sess.parse_sess
                 .span_diagnostic
@@ -781,6 +781,17 @@ impl SyntaxExtension {
                 .span_label(
                     sess.source_map().guess_head_span(span),
                     "const stability attribute affects this macro",
+                )
+                .emit();
+        }
+        if let Some((_, sp)) = body_stability {
+            sess.parse_sess
+                .span_diagnostic
+                .struct_span_err(sp, "macros cannot have body stability attributes")
+                .span_label(sp, "invalid body stability attribute")
+                .span_label(
+                    sess.source_map().guess_head_span(span),
+                    "body stability attribute affects this macro",
                 )
                 .emit();
         }

--- a/compiler/rustc_feature/src/builtin_attrs.rs
+++ b/compiler/rustc_feature/src/builtin_attrs.rs
@@ -499,6 +499,10 @@ pub const BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     ),
     ungated!(rustc_const_unstable, Normal, template!(List: r#"feature = "name""#), DuplicatesOk),
     ungated!(rustc_const_stable, Normal, template!(List: r#"feature = "name""#), DuplicatesOk),
+    ungated!(
+        rustc_default_body_unstable, Normal,
+        template!(List: r#"feature = "name", reason = "...", issue = "N""#), DuplicatesOk
+    ),
     gated!(
         allow_internal_unstable, Normal, template!(Word, List: "feat1, feat2, ..."), DuplicatesOk,
         "allow_internal_unstable side-steps feature gating and stability checks",

--- a/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
@@ -207,6 +207,7 @@ provide! { <'tcx> tcx, def_id, other, cdata,
     def_ident_span => { table }
     lookup_stability => { table }
     lookup_const_stability => { table }
+    lookup_default_body_stability => { table }
     lookup_deprecation_entry => { table }
     visibility => { table }
     unused_generic_params => { table }

--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -1029,6 +1029,7 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
             if should_encode_stability(def_kind) {
                 self.encode_stability(def_id);
                 self.encode_const_stability(def_id);
+                self.encode_default_body_stability(def_id);
                 self.encode_deprecation(def_id);
             }
             if should_encode_variances(def_kind) {
@@ -1393,6 +1394,18 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
         if self.feat.staged_api || self.tcx.sess.opts.unstable_opts.force_unstable_if_unmarked {
             if let Some(stab) = self.tcx.lookup_const_stability(def_id) {
                 record!(self.tables.lookup_const_stability[def_id] <- stab)
+            }
+        }
+    }
+
+    fn encode_default_body_stability(&mut self, def_id: DefId) {
+        debug!("EncodeContext::encode_default_body_stability({:?})", def_id);
+
+        // The query lookup can take a measurable amount of time in crates with many items. Check if
+        // the stability attributes are even enabled before using their queries.
+        if self.feat.staged_api || self.tcx.sess.opts.unstable_opts.force_unstable_if_unmarked {
+            if let Some(stab) = self.tcx.lookup_default_body_stability(def_id) {
+                record!(self.tables.lookup_default_body_stability[def_id] <- stab)
             }
         }
     }

--- a/compiler/rustc_metadata/src/rmeta/mod.rs
+++ b/compiler/rustc_metadata/src/rmeta/mod.rs
@@ -343,6 +343,7 @@ define_tables! {
     def_ident_span: Table<DefIndex, LazyValue<Span>>,
     lookup_stability: Table<DefIndex, LazyValue<attr::Stability>>,
     lookup_const_stability: Table<DefIndex, LazyValue<attr::ConstStability>>,
+    lookup_default_body_stability: Table<DefIndex, LazyValue<attr::DefaultBodyStability>>,
     lookup_deprecation_entry: Table<DefIndex, LazyValue<attr::Deprecation>>,
     // As an optimization, a missing entry indicates an empty `&[]`.
     explicit_item_bounds: Table<DefIndex, LazyArray<(ty::Predicate<'static>, Span)>>,

--- a/compiler/rustc_middle/src/middle/stability.rs
+++ b/compiler/rustc_middle/src/middle/stability.rs
@@ -537,7 +537,6 @@ impl<'tcx> TyCtxt<'tcx> {
                     return EvalResult::Allow;
                 }
 
-                //let suggestion = suggestion_for_allocator_api(self, def_id, span, feature);
                 EvalResult::Deny {
                     feature,
                     reason: reason.to_opt_reason(),

--- a/compiler/rustc_middle/src/middle/stability.rs
+++ b/compiler/rustc_middle/src/middle/stability.rs
@@ -421,18 +421,18 @@ impl<'tcx> TyCtxt<'tcx> {
             return EvalResult::Allow;
         }
 
+        // Only the cross-crate scenario matters when checking unstable APIs
+        let cross_crate = !def_id.is_local();
+        if !cross_crate {
+            return EvalResult::Allow;
+        }
+
         let stability = self.lookup_stability(def_id);
         debug!(
             "stability: \
                 inspecting def_id={:?} span={:?} of stability={:?}",
             def_id, span, stability
         );
-
-        // Only the cross-crate scenario matters when checking unstable APIs
-        let cross_crate = !def_id.is_local();
-        if !cross_crate {
-            return EvalResult::Allow;
-        }
 
         // Issue #38412: private items lack stability markers.
         if skip_stability_check_due_to_privacy(self, def_id) {
@@ -508,16 +508,16 @@ impl<'tcx> TyCtxt<'tcx> {
             return EvalResult::Allow;
         }
 
-        let stability = self.lookup_default_body_stability(def_id);
-        debug!(
-            "body stability: inspecting def_id={def_id:?} span={span:?} of stability={stability:?}"
-        );
-
         // Only the cross-crate scenario matters when checking unstable APIs
         let cross_crate = !def_id.is_local();
         if !cross_crate {
             return EvalResult::Allow;
         }
+
+        let stability = self.lookup_default_body_stability(def_id);
+        debug!(
+            "body stability: inspecting def_id={def_id:?} span={span:?} of stability={stability:?}"
+        );
 
         // Issue #38412: private items lack stability markers.
         if skip_stability_check_due_to_privacy(self, def_id) {

--- a/compiler/rustc_middle/src/middle/stability.rs
+++ b/compiler/rustc_middle/src/middle/stability.rs
@@ -5,7 +5,7 @@ pub use self::StabilityLevel::*;
 
 use crate::ty::{self, DefIdTree, TyCtxt};
 use rustc_ast::NodeId;
-use rustc_attr::{self as attr, ConstStability, Deprecation, Stability};
+use rustc_attr::{self as attr, ConstStability, DefaultBodyStability, Deprecation, Stability};
 use rustc_data_structures::fx::FxHashMap;
 use rustc_errors::{Applicability, Diagnostic};
 use rustc_feature::GateIssue;
@@ -61,6 +61,7 @@ pub struct Index {
     /// are filled by the annotator.
     pub stab_map: FxHashMap<LocalDefId, Stability>,
     pub const_stab_map: FxHashMap<LocalDefId, ConstStability>,
+    pub default_body_stab_map: FxHashMap<LocalDefId, DefaultBodyStability>,
     pub depr_map: FxHashMap<LocalDefId, DeprecationEntry>,
     /// Mapping from feature name to feature name based on the `implied_by` field of `#[unstable]`
     /// attributes. If a `#[unstable(feature = "implier", implied_by = "impliee")]` attribute
@@ -84,6 +85,10 @@ impl Index {
 
     pub fn local_const_stability(&self, def_id: LocalDefId) -> Option<ConstStability> {
         self.const_stab_map.get(&def_id).copied()
+    }
+
+    pub fn local_default_body_stability(&self, def_id: LocalDefId) -> Option<DefaultBodyStability> {
+        self.default_body_stab_map.get(&def_id).copied()
     }
 
     pub fn local_deprecation_entry(&self, def_id: LocalDefId) -> Option<DeprecationEntry> {
@@ -486,6 +491,63 @@ impl<'tcx> TyCtxt<'tcx> {
             Some(_) => {
                 // Stable APIs are always ok to call and deprecated APIs are
                 // handled by the lint emitting logic above.
+                EvalResult::Allow
+            }
+            None => EvalResult::Unmarked,
+        }
+    }
+
+    /// Evaluates the default-impl stability of an item.
+    ///
+    /// Returns `EvalResult::Allow` if the item's default implementation is stable, or unstable but the corresponding
+    /// `#![feature]` has been provided. Returns `EvalResult::Deny` which describes the offending
+    /// unstable feature otherwise.
+    pub fn eval_default_body_stability(self, def_id: DefId, span: Span) -> EvalResult {
+        let is_staged_api = self.lookup_stability(def_id.krate.as_def_id()).is_some();
+        if !is_staged_api {
+            return EvalResult::Allow;
+        }
+
+        let stability = self.lookup_default_body_stability(def_id);
+        debug!(
+            "body stability: inspecting def_id={def_id:?} span={span:?} of stability={stability:?}"
+        );
+
+        // Only the cross-crate scenario matters when checking unstable APIs
+        let cross_crate = !def_id.is_local();
+        if !cross_crate {
+            return EvalResult::Allow;
+        }
+
+        // Issue #38412: private items lack stability markers.
+        if skip_stability_check_due_to_privacy(self, def_id) {
+            return EvalResult::Allow;
+        }
+
+        match stability {
+            Some(DefaultBodyStability {
+                level: attr::Unstable { reason, issue, is_soft, .. },
+                feature,
+            }) => {
+                if span.allows_unstable(feature) {
+                    debug!("body stability: skipping span={:?} since it is internal", span);
+                    return EvalResult::Allow;
+                }
+                if self.features().active(feature) {
+                    return EvalResult::Allow;
+                }
+
+                //let suggestion = suggestion_for_allocator_api(self, def_id, span, feature);
+                EvalResult::Deny {
+                    feature,
+                    reason: reason.to_opt_reason(),
+                    issue,
+                    suggestion: None,
+                    is_soft,
+                }
+            }
+            Some(_) => {
+                // Stable APIs are always ok to call
                 EvalResult::Allow
             }
             None => EvalResult::Unmarked,

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -1094,6 +1094,11 @@ rustc_queries! {
         separate_provide_extern
     }
 
+    query lookup_default_body_stability(def_id: DefId) -> Option<attr::DefaultBodyStability> {
+        desc { |tcx| "looking up default body stability of `{}`", tcx.def_path_str(def_id) }
+        separate_provide_extern
+    }
+
     query should_inherit_track_caller(def_id: DefId) -> bool {
         desc { |tcx| "computing should_inherit_track_caller of `{}`", tcx.def_path_str(def_id) }
     }

--- a/compiler/rustc_middle/src/ty/parameterized.rs
+++ b/compiler/rustc_middle/src/ty/parameterized.rs
@@ -64,6 +64,7 @@ trivially_parameterized_over_tcx! {
     rustc_ast::Attribute,
     rustc_ast::MacArgs,
     rustc_attr::ConstStability,
+    rustc_attr::DefaultBodyStability,
     rustc_attr::Deprecation,
     rustc_attr::Stability,
     rustc_hir::Constness,

--- a/compiler/rustc_passes/src/lib_features.rs
+++ b/compiler/rustc_passes/src/lib_features.rs
@@ -29,11 +29,16 @@ impl<'tcx> LibFeatureCollector<'tcx> {
     }
 
     fn extract(&self, attr: &Attribute) -> Option<(Symbol, Option<Symbol>, Span)> {
-        let stab_attrs =
-            [sym::stable, sym::unstable, sym::rustc_const_stable, sym::rustc_const_unstable];
+        let stab_attrs = [
+            sym::stable,
+            sym::unstable,
+            sym::rustc_const_stable,
+            sym::rustc_const_unstable,
+            sym::rustc_default_body_unstable,
+        ];
 
         // Find a stability attribute: one of #[stable(…)], #[unstable(…)],
-        // #[rustc_const_stable(…)], or #[rustc_const_unstable(…)].
+        // #[rustc_const_stable(…)], #[rustc_const_unstable(…)] or #[rustc_default_body_unstable].
         if let Some(stab_attr) = stab_attrs.iter().find(|stab_attr| attr.has_name(**stab_attr)) {
             let meta_kind = attr.meta_kind();
             if let Some(MetaItemKind::List(ref metas)) = meta_kind {
@@ -53,8 +58,12 @@ impl<'tcx> LibFeatureCollector<'tcx> {
                     // This additional check for stability is to make sure we
                     // don't emit additional, irrelevant errors for malformed
                     // attributes.
-                    let is_unstable =
-                        matches!(*stab_attr, sym::unstable | sym::rustc_const_unstable);
+                    let is_unstable = matches!(
+                        *stab_attr,
+                        sym::unstable
+                            | sym::rustc_const_unstable
+                            | sym::rustc_default_body_unstable
+                    );
                     if since.is_some() || is_unstable {
                         return Some((feature, since, attr.span));
                     }

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1215,6 +1215,7 @@ symbols! {
         rustc_const_unstable,
         rustc_conversion_suggestion,
         rustc_def_path,
+        rustc_default_body_unstable,
         rustc_diagnostic_item,
         rustc_diagnostic_macros,
         rustc_dirty,

--- a/compiler/rustc_typeck/Cargo.toml
+++ b/compiler/rustc_typeck/Cargo.toml
@@ -30,3 +30,4 @@ rustc_ty_utils = { path = "../rustc_ty_utils" }
 rustc_lint = { path = "../rustc_lint" }
 rustc_serialize = { path = "../rustc_serialize" }
 rustc_type_ir = { path = "../rustc_type_ir" }
+rustc_feature = { path = "../rustc_feature" }

--- a/compiler/rustc_typeck/src/check/check.rs
+++ b/compiler/rustc_typeck/src/check/check.rs
@@ -1112,17 +1112,14 @@ fn check_impl_items_against_trait<'tcx>(
 
             if !is_implemented_here {
                 match tcx.eval_default_body_stability(trait_item_id, full_impl_span) {
-                    EvalResult::Deny { feature, reason, issue, is_soft, .. } => {
-                        default_body_is_unstable(
-                            tcx,
-                            full_impl_span,
-                            trait_item_id,
-                            feature,
-                            reason,
-                            issue,
-                            is_soft,
-                        )
-                    }
+                    EvalResult::Deny { feature, reason, issue, .. } => default_body_is_unstable(
+                        tcx,
+                        full_impl_span,
+                        trait_item_id,
+                        feature,
+                        reason,
+                        issue,
+                    ),
 
                     // Unmarked default bodies are considered stable (at least for now).
                     EvalResult::Allow | EvalResult::Unmarked => {}

--- a/compiler/rustc_typeck/src/check/check.rs
+++ b/compiler/rustc_typeck/src/check/check.rs
@@ -18,6 +18,7 @@ use rustc_infer::infer::{DefiningAnchor, RegionVariableOrigin, TyCtxtInferExt};
 use rustc_infer::traits::Obligation;
 use rustc_lint::builtin::REPR_TRANSPARENT_EXTERNAL_PRIVATE_FIELDS;
 use rustc_middle::hir::nested_filter;
+use rustc_middle::middle::stability::EvalResult;
 use rustc_middle::ty::layout::{LayoutError, MAX_SIMD_LANES};
 use rustc_middle::ty::subst::GenericArgKind;
 use rustc_middle::ty::util::{Discr, IntTypeExt};
@@ -1104,12 +1105,31 @@ fn check_impl_items_against_trait<'tcx>(
                 missing_items.push(tcx.associated_item(trait_item_id));
             }
 
-            if let Some(required_items) = &must_implement_one_of {
-                // true if this item is specifically implemented in this impl
-                let is_implemented_here = ancestors
-                    .leaf_def(tcx, trait_item_id)
-                    .map_or(false, |node_item| !node_item.defining_node.is_from_trait());
+            // true if this item is specifically implemented in this impl
+            let is_implemented_here = ancestors
+                .leaf_def(tcx, trait_item_id)
+                .map_or(false, |node_item| !node_item.defining_node.is_from_trait());
 
+            if !is_implemented_here {
+                match tcx.eval_default_body_stability(trait_item_id, full_impl_span) {
+                    EvalResult::Deny { feature, reason, issue, is_soft, .. } => {
+                        default_body_is_unstable(
+                            tcx,
+                            full_impl_span,
+                            trait_item_id,
+                            feature,
+                            reason,
+                            issue,
+                            is_soft,
+                        )
+                    }
+
+                    // Unmarked default bodies are considered stable (at least for now).
+                    EvalResult::Allow | EvalResult::Unmarked => {}
+                }
+            }
+
+            if let Some(required_items) = &must_implement_one_of {
                 if is_implemented_here {
                     let trait_item = tcx.associated_item(trait_item_id);
                     if required_items.contains(&trait_item.ident(tcx)) {

--- a/src/test/ui/stability-attribute/auxiliary/default_body.rs
+++ b/src/test/ui/stability-attribute/auxiliary/default_body.rs
@@ -1,0 +1,29 @@
+#![crate_type = "lib"]
+#![feature(staged_api, rustc_attrs)]
+#![stable(feature = "stable_feature", since = "1.0.0")]
+
+#[stable(feature = "stable_feature", since = "1.0.0")]
+pub trait JustTrait {
+    #[stable(feature = "stable_feature", since = "1.0.0")]
+    #[rustc_default_body_unstable(feature = "constant_default_body", issue = "none")]
+    const CONSTANT: usize = 0;
+
+    #[rustc_default_body_unstable(feature = "fun_default_body", issue = "none")]
+    #[stable(feature = "stable_feature", since = "1.0.0")]
+    fn fun() {}
+}
+
+#[rustc_must_implement_one_of(eq, neq)]
+#[stable(feature = "stable_feature", since = "1.0.0")]
+pub trait Equal {
+    #[rustc_default_body_unstable(feature = "eq_default_body", issue = "none")]
+    #[stable(feature = "stable_feature", since = "1.0.0")]
+    fn eq(&self, other: &Self) -> bool {
+        !self.neq(other)
+    }
+
+    #[stable(feature = "stable_feature", since = "1.0.0")]
+    fn neq(&self, other: &Self) -> bool {
+        !self.eq(other)
+    }
+}

--- a/src/test/ui/stability-attribute/default-body-stability-err.rs
+++ b/src/test/ui/stability-attribute/default-body-stability-err.rs
@@ -1,0 +1,19 @@
+// aux-build:default_body.rs
+#![crate_type = "lib"]
+
+extern crate default_body;
+
+use default_body::{Equal, JustTrait};
+
+struct Type;
+
+impl JustTrait for Type {}
+//~^ ERROR use of unstable library feature 'fun_default_body'
+//~| ERROR use of unstable library feature 'constant_default_body'
+
+impl Equal for Type {
+    //~^ ERROR use of unstable library feature 'eq_default_body'
+    fn neq(&self, other: &Self) -> bool {
+        false
+    }
+}

--- a/src/test/ui/stability-attribute/default-body-stability-err.rs
+++ b/src/test/ui/stability-attribute/default-body-stability-err.rs
@@ -8,11 +8,11 @@ use default_body::{Equal, JustTrait};
 struct Type;
 
 impl JustTrait for Type {}
-//~^ ERROR use of unstable library feature 'fun_default_body'
-//~| ERROR use of unstable library feature 'constant_default_body'
+//~^ ERROR not all trait items implemented, missing: `CONSTANT` [E0046]
+//~| ERROR not all trait items implemented, missing: `fun` [E0046]
 
 impl Equal for Type {
-    //~^ ERROR use of unstable library feature 'eq_default_body'
+    //~^ ERROR not all trait items implemented, missing: `eq` [E0046]
     fn neq(&self, other: &Self) -> bool {
         false
     }

--- a/src/test/ui/stability-attribute/default-body-stability-err.stderr
+++ b/src/test/ui/stability-attribute/default-body-stability-err.stderr
@@ -1,20 +1,24 @@
-error[E0658]: use of unstable library feature 'constant_default_body'
+error[E0046]: not all trait items implemented, missing: `CONSTANT`
   --> $DIR/default-body-stability-err.rs:10:1
    |
 LL | impl JustTrait for Type {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
+   = note: default implementation of `CONSTANT` is unstable
+   = note: use of unstable library feature 'constant_default_body'
    = help: add `#![feature(constant_default_body)]` to the crate attributes to enable
 
-error[E0658]: use of unstable library feature 'fun_default_body'
+error[E0046]: not all trait items implemented, missing: `fun`
   --> $DIR/default-body-stability-err.rs:10:1
    |
 LL | impl JustTrait for Type {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
+   = note: default implementation of `fun` is unstable
+   = note: use of unstable library feature 'fun_default_body'
    = help: add `#![feature(fun_default_body)]` to the crate attributes to enable
 
-error[E0658]: use of unstable library feature 'eq_default_body'
+error[E0046]: not all trait items implemented, missing: `eq`
   --> $DIR/default-body-stability-err.rs:14:1
    |
 LL | / impl Equal for Type {
@@ -25,8 +29,10 @@ LL | |     }
 LL | | }
    | |_^
    |
+   = note: default implementation of `eq` is unstable
+   = note: use of unstable library feature 'eq_default_body'
    = help: add `#![feature(eq_default_body)]` to the crate attributes to enable
 
 error: aborting due to 3 previous errors
 
-For more information about this error, try `rustc --explain E0658`.
+For more information about this error, try `rustc --explain E0046`.

--- a/src/test/ui/stability-attribute/default-body-stability-err.stderr
+++ b/src/test/ui/stability-attribute/default-body-stability-err.stderr
@@ -1,0 +1,32 @@
+error[E0658]: use of unstable library feature 'constant_default_body'
+  --> $DIR/default-body-stability-err.rs:10:1
+   |
+LL | impl JustTrait for Type {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add `#![feature(constant_default_body)]` to the crate attributes to enable
+
+error[E0658]: use of unstable library feature 'fun_default_body'
+  --> $DIR/default-body-stability-err.rs:10:1
+   |
+LL | impl JustTrait for Type {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add `#![feature(fun_default_body)]` to the crate attributes to enable
+
+error[E0658]: use of unstable library feature 'eq_default_body'
+  --> $DIR/default-body-stability-err.rs:14:1
+   |
+LL | / impl Equal for Type {
+LL | |
+LL | |     fn neq(&self, other: &Self) -> bool {
+LL | |         false
+LL | |     }
+LL | | }
+   | |_^
+   |
+   = help: add `#![feature(eq_default_body)]` to the crate attributes to enable
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/stability-attribute/default-body-stability-ok-enables.rs
+++ b/src/test/ui/stability-attribute/default-body-stability-ok-enables.rs
@@ -1,0 +1,18 @@
+// check-pass
+// aux-build:default_body.rs
+#![crate_type = "lib"]
+#![feature(fun_default_body, eq_default_body, constant_default_body)]
+
+extern crate default_body;
+
+use default_body::{Equal, JustTrait};
+
+struct Type;
+
+impl JustTrait for Type {}
+
+impl Equal for Type {
+    fn neq(&self, other: &Self) -> bool {
+        false
+    }
+}

--- a/src/test/ui/stability-attribute/default-body-stability-ok-impls.rs
+++ b/src/test/ui/stability-attribute/default-body-stability-ok-impls.rs
@@ -1,0 +1,21 @@
+// check-pass
+// aux-build:default_body.rs
+#![crate_type = "lib"]
+
+extern crate default_body;
+
+use default_body::{Equal, JustTrait};
+
+struct Type;
+
+impl JustTrait for Type {
+    const CONSTANT: usize = 1;
+
+    fn fun() {}
+}
+
+impl Equal for Type {
+    fn eq(&self, other: &Self) -> bool {
+        false
+    }
+}


### PR DESCRIPTION
This PR implements a new stability attribute — `#[rustc_default_body_unstable]`.

`#[rustc_default_body_unstable]` controls the stability of default bodies in traits.
For example:
```rust
pub trait Trait {
    #[rustc_default_body_unstable(feature = "feat", isssue = "none")]
    fn item() {}
}
```
In order to implement `Trait` user needs to either
- implement `item` (even though it has a default implementation)
- enable `#![feature(feat)]`

This is useful in conjunction with [`#[rustc_must_implement_one_of]`](https://github.com/rust-lang/rust/pull/92164), we may want to relax requirements for a trait, for example allowing implementing either of `PartialEq::{eq, ne}`, but do so in a safe way — making implementation of only `PartialEq::ne` unstable.

r? @Aaron1011 
cc @nrc (iirc you were interested in this wrt `read_buf`), @danielhenrymantilla (you were interested in the related `#[rustc_must_implement_one_of]`)
P.S. This is my first time working with stability attributes, so I'm not sure if I did everything right 😅 