### PR TITLE
Avoid double binding of subdiagnostics inside `#[derive(SessionDiagnostic)]`

### DIFF
--- a/compiler/rustc_macros/src/diagnostics/diagnostic.rs
+++ b/compiler/rustc_macros/src/diagnostics/diagnostic.rs
@@ -354,7 +354,8 @@ impl SessionDiagnosticDeriveBuilder {
                 );
             }
         } else {
-            field.attrs
+            field
+                .attrs
                 .iter()
                 .map(move |attr| {
                     let name = attr.path.segments.last().unwrap().ident.to_string();

--- a/compiler/rustc_macros/src/diagnostics/diagnostic.rs
+++ b/compiler/rustc_macros/src/diagnostics/diagnostic.rs
@@ -360,10 +360,10 @@ impl SessionDiagnosticDeriveBuilder {
         Ok(tokens.drain(..).collect())
     }
 
-    fn generate_field_attrs_code<'a>(
-        &'a mut self,
-        attrs: &'a [syn::Attribute],
-        info: FieldInfo<'a>,
+    fn generate_field_attrs_code(
+        &mut self,
+        attrs: &[syn::Attribute],
+        info: FieldInfo<'_>,
     ) -> TokenStream {
         let field_binding = &info.binding.binding;
 

--- a/compiler/rustc_macros/src/diagnostics/diagnostic.rs
+++ b/compiler/rustc_macros/src/diagnostics/diagnostic.rs
@@ -110,10 +110,6 @@ impl<'a> SessionDiagnosticDerive<'a> {
                         )
                     });
 
-                // When generating `set_arg` or `add_subdiagnostic` calls, move data rather than
-                // borrow it to avoid requiring clones - this must therefore be the last use of
-                // each field (for example, any formatting machinery that might refer to a field
-                // should be generated already).
                 structure.bind_with(|_| synstructure::BindStyle::Move);
                 // When a field has attributes like `#[label]` or `#[note]` then it doesn't
                 // need to be passed as an argument to the diagnostic. But when a field has no
@@ -373,6 +369,10 @@ impl SessionDiagnosticDeriveBuilder {
 
         let inner_ty = FieldInnerTy::from_type(&info.ty);
 
+        // When generating `set_arg` or `add_subdiagnostic` calls, move data rather than
+        // borrow it to avoid requiring clones - this must therefore be the last use of
+        // each field (for example, any formatting machinery that might refer to a field
+        // should be generated already).
         if attrs.is_empty() {
             let diag = &self.diag;
             let ident = info.binding.ast().ident.as_ref().unwrap();

--- a/compiler/rustc_macros/src/diagnostics/subdiagnostic.rs
+++ b/compiler/rustc_macros/src/diagnostics/subdiagnostic.rs
@@ -303,7 +303,6 @@ impl<'a> SessionSubdiagnosticDeriveBuilder<'a> {
 
         let inner_ty = FieldInnerTy::from_type(&ast.ty);
         let info = FieldInfo {
-            vis: &ast.vis,
             binding: binding,
             ty: inner_ty.inner_type().unwrap_or(&ast.ty),
             span: &ast.span(),

--- a/compiler/rustc_macros/src/diagnostics/utils.rs
+++ b/compiler/rustc_macros/src/diagnostics/utils.rs
@@ -4,7 +4,7 @@ use proc_macro2::TokenStream;
 use quote::{format_ident, quote, ToTokens};
 use std::collections::BTreeSet;
 use std::str::FromStr;
-use syn::{spanned::Spanned, Attribute, Meta, Type, TypeTuple, Visibility};
+use syn::{spanned::Spanned, Attribute, Meta, Type, TypeTuple};
 use synstructure::BindingInfo;
 
 /// Checks whether the type name of `ty` matches `name`.
@@ -158,7 +158,6 @@ impl<'ty> FieldInnerTy<'ty> {
 /// Field information passed to the builder. Deliberately omits attrs to discourage the
 /// `generate_*` methods from walking the attributes themselves.
 pub(crate) struct FieldInfo<'a> {
-    pub(crate) vis: &'a Visibility,
     pub(crate) binding: &'a BindingInfo<'a>,
     pub(crate) ty: &'a Type,
     pub(crate) span: &'a proc_macro2::Span,


### PR DESCRIPTION
r? @davidtwco 