### PR TITLE
[EXPERIMENT] disable orphan check for marker traits

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/coherence.rs
+++ b/compiler/rustc_trait_selection/src/traits/coherence.rs
@@ -592,6 +592,11 @@ fn orphan_check_trait_ref<'tcx>(
 ) -> Result<(), OrphanCheckErr<'tcx>> {
     debug!("orphan_check_trait_ref(trait_ref={:?}, in_crate={:?})", trait_ref, in_crate);
 
+    // Allow arbitrary impls of marker traits.
+    if tcx.trait_def(trait_ref.def_id).is_marker {
+        return Ok(());
+    }
+
     if trait_ref.needs_infer() && trait_ref.needs_subst() {
         bug!(
             "can't orphan check a trait ref with both params and inference variables {:?}",

--- a/compiler/rustc_trait_selection/src/traits/select/candidate_assembly.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/candidate_assembly.rs
@@ -223,6 +223,15 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
         // who might care about this case, like coherence, should use
         // that function).
         if candidates.is_empty() {
+            // It's always possible to add a marker trait impl so
+            // we can never consider any `T: Marker` bound to never apply.
+            if self
+                .tcx()
+                .trait_def(stack.obligation.predicate.skip_binder().trait_ref.def_id)
+                .is_marker
+            {
+                return Ok(None);
+            }
             // If there's an error type, 'downgrade' our result from
             // `Err(Unimplemented)` to `Ok(None)`. This helps us avoid
             // emitting additional spurious errors, since we're guaranteed

--- a/src/test/ui/coherence/coherence-conflicting-negative-trait-impl.rs
+++ b/src/test/ui/coherence/coherence-conflicting-negative-trait-impl.rs
@@ -12,6 +12,6 @@ impl<T: MyTrait> !Send for TestType<T> {} //~ ERROR found both positive and nega
 
 unsafe impl<T: 'static> Send for TestType<T> {} //~ ERROR conflicting implementations
 
-impl !Send for TestType<i32> {}
+impl !Send for TestType<i32> {} //~ ERROR found both positive and negative implementation
 
 fn main() {}

--- a/src/test/ui/coherence/coherence-conflicting-negative-trait-impl.stderr
+++ b/src/test/ui/coherence/coherence-conflicting-negative-trait-impl.stderr
@@ -16,7 +16,16 @@ LL | unsafe impl<T: MyTrait + 'static> Send for TestType<T> {}
 LL | unsafe impl<T: 'static> Send for TestType<T> {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `TestType<_>`
 
-error: aborting due to 2 previous errors
+error[E0751]: found both positive and negative implementation of trait `std::marker::Send` for type `TestType<i32>`:
+  --> $DIR/coherence-conflicting-negative-trait-impl.rs:15:1
+   |
+LL | unsafe impl<T: MyTrait + 'static> Send for TestType<T> {}
+   | ------------------------------------------------------ positive implementation here
+...
+LL | impl !Send for TestType<i32> {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ negative implementation here
+
+error: aborting due to 3 previous errors
 
 Some errors have detailed explanations: E0119, E0751.
 For more information about an error, try `rustc --explain E0119`.

--- a/src/test/ui/coherence/negative-impl-marker-traits.rs
+++ b/src/test/ui/coherence/negative-impl-marker-traits.rs
@@ -1,0 +1,10 @@
+#![feature(marker_trait_attr, negative_impls)]
+#[marker]
+trait Trait {}
+
+impl !Trait for () {} //~ ERROR negative impls are not allowed for marker traits
+
+struct Local;
+impl !Trait for Local {} //~ ERROR negative impls are not allowed for marker traits
+
+fn main() {}

--- a/src/test/ui/coherence/negative-impl-marker-traits.stderr
+++ b/src/test/ui/coherence/negative-impl-marker-traits.stderr
@@ -1,0 +1,26 @@
+error: negative impls are not allowed for marker traits
+  --> $DIR/negative-impl-marker-traits.rs:5:6
+   |
+LL | impl !Trait for () {}
+   |      ^
+   |
+note: marker trait
+  --> $DIR/negative-impl-marker-traits.rs:3:7
+   |
+LL | trait Trait {}
+   |       ^^^^^
+
+error: negative impls are not allowed for marker traits
+  --> $DIR/negative-impl-marker-traits.rs:8:6
+   |
+LL | impl !Trait for Local {}
+   |      ^
+   |
+note: marker trait
+  --> $DIR/negative-impl-marker-traits.rs:3:7
+   |
+LL | trait Trait {}
+   |       ^^^^^
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/marker_trait_attr/forbidden-fruit.rs
+++ b/src/test/ui/marker_trait_attr/forbidden-fruit.rs
@@ -1,0 +1,20 @@
+#![feature(marker_trait_attr)]
+#[marker]
+pub trait Marker {}
+
+pub struct B;
+
+trait NotMarker {
+    type Assoc;
+}
+
+impl NotMarker for B {
+    type Assoc = usize;
+}
+
+impl<T: Marker> NotMarker for T {
+    //~^ ERROR conflicting implementations of trait `NotMarker` for type `B`
+    type Assoc = Box<String>;
+}
+
+fn main() {}

--- a/src/test/ui/marker_trait_attr/forbidden-fruit.stderr
+++ b/src/test/ui/marker_trait_attr/forbidden-fruit.stderr
@@ -1,0 +1,14 @@
+error[E0119]: conflicting implementations of trait `NotMarker` for type `B`
+  --> $DIR/forbidden-fruit.rs:15:1
+   |
+LL | impl NotMarker for B {
+   | -------------------- first implementation here
+...
+LL | impl<T: Marker> NotMarker for T {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `B`
+   |
+   = note: downstream crates may implement trait `Marker` for type `B`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0119`.

--- a/src/test/ui/marker_trait_attr/overlap-marker-trait.stderr
+++ b/src/test/ui/marker_trait_attr/overlap-marker-trait.stderr
@@ -1,9 +1,10 @@
-error[E0277]: the trait bound `NotDebugOrDisplay: Marker` is not satisfied
-  --> $DIR/overlap-marker-trait.rs:27:17
+error[E0283]: type annotations needed
+  --> $DIR/overlap-marker-trait.rs:27:5
    |
 LL |     is_marker::<NotDebugOrDisplay>();
-   |                 ^^^^^^^^^^^^^^^^^ the trait `Marker` is not implemented for `NotDebugOrDisplay`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type for struct `NotDebugOrDisplay`
    |
+   = note: cannot satisfy `NotDebugOrDisplay: Marker`
 note: required by a bound in `is_marker`
   --> $DIR/overlap-marker-trait.rs:15:17
    |
@@ -12,4 +13,4 @@ LL | fn is_marker<T: Marker>() { }
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0277`.
+For more information about this error, try `rustc --explain E0283`.


### PR DESCRIPTION
closes #67919, either by landing this or by officially deciding that we don't want this.
I very much prefer to not land this change.

The reasoning for this was given by @Centril in #67919

> In this specific case the user has marked the trait as `#[marker]` (and therefore it has no computational content and overlap is vacuously sound), so it seems to me that their intent was to allow this. Indeed, the reason I found this problem was that I wanted to move [`rustc::hir::ArenaAllocatable`](https://doc.rust-lang.org/nightly/nightly-rustc/rustc/arena/trait.ArenaAllocatable.html) to `rustc_arena`, but couldn't because of the orphan rule.

The original RFC from 2015 seems to imply that the orphan rules should be relaxed, but it was generally light on details. The impact this has on coherence was not mentioned there.

As downstream crates can now implement marker traits for arbitrary types, all `MyType: MarkerTrait` bounds have to either hold or are ambiguous. We can never prove that `T: MarkerTrait` does not hold. This prevents the snippet in the `forbidden-fruit` test.

While I am completely forbidding negative impls for marker traits here, we could allow them in the crate defining the marker trait. They still would be forbidden for impls of foreign marker traits for local types though.

cc https://github.com/rust-lang/rust/pull/68004#issuecomment-575760294

Mostly opened this to get a general consensus from @rust-lang/wg-traits that this is something we do not want ^^

r? @ghost
