### PR TITLE
Fix js error

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -331,7 +331,6 @@ li {
 nav.sub {
 	position: relative;
 	font-size: 1rem;
-	text-transform: uppercase;
 }
 
 .sub-container {

--- a/src/librustdoc/html/static/js/source-script.js
+++ b/src/librustdoc/html/static/js/source-script.js
@@ -1,5 +1,5 @@
 // From rust:
-/* global search, sourcesIndex */
+/* global sourcesIndex */
 
 // Local js definitions:
 /* global addClass, getCurrentValue, hasClass, onEachLazy, removeClass, browserSupportsHistoryApi */
@@ -69,7 +69,6 @@ function createDirEntry(elem, parent, fullPath, currentFile, hasFoundFile) {
             files.appendChild(file);
         }
     }
-    search.fullPath = fullPath;
     children.appendChild(files);
     parent.appendChild(name);
     parent.appendChild(children);

--- a/src/test/rustdoc-gui/sidebar-source-code-display.goml
+++ b/src/test/rustdoc-gui/sidebar-source-code-display.goml
@@ -15,6 +15,5 @@ assert-css: ("#sidebar-toggle", {"visibility": "visible", "opacity": 1})
 assert-css: (".sidebar > *:not(#sidebar-toggle)", {"visibility": "hidden", "opacity": 0})
 // Let's expand the sidebar now.
 click: "#sidebar-toggle"
-// Because of the transition CSS, better wait a second before checking.
+// Because of the transition CSS, we check by using `wait-for-css` instead of `assert-css`.
 wait-for-css: ("#sidebar-toggle", {"visibility": "visible", "opacity": 1})
-assert-css: (".sidebar > *:not(#sidebar-toggle)", {"visibility": "visible", "opacity": 1})


### PR DESCRIPTION
On the source code pages, we get a JS error:

![Screenshot from 2022-05-10 16-26-53](https://user-images.githubusercontent.com/3050060/167656292-51e0b0e9-6b0c-4f94-82e0-dd8fb77adf52.png)

It's fixed in the first commit. The second one is removing an unused CSS rule and the third one is a little cleanup of a GUI test.

cc @jsha 
r? @notriddle 