### PR TITLE
Only compute DefKind through the query.

### DIFF
--- a/compiler/rustc_metadata/src/foreign_modules.rs
+++ b/compiler/rustc_metadata/src/foreign_modules.rs
@@ -6,7 +6,7 @@ use rustc_session::cstore::ForeignModule;
 crate fn collect(tcx: TyCtxt<'_>) -> Vec<ForeignModule> {
     let mut modules = Vec::new();
     for id in tcx.hir().items() {
-        if !matches!(tcx.hir().def_kind(id.def_id), DefKind::ForeignMod) {
+        if !matches!(tcx.def_kind(id.def_id), DefKind::ForeignMod) {
             continue;
         }
         let item = tcx.hir().item(id);

--- a/compiler/rustc_metadata/src/native_libs.rs
+++ b/compiler/rustc_metadata/src/native_libs.rs
@@ -36,7 +36,7 @@ struct Collector<'tcx> {
 
 impl<'tcx> Collector<'tcx> {
     fn process_item(&mut self, id: rustc_hir::ItemId) {
-        if !matches!(self.tcx.hir().def_kind(id.def_id), DefKind::ForeignMod) {
+        if !matches!(self.tcx.def_kind(id.def_id), DefKind::ForeignMod) {
             return;
         }
 

--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -1800,7 +1800,7 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
             FxHashMap::default();
 
         for id in tcx.hir().items() {
-            if matches!(tcx.hir().def_kind(id.def_id), DefKind::Impl) {
+            if matches!(tcx.def_kind(id.def_id), DefKind::Impl) {
                 if let Some(trait_ref) = tcx.impl_trait_ref(id.def_id.to_def_id()) {
                     let simplified_self_ty = fast_reject::simplify_type(
                         self.tcx,

--- a/compiler/rustc_middle/src/hir/map/mod.rs
+++ b/compiler/rustc_middle/src/hir/map/mod.rs
@@ -222,7 +222,8 @@ impl<'hir> Map<'hir> {
         self.tcx.untracked_resolutions.definitions.iter_local_def_id()
     }
 
-    pub fn opt_def_kind(self, local_def_id: LocalDefId) -> Option<DefKind> {
+    /// Do not call this function directly.  The query should be called.
+    pub(super) fn opt_def_kind(self, local_def_id: LocalDefId) -> Option<DefKind> {
         let hir_id = self.local_def_id_to_hir_id(local_def_id);
         let def_kind = match self.find(hir_id)? {
             Node::Item(item) => match item.kind {
@@ -306,11 +307,6 @@ impl<'hir> Map<'hir> {
             | Node::Block(_) => return None,
         };
         Some(def_kind)
-    }
-
-    pub fn def_kind(self, local_def_id: LocalDefId) -> DefKind {
-        self.opt_def_kind(local_def_id)
-            .unwrap_or_else(|| bug!("def_kind: unsupported node: {:?}", local_def_id))
     }
 
     pub fn find_parent_node(self, id: HirId) -> Option<HirId> {

--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -2676,7 +2676,7 @@ fn for_each_def(tcx: TyCtxt<'_>, mut collect_fn: impl for<'b> FnMut(&'b Ident, N
     // Iterate all local crate items no matter where they are defined.
     let hir = tcx.hir();
     for id in hir.items() {
-        if matches!(hir.def_kind(id.def_id), DefKind::Use) {
+        if matches!(tcx.def_kind(id.def_id), DefKind::Use) {
             continue;
         }
 

--- a/compiler/rustc_monomorphize/src/collector.rs
+++ b/compiler/rustc_monomorphize/src/collector.rs
@@ -1169,7 +1169,7 @@ struct RootCollector<'a, 'tcx> {
 
 impl<'v> RootCollector<'_, 'v> {
     fn process_item(&mut self, id: hir::ItemId) {
-        match self.tcx.hir().def_kind(id.def_id) {
+        match self.tcx.def_kind(id.def_id) {
             DefKind::Enum | DefKind::Struct | DefKind::Union => {
                 let item = self.tcx.hir().item(id);
                 match item.kind {
@@ -1230,7 +1230,7 @@ impl<'v> RootCollector<'_, 'v> {
     }
 
     fn process_impl_item(&mut self, id: hir::ImplItemId) {
-        if matches!(self.tcx.hir().def_kind(id.def_id), DefKind::AssocFn) {
+        if matches!(self.tcx.def_kind(id.def_id), DefKind::AssocFn) {
             self.push_if_root(id.def_id);
         }
     }

--- a/compiler/rustc_passes/src/lang_items.rs
+++ b/compiler/rustc_passes/src/lang_items.rs
@@ -240,9 +240,9 @@ fn get_lang_items(tcx: TyCtxt<'_>, (): ()) -> LanguageItems {
     let crate_items = tcx.hir_crate_items(());
 
     for id in crate_items.items() {
-        collector.check_for_lang(Target::from_def_kind(tcx.hir().def_kind(id.def_id)), id.hir_id());
+        collector.check_for_lang(Target::from_def_kind(tcx.def_kind(id.def_id)), id.hir_id());
 
-        if matches!(tcx.hir().def_kind(id.def_id), DefKind::Enum) {
+        if matches!(tcx.def_kind(id.def_id), DefKind::Enum) {
             let item = tcx.hir().item(id);
             if let hir::ItemKind::Enum(def, ..) = &item.kind {
                 for variant in def.variants {

--- a/compiler/rustc_privacy/src/lib.rs
+++ b/compiler/rustc_privacy/src/lib.rs
@@ -459,7 +459,7 @@ impl<'tcx> EmbargoVisitor<'tcx> {
         let item_def_id = local_def_id.to_def_id();
         let macro_module_def_id =
             ty::DefIdTree::parent(self.tcx, item_def_id).unwrap().expect_local();
-        if self.tcx.hir().opt_def_kind(macro_module_def_id) != Some(DefKind::Mod) {
+        if self.tcx.def_kind(macro_module_def_id) != DefKind::Mod {
             // The macro's parent doesn't correspond to a `mod`, return early (#63164, #65252).
             return;
         }

--- a/compiler/rustc_query_impl/src/plumbing.rs
+++ b/compiler/rustc_query_impl/src/plumbing.rs
@@ -294,7 +294,7 @@ macro_rules! define_queries {
                 // accidentally triggering an infinite query loop.
                 let def_kind = key.key_as_def_id()
                     .and_then(|def_id| def_id.as_local())
-                    .and_then(|def_id| tcx.hir().opt_def_kind(def_id));
+                    .map(|def_id| tcx.def_kind(def_id));
                 let hash = || {
                     let mut hcx = tcx.create_stable_hashing_context();
                     let mut hasher = StableHasher::new();

--- a/compiler/rustc_typeck/src/check/fn_ctxt/suggestions.rs
+++ b/compiler/rustc_typeck/src/check/fn_ctxt/suggestions.rs
@@ -83,9 +83,10 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         expected: Ty<'tcx>,
         found: Ty<'tcx>,
     ) -> bool {
+        let tcx = self.tcx;
         let hir = self.tcx.hir();
         let (def_id, sig) = match *found.kind() {
-            ty::FnDef(def_id, _) => (def_id, found.fn_sig(self.tcx)),
+            ty::FnDef(def_id, _) => (def_id, found.fn_sig(tcx)),
             ty::Closure(def_id, substs) => (def_id, substs.as_closure().sig()),
             _ => return false,
         };
@@ -151,7 +152,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 }
                 Some(Node::Ctor(hir::VariantData::Tuple(fields, _))) => {
                     sugg_call = fields.iter().map(|_| "_").collect::<Vec<_>>().join(", ");
-                    match def_id.as_local().map(|def_id| hir.def_kind(def_id)) {
+                    match def_id.as_local().map(|def_id| tcx.def_kind(def_id)) {
                         Some(DefKind::Ctor(hir::def::CtorOf::Variant, _)) => {
                             msg = "instantiate this tuple variant";
                         }

--- a/compiler/rustc_typeck/src/check_unused.rs
+++ b/compiler/rustc_typeck/src/check_unused.rs
@@ -17,7 +17,7 @@ pub fn check_crate(tcx: TyCtxt<'_>) {
     }
 
     for id in tcx.hir().items() {
-        if matches!(tcx.hir().def_kind(id.def_id), DefKind::Use) {
+        if matches!(tcx.def_kind(id.def_id), DefKind::Use) {
             if tcx.visibility(id.def_id).is_public() {
                 continue;
             }
@@ -101,7 +101,7 @@ fn unused_crates_lint(tcx: TyCtxt<'_>) {
     let mut crates_to_lint = vec![];
 
     for id in tcx.hir().items() {
-        if matches!(tcx.hir().def_kind(id.def_id), DefKind::ExternCrate) {
+        if matches!(tcx.def_kind(id.def_id), DefKind::ExternCrate) {
             let item = tcx.hir().item(id);
             if let hir::ItemKind::ExternCrate(orig_name) = item.kind {
                 crates_to_lint.push(ExternCrateToLint {

--- a/compiler/rustc_typeck/src/outlives/implicit_infer.rs
+++ b/compiler/rustc_typeck/src/outlives/implicit_infer.rs
@@ -35,7 +35,7 @@ pub fn infer_predicates<'tcx>(
             debug!("InferVisitor::visit_item(item={:?})", item_did);
 
             let mut item_required_predicates = RequiredPredicates::default();
-            match tcx.hir().def_kind(item_did) {
+            match tcx.def_kind(item_did) {
                 DefKind::Union | DefKind::Enum | DefKind::Struct => {
                     let adt_def = tcx.adt_def(item_did.to_def_id());
 

--- a/src/tools/clippy/clippy_lints/src/same_name_method.rs
+++ b/src/tools/clippy/clippy_lints/src/same_name_method.rs
@@ -51,7 +51,7 @@ impl<'tcx> LateLintPass<'tcx> for SameNameMethod {
         let mut map = FxHashMap::<Res, ExistingName>::default();
 
         for id in cx.tcx.hir().items() {
-            if !matches!(cx.tcx.hir().def_kind(id.def_id), DefKind::Impl) {
+            if !matches!(cx.tcx.def_kind(id.def_id), DefKind::Impl) {
                 continue;
             }
 


### PR DESCRIPTION
The `opt_def_kind` is forced by metadata encoding anyway.

Calling `tcx.def_kind` directly allows to benefit from the caching without recomputing `tcx.hir().opt_def_kind` each time.