### PR TITLE
Implement pointee metadata unsizing via a TypedMetadata<T> container

### DIFF
--- a/compiler/rustc_codegen_ssa/src/lib.rs
+++ b/compiler/rustc_codegen_ssa/src/lib.rs
@@ -1,4 +1,5 @@
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
+#![feature(assert_matches)]
 #![feature(box_patterns)]
 #![feature(try_blocks)]
 #![feature(let_else)]

--- a/compiler/rustc_codegen_ssa/src/mir/rvalue.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/rvalue.rs
@@ -225,7 +225,6 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                         operand.val
                     }
                     mir::CastKind::Pointer(PointerCast::Unsize) => {
-                        assert!(bx.cx().is_backend_scalar_pair(cast));
                         let (lldata, llextra) = match operand.val {
                             OperandValue::Pair(lldata, llextra) => {
                                 // unsize from a fat pointer -- this is a
@@ -240,9 +239,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                                 bug!("by-ref operand {:?} in `codegen_rvalue_operand`", operand);
                             }
                         };
-                        let (lldata, llextra) =
-                            base::unsize_ptr(&mut bx, lldata, operand.layout.ty, cast.ty, llextra);
-                        OperandValue::Pair(lldata, llextra)
+                        base::unsize_ptr(&mut bx, lldata, operand.layout.ty, cast.ty, llextra)
                     }
                     mir::CastKind::Pointer(PointerCast::MutToConstPointer)
                     | mir::CastKind::Misc

