### PR TITLE
optimize Option::insert if it's `Some`

### DIFF
--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -1418,10 +1418,17 @@ impl<T> Option<T> {
     where
         T: ~const Destruct,
     {
-        *self = Some(value);
-
-        // SAFETY: the code above just filled the option
-        unsafe { self.as_mut().unwrap_unchecked() }
+        match *self {
+            Some(ref mut x) => {
+                *x = value;
+                x
+            }
+            None => {
+                *self = Some(value);
+                // SAFETY: the code above just filled the option
+                unsafe { self.as_mut().unwrap_unchecked() }
+            }
+        }
     }
 
     /// Inserts `value` into the option if it is [`None`], then


### PR DESCRIPTION
Refers to the `opt_clone_from_or_clone` function located in https://github.com/rust-lang/rust/blob/master/compiler/rustc_mir_dataflow/src/framework/direction.rs#L640-L656

When `self` is `Some`, this will be more efficient than assigning to the whole `Option`.
If this PR is approved, the `opt_clone_from_or_clone` function can be discarded.