### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/compiler/rustc_middle/src/ty/fold.rs
+++ b/compiler/rustc_middle/src/ty/fold.rs
@@ -1349,7 +1349,7 @@ impl<'tcx> TypeVisitor<'tcx> for LateBoundRegionsCollector {
         // ignore the inputs to a projection, as they may not appear
         // in the normalized form
         if self.just_constrained {
-            if let ty::Projection(..) | ty::Opaque(..) = t.kind() {
+            if let ty::Projection(..) = t.kind() {
                 return ControlFlow::CONTINUE;
             }
         }

--- a/compiler/rustc_mir_transform/src/coverage/spans.rs
+++ b/compiler/rustc_mir_transform/src/coverage/spans.rs
@@ -485,7 +485,7 @@ impl<'a, 'tcx> CoverageSpans<'a, 'tcx> {
             }) {
                 let merged_prefix_len = self.curr_original_span.lo() - self.curr().span.lo();
                 let after_macro_bang =
-                    merged_prefix_len + BytePos(visible_macro.as_str().bytes().count() as u32 + 1);
+                    merged_prefix_len + BytePos(visible_macro.as_str().len() as u32 + 1);
                 let mut macro_name_cov = self.curr().clone();
                 self.curr_mut().span =
                     self.curr().span.with_lo(self.curr().span.lo() + after_macro_bang);

--- a/library/std/src/os/fd/owned.rs
+++ b/library/std/src/os/fd/owned.rs
@@ -66,8 +66,8 @@ impl BorrowedFd<'_> {
     /// the returned `BorrowedFd`, and it must not have the value `-1`.
     #[inline]
     #[unstable(feature = "io_safety", issue = "87074")]
-    pub unsafe fn borrow_raw(fd: RawFd) -> Self {
-        assert_ne!(fd, u32::MAX as RawFd);
+    pub const unsafe fn borrow_raw(fd: RawFd) -> Self {
+        assert!(fd != u32::MAX as RawFd);
         // SAFETY: we just asserted that the value is in the valid range and isn't `-1` (the only value bigger than `0xFF_FF_FF_FE` unsigned)
         unsafe { Self { fd, _phantom: PhantomData } }
     }

--- a/library/std/src/os/windows/io/handle.rs
+++ b/library/std/src/os/windows/io/handle.rs
@@ -137,7 +137,7 @@ impl BorrowedHandle<'_> {
     /// [here]: https://devblogs.microsoft.com/oldnewthing/20040302-00/?p=40443
     #[inline]
     #[unstable(feature = "io_safety", issue = "87074")]
-    pub unsafe fn borrow_raw(handle: RawHandle) -> Self {
+    pub const unsafe fn borrow_raw(handle: RawHandle) -> Self {
         Self { handle, _phantom: PhantomData }
     }
 }

--- a/library/std/src/os/windows/io/socket.rs
+++ b/library/std/src/os/windows/io/socket.rs
@@ -71,8 +71,8 @@ impl BorrowedSocket<'_> {
     /// `INVALID_SOCKET`.
     #[inline]
     #[unstable(feature = "io_safety", issue = "87074")]
-    pub unsafe fn borrow_raw(socket: RawSocket) -> Self {
-        debug_assert_ne!(socket, c::INVALID_SOCKET as RawSocket);
+    pub const unsafe fn borrow_raw(socket: RawSocket) -> Self {
+        assert!(socket != c::INVALID_SOCKET as RawSocket);
         Self { socket, _phantom: PhantomData }
     }
 }

--- a/src/librustdoc/formats/cache.rs
+++ b/src/librustdoc/formats/cache.rs
@@ -293,7 +293,8 @@ impl<'a, 'tcx> DocFolder for CacheBuilder<'a, 'tcx> {
                                 ItemType::Trait
                                 | ItemType::Struct
                                 | ItemType::Union
-                                | ItemType::Enum,
+                                | ItemType::Enum
+                                | ItemType::Typedef,
                             )) => Some(&fqp[..fqp.len() - 1]),
                             Some(..) => Some(&*self.cache.stack),
                             None => None,

--- a/src/librustdoc/formats/cache.rs
+++ b/src/librustdoc/formats/cache.rs
@@ -288,15 +288,7 @@ impl<'a, 'tcx> DocFolder for CacheBuilder<'a, 'tcx> {
                             // for where the type was defined. On the other
                             // hand, `paths` always has the right
                             // information if present.
-                            Some(&(
-                                ref fqp,
-                                ItemType::Trait
-                                | ItemType::Struct
-                                | ItemType::Union
-                                | ItemType::Enum
-                                | ItemType::Typedef,
-                            )) => Some(&fqp[..fqp.len() - 1]),
-                            Some(..) => Some(&*self.cache.stack),
+                            Some(&(ref fqp, _)) => Some(&fqp[..fqp.len() - 1]),
                             None => None,
                         };
                         ((Some(*last), path), true)

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -331,7 +331,6 @@ li {
 nav.sub {
 	position: relative;
 	font-size: 1rem;
-	text-transform: uppercase;
 }
 
 .sub-container {

--- a/src/librustdoc/html/static/js/source-script.js
+++ b/src/librustdoc/html/static/js/source-script.js
@@ -1,5 +1,5 @@
 // From rust:
-/* global search, sourcesIndex */
+/* global sourcesIndex */
 
 // Local js definitions:
 /* global addClass, getCurrentValue, hasClass, onEachLazy, removeClass, browserSupportsHistoryApi */
@@ -69,7 +69,6 @@ function createDirEntry(elem, parent, fullPath, currentFile, hasFoundFile) {
             files.appendChild(file);
         }
     }
-    search.fullPath = fullPath;
     children.appendChild(files);
     parent.appendChild(name);
     parent.appendChild(children);

--- a/src/test/rustdoc-gui/sidebar-source-code-display.goml
+++ b/src/test/rustdoc-gui/sidebar-source-code-display.goml
@@ -15,6 +15,5 @@ assert-css: ("#sidebar-toggle", {"visibility": "visible", "opacity": 1})
 assert-css: (".sidebar > *:not(#sidebar-toggle)", {"visibility": "hidden", "opacity": 0})
 // Let's expand the sidebar now.
 click: "#sidebar-toggle"
-// Because of the transition CSS, better wait a second before checking.
+// Because of the transition CSS, we check by using `wait-for-css` instead of `assert-css`.
 wait-for-css: ("#sidebar-toggle", {"visibility": "visible", "opacity": 1})
-assert-css: (".sidebar > *:not(#sidebar-toggle)", {"visibility": "visible", "opacity": 1})

--- a/src/test/rustdoc-js-std/asrawfd.js
+++ b/src/test/rustdoc-js-std/asrawfd.js
@@ -1,0 +1,14 @@
+// exact-match
+
+const QUERY = 'RawFd::as_raw_fd';
+
+const EXPECTED = {
+    'others': [
+        // Reproduction test for https://github.com/rust-lang/rust/issues/78724
+        // Validate that type alias methods get the correct path.
+        { 'path': 'std::os::unix::io::AsRawFd', 'name': 'as_raw_fd' },
+        { 'path': 'std::os::wasi::io::AsRawFd', 'name': 'as_raw_fd' },
+        { 'path': 'std::os::linux::process::PidFd', 'name': 'as_raw_fd' },
+        { 'path': 'std::os::unix::io::RawFd', 'name': 'as_raw_fd' },
+    ],
+};

--- a/src/test/rustdoc-js/foreign-type-path.js
+++ b/src/test/rustdoc-js/foreign-type-path.js
@@ -1,0 +1,9 @@
+const QUERY = 'MyForeignType::my_method';
+
+const EXPECTED = {
+    'others': [
+        // Test case for https://github.com/rust-lang/rust/pull/96887#pullrequestreview-967154358
+        // Validates that the parent path for a foreign type method is correct.
+        { 'path': 'foreign_type_path::aaaaaaa::MyForeignType', 'name': 'my_method' },
+    ],
+};

--- a/src/test/rustdoc-js/foreign-type-path.rs
+++ b/src/test/rustdoc-js/foreign-type-path.rs
@@ -1,0 +1,13 @@
+#![feature(extern_types)]
+
+pub mod aaaaaaa {
+
+    extern {
+        pub type MyForeignType;
+    }
+
+    impl MyForeignType {
+        pub fn my_method() {}
+    }
+
+}

--- a/src/test/ui/lint/dead-code/issue-68408-false-positive.rs
+++ b/src/test/ui/lint/dead-code/issue-68408-false-positive.rs
@@ -1,0 +1,22 @@
+// check-pass
+
+// Make sure we don't have any false positives here.
+
+#![deny(dead_code)]
+
+enum X {
+    A { _a: () },
+    B { _b: () },
+}
+impl X {
+    fn a() -> X {
+        X::A { _a: () }
+    }
+    fn b() -> Self {
+        Self::B { _b: () }
+    }
+}
+
+fn main() {
+    let (_, _) = (X::a(), X::b());
+}

--- a/src/test/ui/type-alias-impl-trait/constrain_inputs.rs
+++ b/src/test/ui/type-alias-impl-trait/constrain_inputs.rs
@@ -1,0 +1,17 @@
+// check-pass
+
+#![feature(type_alias_impl_trait)]
+
+mod foo {
+    type Ty<'a> = impl Sized;
+    fn defining(s: &str) -> Ty<'_> { s }
+    fn execute(ty: Ty<'_>) -> &str { todo!() }
+}
+
+mod bar {
+    type Ty<'a> = impl FnOnce() -> &'a str;
+    fn defining(s: &str) -> Ty<'_> { move || s }
+    fn execute(ty: Ty<'_>) -> &str { ty() }
+}
+
+fn main() {}


### PR DESCRIPTION
Successful merges:

 - #96232 (Make `BorrowedFd::borrow_raw` a const fn.)
 - #96887 (rustdoc: correct path to type alias methods)
 - #96896 (Add regression test for #68408)
 - #96900 (Fix js error)
 - #96903 (Use lifetimes on type-alias-impl-trait used in function signatures to infer output type lifetimes)
 - #96916 (simplify length count)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=96232,96887,96896,96900,96903,96916)
<!-- homu-ignore:end -->