### PR TITLE
Add `Parser::inlined_bump` and use it for two hot call sites.

### DIFF
--- a/compiler/rustc_parse/src/parser/mod.rs
+++ b/compiler/rustc_parse/src/parser/mod.rs
@@ -989,6 +989,12 @@ impl<'a> Parser<'a> {
 
     /// Advance the parser by one token.
     pub fn bump(&mut self) {
+        self.inlined_bump()
+    }
+
+    /// This always-inlined version should only be used on hot code paths.
+    #[inline(always)]
+    pub fn inlined_bump(&mut self) {
         // Note: destructuring here would give nicer code, but it was found in #96210 to be slower
         // than `.0`/`.1` access.
         let mut next = self.token_cursor.inlined_next(self.desugar_doc_comments);
@@ -1195,7 +1201,7 @@ impl<'a> Parser<'a> {
                 loop {
                     // Advance one token at a time, so `TokenCursor::next()`
                     // can capture these tokens if necessary.
-                    self.bump();
+                    self.inlined_bump();
                     if self.token_cursor.stack.len() == target_depth {
                         debug_assert!(matches!(self.token.kind, token::CloseDelim(_)));
                         break;
@@ -1208,7 +1214,7 @@ impl<'a> Parser<'a> {
             }
             token::CloseDelim(_) | token::Eof => unreachable!(),
             _ => {
-                self.bump();
+                self.inlined_bump();
                 TokenTree::Token(self.prev_token.clone())
             }
         }

--- a/compiler/rustc_parse/src/parser/nonterminal.rs
+++ b/compiler/rustc_parse/src/parser/nonterminal.rs
@@ -98,7 +98,7 @@ impl<'a> Parser<'a> {
     }
 
     /// Parse a non-terminal (e.g. MBE `:pat` or `:ident`). Inlined because there is only one call
-    /// site.
+    /// site, which can be hot.
     #[inline]
     pub fn parse_nonterminal(&mut self, kind: NonterminalKind) -> PResult<'a, NtOrTt> {
         // Any `Nonterminal` which stores its tokens (currently `NtItem` and `NtExpr`)


### PR DESCRIPTION
This gives small wins on a couple of benchmarks.

r? @lqd 