### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4244,6 +4244,7 @@ dependencies = [
  "rustc_serialize",
  "rustc_session",
  "rustc_span",
+ "tracing",
 ]
 
 [[package]]

--- a/compiler/rustc_ast_pretty/src/lib.rs
+++ b/compiler/rustc_ast_pretty/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(bool_to_option)]
 #![feature(crate_visibility_modifier)]
 #![feature(box_patterns)]
 #![recursion_limit = "256"]

--- a/compiler/rustc_borrowck/src/lib.rs
+++ b/compiler/rustc_borrowck/src/lib.rs
@@ -1,7 +1,6 @@
 //! This query borrow-checks the MIR to (further) ensure it is not broken.
 
 #![allow(rustc::potential_query_instability)]
-#![feature(bool_to_option)]
 #![feature(box_patterns)]
 #![feature(crate_visibility_modifier)]
 #![feature(let_chains)]

--- a/compiler/rustc_builtin_macros/src/lib.rs
+++ b/compiler/rustc_builtin_macros/src/lib.rs
@@ -4,7 +4,6 @@
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
 #![feature(array_windows)]
 #![feature(box_patterns)]
-#![feature(bool_to_option)]
 #![feature(crate_visibility_modifier)]
 #![feature(decl_macro)]
 #![feature(is_sorted)]

--- a/compiler/rustc_codegen_llvm/src/lib.rs
+++ b/compiler/rustc_codegen_llvm/src/lib.rs
@@ -5,7 +5,6 @@
 //! This API is completely unstable and subject to change.
 
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
-#![feature(bool_to_option)]
 #![feature(crate_visibility_modifier)]
 #![feature(let_chains)]
 #![feature(let_else)]

--- a/compiler/rustc_codegen_ssa/src/lib.rs
+++ b/compiler/rustc_codegen_ssa/src/lib.rs
@@ -1,5 +1,4 @@
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
-#![feature(bool_to_option)]
 #![feature(box_patterns)]
 #![feature(try_blocks)]
 #![feature(let_else)]

--- a/compiler/rustc_const_eval/src/lib.rs
+++ b/compiler/rustc_const_eval/src/lib.rs
@@ -5,7 +5,6 @@ Rust MIR: a lowered representation of Rust.
 */
 
 #![feature(assert_matches)]
-#![feature(bool_to_option)]
 #![feature(box_patterns)]
 #![feature(control_flow_enum)]
 #![feature(crate_visibility_modifier)]

--- a/compiler/rustc_data_structures/src/lib.rs
+++ b/compiler/rustc_data_structures/src/lib.rs
@@ -10,7 +10,6 @@
 #![feature(array_windows)]
 #![feature(associated_type_bounds)]
 #![feature(auto_traits)]
-#![feature(bool_to_option)]
 #![feature(control_flow_enum)]
 #![feature(core_intrinsics)]
 #![feature(extend_one)]

--- a/compiler/rustc_infer/src/lib.rs
+++ b/compiler/rustc_infer/src/lib.rs
@@ -14,7 +14,6 @@
 
 #![allow(rustc::potential_query_instability)]
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
-#![feature(bool_to_option)]
 #![feature(box_patterns)]
 #![feature(control_flow_enum)]
 #![cfg_attr(bootstrap, feature(derive_default_enum))]

--- a/compiler/rustc_interface/src/lib.rs
+++ b/compiler/rustc_interface/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(bool_to_option)]
 #![feature(box_patterns)]
 #![feature(let_else)]
 #![feature(internal_output_capture)]

--- a/compiler/rustc_lint/src/lib.rs
+++ b/compiler/rustc_lint/src/lib.rs
@@ -28,7 +28,6 @@
 #![allow(rustc::potential_query_instability)]
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
 #![feature(array_windows)]
-#![feature(bool_to_option)]
 #![feature(box_patterns)]
 #![feature(control_flow_enum)]
 #![feature(crate_visibility_modifier)]

--- a/compiler/rustc_middle/src/lib.rs
+++ b/compiler/rustc_middle/src/lib.rs
@@ -27,7 +27,6 @@
 #![feature(array_windows)]
 #![feature(assert_matches)]
 #![feature(backtrace)]
-#![feature(bool_to_option)]
 #![feature(box_patterns)]
 #![feature(core_intrinsics)]
 #![cfg_attr(bootstrap, feature(derive_default_enum))]

--- a/compiler/rustc_mir_build/src/lib.rs
+++ b/compiler/rustc_mir_build/src/lib.rs
@@ -2,7 +2,6 @@
 //!
 //! This crate also contains the match exhaustiveness and usefulness checking.
 #![allow(rustc::potential_query_instability)]
-#![feature(bool_to_option)]
 #![feature(box_patterns)]
 #![feature(control_flow_enum)]
 #![feature(crate_visibility_modifier)]

--- a/compiler/rustc_mir_dataflow/src/lib.rs
+++ b/compiler/rustc_mir_dataflow/src/lib.rs
@@ -1,5 +1,4 @@
 #![feature(associated_type_defaults)]
-#![feature(bool_to_option)]
 #![feature(box_patterns)]
 #![feature(box_syntax)]
 #![feature(exact_size_is_empty)]

--- a/compiler/rustc_monomorphize/src/lib.rs
+++ b/compiler/rustc_monomorphize/src/lib.rs
@@ -1,5 +1,4 @@
 #![feature(array_windows)]
-#![feature(bool_to_option)]
 #![feature(crate_visibility_modifier)]
 #![feature(control_flow_enum)]
 #![feature(let_else)]

--- a/compiler/rustc_query_impl/Cargo.toml
+++ b/compiler/rustc_query_impl/Cargo.toml
@@ -20,6 +20,7 @@ rustc_query_system = { path = "../rustc_query_system" }
 rustc_serialize = { path = "../rustc_serialize" }
 rustc_session = { path = "../rustc_session" }
 rustc_span = { path = "../rustc_span" }
+tracing = "0.1"
 
 [features]
 rustc_use_parallel_compiler = ["rustc-rayon-core", "rustc_query_system/rustc_use_parallel_compiler"]

