### PR TITLE
rustdoc: Remove doc link resolution fallback to all `macro_rules` in the crate

### DIFF
--- a/src/test/rustdoc-ui/intra-doc/macro-rules-error.rs
+++ b/src/test/rustdoc-ui/intra-doc/macro-rules-error.rs
@@ -10,12 +10,11 @@ mod no_escape {
     }
 }
 
-/// [before_but_limited_to_module] FIXME: This error should be reported
-// ERROR unresolved link to `before_but_limited_to_module`
-/// [after] FIXME: This error should be reported
-// ERROR unresolved link to `after`
-/// [str] FIXME: This error shouldn not be reported
-//~^ ERROR `str` is both a builtin type and a macro
+/// [before_but_limited_to_module]
+//~^ ERROR unresolved link to `before_but_limited_to_module`
+/// [after]
+//~^ ERROR unresolved link to `after`
+/// [str]
 fn check() {}
 
 macro_rules! after {

--- a/src/test/rustdoc-ui/intra-doc/macro-rules-error.stderr
+++ b/src/test/rustdoc-ui/intra-doc/macro-rules-error.stderr
@@ -1,22 +1,23 @@
-error: `str` is both a builtin type and a macro
-  --> $DIR/macro-rules-error.rs:17:6
+error: unresolved link to `before_but_limited_to_module`
+  --> $DIR/macro-rules-error.rs:13:6
    |
-LL | /// [str] FIXME: This error shouldn not be reported
-   |      ^^^ ambiguous link
+LL | /// [before_but_limited_to_module]
+   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no item named `before_but_limited_to_module` in scope
    |
 note: the lint level is defined here
   --> $DIR/macro-rules-error.rs:5:9
    |
 LL | #![deny(rustdoc::broken_intra_doc_links)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-help: to link to the builtin type, prefix with `prim@`
-   |
-LL | /// [prim@str] FIXME: This error shouldn not be reported
-   |      +++++
-help: to link to the macro, add an exclamation mark
-   |
-LL | /// [str!] FIXME: This error shouldn not be reported
-   |         +
+   = note: `macro_rules` named `before_but_limited_to_module` exists in this crate, but it is not in scope at this link's location
 
-error: aborting due to previous error
+error: unresolved link to `after`
+  --> $DIR/macro-rules-error.rs:15:6
+   |
+LL | /// [after]
+   |      ^^^^^ no item named `after` in scope
+   |
+   = note: `macro_rules` named `after` exists in this crate, but it is not in scope at this link's location
+
+error: aborting due to 2 previous errors
 


### PR DESCRIPTION
Fallback to all `macro_rules` in the crate is removed, as discussed in https://github.com/rust-lang/rust/pull/96521, with compatibility measures described in https://github.com/rust-lang/rust/pull/96676#issuecomment-1126285563.