### PR TITLE
Use futex-based locks and thread parker on {Free, Open, DragonFly}BSD.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2070,9 +2070,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.121"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efaa7b300f3b5fe8eb6bf21ce3895e1751d9665086af2d64b42f19701015ff4f"
+checksum = "5916d2ae698f6de9bfb891ad7a8d65c09d232dc58cc4ac433c7da3b2fd84bc2b"
 dependencies = [
  "rustc-std-workspace-core",
 ]

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -15,7 +15,7 @@ cfg-if = { version = "0.1.8", features = ['rustc-dep-of-std'] }
 panic_unwind = { path = "../panic_unwind", optional = true }
 panic_abort = { path = "../panic_abort" }
 core = { path = "../core" }
-libc = { version = "0.2.116", default-features = false, features = ['rustc-dep-of-std'] }
+libc = { version = "0.2.125", default-features = false, features = ['rustc-dep-of-std'] }
 compiler_builtins = { version = "0.1.71" }
 profiler_builtins = { path = "../profiler_builtins", optional = true }
 unwind = { path = "../unwind" }

--- a/library/std/src/sync/condvar/tests.rs
+++ b/library/std/src/sync/condvar/tests.rs
@@ -188,24 +188,3 @@ fn wait_timeout_wake() {
         break;
     }
 }
-
-#[test]
-#[should_panic]
-#[cfg(all(unix, not(target_os = "linux"), not(target_os = "android")))]
-fn two_mutexes() {
-    let m = Arc::new(Mutex::new(()));
-    let m2 = m.clone();
-    let c = Arc::new(Condvar::new());
-    let c2 = c.clone();
-
-    let mut g = m.lock().unwrap();
-    let _t = thread::spawn(move || {
-        let _g = m2.lock().unwrap();
-        c2.notify_one();
-    });
-    g = c.wait(g).unwrap();
-    drop(g);
-
-    let m = Mutex::new(());
-    let _ = c.wait(m.lock().unwrap()).unwrap();
-}

--- a/library/std/src/sys/unix/locks/futex_rwlock.rs
+++ b/library/std/src/sys/unix/locks/futex_rwlock.rs
@@ -283,7 +283,18 @@ impl RwLock {
     /// writer that was about to go to sleep.
     fn wake_writer(&self) -> bool {
         self.writer_notify.fetch_add(1, Release);
-        futex_wake(&self.writer_notify)
+        cfg_if::cfg_if! {
+            if #[cfg(target_os = "dragonfly")] {
+                // DragonFlyBSD doesn't tell us whether it woke up any threads or not.
+                // So, we always return `false` here, as that still results in correct behaviour.
+                // The downside is an extra syscall in case both readers and writers were waiting,
+                // and unnecessarily waking up readers when a writer is about to attempt to lock the lock.
+                futex_wake(&self.writer_notify);
+                false
+            } else {
+                futex_wake(&self.writer_notify)
+            }
+        }
     }
 
     /// Spin for a while, but stop directly at the given condition.

