### PR TITLE
Enforce quote rule for JS source code

### DIFF
--- a/src/librustdoc/html/static/.eslintrc.js
+++ b/src/librustdoc/html/static/.eslintrc.js
@@ -17,6 +17,10 @@ module.exports = {
             "error",
             "always"
         ],
+        "quotes": [
+            "error",
+            "double"
+        ],
         "no-var": ["error"],
         "prefer-const": ["error"],
         "prefer-arrow-callback": ["error"],

--- a/src/librustdoc/html/static/js/main.js
+++ b/src/librustdoc/html/static/js/main.js
@@ -291,7 +291,7 @@ function loadCss(cssFileName) {
 
 (function() {
     function loadScript(url) {
-        const script = document.createElement('script');
+        const script = document.createElement("script");
         script.src = url;
         document.head.append(script);
     }
@@ -344,7 +344,7 @@ function loadCss(cssFileName) {
             searchState.input.blur();
         },
         showResults: search => {
-            if (search === null || typeof search === 'undefined') {
+            if (search === null || typeof search === "undefined") {
                 search = searchState.outputElement();
             }
             switchDisplayedElement(search);
@@ -390,7 +390,7 @@ function loadCss(cssFileName) {
                 loadSearch();
             });
 
-            if (search_input.value !== '') {
+            if (search_input.value !== "") {
                 loadSearch();
             }
 
@@ -968,7 +968,7 @@ function loadCss(cssFileName) {
 
     onEachLazy(document.getElementsByClassName("notable-traits"), e => {
         e.onclick = function() {
-            this.getElementsByClassName('notable-traits-tooltiptext')[0]
+            this.getElementsByClassName("notable-traits-tooltiptext")[0]
                 .classList.toggle("force-tooltip");
         };
     });
@@ -1070,29 +1070,29 @@ function loadCss(cssFileName) {
         const path = [];
 
         onEach(parent.childNodes, child => {
-            if (child.tagName === 'A') {
+            if (child.tagName === "A") {
                 path.push(child.textContent);
             }
         });
 
-        const el = document.createElement('textarea');
-        el.value = path.join('::');
-        el.setAttribute('readonly', '');
+        const el = document.createElement("textarea");
+        el.value = path.join("::");
+        el.setAttribute("readonly", "");
         // To not make it appear on the screen.
-        el.style.position = 'absolute';
-        el.style.left = '-9999px';
+        el.style.position = "absolute";
+        el.style.left = "-9999px";
 
         document.body.appendChild(el);
         el.select();
-        document.execCommand('copy');
+        document.execCommand("copy");
         document.body.removeChild(el);
 
         // There is always one children, but multiple childNodes.
-        but.children[0].style.display = 'none';
+        but.children[0].style.display = "none";
 
         let tmp;
         if (but.childNodes.length < 2) {
-            tmp = document.createTextNode('✓');
+            tmp = document.createTextNode("✓");
             but.appendChild(tmp);
         } else {
             onEachLazy(but.childNodes, e => {
@@ -1101,7 +1101,7 @@ function loadCss(cssFileName) {
                     return true;
                 }
             });
-            tmp.textContent = '✓';
+            tmp.textContent = "✓";
         }
 
         if (reset_button_timeout !== null) {
@@ -1109,7 +1109,7 @@ function loadCss(cssFileName) {
         }
 
         function reset_button() {
-            tmp.textContent = '';
+            tmp.textContent = "";
             reset_button_timeout = null;
             but.children[0].style.display = "";
         }

--- a/src/librustdoc/html/static/js/scrape-examples.js
+++ b/src/librustdoc/html/static/js/scrape-examples.js
@@ -8,7 +8,7 @@
 
     // Scroll code block to the given code location
     function scrollToLoc(elt, loc) {
-        const lines = elt.querySelector('.line-numbers');
+        const lines = elt.querySelector(".line-numbers");
         let scrollOffset;
 
         // If the block is greater than the size of the viewer,
@@ -32,16 +32,16 @@
     function updateScrapedExample(example) {
         const locs = JSON.parse(example.attributes.getNamedItem("data-locs").textContent);
         let locIndex = 0;
-        const highlights = Array.prototype.slice.call(example.querySelectorAll('.highlight'));
-        const link = example.querySelector('.scraped-example-title a');
+        const highlights = Array.prototype.slice.call(example.querySelectorAll(".highlight"));
+        const link = example.querySelector(".scraped-example-title a");
 
         if (locs.length > 1) {
             // Toggle through list of examples in a given file
             const onChangeLoc = changeIndex => {
-                removeClass(highlights[locIndex], 'focus');
+                removeClass(highlights[locIndex], "focus");
                 changeIndex();
                 scrollToLoc(example, locs[locIndex][0]);
-                addClass(highlights[locIndex], 'focus');
+                addClass(highlights[locIndex], "focus");
 
                 const url = locs[locIndex][1];
                 const title = locs[locIndex][2];
@@ -50,24 +50,24 @@
                 link.innerHTML = title;
             };
 
-            example.querySelector('.prev')
-                .addEventListener('click', () => {
+            example.querySelector(".prev")
+                .addEventListener("click", () => {
                     onChangeLoc(() => {
                         locIndex = (locIndex - 1 + locs.length) % locs.length;
                     });
                 });
 
-            example.querySelector('.next')
-                .addEventListener('click', () => {
+            example.querySelector("next")
+                .addEventListener("click", () => {
                     onChangeLoc(() => {
                         locIndex = (locIndex + 1) % locs.length;
                     });
                 });
         }
 
-        const expandButton = example.querySelector('.expand');
+        const expandButton = example.querySelector(".expand");
         if (expandButton) {
-            expandButton.addEventListener('click', () => {
+            expandButton.addEventListener("click", () => {
                 if (hasClass(example, "expanded")) {
                     removeClass(example, "expanded");
                     scrollToLoc(example, locs[0][0]);
@@ -81,19 +81,19 @@
         scrollToLoc(example, locs[0][0]);
     }
 
-    const firstExamples = document.querySelectorAll('.scraped-example-list > .scraped-example');
+    const firstExamples = document.querySelectorAll(".scraped-example-list > .scraped-example");
     onEachLazy(firstExamples, updateScrapedExample);
-    onEachLazy(document.querySelectorAll('.more-examples-toggle'), toggle => {
+    onEachLazy(document.querySelectorAll(".more-examples-toggle"), toggle => {
         // Allow users to click the left border of the <details> section to close it,
         // since the section can be large and finding the [+] button is annoying.
-        onEachLazy(toggle.querySelectorAll('.toggle-line, .hide-more'), button => {
-            button.addEventListener('click', () => {
+        onEachLazy(toggle.querySelectorAll(".toggle-line, .hide-more"), button => {
+            button.addEventListener("click", () => {
                 toggle.open = false;
             });
         });
 
-        const moreExamples = toggle.querySelectorAll('.scraped-example');
-        toggle.querySelector('summary').addEventListener('click', () => {
+        const moreExamples = toggle.querySelectorAll(".scraped-example");
+        toggle.querySelector("summary").addEventListener("click", () => {
             // Wrapping in setTimeout ensures the update happens after the elements are actually
             // visible. This is necessary since updateScrapedExample calls scrollToLoc which
             // depends on offsetHeight, a property that requires an element to be visible to

--- a/src/librustdoc/html/static/js/search.js
+++ b/src/librustdoc/html/static/js/search.js
@@ -204,7 +204,7 @@ window.initSearch = rawSearchIndex => {
      * @return {boolean}
      */
     function isPathStart(parserState) {
-        return parserState.userQuery.slice(parserState.pos, parserState.pos + 2) == '::';
+        return parserState.userQuery.slice(parserState.pos, parserState.pos + 2) == "::";
     }
 
     /**
@@ -215,7 +215,7 @@ window.initSearch = rawSearchIndex => {
      * @return {boolean}
      */
     function isReturnArrow(parserState) {
-        return parserState.userQuery.slice(parserState.pos, parserState.pos + 2) == '->';
+        return parserState.userQuery.slice(parserState.pos, parserState.pos + 2) == "->";
     }
 
     /**
@@ -227,10 +227,10 @@ window.initSearch = rawSearchIndex => {
      */
     function isIdentCharacter(c) {
         return (
-            c === '_' ||
-            (c >= '0' && c <= '9') ||
-            (c >= 'a' && c <= 'z') ||
-            (c >= 'A' && c <= 'Z'));
+            c === "_" ||
+            (c >= "0" && c <= "9") ||
+            (c >= "a" && c <= "z") ||
+            (c >= "A" && c <= "Z"));
     }
 
     /**
@@ -264,7 +264,7 @@ window.initSearch = rawSearchIndex => {
      * @return {QueryElement}                - The newly created `QueryElement`.
      */
     function createQueryElement(query, parserState, name, generics, isInGenerics) {
-        if (name === '*' || (name.length === 0 && generics.length === 0)) {
+        if (name === "*" || (name.length === 0 && generics.length === 0)) {
             return;
         }
         if (query.literalSearch && parserState.totalElems - parserState.genericsElems > 0) {
@@ -1708,11 +1708,12 @@ window.initSearch = rawSearchIndex => {
 
         let crates = "";
         if (window.ALL_CRATES.length > 1) {
-            crates = ` in <select id="crate-search"><option value="All crates">All crates</option>`;
+            crates = " in <select id=\"crate-search\"><option value=\"All crates\">" +
+                "All crates</option>";
             for (const c of window.ALL_CRATES) {
                 crates += `<option value="${c}" ${c == filterCrates && "selected"}>${c}</option>`;
             }
-            crates += `</select>`;
+            crates += "</select>";
         }
 
         let typeFilter = "";
@@ -1720,17 +1721,17 @@ window.initSearch = rawSearchIndex => {
             typeFilter = " (type: " + escape(itemTypes[results.query.typeFilter]) + ")";
         }
 
-        let output = `<div id="search-settings">` +
+        let output = "<div id=\"search-settings\">" +
             `<h1 class="search-results-title">Results for ${escape(results.query.userQuery)}` +
             `${typeFilter}</h1> in ${crates} </div>`;
         if (results.query.error !== null) {
             output += `<h3>Query parser error: "${results.query.error}".</h3>`;
-            output += '<div id="titles">' +
+            output += "<div id=\"titles\">" +
                 makeTabHeader(0, "In Names", ret_others[1]) +
                 "</div>";
             currentTab = 0;
         } else if (results.query.foundElems <= 1 && results.query.returned.length === 0) {
-            output += `<div id="titles">` +
+            output += "<div id=\"titles\">" +
                 makeTabHeader(0, "In Names", ret_others[1]) +
                 makeTabHeader(1, "In Parameters", ret_in_args[1]) +
                 makeTabHeader(2, "In Return Types", ret_returned[1]) +
@@ -1740,7 +1741,7 @@ window.initSearch = rawSearchIndex => {
                 results.query.elems.length === 0 ? "In Function Return Types" :
                 results.query.returned.length === 0 ? "In Function Parameters" :
                 "In Function Signatures";
-            output += '<div id="titles">' +
+            output += "<div id=\"titles\">" +
                 makeTabHeader(0, signatureTabTitle, ret_others[1]) +
                 "</div>";
             currentTab = 0;

--- a/src/librustdoc/html/static/js/settings.js
+++ b/src/librustdoc/html/static/js/settings.js
@@ -108,7 +108,7 @@
         let output = "";
 
         for (const setting of settings) {
-            output += `<div class="setting-line">`;
+            output += "<div class=\"setting-line\">";
             const js_data_name = setting["js_name"];
             const setting_name = setting["name"];
 
@@ -217,11 +217,10 @@
 
         if (isSettingsPage) {
             innerHTML +=
-                `<a id="back" href="javascript:void(0)" onclick="history.back();">Back</a>`;
+                "<a id=\"back\" href=\"javascript:void(0)\" onclick=\"history.back();\">Back</a>";
         } else {
-            innerHTML +=
-                `<a id="back" href="javascript:void(0)" onclick="switchDisplayedElement(null);">\
-                    Back</a>`;
+            innerHTML += "<a id=\"back\" href=\"javascript:void(0)\" " +
+                "onclick=\"switchDisplayedElement(null);\">Back</a>";
         }
         innerHTML += `</span>
             </div>

--- a/src/librustdoc/html/static/js/storage.js
+++ b/src/librustdoc/html/static/js/storage.js
@@ -24,7 +24,7 @@ function getSettingValue(settingName) {
     if (settingsDataset !== null) {
         // See the comment for `default_settings.into_iter()` etc. in
         // `Options::from_matches` in `librustdoc/config.rs`.
-        const def = settingsDataset[settingName.replace(/-/g,'_')];
+        const def = settingsDataset[settingName.replace(/-/g,"_")];
         if (def !== undefined) {
             return def;
         }
@@ -173,7 +173,7 @@ const updateSystemTheme = (function () {
         // fallback to the CSS computed value
         return () => {
             const cssTheme = getComputedStyle(document.documentElement)
-                .getPropertyValue('content');
+                .getPropertyValue("content");
 
             switchTheme(
                 window.currentTheme,


### PR DESCRIPTION
We mostly used double quotes but still had a weird mix. This eslint rule will now enforce it.

Part of https://github.com/rust-lang/rust/issues/93058.

r? @notriddle 