### PR TITLE
Quick fix for #96223.

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -866,7 +866,13 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                 return false;
             }
 
-            let orig_ty = old_pred.self_ty().skip_binder();
+            // This is a quick fix to resolve an ICE ([issue#96223](https://github.com/rust-lang/rust/issues/96223)).
+            // This change should probably be deeper.
+            // As suggested by @jackh726, `mk_trait_obligation_with_new_self_ty` could take a `Binder<(TraitRef, Ty)>
+            // instead of `Binder<Ty>` leading to some changes to its call places.
+            let Some(orig_ty) = old_pred.self_ty().no_bound_vars() else {
+                return false;
+            };
             let mk_result = |new_ty| {
                 let obligation =
                     self.mk_trait_obligation_with_new_self_ty(param_env, old_pred, new_ty);

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -866,7 +866,7 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                 return false;
             }
 
-            // This is a quick fix to resolve an ICE ([issue#96223](https://github.com/rust-lang/rust/issues/96223)).
+            // This is a quick fix to resolve an ICE (#96223).
             // This change should probably be deeper.
             // As suggested by @jackh726, `mk_trait_obligation_with_new_self_ty` could take a `Binder<(TraitRef, Ty)>
             // instead of `Binder<Ty>` leading to some changes to its call places.

--- a/src/test/ui/suggestions/issue-96223.rs
+++ b/src/test/ui/suggestions/issue-96223.rs
@@ -1,6 +1,5 @@
-// Test case for #96223.
-// An ICE was triggered because of a failed assertion.
-// Thanks to @Manishearth for the minimal test case.
+// Previously ICEd because we didn't properly track binders in suggestions
+// check-fail
 
 pub trait Foo<'de>: Sized {}
 
@@ -47,7 +46,7 @@ fn icey_bounds<D: Dummy<EmptyMarker>>(p: &D) {}
 
 fn trigger_ice() {
     let p = Empty;
-    icey_bounds(&p); //~ERROR
+    icey_bounds(&p); //~ERROR the trait bound
 }
 
 fn main() {}

--- a/src/test/ui/suggestions/issue-96223.stderr
+++ b/src/test/ui/suggestions/issue-96223.stderr
@@ -1,0 +1,28 @@
+error[E0277]: the trait bound `for<'de> EmptyBis<'de>: Foo<'_>` is not satisfied
+  --> $DIR/issue-96223.rs:50:17
+   |
+LL |     icey_bounds(&p);
+   |     ----------- ^^ the trait `for<'de> Foo<'_>` is not implemented for `EmptyBis<'de>`
+   |     |
+   |     required by a bound introduced by this call
+   |
+   = help: the trait `Foo<'de>` is implemented for `Baz<T>`
+note: required because of the requirements on the impl of `for<'de> Foo<'de>` for `Baz<EmptyBis<'de>>`
+  --> $DIR/issue-96223.rs:17:14
+   |
+LL | impl<'de, T> Foo<'de> for Baz<T> where T: Foo<'de> {}
+   |              ^^^^^^^^     ^^^^^^
+note: required because of the requirements on the impl of `Dummy<EmptyMarker>` for `Empty`
+  --> $DIR/issue-96223.rs:21:9
+   |
+LL | impl<M> Dummy<M> for Empty
+   |         ^^^^^^^^     ^^^^^
+note: required by a bound in `icey_bounds`
+  --> $DIR/issue-96223.rs:46:19
+   |
+LL | fn icey_bounds<D: Dummy<EmptyMarker>>(p: &D) {}
+   |                   ^^^^^^^^^^^^^^^^^^ required by this bound in `icey_bounds`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/suggestions/issue-96223.stderr
+++ b/src/test/ui/suggestions/issue-96223.stderr
@@ -1,5 +1,5 @@
 error[E0277]: the trait bound `for<'de> EmptyBis<'de>: Foo<'_>` is not satisfied
-  --> $DIR/issue-96223.rs:50:17
+  --> $DIR/issue-96223.rs:49:17
    |
 LL |     icey_bounds(&p);
    |     ----------- ^^ the trait `for<'de> Foo<'_>` is not implemented for `EmptyBis<'de>`
@@ -8,17 +8,17 @@ LL |     icey_bounds(&p);
    |
    = help: the trait `Foo<'de>` is implemented for `Baz<T>`
 note: required because of the requirements on the impl of `for<'de> Foo<'de>` for `Baz<EmptyBis<'de>>`
-  --> $DIR/issue-96223.rs:17:14
+  --> $DIR/issue-96223.rs:16:14
    |
 LL | impl<'de, T> Foo<'de> for Baz<T> where T: Foo<'de> {}
    |              ^^^^^^^^     ^^^^^^
 note: required because of the requirements on the impl of `Dummy<EmptyMarker>` for `Empty`
-  --> $DIR/issue-96223.rs:21:9
+  --> $DIR/issue-96223.rs:20:9
    |
 LL | impl<M> Dummy<M> for Empty
    |         ^^^^^^^^     ^^^^^
 note: required by a bound in `icey_bounds`
-  --> $DIR/issue-96223.rs:46:19
+  --> $DIR/issue-96223.rs:45:19
    |
 LL | fn icey_bounds<D: Dummy<EmptyMarker>>(p: &D) {}
    |                   ^^^^^^^^^^^^^^^^^^ required by this bound in `icey_bounds`


### PR DESCRIPTION
This PR is a quick fix regarding #96223.

As mentioned in the issue, others modification could be added to not elide types with bound vars from suggestions.

Special thanks to @jackh726 for mentoring and @Manishearth for minimal test case.

r? @jackh726 