### PR TITLE
rustdoc: Create an attribute version of `--extern-html-root-url`

### DIFF
--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -1020,6 +1020,7 @@ impl CheckAttrVisitor<'_> {
                         | sym::html_root_url
                         | sym::html_no_source
                         | sym::test
+                        | sym::extern_html_root_url
                             if !self.check_attr_crate_level(attr, meta, hir_id) =>
                         {
                             is_valid = false;
@@ -1052,6 +1053,7 @@ impl CheckAttrVisitor<'_> {
                         sym::alias
                         | sym::cfg
                         | sym::cfg_hide
+                        | sym::extern_html_root_url
                         | sym::hidden
                         | sym::html_favicon_url
                         | sym::html_logo_url

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -653,6 +653,7 @@ symbols! {
         extern_absolute_paths,
         extern_crate_item_prelude,
         extern_crate_self,
+        extern_html_root_url,
         extern_in_paths,
         extern_prelude,
         extern_types,

--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -230,7 +230,8 @@ pub(crate) struct RenderOptions {
     pub(crate) extension_css: Option<PathBuf>,
     /// A map of crate names to the URL to use instead of querying the crate's `html_root_url`.
     pub(crate) extern_html_root_urls: BTreeMap<String, String>,
-    /// Whether to give precedence to `html_root_url` or `--exten-html-root-url`.
+    /// Whether to give precedence to `html_root_url` or `--extern-html-root-url`.
+    /// By default it is `html_root_url`.
     pub(crate) extern_html_root_takes_precedence: bool,
     /// A map of the default settings (values are as for DOM storage API). Keys should lack the
     /// `rustdoc-` prefix.

--- a/src/test/rustdoc-ui/extern_html_root_url.rs
+++ b/src/test/rustdoc-ui/extern_html_root_url.rs
@@ -1,0 +1,18 @@
+#![crate_type = "lib"]
+
+#![doc(extern_html_root_url)]
+//~^ ERROR
+#![doc(extern_html_root_url = "a")]
+//~^ ERROR
+#![doc(extern_html_root_url(a))]
+//~^ ERROR
+#![doc(extern_html_root_url(a()))]
+//~^ ERROR
+#![doc(extern_html_root_url(a = 1))]
+//~^ ERROR
+#![doc(extern_html_root_url(a = ""))]
+//~^ ERROR
+#![doc(extern_html_root_url(a = "1"))] // This one is supposed to work.
+#![doc(extern_html_root_url(b = "2", c = "3"))] // This one is supposed to work.
+
+pub fn foo() {}

--- a/src/test/rustdoc-ui/extern_html_root_url.stderr
+++ b/src/test/rustdoc-ui/extern_html_root_url.stderr
@@ -1,0 +1,38 @@
+error: extern_html_root_url only accepts this form: `extern_html_root_url(crate = "url")`
+  --> $DIR/extern_html_root_url.rs:3:8
+   |
+LL | #![doc(extern_html_root_url)]
+   |        ^^^^^^^^^^^^^^^^^^^^
+
+error: extern_html_root_url only accepts this form: `extern_html_root_url(crate = "url")`
+  --> $DIR/extern_html_root_url.rs:5:8
+   |
+LL | #![doc(extern_html_root_url = "a")]
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: extern_html_root_url() only accepts `crate_name = "url"`
+  --> $DIR/extern_html_root_url.rs:7:29
+   |
+LL | #![doc(extern_html_root_url(a))]
+   |                             ^
+
+error: extern_html_root_url() only accepts `crate_name = "url"`
+  --> $DIR/extern_html_root_url.rs:9:29
+   |
+LL | #![doc(extern_html_root_url(a()))]
+   |                             ^^^
+
+error: extern_html_root_url() only accepts `crate_name = "url"`
+  --> $DIR/extern_html_root_url.rs:11:29
+   |
+LL | #![doc(extern_html_root_url(a = 1))]
+   |                             ^^^^^
+
+error: URL cannot be empty
+  --> $DIR/extern_html_root_url.rs:13:29
+   |
+LL | #![doc(extern_html_root_url(a = ""))]
+   |                             ^^^^^^
+
+error: aborting due to 6 previous errors
+

--- a/src/test/rustdoc/extern_html_root_url.rs
+++ b/src/test/rustdoc/extern_html_root_url.rs
@@ -1,0 +1,6 @@
+#![crate_name = "foo"]
+#![doc(extern_html_root_url(std = "https://doc.rust-lang.org/nightly"))]
+
+// @has 'foo/index.html'
+// @has - '//a[@class="mod"]/@href' 'https://doc.rust-lang.org/nightly/std/index.html'
+pub use std as other;


### PR DESCRIPTION
This is a potential first step for a change of behaviour for `--html-root-url`. Currently, unless you use `--extern-html-root-takes-precedence`, if you have set `--html-root-url`, it'll always skip the content of `--extern-html-root-url`. I'd prefer if it did that only in case there is no entry for this crate, which would make more sense I think.

Anyway, this PR is "only" about allowing to write:

```rust
#![doc(extern_html_root_url(std = "https://doc.rust-lang.org/nightly"))]
```

I felt the need for it because of https://github.com/rust-lang/rust/pull/96519.

So what do you think?

cc @rust-lang/rustdoc
r? rust-lang/rustdoc