### PR TITLE
Do leak check after function pointer coercion

### DIFF
--- a/compiler/rustc_infer/src/infer/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/mod.rs
@@ -1442,6 +1442,10 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
     /// the message in `secondary_span` as the primary label, and apply the message that would
     /// otherwise be used for the primary label on the `secondary_span` `Span`. This applies on
     /// E0271, like `src/test/ui/issues/issue-39970.stderr`.
+    #[tracing::instrument(
+        level = "debug",
+        skip(self, diag, secondary_span, swap_secondary_and_primary, force_label)
+    )]
     pub fn note_type_err(
         &self,
         diag: &mut Diagnostic,
@@ -1453,7 +1457,6 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
         force_label: bool,
     ) {
         let span = cause.span(self.tcx);
-        debug!("note_type_err cause={:?} values={:?}, terr={:?}", cause, values, terr);
 
         // For some types of errors, expected-found does not make
         // sense, so just ignore the values we were given.
@@ -1621,9 +1624,9 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
             }
         };
 
-        // Ignore msg for object safe coercion
-        // since E0038 message will be printed
         match terr {
+            // Ignore msg for object safe coercion
+            // since E0038 message will be printed
             TypeError::ObjectUnsafeCoercion(_) => {}
             _ => {
                 let mut label_or_note = |span: Span, msg: &str| {
@@ -1774,6 +1777,8 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
         // It reads better to have the error origin as the final
         // thing.
         self.note_error_origin(diag, cause, exp_found, terr);
+
+        debug!(?diag);
     }
 
     fn suggest_tuple_pattern(

--- a/compiler/rustc_middle/src/ty/error.rs
+++ b/compiler/rustc_middle/src/ty/error.rs
@@ -135,11 +135,10 @@ impl<'tcx> fmt::Display for TypeError<'tcx> {
             ArgCount => write!(f, "incorrect number of function parameters"),
             FieldMisMatch(adt, field) => write!(f, "field type mismatch: {}.{}", adt, field),
             RegionsDoesNotOutlive(..) => write!(f, "lifetime mismatch"),
-            RegionsInsufficientlyPolymorphic(br, _) => write!(
-                f,
-                "expected bound lifetime parameter{}, found concrete lifetime",
-                br_string(br)
-            ),
+            // Actually naming the region here is a bit confusing because context is lacking
+            RegionsInsufficientlyPolymorphic(..) => {
+                write!(f, "one type is more general than the other")
+            }
             RegionsOverlyPolymorphic(br, _) => write!(
                 f,
                 "expected concrete lifetime, found bound lifetime parameter{}",

--- a/compiler/rustc_mir_build/src/build/matches/mod.rs
+++ b/compiler/rustc_mir_build/src/build/matches/mod.rs
@@ -151,6 +151,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
     ///
     /// * From each pre-binding block to the next pre-binding block.
     /// * From each otherwise block to the next pre-binding block.
+    #[tracing::instrument(level = "debug", skip(self, arms))]
     pub(crate) fn match_expr(
         &mut self,
         destination: Place<'tcx>,

--- a/compiler/rustc_mir_build/src/thir/cx/block.rs
+++ b/compiler/rustc_mir_build/src/thir/cx/block.rs
@@ -75,6 +75,7 @@ impl<'tcx> Cx<'tcx> {
                         };
 
                         let mut pattern = self.pattern_from_hir(local.pat);
+                        debug!(?pattern);
 
                         if let Some(ty) = &local.ty {
                             if let Some(&user_ty) =

--- a/compiler/rustc_mir_build/src/thir/cx/mod.rs
+++ b/compiler/rustc_mir_build/src/thir/cx/mod.rs
@@ -98,6 +98,7 @@ impl<'tcx> Cx<'tcx> {
         }
     }
 
+    #[tracing::instrument(level = "debug", skip(self))]
     pub(crate) fn pattern_from_hir(&mut self, p: &hir::Pat<'_>) -> Pat<'tcx> {
         let p = match self.tcx.hir().get(p.hir_id) {
             Node::Pat(p) | Node::Binding(p) => p,

--- a/src/test/ui/hr-subtype/placeholder-pattern-fail.nll.stderr
+++ b/src/test/ui/hr-subtype/placeholder-pattern-fail.nll.stderr
@@ -1,37 +1,12 @@
 error[E0308]: mismatched types
-  --> $DIR/placeholder-pattern-fail.rs:9:12
+  --> $DIR/placeholder-pattern-fail.rs:9:47
    |
 LL |     let _: for<'a, 'b> fn(Inv<'a>, Inv<'b>) = sub;
-   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ one type is more general than the other
+   |                                               ^^^ one type is more general than the other
    |
    = note: expected fn pointer `for<'a, 'b> fn(Inv<'a>, Inv<'b>)`
               found fn pointer `for<'a> fn(Inv<'a>, Inv<'a>)`
 
-error[E0308]: mismatched types
-  --> $DIR/placeholder-pattern-fail.rs:9:12
-   |
-LL |     let _: for<'a, 'b> fn(Inv<'a>, Inv<'b>) = sub;
-   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ one type is more general than the other
-   |
-   = note: expected fn pointer `for<'a, 'b> fn(Inv<'a>, Inv<'b>)`
-              found fn pointer `for<'a> fn(Inv<'a>, Inv<'a>)`
-
-error: lifetime may not live long enough
-  --> $DIR/placeholder-pattern-fail.rs:14:13
-   |
-LL | fn simple1<'c>(x: (&'c i32,)) {
-   |            -- lifetime `'c` defined here
-LL |     let _x: (&'static i32,) = x;
-   |             ^^^^^^^^^^^^^^^ type annotation requires that `'c` must outlive `'static`
-
-error: lifetime may not live long enough
-  --> $DIR/placeholder-pattern-fail.rs:19:12
-   |
-LL | fn simple2<'c>(x: (&'c i32,)) {
-   |            -- lifetime `'c` defined here
-LL |     let _: (&'static i32,) = x;
-   |            ^^^^^^^^^^^^^^^ type annotation requires that `'c` must outlive `'static`
-
-error: aborting due to 4 previous errors
+error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/hrtb/hrtb-exists-forall-fn.nll.stderr
+++ b/src/test/ui/hrtb/hrtb-exists-forall-fn.nll.stderr
@@ -1,8 +1,8 @@
 error[E0308]: mismatched types
-  --> $DIR/hrtb-exists-forall-fn.rs:17:12
+  --> $DIR/hrtb-exists-forall-fn.rs:17:34
    |
 LL |     let _: for<'b> fn(&'b u32) = foo();
-   |            ^^^^^^^^^^^^^^^^^^^ one type is more general than the other
+   |                                  ^^^^^ one type is more general than the other
    |
    = note: expected fn pointer `for<'b> fn(&'b u32)`
               found fn pointer `fn(&u32)`

--- a/src/test/ui/lub-glb/old-lub-glb-hr-noteq1.baseleak.stderr
+++ b/src/test/ui/lub-glb/old-lub-glb-hr-noteq1.baseleak.stderr
@@ -1,0 +1,21 @@
+error[E0308]: `match` arms have incompatible types
+  --> $DIR/old-lub-glb-hr-noteq1.rs:17:14
+   |
+LL |       let z = match 22 {
+   |  _____________-
+LL | |         0 => x,
+   | |              - this is found to be of type `for<'a, 'b> fn(&'a u8, &'b u8) -> &'a u8`
+LL | |         _ => y,
+   | |              ^ one type is more general than the other
+LL | |
+...  |
+LL | |
+LL | |     };
+   | |_____- `match` arms have incompatible types
+   |
+   = note: expected fn pointer `for<'a, 'b> fn(&'a u8, &'b u8) -> &'a u8`
+              found fn pointer `for<'a> fn(&'a u8, &'a u8) -> &'a u8`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/lub-glb/old-lub-glb-hr-noteq1.basenoleak.stderr
+++ b/src/test/ui/lub-glb/old-lub-glb-hr-noteq1.basenoleak.stderr
@@ -1,0 +1,21 @@
+error[E0308]: `match` arms have incompatible types
+  --> $DIR/old-lub-glb-hr-noteq1.rs:17:14
+   |
+LL |       let z = match 22 {
+   |  _____________-
+LL | |         0 => x,
+   | |              - this is found to be of type `for<'a, 'b> fn(&'a u8, &'b u8) -> &'a u8`
+LL | |         _ => y,
+   | |              ^ one type is more general than the other
+LL | |
+...  |
+LL | |
+LL | |     };
+   | |_____- `match` arms have incompatible types
+   |
+   = note: expected fn pointer `for<'a, 'b> fn(&'a u8, &'b u8) -> &'a u8`
+              found fn pointer `for<'a> fn(&'a u8, &'a u8) -> &'a u8`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/lub-glb/old-lub-glb-hr-noteq1.nllleak.stderr
+++ b/src/test/ui/lub-glb/old-lub-glb-hr-noteq1.nllleak.stderr
@@ -1,0 +1,21 @@
+error[E0308]: `match` arms have incompatible types
+  --> $DIR/old-lub-glb-hr-noteq1.rs:17:14
+   |
+LL |       let z = match 22 {
+   |  _____________-
+LL | |         0 => x,
+   | |              - this is found to be of type `for<'a, 'b> fn(&'a u8, &'b u8) -> &'a u8`
+LL | |         _ => y,
+   | |              ^ one type is more general than the other
+LL | |
+...  |
+LL | |
+LL | |     };
+   | |_____- `match` arms have incompatible types
+   |
+   = note: expected fn pointer `for<'a, 'b> fn(&'a u8, &'b u8) -> &'a u8`
+              found fn pointer `for<'a> fn(&'a u8, &'a u8) -> &'a u8`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/lub-glb/old-lub-glb-hr-noteq1.nllnoleak.stderr
+++ b/src/test/ui/lub-glb/old-lub-glb-hr-noteq1.nllnoleak.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/old-lub-glb-hr-noteq1.rs:11:14
+  --> $DIR/old-lub-glb-hr-noteq1.rs:17:14
    |
 LL |         _ => y,
    |              ^ one type is more general than the other

--- a/src/test/ui/lub-glb/old-lub-glb-hr-noteq1.rs
+++ b/src/test/ui/lub-glb/old-lub-glb-hr-noteq1.rs
@@ -2,13 +2,23 @@
 // general than the other. Test the case where the more general type (`x`) is the first
 // match arm specifically.
 
+// revisions: baseleak basenoleak nllleak nllnoleak
+// ignore-compare-mode-nll
+//[nllleak] compile-flags: -Zborrowck=mir
+//[nllnoleak] compile-flags: -Zborrowck=mir -Zno-leak-check
+//[basenoleak] compile-flags:-Zno-leak-check
+
 fn foo(x: for<'a, 'b> fn(&'a u8, &'b u8) -> &'a u8, y: for<'a> fn(&'a u8, &'a u8) -> &'a u8) {
     // The two types above are not equivalent. With the older LUB/GLB
     // algorithm, this may have worked (I don't remember), but now it
     // doesn't because we require equality.
     let z = match 22 {
         0 => x,
-        _ => y, //~ ERROR `match` arms have incompatible types
+        _ => y,
+        //[baseleak]~^ ERROR `match` arms have incompatible types
+        //[nllleak]~^^ ERROR `match` arms have incompatible types
+        //[basenoleak]~^^^ ERROR `match` arms have incompatible types
+        //[nllnoleak]~^^^^ ERROR mismatched types
     };
 }
 

--- a/src/test/ui/lub-glb/old-lub-glb-hr-noteq2.baseleak.stderr
+++ b/src/test/ui/lub-glb/old-lub-glb-hr-noteq2.baseleak.stderr
@@ -1,17 +1,20 @@
 error[E0308]: `match` arms have incompatible types
-  --> $DIR/old-lub-glb-hr-noteq1.rs:11:14
+  --> $DIR/old-lub-glb-hr-noteq2.rs:28:14
    |
 LL |       let z = match 22 {
    |  _____________-
-LL | |         0 => x,
-   | |              - this is found to be of type `for<'a, 'b> fn(&'a u8, &'b u8) -> &'a u8`
-LL | |         _ => y,
+LL | |         0 => y,
+   | |              - this is found to be of type `for<'a> fn(&'a u8, &'a u8) -> &'a u8`
+LL | |         _ => x,
    | |              ^ one type is more general than the other
+LL | |
+LL | |
+LL | |
 LL | |     };
    | |_____- `match` arms have incompatible types
    |
-   = note: expected fn pointer `for<'a, 'b> fn(&'a u8, &'b u8) -> &'a u8`
-              found fn pointer `for<'a> fn(&'a u8, &'a u8) -> &'a u8`
+   = note: expected fn pointer `for<'a> fn(&'a u8, &'a u8) -> &'a u8`
+              found fn pointer `for<'a, 'b> fn(&'a u8, &'b u8) -> &'a u8`
 
 error: aborting due to previous error
 

--- a/src/test/ui/lub-glb/old-lub-glb-hr-noteq2.basenoleak.stderr
+++ b/src/test/ui/lub-glb/old-lub-glb-hr-noteq2.basenoleak.stderr
@@ -1,5 +1,5 @@
 error[E0308]: `match` arms have incompatible types
-  --> $DIR/old-lub-glb-hr-noteq2.rs:21:14
+  --> $DIR/old-lub-glb-hr-noteq2.rs:28:14
    |
 LL |       let z = match 22 {
    |  _____________-
@@ -7,6 +7,9 @@ LL | |         0 => y,
    | |              - this is found to be of type `for<'a> fn(&'a u8, &'a u8) -> &'a u8`
 LL | |         _ => x,
    | |              ^ one type is more general than the other
+LL | |
+LL | |
+LL | |
 LL | |     };
    | |_____- `match` arms have incompatible types
    |

--- a/src/test/ui/lub-glb/old-lub-glb-hr-noteq2.nllleak.stderr
+++ b/src/test/ui/lub-glb/old-lub-glb-hr-noteq2.nllleak.stderr
@@ -1,0 +1,21 @@
+error[E0308]: `match` arms have incompatible types
+  --> $DIR/old-lub-glb-hr-noteq2.rs:28:14
+   |
+LL |       let z = match 22 {
+   |  _____________-
+LL | |         0 => y,
+   | |              - this is found to be of type `for<'a> fn(&'a u8, &'a u8) -> &'a u8`
+LL | |         _ => x,
+   | |              ^ one type is more general than the other
+LL | |
+LL | |
+LL | |
+LL | |     };
+   | |_____- `match` arms have incompatible types
+   |
+   = note: expected fn pointer `for<'a> fn(&'a u8, &'a u8) -> &'a u8`
+              found fn pointer `for<'a, 'b> fn(&'a u8, &'b u8) -> &'a u8`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/regions/region-lifetime-bounds-on-fns-where-clause.base.stderr
+++ b/src/test/ui/regions/region-lifetime-bounds-on-fns-where-clause.base.stderr
@@ -8,7 +8,7 @@ LL |     *x = *y;
    |          ^^ ...but data from `y` flows into `x` here
 
 error[E0623]: lifetime mismatch
-  --> $DIR/region-lifetime-bounds-on-fns-where-clause.rs:20:7
+  --> $DIR/region-lifetime-bounds-on-fns-where-clause.rs:19:7
    |
 LL | fn c<'a,'b>(x: &mut &'a isize, y: &mut &'b isize) {
    |                     ---------          --------- these two types are declared with different lifetimes...
@@ -17,13 +17,13 @@ LL |     a(x, y);
    |       ^ ...but data from `y` flows into `x` here
 
 error[E0308]: mismatched types
-  --> $DIR/region-lifetime-bounds-on-fns-where-clause.rs:28:43
+  --> $DIR/region-lifetime-bounds-on-fns-where-clause.rs:26:43
    |
 LL |     let _: fn(&mut &isize, &mut &isize) = a;
    |                                           ^ one type is more general than the other
    |
    = note: expected fn pointer `for<'r, 's, 't0, 't1> fn(&'r mut &'s isize, &'t0 mut &'t1 isize)`
-              found fn pointer `for<'r, 's> fn(&'r mut &isize, &'s mut &isize)`
+                 found fn item `for<'r, 's> fn(&'r mut &isize, &'s mut &isize) {a::<'_, '_>}`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/regions/region-lifetime-bounds-on-fns-where-clause.nll.stderr
+++ b/src/test/ui/regions/region-lifetime-bounds-on-fns-where-clause.nll.stderr
@@ -1,50 +1,12 @@
-error: lifetime may not live long enough
-  --> $DIR/region-lifetime-bounds-on-fns-where-clause.rs:12:5
-   |
-LL | fn b<'a, 'b>(x: &mut &'a isize, y: &mut &'b isize) {
-   |      --  -- lifetime `'b` defined here
-   |      |
-   |      lifetime `'a` defined here
-LL |     // Illegal now because there is no `'b:'a` declaration.
-LL |     *x = *y;
-   |     ^^^^^^^ assignment requires that `'b` must outlive `'a`
-   |
-   = help: consider adding the following bound: `'b: 'a`
-
-error: lifetime may not live long enough
-  --> $DIR/region-lifetime-bounds-on-fns-where-clause.rs:20:5
-   |
-LL | fn c<'a,'b>(x: &mut &'a isize, y: &mut &'b isize) {
-   |      -- -- lifetime `'b` defined here
-   |      |
-   |      lifetime `'a` defined here
-...
-LL |     a(x, y);
-   |     ^^^^^^^ argument requires that `'b` must outlive `'a`
-   |
-   = help: consider adding the following bound: `'b: 'a`
-   = note: requirement occurs because of a mutable reference to `&isize`
-   = note: mutable references are invariant over their type parameter
-   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
-
 error[E0308]: mismatched types
-  --> $DIR/region-lifetime-bounds-on-fns-where-clause.rs:28:12
+  --> $DIR/region-lifetime-bounds-on-fns-where-clause.rs:26:43
    |
 LL |     let _: fn(&mut &isize, &mut &isize) = a;
-   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ one type is more general than the other
+   |                                           ^ one type is more general than the other
    |
    = note: expected fn pointer `for<'r, 's, 't0, 't1> fn(&'r mut &'s isize, &'t0 mut &'t1 isize)`
-              found fn pointer `for<'r, 's> fn(&'r mut &isize, &'s mut &isize)`
+                 found fn item `for<'r, 's> fn(&'r mut &isize, &'s mut &isize) {a::<'_, '_>}`
 
-error[E0308]: mismatched types
-  --> $DIR/region-lifetime-bounds-on-fns-where-clause.rs:28:12
-   |
-LL |     let _: fn(&mut &isize, &mut &isize) = a;
-   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ one type is more general than the other
-   |
-   = note: expected fn pointer `for<'r, 's, 't0, 't1> fn(&'r mut &'s isize, &'t0 mut &'t1 isize)`
-              found fn pointer `for<'r, 's> fn(&'r mut &isize, &'s mut &isize)`
-
-error: aborting due to 4 previous errors
+error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/regions/region-lifetime-bounds-on-fns-where-clause.rs
+++ b/src/test/ui/regions/region-lifetime-bounds-on-fns-where-clause.rs
@@ -11,7 +11,6 @@ fn b<'a, 'b>(x: &mut &'a isize, y: &mut &'b isize) {
     // Illegal now because there is no `'b:'a` declaration.
     *x = *y;
     //[base]~^ ERROR E0623
-    //[nll]~^^ ERROR lifetime may not live long enough
 }
 
 fn c<'a,'b>(x: &mut &'a isize, y: &mut &'b isize) {
@@ -19,7 +18,6 @@ fn c<'a,'b>(x: &mut &'a isize, y: &mut &'b isize) {
     // related as required.
     a(x, y);
     //[base]~^ ERROR lifetime mismatch [E0623]
-    //[nll]~^^ ERROR lifetime may not live long enough
 }
 
 fn d() {
@@ -27,7 +25,6 @@ fn d() {
     // inconstraints:
     let _: fn(&mut &isize, &mut &isize) = a;
     //~^ ERROR mismatched types [E0308]
-    //[nll]~^^ ERROR mismatched types [E0308]
 }
 
 fn e() {

--- a/src/test/ui/regions/region-multiple-lifetime-bounds-on-fns-where-clause.base.stderr
+++ b/src/test/ui/regions/region-multiple-lifetime-bounds-on-fns-where-clause.base.stderr
@@ -8,7 +8,7 @@ LL |     *x = *y;
    |          ^^ ...but data from `y` flows into `x` here
 
 error[E0623]: lifetime mismatch
-  --> $DIR/region-multiple-lifetime-bounds-on-fns-where-clause.rs:16:10
+  --> $DIR/region-multiple-lifetime-bounds-on-fns-where-clause.rs:15:10
    |
 LL | fn b<'a, 'b, 'c>(x: &mut &'a isize, y: &mut &'b isize, z: &mut &'c isize) {
    |                                             ---------          ---------
@@ -19,7 +19,7 @@ LL |     *z = *y;
    |          ^^ ...but data from `y` flows into `z` here
 
 error[E0623]: lifetime mismatch
-  --> $DIR/region-multiple-lifetime-bounds-on-fns-where-clause.rs:22:7
+  --> $DIR/region-multiple-lifetime-bounds-on-fns-where-clause.rs:21:7
    |
 LL | fn c<'a,'b, 'c>(x: &mut &'a isize, y: &mut &'b isize, z: &mut &'c isize) {
    |                         ---------          --------- these two types are declared with different lifetimes...
@@ -28,13 +28,13 @@ LL |     a(x, y, z);
    |       ^ ...but data from `y` flows into `x` here
 
 error[E0308]: mismatched types
-  --> $DIR/region-multiple-lifetime-bounds-on-fns-where-clause.rs:30:56
+  --> $DIR/region-multiple-lifetime-bounds-on-fns-where-clause.rs:28:56
    |
 LL |     let _: fn(&mut &isize, &mut &isize, &mut &isize) = a;
    |                                                        ^ one type is more general than the other
    |
    = note: expected fn pointer `for<'r, 's, 't0, 't1, 't2, 't3> fn(&'r mut &'s isize, &'t0 mut &'t1 isize, &'t2 mut &'t3 isize)`
-              found fn pointer `for<'r, 's, 't0> fn(&'r mut &isize, &'s mut &isize, &'t0 mut &isize)`
+                 found fn item `for<'r, 's, 't0> fn(&'r mut &isize, &'s mut &isize, &'t0 mut &isize) {a::<'_, '_, '_>}`
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/regions/region-multiple-lifetime-bounds-on-fns-where-clause.nll.stderr
+++ b/src/test/ui/regions/region-multiple-lifetime-bounds-on-fns-where-clause.nll.stderr
@@ -1,59 +1,12 @@
-error: lifetime may not live long enough
-  --> $DIR/region-multiple-lifetime-bounds-on-fns-where-clause.rs:13:5
-   |
-LL | fn b<'a, 'b, 'c>(x: &mut &'a isize, y: &mut &'b isize, z: &mut &'c isize) {
-   |      --  -- lifetime `'b` defined here
-   |      |
-   |      lifetime `'a` defined here
-LL |     // Illegal now because there is no `'b:'a` declaration.
-LL |     *x = *y;
-   |     ^^^^^^^ assignment requires that `'b` must outlive `'a`
-   |
-   = help: consider adding the following bound: `'b: 'a`
-
-error: lifetime may not live long enough
-  --> $DIR/region-multiple-lifetime-bounds-on-fns-where-clause.rs:22:5
-   |
-LL | fn c<'a,'b, 'c>(x: &mut &'a isize, y: &mut &'b isize, z: &mut &'c isize) {
-   |      -- -- lifetime `'b` defined here
-   |      |
-   |      lifetime `'a` defined here
-...
-LL |     a(x, y, z);
-   |     ^^^^^^^^^^ argument requires that `'b` must outlive `'a`
-   |
-   = help: consider adding the following bound: `'b: 'a`
-   = note: requirement occurs because of a mutable reference to `&isize`
-   = note: mutable references are invariant over their type parameter
-   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
-
 error[E0308]: mismatched types
-  --> $DIR/region-multiple-lifetime-bounds-on-fns-where-clause.rs:30:12
+  --> $DIR/region-multiple-lifetime-bounds-on-fns-where-clause.rs:28:56
    |
 LL |     let _: fn(&mut &isize, &mut &isize, &mut &isize) = a;
-   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ one type is more general than the other
+   |                                                        ^ one type is more general than the other
    |
    = note: expected fn pointer `for<'r, 's, 't0, 't1, 't2, 't3> fn(&'r mut &'s isize, &'t0 mut &'t1 isize, &'t2 mut &'t3 isize)`
-              found fn pointer `for<'r, 's, 't0> fn(&'r mut &isize, &'s mut &isize, &'t0 mut &isize)`
+                 found fn item `for<'r, 's, 't0> fn(&'r mut &isize, &'s mut &isize, &'t0 mut &isize) {a::<'_, '_, '_>}`
 
-error[E0308]: mismatched types
-  --> $DIR/region-multiple-lifetime-bounds-on-fns-where-clause.rs:30:12
-   |
-LL |     let _: fn(&mut &isize, &mut &isize, &mut &isize) = a;
-   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ one type is more general than the other
-   |
-   = note: expected fn pointer `for<'r, 's, 't0, 't1, 't2, 't3> fn(&'r mut &'s isize, &'t0 mut &'t1 isize, &'t2 mut &'t3 isize)`
-              found fn pointer `for<'r, 's, 't0> fn(&'r mut &isize, &'s mut &isize, &'t0 mut &isize)`
-
-error[E0308]: mismatched types
-  --> $DIR/region-multiple-lifetime-bounds-on-fns-where-clause.rs:30:12
-   |
-LL |     let _: fn(&mut &isize, &mut &isize, &mut &isize) = a;
-   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ one type is more general than the other
-   |
-   = note: expected fn pointer `for<'r, 's, 't0, 't1, 't2, 't3> fn(&'r mut &'s isize, &'t0 mut &'t1 isize, &'t2 mut &'t3 isize)`
-              found fn pointer `for<'r, 's, 't0> fn(&'r mut &isize, &'s mut &isize, &'t0 mut &isize)`
-
-error: aborting due to 5 previous errors
+error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/regions/region-multiple-lifetime-bounds-on-fns-where-clause.rs
+++ b/src/test/ui/regions/region-multiple-lifetime-bounds-on-fns-where-clause.rs
@@ -12,7 +12,6 @@ fn b<'a, 'b, 'c>(x: &mut &'a isize, y: &mut &'b isize, z: &mut &'c isize) {
     // Illegal now because there is no `'b:'a` declaration.
     *x = *y;
     //[base]~^ ERROR E0623
-    //[nll]~^^ ERROR lifetime may not live long enough
     *z = *y; //[base]~ ERROR E0623
 }
 
@@ -21,7 +20,6 @@ fn c<'a,'b, 'c>(x: &mut &'a isize, y: &mut &'b isize, z: &mut &'c isize) {
     // related as required.
     a(x, y, z);
     //[base]~^ ERROR lifetime mismatch [E0623]
-    //[nll]~^^ ERROR lifetime may not live long enough
 }
 
 fn d() {
@@ -29,8 +27,6 @@ fn d() {
     // inconstraints:
     let _: fn(&mut &isize, &mut &isize, &mut &isize) = a;
     //~^ ERROR E0308
-    //[nll]~^^ ERROR mismatched types [E0308]
-    //[nll]~| ERROR mismatched types [E0308]
 }
 
 fn e() {

--- a/src/test/ui/regions/regions-fn-subtyping-return-static-fail.base.stderr
+++ b/src/test/ui/regions/regions-fn-subtyping-return-static-fail.base.stderr
@@ -2,10 +2,17 @@ error[E0308]: mismatched types
   --> $DIR/regions-fn-subtyping-return-static-fail.rs:52:12
    |
 LL |     want_G(baz);
-   |            ^^^ one type is more general than the other
+   |     ------ ^^^ one type is more general than the other
+   |     |
+   |     arguments to this function are incorrect
    |
    = note: expected fn pointer `for<'cx> fn(&'cx S) -> &'static S`
-              found fn pointer `for<'r> fn(&'r S) -> &'r S`
+                 found fn item `for<'r> fn(&'r S) -> &'r S {baz}`
+note: function defined here
+  --> $DIR/regions-fn-subtyping-return-static-fail.rs:24:4
+   |
+LL | fn want_G(f: G) {}
+   |    ^^^^^^ ----
 
 error: aborting due to previous error
 

--- a/src/test/ui/regions/regions-fn-subtyping-return-static-fail.nll.stderr
+++ b/src/test/ui/regions/regions-fn-subtyping-return-static-fail.nll.stderr
@@ -1,11 +1,18 @@
 error[E0308]: mismatched types
-  --> $DIR/regions-fn-subtyping-return-static-fail.rs:52:5
+  --> $DIR/regions-fn-subtyping-return-static-fail.rs:52:12
    |
 LL |     want_G(baz);
-   |     ^^^^^^^^^^^ one type is more general than the other
+   |     ------ ^^^ one type is more general than the other
+   |     |
+   |     arguments to this function are incorrect
    |
    = note: expected fn pointer `for<'cx> fn(&'cx S) -> &'static S`
-              found fn pointer `for<'r> fn(&'r S) -> &'r S`
+                 found fn item `for<'r> fn(&'r S) -> &'r S {baz}`
+note: function defined here
+  --> $DIR/regions-fn-subtyping-return-static-fail.rs:24:4
+   |
+LL | fn want_G(f: G) {}
+   |    ^^^^^^ ----
 
 error: aborting due to previous error
 

--- a/src/test/ui/regions/regions-lifetime-bounds-on-fns.base.stderr
+++ b/src/test/ui/regions/regions-lifetime-bounds-on-fns.base.stderr
@@ -8,7 +8,7 @@ LL |     *x = *y;
    |          ^^ ...but data from `y` flows into `x` here
 
 error[E0623]: lifetime mismatch
-  --> $DIR/regions-lifetime-bounds-on-fns.rs:20:7
+  --> $DIR/regions-lifetime-bounds-on-fns.rs:19:7
    |
 LL | fn c<'a,'b>(x: &mut &'a isize, y: &mut &'b isize) {
    |                     ---------          --------- these two types are declared with different lifetimes...
@@ -17,13 +17,13 @@ LL |     a(x, y);
    |       ^ ...but data from `y` flows into `x` here
 
 error[E0308]: mismatched types
-  --> $DIR/regions-lifetime-bounds-on-fns.rs:28:43
+  --> $DIR/regions-lifetime-bounds-on-fns.rs:26:43
    |
 LL |     let _: fn(&mut &isize, &mut &isize) = a;
    |                                           ^ one type is more general than the other
    |
    = note: expected fn pointer `for<'r, 's, 't0, 't1> fn(&'r mut &'s isize, &'t0 mut &'t1 isize)`
-              found fn pointer `for<'r, 's> fn(&'r mut &isize, &'s mut &isize)`
+                 found fn item `for<'r, 's> fn(&'r mut &isize, &'s mut &isize) {a::<'_, '_>}`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/regions/regions-lifetime-bounds-on-fns.nll.stderr
+++ b/src/test/ui/regions/regions-lifetime-bounds-on-fns.nll.stderr
@@ -1,50 +1,12 @@
-error: lifetime may not live long enough
-  --> $DIR/regions-lifetime-bounds-on-fns.rs:12:5
-   |
-LL | fn b<'a, 'b>(x: &mut &'a isize, y: &mut &'b isize) {
-   |      --  -- lifetime `'b` defined here
-   |      |
-   |      lifetime `'a` defined here
-LL |     // Illegal now because there is no `'b:'a` declaration.
-LL |     *x = *y;
-   |     ^^^^^^^ assignment requires that `'b` must outlive `'a`
-   |
-   = help: consider adding the following bound: `'b: 'a`
-
-error: lifetime may not live long enough
-  --> $DIR/regions-lifetime-bounds-on-fns.rs:20:5
-   |
-LL | fn c<'a,'b>(x: &mut &'a isize, y: &mut &'b isize) {
-   |      -- -- lifetime `'b` defined here
-   |      |
-   |      lifetime `'a` defined here
-...
-LL |     a(x, y);
-   |     ^^^^^^^ argument requires that `'b` must outlive `'a`
-   |
-   = help: consider adding the following bound: `'b: 'a`
-   = note: requirement occurs because of a mutable reference to `&isize`
-   = note: mutable references are invariant over their type parameter
-   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
-
 error[E0308]: mismatched types
-  --> $DIR/regions-lifetime-bounds-on-fns.rs:28:12
+  --> $DIR/regions-lifetime-bounds-on-fns.rs:26:43
    |
 LL |     let _: fn(&mut &isize, &mut &isize) = a;
-   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ one type is more general than the other
+   |                                           ^ one type is more general than the other
    |
    = note: expected fn pointer `for<'r, 's, 't0, 't1> fn(&'r mut &'s isize, &'t0 mut &'t1 isize)`
-              found fn pointer `for<'r, 's> fn(&'r mut &isize, &'s mut &isize)`
+                 found fn item `for<'r, 's> fn(&'r mut &isize, &'s mut &isize) {a::<'_, '_>}`
 
-error[E0308]: mismatched types
-  --> $DIR/regions-lifetime-bounds-on-fns.rs:28:12
-   |
-LL |     let _: fn(&mut &isize, &mut &isize) = a;
-   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ one type is more general than the other
-   |
-   = note: expected fn pointer `for<'r, 's, 't0, 't1> fn(&'r mut &'s isize, &'t0 mut &'t1 isize)`
-              found fn pointer `for<'r, 's> fn(&'r mut &isize, &'s mut &isize)`
-
-error: aborting due to 4 previous errors
+error: aborting due to previous error
 
 For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/regions/regions-lifetime-bounds-on-fns.rs
+++ b/src/test/ui/regions/regions-lifetime-bounds-on-fns.rs
@@ -11,7 +11,6 @@ fn b<'a, 'b>(x: &mut &'a isize, y: &mut &'b isize) {
     // Illegal now because there is no `'b:'a` declaration.
     *x = *y;
     //[base]~^ ERROR lifetime mismatch [E0623]
-    //[nll]~^^ ERROR lifetime may not live long enough
 }
 
 fn c<'a,'b>(x: &mut &'a isize, y: &mut &'b isize) {
@@ -19,7 +18,6 @@ fn c<'a,'b>(x: &mut &'a isize, y: &mut &'b isize) {
     // related as required.
     a(x, y);
     //[base]~^ ERROR lifetime mismatch [E0623]
-    //[nll]~^^ ERROR lifetime may not live long enough
 }
 
 fn d() {
@@ -27,7 +25,6 @@ fn d() {
     // inconstraints:
     let _: fn(&mut &isize, &mut &isize) = a;
     //~^ ERROR mismatched types [E0308]
-    //[nll]~^^ ERROR mismatched types [E0308]
 }
 
 fn e() {


### PR DESCRIPTION
cc #73154

I still need to clean diagnostics just a tad, but figured I would put this up anyways.

This change is made in order to make match arm coercion order-independent.

Basically, any time we do function pointer coercion, we follow it by doing a leak check. This is necessary because the LUB code doesn't handler higher-ranked things correctly, leading us to "coerce", but use the wrong type. A proper fix is to actually fix that code (so the type returned by `unify_and` is a supertype of both `a` and `b` if `Ok`). However, that requires a more in-depth fix, likely heavily overlapping with the new subtyping changes.

Here, I've been conservative and error early if we generate unsatisfiable constraints. Note, this should *mostly* only affect NLL, since migrate mode falls back to the LUB implementation (followed by leak check), whereas NLL only does sub.

There could be other coercion code that has an order-dependence where a leak check in the coercion code might be useful. However, this is more of a spot-fix for #73154 than a "permanent" fix, since we likely want to go the other way long-term, and allow this pattern without error.

r? @nikomatsakis

