### PR TITLE
Add some regression tests for #90400

### DIFF
--- a/src/test/ui/type-alias-impl-trait/issue-90400-1.rs
+++ b/src/test/ui/type-alias-impl-trait/issue-90400-1.rs
@@ -1,0 +1,30 @@
+// Regression test for #90400,
+// taken from https://github.com/rust-lang/rust/issues/90400#issuecomment-954927836
+
+#![feature(generic_associated_types)]
+#![feature(type_alias_impl_trait)]
+
+trait Bar {
+    fn bar(&self);
+}
+
+trait Foo {
+    type FooFn<B>: FnOnce();
+
+    fn foo<B: Bar>(&self, bar: B) -> Self::FooFn<B>;
+}
+
+struct MyFoo;
+
+impl Foo for MyFoo {
+    type FooFn<B> = impl FnOnce();
+
+    fn foo<B: Bar>(&self, bar: B) -> Self::FooFn<B> {
+        move || bar.bar() //~ ERROR: the trait bound `B: Bar` is not satisfied
+    }
+}
+
+fn main() {
+    let boom: <MyFoo as Foo>::FooFn<u32> = unsafe { core::mem::zeroed() };
+    boom();
+}

--- a/src/test/ui/type-alias-impl-trait/issue-90400-1.stderr
+++ b/src/test/ui/type-alias-impl-trait/issue-90400-1.stderr
@@ -1,0 +1,19 @@
+error[E0277]: the trait bound `B: Bar` is not satisfied
+  --> $DIR/issue-90400-1.rs:23:9
+   |
+LL |         move || bar.bar()
+   |         ^^^^^^^^^^^^^^^^^ the trait `Bar` is not implemented for `B`
+   |
+note: required by a bound in `<MyFoo as Foo>::foo`
+  --> $DIR/issue-90400-1.rs:22:15
+   |
+LL |     fn foo<B: Bar>(&self, bar: B) -> Self::FooFn<B> {
+   |               ^^^ required by this bound in `<MyFoo as Foo>::foo`
+help: consider restricting type parameter `B`
+   |
+LL |     type FooFn<B: Bar> = impl FnOnce();
+   |                 +++++
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/type-alias-impl-trait/issue-90400-2.rs
+++ b/src/test/ui/type-alias-impl-trait/issue-90400-2.rs
@@ -1,0 +1,38 @@
+// Regression test for #90400,
+// taken from https://github.com/rust-lang/rust/issues/90400#issuecomment-954927836
+
+#![feature(generic_associated_types)]
+#![feature(type_alias_impl_trait)]
+
+trait Bar {
+    fn bar(&self);
+}
+
+trait Baz {
+    fn baz(&self);
+}
+
+trait Foo {
+    type FooFn<B>: Baz;
+
+    fn foo<B: Bar>(&self, bar: B) -> Self::FooFn<B>;
+}
+
+struct MyFoo;
+impl Foo for MyFoo {
+    type FooFn<B> = impl Baz;
+
+    fn foo<B: Bar>(&self, bar: B) -> Self::FooFn<B> {
+        MyBaz(bar) //~ ERROR: the trait bound `B: Bar` is not satisfied
+    }
+}
+
+struct MyBaz<B: Bar>(B);
+impl<B: Bar> Baz for MyBaz<B> {
+    fn baz(&self) {}
+}
+
+fn main() {
+    let boom: <MyFoo as Foo>::FooFn<u32> = unsafe { core::mem::zeroed() };
+    boom.baz();
+}

--- a/src/test/ui/type-alias-impl-trait/issue-90400-2.stderr
+++ b/src/test/ui/type-alias-impl-trait/issue-90400-2.stderr
@@ -1,0 +1,19 @@
+error[E0277]: the trait bound `B: Bar` is not satisfied
+  --> $DIR/issue-90400-2.rs:26:9
+   |
+LL |         MyBaz(bar)
+   |         ^^^^^^^^^^ the trait `Bar` is not implemented for `B`
+   |
+note: required because of the requirements on the impl of `Baz` for `MyBaz<B>`
+  --> $DIR/issue-90400-2.rs:31:14
+   |
+LL | impl<B: Bar> Baz for MyBaz<B> {
+   |              ^^^     ^^^^^^^^
+help: consider restricting type parameter `B`
+   |
+LL |     type FooFn<B: Bar> = impl Baz;
+   |                 +++++
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
This adds two regression tests taken from https://github.com/rust-lang/rust/issues/90400#issuecomment-954927836.
Note that we cannot close the issue right now as the [original code](https://github.com/rust-lang/rust/issues/90400#issue-1039577786) still triggers an ICE.

r? @compiler-errors 