### PR TITLE
Fix spurious error when running `build --stage 2 compiler/rustc`

### DIFF
--- a/src/bootstrap/builder/tests.rs
+++ b/src/bootstrap/builder/tests.rs
@@ -501,7 +501,10 @@ mod dist {
                 std!(A => C, stage = 2),
             ]
         );
-        assert_eq!(builder.cache.all::<compile::Assemble>().len(), 5);
+        // Theoretically this should be 5, the same as `compile::Rustc`.
+        // Unfortunately, the sysroot for the stage 3 compiler is broken; see #90244.
+        // Instead we only generate the sysroot for non-stage2 build compilers.
+        assert_eq!(builder.cache.all::<compile::Assemble>().len(), 3);
         assert_eq!(
             first(builder.cache.all::<compile::Rustc>()),
             &[


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/89759 introduced a panic:
```
Assembling stage3 compiler (x86_64-apple-darwin)
thread 'main' panicked at 'fs::read(stamp) failed with No such file or directory (os error 2) ("/Users/user/rust2/build/x86_64-apple-darwin/stage2-rustc/x86_64-apple-darwin/release/.librustc.stamp")', src/bootstrap/lib.rs:1296:24
```
This wasn't actually a bug in that PR - the problem was that `x build --stage 3`
is broken, and has been for quite some time, even ignoring the stamp file error:
```
thread 'main' panicked at 'src.symlink_metadata() failed with No such file or directory (os error 2) ("failed to determine metadata of /home/jnelson/rust-lang/rust/build/x86_64-unknown-linux-gnu/stage2-rustc/x86_64-unknown-linux-gnu/release/rustc-main")', src/bootstrap/lib.rs:1414:24
```

It needs to take into account whether the artifacts from stage1 are being reused, rather than blindly assuming rustc will be recompiled.
Doing so is kind of annoying, because it requires knowing the target the compiler is being built for.
Instead, just revert to the old behavior of `build --stage 2 compiler/rustc`, which avoids trying to create the sysroot in the first place.

Note that this does *not* help with https://github.com/rust-lang/rust/pull/96798#issuecomment-1120326026, which really does need the sysroot available. I think requiring the stage 3 sysroot there is a bug - we should either use `test --stage 1` in CI, or change the stage numbering so that `test --stage 2` matches the behavior of other tools (i.e. it runs the clippy *in* the stage 2 toolchain, not the clippy *built by* the stage 2 toolchain).

Fixes https://github.com/rust-lang/rust/issues/90244.
r? @Mark-Simulacrum