### PR TITLE
Fix an incorrect link in The Unstable Book

### DIFF
--- a/src/doc/unstable-book/src/language-features/plugin.md
+++ b/src/doc/unstable-book/src/language-features/plugin.md
@@ -102,7 +102,7 @@ The components of a lint plugin are:
 
 Lint passes are syntax traversals, but they run at a late stage of compilation
 where type information is available. `rustc`'s [built-in
-lints](https://github.com/rust-lang/rust/blob/master/src/librustc_session/lint/builtin.rs)
+lints](https://github.com/rust-lang/rust/blob/master/compiler/rustc_lint_defs/src/builtin.rs)
 mostly use the same infrastructure as lint plugins, and provide examples of how
 to access type information.
 


### PR DESCRIPTION
https://github.com/rust-lang/rust/blob/master/src/librustc_session/lint/builtin.rs returns page not found.

The following is the background of the move.
First https://github.com/rust-lang/rust/pull/74862 moves from src/librustc_session/lint/builtin.rs to compiler/rustc_session/src/lint/builtin.rs.
Then https://github.com/rust-lang/rust/commit/23018a5 moves from compiler/rustc_session/src/lint/builtin.rs to compiler/rustc_lint_defs/src/builtin.rs.

So, the current correct link is https://github.com/rust-lang/rust/blob/master/compiler/rustc_lint_defs/src/builtin.rs.

This PR fixes a broken link on the following page:
https://doc.rust-lang.org/beta/unstable-book/language-features/plugin.html