### PR TITLE
Fix invalid keyword order for function declarations

### DIFF
--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -1020,7 +1020,7 @@ impl<'a> Parser<'a> {
                                 &format!("`{}` must come before `{}`", invalid_qual, current_qual),
                                 format!("{} {}", invalid_qual, current_qual),
                                 Applicability::MachineApplicable,
-                            ).note("keyword order for functions declaration is `default`, `pub`, `const`, `async`, `unsafe`, `extern`");
+                            ).note("keyword order for functions declaration is `pub`, `default`, `const`, `async`, `unsafe`, `extern`");
                     }
                 }
                 Err(err)
@@ -2086,7 +2086,7 @@ impl<'a> Parser<'a> {
                                     &format!("`{misplaced_qual}` must come before `{current_qual}`"),
                                     format!("{misplaced_qual} {current_qual}"),
                                     Applicability::MachineApplicable,
-                                ).note("keyword order for functions declaration is `default`, `pub`, `const`, `async`, `unsafe`, `extern`");
+                                ).note("keyword order for functions declaration is `pub`, `default`, `const`, `async`, `unsafe`, `extern`");
                         }
                     }
                     // Recover incorrect visibility order such as `async pub`

--- a/src/test/ui/async-await/no-async-const.stderr
+++ b/src/test/ui/async-await/no-async-const.stderr
@@ -7,7 +7,7 @@ LL | pub async const fn x() {}
    |     |     expected one of `extern`, `fn`, or `unsafe`
    |     help: `const` must come before `async`: `const async`
    |
-   = note: keyword order for functions declaration is `default`, `pub`, `const`, `async`, `unsafe`, `extern`
+   = note: keyword order for functions declaration is `pub`, `default`, `const`, `async`, `unsafe`, `extern`
 
 error: aborting due to previous error
 

--- a/src/test/ui/async-await/no-unsafe-async.stderr
+++ b/src/test/ui/async-await/no-unsafe-async.stderr
@@ -12,7 +12,7 @@ LL |     unsafe async fn g() {}
 LL | }
    | - the item list ends here
    |
-   = note: keyword order for functions declaration is `default`, `pub`, `const`, `async`, `unsafe`, `extern`
+   = note: keyword order for functions declaration is `pub`, `default`, `const`, `async`, `unsafe`, `extern`
 
 error: expected one of `extern` or `fn`, found keyword `async`
   --> $DIR/no-unsafe-async.rs:11:8
@@ -23,7 +23,7 @@ LL | unsafe async fn f() {}
    | |      expected one of `extern` or `fn`
    | help: `async` must come before `unsafe`: `async unsafe`
    |
-   = note: keyword order for functions declaration is `default`, `pub`, `const`, `async`, `unsafe`, `extern`
+   = note: keyword order for functions declaration is `pub`, `default`, `const`, `async`, `unsafe`, `extern`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/fn/keyword-order.rs
+++ b/src/test/ui/fn/keyword-order.rs
@@ -1,0 +1,6 @@
+// edition:2018
+
+default pub const async unsafe extern fn err() {} //~ ERROR `default` is not followed by an item
+//~^ ERROR expected item, found keyword `pub`
+
+pub default const async unsafe extern fn ok() {}

--- a/src/test/ui/fn/keyword-order.stderr
+++ b/src/test/ui/fn/keyword-order.stderr
@@ -1,0 +1,16 @@
+error: `default` is not followed by an item
+  --> $DIR/keyword-order.rs:3:1
+   |
+LL | default pub const async unsafe extern fn err() {}
+   | ^^^^^^^ the `default` qualifier
+   |
+   = note: only `fn`, `const`, `type`, or `impl` items may be prefixed by `default`
+
+error: expected item, found keyword `pub`
+  --> $DIR/keyword-order.rs:3:9
+   |
+LL | default pub const async unsafe extern fn err() {}
+   |         ^^^ expected item
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/parser/issues/issue-19398.stderr
+++ b/src/test/ui/parser/issues/issue-19398.stderr
@@ -12,7 +12,7 @@ LL |
 LL | }
    | - the item list ends here
    |
-   = note: keyword order for functions declaration is `default`, `pub`, `const`, `async`, `unsafe`, `extern`
+   = note: keyword order for functions declaration is `pub`, `default`, `const`, `async`, `unsafe`, `extern`
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/issues/issue-87217-keyword-order/several-kw-jump.rs
+++ b/src/test/ui/parser/issues/issue-87217-keyword-order/several-kw-jump.rs
@@ -11,4 +11,4 @@ async unsafe const fn test() {}
 //~| NOTE expected one of `extern` or `fn`
 //~| HELP `const` must come before `async unsafe`
 //~| SUGGESTION const async unsafe
