### PR TITLE
Keep valid scalar ranges attached to newtypes when dealing with their inner field.

### DIFF
--- a/compiler/rustc_codegen_gcc/src/builder.rs
+++ b/compiler/rustc_codegen_gcc/src/builder.rs
@@ -678,7 +678,7 @@ impl<'a, 'gcc, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'gcc, 'tcx> {
         fn scalar_load_metadata<'a, 'gcc, 'tcx>(bx: &mut Builder<'a, 'gcc, 'tcx>, load: RValue<'gcc>, scalar: &abi::Scalar, vr: Option<WrappingRange>) {
             match (vr, scalar.primitive()) {
                 (Some(vr), abi::Int(..)) => {
-                    if !scalar.is_always_valid(bx) {
+                    if !vr.is_full_for(scalar.size(bx)) {
                         bx.range_metadata(load, vr);
                     }
                 }

--- a/compiler/rustc_codegen_gcc/src/builder.rs
+++ b/compiler/rustc_codegen_gcc/src/builder.rs
@@ -747,7 +747,8 @@ impl<'a, 'gcc, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'gcc, 'tcx> {
 
         self.switch_to_block(body_bb);
         let align = dest.align.restrict_for_offset(dest.layout.field(self.cx(), 0).size);
-        cg_elem.val.store(&mut self, PlaceRef::new_sized_aligned(current_val, cg_elem.layout, align));
+        let dest = PlaceRef::new_sized_aligned(self.cx(), current_val, cg_elem.layout, align);
+        cg_elem.val.store(&mut self, dest);
 
         let next = self.inbounds_gep(self.backend_type(cg_elem.layout), current.to_rvalue(), &[self.const_usize(1)]);
         self.llbb().add_assignment(None, current, next);

--- a/compiler/rustc_codegen_gcc/src/common.rs
+++ b/compiler/rustc_codegen_gcc/src/common.rs
@@ -239,7 +239,7 @@ impl<'gcc, 'tcx> ConstMethods<'tcx> for CodegenCx<'gcc, 'tcx> {
                 let value = self.context.new_array_access(None, array, self.const_usize(offset.bytes())).get_address(None);
                 self.const_bitcast(value, ty)
             };
-        PlaceRef::new_sized(value, layout)
+        PlaceRef::new_sized(self, value, layout)
     }
 
     fn const_ptrcast(&self, val: RValue<'gcc>, ty: Type<'gcc>) -> RValue<'gcc> {

--- a/compiler/rustc_codegen_gcc/src/intrinsic/mod.rs
+++ b/compiler/rustc_codegen_gcc/src/intrinsic/mod.rs
@@ -91,7 +91,7 @@ impl<'a, 'gcc, 'tcx> IntrinsicCallMethods<'tcx> for Builder<'a, 'gcc, 'tcx> {
         let name_str = name.as_str();
 
         let llret_ty = self.layout_of(ret_ty).gcc_type(self, true);
-        let result = PlaceRef::new_sized(llresult, fn_abi.ret.layout);
+        let result = PlaceRef::new_sized(self, llresult, fn_abi.ret.layout);
 
         let simple = get_simple_intrinsic(self, name);
         let llval =

--- a/compiler/rustc_codegen_gcc/src/lib.rs
+++ b/compiler/rustc_codegen_gcc/src/lib.rs
@@ -6,7 +6,7 @@
  * TODO(antoyo): remove the patches.
  */
 
-#![feature(rustc_private, decl_macro, associated_type_bounds, never_type, trusted_len)]
+#![feature(rustc_private, decl_macro, associated_type_bounds, never_type, trusted_len, unzip_option)]
 #![allow(broken_intra_doc_links)]
 #![recursion_limit="256"]
 #![warn(rust_2018_idioms)]

--- a/compiler/rustc_codegen_llvm/src/builder.rs
+++ b/compiler/rustc_codegen_llvm/src/builder.rs
@@ -487,7 +487,7 @@ impl<'a, 'll, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'll, 'tcx> {
 
             match (vr, scalar.primitive()) {
                 (Some(vr), abi::Int(..)) => {
-                    if !scalar.is_always_valid(bx) {
+                    if !vr.is_full_for(scalar.size(bx)) {
                         bx.range_metadata(load, vr);
                     }
                 }

--- a/compiler/rustc_codegen_llvm/src/builder.rs
+++ b/compiler/rustc_codegen_llvm/src/builder.rs
@@ -577,9 +577,10 @@ impl<'a, 'll, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'll, 'tcx> {
 
         let mut body_bx = Self::build(self.cx, body_bb);
         let align = dest.align.restrict_for_offset(dest.layout.field(self.cx(), 0).size);
-        cg_elem
-            .val
-            .store(&mut body_bx, PlaceRef::new_sized_aligned(current, cg_elem.layout, align));
+        cg_elem.val.store(
+            &mut body_bx,
+            PlaceRef::new_sized_aligned(self.cx, current, cg_elem.layout, align),
+        );
 
         let next = body_bx.inbounds_gep(
             self.backend_type(cg_elem.layout),

--- a/compiler/rustc_codegen_llvm/src/common.rs
+++ b/compiler/rustc_codegen_llvm/src/common.rs
@@ -308,7 +308,7 @@ impl<'ll, 'tcx> ConstMethods<'tcx> for CodegenCx<'ll, 'tcx> {
             };
             self.const_bitcast(llval, llty)
         };
-        PlaceRef::new_sized(llval, layout)
+        PlaceRef::new_sized(self, llval, layout)
     }
 
     fn const_ptrcast(&self, val: &'ll Value, ty: &'ll Type) -> &'ll Value {

--- a/compiler/rustc_codegen_llvm/src/intrinsic.rs
+++ b/compiler/rustc_codegen_llvm/src/intrinsic.rs
@@ -99,7 +99,7 @@ impl<'ll, 'tcx> IntrinsicCallMethods<'tcx> for Builder<'_, 'll, 'tcx> {
         let name = tcx.item_name(def_id);
 
         let llret_ty = self.layout_of(ret_ty).llvm_type(self);
-        let result = PlaceRef::new_sized(llresult, fn_abi.ret.layout);
+        let result = PlaceRef::new_sized(self, llresult, fn_abi.ret.layout);
 
         let simple = get_simple_intrinsic(self, name);
         let llval = match name {

--- a/compiler/rustc_codegen_llvm/src/lib.rs
+++ b/compiler/rustc_codegen_llvm/src/lib.rs
@@ -11,6 +11,7 @@
 #![feature(once_cell)]
 #![feature(nll)]
 #![feature(iter_intersperse)]
+#![feature(unzip_option)]
 #![recursion_limit = "256"]
 #![allow(rustc::potential_query_instability)]
 

--- a/compiler/rustc_codegen_ssa/src/mir/block.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/block.rs
@@ -1240,7 +1240,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
 
         // Handle both by-ref and immediate tuples.
         if let Ref(llval, None, align) = tuple.val {
-            let tuple_ptr = PlaceRef::new_sized_aligned(llval, tuple.layout, align);
+            let tuple_ptr = PlaceRef::new_sized_aligned(bx, llval, tuple.layout, align);
             for i in 0..tuple.layout.fields.count() {
                 let field_ptr = tuple_ptr.project_field(bx, i);
                 let field = bx.load_operand(field_ptr);
@@ -1581,7 +1581,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
         let llty = bx.backend_type(src.layout);
         let cast_ptr = bx.pointercast(dst.llval, bx.type_ptr_to(llty));
         let align = src.layout.align.abi.min(dst.align);
-        src.val.store(bx, PlaceRef::new_sized_aligned(cast_ptr, src.layout, align));
+        src.val.store(bx, PlaceRef::new_sized_aligned(bx, cast_ptr, src.layout, align));
     }
 
     // Stores the return value of a function call into it's final location.

--- a/compiler/rustc_codegen_ssa/src/mir/intrinsic.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/intrinsic.rs
@@ -70,7 +70,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
         let name_str = name.as_str();
 
         let llret_ty = bx.backend_type(bx.layout_of(ret_ty));
-        let result = PlaceRef::new_sized(llresult, fn_abi.ret.layout);
+        let result = PlaceRef::new_sized(bx, llresult, fn_abi.ret.layout);
 
         let llval = match name {
             sym::assume => {

--- a/compiler/rustc_codegen_ssa/src/mir/mod.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/mod.rs
@@ -217,7 +217,7 @@ pub fn codegen_mir<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
             if local == mir::RETURN_PLACE && fx.fn_abi.ret.is_indirect() {
                 debug!("alloc: {:?} (return place) -> place", local);
                 let llretptr = bx.get_param(0);
-                return LocalRef::Place(PlaceRef::new_sized(llretptr, layout));
+                return LocalRef::Place(PlaceRef::new_sized(&bx, llretptr, layout));
             }
 
             if memory_locals.contains(local) {
@@ -356,7 +356,7 @@ fn arg_local_refs<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
                 // FIXME: lifetimes
                 let llarg = bx.get_param(llarg_idx);
                 llarg_idx += 1;
-                LocalRef::Place(PlaceRef::new_sized(llarg, arg.layout))
+                LocalRef::Place(PlaceRef::new_sized(bx, llarg, arg.layout))
             } else if arg.is_unsized_indirect() {
                 // As the storage for the indirect argument lives during
                 // the whole function call, we just copy the fat pointer.

--- a/compiler/rustc_codegen_ssa/src/mir/operand.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/operand.rs
@@ -137,7 +137,13 @@ impl<'a, 'tcx, V: CodegenObject> OperandRef<'tcx, V> {
             OperandValue::Ref(..) => bug!("Deref of by-Ref operand {:?}", self),
         };
         let layout = cx.layout_of(projected_ty);
-        PlaceRef { llval: llptr, llextra, layout, align: layout.align.abi }
+        PlaceRef {
+            llval: llptr,
+            llextra,
+            layout,
+            align: layout.align.abi,
+            scalar_valid_range: layout.abi.scalar_valid_range(cx),
+        }
     }
 
     /// If this operand is a `Pair`, we return an aggregate with the two values.

--- a/compiler/rustc_codegen_ssa/src/mir/place.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/place.rs
@@ -136,13 +136,14 @@ impl<'a, 'tcx, V: CodegenObject> PlaceRef<'tcx, V> {
             };
 
             // If this field is a primitive type of a newtype, propogate the scalar valid range
-            let scalar_valid_range = if let (0, Variants::Single { .. }, Abi::Scalar(_)) =
-                (offset.bytes(), &self.layout.variants, field.abi)
-            {
-                self.scalar_valid_range
-            } else {
-                field.abi.scalar_valid_range(bx)
-            };
+            let scalar_valid_range =
+                if let (0, Variants::Single { .. }, Abi::Scalar(_) | Abi::ScalarPair(..)) =
+                    (offset.bytes(), &self.layout.variants, field.abi)
+                {
+                    self.scalar_valid_range
+                } else {
+                    field.abi.scalar_valid_range(bx)
+                };
 
             PlaceRef {
                 // HACK(eddyb): have to bitcast pointers until LLVM removes pointee types.

--- a/compiler/rustc_codegen_ssa/src/mir/rvalue.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/rvalue.rs
@@ -64,7 +64,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                         scratch.storage_dead(&mut bx);
                     }
                     OperandValue::Ref(llref, None, align) => {
-                        let source = PlaceRef::new_sized_aligned(llref, operand.layout, align);
+                        let source = PlaceRef::new_sized_aligned(&bx, llref, operand.layout, align);
                         base::coerce_unsized_into(&mut bx, source, dest);
                     }
                     OperandValue::Ref(_, Some(_), _) => {

--- a/src/test/codegen/scalar-ranges-newtypes.rs
+++ b/src/test/codegen/scalar-ranges-newtypes.rs
@@ -1,0 +1,45 @@
+#![crate_type = "lib"]
+#![feature(rustc_attrs, bench_black_box)]
+
+#[rustc_layout_scalar_valid_range_start(1)]
+pub struct NonNull1(*const ());
+
+#[rustc_layout_scalar_valid_range_start(1)]
+pub struct NonNull2 {
+    ptr: *const (),
+}
+
+#[rustc_layout_scalar_valid_range_start(1)]
+pub struct NonNull3 {
+    _marker: std::marker::PhantomData<()>,
+    ptr: *const (),
+}
+
+// CHECK: define void @test_nonnull_load
+#[no_mangle]
+pub fn test_nonnull_load(p1: &NonNull1, p2: &NonNull2, p3: &NonNull3) {
+    // CHECK: %[[P1:[0-9]+]] = bitcast i8** %p1 to {}**
+    // CHECK: load {}*, {}** %[[P1]], align 8, !nonnull
+    std::hint::black_box(p1.0);
+
+    // CHECK: %[[P2:[0-9]+]] = bitcast i8** %p2 to {}**
+    // CHECK: load {}*, {}** %[[P2]], align 8, !nonnull
+    std::hint::black_box(p2.ptr);
+
+    // CHECK: %[[P3:[0-9]+]] = bitcast i8** %p3 to {}**
+    // CHECK: load {}*, {}** %[[P3]], align 8, !nonnull
+    std::hint::black_box(p3.ptr);
+}
+
+#[rustc_layout_scalar_valid_range_start(16)]
+#[rustc_layout_scalar_valid_range_end(2032)]
+pub struct Range(i32);
+
+// CHECK: define void @test_range_load
+#[no_mangle]
+pub fn test_range_load(p: &Range) {
+    // CHECK: load i32, i32* %{{.*}}, align 4, !range ![[RANGE:[0-9]+]]
+    std::hint::black_box(p.0);
+}
+
+// CHECK: ![[RANGE]] = !{i32 16, i32 2033}


### PR DESCRIPTION
Fixes #97161 by keeping an "effective" scalar validity range on `PlaceRef` and propagating it for newtypes of primitives.