### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/compiler/rustc_middle/src/ty/fold.rs
+++ b/compiler/rustc_middle/src/ty/fold.rs
@@ -1349,7 +1349,7 @@ impl<'tcx> TypeVisitor<'tcx> for LateBoundRegionsCollector {
         // ignore the inputs to a projection, as they may not appear
         // in the normalized form
         if self.just_constrained {
-            if let ty::Projection(..) | ty::Opaque(..) = t.kind() {
+            if let ty::Projection(..) = t.kind() {
                 return ControlFlow::CONTINUE;
             }
         }

--- a/compiler/rustc_mir_transform/src/coverage/spans.rs
+++ b/compiler/rustc_mir_transform/src/coverage/spans.rs
@@ -485,7 +485,7 @@ impl<'a, 'tcx> CoverageSpans<'a, 'tcx> {
             }) {
                 let merged_prefix_len = self.curr_original_span.lo() - self.curr().span.lo();
                 let after_macro_bang =
-                    merged_prefix_len + BytePos(visible_macro.as_str().bytes().count() as u32 + 1);
+                    merged_prefix_len + BytePos(visible_macro.as_str().len() as u32 + 1);
                 let mut macro_name_cov = self.curr().clone();
                 self.curr_mut().span =
                     self.curr().span.with_lo(self.curr().span.lo() + after_macro_bang);

--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -2109,8 +2109,7 @@ impl<'a> Parser<'a> {
                     brace_depth -= 1;
                     continue;
                 }
-            } else if self.token == token::Eof || self.eat(&token::CloseDelim(Delimiter::Invisible))
-            {
+            } else if self.token == token::Eof {
                 return;
             } else {
                 self.bump();

--- a/src/librustdoc/formats/cache.rs
+++ b/src/librustdoc/formats/cache.rs
@@ -293,7 +293,8 @@ impl<'a, 'tcx> DocFolder for CacheBuilder<'a, 'tcx> {
                                 ItemType::Trait
                                 | ItemType::Struct
                                 | ItemType::Union
-                                | ItemType::Enum,
+                                | ItemType::Enum
+                                | ItemType::Typedef,
                             )) => Some(&fqp[..fqp.len() - 1]),
                             Some(..) => Some(&*self.cache.stack),
                             None => None,

--- a/src/librustdoc/formats/cache.rs
+++ b/src/librustdoc/formats/cache.rs
@@ -288,15 +288,7 @@ impl<'a, 'tcx> DocFolder for CacheBuilder<'a, 'tcx> {
                             // for where the type was defined. On the other
                             // hand, `paths` always has the right
                             // information if present.
-                            Some(&(
-                                ref fqp,
-                                ItemType::Trait
-                                | ItemType::Struct
-                                | ItemType::Union
-                                | ItemType::Enum
-                                | ItemType::Typedef,
-                            )) => Some(&fqp[..fqp.len() - 1]),
-                            Some(..) => Some(&*self.cache.stack),
+                            Some(&(ref fqp, _)) => Some(&fqp[..fqp.len() - 1]),
                             None => None,
                         };
                         ((Some(*last), path), true)

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -331,7 +331,6 @@ li {
 nav.sub {
 	position: relative;
 	font-size: 1rem;
-	text-transform: uppercase;
 }
 
 .sub-container {

--- a/src/librustdoc/html/static/js/source-script.js
+++ b/src/librustdoc/html/static/js/source-script.js
@@ -1,5 +1,5 @@
 // From rust:
-/* global search, sourcesIndex */
+/* global sourcesIndex */
 
 // Local js definitions:
 /* global addClass, getCurrentValue, hasClass, onEachLazy, removeClass, browserSupportsHistoryApi */
@@ -69,7 +69,6 @@ function createDirEntry(elem, parent, fullPath, currentFile, hasFoundFile) {
             files.appendChild(file);
         }
     }
-    search.fullPath = fullPath;
     children.appendChild(files);
     parent.appendChild(name);
     parent.appendChild(children);

--- a/src/test/rustdoc-gui/sidebar-source-code-display.goml
+++ b/src/test/rustdoc-gui/sidebar-source-code-display.goml
@@ -15,6 +15,5 @@ assert-css: ("#sidebar-toggle", {"visibility": "visible", "opacity": 1})
 assert-css: (".sidebar > *:not(#sidebar-toggle)", {"visibility": "hidden", "opacity": 0})
 // Let's expand the sidebar now.
 click: "#sidebar-toggle"
-// Because of the transition CSS, better wait a second before checking.
+// Because of the transition CSS, we check by using `wait-for-css` instead of `assert-css`.
 wait-for-css: ("#sidebar-toggle", {"visibility": "visible", "opacity": 1})
-assert-css: (".sidebar > *:not(#sidebar-toggle)", {"visibility": "visible", "opacity": 1})

--- a/src/test/rustdoc-js-std/asrawfd.js
+++ b/src/test/rustdoc-js-std/asrawfd.js
@@ -1,0 +1,14 @@
+// exact-match
+
+const QUERY = 'RawFd::as_raw_fd';
+
+const EXPECTED = {
+    'others': [
+        // Reproduction test for https://github.com/rust-lang/rust/issues/78724
+        // Validate that type alias methods get the correct path.
+        { 'path': 'std::os::unix::io::AsRawFd', 'name': 'as_raw_fd' },
+        { 'path': 'std::os::wasi::io::AsRawFd', 'name': 'as_raw_fd' },
+        { 'path': 'std::os::linux::process::PidFd', 'name': 'as_raw_fd' },
+        { 'path': 'std::os::unix::io::RawFd', 'name': 'as_raw_fd' },
+    ],
+};

--- a/src/test/rustdoc-js-std/asrawfd.js
+++ b/src/test/rustdoc-js-std/asrawfd.js
@@ -1,4 +1,4 @@
-// exact-match
+// ignore-order
 
 const QUERY = 'RawFd::as_raw_fd';
 

--- a/src/test/rustdoc-js/foreign-type-path.js
+++ b/src/test/rustdoc-js/foreign-type-path.js
@@ -1,0 +1,9 @@
+const QUERY = 'MyForeignType::my_method';
+
+const EXPECTED = {
+    'others': [
+        // Test case for https://github.com/rust-lang/rust/pull/96887#pullrequestreview-967154358
+        // Validates that the parent path for a foreign type method is correct.
+        { 'path': 'foreign_type_path::aaaaaaa::MyForeignType', 'name': 'my_method' },
+    ],
+};

--- a/src/test/rustdoc-js/foreign-type-path.rs
+++ b/src/test/rustdoc-js/foreign-type-path.rs
@@ -1,0 +1,13 @@
+#![feature(extern_types)]
+
+pub mod aaaaaaa {
+
+    extern {
+        pub type MyForeignType;
+    }
+
+    impl MyForeignType {
+        pub fn my_method() {}
+    }
+
+}

--- a/src/test/ui/lint/dead-code/issue-68408-false-positive.rs
+++ b/src/test/ui/lint/dead-code/issue-68408-false-positive.rs
@@ -1,0 +1,22 @@
+// check-pass
+
+// Make sure we don't have any false positives here.
+
+#![deny(dead_code)]
+
+enum X {
+    A { _a: () },
+    B { _b: () },
+}
+impl X {
+    fn a() -> X {
+        X::A { _a: () }
+    }
+    fn b() -> Self {
+        Self::B { _b: () }
+    }
+}
+
+fn main() {
+    let (_, _) = (X::a(), X::b());
+}

--- a/src/test/ui/rfc-2091-track-caller/macro-declaration.rs
+++ b/src/test/ui/rfc-2091-track-caller/macro-declaration.rs
@@ -1,0 +1,10 @@
+// check-pass
+
+// See https://github.com/rust-lang/rust/issues/95151
+#[track_caller]
+macro_rules! _foo {
+    () => {};
+}
+
+fn main() {
+}

--- a/src/test/ui/type-alias-impl-trait/constrain_inputs.rs
+++ b/src/test/ui/type-alias-impl-trait/constrain_inputs.rs
@@ -1,0 +1,17 @@
+// check-pass
+
+#![feature(type_alias_impl_trait)]
+
+mod foo {
+    type Ty<'a> = impl Sized;
+    fn defining(s: &str) -> Ty<'_> { s }
+    fn execute(ty: Ty<'_>) -> &str { todo!() }
+}
+
+mod bar {
+    type Ty<'a> = impl FnOnce() -> &'a str;
+    fn defining(s: &str) -> Ty<'_> { move || s }
+    fn execute(ty: Ty<'_>) -> &str { ty() }
+}
+
+fn main() {}

--- a/src/tools/rustfmt/src/parse/macros/mod.rs
+++ b/src/tools/rustfmt/src/parse/macros/mod.rs
@@ -79,9 +79,7 @@ fn check_keyword<'a, 'b: 'a>(parser: &'a mut Parser<'b>) -> Option<MacroArg> {
     for &keyword in RUST_KW.iter() {
         if parser.token.is_keyword(keyword)
             && parser.look_ahead(1, |t| {
-                t.kind == TokenKind::Eof
-                    || t.kind == TokenKind::Comma
-                    || t.kind == TokenKind::CloseDelim(Delimiter::Invisible)
+                t.kind == TokenKind::Eof || t.kind == TokenKind::Comma
             })
         {
             parser.bump();


### PR DESCRIPTION
Successful merges:

 - #96543 (Remove hacks in `make_token_stream`.)
 - #96887 (rustdoc: correct path to type alias methods)
 - #96896 (Add regression test for #68408)
 - #96900 (Fix js error)
 - #96903 (Use lifetimes on type-alias-impl-trait used in function signatures to infer output type lifetimes)
 - #96916 (simplify length count)
 - #96925 (Fix issue #95151)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=96543,96887,96896,96900,96903,96916,96925)
<!-- homu-ignore:end -->