### PR TITLE
[compiletest] Ignore known paths when abbreviating output

### DIFF
--- a/src/tools/compiletest/src/read2.rs
+++ b/src/tools/compiletest/src/read2.rs
@@ -1,6 +1,9 @@
 // FIXME: This is a complete copy of `cargo/src/cargo/util/read2.rs`
 // Consider unify the read2() in libstd, cargo and this to prevent further code duplication.
 
+#[cfg(test)]
+mod tests;
+
 pub use self::imp::read2;
 use std::io::{self, Write};
 use std::mem::replace;

--- a/src/tools/compiletest/src/read2.rs
+++ b/src/tools/compiletest/src/read2.rs
@@ -74,7 +74,8 @@ impl ProcOutput {
                 }
 
                 let mut head = replace(bytes, Vec::new());
-                let tail = head.split_off(new_len - TAIL_LEN).into_boxed_slice();
+                let mut middle = head.split_off(HEAD_LEN);
+                let tail = middle.split_off(middle.len() - TAIL_LEN).into_boxed_slice();
                 let skipped = new_len - HEAD_LEN - TAIL_LEN;
                 ProcOutput::Abbreviated { head, skipped, tail }
             }

--- a/src/tools/compiletest/src/read2/tests.rs
+++ b/src/tools/compiletest/src/read2/tests.rs
@@ -1,0 +1,123 @@
+use crate::read2::{ProcOutput, EXCLUDED_PLACEHOLDER_LEN, HEAD_LEN, TAIL_LEN};
+
+#[test]
+fn test_abbreviate_short_string() {
+    let mut out = ProcOutput::new();
+    out.extend(b"Hello world!", &[]);
+    assert_eq!(b"Hello world!", &*out.into_bytes());
+}
+
+#[test]
+fn test_abbreviate_short_string_multiple_steps() {
+    let mut out = ProcOutput::new();
+
+    out.extend(b"Hello ", &[]);
+    out.extend(b"world!", &[]);
+
+    assert_eq!(b"Hello world!", &*out.into_bytes());
+}
+
+#[test]
+fn test_abbreviate_long_string() {
+    let mut out = ProcOutput::new();
+
+    let data = vec![b'.'; HEAD_LEN + TAIL_LEN + 16];
+    out.extend(&data, &[]);
+
+    let mut expected = vec![b'.'; HEAD_LEN];
+    expected.extend_from_slice(b"\n\n<<<<<< SKIPPED 16 BYTES >>>>>>\n\n");
+    expected.extend_from_slice(&vec![b'.'; TAIL_LEN]);
+
+    // We first check the length to avoid endless terminal output if the length differs, since
+    // `out` is hundreds of KBs in size.
+    let out = out.into_bytes();
+    assert_eq!(expected.len(), out.len());
+    assert_eq!(expected, out);
+}
+
+#[test]
+fn test_abbreviate_long_string_multiple_steps() {
+    let mut out = ProcOutput::new();
+
+    out.extend(&vec![b'.'; HEAD_LEN], &[]);
+    out.extend(&vec![b'.'; TAIL_LEN], &[]);
+    // Also test whether the rotation works
+    out.extend(&vec![b'!'; 16], &[]);
+    out.extend(&vec![b'?'; 16], &[]);
+
+    let mut expected = vec![b'.'; HEAD_LEN];
+    expected.extend_from_slice(b"\n\n<<<<<< SKIPPED 32 BYTES >>>>>>\n\n");
+    expected.extend_from_slice(&vec![b'.'; TAIL_LEN - 32]);
+    expected.extend_from_slice(&vec![b'!'; 16]);
+    expected.extend_from_slice(&vec![b'?'; 16]);
+
+    // We first check the length to avoid endless terminal output if the length differs, since
+    // `out` is hundreds of KBs in size.
+    let out = out.into_bytes();
+    assert_eq!(expected.len(), out.len());
+    assert_eq!(expected, out);
+}
+
+#[test]
+fn test_abbreviate_exclusions_are_detected() {
+    let mut out = ProcOutput::new();
+    let exclusions = &["foo".to_string(), "quux".to_string()];
+
+    out.extend(b"Hello foo", exclusions);
+    // Check items from a previous extension are not double-counted.
+    out.extend(b"! This is a qu", exclusions);
+    // Check items are detected across extensions.
+    out.extend(b"ux.", exclusions);
+
+    match out {
+        ProcOutput::Full { excluded_len, .. } => assert_eq!(
+            excluded_len,
+            EXCLUDED_PLACEHOLDER_LEN * exclusions.len() as isize
+                - exclusions.iter().map(|i| i.len() as isize).sum::<isize>()
+        ),
+        ProcOutput::Abbreviated { .. } => panic!("out should not be abbreviated"),
+    }
+
+    assert_eq!(b"Hello foo! This is a quux.", &*out.into_bytes());
+}
+
+#[test]
+fn test_abbreviate_exclusions_avoid_abbreviations() {
+    let mut out = ProcOutput::new();
+    let exclusions = &[std::iter::repeat('a').take(64).collect::<String>()];
+
+    let mut expected = vec![b'.'; HEAD_LEN - EXCLUDED_PLACEHOLDER_LEN as usize];
+    expected.extend_from_slice(exclusions[0].as_bytes());
+    expected.extend_from_slice(&vec![b'.'; TAIL_LEN]);
+
+    out.extend(&expected, exclusions);
+
+    // We first check the length to avoid endless terminal output if the length differs, since
+    // `out` is hundreds of KBs in size.
+    let out = out.into_bytes();
+    assert_eq!(expected.len(), out.len());
+    assert_eq!(expected, out);
+}
+
+#[test]
+fn test_abbreviate_exclusions_can_still_cause_abbreviations() {
+    let mut out = ProcOutput::new();
+    let exclusions = &[std::iter::repeat('a').take(64).collect::<String>()];
+
+    let mut input = vec![b'.'; HEAD_LEN];
+    input.extend_from_slice(&vec![b'.'; TAIL_LEN]);
+    input.extend_from_slice(exclusions[0].as_bytes());
+
+    let mut expected = vec![b'.'; HEAD_LEN];
+    expected.extend_from_slice(b"\n\n<<<<<< SKIPPED 64 BYTES >>>>>>\n\n");
+    expected.extend_from_slice(&vec![b'.'; TAIL_LEN - 64]);
+    expected.extend_from_slice(&vec![b'a'; 64]);
+
+    out.extend(&input, exclusions);
+
+    // We first check the length to avoid endless terminal output if the length differs, since
+    // `out` is hundreds of KBs in size.
+    let out = out.into_bytes();
+    assert_eq!(expected.len(), out.len());
+    assert_eq!(expected, out);
+}

