### PR TITLE
Make rustc_parse_format compile on stable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4171,7 +4171,6 @@ name = "rustc_parse_format"
 version = "0.0.0"
 dependencies = [
  "rustc_lexer",
- "rustc_span",
 ]
 
 [[package]]

--- a/compiler/rustc_builtin_macros/src/format.rs
+++ b/compiler/rustc_builtin_macros/src/format.rs
@@ -242,7 +242,7 @@ impl<'a, 'b> Context<'a, 'b> {
     fn resolve_name_inplace(&self, p: &mut parse::Piece<'_>) {
         // NOTE: the `unwrap_or` branch is needed in case of invalid format
         // arguments, e.g., `format_args!("{foo}")`.
-        let lookup = |s: Symbol| *self.names.get(&s).unwrap_or(&0);
+        let lookup = |s: &str| *self.names.get(&Symbol::intern(s)).unwrap_or(&0);
 
         match *p {
             parse::String(_) => {}
@@ -276,7 +276,9 @@ impl<'a, 'b> Context<'a, 'b> {
                 // it's written second, so it should come after width/precision.
                 let pos = match arg.position {
                     parse::ArgumentIs(i) | parse::ArgumentImplicitlyIs(i) => Exact(i),
-                    parse::ArgumentNamed(s, span) => Named(s, span),
+                    parse::ArgumentNamed(s, span) => {
+                        Named(Symbol::intern(s), InnerSpan::new(span.start, span.end))
+                    }
                 };
 
                 let ty = Placeholder(match arg.format.ty {
@@ -291,7 +293,10 @@ impl<'a, 'b> Context<'a, 'b> {
                     "X" => "UpperHex",
                     _ => {
                         let fmtsp = self.fmtsp;
-                        let sp = arg.format.ty_span.map(|sp| fmtsp.from_inner(sp));
+                        let sp = arg
+                            .format
+                            .ty_span
+                            .map(|sp| fmtsp.from_inner(InnerSpan::new(sp.start, sp.end)));
                         let mut err = self.ecx.struct_span_err(
                             sp.unwrap_or(fmtsp),
                             &format!("unknown format trait `{}`", arg.format.ty),
@@ -340,14 +345,17 @@ impl<'a, 'b> Context<'a, 'b> {
         }
     }
 
-    fn verify_count(&mut self, c: parse::Count) {
+    fn verify_count(&mut self, c: parse::Count<'_>) {
         match c {
             parse::CountImplied | parse::CountIs(..) => {}
             parse::CountIsParam(i) => {
                 self.verify_arg_type(Exact(i), Count);
             }
             parse::CountIsName(s, span) => {
-                self.verify_arg_type(Named(s, span), Count);
+                self.verify_arg_type(
+                    Named(Symbol::intern(s), InnerSpan::new(span.start, span.end)),
+                    Count,
+                );
             }
         }
     }
@@ -425,7 +433,7 @@ impl<'a, 'b> Context<'a, 'b> {
 
         for fmt in &self.arg_with_formatting {
             if let Some(span) = fmt.precision_span {
-                let span = self.fmtsp.from_inner(span);
+                let span = self.fmtsp.from_inner(InnerSpan::new(span.start, span.end));
                 match fmt.precision {
                     parse::CountIsParam(pos) if pos > self.num_args() => {
                         e.span_label(
@@ -471,7 +479,7 @@ impl<'a, 'b> Context<'a, 'b> {
                 }
             }
             if let Some(span) = fmt.width_span {
-                let span = self.fmtsp.from_inner(span);
+                let span = self.fmtsp.from_inner(InnerSpan::new(span.start, span.end));
                 match fmt.width {
                     parse::CountIsParam(pos) if pos > self.num_args() => {
                         e.span_label(
@@ -610,7 +618,7 @@ impl<'a, 'b> Context<'a, 'b> {
         ecx.std_path(&[sym::fmt, sym::rt, sym::v1, s])
     }
 
-    fn build_count(&self, c: parse::Count) -> P<ast::Expr> {
+    fn build_count(&self, c: parse::Count<'_>) -> P<ast::Expr> {
         let sp = self.macsp;
         let count = |c, arg| {
             let mut path = Context::rtpath(self.ecx, sym::Count);
@@ -1033,7 +1041,7 @@ pub fn expand_preparsed_format_args(
     if !parser.errors.is_empty() {
         let err = parser.errors.remove(0);
         let sp = if efmt_kind_is_lit {
-            fmt_span.from_inner(err.span)
+            fmt_span.from_inner(InnerSpan::new(err.span.start, err.span.end))
         } else {
             // The format string could be another macro invocation, e.g.:
             //     format!(concat!("abc", "{}"), 4);
@@ -1052,14 +1060,18 @@ pub fn expand_preparsed_format_args(
         }
         if let Some((label, span)) = err.secondary_label {
             if efmt_kind_is_lit {
-                e.span_label(fmt_span.from_inner(span), label);
+                e.span_label(fmt_span.from_inner(InnerSpan::new(span.start, span.end)), label);
             }
         }
         e.emit();
         return DummyResult::raw_expr(sp, true);
     }
 
-    let arg_spans = parser.arg_places.iter().map(|span| fmt_span.from_inner(*span)).collect();
+    let arg_spans = parser
+        .arg_places
+        .iter()
+        .map(|span| fmt_span.from_inner(InnerSpan::new(span.start, span.end)))
+        .collect();
 
     let named_pos: FxHashSet<usize> = names.values().cloned().collect();
 

--- a/compiler/rustc_lint/src/non_fmt_panic.rs
+++ b/compiler/rustc_lint/src/non_fmt_panic.rs
@@ -254,7 +254,10 @@ fn check_panic_str<'tcx>(
     if n_arguments > 0 && fmt_parser.errors.is_empty() {
         let arg_spans: Vec<_> = match &fmt_parser.arg_places[..] {
             [] => vec![fmt_span],
-            v => v.iter().map(|span| fmt_span.from_inner(*span)).collect(),
+            v => v
+                .iter()
+                .map(|span| fmt_span.from_inner(InnerSpan::new(span.start, span.end)))
+                .collect(),
         };
         cx.struct_span_lint(NON_FMT_PANICS, arg_spans, |lint| {
             let mut l = lint.build(match n_arguments {

--- a/compiler/rustc_parse_format/Cargo.toml
+++ b/compiler/rustc_parse_format/Cargo.toml
@@ -4,5 +4,4 @@ version = "0.0.0"
 edition = "2021"
 
 [dependencies]
-rustc_span = { path = "../rustc_span" }
 rustc_lexer = { path = "../rustc_lexer" }

--- a/compiler/rustc_parse_format/src/tests.rs
+++ b/compiler/rustc_parse_format/src/tests.rs
@@ -144,93 +144,91 @@ fn format_align_fill() {
 }
 #[test]
 fn format_counts() {
-    rustc_span::create_default_session_globals_then(|| {
-        same(
-            "{:10x}",
-            &[NextArgument(Argument {
-                position: ArgumentImplicitlyIs(0),
-                format: FormatSpec {
-                    fill: None,
-                    align: AlignUnknown,
-                    flags: 0,
-                    precision: CountImplied,
-                    width: CountIs(10),
-                    precision_span: None,
-                    width_span: None,
-                    ty: "x",
-                    ty_span: None,
-                },
-            })],
-        );
-        same(
-            "{:10$.10x}",
-            &[NextArgument(Argument {
-                position: ArgumentImplicitlyIs(0),
-                format: FormatSpec {
-                    fill: None,
-                    align: AlignUnknown,
-                    flags: 0,
-                    precision: CountIs(10),
-                    width: CountIsParam(10),
-                    precision_span: None,
-                    width_span: Some(InnerSpan::new(3, 6)),
-                    ty: "x",
-                    ty_span: None,
-                },
-            })],
-        );
-        same(
-            "{:.*x}",
-            &[NextArgument(Argument {
-                position: ArgumentImplicitlyIs(1),
-                format: FormatSpec {
-                    fill: None,
-                    align: AlignUnknown,
-                    flags: 0,
-                    precision: CountIsParam(0),
-                    width: CountImplied,
-                    precision_span: Some(InnerSpan::new(3, 5)),
-                    width_span: None,
-                    ty: "x",
-                    ty_span: None,
-                },
-            })],
-        );
-        same(
-            "{:.10$x}",
-            &[NextArgument(Argument {
-                position: ArgumentImplicitlyIs(0),
-                format: FormatSpec {
-                    fill: None,
-                    align: AlignUnknown,
-                    flags: 0,
-                    precision: CountIsParam(10),
-                    width: CountImplied,
-                    precision_span: Some(InnerSpan::new(3, 7)),
-                    width_span: None,
-                    ty: "x",
-                    ty_span: None,
-                },
-            })],
-        );
-        same(
-            "{:a$.b$?}",
-            &[NextArgument(Argument {
-                position: ArgumentImplicitlyIs(0),
-                format: FormatSpec {
-                    fill: None,
-                    align: AlignUnknown,
-                    flags: 0,
-                    precision: CountIsName(Symbol::intern("b"), InnerSpan::new(6, 7)),
-                    width: CountIsName(Symbol::intern("a"), InnerSpan::new(4, 4)),
-                    precision_span: None,
-                    width_span: None,
-                    ty: "?",
-                    ty_span: None,
-                },
-            })],
-        );
-    });
+    same(
+        "{:10x}",
+        &[NextArgument(Argument {
+            position: ArgumentImplicitlyIs(0),
+            format: FormatSpec {
+                fill: None,
+                align: AlignUnknown,
+                flags: 0,
+                precision: CountImplied,
+                width: CountIs(10),
+                precision_span: None,
+                width_span: None,
+                ty: "x",
+                ty_span: None,
+            },
+        })],
+    );
+    same(
+        "{:10$.10x}",
+        &[NextArgument(Argument {
+            position: ArgumentImplicitlyIs(0),
+            format: FormatSpec {
+                fill: None,
+                align: AlignUnknown,
+                flags: 0,
+                precision: CountIs(10),
+                width: CountIsParam(10),
+                precision_span: None,
+                width_span: Some(InnerSpan::new(3, 6)),
+                ty: "x",
+                ty_span: None,
+            },
+        })],
+    );
+    same(
+        "{:.*x}",
+        &[NextArgument(Argument {
+            position: ArgumentImplicitlyIs(1),
+            format: FormatSpec {
+                fill: None,
+                align: AlignUnknown,
+                flags: 0,
+                precision: CountIsParam(0),
+                width: CountImplied,
+                precision_span: Some(InnerSpan::new(3, 5)),
+                width_span: None,
+                ty: "x",
+                ty_span: None,
+            },
+        })],
+    );
+    same(
+        "{:.10$x}",
+        &[NextArgument(Argument {
+            position: ArgumentImplicitlyIs(0),
+            format: FormatSpec {
+                fill: None,
+                align: AlignUnknown,
+                flags: 0,
+                precision: CountIsParam(10),
+                width: CountImplied,
+                precision_span: Some(InnerSpan::new(3, 7)),
+                width_span: None,
+                ty: "x",
+                ty_span: None,
+            },
+        })],
+    );
+    same(
+        "{:a$.b$?}",
+        &[NextArgument(Argument {
+            position: ArgumentImplicitlyIs(0),
+            format: FormatSpec {
+                fill: None,
+                align: AlignUnknown,
+                flags: 0,
+                precision: CountIsName("b", InnerSpan::new(6, 7)),
+                width: CountIsName("a", InnerSpan::new(4, 4)),
+                precision_span: None,
+                width_span: None,
+                ty: "?",
+                ty_span: None,
+            },
+        })],
+    );
 }
 #[test]
 fn format_flags() {

--- a/src/tools/clippy/clippy_lints/src/write.rs
+++ b/src/tools/clippy/clippy_lints/src/write.rs
@@ -13,7 +13,7 @@ use rustc_lint::{EarlyContext, EarlyLintPass, LintContext};
 use rustc_parse::parser;
 use rustc_session::{declare_tool_lint, impl_lint_pass};
 use rustc_span::symbol::{kw, Symbol};
-use rustc_span::{sym, BytePos, Span, DUMMY_SP};
+use rustc_span::{sym, BytePos, InnerSpan, Span, DUMMY_SP};
 
 declare_clippy_lint! {
     /// ### What it does
@@ -454,6 +454,7 @@ impl SimpleFormatArgs {
                 }
             },
             ArgumentNamed(n, _) => {
+                let n = Symbol::intern(n);
                 if let Some(x) = self.named.iter_mut().find(|x| x.0 == n) {
                     match x.1.as_slice() {
                         // A non-empty format string has been seen already.
@@ -495,7 +496,7 @@ impl Write {
             let span = parser
                 .arg_places
                 .last()
-                .map_or(DUMMY_SP, |&x| str_lit.span.from_inner(x));
+                .map_or(DUMMY_SP, |&x| str_lit.span.from_inner(InnerSpan::new(x.start, x.end)));
 
             if !self.in_debug_impl && arg.format.ty == "?" {
                 // FIXME: modify rustc's fmt string parser to give us the current span


### PR DESCRIPTION
This allows it to be used by lightweight formatting systems and may allow it to be used by rust-analyzer.