### PR TITLE
Allow `unused_macro_rules` in path tests (backport to beta)

### DIFF
--- a/library/std/src/path/tests.rs
+++ b/library/std/src/path/tests.rs
@@ -7,6 +7,7 @@ use crate::rc::Rc;
 use crate::sync::Arc;
 use core::hint::black_box;
 
+#[allow(unknown_lints, unused_macro_rules)]
 macro_rules! t (
     ($path:expr, iter: $iter:expr) => (
         {


### PR DESCRIPTION
PR #96150 adds a new lint to warn about unused macro rules (arms/matchers). This causes errors in library/std/src/path/tests.rs on the x86_64-fortanix-unknown-sgx platform. This PR fixes compilation errors on that platform by allowing unused macro rules.

This PR is a backport from #97009