### PR TITLE
Remove unnecessay .report() on ExitCode

### DIFF
--- a/library/std/src/process.rs
+++ b/library/std/src/process.rs
@@ -2136,7 +2136,7 @@ pub trait Termination {
 impl Termination for () {
     #[inline]
     fn report(self) -> ExitCode {
-        ExitCode::SUCCESS.report()
+        ExitCode::SUCCESS
     }
 }
 
@@ -2162,7 +2162,7 @@ impl<E: fmt::Debug> Termination for Result<!, E> {
     fn report(self) -> ExitCode {
         let Err(err) = self;
         eprintln!("Error: {err:?}");
-        ExitCode::FAILURE.report()
+        ExitCode::FAILURE
     }
 }
 


### PR DESCRIPTION
Since #93442, the return type is `ExitCode` anyway so there's no need to do a conversion using `.report()` (which is now just a no-op).