### PR TITLE
Use `fcntl(fd, F_GETFD)` to detect if standard streams are open

### DIFF
--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -239,6 +239,7 @@
 #![feature(dropck_eyepatch)]
 #![feature(exhaustive_patterns)]
 #![feature(intra_doc_pointers)]
+#![feature(label_break_value)]
 #![feature(lang_items)]
 #![feature(let_chains)]
 #![feature(linkage)]

--- a/src/test/ui/process/nofile-limit.rs
+++ b/src/test/ui/process/nofile-limit.rs
@@ -1,0 +1,46 @@
+// Check that statically linked binary executes successfully
+// with RLIMIT_NOFILE resource lowered to zero. Regression
+// test for issue #96621.
+//
+// run-pass
+// dont-check-compiler-stderr
+// only-linux
+// no-prefer-dynamic
+// compile-flags: -Ctarget-feature=+crt-static -Crpath=no
+#![feature(exit_status_error)]
+#![feature(rustc_private)]
+extern crate libc;
+
+use std::os::unix::process::CommandExt;
+use std::process::Command;
+
+fn main() {
+    let mut args = std::env::args();
+    let this = args.next().unwrap();
+    match args.next().as_deref() {
+        None => {
+            let mut cmd = Command::new(this);
+            cmd.arg("Ok!");
+            unsafe {
+                cmd.pre_exec(|| {
+                    let rlim = libc::rlimit {
+                        rlim_cur: 0,
+                        rlim_max: 0,
+                    };
+                    if libc::setrlimit(libc::RLIMIT_NOFILE, &rlim) == -1 {
+                        Err(std::io::Error::last_os_error())
+                    } else {
+                        Ok(())
+                    }
+                })
+            };
+            let output = cmd.output().unwrap();
+            println!("{:?}", output);
+            output.status.exit_ok().unwrap();
+            assert!(output.stdout.starts_with(b"Ok!"));
+        }
+        Some(word) => {
+            println!("{}", word);
+        }
+    }
+}


### PR DESCRIPTION
In the previous implementation, if the standard streams were open,
but the RLIMIT_NOFILE value was below three, the poll would fail
with EINVAL:

> ERRORS: EINVAL The nfds value exceeds the RLIMIT_NOFILE value.

Switch to the existing fcntl based implementation to avoid the issue.

Fixes #96621.