### PR TITLE
[WIP] Use static linking for compiling `rustc` in CI

### DIFF
--- a/compiler/rustc_driver/Cargo.toml
+++ b/compiler/rustc_driver/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 edition = "2021"
 
 [lib]
-crate-type = ["dylib"]
+crate-type = ["lib"]
 
 [dependencies]
 tracing = { version = "0.1.35" }


### PR DESCRIPTION
I noticed that `rustc` was (probably) being compiled only with thin-local crate LTO (according to https://doc.rust-lang.org/rustc/codegen-options/index.html#lto). Let's see what happens if we compile it with full thin/fat LTO.

Current status:
- Static linking of `rustc` - [perf results](https://perf.rust-lang.org/compare.html?start=a2cdcb3fea2baae5d20eabaa412e0d2f5b98c318&end=7288ad0fd327a539b7e8c597da7ce2f96ac7b3c4&stat=instructions:u)
- Static linking + exported symbols - perf results (TODO)
- Static linking + thin LTO - [perf results](https://perf.rust-lang.org/compare.html?start=dec689432fac6720b2f18101ac28a21add98b1b8&end=268d09249194cf2ba741a0398e14d8cc1de9cf0f&stat=instructions:u)
- Static linking + fat LTO - [perf results](https://perf.rust-lang.org/compare.html?start=5fecdb7c0ab4fb26f37df7c5e6afb4981e0fc71b&end=f488095246805f2455f7bee92f747aeddd049af1&stat=instructions:u)
- Only LTO on `librustc_driver.so` (from this [PR](https://github.com/rust-lang/rust/pull/101403)) - [perf results](https://perf.rust-lang.org/compare.html?start=c2d140bd36e7fcdc894b7c342fd81a63fdd66373&end=af5e9125d450e00077d4680e4e02685ba33e9f8e&stat=instructions:u)

r? @ghost