--- a/src/tools/compiletest/src/read2/tests.rs
+++ b/src/tools/compiletest/src/read2/tests.rs
@@ -1,4 +1,4 @@
-use crate::read2::{ProcOutput, EXCLUDED_PLACEHOLDER_LEN, HEAD_LEN, TAIL_LEN};
+use crate::read2::{ProcOutput, FILTERED_PATHS_PLACEHOLDER_LEN, HEAD_LEN, TAIL_LEN};
 
 #[test]
 fn test_abbreviate_short_string() {
@@ -59,21 +59,21 @@ fn test_abbreviate_long_string_multiple_steps() {
 }
 
 #[test]
-fn test_abbreviate_exclusions_are_detected() {
+fn test_abbreviate_filterss_are_detected() {
     let mut out = ProcOutput::new();
-    let exclusions = &["foo".to_string(), "quux".to_string()];
+    let filters = &["foo".to_string(), "quux".to_string()];
 
-    out.extend(b"Hello foo", exclusions);
+    out.extend(b"Hello foo", filters);
     // Check items from a previous extension are not double-counted.
-    out.extend(b"! This is a qu", exclusions);
+    out.extend(b"! This is a qu", filters);
     // Check items are detected across extensions.
-    out.extend(b"ux.", exclusions);
+    out.extend(b"ux.", filters);
 
-    match out {
-        ProcOutput::Full { excluded_len, .. } => assert_eq!(
-            excluded_len,
-            EXCLUDED_PLACEHOLDER_LEN * exclusions.len() as isize
-                - exclusions.iter().map(|i| i.len() as isize).sum::<isize>()
+    match &out {
+        ProcOutput::Full { bytes, filtered_len } => assert_eq!(
+            *filtered_len,
+            bytes.len() + FILTERED_PATHS_PLACEHOLDER_LEN * filters.len()
+                - filters.iter().map(|i| i.len()).sum::<usize>()
         ),
         ProcOutput::Abbreviated { .. } => panic!("out should not be abbreviated"),
     }
@@ -82,15 +82,15 @@ fn test_abbreviate_exclusions_are_detected() {
 }
 
 #[test]
-fn test_abbreviate_exclusions_avoid_abbreviations() {
+fn test_abbreviate_filters_avoid_abbreviations() {
     let mut out = ProcOutput::new();
-    let exclusions = &[std::iter::repeat('a').take(64).collect::<String>()];
+    let filters = &[std::iter::repeat('a').take(64).collect::<String>()];
 
-    let mut expected = vec![b'.'; HEAD_LEN - EXCLUDED_PLACEHOLDER_LEN as usize];
-    expected.extend_from_slice(exclusions[0].as_bytes());
+    let mut expected = vec![b'.'; HEAD_LEN - FILTERED_PATHS_PLACEHOLDER_LEN as usize];
+    expected.extend_from_slice(filters[0].as_bytes());
     expected.extend_from_slice(&vec![b'.'; TAIL_LEN]);
 
-    out.extend(&expected, exclusions);
+    out.extend(&expected, filters);
 
     // We first check the length to avoid endless terminal output if the length differs, since
     // `out` is hundreds of KBs in size.
@@ -100,20 +100,20 @@ fn test_abbreviate_exclusions_avoid_abbreviations() {
 }
 
 #[test]
-fn test_abbreviate_exclusions_can_still_cause_abbreviations() {
+fn test_abbreviate_filters_can_still_cause_abbreviations() {
     let mut out = ProcOutput::new();
-    let exclusions = &[std::iter::repeat('a').take(64).collect::<String>()];
+    let filters = &[std::iter::repeat('a').take(64).collect::<String>()];
 
     let mut input = vec![b'.'; HEAD_LEN];
     input.extend_from_slice(&vec![b'.'; TAIL_LEN]);
-    input.extend_from_slice(exclusions[0].as_bytes());
+    input.extend_from_slice(filters[0].as_bytes());
 
     let mut expected = vec![b'.'; HEAD_LEN];
     expected.extend_from_slice(b"\n\n<<<<<< SKIPPED 64 BYTES >>>>>>\n\n");
     expected.extend_from_slice(&vec![b'.'; TAIL_LEN - 64]);
     expected.extend_from_slice(&vec![b'a'; 64]);
 
-    out.extend(&input, exclusions);
+    out.extend(&input, filters);
 
     // We first check the length to avoid endless terminal output if the length differs, since
     // `out` is hundreds of KBs in size.

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -28,7 +28,7 @@ use std::hash::{Hash, Hasher};
 use std::io::prelude::*;
 use std::io::{self, BufReader};
 use std::path::{Path, PathBuf};
-use std::process::{Command, ExitStatus, Output, Stdio};
+use std::process::{Child, Command, ExitStatus, Output, Stdio};
 use std::str;
 
 use glob::glob;
@@ -1735,6 +1735,28 @@ impl<'test> TestCx<'test> {
         dylib
     }
 
+    fn read2_abbreviated(&self, child: Child) -> Output {
+        let mut exclude_from_len = Vec::new();
+        let mut add_path = |path: &Path| {
+            let path = path.display().to_string();
+            let windows = path.replace("\\", "\\\\");
+            if windows != path {
+                exclude_from_len.push(windows);
+            }
+            exclude_from_len.push(path);
+        };
+
+        // List of strings that will not be measured when determining whether the output is larger
+        // than the output truncation threshold.
+        //
+        // Note: avoid adding a subdirectory of an already excluded directory here, otherwise the
+        // same slice of text will be double counted and the truncation might not happen.
+        add_path(&self.config.src_base);
+        add_path(&self.config.build_base);
+
+        read2_abbreviated(child, &exclude_from_len).expect("failed to read output")
+    }
+
     fn compose_and_run(
         &self,
         mut command: Command,
@@ -1769,8 +1791,7 @@ impl<'test> TestCx<'test> {
             child.stdin.as_mut().unwrap().write_all(input.as_bytes()).unwrap();
         }
 
-        let Output { status, stdout, stderr } =
-            read2_abbreviated(child).expect("failed to read output");
+        let Output { status, stdout, stderr } = self.read2_abbreviated(child);
 
         let result = ProcRes {
             status,
@@ -2959,7 +2980,7 @@ impl<'test> TestCx<'test> {
             }
         }
 
-        let output = cmd.spawn().and_then(read2_abbreviated).expect("failed to spawn `make`");
+        let output = self.read2_abbreviated(cmd.spawn().expect("failed to spawn `make`"));
         if !output.status.success() {
             let res = ProcRes {
                 status: output.status,

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -1736,25 +1736,25 @@ impl<'test> TestCx<'test> {
     }
 
     fn read2_abbreviated(&self, child: Child) -> Output {
-        let mut exclude_from_len = Vec::new();
+        let mut filter_paths_from_len = Vec::new();
         let mut add_path = |path: &Path| {
             let path = path.display().to_string();
             let windows = path.replace("\\", "\\\\");
             if windows != path {
-                exclude_from_len.push(windows);
+                filter_paths_from_len.push(windows);
             }
-            exclude_from_len.push(path);
+            filter_paths_from_len.push(path);
         };
 
-        // List of strings that will not be measured when determining whether the output is larger
+        // List of paths that will not be measured when determining whether the output is larger
         // than the output truncation threshold.
         //
-        // Note: avoid adding a subdirectory of an already excluded directory here, otherwise the
+        // Note: avoid adding a subdirectory of an already filtered directory here, otherwise the
         // same slice of text will be double counted and the truncation might not happen.
         add_path(&self.config.src_base);
         add_path(&self.config.build_base);
 
-        read2_abbreviated(child, &exclude_from_len).expect("failed to read output")
+        read2_abbreviated(child, &filter_paths_from_len).expect("failed to read output")
     }
 
     fn compose_and_run(


### PR DESCRIPTION
To prevent out of memory conditions, compiletest limits the amount of output a test can generate, abbreviating it if the test emits more than a threshold. While the behavior is desirable, it also causes some issues (like #96229, #94322 and #92211).

The latest one happened recently, when the `src/test/ui/numeric/numeric-cast.rs` test started to fail on systems where the path of the rust-lang/rust checkout is too long. This includes my own development machine and [LLVM's CI](https://github.com/rust-lang/rust/issues/96362#issuecomment-1108609893). Rust's CI uses a pretty short directory name for the checkout, which hides these sort of problems until someone runs the test suite on their own computer.

When developing the fix I tried to find the most targeted fix that would prevent this class of failures from happening in the future, deferring the decision on if/how to redesign abbreviation to a later date. The solution I came up with was to ignore known base paths when calculating whether the output exceeds the abbreviation threshold, which removes this kind of nondeterminism.

This PR is best reviewed commit-by-commit.