### PR TITLE
speed up parsing for short ipv4s in std::net::Ipv4Addr::from_str

### DIFF
--- a/library/std/src/net/parser.rs
+++ b/library/std/src/net/parser.rs
@@ -285,8 +285,8 @@ impl FromStr for IpAddr {
 impl FromStr for Ipv4Addr {
     type Err = AddrParseError;
     fn from_str(s: &str) -> Result<Ipv4Addr, AddrParseError> {
-        // don't try to parse if too long
-        if s.len() > 15 {
+        // don't try to parse if too long or too short
+        if s.len() < 7 || s.len() > 15 {
             Err(AddrParseError(AddrKind::Ipv4))
         } else {
             Parser::new(s).parse_with(|p| p.read_ipv4_addr(), AddrKind::Ipv4)

--- a/library/std/src/net/parser.rs
+++ b/library/std/src/net/parser.rs
@@ -140,6 +140,11 @@ impl<'a> Parser<'a> {
 
     /// Read an IPv4 address.
     fn read_ipv4_addr(&mut self) -> Option<Ipv4Addr> {
+        // don't try to parse if too short or long
+        if self.state.len() < 7 || self.state.len() > 15 {
+            return None;
+        }
+
         self.read_atomically(|p| {
             let mut groups = [0; 4];
 
@@ -285,12 +290,7 @@ impl FromStr for IpAddr {
 impl FromStr for Ipv4Addr {
     type Err = AddrParseError;
     fn from_str(s: &str) -> Result<Ipv4Addr, AddrParseError> {
-        // don't try to parse if too long or too short
-        if s.len() < 7 || s.len() > 15 {
-            Err(AddrParseError(AddrKind::Ipv4))
-        } else {
-            Parser::new(s).parse_with(|p| p.read_ipv4_addr(), AddrKind::Ipv4)
-        }
+        Parser::new(s).parse_with(|p| p.read_ipv4_addr(), AddrKind::Ipv4)
     }
 }
 


### PR DESCRIPTION
This aims to improve parsing speed for short and empty strings. 

There is a proof of concept based on Criterion here: https://github.com/nkconnor/rust-ipv4-optimization/blob/main/benches/ipv4_fromstr_benchmark.rs

On my machine it offers about a 15X speed-up in the happy case (`len() < 7`). The parser today takes a more similar duration for `"1.1.1"` as it does for `"1.1.1.1"`.

Optimizing for this case is especially helpful for situations where input is a non-null string type. For example, a CSV library may offer non-null string type for an IP Address column. IP Address is a _very common_ element in "big data" and this optimization is likely to be appreciated in such contexts.

Criterion Output:

**Main Parse OK           time:   [21.145 ns 21.181 ns 21.222 ns]**
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) low mild
  2 (2.00%) high mild
  1 (1.00%) high severe

**Main Parse <7           time:   [15.268 ns 15.286 ns 15.304 ns]**
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild

**Patch Parse OK          time:   [21.309 ns 21.506 ns 21.843 ns]**
Found 13 outliers among 100 measurements (13.00%)
  4 (4.00%) high mild
  9 (9.00%) high severe

**Patch Parse <7          time:   [998.09 ps 999.02 ps 1.0001 ns]**
