### PR TITLE
Rename `eq_ignore_case` to `starts_with_ignore_case`

### DIFF
--- a/library/core/src/num/dec2flt/common.rs
+++ b/library/core/src/num/dec2flt/common.rs
@@ -36,7 +36,7 @@ pub(crate) trait ByteSlice: AsRef<[u8]> {
     }
 
     /// Check if self starts with u with a case-insensitive comparison.
-    fn eq_ignore_case(&self, u: &[u8]) -> bool {
+    fn starts_with_ignore_case(&self, u: &[u8]) -> bool {
         debug_assert!(self.as_ref().len() >= u.len());
         let iter = self.as_ref().iter().zip(u.iter());
         let d = iter.fold(0, |i, (&x, &y)| i | (x ^ y));

--- a/library/core/src/num/dec2flt/parse.rs
+++ b/library/core/src/num/dec2flt/parse.rs
@@ -207,12 +207,12 @@ pub fn parse_number(s: &[u8], negative: bool) -> Option<Number> {
 /// Parse a partial representation of a special, non-finite float.
 fn parse_partial_inf_nan<F: RawFloat>(s: &[u8]) -> Option<(F, usize)> {
     fn parse_inf_rest(s: &[u8]) -> usize {
-        if s.len() >= 8 && s[3..].as_ref().eq_ignore_case(b"inity") { 8 } else { 3 }
+        if s.len() >= 8 && s[3..].as_ref().starts_with_ignore_case(b"inity") { 8 } else { 3 }
     }
     if s.len() >= 3 {
-        if s.eq_ignore_case(b"nan") {
+        if s.starts_with_ignore_case(b"nan") {
             return Some((F::NAN, 3));
-        } else if s.eq_ignore_case(b"inf") {
+        } else if s.starts_with_ignore_case(b"inf") {
             return Some((F::INFINITY, parse_inf_rest(s)));
         }
     }


### PR DESCRIPTION
The method doesn't test for equality. It tests if the object starts with
a given byte array, so its name is confusing.