### PR TITLE
Add dataflow analysis of enum variants

### DIFF
--- a/compiler/rustc_mir_dataflow/src/framework/fmt.rs
+++ b/compiler/rustc_mir_dataflow/src/framework/fmt.rs
@@ -1,6 +1,7 @@
 //! Custom formatting traits used when outputting Graphviz diagrams with the results of a dataflow
 //! analysis.
 
+use crate::lattice::{FactArray, FactCache};
 use rustc_index::bit_set::{BitSet, ChunkedBitSet, HybridBitSet};
 use rustc_index::vec::Idx;
 use std::fmt;
@@ -121,6 +122,30 @@ where
         }
 
         fmt_diff(&set_in_self, &cleared_in_self, ctxt, f)
+    }
+}
+
+impl<T: Clone + Eq + fmt::Debug, C, const N: usize> DebugWithContext<C> for FactArray<T, N>
+where
+    T: DebugWithContext<C>,
+{
+    fn fmt_with(&self, ctxt: &C, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_map()
+            .entries(
+                self.arr
+                    .iter()
+                    .enumerate()
+                    .map(|(i, ref v)| (i, DebugWithAdapter { this: *v, ctxt })),
+            )
+            .finish()
+    }
+}
+
+impl<I: Eq + fmt::Debug, L: Eq + fmt::Debug, F: Eq + fmt::Debug, C, const N: usize>
+    DebugWithContext<C> for FactCache<I, L, F, N>
+{
+    fn fmt_with(&self, _: &C, _: &mut fmt::Formatter<'_>) -> fmt::Result {
+        todo!();
     }
 }
 

--- a/compiler/rustc_mir_dataflow/src/impls/mod.rs
+++ b/compiler/rustc_mir_dataflow/src/impls/mod.rs
@@ -21,6 +21,7 @@ use crate::{lattice, AnalysisDomain, GenKill, GenKillAnalysis};
 mod borrowed_locals;
 mod init_locals;
 mod liveness;
+mod single_enum_variant;
 mod storage_liveness;
 
 pub use self::borrowed_locals::borrowed_locals;
@@ -28,6 +29,7 @@ pub use self::borrowed_locals::MaybeBorrowedLocals;
 pub use self::init_locals::MaybeInitializedLocals;
 pub use self::liveness::MaybeLiveLocals;
 pub use self::liveness::MaybeTransitiveLiveLocals;
+pub use self::single_enum_variant::SingleEnumVariant;
 pub use self::storage_liveness::{MaybeRequiresStorage, MaybeStorageLive};
 
 /// `MaybeInitializedPlaces` tracks all places that might be

--- a/compiler/rustc_mir_dataflow/src/impls/single_enum_variant.rs
+++ b/compiler/rustc_mir_dataflow/src/impls/single_enum_variant.rs
@@ -1,0 +1,171 @@
+use super::*;
+//use crate::lattice::PackedU8JoinSemiLattice as Fact;
+
+//use crate::lattice::FactArray;
+use crate::lattice::FactCache;
+use rustc_target::abi::VariantIdx;
+
+use rustc_middle::mir::*;
+
+use crate::{Analysis, AnalysisDomain};
+
+/// A dataflow analysis that tracks whether an enum can hold 0, 1, or more than one variants.
+pub struct SingleEnumVariant<'a, 'tcx> {
+    tcx: TyCtxt<'tcx>,
+    body: &'a mir::Body<'tcx>,
+}
+
+impl<'tcx> AnalysisDomain<'tcx> for SingleEnumVariant<'_, 'tcx> {
+    /// For each local, keep track of which enum index it is, if its uninhabited, or unknown.
+    //type Domain = FactArray<Fact, 128>;
+    type Domain = FactCache<Local, Location, VariantIdx, 16>;
+
+    const NAME: &'static str = "single_enum_variant";
+
+    fn bottom_value(&self, _: &mir::Body<'tcx>) -> Self::Domain {
+        //FactArray { arr: [Fact::TOP; 128] }
+        FactCache::new(Local::from_u32(0), Location::START, VariantIdx::MAX)
+    }
+
+    fn initialize_start_block(&self, body: &mir::Body<'tcx>, state: &mut Self::Domain) {
+        // assume everything is top initially.
+        let local_decls = body.local_decls();
+        for (l, _) in local_decls.iter_enumerated() {
+            state.remove(l);
+            //state.insert(l, Fact::TOP);
+            //state[l] = Fact::TOP;
+        }
+    }
+}
+
+impl<'tcx> SingleEnumVariant<'_, 'tcx> {
+    pub fn new<'a>(tcx: TyCtxt<'tcx>, body: &'a mir::Body<'tcx>) -> SingleEnumVariant<'a, 'tcx> {
+        SingleEnumVariant { tcx, body }
+    }
+    #[inline]
+    pub fn is_tracked(&self, place: &Place<'tcx>) -> bool {
+        place.ty(self.body, self.tcx).ty.is_enum()
+    }
+    fn assign(
+        &self,
+        state: &mut <Self as AnalysisDomain<'tcx>>::Domain,
+        lhs: &Place<'tcx>,
+        rhs: &Operand<'tcx>,
+        location: Location,
+    ) {
+        let _: Option<_> = try {
+            if !self.is_tracked(lhs) {
+                return;
+            }
+            let lhs_local = lhs.local_or_deref_local()?;
+
+            let new_fact = match rhs {
+                Operand::Copy(rhs) | Operand::Move(rhs) => {
+                    if let Some(rhs_local) = rhs.local_or_deref_local() {
+                        state.get(rhs_local).map(|f| f.1).copied()
+                    } else {
+                        rhs.ty(self.body, self.tcx).variant_index.map(|var_idx| var_idx)
+                    }
+                }
+                // Assigning a constant does not affect discriminant?
+                Operand::Constant(_c) => return,
+            };
+            if let Some(new_fact) = new_fact {
+                state.insert(lhs_local, location, new_fact);
+            } else {
+                state.remove(lhs_local);
+            }
+        };
+    }
+}
+
+impl<'tcx> Analysis<'tcx> for SingleEnumVariant<'_, 'tcx> {
+    fn apply_statement_effect(
+        &self,
+        state: &mut Self::Domain,
+        statement: &Statement<'tcx>,
+        loc: Location,
+    ) {
+        let (place, fact) = match &statement.kind {
+            StatementKind::Deinit(box place) => (place, None),
+            StatementKind::SetDiscriminant { box place, variant_index } => {
+                (place, Some(*variant_index))
+            }
+            StatementKind::Assign(box (lhs, Rvalue::Use(op))) => {
+                return self.assign(state, lhs, op, loc);
+            }
+            /* may alias/mutate RHS need to specify that it is no longer a single value */
+            StatementKind::Assign(box (
+                _,
+                Rvalue::Ref(_, BorrowKind::Mut { .. }, rhs)
+                | Rvalue::AddressOf(Mutability::Mut, rhs),
+            )) => (rhs, None),
+            StatementKind::CopyNonOverlapping(box ref copy) => {
+                let place = match &copy.dst {
+                    Operand::Copy(p) | Operand::Move(p) => p,
+                    _ => return,
+                };
+                (place, None)
+            }
+            _ => return,
+        };
+        if !self.is_tracked(place) {
+            return;
+        }
+        let Some(local) = place.local_or_deref_local() else { return };
+        if let Some(fact) = fact {
+            state.insert(local, loc, fact);
+        } else {
+            state.remove(local);
+        }
+    }
+    fn apply_terminator_effect(
+        &self,
+        state: &mut Self::Domain,
+        terminator: &Terminator<'tcx>,
+        loc: Location,
+    ) {
+        match &terminator.kind {
+            TerminatorKind::DropAndReplace { place, value, .. } => {
+                self.assign(state, place, value, loc)
+            }
+            TerminatorKind::Drop { place, .. } if self.is_tracked(place) => {
+                let Some(local) = place.local_or_deref_local() else { return };
+                state.remove(local);
+            }
+            _ => {}
+        }
+    }
+
+    fn apply_call_return_effect(
+        &self,
+        _: &mut Self::Domain,
+        _: BasicBlock,
+        _: CallReturnPlaces<'_, 'tcx>,
+    ) {
+    }
+
+    fn apply_switch_int_edge_effects(
+        &self,
+        _block: BasicBlock,
+        discr: &Operand<'tcx>,
+        apply_edge_effects: &mut impl SwitchIntEdgeEffects<Self::Domain>,
+    ) {
+        let Some(place) = discr.place() else { return };
+        if !self.is_tracked(&place) {
+            return;
+        }
+        let Some(local) = place.local_or_deref_local() else { return };
+        apply_edge_effects.apply(|state, target| {
+            // This probably isn't right, need to check that it fits.
+            let new_fact = target.value.map(|v| VariantIdx::from_u32(v as u32));
+
+            if let Some(new_fact) = new_fact {
+                let loc = Location { block: target.target, statement_index: 0 };
+                state.insert(local, loc, new_fact);
+            } else {
+                state.remove(local);
+            }
+        });
+    }
+}

--- a/compiler/rustc_mir_dataflow/src/lib.rs
+++ b/compiler/rustc_mir_dataflow/src/lib.rs
@@ -6,6 +6,7 @@
 #![feature(once_cell)]
 #![feature(stmt_expr_attributes)]
 #![feature(trusted_step)]
+#![feature(try_blocks)]
 #![recursion_limit = "256"]
 
 #[macro_use]

--- a/compiler/rustc_mir_transform/src/lib.rs
+++ b/compiler/rustc_mir_transform/src/lib.rs
@@ -82,6 +82,7 @@ mod required_consts;
 mod reveal_all;
 mod separate_const_switch;
 mod shim;
+mod single_enum;
 // This pass is public to allow external drivers to perform MIR cleanup
 pub mod simplify;
 mod simplify_branches;
@@ -491,6 +492,7 @@ fn run_optimization_passes<'tcx>(tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
             //
             // Const-prop runs unconditionally, but doesn't mutate the MIR at mir-opt-level=0.
             &const_debuginfo::ConstDebugInfo,
+            &single_enum::SingleEnum,
             &o1(simplify_branches::SimplifyConstCondition::new("after-const-prop")),
             &early_otherwise_branch::EarlyOtherwiseBranch,
             &simplify_comparison_integral::SimplifyComparisonIntegral,

