### PR TITLE
diagnostics: port more diagnostics to derive + add support for `Vec` fields

### DIFF
--- a/compiler/rustc_error_messages/locales/en-US/typeck.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/typeck.ftl
@@ -90,3 +90,6 @@ typeck-add-return-type-missing-here = a return type might be missing here
 typeck-expected-default-return-type = expected `()` because of default return type
 
 typeck-expected-return-type = expected `{$expected}` because of return type
+
+typeck-unconstrained-opaque-type = unconstrained opaque type
+    .note = `{$name}` must be used in combination with a concrete type within the same module

--- a/compiler/rustc_error_messages/locales/en-US/typeck.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/typeck.ftl
@@ -93,3 +93,11 @@ typeck-expected-return-type = expected `{$expected}` because of return type
 
 typeck-unconstrained-opaque-type = unconstrained opaque type
     .note = `{$name}` must be used in combination with a concrete type within the same module
+
+typeck-explicit-generic-args-with-impl-trait =
+    cannot provide explicit generic arguments when `impl Trait` is used in argument position
+    .label = explicit generic argument not allowed
+    .note = see issue #83701 <https://github.com/rust-lang/rust/issues/83701> for more information
+
+typeck-explicit-generic-args-with-impl-trait-feature =
+    add `#![feature(explicit_generic_args_with_impl_trait)]` to the crate attributes to enable

--- a/compiler/rustc_session/src/parse.rs
+++ b/compiler/rustc_session/src/parse.rs
@@ -289,12 +289,26 @@ impl ParseSess {
         self.proc_macro_quoted_spans.lock().clone()
     }
 
+    pub fn create_err<'a>(
+        &'a self,
+        err: impl SessionDiagnostic<'a>,
+    ) -> DiagnosticBuilder<'a, ErrorGuaranteed> {
+        err.into_diagnostic(self)
+    }
+
     pub fn emit_err<'a>(&'a self, err: impl SessionDiagnostic<'a>) -> ErrorGuaranteed {
-        err.into_diagnostic(self).emit()
+        self.create_err(err).emit()
+    }
+
+    pub fn create_warning<'a>(
+        &'a self,
+        warning: impl SessionDiagnostic<'a, ()>,
+    ) -> DiagnosticBuilder<'a, ()> {
+        warning.into_diagnostic(self)
     }
 
     pub fn emit_warning<'a>(&'a self, warning: impl SessionDiagnostic<'a, ()>) {
-        warning.into_diagnostic(self).emit()
+        self.create_warning(warning).emit()
     }
 
     pub fn struct_err(

--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -413,8 +413,20 @@ impl Session {
     pub fn err(&self, msg: impl Into<DiagnosticMessage>) -> ErrorGuaranteed {
         self.diagnostic().err(msg)
     }
+    pub fn create_err<'a>(
+        &'a self,
+        err: impl SessionDiagnostic<'a>,
+    ) -> DiagnosticBuilder<'a, ErrorGuaranteed> {
+        self.parse_sess.create_err(err)
+    }
     pub fn emit_err<'a>(&'a self, err: impl SessionDiagnostic<'a>) -> ErrorGuaranteed {
         self.parse_sess.emit_err(err)
+    }
+    pub fn create_warning<'a>(
+        &'a self,
+        err: impl SessionDiagnostic<'a, ()>,
+    ) -> DiagnosticBuilder<'a, ()> {
+        self.parse_sess.create_warning(err)
     }
     pub fn emit_warning<'a>(&'a self, warning: impl SessionDiagnostic<'a, ()>) {
         self.parse_sess.emit_warning(warning)

--- a/compiler/rustc_typeck/src/collect/type_of.rs
+++ b/compiler/rustc_typeck/src/collect/type_of.rs
@@ -14,6 +14,7 @@ use rustc_span::{Span, DUMMY_SP};
 
 use super::ItemCtxt;
 use super::{bad_placeholder, is_suggestable_infer_ty};
+use crate::errors::UnconstrainedOpaqueType;
 
 /// Computes the relevant generic parameter for a potential generic const argument.
 ///
@@ -682,13 +683,10 @@ fn find_opaque_ty_constraints(tcx: TyCtxt<'_>, def_id: LocalDefId) -> Ty<'_> {
     match locator.found {
         Some(hidden) => hidden.ty,
         None => {
-            let span = tcx.def_span(def_id);
-            let name = tcx.item_name(tcx.local_parent(def_id).to_def_id());
-            let label = format!(
-                "`{}` must be used in combination with a concrete type within the same module",
-                name
-            );
-            tcx.sess.struct_span_err(span, "unconstrained opaque type").note(&label).emit();
+            tcx.sess.emit_err(UnconstrainedOpaqueType {
+                span: tcx.def_span(def_id),
+                name: tcx.item_name(tcx.local_parent(def_id).to_def_id()),
+            });
             tcx.ty_error()
         }
     }

--- a/compiler/rustc_typeck/src/errors.rs
+++ b/compiler/rustc_typeck/src/errors.rs
@@ -228,3 +228,12 @@ pub enum ExpectedReturnTypeLabel<'tcx> {
         expected: Ty<'tcx>,
     },
 }
+
+#[derive(SessionDiagnostic)]
+#[error(slug = "typeck-unconstrained-opaque-type")]
+#[note]
+pub struct UnconstrainedOpaqueType {
+    #[primary_span]
+    pub span: Span,
+    pub name: Symbol,
+}

--- a/compiler/rustc_typeck/src/errors.rs
+++ b/compiler/rustc_typeck/src/errors.rs
@@ -237,3 +237,16 @@ pub struct UnconstrainedOpaqueType {
     pub span: Span,
     pub name: Symbol,
 }
+
+#[derive(SessionDiagnostic)]
+#[error(code = "E0632", slug = "typeck-explicit-generic-args-with-impl-trait")]
+#[note]
+pub struct ExplicitGenericArgsWithImplTrait {
+    #[primary_span]
+    #[label]
+    pub spans: Vec<Span>,
+}
+
+#[derive(SessionSubdiagnostic)]
+#[help(slug = "typeck-explicit-generic-args-with-impl-trait-feature")]
+pub struct ExplicitGenericArgsWithImplTraitFeature;

--- a/src/test/ui-fulldeps/session-diagnostic/diagnostic-derive.rs
+++ b/src/test/ui-fulldeps/session-diagnostic/diagnostic-derive.rs
@@ -474,3 +474,11 @@ struct Subdiagnostic {
     #[subdiagnostic]
     note: Note,
 }
+
+#[derive(SessionDiagnostic)]
+#[error(code = "E0123", slug = "foo")]
+struct VecField {
+    #[primary_span]
+    #[label]
+    spans: Vec<Span>,
+}


### PR DESCRIPTION
- Port "unconstrained opaque type" diagnostic to using the derive.
- Allow `Vec` fields in diagnostic derive - enables support for diagnostics that have multiple primary spans, or have subdiagnostics repeated at multiple locations. `Vec<..>` fields in the diagnostic derive become loops in the generated code.
- Add `create_{err,warning}` - there wasn't a way to create a diagnostic from a struct and not emit it straight away. 
- Port "explicit generic args w/ impl trait" diagnostic to using the derive.

r? @oli-obk 
cc @pvdrz 