### PR TITLE
Use lifetimes on type-alias-impl-trait used in function signatures to infer output type lifetimes

### DIFF
--- a/compiler/rustc_middle/src/ty/fold.rs
+++ b/compiler/rustc_middle/src/ty/fold.rs
@@ -1349,7 +1349,7 @@ impl<'tcx> TypeVisitor<'tcx> for LateBoundRegionsCollector {
         // ignore the inputs to a projection, as they may not appear
         // in the normalized form
         if self.just_constrained {
-            if let ty::Projection(..) | ty::Opaque(..) = t.kind() {
+            if let ty::Projection(..) = t.kind() {
                 return ControlFlow::CONTINUE;
             }
         }

--- a/src/test/ui/type-alias-impl-trait/constrain_inputs.rs
+++ b/src/test/ui/type-alias-impl-trait/constrain_inputs.rs
@@ -1,0 +1,17 @@
+// check-pass
+
+#![feature(type_alias_impl_trait)]
+
+mod foo {
+    type Ty<'a> = impl Sized;
+    fn defining(s: &str) -> Ty<'_> { s }
+    fn execute(ty: Ty<'_>) -> &str { todo!() }
+}
+
+mod bar {
+    type Ty<'a> = impl FnOnce() -> &'a str;
+    fn defining(s: &str) -> Ty<'_> { move || s }
+    fn execute(ty: Ty<'_>) -> &str { ty() }
+}
+
+fn main() {}


### PR DESCRIPTION
fixes https://github.com/rust-lang/rust/issues/96564

TLDR:

```rust
fn execute(ty: Ty<'_>) -> &str { todo!() }
```

(`Ty` being a type alias impl trait) used to produce the following error before this PR

```
error[E0581]: return type references an anonymous lifetime, which is not constrained by the fn input types
 --> src/lib.rs:4:27
  |
4 | fn execute(ty: Ty<'_>) -> &str { todo!() }
  |                           ^^^^
  |
  = note: lifetimes appearing in an associated type are not considered constrained
```