--- a/compiler/rustc_mir_transform/src/single_enum.rs
+++ b/compiler/rustc_mir_transform/src/single_enum.rs
@@ -1,0 +1,59 @@
+use rustc_middle::mir::interpret::Scalar;
+use rustc_middle::mir::*;
+use rustc_middle::ty::{ParamEnv, TyCtxt};
+use rustc_mir_dataflow::impls::SingleEnumVariant;
+use rustc_mir_dataflow::Analysis;
+use rustc_span::DUMMY_SP;
+
+use crate::MirPass;
+
+pub struct SingleEnum;
+
+impl<'tcx> MirPass<'tcx> for SingleEnum {
+    fn run_pass(&self, tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
+        let mut single_enum_variants = SingleEnumVariant::new(tcx, body)
+            .into_engine(tcx, body)
+            .iterate_to_fixpoint()
+            .into_results_cursor(body);
+
+        let mut discrs = vec![];
+
+        for (bb, block) in body.basic_blocks().iter_enumerated() {
+            for (i, stmt) in block.statements.iter().enumerate() {
+                let stmt_loc = Location { block: bb.clone(), statement_index: i };
+                let StatementKind::Assign(box(_, Rvalue::Discriminant(src))) = stmt.kind
+                else { continue };
+                if !src.ty(body, tcx).ty.is_enum() {
+                    continue;
+                }
+                let Some(src_local) = src.local_or_deref_local() else { continue };
+
+                single_enum_variants.seek_before_primary_effect(stmt_loc);
+                match single_enum_variants.get().get(src_local) {
+                    None => {}
+                    Some((_, &v)) => discrs.push((stmt_loc, v)),
+                };
+            }
+        }
+
+        for (Location { block, statement_index }, val) in discrs {
+            let (bbs, local_decls) = &mut body.basic_blocks_and_local_decls_mut();
+            let stmt = &mut bbs[block].statements[statement_index];
+            let Some((lhs, rval)) = stmt.kind.as_assign_mut() else { unreachable!() };
+            let Rvalue::Discriminant(rhs) = rval else { unreachable!() };
+
+            let Some(disc) = rhs.ty(*local_decls, tcx).ty.discriminant_for_variant(tcx, val)
+            else { continue };
+
+            let scalar_ty = lhs.ty(*local_decls, tcx).ty;
+            let layout = tcx.layout_of(ParamEnv::empty().and(scalar_ty)).unwrap().layout;
+            let ct = Operand::const_from_scalar(
+                tcx,
+                scalar_ty,
+                Scalar::from_uint(disc.val, layout.size()),
+                DUMMY_SP,
+            );
+            *rval = Rvalue::Use(ct);
+        }
+    }
+}

