### PR TITLE
Add `track_caller` to `DefId::expect_local()`

### DIFF
--- a/compiler/rustc_span/src/def_id.rs
+++ b/compiler/rustc_span/src/def_id.rs
@@ -279,6 +279,7 @@ impl DefId {
     }
 
     #[inline]
+    #[track_caller]
     pub fn expect_local(self) -> LocalDefId {
         self.as_local().unwrap_or_else(|| panic!("DefId::expect_local: `{:?}` isn't local", self))
     }


### PR DESCRIPTION
Suggested in https://github.com/rust-lang/rust/issues/96738#issuecomment-1118961888.
`DefId::expect_local()` often causes ICEs (panics) and should be a good candidate to add `track_caller`.