### PR TITLE
add `no_compile` doctest attribute

### DIFF
--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -745,7 +745,7 @@ pub(crate) fn find_testable_code<T: doctest::Tester>(
                     }
                     CodeBlockKind::Indented => Default::default(),
                 };
-                if !block_info.rust {
+                if !block_info.rust || block_info.no_compile {
                     continue;
                 }
 
@@ -843,6 +843,7 @@ pub(crate) struct LangString {
     pub(crate) rust: bool,
     pub(crate) test_harness: bool,
     pub(crate) compile_fail: bool,
+    pub(crate) no_compile: bool,
     pub(crate) error_codes: Vec<String>,
     pub(crate) edition: Option<Edition>,
 }
@@ -864,6 +865,7 @@ impl Default for LangString {
             rust: true,
             test_harness: false,
             compile_fail: false,
+            no_compile: false,
             error_codes: Vec::new(),
             edition: None,
         }
@@ -930,6 +932,10 @@ impl LangString {
                 }
                 "ignore" => {
                     data.ignore = Ignore::All;
+                    seen_rust_tags = !seen_other_tags;
+                }
+                "no_compile" => {
+                    data.no_compile = true;
                     seen_rust_tags = !seen_other_tags;
                 }
                 x if x.starts_with("ignore-") => {

--- a/src/test/rustdoc-ui/no_compile.rs
+++ b/src/test/rustdoc-ui/no_compile.rs
@@ -19,7 +19,7 @@
 ///
 /// For comparison, ignore does get run:
 ///
-/// ```ignore
+/// ```ignore (but-actually-we-include-ignored)
 /// println!("Hello, world");
 /// ```
 struct S;

--- a/src/test/rustdoc-ui/no_compile.rs
+++ b/src/test/rustdoc-ui/no_compile.rs
@@ -1,0 +1,25 @@
+// check-pass
+
+// compile-flags:--test --test-args=--include-ignored --test-args=--test-threads=1
+// normalize-stdout-test: "src/test/rustdoc-ui" -> "$$DIR"
+// normalize-stdout-test "finished in \d+\.\d+s" -> "finished in $$TIME"
+
+/// These code blocks should be treated as rust code in documentation, but never
+/// treated as a test and compiled, even when testing ignored tests.
+///
+/// ```rust,no_compile
+/// // haha rustc
+/// i"have" 0utsmarted k#thee
+/// ```
+///
+/// ```no_compile
+/// // haha rustc
+/// i"have" 0utsmarted k#thee
+/// ```
+///
+/// For comparison, ignore does get run:
+///
+/// ```ignore
+/// println!("Hello, world");
+/// ```
+struct S;

--- a/src/test/rustdoc-ui/no_compile.stdout
+++ b/src/test/rustdoc-ui/no_compile.stdout
@@ -1,0 +1,6 @@
+
+running 1 test
+test $DIR/no_compile.rs - S (line 22) ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
+


### PR DESCRIPTION
This makes it possible to write a doctest

````rust
```no_compile
my_fancy_macro!(12);
```
````

which is detected as and highlighted as rust code, but is *not* compiled. `ignore` *kind of* serves this purpose, but is still compiled and run when `--include-ignored` or `--ignored` is used.

Maybe should be feature gated / limited to working on the nightly channel (but I personally think this is simple and obviously correct enough that it could potentially just ride the release train).

Fixes #63193, Fixes (kinda) #87586

<details><summary>Big Picture View</summary>

https://rust-lang.zulipchat.com/#narrow/stream/266220-rustdoc/topic/Cleaning.20up.20docblock.20attributes

We currently have

| doctest attribute | test attribute | compile | run |
| -- | -- | -- | -- |
| | ignore | yes | with `--ignored` |
| no_run | | yes | no |
| ignore | | with `--ignored` | with `--ignored` |
| compile_fail | | fail | |
| | cfg(any()) | no | |

I want to clean up this to be

| doctest attribute | test attribute | compile | run |
| -- | -- | -- | -- |
| ignore | ignore | yes | with `--ignored` |
| no_run | | yes | no |
| compile_fail | | fail | |
| no_compile | cfg(any()) | no | |

This does the simple part of adding `no_compile`. After `no_compile` is available, it becomes possible to tell current uses of `ignore` for does-not-compile rust code to use `no_compile` instead, and move towards `ignore` always compiling the code in the next edition.