--- a/compiler/rustc_hir/src/lang_items.rs
+++ b/compiler/rustc_hir/src/lang_items.rs
@@ -182,6 +182,7 @@ language_item_table! {
     PointeeTrait,            sym::pointee_trait,       pointee_trait,              Target::Trait,          GenericRequirement::None;
     Metadata,                sym::metadata_type,       metadata_type,              Target::AssocTy,        GenericRequirement::None;
     DynMetadata,             sym::dyn_metadata,        dyn_metadata,               Target::Struct,         GenericRequirement::None;
+    TypedMetadata,           sym::typed_metadata,      typed_metadata,             Target::Struct,         GenericRequirement::Exact(1);
 
     Freeze,                  sym::freeze,              freeze_trait,               Target::Trait,          GenericRequirement::Exact(0);
 

--- a/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
@@ -215,7 +215,7 @@ provide! { <'tcx> tcx, def_id, other, cdata,
     impl_polarity => { table_direct }
     impl_defaultness => { table_direct }
     constness => { table_direct }
-    coerce_unsized_info => { table }
+    coerce_unsized_kind => { table }
     mir_const_qualif => { table }
     rendered_const => { table }
     asyncness => { table_direct }

--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -1482,9 +1482,9 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
                     // if this is an impl of `CoerceUnsized`, create its
                     // "unsized info", else just store None
                     if Some(trait_ref.def_id) == self.tcx.lang_items().coerce_unsized_trait() {
-                        let coerce_unsized_info =
-                            self.tcx.at(item.span).coerce_unsized_info(def_id);
-                        record!(self.tables.coerce_unsized_info[def_id] <- coerce_unsized_info);
+                        let coerce_unsized_kind =
+                            self.tcx.at(item.span).coerce_unsized_kind(def_id);
+                        record!(self.tables.coerce_unsized_kind[def_id] <- coerce_unsized_kind);
                     }
                 }
 

--- a/compiler/rustc_metadata/src/rmeta/mod.rs
+++ b/compiler/rustc_metadata/src/rmeta/mod.rs
@@ -368,7 +368,7 @@ define_tables! {
     is_intrinsic: Table<DefIndex, ()>,
     impl_defaultness: Table<DefIndex, hir::Defaultness>,
     // FIXME(eddyb) perhaps compute this on the fly if cheap enough?
-    coerce_unsized_info: Table<DefIndex, LazyValue<ty::adjustment::CoerceUnsizedInfo>>,
+    coerce_unsized_kind: Table<DefIndex, LazyValue<ty::adjustment::CoerceUnsizedKind>>,
     mir_const_qualif: Table<DefIndex, LazyValue<mir::ConstQualifs>>,
     rendered_const: Table<DefIndex, LazyValue<String>>,
     asyncness: Table<DefIndex, hir::IsAsync>,

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -835,8 +835,8 @@ rustc_queries! {
     }
 
     /// Caches `CoerceUnsized` kinds for impls on custom types.
-    query coerce_unsized_info(key: DefId) -> ty::adjustment::CoerceUnsizedInfo {
-        desc { |tcx| "computing CoerceUnsized info for `{}`", tcx.def_path_str(key) }
+    query coerce_unsized_kind(key: DefId) -> ty::adjustment::CoerceUnsizedKind {
+        desc { |tcx| "computing CoerceUnsized kind for `{}`", tcx.def_path_str(key) }
         cache_on_disk_if { key.is_local() }
         separate_provide_extern
     }

--- a/compiler/rustc_middle/src/ty/adjustment.rs
+++ b/compiler/rustc_middle/src/ty/adjustment.rs
@@ -177,20 +177,15 @@ pub enum AutoBorrow<'tcx> {
 /// Information for `CoerceUnsized` impls, storing information we
 /// have computed about the coercion.
 ///
-/// This struct can be obtained via the `coerce_impl_info` query.
+/// This enum can be obtained via the `coerce_unsized_kind` query.
 /// Demanding this struct also has the side-effect of reporting errors
 /// for inappropriate impls.
-#[derive(Clone, Copy, TyEncodable, TyDecodable, Debug, HashStable)]
-pub struct CoerceUnsizedInfo {
-    /// If this is a "custom coerce" impl, then what kind of custom
-    /// coercion is it? This applies to impls of `CoerceUnsized` for
-    /// structs, primarily, where we store a bit of info about which
-    /// fields need to be coerced.
-    pub custom_kind: Option<CustomCoerceUnsized>,
-}
-
-#[derive(Clone, Copy, TyEncodable, TyDecodable, Debug, HashStable)]
-pub enum CustomCoerceUnsized {
-    /// Records the index of the field being coerced.
+#[derive(Clone, Copy, PartialEq, TyEncodable, TyDecodable, Debug, HashStable)]
+pub enum CoerceUnsizedKind {
+    /// Coercion of a raw pointer or ref.
+    Ptr,
+    /// Coercion of a struct. Records the index of the field being coerced.
     Struct(usize),
+    /// Coercion of the pointee metadata directly.
+    TypedMetadata,
 }

--- a/compiler/rustc_middle/src/ty/parameterized.rs
+++ b/compiler/rustc_middle/src/ty/parameterized.rs
@@ -59,7 +59,7 @@ trivially_parameterized_over_tcx! {
     ty::ReprOptions,
     ty::TraitDef,
     ty::Visibility,
-    ty::adjustment::CoerceUnsizedInfo,
+    ty::adjustment::CoerceUnsizedKind,
     ty::fast_reject::SimplifiedTypeGen<DefId>,
     rustc_ast::Attribute,
     rustc_ast::MacArgs,

--- a/compiler/rustc_monomorphize/src/lib.rs
+++ b/compiler/rustc_monomorphize/src/lib.rs
@@ -11,7 +11,7 @@ extern crate rustc_middle;
 
 use rustc_hir::lang_items::LangItem;
 use rustc_middle::traits;
-use rustc_middle::ty::adjustment::CustomCoerceUnsized;
+use rustc_middle::ty::adjustment::CoerceUnsizedKind;
 use rustc_middle::ty::query::Providers;
 use rustc_middle::ty::{self, Ty, TyCtxt};
 
@@ -24,7 +24,7 @@ fn custom_coerce_unsize_info<'tcx>(
     tcx: TyCtxt<'tcx>,
     source_ty: Ty<'tcx>,
     target_ty: Ty<'tcx>,
-) -> CustomCoerceUnsized {
+) -> CoerceUnsizedKind {
     let def_id = tcx.require_lang_item(LangItem::CoerceUnsized, None);
 
     let trait_ref = ty::Binder::dummy(ty::TraitRef {
@@ -36,7 +36,7 @@ fn custom_coerce_unsize_info<'tcx>(
         Ok(traits::ImplSource::UserDefined(traits::ImplSourceUserDefinedData {
             impl_def_id,
             ..
-        })) => tcx.coerce_unsized_info(impl_def_id).custom_kind.unwrap(),
+        })) => tcx.coerce_unsized_kind(impl_def_id),
         impl_source => {
             bug!("invalid `CoerceUnsized` impl_source: {:?}", impl_source);
         }

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1466,6 +1466,7 @@ symbols! {
         type_length_limit,
         type_macros,
         type_name,
+        typed_metadata,
         u128,
         u16,
         u32,

--- a/compiler/rustc_typeck/src/coherence/mod.rs
+++ b/compiler/rustc_typeck/src/coherence/mod.rs
@@ -143,7 +143,7 @@ fn enforce_empty_impls_for_marker_traits(
 }
 
 pub fn provide(providers: &mut Providers) {
-    use self::builtin::coerce_unsized_info;
+    use self::builtin::coerce_unsized_kind;
     use self::inherent_impls::{crate_incoherent_impls, crate_inherent_impls, inherent_impls};
     use self::inherent_impls_overlap::crate_inherent_impls_overlap_check;
     use self::orphan::orphan_check_impl;
@@ -154,7 +154,7 @@ pub fn provide(providers: &mut Providers) {
         crate_incoherent_impls,
         inherent_impls,
         crate_inherent_impls_overlap_check,
-        coerce_unsized_info,
+        coerce_unsized_kind,
         orphan_check_impl,
         ..*providers
     };

--- a/library/core/src/ops/unsize.rs
+++ b/library/core/src/ops/unsize.rs
@@ -1,4 +1,6 @@
 use crate::marker::Unsize;
+#[cfg(not(bootstrap))]
+use crate::ptr::TypedMetadata;
 
 /// Trait that indicates that this is a pointer or a wrapper for one,
 /// where unsizing can be performed on the pointee.
@@ -67,6 +69,10 @@ impl<T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<*const U> for *mut T {}
 // *const T -> *const U
 #[unstable(feature = "coerce_unsized", issue = "27732")]
 impl<T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<*const U> for *const T {}
+
+#[cfg(not(bootstrap))]
+#[unstable(feature = "coerce_unsized", issue = "27732")]
+impl<T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<TypedMetadata<U>> for TypedMetadata<T> {}
 
 /// `DispatchFromDyn` is used in the implementation of object safety checks (specifically allowing
 /// arbitrary self types), to guarantee that a method's receiver type can be dispatched on.

--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -392,7 +392,9 @@ pub use crate::intrinsics::write_bytes;
 mod metadata;
 pub(crate) use metadata::PtrRepr;
 #[unstable(feature = "ptr_metadata", issue = "81513")]
-pub use metadata::{from_raw_parts, from_raw_parts_mut, metadata, DynMetadata, Pointee, Thin};
+pub use metadata::{
+    from_raw_parts, from_raw_parts_mut, metadata, DynMetadata, Pointee, Thin, TypedMetadata,
+};
 
 mod non_null;
 #[stable(feature = "nonnull", since = "1.25.0")]

--- a/src/test/ui/coercion/coerce-just-metadata.rs
+++ b/src/test/ui/coercion/coerce-just-metadata.rs
@@ -1,0 +1,26 @@
+// build-pass
+#![feature(ptr_metadata)]
+
+use std::ptr::TypedMetadata;
+
+struct Struct;
+trait Trait {}
+
+impl Trait for Struct {}
+
+fn main() {
+    // array -> slice
+    let sized: TypedMetadata<[u8; 5]> = TypedMetadata(());
+    let _: TypedMetadata<[u8]> = sized;
+
+    // sized -> dyn
+    let sized: TypedMetadata<Struct> = TypedMetadata(());
+    let dyn_trait: TypedMetadata<dyn Trait + Sync> = sized;
+
+    // dyn -> dyn
+    let _: TypedMetadata<dyn Trait> = dyn_trait;
+
+    // identity
+    let sized: TypedMetadata<Struct> = TypedMetadata(());
+    let _ = sized as TypedMetadata<Struct>;
+}

--- a/src/test/ui/coercion/just-metadata-bad-coercions.rs
+++ b/src/test/ui/coercion/just-metadata-bad-coercions.rs
@@ -1,0 +1,18 @@
+#![feature(ptr_metadata)]
+
+use std::ptr::TypedMetadata;
+
+struct Struct;
+trait Trait {}
+
+fn main() {
+    let struct_metadata: TypedMetadata<Struct> = TypedMetadata(());
+
+    let _: TypedMetadata<dyn Trait> = struct_metadata; //~ ERROR `Struct: Trait` is not satisfied
+    let _: TypedMetadata<[Struct]> = struct_metadata; //~ ERROR mismatched types
+
+    let array_metadata: TypedMetadata<[u8; 4]> = TypedMetadata(());
+
+    let _: TypedMetadata<[u32]> = array_metadata; //~ ERROR mismatched types
+    let _: TypedMetadata<Struct> = array_metadata; //~ ERROR mismatched types
+}

--- a/src/test/ui/coercion/just-metadata-bad-coercions.stderr
+++ b/src/test/ui/coercion/just-metadata-bad-coercions.stderr
@@ -1,0 +1,45 @@
+error[E0308]: mismatched types
+  --> $DIR/just-metadata-bad-coercions.rs:12:38
+   |
+LL |     let _: TypedMetadata<[Struct]> = struct_metadata;
+   |            -----------------------   ^^^^^^^^^^^^^^^ expected slice, found struct `Struct`
+   |            |
+   |            expected due to this
+   |
+   = note: expected struct `TypedMetadata<[Struct]>`
+              found struct `TypedMetadata<Struct>`
+
+error[E0277]: the trait bound `Struct: Trait` is not satisfied
+  --> $DIR/just-metadata-bad-coercions.rs:11:39
+   |
+LL |     let _: TypedMetadata<dyn Trait> = struct_metadata;
+   |                                       ^^^^^^^^^^^^^^^ the trait `Trait` is not implemented for `Struct`
+   |
+   = note: required for the cast from `Struct` to the object type `dyn Trait`
+
+error[E0308]: mismatched types
+  --> $DIR/just-metadata-bad-coercions.rs:16:35
+   |
+LL |     let _: TypedMetadata<[u32]> = array_metadata;
+   |            --------------------   ^^^^^^^^^^^^^^ expected slice `[u32]`, found array `[u8; 4]`
+   |            |
+   |            expected due to this
+   |
+   = note: expected struct `TypedMetadata<[u32]>`
+              found struct `TypedMetadata<[u8; 4]>`
+
+error[E0308]: mismatched types
+  --> $DIR/just-metadata-bad-coercions.rs:17:36
+   |
+LL |     let _: TypedMetadata<Struct> = array_metadata;
+   |            ---------------------   ^^^^^^^^^^^^^^ expected struct `Struct`, found array `[u8; 4]`
+   |            |
+   |            expected due to this
+   |
+   = note: expected struct `TypedMetadata<Struct>`
+              found struct `TypedMetadata<[u8; 4]>`
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0277, E0308.
+For more information about an error, try `rustc --explain E0277`.

--- a/src/test/ui/coercion/silly-box.rs
+++ b/src/test/ui/coercion/silly-box.rs
@@ -1,0 +1,27 @@
+// build-pass
+#![feature(coerce_unsized, ptr_metadata, unsize)]
+
+use std::marker::Unsize;
+use std::ops::CoerceUnsized;
+use std::ptr::{NonNull, TypedMetadata};
+
+struct SillyBox<T: ?Sized> {
+    data: NonNull<()>,
+    meta: TypedMetadata<T>,
+}
+
+impl<T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<SillyBox<U>> for SillyBox<T> {}
+
+fn do_unsize_slice(it: SillyBox<[u8; 5]>) -> SillyBox<[u8]> {
+    it
+}
+
+struct S;
+trait Trait {}
+impl Trait for S {}
+
+fn do_unsize_trait(it: SillyBox<S>) -> SillyBox<dyn Trait> {
+    it
+}
+
+fn main() {}


### PR DESCRIPTION
TL;DR:

```rust
// std::ptr
struct TypedMetadata<T: ?Sized>(pub <T as Pointee>::Metadata);
impl<T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<TypedMetadata<U>> for TypedMetadata<T> {}
```

See src/test/ui/coercion/coerce-just-metadata.rs for an example of this working.

The motivating example is being able to spell a type like

```rust
struct SillyBox<T: ?Sized> {
    data: ptr::NonNull<()>,
    meta: TypedMetadata<T>,
}
```

and implement `CoerceUnsized` for it. This is shown to work in src/test/ui/coercion/silly-box.rs.

It may be desirable to support coercing `DynMetadata<T>` in the future (e.g. `DynMetadata<dyn Trait + Sync> -> DynMetadata<dyn Trait>`). This PR does not add this, but it could be added fairly easily by adding a `CoerceUnsized` impl for `DynMetadata` and allowing `DynMetadata` where `TypedMetadata` is checked for here.

-----

### FAQ

#### Isn't `TypedMetadata<T>` just a type alias for `<T as Pointee>::Metadata`?

Yes and no. The main problem at hand is that `<T as Pointee>::Metadata` no longer remembers what `T` is once the projection has been resolved. `TypedMetadata<T>` then is a "strongly typed alias" which reintroduces `T` and provides the ability to implement `CoerceUnsized`, which cannot be directly implemented on a resolved `<T as Pointee>::Metadata`.

There is a potential alternative -- instead of getting `impl CoerceUnsized` to work for `TypedMetadata<T>` as a builtin and then using the existing `struct` behavior for `impl CoerceUnsized`, we could teach coercion (and `impl CoerceUnsized`) to recognize the `<T as Pointee>::Metadata` projection and *directly* coerce that (as is currently done in `TypedMetadata<T>`) rather than delegating to the field's `CoerceUnsized` implementation. (However, this may be impractical, as type projections tend to get normalized away.)

This would make `TypedMetadata` a pure library type, but it would still be necessary if wanting to coerce/convert `<T as Pointee>::Metadata` in a function body or for some concrete `T`, rather than as a generic struct field.

#### Why a coercion instead of just a conversion?

Such that `SillyBox<T>` can be coerced. (See also the next question.)

A conversion is fairly simple to write: just `ptr::from_raw_parts` a null data pointer and the metadata, then coerce that.

#### Why not use `*mut T` instead of `(*mut (), <T as Pointee>::Metadata)`?

The short version: because you might not always have a pointer.

There are a few reasons you might want to elide storing the actual pointer-to-`T`, or store something other than a pointer alongside the pointee metadata.

One such case is if you have some allocation at a statically known location; in this case it could make sense to have a `StaticRef` which just stores the pointee metadata and implements `Deref` by constructing a normal reference from the raw parts of the static location and the stored metadata. Normally such usage would necessarily also know the full concrete type and thus not need to use non-`()` metadata, but situations such as using linker functionality to place a slice at a (linker-known) static address could want to have `StaticRef<[T]>` to avoid re-deriving the linker-provided length multiple times.

Another such case is the use of something like an arena allocator, or a compacting allocator, or any storage allocation which doesn't hand out raw pointers and pin the allocated memory. Here, your `ArenaBox<T>`/`ArenaRef<T>` would store the index into the arena (and perhaps additional metadata like a generation) and the pointee metadata, and then you ask the arena to temporarily resolve the `ArenaRef<T>` into a normal `&T`.

Yet another is `StackBox<T>`, which stores a potentially unsized pointee in its own inline memory, allowing for the use of unsized types (such as `dyn Trait`) without indirection by always reserving a fixed max size/align for them on the stack.

All of these *could* be serviced by storing the metadata on a dangling pointer; however, this extra stored pointer exists solely to appease the compiler, and not for any actual benefit to the program.