### PR TITLE
Handle mismatched generic param kinds in trait impls betterly

### DIFF
--- a/compiler/rustc_typeck/src/check/compare_method.rs
+++ b/compiler/rustc_typeck/src/check/compare_method.rs
@@ -1003,7 +1003,7 @@ fn compare_generic_param_kinds<'tcx>(
         } {
             let make_param_message = |prefix: &str, param: &ty::GenericParamDef| match param.kind {
                 Const { .. } => {
-                    format!("{} const parameter with type `{}`", prefix, tcx.type_of(param.def_id))
+                    format!("{} const parameter of type `{}`", prefix, tcx.type_of(param.def_id))
                 }
                 Type { .. } => format!("{} type parameter", prefix),
                 Lifetime { .. } => unreachable!(),
@@ -1016,7 +1016,7 @@ fn compare_generic_param_kinds<'tcx>(
                 tcx.sess,
                 param_impl_span,
                 E0053,
-                "{} `{}` has an incompatible generic parameter for trait: `{}`",
+                "{} `{}` has an incompatible generic parameter for trait `{}`",
                 assoc_item_kind_str(&impl_item),
                 trait_item.name,
                 &tcx.def_path_str(tcx.parent(trait_item.def_id))

--- a/compiler/rustc_typeck/src/check/compare_method.rs
+++ b/compiler/rustc_typeck/src/check/compare_method.rs
@@ -1001,14 +1001,6 @@ fn compare_generic_param_kinds<'tcx>(
             (Const { .. }, Const { .. }) | (Type { .. }, Type { .. }) => false,
             (Lifetime { .. }, _) | (_, Lifetime { .. }) => unreachable!(),
         } {
-            let make_param_message = |prefix: &str, param: &ty::GenericParamDef| match param.kind {
-                Const { .. } => {
-                    format!("{} const parameter of type `{}`", prefix, tcx.type_of(param.def_id))
-                }
-                Type { .. } => format!("{} type parameter", prefix),
-                Lifetime { .. } => unreachable!(),
-            };
-
             let param_impl_span = tcx.def_span(param_impl.def_id);
             let param_trait_span = tcx.def_span(param_trait.def_id);
 
@@ -1021,6 +1013,14 @@ fn compare_generic_param_kinds<'tcx>(
                 trait_item.name,
                 &tcx.def_path_str(tcx.parent(trait_item.def_id))
             );
+
+            let make_param_message = |prefix: &str, param: &ty::GenericParamDef| match param.kind {
+                Const { .. } => {
+                    format!("{} const parameter of type `{}`", prefix, tcx.type_of(param.def_id))
+                }
+                Type { .. } => format!("{} type parameter", prefix),
+                Lifetime { .. } => unreachable!(),
+            };
 
             let trait_header_span = tcx.def_ident_span(tcx.parent(trait_item.def_id)).unwrap();
             err.span_label(trait_header_span, "");

--- a/src/test/ui/const-generics/defaults/mismatched_ty_const_in_trait_impl.rs
+++ b/src/test/ui/const-generics/defaults/mismatched_ty_const_in_trait_impl.rs
@@ -1,0 +1,25 @@
+trait Trait {
+    fn foo<U>() {}
+}
+impl Trait for () {
+    fn foo<const M: u64>() {}
+    //~^ error: method `foo` has an incompatble generic parameter for trait
+}
+
+trait Other {
+    fn bar<const M: u8>() {}
+}
+impl Other for () {
+    fn bar<T>() {}
+    //~^ error: method `bar` has an incompatible generic parameter for trait
+}
+
+trait Uwu {
+    fn baz<const N: u32>() {}
+}
+impl Uwu for () {
+    fn baz<const N: i32>() {}
+    //~^ error: method `baz` has an incompatible generic parameter for trait
+}
+
+fn main() {}

--- a/src/test/ui/const-generics/defaults/mismatched_ty_const_in_trait_impl.rs
+++ b/src/test/ui/const-generics/defaults/mismatched_ty_const_in_trait_impl.rs
@@ -3,7 +3,7 @@ trait Trait {
 }
 impl Trait for () {
     fn foo<const M: u64>() {}
-    //~^ error: method `foo` has an incompatble generic parameter for trait
+    //~^ error: method `foo` has an incompatible generic parameter for trait
 }
 
 trait Other {
@@ -19,7 +19,7 @@ trait Uwu {
 }
 impl Uwu for () {
     fn baz<const N: i32>() {}
-    //~^ error: method `baz` has an incompatible generic parameter for trait
+    //~^ error: method `baz` has an incompatible const parameter type for trait
 }
 
 fn main() {}

--- a/src/test/ui/const-generics/defaults/mismatched_ty_const_in_trait_impl.rs
+++ b/src/test/ui/const-generics/defaults/mismatched_ty_const_in_trait_impl.rs
@@ -19,7 +19,23 @@ trait Uwu {
 }
 impl Uwu for () {
     fn baz<const N: i32>() {}
-    //~^ error: method `baz` has an incompatible const parameter type for trait
+    //~^ error: method `baz` has an incompatible generic parameter for trait
+}
+
+trait Aaaaaa {
+    fn bbbb<const N: u32, T>() {}
+}
+impl Aaaaaa for () {
+    fn bbbb<T, const N: u32>() {}
+    //~^ error: method `bbbb` has an incompatible generic parameter for trait
+}
+
+trait Names {
+    fn abcd<T, const N: u32>() {}
+}
+impl Names for () {
+    fn abcd<const N: u32, T>() {}
+    //~^ error: method `abcd` has an incompatible generic parameter for trait
 }
 
 fn main() {}

--- a/src/test/ui/const-generics/defaults/mismatched_ty_const_in_trait_impl.stderr
+++ b/src/test/ui/const-generics/defaults/mismatched_ty_const_in_trait_impl.stderr
@@ -1,0 +1,52 @@
+error[E0049]: method `foo` has 0 type parameters but its trait declaration has 1 type parameter
+  --> $DIR/mismatched_ty_const_in_trait_impl.rs:5:12
+   |
+LL |     fn foo<U>() {}
+   |            - expected 1 type parameter
+...
+LL |     fn foo<const M: u64>() {}
+   |            ^^^^^^^^^^^^ found 0 type parameters
+
+error[E0049]: method `foo` has 1 const parameter but its trait declaration has 0 const parameters
+  --> $DIR/mismatched_ty_const_in_trait_impl.rs:5:12
+   |
+LL |     fn foo<U>() {}
+   |            - expected 0 const parameters
+...
+LL |     fn foo<const M: u64>() {}
+   |            ^^^^^^^^^^^^ found 1 const parameter
+
+error[E0049]: method `bar` has 1 type parameter but its trait declaration has 0 type parameters
+  --> $DIR/mismatched_ty_const_in_trait_impl.rs:13:12
+   |
+LL |     fn bar<const M: u8>() {}
+   |            ----------- expected 0 type parameters
+...
+LL |     fn bar<T>() {}
+   |            ^ found 1 type parameter
+
+error[E0049]: method `bar` has 0 const parameters but its trait declaration has 1 const parameter
+  --> $DIR/mismatched_ty_const_in_trait_impl.rs:13:12
+   |
+LL |     fn bar<const M: u8>() {}
+   |            ----------- expected 1 const parameter
+...
+LL |     fn bar<T>() {}
+   |            ^ found 0 const parameters
+
+error[E0053]: method `baz` has an incompatible const parameter type for trait
+  --> $DIR/mismatched_ty_const_in_trait_impl.rs:21:12
+   |
+LL |     fn baz<const N: i32>() {}
+   |            ^^^^^^^^^^^^
+   |
+note: the const parameter `N` has type `i32`, but the declaration in trait `Uwu::baz` has type `u32`
+  --> $DIR/mismatched_ty_const_in_trait_impl.rs:18:12
+   |
+LL |     fn baz<const N: u32>() {}
+   |            ^^^^^^^^^^^^
+
+error: aborting due to 5 previous errors
+
+Some errors have detailed explanations: E0049, E0053.
+For more information about an error, try `rustc --explain E0049`.

--- a/src/test/ui/const-generics/defaults/mismatched_ty_const_in_trait_impl.stderr
+++ b/src/test/ui/const-generics/defaults/mismatched_ty_const_in_trait_impl.stderr
@@ -1,4 +1,4 @@
-error[E0053]: method `foo` has an incompatible generic parameter for trait: `Trait`
+error[E0053]: method `foo` has an incompatible generic parameter for trait `Trait`
   --> $DIR/mismatched_ty_const_in_trait_impl.rs:5:12
    |
 LL | trait Trait {
@@ -9,48 +9,48 @@ LL | }
 LL | impl Trait for () {
    | -----------------
 LL |     fn foo<const M: u64>() {}
-   |            ^^^^^^^^^^^^ found const parameter with type `u64`
+   |            ^^^^^^^^^^^^ found const parameter of type `u64`
 
-error[E0053]: method `bar` has an incompatible generic parameter for trait: `Other`
+error[E0053]: method `bar` has an incompatible generic parameter for trait `Other`
   --> $DIR/mismatched_ty_const_in_trait_impl.rs:13:12
    |
 LL | trait Other {
    |       -----
 LL |     fn bar<const M: u8>() {}
-   |            ----------- expected const parameter with type `u8`
+   |            ----------- expected const parameter of type `u8`
 LL | }
 LL | impl Other for () {
    | -----------------
 LL |     fn bar<T>() {}
    |            ^ found type parameter
 
-error[E0053]: method `baz` has an incompatible generic parameter for trait: `Uwu`
+error[E0053]: method `baz` has an incompatible generic parameter for trait `Uwu`
   --> $DIR/mismatched_ty_const_in_trait_impl.rs:21:12
    |
 LL | trait Uwu {
    |       ---
 LL |     fn baz<const N: u32>() {}
-   |            ------------ expected const parameter with type `u32`
+   |            ------------ expected const parameter of type `u32`
 LL | }
 LL | impl Uwu for () {
    | ---------------
 LL |     fn baz<const N: i32>() {}
-   |            ^^^^^^^^^^^^ found const parameter with type `i32`
+   |            ^^^^^^^^^^^^ found const parameter of type `i32`
 
-error[E0053]: method `bbbb` has an incompatible generic parameter for trait: `Aaaaaa`
+error[E0053]: method `bbbb` has an incompatible generic parameter for trait `Aaaaaa`
   --> $DIR/mismatched_ty_const_in_trait_impl.rs:29:13
    |
 LL | trait Aaaaaa {
    |       ------
 LL |     fn bbbb<const N: u32, T>() {}
-   |             ------------ expected const parameter with type `u32`
+   |             ------------ expected const parameter of type `u32`
 LL | }
 LL | impl Aaaaaa for () {
    | ------------------
 LL |     fn bbbb<T, const N: u32>() {}
    |             ^ found type parameter
 
-error[E0053]: method `abcd` has an incompatible generic parameter for trait: `Names`
+error[E0053]: method `abcd` has an incompatible generic parameter for trait `Names`
   --> $DIR/mismatched_ty_const_in_trait_impl.rs:37:13
    |
 LL | trait Names {
@@ -61,7 +61,7 @@ LL | }
 LL | impl Names for () {
    | -----------------
 LL |     fn abcd<const N: u32, T>() {}
-   |             ^^^^^^^^^^^^ found const parameter with type `u32`
+   |             ^^^^^^^^^^^^ found const parameter of type `u32`
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/const-generics/defaults/mismatched_ty_const_in_trait_impl.stderr
+++ b/src/test/ui/const-generics/defaults/mismatched_ty_const_in_trait_impl.stderr
@@ -1,38 +1,26 @@
-error[E0049]: method `foo` has 0 type parameters but its trait declaration has 1 type parameter
+error[E0053]: method `foo` has an incompatible generic parameter for trait
   --> $DIR/mismatched_ty_const_in_trait_impl.rs:5:12
    |
-LL |     fn foo<U>() {}
-   |            - expected 1 type parameter
-...
 LL |     fn foo<const M: u64>() {}
-   |            ^^^^^^^^^^^^ found 0 type parameters
-
-error[E0049]: method `foo` has 1 const parameter but its trait declaration has 0 const parameters
-  --> $DIR/mismatched_ty_const_in_trait_impl.rs:5:12
+   |            ^^^^^^^^^^^^
+   |
+note: the trait impl specifies `M` is a const parameter of type `u64`, but the declaration in trait `Trait::foo` requires it is a type parameter
+  --> $DIR/mismatched_ty_const_in_trait_impl.rs:2:12
    |
 LL |     fn foo<U>() {}
-   |            - expected 0 const parameters
-...
-LL |     fn foo<const M: u64>() {}
-   |            ^^^^^^^^^^^^ found 1 const parameter
+   |            ^
 
-error[E0049]: method `bar` has 1 type parameter but its trait declaration has 0 type parameters
+error[E0053]: method `bar` has an incompatible generic parameter for trait
   --> $DIR/mismatched_ty_const_in_trait_impl.rs:13:12
    |
-LL |     fn bar<const M: u8>() {}
-   |            ----------- expected 0 type parameters
-...
 LL |     fn bar<T>() {}
-   |            ^ found 1 type parameter
-
-error[E0049]: method `bar` has 0 const parameters but its trait declaration has 1 const parameter
-  --> $DIR/mismatched_ty_const_in_trait_impl.rs:13:12
+   |            ^
+   |
+note: the trait impl specifies `T` is a type parameter, but the declaration in trait `Other::bar` requires it is a const parameter of type `u8`
+  --> $DIR/mismatched_ty_const_in_trait_impl.rs:10:12
    |
 LL |     fn bar<const M: u8>() {}
-   |            ----------- expected 1 const parameter
-...
-LL |     fn bar<T>() {}
-   |            ^ found 0 const parameters
+   |            ^^^^^^^^^^^
 
 error[E0053]: method `baz` has an incompatible const parameter type for trait
   --> $DIR/mismatched_ty_const_in_trait_impl.rs:21:12
@@ -46,7 +34,6 @@ note: the const parameter `N` has type `i32`, but the declaration in trait `Uwu:
 LL |     fn baz<const N: u32>() {}
    |            ^^^^^^^^^^^^
 
-error: aborting due to 5 previous errors
+error: aborting due to 3 previous errors
 
-Some errors have detailed explanations: E0049, E0053.
-For more information about an error, try `rustc --explain E0049`.
+For more information about this error, try `rustc --explain E0053`.

--- a/src/test/ui/const-generics/defaults/mismatched_ty_const_in_trait_impl.stderr
+++ b/src/test/ui/const-generics/defaults/mismatched_ty_const_in_trait_impl.stderr
@@ -1,39 +1,68 @@
-error[E0053]: method `foo` has an incompatible generic parameter for trait
+error[E0053]: method `foo` has an incompatible generic parameter for trait: `Trait`
   --> $DIR/mismatched_ty_const_in_trait_impl.rs:5:12
    |
-LL |     fn foo<const M: u64>() {}
-   |            ^^^^^^^^^^^^
-   |
-note: the trait impl specifies `M` is a const parameter of type `u64`, but the declaration in trait `Trait::foo` requires it is a type parameter
-  --> $DIR/mismatched_ty_const_in_trait_impl.rs:2:12
-   |
+LL | trait Trait {
+   |       -----
 LL |     fn foo<U>() {}
-   |            ^
+   |            - expected type parameter
+LL | }
+LL | impl Trait for () {
+   | -----------------
+LL |     fn foo<const M: u64>() {}
+   |            ^^^^^^^^^^^^ found const parameter with type `u64`
 
-error[E0053]: method `bar` has an incompatible generic parameter for trait
+error[E0053]: method `bar` has an incompatible generic parameter for trait: `Other`
   --> $DIR/mismatched_ty_const_in_trait_impl.rs:13:12
    |
-LL |     fn bar<T>() {}
-   |            ^
-   |
-note: the trait impl specifies `T` is a type parameter, but the declaration in trait `Other::bar` requires it is a const parameter of type `u8`
-  --> $DIR/mismatched_ty_const_in_trait_impl.rs:10:12
-   |
+LL | trait Other {
+   |       -----
 LL |     fn bar<const M: u8>() {}
-   |            ^^^^^^^^^^^
+   |            ----------- expected const parameter with type `u8`
+LL | }
+LL | impl Other for () {
+   | -----------------
+LL |     fn bar<T>() {}
+   |            ^ found type parameter
 
-error[E0053]: method `baz` has an incompatible const parameter type for trait
+error[E0053]: method `baz` has an incompatible generic parameter for trait: `Uwu`
   --> $DIR/mismatched_ty_const_in_trait_impl.rs:21:12
    |
-LL |     fn baz<const N: i32>() {}
-   |            ^^^^^^^^^^^^
-   |
-note: the const parameter `N` has type `i32`, but the declaration in trait `Uwu::baz` has type `u32`
-  --> $DIR/mismatched_ty_const_in_trait_impl.rs:18:12
-   |
+LL | trait Uwu {
+   |       ---
 LL |     fn baz<const N: u32>() {}
-   |            ^^^^^^^^^^^^
+   |            ------------ expected const parameter with type `u32`
+LL | }
+LL | impl Uwu for () {
+   | ---------------
+LL |     fn baz<const N: i32>() {}
+   |            ^^^^^^^^^^^^ found const parameter with type `i32`
 
-error: aborting due to 3 previous errors
+error[E0053]: method `bbbb` has an incompatible generic parameter for trait: `Aaaaaa`
+  --> $DIR/mismatched_ty_const_in_trait_impl.rs:29:13
+   |
+LL | trait Aaaaaa {
+   |       ------
+LL |     fn bbbb<const N: u32, T>() {}
+   |             ------------ expected const parameter with type `u32`
+LL | }
+LL | impl Aaaaaa for () {
+   | ------------------
+LL |     fn bbbb<T, const N: u32>() {}
+   |             ^ found type parameter
+
+error[E0053]: method `abcd` has an incompatible generic parameter for trait: `Names`
+  --> $DIR/mismatched_ty_const_in_trait_impl.rs:37:13
+   |
+LL | trait Names {
+   |       -----
+LL |     fn abcd<T, const N: u32>() {}
+   |             - expected type parameter
+LL | }
+LL | impl Names for () {
+   | -----------------
+LL |     fn abcd<const N: u32, T>() {}
+   |             ^^^^^^^^^^^^ found const parameter with type `u32`
+
+error: aborting due to 5 previous errors
 
 For more information about this error, try `rustc --explain E0053`.

--- a/src/test/ui/const-generics/issues/issue-86820.rs
+++ b/src/test/ui/const-generics/issues/issue-86820.rs
@@ -1,6 +1,6 @@
 // Regression test for the ICE described in #86820.
 
-#![allow(unused,dead_code)]
+#![allow(unused, dead_code)]
 use std::ops::BitAnd;
 
 const C: fn() = || is_set();
@@ -9,13 +9,12 @@ fn is_set() {
 }
 
 trait Bits {
-    fn bit<const I : u8>(self) -> bool;
-    //~^ NOTE: the const parameter `I` has type `usize`, but the declaration in trait `Bits::bit` has type `u8`
+    fn bit<const I: u8>(self) -> bool;
 }
 
 impl Bits for u8 {
-    fn bit<const I : usize>(self) -> bool {
-    //~^ ERROR: method `bit` has an incompatible const parameter type for trait [E0053]
+    fn bit<const I: usize>(self) -> bool {
+        //~^ ERROR: method `bit` has an incompatible generic parameter for trait: `Bits` [E0053]
         let i = 1 << I;
         let mask = u8::from(i);
         mask & self == mask

--- a/src/test/ui/const-generics/issues/issue-86820.rs
+++ b/src/test/ui/const-generics/issues/issue-86820.rs
@@ -14,7 +14,7 @@ trait Bits {
 
 impl Bits for u8 {
     fn bit<const I: usize>(self) -> bool {
-        //~^ ERROR: method `bit` has an incompatible generic parameter for trait: `Bits` [E0053]
+        //~^ ERROR: method `bit` has an incompatible generic parameter for trait `Bits` [E0053]
         let i = 1 << I;
         let mask = u8::from(i);
         mask & self == mask

--- a/src/test/ui/const-generics/issues/issue-86820.stderr
+++ b/src/test/ui/const-generics/issues/issue-86820.stderr
@@ -1,14 +1,15 @@
-error[E0053]: method `bit` has an incompatible const parameter type for trait
-  --> $DIR/issue-86820.rs:17:12
+error[E0053]: method `bit` has an incompatible generic parameter for trait: `Bits`
+  --> $DIR/issue-86820.rs:16:12
    |
-LL |     fn bit<const I : usize>(self) -> bool {
-   |            ^^^^^^^^^^^^^^^
-   |
-note: the const parameter `I` has type `usize`, but the declaration in trait `Bits::bit` has type `u8`
-  --> $DIR/issue-86820.rs:12:12
-   |
-LL |     fn bit<const I : u8>(self) -> bool;
-   |            ^^^^^^^^^^^^
+LL | trait Bits {
+   |       ----
+LL |     fn bit<const I: u8>(self) -> bool;
+   |            ----------- expected const parameter with type `u8`
+...
+LL | impl Bits for u8 {
+   | ----------------
+LL |     fn bit<const I: usize>(self) -> bool {
+   |            ^^^^^^^^^^^^^^ found const parameter with type `usize`
 
 error: aborting due to previous error
 

--- a/src/test/ui/const-generics/issues/issue-86820.stderr
+++ b/src/test/ui/const-generics/issues/issue-86820.stderr
@@ -1,15 +1,15 @@
-error[E0053]: method `bit` has an incompatible generic parameter for trait: `Bits`
+error[E0053]: method `bit` has an incompatible generic parameter for trait `Bits`
   --> $DIR/issue-86820.rs:16:12
    |
 LL | trait Bits {
    |       ----
 LL |     fn bit<const I: u8>(self) -> bool;
-   |            ----------- expected const parameter with type `u8`
+   |            ----------- expected const parameter of type `u8`
 ...
 LL | impl Bits for u8 {
    | ----------------
 LL |     fn bit<const I: usize>(self) -> bool {
-   |            ^^^^^^^^^^^^^^ found const parameter with type `usize`
+   |            ^^^^^^^^^^^^^^ found const parameter of type `usize`
 
 error: aborting due to previous error
 

--- a/src/test/ui/generic-associated-types/const_params_have_right_type.rs
+++ b/src/test/ui/generic-associated-types/const_params_have_right_type.rs
@@ -6,7 +6,7 @@ trait Trait {
 
 impl Trait for () {
     type Foo<const N: u64> = u32;
-    //~^ error: type `Foo` has an incompatible const parameter type
+    //~^ error: type `Foo` has an incompatible generic parameter for trait
 }
 
 fn main() {}

--- a/src/test/ui/generic-associated-types/const_params_have_right_type.rs
+++ b/src/test/ui/generic-associated-types/const_params_have_right_type.rs
@@ -1,0 +1,12 @@
+#![feature(generic_associated_types)]
+
+trait Trait {
+    type Foo<const N: u8>;
+}
+
+impl Trait for () {
+    type Foo<const N: u64> = u32;
+    //~^ error: associated type `Foo` has an incompatible const parameter type
+}
+
+fn main() {}

--- a/src/test/ui/generic-associated-types/const_params_have_right_type.rs
+++ b/src/test/ui/generic-associated-types/const_params_have_right_type.rs
@@ -6,7 +6,7 @@ trait Trait {
 
 impl Trait for () {
     type Foo<const N: u64> = u32;
-    //~^ error: associated type `Foo` has an incompatible const parameter type
+    //~^ error: type `Foo` has an incompatible const parameter type
 }
 
 fn main() {}

--- a/src/test/ui/generic-associated-types/const_params_have_right_type.stderr
+++ b/src/test/ui/generic-associated-types/const_params_have_right_type.stderr
@@ -1,15 +1,15 @@
-error[E0053]: type `Foo` has an incompatible generic parameter for trait: `Trait`
+error[E0053]: type `Foo` has an incompatible generic parameter for trait `Trait`
   --> $DIR/const_params_have_right_type.rs:8:14
    |
 LL | trait Trait {
    |       -----
 LL |     type Foo<const N: u8>;
-   |              ----------- expected const parameter with type `u8`
+   |              ----------- expected const parameter of type `u8`
 ...
 LL | impl Trait for () {
    | -----------------
 LL |     type Foo<const N: u64> = u32;
-   |              ^^^^^^^^^^^^ found const parameter with type `u64`
+   |              ^^^^^^^^^^^^ found const parameter of type `u64`
 
 error: aborting due to previous error
 

--- a/src/test/ui/generic-associated-types/const_params_have_right_type.stderr
+++ b/src/test/ui/generic-associated-types/const_params_have_right_type.stderr
@@ -1,0 +1,15 @@
+error[E0053]: associated type `Foo` has an incompatible const parameter type for trait
+  --> $DIR/const_params_have_right_type.rs:8:14
+   |
+LL |     type Foo<const N: u64> = u32;
+   |              ^^^^^^^^^^^^
+   |
+note: the const parameter `N` has type `u64`, but the declaration in trait `Trait::Foo` has type `u8`
+  --> $DIR/const_params_have_right_type.rs:4:14
+   |
+LL |     type Foo<const N: u8>;
+   |              ^^^^^^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0053`.

--- a/src/test/ui/generic-associated-types/const_params_have_right_type.stderr
+++ b/src/test/ui/generic-associated-types/const_params_have_right_type.stderr
@@ -1,14 +1,15 @@
-error[E0053]: type `Foo` has an incompatible const parameter type for trait
+error[E0053]: type `Foo` has an incompatible generic parameter for trait: `Trait`
   --> $DIR/const_params_have_right_type.rs:8:14
    |
-LL |     type Foo<const N: u64> = u32;
-   |              ^^^^^^^^^^^^
-   |
-note: the const parameter `N` has type `u64`, but the declaration in trait `Trait::Foo` has type `u8`
-  --> $DIR/const_params_have_right_type.rs:4:14
-   |
+LL | trait Trait {
+   |       -----
 LL |     type Foo<const N: u8>;
-   |              ^^^^^^^^^^^
+   |              ----------- expected const parameter with type `u8`
+...
+LL | impl Trait for () {
+   | -----------------
+LL |     type Foo<const N: u64> = u32;
+   |              ^^^^^^^^^^^^ found const parameter with type `u64`
 
 error: aborting due to previous error
 

--- a/src/test/ui/generic-associated-types/const_params_have_right_type.stderr
+++ b/src/test/ui/generic-associated-types/const_params_have_right_type.stderr
@@ -1,4 +1,4 @@
-error[E0053]: associated type `Foo` has an incompatible const parameter type for trait
+error[E0053]: type `Foo` has an incompatible const parameter type for trait
   --> $DIR/const_params_have_right_type.rs:8:14
    |
 LL |     type Foo<const N: u64> = u32;


### PR DESCRIPTION
- Check that generic params on a generic associated type are the same as in the trait definition
- Check that const generics are not used in place of type generics (and the other way round too)

r? @lcnr 