### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/compiler/rustc_const_eval/src/transform/validate.rs
+++ b/compiler/rustc_const_eval/src/transform/validate.rs
@@ -14,7 +14,7 @@ use rustc_middle::ty::{self, InstanceDef, ParamEnv, Ty, TyCtxt, TypeFoldable};
 use rustc_mir_dataflow::impls::MaybeStorageLive;
 use rustc_mir_dataflow::storage::AlwaysLiveLocals;
 use rustc_mir_dataflow::{Analysis, ResultsCursor};
-use rustc_target::abi::Size;
+use rustc_target::abi::{Size, VariantIdx};
 
 #[derive(Copy, Clone, Debug)]
 enum EdgeKind {
@@ -242,6 +242,60 @@ impl<'a, 'tcx> Visitor<'tcx> for TypeChecker<'a, 'tcx> {
             let index_ty = self.body.local_decls[index].ty;
             if index_ty != self.tcx.types.usize {
                 self.fail(location, format!("bad index ({:?} != usize)", index_ty))
+            }
+        }
+        if let ProjectionElem::Field(f, ty) = elem {
+            let parent = Place { local, projection: self.tcx.intern_place_elems(proj_base) };
+            let parent_ty = parent.ty(&self.body.local_decls, self.tcx);
+            let fail_out_of_bounds = |this: &Self, location| {
+                this.fail(location, format!("Out of bounds field {:?} for {:?}", f, parent_ty));
+            };
+            let check_equal = |this: &Self, location, f_ty| {
+                if !this.mir_assign_valid_types(ty, f_ty) {
+                    this.fail(
+                        location,
+                        format!(
+                            "Field projection `{:?}.{:?}` specified type `{:?}`, but actual type is {:?}",
+                            parent, f, ty, f_ty
+                        )
+                    )
+                }
+            };
+            match parent_ty.ty.kind() {
+                ty::Tuple(fields) => {
+                    let Some(f_ty) = fields.get(f.as_usize()) else {
+                        fail_out_of_bounds(self, location);
+                        return;
+                    };
+                    check_equal(self, location, *f_ty);
+                }
+                ty::Adt(adt_def, substs) => {
+                    let var = parent_ty.variant_index.unwrap_or(VariantIdx::from_u32(0));
+                    let Some(field) = adt_def.variant(var).fields.get(f.as_usize()) else {
+                        fail_out_of_bounds(self, location);
+                        return;
+                    };
+                    check_equal(self, location, field.ty(self.tcx, substs));
+                }
+                ty::Closure(_, substs) => {
+                    let substs = substs.as_closure();
+                    let Some(f_ty) = substs.upvar_tys().nth(f.as_usize()) else {
+                        fail_out_of_bounds(self, location);
+                        return;
+                    };
+                    check_equal(self, location, f_ty);
+                }
+                ty::Generator(_, substs, _) => {
+                    let substs = substs.as_generator();
+                    let Some(f_ty) = substs.upvar_tys().nth(f.as_usize()) else {
+                        fail_out_of_bounds(self, location);
+                        return;
+                    };
+                    check_equal(self, location, f_ty);
+                }
+                _ => {
+                    self.fail(location, format!("{:?} does not have fields", parent_ty.ty));
+                }
             }
         }
         self.super_projection_elem(local, proj_base, elem, context, location);

--- a/compiler/rustc_error_messages/locales/en-US/typeck.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/typeck.ftl
@@ -90,3 +90,6 @@ typeck-add-return-type-missing-here = a return type might be missing here
 typeck-expected-default-return-type = expected `()` because of default return type
 
 typeck-expected-return-type = expected `{$expected}` because of return type
+
+typeck-unconstrained-opaque-type = unconstrained opaque type
+    .note = `{$name}` must be used in combination with a concrete type within the same module

--- a/compiler/rustc_error_messages/locales/en-US/typeck.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/typeck.ftl
@@ -93,3 +93,11 @@ typeck-expected-return-type = expected `{$expected}` because of return type
 
 typeck-unconstrained-opaque-type = unconstrained opaque type
     .note = `{$name}` must be used in combination with a concrete type within the same module
+
+typeck-explicit-generic-args-with-impl-trait =
+    cannot provide explicit generic arguments when `impl Trait` is used in argument position
+    .label = explicit generic argument not allowed
+    .note = see issue #83701 <https://github.com/rust-lang/rust/issues/83701> for more information
+
+typeck-explicit-generic-args-with-impl-trait-feature =
+    add `#![feature(explicit_generic_args_with_impl_trait)]` to the crate attributes to enable

--- a/compiler/rustc_middle/src/mir/pretty.rs
+++ b/compiler/rustc_middle/src/mir/pretty.rs
@@ -448,6 +448,12 @@ impl<'tcx> Visitor<'tcx> for ExtraComments<'tcx> {
                 self.push(&format!("+ user_ty: {:?}", user_ty));
             }
 
+            let fmt_val = |val: &ConstValue<'tcx>| match val {
+                ConstValue::Scalar(s) => format!("Scalar({:?})", s),
+                ConstValue::Slice { .. } => format!("Slice(..)"),
+                ConstValue::ByRef { .. } => format!("ByRef(..)"),
+            };
+
             let val = match literal {
                 ConstantKind::Ty(ct) => match ct.val() {
                     ty::ConstKind::Param(p) => format!("Param({})", p),
@@ -457,7 +463,7 @@ impl<'tcx> Visitor<'tcx> for ExtraComments<'tcx> {
                         uv.substs,
                         uv.promoted,
                     ),
-                    ty::ConstKind::Value(val) => format!("Value({:?})", val),
+                    ty::ConstKind::Value(val) => format!("Value({})", fmt_val(&val)),
                     ty::ConstKind::Error(_) => "Error".to_string(),
                     // These variants shouldn't exist in the MIR.
                     ty::ConstKind::Placeholder(_)
@@ -467,7 +473,7 @@ impl<'tcx> Visitor<'tcx> for ExtraComments<'tcx> {
                 // To keep the diffs small, we render this like we render `ty::Const::Value`.
                 //
                 // This changes once `ty::Const::Value` is represented using valtrees.
-                ConstantKind::Val(val, _) => format!("Value({:?})", val),
+                ConstantKind::Val(val, _) => format!("Value({})", fmt_val(&val)),
             };
 
             self.push(&format!("+ literal: Const {{ ty: {}, val: {} }}", literal.ty(), val));

--- a/compiler/rustc_session/src/parse.rs
+++ b/compiler/rustc_session/src/parse.rs
@@ -289,12 +289,26 @@ impl ParseSess {
         self.proc_macro_quoted_spans.lock().clone()
     }
 
+    pub fn create_err<'a>(
+        &'a self,
+        err: impl SessionDiagnostic<'a>,
+    ) -> DiagnosticBuilder<'a, ErrorGuaranteed> {
+        err.into_diagnostic(self)
+    }
+
     pub fn emit_err<'a>(&'a self, err: impl SessionDiagnostic<'a>) -> ErrorGuaranteed {
-        err.into_diagnostic(self).emit()
+        self.create_err(err).emit()
+    }
+
+    pub fn create_warning<'a>(
+        &'a self,
+        warning: impl SessionDiagnostic<'a, ()>,
+    ) -> DiagnosticBuilder<'a, ()> {
+        warning.into_diagnostic(self)
     }
 
     pub fn emit_warning<'a>(&'a self, warning: impl SessionDiagnostic<'a, ()>) {
-        warning.into_diagnostic(self).emit()
+        self.create_warning(warning).emit()
     }
 
     pub fn struct_err(

--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -413,8 +413,20 @@ impl Session {
     pub fn err(&self, msg: impl Into<DiagnosticMessage>) -> ErrorGuaranteed {
         self.diagnostic().err(msg)
     }
+    pub fn create_err<'a>(
+        &'a self,
+        err: impl SessionDiagnostic<'a>,
+    ) -> DiagnosticBuilder<'a, ErrorGuaranteed> {
+        self.parse_sess.create_err(err)
+    }
     pub fn emit_err<'a>(&'a self, err: impl SessionDiagnostic<'a>) -> ErrorGuaranteed {
         self.parse_sess.emit_err(err)
+    }
+    pub fn create_warning<'a>(
+        &'a self,
+        err: impl SessionDiagnostic<'a, ()>,
+    ) -> DiagnosticBuilder<'a, ()> {
+        self.parse_sess.create_warning(err)
     }
     pub fn emit_warning<'a>(&'a self, warning: impl SessionDiagnostic<'a, ()>) {
         self.parse_sess.emit_warning(warning)

