### PR TITLE
change `ConstInt` impl to not rely on `ScalarInt`

### DIFF
--- a/compiler/rustc_const_eval/src/interpret/operand.rs
+++ b/compiler/rustc_const_eval/src/interpret/operand.rs
@@ -245,7 +245,11 @@ impl<'tcx, Tag: Provenance> ImmTy<'tcx, Tag> {
     pub fn to_const_int(self) -> ConstInt {
         assert!(self.layout.ty.is_integral());
         let int = self.to_scalar().expect("to_const_int doesn't work on scalar pairs").assert_int();
-        ConstInt::new(int, self.layout.ty.is_signed(), self.layout.ty.is_ptr_sized_integral())
+        ConstInt::new_with_width(
+            int.assert_bits(int.size()),
+            self.layout.ty,
+            int.size().bytes() as u32,
+        )
     }
 }
 

--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -1329,8 +1329,7 @@ pub trait PrettyPrinter<'tcx>:
             }
             // Int
             ty::Uint(_) | ty::Int(_) => {
-                let int =
-                    ConstInt::new(int, matches!(ty.kind(), ty::Int(_)), ty.is_ptr_sized_integral());
+                let int = ConstInt::new(self.tcx(), int.assert_bits(int.size()), ty);
                 if print_ty { p!(write("{:#?}", int)) } else { p!(write("{:?}", int)) }
             }
             // Char

--- a/compiler/rustc_mir_transform/src/const_prop_lint.rs
+++ b/compiler/rustc_mir_transform/src/const_prop_lint.rs
@@ -18,7 +18,7 @@ use rustc_middle::mir::{
 use rustc_middle::ty::layout::{LayoutError, LayoutOf, LayoutOfHelpers, TyAndLayout};
 use rustc_middle::ty::subst::{InternalSubsts, Subst};
 use rustc_middle::ty::{
-    self, ConstInt, ConstKind, Instance, ParamEnv, ScalarInt, Ty, TyCtxt, TypeFoldable,
+    self, ConstInt, ConstKind, Instance, ParamEnv, Ty, TyCtxt, TypeFoldable,
 };
 use rustc_session::lint;
 use rustc_span::{def_id::DefId, Span};
@@ -579,10 +579,10 @@ impl<'mir, 'tcx> ConstPropagator<'mir, 'tcx> {
                         match l {
                             Some(l) => l.to_const_int(),
                             // Invent a dummy value, the diagnostic ignores it anyway
-                            None => ConstInt::new(
-                                ScalarInt::try_from_uint(1_u8, left_size).unwrap(),
-                                left_ty.is_signed(),
-                                left_ty.is_ptr_sized_integral(),
+                            None => ConstInt::new_with_width(
+                                1,
+                                left_ty,
+                                left_size.bytes() as u32,
                             ),
                         },
                         r.to_const_int(),

--- a/compiler/rustc_symbol_mangling/src/legacy.rs
+++ b/compiler/rustc_symbol_mangling/src/legacy.rs
@@ -267,11 +267,10 @@ impl<'tcx> Printer<'tcx> for &mut SymbolPrinter<'tcx> {
             ) => {
                 // The `pretty_print_const` formatting depends on -Zverbose
                 // flag, so we cannot reuse it here.
-                let signed = matches!(ct.ty().kind(), ty::Int(_));
                 write!(
                     self,
                     "{:#?}",
-                    ty::ConstInt::new(scalar, signed, ct.ty().is_ptr_sized_integral())
+                    ty::ConstInt::new(self.tcx, scalar.assert_bits(scalar.size()), ct.ty())
                 )?;
             }
             _ => self.write_str("_")?,


### PR DESCRIPTION
This allows us to use it in the thir pattern code in the future without having to first go through `ScalarInt`. Patterns currently use `u128` instead of `ScalarInt` and moving away from that seems more challenging than this while maybe even impacting perf.