### PR TITLE
Minor improvement on else-no-if diagnostic

### DIFF
--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -2291,15 +2291,8 @@ impl<'a> Parser<'a> {
                         .span_label(else_span, "expected an `if` or a block after this `else`")
                         .span_suggestion(
                             cond.span.shrink_to_lo(),
-                            "add an `if` if this is the condition to an chained `if` statement after the `else`",
+                            "add an `if` if this is the condition of a chained `else if` statement",
                             "if ".to_string(),
-                            Applicability::MaybeIncorrect,
-                        ).multipart_suggestion(
-                            "... otherwise, place this expression inside of a block if it is not an `if` condition",
-                            vec![
-                                (cond.span.shrink_to_lo(), "{ ".to_string()),
-                                (cond.span.shrink_to_hi(), " }".to_string()),
-                            ],
                             Applicability::MaybeIncorrect,
                         )
                         .emit();

--- a/src/test/ui/parser/else-no-if.stderr
+++ b/src/test/ui/parser/else-no-if.stderr
@@ -6,14 +6,10 @@ LL |     } else false {
    |       |
    |       expected an `if` or a block after this `else`
    |
-help: add an `if` if this is the condition to an chained `if` statement after the `else`
+help: add an `if` if this is the condition of a chained `else if` statement
    |
 LL |     } else if false {
    |            ++
-help: ... otherwise, place this expression inside of a block if it is not an `if` condition
-   |
-LL |     } else { false } {
-   |            +       +
 
 error: expected `{`, found `falsy`
   --> $DIR/else-no-if.rs:10:12
@@ -23,14 +19,10 @@ LL |     } else falsy() {
    |       |
    |       expected an `if` or a block after this `else`
    |
-help: add an `if` if this is the condition to an chained `if` statement after the `else`
+help: add an `if` if this is the condition of a chained `else if` statement
    |
 LL |     } else if falsy() {
    |            ++
-help: ... otherwise, place this expression inside of a block if it is not an `if` condition
-   |
-LL |     } else { falsy() } {
-   |            +         +
 
 error: expected `{`, found `falsy`
   --> $DIR/else-no-if.rs:17:12


### PR DESCRIPTION
Don't suggest wrapping in block since it's highly likely to be a missing `if` after `else`. Also rework message a bit (open to further suggestions).

cc: https://github.com/rust-lang/rust/pull/97298#discussion_r880933431

r? @estebank