### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -1169,15 +1169,16 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
             TyKind::Ptr(ref mt) => hir::TyKind::Ptr(self.lower_mt(mt, itctx)),
             TyKind::Rptr(ref region, ref mt) => {
                 let region = region.unwrap_or_else(|| {
-                    let Some(LifetimeRes::ElidedAnchor { start, end }) = self.resolver.get_lifetime_res(t.id) else {
-                        panic!()
+                    let id = if let Some(LifetimeRes::ElidedAnchor { start, end }) =
+                        self.resolver.get_lifetime_res(t.id)
+                    {
+                        debug_assert_eq!(start.plus(1), end);
+                        start
+                    } else {
+                        self.resolver.next_node_id()
                     };
-                    debug_assert_eq!(start.plus(1), end);
                     let span = self.sess.source_map().next_point(t.span.shrink_to_lo());
-                    Lifetime {
-                        ident: Ident::new(kw::UnderscoreLifetime, span),
-                        id: start,
-                    }
+                    Lifetime { ident: Ident::new(kw::UnderscoreLifetime, span), id }
                 });
                 let lifetime = self.lower_lifetime(&region);
                 hir::TyKind::Rptr(lifetime, self.lower_mt(mt, itctx))
@@ -1836,10 +1837,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
     fn lower_lifetime(&mut self, l: &Lifetime) -> hir::Lifetime {
         let span = self.lower_span(l.ident.span);
         let ident = self.lower_ident(l.ident);
-        let res = self
-            .resolver
-            .get_lifetime_res(l.id)
-            .unwrap_or_else(|| panic!("Missing resolution for lifetime {:?} at {:?}", l, span));
+        let res = self.resolver.get_lifetime_res(l.id).unwrap_or(LifetimeRes::Error);
         self.new_named_lifetime_with_res(l.id, span, ident, res)
     }
 

--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -189,7 +189,7 @@ pub enum MirPhase {
     ///
     /// Beginning with this phase, the following variants are disallowed:
     /// * [`TerminatorKind::Yield`](terminator::TerminatorKind::Yield)
-    /// * [`TerminatorKind::GeneratorDrop](terminator::TerminatorKind::GeneratorDrop)
+    /// * [`TerminatorKind::GeneratorDrop`](terminator::TerminatorKind::GeneratorDrop)
     GeneratorsLowered = 5,
     Optimized = 6,
 }

--- a/library/core/src/cell.rs
+++ b/library/core/src/cell.rs
@@ -1487,7 +1487,7 @@ impl<'b, T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<Ref<'b, U>> for Ref<'b,
 #[stable(feature = "std_guard_impls", since = "1.20.0")]
 impl<T: ?Sized + fmt::Display> fmt::Display for Ref<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.value.fmt(f)
+        (**self).fmt(f)
     }
 }
 
@@ -1735,7 +1735,7 @@ impl<'b, T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<RefMut<'b, U>> for RefM
 #[stable(feature = "std_guard_impls", since = "1.20.0")]
 impl<T: ?Sized + fmt::Display> fmt::Display for RefMut<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.value.fmt(f)
+        (**self).fmt(f)
     }
 }
 

--- a/library/core/tests/cell.rs
+++ b/library/core/tests/cell.rs
@@ -73,11 +73,13 @@ fn ref_and_refmut_have_sensible_show() {
     let refcell = RefCell::new("foo");
 
     let refcell_refmut = refcell.borrow_mut();
-    assert!(format!("{refcell_refmut:?}").contains("foo"));
+    assert_eq!(format!("{refcell_refmut}"), "foo"); // Display
+    assert!(format!("{refcell_refmut:?}").contains("foo")); // Debug
     drop(refcell_refmut);
 
     let refcell_ref = refcell.borrow();
-    assert!(format!("{refcell_ref:?}").contains("foo"));
+    assert_eq!(format!("{refcell_ref}"), "foo"); // Display
+    assert!(format!("{refcell_ref:?}").contains("foo")); // Debug
     drop(refcell_ref);
 }
 

--- a/library/std/src/error.rs
+++ b/library/std/src/error.rs
@@ -863,12 +863,12 @@ impl dyn Error + Send + Sync {
     }
 }
 
-/// An error reporter that print's an error and its sources.
+/// An error reporter that prints an error and its sources.
 ///
 /// Report also exposes configuration options for formatting the error chain, either entirely on a
 /// single line, or in multi-line format with each cause in the error chain on a new line.
 ///
-/// `Report` only requires that the wrapped error implements `Error`. It doesn't require that the
+/// `Report` only requires that the wrapped error implement `Error`. It doesn't require that the
 /// wrapped error be `Send`, `Sync`, or `'static`.
 ///
 /// # Examples
