### PR TITLE
Fixed grammatical error in example comment

### DIFF
--- a/library/core/src/iter/sources/repeat_with.rs
+++ b/library/core/src/iter/sources/repeat_with.rs
@@ -27,7 +27,7 @@ use crate::iter::{FusedIterator, TrustedLen};
 /// use std::iter;
 ///
 /// // let's assume we have some value of a type that is not `Clone`
-/// // or which don't want to have in memory just yet because it is expensive:
+/// // or which we don't want to have in memory just yet because it is expensive:
 /// #[derive(PartialEq, Debug)]
 /// struct Expensive;
 ///


### PR DESCRIPTION
Added missing "we" in sentence. 