### PR TITLE
Fix links pointing to std_detect

### DIFF
--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -463,7 +463,10 @@ impl Step for Std {
                 .arg("--resource-suffix")
                 .arg(&builder.version)
                 .arg("--index-page")
-                .arg(&builder.src.join("src/doc/index.md"));
+                .arg(&builder.src.join("src/doc/index.md"))
+                .arg("--extern-html-root-url")
+                .arg("std_detect=https://docs.rs/std_detect/0.1.5/")
+                .arg("--extern-html-root-takes-precedence");
 
             if !builder.config.docs_minification {
                 cargo.arg("--disable-minification");


### PR DESCRIPTION
This PR is one way to fix https://github.com/rust-lang/rust/issues/96506. Another one would be to extend `html_root_url` attribute to allow it to work like the unstable `--html-root-url` option.

Any opinion maybe?