### PR TITLE
Forbid lifetime bounds in nested opaque types in binders

### DIFF
--- a/src/test/ui/associated-type-bounds/rpit.rs
+++ b/src/test/ui/associated-type-bounds/rpit.rs
@@ -1,5 +1,3 @@
-// run-pass
-
 #![feature(associated_type_bounds)]
 
 use std::ops::Add;
@@ -42,6 +40,7 @@ pub fn use_et3() {
 }
 
 fn def_et4() -> impl Tr1<As1: for<'a> Tr2<'a>> {
+    //~^ ERROR lifetime bounds on nested opaque types are not supported yet
     #[derive(Copy, Clone)]
     struct A;
     impl Tr1 for A {

--- a/src/test/ui/associated-type-bounds/rpit.stderr
+++ b/src/test/ui/associated-type-bounds/rpit.stderr
@@ -1,0 +1,10 @@
+error: higher kinded lifetime bounds on nested opaque types are not supported yet
+  --> $DIR/rpit.rs:42:43
+   |
+LL | fn def_et4() -> impl Tr1<As1: for<'a> Tr2<'a>> {
+   |                                           ^^
+   |
+   = help: See https://github.com/rust-lang/rust/issues/96194 for further details
+
+error: aborting due to previous error
+

--- a/src/test/ui/impl-trait/issues/issue-54895.rs
+++ b/src/test/ui/impl-trait/issues/issue-54895.rs
@@ -1,5 +1,3 @@
-// check-pass
-
 trait Trait<'a> {
     type Out;
     fn call(&'a self) -> Self::Out;
@@ -15,6 +13,7 @@ impl<'a> Trait<'a> for X {
 }
 
 fn f() -> impl for<'a> Trait<'a, Out = impl Sized + 'a> {
+    //~^ ERROR lifetime bounds on nested opaque types are not supported yet
     X(())
 }
 

--- a/src/test/ui/impl-trait/issues/issue-54895.stderr
+++ b/src/test/ui/impl-trait/issues/issue-54895.stderr
@@ -1,0 +1,10 @@
+error: higher kinded lifetime bounds on nested opaque types are not supported yet
+  --> $DIR/issue-54895.rs:15:53
+   |
+LL | fn f() -> impl for<'a> Trait<'a, Out = impl Sized + 'a> {
+   |                                                     ^^
+   |
+   = help: See https://github.com/rust-lang/rust/issues/96194 for further details
+
+error: aborting due to previous error
+

--- a/src/test/ui/impl-trait/issues/issue-67830.rs
+++ b/src/test/ui/impl-trait/issues/issue-67830.rs
@@ -20,6 +20,7 @@ where
 struct A;
 fn test() -> impl for<'a> MyFn<&'a A, Output=impl Iterator + 'a> {
     //~^ ERROR implementation of `FnOnce` is not general enough
+    //~| ERROR lifetime bounds on nested opaque types are not supported yet
     Wrap(|a| Some(a).into_iter())
 }
 

--- a/src/test/ui/impl-trait/issues/issue-67830.stderr
+++ b/src/test/ui/impl-trait/issues/issue-67830.stderr
@@ -1,3 +1,11 @@
+error: higher kinded lifetime bounds on nested opaque types are not supported yet
+  --> $DIR/issue-67830.rs:21:62
+   |
+LL | fn test() -> impl for<'a> MyFn<&'a A, Output=impl Iterator + 'a> {
+   |                                                              ^^
+   |
+   = help: See https://github.com/rust-lang/rust/issues/96194 for further details
+
 error: implementation of `FnOnce` is not general enough
   --> $DIR/issue-67830.rs:21:14
    |
@@ -7,5 +15,5 @@ LL | fn test() -> impl for<'a> MyFn<&'a A, Output=impl Iterator + 'a> {
    = note: closure with signature `fn(&'2 A) -> std::option::IntoIter<&A>` must implement `FnOnce<(&'1 A,)>`, for any lifetime `'1`...
    = note: ...but it actually implements `FnOnce<(&'2 A,)>`, for some specific lifetime `'2`
 
-error: aborting due to previous error
+error: aborting due to 2 previous errors
 

--- a/src/test/ui/impl-trait/issues/issue-88236-2.rs
+++ b/src/test/ui/impl-trait/issues/issue-88236-2.rs
@@ -13,11 +13,23 @@ impl<'a> Hrtb<'a> for &'a () {
 }
 
 fn make_impl() -> impl for<'a> Hrtb<'a, Assoc = impl Send + 'a> {}
+//~^ ERROR lifetime bounds on nested opaque types are not supported yet
 fn make_weird_impl<'b>(x: &'b ()) -> impl for<'a> Hrtb<'a, Assoc = impl Send + 'a> {
     &() //~^ ERROR implementation of `Hrtb` is not general enough
+    //~| ERROR lifetime bounds on nested opaque types are not supported yet
 }
 fn make_bad_impl<'b>(x: &'b ()) -> impl for<'a> Hrtb<'a, Assoc = impl Send + 'a> {
     x //~^ ERROR implementation of `Hrtb` is not general enough
+    //~| ERROR lifetime bounds on nested opaque types are not supported yet
+}
+
+trait Zend<'a>: Send {}
+
+impl<'a, T: Send> Zend<'a> for T {}
+
+fn make_bad_impl_2<'b>(x: &'b ()) -> impl for<'a> Hrtb<'a, Assoc = impl Zend<'a>> {
+    x //~^ ERROR implementation of `Hrtb` is not general enough
+    //~| ERROR lifetime bounds on nested opaque types are not supported yet
 }
 
 fn main() {}

