### PR TITLE
Update cargo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -448,9 +448,10 @@ dependencies = [
  "lazy_static",
  "remove_dir_all",
  "serde_json",
+ "snapbox",
  "tar",
  "termcolor",
- "toml_edit 0.13.4",
+ "toml_edit 0.14.3",
  "url 2.2.2",
 ]
 


### PR DESCRIPTION
7 commits in f63f23ff1f1a12ede8585bbd1bbf0c536e50293d..a44758ac805600edbb6ba51e7e6fb81a6077c0cd
2022-04-28 03:15:50 +0000 to 2022-05-04 02:29:34 +0000
- Add support for `-Zbuild-std` to `cargo fetch` (rust-lang/cargo#10129)
- Migrate tests of `cargo-init` to snapbox (rust-lang/cargo#10620)
- dedupe toml_edit crate, followup rust-lang/cargo#10603 (rust-lang/cargo#10619)
- Update GitHub Actions actions/checkout@v2 to v3 (rust-lang/cargo#10618)
- Integrate snapbox in with cargo-test-support (rust-lang/cargo#10581)
- Fix zsh completion (rust-lang/cargo#10613)
- Update documentation for workspace inheritance (rust-lang/cargo#10611)