### PR TITLE
Update jemalloc to v5.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1898,6 +1898,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
 
 [[package]]
+name = "jemalloc-sys"
+version = "0.5.0+5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f655c3ecfa6b0d03634595b4b54551d4bd5ac208b9e0124873949a7ab168f70b"
+dependencies = [
+ "cc",
+ "fs_extra",
+ "libc",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3360,9 +3371,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 name = "rustc-main"
 version = "0.0.0"
 dependencies = [
+ "jemalloc-sys",
  "rustc_codegen_ssa",
  "rustc_driver",
- "tikv-jemalloc-sys",
 ]
 
 [[package]]
@@ -5233,17 +5244,6 @@ dependencies = [
 [[package]]
 name = "tier-check"
 version = "0.1.0"
-
-[[package]]
-name = "tikv-jemalloc-sys"
-version = "0.4.1+5.2.1-patched"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a26331b05179d4cb505c8d6814a7e18d298972f0a551b0e3cefccff927f86d3"
-dependencies = [
- "cc",
- "fs_extra",
- "libc",
-]
 
 [[package]]
 name = "time"

--- a/compiler/rustc/Cargo.toml
+++ b/compiler/rustc/Cargo.toml
@@ -10,13 +10,13 @@ rustc_driver = { path = "../rustc_driver" }
 # crate is intended to be used by codegen backends, which may not be in-tree.
 rustc_codegen_ssa = { path = "../rustc_codegen_ssa" }
 
-[dependencies.tikv-jemalloc-sys]
-version = '0.4.0'
+[dependencies.jemalloc-sys]
+version = "0.5.0"
 optional = true
 features = ['unprefixed_malloc_on_supported_platforms']
 
 [features]
-jemalloc = ['tikv-jemalloc-sys']
+jemalloc = ['jemalloc-sys']
 llvm = ['rustc_driver/llvm']
 max_level_info = ['rustc_driver/max_level_info']
 rustc_use_parallel_compiler = ['rustc_driver/rustc_use_parallel_compiler']

--- a/compiler/rustc/src/main.rs
+++ b/compiler/rustc/src/main.rs
@@ -22,12 +22,10 @@
 // The two crates we link to here, `std` and `rustc_driver`, are both dynamic
 // libraries. So we must reference jemalloc symbols one way or another, because
 // this file is the only object code in the rustc executable.
-#[cfg(feature = "tikv-jemalloc-sys")]
-use tikv_jemalloc_sys as jemalloc_sys;
 
 fn main() {
     // See the comment at the top of this file for an explanation of this.
-    #[cfg(feature = "tikv-jemalloc-sys")]
+    #[cfg(feature = "jemalloc-sys")]
     {
         use std::os::raw::{c_int, c_void};
 

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -70,9 +70,7 @@ extern crate test;
 // See docs in https://github.com/rust-lang/rust/blob/master/compiler/rustc/src/main.rs
 // about jemalloc.
 #[cfg(feature = "jemalloc")]
-extern crate tikv_jemalloc_sys;
-#[cfg(feature = "jemalloc")]
-use tikv_jemalloc_sys as jemalloc_sys;
+extern crate jemalloc_sys;
 
 use std::default::Default;
 use std::env::{self, VarError};


### PR DESCRIPTION
Now that `jemalloc` version 5.3 has been released, this PR updates `tikv-jemalloc-sys` to the corresponding release. 

The crates.io publishing issue seems to have been resolved for the `jemalloc-sys` package, and version 5.3.0 is now also available under the historical name (and should become the preferred crate to be used). Therefore, this PR also switches back to using `jemalloc-sys` instead of  `tikv-jemalloc-sys`.