### PR TITLE
Fix a small mistake in `SliceIndex`'s documentation

### DIFF
--- a/library/core/src/slice/index.rs
+++ b/library/core/src/slice/index.rs
@@ -138,7 +138,7 @@ mod private_slice_index {
 /// A helper trait used for indexing operations.
 ///
 /// Implementations of this trait have to promise that if the argument
-/// to `get_(mut_)unchecked` is a safe reference, then so is the result.
+/// to `get_unchecked(_mut)` is a safe reference, then so is the result.
 #[stable(feature = "slice_get_slice", since = "1.28.0")]
 #[rustc_diagnostic_item = "SliceIndex"]
 #[rustc_on_unimplemented(


### PR DESCRIPTION
Originally, it said "`get_(mut_)unchecked`," but the method's actual name is `get_unchecked_mut`.