--- a/compiler/rustc_target/src/abi/mod.rs
+++ b/compiler/rustc_target/src/abi/mod.rs
@@ -276,10 +276,17 @@ impl ToJson for Endian {
 }
 
 /// Size of a type in bytes.
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Encodable, Decodable)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Encodable, Decodable)]
 #[derive(HashStable_Generic)]
 pub struct Size {
     raw: u64,
+}
+
+// This is debug-printed a lot in larger structs, don't waste too much space there
+impl fmt::Debug for Size {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Size({} bytes)", self.bytes())
+    }
 }
 
 impl Size {
@@ -485,10 +492,17 @@ impl Step for Size {
 }
 
 /// Alignment of a type in bytes (always a power of two).
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Encodable, Decodable)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Encodable, Decodable)]
 #[derive(HashStable_Generic)]
 pub struct Align {
     pow2: u8,
+}
+
+// This is debug-printed a lot in larger structs, don't waste too much space there
+impl fmt::Debug for Align {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Align({} bytes)", self.bytes())
+    }
 }
 
 impl Align {

--- a/compiler/rustc_typeck/src/collect/type_of.rs
+++ b/compiler/rustc_typeck/src/collect/type_of.rs
@@ -14,6 +14,7 @@ use rustc_span::{Span, DUMMY_SP};
 
 use super::ItemCtxt;
 use super::{bad_placeholder, is_suggestable_infer_ty};
+use crate::errors::UnconstrainedOpaqueType;
 
 /// Computes the relevant generic parameter for a potential generic const argument.
 ///
@@ -682,13 +683,10 @@ fn find_opaque_ty_constraints(tcx: TyCtxt<'_>, def_id: LocalDefId) -> Ty<'_> {
     match locator.found {
         Some(hidden) => hidden.ty,
         None => {
-            let span = tcx.def_span(def_id);
-            let name = tcx.item_name(tcx.local_parent(def_id).to_def_id());
-            let label = format!(
-                "`{}` must be used in combination with a concrete type within the same module",
-                name
-            );
-            tcx.sess.struct_span_err(span, "unconstrained opaque type").note(&label).emit();
+            tcx.sess.emit_err(UnconstrainedOpaqueType {
+                span: tcx.def_span(def_id),
+                name: tcx.item_name(tcx.local_parent(def_id).to_def_id()),
+            });
             tcx.ty_error()
         }
     }

--- a/compiler/rustc_typeck/src/errors.rs
+++ b/compiler/rustc_typeck/src/errors.rs
@@ -228,3 +228,12 @@ pub enum ExpectedReturnTypeLabel<'tcx> {
         expected: Ty<'tcx>,
     },
 }
+
+#[derive(SessionDiagnostic)]
+#[error(slug = "typeck-unconstrained-opaque-type")]
+#[note]
+pub struct UnconstrainedOpaqueType {
+    #[primary_span]
+    pub span: Span,
+    pub name: Symbol,
+}

--- a/compiler/rustc_typeck/src/errors.rs
+++ b/compiler/rustc_typeck/src/errors.rs
@@ -237,3 +237,16 @@ pub struct UnconstrainedOpaqueType {
     pub span: Span,
     pub name: Symbol,
 }
+
+#[derive(SessionDiagnostic)]
+#[error(code = "E0632", slug = "typeck-explicit-generic-args-with-impl-trait")]
+#[note]
+pub struct ExplicitGenericArgsWithImplTrait {
+    #[primary_span]
+    #[label]
+    pub spans: Vec<Span>,
+}
+
+#[derive(SessionSubdiagnostic)]
+#[help(slug = "typeck-explicit-generic-args-with-impl-trait-feature")]
+pub struct ExplicitGenericArgsWithImplTraitFeature;

--- a/library/core/src/fmt/mod.rs
+++ b/library/core/src/fmt/mod.rs
@@ -600,7 +600,7 @@ impl Display for Arguments<'_> {
 ///
 /// Types that do not wish to use the standard suite of debug representations
 /// provided by the `Formatter` trait (`debug_struct`, `debug_tuple`,
-/// `debut_list`, `debug_set`, `debug_map`) can do something totally custom by
+/// `debug_list`, `debug_set`, `debug_map`) can do something totally custom by
 /// manually writing an arbitrary representation to the `Formatter`.
 ///
 /// ```

--- a/src/ci/docker/host-x86_64/mingw-check/Dockerfile
+++ b/src/ci/docker/host-x86_64/mingw-check/Dockerfile
@@ -41,4 +41,4 @@ ENV SCRIPT python3 ../x.py --stage 2 test src/tools/expand-yaml-anchors && \
            /scripts/validate-error-codes.sh && \
            # Runs checks to ensure that there are no ES5 issues in our JS code.
            es-check es6 ../src/librustdoc/html/static/js/*.js && \
-           eslint ../src/librustdoc/html/static/js/*.js
+           eslint -c ../src/librustdoc/html/static/.eslintrc.js ../src/librustdoc/html/static/js/*.js

--- a/src/doc/rustdoc/src/unstable-features.md
+++ b/src/doc/rustdoc/src/unstable-features.md
@@ -567,3 +567,10 @@ $ rustdoc src/lib.rs -Z unstable-options \
 
 The example above check every well known names (`target_os`, `doc`, `test`, ... via `names()`)
 and check the values of `feature`: `foo` and `bar`.
+
+### `--generate-link-to-definition`: Generate links on types in source code
+
+ * Tracking issue: [#89095](https://github.com/rust-lang/rust/issues/89095)
+
+This flag enables the generation of links in the source code pages which allow the reader
+to jump to a type definition.

--- a/src/librustdoc/html/render/span_map.rs
+++ b/src/librustdoc/html/render/span_map.rs
@@ -5,7 +5,7 @@ use rustc_data_structures::fx::FxHashMap;
 use rustc_hir::def::{DefKind, Res};
 use rustc_hir::def_id::DefId;
 use rustc_hir::intravisit::{self, Visitor};
-use rustc_hir::{ExprKind, Generics, HirId, Mod, Node, WherePredicate};
+use rustc_hir::{ExprKind, HirId, Mod, Node};
 use rustc_middle::hir::nested_filter;
 use rustc_middle::ty::TyCtxt;
 use rustc_span::Span;
@@ -98,18 +98,6 @@ impl<'tcx> Visitor<'tcx> for SpanMapVisitor<'tcx> {
 
     fn nested_visit_map(&mut self) -> Self::Map {
         self.tcx.hir()
-    }
-
-    fn visit_generics(&mut self, g: &'tcx Generics<'tcx>) {
-        for predicate in g.predicates {
-            if let WherePredicate::BoundPredicate(w) = predicate {
-                for bound in w.bounds {
-                    if let Some(trait_ref) = bound.trait_ref() {
-                        self.handle_path(trait_ref.path, None);
-                    }
-                }
-            }
-        }
     }
 
     fn visit_path(&mut self, path: &'tcx rustc_hir::Path<'tcx>, _id: HirId) {

--- a/src/librustdoc/html/render/span_map.rs
+++ b/src/librustdoc/html/render/span_map.rs
@@ -5,7 +5,7 @@ use rustc_data_structures::fx::FxHashMap;
 use rustc_hir::def::{DefKind, Res};
 use rustc_hir::def_id::DefId;
 use rustc_hir::intravisit::{self, Visitor};
-use rustc_hir::{ExprKind, GenericParam, HirId, Mod, Node};
+use rustc_hir::{ExprKind, Generics, HirId, Mod, Node, WherePredicate};
 use rustc_middle::hir::nested_filter;
 use rustc_middle::ty::TyCtxt;
 use rustc_span::Span;
@@ -100,7 +100,17 @@ impl<'tcx> Visitor<'tcx> for SpanMapVisitor<'tcx> {
         self.tcx.hir()
     }
 
-    fn visit_generic_param(&mut self, _: &'tcx GenericParam<'tcx>) {}
+    fn visit_generics(&mut self, g: &'tcx Generics<'tcx>) {
+        for predicate in g.predicates {
+            if let WherePredicate::BoundPredicate(w) = predicate {
+                for bound in w.bounds {
+                    if let Some(trait_ref) = bound.trait_ref() {
+                        self.handle_path(trait_ref.path, None);
+                    }
+                }
+            }
+        }
+    }
 
     fn visit_path(&mut self, path: &'tcx rustc_hir::Path<'tcx>, _id: HirId) {
         self.handle_path(path, None);

--- a/src/librustdoc/html/static/.eslintrc.js
+++ b/src/librustdoc/html/static/.eslintrc.js
@@ -16,6 +16,9 @@ module.exports = {
         "semi": [
             "error",
             "always"
-        ]
+        ],
+        "no-var": ["error"],
+        "prefer-const": ["error"],
+        "prefer-arrow-callback": ["error"],
     }
 };

--- a/src/librustdoc/html/static/js/externs.js
+++ b/src/librustdoc/html/static/js/externs.js
@@ -1,9 +1,6 @@
 // This file contains type definitions that are processed by the Closure Compiler but are
 // not put into the JavaScript we include as part of the documentation. It is used for
 // type checking. See README.md in this directory for more info.
-/* eslint-env es6 */
-/* eslint no-var: "error" */
-/* eslint prefer-const: "error" */
 
 /* eslint-disable */
 let searchState;

--- a/src/librustdoc/html/static/js/main.js
+++ b/src/librustdoc/html/static/js/main.js
@@ -1,7 +1,3 @@
-/* eslint-env es6 */
-/* eslint no-var: "error" */
-/* eslint prefer-const: "error" */
-/* eslint prefer-arrow-callback: "error" */
 // Local js definitions:
 /* global addClass, getSettingValue, hasClass, searchState */
 /* global onEach, onEachLazy, removeClass */

--- a/src/librustdoc/html/static/js/scrape-examples.js
+++ b/src/librustdoc/html/static/js/scrape-examples.js
@@ -1,7 +1,3 @@
-/* eslint-env es6 */
-/* eslint no-var: "error" */
-/* eslint prefer-const: "error" */
-/* eslint prefer-arrow-callback: "error" */
 /* global addClass, hasClass, removeClass, onEachLazy */
 
 "use strict";

--- a/src/librustdoc/html/static/js/search.js
+++ b/src/librustdoc/html/static/js/search.js
@@ -1,7 +1,3 @@
-/* eslint-env es6 */
-/* eslint no-var: "error" */
-/* eslint prefer-const: "error" */
-/* eslint prefer-arrow-callback: "error" */
 /* global addClass, getNakedUrl, getSettingValue, hasOwnPropertyRustdoc, initSearch, onEach */
 /* global onEachLazy, removeClass, searchState, browserSupportsHistoryApi */
 

--- a/src/librustdoc/html/static/js/settings.js
+++ b/src/librustdoc/html/static/js/settings.js
@@ -1,7 +1,3 @@
-/* eslint-env es6 */
-/* eslint no-var: "error" */
-/* eslint prefer-const: "error" */
-/* eslint prefer-arrow-callback: "error" */
 // Local js definitions:
 /* global getSettingValue, getVirtualKey, updateLocalStorage, updateSystemTheme */
 /* global addClass, removeClass, onEach, onEachLazy, NOT_DISPLAYED_ID */

--- a/src/librustdoc/html/static/js/source-script.js
+++ b/src/librustdoc/html/static/js/source-script.js
@@ -1,8 +1,3 @@
-/* eslint-env es6 */
-/* eslint no-var: "error" */
-/* eslint prefer-const: "error" */
-/* eslint prefer-arrow-callback: "error" */
-
 // From rust:
 /* global search, sourcesIndex */
 

--- a/src/librustdoc/html/static/js/storage.js
+++ b/src/librustdoc/html/static/js/storage.js
@@ -1,8 +1,3 @@
-/* eslint-env es6 */
-/* eslint no-var: "error" */
-/* eslint prefer-const: "error" */
-/* eslint prefer-arrow-callback: "error" */
-
 "use strict";
 
 const darkThemes = ["dark", "ayu"];

--- a/src/test/mir-opt/const_debuginfo.main.ConstDebugInfo.diff
+++ b/src/test/mir-opt/const_debuginfo.main.ConstDebugInfo.diff
@@ -77,7 +77,7 @@
           _9 = const "hello, world!";      // scope 4 at $DIR/const_debuginfo.rs:14:13: 14:28
                                            // mir::Constant
                                            // + span: $DIR/const_debuginfo.rs:14:13: 14:28
-                                           // + literal: Const { ty: &str, val: Value(Slice { data: Allocation { bytes: [104, 101, 108, 108, 111, 44, 32, 119, 111, 114, 108, 100, 33], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [8191], len: Size { raw: 13 } }, align: Align { pow2: 0 }, mutability: Not, extra: () }, start: 0, end: 13 }) }
+                                           // + literal: Const { ty: &str, val: Value(Slice(..)) }
           StorageLive(_10);                // scope 5 at $DIR/const_debuginfo.rs:16:9: 16:10
           Deinit(_10);                     // scope 5 at $DIR/const_debuginfo.rs:16:13: 16:34
           (_10.0: bool) = const true;      // scope 5 at $DIR/const_debuginfo.rs:16:13: 16:34

--- a/src/test/mir-opt/const_prop/control_flow_simplification.hello.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/control_flow_simplification.hello.ConstProp.diff
@@ -22,7 +22,7 @@
                                            // + literal: Const { ty: fn(&str) -> ! {begin_panic::<&str>}, val: Value(Scalar(<ZST>)) }
                                            // mir::Constant
                                            // + span: $SRC_DIR/std/src/panic.rs:LL:COL
-                                           // + literal: Const { ty: &str, val: Value(Slice { data: Allocation { bytes: [101, 120, 112, 108, 105, 99, 105, 116, 32, 112, 97, 110, 105, 99], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [16383], len: Size { raw: 14 } }, align: Align { pow2: 0 }, mutability: Not, extra: () }, start: 0, end: 14 }) }
+                                           // + literal: Const { ty: &str, val: Value(Slice(..)) }
       }
   
       bb2: {

--- a/src/test/mir-opt/inline/inline_diverging.g.Inline.diff
+++ b/src/test/mir-opt/inline/inline_diverging.g.Inline.diff
@@ -43,7 +43,7 @@
 +                                          // + literal: Const { ty: fn(&str) -> ! {begin_panic::<&str>}, val: Value(Scalar(<ZST>)) }
 +                                          // mir::Constant
 +                                          // + span: $SRC_DIR/std/src/panic.rs:LL:COL
-+                                          // + literal: Const { ty: &str, val: Value(Slice { data: Allocation { bytes: [101, 120, 112, 108, 105, 99, 105, 116, 32, 112, 97, 110, 105, 99], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [16383], len: Size { raw: 14 } }, align: Align { pow2: 0 }, mutability: Not, extra: () }, start: 0, end: 14 }) }
++                                          // + literal: Const { ty: &str, val: Value(Slice(..)) }
       }
   }
   

