### PR TITLE
Enable full revision in const generics ui tests

### DIFF
--- a/src/test/ui/const-generics/const-arg-in-const-arg.full.stderr
+++ b/src/test/ui/const-generics/const-arg-in-const-arg.full.stderr
@@ -1,0 +1,162 @@
+error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
+  --> $DIR/const-arg-in-const-arg.rs:18:23
+   |
+LL |     let _: [u8; faz::<'a>(&())];
+   |                       ^^
+   |
+note: the late bound lifetime parameter is introduced here
+  --> $DIR/const-arg-in-const-arg.rs:8:14
+   |
+LL | const fn faz<'a>(_: &'a ()) -> usize { 13 }
+   |              ^^
+
+error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
+  --> $DIR/const-arg-in-const-arg.rs:21:23
+   |
+LL |     let _: [u8; faz::<'b>(&())];
+   |                       ^^
+   |
+note: the late bound lifetime parameter is introduced here
+  --> $DIR/const-arg-in-const-arg.rs:8:14
+   |
+LL | const fn faz<'a>(_: &'a ()) -> usize { 13 }
+   |              ^^
+
+error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
+  --> $DIR/const-arg-in-const-arg.rs:30:23
+   |
+LL |     let _ = [0; faz::<'a>(&())];
+   |                       ^^
+   |
+note: the late bound lifetime parameter is introduced here
+  --> $DIR/const-arg-in-const-arg.rs:8:14
+   |
+LL | const fn faz<'a>(_: &'a ()) -> usize { 13 }
+   |              ^^
+
+error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
+  --> $DIR/const-arg-in-const-arg.rs:33:23
+   |
+LL |     let _ = [0; faz::<'b>(&())];
+   |                       ^^
+   |
+note: the late bound lifetime parameter is introduced here
+  --> $DIR/const-arg-in-const-arg.rs:8:14
+   |
+LL | const fn faz<'a>(_: &'a ()) -> usize { 13 }
+   |              ^^
+
+error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
+  --> $DIR/const-arg-in-const-arg.rs:41:24
+   |
+LL |     let _: Foo<{ faz::<'a>(&()) }>;
+   |                        ^^
+   |
+note: the late bound lifetime parameter is introduced here
+  --> $DIR/const-arg-in-const-arg.rs:8:14
+   |
+LL | const fn faz<'a>(_: &'a ()) -> usize { 13 }
+   |              ^^
+
+error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
+  --> $DIR/const-arg-in-const-arg.rs:44:24
+   |
+LL |     let _: Foo<{ faz::<'b>(&()) }>;
+   |                        ^^
+   |
+note: the late bound lifetime parameter is introduced here
+  --> $DIR/const-arg-in-const-arg.rs:8:14
+   |
+LL | const fn faz<'a>(_: &'a ()) -> usize { 13 }
+   |              ^^
+
+error: unconstrained generic constant
+  --> $DIR/const-arg-in-const-arg.rs:13:12
+   |
+LL |     let _: [u8; foo::<T>()];
+   |            ^^^^^^^^^^^^^^^^
+   |
+   = help: try adding a `where` bound using this expression: `where [(); foo::<T>()]:`
+
+error: unconstrained generic constant
+  --> $DIR/const-arg-in-const-arg.rs:15:12
+   |
+LL |     let _: [u8; bar::<N>()];
+   |            ^^^^^^^^^^^^^^^^
+   |
+   = help: try adding a `where` bound using this expression: `where [(); bar::<N>()]:`
+
+error: unconstrained generic constant
+  --> $DIR/const-arg-in-const-arg.rs:36:12
+   |
+LL |     let _: Foo<{ foo::<T>() }>;
+   |            ^^^^^^^^^^^^^^^^^^^
+   |
+   = help: try adding a `where` bound using this expression: `where [(); { foo::<T>() }]:`
+
+error: unconstrained generic constant
+  --> $DIR/const-arg-in-const-arg.rs:38:12
+   |
+LL |     let _: Foo<{ bar::<N>() }>;
+   |            ^^^^^^^^^^^^^^^^^^^
+   |
+   = help: try adding a `where` bound using this expression: `where [(); { bar::<N>() }]:`
+
+error: unconstrained generic constant
+  --> $DIR/const-arg-in-const-arg.rs:25:17
+   |
+LL |     let _ = [0; foo::<T>()];
+   |                 ^^^^^^^^^^
+   |
+   = help: try adding a `where` bound using this expression: `where [(); foo::<T>()]:`
+
+error: unconstrained generic constant
+  --> $DIR/const-arg-in-const-arg.rs:27:17
+   |
+LL |     let _ = [0; bar::<N>()];
+   |                 ^^^^^^^^^^
+   |
+   = help: try adding a `where` bound using this expression: `where [(); bar::<N>()]:`
+
+error: unconstrained generic constant
+  --> $DIR/const-arg-in-const-arg.rs:47:19
+   |
+LL |     let _ = Foo::<{ foo::<T>() }>;
+   |                   ^^^^^^^^^^^^^^
+   |
+   = help: try adding a `where` bound using this expression: `where [(); { foo::<T>() }]:`
+
+error: unconstrained generic constant
+  --> $DIR/const-arg-in-const-arg.rs:49:19
+   |
+LL |     let _ = Foo::<{ bar::<N>() }>;
+   |                   ^^^^^^^^^^^^^^
+   |
+   = help: try adding a `where` bound using this expression: `where [(); { bar::<N>() }]:`
+
+error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
+  --> $DIR/const-arg-in-const-arg.rs:52:27
+   |
+LL |     let _ = Foo::<{ faz::<'a>(&()) }>;
+   |                           ^^
+   |
+note: the late bound lifetime parameter is introduced here
+  --> $DIR/const-arg-in-const-arg.rs:8:14
+   |
+LL | const fn faz<'a>(_: &'a ()) -> usize { 13 }
+   |              ^^
+
+error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
+  --> $DIR/const-arg-in-const-arg.rs:55:27
+   |
+LL |     let _ = Foo::<{ faz::<'b>(&()) }>;
+   |                           ^^
+   |
+note: the late bound lifetime parameter is introduced here
+  --> $DIR/const-arg-in-const-arg.rs:8:14
+   |
+LL | const fn faz<'a>(_: &'a ()) -> usize { 13 }
+   |              ^^
+
+error: aborting due to 16 previous errors
+