--- a/library/std/src/sys/unix/locks/futex_rwlock.rs
+++ b/library/std/src/sys/unix/locks/futex_rwlock.rs
@@ -284,8 +284,8 @@ impl RwLock {
     fn wake_writer(&self) -> bool {
         self.writer_notify.fetch_add(1, Release);
         cfg_if::cfg_if! {
-            if #[cfg(target_os = "dragonfly")] {
-                // DragonFlyBSD doesn't tell us whether it woke up any threads or not.
+            if #[cfg(any(target_os = "freebsd", target_os = "dragonfly"))] {
+                // FreeBSD and DragonFlyBSD don't tell us whether they woke up any threads or not.
                 // So, we always return `false` here, as that still results in correct behaviour.
                 // The downside is an extra syscall in case both readers and writers were waiting,
                 // and unnecessarily waking up readers when a writer is about to attempt to lock the lock.

--- a/library/std/src/sys/unix/locks/mod.rs
+++ b/library/std/src/sys/unix/locks/mod.rs
@@ -5,6 +5,7 @@ cfg_if::cfg_if! {
         all(target_os = "emscripten", target_feature = "atomics"),
         target_os = "openbsd",
         target_os = "netbsd",
+        target_os = "dragonfly",
     ))] {
         mod futex;
         mod futex_rwlock;

--- a/library/std/src/sys/unix/locks/mod.rs
+++ b/library/std/src/sys/unix/locks/mod.rs
@@ -3,6 +3,7 @@ cfg_if::cfg_if! {
         target_os = "linux",
         target_os = "android",
         all(target_os = "emscripten", target_feature = "atomics"),
+        target_os = "freebsd",
         target_os = "openbsd",
         target_os = "netbsd",
         target_os = "dragonfly",

--- a/library/std/src/sys/unix/locks/mod.rs
+++ b/library/std/src/sys/unix/locks/mod.rs
@@ -3,6 +3,7 @@ cfg_if::cfg_if! {
         target_os = "linux",
         target_os = "android",
         all(target_os = "emscripten", target_feature = "atomics"),
+        target_os = "openbsd",
     ))] {
         mod futex;
         mod futex_rwlock;

--- a/library/std/src/sys/unix/locks/mod.rs
+++ b/library/std/src/sys/unix/locks/mod.rs
@@ -4,6 +4,7 @@ cfg_if::cfg_if! {
         target_os = "android",
         all(target_os = "emscripten", target_feature = "atomics"),
         target_os = "openbsd",
+        target_os = "netbsd",
     ))] {
         mod futex;
         mod futex_rwlock;

--- a/library/std/src/sys/unix/locks/mod.rs
+++ b/library/std/src/sys/unix/locks/mod.rs
@@ -5,7 +5,6 @@ cfg_if::cfg_if! {
         all(target_os = "emscripten", target_feature = "atomics"),
         target_os = "freebsd",
         target_os = "openbsd",
-        target_os = "netbsd",
         target_os = "dragonfly",
     ))] {
         mod futex;

--- a/library/std/src/sys/unix/thread_parker.rs
+++ b/library/std/src/sys/unix/thread_parker.rs
@@ -6,7 +6,6 @@
     all(target_os = "emscripten", target_feature = "atomics"),
     target_os = "freebsd",
     target_os = "openbsd",
-    target_os = "netbsd",
     target_os = "dragonfly",
 )))]
 

--- a/library/std/src/sys/unix/thread_parker.rs
+++ b/library/std/src/sys/unix/thread_parker.rs
@@ -3,7 +3,11 @@
 #![cfg(not(any(
     target_os = "linux",
     target_os = "android",
-    all(target_os = "emscripten", target_feature = "atomics")
+    all(target_os = "emscripten", target_feature = "atomics"),
+    target_os = "freebsd",
+    target_os = "openbsd",
+    target_os = "netbsd",
+    target_os = "dragonfly",
 )))]
 
 use crate::cell::UnsafeCell;

--- a/library/std/src/sys_common/thread_parker/mod.rs
+++ b/library/std/src/sys_common/thread_parker/mod.rs
@@ -3,6 +3,7 @@ cfg_if::cfg_if! {
         target_os = "linux",
         target_os = "android",
         all(target_arch = "wasm32", target_feature = "atomics"),
+        target_os = "openbsd",
     ))] {
         mod futex;
         pub use futex::Parker;

--- a/library/std/src/sys_common/thread_parker/mod.rs
+++ b/library/std/src/sys_common/thread_parker/mod.rs
@@ -5,7 +5,6 @@ cfg_if::cfg_if! {
         all(target_arch = "wasm32", target_feature = "atomics"),
         target_os = "freebsd",
         target_os = "openbsd",
-        target_os = "netbsd",
         target_os = "dragonfly",
     ))] {
         mod futex;

--- a/library/std/src/sys_common/thread_parker/mod.rs
+++ b/library/std/src/sys_common/thread_parker/mod.rs
@@ -4,6 +4,7 @@ cfg_if::cfg_if! {
         target_os = "android",
         all(target_arch = "wasm32", target_feature = "atomics"),
         target_os = "openbsd",
+        target_os = "netbsd",
     ))] {
         mod futex;
         pub use futex::Parker;

--- a/library/std/src/sys_common/thread_parker/mod.rs
+++ b/library/std/src/sys_common/thread_parker/mod.rs
@@ -5,6 +5,7 @@ cfg_if::cfg_if! {
         all(target_arch = "wasm32", target_feature = "atomics"),
         target_os = "openbsd",
         target_os = "netbsd",
+        target_os = "dragonfly",
     ))] {
         mod futex;
         pub use futex::Parker;

--- a/library/std/src/sys_common/thread_parker/mod.rs
+++ b/library/std/src/sys_common/thread_parker/mod.rs
@@ -3,6 +3,7 @@ cfg_if::cfg_if! {
         target_os = "linux",
         target_os = "android",
         all(target_arch = "wasm32", target_feature = "atomics"),
+        target_os = "freebsd",
         target_os = "openbsd",
         target_os = "netbsd",
         target_os = "dragonfly",


### PR DESCRIPTION
This switches *BSD to our futex-based locks and thread parker.

Tracking issue: https://github.com/rust-lang/rust/issues/93740

r? @Amanieu