### PR TITLE
[WIP] Apply latest PGO artifacts to CI dist builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,15 +37,6 @@ jobs:
       TOOLSTATE_REPO: "https://github.com/rust-lang-nursery/rust-toolstate"
       CACHE_DOMAIN: ci-caches.rust-lang.org
     if: "github.event_name == 'pull_request'"
-    strategy:
-      matrix:
-        include:
-          - name: dist-x86_64-msvc
-            env:
-              RUST_CONFIGURE_ARGS: "--build=x86_64-pc-windows-msvc --host=x86_64-pc-windows-msvc --target=x86_64-pc-windows-msvc --enable-full-tools --enable-profiler"
-              SCRIPT: python src/ci/pgo-windows.py
-              DIST_REQUIRE_ALL_TOOLS: 1
-            os: windows-latest-xl
     timeout-minutes: 600
     runs-on: "${{ matrix.os }}"
     steps:
@@ -554,9 +545,12 @@ jobs:
     strategy:
       matrix:
         include:
-          - name: dist-x86_64-linux
-            os: ubuntu-20.04-xl
-            env: {}
+          - name: dist-x86_64-msvc
+            env:
+              RUST_CONFIGURE_ARGS: "--build=x86_64-pc-windows-msvc --host=x86_64-pc-windows-msvc --target=x86_64-pc-windows-msvc --enable-full-tools --enable-profiler"
+              SCRIPT: python src/ci/pgo-windows.py
+              DIST_REQUIRE_ALL_TOOLS: 1
+            os: windows-latest-xl
     timeout-minutes: 600
     runs-on: "${{ matrix.os }}"
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,16 +40,12 @@ jobs:
     strategy:
       matrix:
         include:
-          - name: mingw-check
-            os: ubuntu-20.04-xl
-            env: {}
-          - name: x86_64-gnu-llvm-12
-            os: ubuntu-20.04-xl
-            env: {}
-          - name: x86_64-gnu-tools
+          - name: dist-x86_64-msvc
             env:
-              CI_ONLY_WHEN_SUBMODULES_CHANGED: 1
-            os: ubuntu-20.04-xl
+              RUST_CONFIGURE_ARGS: "--build=x86_64-pc-windows-msvc --host=x86_64-pc-windows-msvc --target=x86_64-pc-windows-msvc --enable-full-tools --enable-profiler"
+              SCRIPT: python src/ci/pgo-windows.py
+              DIST_REQUIRE_ALL_TOOLS: 1
+            os: windows-latest-xl
     timeout-minutes: 600
     runs-on: "${{ matrix.os }}"
     steps:

--- a/src/ci/github-actions/ci.yml
+++ b/src/ci/github-actions/ci.yml
@@ -282,9 +282,9 @@ jobs:
     env:
       <<: [*shared-ci-variables, *public-variables]
     if: github.event_name == 'pull_request'
-    strategy:
-      matrix:
-        include:
+#    strategy:
+#      matrix:
+#        include:
 #          - name: mingw-check
 #            <<: *job-linux-xl
 #
@@ -295,17 +295,17 @@ jobs:
 #            env:
 #              CI_ONLY_WHEN_SUBMODULES_CHANGED: 1
 #            <<: *job-linux-xl
-          - name: dist-x86_64-msvc
-            env:
-              RUST_CONFIGURE_ARGS: >-
-                --build=x86_64-pc-windows-msvc
-                --host=x86_64-pc-windows-msvc
-                --target=x86_64-pc-windows-msvc
-                --enable-full-tools
-                --enable-profiler
-              SCRIPT: python src/ci/pgo-windows.py
-              DIST_REQUIRE_ALL_TOOLS: 1
-            <<: *job-windows-xl
+#          - name: dist-x86_64-msvc
+#            env:
+#              RUST_CONFIGURE_ARGS: >-
+#                --build=x86_64-pc-windows-msvc
+#                --host=x86_64-pc-windows-msvc
+#                --target=x86_64-pc-windows-msvc
+#                --enable-full-tools
+#                --enable-profiler
+#              SCRIPT: python src/ci/pgo-windows.py
+#              DIST_REQUIRE_ALL_TOOLS: 1
+#            <<: *job-windows-xl
 
   auto:
     <<: *base-ci-job
