### PR TITLE
Work around bad `ptr::with_addr` codegen in `core::ptr`

### DIFF
--- a/library/core/src/ptr/const_ptr.rs
+++ b/library/core/src/ptr/const_ptr.rs
@@ -260,7 +260,7 @@ impl<T: ?Sized> *const T {
         //
         // As a result, we use the following implementation, which would be
         // wrong on CHERI, but right everywhere else.
-        self.cast::<u8>().wrapping_sub(self_addr).wrapping_add(addr).cast::<T>()
+        self.cast::<u8>().wrapping_add(addr).wrapping_sub(self_addr).cast::<T>()
     }
 
     /// Creates a new pointer by mapping `self`'s address to a new one.

--- a/library/core/src/ptr/const_ptr.rs
+++ b/library/core/src/ptr/const_ptr.rs
@@ -242,12 +242,20 @@ impl<T: ?Sized> *const T {
         // In the mean-time, this operation is defined to be "as if" it was
         // a wrapping_offset, so we can emulate it as such. This should properly
         // restore pointer provenance even under today's compiler.
-        let self_addr = self.addr() as isize;
-        let dest_addr = addr as isize;
-        let offset = dest_addr.wrapping_sub(self_addr);
-
-        // This is the canonical desugarring of this operation
-        self.cast::<u8>().wrapping_offset(offset).cast::<T>()
+        let self_addr = self.addr();
+        // Unfortunately, the CHERI-compatible way of defining this operation
+        // optimizes worse, so we special case it... in a somewhat ad-hoc way
+        // (checking for 128 bit pointers) because at the time of this writing,
+        // we don't actually support CHERI yet. Ideally this would be
+        // `cfg!(target_supports_large_wrapping_offsets)` or something, see
+        // #96152 for details.
+        if cfg!(target_pointer_width = "128") {
+            let offset = (addr as isize).wrapping_sub(self_addr as isize);
+            // This is the canonical desugarring of this operation
+            self.cast::<u8>().wrapping_offset(offset).cast::<T>()
+        } else {
+            self.cast::<u8>().wrapping_sub(self_addr).wrapping_add(addr).cast::<T>()
+        }
     }
 
     /// Creates a new pointer by mapping `self`'s address to a new one.

--- a/library/core/src/ptr/mut_ptr.rs
+++ b/library/core/src/ptr/mut_ptr.rs
@@ -264,7 +264,7 @@ impl<T: ?Sized> *mut T {
         //
         // As a result, we use the following implementation, which would be
         // wrong on CHERI, but right everywhere else.
-        self.cast::<u8>().wrapping_sub(self_addr).wrapping_add(addr).cast::<T>()
+        self.cast::<u8>().wrapping_add(addr).wrapping_sub(self_addr).cast::<T>()
     }
 
     /// Creates a new pointer by mapping `self`'s address to a new one.

--- a/library/core/src/ptr/mut_ptr.rs
+++ b/library/core/src/ptr/mut_ptr.rs
@@ -247,19 +247,24 @@ impl<T: ?Sized> *mut T {
         // a wrapping_offset, so we can emulate it as such. This should properly
         // restore pointer provenance even under today's compiler.
         let self_addr = self.addr();
-        // Unfortunately, the CHERI-compatible way of defining this operation
-        // optimizes worse, so we special case it... in a somewhat ad-hoc way
-        // (checking for 128 bit pointers) because at the time of this writing,
-        // we don't actually support CHERI yet. Ideally this would be
-        // `cfg!(target_supports_large_wrapping_offsets)` or something, see
-        // #96152 for details.
-        if cfg!(target_pointer_width = "128") {
-            let offset = (addr as isize).wrapping_sub(self_addr as isize);
-            // This is the canonical desugarring of this operation
-            self.cast::<u8>().wrapping_offset(offset).cast::<T>()
-        } else {
-            self.cast::<u8>().wrapping_sub(self_addr).wrapping_add(addr).cast::<T>()
-        }
+        // In an ideal world (err, an ideal world we'd have an intrinsic, but
+        // short of that), we'd implement this as follows:
+        // ```
+        // let offset = (addr as isize).wrapping_sub(self_addr as isize);
+        // self.cast::<u8>().wrapping_offset(offset).cast::<T>()
+        // ```
+        // This is the canonical desugaring of this operation, and is compatible
+        // with targets which don't allow large wrapping add/sub/offset
+        // operations, including CHERI.
+        //
+        // Unfortunately, this causes worse codegen than the following
+        // implementation, which should be correct on all targets we currently
+        // support (at the moment AFAICT, we don't yet support CHERI, or we'd
+        // special-case it to use the desugaring listed above).
+        //
+        // As a result, we use the following implementation, which would be
+        // wrong on CHERI, but right everywhere else.
+        self.cast::<u8>().wrapping_sub(self_addr).wrapping_add(addr).cast::<T>()
     }
 
     /// Creates a new pointer by mapping `self`'s address to a new one.


### PR DESCRIPTION
Fixes #96152.

Probably not really the ideal way to fix this, but the ideal way is an LLVM patch (or to make it an intrinsic), and I'm not a compiler person.