### PR TITLE
[WIP] Diagnose elision failure on the AST

### DIFF
--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -1,3 +1,5 @@
+// ignore-tidy-filelength
+// FIXME(cjgillot) Separate name and lifetime resolution since they use separate namespaces.
 //! "Late resolution" is the pass that resolves most of names in a crate beside imports and macros.
 //! It runs when the crate is fully expanded and its module structure is fully built.
 //! So it just walks through the crate and resolves all the expressions, types, etc.

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -199,6 +199,11 @@ enum LifetimeRibKind {
     /// This rib declares generic parameters.
     Generics { parent: NodeId, span: Span, kind: LifetimeBinderKind },
 
+    /// FIXME(const_generics): This patches over an ICE caused by non-'static lifetimes in const
+    /// generics. We are disallowing this until we can decide on how we want to handle non-'static
+    /// lifetimes in const generics. See issue #74052 for discussion.
+    ConstGeneric,
+
     /// For **Modern** cases, create a new anonymous region parameter
     /// and reference that.
     ///
@@ -1102,14 +1107,18 @@ impl<'a: 'ast, 'b, 'ast> LateResolutionVisitor<'a, 'b, 'ast> {
 
                         this.ribs[TypeNS].push(Rib::new(ConstParamTyRibKind));
                         this.ribs[ValueNS].push(Rib::new(ConstParamTyRibKind));
-                        this.visit_ty(ty);
+                        this.with_lifetime_rib(LifetimeRibKind::ConstGeneric, |this| {
+                            this.visit_ty(ty)
+                        });
                         this.ribs[TypeNS].pop().unwrap();
                         this.ribs[ValueNS].pop().unwrap();
 
                         if let Some(ref expr) = default {
                             this.ribs[TypeNS].push(forward_ty_ban_rib);
                             this.ribs[ValueNS].push(forward_const_ban_rib);
-                            this.visit_anon_const(expr);
+                            this.with_lifetime_rib(LifetimeRibKind::ConstGeneric, |this| {
+                                this.visit_anon_const(expr)
+                            });
                             forward_const_ban_rib = this.ribs[ValueNS].pop().unwrap();
                             forward_ty_ban_rib = this.ribs[TypeNS].pop().unwrap();
                         }
@@ -1158,8 +1167,14 @@ impl<'a: 'ast, 'b, 'ast> LateResolutionVisitor<'a, 'b, 'ast> {
                 return;
             }
 
-            if let LifetimeRibKind::Item = rib.kind {
-                break;
+            match rib.kind {
+                LifetimeRibKind::Item => break,
+                LifetimeRibKind::ConstGeneric => {
+                    self.emit_non_static_lt_in_const_generic_error(lifetime);
+                    self.r.lifetimes_res_map.insert(lifetime.id, LifetimeRes::Error);
+                    return;
+                }
+                _ => {}
             }
         }
 

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -1655,72 +1655,7 @@ impl<'a: 'ast, 'b, 'ast> LateResolutionVisitor<'a, 'b, 'ast> {
                             |this| {
                                 this.visit_generics(generics);
                                 walk_list!(this, visit_param_bound, bounds, BoundKind::SuperTraits);
-
-                                let walk_assoc_item =
-                                    |this: &mut Self,
-                                     generics: &Generics,
-                                     kind,
-                                     item: &'ast AssocItem| {
-                                        this.with_generic_param_rib(
-                                            &generics.params,
-                                            AssocItemRibKind,
-                                            LifetimeRibKind::Generics {
-                                                parent: item.id,
-                                                span: generics.span,
-                                                kind,
-                                            },
-                                            |this| {
-                                                visit::walk_assoc_item(this, item, AssocCtxt::Trait)
-                                            },
-                                        );
-                                    };
-
-                                this.with_trait_items(items, |this| {
-                                    for item in items {
-                                        match &item.kind {
-                                            AssocItemKind::Const(_, ty, default) => {
-                                                this.visit_ty(ty);
-                                                // Only impose the restrictions of `ConstRibKind` for an
-                                                // actual constant expression in a provided default.
-                                                if let Some(expr) = default {
-                                                    // We allow arbitrary const expressions inside of associated consts,
-                                                    // even if they are potentially not const evaluatable.
-                                                    //
-                                                    // Type parameters can already be used and as associated consts are
-                                                    // not used as part of the type system, this is far less surprising.
-                                                    this.with_constant_rib(
-                                                        IsRepeatExpr::No,
-                                                        true,
-                                                        None,
-                                                        |this| this.visit_expr(expr),
-                                                    );
-                                                }
-                                            }
-                                            AssocItemKind::Fn(box Fn { generics, .. }) => {
-                                                walk_assoc_item(
-                                                    this,
-                                                    generics,
-                                                    LifetimeBinderKind::Function,
-                                                    item,
-                                                );
-                                            }
-                                            AssocItemKind::TyAlias(box TyAlias {
-                                                generics,
-                                                ..
-                                            }) => {
-                                                walk_assoc_item(
-                                                    this,
-                                                    generics,
-                                                    LifetimeBinderKind::Item,
-                                                    item,
-                                                );
-                                            }
-                                            AssocItemKind::MacCall(_) => {
-                                                panic!("unexpanded macro in resolve!")
-                                            }
-                                        };
-                                    }
-                                });
+                                this.resolve_trait_items(items);
                             },
                         );
                     },
@@ -1952,16 +1887,50 @@ impl<'a: 'ast, 'b, 'ast> LateResolutionVisitor<'a, 'b, 'ast> {
     }
 
     /// When evaluating a `trait` use its associated types' idents for suggestions in E0412.
-    fn with_trait_items<T>(
-        &mut self,
-        trait_items: &'ast [P<AssocItem>],
-        f: impl FnOnce(&mut Self) -> T,
-    ) -> T {
+    fn resolve_trait_items(&mut self, trait_items: &'ast [P<AssocItem>]) {
         let trait_assoc_items =
             replace(&mut self.diagnostic_metadata.current_trait_assoc_items, Some(&trait_items));
-        let result = f(self);
+
+        let walk_assoc_item =
+            |this: &mut Self, generics: &Generics, kind, item: &'ast AssocItem| {
+                this.with_generic_param_rib(
+                    &generics.params,
+                    AssocItemRibKind,
+                    LifetimeRibKind::Generics { parent: item.id, span: generics.span, kind },
+                    |this| visit::walk_assoc_item(this, item, AssocCtxt::Trait),
+                );
+            };
+
+        for item in trait_items {
+            match &item.kind {
+                AssocItemKind::Const(_, ty, default) => {
+                    self.visit_ty(ty);
+                    // Only impose the restrictions of `ConstRibKind` for an
+                    // actual constant expression in a provided default.
+                    if let Some(expr) = default {
+                        // We allow arbitrary const expressions inside of associated consts,
+                        // even if they are potentially not const evaluatable.
+                        //
+                        // Type parameters can already be used and as associated consts are
+                        // not used as part of the type system, this is far less surprising.
+                        self.with_constant_rib(IsRepeatExpr::No, true, None, |this| {
+                            this.visit_expr(expr)
+                        });
+                    }
+                }
+                AssocItemKind::Fn(box Fn { generics, .. }) => {
+                    walk_assoc_item(self, generics, LifetimeBinderKind::Function, item);
+                }
+                AssocItemKind::TyAlias(box TyAlias { generics, .. }) => {
+                    walk_assoc_item(self, generics, LifetimeBinderKind::Item, item);
+                }
+                AssocItemKind::MacCall(_) => {
+                    panic!("unexpanded macro in resolve!")
+                }
+            };
+        }
+
         self.diagnostic_metadata.current_trait_assoc_items = trait_assoc_items;
-        result
     }
 
     /// This is called to resolve a trait reference from an `impl` (i.e., `impl Trait for Foo`).
@@ -2048,99 +2017,7 @@ impl<'a: 'ast, 'b, 'ast> LateResolutionVisitor<'a, 'b, 'ast> {
                                         this.with_self_rib_ns(ValueNS, Res::SelfCtor(item_def_id), |this| {
                                             debug!("resolve_implementation with_self_rib_ns(ValueNS, ...)");
                                             for item in impl_items {
-                                                use crate::ResolutionError::*;
-                                                match &item.kind {
-                                                    AssocItemKind::Const(_default, _ty, _expr) => {
-                                                        debug!("resolve_implementation AssocItemKind::Const");
-                                                        // If this is a trait impl, ensure the const
-                                                        // exists in trait
-                                                        this.check_trait_item(
-                                                            item.id,
-                                                            item.ident,
-                                                            &item.kind,
-                                                            ValueNS,
-                                                            item.span,
-                                                            |i, s, c| ConstNotMemberOfTrait(i, s, c),
-                                                        );
-
-                                                        // We allow arbitrary const expressions inside of associated consts,
-                                                        // even if they are potentially not const evaluatable.
-                                                        //
-                                                        // Type parameters can already be used and as associated consts are
-                                                        // not used as part of the type system, this is far less surprising.
-                                                        this.with_constant_rib(
-                                                            IsRepeatExpr::No,
-                                                            true,
-                                                            None,
-                                                            |this| {
-                                                                visit::walk_assoc_item(
-                                                                    this,
-                                                                    item,
-                                                                    AssocCtxt::Impl,
-                                                                )
-                                                            },
-                                                        );
-                                                    }
-                                                    AssocItemKind::Fn(box Fn { generics, .. }) => {
-                                                        debug!("resolve_implementation AssocItemKind::Fn");
-                                                        // We also need a new scope for the impl item type parameters.
-                                                        this.with_generic_param_rib(
-                                                            &generics.params,
-                                                            AssocItemRibKind,
-                                                            LifetimeRibKind::Generics { parent: item.id, span: generics.span, kind: LifetimeBinderKind::Function },
-                                                            |this| {
-                                                                // If this is a trait impl, ensure the method
-                                                                // exists in trait
-                                                                this.check_trait_item(
-                                                                    item.id,
-                                                                    item.ident,
-                                                                    &item.kind,
-                                                                    ValueNS,
-                                                                    item.span,
-                                                                    |i, s, c| MethodNotMemberOfTrait(i, s, c),
-                                                                );
-
-                                                                visit::walk_assoc_item(
-                                                                    this,
-                                                                    item,
-                                                                    AssocCtxt::Impl,
-                                                                )
-                                                            },
-                                                        );
-                                                    }
-                                                    AssocItemKind::TyAlias(box TyAlias {
-                                                        generics, ..
-                                                    }) => {
-                                                        debug!("resolve_implementation AssocItemKind::TyAlias");
-                                                        // We also need a new scope for the impl item type parameters.
-                                                        this.with_generic_param_rib(
-                                                            &generics.params,
-                                                            AssocItemRibKind,
-                                                            LifetimeRibKind::Generics { parent: item.id, span: generics.span, kind: LifetimeBinderKind::Item },
-                                                            |this| {
-                                                                // If this is a trait impl, ensure the type
-                                                                // exists in trait
-                                                                this.check_trait_item(
-                                                                    item.id,
-                                                                    item.ident,
-                                                                    &item.kind,
-                                                                    TypeNS,
-                                                                    item.span,
-                                                                    |i, s, c| TypeNotMemberOfTrait(i, s, c),
-                                                                );
-
-                                                                visit::walk_assoc_item(
-                                                                    this,
-                                                                    item,
-                                                                    AssocCtxt::Impl,
-                                                                )
-                                                            },
-                                                        );
-                                                    }
-                                                    AssocItemKind::MacCall(_) => {
-                                                        panic!("unexpanded macro in resolve!")
-                                                    }
-                                                }
+                                                this.resolve_impl_item(&**item);
                                             }
                                         });
                                     });
@@ -2151,6 +2028,91 @@ impl<'a: 'ast, 'b, 'ast> LateResolutionVisitor<'a, 'b, 'ast> {
                 });
             });
         });
