### PR TITLE
[CI] Build ninja on Linux Docker CI builds

### DIFF
--- a/src/ci/docker/host-x86_64/dist-x86_64-linux/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-x86_64-linux/Dockerfile
@@ -125,7 +125,7 @@ ENV RUST_CONFIGURE_ARGS \
       --set target.x86_64-unknown-linux-gnu.ar=/rustroot/bin/llvm-ar \
       --set target.x86_64-unknown-linux-gnu.ranlib=/rustroot/bin/llvm-ranlib \
       --set llvm.thin-lto=true \
-      --set llvm.ninja=false \
+      --set llvm.ninja=true \
       --set rust.jemalloc
 ENV SCRIPT ../src/ci/pgo.sh python3 ../x.py dist \
     --host $HOSTS --target $HOSTS \

--- a/src/ci/docker/host-x86_64/dist-x86_64-linux/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-x86_64-linux/Dockerfile
@@ -98,6 +98,10 @@ COPY host-x86_64/dist-x86_64-linux/build-clang.sh /tmp/
 RUN ./build-clang.sh
 ENV CC=clang CXX=clang++
 
+# Build Ninja for faster LLVM builds.
+COPY host-x86_64/dist-x86_64-linux/build-ninja.sh /tmp/
+RUN ./build-ninja.sh
+
 # rustc-perf version from 2022-04-05
 ENV PERF_COMMIT 04fccd80396f954b339c366e30221f4bd52c5e03
 RUN curl -LS -o perf.zip https://github.com/rust-lang/rustc-perf/archive/$PERF_COMMIT.zip && \

--- a/src/ci/docker/host-x86_64/dist-x86_64-linux/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-x86_64-linux/Dockerfile
@@ -88,7 +88,7 @@ COPY host-x86_64/dist-x86_64-linux/build-python.sh /tmp/
 # Build Python 3 needed for LLVM 12.
 RUN ./build-python.sh 3.9.1
 
-# LLVM needs cmake 3.13.4 or higher.
+# Ninja needs cmake 3.15 or higher.
 COPY host-x86_64/dist-x86_64-linux/build-cmake.sh /tmp/
 RUN ./build-cmake.sh
 

--- a/src/ci/docker/host-x86_64/dist-x86_64-linux/build-cmake.sh
+++ b/src/ci/docker/host-x86_64/dist-x86_64-linux/build-cmake.sh
@@ -3,7 +3,7 @@
 set -ex
 source shared.sh
 
-CMAKE=3.13.4
+CMAKE=3.15.6
 curl -L https://github.com/Kitware/CMake/releases/download/v$CMAKE/cmake-$CMAKE.tar.gz | tar xzf -
 
 mkdir cmake-build

--- a/src/ci/docker/host-x86_64/dist-x86_64-linux/build-ninja.sh
+++ b/src/ci/docker/host-x86_64/dist-x86_64-linux/build-ninja.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -ex
+
+source shared.sh
+
+NINJA=v1.10.2
+
+mkdir ninja
+cd ninja
+
+curl -L https://github.com/ninja-build/ninja/archive/refs/tags/$NINJA.tar.gz | \
+  tar xzf - --strip-components 1
+
+mkdir ninja-build
+cd ninja-build
+
+hide_output cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/rustroot
+
+hide_output make -j$(nproc)
+hide_output make install
+
+cd ../..
+rm -rf ninja


### PR DESCRIPTION
I want to test if/how much using `ninja` instead of `make` speeds up `try`/`dist` Linux CI builds. They rebuild LLVM several times, so it could be worth it.