### PR TITLE
coverage: Don't underflow column number

### DIFF
--- a/compiler/rustc_mir_transform/src/coverage/mod.rs
+++ b/compiler/rustc_mir_transform/src/coverage/mod.rs
@@ -515,7 +515,7 @@ fn make_code_region(
         // Extend an empty span by one character so the region will be counted.
         let CharPos(char_pos) = start_col;
         if span.hi() == body_span.hi() {
-            start_col = CharPos(char_pos - 1);
+            start_col = CharPos(char_pos.saturating_sub(1));
         } else {
             end_col = CharPos(char_pos + 1);
         }


### PR DESCRIPTION
I noticed this when running coverage on a debug build of rustc. There
may be other places that do this but I'm just fixing the one I hit.

r? @wesleywiser @richkadel
