### PR TITLE
[don't merge] See what happens if we run PGO on Apple

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,19 +37,6 @@ jobs:
       TOOLSTATE_REPO: "https://github.com/rust-lang-nursery/rust-toolstate"
       CACHE_DOMAIN: ci-caches.rust-lang.org
     if: "github.event_name == 'pull_request'"
-    strategy:
-      matrix:
-        include:
-          - name: mingw-check
-            os: ubuntu-20.04-xl
-            env: {}
-          - name: x86_64-gnu-llvm-12
-            os: ubuntu-20.04-xl
-            env: {}
-          - name: x86_64-gnu-tools
-            env:
-              CI_ONLY_WHEN_SUBMODULES_CHANGED: 1
-            os: ubuntu-20.04-xl
     timeout-minutes: 600
     runs-on: "${{ matrix.os }}"
     steps:
@@ -290,7 +277,7 @@ jobs:
             os: ubuntu-20.04-xl
           - name: dist-x86_64-apple
             env:
-              SCRIPT: "./x.py dist --host=x86_64-apple-darwin --target=x86_64-apple-darwin"
+              SCRIPT: python3 src/ci/pgo-dist.py --host=x86_64-apple-darwin --target=x86_64-apple-darwin
               RUST_CONFIGURE_ARGS: "--enable-full-tools --enable-sanitizers --enable-profiler --set rust.jemalloc --set llvm.ninja=false"
               RUSTC_RETRY_LINKER_ON_SEGFAULT: 1
               MACOSX_DEPLOYMENT_TARGET: 10.7
@@ -558,9 +545,17 @@ jobs:
     strategy:
       matrix:
         include:
-          - name: dist-x86_64-linux
-            os: ubuntu-20.04-xl
-            env: {}
+          - name: dist-x86_64-apple
+            env:
+              SCRIPT: python3 src/ci/pgo-dist.py --host=x86_64-apple-darwin --target=x86_64-apple-darwin
+              RUST_CONFIGURE_ARGS: "--enable-full-tools --enable-sanitizers --enable-profiler --set rust.jemalloc --set llvm.ninja=false"
+              RUSTC_RETRY_LINKER_ON_SEGFAULT: 1
+              MACOSX_DEPLOYMENT_TARGET: 10.7
+              NO_LLVM_ASSERTIONS: 1
+              NO_DEBUG_ASSERTIONS: 1
+              NO_OVERFLOW_CHECKS: 1
+              DIST_REQUIRE_ALL_TOOLS: 1
+            os: macos-latest
     timeout-minutes: 600
     runs-on: "${{ matrix.os }}"
     steps:

--- a/src/ci/github-actions/ci.yml
+++ b/src/ci/github-actions/ci.yml
@@ -282,19 +282,19 @@ jobs:
     env:
       <<: [*shared-ci-variables, *public-variables]
     if: github.event_name == 'pull_request'
-    strategy:
-      matrix:
-        include:
-          - name: mingw-check
-            <<: *job-linux-xl
-
-          - name: x86_64-gnu-llvm-12
-            <<: *job-linux-xl
-
-          - name: x86_64-gnu-tools
-            env:
-              CI_ONLY_WHEN_SUBMODULES_CHANGED: 1
-            <<: *job-linux-xl
+#    strategy:
+#      matrix:
+#        include:
+#          - name: mingw-check
+#            <<: *job-linux-xl
+#
+#          - name: x86_64-gnu-llvm-12
+#            <<: *job-linux-xl
+#
+#          - name: x86_64-gnu-tools
+#            env:
+#              CI_ONLY_WHEN_SUBMODULES_CHANGED: 1
+#            <<: *job-linux-xl
 
   auto:
     <<: *base-ci-job
@@ -454,7 +454,7 @@ jobs:
 
           - name: dist-x86_64-apple
             env:
-              SCRIPT: ./x.py dist --host=x86_64-apple-darwin --target=x86_64-apple-darwin
+              SCRIPT: python3 src/ci/pgo-dist.py --host=x86_64-apple-darwin --target=x86_64-apple-darwin
               RUST_CONFIGURE_ARGS: --enable-full-tools --enable-sanitizers --enable-profiler --set rust.jemalloc --set llvm.ninja=false
               RUSTC_RETRY_LINKER_ON_SEGFAULT: 1
               MACOSX_DEPLOYMENT_TARGET: 10.7
@@ -691,9 +691,17 @@ jobs:
     strategy:
       matrix:
         include:
-          - &dist-x86_64-linux
-            name: dist-x86_64-linux
-            <<: *job-linux-xl
+          - name: dist-x86_64-apple
+            env:
+              SCRIPT: python3 src/ci/pgo-dist.py --host=x86_64-apple-darwin --target=x86_64-apple-darwin
+              RUST_CONFIGURE_ARGS: --enable-full-tools --enable-sanitizers --enable-profiler --set rust.jemalloc --set llvm.ninja=false
+              RUSTC_RETRY_LINKER_ON_SEGFAULT: 1
+              MACOSX_DEPLOYMENT_TARGET: 10.7
+              NO_LLVM_ASSERTIONS: 1
+              NO_DEBUG_ASSERTIONS: 1
+              NO_OVERFLOW_CHECKS: 1
+              DIST_REQUIRE_ALL_TOOLS: 1
+            <<: *job-macos-xl
 
   master:
     name: master

--- a/src/ci/pgo-dist.py
+++ b/src/ci/pgo-dist.py
@@ -1,0 +1,32 @@
+# ignore-tidy-linelength
+import os
+import subprocess
+import sys
+from pathlib import Path
+from urllib.request import urlretrieve
+import tarfile
+
+
+artifact_url = "https://ci-artifacts.rust-lang.org/rustc-builds/de1bc0008be096cf7ed67b93402250d3b3e480d0/reproducible-artifacts-nightly-x86_64-unknown-linux-gnu.tar.xz"
+
+archive = "artifacts.tar.xz"
+urlretrieve(artifact_url, archive)
+
+with tarfile.open(archive) as f:
+    f.extractall("artifacts")
+
+# llvm_pgo_path = Path("artifacts/reproducible-artifacts-nightly-x86_64-unknown-linux-gnu/reproducible-artifacts/llvm-pgo.profdata")
+# assert llvm_pgo_path.exists()
+
+rustc_pgo_path = Path("artifacts/reproducible-artifacts-nightly-x86_64-unknown-linux-gnu/reproducible-artifacts/rustc-pgo.profdata")
+assert rustc_pgo_path.exists()
+
+env = os.environ.copy()
+env["RUST_BACKTRACE"] = "full"
+
+args = [
+    "python", "x.py", "dist",
+    "--rust-profile-use", str(rustc_pgo_path)
+] + sys.argv[1:]
+print(f"Running {' '.join(args)}")
+subprocess.run(args, check=True, env=env)

--- a/src/ci/pgo-dist.py
+++ b/src/ci/pgo-dist.py
@@ -18,7 +18,7 @@ with tarfile.open(archive) as f:
 # llvm_pgo_path = Path("artifacts/reproducible-artifacts-nightly-x86_64-unknown-linux-gnu/reproducible-artifacts/llvm-pgo.profdata")
 # assert llvm_pgo_path.exists()
 
-rustc_pgo_path = Path("artifacts/reproducible-artifacts-nightly-x86_64-unknown-linux-gnu/reproducible-artifacts/rustc-pgo.profdata")
+rustc_pgo_path = Path("artifacts/reproducible-artifacts-nightly-x86_64-unknown-linux-gnu/reproducible-artifacts/rustc-pgo.profdata").resolve()
 assert rustc_pgo_path.exists()
 
 env = os.environ.copy()


### PR DESCRIPTION
Currently, PGO is executed on CI only for the `x64` linux target. It could be quite helpful for compiler performance (and possibly not that difficult) to also run it for other important targets, like `OS X` and `Windows`. This is just an experimental PR where we want to try how could we achieve that.

I modified the CI workflows so that they will try to run apple try build after each push.

r? @lqd