--- a/compiler/rustc_query_impl/src/plumbing.rs
+++ b/compiler/rustc_query_impl/src/plumbing.rs
@@ -435,6 +435,8 @@ macro_rules! define_queries {
 
                 fn force_from_dep_node(tcx: TyCtxt<'_>, dep_node: DepNode) -> bool {
                     if let Some(key) = recover(tcx, dep_node) {
+                        #[cfg(debug_assertions)]
+                        let _guard = tracing::span!(tracing::Level::TRACE, stringify!($name), ?key).entered();
                         let tcx = QueryCtxt::from_tcx(tcx);
                         force_query::<queries::$name<'_>, _>(tcx, key, dep_node);
                         true
@@ -532,6 +534,7 @@ macro_rules! define_queries_struct {
 
             $($(#[$attr])*
             #[inline(always)]
+            #[tracing::instrument(level = "trace", skip(self, tcx))]
             fn $name(
                 &'tcx self,
                 tcx: TyCtxt<$tcx>,

--- a/compiler/rustc_query_system/src/lib.rs
+++ b/compiler/rustc_query_system/src/lib.rs
@@ -1,5 +1,4 @@
 #![feature(assert_matches)]
-#![feature(bool_to_option)]
 #![feature(core_intrinsics)]
 #![feature(hash_raw_entry)]
 #![feature(let_else)]

--- a/compiler/rustc_query_system/src/query/plumbing.rs
+++ b/compiler/rustc_query_system/src/query/plumbing.rs
@@ -675,6 +675,7 @@ where
     }
 }
 
+#[derive(Debug)]
 pub enum QueryMode {
     Get,
     Ensure,
@@ -697,7 +698,6 @@ where
         None
     };
 
-    debug!("ty::query::get_query<{}>(key={:?}, span={:?})", Q::NAME, key, span);
     let (result, dep_node_index) = try_execute_query(
         tcx,
         Q::query_state(tcx),

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -9,7 +9,6 @@
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
 #![feature(box_patterns)]
 #![feature(drain_filter)]
-#![feature(bool_to_option)]
 #![feature(crate_visibility_modifier)]
 #![feature(if_let_guard)]
 #![feature(let_chains)]

--- a/compiler/rustc_span/src/lib.rs
+++ b/compiler/rustc_span/src/lib.rs
@@ -15,7 +15,6 @@
 
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
 #![feature(array_windows)]
-#![feature(bool_to_option)]
 #![feature(crate_visibility_modifier)]
 #![feature(let_else)]
 #![feature(if_let_guard)]

--- a/compiler/rustc_target/src/lib.rs
+++ b/compiler/rustc_target/src/lib.rs
@@ -9,7 +9,6 @@
 
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
 #![feature(associated_type_bounds)]
-#![feature(bool_to_option)]
 #![feature(exhaustive_patterns)]
 #![feature(let_else)]
 #![feature(min_specialization)]

--- a/compiler/rustc_trait_selection/src/lib.rs
+++ b/compiler/rustc_trait_selection/src/lib.rs
@@ -12,7 +12,6 @@
 
 #![allow(rustc::potential_query_instability)]
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
-#![feature(bool_to_option)]
 #![feature(box_patterns)]
 #![feature(control_flow_enum)]
 #![feature(crate_visibility_modifier)]

--- a/compiler/rustc_typeck/src/lib.rs
+++ b/compiler/rustc_typeck/src/lib.rs
@@ -57,7 +57,6 @@ This API is completely unstable and subject to change.
 
 #![allow(rustc::potential_query_instability)]
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
-#![feature(bool_to_option)]
 #![feature(box_patterns)]
 #![feature(control_flow_enum)]
 #![feature(crate_visibility_modifier)]

--- a/library/core/src/bool.rs
+++ b/library/core/src/bool.rs
@@ -9,12 +9,10 @@ impl bool {
     /// # Examples
     ///
     /// ```
-    /// #![feature(bool_to_option)]
-    ///
     /// assert_eq!(false.then_some(0), None);
     /// assert_eq!(true.then_some(0), Some(0));
     /// ```
-    #[unstable(feature = "bool_to_option", issue = "80967")]
+    #[stable(feature = "bool_to_option", since = "1.62.0")]
     #[rustc_const_unstable(feature = "const_bool_to_option", issue = "91917")]
     #[inline]
     pub const fn then_some<T>(self, t: T) -> Option<T>

--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -3,7 +3,6 @@
 #![feature(array_methods)]
 #![feature(array_windows)]
 #![feature(bench_black_box)]
-#![feature(bool_to_option)]
 #![feature(box_syntax)]
 #![feature(cell_update)]
 #![feature(const_assume)]

--- a/library/std/src/sys_common/condvar/check.rs
+++ b/library/std/src/sys_common/condvar/check.rs
@@ -24,7 +24,7 @@ impl SameMutexCheck {
     }
     pub fn verify(&self, mutex: &MovableMutex) {
         let addr = mutex.raw() as *const imp::Mutex as *const () as *mut _;
-        match self.addr.compare_exchange(ptr::null_mut(), addr, Ordering::SeqCst, Ordering::SeqCst)
+        match self.addr.compare_exchange(ptr::null_mut(), addr, Ordering::Relaxed, Ordering::Relaxed)
         {
             Ok(_) => {}               // Stored the address
             Err(n) if n == addr => {} // Lost a race to store the same address

--- a/library/std/src/sys_common/condvar/check.rs
+++ b/library/std/src/sys_common/condvar/check.rs
@@ -24,8 +24,12 @@ impl SameMutexCheck {
     }
     pub fn verify(&self, mutex: &MovableMutex) {
         let addr = mutex.raw() as *const imp::Mutex as *const () as *mut _;
-        match self.addr.compare_exchange(ptr::null_mut(), addr, Ordering::Relaxed, Ordering::Relaxed)
-        {
+        match self.addr.compare_exchange(
+            ptr::null_mut(),
+            addr,
+            Ordering::Relaxed,
+            Ordering::Relaxed,
+        ) {
             Ok(_) => {}               // Stored the address
             Err(n) if n == addr => {} // Lost a race to store the same address
             _ => panic!("attempted to use a condition variable with two mutexes"),

--- a/library/std/src/sys_common/condvar/check.rs
+++ b/library/std/src/sys_common/condvar/check.rs
@@ -24,6 +24,8 @@ impl SameMutexCheck {
     }
     pub fn verify(&self, mutex: &MovableMutex) {
         let addr = mutex.raw() as *const imp::Mutex as *const () as *mut _;
+        // Relaxed is okay here because we never read through `self.addr`, and only use it to
+        // compare addresses.
         match self.addr.compare_exchange(
             ptr::null_mut(),
             addr,

--- a/library/std/src/sys_common/thread.rs
+++ b/library/std/src/sys_common/thread.rs
@@ -4,7 +4,7 @@ use crate::sys::thread as imp;
 
 pub fn min_stack() -> usize {
     static MIN: atomic::AtomicUsize = atomic::AtomicUsize::new(0);
-    match MIN.load(Ordering::SeqCst) {
+    match MIN.load(Ordering::Relaxed) {
         0 => {}
         n => return n - 1,
     }
@@ -13,6 +13,6 @@ pub fn min_stack() -> usize {
 
     // 0 is our sentinel value, so ensure that we'll never see 0 after
     // initialization has run
-    MIN.store(amt + 1, Ordering::SeqCst);
+    MIN.store(amt + 1, Ordering::Relaxed);
     amt
 }

--- a/src/librustdoc/html/static/js/main.js
+++ b/src/librustdoc/html/static/js/main.js
@@ -1,6 +1,7 @@
 /* eslint-env es6 */
 /* eslint no-var: "error" */
 /* eslint prefer-const: "error" */
+/* eslint prefer-arrow-callback: "error" */
 // Local js definitions:
 /* global addClass, getSettingValue, hasClass, searchState */
 /* global onEach, onEachLazy, removeClass */
@@ -152,7 +153,7 @@ function hideThemeButtonState() {
     themePicker.style.borderBottomLeftRadius = "3px";
 }
 
-window.hideSettings = function() {
+window.hideSettings = () => {
     // Does nothing by default.
 };
 
@@ -190,10 +191,10 @@ window.hideSettings = function() {
 
     themePicker.onclick = switchThemeButtonState;
     themePicker.onblur = handleThemeButtonsBlur;
-    availableThemes.forEach(function(item) {
+    availableThemes.forEach(item => {
         const but = document.createElement("button");
         but.textContent = item;
-        but.onclick = function() {
+        but.onclick = () => {
             switchTheme(window.currentTheme, window.mainTheme, item, true);
             useSystemTheme(false);
         };
@@ -300,7 +301,7 @@ function loadCss(cssFileName) {
     }
 
 
-    getSettingsButton().onclick = function(event) {
+    getSettingsButton().onclick = event => {
         event.preventDefault();
         loadScript(window.settingsJS);
     };
@@ -308,7 +309,7 @@ function loadCss(cssFileName) {
     window.searchState = {
         loadingText: "Loading search results...",
         input: document.getElementsByClassName("search-input")[0],
-        outputElement: function() {
+        outputElement: () => {
             let el = document.getElementById("search");
             if (!el) {
                 el = document.createElement("section");
@@ -328,24 +329,22 @@ function loadCss(cssFileName) {
         currentTab: 0,
         // tab and back preserves the element that was focused.
         focusedByTab: [null, null, null],
-        clearInputTimeout: function() {
+        clearInputTimeout: () => {
             if (searchState.timeout !== null) {
                 clearTimeout(searchState.timeout);
                 searchState.timeout = null;
             }
         },
-        isDisplayed: function() {
-            return searchState.outputElement().parentElement.id === ALTERNATIVE_DISPLAY_ID;
-        },
+        isDisplayed: () => searchState.outputElement().parentElement.id === ALTERNATIVE_DISPLAY_ID,
         // Sets the focus on the search bar at the top of the page
-        focus: function() {
+        focus: () => {
             searchState.input.focus();
         },
         // Removes the focus from the search bar.
-        defocus: function() {
+        defocus: () => {
             searchState.input.blur();
         },
-        showResults: function(search) {
+        showResults: search => {
             if (search === null || typeof search === 'undefined') {
                 search = searchState.outputElement();
             }
@@ -353,7 +352,7 @@ function loadCss(cssFileName) {
             searchState.mouseMovedAfterSearch = false;
             document.title = searchState.title;
         },
-        hideResults: function() {
+        hideResults: () => {
             switchDisplayedElement(null);
             document.title = searchState.titleBeforeSearch;
             // We also remove the query parameter from the URL.
@@ -362,17 +361,17 @@ function loadCss(cssFileName) {
                     getNakedUrl() + window.location.hash);
             }
         },
-        getQueryStringParams: function() {
+        getQueryStringParams: () => {
             const params = {};
             window.location.search.substring(1).split("&").
-                map(function(s) {
+                map(s => {
                     const pair = s.split("=");
                     params[decodeURIComponent(pair[0])] =
                         typeof pair[1] === "undefined" ? null : decodeURIComponent(pair[1]);
                 });
             return params;
         },
-        setup: function() {
+        setup: () => {
             const search_input = searchState.input;
             if (!searchState.input) {
                 return;
@@ -386,13 +385,13 @@ function loadCss(cssFileName) {
                 }
             }
 
-            search_input.addEventListener("focus", function() {
+            search_input.addEventListener("focus", () => {
                 search_input.origPlaceholder = search_input.placeholder;
                 search_input.placeholder = "Type your search here.";
                 loadSearch();
             });
 
-            if (search_input.value != '') {
+            if (search_input.value !== '') {
                 loadSearch();
             }
 
@@ -620,7 +619,7 @@ function loadCss(cssFileName) {
     document.addEventListener("keydown", handleShortcut);
 
     // delayed sidebar rendering.
-    window.initSidebarItems = function(items) {
+    window.initSidebarItems = items => {
         const sidebar = document.getElementsByClassName("sidebar-elems")[0];
         let others;
         const current = window.sidebarCurrent;
@@ -731,7 +730,7 @@ function loadCss(cssFileName) {
         }
     };
 
-    window.register_implementors = function(imp) {
+    window.register_implementors = imp => {
         const implementors = document.getElementById("implementors-list");
         const synthetic_implementors = document.getElementById("synthetic-implementors-list");
         const inlined_types = new Set();
@@ -742,12 +741,12 @@ function loadCss(cssFileName) {
             //
             // By the way, this is only used by and useful for traits implemented automatically
             // (like "Send" and "Sync").
-            onEachLazy(synthetic_implementors.getElementsByClassName("impl"), function(el) {
+            onEachLazy(synthetic_implementors.getElementsByClassName("impl"), el => {
                 const aliases = el.getAttribute("data-aliases");
                 if (!aliases) {
                     return;
                 }
-                aliases.split(",").forEach(function(alias) {
+                aliases.split(",").forEach(alias => {
                     inlined_types.add(alias);
                 });
             });
@@ -781,7 +780,7 @@ function loadCss(cssFileName) {
                 addClass(code, "code-header");
                 addClass(code, "in-band");
 
-                onEachLazy(code.getElementsByTagName("a"), function(elem) {
+                onEachLazy(code.getElementsByTagName("a"), elem => {
                     const href = elem.getAttribute("href");
 
                     if (href && href.indexOf("http") !== 0) {
@@ -826,7 +825,7 @@ function loadCss(cssFileName) {
         let sectionIsCollapsed = false;
         if (hasClass(innerToggle, "will-expand")) {
             removeClass(innerToggle, "will-expand");
-            onEachLazy(document.getElementsByClassName("rustdoc-toggle"), function(e) {
+            onEachLazy(document.getElementsByClassName("rustdoc-toggle"), e => {
                 if (!hasClass(e, "type-contents-toggle")) {
                     e.open = true;
                 }
@@ -834,7 +833,7 @@ function loadCss(cssFileName) {
             innerToggle.title = "collapse all docs";
         } else {
             addClass(innerToggle, "will-expand");
-            onEachLazy(document.getElementsByClassName("rustdoc-toggle"), function(e) {
+            onEachLazy(document.getElementsByClassName("rustdoc-toggle"), e => {
                 if (e.parentNode.id !== "implementations-list" ||
                     (!hasClass(e, "implementors-toggle") &&
                      !hasClass(e, "type-contents-toggle")))
@@ -861,7 +860,7 @@ function loadCss(cssFileName) {
         function setImplementorsTogglesOpen(id, open) {
             const list = document.getElementById(id);
             if (list !== null) {
-                onEachLazy(list.getElementsByClassName("implementors-toggle"), function(e) {
+                onEachLazy(list.getElementsByClassName("implementors-toggle"), e => {
                     e.open = open;
                 });
             }
@@ -872,7 +871,7 @@ function loadCss(cssFileName) {
             setImplementorsTogglesOpen("blanket-implementations-list", false);
         }
 
-        onEachLazy(document.getElementsByClassName("rustdoc-toggle"), function (e) {
+        onEachLazy(document.getElementsByClassName("rustdoc-toggle"), e => {
             if (!hideLargeItemContents && hasClass(e, "type-contents-toggle")) {
                 e.open = true;
             }
@@ -890,9 +889,9 @@ function loadCss(cssFileName) {
 
     (function() {
         // To avoid checking on "rustdoc-line-numbers" value on every loop...
-        let lineNumbersFunc = function() {};
+        let lineNumbersFunc = () => {};
         if (getSettingValue("line-numbers") === "true") {
-            lineNumbersFunc = function(x) {
+            lineNumbersFunc = x => {
                 const count = x.textContent.split("\n").length;
                 const elems = [];
                 for (let i = 0; i < count; ++i) {
@@ -904,7 +903,7 @@ function loadCss(cssFileName) {
                 x.parentNode.insertBefore(node, x);
             };
         }
-        onEachLazy(document.getElementsByClassName("rust-example-rendered"), function(e) {
+        onEachLazy(document.getElementsByClassName("rust-example-rendered"), e => {
             if (hasClass(e, "compile_fail")) {
                 e.addEventListener("mouseover", function() {
                     this.parentElement.previousElementSibling.childNodes[0].style.color = "#f00";
@@ -935,34 +934,34 @@ function loadCss(cssFileName) {
             elem.addEventListener("click", f);
         }
     }
-    handleClick("help-button", function(ev) {
+    handleClick("help-button", ev => {
         displayHelp(true, ev);
     });
-    handleClick(MAIN_ID, function() {
+    handleClick(MAIN_ID, () => {
         hideSidebar();
     });
 
-    onEachLazy(document.getElementsByTagName("a"), function(el) {
+    onEachLazy(document.getElementsByTagName("a"), el => {
         // For clicks on internal links (<A> tags with a hash property), we expand the section we're
         // jumping to *before* jumping there. We can't do this in onHashChange, because it changes
         // the height of the document so we wind up scrolled to the wrong place.
         if (el.hash) {
-            el.addEventListener("click", function() {
+            el.addEventListener("click", () => {
                 expandSection(el.hash.slice(1));
                 hideSidebar();
             });
         }
     });
 
-    onEachLazy(document.querySelectorAll(".rustdoc-toggle > summary:not(.hideme)"), function(el) {
-        el.addEventListener("click", function(e) {
-            if (e.target.tagName != "SUMMARY" && e.target.tagName != "A") {
+    onEachLazy(document.querySelectorAll(".rustdoc-toggle > summary:not(.hideme)"), el => {
+        el.addEventListener("click", e => {
+            if (e.target.tagName !== "SUMMARY" && e.target.tagName !== "A") {
                 e.preventDefault();
             }
         });
     });
 
-    onEachLazy(document.getElementsByClassName("notable-traits"), function(e) {
+    onEachLazy(document.getElementsByClassName("notable-traits"), e => {
         e.onclick = function() {
             this.getElementsByClassName('notable-traits-tooltiptext')[0]
                 .classList.toggle("force-tooltip");
@@ -971,7 +970,7 @@ function loadCss(cssFileName) {
 
     const sidebar_menu_toggle = document.getElementsByClassName("sidebar-menu-toggle")[0];
     if (sidebar_menu_toggle) {
-        sidebar_menu_toggle.addEventListener("click", function() {
+        sidebar_menu_toggle.addEventListener("click", () => {
             const sidebar = document.getElementsByClassName("sidebar")[0];
             if (!hasClass(sidebar, "shown")) {
                 addClass(sidebar, "shown");
@@ -981,12 +980,12 @@ function loadCss(cssFileName) {
         });
     }
 
-    let buildHelperPopup = function() {
+    let buildHelperPopup = () => {
         const popup = document.createElement("aside");
         addClass(popup, "hidden");
         popup.id = "help";
 
-        popup.addEventListener("click", function(ev) {
+        popup.addEventListener("click", ev => {
             if (ev.target === popup) {
                 // Clicked the blurred zone outside the help popup; dismiss help.
                 displayHelp(false, ev);
@@ -1009,14 +1008,10 @@ function loadCss(cssFileName) {
             ["&#9166;", "Go to active search result"],
             ["+", "Expand all sections"],
             ["-", "Collapse all sections"],
-        ].map(function(x) {
-            return "<dt>" +
-                x[0].split(" ")
-                    .map(function(y, index) {
-                        return (index & 1) === 0 ? "<kbd>" + y + "</kbd>" : " " + y + " ";
-                    })
-                    .join("") + "</dt><dd>" + x[1] + "</dd>";
-        }).join("");
+        ].map(x => "<dt>" +
+            x[0].split(" ")
+                .map((y, index) => (index & 1) === 0 ? "<kbd>" + y + "</kbd>" : " " + y + " ")
+                .join("") + "</dt><dd>" + x[1] + "</dd>").join("");
         const div_shortcuts = document.createElement("div");
         addClass(div_shortcuts, "shortcuts");
         div_shortcuts.innerHTML = "<h2>Keyboard Shortcuts</h2><dl>" + shortcuts + "</dl></div>";
@@ -1034,9 +1029,7 @@ function loadCss(cssFileName) {
             "You can look for items with an exact name by putting double quotes around \
              your request: <code>\"string\"</code>",
             "Look for items inside another one by searching for a path: <code>vec::Vec</code>",
-        ].map(function(x) {
-            return "<p>" + x + "</p>";
-        }).join("");
+        ].map(x => "<p>" + x + "</p>").join("");
         const div_infos = document.createElement("div");
         addClass(div_infos, "infos");
         div_infos.innerHTML = "<h2>Search Tricks</h2>" + infos;
@@ -1056,7 +1049,7 @@ function loadCss(cssFileName) {
         popup.appendChild(container);
         insertAfter(popup, document.querySelector("main"));
         // So that it's only built once and then it'll do nothing when called!
-        buildHelperPopup = function() {};
+        buildHelperPopup = () => {};
     };
 
     onHashChange(null);
@@ -1067,11 +1060,11 @@ function loadCss(cssFileName) {
 (function () {
     let reset_button_timeout = null;
 
-    window.copy_path = function(but) {
+    window.copy_path = but => {
         const parent = but.parentElement;
         const path = [];
 
-        onEach(parent.childNodes, function(child) {
+        onEach(parent.childNodes, child => {
             if (child.tagName === 'A') {
                 path.push(child.textContent);
             }
@@ -1097,7 +1090,7 @@ function loadCss(cssFileName) {
             tmp = document.createTextNode('✓');
             but.appendChild(tmp);
         } else {
-            onEachLazy(but.childNodes, function(e) {
+            onEachLazy(but.childNodes, e => {
                 if (e.nodeType === Node.TEXT_NODE) {
                     tmp = e;
                     return true;

--- a/src/librustdoc/html/static/js/scrape-examples.js
+++ b/src/librustdoc/html/static/js/scrape-examples.js
@@ -1,6 +1,7 @@
 /* eslint-env es6 */
 /* eslint no-var: "error" */
 /* eslint prefer-const: "error" */
+/* eslint prefer-arrow-callback: "error" */
 /* global addClass, hasClass, removeClass, onEachLazy */
 
 (function () {
@@ -38,7 +39,7 @@
 
         if (locs.length > 1) {
             // Toggle through list of examples in a given file
-            const onChangeLoc = function(changeIndex) {
+            const onChangeLoc = changeIndex => {
                 removeClass(highlights[locIndex], 'focus');
                 changeIndex();
                 scrollToLoc(example, locs[locIndex][0]);
@@ -52,15 +53,15 @@
             };
 
             example.querySelector('.prev')
-                .addEventListener('click', function() {
-                    onChangeLoc(function() {
+                .addEventListener('click', () => {
+                    onChangeLoc(() => {
                         locIndex = (locIndex - 1 + locs.length) % locs.length;
                     });
                 });
 
             example.querySelector('.next')
-                .addEventListener('click', function() {
-                    onChangeLoc(function() {
+                .addEventListener('click', () => {
+                    onChangeLoc(() => {
                         locIndex = (locIndex + 1) % locs.length;
                     });
                 });
@@ -68,7 +69,7 @@
 
         const expandButton = example.querySelector('.expand');
         if (expandButton) {
-            expandButton.addEventListener('click', function () {
+            expandButton.addEventListener('click', () => {
                 if (hasClass(example, "expanded")) {
                     removeClass(example, "expanded");
                     scrollToLoc(example, locs[0][0]);
@@ -84,22 +85,22 @@
 
     const firstExamples = document.querySelectorAll('.scraped-example-list > .scraped-example');
     onEachLazy(firstExamples, updateScrapedExample);
-    onEachLazy(document.querySelectorAll('.more-examples-toggle'), function(toggle) {
+    onEachLazy(document.querySelectorAll('.more-examples-toggle'), toggle => {
         // Allow users to click the left border of the <details> section to close it,
         // since the section can be large and finding the [+] button is annoying.
         onEachLazy(toggle.querySelectorAll('.toggle-line, .hide-more'), button => {
-            button.addEventListener('click', function() {
+            button.addEventListener('click', () => {
                 toggle.open = false;
             });
         });
 
         const moreExamples = toggle.querySelectorAll('.scraped-example');
-        toggle.querySelector('summary').addEventListener('click', function() {
+        toggle.querySelector('summary').addEventListener('click', () => {
             // Wrapping in setTimeout ensures the update happens after the elements are actually
             // visible. This is necessary since updateScrapedExample calls scrollToLoc which
             // depends on offsetHeight, a property that requires an element to be visible to
             // compute correctly.
-            setTimeout(function() { onEachLazy(moreExamples, updateScrapedExample); });
+            setTimeout(() => { onEachLazy(moreExamples, updateScrapedExample); });
         }, {once: true});
     });
 })();

--- a/src/librustdoc/html/static/js/search.js
+++ b/src/librustdoc/html/static/js/search.js
@@ -1,10 +1,11 @@
 /* eslint-env es6 */
 /* eslint no-var: "error" */
 /* eslint prefer-const: "error" */
+/* eslint prefer-arrow-callback: "error" */
 /* global addClass, getNakedUrl, getSettingValue, hasOwnPropertyRustdoc, initSearch, onEach */
 /* global onEachLazy, removeClass, searchState, browserSupportsHistoryApi */
 
-(function() {
+(function () {
 // This mapping table should match the discriminants of
 // `rustdoc::formats::item_type::ItemType` type in Rust.
 const itemTypes = [
@@ -46,7 +47,7 @@ function printTab(nb) {
         searchState.currentTab = nb;
     }
     let nb_copy = nb;
-    onEachLazy(document.getElementById("titles").childNodes, function(elem) {
+    onEachLazy(document.getElementById("titles").childNodes, elem => {
         if (nb_copy === 0) {
             addClass(elem, "selected");
         } else {
@@ -54,7 +55,7 @@ function printTab(nb) {
         }
         nb_copy -= 1;
     });
-    onEachLazy(document.getElementById("results").childNodes, function(elem) {
+    onEachLazy(document.getElementById("results").childNodes, elem => {
         if (nb === 0) {
             addClass(elem, "active");
         } else {
@@ -100,7 +101,7 @@ function levenshtein(s1, s2) {
     return s1_len + s2_len;
 }
 
-window.initSearch = function(rawSearchIndex) {
+window.initSearch = rawSearchIndex => {
     const MAX_LEV_DISTANCE = 3;
     const MAX_RESULTS = 200;
     const GENERICS_DATA = 2;
@@ -774,7 +775,7 @@ window.initSearch = function(rawSearchIndex) {
                 return [];
             }
 
-            results.sort(function(aaa, bbb) {
+            results.sort((aaa, bbb) => {
                 let a, b;
 
                 // sort by exact match with regard to the last word (mismatch goes later)
@@ -978,9 +979,8 @@ window.initSearch = function(rawSearchIndex) {
                     if (elem.generics.length === 0) {
                         const checkGeneric = (row.length > GENERICS_DATA &&
                             row[GENERICS_DATA].length > 0);
-                        if (checkGeneric && row[GENERICS_DATA].findIndex(function(tmp_elem) {
-                            return tmp_elem[NAME] === elem.name;
-                        }) !== -1) {
+                        if (checkGeneric && row[GENERICS_DATA]
+                            .findIndex(tmp_elem => tmp_elem[NAME] === elem.name) !== -1) {
                             return 0;
                         }
                     }
@@ -1169,7 +1169,7 @@ window.initSearch = function(rawSearchIndex) {
                     }
                 }
             } else {
-                Object.keys(ALIASES).forEach(function(crate) {
+                Object.keys(ALIASES).forEach(crate => {
                     if (ALIASES[crate][lowerQuery]) {
                         const pushTo = crate === window.currentCrate ? crateAliases : aliases;
                         const query_aliases = ALIASES[crate][lowerQuery];
@@ -1180,7 +1180,7 @@ window.initSearch = function(rawSearchIndex) {
                 });
             }
 
-            const sortFunc = function(aaa, bbb) {
+            const sortFunc = (aaa, bbb) => {
                 if (aaa.path < bbb.path) {
                     return 1;
                 } else if (aaa.path === bbb.path) {
@@ -1191,7 +1191,7 @@ window.initSearch = function(rawSearchIndex) {
             crateAliases.sort(sortFunc);
             aliases.sort(sortFunc);
 
-            const pushFunc = function(alias) {
+            const pushFunc = alias => {
                 alias.alias = query;
                 const res = buildHrefAndPath(alias);
                 alias.displayPath = pathSplitter(res[0]);
@@ -1579,7 +1579,7 @@ window.initSearch = function(rawSearchIndex) {
         if (array.length > 0) {
             output.className = "search-results " + extraClass;
 
-            array.forEach(function(item) {
+            array.forEach(item => {
                 const name = item.name;
                 const type = itemTypes[item.ty];
 
@@ -1746,9 +1746,9 @@ window.initSearch = function(rawSearchIndex) {
         searchState.focusedByTab = [null, null, null];
         searchState.showResults(search);
         const elems = document.getElementById("titles").childNodes;
-        elems[0].onclick = function() { printTab(0); };
-        elems[1].onclick = function() { printTab(1); };
-        elems[2].onclick = function() { printTab(2); };
+        elems[0].onclick = () => { printTab(0); };
+        elems[1].onclick = () => { printTab(1); };
+        elems[2].onclick = () => { printTab(2); };
         printTab(currentTab);
     }
 
@@ -1977,7 +1977,7 @@ window.initSearch = function(rawSearchIndex) {
     }
 
     function registerSearchEvents() {
-        const searchAfter500ms = function() {
+        const searchAfter500ms = () => {
             searchState.clearInputTimeout();
             if (searchState.input.value.length === 0) {
                 if (browserSupportsHistoryApi()) {
@@ -1992,7 +1992,7 @@ window.initSearch = function(rawSearchIndex) {
         searchState.input.onkeyup = searchAfter500ms;
         searchState.input.oninput = searchAfter500ms;
         document.getElementsByClassName("search-form")[0].onsubmit = onSearchSubmit;
-        searchState.input.onchange = function(e) {
+        searchState.input.onchange = e => {
             if (e.target !== document.activeElement) {
                 // To prevent doing anything when it's from a blur event.
                 return;
@@ -2006,7 +2006,7 @@ window.initSearch = function(rawSearchIndex) {
         };
         searchState.input.onpaste = searchState.input.onchange;
 
-        searchState.outputElement().addEventListener("keydown", function(e) {
+        searchState.outputElement().addEventListener("keydown", e => {
             // We only handle unmodified keystrokes here. We don't want to interfere with,
             // for instance, alt-left and alt-right for history navigation.
             if (e.altKey || e.ctrlKey || e.shiftKey || e.metaKey) {
@@ -2041,18 +2041,18 @@ window.initSearch = function(rawSearchIndex) {
             }
         });
 
-        searchState.input.addEventListener("keydown", function(e) {
+        searchState.input.addEventListener("keydown", e => {
             if (e.which === 40) { // down
                 focusSearchResult();
                 e.preventDefault();
             }
         });
 
-        searchState.input.addEventListener("focus", function() {
+        searchState.input.addEventListener("focus", () => {
             putBackSearch();
         });
 
-        searchState.input.addEventListener("blur", function() {
+        searchState.input.addEventListener("blur", () => {
             searchState.input.placeholder = searchState.input.origPlaceholder;
         });
 
@@ -2062,7 +2062,7 @@ window.initSearch = function(rawSearchIndex) {
             // Store the previous <title> so we can revert back to it later.
             const previousTitle = document.title;
 
-            window.addEventListener("popstate", function(e) {
+            window.addEventListener("popstate", e => {
                 const params = searchState.getQueryStringParams();
                 // Revert to the previous title manually since the History
                 // API ignores the title parameter.
@@ -2098,7 +2098,7 @@ window.initSearch = function(rawSearchIndex) {
         // This was an interaction between the back-forward cache and our handlers
         // that try to sync state between the URL and the search input. To work around it,
         // do a small amount of re-init on page show.
-        window.onpageshow = function(){
+        window.onpageshow = () => {
             const qSearch = searchState.getQueryStringParams().search;
             if (searchState.input.value === "" && qSearch) {
                 searchState.input.value = qSearch;

--- a/src/librustdoc/html/static/js/settings.js
+++ b/src/librustdoc/html/static/js/settings.js
@@ -1,6 +1,7 @@
 /* eslint-env es6 */
 /* eslint no-var: "error" */
 /* eslint prefer-const: "error" */
+/* eslint prefer-arrow-callback: "error" */
 // Local js definitions:
 /* global getSettingValue, getVirtualKey, updateLocalStorage, updateSystemTheme, loadCss */
 /* global addClass, removeClass, onEach, onEachLazy, NOT_DISPLAYED_ID */
@@ -60,7 +61,7 @@
 
     function setEvents(settingsElement) {
         updateLightAndDark();
-        onEachLazy(settingsElement.getElementsByClassName("slider"), function(elem) {
+        onEachLazy(settingsElement.getElementsByClassName("slider"), elem => {
             const toggle = elem.previousElementSibling;
             const settingId = toggle.id;
             const settingValue = getSettingValue(settingId);
@@ -73,7 +74,7 @@
             toggle.onkeyup = handleKey;
             toggle.onkeyrelease = handleKey;
         });
-        onEachLazy(settingsElement.getElementsByClassName("select-wrapper"), function(elem) {
+        onEachLazy(settingsElement.getElementsByClassName("select-wrapper"), elem => {
             const select = elem.getElementsByTagName("select")[0];
             const settingId = select.id;
             const settingValue = getSettingValue(settingId);
@@ -84,13 +85,13 @@
                 changeSetting(this.id, this.value);
             };
         });
-        onEachLazy(settingsElement.querySelectorAll("input[type=\"radio\"]"), function(elem) {
+        onEachLazy(settingsElement.querySelectorAll("input[type=\"radio\"]"), elem => {
             const settingId = elem.name;
             const settingValue = getSettingValue(settingId);
             if (settingValue !== null && settingValue !== "null") {
                 elem.checked = settingValue === elem.value;
             }
-            elem.addEventListener("change", function(ev) {
+            elem.addEventListener("change", ev => {
                 changeSetting(ev.target.name, ev.target.value);
             });
         });
@@ -118,7 +119,7 @@
                 output += `<div class="radio-line" id="${js_data_name}">\
                         <span class="setting-name">${setting_name}</span>\
                         <div class="choices">`;
-                onEach(setting["options"], function(option) {
+                onEach(setting["options"], option => {
                     const checked = option === setting["default"] ? " checked" : "";
 
                     output += `<label for="${js_data_name}-${option}" class="choice">\
@@ -265,7 +266,7 @@
     }
 
     // We now wait a bit for the web browser to end re-computing the DOM...
-    setTimeout(function() {
+    setTimeout(() => {
         setEvents(settingsMenu);
         // The setting menu is already displayed if we're on the settings page.
         if (!isSettingsPage) {

--- a/src/librustdoc/html/static/js/source-script.js
+++ b/src/librustdoc/html/static/js/source-script.js
@@ -1,6 +1,7 @@
 /* eslint-env es6 */
 /* eslint no-var: "error" */
 /* eslint prefer-const: "error" */
+/* eslint prefer-arrow-callback: "error" */
 
 // From rust:
 /* global search, sourcesIndex */
@@ -8,7 +9,7 @@
 // Local js definitions:
 /* global addClass, getCurrentValue, hasClass, onEachLazy, removeClass, browserSupportsHistoryApi */
 /* global updateLocalStorage */
-(function() {
+(function () {
 
 function getCurrentFilePath() {
     const parts = window.location.pathname.split("/");
@@ -32,7 +33,7 @@ function createDirEntry(elem, parent, fullPath, currentFile, hasFoundFile) {
 
     fullPath += elem["name"] + "/";
 
-    name.onclick = function() {
+    name.onclick = () => {
         if (hasClass(this, "expand")) {
             removeClass(this, "expand");
         } else {
@@ -134,7 +135,7 @@ function createSourceSidebar() {
     title.className = "title";
     title.innerText = "Files";
     sidebar.appendChild(title);
-    Object.keys(sourcesIndex).forEach(function(key) {
+    Object.keys(sourcesIndex).forEach(key => {
         sourcesIndex[key].name = key;
         hasFoundFile = createDirEntry(sourcesIndex[key], sidebar, "",
                                       currentFile, hasFoundFile);
@@ -175,8 +176,8 @@ function highlightSourceLines(match) {
     if (x) {
         x.scrollIntoView();
     }
-    onEachLazy(document.getElementsByClassName("line-numbers"), function(e) {
-        onEachLazy(e.getElementsByTagName("span"), function(i_e) {
+    onEachLazy(document.getElementsByClassName("line-numbers"), e => {
+        onEachLazy(e.getElementsByTagName("span"), i_e => {
             removeClass(i_e, "line-highlighted");
         });
     });
@@ -189,10 +190,10 @@ function highlightSourceLines(match) {
     }
 }
 
-const handleSourceHighlight = (function() {
+const handleSourceHighlight = (function () {
     let prev_line_id = 0;
 
-    const set_fragment = function(name) {
+    const set_fragment = name => {
         const x = window.scrollX,
             y = window.scrollY;
         if (browserSupportsHistoryApi()) {
@@ -205,7 +206,7 @@ const handleSourceHighlight = (function() {
         window.scrollTo(x, y);
     };
 
-    return function(ev) {
+    return ev => {
         let cur_line_id = parseInt(ev.target.id, 10);
         ev.preventDefault();
 
@@ -226,14 +227,14 @@ const handleSourceHighlight = (function() {
     };
 }());
 
-window.addEventListener("hashchange", function() {
+window.addEventListener("hashchange", () => {
     const match = window.location.hash.match(lineNumbersRegex);
     if (match) {
         return highlightSourceLines(match);
     }
 });
 
-onEachLazy(document.getElementsByClassName("line-numbers"), function(el) {
+onEachLazy(document.getElementsByClassName("line-numbers"), el => {
     el.addEventListener("click", handleSourceHighlight);
 });
 

--- a/src/librustdoc/html/static/js/storage.js
+++ b/src/librustdoc/html/static/js/storage.js
@@ -1,6 +1,7 @@
 /* eslint-env es6 */
 /* eslint no-var: "error" */
 /* eslint prefer-const: "error" */
+/* eslint prefer-arrow-callback: "error" */
 
 const darkThemes = ["dark", "ayu"];
 window.currentTheme = document.getElementById("themeStyle");
@@ -139,11 +140,11 @@ function switchTheme(styleElem, mainStyleElem, newTheme, saveTheme) {
 
     let found = false;
     if (savedHref.length === 0) {
-        onEachLazy(document.getElementsByTagName("link"), function(el) {
+        onEachLazy(document.getElementsByTagName("link"), el => {
             savedHref.push(el.href);
         });
     }
-    onEach(savedHref, function(el) {
+    onEach(savedHref, el => {
         if (el === newHref) {
             found = true;
             return true;
@@ -170,10 +171,10 @@ function useSystemTheme(value) {
     }
 }
 
-const updateSystemTheme = (function() {
+const updateSystemTheme = (function () {
     if (!window.matchMedia) {
         // fallback to the CSS computed value
-        return function() {
+        return () => {
             const cssTheme = getComputedStyle(document.documentElement)
                 .getPropertyValue('content');
 
@@ -190,7 +191,7 @@ const updateSystemTheme = (function() {
     const mql = window.matchMedia("(prefers-color-scheme: dark)");
 
     function handlePreferenceChange(mql) {
-        const use = function(theme) {
+        const use = theme => {
             switchTheme(window.currentTheme, window.mainTheme, theme, true);
         };
         // maybe the user has disabled the setting in the meantime!
@@ -214,7 +215,7 @@ const updateSystemTheme = (function() {
 
     mql.addListener(handlePreferenceChange);
 
-    return function() {
+    return () => {
         handlePreferenceChange(mql);
     };
 })();
@@ -252,7 +253,7 @@ if (getSettingValue("use-system-theme") !== "false" && window.matchMedia) {
 // For some reason, if we try to change the theme while the `pageshow` event is
 // running, it sometimes fails to take effect. The problem manifests on Chrome,
 // specifically when talking to a remote website with no caching.
-window.addEventListener("pageshow", function(ev) {
+window.addEventListener("pageshow", ev => {
     if (ev.persisted) {
         setTimeout(switchToSavedTheme, 0);
     }

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -5,7 +5,6 @@
 #![feature(rustc_private)]
 #![feature(array_methods)]
 #![feature(assert_matches)]
-#![feature(bool_to_option)]
 #![feature(box_patterns)]
 #![feature(control_flow_enum)]
 #![feature(box_syntax)]

--- a/src/test/ui/const-generics/const-arg-in-const-arg.full.stderr
+++ b/src/test/ui/const-generics/const-arg-in-const-arg.full.stderr
@@ -1,0 +1,162 @@
+error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
+  --> $DIR/const-arg-in-const-arg.rs:18:23
+   |
+LL |     let _: [u8; faz::<'a>(&())];
+   |                       ^^
+   |
+note: the late bound lifetime parameter is introduced here
+  --> $DIR/const-arg-in-const-arg.rs:8:14
+   |
+LL | const fn faz<'a>(_: &'a ()) -> usize { 13 }
+   |              ^^
+
+error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
+  --> $DIR/const-arg-in-const-arg.rs:21:23
+   |
+LL |     let _: [u8; faz::<'b>(&())];
+   |                       ^^
+   |
+note: the late bound lifetime parameter is introduced here
+  --> $DIR/const-arg-in-const-arg.rs:8:14
+   |
+LL | const fn faz<'a>(_: &'a ()) -> usize { 13 }
+   |              ^^
+
+error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
+  --> $DIR/const-arg-in-const-arg.rs:30:23
+   |
+LL |     let _ = [0; faz::<'a>(&())];
+   |                       ^^
+   |
+note: the late bound lifetime parameter is introduced here
+  --> $DIR/const-arg-in-const-arg.rs:8:14
+   |
+LL | const fn faz<'a>(_: &'a ()) -> usize { 13 }
+   |              ^^
+
+error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
+  --> $DIR/const-arg-in-const-arg.rs:33:23
+   |
+LL |     let _ = [0; faz::<'b>(&())];
+   |                       ^^
+   |
+note: the late bound lifetime parameter is introduced here
+  --> $DIR/const-arg-in-const-arg.rs:8:14
+   |
+LL | const fn faz<'a>(_: &'a ()) -> usize { 13 }
+   |              ^^
+
+error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
+  --> $DIR/const-arg-in-const-arg.rs:41:24
+   |
+LL |     let _: Foo<{ faz::<'a>(&()) }>;
+   |                        ^^
+   |
+note: the late bound lifetime parameter is introduced here
+  --> $DIR/const-arg-in-const-arg.rs:8:14
+   |
+LL | const fn faz<'a>(_: &'a ()) -> usize { 13 }
+   |              ^^
+
+error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
+  --> $DIR/const-arg-in-const-arg.rs:44:24
+   |
+LL |     let _: Foo<{ faz::<'b>(&()) }>;
+   |                        ^^
+   |
+note: the late bound lifetime parameter is introduced here
+  --> $DIR/const-arg-in-const-arg.rs:8:14
+   |
+LL | const fn faz<'a>(_: &'a ()) -> usize { 13 }
+   |              ^^
+
+error: unconstrained generic constant
+  --> $DIR/const-arg-in-const-arg.rs:13:12
+   |
+LL |     let _: [u8; foo::<T>()];
+   |            ^^^^^^^^^^^^^^^^
+   |
+   = help: try adding a `where` bound using this expression: `where [(); foo::<T>()]:`
+
+error: unconstrained generic constant
+  --> $DIR/const-arg-in-const-arg.rs:15:12
+   |
+LL |     let _: [u8; bar::<N>()];
+   |            ^^^^^^^^^^^^^^^^
+   |
+   = help: try adding a `where` bound using this expression: `where [(); bar::<N>()]:`
+
+error: unconstrained generic constant
+  --> $DIR/const-arg-in-const-arg.rs:36:12
+   |
+LL |     let _: Foo<{ foo::<T>() }>;
+   |            ^^^^^^^^^^^^^^^^^^^
+   |
+   = help: try adding a `where` bound using this expression: `where [(); { foo::<T>() }]:`
+
+error: unconstrained generic constant
+  --> $DIR/const-arg-in-const-arg.rs:38:12
+   |
+LL |     let _: Foo<{ bar::<N>() }>;
+   |            ^^^^^^^^^^^^^^^^^^^
+   |
+   = help: try adding a `where` bound using this expression: `where [(); { bar::<N>() }]:`
+
+error: unconstrained generic constant
+  --> $DIR/const-arg-in-const-arg.rs:25:17
+   |
+LL |     let _ = [0; foo::<T>()];
+   |                 ^^^^^^^^^^
+   |
+   = help: try adding a `where` bound using this expression: `where [(); foo::<T>()]:`
+
+error: unconstrained generic constant
+  --> $DIR/const-arg-in-const-arg.rs:27:17
+   |
+LL |     let _ = [0; bar::<N>()];
+   |                 ^^^^^^^^^^
+   |
+   = help: try adding a `where` bound using this expression: `where [(); bar::<N>()]:`
+
+error: unconstrained generic constant
+  --> $DIR/const-arg-in-const-arg.rs:47:19
+   |
+LL |     let _ = Foo::<{ foo::<T>() }>;
+   |                   ^^^^^^^^^^^^^^
+   |
+   = help: try adding a `where` bound using this expression: `where [(); { foo::<T>() }]:`
+
+error: unconstrained generic constant
+  --> $DIR/const-arg-in-const-arg.rs:49:19
+   |
+LL |     let _ = Foo::<{ bar::<N>() }>;
+   |                   ^^^^^^^^^^^^^^
+   |
+   = help: try adding a `where` bound using this expression: `where [(); { bar::<N>() }]:`
+
+error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
+  --> $DIR/const-arg-in-const-arg.rs:52:27
+   |
+LL |     let _ = Foo::<{ faz::<'a>(&()) }>;
+   |                           ^^
+   |
+note: the late bound lifetime parameter is introduced here
+  --> $DIR/const-arg-in-const-arg.rs:8:14
+   |
+LL | const fn faz<'a>(_: &'a ()) -> usize { 13 }
+   |              ^^
+
+error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
+  --> $DIR/const-arg-in-const-arg.rs:55:27
+   |
+LL |     let _ = Foo::<{ faz::<'b>(&()) }>;
+   |                           ^^
+   |
+note: the late bound lifetime parameter is introduced here
+  --> $DIR/const-arg-in-const-arg.rs:8:14
+   |
+LL | const fn faz<'a>(_: &'a ()) -> usize { 13 }
+   |              ^^
+
+error: aborting due to 16 previous errors
+

--- a/src/test/ui/const-generics/const-arg-in-const-arg.min.stderr
+++ b/src/test/ui/const-generics/const-arg-in-const-arg.min.stderr
@@ -8,7 +8,7 @@ LL |     let _: [u8; foo::<T>()];
    = help: use `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: generic parameters may not be used in const operations
-  --> $DIR/const-arg-in-const-arg.rs:14:23
+  --> $DIR/const-arg-in-const-arg.rs:15:23
    |
 LL |     let _: [u8; bar::<N>()];
    |                       ^ cannot perform const operation using `N`
@@ -17,7 +17,7 @@ LL |     let _: [u8; bar::<N>()];
    = help: use `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error[E0658]: a non-static lifetime is not allowed in a `const`
-  --> $DIR/const-arg-in-const-arg.rs:16:23
+  --> $DIR/const-arg-in-const-arg.rs:18:23
    |
 LL |     let _: [u8; faz::<'a>(&())];
    |                       ^^
@@ -26,7 +26,7 @@ LL |     let _: [u8; faz::<'a>(&())];
    = help: add `#![feature(generic_const_exprs)]` to the crate attributes to enable
 
 error[E0658]: a non-static lifetime is not allowed in a `const`
-  --> $DIR/const-arg-in-const-arg.rs:18:23
+  --> $DIR/const-arg-in-const-arg.rs:20:23
    |
 LL |     let _: [u8; baz::<'a>(&())];
    |                       ^^
@@ -35,7 +35,7 @@ LL |     let _: [u8; baz::<'a>(&())];
    = help: add `#![feature(generic_const_exprs)]` to the crate attributes to enable
 
 error[E0658]: a non-static lifetime is not allowed in a `const`
-  --> $DIR/const-arg-in-const-arg.rs:19:23
+  --> $DIR/const-arg-in-const-arg.rs:21:23
    |
 LL |     let _: [u8; faz::<'b>(&())];
    |                       ^^
@@ -44,7 +44,7 @@ LL |     let _: [u8; faz::<'b>(&())];
    = help: add `#![feature(generic_const_exprs)]` to the crate attributes to enable
 
 error[E0658]: a non-static lifetime is not allowed in a `const`
-  --> $DIR/const-arg-in-const-arg.rs:21:23
+  --> $DIR/const-arg-in-const-arg.rs:23:23
    |
 LL |     let _: [u8; baz::<'b>(&())];
    |                       ^^
@@ -53,7 +53,7 @@ LL |     let _: [u8; baz::<'b>(&())];
    = help: add `#![feature(generic_const_exprs)]` to the crate attributes to enable
 
 error: generic parameters may not be used in const operations
-  --> $DIR/const-arg-in-const-arg.rs:24:23
+  --> $DIR/const-arg-in-const-arg.rs:27:23
    |
 LL |     let _ = [0; bar::<N>()];
    |                       ^ cannot perform const operation using `N`
@@ -62,7 +62,7 @@ LL |     let _ = [0; bar::<N>()];
    = help: use `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error[E0658]: a non-static lifetime is not allowed in a `const`
-  --> $DIR/const-arg-in-const-arg.rs:26:23
+  --> $DIR/const-arg-in-const-arg.rs:30:23
    |
 LL |     let _ = [0; faz::<'a>(&())];
    |                       ^^
@@ -71,7 +71,7 @@ LL |     let _ = [0; faz::<'a>(&())];
    = help: add `#![feature(generic_const_exprs)]` to the crate attributes to enable
 
 error[E0658]: a non-static lifetime is not allowed in a `const`
-  --> $DIR/const-arg-in-const-arg.rs:28:23
+  --> $DIR/const-arg-in-const-arg.rs:32:23
    |
 LL |     let _ = [0; baz::<'a>(&())];
    |                       ^^
@@ -80,7 +80,7 @@ LL |     let _ = [0; baz::<'a>(&())];
    = help: add `#![feature(generic_const_exprs)]` to the crate attributes to enable
 
 error[E0658]: a non-static lifetime is not allowed in a `const`
-  --> $DIR/const-arg-in-const-arg.rs:29:23
+  --> $DIR/const-arg-in-const-arg.rs:33:23
    |
 LL |     let _ = [0; faz::<'b>(&())];
    |                       ^^
@@ -89,7 +89,7 @@ LL |     let _ = [0; faz::<'b>(&())];
    = help: add `#![feature(generic_const_exprs)]` to the crate attributes to enable
 
 error[E0658]: a non-static lifetime is not allowed in a `const`
-  --> $DIR/const-arg-in-const-arg.rs:31:23
+  --> $DIR/const-arg-in-const-arg.rs:35:23
    |
 LL |     let _ = [0; baz::<'b>(&())];
    |                       ^^
@@ -98,7 +98,7 @@ LL |     let _ = [0; baz::<'b>(&())];
    = help: add `#![feature(generic_const_exprs)]` to the crate attributes to enable
 
 error: generic parameters may not be used in const operations
-  --> $DIR/const-arg-in-const-arg.rs:32:24
+  --> $DIR/const-arg-in-const-arg.rs:36:24
    |
 LL |     let _: Foo<{ foo::<T>() }>;
    |                        ^ cannot perform const operation using `T`
@@ -107,7 +107,7 @@ LL |     let _: Foo<{ foo::<T>() }>;
    = help: use `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: generic parameters may not be used in const operations
-  --> $DIR/const-arg-in-const-arg.rs:33:24
+  --> $DIR/const-arg-in-const-arg.rs:38:24
    |
 LL |     let _: Foo<{ bar::<N>() }>;
    |                        ^ cannot perform const operation using `N`
@@ -116,7 +116,7 @@ LL |     let _: Foo<{ bar::<N>() }>;
    = help: use `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error[E0658]: a non-static lifetime is not allowed in a `const`
-  --> $DIR/const-arg-in-const-arg.rs:35:24
+  --> $DIR/const-arg-in-const-arg.rs:41:24
    |
 LL |     let _: Foo<{ faz::<'a>(&()) }>;
    |                        ^^
@@ -125,7 +125,7 @@ LL |     let _: Foo<{ faz::<'a>(&()) }>;
    = help: add `#![feature(generic_const_exprs)]` to the crate attributes to enable
 
 error[E0658]: a non-static lifetime is not allowed in a `const`
-  --> $DIR/const-arg-in-const-arg.rs:37:24
+  --> $DIR/const-arg-in-const-arg.rs:43:24
    |
 LL |     let _: Foo<{ baz::<'a>(&()) }>;
    |                        ^^
@@ -134,7 +134,7 @@ LL |     let _: Foo<{ baz::<'a>(&()) }>;
    = help: add `#![feature(generic_const_exprs)]` to the crate attributes to enable
 
 error[E0658]: a non-static lifetime is not allowed in a `const`
-  --> $DIR/const-arg-in-const-arg.rs:38:24
+  --> $DIR/const-arg-in-const-arg.rs:44:24
    |
 LL |     let _: Foo<{ faz::<'b>(&()) }>;
    |                        ^^
@@ -143,7 +143,7 @@ LL |     let _: Foo<{ faz::<'b>(&()) }>;
    = help: add `#![feature(generic_const_exprs)]` to the crate attributes to enable
 
 error[E0658]: a non-static lifetime is not allowed in a `const`
-  --> $DIR/const-arg-in-const-arg.rs:40:24
+  --> $DIR/const-arg-in-const-arg.rs:46:24
    |
 LL |     let _: Foo<{ baz::<'b>(&()) }>;
    |                        ^^
@@ -152,7 +152,7 @@ LL |     let _: Foo<{ baz::<'b>(&()) }>;
    = help: add `#![feature(generic_const_exprs)]` to the crate attributes to enable
 
 error: generic parameters may not be used in const operations
-  --> $DIR/const-arg-in-const-arg.rs:41:27
+  --> $DIR/const-arg-in-const-arg.rs:47:27
    |
 LL |     let _ = Foo::<{ foo::<T>() }>;
    |                           ^ cannot perform const operation using `T`
@@ -161,7 +161,7 @@ LL |     let _ = Foo::<{ foo::<T>() }>;
    = help: use `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error: generic parameters may not be used in const operations
-  --> $DIR/const-arg-in-const-arg.rs:42:27
+  --> $DIR/const-arg-in-const-arg.rs:49:27
    |
 LL |     let _ = Foo::<{ bar::<N>() }>;
    |                           ^ cannot perform const operation using `N`
@@ -170,7 +170,7 @@ LL |     let _ = Foo::<{ bar::<N>() }>;
    = help: use `#![feature(generic_const_exprs)]` to allow generic const expressions
 
 error[E0658]: a non-static lifetime is not allowed in a `const`
-  --> $DIR/const-arg-in-const-arg.rs:44:27
+  --> $DIR/const-arg-in-const-arg.rs:52:27
    |
 LL |     let _ = Foo::<{ faz::<'a>(&()) }>;
    |                           ^^
@@ -179,7 +179,7 @@ LL |     let _ = Foo::<{ faz::<'a>(&()) }>;
    = help: add `#![feature(generic_const_exprs)]` to the crate attributes to enable
 
 error[E0658]: a non-static lifetime is not allowed in a `const`
-  --> $DIR/const-arg-in-const-arg.rs:46:27
+  --> $DIR/const-arg-in-const-arg.rs:54:27
    |
 LL |     let _ = Foo::<{ baz::<'a>(&()) }>;
    |                           ^^
@@ -188,7 +188,7 @@ LL |     let _ = Foo::<{ baz::<'a>(&()) }>;
    = help: add `#![feature(generic_const_exprs)]` to the crate attributes to enable
 
 error[E0658]: a non-static lifetime is not allowed in a `const`
-  --> $DIR/const-arg-in-const-arg.rs:47:27
+  --> $DIR/const-arg-in-const-arg.rs:55:27
    |
 LL |     let _ = Foo::<{ faz::<'b>(&()) }>;
    |                           ^^
@@ -197,7 +197,7 @@ LL |     let _ = Foo::<{ faz::<'b>(&()) }>;
    = help: add `#![feature(generic_const_exprs)]` to the crate attributes to enable
 
 error[E0658]: a non-static lifetime is not allowed in a `const`
-  --> $DIR/const-arg-in-const-arg.rs:49:27
+  --> $DIR/const-arg-in-const-arg.rs:57:27
    |
 LL |     let _ = Foo::<{ baz::<'b>(&()) }>;
    |                           ^^
@@ -206,7 +206,7 @@ LL |     let _ = Foo::<{ baz::<'b>(&()) }>;
    = help: add `#![feature(generic_const_exprs)]` to the crate attributes to enable
 
 error[E0747]: unresolved item provided when a constant was expected
-  --> $DIR/const-arg-in-const-arg.rs:14:23
+  --> $DIR/const-arg-in-const-arg.rs:15:23
    |
 LL |     let _: [u8; bar::<N>()];
    |                       ^
@@ -217,7 +217,7 @@ LL |     let _: [u8; bar::<{ N }>()];
    |                       +   +
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
-  --> $DIR/const-arg-in-const-arg.rs:16:23
+  --> $DIR/const-arg-in-const-arg.rs:18:23
    |
 LL |     let _: [u8; faz::<'a>(&())];
    |                       ^^
@@ -229,7 +229,7 @@ LL | const fn faz<'a>(_: &'a ()) -> usize { 13 }
    |              ^^
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
-  --> $DIR/const-arg-in-const-arg.rs:19:23
+  --> $DIR/const-arg-in-const-arg.rs:21:23
    |
 LL |     let _: [u8; faz::<'b>(&())];
    |                       ^^
@@ -241,7 +241,7 @@ LL | const fn faz<'a>(_: &'a ()) -> usize { 13 }
    |              ^^
 
 error[E0747]: unresolved item provided when a constant was expected
-  --> $DIR/const-arg-in-const-arg.rs:24:23
+  --> $DIR/const-arg-in-const-arg.rs:27:23
    |
 LL |     let _ = [0; bar::<N>()];
    |                       ^
@@ -252,7 +252,7 @@ LL |     let _ = [0; bar::<{ N }>()];
    |                       +   +
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
-  --> $DIR/const-arg-in-const-arg.rs:26:23
+  --> $DIR/const-arg-in-const-arg.rs:30:23
    |
 LL |     let _ = [0; faz::<'a>(&())];
    |                       ^^
@@ -264,7 +264,7 @@ LL | const fn faz<'a>(_: &'a ()) -> usize { 13 }
    |              ^^
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
-  --> $DIR/const-arg-in-const-arg.rs:29:23
+  --> $DIR/const-arg-in-const-arg.rs:33:23
    |
 LL |     let _ = [0; faz::<'b>(&())];
    |                       ^^
@@ -276,7 +276,7 @@ LL | const fn faz<'a>(_: &'a ()) -> usize { 13 }
    |              ^^
 
 error[E0747]: unresolved item provided when a constant was expected
-  --> $DIR/const-arg-in-const-arg.rs:33:24
+  --> $DIR/const-arg-in-const-arg.rs:38:24
    |
 LL |     let _: Foo<{ bar::<N>() }>;
    |                        ^
@@ -287,7 +287,7 @@ LL |     let _: Foo<{ bar::<{ N }>() }>;
    |                        +   +
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
-  --> $DIR/const-arg-in-const-arg.rs:35:24
+  --> $DIR/const-arg-in-const-arg.rs:41:24
    |
 LL |     let _: Foo<{ faz::<'a>(&()) }>;
    |                        ^^
@@ -299,7 +299,7 @@ LL | const fn faz<'a>(_: &'a ()) -> usize { 13 }
    |              ^^
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
-  --> $DIR/const-arg-in-const-arg.rs:38:24
+  --> $DIR/const-arg-in-const-arg.rs:44:24
    |
 LL |     let _: Foo<{ faz::<'b>(&()) }>;
    |                        ^^
@@ -311,7 +311,7 @@ LL | const fn faz<'a>(_: &'a ()) -> usize { 13 }
    |              ^^
 
 error: constant expression depends on a generic parameter
-  --> $DIR/const-arg-in-const-arg.rs:23:17
+  --> $DIR/const-arg-in-const-arg.rs:25:17
    |
 LL |     let _ = [0; foo::<T>()];
    |                 ^^^^^^^^^^
@@ -319,7 +319,7 @@ LL |     let _ = [0; foo::<T>()];
    = note: this may fail depending on what value the parameter takes
 
 error[E0747]: unresolved item provided when a constant was expected
-  --> $DIR/const-arg-in-const-arg.rs:42:27
+  --> $DIR/const-arg-in-const-arg.rs:49:27
    |
 LL |     let _ = Foo::<{ bar::<N>() }>;
    |                           ^
@@ -330,7 +330,7 @@ LL |     let _ = Foo::<{ bar::<{ N }>() }>;
    |                           +   +
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
-  --> $DIR/const-arg-in-const-arg.rs:44:27
+  --> $DIR/const-arg-in-const-arg.rs:52:27
    |
 LL |     let _ = Foo::<{ faz::<'a>(&()) }>;
    |                           ^^
@@ -342,7 +342,7 @@ LL | const fn faz<'a>(_: &'a ()) -> usize { 13 }
    |              ^^
 
 error: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
-  --> $DIR/const-arg-in-const-arg.rs:47:27
+  --> $DIR/const-arg-in-const-arg.rs:55:27
    |
 LL |     let _ = Foo::<{ faz::<'b>(&()) }>;
    |                           ^^

--- a/src/test/ui/const-generics/const-arg-in-const-arg.rs
+++ b/src/test/ui/const-generics/const-arg-in-const-arg.rs
@@ -1,7 +1,7 @@
-// revisions: min
-// FIXME(generic_const_exprs): This test currently causes an ICE because
-// we don't yet correctly deal with lifetimes, reenable this test once
-// this is fixed.
+// revisions: full min
+
+#![cfg_attr(full, feature(generic_const_exprs))]
+#![cfg_attr(full, allow(incomplete_features))]
 
 const fn foo<T>() -> usize { std::mem::size_of::<T>() }
 const fn bar<const N: usize>() -> usize { N }
@@ -10,43 +10,51 @@ const fn baz<'a>(_: &'a ()) -> usize where &'a (): Sized { 13 }
 
 struct Foo<const N: usize>;
 fn test<'a, 'b, T, const N: usize>() where &'b (): Sized {
-    let _: [u8; foo::<T>()]; //~ ERROR generic parameters may not
-    let _: [u8; bar::<N>()]; //~ ERROR generic parameters may not
-                             //~^ ERROR unresolved item provided when a constant was expected
-    let _: [u8; faz::<'a>(&())]; //~ ERROR a non-static lifetime
+    let _: [u8; foo::<T>()]; //[min]~ ERROR generic parameters may not
+                             //[full]~^ ERROR unconstrained generic constant
+    let _: [u8; bar::<N>()]; //[min]~ ERROR generic parameters may not
+                             //[min]~^ ERROR unresolved item provided when a constant was expected
+                             //[full]~^^ ERROR unconstrained generic constant
+    let _: [u8; faz::<'a>(&())]; //[min]~ ERROR a non-static lifetime
                                  //~^ ERROR cannot specify lifetime arguments
-    let _: [u8; baz::<'a>(&())]; //~ ERROR a non-static lifetime
-    let _: [u8; faz::<'b>(&())]; //~ ERROR a non-static lifetime
+    let _: [u8; baz::<'a>(&())]; //[min]~ ERROR a non-static lifetime
+    let _: [u8; faz::<'b>(&())]; //[min]~ ERROR a non-static lifetime
                                  //~^ ERROR cannot specify lifetime arguments
-    let _: [u8; baz::<'b>(&())]; //~ ERROR a non-static lifetime
+    let _: [u8; baz::<'b>(&())]; //[min]~ ERROR a non-static lifetime
 
-    let _ = [0; foo::<T>()]; //~ ERROR constant expression depends on a generic parameter
-    let _ = [0; bar::<N>()]; //~ ERROR generic parameters may not
-                             //~^ ERROR unresolved item provided when a constant was expected
-    let _ = [0; faz::<'a>(&())]; //~ ERROR a non-static lifetime
+    let _ = [0; foo::<T>()]; //[min]~ ERROR constant expression depends on a generic parameter
+                             //[full]~^ ERROR unconstrained generic constant
+    let _ = [0; bar::<N>()]; //[min]~ ERROR generic parameters may not
+                             //[min]~^ ERROR unresolved item provided when a constant was expected
+                             //[full]~^^ ERROR unconstrained generic constant
+    let _ = [0; faz::<'a>(&())]; //[min]~ ERROR a non-static lifetime
                                  //~^ ERROR cannot specify lifetime arguments
-    let _ = [0; baz::<'a>(&())]; //~ ERROR a non-static lifetime
-    let _ = [0; faz::<'b>(&())]; //~ ERROR a non-static lifetime
+    let _ = [0; baz::<'a>(&())]; //[min]~ ERROR a non-static lifetime
+    let _ = [0; faz::<'b>(&())]; //[min]~ ERROR a non-static lifetime
                                  //~^ ERROR cannot specify lifetime arguments
-    let _ = [0; baz::<'b>(&())]; //~ ERROR a non-static lifetime
-    let _: Foo<{ foo::<T>() }>; //~ ERROR generic parameters may not
-    let _: Foo<{ bar::<N>() }>; //~ ERROR generic parameters may not
-                                //~^ ERROR unresolved item provided when a constant was expected
-    let _: Foo<{ faz::<'a>(&()) }>; //~ ERROR a non-static lifetime
+    let _ = [0; baz::<'b>(&())]; //[min]~ ERROR a non-static lifetime
+    let _: Foo<{ foo::<T>() }>; //[min]~ ERROR generic parameters may not
+                                //[full]~^ ERROR unconstrained generic constant
+    let _: Foo<{ bar::<N>() }>; //[min]~ ERROR generic parameters may not
+                                //[min]~^ ERROR unresolved item provided when a constant was expected
+                                //[full]~^^ ERROR unconstrained generic constant
+    let _: Foo<{ faz::<'a>(&()) }>; //[min]~ ERROR a non-static lifetime
                                     //~^ ERROR cannot specify lifetime arguments
-    let _: Foo<{ baz::<'a>(&()) }>; //~ ERROR a non-static lifetime
-    let _: Foo<{ faz::<'b>(&()) }>; //~ ERROR a non-static lifetime
+    let _: Foo<{ baz::<'a>(&()) }>; //[min]~ ERROR a non-static lifetime
+    let _: Foo<{ faz::<'b>(&()) }>; //[min]~ ERROR a non-static lifetime
                                     //~^ ERROR cannot specify lifetime arguments
-    let _: Foo<{ baz::<'b>(&()) }>; //~ ERROR a non-static lifetime
-    let _ = Foo::<{ foo::<T>() }>; //~ ERROR generic parameters may not
-    let _ = Foo::<{ bar::<N>() }>; //~ ERROR generic parameters may not
-                                   //~^ ERROR unresolved item provided when a constant was expected
-    let _ = Foo::<{ faz::<'a>(&()) }>; //~ ERROR a non-static lifetime
+    let _: Foo<{ baz::<'b>(&()) }>; //[min]~ ERROR a non-static lifetime
+    let _ = Foo::<{ foo::<T>() }>; //[min]~ ERROR generic parameters may not
+                                   //[full]~^ ERROR unconstrained generic constant
+    let _ = Foo::<{ bar::<N>() }>; //[min]~ ERROR generic parameters may not
+                                   //[min]~^ ERROR unresolved item provided when a constant was expected
+                                   //[full]~^^ ERROR unconstrained generic constant
+    let _ = Foo::<{ faz::<'a>(&()) }>; //[min]~ ERROR a non-static lifetime
                                        //~^ ERROR cannot specify lifetime arguments
-    let _ = Foo::<{ baz::<'a>(&()) }>; //~ ERROR a non-static lifetime
-    let _ = Foo::<{ faz::<'b>(&()) }>; //~ ERROR a non-static lifetime
+    let _ = Foo::<{ baz::<'a>(&()) }>; //[min]~ ERROR a non-static lifetime
+    let _ = Foo::<{ faz::<'b>(&()) }>; //[min]~ ERROR a non-static lifetime
                                        //~^ ERROR cannot specify lifetime arguments
-    let _ = Foo::<{ baz::<'b>(&()) }>; //~ ERROR a non-static lifetime
+    let _ = Foo::<{ baz::<'b>(&()) }>; //[min]~ ERROR a non-static lifetime
 }
 
 fn main() {}

--- a/src/test/ui/const-generics/const-argument-non-static-lifetime.min.stderr
+++ b/src/test/ui/const-generics/const-argument-non-static-lifetime.min.stderr
@@ -1,0 +1,12 @@
+error[E0658]: a non-static lifetime is not allowed in a `const`
+  --> $DIR/const-argument-non-static-lifetime.rs:15:17
+   |
+LL |         let _: &'a ();
+   |                 ^^
+   |
+   = note: see issue #76560 <https://github.com/rust-lang/rust/issues/76560> for more information
+   = help: add `#![feature(generic_const_exprs)]` to the crate attributes to enable
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0658`.

--- a/src/test/ui/const-generics/const-argument-non-static-lifetime.rs
+++ b/src/test/ui/const-generics/const-argument-non-static-lifetime.rs
@@ -1,6 +1,8 @@
-// run-pass
-// revisions: full
-// FIXME(#75323) Omitted min revision for now due to ICE.
+// [full] run-pass
+// revisions: full min
+
+// regression test for #78180
+// compile-flags: -Zsave-analysis
 
 #![cfg_attr(full, feature(generic_const_exprs))]
 #![cfg_attr(full, allow(incomplete_features))]
@@ -10,7 +12,7 @@ fn test<const N: usize>() {}
 
 fn wow<'a>() -> &'a () {
     test::<{
-        let _: &'a ();
+        let _: &'a (); //[min]~ ERROR a non-static lifetime
         3
     }>();
     &()

--- a/src/test/ui/const-generics/issues/issue-775377.rs
+++ b/src/test/ui/const-generics/issues/issue-775377.rs
@@ -1,0 +1,11 @@
+#![feature(generic_const_exprs)]
+#![allow(incomplete_features)]
+
+trait MyTrait<T> {}
+
+fn bug<'a, T>() -> &'static dyn MyTrait<[(); { |x: &'a u32| { x }; 4 }]> {
+    //~^ ERROR overly complex generic constant
+    todo!()
+}
+
+fn main() {}

--- a/src/test/ui/const-generics/issues/issue-775377.stderr
+++ b/src/test/ui/const-generics/issues/issue-775377.stderr
@@ -1,0 +1,11 @@
+error: overly complex generic constant
+  --> $DIR/issue-775377.rs:6:46
+   |
+LL | fn bug<'a, T>() -> &'static dyn MyTrait<[(); { |x: &'a u32| { x }; 4 }]> {
+   |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^ blocks are not supported in generic constant
+   |
+   = help: consider moving this anonymous constant into a `const` function
+   = note: this operation may be supported in the future
+
+error: aborting due to previous error
+

--- a/src/test/ui/const-generics/issues/issue-83993.rs
+++ b/src/test/ui/const-generics/issues/issue-83993.rs
@@ -1,0 +1,14 @@
+// check-pass
+
+#![feature(generic_const_exprs)]
+#![allow(incomplete_features)]
+
+fn bug<'a>()
+where
+    for<'b> [(); {
+        let x: &'b ();
+        0
+    }]:
+{}
+
+fn main() {}

--- a/src/test/ui/for-loop-while/label_break_value.stderr
+++ b/src/test/ui/for-loop-while/label_break_value.stderr
@@ -1,0 +1,28 @@
+warning: label name `'b` shadows a label name that is already in scope
+  --> $DIR/label_break_value.rs:105:18
+   |
+LL |             v if { 'b: { break 'b v == 5; } } => { x = 41; },
+   |                    -- first declared here
+LL |             _ => 'b: {
+   |                  ^^ label `'b` already in scope
+
+warning: label name `'a` shadows a label name that is already in scope
+  --> $DIR/label_break_value.rs:131:17
+   |
+LL |     let x: u8 = 'a: {
+   |                 -- first declared here
+...
+LL |     let x: u8 = 'a: {
+   |                 ^^ label `'a` already in scope
+
+warning: label name `'b` shadows a label name that is already in scope
+  --> $DIR/label_break_value.rs:132:9
+   |
+LL |         'b: {
+   |         -- first declared here
+...
+LL |         'b: {
+   |         ^^ label `'b` already in scope
+
+warning: 3 warnings emitted
+

--- a/src/test/ui/for-loop-while/label_break_value_invalid.rs
+++ b/src/test/ui/for-loop-while/label_break_value_invalid.rs
@@ -1,0 +1,39 @@
+#![crate_type = "lib"]
+#![feature(label_break_value)]
+
+fn lbv_macro_test_hygiene_respected() {
+    macro_rules! mac2 {
+        ($val:expr) => {
+            break 'a $val; //~ ERROR undeclared label `'a` [E0426]
+        };
+    }
+    let x: u8 = 'a: {
+        'b: {
+            if true {
+                mac2!(2);
+            }
+        };
+        0
+    };
+    assert_eq!(x, 2);
+
+    macro_rules! mac3 {
+        ($val:expr) => {
+            'a: {
+            //~^ WARNING `'a` shadows a label
+            //~| WARNING `'a` shadows a label
+            //~| WARNING `'a` shadows a label
+                $val
+            }
+        };
+    }
+    let x: u8 = mac3!('b: { //~ WARNING `'b` shadows a label
+        if true {
+            break 'a 3; //~ ERROR undeclared label `'a` [E0426]
+        }
+        0
+    });
+    assert_eq!(x, 3);
+    let x: u8 = mac3!(break 'a 4); //~ ERROR undeclared label `'a` [E0426]
+    assert_eq!(x, 4);
+}

--- a/src/test/ui/for-loop-while/label_break_value_invalid.stderr
+++ b/src/test/ui/for-loop-while/label_break_value_invalid.stderr
@@ -1,0 +1,89 @@
+error[E0426]: use of undeclared label `'a`
+  --> $DIR/label_break_value_invalid.rs:7:19
+   |
+LL |             break 'a $val;
+   |                   ^^ undeclared label `'a`
+...
+LL |                 mac2!(2);
+   |                 -------- in this macro invocation
+   |
+   = note: this error originates in the macro `mac2` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0426]: use of undeclared label `'a`
+  --> $DIR/label_break_value_invalid.rs:32:19
+   |
+LL |     let x: u8 = mac3!('b: {
+   |                       -- a label with a similar name is reachable
+LL |         if true {
+LL |             break 'a 3;
+   |                   ^^
+   |                   |
+   |                   undeclared label `'a`
+   |                   help: try using similarly named label: `'b`
+
+error[E0426]: use of undeclared label `'a`
+  --> $DIR/label_break_value_invalid.rs:37:29
+   |
+LL |     let x: u8 = mac3!(break 'a 4);
+   |                             ^^ undeclared label `'a`
+
+warning: label name `'a` shadows a label name that is already in scope
+  --> $DIR/label_break_value_invalid.rs:22:13
+   |
+LL |       let x: u8 = 'a: {
+   |                   -- first declared here
+...
+LL |               'a: {
+   |               ^^ label `'a` already in scope
+...
+LL |       let x: u8 = mac3!('b: {
+   |  _________________-
+LL | |         if true {
+LL | |             break 'a 3;
+LL | |         }
+LL | |         0
+LL | |     });
+   | |______- in this macro invocation
+   |
+   = note: this warning originates in the macro `mac3` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+warning: label name `'b` shadows a label name that is already in scope
+  --> $DIR/label_break_value_invalid.rs:30:23
+   |
+LL |         'b: {
+   |         -- first declared here
+...
+LL |     let x: u8 = mac3!('b: {
+   |                       ^^ label `'b` already in scope
+
+warning: label name `'a` shadows a label name that is already in scope
+  --> $DIR/label_break_value_invalid.rs:22:13
+   |
+LL |     let x: u8 = 'a: {
+   |                 -- first declared here
+...
+LL |             'a: {
+   |             ^^ label `'a` already in scope
+...
+LL |     let x: u8 = mac3!(break 'a 4);
+   |                 ----------------- in this macro invocation
+   |
+   = note: this warning originates in the macro `mac3` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+warning: label name `'a` shadows a label name that is already in scope
+  --> $DIR/label_break_value_invalid.rs:22:13
+   |
+LL |             'a: {
+   |             ^^
+   |             |
+   |             first declared here
+   |             label `'a` already in scope
+...
+LL |     let x: u8 = mac3!(break 'a 4);
+   |                 ----------------- in this macro invocation
+   |
+   = note: this warning originates in the macro `mac3` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 3 previous errors; 4 warnings emitted
+
+For more information about this error, try `rustc --explain E0426`.


### PR DESCRIPTION
Successful merges:

 - #96603 (Enable full revision in const generics ui tests)
 - #96616 (Relax memory ordering used in `min_stack`)
 - #96619 (Relax memory ordering used in SameMutexCheck)
 - #96628 (Stabilize `bool::then_some`)
 - #96658 (Move callback to the () => {} syntax.)
 - #96677 (Add more tests for label-break-value)
 - #96697 (Enable tracing for all queries)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=96603,96616,96619,96628,96658,96677,96697)
<!-- homu-ignore:end -->