### PR TITLE
Do writeback of Closure params before visiting the parent expression

### DIFF
--- a/compiler/rustc_typeck/src/check/writeback.rs
+++ b/compiler/rustc_typeck/src/check/writeback.rs
@@ -263,8 +263,6 @@ impl<'cx, 'tcx> Visitor<'tcx> for WritebackCx<'cx, 'tcx> {
         self.fix_scalar_builtin_expr(e);
         self.fix_index_builtin_expr(e);
 
-        self.visit_node_id(e.span, e.hir_id);
-
         match e.kind {
             hir::ExprKind::Closure(_, _, body, _, _) => {
                 let body = self.fcx.tcx.hir().body(body);
@@ -291,6 +289,7 @@ impl<'cx, 'tcx> Visitor<'tcx> for WritebackCx<'cx, 'tcx> {
             _ => {}
         }
 
+        self.visit_node_id(e.span, e.hir_id);
         intravisit::walk_expr(self, e);
     }
 

--- a/src/test/ui/type/type-check/unknown_type_for_closure.rs
+++ b/src/test/ui/type/type-check/unknown_type_for_closure.rs
@@ -1,3 +1,17 @@
-fn main() {
-    let x = |_| {    }; //~ ERROR type annotations needed
+fn infer_in_arg() {
+    let x = |b: Vec<_>| {}; //~ ERROR E0282
 }
+
+fn empty_pattern() {
+    let x = |_| {}; //~ ERROR type annotations needed
+}
+
+fn infer_ty() {
+    let x = |k: _| {}; //~ ERROR type annotations needed
+}
+
+fn ambig_return() {
+    let x = || -> Vec<_> { Vec::new() }; //~ ERROR type annotations needed for the closure `fn() -> Vec<_>`
+}
+
+fn main() {}

--- a/src/test/ui/type/type-check/unknown_type_for_closure.stderr
+++ b/src/test/ui/type/type-check/unknown_type_for_closure.stderr
@@ -1,9 +1,32 @@
-error[E0282]: type annotations needed
+error[E0282]: type annotations needed for `Vec<_>`
   --> $DIR/unknown_type_for_closure.rs:2:14
    |
-LL |     let x = |_| {    };
+LL |     let x = |b: Vec<_>| {};
    |              ^ consider giving this closure parameter a type
 
-error: aborting due to previous error
+error[E0282]: type annotations needed
+  --> $DIR/unknown_type_for_closure.rs:6:14
+   |
+LL |     let x = |_| {};
+   |              ^ consider giving this closure parameter a type
+
+error[E0282]: type annotations needed
+  --> $DIR/unknown_type_for_closure.rs:10:14
+   |
+LL |     let x = |k: _| {};
+   |              ^ consider giving this closure parameter a type
+
+error[E0282]: type annotations needed for the closure `fn() -> Vec<_>`
+  --> $DIR/unknown_type_for_closure.rs:14:28
+   |
+LL |     let x = || -> Vec<_> { Vec::new() };
+   |                            ^^^^^^^^ cannot infer type for type parameter `T`
+   |
+help: give this closure an explicit return type without `_` placeholders
+   |
+LL |     let x = || -> Vec<_> { Vec::new() };
+   |                   ~~~~~~
+
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0282`.


### PR DESCRIPTION
This means that given the expression:

```
let x = |a: Vec<_>| {};
```

We will visit the HIR node for `a` before `x`, and report the ambiguity on the former instead of the latter. This also moves writeback for struct field ids and const blocks before, but the ordering of this and walking the expr doesn't seem to matter.