### PR TITLE
Allow `test` to be built with build-std

### DIFF
--- a/library/test/src/lib.rs
+++ b/library/test/src/lib.rs
@@ -21,6 +21,7 @@
 #![feature(staged_api)]
 #![feature(process_exitcode_internals)]
 #![feature(test)]
+#![feature(restricted_std)]
 
 // Public reexports
 pub use self::bench::{black_box, Bencher};


### PR DESCRIPTION
`test` requires the feature `restricted_std` to be enabled in order to be built with build-std.
For me this solves issue https://github.com/rust-lang/wg-cargo-std-aware/issues/72, at least in so far as that building the test crate with `build-std` is successfull. 

I am not familiar with `restricted_std`, but enabling it doesn't seem to cause any test failures. Would this be acceptable, or is there something else I'm not aware of, that makes adding `restricted_std` not desirable?