### PR TITLE
Simplify some code that depend on Deref

### DIFF
--- a/compiler/rustc_codegen_ssa/src/mir/place.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/place.rs
@@ -435,13 +435,12 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
             LocalRef::Place(place) => place,
             LocalRef::UnsizedPlace(place) => bx.load_operand(place).deref(cx),
             LocalRef::Operand(..) => {
-                if place_ref.ret_deref().is_some() {
+                if place_ref.has_deref() {
                     base = 1;
                     let cg_base = self.codegen_consume(
                         bx,
                         mir::PlaceRef { projection: &place_ref.projection[..0], ..place_ref },
                     );
-
                     cg_base.deref(bx.cx())
                 } else {
                     bug!("using operand local {:?} as place", place_ref);

--- a/compiler/rustc_codegen_ssa/src/mir/place.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/place.rs
@@ -435,16 +435,11 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
             LocalRef::Place(place) => place,
             LocalRef::UnsizedPlace(place) => bx.load_operand(place).deref(cx),
             LocalRef::Operand(..) => {
-                if let Some(elem) = place_ref
-                    .projection
-                    .iter()
-                    .enumerate()
-                    .find(|elem| matches!(elem.1, mir::ProjectionElem::Deref))
-                {
-                    base = elem.0 + 1;
+                if place_ref.ret_deref().is_some() {
+                    base = 1;
                     let cg_base = self.codegen_consume(
                         bx,
-                        mir::PlaceRef { projection: &place_ref.projection[..elem.0], ..place_ref },
+                        mir::PlaceRef { projection: &place_ref.projection[..0], ..place_ref },
                     );
 
                     cg_base.deref(bx.cx())

--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -1463,11 +1463,11 @@ impl<'tcx> Place<'tcx> {
 
     /// If MirPhase >= Derefered and if projection contains Deref,
     /// It's guaranteed to be in the first place
-    pub fn ret_deref(&self) -> Option<PlaceElem<'tcx>> {
+    pub fn has_deref(&self) -> bool {
         if !self.projection.is_empty() && self.projection[0] == PlaceElem::Deref {
-            return Some(self.projection[0]);
+            true
         } else {
-            None
+            false
         }
     }
 
@@ -1545,11 +1545,11 @@ impl<'tcx> PlaceRef<'tcx> {
 
     /// If MirPhase >= Derefered and if projection contains Deref,
     /// It's guaranteed to be in the first place
-    pub fn ret_deref(&self) -> Option<PlaceElem<'tcx>> {
+    pub fn has_deref(&self) -> bool {
         if !self.projection.is_empty() && self.projection[0] == PlaceElem::Deref {
-            return Some(self.projection[0]);
+            true
         } else {
-            None
+            false
         }
     }
 

--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -1464,11 +1464,7 @@ impl<'tcx> Place<'tcx> {
     /// If MirPhase >= Derefered and if projection contains Deref,
     /// It's guaranteed to be in the first place
     pub fn has_deref(&self) -> bool {
-        if !self.projection.is_empty() && self.projection[0] == PlaceElem::Deref {
-            true
-        } else {
-            false
-        }
+        self.projection.first() == Some(&PlaceElem::Deref)
     }
 
     /// Finds the innermost `Local` from this `Place`, *if* it is either a local itself or
@@ -1546,11 +1542,7 @@ impl<'tcx> PlaceRef<'tcx> {
     /// If MirPhase >= Derefered and if projection contains Deref,
     /// It's guaranteed to be in the first place
     pub fn has_deref(&self) -> bool {
-        if !self.projection.is_empty() && self.projection[0] == PlaceElem::Deref {
-            true
-        } else {
-            false
-        }
+        self.projection.first() == Some(&PlaceElem::Deref)
     }
 
     /// If this place represents a local variable like `_X` with no

--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -1464,6 +1464,8 @@ impl<'tcx> Place<'tcx> {
     /// If MirPhase >= Derefered and if projection contains Deref,
     /// It's guaranteed to be in the first place
     pub fn has_deref(&self) -> bool {
+        // To make sure this is not accidently used in wrong mir phase
+        debug_assert!(!self.projection[1..].contains(&PlaceElem::Deref));
         self.projection.first() == Some(&PlaceElem::Deref)
     }
 

--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -1461,6 +1461,16 @@ impl<'tcx> Place<'tcx> {
         self.projection.iter().any(|elem| elem.is_indirect())
     }
 
+    /// If MirPhase >= Derefered and if projection contains Deref,
+    /// It's guaranteed to be in the first place
+    pub fn ret_deref(&self) -> Option<PlaceElem<'tcx>> {
+        if !self.projection.is_empty() && self.projection[0] == PlaceElem::Deref {
+            return Some(self.projection[0]);
+        } else {
+            None
+        }
+    }
+
     /// Finds the innermost `Local` from this `Place`, *if* it is either a local itself or
     /// a single deref of a local.
     #[inline(always)]
@@ -1530,6 +1540,16 @@ impl<'tcx> PlaceRef<'tcx> {
             PlaceRef { local, projection: [] }
             | PlaceRef { local, projection: [ProjectionElem::Deref] } => Some(local),
             _ => None,
+        }
+    }
+
+    /// If MirPhase >= Derefered and if projection contains Deref,
+    /// It's guaranteed to be in the first place
+    pub fn ret_deref(&self) -> Option<PlaceElem<'tcx>> {
+        if !self.projection.is_empty() && self.projection[0] == PlaceElem::Deref {
+            return Some(self.projection[0]);
+        } else {
+            None
         }
     }
 

--- a/compiler/rustc_mir_transform/src/add_retag.rs
+++ b/compiler/rustc_mir_transform/src/add_retag.rs
@@ -15,7 +15,7 @@ pub struct AddRetag;
 /// (Concurrent accesses by other threads are no problem as these are anyway non-atomic
 /// copies.  Data races are UB.)
 fn is_stable(place: PlaceRef<'_>) -> bool {
-    if place.ret_deref().is_some() {
+    if place.has_deref() {
         // Which place this evaluates to can change with any memory write,
         // so cannot assume deref to be stable.
         return false;
@@ -83,8 +83,7 @@ impl<'tcx> MirPass<'tcx> for AddRetag {
         let place_base_raw = |place: &Place<'tcx>| {
             // If this is a `Deref`, get the type of what we are deref'ing.
             if place.ret_deref().is_some() {
-                let base_proj = &place.projection[..0];
-                let ty = Place::ty_from(place.local, base_proj, &*local_decls, tcx).ty;
+                let ty = place.ty(local_decls, tcx).ty;
                 ty.is_unsafe_ptr()
             } else {
                 // Not a deref, and thus not raw.

--- a/compiler/rustc_mir_transform/src/add_retag.rs
+++ b/compiler/rustc_mir_transform/src/add_retag.rs
@@ -15,22 +15,13 @@ pub struct AddRetag;
 /// (Concurrent accesses by other threads are no problem as these are anyway non-atomic
 /// copies.  Data races are UB.)
 fn is_stable(place: PlaceRef<'_>) -> bool {
-    place.projection.iter().all(|elem| {
-        match elem {
-            // Which place this evaluates to can change with any memory write,
-            // so cannot assume this to be stable.
-            ProjectionElem::Deref => false,
-            // Array indices are interesting, but MIR building generates a *fresh*
-            // temporary for every array access, so the index cannot be changed as
-            // a side-effect.
-            ProjectionElem::Index { .. } |
-            // The rest is completely boring, they just offset by a constant.
-            ProjectionElem::Field { .. } |
-            ProjectionElem::ConstantIndex { .. } |
-            ProjectionElem::Subslice { .. } |
-            ProjectionElem::Downcast { .. } => true,
-        }
-    })
+    if place.ret_deref().is_some() {
+        // Which place this evaluates to can change with any memory write,
+        // so cannot assume deref to be stable.
+        return false;
+    } else {
+        return true;
+    }
 }
 
 /// Determine whether this type may contain a reference (or box), and thus needs retagging.
@@ -91,10 +82,8 @@ impl<'tcx> MirPass<'tcx> for AddRetag {
         };
         let place_base_raw = |place: &Place<'tcx>| {
             // If this is a `Deref`, get the type of what we are deref'ing.
-            let deref_base =
-                place.projection.iter().rposition(|p| matches!(p, ProjectionElem::Deref));
-            if let Some(deref_base) = deref_base {
-                let base_proj = &place.projection[..deref_base];
+            if place.ret_deref().is_some() {
+                let base_proj = &place.projection[..0];
                 let ty = Place::ty_from(place.local, base_proj, &*local_decls, tcx).ty;
                 ty.is_unsafe_ptr()
             } else {


### PR DESCRIPTION
Now that we can assume #97025 works, it's safe to expect Deref is always in the first place of projections. With this, I was able to simplify some code that depended on Deref's place in projections. When we are able to move Derefer before `ElaborateDrops` successfully we will be able to optimize more places.

r? @oli-obk 