### PR TITLE
Implement `From<TryReserveError>` for `io::Error`

### DIFF
--- a/library/std/src/io/error.rs
+++ b/library/std/src/io/error.rs
@@ -11,6 +11,7 @@ mod repr_unpacked;
 #[cfg(not(target_pointer_width = "64"))]
 use repr_unpacked::Repr;
 
+use crate::collections::{TryReserveError, TryReserveErrorKind};
 use crate::convert::From;
 use crate::error;
 use crate::fmt;
@@ -462,6 +463,21 @@ impl From<ErrorKind> for Error {
     #[inline]
     fn from(kind: ErrorKind) -> Error {
         Error { repr: Repr::new_simple(kind) }
+    }
+}
+
+#[stable(feature = "io_error_from_try_reserve", since = "1.62.0")]
+impl From<TryReserveError> for Error {
+    #[inline]
+    fn from(error: TryReserveError) -> Error {
+        match error.kind() {
+            TryReserveErrorKind::CapacityOverflow => {
+                ErrorKind::InvalidInput.into()
+            }
+            TryReserveErrorKind::AllocError { .. } => {
+                ErrorKind::OutOfMemory.into()
+            }
+        }
     }
 }
 

--- a/library/std/src/io/error.rs
+++ b/library/std/src/io/error.rs
@@ -470,14 +470,12 @@ impl From<ErrorKind> for Error {
 impl From<TryReserveError> for Error {
     #[inline]
     fn from(error: TryReserveError) -> Error {
-        match error.kind() {
-            TryReserveErrorKind::CapacityOverflow => {
-                const_io_error!(ErrorKind::InvalidInput, "collection capacity overflowed")
-            }
-            TryReserveErrorKind::AllocError { .. } => {
-                const_io_error!(ErrorKind::OutOfMemory, "collection cannot allocate memory")
-            }
-        }
+        let kind = match error.kind() {
+            TryReserveErrorKind::CapacityOverflow => ErrorKind::InvalidInput,
+            TryReserveErrorKind::AllocError { .. } => ErrorKind::OutOfMemory,
+        };
+
+        Error::new(kind, error)
     }
 }
 

--- a/library/std/src/io/error.rs
+++ b/library/std/src/io/error.rs
@@ -472,10 +472,10 @@ impl From<TryReserveError> for Error {
     fn from(error: TryReserveError) -> Error {
         match error.kind() {
             TryReserveErrorKind::CapacityOverflow => {
-                ErrorKind::InvalidInput.into()
+                const_io_error!(ErrorKind::InvalidInput, "collection capacity overflowed")
             }
             TryReserveErrorKind::AllocError { .. } => {
-                ErrorKind::OutOfMemory.into()
+                const_io_error!(ErrorKind::OutOfMemory, "collection cannot allocate memory")
             }
         }
     }


### PR DESCRIPTION
The `try_reserve` methods may be called when allocating for I/O.