### PR TITLE
Allow inline consts to reference generic params

### DIFF
--- a/compiler/rustc_middle/src/ty/print/mod.rs
+++ b/compiler/rustc_middle/src/ty/print/mod.rs
@@ -136,6 +136,10 @@ pub trait Printer<'tcx>: Sized {
                     match key.disambiguated_data.data {
                         // Closures' own generics are only captures, don't print them.
                         DefPathData::ClosureExpr => {}
+                        // This covers both `DefKind::AnonConst` and `DefKind::InlineConst`.
+                        // Anon consts doesn't have their own generics, and inline consts' own
+                        // generics are their inferred types, so don't print them.
+                        DefPathData::AnonConst => {}
 
                         // If we have any generic arguments to print, we do that
                         // on top of the same path, but without its own generics.

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -3101,6 +3101,13 @@ impl<'a: 'ast, 'b, 'ast> LateResolutionVisitor<'a, 'b, 'ast> {
         );
     }
 
+    fn resolve_inline_const(&mut self, constant: &'ast AnonConst) {
+        debug!("resolve_anon_const {constant:?}");
+        self.with_constant_rib(IsRepeatExpr::No, HasGenericParams::Yes, None, |this| {
+            visit::walk_anon_const(this, constant);
+        });
+    }
+
     fn resolve_expr(&mut self, expr: &'ast Expr, parent: Option<&'ast Expr>) {
         // First, record candidate traits for this expression if it could
         // result in the invocation of a method call.
@@ -3257,7 +3264,7 @@ impl<'a: 'ast, 'b, 'ast> LateResolutionVisitor<'a, 'b, 'ast> {
                 });
             }
             ExprKind::ConstBlock(ref ct) => {
-                self.resolve_anon_const(ct, IsRepeatExpr::No);
+                self.resolve_inline_const(ct);
             }
             ExprKind::Index(ref elem, ref idx) => {
                 self.resolve_expr(elem, Some(expr));

--- a/src/test/ui/inline-const/const-expr-generic-err.rs
+++ b/src/test/ui/inline-const/const-expr-generic-err.rs
@@ -1,0 +1,15 @@
+// build-fail
+#![feature(inline_const)]
+
+fn foo<T>() {
+    const { assert!(std::mem::size_of::<T>() == 0); } //~ ERROR E0080
+}
+
+fn bar<const N: usize>() -> usize {
+    const { N - 1 } //~ ERROR E0080
+}
+
+fn main() {
+    foo::<i32>();
+    bar::<0>();
+}

--- a/src/test/ui/inline-const/const-expr-generic-err.stderr
+++ b/src/test/ui/inline-const/const-expr-generic-err.stderr
@@ -1,0 +1,29 @@
+error[E0080]: evaluation of `foo::<i32>::{constant#0}` failed
+  --> $DIR/const-expr-generic-err.rs:5:13
+   |
+LL |     const { assert!(std::mem::size_of::<T>() == 0); }
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'assertion failed: std::mem::size_of::<T>() == 0', $DIR/const-expr-generic-err.rs:5:13
+   |
+   = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+note: the above error was encountered while instantiating `fn foo::<i32>`
+  --> $DIR/const-expr-generic-err.rs:13:5
+   |
+LL |     foo::<i32>();
+   |     ^^^^^^^^^^^^
+
+error[E0080]: evaluation of `bar::<0_usize>::{constant#0}` failed
+  --> $DIR/const-expr-generic-err.rs:9:13
+   |
+LL |     const { N - 1 }
+   |             ^^^^^ attempt to compute `0_usize - 1_usize`, which would overflow
+
+note: the above error was encountered while instantiating `fn bar::<0_usize>`
+  --> $DIR/const-expr-generic-err.rs:14:5
+   |
+LL |     bar::<0>();
+   |     ^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/inline-const/const-expr-generic-err2.rs
+++ b/src/test/ui/inline-const/const-expr-generic-err2.rs
@@ -1,0 +1,10 @@
+#![feature(inline_const)]
+
+fn foo<T>() {
+    let _ = [0u8; const { std::mem::size_of::<T>() }];
+    //~^ ERROR: constant expression depends on a generic parameter
+}
+
+fn main() {
+    foo::<i32>();
+}

--- a/src/test/ui/inline-const/const-expr-generic-err2.stderr
+++ b/src/test/ui/inline-const/const-expr-generic-err2.stderr
@@ -1,0 +1,10 @@
+error: constant expression depends on a generic parameter
+  --> $DIR/const-expr-generic-err2.rs:4:19
+   |
+LL |     let _ = [0u8; const { std::mem::size_of::<T>() }];
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this may fail depending on what value the parameter takes
+
+error: aborting due to previous error
+

--- a/src/test/ui/inline-const/const-expr-generic.rs
+++ b/src/test/ui/inline-const/const-expr-generic.rs
@@ -1,0 +1,15 @@
+// check-pass
+#![feature(inline_const)]
+
+fn foo<T>() -> usize {
+    const { std::mem::size_of::<T>() }
+}
+
+fn bar<const N: usize>() -> usize {
+    const { N + 1 }
+}
+
+fn main() {
+    foo::<i32>();
+    bar::<1>();
+}

--- a/src/test/ui/inline-const/const-match-pat-generic.rs
+++ b/src/test/ui/inline-const/const-match-pat-generic.rs
@@ -1,6 +1,5 @@
 #![allow(incomplete_features)]
 #![feature(inline_const_pat)]
-#![feature(generic_const_exprs)]
 
 // rust-lang/rust#82518: ICE with inline-const in match referencing const-generic parameter
 
@@ -16,7 +15,7 @@ const fn f(x: usize) -> usize {
     x + 1
 }
 
-fn bar<const V: usize>() where [(); f(V)]: {
+fn bar<const V: usize>() {
     match 0 {
         const { f(V) } => {},
         //~^ ERROR constant pattern depends on a generic parameter

--- a/src/test/ui/inline-const/const-match-pat-generic.stderr
+++ b/src/test/ui/inline-const/const-match-pat-generic.stderr
@@ -1,17 +1,17 @@
 error[E0158]: const parameters cannot be referenced in patterns
-  --> $DIR/const-match-pat-generic.rs:9:9
+  --> $DIR/const-match-pat-generic.rs:8:9
    |
 LL |         const { V } => {},
    |         ^^^^^^^^^^^
 
 error: constant pattern depends on a generic parameter
-  --> $DIR/const-match-pat-generic.rs:21:9
+  --> $DIR/const-match-pat-generic.rs:20:9
    |
 LL |         const { f(V) } => {},
    |         ^^^^^^^^^^^^^^
 
 error: constant pattern depends on a generic parameter
-  --> $DIR/const-match-pat-generic.rs:21:9
+  --> $DIR/const-match-pat-generic.rs:20:9
    |
 LL |         const { f(V) } => {},
    |         ^^^^^^^^^^^^^^

--- a/src/tools/clippy/tests/ui/indexing_slicing_index.stderr
+++ b/src/tools/clippy/tests/ui/indexing_slicing_index.stderr
@@ -1,4 +1,4 @@
-error[E0080]: evaluation of `main::{constant#3}::<&i32>` failed
+error[E0080]: evaluation of `main::{constant#3}` failed
   --> $DIR/indexing_slicing_index.rs:31:14
    |
 LL |     const { &ARR[idx4()] }; // Ok, let rustc handle const contexts.


### PR DESCRIPTION
Tracking issue: #76001

The RFC says that inline consts cannot reference to generic parameters (for now), same as array length expressions. And expresses that it's desirable for it to reference in-scope generics, when array length expressions gain that feature as well.

However it is possible to implement this for inline consts before doing this for all anon consts, because inline consts are only used as values and they won't be used in the type system. So we can have:
```rust
fn foo<T>() {
    let x = [4i32; std::mem::size_of::<T>()];   // NOT ALLOWED (for now)
    let x = const { std::mem::size_of::<T>() }; // ALLOWED with this PR!
    let x = [4i32; const { std::mem::size_of::<T>() }];   // NOT ALLOWED (for now)
}
```

This would make inline consts super useful for compile-time checks and assertions:
```rust
fn assert_zst<T>() {
    const { assert!(std::mem::size_of::<T>() == 0) };
}
```

This would create an error during monomorphization when `assert_zst` is instantiated with non-ZST `T`s. A error during mono might sound scary, but this is exactly what a "desugared" inline const would do:
```rust
fn assert_zst<T>() {
    struct F<T>(T);
    impl<T> F<T> {
        const V: () = assert!(std::mem::size_of::<T>() == 0);
    }
    let _ = F::<T>::V;
}
```

It should also be noted that the current inline const implementation can already reference the type params via type inference, so this resolver-level restriction is not any useful either:
```rust
fn foo<T>() -> usize {
    let (_, size): (PhantomData<T>, usize) = const {
        const fn my_size_of<T>() -> (PhantomData<T>, usize) {
            (PhantomData, std::mem::size_of::<T>())
        }
        my_size_of()
    };
    size
}
```

@rustbot label: F-inline_const