### PR TITLE
Fix typo in futex RwLock::write_contended.

### DIFF
--- a/library/std/src/sys/unix/locks/futex_rwlock.rs
+++ b/library/std/src/sys/unix/locks/futex_rwlock.rs
@@ -208,9 +208,8 @@ impl RwLock {
 
             // Don't go to sleep if the lock has become available,
             // or if the writers waiting bit is no longer set.
-            let s = self.state.load(Relaxed);
-            if is_unlocked(state) || !has_writers_waiting(s) {
-                state = s;
+            state = self.state.load(Relaxed);
+            if is_unlocked(state) || !has_writers_waiting(state) {
                 continue;
             }
 


### PR DESCRIPTION
I wrote `state` where I should've used `s`.

This was spotted by @Warrenren.

This change removes the unnecessary `s` variable to prevent that mistake.

Fortunately, this typo didn't affect the correctness of the lock, as the
second half of the condition (!has_writers_waiting) is enough for
correctness, which explains why this mistake didn't show up during
testing.

Fixes https://github.com/rust-lang/rust/issues/97162