### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -2017,9 +2017,7 @@ pub enum ProjectionElem<V, T> {
         from_end: bool,
     },
 
-    /// "Downcast" to a variant of an ADT. Currently, we only introduce
-    /// this for ADTs with more than one variant. It may be better to
-    /// just introduce it always, or always for enums.
+    /// "Downcast" to a variant of an enum or a generator.
     ///
     /// The included Symbol is the name of the variant, used for printing MIR.
     Downcast(Option<Symbol>, VariantIdx),

--- a/compiler/rustc_middle/src/mir/tcx.rs
+++ b/compiler/rustc_middle/src/mir/tcx.rs
@@ -12,7 +12,7 @@ use rustc_target::abi::VariantIdx;
 #[derive(Copy, Clone, Debug, TypeFoldable)]
 pub struct PlaceTy<'tcx> {
     pub ty: Ty<'tcx>,
-    /// Downcast to a particular variant of an enum, if included.
+    /// Downcast to a particular variant of an enum or a generator, if included.
     pub variant_index: Option<VariantIdx>,
 }
 

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -866,7 +866,13 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                 return false;
             }
 
-            let orig_ty = old_pred.self_ty().skip_binder();
+            // This is a quick fix to resolve an ICE ([issue#96223](https://github.com/rust-lang/rust/issues/96223)).
+            // This change should probably be deeper.
+            // As suggested by @jackh726, `mk_trait_obligation_with_new_self_ty` could take a `Binder<(TraitRef, Ty)>
+            // instead of `Binder<Ty>` leading to some changes to its call places.
+            let Some(orig_ty) = old_pred.self_ty().no_bound_vars() else {
+                return false;
+            };
             let mk_result = |new_ty| {
                 let obligation =
                     self.mk_trait_obligation_with_new_self_ty(param_env, old_pred, new_ty);

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -866,7 +866,7 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                 return false;
             }
 
