### PR TITLE
Enable tracing for all queries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4244,6 +4244,7 @@ dependencies = [
  "rustc_serialize",
  "rustc_session",
  "rustc_span",
+ "tracing",
 ]
 
 [[package]]

--- a/compiler/rustc_query_impl/Cargo.toml
+++ b/compiler/rustc_query_impl/Cargo.toml
@@ -20,6 +20,7 @@ rustc_query_system = { path = "../rustc_query_system" }
 rustc_serialize = { path = "../rustc_serialize" }
 rustc_session = { path = "../rustc_session" }
 rustc_span = { path = "../rustc_span" }
+tracing = "0.1"
 
 [features]
 rustc_use_parallel_compiler = ["rustc-rayon-core", "rustc_query_system/rustc_use_parallel_compiler"]

--- a/compiler/rustc_query_impl/src/plumbing.rs
+++ b/compiler/rustc_query_impl/src/plumbing.rs
@@ -435,6 +435,8 @@ macro_rules! define_queries {
 
                 fn force_from_dep_node(tcx: TyCtxt<'_>, dep_node: DepNode) -> bool {
                     if let Some(key) = recover(tcx, dep_node) {
+                        #[cfg(debug_assertions)]
+                        let _guard = tracing::span!(tracing::Level::TRACE, stringify!($name), ?key).entered();
                         let tcx = QueryCtxt::from_tcx(tcx);
                         force_query::<queries::$name<'_>, _>(tcx, key, dep_node);
                         true
@@ -532,6 +534,7 @@ macro_rules! define_queries_struct {
 
             $($(#[$attr])*
             #[inline(always)]
+            #[tracing::instrument(level = "trace", skip(self, tcx))]
             fn $name(
                 &'tcx self,
                 tcx: TyCtxt<$tcx>,

--- a/compiler/rustc_query_system/src/query/plumbing.rs
+++ b/compiler/rustc_query_system/src/query/plumbing.rs
@@ -675,6 +675,7 @@ where
     }
 }
 
+#[derive(Debug)]
 pub enum QueryMode {
     Get,
     Ensure,
@@ -697,7 +698,6 @@ where
         None
     };
 
-    debug!("ty::query::get_query<{}>(key={:?}, span={:?})", Q::NAME, key, span);
     let (result, dep_node_index) = try_execute_query(
         tcx,
         Q::query_state(tcx),


### PR DESCRIPTION
This allows you to log everything within a specific query, e.g.

```
env RUSTC_LOG=[mir_borrowck]
```

dumping all borrowck queries may be a bit verbose, so you can also restrict it to just an item of your choice:

```
env RUSTC_LOG=[mir_borrowck{key=\.\*name_of_item\.\*}]
```

the regex `.*` in the key name are because the key is a debug printed DefId, so you'd get all kinds of things like hashes in there. The tracing logs will show you the key, so you can restrict it further if you want.