### PR TITLE
Omit stdarch workspace from rust-src

### DIFF
--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -814,7 +814,7 @@ impl Step for Src {
                 "library/backtrace/crates",
                 // these are 30MB combined and aren't necessary for building
                 // the standard library.
-                "library/stdarch/crates/Cargo.toml",
+                "library/stdarch/Cargo.toml",
                 "library/stdarch/crates/stdarch-verify",
                 "library/stdarch/crates/intrinsic-test",
             ],


### PR DESCRIPTION
The path `library/stdarch/crates/Cargo.toml` does not exist.

In Rust 1.61.0, `rust-src` still includes `src/rust/library/stdarch/Cargo.toml` (but not `stdarch-verify`), which includes
```toml
[workspace]
members = [
  "crates/stdarch-verify"
```

This didn't show up when testing with `-Zbuild-std` in https://github.com/rust-lang/rust/pull/94907 since the [standard list of crates](https://github.com/rust-lang/cargo/blob/f624095e1c98228a74a165ddb702078c0dd8b81e/src/cargo/core/compiler/standard_lib.rs#L26-L30) to include when building `std` does not include `stdarch`, but it will show up if a user explicitly requests `stdarch`. Or, perhaps more importantly, because of https://github.com/rust-lang/rust/issues/95736, many editors (like IntelliJ) won't treat the root of `rust-src` as a workspace, and will instead recurse into all the sub-crates directly, which then includes `stdarch`.

Also related to https://github.com/rust-lang/rust/issues/94906.