### PR TITLE
Improve error for missing cmake

### DIFF
--- a/src/bootstrap/sanity.rs
+++ b/src/bootstrap/sanity.rs
@@ -94,7 +94,18 @@ pub fn check(build: &mut Build) {
             .any(|build_llvm_ourselves| build_llvm_ourselves);
     let need_cmake = building_llvm || build.config.any_sanitizers_enabled();
     if need_cmake {
-        cmd_finder.must_have("cmake");
+        if cmd_finder.maybe_have("cmake").is_none() {
+            eprintln!(
+                "
+Couldn't find required command: cmake
+
+You should install cmake, or set `download-ci-llvm = true` in the
+`[llvm]` section section of `config.toml` to download LLVM rather
+than building it.
+"
+            );
+            std::process::exit(1);
+        }
     }
 
     build.config.python = build


### PR DESCRIPTION
This PR updates the error message for a missing `cmake` to be more in line with the error message for a missing installation of `ninja`. 
The original issue, (#90679), suggests that both `ninja` and `cmake` are only needed for building LLVM, so I have included the suggestion from `ninja` to set `download-ci-llvm = true` if the user would rather download LLVM. If `cmake` actually is used in other areas, I can remove that part of the message.

Fixes: #90679