### PR TITLE
Update cargo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -364,7 +364,7 @@ dependencies = [
  "tar",
  "tempfile",
  "termcolor",
- "toml_edit",
+ "toml_edit 0.14.3",
  "unicode-width",
  "unicode-xid",
  "url 2.2.2",
@@ -450,7 +450,7 @@ dependencies = [
  "serde_json",
  "tar",
  "termcolor",
- "toml_edit",
+ "toml_edit 0.13.4",
  "url 2.2.2",
 ]
 
@@ -2048,6 +2048,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "kstring"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3066350882a1cd6d950d055997f379ac37fd39f81cd4d8ed186032eb3c5747"
+dependencies = [
+ "static_assertions",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3234,7 +3243,7 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "toml",
- "toml_edit",
+ "toml_edit 0.13.4",
  "url 2.2.2",
  "walkdir",
 ]
@@ -4893,6 +4902,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "std"
 version = "0.0.0"
 dependencies = [
@@ -5309,7 +5324,20 @@ dependencies = [
  "combine",
  "indexmap",
  "itertools",
- "kstring",
+ "kstring 1.0.6",
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba98375fd631b83696f87c64e4ed8e29e6a1f3404d6aed95fa95163bad38e705"
+dependencies = [
+ "combine",
+ "indexmap",
+ "itertools",
+ "kstring 2.0.0",
  "serde",
 ]
 


### PR DESCRIPTION
8 commits in edffc4ada3d77799e5a04eeafd9b2f843d29fc23..f63f23ff1f1a12ede8585bbd1bbf0c536e50293d
2022-04-19 17:38:29 +0000 to 2022-04-28 03:15:50 +0000
- move workspace inheritance untable docs to the correct place (rust-lang/cargo#10609)
- Cargo add support for workspace inheritance (rust-lang/cargo#10606)
- chore: Upgrade toml_edit (rust-lang/cargo#10603)
- Mark .cargo/git and .cargo/registry as cache dirs (rust-lang/cargo#10553)
- fix(yank): Use '--version' like install (rust-lang/cargo#10575)
- Disallow setting registry tokens with --config (rust-lang/cargo#10580)
- Set cargo --version git hash length to 9 (rust-lang/cargo#10579)
- Prefer `key.workspace = true` to `key = { workspace = true }` (rust-lang/cargo#10584)