### PR TITLE
logging: add env var to control verbose scope entry/exit logging

### DIFF
--- a/compiler/rustc_log/src/lib.rs
+++ b/compiler/rustc_log/src/lib.rs
@@ -67,11 +67,24 @@ pub fn init_env_logger(env: &str) -> Result<(), Error> {
         Err(VarError::NotUnicode(_value)) => return Err(Error::NonUnicodeColorValue),
     };
 
+    let verbose_entry_exit = match env::var_os(String::from(env) + "_ENTRY_EXIT") {
+        None => false,
+        Some(v) => {
+            if &v == "0" {
+                false
+            } else {
+                true
+            }
+        }
+    };
+
     let layer = tracing_tree::HierarchicalLayer::default()
         .with_writer(io::stderr)
         .with_indent_lines(true)
         .with_ansi(color_logs)
         .with_targets(true)
+        .with_verbose_exit(verbose_entry_exit)
+        .with_verbose_entry(verbose_entry_exit)
         .with_indent_amount(2);
     #[cfg(parallel_compiler)]
     let layer = layer.with_thread_ids(true).with_thread_names(true);


### PR DESCRIPTION
~~This got removed in https://github.com/rust-lang/rust/pull/75143, and I find this makes long traces a lot harder to read, so I propose we add this back.~~

Example trace:
```
│ │ ├─0ms  INFO rustc_const_eval::interpret::step return
│ │ ├─0ms  INFO rustc_const_eval::interpret::eval_context popping stack frame (returning from function)
│ │┌┘rustc_const_eval::interpret::eval_context::frame std::ptr::mut_ptr::<impl *mut u8>::guaranteed_eq
│ ├┘rustc_const_eval::interpret::eval_context::frame std::ptr::mut_ptr::<impl *mut u8>::is_null
│ ├─1ms  INFO rustc_const_eval::interpret::step // executing bb2
│ ├─1ms  INFO rustc_const_eval::interpret::step StorageDead(_4)
│ ├─1ms  INFO rustc_const_eval::interpret::step StorageDead(_2)
│ ├─1ms  INFO rustc_const_eval::interpret::step return
│ ├─1ms  INFO rustc_const_eval::interpret::eval_context popping stack frame (returning from function)
│┌┘rustc_const_eval::interpret::eval_context::frame std::ptr::mut_ptr::<impl *mut u8>::is_null
├┘rustc_const_eval::interpret::eval_context::frame std::sys_common::thread_local_dtor::register_dtor_fallback::run_dtors
├─178ms  INFO rustc_const_eval::interpret::step // executing bb2
├─178ms  INFO rustc_const_eval::interpret::step StorageDead(_5)

```

r? @oli-obk 