### PR TITLE
Clarify what values `BorrowedHandle`, `OwnedHandle` etc. can hold.

### DIFF
--- a/library/std/src/os/windows/io/handle.rs
+++ b/library/std/src/os/windows/io/handle.rs
@@ -22,7 +22,7 @@ use crate::sys_common::{AsInner, FromInner, IntoInner};
 /// so it can be used in FFI in places where a handle is passed as an argument,
 /// it is not captured or consumed.
 ///
-/// Note that it *may* have the value `-1`, which in `BorrowedFd` always
+/// Note that it *may* have the value `-1`, which in `BorrowedHandle` always
 /// represents the current process handle, and not `INVALID_HANDLE_VALUE`,
 /// despite the two having the same value. See [here] for the full story.
 ///
@@ -46,7 +46,7 @@ pub struct BorrowedHandle<'handle> {
 ///
 /// This closes the handle on drop.
 ///
-/// Note that it *may* have the value `-1`, which in `OwnedFd` always
+/// Note that it *may* have the value `-1`, which in `OwnedHandle` always
 /// represents the current process handle, and not `INVALID_HANDLE_VALUE`,
 /// despite the two having the same value. See [here] for the full story.
 ///
@@ -77,7 +77,7 @@ pub struct OwnedHandle {
 /// `NULL`. This ensures that such FFI calls cannot start using the handle without
 /// checking for `NULL` first.
 ///
-/// This type may hold any handle value that [`OwnedFd`] may hold, except `NULL`. It may
+/// This type may hold any handle value that [`OwnedHandle`] may hold, except `NULL`. It may
 /// hold `-1`, even though `-1` has the same value as `INVALID_HANDLE_VALUE`, because in
 /// `HandleOrNull`, `-1` is interpreted to mean the current process handle.
 ///
@@ -97,7 +97,7 @@ pub struct HandleOrNull(OwnedHandle);
 /// `INVALID_HANDLE_VALUE`. This ensures that such FFI calls cannot start using the handle without
 /// checking for `INVALID_HANDLE_VALUE` first.
 ///
-/// This type may hold any handle value that [`OwnedFd`] may hold, except `-1`. It must not
+/// This type may hold any handle value that [`OwnedHandle`] may hold, except `-1`. It must not
 /// hold `-1`, because `-1` in `HandleOrInvalid` is interpreted to mean `INVALID_HANDLE_VALUE`.
 ///
 /// This type may hold `NULL`, because APIs that use `INVALID_HANDLE_VALUE` as their sentry value

--- a/library/std/src/os/windows/io/handle.rs
+++ b/library/std/src/os/windows/io/handle.rs
@@ -86,6 +86,7 @@ pub struct OwnedHandle {
 /// [the current process handle], and not `INVALID_HANDLE_VALUE`.
 ///
 /// If this holds a non-null handle, it will close the handle on drop.
+///
 /// [the current process handle]: https://docs.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-getcurrentprocess#remarks
 #[repr(transparent)]
 #[unstable(feature = "io_safety", issue = "87074")]

--- a/library/std/src/os/windows/io/handle.rs
+++ b/library/std/src/os/windows/io/handle.rs
@@ -77,9 +77,9 @@ pub struct OwnedHandle {
 /// `NULL`. This ensures that such FFI calls cannot start using the handle without
 /// checking for `NULL` first.
 ///
-/// This type may hold any handle value that [`OwnedHandle`] may hold, except `NULL`. It may
-/// hold `-1`, even though `-1` has the same value as `INVALID_HANDLE_VALUE`, because in
-/// `HandleOrNull`, `-1` is interpreted to mean the current process handle.
+/// This type may hold any handle value that [`OwnedHandle`] may hold. As with `OwnedHandle`, when
+/// it holds `-1`, that value is interpreted as the current process handle, and not
+/// `INVALID_HANDLE_VALUE`.
 ///
 /// If this holds a non-null handle, it will close the handle on drop.
 #[repr(transparent)]
@@ -97,12 +97,8 @@ pub struct HandleOrNull(OwnedHandle);
 /// `INVALID_HANDLE_VALUE`. This ensures that such FFI calls cannot start using the handle without
 /// checking for `INVALID_HANDLE_VALUE` first.
 ///
-/// This type may hold any handle value that [`OwnedHandle`] may hold, except `-1`. It must not
-/// hold `-1`, because `-1` in `HandleOrInvalid` is interpreted to mean `INVALID_HANDLE_VALUE`.
-///
-/// This type may hold `NULL`, because APIs that use `INVALID_HANDLE_VALUE` as their sentry value
-/// may return `NULL` under `windows_subsystem = "windows"` or other situations where I/O devices
-/// are detached.
+/// This type may hold any handle value that [`OwnedHandle`] may hold, except that when it holds
+/// `-1`, that value is interpreted to mean `INVALID_HANDLE_VALUE`.
 ///
 /// If holds a handle other than `INVALID_HANDLE_VALUE`, it will close the handle on drop.
 #[repr(transparent)]

--- a/library/std/src/os/windows/io/handle.rs
+++ b/library/std/src/os/windows/io/handle.rs
@@ -23,8 +23,9 @@ use crate::sys_common::{AsInner, FromInner, IntoInner};
 /// it is not captured or consumed.
 ///
 /// Note that it *may* have the value `-1`, which in `BorrowedHandle` always
-/// represents the current process handle, and not `INVALID_HANDLE_VALUE`,
-/// despite the two having the same value. See [here] for the full story.
+/// represents a valid handle value, such as [the current process handle], and
+/// not `INVALID_HANDLE_VALUE`, despite the two having the same value. See
+/// [here] for the full story.
 ///
 /// And, it *may* have the value `NULL` (0), which can occur when consoles are
 /// detached from processes, or when `windows_subsystem` is used.
@@ -34,6 +35,7 @@ use crate::sys_common::{AsInner, FromInner, IntoInner};
 /// handle, which is then borrowed under the same lifetime.
 ///
 /// [here]: https://devblogs.microsoft.com/oldnewthing/20040302-00/?p=40443
+/// [the current process handle]: https://docs.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-getcurrentprocess#remarks
 #[derive(Copy, Clone)]
 #[repr(transparent)]
 #[unstable(feature = "io_safety", issue = "87074")]
@@ -47,8 +49,9 @@ pub struct BorrowedHandle<'handle> {
 /// This closes the handle on drop.
 ///
 /// Note that it *may* have the value `-1`, which in `OwnedHandle` always
-/// represents the current process handle, and not `INVALID_HANDLE_VALUE`,
-/// despite the two having the same value. See [here] for the full story.
+/// represents a valid handle value, such as [the current process handle], and
+/// not `INVALID_HANDLE_VALUE`, despite the two having the same value. See
+/// [here] for the full story.
 ///
 /// And, it *may* have the value `NULL` (0), which can occur when consoles are
 /// detached from processes, or when `windows_subsystem` is used.
@@ -61,6 +64,7 @@ pub struct BorrowedHandle<'handle> {
 /// [`RegCloseKey`]: https://docs.microsoft.com/en-us/windows/win32/api/winreg/nf-winreg-regclosekey
 ///
 /// [here]: https://devblogs.microsoft.com/oldnewthing/20040302-00/?p=40443
+/// [the current process handle]: https://docs.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-getcurrentprocess#remarks
 #[repr(transparent)]
 #[unstable(feature = "io_safety", issue = "87074")]
 pub struct OwnedHandle {
@@ -78,10 +82,11 @@ pub struct OwnedHandle {
 /// checking for `NULL` first.
 ///
 /// This type may hold any handle value that [`OwnedHandle`] may hold. As with `OwnedHandle`, when
-/// it holds `-1`, that value is interpreted as the current process handle, and not
-/// `INVALID_HANDLE_VALUE`.
+/// it holds `-1`, that value is interpreted as a valid handle value, such as
+/// [the current process handle], and not `INVALID_HANDLE_VALUE`.
 ///
 /// If this holds a non-null handle, it will close the handle on drop.
+/// [the current process handle]: https://docs.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-getcurrentprocess#remarks
 #[repr(transparent)]
 #[unstable(feature = "io_safety", issue = "87074")]
 #[derive(Debug)]

--- a/library/std/src/os/windows/io/raw.rs
+++ b/library/std/src/os/windows/io/raw.rs
@@ -32,8 +32,15 @@ pub trait AsRawHandle {
     /// raw handle to the caller, and the handle is only guaranteed
     /// to be valid while the original object has not yet been destroyed.
     ///
+    /// This function may return null, such as when called on [`Stdin`],
+    /// [`Stdout`], or [`Stderr`] when the console is detached.
+    ///
     /// However, borrowing is not strictly required. See [`AsHandle::as_handle`]
     /// for an API which strictly borrows a handle.
+    ///
+    /// [`Stdin`]: io::Stdin
+    /// [`Stdout`]: io::Stdout
+    /// [`Stderr`]: io::Stderr
     #[stable(feature = "rust1", since = "1.0.0")]
     fn as_raw_handle(&self) -> RawHandle;
 }


### PR DESCRIPTION
Reword the documentation to clarify that when `BorrowedHandle`, `OwnedHandle`, or `HandleOrNull` hold the value `-1`, it always means the current process handle, and not `INVALID_HANDLE_VALUE`.

`-1` should only mean `INVALID_HANDLE_VALUE` after a call to a function documented to return that to report errors, which should lead I/O functions to produce errors rather than succeeding and producing `OwnedHandle` or `BorrowedHandle` values. So if a consumer of an `OwnedHandle` or `BorrowedHandle` ever sees them holding a `-1`, it should always mean the current process handle.
