### PR TITLE
[WIP] Add `optimized_to_const` intrinsic

### DIFF
--- a/compiler/rustc_codegen_llvm/src/context.rs
+++ b/compiler/rustc_codegen_llvm/src/context.rs
@@ -103,6 +103,7 @@ pub struct CodegenCx<'ll, 'tcx> {
     pub rust_try_fn: Cell<Option<(&'ll Type, &'ll Value)>>,
 
     intrinsics: RefCell<FxHashMap<&'static str, (&'ll Type, &'ll Value)>>,
+    pub is_constant_intrinsics: RefCell<FxHashMap<Ty<'tcx>, (&'ll Type, &'ll Value)>>,
 
     /// A counter that is used for generating local symbol names
     local_gen_sym_counter: Cell<usize>,
@@ -442,6 +443,7 @@ impl<'ll, 'tcx> CodegenCx<'ll, 'tcx> {
             eh_catch_typeinfo: Cell::new(None),
             rust_try_fn: Cell::new(None),
             intrinsics: Default::default(),
+            is_constant_intrinsics: Default::default(),
             local_gen_sym_counter: Cell::new(0),
             renamed_statics: Default::default(),
         }

--- a/compiler/rustc_const_eval/src/interpret/intrinsics.rs
+++ b/compiler/rustc_const_eval/src/interpret/intrinsics.rs
@@ -451,6 +451,9 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 let result = self.raw_eq_intrinsic(&args[0], &args[1])?;
                 self.write_scalar(result, dest)?;
             }
+            sym::optimized_to_const => {
+                self.write_scalar(Scalar::from_bool(true), dest)?;
+            }
             _ => return Ok(false),
         }
 

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -986,6 +986,7 @@ symbols! {
         opt_out_copy,
         optimize,
         optimize_attribute,
+        optimized_to_const,
         optin_builtin_traits,
         option,
         option_env,

--- a/compiler/rustc_typeck/src/check/intrinsic.rs
+++ b/compiler/rustc_typeck/src/check/intrinsic.rs
@@ -102,6 +102,7 @@ pub fn intrinsic_operation_unsafety(intrinsic: Symbol) -> hir::Unsafety {
         | sym::type_name
         | sym::forget
         | sym::black_box
+        | sym::optimized_to_const
         | sym::variant_count => hir::Unsafety::Normal,
         _ => hir::Unsafety::Unsafe,
     }
@@ -396,6 +397,13 @@ pub fn check_intrinsic_type(tcx: TyCtxt<'_>, it: &hir::ForeignItem<'_>) {
             sym::black_box => (1, vec![param(0)], param(0)),
 
             sym::const_eval_select => (4, vec![param(0), param(1), param(2)], param(3)),
+
+            sym::optimized_to_const => {
+                let br = ty::BoundRegion { var: ty::BoundVar::from_u32(0), kind: ty::BrAnon(0) };
+                let param_ty =
+                    tcx.mk_imm_ref(tcx.mk_region(ty::ReLateBound(ty::INNERMOST, br)), param(0));
+                (1, vec![param_ty], tcx.types.bool)
+            }
 
             other => {
                 tcx.sess.emit_err(UnrecognizedIntrinsicFunction { span: it.span, name: other });

--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -1976,6 +1976,7 @@ extern "rust-intrinsic" {
     /// Determines if the supplied value is a constant or has been folded to a constant during
     /// optimization.
     #[cfg(not(bootstrap))]
+    #[rustc_const_unstable(feature = "core_intrinsics", issue = "none")]
     pub fn optimized_to_const<T>(value: &T) -> bool;
 }
 

--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -1972,6 +1972,11 @@ extern "rust-intrinsic" {
     /// [`std::hint::black_box`]: crate::hint::black_box
     #[rustc_const_unstable(feature = "const_black_box", issue = "none")]
     pub fn black_box<T>(dummy: T) -> T;
+
+    /// Determines if the supplied value is a constant or has been folded to a constant during
+    /// optimization.
+    #[cfg(not(bootstrap))]
+    pub fn optimized_to_const<T>(value: &T) -> bool;
 }
 
 // Some functions are defined here because they accidentally got made


### PR DESCRIPTION
This PR adds an `optimized_to_const` that is roughly equivalent to GCC's `__builtin_constant_p` -- returns true if the argument is folded to const and false is not.

Example::
```rust
#![feature(core_intrinsics)]

use core::intrinsics::optimized_to_const;

fn is_zero(x: &[u8]) -> bool {
    x.iter().all(|x| *x == 0)
}

#[inline(always)]
fn is_definitely_zero<const N: usize>(x: &[u8; N]) -> bool {
    if optimized_to_const(x) {
        is_zero(x)
    } else {
        false
    }
}

pub fn foo() -> bool {
    is_definitely_zero(&[0; 32])
}

pub fn bar() -> bool {
    is_definitely_zero(&[1; 32])
}

pub fn baz(v: &[u8; 32]) -> bool {
    is_definitely_zero(v)
}
```
This code snippet generates:
```objdump
Disassembly of section .text.example::foo:

0000000000000000 <example::foo>:
   0:	b0 01                	mov    $0x1,%al
   2:	c3                   	retq   

Disassembly of section .text.example::bar:

0000000000000000 <example::bar>:
   0:	31 c0                	xor    %eax,%eax
   2:	c3                   	retq   

Disassembly of section .text.example::baz:

0000000000000000 <example::baz>:
   0:	31 c0                	xor    %eax,%eax
   2:	c3                   	retq   
```

cc @scottmcm @Mark-Simulacrum

r? @ghost