### PR TITLE
Fix some typos in arg checking algorithm

### DIFF
--- a/compiler/rustc_typeck/src/check/fn_ctxt/checks.rs
+++ b/compiler/rustc_typeck/src/check/fn_ctxt/checks.rs
@@ -768,7 +768,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                                 let second_input_ty =
                                     self.resolve_vars_if_possible(expected_input_tys[second_idx]);
                                 let third_input_ty =
-                                    self.resolve_vars_if_possible(expected_input_tys[second_idx]);
+                                    self.resolve_vars_if_possible(expected_input_tys[third_idx]);
                                 let span = if third_idx < provided_arg_count {
                                     let first_arg_span = provided_args[first_idx].span;
                                     let third_arg_span = provided_args[third_idx].span;
@@ -809,16 +809,16 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             }
                             missing_idxs => {
                                 let first_idx = *missing_idxs.first().unwrap();
-                                let second_idx = *missing_idxs.last().unwrap();
+                                let last_idx = *missing_idxs.last().unwrap();
                                 // NOTE: Because we might be re-arranging arguments, might have extra arguments, etc.
                                 // It's hard to *really* know where we should provide this error label, so this is a
                                 // decent heuristic
-                                let span = if first_idx < provided_arg_count {
+                                let span = if last_idx < provided_arg_count {
                                     let first_arg_span = provided_args[first_idx].span;
-                                    let second_arg_span = provided_args[second_idx].span;
+                                    let last_arg_span = provided_args[last_idx].span;
                                     Span::new(
                                         first_arg_span.lo(),
-                                        second_arg_span.hi(),
+                                        last_arg_span.hi(),
                                         first_arg_span.ctxt(),
                                         None,
                                     )

--- a/src/test/ui/argument-suggestions/issue-97197.rs
+++ b/src/test/ui/argument-suggestions/issue-97197.rs
@@ -1,0 +1,6 @@
+fn main() {
+    g((), ());
+    //~^ ERROR this function takes 6 arguments but 2 arguments were supplied
+}
+
+pub fn g(a1: (), a2: bool, a3: bool, a4: bool, a5: bool, a6: ()) -> () {}

--- a/src/test/ui/argument-suggestions/issue-97197.stderr
+++ b/src/test/ui/argument-suggestions/issue-97197.stderr
@@ -1,0 +1,19 @@
+error[E0061]: this function takes 6 arguments but 2 arguments were supplied
+  --> $DIR/issue-97197.rs:2:5
+   |
+LL |     g((), ());
+   |     ^-------- multiple arguments are missing
+   |
+note: function defined here
+  --> $DIR/issue-97197.rs:6:8
+   |
+LL | pub fn g(a1: (), a2: bool, a3: bool, a4: bool, a5: bool, a6: ()) -> () {}
+   |        ^ ------  --------  --------  --------  --------  ------
+help: provide the arguments
+   |
+LL |     g((), {bool}, {bool}, {bool}, {bool}, ());
+   |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0061`.

--- a/src/test/ui/argument-suggestions/missing_arguments.stderr
+++ b/src/test/ui/argument-suggestions/missing_arguments.stderr
@@ -293,7 +293,7 @@ error[E0061]: this function takes 5 arguments but 2 arguments were supplied
   --> $DIR/missing_arguments.rs:39:3
    |
 LL |   complex(   1,                     ""   );
-   |   ^^^^^^^--------------------------------- three arguments of type `f32`, `i32`, and `i32` are missing
+   |   ^^^^^^^--------------------------------- three arguments of type `f32`, `i32`, and `f32` are missing
    |
 note: function defined here
   --> $DIR/missing_arguments.rs:7:4


### PR DESCRIPTION
Fixes #97197 

Also fixes a typo where if we're missing args A, B, C, we actually say A, B, B