@@ -972,7 +972,7 @@ impl dyn Error + Send + Sync {
 ///
 /// ## Return from `main`
 ///
-/// `Report` also implements `From` for all types that implement [`Error`], this when combined with
+/// `Report` also implements `From` for all types that implement [`Error`]; this when combined with
 /// the `Debug` output means `Report` is an ideal starting place for formatting errors returned
 /// from `main`.
 ///
@@ -1020,7 +1020,7 @@ impl dyn Error + Send + Sync {
 /// ```
 ///
 /// **Note**: `Report`s constructed via `?` and `From` will be configured to use the single line
-/// output format, if you want to make sure your `Report`s are pretty printed and include backtrace
+/// output format. If you want to make sure your `Report`s are pretty printed and include backtrace
 /// you will need to manually convert and enable those flags.
 ///
 /// ```should_panic

--- a/library/std/src/sys/unix/locks/futex_rwlock.rs
+++ b/library/std/src/sys/unix/locks/futex_rwlock.rs
@@ -208,9 +208,8 @@ impl RwLock {
 
             // Don't go to sleep if the lock has become available,
             // or if the writers waiting bit is no longer set.
-            let s = self.state.load(Relaxed);
-            if is_unlocked(state) || !has_writers_waiting(s) {
-                state = s;
+            state = self.state.load(Relaxed);
+            if is_unlocked(state) || !has_writers_waiting(state) {
                 continue;
             }
 

--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -814,7 +814,7 @@ impl Step for Src {
                 "library/backtrace/crates",
                 // these are 30MB combined and aren't necessary for building
                 // the standard library.
-                "library/stdarch/crates/Cargo.toml",
+                "library/stdarch/Cargo.toml",
                 "library/stdarch/crates/stdarch-verify",
                 "library/stdarch/crates/intrinsic-test",
             ],

--- a/src/test/ui/lifetimes/issue-97193.rs
+++ b/src/test/ui/lifetimes/issue-97193.rs
@@ -1,0 +1,9 @@
+extern "C" {
+    fn a(&mut self) {
+        //~^ ERROR incorrect function inside `extern` block
+        //~| ERROR `self` parameter is only allowed in associated functions
+        fn b(buf: &Self) {}
+    }
+}
+
+fn main() {}

--- a/src/test/ui/lifetimes/issue-97193.stderr
+++ b/src/test/ui/lifetimes/issue-97193.stderr
@@ -1,0 +1,28 @@
+error: incorrect function inside `extern` block
+  --> $DIR/issue-97193.rs:2:8
+   |
+LL |   extern "C" {
+   |   ---------- `extern` blocks define existing foreign functions and functions inside of them cannot have a body
+LL |       fn a(&mut self) {
+   |  ________^____________-
+   | |        |
+   | |        cannot have a body
+LL | |
+LL | |
+LL | |         fn b(buf: &Self) {}
+LL | |     }
+   | |_____- help: remove the invalid body: `;`
+   |
+   = help: you might have meant to write a function accessible through FFI, which can be done by writing `extern fn` outside of the `extern` block
+   = note: for more information, visit https://doc.rust-lang.org/std/keyword.extern.html
+
+error: `self` parameter is only allowed in associated functions
+  --> $DIR/issue-97193.rs:2:10
+   |
+LL |     fn a(&mut self) {
+   |          ^^^^^^^^^ not semantically valid as function parameter
+   |
+   = note: associated functions are those in `impl` or `trait` definitions
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/lifetimes/issue-97194.rs
+++ b/src/test/ui/lifetimes/issue-97194.rs
@@ -1,0 +1,10 @@
+extern "C" {
+    fn bget(&self, index: [usize; Self::DIM]) -> bool {
+        //~^ ERROR incorrect function inside `extern` block
+        //~| ERROR `self` parameter is only allowed in associated functions
+        //~| ERROR use of undeclared type `Self`
+        type T<'a> = &'a str;
+    }
+}
+
+fn main() {}

--- a/src/test/ui/lifetimes/issue-97194.stderr
+++ b/src/test/ui/lifetimes/issue-97194.stderr
@@ -1,0 +1,36 @@
+error: incorrect function inside `extern` block
+  --> $DIR/issue-97194.rs:2:8
+   |
+LL |   extern "C" {
+   |   ---------- `extern` blocks define existing foreign functions and functions inside of them cannot have a body
+LL |       fn bget(&self, index: [usize; Self::DIM]) -> bool {
+   |  ________^^^^___________________________________________-
+   | |        |
+   | |        cannot have a body
+LL | |
+LL | |
+LL | |
+LL | |         type T<'a> = &'a str;
+LL | |     }
+   | |_____- help: remove the invalid body: `;`
+   |
+   = help: you might have meant to write a function accessible through FFI, which can be done by writing `extern fn` outside of the `extern` block
+   = note: for more information, visit https://doc.rust-lang.org/std/keyword.extern.html
+
+error: `self` parameter is only allowed in associated functions
+  --> $DIR/issue-97194.rs:2:13
+   |
+LL |     fn bget(&self, index: [usize; Self::DIM]) -> bool {
+   |             ^^^^^ not semantically valid as function parameter
+   |
+   = note: associated functions are those in `impl` or `trait` definitions
+
+error[E0433]: failed to resolve: use of undeclared type `Self`
+  --> $DIR/issue-97194.rs:2:35
+   |
+LL |     fn bget(&self, index: [usize; Self::DIM]) -> bool {
+   |                                   ^^^^ use of undeclared type `Self`
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0433`.


### PR DESCRIPTION
Successful merges:

 - #97144 (Fix rusty grammar in `std::error::Reporter` docs)
 - #97225 (Fix `Display` for `cell::{Ref,RefMut}`)
 - #97228 (Omit stdarch workspace from rust-src)
 - #97236 (Recover when resolution did not resolve lifetimes.)
 - #97245 (Fix typo in futex RwLock::write_contended.)
 - #97259 (Fix typo in Mir phase docs)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=97144,97225,97228,97236,97245,97259)
<!-- homu-ignore:end -->