### PR TITLE
Fix inline-const generic-const-exprs interaction

### DIFF
--- a/compiler/rustc_mir_build/src/thir/cx/expr.rs
+++ b/compiler/rustc_mir_build/src/thir/cx/expr.rs
@@ -524,8 +524,7 @@ impl<'tcx> Cx<'tcx> {
                 let anon_const_def_id = local_def_id.to_def_id();
 
                 // Need to include the parent substs
-                let hir_id = tcx.hir().local_def_id_to_hir_id(local_def_id);
-                let ty = tcx.typeck(local_def_id).node_type(hir_id);
+                let ty = self.typeck_results().expr_ty(expr);
                 let typeck_root_def_id = tcx.typeck_root_def_id(anon_const_def_id);
                 let parent_substs =
                     tcx.erase_regions(InternalSubsts::identity_for_item(tcx, typeck_root_def_id));

--- a/compiler/rustc_trait_selection/src/traits/const_evaluatable.rs
+++ b/compiler/rustc_trait_selection/src/traits/const_evaluatable.rs
@@ -332,6 +332,7 @@ impl<'a, 'tcx> AbstractConstBuilder<'a, 'tcx> {
                 match expr.kind {
                     thir::ExprKind::NamedConst { substs, .. } => substs.has_param_types_or_consts(),
                     thir::ExprKind::ConstParam { .. } => true,
+                    thir::ExprKind::ConstBlock { .. } => true,
                     thir::ExprKind::Repeat { value, count } => {
                         self.visit_expr(&self.thir()[value]);
                         count.has_param_types_or_consts()

--- a/src/test/ui/const-generics/generic_const_exprs/inline-const.rs
+++ b/src/test/ui/const-generics/generic_const_exprs/inline-const.rs
@@ -1,0 +1,11 @@
+#![feature(generic_const_exprs)]
+#![feature(inline_const)]
+#![allow(incomplete_features)]
+
+fn test<const N: usize>() {
+}
+
+fn main() {
+    let _ = test::<{const {1}}>();
+    //~^ ERROR overly complex generic constant
+}

--- a/src/test/ui/const-generics/generic_const_exprs/inline-const.stderr
+++ b/src/test/ui/const-generics/generic_const_exprs/inline-const.stderr
@@ -1,0 +1,13 @@
+error: overly complex generic constant
+  --> $DIR/inline-const.rs:9:20
+   |
+LL |     let _ = test::<{const {1}}>();
+   |                    ^---------^
+   |                     |
+   |                     const blocks are not supported in generic constant
+   |
+   = help: consider moving this anonymous constant into a `const` function
+   = note: this operation may be supported in the future
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Currently this code:
```rust
#![feature(generic_const_exprs)]
#![feature(inline_const)]
#![allow(incomplete_features)]

fn test<const N: usize>() {
}

fn main() {
    let _ = test::<{const {1}}>();
}
```
will cause a cycle error:

<details>
<summary>Details</summary>

```
error[E0391]: cycle detected when type-checking `main::{constant#0}::{constant#0}`
 --> inline-const.rs:9:27
  |
9 |     let _ = test::<{const {1}}>();
  |                           ^^^
  |
note: ...which requires type-checking `main::{constant#0}`...
 --> inline-const.rs:9:20
  |
9 |     let _ = test::<{const {1}}>();
  |                    ^^^^^^^^^^^
note: ...which requires computing the optional const parameter of `main::{constant#0}`...
 --> inline-const.rs:9:20
  |
9 |     let _ = test::<{const {1}}>();
  |                    ^^^^^^^^^^^
note: ...which requires type-checking `main`...
 --> inline-const.rs:8:1
  |
8 | fn main() {
  | ^^^^^^^^^
note: ...which requires building an abstract representation for the const argument main::{constant#0}...
 --> inline-const.rs:9:20
  |
9 |     let _ = test::<{const {1}}>();
  |                    ^^^^^^^^^^^
note: ...which requires building THIR for `main::{constant#0}`...
 --> inline-const.rs:9:20
  |
9 |     let _ = test::<{const {1}}>();
  |                    ^^^^^^^^^^^
  = note: ...which again requires type-checking `main::{constant#0}::{constant#0}`, completing the cycle
  = note: cycle used when type-checking all item bodies

error: aborting due to previous error
```
</details>

while it should simply reject the code as an overly complex generic constant.

r? @lcnr

@rustbot label: F-inline_const