### PR TITLE
fix wrong ordering in once

### DIFF
--- a/library/std/src/sync/once.rs
+++ b/library/std/src/sync/once.rs
@@ -470,8 +470,8 @@ fn wait(state_and_queue: &AtomicPtr<Masked>, mut current_state: *mut Masked) {
         let exchange_result = state_and_queue.compare_exchange(
             current_state,
             me.with_addr(me.addr() | RUNNING),
-            Ordering::Release,
-            Ordering::Relaxed,
+            Ordering::AcqRel,
+            Ordering::Acquire,
         );
         if let Err(old) = exchange_result {
             current_state = old;


### PR DESCRIPTION
I believe `Relaxed` on error path is too weak here, and we need Acquire.
On the `Err` path, we use the `old` value to update `current_state`.
With `Relaxed`, I _think_ this can lead to a situation where we add a
partially-initialised node to the waiters list. The waker thread then
will correctly read *Waiter, but `*Waiter.thread` might be garbage.

With an Acquire here we make sure that the `next` field in

    next: current_state.with_addr(current_state.addr() & !STATE_MASK) as *const Waiter,

points to a fully initialized node, which we can then safely read with

`let next = (*queue).next;`

In other words, we want this `Acquire` to synchronize with `AcqRel` in
the same `compare_exchange` statement (on a different thread).

The Release ordering was introduced in

https://github.com/rust-lang/rust/pull/65719/commits/7f1e166899a90226480d564549c36a395e2d8f47

r? @ghost