### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/compiler/rustc_span/src/def_id.rs
+++ b/compiler/rustc_span/src/def_id.rs
@@ -279,6 +279,7 @@ impl DefId {
     }
 
     #[inline]
+    #[track_caller]
     pub fn expect_local(self) -> LocalDefId {
         self.as_local().unwrap_or_else(|| panic!("DefId::expect_local: `{:?}` isn't local", self))
     }

--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -981,7 +981,7 @@ extern "rust-intrinsic" {
     ///
     /// Turning a pointer into a `usize`:
     ///
-    /// ```
+    /// ```no_run
     /// let ptr = &0;
     /// let ptr_num_transmute = unsafe {
     ///     std::mem::transmute::<&i32, usize>(ptr)

--- a/library/core/src/ptr/const_ptr.rs
+++ b/library/core/src/ptr/const_ptr.rs
@@ -518,7 +518,7 @@ impl<T: ?Sized> *const T {
     }
 
     /// Calculates the distance between two pointers. The returned value is in
-    /// units of T: the distance in bytes is divided by `mem::size_of::<T>()`.
+    /// units of T: the distance in bytes divided by `mem::size_of::<T>()`.
     ///
     /// This function is the inverse of [`offset`].
     ///

--- a/library/core/src/ptr/mut_ptr.rs
+++ b/library/core/src/ptr/mut_ptr.rs
@@ -696,7 +696,7 @@ impl<T: ?Sized> *mut T {
     }
 
     /// Calculates the distance between two pointers. The returned value is in
-    /// units of T: the distance in bytes is divided by `mem::size_of::<T>()`.
+    /// units of T: the distance in bytes divided by `mem::size_of::<T>()`.
     ///
     /// This function is the inverse of [`offset`].
     ///

--- a/library/std/src/ffi/os_str.rs
+++ b/library/std/src/ffi/os_str.rs
@@ -1222,6 +1222,23 @@ impl OsStr {
     }
 }
 
+#[unstable(feature = "slice_concat_ext", issue = "27747")]
+impl<S: Borrow<OsStr>> alloc::slice::Join<&OsStr> for [S] {
+    type Output = OsString;
+
+    fn join(slice: &Self, sep: &OsStr) -> OsString {
+        let Some(first) = slice.first() else {
+            return OsString::new();
+        };
+        let first = first.borrow().to_owned();
+        slice[1..].iter().fold(first, |mut a, b| {
+            a.push(sep);
+            a.push(b.borrow());
+            a
+        })
+    }
+}
+
 #[stable(feature = "rust1", since = "1.0.0")]
 impl Borrow<OsStr> for OsString {
     #[inline]

--- a/library/std/src/ffi/os_str/tests.rs
+++ b/library/std/src/ffi/os_str/tests.rs
@@ -85,6 +85,20 @@ fn test_os_string_reserve_exact() {
 }
 
 #[test]
+fn test_os_string_join() {
+    let strings = [OsStr::new("hello"), OsStr::new("dear"), OsStr::new("world")];
+    assert_eq!("hello", strings[..1].join(OsStr::new(" ")));
+    assert_eq!("hello dear world", strings.join(OsStr::new(" ")));
+    assert_eq!("hellodearworld", strings.join(OsStr::new("")));
+    assert_eq!("hello.\n dear.\n world", strings.join(OsStr::new(".\n ")));
+
+    assert_eq!("dear world", strings[1..].join(&OsString::from(" ")));
+
+    let strings_abc = [OsString::from("a"), OsString::from("b"), OsString::from("c")];
+    assert_eq!("a b c", strings_abc.join(OsStr::new(" ")));
+}
+
+#[test]
 fn test_os_string_default() {
     let os_string: OsString = Default::default();
     assert_eq!("", &os_string);

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -241,6 +241,7 @@
 #![feature(intra_doc_pointers)]
 #![feature(lang_items)]
 #![feature(let_chains)]
+#![feature(let_else)]
 #![feature(linkage)]
 #![feature(min_specialization)]
 #![feature(must_not_suspend)]
@@ -300,6 +301,7 @@
 #![feature(toowned_clone_into)]
 #![feature(try_reserve_kind)]
 #![feature(vec_into_raw_parts)]
+#![feature(slice_concat_trait)]
 //
 // Library features (unwind):
 #![feature(panic_unwind)]

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1401,6 +1401,18 @@ pre.rust {
 	cursor: pointer;
 }
 
+@keyframes rotating {
+	from {
+		transform: rotate(0deg);
+	}
+	to {
+		transform: rotate(360deg);
+	}
+}
+#settings-menu.rotate img {
+	animation: rotating 2s linear infinite;
+}
+
 #help-button {
 	font-family: "Fira Sans", Arial, sans-serif;
 	text-align: center;

--- a/src/librustdoc/html/static/js/main.js
+++ b/src/librustdoc/html/static/js/main.js
@@ -300,8 +300,8 @@ function loadCss(cssFileName) {
         document.head.append(script);
     }
 
-
     getSettingsButton().onclick = event => {
+        addClass(getSettingsButton(), "rotate");
         event.preventDefault();
         loadScript(window.settingsJS);
     };

--- a/src/librustdoc/html/static/js/main.js
+++ b/src/librustdoc/html/static/js/main.js
@@ -303,6 +303,9 @@ function loadCss(cssFileName) {
 
     getSettingsButton().onclick = event => {
         event.preventDefault();
+        // Sending request for the CSS and the JS files at the same time so it will
+        // hopefully be loaded when the JS will generate the settings content.
+        loadCss("settings");
         loadScript(window.settingsJS);
     };
 

--- a/src/librustdoc/html/static/js/settings.js
+++ b/src/librustdoc/html/static/js/settings.js
@@ -3,7 +3,7 @@
 /* eslint prefer-const: "error" */
 /* eslint prefer-arrow-callback: "error" */
 // Local js definitions:
-/* global getSettingValue, getVirtualKey, updateLocalStorage, updateSystemTheme, loadCss */
+/* global getSettingValue, getVirtualKey, updateLocalStorage, updateSystemTheme */
 /* global addClass, removeClass, onEach, onEachLazy, NOT_DISPLAYED_ID */
 /* global MAIN_ID, getVar, getSettingsButton, switchDisplayedElement, getNotDisplayedElem */
 
@@ -206,9 +206,6 @@
                 "default": false,
             },
         ];
