### PR TITLE
rustdoc: don't build `rayon` for non-windows targets

### DIFF
--- a/src/librustdoc/Cargo.toml
+++ b/src/librustdoc/Cargo.toml
@@ -12,7 +12,6 @@ askama = { version = "0.11", default-features = false, features = ["config"] }
 atty = "0.2"
 pulldown-cmark = { version = "0.9", default-features = false }
 minifier = "0.0.43"
-rayon = "1.5.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 smallvec = "1.6.1"
@@ -28,6 +27,9 @@ once_cell = "1.10.0"
 version = "0.3.3"
 default-features = false
 features = ["fmt", "env-filter", "smallvec", "parking_lot", "ansi"]
+
+[target.'cfg(windows)'.dependencies]
+rayon = "1.5.1"
 
 [dev-dependencies]
 expect-test = "1.0"

--- a/src/librustdoc/docfs.rs
+++ b/src/librustdoc/docfs.rs
@@ -54,7 +54,8 @@ impl DocFS {
     where
         E: PathError,
     {
-        if !self.sync_only && cfg!(windows) {
+        #[cfg(windows)]
+        if !self.sync_only {
             // A possible future enhancement after more detailed profiling would
             // be to create the file sync so errors are reported eagerly.
             let sender = self.errors.clone().expect("can't write after closing");
@@ -68,6 +69,10 @@ impl DocFS {
         } else {
             fs::write(&path, contents).map_err(|e| E::new(e, path))?;
         }
+
+        #[cfg(not(windows))]
+        fs::write(&path, contents).map_err(|e| E::new(e, path))?;
+
         Ok(())
     }
 }


### PR DESCRIPTION
`rayon` used only on windows targets, so no need to build it otherwise.