### PR TITLE
Utilize PGO for windows x64 rustc dist builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -410,7 +410,7 @@ jobs:
           - name: dist-x86_64-msvc
             env:
               RUST_CONFIGURE_ARGS: "--build=x86_64-pc-windows-msvc --host=x86_64-pc-windows-msvc --target=x86_64-pc-windows-msvc --enable-full-tools --enable-profiler"
-              SCRIPT: python x.py dist
+              SCRIPT: PGO_HOST=x86_64-pc-windows-msvc src/ci/pgo.sh python x.py dist
               DIST_REQUIRE_ALL_TOOLS: 1
             os: windows-latest-xl
           - name: dist-i686-msvc

--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -25,6 +25,7 @@ use crate::config::{LlvmLibunwind, TargetSelection};
 use crate::dist;
 use crate::native;
 use crate::tool::SourceType;
+use crate::util::get_clang_cl_resource_dir;
 use crate::util::{exe, is_debug_info, is_dylib, output, symlink_dir, t, up_to_date};
 use crate::LLVM_TOOLS;
 use crate::{CLang, Compiler, DependencyType, GitRepo, Mode};
@@ -769,10 +770,38 @@ pub fn rustc_cargo_env(builder: &Builder<'_>, cargo: &mut Cargo, target: TargetS
         if let Some(s) = target_config.and_then(|c| c.llvm_config.as_ref()) {
             cargo.env("CFG_LLVM_ROOT", s);
         }
-        // Some LLVM linker flags (-L and -l) may be needed to link rustc_llvm.
-        if let Some(ref s) = builder.config.llvm_ldflags {
-            cargo.env("LLVM_LINKER_FLAGS", s);
+
+        // Some LLVM linker flags (-L and -l) may be needed to link `rustc_llvm`. Its build script
+        // expects these to be passed via the `LLVM_LINKER_FLAGS` env variable, separated by
+        // whitespace.
+        //
+        // For example:
+        // - on windows, when `clang-cl` is used with instrumentation, we need to manually add
+        // clang's runtime library resource directory so that the profiler runtime library can be
+        // found. This is to avoid the linker errors about undefined references to
+        // `__llvm_profile_instrument_memop` when linking `rustc_driver`.
+        let mut llvm_linker_flags = String::new();
+        if builder.config.llvm_profile_generate && target.contains("msvc") {
+            if let Some(ref clang_cl_path) = builder.config.llvm_clang_cl {
+                // Add clang's runtime library directory to the search path
+                let clang_rt_dir = get_clang_cl_resource_dir(clang_cl_path);
+                llvm_linker_flags.push_str(&format!("-L{}", clang_rt_dir.display()));
+            }
         }
+
+        // The config can also specify its own llvm linker flags.
+        if let Some(ref s) = builder.config.llvm_ldflags {
+            if !llvm_linker_flags.is_empty() {
+                llvm_linker_flags.push_str(" ");
+            }
+            llvm_linker_flags.push_str(s);
+        }
+
+        // Set the linker flags via the env var that `rustc_llvm`'s build script will read.
+        if !llvm_linker_flags.is_empty() {
+            cargo.env("LLVM_LINKER_FLAGS", llvm_linker_flags);
+        }
+
         // Building with a static libstdc++ is only supported on linux right now,
         // not for MSVC or macOS
         if builder.config.llvm_static_stdcpp

--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -18,6 +18,7 @@ use std::process::Command;
 
 use crate::builder::{Builder, RunConfig, ShouldRun, Step};
 use crate::config::TargetSelection;
+use crate::util::get_clang_cl_resource_dir;
 use crate::util::{self, exe, output, program_out_of_date, t, up_to_date};
 use crate::{CLang, GitRepo};
 
@@ -755,7 +756,22 @@ impl Step for Lld {
         t!(fs::create_dir_all(&out_dir));
 
         let mut cfg = cmake::Config::new(builder.src.join("src/llvm-project/lld"));
-        configure_cmake(builder, target, &mut cfg, true, LdFlags::default());
+        let mut ldflags = LdFlags::default();
+
+        // When building LLD as part of a build with instrumentation on windows, for example
+        // when doing PGO on CI, cmake or clang-cl don't automatically link clang's
+        // profiler runtime in. In that case, we need to manually ask cmake to do it, to avoid
+        // linking errors, much like LLVM's cmake setup does in that situation.
+        if builder.config.llvm_profile_generate && target.contains("msvc") {
+            if let Some(clang_cl_path) = builder.config.llvm_clang_cl.as_ref() {
+                // Find clang's runtime library directory and push that as a search path to the
+                // cmake linker flags.
+                let clang_rt_dir = get_clang_cl_resource_dir(clang_cl_path);
+                ldflags.push_all(&format!("/libpath:{}", clang_rt_dir.display()));
+            }
+        }
+
+        configure_cmake(builder, target, &mut cfg, true, ldflags);
 
         // This is an awful, awful hack. Discovered when we migrated to using
         // clang-cl to compile LLVM/LLD it turns out that LLD, when built out of

--- a/src/ci/docker/host-x86_64/dist-x86_64-linux/build-clang.sh
+++ b/src/ci/docker/host-x86_64/dist-x86_64-linux/build-clang.sh
@@ -4,7 +4,7 @@ set -ex
 
 source shared.sh
 
-LLVM=llvmorg-14.0.2
+LLVM=llvmorg-14.0.5
 
 mkdir llvm-project
 cd llvm-project

--- a/src/ci/github-actions/ci.yml
+++ b/src/ci/github-actions/ci.yml
@@ -625,7 +625,7 @@ jobs:
                 --target=x86_64-pc-windows-msvc
                 --enable-full-tools
                 --enable-profiler
-              SCRIPT: python x.py dist
+              SCRIPT: PGO_HOST=x86_64-pc-windows-msvc src/ci/pgo.sh python x.py dist
               DIST_REQUIRE_ALL_TOOLS: 1
             <<: *job-windows-xl
 

--- a/src/ci/pgo.sh
+++ b/src/ci/pgo.sh
@@ -3,44 +3,69 @@
 
 set -euxo pipefail
 
+ci_dir=`cd $(dirname $0) && pwd`
+source "$ci_dir/shared.sh"
+
+# The root checkout, where the source is located
+CHECKOUT=/checkout
+
+DOWNLOADED_LLVM=/rustroot
+
+# The main directory where the build occurs, which can be different between linux and windows
+BUILD_ROOT=$CHECKOUT/obj
+
+# The various build artifacts used in other commands: to launch rustc builds, build the perf
+# collector, and run benchmarks to gather profiling data
+BUILD_ARTIFACTS=$BUILD_ROOT/build/$PGO_HOST
+RUSTC_STAGE_0=$BUILD_ARTIFACTS/stage0/bin/rustc
+CARGO_STAGE_0=$BUILD_ARTIFACTS/stage0/bin/cargo
+RUSTC_STAGE_2=$BUILD_ARTIFACTS/stage2/bin/rustc
+
+# Make sure we have a temporary PGO work folder
+PGO_TMP=/tmp/tmp-pgo
+mkdir -p $PGO_TMP
+rm -rf $PGO_TMP/*
+
+RUSTC_PERF=$PGO_TMP/rustc-perf
+
 # Compile several crates to gather execution PGO profiles.
 # Arg0 => profiles (Debug, Opt)
 # Arg1 => scenarios (Full, IncrFull, All)
 # Arg2 => crates (syn, cargo, ...)
 gather_profiles () {
-  cd /checkout/obj
+  cd $BUILD_ROOT
 
   # Compile libcore, both in opt-level=0 and opt-level=3
-  RUSTC_BOOTSTRAP=1 ./build/$PGO_HOST/stage2/bin/rustc \
-      --edition=2021 --crate-type=lib ../library/core/src/lib.rs
-  RUSTC_BOOTSTRAP=1 ./build/$PGO_HOST/stage2/bin/rustc \
-      --edition=2021 --crate-type=lib -Copt-level=3 ../library/core/src/lib.rs
+  RUSTC_BOOTSTRAP=1 $RUSTC_STAGE_2 \
+      --edition=2021 --crate-type=lib $CHECKOUT/library/core/src/lib.rs \
+      --out-dir $PGO_TMP
+  RUSTC_BOOTSTRAP=1 $RUSTC_STAGE_2 \
+      --edition=2021 --crate-type=lib -Copt-level=3 $CHECKOUT/library/core/src/lib.rs \
+      --out-dir $PGO_TMP
 
-  cd rustc-perf
+  cd $RUSTC_PERF
 
   # Run rustc-perf benchmarks
   # Benchmark using profile_local with eprintln, which essentially just means
   # don't actually benchmark -- just make sure we run rustc a bunch of times.
   RUST_LOG=collector=debug \
-  RUSTC=/checkout/obj/build/$PGO_HOST/stage0/bin/rustc \
+  RUSTC=$RUSTC_STAGE_0 \
   RUSTC_BOOTSTRAP=1 \
-  /checkout/obj/build/$PGO_HOST/stage0/bin/cargo run -p collector --bin collector -- \
-          profile_local \
-          eprintln \
-          /checkout/obj/build/$PGO_HOST/stage2/bin/rustc \
-          --id Test \
-          --profiles $1 \
-          --cargo /checkout/obj/build/$PGO_HOST/stage0/bin/cargo \
-          --scenarios $2 \
-          --include $3
+  $CARGO_STAGE_0 run -p collector --bin collector -- \
+      profile_local \
+      eprintln \
+      $RUSTC_STAGE_2 \
+      --id Test \
+      --profiles $1 \
+      --cargo $CARGO_STAGE_0 \
+      --scenarios $2 \
+      --include $3
 
-  cd /checkout/obj
+  cd $BUILD_ROOT
 }
 
-rm -rf /tmp/rustc-pgo
-
 # This path has to be absolute
-LLVM_PROFILE_DIRECTORY_ROOT=/tmp/llvm-pgo
+LLVM_PROFILE_DIRECTORY_ROOT=$PGO_TMP/llvm-pgo
 
 # We collect LLVM profiling information and rustc profiling information in
 # separate phases. This increases build time -- though not by a huge amount --
@@ -49,34 +74,34 @@ LLVM_PROFILE_DIRECTORY_ROOT=/tmp/llvm-pgo
 # LLVM IR PGO does not respect LLVM_PROFILE_FILE, so we have to set the profiling file
 # path through our custom environment variable. We include the PID in the directory path
 # to avoid updates to profile files being lost because of race conditions.
-LLVM_PROFILE_DIR=${LLVM_PROFILE_DIRECTORY_ROOT}/prof-%p python3 ../x.py build \
+LLVM_PROFILE_DIR=${LLVM_PROFILE_DIRECTORY_ROOT}/prof-%p python3 $CHECKOUT/x.py build \
     --target=$PGO_HOST \
     --host=$PGO_HOST \
     --stage 2 library/std \
     --llvm-profile-generate
 
 # Compile rustc perf
-cp -r /tmp/rustc-perf ./
-chown -R $(whoami): ./rustc-perf
-cd rustc-perf
+cp -r /tmp/rustc-perf $RUSTC_PERF
+chown -R $(whoami): $RUSTC_PERF
+cd $RUSTC_PERF
 
-# Build the collector ahead of time, which is needed to make sure the rustc-fake
+# Build rustc-perf's collector ahead of time, which is needed to make sure the rustc-fake
 # binary used by the collector is present.
-RUSTC=/checkout/obj/build/$PGO_HOST/stage0/bin/rustc \
+RUSTC=$RUSTC_STAGE_0 \
 RUSTC_BOOTSTRAP=1 \
-/checkout/obj/build/$PGO_HOST/stage0/bin/cargo build -p collector
+$CARGO_STAGE_0 build -p collector
 
 # Here we're profiling LLVM, so we only care about `Debug` and `Opt`, because we want to stress
 # codegen. We also profile some of the most prolific crates.
 gather_profiles "Debug,Opt" "Full" \
-"syn-1.0.89,cargo-0.60.0,serde-1.0.136,ripgrep-13.0.0,regex-1.5.5,clap-3.1.6,hyper-0.14.18"
+    "syn-1.0.89,cargo-0.60.0,serde-1.0.136,ripgrep-13.0.0,regex-1.5.5,clap-3.1.6,hyper-0.14.18"
 
-LLVM_PROFILE_MERGED_FILE=/tmp/llvm-pgo.profdata
+LLVM_PROFILE_MERGED_FILE=$PGO_TMP/llvm-pgo.profdata
 
 # Merge the profile data we gathered for LLVM
 # Note that this uses the profdata from the clang we used to build LLVM,
 # which likely has a different version than our in-tree clang.
-/rustroot/bin/llvm-profdata merge -o ${LLVM_PROFILE_MERGED_FILE} ${LLVM_PROFILE_DIRECTORY_ROOT}
+$DOWNLOADED_LLVM/bin/llvm-profdata merge -o ${LLVM_PROFILE_MERGED_FILE} ${LLVM_PROFILE_DIRECTORY_ROOT}
 
 echo "LLVM PGO statistics"
 du -sh ${LLVM_PROFILE_MERGED_FILE}
@@ -84,17 +109,20 @@ du -sh ${LLVM_PROFILE_DIRECTORY_ROOT}
 echo "Profile file count"
 find ${LLVM_PROFILE_DIRECTORY_ROOT} -type f | wc -l
 
+# We don't need the individual .profraw files now that they have been merged into a final .profdata
+rm -r $LLVM_PROFILE_DIRECTORY_ROOT
+
 # Rustbuild currently doesn't support rebuilding LLVM when PGO options
 # change (or any other llvm-related options); so just clear out the relevant
 # directories ourselves.
-rm -r ./build/$PGO_HOST/llvm ./build/$PGO_HOST/lld
+rm -r $BUILD_ARTIFACTS/llvm $BUILD_ARTIFACTS/lld
 
 # Okay, LLVM profiling is done, switch to rustc PGO.
 
 # The path has to be absolute
-RUSTC_PROFILE_DIRECTORY_ROOT=/tmp/rustc-pgo
+RUSTC_PROFILE_DIRECTORY_ROOT=$PGO_TMP/rustc-pgo
 
-python3 ../x.py build --target=$PGO_HOST --host=$PGO_HOST \
+python3 $CHECKOUT/x.py build --target=$PGO_HOST --host=$PGO_HOST \
     --stage 2 library/std \
     --rust-profile-generate=${RUSTC_PROFILE_DIRECTORY_ROOT}
 
@@ -105,13 +133,13 @@ python3 ../x.py build --target=$PGO_HOST --host=$PGO_HOST \
 # That's why we override the profile path to include the PID. This will produce many more profiling
 # files, but the resulting profile will produce a slightly faster rustc binary.
 LLVM_PROFILE_FILE=${RUSTC_PROFILE_DIRECTORY_ROOT}/default_%m_%p.profraw gather_profiles \
-  "Check,Debug,Opt" "All" \
-  "externs,ctfe-stress-5,cargo-0.60.0,token-stream-stress,match-stress,tuple-stress,diesel-1.4.8,bitmaps-3.1.0"
+    "Check,Debug,Opt" "All" \
+    "externs,ctfe-stress-5,cargo-0.60.0,token-stream-stress,match-stress,tuple-stress,diesel-1.4.8,bitmaps-3.1.0"
 
-RUSTC_PROFILE_MERGED_FILE=/tmp/rustc-pgo.profdata
+RUSTC_PROFILE_MERGED_FILE=$PGO_TMP/rustc-pgo.profdata
 
 # Merge the profile data we gathered
-./build/$PGO_HOST/llvm/bin/llvm-profdata \
+$BUILD_ARTIFACTS/llvm/bin/llvm-profdata \
     merge -o ${RUSTC_PROFILE_MERGED_FILE} ${RUSTC_PROFILE_DIRECTORY_ROOT}
 
 echo "Rustc PGO statistics"
@@ -120,10 +148,13 @@ du -sh ${RUSTC_PROFILE_DIRECTORY_ROOT}
 echo "Profile file count"
 find ${RUSTC_PROFILE_DIRECTORY_ROOT} -type f | wc -l
 
+# We don't need the individual .profraw files now that they have been merged into a final .profdata
+rm -r $RUSTC_PROFILE_DIRECTORY_ROOT
+
 # Rustbuild currently doesn't support rebuilding LLVM when PGO options
 # change (or any other llvm-related options); so just clear out the relevant
 # directories ourselves.
-rm -r ./build/$PGO_HOST/llvm ./build/$PGO_HOST/lld
+rm -r $BUILD_ARTIFACTS/llvm $BUILD_ARTIFACTS/lld
 
 # This produces the actual final set of artifacts, using both the LLVM and rustc
 # collected profiling data.

--- a/src/ci/scripts/install-clang.sh
+++ b/src/ci/scripts/install-clang.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# ignore-tidy-linelength
 # This script installs clang on the local machine. Note that we don't install
 # clang on Linux since its compiler story is just so different. Each container
 # has its own toolchain configured appropriately already.
@@ -9,7 +10,7 @@ IFS=$'\n\t'
 source "$(cd "$(dirname "$0")" && pwd)/../shared.sh"
 
 # Update both macOS's and Windows's tarballs when bumping the version here.
-LLVM_VERSION="14.0.2"
+LLVM_VERSION="14.0.5"
 
 if isMacOS; then
     # If the job selects a specific Xcode version, use that instead of


### PR DESCRIPTION
This PR adds PGO support for the CI x64 windows dist builds.

These are the results from running the rustc-perf benchmarks:
![image](https://user-images.githubusercontent.com/247183/177662869-683a8034-7c95-42bf-9900-9ffd66677fcf.png)


Thanks to @Kobzol, @michaelwoerister, @wesleywiser, @Mark-Simulacrum for their precious help.