### PR TITLE
rustdoc: show implementations on `#[fundamental]` wrappers

### DIFF
--- a/src/librustdoc/formats/cache.rs
+++ b/src/librustdoc/formats/cache.rs
@@ -3,7 +3,7 @@ use std::mem;
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_hir::def_id::{CrateNum, DefId};
 use rustc_middle::middle::privacy::AccessLevels;
-use rustc_middle::ty::TyCtxt;
+use rustc_middle::ty::{self, TyCtxt};
 use rustc_span::{sym, Symbol};
 
 use crate::clean::{self, types::ExternalLocation, ExternalCrate, ItemId, PrimitiveType};
@@ -450,6 +450,15 @@ impl<'a, 'tcx> DocFolder for CacheBuilder<'a, 'tcx> {
                 clean::Type::Path { ref path }
                 | clean::BorrowedRef { type_: box clean::Type::Path { ref path }, .. } => {
                     dids.insert(path.def_id());
+                    if let Some(generics) = path.generics() &&
+                        let ty::Adt(adt, _) = self.tcx.type_of(path.def_id()).kind() &&
+                        adt.is_fundamental() {
+                        for ty in generics {
+                            if let Some(did) = ty.def_id(&self.cache) {
+                                dids.insert(did);
+                            }
+                        }
+                    }
                 }
                 clean::DynTrait(ref bounds, _)
                 | clean::BorrowedRef { type_: box clean::DynTrait(ref bounds, _), .. } => {

--- a/src/test/rustdoc/impl-box.rs
+++ b/src/test/rustdoc/impl-box.rs
@@ -1,0 +1,16 @@
+// https://github.com/rust-lang/rust/issues/92940
+//
+// Show traits implemented on fundamental types that wrap local ones.
+
+pub struct MyType;
+
+// @has 'impl_box/struct.MyType.html'
+// @has '-' '//*[@id="impl-Iterator"]' 'impl Iterator for Box<MyType>'
+
+impl Iterator for Box<MyType> {
+    type Item = ();
+
+    fn next(&mut self) -> Option<Self::Item> {
+        todo!()
+    }
+}


### PR DESCRIPTION
Fixes #92940