### PR TITLE
Don't constantly rebuild clippy on `x test src/tools/clippy`.

### DIFF
--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -664,8 +664,6 @@ impl Step for Clippy {
             &[],
         );
 
-        // clippy tests need to know about the stage sysroot
-        cargo.env("SYSROOT", builder.sysroot(compiler));
         cargo.env("RUSTC_TEST_SUITE", builder.rustc(compiler));
         cargo.env("RUSTC_LIB_PATH", builder.rustc_libdir(compiler));
         let host_libs = builder.stage_out(compiler, Mode::ToolRustc).join(builder.cargo_dir());

--- a/src/bootstrap/tool.rs
+++ b/src/bootstrap/tool.rs
@@ -250,6 +250,10 @@ pub fn prepare_tool_cargo(
         }
     }
 
+    // clippy tests need to know about the stage sysroot. Set them consistently while building to
+    // avoid rebuilding when running tests.
+    cargo.env("SYSROOT", builder.sysroot(compiler));
+
     // if tools are using lzma we want to force the build script to build its
     // own copy
     cargo.env("LZMA_API_STATIC", "1");


### PR DESCRIPTION
This happened because the `SYSROOT` variable was set for `x test`, but not `x build`.
Set it consistently for both to avoid unnecessary rebuilds.

This is a very small step towards https://github.com/rust-lang/rust/issues/76495.