### PR TITLE
Fix typo in `offset_from` documentation

### DIFF
--- a/library/core/src/ptr/const_ptr.rs
+++ b/library/core/src/ptr/const_ptr.rs
@@ -518,7 +518,7 @@ impl<T: ?Sized> *const T {
     }
 
     /// Calculates the distance between two pointers. The returned value is in
-    /// units of T: the distance in bytes is divided by `mem::size_of::<T>()`.
+    /// units of T: the distance in bytes divided by `mem::size_of::<T>()`.
     ///
     /// This function is the inverse of [`offset`].
     ///

--- a/library/core/src/ptr/mut_ptr.rs
+++ b/library/core/src/ptr/mut_ptr.rs
@@ -696,7 +696,7 @@ impl<T: ?Sized> *mut T {
     }
 
     /// Calculates the distance between two pointers. The returned value is in
-    /// units of T: the distance in bytes is divided by `mem::size_of::<T>()`.
+    /// units of T: the distance in bytes divided by `mem::size_of::<T>()`.
     ///
     /// This function is the inverse of [`offset`].
     ///


### PR DESCRIPTION
Small fix for what I think is a typo in the `offset_from` documentation.

Someone reading this may understand that the distance in bytes is obtained by dividing the distance by `mem::size_of::<T>()`, but here we just want to define "units of T" in terms of bytes (i.e., units of T == bytes / `mem::size_of::<T>()`).