### PR TITLE
Replace `#[default_method_body_is_const]` with `#[const_trait]`

### DIFF
--- a/compiler/rustc_const_eval/src/const_eval/machine.rs
+++ b/compiler/rustc_const_eval/src/const_eval/machine.rs
@@ -278,8 +278,7 @@ impl<'mir, 'tcx> interpret::Machine<'mir, 'tcx> for CompileTimeInterpreter<'mir,
             // at all.
             if !ecx.tcx.is_const_fn_raw(def.did) {
                 // allow calling functions inside a trait marked with #[const_trait].
-                if !matches!(ecx.tcx.trait_of_item(def.did), Some(trait_id) if ecx.tcx.has_attr(trait_id, sym::const_trait))
-                {
+                if !ecx.tcx.is_const_default_method(def.did) {
                     // We certainly do *not* want to actually call the fn
                     // though, so be sure we return here.
                     throw_unsup_format!("calling non-const function `{}`", instance)

--- a/compiler/rustc_const_eval/src/const_eval/machine.rs
+++ b/compiler/rustc_const_eval/src/const_eval/machine.rs
@@ -277,8 +277,9 @@ impl<'mir, 'tcx> interpret::Machine<'mir, 'tcx> for CompileTimeInterpreter<'mir,
             // sensitive check here.  But we can at least rule out functions that are not const
             // at all.
             if !ecx.tcx.is_const_fn_raw(def.did) {
-                // allow calling functions marked with #[default_method_body_is_const].
-                if !ecx.tcx.has_attr(def.did, sym::default_method_body_is_const) {
+                // allow calling functions inside a trait marked with #[const_trait].
+                if !matches!(ecx.tcx.trait_of_item(def.did), Some(trait_id) if ecx.tcx.has_attr(trait_id, sym::const_trait))
+                {
                     // We certainly do *not* want to actually call the fn
                     // though, so be sure we return here.
                     throw_unsup_format!("calling non-const function `{}`", instance)

--- a/compiler/rustc_const_eval/src/lib.rs
+++ b/compiler/rustc_const_eval/src/lib.rs
@@ -9,6 +9,7 @@ Rust MIR: a lowered representation of Rust.
 #![feature(control_flow_enum)]
 #![feature(decl_macro)]
 #![feature(exact_size_is_empty)]
+#![feature(let_chains)]
 #![feature(let_else)]
 #![feature(map_try_insert)]
 #![feature(min_specialization)]

--- a/compiler/rustc_const_eval/src/transform/check_consts/check.rs
+++ b/compiler/rustc_const_eval/src/transform/check_consts/check.rs
@@ -774,13 +774,11 @@ impl<'tcx> Visitor<'tcx> for Checker<'_, 'tcx> {
                             }
                         }
                         _ if !tcx.is_const_fn_raw(callee) => {
-                            // At this point, it is only legal when the caller is marked with
-                            // #[default_method_body_is_const], and the callee is in the same
-                            // trait.
-                            let callee_trait = tcx.trait_of_item(callee);
-                            if callee_trait.is_some()
-                                && tcx.has_attr(caller.to_def_id(), sym::default_method_body_is_const)
-                                && callee_trait == tcx.trait_of_item(caller)
+                            // At this point, it is only legal when the caller is in a trait
+                            // marked with #[const_trait], and the callee is in the same trait.
+                            if let Some(callee_trait) = tcx.trait_of_item(callee)
+                                && tcx.has_attr(callee_trait, sym::const_trait)
+                                && Some(callee_trait) == tcx.trait_of_item(caller)
                                 // Can only call methods when it's `<Self as TheTrait>::f`.
                                 && tcx.types.self_param == substs.type_at(0)
                             {
@@ -875,7 +873,7 @@ impl<'tcx> Visitor<'tcx> for Checker<'_, 'tcx> {
 
                 if !tcx.is_const_fn_raw(callee) {
                     if tcx.trait_of_item(callee).is_some() {
-                        if tcx.has_attr(callee, sym::default_method_body_is_const) {
+                        if let Some(callee_trait) = tcx.trait_of_item(callee) && tcx.has_attr(callee_trait, sym::const_trait) {
                             // To get to here we must have already found a const impl for the
                             // trait, but for it to still be non-const can be that the impl is
                             // using default method bodies.

--- a/compiler/rustc_const_eval/src/transform/check_consts/check.rs
+++ b/compiler/rustc_const_eval/src/transform/check_consts/check.rs
@@ -872,13 +872,11 @@ impl<'tcx> Visitor<'tcx> for Checker<'_, 'tcx> {
                 let is_intrinsic = tcx.is_intrinsic(callee);
 
                 if !tcx.is_const_fn_raw(callee) {
-                    if tcx.trait_of_item(callee).is_some() {
-                        if let Some(callee_trait) = tcx.trait_of_item(callee) && tcx.has_attr(callee_trait, sym::const_trait) {
-                            // To get to here we must have already found a const impl for the
-                            // trait, but for it to still be non-const can be that the impl is
-                            // using default method bodies.
-                            nonconst_call_permission = true;
-                        }
+                    if tcx.is_const_default_method(callee) {
+                        // To get to here we must have already found a const impl for the
+                        // trait, but for it to still be non-const can be that the impl is
+                        // using default method bodies.
+                        nonconst_call_permission = true;
                     }
 
                     if !nonconst_call_permission {

--- a/compiler/rustc_const_eval/src/transform/check_consts/check.rs
+++ b/compiler/rustc_const_eval/src/transform/check_consts/check.rs
@@ -711,8 +711,6 @@ impl<'tcx> Visitor<'tcx> for Checker<'_, 'tcx> {
                     }
                 };
 
-                let mut nonconst_call_permission = false;
-
                 // Attempting to call a trait method?
                 if let Some(trait_id) = tcx.trait_of_item(callee) {
                     trace!("attempting to call a trait method");
@@ -776,6 +774,7 @@ impl<'tcx> Visitor<'tcx> for Checker<'_, 'tcx> {
                         _ if !tcx.is_const_fn_raw(callee) => {
                             // At this point, it is only legal when the caller is in a trait
                             // marked with #[const_trait], and the callee is in the same trait.
+                            let mut nonconst_call_permission = false;
                             if let Some(callee_trait) = tcx.trait_of_item(callee)
                                 && tcx.has_attr(callee_trait, sym::const_trait)
                                 && Some(callee_trait) == tcx.trait_of_item(caller)
@@ -872,14 +871,10 @@ impl<'tcx> Visitor<'tcx> for Checker<'_, 'tcx> {
                 let is_intrinsic = tcx.is_intrinsic(callee);
 
                 if !tcx.is_const_fn_raw(callee) {
-                    if tcx.is_const_default_method(callee) {
+                    if !tcx.is_const_default_method(callee) {
                         // To get to here we must have already found a const impl for the
                         // trait, but for it to still be non-const can be that the impl is
                         // using default method bodies.
-                        nonconst_call_permission = true;
-                    }
-
-                    if !nonconst_call_permission {
                         self.check_op(ops::FnCallNonConst {
                             caller,
                             callee,

--- a/compiler/rustc_const_eval/src/transform/check_consts/mod.rs
+++ b/compiler/rustc_const_eval/src/transform/check_consts/mod.rs
@@ -84,10 +84,10 @@ pub fn rustc_allow_const_fn_unstable(
 // functions are subject to more stringent restrictions than "const-unstable" functions: They
 // cannot use unstable features and can only call other "const-stable" functions.
 pub fn is_const_stable_const_fn(tcx: TyCtxt<'_>, def_id: DefId) -> bool {
-    // A default body marked const is not const-stable because const
+    // A default body in a `#[const_trait]` is not const-stable because const
     // trait fns currently cannot be const-stable. We shouldn't
     // restrict default bodies to only call const-stable functions.
-    if tcx.has_attr(def_id, sym::default_method_body_is_const) {
+    if let Some(trait_id) = tcx.trait_of_item(def_id) && tcx.has_attr(trait_id, sym::const_trait) {
         return false;
     }
 

--- a/compiler/rustc_const_eval/src/transform/check_consts/mod.rs
+++ b/compiler/rustc_const_eval/src/transform/check_consts/mod.rs
@@ -9,7 +9,7 @@ use rustc_hir as hir;
 use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_middle::mir;
 use rustc_middle::ty::{self, TyCtxt};
-use rustc_span::{sym, Symbol};
+use rustc_span::Symbol;
 
 pub use self::qualifs::Qualif;
 
@@ -87,7 +87,7 @@ pub fn is_const_stable_const_fn(tcx: TyCtxt<'_>, def_id: DefId) -> bool {
     // A default body in a `#[const_trait]` is not const-stable because const
     // trait fns currently cannot be const-stable. We shouldn't
     // restrict default bodies to only call const-stable functions.
-    if let Some(trait_id) = tcx.trait_of_item(def_id) && tcx.has_attr(trait_id, sym::const_trait) {
+    if tcx.is_const_default_method(def_id) {
         return false;
     }
 

--- a/compiler/rustc_feature/src/builtin_attrs.rs
+++ b/compiler/rustc_feature/src/builtin_attrs.rs
@@ -473,9 +473,10 @@ pub const BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
     ),
     // RFC 2632
     gated!(
-        default_method_body_is_const, Normal, template!(Word), WarnFollowing, const_trait_impl,
-        "`default_method_body_is_const` is a temporary placeholder for declaring default bodies \
-        as `const`, which may be removed or renamed in the future."
+        const_trait, Normal, template!(Word), WarnFollowing, const_trait_impl,
+        "`const` is a temporary placeholder for marking a trait that is suitable for `const` \
+        `impls` and all default bodies as `const`, which may be removed or renamed in the \
+        future."
     ),
     // lang-team MCP 147
     gated!(

--- a/compiler/rustc_hir/src/def.rs
+++ b/compiler/rustc_hir/src/def.rs
@@ -92,6 +92,7 @@ pub enum DefKind {
     /// [RFC 2593]: https://github.com/rust-lang/rfcs/pull/2593
     Ctor(CtorOf, CtorKind),
     /// Associated function: `impl MyStruct { fn associated() {} }`
+    /// or `trait Foo { fn associated() {} }`
     AssocFn,
     /// Associated constant: `trait MyTrait { const ASSOC: usize; }`
     AssocConst,

--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -892,10 +892,8 @@ fn should_encode_mir(tcx: TyCtxt<'_>, def_id: LocalDefId) -> (bool, bool) {
                 || tcx.codegen_fn_attrs(def_id).requests_inline())
                 && tcx.sess.opts.output_types.should_codegen();
             // The function has a `const` modifier or is in a `#[const_trait]`.
-            let mut is_const_fn = tcx.is_const_fn_raw(def_id.to_def_id());
-            if let Some(trait_) = tcx.trait_of_item(def_id.to_def_id()) {
-                is_const_fn = is_const_fn || tcx.has_attr(trait_, sym::const_trait);
-            }
+            let is_const_fn = tcx.is_const_fn_raw(def_id.to_def_id())
+                || tcx.is_const_default_method(def_id.to_def_id());
             let always_encode_mir = tcx.sess.opts.debugging_opts.always_encode_mir;
             (is_const_fn, needs_inline || always_encode_mir)
         }

--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -891,9 +891,11 @@ fn should_encode_mir(tcx: TyCtxt<'_>, def_id: LocalDefId) -> (bool, bool) {
             let needs_inline = (generics.requires_monomorphization(tcx)
                 || tcx.codegen_fn_attrs(def_id).requests_inline())
                 && tcx.sess.opts.output_types.should_codegen();
-            // The function has a `const` modifier or is annotated with `default_method_body_is_const`.
-            let is_const_fn = tcx.is_const_fn_raw(def_id.to_def_id())
-                || tcx.has_attr(def_id.to_def_id(), sym::default_method_body_is_const);
+            // The function has a `const` modifier or is in a `#[const_trait]`.
+            let mut is_const_fn = tcx.is_const_fn_raw(def_id.to_def_id());
+            if let Some(trait_) = tcx.trait_of_item(def_id.to_def_id()) {
+                is_const_fn = is_const_fn || tcx.has_attr(trait_, sym::const_trait);
+            }
             let always_encode_mir = tcx.sess.opts.debugging_opts.always_encode_mir;
             (is_const_fn, needs_inline || always_encode_mir)
         }

--- a/compiler/rustc_middle/src/hir/map/mod.rs
+++ b/compiler/rustc_middle/src/hir/map/mod.rs
@@ -494,7 +494,7 @@ impl<'hir> Map<'hir> {
             BodyOwnerKind::Fn if self.tcx.is_const_fn_raw(def_id.to_def_id()) => {
                 ConstContext::ConstFn
             }
-            BodyOwnerKind::Fn if matches!(self.tcx.trait_of_item(def_id.to_def_id()), Some(trait_id) if self.tcx.has_attr(trait_id, sym::const_trait)) => {
+            BodyOwnerKind::Fn if self.tcx.is_const_default_method(def_id.to_def_id()) => {
                 ConstContext::ConstFn
             }
             BodyOwnerKind::Fn | BodyOwnerKind::Closure => return None,

--- a/compiler/rustc_middle/src/hir/map/mod.rs
+++ b/compiler/rustc_middle/src/hir/map/mod.rs
@@ -494,9 +494,7 @@ impl<'hir> Map<'hir> {
             BodyOwnerKind::Fn if self.tcx.is_const_fn_raw(def_id.to_def_id()) => {
                 ConstContext::ConstFn
             }
-            BodyOwnerKind::Fn
-                if self.tcx.has_attr(def_id.to_def_id(), sym::default_method_body_is_const) =>
-            {
+            BodyOwnerKind::Fn if matches!(self.tcx.trait_of_item(def_id.to_def_id()), Some(trait_id) if self.tcx.has_attr(trait_id, sym::const_trait)) => {
                 ConstContext::ConstFn
             }
             BodyOwnerKind::Fn | BodyOwnerKind::Closure => return None,

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -2301,6 +2301,11 @@ impl<'tcx> TyCtxt<'tcx> {
         matches!(self.def_kind(def_id), DefKind::Fn | DefKind::AssocFn | DefKind::Ctor(..))
             && self.impl_constness(def_id) == hir::Constness::Const
     }
+
+    #[inline]
+    pub fn is_const_default_method(self, def_id: DefId) -> bool {
+        matches!(self.trait_of_item(def_id), Some(trait_id) if self.has_attr(trait_id, sym::const_trait))
+    }
 }
 
 /// Yields the parent function's `LocalDefId` if `def_id` is an `impl Trait` definition.

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -2181,7 +2181,7 @@ impl CheckAttrVisitor<'_> {
                 attr.name_or_empty()
             )
         } else if attr.name_or_empty() == sym::default_method_body_is_const {
-            format!("`default_method_body_is_const` has been removed")
+            format!("`default_method_body_is_const` has been replaced with `#[const_trait]` on traits")
         } else {
             return;
         };

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -121,9 +121,7 @@ impl CheckAttrVisitor<'_> {
                 | sym::rustc_if_this_changed
                 | sym::rustc_then_this_would_need => self.check_rustc_dirty_clean(&attr),
                 sym::cmse_nonsecure_entry => self.check_cmse_nonsecure_entry(attr, span, target),
-                sym::default_method_body_is_const => {
-                    self.check_default_method_body_is_const(attr, span, target)
-                }
+                sym::const_trait => self.check_const_trait(attr, span, target),
                 sym::must_not_suspend => self.check_must_not_suspend(&attr, span, target),
                 sym::must_use => self.check_must_use(hir_id, &attr, span, target),
                 sym::rustc_pass_by_value => self.check_pass_by_value(&attr, span, target),
@@ -2081,23 +2079,14 @@ impl CheckAttrVisitor<'_> {
         }
     }
 
-    /// default_method_body_is_const should only be applied to trait methods with default bodies.
-    fn check_default_method_body_is_const(
-        &self,
-        attr: &Attribute,
-        span: Span,
-        target: Target,
-    ) -> bool {
+    /// `#[const_trait]` only applies to traits.
+    fn check_const_trait(&self, attr: &Attribute, _span: Span, target: Target) -> bool {
         match target {
-            Target::Method(MethodKind::Trait { body: true }) => true,
+            Target::Trait => true,
             _ => {
                 self.tcx
                     .sess
-                    .struct_span_err(
-                        attr.span,
-                        "attribute should be applied to a trait method with body",
-                    )
-                    .span_label(span, "not a trait method or missing a body")
+                    .struct_span_err(attr.span, "attribute should be applied to a trait")
                     .emit();
                 false
             }
@@ -2191,6 +2180,8 @@ impl CheckAttrVisitor<'_> {
                 "attribute `{}` without any lints has no effect",
                 attr.name_or_empty()
             )
+        } else if attr.name_or_empty() == sym::default_method_body_is_const {
+            format!("`default_method_body_is_const` has been removed")
         } else {
             return;
         };

--- a/compiler/rustc_passes/src/check_const.rs
+++ b/compiler/rustc_passes/src/check_const.rs
@@ -13,7 +13,6 @@ use rustc_hir as hir;
 use rustc_hir::def_id::LocalDefId;
 use rustc_hir::intravisit::{self, Visitor};
 use rustc_middle::hir::nested_filter;
-use rustc_middle::ty;
 use rustc_middle::ty::query::Providers;
 use rustc_middle::ty::TyCtxt;
 use rustc_session::parse::feature_err;
@@ -62,66 +61,6 @@ fn check_mod_const_bodies(tcx: TyCtxt<'_>, module_def_id: LocalDefId) {
 
 pub(crate) fn provide(providers: &mut Providers) {
     *providers = Providers { check_mod_const_bodies, ..*providers };
-}
-
-fn check_item<'tcx>(tcx: TyCtxt<'tcx>, item: &'tcx hir::Item<'tcx>) {
-    let _: Option<_> = try {
-        if let hir::ItemKind::Impl(ref imp) = item.kind && let hir::Constness::Const = imp.constness {
-            let trait_def_id = imp.of_trait.as_ref()?.trait_def_id()?;
-            let ancestors = tcx
-                .trait_def(trait_def_id)
-                .ancestors(tcx, item.def_id.to_def_id())
-                .ok()?;
-            let mut to_implement = Vec::new();
-
-            for trait_item in tcx.associated_items(trait_def_id).in_definition_order()
-            {
-                if let ty::AssocItem {
-                    kind: ty::AssocKind::Fn,
-                    defaultness,
-                    def_id: trait_item_id,
-                    ..
-                } = *trait_item
-                {
-                    // we can ignore functions that do not have default bodies:
-                    // if those are unimplemented it will be caught by typeck.
-                    if !defaultness.has_value()
-                        || tcx
-                        .has_attr(trait_item_id, sym::default_method_body_is_const)
-                    {
-                        continue;
-                    }
-
-                    let is_implemented = ancestors
-                        .leaf_def(tcx, trait_item_id)
-                        .map(|node_item| !node_item.defining_node.is_from_trait())
-                        .unwrap_or(false);
-
-                    if !is_implemented {
-                        to_implement.push(trait_item_id);
-                    }
-                }
-            }
-
-            // all nonconst trait functions (not marked with #[default_method_body_is_const])
-            // must be implemented
-            if !to_implement.is_empty() {
-                let not_implemented = to_implement
-                    .into_iter()
-                    .map(|did| tcx.item_name(did).to_string())
-                    .collect::<Vec<_>>()
-                    .join("`, `");
-                tcx
-                    .sess
-                    .struct_span_err(
-                        item.span,
-                        "const trait implementations may not use non-const default functions",
-                    )
-                    .note(&format!("`{}` not implemented", not_implemented))
-                    .emit();
-            }
-        }
-    };
 }
 
 #[derive(Copy, Clone)]
@@ -254,7 +193,6 @@ impl<'tcx> Visitor<'tcx> for CheckConstVisitor<'tcx> {
 
     fn visit_item(&mut self, item: &'tcx hir::Item<'tcx>) {
         intravisit::walk_item(self, item);
-        check_item(self.tcx, item);
     }
 
     fn visit_anon_const(&mut self, anon: &'tcx hir::AnonConst) {

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -504,6 +504,7 @@ symbols! {
         const_raw_ptr_deref,
         const_raw_ptr_to_usize_cast,
         const_refs_to_cell,
+        const_trait,
         const_trait_bound_opt_out,
         const_trait_impl,
         const_transmute,

--- a/compiler/rustc_ty_utils/src/ty.rs
+++ b/compiler/rustc_ty_utils/src/ty.rs
@@ -152,9 +152,7 @@ fn param_env(tcx: TyCtxt<'_>, def_id: DefId) -> ty::ParamEnv<'_> {
 
     let constness = match hir_id {
         Some(hir_id) => match tcx.hir().get(hir_id) {
-            hir::Node::TraitItem(hir::TraitItem { kind: hir::TraitItemKind::Fn(..), .. })
-                if tcx.has_attr(def_id, sym::default_method_body_is_const) =>
-            {
+            hir::Node::TraitItem(hir::TraitItem { kind: hir::TraitItemKind::Fn(..), .. }) if matches!(tcx.trait_of_item(def_id), Some(trait_id) if tcx.has_attr(trait_id, sym::const_trait)) => {
                 hir::Constness::Const
             }
 

--- a/compiler/rustc_ty_utils/src/ty.rs
+++ b/compiler/rustc_ty_utils/src/ty.rs
@@ -5,7 +5,7 @@ use rustc_middle::ty::subst::Subst;
 use rustc_middle::ty::{
     self, Binder, EarlyBinder, Predicate, PredicateKind, ToPredicate, Ty, TyCtxt,
 };
-use rustc_span::{sym, Span};
+use rustc_span::Span;
 use rustc_trait_selection::traits;
 
 fn sized_constraint_for_ty<'tcx>(
@@ -152,7 +152,9 @@ fn param_env(tcx: TyCtxt<'_>, def_id: DefId) -> ty::ParamEnv<'_> {
 
     let constness = match hir_id {
         Some(hir_id) => match tcx.hir().get(hir_id) {
-            hir::Node::TraitItem(hir::TraitItem { kind: hir::TraitItemKind::Fn(..), .. }) if matches!(tcx.trait_of_item(def_id), Some(trait_id) if tcx.has_attr(trait_id, sym::const_trait)) => {
+            hir::Node::TraitItem(hir::TraitItem { kind: hir::TraitItemKind::Fn(..), .. })
+                if tcx.is_const_default_method(def_id) =>
+            {
                 hir::Constness::Const
             }
 

--- a/library/core/src/clone.rs
+++ b/library/core/src/clone.rs
@@ -107,6 +107,7 @@ use crate::marker::Destruct;
 #[lang = "clone"]
 #[rustc_diagnostic_item = "Clone"]
 #[rustc_trivial_field_reads]
+#[cfg_attr(not(bootstrap), const_trait)]
 pub trait Clone: Sized {
     /// Returns a copy of the value.
     ///
@@ -129,7 +130,7 @@ pub trait Clone: Sized {
     /// allocations.
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[default_method_body_is_const]
+    #[cfg_attr(bootstrap, default_method_body_is_const)]
     fn clone_from(&mut self, source: &Self)
     where
         Self: ~const Destruct,

--- a/library/core/src/cmp.rs
+++ b/library/core/src/cmp.rs
@@ -214,6 +214,7 @@ use self::Ordering::*;
         append_const_msg,
     )
 )]
+#[cfg_attr(not(bootstrap), const_trait)]
 #[rustc_diagnostic_item = "PartialEq"]
 pub trait PartialEq<Rhs: ?Sized = Self> {
     /// This method tests for `self` and `other` values to be equal, and is used
@@ -226,7 +227,7 @@ pub trait PartialEq<Rhs: ?Sized = Self> {
     #[inline]
     #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[default_method_body_is_const]
+    #[cfg_attr(bootstrap, default_method_body_is_const)]
     fn ne(&self, other: &Rhs) -> bool {
         !self.eq(other)
     }
@@ -1053,6 +1054,7 @@ impl PartialOrd for Ordering {
         append_const_msg,
     )
 )]
+#[cfg_attr(not(bootstrap), const_trait)]
 #[rustc_diagnostic_item = "PartialOrd"]
 pub trait PartialOrd<Rhs: ?Sized = Self>: PartialEq<Rhs> {
     /// This method returns an ordering between `self` and `other` values if one exists.
@@ -1096,7 +1098,7 @@ pub trait PartialOrd<Rhs: ?Sized = Self>: PartialEq<Rhs> {
     #[inline]
     #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[default_method_body_is_const]
+    #[cfg_attr(bootstrap, default_method_body_is_const)]
     fn lt(&self, other: &Rhs) -> bool {
         matches!(self.partial_cmp(other), Some(Less))
     }
@@ -1116,7 +1118,7 @@ pub trait PartialOrd<Rhs: ?Sized = Self>: PartialEq<Rhs> {
     #[inline]
     #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[default_method_body_is_const]
+    #[cfg_attr(bootstrap, default_method_body_is_const)]
     fn le(&self, other: &Rhs) -> bool {
         // Pattern `Some(Less | Eq)` optimizes worse than negating `None | Some(Greater)`.
         // FIXME: The root cause was fixed upstream in LLVM with:
@@ -1139,7 +1141,7 @@ pub trait PartialOrd<Rhs: ?Sized = Self>: PartialEq<Rhs> {
     #[inline]
     #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[default_method_body_is_const]
+    #[cfg_attr(bootstrap, default_method_body_is_const)]
     fn gt(&self, other: &Rhs) -> bool {
         matches!(self.partial_cmp(other), Some(Greater))
     }
@@ -1159,7 +1161,7 @@ pub trait PartialOrd<Rhs: ?Sized = Self>: PartialEq<Rhs> {
     #[inline]
     #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[default_method_body_is_const]
+    #[cfg_attr(bootstrap, default_method_body_is_const)]
     fn ge(&self, other: &Rhs) -> bool {
         matches!(self.partial_cmp(other), Some(Greater | Equal))
     }

--- a/src/test/rustdoc/rfc-2632-const-trait-impl.rs
+++ b/src/test/rustdoc/rfc-2632-const-trait-impl.rs
@@ -16,12 +16,12 @@ pub struct S<T>(T);
 // @has - '//pre[@class="rust trait"]/code/a[@class="trait"]' 'Clone'
 // @!has - '//pre[@class="rust trait"]/code/span[@class="where"]' '~const'
 // @has - '//pre[@class="rust trait"]/code/span[@class="where"]' ': Clone'
+#[const_trait]
 pub trait Tr<T> {
     // @!has - '//div[@id="method.a"]/h4[@class="code-header"]' '~const'
     // @has - '//div[@id="method.a"]/h4[@class="code-header"]/a[@class="trait"]' 'Clone'
     // @!has - '//div[@id="method.a"]/h4[@class="code-header"]/span[@class="where"]' '~const'
     // @has - '//div[@id="method.a"]/h4[@class="code-header"]/span[@class="where fmt-newline"]' ': Clone'
-    #[default_method_body_is_const]
     fn a<A: ~const Clone + ~const Destruct>()
     where
         Option<A>: ~const Clone + ~const Destruct,

--- a/src/test/ui/rfc-2632-const-trait-impl/attr-misuse.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/attr-misuse.rs
@@ -1,13 +1,10 @@
 #![feature(const_trait_impl)]
 
-#[default_method_body_is_const] //~ ERROR attribute should be applied
+#[const_trait]
 trait A {
-    #[default_method_body_is_const] //~ ERROR attribute should be applied
-    fn no_body(self);
-
-    #[default_method_body_is_const]
-    fn correct_use(&self) {}
+    #[const_trait] //~ ERROR attribute should be applied
+    fn foo(self);
 }
 
-#[default_method_body_is_const] //~ ERROR attribute should be applied
+#[const_trait] //~ ERROR attribute should be applied
 fn main() {}

--- a/src/test/ui/rfc-2632-const-trait-impl/attr-misuse.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/attr-misuse.stderr
@@ -1,32 +1,14 @@
-error: attribute should be applied to a trait method with body
-  --> $DIR/attr-misuse.rs:3:1
+error: attribute should be applied to a trait
+  --> $DIR/attr-misuse.rs:9:1
    |
-LL |   #[default_method_body_is_const]
-   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-LL | / trait A {
-LL | |     #[default_method_body_is_const]
-LL | |     fn no_body(self);
-LL | |
-LL | |     #[default_method_body_is_const]
-LL | |     fn correct_use(&self) {}
-LL | | }
-   | |_- not a trait method or missing a body
+LL | #[const_trait]
+   | ^^^^^^^^^^^^^^
 
-error: attribute should be applied to a trait method with body
-  --> $DIR/attr-misuse.rs:12:1
-   |
-LL | #[default_method_body_is_const]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-LL | fn main() {}
-   | ------------ not a trait method or missing a body
-
-error: attribute should be applied to a trait method with body
+error: attribute should be applied to a trait
   --> $DIR/attr-misuse.rs:5:5
    |
-LL |     #[default_method_body_is_const]
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-LL |     fn no_body(self);
-   |     ----------------- not a trait method or missing a body
+LL |     #[const_trait]
+   |     ^^^^^^^^^^^^^^
 
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 

--- a/src/test/ui/rfc-2632-const-trait-impl/auxiliary/cross-crate.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/auxiliary/cross-crate.rs
@@ -1,7 +1,7 @@
 #![feature(const_trait_impl)]
 
+#[const_trait]
 pub trait MyTrait {
-    #[default_method_body_is_const]
     fn defaulted_func(&self) {}
     fn func(self);
 }

--- a/src/test/ui/rfc-2632-const-trait-impl/const-and-non-const-impl.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/const-and-non-const-impl.rs
@@ -2,7 +2,7 @@
 
 pub struct Int(i32);
 
-impl const std::ops::Add for i32 { //~ ERROR type annotations needed
+impl const std::ops::Add for i32 {
     //~^ ERROR only traits defined in the current crate can be implemented for primitive types
     type Output = Self;
 
@@ -11,7 +11,7 @@ impl const std::ops::Add for i32 { //~ ERROR type annotations needed
     }
 }
 
-impl std::ops::Add for Int { //~ ERROR type annotations needed
+impl std::ops::Add for Int {
     type Output = Self;
 
     fn add(self, rhs: Self) -> Self {
@@ -19,7 +19,7 @@ impl std::ops::Add for Int { //~ ERROR type annotations needed
     }
 }
 
-impl const std::ops::Add for Int { //~ ERROR type annotations needed
+impl const std::ops::Add for Int {
     //~^ ERROR conflicting implementations of trait
     type Output = Self;
 

--- a/src/test/ui/rfc-2632-const-trait-impl/const-and-non-const-impl.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/const-and-non-const-impl.stderr
@@ -19,50 +19,7 @@ LL | impl std::ops::Add for Int {
 LL | impl const std::ops::Add for Int {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `Int`
 
-error[E0283]: type annotations needed
-  --> $DIR/const-and-non-const-impl.rs:5:12
-   |
-LL | impl const std::ops::Add for i32 {
-   |            ^^^^^^^^^^^^^ cannot infer type for type `i32`
-   |
-note: multiple `impl`s satisfying `i32: Add` found
-  --> $DIR/const-and-non-const-impl.rs:5:1
-   |
-LL | impl const std::ops::Add for i32 {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: and another `impl` found in the `core` crate: `impl Add for i32;`
+error: aborting due to 2 previous errors
 
-error[E0283]: type annotations needed
-  --> $DIR/const-and-non-const-impl.rs:14:6
-   |
-LL | impl std::ops::Add for Int {
-   |      ^^^^^^^^^^^^^ cannot infer type for struct `Int`
-   |
-note: multiple `impl`s satisfying `Int: Add` found
-  --> $DIR/const-and-non-const-impl.rs:14:1
-   |
-LL | impl std::ops::Add for Int {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
-...
-LL | impl const std::ops::Add for Int {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error[E0283]: type annotations needed
-  --> $DIR/const-and-non-const-impl.rs:22:12
-   |
-LL | impl const std::ops::Add for Int {
-   |            ^^^^^^^^^^^^^ cannot infer type for struct `Int`
-   |
-note: multiple `impl`s satisfying `Int: Add` found
-  --> $DIR/const-and-non-const-impl.rs:14:1
-   |
-LL | impl std::ops::Add for Int {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
-...
-LL | impl const std::ops::Add for Int {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: aborting due to 5 previous errors
-
-Some errors have detailed explanations: E0117, E0119, E0283.
+Some errors have detailed explanations: E0117, E0119.
 For more information about an error, try `rustc --explain E0117`.

--- a/src/test/ui/rfc-2632-const-trait-impl/const-default-method-bodies.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/const-default-method-bodies.rs
@@ -1,9 +1,9 @@
 #![feature(const_trait_impl)]
 
+#[const_trait]
 trait ConstDefaultFn: Sized {
     fn b(self);
 
-    #[default_method_body_is_const]
     fn a(self) {
         self.b();
     }

--- a/src/test/ui/rfc-2632-const-trait-impl/cross-crate-default-method-body-is-const.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/cross-crate-default-method-body-is-const.rs
@@ -1,4 +1,4 @@
-// This tests that `default_method_body_is_const` methods can
+// This tests that `const_trait` default methods can
 // be called from a const context when used across crates.
 //
 // check-pass

--- a/src/test/ui/rfc-2632-const-trait-impl/default-method-body-is-const-body-checking.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/default-method-body-is-const-body-checking.rs
@@ -5,8 +5,8 @@ impl Tr for () {}
 
 const fn foo<T>() where T: ~const Tr {}
 
+#[const_trait]
 pub trait Foo {
-    #[default_method_body_is_const]
     fn foo() {
         foo::<()>();
         //~^ ERROR the trait bound `(): ~const Tr` is not satisfied

--- a/src/test/ui/rfc-2632-const-trait-impl/default-method-body-is-const-same-trait-ck.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/default-method-body-is-const-same-trait-ck.rs
@@ -1,10 +1,9 @@
 #![feature(const_trait_impl)]
 
+#[const_trait]
 pub trait Tr {
-    #[default_method_body_is_const]
     fn a(&self) {}
 
-    #[default_method_body_is_const]
     fn b(&self) {
         ().a()
         //~^ ERROR the trait bound

--- a/src/test/ui/rfc-2632-const-trait-impl/default-method-body-is-const-same-trait-ck.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/default-method-body-is-const-same-trait-ck.stderr
@@ -1,17 +1,17 @@
 error[E0277]: the trait bound `(): ~const Tr` is not satisfied
-  --> $DIR/default-method-body-is-const-same-trait-ck.rs:9:12
+  --> $DIR/default-method-body-is-const-same-trait-ck.rs:8:12
    |
 LL |         ().a()
    |            ^^^ the trait `~const Tr` is not implemented for `()`
    |
 note: the trait `Tr` is implemented for `()`, but that implementation is not `const`
-  --> $DIR/default-method-body-is-const-same-trait-ck.rs:9:12
+  --> $DIR/default-method-body-is-const-same-trait-ck.rs:8:12
    |
 LL |         ().a()
    |            ^^^
 
 error[E0015]: cannot call non-const fn `<() as Tr>::a` in constant functions
-  --> $DIR/default-method-body-is-const-same-trait-ck.rs:9:12
+  --> $DIR/default-method-body-is-const-same-trait-ck.rs:8:12
    |
 LL |         ().a()
    |            ^^^

--- a/src/test/ui/rfc-2632-const-trait-impl/default-method-body-is-const-with-staged-api.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/default-method-body-is-const-with-staged-api.rs
@@ -9,8 +9,8 @@
 #![feature(const_trait_impl)]
 #![stable(since = "1", feature = "foo")]
 
+#[const_trait]
 trait Tr {
-    #[default_method_body_is_const]
     fn a() {}
 }
 

--- a/src/test/ui/rfc-2632-const-trait-impl/impl-with-default-fn-fail.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/impl-with-default-fn-fail.rs
@@ -1,32 +1,17 @@
 #![feature(const_trait_impl)]
 
+#[const_trait]
 trait Tr {
     fn req(&self);
 
-    fn prov(&self) {
-        println!("lul");
-        self.req();
-    }
-
-    #[default_method_body_is_const]
     fn default() {}
 }
 
 struct S;
 
-impl const Tr for S {
-    fn req(&self) {}
-} //~^^ ERROR const trait implementations may not use non-const default functions
-
 impl const Tr for u16 {
-    fn prov(&self) {}
     fn default() {}
-} //~^^^ ERROR not all trait items implemented
+} //~^^ ERROR not all trait items implemented
 
-
-impl const Tr for u32 {
-    fn req(&self) {}
-    fn default() {}
-} //~^^^ ERROR const trait implementations may not use non-const default functions
 
 fn main() {}

--- a/src/test/ui/rfc-2632-const-trait-impl/impl-with-default-fn-fail.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/impl-with-default-fn-fail.stderr
@@ -1,26 +1,5 @@
-error: const trait implementations may not use non-const default functions
-  --> $DIR/impl-with-default-fn-fail.rs:17:1
-   |
-LL | / impl const Tr for S {
-LL | |     fn req(&self) {}
-LL | | }
-   | |_^
-   |
-   = note: `prov` not implemented
-
-error: const trait implementations may not use non-const default functions
-  --> $DIR/impl-with-default-fn-fail.rs:27:1
-   |
-LL | / impl const Tr for u32 {
-LL | |     fn req(&self) {}
-LL | |     fn default() {}
-LL | | }
-   | |_^
-   |
-   = note: `prov` not implemented
-
 error[E0046]: not all trait items implemented, missing: `req`
-  --> $DIR/impl-with-default-fn-fail.rs:21:1
+  --> $DIR/impl-with-default-fn-fail.rs:12:1
    |
 LL |     fn req(&self);
    |     -------------- `req` from trait
@@ -28,6 +7,6 @@ LL |     fn req(&self);
 LL | impl const Tr for u16 {
    | ^^^^^^^^^^^^^^^^^^^^^ missing `req` in implementation
 
-error: aborting due to 3 previous errors
+error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0046`.

--- a/src/test/ui/rfc-2632-const-trait-impl/impl-with-default-fn-pass.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/impl-with-default-fn-pass.rs
@@ -2,28 +2,21 @@
 
 #![feature(const_trait_impl)]
 
+#[const_trait]
 trait Tr {
     fn req(&self);
 
-    fn prov(&self) {
-        println!("lul");
-        self.req();
-    }
-
-    #[default_method_body_is_const]
     fn default() {}
 }
 
 impl const Tr for u8 {
     fn req(&self) {}
-    fn prov(&self) {}
 }
 
 macro_rules! impl_tr {
     ($ty: ty) => {
         impl const Tr for $ty {
             fn req(&self) {}
-            fn prov(&self) {}
         }
     }
 }

--- a/src/test/ui/rfc-2632-const-trait-impl/trait-default-body-stability.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/trait-default-body-stability.rs
@@ -37,8 +37,8 @@ impl const FromResidual for T {
 }
 
 #[stable(feature = "foo", since = "1.0")]
+#[const_trait]
 pub trait Tr {
-    #[default_method_body_is_const]
     #[stable(feature = "foo", since = "1.0")]
     fn bar() -> T {
         T?

--- a/src/test/ui/rfc-2632-const-trait-impl/trait-where-clause-run.rs
+++ b/src/test/ui/rfc-2632-const-trait-impl/trait-where-clause-run.rs
@@ -6,8 +6,8 @@ trait Bar {
     fn bar() -> u8;
 }
 
+#[const_trait]
 trait Foo {
-    #[default_method_body_is_const]
     fn foo() -> u8 where Self: ~const Bar {
         <Self as Bar>::bar() * 6
     }


### PR DESCRIPTION
pulled out of #96077

related issues:  #67792 and #92158

cc @fee1-dead 

This is groundwork to only allowing `impl const Trait` for traits that are marked with `#[const_trait]`. This is necessary to prevent adding a new default method from becoming a breaking change (as it could be a non-const fn).