### PR TITLE
Collect function instance used in `global_asm!` sym operand

### DIFF
--- a/compiler/rustc_monomorphize/src/collector.rs
+++ b/compiler/rustc_monomorphize/src/collector.rs
@@ -445,12 +445,9 @@ fn collect_items_rec<'tcx>(
                             // depend on any other items.
                         }
                         hir::InlineAsmOperand::SymFn { anon_const } => {
-                            let def_id = tcx.hir().body_owner_def_id(anon_const.body).to_def_id();
-                            if let Ok(val) = tcx.const_eval_poly(def_id) {
-                                rustc_data_structures::stack::ensure_sufficient_stack(|| {
-                                    collect_const_value(tcx, val, &mut neighbors);
-                                });
-                            }
+                            let fn_ty =
+                                tcx.typeck_body(anon_const.body).node_type(anon_const.hir_id);
+                            visit_fn_use(tcx, fn_ty, false, *op_sp, &mut neighbors);
                         }
                         hir::InlineAsmOperand::SymStatic { path: _, def_id } => {
                             let instance = Instance::mono(tcx, *def_id);

--- a/src/test/assembly/asm/global_asm.rs
+++ b/src/test/assembly/asm/global_asm.rs
@@ -2,6 +2,7 @@
 // only-linux
 // assembly-output: emit-asm
 // compile-flags: -C llvm-args=--x86-asm-syntax=intel
+// compile-flags: -C symbol-mangling-version=v0
 
 #![feature(asm_const, asm_sym)]
 #![crate_type = "rlib"]
@@ -24,3 +25,7 @@ global_asm!("movl ${}, %ecx", const 5, options(att_syntax));
 global_asm!("call {}", sym my_func);
 // CHECK: lea rax, [rip + MY_STATIC]
 global_asm!("lea rax, [rip + {}]", sym MY_STATIC);
+// CHECK: call _RNvCsiubXh4Yz005_10global_asm6foobar
+global_asm!("call {}", sym foobar);
+// CHECK: _RNvCsiubXh4Yz005_10global_asm6foobar:
+fn foobar() { loop {} }


### PR DESCRIPTION
The constants used in SymFn operands have FnDef type,
so the type of the constant identifies the function.

Fixes #96623.