### PR TITLE
Stabilize checked slice->str conversion functions

### DIFF
--- a/library/core/src/str/converts.rs
+++ b/library/core/src/str/converts.rs
@@ -83,6 +83,7 @@ use super::Utf8Error;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_const_stable(feature = "const_str_from_utf8_shared", since = "1.63.0")]
+#[rustc_allow_const_fn_unstable(str_internals)]
 pub const fn from_utf8(v: &[u8]) -> Result<&str, Utf8Error> {
     // FIXME: This should use `?` again, once it's `const`
     match run_utf8_validation(v) {

--- a/library/core/src/str/converts.rs
+++ b/library/core/src/str/converts.rs
@@ -82,9 +82,9 @@ use super::Utf8Error;
 /// assert_eq!("💖", sparkle_heart);
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_const_unstable(feature = "const_str_from_utf8", issue = "91006")]
+#[rustc_const_stable(feature = "const_str_from_utf8_shared", since = "1.63.0")]
 pub const fn from_utf8(v: &[u8]) -> Result<&str, Utf8Error> {
-    // This should use `?` again, once it's `const`
+    // FIXME: This should use `?` again, once it's `const`
     match run_utf8_validation(v) {
         Ok(_) => {
             // SAFETY: validation succeeded.

--- a/library/core/src/str/error.rs
+++ b/library/core/src/str/error.rs
@@ -72,7 +72,7 @@ impl Utf8Error {
     /// assert_eq!(1, error.valid_up_to());
     /// ```
     #[stable(feature = "utf8_error", since = "1.5.0")]
-    #[rustc_const_unstable(feature = "const_str_from_utf8", issue = "91006")]
+    #[rustc_const_stable(feature = "const_str_from_utf8_shared", since = "1.63.0")]
     #[must_use]
     #[inline]
     pub const fn valid_up_to(&self) -> usize {
@@ -95,11 +95,11 @@ impl Utf8Error {
     ///
     /// [U+FFFD]: ../../std/char/constant.REPLACEMENT_CHARACTER.html
     #[stable(feature = "utf8_error_error_len", since = "1.20.0")]
-    #[rustc_const_unstable(feature = "const_str_from_utf8", issue = "91006")]
+    #[rustc_const_stable(feature = "const_str_from_utf8_shared", since = "1.63.0")]
     #[must_use]
     #[inline]
     pub const fn error_len(&self) -> Option<usize> {
-        // This should become `map` again, once it's `const`
+        // FIXME: This should become `map` again, once it's `const`
         match self.error_len {
             Some(len) => Some(len as usize),
             None => None,


### PR DESCRIPTION
This PR stabilizes the following APIs as `const` functions in Rust 1.63:
```rust
// core::str

pub const fn from_utf8(v: &[u8]) -> Result<&str, Utf8Error>;

impl Utf8Error {
    pub const fn valid_up_to(&self) -> usize;
    pub const fn error_len(&self) -> Option<usize>;
}
```

Note that the `from_utf8_mut` function is not stabilized as unique references (`&mut _`) are [unstable in const context].

FCP: https://github.com/rust-lang/rust/issues/91006#issuecomment-1134593095

[unstable in const context]: https://github.com/rust-lang/rust/issues/57349