### PR TITLE
[WIP] Try using call-site aware IR PGO for LLVM

### DIFF
--- a/src/ci/docker/host-x86_64/dist-x86_64-linux/build-clang.sh
+++ b/src/ci/docker/host-x86_64/dist-x86_64-linux/build-clang.sh
@@ -4,7 +4,7 @@ set -ex
 
 source shared.sh
 
-LLVM=llvmorg-14.0.2
+LLVM=llvmorg-14.0.4
 
 mkdir llvm-project
 cd llvm-project


### PR DESCRIPTION
LLVM has a second mode of PGO, called call-site aware PGO. Let's try if and how it works.

r? @ghost