### PR TITLE
Make weird name lints trigger behind cfg_attr

### DIFF
--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -474,7 +474,7 @@ declare_lint! {
 }
 
 declare_lint! {
-    /// The `unknown_lints` lint detects unrecognized lint attribute.
+    /// The `unknown_lints` lint detects unrecognized lint attributes.
     ///
     /// ### Example
     ///

--- a/src/test/ui-fulldeps/lint-tool-test.stderr
+++ b/src/test/ui-fulldeps/lint-tool-test.stderr
@@ -18,14 +18,6 @@ warning: lint name `test_group` is deprecated and may not have an effect in the 
 LL | #[allow(test_group)]
    |         ^^^^^^^^^^ help: change it to: `clippy::test_group`
 
-warning: unknown lint: `this_lint_does_not_exist`
-  --> $DIR/lint-tool-test.rs:36:8
-   |
-LL | #[deny(this_lint_does_not_exist)]
-   |        ^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: `#[warn(unknown_lints)]` on by default
-
 warning: lint name `test_lint` is deprecated and may not have an effect in the future.
   --> $DIR/lint-tool-test.rs:9:23
    |
@@ -43,6 +35,14 @@ warning: lint name `test_group` is deprecated and may not have an effect in the 
    |
 LL | #[allow(test_group)]
    |         ^^^^^^^^^^ help: change it to: `clippy::test_group`
+
+warning: unknown lint: `this_lint_does_not_exist`
+  --> $DIR/lint-tool-test.rs:36:8
+   |
+LL | #[deny(this_lint_does_not_exist)]
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(unknown_lints)]` on by default
 
 warning: use of deprecated attribute `plugin`: compiler plugins are deprecated. See https://github.com/rust-lang/rust/pull/64675
   --> $DIR/lint-tool-test.rs:6:1

--- a/src/test/ui/feature-gates/issue-43106-gating-of-builtin-attrs.stderr
+++ b/src/test/ui/feature-gates/issue-43106-gating-of-builtin-attrs.stderr
@@ -1,3 +1,17 @@
+warning: `#[macro_escape]` is a deprecated synonym for `#[macro_use]`
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:401:17
+   |
+LL |     mod inner { #![macro_escape] }
+   |                 ^^^^^^^^^^^^^^^^
+   |
+   = help: try an outer attribute: `#[macro_use]`
+
+warning: `#[macro_escape]` is a deprecated synonym for `#[macro_use]`
+  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:398:1
+   |
+LL | #[macro_escape]
+   | ^^^^^^^^^^^^^^^
+
 warning: unknown lint: `x5400`
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:46:9
    |
@@ -171,20 +185,6 @@ warning: unknown lint: `x5100`
    |
 LL |     #[deny(x5100)] impl S { }
    |            ^^^^^
-
-warning: `#[macro_escape]` is a deprecated synonym for `#[macro_use]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:401:17
-   |
-LL |     mod inner { #![macro_escape] }
-   |                 ^^^^^^^^^^^^^^^^
-   |
-   = help: try an outer attribute: `#[macro_use]`
-
-warning: `#[macro_escape]` is a deprecated synonym for `#[macro_use]`
-  --> $DIR/issue-43106-gating-of-builtin-attrs.rs:398:1
-   |
-LL | #[macro_escape]
-   | ^^^^^^^^^^^^^^^
 
 warning: use of deprecated attribute `crate_id`: no longer used.
   --> $DIR/issue-43106-gating-of-builtin-attrs.rs:85:1

--- a/src/test/ui/lint/issue-97094.interleaved.stderr
+++ b/src/test/ui/lint/issue-97094.interleaved.stderr
@@ -1,0 +1,53 @@
+error: unknown lint: `nonex_lint_top_level`
+  --> $DIR/issue-97094.rs:14:26
+   |
+LL | #![cfg_attr(all(), allow(nonex_lint_top_level))]
+   |                          ^^^^^^^^^^^^^^^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/issue-97094.rs:10:9
+   |
+LL | #![deny(warnings)]
+   |         ^^^^^^^^
+   = note: `#[deny(unknown_lints)]` implied by `#[deny(warnings)]`
+
+error: lint `bare_trait_object` has been renamed to `bare_trait_objects`
+  --> $DIR/issue-97094.rs:16:26
+   |
+LL | #![cfg_attr(all(), allow(bare_trait_object))]
+   |                          ^^^^^^^^^^^^^^^^^ help: use the new name: `bare_trait_objects`
+   |
+   = note: `#[deny(renamed_and_removed_lints)]` implied by `#[deny(warnings)]`
+
+error: unknown lint: `nonex_lint_mod`
+  --> $DIR/issue-97094.rs:19:25
+   |
+LL | #[cfg_attr(all(), allow(nonex_lint_mod))]
+   |                         ^^^^^^^^^^^^^^
+
+error: unknown lint: `nonex_lint_mod_inner`
+  --> $DIR/issue-97094.rs:22:30
+   |
+LL |     #![cfg_attr(all(), allow(nonex_lint_mod_inner))]
+   |                              ^^^^^^^^^^^^^^^^^^^^
+
+error: unknown lint: `nonex_lint_fn`
+  --> $DIR/issue-97094.rs:26:25
+   |
+LL | #[cfg_attr(all(), allow(nonex_lint_fn))]
+   |                         ^^^^^^^^^^^^^
+
+error: unknown lint: `nonex_lint_in_macro`
+  --> $DIR/issue-97094.rs:37:29
+   |
+LL |     #[cfg_attr(all(), allow(nonex_lint_in_macro))]
+   |                             ^^^^^^^^^^^^^^^^^^^
+
+error: unknown lint: `nonex_lint_fn`
+  --> $DIR/issue-97094.rs:56:13
+   |
+LL |     #[allow(nonex_lint_fn)]
+   |             ^^^^^^^^^^^^^
+
+error: aborting due to 7 previous errors
+

--- a/src/test/ui/lint/issue-97094.nointerleaved.stderr
+++ b/src/test/ui/lint/issue-97094.nointerleaved.stderr
@@ -1,0 +1,53 @@
+error: unknown lint: `nonex_lint_top_level`
+  --> $DIR/issue-97094.rs:14:26
+   |
+LL | #![cfg_attr(all(), allow(nonex_lint_top_level))]
+   |                          ^^^^^^^^^^^^^^^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/issue-97094.rs:10:9
+   |
+LL | #![deny(warnings)]
+   |         ^^^^^^^^
+   = note: `#[deny(unknown_lints)]` implied by `#[deny(warnings)]`
+
+error: lint `bare_trait_object` has been renamed to `bare_trait_objects`
+  --> $DIR/issue-97094.rs:16:26
+   |
+LL | #![cfg_attr(all(), allow(bare_trait_object))]
+   |                          ^^^^^^^^^^^^^^^^^ help: use the new name: `bare_trait_objects`
+   |
+   = note: `#[deny(renamed_and_removed_lints)]` implied by `#[deny(warnings)]`
+
+error: unknown lint: `nonex_lint_mod`
+  --> $DIR/issue-97094.rs:19:25
+   |
+LL | #[cfg_attr(all(), allow(nonex_lint_mod))]
+   |                         ^^^^^^^^^^^^^^
+
+error: unknown lint: `nonex_lint_mod_inner`
+  --> $DIR/issue-97094.rs:22:30
+   |
+LL |     #![cfg_attr(all(), allow(nonex_lint_mod_inner))]
+   |                              ^^^^^^^^^^^^^^^^^^^^
+
+error: unknown lint: `nonex_lint_fn`
+  --> $DIR/issue-97094.rs:26:25
+   |
+LL | #[cfg_attr(all(), allow(nonex_lint_fn))]
+   |                         ^^^^^^^^^^^^^
+
+error: unknown lint: `nonex_lint_in_macro`
+  --> $DIR/issue-97094.rs:37:29
+   |
+LL |     #[cfg_attr(all(), allow(nonex_lint_in_macro))]
+   |                             ^^^^^^^^^^^^^^^^^^^
+
+error: unknown lint: `nonex_lint_fn`
+  --> $DIR/issue-97094.rs:56:13
+   |
+LL |     #[allow(nonex_lint_fn)]
+   |             ^^^^^^^^^^^^^
+
+error: aborting due to 7 previous errors
+

--- a/src/test/ui/lint/issue-97094.rs
+++ b/src/test/ui/lint/issue-97094.rs
@@ -1,0 +1,59 @@
+// revisions: interleaved nointerleaved
+// [nointerleaved]compile-flags: -Z no-interleave-lints
+
+// This test has two revisions because the logic change
+// needed to make this test pass had to be adjusted
+// for no-interleave-lints. Should the debug option
+// be removed one day, please don't remove this
+// test entirely, just remove the revision from it.
+
+#![deny(warnings)]
+
+// Ensure that unknown lints inside cfg-attr's are linted for
+
+#![cfg_attr(all(), allow(nonex_lint_top_level))]
+//~^ ERROR unknown lint
+#![cfg_attr(all(), allow(bare_trait_object))]
+//~^ ERROR has been renamed
+
+#[cfg_attr(all(), allow(nonex_lint_mod))]
+//~^ ERROR unknown lint
+mod baz {
+    #![cfg_attr(all(), allow(nonex_lint_mod_inner))]
+    //~^ ERROR unknown lint
+}
+
+#[cfg_attr(all(), allow(nonex_lint_fn))]
+//~^ ERROR unknown lint
+pub fn main() {}
+
+macro_rules! bar {
+    ($($t:tt)*) => {
+        $($t)*
+    };
+}
+
+bar!(
+    #[cfg_attr(all(), allow(nonex_lint_in_macro))]
+    //~^ ERROR unknown lint
+    pub fn _bar() {}
+);
+
+// No warning for non-applying cfg
+#[cfg_attr(any(), allow(nonex_lint_fn))]
+pub fn _foo() {}
+
+// Allowing unknown lints works if inside cfg_attr
+#[cfg_attr(all(), allow(unknown_lints))]
+mod bar_allowed {
+    #[allow(nonex_lint_fn)]
+    fn _foo() {}
+}
+
+// ... but not if the cfg_attr doesn't evaluate
+#[cfg_attr(any(), allow(unknown_lints))]
+mod bar_not_allowed {
+    #[allow(nonex_lint_fn)]
+    //~^ ERROR unknown lint
+    fn _foo() {}
+}

--- a/src/test/ui/lint/reasons-erroneous.stderr
+++ b/src/test/ui/lint/reasons-erroneous.stderr
@@ -58,14 +58,6 @@ error[E0452]: malformed lint attribute input
 LL | #![warn(keyword_idents, reason = "root in rubble", macro_use_extern_crate)]
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^ reason in lint attribute must come last
 
-warning: unknown lint: `reason`
-  --> $DIR/reasons-erroneous.rs:50:39
-   |
-LL | #![warn(missing_copy_implementations, reason)]
-   |                                       ^^^^^^
-   |
-   = note: `#[warn(unknown_lints)]` on by default
-
 error[E0452]: malformed lint attribute input
   --> $DIR/reasons-erroneous.rs:3:58
    |
@@ -125,6 +117,14 @@ error[E0452]: malformed lint attribute input
    |
 LL | #![warn(keyword_idents, reason = "root in rubble", macro_use_extern_crate)]
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^ reason in lint attribute must come last
+
+warning: unknown lint: `reason`
+  --> $DIR/reasons-erroneous.rs:50:39
+   |
+LL | #![warn(missing_copy_implementations, reason)]
+   |                                       ^^^^^^
+   |
+   = note: `#[warn(unknown_lints)]` on by default
 
 error: aborting due to 20 previous errors; 1 warning emitted
 


### PR DESCRIPTION
The weird name lints (`unknown_lints`, `renamed_and_removed_lints`), the lints that lint the linting, were previously not firing for lint level declarations behind `cfg_attr`, as they were only running before expansion.

Now, this will give a `unknown_lints` warning:

```Rust
#[cfg_attr(all(), allow(this_lint_does_not_exist))]
fn foo() {}
```

Lint level declarations behind a `cfg_attr` whose condition is not applying are still ignored. So this still won't give a warning:

```Rust
#[cfg_attr(any(), allow(this_lint_does_not_exist))]
fn foo() {}
```

Furthermore, this PR also makes the weird name lints respect level delcarations for *them* that were hidden by `cfg_attr`, making them consistent to other lints. So this will now not issue a warning:

```Rust
#[cfg_attr(all(), allow(unknown_lints))]
mod foo {
    #[allow(does_not_exist)]
    fn foo() {
    }
}
```

Fixes #97094