### PR TITLE
Improve suggestions for closure parameters

### DIFF
--- a/src/test/ui/closures/closure-signature/unspecified-output.rs
+++ b/src/test/ui/closures/closure-signature/unspecified-output.rs
@@ -1,0 +1,3 @@
+fn main() {
+    let a = |a: i32, b: &i32| Vec::new(); //~ ERROR E0282
+}

--- a/src/test/ui/closures/closure-signature/unspecified-output.stderr
+++ b/src/test/ui/closures/closure-signature/unspecified-output.stderr
@@ -1,0 +1,14 @@
+error[E0282]: type annotations needed for the closure `fn(i32, &i32) -> Vec<_>`
+  --> $DIR/unspecified-output.rs:2:31
+   |
+LL |     let a = |a: i32, b: &i32| Vec::new();
+   |                               ^^^^^^^^ cannot infer type for type parameter `T`
+   |
+help: give this closure an explicit return type without `_` placeholders
+   |
+LL |     let a = |a: i32, b: &i32| -> Vec<_> { Vec::new() };
+   |                               +++++++++++            +
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0282`.

--- a/src/test/ui/closures/closure-signature/unspecified-parameter-fn.rs
+++ b/src/test/ui/closures/closure-signature/unspecified-parameter-fn.rs
@@ -1,0 +1,3 @@
+fn main() {
+    let a = |a: i32, b: fn(i32) -> _| -> Vec<i32> { Vec::new() }; //~ ERROR E0282
+}

--- a/src/test/ui/closures/closure-signature/unspecified-parameter-fn.stderr
+++ b/src/test/ui/closures/closure-signature/unspecified-parameter-fn.stderr
@@ -1,0 +1,11 @@
+error[E0282]: type annotations needed for the closure `fn(i32, fn(i32) -> _) -> Vec<i32>`
+  --> $DIR/unspecified-parameter-fn.rs:2:13
+   |
+LL |     let a = |a: i32, b: fn(i32) -> _| -> Vec<i32> { Vec::new() };
+   |             ^^^^^^^^^^^^^^^^^^^^^^^-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                                    |
+   |                                    give this closure parameter an explicit type instead of `_`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0282`.

--- a/src/test/ui/closures/closure-signature/unspecified-parameter-ref.rs
+++ b/src/test/ui/closures/closure-signature/unspecified-parameter-ref.rs
@@ -1,0 +1,3 @@
+fn main() {
+    let a = |a: i32, b: &_| -> Vec<i32> { Vec::new() }; //~ ERROR E0282
+}

--- a/src/test/ui/closures/closure-signature/unspecified-parameter-ref.stderr
+++ b/src/test/ui/closures/closure-signature/unspecified-parameter-ref.stderr
@@ -1,0 +1,11 @@
+error[E0282]: type annotations needed for the closure `fn(i32, &_) -> Vec<i32>`
+  --> $DIR/unspecified-parameter-ref.rs:2:13
+   |
+LL |     let a = |a: i32, b: &_| -> Vec<i32> { Vec::new() };
+   |             ^^^^^^^^^^^^^-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                          |
+   |                          give this closure parameter an explicit type instead of `_`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0282`.

--- a/src/test/ui/closures/closure-signature/unspecified-parameter-type-param.rs
+++ b/src/test/ui/closures/closure-signature/unspecified-parameter-type-param.rs
@@ -1,0 +1,3 @@
+fn main() {
+    let a = |a: i32, b: Vec<_>| -> Vec<i32> { Vec::new() }; //~ ERROR E0282
+}

--- a/src/test/ui/closures/closure-signature/unspecified-parameter-type-param.stderr
+++ b/src/test/ui/closures/closure-signature/unspecified-parameter-type-param.stderr
@@ -1,0 +1,11 @@
+error[E0282]: type annotations needed for the closure `fn(i32, Vec<_>) -> Vec<i32>`
+  --> $DIR/unspecified-parameter-type-param.rs:2:13
+   |
+LL |     let a = |a: i32, b: Vec<_>| -> Vec<i32> { Vec::new() };
+   |             ^^^^^^^^^^^^^^^^-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                             |
+   |                             give this closure parameter an explicit type instead of `_`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0282`.

--- a/src/test/ui/closures/closure-signature/unspecified-parameter.rs
+++ b/src/test/ui/closures/closure-signature/unspecified-parameter.rs
@@ -1,0 +1,3 @@
+fn main() {
+    let a = |a: _, b: &i32| -> Vec<i32> { Vec::new() }; //~ ERROR E0282
+}

--- a/src/test/ui/closures/closure-signature/unspecified-parameter.stderr
+++ b/src/test/ui/closures/closure-signature/unspecified-parameter.stderr
@@ -1,0 +1,9 @@
+error[E0282]: type annotations needed
+  --> $DIR/unspecified-parameter.rs:2:14
+   |
+LL |     let a = |a: _, b: &i32| -> Vec<i32> { Vec::new() };
+   |              ^ consider giving this closure parameter a type
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0282`.


### PR DESCRIPTION
Currently, the type inference for closures does not handle `_` in the arguments very well. It works specifically for the case of having something like `|x: _|`, but not if the `_` has any indirection like `|x: &_|` or `|x: Vec<_>|` etc. Instead, the compiler assumes the issue has to do with the return type annotation, leading to some silly suggestions. The motivating example was this:
```
fn main() {
    let x = |a: &_| -> i32 { 1 };
}
```
Which currently gives a silly suggestion:
```
error[[E0282]](https://doc.rust-lang.org/stable/error-index.html#E0282): type annotations needed for the closure `fn(&_) -> i32`
 --> src/main.rs:2:13
  |
2 |     let x = |a: &_| -> i32 { 1 };
  |             ^^^^^^^^^^^^^^^^^^^^ cannot infer type for closure `[closure@src/main.rs:2:13: 2:33]`
  |
help: give this closure an explicit return type without `_` placeholders
  |
2 |     let x = |a: &_| -> i32 { 1 };
  |                        ~~~

For more information about this error, try `rustc --explain E0282`.
```
(playground link: https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=cb2ba62db3f94f09c2f5dc83217e877e).

This diff changes the diagnostic so that it now looks for any unresolved input parameters before and suggest specifying those before defaulting to the return value.

r? @compiler-errors 