### PR TITLE
Update LLVM version used to build OS X and Windows artifacts to 14.0.2

### DIFF
--- a/src/ci/scripts/install-clang.sh
+++ b/src/ci/scripts/install-clang.sh
@@ -9,7 +9,7 @@ IFS=$'\n\t'
 source "$(cd "$(dirname "$0")" && pwd)/../shared.sh"
 
 # Update both macOS's and Windows's tarballs when bumping the version here.
-LLVM_VERSION="12.0.0"
+LLVM_VERSION="14.0.2"
 
 if isMacOS; then
     # If the job selects a specific Xcode version, use that instead of


### PR DESCRIPTION
Let's see what breaks.

r? @Mark-Simulacrum