### PR TITLE
DO NOT MERGE (yet): Enable `-Zdrop-tracking` by default

### DIFF
--- a/compiler/rustc_interface/src/tests.rs
+++ b/compiler/rustc_interface/src/tests.rs
@@ -738,7 +738,7 @@ fn test_unstable_options_tracking_hash() {
     tracked!(debug_info_for_profiling, true);
     tracked!(debug_macros, true);
     tracked!(dep_info_omit_d_target, true);
-    tracked!(drop_tracking, true);
+    tracked!(drop_tracking, false);
     tracked!(dual_proc_macros, true);
     tracked!(dwarf_version, Some(5));
     tracked!(emit_thin_lto, false);

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -1366,8 +1366,8 @@ options! {
     dont_buffer_diagnostics: bool = (false, parse_bool, [UNTRACKED],
         "emit diagnostics rather than buffering (breaks NLL error downgrading, sorting) \
         (default: no)"),
-    drop_tracking: bool = (false, parse_bool, [TRACKED],
-        "enables drop tracking in generators (default: no)"),
+    drop_tracking: bool = (true, parse_bool, [TRACKED],
+        "enables drop tracking in generators (default: yes)"),
     drop_tracking_mir: bool = (false, parse_bool, [TRACKED],
         "enables drop tracking on MIR in generators (default: no)"),
     dual_proc_macros: bool = (false, parse_bool, [TRACKED],

--- a/tests/rustdoc-ui/z-help.stdout
+++ b/tests/rustdoc-ui/z-help.stdout
@@ -19,7 +19,7 @@
     -Z                      diagnostic-width=val -- set the current output width for diagnostic truncation
     -Z                               dlltool=val -- import library generation tool (windows-gnu only)
     -Z               dont-buffer-diagnostics=val -- emit diagnostics rather than buffering (breaks NLL error downgrading, sorting) (default: no)
-    -Z                         drop-tracking=val -- enables drop tracking in generators (default: no)
+    -Z                         drop-tracking=val -- enables drop tracking in generators (default: yes)
     -Z                     drop-tracking-mir=val -- enables drop tracking on MIR in generators (default: no)
     -Z                      dual-proc-macros=val -- load proc macros for both target and host, but only link to the target (default: no)
     -Z                        dump-dep-graph=val -- dump the dependency graph to $RUST_DEP_GRAPH (default: /tmp/dep_graph.gv) (default: no)


### PR DESCRIPTION
This is not quite ready to merge yet because we still need fixes for a couple of issues (See #97331 for details), but we can probably go ahead and kick off a crater run to see if there are any additional regressions we don't know about yet.

@bors r? @wesleywiser 