### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/compiler/rustc_interface/src/callbacks.rs
+++ b/compiler/rustc_interface/src/callbacks.rs
@@ -24,7 +24,7 @@ fn track_span_parent(def_id: rustc_span::def_id::LocalDefId) {
 }
 
 /// This is a callback from `rustc_ast` as it cannot access the implicit state
-/// in `rustc_middle` otherwise. It is used to when diagnostic messages are
+/// in `rustc_middle` otherwise. It is used when diagnostic messages are
 /// emitted and stores them in the current query, if there is one.
 fn track_diagnostic(diagnostic: &Diagnostic) {
     tls::with_context_opt(|icx| {

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -443,6 +443,8 @@ impl<'a: 'ast, 'ast> LateResolutionVisitor<'a, '_, 'ast> {
                 );
             }
         }
+        // Try Levenshtein algorithm.
+        let typo_sugg = self.lookup_typo_candidate(path, ns, is_expected);
         if path.len() == 1 && self.self_type_is_available() {
             if let Some(candidate) = self.lookup_assoc_candidate(ident, ns, is_expected) {
                 let self_is_available = self.self_value_is_available(path[0].ident.span);
@@ -452,18 +454,19 @@ impl<'a: 'ast, 'ast> LateResolutionVisitor<'a, '_, 'ast> {
                             err.span_suggestion(
                                 span,
                                 "you might have meant to use the available field",
-                                format!("self.{}", path_str),
+                                format!("self.{path_str}"),
                                 Applicability::MachineApplicable,
                             );
                         } else {
                             err.span_label(span, "a field by this name exists in `Self`");
                         }
+                        self.r.add_typo_suggestion(&mut err, typo_sugg, ident_span);
                     }
                     AssocSuggestion::MethodWithSelf if self_is_available => {
                         err.span_suggestion(
                             span,
                             "you might have meant to call the method",
-                            format!("self.{}", path_str),
+                            format!("self.{path_str}"),
                             Applicability::MachineApplicable,
                         );
                     }
@@ -474,7 +477,7 @@ impl<'a: 'ast, 'ast> LateResolutionVisitor<'a, '_, 'ast> {
                         err.span_suggestion(
                             span,
                             &format!("you might have meant to {}", candidate.action()),
-                            format!("Self::{}", path_str),
+                            format!("Self::{path_str}"),
                             Applicability::MachineApplicable,
                         );
                     }
@@ -493,16 +496,14 @@ impl<'a: 'ast, 'ast> LateResolutionVisitor<'a, '_, 'ast> {
 
                 err.span_suggestion(
                     call_span,
-                    &format!("try calling `{}` as a method", ident),
-                    format!("self.{}({})", path_str, args_snippet),
+                    &format!("try calling `{ident}` as a method"),
+                    format!("self.{path_str}({args_snippet})"),
                     Applicability::MachineApplicable,
                 );
                 return (err, candidates);
             }
         }
 
-        // Try Levenshtein algorithm.
-        let typo_sugg = self.lookup_typo_candidate(path, ns, is_expected);
         // Try context-dependent help if relaxed lookup didn't work.
         if let Some(res) = res {
             if self.smart_resolve_context_dependent_help(

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -460,7 +460,6 @@ impl<'a: 'ast, 'ast> LateResolutionVisitor<'a, '_, 'ast> {
                         } else {
                             err.span_label(span, "a field by this name exists in `Self`");
                         }
-                        self.r.add_typo_suggestion(&mut err, typo_sugg, ident_span);
                     }
                     AssocSuggestion::MethodWithSelf if self_is_available => {
                         err.span_suggestion(
@@ -482,6 +481,7 @@ impl<'a: 'ast, 'ast> LateResolutionVisitor<'a, '_, 'ast> {
                         );
                     }
                 }
+                self.r.add_typo_suggestion(&mut err, typo_sugg, ident_span);
                 return (err, candidates);
             }
 

--- a/config.toml.example
+++ b/config.toml.example
@@ -240,10 +240,6 @@ changelog-seen = 2
 # Indicate whether git submodules are managed and updated automatically.
 #submodules = true
 
-# Update git submodules only when the checked out commit in the submodules differs
-# from what is committed in the main rustc repo.
-#fast-submodules = true
-
 # The path to (or name of) the GDB executable to use. This is only used for
 # executing the debuginfo test suite.
 #gdb = "gdb"

--- a/library/std/src/net/ip.rs
+++ b/library/std/src/net/ip.rs
@@ -1655,7 +1655,7 @@ impl Ipv6Addr {
     /// assert_eq!(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1).to_ipv4_mapped(), None);
     /// ```
     #[rustc_const_unstable(feature = "const_ipv6", issue = "76205")]
-    #[stable(feature = "ipv6_to_ipv4_mapped", since = "1.62.0")]
+    #[stable(feature = "ipv6_to_ipv4_mapped", since = "1.63.0")]
     #[must_use = "this returns the result of the operation, \
                   without modifying the original"]
     #[inline]

--- a/src/bootstrap/CHANGELOG.md
+++ b/src/bootstrap/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - The options `infodir`, `localstatedir`, and `gpg-password-file` are no longer allowed in config.toml. Previously, they were ignored without warning. Note that `infodir` and `localstatedir` are still accepted by `./configure`, with a warning. [#82451](https://github.com/rust-lang/rust/pull/82451)
 - Add options for enabling overflow checks, one for std (`overflow-checks-std`) and one for everything else (`overflow-checks`). Both default to false.
 - Change the names for `dist` commands to match the component they generate. [#90684](https://github.com/rust-lang/rust/pull/90684)
+- The `build.fast-submodules` option has been removed. Fast submodule checkouts are enabled unconditionally. Automatic submodule handling can still be disabled with `build.submodules = false`.
 
 ### Non-breaking changes
 

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -50,7 +50,6 @@ pub struct Config {
     pub ninja_in_file: bool,
     pub verbose: usize,
     pub submodules: Option<bool>,
-    pub fast_submodules: bool,
     pub compiler_docs: bool,
     pub docs_minification: bool,
     pub docs: bool,
@@ -517,7 +516,6 @@ define_config! {
         compiler_docs: Option<bool> = "compiler-docs",
         docs_minification: Option<bool> = "docs-minification",
         submodules: Option<bool> = "submodules",
-        fast_submodules: Option<bool> = "fast-submodules",
         gdb: Option<String> = "gdb",
         nodejs: Option<String> = "nodejs",
         npm: Option<String> = "npm",
@@ -705,7 +703,6 @@ impl Config {
         config.rust_optimize = true;
         config.rust_optimize_tests = true;
         config.submodules = None;
-        config.fast_submodules = true;
         config.docs = true;
         config.docs_minification = true;
         config.rust_rpath = true;
@@ -847,7 +844,6 @@ impl Config {
         set(&mut config.compiler_docs, build.compiler_docs);
         set(&mut config.docs_minification, build.docs_minification);
         set(&mut config.docs, build.docs);
-        set(&mut config.fast_submodules, build.fast_submodules);
         set(&mut config.locked_deps, build.locked_deps);
         set(&mut config.vendor, build.vendor);
         set(&mut config.full_bootstrap, build.full_bootstrap);

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -556,27 +556,24 @@ impl Build {
         }
 
         // check_submodule
-        if self.config.fast_submodules {
-            let checked_out_hash = output(
-                Command::new("git").args(&["rev-parse", "HEAD"]).current_dir(&absolute_path),
-            );
-            // update_submodules
-            let recorded = output(
-                Command::new("git")
-                    .args(&["ls-tree", "HEAD"])
-                    .arg(relative_path)
-                    .current_dir(&self.config.src),
-            );
-            let actual_hash = recorded
-                .split_whitespace()
-                .nth(2)
-                .unwrap_or_else(|| panic!("unexpected output `{}`", recorded));
+        let checked_out_hash =
+            output(Command::new("git").args(&["rev-parse", "HEAD"]).current_dir(&absolute_path));
+        // update_submodules
+        let recorded = output(
+            Command::new("git")
+                .args(&["ls-tree", "HEAD"])
+                .arg(relative_path)
+                .current_dir(&self.config.src),
+        );
+        let actual_hash = recorded
+            .split_whitespace()
+            .nth(2)
+            .unwrap_or_else(|| panic!("unexpected output `{}`", recorded));
 
-            // update_submodule
-            if actual_hash == checked_out_hash.trim_end() {
-                // already checked out
-                return;
-            }
+        // update_submodule
+        if actual_hash == checked_out_hash.trim_end() {
+            // already checked out
+            return;
         }
 
         println!("Updating submodule {}", relative_path.display());

--- a/src/test/ui/resolve/typo-suggestion-for-variable-with-name-similar-to-struct-field.rs
+++ b/src/test/ui/resolve/typo-suggestion-for-variable-with-name-similar-to-struct-field.rs
@@ -1,8 +1,8 @@
-struct Foo {
+struct A {
     config: String,
 }
 
-impl Foo {
+impl A {
     fn new(cofig: String) -> Self {
         Self { config } //~ Error cannot find value `config` in this scope
     }
@@ -15,5 +15,32 @@ impl Foo {
         println!("{config}"); //~ Error cannot find value `config` in this scope
     }
 }
+
+trait B {
+    const BAR: u32 = 3;
+    type Baz;
+    fn bar(&self);
+    fn baz(&self) {}
+    fn bah() {}
+}
+
+impl B for Box<isize> {
+    type Baz = String;
+    fn bar(&self) {
+        // let baz = 3;
+        baz();
+        //~^ ERROR cannot find function `baz`
+        bah;
+        //~^ ERROR cannot find value `bah`
+        BAR;
+        //~^ ERROR cannot find value `BAR` in this scope
+        let foo: Baz = "".to_string();
+        //~^ ERROR cannot find type `Baz` in this scope
+    }
+}
+
+fn ba() {}
+const BARR: u32 = 3;
+type Bar = String;
 
 fn main() {}

--- a/src/test/ui/resolve/typo-suggestion-for-variable-with-name-similar-to-struct-field.rs
+++ b/src/test/ui/resolve/typo-suggestion-for-variable-with-name-similar-to-struct-field.rs
@@ -1,0 +1,19 @@
+struct Foo {
+    config: String,
+}
+
+impl Foo {
+    fn new(cofig: String) -> Self {
+        Self { config } //~ Error cannot find value `config` in this scope
+    }
+
+    fn do_something(cofig: String) {
+        println!("{config}"); //~ Error cannot find value `config` in this scope
+    }
+
+    fn self_is_available(self, cofig: String) {
+        println!("{config}"); //~ Error cannot find value `config` in this scope
+    }
+}
+
+fn main() {}

--- a/src/test/ui/resolve/typo-suggestion-for-variable-with-name-similar-to-struct-field.stderr
+++ b/src/test/ui/resolve/typo-suggestion-for-variable-with-name-similar-to-struct-field.stderr
@@ -1,0 +1,36 @@
+error[E0425]: cannot find value `config` in this scope
+  --> $DIR/typo-suggestion-for-variable-with-name-similar-to-struct-field.rs:7:16
+   |
+LL |         Self { config }
+   |                ^^^^^^
+   |                |
+   |                a field by this name exists in `Self`
+   |                help: a local variable with a similar name exists: `cofig`
+
+error[E0425]: cannot find value `config` in this scope
+  --> $DIR/typo-suggestion-for-variable-with-name-similar-to-struct-field.rs:11:20
+   |
+LL |         println!("{config}");
+   |                    ^^^^^^
+   |                    |
+   |                    a field by this name exists in `Self`
+   |                    help: a local variable with a similar name exists: `cofig`
+
+error[E0425]: cannot find value `config` in this scope
+  --> $DIR/typo-suggestion-for-variable-with-name-similar-to-struct-field.rs:15:20
+   |
+LL |         println!("{config}");
+   |                    ^^^^^^
+   |
+help: you might have meant to use the available field
+   |
+LL |         println!("{self.config}");
+   |                    ~~~~~~~~~~~
+help: a local variable with a similar name exists
+   |
+LL |         println!("{cofig}");
+   |                    ~~~~~
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0425`.

--- a/src/test/ui/resolve/typo-suggestion-for-variable-with-name-similar-to-struct-field.stderr
+++ b/src/test/ui/resolve/typo-suggestion-for-variable-with-name-similar-to-struct-field.stderr
@@ -31,6 +31,79 @@ help: a local variable with a similar name exists
 LL |         println!("{cofig}");
    |                    ~~~~~
 
-error: aborting due to 3 previous errors
+error[E0425]: cannot find function `baz` in this scope
+  --> $DIR/typo-suggestion-for-variable-with-name-similar-to-struct-field.rs:31:9
+   |
+LL |         baz();
+   |         ^^^
+...
+LL | fn ba() {}
+   | ------- similarly named function `ba` defined here
+   |
+help: you might have meant to call the method
+   |
+LL |         self.baz();
+   |         ~~~~~~~~
+help: a function with a similar name exists
+   |
+LL |         ba();
+   |         ~~
 
-For more information about this error, try `rustc --explain E0425`.
+error[E0425]: cannot find value `bah` in this scope
+  --> $DIR/typo-suggestion-for-variable-with-name-similar-to-struct-field.rs:33:9
+   |
+LL |         bah;
+   |         ^^^
+...
+LL | fn ba() {}
+   | ------- similarly named function `ba` defined here
+   |
+help: you might have meant to call the associated function
+   |
+LL |         Self::bah;
+   |         ~~~~~~~~~
+help: a function with a similar name exists
+   |
+LL |         ba;
+   |         ~~
+
+error[E0425]: cannot find value `BAR` in this scope
+  --> $DIR/typo-suggestion-for-variable-with-name-similar-to-struct-field.rs:35:9
+   |
+LL |         BAR;
+   |         ^^^
+...
+LL | const BARR: u32 = 3;
+   | -------------------- similarly named constant `BARR` defined here
+   |
+help: you might have meant to use the associated `const`
+   |
+LL |         Self::BAR;
+   |         ~~~~~~~~~
+help: a constant with a similar name exists
+   |
+LL |         BARR;
+   |         ~~~~
+
+error[E0412]: cannot find type `Baz` in this scope
+  --> $DIR/typo-suggestion-for-variable-with-name-similar-to-struct-field.rs:37:18
+   |
+LL |         let foo: Baz = "".to_string();
+   |                  ^^^
+...
+LL | type Bar = String;
+   | ------------------ similarly named type alias `Bar` defined here
+   |
+help: you might have meant to use the associated type
+   |
+LL |         let foo: Self::Baz = "".to_string();
+   |                  ~~~~~~~~~
+help: a type alias with a similar name exists
+   |
+LL |         let foo: Bar = "".to_string();
+   |                  ~~~
+
+error: aborting due to 7 previous errors
+
+Some errors have detailed explanations: E0412, E0425.
+For more information about an error, try `rustc --explain E0412`.

--- a/src/tools/clippy/clippy_lints/src/casts/unnecessary_cast.rs
+++ b/src/tools/clippy/clippy_lints/src/casts/unnecessary_cast.rs
@@ -12,12 +12,12 @@ use rustc_middle::ty::{self, FloatTy, InferTy, Ty};
 
 use super::UNNECESSARY_CAST;
 
-pub(super) fn check(
-    cx: &LateContext<'_>,
-    expr: &Expr<'_>,
-    cast_expr: &Expr<'_>,
-    cast_from: Ty<'_>,
-    cast_to: Ty<'_>,
+pub(super) fn check<'tcx>(
+    cx: &LateContext<'tcx>,
+    expr: &Expr<'tcx>,
+    cast_expr: &Expr<'tcx>,
+    cast_from: Ty<'tcx>,
+    cast_to: Ty<'tcx>,
 ) -> bool {
     // skip non-primitive type cast
     if_chain! {

--- a/src/tools/clippy/clippy_lints/src/dereference.rs
+++ b/src/tools/clippy/clippy_lints/src/dereference.rs
@@ -446,7 +446,7 @@ fn try_parse_ref_op<'tcx>(
 
 // Checks whether the type for a deref call actually changed the type, not just the mutability of
 // the reference.
-fn deref_method_same_type(result_ty: Ty<'_>, arg_ty: Ty<'_>) -> bool {
+fn deref_method_same_type<'tcx>(result_ty: Ty<'tcx>, arg_ty: Ty<'tcx>) -> bool {
     match (result_ty.kind(), arg_ty.kind()) {
         (ty::Ref(_, result_ty, _), ty::Ref(_, arg_ty, _)) => result_ty == arg_ty,
 
@@ -541,8 +541,8 @@ fn is_auto_borrow_position(parent: Option<Node<'_>>, child_id: HirId) -> bool {
 /// Adjustments are sometimes made in the parent block rather than the expression itself.
 fn find_adjustments<'tcx>(
     tcx: TyCtxt<'tcx>,
-    typeck: &'tcx TypeckResults<'_>,
-    expr: &'tcx Expr<'_>,
+    typeck: &'tcx TypeckResults<'tcx>,
+    expr: &'tcx Expr<'tcx>,
 ) -> &'tcx [Adjustment<'tcx>] {
     let map = tcx.hir();
     let mut iter = map.parent_iter(expr.hir_id);
@@ -581,7 +581,7 @@ fn find_adjustments<'tcx>(
 }
 
 #[expect(clippy::needless_pass_by_value)]
-fn report(cx: &LateContext<'_>, expr: &Expr<'_>, state: State, data: StateData) {
+fn report<'tcx>(cx: &LateContext<'tcx>, expr: &Expr<'tcx>, state: State, data: StateData) {
     match state {
         State::DerefMethod {
             ty_changed_count,
@@ -656,7 +656,7 @@ fn report(cx: &LateContext<'_>, expr: &Expr<'_>, state: State, data: StateData) 
 }
 
 impl Dereferencing {
-    fn check_local_usage(&mut self, cx: &LateContext<'_>, e: &Expr<'_>, local: HirId) {
+    fn check_local_usage<'tcx>(&mut self, cx: &LateContext<'tcx>, e: &Expr<'tcx>, local: HirId) {
         if let Some(outer_pat) = self.ref_locals.get_mut(&local) {
             if let Some(pat) = outer_pat {
                 // Check for auto-deref

--- a/src/tools/clippy/clippy_lints/src/len_zero.rs
+++ b/src/tools/clippy/clippy_lints/src/len_zero.rs
@@ -259,8 +259,8 @@ fn parse_len_output<'tcx>(cx: &LateContext<'_>, sig: FnSig<'tcx>) -> Option<LenO
     }
 }
 
-impl LenOutput<'_> {
-    fn matches_is_empty_output(self, ty: Ty<'_>) -> bool {
+impl<'tcx> LenOutput<'tcx> {
+    fn matches_is_empty_output(self, ty: Ty<'tcx>) -> bool {
         match (self, ty.kind()) {
             (_, &ty::Bool) => true,
             (Self::Option(id), &ty::Adt(adt, subs)) if id == adt.did() => subs.type_at(0).is_bool(),
@@ -292,7 +292,7 @@ impl LenOutput<'_> {
 }
 
 /// Checks if the given signature matches the expectations for `is_empty`
-fn check_is_empty_sig(sig: FnSig<'_>, self_kind: ImplicitSelfKind, len_output: LenOutput<'_>) -> bool {
+fn check_is_empty_sig<'tcx>(sig: FnSig<'tcx>, self_kind: ImplicitSelfKind, len_output: LenOutput<'tcx>) -> bool {
     match &**sig.inputs_and_output {
         [arg, res] if len_output.matches_is_empty_output(*res) => {
             matches!(
@@ -306,11 +306,11 @@ fn check_is_empty_sig(sig: FnSig<'_>, self_kind: ImplicitSelfKind, len_output: L
 }
 
 /// Checks if the given type has an `is_empty` method with the appropriate signature.
-fn check_for_is_empty(
-    cx: &LateContext<'_>,
+fn check_for_is_empty<'tcx>(
+    cx: &LateContext<'tcx>,
     span: Span,
     self_kind: ImplicitSelfKind,
-    output: LenOutput<'_>,
+    output: LenOutput<'tcx>,
     impl_ty: DefId,
     item_name: Symbol,
     item_kind: &str,

--- a/src/tools/clippy/clippy_lints/src/methods/mod.rs
+++ b/src/tools/clippy/clippy_lints/src/methods/mod.rs
@@ -2843,7 +2843,7 @@ enum SelfKind {
 
 impl SelfKind {
     fn matches<'a>(self, cx: &LateContext<'a>, parent_ty: Ty<'a>, ty: Ty<'a>) -> bool {
-        fn matches_value<'a>(cx: &LateContext<'a>, parent_ty: Ty<'_>, ty: Ty<'_>) -> bool {
+        fn matches_value<'a>(cx: &LateContext<'a>, parent_ty: Ty<'a>, ty: Ty<'a>) -> bool {
             if ty == parent_ty {
                 true
             } else if ty.is_box() {

--- a/src/tools/clippy/clippy_lints/src/ptr.rs
+++ b/src/tools/clippy/clippy_lints/src/ptr.rs
@@ -395,9 +395,9 @@ impl<'tcx> DerefTy<'tcx> {
 
 fn check_fn_args<'cx, 'tcx: 'cx>(
     cx: &'cx LateContext<'tcx>,
-    tys: &'tcx [Ty<'_>],
-    hir_tys: &'tcx [hir::Ty<'_>],
-    params: &'tcx [Param<'_>],
+    tys: &'tcx [Ty<'tcx>],
+    hir_tys: &'tcx [hir::Ty<'tcx>],
+    params: &'tcx [Param<'tcx>],
 ) -> impl Iterator<Item = PtrArg<'tcx>> + 'cx {
     tys.iter()
         .zip(hir_tys.iter())

--- a/src/tools/clippy/clippy_lints/src/transmute/transmute_undefined_repr.rs
+++ b/src/tools/clippy/clippy_lints/src/transmute/transmute_undefined_repr.rs
@@ -358,7 +358,7 @@ fn is_size_pair(ty: Ty<'_>) -> bool {
     }
 }
 
-fn same_except_params(subs1: SubstsRef<'_>, subs2: SubstsRef<'_>) -> bool {
+fn same_except_params<'tcx>(subs1: SubstsRef<'tcx>, subs2: SubstsRef<'tcx>) -> bool {
     // TODO: check const parameters as well. Currently this will consider `Array<5>` the same as
     // `Array<6>`
     for (ty1, ty2) in subs1.types().zip(subs2.types()).filter(|(ty1, ty2)| ty1 != ty2) {

--- a/src/tools/clippy/clippy_utils/src/ty.rs
+++ b/src/tools/clippy/clippy_utils/src/ty.rs
@@ -42,7 +42,7 @@ pub fn can_partially_move_ty<'tcx>(cx: &LateContext<'tcx>, ty: Ty<'tcx>) -> bool
 }
 
 /// Walks into `ty` and returns `true` if any inner type is the same as `other_ty`
-pub fn contains_ty(ty: Ty<'_>, other_ty: Ty<'_>) -> bool {
+pub fn contains_ty<'tcx>(ty: Ty<'tcx>, other_ty: Ty<'tcx>) -> bool {
     ty.walk().any(|inner| match inner.unpack() {
         GenericArgKind::Type(inner_ty) => other_ty == inner_ty,
         GenericArgKind::Lifetime(_) | GenericArgKind::Const(_) => false,
@@ -51,7 +51,7 @@ pub fn contains_ty(ty: Ty<'_>, other_ty: Ty<'_>) -> bool {
 
 /// Walks into `ty` and returns `true` if any inner type is an instance of the given adt
 /// constructor.
-pub fn contains_adt_constructor(ty: Ty<'_>, adt: AdtDef<'_>) -> bool {
+pub fn contains_adt_constructor<'tcx>(ty: Ty<'tcx>, adt: AdtDef<'tcx>) -> bool {
     ty.walk().any(|inner| match inner.unpack() {
         GenericArgKind::Type(inner_ty) => inner_ty.ty_adt_def() == Some(adt),
         GenericArgKind::Lifetime(_) | GenericArgKind::Const(_) => false,


### PR DESCRIPTION
Successful merges:

 - #97240 (Typo suggestion for a variable with a name similar to struct fields)
 - #97289 (Lifetime variance fixes for clippy)
 - #97290 (Turn on `fast_submodules` unconditionally)
 - #97336 (typo)
 - #97337 (Fix stabilization version of `Ipv6Addr::to_ipv4_mapped`)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=97240,97289,97290,97336,97337)
<!-- homu-ignore:end -->