### PR TITLE
Add rotation animation on settings button when loading

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1401,6 +1401,18 @@ pre.rust {
 	cursor: pointer;
 }
 
+@keyframes rotating {
+	from {
+		transform: rotate(0deg);
+	}
+	to {
+		transform: rotate(360deg);
+	}
+}
+#settings-menu.rotate img {
+	animation: rotating 2s linear infinite;
+}
+
 #help-button {
 	font-family: "Fira Sans", Arial, sans-serif;
 	text-align: center;

--- a/src/librustdoc/html/static/js/main.js
+++ b/src/librustdoc/html/static/js/main.js
@@ -300,8 +300,8 @@ function loadCss(cssFileName) {
         document.head.append(script);
     }
 
-
     getSettingsButton().onclick = event => {
+        addClass(getSettingsButton(), "rotate");
         event.preventDefault();
         loadScript(window.settingsJS);
     };

--- a/src/librustdoc/html/static/js/settings.js
+++ b/src/librustdoc/html/static/js/settings.js
@@ -272,5 +272,6 @@
         if (!isSettingsPage) {
             switchDisplayedElement(settingsMenu);
         }
+        removeClass(getSettingsButton(), "rotate");
     }, 0);
 })();


### PR DESCRIPTION
As discussed, I added an animation when the settings JS file is loading (I voluntarily made the timeout at the end of the `settings.js` super long so we can see what the animation looks like):

https://user-images.githubusercontent.com/3050060/166693243-816a08b7-5e39-4142-acd3-686ad9950d8e.mp4

r? @jsha 