### PR TITLE
Remove box syntax from rustc_mir_dataflow and rustc_mir_transform

### DIFF
--- a/compiler/rustc_mir_dataflow/src/lib.rs
+++ b/compiler/rustc_mir_dataflow/src/lib.rs
@@ -1,6 +1,5 @@
 #![feature(associated_type_defaults)]
 #![feature(box_patterns)]
-#![feature(box_syntax)]
 #![feature(exact_size_is_empty)]
 #![feature(let_else)]
 #![feature(min_specialization)]

--- a/compiler/rustc_mir_transform/src/instcombine.rs
+++ b/compiler/rustc_mir_transform/src/instcombine.rs
@@ -192,12 +192,12 @@ impl<'tcx> InstCombineContext<'tcx, '_> {
 
         statements.push(Statement {
             source_info: terminator.source_info,
-            kind: StatementKind::Assign(box (
+            kind: StatementKind::Assign(Box::new((
                 destination_place,
                 Rvalue::Use(Operand::Copy(
                     arg_place.project_deeper(&[ProjectionElem::Deref], self.tcx),
                 )),
-            )),
+            ))),
         });
         terminator.kind = TerminatorKind::Goto { target: destination_block };
     }

--- a/compiler/rustc_mir_transform/src/lib.rs
+++ b/compiler/rustc_mir_transform/src/lib.rs
@@ -1,6 +1,5 @@
 #![allow(rustc::potential_query_instability)]
 #![feature(box_patterns)]
-#![feature(box_syntax)]
 #![feature(let_chains)]
 #![feature(let_else)]
 #![feature(map_try_insert)]

--- a/compiler/rustc_mir_transform/src/normalize_array_len.rs
+++ b/compiler/rustc_mir_transform/src/normalize_array_len.rs
@@ -125,7 +125,7 @@ impl<'tcx> Patcher<'_, 'tcx> {
                             let assign_to = Place::from(local);
                             let rvalue = Rvalue::Use(operand);
                             make_copy_statement.kind =
-                                StatementKind::Assign(box (assign_to, rvalue));
+                                StatementKind::Assign(Box::new((assign_to, rvalue)));
                             statements.push(make_copy_statement);
 
                             // to reorder we have to copy and make NOP
@@ -165,7 +165,8 @@ impl<'tcx> Patcher<'_, 'tcx> {
                     if add_deref {
                         place = self.tcx.mk_place_deref(place);
                     }
-                    len_statement.kind = StatementKind::Assign(box (*into, Rvalue::Len(place)));
+                    len_statement.kind =
+                        StatementKind::Assign(Box::new((*into, Rvalue::Len(place))));
                     statements.push(len_statement);
 
                     // make temporary dead


### PR DESCRIPTION
Continuation of #87781, inspired by #97239. The usages that this PR removes have not appeared from nothing, instead the usage in `rustc_mir_dataflow` and `rustc_mir_transform` was from #80522 which split up `rustc_mir`, and which was filed before I filed #87781, so it was using the state from before my PR. But it was merged after my PR was merged, so the `box_syntax` uses were able to survive here. Outside of this introduction due to the code being outside of the master branch at the point of merging of my PR, there was only one other introduction of box syntax, in #95159. That box syntax was removed again though in #95555. Outside of that, `box_syntax` has not made its reoccurrance in compiler crates.