### PR TITLE
Rollup of 10 pull requests

### DIFF
--- a/compiler/rustc_feature/src/active.rs
+++ b/compiler/rustc_feature/src/active.rs
@@ -244,7 +244,6 @@ declare_features! (
 
     // Unstable `#[target_feature]` directives.
     (active, aarch64_ver_target_feature, "1.27.0", Some(44839), None),
-    (active, adx_target_feature, "1.32.0", Some(44839), None),
     (active, arm_target_feature, "1.27.0", Some(44839), None),
     (active, avx512_target_feature, "1.27.0", Some(44839), None),
     (active, bpf_target_feature, "1.54.0", Some(44839), None),

--- a/library/core/src/ptr/mut_ptr.rs
+++ b/library/core/src/ptr/mut_ptr.rs
@@ -287,7 +287,7 @@ impl<T: ?Sized> *mut T {
     /// For the mutable counterpart see [`as_mut`].
     ///
     /// [`as_uninit_ref`]: #method.as_uninit_ref-1
-    /// [`as_mut`]: #method.as_mut
+    /// [`as_mut`]: #method.as_mut-1
     ///
     /// # Safety
     ///

--- a/library/std/src/env.rs
+++ b/library/std/src/env.rs
@@ -644,36 +644,23 @@ pub fn temp_dir() -> PathBuf {
 ///
 /// # Security
 ///
-/// The output of this function should not be used in anything that might have
-/// security implications. For example:
+/// The output of this function should not be trusted for anything
+/// that might have security implications. Basically, if users can run
+/// the executable, they can change the output arbitrarily.
 ///
-/// ```
-/// fn main() {
-///     println!("{:?}", std::env::current_exe());
-/// }
-/// ```
+/// As an example, you can easily introduce a race condition. It goes
+/// like this:
 ///
-/// On Linux systems, if this is compiled as `foo`:
+/// 1. You get the path to the current executable using `current_exe()`, and
+///    store it in a variable.
+/// 2. Time passes. A malicious actor removes the current executable, and
+///    replaces it with a malicious one.
+/// 3. You then use the stored path to re-execute the current
+///    executable.
 ///
-/// ```bash
-/// $ rustc foo.rs
-/// $ ./foo
-/// Ok("/home/alex/foo")
-/// ```
-///
-/// And you make a hard link of the program:
-///
-/// ```bash
-/// $ ln foo bar
-/// ```
-///
-/// When you run it, you won’t get the path of the original executable, you’ll
-/// get the path of the hard link:
-///
-/// ```bash
-/// $ ./bar
-/// Ok("/home/alex/bar")
-/// ```
+/// You expected to safely execute the current executable, but you're
+/// instead executing something completely different. The code you
+/// just executed run with your privileges.
 ///
 /// This sort of behavior has been known to [lead to privilege escalation] when
 /// used incorrectly.

--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -1930,6 +1930,8 @@ pub fn read_link<P: AsRef<Path>>(path: P) -> io::Result<PathBuf> {
 ///     Ok(())
 /// }
 /// ```
+#[doc(alias = "realpath")]
+#[doc(alias = "GetFinalPathNameByHandle")]
 #[stable(feature = "fs_canonicalize", since = "1.5.0")]
 pub fn canonicalize<P: AsRef<Path>>(path: P) -> io::Result<PathBuf> {
     fs_imp::canonicalize(path.as_ref())

--- a/src/bootstrap/defaults/config.codegen.toml
+++ b/src/bootstrap/defaults/config.codegen.toml
@@ -1,4 +1,8 @@
 # These defaults are meant for contributors to the compiler who modify codegen or LLVM
+[build]
+# Contributors working on the compiler will probably expect compiler docs to be generated.
+compiler-docs = true
+
 [llvm]
 # This enables debug-assertions in LLVM,
 # catching logic errors in codegen much earlier in the process.

--- a/src/bootstrap/defaults/config.compiler.toml
+++ b/src/bootstrap/defaults/config.compiler.toml
@@ -1,4 +1,8 @@
 # These defaults are meant for contributors to the compiler who do not modify codegen or LLVM
+[build]
+# Contributors working on the compiler will probably expect compiler docs to be generated.
+compiler-docs = true
+
 [rust]
 # This enables `RUSTC_LOG=debug`, avoiding confusing situations
 # where adding `debug!()` appears to do nothing.

--- a/src/bootstrap/defaults/config.tools.toml
+++ b/src/bootstrap/defaults/config.tools.toml
@@ -14,6 +14,8 @@ download-rustc = "if-unchanged"
 [build]
 # Document with the in-tree rustdoc by default, since `download-rustc` makes it quick to compile.
 doc-stage = 2
+# Contributors working on tools will probably expect compiler docs to be generated, so they can figure out how to use the API.
+compiler-docs = true
 
 [llvm]
 # Will download LLVM from CI if available on your platform.

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -664,8 +664,6 @@ impl Step for Clippy {
             &[],
         );
 
-        // clippy tests need to know about the stage sysroot
-        cargo.env("SYSROOT", builder.sysroot(compiler));
         cargo.env("RUSTC_TEST_SUITE", builder.rustc(compiler));
         cargo.env("RUSTC_LIB_PATH", builder.rustc_libdir(compiler));
         let host_libs = builder.stage_out(compiler, Mode::ToolRustc).join(builder.cargo_dir());

--- a/src/bootstrap/tool.rs
+++ b/src/bootstrap/tool.rs
@@ -250,6 +250,10 @@ pub fn prepare_tool_cargo(
         }
     }
 
+    // clippy tests need to know about the stage sysroot. Set them consistently while building to
+    // avoid rebuilding when running tests.
+    cargo.env("SYSROOT", builder.sysroot(compiler));
+
     // if tools are using lzma we want to force the build script to build its
     // own copy
     cargo.env("LZMA_API_STATIC", "1");

--- a/src/librustdoc/html/static/.eslintrc.js
+++ b/src/librustdoc/html/static/.eslintrc.js
@@ -17,6 +17,10 @@ module.exports = {
             "error",
             "always"
         ],
+        "quotes": [
+            "error",
+            "double"
+        ],
         "no-var": ["error"],
         "prefer-const": ["error"],
         "prefer-arrow-callback": ["error"],

--- a/src/librustdoc/html/static/js/main.js
+++ b/src/librustdoc/html/static/js/main.js
@@ -291,7 +291,7 @@ function loadCss(cssFileName) {
 
 (function() {
     function loadScript(url) {
-        const script = document.createElement('script');
+        const script = document.createElement("script");
         script.src = url;
         document.head.append(script);
     }
@@ -344,7 +344,7 @@ function loadCss(cssFileName) {
             searchState.input.blur();
         },
         showResults: search => {
-            if (search === null || typeof search === 'undefined') {
+            if (search === null || typeof search === "undefined") {
                 search = searchState.outputElement();
             }
             switchDisplayedElement(search);
@@ -390,7 +390,7 @@ function loadCss(cssFileName) {
                 loadSearch();
             });
 
-            if (search_input.value !== '') {
+            if (search_input.value !== "") {
                 loadSearch();
             }
 
@@ -968,7 +968,7 @@ function loadCss(cssFileName) {
 
     onEachLazy(document.getElementsByClassName("notable-traits"), e => {
         e.onclick = function() {
-            this.getElementsByClassName('notable-traits-tooltiptext')[0]
+            this.getElementsByClassName("notable-traits-tooltiptext")[0]
                 .classList.toggle("force-tooltip");
         };
     });
@@ -1070,29 +1070,29 @@ function loadCss(cssFileName) {
         const path = [];
 
         onEach(parent.childNodes, child => {
-            if (child.tagName === 'A') {
+            if (child.tagName === "A") {
                 path.push(child.textContent);
             }
         });
 
-        const el = document.createElement('textarea');
-        el.value = path.join('::');
-        el.setAttribute('readonly', '');
+        const el = document.createElement("textarea");
+        el.value = path.join("::");
+        el.setAttribute("readonly", "");
         // To not make it appear on the screen.
-        el.style.position = 'absolute';
-        el.style.left = '-9999px';
+        el.style.position = "absolute";
+        el.style.left = "-9999px";
 
         document.body.appendChild(el);
         el.select();
-        document.execCommand('copy');
+        document.execCommand("copy");
         document.body.removeChild(el);
 
         // There is always one children, but multiple childNodes.
-        but.children[0].style.display = 'none';
+        but.children[0].style.display = "none";
 
         let tmp;
         if (but.childNodes.length < 2) {
-            tmp = document.createTextNode('✓');
+            tmp = document.createTextNode("✓");
             but.appendChild(tmp);
         } else {
             onEachLazy(but.childNodes, e => {
@@ -1101,7 +1101,7 @@ function loadCss(cssFileName) {
                     return true;
                 }
             });
-            tmp.textContent = '✓';
+            tmp.textContent = "✓";
         }
 
         if (reset_button_timeout !== null) {
@@ -1109,7 +1109,7 @@ function loadCss(cssFileName) {
         }
 
         function reset_button() {
-            tmp.textContent = '';
+            tmp.textContent = "";
             reset_button_timeout = null;
             but.children[0].style.display = "";
         }

--- a/src/librustdoc/html/static/js/scrape-examples.js
+++ b/src/librustdoc/html/static/js/scrape-examples.js
@@ -8,7 +8,7 @@
 
     // Scroll code block to the given code location
     function scrollToLoc(elt, loc) {
-        const lines = elt.querySelector('.line-numbers');
+        const lines = elt.querySelector(".line-numbers");
         let scrollOffset;
 
         // If the block is greater than the size of the viewer,
@@ -32,16 +32,16 @@
     function updateScrapedExample(example) {
         const locs = JSON.parse(example.attributes.getNamedItem("data-locs").textContent);
         let locIndex = 0;
-        const highlights = Array.prototype.slice.call(example.querySelectorAll('.highlight'));
-        const link = example.querySelector('.scraped-example-title a');
+        const highlights = Array.prototype.slice.call(example.querySelectorAll(".highlight"));
+        const link = example.querySelector(".scraped-example-title a");
 
         if (locs.length > 1) {
             // Toggle through list of examples in a given file
             const onChangeLoc = changeIndex => {
-                removeClass(highlights[locIndex], 'focus');
+                removeClass(highlights[locIndex], "focus");
                 changeIndex();
                 scrollToLoc(example, locs[locIndex][0]);
-                addClass(highlights[locIndex], 'focus');
+                addClass(highlights[locIndex], "focus");
 
                 const url = locs[locIndex][1];
                 const title = locs[locIndex][2];
@@ -50,24 +50,24 @@
                 link.innerHTML = title;
             };
 
-            example.querySelector('.prev')
-                .addEventListener('click', () => {
+            example.querySelector(".prev")
+                .addEventListener("click", () => {
                     onChangeLoc(() => {
                         locIndex = (locIndex - 1 + locs.length) % locs.length;
                     });
                 });
 
-            example.querySelector('.next')
-                .addEventListener('click', () => {
+            example.querySelector("next")
+                .addEventListener("click", () => {
                     onChangeLoc(() => {
                         locIndex = (locIndex + 1) % locs.length;
                     });
                 });
         }
 
-        const expandButton = example.querySelector('.expand');
+        const expandButton = example.querySelector(".expand");
         if (expandButton) {
-            expandButton.addEventListener('click', () => {
+            expandButton.addEventListener("click", () => {
                 if (hasClass(example, "expanded")) {
                     removeClass(example, "expanded");
                     scrollToLoc(example, locs[0][0]);
@@ -81,19 +81,19 @@
         scrollToLoc(example, locs[0][0]);
     }
 
-    const firstExamples = document.querySelectorAll('.scraped-example-list > .scraped-example');
+    const firstExamples = document.querySelectorAll(".scraped-example-list > .scraped-example");
     onEachLazy(firstExamples, updateScrapedExample);
-    onEachLazy(document.querySelectorAll('.more-examples-toggle'), toggle => {
+    onEachLazy(document.querySelectorAll(".more-examples-toggle"), toggle => {
         // Allow users to click the left border of the <details> section to close it,
         // since the section can be large and finding the [+] button is annoying.
-        onEachLazy(toggle.querySelectorAll('.toggle-line, .hide-more'), button => {
-            button.addEventListener('click', () => {
+        onEachLazy(toggle.querySelectorAll(".toggle-line, .hide-more"), button => {
+            button.addEventListener("click", () => {
                 toggle.open = false;
             });
         });
 
-        const moreExamples = toggle.querySelectorAll('.scraped-example');
-        toggle.querySelector('summary').addEventListener('click', () => {
+        const moreExamples = toggle.querySelectorAll(".scraped-example");
+        toggle.querySelector("summary").addEventListener("click", () => {
             // Wrapping in setTimeout ensures the update happens after the elements are actually
             // visible. This is necessary since updateScrapedExample calls scrollToLoc which
             // depends on offsetHeight, a property that requires an element to be visible to

--- a/src/librustdoc/html/static/js/search.js
+++ b/src/librustdoc/html/static/js/search.js
@@ -204,7 +204,7 @@ window.initSearch = rawSearchIndex => {
      * @return {boolean}
      */
     function isPathStart(parserState) {
-        return parserState.userQuery.slice(parserState.pos, parserState.pos + 2) == '::';
+        return parserState.userQuery.slice(parserState.pos, parserState.pos + 2) == "::";
     }
 
     /**
@@ -215,7 +215,7 @@ window.initSearch = rawSearchIndex => {
      * @return {boolean}
      */
     function isReturnArrow(parserState) {
-        return parserState.userQuery.slice(parserState.pos, parserState.pos + 2) == '->';
+        return parserState.userQuery.slice(parserState.pos, parserState.pos + 2) == "->";
     }
 
     /**
@@ -227,10 +227,10 @@ window.initSearch = rawSearchIndex => {
      */
     function isIdentCharacter(c) {
         return (
-            c === '_' ||
-            (c >= '0' && c <= '9') ||
-            (c >= 'a' && c <= 'z') ||
-            (c >= 'A' && c <= 'Z'));
+            c === "_" ||
+            (c >= "0" && c <= "9") ||
+            (c >= "a" && c <= "z") ||
+            (c >= "A" && c <= "Z"));
     }
 
     /**
@@ -264,7 +264,7 @@ window.initSearch = rawSearchIndex => {
      * @return {QueryElement}                - The newly created `QueryElement`.
      */
     function createQueryElement(query, parserState, name, generics, isInGenerics) {
-        if (name === '*' || (name.length === 0 && generics.length === 0)) {
+        if (name === "*" || (name.length === 0 && generics.length === 0)) {
             return;
         }
         if (query.literalSearch && parserState.totalElems - parserState.genericsElems > 0) {
@@ -1708,11 +1708,12 @@ window.initSearch = rawSearchIndex => {
 
         let crates = "";
         if (window.ALL_CRATES.length > 1) {
-            crates = ` in <select id="crate-search"><option value="All crates">All crates</option>`;
+            crates = " in <select id=\"crate-search\"><option value=\"All crates\">" +
+                "All crates</option>";
             for (const c of window.ALL_CRATES) {
                 crates += `<option value="${c}" ${c == filterCrates && "selected"}>${c}</option>`;
             }
-            crates += `</select>`;
+            crates += "</select>";
         }
 
         let typeFilter = "";
@@ -1720,17 +1721,17 @@ window.initSearch = rawSearchIndex => {
             typeFilter = " (type: " + escape(itemTypes[results.query.typeFilter]) + ")";
         }
 
-        let output = `<div id="search-settings">` +
+        let output = "<div id=\"search-settings\">" +
             `<h1 class="search-results-title">Results for ${escape(results.query.userQuery)}` +
             `${typeFilter}</h1> in ${crates} </div>`;
         if (results.query.error !== null) {
             output += `<h3>Query parser error: "${results.query.error}".</h3>`;
-            output += '<div id="titles">' +
+            output += "<div id=\"titles\">" +
                 makeTabHeader(0, "In Names", ret_others[1]) +
                 "</div>";
             currentTab = 0;
         } else if (results.query.foundElems <= 1 && results.query.returned.length === 0) {
-            output += `<div id="titles">` +
+            output += "<div id=\"titles\">" +
                 makeTabHeader(0, "In Names", ret_others[1]) +
                 makeTabHeader(1, "In Parameters", ret_in_args[1]) +
                 makeTabHeader(2, "In Return Types", ret_returned[1]) +
@@ -1740,7 +1741,7 @@ window.initSearch = rawSearchIndex => {
                 results.query.elems.length === 0 ? "In Function Return Types" :
                 results.query.returned.length === 0 ? "In Function Parameters" :
                 "In Function Signatures";
-            output += '<div id="titles">' +
+            output += "<div id=\"titles\">" +
                 makeTabHeader(0, signatureTabTitle, ret_others[1]) +
                 "</div>";
             currentTab = 0;

--- a/src/librustdoc/html/static/js/settings.js
+++ b/src/librustdoc/html/static/js/settings.js
@@ -108,7 +108,7 @@
         let output = "";
 
         for (const setting of settings) {
-            output += `<div class="setting-line">`;
+            output += "<div class=\"setting-line\">";
             const js_data_name = setting["js_name"];
             const setting_name = setting["name"];
 
@@ -217,11 +217,10 @@
 
         if (isSettingsPage) {
             innerHTML +=
-                `<a id="back" href="javascript:void(0)" onclick="history.back();">Back</a>`;
+                "<a id=\"back\" href=\"javascript:void(0)\" onclick=\"history.back();\">Back</a>";
         } else {
-            innerHTML +=
-                `<a id="back" href="javascript:void(0)" onclick="switchDisplayedElement(null);">\
-                    Back</a>`;
+            innerHTML += "<a id=\"back\" href=\"javascript:void(0)\" " +
+                "onclick=\"switchDisplayedElement(null);\">Back</a>";
         }
         innerHTML += `</span>
             </div>

--- a/src/librustdoc/html/static/js/storage.js
+++ b/src/librustdoc/html/static/js/storage.js
@@ -24,7 +24,7 @@ function getSettingValue(settingName) {
     if (settingsDataset !== null) {
         // See the comment for `default_settings.into_iter()` etc. in
         // `Options::from_matches` in `librustdoc/config.rs`.
-        const def = settingsDataset[settingName.replace(/-/g,'_')];
+        const def = settingsDataset[settingName.replace(/-/g,"_")];
         if (def !== undefined) {
             return def;
         }
@@ -173,7 +173,7 @@ const updateSystemTheme = (function () {
         // fallback to the CSS computed value
         return () => {
             const cssTheme = getComputedStyle(document.documentElement)
-                .getPropertyValue('content');
+                .getPropertyValue("content");
 
             switchTheme(
                 window.currentTheme,

--- a/src/test/ui/const-generics/const-argument-non-static-lifetime.rs
+++ b/src/test/ui/const-generics/const-argument-non-static-lifetime.rs
@@ -1,4 +1,4 @@
-// [full] run-pass
+// [full] check-pass
 // revisions: full min
 
 // regression test for #78180

--- a/src/test/ui/type-alias-impl-trait/auxiliary/collect_hidden_types.rs
+++ b/src/test/ui/type-alias-impl-trait/auxiliary/collect_hidden_types.rs
@@ -1,0 +1,21 @@
+#![feature(type_alias_impl_trait)]
+
+// edition:2018
+
+use std::future::Future;
+
+pub trait Service<Request> {
+    type Future: Future<Output = ()>;
+    fn call(&mut self, req: Request) -> Self::Future;
+}
+
+// NOTE: the pub(crate) here is critical
+pub(crate) fn new() -> () {}
+
+pub struct A;
+impl Service<()> for A {
+    type Future = impl Future<Output = ()>;
+    fn call(&mut self, _: ()) -> Self::Future {
+        async { new() }
+    }
+}

--- a/src/test/ui/type-alias-impl-trait/collect_hidden_types.rs
+++ b/src/test/ui/type-alias-impl-trait/collect_hidden_types.rs
@@ -1,0 +1,22 @@
+// aux-build:collect_hidden_types.rs
+use collect_hidden_types::Service;
+use std::future::Future;
+use std::pin::Pin;
+use std::task::Context;
+
+// build-pass
+
+// edition:2018
+
+extern crate collect_hidden_types;
+
+fn broken(mut a: collect_hidden_types::A, cx: &mut Context<'_>) {
+    let mut fut = a.call(());
+    let _ = unsafe { Pin::new_unchecked(&mut fut) }.poll(cx);
+}
+
+pub async fn meeb(cx: &mut Context<'_>) {
+    broken(collect_hidden_types::A, cx);
+}
+
+fn main() {}

--- a/src/test/ui/type-alias-impl-trait/cross_inference.rs
+++ b/src/test/ui/type-alias-impl-trait/cross_inference.rs
@@ -1,0 +1,10 @@
+// check-pass
+
+#![feature(type_alias_impl_trait)]
+
+fn main() {
+    type T = impl Copy;
+    let foo: T = (1u32, 2u32);
+    let x: (_, _) = foo;
+    println!("{:?}", x);
+}

--- a/src/test/ui/type-alias-impl-trait/cross_inference_pattern_bug.rs
+++ b/src/test/ui/type-alias-impl-trait/cross_inference_pattern_bug.rs
@@ -1,0 +1,24 @@
+// known-bug
+// failure-status: 101
+// compile-flags: --edition=2021 --crate-type=lib
+// rustc-env:RUST_BACKTRACE=0
+
+// normalize-stderr-test "thread 'rustc' panicked.*" -> "thread 'rustc' panicked"
+// normalize-stderr-test "note:.*RUST_BACKTRACE=1.*\n" -> ""
+// normalize-stderr-test "\nerror: internal compiler error.*\n\n" -> ""
+// normalize-stderr-test "note:.*unexpectedly panicked.*\n\n" -> ""
+// normalize-stderr-test "note: we would appreciate a bug report.*\n\n" -> ""
+// normalize-stderr-test "note: compiler flags.*\n\n" -> ""
+// normalize-stderr-test "note: rustc.*running on.*\n\n" -> ""
+// normalize-stderr-test "#.*\n" -> ""
+// normalize-stderr-test ".*delayed.*\n" -> ""
+
+// tracked in https://github.com/rust-lang/rust/issues/96572
+
+#![feature(type_alias_impl_trait)]
+
+fn main() {
+    type T = impl Copy;
+    let foo: T = (1u32, 2u32);
+    let (a, b): (u32, u32) = foo;
+}

--- a/src/test/ui/type-alias-impl-trait/cross_inference_pattern_bug.stderr
+++ b/src/test/ui/type-alias-impl-trait/cross_inference_pattern_bug.stderr
@@ -1,0 +1,32 @@
+error: internal compiler error: no errors encountered even though `delay_span_bug` issued
+
+error: internal compiler error: broken MIR in DefId(0:3 ~ cross_inference_pattern_bug[646d]::main) ((_1.0: u32)): can't project out of PlaceTy { ty: main::T, variant_index: None }
+  --> $DIR/cross_inference_pattern_bug.rs:23:10
+   |
+LL |     let (a, b): (u32, u32) = foo;
+   |          ^
+   |
+
+error: internal compiler error: TyKind::Error constructed but no error reported
+   |
+
+error: internal compiler error: TyKind::Error constructed but no error reported
+   |
+
+error: internal compiler error: broken MIR in DefId(0:3 ~ cross_inference_pattern_bug[646d]::main) ((_1.1: u32)): can't project out of PlaceTy { ty: main::T, variant_index: None }
+  --> $DIR/cross_inference_pattern_bug.rs:23:13
+   |
+LL |     let (a, b): (u32, u32) = foo;
+   |             ^
+   |
+
+error: internal compiler error: TyKind::Error constructed but no error reported
+   |
+
+error: internal compiler error: TyKind::Error constructed but no error reported
+   |
+
+thread 'rustc' panicked
+
+query stack during panic:
+end of query stack

--- a/src/test/ui/type-alias-impl-trait/cross_inference_pattern_bug_no_type.rs
+++ b/src/test/ui/type-alias-impl-trait/cross_inference_pattern_bug_no_type.rs
@@ -1,0 +1,13 @@
+// known-bug
+// compile-flags: --edition=2021 --crate-type=lib
+// rustc-env:RUST_BACKTRACE=0
+
+// tracked in https://github.com/rust-lang/rust/issues/96572
+
+#![feature(type_alias_impl_trait)]
+
+fn main() {
+    type T = impl Copy;  // error: unconstrained opaque type
+    let foo: T = (1u32, 2u32);
+    let (a, b) = foo; // removing this line makes the code compile
+}

--- a/src/test/ui/type-alias-impl-trait/cross_inference_pattern_bug_no_type.stderr
+++ b/src/test/ui/type-alias-impl-trait/cross_inference_pattern_bug_no_type.stderr
@@ -1,0 +1,10 @@
+error: unconstrained opaque type
+  --> $DIR/cross_inference_pattern_bug_no_type.rs:10:14
+   |
+LL |     type T = impl Copy;  // error: unconstrained opaque type
+   |              ^^^^^^^^^
+   |
+   = note: `T` must be used in combination with a concrete type within the same module
+
+error: aborting due to previous error
+

--- a/src/test/ui/type-alias-impl-trait/cross_inference_rpit.rs
+++ b/src/test/ui/type-alias-impl-trait/cross_inference_rpit.rs
@@ -1,0 +1,14 @@
+// check-pass
+
+fn foo(b: bool) -> impl Copy {
+    if b {
+        return (5,6)
+    }
+    let x: (_, _) = foo(true);
+    println!("{:?}", x);
+    (1u32, 2u32)
+}
+
+fn main() {
+    foo(false);
+}


### PR DESCRIPTION
Successful merges:

 - #96336 (Link to correct `as_mut` in docs for `pointer::as_ref`)
 - #96586 (Add aliases for std::fs::canonicalize)
 - #96667 (Add regression test)
 - #96671 (Remove hard links from `env::current_exe` security example)
 - #96726 (Add regression and bug tests)
 - #96756 (Enable compiler-docs by default for `compiler`, `codegen`, and `tools` profiles)
 - #96757 (Don't constantly rebuild clippy on `x test src/tools/clippy`.)
 - #96769 (Remove `adx_target_feature` feature from active features list)
 - #96777 (Make the test `check-pass` not to produce a JSON file)
 - #96822 (Enforce quote rule for JS source code)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=96336,96586,96667,96671,96726,96756,96757,96769,96777,96822)
<!-- homu-ignore:end -->