@@ -702,9 +702,12 @@ jobs:
     strategy:
       matrix:
         include:
-          - &dist-x86_64-linux
-            name: dist-x86_64-linux
-            <<: *job-linux-xl
+          - name: dist-x86_64-msvc
+            env:
+              RUST_CONFIGURE_ARGS: "--build=x86_64-pc-windows-msvc --host=x86_64-pc-windows-msvc --target=x86_64-pc-windows-msvc --enable-full-tools --enable-profiler"
+              SCRIPT: python src/ci/pgo-windows.py
+              DIST_REQUIRE_ALL_TOOLS: 1
+            os: windows-latest-xl
 
   master:
     name: master

--- a/src/ci/github-actions/ci.yml
+++ b/src/ci/github-actions/ci.yml
@@ -285,16 +285,27 @@ jobs:
     strategy:
       matrix:
         include:
-          - name: mingw-check
-            <<: *job-linux-xl
-
-          - name: x86_64-gnu-llvm-12
-            <<: *job-linux-xl
-
-          - name: x86_64-gnu-tools
+#          - name: mingw-check
+#            <<: *job-linux-xl
+#
+#          - name: x86_64-gnu-llvm-12
+#            <<: *job-linux-xl
+#
+#          - name: x86_64-gnu-tools
+#            env:
+#              CI_ONLY_WHEN_SUBMODULES_CHANGED: 1
+#            <<: *job-linux-xl
+          - name: dist-x86_64-msvc
             env:
-              CI_ONLY_WHEN_SUBMODULES_CHANGED: 1
-            <<: *job-linux-xl
+              RUST_CONFIGURE_ARGS: >-
+                --build=x86_64-pc-windows-msvc
+                --host=x86_64-pc-windows-msvc
+                --target=x86_64-pc-windows-msvc
+                --enable-full-tools
+                --enable-profiler
+              SCRIPT: python src/ci/pgo-windows.py
+              DIST_REQUIRE_ALL_TOOLS: 1
+            <<: *job-windows-xl
 
   auto:
     <<: *base-ci-job

--- a/src/ci/pgo-windows.py
+++ b/src/ci/pgo-windows.py
@@ -1,0 +1,25 @@
+# ignore-tidy-linelength
+import os
+import subprocess
+from pathlib import Path
+from urllib.request import urlretrieve
+import tarfile
+
+
+artifact_url = "https://ci-artifacts.rust-lang.org/rustc-builds/de1bc0008be096cf7ed67b93402250d3b3e480d0/reproducible-artifacts-nightly-x86_64-unknown-linux-gnu.tar.xz"
+
+archive = "artifacts.tar.xz"
+urlretrieve(artifact_url, archive)
+
+with tarfile.open(archive) as f:
+    f.extractall("artifacts")
+
+llvm_pgo_path = Path("artifacts/reproducible-artifacts-nightly-x86_64-unknown-linux-gnu/reproducible-artifacts/llvm-pgo.profdata")
+assert llvm_pgo_path.exists()
+
+env = os.environ.copy()
+env["RUST_BACKTRACE"] = "full"
+subprocess.run([
+    "python", "x.py", "dist",
+    "--llvm-profile-use", str(llvm_pgo_path)
+], check=True, env=env)


### PR DESCRIPTION
Trying to experiment with applying latest PGO artifacts to CI dist builds (currently for Windows). Even if we apply already pre-built PGO artifacts, LLVM will have to be rebuilt probably, so we will need to setup it somehow for compilation on Windows.

Using Python scripts now for flexibility.