### PR TITLE
generalize "incoherent impls" impl for user defined types

### DIFF
--- a/compiler/rustc_feature/src/builtin_attrs.rs
+++ b/compiler/rustc_feature/src/builtin_attrs.rs
@@ -644,6 +644,11 @@ pub const BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
         rustc_allow_incoherent_impl, AttributeType::Normal, template!(Word), ErrorFollowing,
         "#[rustc_allow_incoherent_impl] has to be added to all impl items of an incoherent inherent impl."
     ),
+    rustc_attr!(
+        rustc_has_incoherent_inherent_impls, AttributeType::Normal, template!(Word), ErrorFollowing,
+        "#[rustc_has_incoherent_inherent_impls] allows the addition of incoherent inherent impls for \
+         the given type by annotating all impl items with #[rustc_allow_incoherent_impl]."
+    ),
     BuiltinAttribute {
         name: sym::rustc_diagnostic_item,
         type_: Normal,

--- a/compiler/rustc_hir/src/lang_items.rs
+++ b/compiler/rustc_hir/src/lang_items.rs
@@ -327,8 +327,6 @@ language_item_table! {
     Range,                   sym::Range,               range_struct,               Target::Struct,         GenericRequirement::None;
     RangeToInclusive,        sym::RangeToInclusive,    range_to_inclusive_struct,  Target::Struct,         GenericRequirement::None;
     RangeTo,                 sym::RangeTo,             range_to_struct,            Target::Struct,         GenericRequirement::None;
-
-    CStr,                    sym::CStr,                c_str,                      Target::Struct,         GenericRequirement::None;
 }
 
 pub enum GenericRequirement {

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -124,6 +124,9 @@ impl CheckAttrVisitor<'_> {
                 sym::rustc_allow_incoherent_impl => {
                     self.check_allow_incoherent_impl(&attr, span, target)
                 }
+                sym::rustc_has_incoherent_inherent_impls => {
+                    self.check_has_incoherent_inherent_impls(&attr, span, target)
+                }
                 sym::rustc_const_unstable
                 | sym::rustc_const_stable
                 | sym::unstable
@@ -1095,7 +1098,6 @@ impl CheckAttrVisitor<'_> {
         }
     }
 
