### PR TITLE
[DO NOT MERGE] Perf run for zoxc's rustc-hash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -538,7 +538,7 @@ dependencies = [
  "chalk-derive",
  "chalk-ir",
  "chalk-solve",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "tracing",
 ]
 
@@ -565,7 +565,7 @@ dependencies = [
  "indexmap",
  "itertools",
  "petgraph",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "tracing",
  "tracing-subscriber",
  "tracing-tree",
@@ -1293,7 +1293,7 @@ dependencies = [
  "fluent-syntax",
  "intl-memoizer",
  "intl_pluralrules",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "self_cell",
  "smallvec",
  "unic-langid",
@@ -2321,7 +2321,7 @@ dependencies = [
  "memmap2",
  "parking_lot",
  "perf-event-open-sys",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "smallvec",
 ]
 
@@ -2335,7 +2335,7 @@ dependencies = [
  "memmap2",
  "parking_lot",
  "perf-event-open-sys",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "smallvec",
 ]
 
@@ -2845,7 +2845,7 @@ checksum = "c4e8e505342045d397d0b6674dcb82d6faf5cf40484d30eeb88fc82ef14e903f"
 dependencies = [
  "datafrog",
  "log",
- "rustc-hash",
+ "rustc-hash 1.1.0",
 ]
 
 [[package]]
@@ -3353,6 +3353,11 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
+version = "1.0.1"
+source = "git+https://github.com/Zoxc/rustc-hash/?branch=new-hash#a5a1e17e92967bb98ff8513d25a9bc07bf12caca"
+
+[[package]]
+name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
@@ -3683,7 +3688,7 @@ dependencies = [
  "measureme 10.0.0",
  "memmap2",
  "parking_lot",
- "rustc-hash",
+ "rustc-hash 1.0.1",
  "rustc-rayon",
  "rustc-rayon-core",
  "rustc_graphviz",
@@ -5439,7 +5444,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d3364c5e96cb2ad1603037ab253ddd34d7fb72a58bdddf4b7350760fc69a46"
 dependencies = [
- "rustc-hash",
+ "rustc-hash 1.1.0",
 ]
 
 [[package]]

--- a/compiler/rustc_data_structures/Cargo.toml
+++ b/compiler/rustc_data_structures/Cargo.toml
@@ -19,7 +19,7 @@ cfg-if = "0.1.2"
 stable_deref_trait = "1.0.0"
 rayon = { version = "0.3.2", package = "rustc-rayon", optional = true }
 rayon-core = { version = "0.3.2", package = "rustc-rayon-core", optional = true }
-rustc-hash = "1.1.0"
+rustc-hash = { git = "https://github.com/Zoxc/rustc-hash/", branch = "new-hash" }
 smallvec = { version = "1.6.1", features = ["const_generics", "union", "may_dangle"] }
 rustc_index = { path = "../rustc_index", package = "rustc_index" }
 bitflags = "1.2.1"

--- a/src/tools/tidy/src/extdeps.rs
+++ b/src/tools/tidy/src/extdeps.rs
@@ -8,7 +8,7 @@ const ALLOWED_SOURCES: &[&str] = &["\"registry+https://github.com/rust-lang/crat
 
 /// Checks for external package sources. `root` is the path to the directory that contains the
 /// workspace `Cargo.toml`.
-pub fn check(root: &Path, bad: &mut bool) {
+pub fn check(root: &Path, _bad: &mut bool) {
     // `Cargo.lock` of rust.
     let path = root.join("Cargo.lock");
 
@@ -27,7 +27,7 @@ pub fn check(root: &Path, bad: &mut bool) {
 
         // Ensure source is allowed.
         if !ALLOWED_SOURCES.contains(&&*source) {
-            tidy_error!(bad, "invalid source: {}", source);
+            // tidy_error!(bad, "invalid source: {}", source);
         }
     }
 }


### PR DESCRIPTION
This is another perf run to try and see the results of zoxc's version of the 64b fxhash, from their [rustc-hash PR](https://github.com/rust-lang/rustc-hash/pull/18).

This was previously tried in https://github.com/rust-lang/rust/pull/93651 on the older benchmarks, and we now want to see the results on the recently updated `rustc-perf` benchmarks.

r? @ghost