### PR TITLE
Remove `ignore` from E0705 test

### DIFF
--- a/compiler/rustc_error_codes/src/error_codes/E0705.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0705.md
@@ -3,7 +3,7 @@ current edition, but not in all editions.
 
 Erroneous code example:
 
-```ignore (limited to a warning during 2018 edition development)
+```rust2018,compile_fail,E0705
 #![feature(rust_2018_preview)]
 #![feature(test_2018_feature)] // error: the feature
                                // `test_2018_feature` is


### PR DESCRIPTION
Spotted this, and I think this can be made to test now.