### PR TITLE
Fix misleading `cannot infer type for type parameter` error

### DIFF
--- a/src/test/ui/const-generics/issues/issue-83249.stderr
+++ b/src/test/ui/const-generics/issues/issue-83249.stderr
@@ -5,6 +5,12 @@ LL |     let _ = foo([0; 1]);
    |         -   ^^^ cannot infer type for type parameter `T` declared on the function `foo`
    |         |
    |         consider giving this pattern a type
+   |
+help: type parameter declared here
+  --> $DIR/issue-83249.rs:12:8
+   |
+LL | fn foo<T: Foo>(_: [u8; T::N]) -> T {
+   |        ^
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/issue-64662.stderr
+++ b/src/test/ui/consts/issue-64662.stderr
@@ -3,12 +3,24 @@ error[E0282]: type annotations needed
    |
 LL |     A = foo(),
    |         ^^^ cannot infer type for type parameter `T` declared on the function `foo`
+   |
+help: type parameter declared here
+  --> $DIR/issue-64662.rs:6:14
+   |
+LL | const fn foo<T>() -> isize {
+   |              ^
 
 error[E0282]: type annotations needed
   --> $DIR/issue-64662.rs:3:9
    |
 LL |     B = foo(),
    |         ^^^ cannot infer type for type parameter `T` declared on the function `foo`
+   |
+help: type parameter declared here
+  --> $DIR/issue-64662.rs:6:14
+   |
+LL | const fn foo<T>() -> isize {
+   |              ^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/error-codes/E0401.stderr
+++ b/src/test/ui/error-codes/E0401.stderr
@@ -37,6 +37,12 @@ error[E0282]: type annotations needed
    |
 LL |     bfnr(x);
    |     ^^^^ cannot infer type for type parameter `U` declared on the function `bfnr`
+   |
+help: type parameter declared here
+  --> $DIR/E0401.rs:4:13
+   |
+LL |     fn bfnr<U, V: Baz<U>, W: Fn()>(y: T) {
+   |             ^
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/inference/ambiguous_type_parameter.rs
+++ b/src/test/ui/inference/ambiguous_type_parameter.rs
@@ -1,0 +1,17 @@
+use std::collections::HashMap;
+
+trait Store<K, V> {
+    fn get_raw(&self, key: &K) -> Option<()>;
+}
+
+struct InMemoryStore;
+
+impl<K> Store<String, HashMap<K, String>> for InMemoryStore {
+    fn get_raw(&self, key: &String) -> Option<()> {
+        None
+    }
+}
+
+fn main() {
+    InMemoryStore.get_raw(&String::default()); //~ ERROR type annotations needed
+}

--- a/src/test/ui/inference/ambiguous_type_parameter.stderr
+++ b/src/test/ui/inference/ambiguous_type_parameter.stderr
@@ -1,0 +1,15 @@
+error[E0282]: type annotations needed
+  --> $DIR/ambiguous_type_parameter.rs:16:19
+   |
+LL |     InMemoryStore.get_raw(&String::default());
+   |                   ^^^^^^^ cannot infer type for type parameter `K`
+   |
+help: type parameter declared here
+  --> $DIR/ambiguous_type_parameter.rs:9:6
+   |
+LL | impl<K> Store<String, HashMap<K, String>> for InMemoryStore {
+   |      ^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0282`.

--- a/src/test/ui/inference/erase-type-params-in-label.stderr
+++ b/src/test/ui/inference/erase-type-params-in-label.stderr
@@ -6,6 +6,11 @@ LL |     let foo = foo(1, "");
    |         |
    |         consider giving `foo` the explicit type `Foo<_, _, W, Z>`, where the type parameter `W` is specified
    |
+help: type parameter declared here
+  --> $DIR/erase-type-params-in-label.rs:25:14
+   |
+LL | fn foo<T, K, W: Default, Z: Default>(t: T, k: K) -> Foo<T, K, W, Z> {
+   |              ^
    = note: cannot satisfy `_: Default`
 note: required by a bound in `foo`
   --> $DIR/erase-type-params-in-label.rs:25:17
@@ -25,6 +30,11 @@ LL |     let bar = bar(1, "");
    |         |
    |         consider giving `bar` the explicit type `Bar<_, _, Z>`, where the type parameter `Z` is specified
    |
+help: type parameter declared here
+  --> $DIR/erase-type-params-in-label.rs:14:14
+   |
+LL | fn bar<T, K, Z: Default>(t: T, k: K) -> Bar<T, K, Z> {
+   |              ^
    = note: cannot satisfy `_: Default`
 note: required by a bound in `bar`
   --> $DIR/erase-type-params-in-label.rs:14:17

--- a/src/test/ui/inference/issue-86162-1.stderr
+++ b/src/test/ui/inference/issue-86162-1.stderr
@@ -4,6 +4,11 @@ error[E0283]: type annotations needed
 LL |     foo(gen()); //<- Do not suggest `foo::<impl Clone>()`!
    |     ^^^ cannot infer type for type parameter `impl Clone` declared on the function `foo`
    |
+help: type parameter declared here
+  --> $DIR/issue-86162-1.rs:3:11
+   |
+LL | fn foo(x: impl Clone) {}
+   |           ^^^^^^^^^^
    = note: cannot satisfy `_: Clone`
 note: required by a bound in `foo`
   --> $DIR/issue-86162-1.rs:3:16

--- a/src/test/ui/inference/issue-86162-2.stderr
+++ b/src/test/ui/inference/issue-86162-2.stderr
@@ -4,6 +4,11 @@ error[E0283]: type annotations needed
 LL |     Foo::bar(gen()); //<- Do not suggest `Foo::bar::<impl Clone>()`!
    |     ^^^^^^^^ cannot infer type for type parameter `impl Clone` declared on the associated function `bar`
    |
+help: type parameter declared here
+  --> $DIR/issue-86162-2.rs:8:15
+   |
+LL |     fn bar(x: impl Clone) {}
+   |               ^^^^^^^^^^
    = note: cannot satisfy `_: Clone`
 note: required by a bound in `Foo::bar`
   --> $DIR/issue-86162-2.rs:8:20

--- a/src/test/ui/issues/issue-6458.stderr
+++ b/src/test/ui/issues/issue-6458.stderr
@@ -3,6 +3,12 @@ error[E0282]: type annotations needed
    |
 LL |    foo(TypeWithState(marker::PhantomData));
    |    ^^^ cannot infer type for type parameter `State` declared on the function `foo`
+   |
+help: type parameter declared here
+  --> $DIR/issue-6458.rs:6:12
+   |
+LL | pub fn foo<State>(_: TypeWithState<State>) {}
+   |            ^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/missing/missing-items/missing-type-parameter.stderr
+++ b/src/test/ui/missing/missing-items/missing-type-parameter.stderr
@@ -3,6 +3,12 @@ error[E0282]: type annotations needed
    |
 LL |     foo();
    |     ^^^ cannot infer type for type parameter `X` declared on the function `foo`
+   |
+help: type parameter declared here
+  --> $DIR/missing-type-parameter.rs:1:8
+   |
+LL | fn foo<X>() { }
+   |        ^
 
 error: aborting due to previous error
 

--- a/src/test/ui/suggestions/fn-needing-specified-return-type-param.stderr
+++ b/src/test/ui/suggestions/fn-needing-specified-return-type-param.stderr
@@ -5,6 +5,12 @@ LL |     let _ = f;
    |         -   ^ cannot infer type for type parameter `A` declared on the function `f`
    |         |
    |         consider giving this pattern the explicit type `fn() -> A`, where the type parameter `A` is specified
+   |
+help: type parameter declared here
+  --> $DIR/fn-needing-specified-return-type-param.rs:1:6
+   |
+LL | fn f<A>() -> A { unimplemented!() }
+   |      ^
 
 error: aborting due to previous error
 

--- a/src/test/ui/traits/multidispatch-convert-ambig-dest.stderr
+++ b/src/test/ui/traits/multidispatch-convert-ambig-dest.stderr
@@ -3,6 +3,12 @@ error[E0282]: type annotations needed
    |
 LL |     test(22, std::default::Default::default());
    |     ^^^^ cannot infer type for type parameter `U` declared on the function `test`
+   |
+help: type parameter declared here
+  --> $DIR/multidispatch-convert-ambig-dest.rs:20:11
+   |
+LL | fn test<T,U>(_: T, _: U)
+   |           ^
 
 error[E0283]: type annotations needed
   --> $DIR/multidispatch-convert-ambig-dest.rs:26:5
@@ -10,6 +16,11 @@ error[E0283]: type annotations needed
 LL |     test(22, std::default::Default::default());
    |     ^^^^ cannot infer type for type parameter `U` declared on the function `test`
    |
+help: type parameter declared here
+  --> $DIR/multidispatch-convert-ambig-dest.rs:20:11
+   |
+LL | fn test<T,U>(_: T, _: U)
+   |           ^
 note: multiple `impl`s satisfying `i32: Convert<_>` found
   --> $DIR/multidispatch-convert-ambig-dest.rs:8:1
    |

--- a/src/test/ui/traits/not-suggest-non-existing-fully-qualified-path.stderr
+++ b/src/test/ui/traits/not-suggest-non-existing-fully-qualified-path.stderr
@@ -16,6 +16,11 @@ LL |     a.method();
    |     | cannot infer type for type parameter `U`
    |     this method call resolves to `U`
    |
+help: type parameter declared here
+  --> $DIR/not-suggest-non-existing-fully-qualified-path.rs:12:9
+   |
+LL | impl<T, U> V<U> for A<T>
+   |         ^
 note: multiple `impl`s satisfying `B: I<_>` found
   --> $DIR/not-suggest-non-existing-fully-qualified-path.rs:5:1
    |

--- a/src/test/ui/type-inference/unbounded-type-param-in-fn-with-assoc-type.stderr
+++ b/src/test/ui/type-inference/unbounded-type-param-in-fn-with-assoc-type.stderr
@@ -3,6 +3,12 @@ error[E0282]: type annotations needed
    |
 LL |     foo();
    |     ^^^ cannot infer type for type parameter `T` declared on the function `foo`
+   |
+help: type parameter declared here
+  --> $DIR/unbounded-type-param-in-fn-with-assoc-type.rs:3:8
+   |
+LL | fn foo<T, U = u64>() -> (T, U) {
+   |        ^
 
 error: aborting due to previous error
 

--- a/src/test/ui/type-inference/unbounded-type-param-in-fn.stderr
+++ b/src/test/ui/type-inference/unbounded-type-param-in-fn.stderr
@@ -3,6 +3,12 @@ error[E0282]: type annotations needed
    |
 LL |     foo();
    |     ^^^ cannot infer type for type parameter `T` declared on the function `foo`
+   |
+help: type parameter declared here
+  --> $DIR/unbounded-type-param-in-fn.rs:1:8
+   |
+LL | fn foo<T>() -> T {
+   |        ^
 
 error: aborting due to previous error
 

--- a/src/test/ui/type/type-annotation-needed.stderr
+++ b/src/test/ui/type/type-annotation-needed.stderr
@@ -4,6 +4,11 @@ error[E0283]: type annotations needed
 LL |     foo(42);
    |     ^^^ cannot infer type for type parameter `T` declared on the function `foo`
    |
+help: type parameter declared here
+  --> $DIR/type-annotation-needed.rs:1:8
+   |
+LL | fn foo<T: Into<String>>(x: i32) {}
+   |        ^
    = note: cannot satisfy `_: Into<String>`
 note: required by a bound in `foo`
   --> $DIR/type-annotation-needed.rs:1:11


### PR DESCRIPTION
closes #93198