### PR TITLE
Check hidden types for well formedness at the definition site instead of only at the opaque type itself

### DIFF
--- a/compiler/rustc_borrowck/src/region_infer/opaque_types.rs
+++ b/compiler/rustc_borrowck/src/region_infer/opaque_types.rs
@@ -110,6 +110,7 @@ impl<'tcx> RegionInferenceContext<'tcx> {
             let remapped_type = infcx.infer_opaque_definition_from_instantiation(
                 opaque_type_key,
                 universal_concrete_type,
+                origin,
             );
             let ty = if check_opaque_type_parameter_valid(
                 infcx.tcx,

--- a/src/test/ui/type-alias-impl-trait/bounds-are-checked-2.rs
+++ b/src/test/ui/type-alias-impl-trait/bounds-are-checked-2.rs
@@ -4,10 +4,10 @@
 #![feature(type_alias_impl_trait)]
 
 type X<T> = impl Clone;
-//~^ ERROR the trait bound `T: Clone` is not satisfied
 
 fn f<T: Clone>(t: T) -> X<T> {
     t
+    //~^ ERROR the trait bound `T: Clone` is not satisfied
 }
 
 fn g<T>(o: Option<X<T>>) -> Option<X<T>> {

--- a/src/test/ui/type-alias-impl-trait/bounds-are-checked-2.stderr
+++ b/src/test/ui/type-alias-impl-trait/bounds-are-checked-2.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the trait bound `T: Clone` is not satisfied
-  --> $DIR/bounds-are-checked-2.rs:6:13
+  --> $DIR/bounds-are-checked-2.rs:9:5
    |
-LL | type X<T> = impl Clone;
-   |             ^^^^^^^^^^ the trait `Clone` is not implemented for `T`
+LL |     t
+   |     ^ the trait `Clone` is not implemented for `T`
    |
 help: consider restricting type parameter `T`
    |

--- a/src/test/ui/type-alias-impl-trait/generic_duplicate_param_use.rs
+++ b/src/test/ui/type-alias-impl-trait/generic_duplicate_param_use.rs
@@ -15,6 +15,7 @@ type TwoConsts<const X: usize, const Y: usize> = impl Debug;
 fn one_ty<T: Debug>(t: T) -> TwoTys<T, T> {
     t
     //~^ ERROR non-defining opaque type use in defining scope
+    //~| ERROR `U` doesn't implement `Debug`
 }
 
 fn one_lifetime<'a>(t: &'a u32) -> TwoLifetimes<'a, 'a> {

--- a/src/test/ui/type-alias-impl-trait/generic_duplicate_param_use.stderr
+++ b/src/test/ui/type-alias-impl-trait/generic_duplicate_param_use.stderr
@@ -1,3 +1,14 @@
+error[E0277]: `U` doesn't implement `Debug`
+  --> $DIR/generic_duplicate_param_use.rs:16:5
+   |
+LL |     t
+   |     ^ `U` cannot be formatted using `{:?}` because it doesn't implement `Debug`
+   |
+help: consider restricting type parameter `U`
+   |
+LL | type TwoTys<T, U: std::fmt::Debug> = impl Debug;
+   |                 +++++++++++++++++
+
 error: non-defining opaque type use in defining scope
   --> $DIR/generic_duplicate_param_use.rs:16:5
    |
@@ -11,7 +22,7 @@ LL | type TwoTys<T, U> = impl Debug;
    |             ^  ^
 
 error: non-defining opaque type use in defining scope
-  --> $DIR/generic_duplicate_param_use.rs:21:5
+  --> $DIR/generic_duplicate_param_use.rs:22:5
    |
 LL |     t
    |     ^
@@ -23,7 +34,7 @@ LL | type TwoLifetimes<'a, 'b> = impl Debug;
    |                   ^^  ^^
 
 error: non-defining opaque type use in defining scope
-  --> $DIR/generic_duplicate_param_use.rs:26:5
+  --> $DIR/generic_duplicate_param_use.rs:27:5
    |
 LL |     t
    |     ^
@@ -34,5 +45,6 @@ note: constant used multiple times
 LL | type TwoConsts<const X: usize, const Y: usize> = impl Debug;
    |                ^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^
 
-error: aborting due to 3 previous errors
+error: aborting due to 4 previous errors
 
+For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/type-alias-impl-trait/generic_duplicate_param_use2.rs
+++ b/src/test/ui/type-alias-impl-trait/generic_duplicate_param_use2.rs
@@ -6,8 +6,8 @@ fn main() {}
 
 // test that unused generic parameters are ok
 type Two<T, U> = impl Debug;
-//~^ ERROR `T` doesn't implement `Debug`
 
 fn two<T: Debug, U>(t: T, _: U) -> Two<T, U> {
     t
+    //~^ ERROR `T` doesn't implement `Debug`
 }

--- a/src/test/ui/type-alias-impl-trait/generic_duplicate_param_use2.stderr
+++ b/src/test/ui/type-alias-impl-trait/generic_duplicate_param_use2.stderr
@@ -1,8 +1,8 @@
 error[E0277]: `T` doesn't implement `Debug`
-  --> $DIR/generic_duplicate_param_use2.rs:8:18
+  --> $DIR/generic_duplicate_param_use2.rs:11:5
    |
-LL | type Two<T, U> = impl Debug;
-   |                  ^^^^^^^^^^ `T` cannot be formatted using `{:?}` because it doesn't implement `Debug`
+LL |     t
+   |     ^ `T` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
 help: consider restricting type parameter `T`
    |

--- a/src/test/ui/type-alias-impl-trait/generic_duplicate_param_use3.rs
+++ b/src/test/ui/type-alias-impl-trait/generic_duplicate_param_use3.rs
@@ -6,13 +6,13 @@ fn main() {}
 
 // test that unused generic parameters are ok
 type Two<T, U> = impl Debug;
-//~^ ERROR `T` doesn't implement `Debug`
 
 fn two<T: Debug, U>(t: T, _: U) -> Two<T, U> {
     t
+    //~^ ERROR `T` doesn't implement `Debug`
 }
 
 fn three<T, U: Debug>(_: T, u: U) -> Two<T, U> {
     u
-    //~^ ERROR concrete type differs from previous defining opaque type use
+    //~^ ERROR `U` doesn't implement `Debug`
 }

--- a/src/test/ui/type-alias-impl-trait/generic_duplicate_param_use3.stderr
+++ b/src/test/ui/type-alias-impl-trait/generic_duplicate_param_use3.stderr
@@ -1,25 +1,24 @@
-error: concrete type differs from previous defining opaque type use
-  --> $DIR/generic_duplicate_param_use3.rs:16:5
-   |
-LL |     u
-   |     ^ expected `T`, got `U`
-   |
-note: previous use here
-  --> $DIR/generic_duplicate_param_use3.rs:12:5
+error[E0277]: `T` doesn't implement `Debug`
+  --> $DIR/generic_duplicate_param_use3.rs:11:5
    |
 LL |     t
-   |     ^
-
-error[E0277]: `T` doesn't implement `Debug`
-  --> $DIR/generic_duplicate_param_use3.rs:8:18
-   |
-LL | type Two<T, U> = impl Debug;
-   |                  ^^^^^^^^^^ `T` cannot be formatted using `{:?}` because it doesn't implement `Debug`
+   |     ^ `T` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
 help: consider restricting type parameter `T`
    |
 LL | type Two<T: std::fmt::Debug, U> = impl Debug;
    |           +++++++++++++++++
+
+error[E0277]: `U` doesn't implement `Debug`
+  --> $DIR/generic_duplicate_param_use3.rs:16:5
+   |
+LL |     u
+   |     ^ `U` cannot be formatted using `{:?}` because it doesn't implement `Debug`
+   |
+help: consider restricting type parameter `U`
+   |
+LL | type Two<T, U: std::fmt::Debug> = impl Debug;
+   |              +++++++++++++++++
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/type-alias-impl-trait/generic_duplicate_param_use4.rs
+++ b/src/test/ui/type-alias-impl-trait/generic_duplicate_param_use4.rs
@@ -6,8 +6,8 @@ fn main() {}
 
 // test that unused generic parameters are ok
 type Two<T, U> = impl Debug;
-//~^ ERROR `U` doesn't implement `Debug`
 
 fn three<T, U: Debug>(_: T, u: U) -> Two<T, U> {
     u
+    //~^ ERROR `U` doesn't implement `Debug`
 }

--- a/src/test/ui/type-alias-impl-trait/generic_duplicate_param_use4.stderr
+++ b/src/test/ui/type-alias-impl-trait/generic_duplicate_param_use4.stderr
@@ -1,8 +1,8 @@
 error[E0277]: `U` doesn't implement `Debug`
-  --> $DIR/generic_duplicate_param_use4.rs:8:18
+  --> $DIR/generic_duplicate_param_use4.rs:11:5
    |
-LL | type Two<T, U> = impl Debug;
-   |                  ^^^^^^^^^^ `U` cannot be formatted using `{:?}` because it doesn't implement `Debug`
+LL |     u
+   |     ^ `U` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
 help: consider restricting type parameter `U`
    |

--- a/src/test/ui/type-alias-impl-trait/generic_duplicate_param_use5.rs
+++ b/src/test/ui/type-alias-impl-trait/generic_duplicate_param_use5.rs
@@ -6,14 +6,15 @@ fn main() {}
 
 // test that unused generic parameters are ok
 type Two<T, U> = impl Debug;
-//~^ ERROR `T` doesn't implement `Debug`
-//~| ERROR `U` doesn't implement `Debug`
 
 fn two<T: Debug, U: Debug>(t: T, u: U) -> Two<T, U> {
     (t, u)
+    //~^ ERROR `T` doesn't implement `Debug`
+    //~| ERROR `U` doesn't implement `Debug`
 }
 
 fn three<T: Debug, U: Debug>(t: T, u: U) -> Two<T, U> {
     (u, t)
-    //~^ concrete type differs from previous
+    //~^ ERROR `T` doesn't implement `Debug`
+    //~| ERROR `U` doesn't implement `Debug`
 }

--- a/src/test/ui/type-alias-impl-trait/generic_duplicate_param_use5.stderr
+++ b/src/test/ui/type-alias-impl-trait/generic_duplicate_param_use5.stderr
@@ -1,20 +1,8 @@
-error: concrete type differs from previous defining opaque type use
-  --> $DIR/generic_duplicate_param_use5.rs:17:5
-   |
-LL |     (u, t)
-   |     ^^^^^^ expected `(T, U)`, got `(U, T)`
-   |
-note: previous use here
-  --> $DIR/generic_duplicate_param_use5.rs:13:5
+error[E0277]: `T` doesn't implement `Debug`
+  --> $DIR/generic_duplicate_param_use5.rs:11:5
    |
 LL |     (t, u)
-   |     ^^^^^^
-
-error[E0277]: `T` doesn't implement `Debug`
-  --> $DIR/generic_duplicate_param_use5.rs:8:18
-   |
-LL | type Two<T, U> = impl Debug;
-   |                  ^^^^^^^^^^ `T` cannot be formatted using `{:?}` because it doesn't implement `Debug`
+   |     ^^^^^^ `T` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
    = note: required because of the requirements on the impl of `Debug` for `(T, U)`
 help: consider restricting type parameter `T`
@@ -23,10 +11,10 @@ LL | type Two<T: std::fmt::Debug, U> = impl Debug;
    |           +++++++++++++++++
 
 error[E0277]: `U` doesn't implement `Debug`
-  --> $DIR/generic_duplicate_param_use5.rs:8:18
+  --> $DIR/generic_duplicate_param_use5.rs:11:5
    |
-LL | type Two<T, U> = impl Debug;
-   |                  ^^^^^^^^^^ `U` cannot be formatted using `{:?}` because it doesn't implement `Debug`
+LL |     (t, u)
+   |     ^^^^^^ `U` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
    = note: required because of the requirements on the impl of `Debug` for `(T, U)`
 help: consider restricting type parameter `U`
@@ -34,6 +22,30 @@ help: consider restricting type parameter `U`
 LL | type Two<T, U: std::fmt::Debug> = impl Debug;
    |              +++++++++++++++++
 
-error: aborting due to 3 previous errors
+error[E0277]: `U` doesn't implement `Debug`
+  --> $DIR/generic_duplicate_param_use5.rs:17:5
+   |
+LL |     (u, t)
+   |     ^^^^^^ `U` cannot be formatted using `{:?}` because it doesn't implement `Debug`
+   |
+   = note: required because of the requirements on the impl of `Debug` for `(U, T)`
+help: consider restricting type parameter `U`
+   |
+LL | type Two<T, U: std::fmt::Debug> = impl Debug;
+   |              +++++++++++++++++
+
+error[E0277]: `T` doesn't implement `Debug`
+  --> $DIR/generic_duplicate_param_use5.rs:17:5
+   |
+LL |     (u, t)
+   |     ^^^^^^ `T` cannot be formatted using `{:?}` because it doesn't implement `Debug`
+   |
+   = note: required because of the requirements on the impl of `Debug` for `(U, T)`
+help: consider restricting type parameter `T`
+   |
+LL | type Two<T: std::fmt::Debug, U> = impl Debug;
+   |           +++++++++++++++++
+
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/type-alias-impl-trait/generic_duplicate_param_use6.rs
+++ b/src/test/ui/type-alias-impl-trait/generic_duplicate_param_use6.rs
@@ -6,13 +6,14 @@ fn main() {}
 
 // test that unused generic parameters are ok
 type Two<T, U> = impl Debug;
-//~^ ERROR `T` doesn't implement `Debug`
 
 fn two<T: Copy + Debug, U: Debug>(t: T, u: U) -> Two<T, U> {
     (t, t)
+    //~^ ERROR `T` doesn't implement `Debug`
 }
 
 fn three<T: Copy + Debug, U: Debug>(t: T, u: U) -> Two<T, U> {
     (u, t)
-    //~^ ERROR concrete type differs from previous
+    //~^ ERROR `T` doesn't implement `Debug`
+    //~| ERROR `U` doesn't implement `Debug`
 }

--- a/src/test/ui/type-alias-impl-trait/generic_duplicate_param_use6.stderr
+++ b/src/test/ui/type-alias-impl-trait/generic_duplicate_param_use6.stderr
@@ -1,20 +1,8 @@
-error: concrete type differs from previous defining opaque type use
-  --> $DIR/generic_duplicate_param_use6.rs:16:5
-   |
-LL |     (u, t)
-   |     ^^^^^^ expected `(T, T)`, got `(U, T)`
-   |
-note: previous use here
-  --> $DIR/generic_duplicate_param_use6.rs:12:5
+error[E0277]: `T` doesn't implement `Debug`
+  --> $DIR/generic_duplicate_param_use6.rs:11:5
    |
 LL |     (t, t)
-   |     ^^^^^^
-
-error[E0277]: `T` doesn't implement `Debug`
-  --> $DIR/generic_duplicate_param_use6.rs:8:18
-   |
-LL | type Two<T, U> = impl Debug;
-   |                  ^^^^^^^^^^ `T` cannot be formatted using `{:?}` because it doesn't implement `Debug`
+   |     ^^^^^^ `T` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
    = note: required because of the requirements on the impl of `Debug` for `(T, T)`
 help: consider restricting type parameter `T`
@@ -22,6 +10,30 @@ help: consider restricting type parameter `T`
 LL | type Two<T: std::fmt::Debug, U> = impl Debug;
    |           +++++++++++++++++
 
-error: aborting due to 2 previous errors
+error[E0277]: `U` doesn't implement `Debug`
+  --> $DIR/generic_duplicate_param_use6.rs:16:5
+   |
+LL |     (u, t)
+   |     ^^^^^^ `U` cannot be formatted using `{:?}` because it doesn't implement `Debug`
+   |
+   = note: required because of the requirements on the impl of `Debug` for `(U, T)`
+help: consider restricting type parameter `U`
+   |
+LL | type Two<T, U: std::fmt::Debug> = impl Debug;
+   |              +++++++++++++++++
+
+error[E0277]: `T` doesn't implement `Debug`
+  --> $DIR/generic_duplicate_param_use6.rs:16:5
+   |
+LL |     (u, t)
+   |     ^^^^^^ `T` cannot be formatted using `{:?}` because it doesn't implement `Debug`
+   |
+   = note: required because of the requirements on the impl of `Debug` for `(U, T)`
+help: consider restricting type parameter `T`
+   |
+LL | type Two<T: std::fmt::Debug, U> = impl Debug;
+   |           +++++++++++++++++
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/type-alias-impl-trait/generic_duplicate_param_use8.rs
+++ b/src/test/ui/type-alias-impl-trait/generic_duplicate_param_use8.rs
@@ -5,13 +5,13 @@ use std::fmt::Debug;
 fn main() {}
 
 type Two<T, U> = impl Debug;
-//~^ ERROR `T` doesn't implement `Debug`
 
 fn two<T: Debug, U: Debug>(t: T, _: U) -> Two<T, U> {
     (t, 4u32)
+    //~^ ERROR `T` doesn't implement `Debug`
 }
 
 fn three<T: Debug, U: Debug>(_: T, u: U) -> Two<T, U> {
     (u, 4u32)
-    //~^ concrete type differs from previous
+    //~^ ERROR `U` doesn't implement `Debug`
 }

--- a/src/test/ui/type-alias-impl-trait/generic_duplicate_param_use8.stderr
+++ b/src/test/ui/type-alias-impl-trait/generic_duplicate_param_use8.stderr
@@ -1,26 +1,26 @@
-error: concrete type differs from previous defining opaque type use
-  --> $DIR/generic_duplicate_param_use8.rs:15:5
-   |
-LL |     (u, 4u32)
-   |     ^^^^^^^^^ expected `(T, u32)`, got `(U, u32)`
-   |
-note: previous use here
-  --> $DIR/generic_duplicate_param_use8.rs:11:5
+error[E0277]: `T` doesn't implement `Debug`
+  --> $DIR/generic_duplicate_param_use8.rs:10:5
    |
 LL |     (t, 4u32)
-   |     ^^^^^^^^^
-
-error[E0277]: `T` doesn't implement `Debug`
-  --> $DIR/generic_duplicate_param_use8.rs:7:18
-   |
-LL | type Two<T, U> = impl Debug;
-   |                  ^^^^^^^^^^ `T` cannot be formatted using `{:?}` because it doesn't implement `Debug`
+   |     ^^^^^^^^^ `T` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
    = note: required because of the requirements on the impl of `Debug` for `(T, u32)`
 help: consider restricting type parameter `T`
    |
 LL | type Two<T: std::fmt::Debug, U> = impl Debug;
    |           +++++++++++++++++
+
+error[E0277]: `U` doesn't implement `Debug`
+  --> $DIR/generic_duplicate_param_use8.rs:15:5
+   |
+LL |     (u, 4u32)
+   |     ^^^^^^^^^ `U` cannot be formatted using `{:?}` because it doesn't implement `Debug`
+   |
+   = note: required because of the requirements on the impl of `Debug` for `(U, u32)`
+help: consider restricting type parameter `U`
+   |
+LL | type Two<T, U: std::fmt::Debug> = impl Debug;
+   |              +++++++++++++++++
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/type-alias-impl-trait/generic_duplicate_param_use9.rs
+++ b/src/test/ui/type-alias-impl-trait/generic_duplicate_param_use9.rs
@@ -5,9 +5,6 @@ use std::fmt::Debug;
 fn main() {}
 
 type Two<A, B> = impl Debug;
-//~^ ERROR the trait bound `A: Foo` is not satisfied
-//~| ERROR `A` doesn't implement `Debug`
-//~| ERROR `B` doesn't implement `Debug`
 
 trait Foo {
     type Bar: Debug;
@@ -16,8 +13,13 @@ trait Foo {
 
 fn two<T: Debug + Foo, U: Debug>(t: T, u: U) -> Two<T, U> {
     (t, u, T::BAR)
+    //~^ ERROR the trait bound `A: Foo` is not satisfied
+    //~| ERROR `A` doesn't implement `Debug`
+    //~| ERROR `B` doesn't implement `Debug`
 }
 
 fn three<T: Debug, U: Debug>(t: T, u: U) -> Two<T, U> {
-    (t, u, 42) //~ ERROR concrete type differs from previous
+    (t, u, 42)
+    //~^ ERROR `A` doesn't implement `Debug`
+    //~| ERROR `B` doesn't implement `Debug`
 }

--- a/src/test/ui/type-alias-impl-trait/generic_duplicate_param_use9.stderr
+++ b/src/test/ui/type-alias-impl-trait/generic_duplicate_param_use9.stderr
@@ -1,20 +1,8 @@
-error: concrete type differs from previous defining opaque type use
-  --> $DIR/generic_duplicate_param_use9.rs:22:5
-   |
-LL |     (t, u, 42)
-   |     ^^^^^^^^^^ expected `(A, B, <A as Foo>::Bar)`, got `(A, B, i32)`
-   |
-note: previous use here
-  --> $DIR/generic_duplicate_param_use9.rs:18:5
+error[E0277]: the trait bound `A: Foo` is not satisfied
+  --> $DIR/generic_duplicate_param_use9.rs:15:5
    |
 LL |     (t, u, T::BAR)
-   |     ^^^^^^^^^^^^^^
-
-error[E0277]: the trait bound `A: Foo` is not satisfied
-  --> $DIR/generic_duplicate_param_use9.rs:7:18
-   |
-LL | type Two<A, B> = impl Debug;
-   |                  ^^^^^^^^^^ the trait `Foo` is not implemented for `A`
+   |     ^^^^^^^^^^^^^^ the trait `Foo` is not implemented for `A`
    |
 help: consider restricting type parameter `A`
    |
@@ -22,10 +10,10 @@ LL | type Two<A: Foo, B> = impl Debug;
    |           +++++
 
 error[E0277]: `A` doesn't implement `Debug`
-  --> $DIR/generic_duplicate_param_use9.rs:7:18
+  --> $DIR/generic_duplicate_param_use9.rs:15:5
    |
-LL | type Two<A, B> = impl Debug;
-   |                  ^^^^^^^^^^ `A` cannot be formatted using `{:?}` because it doesn't implement `Debug`
+LL |     (t, u, T::BAR)
+   |     ^^^^^^^^^^^^^^ `A` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
    = note: required because of the requirements on the impl of `Debug` for `(A, B, _)`
 help: consider restricting type parameter `A`
@@ -34,10 +22,10 @@ LL | type Two<A: std::fmt::Debug, B> = impl Debug;
    |           +++++++++++++++++
 
 error[E0277]: `B` doesn't implement `Debug`
-  --> $DIR/generic_duplicate_param_use9.rs:7:18
+  --> $DIR/generic_duplicate_param_use9.rs:15:5
    |
-LL | type Two<A, B> = impl Debug;
-   |                  ^^^^^^^^^^ `B` cannot be formatted using `{:?}` because it doesn't implement `Debug`
+LL |     (t, u, T::BAR)
+   |     ^^^^^^^^^^^^^^ `B` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
    = note: required because of the requirements on the impl of `Debug` for `(A, B, _)`
 help: consider restricting type parameter `B`
@@ -45,6 +33,30 @@ help: consider restricting type parameter `B`
 LL | type Two<A, B: std::fmt::Debug> = impl Debug;
    |              +++++++++++++++++
 
-error: aborting due to 4 previous errors
+error[E0277]: `A` doesn't implement `Debug`
+  --> $DIR/generic_duplicate_param_use9.rs:22:5
+   |
+LL |     (t, u, 42)
+   |     ^^^^^^^^^^ `A` cannot be formatted using `{:?}` because it doesn't implement `Debug`
+   |
+   = note: required because of the requirements on the impl of `Debug` for `(A, B, i32)`
+help: consider restricting type parameter `A`
+   |
+LL | type Two<A: std::fmt::Debug, B> = impl Debug;
+   |           +++++++++++++++++
+
+error[E0277]: `B` doesn't implement `Debug`
+  --> $DIR/generic_duplicate_param_use9.rs:22:5
+   |
+LL |     (t, u, 42)
+   |     ^^^^^^^^^^ `B` cannot be formatted using `{:?}` because it doesn't implement `Debug`
+   |
+   = note: required because of the requirements on the impl of `Debug` for `(A, B, i32)`
+help: consider restricting type parameter `B`
+   |
+LL | type Two<A, B: std::fmt::Debug> = impl Debug;
+   |              +++++++++++++++++
+
+error: aborting due to 5 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/type-alias-impl-trait/issue-52843.rs
+++ b/src/test/ui/type-alias-impl-trait/issue-52843.rs
@@ -1,11 +1,11 @@
 #![feature(type_alias_impl_trait)]
 
 type Foo<T> = impl Default;
-//~^ ERROR: the trait bound `T: Default` is not satisfied
 
 #[allow(unused)]
 fn foo<T: Default>(t: T) -> Foo<T> {
     t
+    //~^ ERROR: the trait bound `T: Default` is not satisfied
 }
 
 struct NotDefault;

--- a/src/test/ui/type-alias-impl-trait/issue-52843.stderr
+++ b/src/test/ui/type-alias-impl-trait/issue-52843.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the trait bound `T: Default` is not satisfied
-  --> $DIR/issue-52843.rs:3:15
+  --> $DIR/issue-52843.rs:7:5
    |
-LL | type Foo<T> = impl Default;
-   |               ^^^^^^^^^^^^ the trait `Default` is not implemented for `T`
+LL |     t
+   |     ^ the trait `Default` is not implemented for `T`
    |
 help: consider restricting type parameter `T`
    |

--- a/src/test/ui/type-alias-impl-trait/issue-60564.rs
+++ b/src/test/ui/type-alias-impl-trait/issue-60564.rs
@@ -19,6 +19,7 @@ where
     fn iter_bits(self, n: u8) -> Self::BitsIter {
         (0u8..n).rev().map(move |shift| ((self >> T::from(shift)) & T::from(1)).try_into().unwrap())
         //~^ ERROR non-defining opaque type use in defining scope
+        //~| ERROR type mismatch resolving
     }
 }
 

--- a/src/test/ui/type-alias-impl-trait/issue-60564.stderr
+++ b/src/test/ui/type-alias-impl-trait/issue-60564.stderr
@@ -1,3 +1,16 @@
+error[E0271]: type mismatch resolving `<[closure@$DIR/issue-60564.rs:20:28: 20:100] as FnOnce<(u8,)>>::Output == I`
+  --> $DIR/issue-60564.rs:20:9
+   |
+LL | type IterBitsIter<T, E, I> = impl std::iter::Iterator<Item = I>;
+   |                         - this type parameter
+...
+LL |         (0u8..n).rev().map(move |shift| ((self >> T::from(shift)) & T::from(1)).try_into().unwrap())
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `u8`, found type parameter `I`
+   |
+   = note:        expected type `u8`
+           found type parameter `I`
+   = note: required because of the requirements on the impl of `Iterator` for `Map<Rev<std::ops::Range<u8>>, [closure@$DIR/issue-60564.rs:20:28: 20:100]>`
+
 error: non-defining opaque type use in defining scope
   --> $DIR/issue-60564.rs:20:9
    |
@@ -10,5 +23,6 @@ note: used non-generic type `u8` for generic parameter
 LL | type IterBitsIter<T, E, I> = impl std::iter::Iterator<Item = I>;
    |                         ^
 
-error: aborting due to previous error
+error: aborting due to 2 previous errors
 
+For more information about this error, try `rustc --explain E0271`.

--- a/src/test/ui/type-alias-impl-trait/issue-68368-non-defining-use.rs
+++ b/src/test/ui/type-alias-impl-trait/issue-68368-non-defining-use.rs
@@ -8,6 +8,7 @@ type Alias<'a, U> = impl Trait<U>;
 
 fn f<'a>() -> Alias<'a, ()> {}
 //~^ ERROR non-defining opaque type use in defining scope
+//~| ERROR the trait bound `(): Trait<U>` is not satisfied
 
 fn main() {}
 

--- a/src/test/ui/type-alias-impl-trait/issue-68368-non-defining-use.stderr
+++ b/src/test/ui/type-alias-impl-trait/issue-68368-non-defining-use.stderr
@@ -1,3 +1,14 @@
+error[E0277]: the trait bound `(): Trait<U>` is not satisfied
+  --> $DIR/issue-68368-non-defining-use.rs:9:29
+   |
+LL | fn f<'a>() -> Alias<'a, ()> {}
+   |                             ^^ the trait `Trait<U>` is not implemented for `()`
+   |
+help: consider introducing a `where` bound, but there might be an alternative better way to express this requirement
+   |
+LL | type Alias<'a, U> = impl Trait<U> where (): Trait<U>;
+   |                                   ++++++++++++++++++
+
 error: non-defining opaque type use in defining scope
   --> $DIR/issue-68368-non-defining-use.rs:9:29
    |
@@ -10,5 +21,6 @@ note: used non-generic type `()` for generic parameter
 LL | type Alias<'a, U> = impl Trait<U>;
    |                ^
 
-error: aborting due to previous error
+error: aborting due to 2 previous errors
 
+For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/type-alias-impl-trait/issue-89686.rs
+++ b/src/test/ui/type-alias-impl-trait/issue-89686.rs
@@ -5,7 +5,6 @@
 use std::future::Future;
 
 type G<'a, T> = impl Future<Output = ()>;
-//~^ ERROR: the trait bound `T: Trait` is not satisfied
 
 trait Trait {
     type F: Future<Output = ()>;
@@ -17,6 +16,7 @@ trait Trait {
         Self: Sized,
     {
         async move { self.f().await }
+        //~^ ERROR: the trait bound `T: Trait` is not satisfied
     }
 }
 

--- a/src/test/ui/type-alias-impl-trait/issue-89686.stderr
+++ b/src/test/ui/type-alias-impl-trait/issue-89686.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the trait bound `T: Trait` is not satisfied
-  --> $DIR/issue-89686.rs:7:17
+  --> $DIR/issue-89686.rs:18:9
    |
-LL | type G<'a, T> = impl Future<Output = ()>;
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Trait` is not implemented for `T`
+LL |         async move { self.f().await }
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Trait` is not implemented for `T`
    |
 help: consider restricting type parameter `T`
    |

--- a/src/test/ui/type-alias-impl-trait/not_a_defining_use.rs
+++ b/src/test/ui/type-alias-impl-trait/not_a_defining_use.rs
@@ -5,10 +5,10 @@ use std::fmt::Debug;
 fn main() {}
 
 type Two<T, U> = impl Debug;
-//~^ ERROR `T` doesn't implement `Debug`
 
 fn three<T: Debug, U>(t: T) -> Two<T, U> {
     (t, 5i8)
+    //~^ ERROR `T` doesn't implement `Debug`
 }
 
 trait Bar {
@@ -23,7 +23,8 @@ impl Bar for u32 {
 
 fn four<T: Debug, U: Bar>(t: T) -> Two<T, U> {
     (t, <U as Bar>::FOO)
-    //~^ ERROR concrete type differs from previous
+    //~^ ERROR `U: Bar` is not satisfied
+    //~| ERROR `T` doesn't implement `Debug`
 }
 
 fn is_sync<T: Sync>() {}

--- a/src/test/ui/type-alias-impl-trait/not_a_defining_use.stderr
+++ b/src/test/ui/type-alias-impl-trait/not_a_defining_use.stderr
@@ -1,20 +1,8 @@
-error: concrete type differs from previous defining opaque type use
-  --> $DIR/not_a_defining_use.rs:25:5
-   |
-LL |     (t, <U as Bar>::FOO)
-   |     ^^^^^^^^^^^^^^^^^^^^ expected `(T, i8)`, got `(T, <U as Bar>::Blub)`
-   |
-note: previous use here
-  --> $DIR/not_a_defining_use.rs:11:5
+error[E0277]: `T` doesn't implement `Debug`
+  --> $DIR/not_a_defining_use.rs:10:5
    |
 LL |     (t, 5i8)
-   |     ^^^^^^^^
-
-error[E0277]: `T` doesn't implement `Debug`
-  --> $DIR/not_a_defining_use.rs:7:18
-   |
-LL | type Two<T, U> = impl Debug;
-   |                  ^^^^^^^^^^ `T` cannot be formatted using `{:?}` because it doesn't implement `Debug`
+   |     ^^^^^^^^ `T` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
    = note: required because of the requirements on the impl of `Debug` for `(T, i8)`
 help: consider restricting type parameter `T`
@@ -22,6 +10,29 @@ help: consider restricting type parameter `T`
 LL | type Two<T: std::fmt::Debug, U> = impl Debug;
    |           +++++++++++++++++
 
-error: aborting due to 2 previous errors
+error[E0277]: the trait bound `U: Bar` is not satisfied
+  --> $DIR/not_a_defining_use.rs:25:5
+   |
+LL |     (t, <U as Bar>::FOO)
+   |     ^^^^^^^^^^^^^^^^^^^^ the trait `Bar` is not implemented for `U`
+   |
+help: consider restricting type parameter `U`
+   |
+LL | type Two<T, U: Bar> = impl Debug;
+   |              +++++
+
+error[E0277]: `T` doesn't implement `Debug`
+  --> $DIR/not_a_defining_use.rs:25:5
+   |
+LL |     (t, <U as Bar>::FOO)
+   |     ^^^^^^^^^^^^^^^^^^^^ `T` cannot be formatted using `{:?}` because it doesn't implement `Debug`
+   |
+   = note: required because of the requirements on the impl of `Debug` for `(T, _)`
+help: consider restricting type parameter `T`
+   |
+LL | type Two<T: std::fmt::Debug, U> = impl Debug;
+   |           +++++++++++++++++
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/type-alias-impl-trait/underconstrained_generic.rs
+++ b/src/test/ui/type-alias-impl-trait/underconstrained_generic.rs
@@ -17,10 +17,10 @@ impl<X: Trait> ProofForConversion<X> for () {
 }
 
 type Converter<T> = impl ProofForConversion<T>;
-//~^ ERROR the trait bound `T: Trait` is not satisfied
 
 fn _defining_use<T: Trait>() -> Converter<T> {
     ()
+    //~^ ERROR the trait bound `T: Trait` is not satisfied
 }
 
 

--- a/src/test/ui/type-alias-impl-trait/underconstrained_generic.stderr
+++ b/src/test/ui/type-alias-impl-trait/underconstrained_generic.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the trait bound `T: Trait` is not satisfied
-  --> $DIR/underconstrained_generic.rs:19:21
+  --> $DIR/underconstrained_generic.rs:22:5
    |
-LL | type Converter<T> = impl ProofForConversion<T>;
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Trait` is not implemented for `T`
+LL |     ()
+   |     ^^ the trait `Trait` is not implemented for `T`
    |
 note: required because of the requirements on the impl of `ProofForConversion<T>` for `()`
   --> $DIR/underconstrained_generic.rs:13:16


### PR DESCRIPTION
work towards #90409 . We'll need to look into closure and generator bodies of closures and generators nested inside the hidden type in order to fix that. In hindsight this PR is not necessary for that, but it may be a bit easier with it and we'll get better diagnostics from it on its own.