### PR TITLE
Add new lint to enforce whitespace after keywords

### DIFF
--- a/src/librustdoc/html/static/.eslintrc.js
+++ b/src/librustdoc/html/static/.eslintrc.js
@@ -34,5 +34,9 @@ module.exports = {
             "1tbs",
             { "allowSingleLine": false }
         ],
+        "keyword-spacing": [
+            "error",
+            { "before": true, "after": true }
+        ],
     }
 };

--- a/src/librustdoc/html/static/js/storage.js
+++ b/src/librustdoc/html/static/js/storage.js
@@ -103,7 +103,7 @@ function onEachLazy(lazyArray, func, reversed) {
 function updateLocalStorage(name, value) {
     try {
         window.localStorage.setItem("rustdoc-" + name, value);
-    } catch(e) {
+    } catch (e) {
         // localStorage is not accessible, do nothing
     }
 }
@@ -111,7 +111,7 @@ function updateLocalStorage(name, value) {
 function getCurrentValue(name) {
     try {
         return window.localStorage.getItem("rustdoc-" + name);
-    } catch(e) {
+    } catch (e) {
         return null;
     }
 }


### PR DESCRIPTION
r? @notriddle 