### PR TITLE
Fix `Display` for `cell::{Ref,RefMut}`

### DIFF
--- a/library/core/src/cell.rs
+++ b/library/core/src/cell.rs
@@ -1487,7 +1487,7 @@ impl<'b, T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<Ref<'b, U>> for Ref<'b,
 #[stable(feature = "std_guard_impls", since = "1.20.0")]
 impl<T: ?Sized + fmt::Display> fmt::Display for Ref<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.value.fmt(f)
+        (**self).fmt(f)
     }
 }
 
@@ -1735,7 +1735,7 @@ impl<'b, T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<RefMut<'b, U>> for RefM
 #[stable(feature = "std_guard_impls", since = "1.20.0")]
 impl<T: ?Sized + fmt::Display> fmt::Display for RefMut<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.value.fmt(f)
+        (**self).fmt(f)
     }
 }
 

--- a/library/core/tests/cell.rs
+++ b/library/core/tests/cell.rs
@@ -73,11 +73,13 @@ fn ref_and_refmut_have_sensible_show() {
     let refcell = RefCell::new("foo");
 
     let refcell_refmut = refcell.borrow_mut();
-    assert!(format!("{refcell_refmut:?}").contains("foo"));
+    assert_eq!(format!("{refcell_refmut}"), "foo"); // Display
+    assert!(format!("{refcell_refmut:?}").contains("foo")); // Debug
     drop(refcell_refmut);
 
     let refcell_ref = refcell.borrow();
-    assert!(format!("{refcell_ref:?}").contains("foo"));
+    assert_eq!(format!("{refcell_ref}"), "foo"); // Display
+    assert!(format!("{refcell_ref:?}").contains("foo")); // Debug
     drop(refcell_ref);
 }
 


### PR DESCRIPTION
These guards changed to pointers in #97027, but their `Display` was
formatting that field directly, which made it show the raw pointer
value. Now we go through `Deref` to display the real value again.

Miri noticed this change, #97204, so hopefully that will be fixed.