### PR TITLE
Make RwLockReadGuard covariant

### DIFF
--- a/library/std/src/sync/rwlock.rs
+++ b/library/std/src/sync/rwlock.rs
@@ -101,7 +101,8 @@ unsafe impl<T: ?Sized + Send + Sync> Sync for RwLock<T> {}
 #[stable(feature = "rust1", since = "1.0.0")]
 #[clippy::has_significant_drop]
 pub struct RwLockReadGuard<'a, T: ?Sized + 'a> {
-    lock: &'a RwLock<T>,
+    inner_lock: &'a sys::MovableRwLock,
+    data: &'a T,
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -510,7 +511,7 @@ impl<T> From<T> for RwLock<T> {
 
 impl<'rwlock, T: ?Sized> RwLockReadGuard<'rwlock, T> {
     unsafe fn new(lock: &'rwlock RwLock<T>) -> LockResult<RwLockReadGuard<'rwlock, T>> {
-        poison::map_result(lock.poison.borrow(), |()| RwLockReadGuard { lock })
+        poison::map_result(lock.poison.borrow(), |()| RwLockReadGuard { inner_lock: &lock.inner, data: &*lock.data.get() })
     }
 }
 
@@ -553,7 +554,7 @@ impl<T: ?Sized> Deref for RwLockReadGuard<'_, T> {
     type Target = T;
 
     fn deref(&self) -> &T {
-        unsafe { &*self.lock.data.get() }
+        self.data
     }
 }
 
@@ -577,7 +578,7 @@ impl<T: ?Sized> DerefMut for RwLockWriteGuard<'_, T> {
 impl<T: ?Sized> Drop for RwLockReadGuard<'_, T> {
     fn drop(&mut self) {
         unsafe {
-            self.lock.inner.read_unlock();
+            self.inner_lock.read_unlock();
         }
     }
 }

--- a/library/std/src/sync/rwlock.rs
+++ b/library/std/src/sync/rwlock.rs
@@ -102,6 +102,10 @@ unsafe impl<T: ?Sized + Send + Sync> Sync for RwLock<T> {}
 #[stable(feature = "rust1", since = "1.0.0")]
 #[clippy::has_significant_drop]
 pub struct RwLockReadGuard<'a, T: ?Sized + 'a> {
+    // NB: we use a pointer instead of `&'a T` to avoid `noalias` violations, because a
+    // `Ref` argument doesn't hold immutability for its whole scope, only until it drops.
+    // `NonNull` is also covariant over `T`, just like we would have with `&T`. `NonNull`
+    // is preferable over `const* T` to allow for niche optimization.
     data: NonNull<T>,
     inner_lock: &'a sys::MovableRwLock,
 }

--- a/library/std/src/sync/rwlock.rs
+++ b/library/std/src/sync/rwlock.rs
@@ -524,7 +524,7 @@ impl<'rwlock, T: ?Sized> RwLockReadGuard<'rwlock, T> {
 }
 
 impl<'rwlock, T: ?Sized> RwLockWriteGuard<'rwlock, T> {
-    /// Create a new instance of `RwLockReadGuard<T>` from a `RwLock<T>`.
+    /// Create a new instance of `RwLockWriteGuard<T>` from a `RwLock<T>`.
     ///
     /// It is safe to call this function if and only if `lock.inner.write()` (or
     /// `lock.inner.try_write()`) has been successfully called before instantiating this object.

--- a/library/std/src/sync/rwlock.rs
+++ b/library/std/src/sync/rwlock.rs
@@ -101,8 +101,8 @@ unsafe impl<T: ?Sized + Send + Sync> Sync for RwLock<T> {}
 #[stable(feature = "rust1", since = "1.0.0")]
 #[clippy::has_significant_drop]
 pub struct RwLockReadGuard<'a, T: ?Sized + 'a> {
+    data: *const T,
     inner_lock: &'a sys::MovableRwLock,
-    data: &'a T,
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -513,7 +513,7 @@ impl<'rwlock, T: ?Sized> RwLockReadGuard<'rwlock, T> {
     unsafe fn new(lock: &'rwlock RwLock<T>) -> LockResult<RwLockReadGuard<'rwlock, T>> {
         poison::map_result(lock.poison.borrow(), |()| RwLockReadGuard {
             inner_lock: &lock.inner,
-            data: &*lock.data.get(),
+            data: lock.data.get(),
         })
     }
 }
@@ -557,7 +557,7 @@ impl<T: ?Sized> Deref for RwLockReadGuard<'_, T> {
     type Target = T;
 
     fn deref(&self) -> &T {
-        self.data
+        unsafe { &*self.data }
     }
 }
 

--- a/library/std/src/sync/rwlock.rs
+++ b/library/std/src/sync/rwlock.rs
@@ -511,7 +511,10 @@ impl<T> From<T> for RwLock<T> {
 
 impl<'rwlock, T: ?Sized> RwLockReadGuard<'rwlock, T> {
     unsafe fn new(lock: &'rwlock RwLock<T>) -> LockResult<RwLockReadGuard<'rwlock, T>> {
-        poison::map_result(lock.poison.borrow(), |()| RwLockReadGuard { inner_lock: &lock.inner, data: &*lock.data.get() })
+        poison::map_result(lock.poison.borrow(), |()| RwLockReadGuard {
+            inner_lock: &lock.inner,
+            data: &*lock.data.get()
+        })
     }
 }
 

--- a/library/std/src/sync/rwlock.rs
+++ b/library/std/src/sync/rwlock.rs
@@ -513,7 +513,7 @@ impl<'rwlock, T: ?Sized> RwLockReadGuard<'rwlock, T> {
     unsafe fn new(lock: &'rwlock RwLock<T>) -> LockResult<RwLockReadGuard<'rwlock, T>> {
         poison::map_result(lock.poison.borrow(), |()| RwLockReadGuard {
             inner_lock: &lock.inner,
-            data: &*lock.data.get()
+            data: &*lock.data.get(),
         })
     }
 }

--- a/library/std/src/sync/rwlock/tests.rs
+++ b/library/std/src/sync/rwlock/tests.rs
@@ -1,6 +1,6 @@
 use crate::sync::atomic::{AtomicUsize, Ordering};
 use crate::sync::mpsc::channel;
-use crate::sync::{Arc, RwLock, TryLockError, RwLockReadGuard};
+use crate::sync::{Arc, RwLock, RwLockReadGuard, TryLockError};
 use crate::thread;
 use rand::{self, Rng};
 

--- a/src/test/codegen/noalias-rwlockreadguard.rs
+++ b/src/test/codegen/noalias-rwlockreadguard.rs
@@ -2,14 +2,13 @@
 
 #![crate_type = "lib"]
 
-use std::cell::UnsafeCell;
-use std::sync::RwLockReadGuard;
+use std::sync::{RwLock, RwLockReadGuard};
 
 // Make sure that `RwLockReadGuard` does not get a `noalias` attribute, because
-// the `UnsafeCell` might alias writes after it is dropped.
+// the `RwLock` might alias writes after it is dropped.
 
 // CHECK-LABEL: @maybe_aliased(
 // CHECK-NOT: noalias
 // CHECK-SAME: %_data
 #[no_mangle]
-pub unsafe fn maybe_aliased(_: RwLockReadGuard<'_, i32>, _data: &UnsafeCell<i32>) {}
+pub unsafe fn maybe_aliased(_: RwLockReadGuard<'_, i32>, _data: &RwLock<i32>) {}

--- a/src/test/codegen/noalias-rwlockreadguard.rs
+++ b/src/test/codegen/noalias-rwlockreadguard.rs
@@ -10,5 +10,6 @@ use std::sync::RwLockReadGuard;
 
 // CHECK-LABEL: @maybe_aliased(
 // CHECK-NOT: noalias
+// CHECK-SAME: %_data
 #[no_mangle]
 pub unsafe fn maybe_aliased(_: RwLockReadGuard<'_, i32>, _data: &UnsafeCell<i32>) {}

--- a/src/test/codegen/noalias-rwlockreadguard.rs
+++ b/src/test/codegen/noalias-rwlockreadguard.rs
@@ -1,0 +1,14 @@
+// compile-flags: -O -C no-prepopulate-passes -Z mutable-noalias=yes
+
+#![crate_type = "lib"]
+
+use std::cell::UnsafeCell;
+use std::sync::RwLockReadGuard;
+
+// Make sure that `RwLockReadGuard` does not get a `noalias` attribute, because
+// the `UnsafeCell` might alias writes after it is dropped.
+
+// CHECK-LABEL: @maybe_aliased(
+// CHECK-NOT: noalias
+#[no_mangle]
+pub unsafe fn maybe_aliased(_: RwLockReadGuard<'_, i32>, _data: &UnsafeCell<i32>) {}

--- a/src/test/debuginfo/rwlock-read.rs
+++ b/src/test/debuginfo/rwlock-read.rs
@@ -15,11 +15,8 @@
 //
 // cdb-command:dx r
 // cdb-check:r                [Type: std::sync::rwlock::RwLockReadGuard<i32>]
-// cdb-check:    [...] lock             : [...] [Type: std::sync::rwlock::RwLock<i32> *]
-//
-// cdb-command:dx r.lock->data,d
-// cdb-check:r.lock->data,d   : 0 [Type: core::cell::UnsafeCell<i32>]
-// cdb-check:    [<Raw View>]     [Type: core::cell::UnsafeCell<i32>]
+// cdb-check:    [...] data             : NonNull([...]: 0) [Type: core::ptr::non_null::NonNull<i32>]
+// cdb-check:    [...] inner_lock       : [...] [Type: std::sys_common::rwlock::MovableRwLock *]
 
 #[allow(unused_variables)]
 


### PR DESCRIPTION
Hi, first time contributor here, if anything is not as expected, please let me know.

`RwLockReadGoard`'s type constructor is invariant. Since it behaves like a smart pointer to an immutable reference, there is no reason that it should not be covariant. Take e.g.

```
fn test_read_guard_covariance() {
    fn do_stuff<'a>(_: RwLockReadGuard<'_, &'a i32>, _: &'a i32) {}
    let j: i32 = 5;
    let lock = RwLock::new(&j);
    {
        let i = 6;
        do_stuff(lock.read().unwrap(), &i);
    }
    drop(lock);
}
```
where the compiler complains that &i doesn't live long enough. If `RwLockReadGuard` is covariant, then the above code is accepted because the lifetime can be shorter than `'a`. 

In order for `RwLockReadGuard` to be covariant, it can't contain a full reference to the `RwLock`, which can never be covariant (because it exposes a mutable reference to the underlying data structure). By reducing the data structure to the required pieces of `RwLock`, the rest falls in place.

If there is a better way to do a test that tests successful compilation, please let me know.

Fixes #80392