### PR TITLE
Recover when resolution did not resolve lifetimes.

### DIFF
--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -1169,15 +1169,16 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
             TyKind::Ptr(ref mt) => hir::TyKind::Ptr(self.lower_mt(mt, itctx)),
             TyKind::Rptr(ref region, ref mt) => {
                 let region = region.unwrap_or_else(|| {
-                    let Some(LifetimeRes::ElidedAnchor { start, end }) = self.resolver.get_lifetime_res(t.id) else {
-                        panic!()
+                    let id = if let Some(LifetimeRes::ElidedAnchor { start, end }) =
+                        self.resolver.get_lifetime_res(t.id)
+                    {
+                        debug_assert_eq!(start.plus(1), end);
+                        start
+                    } else {
+                        self.resolver.next_node_id()
                     };
-                    debug_assert_eq!(start.plus(1), end);
                     let span = self.sess.source_map().next_point(t.span.shrink_to_lo());
-                    Lifetime {
-                        ident: Ident::new(kw::UnderscoreLifetime, span),
-                        id: start,
-                    }
+                    Lifetime { ident: Ident::new(kw::UnderscoreLifetime, span), id }
                 });
                 let lifetime = self.lower_lifetime(&region);
                 hir::TyKind::Rptr(lifetime, self.lower_mt(mt, itctx))
@@ -1836,10 +1837,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
     fn lower_lifetime(&mut self, l: &Lifetime) -> hir::Lifetime {
         let span = self.lower_span(l.ident.span);
         let ident = self.lower_ident(l.ident);
-        let res = self
-            .resolver
-            .get_lifetime_res(l.id)
-            .unwrap_or_else(|| panic!("Missing resolution for lifetime {:?} at {:?}", l, span));
+        let res = self.resolver.get_lifetime_res(l.id).unwrap_or(LifetimeRes::Error);
         self.new_named_lifetime_with_res(l.id, span, ident, res)
     }
 

--- a/src/test/ui/lifetimes/issue-97193.rs
+++ b/src/test/ui/lifetimes/issue-97193.rs
@@ -1,0 +1,9 @@
+extern "C" {
+    fn a(&mut self) {
+        //~^ ERROR incorrect function inside `extern` block
+        //~| ERROR `self` parameter is only allowed in associated functions
+        fn b(buf: &Self) {}
+    }
+}
+
+fn main() {}

--- a/src/test/ui/lifetimes/issue-97193.stderr
+++ b/src/test/ui/lifetimes/issue-97193.stderr
@@ -1,0 +1,28 @@
+error: incorrect function inside `extern` block
+  --> $DIR/issue-97193.rs:2:8
+   |
+LL |   extern "C" {
+   |   ---------- `extern` blocks define existing foreign functions and functions inside of them cannot have a body
+LL |       fn a(&mut self) {
+   |  ________^____________-
+   | |        |
+   | |        cannot have a body
+LL | |
+LL | |
+LL | |         fn b(buf: &Self) {}
+LL | |     }
+   | |_____- help: remove the invalid body: `;`
+   |
+   = help: you might have meant to write a function accessible through FFI, which can be done by writing `extern fn` outside of the `extern` block
+   = note: for more information, visit https://doc.rust-lang.org/std/keyword.extern.html
+
+error: `self` parameter is only allowed in associated functions
+  --> $DIR/issue-97193.rs:2:10
+   |
+LL |     fn a(&mut self) {
+   |          ^^^^^^^^^ not semantically valid as function parameter
+   |
+   = note: associated functions are those in `impl` or `trait` definitions
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/lifetimes/issue-97194.rs
+++ b/src/test/ui/lifetimes/issue-97194.rs
@@ -1,0 +1,10 @@
+extern "C" {
+    fn bget(&self, index: [usize; Self::DIM]) -> bool {
+        //~^ ERROR incorrect function inside `extern` block
+        //~| ERROR `self` parameter is only allowed in associated functions
+        //~| ERROR use of undeclared type `Self`
+        type T<'a> = &'a str;
+    }
+}
+
+fn main() {}

--- a/src/test/ui/lifetimes/issue-97194.stderr
+++ b/src/test/ui/lifetimes/issue-97194.stderr
@@ -1,0 +1,36 @@
+error: incorrect function inside `extern` block
+  --> $DIR/issue-97194.rs:2:8
+   |
+LL |   extern "C" {
+   |   ---------- `extern` blocks define existing foreign functions and functions inside of them cannot have a body
+LL |       fn bget(&self, index: [usize; Self::DIM]) -> bool {
+   |  ________^^^^___________________________________________-
+   | |        |
+   | |        cannot have a body
+LL | |
+LL | |
+LL | |
+LL | |         type T<'a> = &'a str;
+LL | |     }
+   | |_____- help: remove the invalid body: `;`
+   |
+   = help: you might have meant to write a function accessible through FFI, which can be done by writing `extern fn` outside of the `extern` block
+   = note: for more information, visit https://doc.rust-lang.org/std/keyword.extern.html
+
+error: `self` parameter is only allowed in associated functions
+  --> $DIR/issue-97194.rs:2:13
+   |
+LL |     fn bget(&self, index: [usize; Self::DIM]) -> bool {
+   |             ^^^^^ not semantically valid as function parameter
+   |
+   = note: associated functions are those in `impl` or `trait` definitions
+
+error[E0433]: failed to resolve: use of undeclared type `Self`
+  --> $DIR/issue-97194.rs:2:35
+   |
+LL |     fn bget(&self, index: [usize; Self::DIM]) -> bool {
+   |                                   ^^^^ use of undeclared type `Self`
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0433`.


### PR DESCRIPTION
This can happen for items inside a foreign fn's body, which are not visited at all.

Fixes https://github.com/rust-lang/rust/issues/97193
Fixes https://github.com/rust-lang/rust/issues/97194