### PR TITLE
[PERF TEST] Make TokenKind `Copy`

### DIFF
--- a/compiler/rustc_ast/src/mut_visit.rs
+++ b/compiler/rustc_ast/src/mut_visit.rs
@@ -756,7 +756,10 @@ pub fn visit_token<T: MutVisitor>(t: &mut Token, vis: &mut T) {
             return; // Avoid visiting the span for the second time.
         }
         token::Interpolated(nt) => {
-            visit_nonterminal(Lrc::make_mut(nt), vis);
+            let mut nt2 = nt.clone();
+            visit_nonterminal(&mut nt2, vis);
+            // njn: skip this step if nt == nt2?
+            *nt = Box::leak(Box::new(nt2));
         }
         _ => {}
     }

--- a/compiler/rustc_expand/src/mbe/transcribe.rs
+++ b/compiler/rustc_expand/src/mbe/transcribe.rs
@@ -228,7 +228,11 @@ pub(super) fn transcribe<'a>(
                             // `Delimiter::Invisible` to maintain parsing priorities.
                             // `Interpolated` is currently used for such groups in rustc parser.
                             marker.visit_span(&mut sp);
-                            let token = TokenTree::token_alone(token::Interpolated(nt.clone()), sp);
+                            let token = TokenTree::token_alone(
+                                // njn: nt.clone()?
+                                token::Interpolated(Box::leak(Box::new(nt.clone()))),
+                                sp,
+                            );
                             result.push(token);
                         }
                         MatchedSeq(..) => {

--- a/compiler/rustc_expand/src/proc_macro.rs
+++ b/compiler/rustc_expand/src/proc_macro.rs
@@ -6,7 +6,6 @@ use rustc_ast as ast;
 use rustc_ast::ptr::P;
 use rustc_ast::token;
 use rustc_ast::tokenstream::TokenStream;
-use rustc_data_structures::sync::Lrc;
 use rustc_errors::ErrorGuaranteed;
 use rustc_parse::parser::ForceCollect;
 use rustc_session::config::ProcMacroExecutionStrategy;
@@ -126,7 +125,7 @@ impl MultiItemModifier for DeriveProcMacro {
                 Annotatable::Stmt(stmt) => token::NtStmt(stmt),
                 _ => unreachable!(),
             };
-            TokenStream::token_alone(token::Interpolated(Lrc::new(nt)), DUMMY_SP)
+            TokenStream::token_alone(token::Interpolated(Box::leak(Box::new(nt))), DUMMY_SP)
         } else {
             item.to_tokens()
         };


### PR DESCRIPTION
By leaking nonterminals we can make them `&'static` instead of
ref-counted, which is enough for this test.

r? @ghost