### PR TITLE
Parse expression after `else` as a condition if followed by `{`

### DIFF
--- a/src/test/ui/parser/else-no-if.rs
+++ b/src/test/ui/parser/else-no-if.rs
@@ -1,0 +1,32 @@
+fn foo() {
+    if true {
+    } else false {
+    //~^ ERROR expected `{`, found keyword `false`
+    }
+}
+
+fn foo2() {
+    if true {
+    } else falsy() {
+    //~^ ERROR expected `{`, found `falsy`
+    }
+}
+
+fn foo3() {
+    if true {
+    } else falsy();
+    //~^ ERROR expected `{`, found `falsy`
+}
+
+fn foo4() {
+    if true {
+    } else loop{}
+    //~^ ERROR expected `{`, found keyword `loop`
+    {}
+}
+
+fn falsy() -> bool {
+    false
+}
+
+fn main() {}

--- a/src/test/ui/parser/else-no-if.stderr
+++ b/src/test/ui/parser/else-no-if.stderr
@@ -1,0 +1,58 @@
+error: expected `{`, found keyword `false`
+  --> $DIR/else-no-if.rs:3:12
+   |
+LL |     } else false {
+   |       ---- ^^^^^
+   |       |
+   |       expected an `if` or a block after this `else`
+   |
+help: add an `if` if this is the condition to an chained `if` statement after the `else`
+   |
+LL |     } else if false {
+   |            ++
+help: ... otherwise, place this expression inside of a block if it is not an `if` condition
+   |
+LL |     } else { false } {
+   |            +       +
+
+error: expected `{`, found `falsy`
+  --> $DIR/else-no-if.rs:10:12
+   |
+LL |     } else falsy() {
+   |       ---- ^^^^^
+   |       |
+   |       expected an `if` or a block after this `else`
+   |
+help: add an `if` if this is the condition to an chained `if` statement after the `else`
+   |
+LL |     } else if falsy() {
+   |            ++
+help: ... otherwise, place this expression inside of a block if it is not an `if` condition
+   |
+LL |     } else { falsy() } {
+   |            +         +
+
+error: expected `{`, found `falsy`
+  --> $DIR/else-no-if.rs:17:12
+   |
+LL |     } else falsy();
+   |            ^^^^^ expected `{`
+   |
+help: try placing this code inside a block
+   |
+LL |     } else { falsy() };
+   |            +         +
+
+error: expected `{`, found keyword `loop`
+  --> $DIR/else-no-if.rs:23:12
+   |
+LL |     } else loop{}
+   |            ^^^^ expected `{`
+   |
+help: try placing this code inside a block
+   |
+LL |     } else { loop{} }
+   |            +        +
+
+error: aborting due to 4 previous errors
+


### PR DESCRIPTION
Fixes #49361.

Two things:
1. This wording needs help. I can never find a natural/intuitive phrasing when I write diagnostics :sweat_smile: 
2. Do we even want to show the "wrap in braces" case? I would assume most of the time the "add an `if`" case is the right one.