### PR TITLE
Bump LLVM fetched from CI to fix run-make

### DIFF
--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -2038,6 +2038,9 @@ impl Step for RustDev {
         tarball.set_overlay(OverlayKind::LLVM);
 
         let src_bindir = builder.llvm_out(target).join("bin");
+        // If updating this list, you likely want to change
+        // src/bootstrap/download-ci-llvm-stamp as well, otherwise local users
+        // will not pick up the extra file until LLVM gets bumped.
         for bin in &[
             "llvm-config",
             "llvm-ar",

--- a/src/bootstrap/download-ci-llvm-stamp
+++ b/src/bootstrap/download-ci-llvm-stamp
@@ -1,4 +1,4 @@
 Change this file to make users of the `download-ci-llvm` configuration download
 a new version of LLVM from CI, even if the LLVM submodule hasn’t changed.
 
-Last change is for: https://github.com/rust-lang/rust/pull/94023
+Last change is for: https://github.com/rust-lang/rust/pull/96867


### PR DESCRIPTION
cc @yaahc, who found this while testing locally

Ideally we'd detect this in CI and catch it, but at least we have a comment now which should hopefully prevent this from happening in the future.

r? @pietroalbini or @jyn514 