--- a/src/test/mir-opt/enum_prop.main.SingleEnum.diff
+++ b/src/test/mir-opt/enum_prop.main.SingleEnum.diff
@@ -1,0 +1,475 @@
+- // MIR for `main` before SingleEnum
++ // MIR for `main` after SingleEnum
+  
+  fn main() -> () {
+      let mut _0: ();                      // return place in scope 0 at $DIR/enum_prop.rs:3:11: 3:11
+      let _1: i32;                         // in scope 0 at $DIR/enum_prop.rs:4:7: 4:8
+      let mut _2: std::option::Option<std::boxed::Box<i32>>; // in scope 0 at $DIR/enum_prop.rs:4:17: 4:35
+      let mut _3: std::boxed::Box<i32>;    // in scope 0 at $DIR/enum_prop.rs:4:22: 4:34
+      let mut _4: isize;                   // in scope 0 at $DIR/enum_prop.rs:5:5: 5:12
+      let _5: std::boxed::Box<i32>;        // in scope 0 at $DIR/enum_prop.rs:5:10: 5:11
+      let _6: ();                          // in scope 0 at $SRC_DIR/std/src/macros.rs:LL:COL
+      let _7: ();                          // in scope 0 at $SRC_DIR/std/src/macros.rs:LL:COL
+      let mut _8: std::fmt::Arguments;     // in scope 0 at $SRC_DIR/std/src/macros.rs:LL:COL
+      let mut _9: &[&str];                 // in scope 0 at $DIR/enum_prop.rs:6:16: 6:20
+      let mut _10: &[&str; 2];             // in scope 0 at $DIR/enum_prop.rs:6:16: 6:20
+      let _11: &[&str; 2];                 // in scope 0 at $DIR/enum_prop.rs:6:16: 6:20
+      let _12: [&str; 2];                  // in scope 0 at $DIR/enum_prop.rs:6:16: 6:20
+      let mut _13: &[std::fmt::ArgumentV1]; // in scope 0 at $SRC_DIR/std/src/macros.rs:LL:COL
+      let mut _14: &[std::fmt::ArgumentV1; 1]; // in scope 0 at $SRC_DIR/std/src/macros.rs:LL:COL
+      let _15: &[std::fmt::ArgumentV1; 1]; // in scope 0 at $SRC_DIR/std/src/macros.rs:LL:COL
+      let _16: [std::fmt::ArgumentV1; 1];  // in scope 0 at $SRC_DIR/std/src/macros.rs:LL:COL
+      let mut _17: std::fmt::ArgumentV1;   // in scope 0 at $DIR/enum_prop.rs:6:22: 6:23
+      let mut _18: &std::boxed::Box<i32>;  // in scope 0 at $DIR/enum_prop.rs:6:22: 6:23
+      let _19: &std::boxed::Box<i32>;      // in scope 0 at $DIR/enum_prop.rs:6:22: 6:23
+      let _20: ();                         // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _21: (&i32, &i32);           // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _22: &i32;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _23: &i32;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let _24: i32;                        // in scope 0 at $DIR/enum_prop.rs:11:16: 11:18
+      let mut _27: bool;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _28: bool;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _29: i32;                    // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _30: i32;                    // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _31: !;                      // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let _33: !;                          // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _34: core::panicking::AssertKind; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _35: &i32;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let _36: &i32;                       // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _37: &i32;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let _38: &i32;                       // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _39: std::option::Option<std::fmt::Arguments>; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _41: std::option::Option<i32>; // in scope 0 at $DIR/enum_prop.rs:14:17: 14:24
+      let mut _42: isize;                  // in scope 0 at $DIR/enum_prop.rs:15:14: 15:21
+      let _44: ();                         // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _45: (&i32, &i32);           // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _46: &i32;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _47: &i32;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let _48: i32;                        // in scope 0 at $DIR/enum_prop.rs:18:17: 18:18
+      let mut _51: bool;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _52: bool;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _53: i32;                    // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _54: i32;                    // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _55: !;                      // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let _57: !;                          // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _58: core::panicking::AssertKind; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _59: &i32;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let _60: &i32;                       // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _61: &i32;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let _62: &i32;                       // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _63: std::option::Option<std::fmt::Arguments>; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _68: bool;                   // in scope 0 at $DIR/enum_prop.rs:10:4: 10:5
+      let mut _69: isize;                  // in scope 0 at $DIR/enum_prop.rs:10:4: 10:5
+      let mut _70: isize;                  // in scope 0 at $DIR/enum_prop.rs:10:4: 10:5
+      let mut _71: isize;                  // in scope 0 at $DIR/enum_prop.rs:10:4: 10:5
+      let mut _72: i32;                    // in scope 0 at $DIR/enum_prop.rs:4:22: 4:34
+      scope 1 {
+          debug v => _1;                   // in scope 1 at $DIR/enum_prop.rs:4:7: 4:8
+          let _25: &i32;                   // in scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          let _26: &i32;                   // in scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          let _40: i32;                    // in scope 1 at $DIR/enum_prop.rs:14:7: 14:8
+          let _43: &std::option::Option<i32>; // in scope 1 at $DIR/enum_prop.rs:15:5: 15:21
+          let mut _65: &std::option::Option<i32>; // in scope 1 at $DIR/enum_prop.rs:15:5: 15:21
+          let mut _66: &i32;               // in scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          scope 3 {
+              debug left_val => _25;       // in scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+              debug right_val => _26;      // in scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+              let _32: core::panicking::AssertKind; // in scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+              scope 4 {
+                  debug kind => _32;       // in scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+              }
+          }
+          scope 5 {
+              debug x => _40;              // in scope 5 at $DIR/enum_prop.rs:14:7: 14:8
+              let _49: &i32;               // in scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+              let _50: &i32;               // in scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+              let mut _64: &i32;           // in scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+              scope 7 {
+                  debug left_val => _49;   // in scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                  debug right_val => _50;  // in scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                  let _56: core::panicking::AssertKind; // in scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                  scope 8 {
+                      debug kind => _56;   // in scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                  }
+              }
+          }
+          scope 6 {
+              debug _y => _43;             // in scope 6 at $DIR/enum_prop.rs:15:5: 15:21
+          }
+      }
+      scope 2 {
+          debug x => _5;                   // in scope 2 at $DIR/enum_prop.rs:5:10: 5:11
+          let mut _67: &[&str; 2];         // in scope 2 at $DIR/enum_prop.rs:6:16: 6:20
+          scope 11 (inlined ArgumentV1::new_display::<Box<i32>>) { // at $DIR/enum_prop.rs:6:22: 6:23
+              debug x => _18;              // in scope 11 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+              let mut _76: &std::boxed::Box<i32>; // in scope 11 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+              let mut _77: for<'r, 's, 't0> fn(&'r std::boxed::Box<i32>, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>; // in scope 11 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+              scope 12 (inlined ArgumentV1::new::<Box<i32>>) { // at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+                  debug x => _76;          // in scope 12 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+                  debug f => _77;          // in scope 12 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+                  let mut _78: for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>; // in scope 12 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+                  let mut _79: for<'r, 's, 't0> fn(&'r std::boxed::Box<i32>, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>; // in scope 12 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+                  let mut _80: &core::fmt::Opaque; // in scope 12 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+                  let mut _81: &std::boxed::Box<i32>; // in scope 12 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+                  scope 13 {
+                  }
+              }
+          }
+      }
+      scope 9 (inlined Box::<i32>::new) {  // at $DIR/enum_prop.rs:4:22: 4:34
+          debug x => _72;                  // in scope 9 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
+          let mut _73: usize;              // in scope 9 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
+          let mut _74: usize;              // in scope 9 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
+          let mut _75: *mut u8;            // in scope 9 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
+          scope 10 {
+          }
+      }
+  
+      bb0: {
+          _68 = const false;               // scope 0 at $DIR/enum_prop.rs:4:7: 4:8
+          StorageLive(_1);                 // scope 0 at $DIR/enum_prop.rs:4:7: 4:8
+          StorageLive(_2);                 // scope 0 at $DIR/enum_prop.rs:4:17: 4:35
+          StorageLive(_3);                 // scope 0 at $DIR/enum_prop.rs:4:22: 4:34
+          StorageLive(_72);                // scope 0 at $DIR/enum_prop.rs:4:22: 4:34
+          _72 = const 10_i32;              // scope 0 at $DIR/enum_prop.rs:4:22: 4:34
+          StorageLive(_73);                // scope 0 at $DIR/enum_prop.rs:4:22: 4:34
+          StorageLive(_74);                // scope 0 at $DIR/enum_prop.rs:4:22: 4:34
+          StorageLive(_75);                // scope 0 at $DIR/enum_prop.rs:4:22: 4:34
+          _73 = const 4_usize;             // scope 10 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
+          _74 = const 4_usize;             // scope 10 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
+          _75 = alloc::alloc::exchange_malloc(const 4_usize, const 4_usize) -> [return: bb20, unwind: bb21]; // scope 10 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
+                                           // mir::Constant
+                                           // + span: $SRC_DIR/alloc/src/boxed.rs:LL:COL
+                                           // + literal: Const { ty: unsafe fn(usize, usize) -> *mut u8 {alloc::alloc::exchange_malloc}, val: Value(Scalar(<ZST>)) }
+      }
+  
+      bb1: {
+          _1 = const 3_i32;                // scope 0 at $DIR/enum_prop.rs:9:10: 9:11
+          goto -> bb18;                    // scope 0 at $DIR/enum_prop.rs:9:10: 9:11
+      }
+  
+      bb2: {
+          StorageLive(_5);                 // scope 0 at $DIR/enum_prop.rs:5:10: 5:11
+          _68 = const false;               // scope 0 at $DIR/enum_prop.rs:5:10: 5:11
+          _5 = move ((_2 as Some).0: std::boxed::Box<i32>); // scope 0 at $DIR/enum_prop.rs:5:10: 5:11
+          StorageLive(_6);                 // scope 2 at $SRC_DIR/std/src/macros.rs:LL:COL
+          StorageLive(_7);                 // scope 2 at $SRC_DIR/std/src/macros.rs:LL:COL
+          StorageLive(_8);                 // scope 2 at $SRC_DIR/std/src/macros.rs:LL:COL
+          StorageLive(_9);                 // scope 2 at $DIR/enum_prop.rs:6:16: 6:20
+          StorageLive(_10);                // scope 2 at $DIR/enum_prop.rs:6:16: 6:20
+          StorageLive(_11);                // scope 2 at $DIR/enum_prop.rs:6:16: 6:20
+          _67 = const main::promoted[3];   // scope 2 at $DIR/enum_prop.rs:6:16: 6:20
+                                           // mir::Constant
+                                           // + span: $DIR/enum_prop.rs:6:16: 6:20
+                                           // + literal: Const { ty: &[&str; 2], val: Unevaluated(main, [], Some(promoted[3])) }
+          _11 = _67;                       // scope 2 at $DIR/enum_prop.rs:6:16: 6:20
+          _10 = _11;                       // scope 2 at $DIR/enum_prop.rs:6:16: 6:20
+          _9 = move _10 as &[&str] (Pointer(Unsize)); // scope 2 at $DIR/enum_prop.rs:6:16: 6:20
+          StorageDead(_10);                // scope 2 at $DIR/enum_prop.rs:6:19: 6:20
+          StorageLive(_13);                // scope 2 at $SRC_DIR/std/src/macros.rs:LL:COL
+          StorageLive(_14);                // scope 2 at $SRC_DIR/std/src/macros.rs:LL:COL
+          StorageLive(_15);                // scope 2 at $SRC_DIR/std/src/macros.rs:LL:COL
+          StorageLive(_16);                // scope 2 at $SRC_DIR/std/src/macros.rs:LL:COL
+          StorageLive(_17);                // scope 2 at $DIR/enum_prop.rs:6:22: 6:23
+          StorageLive(_18);                // scope 2 at $DIR/enum_prop.rs:6:22: 6:23
+          StorageLive(_19);                // scope 2 at $DIR/enum_prop.rs:6:22: 6:23
+          _19 = &_5;                       // scope 2 at $DIR/enum_prop.rs:6:22: 6:23
+          _18 = _19;                       // scope 2 at $DIR/enum_prop.rs:6:22: 6:23
+          StorageLive(_76);                // scope 11 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+          _76 = _18;                       // scope 11 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+          StorageLive(_77);                // scope 11 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+          _77 = <Box<i32> as std::fmt::Display>::fmt as for<'r, 's, 't0> fn(&'r std::boxed::Box<i32>, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> (Pointer(ReifyFnPointer)); // scope 11 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+                                           // mir::Constant
+                                           // + span: $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+                                           // + literal: Const { ty: for<'r, 's, 't0> fn(&'r Box<i32>, &'s mut Formatter<'t0>) -> Result<(), std::fmt::Error> {<Box<i32> as std::fmt::Display>::fmt}, val: Value(Scalar(<ZST>)) }
+          StorageLive(_78);                // scope 13 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+          StorageLive(_79);                // scope 13 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+          _79 = _77;                       // scope 13 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+          _78 = transmute::<for<'r, 's, 't0> fn(&'r Box<i32>, &'s mut Formatter<'t0>) -> Result<(), std::fmt::Error>, for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut Formatter<'t0>) -> Result<(), std::fmt::Error>>(move _79) -> [return: bb22, unwind: bb13]; // scope 13 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+                                           // mir::Constant
+                                           // + span: $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+                                           // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(for<'r, 's, 't0> fn(&'r Box<i32>, &'s mut Formatter<'t0>) -> Result<(), std::fmt::Error>) -> for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut Formatter<'t0>) -> Result<(), std::fmt::Error> {transmute::<for<'r, 's, 't0> fn(&'r Box<i32>, &'s mut Formatter<'t0>) -> Result<(), std::fmt::Error>, for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut Formatter<'t0>) -> Result<(), std::fmt::Error>>}, val: Value(Scalar(<ZST>)) }
+      }
+  
+      bb3: {
+          StorageDead(_13);                // scope 2 at $SRC_DIR/std/src/macros.rs:LL:COL
+          StorageDead(_9);                 // scope 2 at $SRC_DIR/std/src/macros.rs:LL:COL
+          _7 = _print(move _8) -> [return: bb4, unwind: bb13]; // scope 2 at $SRC_DIR/std/src/macros.rs:LL:COL
+                                           // mir::Constant
+                                           // + span: $SRC_DIR/std/src/macros.rs:LL:COL
+                                           // + literal: Const { ty: for<'r> fn(Arguments<'r>) {_print}, val: Value(Scalar(<ZST>)) }
+      }
+  
+      bb4: {
+          StorageDead(_8);                 // scope 2 at $SRC_DIR/std/src/macros.rs:LL:COL
+          StorageDead(_19);                // scope 2 at $SRC_DIR/std/src/macros.rs:LL:COL
+          StorageDead(_16);                // scope 2 at $SRC_DIR/std/src/macros.rs:LL:COL
+          StorageDead(_15);                // scope 2 at $SRC_DIR/std/src/macros.rs:LL:COL
+          StorageDead(_11);                // scope 2 at $SRC_DIR/std/src/macros.rs:LL:COL
+          StorageDead(_7);                 // scope 2 at $SRC_DIR/std/src/macros.rs:LL:COL
+          StorageDead(_6);                 // scope 2 at $SRC_DIR/std/src/macros.rs:LL:COL
+          _1 = (*_5);                      // scope 2 at $DIR/enum_prop.rs:7:7: 7:9
+          drop(_5) -> [return: bb5, unwind: bb19]; // scope 0 at $DIR/enum_prop.rs:8:5: 8:6
+      }
+  
+      bb5: {
+          StorageDead(_5);                 // scope 0 at $DIR/enum_prop.rs:8:5: 8:6
+          goto -> bb18;                    // scope 0 at $DIR/enum_prop.rs:8:5: 8:6
+      }
+  
+      bb6: {
+          StorageLive(_32);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          Deinit(_32);                     // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          discriminant(_32) = 0;           // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_33);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_34);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _34 = const core::panicking::AssertKind::Eq; // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                                           // mir::Constant
+                                           // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                                           // + literal: Const { ty: core::panicking::AssertKind, val: Value(Scalar(0x00)) }
+          StorageLive(_35);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_36);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _36 = _25;                       // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _35 = _36;                       // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_37);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_38);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _38 = _26;                       // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _37 = _38;                       // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_39);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          Deinit(_39);                     // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          discriminant(_39) = 0;           // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _33 = core::panicking::assert_failed::<i32, i32>(const core::panicking::AssertKind::Eq, move _35, move _37, move _39); // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                                           // mir::Constant
+                                           // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                                           // + literal: Const { ty: for<'r, 's, 't0> fn(core::panicking::AssertKind, &'r i32, &'s i32, Option<Arguments<'t0>>) -> ! {core::panicking::assert_failed::<i32, i32>}, val: Value(Scalar(<ZST>)) }
+                                           // mir::Constant
+                                           // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                                           // + literal: Const { ty: core::panicking::AssertKind, val: Value(Scalar(0x00)) }
+      }
+  
+      bb7: {
+          StorageDead(_27);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_26);                // scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_25);                // scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_21);                // scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_20);                // scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_40);                // scope 1 at $DIR/enum_prop.rs:14:7: 14:8
+          StorageLive(_41);                // scope 1 at $DIR/enum_prop.rs:14:17: 14:24
+          Deinit(_41);                     // scope 1 at $DIR/enum_prop.rs:14:17: 14:24
+          ((_41 as Some).0: i32) = const 1_i32; // scope 1 at $DIR/enum_prop.rs:14:17: 14:24
+          discriminant(_41) = 1;           // scope 1 at $DIR/enum_prop.rs:14:17: 14:24
+          _42 = const 1_isize;             // scope 1 at $DIR/enum_prop.rs:14:17: 14:24
+          switchInt(const 1_isize) -> [0_isize: bb8, otherwise: bb9]; // scope 1 at $DIR/enum_prop.rs:14:11: 14:24
+      }
+  
+      bb8: {
+          _40 = const 2_i32;               // scope 1 at $DIR/enum_prop.rs:16:13: 16:14
+          goto -> bb10;                    // scope 1 at $DIR/enum_prop.rs:16:13: 16:14
+      }
+  
+      bb9: {
+          StorageLive(_43);                // scope 1 at $DIR/enum_prop.rs:15:5: 15:21
+          _65 = const main::promoted[1];   // scope 1 at $DIR/enum_prop.rs:15:5: 15:21
+                                           // mir::Constant
+                                           // + span: $DIR/enum_prop.rs:15:5: 15:21
+                                           // + literal: Const { ty: &Option<i32>, val: Unevaluated(main, [], Some(promoted[1])) }
+          _43 = _65;                       // scope 1 at $DIR/enum_prop.rs:15:5: 15:21
+          _40 = const 1_i32;               // scope 6 at $DIR/enum_prop.rs:15:25: 15:26
+          StorageDead(_43);                // scope 1 at $DIR/enum_prop.rs:15:25: 15:26
+          goto -> bb10;                    // scope 1 at $DIR/enum_prop.rs:15:25: 15:26
+      }
+  
+      bb10: {
+          StorageDead(_41);                // scope 1 at $DIR/enum_prop.rs:17:4: 17:5
+          StorageLive(_44);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_45);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_46);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _46 = &_40;                      // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_47);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _64 = const main::promoted[0];   // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                                           // mir::Constant
+                                           // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                                           // + literal: Const { ty: &i32, val: Unevaluated(main, [], Some(promoted[0])) }
+          _47 = _64;                       // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          Deinit(_45);                     // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          (_45.0: &i32) = move _46;        // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          (_45.1: &i32) = move _47;        // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_47);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_46);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_49);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _49 = (_45.0: &i32);             // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_50);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _50 = (_45.1: &i32);             // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_51);                // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_52);                // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_53);                // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _53 = (*_49);                    // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_54);                // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _54 = const 1_i32;               // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _52 = Eq(move _53, const 1_i32); // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_54);                // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_53);                // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _51 = Not(move _52);             // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_52);                // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          switchInt(move _51) -> [false: bb12, otherwise: bb11]; // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      }
+  
+      bb11: {
+          StorageLive(_56);                // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          Deinit(_56);                     // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          discriminant(_56) = 0;           // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_57);                // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_58);                // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _58 = const core::panicking::AssertKind::Eq; // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                                           // mir::Constant
+                                           // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                                           // + literal: Const { ty: core::panicking::AssertKind, val: Value(Scalar(0x00)) }
+          StorageLive(_59);                // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_60);                // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _60 = _49;                       // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _59 = _60;                       // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_61);                // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_62);                // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _62 = _50;                       // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _61 = _62;                       // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_63);                // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          Deinit(_63);                     // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          discriminant(_63) = 0;           // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _57 = core::panicking::assert_failed::<i32, i32>(const core::panicking::AssertKind::Eq, move _59, move _61, move _63); // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                                           // mir::Constant
+                                           // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                                           // + literal: Const { ty: for<'r, 's, 't0> fn(core::panicking::AssertKind, &'r i32, &'s i32, Option<Arguments<'t0>>) -> ! {core::panicking::assert_failed::<i32, i32>}, val: Value(Scalar(<ZST>)) }
+                                           // mir::Constant
+                                           // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                                           // + literal: Const { ty: core::panicking::AssertKind, val: Value(Scalar(0x00)) }
+      }
+  
+      bb12: {
+          StorageDead(_51);                // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_50);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_49);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_45);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_44);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_40);                // scope 1 at $DIR/enum_prop.rs:20:1: 20:2
+          StorageDead(_1);                 // scope 0 at $DIR/enum_prop.rs:20:1: 20:2
+          return;                          // scope 0 at $DIR/enum_prop.rs:20:2: 20:2
+      }
+  
+      bb13 (cleanup): {
+          drop(_5) -> bb19;                // scope 0 at $DIR/enum_prop.rs:8:5: 8:6
+      }
+  
+      bb14 (cleanup): {
+          resume;                          // scope 0 at $DIR/enum_prop.rs:3:1: 20:2
+      }
+  
+      bb15: {
+          _68 = const false;               // scope 0 at $DIR/enum_prop.rs:10:4: 10:5
+          StorageDead(_2);                 // scope 0 at $DIR/enum_prop.rs:10:4: 10:5
+          StorageLive(_20);                // scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_21);                // scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_22);                // scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _22 = &_1;                       // scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_23);                // scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _66 = const main::promoted[2];   // scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                                           // mir::Constant
+                                           // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                                           // + literal: Const { ty: &i32, val: Unevaluated(main, [], Some(promoted[2])) }
+          _23 = _66;                       // scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          Deinit(_21);                     // scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          (_21.0: &i32) = move _22;        // scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          (_21.1: &i32) = move _23;        // scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_23);                // scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_22);                // scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_25);                // scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _25 = (_21.0: &i32);             // scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_26);                // scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _26 = (_21.1: &i32);             // scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_27);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_28);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_29);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _29 = (*_25);                    // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_30);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _30 = const 10_i32;              // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _28 = Eq(move _29, const 10_i32); // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_30);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_29);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _27 = Not(move _28);             // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_28);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          switchInt(move _27) -> [false: bb7, otherwise: bb6]; // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      }
+  
+      bb16: {
+          switchInt(_68) -> [false: bb15, otherwise: bb17]; // scope 0 at $DIR/enum_prop.rs:10:4: 10:5
+      }
+  
+      bb17: {
+          drop(((_2 as Some).0: std::boxed::Box<i32>)) -> [return: bb15, unwind: bb14]; // scope 0 at $DIR/enum_prop.rs:10:4: 10:5
+      }
+  
+      bb18: {
+          _69 = discriminant(_2);          // scope 0 at $DIR/enum_prop.rs:10:4: 10:5
+          switchInt(move _69) -> [1_isize: bb16, otherwise: bb15]; // scope 0 at $DIR/enum_prop.rs:10:4: 10:5
+      }
+  
+      bb19 (cleanup): {
+          _71 = discriminant(_2);          // scope 0 at $DIR/enum_prop.rs:10:4: 10:5
+          goto -> bb14;                    // scope 0 at $DIR/enum_prop.rs:10:4: 10:5
+      }
+  
+      bb20: {
+          _3 = ShallowInitBox(move _75, i32); // scope 9 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
+          (*_3) = const 10_i32;            // scope 9 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
+          StorageDead(_75);                // scope 0 at $DIR/enum_prop.rs:4:22: 4:34
+          StorageDead(_74);                // scope 0 at $DIR/enum_prop.rs:4:22: 4:34
+          StorageDead(_73);                // scope 0 at $DIR/enum_prop.rs:4:22: 4:34
+          StorageDead(_72);                // scope 0 at $DIR/enum_prop.rs:4:22: 4:34
+          _68 = const true;                // scope 0 at $DIR/enum_prop.rs:4:17: 4:35
+          Deinit(_2);                      // scope 0 at $DIR/enum_prop.rs:4:17: 4:35
+          ((_2 as Some).0: std::boxed::Box<i32>) = move _3; // scope 0 at $DIR/enum_prop.rs:4:17: 4:35
+          discriminant(_2) = 1;            // scope 0 at $DIR/enum_prop.rs:4:17: 4:35
+          StorageDead(_3);                 // scope 0 at $DIR/enum_prop.rs:4:34: 4:35
+-         _4 = discriminant(_2);           // scope 0 at $DIR/enum_prop.rs:4:17: 4:35
++         _4 = const 1_isize;              // scope 0 at $DIR/enum_prop.rs:4:17: 4:35
+          switchInt(move _4) -> [1_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/enum_prop.rs:4:11: 4:35
+      }
+  
+      bb21 (cleanup): {
+          resume;                          // scope 9 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
+      }
+  
+      bb22: {
+          StorageDead(_79);                // scope 13 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+          StorageLive(_80);                // scope 13 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+          StorageLive(_81);                // scope 13 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+          _81 = _76;                       // scope 13 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+          _80 = transmute::<&Box<i32>, &core::fmt::Opaque>(move _81) -> [return: bb23, unwind: bb13]; // scope 13 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+                                           // mir::Constant
+                                           // + span: $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+                                           // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(&Box<i32>) -> &core::fmt::Opaque {transmute::<&Box<i32>, &core::fmt::Opaque>}, val: Value(Scalar(<ZST>)) }
+      }
+  
+      bb23: {
+          StorageDead(_81);                // scope 13 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+          Deinit(_17);                     // scope 13 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+          (_17.0: &core::fmt::Opaque) = move _80; // scope 13 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+          (_17.1: for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>) = move _78; // scope 13 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+          StorageDead(_80);                // scope 13 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+          StorageDead(_78);                // scope 13 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+          StorageDead(_77);                // scope 11 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+          StorageDead(_76);                // scope 11 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
+          StorageDead(_18);                // scope 2 at $DIR/enum_prop.rs:6:22: 6:23
+          _16 = [move _17];                // scope 2 at $SRC_DIR/std/src/macros.rs:LL:COL
+          StorageDead(_17);                // scope 2 at $SRC_DIR/std/src/macros.rs:LL:COL
+          _15 = &_16;                      // scope 2 at $SRC_DIR/std/src/macros.rs:LL:COL
+          _14 = _15;                       // scope 2 at $SRC_DIR/std/src/macros.rs:LL:COL
+          _13 = move _14 as &[std::fmt::ArgumentV1] (Pointer(Unsize)); // scope 2 at $SRC_DIR/std/src/macros.rs:LL:COL
+          StorageDead(_14);                // scope 2 at $SRC_DIR/std/src/macros.rs:LL:COL
+          _8 = Arguments::new_v1(move _9, move _13) -> [return: bb3, unwind: bb13]; // scope 2 at $SRC_DIR/std/src/macros.rs:LL:COL
+                                           // mir::Constant
+                                           // + span: $SRC_DIR/std/src/macros.rs:LL:COL
+                                           // + user_ty: UserType(1)
+                                           // + literal: Const { ty: fn(&[&'static str], &[ArgumentV1]) -> Arguments {Arguments::new_v1}, val: Value(Scalar(<ZST>)) }
+      }
+  }
+  

--- a/src/test/mir-opt/enum_prop.main.SingleEnum.diff
+++ b/src/test/mir-opt/enum_prop.main.SingleEnum.diff
@@ -8,423 +8,342 @@
       let mut _3: std::boxed::Box<i32>;    // in scope 0 at $DIR/enum_prop.rs:4:22: 4:34
       let mut _4: isize;                   // in scope 0 at $DIR/enum_prop.rs:5:5: 5:12
       let _5: std::boxed::Box<i32>;        // in scope 0 at $DIR/enum_prop.rs:5:10: 5:11
-      let _6: ();                          // in scope 0 at $SRC_DIR/std/src/macros.rs:LL:COL
-      let _7: ();                          // in scope 0 at $SRC_DIR/std/src/macros.rs:LL:COL
-      let mut _8: std::fmt::Arguments;     // in scope 0 at $SRC_DIR/std/src/macros.rs:LL:COL
-      let mut _9: &[&str];                 // in scope 0 at $DIR/enum_prop.rs:6:16: 6:20
-      let mut _10: &[&str; 2];             // in scope 0 at $DIR/enum_prop.rs:6:16: 6:20
-      let _11: &[&str; 2];                 // in scope 0 at $DIR/enum_prop.rs:6:16: 6:20
-      let _12: [&str; 2];                  // in scope 0 at $DIR/enum_prop.rs:6:16: 6:20
-      let mut _13: &[std::fmt::ArgumentV1]; // in scope 0 at $SRC_DIR/std/src/macros.rs:LL:COL
-      let mut _14: &[std::fmt::ArgumentV1; 1]; // in scope 0 at $SRC_DIR/std/src/macros.rs:LL:COL
-      let _15: &[std::fmt::ArgumentV1; 1]; // in scope 0 at $SRC_DIR/std/src/macros.rs:LL:COL
-      let _16: [std::fmt::ArgumentV1; 1];  // in scope 0 at $SRC_DIR/std/src/macros.rs:LL:COL
-      let mut _17: std::fmt::ArgumentV1;   // in scope 0 at $DIR/enum_prop.rs:6:22: 6:23
-      let mut _18: &std::boxed::Box<i32>;  // in scope 0 at $DIR/enum_prop.rs:6:22: 6:23
-      let _19: &std::boxed::Box<i32>;      // in scope 0 at $DIR/enum_prop.rs:6:22: 6:23
-      let _20: ();                         // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _21: (&i32, &i32);           // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _22: &i32;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let _6: ();                          // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _7: (&i32, &i32);            // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _8: &i32;                    // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _9: &i32;                    // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let _10: i32;                        // in scope 0 at $DIR/enum_prop.rs:10:16: 10:18
+      let mut _13: bool;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _14: bool;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _15: i32;                    // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _16: i32;                    // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _17: !;                      // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let _19: !;                          // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _20: core::panicking::AssertKind; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _21: &i32;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let _22: &i32;                       // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       let mut _23: &i32;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let _24: i32;                        // in scope 0 at $DIR/enum_prop.rs:11:16: 11:18
-      let mut _27: bool;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _28: bool;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _29: i32;                    // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _30: i32;                    // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _31: !;                      // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let _33: !;                          // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _34: core::panicking::AssertKind; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _35: &i32;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let _36: &i32;                       // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _37: &i32;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let _38: &i32;                       // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _39: std::option::Option<std::fmt::Arguments>; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _41: std::option::Option<i32>; // in scope 0 at $DIR/enum_prop.rs:14:17: 14:24
-      let mut _42: isize;                  // in scope 0 at $DIR/enum_prop.rs:15:14: 15:21
-      let _44: ();                         // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _45: (&i32, &i32);           // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _46: &i32;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let _24: &i32;                       // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _25: std::option::Option<std::fmt::Arguments>; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _27: std::option::Option<i32>; // in scope 0 at $DIR/enum_prop.rs:13:17: 13:24
+      let mut _28: isize;                  // in scope 0 at $DIR/enum_prop.rs:14:14: 14:21
+      let _30: ();                         // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _31: (&i32, &i32);           // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _32: &i32;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _33: &i32;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let _34: i32;                        // in scope 0 at $DIR/enum_prop.rs:17:17: 17:18
+      let mut _37: bool;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _38: bool;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _39: i32;                    // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _40: i32;                    // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _41: !;                      // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let _43: !;                          // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _44: core::panicking::AssertKind; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _45: &i32;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let _46: &i32;                       // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       let mut _47: &i32;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let _48: i32;                        // in scope 0 at $DIR/enum_prop.rs:18:17: 18:18
-      let mut _51: bool;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _52: bool;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _53: i32;                    // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _54: i32;                    // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _55: !;                      // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let _57: !;                          // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _58: core::panicking::AssertKind; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _59: &i32;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let _60: &i32;                       // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _61: &i32;                   // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let _62: &i32;                       // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _63: std::option::Option<std::fmt::Arguments>; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-      let mut _68: bool;                   // in scope 0 at $DIR/enum_prop.rs:10:4: 10:5
-      let mut _69: isize;                  // in scope 0 at $DIR/enum_prop.rs:10:4: 10:5
-      let mut _70: isize;                  // in scope 0 at $DIR/enum_prop.rs:10:4: 10:5
-      let mut _71: isize;                  // in scope 0 at $DIR/enum_prop.rs:10:4: 10:5
-      let mut _72: i32;                    // in scope 0 at $DIR/enum_prop.rs:4:22: 4:34
+      let _48: &i32;                       // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _49: std::option::Option<std::fmt::Arguments>; // in scope 0 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      let mut _53: bool;                   // in scope 0 at $DIR/enum_prop.rs:9:4: 9:5
+      let mut _54: isize;                  // in scope 0 at $DIR/enum_prop.rs:9:4: 9:5
+      let mut _55: isize;                  // in scope 0 at $DIR/enum_prop.rs:9:4: 9:5
+      let mut _56: isize;                  // in scope 0 at $DIR/enum_prop.rs:9:4: 9:5
+      let mut _57: *const i32;             // in scope 0 at $DIR/enum_prop.rs:5:10: 5:11
+      let mut _58: *const i32;             // in scope 0 at $DIR/enum_prop.rs:5:10: 5:11
+      let mut _59: i32;                    // in scope 0 at $DIR/enum_prop.rs:4:22: 4:34
       scope 1 {
           debug v => _1;                   // in scope 1 at $DIR/enum_prop.rs:4:7: 4:8
-          let _25: &i32;                   // in scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          let _26: &i32;                   // in scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          let _40: i32;                    // in scope 1 at $DIR/enum_prop.rs:14:7: 14:8
-          let _43: &std::option::Option<i32>; // in scope 1 at $DIR/enum_prop.rs:15:5: 15:21
-          let mut _65: &std::option::Option<i32>; // in scope 1 at $DIR/enum_prop.rs:15:5: 15:21
-          let mut _66: &i32;               // in scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          let _11: &i32;                   // in scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          let _12: &i32;                   // in scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          let _26: i32;                    // in scope 1 at $DIR/enum_prop.rs:13:7: 13:8
+          let _29: &std::option::Option<i32>; // in scope 1 at $DIR/enum_prop.rs:14:5: 14:21
+          let mut _51: &std::option::Option<i32>; // in scope 1 at $DIR/enum_prop.rs:14:5: 14:21
+          let mut _52: &i32;               // in scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
           scope 3 {
-              debug left_val => _25;       // in scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-              debug right_val => _26;      // in scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-              let _32: core::panicking::AssertKind; // in scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+              debug left_val => _11;       // in scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+              debug right_val => _12;      // in scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+              let _18: core::panicking::AssertKind; // in scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
               scope 4 {
-                  debug kind => _32;       // in scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                  debug kind => _18;       // in scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
               }
           }
           scope 5 {
-              debug x => _40;              // in scope 5 at $DIR/enum_prop.rs:14:7: 14:8
-              let _49: &i32;               // in scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-              let _50: &i32;               // in scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-              let mut _64: &i32;           // in scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+              debug x => _26;              // in scope 5 at $DIR/enum_prop.rs:13:7: 13:8
+              let _35: &i32;               // in scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+              let _36: &i32;               // in scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+              let mut _50: &i32;           // in scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
               scope 7 {
-                  debug left_val => _49;   // in scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                  debug right_val => _50;  // in scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                  let _56: core::panicking::AssertKind; // in scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                  debug left_val => _35;   // in scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                  debug right_val => _36;  // in scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                  let _42: core::panicking::AssertKind; // in scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                   scope 8 {
-                      debug kind => _56;   // in scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                      debug kind => _42;   // in scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                   }
               }
           }
           scope 6 {
-              debug _y => _43;             // in scope 6 at $DIR/enum_prop.rs:15:5: 15:21
+              debug _y => _29;             // in scope 6 at $DIR/enum_prop.rs:14:5: 14:21
           }
       }
       scope 2 {
           debug x => _5;                   // in scope 2 at $DIR/enum_prop.rs:5:10: 5:11
-          let mut _67: &[&str; 2];         // in scope 2 at $DIR/enum_prop.rs:6:16: 6:20
-          scope 11 (inlined ArgumentV1::new_display::<Box<i32>>) { // at $DIR/enum_prop.rs:6:22: 6:23
-              debug x => _18;              // in scope 11 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-              let mut _76: &std::boxed::Box<i32>; // in scope 11 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-              let mut _77: for<'r, 's, 't0> fn(&'r std::boxed::Box<i32>, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>; // in scope 11 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-              scope 12 (inlined ArgumentV1::new::<Box<i32>>) { // at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-                  debug x => _76;          // in scope 12 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-                  debug f => _77;          // in scope 12 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-                  let mut _78: for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>; // in scope 12 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-                  let mut _79: for<'r, 's, 't0> fn(&'r std::boxed::Box<i32>, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>; // in scope 12 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-                  let mut _80: &core::fmt::Opaque; // in scope 12 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-                  let mut _81: &std::boxed::Box<i32>; // in scope 12 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-                  scope 13 {
-                  }
-              }
-          }
       }
       scope 9 (inlined Box::<i32>::new) {  // at $DIR/enum_prop.rs:4:22: 4:34
-          debug x => _72;                  // in scope 9 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
-          let mut _73: usize;              // in scope 9 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
-          let mut _74: usize;              // in scope 9 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
-          let mut _75: *mut u8;            // in scope 9 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
+          debug x => _59;                  // in scope 9 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
+          let mut _60: usize;              // in scope 9 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
+          let mut _61: usize;              // in scope 9 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
+          let mut _62: *mut u8;            // in scope 9 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
+          let mut _63: *const i32;         // in scope 9 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
           scope 10 {
           }
       }
   
       bb0: {
-          _68 = const false;               // scope 0 at $DIR/enum_prop.rs:4:7: 4:8
+          _53 = const false;               // scope 0 at $DIR/enum_prop.rs:4:7: 4:8
           StorageLive(_1);                 // scope 0 at $DIR/enum_prop.rs:4:7: 4:8
           StorageLive(_2);                 // scope 0 at $DIR/enum_prop.rs:4:17: 4:35
           StorageLive(_3);                 // scope 0 at $DIR/enum_prop.rs:4:22: 4:34
-          StorageLive(_72);                // scope 0 at $DIR/enum_prop.rs:4:22: 4:34
-          _72 = const 10_i32;              // scope 0 at $DIR/enum_prop.rs:4:22: 4:34
-          StorageLive(_73);                // scope 0 at $DIR/enum_prop.rs:4:22: 4:34
-          StorageLive(_74);                // scope 0 at $DIR/enum_prop.rs:4:22: 4:34
-          StorageLive(_75);                // scope 0 at $DIR/enum_prop.rs:4:22: 4:34
-          _73 = const 4_usize;             // scope 10 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
-          _74 = const 4_usize;             // scope 10 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
-          _75 = alloc::alloc::exchange_malloc(const 4_usize, const 4_usize) -> [return: bb20, unwind: bb21]; // scope 10 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
+          StorageLive(_59);                // scope 0 at $DIR/enum_prop.rs:4:22: 4:34
+          _59 = const 10_i32;              // scope 0 at $DIR/enum_prop.rs:4:22: 4:34
+          StorageLive(_60);                // scope 0 at $DIR/enum_prop.rs:4:22: 4:34
+          StorageLive(_61);                // scope 0 at $DIR/enum_prop.rs:4:22: 4:34
+          StorageLive(_62);                // scope 0 at $DIR/enum_prop.rs:4:22: 4:34
+          _60 = const 4_usize;             // scope 10 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
+          _61 = const 4_usize;             // scope 10 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
+          _62 = alloc::alloc::exchange_malloc(const 4_usize, const 4_usize) -> [return: bb17, unwind: bb18]; // scope 10 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
                                            // mir::Constant
                                            // + span: $SRC_DIR/alloc/src/boxed.rs:LL:COL
-                                           // + literal: Const { ty: unsafe fn(usize, usize) -> *mut u8 {alloc::alloc::exchange_malloc}, val: Value(Scalar(<ZST>)) }
+                                           // + literal: Const { ty: unsafe fn(usize, usize) -> *mut u8 {alloc::alloc::exchange_malloc}, val: Value(<ZST>) }
       }
   
       bb1: {
-          _1 = const 3_i32;                // scope 0 at $DIR/enum_prop.rs:9:10: 9:11
-          goto -> bb18;                    // scope 0 at $DIR/enum_prop.rs:9:10: 9:11
+          _1 = const 3_i32;                // scope 0 at $DIR/enum_prop.rs:8:10: 8:11
+          goto -> bb15;                    // scope 0 at $DIR/enum_prop.rs:8:10: 8:11
       }
   
       bb2: {
           StorageLive(_5);                 // scope 0 at $DIR/enum_prop.rs:5:10: 5:11
-          _68 = const false;               // scope 0 at $DIR/enum_prop.rs:5:10: 5:11
+          _53 = const false;               // scope 0 at $DIR/enum_prop.rs:5:10: 5:11
           _5 = move ((_2 as Some).0: std::boxed::Box<i32>); // scope 0 at $DIR/enum_prop.rs:5:10: 5:11
-          StorageLive(_6);                 // scope 2 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageLive(_7);                 // scope 2 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageLive(_8);                 // scope 2 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageLive(_9);                 // scope 2 at $DIR/enum_prop.rs:6:16: 6:20
-          StorageLive(_10);                // scope 2 at $DIR/enum_prop.rs:6:16: 6:20
-          StorageLive(_11);                // scope 2 at $DIR/enum_prop.rs:6:16: 6:20
-          _67 = const main::promoted[3];   // scope 2 at $DIR/enum_prop.rs:6:16: 6:20
-                                           // mir::Constant
-                                           // + span: $DIR/enum_prop.rs:6:16: 6:20
-                                           // + literal: Const { ty: &[&str; 2], val: Unevaluated(main, [], Some(promoted[3])) }
-          _11 = _67;                       // scope 2 at $DIR/enum_prop.rs:6:16: 6:20
-          _10 = _11;                       // scope 2 at $DIR/enum_prop.rs:6:16: 6:20
-          _9 = move _10 as &[&str] (Pointer(Unsize)); // scope 2 at $DIR/enum_prop.rs:6:16: 6:20
-          StorageDead(_10);                // scope 2 at $DIR/enum_prop.rs:6:19: 6:20
-          StorageLive(_13);                // scope 2 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageLive(_14);                // scope 2 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageLive(_15);                // scope 2 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageLive(_16);                // scope 2 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageLive(_17);                // scope 2 at $DIR/enum_prop.rs:6:22: 6:23
-          StorageLive(_18);                // scope 2 at $DIR/enum_prop.rs:6:22: 6:23
-          StorageLive(_19);                // scope 2 at $DIR/enum_prop.rs:6:22: 6:23
-          _19 = &_5;                       // scope 2 at $DIR/enum_prop.rs:6:22: 6:23
-          _18 = _19;                       // scope 2 at $DIR/enum_prop.rs:6:22: 6:23
-          StorageLive(_76);                // scope 11 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          _76 = _18;                       // scope 11 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          StorageLive(_77);                // scope 11 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          _77 = <Box<i32> as std::fmt::Display>::fmt as for<'r, 's, 't0> fn(&'r std::boxed::Box<i32>, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error> (Pointer(ReifyFnPointer)); // scope 11 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-                                           // mir::Constant
-                                           // + span: $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-                                           // + literal: Const { ty: for<'r, 's, 't0> fn(&'r Box<i32>, &'s mut Formatter<'t0>) -> Result<(), std::fmt::Error> {<Box<i32> as std::fmt::Display>::fmt}, val: Value(Scalar(<ZST>)) }
-          StorageLive(_78);                // scope 13 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          StorageLive(_79);                // scope 13 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          _79 = _77;                       // scope 13 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          _78 = transmute::<for<'r, 's, 't0> fn(&'r Box<i32>, &'s mut Formatter<'t0>) -> Result<(), std::fmt::Error>, for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut Formatter<'t0>) -> Result<(), std::fmt::Error>>(move _79) -> [return: bb22, unwind: bb13]; // scope 13 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-                                           // mir::Constant
-                                           // + span: $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-                                           // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(for<'r, 's, 't0> fn(&'r Box<i32>, &'s mut Formatter<'t0>) -> Result<(), std::fmt::Error>) -> for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut Formatter<'t0>) -> Result<(), std::fmt::Error> {transmute::<for<'r, 's, 't0> fn(&'r Box<i32>, &'s mut Formatter<'t0>) -> Result<(), std::fmt::Error>, for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut Formatter<'t0>) -> Result<(), std::fmt::Error>>}, val: Value(Scalar(<ZST>)) }
+          StorageLive(_57);                // scope 2 at $DIR/enum_prop.rs:6:7: 6:9
+          _57 = (((_5.0: std::ptr::Unique<i32>).0: std::ptr::NonNull<i32>).0: *const i32); // scope 2 at $DIR/enum_prop.rs:6:7: 6:9
+          _1 = (*_57);                     // scope 2 at $DIR/enum_prop.rs:6:7: 6:9
+          StorageDead(_57);                // scope 0 at $DIR/enum_prop.rs:7:5: 7:6
+          drop(_5) -> [return: bb3, unwind: bb16]; // scope 0 at $DIR/enum_prop.rs:7:5: 7:6
       }
   
       bb3: {
-          StorageDead(_13);                // scope 2 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageDead(_9);                 // scope 2 at $SRC_DIR/std/src/macros.rs:LL:COL
-          _7 = _print(move _8) -> [return: bb4, unwind: bb13]; // scope 2 at $SRC_DIR/std/src/macros.rs:LL:COL
-                                           // mir::Constant
-                                           // + span: $SRC_DIR/std/src/macros.rs:LL:COL
-                                           // + literal: Const { ty: for<'r> fn(Arguments<'r>) {_print}, val: Value(Scalar(<ZST>)) }
+          StorageDead(_5);                 // scope 0 at $DIR/enum_prop.rs:7:5: 7:6
+          goto -> bb15;                    // scope 0 at $DIR/enum_prop.rs:7:5: 7:6
       }
   
       bb4: {
-          StorageDead(_8);                 // scope 2 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageDead(_19);                // scope 2 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageDead(_16);                // scope 2 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageDead(_15);                // scope 2 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageDead(_11);                // scope 2 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageDead(_7);                 // scope 2 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageDead(_6);                 // scope 2 at $SRC_DIR/std/src/macros.rs:LL:COL
-          _1 = (*_5);                      // scope 2 at $DIR/enum_prop.rs:7:7: 7:9
-          drop(_5) -> [return: bb5, unwind: bb19]; // scope 0 at $DIR/enum_prop.rs:8:5: 8:6
+          StorageLive(_18);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          Deinit(_18);                     // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          discriminant(_18) = 0;           // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_19);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_20);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _20 = const core::panicking::AssertKind::Eq; // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                                           // mir::Constant
+                                           // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                                           // + literal: Const { ty: core::panicking::AssertKind, val: Value(Scalar(0x00)) }
+          StorageLive(_21);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_22);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _22 = _11;                       // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _21 = _22;                       // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_23);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_24);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _24 = _12;                       // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _23 = _24;                       // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_25);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          Deinit(_25);                     // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          discriminant(_25) = 0;           // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _19 = core::panicking::assert_failed::<i32, i32>(const core::panicking::AssertKind::Eq, move _21, move _23, move _25); // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                                           // mir::Constant
+                                           // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                                           // + literal: Const { ty: for<'r, 's, 't0> fn(core::panicking::AssertKind, &'r i32, &'s i32, Option<Arguments<'t0>>) -> ! {core::panicking::assert_failed::<i32, i32>}, val: Value(<ZST>) }
+                                           // mir::Constant
+                                           // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
+                                           // + literal: Const { ty: core::panicking::AssertKind, val: Value(Scalar(0x00)) }
       }
   
       bb5: {
-          StorageDead(_5);                 // scope 0 at $DIR/enum_prop.rs:8:5: 8:6
-          goto -> bb18;                    // scope 0 at $DIR/enum_prop.rs:8:5: 8:6
+          StorageDead(_13);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_12);                // scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_11);                // scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_7);                 // scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_6);                 // scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_26);                // scope 1 at $DIR/enum_prop.rs:13:7: 13:8
+          StorageLive(_27);                // scope 1 at $DIR/enum_prop.rs:13:17: 13:24
+          Deinit(_27);                     // scope 1 at $DIR/enum_prop.rs:13:17: 13:24
+          ((_27 as Some).0: i32) = const 1_i32; // scope 1 at $DIR/enum_prop.rs:13:17: 13:24
+          discriminant(_27) = 1;           // scope 1 at $DIR/enum_prop.rs:13:17: 13:24
+          _28 = const 1_isize;             // scope 1 at $DIR/enum_prop.rs:13:17: 13:24
+          switchInt(const 1_isize) -> [0_isize: bb6, otherwise: bb7]; // scope 1 at $DIR/enum_prop.rs:13:11: 13:24
       }
   
       bb6: {
-          StorageLive(_32);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          Deinit(_32);                     // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          discriminant(_32) = 0;           // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_33);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_34);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _34 = const core::panicking::AssertKind::Eq; // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                                           // mir::Constant
-                                           // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                                           // + literal: Const { ty: core::panicking::AssertKind, val: Value(Scalar(0x00)) }
-          StorageLive(_35);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_36);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _36 = _25;                       // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _35 = _36;                       // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_37);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_38);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _38 = _26;                       // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _37 = _38;                       // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_39);                // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          Deinit(_39);                     // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          discriminant(_39) = 0;           // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _33 = core::panicking::assert_failed::<i32, i32>(const core::panicking::AssertKind::Eq, move _35, move _37, move _39); // scope 4 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                                           // mir::Constant
-                                           // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                                           // + literal: Const { ty: for<'r, 's, 't0> fn(core::panicking::AssertKind, &'r i32, &'s i32, Option<Arguments<'t0>>) -> ! {core::panicking::assert_failed::<i32, i32>}, val: Value(Scalar(<ZST>)) }
-                                           // mir::Constant
-                                           // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                                           // + literal: Const { ty: core::panicking::AssertKind, val: Value(Scalar(0x00)) }
+          _26 = const 2_i32;               // scope 1 at $DIR/enum_prop.rs:15:13: 15:14
+          goto -> bb8;                     // scope 1 at $DIR/enum_prop.rs:15:13: 15:14
       }
   
       bb7: {
-          StorageDead(_27);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageDead(_26);                // scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageDead(_25);                // scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageDead(_21);                // scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageDead(_20);                // scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_40);                // scope 1 at $DIR/enum_prop.rs:14:7: 14:8
-          StorageLive(_41);                // scope 1 at $DIR/enum_prop.rs:14:17: 14:24
-          Deinit(_41);                     // scope 1 at $DIR/enum_prop.rs:14:17: 14:24
-          ((_41 as Some).0: i32) = const 1_i32; // scope 1 at $DIR/enum_prop.rs:14:17: 14:24
-          discriminant(_41) = 1;           // scope 1 at $DIR/enum_prop.rs:14:17: 14:24
-          _42 = const 1_isize;             // scope 1 at $DIR/enum_prop.rs:14:17: 14:24
-          switchInt(const 1_isize) -> [0_isize: bb8, otherwise: bb9]; // scope 1 at $DIR/enum_prop.rs:14:11: 14:24
+          StorageLive(_29);                // scope 1 at $DIR/enum_prop.rs:14:5: 14:21
+          _51 = const main::promoted[1];   // scope 1 at $DIR/enum_prop.rs:14:5: 14:21
+                                           // mir::Constant
+                                           // + span: $DIR/enum_prop.rs:14:5: 14:21
+                                           // + literal: Const { ty: &Option<i32>, val: Unevaluated(main, [], Some(promoted[1])) }
+          _29 = _51;                       // scope 1 at $DIR/enum_prop.rs:14:5: 14:21
+          _26 = const 1_i32;               // scope 6 at $DIR/enum_prop.rs:14:25: 14:26
+          StorageDead(_29);                // scope 1 at $DIR/enum_prop.rs:14:25: 14:26
+          goto -> bb8;                     // scope 1 at $DIR/enum_prop.rs:14:25: 14:26
       }
   
       bb8: {
-          _40 = const 2_i32;               // scope 1 at $DIR/enum_prop.rs:16:13: 16:14
-          goto -> bb10;                    // scope 1 at $DIR/enum_prop.rs:16:13: 16:14
-      }
-  
-      bb9: {
-          StorageLive(_43);                // scope 1 at $DIR/enum_prop.rs:15:5: 15:21
-          _65 = const main::promoted[1];   // scope 1 at $DIR/enum_prop.rs:15:5: 15:21
-                                           // mir::Constant
-                                           // + span: $DIR/enum_prop.rs:15:5: 15:21
-                                           // + literal: Const { ty: &Option<i32>, val: Unevaluated(main, [], Some(promoted[1])) }
-          _43 = _65;                       // scope 1 at $DIR/enum_prop.rs:15:5: 15:21
-          _40 = const 1_i32;               // scope 6 at $DIR/enum_prop.rs:15:25: 15:26
-          StorageDead(_43);                // scope 1 at $DIR/enum_prop.rs:15:25: 15:26
-          goto -> bb10;                    // scope 1 at $DIR/enum_prop.rs:15:25: 15:26
-      }
-  
-      bb10: {
-          StorageDead(_41);                // scope 1 at $DIR/enum_prop.rs:17:4: 17:5
-          StorageLive(_44);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_45);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_46);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _46 = &_40;                      // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_47);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _64 = const main::promoted[0];   // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_27);                // scope 1 at $DIR/enum_prop.rs:16:4: 16:5
+          StorageLive(_30);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_31);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_32);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _32 = &_26;                      // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_33);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _50 = const main::promoted[0];   // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // mir::Constant
                                            // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // + literal: Const { ty: &i32, val: Unevaluated(main, [], Some(promoted[0])) }
