### PR TITLE
Remove closures on `expect_local` to apply `#[track_caller]`

### DIFF
--- a/compiler/rustc_span/src/def_id.rs
+++ b/compiler/rustc_span/src/def_id.rs
@@ -281,7 +281,12 @@ impl DefId {
     #[inline]
     #[track_caller]
     pub fn expect_local(self) -> LocalDefId {
-        self.as_local().unwrap_or_else(|| panic!("DefId::expect_local: `{:?}` isn't local", self))
+        // NOTE: `match` below is required to apply `#[track_caller]`,
+        // i.e. don't use closures.
+        match self.as_local() {
+            Some(local_def_id) => local_def_id,
+            None => panic!("DefId::expect_local: `{:?}` isn't local", self),
+        }
     }
 
     #[inline]


### PR DESCRIPTION
Pointed out in https://github.com/rust-lang/rust/pull/96747#discussion_r866576196
Didn't change `expect_non_local` as I'm not sure if it's also the case.
r? @petrochenkov 