### PR TITLE
Do not lint on explicit outlives requirements from external macros.

### DIFF
--- a/compiler/rustc_lint/src/builtin.rs
+++ b/compiler/rustc_lint/src/builtin.rs
@@ -38,7 +38,7 @@ use rustc_hir::def::{DefKind, Res};
 use rustc_hir::def_id::{DefId, LocalDefId, LocalDefIdSet, CRATE_DEF_ID};
 use rustc_hir::{ForeignItemKind, GenericParamKind, HirId, PatKind};
 use rustc_index::vec::Idx;
-use rustc_middle::lint::LintDiagnosticBuilder;
+use rustc_middle::lint::{in_external_macro, LintDiagnosticBuilder};
 use rustc_middle::ty::layout::{LayoutError, LayoutOf};
 use rustc_middle::ty::print::with_no_trimmed_paths;
 use rustc_middle::ty::subst::{GenericArgKind, Subst};
@@ -2115,6 +2115,7 @@ impl ExplicitOutlivesRequirements {
                     None
                 }
             })
+            .filter(|(_, span)| !in_external_macro(tcx.sess, *span))
             .collect()
     }
 

--- a/src/test/ui/rust-2018/auxiliary/edition-lint-infer-outlives-macro.rs
+++ b/src/test/ui/rust-2018/auxiliary/edition-lint-infer-outlives-macro.rs
@@ -1,0 +1,6 @@
+pub fn foo() {}
+
+#[macro_export]
+macro_rules! gimme_a {
+    ($($mac:tt)*) => { $($mac)* { 'a } }
+}

--- a/src/test/ui/rust-2018/edition-lint-infer-outlives-macro.rs
+++ b/src/test/ui/rust-2018/edition-lint-infer-outlives-macro.rs
@@ -1,0 +1,28 @@
+// edition:2018
+// aux-build:edition-lint-infer-outlives-macro.rs
+
+// Test that the lint does not fire if the where predicate
+// is from the local crate, but all the bounds are from an
+// external macro.
+
+#![deny(explicit_outlives_requirements)]
+
+#[macro_use]
+extern crate edition_lint_infer_outlives_macro;
+
+macro_rules! make_foo {
+    ($a:tt) => {
+        struct Foo<$a, 'b> where 'b: $a {
+            foo: &$a &'b (),
+        }
+    }
+}
+
+gimme_a! {make_foo!}
+
+struct Bar<'a, 'b: 'a> {
+    //~^ ERROR: outlives requirements can be inferred
+    bar: &'a &'b (),
+}
+
+fn main() {}

--- a/src/test/ui/rust-2018/edition-lint-infer-outlives-macro.stderr
+++ b/src/test/ui/rust-2018/edition-lint-infer-outlives-macro.stderr
@@ -1,0 +1,14 @@
+error: outlives requirements can be inferred
+  --> $DIR/edition-lint-infer-outlives-macro.rs:23:18
+   |
+LL | struct Bar<'a, 'b: 'a> {
+   |                  ^^^^ help: remove this bound
+   |
+note: the lint level is defined here
+  --> $DIR/edition-lint-infer-outlives-macro.rs:8:9
+   |
+LL | #![deny(explicit_outlives_requirements)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+


### PR DESCRIPTION
The current implementation of the list rightfully skipped where predicates from external macros.
However, if the where predicate came from the current macro but the bounds were from an external macro, the lint still fired.

Closes https://github.com/rust-lang/rust/issues/96640