### PR TITLE
wf-check generators

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/fulfill.rs
+++ b/compiler/rustc_trait_selection/src/traits/fulfill.rs
@@ -295,6 +295,7 @@ impl<'a, 'b, 'tcx> ObligationProcessor for FulfillProcessor<'a, 'b, 'tcx> {
     /// This is called much less often than `needs_process_obligation`, so we
     /// never inline it.
     #[inline(never)]
+    #[instrument(level = "debug", skip(self, pending_obligation))]
     fn process_obligation(
         &mut self,
         pending_obligation: &mut PendingPredicateObligation<'tcx>,
@@ -303,7 +304,7 @@ impl<'a, 'b, 'tcx> ObligationProcessor for FulfillProcessor<'a, 'b, 'tcx> {
 
         let obligation = &mut pending_obligation.obligation;
 
-        debug!(?obligation, "process_obligation pre-resolve");
+        debug!(?obligation, "pre-resolve");
 
         if obligation.predicate.has_infer_types_or_consts() {
             obligation.predicate =
@@ -311,8 +312,6 @@ impl<'a, 'b, 'tcx> ObligationProcessor for FulfillProcessor<'a, 'b, 'tcx> {
         }
 
         let obligation = &pending_obligation.obligation;
-
-        debug!(?obligation, ?obligation.cause, "process_obligation");
 
         let infcx = self.selcx.infcx();
 

--- a/src/test/ui/generic-associated-types/issue-88287.rs
+++ b/src/test/ui/generic-associated-types/issue-88287.rs
@@ -1,4 +1,3 @@
-// check-pass
 // edition:2018
 
 #![feature(generic_associated_types)]
@@ -34,6 +33,7 @@ where
 
     fn search<'c>(&'c self, _client: &'c ()) -> Self::Future<'c, Self, Criteria> {
         async move { todo!() }
+        //~^ ERROR: the size for values of type `A` cannot be known at compilation time
     }
 }
 

--- a/src/test/ui/generic-associated-types/issue-88287.stderr
+++ b/src/test/ui/generic-associated-types/issue-88287.stderr
@@ -1,0 +1,27 @@
+error[E0277]: the size for values of type `A` cannot be known at compilation time
+  --> $DIR/issue-88287.rs:35:9
+   |
+LL | type SearchFutureTy<'f, A, B: 'f>
+   |                         - this type parameter needs to be `std::marker::Sized`
+...
+LL |         async move { todo!() }
+   |         ^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+note: required by a bound in `<T as SearchableResourceExt<Criteria>>`
+  --> $DIR/issue-88287.rs:25:6
+   |
+LL | impl<T, Criteria> SearchableResourceExt<Criteria> for T
+   |      ^ required by this bound in `<T as SearchableResourceExt<Criteria>>`
+help: consider removing the `?Sized` bound to make the type parameter `Sized`
+   |
+LL -     A: SearchableResource<B> + ?Sized + 'f,
+LL +     A: SearchableResource<B> + 'f,
+   |
+help: consider relaxing the implicit `Sized` restriction
+   |
+LL |     T: SearchableResource<Criteria> + ?Sized,
+   |                                     ++++++++
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/lifetimes/issue-76168-hr-outlives-2.rs
+++ b/src/test/ui/lifetimes/issue-76168-hr-outlives-2.rs
@@ -1,0 +1,22 @@
+// edition:2018
+// check-pass
+
+trait Trait<Input> {
+    type Output;
+}
+
+async fn walk<F>(filter: F)
+where
+    for<'a> F: Trait<&'a u32> + 'a,
+    for<'a> <F as Trait<&'a u32>>::Output: 'a,
+{
+}
+
+async fn walk2<F: 'static>(filter: F)
+where
+    for<'a> F: Trait<&'a u32> + 'a,
+    for<'a> <F as Trait<&'a u32>>::Output: 'a,
+{
+}
+
+fn main() {}

--- a/src/test/ui/type-alias-impl-trait/future.rs
+++ b/src/test/ui/type-alias-impl-trait/future.rs
@@ -1,0 +1,22 @@
+#![feature(type_alias_impl_trait)]
+
+// edition:2021
+// compile-flags: --crate-type=lib
+
+use std::future::Future;
+
+trait Bar {
+    fn bar(&self);
+}
+
+type FooFuture<B> = impl Future<Output = ()>;
+
+fn foo<B: Bar>(bar: B) -> FooFuture<B> {
+    async move { bar.bar() }
+    //~^ ERROR: the trait bound `B: Bar` is not satisfied
+}
+
+pub fn mainish(ctx: &mut std::task::Context) {
+    let boom: FooFuture<u32> = unsafe { core::mem::zeroed() };
+    Box::pin(boom).as_mut().poll(ctx);
+}

--- a/src/test/ui/type-alias-impl-trait/future.stderr
+++ b/src/test/ui/type-alias-impl-trait/future.stderr
@@ -1,0 +1,19 @@
+error[E0277]: the trait bound `B: Bar` is not satisfied
+  --> $DIR/future.rs:15:5
+   |
+LL |     async move { bar.bar() }
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Bar` is not implemented for `B`
+   |
+note: required by a bound in `foo`
+  --> $DIR/future.rs:14:11
+   |
+LL | fn foo<B: Bar>(bar: B) -> FooFuture<B> {
+   |           ^^^ required by this bound in `foo`
+help: consider restricting type parameter `B`
+   |
+LL | type FooFuture<B: Bar> = impl Future<Output = ()>;
+   |                 +++++
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
fixes #90409

We should not rely on generators being well formed by construction now that they can get used via type alias impl trait (and thus users can choose generic arguments that are invalid). This can cause surprising behaviour if (definitely unsound) transmutes are used, and it's generally saner to just check for well formedness.