### PR TITLE
Fix maintainer validation message

### DIFF
--- a/src/ci/docker/host-x86_64/mingw-check/validate-toolstate.sh
+++ b/src/ci/docker/host-x86_64/mingw-check/validate-toolstate.sh
@@ -9,11 +9,5 @@ git clone --depth=1 https://github.com/rust-lang-nursery/rust-toolstate.git
 cd rust-toolstate
 python3 "../../src/tools/publish_toolstate.py" "$(git rev-parse HEAD)" \
     "$(git log --format=%s -n1 HEAD)" "" ""
-# Only check maintainers if this build is supposed to publish toolstate.
-# Builds that are not supposed to publish don't have the access token.
-if [ -n "${TOOLSTATE_PUBLISH+is_set}" ]; then
-  TOOLSTATE_VALIDATE_MAINTAINERS_REPO=rust-lang/rust python3 \
-      "../../src/tools/publish_toolstate.py"
-fi
 cd ..
 rm -rf rust-toolstate

--- a/src/tools/publish_toolstate.py
+++ b/src/tools/publish_toolstate.py
@@ -77,52 +77,6 @@ def load_json_from_response(resp):
         print("Refusing to decode " + str(type(content)) + " to str")
     return json.loads(content_str)
 
-def validate_maintainers(repo, github_token):
-    # type: (str, str) -> None
-    '''Ensure all maintainers are assignable on a GitHub repo'''
-    next_link_re = re.compile(r'<([^>]+)>; rel="next"')
-
-    # Load the list of assignable people in the GitHub repo
-    assignable = [] # type: typing.List[str]
-    url = 'https://api.github.com/repos/' \
-        + '%s/collaborators?per_page=100' % repo # type: typing.Optional[str]
-    while url is not None:
-        response = urllib2.urlopen(urllib2.Request(url, headers={
-            'Authorization': 'token ' + github_token,
-            # Properly load nested teams.
-            'Accept': 'application/vnd.github.hellcat-preview+json',
-        }))
-        assignable.extend(user['login'] for user in load_json_from_response(response))
-        # Load the next page if available
-        url = None
-        link_header = response.headers.get('Link')
-        if link_header:
-            matches = next_link_re.match(link_header)
-            if matches is not None:
-                url = matches.group(1)
-
-    errors = False
-    for tool, maintainers in MAINTAINERS.items():
-        for maintainer in maintainers:
-            if maintainer not in assignable:
-                errors = True
-                print(
-                    "error: %s maintainer @%s is not assignable in the %s repo"
-                    % (tool, maintainer, repo),
-                )
-
-    if errors:
-        print()
-        print("  To be assignable, a person needs to be explicitly listed as a")
-        print("  collaborator in the repository settings. The simple way to")
-        print("  fix this is to ask someone with 'admin' privileges on the repo")
-        print("  to add the person or whole team as a collaborator with 'read'")
-        print("  privileges. Those privileges don't grant any extra permissions")
-        print("  so it's safe to apply them.")
-        print()
-        print("The build will fail due to this.")
-        exit(1)
-
 
 def read_current_status(current_commit, path):
     # type: (str, str) -> typing.Mapping[str, typing.Any]
@@ -294,21 +248,6 @@ def update_latest(
 # which ones precisely but at least this is true for `github_token`.
 try:
     if __name__ != '__main__':
-        exit(0)
-    repo = os.environ.get('TOOLSTATE_VALIDATE_MAINTAINERS_REPO')
-    if repo:
-        github_token = os.environ.get('TOOLSTATE_REPO_ACCESS_TOKEN')
-        if github_token:
-            # FIXME: This is currently broken. Starting on 2021-09-15, GitHub
-            # seems to have changed it so that to list the collaborators
-            # requires admin permissions. I think this will probably just need
-            # to be removed since we are probably not going to use an admin
-            # token, and I don't see another way to do this.
-            print('maintainer validation disabled')
-            # validate_maintainers(repo, github_token)
-        else:
-            print('skipping toolstate maintainers validation since no GitHub token is present')
-        # When validating maintainers don't run the full script.
         exit(0)
 
     cur_commit = sys.argv[1]


### PR DESCRIPTION
State clearly why maintainer verification is not activating, ruling out the user thinking they misconfigured something.