--- a/src/test/ui/impl-trait/issues/issue-88236-2.stderr
+++ b/src/test/ui/impl-trait/issues/issue-88236-2.stderr
@@ -1,5 +1,37 @@
+error: higher kinded lifetime bounds on nested opaque types are not supported yet
+  --> $DIR/issue-88236-2.rs:15:61
+   |
+LL | fn make_impl() -> impl for<'a> Hrtb<'a, Assoc = impl Send + 'a> {}
+   |                                                             ^^
+   |
+   = help: See https://github.com/rust-lang/rust/issues/96194 for further details
+
+error: higher kinded lifetime bounds on nested opaque types are not supported yet
+  --> $DIR/issue-88236-2.rs:17:80
+   |
+LL | fn make_weird_impl<'b>(x: &'b ()) -> impl for<'a> Hrtb<'a, Assoc = impl Send + 'a> {
+   |                                                                                ^^
+   |
+   = help: See https://github.com/rust-lang/rust/issues/96194 for further details
+
+error: higher kinded lifetime bounds on nested opaque types are not supported yet
+  --> $DIR/issue-88236-2.rs:21:78
+   |
+LL | fn make_bad_impl<'b>(x: &'b ()) -> impl for<'a> Hrtb<'a, Assoc = impl Send + 'a> {
+   |                                                                              ^^
+   |
+   = help: See https://github.com/rust-lang/rust/issues/96194 for further details
+
+error: higher kinded lifetime bounds on nested opaque types are not supported yet
+  --> $DIR/issue-88236-2.rs:30:78
+   |
+LL | fn make_bad_impl_2<'b>(x: &'b ()) -> impl for<'a> Hrtb<'a, Assoc = impl Zend<'a>> {
+   |                                                                              ^^
+   |
+   = help: See https://github.com/rust-lang/rust/issues/96194 for further details
+
 error: implementation of `Hrtb` is not general enough
-  --> $DIR/issue-88236-2.rs:16:38
+  --> $DIR/issue-88236-2.rs:17:38
    |
 LL | fn make_weird_impl<'b>(x: &'b ()) -> impl for<'a> Hrtb<'a, Assoc = impl Send + 'a> {
    |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ implementation of `Hrtb` is not general enough
@@ -8,7 +40,7 @@ LL | fn make_weird_impl<'b>(x: &'b ()) -> impl for<'a> Hrtb<'a, Assoc = impl Sen
    = note: ...but `Hrtb<'1>` is actually implemented for the type `&'1 ()`, for some specific lifetime `'1`
 
 error: implementation of `Hrtb` is not general enough
-  --> $DIR/issue-88236-2.rs:19:36
+  --> $DIR/issue-88236-2.rs:21:36
    |
 LL | fn make_bad_impl<'b>(x: &'b ()) -> impl for<'a> Hrtb<'a, Assoc = impl Send + 'a> {
    |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ implementation of `Hrtb` is not general enough
@@ -16,5 +48,14 @@ LL | fn make_bad_impl<'b>(x: &'b ()) -> impl for<'a> Hrtb<'a, Assoc = impl Send 
    = note: `Hrtb<'1>` would have to be implemented for the type `&()`, for any lifetime `'1`...
    = note: ...but `Hrtb<'_>` is actually implemented for the type `&()`
 
-error: aborting due to 2 previous errors
+error: implementation of `Hrtb` is not general enough
+  --> $DIR/issue-88236-2.rs:30:38
+   |
+LL | fn make_bad_impl_2<'b>(x: &'b ()) -> impl for<'a> Hrtb<'a, Assoc = impl Zend<'a>> {
+   |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ implementation of `Hrtb` is not general enough
+   |
+   = note: `Hrtb<'1>` would have to be implemented for the type `&()`, for any lifetime `'1`...
+   = note: ...but `Hrtb<'_>` is actually implemented for the type `&()`
+
+error: aborting due to 7 previous errors
 

--- a/src/test/ui/impl-trait/issues/issue-88236.rs
+++ b/src/test/ui/impl-trait/issues/issue-88236.rs
@@ -1,5 +1,3 @@
-// check-pass
-
 // this used to cause stack overflows
 
 trait Hrtb<'a> {
@@ -15,5 +13,6 @@ impl<'a> Hrtb<'a> for &'a () {
 }
 
 fn make_impl() -> impl for<'a> Hrtb<'a, Assoc = impl Send + 'a> {}
+//~^ ERROR lifetime bounds on nested opaque types are not supported yet
 
 fn main() {}

--- a/src/test/ui/impl-trait/issues/issue-88236.stderr
+++ b/src/test/ui/impl-trait/issues/issue-88236.stderr
@@ -1,0 +1,10 @@
+error: higher kinded lifetime bounds on nested opaque types are not supported yet
+  --> $DIR/issue-88236.rs:15:61
+   |
+LL | fn make_impl() -> impl for<'a> Hrtb<'a, Assoc = impl Send + 'a> {}
+   |                                                             ^^
+   |
+   = help: See https://github.com/rust-lang/rust/issues/96194 for further details
+
+error: aborting due to previous error
+


### PR DESCRIPTION
avoids #96194

Not closing the issue until we have this behind a feature gate and with a corresponding tracking issue.

Since this change is supposed to get backported to beta, I don't want to add a gate and more logic in this PR. Instead, it will happen on a follow up PR solely on nightly.