### PR TITLE
generator_interior: Count match pattern bindings as borrowed for the whole guard expression

### DIFF
--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -1323,6 +1323,20 @@ pub enum Guard<'hir> {
     IfLet(&'hir Let<'hir>),
 }
 
+impl<'hir> Guard<'hir> {
+    /// Returns the body of the guard
+    ///
+    /// In other words, returns the e in either of the following:
+    ///
+    /// - `if e`
+    /// - `if let x = e`
+    pub fn body(&self) -> &'hir Expr<'hir> {
+        match self {
+            Guard::If(e) | Guard::IfLet(_, e) => e,
+        }
+    }
+}
+
 #[derive(Debug, HashStable_Generic)]
 pub struct ExprField<'hir> {
     #[stable_hasher(ignore)]

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -1332,7 +1332,7 @@ impl<'hir> Guard<'hir> {
     /// - `if let x = e`
     pub fn body(&self) -> &'hir Expr<'hir> {
         match self {
-            Guard::If(e) | Guard::IfLet(_, e) => e,
+            Guard::If(e) | Guard::IfLet(Let { init: e, .. }) => e,
         }
     }
 }

--- a/compiler/rustc_typeck/src/check/generator_interior.rs
+++ b/compiler/rustc_typeck/src/check/generator_interior.rs
@@ -17,7 +17,6 @@ use rustc_middle::middle::region::{self, Scope, ScopeData, YieldData};
 use rustc_middle::ty::{self, Ty, TyCtxt};
 use rustc_span::symbol::sym;
 use rustc_span::Span;
-use smallvec::SmallVec;
 use tracing::debug;
 
 mod drop_ranges;
@@ -29,13 +28,6 @@ struct InteriorVisitor<'a, 'tcx> {
     expr_count: usize,
     kind: hir::GeneratorKind,
     prev_unresolved_span: Option<Span>,
-    /// Match arm guards have temporary borrows from the pattern bindings.
-    /// In case there is a yield point in a guard with a reference to such bindings,
-    /// such borrows can span across this yield point.
-    /// As such, we need to track these borrows and record them despite of the fact
-    /// that they may succeed the said yield point in the post-order.
-    guard_bindings: SmallVec<[SmallVec<[HirId; 4]>; 1]>,
-    guard_bindings_set: HirIdSet,
     linted_values: HirIdSet,
     drop_ranges: DropRanges,
 }
@@ -48,7 +40,6 @@ impl<'a, 'tcx> InteriorVisitor<'a, 'tcx> {
         scope: Option<region::Scope>,
         expr: Option<&'tcx Expr<'tcx>>,
         source_span: Span,
-        guard_borrowing_from_pattern: bool,
     ) {
         use rustc_span::DUMMY_SP;
 
@@ -89,8 +80,7 @@ impl<'a, 'tcx> InteriorVisitor<'a, 'tcx> {
                             // If it is a borrowing happening in the guard,
                             // it needs to be recorded regardless because they
                             // do live across this yield point.
-                            guard_borrowing_from_pattern
-                                || yield_data.expr_and_pat_count >= self.expr_count
+                            yield_data.expr_and_pat_count >= self.expr_count
                         })
                         .cloned()
                 })
@@ -196,8 +186,6 @@ pub fn resolve_interior<'a, 'tcx>(
         expr_count: 0,
         kind,
         prev_unresolved_span: None,
-        guard_bindings: <_>::default(),
-        guard_bindings_set: <_>::default(),
         linted_values: <_>::default(),
         drop_ranges: drop_ranges::compute_drop_ranges(fcx, def_id, body),
     };
