### PR TITLE
Do not suggest adding semicolon/changing delimiters for macros in item position that originates in macros

### DIFF
--- a/src/test/ui/proc-macro/auxiliary/issue-91800-macro.rs
+++ b/src/test/ui/proc-macro/auxiliary/issue-91800-macro.rs
@@ -1,0 +1,26 @@
+// force-host
+// no-prefer-dynamic
+
+#![crate_type = "proc-macro"]
+
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+
+fn compile_error() -> TokenStream {
+    r#"compile_error!("")"#.parse().unwrap()
+}
+
+#[proc_macro_derive(MyTrait)]
+pub fn derive(input: TokenStream) -> TokenStream {
+    compile_error()
+}
+#[proc_macro_attribute]
+pub fn attribute_macro(_attr: TokenStream, mut input: TokenStream) -> TokenStream {
+    input.extend(compile_error());
+    input
+}
+#[proc_macro]
+pub fn fn_macro(_item: TokenStream) -> TokenStream {
+    compile_error()
+}

--- a/src/test/ui/proc-macro/issue-91800.rs
+++ b/src/test/ui/proc-macro/issue-91800.rs
@@ -1,0 +1,16 @@
+// aux-build: issue-91800-macro.rs
+
+#[macro_use]
+extern crate issue_91800_macro;
+
+#[derive(MyTrait)]
+//~^ ERROR macros that expand to items must be delimited with braces or followed by a semicolon
+//~| ERROR proc-macro derive produced unparseable tokens
+#[attribute_macro]
+//~^ ERROR macros that expand to items must be delimited with braces or followed by a semicolon
+struct MyStruct;
+
+fn_macro! {}
+//~^ ERROR macros that expand to items must be delimited with braces or followed by a semicolon
+
+fn main() {}

--- a/src/test/ui/proc-macro/issue-91800.stderr
+++ b/src/test/ui/proc-macro/issue-91800.stderr
@@ -1,0 +1,56 @@
+error: macros that expand to items must be delimited with braces or followed by a semicolon
+  --> $DIR/issue-91800.rs:6:10
+   |
+LL | #[derive(MyTrait)]
+   |          ^^^^^^^
+   |
+   = note: this error originates in the derive macro `MyTrait` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: proc-macro derive produced unparseable tokens
+  --> $DIR/issue-91800.rs:6:10
+   |
+LL | #[derive(MyTrait)]
+   |          ^^^^^^^
+
+error: 
+  --> $DIR/issue-91800.rs:6:10
+   |
+LL | #[derive(MyTrait)]
+   |          ^^^^^^^
+   |
+   = note: this error originates in the derive macro `MyTrait` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: macros that expand to items must be delimited with braces or followed by a semicolon
+  --> $DIR/issue-91800.rs:9:1
+   |
+LL | #[attribute_macro]
+   | ^^^^^^^^^^^^^^^^^^
+   |
+   = note: this error originates in the attribute macro `attribute_macro` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: 
+  --> $DIR/issue-91800.rs:9:1
+   |
+LL | #[attribute_macro]
+   | ^^^^^^^^^^^^^^^^^^
+   |
+   = note: this error originates in the attribute macro `attribute_macro` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: macros that expand to items must be delimited with braces or followed by a semicolon
+  --> $DIR/issue-91800.rs:13:1
+   |
+LL | fn_macro! {}
+   | ^^^^^^^^^^^^
+   |
+   = note: this error originates in the macro `fn_macro` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: 
+  --> $DIR/issue-91800.rs:13:1
+   |
+LL | fn_macro! {}
+   | ^^^^^^^^^^^^
+   |
+   = note: this error originates in the macro `fn_macro` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 7 previous errors
+


### PR DESCRIPTION
Fixes #91800.