-    /// Warns against some misuses of `#[pass_by_value]`
     fn check_allow_incoherent_impl(&self, attr: &Attribute, span: Span, target: Target) -> bool {
         match target {
             Target::Method(MethodKind::Inherent) => true,
@@ -1107,6 +1109,30 @@ impl CheckAttrVisitor<'_> {
                         "`rustc_allow_incoherent_impl` attribute should be applied to impl items.",
                     )
                     .span_label(span, "the only currently supported targets are inherent methods")
+                    .emit();
+                false
+            }
+        }
+    }
+
+    fn check_has_incoherent_inherent_impls(
+        &self,
+        attr: &Attribute,
+        span: Span,
+        target: Target,
+    ) -> bool {
+        match target {
+            Target::Trait | Target::Struct | Target::Enum | Target::Union | Target::ForeignTy => {
+                true
+            }
+            _ => {
+                self.tcx
+                    .sess
+                    .struct_span_err(
+                        attr.span,
+                        "`rustc_has_incoherent_inherent_impls` attribute should be applied to types or traits.",
+                    )
+                    .span_label(span, "only adts, extern types and traits are supported")
                     .emit();
                 false
             }

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1187,6 +1187,7 @@ symbols! {
         rustc_error,
         rustc_evaluate_where_clauses,
         rustc_expected_cgu_reuse,
+        rustc_has_incoherent_inherent_impls,
         rustc_if_this_changed,
         rustc_inherit_overflow_checks,
         rustc_insignificant_dtor,

--- a/compiler/rustc_typeck/src/coherence/inherent_impls.rs
+++ b/compiler/rustc_typeck/src/coherence/inherent_impls.rs
@@ -149,7 +149,7 @@ impl<'tcx> InherentCollect<'tcx> {
                     self.tcx.sess,
                     item.span,
                     E0390,
-                    "cannot define inherent `impl` for a type outside of crate where the type is defined",
+                    "cannot define inherent `impl` for a type outside of the crate where the type is defined",
                 )
                 .help(INTO_DEFINING_CRATE)
                 .span_help(item.span, ADD_ATTR_TO_TY)
@@ -166,7 +166,7 @@ impl<'tcx> InherentCollect<'tcx> {
                         self.tcx.sess,
                         item.span,
                         E0390,
-                        "cannot define inherent `impl` for a type outside of crate where the type is defined",
+                        "cannot define inherent `impl` for a type outside of the crate where the type is defined",
                     )
                     .help(INTO_DEFINING_CRATE)
                     .span_help(impl_item.span, ADD_ATTR)

--- a/compiler/rustc_typeck/src/coherence/inherent_impls.rs
+++ b/compiler/rustc_typeck/src/coherence/inherent_impls.rs
@@ -137,9 +137,7 @@ impl<'tcx> InherentCollect<'tcx> {
             return;
         }
 
-        if self.tcx.features().rustc_attrs
-            && self.tcx.has_attr(def_id, sym::rustc_has_incoherent_inherent_impls)
-        {
+        if self.tcx.has_attr(def_id, sym::rustc_has_incoherent_inherent_impls) {
             let hir::ItemKind::Impl(hir::Impl { items, .. }) = item.kind else {
                 bug!("expected `impl` item: {:?}", item);
             };

--- a/compiler/rustc_typeck/src/coherence/inherent_impls.rs
+++ b/compiler/rustc_typeck/src/coherence/inherent_impls.rs
@@ -55,18 +55,13 @@ impl<'tcx> ItemLikeVisitor<'_> for InherentCollect<'tcx> {
         let self_ty = self.tcx.type_of(item.def_id);
         match *self_ty.kind() {
             ty::Adt(def, _) => {
-                let def_id = def.did();
-                if !def_id.is_local() && Some(def_id) == self.tcx.lang_items().c_str() {
-                    self.check_primitive_impl(item.def_id, self_ty, items, ty.span)
-                } else {
-                    self.check_def_id(item, def_id);
-                }
+                self.check_def_id(item, self_ty, def.did());
             }
             ty::Foreign(did) => {
-                self.check_def_id(item, did);
+                self.check_def_id(item, self_ty, did);
             }
             ty::Dynamic(data, ..) if data.principal_def_id().is_some() => {
-                self.check_def_id(item, data.principal_def_id().unwrap());
+                self.check_def_id(item, self_ty, data.principal_def_id().unwrap());
             }
             ty::Dynamic(..) => {
                 struct_span_err!(
@@ -124,14 +119,52 @@ impl<'tcx> ItemLikeVisitor<'_> for InherentCollect<'tcx> {
     fn visit_foreign_item(&mut self, _foreign_item: &hir::ForeignItem<'_>) {}
 }
 
+const INTO_CORE: &str = "consider moving this inherent impl into `core` if possible";
+const INTO_DEFINING_CRATE: &str =
+    "consider moving this inherent impl into the crate defining the type if possible";
+const ADD_ATTR: &str =
+    "alternatively add `#[rustc_allow_incoherent_impl]` to the relevant impl items";
+
 impl<'tcx> InherentCollect<'tcx> {
-    fn check_def_id(&mut self, item: &hir::Item<'_>, def_id: DefId) {
+    fn check_def_id(&mut self, item: &hir::Item<'_>, self_ty: Ty<'tcx>, def_id: DefId) {
+        let impl_def_id = item.def_id;
         if let Some(def_id) = def_id.as_local() {
             // Add the implementation to the mapping from implementation to base
             // type def ID, if there is a base type for this implementation and
             // the implementation does not have any associated traits.
             let vec = self.impls_map.inherent_impls.entry(def_id).or_default();
-            vec.push(item.def_id.to_def_id());
+            vec.push(impl_def_id.to_def_id());
+            return;
+        }
+
+        if self.tcx.features().rustc_attrs
+            && self.tcx.has_attr(def_id, sym::rustc_has_incoherent_inherent_impls)
+        {
+            let hir::ItemKind::Impl(hir::Impl { items, .. }) = item.kind else {
+                bug!("expected `impl` item: {:?}", item);
+            };
+
+            for item in items {
+                if !self.tcx.has_attr(item.id.def_id.to_def_id(), sym::rustc_allow_incoherent_impl)
+                {
+                    struct_span_err!(
+                        self.tcx.sess,
+                        item.span,
+                        E0390,
+                        "cannot define inherent `impl` for a type outside of crate where the type is defined",
+                    )
+                    .help(INTO_DEFINING_CRATE)
+                    .span_help(item.span, ADD_ATTR)
+                    .emit();
+                    return;
+                }
+            }
+
+            if let Some(simp) = simplify_type(self.tcx, self_ty, TreatParams::AsPlaceholders) {
+                self.impls_map.incoherent_impls.entry(simp).or_default().push(impl_def_id);
+            } else {
+                bug!("unexpected self type: {:?}", self_ty);
+            }
         } else {
             struct_span_err!(
                 self.tcx.sess,
@@ -153,9 +186,6 @@ impl<'tcx> InherentCollect<'tcx> {
         items: &[hir::ImplItemRef],
         span: Span,
     ) {
-        const INTO_CORE: &str = "consider moving this inherent impl into `core` if possible";
-        const ADD_ATTR: &str =
-            "alternatively add `#[rustc_allow_incoherent_impl]` to the relevant impl items";
         if !self.tcx.hir().rustc_coherence_is_core() {
             if self.tcx.features().rustc_attrs {
                 for item in items {

--- a/library/core/src/ffi/c_str.rs
+++ b/library/core/src/ffi/c_str.rs
@@ -77,7 +77,7 @@ use crate::str;
 #[derive(Hash)]
 #[cfg_attr(not(test), rustc_diagnostic_item = "CStr")]
 #[unstable(feature = "core_c_str", issue = "94079")]
-#[cfg_attr(not(bootstrap), lang = "CStr")]
+#[cfg_attr(not(bootstrap), rustc_has_incoherent_inherent_impls)]
 // FIXME:
 // `fn from` in `impl From<&CStr> for Box<CStr>` current implementation relies
 // on `CStr` being layout-compatible with `[u8]`.

--- a/src/test/ui/incoherent-inherent-impls/auxiliary/extern-crate.rs
+++ b/src/test/ui/incoherent-inherent-impls/auxiliary/extern-crate.rs
@@ -1,0 +1,9 @@
+#![feature(rustc_attrs)]
+
+#[rustc_has_incoherent_inherent_impls]
+pub struct StructWithAttr;
+pub struct StructNoAttr;
+
+#[rustc_has_incoherent_inherent_impls]
+pub enum EnumWithAttr {}
+pub enum EnumNoAttr {}

--- a/src/test/ui/incoherent-inherent-impls/needs-has-incoherent-impls.rs
+++ b/src/test/ui/incoherent-inherent-impls/needs-has-incoherent-impls.rs
@@ -2,31 +2,37 @@
 #![feature(rustc_attrs)]
 extern crate extern_crate;
 
-impl extern_crate::StructWithAttr { //~ ERROR
+impl extern_crate::StructWithAttr {
+    //~^ ERROR cannot define inherent `impl` for a type outside of the crate
     fn foo() {}
 }
 impl extern_crate::StructWithAttr {
     #[rustc_allow_incoherent_impl]
     fn bar() {}
 }
-impl extern_crate::StructNoAttr { //~ ERROR
+impl extern_crate::StructNoAttr {
+    //~^ ERROR cannot define inherent `impl` for a type outside of the crate
     fn foo() {}
 }
-impl extern_crate::StructNoAttr { //~ ERROR
+impl extern_crate::StructNoAttr {
+    //~^ ERROR cannot define inherent `impl` for a type outside of the crate
     #[rustc_allow_incoherent_impl]
     fn bar() {}
 }
-impl extern_crate::EnumWithAttr { //~ ERROR
+impl extern_crate::EnumWithAttr {
+    //~^ ERROR cannot define inherent `impl` for a type outside of the crate
     fn foo() {}
 }
 impl extern_crate::EnumWithAttr {
     #[rustc_allow_incoherent_impl]
     fn bar() {}
 }
-impl extern_crate::EnumNoAttr { //~ ERROR
+impl extern_crate::EnumNoAttr {
+    //~^ ERROR cannot define inherent `impl` for a type outside of the crate
     fn foo() {}
 }
-impl extern_crate::EnumNoAttr { //~ ERROR
+impl extern_crate::EnumNoAttr {
+    //~^ ERROR cannot define inherent `impl` for a type outside of the crate
     #[rustc_allow_incoherent_impl]
     fn bar() {}
 }

--- a/src/test/ui/incoherent-inherent-impls/needs-has-incoherent-impls.rs
+++ b/src/test/ui/incoherent-inherent-impls/needs-has-incoherent-impls.rs
@@ -1,0 +1,34 @@
+// aux-build:extern-crate.rs
+#![feature(rustc_attrs)]
+extern crate extern_crate;
+
+impl extern_crate::StructWithAttr { //~ ERROR
+    fn foo() {}
+}
+impl extern_crate::StructWithAttr {
+    #[rustc_allow_incoherent_impl]
+    fn bar() {}
+}
+impl extern_crate::StructNoAttr { //~ ERROR
+    fn foo() {}
+}
+impl extern_crate::StructNoAttr { //~ ERROR
+    #[rustc_allow_incoherent_impl]
+    fn bar() {}
+}
+impl extern_crate::EnumWithAttr { //~ ERROR
+    fn foo() {}
+}
+impl extern_crate::EnumWithAttr {
+    #[rustc_allow_incoherent_impl]
+    fn bar() {}
+}
+impl extern_crate::EnumNoAttr { //~ ERROR
+    fn foo() {}
+}
+impl extern_crate::EnumNoAttr { //~ ERROR
+    #[rustc_allow_incoherent_impl]
+    fn bar() {}
+}
+
+fn main() {}

--- a/src/test/ui/incoherent-inherent-impls/needs-has-incoherent-impls.stderr
+++ b/src/test/ui/incoherent-inherent-impls/needs-has-incoherent-impls.stderr
@@ -1,0 +1,105 @@
+error[E0390]: cannot define inherent `impl` for a type outside of crate where the type is defined
+  --> $DIR/needs-has-incoherent-impls.rs:5:1
+   |
+LL | / impl extern_crate::StructWithAttr {
+LL | |     fn foo() {}
+LL | | }
+   | |_^
+   |
+   = help: consider moving this inherent impl into the crate defining the type if possible
+help: alternatively add `#[rustc_allow_incoherent_impl]` to the relevant impl items
+  --> $DIR/needs-has-incoherent-impls.rs:6:5
+   |
+LL |     fn foo() {}
+   |     ^^^^^^^^^^^
+
+error[E0390]: cannot define inherent `impl` for a type outside of crate where the type is defined
+  --> $DIR/needs-has-incoherent-impls.rs:12:1
+   |
+LL | / impl extern_crate::StructNoAttr {
+LL | |     fn foo() {}
+LL | | }
+   | |_^
+   |
+   = help: consider moving this inherent impl into the crate defining the type if possible
+help: alternatively add `#[rustc_has_incoherent_inherent_impls]` to the type and `#[rustc_allow_incoherent_impl]` to the relevant impl items
+  --> $DIR/needs-has-incoherent-impls.rs:12:1
+   |
+LL | / impl extern_crate::StructNoAttr {
+LL | |     fn foo() {}
+LL | | }
+   | |_^
+
+error[E0390]: cannot define inherent `impl` for a type outside of crate where the type is defined
+  --> $DIR/needs-has-incoherent-impls.rs:15:1
+   |
+LL | / impl extern_crate::StructNoAttr {
+LL | |     #[rustc_allow_incoherent_impl]
+LL | |     fn bar() {}
+LL | | }
+   | |_^
+   |
+   = help: consider moving this inherent impl into the crate defining the type if possible
+help: alternatively add `#[rustc_has_incoherent_inherent_impls]` to the type and `#[rustc_allow_incoherent_impl]` to the relevant impl items
+  --> $DIR/needs-has-incoherent-impls.rs:15:1
+   |
+LL | / impl extern_crate::StructNoAttr {
+LL | |     #[rustc_allow_incoherent_impl]
+LL | |     fn bar() {}
+LL | | }
+   | |_^
+
+error[E0390]: cannot define inherent `impl` for a type outside of crate where the type is defined
+  --> $DIR/needs-has-incoherent-impls.rs:19:1
+   |
+LL | / impl extern_crate::EnumWithAttr {
+LL | |     fn foo() {}
+LL | | }
+   | |_^
+   |
+   = help: consider moving this inherent impl into the crate defining the type if possible
+help: alternatively add `#[rustc_allow_incoherent_impl]` to the relevant impl items
+  --> $DIR/needs-has-incoherent-impls.rs:20:5
+   |
+LL |     fn foo() {}
+   |     ^^^^^^^^^^^
+
+error[E0390]: cannot define inherent `impl` for a type outside of crate where the type is defined
+  --> $DIR/needs-has-incoherent-impls.rs:26:1
+   |
+LL | / impl extern_crate::EnumNoAttr {
+LL | |     fn foo() {}
+LL | | }
+   | |_^
+   |
+   = help: consider moving this inherent impl into the crate defining the type if possible
+help: alternatively add `#[rustc_has_incoherent_inherent_impls]` to the type and `#[rustc_allow_incoherent_impl]` to the relevant impl items
+  --> $DIR/needs-has-incoherent-impls.rs:26:1
+   |
+LL | / impl extern_crate::EnumNoAttr {
+LL | |     fn foo() {}
+LL | | }
+   | |_^
+
+error[E0390]: cannot define inherent `impl` for a type outside of crate where the type is defined
+  --> $DIR/needs-has-incoherent-impls.rs:29:1
+   |
+LL | / impl extern_crate::EnumNoAttr {
+LL | |     #[rustc_allow_incoherent_impl]
+LL | |     fn bar() {}
+LL | | }
+   | |_^
+   |
+   = help: consider moving this inherent impl into the crate defining the type if possible
+help: alternatively add `#[rustc_has_incoherent_inherent_impls]` to the type and `#[rustc_allow_incoherent_impl]` to the relevant impl items
+  --> $DIR/needs-has-incoherent-impls.rs:29:1
+   |
+LL | / impl extern_crate::EnumNoAttr {
+LL | |     #[rustc_allow_incoherent_impl]
+LL | |     fn bar() {}
+LL | | }
+   | |_^
+
+error: aborting due to 6 previous errors
+
+For more information about this error, try `rustc --explain E0390`.

--- a/src/test/ui/incoherent-inherent-impls/needs-has-incoherent-impls.stderr
+++ b/src/test/ui/incoherent-inherent-impls/needs-has-incoherent-impls.stderr
@@ -1,39 +1,43 @@
-error[E0390]: cannot define inherent `impl` for a type outside of crate where the type is defined
+error[E0390]: cannot define inherent `impl` for a type outside of the crate where the type is defined
   --> $DIR/needs-has-incoherent-impls.rs:5:1
    |
 LL | / impl extern_crate::StructWithAttr {
+LL | |
 LL | |     fn foo() {}
 LL | | }
    | |_^
    |
    = help: consider moving this inherent impl into the crate defining the type if possible
 help: alternatively add `#[rustc_allow_incoherent_impl]` to the relevant impl items
-  --> $DIR/needs-has-incoherent-impls.rs:6:5
+  --> $DIR/needs-has-incoherent-impls.rs:7:5
    |
 LL |     fn foo() {}
    |     ^^^^^^^^^^^
 
-error[E0390]: cannot define inherent `impl` for a type outside of crate where the type is defined
-  --> $DIR/needs-has-incoherent-impls.rs:12:1
+error[E0390]: cannot define inherent `impl` for a type outside of the crate where the type is defined
+  --> $DIR/needs-has-incoherent-impls.rs:13:1
    |
 LL | / impl extern_crate::StructNoAttr {
+LL | |
 LL | |     fn foo() {}
 LL | | }
    | |_^
    |
    = help: consider moving this inherent impl into the crate defining the type if possible
 help: alternatively add `#[rustc_has_incoherent_inherent_impls]` to the type and `#[rustc_allow_incoherent_impl]` to the relevant impl items
-  --> $DIR/needs-has-incoherent-impls.rs:12:1
+  --> $DIR/needs-has-incoherent-impls.rs:13:1
    |
 LL | / impl extern_crate::StructNoAttr {
+LL | |
 LL | |     fn foo() {}
 LL | | }
    | |_^
 
-error[E0390]: cannot define inherent `impl` for a type outside of crate where the type is defined
-  --> $DIR/needs-has-incoherent-impls.rs:15:1
+error[E0390]: cannot define inherent `impl` for a type outside of the crate where the type is defined
+  --> $DIR/needs-has-incoherent-impls.rs:17:1
    |
 LL | / impl extern_crate::StructNoAttr {
+LL | |
 LL | |     #[rustc_allow_incoherent_impl]
 LL | |     fn bar() {}
 LL | | }
@@ -41,50 +45,55 @@ LL | | }
    |
    = help: consider moving this inherent impl into the crate defining the type if possible
 help: alternatively add `#[rustc_has_incoherent_inherent_impls]` to the type and `#[rustc_allow_incoherent_impl]` to the relevant impl items
-  --> $DIR/needs-has-incoherent-impls.rs:15:1
+  --> $DIR/needs-has-incoherent-impls.rs:17:1
    |
 LL | / impl extern_crate::StructNoAttr {
+LL | |
 LL | |     #[rustc_allow_incoherent_impl]
 LL | |     fn bar() {}
 LL | | }
    | |_^
 
-error[E0390]: cannot define inherent `impl` for a type outside of crate where the type is defined
-  --> $DIR/needs-has-incoherent-impls.rs:19:1
+error[E0390]: cannot define inherent `impl` for a type outside of the crate where the type is defined
+  --> $DIR/needs-has-incoherent-impls.rs:22:1
    |
 LL | / impl extern_crate::EnumWithAttr {
+LL | |
 LL | |     fn foo() {}
 LL | | }
    | |_^
    |
    = help: consider moving this inherent impl into the crate defining the type if possible
 help: alternatively add `#[rustc_allow_incoherent_impl]` to the relevant impl items
-  --> $DIR/needs-has-incoherent-impls.rs:20:5
+  --> $DIR/needs-has-incoherent-impls.rs:24:5
    |
 LL |     fn foo() {}
    |     ^^^^^^^^^^^
 
-error[E0390]: cannot define inherent `impl` for a type outside of crate where the type is defined
-  --> $DIR/needs-has-incoherent-impls.rs:26:1
+error[E0390]: cannot define inherent `impl` for a type outside of the crate where the type is defined
+  --> $DIR/needs-has-incoherent-impls.rs:30:1
    |
 LL | / impl extern_crate::EnumNoAttr {
+LL | |
 LL | |     fn foo() {}
 LL | | }
    | |_^
    |
    = help: consider moving this inherent impl into the crate defining the type if possible
 help: alternatively add `#[rustc_has_incoherent_inherent_impls]` to the type and `#[rustc_allow_incoherent_impl]` to the relevant impl items
-  --> $DIR/needs-has-incoherent-impls.rs:26:1
+  --> $DIR/needs-has-incoherent-impls.rs:30:1
    |
 LL | / impl extern_crate::EnumNoAttr {
+LL | |
 LL | |     fn foo() {}
 LL | | }
    | |_^
 
-error[E0390]: cannot define inherent `impl` for a type outside of crate where the type is defined
-  --> $DIR/needs-has-incoherent-impls.rs:29:1
+error[E0390]: cannot define inherent `impl` for a type outside of the crate where the type is defined
+  --> $DIR/needs-has-incoherent-impls.rs:34:1
    |
 LL | / impl extern_crate::EnumNoAttr {
+LL | |
 LL | |     #[rustc_allow_incoherent_impl]
 LL | |     fn bar() {}
 LL | | }
@@ -92,9 +101,10 @@ LL | | }
    |
    = help: consider moving this inherent impl into the crate defining the type if possible
 help: alternatively add `#[rustc_has_incoherent_inherent_impls]` to the type and `#[rustc_allow_incoherent_impl]` to the relevant impl items
-  --> $DIR/needs-has-incoherent-impls.rs:29:1
+  --> $DIR/needs-has-incoherent-impls.rs:34:1
    |
 LL | / impl extern_crate::EnumNoAttr {
+LL | |
 LL | |     #[rustc_allow_incoherent_impl]
 LL | |     fn bar() {}
 LL | | }

--- a/src/test/ui/incoherent-inherent-impls/no-attr-empty-impl.rs
+++ b/src/test/ui/incoherent-inherent-impls/no-attr-empty-impl.rs
@@ -1,0 +1,14 @@
+// aux-build:extern-crate.rs
+extern crate extern_crate;
+
+impl extern_crate::StructWithAttr {} //~ ERROR
+
+impl extern_crate::StructNoAttr {} //~ ERROR
+
+impl extern_crate::EnumWithAttr {} //~ ERROR
+
+impl extern_crate::EnumNoAttr {} //~ ERROR
+
+impl f32 {} //~ ERROR
+
+fn main() {}

--- a/src/test/ui/incoherent-inherent-impls/no-attr-empty-impl.rs
+++ b/src/test/ui/incoherent-inherent-impls/no-attr-empty-impl.rs
@@ -1,14 +1,18 @@
 // aux-build:extern-crate.rs
 extern crate extern_crate;
 
-impl extern_crate::StructWithAttr {} //~ ERROR
+impl extern_crate::StructWithAttr {}
+//~^ ERROR cannot define inherent `impl` for a type outside of the crate
 
-impl extern_crate::StructNoAttr {} //~ ERROR
+impl extern_crate::StructNoAttr {}
+//~^ ERROR cannot define inherent `impl` for a type outside of the crate
 
-impl extern_crate::EnumWithAttr {} //~ ERROR
+impl extern_crate::EnumWithAttr {}
+//~^ ERROR cannot define inherent `impl` for a type outside of the crate
 
-impl extern_crate::EnumNoAttr {} //~ ERROR
+impl extern_crate::EnumNoAttr {}
+//~^ ERROR cannot define inherent `impl` for a type outside of the crate
 
-impl f32 {} //~ ERROR
+impl f32 {} //~ ERROR cannot define inherent `impl` for primitive types
 
 fn main() {}

--- a/src/test/ui/incoherent-inherent-impls/no-attr-empty-impl.stderr
+++ b/src/test/ui/incoherent-inherent-impls/no-attr-empty-impl.stderr
@@ -7,7 +7,7 @@ LL | impl extern_crate::StructWithAttr {}
    = note: define and implement a trait or new type instead
 
 error[E0116]: cannot define inherent `impl` for a type outside of the crate where the type is defined
-  --> $DIR/no-attr-empty-impl.rs:6:1
+  --> $DIR/no-attr-empty-impl.rs:7:1
    |
 LL | impl extern_crate::StructNoAttr {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl for type defined outside of crate.
@@ -15,7 +15,7 @@ LL | impl extern_crate::StructNoAttr {}
    = note: define and implement a trait or new type instead
 
 error[E0116]: cannot define inherent `impl` for a type outside of the crate where the type is defined
-  --> $DIR/no-attr-empty-impl.rs:8:1
+  --> $DIR/no-attr-empty-impl.rs:10:1
    |
 LL | impl extern_crate::EnumWithAttr {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl for type defined outside of crate.
@@ -23,7 +23,7 @@ LL | impl extern_crate::EnumWithAttr {}
    = note: define and implement a trait or new type instead
 
 error[E0116]: cannot define inherent `impl` for a type outside of the crate where the type is defined
-  --> $DIR/no-attr-empty-impl.rs:10:1
+  --> $DIR/no-attr-empty-impl.rs:13:1
    |
 LL | impl extern_crate::EnumNoAttr {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl for type defined outside of crate.
@@ -31,7 +31,7 @@ LL | impl extern_crate::EnumNoAttr {}
    = note: define and implement a trait or new type instead
 
 error[E0390]: cannot define inherent `impl` for primitive types
-  --> $DIR/no-attr-empty-impl.rs:12:6
+  --> $DIR/no-attr-empty-impl.rs:16:6
    |
 LL | impl f32 {}
    |      ^^^

--- a/src/test/ui/incoherent-inherent-impls/no-attr-empty-impl.stderr
+++ b/src/test/ui/incoherent-inherent-impls/no-attr-empty-impl.stderr
@@ -1,0 +1,44 @@
+error[E0116]: cannot define inherent `impl` for a type outside of the crate where the type is defined
+  --> $DIR/no-attr-empty-impl.rs:4:1
+   |
+LL | impl extern_crate::StructWithAttr {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl for type defined outside of crate.
+   |
+   = note: define and implement a trait or new type instead
+
+error[E0116]: cannot define inherent `impl` for a type outside of the crate where the type is defined
+  --> $DIR/no-attr-empty-impl.rs:6:1
+   |
+LL | impl extern_crate::StructNoAttr {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl for type defined outside of crate.
+   |
+   = note: define and implement a trait or new type instead
+
+error[E0116]: cannot define inherent `impl` for a type outside of the crate where the type is defined
+  --> $DIR/no-attr-empty-impl.rs:8:1
+   |
+LL | impl extern_crate::EnumWithAttr {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl for type defined outside of crate.
+   |
+   = note: define and implement a trait or new type instead
+
+error[E0116]: cannot define inherent `impl` for a type outside of the crate where the type is defined
+  --> $DIR/no-attr-empty-impl.rs:10:1
+   |
+LL | impl extern_crate::EnumNoAttr {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl for type defined outside of crate.
+   |
+   = note: define and implement a trait or new type instead
+
+error[E0390]: cannot define inherent `impl` for primitive types
+  --> $DIR/no-attr-empty-impl.rs:12:6
+   |
+LL | impl f32 {}
+   |      ^^^
+   |
+   = help: consider using an extension trait instead
+
+error: aborting due to 5 previous errors
+
+Some errors have detailed explanations: E0116, E0390.
+For more information about an error, try `rustc --explain E0116`.


### PR DESCRIPTION
To allow the move of `trait Error` into core.

continues the work from #94963, finishes https://github.com/rust-lang/compiler-team/issues/487

r? @petrochenkov cc @yaahc