@@ -284,8 +272,41 @@ impl<'a, 'tcx> Visitor<'tcx> for InteriorVisitor<'a, 'tcx> {
         let Arm { guard, pat, body, .. } = arm;
         self.visit_pat(pat);
         if let Some(ref g) = guard {
-            self.guard_bindings.push(<_>::default());
             {
+                // If there is a guard, we need to count all variables bound in the pattern as
+                // borrowed for the entire guard body, regardless of whether they are accessed.
+                // We do this by walking the pattern bindings and recording `&T` for any `x: T`
+                // that is bound.
+
+                struct ArmPatCollector<'a, 'b, 'tcx> {
+                    interior_visitor: &'a mut InteriorVisitor<'b, 'tcx>,
+                    scope: Scope,
+                }
+
+                impl<'a, 'b, 'tcx> Visitor<'tcx> for ArmPatCollector<'a, 'b, 'tcx> {
+                    fn visit_pat(&mut self, pat: &'tcx Pat<'tcx>) {
+                        intravisit::walk_pat(self, pat);
+                        if let PatKind::Binding(_, id, ident, ..) = pat.kind {
+                            let ty =
+                                self.interior_visitor.fcx.typeck_results.borrow().node_type(id);
+                            let tcx = self.interior_visitor.fcx.tcx;
+                            let ty = tcx.mk_ref(
+                                // Use `ReErased` as `resolve_interior` is going to replace all the
+                                // regions anyway.
+                                tcx.mk_region(ty::ReErased),
+                                ty::TypeAndMut { ty, mutbl: hir::Mutability::Not },
+                            );
+                            self.interior_visitor.record(
+                                ty,
+                                id,
+                                Some(self.scope),
+                                None,
+                                ident.span,
+                            );
+                        }
+                    }
+                }
+
                 ArmPatCollector {
                     interior_visitor: self,
                     scope: Scope { id: g.body().hir_id.local_id, data: ScopeData::Node },
@@ -301,12 +322,6 @@ impl<'a, 'tcx> Visitor<'tcx> for InteriorVisitor<'a, 'tcx> {
                     self.visit_let_expr(l);
                 }
             }
-
-            let mut scope_var_ids =
-                self.guard_bindings.pop().expect("should have pushed at least one earlier");
-            for var_id in scope_var_ids.drain(..) {
-                self.guard_bindings_set.remove(&var_id);
-            }
         }
         self.visit_expr(body);
     }
@@ -319,13 +334,11 @@ impl<'a, 'tcx> Visitor<'tcx> for InteriorVisitor<'a, 'tcx> {
         if let PatKind::Binding(..) = pat.kind {
             let scope = self.region_scope_tree.var_scope(pat.hir_id.local_id).unwrap();
             let ty = self.fcx.typeck_results.borrow().pat_ty(pat);
-            self.record(ty, pat.hir_id, Some(scope), None, pat.span, false);
+            self.record(ty, pat.hir_id, Some(scope), None, pat.span);
         }
     }
 
     fn visit_expr(&mut self, expr: &'tcx Expr<'tcx>) {
-        let mut guard_borrowing_from_pattern = false;
-
         match &expr.kind {
             ExprKind::Call(callee, args) => match &callee.kind {
                 ExprKind::Path(qpath) => {
@@ -352,16 +365,6 @@ impl<'a, 'tcx> Visitor<'tcx> for InteriorVisitor<'a, 'tcx> {
                 }
                 _ => intravisit::walk_expr(self, expr),
             },
-            ExprKind::Path(qpath) => {
-                intravisit::walk_expr(self, expr);
-                let res = self.fcx.typeck_results.borrow().qpath_res(qpath, expr.hir_id);
-                match res {
-                    Res::Local(id) if self.guard_bindings_set.contains(&id) => {
-                        guard_borrowing_from_pattern = true;
-                    }
-                    _ => {}
-                }
-            }
             _ => intravisit::walk_expr(self, expr),
         }
 
@@ -390,14 +393,7 @@ impl<'a, 'tcx> Visitor<'tcx> for InteriorVisitor<'a, 'tcx> {
         // If there are adjustments, then record the final type --
         // this is the actual value that is being produced.
         if let Some(adjusted_ty) = self.fcx.typeck_results.borrow().expr_ty_adjusted_opt(expr) {
-            self.record(
-                adjusted_ty,
-                expr.hir_id,
-                scope,
-                Some(expr),
-                expr.span,
-                guard_borrowing_from_pattern,
-            );
+            self.record(adjusted_ty, expr.hir_id, scope, Some(expr), expr.span);
         }
 
         // Also record the unadjusted type (which is the only type if
@@ -425,64 +421,9 @@ impl<'a, 'tcx> Visitor<'tcx> for InteriorVisitor<'a, 'tcx> {
         // The type table might not have information for this expression
         // if it is in a malformed scope. (#66387)
         if let Some(ty) = self.fcx.typeck_results.borrow().expr_ty_opt(expr) {
-            if guard_borrowing_from_pattern {
-                // Match guards create references to all the bindings in the pattern that are used
-                // in the guard, e.g. `y if is_even(y) => ...` becomes `is_even(*r_y)` where `r_y`
-                // is a reference to `y`, so we must record a reference to the type of the binding.
-                let tcx = self.fcx.tcx;
-                let ref_ty = tcx.mk_ref(
-                    // Use `ReErased` as `resolve_interior` is going to replace all the regions anyway.
-                    tcx.mk_region(ty::ReErased),
-                    ty::TypeAndMut { ty, mutbl: hir::Mutability::Not },
-                );
-                self.record(
-                    ref_ty,
-                    expr.hir_id,
-                    scope,
-                    Some(expr),
-                    expr.span,
-                    guard_borrowing_from_pattern,
-                );
-            }
-            self.record(
-                ty,
-                expr.hir_id,
-                scope,
-                Some(expr),
-                expr.span,
-                guard_borrowing_from_pattern,
-            );
+            self.record(ty, expr.hir_id, scope, Some(expr), expr.span);
         } else {
             self.fcx.tcx.sess.delay_span_bug(expr.span, "no type for node");
-        }
-    }
-}
-
-struct ArmPatCollector<'a, 'b, 'tcx> {
-    interior_visitor: &'a mut InteriorVisitor<'b, 'tcx>,
-    scope: Scope,
-}
-
-impl<'a, 'b, 'tcx> Visitor<'tcx> for ArmPatCollector<'a, 'b, 'tcx> {
-    fn visit_pat(&mut self, pat: &'tcx Pat<'tcx>) {
-        intravisit::walk_pat(self, pat);
-        if let PatKind::Binding(_, id, ..) = pat.kind {
-            self.interior_visitor
-                .guard_bindings
-                .last_mut()
-                .expect("should have pushed at least one earlier")
-                .push(id);
-            self.interior_visitor.guard_bindings_set.insert(id);
-
-            let ty = self.interior_visitor.fcx.typeck_results.borrow().node_type(id);
-            let ty = self.interior_visitor.fcx.tcx.mk_ref(
-                // Use `ReErased` as `resolve_interior` is going to replace all the regions anyway.
-                self.interior_visitor.fcx.tcx.mk_region(ty::ReErased),
-                ty::TypeAndMut { ty, mutbl: hir::Mutability::Not },
-            );
-            // FIXME: use the right span
-            let span = rustc_span::DUMMY_SP;
-            self.interior_visitor.record(ty, id, Some(self.scope), None, span, true);
         }
     }
 }

