### PR TITLE
 Implement unstable `-Clink-self-contained` values for MCP 510

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -1534,7 +1534,7 @@ fn detect_self_contained_mingw(sess: &Session) -> bool {
 /// Whether we link to our own CRT objects instead of relying on gcc to pull them.
 /// We only provide such support for a very limited number of targets.
 fn crt_objects_fallback(sess: &Session, crate_type: CrateType) -> bool {
-    if let Some(self_contained) = sess.opts.cg.link_self_contained {
+    if let Some(self_contained) = sess.opts.cg.link_self_contained.crt.is_explicitly_set() {
         return self_contained;
     }
 

--- a/compiler/rustc_interface/src/tests.rs
+++ b/compiler/rustc_interface/src/tests.rs
@@ -3,6 +3,7 @@ use crate::interface::parse_cfgspecs;
 use rustc_data_structures::fx::FxHashSet;
 use rustc_errors::{emitter::HumanReadableErrorType, registry, ColorConfig};
 use rustc_session::config::InstrumentCoverage;
+use rustc_session::config::LinkSelfContained;
 use rustc_session::config::Strip;
 use rustc_session::config::{build_configuration, build_session_options, to_crate_config};
 use rustc_session::config::{
@@ -549,7 +550,7 @@ fn test_codegen_options_tracking_hash() {
     untracked!(incremental, Some(String::from("abc")));
     // `link_arg` is omitted because it just forwards to `link_args`.
     untracked!(link_args, vec![String::from("abc"), String::from("def")]);
-    untracked!(link_self_contained, Some(true));
+    untracked!(link_self_contained, LinkSelfContained::on());
     untracked!(linker, Some(PathBuf::from("linker")));
     untracked!(linker_flavor, Some(LinkerFlavor::Gcc));
     untracked!(no_stack_check, true);

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -2543,6 +2543,26 @@ pub fn build_session_options(matches: &getopts::Matches) -> Options {
         );
     }
 
+    // For testing purposes, until we have more feedback about these options: ensure `-Z
+    // unstable-options` is enabled when using the unstable `-C link-self-contained` options.
+    if !debugging_opts.unstable_options {
+        let uses_unstable_self_contained_option =
+            matches.opt_strs("C").iter().any(|option| match option.as_str() {
+                "link-self-contained=crt"
+                | "link-self-contained=auto"
+                | "link-self-contained=linker"
+                | "link-self-contained=all" => true,
+                _ => false,
+            });
+        if uses_unstable_self_contained_option {
+            early_error(
+                error_format,
+                "only `-C link-self-contained` values `y`/`yes`/`on`/`n`/`no`/`off` are stable, \
+                the `-Z unstable-options` flag must also be passed to use the unstable values",
+            );
+        }
+    }
+
     let prints = collect_print_requests(&mut cg, &mut debugging_opts, matches, error_format);
 
     let cg = cg;

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -230,7 +230,7 @@ impl LinkSelfContained {
     }
 
     /// Keeps stable behavior only turning the self-contained CRT linking on.
-    fn on() -> Self {
+    pub fn on() -> Self {
         LinkSelfContained::crt_only()
     }
 

--- a/compiler/rustc_session/src/lib.rs
+++ b/compiler/rustc_session/src/lib.rs
@@ -33,6 +33,9 @@ pub mod output;
 
 pub use getopts;
 
+#[cfg(test)]
+mod tests;
+
 /// Requirements for a `StableHashingContext` to be used in this crate.
 /// This is a hack to allow using the `HashStable_Generic` derive macro
 /// instead of implementing everything in `rustc_middle`.

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -414,6 +414,8 @@ mod desc {
     pub const parse_split_dwarf_kind: &str =
         "one of supported split dwarf modes (`split` or `single`)";
     pub const parse_gcc_ld: &str = "one of: no value, `lld`";
+    // FIXME: add link to reference or other documentation, where the `-Clink-self-contained`
+    // options will be explained in more detail.
     pub const parse_link_self_contained: &str =
         "one of: `y`, `yes`, `on`, `n`, `no`, `off`, `auto`, `crt`, `linker`, `all`";
     pub const parse_stack_protector: &str =

--- a/compiler/rustc_session/src/tests.rs
+++ b/compiler/rustc_session/src/tests.rs
@@ -1,0 +1,71 @@
+use std::str::FromStr;
+
+use crate::config::{LinkSelfContained, LinkSelfContainedCrt, LinkSelfContainedLinker};
+
+/// When adding support for `-C link-self-contained=linker`, we want to ensure the existing
+/// values are still supported as-is: they are option values that can be used on stable.
+#[test]
+pub fn parse_stable_self_contained() {
+    // The existing default is when the argument is not used, the behavior depends on the
+    // target.
+    assert_eq!(
+        LinkSelfContained::default(),
+        LinkSelfContained { crt: LinkSelfContainedCrt::Auto, linker: LinkSelfContainedLinker::Off }
+    );
+
+    // Turning the flag `on` should currently only enable the default on stable.
+    assert_eq!(
+        LinkSelfContained::from_str("on"),
+        Ok(LinkSelfContained {
+            crt: LinkSelfContainedCrt::On,
+            linker: LinkSelfContainedLinker::Off
+        })
+    );
+
+    // Turning the flag `off` applies to both facets.
+    assert_eq!(
+        LinkSelfContained::from_str("off"),
+        Ok(LinkSelfContained {
+            crt: LinkSelfContainedCrt::Off,
+            linker: LinkSelfContainedLinker::Off
+        })
+    );
+
+    assert_eq!(
+        LinkSelfContained::from_str("crt"),
+        Ok(LinkSelfContained {
+            crt: LinkSelfContainedCrt::On,
+            linker: LinkSelfContainedLinker::Off
+        })
+    );
+}
+
+#[test]
+pub fn parse_self_contained_with_linker() {
+    // Turning the linker on doesn't change the CRT behavior
+    assert_eq!(
+        LinkSelfContained::from_str("linker"),
+        Ok(LinkSelfContained {
+            crt: LinkSelfContainedCrt::Auto,
+            linker: LinkSelfContainedLinker::On
+        })
+    );
+
+    assert_eq!(
+        LinkSelfContained::from_str("all"),
+        Ok(LinkSelfContained {
+            crt: LinkSelfContainedCrt::On,
+            linker: LinkSelfContainedLinker::On
+        })
+    );
+
+    // If `linker` is turned on by default someday, we need to be able to go back to the current
+    // default.
+    assert_eq!(
+        LinkSelfContained::from_str("auto"),
+        Ok(LinkSelfContained {
+            crt: LinkSelfContainedCrt::Auto,
+            linker: LinkSelfContainedLinker::Off
+        })
+    );
+}

--- a/src/test/ui/linkers/unstable_link_self_contained.all.stderr
+++ b/src/test/ui/linkers/unstable_link_self_contained.all.stderr
@@ -1,0 +1,2 @@
+error: only `-C link-self-contained` values `y`/`yes`/`on`/`n`/`no`/`off` are stable, the `-Z unstable-options` flag must also be passed to use the unstable values
+

--- a/src/test/ui/linkers/unstable_link_self_contained.auto.stderr
+++ b/src/test/ui/linkers/unstable_link_self_contained.auto.stderr
@@ -1,0 +1,2 @@
+error: only `-C link-self-contained` values `y`/`yes`/`on`/`n`/`no`/`off` are stable, the `-Z unstable-options` flag must also be passed to use the unstable values
+

--- a/src/test/ui/linkers/unstable_link_self_contained.crt.stderr
+++ b/src/test/ui/linkers/unstable_link_self_contained.crt.stderr
@@ -1,0 +1,2 @@
+error: only `-C link-self-contained` values `y`/`yes`/`on`/`n`/`no`/`off` are stable, the `-Z unstable-options` flag must also be passed to use the unstable values
+

--- a/src/test/ui/linkers/unstable_link_self_contained.linker.stderr
+++ b/src/test/ui/linkers/unstable_link_self_contained.linker.stderr
@@ -1,0 +1,2 @@
+error: only `-C link-self-contained` values `y`/`yes`/`on`/`n`/`no`/`off` are stable, the `-Z unstable-options` flag must also be passed to use the unstable values
+

--- a/src/test/ui/linkers/unstable_link_self_contained.rs
+++ b/src/test/ui/linkers/unstable_link_self_contained.rs
@@ -1,0 +1,11 @@
+// check-fail
+// revisions: crt auto linker all
+// [crt] compile-flags: -C link-self-contained=crt
+// [auto] compile-flags: -C link-self-contained=auto
+// [linker] compile-flags: -C link-self-contained=linker
+// [all] compile-flags: -C link-self-contained=all
+
+// Test ensuring that the unstable values of the stable `-C link-self-contained` flag
+// require using `-Z unstable options`
+
+fn main() {}


### PR DESCRIPTION
This PR is extracted from #96401 for easier review.

It implements half of [MCP #510](https://github.com/rust-lang/compiler-team/issues/510) as a prerequisite for supporting `rust-lld` via a command similar to `-Clinker-flavor=gcc:lld -Clink-self-contained=linker`: adding new unstable values to the `-Clink-self-contained` to independently control:
- the CRT object linking, and
- using the rustup-distributed linker

r? @petrochenkov

I know you plan on switching this to a `+/-` list: I didn't do this yet so this PR still represents the rough interface that was described in the zulip thread for opting in and out of both facets. And so still has temporary work, until we finalize the interface we want, and I'll make the changes you'd like to see in this PR.