### PR TITLE
Make the test `check-pass` not to produce a JSON file

### DIFF
--- a/src/test/ui/const-generics/const-argument-non-static-lifetime.rs
+++ b/src/test/ui/const-generics/const-argument-non-static-lifetime.rs
@@ -1,4 +1,4 @@
-// [full] run-pass
+// [full] check-pass
 // revisions: full min
 
 // regression test for #78180


### PR DESCRIPTION
`run-pass` produces a JSON file when enabling save analysis.
The original ICE happened on `cargo check`, moreover **without** the `generic_const_exprs` feature, so `check-pass` should be enough.