### PR TITLE
Add `inline(always)` to a few functions that end up in `opt-level=z` compiled output

### DIFF
--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -2914,6 +2914,7 @@ impl<T, A: Allocator> AsMut<Vec<T, A>> for Vec<T, A> {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T, A: Allocator> AsRef<[T]> for Vec<T, A> {
+    #[inline(always)]
     fn as_ref(&self) -> &[T] {
         self
     }
@@ -2921,6 +2922,7 @@ impl<T, A: Allocator> AsRef<[T]> for Vec<T, A> {
 
 #[stable(feature = "vec_as_mut", since = "1.5.0")]
 impl<T, A: Allocator> AsMut<[T]> for Vec<T, A> {
+    #[inline(always)]
     fn as_mut(&mut self) -> &mut [T] {
         self
     }

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -2491,6 +2491,7 @@ impl<T: Copy, A: Allocator> ExtendFromWithinSpec for Vec<T, A> {
 impl<T, A: Allocator> ops::Deref for Vec<T, A> {
     type Target = [T];
 
+    #[inline(always)]
     fn deref(&self) -> &[T] {
         unsafe { slice::from_raw_parts(self.as_ptr(), self.len) }
     }
@@ -2498,6 +2499,7 @@ impl<T, A: Allocator> ops::Deref for Vec<T, A> {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T, A: Allocator> ops::DerefMut for Vec<T, A> {
+    #[inline(always)]
     fn deref_mut(&mut self) -> &mut [T] {
         unsafe { slice::from_raw_parts_mut(self.as_mut_ptr(), self.len) }
     }

--- a/library/core/src/any.rs
+++ b/library/core/src/any.rs
@@ -619,6 +619,7 @@ impl TypeId {
     #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_const_unstable(feature = "const_type_id", issue = "77125")]
+    #[inline(always)]
     pub const fn of<T: ?Sized + 'static>() -> TypeId {
         TypeId { t: intrinsics::type_id::<T>() }
     }


### PR DESCRIPTION
I've noticed these repeated many[^1] times in a projects `-Copt-level=z` output (rustc seems to manage to remove them for 2 and 3, but not `z`. I haven't checked `s`). You can see this behavior in an isolated case here: https://rust.godbolt.org/z/ThMrGeb6v. Note that I believe this only happens in the asm and static outputs (and presumably stuff like IR and the like, but I don't think this would help IR, since it still has `inline(always)` functions present).

[^1]: In smaller project I had around 30 copies of `TypeId::of`, over 100 copies of `<Vec<T> as AsRef<[T]>>::as_ref`, and even more for `Deref` -- tragically I've deleted the file with the counts (I'll get another one shortly, after the `x install` finishes and my computer returns to a usable state), but I think it was around 150 for each of the Derefs.

Anyway, as you might note, the functions do actually get inlined. They just... end up in the compiled output anyway. Someone explained to me why this happened at some point, but I've since forgotten it. Either way, in practice this has bad behavior with tooling (it confuses anything that looks at assembly or staticlib output), although this is probably not a *huge* deal, since I imagine that the linker which strips dead code is able to figure this out and remove them (and presumably users without such linker functionality have larger problems when it comes to code size).

So, in practice, this probably doesn't *actually* matter, although it leads to some... odd behaviors in addition to the tooling weirdness. For example, on `aarch64`, the machine-outliner pass (which isn't enabled on x86_64 for whatever reason -- perhaps it only supports aarch64) even bothers to go through the trouble of [deduplicating](https://rust.godbolt.org/z/c65j9n98q) many hundreds of these functions. This sort of thing seems... goofy, but is hopefully harmless.

Anyway, some of these pretty important and common functions, so this definitely needs a perf run before landing. Like, Deref/DerefMut for Vec is *really* important, and has a real chance of causing some... changes in terms of perf. So I'll be doing a perf run for this (after tests pass to make sure there's no major fumbles). That said, if it's too costly, I might try again without the patch adding `Deref` -- since that would still be an improvement.

P.S. `x install` is still running, and so I haven't verified this actually fixes the issue -- I'm just assuming it will. That said, given that I don't *really* remember why these are showing up in the first place, I could be mistaken. Sorry if this is the case -- It actually seems somewhat plausible to me so I'll wait to ensure this before kicking off the perf run.