### PR TITLE
Add eslint checks

### DIFF
--- a/src/librustdoc/html/static/.eslintrc.js
+++ b/src/librustdoc/html/static/.eslintrc.js
@@ -42,5 +42,9 @@ module.exports = {
             "error",
             { "before": true, "after": true }
         ],
+        "key-spacing": [
+            "error",
+            { "beforeColon": false, "afterColon": true, "mode": "strict" }
+        ],
     }
 };

--- a/src/librustdoc/html/static/.eslintrc.js
+++ b/src/librustdoc/html/static/.eslintrc.js
@@ -38,5 +38,9 @@ module.exports = {
             "error",
             { "before": true, "after": true }
         ],
+        "arrow-spacing": [
+            "error",
+            { "before": true, "after": true }
+        ],
     }
 };


### PR DESCRIPTION
The first check is to ensure that `=>` is always surrounded with whitespaces.

The second is to ensure that the dict objects looks like this: `{"a": 2}` and not `{"a" : 2}` or `{"a":2}`.

r? @notriddle 