### PR TITLE
Change enum->int casts to not go through MIR casts.

### DIFF
--- a/compiler/rustc_codegen_cranelift/src/base.rs
+++ b/compiler/rustc_codegen_cranelift/src/base.rs
@@ -635,29 +635,6 @@ fn codegen_stmt<'tcx>(
                             let (ptr, _extra) = operand.load_scalar_pair(fx);
                             lval.write_cvalue(fx, CValue::by_val(ptr, dest_layout))
                         }
-                    } else if let ty::Adt(adt_def, _substs) = from_ty.kind() {
-                        // enum -> discriminant value
-                        assert!(adt_def.is_enum());
-                        match to_ty.kind() {
-                            ty::Uint(_) | ty::Int(_) => {}
-                            _ => unreachable!("cast adt {} -> {}", from_ty, to_ty),
-                        }
-                        let to_clif_ty = fx.clif_type(to_ty).unwrap();
-
-                        let discriminant = crate::discriminant::codegen_get_discriminant(
-                            fx,
-                            operand,
-                            fx.layout_of(operand.layout().ty.discriminant_ty(fx.tcx)),
-                        )
-                        .load_scalar(fx);
-
-                        let res = crate::cast::clif_intcast(
-                            fx,
-                            discriminant,
-                            to_clif_ty,
-                            to_ty.is_signed(),
-                        );
-                        lval.write_cvalue(fx, CValue::by_val(res, dest_layout));
                     } else {
                         let to_clif_ty = fx.clif_type(to_ty).unwrap();
                         let from = operand.load_scalar(fx);

--- a/compiler/rustc_codegen_llvm/src/builder.rs
+++ b/compiler/rustc_codegen_llvm/src/builder.rs
@@ -464,7 +464,7 @@ impl<'a, 'll, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'll, 'tcx> {
         }
     }
 
-    #[instrument(level = "debug", skip(self))]
+    #[instrument(level = "trace", skip(self))]
     fn load_operand(&mut self, place: PlaceRef<'tcx, &'ll Value>) -> OperandRef<'tcx, &'ll Value> {
         assert_eq!(place.llextra.is_some(), place.layout.is_unsized());
 

--- a/compiler/rustc_codegen_llvm/src/builder.rs
+++ b/compiler/rustc_codegen_llvm/src/builder.rs
@@ -28,7 +28,7 @@ use std::ffi::CStr;
 use std::iter;
 use std::ops::Deref;
 use std::ptr;
-use tracing::debug;
+use tracing::{debug, instrument};
 
 // All Builders must have an llfn associated with them
 #[must_use]
@@ -464,15 +464,15 @@ impl<'a, 'll, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'll, 'tcx> {
         }
     }
 
+    #[instrument(level = "debug", skip(self))]
     fn load_operand(&mut self, place: PlaceRef<'tcx, &'ll Value>) -> OperandRef<'tcx, &'ll Value> {
-        debug!("PlaceRef::load: {:?}", place);
-
         assert_eq!(place.llextra.is_some(), place.layout.is_unsized());
 
         if place.layout.is_zst() {
             return OperandRef::new_zst(self, place.layout);
         }
 
+        #[instrument(level = "trace", skip(bx))]
         fn scalar_load_metadata<'a, 'll, 'tcx>(
             bx: &mut Builder<'a, 'll, 'tcx>,
             load: &'ll Value,

--- a/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
@@ -1623,7 +1623,7 @@ extern "C" {
         B: &Builder<'a>,
         Val: &'a Value,
         DestTy: &'a Type,
-        IsSized: bool,
+        IsSigned: bool,
     ) -> &'a Value;
 
     // Comparisons

--- a/compiler/rustc_codegen_ssa/src/mir/place.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/place.rs
@@ -204,6 +204,7 @@ impl<'a, 'tcx, V: CodegenObject> PlaceRef<'tcx, V> {
     }
 
     /// Obtain the actual discriminant of a value.
