### PR TITLE
Use source callsite in check_argument_types suggestion

### DIFF
--- a/compiler/rustc_typeck/src/check/fn_ctxt/checks.rs
+++ b/compiler/rustc_typeck/src/check/fn_ctxt/checks.rs
@@ -980,7 +980,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 );
                 for (idx, arg) in matched_inputs.iter().enumerate() {
                     let suggestion_text = if let Some(arg) = arg {
-                        let arg_span = provided_args[*arg].span;
+                        let arg_span = provided_args[*arg].span.source_callsite();
                         let arg_text = source_map.span_to_snippet(arg_span).unwrap();
                         arg_text
                     } else {

--- a/src/test/ui/typeck/remove-extra-argument.fixed
+++ b/src/test/ui/typeck/remove-extra-argument.fixed
@@ -1,0 +1,9 @@
+// run-rustfix
+// Check that the HELP suggestion is `l(vec![])` instead of `l($crate::vec::Vec::new())`
+fn l(_a: Vec<u8>) {}
+
+fn main() {
+    l(vec![])
+    //~^ ERROR this function takes 1 argument but 2 arguments were supplied
+    //~| HELP remove the extra argument
+}

--- a/src/test/ui/typeck/remove-extra-argument.rs
+++ b/src/test/ui/typeck/remove-extra-argument.rs
@@ -1,0 +1,9 @@
+// run-rustfix
+// Check that the HELP suggestion is `l(vec![])` instead of `l($crate::vec::Vec::new())`
+fn l(_a: Vec<u8>) {}
+
+fn main() {
+    l(vec![], vec![])
+    //~^ ERROR this function takes 1 argument but 2 arguments were supplied
+    //~| HELP remove the extra argument
+}

--- a/src/test/ui/typeck/remove-extra-argument.stderr
+++ b/src/test/ui/typeck/remove-extra-argument.stderr
@@ -1,0 +1,19 @@
+error[E0061]: this function takes 1 argument but 2 arguments were supplied
+  --> $DIR/remove-extra-argument.rs:6:5
+   |
+LL |     l(vec![], vec![])
+   |     ^         ------ argument unexpected
+   |
+note: function defined here
+  --> $DIR/remove-extra-argument.rs:3:4
+   |
+LL | fn l(_a: Vec<u8>) {}
+   |    ^ -----------
+help: remove the extra argument
+   |
+LL |     l(vec![])
+   |
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0061`.


### PR DESCRIPTION
This makes the "remove extra arguement" suggestion valid when the function argument is a macro.

Additionally, this may fix #96225, but the only way I can reproduce that issue is using the playground, so we will need to wait until after this is merged to ensure it's fixed.