-            // This is a quick fix to resolve an ICE ([issue#96223](https://github.com/rust-lang/rust/issues/96223)).
+            // This is a quick fix to resolve an ICE (#96223).
             // This change should probably be deeper.
             // As suggested by @jackh726, `mk_trait_obligation_with_new_self_ty` could take a `Binder<(TraitRef, Ty)>
             // instead of `Binder<Ty>` leading to some changes to its call places.

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -1406,7 +1406,8 @@ impl<'a> Builder<'a> {
         // FIXME(davidtwco): #[cfg(not(bootstrap))] - #95612 needs to be in the bootstrap compiler
         // for this conditional to be removed.
         if !target.contains("windows") || compiler.stage >= 1 {
-            if target.contains("linux") || target.contains("windows") {
+            if target.contains("linux") || target.contains("windows") || target.contains("openbsd")
+            {
                 rustflags.arg("-Zunstable-options");
             }
             match self.config.rust_split_debuginfo {

--- a/src/doc/rustc/src/lints/levels.md
+++ b/src/doc/rustc/src/lints/levels.md
@@ -100,9 +100,8 @@ This lint level gives you that.
 'force-warn' does for 'warn'. It's the same as 'deny' in that a lint at this
 level will produce an error, but unlike the 'deny' level, the 'forbid' level
 can not be overridden to be anything lower than an error.  However, lint
-levels may still be capped with `--cap-lints` (see below) so `rustc --cap-
-lints warn` will make lints set to 'forbid' just
-warn.
+levels may still be capped with `--cap-lints` (see below) so `rustc --cap-lints warn`
+will make lints set to 'forbid' just warn.
 
 ## Configuring warning levels
 

--- a/src/test/rustdoc-ui/block-doc-comment.rs
+++ b/src/test/rustdoc-ui/block-doc-comment.rs
@@ -1,5 +1,6 @@
 // check-pass
 // compile-flags:--test
+// normalize-stdout-test "finished in \d+\.\d+s" -> "finished in $$TIME"
 
 // This test ensures that no code block is detected in the doc comments.
 

--- a/src/test/rustdoc-ui/block-doc-comment.stdout
+++ b/src/test/rustdoc-ui/block-doc-comment.stdout
@@ -1,5 +1,5 @@
 
 running 0 tests
 
-test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
 

--- a/src/test/ui/suggestions/issue-96223.rs
+++ b/src/test/ui/suggestions/issue-96223.rs
@@ -1,6 +1,5 @@
-// Test case for #96223.
-// An ICE was triggered because of a failed assertion.
-// Thanks to @Manishearth for the minimal test case.
+// Previously ICEd because we didn't properly track binders in suggestions
+// check-fail
 
 pub trait Foo<'de>: Sized {}
 
@@ -47,7 +46,7 @@ fn icey_bounds<D: Dummy<EmptyMarker>>(p: &D) {}
 
 fn trigger_ice() {
     let p = Empty;
-    icey_bounds(&p); //~ERROR
+    icey_bounds(&p); //~ERROR the trait bound
 }
 
 fn main() {}

--- a/src/test/ui/suggestions/issue-96223.stderr
+++ b/src/test/ui/suggestions/issue-96223.stderr
@@ -1,0 +1,28 @@
+error[E0277]: the trait bound `for<'de> EmptyBis<'de>: Foo<'_>` is not satisfied
+  --> $DIR/issue-96223.rs:50:17
+   |
+LL |     icey_bounds(&p);
+   |     ----------- ^^ the trait `for<'de> Foo<'_>` is not implemented for `EmptyBis<'de>`
+   |     |
+   |     required by a bound introduced by this call
+   |
+   = help: the trait `Foo<'de>` is implemented for `Baz<T>`
+note: required because of the requirements on the impl of `for<'de> Foo<'de>` for `Baz<EmptyBis<'de>>`
+  --> $DIR/issue-96223.rs:17:14
+   |
+LL | impl<'de, T> Foo<'de> for Baz<T> where T: Foo<'de> {}
+   |              ^^^^^^^^     ^^^^^^
+note: required because of the requirements on the impl of `Dummy<EmptyMarker>` for `Empty`
+  --> $DIR/issue-96223.rs:21:9
+   |
+LL | impl<M> Dummy<M> for Empty
+   |         ^^^^^^^^     ^^^^^
+note: required by a bound in `icey_bounds`
+  --> $DIR/issue-96223.rs:46:19
+   |
+LL | fn icey_bounds<D: Dummy<EmptyMarker>>(p: &D) {}
+   |                   ^^^^^^^^^^^^^^^^^^ required by this bound in `icey_bounds`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/suggestions/issue-96223.stderr
+++ b/src/test/ui/suggestions/issue-96223.stderr
@@ -1,5 +1,5 @@
 error[E0277]: the trait bound `for<'de> EmptyBis<'de>: Foo<'_>` is not satisfied
-  --> $DIR/issue-96223.rs:50:17
+  --> $DIR/issue-96223.rs:49:17
    |
 LL |     icey_bounds(&p);
    |     ----------- ^^ the trait `for<'de> Foo<'_>` is not implemented for `EmptyBis<'de>`
@@ -8,17 +8,17 @@ LL |     icey_bounds(&p);
    |
    = help: the trait `Foo<'de>` is implemented for `Baz<T>`
 note: required because of the requirements on the impl of `for<'de> Foo<'de>` for `Baz<EmptyBis<'de>>`
-  --> $DIR/issue-96223.rs:17:14
+  --> $DIR/issue-96223.rs:16:14
    |
 LL | impl<'de, T> Foo<'de> for Baz<T> where T: Foo<'de> {}
    |              ^^^^^^^^     ^^^^^^
 note: required because of the requirements on the impl of `Dummy<EmptyMarker>` for `Empty`
-  --> $DIR/issue-96223.rs:21:9
+  --> $DIR/issue-96223.rs:20:9
    |
 LL | impl<M> Dummy<M> for Empty
    |         ^^^^^^^^     ^^^^^
 note: required by a bound in `icey_bounds`
-  --> $DIR/issue-96223.rs:46:19
+  --> $DIR/issue-96223.rs:45:19
    |
 LL | fn icey_bounds<D: Dummy<EmptyMarker>>(p: &D) {}
    |                   ^^^^^^^^^^^^^^^^^^ required by this bound in `icey_bounds`

--- a/src/test/ui/type-alias-impl-trait/issue-53398-cyclic-types.rs
+++ b/src/test/ui/type-alias-impl-trait/issue-53398-cyclic-types.rs
@@ -1,0 +1,9 @@
+#![feature(type_alias_impl_trait)]
+
+type Foo = impl Fn() -> Foo;
+
+fn foo() -> Foo {
+    foo //~ ERROR: overflow evaluating the requirement `fn() -> Foo {foo}: Sized`
+}
+
+fn main() {}

--- a/src/test/ui/type-alias-impl-trait/issue-53398-cyclic-types.stderr
+++ b/src/test/ui/type-alias-impl-trait/issue-53398-cyclic-types.stderr
@@ -1,0 +1,11 @@
+error[E0275]: overflow evaluating the requirement `fn() -> Foo {foo}: Sized`
+  --> $DIR/issue-53398-cyclic-types.rs:6:5
+   |
+LL |     foo
+   |     ^^^
+   |
+   = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`issue_53398_cyclic_types`)
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0275`.

--- a/src/test/ui/type-alias-impl-trait/issue-58662-generator-with-lifetime.rs
+++ b/src/test/ui/type-alias-impl-trait/issue-58662-generator-with-lifetime.rs
@@ -1,0 +1,39 @@
+// check-pass
+
+#![feature(generators, generator_trait)]
+#![feature(type_alias_impl_trait)]
+
+use std::ops::{Generator, GeneratorState};
+use std::pin::Pin;
+
+type RandGenerator<'a> = impl Generator<Return = (), Yield = u64> + 'a;
+fn rand_generator<'a>(rng: &'a ()) -> RandGenerator<'a> {
+    move || {
+        let _rng = rng;
+        loop {
+            yield 0;
+        }
+    }
+}
+
+pub type RandGeneratorWithIndirection<'a> = impl Generator<Return = (), Yield = u64> + 'a;
+pub fn rand_generator_with_indirection<'a>(rng: &'a ()) -> RandGeneratorWithIndirection<'a> {
+    fn helper<'b>(rng: &'b ()) -> impl 'b + Generator<Return = (), Yield = u64> {
+        move || {
+            let _rng = rng;
+            loop {
+                yield 0;
+            }
+        }
+    }
+
+    helper(rng)
+}
+
+fn main() {
+    let mut gen = rand_generator(&());
+    match unsafe { Pin::new_unchecked(&mut gen) }.resume(()) {
+        GeneratorState::Yielded(_) => {}
+        GeneratorState::Complete(_) => {}
+    };
+}

--- a/src/test/ui/type-alias-impl-trait/issue-89952.rs
+++ b/src/test/ui/type-alias-impl-trait/issue-89952.rs
@@ -1,0 +1,31 @@
+// check-pass
+
+#![feature(type_alias_impl_trait)]
+
+trait SomeTrait {}
+impl SomeTrait for () {}
+
+trait MyFuture {
+    type Output;
+}
+impl<T> MyFuture for T {
+    type Output = T;
+}
+
+trait ReturnsFuture {
+    type Output: SomeTrait;
+    type Future: MyFuture<Output = Result<Self::Output, ()>>;
+    fn func() -> Self::Future;
+}
+
+struct Foo;
+
+impl ReturnsFuture for Foo {
+    type Output = impl SomeTrait;
+    type Future = impl MyFuture<Output = Result<Self::Output, ()>>;
+    fn func() -> Self::Future {
+        Result::<(), ()>::Err(())
+    }
+}
+
+fn main() {}

--- a/src/test/ui/type-alias-impl-trait/issue-94429.rs
+++ b/src/test/ui/type-alias-impl-trait/issue-94429.rs
@@ -1,0 +1,22 @@
+#![feature(type_alias_impl_trait, generator_trait, generators)]
+use std::ops::Generator;
+
+trait Runnable {
+    type Gen: Generator<Yield = (), Return = ()>;
+
+    fn run(&mut self) -> Self::Gen;
+}
+
+struct Implementor {}
+
+impl Runnable for Implementor {
+    type Gen = impl Generator<Yield = (), Return = ()>;
+
+    fn run(&mut self) -> Self::Gen {
+        move || { //~ ERROR: type mismatch resolving
+            yield 1;
+        }
+    }
+}
+
+fn main() {}

--- a/src/test/ui/type-alias-impl-trait/issue-94429.stderr
+++ b/src/test/ui/type-alias-impl-trait/issue-94429.stderr
@@ -1,0 +1,11 @@
+error[E0271]: type mismatch resolving `<[generator@$DIR/issue-94429.rs:16:9: 18:10] as Generator>::Yield == ()`
+  --> $DIR/issue-94429.rs:16:9
+   |
+LL | /         move || {
+LL | |             yield 1;
+LL | |         }
+   | |_________^ expected integer, found `()`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0271`.


### PR DESCRIPTION
Successful merges:

 - #96597 (openbsd: unbreak build on native platform)
 - #96662 (Fix typo in lint levels doc)
 - #96668 (Fix flaky rustdoc-ui test because it did not replace time result)
 - #96679 (Quick fix for #96223.)
 - #96684 (Update `ProjectionElem::Downcast` documentation)
 - #96686 (Add some TAIT-related tests)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=96597,96662,96668,96679,96684,96686)
<!-- homu-ignore:end -->