### PR TITLE
Proof of concept: implement test ignore-by-panic

### DIFF
--- a/library/test/src/console.rs
+++ b/library/test/src/console.rs
@@ -106,10 +106,10 @@ impl ConsoleTestState {
             let TestDesc { name, ignore_message, .. } = test;
             format!(
                 "{} {}",
-                match *result {
+                match result {
                     TestResult::TrOk => "ok".to_owned(),
                     TestResult::TrFailed => "failed".to_owned(),
-                    TestResult::TrFailedMsg(ref msg) => format!("failed: {msg}"),
+                    TestResult::TrFailedMsg(msg) => format!("failed: {msg}"),
                     TestResult::TrIgnored => {
                         if let Some(msg) = ignore_message {
                             format!("ignored: {msg}")
@@ -117,7 +117,8 @@ impl ConsoleTestState {
                             "ignored".to_owned()
                         }
                     }
-                    TestResult::TrBench(ref bs) => fmt_bench_samples(bs),
+                    TestResult::TrIgnoredMsg(msg) => format!("ignored: {msg}"),
+                    TestResult::TrBench(bs) => fmt_bench_samples(bs),
                     TestResult::TrTimedFail => "failed (time limit exceeded)".to_owned(),
                 },
                 name,
@@ -194,7 +195,7 @@ fn handle_test_result(st: &mut ConsoleTestState, completed_test: CompletedTest) 
             st.passed += 1;
             st.not_failures.push((test, stdout));
         }
-        TestResult::TrIgnored => st.ignored += 1,
+        TestResult::TrIgnored | TestResult::TrIgnoredMsg(_) => st.ignored += 1,
         TestResult::TrBench(bs) => {
             st.metrics.insert_metric(
                 test.name.as_slice(),

--- a/library/test/src/formatters/json.rs
+++ b/library/test/src/formatters/json.rs
@@ -93,7 +93,7 @@ impl<T: Write> OutputFormatter for JsonFormatter<T> {
         } else {
             None
         };
-        match *result {
+        match result {
             TestResult::TrOk => {
                 self.write_event("test", desc.name.as_slice(), "ok", exec_time, stdout, None)
             }
@@ -111,7 +111,7 @@ impl<T: Write> OutputFormatter for JsonFormatter<T> {
                 Some(r#""reason": "time limit exceeded""#),
             ),
 
-            TestResult::TrFailedMsg(ref m) => self.write_event(
+            TestResult::TrFailedMsg(m) => self.write_event(
                 "test",
                 desc.name.as_slice(),
                 "failed",
@@ -131,7 +131,16 @@ impl<T: Write> OutputFormatter for JsonFormatter<T> {
                     .as_deref(),
             ),
 
-            TestResult::TrBench(ref bs) => {
+            TestResult::TrIgnoredMsg(msg) => self.write_event(
+                "test",
+                desc.name.as_slice(),
+                "ignored",
+                exec_time,
+                stdout,
+                Some(&*msg),
+            ),
+
+            TestResult::TrBench(bs) => {
                 let median = bs.ns_iter_summ.median as usize;
                 let deviation = (bs.ns_iter_summ.max - bs.ns_iter_summ.min) as usize;
 

--- a/library/test/src/formatters/junit.rs
+++ b/library/test/src/formatters/junit.rs
@@ -76,7 +76,7 @@ impl<T: Write> OutputFormatter for JunitFormatter<T> {
         for (desc, result, duration) in std::mem::replace(&mut self.results, Vec::new()) {
             let (class_name, test_name) = parse_class_name(&desc);
             match result {
-                TestResult::TrIgnored => { /* no-op */ }
+                TestResult::TrIgnored | TestResult::TrIgnoredMsg(_) => { /* no-op */ }
                 TestResult::TrFailed => {
                     self.write_message(&*format!(
                         "<testcase classname=\"{}\" \

--- a/library/test/src/formatters/pretty.rs
+++ b/library/test/src/formatters/pretty.rs
@@ -45,7 +45,7 @@ impl<T: Write> PrettyFormatter<T> {
         self.write_short_result("FAILED", term::color::RED)
     }
 
-    pub fn write_ignored(&mut self, message: Option<&'static str>) -> io::Result<()> {
+    pub fn write_ignored(&mut self, message: Option<&str>) -> io::Result<()> {
         if let Some(message) = message {
             self.write_short_result(&format!("ignored, {}", message), term::color::YELLOW)
         } else {
@@ -215,11 +215,12 @@ impl<T: Write> OutputFormatter for PrettyFormatter<T> {
             self.write_test_name(desc)?;
         }
 
-        match *result {
+        match result {
             TestResult::TrOk => self.write_ok()?,
             TestResult::TrFailed | TestResult::TrFailedMsg(_) => self.write_failed()?,
             TestResult::TrIgnored => self.write_ignored(desc.ignore_message)?,
-            TestResult::TrBench(ref bs) => {
+            TestResult::TrIgnoredMsg(msg) => self.write_ignored(Some(msg))?,
+            TestResult::TrBench(bs) => {
                 self.write_bench()?;
                 self.write_plain(&format!(": {}", fmt_bench_samples(bs)))?;
             }

--- a/library/test/src/formatters/terse.rs
+++ b/library/test/src/formatters/terse.rs
@@ -203,7 +203,7 @@ impl<T: Write> OutputFormatter for TerseFormatter<T> {
             TestResult::TrFailed | TestResult::TrFailedMsg(_) | TestResult::TrTimedFail => {
                 self.write_failed()
             }
-            TestResult::TrIgnored => self.write_ignored(),
+            TestResult::TrIgnored | TestResult::TrIgnoredMsg(_) => self.write_ignored(),
             TestResult::TrBench(ref bs) => {
                 if self.is_multithreaded {
                     self.write_test_name(desc)?;


### PR DESCRIPTION
Implements dynamic ignoring of tests via `panic_any(IgnoreTest { reason })`. Additionally, does the work to pass through the ignored status via exit code across the process boundary in order to support doing so both in process-isolated `cargo test` tests and rustdoc documentation tests.

The actual API might look like `panic_any(test::IgnoreTest { reason })` or `test::ignore(reason) -> !`; I've just implemented the mechanism.

I know this has been asked about before, though I can't find references at the moment.

The sketchiest part is enabling this in rustdoc, since it needs to inject uses of unstable API into the doctest. I've gone for the hacky solution of only enabling it when an attribute `feature(test)` and `extern crate test;` are both present in the test but would appreciate advice here on a better way to gate this. Just always adding the extra shim on the nightly toolchain isn't the most desirable, as then doctests would be able to use `feature(test)` without explicitly saying `#![feature(test)]`.

@rustbot modify labels +T-lang +T-rustdoc