### PR TITLE
[beta] Beta backports

### DIFF
--- a/compiler/rustc_typeck/src/check/check.rs
+++ b/compiler/rustc_typeck/src/check/check.rs
@@ -102,6 +102,12 @@ pub(super) fn check_fn<'a, 'tcx>(
             DUMMY_SP,
             param_env,
         ));
+    // HACK(oli-obk): we rewrite the declared return type, too, so that we don't end up inferring all
+    // unconstrained RPIT to have `()` as their hidden type. This would happen because further down we
+    // compare the ret_coercion with declared_ret_ty, and anything uninferred would be inferred to the
+    // opaque type itself. That again would cause writeback to assume we have a recursive call site
+    // and do the sadly stabilized fallback to `()`.
+    let declared_ret_ty = ret_ty;
     fcx.ret_coercion = Some(RefCell::new(CoerceMany::new(ret_ty)));
     fcx.ret_type_span = Some(decl.output.span());
 

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -2931,48 +2931,6 @@ impl<T, const N: usize> From<[T; N]> for Vec<T> {
     }
 }
 
-#[cfg(not(no_global_oom_handling))]
-#[stable(feature = "vec_from_array_ref", since = "1.61.0")]
-impl<T: Clone, const N: usize> From<&[T; N]> for Vec<T> {
-    /// Allocate a `Vec<T>` and fill it by cloning `s`'s items.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// assert_eq!(Vec::from(b"raw"), vec![b'r', b'a', b'w']);
-    /// ```
-    #[cfg(not(test))]
-    fn from(s: &[T; N]) -> Vec<T> {
-        s.to_vec()
-    }
-
-    #[cfg(test)]
-    fn from(s: &[T; N]) -> Vec<T> {
-        crate::slice::to_vec(s, Global)
-    }
-}
-
-#[cfg(not(no_global_oom_handling))]
-#[stable(feature = "vec_from_array_ref", since = "1.61.0")]
-impl<T: Clone, const N: usize> From<&mut [T; N]> for Vec<T> {
-    /// Allocate a `Vec<T>` and fill it by cloning `s`'s items.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// assert_eq!(Vec::from(&mut [1, 2, 3]), vec![1, 2, 3]);
-    /// ```
-    #[cfg(not(test))]
-    fn from(s: &mut [T; N]) -> Vec<T> {
-        s.to_vec()
-    }
-
-    #[cfg(test)]
-    fn from(s: &mut [T; N]) -> Vec<T> {
-        crate::slice::to_vec(s, Global)
-    }
-}
-
 #[stable(feature = "vec_from_cow_slice", since = "1.14.0")]
 impl<'a, T> From<Cow<'a, [T]>> for Vec<T>
 where

--- a/library/std/src/ffi/mod.rs
+++ b/library/std/src/ffi/mod.rs
@@ -159,15 +159,6 @@ pub use self::os_str::{OsStr, OsString};
 #[stable(feature = "core_c_void", since = "1.30.0")]
 pub use core::ffi::c_void;
 
-#[unstable(feature = "core_ffi_c", issue = "94501")]
-pub use core::ffi::{
-    c_char, c_double, c_float, c_int, c_long, c_longlong, c_schar, c_short, c_uchar, c_uint,
-    c_ulong, c_ulonglong, c_ushort,
-};
-
-#[unstable(feature = "c_size_t", issue = "88345")]
-pub use core::ffi::{c_ptrdiff_t, c_size_t, c_ssize_t};
-
 #[unstable(
     feature = "c_variadic",
     reason = "the `c_variadic` feature has not been properly tested on \

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -303,7 +303,6 @@
 // Only for re-exporting:
 #![feature(assert_matches)]
 #![feature(async_iterator)]
-#![feature(c_size_t)]
 #![feature(c_variadic)]
 #![feature(cfg_accessible)]
 #![feature(cfg_eval)]

--- a/library/std/src/macros.rs
+++ b/library/std/src/macros.rs
@@ -99,9 +99,9 @@ macro_rules! println {
     () => {
         $crate::print!("\n")
     };
-    ($($arg:tt)*) => {
-        $crate::io::_print($crate::format_args_nl!($($arg)*))
-    };
+    ($($arg:tt)*) => {{
+        $crate::io::_print($crate::format_args_nl!($($arg)*));
+    }};
 }
 
 /// Prints to the standard error.
@@ -164,9 +164,9 @@ macro_rules! eprintln {
     () => {
         $crate::eprint!("\n")
     };
-    ($($arg:tt)*) => {
-        $crate::io::_eprint($crate::format_args_nl!($($arg)*))
-    };
+    ($($arg:tt)*) => {{
+        $crate::io::_eprint($crate::format_args_nl!($($arg)*));
+    }};
 }
 
 /// Prints and returns the value of a given expression for quick and dirty

--- a/src/test/pretty/dollar-crate.pp
+++ b/src/test/pretty/dollar-crate.pp
@@ -9,5 +9,5 @@ extern crate std;
 // pp-exact:dollar-crate.pp
 
 fn main() {
-    ::std::io::_print(::core::fmt::Arguments::new_v1(&["rust\n"], &[]));
+    { ::std::io::_print(::core::fmt::Arguments::new_v1(&["rust\n"], &[])); };
 }

--- a/src/test/run-make-fulldeps/coverage-reports/expected_show_coverage.closure.txt
+++ b/src/test/run-make-fulldeps/coverage-reports/expected_show_coverage.closure.txt
@@ -116,8 +116,8 @@
   116|      1|
   117|      1|    let
   118|      1|        _unused_closure
