### PR TITLE
Update `rustc` PGO benchmark list

### DIFF
--- a/src/ci/docker/host-x86_64/dist-x86_64-linux/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-x86_64-linux/Dockerfile
@@ -98,8 +98,8 @@ COPY host-x86_64/dist-x86_64-linux/build-clang.sh /tmp/
 RUN ./build-clang.sh
 ENV CC=clang CXX=clang++
 
-# rustc-perf version from 2022-04-05
-ENV PERF_COMMIT 04fccd80396f954b339c366e30221f4bd52c5e03
+# rustc-perf version from 2022-05-18
+ENV PERF_COMMIT f66cc8f3e04392b0e2fd811f21fd1ece6ebaded3
 RUN curl -LS -o perf.zip https://github.com/rust-lang/rustc-perf/archive/$PERF_COMMIT.zip && \
     unzip perf.zip && \
     mv rustc-perf-$PERF_COMMIT rustc-perf && \

--- a/src/ci/pgo.sh
+++ b/src/ci/pgo.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# ignore-tidy-linelength
 
 set -euxo pipefail
 
@@ -87,7 +88,7 @@ python3 ../x.py build --target=$PGO_HOST --host=$PGO_HOST \
 # That's why we override the profile path to include the PID. This will produce many more profiling
 # files, but the resulting profile will produce a slightly faster rustc binary.
 LLVM_PROFILE_FILE=/tmp/rustc-pgo/default_%m_%p.profraw gather_profiles "Check,Debug,Opt" "All" \
-  "externs,ctfe-stress-4,cargo-0.60.0,token-stream-stress,match-stress,tuple-stress"
+"externs,ctfe-stress-5,cargo-0.60.0,token-stream-stress,match-stress,tuple-stress,diesel-1.4.8,bitmaps-3.1.0"
 
 # Merge the profile data we gathered
 ./build/$PGO_HOST/llvm/bin/llvm-profdata \


### PR DESCRIPTION
I noticed that the `rustc` PGO crates do not contain any crate that would stress the trait system. I tried adding and removing various crates to the PGO benchmark list here. Here's what I found:

- Removing [`externs` and `match-stress`](https://perf.rust-lang.org/compare.html?start=c0672870491e84362f76ddecd50fa229f9b06dff&end=b056963e0324fa76c721d79f12658a64cfa4cb5e&stat=instructions:u) regresses these two benchmarks by up to 15 % and removing them doesn't improve anything else, so we should keep them.
- Adding [`keccak`](https://perf.rust-lang.org/compare.html?start=52cc7795245347500ddf6dc959cf58a7abe2d935&end=6fd27b23fd7860c79752479173b4a1b877cba490) regresses `diesel`, otherwise it doesn't do much.
- Adding [`tt-muncher`](https://perf.rust-lang.org/compare.html?start=c0672870491e84362f76ddecd50fa229f9b06dff&end=2ab5994d9cdfb098344895f7d8d5aee3cf3d6eff&stat=instructions:u) improves it very slightly, not worth it to include it IMO.
- Adding just [`diesel`](https://perf.rust-lang.org/compare.html?start=00755e4ca68f12ed200e921276788ab19975e85f&end=cd37706ad459ee8ddfda4631be71120cb7eda19d) improves it by up to 1.5 % and others crate slightly, but regresses `bitmaps`.
- Adding [`bitmaps`](https://perf.rust-lang.org/compare.html?start=67a9bcb31b85e87cc8bb327022632e48a0ca64a8&end=0cd80ba74425e6614cd52c4ea2bf6b0191c6dbc4&stat=instructions:u) improves both it and diesel, no other regressions.
- Adding [both](https://perf.rust-lang.org/compare.html?start=77972d2d0134fb597249b3b64dcf9510a790c34e&end=f968d7af511d750db96cfdc04f844fb017c079ce) `bitmaps` and `diesel` produces quite nice improvements and almost no regressions.
- Adding [ucd](https://perf.rust-lang.org/compare.html?start=b5caa5a8421f84cb7664f999b7635801bcf3f96a&end=327cc09917311f65cf427e6c0bf5f7424af9fd05&stat=instructions:u) did not have a large effect on primary benchmarks.

r? @lqd