### PR TITLE
BTree: keep values off the function call stack while inserting

### DIFF
--- a/library/alloc/src/collections/btree/append.rs
+++ b/library/alloc/src/collections/btree/append.rs
@@ -44,7 +44,7 @@ impl<K, V> Root<K, V> {
         for (key, value) in iter {
             // Try to push key-value pair into the current leaf node.
             if cur_node.len() < node::CAPACITY {
-                cur_node.push(key, value);
+                cur_node.push(key).write(value);
             } else {
                 // No space left, go up and push there.
                 let mut open_node;

--- a/library/alloc/src/collections/btree/map.rs
+++ b/library/alloc/src/collections/btree/map.rs
@@ -216,7 +216,7 @@ impl<K: Clone, V: Clone, A: Clone + Allocator> Clone for BTreeMap<K, V, A> {
                             let (k, v) = kv.into_kv();
                             in_edge = kv.right_edge();
 
-                            out_node.push(k.clone(), v.clone());
+                            out_node.push(k.clone()).write(v.clone());
                             out_tree.length += 1;
                         }
                     }

--- a/library/alloc/src/collections/btree/node/tests.rs
+++ b/library/alloc/src/collections/btree/node/tests.rs
@@ -69,7 +69,7 @@ fn test_splitpoint() {
 #[test]
 fn test_partial_eq() {
     let mut root1 = NodeRef::new_leaf(&Global);
-    root1.borrow_mut().push(1, ());
+    root1.borrow_mut().push(1).write(());
     let mut root1 = NodeRef::new_internal(root1.forget_type(), &Global).forget_type();
     let root2 = Root::new(&Global);
     root1.reborrow().assert_back_pointers();


### PR DESCRIPTION
`VacantEntry::insert` receives a value and returns a reference to the value's final location. Internally, it passes the value several levels down the stack, sneaks back a pointer to the place where the value was written, and converts that pointer to a reference at the last minute. I think it's actually safer and more efficient to not pass the value around, but only the location, and write the value there at the last minute.

- Safer because every use of `VacantEntry::insert` (including your average `BTreeMap::insert`) ensures the correct address is returned, whereas now there is only one unit test (in `test_entry`) superficially testing that the returned reference really points to the value.
- More efficient because we don't need to move the value down the stack (as witnessed in #81444), in case that's representative for something that matters.