### PR TITLE
Add missing `target_feature` to the list of well known cfg names

### DIFF
--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -1038,6 +1038,7 @@ impl CrateCheckConfig {
             sym::target_has_atomic_load_store,
             sym::target_has_atomic,
             sym::target_has_atomic_equal_alignment,
+            sym::target_feature,
             sym::panic,
             sym::sanitize,
             sym::debug_assertions,
@@ -1080,6 +1081,10 @@ impl CrateCheckConfig {
         let sanitize_values = SanitizerSet::all()
             .into_iter()
             .map(|sanitizer| Symbol::intern(sanitizer.as_str().unwrap()));
+
+        // Unknown possible values:
+        //  - `feature`
+        //  - `target_feature`
 
         // No-values
         for name in [


### PR DESCRIPTION
This PR adds the missing `target_feature` cfg name to the list of well known cfg names.

It was notice missing in https://github.com/rust-lang/rust/issues/96472 thanks to @bjorn3, the reason being that `--check-cfg=names()` automatically inherit the names passed by `--cfg` (or internal to `rustc`) and is seems that the vast majority of targets have at least one target feature leading to `target_feature` being a well known name in most target but it should always be a well known name so this PR add it unconditionally to list.

r? @petrochenkov