### PR TITLE
Fix use of SetHandleInformation on UWP

### DIFF
--- a/library/std/src/os/windows/io/handle.rs
+++ b/library/std/src/os/windows/io/handle.rs
@@ -206,6 +206,7 @@ impl OwnedHandle {
     }
 
     /// Allow child processes to inherit the handle.
+    #[cfg(not(target_vendor = "uwp"))]
     pub(crate) fn set_inheritable(&self) -> io::Result<()> {
         cvt(unsafe {
             c::SetHandleInformation(

--- a/library/std/src/os/windows/io/socket.rs
+++ b/library/std/src/os/windows/io/socket.rs
@@ -10,6 +10,7 @@ use crate::mem;
 use crate::mem::forget;
 use crate::sys;
 use crate::sys::c;
+#[cfg(not(target_vendor = "uwp"))]
 use crate::sys::cvt;
 
 /// A borrowed socket.

--- a/library/std/src/sys/windows/handle.rs
+++ b/library/std/src/sys/windows/handle.rs
@@ -221,6 +221,7 @@ impl Handle {
         Ok(Self(self.0.duplicate(access, inherit, options)?))
     }
 
+    #[cfg(not(target_vendor = "uwp"))]
     pub(crate) fn set_inheritable(&self) -> io::Result<()> {
         self.0.set_inheritable()
     }

--- a/library/std/src/sys/windows/pipe.rs
+++ b/library/std/src/sys/windows/pipe.rs
@@ -57,10 +57,21 @@ impl Pipes {
             } else {
                 let (ours, theirs) = if ours_readable { (read, write) } else { (write, read) };
                 let ours = Handle::from_raw_handle(ours);
+                #[cfg(not(target_vendor = "uwp"))]
                 let theirs = Handle::from_raw_handle(theirs);
+                #[cfg(target_vendor = "uwp")]
+                let mut theirs = Handle::from_raw_handle(theirs);
 
                 if their_handle_inheritable {
-                    theirs.set_inheritable()?;
+                    #[cfg(not(target_vendor = "uwp"))]
+                    {
+                        theirs.set_inheritable()?;
+                    }
+
+                    #[cfg(target_vendor = "uwp")]
+                    {
+                        theirs = theirs.duplicate(0, true, c::DUPLICATE_SAME_ACCESS)?;
+                    }
                 }
 
                 Ok(Pipes { ours: AnonPipe::Sync(ours), theirs: AnonPipe::Sync(theirs) })


### PR DESCRIPTION
The use of `SetHandleInformation` (introduced in #96441 to make `HANDLE` inheritable) breaks UWP builds because it is not available for UWP targets.

Proposed workaround: duplicate the `HANDLE` with `inherit = true` and immediately close the old one. Traditional Windows Desktop programs are not affected.

cc @ChrisDenton