### PR TITLE
Add `const` to `Vec::len()` and `Vec::is_empty()`

### DIFF
--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -1908,6 +1908,7 @@ impl<T, A: Allocator> Vec<T, A> {
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[rustc_const_stable(feature = "const-vec-len", since = "1.62.0")]
     pub const fn len(&self) -> usize {
         self.len
     }
@@ -1924,6 +1925,7 @@ impl<T, A: Allocator> Vec<T, A> {
     /// assert!(!v.is_empty());
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[rustc_const_stable(feature = "const-vec-len", since = "1.62.0")]
     pub const fn is_empty(&self) -> bool {
         self.len() == 0
     }

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -1908,7 +1908,7 @@ impl<T, A: Allocator> Vec<T, A> {
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn len(&self) -> usize {
+    pub const fn len(&self) -> usize {
         self.len
     }
 
@@ -1924,7 +1924,7 @@ impl<T, A: Allocator> Vec<T, A> {
     /// assert!(!v.is_empty());
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn is_empty(&self) -> bool {
+    pub const fn is_empty(&self) -> bool {
         self.len() == 0
     }
 


### PR DESCRIPTION
Came across this while converting the const methods of a slice-based type into an owned version. Should be no change in behavior to any existing code, but allows vector length to be used in a const fn.

This has some amount of precedent, as `<[T]>::len()` and `<[T]>::is_empty()` are both also const; In addition, `Vec` already has a const fn in `Vec::new()`.

There are a few other `Vec` methods that look `const`able to me on the surface, but I figured it would be best to start with just these two, as they rely only on a single field.