### PR TITLE
Provide fnptr impls for extern "system"

### DIFF
--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -1851,16 +1851,20 @@ macro_rules! fnptr_impls_args {
         fnptr_impls_safety_abi! { extern "Rust" fn($($Arg),+) -> Ret, $($Arg),+ }
         fnptr_impls_safety_abi! { extern "C" fn($($Arg),+) -> Ret, $($Arg),+ }
         fnptr_impls_safety_abi! { extern "C" fn($($Arg),+ , ...) -> Ret, $($Arg),+ }
+        fnptr_impls_safety_abi! { extern "system" fn($($Arg),+) -> Ret, $($Arg),+ }
         fnptr_impls_safety_abi! { unsafe extern "Rust" fn($($Arg),+) -> Ret, $($Arg),+ }
         fnptr_impls_safety_abi! { unsafe extern "C" fn($($Arg),+) -> Ret, $($Arg),+ }
         fnptr_impls_safety_abi! { unsafe extern "C" fn($($Arg),+ , ...) -> Ret, $($Arg),+ }
+        fnptr_impls_safety_abi! { unsafe extern "system" fn($($Arg),+) -> Ret, $($Arg),+ }
     };
     () => {
         // No variadic functions with 0 parameters
         fnptr_impls_safety_abi! { extern "Rust" fn() -> Ret, }
         fnptr_impls_safety_abi! { extern "C" fn() -> Ret, }
+        fnptr_impls_safety_abi! { extern "system" fn() -> Ret, }
         fnptr_impls_safety_abi! { unsafe extern "Rust" fn() -> Ret, }
         fnptr_impls_safety_abi! { unsafe extern "C" fn() -> Ret, }
+        fnptr_impls_safety_abi! { unsafe extern "system" fn() -> Ret, }
     };
 }
 

--- a/src/test/ui/binop/issue-77910-1.stderr
+++ b/src/test/ui/binop/issue-77910-1.stderr
@@ -25,7 +25,7 @@ LL |     assert_eq!(foo, y);
              extern "C" fn(A, B, C) -> Ret
              extern "C" fn(A, B, C, ...) -> Ret
              extern "C" fn(A, B, C, D) -> Ret
-           and 68 others
+           and 94 others
    = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/issues/issue-59488.stderr
+++ b/src/test/ui/issues/issue-59488.stderr
@@ -103,7 +103,7 @@ LL |     assert_eq!(Foo::Bar, i);
              extern "C" fn(A, B, C) -> Ret
              extern "C" fn(A, B, C, ...) -> Ret
              extern "C" fn(A, B, C, D) -> Ret
-           and 68 others
+           and 94 others
    = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 9 previous errors


### PR DESCRIPTION
`extern "system"` is a cross-platform ABI. Adding these impls means that we provide the fnptr impls for all cross-platform ABIs.

A perfect solution would be to have the compiler provide these implementations, so that they're available for all ABIs and all airities, not just arities up to 12. Until we have that perfect shiny future, there's imho three defensible positions to take:

- Provide impls for just `extern "Rust"` and `extern "C"` — status quo
- Provide impls for all cross-platform ABIs — this PR
- Provide impls for all ABIs, including platform-specific — assumed intractable

The downside of providing more impls is that the [fn primitive documentation](https://doc.rust-lang.org/nightly/std/primitive.fn.html) gets more crowded with more implementations. I think the benefit outweighs the downside here, especially since the trait implementations on that page are already effectively unusable.

(Side note: stable 1.60 only provides one Debug link in the sidebar, whereas beta 1.61 has one for each `impl`. This is the case for any impl which isn't parameterized.)