### PR TITLE
Revert "Implement [OsStr]::join", which was merged without FCP.

### DIFF
--- a/library/std/src/ffi/os_str.rs
+++ b/library/std/src/ffi/os_str.rs
@@ -1222,23 +1222,6 @@ impl OsStr {
     }
 }
 
-#[unstable(feature = "slice_concat_ext", issue = "27747")]
-impl<S: Borrow<OsStr>> alloc::slice::Join<&OsStr> for [S] {
-    type Output = OsString;
-
-    fn join(slice: &Self, sep: &OsStr) -> OsString {
-        let Some(first) = slice.first() else {
-            return OsString::new();
-        };
-        let first = first.borrow().to_owned();
-        slice[1..].iter().fold(first, |mut a, b| {
-            a.push(sep);
-            a.push(b.borrow());
-            a
-        })
-    }
-}
-
 #[stable(feature = "rust1", since = "1.0.0")]
 impl Borrow<OsStr> for OsString {
     #[inline]

--- a/library/std/src/ffi/os_str/tests.rs
+++ b/library/std/src/ffi/os_str/tests.rs
@@ -85,20 +85,6 @@ fn test_os_string_reserve_exact() {
 }
 
 #[test]
-fn test_os_string_join() {
-    let strings = [OsStr::new("hello"), OsStr::new("dear"), OsStr::new("world")];
-    assert_eq!("hello", strings[..1].join(OsStr::new(" ")));
-    assert_eq!("hello dear world", strings.join(OsStr::new(" ")));
-    assert_eq!("hellodearworld", strings.join(OsStr::new("")));
-    assert_eq!("hello.\n dear.\n world", strings.join(OsStr::new(".\n ")));
-
-    assert_eq!("dear world", strings[1..].join(&OsString::from(" ")));
-
-    let strings_abc = [OsString::from("a"), OsString::from("b"), OsString::from("c")];
-    assert_eq!("a b c", strings_abc.join(OsStr::new(" ")));
-}
-
-#[test]
 fn test_os_string_default() {
     let os_string: OsString = Default::default();
     assert_eq!("", &os_string);

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -241,7 +241,6 @@
 #![feature(intra_doc_pointers)]
 #![feature(lang_items)]
 #![feature(let_chains)]
-#![feature(let_else)]
 #![feature(linkage)]
 #![feature(min_specialization)]
 #![feature(must_not_suspend)]
@@ -302,7 +301,6 @@
 #![feature(toowned_clone_into)]
 #![feature(try_reserve_kind)]
 #![feature(vec_into_raw_parts)]
-#![feature(slice_concat_trait)]
 //
 // Library features (unwind):
 #![feature(panic_unwind)]


### PR DESCRIPTION
This reverts commit 4fcbc53820ab423bbeb41f07822369aa05da1d68, see https://github.com/rust-lang/rust/pull/96744. (I'm terribly sorry, and truly don't remember r+ing it, or even having seen it before yesterday, which is... genuinely very worrisome for me).

r? @m-ou-se