--- a/src/test/ui/const-generics/const-arg-in-const-arg.min.stderr
+++ b/src/test/ui/const-generics/const-arg-in-const-arg.min.stderr
@@ -8,7 +8,7 @@ LL |     let _: [u8; foo::<T>()];
    = help: use `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: generic parameters may not be used in const operations
-  --> $DIR/const-arg-in-const-arg.rs:14:23
+  --> $DIR/const-arg-in-const-arg.rs:15:23
    |
 LL |     let _: [u8; bar::<N>()];
    |                       ^ cannot perform const operation using `N`
@@ -17,7 +17,7 @@ LL |     let _: [u8; bar::<N>()];
    = help: use `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error[E0658]: a non-static lifetime is not allowed in a `const`
-  --> $DIR/const-arg-in-const-arg.rs:16:23
+  --> $DIR/const-arg-in-const-arg.rs:18:23
    |
 LL |     let _: [u8; faz::<'a>(&())];
    |                       ^^
@@ -26,7 +26,7 @@ LL |     let _: [u8; faz::<'a>(&())];
    = help: add `#![feature(generic_const_exprs)]` to the crate attributes to enable
 
 error[E0658]: a non-static lifetime is not allowed in a `const`
-  --> $DIR/const-arg-in-const-arg.rs:18:23
+  --> $DIR/const-arg-in-const-arg.rs:20:23
    |
 LL |     let _: [u8; baz::<'a>(&())];
    |                       ^^
@@ -35,7 +35,7 @@ LL |     let _: [u8; baz::<'a>(&())];
    = help: add `#![feature(generic_const_exprs)]` to the crate attributes to enable
 
 error[E0658]: a non-static lifetime is not allowed in a `const`
-  --> $DIR/const-arg-in-const-arg.rs:19:23
+  --> $DIR/const-arg-in-const-arg.rs:21:23
    |
 LL |     let _: [u8; faz::<'b>(&())];
    |                       ^^
@@ -44,7 +44,7 @@ LL |     let _: [u8; faz::<'b>(&())];
    = help: add `#![feature(generic_const_exprs)]` to the crate attributes to enable
 
 error[E0658]: a non-static lifetime is not allowed in a `const`
-  --> $DIR/const-arg-in-const-arg.rs:21:23
+  --> $DIR/const-arg-in-const-arg.rs:23:23
    |
 LL |     let _: [u8; baz::<'b>(&())];
    |                       ^^
@@ -53,7 +53,7 @@ LL |     let _: [u8; baz::<'b>(&())];
    = help: add `#![feature(generic_const_exprs)]` to the crate attributes to enable
 
 error: generic parameters may not be used in const operations
-  --> $DIR/const-arg-in-const-arg.rs:24:23
+  --> $DIR/const-arg-in-const-arg.rs:27:23
    |
 LL |     let _ = [0; bar::<N>()];
    |                       ^ cannot perform const operation using `N`
@@ -62,7 +62,7 @@ LL |     let _ = [0; bar::<N>()];
    = help: use `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error[E0658]: a non-static lifetime is not allowed in a `const`
-  --> $DIR/const-arg-in-const-arg.rs:26:23
+  --> $DIR/const-arg-in-const-arg.rs:30:23
    |
 LL |     let _ = [0; faz::<'a>(&())];
    |                       ^^
@@ -71,7 +71,7 @@ LL |     let _ = [0; faz::<'a>(&())];
    = help: add `#![feature(generic_const_exprs)]` to the crate attributes to enable
 
 error[E0658]: a non-static lifetime is not allowed in a `const`
-  --> $DIR/const-arg-in-const-arg.rs:28:23
+  --> $DIR/const-arg-in-const-arg.rs:32:23
    |
 LL |     let _ = [0; baz::<'a>(&())];
    |                       ^^
@@ -80,7 +80,7 @@ LL |     let _ = [0; baz::<'a>(&())];
    = help: add `#![feature(generic_const_exprs)]` to the crate attributes to enable
 
 error[E0658]: a non-static lifetime is not allowed in a `const`
-  --> $DIR/const-arg-in-const-arg.rs:29:23
+  --> $DIR/const-arg-in-const-arg.rs:33:23
    |
 LL |     let _ = [0; faz::<'b>(&())];
    |                       ^^
@@ -89,7 +89,7 @@ LL |     let _ = [0; faz::<'b>(&())];
    = help: add `#![feature(generic_const_exprs)]` to the crate attributes to enable
 
 error[E0658]: a non-static lifetime is not allowed in a `const`
-  --> $DIR/const-arg-in-const-arg.rs:31:23
+  --> $DIR/const-arg-in-const-arg.rs:35:23
    |
 LL |     let _ = [0; baz::<'b>(&())];
    |                       ^^
@@ -98,7 +98,7 @@ LL |     let _ = [0; baz::<'b>(&())];
    = help: add `#![feature(generic_const_exprs)]` to the crate attributes to enable
 
 error: generic parameters may not be used in const operations
-  --> $DIR/const-arg-in-const-arg.rs:32:24
+  --> $DIR/const-arg-in-const-arg.rs:36:24
    |
 LL |     let _: Foo<{ foo::<T>() }>;
    |                        ^ cannot perform const operation using `T`
@@ -107,7 +107,7 @@ LL |     let _: Foo<{ foo::<T>() }>;
    = help: use `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: generic parameters may not be used in const operations
-  --> $DIR/const-arg-in-const-arg.rs:33:24
+  --> $DIR/const-arg-in-const-arg.rs:38:24
    |
 LL |     let _: Foo<{ bar::<N>() }>;
    |                        ^ cannot perform const operation using `N`
@@ -116,7 +116,7 @@ LL |     let _: Foo<{ bar::<N>() }>;
    = help: use `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error[E0658]: a non-static lifetime is not allowed in a `const`
-  --> $DIR/const-arg-in-const-arg.rs:35:24
+  --> $DIR/const-arg-in-const-arg.rs:41:24
    |
 LL |     let _: Foo<{ faz::<'a>(&()) }>;
    |                        ^^
@@ -125,7 +125,7 @@ LL |     let _: Foo<{ faz::<'a>(&()) }>;
    = help: add `#![feature(generic_const_exprs)]` to the crate attributes to enable
 
 error[E0658]: a non-static lifetime is not allowed in a `const`
-  --> $DIR/const-arg-in-const-arg.rs:37:24
+  --> $DIR/const-arg-in-const-arg.rs:43:24
    |
 LL |     let _: Foo<{ baz::<'a>(&()) }>;
    |                        ^^
@@ -134,7 +134,7 @@ LL |     let _: Foo<{ baz::<'a>(&()) }>;
    = help: add `#![feature(generic_const_exprs)]` to the crate attributes to enable
 
 error[E0658]: a non-static lifetime is not allowed in a `const`
-  --> $DIR/const-arg-in-const-arg.rs:38:24
+  --> $DIR/const-arg-in-const-arg.rs:44:24
    |
 LL |     let _: Foo<{ faz::<'b>(&()) }>;
    |                        ^^
@@ -143,7 +143,7 @@ LL |     let _: Foo<{ faz::<'b>(&()) }>;
    = help: add `#![feature(generic_const_exprs)]` to the crate attributes to enable
 
 error[E0658]: a non-static lifetime is not allowed in a `const`
-  --> $DIR/const-arg-in-const-arg.rs:40:24
+  --> $DIR/const-arg-in-const-arg.rs:46:24
    |
 LL |     let _: Foo<{ baz::<'b>(&()) }>;
    |                        ^^
@@ -152,7 +152,7 @@ LL |     let _: Foo<{ baz::<'b>(&()) }>;
    = help: add `#![feature(generic_const_exprs)]` to the crate attributes to enable
 
 error: generic parameters may not be used in const operations
-  --> $DIR/const-arg-in-const-arg.rs:41:27
+  --> $DIR/const-arg-in-const-arg.rs:47:27
    |
 LL |     let _ = Foo::<{ foo::<T>() }>;
    |                           ^ cannot perform const operation using `T`
@@ -161,7 +161,7 @@ LL |     let _ = Foo::<{ foo::<T>() }>;
    = help: use `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: generic parameters may not be used in const operations
-  --> $DIR/const-arg-in-const-arg.rs:42:27
+  --> $DIR/const-arg-in-const-arg.rs:49:27
    |
 LL |     let _ = Foo::<{ bar::<N>() }>;
    |                           ^ cannot perform const operation using `N`
@@ -170,7 +170,7 @@ LL |     let _ = Foo::<{ bar::<N>() }>;
    = help: use `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error[E0658]: a non-static lifetime is not allowed in a `const`
-  --> $DIR/const-arg-in-const-arg.rs:44:27
+  --> $DIR/const-arg-in-const-arg.rs:52:27
    |
 LL |     let _ = Foo::<{ faz::<'a>(&()) }>;
    |                           ^^
@@ -179,7 +179,7 @@ LL |     let _ = Foo::<{ faz::<'a>(&()) }>;
    = help: add `#![feature(generic_const_exprs)]` to the crate attributes to enable
 
 error[E0658]: a non-static lifetime is not allowed in a `const`
-  --> $DIR/const-arg-in-const-arg.rs:46:27
+  --> $DIR/const-arg-in-const-arg.rs:54:27
    |
 LL |     let _ = Foo::<{ baz::<'a>(&()) }>;
    |                           ^^
@@ -188,7 +188,7 @@ LL |     let _ = Foo::<{ baz::<'a>(&()) }>;
    = help: add `#![feature(generic_const_exprs)]` to the crate attributes to enable
 
 error[E0658]: a non-static lifetime is not allowed in a `const`
-  --> $DIR/const-arg-in-const-arg.rs:47:27
+  --> $DIR/const-arg-in-const-arg.rs:55:27
    |
 LL |     let _ = Foo::<{ faz::<'b>(&()) }>;
    |                           ^^
@@ -197,7 +197,7 @@ LL |     let _ = Foo::<{ faz::<'b>(&()) }>;
    = help: add `#![feature(generic_const_exprs)]` to the crate attributes to enable
 
 error[E0658]: a non-static lifetime is not allowed in a `const`
-  --> $DIR/const-arg-in-const-arg.rs:49:27
+  --> $DIR/const-arg-in-const-arg.rs:57:27
    |
 LL |     let _ = Foo::<{ baz::<'b>(&()) }>;
    |                           ^^
@@ -206,7 +206,7 @@ LL |     let _ = Foo::<{ baz::<'b>(&()) }>;
    = help: add `#![feature(generic_const_exprs)]` to the crate attributes to enable
 
 error[E0747]: unresolved item provided when a constant was expected
-  --> $DIR/const-arg-in-const-arg.rs:14:23
+  --> $DIR/const-arg-in-const-arg.rs:15:23
    |
 LL |     let _: [u8; bar::<N>()];
    |                       ^
@@ -217,7 +217,7 @@ LL |     let _: [u8; bar::<{ N }>()];
    |                       +   +
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
-  --> $DIR/const-arg-in-const-arg.rs:16:23
+  --> $DIR/const-arg-in-const-arg.rs:18:23
    |
 LL |     let _: [u8; faz::<'a>(&())];
    |                       ^^
@@ -229,7 +229,7 @@ LL | const fn faz<'a>(_: &'a ()) -> usize { 13 }
    |              ^^
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
-  --> $DIR/const-arg-in-const-arg.rs:19:23
+  --> $DIR/const-arg-in-const-arg.rs:21:23
    |
 LL |     let _: [u8; faz::<'b>(&())];
    |                       ^^
@@ -241,7 +241,7 @@ LL | const fn faz<'a>(_: &'a ()) -> usize { 13 }
    |              ^^
 
 error[E0747]: unresolved item provided when a constant was expected
-  --> $DIR/const-arg-in-const-arg.rs:24:23
+  --> $DIR/const-arg-in-const-arg.rs:27:23
    |
 LL |     let _ = [0; bar::<N>()];
    |                       ^
@@ -252,7 +252,7 @@ LL |     let _ = [0; bar::<{ N }>()];
    |                       +   +
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
-  --> $DIR/const-arg-in-const-arg.rs:26:23
+  --> $DIR/const-arg-in-const-arg.rs:30:23
    |
 LL |     let _ = [0; faz::<'a>(&())];
    |                       ^^
@@ -264,7 +264,7 @@ LL | const fn faz<'a>(_: &'a ()) -> usize { 13 }
    |              ^^
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
-  --> $DIR/const-arg-in-const-arg.rs:29:23
+  --> $DIR/const-arg-in-const-arg.rs:33:23
    |
 LL |     let _ = [0; faz::<'b>(&())];
    |                       ^^
@@ -276,7 +276,7 @@ LL | const fn faz<'a>(_: &'a ()) -> usize { 13 }
    |              ^^
 
 error[E0747]: unresolved item provided when a constant was expected
-  --> $DIR/const-arg-in-const-arg.rs:33:24
+  --> $DIR/const-arg-in-const-arg.rs:38:24
    |
 LL |     let _: Foo<{ bar::<N>() }>;
    |                        ^
@@ -287,7 +287,7 @@ LL |     let _: Foo<{ bar::<{ N }>() }>;
    |                        +   +
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
-  --> $DIR/const-arg-in-const-arg.rs:35:24
+  --> $DIR/const-arg-in-const-arg.rs:41:24
    |
 LL |     let _: Foo<{ faz::<'a>(&()) }>;
    |                        ^^
@@ -299,7 +299,7 @@ LL | const fn faz<'a>(_: &'a ()) -> usize { 13 }
    |              ^^
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
-  --> $DIR/const-arg-in-const-arg.rs:38:24
+  --> $DIR/const-arg-in-const-arg.rs:44:24
    |
 LL |     let _: Foo<{ faz::<'b>(&()) }>;
    |                        ^^
@@ -311,7 +311,7 @@ LL | const fn faz<'a>(_: &'a ()) -> usize { 13 }
    |              ^^
 
 error: constant expression depends on a generic parameter
-  --> $DIR/const-arg-in-const-arg.rs:23:17
+  --> $DIR/const-arg-in-const-arg.rs:25:17
    |
 LL |     let _ = [0; foo::<T>()];
    |                 ^^^^^^^^^^
@@ -319,7 +319,7 @@ LL |     let _ = [0; foo::<T>()];
    = note: this may fail depending on what value the parameter takes
 
 error[E0747]: unresolved item provided when a constant was expected
-  --> $DIR/const-arg-in-const-arg.rs:42:27
+  --> $DIR/const-arg-in-const-arg.rs:49:27
    |
 LL |     let _ = Foo::<{ bar::<N>() }>;
    |                           ^
@@ -330,7 +330,7 @@ LL |     let _ = Foo::<{ bar::<{ N }>() }>;
    |                           +   +
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
-  --> $DIR/const-arg-in-const-arg.rs:44:27
+  --> $DIR/const-arg-in-const-arg.rs:52:27
    |
 LL |     let _ = Foo::<{ faz::<'a>(&()) }>;
    |                           ^^
@@ -342,7 +342,7 @@ LL | const fn faz<'a>(_: &'a ()) -> usize { 13 }
    |              ^^
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
-  --> $DIR/const-arg-in-const-arg.rs:47:27
+  --> $DIR/const-arg-in-const-arg.rs:55:27
    |
 LL |     let _ = Foo::<{ faz::<'b>(&()) }>;
    |                           ^^

--- a/src/test/ui/const-generics/const-arg-in-const-arg.rs
+++ b/src/test/ui/const-generics/const-arg-in-const-arg.rs
@@ -1,7 +1,7 @@
-// revisions: min
-// FIXME(generic_const_exprs): This test currently causes an ICE because
-// we don't yet correctly deal with lifetimes, reenable this test once
-// this is fixed.
+// revisions: full min
+
+#![cfg_attr(full, feature(generic_const_exprs))]
+#![cfg_attr(full, allow(incomplete_features))]
 
 const fn foo<T>() -> usize { std::mem::size_of::<T>() }
 const fn bar<const N: usize>() -> usize { N }
@@ -10,43 +10,51 @@ const fn baz<'a>(_: &'a ()) -> usize where &'a (): Sized { 13 }
 
 struct Foo<const N: usize>;
 fn test<'a, 'b, T, const N: usize>() where &'b (): Sized {
-    let _: [u8; foo::<T>()]; //~ ERROR generic parameters may not
-    let _: [u8; bar::<N>()]; //~ ERROR generic parameters may not
-                             //~^ ERROR unresolved item provided when a constant was expected
-    let _: [u8; faz::<'a>(&())]; //~ ERROR a non-static lifetime
+    let _: [u8; foo::<T>()]; //[min]~ ERROR generic parameters may not
+                             //[full]~^ ERROR unconstrained generic constant
+    let _: [u8; bar::<N>()]; //[min]~ ERROR generic parameters may not
+                             //[min]~^ ERROR unresolved item provided when a constant was expected
+                             //[full]~^^ ERROR unconstrained generic constant
+    let _: [u8; faz::<'a>(&())]; //[min]~ ERROR a non-static lifetime
                                  //~^ ERROR cannot specify lifetime arguments
-    let _: [u8; baz::<'a>(&())]; //~ ERROR a non-static lifetime
-    let _: [u8; faz::<'b>(&())]; //~ ERROR a non-static lifetime
+    let _: [u8; baz::<'a>(&())]; //[min]~ ERROR a non-static lifetime
+    let _: [u8; faz::<'b>(&())]; //[min]~ ERROR a non-static lifetime
                                  //~^ ERROR cannot specify lifetime arguments
-    let _: [u8; baz::<'b>(&())]; //~ ERROR a non-static lifetime
+    let _: [u8; baz::<'b>(&())]; //[min]~ ERROR a non-static lifetime
 
-    let _ = [0; foo::<T>()]; //~ ERROR constant expression depends on a generic parameter
-    let _ = [0; bar::<N>()]; //~ ERROR generic parameters may not
-                             //~^ ERROR unresolved item provided when a constant was expected
-    let _ = [0; faz::<'a>(&())]; //~ ERROR a non-static lifetime
+    let _ = [0; foo::<T>()]; //[min]~ ERROR constant expression depends on a generic parameter
+                             //[full]~^ ERROR unconstrained generic constant
+    let _ = [0; bar::<N>()]; //[min]~ ERROR generic parameters may not
+                             //[min]~^ ERROR unresolved item provided when a constant was expected
+                             //[full]~^^ ERROR unconstrained generic constant
+    let _ = [0; faz::<'a>(&())]; //[min]~ ERROR a non-static lifetime
                                  //~^ ERROR cannot specify lifetime arguments
-    let _ = [0; baz::<'a>(&())]; //~ ERROR a non-static lifetime
-    let _ = [0; faz::<'b>(&())]; //~ ERROR a non-static lifetime
+    let _ = [0; baz::<'a>(&())]; //[min]~ ERROR a non-static lifetime
+    let _ = [0; faz::<'b>(&())]; //[min]~ ERROR a non-static lifetime
                                  //~^ ERROR cannot specify lifetime arguments
-    let _ = [0; baz::<'b>(&())]; //~ ERROR a non-static lifetime
-    let _: Foo<{ foo::<T>() }>; //~ ERROR generic parameters may not
-    let _: Foo<{ bar::<N>() }>; //~ ERROR generic parameters may not
-                                //~^ ERROR unresolved item provided when a constant was expected
-    let _: Foo<{ faz::<'a>(&()) }>; //~ ERROR a non-static lifetime
+    let _ = [0; baz::<'b>(&())]; //[min]~ ERROR a non-static lifetime
+    let _: Foo<{ foo::<T>() }>; //[min]~ ERROR generic parameters may not
+                                //[full]~^ ERROR unconstrained generic constant
+    let _: Foo<{ bar::<N>() }>; //[min]~ ERROR generic parameters may not
+                                //[min]~^ ERROR unresolved item provided when a constant was expected
+                                //[full]~^^ ERROR unconstrained generic constant
+    let _: Foo<{ faz::<'a>(&()) }>; //[min]~ ERROR a non-static lifetime
                                     //~^ ERROR cannot specify lifetime arguments
-    let _: Foo<{ baz::<'a>(&()) }>; //~ ERROR a non-static lifetime
-    let _: Foo<{ faz::<'b>(&()) }>; //~ ERROR a non-static lifetime
+    let _: Foo<{ baz::<'a>(&()) }>; //[min]~ ERROR a non-static lifetime
+    let _: Foo<{ faz::<'b>(&()) }>; //[min]~ ERROR a non-static lifetime
                                     //~^ ERROR cannot specify lifetime arguments
-    let _: Foo<{ baz::<'b>(&()) }>; //~ ERROR a non-static lifetime
-    let _ = Foo::<{ foo::<T>() }>; //~ ERROR generic parameters may not
-    let _ = Foo::<{ bar::<N>() }>; //~ ERROR generic parameters may not
-                                   //~^ ERROR unresolved item provided when a constant was expected
-    let _ = Foo::<{ faz::<'a>(&()) }>; //~ ERROR a non-static lifetime
+    let _: Foo<{ baz::<'b>(&()) }>; //[min]~ ERROR a non-static lifetime
+    let _ = Foo::<{ foo::<T>() }>; //[min]~ ERROR generic parameters may not
+                                   //[full]~^ ERROR unconstrained generic constant
+    let _ = Foo::<{ bar::<N>() }>; //[min]~ ERROR generic parameters may not
+                                   //[min]~^ ERROR unresolved item provided when a constant was expected
+                                   //[full]~^^ ERROR unconstrained generic constant
+    let _ = Foo::<{ faz::<'a>(&()) }>; //[min]~ ERROR a non-static lifetime
                                        //~^ ERROR cannot specify lifetime arguments
-    let _ = Foo::<{ baz::<'a>(&()) }>; //~ ERROR a non-static lifetime
-    let _ = Foo::<{ faz::<'b>(&()) }>; //~ ERROR a non-static lifetime
+    let _ = Foo::<{ baz::<'a>(&()) }>; //[min]~ ERROR a non-static lifetime
+    let _ = Foo::<{ faz::<'b>(&()) }>; //[min]~ ERROR a non-static lifetime
                                        //~^ ERROR cannot specify lifetime arguments
-    let _ = Foo::<{ baz::<'b>(&()) }>; //~ ERROR a non-static lifetime
+    let _ = Foo::<{ baz::<'b>(&()) }>; //[min]~ ERROR a non-static lifetime
 }
 
 fn main() {}

--- a/src/test/ui/const-generics/const-argument-non-static-lifetime.min.stderr
+++ b/src/test/ui/const-generics/const-argument-non-static-lifetime.min.stderr
@@ -1,0 +1,12 @@
+error[E0658]: a non-static lifetime is not allowed in a `const`
+  --> $DIR/const-argument-non-static-lifetime.rs:15:17
+   |
+LL |         let _: &'a ();
+   |                 ^^
+   |
+   = note: see issue #76560 <https://github.com/rust-lang/rust/issues/76560> for more information
+   = help: add `#![feature(generic_const_exprs)]` to the crate attributes to enable
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/const-generics/const-argument-non-static-lifetime.rs
+++ b/src/test/ui/const-generics/const-argument-non-static-lifetime.rs
@@ -1,6 +1,8 @@
-// run-pass
-// revisions: full
-// FIXME(#75323) Omitted min revision for now due to ICE.
+// [full] run-pass
+// revisions: full min
+
+// regression test for #78180
+// compile-flags: -Zsave-analysis
 
 #![cfg_attr(full, feature(generic_const_exprs))]
 #![cfg_attr(full, allow(incomplete_features))]
@@ -10,7 +12,7 @@ fn test<const N: usize>() {}
 
 fn wow<'a>() -> &'a () {
     test::<{
-        let _: &'a ();
+        let _: &'a (); //[min]~ ERROR a non-static lifetime
         3
     }>();
     &()

--- a/src/test/ui/const-generics/issues/issue-775377.rs
+++ b/src/test/ui/const-generics/issues/issue-775377.rs
@@ -1,0 +1,11 @@
+#![feature(generic_const_exprs)]
+#![allow(incomplete_features)]
+
+trait MyTrait<T> {}
+
+fn bug<'a, T>() -> &'static dyn MyTrait<[(); { |x: &'a u32| { x }; 4 }]> {
+    //~^ ERROR overly complex generic constant
+    todo!()
+}
+
+fn main() {}

--- a/src/test/ui/const-generics/issues/issue-775377.stderr
+++ b/src/test/ui/const-generics/issues/issue-775377.stderr
@@ -1,0 +1,11 @@
+error: overly complex generic constant
+  --> $DIR/issue-775377.rs:6:46
+   |
+LL | fn bug<'a, T>() -> &'static dyn MyTrait<[(); { |x: &'a u32| { x }; 4 }]> {
+   |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^ blocks are not supported in generic constant
+   |
+   = help: consider moving this anonymous constant into a `const` function
+   = note: this operation may be supported in the future
+
+error: aborting due to previous error
+

--- a/src/test/ui/const-generics/issues/issue-83993.rs
+++ b/src/test/ui/const-generics/issues/issue-83993.rs
@@ -1,0 +1,14 @@
+// check-pass
+
+#![feature(generic_const_exprs)]
+#![allow(incomplete_features)]
+
+fn bug<'a>()
+where
+    for<'b> [(); {
+        let x: &'b ();
+        0
+    }]:
+{}
+
+fn main() {}


### PR DESCRIPTION
The ICEs no longer occur since https://github.com/rust-lang/rust/pull/95776 so the revisions can be reenabled

Also adds some regression tests for issues that no longer ICE because of it

closes #77357
closes #78180
closes #83993