### PR TITLE
Re-enable nvptx tests

### DIFF
--- a/src/test/assembly/nvptx-arch-default.rs
+++ b/src/test/assembly/nvptx-arch-default.rs
@@ -1,7 +1,6 @@
 // assembly-output: ptx-linker
 // compile-flags: --crate-type cdylib
 // only-nvptx64
-// ignore-nvptx64
 
 #![no_std]
 

--- a/src/test/assembly/nvptx-arch-emit-asm.rs
+++ b/src/test/assembly/nvptx-arch-emit-asm.rs
@@ -1,7 +1,6 @@
 // assembly-output: emit-asm
 // compile-flags: --crate-type rlib
 // only-nvptx64
-// ignore-nvptx64
 
 #![no_std]
 

--- a/src/test/assembly/nvptx-arch-link-arg.rs
+++ b/src/test/assembly/nvptx-arch-link-arg.rs
@@ -1,7 +1,6 @@
 // assembly-output: ptx-linker
 // compile-flags: --crate-type cdylib -C link-arg=--arch=sm_60
 // only-nvptx64
-// ignore-nvptx64
 
 #![no_std]
 

--- a/src/test/assembly/nvptx-arch-target-cpu.rs
+++ b/src/test/assembly/nvptx-arch-target-cpu.rs
@@ -1,7 +1,6 @@
 // assembly-output: ptx-linker
 // compile-flags: --crate-type cdylib -C target-cpu=sm_50
 // only-nvptx64
-// ignore-nvptx64
 
 #![no_std]
 

--- a/src/test/assembly/nvptx-atomics.rs
+++ b/src/test/assembly/nvptx-atomics.rs
@@ -1,7 +1,6 @@
 // assembly-output: ptx-linker
 // compile-flags: --crate-type cdylib
 // only-nvptx64
-// ignore-nvptx64
 
 #![feature(abi_ptx, core_intrinsics)]
 #![no_std]
@@ -23,7 +22,7 @@ extern crate breakpoint_panic_handler;
 // FIXME(denzp): add tests for `core::sync::atomic::*`.
 
 #[no_mangle]
-pub unsafe extern "ptx-kernel" fn atomics_kernel(a: *mut u32) {
+pub unsafe extern "ptx-kernel" fn atomics_kernel(a: *mut u32, out: *mut u32) {
     // CHECK: atom.global.and.b32 %{{r[0-9]+}}, [%{{rd[0-9]+}}], 1;
     // CHECK: atom.global.and.b32 %{{r[0-9]+}}, [%{{rd[0-9]+}}], 1;
     atomic_and(a, 1);
@@ -66,8 +65,8 @@ pub unsafe extern "ptx-kernel" fn atomics_kernel(a: *mut u32) {
 
     // CHECK: atom.global.exch.b32 %{{r[0-9]+}}, [%{{rd[0-9]+}}], 1;
     // CHECK: atom.global.exch.b32 %{{r[0-9]+}}, [%{{rd[0-9]+}}], 1;
-    atomic_xchg(a, 1);
-    atomic_xchg_relaxed(a, 1);
+    *out = atomic_xchg(a, 1);
+    *out = atomic_xchg_relaxed(a, 1);
 
     // CHECK: atom.global.xor.b32 %{{r[0-9]+}}, [%{{rd[0-9]+}}], 1;
     // CHECK: atom.global.xor.b32 %{{r[0-9]+}}, [%{{rd[0-9]+}}], 1;

--- a/src/test/assembly/nvptx-internalizing.rs
+++ b/src/test/assembly/nvptx-internalizing.rs
@@ -1,7 +1,6 @@
 // assembly-output: ptx-linker
 // compile-flags: --crate-type cdylib
 // only-nvptx64
-// ignore-nvptx64
 
 #![feature(abi_ptx)]
 #![no_std]

--- a/src/test/assembly/nvptx-kernel-abi/nvptx-kernel-args-abi-v7.rs
+++ b/src/test/assembly/nvptx-kernel-abi/nvptx-kernel-args-abi-v7.rs
@@ -1,7 +1,6 @@
 // assembly-output: ptx-linker
 // compile-flags: --crate-type cdylib -C target-cpu=sm_86
 // only-nvptx64
-// ignore-nvptx64
 
 // The following ABI tests are made with nvcc 11.6 does.
 //

--- a/src/test/assembly/nvptx-linking-binary.rs
+++ b/src/test/assembly/nvptx-linking-binary.rs
@@ -1,7 +1,6 @@
 // assembly-output: ptx-linker
 // compile-flags: --crate-type bin
 // only-nvptx64
-// ignore-nvptx64
 
 #![feature(abi_ptx)]
 #![no_main]

--- a/src/test/assembly/nvptx-linking-cdylib.rs
+++ b/src/test/assembly/nvptx-linking-cdylib.rs
@@ -1,7 +1,6 @@
 // assembly-output: ptx-linker
 // compile-flags: --crate-type cdylib
 // only-nvptx64
-// ignore-nvptx64
 
 #![feature(abi_ptx)]
 #![no_std]

--- a/src/test/assembly/nvptx-safe-naming.rs
+++ b/src/test/assembly/nvptx-safe-naming.rs
@@ -1,7 +1,6 @@
 // assembly-output: ptx-linker
 // compile-flags: --crate-type cdylib
 // only-nvptx64
-// ignore-nvptx64
 
 #![feature(abi_ptx)]
 #![no_std]
@@ -10,7 +9,7 @@
 extern crate breakpoint_panic_handler;
 
 // Verify function name doesn't contain unacceaptable characters.
-// CHECK: .func (.param .b32 func_retval0) [[IMPL_FN:[a-zA-Z0-9$_]+square[a-zA-Z0-9$_]+]](
+// CHECK: .func (.param .b32 func_retval0) [[IMPL_FN:[a-zA-Z0-9$_]+square[a-zA-Z0-9$_]+]]
 
 // CHECK-LABEL: .visible .entry top_kernel(
 #[no_mangle]


### PR DESCRIPTION
This is a PR to re-enable CI testing of the nvptx64-nvidia-cuda target. It requires two things to work:
 - [x] Re-enable and fix tests
 - [ ] Add rust-ptx-linker to CI

ptx-linker was removed from the CI in 2019 [here](https://github.com/rust-lang/rust/commit/f8f9a2869cce570c994d96afb82f4162b1b44cca). This was due to the [old version relying on symbols from rustc_codegen_llvm](https://github.com/rust-lang/rust/pull/59752#issuecomment-486245922). This has been [changed since then](https://github.com/denzp/rustc-llvm-proxy/pull/7).

My proposal for the short term is that @denzp creates a release for v0.9.1 on github. Then we can then download it with wget/curl like we used to do with the 0.9.0 ptx linker. This PR is therefore blocked right now on a suitable place where ptx-linker can be downloaded.

For the long term ptx-linker should be distributed in a more proper way, but I suspect this is not the most pressing matter when it comes to nvptx. I have created [this issue](https://github.com/denzp/rust-ptx-linker/issues/34) asking for re-licensing to MIT/Apache-2. But I'm honestly not sure if it is absolutely necessary for a tool? There are also many more things I'm uncertain about when it comes to the long-term plan like: where the code should live, does it need to be a rustup component or can it be bundled with the nvptx64 toolchain, and what the proper way to build it for nvptx targets in CI. Hopefully we do not have to attack that right now before making progress on the CI situation?

Requesting review since nagisa is familiar with the work I'm currently doing from previous PR.
r? @nagisa