### PR TITLE
bootstrap: bsd platform flags for split debuginfo

### DIFF
--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -1405,8 +1405,12 @@ impl<'a> Builder<'a> {
         // FIXME(davidtwco): #[cfg(not(bootstrap))] - #95612 needs to be in the bootstrap compiler
         // for this conditional to be removed.
         if !target.contains("windows") || compiler.stage >= 1 {
-            if target.contains("linux") || target.contains("windows") || target.contains("openbsd")
-            {
+            let needs_unstable_opts = target.contains("linux")
+                || target.contains("windows")
+                || target.contains("bsd")
+                || target.contains("dragonfly");
+
+            if needs_unstable_opts {
                 rustflags.arg("-Zunstable-options");
             }
             match self.config.rust_split_debuginfo {


### PR DESCRIPTION
Addresses https://github.com/rust-lang/rust/pull/96597#issuecomment-1118905025.

Bootstrap currently provides `-Zunstable-options` for OpenBSD when using split debuginfo - this commit provides it for all BSD targets.

We should probably work out a better way of handling the stability of the split debuginfo flag - all options for the flag are unstable but one of them is the default for each platform already.

cc @m-ou-se 
r? @Mark-Simulacrum 