### PR TITLE
Enable compiler-docs by default for `compiler`, `codegen`, and `tools` profiles

### DIFF
--- a/src/bootstrap/defaults/config.codegen.toml
+++ b/src/bootstrap/defaults/config.codegen.toml
@@ -1,4 +1,8 @@
 # These defaults are meant for contributors to the compiler who modify codegen or LLVM
+[build]
+# Contributors working on the compiler will probably expect compiler docs to be generated.
+compiler-docs = true
+
 [llvm]
 # This enables debug-assertions in LLVM,
 # catching logic errors in codegen much earlier in the process.

--- a/src/bootstrap/defaults/config.compiler.toml
+++ b/src/bootstrap/defaults/config.compiler.toml
@@ -1,4 +1,8 @@
 # These defaults are meant for contributors to the compiler who do not modify codegen or LLVM
+[build]
+# Contributors working on the compiler will probably expect compiler docs to be generated.
+compiler-docs = true
+
 [rust]
 # This enables `RUSTC_LOG=debug`, avoiding confusing situations
 # where adding `debug!()` appears to do nothing.

--- a/src/bootstrap/defaults/config.tools.toml
+++ b/src/bootstrap/defaults/config.tools.toml
@@ -14,6 +14,8 @@ download-rustc = "if-unchanged"
 [build]
 # Document with the in-tree rustdoc by default, since `download-rustc` makes it quick to compile.
 doc-stage = 2
+# Contributors working on tools will probably expect compiler docs to be generated, so they can figure out how to use the API.
+compiler-docs = true
 
 [llvm]
 # Will download LLVM from CI if available on your platform.


### PR DESCRIPTION
I had this overridden locally for a while and realized just now it should probably just be a default.