### PR TITLE
Create Item::full_name method to include name of reexports

### DIFF
--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -404,6 +404,16 @@ pub(crate) fn rustc_span(def_id: DefId, tcx: TyCtxt<'_>) -> Span {
 }
 
 impl Item {
+    /// If `item.name` is `None` and `self` is an `ImportItem`, it'll look for it.
+    ///
+    /// It's especially usefully to get the name of `pub use x;` or `pub use x as y;`.
+    pub(crate) fn full_name(&self) -> Option<Symbol> {
+        self.name.or_else(|| {
+            if let ImportItem(ref i) = *self.kind &&
+            let ImportKind::Simple(s) = i.kind { Some(s) } else { None }
+        })
+    }
+
     pub(crate) fn stability<'tcx>(&self, tcx: TyCtxt<'tcx>) -> Option<Stability> {
         self.item_id.as_def_id().and_then(|did| tcx.lookup_stability(did))
     }

--- a/src/librustdoc/formats/cache.rs
+++ b/src/librustdoc/formats/cache.rs
@@ -248,16 +248,7 @@ impl<'a, 'tcx> DocFolder for CacheBuilder<'a, 'tcx> {
         }
 
         // Index this method for searching later on.
-        if let Some(ref s) = item.name.or_else(|| {
-            if item.is_stripped() {
-                None
-            } else if let clean::ImportItem(ref i) = *item.kind &&
-                let clean::ImportKind::Simple(s) = i.kind {
-                Some(s)
-            } else {
-                None
-            }
-        }) {
+        if let Some(ref s) = item.full_name() && !item.is_stripped() {
             let (parent, is_inherent_impl_item) = match *item.kind {
                 clean::StrippedItem(..) => ((None, None), false),
                 clean::AssocConstItem(..) | clean::AssocTypeItem(..)

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -2542,16 +2542,7 @@ fn sidebar_module(buf: &mut Buffer, items: &[clean::Item]) {
 
     let item_sections_in_use: FxHashSet<_> = items
         .iter()
-        .filter(|it| {
-            !it.is_stripped()
-                && it
-                    .name
-                    .or_else(|| {
-                        if let clean::ImportItem(ref i) = *it.kind &&
-                            let clean::ImportKind::Simple(s) = i.kind { Some(s) } else { None }
-                    })
-                    .is_some()
-        })
+        .filter(|it| !it.is_stripped() && it.full_name().is_some())
         .map(|it| item_ty_to_section(it.type_()))
         .collect();
     for &sec in ItemSection::ALL.iter().filter(|sec| item_sections_in_use.contains(sec)) {


### PR DESCRIPTION
I originally wanted to make `Item::name` field private and implement `full_name` as `name` replacement directly. Not sure if it's a good idea though. What do you think?

cc @camelid 
r? @notriddle 