### PR TITLE
Clarify Cargo.toml's LTO parse error message

### DIFF
--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -392,8 +392,7 @@ mod desc {
         "`all` (default), `except-unused-generics`, `except-unused-functions`, or `off`";
     pub const parse_unpretty: &str = "`string` or `string=string`";
     pub const parse_treat_err_as_bug: &str = "either no value or a number bigger than 0";
-    pub const parse_lto: &str =
-        "either a boolean (`true`, `false`, `yes`, `no`, `on`, `off`, etc), or a string (`\"thin\"`, `\"fat\"`), or omitted";
+    pub const parse_lto: &str = "either a boolean (`true`, `false`, `yes`, `no`, `on`, `off`, etc), or a string (`\"thin\"`, `\"fat\"`), or omitted";
     pub const parse_linker_plugin_lto: &str =
         "either a boolean (`yes`, `no`, `on`, `off`, etc), or the path to the linker plugin";
     pub const parse_location_detail: &str =

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -393,7 +393,7 @@ mod desc {
     pub const parse_unpretty: &str = "`string` or `string=string`";
     pub const parse_treat_err_as_bug: &str = "either no value or a number bigger than 0";
     pub const parse_lto: &str =
-        "either a boolean (`yes`, `no`, `on`, `off`, etc), `thin`, `fat`, or omitted";
+        "either a boolean (`true`, `false`, `yes`, `no`, `on`, `off`, etc), or a string (`\"thin\"`, `\"fat\"`), or omitted";
     pub const parse_linker_plugin_lto: &str =
         "either a boolean (`yes`, `no`, `on`, `off`, etc), or the path to the linker plugin";
     pub const parse_location_detail: &str =


### PR DESCRIPTION
Make the TOML LTO parse error message a little more specific, to be clear that it accepts both boolean and string valued expressions.

Only taken a month to edit a single string 😅 

Closes https://github.com/rust-lang/cargo/issues/10572