-          _47 = _64;                       // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          Deinit(_45);                     // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          (_45.0: &i32) = move _46;        // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          (_45.1: &i32) = move _47;        // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageDead(_47);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageDead(_46);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_49);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _49 = (_45.0: &i32);             // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_50);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _50 = (_45.1: &i32);             // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_51);                // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_52);                // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_53);                // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _53 = (*_49);                    // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_54);                // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _54 = const 1_i32;               // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _52 = Eq(move _53, const 1_i32); // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageDead(_54);                // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageDead(_53);                // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _51 = Not(move _52);             // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageDead(_52);                // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          switchInt(move _51) -> [false: bb12, otherwise: bb11]; // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _33 = _50;                       // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          Deinit(_31);                     // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          (_31.0: &i32) = move _32;        // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          (_31.1: &i32) = move _33;        // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_33);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_32);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_35);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _35 = (_31.0: &i32);             // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_36);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _36 = (_31.1: &i32);             // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_37);                // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_38);                // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_39);                // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _39 = (*_35);                    // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_40);                // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _40 = const 1_i32;               // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _38 = Eq(move _39, const 1_i32); // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_40);                // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_39);                // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _37 = Not(move _38);             // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_38);                // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          switchInt(move _37) -> [false: bb10, otherwise: bb9]; // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       }
   
