### PR TITLE
openbsd: convert futex timeout managment to Timespec usage

### DIFF
--- a/library/std/src/sys/unix/futex.rs
+++ b/library/std/src/sys/unix/futex.rs
@@ -25,7 +25,7 @@ pub fn futex_wait(futex: &AtomicU32, expected: u32, timeout: Option<Duration>) -
     //
     // Overflows are rounded up to an infinite timeout (None).
     let timespec = timeout
-        .and_then(|d| Some(Timespec::now(libc::CLOCK_MONOTONIC).checked_add_duration(&d)?))
+        .and_then(|d| Timespec::now(libc::CLOCK_MONOTONIC).checked_add_duration(&d))
         .and_then(|t| t.to_timespec());
 
     loop {

--- a/library/std/src/sys/unix/time.rs
+++ b/library/std/src/sys/unix/time.rs
@@ -51,7 +51,7 @@ impl fmt::Debug for SystemTime {
 }
 
 impl Timespec {
-    const fn zero() -> Timespec {
+    pub const fn zero() -> Timespec {
         Timespec { tv_sec: 0, tv_nsec: 0 }
     }
 

--- a/library/std/src/sys/unix/time.rs
+++ b/library/std/src/sys/unix/time.rs
@@ -125,6 +125,7 @@ impl Timespec {
         Some(Timespec::new(secs, nsec as i64))
     }
 
+    #[allow(dead_code)]
     pub fn to_timespec(&self) -> Option<libc::timespec> {
         Some(libc::timespec {
             tv_sec: self.tv_sec.try_into().ok()?,


### PR DESCRIPTION
unbreak openbsd build after #96657

r? cuviper

please note I made `Timespec::zero()` public to be able to use it. OpenBSD is using relative timeout for `futex(2)` and I don't find simple way to use `Timespec` this way.