### PR TITLE
Drop tracking: handle invalid assignments better

### DIFF
--- a/compiler/rustc_typeck/src/check/generator_interior/drop_ranges/record_consumed_borrow.rs
+++ b/compiler/rustc_typeck/src/check/generator_interior/drop_ranges/record_consumed_borrow.rs
@@ -180,6 +180,15 @@ impl<'tcx> expr_use_visitor::Delegate<'tcx> for ExprUseDelegate<'tcx> {
         diag_expr_id: HirId,
     ) {
         debug!("mutate {assignee_place:?}; diag_expr_id={diag_expr_id:?}");
+
+        if assignee_place.place.base == PlaceBase::Rvalue
+            && assignee_place.place.projections.len() == 0
+        {
+            // Assigning to an Rvalue is illegal unless done through a dereference. We would have
+            // already gotten a type error, so we will just return here.
+            return;
+        }
+
         // If the type being assigned needs dropped, then the mutation counts as a borrow
         // since it is essentially doing `Drop::drop(&mut x); x = new_value;`.
         if assignee_place.place.base_ty.needs_drop(self.tcx, self.param_env) {

--- a/compiler/rustc_typeck/src/check/generator_interior/drop_ranges/record_consumed_borrow.rs
+++ b/compiler/rustc_typeck/src/check/generator_interior/drop_ranges/record_consumed_borrow.rs
@@ -182,7 +182,7 @@ impl<'tcx> expr_use_visitor::Delegate<'tcx> for ExprUseDelegate<'tcx> {
         debug!("mutate {assignee_place:?}; diag_expr_id={diag_expr_id:?}");
 
         if assignee_place.place.base == PlaceBase::Rvalue
-            && assignee_place.place.projections.len() == 0
+            && assignee_place.place.projections.is_empty()
         {
             // Assigning to an Rvalue is illegal unless done through a dereference. We would have
             // already gotten a type error, so we will just return here.

--- a/src/test/ui/async-await/issue-73741-type-err-drop-tracking.rs
+++ b/src/test/ui/async-await/issue-73741-type-err-drop-tracking.rs
@@ -1,0 +1,14 @@
+// edition:2018
+// compile-flags: -Zdrop-tracking
+// Regression test for issue #73741
+// Ensures that we don't emit spurious errors when
+// a type error ocurrs in an `async fn`
+
+async fn weird() {
+    1 = 2; //~ ERROR invalid left-hand side
+
+    let mut loop_count = 0;
+    async {}.await
+}
+
+fn main() {}

--- a/src/test/ui/async-await/issue-73741-type-err-drop-tracking.stderr
+++ b/src/test/ui/async-await/issue-73741-type-err-drop-tracking.stderr
@@ -1,0 +1,11 @@
+error[E0070]: invalid left-hand side of assignment
+  --> $DIR/issue-73741-type-err-drop-tracking.rs:8:7
+   |
+LL |     1 = 2;
+   |     - ^
+   |     |
+   |     cannot assign to this expression
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0070`.


### PR DESCRIPTION
Previously this test case was crashing with an index out of bounds error deep in the call to `needs_drop`. We avoid this by detecting clearly invalid assignees in the `mutate` callback and ignoring these.