+    #[instrument(level = "trace", skip(bx))]
     pub fn codegen_get_discr<Bx: BuilderMethods<'a, 'tcx, Value = V>>(
         self,
         bx: &mut Bx,
@@ -420,12 +421,12 @@ impl<'a, 'tcx, V: CodegenObject> PlaceRef<'tcx, V> {
 }
 
 impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
+    #[instrument(level = "debug", skip(self, bx))]
     pub fn codegen_place(
         &mut self,
         bx: &mut Bx,
         place_ref: mir::PlaceRef<'tcx>,
     ) -> PlaceRef<'tcx, Bx::Value> {
-        debug!("codegen_place(place_ref={:?})", place_ref);
         let cx = self.cx;
         let tcx = self.cx.tcx();
 

--- a/compiler/rustc_codegen_ssa/src/mir/place.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/place.rs
@@ -421,7 +421,7 @@ impl<'a, 'tcx, V: CodegenObject> PlaceRef<'tcx, V> {
 }
 
 impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
-    #[instrument(level = "debug", skip(self, bx))]
+    #[instrument(level = "trace", skip(self, bx))]
     pub fn codegen_place(
         &mut self,
         bx: &mut Bx,

--- a/compiler/rustc_codegen_ssa/src/mir/rvalue.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/rvalue.rs
@@ -14,7 +14,7 @@ use rustc_middle::ty::{self, adjustment::PointerCast, Instance, Ty, TyCtxt};
 use rustc_span::source_map::{Span, DUMMY_SP};
 
 impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
-    #[instrument(level = "debug", skip(self, bx))]
+    #[instrument(level = "trace", skip(self, bx))]
     pub fn codegen_rvalue(
         &mut self,
         mut bx: Bx,

--- a/compiler/rustc_codegen_ssa/src/mir/rvalue.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/rvalue.rs
@@ -15,14 +15,13 @@ use rustc_span::source_map::{Span, DUMMY_SP};
 use rustc_target::abi::{Abi, Int, Variants};
 
 impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
+    #[instrument(level = "debug", skip(self, bx))]
     pub fn codegen_rvalue(
         &mut self,
         mut bx: Bx,
         dest: PlaceRef<'tcx, Bx::Value>,
         rvalue: &mir::Rvalue<'tcx>,
     ) -> Bx {
-        debug!("codegen_rvalue(dest.llval={:?}, rvalue={:?})", dest.llval, rvalue);
-
         match *rvalue {
             mir::Rvalue::Use(ref operand) => {
                 let cg_operand = self.codegen_operand(&mut bx, operand);

--- a/compiler/rustc_codegen_ssa/src/mir/rvalue.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/rvalue.rs
@@ -286,7 +286,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
 
                         let newval = match (r_t_in, r_t_out) {
                             (CastTy::Int(i), CastTy::Int(_)) => {
-                                bx.intcast(llval, ll_t_out, matches!(i, IntTy::I))
+                                bx.intcast(llval, ll_t_out, i.is_signed())
                             }
                             (CastTy::Float, CastTy::Float) => {
                                 let srcsz = bx.cx().float_width(ll_t_in);
@@ -300,7 +300,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                                 }
                             }
                             (CastTy::Int(i), CastTy::Float) => {
-                                if matches!(i, IntTy::I) {
+                                if i.is_signed() {
                                     bx.sitofp(llval, ll_t_out)
                                 } else {
                                     bx.uitofp(llval, ll_t_out)
@@ -311,7 +311,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                             }
                             (CastTy::Int(i), CastTy::Ptr(_)) => {
                                 let usize_llval =
-                                    bx.intcast(llval, bx.cx().type_isize(), matches!(i, IntTy::I));
+                                    bx.intcast(llval, bx.cx().type_isize(), i.is_signed());
                                 bx.inttoptr(usize_llval, ll_t_out)
                             }
                             (CastTy::Float, CastTy::Int(IntTy::I)) => {

--- a/compiler/rustc_codegen_ssa/src/mir/statement.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/statement.rs
@@ -6,9 +6,8 @@ use crate::traits::BuilderMethods;
 use crate::traits::*;
 
 impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
+    #[instrument(level = "debug", skip(self, bx))]
     pub fn codegen_statement(&mut self, mut bx: Bx, statement: &mir::Statement<'tcx>) -> Bx {
-        debug!("codegen_statement(statement={:?})", statement);
-
         self.set_debug_loc(&mut bx, statement.source_info);
         match statement.kind {
             mir::StatementKind::Assign(box (ref place, ref rvalue)) => {

--- a/compiler/rustc_middle/src/ty/cast.rs
+++ b/compiler/rustc_middle/src/ty/cast.rs
@@ -15,6 +15,12 @@ pub enum IntTy {
     Char,
 }
 
+impl IntTy {
+    pub fn is_signed(self) -> bool {
+        matches!(self, Self::I)
+    }
+}
+
 // Valid types for the result of a non-coercion cast
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum CastTy<'tcx> {

--- a/compiler/rustc_mir_build/src/thir/cx/expr.rs
+++ b/compiler/rustc_mir_build/src/thir/cx/expr.rs
@@ -32,13 +32,14 @@ impl<'tcx> Cx<'tcx> {
         exprs.iter().map(|expr| self.mirror_expr_inner(expr)).collect()
     }
 
+    #[instrument(level = "debug", skip(self, hir_expr))]
     pub(super) fn mirror_expr_inner(&mut self, hir_expr: &'tcx hir::Expr<'tcx>) -> ExprId {
         let temp_lifetime =
             self.rvalue_scopes.temporary_scope(self.region_scope_tree, hir_expr.hir_id.local_id);
         let expr_scope =
             region::Scope { id: hir_expr.hir_id.local_id, data: region::ScopeData::Node };
 
-        debug!("Expr::make_mirror(): id={}, span={:?}", hir_expr.hir_id, hir_expr.span);
+        debug!(?hir_expr.hir_id, ?hir_expr.span);
 
         let mut expr = self.make_mirror_unadjusted(hir_expr);
 
@@ -49,7 +50,7 @@ impl<'tcx> Cx<'tcx> {
 
         // Now apply adjustments, if any.
         for adjustment in self.typeck_results.expr_adjustments(hir_expr) {
-            debug!("make_mirror: expr={:?} applying adjustment={:?}", expr, adjustment);
+            trace!(?expr, ?adjustment);
             let span = expr.span;
             expr =
                 self.apply_adjustment(hir_expr, expr, adjustment, adjustment_span.unwrap_or(span));

--- a/compiler/rustc_mir_build/src/thir/cx/expr.rs
+++ b/compiler/rustc_mir_build/src/thir/cx/expr.rs
@@ -32,14 +32,14 @@ impl<'tcx> Cx<'tcx> {
         exprs.iter().map(|expr| self.mirror_expr_inner(expr)).collect()
     }
 
-    #[instrument(level = "debug", skip(self, hir_expr))]
+    #[instrument(level = "trace", skip(self, hir_expr))]
     pub(super) fn mirror_expr_inner(&mut self, hir_expr: &'tcx hir::Expr<'tcx>) -> ExprId {
         let temp_lifetime =
             self.rvalue_scopes.temporary_scope(self.region_scope_tree, hir_expr.hir_id.local_id);
         let expr_scope =
             region::Scope { id: hir_expr.hir_id.local_id, data: region::ScopeData::Node };
 
-        debug!(?hir_expr.hir_id, ?hir_expr.span);
+        trace!(?hir_expr.hir_id, ?hir_expr.span);
 
         let mut expr = self.make_mirror_unadjusted(hir_expr);
 

--- a/src/test/codegen/enum-bounds-check-derived-idx.rs
+++ b/src/test/codegen/enum-bounds-check-derived-idx.rs
@@ -12,13 +12,15 @@ pub enum Bar {
 // CHECK-LABEL: @lookup_inc
 #[no_mangle]
 pub fn lookup_inc(buf: &[u8; 5], f: Bar) -> u8 {
-    // CHECK-NOT: panic_bounds_check
+    // FIXME: panic check can be removed by adding the assumes back after https://github.com/rust-lang/rust/pull/98332
+    // CHECK: panic_bounds_check
     buf[f as usize + 1]
 }
 
 // CHECK-LABEL: @lookup_dec
 #[no_mangle]
 pub fn lookup_dec(buf: &[u8; 5], f: Bar) -> u8 {
-    // CHECK-NOT: panic_bounds_check
+    // FIXME: panic check can be removed by adding the assumes back after https://github.com/rust-lang/rust/pull/98332
+    // CHECK: panic_bounds_check
     buf[f as usize - 1]
 }

--- a/src/test/codegen/enum-bounds-check-issue-13926.rs
+++ b/src/test/codegen/enum-bounds-check-issue-13926.rs
@@ -13,6 +13,7 @@ pub enum Exception {
 // CHECK-LABEL: @access
 #[no_mangle]
 pub fn access(array: &[usize; 12], exc: Exception) -> usize {
-    // CHECK-NOT: panic_bounds_check
+    // FIXME: panic check can be removed by adding the assumes back after https://github.com/rust-lang/rust/pull/98332
+    // CHECK: panic_bounds_check
     array[(exc as u8 - 4) as usize]
 }

--- a/src/test/codegen/enum-bounds-check-issue-82871.rs
+++ b/src/test/codegen/enum-bounds-check-issue-82871.rs
@@ -1,4 +1,4 @@
-// compile-flags: -O
+// compile-flags: -C opt-level=0
 
 #![crate_type = "lib"]
 
@@ -9,7 +9,10 @@ pub enum E {
 
 // CHECK-LABEL: @index
 #[no_mangle]
-pub fn index(x: &[u32; 3], ind: E) -> u32{
-    // CHECK-NOT: panic_bounds_check
+pub fn index(x: &[u32; 3], ind: E) -> u32 {
+    // Canary: we should be able to optimize out the bounds check, but we need
+    // to track the range of the discriminant result in order to be able to do that.
+    // oli-obk tried to add that, but that caused miscompilations all over the place.
+    // CHECK: panic_bounds_check
     x[ind as usize]
 }

--- a/src/test/codegen/enum-bounds-check.rs
+++ b/src/test/codegen/enum-bounds-check.rs
@@ -21,6 +21,7 @@ pub enum Bar {
 // CHECK-LABEL: @lookup_unmodified
 #[no_mangle]
 pub fn lookup_unmodified(buf: &[u8; 5], f: Bar) -> u8 {
-    // CHECK-NOT: panic_bounds_check
+    // FIXME: panic check can be removed by adding the assumes back after https://github.com/rust-lang/rust/pull/98332
+    // CHECK: panic_bounds_check
     buf[f as usize]
 }

--- a/src/test/mir-opt/enum_cast.bar.mir_map.0.mir
+++ b/src/test/mir-opt/enum_cast.bar.mir_map.0.mir
@@ -1,0 +1,13 @@
+// MIR for `bar` 0 mir_map
+
+fn bar(_1: Bar) -> usize {
+    debug bar => _1;                     // in scope 0 at $DIR/enum_cast.rs:22:8: 22:11
+    let mut _0: usize;                   // return place in scope 0 at $DIR/enum_cast.rs:22:21: 22:26
+    let mut _2: isize;                   // in scope 0 at $DIR/enum_cast.rs:23:5: 23:8
+
+    bb0: {
+        _2 = discriminant(_1);           // scope 0 at $DIR/enum_cast.rs:23:5: 23:17
+        _0 = move _2 as usize (Misc);    // scope 0 at $DIR/enum_cast.rs:23:5: 23:17
+        return;                          // scope 0 at $DIR/enum_cast.rs:24:2: 24:2
+    }
+}

--- a/src/test/mir-opt/enum_cast.boo.mir_map.0.mir
+++ b/src/test/mir-opt/enum_cast.boo.mir_map.0.mir
@@ -1,0 +1,13 @@
+// MIR for `boo` 0 mir_map
+
+fn boo(_1: Boo) -> usize {
+    debug boo => _1;                     // in scope 0 at $DIR/enum_cast.rs:26:8: 26:11
+    let mut _0: usize;                   // return place in scope 0 at $DIR/enum_cast.rs:26:21: 26:26
+    let mut _2: u8;                      // in scope 0 at $DIR/enum_cast.rs:27:5: 27:8
+
+    bb0: {
+        _2 = discriminant(_1);           // scope 0 at $DIR/enum_cast.rs:27:5: 27:17
+        _0 = move _2 as usize (Misc);    // scope 0 at $DIR/enum_cast.rs:27:5: 27:17
+        return;                          // scope 0 at $DIR/enum_cast.rs:28:2: 28:2
+    }
+}

--- a/src/test/mir-opt/enum_cast.droppy.mir_map.0.mir
+++ b/src/test/mir-opt/enum_cast.droppy.mir_map.0.mir
@@ -1,0 +1,54 @@
+// MIR for `droppy` 0 mir_map
+
+fn droppy() -> () {
+    let mut _0: ();                      // return place in scope 0 at $DIR/enum_cast.rs:39:13: 39:13
+    let _1: ();                          // in scope 0 at $DIR/enum_cast.rs:40:5: 45:6
+    let _2: Droppy;                      // in scope 0 at $DIR/enum_cast.rs:41:13: 41:14
+    let mut _4: isize;                   // in scope 0 at $DIR/enum_cast.rs:44:17: 44:18
+    let _5: Droppy;                      // in scope 0 at $DIR/enum_cast.rs:46:9: 46:10
+    scope 1 {
+        debug x => _2;                   // in scope 1 at $DIR/enum_cast.rs:41:13: 41:14
+        scope 2 {
+            debug y => _3;               // in scope 2 at $DIR/enum_cast.rs:44:13: 44:14
+        }
+        scope 3 {
+            let _3: usize;               // in scope 3 at $DIR/enum_cast.rs:44:13: 44:14
+        }
+    }
+    scope 4 {
+        debug z => _5;                   // in scope 4 at $DIR/enum_cast.rs:46:9: 46:10
+    }
+
+    bb0: {
+        StorageLive(_1);                 // scope 0 at $DIR/enum_cast.rs:40:5: 45:6
+        StorageLive(_2);                 // scope 0 at $DIR/enum_cast.rs:41:13: 41:14
+        _2 = Droppy::C;                  // scope 0 at $DIR/enum_cast.rs:41:17: 41:26
+        FakeRead(ForLet(None), _2);      // scope 0 at $DIR/enum_cast.rs:41:13: 41:14
+        StorageLive(_3);                 // scope 3 at $DIR/enum_cast.rs:44:13: 44:14
+        _4 = discriminant(_2);           // scope 3 at $DIR/enum_cast.rs:44:17: 44:27
+        _3 = move _4 as usize (Misc);    // scope 3 at $DIR/enum_cast.rs:44:17: 44:27
+        FakeRead(ForLet(None), _3);      // scope 3 at $DIR/enum_cast.rs:44:13: 44:14
+        _1 = const ();                   // scope 0 at $DIR/enum_cast.rs:40:5: 45:6
+        StorageDead(_3);                 // scope 1 at $DIR/enum_cast.rs:45:5: 45:6
+        drop(_2) -> [return: bb1, unwind: bb3]; // scope 0 at $DIR/enum_cast.rs:45:5: 45:6
+    }
+
+    bb1: {
+        StorageDead(_2);                 // scope 0 at $DIR/enum_cast.rs:45:5: 45:6
+        StorageDead(_1);                 // scope 0 at $DIR/enum_cast.rs:45:5: 45:6
+        StorageLive(_5);                 // scope 0 at $DIR/enum_cast.rs:46:9: 46:10
+        _5 = Droppy::B;                  // scope 0 at $DIR/enum_cast.rs:46:13: 46:22
+        FakeRead(ForLet(None), _5);      // scope 0 at $DIR/enum_cast.rs:46:9: 46:10
+        _0 = const ();                   // scope 0 at $DIR/enum_cast.rs:39:13: 47:2
+        drop(_5) -> [return: bb2, unwind: bb3]; // scope 0 at $DIR/enum_cast.rs:47:1: 47:2
+    }
+
+    bb2: {
+        StorageDead(_5);                 // scope 0 at $DIR/enum_cast.rs:47:1: 47:2
+        return;                          // scope 0 at $DIR/enum_cast.rs:47:2: 47:2
+    }
+
+    bb3 (cleanup): {
+        resume;                          // scope 0 at $DIR/enum_cast.rs:39:1: 47:2
+    }
+}

--- a/src/test/mir-opt/enum_cast.foo.mir_map.0.mir
+++ b/src/test/mir-opt/enum_cast.foo.mir_map.0.mir
@@ -1,0 +1,13 @@
+// MIR for `foo` 0 mir_map
+
+fn foo(_1: Foo) -> usize {
+    debug foo => _1;                     // in scope 0 at $DIR/enum_cast.rs:18:8: 18:11
+    let mut _0: usize;                   // return place in scope 0 at $DIR/enum_cast.rs:18:21: 18:26
+    let mut _2: isize;                   // in scope 0 at $DIR/enum_cast.rs:19:5: 19:8
+
+    bb0: {
+        _2 = discriminant(_1);           // scope 0 at $DIR/enum_cast.rs:19:5: 19:17
+        _0 = move _2 as usize (Misc);    // scope 0 at $DIR/enum_cast.rs:19:5: 19:17
+        return;                          // scope 0 at $DIR/enum_cast.rs:20:2: 20:2
+    }
+}

--- a/src/test/mir-opt/enum_cast.rs
+++ b/src/test/mir-opt/enum_cast.rs
@@ -1,0 +1,50 @@
+// EMIT_MIR enum_cast.foo.mir_map.0.mir
+// EMIT_MIR enum_cast.bar.mir_map.0.mir
+// EMIT_MIR enum_cast.boo.mir_map.0.mir
+
+enum Foo {
+    A
+}
+
+enum Bar {
+    A, B
+}
+
+#[repr(u8)]
+enum Boo {
+    A, B
+}
+
+fn foo(foo: Foo) -> usize {
+    foo as usize
+}
+
+fn bar(bar: Bar) -> usize {
+    bar as usize
+}
+
+fn boo(boo: Boo) -> usize {
+    boo as usize
+}
+
+// EMIT_MIR enum_cast.droppy.mir_map.0.mir
+enum Droppy {
+    A, B, C
+}
+
+impl Drop for Droppy {
+    fn drop(&mut self) {}
+}
+
+fn droppy() {
+    {
+        let x = Droppy::C;
+        // remove this entire test once `cenum_impl_drop_cast` becomes a hard error
+        #[allow(cenum_impl_drop_cast)]
+        let y = x as usize;
+    }
+    let z = Droppy::B;
+}
+
+fn main() {
+}

--- a/src/test/run-pass-valgrind/cast-enum-with-dtor.rs
+++ b/src/test/run-pass-valgrind/cast-enum-with-dtor.rs
@@ -30,5 +30,5 @@ fn main() {
         assert_eq!(e as u32, 2);
         assert_eq!(FLAG.load(Ordering::SeqCst), 0);
     }
-    assert_eq!(FLAG.load(Ordering::SeqCst), 0);
+    assert_eq!(FLAG.load(Ordering::SeqCst), 1);
 }


### PR DESCRIPTION
follow-up to https://github.com/rust-lang/rust/pull/96814

this simplifies all backends and even gives LLVM more information about the return value of `Rvalue::Discriminant`, enabling optimizations in more cases.