-      bb11: {
-          StorageLive(_56);                // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          Deinit(_56);                     // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          discriminant(_56) = 0;           // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_57);                // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_58);                // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _58 = const core::panicking::AssertKind::Eq; // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+      bb9: {
+          StorageLive(_42);                // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          Deinit(_42);                     // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          discriminant(_42) = 0;           // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_43);                // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_44);                // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _44 = const core::panicking::AssertKind::Eq; // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // mir::Constant
                                            // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // + literal: Const { ty: core::panicking::AssertKind, val: Value(Scalar(0x00)) }
-          StorageLive(_59);                // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_60);                // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _60 = _49;                       // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _59 = _60;                       // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_61);                // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_62);                // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _62 = _50;                       // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _61 = _62;                       // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_63);                // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          Deinit(_63);                     // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          discriminant(_63) = 0;           // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _57 = core::panicking::assert_failed::<i32, i32>(const core::panicking::AssertKind::Eq, move _59, move _61, move _63); // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_45);                // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_46);                // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _46 = _35;                       // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _45 = _46;                       // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_47);                // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_48);                // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _48 = _36;                       // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _47 = _48;                       // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_49);                // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          Deinit(_49);                     // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          discriminant(_49) = 0;           // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _43 = core::panicking::assert_failed::<i32, i32>(const core::panicking::AssertKind::Eq, move _45, move _47, move _49); // scope 8 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // mir::Constant
                                            // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
-                                           // + literal: Const { ty: for<'r, 's, 't0> fn(core::panicking::AssertKind, &'r i32, &'s i32, Option<Arguments<'t0>>) -> ! {core::panicking::assert_failed::<i32, i32>}, val: Value(Scalar(<ZST>)) }
+                                           // + literal: Const { ty: for<'r, 's, 't0> fn(core::panicking::AssertKind, &'r i32, &'s i32, Option<Arguments<'t0>>) -> ! {core::panicking::assert_failed::<i32, i32>}, val: Value(<ZST>) }
                                            // mir::Constant
                                            // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // + literal: Const { ty: core::panicking::AssertKind, val: Value(Scalar(0x00)) }
+      }
+  
+      bb10: {
+          StorageDead(_37);                // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_36);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_35);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_31);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_30);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_26);                // scope 1 at $DIR/enum_prop.rs:19:1: 19:2
+          StorageDead(_1);                 // scope 0 at $DIR/enum_prop.rs:19:1: 19:2
+          return;                          // scope 0 at $DIR/enum_prop.rs:19:2: 19:2
+      }
+  
+      bb11 (cleanup): {
+          resume;                          // scope 0 at $DIR/enum_prop.rs:3:1: 19:2
       }
   
       bb12: {
-          StorageDead(_51);                // scope 7 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageDead(_50);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageDead(_49);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageDead(_45);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageDead(_44);                // scope 5 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageDead(_40);                // scope 1 at $DIR/enum_prop.rs:20:1: 20:2
-          StorageDead(_1);                 // scope 0 at $DIR/enum_prop.rs:20:1: 20:2
-          return;                          // scope 0 at $DIR/enum_prop.rs:20:2: 20:2
-      }
-  
-      bb13 (cleanup): {
-          drop(_5) -> bb19;                // scope 0 at $DIR/enum_prop.rs:8:5: 8:6
-      }
-  
-      bb14 (cleanup): {
-          resume;                          // scope 0 at $DIR/enum_prop.rs:3:1: 20:2
-      }
-  
-      bb15: {
-          _68 = const false;               // scope 0 at $DIR/enum_prop.rs:10:4: 10:5
-          StorageDead(_2);                 // scope 0 at $DIR/enum_prop.rs:10:4: 10:5
-          StorageLive(_20);                // scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_21);                // scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_22);                // scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _22 = &_1;                       // scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_23);                // scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _66 = const main::promoted[2];   // scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _53 = const false;               // scope 0 at $DIR/enum_prop.rs:9:4: 9:5
+          StorageDead(_2);                 // scope 0 at $DIR/enum_prop.rs:9:4: 9:5
+          StorageLive(_6);                 // scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_7);                 // scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_8);                 // scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _8 = &_1;                        // scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_9);                 // scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _52 = const main::promoted[2];   // scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // mir::Constant
                                            // + span: $SRC_DIR/core/src/macros/mod.rs:LL:COL
                                            // + literal: Const { ty: &i32, val: Unevaluated(main, [], Some(promoted[2])) }
-          _23 = _66;                       // scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          Deinit(_21);                     // scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          (_21.0: &i32) = move _22;        // scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          (_21.1: &i32) = move _23;        // scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageDead(_23);                // scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageDead(_22);                // scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_25);                // scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _25 = (_21.0: &i32);             // scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_26);                // scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _26 = (_21.1: &i32);             // scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_27);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_28);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_29);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _29 = (*_25);                    // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageLive(_30);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _30 = const 10_i32;              // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _28 = Eq(move _29, const 10_i32); // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageDead(_30);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageDead(_29);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          _27 = Not(move _28);             // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          StorageDead(_28);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
-          switchInt(move _27) -> [false: bb7, otherwise: bb6]; // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _9 = _52;                        // scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          Deinit(_7);                      // scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          (_7.0: &i32) = move _8;          // scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          (_7.1: &i32) = move _9;          // scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_9);                 // scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_8);                 // scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_11);                // scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _11 = (_7.0: &i32);              // scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_12);                // scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _12 = (_7.1: &i32);              // scope 1 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_13);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_14);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_15);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _15 = (*_11);                    // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageLive(_16);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _16 = const 10_i32;              // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _14 = Eq(move _15, const 10_i32); // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_16);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_15);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          _13 = Not(move _14);             // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          StorageDead(_14);                // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
+          switchInt(move _13) -> [false: bb5, otherwise: bb4]; // scope 3 at $SRC_DIR/core/src/macros/mod.rs:LL:COL
       }
   
