### PR TITLE
Fix flaky rustdoc-ui test because it did not replace time result

### DIFF
--- a/src/test/rustdoc-ui/block-doc-comment.rs
+++ b/src/test/rustdoc-ui/block-doc-comment.rs
@@ -1,5 +1,6 @@
 // check-pass
 // compile-flags:--test
+// normalize-stdout-test "finished in \d+\.\d+s" -> "finished in $$TIME"
 
 // This test ensures that no code block is detected in the doc comments.
 

--- a/src/test/rustdoc-ui/block-doc-comment.stdout
+++ b/src/test/rustdoc-ui/block-doc-comment.stdout
@@ -1,5 +1,5 @@
 
 running 0 tests
 
-test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
 


### PR DESCRIPTION
As mentioned in https://github.com/rust-lang/rust/pull/93715: a test is flaky because I forgot to replace the time value.

This PR fixes it.

r? @petrochenkov 