### PR TITLE
Pass all paths to `Step::run` at once when using `ShouldRun::krate`

### DIFF
--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -348,7 +348,11 @@ impl StepDescription {
             eprintln!(
                 "note: if you are adding a new Step to bootstrap itself, make sure you register it with `describe!`"
             );
+            #[cfg(not(test))]
             std::process::exit(1);
+            #[cfg(test)]
+            // so we can use #[should_panic]
+            panic!()
         }
     }
 }

--- a/src/bootstrap/builder/tests.rs
+++ b/src/bootstrap/builder/tests.rs
@@ -3,7 +3,11 @@ use crate::config::{Config, TargetSelection};
 use std::thread;
 
 fn configure(cmd: &str, host: &[&str], target: &[&str]) -> Config {
-    let mut config = Config::parse(&[cmd.to_owned()]);
+    configure_with_args(&[cmd.to_owned()], host, target)
+}
+
+fn configure_with_args(cmd: &[String], host: &[&str], target: &[&str]) -> Config {
+    let mut config = Config::parse(cmd);
     // don't save toolstates
     config.save_toolstates = None;
     config.dry_run = true;
@@ -46,11 +50,39 @@ fn run_build(paths: &[PathBuf], config: Config) -> Cache {
     builder.cache
 }
 
+fn check_cli<const N: usize>(paths: [&str; N]) {
+    run_build(
+        &paths.map(PathBuf::from),
+        configure_with_args(&paths.map(String::from), &["A"], &["A"]),
+    );
+}
+
+#[test]
+fn test_valid() {
+    // make sure multi suite paths are accepted
+    check_cli(["test", "src/test/ui/attr-start.rs", "src/test/ui/attr-shebang.rs"]);
+}
+
+#[test]
+#[should_panic]
+fn test_invalid() {
+    // make sure that invalid paths are caught, even when combined with valid paths
+    check_cli(["test", "library/std", "x"]);
+}
+
 #[test]
 fn test_intersection() {
-    let set = PathSet::Set(["library/core", "library/alloc", "library/std"].into_iter().map(TaskPath::parse).collect());
-    let subset = set.intersection(&[Path::new("library/core"), Path::new("library/alloc"), Path::new("library/stdarch")], None);
-    assert_eq!(subset, PathSet::Set(["library/core", "library/alloc"].into_iter().map(TaskPath::parse).collect()));
+    let set = PathSet::Set(
+        ["library/core", "library/alloc", "library/std"].into_iter().map(TaskPath::parse).collect(),
+    );
+    let mut command_paths =
+        vec![Path::new("library/core"), Path::new("library/alloc"), Path::new("library/stdarch")];
+    let subset = set.intersection_removing_matches(&mut command_paths, None);
+    assert_eq!(
+        subset,
+        PathSet::Set(["library/core", "library/alloc"].into_iter().map(TaskPath::parse).collect())
+    );
+    assert_eq!(command_paths, vec![Path::new("library/stdarch")]);
 }
 
 #[test]

--- a/src/bootstrap/builder/tests.rs
+++ b/src/bootstrap/builder/tests.rs
@@ -47,6 +47,13 @@ fn run_build(paths: &[PathBuf], config: Config) -> Cache {
 }
 
 #[test]
+fn test_intersection() {
+    let set = PathSet::Set(["library/core", "library/alloc", "library/std"].into_iter().map(TaskPath::parse).collect());
+    let subset = set.intersection(&[Path::new("library/core"), Path::new("library/alloc"), Path::new("library/stdarch")], None);
+    assert_eq!(subset, PathSet::Set(["library/core", "library/alloc"].into_iter().map(TaskPath::parse).collect()));
+}
+
+#[test]
 fn test_exclude() {
     let mut config = configure("test", &["A"], &["A"]);
     config.exclude = vec![TaskPath::parse("src/tools/tidy")];
@@ -539,7 +546,7 @@ mod dist {
                 target: host,
                 mode: Mode::Std,
                 test_kind: test::TestKind::Test,
-                krate: INTERNER.intern_str("std"),
+                crates: vec![INTERNER.intern_str("std")],
             },]
         );
     }

--- a/src/bootstrap/cache.rs
+++ b/src/bootstrap/cache.rs
@@ -270,7 +270,7 @@ impl Cache {
 
 #[cfg(test)]
 impl Cache {
-    pub fn all<S: Ord + Copy + Step>(&mut self) -> Vec<(S, S::Output)> {
+    pub fn all<S: Ord + Clone + Step>(&mut self) -> Vec<(S, S::Output)> {
         let cache = self.0.get_mut();
         let type_id = TypeId::of::<S>();
         let mut v = cache
@@ -278,7 +278,7 @@ impl Cache {
             .map(|b| b.downcast::<HashMap<S, S::Output>>().expect("correct type"))
             .map(|m| m.into_iter().collect::<Vec<_>>())
             .unwrap_or_default();
-        v.sort_by_key(|&(a, _)| a);
+        v.sort_by_key(|(s, _)| s.clone());
         v
     }
 

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -171,6 +171,7 @@ mod job {
     pub unsafe fn setup(_build: &mut crate::Build) {}
 }
 
+pub use crate::builder::PathSet;
 use crate::cache::{Interned, INTERNER};
 pub use crate::config::Config;
 pub use crate::flags::Subcommand;


### PR DESCRIPTION
Helps with https://github.com/rust-lang/rust/pull/95503. The goal is to run `cargo test -p rustc_data_structures -p rustc_lint_defs` instead of `cargo test -p rustc_data_structures; cargo test -p rustc_lint_defs`, which should both recompile less and avoid replaying cached warnings.

This was surprisingly complicated. The main changes are:
1. Invert the order of iteration in `StepDescription::run`.

    Previously, it did something like:
    ```python
    for path in paths:
    for (step, should_run) in should_runs:
        if let Some(set) = should_run.pathset_for_path(path):
        step.run(builder, set)
    ```

    That worked ok for individual paths, but didn't allow passing more than one path at a time to `Step::run`
    (since `pathset_for_paths` only had one path available to it).
    Change it to instead look at the intersection of `paths` and `should_run.paths`:

    ```python
    for (step, should_run) in should_runs:
    if let Some(set) = should_run.pathset_for_paths(paths):
        step.run(builder, set)
    ```

2. Change `pathset_for_path` to take multiple pathsets.

    The goal is to avoid `x test library/alloc` testing *all* library crates, instead of just alloc.
    The changes here are similarly subtle, to use the intersection between the paths rather than all
    paths in `should_run.paths`. I added a test for the behavior to try and make it more clear.

    Note that we use pathsets instead of just paths to allow for sets with multiple aliases (*cough* `all_krates` *cough*).
    See the documentation added in the next commit for more detail.

3. Change `StepDescription::run` to explicitly handle 0 paths.

    Before this was implicitly handled by the `for` loop, which just didn't excute when there were no paths.
    Now it needs a check, to avoid trying to run all steps (this is a problem for steps that use `default_condition`).

4. Change `RunDescription` to have a list of pathsets, rather than a single path.

5. Remove paths as they're matched

    This allows checking at the end that no invalid paths are left over.
    Note that if two steps matched the same path, this will no longer run both;
    but that's a bug anyway.

6. Handle suite paths separately from regular sets.

    Running multiple suite paths at once instead of in separate `make_run` invocations is both tricky and not particularly useful.
    The respective test Steps already handle this by introspecting the original paths.

    Avoid having to deal with it by moving suite handling into a seperate loop than `PathSet::Set` checks.

@rustbot label +A-rustbuild