### PR TITLE
Render all trait bounds in where clauses in rustdoc

### DIFF
--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -1362,15 +1362,9 @@ impl WherePredicate {
 
 #[derive(Clone, PartialEq, Eq, Debug, Hash)]
 pub(crate) enum GenericParamDefKind {
-    Lifetime { outlives: Vec<Lifetime> },
-    Type { did: DefId, bounds: Vec<GenericBound>, default: Option<Box<Type>>, synthetic: bool },
+    Lifetime,
+    Type { did: DefId, default: Option<Box<Type>>, synthetic: bool },
     Const { did: DefId, ty: Box<Type>, default: Option<Box<String>> },
-}
-
-impl GenericParamDefKind {
-    pub(crate) fn is_type(&self) -> bool {
-        matches!(self, GenericParamDefKind::Type { .. })
-    }
 }
 
 #[derive(Clone, PartialEq, Eq, Debug, Hash)]
@@ -1381,24 +1375,13 @@ pub(crate) struct GenericParamDef {
 
 // `GenericParamDef` is used in many places. Make sure it doesn't unintentionally get bigger.
 #[cfg(all(target_arch = "x86_64", target_pointer_width = "64"))]
-rustc_data_structures::static_assert_size!(GenericParamDef, 56);
+rustc_data_structures::static_assert_size!(GenericParamDef, 40);
 
 impl GenericParamDef {
     pub(crate) fn is_synthetic_type_param(&self) -> bool {
         match self.kind {
-            GenericParamDefKind::Lifetime { .. } | GenericParamDefKind::Const { .. } => false,
+            GenericParamDefKind::Lifetime | GenericParamDefKind::Const { .. } => false,
             GenericParamDefKind::Type { synthetic, .. } => synthetic,
-        }
-    }
-
-    pub(crate) fn is_type(&self) -> bool {
-        self.kind.is_type()
-    }
-
-    pub(crate) fn get_bounds(&self) -> Option<&[GenericBound]> {
-        match self.kind {
-            GenericParamDefKind::Type { ref bounds, .. } => Some(bounds),
-            _ => None,
         }
     }
 }

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -182,31 +182,9 @@ impl clean::GenericParamDef {
         cx: &'a Context<'tcx>,
     ) -> impl fmt::Display + 'a + Captures<'tcx> {
         display_fn(move |f| match &self.kind {
-            clean::GenericParamDefKind::Lifetime { outlives } => {
-                write!(f, "{}", self.name)?;
-
-                if !outlives.is_empty() {
-                    f.write_str(": ")?;
-                    for (i, lt) in outlives.iter().enumerate() {
-                        if i != 0 {
-                            f.write_str(" + ")?;
-                        }
-                        write!(f, "{}", lt.print())?;
-                    }
-                }
-
-                Ok(())
-            }
-            clean::GenericParamDefKind::Type { bounds, default, .. } => {
+            clean::GenericParamDefKind::Lifetime => write!(f, "{}", self.name),
+            clean::GenericParamDefKind::Type { default, .. } => {
                 f.write_str(self.name.as_str())?;
-
-                if !bounds.is_empty() {
-                    if f.alternate() {
-                        write!(f, ": {:#}", print_generic_bounds(bounds, cx))?;
-                    } else {
-                        write!(f, ":&nbsp;{}", print_generic_bounds(bounds, cx))?;
-                    }
-                }
 
                 if let Some(ref ty) = default {
                     if f.alternate() {

--- a/src/librustdoc/html/render/search_index.rs
+++ b/src/librustdoc/html/render/search_index.rs
@@ -351,7 +351,7 @@ fn add_generics_and_bounds_as_types<'tcx, 'a>(
 
     // If this argument is a type parameter and not a trait bound or a type, we need to look
     // for its bounds.
-    if let Type::Generic(arg_s) = *arg {
+    if let Type::Generic(_) = *arg {
         // First we check if the bounds are in a `where` predicate...
         if let Some(where_pred) = generics.where_predicates.iter().find(|g| match g {
             WherePredicate::BoundPredicate { ty, .. } => ty.def_id(cache) == arg.def_id(cache),
@@ -377,25 +377,6 @@ fn add_generics_and_bounds_as_types<'tcx, 'a>(
                             _ => {}
                         }
                     }
-                }
-            }
-            insert_ty(res, tcx, arg.clone(), ty_generics, cache);
-        }
-        // Otherwise we check if the trait bounds are "inlined" like `T: Option<u32>`...
-        if let Some(bound) = generics.params.iter().find(|g| g.is_type() && g.name == arg_s) {
-            let mut ty_generics = Vec::new();
-            for bound in bound.get_bounds().unwrap_or(&[]) {
-                if let Some(path) = bound.get_trait_path() {
-                    let ty = Type::Path { path };
-                    add_generics_and_bounds_as_types(
-                        self_,
-                        generics,
-                        &ty,
-                        tcx,
-                        recurse + 1,
-                        &mut ty_generics,
-                        cache,
-                    );
                 }
             }
             insert_ty(res, tcx, arg.clone(), ty_generics, cache);

--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -351,11 +351,8 @@ impl FromWithTcx<clean::GenericParamDefKind> for GenericParamDefKind {
     fn from_tcx(kind: clean::GenericParamDefKind, tcx: TyCtxt<'_>) -> Self {
         use clean::GenericParamDefKind::*;
         match kind {
-            Lifetime { outlives } => GenericParamDefKind::Lifetime {
-                outlives: outlives.into_iter().map(|lt| lt.0.to_string()).collect(),
-            },
-            Type { did: _, bounds, default, synthetic } => GenericParamDefKind::Type {
-                bounds: bounds.into_iter().map(|x| x.into_tcx(tcx)).collect(),
+            Lifetime => GenericParamDefKind::Lifetime,
+            Type { did: _, default, synthetic } => GenericParamDefKind::Type {
                 default: default.map(|x| (*x).into_tcx(tcx)),
                 synthetic,
             },
@@ -378,7 +375,7 @@ impl FromWithTcx<clean::WherePredicate> for WherePredicate {
                     .into_iter()
                     .map(|x| GenericParamDef {
                         name: x.0.to_string(),
-                        kind: GenericParamDefKind::Lifetime { outlives: vec![] },
+                        kind: GenericParamDefKind::Lifetime,
                     })
                     .collect(),
             },

--- a/src/rustdoc-json-types/lib.rs
+++ b/src/rustdoc-json-types/lib.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 use serde::{Deserialize, Serialize};
 
 /// rustdoc format-version.
-pub const FORMAT_VERSION: u32 = 15;
+pub const FORMAT_VERSION: u32 = 16;
 
 /// A `Crate` is the root of the emitted JSON blob. It contains all type/documentation information
 /// about the language items in the local crate, as well as info about external items to allow
@@ -346,11 +346,8 @@ pub struct GenericParamDef {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum GenericParamDefKind {
-    Lifetime {
-        outlives: Vec<String>,
-    },
+    Lifetime,
     Type {
-        bounds: Vec<GenericBound>,
         default: Option<Type>,
         /// This is normally `false`, which means that this generic parameter is
         /// declared in the Rust source text.

--- a/src/test/rustdoc-js/generics-multi-trait.js
+++ b/src/test/rustdoc-js/generics-multi-trait.js
@@ -9,20 +9,12 @@ const QUERY = [
 const EXPECTED = [
     // check one of the generic items
     {
-        'in_args': [
-            { 'path': 'generics_multi_trait', 'name': 'beta' },
-        ],
-        'returned': [
-            { 'path': 'generics_multi_trait', 'name': 'bet' },
-        ],
+        'in_args': [],
+        'returned': [],
     },
     {
-        'in_args': [
-            { 'path': 'generics_multi_trait', 'name': 'beta' },
-        ],
-        'returned': [
-            { 'path': 'generics_multi_trait', 'name': 'bet' },
-        ],
+        'in_args': [],
+        'returned': [],
     },
     // ignore the name of the generic itself
     {

--- a/src/test/rustdoc-js/generics-trait.js
+++ b/src/test/rustdoc-js/generics-trait.js
@@ -5,19 +5,11 @@ const QUERY = [
 
 const EXPECTED = [
     {
-        'in_args': [
-            { 'path': 'generics_trait', 'name': 'beta' },
-        ],
-        'returned': [
-            { 'path': 'generics_trait', 'name': 'bet' },
-        ],
+        'in_args': [],
+        'returned': [],
     },
     {
-        'in_args': [
-            { 'path': 'generics_trait', 'name': 'alpha' },
-        ],
-        'returned': [
-            { 'path': 'generics_trait', 'name': 'alef' },
-        ],
+        'in_args': [],
+        'returned': [],
     },
 ];

--- a/src/test/rustdoc-js/generics.js
+++ b/src/test/rustdoc-js/generics.js
@@ -50,15 +50,11 @@ const EXPECTED = [
     },
     {
         // TraitCat
-        'in_args': [
-            { 'path': 'generics', 'name': 'gamma' },
-        ],
+        'in_args': [],
     },
     {
         // TraitDog
-        'in_args': [
-            { 'path': 'generics', 'name': 'gamma' },
-        ],
+        'in_args': [],
     },
     {
         // Result<String>

--- a/src/test/rustdoc-json/fn_pointer/generics.rs
+++ b/src/test/rustdoc-json/fn_pointer/generics.rs
@@ -10,5 +10,5 @@
 // @is - "$.index[*][?(@.name=='WithHigherRankTraitBounds')].inner.type.inner.decl.output" '{ "kind": "primitive", "inner": "i32" }'
 // @count - "$.index[*][?(@.name=='WithHigherRankTraitBounds')].inner.type.inner.generic_params[*]" 1
 // @is - "$.index[*][?(@.name=='WithHigherRankTraitBounds')].inner.type.inner.generic_params[0].name" \"\'c\"
-// @is - "$.index[*][?(@.name=='WithHigherRankTraitBounds')].inner.type.inner.generic_params[0].kind" '{ "lifetime": { "outlives": [] } }'
+// @is - "$.index[*][?(@.name=='WithHigherRankTraitBounds')].inner.type.inner.generic_params[0].kind" '"lifetime"'
 pub type WithHigherRankTraitBounds = for<'c> fn(val: &'c i32) -> i32;

--- a/src/test/rustdoc-json/fns/generic_args.rs
+++ b/src/test/rustdoc-json/fns/generic_args.rs
@@ -9,32 +9,32 @@ pub trait Foo {}
 // @set generic_foo = generic_args.json "$.index[*][?(@.name=='GenericFoo')].id"
 pub trait GenericFoo<'a> {}
 
-// @is - "$.index[*][?(@.name=='generics')].inner.generics.where_predicates" "[]"
 // @count - "$.index[*][?(@.name=='generics')].inner.generics.params[*]" 1
 // @is - "$.index[*][?(@.name=='generics')].inner.generics.params[0].name" '"F"'
 // @is - "$.index[*][?(@.name=='generics')].inner.generics.params[0].kind.type.default" 'null'
-// @count - "$.index[*][?(@.name=='generics')].inner.generics.params[0].kind.type.bounds[*]" 1
-// @is - "$.index[*][?(@.name=='generics')].inner.generics.params[0].kind.type.bounds[0].trait_bound.trait.inner.id" '$foo'
 // @count - "$.index[*][?(@.name=='generics')].inner.decl.inputs[*]" 1
 // @is - "$.index[*][?(@.name=='generics')].inner.decl.inputs[0][0]" '"f"'
 // @is - "$.index[*][?(@.name=='generics')].inner.decl.inputs[0][1].kind" '"generic"'
 // @is - "$.index[*][?(@.name=='generics')].inner.decl.inputs[0][1].inner" '"F"'
+// @count - "$.index[*][?(@.name=='generics')].inner.generics.where_predicates" 1
+// @is - "$.index[*][?(@.name=='generics')].inner.generics.where_predicates[0].bound_predicate.type" '{"inner": "F", "kind": "generic"}'
+// @count - "$.index[*][?(@.name=='generics')].inner.generics.where_predicates[0].bound_predicate.bounds[*]" 1
+// @is - "$.index[*][?(@.name=='generics')].inner.generics.where_predicates[0].bound_predicate.bounds[0].trait_bound.trait.inner.id" '$foo'
 pub fn generics<F: Foo>(f: F) {}
 
-// @is - "$.index[*][?(@.name=='impl_trait')].inner.generics.where_predicates" "[]"
 // @count - "$.index[*][?(@.name=='impl_trait')].inner.generics.params[*]" 1
 // @is - "$.index[*][?(@.name=='impl_trait')].inner.generics.params[0].name" '"impl Foo"'
-// @is - "$.index[*][?(@.name=='impl_trait')].inner.generics.params[0].kind.type.bounds[0].trait_bound.trait.inner.id" $foo
 // @count - "$.index[*][?(@.name=='impl_trait')].inner.decl.inputs[*]" 1
 // @is - "$.index[*][?(@.name=='impl_trait')].inner.decl.inputs[0][0]" '"f"'
 // @is - "$.index[*][?(@.name=='impl_trait')].inner.decl.inputs[0][1].kind" '"impl_trait"'
 // @count - "$.index[*][?(@.name=='impl_trait')].inner.decl.inputs[0][1].inner[*]" 1
 // @is - "$.index[*][?(@.name=='impl_trait')].inner.decl.inputs[0][1].inner[0].trait_bound.trait.inner.id" $foo
+// @is - "$.index[*][?(@.name=='impl_trait')].inner.generics.where_predicates" '[]'
 pub fn impl_trait(f: impl Foo) {}
 
 // @count - "$.index[*][?(@.name=='where_clase')].inner.generics.params[*]" 3
 // @is - "$.index[*][?(@.name=='where_clase')].inner.generics.params[0].name" '"F"'
-// @is - "$.index[*][?(@.name=='where_clase')].inner.generics.params[0].kind" '{"type": {"bounds": [], "default": null, "synthetic": false}}'
+// @is - "$.index[*][?(@.name=='where_clase')].inner.generics.params[0].kind" '{"type": {"default": null, "synthetic": false}}'
 // @count - "$.index[*][?(@.name=='where_clase')].inner.decl.inputs[*]" 3
 // @is - "$.index[*][?(@.name=='where_clase')].inner.decl.inputs[0][0]" '"f"'
 // @is - "$.index[*][?(@.name=='where_clase')].inner.decl.inputs[0][1].kind" '"generic"'
@@ -50,7 +50,7 @@ pub fn impl_trait(f: impl Foo) {}
 // @is - "$.index[*][?(@.name=='where_clase')].inner.generics.where_predicates[1].bound_predicate.bounds[0].trait_bound.trait.inner.id" $generic_foo
 // @count - "$.index[*][?(@.name=='where_clase')].inner.generics.where_predicates[1].bound_predicate.bounds[0].trait_bound.generic_params[*]" 1
 // @is - "$.index[*][?(@.name=='where_clase')].inner.generics.where_predicates[1].bound_predicate.bounds[0].trait_bound.generic_params[0].name" \"\'a\"
-// @is - "$.index[*][?(@.name=='where_clase')].inner.generics.where_predicates[1].bound_predicate.bounds[0].trait_bound.generic_params[0].kind" '{ "lifetime": { "outlives": [] } }'
+// @is - "$.index[*][?(@.name=='where_clase')].inner.generics.where_predicates[1].bound_predicate.bounds[0].trait_bound.generic_params[0].kind" '"lifetime"'
 // @is - "$.index[*][?(@.name=='where_clase')].inner.generics.where_predicates[1].bound_predicate.generic_params" "[]"
 
 // @is - "$.index[*][?(@.name=='where_clase')].inner.generics.where_predicates[2].bound_predicate.type.kind" '"borrowed_ref"'
@@ -61,7 +61,7 @@ pub fn impl_trait(f: impl Foo) {}
 // @is - "$.index[*][?(@.name=='where_clase')].inner.generics.where_predicates[2].bound_predicate.bounds[0].trait_bound.generic_params" "[]"
 // @count - "$.index[*][?(@.name=='where_clase')].inner.generics.where_predicates[2].bound_predicate.generic_params[*]" 1
 // @is - "$.index[*][?(@.name=='where_clase')].inner.generics.where_predicates[2].bound_predicate.generic_params[0].name" \"\'b\"
-// @is - "$.index[*][?(@.name=='where_clase')].inner.generics.where_predicates[2].bound_predicate.generic_params[0].kind" '{ "lifetime": { "outlives": [] } }'
+// @is - "$.index[*][?(@.name=='where_clase')].inner.generics.where_predicates[2].bound_predicate.generic_params[0].kind" '"lifetime"'
 pub fn where_clase<F, G, H>(f: F, g: G, h: H)
 where
     F: Foo,

--- a/src/test/rustdoc-json/fns/generics.rs
+++ b/src/test/rustdoc-json/fns/generics.rs
@@ -6,11 +6,11 @@
 // @set wham_id = generics.json "$.index[*][?(@.name=='Wham')].id"
 pub trait Wham {}
 
-// @is    - "$.index[*][?(@.name=='one_generic_param_fn')].inner.generics.where_predicates" []
 // @count - "$.index[*][?(@.name=='one_generic_param_fn')].inner.generics.params[*]" 1
 // @is    - "$.index[*][?(@.name=='one_generic_param_fn')].inner.generics.params[0].name" '"T"'
 // @has   - "$.index[*][?(@.name=='one_generic_param_fn')].inner.generics.params[0].kind.type.synthetic" false
-// @has   - "$.index[*][?(@.name=='one_generic_param_fn')].inner.generics.params[0].kind.type.bounds[0].trait_bound.trait.inner.id" $wham_id
+// @is    - "$.index[*][?(@.name=='one_generic_param_fn')].inner.generics.where_predicates[0].bound_predicate.type" '{"kind": "generic", "inner": "T"}'
+// @has   - "$.index[*][?(@.name=='one_generic_param_fn')].inner.generics.where_predicates[0].bound_predicate.bounds[0].trait_bound.trait.inner.id" $wham_id
 // @is    - "$.index[*][?(@.name=='one_generic_param_fn')].inner.decl.inputs" '[["w", {"inner": "T", "kind": "generic"}]]'
 pub fn one_generic_param_fn<T: Wham>(w: T) {}
 
@@ -18,7 +18,6 @@ pub fn one_generic_param_fn<T: Wham>(w: T) {}
 // @count - "$.index[*][?(@.name=='one_synthetic_generic_param_fn')].inner.generics.params[*]" 1
 // @is    - "$.index[*][?(@.name=='one_synthetic_generic_param_fn')].inner.generics.params[0].name" '"impl Wham"'
 // @has   - "$.index[*][?(@.name=='one_synthetic_generic_param_fn')].inner.generics.params[0].kind.type.synthetic" true
-// @has   - "$.index[*][?(@.name=='one_synthetic_generic_param_fn')].inner.generics.params[0].kind.type.bounds[0].trait_bound.trait.inner.id" $wham_id
 // @count - "$.index[*][?(@.name=='one_synthetic_generic_param_fn')].inner.decl.inputs[*]" 1
 // @is    - "$.index[*][?(@.name=='one_synthetic_generic_param_fn')].inner.decl.inputs[0][0]" '"w"'
 // @is    - "$.index[*][?(@.name=='one_synthetic_generic_param_fn')].inner.decl.inputs[0][1].kind" '"impl_trait"'

--- a/src/test/rustdoc-json/lifetime/longest.rs
+++ b/src/test/rustdoc-json/lifetime/longest.rs
@@ -4,8 +4,8 @@
 #![no_core]
 
 // @is longest.json "$.index[*][?(@.name=='longest')].inner.generics.params[0].name"  \"\'a\"
-// @is - "$.index[*][?(@.name=='longest')].inner.generics.params[0].kind"  '{"lifetime": {"outlives": []}}'
-// @is - "$.index[*][?(@.name=='longest')].inner.generics.params[0].kind"  '{"lifetime": {"outlives": []}}'
+// @is - "$.index[*][?(@.name=='longest')].inner.generics.params[0].kind"  '"lifetime"'
+// @is - "$.index[*][?(@.name=='longest')].inner.generics.params[0].kind"  '"lifetime"'
 // @count - "$.index[*][?(@.name=='longest')].inner.generics.params[*]" 1
 // @is - "$.index[*][?(@.name=='longest')].inner.generics.where_predicates" []
 

--- a/src/test/rustdoc-json/lifetime/outlives.rs
+++ b/src/test/rustdoc-json/lifetime/outlives.rs
@@ -4,15 +4,10 @@
 #![no_core]
 
 // @count outlives.json "$.index[*][?(@.name=='foo')].inner.generics.params[*]" 3
-// @is - "$.index[*][?(@.name=='foo')].inner.generics.where_predicates" []
 // @is - "$.index[*][?(@.name=='foo')].inner.generics.params[0].name" \"\'a\"
 // @is - "$.index[*][?(@.name=='foo')].inner.generics.params[1].name" \"\'b\"
 // @is - "$.index[*][?(@.name=='foo')].inner.generics.params[2].name" '"T"'
-// @is - "$.index[*][?(@.name=='foo')].inner.generics.params[0].kind.lifetime.outlives" []
-// @is - "$.index[*][?(@.name=='foo')].inner.generics.params[1].kind.lifetime.outlives" [\"\'a\"]
 // @is - "$.index[*][?(@.name=='foo')].inner.generics.params[2].kind.type.default" null
-// @count - "$.index[*][?(@.name=='foo')].inner.generics.params[2].kind.type.bounds[*]" 1
-// @is - "$.index[*][?(@.name=='foo')].inner.generics.params[2].kind.type.bounds[0].outlives" \"\'b\"
 // @is - "$.index[*][?(@.name=='foo')].inner.decl.inputs[0][1].kind" '"borrowed_ref"'
 // @is - "$.index[*][?(@.name=='foo')].inner.decl.inputs[0][1].inner.lifetime" \"\'a\"
 // @is - "$.index[*][?(@.name=='foo')].inner.decl.inputs[0][1].inner.mutable" false
@@ -20,4 +15,10 @@
 // @is - "$.index[*][?(@.name=='foo')].inner.decl.inputs[0][1].inner.type.inner.lifetime" \"\'b\"
 // @is - "$.index[*][?(@.name=='foo')].inner.decl.inputs[0][1].inner.type.inner.mutable" false
 // @is - "$.index[*][?(@.name=='foo')].inner.decl.inputs[0][1].inner.type.inner.type" '{"inner": "T", "kind": "generic"}'
+// @count - "$.index[*][?(@.name=='foo')].inner.generics.where_predicates[*]" 2
+// @is - "$.index[*][?(@.name=='foo')].inner.generics.where_predicates[0].region_predicate.lifetime" \"\'b\"
+// @count - "$.index[*][?(@.name=='foo')].inner.generics.where_predicates[0].region_predicate.bounds[*]" 1
+// @is - "$.index[*][?(@.name=='foo')].inner.generics.where_predicates[0].region_predicate.bounds[0].outlives" \"\'a\"
+// @is - "$.index[*][?(@.name=='foo')].inner.generics.where_predicates[1].bound_predicate.type.inner" '"T"'
+// @is - "$.index[*][?(@.name=='foo')].inner.generics.where_predicates[1].bound_predicate.bounds[0].outlives" \"\'b\"
 pub fn foo<'a, 'b: 'a, T: 'b>(_: &'a &'b T) {}

--- a/src/test/rustdoc-json/structs/with_primitives.rs
+++ b/src/test/rustdoc-json/structs/with_primitives.rs
@@ -1,7 +1,6 @@
 // @has with_primitives.json "$.index[*][?(@.name=='WithPrimitives')].visibility" \"public\"
 // @has - "$.index[*][?(@.name=='WithPrimitives')].kind" \"struct\"
 // @has - "$.index[*][?(@.name=='WithPrimitives')].inner.generics.params[0].name" \"\'a\"
-// @has - "$.index[*][?(@.name=='WithPrimitives')].inner.generics.params[0].kind.lifetime.outlives" []
 // @has - "$.index[*][?(@.name=='WithPrimitives')].inner.struct_type" \"plain\"
 // @has - "$.index[*][?(@.name=='WithPrimitives')].inner.fields_stripped" true
 pub struct WithPrimitives<'a> {

--- a/src/test/rustdoc-json/type/fn_lifetime.rs
+++ b/src/test/rustdoc-json/type/fn_lifetime.rs
@@ -4,8 +4,7 @@
 
 // @count - "$.index[*][?(@.name=='GenericFn')].inner.generics.params[*]" 1
 // @is    - "$.index[*][?(@.name=='GenericFn')].inner.generics.params[*].name" \"\'a\"
-// @has   - "$.index[*][?(@.name=='GenericFn')].inner.generics.params[*].kind.lifetime"
-// @count - "$.index[*][?(@.name=='GenericFn')].inner.generics.params[*].kind.lifetime.outlives[*]" 0
+// @is    - "$.index[*][?(@.name=='GenericFn')].inner.generics.params[*].kind" \"lifetime\"
 // @count - "$.index[*][?(@.name=='GenericFn')].inner.generics.where_predicates[*]" 0
 // @is    - "$.index[*][?(@.name=='GenericFn')].inner.type.kind" \"function_pointer\"
 // @count - "$.index[*][?(@.name=='GenericFn')].inner.type.inner.generic_params[*]" 0
@@ -20,8 +19,7 @@ pub type GenericFn<'a> = fn(&'a i32) -> &'a i32;
 // @count - "$.index[*][?(@.name=='ForAll')].inner.generics.where_predicates[*]" 0
 // @count - "$.index[*][?(@.name=='ForAll')].inner.type.inner.generic_params[*]" 1
 // @is    - "$.index[*][?(@.name=='ForAll')].inner.type.inner.generic_params[*].name" \"\'a\"
-// @has   - "$.index[*][?(@.name=='ForAll')].inner.type.inner.generic_params[*].kind.lifetime"
-// @count - "$.index[*][?(@.name=='ForAll')].inner.type.inner.generic_params[*].kind.lifetime.outlives[*]" 0
+// @is    - "$.index[*][?(@.name=='ForAll')].inner.type.inner.generic_params[*].kind" \"lifetime\"
 // @count - "$.index[*][?(@.name=='ForAll')].inner.type.inner.decl.inputs[*]" 1
 // @is    - "$.index[*][?(@.name=='ForAll')].inner.type.inner.decl.inputs[*][1].inner.lifetime" \"\'a\"
 // @is    - "$.index[*][?(@.name=='ForAll')].inner.type.inner.decl.output.inner.lifetime" \"\'a\"

--- a/src/test/rustdoc/anonymous-lifetime.rs
+++ b/src/test/rustdoc/anonymous-lifetime.rs
@@ -12,7 +12,8 @@ pub trait Stream {
 }
 
 // @has 'foo/trait.Stream.html'
-// @has - '//*[@class="code-header in-band"]' 'impl<S: ?Sized + Stream + Unpin> Stream for &mut S'
+// @has - '//*[@class="code-header in-band"]' 'impl<S> Stream for &mut S'
+// @has - '//*[@class="where fmt-newline"]' 'where S: ?Sized + Stream + Unpin'
 impl<S: ?Sized + Stream + Unpin> Stream for &mut S {
     type Item = S::Item;
 

--- a/src/test/rustdoc/assoc-types.rs
+++ b/src/test/rustdoc/assoc-types.rs
@@ -1,8 +1,8 @@
-#![crate_type="lib"]
+#![crate_type = "lib"]
 
 // @has assoc_types/trait.Index.html
 pub trait Index<I: ?Sized> {
-        // @has - '//*[@id="associatedtype.Output"]//h4[@class="code-header"]' 'type Output: ?Sized'
+    // @has - '//*[@id="associatedtype.Output"]//h4[@class="code-header"]' 'type Output: ?Sized'
     type Output: ?Sized;
     // @has - '//*[@id="tymethod.index"]//h4[@class="code-header"]' \
     //      "fn index<'a>(&'a self, index: I) -> &'a Self::Output"
@@ -25,13 +25,16 @@ pub trait Feed {
 // @has assoc_types/fn.use_input.html
 // @has - '//*[@class="rust fn"]' 'T::Input'
 // @has - '//*[@class="rust fn"]//a[@href="trait.Feed.html#associatedtype.Input"]' 'Input'
-pub fn use_input<T: Feed>(_feed: &T, _element: T::Input) { }
+pub fn use_input<T: Feed>(_feed: &T, _element: T::Input) {}
 
 // @has assoc_types/fn.cmp_input.html
-// @has - '//*[@class="rust fn"]' 'where T::Input: PartialEq<U::Input>'
+// @has - '//*[@class="rust fn"]' 'where T: Feed,'
+// @has - '//*[@class="rust fn"]' 'U: Feed,'
+// @has - '//*[@class="rust fn"]' 'T::Input: PartialEq<U::Input>'
 // @has - '//*[@class="rust fn"]//a[@href="trait.Feed.html#associatedtype.Input"]' 'Input'
 pub fn cmp_input<T: Feed, U: Feed>(a: &T::Input, b: &U::Input) -> bool
-    where T::Input: PartialEq<U::Input>
+where
+    T::Input: PartialEq<U::Input>,
 {
     a == b
 }

--- a/src/test/rustdoc/doc-assoc-item.rs
+++ b/src/test/rustdoc/doc-assoc-item.rs
@@ -8,11 +8,11 @@ pub trait Bar {
     fn foo(foo: Self::Fuu);
 }
 
-// @has doc_assoc_item/struct.Foo.html '//*[@class="impl has-srclink"]' 'impl<T: Bar<Fuu = u32>> Foo<T>'
+// @has doc_assoc_item/struct.Foo.html
+// @has - '//*[@class="impl has-srclink"]' 'impl<T> Foo<T>'
+// @has - '//*[@class="impl has-srclink"]' 'where T: Bar<Fuu = u32>'
 impl<T: Bar<Fuu = u32>> Foo<T> {
     pub fn new(t: T) -> Foo<T> {
-        Foo {
-            x: t,
-        }
+        Foo { x: t }
     }
 }

--- a/src/test/rustdoc/doc-notable_trait.rs
+++ b/src/test/rustdoc/doc-notable_trait.rs
@@ -9,11 +9,12 @@ impl<T: SomeTrait> SomeTrait for Wrapper<T> {}
 #[doc(notable_trait)]
 pub trait SomeTrait {
     // @has doc_notable_trait/trait.SomeTrait.html
-    // @has - '//code[@class="content"]' 'impl<T: SomeTrait> SomeTrait for Wrapper<T>'
-    fn wrap_me(self) -> Wrapper<Self> where Self: Sized {
-        Wrapper {
-            inner: self,
-        }
+    // @has - '//code[@class="content"]' 'impl<T> SomeTrait for Wrapper<T>'
+    fn wrap_me(self) -> Wrapper<Self>
+    where
+        Self: Sized,
+    {
+        Wrapper { inner: self }
     }
 }
 
@@ -23,7 +24,7 @@ impl SomeTrait for SomeStruct {}
 impl SomeStruct {
     // @has doc_notable_trait/struct.SomeStruct.html
     // @has - '//code[@class="content"]' 'impl SomeTrait for SomeStruct'
-    // @has - '//code[@class="content"]' 'impl<T: SomeTrait> SomeTrait for Wrapper<T>'
+    // @has - '//code[@class="content"]' 'impl<T> SomeTrait for Wrapper<T>'
     pub fn new() -> SomeStruct {
         SomeStruct
     }

--- a/src/test/rustdoc/impl-parts.rs
+++ b/src/test/rustdoc/impl-parts.rs
@@ -3,10 +3,12 @@
 
 pub auto trait AnAutoTrait {}
 
-pub struct Foo<T> { field: T }
+pub struct Foo<T> {
+    field: T,
+}
 
 // @has impl_parts/struct.Foo.html '//*[@class="impl has-srclink"]//h3[@class="code-header in-band"]' \
-//     "impl<T: Clone> !AnAutoTrait for Foo<T> where T: Sync,"
+//     "impl<T> !AnAutoTrait for Foo<T> where T: Clone, T: Sync,"
 // @has impl_parts/trait.AnAutoTrait.html '//*[@class="item-list"]//h3[@class="code-header in-band"]' \
-//     "impl<T: Clone> !AnAutoTrait for Foo<T> where T: Sync,"
+//     "impl<T> !AnAutoTrait for Foo<T> where T: Clone, T: Sync,"
 impl<T: Clone> !AnAutoTrait for Foo<T> where T: Sync {}

--- a/src/test/rustdoc/issue-20727-4.rs
+++ b/src/test/rustdoc/issue-20727-4.rs
@@ -5,7 +5,7 @@ extern crate issue_20727;
 
 // @has issue_20727_4/trait.Index.html
 pub trait Index<Idx: ?Sized> {
-    // @has - '//*[@class="rust trait"]' 'trait Index<Idx: ?Sized> {'
+    // @has - '//*[@class="rust trait"]' 'trait Index<Idx> where Idx: ?Sized, {'
     // @has - '//*[@class="rust trait"]' 'type Output: ?Sized'
     type Output: ?Sized;
 
@@ -17,7 +17,7 @@ pub trait Index<Idx: ?Sized> {
 // @has issue_20727_4/trait.IndexMut.html
 pub trait IndexMut<Idx: ?Sized>: Index<Idx> {
     // @has - '//*[@class="rust trait"]' \
-    //        'trait IndexMut<Idx: ?Sized>: Index<Idx> {'
+    //        'trait IndexMut<Idx>: Index<Idx> where Idx: ?Sized, {'
     // @has - '//*[@class="rust trait"]' \
     //        'fn index_mut(&mut self, index: Idx) -> &mut Self::Output;'
     fn index_mut(&mut self, index: Idx) -> &mut Self::Output;

--- a/src/test/rustdoc/normalize-assoc-item.rs
+++ b/src/test/rustdoc/normalize-assoc-item.rs
@@ -36,10 +36,10 @@ impl<Inner: Trait> Trait for Generic<Inner> {
 // These can't be normalized because they depend on a generic parameter.
 // However the user can choose whether the text should be displayed as `Inner::X` or `<Inner as Trait>::X`.
 
-// @has 'normalize_assoc_item/struct.Unknown.html' '//pre[@class="rust struct"]' 'pub struct Unknown<Inner: Trait>(pub <Inner as Trait>::X);'
+// @has 'normalize_assoc_item/struct.Unknown.html' '//pre[@class="rust struct"]' 'pub struct Unknown<Inner>(pub <Inner as Trait>::X) where Inner: Trait;'
 pub struct Unknown<Inner: Trait>(pub <Inner as Trait>::X);
 
-// @has 'normalize_assoc_item/struct.Unknown2.html' '//pre[@class="rust struct"]' 'pub struct Unknown2<Inner: Trait>(pub Inner::X);'
+// @has 'normalize_assoc_item/struct.Unknown2.html' '//pre[@class="rust struct"]' 'pub struct Unknown2<Inner>(pub Inner::X) where Inner: Trait;'
 pub struct Unknown2<Inner: Trait>(pub Inner::X);
 
 trait Lifetimes<'a> {

--- a/src/test/rustdoc/primitive-tuple-variadic.rs
+++ b/src/test/rustdoc/primitive-tuple-variadic.rs
@@ -13,6 +13,7 @@ impl<T> Foo for (T,) {}
 pub trait Bar {}
 
 // @has foo/trait.Bar.html
-// @has - '//section[@id="impl-Bar-for-(U%2C)"]/h3' 'impl<U: Foo> Bar for (U₁, U₂, …, Uₙ)'
+// @has - '//section[@id="impl-Bar-for-(U%2C)"]/h3' 'impl<U> Bar for (U₁, U₂, …, Uₙ)'
+// @has - '//section[@id="impl-Bar-for-(U%2C)"]/h3' 'where U: Foo'
 #[doc(tuple_variadic)]
 impl<U: Foo> Bar for (U,) {}

--- a/src/test/rustdoc/rfc-2632-const-trait-impl.rs
+++ b/src/test/rustdoc/rfc-2632-const-trait-impl.rs
@@ -13,13 +13,11 @@ use std::marker::Destruct;
 pub struct S<T>(T);
 
 // @!has foo/trait.Tr.html '//pre[@class="rust trait"]/code/a[@class="trait"]' '~const'
-// @has - '//pre[@class="rust trait"]/code/a[@class="trait"]' 'Clone'
 // @!has - '//pre[@class="rust trait"]/code/span[@class="where"]' '~const'
 // @has - '//pre[@class="rust trait"]/code/span[@class="where"]' ': Clone'
 #[const_trait]
 pub trait Tr<T> {
     // @!has - '//div[@id="method.a"]/h4[@class="code-header"]' '~const'
-    // @has - '//div[@id="method.a"]/h4[@class="code-header"]/a[@class="trait"]' 'Clone'
     // @!has - '//div[@id="method.a"]/h4[@class="code-header"]/span[@class="where"]' '~const'
     // @has - '//div[@id="method.a"]/h4[@class="code-header"]/span[@class="where fmt-newline"]' ': Clone'
     fn a<A: ~const Clone + ~const Destruct>()
@@ -30,9 +28,9 @@ pub trait Tr<T> {
 }
 
 // @!has - '//section[@id="impl-Tr%3CT%3E"]/h3[@class="code-header in-band"]' '~const'
-// @has - '//section[@id="impl-Tr%3CT%3E"]/h3[@class="code-header in-band"]/a[@class="trait"]' 'Clone'
 // @!has - '//section[@id="impl-Tr%3CT%3E"]/h3[@class="code-header in-band"]/span[@class="where"]' '~const'
-// @has - '//section[@id="impl-Tr%3CT%3E"]/h3[@class="code-header in-band"]/span[@class="where fmt-newline"]' ': Clone'
+// @has - '//section[@id="impl-Tr%3CT%3E"]/h3[@class="code-header in-band"]/span[@class="where fmt-newline"]/a[@class="trait"]' 'Clone'
+// @!has - '//section[@id="impl-Tr%3CT%3E"]/h3[@class="code-header in-band"]/span[@class="where fmt-newline"]/a[@class="trait"]' 'Destruct'
 impl<T: ~const Clone + ~const Destruct> const Tr<T> for T
 where
     Option<T>: ~const Clone + ~const Destruct,
@@ -45,8 +43,9 @@ where
 }
 
 // @!has foo/fn.foo.html '//pre[@class="rust fn"]/code/a[@class="trait"]' '~const'
-// @has - '//pre[@class="rust fn"]/code/a[@class="trait"]' 'Clone'
 // @!has - '//pre[@class="rust fn"]/code/span[@class="where fmt-newline"]' '~const'
+// @has - '//pre[@class="rust fn"]/code/span[@class="where fmt-newline"]/a[@class="trait"]' 'Clone'
+// @!has - '//pre[@class="rust fn"]/code/span[@class="where fmt-newline"]/a[@class="trait"]' 'Destruct'
 // @has - '//pre[@class="rust fn"]/code/span[@class="where fmt-newline"]' ': Clone'
 pub const fn foo<F: ~const Clone + ~const Destruct>()
 where
@@ -57,9 +56,9 @@ where
 
 impl<T> S<T> {
     // @!has foo/struct.S.html '//section[@id="method.foo"]/h4[@class="code-header"]' '~const'
-    // @has - '//section[@id="method.foo"]/h4[@class="code-header"]/a[@class="trait"]' 'Clone'
     // @!has - '//section[@id="method.foo"]/h4[@class="code-header"]/span[@class="where"]' '~const'
-    // @has - '//section[@id="method.foo"]/h4[@class="code-header"]/span[@class="where fmt-newline"]' ': Clone'
+    // @has - '//section[@id="method.foo"]/h4[@class="code-header"]/span[@class="where fmt-newline"]/a[@class="trait"]' 'Clone'
+    // @!has - '//section[@id="method.foo"]/h4[@class="code-header"]/span[@class="where fmt-newline"]/a[@class="trait"]' 'Destruct'
     pub const fn foo<B: ~const Clone + ~const Destruct>()
     where
         B: ~const Clone + ~const Destruct,

--- a/src/test/rustdoc/synthetic_auto/complex.rs
+++ b/src/test/rustdoc/synthetic_auto/complex.rs
@@ -21,16 +21,12 @@ mod foo {
 
 // @has complex/struct.NotOuter.html
 // @has - '//*[@id="synthetic-implementations-list"]//*[@class="impl has-srclink"]//h3[@class="code-header in-band"]' \
-// "impl<'a, T, K: ?Sized> Send for Outer<'a, T, K> where K: for<'b> Fn((&'b bool, &'a u8)) \
+// "impl<'a, T, K> Send for Outer<'a, T, K> where K: ?Sized + for<'b> Fn((&'b bool, &'a u8)) \
 // -> &'b i8, T: MyTrait<'a>, <T as MyTrait<'a>>::MyItem: Copy, 'a: 'static"
 
 pub use foo::{Foo, Inner as NotInner, MyTrait as NotMyTrait, Outer as NotOuter};
 
-unsafe impl<T> Send for Foo<T>
-where
-    T: NotMyTrait<'static>,
-{
-}
+unsafe impl<T> Send for Foo<T> where T: NotMyTrait<'static> {}
 
 unsafe impl<'a, Q, R: ?Sized> Send for NotInner<'a, Q, R>
 where

--- a/src/test/rustdoc/where-sized.rs
+++ b/src/test/rustdoc/where-sized.rs
@@ -1,6 +1,11 @@
 #![crate_name = "foo"]
 
 // @has foo/fn.foo.html
-// @has - '//*[@class="rust fn"]' 'pub fn foo<X, Y: ?Sized>(_: &X)'
-// @has - '//*[@class="rust fn"]' 'where X: ?Sized,'
-pub fn foo<X, Y: ?Sized>(_: &X) where X: ?Sized {}
+// @has - '//*[@class="rust fn"]' 'pub fn foo<X, Y>(_: &X)'
+// @has - '//*[@class="rust fn"]' 'where Y: ?Sized,'
+// @has - '//*[@class="rust fn"]' 'X: ?Sized,'
+pub fn foo<X, Y: ?Sized>(_: &X)
+where
+    X: ?Sized,
+{
+}


### PR DESCRIPTION
Split from #93803.

This PR modifies the rendering of bounds on generic parameters in rustdoc.
```rust
fn foo<T: Default, U>(x: impl Copy) where U: Clone
```
into
```rust
fn foo<T, U>(x: impl Copy) where T: Default, U: Clone
```

r? @GuillaumeGomez 