### PR TITLE
The len() method is missing in the docs!

### DIFF
--- a/library/core/src/array/mod.rs
+++ b/library/core/src/array/mod.rs
@@ -435,6 +435,21 @@ impl<T, const N: usize> [T; N] {
     /// let y = x.map(|v| v.len());
     /// assert_eq!(y, [6, 9, 3, 3]);
     /// ```
+    #[stable(feature = "len", since = "1.??.0")]
+    pub fn len() -> usize
+    /// Returns the length of the array.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// let arr: [&str; 3] = ["first","second","last"];
+    /// 
+    /// let lastItem: &str = arr[arr.len()-1];
+    ///  
+    /// println!("{}",lastItem);
+    /// ```
     #[stable(feature = "array_map", since = "1.55.0")]
     pub fn map<F, U>(self, f: F) -> [U; N]
     where


### PR DESCRIPTION
I'm a new rust user and I was really surprised that there seemed to be no method to get the length of an array.
See: https://doc.rust-lang.org/std/primitive.array.html#
But there actually is one.
If you Ctrl + F and search for "len" you'll see the method used in code examples, but it's not listed as a method!

Also, it's such a pain in the butt to find the doc source code, understand whatever the hell this format is and edit it.