### PR TITLE
Print type of every call in a method call chain

### DIFF
--- a/src/test/ui/issues/issue-31173.stderr
+++ b/src/test/ui/issues/issue-31173.stderr
@@ -1,6 +1,9 @@
 error[E0271]: type mismatch resolving `<TakeWhile<&mut std::vec::IntoIter<u8>, [closure@$DIR/issue-31173.rs:6:39: 9:6]> as Iterator>::Item == &_`
   --> $DIR/issue-31173.rs:10:10
    |
+LL |     let temp: Vec<u8> = it.take_while(|&x| {
+   |                            ---------- this call is of type `TakeWhile<&mut std::vec::IntoIter<u8>, _>`
+...
 LL |         .cloned()
    |          ^^^^^^ expected reference, found `u8`
    |

--- a/src/test/ui/issues/issue-33941.stderr
+++ b/src/test/ui/issues/issue-33941.stderr
@@ -2,7 +2,10 @@ error[E0271]: type mismatch resolving `<std::collections::hash_map::Iter<'_, _, 
   --> $DIR/issue-33941.rs:6:36
    |
 LL |     for _ in HashMap::new().iter().cloned() {}
-   |                                    ^^^^^^ expected reference, found tuple
+   |              ------------   ----   ^^^^^^ expected reference, found tuple
+   |              |              |
+   |              |              this call is of type `std::collections::hash_map::Iter<'_, _, _>`
+   |              this call is of type `&HashMap<_, _>`
    |
    = note: expected reference `&_`
                   found tuple `(&_, &_)`


### PR DESCRIPTION
```
error[E0271]: type mismatch resolving `<std::collections::hash_map::Iter<'_, _, _> as Iterator>::Item == &_`
  --> $DIR/issue-33941.rs:6:36
   |
LL |     for _ in HashMap::new().iter().cloned() {}
   |              ------------   ----   ^^^^^^ expected reference, found tuple
   |              |              |
   |              |              this call is of type `std::collections::hash_map::Iter<'_, _, _>`
   |              this call is of type `&HashMap<_, _>`
   |
   = note: expected reference `&_`
                  found tuple `(&_, &_)`
note: required by a bound in `cloned`
  --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
   |
LL |         Self: Sized + Iterator<Item = &'a T>,
   |                                ^^^^^^^^^^^^ required by this bound in `cloned`
```

Partially address #33941.