--- a/src/test/mir-opt/inline/inline_into_box_place.main.Inline.32bit.diff
+++ b/src/test/mir-opt/inline/inline_into_box_place.main.Inline.32bit.diff
@@ -46,7 +46,7 @@
 -     bb2: {
 +                                          // + span: $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
 +                                          // + user_ty: UserType(0)
-+                                          // + literal: Const { ty: alloc::raw_vec::RawVec<u32>, val: Value(ByRef { alloc: Allocation { bytes: [4, 0, 0, 0, 0, 0, 0, 0], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [255], len: Size { raw: 8 } }, align: Align { pow2: 2 }, mutability: Not, extra: () }, offset: Size { raw: 0 } }) }
++                                          // + literal: Const { ty: alloc::raw_vec::RawVec<u32>, val: Value(ByRef(..)) }
 +         Deinit((*_7));                   // scope 3 at $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
 +         ((*_7).0: alloc::raw_vec::RawVec<u32>) = move _8; // scope 3 at $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
 +         ((*_7).1: usize) = const 0_usize; // scope 3 at $SRC_DIR/alloc/src/vec/mod.rs:LL:COL

--- a/src/test/mir-opt/inline/inline_into_box_place.main.Inline.64bit.diff
+++ b/src/test/mir-opt/inline/inline_into_box_place.main.Inline.64bit.diff
@@ -46,7 +46,7 @@
 -     bb2: {
 +                                          // + span: $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
 +                                          // + user_ty: UserType(0)
-+                                          // + literal: Const { ty: alloc::raw_vec::RawVec<u32>, val: Value(ByRef { alloc: Allocation { bytes: [4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [65535], len: Size { raw: 16 } }, align: Align { pow2: 3 }, mutability: Not, extra: () }, offset: Size { raw: 0 } }) }
++                                          // + literal: Const { ty: alloc::raw_vec::RawVec<u32>, val: Value(ByRef(..)) }
 +         Deinit((*_7));                   // scope 3 at $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
 +         ((*_7).0: alloc::raw_vec::RawVec<u32>) = move _8; // scope 3 at $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
 +         ((*_7).1: usize) = const 0_usize; // scope 3 at $SRC_DIR/alloc/src/vec/mod.rs:LL:COL

--- a/src/test/mir-opt/issue_76432.test.SimplifyComparisonIntegral.diff
+++ b/src/test/mir-opt/issue_76432.test.SimplifyComparisonIntegral.diff
@@ -73,7 +73,7 @@
                                            // + literal: Const { ty: fn(&'static str) -> ! {core::panicking::panic}, val: Value(Scalar(<ZST>)) }
                                            // mir::Constant
                                            // + span: $SRC_DIR/core/src/panic.rs:LL:COL
-                                           // + literal: Const { ty: &str, val: Value(Slice { data: Allocation { bytes: [105, 110, 116, 101, 114, 110, 97, 108, 32, 101, 114, 114, 111, 114, 58, 32, 101, 110, 116, 101, 114, 101, 100, 32, 117, 110, 114, 101, 97, 99, 104, 97, 98, 108, 101, 32, 99, 111, 100, 101], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [1099511627775], len: Size { raw: 40 } }, align: Align { pow2: 0 }, mutability: Not, extra: () }, start: 0, end: 40 }) }
+                                           // + literal: Const { ty: &str, val: Value(Slice(..)) }
       }
   
       bb2: {

--- a/src/test/mir-opt/issues/issue_59352.num_to_digit.PreCodegen.after.mir
+++ b/src/test/mir-opt/issues/issue_59352.num_to_digit.PreCodegen.after.mir
@@ -92,7 +92,7 @@ fn num_to_digit(_1: char) -> u32 {
                                          // + literal: Const { ty: fn(&'static str) -> ! {core::panicking::panic}, val: Value(Scalar(<ZST>)) }
                                          // mir::Constant
                                          // + span: $SRC_DIR/core/src/option.rs:LL:COL
-                                         // + literal: Const { ty: &str, val: Value(Slice { data: Allocation { bytes: [99, 97, 108, 108, 101, 100, 32, 96, 79, 112, 116, 105, 111, 110, 58, 58, 117, 110, 119, 114, 97, 112, 40, 41, 96, 32, 111, 110, 32, 97, 32, 96, 78, 111, 110, 101, 96, 32, 118, 97, 108, 117, 101], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [8796093022207], len: Size { raw: 43 } }, align: Align { pow2: 0 }, mutability: Not, extra: () }, start: 0, end: 43 }) }
+                                         // + literal: Const { ty: &str, val: Value(Slice(..)) }
     }
 
     bb7: {

--- a/src/test/mir-opt/no_drop_for_inactive_variant.unwrap.SimplifyCfg-elaborate-drops.after.mir
+++ b/src/test/mir-opt/no_drop_for_inactive_variant.unwrap.SimplifyCfg-elaborate-drops.after.mir
@@ -26,7 +26,7 @@ fn unwrap(_1: Option<T>) -> T {
                                          // + literal: Const { ty: fn(&str) -> ! {begin_panic::<&str>}, val: Value(Scalar(<ZST>)) }
                                          // mir::Constant
                                          // + span: $SRC_DIR/std/src/panic.rs:LL:COL
-                                         // + literal: Const { ty: &str, val: Value(Slice { data: Allocation { bytes: [101, 120, 112, 108, 105, 99, 105, 116, 32, 112, 97, 110, 105, 99], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [16383], len: Size { raw: 14 } }, align: Align { pow2: 0 }, mutability: Not, extra: () }, start: 0, end: 14 }) }
+                                         // + literal: Const { ty: &str, val: Value(Slice(..)) }
     }
 
     bb2: {

--- a/src/test/mir-opt/no_spurious_drop_after_call.main.ElaborateDrops.before.mir
+++ b/src/test/mir-opt/no_spurious_drop_after_call.main.ElaborateDrops.before.mir
@@ -15,7 +15,7 @@ fn main() -> () {
         _4 = const "";                   // scope 0 at $DIR/no-spurious-drop-after-call.rs:9:20: 9:22
                                          // mir::Constant
                                          // + span: $DIR/no-spurious-drop-after-call.rs:9:20: 9:22
-                                         // + literal: Const { ty: &str, val: Value(Slice { data: Allocation { bytes: [], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [], len: Size { raw: 0 } }, align: Align { pow2: 0 }, mutability: Not, extra: () }, start: 0, end: 0 }) }
+                                         // + literal: Const { ty: &str, val: Value(Slice(..)) }
         _3 = &(*_4);                     // scope 0 at $DIR/no-spurious-drop-after-call.rs:9:20: 9:34
         _2 = <str as ToString>::to_string(move _3) -> bb1; // scope 0 at $DIR/no-spurious-drop-after-call.rs:9:20: 9:34
                                          // mir::Constant

--- a/src/test/mir-opt/storage_live_dead_in_statics.XXX.mir_map.0.mir
+++ b/src/test/mir-opt/storage_live_dead_in_statics.XXX.mir_map.0.mir
@@ -192,7 +192,7 @@ static XXX: &Foo = {
         _2 = Foo { tup: const "hi", data: move _3 }; // scope 0 at $DIR/storage_live_dead_in_statics.rs:5:29: 23:2
                                          // mir::Constant
                                          // + span: $DIR/storage_live_dead_in_statics.rs:6:10: 6:14
-                                         // + literal: Const { ty: &str, val: Value(Slice { data: Allocation { bytes: [104, 105], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [3], len: Size { raw: 2 } }, align: Align { pow2: 0 }, mutability: Not, extra: () }, start: 0, end: 2 }) }
+                                         // + literal: Const { ty: &str, val: Value(Slice(..)) }
         StorageDead(_3);                 // scope 0 at $DIR/storage_live_dead_in_statics.rs:23:1: 23:2
         _1 = &_2;                        // scope 0 at $DIR/storage_live_dead_in_statics.rs:5:28: 23:2
         _0 = &(*_1);                     // scope 0 at $DIR/storage_live_dead_in_statics.rs:5:28: 23:2

--- a/src/test/mir-opt/uninhabited_enum_branching.main.SimplifyCfg-after-uninhabited-enum-branching.after.mir
+++ b/src/test/mir-opt/uninhabited_enum_branching.main.SimplifyCfg-after-uninhabited-enum-branching.after.mir
@@ -22,7 +22,7 @@ fn main() -> () {
         _5 = const "C";                  // scope 0 at $DIR/uninhabited_enum_branching.rs:23:21: 23:24
                                          // mir::Constant
                                          // + span: $DIR/uninhabited_enum_branching.rs:23:21: 23:24
-                                         // + literal: Const { ty: &str, val: Value(Slice { data: Allocation { bytes: [67], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [1], len: Size { raw: 1 } }, align: Align { pow2: 0 }, mutability: Not, extra: () }, start: 0, end: 1 }) }
+                                         // + literal: Const { ty: &str, val: Value(Slice(..)) }
         _1 = &(*_5);                     // scope 0 at $DIR/uninhabited_enum_branching.rs:23:21: 23:24
         StorageDead(_5);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:23:23: 23:24
         StorageDead(_2);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:24:6: 24:7
@@ -40,7 +40,7 @@ fn main() -> () {
         _9 = const "E";                  // scope 0 at $DIR/uninhabited_enum_branching.rs:28:21: 28:24
                                          // mir::Constant
                                          // + span: $DIR/uninhabited_enum_branching.rs:28:21: 28:24
-                                         // + literal: Const { ty: &str, val: Value(Slice { data: Allocation { bytes: [69], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [1], len: Size { raw: 1 } }, align: Align { pow2: 0 }, mutability: Not, extra: () }, start: 0, end: 1 }) }
+                                         // + literal: Const { ty: &str, val: Value(Slice(..)) }
         _6 = &(*_9);                     // scope 0 at $DIR/uninhabited_enum_branching.rs:28:21: 28:24
         StorageDead(_9);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:28:23: 28:24
         goto -> bb3;                     // scope 0 at $DIR/uninhabited_enum_branching.rs:28:23: 28:24
@@ -50,7 +50,7 @@ fn main() -> () {
         _6 = const "D";                  // scope 0 at $DIR/uninhabited_enum_branching.rs:27:21: 27:24
                                          // mir::Constant
                                          // + span: $DIR/uninhabited_enum_branching.rs:27:21: 27:24
-                                         // + literal: Const { ty: &str, val: Value(Slice { data: Allocation { bytes: [68], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [1], len: Size { raw: 1 } }, align: Align { pow2: 0 }, mutability: Not, extra: () }, start: 0, end: 1 }) }
+                                         // + literal: Const { ty: &str, val: Value(Slice(..)) }
         goto -> bb3;                     // scope 0 at $DIR/uninhabited_enum_branching.rs:27:21: 27:24
     }
 

--- a/src/test/mir-opt/uninhabited_enum_branching.main.UninhabitedEnumBranching.diff
+++ b/src/test/mir-opt/uninhabited_enum_branching.main.UninhabitedEnumBranching.diff
@@ -28,7 +28,7 @@
           _5 = const "C";                  // scope 0 at $DIR/uninhabited_enum_branching.rs:23:21: 23:24
                                            // mir::Constant
                                            // + span: $DIR/uninhabited_enum_branching.rs:23:21: 23:24
-                                           // + literal: Const { ty: &str, val: Value(Slice { data: Allocation { bytes: [67], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [1], len: Size { raw: 1 } }, align: Align { pow2: 0 }, mutability: Not, extra: () }, start: 0, end: 1 }) }
+                                           // + literal: Const { ty: &str, val: Value(Slice(..)) }
           _1 = &(*_5);                     // scope 0 at $DIR/uninhabited_enum_branching.rs:23:21: 23:24
           StorageDead(_5);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:23:23: 23:24
           goto -> bb4;                     // scope 0 at $DIR/uninhabited_enum_branching.rs:23:23: 23:24
@@ -38,7 +38,7 @@
           _1 = const "A(Empty)";           // scope 0 at $DIR/uninhabited_enum_branching.rs:21:24: 21:34
                                            // mir::Constant
                                            // + span: $DIR/uninhabited_enum_branching.rs:21:24: 21:34
-                                           // + literal: Const { ty: &str, val: Value(Slice { data: Allocation { bytes: [65, 40, 69, 109, 112, 116, 121, 41], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [255], len: Size { raw: 8 } }, align: Align { pow2: 0 }, mutability: Not, extra: () }, start: 0, end: 8 }) }
+                                           // + literal: Const { ty: &str, val: Value(Slice(..)) }
           goto -> bb4;                     // scope 0 at $DIR/uninhabited_enum_branching.rs:21:24: 21:34
       }
   
@@ -47,7 +47,7 @@
           _4 = const "B(Empty)";           // scope 0 at $DIR/uninhabited_enum_branching.rs:22:24: 22:34
                                            // mir::Constant
                                            // + span: $DIR/uninhabited_enum_branching.rs:22:24: 22:34
-                                           // + literal: Const { ty: &str, val: Value(Slice { data: Allocation { bytes: [66, 40, 69, 109, 112, 116, 121, 41], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [255], len: Size { raw: 8 } }, align: Align { pow2: 0 }, mutability: Not, extra: () }, start: 0, end: 8 }) }
+                                           // + literal: Const { ty: &str, val: Value(Slice(..)) }
           _1 = &(*_4);                     // scope 0 at $DIR/uninhabited_enum_branching.rs:22:24: 22:34
           StorageDead(_4);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:22:33: 22:34
           goto -> bb4;                     // scope 0 at $DIR/uninhabited_enum_branching.rs:22:33: 22:34
@@ -69,7 +69,7 @@
           _9 = const "E";                  // scope 0 at $DIR/uninhabited_enum_branching.rs:28:21: 28:24
                                            // mir::Constant
                                            // + span: $DIR/uninhabited_enum_branching.rs:28:21: 28:24
-                                           // + literal: Const { ty: &str, val: Value(Slice { data: Allocation { bytes: [69], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [1], len: Size { raw: 1 } }, align: Align { pow2: 0 }, mutability: Not, extra: () }, start: 0, end: 1 }) }
+                                           // + literal: Const { ty: &str, val: Value(Slice(..)) }
           _6 = &(*_9);                     // scope 0 at $DIR/uninhabited_enum_branching.rs:28:21: 28:24
           StorageDead(_9);                 // scope 0 at $DIR/uninhabited_enum_branching.rs:28:23: 28:24
           goto -> bb7;                     // scope 0 at $DIR/uninhabited_enum_branching.rs:28:23: 28:24
@@ -79,7 +79,7 @@
           _6 = const "D";                  // scope 0 at $DIR/uninhabited_enum_branching.rs:27:21: 27:24
                                            // mir::Constant
                                            // + span: $DIR/uninhabited_enum_branching.rs:27:21: 27:24
-                                           // + literal: Const { ty: &str, val: Value(Slice { data: Allocation { bytes: [68], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [1], len: Size { raw: 1 } }, align: Align { pow2: 0 }, mutability: Not, extra: () }, start: 0, end: 1 }) }
+                                           // + literal: Const { ty: &str, val: Value(Slice(..)) }
           goto -> bb7;                     // scope 0 at $DIR/uninhabited_enum_branching.rs:27:21: 27:24
       }
   

--- a/src/test/mir-opt/uninhabited_enum_branching2.main.SimplifyCfg-after-uninhabited-enum-branching.after.mir
+++ b/src/test/mir-opt/uninhabited_enum_branching2.main.SimplifyCfg-after-uninhabited-enum-branching.after.mir
@@ -40,7 +40,7 @@ fn main() -> () {
         _8 = const "D";                  // scope 1 at $DIR/uninhabited_enum_branching2.rs:25:21: 25:24
                                          // mir::Constant
                                          // + span: $DIR/uninhabited_enum_branching2.rs:25:21: 25:24
-                                         // + literal: Const { ty: &str, val: Value(Slice { data: Allocation { bytes: [68], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [1], len: Size { raw: 1 } }, align: Align { pow2: 0 }, mutability: Not, extra: () }, start: 0, end: 1 }) }
+                                         // + literal: Const { ty: &str, val: Value(Slice(..)) }
         _3 = &(*_8);                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:25:21: 25:24
         StorageDead(_8);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:25:23: 25:24
         goto -> bb3;                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:25:23: 25:24
@@ -51,7 +51,7 @@ fn main() -> () {
         _7 = const "C";                  // scope 1 at $DIR/uninhabited_enum_branching2.rs:24:21: 24:24
                                          // mir::Constant
                                          // + span: $DIR/uninhabited_enum_branching2.rs:24:21: 24:24
-                                         // + literal: Const { ty: &str, val: Value(Slice { data: Allocation { bytes: [67], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [1], len: Size { raw: 1 } }, align: Align { pow2: 0 }, mutability: Not, extra: () }, start: 0, end: 1 }) }
+                                         // + literal: Const { ty: &str, val: Value(Slice(..)) }
         _3 = &(*_7);                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:24:21: 24:24
         StorageDead(_7);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:24:23: 24:24
         goto -> bb3;                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:24:23: 24:24
@@ -70,7 +70,7 @@ fn main() -> () {
         _13 = const "D";                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:32:21: 32:24
                                          // mir::Constant
                                          // + span: $DIR/uninhabited_enum_branching2.rs:32:21: 32:24
-                                         // + literal: Const { ty: &str, val: Value(Slice { data: Allocation { bytes: [68], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [1], len: Size { raw: 1 } }, align: Align { pow2: 0 }, mutability: Not, extra: () }, start: 0, end: 1 }) }
+                                         // + literal: Const { ty: &str, val: Value(Slice(..)) }
         _9 = &(*_13);                    // scope 1 at $DIR/uninhabited_enum_branching2.rs:32:21: 32:24
         StorageDead(_13);                // scope 1 at $DIR/uninhabited_enum_branching2.rs:32:23: 32:24
         goto -> bb6;                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:32:23: 32:24
@@ -81,7 +81,7 @@ fn main() -> () {
         _12 = const "C";                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:31:21: 31:24
                                          // mir::Constant
                                          // + span: $DIR/uninhabited_enum_branching2.rs:31:21: 31:24
-                                         // + literal: Const { ty: &str, val: Value(Slice { data: Allocation { bytes: [67], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [1], len: Size { raw: 1 } }, align: Align { pow2: 0 }, mutability: Not, extra: () }, start: 0, end: 1 }) }
+                                         // + literal: Const { ty: &str, val: Value(Slice(..)) }
         _9 = &(*_12);                    // scope 1 at $DIR/uninhabited_enum_branching2.rs:31:21: 31:24
         StorageDead(_12);                // scope 1 at $DIR/uninhabited_enum_branching2.rs:31:23: 31:24
         goto -> bb6;                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:31:23: 31:24

--- a/src/test/mir-opt/uninhabited_enum_branching2.main.UninhabitedEnumBranching.diff
+++ b/src/test/mir-opt/uninhabited_enum_branching2.main.UninhabitedEnumBranching.diff
@@ -42,7 +42,7 @@
           _8 = const "D";                  // scope 1 at $DIR/uninhabited_enum_branching2.rs:25:21: 25:24
                                            // mir::Constant
                                            // + span: $DIR/uninhabited_enum_branching2.rs:25:21: 25:24
-                                           // + literal: Const { ty: &str, val: Value(Slice { data: Allocation { bytes: [68], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [1], len: Size { raw: 1 } }, align: Align { pow2: 0 }, mutability: Not, extra: () }, start: 0, end: 1 }) }
+                                           // + literal: Const { ty: &str, val: Value(Slice(..)) }
           _3 = &(*_8);                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:25:21: 25:24
           StorageDead(_8);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:25:23: 25:24
           goto -> bb5;                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:25:23: 25:24
@@ -52,7 +52,7 @@
           _3 = const "A(Empty)";           // scope 1 at $DIR/uninhabited_enum_branching2.rs:22:24: 22:34
                                            // mir::Constant
                                            // + span: $DIR/uninhabited_enum_branching2.rs:22:24: 22:34
-                                           // + literal: Const { ty: &str, val: Value(Slice { data: Allocation { bytes: [65, 40, 69, 109, 112, 116, 121, 41], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [255], len: Size { raw: 8 } }, align: Align { pow2: 0 }, mutability: Not, extra: () }, start: 0, end: 8 }) }
+                                           // + literal: Const { ty: &str, val: Value(Slice(..)) }
           goto -> bb5;                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:22:24: 22:34
       }
   
@@ -61,7 +61,7 @@
           _6 = const "B(Empty)";           // scope 1 at $DIR/uninhabited_enum_branching2.rs:23:24: 23:34
                                            // mir::Constant
                                            // + span: $DIR/uninhabited_enum_branching2.rs:23:24: 23:34
-                                           // + literal: Const { ty: &str, val: Value(Slice { data: Allocation { bytes: [66, 40, 69, 109, 112, 116, 121, 41], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [255], len: Size { raw: 8 } }, align: Align { pow2: 0 }, mutability: Not, extra: () }, start: 0, end: 8 }) }
+                                           // + literal: Const { ty: &str, val: Value(Slice(..)) }
           _3 = &(*_6);                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:23:24: 23:34
           StorageDead(_6);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:23:33: 23:34
           goto -> bb5;                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:23:33: 23:34
@@ -72,7 +72,7 @@
           _7 = const "C";                  // scope 1 at $DIR/uninhabited_enum_branching2.rs:24:21: 24:24
                                            // mir::Constant
                                            // + span: $DIR/uninhabited_enum_branching2.rs:24:21: 24:24
-                                           // + literal: Const { ty: &str, val: Value(Slice { data: Allocation { bytes: [67], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [1], len: Size { raw: 1 } }, align: Align { pow2: 0 }, mutability: Not, extra: () }, start: 0, end: 1 }) }
+                                           // + literal: Const { ty: &str, val: Value(Slice(..)) }
           _3 = &(*_7);                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:24:21: 24:24
           StorageDead(_7);                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:24:23: 24:24
           goto -> bb5;                     // scope 1 at $DIR/uninhabited_enum_branching2.rs:24:23: 24:24
@@ -92,7 +92,7 @@
           _13 = const "D";                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:32:21: 32:24
                                            // mir::Constant
                                            // + span: $DIR/uninhabited_enum_branching2.rs:32:21: 32:24
-                                           // + literal: Const { ty: &str, val: Value(Slice { data: Allocation { bytes: [68], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [1], len: Size { raw: 1 } }, align: Align { pow2: 0 }, mutability: Not, extra: () }, start: 0, end: 1 }) }
+                                           // + literal: Const { ty: &str, val: Value(Slice(..)) }
           _9 = &(*_13);                    // scope 1 at $DIR/uninhabited_enum_branching2.rs:32:21: 32:24
           StorageDead(_13);                // scope 1 at $DIR/uninhabited_enum_branching2.rs:32:23: 32:24
           goto -> bb10;                    // scope 1 at $DIR/uninhabited_enum_branching2.rs:32:23: 32:24
@@ -102,7 +102,7 @@
           _9 = const "A(Empty)";           // scope 1 at $DIR/uninhabited_enum_branching2.rs:29:24: 29:34
                                            // mir::Constant
                                            // + span: $DIR/uninhabited_enum_branching2.rs:29:24: 29:34
-                                           // + literal: Const { ty: &str, val: Value(Slice { data: Allocation { bytes: [65, 40, 69, 109, 112, 116, 121, 41], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [255], len: Size { raw: 8 } }, align: Align { pow2: 0 }, mutability: Not, extra: () }, start: 0, end: 8 }) }
+                                           // + literal: Const { ty: &str, val: Value(Slice(..)) }
           goto -> bb10;                    // scope 1 at $DIR/uninhabited_enum_branching2.rs:29:24: 29:34
       }
   
@@ -111,7 +111,7 @@
           _11 = const "B(Empty)";          // scope 1 at $DIR/uninhabited_enum_branching2.rs:30:24: 30:34
                                            // mir::Constant
                                            // + span: $DIR/uninhabited_enum_branching2.rs:30:24: 30:34
-                                           // + literal: Const { ty: &str, val: Value(Slice { data: Allocation { bytes: [66, 40, 69, 109, 112, 116, 121, 41], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [255], len: Size { raw: 8 } }, align: Align { pow2: 0 }, mutability: Not, extra: () }, start: 0, end: 8 }) }
+                                           // + literal: Const { ty: &str, val: Value(Slice(..)) }
           _9 = &(*_11);                    // scope 1 at $DIR/uninhabited_enum_branching2.rs:30:24: 30:34
           StorageDead(_11);                // scope 1 at $DIR/uninhabited_enum_branching2.rs:30:33: 30:34
           goto -> bb10;                    // scope 1 at $DIR/uninhabited_enum_branching2.rs:30:33: 30:34
@@ -122,7 +122,7 @@
           _12 = const "C";                 // scope 1 at $DIR/uninhabited_enum_branching2.rs:31:21: 31:24
                                            // mir::Constant
                                            // + span: $DIR/uninhabited_enum_branching2.rs:31:21: 31:24
-                                           // + literal: Const { ty: &str, val: Value(Slice { data: Allocation { bytes: [67], relocations: Relocations(SortedMap { data: [] }), init_mask: InitMask { blocks: [1], len: Size { raw: 1 } }, align: Align { pow2: 0 }, mutability: Not, extra: () }, start: 0, end: 1 }) }
+                                           // + literal: Const { ty: &str, val: Value(Slice(..)) }
           _9 = &(*_12);                    // scope 1 at $DIR/uninhabited_enum_branching2.rs:31:21: 31:24
           StorageDead(_12);                // scope 1 at $DIR/uninhabited_enum_branching2.rs:31:23: 31:24
           goto -> bb10;                    // scope 1 at $DIR/uninhabited_enum_branching2.rs:31:23: 31:24

--- a/src/test/rustdoc/check-source-code-urls-to-def.rs
+++ b/src/test/rustdoc/check-source-code-urls-to-def.rs
@@ -46,6 +46,24 @@ pub fn foo(a: u32, b: &str, c: String, d: Foo, e: bar::Bar, f: source_code::Sour
 // @has - '//a[@href="../../src/foo/auxiliary/source-code-bar.rs.html#14-16"]' 'Trait'
 pub fn foo2<T: bar::sub::Trait, V: Trait>(t: &T, v: &V, b: bool) {}
 
+pub trait AnotherTrait {}
+pub trait WhyNot {}
+
+// @has - '//a[@href="../../src/foo/check-source-code-urls-to-def.rs.html#49"]' 'AnotherTrait'
+// @has - '//a[@href="../../src/foo/check-source-code-urls-to-def.rs.html#50"]' 'WhyNot'
+pub fn foo3<T, V>(t: &T, v: &V)
+where
+    T: AnotherTrait,
+    V: WhyNot
+{}
+
+pub trait AnotherTrait2 {}
+
+// @has - '//a[@href="../../src/foo/check-source-code-urls-to-def.rs.html#60"]' 'AnotherTrait2'
+pub fn foo4() {
+    let x: Vec<AnotherTrait2> = Vec::new();
+}
+
 // @has - '//a[@href="../../foo/primitive.bool.html"]' 'bool'
 #[doc(primitive = "bool")]
 mod whatever {}

--- a/src/test/ui-fulldeps/session-diagnostic/diagnostic-derive.rs
+++ b/src/test/ui-fulldeps/session-diagnostic/diagnostic-derive.rs
@@ -474,3 +474,11 @@ struct Subdiagnostic {
     #[subdiagnostic]
     note: Note,
 }
+
+#[derive(SessionDiagnostic)]
+#[error(code = "E0123", slug = "foo")]
+struct VecField {
+    #[primary_span]
+    #[label]
+    spans: Vec<Span>,
+}

--- a/src/test/ui/layout/debug.rs
+++ b/src/test/ui/layout/debug.rs
@@ -1,4 +1,4 @@
-// normalize-stderr-test "pref: Align \{\n *pow2: [1-3],\n *\}" -> "pref: $$PREF_ALIGN"
+// normalize-stderr-test "pref: Align\([1-8] bytes\)" -> "pref: $$PREF_ALIGN"
 #![feature(never_type, rustc_attrs, type_alias_impl_trait)]
 #![crate_type = "lib"]
 

--- a/src/test/ui/layout/debug.stderr
+++ b/src/test/ui/layout/debug.stderr
@@ -1,9 +1,7 @@
 error: layout_of(E) = Layout {
            fields: Arbitrary {
                offsets: [
-                   Size {
-                       raw: 0,
-                   },
+                   Size(0 bytes),
                ],
                memory_index: [
                    0,
@@ -33,27 +31,17 @@ error: layout_of(E) = Layout {
                        },
                        largest_niche: None,
                        align: AbiAndPrefAlign {
-                           abi: Align {
-                               pow2: 0,
-                           },
+                           abi: Align(1 bytes),
                            pref: $PREF_ALIGN,
                        },
-                       size: Size {
-                           raw: 4,
-                       },
+                       size: Size(4 bytes),
                    },
                    Layout {
                        fields: Arbitrary {
                            offsets: [
-                               Size {
-                                   raw: 4,
-                               },
-                               Size {
-                                   raw: 4,
-                               },
-                               Size {
-                                   raw: 8,
-                               },
+                               Size(4 bytes),
+                               Size(4 bytes),
+                               Size(8 bytes),
                            ],
                            memory_index: [
                                0,
@@ -67,14 +55,10 @@ error: layout_of(E) = Layout {
                        abi: Uninhabited,
                        largest_niche: None,
                        align: AbiAndPrefAlign {
-                           abi: Align {
-                               pow2: 2,
-                           },
+                           abi: Align(4 bytes),
                            pref: $PREF_ALIGN,
                        },
-                       size: Size {
-                           raw: 12,
-                       },
+                       size: Size(12 bytes),
                    },
                ],
            },
@@ -83,9 +67,7 @@ error: layout_of(E) = Layout {
            },
            largest_niche: Some(
                Niche {
-                   offset: Size {
-                       raw: 0,
-                   },
+                   offset: Size(0 bytes),
                    value: Int(
                        I32,
                        false,
@@ -94,14 +76,10 @@ error: layout_of(E) = Layout {
                },
            ),
            align: AbiAndPrefAlign {
-               abi: Align {
-                   pow2: 2,
-               },
+               abi: Align(4 bytes),
                pref: $PREF_ALIGN,
            },
-           size: Size {
-               raw: 12,
-           },
+           size: Size(12 bytes),
        }
   --> $DIR/debug.rs:6:1
    |
@@ -111,15 +89,9 @@ LL | enum E { Foo, Bar(!, i32, i32) }
 error: layout_of(S) = Layout {
            fields: Arbitrary {
                offsets: [
-                   Size {
-                       raw: 0,
-                   },
-                   Size {
-                       raw: 0,
-                   },
-                   Size {
-                       raw: 4,
-                   },
+                   Size(0 bytes),
+                   Size(0 bytes),
+                   Size(4 bytes),
                ],
                memory_index: [
                    1,
@@ -148,14 +120,10 @@ error: layout_of(S) = Layout {
            ),
            largest_niche: None,
            align: AbiAndPrefAlign {
-               abi: Align {
-                   pow2: 2,
-               },
+               abi: Align(4 bytes),
                pref: $PREF_ALIGN,
            },
-           size: Size {
-               raw: 8,
-           },
+           size: Size(8 bytes),
        }
   --> $DIR/debug.rs:9:1
    |
@@ -174,14 +142,10 @@ error: layout_of(U) = Layout {
            },
            largest_niche: None,
            align: AbiAndPrefAlign {
-               abi: Align {
-                   pow2: 2,
-               },
+               abi: Align(4 bytes),
                pref: $PREF_ALIGN,
            },
-           size: Size {
-               raw: 8,
-           },
+           size: Size(8 bytes),
        }
   --> $DIR/debug.rs:12:1
    |
@@ -191,9 +155,7 @@ LL | union U { f1: (i32, i32), f3: i32 }
 error: layout_of(std::result::Result<i32, i32>) = Layout {
            fields: Arbitrary {
                offsets: [
-                   Size {
-                       raw: 0,
-                   },
+                   Size(0 bytes),
                ],
                memory_index: [
                    0,
@@ -213,9 +175,7 @@ error: layout_of(std::result::Result<i32, i32>) = Layout {
                    Layout {
                        fields: Arbitrary {
                            offsets: [
-                               Size {
-                                   raw: 4,
-                               },
+                               Size(4 bytes),
                            ],
                            memory_index: [
                                0,
@@ -229,21 +189,15 @@ error: layout_of(std::result::Result<i32, i32>) = Layout {
                        },
                        largest_niche: None,
                        align: AbiAndPrefAlign {
-                           abi: Align {
-                               pow2: 2,
-                           },
+                           abi: Align(4 bytes),
                            pref: $PREF_ALIGN,
                        },
-                       size: Size {
-                           raw: 8,
-                       },
+                       size: Size(8 bytes),
                    },
                    Layout {
                        fields: Arbitrary {
                            offsets: [
-                               Size {
-                                   raw: 4,
-                               },
+                               Size(4 bytes),
                            ],
                            memory_index: [
                                0,
@@ -257,14 +211,10 @@ error: layout_of(std::result::Result<i32, i32>) = Layout {
                        },
                        largest_niche: None,
                        align: AbiAndPrefAlign {
-                           abi: Align {
-                               pow2: 2,
-                           },
+                           abi: Align(4 bytes),
                            pref: $PREF_ALIGN,
                        },
-                       size: Size {
-                           raw: 8,
-                       },
+                       size: Size(8 bytes),
                    },
                ],
            },
@@ -286,9 +236,7 @@ error: layout_of(std::result::Result<i32, i32>) = Layout {
            ),
            largest_niche: Some(
                Niche {
-                   offset: Size {
-                       raw: 0,
-                   },
+                   offset: Size(0 bytes),
                    value: Int(
                        I32,
                        false,
@@ -297,14 +245,10 @@ error: layout_of(std::result::Result<i32, i32>) = Layout {
                },
            ),
            align: AbiAndPrefAlign {
-               abi: Align {
-                   pow2: 2,
-               },
+               abi: Align(4 bytes),
                pref: $PREF_ALIGN,
            },
-           size: Size {
-               raw: 8,
-           },
+           size: Size(8 bytes),
        }
   --> $DIR/debug.rs:15:1
    |
@@ -327,14 +271,10 @@ error: layout_of(i32) = Layout {
            ),
            largest_niche: None,
            align: AbiAndPrefAlign {
-               abi: Align {
-                   pow2: 2,
-               },
+               abi: Align(4 bytes),
                pref: $PREF_ALIGN,
            },
-           size: Size {
-               raw: 4,
-           },
+           size: Size(4 bytes),
        }
   --> $DIR/debug.rs:18:1
    |

--- a/src/test/ui/layout/hexagon-enum.stderr
+++ b/src/test/ui/layout/hexagon-enum.stderr
@@ -1,9 +1,7 @@
 error: layout_of(A) = Layout {
            fields: Arbitrary {
                offsets: [
-                   Size {
-                       raw: 0,
-                   },
+                   Size(0 bytes),
                ],
                memory_index: [
                    0,
@@ -33,16 +31,10 @@ error: layout_of(A) = Layout {
                        },
                        largest_niche: None,
                        align: AbiAndPrefAlign {
-                           abi: Align {
-                               pow2: 0,
-                           },
-                           pref: Align {
-                               pow2: 0,
-                           },
+                           abi: Align(1 bytes),
+                           pref: Align(1 bytes),
                        },
-                       size: Size {
-                           raw: 1,
-                       },
+                       size: Size(1 bytes),
                    },
                ],
            },
@@ -57,9 +49,7 @@ error: layout_of(A) = Layout {
            ),
            largest_niche: Some(
                Niche {
-                   offset: Size {
-                       raw: 0,
-                   },
+                   offset: Size(0 bytes),
                    value: Int(
                        I8,
                        false,
@@ -68,16 +58,10 @@ error: layout_of(A) = Layout {
                },
            ),
            align: AbiAndPrefAlign {
-               abi: Align {
-                   pow2: 0,
-               },
-               pref: Align {
-                   pow2: 0,
-               },
+               abi: Align(1 bytes),
+               pref: Align(1 bytes),
            },
-           size: Size {
-               raw: 1,
-           },
+           size: Size(1 bytes),
        }
   --> $DIR/hexagon-enum.rs:16:1
    |
@@ -87,9 +71,7 @@ LL | enum A { Apple }
 error: layout_of(B) = Layout {
            fields: Arbitrary {
                offsets: [
-                   Size {
-                       raw: 0,
-                   },
+                   Size(0 bytes),
                ],
                memory_index: [
                    0,
@@ -119,16 +101,10 @@ error: layout_of(B) = Layout {
                        },
                        largest_niche: None,
                        align: AbiAndPrefAlign {
-                           abi: Align {
-                               pow2: 0,
-                           },
-                           pref: Align {
-                               pow2: 0,
-                           },
+                           abi: Align(1 bytes),
+                           pref: Align(1 bytes),
                        },
-                       size: Size {
-                           raw: 1,
-                       },
+                       size: Size(1 bytes),
                    },
                ],
            },
@@ -143,9 +119,7 @@ error: layout_of(B) = Layout {
            ),
            largest_niche: Some(
                Niche {
-                   offset: Size {
-                       raw: 0,
-                   },
+                   offset: Size(0 bytes),
                    value: Int(
                        I8,
                        false,
@@ -154,16 +128,10 @@ error: layout_of(B) = Layout {
                },
            ),
            align: AbiAndPrefAlign {
-               abi: Align {
-                   pow2: 0,
-               },
-               pref: Align {
-                   pow2: 0,
-               },
+               abi: Align(1 bytes),
+               pref: Align(1 bytes),
            },
-           size: Size {
-               raw: 1,
-           },
+           size: Size(1 bytes),
        }
   --> $DIR/hexagon-enum.rs:20:1
    |
@@ -173,9 +141,7 @@ LL | enum B { Banana = 255, }
 error: layout_of(C) = Layout {
            fields: Arbitrary {
                offsets: [
-                   Size {
-                       raw: 0,
-                   },
+                   Size(0 bytes),
                ],
                memory_index: [
                    0,
@@ -205,16 +171,10 @@ error: layout_of(C) = Layout {
                        },
                        largest_niche: None,
                        align: AbiAndPrefAlign {
-                           abi: Align {
-                               pow2: 1,
-                           },
-                           pref: Align {
-                               pow2: 1,
-                           },
+                           abi: Align(2 bytes),
+                           pref: Align(2 bytes),
                        },
-                       size: Size {
-                           raw: 2,
-                       },
+                       size: Size(2 bytes),
                    },
                ],
            },
@@ -229,9 +189,7 @@ error: layout_of(C) = Layout {
            ),
            largest_niche: Some(
                Niche {
-                   offset: Size {
-                       raw: 0,
-                   },
+                   offset: Size(0 bytes),
                    value: Int(
                        I16,
                        false,
@@ -240,16 +198,10 @@ error: layout_of(C) = Layout {
                },
            ),
            align: AbiAndPrefAlign {
-               abi: Align {
-                   pow2: 1,
-               },
-               pref: Align {
-                   pow2: 1,
-               },
+               abi: Align(2 bytes),
+               pref: Align(2 bytes),
            },
-           size: Size {
-               raw: 2,
-           },
+           size: Size(2 bytes),
        }
   --> $DIR/hexagon-enum.rs:24:1
    |
@@ -259,9 +211,7 @@ LL | enum C { Chaenomeles = 256, }
 error: layout_of(P) = Layout {
            fields: Arbitrary {
                offsets: [
-                   Size {
-                       raw: 0,
-                   },
+                   Size(0 bytes),
                ],
                memory_index: [
                    0,
@@ -291,16 +241,10 @@ error: layout_of(P) = Layout {
                        },
                        largest_niche: None,
                        align: AbiAndPrefAlign {
-                           abi: Align {
-                               pow2: 2,
-                           },
-                           pref: Align {
-                               pow2: 2,
-                           },
+                           abi: Align(4 bytes),
+                           pref: Align(4 bytes),
                        },
-                       size: Size {
-                           raw: 4,
-                       },
+                       size: Size(4 bytes),
                    },
                ],
            },
@@ -315,9 +259,7 @@ error: layout_of(P) = Layout {
            ),
            largest_niche: Some(
                Niche {
-                   offset: Size {
-                       raw: 0,
-                   },
+                   offset: Size(0 bytes),
                    value: Int(
                        I32,
                        false,
@@ -326,16 +268,10 @@ error: layout_of(P) = Layout {
                },
            ),
            align: AbiAndPrefAlign {
-               abi: Align {
-                   pow2: 2,
-               },
-               pref: Align {
-                   pow2: 2,
-               },
+               abi: Align(4 bytes),
+               pref: Align(4 bytes),
            },
-           size: Size {
-               raw: 4,
-           },
+           size: Size(4 bytes),
        }
   --> $DIR/hexagon-enum.rs:28:1
    |
@@ -345,9 +281,7 @@ LL | enum P { Peach = 0x1000_0000isize, }
 error: layout_of(T) = Layout {
            fields: Arbitrary {
                offsets: [
-                   Size {
-                       raw: 0,
-                   },
+                   Size(0 bytes),
                ],
                memory_index: [
                    0,
@@ -377,16 +311,10 @@ error: layout_of(T) = Layout {
                        },
                        largest_niche: None,
                        align: AbiAndPrefAlign {
-                           abi: Align {
-                               pow2: 2,
-                           },
-                           pref: Align {
-                               pow2: 2,
-                           },
+                           abi: Align(4 bytes),
+                           pref: Align(4 bytes),
                        },
-                       size: Size {
-                           raw: 4,
-                       },
+                       size: Size(4 bytes),
                    },
                ],
            },
@@ -401,9 +329,7 @@ error: layout_of(T) = Layout {
            ),
            largest_niche: Some(
                Niche {
-                   offset: Size {
-                       raw: 0,
-                   },
+                   offset: Size(0 bytes),
                    value: Int(
                        I32,
                        true,
@@ -412,16 +338,10 @@ error: layout_of(T) = Layout {
                },
            ),
            align: AbiAndPrefAlign {
-               abi: Align {
-                   pow2: 2,
-               },
-               pref: Align {
-                   pow2: 2,
-               },
+               abi: Align(4 bytes),
+               pref: Align(4 bytes),
            },
-           size: Size {
-               raw: 4,
-           },
+           size: Size(4 bytes),
        }
   --> $DIR/hexagon-enum.rs:34:1
    |

--- a/src/test/ui/layout/homogeneous-aggr-zero-sized-c-struct.stderr
+++ b/src/test/ui/layout/homogeneous-aggr-zero-sized-c-struct.stderr
@@ -1,10 +1,10 @@
-error: homogeneous_aggregate: Ok(Homogeneous(Reg { kind: Float, size: Size { raw: 4 } }))
+error: homogeneous_aggregate: Ok(Homogeneous(Reg { kind: Float, size: Size(4 bytes) }))
   --> $DIR/homogeneous-aggr-zero-sized-c-struct.rs:22:1
    |
 LL | pub type TestMiddle = Middle;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: homogeneous_aggregate: Ok(Homogeneous(Reg { kind: Float, size: Size { raw: 4 } }))
+error: homogeneous_aggregate: Ok(Homogeneous(Reg { kind: Float, size: Size(4 bytes) }))
   --> $DIR/homogeneous-aggr-zero-sized-c-struct.rs:33:1
    |
 LL | pub type TestFinal = Final;

--- a/src/test/ui/layout/homogeneous-aggr-zero-sized-repr-rust.rs
+++ b/src/test/ui/layout/homogeneous-aggr-zero-sized-repr-rust.rs
@@ -17,8 +17,7 @@ pub struct WithPhantomData {
     pub _unit: std::marker::PhantomData<()>,
 }
 
-pub struct EmptyRustStruct {
-}
+pub struct EmptyRustStruct {}
 
 #[repr(C)]
 pub struct WithEmptyRustStruct {
@@ -52,22 +51,22 @@ pub struct WithEmptyRustEnum {
 
 #[rustc_layout(homogeneous_aggregate)]
 pub type Test1 = BaseCase;
-//~^ ERROR homogeneous_aggregate: Ok(Homogeneous(Reg { kind: Float, size: Size { raw: 4 } }))
+//~^ ERROR homogeneous_aggregate: Ok(Homogeneous(Reg { kind: Float, size: Size(4 bytes) }))
 
 #[rustc_layout(homogeneous_aggregate)]
 pub type Test2 = WithPhantomData;
-//~^ ERROR homogeneous_aggregate: Ok(Homogeneous(Reg { kind: Float, size: Size { raw: 4 } }))
+//~^ ERROR homogeneous_aggregate: Ok(Homogeneous(Reg { kind: Float, size: Size(4 bytes) }))
 
 #[rustc_layout(homogeneous_aggregate)]
 pub type Test3 = WithEmptyRustStruct;
-//~^ ERROR homogeneous_aggregate: Ok(Homogeneous(Reg { kind: Float, size: Size { raw: 4 } }))
+//~^ ERROR homogeneous_aggregate: Ok(Homogeneous(Reg { kind: Float, size: Size(4 bytes) }))
 
 #[rustc_layout(homogeneous_aggregate)]
 pub type Test4 = WithTransitivelyEmptyRustStruct;
-//~^ ERROR homogeneous_aggregate: Ok(Homogeneous(Reg { kind: Float, size: Size { raw: 4 } }))
+//~^ ERROR homogeneous_aggregate: Ok(Homogeneous(Reg { kind: Float, size: Size(4 bytes) }))
 
 #[rustc_layout(homogeneous_aggregate)]
 pub type Test5 = WithEmptyRustEnum;
-//~^ ERROR homogeneous_aggregate: Ok(Homogeneous(Reg { kind: Float, size: Size { raw: 4 } }))
+//~^ ERROR homogeneous_aggregate: Ok(Homogeneous(Reg { kind: Float, size: Size(4 bytes) }))
 
-fn main() { }
+fn main() {}

--- a/src/test/ui/layout/homogeneous-aggr-zero-sized-repr-rust.stderr
+++ b/src/test/ui/layout/homogeneous-aggr-zero-sized-repr-rust.stderr
@@ -1,29 +1,29 @@
-error: homogeneous_aggregate: Ok(Homogeneous(Reg { kind: Float, size: Size { raw: 4 } }))
-  --> $DIR/homogeneous-aggr-zero-sized-repr-rust.rs:54:1
+error: homogeneous_aggregate: Ok(Homogeneous(Reg { kind: Float, size: Size(4 bytes) }))
+  --> $DIR/homogeneous-aggr-zero-sized-repr-rust.rs:53:1
    |
 LL | pub type Test1 = BaseCase;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: homogeneous_aggregate: Ok(Homogeneous(Reg { kind: Float, size: Size { raw: 4 } }))
-  --> $DIR/homogeneous-aggr-zero-sized-repr-rust.rs:58:1
+error: homogeneous_aggregate: Ok(Homogeneous(Reg { kind: Float, size: Size(4 bytes) }))
+  --> $DIR/homogeneous-aggr-zero-sized-repr-rust.rs:57:1
    |
 LL | pub type Test2 = WithPhantomData;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: homogeneous_aggregate: Ok(Homogeneous(Reg { kind: Float, size: Size { raw: 4 } }))
-  --> $DIR/homogeneous-aggr-zero-sized-repr-rust.rs:62:1
+error: homogeneous_aggregate: Ok(Homogeneous(Reg { kind: Float, size: Size(4 bytes) }))
+  --> $DIR/homogeneous-aggr-zero-sized-repr-rust.rs:61:1
    |
 LL | pub type Test3 = WithEmptyRustStruct;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: homogeneous_aggregate: Ok(Homogeneous(Reg { kind: Float, size: Size { raw: 4 } }))
-  --> $DIR/homogeneous-aggr-zero-sized-repr-rust.rs:66:1
+error: homogeneous_aggregate: Ok(Homogeneous(Reg { kind: Float, size: Size(4 bytes) }))
+  --> $DIR/homogeneous-aggr-zero-sized-repr-rust.rs:65:1
    |
 LL | pub type Test4 = WithTransitivelyEmptyRustStruct;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: homogeneous_aggregate: Ok(Homogeneous(Reg { kind: Float, size: Size { raw: 4 } }))
-  --> $DIR/homogeneous-aggr-zero-sized-repr-rust.rs:70:1
+error: homogeneous_aggregate: Ok(Homogeneous(Reg { kind: Float, size: Size(4 bytes) }))
+  --> $DIR/homogeneous-aggr-zero-sized-repr-rust.rs:69:1
    |
 LL | pub type Test5 = WithEmptyRustEnum;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/test/ui/layout/issue-96158-scalarpair-payload-might-be-uninit.rs
+++ b/src/test/ui/layout/issue-96158-scalarpair-payload-might-be-uninit.rs
@@ -1,4 +1,4 @@
-// normalize-stderr-test "pref: Align \{\n *pow2: [1-3],\n *\}" -> "pref: $$PREF_ALIGN"
+// normalize-stderr-test "pref: Align\([1-8] bytes\)" -> "pref: $$PREF_ALIGN"
 #![crate_type = "lib"]
 #![feature(rustc_attrs)]
 

--- a/src/test/ui/layout/issue-96158-scalarpair-payload-might-be-uninit.stderr
+++ b/src/test/ui/layout/issue-96158-scalarpair-payload-might-be-uninit.stderr
@@ -1,9 +1,7 @@
 error: layout_of(MissingPayloadField) = Layout {
            fields: Arbitrary {
                offsets: [
-                   Size {
-                       raw: 0,
-                   },
+                   Size(0 bytes),
                ],
                memory_index: [
                    0,
@@ -23,9 +21,7 @@ error: layout_of(MissingPayloadField) = Layout {
                    Layout {
                        fields: Arbitrary {
                            offsets: [
-                               Size {
-                                   raw: 1,
-                               },
+                               Size(1 bytes),
                            ],
                            memory_index: [
                                0,
@@ -39,14 +35,10 @@ error: layout_of(MissingPayloadField) = Layout {
                        },
                        largest_niche: None,
                        align: AbiAndPrefAlign {
-                           abi: Align {
-                               pow2: 0,
-                           },
+                           abi: Align(1 bytes),
                            pref: $PREF_ALIGN,
                        },
-                       size: Size {
-                           raw: 2,
-                       },
+                       size: Size(2 bytes),
                    },
                    Layout {
                        fields: Arbitrary {
@@ -61,14 +53,10 @@ error: layout_of(MissingPayloadField) = Layout {
                        },
                        largest_niche: None,
                        align: AbiAndPrefAlign {
-                           abi: Align {
-                               pow2: 0,
-                           },
+                           abi: Align(1 bytes),
                            pref: $PREF_ALIGN,
                        },
-                       size: Size {
-                           raw: 1,
-                       },
+                       size: Size(1 bytes),
                    },
                ],
            },
@@ -89,9 +77,7 @@ error: layout_of(MissingPayloadField) = Layout {
            ),
            largest_niche: Some(
                Niche {
-                   offset: Size {
-                       raw: 0,
-                   },
+                   offset: Size(0 bytes),
                    value: Int(
                        I8,
                        false,
@@ -100,14 +86,10 @@ error: layout_of(MissingPayloadField) = Layout {
                },
            ),
            align: AbiAndPrefAlign {
-               abi: Align {
-                   pow2: 0,
-               },
+               abi: Align(1 bytes),
                pref: $PREF_ALIGN,
            },
-           size: Size {
-               raw: 2,
-           },
+           size: Size(2 bytes),
        }
   --> $DIR/issue-96158-scalarpair-payload-might-be-uninit.rs:16:1
    |
@@ -120,9 +102,7 @@ LL | | }
 error: layout_of(CommonPayloadField) = Layout {
            fields: Arbitrary {
                offsets: [
-                   Size {
-                       raw: 0,
-                   },
+                   Size(0 bytes),
                ],
                memory_index: [
                    0,
@@ -142,9 +122,7 @@ error: layout_of(CommonPayloadField) = Layout {
                    Layout {
                        fields: Arbitrary {
                            offsets: [
-                               Size {
-                                   raw: 1,
-                               },
+                               Size(1 bytes),
                            ],
                            memory_index: [
                                0,
@@ -158,21 +136,15 @@ error: layout_of(CommonPayloadField) = Layout {
                        },
                        largest_niche: None,
                        align: AbiAndPrefAlign {
-                           abi: Align {
-                               pow2: 0,
-                           },
+                           abi: Align(1 bytes),
                            pref: $PREF_ALIGN,
                        },
-                       size: Size {
-                           raw: 2,
-                       },
+                       size: Size(2 bytes),
                    },
                    Layout {
                        fields: Arbitrary {
                            offsets: [
-                               Size {
-                                   raw: 1,
-                               },
+                               Size(1 bytes),
                            ],
                            memory_index: [
                                0,
@@ -186,14 +158,10 @@ error: layout_of(CommonPayloadField) = Layout {
                        },
                        largest_niche: None,
                        align: AbiAndPrefAlign {
-                           abi: Align {
-                               pow2: 0,
-                           },
+                           abi: Align(1 bytes),
                            pref: $PREF_ALIGN,
                        },
-                       size: Size {
-                           raw: 2,
-                       },
+                       size: Size(2 bytes),
                    },
                ],
            },
@@ -215,9 +183,7 @@ error: layout_of(CommonPayloadField) = Layout {
            ),
            largest_niche: Some(
                Niche {
-                   offset: Size {
-                       raw: 0,
-                   },
+                   offset: Size(0 bytes),
                    value: Int(
                        I8,
                        false,
@@ -226,14 +192,10 @@ error: layout_of(CommonPayloadField) = Layout {
                },
            ),
            align: AbiAndPrefAlign {
-               abi: Align {
-                   pow2: 0,
-               },
+               abi: Align(1 bytes),
                pref: $PREF_ALIGN,
            },
-           size: Size {
-               raw: 2,
-           },
+           size: Size(2 bytes),
        }
   --> $DIR/issue-96158-scalarpair-payload-might-be-uninit.rs:25:1
    |
@@ -246,9 +208,7 @@ LL | | }
 error: layout_of(CommonPayloadFieldIsMaybeUninit) = Layout {
            fields: Arbitrary {
                offsets: [
-                   Size {
-                       raw: 0,
-                   },
+                   Size(0 bytes),
                ],
                memory_index: [
                    0,
@@ -268,9 +228,7 @@ error: layout_of(CommonPayloadFieldIsMaybeUninit) = Layout {
                    Layout {
                        fields: Arbitrary {
                            offsets: [
-                               Size {
-                                   raw: 1,
-                               },
+                               Size(1 bytes),
                            ],
                            memory_index: [
                                0,
@@ -284,21 +242,15 @@ error: layout_of(CommonPayloadFieldIsMaybeUninit) = Layout {
                        },
                        largest_niche: None,
                        align: AbiAndPrefAlign {
-                           abi: Align {
-                               pow2: 0,
-                           },
+                           abi: Align(1 bytes),
                            pref: $PREF_ALIGN,
                        },
-                       size: Size {
-                           raw: 2,
-                       },
+                       size: Size(2 bytes),
                    },
                    Layout {
                        fields: Arbitrary {
                            offsets: [
-                               Size {
-                                   raw: 1,
-                               },
+                               Size(1 bytes),
                            ],
                            memory_index: [
                                0,
@@ -312,14 +264,10 @@ error: layout_of(CommonPayloadFieldIsMaybeUninit) = Layout {
                        },
                        largest_niche: None,
                        align: AbiAndPrefAlign {
-                           abi: Align {
-                               pow2: 0,
-                           },
+                           abi: Align(1 bytes),
                            pref: $PREF_ALIGN,
                        },
-                       size: Size {
-                           raw: 2,
-                       },
+                       size: Size(2 bytes),
                    },
                ],
            },
@@ -340,9 +288,7 @@ error: layout_of(CommonPayloadFieldIsMaybeUninit) = Layout {
            ),
            largest_niche: Some(
                Niche {
-                   offset: Size {
-                       raw: 0,
-                   },
+                   offset: Size(0 bytes),
                    value: Int(
                        I8,
                        false,
@@ -351,14 +297,10 @@ error: layout_of(CommonPayloadFieldIsMaybeUninit) = Layout {
                },
            ),
            align: AbiAndPrefAlign {
-               abi: Align {
-                   pow2: 0,
-               },
+               abi: Align(1 bytes),
                pref: $PREF_ALIGN,
            },
-           size: Size {
-               raw: 2,
-           },
+           size: Size(2 bytes),
        }
   --> $DIR/issue-96158-scalarpair-payload-might-be-uninit.rs:33:1
    |
@@ -371,9 +313,7 @@ LL | | }
 error: layout_of(NicheFirst) = Layout {
            fields: Arbitrary {
                offsets: [
-                   Size {
-                       raw: 0,
-                   },
+                   Size(0 bytes),
                ],
                memory_index: [
                    0,
@@ -397,12 +337,8 @@ error: layout_of(NicheFirst) = Layout {
                    Layout {
                        fields: Arbitrary {
                            offsets: [
-                               Size {
-                                   raw: 0,
-                               },
-                               Size {
-                                   raw: 1,
-                               },
+                               Size(0 bytes),
+                               Size(1 bytes),
                            ],
                            memory_index: [
                                0,
@@ -430,9 +366,7 @@ error: layout_of(NicheFirst) = Layout {
                        ),
                        largest_niche: Some(
                            Niche {
-                               offset: Size {
-                                   raw: 0,
-                               },
+                               offset: Size(0 bytes),
                                value: Int(
                                    I8,
                                    false,
@@ -441,14 +375,10 @@ error: layout_of(NicheFirst) = Layout {
                            },
                        ),
                        align: AbiAndPrefAlign {
-                           abi: Align {
-                               pow2: 0,
-                           },
+                           abi: Align(1 bytes),
                            pref: $PREF_ALIGN,
                        },
-                       size: Size {
-                           raw: 2,
-                       },
+                       size: Size(2 bytes),
                    },
                    Layout {
                        fields: Arbitrary {
@@ -463,14 +393,10 @@ error: layout_of(NicheFirst) = Layout {
                        },
                        largest_niche: None,
                        align: AbiAndPrefAlign {
-                           abi: Align {
-                               pow2: 0,
-                           },
+                           abi: Align(1 bytes),
                            pref: $PREF_ALIGN,
                        },
-                       size: Size {
-                           raw: 0,
-                       },
+                       size: Size(0 bytes),
                    },
                    Layout {
                        fields: Arbitrary {
@@ -485,14 +411,10 @@ error: layout_of(NicheFirst) = Layout {
                        },
                        largest_niche: None,
                        align: AbiAndPrefAlign {
-                           abi: Align {
-                               pow2: 0,
-                           },
+                           abi: Align(1 bytes),
                            pref: $PREF_ALIGN,
                        },
-                       size: Size {
-                           raw: 0,
-                       },
+                       size: Size(0 bytes),
                    },
                ],
            },
@@ -513,9 +435,7 @@ error: layout_of(NicheFirst) = Layout {
            ),
            largest_niche: Some(
                Niche {
-                   offset: Size {
-                       raw: 0,
-                   },
+                   offset: Size(0 bytes),
                    value: Int(
                        I8,
                        false,
@@ -524,14 +444,10 @@ error: layout_of(NicheFirst) = Layout {
                },
            ),
            align: AbiAndPrefAlign {
-               abi: Align {
-                   pow2: 0,
-               },
+               abi: Align(1 bytes),
                pref: $PREF_ALIGN,
            },
-           size: Size {
-               raw: 2,
-           },
+           size: Size(2 bytes),
        }
   --> $DIR/issue-96158-scalarpair-payload-might-be-uninit.rs:41:1
    |
@@ -545,9 +461,7 @@ LL | | }
 error: layout_of(NicheSecond) = Layout {
            fields: Arbitrary {
                offsets: [
-                   Size {
-                       raw: 1,
-                   },
+                   Size(1 bytes),
                ],
                memory_index: [
                    0,
@@ -571,12 +485,8 @@ error: layout_of(NicheSecond) = Layout {
                    Layout {
                        fields: Arbitrary {
                            offsets: [
-                               Size {
-                                   raw: 0,
-                               },
-                               Size {
-                                   raw: 1,
-                               },
+                               Size(0 bytes),
+                               Size(1 bytes),
                            ],
                            memory_index: [
                                0,
@@ -604,9 +514,7 @@ error: layout_of(NicheSecond) = Layout {
                        ),
                        largest_niche: Some(
                            Niche {
-                               offset: Size {
-                                   raw: 1,
-                               },
+                               offset: Size(1 bytes),
                                value: Int(
                                    I8,
                                    false,
@@ -615,14 +523,10 @@ error: layout_of(NicheSecond) = Layout {
                            },
                        ),
                        align: AbiAndPrefAlign {
-                           abi: Align {
-                               pow2: 0,
-                           },
+                           abi: Align(1 bytes),
                            pref: $PREF_ALIGN,
                        },
-                       size: Size {
-                           raw: 2,
-                       },
+                       size: Size(2 bytes),
                    },
                    Layout {
                        fields: Arbitrary {
@@ -637,14 +541,10 @@ error: layout_of(NicheSecond) = Layout {
                        },
                        largest_niche: None,
                        align: AbiAndPrefAlign {
-                           abi: Align {
-                               pow2: 0,
-                           },
+                           abi: Align(1 bytes),
                            pref: $PREF_ALIGN,
                        },
-                       size: Size {
-                           raw: 0,
-                       },
+                       size: Size(0 bytes),
                    },
                    Layout {
                        fields: Arbitrary {
@@ -659,14 +559,10 @@ error: layout_of(NicheSecond) = Layout {
                        },
                        largest_niche: None,
                        align: AbiAndPrefAlign {
-                           abi: Align {
-                               pow2: 0,
-                           },
+                           abi: Align(1 bytes),
                            pref: $PREF_ALIGN,
                        },
-                       size: Size {
-                           raw: 0,
-                       },
+                       size: Size(0 bytes),
                    },
                ],
            },
@@ -687,9 +583,7 @@ error: layout_of(NicheSecond) = Layout {
            ),
            largest_niche: Some(
                Niche {
-                   offset: Size {
-                       raw: 1,
-                   },
+                   offset: Size(1 bytes),
                    value: Int(
                        I8,
                        false,
@@ -698,14 +592,10 @@ error: layout_of(NicheSecond) = Layout {
                },
            ),
            align: AbiAndPrefAlign {
-               abi: Align {
-                   pow2: 0,
-               },
+               abi: Align(1 bytes),
                pref: $PREF_ALIGN,
            },
-           size: Size {
-               raw: 2,
-           },
+           size: Size(2 bytes),
        }
   --> $DIR/issue-96158-scalarpair-payload-might-be-uninit.rs:50:1
    |

--- a/src/test/ui/layout/thumb-enum.stderr
+++ b/src/test/ui/layout/thumb-enum.stderr
@@ -1,9 +1,7 @@
 error: layout_of(A) = Layout {
            fields: Arbitrary {
                offsets: [
-                   Size {
-                       raw: 0,
-                   },
+                   Size(0 bytes),
                ],
                memory_index: [
                    0,
@@ -33,16 +31,10 @@ error: layout_of(A) = Layout {
                        },
                        largest_niche: None,
                        align: AbiAndPrefAlign {
-                           abi: Align {
-                               pow2: 0,
-                           },
-                           pref: Align {
-                               pow2: 2,
-                           },
+                           abi: Align(1 bytes),
+                           pref: Align(4 bytes),
                        },
-                       size: Size {
-                           raw: 1,
-                       },
+                       size: Size(1 bytes),
                    },
                ],
            },
@@ -57,9 +49,7 @@ error: layout_of(A) = Layout {
            ),
            largest_niche: Some(
                Niche {
-                   offset: Size {
-                       raw: 0,
-                   },
+                   offset: Size(0 bytes),
                    value: Int(
                        I8,
                        false,
@@ -68,16 +58,10 @@ error: layout_of(A) = Layout {
                },
            ),
            align: AbiAndPrefAlign {
-               abi: Align {
-                   pow2: 0,
-               },
-               pref: Align {
-                   pow2: 2,
-               },
+               abi: Align(1 bytes),
+               pref: Align(4 bytes),
            },
-           size: Size {
-               raw: 1,
-           },
+           size: Size(1 bytes),
        }
   --> $DIR/thumb-enum.rs:16:1
    |
@@ -87,9 +71,7 @@ LL | enum A { Apple }
 error: layout_of(B) = Layout {
            fields: Arbitrary {
                offsets: [
-                   Size {
-                       raw: 0,
-                   },
+                   Size(0 bytes),
                ],
                memory_index: [
                    0,
@@ -119,16 +101,10 @@ error: layout_of(B) = Layout {
                        },
                        largest_niche: None,
                        align: AbiAndPrefAlign {
-                           abi: Align {
-                               pow2: 0,
-                           },
-                           pref: Align {
-                               pow2: 2,
-                           },
+                           abi: Align(1 bytes),
+                           pref: Align(4 bytes),
                        },
-                       size: Size {
-                           raw: 1,
-                       },
+                       size: Size(1 bytes),
                    },
                ],
            },
@@ -143,9 +119,7 @@ error: layout_of(B) = Layout {
            ),
            largest_niche: Some(
                Niche {
-                   offset: Size {
-                       raw: 0,
-                   },
+                   offset: Size(0 bytes),
                    value: Int(
                        I8,
                        false,
@@ -154,16 +128,10 @@ error: layout_of(B) = Layout {
                },
            ),
            align: AbiAndPrefAlign {
-               abi: Align {
-                   pow2: 0,
-               },
-               pref: Align {
-                   pow2: 2,
-               },
+               abi: Align(1 bytes),
+               pref: Align(4 bytes),
            },
-           size: Size {
-               raw: 1,
-           },
+           size: Size(1 bytes),
        }
   --> $DIR/thumb-enum.rs:20:1
    |
@@ -173,9 +141,7 @@ LL | enum B { Banana = 255, }
 error: layout_of(C) = Layout {
            fields: Arbitrary {
                offsets: [
-                   Size {
-                       raw: 0,
-                   },
+                   Size(0 bytes),
                ],
                memory_index: [
                    0,
@@ -205,16 +171,10 @@ error: layout_of(C) = Layout {
                        },
                        largest_niche: None,
                        align: AbiAndPrefAlign {
-                           abi: Align {
-                               pow2: 1,
-                           },
-                           pref: Align {
-                               pow2: 2,
-                           },
+                           abi: Align(2 bytes),
+                           pref: Align(4 bytes),
                        },
-                       size: Size {
-                           raw: 2,
-                       },
+                       size: Size(2 bytes),
                    },
                ],
            },
@@ -229,9 +189,7 @@ error: layout_of(C) = Layout {
            ),
            largest_niche: Some(
                Niche {
-                   offset: Size {
-                       raw: 0,
-                   },
+                   offset: Size(0 bytes),
                    value: Int(
                        I16,
                        false,
@@ -240,16 +198,10 @@ error: layout_of(C) = Layout {
                },
            ),
            align: AbiAndPrefAlign {
-               abi: Align {
-                   pow2: 1,
-               },
-               pref: Align {
-                   pow2: 2,
-               },
+               abi: Align(2 bytes),
+               pref: Align(4 bytes),
            },
-           size: Size {
-               raw: 2,
-           },
+           size: Size(2 bytes),
        }
   --> $DIR/thumb-enum.rs:24:1
    |
@@ -259,9 +211,7 @@ LL | enum C { Chaenomeles = 256, }
 error: layout_of(P) = Layout {
            fields: Arbitrary {
                offsets: [
-                   Size {
-                       raw: 0,
-                   },
+                   Size(0 bytes),
                ],
                memory_index: [
                    0,
@@ -291,16 +241,10 @@ error: layout_of(P) = Layout {
                        },
                        largest_niche: None,
                        align: AbiAndPrefAlign {
-                           abi: Align {
-                               pow2: 2,
-                           },
-                           pref: Align {
-                               pow2: 2,
-                           },
+                           abi: Align(4 bytes),
+                           pref: Align(4 bytes),
                        },
-                       size: Size {
-                           raw: 4,
-                       },
+                       size: Size(4 bytes),
                    },
                ],
            },
@@ -315,9 +259,7 @@ error: layout_of(P) = Layout {
            ),
            largest_niche: Some(
                Niche {
-                   offset: Size {
-                       raw: 0,
-                   },
+                   offset: Size(0 bytes),
                    value: Int(
                        I32,
                        false,
@@ -326,16 +268,10 @@ error: layout_of(P) = Layout {
                },
            ),
            align: AbiAndPrefAlign {
-               abi: Align {
-                   pow2: 2,
-               },
-               pref: Align {
-                   pow2: 2,
-               },
+               abi: Align(4 bytes),
+               pref: Align(4 bytes),
            },
-           size: Size {
-               raw: 4,
-           },
+           size: Size(4 bytes),
        }
   --> $DIR/thumb-enum.rs:28:1
    |
@@ -345,9 +281,7 @@ LL | enum P { Peach = 0x1000_0000isize, }
 error: layout_of(T) = Layout {
            fields: Arbitrary {
                offsets: [
-                   Size {
-                       raw: 0,
-                   },
+                   Size(0 bytes),
                ],
                memory_index: [
                    0,
@@ -377,16 +311,10 @@ error: layout_of(T) = Layout {
                        },
                        largest_niche: None,
                        align: AbiAndPrefAlign {
-                           abi: Align {
-                               pow2: 2,
-                           },
-                           pref: Align {
-                               pow2: 2,
-                           },
+                           abi: Align(4 bytes),
+                           pref: Align(4 bytes),
                        },
-                       size: Size {
-                           raw: 4,
-                       },
+                       size: Size(4 bytes),
                    },
                ],
            },
@@ -401,9 +329,7 @@ error: layout_of(T) = Layout {
            ),
            largest_niche: Some(
                Niche {
-                   offset: Size {
-                       raw: 0,
-                   },
+                   offset: Size(0 bytes),
                    value: Int(
                        I32,
                        true,
@@ -412,16 +338,10 @@ error: layout_of(T) = Layout {
                },
            ),
            align: AbiAndPrefAlign {
-               abi: Align {
-                   pow2: 2,
-               },
-               pref: Align {
-                   pow2: 2,
-               },
+               abi: Align(4 bytes),
+               pref: Align(4 bytes),
            },
-           size: Size {
-               raw: 4,
-           },
+           size: Size(4 bytes),
        }
   --> $DIR/thumb-enum.rs:34:1
    |

--- a/src/test/ui/layout/zero-sized-array-union.stderr
+++ b/src/test/ui/layout/zero-sized-array-union.stderr
@@ -1,22 +1,22 @@
-error: homogeneous_aggregate: Ok(Homogeneous(Reg { kind: Float, size: Size { raw: 4 } }))
+error: homogeneous_aggregate: Ok(Homogeneous(Reg { kind: Float, size: Size(4 bytes) }))
   --> $DIR/zero-sized-array-union.rs:59:1
    |
 LL | type TestBaz1 = Baz1;
    | ^^^^^^^^^^^^^^^^^^^^^
 
-error: homogeneous_aggregate: Ok(Homogeneous(Reg { kind: Float, size: Size { raw: 4 } }))
+error: homogeneous_aggregate: Ok(Homogeneous(Reg { kind: Float, size: Size(4 bytes) }))
   --> $DIR/zero-sized-array-union.rs:70:1
    |
 LL | type TestBaz2 = Baz2;
    | ^^^^^^^^^^^^^^^^^^^^^
 
-error: homogeneous_aggregate: Ok(Homogeneous(Reg { kind: Float, size: Size { raw: 4 } }))
+error: homogeneous_aggregate: Ok(Homogeneous(Reg { kind: Float, size: Size(4 bytes) }))
   --> $DIR/zero-sized-array-union.rs:81:1
    |
 LL | type TestBaz3 = Baz3;
    | ^^^^^^^^^^^^^^^^^^^^^
 
-error: homogeneous_aggregate: Ok(Homogeneous(Reg { kind: Float, size: Size { raw: 4 } }))
+error: homogeneous_aggregate: Ok(Homogeneous(Reg { kind: Float, size: Size(4 bytes) }))
   --> $DIR/zero-sized-array-union.rs:92:1
    |
 LL | type TestBaz4 = Baz4;


### PR DESCRIPTION
Successful merges:

 - #96581 (make Size and Align debug-printing a bit more compact)
 - #96636 (Fix jump to def regression)
 - #96760 (diagnostics: port more diagnostics to derive + add support for `Vec` fields)
 - #96788 (Improve validator around field projections and checked bin ops)
 - #96805 (Change eslint rules from configuration comments to configuration file)
 - #96807 (update Miri)
 - #96811 (Fix a minor typo in the description of Formatter)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=96581,96636,96760,96788,96805,96807,96811)
<!-- homu-ignore:end -->