### PR TITLE
Also report the call site of PME errors locally.

### DIFF
--- a/src/test/ui/consts/const-eval/issue-50814-2.stderr
+++ b/src/test/ui/consts/const-eval/issue-50814-2.stderr
@@ -16,6 +16,12 @@ error[E0080]: evaluation of `foo::<()>` failed
 LL |     &<A<T> as Foo<T>>::BAR
    |      ^^^^^^^^^^^^^^^^^^^^^ referenced constant has errors
 
+note: the above error was encountered while instantiating `fn foo::<()>`
+  --> $DIR/issue-50814-2.rs:31:22
+   |
+LL |     println!("{:x}", foo::<()>() as *const usize as usize);
+   |                      ^^^^^^^^^^^
+
 error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/consts/const-eval/issue-50814.stderr
+++ b/src/test/ui/consts/const-eval/issue-50814.stderr
@@ -16,6 +16,12 @@ error[E0080]: evaluation of `foo::<i32>` failed
 LL |     &Sum::<U8,U8>::MAX
    |      ^^^^^^^^^^^^^^^^^ referenced constant has errors
 
+note: the above error was encountered while instantiating `fn foo::<i32>`
+  --> $DIR/issue-50814.rs:26:5
+   |
+LL |     foo(0);
+   |     ^^^^^^
+
 error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/generics/post_monomorphization_error_backtrace.rs
+++ b/src/test/ui/generics/post_monomorphization_error_backtrace.rs
@@ -1,0 +1,33 @@
+// build-fail
+
+fn assert_zst<T>() {
+    struct F<T>(T);
+    impl<T> F<T> {
+        const V: () = assert!(std::mem::size_of::<T>() == 0);
+        //~^ ERROR: evaluation of `assert_zst::F::<u32>::V` failed [E0080]
+        //~| NOTE: in this expansion of assert!
+        //~| NOTE: the evaluated program panicked
+        //~| ERROR: evaluation of `assert_zst::F::<i32>::V` failed [E0080]
+        //~| NOTE: in this expansion of assert!
+        //~| NOTE: the evaluated program panicked
+    }
+    let _ = F::<T>::V;
+}
+
+fn foo<U>() {
+    assert_zst::<U>()
+    //~^ NOTE: the above error was encountered while instantiating `fn assert_zst::<u32>`
+    //~| NOTE: the above error was encountered while instantiating `fn assert_zst::<i32>`
+}
+
+
+fn bar<V>() {
+    foo::<V>()
+}
+
+fn main() {
+    bar::<()>();
+    bar::<u32>();
+    bar::<u32>();
+    bar::<i32>();
+}

--- a/src/test/ui/generics/post_monomorphization_error_backtrace.stderr
+++ b/src/test/ui/generics/post_monomorphization_error_backtrace.stderr
@@ -1,0 +1,31 @@
+error[E0080]: evaluation of `assert_zst::F::<u32>::V` failed
+  --> $DIR/post_monomorphization_error_backtrace.rs:6:23
+   |
+LL |         const V: () = assert!(std::mem::size_of::<T>() == 0);
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'assertion failed: std::mem::size_of::<T>() == 0', $DIR/post_monomorphization_error_backtrace.rs:6:23
+   |
+   = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+note: the above error was encountered while instantiating `fn assert_zst::<u32>`
+  --> $DIR/post_monomorphization_error_backtrace.rs:18:5
+   |
+LL |     assert_zst::<U>()
+   |     ^^^^^^^^^^^^^^^^^
+
+error[E0080]: evaluation of `assert_zst::F::<i32>::V` failed
+  --> $DIR/post_monomorphization_error_backtrace.rs:6:23
+   |
+LL |         const V: () = assert!(std::mem::size_of::<T>() == 0);
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'assertion failed: std::mem::size_of::<T>() == 0', $DIR/post_monomorphization_error_backtrace.rs:6:23
+   |
+   = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+note: the above error was encountered while instantiating `fn assert_zst::<i32>`
+  --> $DIR/post_monomorphization_error_backtrace.rs:18:5
+   |
+LL |     assert_zst::<U>()
+   |     ^^^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/polymorphization/generators.stderr
+++ b/src/test/ui/polymorphization/generators.stderr
@@ -19,6 +19,12 @@ LL | |         2
 LL | |     }
    | |_____^
 
+note: the above error was encountered while instantiating `fn finish::<[generator@$DIR/generators.rs:35:5: 39:6], u32, u32>`
+  --> $DIR/generators.rs:86:5
+   |
+LL |     finish(unused_type::<u32>());
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 error: item has unused generic parameters
   --> $DIR/generators.rs:60:5
    |
@@ -30,6 +36,12 @@ LL | |         yield 1;
 LL | |         2
 LL | |     }
    | |_____^
+
+note: the above error was encountered while instantiating `fn finish::<[generator@$DIR/generators.rs:60:5: 64:6], u32, u32>`
+  --> $DIR/generators.rs:89:5
+   |
+LL |     finish(unused_const::<1u32>());
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors; 1 warning emitted
 

--- a/src/test/ui/polymorphization/predicates.stderr
+++ b/src/test/ui/polymorphization/predicates.stderr
@@ -41,5 +41,11 @@ error: item has unused generic parameters
 LL | fn bar<I>() {
    |    ^^^ - generic parameter `I` is unused
 
+note: the above error was encountered while instantiating `fn foo::<std::slice::Iter<u32>, T>`
+  --> $DIR/predicates.rs:85:5
+   |
+LL |     foo(x.iter());
+   |     ^^^^^^^^^^^^^
+
 error: aborting due to 6 previous errors
 


### PR DESCRIPTION
Note this does not produce a full stack all the way to the first call that specifies all monomorphic parameters, it's just shallowly mentioning the last call site.

previous work: https://github.com/rust-lang/rust/pull/85633
tracking issue: https://github.com/rust-lang/rust/issues/85155

r? @lqd

I figured we could get some improvement for traces in local crates without going into the backtrace hell you landed in last time