### PR TITLE
Include nonexported macro_rules! macros in the doctest target

### DIFF
--- a/library/core/src/internal_macros.rs
+++ b/library/core/src/internal_macros.rs
@@ -190,7 +190,7 @@ macro_rules! impl_fn_for_zst {
 ///
 /// # Example
 ///
-/// ```
+/// ```ignore(cannot-test-this-because-non-exported-macro)
 /// cfg_if! {
 ///     if #[cfg(unix)] {
 ///         fn foo() { /* unix specific functionality */ }

--- a/src/librustdoc/doctest.rs
+++ b/src/librustdoc/doctest.rs
@@ -1225,16 +1225,6 @@ impl<'a, 'hir, 'tcx> intravisit::Visitor<'hir> for HirCollector<'a, 'hir, 'tcx> 
 
     fn visit_item(&mut self, item: &'hir hir::Item<'_>) {
         let name = match &item.kind {
-            hir::ItemKind::Macro(ref macro_def, _) => {
-                // FIXME(#88038): Non exported macros have historically not been tested,
-                // but we really ought to start testing them.
-                let def_id = item.def_id.to_def_id();
-                if macro_def.macro_rules && !self.tcx.has_attr(def_id, sym::macro_export) {
-                    intravisit::walk_item(self, item);
-                    return;
-                }
-                item.ident.to_string()
-            }
             hir::ItemKind::Impl(impl_) => {
                 rustc_hir_pretty::id_to_string(&self.map, impl_.self_ty.hir_id)
             }

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -96,7 +96,7 @@ use crate::passes::collect_intra_doc_links;
 ///
 /// Example:
 ///
-/// ```
+/// ```ignore(cannot-test-this-because-non-exported-macro)
 /// let letters = map!{"a" => "b", "c" => "d"};
 /// ```
 ///


### PR DESCRIPTION
Fixes #88038 

This PR aims to include nonexported `macro_rules!` macros in the doctest target. For more details, please see the above issue.