-      bb16: {
-          switchInt(_68) -> [false: bb15, otherwise: bb17]; // scope 0 at $DIR/enum_prop.rs:10:4: 10:5
+      bb13: {
+          switchInt(_53) -> [false: bb12, otherwise: bb14]; // scope 0 at $DIR/enum_prop.rs:9:4: 9:5
+      }
+  
+      bb14: {
+          drop(((_2 as Some).0: std::boxed::Box<i32>)) -> [return: bb12, unwind: bb11]; // scope 0 at $DIR/enum_prop.rs:9:4: 9:5
+      }
+  
+      bb15: {
+          _54 = discriminant(_2);          // scope 0 at $DIR/enum_prop.rs:9:4: 9:5
+          switchInt(move _54) -> [1_isize: bb13, otherwise: bb12]; // scope 0 at $DIR/enum_prop.rs:9:4: 9:5
+      }
+  
+      bb16 (cleanup): {
+          _56 = discriminant(_2);          // scope 0 at $DIR/enum_prop.rs:9:4: 9:5
+          goto -> bb11;                    // scope 0 at $DIR/enum_prop.rs:9:4: 9:5
       }
   
       bb17: {
-          drop(((_2 as Some).0: std::boxed::Box<i32>)) -> [return: bb15, unwind: bb14]; // scope 0 at $DIR/enum_prop.rs:10:4: 10:5
-      }
-  
-      bb18: {
-          _69 = discriminant(_2);          // scope 0 at $DIR/enum_prop.rs:10:4: 10:5
-          switchInt(move _69) -> [1_isize: bb16, otherwise: bb15]; // scope 0 at $DIR/enum_prop.rs:10:4: 10:5
-      }
-  
-      bb19 (cleanup): {
-          _71 = discriminant(_2);          // scope 0 at $DIR/enum_prop.rs:10:4: 10:5
-          goto -> bb14;                    // scope 0 at $DIR/enum_prop.rs:10:4: 10:5
-      }
-  
-      bb20: {
-          _3 = ShallowInitBox(move _75, i32); // scope 9 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
-          (*_3) = const 10_i32;            // scope 9 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
-          StorageDead(_75);                // scope 0 at $DIR/enum_prop.rs:4:22: 4:34
-          StorageDead(_74);                // scope 0 at $DIR/enum_prop.rs:4:22: 4:34
-          StorageDead(_73);                // scope 0 at $DIR/enum_prop.rs:4:22: 4:34
-          StorageDead(_72);                // scope 0 at $DIR/enum_prop.rs:4:22: 4:34
-          _68 = const true;                // scope 0 at $DIR/enum_prop.rs:4:17: 4:35
+          _3 = ShallowInitBox(move _62, i32); // scope 9 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
+          StorageLive(_63);                // scope 9 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
+          _63 = (((_3.0: std::ptr::Unique<i32>).0: std::ptr::NonNull<i32>).0: *const i32); // scope 9 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
+          (*_63) = const 10_i32;           // scope 9 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
+          StorageDead(_63);                // scope 9 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
+          StorageDead(_62);                // scope 0 at $DIR/enum_prop.rs:4:22: 4:34
+          StorageDead(_61);                // scope 0 at $DIR/enum_prop.rs:4:22: 4:34
+          StorageDead(_60);                // scope 0 at $DIR/enum_prop.rs:4:22: 4:34
+          StorageDead(_59);                // scope 0 at $DIR/enum_prop.rs:4:22: 4:34
+          _53 = const true;                // scope 0 at $DIR/enum_prop.rs:4:17: 4:35
           Deinit(_2);                      // scope 0 at $DIR/enum_prop.rs:4:17: 4:35
           ((_2 as Some).0: std::boxed::Box<i32>) = move _3; // scope 0 at $DIR/enum_prop.rs:4:17: 4:35
           discriminant(_2) = 1;            // scope 0 at $DIR/enum_prop.rs:4:17: 4:35
@@ -434,42 +353,8 @@
           switchInt(move _4) -> [1_isize: bb2, otherwise: bb1]; // scope 0 at $DIR/enum_prop.rs:4:11: 4:35
       }
   
-      bb21 (cleanup): {
+      bb18 (cleanup): {
           resume;                          // scope 9 at $SRC_DIR/alloc/src/boxed.rs:LL:COL
-      }
-  
-      bb22: {
-          StorageDead(_79);                // scope 13 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          StorageLive(_80);                // scope 13 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          StorageLive(_81);                // scope 13 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          _81 = _76;                       // scope 13 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          _80 = transmute::<&Box<i32>, &core::fmt::Opaque>(move _81) -> [return: bb23, unwind: bb13]; // scope 13 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-                                           // mir::Constant
-                                           // + span: $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-                                           // + literal: Const { ty: unsafe extern "rust-intrinsic" fn(&Box<i32>) -> &core::fmt::Opaque {transmute::<&Box<i32>, &core::fmt::Opaque>}, val: Value(Scalar(<ZST>)) }
-      }
-  
-      bb23: {
-          StorageDead(_81);                // scope 13 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          Deinit(_17);                     // scope 13 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          (_17.0: &core::fmt::Opaque) = move _80; // scope 13 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          (_17.1: for<'r, 's, 't0> fn(&'r core::fmt::Opaque, &'s mut std::fmt::Formatter<'t0>) -> std::result::Result<(), std::fmt::Error>) = move _78; // scope 13 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          StorageDead(_80);                // scope 13 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          StorageDead(_78);                // scope 13 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          StorageDead(_77);                // scope 11 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          StorageDead(_76);                // scope 11 at $SRC_DIR/core/src/fmt/mod.rs:LL:COL
-          StorageDead(_18);                // scope 2 at $DIR/enum_prop.rs:6:22: 6:23
-          _16 = [move _17];                // scope 2 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageDead(_17);                // scope 2 at $SRC_DIR/std/src/macros.rs:LL:COL
-          _15 = &_16;                      // scope 2 at $SRC_DIR/std/src/macros.rs:LL:COL
-          _14 = _15;                       // scope 2 at $SRC_DIR/std/src/macros.rs:LL:COL
-          _13 = move _14 as &[std::fmt::ArgumentV1] (Pointer(Unsize)); // scope 2 at $SRC_DIR/std/src/macros.rs:LL:COL
-          StorageDead(_14);                // scope 2 at $SRC_DIR/std/src/macros.rs:LL:COL
-          _8 = Arguments::new_v1(move _9, move _13) -> [return: bb3, unwind: bb13]; // scope 2 at $SRC_DIR/std/src/macros.rs:LL:COL
-                                           // mir::Constant
-                                           // + span: $SRC_DIR/std/src/macros.rs:LL:COL
-                                           // + user_ty: UserType(1)
-                                           // + literal: Const { ty: fn(&[&'static str], &[ArgumentV1]) -> Arguments {Arguments::new_v1}, val: Value(Scalar(<ZST>)) }
       }
   }
   

--- a/src/test/mir-opt/enum_prop.rs
+++ b/src/test/mir-opt/enum_prop.rs
@@ -1,0 +1,20 @@
+// EMIT_MIR enum_prop.main.SingleEnum.diff
+
+fn main() {
+  let v = match Some(Box::new(10)) {
+    Some(x) => {
+      println!("{}", x);
+      *x
+    },
+    _ => 3,
+  };
+  assert_eq!(v,10);
+
+
+  let x = match Some(1) {
+    ref _y @ Some(_) => 1,
+    None => 2,
+  };
+  assert_eq!(x, 1);
+
+}

--- a/src/test/mir-opt/enum_prop.rs
+++ b/src/test/mir-opt/enum_prop.rs
@@ -3,7 +3,6 @@
 fn main() {
   let v = match Some(Box::new(10)) {
     Some(x) => {
-      println!("{}", x);
       *x
     },
     _ => 3,

--- a/src/test/ui/drop/issue-90752.rs
+++ b/src/test/ui/drop/issue-90752.rs
@@ -14,14 +14,14 @@ fn test(drops: &RefCell<Vec<i32>>) {
     let mut foo = None;
     match foo {
         None => (),
-        _ => return,
+        _ => panic!(),
     }
 
     *(&mut foo) = Some((S(0, drops), S(1, drops))); // Both S(0) and S(1) should be dropped
 
     match foo {
         Some((_x, _)) => {}
-        _ => {}
+        _ => panic!("Should not match"),
     }
 }
 

--- a/src/test/ui/let-else/let-else-run-pass.rs
+++ b/src/test/ui/let-else/let-else-run-pass.rs
@@ -11,7 +11,7 @@ fn main() {
     }
     // ref binding to non-copy value and or-pattern
     let (MyEnum::A(ref x) | MyEnum::B { f: ref x }) = (MyEnum::B { f: String::new() }) else {
-        panic!();
+        panic!("Shouldn't have matched enum");
     };
     assert_eq!(x, "");
 
@@ -25,11 +25,11 @@ fn main() {
             };
             break;
         };
-        panic!();
+        panic!("Shouldn't have matched int");
     }
     assert_eq!(x, 3);
 
     // else return
     let Some(1) = Some(2) else { return };
-    panic!();
+    panic!("Shouldn't have matched");
 }


### PR DESCRIPTION
This adds a dataflow analysis in MIR, in the case that at compile time it is known that a variable will have a specific value for an enum, it converts `Discriminant` calls to constants. There seemed to be a number of issues where codegen could not remove matches when a constant was known, so adding an explicit analysis in MIR should help give more control.

I still need to add tests that it works, but it seems to apply to a number of tests already. If possible, a perf-run would be appreciated.