-//~| NOTE keyword order for functions declaration is `default`, `pub`, `const`, `async`, `unsafe`, `extern`
+//~| NOTE keyword order for functions declaration is `pub`, `default`, `const`, `async`, `unsafe`, `extern`

--- a/src/test/ui/parser/issues/issue-87217-keyword-order/several-kw-jump.stderr
+++ b/src/test/ui/parser/issues/issue-87217-keyword-order/several-kw-jump.stderr
@@ -7,7 +7,7 @@ LL | async unsafe const fn test() {}
    | |            expected one of `extern` or `fn`
    | help: `const` must come before `async unsafe`: `const async unsafe`
    |
-   = note: keyword order for functions declaration is `default`, `pub`, `const`, `async`, `unsafe`, `extern`
+   = note: keyword order for functions declaration is `pub`, `default`, `const`, `async`, `unsafe`, `extern`
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/issues/issue-87217-keyword-order/wrong-async.rs
+++ b/src/test/ui/parser/issues/issue-87217-keyword-order/wrong-async.rs
@@ -11,4 +11,4 @@ unsafe async fn test() {}
 //~| NOTE expected one of `extern` or `fn`
 //~| HELP `async` must come before `unsafe`
 //~| SUGGESTION async unsafe
-//~| NOTE keyword order for functions declaration is `default`, `pub`, `const`, `async`, `unsafe`, `extern`
+//~| NOTE keyword order for functions declaration is `pub`, `default`, `const`, `async`, `unsafe`, `extern`

--- a/src/test/ui/parser/issues/issue-87217-keyword-order/wrong-async.stderr
+++ b/src/test/ui/parser/issues/issue-87217-keyword-order/wrong-async.stderr
@@ -7,7 +7,7 @@ LL | unsafe async fn test() {}
    | |      expected one of `extern` or `fn`
    | help: `async` must come before `unsafe`: `async unsafe`
    |
-   = note: keyword order for functions declaration is `default`, `pub`, `const`, `async`, `unsafe`, `extern`
+   = note: keyword order for functions declaration is `pub`, `default`, `const`, `async`, `unsafe`, `extern`
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/issues/issue-87217-keyword-order/wrong-const.rs
+++ b/src/test/ui/parser/issues/issue-87217-keyword-order/wrong-const.rs
@@ -11,4 +11,4 @@ unsafe const fn test() {}
 //~| NOTE expected one of `extern` or `fn`
 //~| HELP `const` must come before `unsafe`
 //~| SUGGESTION const unsafe
-//~| NOTE keyword order for functions declaration is `default`, `pub`, `const`, `async`, `unsafe`, `extern`
+//~| NOTE keyword order for functions declaration is `pub`, `default`, `const`, `async`, `unsafe`, `extern`

--- a/src/test/ui/parser/issues/issue-87217-keyword-order/wrong-const.stderr
+++ b/src/test/ui/parser/issues/issue-87217-keyword-order/wrong-const.stderr
@@ -7,7 +7,7 @@ LL | unsafe const fn test() {}
    | |      expected one of `extern` or `fn`
    | help: `const` must come before `unsafe`: `const unsafe`
    |
-   = note: keyword order for functions declaration is `default`, `pub`, `const`, `async`, `unsafe`, `extern`
+   = note: keyword order for functions declaration is `pub`, `default`, `const`, `async`, `unsafe`, `extern`
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/issues/issue-87217-keyword-order/wrong-unsafe.rs
+++ b/src/test/ui/parser/issues/issue-87217-keyword-order/wrong-unsafe.rs
@@ -11,4 +11,4 @@ extern unsafe fn test() {}
 //~| NOTE expected `fn`
 //~| HELP `unsafe` must come before `extern`
 //~| SUGGESTION unsafe extern
-//~| NOTE keyword order for functions declaration is `default`, `pub`, `const`, `async`, `unsafe`, `extern`
+//~| NOTE keyword order for functions declaration is `pub`, `default`, `const`, `async`, `unsafe`, `extern`

--- a/src/test/ui/parser/issues/issue-87217-keyword-order/wrong-unsafe.stderr
+++ b/src/test/ui/parser/issues/issue-87217-keyword-order/wrong-unsafe.stderr
@@ -7,7 +7,7 @@ LL | extern unsafe fn test() {}
    | |      expected `fn`
    | help: `unsafe` must come before `extern`: `unsafe extern`
    |
-   = note: keyword order for functions declaration is `default`, `pub`, `const`, `async`, `unsafe`, `extern`
+   = note: keyword order for functions declaration is `pub`, `default`, `const`, `async`, `unsafe`, `extern`
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Closes: https://github.com/rust-lang/rust/issues/94879