### PR TITLE
Disallow compare-mode=nll test differences

### DIFF
--- a/src/test/ui/json-multiple.nll.stderr
+++ b/src/test/ui/json-multiple.nll.stderr
@@ -1,1 +1,0 @@
-{"artifact":"$TEST_BUILD_DIR/json-multiple.nll/libjson_multiple.rlib","emit":"link"}

--- a/src/test/ui/json-multiple.rs
+++ b/src/test/ui/json-multiple.rs
@@ -1,5 +1,6 @@
 // build-pass
 // ignore-pass (different metadata emitted in different modes)
 // compile-flags: --json=diagnostic-short --json artifacts --error-format=json
+// ignore-compare-mode-nll
 
 #![crate_type = "lib"]

--- a/src/test/ui/json-options.nll.stderr
+++ b/src/test/ui/json-options.nll.stderr
@@ -1,1 +1,0 @@
-{"artifact":"$TEST_BUILD_DIR/json-options.nll/libjson_options.rlib","emit":"link"}

--- a/src/test/ui/json-options.rs
+++ b/src/test/ui/json-options.rs
@@ -1,5 +1,6 @@
 // build-pass
 // ignore-pass (different metadata emitted in different modes)
 // compile-flags: --json=diagnostic-short,artifacts --error-format=json
+// ignore-compare-mode-nll
 
 #![crate_type = "lib"]

--- a/src/test/ui/rmeta/emit-artifact-notifications.nll.stderr
+++ b/src/test/ui/rmeta/emit-artifact-notifications.nll.stderr
@@ -1,1 +1,0 @@
-{"artifact":"$TEST_BUILD_DIR/rmeta/emit-artifact-notifications.nll/libemit_artifact_notifications.rmeta","emit":"metadata"}

--- a/src/test/ui/rmeta/emit-artifact-notifications.rs
+++ b/src/test/ui/rmeta/emit-artifact-notifications.rs
@@ -2,6 +2,7 @@
 // build-pass
 // ignore-pass
 // ^-- needed because `--pass check` does not emit the output needed.
+// ignore-compare-mode-nll
 
 // A very basic test for the emission of artifact notifications in JSON output.
 

--- a/src/test/ui/save-analysis/emit-notifications.nll.stderr
+++ b/src/test/ui/save-analysis/emit-notifications.nll.stderr
@@ -1,2 +1,0 @@
-{"artifact":"$TEST_BUILD_DIR/save-analysis/emit-notifications.nll/save-analysis/libemit_notifications.json","emit":"save-analysis"}
-{"artifact":"$TEST_BUILD_DIR/save-analysis/emit-notifications.nll/libemit_notifications.rlib","emit":"link"}

--- a/src/test/ui/save-analysis/emit-notifications.rs
+++ b/src/test/ui/save-analysis/emit-notifications.rs
@@ -3,5 +3,6 @@
 // compile-flags: --crate-type rlib --error-format=json
 // ignore-pass
 // ^-- needed because otherwise, the .stderr file changes with --pass check
+// ignore-compare-mode-nll
 
 pub fn foo() {}


### PR DESCRIPTION
This ensures that new tests don't get added not as revisions if they have nll output. This will make stabilization PR easier.

r? @Mark-Simulacrum 