### PR TITLE
Use unchecked_add in checked_add to make it easier to optimize

### DIFF
--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -434,10 +434,18 @@ macro_rules! uint_impl {
         #[rustc_const_stable(feature = "const_checked_int_methods", since = "1.47.0")]
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
+        #[rustc_allow_const_fn_unstable(unchecked_math)]
+        #[rustc_allow_const_fn_unstable(const_inherent_unchecked_arith)]
         #[inline]
         pub const fn checked_add(self, rhs: Self) -> Option<Self> {
-            let (a, b) = self.overflowing_add(rhs);
-            if unlikely!(b) {None} else {Some(a)}
+            let (_, overflow) = self.overflowing_add(rhs);
+            if unlikely!(overflow) {
+                None
+            } else {
+                // SAFETY: if(not overflow_on_add) checks the precondition for
+                // `unchecked_add`.
+                Some(unsafe {self.unchecked_add(rhs)})
+            }
         }
 
         /// Unchecked integer addition. Computes `self + rhs`, assuming overflow
@@ -503,10 +511,18 @@ macro_rules! uint_impl {
         #[rustc_const_stable(feature = "const_checked_int_methods", since = "1.47.0")]
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
+        #[rustc_allow_const_fn_unstable(unchecked_math)]
+        #[rustc_allow_const_fn_unstable(const_inherent_unchecked_arith)]
         #[inline]
         pub const fn checked_sub(self, rhs: Self) -> Option<Self> {
-            let (a, b) = self.overflowing_sub(rhs);
-            if unlikely!(b) {None} else {Some(a)}
+            let (_, overflow) = self.overflowing_sub(rhs);
+            if unlikely!(overflow) {
+                None
+            } else {
+                // SAFETY: if(not overflow_on_sub) checks the precondition for
+                // `unchecked_sub`.
+                Some(unsafe {self.unchecked_sub(rhs)})
+            }
         }
 
         /// Unchecked integer subtraction. Computes `self - rhs`, assuming overflow
@@ -550,10 +566,18 @@ macro_rules! uint_impl {
         #[rustc_const_stable(feature = "const_checked_int_methods", since = "1.47.0")]
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
+        #[rustc_allow_const_fn_unstable(unchecked_math)]
+        #[rustc_allow_const_fn_unstable(const_inherent_unchecked_arith)]
         #[inline]
         pub const fn checked_mul(self, rhs: Self) -> Option<Self> {
-            let (a, b) = self.overflowing_mul(rhs);
-            if unlikely!(b) {None} else {Some(a)}
+            let (_, overflow) = self.overflowing_mul(rhs);
+            if unlikely!(overflow) {
+                None
+            } else {
+                // SAFETY: if(not overflow_on_mul) checks the precondition for
+                // `unchecked_mul`.
+                Some(unsafe {self.unchecked_mul(rhs)})
+            }
         }
 
         /// Unchecked integer multiplication. Computes `self * rhs`, assuming overflow


### PR DESCRIPTION
See https://github.com/llvm/llvm-project/issues/53978
Using overflowing_add seems to make it harder for LLVM to optimize since it returns the wrapped value, which we never use when it wraps and we rely on LLVM noticing that we only use it after checking !overflow. I tried sending an LLVM [patch](https://reviews.llvm.org/D124722) to fix the example mentioned in that issue, but the specific transformation I tried wasn't sound and it was suggested it might be better to handle it in the frontend

> This might need to be addressed on the front-end side instead, by not emitting uadd/usub intrinsics in the first place.

I also changed checked_sub and mul. I don't know how heavily checked_add is used but I'm curious on what a perf run looks like for this change. I understand the use of unsafe may not be worth the gains.
I had 2 problems writing this, one was that `x.py fmt` did not format the code, but I eventually figured out it's because it's a macro, so my apologies if the formatting is incorrect. The second one seems more important, `unchecked_[add|sub|mul]` are not stable and are also not const-stable so I had to use 

```rs
        #[rustc_allow_const_fn_unstable(unchecked_math)]
        #[rustc_allow_const_fn_unstable(const_inherent_unchecked_arith)]
```

To get them to compile when used in stable fns. I do not know if their const impls are robust enough to be used on stable, but they seemed to work fine on a simple test. I don't think the non-const usage should pose a problem since they just call the intrinsics, and this shouldn't be "de-facto stabilizing" the unchecked versions since the functionality/API is different and can be rolled back to overflowing_X .



<details>
<summary>Comparison of generated assembly for the motivating example (msvc target, dumped via `dumpbin /DISASM`)</summary>

```
PS D:\dev\rust> cat .\std.rs
pub fn std(x: u32) -> bool {
    if let Some(s) = x.checked_add(77) {
        s <= 4 && x % 8 == 0
    } else {
        false
    }
}
PS D:\dev\rust> rustc +nightly -V
rustc 1.62.0-nightly (18f314e70 2022-04-24)

PS D:\dev\rust> rustc +nightly .\std.rs -C opt-level=3 --emit=obj -o std_nightly_1_62.obj --crate-type=lib
PS D:\dev\rust> .\build\x86_64-pc-windows-msvc\stage1\bin\rustc.exe .\std.rs -C opt-level=3 --emit=obj -o std_patch.obj --crate-type=lib
PS D:\dev\rust> dumpbin /DISASM .\std_nightly_1_62.obj
Dump of file .\std_nightly_1_62.obj

File Type: COFF OBJECT

_ZN3std3std17h0289f9e8c34b338aE:
  0000000000000000: 31 C0              xor         eax,eax
  0000000000000002: 89 CA              mov         edx,ecx
  0000000000000004: 83 C2 4D           add         edx,4Dh
  0000000000000007: 72 0B              jb          0000000000000014
  0000000000000009: 83 FA 05           cmp         edx,5
  000000000000000C: 73 06              jae         0000000000000014
  000000000000000E: F6 C1 07           test        cl,7
  0000000000000011: 0F 94 C0           sete        al
  0000000000000014: C3                 ret
PS D:\dev\rust> dumpbin /DISASM .\std_patch.obj
Dump of file .\std_patch.obj

File Type: COFF OBJECT

_ZN3std3std17h5b45c7b980977b3eE:
  0000000000000000: 31 C0              xor         eax,eax
  0000000000000002: C3                 ret
```

</details>