### PR TITLE
rustdoc: correct path to type alias methods

### DIFF
--- a/src/librustdoc/formats/cache.rs
+++ b/src/librustdoc/formats/cache.rs
@@ -293,7 +293,8 @@ impl<'a, 'tcx> DocFolder for CacheBuilder<'a, 'tcx> {
                                 ItemType::Trait
                                 | ItemType::Struct
                                 | ItemType::Union
-                                | ItemType::Enum,
+                                | ItemType::Enum
+                                | ItemType::Typedef,
                             )) => Some(&fqp[..fqp.len() - 1]),
                             Some(..) => Some(&*self.cache.stack),
                             None => None,

--- a/src/librustdoc/formats/cache.rs
+++ b/src/librustdoc/formats/cache.rs
@@ -288,15 +288,7 @@ impl<'a, 'tcx> DocFolder for CacheBuilder<'a, 'tcx> {
                             // for where the type was defined. On the other
                             // hand, `paths` always has the right
                             // information if present.
-                            Some(&(
-                                ref fqp,
-                                ItemType::Trait
-                                | ItemType::Struct
-                                | ItemType::Union
-                                | ItemType::Enum
-                                | ItemType::Typedef,
-                            )) => Some(&fqp[..fqp.len() - 1]),
-                            Some(..) => Some(&*self.cache.stack),
+                            Some(&(ref fqp, _)) => Some(&fqp[..fqp.len() - 1]),
                             None => None,
                         };
                         ((Some(*last), path), true)

--- a/src/test/rustdoc-js-std/asrawfd.js
+++ b/src/test/rustdoc-js-std/asrawfd.js
@@ -1,0 +1,14 @@
+// exact-match
+
+const QUERY = 'RawFd::as_raw_fd';
+
+const EXPECTED = {
+    'others': [
+        // Reproduction test for https://github.com/rust-lang/rust/issues/78724
+        // Validate that type alias methods get the correct path.
+        { 'path': 'std::os::unix::io::AsRawFd', 'name': 'as_raw_fd' },
+        { 'path': 'std::os::wasi::io::AsRawFd', 'name': 'as_raw_fd' },
+        { 'path': 'std::os::linux::process::PidFd', 'name': 'as_raw_fd' },
+        { 'path': 'std::os::unix::io::RawFd', 'name': 'as_raw_fd' },
+    ],
+};

--- a/src/test/rustdoc-js-std/asrawfd.js
+++ b/src/test/rustdoc-js-std/asrawfd.js
@@ -1,4 +1,4 @@
-// exact-match
+// ignore-order
 
 const QUERY = 'RawFd::as_raw_fd';
 

--- a/src/test/rustdoc-js/foreign-type-path.js
+++ b/src/test/rustdoc-js/foreign-type-path.js
@@ -1,0 +1,9 @@
+const QUERY = 'MyForeignType::my_method';
+
+const EXPECTED = {
+    'others': [
+        // Test case for https://github.com/rust-lang/rust/pull/96887#pullrequestreview-967154358
+        // Validates that the parent path for a foreign type method is correct.
+        { 'path': 'foreign_type_path::aaaaaaa::MyForeignType', 'name': 'my_method' },
+    ],
+};

--- a/src/test/rustdoc-js/foreign-type-path.rs
+++ b/src/test/rustdoc-js/foreign-type-path.rs
@@ -1,0 +1,13 @@
+#![feature(extern_types)]
+
+pub mod aaaaaaa {
+
+    extern {
+        pub type MyForeignType;
+    }
+
+    impl MyForeignType {
+        pub fn my_method() {}
+    }
+
+}


### PR DESCRIPTION
Fixes #83991