### PR TITLE
Add new eslint rule to prevent whitespace before function call paren

### DIFF
--- a/src/librustdoc/html/static/.eslintrc.js
+++ b/src/librustdoc/html/static/.eslintrc.js
@@ -46,5 +46,6 @@ module.exports = {
             "error",
             { "beforeColon": false, "afterColon": true, "mode": "strict" }
         ],
+        "func-call-spacing": ["error", "never"],
     }
 };


### PR DESCRIPTION
It prevents `foo ()` basically. :)

r? @notriddle 