### PR TITLE
Decrease bootstrap MSRV to 1.59

### DIFF
--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -1158,7 +1158,7 @@ impl<'a> Builder<'a> {
                             .collect::<String>(),
                         None => String::new(),
                     };
-                    rustflags.arg(&format!("--check-cfg=values({name}{values})"));
+                    rustflags.arg(&format!("--check-cfg=values({}{})", name, values));
                 }
             }
         }

--- a/src/bootstrap/doc.rs
+++ b/src/bootstrap/doc.rs
@@ -433,8 +433,8 @@ impl Step for Std {
         builder.info(&format!("Documenting stage{} std ({})", stage, target));
         if builder.no_std(target) == Some(true) {
             panic!(
-                "building std documentation for no_std target {target} is not supported\n\
-                 Set `docs = false` in the config to disable documentation."
+                "building std documentation for no_std target {} is not supported\n\
+                 Set `docs = false` in the config to disable documentation.", target
             );
         }
         let out = builder.doc_out(target);

--- a/src/bootstrap/setup.rs
+++ b/src/bootstrap/setup.rs
@@ -2,7 +2,6 @@ use crate::{t, VERSION};
 use crate::{Config, TargetSelection};
 use std::env::consts::EXE_SUFFIX;
 use std::fmt::Write as _;
-use std::fs::File;
 use std::path::{Path, PathBuf, MAIN_SEPARATOR};
 use std::process::Command;
 use std::str::FromStr;
@@ -246,7 +245,7 @@ fn ensure_stage1_toolchain_placeholder_exists(stage_path: &str) -> bool {
     }
 
     // Take care not to overwrite the file
-    let result = File::options().append(true).create(true).open(&pathbuf);
+    let result = fs::OpenOptions::new().append(true).create(true).open(&pathbuf);
     if result.is_err() {
         return false;
     }


### PR DESCRIPTION
The motivation here is to eventually allow `cargo run` on bootstrap with the system toolchain, even
if it's significantly out of date. I have vague plans for bootstrap to download the beta toolchain
when compiled without python which are not really thought through; this PR is a draft until then.
See https://rust-lang.zulipchat.com/#narrow/stream/122651-general/topic/bootstrap.20user.20survey
for more context about entrypoints.

Going lower (to 1.56) requires adding back the `num_cpus` dependency,
which makes bootstrap slower to compile. I think we may want to do it eventually though, since CentOS 8 only packages 1.58.

cc https://github.com/rust-lang/rust/issues/94829
r? @ghost