-  119|      1|    =
-  120|      1|        |
+  119|       |    =
+  120|       |        |
   121|       |            mut countdown
   122|       |        |
   123|      0|    {
@@ -173,7 +173,7 @@
   169|       |    ;
   170|       |
   171|      1|    let short_used_not_covered_closure_line_break_no_block_embedded_branch =
-  172|      1|        | _unused_arg: u8 |
+  172|       |        | _unused_arg: u8 |
   173|      0|            println!(
   174|      0|                "not called: {}",
   175|      0|                if is_true { "check" } else { "me" }
@@ -191,7 +191,7 @@
   187|       |    ;
   188|       |
   189|      1|    let short_used_covered_closure_line_break_no_block_embedded_branch =
-  190|       |        | _unused_arg: u8 |
+  190|      1|        | _unused_arg: u8 |
   191|      1|            println!(
   192|      1|                "not called: {}",
   193|      1|                if is_true { "check" } else { "me" }

--- a/src/test/ui/associated-types/impl-trait-return-missing-constraint.rs
+++ b/src/test/ui/associated-types/impl-trait-return-missing-constraint.rs
@@ -24,7 +24,6 @@ fn bar() -> impl Bar {
 
 fn baz() -> impl Bar<Item = i32> {
     //~^ ERROR type mismatch resolving `<impl Bar as Foo>::Item == i32`
-    //~| ERROR type mismatch resolving `<impl Bar as Foo>::Item == i32`
     bar()
 }
 

--- a/src/test/ui/associated-types/impl-trait-return-missing-constraint.stderr
+++ b/src/test/ui/associated-types/impl-trait-return-missing-constraint.stderr
@@ -16,29 +16,6 @@ help: consider constraining the associated type `<impl Bar as Foo>::Item` to `i3
 LL | fn bar() -> impl Bar<Item = i32> {
    |                     ++++++++++++
 
-error[E0271]: type mismatch resolving `<impl Bar as Foo>::Item == i32`
-  --> $DIR/impl-trait-return-missing-constraint.rs:25:34
-   |
-LL |   fn bar() -> impl Bar {
-   |               -------- the expected opaque type
-...
-LL |   fn baz() -> impl Bar<Item = i32> {
-   |  __________________________________^
-LL | |
-LL | |
-LL | |     bar()
-LL | | }
-   | |_^ expected associated type, found `i32`
-   |
-   = note: expected associated type `<impl Bar as Foo>::Item`
-                         found type `i32`
-   = help: consider constraining the associated type `<impl Bar as Foo>::Item` to `i32` or calling a method that returns `<impl Bar as Foo>::Item`
-   = note: for more information, visit https://doc.rust-lang.org/book/ch19-03-advanced-traits.html
-help: consider constraining the associated type `<impl Bar as Foo>::Item` to `i32`
-   |
-LL | fn bar() -> impl Bar<Item = i32> {
-   |                     ++++++++++++
-
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0271`.

--- a/src/test/ui/conservative_impl_trait.rs
+++ b/src/test/ui/conservative_impl_trait.rs
@@ -2,7 +2,6 @@
 
 fn will_ice(something: &u32) -> impl Iterator<Item = &u32> {
     //~^ ERROR `()` is not an iterator
-    //~| ERROR `()` is not an iterator
 }
 
 fn main() {}

--- a/src/test/ui/conservative_impl_trait.stderr
+++ b/src/test/ui/conservative_impl_trait.stderr
@@ -6,18 +6,6 @@ LL | fn will_ice(something: &u32) -> impl Iterator<Item = &u32> {
    |
    = help: the trait `Iterator` is not implemented for `()`
 
-error[E0277]: `()` is not an iterator
-  --> $DIR/conservative_impl_trait.rs:3:60
-   |
-LL |   fn will_ice(something: &u32) -> impl Iterator<Item = &u32> {
-   |  ____________________________________________________________^
-LL | |
-LL | |
-LL | | }
-   | |_^ `()` is not an iterator
-   |
-   = help: the trait `Iterator` is not implemented for `()`
-
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/const-generics/defaults/rp_impl_trait_fail.rs
+++ b/src/test/ui/const-generics/defaults/rp_impl_trait_fail.rs
@@ -5,7 +5,6 @@ impl<const N: u32> Trait for Uwu<N> {}
 
 fn rawr() -> impl Trait {
     //~^ error: the trait bound `Uwu<10_u32, 12_u32>: Trait` is not satisfied
-    //~| error: the trait bound `Uwu<10_u32, 12_u32>: Trait` is not satisfied
     Uwu::<10, 12>
 }
 
@@ -17,13 +16,11 @@ impl Traitor<1, 2> for u64 {}
 
 fn uwu<const N: u8>() -> impl Traitor<N> {
     //~^ error: the trait bound `u32: Traitor<N, N>` is not satisfied
-    //~| error: the trait bound `u32: Traitor<N, N>` is not satisfied
     1_u32
 }
 
 fn owo() -> impl Traitor {
     //~^ error: the trait bound `u64: Traitor<1_u8, 1_u8>` is not satisfied
-    //~| error: the trait bound `u64: Traitor<1_u8, 1_u8>` is not satisfied
     1_u64
 }
 

--- a/src/test/ui/const-generics/defaults/rp_impl_trait_fail.stderr
+++ b/src/test/ui/const-generics/defaults/rp_impl_trait_fail.stderr
@@ -7,22 +7,8 @@ LL | fn rawr() -> impl Trait {
    = help: the following implementations were found:
              <Uwu<N> as Trait>
 
-error[E0277]: the trait bound `Uwu<10_u32, 12_u32>: Trait` is not satisfied
-  --> $DIR/rp_impl_trait_fail.rs:6:25
-   |
-LL |   fn rawr() -> impl Trait {
-   |  _________________________^
-LL | |
-LL | |
-LL | |     Uwu::<10, 12>
-LL | | }
-   | |_^ the trait `Trait` is not implemented for `Uwu<10_u32, 12_u32>`
-   |
-   = help: the following implementations were found:
-             <Uwu<N> as Trait>
-
 error[E0277]: the trait bound `u32: Traitor<N, N>` is not satisfied
-  --> $DIR/rp_impl_trait_fail.rs:18:26
+  --> $DIR/rp_impl_trait_fail.rs:17:26
    |
 LL | fn uwu<const N: u8>() -> impl Traitor<N> {
    |                          ^^^^^^^^^^^^^^^ the trait `Traitor<N, N>` is not implemented for `u32`
@@ -31,23 +17,8 @@ LL | fn uwu<const N: u8>() -> impl Traitor<N> {
              <u32 as Traitor<N, 2_u8>>
              <u64 as Traitor<1_u8, 2_u8>>
 
-error[E0277]: the trait bound `u32: Traitor<N, N>` is not satisfied
-  --> $DIR/rp_impl_trait_fail.rs:18:42
-   |
-LL |   fn uwu<const N: u8>() -> impl Traitor<N> {
-   |  __________________________________________^
-LL | |
-LL | |
-LL | |     1_u32
-LL | | }
-   | |_^ the trait `Traitor<N, N>` is not implemented for `u32`
-   |
-   = help: the following implementations were found:
-             <u32 as Traitor<N, 2_u8>>
-             <u64 as Traitor<1_u8, 2_u8>>
-
 error[E0277]: the trait bound `u64: Traitor<1_u8, 1_u8>` is not satisfied
-  --> $DIR/rp_impl_trait_fail.rs:24:13
+  --> $DIR/rp_impl_trait_fail.rs:22:13
    |
 LL | fn owo() -> impl Traitor {
    |             ^^^^^^^^^^^^ the trait `Traitor<1_u8, 1_u8>` is not implemented for `u64`
@@ -56,21 +27,6 @@ LL | fn owo() -> impl Traitor {
              <u64 as Traitor<1_u8, 2_u8>>
              <u32 as Traitor<N, 2_u8>>
 
-error[E0277]: the trait bound `u64: Traitor<1_u8, 1_u8>` is not satisfied
-  --> $DIR/rp_impl_trait_fail.rs:24:26
-   |
-LL |   fn owo() -> impl Traitor {
-   |  __________________________^
-LL | |
-LL | |
-LL | |     1_u64
-LL | | }
-   | |_^ the trait `Traitor<1_u8, 1_u8>` is not implemented for `u64`
-   |
-   = help: the following implementations were found:
-             <u64 as Traitor<1_u8, 2_u8>>
-             <u32 as Traitor<N, 2_u8>>
-
-error: aborting due to 6 previous errors
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/generator/issue-88653.rs
+++ b/src/test/ui/generator/issue-88653.rs
@@ -7,13 +7,10 @@ use std::ops::Generator;
 
 fn foo(bar: bool) -> impl Generator<(bool,)> {
     //~^ ERROR: type mismatch in generator arguments [E0631]
-    //~| ERROR: type mismatch in generator arguments [E0631]
-    //~| NOTE: expected signature of `fn((bool,)) -> _`
     //~| NOTE: expected signature of `fn((bool,)) -> _`
     //~| NOTE: in this expansion of desugaring of `impl Trait`
     |bar| {
         //~^ NOTE: found signature of `fn(bool) -> _`
-        //~| NOTE: found signature of `fn(bool) -> _`
         if bar {
             yield bar;
         }

--- a/src/test/ui/generator/issue-88653.stderr
+++ b/src/test/ui/generator/issue-88653.stderr
@@ -7,22 +7,6 @@ LL | fn foo(bar: bool) -> impl Generator<(bool,)> {
 LL |     |bar| {
    |     ----- found signature of `fn(bool) -> _`
 
-error[E0631]: type mismatch in generator arguments
-  --> $DIR/issue-88653.rs:8:46
-   |
-LL |   fn foo(bar: bool) -> impl Generator<(bool,)> {
-   |  ______________________________________________^
-LL | |
-LL | |
-LL | |
-...  |
-LL | |     |bar| {
-   | |     ----- found signature of `fn(bool) -> _`
-...  |
-LL | |     }
-LL | | }
-   | |_^ expected signature of `fn((bool,)) -> _`
-
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0631`.

--- a/src/test/ui/generator/type-mismatch-signature-deduction.rs
+++ b/src/test/ui/generator/type-mismatch-signature-deduction.rs
@@ -4,7 +4,6 @@ use std::ops::Generator;
 
 fn foo() -> impl Generator<Return = i32> {
     //~^ ERROR type mismatch
-    //~| ERROR type mismatch
     || {
         if false {
             return Ok(6);

--- a/src/test/ui/generator/type-mismatch-signature-deduction.stderr
+++ b/src/test/ui/generator/type-mismatch-signature-deduction.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/type-mismatch-signature-deduction.rs:15:9
+  --> $DIR/type-mismatch-signature-deduction.rs:14:9
    |
 LL |         5
    |         ^ expected enum `Result`, found integer
@@ -7,12 +7,12 @@ LL |         5
    = note: expected type `Result<{integer}, _>`
               found type `{integer}`
 note: return type inferred to be `Result<{integer}, _>` here
-  --> $DIR/type-mismatch-signature-deduction.rs:10:20
+  --> $DIR/type-mismatch-signature-deduction.rs:9:20
    |
 LL |             return Ok(6);
    |                    ^^^^^
 
-error[E0271]: type mismatch resolving `<[generator@$DIR/type-mismatch-signature-deduction.rs:8:5: 16:6] as Generator>::Return == i32`
+error[E0271]: type mismatch resolving `<[generator@$DIR/type-mismatch-signature-deduction.rs:7:5: 15:6] as Generator>::Return == i32`
   --> $DIR/type-mismatch-signature-deduction.rs:5:13
    |
 LL | fn foo() -> impl Generator<Return = i32> {
@@ -21,23 +21,7 @@ LL | fn foo() -> impl Generator<Return = i32> {
    = note: expected enum `Result<{integer}, _>`
               found type `i32`
 
-error[E0271]: type mismatch resolving `<[generator@$DIR/type-mismatch-signature-deduction.rs:8:5: 16:6] as Generator>::Return == i32`
-  --> $DIR/type-mismatch-signature-deduction.rs:5:42
-   |
-LL |   fn foo() -> impl Generator<Return = i32> {
-   |  __________________________________________^
-LL | |
-LL | |
-LL | |     || {
-...  |
-LL | |     }
-LL | | }
-   | |_^ expected enum `Result`, found `i32`
-   |
-   = note: expected enum `Result<{integer}, _>`
-              found type `i32`
-
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 
 Some errors have detailed explanations: E0271, E0308.
 For more information about an error, try `rustc --explain E0271`.

--- a/src/test/ui/impl-trait/bound-normalization-fail.rs
+++ b/src/test/ui/impl-trait/bound-normalization-fail.rs
@@ -24,7 +24,6 @@ mod impl_trait {
     /// `T::Assoc` can't be normalized any further here.
     fn foo_fail<T: Trait>() -> impl FooLike<Output = T::Assoc> {
         //~^ ERROR: type mismatch
-        //~| ERROR: type mismatch
         Foo(())
     }
 }
@@ -41,7 +40,6 @@ mod lifetimes {
     /// Missing bound constraining `Assoc`, `T::Assoc` can't be normalized further.
     fn foo2_fail<'a, T: Trait<'a>>() -> impl FooLike<Output = T::Assoc> {
         //~^ ERROR `impl Trait` return type cannot contain a projection or `Self` that references lifetimes from a parent scope
-        //~| ERROR: type mismatch
         //~| ERROR: type mismatch
         Foo(())
     }

--- a/src/test/ui/impl-trait/bound-normalization-fail.stderr
+++ b/src/test/ui/impl-trait/bound-normalization-fail.stderr
@@ -16,37 +16,14 @@ help: consider constraining the associated type `<T as impl_trait::Trait>::Assoc
 LL |     fn foo_fail<T: Trait<Assoc = ()>>() -> impl FooLike<Output = T::Assoc> {
    |                         ++++++++++++
 
-error[E0271]: type mismatch resolving `<Foo<()> as FooLike>::Output == <T as impl_trait::Trait>::Assoc`
-  --> $DIR/bound-normalization-fail.rs:25:64
-   |
-LL |       fn foo_fail<T: Trait>() -> impl FooLike<Output = T::Assoc> {
-   |  ________________________________________________________________^
-LL | |
-LL | |
-LL | |         Foo(())
-LL | |     }
-   | |_____^ type mismatch resolving `<Foo<()> as FooLike>::Output == <T as impl_trait::Trait>::Assoc`
-   |
-note: expected this to be `()`
-  --> $DIR/bound-normalization-fail.rs:14:19
-   |
-LL |     type Output = T;
-   |                   ^
-   = note:    expected unit type `()`
-           found associated type `<T as impl_trait::Trait>::Assoc`
-help: consider constraining the associated type `<T as impl_trait::Trait>::Assoc` to `()`
-   |
-LL |     fn foo_fail<T: Trait<Assoc = ()>>() -> impl FooLike<Output = T::Assoc> {
-   |                         ++++++++++++
-
 error[E0760]: `impl Trait` return type cannot contain a projection or `Self` that references lifetimes from a parent scope
-  --> $DIR/bound-normalization-fail.rs:42:41
+  --> $DIR/bound-normalization-fail.rs:41:41
    |
 LL |     fn foo2_fail<'a, T: Trait<'a>>() -> impl FooLike<Output = T::Assoc> {
    |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0271]: type mismatch resolving `<Foo<()> as FooLike>::Output == <T as lifetimes::Trait<'static>>::Assoc`
-  --> $DIR/bound-normalization-fail.rs:42:41
+  --> $DIR/bound-normalization-fail.rs:41:41
    |
 LL |     fn foo2_fail<'a, T: Trait<'a>>() -> impl FooLike<Output = T::Assoc> {
    |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type mismatch resolving `<Foo<()> as FooLike>::Output == <T as lifetimes::Trait<'static>>::Assoc`
@@ -63,31 +40,7 @@ help: consider constraining the associated type `<T as lifetimes::Trait<'static>
 LL |     fn foo2_fail<'a, T: Trait<'a, Assoc = ()>>() -> impl FooLike<Output = T::Assoc> {
    |                                 ++++++++++++
 
-error[E0271]: type mismatch resolving `<Foo<()> as FooLike>::Output == <T as lifetimes::Trait<'static>>::Assoc`
-  --> $DIR/bound-normalization-fail.rs:42:73
-   |
-LL |       fn foo2_fail<'a, T: Trait<'a>>() -> impl FooLike<Output = T::Assoc> {
-   |  _________________________________________________________________________^
-LL | |
-LL | |
-LL | |
-LL | |         Foo(())
-LL | |     }
-   | |_____^ type mismatch resolving `<Foo<()> as FooLike>::Output == <T as lifetimes::Trait<'static>>::Assoc`
-   |
-note: expected this to be `()`
-  --> $DIR/bound-normalization-fail.rs:14:19
-   |
-LL |     type Output = T;
-   |                   ^
-   = note:    expected unit type `()`
-           found associated type `<T as lifetimes::Trait<'static>>::Assoc`
-help: consider constraining the associated type `<T as lifetimes::Trait<'static>>::Assoc` to `()`
-   |
-LL |     fn foo2_fail<'a, T: Trait<'a, Assoc = ()>>() -> impl FooLike<Output = T::Assoc> {
-   |                                 ++++++++++++
-
-error: aborting due to 5 previous errors
+error: aborting due to 3 previous errors
 
 Some errors have detailed explanations: E0271, E0760.
 For more information about an error, try `rustc --explain E0271`.

--- a/src/test/ui/impl-trait/cross-return-site-inference.rs
+++ b/src/test/ui/impl-trait/cross-return-site-inference.rs
@@ -29,17 +29,17 @@ fn baa(b: bool) -> impl std::fmt::Debug {
 }
 
 fn muh() -> Result<(), impl std::fmt::Debug> {
-    Err("whoops")?; //~ ERROR `?` couldn't convert the error to `impl Debug`
+    Err("whoops")?; //~^ ERROR type annotations needed
     Ok(())
 }
 
 fn muh2() -> Result<(), impl std::fmt::Debug> {
-    return Err(From::from("foo")); //~ ERROR the trait bound `impl Debug: From<&str>` is not satisfied
+    return Err(From::from("foo")); //~^ ERROR type annotations needed
     Ok(())
 }
 
 fn muh3() -> Result<(), impl std::fmt::Debug> {
-    Err(From::from("foo")) //~ ERROR the trait bound `impl Debug: From<&str>` is not satisfied
+    Err(From::from("foo")) //~^ ERROR type annotations needed
 }
 
 fn main() {}

--- a/src/test/ui/impl-trait/cross-return-site-inference.stderr
+++ b/src/test/ui/impl-trait/cross-return-site-inference.stderr
@@ -1,26 +1,21 @@
-error[E0277]: `?` couldn't convert the error to `impl Debug`
-  --> $DIR/cross-return-site-inference.rs:32:18
+error[E0282]: type annotations needed
+  --> $DIR/cross-return-site-inference.rs:31:24
    |
 LL | fn muh() -> Result<(), impl std::fmt::Debug> {
-   |             -------------------------------- expected `impl Debug` because of this
-LL |     Err("whoops")?;
-   |                  ^ the trait `From<&str>` is not implemented for `impl Debug`
-   |
-   = note: the question mark operation (`?`) implicitly performs a conversion on the error value using the `From` trait
-   = note: required because of the requirements on the impl of `FromResidual<Result<Infallible, &str>>` for `Result<(), impl Debug>`
+   |                        ^^^^^^^^^^^^^^^^^^^^ cannot infer type
 
-error[E0277]: the trait bound `impl Debug: From<&str>` is not satisfied
-  --> $DIR/cross-return-site-inference.rs:37:16
+error[E0282]: type annotations needed
+  --> $DIR/cross-return-site-inference.rs:36:25
    |
-LL |     return Err(From::from("foo"));
-   |                ^^^^^^^^^^ the trait `From<&str>` is not implemented for `impl Debug`
+LL | fn muh2() -> Result<(), impl std::fmt::Debug> {
+   |                         ^^^^^^^^^^^^^^^^^^^^ cannot infer type
 
-error[E0277]: the trait bound `impl Debug: From<&str>` is not satisfied
-  --> $DIR/cross-return-site-inference.rs:42:9
+error[E0282]: type annotations needed
+  --> $DIR/cross-return-site-inference.rs:41:25
    |
-LL |     Err(From::from("foo"))
-   |         ^^^^^^^^^^ the trait `From<&str>` is not implemented for `impl Debug`
+LL | fn muh3() -> Result<(), impl std::fmt::Debug> {
+   |                         ^^^^^^^^^^^^^^^^^^^^ cannot infer type
 
 error: aborting due to 3 previous errors
 
-For more information about this error, try `rustc --explain E0277`.
+For more information about this error, try `rustc --explain E0282`.

--- a/src/test/ui/impl-trait/fallback_inference.rs
+++ b/src/test/ui/impl-trait/fallback_inference.rs
@@ -1,0 +1,7 @@
+use std::marker::PhantomData;
+
+fn weird() -> PhantomData<impl Sized> {
+    PhantomData //~^ ERROR type annotations needed
+}
+
+fn main() {}

--- a/src/test/ui/impl-trait/fallback_inference.stderr
+++ b/src/test/ui/impl-trait/fallback_inference.stderr
@@ -1,0 +1,9 @@
+error[E0282]: type annotations needed
+  --> $DIR/fallback_inference.rs:3:27
+   |
+LL | fn weird() -> PhantomData<impl Sized> {
+   |                           ^^^^^^^^^^ cannot infer type
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0282`.

--- a/src/test/ui/impl-trait/issue-72911.rs
+++ b/src/test/ui/impl-trait/issue-72911.rs
@@ -5,7 +5,7 @@ pub struct Lint {}
 impl Lint {}
 
 pub fn gather_all() -> impl Iterator<Item = Lint> {
-    //~^ ERROR `()` is not an iterator
+    //~^ ERROR type annotations needed
     lint_files().flat_map(|f| gather_from_file(&f))
 }
 

--- a/src/test/ui/impl-trait/issue-72911.stderr
+++ b/src/test/ui/impl-trait/issue-72911.stderr
@@ -10,15 +10,13 @@ error[E0433]: failed to resolve: use of undeclared crate or module `foo`
 LL | fn lint_files() -> impl Iterator<Item = foo::MissingItem> {
    |                                         ^^^ use of undeclared crate or module `foo`
 
-error[E0277]: `()` is not an iterator
+error[E0282]: type annotations needed
   --> $DIR/issue-72911.rs:7:24
    |
 LL | pub fn gather_all() -> impl Iterator<Item = Lint> {
-   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^ `()` is not an iterator
-   |
-   = help: the trait `Iterator` is not implemented for `()`
+   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type
 
 error: aborting due to 3 previous errors
 
-Some errors have detailed explanations: E0277, E0433.
-For more information about an error, try `rustc --explain E0277`.
+Some errors have detailed explanations: E0282, E0433.
+For more information about an error, try `rustc --explain E0282`.

--- a/src/test/ui/impl-trait/issues/issue-67830.stderr
+++ b/src/test/ui/impl-trait/issues/issue-67830.stderr
@@ -1,12 +1,8 @@
 error: implementation of `FnOnce` is not general enough
-  --> $DIR/issue-67830.rs:21:66
+  --> $DIR/issue-67830.rs:21:14
    |
-LL |   fn test() -> impl for<'a> MyFn<&'a A, Output=impl Iterator + 'a> {
-   |  __________________________________________________________________^
-LL | |
-LL | |     Wrap(|a| Some(a).into_iter())
-LL | | }
-   | |_^ implementation of `FnOnce` is not general enough
+LL | fn test() -> impl for<'a> MyFn<&'a A, Output=impl Iterator + 'a> {
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ implementation of `FnOnce` is not general enough
    |
    = note: closure with signature `fn(&'2 A) -> std::option::IntoIter<&A>` must implement `FnOnce<(&'1 A,)>`, for any lifetime `'1`...
    = note: ...but it actually implements `FnOnce<(&'2 A,)>`, for some specific lifetime `'2`

--- a/src/test/ui/impl-trait/issues/issue-88236-2.stderr
+++ b/src/test/ui/impl-trait/issues/issue-88236-2.stderr
@@ -8,15 +8,12 @@ LL | fn make_weird_impl<'b>(x: &'b ()) -> impl for<'a> Hrtb<'a, Assoc = impl Sen
    = note: ...but `Hrtb<'1>` is actually implemented for the type `&'1 ()`, for some specific lifetime `'1`
 
 error: implementation of `Hrtb` is not general enough
-  --> $DIR/issue-88236-2.rs:19:82
+  --> $DIR/issue-88236-2.rs:19:36
    |
-LL |   fn make_bad_impl<'b>(x: &'b ()) -> impl for<'a> Hrtb<'a, Assoc = impl Send + 'a> {
-   |  __________________________________________________________________________________^
-LL | |     x
-LL | | }
-   | |_^ implementation of `Hrtb` is not general enough
+LL | fn make_bad_impl<'b>(x: &'b ()) -> impl for<'a> Hrtb<'a, Assoc = impl Send + 'a> {
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ implementation of `Hrtb` is not general enough
    |
-   = note: `&()` must implement `Hrtb<'0>`, for any lifetime `'0`...
+   = note: `Hrtb<'1>` would have to be implemented for the type `&()`, for any lifetime `'1`...
    = note: ...but `Hrtb<'_>` is actually implemented for the type `&()`
 
 error: aborting due to 2 previous errors

--- a/src/test/ui/impl-trait/must_outlive_least_region_or_bound.nll.stderr
+++ b/src/test/ui/impl-trait/must_outlive_least_region_or_bound.nll.stderr
@@ -80,7 +80,7 @@ LL | fn move_lifetime_into_fn<'a, 'b>(x: &'a u32, y: &'b u32) -> impl Fn(&'a u32
    |                                                                              ++++
 
 error[E0310]: the parameter type `T` may not live long enough
-  --> $DIR/must_outlive_least_region_or_bound.rs:41:5
+  --> $DIR/must_outlive_least_region_or_bound.rs:40:5
    |
 LL |     x
    |     ^

--- a/src/test/ui/impl-trait/must_outlive_least_region_or_bound.rs
+++ b/src/test/ui/impl-trait/must_outlive_least_region_or_bound.rs
@@ -37,7 +37,6 @@ fn move_lifetime_into_fn<'a, 'b>(x: &'a u32, y: &'b u32) -> impl Fn(&'a u32) {
 
 fn ty_param_wont_outlive_static<T:Debug>(x: T) -> impl Debug + 'static {
     //~^ ERROR the parameter type `T` may not live long enough
-    //~| ERROR the parameter type `T` may not live long enough
     x
 }
 

--- a/src/test/ui/impl-trait/must_outlive_least_region_or_bound.stderr
+++ b/src/test/ui/impl-trait/must_outlive_least_region_or_bound.stderr
@@ -132,19 +132,6 @@ LL | fn ty_param_wont_outlive_static<T:Debug>(x: T) -> impl Debug + 'static {
    |                                 |
    |                                 help: consider adding an explicit lifetime bound...: `T: 'static +`
 
-error[E0310]: the parameter type `T` may not live long enough
-  --> $DIR/must_outlive_least_region_or_bound.rs:38:72
-   |
-LL |   fn ty_param_wont_outlive_static<T:Debug>(x: T) -> impl Debug + 'static {
-   |  _________________________________--_____________________________________^
-   | |                                 |
-   | |                                 help: consider adding an explicit lifetime bound...: `T: 'static +`
-LL | |
-LL | |
-LL | |     x
-LL | | }
-   | |_^ ...so that the type `T` will meet its required lifetime bounds
-
 error[E0759]: `x` has an anonymous lifetime `'_` but it needs to satisfy a `'static` lifetime requirement
   --> $DIR/must_outlive_least_region_or_bound.rs:16:50
    |
@@ -231,7 +218,7 @@ help: alternatively, add an explicit `'static` bound to this reference
 LL | fn explicit4<'a>(x: &'static i32) -> Box<dyn Debug + 'static> { Box::new(x) }
    |                     ~~~~~~~~~~~~
 
-error: aborting due to 14 previous errors
+error: aborting due to 13 previous errors
 
 Some errors have detailed explanations: E0310, E0621, E0700, E0759.
 For more information about an error, try `rustc --explain E0310`.

--- a/src/test/ui/impl-trait/nested-return-type2-tait.rs
+++ b/src/test/ui/impl-trait/nested-return-type2-tait.rs
@@ -24,7 +24,6 @@ type Sendable = impl Send;
 // type does not implement `Duh`, even if its hidden type does. So we error out.
 fn foo() -> impl Trait<Assoc = Sendable> {
     //~^ ERROR `Sendable: Duh` is not satisfied
-    //~| ERROR `Sendable: Duh` is not satisfied
     || 42
 }
 

--- a/src/test/ui/impl-trait/nested-return-type2-tait.stderr
+++ b/src/test/ui/impl-trait/nested-return-type2-tait.stderr
@@ -4,29 +4,12 @@ error[E0277]: the trait bound `Sendable: Duh` is not satisfied
 LL | fn foo() -> impl Trait<Assoc = Sendable> {
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Duh` is not implemented for `Sendable`
    |
-note: required because of the requirements on the impl of `Trait` for `[closure@$DIR/nested-return-type2-tait.rs:28:5: 28:10]`
+note: required because of the requirements on the impl of `Trait` for `[closure@$DIR/nested-return-type2-tait.rs:27:5: 27:10]`
   --> $DIR/nested-return-type2-tait.rs:14:31
    |
 LL | impl<R: Duh, F: FnMut() -> R> Trait for F {
    |                               ^^^^^     ^
 
-error[E0277]: the trait bound `Sendable: Duh` is not satisfied
-  --> $DIR/nested-return-type2-tait.rs:25:42
-   |
-LL |   fn foo() -> impl Trait<Assoc = Sendable> {
-   |  __________________________________________^
-LL | |
-LL | |
-LL | |     || 42
-LL | | }
-   | |_^ the trait `Duh` is not implemented for `Sendable`
-   |
-note: required because of the requirements on the impl of `Trait` for `[closure@$DIR/nested-return-type2-tait.rs:28:5: 28:10]`
-  --> $DIR/nested-return-type2-tait.rs:14:31
-   |
-LL | impl<R: Duh, F: FnMut() -> R> Trait for F {
-   |                               ^^^^^     ^
-
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/impl-trait/type_parameters_captured.nll.stderr
+++ b/src/test/ui/impl-trait/type_parameters_captured.nll.stderr
@@ -1,5 +1,5 @@
 error[E0310]: the parameter type `T` may not live long enough
-  --> $DIR/type_parameters_captured.rs:10:5
+  --> $DIR/type_parameters_captured.rs:9:5
    |
 LL |     x
    |     ^

--- a/src/test/ui/impl-trait/type_parameters_captured.rs
+++ b/src/test/ui/impl-trait/type_parameters_captured.rs
@@ -6,7 +6,6 @@ impl<T> Any for T {}
 // Check that type parameters are captured and not considered 'static
 fn foo<T>(x: T) -> impl Any + 'static {
     //~^ ERROR the parameter type `T` may not live long enough
-    //~| ERROR the parameter type `T` may not live long enough
     x
 }
 

--- a/src/test/ui/impl-trait/type_parameters_captured.stderr
+++ b/src/test/ui/impl-trait/type_parameters_captured.stderr
@@ -6,19 +6,6 @@ LL | fn foo<T>(x: T) -> impl Any + 'static {
    |        |
    |        help: consider adding an explicit lifetime bound...: `T: 'static`
 
-error[E0310]: the parameter type `T` may not live long enough
-  --> $DIR/type_parameters_captured.rs:7:39
-   |
-LL |   fn foo<T>(x: T) -> impl Any + 'static {
-   |  ________-______________________________^
-   | |        |
-   | |        help: consider adding an explicit lifetime bound...: `T: 'static`
-LL | |
-LL | |
-LL | |     x
-LL | | }
-   | |_^ ...so that the type `T` will meet its required lifetime bounds
-
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0310`.

--- a/src/test/ui/impl-trait/where-allowed-2.rs
+++ b/src/test/ui/impl-trait/where-allowed-2.rs
@@ -1,7 +1,6 @@
 use std::fmt::Debug;
 
-// check-pass
-
 fn in_adt_in_return() -> Vec<impl Debug> { panic!() }
+//~^ ERROR type annotations needed
 
 fn main() {}

--- a/src/test/ui/impl-trait/where-allowed-2.stderr
+++ b/src/test/ui/impl-trait/where-allowed-2.stderr
@@ -1,0 +1,9 @@
+error[E0282]: type annotations needed
+  --> $DIR/where-allowed-2.rs:3:30
+   |
+LL | fn in_adt_in_return() -> Vec<impl Debug> { panic!() }
+   |                              ^^^^^^^^^^ cannot infer type
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0282`.

--- a/src/test/ui/issues-71798.rs
+++ b/src/test/ui/issues-71798.rs
@@ -1,6 +1,5 @@
 fn test_ref(x: &u32) -> impl std::future::Future<Output = u32> + '_ {
     //~^ ERROR `u32` is not a future
-    //~| ERROR `u32` is not a future
     *x
 }
 

--- a/src/test/ui/issues-71798.stderr
+++ b/src/test/ui/issues-71798.stderr
@@ -1,5 +1,5 @@
 error[E0425]: cannot find value `u` in this scope
-  --> $DIR/issues-71798.rs:8:24
+  --> $DIR/issues-71798.rs:7:24
    |
 LL |     let _ = test_ref & u;
    |                        ^ not found in this scope
@@ -13,21 +13,7 @@ LL | fn test_ref(x: &u32) -> impl std::future::Future<Output = u32> + '_ {
    = help: the trait `Future` is not implemented for `u32`
    = note: u32 must be a future or must implement `IntoFuture` to be awaited
 
-error[E0277]: `u32` is not a future
-  --> $DIR/issues-71798.rs:1:69
-   |
-LL |   fn test_ref(x: &u32) -> impl std::future::Future<Output = u32> + '_ {
-   |  _____________________________________________________________________^
-LL | |
-LL | |
-LL | |     *x
-LL | | }
-   | |_^ `u32` is not a future
-   |
-   = help: the trait `Future` is not implemented for `u32`
-   = note: u32 must be a future or must implement `IntoFuture` to be awaited
-
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 
 Some errors have detailed explanations: E0277, E0425.
 For more information about an error, try `rustc --explain E0277`.

--- a/src/test/ui/lifetimes/lifetime-elision-return-type-trait.rs
+++ b/src/test/ui/lifetimes/lifetime-elision-return-type-trait.rs
@@ -7,7 +7,6 @@ use std::error::Error;
 
 fn foo() -> impl Future<Item=(), Error=Box<dyn Error>> {
     //~^ ERROR not satisfied
-    //~| ERROR not satisfied
     Ok(())
 }
 

--- a/src/test/ui/lifetimes/lifetime-elision-return-type-trait.stderr
+++ b/src/test/ui/lifetimes/lifetime-elision-return-type-trait.stderr
@@ -4,17 +4,6 @@ error[E0277]: the trait bound `Result<(), _>: Future` is not satisfied
 LL | fn foo() -> impl Future<Item=(), Error=Box<dyn Error>> {
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Future` is not implemented for `Result<(), _>`
 
-error[E0277]: the trait bound `Result<(), _>: Future` is not satisfied
-  --> $DIR/lifetime-elision-return-type-trait.rs:8:56
-   |
-LL |   fn foo() -> impl Future<Item=(), Error=Box<dyn Error>> {
-   |  ________________________________________________________^
-LL | |
-LL | |
-LL | |     Ok(())
-LL | | }
-   | |_^ the trait `Future` is not implemented for `Result<(), _>`
-
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/macros/trace-macro.stderr
+++ b/src/test/ui/macros/trace-macro.stderr
@@ -5,5 +5,5 @@ LL |     println!("Hello, World!");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: expanding `println! { "Hello, World!" }`
-   = note: to `$crate :: io :: _print($crate :: format_args_nl! ("Hello, World!"))`
+   = note: to `{ $crate :: io :: _print($crate :: format_args_nl! ("Hello, World!")) ; }`
 

--- a/src/test/ui/pattern/usefulness/tuple-struct-nonexhaustive.stderr
+++ b/src/test/ui/pattern/usefulness/tuple-struct-nonexhaustive.stderr
@@ -12,7 +12,7 @@ LL | struct Foo(isize, isize);
    = note: the matched value is of type `Foo`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         Foo(2, b) => println!("{}", b),
+LL ~         Foo(2, b) => println!("{}", b)
 LL +         Foo(_, _) => todo!()
    |
 

--- a/src/test/ui/suggestions/impl-trait-return-trailing-semicolon.rs
+++ b/src/test/ui/suggestions/impl-trait-return-trailing-semicolon.rs
@@ -2,7 +2,6 @@ trait Bar {}
 impl Bar for u8 {}
 fn foo() -> impl Bar {
     5; //~^ ERROR the trait bound `(): Bar` is not satisfied
-    //~| ERROR the trait bound `(): Bar` is not satisfied
 }
 
 fn main() {}

--- a/src/test/ui/suggestions/impl-trait-return-trailing-semicolon.stderr
+++ b/src/test/ui/suggestions/impl-trait-return-trailing-semicolon.stderr
@@ -6,16 +6,6 @@ LL | fn foo() -> impl Bar {
 LL |     5;
    |      - consider removing this semicolon
 
-error[E0277]: the trait bound `(): Bar` is not satisfied
-  --> $DIR/impl-trait-return-trailing-semicolon.rs:3:22
-   |
-LL |   fn foo() -> impl Bar {
-   |  ______________________^
-LL | |     5;
-LL | |
-LL | | }
-   | |_^ the trait `Bar` is not implemented for `()`
-
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/suggestions/issue-81098.rs
+++ b/src/test/ui/suggestions/issue-81098.rs
@@ -1,14 +1,12 @@
 // Don't suggest removing a semicolon if the last statement isn't an expression with semicolon
 // (#81098)
 fn wat() -> impl core::fmt::Display { //~ ERROR: `()` doesn't implement `std::fmt::Display`
-    //~^ ERROR: `()` doesn't implement `std::fmt::Display`
     fn why() {}
 }
 
 // Do it if the last statement is an expression with semicolon
 // (#54771)
 fn ok() -> impl core::fmt::Display { //~ ERROR: `()` doesn't implement `std::fmt::Display`
-    //~^ ERROR: `()` doesn't implement `std::fmt::Display`
     1;
 }
 

--- a/src/test/ui/suggestions/issue-81098.stderr
+++ b/src/test/ui/suggestions/issue-81098.stderr
@@ -8,43 +8,16 @@ LL | fn wat() -> impl core::fmt::Display {
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
 
 error[E0277]: `()` doesn't implement `std::fmt::Display`
-  --> $DIR/issue-81098.rs:3:37
-   |
-LL |   fn wat() -> impl core::fmt::Display {
-   |  _____________________________________^
-LL | |
-LL | |     fn why() {}
-LL | | }
-   | |_^ `()` cannot be formatted with the default formatter
-   |
-   = help: the trait `std::fmt::Display` is not implemented for `()`
-   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
-
-error[E0277]: `()` doesn't implement `std::fmt::Display`
-  --> $DIR/issue-81098.rs:10:12
+  --> $DIR/issue-81098.rs:9:12
    |
 LL | fn ok() -> impl core::fmt::Display {
    |            ^^^^^^^^^^^^^^^^^^^^^^^ `()` cannot be formatted with the default formatter
-LL |
 LL |     1;
    |      - consider removing this semicolon
    |
    = help: the trait `std::fmt::Display` is not implemented for `()`
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
 
-error[E0277]: `()` doesn't implement `std::fmt::Display`
-  --> $DIR/issue-81098.rs:10:36
-   |
-LL |   fn ok() -> impl core::fmt::Display {
-   |  ____________________________________^
-LL | |
-LL | |     1;
-LL | | }
-   | |_^ `()` cannot be formatted with the default formatter
-   |
-   = help: the trait `std::fmt::Display` is not implemented for `()`
-   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
-
-error: aborting due to 4 previous errors
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/suggestions/lifetimes/missing-lifetimes-in-signature.nll.stderr
+++ b/src/test/ui/suggestions/lifetimes/missing-lifetimes-in-signature.nll.stderr
@@ -1,0 +1,11 @@
+error[E0261]: use of undeclared lifetime name `'a`
+  --> $DIR/missing-lifetimes-in-signature.rs:36:11
+   |
+LL | fn baz<G: 'a, T>(g: G, dest: &mut T) -> impl FnOnce() + '_
+   |        -  ^^ undeclared lifetime
+   |        |
+   |        help: consider introducing lifetime `'a` here: `'a,`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0261`.

--- a/src/test/ui/type-alias-impl-trait/nested-tait-inference.rs
+++ b/src/test/ui/type-alias-impl-trait/nested-tait-inference.rs
@@ -11,7 +11,6 @@ impl Foo<()> for () { }
 
 fn foo() -> impl Foo<FooX> {
     //~^ ERROR: the trait bound `(): Foo<FooX>` is not satisfied
-    //~| ERROR: the trait bound `(): Foo<FooX>` is not satisfied
     // FIXME(type-alias-impl-trait): We could probably make this work.
     ()
 }

--- a/src/test/ui/type-alias-impl-trait/nested-tait-inference.stderr
+++ b/src/test/ui/type-alias-impl-trait/nested-tait-inference.stderr
@@ -7,21 +7,6 @@ LL | fn foo() -> impl Foo<FooX> {
    = help: the following implementations were found:
              <() as Foo<()>>
 
-error[E0277]: the trait bound `(): Foo<FooX>` is not satisfied
-  --> $DIR/nested-tait-inference.rs:12:28
-   |
-LL |   fn foo() -> impl Foo<FooX> {
-   |  ____________________________^
-LL | |
-LL | |
-LL | |     // FIXME(type-alias-impl-trait): We could probably make this work.
-LL | |     ()
-LL | | }
-   | |_^ the trait `Foo<FooX>` is not implemented for `()`
-   |
-   = help: the following implementations were found:
-             <() as Foo<()>>
-
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/type-alias-impl-trait/nested-tait-inference2.rs
+++ b/src/test/ui/type-alias-impl-trait/nested-tait-inference2.rs
@@ -12,7 +12,6 @@ impl Foo<u32> for () {}
 
 fn foo() -> impl Foo<FooX> {
     //~^ ERROR: the trait bound `(): Foo<FooX>` is not satisfied
-    //~| ERROR: the trait bound `(): Foo<FooX>` is not satisfied
     ()
 }
 

--- a/src/test/ui/type-alias-impl-trait/nested-tait-inference2.stderr
+++ b/src/test/ui/type-alias-impl-trait/nested-tait-inference2.stderr
@@ -8,21 +8,6 @@ LL | fn foo() -> impl Foo<FooX> {
              <() as Foo<()>>
              <() as Foo<u32>>
 
-error[E0277]: the trait bound `(): Foo<FooX>` is not satisfied
-  --> $DIR/nested-tait-inference2.rs:13:28
-   |
-LL |   fn foo() -> impl Foo<FooX> {
-   |  ____________________________^
-LL | |
-LL | |
-LL | |     ()
-LL | | }
-   | |_^ the trait `Foo<FooX>` is not implemented for `()`
-   |
-   = help: the following implementations were found:
-             <() as Foo<()>>
-             <() as Foo<u32>>
-
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
* Revert diagnostic duplication and accidental stabilization #96516 
* Revert "Re-export core::ffi types from std::ffi" #96492 
* Make [e]println macros eagerly drop temporaries (for backport) #96490 
* Revert "impl From<&[T; N]> and From<&mut [T; N]> for Vec<T>" #96489 
* Cargo:
    * move workspace inheritance unstable docs to the correct place (rust-lang/cargo#10616)