-
-        // First, we add the settings.css file.
-        loadCss("settings");
 
         // Then we build the DOM.
         const el = document.createElement("section");

--- a/src/librustdoc/html/static/js/settings.js
+++ b/src/librustdoc/html/static/js/settings.js
@@ -272,5 +272,6 @@
         if (!isSettingsPage) {
             switchDisplayedElement(settingsMenu);
         }
+        removeClass(getSettingsButton(), "rotate");
     }, 0);
 })();

--- a/src/test/ui/lifetimes/issue-64173-unused-lifetimes.rs
+++ b/src/test/ui/lifetimes/issue-64173-unused-lifetimes.rs
@@ -1,0 +1,19 @@
+use std::mem::size_of;
+
+struct Foo<'s> { //~ ERROR: parameter `'s` is never used
+    array: [(); size_of::<&Self>()],
+    //~^ ERROR: generic `Self` types are currently not permitted in anonymous constants
+}
+
+// The below is taken from https://github.com/rust-lang/rust/issues/66152#issuecomment-550275017
+// as the root cause seems the same.
+
+const fn foo<T>() -> usize {
+    0
+}
+
+struct Bar<'a> { //~ ERROR: parameter `'a` is never used
+    beta: [(); foo::<&'a ()>()], //~ ERROR: a non-static lifetime is not allowed in a `const`
+}
+
+fn main() {}

--- a/src/test/ui/lifetimes/issue-64173-unused-lifetimes.stderr
+++ b/src/test/ui/lifetimes/issue-64173-unused-lifetimes.stderr
@@ -1,0 +1,35 @@
+error[E0658]: a non-static lifetime is not allowed in a `const`
+  --> $DIR/issue-64173-unused-lifetimes.rs:16:23
+   |
+LL |     beta: [(); foo::<&'a ()>()],
+   |                       ^^
+   |
+   = note: see issue #76560 <https://github.com/rust-lang/rust/issues/76560> for more information
+   = help: add `#![feature(generic_const_exprs)]` to the crate attributes to enable
+
+error: generic `Self` types are currently not permitted in anonymous constants
+  --> $DIR/issue-64173-unused-lifetimes.rs:4:28
+   |
+LL |     array: [(); size_of::<&Self>()],
+   |                            ^^^^
+
+error[E0392]: parameter `'s` is never used
+  --> $DIR/issue-64173-unused-lifetimes.rs:3:12
+   |
+LL | struct Foo<'s> {
+   |            ^^ unused parameter
+   |
+   = help: consider removing `'s`, referring to it in a field, or using a marker such as `PhantomData`
+
+error[E0392]: parameter `'a` is never used
+  --> $DIR/issue-64173-unused-lifetimes.rs:15:12
+   |
+LL | struct Bar<'a> {
+   |            ^^ unused parameter
+   |
+   = help: consider removing `'a`, referring to it in a field, or using a marker such as `PhantomData`
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0392, E0658.
+For more information about an error, try `rustc --explain E0392`.


### PR DESCRIPTION
Successful merges:

 - #96174 (mark ptr-int-transmute test as no_run)
 - #96639 (Fix typo in `offset_from` documentation)
 - #96704 (Add rotation animation on settings button when loading)
 - #96730 (Add a regression test for #64173 and #66152)
 - #96741 (Improve settings loading strategy)
 - #96744 (Implement [OsStr]::join)
 - #96747 (Add `track_caller` to `DefId::expect_local()`)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=96174,96639,96704,96730,96741,96744,96747)
<!-- homu-ignore:end -->