### PR TITLE
adjust transmute const stabilization version

### DIFF
--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -1141,7 +1141,7 @@ extern "rust-intrinsic" {
     /// }
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[rustc_const_stable(feature = "const_transmute", since = "1.46.0")]
+    #[rustc_const_stable(feature = "const_transmute", since = "1.56.0")]
     #[rustc_diagnostic_item = "transmute"]
     pub fn transmute<T, U>(e: T) -> U;
 


### PR DESCRIPTION
With 1.46, this became callable only in `const`/`static` items.

Only since 1.56 is this callable in `const fn`: [changelog](https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1560-2021-10-21)

Also see [Zulip discussion](https://rust-lang.zulipchat.com/#narrow/stream/122651-general/topic/transmute.20const.20fn.20stabilization).