### PR TITLE
Do not emit the lint `unused_attributes` for *inherent* `#[doc(hidden)]` associated items

### DIFF
--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -832,7 +832,7 @@ impl CheckAttrVisitor<'_> {
             let parent_hir_id = self.tcx.hir().get_parent_item(hir_id);
             let containing_item = self.tcx.hir().expect_item(parent_hir_id);
 
-            if Target::from_item(containing_item) == Target::Impl {
+            if let hir::ItemKind::Impl(hir::Impl { of_trait: Some(_), .. }) = containing_item.kind {
                 let meta_items = attr.meta_item_list().unwrap();
 
                 let (span, replacement_span) = if meta_items.len() == 1 {

--- a/src/test/ui/lint/unused/unused-attr-doc-hidden.fixed
+++ b/src/test/ui/lint/unused/unused-attr-doc-hidden.fixed
@@ -1,5 +1,7 @@
-#![deny(unused_attributes)]
+#![feature(inherent_associated_types)]
+#![allow(dead_code, incomplete_features)]
 #![crate_type = "lib"]
+#![deny(unused_attributes)]
 // run-rustfix
 
 pub trait Trait {
@@ -11,6 +13,17 @@ pub trait Trait {
 }
 
 pub struct Implementor;
+
+impl Implementor {
+    #[doc(hidden)] // no error
+    type Inh = ();
+
+    #[doc(hidden)] // no error
+    const INH: () = ();
+
+    #[doc(hidden)] // no error
+    fn inh() {}
+}
 
 impl Trait for Implementor {
     

--- a/src/test/ui/lint/unused/unused-attr-doc-hidden.rs
+++ b/src/test/ui/lint/unused/unused-attr-doc-hidden.rs
@@ -1,5 +1,7 @@
-#![deny(unused_attributes)]
+#![feature(inherent_associated_types)]
+#![allow(dead_code, incomplete_features)]
 #![crate_type = "lib"]
+#![deny(unused_attributes)]
 // run-rustfix
 
 pub trait Trait {
@@ -11,6 +13,17 @@ pub trait Trait {
 }
 
 pub struct Implementor;
+
+impl Implementor {
+    #[doc(hidden)] // no error
+    type Inh = ();
+
+    #[doc(hidden)] // no error
+    const INH: () = ();
+
+    #[doc(hidden)] // no error
+    fn inh() {}
+}
 
 impl Trait for Implementor {
     #[doc(hidden)]

--- a/src/test/ui/lint/unused/unused-attr-doc-hidden.stderr
+++ b/src/test/ui/lint/unused/unused-attr-doc-hidden.stderr
@@ -1,11 +1,11 @@
 error: `#[doc(hidden)]` is ignored on trait impl items
-  --> $DIR/unused-attr-doc-hidden.rs:16:5
+  --> $DIR/unused-attr-doc-hidden.rs:29:5
    |
 LL |     #[doc(hidden)]
    |     ^^^^^^^^^^^^^^ help: remove this attribute
    |
 note: the lint level is defined here
-  --> $DIR/unused-attr-doc-hidden.rs:1:9
+  --> $DIR/unused-attr-doc-hidden.rs:4:9
    |
 LL | #![deny(unused_attributes)]
    |         ^^^^^^^^^^^^^^^^^
@@ -13,7 +13,7 @@ LL | #![deny(unused_attributes)]
    = note: whether the impl item is `doc(hidden)` or not entirely depends on the corresponding trait item
 
 error: `#[doc(hidden)]` is ignored on trait impl items
-  --> $DIR/unused-attr-doc-hidden.rs:21:5
+  --> $DIR/unused-attr-doc-hidden.rs:34:5
    |
 LL |     #[doc(hidden)]
    |     ^^^^^^^^^^^^^^ help: remove this attribute
@@ -22,7 +22,7 @@ LL |     #[doc(hidden)]
    = note: whether the impl item is `doc(hidden)` or not entirely depends on the corresponding trait item
 
 error: `#[doc(hidden)]` is ignored on trait impl items
-  --> $DIR/unused-attr-doc-hidden.rs:26:11
+  --> $DIR/unused-attr-doc-hidden.rs:39:11
    |
 LL |     #[doc(hidden, alias = "aka")]
    |           ^^^^^^--
@@ -33,7 +33,7 @@ LL |     #[doc(hidden, alias = "aka")]
    = note: whether the impl item is `doc(hidden)` or not entirely depends on the corresponding trait item
 
 error: `#[doc(hidden)]` is ignored on trait impl items
-  --> $DIR/unused-attr-doc-hidden.rs:31:27
+  --> $DIR/unused-attr-doc-hidden.rs:44:27
    |
 LL |     #[doc(alias = "this", hidden,)]
    |                           ^^^^^^-
@@ -44,7 +44,7 @@ LL |     #[doc(alias = "this", hidden,)]
    = note: whether the impl item is `doc(hidden)` or not entirely depends on the corresponding trait item
 
 error: `#[doc(hidden)]` is ignored on trait impl items
-  --> $DIR/unused-attr-doc-hidden.rs:36:11
+  --> $DIR/unused-attr-doc-hidden.rs:49:11
    |
 LL |     #[doc(hidden, hidden)]
    |           ^^^^^^--
@@ -55,7 +55,7 @@ LL |     #[doc(hidden, hidden)]
    = note: whether the impl item is `doc(hidden)` or not entirely depends on the corresponding trait item
 
 error: `#[doc(hidden)]` is ignored on trait impl items
-  --> $DIR/unused-attr-doc-hidden.rs:36:19
+  --> $DIR/unused-attr-doc-hidden.rs:49:19
    |
 LL |     #[doc(hidden, hidden)]
    |                   ^^^^^^ help: remove this attribute


### PR DESCRIPTION
Fixes #97205 (embarrassing oversight from #96008).

@rustbot label A-lint