+    }
+
+    fn resolve_impl_item(&mut self, item: &'ast AssocItem) {
+        use crate::ResolutionError::*;
+        match &item.kind {
+            AssocItemKind::Const(_default, _ty, _expr) => {
+                debug!("resolve_implementation AssocItemKind::Const");
+                // If this is a trait impl, ensure the const
+                // exists in trait
+                self.check_trait_item(
+                    item.id,
+                    item.ident,
+                    &item.kind,
+                    ValueNS,
+                    item.span,
+                    |i, s, c| ConstNotMemberOfTrait(i, s, c),
+                );
+
+                // We allow arbitrary const expressions inside of associated consts,
+                // even if they are potentially not const evaluatable.
+                //
+                // Type parameters can already be used and as associated consts are
+                // not used as part of the type system, this is far less surprising.
+                self.with_constant_rib(IsRepeatExpr::No, true, None, |this| {
+                    visit::walk_assoc_item(this, item, AssocCtxt::Impl)
+                });
+            }
+            AssocItemKind::Fn(box Fn { generics, .. }) => {
+                debug!("resolve_implementation AssocItemKind::Fn");
+                // We also need a new scope for the impl item type parameters.
+                self.with_generic_param_rib(
+                    &generics.params,
+                    AssocItemRibKind,
+                    LifetimeRibKind::Generics {
+                        parent: item.id,
+                        span: generics.span,
+                        kind: LifetimeBinderKind::Function,
+                    },
+                    |this| {
+                        // If this is a trait impl, ensure the method
+                        // exists in trait
+                        this.check_trait_item(
+                            item.id,
+                            item.ident,
+                            &item.kind,
+                            ValueNS,
+                            item.span,
+                            |i, s, c| MethodNotMemberOfTrait(i, s, c),
+                        );
+
+                        visit::walk_assoc_item(this, item, AssocCtxt::Impl)
+                    },
+                );
+            }
+            AssocItemKind::TyAlias(box TyAlias { generics, .. }) => {
+                debug!("resolve_implementation AssocItemKind::TyAlias");
+                // We also need a new scope for the impl item type parameters.
+                self.with_generic_param_rib(
+                    &generics.params,
+                    AssocItemRibKind,
+                    LifetimeRibKind::Generics {
+                        parent: item.id,
+                        span: generics.span,
+                        kind: LifetimeBinderKind::Item,
+                    },
+                    |this| {
+                        // If this is a trait impl, ensure the type
+                        // exists in trait
+                        this.check_trait_item(
+                            item.id,
+                            item.ident,
+                            &item.kind,
+                            TypeNS,
+                            item.span,
+                            |i, s, c| TypeNotMemberOfTrait(i, s, c),
+                        );
+
+                        visit::walk_assoc_item(this, item, AssocCtxt::Impl)
+                    },
+                );
+            }
+            AssocItemKind::MacCall(_) => {
+                panic!("unexpanded macro in resolve!")
+            }
+        }
     }
 
     fn check_trait_item<F>(

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -208,23 +208,6 @@ enum LifetimeRibKind {
     /// This function will emit an error if `generic_const_exprs` is not enabled, the body identified by
     /// `body_id` is an anonymous constant and `lifetime_ref` is non-static.
     AnonConst,
-
-    /// For **Modern** cases, create a new anonymous region parameter
-    /// and reference that.
-    ///
-    /// For **Dyn Bound** cases, pass responsibility to
-    /// `resolve_lifetime` code.
-    ///
-    /// For **Deprecated** cases, report an error.
-    AnonymousCreateParameter(NodeId),
-
-    /// Give a hard error when either `&` or `'_` is written. Used to
-    /// rule out things like `where T: Foo<'_>`. Does not imply an
-    /// error on default object bounds (e.g., `Box<dyn Foo>`).
-    AnonymousReportError,
-
-    /// Pass responsibility to `resolve_lifetime` code for all cases.
-    AnonymousPassThrough(NodeId),
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -262,6 +245,29 @@ impl LifetimeRib {
     fn new(kind: LifetimeRibKind) -> LifetimeRib {
         LifetimeRib { bindings: Default::default(), kind }
     }
+}
+
+#[derive(Copy, Clone, Debug)]
+enum AnonymousLifetimeRib {
+    /// This rib acts as a barrier to forbid reference to lifetimes of a parent item.
+    Item,
+
+    /// For **Modern** cases, create a new anonymous region parameter
+    /// and reference that.
+    ///
+    /// For **Dyn Bound** cases, pass responsibility to
+    /// `resolve_lifetime` code.
+    ///
+    /// For **Deprecated** cases, report an error.
+    CreateParameter(NodeId),
+
+    /// Give a hard error when either `&` or `'_` is written. Used to
+    /// rule out things like `where T: Foo<'_>`. Does not imply an
+    /// error on default object bounds (e.g., `Box<dyn Foo>`).
+    ReportError,
+
+    /// Pass responsibility to `resolve_lifetime` code for all cases.
+    PassThrough(NodeId),
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
@@ -501,6 +507,9 @@ struct LateResolutionVisitor<'a, 'b, 'ast> {
     /// The current set of local scopes for lifetimes.
     lifetime_ribs: Vec<LifetimeRib>,
 
+    /// The current set of local scopes for anonymous lifetimes.
+    anonymous_lifetime_ribs: Vec<AnonymousLifetimeRib>,
+
     /// The trait that the current context can refer to.
     current_trait_ref: Option<(Module<'a>, TraitRef)>,
 
@@ -525,7 +534,9 @@ impl<'a: 'ast, 'ast> Visitor<'ast> for LateResolutionVisitor<'a, '_, 'ast> {
         let prev = replace(&mut self.diagnostic_metadata.current_item, Some(item));
         // Always report errors in items we just entered.
         let old_ignore = replace(&mut self.in_func_body, false);
-        self.with_lifetime_rib(LifetimeRibKind::Item, |this| this.resolve_item(item));
+        self.with_lifetime_rib(LifetimeRibKind::Item, |this| {
+            this.with_anon_lifetime_rib(AnonymousLifetimeRib::Item, |this| this.resolve_item(item))
+        });
         self.in_func_body = old_ignore;
         self.diagnostic_metadata.current_item = prev;
     }
@@ -542,7 +553,9 @@ impl<'a: 'ast, 'ast> Visitor<'ast> for LateResolutionVisitor<'a, '_, 'ast> {
         })
     }
     fn visit_expr(&mut self, expr: &'ast Expr) {
-        self.resolve_expr(expr, None);
+        self.with_anon_lifetime_rib(AnonymousLifetimeRib::PassThrough(expr.id), |this| {
+            this.resolve_expr(expr, None);
+        })
     }
     fn visit_local(&mut self, local: &'ast Local) {
         let local_spans = match local.pat.kind {
@@ -602,8 +615,8 @@ impl<'a: 'ast, 'ast> Visitor<'ast> for LateResolutionVisitor<'a, '_, 'ast> {
                         span,
                     },
                     |this| {
-                        this.with_lifetime_rib(
-                            LifetimeRibKind::AnonymousPassThrough(ty.id),
+                        this.with_anon_lifetime_rib(
+                            AnonymousLifetimeRib::PassThrough(ty.id),
                             |this| {
                                 this.visit_generic_param_vec(&bare_fn.generic_params, false);
                                 visit::walk_fn_decl(this, &bare_fn.decl);
@@ -647,30 +660,34 @@ impl<'a: 'ast, 'ast> Visitor<'ast> for LateResolutionVisitor<'a, '_, 'ast> {
         match foreign_item.kind {
             ForeignItemKind::TyAlias(box TyAlias { ref generics, .. }) => {
                 self.with_lifetime_rib(LifetimeRibKind::Item, |this| {
-                    this.with_generic_param_rib(
-                        &generics.params,
-                        ItemRibKind(HasGenericParams::Yes),
-                        LifetimeRibKind::Generics {
-                            parent: foreign_item.id,
-                            kind: LifetimeBinderKind::Item,
-                            span: generics.span,
-                        },
-                        |this| visit::walk_foreign_item(this, foreign_item),
-                    )
+                    this.with_anon_lifetime_rib(AnonymousLifetimeRib::Item, |this| {
+                        this.with_generic_param_rib(
+                            &generics.params,
+                            ItemRibKind(HasGenericParams::Yes),
+                            LifetimeRibKind::Generics {
+                                parent: foreign_item.id,
+                                kind: LifetimeBinderKind::Item,
+                                span: generics.span,
+                            },
+                            |this| visit::walk_foreign_item(this, foreign_item),
+                        )
+                    })
                 });
             }
             ForeignItemKind::Fn(box Fn { ref generics, .. }) => {
                 self.with_lifetime_rib(LifetimeRibKind::Item, |this| {
-                    this.with_generic_param_rib(
-                        &generics.params,
-                        ItemRibKind(HasGenericParams::Yes),
-                        LifetimeRibKind::Generics {
-                            parent: foreign_item.id,
-                            kind: LifetimeBinderKind::Function,
-                            span: generics.span,
-                        },
-                        |this| visit::walk_foreign_item(this, foreign_item),
-                    )
+                    this.with_anon_lifetime_rib(AnonymousLifetimeRib::Item, |this| {
+                        this.with_generic_param_rib(
+                            &generics.params,
+                            ItemRibKind(HasGenericParams::Yes),
+                            LifetimeRibKind::Generics {
+                                parent: foreign_item.id,
+                                kind: LifetimeBinderKind::Function,
+                                span: generics.span,
+                            },
+                            |this| visit::walk_foreign_item(this, foreign_item),
+                        )
+                    })
                 });
             }
             ForeignItemKind::Static(..) => {
@@ -689,7 +706,7 @@ impl<'a: 'ast, 'ast> Visitor<'ast> for LateResolutionVisitor<'a, '_, 'ast> {
             // a body, or if there's no body for some other reason.
             FnKind::Fn(FnCtxt::Foreign, _, sig, _, generics, _)
             | FnKind::Fn(_, _, sig, _, generics, None) => {
-                self.with_lifetime_rib(LifetimeRibKind::AnonymousPassThrough(fn_id), |this| {
+                self.with_anon_lifetime_rib(AnonymousLifetimeRib::PassThrough(fn_id), |this| {
                     // We don't need to deal with patterns in parameters, because
                     // they are not possible for foreign or bodiless functions.
                     this.visit_fn_header(&sig.header);
@@ -723,8 +740,8 @@ impl<'a: 'ast, 'ast> Visitor<'ast> for LateResolutionVisitor<'a, '_, 'ast> {
                     // In `async fn`, argument-position elided lifetimes
                     // must be transformed into fresh generic parameters so that
                     // they can be applied to the opaque `impl Trait` return type.
-                    this.with_lifetime_rib(
-                        LifetimeRibKind::AnonymousCreateParameter(fn_id),
+                    this.with_anon_lifetime_rib(
+                        AnonymousLifetimeRib::CreateParameter(fn_id),
                         |this| {
                             // Add each argument to the rib.
                             this.resolve_params(&declaration.inputs)
@@ -743,9 +760,14 @@ impl<'a: 'ast, 'ast> Visitor<'ast> for LateResolutionVisitor<'a, '_, 'ast> {
                                 .iter()
                                 .map(|(&ident, &(node_id, res))| (ident, node_id, res)),
                         );
-                        match rib.kind {
-                            LifetimeRibKind::Item => break,
-                            LifetimeRibKind::AnonymousCreateParameter(id) => {
+                        if let LifetimeRibKind::Item = rib.kind {
+                            break;
+                        }
+                    }
+                    for rib in this.anonymous_lifetime_ribs.iter().rev() {
+                        match rib {
+                            AnonymousLifetimeRib::Item => break,
+                            AnonymousLifetimeRib::CreateParameter(id) => {
                                 if let Some(earlier_fresh) =
                                     this.r.extra_lifetime_params_map.get(&id)
                                 {
@@ -757,12 +779,12 @@ impl<'a: 'ast, 'ast> Visitor<'ast> for LateResolutionVisitor<'a, '_, 'ast> {
                     }
                     this.r.extra_lifetime_params_map.insert(async_node_id, extra_lifetime_params);
 
-                    this.with_lifetime_rib(
-                        LifetimeRibKind::AnonymousPassThrough(async_node_id),
+                    this.with_anon_lifetime_rib(
+                        AnonymousLifetimeRib::PassThrough(async_node_id),
                         |this| visit::walk_fn_ret_ty(this, &declaration.output),
                     );
                 } else {
-                    this.with_lifetime_rib(LifetimeRibKind::AnonymousPassThrough(fn_id), |this| {
+                    this.with_anon_lifetime_rib(AnonymousLifetimeRib::PassThrough(fn_id), |this| {
                         // Add each argument to the rib.
                         this.resolve_params(&declaration.inputs);
 
@@ -774,7 +796,7 @@ impl<'a: 'ast, 'ast> Visitor<'ast> for LateResolutionVisitor<'a, '_, 'ast> {
                 // Be sure not to set this until the function signature has been resolved.
                 let previous_state = replace(&mut this.in_func_body, true);
                 // Resolve the function body, potentially inside the body of an async closure
-                this.with_lifetime_rib(LifetimeRibKind::AnonymousPassThrough(fn_id), |this| {
+                this.with_anon_lifetime_rib(AnonymousLifetimeRib::PassThrough(fn_id), |this| {
                     match fn_kind {
                         FnKind::Fn(.., body) => walk_list!(this, visit_block, body),
                         FnKind::Closure(_, body) => this.visit_expr(body),
@@ -858,8 +880,8 @@ impl<'a: 'ast, 'ast> Visitor<'ast> for LateResolutionVisitor<'a, '_, 'ast> {
         if let Some(ref args) = path_segment.args {
             match &**args {
                 GenericArgs::AngleBracketed(..) => visit::walk_generic_args(self, path_span, args),
-                GenericArgs::Parenthesized(..) => self.with_lifetime_rib(
-                    LifetimeRibKind::AnonymousPassThrough(path_segment.id),
+                GenericArgs::Parenthesized(..) => self.with_anon_lifetime_rib(
+                    AnonymousLifetimeRib::PassThrough(path_segment.id),
                     |this| visit::walk_generic_args(this, path_span, args),
                 ),
             }
@@ -870,7 +892,7 @@ impl<'a: 'ast, 'ast> Visitor<'ast> for LateResolutionVisitor<'a, '_, 'ast> {
         debug!("visit_where_predicate {:?}", p);
         let previous_value =
             replace(&mut self.diagnostic_metadata.current_where_predicate, Some(p));
-        self.with_lifetime_rib(LifetimeRibKind::AnonymousReportError, |this| {
+        self.with_anon_lifetime_rib(AnonymousLifetimeRib::ReportError, |this| {
             if let WherePredicate::BoundPredicate(WhereBoundPredicate {
                 ref bounded_ty,
                 ref bounds,
@@ -942,6 +964,7 @@ impl<'a: 'ast, 'b, 'ast> LateResolutionVisitor<'a, 'b, 'ast> {
             },
             label_ribs: Vec::new(),
             lifetime_ribs: Vec::new(),
+            anonymous_lifetime_ribs: vec![AnonymousLifetimeRib::Item],
             current_trait_ref: None,
             diagnostic_metadata: DiagnosticMetadata::default(),
             // errors at module scope should always be reported
@@ -1082,7 +1105,7 @@ impl<'a: 'ast, 'b, 'ast> LateResolutionVisitor<'a, 'b, 'ast> {
             forward_ty_ban_rib.bindings.insert(Ident::with_dummy_span(kw::SelfUpper), Res::Err);
         }
 
-        self.with_lifetime_rib(LifetimeRibKind::AnonymousReportError, |this| {
+        self.with_anon_lifetime_rib(AnonymousLifetimeRib::ReportError, |this| {
             for param in params {
                 match param.kind {
                     GenericParamKind::Lifetime => {
@@ -1204,56 +1227,55 @@ impl<'a: 'ast, 'b, 'ast> LateResolutionVisitor<'a, 'b, 'ast> {
         self.record_lifetime_res(lifetime.id, LifetimeRes::Error);
     }
 
+    #[tracing::instrument(level = "debug", skip(self, work))]
+    fn with_anon_lifetime_rib<T>(
+        &mut self,
+        rib: AnonymousLifetimeRib,
+        work: impl FnOnce(&mut Self) -> T,
+    ) -> T {
+        self.anonymous_lifetime_ribs.push(rib);
+        let ret = work(self);
+        self.anonymous_lifetime_ribs.pop();
+        ret
+    }
+
     #[tracing::instrument(level = "debug", skip(self))]
     fn resolve_anonymous_lifetime(&mut self, lifetime: &Lifetime, elided: bool) {
         debug_assert_eq!(lifetime.ident.name, kw::UnderscoreLifetime);
 
-        for i in (0..self.lifetime_ribs.len()).rev() {
-            let rib = &mut self.lifetime_ribs[i];
-            match rib.kind {
-                LifetimeRibKind::AnonymousCreateParameter(item_node_id) => {
-                    self.create_fresh_lifetime(lifetime.id, lifetime.ident, item_node_id);
-                    return;
-                }
-                LifetimeRibKind::AnonymousReportError => {
-                    let (msg, note) = if elided {
-                        (
-                            "`&` without an explicit lifetime name cannot be used here",
-                            "explicit lifetime name needed here",
-                        )
-                    } else {
-                        ("`'_` cannot be used here", "`'_` is a reserved lifetime name")
-                    };
-                    rustc_errors::struct_span_err!(
-                        self.r.session,
-                        lifetime.ident.span,
-                        E0637,
-                        "{}",
-                        msg,
-                    )
-                    .span_label(lifetime.ident.span, note)
-                    .emit();
-
-                    self.record_lifetime_res(lifetime.id, LifetimeRes::Error);
-                    return;
-                }
-                LifetimeRibKind::AnonymousPassThrough(node_id) => {
-                    self.record_lifetime_res(
-                        lifetime.id,
-                        LifetimeRes::Anonymous { binder: node_id, elided },
-                    );
-                    return;
-                }
-                LifetimeRibKind::Item => break,
-                _ => {}
+        let res = match *self.anonymous_lifetime_ribs.last().unwrap() {
+            AnonymousLifetimeRib::CreateParameter(item_node_id) => {
+                self.create_fresh_lifetime(lifetime.id, lifetime.ident, item_node_id)
             }
-        }
-        // This resolution is wrong, it passes the work to HIR lifetime resolution.
-        // We cannot use `LifetimeRes::Error` because we do not emit a diagnostic.
-        self.record_lifetime_res(
-            lifetime.id,
-            LifetimeRes::Anonymous { binder: DUMMY_NODE_ID, elided },
-        );
+            AnonymousLifetimeRib::ReportError => {
+                let (msg, note) = if elided {
+                    (
+                        "`&` without an explicit lifetime name cannot be used here",
+                        "explicit lifetime name needed here",
+                    )
+                } else {
+                    ("`'_` cannot be used here", "`'_` is a reserved lifetime name")
+                };
+                rustc_errors::struct_span_err!(
+                    self.r.session,
+                    lifetime.ident.span,
+                    E0637,
+                    "{}",
+                    msg,
+                )
+                .span_label(lifetime.ident.span, note)
+                .emit();
+
+                LifetimeRes::Error
+            }
+            AnonymousLifetimeRib::PassThrough(node_id) => {
+                LifetimeRes::Anonymous { binder: node_id, elided }
+            }
+            // This resolution is wrong, it passes the work to HIR lifetime resolution.
+            // We cannot use `LifetimeRes::Error` because we do not emit a diagnostic.
+            AnonymousLifetimeRib::Item => LifetimeRes::Anonymous { binder: DUMMY_NODE_ID, elided },
+        };
+        self.record_lifetime_res(lifetime.id, res);
     }
 
     #[tracing::instrument(level = "debug", skip(self))]
@@ -1269,7 +1291,12 @@ impl<'a: 'ast, 'b, 'ast> LateResolutionVisitor<'a, 'b, 'ast> {
     }
 
     #[tracing::instrument(level = "debug", skip(self))]
-    fn create_fresh_lifetime(&mut self, id: NodeId, ident: Ident, item_node_id: NodeId) {
+    fn create_fresh_lifetime(
+        &mut self,
+        id: NodeId,
+        ident: Ident,
+        item_node_id: NodeId,
+    ) -> LifetimeRes {
         debug_assert_eq!(ident.name, kw::UnderscoreLifetime);
         debug!(?ident.span);
         let item_def_id = self.r.local_def_id(item_node_id);
@@ -1284,12 +1311,12 @@ impl<'a: 'ast, 'b, 'ast> LateResolutionVisitor<'a, 'b, 'ast> {
         debug!(?def_id);
 
         let region = LifetimeRes::Fresh { param: def_id, binder: item_node_id };
-        self.record_lifetime_res(id, region);
         self.r.extra_lifetime_params_map.entry(item_node_id).or_insert_with(Vec::new).push((
             ident,
             def_node_id,
             region,
         ));
+        region
     }
 
     #[tracing::instrument(level = "debug", skip(self))]
@@ -1346,38 +1373,30 @@ impl<'a: 'ast, 'b, 'ast> LateResolutionVisitor<'a, 'b, 'ast> {
                 | PathSource::Struct
                 | PathSource::TupleStruct(..) => false,
             };
-            let mut res = LifetimeRes::Error;
-            for rib in self.lifetime_ribs.iter().rev() {
-                match rib.kind {
-                    // In create-parameter mode we error here because we don't want to support
-                    // deprecated impl elision in new features like impl elision and `async fn`,
-                    // both of which work using the `CreateParameter` mode:
-                    //
-                    //     impl Foo for std::cell::Ref<u32> // note lack of '_
-                    //     async fn foo(_: std::cell::Ref<u32>) { ... }
-                    LifetimeRibKind::AnonymousCreateParameter(_) => {
-                        break;
-                    }
-                    // `PassThrough` is the normal case.
-                    // `new_error_lifetime`, which would usually be used in the case of `ReportError`,
-                    // is unsuitable here, as these can occur from missing lifetime parameters in a
-                    // `PathSegment`, for which there is no associated `'_` or `&T` with no explicit
-                    // lifetime. Instead, we simply create an implicit lifetime, which will be checked
-                    // later, at which point a suitable error will be emitted.
-                    LifetimeRibKind::AnonymousPassThrough(binder) => {
-                        res = LifetimeRes::Anonymous { binder, elided: true };
-                        break;
-                    }
-                    LifetimeRibKind::AnonymousReportError | LifetimeRibKind::Item => {
-                        // FIXME(cjgillot) This resolution is wrong, but this does not matter
-                        // since these cases are erroneous anyway.  Lifetime resolution should
-                        // emit a "missing lifetime specifier" diagnostic.
-                        res = LifetimeRes::Anonymous { binder: DUMMY_NODE_ID, elided: true };
-                        break;
-                    }
-                    _ => {}
+            let res = match self.anonymous_lifetime_ribs.last().unwrap() {
+                // In create-parameter mode we error here because we don't want to support
+                // deprecated impl elision in new features like impl elision and `async fn`,
+                // both of which work using the `CreateParameter` mode:
+                //
+                //     impl Foo for std::cell::Ref<u32> // note lack of '_
+                //     async fn foo(_: std::cell::Ref<u32>) { ... }
+                AnonymousLifetimeRib::CreateParameter(_) => LifetimeRes::Error,
+                // `PassThrough` is the normal case.
+                // `new_error_lifetime`, which would usually be used in the case of `ReportError`,
+                // is unsuitable here, as these can occur from missing lifetime parameters in a
+                // `PathSegment`, for which there is no associated `'_` or `&T` with no explicit
+                // lifetime. Instead, we simply create an implicit lifetime, which will be checked
+                // later, at which point a suitable error will be emitted.
+                AnonymousLifetimeRib::PassThrough(binder) => {
+                    LifetimeRes::Anonymous { binder: *binder, elided: true }
                 }
-            }
+                // FIXME(cjgillot) This resolution is wrong, but this does not matter
+                // since these cases are erroneous anyway.  Lifetime resolution should
+                // emit a "missing lifetime specifier" diagnostic.
+                AnonymousLifetimeRib::ReportError | AnonymousLifetimeRib::Item => {
+                    LifetimeRes::Anonymous { binder: DUMMY_NODE_ID, elided: true }
+                }
+            };
 
             let node_ids = self.r.next_node_ids(expected_lifetimes);
             self.record_lifetime_res(
@@ -1838,7 +1857,9 @@ impl<'a: 'ast, 'b, 'ast> LateResolutionVisitor<'a, 'b, 'ast> {
     fn with_item_rib(&mut self, f: impl FnOnce(&mut Self)) {
         let kind = ItemRibKind(HasGenericParams::No);
         self.with_lifetime_rib(LifetimeRibKind::Item, |this| {
-            this.with_rib(ValueNS, kind, |this| this.with_rib(TypeNS, kind, f))
+            this.with_anon_lifetime_rib(AnonymousLifetimeRib::Item, |this| {
+                this.with_rib(ValueNS, kind, |this| this.with_rib(TypeNS, kind, f))
+            })
         })
     }
 
@@ -1987,7 +2008,7 @@ impl<'a: 'ast, 'b, 'ast> LateResolutionVisitor<'a, 'b, 'ast> {
         self.with_generic_param_rib(&generics.params, ItemRibKind(HasGenericParams::Yes), LifetimeRibKind::Generics { span: generics.span, parent: item_id, kind: LifetimeBinderKind::ImplBlock }, |this| {
             // Dummy self type for better errors if `Self` is used in the trait path.
             this.with_self_rib(Res::SelfTy { trait_: None, alias_to: None }, |this| {
-                this.with_lifetime_rib(LifetimeRibKind::AnonymousCreateParameter(item_id), |this| {
+                this.with_anon_lifetime_rib(AnonymousLifetimeRib::CreateParameter(item_id), |this| {
                     // Resolve the trait reference, if necessary.
                     this.with_optional_trait_ref(opt_trait_reference.as_ref(), |this, trait_id| {
                         let item_def_id = this.r.local_def_id(item_id);
@@ -2011,7 +2032,7 @@ impl<'a: 'ast, 'b, 'ast> LateResolutionVisitor<'a, 'b, 'ast> {
                             this.visit_generics(generics);
 
                             // Resolve the items within the impl.
-                            this.with_lifetime_rib(LifetimeRibKind::AnonymousPassThrough(item_id),
+                            this.with_anon_lifetime_rib(AnonymousLifetimeRib::PassThrough(item_id),
                                 |this| {
                                     this.with_current_self_type(self_type, |this| {
                                         this.with_self_rib_ns(ValueNS, Res::SelfCtor(item_def_id), |this| {

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -204,6 +204,11 @@ enum LifetimeRibKind {
     /// lifetimes in const generics. See issue #74052 for discussion.
     ConstGeneric,
 
+    /// Non-static lifetimes are prohibited in anonymous constants under `min_const_generics`.
+    /// This function will emit an error if `generic_const_exprs` is not enabled, the body identified by
+    /// `body_id` is an anonymous constant and `lifetime_ref` is non-static.
+    AnonConst,
+
     /// For **Modern** cases, create a new anonymous region parameter
     /// and reference that.
     ///
@@ -532,7 +537,9 @@ impl<'a: 'ast, 'ast> Visitor<'ast> for LateResolutionVisitor<'a, '_, 'ast> {
     }
     fn visit_anon_const(&mut self, constant: &'ast AnonConst) {
         // We deal with repeat expressions explicitly in `resolve_expr`.
-        self.resolve_anon_const(constant, IsRepeatExpr::No);
+        self.with_lifetime_rib(LifetimeRibKind::AnonConst, |this| {
+            this.resolve_anon_const(constant, IsRepeatExpr::No);
+        })
     }
     fn visit_expr(&mut self, expr: &'ast Expr) {
         self.resolve_expr(expr, None);
@@ -1117,7 +1124,7 @@ impl<'a: 'ast, 'b, 'ast> LateResolutionVisitor<'a, 'b, 'ast> {
                             this.ribs[TypeNS].push(forward_ty_ban_rib);
                             this.ribs[ValueNS].push(forward_const_ban_rib);
                             this.with_lifetime_rib(LifetimeRibKind::ConstGeneric, |this| {
-                                this.visit_anon_const(expr)
+                                this.resolve_anon_const(expr, IsRepeatExpr::No)
                             });
                             forward_const_ban_rib = this.ribs[ValueNS].pop().unwrap();
                             forward_ty_ban_rib = this.ribs[TypeNS].pop().unwrap();
@@ -1171,6 +1178,11 @@ impl<'a: 'ast, 'b, 'ast> LateResolutionVisitor<'a, 'b, 'ast> {
                 LifetimeRibKind::Item => break,
                 LifetimeRibKind::ConstGeneric => {
                     self.emit_non_static_lt_in_const_generic_error(lifetime);
+                    self.r.lifetimes_res_map.insert(lifetime.id, LifetimeRes::Error);
+                    return;
+                }
+                LifetimeRibKind::AnonConst => {
+                    self.maybe_emit_forbidden_non_static_lifetime_error(lifetime);
                     self.r.lifetimes_res_map.insert(lifetime.id, LifetimeRes::Error);
                     return;
                 }
@@ -3076,9 +3088,7 @@ impl<'a: 'ast, 'b, 'ast> LateResolutionVisitor<'a, 'b, 'ast> {
             is_repeat,
             constant.value.is_potential_trivial_const_param(),
             None,
-            |this| {
-                visit::walk_anon_const(this, constant);
-            },
+            |this| visit::walk_anon_const(this, constant),
         );
     }
 
@@ -3229,7 +3239,12 @@ impl<'a: 'ast, 'b, 'ast> LateResolutionVisitor<'a, 'b, 'ast> {
             }
             ExprKind::Repeat(ref elem, ref ct) => {
                 self.visit_expr(elem);
-                self.resolve_anon_const(ct, IsRepeatExpr::Yes);
+                self.with_lifetime_rib(LifetimeRibKind::AnonConst, |this| {
+                    this.resolve_anon_const(ct, IsRepeatExpr::Yes)
+                });
+            }
+            ExprKind::ConstBlock(ref ct) => {
+                self.resolve_anon_const(ct, IsRepeatExpr::No);
             }
             ExprKind::Index(ref elem, ref idx) => {
                 self.resolve_expr(elem, Some(expr));

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -1901,6 +1901,22 @@ impl<'a: 'ast, 'ast> LateResolutionVisitor<'a, '_, 'ast> {
         )
         .emit();
     }
+
+    /// Non-static lifetimes are prohibited in anonymous constants under `min_const_generics`.
+    /// This function will emit an error if `generic_const_exprs` is not enabled, the body identified by
+    /// `body_id` is an anonymous constant and `lifetime_ref` is non-static.
+    crate fn maybe_emit_forbidden_non_static_lifetime_error(&self, lifetime_ref: &ast::Lifetime) {
+        let feature_active = self.r.session.features_untracked().generic_const_exprs;
+        if !feature_active {
+            feature_err(
+                &self.r.session.parse_sess,
+                sym::generic_const_exprs,
+                lifetime_ref.ident.span,
+                "a non-static lifetime is not allowed in a `const`",
+            )
+            .emit();
+        }
+    }
 }
 
 impl<'tcx> LifetimeContext<'_, 'tcx> {
@@ -2396,34 +2412,6 @@ impl<'tcx> LifetimeContext<'_, 'tcx> {
                 }
             }
             _ => unreachable!(),
-        }
-    }
-
-    /// Non-static lifetimes are prohibited in anonymous constants under `min_const_generics`.
-    /// This function will emit an error if `generic_const_exprs` is not enabled, the body identified by
-    /// `body_id` is an anonymous constant and `lifetime_ref` is non-static.
-    crate fn maybe_emit_forbidden_non_static_lifetime_error(
-        &self,
-        body_id: hir::BodyId,
-        lifetime_ref: &'tcx hir::Lifetime,
-    ) {
-        let is_anon_const = matches!(
-            self.tcx.def_kind(self.tcx.hir().body_owner_def_id(body_id)),
-            hir::def::DefKind::AnonConst
-        );
-        let is_allowed_lifetime = matches!(
-            lifetime_ref.name,
-            hir::LifetimeName::Implicit | hir::LifetimeName::Static | hir::LifetimeName::Underscore
-        );
-
-        if !self.tcx.lazy_normalization() && is_anon_const && !is_allowed_lifetime {
-            feature_err(
-                &self.tcx.sess.parse_sess,
-                sym::generic_const_exprs,
-                lifetime_ref.span,
-                "a non-static lifetime is not allowed in a `const`",
-            )
-            .emit();
         }
     }
 }

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -1886,6 +1886,21 @@ impl<'a: 'ast, 'ast> LateResolutionVisitor<'a, '_, 'ast> {
 
         err.emit();
     }
+
+    crate fn emit_non_static_lt_in_const_generic_error(&self, lifetime_ref: &ast::Lifetime) {
+        struct_span_err!(
+            self.r.session,
+            lifetime_ref.ident.span,
+            E0771,
+            "use of non-static lifetime `{}` in const generic",
+            lifetime_ref.ident
+        )
+        .note(
+            "for more information, see issue #74052 \
+            <https://github.com/rust-lang/rust/issues/74052>",
+        )
+        .emit();
+    }
 }
 
 impl<'tcx> LifetimeContext<'_, 'tcx> {
@@ -1980,24 +1995,6 @@ impl<'tcx> LifetimeContext<'_, 'tcx> {
             ));
             false
         }
-    }
-
-    // FIXME(const_generics): This patches over an ICE caused by non-'static lifetimes in const
-    // generics. We are disallowing this until we can decide on how we want to handle non-'static
-    // lifetimes in const generics. See issue #74052 for discussion.
-    crate fn emit_non_static_lt_in_const_generic_error(&self, lifetime_ref: &hir::Lifetime) {
-        let mut err = struct_span_err!(
-            self.tcx.sess,
-            lifetime_ref.span,
-            E0771,
-            "use of non-static lifetime `{}` in const generic",
-            lifetime_ref
-        );
-        err.note(
-            "for more information, see issue #74052 \
-            <https://github.com/rust-lang/rust/issues/74052>",
-        );
-        err.emit();
     }
 
     crate fn is_trait_ref_fn_scope(&mut self, trait_ref: &'tcx hir::PolyTraitRef<'tcx>) -> bool {

--- a/compiler/rustc_resolve/src/late/lifetimes.rs
+++ b/compiler/rustc_resolve/src/late/lifetimes.rs
@@ -2243,10 +2243,6 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
         let result = loop {
             match *scope {
                 Scope::Body { id, s } => {
-                    // Non-static lifetimes are prohibited in anonymous constants without
-                    // `generic_const_exprs`.
-                    self.maybe_emit_forbidden_non_static_lifetime_error(id, lifetime_ref);
-
                     outermost_body = Some(id);
                     scope = s;
                 }

--- a/compiler/rustc_resolve/src/late/lifetimes.rs
+++ b/compiler/rustc_resolve/src/late/lifetimes.rs
@@ -164,8 +164,6 @@ crate struct LifetimeContext<'a, 'tcx> {
     map: &'a mut NamedRegionMap,
     scope: ScopeRef<'a>,
 
-    is_in_const_generic: bool,
-
     /// Indicates that we only care about the definition of a trait. This should
     /// be false if the `Item` we are resolving lifetimes for is not a trait or
     /// we eventually need lifetimes resolve for trait items.
@@ -452,7 +450,6 @@ fn do_resolve(
         tcx,
         map: &mut named_region_map,
         scope: ROOT_SCOPE,
-        is_in_const_generic: false,
         trait_definition_only,
         labels_in_fn: vec![],
         xcrate_object_lifetime_defaults: Default::default(),
@@ -1266,10 +1263,6 @@ impl<'a, 'tcx> Visitor<'tcx> for LifetimeContext<'a, 'tcx> {
             self.insert_lifetime(lifetime_ref, Region::Static);
             return;
         }
-        if self.is_in_const_generic && lifetime_ref.name != LifetimeName::Error {
-            self.emit_non_static_lt_in_const_generic_error(lifetime_ref);
-            return;
-        }
         self.resolve_lifetime_ref(lifetime_ref);
     }
 
@@ -1341,14 +1334,11 @@ impl<'a, 'tcx> Visitor<'tcx> for LifetimeContext<'a, 'tcx> {
                         }
                     }
                     GenericParamKind::Const { ref ty, default } => {
-                        let was_in_const_generic = this.is_in_const_generic;
-                        this.is_in_const_generic = true;
                         walk_list!(this, visit_param_bound, param.bounds);
                         this.visit_ty(&ty);
                         if let Some(default) = default {
                             this.visit_body(this.tcx.hir().body(default.body));
                         }
-                        this.is_in_const_generic = was_in_const_generic;
                     }
                 }
             }
@@ -1798,7 +1788,6 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
             tcx: *tcx,
             map,
             scope: &wrap_scope,
-            is_in_const_generic: self.is_in_const_generic,
             trait_definition_only: self.trait_definition_only,
             labels_in_fn,
             xcrate_object_lifetime_defaults,

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -12,6 +12,7 @@
 #![feature(bool_to_option)]
 #![feature(crate_visibility_modifier)]
 #![feature(if_let_guard)]
+#![feature(iter_intersperse)]
 #![feature(let_chains)]
 #![feature(let_else)]
 #![feature(never_type)]

--- a/src/test/ui/abi/numbers-arithmetic/i128-ffi.rs
+++ b/src/test/ui/abi/numbers-arithmetic/i128-ffi.rs
@@ -12,7 +12,7 @@
 extern "C" {
     fn identity(f: u128) -> u128;
     fn square(f: i128) -> i128;
-    fn sub(f: i128, f: i128) -> i128;
+    fn sub(f: i128, g: i128) -> i128;
 }
 
 fn main() {

--- a/src/test/ui/abi/numbers-arithmetic/i128-ffi.rs
+++ b/src/test/ui/abi/numbers-arithmetic/i128-ffi.rs
@@ -12,7 +12,7 @@
 extern "C" {
     fn identity(f: u128) -> u128;
     fn square(f: i128) -> i128;
-    fn sub(f: i128, g: i128) -> i128;
+    fn sub(f: i128, f: i128) -> i128;
 }
 
 fn main() {

--- a/src/test/ui/associated-types/bound-lifetime-in-binding-only.elision.stderr
+++ b/src/test/ui/associated-types/bound-lifetime-in-binding-only.elision.stderr
@@ -5,15 +5,10 @@ LL | fn elision<T: Fn() -> &i32>() {
    |                       ^ expected named lifetime parameter
    |
    = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
-   = note: for more information on higher-ranked polymorphism, visit https://doc.rust-lang.org/nomicon/hrtb.html
-help: consider making the bound lifetime-generic with a new `'a` lifetime
-   |
-LL | fn elision<T: for<'a> Fn() -> &'a i32>() {
-   |               +++++++         ~~~
 help: consider using the `'static` lifetime
    |
 LL | fn elision<T: Fn() -> &'static i32>() {
-   |                       ~~~~~~~~
+   |                        +++++++
 
 error: aborting due to previous error
 

--- a/src/test/ui/associated-types/bound-lifetime-in-return-only.elision.stderr
+++ b/src/test/ui/associated-types/bound-lifetime-in-return-only.elision.stderr
@@ -5,15 +5,10 @@ LL | fn elision(_: fn() -> &i32) {
    |                       ^ expected named lifetime parameter
    |
    = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
-   = note: for more information on higher-ranked polymorphism, visit https://doc.rust-lang.org/nomicon/hrtb.html
-help: consider making the type lifetime-generic with a new `'a` lifetime
-   |
-LL | fn elision(_: for<'a> fn() -> &'a i32) {
-   |               +++++++         ~~~
 help: consider using the `'static` lifetime
    |
 LL | fn elision(_: fn() -> &'static i32) {
-   |                       ~~~~~~~~
+   |                        +++++++
 
 error: aborting due to previous error
 

--- a/src/test/ui/async-await/issues/issue-63388-2.rs
+++ b/src/test/ui/async-await/issues/issue-63388-2.rs
@@ -9,6 +9,7 @@ trait Foo {}
 impl Xyz {
     async fn do_sth<'a>(
         foo: &dyn Foo, bar: &'a dyn Foo
+        //~^ ERROR `foo` has an anonymous lifetime `'_` but it needs to satisfy a `'static`
     ) -> &dyn Foo //~ ERROR missing lifetime specifier
     {
         foo

--- a/src/test/ui/async-await/issues/issue-63388-2.stderr
+++ b/src/test/ui/async-await/issues/issue-63388-2.stderr
@@ -1,8 +1,9 @@
 error[E0106]: missing lifetime specifier
-  --> $DIR/issue-63388-2.rs:12:10
+  --> $DIR/issue-63388-2.rs:13:10
    |
 LL |         foo: &dyn Foo, bar: &'a dyn Foo
    |              --------       -----------
+LL |
 LL |     ) -> &dyn Foo
    |          ^ expected named lifetime parameter
    |
@@ -10,8 +11,33 @@ LL |     ) -> &dyn Foo
 help: consider using the `'a` lifetime
    |
 LL |     ) -> &'a dyn Foo
-   |          ~~~
+   |           ++
 
-error: aborting due to previous error
+error[E0759]: `foo` has an anonymous lifetime `'_` but it needs to satisfy a `'static` lifetime requirement
+  --> $DIR/issue-63388-2.rs:11:9
+   |
+LL |         foo: &dyn Foo, bar: &'a dyn Foo
+   |         ^^^  -------- this data with an anonymous lifetime `'_`...
+   |         |
+   |         ...is used here...
+...
+LL |         foo
+   |         --- ...and is required to live as long as `'static` here
+   |
+note: `'static` lifetime requirement introduced by the return type
+  --> $DIR/issue-63388-2.rs:13:10
+   |
+LL |     ) -> &dyn Foo
+   |          ^^^^^^^^ requirement introduced by this return type
+LL |     {
+LL |         foo
+   |         --- because of this returned expression
+help: to declare that the trait object captures data from argument `foo`, you can add an explicit `'_` lifetime bound
+   |
+LL |     ) -> &dyn Foo + '_
+   |                   ++++
 
-For more information about this error, try `rustc --explain E0106`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0106, E0759.
+For more information about an error, try `rustc --explain E0106`.

--- a/src/test/ui/c-variadic/variadic-ffi-6.stderr
+++ b/src/test/ui/c-variadic/variadic-ffi-6.stderr
@@ -4,11 +4,11 @@ error[E0106]: missing lifetime specifier
 LL | ) -> &usize {
    |      ^ expected named lifetime parameter
    |
-   = help: this function's return type contains a borrowed value with an elided lifetime, but the lifetime cannot be derived from the arguments
+   = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
 help: consider using the `'static` lifetime
    |
 LL | ) -> &'static usize {
-   |      ~~~~~~~~
+   |       +++++++
 
 error: aborting due to previous error
 

--- a/src/test/ui/const-generics/const-arg-in-const-arg.min.stderr
+++ b/src/test/ui/const-generics/const-arg-in-const-arg.min.stderr
@@ -16,6 +16,42 @@ LL |     let _: [u8; bar::<N>()];
    = help: const parameters may only be used as standalone arguments, i.e. `N`
    = help: use `#![feature(generic_const_exprs)]` to allow generic const expressions
 
+error[E0658]: a non-static lifetime is not allowed in a `const`
+  --> $DIR/const-arg-in-const-arg.rs:16:23
+   |
+LL |     let _: [u8; faz::<'a>(&())];
+   |                       ^^
+   |
+   = note: see issue #76560 <https://github.com/rust-lang/rust/issues/76560> for more information
+   = help: add `#![feature(generic_const_exprs)]` to the crate attributes to enable
+
+error[E0658]: a non-static lifetime is not allowed in a `const`
+  --> $DIR/const-arg-in-const-arg.rs:18:23
+   |
+LL |     let _: [u8; baz::<'a>(&())];
+   |                       ^^
+   |
+   = note: see issue #76560 <https://github.com/rust-lang/rust/issues/76560> for more information
+   = help: add `#![feature(generic_const_exprs)]` to the crate attributes to enable
+
+error[E0658]: a non-static lifetime is not allowed in a `const`
+  --> $DIR/const-arg-in-const-arg.rs:19:23
+   |
+LL |     let _: [u8; faz::<'b>(&())];
+   |                       ^^
+   |
+   = note: see issue #76560 <https://github.com/rust-lang/rust/issues/76560> for more information
+   = help: add `#![feature(generic_const_exprs)]` to the crate attributes to enable
+
+error[E0658]: a non-static lifetime is not allowed in a `const`
+  --> $DIR/const-arg-in-const-arg.rs:21:23
+   |
+LL |     let _: [u8; baz::<'b>(&())];
+   |                       ^^
+   |
+   = note: see issue #76560 <https://github.com/rust-lang/rust/issues/76560> for more information
+   = help: add `#![feature(generic_const_exprs)]` to the crate attributes to enable
+
 error: generic parameters may not be used in const operations
   --> $DIR/const-arg-in-const-arg.rs:24:23
    |
@@ -25,80 +61,8 @@ LL |     let _ = [0; bar::<N>()];
    = help: const parameters may only be used as standalone arguments, i.e. `N`
    = help: use `#![feature(generic_const_exprs)]` to allow generic const expressions
 
-error: generic parameters may not be used in const operations
-  --> $DIR/const-arg-in-const-arg.rs:29:24
-   |
-LL |     let _: Foo<{ foo::<T>() }>;
-   |                        ^ cannot perform const operation using `T`
-   |
-   = note: type parameters may not be used in const expressions
-   = help: use `#![feature(generic_const_exprs)]` to allow generic const expressions
-
-error: generic parameters may not be used in const operations
-  --> $DIR/const-arg-in-const-arg.rs:30:24
-   |
-LL |     let _: Foo<{ bar::<N>() }>;
-   |                        ^ cannot perform const operation using `N`
-   |
-   = help: const parameters may only be used as standalone arguments, i.e. `N`
-   = help: use `#![feature(generic_const_exprs)]` to allow generic const expressions
-
-error: generic parameters may not be used in const operations
-  --> $DIR/const-arg-in-const-arg.rs:35:27
-   |
-LL |     let _ = Foo::<{ foo::<T>() }>;
-   |                           ^ cannot perform const operation using `T`
-   |
-   = note: type parameters may not be used in const expressions
-   = help: use `#![feature(generic_const_exprs)]` to allow generic const expressions
-
-error: generic parameters may not be used in const operations
-  --> $DIR/const-arg-in-const-arg.rs:36:27
-   |
-LL |     let _ = Foo::<{ bar::<N>() }>;
-   |                           ^ cannot perform const operation using `N`
-   |
-   = help: const parameters may only be used as standalone arguments, i.e. `N`
-   = help: use `#![feature(generic_const_exprs)]` to allow generic const expressions
-
 error[E0658]: a non-static lifetime is not allowed in a `const`
-  --> $DIR/const-arg-in-const-arg.rs:15:23
-   |
-LL |     let _: [u8; faz::<'a>(&())];
-   |                       ^^
-   |
-   = note: see issue #76560 <https://github.com/rust-lang/rust/issues/76560> for more information
-   = help: add `#![feature(generic_const_exprs)]` to the crate attributes to enable
-
-error[E0658]: a non-static lifetime is not allowed in a `const`
-  --> $DIR/const-arg-in-const-arg.rs:16:23
-   |
-LL |     let _: [u8; baz::<'a>(&())];
-   |                       ^^
-   |
-   = note: see issue #76560 <https://github.com/rust-lang/rust/issues/76560> for more information
-   = help: add `#![feature(generic_const_exprs)]` to the crate attributes to enable
-
-error[E0658]: a non-static lifetime is not allowed in a `const`
-  --> $DIR/const-arg-in-const-arg.rs:17:23
-   |
-LL |     let _: [u8; faz::<'b>(&())];
-   |                       ^^
-   |
-   = note: see issue #76560 <https://github.com/rust-lang/rust/issues/76560> for more information
-   = help: add `#![feature(generic_const_exprs)]` to the crate attributes to enable
-
-error[E0658]: a non-static lifetime is not allowed in a `const`
-  --> $DIR/const-arg-in-const-arg.rs:18:23
-   |
-LL |     let _: [u8; baz::<'b>(&())];
-   |                       ^^
-   |
-   = note: see issue #76560 <https://github.com/rust-lang/rust/issues/76560> for more information
-   = help: add `#![feature(generic_const_exprs)]` to the crate attributes to enable
-
-error[E0658]: a non-static lifetime is not allowed in a `const`
-  --> $DIR/const-arg-in-const-arg.rs:25:23
+  --> $DIR/const-arg-in-const-arg.rs:26:23
    |
 LL |     let _ = [0; faz::<'a>(&())];
    |                       ^^
@@ -107,7 +71,7 @@ LL |     let _ = [0; faz::<'a>(&())];
    = help: add `#![feature(generic_const_exprs)]` to the crate attributes to enable
 
 error[E0658]: a non-static lifetime is not allowed in a `const`
-  --> $DIR/const-arg-in-const-arg.rs:26:23
+  --> $DIR/const-arg-in-const-arg.rs:28:23
    |
 LL |     let _ = [0; baz::<'a>(&())];
    |                       ^^
@@ -116,7 +80,7 @@ LL |     let _ = [0; baz::<'a>(&())];
    = help: add `#![feature(generic_const_exprs)]` to the crate attributes to enable
 
 error[E0658]: a non-static lifetime is not allowed in a `const`
-  --> $DIR/const-arg-in-const-arg.rs:27:23
+  --> $DIR/const-arg-in-const-arg.rs:29:23
    |
 LL |     let _ = [0; faz::<'b>(&())];
    |                       ^^
@@ -125,7 +89,7 @@ LL |     let _ = [0; faz::<'b>(&())];
    = help: add `#![feature(generic_const_exprs)]` to the crate attributes to enable
 
 error[E0658]: a non-static lifetime is not allowed in a `const`
-  --> $DIR/const-arg-in-const-arg.rs:28:23
+  --> $DIR/const-arg-in-const-arg.rs:31:23
    |
 LL |     let _ = [0; baz::<'b>(&())];
    |                       ^^
@@ -133,8 +97,26 @@ LL |     let _ = [0; baz::<'b>(&())];
    = note: see issue #76560 <https://github.com/rust-lang/rust/issues/76560> for more information
    = help: add `#![feature(generic_const_exprs)]` to the crate attributes to enable
 
+error: generic parameters may not be used in const operations
+  --> $DIR/const-arg-in-const-arg.rs:32:24
+   |
+LL |     let _: Foo<{ foo::<T>() }>;
+   |                        ^ cannot perform const operation using `T`
+   |
+   = note: type parameters may not be used in const expressions
+   = help: use `#![feature(generic_const_exprs)]` to allow generic const expressions
+
+error: generic parameters may not be used in const operations
+  --> $DIR/const-arg-in-const-arg.rs:33:24
+   |
+LL |     let _: Foo<{ bar::<N>() }>;
+   |                        ^ cannot perform const operation using `N`
+   |
+   = help: const parameters may only be used as standalone arguments, i.e. `N`
+   = help: use `#![feature(generic_const_exprs)]` to allow generic const expressions
+
 error[E0658]: a non-static lifetime is not allowed in a `const`
-  --> $DIR/const-arg-in-const-arg.rs:31:24
+  --> $DIR/const-arg-in-const-arg.rs:35:24
    |
 LL |     let _: Foo<{ faz::<'a>(&()) }>;
    |                        ^^
@@ -143,7 +125,7 @@ LL |     let _: Foo<{ faz::<'a>(&()) }>;
    = help: add `#![feature(generic_const_exprs)]` to the crate attributes to enable
 
 error[E0658]: a non-static lifetime is not allowed in a `const`
-  --> $DIR/const-arg-in-const-arg.rs:32:24
+  --> $DIR/const-arg-in-const-arg.rs:37:24
    |
 LL |     let _: Foo<{ baz::<'a>(&()) }>;
    |                        ^^
@@ -152,7 +134,7 @@ LL |     let _: Foo<{ baz::<'a>(&()) }>;
    = help: add `#![feature(generic_const_exprs)]` to the crate attributes to enable
 
 error[E0658]: a non-static lifetime is not allowed in a `const`
-  --> $DIR/const-arg-in-const-arg.rs:33:24
+  --> $DIR/const-arg-in-const-arg.rs:38:24
    |
 LL |     let _: Foo<{ faz::<'b>(&()) }>;
    |                        ^^
@@ -161,7 +143,7 @@ LL |     let _: Foo<{ faz::<'b>(&()) }>;
    = help: add `#![feature(generic_const_exprs)]` to the crate attributes to enable
 
 error[E0658]: a non-static lifetime is not allowed in a `const`
-  --> $DIR/const-arg-in-const-arg.rs:34:24
+  --> $DIR/const-arg-in-const-arg.rs:40:24
    |
 LL |     let _: Foo<{ baz::<'b>(&()) }>;
    |                        ^^
@@ -169,8 +151,26 @@ LL |     let _: Foo<{ baz::<'b>(&()) }>;
    = note: see issue #76560 <https://github.com/rust-lang/rust/issues/76560> for more information
    = help: add `#![feature(generic_const_exprs)]` to the crate attributes to enable
 
+error: generic parameters may not be used in const operations
+  --> $DIR/const-arg-in-const-arg.rs:41:27
+   |
+LL |     let _ = Foo::<{ foo::<T>() }>;
+   |                           ^ cannot perform const operation using `T`
+   |
+   = note: type parameters may not be used in const expressions
+   = help: use `#![feature(generic_const_exprs)]` to allow generic const expressions
+
+error: generic parameters may not be used in const operations
+  --> $DIR/const-arg-in-const-arg.rs:42:27
+   |
+LL |     let _ = Foo::<{ bar::<N>() }>;
+   |                           ^ cannot perform const operation using `N`
+   |
+   = help: const parameters may only be used as standalone arguments, i.e. `N`
+   = help: use `#![feature(generic_const_exprs)]` to allow generic const expressions
+
 error[E0658]: a non-static lifetime is not allowed in a `const`
-  --> $DIR/const-arg-in-const-arg.rs:37:27
+  --> $DIR/const-arg-in-const-arg.rs:44:27
    |
 LL |     let _ = Foo::<{ faz::<'a>(&()) }>;
    |                           ^^
@@ -179,7 +179,7 @@ LL |     let _ = Foo::<{ faz::<'a>(&()) }>;
    = help: add `#![feature(generic_const_exprs)]` to the crate attributes to enable
 
 error[E0658]: a non-static lifetime is not allowed in a `const`
-  --> $DIR/const-arg-in-const-arg.rs:38:27
+  --> $DIR/const-arg-in-const-arg.rs:46:27
    |
 LL |     let _ = Foo::<{ baz::<'a>(&()) }>;
    |                           ^^
@@ -188,7 +188,7 @@ LL |     let _ = Foo::<{ baz::<'a>(&()) }>;
    = help: add `#![feature(generic_const_exprs)]` to the crate attributes to enable
 
 error[E0658]: a non-static lifetime is not allowed in a `const`
-  --> $DIR/const-arg-in-const-arg.rs:39:27
+  --> $DIR/const-arg-in-const-arg.rs:47:27
    |
 LL |     let _ = Foo::<{ faz::<'b>(&()) }>;
    |                           ^^
@@ -197,7 +197,7 @@ LL |     let _ = Foo::<{ faz::<'b>(&()) }>;
    = help: add `#![feature(generic_const_exprs)]` to the crate attributes to enable
 
 error[E0658]: a non-static lifetime is not allowed in a `const`
-  --> $DIR/const-arg-in-const-arg.rs:40:27
+  --> $DIR/const-arg-in-const-arg.rs:49:27
    |
 LL |     let _ = Foo::<{ baz::<'b>(&()) }>;
    |                           ^^
@@ -205,6 +205,155 @@ LL |     let _ = Foo::<{ baz::<'b>(&()) }>;
    = note: see issue #76560 <https://github.com/rust-lang/rust/issues/76560> for more information
    = help: add `#![feature(generic_const_exprs)]` to the crate attributes to enable
 
-error: aborting due to 23 previous errors
+error[E0747]: unresolved item provided when a constant was expected
+  --> $DIR/const-arg-in-const-arg.rs:14:23
+   |
+LL |     let _: [u8; bar::<N>()];
+   |                       ^
+   |
+help: if this generic argument was intended as a const parameter, surround it with braces
+   |
+LL |     let _: [u8; bar::<{ N }>()];
+   |                       +   +
 
-For more information about this error, try `rustc --explain E0658`.
+error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
+  --> $DIR/const-arg-in-const-arg.rs:16:23
+   |
+LL |     let _: [u8; faz::<'a>(&())];
+   |                       ^^
+   |
+note: the late bound lifetime parameter is introduced here
+  --> $DIR/const-arg-in-const-arg.rs:8:14
+   |
+LL | const fn faz<'a>(_: &'a ()) -> usize { 13 }
+   |              ^^
+
+error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
+  --> $DIR/const-arg-in-const-arg.rs:19:23
+   |
+LL |     let _: [u8; faz::<'b>(&())];
+   |                       ^^
+   |
+note: the late bound lifetime parameter is introduced here
+  --> $DIR/const-arg-in-const-arg.rs:8:14
+   |
+LL | const fn faz<'a>(_: &'a ()) -> usize { 13 }
+   |              ^^
+
+error[E0747]: unresolved item provided when a constant was expected
+  --> $DIR/const-arg-in-const-arg.rs:24:23
+   |
+LL |     let _ = [0; bar::<N>()];
+   |                       ^
+   |
+help: if this generic argument was intended as a const parameter, surround it with braces
+   |
+LL |     let _ = [0; bar::<{ N }>()];
+   |                       +   +
+
+error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
+  --> $DIR/const-arg-in-const-arg.rs:26:23
+   |
+LL |     let _ = [0; faz::<'a>(&())];
+   |                       ^^
+   |
+note: the late bound lifetime parameter is introduced here
+  --> $DIR/const-arg-in-const-arg.rs:8:14
+   |
+LL | const fn faz<'a>(_: &'a ()) -> usize { 13 }
+   |              ^^
+
+error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
+  --> $DIR/const-arg-in-const-arg.rs:29:23
+   |
+LL |     let _ = [0; faz::<'b>(&())];
+   |                       ^^
+   |
+note: the late bound lifetime parameter is introduced here
+  --> $DIR/const-arg-in-const-arg.rs:8:14
+   |
+LL | const fn faz<'a>(_: &'a ()) -> usize { 13 }
+   |              ^^
+
+error[E0747]: unresolved item provided when a constant was expected
+  --> $DIR/const-arg-in-const-arg.rs:33:24
+   |
+LL |     let _: Foo<{ bar::<N>() }>;
+   |                        ^
+   |
+help: if this generic argument was intended as a const parameter, surround it with braces
+   |
+LL |     let _: Foo<{ bar::<{ N }>() }>;
+   |                        +   +
+
+error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
+  --> $DIR/const-arg-in-const-arg.rs:35:24
+   |
+LL |     let _: Foo<{ faz::<'a>(&()) }>;
+   |                        ^^
+   |
+note: the late bound lifetime parameter is introduced here
+  --> $DIR/const-arg-in-const-arg.rs:8:14
+   |
+LL | const fn faz<'a>(_: &'a ()) -> usize { 13 }
+   |              ^^
+
+error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
+  --> $DIR/const-arg-in-const-arg.rs:38:24
+   |
+LL |     let _: Foo<{ faz::<'b>(&()) }>;
+   |                        ^^
+   |
+note: the late bound lifetime parameter is introduced here
+  --> $DIR/const-arg-in-const-arg.rs:8:14
+   |
+LL | const fn faz<'a>(_: &'a ()) -> usize { 13 }
+   |              ^^
+
+error: constant expression depends on a generic parameter
+  --> $DIR/const-arg-in-const-arg.rs:23:17
+   |
+LL |     let _ = [0; foo::<T>()];
+   |                 ^^^^^^^^^^
+   |
+   = note: this may fail depending on what value the parameter takes
+
+error[E0747]: unresolved item provided when a constant was expected
+  --> $DIR/const-arg-in-const-arg.rs:42:27
+   |
+LL |     let _ = Foo::<{ bar::<N>() }>;
+   |                           ^
+   |
+help: if this generic argument was intended as a const parameter, surround it with braces
+   |
+LL |     let _ = Foo::<{ bar::<{ N }>() }>;
+   |                           +   +
+
+error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
+  --> $DIR/const-arg-in-const-arg.rs:44:27
+   |
+LL |     let _ = Foo::<{ faz::<'a>(&()) }>;
+   |                           ^^
+   |
+note: the late bound lifetime parameter is introduced here
+  --> $DIR/const-arg-in-const-arg.rs:8:14
+   |
+LL | const fn faz<'a>(_: &'a ()) -> usize { 13 }
+   |              ^^
+
+error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
+  --> $DIR/const-arg-in-const-arg.rs:47:27
+   |
+LL |     let _ = Foo::<{ faz::<'b>(&()) }>;
+   |                           ^^
+   |
+note: the late bound lifetime parameter is introduced here
+  --> $DIR/const-arg-in-const-arg.rs:8:14
+   |
+LL | const fn faz<'a>(_: &'a ()) -> usize { 13 }
+   |              ^^
+
+error: aborting due to 36 previous errors
+
+Some errors have detailed explanations: E0658, E0747.
+For more information about an error, try `rustc --explain E0658`.

--- a/src/test/ui/const-generics/const-arg-in-const-arg.rs
+++ b/src/test/ui/const-generics/const-arg-in-const-arg.rs
@@ -12,31 +12,40 @@ struct Foo<const N: usize>;
 fn test<'a, 'b, T, const N: usize>() where &'b (): Sized {
     let _: [u8; foo::<T>()]; //~ ERROR generic parameters may not
     let _: [u8; bar::<N>()]; //~ ERROR generic parameters may not
+                             //~^ ERROR unresolved item provided when a constant was expected
     let _: [u8; faz::<'a>(&())]; //~ ERROR a non-static lifetime
+                                 //~^ ERROR cannot specify lifetime arguments
     let _: [u8; baz::<'a>(&())]; //~ ERROR a non-static lifetime
     let _: [u8; faz::<'b>(&())]; //~ ERROR a non-static lifetime
+                                 //~^ ERROR cannot specify lifetime arguments
     let _: [u8; baz::<'b>(&())]; //~ ERROR a non-static lifetime
 
-    // NOTE: This can be a future compat warning instead of an error,
-    // so we stop compilation before emitting this error in this test.
-    let _ = [0; foo::<T>()];
-
+    let _ = [0; foo::<T>()]; //~ ERROR constant expression depends on a generic parameter
     let _ = [0; bar::<N>()]; //~ ERROR generic parameters may not
+                             //~^ ERROR unresolved item provided when a constant was expected
     let _ = [0; faz::<'a>(&())]; //~ ERROR a non-static lifetime
+                                 //~^ ERROR cannot specify lifetime arguments
     let _ = [0; baz::<'a>(&())]; //~ ERROR a non-static lifetime
     let _ = [0; faz::<'b>(&())]; //~ ERROR a non-static lifetime
+                                 //~^ ERROR cannot specify lifetime arguments
     let _ = [0; baz::<'b>(&())]; //~ ERROR a non-static lifetime
     let _: Foo<{ foo::<T>() }>; //~ ERROR generic parameters may not
     let _: Foo<{ bar::<N>() }>; //~ ERROR generic parameters may not
+                                //~^ ERROR unresolved item provided when a constant was expected
     let _: Foo<{ faz::<'a>(&()) }>; //~ ERROR a non-static lifetime
+                                    //~^ ERROR cannot specify lifetime arguments
     let _: Foo<{ baz::<'a>(&()) }>; //~ ERROR a non-static lifetime
     let _: Foo<{ faz::<'b>(&()) }>; //~ ERROR a non-static lifetime
+                                    //~^ ERROR cannot specify lifetime arguments
     let _: Foo<{ baz::<'b>(&()) }>; //~ ERROR a non-static lifetime
     let _ = Foo::<{ foo::<T>() }>; //~ ERROR generic parameters may not
     let _ = Foo::<{ bar::<N>() }>; //~ ERROR generic parameters may not
+                                   //~^ ERROR unresolved item provided when a constant was expected
     let _ = Foo::<{ faz::<'a>(&()) }>; //~ ERROR a non-static lifetime
+                                       //~^ ERROR cannot specify lifetime arguments
     let _ = Foo::<{ baz::<'a>(&()) }>; //~ ERROR a non-static lifetime
     let _ = Foo::<{ faz::<'b>(&()) }>; //~ ERROR a non-static lifetime
+                                       //~^ ERROR cannot specify lifetime arguments
     let _ = Foo::<{ baz::<'b>(&()) }>; //~ ERROR a non-static lifetime
 }
 

--- a/src/test/ui/const-generics/issues/issue-56445-1.min.stderr
+++ b/src/test/ui/const-generics/issues/issue-56445-1.min.stderr
@@ -6,6 +6,15 @@ LL | struct Bug<'a, const S: &'a str>(PhantomData<&'a ()>);
    |
    = note: for more information, see issue #74052 <https://github.com/rust-lang/rust/issues/74052>
 
-error: aborting due to previous error
+error: `&'static str` is forbidden as the type of a const generic parameter
+  --> $DIR/issue-56445-1.rs:9:25
+   |
+LL | struct Bug<'a, const S: &'a str>(PhantomData<&'a ()>);
+   |                         ^^^^^^^
+   |
+   = note: the only supported types are integers, `bool` and `char`
+   = help: more complex types are supported with `#![feature(adt_const_params)]`
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0771`.

--- a/src/test/ui/const-generics/issues/issue-56445-1.rs
+++ b/src/test/ui/const-generics/issues/issue-56445-1.rs
@@ -8,5 +8,6 @@ use std::marker::PhantomData;
 
 struct Bug<'a, const S: &'a str>(PhantomData<&'a ()>);
 //~^ ERROR: use of non-static lifetime `'a` in const generic
+//[min]~| ERROR: `&'static str` is forbidden as the type of a const generic parameter
 
 impl Bug<'_, ""> {}

--- a/src/test/ui/error-codes/E0106.stderr
+++ b/src/test/ui/error-codes/E0106.stderr
@@ -24,6 +24,17 @@ LL ~     B(&'a bool),
    |
 
 error[E0106]: missing lifetime specifier
+  --> $DIR/E0106.rs:10:14
+   |
+LL | type MyStr = &str;
+   |              ^ expected named lifetime parameter
+   |
+help: consider introducing a named lifetime parameter
+   |
+LL | type MyStr<'a> = &'a str;
+   |           ++++    ++
+
+error[E0106]: missing lifetime specifier
   --> $DIR/E0106.rs:17:10
    |
 LL |     baz: Baz,
@@ -49,17 +60,6 @@ LL |
 LL |
 LL ~     buzz: Buzz<'a, 'a>,
    |
-
-error[E0106]: missing lifetime specifier
-  --> $DIR/E0106.rs:10:14
-   |
-LL | type MyStr = &str;
-   |              ^ expected named lifetime parameter
-   |
-help: consider introducing a named lifetime parameter
-   |
-LL | type MyStr<'a> = &'a str;
-   |           ++++    ++
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/error-codes/E0637.rs
+++ b/src/test/ui/error-codes/E0637.rs
@@ -3,8 +3,10 @@ fn underscore_lifetime<'_>(str1: &'_ str, str2: &'_ str) -> &'_ str {
     //~| ERROR: missing lifetime specifier
     if str1.len() > str2.len() {
         str1
+        //~^ ERROR: [E0312]
     } else {
         str2
+        //~^ ERROR: [E0312]
     }
 }
 

--- a/src/test/ui/error-codes/E0637.stderr
+++ b/src/test/ui/error-codes/E0637.stderr
@@ -4,12 +4,6 @@ error[E0637]: `'_` cannot be used here
 LL | fn underscore_lifetime<'_>(str1: &'_ str, str2: &'_ str) -> &'_ str {
    |                        ^^ `'_` is a reserved lifetime name
 
-error[E0637]: `&` without an explicit lifetime name cannot be used here
-  --> $DIR/E0637.rs:13:13
-   |
-LL |     T: Into<&u32>,
-   |             ^ explicit lifetime name needed here
-
 error[E0106]: missing lifetime specifier
   --> $DIR/E0637.rs:1:62
    |
@@ -19,10 +13,42 @@ LL | fn underscore_lifetime<'_>(str1: &'_ str, str2: &'_ str) -> &'_ str {
    = help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from `str1` or `str2`
 help: consider introducing a named lifetime parameter
    |
-LL | fn underscore_lifetime<'a, '_>(str1: &'a str, str2: &'a str) -> &'a str {
-   |                        +++            ~~             ~~          ~~
+LL | fn underscore_lifetime<'a, '_>(str1: &'_ str, str2: &'_ str) -> &'a str {
+   |                        +++                                       ~~
 
-error: aborting due to 3 previous errors
+error[E0637]: `&` without an explicit lifetime name cannot be used here
+  --> $DIR/E0637.rs:15:13
+   |
+LL |     T: Into<&u32>,
+   |             ^ explicit lifetime name needed here
 
-Some errors have detailed explanations: E0106, E0637.
+error[E0312]: lifetime of reference outlives lifetime of borrowed content...
+  --> $DIR/E0637.rs:5:9
+   |
+LL |         str1
+   |         ^^^^
+   |
+   = note: ...the reference is valid for the static lifetime...
+note: ...but the borrowed content is only valid for the anonymous lifetime defined here
+  --> $DIR/E0637.rs:1:34
+   |
+LL | fn underscore_lifetime<'_>(str1: &'_ str, str2: &'_ str) -> &'_ str {
+   |                                  ^^^^^^^
+
+error[E0312]: lifetime of reference outlives lifetime of borrowed content...
+  --> $DIR/E0637.rs:8:9
+   |
+LL |         str2
+   |         ^^^^
+   |
+   = note: ...the reference is valid for the static lifetime...
+note: ...but the borrowed content is only valid for the anonymous lifetime defined here
+  --> $DIR/E0637.rs:1:49
+   |
+LL | fn underscore_lifetime<'_>(str1: &'_ str, str2: &'_ str) -> &'_ str {
+   |                                                 ^^^^^^^
+
+error: aborting due to 5 previous errors
+
+Some errors have detailed explanations: E0106, E0312, E0637.
 For more information about an error, try `rustc --explain E0106`.

--- a/src/test/ui/error-codes/E0771.stderr
+++ b/src/test/ui/error-codes/E0771.stderr
@@ -1,3 +1,11 @@
+error[E0771]: use of non-static lifetime `'a` in const generic
+  --> $DIR/E0771.rs:4:41
+   |
+LL | fn function_with_str<'a, const STRING: &'a str>() {}
+   |                                         ^^
+   |
+   = note: for more information, see issue #74052 <https://github.com/rust-lang/rust/issues/74052>
+
 warning: the feature `adt_const_params` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/E0771.rs:1:12
    |
@@ -6,14 +14,6 @@ LL | #![feature(adt_const_params)]
    |
    = note: `#[warn(incomplete_features)]` on by default
    = note: see issue #95174 <https://github.com/rust-lang/rust/issues/95174> for more information
-
-error[E0771]: use of non-static lifetime `'a` in const generic
-  --> $DIR/E0771.rs:4:41
-   |
-LL | fn function_with_str<'a, const STRING: &'a str>() {}
-   |                                         ^^
-   |
-   = note: for more information, see issue #74052 <https://github.com/rust-lang/rust/issues/74052>
 
 error: aborting due to previous error; 1 warning emitted
 

--- a/src/test/ui/foreign-fn-return-lifetime.stderr
+++ b/src/test/ui/foreign-fn-return-lifetime.stderr
@@ -8,7 +8,7 @@ LL |     pub fn f() -> &u8;
 help: consider using the `'static` lifetime
    |
 LL |     pub fn f() -> &'static u8;
-   |                   ~~~~~~~~
+   |                    +++++++
 
 error: aborting due to previous error
 

--- a/src/test/ui/generic-associated-types/gat-trait-path-generic-type-arg.rs
+++ b/src/test/ui/generic-associated-types/gat-trait-path-generic-type-arg.rs
@@ -7,6 +7,7 @@ trait Foo {
 }
 
 impl <T, T1> Foo for T {
+    //~^ ERROR: the type parameter `T1` is not constrained
     type F<T1> = &[u8];
       //~^ ERROR: the name `T1` is already used for
       //~| ERROR: missing lifetime specifier

--- a/src/test/ui/generic-associated-types/gat-trait-path-generic-type-arg.stderr
+++ b/src/test/ui/generic-associated-types/gat-trait-path-generic-type-arg.stderr
@@ -1,13 +1,14 @@
 error[E0403]: the name `T1` is already used for a generic parameter in this item's generic parameters
-  --> $DIR/gat-trait-path-generic-type-arg.rs:10:12
+  --> $DIR/gat-trait-path-generic-type-arg.rs:11:12
    |
 LL | impl <T, T1> Foo for T {
    |          -- first use of `T1`
+LL |
 LL |     type F<T1> = &[u8];
    |            ^^ already used
 
 error[E0106]: missing lifetime specifier
-  --> $DIR/gat-trait-path-generic-type-arg.rs:10:18
+  --> $DIR/gat-trait-path-generic-type-arg.rs:11:18
    |
 LL |     type F<T1> = &[u8];
    |                  ^ expected named lifetime parameter
@@ -17,7 +18,13 @@ help: consider introducing a named lifetime parameter
 LL |     type F<'a, T1> = &'a [u8];
    |            +++        ++
 
-error: aborting due to 2 previous errors
+error[E0207]: the type parameter `T1` is not constrained by the impl trait, self type, or predicates
+  --> $DIR/gat-trait-path-generic-type-arg.rs:9:10
+   |
+LL | impl <T, T1> Foo for T {
+   |          ^^ unconstrained type parameter
 
-Some errors have detailed explanations: E0106, E0403.
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0106, E0207, E0403.
 For more information about an error, try `rustc --explain E0106`.

--- a/src/test/ui/generic-associated-types/issue-70304.rs
+++ b/src/test/ui/generic-associated-types/issue-70304.rs
@@ -2,6 +2,7 @@
 
 trait Document {
     type Cursor<'a>: DocCursor<'a>;
+    //~^ ERROR: missing required bound on `Cursor`
 
     fn cursor(&self) -> Self::Cursor<'_>;
 }
@@ -45,8 +46,7 @@ where
 }
 
 fn create_doc() -> impl Document<Cursor<'_> = DocCursorImpl<'_>> {
-    //~^ ERROR: missing lifetime specifier
-    //~| ERROR: missing lifetime specifier
+    //~^ ERROR: missing lifetime specifiers
     DocumentImpl {}
 }
 

--- a/src/test/ui/generic-associated-types/issue-70304.stderr
+++ b/src/test/ui/generic-associated-types/issue-70304.stderr
@@ -1,26 +1,27 @@
-error[E0106]: missing lifetime specifier
-  --> $DIR/issue-70304.rs:47:41
+error[E0106]: missing lifetime specifiers
+  --> $DIR/issue-70304.rs:48:41
    |
 LL | fn create_doc() -> impl Document<Cursor<'_> = DocCursorImpl<'_>> {
-   |                                         ^^ expected named lifetime parameter
+   |                                         ^^                  ^^ expected named lifetime parameter
+   |                                         |
+   |                                         expected named lifetime parameter
    |
    = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
 help: consider using the `'static` lifetime
    |
-LL | fn create_doc() -> impl Document<Cursor<'static> = DocCursorImpl<'_>> {
-   |                                         ~~~~~~~
+LL | fn create_doc() -> impl Document<Cursor<'static> = DocCursorImpl<'static>> {
+   |                                         ~~~~~~~                  ~~~~~~~
 
-error[E0106]: missing lifetime specifier
-  --> $DIR/issue-70304.rs:47:61
+error: missing required bound on `Cursor`
+  --> $DIR/issue-70304.rs:4:5
    |
-LL | fn create_doc() -> impl Document<Cursor<'_> = DocCursorImpl<'_>> {
-   |                                                             ^^ expected named lifetime parameter
+LL |     type Cursor<'a>: DocCursor<'a>;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
+   |                                   |
+   |                                   help: add the required where clause: `where Self: 'a`
    |
-   = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
-help: consider using the `'static` lifetime
-   |
-LL | fn create_doc() -> impl Document<Cursor<'_> = DocCursorImpl<'static>> {
-   |                                                             ~~~~~~~
+   = note: this bound is currently required to ensure that impls have maximum flexibility
+   = note: we are soliciting feedback, see issue #87479 <https://github.com/rust-lang/rust/issues/87479> for more information
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/generic-associated-types/issue-95305.rs
+++ b/src/test/ui/generic-associated-types/issue-95305.rs
@@ -8,10 +8,10 @@ trait Foo {
     type Item<'a>;
 }
 
-fn foo(x: &impl Foo<Item<'_> = u32>) { }
-                       //~^ ERROR missing lifetime specifier
+fn foo(x: &impl Foo<Item<'_> = u32>) {}
+//~^ ERROR `'_` cannot be used here [E0637]
 
-fn bar(x: &impl for<'a> Foo<Item<'a> = &'_ u32>) { }
-                                      //~^ ERROR missing lifetime specifier
+fn bar(x: &impl for<'a> Foo<Item<'a> = &'_ u32>) {}
+//~^ ERROR `'_` cannot be used here [E0637]
 
 fn main() {}

--- a/src/test/ui/generic-associated-types/issue-95305.stderr
+++ b/src/test/ui/generic-associated-types/issue-95305.stderr
@@ -1,25 +1,15 @@
-error[E0106]: missing lifetime specifier
+error[E0637]: `'_` cannot be used here
   --> $DIR/issue-95305.rs:11:26
    |
-LL | fn foo(x: &impl Foo<Item<'_> = u32>) { }
-   |                          ^^ expected named lifetime parameter
-   |
-help: consider introducing a named lifetime parameter
-   |
-LL | fn foo<'a>(x: &impl Foo<Item<'a> = u32>) { }
-   |       ++++                   ~~
+LL | fn foo(x: &impl Foo<Item<'_> = u32>) {}
+   |                          ^^ `'_` is a reserved lifetime name
 
-error[E0106]: missing lifetime specifier
+error[E0637]: `'_` cannot be used here
   --> $DIR/issue-95305.rs:14:41
    |
-LL | fn bar(x: &impl for<'a> Foo<Item<'a> = &'_ u32>) { }
-   |                                         ^^ expected named lifetime parameter
-   |
-help: consider using the `'a` lifetime
-   |
-LL | fn bar(x: &impl for<'a> Foo<Item<'a> = &'a u32>) { }
-   |                                         ~~
+LL | fn bar(x: &impl for<'a> Foo<Item<'a> = &'_ u32>) {}
+   |                                         ^^ `'_` is a reserved lifetime name
 
 error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0106`.
+For more information about this error, try `rustc --explain E0637`.

--- a/src/test/ui/generics/issue-65285-incorrect-explicit-lifetime-name-needed.rs
+++ b/src/test/ui/generics/issue-65285-incorrect-explicit-lifetime-name-needed.rs
@@ -8,7 +8,9 @@ fn should_error<T>() where T : Into<&u32> {}
 trait X<'a, K: 'a> {
     fn foo<'b, L: X<&'b Nested<K>>>();
     //~^ ERROR missing lifetime specifier [E0106]
+    //~| ERROR the type `&'b Nested<K>` does not fulfill the required lifetime
 }
 
 fn bar<'b, L: X<&'b Nested<i32>>>(){}
 //~^ ERROR missing lifetime specifier [E0106]
+//~| ERROR the type `&'b Nested<i32>` does not fulfill the required lifetime

--- a/src/test/ui/generics/issue-65285-incorrect-explicit-lifetime-name-needed.stderr
+++ b/src/test/ui/generics/issue-65285-incorrect-explicit-lifetime-name-needed.stderr
@@ -5,21 +5,10 @@ LL | fn should_error<T>() where T : Into<&u32> {}
    |                                     ^ explicit lifetime name needed here
 
 error[E0106]: missing lifetime specifier
-  --> $DIR/issue-65285-incorrect-explicit-lifetime-name-needed.rs:13:17
-   |
-LL | fn bar<'b, L: X<&'b Nested<i32>>>(){}
-   |                 ^ expected named lifetime parameter
-   |
-help: consider using the `'b` lifetime
-   |
-LL | fn bar<'b, L: X<'b, &'b Nested<i32>>>(){}
-   |                 +++
-
-error[E0106]: missing lifetime specifier
-  --> $DIR/issue-65285-incorrect-explicit-lifetime-name-needed.rs:9:21
+  --> $DIR/issue-65285-incorrect-explicit-lifetime-name-needed.rs:9:20
    |
 LL |     fn foo<'b, L: X<&'b Nested<K>>>();
-   |                     ^ expected named lifetime parameter
+   |                    ^ expected named lifetime parameter
    |
 note: these named lifetimes are available to use
   --> $DIR/issue-65285-incorrect-explicit-lifetime-name-needed.rs:8:9
@@ -33,7 +22,42 @@ help: consider using one of the available lifetimes here
 LL |     fn foo<'b, L: X<'lifetime, &'b Nested<K>>>();
    |                     ++++++++++
 
-error: aborting due to 3 previous errors
+error[E0106]: missing lifetime specifier
+  --> $DIR/issue-65285-incorrect-explicit-lifetime-name-needed.rs:14:16
+   |
+LL | fn bar<'b, L: X<&'b Nested<i32>>>(){}
+   |                ^ expected named lifetime parameter
+   |
+help: consider using the `'b` lifetime
+   |
+LL | fn bar<'b, L: X<'b, &'b Nested<i32>>>(){}
+   |                 +++
 
-Some errors have detailed explanations: E0106, E0637.
+error[E0477]: the type `&'b Nested<K>` does not fulfill the required lifetime
+  --> $DIR/issue-65285-incorrect-explicit-lifetime-name-needed.rs:9:19
+   |
+LL |     fn foo<'b, L: X<&'b Nested<K>>>();
+   |                   ^^^^^^^^^^^^^^^^
+   |
+note: type must satisfy the static lifetime as required by this binding
+  --> $DIR/issue-65285-incorrect-explicit-lifetime-name-needed.rs:8:16
+   |
+LL | trait X<'a, K: 'a> {
+   |                ^^
+
+error[E0477]: the type `&'b Nested<i32>` does not fulfill the required lifetime
+  --> $DIR/issue-65285-incorrect-explicit-lifetime-name-needed.rs:14:15
+   |
+LL | fn bar<'b, L: X<&'b Nested<i32>>>(){}
+   |               ^^^^^^^^^^^^^^^^^^
+   |
+note: type must satisfy the static lifetime as required by this binding
+  --> $DIR/issue-65285-incorrect-explicit-lifetime-name-needed.rs:8:16
+   |
+LL | trait X<'a, K: 'a> {
+   |                ^^
+
+error: aborting due to 5 previous errors
+
+Some errors have detailed explanations: E0106, E0477, E0637.
 For more information about an error, try `rustc --explain E0106`.

--- a/src/test/ui/generics/wrong-number-of-args.rs
+++ b/src/test/ui/generics/wrong-number-of-args.rs
@@ -120,6 +120,7 @@ mod r#trait {
     type B = Box<dyn GenericLifetime>;
     //~^ ERROR missing lifetime specifier
     //~| HELP consider introducing
+    //~| HELP consider making the bound lifetime-generic
 
     type C = Box<dyn GenericLifetime<'static, 'static>>;
     //~^ ERROR this trait takes 1 lifetime argument but 2 lifetime arguments were supplied
@@ -136,6 +137,7 @@ mod r#trait {
     type F = Box<dyn GenericLifetime<>>;
     //~^ ERROR missing lifetime specifier
     //~| HELP consider introducing
+    //~| HELP consider making the bound lifetime-generic
 
     type G = Box<dyn GenericType<>>;
     //~^ ERROR this trait takes 1 generic argument but 0 generic arguments
@@ -161,6 +163,7 @@ mod associated_item {
         type A = Box<dyn GenericLifetimeAT<AssocTy=()>>;
         //~^ ERROR missing lifetime specifier
         //~| HELP consider introducing
+        //~| HELP consider making the bound lifetime-generic
 
         type B = Box<dyn GenericLifetimeAT<'static, 'static, AssocTy=()>>;
         //~^ ERROR this trait takes 1 lifetime argument but 2 lifetime arguments were supplied
@@ -169,6 +172,7 @@ mod associated_item {
         type C = Box<dyn GenericLifetimeAT<(), AssocTy=()>>;
         //~^ ERROR missing lifetime specifier
         //~| HELP consider introducing
+        //~| HELP consider making the bound lifetime-generic
         //~| ERROR this trait takes 0 generic arguments but 1 generic argument
         //~| HELP remove
     }
@@ -203,6 +207,7 @@ mod associated_item {
         //~| HELP add missing
         //~| ERROR missing lifetime specifier
         //~| HELP consider introducing
+        //~| HELP consider making the bound lifetime-generic
 
         type B = Box<dyn GenericLifetimeTypeAT<'static, AssocTy=()>>;
         //~^ ERROR this trait takes 1 generic argument but 0 generic arguments were supplied
@@ -217,10 +222,12 @@ mod associated_item {
         type D = Box<dyn GenericLifetimeTypeAT<(), AssocTy=()>>;
         //~^ ERROR missing lifetime specifier
         //~| HELP consider introducing
+        //~| HELP consider making the bound lifetime-generic
 
         type E = Box<dyn GenericLifetimeTypeAT<(), (), AssocTy=()>>;
         //~^ ERROR missing lifetime specifier
         //~| HELP consider introducing
+        //~| HELP consider making the bound lifetime-generic
         //~| ERROR this trait takes 1 generic argument but 2 generic arguments
         //~| HELP remove
 
@@ -265,6 +272,7 @@ mod associated_item {
         type A = Box<dyn GenericLifetimeLifetimeAT<AssocTy=()>>;
         //~^ ERROR missing lifetime specifier
         //~| HELP consider introducing
+        //~| HELP consider making the bound lifetime-generic
 
         type B = Box<dyn GenericLifetimeLifetimeAT<'static, AssocTy=()>>;
         //~^ ERROR this trait takes 2 lifetime arguments but 1 lifetime argument was supplied
@@ -279,6 +287,7 @@ mod associated_item {
         type A = Box<dyn GenericLifetimeLifetimeTypeAT<AssocTy=()>>;
         //~^ ERROR missing lifetime specifier
         //~| HELP consider introducing
+        //~| HELP consider making the bound lifetime-generic
         //~| ERROR this trait takes 1 generic argument but 0 generic arguments
         //~| HELP add missing
 

--- a/src/test/ui/generics/wrong-number-of-args.stderr
+++ b/src/test/ui/generics/wrong-number-of-args.stderr
@@ -1,3 +1,172 @@
+error[E0106]: missing lifetime specifier
+  --> $DIR/wrong-number-of-args.rs:48:14
+   |
+LL |     type A = Ty;
+   |              ^^ expected named lifetime parameter
+   |
+help: consider introducing a named lifetime parameter
+   |
+LL |     type A<'a> = Ty<'a>;
+   |           ++++     ++++
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/wrong-number-of-args.rs:58:16
+   |
+LL |     type C = Ty<usize>;
+   |                ^ expected named lifetime parameter
+   |
+help: consider introducing a named lifetime parameter
+   |
+LL |     type C<'a> = Ty<'a, usize>;
+   |           ++++      +++
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/wrong-number-of-args.rs:64:16
+   |
+LL |     type E = Ty<>;
+   |                ^ expected named lifetime parameter
+   |
+help: consider introducing a named lifetime parameter
+   |
+LL |     type E<'a> = Ty<'a, >;
+   |           ++++      +++
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/wrong-number-of-args.rs:120:22
+   |
+LL |     type B = Box<dyn GenericLifetime>;
+   |                      ^^^^^^^^^^^^^^^ expected named lifetime parameter
+   |
+   = note: for more information on higher-ranked polymorphism, visit https://doc.rust-lang.org/nomicon/hrtb.html
+help: consider making the bound lifetime-generic with a new `'a` lifetime
+   |
+LL |     type B = Box<dyn for<'a> GenericLifetime<'a>>;
+   |                      +++++++                ++++
+help: consider introducing a named lifetime parameter
+   |
+LL |     type B<'a> = Box<dyn GenericLifetime<'a>>;
+   |           ++++                          ++++
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/wrong-number-of-args.rs:137:37
+   |
+LL |     type F = Box<dyn GenericLifetime<>>;
+   |                                     ^ expected named lifetime parameter
+   |
+help: consider making the bound lifetime-generic with a new `'a` lifetime
+   |
+LL |     type F = Box<dyn for<'a> GenericLifetime<'a, >>;
+   |                      +++++++                 +++
+help: consider introducing a named lifetime parameter
+   |
+LL |     type F<'a> = Box<dyn GenericLifetime<'a, >>;
+   |           ++++                           +++
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/wrong-number-of-args.rs:163:43
+   |
+LL |         type A = Box<dyn GenericLifetimeAT<AssocTy=()>>;
+   |                                           ^ expected named lifetime parameter
+   |
+help: consider making the bound lifetime-generic with a new `'a` lifetime
+   |
+LL |         type A = Box<dyn for<'a> GenericLifetimeAT<'a, AssocTy=()>>;
+   |                          +++++++                   +++
+help: consider introducing a named lifetime parameter
+   |
+LL |         type A<'a> = Box<dyn GenericLifetimeAT<'a, AssocTy=()>>;
+   |               ++++                             +++
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/wrong-number-of-args.rs:172:43
+   |
+LL |         type C = Box<dyn GenericLifetimeAT<(), AssocTy=()>>;
+   |                                           ^ expected named lifetime parameter
+   |
+help: consider making the bound lifetime-generic with a new `'a` lifetime
+   |
+LL |         type C = Box<dyn for<'a> GenericLifetimeAT<'a, (), AssocTy=()>>;
+   |                          +++++++                   +++
+help: consider introducing a named lifetime parameter
+   |
+LL |         type C<'a> = Box<dyn GenericLifetimeAT<'a, (), AssocTy=()>>;
+   |               ++++                             +++
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/wrong-number-of-args.rs:205:47
+   |
+LL |         type A = Box<dyn GenericLifetimeTypeAT<AssocTy=()>>;
+   |                                               ^ expected named lifetime parameter
+   |
+help: consider making the bound lifetime-generic with a new `'a` lifetime
+   |
+LL |         type A = Box<dyn for<'a> GenericLifetimeTypeAT<'a, AssocTy=()>>;
+   |                          +++++++                       +++
+help: consider introducing a named lifetime parameter
+   |
+LL |         type A<'a> = Box<dyn GenericLifetimeTypeAT<'a, AssocTy=()>>;
+   |               ++++                                 +++
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/wrong-number-of-args.rs:222:47
+   |
+LL |         type D = Box<dyn GenericLifetimeTypeAT<(), AssocTy=()>>;
+   |                                               ^ expected named lifetime parameter
+   |
+help: consider making the bound lifetime-generic with a new `'a` lifetime
+   |
+LL |         type D = Box<dyn for<'a> GenericLifetimeTypeAT<'a, (), AssocTy=()>>;
+   |                          +++++++                       +++
+help: consider introducing a named lifetime parameter
+   |
+LL |         type D<'a> = Box<dyn GenericLifetimeTypeAT<'a, (), AssocTy=()>>;
+   |               ++++                                 +++
+
+error[E0106]: missing lifetime specifier
+  --> $DIR/wrong-number-of-args.rs:227:47
+   |
+LL |         type E = Box<dyn GenericLifetimeTypeAT<(), (), AssocTy=()>>;
+   |                                               ^ expected named lifetime parameter
+   |
+help: consider making the bound lifetime-generic with a new `'a` lifetime
+   |
+LL |         type E = Box<dyn for<'a> GenericLifetimeTypeAT<'a, (), (), AssocTy=()>>;
+   |                          +++++++                       +++
+help: consider introducing a named lifetime parameter
+   |
+LL |         type E<'a> = Box<dyn GenericLifetimeTypeAT<'a, (), (), AssocTy=()>>;
+   |               ++++                                 +++
+
+error[E0106]: missing lifetime specifiers
+  --> $DIR/wrong-number-of-args.rs:272:51
+   |
+LL |         type A = Box<dyn GenericLifetimeLifetimeAT<AssocTy=()>>;
+   |                                                   ^ expected 2 lifetime parameters
+   |
+help: consider making the bound lifetime-generic with a new `'a` lifetime
+   |
+LL |         type A = Box<dyn for<'a> GenericLifetimeLifetimeAT<'a, 'a, AssocTy=()>>;
+   |                          +++++++                           +++++++
+help: consider introducing a named lifetime parameter
+   |
+LL |         type A<'a> = Box<dyn GenericLifetimeLifetimeAT<'a, 'a, AssocTy=()>>;
+   |               ++++                                     +++++++
+
+error[E0106]: missing lifetime specifiers
+  --> $DIR/wrong-number-of-args.rs:287:55
+   |
+LL |         type A = Box<dyn GenericLifetimeLifetimeTypeAT<AssocTy=()>>;
+   |                                                       ^ expected 2 lifetime parameters
+   |
+help: consider making the bound lifetime-generic with a new `'a` lifetime
+   |
+LL |         type A = Box<dyn for<'a> GenericLifetimeLifetimeTypeAT<'a, 'a, AssocTy=()>>;
+   |                          +++++++                               +++++++
+help: consider introducing a named lifetime parameter
+   |
+LL |         type A<'a> = Box<dyn GenericLifetimeLifetimeTypeAT<'a, 'a, AssocTy=()>>;
+   |               ++++                                         +++++++
+
 error[E0107]: this struct takes 0 lifetime arguments but 1 lifetime argument was supplied
   --> $DIR/wrong-number-of-args.rs:6:14
    |
@@ -148,17 +317,6 @@ help: add missing generic argument
 LL |     type A = Ty<T>;
    |              ~~~~~
 
-error[E0106]: missing lifetime specifier
-  --> $DIR/wrong-number-of-args.rs:48:14
-   |
-LL |     type A = Ty;
-   |              ^^ expected named lifetime parameter
-   |
-help: consider introducing a named lifetime parameter
-   |
-LL |     type A<'a> = Ty<'a>;
-   |           ++++   ~~~~~~
-
 error[E0107]: this struct takes 1 generic argument but 0 generic arguments were supplied
   --> $DIR/wrong-number-of-args.rs:54:14
    |
@@ -175,17 +333,6 @@ help: add missing generic argument
 LL |     type B = Ty<'static, T>;
    |                        +++
 
-error[E0106]: missing lifetime specifier
-  --> $DIR/wrong-number-of-args.rs:58:17
-   |
-LL |     type C = Ty<usize>;
-   |                 ^ expected named lifetime parameter
-   |
-help: consider introducing a named lifetime parameter
-   |
-LL |     type C<'a> = Ty<'a, usize>;
-   |           ++++      +++
-
 error[E0107]: this struct takes 1 generic argument but 0 generic arguments were supplied
   --> $DIR/wrong-number-of-args.rs:64:14
    |
@@ -201,17 +348,6 @@ help: add missing generic argument
    |
 LL |     type E = Ty<T>;
    |                 +
-
-error[E0106]: missing lifetime specifier
-  --> $DIR/wrong-number-of-args.rs:64:16
-   |
-LL |     type E = Ty<>;
-   |                ^- expected named lifetime parameter
-   |
-help: consider introducing a named lifetime parameter
-   |
-LL |     type E<'a> = Ty<'a>;
-   |           ++++      ++
 
 error[E0107]: this struct takes 1 lifetime argument but 2 lifetime arguments were supplied
   --> $DIR/wrong-number-of-args.rs:70:14
@@ -319,19 +455,8 @@ note: trait defined here, with 0 generic parameters
 LL |     trait NonGeneric {
    |           ^^^^^^^^^^
 
-error[E0106]: missing lifetime specifier
-  --> $DIR/wrong-number-of-args.rs:120:22
-   |
-LL |     type B = Box<dyn GenericLifetime>;
-   |                      ^^^^^^^^^^^^^^^ expected named lifetime parameter
-   |
-help: consider introducing a named lifetime parameter
-   |
-LL |     type B<'a> = Box<dyn GenericLifetime<'a>>;
-   |           ++++           ~~~~~~~~~~~~~~~~~~~
-
 error[E0107]: this trait takes 1 lifetime argument but 2 lifetime arguments were supplied
-  --> $DIR/wrong-number-of-args.rs:124:22
+  --> $DIR/wrong-number-of-args.rs:125:22
    |
 LL |     type C = Box<dyn GenericLifetime<'static, 'static>>;
    |                      ^^^^^^^^^^^^^^^          ------- help: remove this lifetime argument
@@ -345,7 +470,7 @@ LL |     trait GenericLifetime<'a> {
    |           ^^^^^^^^^^^^^^^ --
 
 error[E0107]: missing generics for trait `GenericType`
-  --> $DIR/wrong-number-of-args.rs:128:22
+  --> $DIR/wrong-number-of-args.rs:129:22
    |
 LL |     type D = Box<dyn GenericType>;
    |                      ^^^^^^^^^^^ expected 1 generic argument
@@ -361,7 +486,7 @@ LL |     type D = Box<dyn GenericType<A>>;
    |                      ~~~~~~~~~~~~~~
 
 error[E0107]: this trait takes 1 generic argument but 2 generic arguments were supplied
-  --> $DIR/wrong-number-of-args.rs:132:22
+  --> $DIR/wrong-number-of-args.rs:133:22
    |
 LL |     type E = Box<dyn GenericType<String, usize>>;
    |                      ^^^^^^^^^^^         ----- help: remove this generic argument
@@ -374,19 +499,8 @@ note: trait defined here, with 1 generic parameter: `A`
 LL |     trait GenericType<A> {
    |           ^^^^^^^^^^^ -
 
-error[E0106]: missing lifetime specifier
-  --> $DIR/wrong-number-of-args.rs:136:37
-   |
-LL |     type F = Box<dyn GenericLifetime<>>;
-   |                                     ^- expected named lifetime parameter
-   |
-help: consider introducing a named lifetime parameter
-   |
-LL |     type F<'a> = Box<dyn GenericLifetime<'a>>;
-   |           ++++                           ++
-
 error[E0107]: this trait takes 1 generic argument but 0 generic arguments were supplied
-  --> $DIR/wrong-number-of-args.rs:140:22
+  --> $DIR/wrong-number-of-args.rs:142:22
    |
 LL |     type G = Box<dyn GenericType<>>;
    |                      ^^^^^^^^^^^ expected 1 generic argument
@@ -402,7 +516,7 @@ LL |     type G = Box<dyn GenericType<A>>;
    |                                  +
 
 error[E0107]: this trait takes 0 generic arguments but 1 generic argument was supplied
-  --> $DIR/wrong-number-of-args.rs:151:26
+  --> $DIR/wrong-number-of-args.rs:153:26
    |
 LL |         type A = Box<dyn NonGenericAT<usize, AssocTy=()>>;
    |                          ^^^^^^^^^^^^------------------- help: remove these generics
@@ -410,24 +524,13 @@ LL |         type A = Box<dyn NonGenericAT<usize, AssocTy=()>>;
    |                          expected 0 generic arguments
    |
 note: trait defined here, with 0 generic parameters
-  --> $DIR/wrong-number-of-args.rs:147:15
+  --> $DIR/wrong-number-of-args.rs:149:15
    |
 LL |         trait NonGenericAT {
    |               ^^^^^^^^^^^^
 
-error[E0106]: missing lifetime specifier
-  --> $DIR/wrong-number-of-args.rs:161:44
-   |
-LL |         type A = Box<dyn GenericLifetimeAT<AssocTy=()>>;
-   |                                            ^ expected named lifetime parameter
-   |
-help: consider introducing a named lifetime parameter
-   |
-LL |         type A<'a> = Box<dyn GenericLifetimeAT<'a, AssocTy=()>>;
-   |               ++++                             +++
-
 error[E0107]: this trait takes 1 lifetime argument but 2 lifetime arguments were supplied
-  --> $DIR/wrong-number-of-args.rs:165:26
+  --> $DIR/wrong-number-of-args.rs:168:26
    |
 LL |         type B = Box<dyn GenericLifetimeAT<'static, 'static, AssocTy=()>>;
    |                          ^^^^^^^^^^^^^^^^^          ------- help: remove this lifetime argument
@@ -435,13 +538,13 @@ LL |         type B = Box<dyn GenericLifetimeAT<'static, 'static, AssocTy=()>>;
    |                          expected 1 lifetime argument
    |
 note: trait defined here, with 1 lifetime parameter: `'a`
-  --> $DIR/wrong-number-of-args.rs:157:15
+  --> $DIR/wrong-number-of-args.rs:159:15
    |
 LL |         trait GenericLifetimeAT<'a> {
    |               ^^^^^^^^^^^^^^^^^ --
 
 error[E0107]: this trait takes 0 generic arguments but 1 generic argument was supplied
-  --> $DIR/wrong-number-of-args.rs:169:26
+  --> $DIR/wrong-number-of-args.rs:172:26
    |
 LL |         type C = Box<dyn GenericLifetimeAT<(), AssocTy=()>>;
    |                          ^^^^^^^^^^^^^^^^^ -- help: remove this generic argument
@@ -449,30 +552,19 @@ LL |         type C = Box<dyn GenericLifetimeAT<(), AssocTy=()>>;
    |                          expected 0 generic arguments
    |
 note: trait defined here, with 0 generic parameters
-  --> $DIR/wrong-number-of-args.rs:157:15
+  --> $DIR/wrong-number-of-args.rs:159:15
    |
 LL |         trait GenericLifetimeAT<'a> {
    |               ^^^^^^^^^^^^^^^^^
 
-error[E0106]: missing lifetime specifier
-  --> $DIR/wrong-number-of-args.rs:169:44
-   |
-LL |         type C = Box<dyn GenericLifetimeAT<(), AssocTy=()>>;
-   |                                            ^ expected named lifetime parameter
-   |
-help: consider introducing a named lifetime parameter
-   |
-LL |         type C<'a> = Box<dyn GenericLifetimeAT<'a, (), AssocTy=()>>;
-   |               ++++                             +++
-
 error[E0107]: this trait takes 1 generic argument but 0 generic arguments were supplied
-  --> $DIR/wrong-number-of-args.rs:181:26
+  --> $DIR/wrong-number-of-args.rs:185:26
    |
 LL |         type A = Box<dyn GenericTypeAT<AssocTy=()>>;
    |                          ^^^^^^^^^^^^^ expected 1 generic argument
    |
 note: trait defined here, with 1 generic parameter: `A`
-  --> $DIR/wrong-number-of-args.rs:177:15
+  --> $DIR/wrong-number-of-args.rs:181:15
    |
 LL |         trait GenericTypeAT<A> {
    |               ^^^^^^^^^^^^^ -
@@ -482,7 +574,7 @@ LL |         type A = Box<dyn GenericTypeAT<A, AssocTy=()>>;
    |                                        ++
 
 error[E0107]: this trait takes 1 generic argument but 2 generic arguments were supplied
-  --> $DIR/wrong-number-of-args.rs:185:26
+  --> $DIR/wrong-number-of-args.rs:189:26
    |
 LL |         type B = Box<dyn GenericTypeAT<(), (), AssocTy=()>>;
    |                          ^^^^^^^^^^^^^     -- help: remove this generic argument
@@ -490,13 +582,13 @@ LL |         type B = Box<dyn GenericTypeAT<(), (), AssocTy=()>>;
    |                          expected 1 generic argument
    |
 note: trait defined here, with 1 generic parameter: `A`
-  --> $DIR/wrong-number-of-args.rs:177:15
+  --> $DIR/wrong-number-of-args.rs:181:15
    |
 LL |         trait GenericTypeAT<A> {
    |               ^^^^^^^^^^^^^ -
 
 error[E0107]: this trait takes 0 lifetime arguments but 1 lifetime argument was supplied
-  --> $DIR/wrong-number-of-args.rs:189:26
+  --> $DIR/wrong-number-of-args.rs:193:26
    |
 LL |         type C = Box<dyn GenericTypeAT<'static, AssocTy=()>>;
    |                          ^^^^^^^^^^^^^--------------------- help: remove these generics
@@ -504,19 +596,19 @@ LL |         type C = Box<dyn GenericTypeAT<'static, AssocTy=()>>;
    |                          expected 0 lifetime arguments
    |
 note: trait defined here, with 0 lifetime parameters
-  --> $DIR/wrong-number-of-args.rs:177:15
+  --> $DIR/wrong-number-of-args.rs:181:15
    |
 LL |         trait GenericTypeAT<A> {
    |               ^^^^^^^^^^^^^
 
 error[E0107]: this trait takes 1 generic argument but 0 generic arguments were supplied
-  --> $DIR/wrong-number-of-args.rs:189:26
+  --> $DIR/wrong-number-of-args.rs:193:26
    |
 LL |         type C = Box<dyn GenericTypeAT<'static, AssocTy=()>>;
    |                          ^^^^^^^^^^^^^ expected 1 generic argument
    |
 note: trait defined here, with 1 generic parameter: `A`
-  --> $DIR/wrong-number-of-args.rs:177:15
+  --> $DIR/wrong-number-of-args.rs:181:15
    |
 LL |         trait GenericTypeAT<A> {
    |               ^^^^^^^^^^^^^ -
@@ -526,13 +618,13 @@ LL |         type C = Box<dyn GenericTypeAT<'static, A, AssocTy=()>>;
    |                                               +++
 
 error[E0107]: this trait takes 1 generic argument but 0 generic arguments were supplied
-  --> $DIR/wrong-number-of-args.rs:201:26
+  --> $DIR/wrong-number-of-args.rs:205:26
    |
 LL |         type A = Box<dyn GenericLifetimeTypeAT<AssocTy=()>>;
    |                          ^^^^^^^^^^^^^^^^^^^^^ expected 1 generic argument
    |
 note: trait defined here, with 1 generic parameter: `A`
-  --> $DIR/wrong-number-of-args.rs:197:15
+  --> $DIR/wrong-number-of-args.rs:201:15
    |
 LL |         trait GenericLifetimeTypeAT<'a, A> {
    |               ^^^^^^^^^^^^^^^^^^^^^     -
@@ -541,25 +633,14 @@ help: add missing generic argument
 LL |         type A = Box<dyn GenericLifetimeTypeAT<A, AssocTy=()>>;
    |                                                ++
 
-error[E0106]: missing lifetime specifier
-  --> $DIR/wrong-number-of-args.rs:201:48
-   |
-LL |         type A = Box<dyn GenericLifetimeTypeAT<AssocTy=()>>;
-   |                                                ^ expected named lifetime parameter
-   |
-help: consider introducing a named lifetime parameter
-   |
-LL |         type A<'a> = Box<dyn GenericLifetimeTypeAT<'a, AssocTy=()>>;
-   |               ++++                                 +++
-
 error[E0107]: this trait takes 1 generic argument but 0 generic arguments were supplied
-  --> $DIR/wrong-number-of-args.rs:207:26
+  --> $DIR/wrong-number-of-args.rs:212:26
    |
 LL |         type B = Box<dyn GenericLifetimeTypeAT<'static, AssocTy=()>>;
    |                          ^^^^^^^^^^^^^^^^^^^^^ expected 1 generic argument
    |
 note: trait defined here, with 1 generic parameter: `A`
-  --> $DIR/wrong-number-of-args.rs:197:15
+  --> $DIR/wrong-number-of-args.rs:201:15
    |
 LL |         trait GenericLifetimeTypeAT<'a, A> {
    |               ^^^^^^^^^^^^^^^^^^^^^     -
@@ -569,7 +650,7 @@ LL |         type B = Box<dyn GenericLifetimeTypeAT<'static, A, AssocTy=()>>;
    |                                                       +++
 
 error[E0107]: this trait takes 1 lifetime argument but 2 lifetime arguments were supplied
-  --> $DIR/wrong-number-of-args.rs:211:26
+  --> $DIR/wrong-number-of-args.rs:216:26
    |
 LL |         type C = Box<dyn GenericLifetimeTypeAT<'static, 'static, AssocTy=()>>;
    |                          ^^^^^^^^^^^^^^^^^^^^^          ------- help: remove this lifetime argument
@@ -577,19 +658,19 @@ LL |         type C = Box<dyn GenericLifetimeTypeAT<'static, 'static, AssocTy=()
    |                          expected 1 lifetime argument
    |
 note: trait defined here, with 1 lifetime parameter: `'a`
-  --> $DIR/wrong-number-of-args.rs:197:15
+  --> $DIR/wrong-number-of-args.rs:201:15
    |
 LL |         trait GenericLifetimeTypeAT<'a, A> {
    |               ^^^^^^^^^^^^^^^^^^^^^ --
 
 error[E0107]: this trait takes 1 generic argument but 0 generic arguments were supplied
-  --> $DIR/wrong-number-of-args.rs:211:26
+  --> $DIR/wrong-number-of-args.rs:216:26
    |
 LL |         type C = Box<dyn GenericLifetimeTypeAT<'static, 'static, AssocTy=()>>;
    |                          ^^^^^^^^^^^^^^^^^^^^^ expected 1 generic argument
    |
 note: trait defined here, with 1 generic parameter: `A`
-  --> $DIR/wrong-number-of-args.rs:197:15
+  --> $DIR/wrong-number-of-args.rs:201:15
    |
 LL |         trait GenericLifetimeTypeAT<'a, A> {
    |               ^^^^^^^^^^^^^^^^^^^^^     -
@@ -598,19 +679,8 @@ help: add missing generic argument
 LL |         type C = Box<dyn GenericLifetimeTypeAT<'static, 'static, A, AssocTy=()>>;
    |                                                                +++
 
-error[E0106]: missing lifetime specifier
-  --> $DIR/wrong-number-of-args.rs:217:48
-   |
-LL |         type D = Box<dyn GenericLifetimeTypeAT<(), AssocTy=()>>;
-   |                                                ^ expected named lifetime parameter
-   |
-help: consider introducing a named lifetime parameter
-   |
-LL |         type D<'a> = Box<dyn GenericLifetimeTypeAT<'a, (), AssocTy=()>>;
-   |               ++++                                 +++
-
 error[E0107]: this trait takes 1 generic argument but 2 generic arguments were supplied
-  --> $DIR/wrong-number-of-args.rs:221:26
+  --> $DIR/wrong-number-of-args.rs:227:26
    |
 LL |         type E = Box<dyn GenericLifetimeTypeAT<(), (), AssocTy=()>>;
    |                          ^^^^^^^^^^^^^^^^^^^^^     -- help: remove this generic argument
@@ -618,24 +688,13 @@ LL |         type E = Box<dyn GenericLifetimeTypeAT<(), (), AssocTy=()>>;
    |                          expected 1 generic argument
    |
 note: trait defined here, with 1 generic parameter: `A`
-  --> $DIR/wrong-number-of-args.rs:197:15
+  --> $DIR/wrong-number-of-args.rs:201:15
    |
 LL |         trait GenericLifetimeTypeAT<'a, A> {
    |               ^^^^^^^^^^^^^^^^^^^^^     -
 
-error[E0106]: missing lifetime specifier
-  --> $DIR/wrong-number-of-args.rs:221:48
-   |
-LL |         type E = Box<dyn GenericLifetimeTypeAT<(), (), AssocTy=()>>;
-   |                                                ^ expected named lifetime parameter
-   |
-help: consider introducing a named lifetime parameter
-   |
-LL |         type E<'a> = Box<dyn GenericLifetimeTypeAT<'a, (), (), AssocTy=()>>;
-   |               ++++                                 +++
-
 error[E0107]: this trait takes 1 lifetime argument but 2 lifetime arguments were supplied
-  --> $DIR/wrong-number-of-args.rs:227:26
+  --> $DIR/wrong-number-of-args.rs:234:26
    |
 LL |         type F = Box<dyn GenericLifetimeTypeAT<'static, 'static, (), AssocTy=()>>;
    |                          ^^^^^^^^^^^^^^^^^^^^^          ------- help: remove this lifetime argument
@@ -643,13 +702,13 @@ LL |         type F = Box<dyn GenericLifetimeTypeAT<'static, 'static, (), AssocT
    |                          expected 1 lifetime argument
    |
 note: trait defined here, with 1 lifetime parameter: `'a`
-  --> $DIR/wrong-number-of-args.rs:197:15
+  --> $DIR/wrong-number-of-args.rs:201:15
    |
 LL |         trait GenericLifetimeTypeAT<'a, A> {
    |               ^^^^^^^^^^^^^^^^^^^^^ --
 
 error[E0107]: this trait takes 1 generic argument but 2 generic arguments were supplied
-  --> $DIR/wrong-number-of-args.rs:231:26
+  --> $DIR/wrong-number-of-args.rs:238:26
    |
 LL |         type G = Box<dyn GenericLifetimeTypeAT<'static, (), (), AssocTy=()>>;
    |                          ^^^^^^^^^^^^^^^^^^^^^              -- help: remove this generic argument
@@ -657,13 +716,13 @@ LL |         type G = Box<dyn GenericLifetimeTypeAT<'static, (), (), AssocTy=()>
    |                          expected 1 generic argument
    |
 note: trait defined here, with 1 generic parameter: `A`
-  --> $DIR/wrong-number-of-args.rs:197:15
+  --> $DIR/wrong-number-of-args.rs:201:15
    |
 LL |         trait GenericLifetimeTypeAT<'a, A> {
    |               ^^^^^^^^^^^^^^^^^^^^^     -
 
 error[E0107]: this trait takes 1 lifetime argument but 2 lifetime arguments were supplied
-  --> $DIR/wrong-number-of-args.rs:235:26
+  --> $DIR/wrong-number-of-args.rs:242:26
    |
 LL |         type H = Box<dyn GenericLifetimeTypeAT<'static, 'static, (), (), AssocTy=()>>;
    |                          ^^^^^^^^^^^^^^^^^^^^^          ------- help: remove this lifetime argument
@@ -671,13 +730,13 @@ LL |         type H = Box<dyn GenericLifetimeTypeAT<'static, 'static, (), (), As
    |                          expected 1 lifetime argument
    |
 note: trait defined here, with 1 lifetime parameter: `'a`
-  --> $DIR/wrong-number-of-args.rs:197:15
+  --> $DIR/wrong-number-of-args.rs:201:15
    |
 LL |         trait GenericLifetimeTypeAT<'a, A> {
    |               ^^^^^^^^^^^^^^^^^^^^^ --
 
 error[E0107]: this trait takes 1 generic argument but 2 generic arguments were supplied
-  --> $DIR/wrong-number-of-args.rs:235:26
+  --> $DIR/wrong-number-of-args.rs:242:26
    |
 LL |         type H = Box<dyn GenericLifetimeTypeAT<'static, 'static, (), (), AssocTy=()>>;
    |                          ^^^^^^^^^^^^^^^^^^^^^                       -- help: remove this generic argument
@@ -685,19 +744,19 @@ LL |         type H = Box<dyn GenericLifetimeTypeAT<'static, 'static, (), (), As
    |                          expected 1 generic argument
    |
 note: trait defined here, with 1 generic parameter: `A`
-  --> $DIR/wrong-number-of-args.rs:197:15
+  --> $DIR/wrong-number-of-args.rs:201:15
    |
 LL |         trait GenericLifetimeTypeAT<'a, A> {
    |               ^^^^^^^^^^^^^^^^^^^^^     -
 
 error[E0107]: this trait takes 2 generic arguments but 0 generic arguments were supplied
-  --> $DIR/wrong-number-of-args.rs:247:26
+  --> $DIR/wrong-number-of-args.rs:254:26
    |
 LL |         type A = Box<dyn GenericTypeTypeAT<AssocTy=()>>;
    |                          ^^^^^^^^^^^^^^^^^ expected 2 generic arguments
    |
 note: trait defined here, with 2 generic parameters: `A`, `B`
-  --> $DIR/wrong-number-of-args.rs:243:15
+  --> $DIR/wrong-number-of-args.rs:250:15
    |
 LL |         trait GenericTypeTypeAT<A, B> {
    |               ^^^^^^^^^^^^^^^^^ -  -
@@ -707,7 +766,7 @@ LL |         type A = Box<dyn GenericTypeTypeAT<A, B, AssocTy=()>>;
    |                                            +++++
 
 error[E0107]: this trait takes 2 generic arguments but 1 generic argument was supplied
-  --> $DIR/wrong-number-of-args.rs:251:26
+  --> $DIR/wrong-number-of-args.rs:258:26
    |
 LL |         type B = Box<dyn GenericTypeTypeAT<(), AssocTy=()>>;
    |                          ^^^^^^^^^^^^^^^^^ -- supplied 1 generic argument
@@ -715,7 +774,7 @@ LL |         type B = Box<dyn GenericTypeTypeAT<(), AssocTy=()>>;
    |                          expected 2 generic arguments
    |
 note: trait defined here, with 2 generic parameters: `A`, `B`
-  --> $DIR/wrong-number-of-args.rs:243:15
+  --> $DIR/wrong-number-of-args.rs:250:15
    |
 LL |         trait GenericTypeTypeAT<A, B> {
    |               ^^^^^^^^^^^^^^^^^ -  -
@@ -725,7 +784,7 @@ LL |         type B = Box<dyn GenericTypeTypeAT<(), B, AssocTy=()>>;
    |                                              +++
 
 error[E0107]: this trait takes 2 generic arguments but 3 generic arguments were supplied
-  --> $DIR/wrong-number-of-args.rs:255:26
+  --> $DIR/wrong-number-of-args.rs:262:26
    |
 LL |         type C = Box<dyn GenericTypeTypeAT<(), (), (), AssocTy=()>>;
    |                          ^^^^^^^^^^^^^^^^^         -- help: remove this generic argument
@@ -733,24 +792,13 @@ LL |         type C = Box<dyn GenericTypeTypeAT<(), (), (), AssocTy=()>>;
    |                          expected 2 generic arguments
    |
 note: trait defined here, with 2 generic parameters: `A`, `B`
-  --> $DIR/wrong-number-of-args.rs:243:15
+  --> $DIR/wrong-number-of-args.rs:250:15
    |
 LL |         trait GenericTypeTypeAT<A, B> {
    |               ^^^^^^^^^^^^^^^^^ -  -
 
-error[E0106]: missing lifetime specifiers
-  --> $DIR/wrong-number-of-args.rs:265:52
-   |
-LL |         type A = Box<dyn GenericLifetimeLifetimeAT<AssocTy=()>>;
-   |                                                    ^ expected 2 lifetime parameters
-   |
-help: consider introducing a named lifetime parameter
-   |
-LL |         type A<'a> = Box<dyn GenericLifetimeLifetimeAT<'a, 'a, AssocTy=()>>;
-   |               ++++                                     +++++++
-
 error[E0107]: this trait takes 2 lifetime arguments but 1 lifetime argument was supplied
-  --> $DIR/wrong-number-of-args.rs:269:26
+  --> $DIR/wrong-number-of-args.rs:277:26
    |
 LL |         type B = Box<dyn GenericLifetimeLifetimeAT<'static, AssocTy=()>>;
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^ ------- supplied 1 lifetime argument
@@ -758,7 +806,7 @@ LL |         type B = Box<dyn GenericLifetimeLifetimeAT<'static, AssocTy=()>>;
    |                          expected 2 lifetime arguments
    |
 note: trait defined here, with 2 lifetime parameters: `'a`, `'b`
-  --> $DIR/wrong-number-of-args.rs:261:15
+  --> $DIR/wrong-number-of-args.rs:268:15
    |
 LL |         trait GenericLifetimeLifetimeAT<'a, 'b> {
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^ --  --
@@ -768,13 +816,13 @@ LL |         type B = Box<dyn GenericLifetimeLifetimeAT<'static, 'b, AssocTy=()>
    |                                                           ++++
 
 error[E0107]: this trait takes 1 generic argument but 0 generic arguments were supplied
-  --> $DIR/wrong-number-of-args.rs:279:26
+  --> $DIR/wrong-number-of-args.rs:287:26
    |
 LL |         type A = Box<dyn GenericLifetimeLifetimeTypeAT<AssocTy=()>>;
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected 1 generic argument
    |
 note: trait defined here, with 1 generic parameter: `A`
-  --> $DIR/wrong-number-of-args.rs:275:15
+  --> $DIR/wrong-number-of-args.rs:283:15
    |
 LL |         trait GenericLifetimeLifetimeTypeAT<'a, 'b, A> {
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^         -
@@ -783,19 +831,8 @@ help: add missing generic argument
 LL |         type A = Box<dyn GenericLifetimeLifetimeTypeAT<A, AssocTy=()>>;
    |                                                        ++
 
-error[E0106]: missing lifetime specifiers
-  --> $DIR/wrong-number-of-args.rs:279:56
-   |
-LL |         type A = Box<dyn GenericLifetimeLifetimeTypeAT<AssocTy=()>>;
-   |                                                        ^ expected 2 lifetime parameters
-   |
-help: consider introducing a named lifetime parameter
-   |
-LL |         type A<'a> = Box<dyn GenericLifetimeLifetimeTypeAT<'a, 'a, AssocTy=()>>;
-   |               ++++                                         +++++++
-
 error[E0107]: this trait takes 2 lifetime arguments but 1 lifetime argument was supplied
-  --> $DIR/wrong-number-of-args.rs:285:26
+  --> $DIR/wrong-number-of-args.rs:294:26
    |
 LL |         type B = Box<dyn GenericLifetimeLifetimeTypeAT<'static, AssocTy=()>>;
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ------- supplied 1 lifetime argument
@@ -803,7 +840,7 @@ LL |         type B = Box<dyn GenericLifetimeLifetimeTypeAT<'static, AssocTy=()>
    |                          expected 2 lifetime arguments
    |
 note: trait defined here, with 2 lifetime parameters: `'a`, `'b`
-  --> $DIR/wrong-number-of-args.rs:275:15
+  --> $DIR/wrong-number-of-args.rs:283:15
    |
 LL |         trait GenericLifetimeLifetimeTypeAT<'a, 'b, A> {
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ --  --
@@ -813,13 +850,13 @@ LL |         type B = Box<dyn GenericLifetimeLifetimeTypeAT<'static, 'b, AssocTy
    |                                                               ++++
 
 error[E0107]: this trait takes 1 generic argument but 0 generic arguments were supplied
-  --> $DIR/wrong-number-of-args.rs:285:26
+  --> $DIR/wrong-number-of-args.rs:294:26
    |
 LL |         type B = Box<dyn GenericLifetimeLifetimeTypeAT<'static, AssocTy=()>>;
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected 1 generic argument
    |
 note: trait defined here, with 1 generic parameter: `A`
-  --> $DIR/wrong-number-of-args.rs:275:15
+  --> $DIR/wrong-number-of-args.rs:283:15
    |
 LL |         trait GenericLifetimeLifetimeTypeAT<'a, 'b, A> {
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^         -
@@ -829,7 +866,7 @@ LL |         type B = Box<dyn GenericLifetimeLifetimeTypeAT<'static, A, AssocTy=
    |                                                               +++
 
 error[E0107]: this trait takes 2 lifetime arguments but 1 lifetime argument was supplied
-  --> $DIR/wrong-number-of-args.rs:291:26
+  --> $DIR/wrong-number-of-args.rs:300:26
    |
 LL |         type C = Box<dyn GenericLifetimeLifetimeTypeAT<'static, (), AssocTy=()>>;
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ------- supplied 1 lifetime argument
@@ -837,7 +874,7 @@ LL |         type C = Box<dyn GenericLifetimeLifetimeTypeAT<'static, (), AssocTy
    |                          expected 2 lifetime arguments
    |
 note: trait defined here, with 2 lifetime parameters: `'a`, `'b`
-  --> $DIR/wrong-number-of-args.rs:275:15
+  --> $DIR/wrong-number-of-args.rs:283:15
    |
 LL |         trait GenericLifetimeLifetimeTypeAT<'a, 'b, A> {
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ --  --
@@ -847,7 +884,7 @@ LL |         type C = Box<dyn GenericLifetimeLifetimeTypeAT<'static, 'b, (), Ass
    |                                                               ++++
 
 error[E0107]: missing generics for struct `HashMap`
-  --> $DIR/wrong-number-of-args.rs:301:18
+  --> $DIR/wrong-number-of-args.rs:310:18
    |
 LL |         type A = HashMap;
    |                  ^^^^^^^ expected at least 2 generic arguments
@@ -863,7 +900,7 @@ LL |         type A = HashMap<K, V>;
    |                  ~~~~~~~~~~~~~
 
 error[E0107]: this struct takes at least 2 generic arguments but 1 generic argument was supplied
-  --> $DIR/wrong-number-of-args.rs:305:18
+  --> $DIR/wrong-number-of-args.rs:314:18
    |
 LL |         type B = HashMap<String>;
    |                  ^^^^^^^ ------ supplied 1 generic argument
@@ -881,7 +918,7 @@ LL |         type B = HashMap<String, V>;
    |                                +++
 
 error[E0107]: this struct takes 0 lifetime arguments but 1 lifetime argument was supplied
-  --> $DIR/wrong-number-of-args.rs:309:18
+  --> $DIR/wrong-number-of-args.rs:318:18
    |
 LL |         type C = HashMap<'static>;
    |                  ^^^^^^^--------- help: remove these generics
@@ -895,7 +932,7 @@ LL | pub struct HashMap<K, V, S = RandomState> {
    |            ^^^^^^^
 
 error[E0107]: this struct takes at least 2 generic arguments but 0 generic arguments were supplied
-  --> $DIR/wrong-number-of-args.rs:309:18
+  --> $DIR/wrong-number-of-args.rs:318:18
    |
 LL |         type C = HashMap<'static>;
    |                  ^^^^^^^ expected at least 2 generic arguments
@@ -911,7 +948,7 @@ LL |         type C = HashMap<'static, K, V>;
    |                                 ++++++
 
 error[E0107]: this struct takes at most 3 generic arguments but 4 generic arguments were supplied
-  --> $DIR/wrong-number-of-args.rs:315:18
+  --> $DIR/wrong-number-of-args.rs:324:18
    |
 LL |         type D = HashMap<usize, String, char, f64>;
    |                  ^^^^^^^                      --- help: remove this generic argument
@@ -925,7 +962,7 @@ LL | pub struct HashMap<K, V, S = RandomState> {
    |            ^^^^^^^ -  -  ---------------
 
 error[E0107]: this struct takes at least 2 generic arguments but 0 generic arguments were supplied
-  --> $DIR/wrong-number-of-args.rs:319:18
+  --> $DIR/wrong-number-of-args.rs:328:18
    |
 LL |         type E = HashMap<>;
    |                  ^^^^^^^ expected at least 2 generic arguments
@@ -941,7 +978,7 @@ LL |         type E = HashMap<K, V>;
    |                          ++++
 
 error[E0107]: missing generics for enum `Result`
-  --> $DIR/wrong-number-of-args.rs:325:18
+  --> $DIR/wrong-number-of-args.rs:334:18
    |
 LL |         type A = Result;
    |                  ^^^^^^ expected 2 generic arguments
@@ -957,7 +994,7 @@ LL |         type A = Result<T, E>;
    |                  ~~~~~~~~~~~~
 
 error[E0107]: this enum takes 2 generic arguments but 1 generic argument was supplied
-  --> $DIR/wrong-number-of-args.rs:329:18
+  --> $DIR/wrong-number-of-args.rs:338:18
    |
 LL |         type B = Result<String>;
    |                  ^^^^^^ ------ supplied 1 generic argument
@@ -975,7 +1012,7 @@ LL |         type B = Result<String, E>;
    |                               +++
 
 error[E0107]: this enum takes 0 lifetime arguments but 1 lifetime argument was supplied
-  --> $DIR/wrong-number-of-args.rs:333:18
+  --> $DIR/wrong-number-of-args.rs:342:18
    |
 LL |         type C = Result<'static>;
    |                  ^^^^^^--------- help: remove these generics
@@ -989,7 +1026,7 @@ LL | pub enum Result<T, E> {
    |          ^^^^^^
 
 error[E0107]: this enum takes 2 generic arguments but 0 generic arguments were supplied
-  --> $DIR/wrong-number-of-args.rs:333:18
+  --> $DIR/wrong-number-of-args.rs:342:18
    |
 LL |         type C = Result<'static>;
    |                  ^^^^^^ expected 2 generic arguments
@@ -1005,7 +1042,7 @@ LL |         type C = Result<'static, T, E>;
    |                                ++++++
 
 error[E0107]: this enum takes 2 generic arguments but 3 generic arguments were supplied
-  --> $DIR/wrong-number-of-args.rs:339:18
+  --> $DIR/wrong-number-of-args.rs:348:18
    |
 LL |         type D = Result<usize, String, char>;
    |                  ^^^^^^                ---- help: remove this generic argument
@@ -1019,7 +1056,7 @@ LL | pub enum Result<T, E> {
    |          ^^^^^^ -  -
 
 error[E0107]: this enum takes 2 generic arguments but 0 generic arguments were supplied
-  --> $DIR/wrong-number-of-args.rs:343:18
+  --> $DIR/wrong-number-of-args.rs:352:18
    |
 LL |         type E = Result<>;
    |                  ^^^^^^ expected 2 generic arguments

--- a/src/test/ui/issues/issue-13497.stderr
+++ b/src/test/ui/issues/issue-13497.stderr
@@ -8,7 +8,7 @@ LL |     &str
 help: consider using the `'static` lifetime
    |
 LL |     &'static str
-   |     ~~~~~~~~
+   |      +++++++
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-19707.stderr
+++ b/src/test/ui/issues/issue-19707.stderr
@@ -8,12 +8,12 @@ LL | type Foo = fn(&u8, &u8) -> &u8;
    = note: for more information on higher-ranked polymorphism, visit https://doc.rust-lang.org/nomicon/hrtb.html
 help: consider making the type lifetime-generic with a new `'a` lifetime
    |
-LL | type Foo = for<'a> fn(&'a u8, &'a u8) -> &'a u8;
-   |            +++++++     ++      ++         ++
+LL | type Foo = for<'a> fn(&u8, &u8) -> &'a u8;
+   |            +++++++                  ++
 help: consider introducing a named lifetime parameter
    |
-LL | type Foo<'a> = fn(&'a u8, &'a u8) -> &'a u8;
-   |         ++++       ++      ++         ++
+LL | type Foo<'a> = fn(&u8, &u8) -> &'a u8;
+   |         ++++                    ++
 
 error[E0106]: missing lifetime specifier
   --> $DIR/issue-19707.rs:5:27
@@ -22,15 +22,14 @@ LL | fn bar<F: Fn(&u8, &u8) -> &u8>(f: &F) {}
    |              ---  ---     ^ expected named lifetime parameter
    |
    = help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from argument 1 or argument 2
-   = note: for more information on higher-ranked polymorphism, visit https://doc.rust-lang.org/nomicon/hrtb.html
 help: consider making the bound lifetime-generic with a new `'a` lifetime
    |
-LL | fn bar<F: for<'a> Fn(&'a u8, &'a u8) -> &'a u8>(f: &F) {}
-   |           +++++++     ++      ++         ++
+LL | fn bar<F: for<'a> Fn(&u8, &u8) -> &'a u8>(f: &F) {}
+   |           +++++++                  ++
 help: consider introducing a named lifetime parameter
    |
-LL | fn bar<'a, F: Fn(&'a u8, &'a u8) -> &'a u8>(f: &F) {}
-   |        +++        ++      ++         ++
+LL | fn bar<'a, F: Fn(&u8, &u8) -> &'a u8>(f: &F) {}
+   |        +++                     ++
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/issues/issue-30255.stderr
+++ b/src/test/ui/issues/issue-30255.stderr
@@ -7,8 +7,8 @@ LL | fn f(a: &S, b: i32) -> &i32 {
    = help: this function's return type contains a borrowed value, but the signature does not say which one of `a`'s 2 lifetimes it is borrowed from
 help: consider introducing a named lifetime parameter
    |
-LL | fn f<'a>(a: &'a S, b: i32) -> &'a i32 {
-   |     ++++     ++                ++
+LL | fn f<'a>(a: &S, b: i32) -> &'a i32 {
+   |     ++++                    ++
 
 error[E0106]: missing lifetime specifier
   --> $DIR/issue-30255.rs:14:34
@@ -19,8 +19,8 @@ LL | fn g(a: &S, b: bool, c: &i32) -> &i32 {
    = help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from one of `a`'s 2 lifetimes or `c`
 help: consider introducing a named lifetime parameter
    |
-LL | fn g<'a>(a: &'a S, b: bool, c: &'a i32) -> &'a i32 {
-   |     ++++     ++                 ++          ++
+LL | fn g<'a>(a: &S, b: bool, c: &i32) -> &'a i32 {
+   |     ++++                              ++
 
 error[E0106]: missing lifetime specifier
   --> $DIR/issue-30255.rs:19:44
@@ -31,8 +31,8 @@ LL | fn h(a: &bool, b: bool, c: &S, d: &i32) -> &i32 {
    = help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from `a`, one of `c`'s 2 lifetimes, or `d`
 help: consider introducing a named lifetime parameter
    |
-LL | fn h<'a>(a: &'a bool, b: bool, c: &'a S, d: &'a i32) -> &'a i32 {
-   |     ++++     ++                    ++        ++          ++
+LL | fn h<'a>(a: &bool, b: bool, c: &S, d: &i32) -> &'a i32 {
+   |     ++++                                        ++
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/lifetimes/issue-26638.rs
+++ b/src/test/ui/lifetimes/issue-26638.rs
@@ -1,8 +1,11 @@
 fn parse_type(iter: Box<dyn Iterator<Item=&str>+'static>) -> &str { iter.next() }
 //~^ ERROR missing lifetime specifier [E0106]
+//~| ERROR mismatched types
 
 fn parse_type_2(iter: fn(&u8)->&u8) -> &str { iter() }
 //~^ ERROR missing lifetime specifier [E0106]
+//~| ERROR mismatched types
+//~| ERROR this function takes 1 argument but 0 arguments were supplied
 
 fn parse_type_3() -> &str { unimplemented!() }
 //~^ ERROR missing lifetime specifier [E0106]

--- a/src/test/ui/lifetimes/issue-26638.stderr
+++ b/src/test/ui/lifetimes/issue-26638.stderr
@@ -11,19 +11,19 @@ LL | fn parse_type<'a>(iter: Box<dyn Iterator<Item=&str>+'static>) -> &'a str { 
    |              ++++                                                 ++
 
 error[E0106]: missing lifetime specifier
-  --> $DIR/issue-26638.rs:4:40
+  --> $DIR/issue-26638.rs:5:40
    |
 LL | fn parse_type_2(iter: fn(&u8)->&u8) -> &str { iter() }
    |                                        ^ expected named lifetime parameter
    |
-   = help: this function's return type contains a borrowed value with an elided lifetime, but the lifetime cannot be derived from the arguments
+   = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
 help: consider using the `'static` lifetime
    |
 LL | fn parse_type_2(iter: fn(&u8)->&u8) -> &'static str { iter() }
-   |                                        ~~~~~~~~
+   |                                         +++++++
 
 error[E0106]: missing lifetime specifier
-  --> $DIR/issue-26638.rs:7:22
+  --> $DIR/issue-26638.rs:10:22
    |
 LL | fn parse_type_3() -> &str { unimplemented!() }
    |                      ^ expected named lifetime parameter
@@ -32,8 +32,42 @@ LL | fn parse_type_3() -> &str { unimplemented!() }
 help: consider using the `'static` lifetime
    |
 LL | fn parse_type_3() -> &'static str { unimplemented!() }
-   |                      ~~~~~~~~
+   |                       +++++++
 
-error: aborting due to 3 previous errors
+error[E0308]: mismatched types
+  --> $DIR/issue-26638.rs:1:69
+   |
+LL | fn parse_type(iter: Box<dyn Iterator<Item=&str>+'static>) -> &str { iter.next() }
+   |                                                              ----   ^^^^^^^^^^^ expected `&str`, found enum `Option`
+   |                                                              |
+   |                                                              expected `&'static str` because of return type
+   |
+   = note: expected reference `&'static str`
+                   found enum `Option<&str>`
 
-For more information about this error, try `rustc --explain E0106`.
+error[E0061]: this function takes 1 argument but 0 arguments were supplied
+  --> $DIR/issue-26638.rs:5:47
+   |
+LL | fn parse_type_2(iter: fn(&u8)->&u8) -> &str { iter() }
+   |                                               ^^^^-- an argument of type `&u8` is missing
+   |
+help: provide the argument
+   |
+LL | fn parse_type_2(iter: fn(&u8)->&u8) -> &str { iter({&u8}) }
+   |                                               ~~~~~~~~~~~
+
+error[E0308]: mismatched types
+  --> $DIR/issue-26638.rs:5:47
+   |
+LL | fn parse_type_2(iter: fn(&u8)->&u8) -> &str { iter() }
+   |                                        ----   ^^^^^^ expected `str`, found `u8`
+   |                                        |
+   |                                        expected `&'static str` because of return type
+   |
+   = note: expected reference `&'static str`
+              found reference `&u8`
+
+error: aborting due to 6 previous errors
+
+Some errors have detailed explanations: E0061, E0106, E0308.
+For more information about an error, try `rustc --explain E0061`.

--- a/src/test/ui/lifetimes/lifetime-elision-return-type-requires-explicit-lifetime.stderr
+++ b/src/test/ui/lifetimes/lifetime-elision-return-type-requires-explicit-lifetime.stderr
@@ -8,7 +8,7 @@ LL | fn f() -> &isize {
 help: consider using the `'static` lifetime
    |
 LL | fn f() -> &'static isize {
-   |           ~~~~~~~~
+   |            +++++++
 
 error[E0106]: missing lifetime specifier
   --> $DIR/lifetime-elision-return-type-requires-explicit-lifetime.rs:7:33
@@ -19,8 +19,8 @@ LL | fn g(_x: &isize, _y: &isize) -> &isize {
    = help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from `_x` or `_y`
 help: consider introducing a named lifetime parameter
    |
-LL | fn g<'a>(_x: &'a isize, _y: &'a isize) -> &'a isize {
-   |     ++++      ++             ++            ++
+LL | fn g<'a>(_x: &isize, _y: &isize) -> &'a isize {
+   |     ++++                             ++
 
 error[E0106]: missing lifetime specifier
   --> $DIR/lifetime-elision-return-type-requires-explicit-lifetime.rs:17:19
@@ -31,8 +31,8 @@ LL | fn h(_x: &Foo) -> &isize {
    = help: this function's return type contains a borrowed value, but the signature does not say which one of `_x`'s 2 lifetimes it is borrowed from
 help: consider introducing a named lifetime parameter
    |
-LL | fn h<'a>(_x: &'a Foo) -> &'a isize {
-   |     ++++      ++          ++
+LL | fn h<'a>(_x: &Foo) -> &'a isize {
+   |     ++++               ++
 
 error[E0106]: missing lifetime specifier
   --> $DIR/lifetime-elision-return-type-requires-explicit-lifetime.rs:21:20
@@ -40,11 +40,11 @@ error[E0106]: missing lifetime specifier
 LL | fn i(_x: isize) -> &isize {
    |                    ^ expected named lifetime parameter
    |
-   = help: this function's return type contains a borrowed value with an elided lifetime, but the lifetime cannot be derived from the arguments
+   = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
 help: consider using the `'static` lifetime
    |
 LL | fn i(_x: isize) -> &'static isize {
-   |                    ~~~~~~~~
+   |                     +++++++
 
 error[E0106]: missing lifetime specifier
   --> $DIR/lifetime-elision-return-type-requires-explicit-lifetime.rs:34:24
@@ -52,11 +52,11 @@ error[E0106]: missing lifetime specifier
 LL | fn j(_x: StaticStr) -> &isize {
    |                        ^ expected named lifetime parameter
    |
-   = help: this function's return type contains a borrowed value with an elided lifetime, but the lifetime cannot be derived from the arguments
+   = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
 help: consider using the `'static` lifetime
    |
 LL | fn j(_x: StaticStr) -> &'static isize {
-   |                        ~~~~~~~~
+   |                         +++++++
 
 error[E0106]: missing lifetime specifier
   --> $DIR/lifetime-elision-return-type-requires-explicit-lifetime.rs:40:49
@@ -64,11 +64,11 @@ error[E0106]: missing lifetime specifier
 LL | fn k<'a, T: WithLifetime<'a>>(_x: T::Output) -> &isize {
    |                                                 ^ expected named lifetime parameter
    |
-   = help: this function's return type contains a borrowed value with an elided lifetime, but the lifetime cannot be derived from the arguments
-help: consider using the `'a` lifetime
+   = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
+help: consider using the `'static` lifetime
    |
-LL | fn k<'a, T: WithLifetime<'a>>(_x: T::Output) -> &'a isize {
-   |                                                 ~~~
+LL | fn k<'a, T: WithLifetime<'a>>(_x: T::Output) -> &'static isize {
+   |                                                  +++++++
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/lifetimes/lifetime-errors/ex1b-return-no-names-if-else.rs
+++ b/src/test/ui/lifetimes/lifetime-errors/ex1b-return-no-names-if-else.rs
@@ -1,5 +1,8 @@
-fn foo(x: &i32, y: &i32) -> &i32 { //~ ERROR missing lifetime
+fn foo(x: &i32, y: &i32) -> &i32 {
+    //~^ ERROR missing lifetime
     if x > y { x } else { y }
+    //~^ ERROR lifetime of reference outlives
+    //~| ERROR lifetime of reference outlives
 }
 
-fn main() { }
+fn main() {}

--- a/src/test/ui/lifetimes/lifetime-errors/ex1b-return-no-names-if-else.stderr
+++ b/src/test/ui/lifetimes/lifetime-errors/ex1b-return-no-names-if-else.stderr
@@ -7,9 +7,36 @@ LL | fn foo(x: &i32, y: &i32) -> &i32 {
    = help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from `x` or `y`
 help: consider introducing a named lifetime parameter
    |
-LL | fn foo<'a>(x: &'a i32, y: &'a i32) -> &'a i32 {
-   |       ++++     ++          ++          ++
+LL | fn foo<'a>(x: &i32, y: &i32) -> &'a i32 {
+   |       ++++                       ++
 
-error: aborting due to previous error
+error[E0312]: lifetime of reference outlives lifetime of borrowed content...
+  --> $DIR/ex1b-return-no-names-if-else.rs:3:16
+   |
+LL |     if x > y { x } else { y }
+   |                ^
+   |
+   = note: ...the reference is valid for the static lifetime...
+note: ...but the borrowed content is only valid for the anonymous lifetime defined here
+  --> $DIR/ex1b-return-no-names-if-else.rs:1:11
+   |
+LL | fn foo(x: &i32, y: &i32) -> &i32 {
+   |           ^^^^
 
-For more information about this error, try `rustc --explain E0106`.
+error[E0312]: lifetime of reference outlives lifetime of borrowed content...
+  --> $DIR/ex1b-return-no-names-if-else.rs:3:27
+   |
+LL |     if x > y { x } else { y }
+   |                           ^
+   |
+   = note: ...the reference is valid for the static lifetime...
+note: ...but the borrowed content is only valid for the anonymous lifetime defined here
+  --> $DIR/ex1b-return-no-names-if-else.rs:1:20
+   |
+LL | fn foo(x: &i32, y: &i32) -> &i32 {
+   |                    ^^^^
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0106, E0312.
+For more information about an error, try `rustc --explain E0106`.

--- a/src/test/ui/lifetimes/missing-lifetime-in-alias.stderr
+++ b/src/test/ui/lifetimes/missing-lifetime-in-alias.stderr
@@ -7,7 +7,7 @@ LL | type B<'a> = <A<'a> as Trait>::Foo;
 help: consider using the `'a` lifetime
    |
 LL | type B<'a> = <A<'a> as Trait<'a>>::Foo;
-   |                        ~~~~~~~~~
+   |                             ++++
 
 error[E0106]: missing lifetime specifier
   --> $DIR/missing-lifetime-in-alias.rs:26:28
@@ -20,6 +20,10 @@ note: these named lifetimes are available to use
    |
 LL | type C<'a, 'b> = <A<'a> as Trait>::Bar;
    |        ^^  ^^
+help: consider using one of the available lifetimes here
+   |
+LL | type C<'a, 'b> = <A<'a> as Trait<'lifetime>>::Bar;
+   |                                 +++++++++++
 
 error[E0107]: missing generics for associated type `Trait::Bar`
   --> $DIR/missing-lifetime-in-alias.rs:26:36

--- a/src/test/ui/mismatched_types/issue-74918-missing-lifetime.rs
+++ b/src/test/ui/mismatched_types/issue-74918-missing-lifetime.rs
@@ -9,6 +9,7 @@ impl<T, S: Iterator<Item = T>> Iterator for ChunkingIterator<T, S> {
     type Item = IteratorChunk<T, S>; //~ ERROR missing lifetime
 
     fn next(&mut self) -> Option<IteratorChunk<T, S>> {
+        //~^ ERROR `impl` item signature doesn't match `trait` item signature
         todo!()
     }
 }

--- a/src/test/ui/mismatched_types/issue-74918-missing-lifetime.stderr
+++ b/src/test/ui/mismatched_types/issue-74918-missing-lifetime.stderr
@@ -1,14 +1,30 @@
 error[E0106]: missing lifetime specifier
-  --> $DIR/issue-74918-missing-lifetime.rs:9:31
+  --> $DIR/issue-74918-missing-lifetime.rs:9:30
    |
 LL |     type Item = IteratorChunk<T, S>;
-   |                               ^ expected named lifetime parameter
+   |                              ^ expected named lifetime parameter
    |
 help: consider introducing a named lifetime parameter
    |
 LL |     type Item<'a> = IteratorChunk<'a, T, S>;
    |              ++++                 +++
 
-error: aborting due to previous error
+error: `impl` item signature doesn't match `trait` item signature
+  --> $DIR/issue-74918-missing-lifetime.rs:11:5
+   |
+LL |     fn next(&mut self) -> Option<IteratorChunk<T, S>> {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ found `fn(&'1 mut ChunkingIterator<T, S>) -> Option<IteratorChunk<'1, T, S>>`
+   |
+  ::: $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
+   |
+LL |     fn next(&mut self) -> Option<Self::Item>;
+   |     ----------------------------------------- expected `fn(&'1 mut ChunkingIterator<T, S>) -> Option<IteratorChunk<'static, T, S>>`
+   |
+   = note: expected `fn(&'1 mut ChunkingIterator<T, S>) -> Option<IteratorChunk<'static, T, S>>`
+              found `fn(&'1 mut ChunkingIterator<T, S>) -> Option<IteratorChunk<'1, T, S>>`
+   = help: the lifetime requirements from the `impl` do not correspond to the requirements in the `trait`
+   = help: verify the lifetime relationships in the `trait` and `impl` between the `self` argument, the other inputs and its output
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0106`.

--- a/src/test/ui/resolve/issue-69401-trait-fn-no-body-ty-local.rs
+++ b/src/test/ui/resolve/issue-69401-trait-fn-no-body-ty-local.rs
@@ -2,5 +2,5 @@ fn main() {}
 
 trait Foo {
     fn fn_with_type_named_same_as_local_in_param(b: b);
-    //~^ ERROR cannot find type `b` in this scope
+    //~^ ERROR cannot find type `b` in this scope [E0412]
 }

--- a/src/test/ui/rfc1623-2.rs
+++ b/src/test/ui/rfc1623-2.rs
@@ -9,5 +9,6 @@ static NON_ELIDABLE_FN: &fn(&u8, &u8) -> &u8 =
 //~^ ERROR missing lifetime specifier [E0106]
     &(non_elidable as fn(&u8, &u8) -> &u8);
     //~^ ERROR missing lifetime specifier [E0106]
+    //~| ERROR mismatched types
 
 fn main() {}

--- a/src/test/ui/rfc1623-2.stderr
+++ b/src/test/ui/rfc1623-2.stderr
@@ -8,8 +8,8 @@ LL | static NON_ELIDABLE_FN: &fn(&u8, &u8) -> &u8 =
    = note: for more information on higher-ranked polymorphism, visit https://doc.rust-lang.org/nomicon/hrtb.html
 help: consider making the type lifetime-generic with a new `'a` lifetime
    |
-LL | static NON_ELIDABLE_FN: &for<'a> fn(&'a u8, &'a u8) -> &'a u8 =
-   |                          +++++++     ++      ++         ++
+LL | static NON_ELIDABLE_FN: &for<'a> fn(&u8, &u8) -> &'a u8 =
+   |                          +++++++                  ++
 
 error[E0106]: missing lifetime specifier
   --> $DIR/rfc1623-2.rs:10:39
@@ -18,12 +18,21 @@ LL |     &(non_elidable as fn(&u8, &u8) -> &u8);
    |                          ---  ---     ^ expected named lifetime parameter
    |
    = help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from argument 1 or argument 2
-   = note: for more information on higher-ranked polymorphism, visit https://doc.rust-lang.org/nomicon/hrtb.html
 help: consider making the type lifetime-generic with a new `'a` lifetime
    |
-LL |     &(non_elidable as for<'a> fn(&'a u8, &'a u8) -> &'a u8);
-   |                       +++++++     ++      ++         ++
+LL |     &(non_elidable as for<'a> fn(&u8, &u8) -> &'a u8);
+   |                       +++++++                  ++
 
-error: aborting due to 2 previous errors
+error[E0308]: mismatched types
+  --> $DIR/rfc1623-2.rs:10:7
+   |
+LL |     &(non_elidable as fn(&u8, &u8) -> &u8);
+   |       ^^^^^^^^^^^^ one type is more general than the other
+   |
+   = note: expected fn pointer `for<'r, 's> fn(&'r u8, &'s u8) -> &u8`
+              found fn pointer `for<'a, 'b> fn(&'a u8, &'b u8) -> &'a u8`
 
-For more information about this error, try `rustc --explain E0106`.
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0106, E0308.
+For more information about an error, try `rustc --explain E0106`.

--- a/src/test/ui/suggestions/fn-missing-lifetime-in-item.stderr
+++ b/src/test/ui/suggestions/fn-missing-lifetime-in-item.stderr
@@ -21,15 +21,14 @@ LL | struct S2<F: Fn(&i32, &i32) -> &i32>(F);
    |                 ----  ----     ^ expected named lifetime parameter
    |
    = help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from argument 1 or argument 2
-   = note: for more information on higher-ranked polymorphism, visit https://doc.rust-lang.org/nomicon/hrtb.html
 help: consider making the bound lifetime-generic with a new `'a` lifetime
    |
-LL | struct S2<F: for<'a> Fn(&'a i32, &'a i32) -> &'a i32>(F);
-   |              +++++++     ++       ++          ++
+LL | struct S2<F: for<'a> Fn(&i32, &i32) -> &'a i32>(F);
+   |              +++++++                    ++
 help: consider introducing a named lifetime parameter
    |
-LL | struct S2<'a, F: Fn(&'a i32, &'a i32) -> &'a i32>(F);
-   |           +++        ++       ++          ++
+LL | struct S2<'a, F: Fn(&i32, &i32) -> &'a i32>(F);
+   |           +++                       ++
 
 error[E0582]: binding for associated type `Output` references lifetime `'a`, which does not appear in the trait input types
   --> $DIR/fn-missing-lifetime-in-item.rs:3:40

--- a/src/test/ui/suggestions/impl-trait-missing-lifetime.rs
+++ b/src/test/ui/suggestions/impl-trait-missing-lifetime.rs
@@ -1,2 +1,2 @@
-fn f(_: impl Iterator<Item = &'_ ()>) {} //~ ERROR missing lifetime specifier
+fn f(_: impl Iterator<Item = &'_ ()>) {} //~ ERROR `'_` cannot be used here [E0637]
 fn main() {}

--- a/src/test/ui/suggestions/impl-trait-missing-lifetime.stderr
+++ b/src/test/ui/suggestions/impl-trait-missing-lifetime.stderr
@@ -1,14 +1,9 @@
-error[E0106]: missing lifetime specifier
+error[E0637]: `'_` cannot be used here
   --> $DIR/impl-trait-missing-lifetime.rs:1:31
    |
 LL | fn f(_: impl Iterator<Item = &'_ ()>) {}
-   |                               ^^ expected named lifetime parameter
-   |
-help: consider introducing a named lifetime parameter
-   |
-LL | fn f<'a>(_: impl Iterator<Item = &'a ()>) {}
-   |     ++++                          ~~
+   |                               ^^ `'_` is a reserved lifetime name
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0106`.
+For more information about this error, try `rustc --explain E0637`.

--- a/src/test/ui/suggestions/issue-84592.stderr
+++ b/src/test/ui/suggestions/issue-84592.stderr
@@ -9,8 +9,8 @@ LL | fn two_lifetimes_needed(a: &(), b: &()) -> TwoLifetimes<'_, '_> {
    = help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from `a` or `b`
 help: consider introducing a named lifetime parameter
    |
-LL | fn two_lifetimes_needed<'a>(a: &'a (), b: &'a ()) -> TwoLifetimes<'a, 'a> {
-   |                        ++++     ++         ++                     ~~  ~~
+LL | fn two_lifetimes_needed<'a>(a: &(), b: &()) -> TwoLifetimes<'a, 'a> {
+   |                        ++++                                 ~~  ~~
 
 error: aborting due to previous error
 

--- a/src/test/ui/suggestions/issue-86667.rs
+++ b/src/test/ui/suggestions/issue-86667.rs
@@ -5,12 +5,14 @@
 
 async fn a(s1: &str, s2: &str) -> &str {
 //~^ ERROR: missing lifetime specifier [E0106]
+//~| ERROR: `s1` has an anonymous lifetime `'_` but it needs to satisfy a `'static`
     s1
 }
 
 fn b(s1: &str, s2: &str) -> &str {
 //~^ ERROR: missing lifetime specifier [E0106]
     s1
+    //~^ ERROR: lifetime of reference outlives lifetime of borrowed content...
 }
 
 fn main() {}

--- a/src/test/ui/suggestions/issue-86667.stderr
+++ b/src/test/ui/suggestions/issue-86667.stderr
@@ -7,11 +7,11 @@ LL | async fn a(s1: &str, s2: &str) -> &str {
    = help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from `s1` or `s2`
 help: consider introducing a named lifetime parameter
    |
-LL | async fn a<'a>(s1: &'a str, s2: &'a str) -> &'a str {
-   |           ++++      ++           ++          ++
+LL | async fn a<'a>(s1: &str, s2: &str) -> &'a str {
+   |           ++++                         ++
 
 error[E0106]: missing lifetime specifier
-  --> $DIR/issue-86667.rs:11:29
+  --> $DIR/issue-86667.rs:12:29
    |
 LL | fn b(s1: &str, s2: &str) -> &str {
    |          ----      ----     ^ expected named lifetime parameter
@@ -19,9 +19,34 @@ LL | fn b(s1: &str, s2: &str) -> &str {
    = help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from `s1` or `s2`
 help: consider introducing a named lifetime parameter
    |
-LL | fn b<'a>(s1: &'a str, s2: &'a str) -> &'a str {
-   |     ++++      ++           ++          ++
+LL | fn b<'a>(s1: &str, s2: &str) -> &'a str {
+   |     ++++                         ++
 
-error: aborting due to 2 previous errors
+error[E0759]: `s1` has an anonymous lifetime `'_` but it needs to satisfy a `'static` lifetime requirement
+  --> $DIR/issue-86667.rs:6:12
+   |
+LL | async fn a(s1: &str, s2: &str) -> &str {
+   |            ^^  ---- this data with an anonymous lifetime `'_`...
+   |            |
+   |            ...is used here...
+...
+LL |     s1
+   |     -- ...and is required to live as long as `'static` here
 
-For more information about this error, try `rustc --explain E0106`.
+error[E0312]: lifetime of reference outlives lifetime of borrowed content...
+  --> $DIR/issue-86667.rs:14:5
+   |
+LL |     s1
+   |     ^^
+   |
+   = note: ...the reference is valid for the static lifetime...
+note: ...but the borrowed content is only valid for the anonymous lifetime defined here
+  --> $DIR/issue-86667.rs:12:10
+   |
+LL | fn b(s1: &str, s2: &str) -> &str {
+   |          ^^^^
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0106, E0312, E0759.
+For more information about an error, try `rustc --explain E0106`.

--- a/src/test/ui/suggestions/lifetimes/missing-lifetimes-in-signature-before-const.fixed
+++ b/src/test/ui/suggestions/lifetimes/missing-lifetimes-in-signature-before-const.fixed
@@ -1,7 +1,7 @@
 // run-rustfix
 // https://github.com/rust-lang/rust/issues/95616
 
-fn buggy_const<'a, const N: usize>(_a: &'a Option<[u8; N]>, _f: &'a str) -> &'a str { //~ERROR [E0106]
+fn buggy_const<'a, const N: usize>(_a: &Option<[u8; N]>, _f: &str) -> &'a str { //~ERROR [E0106]
     return "";
 }
 

--- a/src/test/ui/suggestions/lifetimes/missing-lifetimes-in-signature-before-const.stderr
+++ b/src/test/ui/suggestions/lifetimes/missing-lifetimes-in-signature-before-const.stderr
@@ -7,8 +7,8 @@ LL | fn buggy_const<const N: usize>(_a: &Option<[u8; N]>, _f: &str) -> &str {
    = help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from `_a` or `_f`
 help: consider introducing a named lifetime parameter
    |
-LL | fn buggy_const<'a, const N: usize>(_a: &'a Option<[u8; N]>, _f: &'a str) -> &'a str {
-   |                +++                      ++                       ++          ++
+LL | fn buggy_const<'a, const N: usize>(_a: &Option<[u8; N]>, _f: &str) -> &'a str {
+   |                +++                                                     ++
 
 error: aborting due to previous error
 

--- a/src/test/ui/suggestions/missing-lifetime-in-assoc-const-type.stderr
+++ b/src/test/ui/suggestions/missing-lifetime-in-assoc-const-type.stderr
@@ -4,10 +4,6 @@ error[E0106]: missing lifetime specifier
 LL |     const A: &str = "";
    |              ^ expected named lifetime parameter
    |
-help: consider using the `'static` lifetime
-   |
-LL |     const A: &'static str = "";
-   |               +++++++
 help: consider introducing a named lifetime parameter
    |
 LL ~ trait ZstAssert<'a>: Sized {
@@ -20,10 +16,6 @@ error[E0106]: missing lifetime specifier
 LL |     const B: S = S { s: &() };
    |              ^ expected named lifetime parameter
    |
-help: consider using the `'static` lifetime
-   |
-LL |     const B: S<'static> = S { s: &() };
-   |               +++++++++
 help: consider introducing a named lifetime parameter
    |
 LL ~ trait ZstAssert<'a>: Sized {
@@ -37,10 +29,6 @@ error[E0106]: missing lifetime specifier
 LL |     const C: &'_ str = "";
    |               ^^ expected named lifetime parameter
    |
-help: consider using the `'static` lifetime
-   |
-LL |     const C: &'static str = "";
-   |               ~~~~~~~
 help: consider introducing a named lifetime parameter
    |
 LL ~ trait ZstAssert<'a>: Sized {
@@ -55,10 +43,6 @@ error[E0106]: missing lifetime specifiers
 LL |     const D: T = T { a: &(), b: &() };
    |              ^ expected 2 lifetime parameters
    |
-help: consider using the `'static` lifetime
-   |
-LL |     const D: T<'static, 'static> = T { a: &(), b: &() };
-   |               ++++++++++++++++++
 help: consider introducing a named lifetime parameter
    |
 LL ~ trait ZstAssert<'a>: Sized {

--- a/src/test/ui/suggestions/missing-lifetime-specifier.rs
+++ b/src/test/ui/suggestions/missing-lifetime-specifier.rs
@@ -21,22 +21,18 @@ thread_local! {
 }
 thread_local! {
     static b: RefCell<HashMap<i32, Vec<Vec<&Bar>>>> = RefCell::new(HashMap::new());
-      //~^ ERROR missing lifetime specifier
-      //~| ERROR missing lifetime specifier
-      //~| ERROR missing lifetime specifier
-      //~| ERROR missing lifetime specifier
+      //~^ ERROR missing lifetime specifiers
+      //~| ERROR missing lifetime specifiers
 }
 thread_local! {
     static c: RefCell<HashMap<i32, Vec<Vec<Qux<i32>>>>> = RefCell::new(HashMap::new());
-    //~^ ERROR missing lifetime
-    //~| ERROR missing lifetime
+    //~^ ERROR missing lifetime specifiers
+    //~| ERROR missing lifetime specifiers
 }
 thread_local! {
     static d: RefCell<HashMap<i32, Vec<Vec<&Tar<i32>>>>> = RefCell::new(HashMap::new());
-    //~^ ERROR missing lifetime
-    //~| ERROR missing lifetime
-    //~| ERROR missing lifetime
-    //~| ERROR missing lifetime
+    //~^ ERROR missing lifetime specifiers
+    //~| ERROR missing lifetime specifiers
 }
 
 thread_local! {

--- a/src/test/ui/suggestions/missing-lifetime-specifier.stderr
+++ b/src/test/ui/suggestions/missing-lifetime-specifier.stderr
@@ -8,7 +8,7 @@ LL |     static a: RefCell<HashMap<i32, Vec<Vec<Foo>>>> = RefCell::new(HashMap::
 help: consider using the `'static` lifetime
    |
 LL |     static a: RefCell<HashMap<i32, Vec<Vec<Foo<'static, 'static>>>>> = RefCell::new(HashMap::new());
-   |                                            ~~~~~~~~~~~~~~~~~~~~~
+   |                                               ++++++++++++++++++
 
 error[E0106]: missing lifetime specifiers
   --> $DIR/missing-lifetime-specifier.rs:18:44
@@ -23,38 +23,28 @@ LL | | }
    |
    = help: this function's return type contains a borrowed value, but the signature does not say which one of `init`'s 3 lifetimes it is borrowed from
 
-error[E0106]: missing lifetime specifier
+error[E0106]: missing lifetime specifiers
   --> $DIR/missing-lifetime-specifier.rs:23:44
    |
 LL |     static b: RefCell<HashMap<i32, Vec<Vec<&Bar>>>> = RefCell::new(HashMap::new());
-   |                                            ^ expected named lifetime parameter
+   |                                            ^^^^ expected 2 lifetime parameters
+   |                                            |
+   |                                            expected named lifetime parameter
    |
    = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
 help: consider using the `'static` lifetime
    |
-LL |     static b: RefCell<HashMap<i32, Vec<Vec<&'static Bar>>>> = RefCell::new(HashMap::new());
-   |                                            ~~~~~~~~
+LL |     static b: RefCell<HashMap<i32, Vec<Vec<&'static Bar<'static, 'static>>>>> = RefCell::new(HashMap::new());
+   |                                             +++++++    ++++++++++++++++++
 
 error[E0106]: missing lifetime specifiers
-  --> $DIR/missing-lifetime-specifier.rs:23:45
-   |
-LL |     static b: RefCell<HashMap<i32, Vec<Vec<&Bar>>>> = RefCell::new(HashMap::new());
-   |                                             ^^^ expected 2 lifetime parameters
-   |
-   = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
-help: consider using the `'static` lifetime
-   |
-LL |     static b: RefCell<HashMap<i32, Vec<Vec<&Bar<'static, 'static>>>>> = RefCell::new(HashMap::new());
-   |                                             ~~~~~~~~~~~~~~~~~~~~~
-
-error[E0106]: missing lifetime specifier
   --> $DIR/missing-lifetime-specifier.rs:23:44
    |
 LL | / thread_local! {
 LL | |     static b: RefCell<HashMap<i32, Vec<Vec<&Bar>>>> = RefCell::new(HashMap::new());
-   | |                                            ^ expected named lifetime parameter
-LL | |
-LL | |
+   | |                                            ^^^^ expected 2 lifetime parameters
+   | |                                            |
+   | |                                            expected named lifetime parameter
 LL | |
 LL | |
 LL | | }
@@ -63,25 +53,10 @@ LL | | }
    = help: this function's return type contains a borrowed value, but the signature does not say which one of `init`'s 4 lifetimes it is borrowed from
 
 error[E0106]: missing lifetime specifiers
-  --> $DIR/missing-lifetime-specifier.rs:23:45
-   |
-LL | / thread_local! {
-LL | |     static b: RefCell<HashMap<i32, Vec<Vec<&Bar>>>> = RefCell::new(HashMap::new());
-   | |                                             ^^^ expected 2 lifetime parameters
-LL | |
-LL | |
-LL | |
-LL | |
-LL | | }
-   | |_-
-   |
-   = help: this function's return type contains a borrowed value, but the signature does not say which one of `init`'s 4 lifetimes it is borrowed from
-
-error[E0106]: missing lifetime specifiers
-  --> $DIR/missing-lifetime-specifier.rs:30:48
+  --> $DIR/missing-lifetime-specifier.rs:28:47
    |
 LL |     static c: RefCell<HashMap<i32, Vec<Vec<Qux<i32>>>>> = RefCell::new(HashMap::new());
-   |                                                ^ expected 2 lifetime parameters
+   |                                               ^ expected 2 lifetime parameters
    |
    = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
 help: consider using the `'static` lifetime
@@ -90,11 +65,11 @@ LL |     static c: RefCell<HashMap<i32, Vec<Vec<Qux<'static, 'static, i32>>>>> =
    |                                                +++++++++++++++++
 
 error[E0106]: missing lifetime specifiers
-  --> $DIR/missing-lifetime-specifier.rs:30:48
+  --> $DIR/missing-lifetime-specifier.rs:28:47
    |
 LL | / thread_local! {
 LL | |     static c: RefCell<HashMap<i32, Vec<Vec<Qux<i32>>>>> = RefCell::new(HashMap::new());
-   | |                                                ^ expected 2 lifetime parameters
+   | |                                               ^ expected 2 lifetime parameters
 LL | |
 LL | |
 LL | | }
@@ -102,38 +77,28 @@ LL | | }
    |
    = help: this function's return type contains a borrowed value, but the signature does not say which one of `init`'s 3 lifetimes it is borrowed from
 
-error[E0106]: missing lifetime specifier
-  --> $DIR/missing-lifetime-specifier.rs:35:44
+error[E0106]: missing lifetime specifiers
+  --> $DIR/missing-lifetime-specifier.rs:33:44
    |
 LL |     static d: RefCell<HashMap<i32, Vec<Vec<&Tar<i32>>>>> = RefCell::new(HashMap::new());
-   |                                            ^ expected named lifetime parameter
+   |                                            ^   ^ expected 2 lifetime parameters
+   |                                            |
+   |                                            expected named lifetime parameter
    |
    = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
 help: consider using the `'static` lifetime
    |
-LL |     static d: RefCell<HashMap<i32, Vec<Vec<&'static Tar<i32>>>>> = RefCell::new(HashMap::new());
-   |                                            ~~~~~~~~
+LL |     static d: RefCell<HashMap<i32, Vec<Vec<&'static Tar<'static, 'static, i32>>>>> = RefCell::new(HashMap::new());
+   |                                             +++++++     +++++++++++++++++
 
 error[E0106]: missing lifetime specifiers
-  --> $DIR/missing-lifetime-specifier.rs:35:49
-   |
-LL |     static d: RefCell<HashMap<i32, Vec<Vec<&Tar<i32>>>>> = RefCell::new(HashMap::new());
-   |                                                 ^ expected 2 lifetime parameters
-   |
-   = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
-help: consider using the `'static` lifetime
-   |
-LL |     static d: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, 'static, i32>>>>> = RefCell::new(HashMap::new());
-   |                                                 +++++++++++++++++
-
-error[E0106]: missing lifetime specifier
-  --> $DIR/missing-lifetime-specifier.rs:35:44
+  --> $DIR/missing-lifetime-specifier.rs:33:44
    |
 LL | / thread_local! {
 LL | |     static d: RefCell<HashMap<i32, Vec<Vec<&Tar<i32>>>>> = RefCell::new(HashMap::new());
-   | |                                            ^ expected named lifetime parameter
-LL | |
-LL | |
+   | |                                            ^   ^ expected 2 lifetime parameters
+   | |                                            |
+   | |                                            expected named lifetime parameter
 LL | |
 LL | |
 LL | | }
@@ -141,131 +106,8 @@ LL | | }
    |
    = help: this function's return type contains a borrowed value, but the signature does not say which one of `init`'s 4 lifetimes it is borrowed from
 
-error[E0106]: missing lifetime specifiers
-  --> $DIR/missing-lifetime-specifier.rs:35:49
-   |
-LL | / thread_local! {
-LL | |     static d: RefCell<HashMap<i32, Vec<Vec<&Tar<i32>>>>> = RefCell::new(HashMap::new());
-   | |                                                 ^ expected 2 lifetime parameters
-LL | |
-LL | |
-LL | |
-LL | |
-LL | | }
-   | |_-
-   |
-   = help: this function's return type contains a borrowed value, but the signature does not say which one of `init`'s 4 lifetimes it is borrowed from
-
-error[E0107]: this union takes 2 lifetime arguments but 1 lifetime argument was supplied
-  --> $DIR/missing-lifetime-specifier.rs:43:44
-   |
-LL |     static e: RefCell<HashMap<i32, Vec<Vec<Qux<'static, i32>>>>> = RefCell::new(HashMap::new());
-   |                                            ^^^ ------- supplied 1 lifetime argument
-   |                                            |
-   |                                            expected 2 lifetime arguments
-   |
-note: union defined here, with 2 lifetime parameters: `'t`, `'k`
-  --> $DIR/missing-lifetime-specifier.rs:11:11
-   |
-LL | pub union Qux<'t, 'k, I> {
-   |           ^^^ --  --
-help: add missing lifetime argument
-   |
-LL |     static e: RefCell<HashMap<i32, Vec<Vec<Qux<'static, '_, i32>>>>> = RefCell::new(HashMap::new());
-   |                                                       ++++
-
-error[E0107]: this union takes 2 lifetime arguments but 1 lifetime argument was supplied
-  --> $DIR/missing-lifetime-specifier.rs:43:44
-   |
-LL |     static e: RefCell<HashMap<i32, Vec<Vec<Qux<'static, i32>>>>> = RefCell::new(HashMap::new());
-   |                                            ^^^ ------- supplied 1 lifetime argument
-   |                                            |
-   |                                            expected 2 lifetime arguments
-   |
-note: union defined here, with 2 lifetime parameters: `'t`, `'k`
-  --> $DIR/missing-lifetime-specifier.rs:11:11
-   |
-LL | pub union Qux<'t, 'k, I> {
-   |           ^^^ --  --
-help: add missing lifetime argument
-   |
-LL |     static e: RefCell<HashMap<i32, Vec<Vec<Qux<'static, 'k, i32>>>>> = RefCell::new(HashMap::new());
-   |                                                       ++++
-
-error[E0107]: this union takes 2 lifetime arguments but 1 lifetime argument was supplied
-  --> $DIR/missing-lifetime-specifier.rs:43:44
-   |
-LL |     static e: RefCell<HashMap<i32, Vec<Vec<Qux<'static, i32>>>>> = RefCell::new(HashMap::new());
-   |                                            ^^^ ------- supplied 1 lifetime argument
-   |                                            |
-   |                                            expected 2 lifetime arguments
-   |
-note: union defined here, with 2 lifetime parameters: `'t`, `'k`
-  --> $DIR/missing-lifetime-specifier.rs:11:11
-   |
-LL | pub union Qux<'t, 'k, I> {
-   |           ^^^ --  --
-help: add missing lifetime argument
-   |
-LL |     static e: RefCell<HashMap<i32, Vec<Vec<Qux<'static, 'k, i32>>>>> = RefCell::new(HashMap::new());
-   |                                                       ++++
-
-error[E0107]: this union takes 2 lifetime arguments but 1 lifetime argument was supplied
-  --> $DIR/missing-lifetime-specifier.rs:43:44
-   |
-LL |     static e: RefCell<HashMap<i32, Vec<Vec<Qux<'static, i32>>>>> = RefCell::new(HashMap::new());
-   |                                            ^^^ ------- supplied 1 lifetime argument
-   |                                            |
-   |                                            expected 2 lifetime arguments
-   |
-note: union defined here, with 2 lifetime parameters: `'t`, `'k`
-  --> $DIR/missing-lifetime-specifier.rs:11:11
-   |
-LL | pub union Qux<'t, 'k, I> {
-   |           ^^^ --  --
-help: add missing lifetime argument
-   |
-LL |     static e: RefCell<HashMap<i32, Vec<Vec<Qux<'static, 'k, i32>>>>> = RefCell::new(HashMap::new());
-   |                                                       ++++
-
-error[E0107]: this union takes 2 lifetime arguments but 1 lifetime argument was supplied
-  --> $DIR/missing-lifetime-specifier.rs:43:44
-   |
-LL |     static e: RefCell<HashMap<i32, Vec<Vec<Qux<'static, i32>>>>> = RefCell::new(HashMap::new());
-   |                                            ^^^ ------- supplied 1 lifetime argument
-   |                                            |
-   |                                            expected 2 lifetime arguments
-   |
-note: union defined here, with 2 lifetime parameters: `'t`, `'k`
-  --> $DIR/missing-lifetime-specifier.rs:11:11
-   |
-LL | pub union Qux<'t, 'k, I> {
-   |           ^^^ --  --
-help: add missing lifetime argument
-   |
-LL |     static e: RefCell<HashMap<i32, Vec<Vec<Qux<'static, '_, i32>>>>> = RefCell::new(HashMap::new());
-   |                                                       ++++
-
-error[E0107]: this trait takes 2 lifetime arguments but 1 lifetime argument was supplied
-  --> $DIR/missing-lifetime-specifier.rs:51:45
-   |
-LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, i32>>>>> = RefCell::new(HashMap::new());
-   |                                             ^^^ ------- supplied 1 lifetime argument
-   |                                             |
-   |                                             expected 2 lifetime arguments
-   |
-note: trait defined here, with 2 lifetime parameters: `'t`, `'k`
-  --> $DIR/missing-lifetime-specifier.rs:15:7
-   |
-LL | trait Tar<'t, 'k, I> {}
-   |       ^^^ --  --
-help: add missing lifetime argument
-   |
-LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, '_, i32>>>>> = RefCell::new(HashMap::new());
-   |                                                        ++++
-
 error[E0106]: missing lifetime specifier
-  --> $DIR/missing-lifetime-specifier.rs:51:44
+  --> $DIR/missing-lifetime-specifier.rs:47:44
    |
 LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, i32>>>>> = RefCell::new(HashMap::new());
    |                                            ^ expected named lifetime parameter
@@ -274,28 +116,10 @@ LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, i32>>>>> = RefCell
 help: consider using the `'static` lifetime
    |
 LL |     static f: RefCell<HashMap<i32, Vec<Vec<&'static Tar<'static, i32>>>>> = RefCell::new(HashMap::new());
-   |                                            ~~~~~~~~
-
-error[E0107]: this trait takes 2 lifetime arguments but 1 lifetime argument was supplied
-  --> $DIR/missing-lifetime-specifier.rs:51:45
-   |
-LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, i32>>>>> = RefCell::new(HashMap::new());
-   |                                             ^^^ ------- supplied 1 lifetime argument
-   |                                             |
-   |                                             expected 2 lifetime arguments
-   |
-note: trait defined here, with 2 lifetime parameters: `'t`, `'k`
-  --> $DIR/missing-lifetime-specifier.rs:15:7
-   |
-LL | trait Tar<'t, 'k, I> {}
-   |       ^^^ --  --
-help: add missing lifetime argument
-   |
-LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, 'k, i32>>>>> = RefCell::new(HashMap::new());
-   |                                                        ++++
+   |                                             +++++++
 
 error[E0106]: missing lifetime specifier
-  --> $DIR/missing-lifetime-specifier.rs:51:44
+  --> $DIR/missing-lifetime-specifier.rs:47:44
    |
 LL | / thread_local! {
 LL | |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, i32>>>>> = RefCell::new(HashMap::new());
@@ -309,44 +133,98 @@ LL | | }
    |
    = help: this function's return type contains a borrowed value, but the signature does not say which one of `init`'s 3 lifetimes it is borrowed from
 
-error[E0107]: this trait takes 2 lifetime arguments but 1 lifetime argument was supplied
-  --> $DIR/missing-lifetime-specifier.rs:51:45
+error[E0107]: this union takes 2 lifetime arguments but 1 lifetime argument was supplied
+  --> $DIR/missing-lifetime-specifier.rs:39:44
    |
-LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, i32>>>>> = RefCell::new(HashMap::new());
-   |                                             ^^^ ------- supplied 1 lifetime argument
-   |                                             |
-   |                                             expected 2 lifetime arguments
+LL |     static e: RefCell<HashMap<i32, Vec<Vec<Qux<'static, i32>>>>> = RefCell::new(HashMap::new());
+   |                                            ^^^ ------- supplied 1 lifetime argument
+   |                                            |
+   |                                            expected 2 lifetime arguments
    |
-note: trait defined here, with 2 lifetime parameters: `'t`, `'k`
-  --> $DIR/missing-lifetime-specifier.rs:15:7
+note: union defined here, with 2 lifetime parameters: `'t`, `'k`
+  --> $DIR/missing-lifetime-specifier.rs:11:11
    |
-LL | trait Tar<'t, 'k, I> {}
-   |       ^^^ --  --
+LL | pub union Qux<'t, 'k, I> {
+   |           ^^^ --  --
 help: add missing lifetime argument
    |
-LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, 'k, i32>>>>> = RefCell::new(HashMap::new());
-   |                                                        ++++
+LL |     static e: RefCell<HashMap<i32, Vec<Vec<Qux<'static, '_, i32>>>>> = RefCell::new(HashMap::new());
+   |                                                       ++++
 
-error[E0107]: this trait takes 2 lifetime arguments but 1 lifetime argument was supplied
-  --> $DIR/missing-lifetime-specifier.rs:51:45
+error[E0107]: this union takes 2 lifetime arguments but 1 lifetime argument was supplied
+  --> $DIR/missing-lifetime-specifier.rs:39:44
    |
-LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, i32>>>>> = RefCell::new(HashMap::new());
-   |                                             ^^^ ------- supplied 1 lifetime argument
-   |                                             |
-   |                                             expected 2 lifetime arguments
+LL |     static e: RefCell<HashMap<i32, Vec<Vec<Qux<'static, i32>>>>> = RefCell::new(HashMap::new());
+   |                                            ^^^ ------- supplied 1 lifetime argument
+   |                                            |
+   |                                            expected 2 lifetime arguments
    |
-note: trait defined here, with 2 lifetime parameters: `'t`, `'k`
-  --> $DIR/missing-lifetime-specifier.rs:15:7
+note: union defined here, with 2 lifetime parameters: `'t`, `'k`
+  --> $DIR/missing-lifetime-specifier.rs:11:11
    |
-LL | trait Tar<'t, 'k, I> {}
-   |       ^^^ --  --
+LL | pub union Qux<'t, 'k, I> {
+   |           ^^^ --  --
 help: add missing lifetime argument
    |
-LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, 'k, i32>>>>> = RefCell::new(HashMap::new());
-   |                                                        ++++
+LL |     static e: RefCell<HashMap<i32, Vec<Vec<Qux<'static, 'k, i32>>>>> = RefCell::new(HashMap::new());
+   |                                                       ++++
+
+error[E0107]: this union takes 2 lifetime arguments but 1 lifetime argument was supplied
+  --> $DIR/missing-lifetime-specifier.rs:39:44
+   |
+LL |     static e: RefCell<HashMap<i32, Vec<Vec<Qux<'static, i32>>>>> = RefCell::new(HashMap::new());
+   |                                            ^^^ ------- supplied 1 lifetime argument
+   |                                            |
+   |                                            expected 2 lifetime arguments
+   |
+note: union defined here, with 2 lifetime parameters: `'t`, `'k`
+  --> $DIR/missing-lifetime-specifier.rs:11:11
+   |
+LL | pub union Qux<'t, 'k, I> {
+   |           ^^^ --  --
+help: add missing lifetime argument
+   |
+LL |     static e: RefCell<HashMap<i32, Vec<Vec<Qux<'static, 'k, i32>>>>> = RefCell::new(HashMap::new());
+   |                                                       ++++
+
+error[E0107]: this union takes 2 lifetime arguments but 1 lifetime argument was supplied
+  --> $DIR/missing-lifetime-specifier.rs:39:44
+   |
+LL |     static e: RefCell<HashMap<i32, Vec<Vec<Qux<'static, i32>>>>> = RefCell::new(HashMap::new());
+   |                                            ^^^ ------- supplied 1 lifetime argument
+   |                                            |
+   |                                            expected 2 lifetime arguments
+   |
+note: union defined here, with 2 lifetime parameters: `'t`, `'k`
+  --> $DIR/missing-lifetime-specifier.rs:11:11
+   |
+LL | pub union Qux<'t, 'k, I> {
+   |           ^^^ --  --
+help: add missing lifetime argument
+   |
+LL |     static e: RefCell<HashMap<i32, Vec<Vec<Qux<'static, 'k, i32>>>>> = RefCell::new(HashMap::new());
+   |                                                       ++++
+
+error[E0107]: this union takes 2 lifetime arguments but 1 lifetime argument was supplied
+  --> $DIR/missing-lifetime-specifier.rs:39:44
+   |
+LL |     static e: RefCell<HashMap<i32, Vec<Vec<Qux<'static, i32>>>>> = RefCell::new(HashMap::new());
+   |                                            ^^^ ------- supplied 1 lifetime argument
+   |                                            |
+   |                                            expected 2 lifetime arguments
+   |
+note: union defined here, with 2 lifetime parameters: `'t`, `'k`
+  --> $DIR/missing-lifetime-specifier.rs:11:11
+   |
+LL | pub union Qux<'t, 'k, I> {
+   |           ^^^ --  --
+help: add missing lifetime argument
+   |
+LL |     static e: RefCell<HashMap<i32, Vec<Vec<Qux<'static, '_, i32>>>>> = RefCell::new(HashMap::new());
+   |                                                       ++++
 
 error[E0107]: this trait takes 2 lifetime arguments but 1 lifetime argument was supplied
-  --> $DIR/missing-lifetime-specifier.rs:51:45
+  --> $DIR/missing-lifetime-specifier.rs:47:45
    |
 LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, i32>>>>> = RefCell::new(HashMap::new());
    |                                             ^^^ ------- supplied 1 lifetime argument
@@ -363,7 +241,79 @@ help: add missing lifetime argument
 LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, '_, i32>>>>> = RefCell::new(HashMap::new());
    |                                                        ++++
 
-error: aborting due to 24 previous errors
+error[E0107]: this trait takes 2 lifetime arguments but 1 lifetime argument was supplied
+  --> $DIR/missing-lifetime-specifier.rs:47:45
+   |
+LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, i32>>>>> = RefCell::new(HashMap::new());
+   |                                             ^^^ ------- supplied 1 lifetime argument
+   |                                             |
+   |                                             expected 2 lifetime arguments
+   |
+note: trait defined here, with 2 lifetime parameters: `'t`, `'k`
+  --> $DIR/missing-lifetime-specifier.rs:15:7
+   |
+LL | trait Tar<'t, 'k, I> {}
+   |       ^^^ --  --
+help: add missing lifetime argument
+   |
+LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, 'k, i32>>>>> = RefCell::new(HashMap::new());
+   |                                                        ++++
+
+error[E0107]: this trait takes 2 lifetime arguments but 1 lifetime argument was supplied
+  --> $DIR/missing-lifetime-specifier.rs:47:45
+   |
+LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, i32>>>>> = RefCell::new(HashMap::new());
+   |                                             ^^^ ------- supplied 1 lifetime argument
+   |                                             |
+   |                                             expected 2 lifetime arguments
+   |
+note: trait defined here, with 2 lifetime parameters: `'t`, `'k`
+  --> $DIR/missing-lifetime-specifier.rs:15:7
+   |
+LL | trait Tar<'t, 'k, I> {}
+   |       ^^^ --  --
+help: add missing lifetime argument
+   |
+LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, 'k, i32>>>>> = RefCell::new(HashMap::new());
+   |                                                        ++++
+
+error[E0107]: this trait takes 2 lifetime arguments but 1 lifetime argument was supplied
+  --> $DIR/missing-lifetime-specifier.rs:47:45
+   |
+LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, i32>>>>> = RefCell::new(HashMap::new());
+   |                                             ^^^ ------- supplied 1 lifetime argument
+   |                                             |
+   |                                             expected 2 lifetime arguments
+   |
+note: trait defined here, with 2 lifetime parameters: `'t`, `'k`
+  --> $DIR/missing-lifetime-specifier.rs:15:7
+   |
+LL | trait Tar<'t, 'k, I> {}
+   |       ^^^ --  --
+help: add missing lifetime argument
+   |
+LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, 'k, i32>>>>> = RefCell::new(HashMap::new());
+   |                                                        ++++
+
+error[E0107]: this trait takes 2 lifetime arguments but 1 lifetime argument was supplied
+  --> $DIR/missing-lifetime-specifier.rs:47:45
+   |
+LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, i32>>>>> = RefCell::new(HashMap::new());
+   |                                             ^^^ ------- supplied 1 lifetime argument
+   |                                             |
+   |                                             expected 2 lifetime arguments
+   |
+note: trait defined here, with 2 lifetime parameters: `'t`, `'k`
+  --> $DIR/missing-lifetime-specifier.rs:15:7
+   |
+LL | trait Tar<'t, 'k, I> {}
+   |       ^^^ --  --
+help: add missing lifetime argument
+   |
+LL |     static f: RefCell<HashMap<i32, Vec<Vec<&Tar<'static, '_, i32>>>>> = RefCell::new(HashMap::new());
+   |                                                        ++++
+
+error: aborting due to 20 previous errors
 
 Some errors have detailed explanations: E0106, E0107.
 For more information about an error, try `rustc --explain E0106`.

--- a/src/test/ui/suggestions/missing-lt-for-hrtb.rs
+++ b/src/test/ui/suggestions/missing-lt-for-hrtb.rs
@@ -1,15 +1,15 @@
 struct X<'a>(&'a ());
 struct S<'a>(&'a dyn Fn(&X) -> &X);
-//~^ ERROR missing lifetime specifier
-//~| ERROR missing lifetime specifier
+//~^ ERROR missing lifetime specifiers
 struct V<'a>(&'a dyn for<'b> Fn(&X) -> &X);
-//~^ ERROR missing lifetime specifier
-//~| ERROR missing lifetime specifier
+//~^ ERROR missing lifetime specifiers
 
 fn main() {
     let x = S(&|x| {
         println!("hi");
         x
+        //~^ ERROR lifetime of reference outlives lifetime of borrowed content... [E0312]
+        //~| ERROR mismatched types
     });
     x.0(&X(&()));
 }

--- a/src/test/ui/suggestions/missing-lt-for-hrtb.stderr
+++ b/src/test/ui/suggestions/missing-lt-for-hrtb.stderr
@@ -1,67 +1,77 @@
-error[E0106]: missing lifetime specifier
+error[E0106]: missing lifetime specifiers
   --> $DIR/missing-lt-for-hrtb.rs:2:32
    |
 LL | struct S<'a>(&'a dyn Fn(&X) -> &X);
-   |                         --     ^ expected named lifetime parameter
+   |                         --     ^^ expected named lifetime parameter
+   |                                |
+   |                                expected named lifetime parameter
    |
    = help: this function's return type contains a borrowed value, but the signature does not say which one of argument 1's 2 lifetimes it is borrowed from
-   = note: for more information on higher-ranked polymorphism, visit https://doc.rust-lang.org/nomicon/hrtb.html
-help: consider making the bound lifetime-generic with a new `'b` lifetime
-   |
-LL | struct S<'a>(&'a dyn for<'b> Fn(&'b X) -> &'b X);
-   |                      +++++++    ~~~~~     ~~~
 help: consider using the `'a` lifetime
    |
-LL | struct S<'a>(&'a dyn Fn(&X) -> &'a X);
-   |                                ~~~
+LL | struct S<'a>(&'a dyn Fn(&X) -> &'a X<'a>);
+   |                                 ++  ++++
 
-error[E0106]: missing lifetime specifier
-  --> $DIR/missing-lt-for-hrtb.rs:2:33
-   |
-LL | struct S<'a>(&'a dyn Fn(&X) -> &X);
-   |                         --      ^ expected named lifetime parameter
-   |
-   = help: this function's return type contains a borrowed value, but the signature does not say which one of argument 1's 2 lifetimes it is borrowed from
-   = note: for more information on higher-ranked polymorphism, visit https://doc.rust-lang.org/nomicon/hrtb.html
-help: consider making the bound lifetime-generic with a new `'b` lifetime
-   |
-LL | struct S<'a>(&'a dyn for<'b> Fn(&'b X) -> &X<'b>);
-   |                      +++++++    ~~~~~      ~~~~~
-help: consider using the `'a` lifetime
-   |
-LL | struct S<'a>(&'a dyn Fn(&X) -> &X<'a>);
-   |                                 ~~~~~
-
-error[E0106]: missing lifetime specifier
-  --> $DIR/missing-lt-for-hrtb.rs:5:40
+error[E0106]: missing lifetime specifiers
+  --> $DIR/missing-lt-for-hrtb.rs:4:40
    |
 LL | struct V<'a>(&'a dyn for<'b> Fn(&X) -> &X);
-   |                                 --     ^ expected named lifetime parameter
+   |                                 --     ^^ expected named lifetime parameter
+   |                                        |
+   |                                        expected named lifetime parameter
    |
    = help: this function's return type contains a borrowed value, but the signature does not say which one of argument 1's 2 lifetimes it is borrowed from
 note: these named lifetimes are available to use
-  --> $DIR/missing-lt-for-hrtb.rs:5:10
+  --> $DIR/missing-lt-for-hrtb.rs:4:10
    |
 LL | struct V<'a>(&'a dyn for<'b> Fn(&X) -> &X);
    |          ^^              ^^
 help: consider using one of the available lifetimes here
    |
-LL | struct V<'a>(&'a dyn for<'b> Fn(&X) -> &'lifetime X);
-   |                                         +++++++++
+LL | struct V<'a>(&'a dyn for<'b> Fn(&X) -> &'lifetime X<'lifetime>);
+   |                                         +++++++++  +++++++++++
 
-error[E0106]: missing lifetime specifier
-  --> $DIR/missing-lt-for-hrtb.rs:5:41
+error[E0312]: lifetime of reference outlives lifetime of borrowed content...
+  --> $DIR/missing-lt-for-hrtb.rs:10:9
    |
-LL | struct V<'a>(&'a dyn for<'b> Fn(&X) -> &X);
-   |                                 --      ^ expected named lifetime parameter
+LL |         x
+   |         ^
    |
-   = help: this function's return type contains a borrowed value, but the signature does not say which one of argument 1's 2 lifetimes it is borrowed from
-note: these named lifetimes are available to use
-  --> $DIR/missing-lt-for-hrtb.rs:5:10
+   = note: ...the reference is valid for the static lifetime...
+note: ...but the borrowed content is only valid for the anonymous lifetime #1 defined here
+  --> $DIR/missing-lt-for-hrtb.rs:8:16
    |
-LL | struct V<'a>(&'a dyn for<'b> Fn(&X) -> &X);
-   |          ^^              ^^
+LL |       let x = S(&|x| {
+   |  ________________^
+LL | |         println!("hi");
+LL | |         x
+LL | |
+LL | |
+LL | |     });
+   | |_____^
+
+error[E0308]: mismatched types
+  --> $DIR/missing-lt-for-hrtb.rs:10:9
+   |
+LL |         x
+   |         ^ lifetime mismatch
+   |
+   = note: expected reference `&'static X<'static>`
+              found reference `&'static X<'_>`
+note: the anonymous lifetime #2 defined here...
+  --> $DIR/missing-lt-for-hrtb.rs:8:16
+   |
+LL |       let x = S(&|x| {
+   |  ________________^
+LL | |         println!("hi");
+LL | |         x
+LL | |
+LL | |
+LL | |     });
+   | |_____^
+   = note: ...does not necessarily outlive the static lifetime
 
 error: aborting due to 4 previous errors
 
-For more information about this error, try `rustc --explain E0106`.
+Some errors have detailed explanations: E0106, E0308, E0312.
+For more information about an error, try `rustc --explain E0106`.

--- a/src/test/ui/suggestions/return-elided-lifetime.rs
+++ b/src/test/ui/suggestions/return-elided-lifetime.rs
@@ -6,32 +6,27 @@
 fn f1() -> &i32 { loop {} }
 //~^ ERROR missing lifetime specifier [E0106]
 fn f1_() -> (&i32, &i32) { loop {} }
-//~^ ERROR missing lifetime specifier [E0106]
-//~^^ ERROR missing lifetime specifier [E0106]
+//~^ ERROR missing lifetime specifiers [E0106]
 
 fn f2(a: i32, b: i32) -> &i32 { loop {} }
 //~^ ERROR missing lifetime specifier [E0106]
 fn f2_(a: i32, b: i32) -> (&i32, &i32) { loop {} }
-//~^ ERROR missing lifetime specifier [E0106]
-//~^^ ERROR missing lifetime specifier [E0106]
+//~^ ERROR missing lifetime specifiers [E0106]
 
 struct S<'a, 'b> { a: &'a i32, b: &'b i32 }
 fn f3(s: &S) -> &i32 { loop {} }
 //~^ ERROR missing lifetime specifier [E0106]
 fn f3_(s: &S, t: &S) -> (&i32, &i32) { loop {} }
-//~^ ERROR missing lifetime specifier [E0106]
-//~^^ ERROR missing lifetime specifier [E0106]
+//~^ ERROR missing lifetime specifiers [E0106]
 
 fn f4<'a, 'b>(a: &'a i32, b: &'b i32) -> &i32 { loop {} }
 //~^ ERROR missing lifetime specifier [E0106]
 fn f4_<'a, 'b>(a: &'a i32, b: &'b i32) -> (&i32, &i32) { loop {} }
-//~^ ERROR missing lifetime specifier [E0106]
-//~^^ ERROR missing lifetime specifier [E0106]
+//~^ ERROR missing lifetime specifiers [E0106]
 
 fn f5<'a>(a: &'a i32, b: &i32) -> &i32 { loop {} }
 //~^ ERROR missing lifetime specifier [E0106]
 fn f5_<'a>(a: &'a i32, b: &i32) -> (&i32, &i32) { loop {} }
-//~^ ERROR missing lifetime specifier [E0106]
-//~^^ ERROR missing lifetime specifier [E0106]
+//~^ ERROR missing lifetime specifiers [E0106]
 
 fn main() {}

--- a/src/test/ui/suggestions/return-elided-lifetime.stderr
+++ b/src/test/ui/suggestions/return-elided-lifetime.stderr
@@ -8,70 +8,50 @@ LL | fn f1() -> &i32 { loop {} }
 help: consider using the `'static` lifetime
    |
 LL | fn f1() -> &'static i32 { loop {} }
-   |            ~~~~~~~~
+   |             +++++++
 
-error[E0106]: missing lifetime specifier
+error[E0106]: missing lifetime specifiers
   --> $DIR/return-elided-lifetime.rs:8:14
    |
 LL | fn f1_() -> (&i32, &i32) { loop {} }
-   |              ^ expected named lifetime parameter
+   |              ^     ^ expected named lifetime parameter
+   |              |
+   |              expected named lifetime parameter
    |
    = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
 help: consider using the `'static` lifetime
    |
-LL | fn f1_() -> (&'static i32, &i32) { loop {} }
-   |              ~~~~~~~~
+LL | fn f1_() -> (&'static i32, &'static i32) { loop {} }
+   |               +++++++       +++++++
 
 error[E0106]: missing lifetime specifier
-  --> $DIR/return-elided-lifetime.rs:8:20
-   |
-LL | fn f1_() -> (&i32, &i32) { loop {} }
-   |                    ^ expected named lifetime parameter
-   |
-   = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
-help: consider using the `'static` lifetime
-   |
-LL | fn f1_() -> (&i32, &'static i32) { loop {} }
-   |                    ~~~~~~~~
-
-error[E0106]: missing lifetime specifier
-  --> $DIR/return-elided-lifetime.rs:12:26
+  --> $DIR/return-elided-lifetime.rs:11:26
    |
 LL | fn f2(a: i32, b: i32) -> &i32 { loop {} }
    |                          ^ expected named lifetime parameter
    |
-   = help: this function's return type contains a borrowed value with an elided lifetime, but the lifetime cannot be derived from the arguments
+   = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
 help: consider using the `'static` lifetime
    |
 LL | fn f2(a: i32, b: i32) -> &'static i32 { loop {} }
-   |                          ~~~~~~~~
+   |                           +++++++
 
-error[E0106]: missing lifetime specifier
-  --> $DIR/return-elided-lifetime.rs:14:28
+error[E0106]: missing lifetime specifiers
+  --> $DIR/return-elided-lifetime.rs:13:28
    |
 LL | fn f2_(a: i32, b: i32) -> (&i32, &i32) { loop {} }
-   |                            ^ expected named lifetime parameter
+   |                            ^     ^ expected named lifetime parameter
+   |                            |
+   |                            expected named lifetime parameter
    |
-   = help: this function's return type contains a borrowed value with an elided lifetime, but the lifetime cannot be derived from the arguments
+   = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
 help: consider using the `'static` lifetime
    |
-LL | fn f2_(a: i32, b: i32) -> (&'static i32, &i32) { loop {} }
-   |                            ~~~~~~~~
+LL | fn f2_(a: i32, b: i32) -> (&'static i32, &'static i32) { loop {} }
+   |                             +++++++       +++++++
 
 error[E0106]: missing lifetime specifier
-  --> $DIR/return-elided-lifetime.rs:14:34
-   |
-LL | fn f2_(a: i32, b: i32) -> (&i32, &i32) { loop {} }
-   |                                  ^ expected named lifetime parameter
-   |
-   = help: this function's return type contains a borrowed value with an elided lifetime, but the lifetime cannot be derived from the arguments
-help: consider using the `'static` lifetime
-   |
-LL | fn f2_(a: i32, b: i32) -> (&i32, &'static i32) { loop {} }
-   |                                  ~~~~~~~~
-
-error[E0106]: missing lifetime specifier
-  --> $DIR/return-elided-lifetime.rs:19:17
+  --> $DIR/return-elided-lifetime.rs:17:17
    |
 LL | fn f3(s: &S) -> &i32 { loop {} }
    |          --     ^ expected named lifetime parameter
@@ -79,86 +59,51 @@ LL | fn f3(s: &S) -> &i32 { loop {} }
    = help: this function's return type contains a borrowed value, but the signature does not say which one of `s`'s 3 lifetimes it is borrowed from
 help: consider introducing a named lifetime parameter
    |
-LL | fn f3<'a>(s: &'a S) -> &'a i32 { loop {} }
-   |      ++++     ++        ++
+LL | fn f3<'a>(s: &S) -> &'a i32 { loop {} }
+   |      ++++            ++
 
-error[E0106]: missing lifetime specifier
-  --> $DIR/return-elided-lifetime.rs:21:26
+error[E0106]: missing lifetime specifiers
+  --> $DIR/return-elided-lifetime.rs:19:26
    |
 LL | fn f3_(s: &S, t: &S) -> (&i32, &i32) { loop {} }
-   |           --     --      ^ expected named lifetime parameter
+   |           --     --      ^     ^ expected named lifetime parameter
+   |                          |
+   |                          expected named lifetime parameter
    |
    = help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from one of `s`'s 3 lifetimes or one of `t`'s 3 lifetimes
 help: consider introducing a named lifetime parameter
    |
-LL | fn f3_<'a>(s: &'a S, t: &'a S) -> (&'a i32, &i32) { loop {} }
-   |       ++++     ++        ++         ++
+LL | fn f3_<'a>(s: &S, t: &S) -> (&'a i32, &'a i32) { loop {} }
+   |       ++++                    ++       ++
 
 error[E0106]: missing lifetime specifier
-  --> $DIR/return-elided-lifetime.rs:21:32
-   |
-LL | fn f3_(s: &S, t: &S) -> (&i32, &i32) { loop {} }
-   |           --     --            ^ expected named lifetime parameter
-   |
-   = help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from one of `s`'s 3 lifetimes or one of `t`'s 3 lifetimes
-help: consider introducing a named lifetime parameter
-   |
-LL | fn f3_<'a>(s: &'a S, t: &'a S) -> (&i32, &'a i32) { loop {} }
-   |       ++++     ++        ++               ++
-
-error[E0106]: missing lifetime specifier
-  --> $DIR/return-elided-lifetime.rs:25:42
+  --> $DIR/return-elided-lifetime.rs:22:42
    |
 LL | fn f4<'a, 'b>(a: &'a i32, b: &'b i32) -> &i32 { loop {} }
    |                  -------     -------     ^ expected named lifetime parameter
    |
-   = help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from `a` or `b`
-note: these named lifetimes are available to use
-  --> $DIR/return-elided-lifetime.rs:25:7
+   = help: this function's return type contains a borrowed value with an elided lifetime, but the lifetime cannot be derived from the arguments
+help: consider using the `'static` lifetime
    |
-LL | fn f4<'a, 'b>(a: &'a i32, b: &'b i32) -> &i32 { loop {} }
-   |       ^^  ^^
-help: consider using one of the available lifetimes here
+LL | fn f4<'a, 'b>(a: &'a i32, b: &'b i32) -> &'static i32 { loop {} }
+   |                                           +++++++
+
+error[E0106]: missing lifetime specifiers
+  --> $DIR/return-elided-lifetime.rs:24:44
    |
-LL | fn f4<'a, 'b>(a: &'a i32, b: &'b i32) -> &'lifetime i32 { loop {} }
-   |                                           +++++++++
+LL | fn f4_<'a, 'b>(a: &'a i32, b: &'b i32) -> (&i32, &i32) { loop {} }
+   |                   -------     -------      ^     ^ expected named lifetime parameter
+   |                                            |
+   |                                            expected named lifetime parameter
+   |
+   = help: this function's return type contains a borrowed value with an elided lifetime, but the lifetime cannot be derived from the arguments
+help: consider using the `'static` lifetime
+   |
+LL | fn f4_<'a, 'b>(a: &'a i32, b: &'b i32) -> (&'static i32, &'static i32) { loop {} }
+   |                                             +++++++       +++++++
 
 error[E0106]: missing lifetime specifier
-  --> $DIR/return-elided-lifetime.rs:27:44
-   |
-LL | fn f4_<'a, 'b>(a: &'a i32, b: &'b i32) -> (&i32, &i32) { loop {} }
-   |                   -------     -------      ^ expected named lifetime parameter
-   |
-   = help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from `a` or `b`
-note: these named lifetimes are available to use
-  --> $DIR/return-elided-lifetime.rs:27:8
-   |
-LL | fn f4_<'a, 'b>(a: &'a i32, b: &'b i32) -> (&i32, &i32) { loop {} }
-   |        ^^  ^^
-help: consider using one of the available lifetimes here
-   |
-LL | fn f4_<'a, 'b>(a: &'a i32, b: &'b i32) -> (&'lifetime i32, &i32) { loop {} }
-   |                                             +++++++++
-
-error[E0106]: missing lifetime specifier
-  --> $DIR/return-elided-lifetime.rs:27:50
-   |
-LL | fn f4_<'a, 'b>(a: &'a i32, b: &'b i32) -> (&i32, &i32) { loop {} }
-   |                   -------     -------            ^ expected named lifetime parameter
-   |
-   = help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from `a` or `b`
-note: these named lifetimes are available to use
-  --> $DIR/return-elided-lifetime.rs:27:8
-   |
-LL | fn f4_<'a, 'b>(a: &'a i32, b: &'b i32) -> (&i32, &i32) { loop {} }
-   |        ^^  ^^
-help: consider using one of the available lifetimes here
-   |
-LL | fn f4_<'a, 'b>(a: &'a i32, b: &'b i32) -> (&i32, &'lifetime i32) { loop {} }
-   |                                                   +++++++++
-
-error[E0106]: missing lifetime specifier
-  --> $DIR/return-elided-lifetime.rs:31:35
+  --> $DIR/return-elided-lifetime.rs:27:35
    |
 LL | fn f5<'a>(a: &'a i32, b: &i32) -> &i32 { loop {} }
    |              -------     ----     ^ expected named lifetime parameter
@@ -167,32 +112,22 @@ LL | fn f5<'a>(a: &'a i32, b: &i32) -> &i32 { loop {} }
 help: consider using the `'a` lifetime
    |
 LL | fn f5<'a>(a: &'a i32, b: &i32) -> &'a i32 { loop {} }
-   |                                   ~~~
+   |                                    ++
 
-error[E0106]: missing lifetime specifier
-  --> $DIR/return-elided-lifetime.rs:33:37
+error[E0106]: missing lifetime specifiers
+  --> $DIR/return-elided-lifetime.rs:29:37
    |
 LL | fn f5_<'a>(a: &'a i32, b: &i32) -> (&i32, &i32) { loop {} }
-   |               -------     ----      ^ expected named lifetime parameter
+   |               -------     ----      ^     ^ expected named lifetime parameter
+   |                                     |
+   |                                     expected named lifetime parameter
    |
    = help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from `a` or `b`
 help: consider using the `'a` lifetime
    |
-LL | fn f5_<'a>(a: &'a i32, b: &i32) -> (&'a i32, &i32) { loop {} }
-   |                                     ~~~
+LL | fn f5_<'a>(a: &'a i32, b: &i32) -> (&'a i32, &'a i32) { loop {} }
+   |                                      ++       ++
 
-error[E0106]: missing lifetime specifier
-  --> $DIR/return-elided-lifetime.rs:33:43
-   |
-LL | fn f5_<'a>(a: &'a i32, b: &i32) -> (&i32, &i32) { loop {} }
-   |               -------     ----            ^ expected named lifetime parameter
-   |
-   = help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from `a` or `b`
-help: consider using the `'a` lifetime
-   |
-LL | fn f5_<'a>(a: &'a i32, b: &i32) -> (&i32, &'a i32) { loop {} }
-   |                                           ~~~
-
-error: aborting due to 15 previous errors
+error: aborting due to 10 previous errors
 
 For more information about this error, try `rustc --explain E0106`.

--- a/src/test/ui/suggestions/return-without-lifetime.rs
+++ b/src/test/ui/suggestions/return-without-lifetime.rs
@@ -1,6 +1,7 @@
 struct Thing<'a>(&'a ());
 struct Foo<'a>(&usize);
 //~^ ERROR missing lifetime specifier
+//~| ERROR parameter `'a` is never used [E0392]
 
 fn func1<'a>(_arg: &'a Thing) -> &() { unimplemented!() }
 //~^ ERROR missing lifetime specifier

--- a/src/test/ui/suggestions/return-without-lifetime.stderr
+++ b/src/test/ui/suggestions/return-without-lifetime.stderr
@@ -7,10 +7,10 @@ LL | struct Foo<'a>(&usize);
 help: consider using the `'a` lifetime
    |
 LL | struct Foo<'a>(&'a usize);
-   |                ~~~
+   |                 ++
 
 error[E0106]: missing lifetime specifier
-  --> $DIR/return-without-lifetime.rs:5:34
+  --> $DIR/return-without-lifetime.rs:6:34
    |
 LL | fn func1<'a>(_arg: &'a Thing) -> &() { unimplemented!() }
    |                    ---------     ^ expected named lifetime parameter
@@ -19,10 +19,10 @@ LL | fn func1<'a>(_arg: &'a Thing) -> &() { unimplemented!() }
 help: consider using the `'a` lifetime
    |
 LL | fn func1<'a>(_arg: &'a Thing) -> &'a () { unimplemented!() }
-   |                                  ~~~
+   |                                   ++
 
 error[E0106]: missing lifetime specifier
-  --> $DIR/return-without-lifetime.rs:7:35
+  --> $DIR/return-without-lifetime.rs:8:35
    |
 LL | fn func2<'a>(_arg: &Thing<'a>) -> &() { unimplemented!() }
    |                    ----------     ^ expected named lifetime parameter
@@ -31,8 +31,17 @@ LL | fn func2<'a>(_arg: &Thing<'a>) -> &() { unimplemented!() }
 help: consider using the `'a` lifetime
    |
 LL | fn func2<'a>(_arg: &Thing<'a>) -> &'a () { unimplemented!() }
-   |                                   ~~~
+   |                                    ++
 
-error: aborting due to 3 previous errors
+error[E0392]: parameter `'a` is never used
+  --> $DIR/return-without-lifetime.rs:2:12
+   |
+LL | struct Foo<'a>(&usize);
+   |            ^^ unused parameter
+   |
+   = help: consider removing `'a`, referring to it in a field, or using a marker such as `PhantomData`
 
-For more information about this error, try `rustc --explain E0106`.
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0106, E0392.
+For more information about an error, try `rustc --explain E0106`.

--- a/src/test/ui/unboxed-closures/unboxed-closure-sugar-lifetime-elision.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closure-sugar-lifetime-elision.stderr
@@ -5,6 +5,11 @@ LL |     let _: dyn Foo(&isize, &usize) -> &usize;
    |                    ------  ------     ^ expected named lifetime parameter
    |
    = help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from argument 1 or argument 2
+   = note: for more information on higher-ranked polymorphism, visit https://doc.rust-lang.org/nomicon/hrtb.html
+help: consider making the bound lifetime-generic with a new `'a` lifetime
+   |
+LL |     let _: dyn for<'a> Foo(&isize, &usize) -> &'a usize;
+   |                +++++++                         ++
 help: consider introducing a named lifetime parameter
    |
 LL ~ fn main<'a>() {

--- a/src/test/ui/underscore-lifetime/dyn-trait-underscore-in-struct.rs
+++ b/src/test/ui/underscore-lifetime/dyn-trait-underscore-in-struct.rs
@@ -7,7 +7,6 @@ use std::fmt::Debug;
 
 struct Foo {
     x: Box<dyn Debug + '_>, //~ ERROR missing lifetime specifier
-    //~^ ERROR E0228
 }
 
-fn main() { }
+fn main() {}

--- a/src/test/ui/underscore-lifetime/dyn-trait-underscore-in-struct.stderr
+++ b/src/test/ui/underscore-lifetime/dyn-trait-underscore-in-struct.stderr
@@ -10,13 +10,6 @@ LL ~ struct Foo<'a> {
 LL ~     x: Box<dyn Debug + 'a>,
    |
 
-error[E0228]: the lifetime bound for this object type cannot be deduced from context; please supply an explicit bound
-  --> $DIR/dyn-trait-underscore-in-struct.rs:9:12
-   |
-LL |     x: Box<dyn Debug + '_>,
-   |            ^^^^^^^^^^^^^^
+error: aborting due to previous error
 
-error: aborting due to 2 previous errors
-
-Some errors have detailed explanations: E0106, E0228.
-For more information about an error, try `rustc --explain E0106`.
+For more information about this error, try `rustc --explain E0106`.

--- a/src/test/ui/underscore-lifetime/in-fn-return-illegal.stderr
+++ b/src/test/ui/underscore-lifetime/in-fn-return-illegal.stderr
@@ -7,8 +7,8 @@ LL | fn foo(x: &u32, y: &u32) -> &'_ u32 { loop { } }
    = help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from `x` or `y`
 help: consider introducing a named lifetime parameter
    |
-LL | fn foo<'a>(x: &'a u32, y: &'a u32) -> &'a u32 { loop { } }
-   |       ++++     ++          ++          ~~
+LL | fn foo<'a>(x: &u32, y: &u32) -> &'a u32 { loop { } }
+   |       ++++                       ~~
 
 error: aborting due to previous error
 

--- a/src/test/ui/underscore-lifetime/underscore-lifetime-binders.rs
+++ b/src/test/ui/underscore-lifetime/underscore-lifetime-binders.rs
@@ -1,5 +1,6 @@
 struct Foo<'a>(&'a u8);
 struct Baz<'a>(&'_ &'a u8); //~ ERROR missing lifetime specifier
+//~^ ERROR in type `&'static &'a u8`, reference has a longer lifetime than the data it references
 
 fn foo<'_> //~ ERROR cannot be used here
 (_: Foo<'_>) {}

--- a/src/test/ui/underscore-lifetime/underscore-lifetime-binders.stderr
+++ b/src/test/ui/underscore-lifetime/underscore-lifetime-binders.stderr
@@ -1,15 +1,3 @@
-error[E0637]: `'_` cannot be used here
-  --> $DIR/underscore-lifetime-binders.rs:4:8
-   |
-LL | fn foo<'_>
-   |        ^^ `'_` is a reserved lifetime name
-
-error[E0637]: `'_` cannot be used here
-  --> $DIR/underscore-lifetime-binders.rs:10:25
-   |
-LL | fn meh() -> Box<dyn for<'_> Meh<'_>>
-   |                         ^^ `'_` is a reserved lifetime name
-
 error[E0106]: missing lifetime specifier
   --> $DIR/underscore-lifetime-binders.rs:2:17
    |
@@ -21,8 +9,20 @@ help: consider using the `'a` lifetime
 LL | struct Baz<'a>(&'a &'a u8);
    |                 ~~
 
+error[E0637]: `'_` cannot be used here
+  --> $DIR/underscore-lifetime-binders.rs:5:8
+   |
+LL | fn foo<'_>
+   |        ^^ `'_` is a reserved lifetime name
+
+error[E0637]: `'_` cannot be used here
+  --> $DIR/underscore-lifetime-binders.rs:11:25
+   |
+LL | fn meh() -> Box<dyn for<'_> Meh<'_>>
+   |                         ^^ `'_` is a reserved lifetime name
+
 error[E0106]: missing lifetime specifier
-  --> $DIR/underscore-lifetime-binders.rs:10:33
+  --> $DIR/underscore-lifetime-binders.rs:11:33
    |
 LL | fn meh() -> Box<dyn for<'_> Meh<'_>>
    |                                 ^^ expected named lifetime parameter
@@ -34,7 +34,7 @@ LL | fn meh() -> Box<dyn for<'_> Meh<'static>>
    |                                 ~~~~~~~
 
 error[E0106]: missing lifetime specifier
-  --> $DIR/underscore-lifetime-binders.rs:16:35
+  --> $DIR/underscore-lifetime-binders.rs:17:35
    |
 LL | fn foo2(_: &'_ u8, y: &'_ u8) -> &'_ u8 { y }
    |            ------     ------      ^^ expected named lifetime parameter
@@ -42,10 +42,23 @@ LL | fn foo2(_: &'_ u8, y: &'_ u8) -> &'_ u8 { y }
    = help: this function's return type contains a borrowed value, but the signature does not say whether it is borrowed from argument 1 or `y`
 help: consider introducing a named lifetime parameter
    |
-LL | fn foo2<'a>(_: &'a u8, y: &'a u8) -> &'a u8 { y }
-   |        ++++     ~~         ~~         ~~
+LL | fn foo2<'a>(_: &'_ u8, y: &'_ u8) -> &'a u8 { y }
+   |        ++++                           ~~
 
-error: aborting due to 5 previous errors
+error[E0491]: in type `&'static &'a u8`, reference has a longer lifetime than the data it references
+  --> $DIR/underscore-lifetime-binders.rs:2:16
+   |
+LL | struct Baz<'a>(&'_ &'a u8);
+   |                ^^^^^^^^^^
+   |
+   = note: the pointer is valid for the static lifetime
+note: but the referenced data is only valid for the lifetime `'a` as defined here
+  --> $DIR/underscore-lifetime-binders.rs:2:12
+   |
+LL | struct Baz<'a>(&'_ &'a u8);
+   |            ^^
 
-Some errors have detailed explanations: E0106, E0637.
+error: aborting due to 6 previous errors
+
+Some errors have detailed explanations: E0106, E0491, E0637.
 For more information about an error, try `rustc --explain E0106`.


### PR DESCRIPTION
Based on https://github.com/rust-lang/rust/pull/95776 and https://github.com/rust-lang/rust/pull/96559.

This PR moves the elision failure diagnostics ("expected named lifetime") from HIR to the AST.
This is is done by introducing a pair of functions `resolve_fn_like_elision` which handles ribs for functions and `elision_lifetime` which resolve parameters and return the proper lifetime for elision.

I am not very confident in the elision logic: the currently implemented code allows a few more cases than is specified in the documentation. For instance, this is allowed:
```
fn foo(x: Pin<&Self>, y: &u32) -> &u64
```

This PR is WIP since its handling of impl-trait is a bit ad-hoc until https://github.com/rust-lang/rust/issues/96529 is resolved.