### PR TITLE
Add PID to PGO profile data filename

### DIFF
--- a/src/ci/pgo.sh
+++ b/src/ci/pgo.sh
@@ -82,7 +82,11 @@ python3 ../x.py build --target=$PGO_HOST --host=$PGO_HOST \
 
 # Here we're profiling the `rustc` frontend, so we also include `Check`.
 # The benchmark set includes various stress tests that put the frontend under pressure.
-gather_profiles "Check,Debug,Opt" "All" \
+# The profile data is written into a single filepath that is being repeatedly merged when each
+# rustc invocation ends. Empirically, this can result in some profiling data being lost.
+# That's why we override the profile path to include the PID. This will produce many more profiling
+# files, but the resulting profile will produce a slightly faster rustc binary.
+LLVM_PROFILE_FILE=/tmp/rustc-pgo/default_%m_%p.profraw gather_profiles "Check,Debug,Opt" "All" \
   "externs,ctfe-stress-4,cargo-0.60.0,token-stream-stress,match-stress,tuple-stress"
 
 # Merge the profile data we gathered


### PR DESCRIPTION
After experimenting with PGO, it looks like the generated profile data files can be sometimes overwritten if there is a race condition, because multiple `rustc` processes are usually invoked in parallel by `cargo`. Adding the PID to the resulting profile filename pattern makes sure that the profiles will be stored in separate files.

This generates ~20 GiB more space on disk on the CI run, but that seems harmless (?). Merging the profiles is not a bottleneck, the perf. run took the same amount of time as usually (~1h 24m).

r? @lqd