### PR TITLE
Inline BuildHasherDefault<DefaultHasher>::build_hasher

### DIFF
--- a/library/core/src/hash/mod.rs
+++ b/library/core/src/hash/mod.rs
@@ -767,6 +767,7 @@ impl<H> fmt::Debug for BuildHasherDefault<H> {
 impl<H: Default + Hasher> BuildHasher for BuildHasherDefault<H> {
     type Hasher = H;
 
+    #[inline]
     fn build_hasher(&self) -> H {
         H::default()
     }

--- a/library/std/src/collections/hash/map.rs
+++ b/library/std/src/collections/hash/map.rs
@@ -2987,6 +2987,7 @@ impl DefaultHasher {
     /// instances created through `new` or `default`.
     #[stable(feature = "hashmap_default_hasher", since = "1.13.0")]
     #[allow(deprecated)]
+    #[inline]
     #[must_use]
     pub fn new() -> DefaultHasher {
         DefaultHasher(SipHasher13::new_with_keys(0, 0))
@@ -2999,6 +3000,7 @@ impl Default for DefaultHasher {
     /// See its documentation for more.
     ///
     /// [`new`]: DefaultHasher::new
+    #[inline]
     fn default() -> DefaultHasher {
         DefaultHasher::new()
     }


### PR DESCRIPTION
Today this doesn't get inlined causing `<BuildHasherDefault<DefaultHasher> as BuildHasher>::hash_one` to be more complex than it needs to be (as used in `HashMap<K, V, BuildHasherDefault<DefaultHasher>>`), but with inlining it should simplify a decent amount.