--- a/compiler/rustc_typeck/src/check/generator_interior/drop_ranges/record_consumed_borrow.rs
+++ b/compiler/rustc_typeck/src/check/generator_interior/drop_ranges/record_consumed_borrow.rs
@@ -171,7 +171,13 @@ impl<'tcx> expr_use_visitor::Delegate<'tcx> for ExprUseDelegate<'tcx> {
             .insert(TrackedValue::from_place_with_projections_allowed(place_with_id));
 
         // For copied we treat this mostly like a borrow except that we don't add the place
-        // to borrowed_temporaries because the copy is consumed.
+        // to borrowed_temporaries if it is not a local because the copy is consumed.
+        match place_with_id.place.base {
+            PlaceBase::Rvalue | PlaceBase::StaticItem | PlaceBase::Upvar(_) => (),
+            PlaceBase::Local(_) => {
+                self.places.borrowed_temporaries.insert(place_with_id.hir_id);
+            }
+        }
     }
 
     fn mutate(

--- a/compiler/rustc_typeck/src/check/generator_interior/drop_ranges/record_consumed_borrow.rs
+++ b/compiler/rustc_typeck/src/check/generator_interior/drop_ranges/record_consumed_borrow.rs
@@ -171,13 +171,7 @@ impl<'tcx> expr_use_visitor::Delegate<'tcx> for ExprUseDelegate<'tcx> {
             .insert(TrackedValue::from_place_with_projections_allowed(place_with_id));
 
         // For copied we treat this mostly like a borrow except that we don't add the place
-        // to borrowed_temporaries if it is not a local because the copy is consumed.
-        match place_with_id.place.base {
-            PlaceBase::Rvalue | PlaceBase::StaticItem | PlaceBase::Upvar(_) => (),
-            PlaceBase::Local(_) => {
-                self.places.borrowed_temporaries.insert(place_with_id.hir_id);
-            }
-        }
+        // to borrowed_temporaries because the copy is consumed.
     }
 
     fn mutate(

--- a/src/test/ui/generator/drop-tracking-yielding-in-match-guards.rs
+++ b/src/test/ui/generator/drop-tracking-yielding-in-match-guards.rs
@@ -14,20 +14,8 @@
 #![feature(generators)]
 
 fn main() {
-    let _a = static |x: u8| match x {
+    let _ = static |x: u8| match x {
         y if { yield } == y + 1 => (),
-        _ => (),
-    };
-
-    static STATIC: u8 = 42;
-    let _b = static |x: u8| match x {
-        y if { yield } == STATIC + 1 => (),
-        _ => (),
-    };
-
-    let upvar = 42u8;
-    let _c = static |x: u8| match x {
-        y if { yield } == upvar + 1 => (),
         _ => (),
     };
 }

--- a/src/test/ui/generator/drop-tracking-yielding-in-match-guards.rs
+++ b/src/test/ui/generator/drop-tracking-yielding-in-match-guards.rs
@@ -1,0 +1,25 @@
+// build-pass
+// edition:2018
+// compile-flags: -Zdrop-tracking
+
+// This test is derived from
+// https://github.com/rust-lang/rust/issues/72651#issuecomment-668720468
+
+// This test demonstrates that, in `async fn g()`,
+// indeed a temporary borrow `y` from `x` is live
+// while `f().await` is being evaluated.
+// Thus, `&'_ u8` should be included in type signature
+// of the underlying generator.
+
+async fn f() -> u8 { 1 }
+
+async fn i(x: u8) {
+    match x {
+        y if f().await == y + 1 => (),
+        _ => (),
+    }
+}
+
+fn main() {
+    let _ = i(8);
+}

--- a/src/test/ui/generator/drop-tracking-yielding-in-match-guards.rs
+++ b/src/test/ui/generator/drop-tracking-yielding-in-match-guards.rs
@@ -11,15 +11,11 @@
 // Thus, `&'_ u8` should be included in type signature
 // of the underlying generator.
 
-async fn f() -> u8 { 1 }
-
-async fn i(x: u8) {
-    match x {
-        y if f().await == y + 1 => (),
-        _ => (),
-    }
-}
+#![feature(generators)]
 
 fn main() {
-    let _ = i(8);
+    let _ = static |x: u8| match x {
+        y if { yield } == y + 1 => (),
+        _ => (),
+    };
 }

--- a/src/test/ui/generator/drop-tracking-yielding-in-match-guards.rs
+++ b/src/test/ui/generator/drop-tracking-yielding-in-match-guards.rs
@@ -14,8 +14,20 @@
 #![feature(generators)]
 
 fn main() {
-    let _ = static |x: u8| match x {
+    let _a = static |x: u8| match x {
         y if { yield } == y + 1 => (),
+        _ => (),
+    };
+
+    static STATIC: u8 = 42;
+    let _b = static |x: u8| match x {
+        y if { yield } == STATIC + 1 => (),
+        _ => (),
+    };
+
+    let upvar = 42u8;
+    let _c = static |x: u8| match x {
+        y if { yield } == upvar + 1 => (),
         _ => (),
     };
 }

--- a/src/test/ui/generator/drop-tracking-yielding-in-match-guards.rs
+++ b/src/test/ui/generator/drop-tracking-yielding-in-match-guards.rs
@@ -2,15 +2,6 @@
 // edition:2018
 // compile-flags: -Zdrop-tracking
 
-// This test is derived from
-// https://github.com/rust-lang/rust/issues/72651#issuecomment-668720468
-
-// This test demonstrates that, in `async fn g()`,
-// indeed a temporary borrow `y` from `x` is live
-// while `f().await` is being evaluated.
-// Thus, `&'_ u8` should be included in type signature
-// of the underlying generator.
-
 #![feature(generators)]
 
 fn main() {


### PR DESCRIPTION
The test case `yielding-in-match-guard.rs` was failing with `-Zdrop-tracking` enabled. The reason is that the copy of a local (`y`) was not counted as a borrow in typeck, while MIR did consider this as borrowed.

The correct thing to do here is to count pattern bindings are borrowed for the whole guard. Instead, what we were doing is to record the type at the use site of the variable and check if the variable comes from a borrowed pattern. Due to the fix for #57017, we were considering too small of a scope for this variable, which meant it was not counted as borrowed.

Because we now unconditionally record the borrow, rather than only for bindings that are used, this PR is also able to remove a lot of the logic around match bindings that was there before.

r? @nikomatsakis 