### PR TITLE
Update function pointer call error message

### DIFF
--- a/compiler/rustc_const_eval/src/transform/check_consts/ops.rs
+++ b/compiler/rustc_const_eval/src/transform/check_consts/ops.rs
@@ -89,7 +89,10 @@ impl<'tcx> NonConstOp<'tcx> for FnCallIndirect {
         ccx: &ConstCx<'_, 'tcx>,
         span: Span,
     ) -> DiagnosticBuilder<'tcx, ErrorGuaranteed> {
-        ccx.tcx.sess.struct_span_err(span, "function pointers are not allowed in const fn")
+        ccx.tcx.sess.struct_span_err(
+            span,
+            &format!("function pointer calls are not allowed in {}s", ccx.const_kind()),
+        )
     }
 }
 

--- a/src/test/ui/consts/const-fn-ptr.rs
+++ b/src/test/ui/consts/const-fn-ptr.rs
@@ -1,0 +1,16 @@
+const fn make_fn_ptr() -> fn() {
+    || {}
+}
+
+static STAT: () = make_fn_ptr()();
+//~^ ERROR function pointer
+
+const CONST: () = make_fn_ptr()();
+//~^ ERROR function pointer
+
+const fn call_ptr() {
+    make_fn_ptr()();
+    //~^ ERROR function pointer
+}
+
+fn main() {}

--- a/src/test/ui/consts/const-fn-ptr.stderr
+++ b/src/test/ui/consts/const-fn-ptr.stderr
@@ -1,0 +1,20 @@
+error: function pointer calls are not allowed in statics
+  --> $DIR/const-fn-ptr.rs:5:19
+   |
+LL | static STAT: () = make_fn_ptr()();
+   |                   ^^^^^^^^^^^^^^^
+
+error: function pointer calls are not allowed in constants
+  --> $DIR/const-fn-ptr.rs:8:19
+   |
+LL | const CONST: () = make_fn_ptr()();
+   |                   ^^^^^^^^^^^^^^^
+
+error: function pointer calls are not allowed in constant functions
+  --> $DIR/const-fn-ptr.rs:12:5
+   |
+LL |     make_fn_ptr()();
+   |     ^^^^^^^^^^^^^^^
+
+error: aborting due to 3 previous errors
+

--- a/src/test/ui/consts/issue-56164.stderr
+++ b/src/test/ui/consts/issue-56164.stderr
@@ -7,7 +7,7 @@ LL | const fn foo() { (||{})() }
    = note: closures need an RFC before allowed to be called in constant functions
    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
 
-error: function pointers are not allowed in const fn
+error: function pointer calls are not allowed in constant functions
   --> $DIR/issue-56164.rs:7:5
    |
 LL |     input()


### PR DESCRIPTION
It now uses the type of context. (fixes #97082)