### PR TITLE
Improve memory ordering diagnostics

### DIFF
--- a/compiler/rustc_lint/src/types.rs
+++ b/compiler/rustc_lint/src/types.rs
@@ -1554,11 +1554,11 @@ impl InvalidAtomicOrdering {
         if matches!(fail_ordering, sym::Release | sym::AcqRel) {
             cx.struct_span_lint(INVALID_ATOMIC_ORDERING, fail_order_arg.span, |diag| {
                 diag.build(&format!(
-                    "{method}'s failure ordering may not be `Release` or `AcqRel`, \
-                    since a failed {method} does not result in a write",
+                    "`{method}`'s failure ordering may not be `Release` or `AcqRel`, \
+                    since a failed `{method}` does not result in a write",
                 ))
                 .span_label(fail_order_arg.span, "invalid failure ordering")
-                .help("consider using Acquire or Relaxed failure ordering instead")
+                .help("consider using `Acquire` or `Relaxed` failure ordering instead")
                 .emit();
             });
         }
@@ -1578,14 +1578,14 @@ impl InvalidAtomicOrdering {
                 };
             cx.struct_span_lint(INVALID_ATOMIC_ORDERING, success_order_arg.span, |diag| {
                 diag.build(&format!(
-                    "{method}'s success ordering must be at least as strong as its failure ordering"
+                    "`{method}`'s success ordering must be at least as strong as its failure ordering"
                 ))
-                .span_label(fail_order_arg.span, format!("{fail_ordering} failure ordering"))
-                .span_label(success_order_arg.span, format!("{success_ordering} success ordering"))
+                .span_label(fail_order_arg.span, format!("`{fail_ordering}` failure ordering"))
+                .span_label(success_order_arg.span, format!("`{success_ordering}` success ordering"))
                 .span_suggestion_short(
                     success_order_arg.span,
-                    format!("consider using {success_suggestion} success ordering instead"),
-                    success_suggestion.to_string(),
+                    format!("consider using `{success_suggestion}` success ordering instead"),
+                    format!("std::sync::atomic::Ordering::{success_suggestion}"),
                     Applicability::MaybeIncorrect,
                 )
                 .emit();

--- a/compiler/rustc_lint/src/types.rs
+++ b/compiler/rustc_lint/src/types.rs
@@ -4,7 +4,6 @@ use rustc_attr as attr;
 use rustc_data_structures::fx::FxHashSet;
 use rustc_errors::Applicability;
 use rustc_hir as hir;
-use rustc_hir::def_id::DefId;
 use rustc_hir::{is_range_literal, Expr, ExprKind, Node};
 use rustc_middle::ty::layout::{IntegerExt, LayoutOf, SizeSkeleton};
 use rustc_middle::ty::subst::SubstsRef;
@@ -1483,39 +1482,32 @@ impl InvalidAtomicOrdering {
         None
     }
 
-    fn matches_ordering(cx: &LateContext<'_>, did: DefId, orderings: &[Symbol]) -> bool {
+    fn match_ordering(cx: &LateContext<'_>, ord_arg: &Expr<'_>) -> Option<Symbol> {
+        let ExprKind::Path(ref ord_qpath) = ord_arg.kind else { return None };
+        let did = cx.qpath_res(ord_qpath, ord_arg.hir_id).opt_def_id()?;
         let tcx = cx.tcx;
         let atomic_ordering = tcx.get_diagnostic_item(sym::Ordering);
-        orderings.iter().any(|ordering| {
-            tcx.item_name(did) == *ordering && {
-                let parent = tcx.parent(did);
-                Some(parent) == atomic_ordering
-                    // needed in case this is a ctor, not a variant
-                    || tcx.opt_parent(parent) == atomic_ordering
-            }
-        })
-    }
-
-    fn opt_ordering_defid(cx: &LateContext<'_>, ord_arg: &Expr<'_>) -> Option<DefId> {
-        if let ExprKind::Path(ref ord_qpath) = ord_arg.kind {
-            cx.qpath_res(ord_qpath, ord_arg.hir_id).opt_def_id()
-        } else {
-            None
-        }
+        let name = tcx.item_name(did);
+        let parent = tcx.parent(did);
+        [sym::Relaxed, sym::Release, sym::Acquire, sym::AcqRel, sym::SeqCst].into_iter().find(
+            |&ordering| {
+                name == ordering
+                    && (Some(parent) == atomic_ordering
+                            // needed in case this is a ctor, not a variant
+                            || tcx.opt_parent(parent) == atomic_ordering)
+            },
+        )
     }
 
     fn check_atomic_load_store(cx: &LateContext<'_>, expr: &Expr<'_>) {
-        use rustc_hir::def::{DefKind, Res};
-        use rustc_hir::QPath;
         if let Some((method, args)) = Self::inherent_atomic_method_call(cx, expr, &[sym::load, sym::store])
             && let Some((ordering_arg, invalid_ordering)) = match method {
                 sym::load => Some((&args[1], sym::Release)),
                 sym::store => Some((&args[2], sym::Acquire)),
                 _ => None,
             }
-            && let ExprKind::Path(QPath::Resolved(_, path)) = ordering_arg.kind
-            && let Res::Def(DefKind::Ctor(..), ctor_id) = path.res
-            && Self::matches_ordering(cx, ctor_id, &[invalid_ordering, sym::AcqRel])
+            && let Some(ordering) = Self::match_ordering(cx, ordering_arg)
+            && (ordering == invalid_ordering || ordering == sym::AcqRel)
         {
             cx.struct_span_lint(INVALID_ATOMIC_ORDERING, ordering_arg.span, |diag| {
                 if method == sym::load {
@@ -1537,9 +1529,7 @@ impl InvalidAtomicOrdering {
             && let ExprKind::Path(ref func_qpath) = func.kind
             && let Some(def_id) = cx.qpath_res(func_qpath, func.hir_id).opt_def_id()
             && matches!(cx.tcx.get_diagnostic_name(def_id), Some(sym::fence | sym::compiler_fence))
-            && let ExprKind::Path(ref ordering_qpath) = &args[0].kind
-            && let Some(ordering_def_id) = cx.qpath_res(ordering_qpath, args[0].hir_id).opt_def_id()
-            && Self::matches_ordering(cx, ordering_def_id, &[sym::Relaxed])
+            && Self::match_ordering(cx, &args[0]) == Some(sym::Relaxed)
         {
             cx.struct_span_lint(INVALID_ATOMIC_ORDERING, args[0].span, |diag| {
                 diag.build("memory fences cannot have `Relaxed` ordering")
@@ -1550,62 +1540,51 @@ impl InvalidAtomicOrdering {
     }
 
     fn check_atomic_compare_exchange(cx: &LateContext<'_>, expr: &Expr<'_>) {
-        if let Some((method, args)) = Self::inherent_atomic_method_call(cx, expr, &[sym::fetch_update, sym::compare_exchange, sym::compare_exchange_weak])
-            && let Some((success_order_arg, failure_order_arg)) = match method {
-                sym::fetch_update => Some((&args[1], &args[2])),
-                sym::compare_exchange | sym::compare_exchange_weak => Some((&args[3], &args[4])),
-                _ => None,
-            }
-            && let Some(fail_ordering_def_id) = Self::opt_ordering_defid(cx, failure_order_arg)
-        {
-            // Helper type holding on to some checking and error reporting data. Has
-            // - (success ordering,
-            // - list of failure orderings forbidden by the success order,
-            // - suggestion message)
-            type OrdLintInfo = (Symbol, &'static [Symbol], &'static str);
-            const RELAXED: OrdLintInfo = (sym::Relaxed, &[sym::SeqCst, sym::Acquire], "ordering mode `Relaxed`");
-            const ACQUIRE: OrdLintInfo = (sym::Acquire, &[sym::SeqCst], "ordering modes `Acquire` or `Relaxed`");
-            const SEQ_CST: OrdLintInfo = (sym::SeqCst, &[], "ordering modes `Acquire`, `SeqCst` or `Relaxed`");
-            const RELEASE: OrdLintInfo = (sym::Release, RELAXED.1, RELAXED.2);
-            const ACQREL: OrdLintInfo = (sym::AcqRel, ACQUIRE.1, ACQUIRE.2);
-            const SEARCH: [OrdLintInfo; 5] = [RELAXED, ACQUIRE, SEQ_CST, RELEASE, ACQREL];
+        let Some((method, args)) = Self::inherent_atomic_method_call(cx, expr, &[sym::fetch_update, sym::compare_exchange, sym::compare_exchange_weak])
+            else {return };
 
-            let success_lint_info = Self::opt_ordering_defid(cx, success_order_arg)
-                .and_then(|success_ord_def_id| -> Option<OrdLintInfo> {
-                    SEARCH
-                        .iter()
-                        .copied()
-                        .find(|(ordering, ..)| {
-                            Self::matches_ordering(cx, success_ord_def_id, &[*ordering])
-                        })
-                });
-            if Self::matches_ordering(cx, fail_ordering_def_id, &[sym::Release, sym::AcqRel]) {
-                // If we don't know the success order is, use what we'd suggest
-                // if it were maximally permissive.
-                let suggested = success_lint_info.unwrap_or(SEQ_CST).2;
-                cx.struct_span_lint(INVALID_ATOMIC_ORDERING, failure_order_arg.span, |diag| {
-                    let msg = format!(
-                        "{}'s failure ordering may not be `Release` or `AcqRel`",
-                        method,
-                    );
-                    diag.build(&msg)
-                        .help(&format!("consider using {} instead", suggested))
-                        .emit();
-                });
-            } else if let Some((success_ord, bad_ords_given_success, suggested)) = success_lint_info {
-                if Self::matches_ordering(cx, fail_ordering_def_id, bad_ords_given_success) {
-                    cx.struct_span_lint(INVALID_ATOMIC_ORDERING, failure_order_arg.span, |diag| {
-                        let msg = format!(
-                            "{}'s failure ordering may not be stronger than the success ordering of `{}`",
-                            method,
-                            success_ord,
-                        );
-                        diag.build(&msg)
-                            .help(&format!("consider using {} instead", suggested))
-                            .emit();
-                    });
-                }
-            }
+        let (success_order_arg, fail_order_arg) = match method {
+            sym::fetch_update => (&args[1], &args[2]),
+            sym::compare_exchange | sym::compare_exchange_weak => (&args[3], &args[4]),
+            _ => return,
+        };
+
+        let Some(fail_ordering) = Self::match_ordering(cx, fail_order_arg) else { return };
+
+        if matches!(fail_ordering, sym::Release | sym::AcqRel) {
+            cx.struct_span_lint(INVALID_ATOMIC_ORDERING, fail_order_arg.span, |diag| {
+                diag.build(&format!(
+                    "{method}'s failure ordering may not be `Release` or `AcqRel`, \
+                    since a failed {method} does not result in a write",
+                ))
+                .span_label(fail_order_arg.span, "invalid failure ordering")
+                .help("consider using Acquire or Relaxed failure ordering instead")
+                .emit();
+            });
+        }
+
+        let Some(success_ordering) = Self::match_ordering(cx, success_order_arg) else { return };
+
+        if matches!(
+            (success_ordering, fail_ordering),
+            (sym::Relaxed | sym::Release, sym::Acquire)
+                | (sym::Relaxed | sym::Release | sym::Acquire | sym::AcqRel, sym::SeqCst)
+        ) {
+            let success_suggestion =
+                if success_ordering == sym::Release && fail_ordering == sym::Acquire {
+                    sym::AcqRel
+                } else {
+                    fail_ordering
+                };
+            cx.struct_span_lint(INVALID_ATOMIC_ORDERING, success_order_arg.span, |diag| {
+                diag.build(&format!(
+                    "{method}'s success ordering must be at least as strong as its failure ordering"
+                ))
+                .span_label(fail_order_arg.span, format!("{fail_ordering} failure ordering"))
+                .span_label(success_order_arg.span, format!("{success_ordering} success ordering"))
+                .help(format!("consider using {success_suggestion} success ordering instead"))
+                .emit();
+            });
         }
     }
 }

--- a/compiler/rustc_lint/src/types.rs
+++ b/compiler/rustc_lint/src/types.rs
@@ -1582,7 +1582,12 @@ impl InvalidAtomicOrdering {
                 ))
                 .span_label(fail_order_arg.span, format!("{fail_ordering} failure ordering"))
                 .span_label(success_order_arg.span, format!("{success_ordering} success ordering"))
-                .help(format!("consider using {success_suggestion} success ordering instead"))
+                .span_suggestion_short(
+                    success_order_arg.span,
+                    format!("consider using {success_suggestion} success ordering instead"),
+                    success_suggestion.to_string(),
+                    Applicability::MaybeIncorrect,
+                )
                 .emit();
             });
         }

--- a/src/test/ui/lint/lint-invalid-atomic-ordering-exchange-weak.rs
+++ b/src/test/ui/lint/lint-invalid-atomic-ordering-exchange-weak.rs
@@ -20,43 +20,43 @@ fn main() {
 
     // AcqRel is always forbidden as a failure ordering
     let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::Relaxed, Ordering::AcqRel);
-    //~^ ERROR compare_exchange_weak's failure ordering may not be `Release` or `AcqRel`
+    //~^ ERROR `compare_exchange_weak`'s failure ordering may not be `Release` or `AcqRel`
     let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::Acquire, Ordering::AcqRel);
-    //~^ ERROR compare_exchange_weak's failure ordering may not be `Release` or `AcqRel`
+    //~^ ERROR `compare_exchange_weak`'s failure ordering may not be `Release` or `AcqRel`
     let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::Release, Ordering::AcqRel);
-    //~^ ERROR compare_exchange_weak's failure ordering may not be `Release` or `AcqRel`
+    //~^ ERROR `compare_exchange_weak`'s failure ordering may not be `Release` or `AcqRel`
     let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::AcqRel, Ordering::AcqRel);
-    //~^ ERROR compare_exchange_weak's failure ordering may not be `Release` or `AcqRel`
+    //~^ ERROR `compare_exchange_weak`'s failure ordering may not be `Release` or `AcqRel`
     let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::SeqCst, Ordering::AcqRel);
-    //~^ ERROR compare_exchange_weak's failure ordering may not be `Release` or `AcqRel`
+    //~^ ERROR `compare_exchange_weak`'s failure ordering may not be `Release` or `AcqRel`
 
     // Release is always forbidden as a failure ordering
     let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::Relaxed, Ordering::Release);
-    //~^ ERROR compare_exchange_weak's failure ordering may not be `Release` or `AcqRel`
+    //~^ ERROR `compare_exchange_weak`'s failure ordering may not be `Release` or `AcqRel`
     let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::Acquire, Ordering::Release);
-    //~^ ERROR compare_exchange_weak's failure ordering may not be `Release` or `AcqRel`
+    //~^ ERROR `compare_exchange_weak`'s failure ordering may not be `Release` or `AcqRel`
     let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::Release, Ordering::Release);
-    //~^ ERROR compare_exchange_weak's failure ordering may not be `Release` or `AcqRel`
+    //~^ ERROR `compare_exchange_weak`'s failure ordering may not be `Release` or `AcqRel`
     let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::AcqRel, Ordering::Release);
-    //~^ ERROR compare_exchange_weak's failure ordering may not be `Release` or `AcqRel`
+    //~^ ERROR `compare_exchange_weak`'s failure ordering may not be `Release` or `AcqRel`
     let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::SeqCst, Ordering::Release);
-    //~^ ERROR compare_exchange_weak's failure ordering may not be `Release` or `AcqRel`
+    //~^ ERROR `compare_exchange_weak`'s failure ordering may not be `Release` or `AcqRel`
 
     // Release success order forbids failure order of Acquire or SeqCst
     let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::Release, Ordering::Acquire);
-    //~^ ERROR compare_exchange_weak's success ordering must be at least as strong as
+    //~^ ERROR `compare_exchange_weak`'s success ordering must be at least as strong as
     let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::Release, Ordering::SeqCst);
-    //~^ ERROR compare_exchange_weak's success ordering must be at least as strong as
+    //~^ ERROR `compare_exchange_weak`'s success ordering must be at least as strong as
 
     // Relaxed success order also forbids failure order of Acquire or SeqCst
     let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::Relaxed, Ordering::SeqCst);
-    //~^ ERROR compare_exchange_weak's success ordering must be at least as strong as
+    //~^ ERROR `compare_exchange_weak`'s success ordering must be at least as strong as
     let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::Relaxed, Ordering::Acquire);
-    //~^ ERROR compare_exchange_weak's success ordering must be at least as strong as
+    //~^ ERROR `compare_exchange_weak`'s success ordering must be at least as strong as
 
     // Acquire/AcqRel forbids failure order of SeqCst
     let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::Acquire, Ordering::SeqCst);
-    //~^ ERROR compare_exchange_weak's success ordering must be at least as strong as
+    //~^ ERROR `compare_exchange_weak`'s success ordering must be at least as strong as
     let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::AcqRel, Ordering::SeqCst);
-    //~^ ERROR compare_exchange_weak's success ordering must be at least as strong as
+    //~^ ERROR `compare_exchange_weak`'s success ordering must be at least as strong as
 }

--- a/src/test/ui/lint/lint-invalid-atomic-ordering-exchange-weak.rs
+++ b/src/test/ui/lint/lint-invalid-atomic-ordering-exchange-weak.rs
@@ -44,19 +44,19 @@ fn main() {
 
     // Release success order forbids failure order of Acquire or SeqCst
     let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::Release, Ordering::Acquire);
-    //~^ ERROR compare_exchange_weak's failure ordering may not be stronger
+    //~^ ERROR compare_exchange_weak's success ordering must be at least as strong as
     let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::Release, Ordering::SeqCst);
-    //~^ ERROR compare_exchange_weak's failure ordering may not be stronger
+    //~^ ERROR compare_exchange_weak's success ordering must be at least as strong as
 
     // Relaxed success order also forbids failure order of Acquire or SeqCst
     let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::Relaxed, Ordering::SeqCst);
-    //~^ ERROR compare_exchange_weak's failure ordering may not be stronger
+    //~^ ERROR compare_exchange_weak's success ordering must be at least as strong as
     let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::Relaxed, Ordering::Acquire);
-    //~^ ERROR compare_exchange_weak's failure ordering may not be stronger
+    //~^ ERROR compare_exchange_weak's success ordering must be at least as strong as
 
     // Acquire/AcqRel forbids failure order of SeqCst
     let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::Acquire, Ordering::SeqCst);
-    //~^ ERROR compare_exchange_weak's failure ordering may not be stronger
+    //~^ ERROR compare_exchange_weak's success ordering must be at least as strong as
     let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::AcqRel, Ordering::SeqCst);
-    //~^ ERROR compare_exchange_weak's failure ordering may not be stronger
+    //~^ ERROR compare_exchange_weak's success ordering must be at least as strong as
 }

--- a/src/test/ui/lint/lint-invalid-atomic-ordering-exchange-weak.stderr
+++ b/src/test/ui/lint/lint-invalid-atomic-ordering-exchange-weak.stderr
@@ -1,137 +1,137 @@
-error: compare_exchange_weak's failure ordering may not be `Release` or `AcqRel`, since a failed compare_exchange_weak does not result in a write
+error: `compare_exchange_weak`'s failure ordering may not be `Release` or `AcqRel`, since a failed `compare_exchange_weak` does not result in a write
   --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:22:67
    |
 LL |     let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::Relaxed, Ordering::AcqRel);
    |                                                                   ^^^^^^^^^^^^^^^^ invalid failure ordering
    |
    = note: `#[deny(invalid_atomic_ordering)]` on by default
-   = help: consider using Acquire or Relaxed failure ordering instead
+   = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
-error: compare_exchange_weak's failure ordering may not be `Release` or `AcqRel`, since a failed compare_exchange_weak does not result in a write
+error: `compare_exchange_weak`'s failure ordering may not be `Release` or `AcqRel`, since a failed `compare_exchange_weak` does not result in a write
   --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:24:67
    |
 LL |     let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::Acquire, Ordering::AcqRel);
    |                                                                   ^^^^^^^^^^^^^^^^ invalid failure ordering
    |
-   = help: consider using Acquire or Relaxed failure ordering instead
+   = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
-error: compare_exchange_weak's failure ordering may not be `Release` or `AcqRel`, since a failed compare_exchange_weak does not result in a write
+error: `compare_exchange_weak`'s failure ordering may not be `Release` or `AcqRel`, since a failed `compare_exchange_weak` does not result in a write
   --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:26:67
    |
 LL |     let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::Release, Ordering::AcqRel);
    |                                                                   ^^^^^^^^^^^^^^^^ invalid failure ordering
    |
-   = help: consider using Acquire or Relaxed failure ordering instead
+   = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
-error: compare_exchange_weak's failure ordering may not be `Release` or `AcqRel`, since a failed compare_exchange_weak does not result in a write
+error: `compare_exchange_weak`'s failure ordering may not be `Release` or `AcqRel`, since a failed `compare_exchange_weak` does not result in a write
   --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:28:66
    |
 LL |     let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::AcqRel, Ordering::AcqRel);
    |                                                                  ^^^^^^^^^^^^^^^^ invalid failure ordering
    |
-   = help: consider using Acquire or Relaxed failure ordering instead
+   = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
-error: compare_exchange_weak's failure ordering may not be `Release` or `AcqRel`, since a failed compare_exchange_weak does not result in a write
+error: `compare_exchange_weak`'s failure ordering may not be `Release` or `AcqRel`, since a failed `compare_exchange_weak` does not result in a write
   --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:30:66
    |
 LL |     let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::SeqCst, Ordering::AcqRel);
    |                                                                  ^^^^^^^^^^^^^^^^ invalid failure ordering
    |
-   = help: consider using Acquire or Relaxed failure ordering instead
+   = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
-error: compare_exchange_weak's failure ordering may not be `Release` or `AcqRel`, since a failed compare_exchange_weak does not result in a write
+error: `compare_exchange_weak`'s failure ordering may not be `Release` or `AcqRel`, since a failed `compare_exchange_weak` does not result in a write
   --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:34:67
    |
 LL |     let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::Relaxed, Ordering::Release);
    |                                                                   ^^^^^^^^^^^^^^^^^ invalid failure ordering
    |
-   = help: consider using Acquire or Relaxed failure ordering instead
+   = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
-error: compare_exchange_weak's failure ordering may not be `Release` or `AcqRel`, since a failed compare_exchange_weak does not result in a write
+error: `compare_exchange_weak`'s failure ordering may not be `Release` or `AcqRel`, since a failed `compare_exchange_weak` does not result in a write
   --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:36:67
    |
 LL |     let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::Acquire, Ordering::Release);
    |                                                                   ^^^^^^^^^^^^^^^^^ invalid failure ordering
    |
-   = help: consider using Acquire or Relaxed failure ordering instead
+   = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
-error: compare_exchange_weak's failure ordering may not be `Release` or `AcqRel`, since a failed compare_exchange_weak does not result in a write
+error: `compare_exchange_weak`'s failure ordering may not be `Release` or `AcqRel`, since a failed `compare_exchange_weak` does not result in a write
   --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:38:67
    |
 LL |     let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::Release, Ordering::Release);
    |                                                                   ^^^^^^^^^^^^^^^^^ invalid failure ordering
    |
-   = help: consider using Acquire or Relaxed failure ordering instead
+   = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
-error: compare_exchange_weak's failure ordering may not be `Release` or `AcqRel`, since a failed compare_exchange_weak does not result in a write
+error: `compare_exchange_weak`'s failure ordering may not be `Release` or `AcqRel`, since a failed `compare_exchange_weak` does not result in a write
   --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:40:66
    |
 LL |     let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::AcqRel, Ordering::Release);
    |                                                                  ^^^^^^^^^^^^^^^^^ invalid failure ordering
    |
-   = help: consider using Acquire or Relaxed failure ordering instead
+   = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
-error: compare_exchange_weak's failure ordering may not be `Release` or `AcqRel`, since a failed compare_exchange_weak does not result in a write
+error: `compare_exchange_weak`'s failure ordering may not be `Release` or `AcqRel`, since a failed `compare_exchange_weak` does not result in a write
   --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:42:66
    |
 LL |     let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::SeqCst, Ordering::Release);
    |                                                                  ^^^^^^^^^^^^^^^^^ invalid failure ordering
    |
-   = help: consider using Acquire or Relaxed failure ordering instead
+   = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
-error: compare_exchange_weak's success ordering must be at least as strong as its failure ordering
+error: `compare_exchange_weak`'s success ordering must be at least as strong as its failure ordering
   --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:46:48
    |
 LL |     let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::Release, Ordering::Acquire);
-   |                                                ^^^^^^^^^^^^^^^^^  ----------------- Acquire failure ordering
+   |                                                ^^^^^^^^^^^^^^^^^  ----------------- `Acquire` failure ordering
    |                                                |
-   |                                                Release success ordering
-   |                                                help: consider using AcqRel success ordering instead
+   |                                                `Release` success ordering
+   |                                                help: consider using `AcqRel` success ordering instead
 
-error: compare_exchange_weak's success ordering must be at least as strong as its failure ordering
+error: `compare_exchange_weak`'s success ordering must be at least as strong as its failure ordering
   --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:48:48
    |
 LL |     let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::Release, Ordering::SeqCst);
-   |                                                ^^^^^^^^^^^^^^^^^  ---------------- SeqCst failure ordering
+   |                                                ^^^^^^^^^^^^^^^^^  ---------------- `SeqCst` failure ordering
    |                                                |
-   |                                                Release success ordering
-   |                                                help: consider using SeqCst success ordering instead
+   |                                                `Release` success ordering
+   |                                                help: consider using `SeqCst` success ordering instead
 
-error: compare_exchange_weak's success ordering must be at least as strong as its failure ordering
+error: `compare_exchange_weak`'s success ordering must be at least as strong as its failure ordering
   --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:52:48
    |
 LL |     let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::Relaxed, Ordering::SeqCst);
-   |                                                ^^^^^^^^^^^^^^^^^  ---------------- SeqCst failure ordering
+   |                                                ^^^^^^^^^^^^^^^^^  ---------------- `SeqCst` failure ordering
    |                                                |
-   |                                                Relaxed success ordering
-   |                                                help: consider using SeqCst success ordering instead
+   |                                                `Relaxed` success ordering
+   |                                                help: consider using `SeqCst` success ordering instead
 
-error: compare_exchange_weak's success ordering must be at least as strong as its failure ordering
+error: `compare_exchange_weak`'s success ordering must be at least as strong as its failure ordering
   --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:54:48
    |
 LL |     let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::Relaxed, Ordering::Acquire);
-   |                                                ^^^^^^^^^^^^^^^^^  ----------------- Acquire failure ordering
+   |                                                ^^^^^^^^^^^^^^^^^  ----------------- `Acquire` failure ordering
    |                                                |
-   |                                                Relaxed success ordering
-   |                                                help: consider using Acquire success ordering instead
+   |                                                `Relaxed` success ordering
+   |                                                help: consider using `Acquire` success ordering instead
 
-error: compare_exchange_weak's success ordering must be at least as strong as its failure ordering
+error: `compare_exchange_weak`'s success ordering must be at least as strong as its failure ordering
   --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:58:48
    |
 LL |     let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::Acquire, Ordering::SeqCst);
-   |                                                ^^^^^^^^^^^^^^^^^  ---------------- SeqCst failure ordering
+   |                                                ^^^^^^^^^^^^^^^^^  ---------------- `SeqCst` failure ordering
    |                                                |
-   |                                                Acquire success ordering
-   |                                                help: consider using SeqCst success ordering instead
+   |                                                `Acquire` success ordering
+   |                                                help: consider using `SeqCst` success ordering instead
 
-error: compare_exchange_weak's success ordering must be at least as strong as its failure ordering
+error: `compare_exchange_weak`'s success ordering must be at least as strong as its failure ordering
   --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:60:48
    |
 LL |     let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::AcqRel, Ordering::SeqCst);
-   |                                                ^^^^^^^^^^^^^^^^  ---------------- SeqCst failure ordering
+   |                                                ^^^^^^^^^^^^^^^^  ---------------- `SeqCst` failure ordering
    |                                                |
-   |                                                AcqRel success ordering
-   |                                                help: consider using SeqCst success ordering instead
+   |                                                `AcqRel` success ordering
+   |                                                help: consider using `SeqCst` success ordering instead
 
 error: aborting due to 16 previous errors
 

--- a/src/test/ui/lint/lint-invalid-atomic-ordering-exchange-weak.stderr
+++ b/src/test/ui/lint/lint-invalid-atomic-ordering-exchange-weak.stderr
@@ -86,8 +86,7 @@ LL |     let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::Release, Ordering:
    |                                                ^^^^^^^^^^^^^^^^^  ----------------- Acquire failure ordering
    |                                                |
    |                                                Release success ordering
-   |
-   = help: consider using AcqRel success ordering instead
+   |                                                help: consider using AcqRel success ordering instead
 
 error: compare_exchange_weak's success ordering must be at least as strong as its failure ordering
   --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:48:48
@@ -96,8 +95,7 @@ LL |     let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::Release, Ordering:
    |                                                ^^^^^^^^^^^^^^^^^  ---------------- SeqCst failure ordering
    |                                                |
    |                                                Release success ordering
-   |
-   = help: consider using SeqCst success ordering instead
+   |                                                help: consider using SeqCst success ordering instead
 
 error: compare_exchange_weak's success ordering must be at least as strong as its failure ordering
   --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:52:48
@@ -106,8 +104,7 @@ LL |     let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::Relaxed, Ordering:
    |                                                ^^^^^^^^^^^^^^^^^  ---------------- SeqCst failure ordering
    |                                                |
    |                                                Relaxed success ordering
-   |
-   = help: consider using SeqCst success ordering instead
+   |                                                help: consider using SeqCst success ordering instead
 
 error: compare_exchange_weak's success ordering must be at least as strong as its failure ordering
   --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:54:48
@@ -116,8 +113,7 @@ LL |     let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::Relaxed, Ordering:
    |                                                ^^^^^^^^^^^^^^^^^  ----------------- Acquire failure ordering
    |                                                |
    |                                                Relaxed success ordering
-   |
-   = help: consider using Acquire success ordering instead
+   |                                                help: consider using Acquire success ordering instead
 
 error: compare_exchange_weak's success ordering must be at least as strong as its failure ordering
   --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:58:48
@@ -126,8 +122,7 @@ LL |     let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::Acquire, Ordering:
    |                                                ^^^^^^^^^^^^^^^^^  ---------------- SeqCst failure ordering
    |                                                |
    |                                                Acquire success ordering
-   |
-   = help: consider using SeqCst success ordering instead
+   |                                                help: consider using SeqCst success ordering instead
 
 error: compare_exchange_weak's success ordering must be at least as strong as its failure ordering
   --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:60:48
@@ -136,8 +131,7 @@ LL |     let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::AcqRel, Ordering::
    |                                                ^^^^^^^^^^^^^^^^  ---------------- SeqCst failure ordering
    |                                                |
    |                                                AcqRel success ordering
-   |
-   = help: consider using SeqCst success ordering instead
+   |                                                help: consider using SeqCst success ordering instead
 
 error: aborting due to 16 previous errors
 

--- a/src/test/ui/lint/lint-invalid-atomic-ordering-exchange-weak.stderr
+++ b/src/test/ui/lint/lint-invalid-atomic-ordering-exchange-weak.stderr
@@ -1,131 +1,143 @@
-error: compare_exchange_weak's failure ordering may not be `Release` or `AcqRel`
+error: compare_exchange_weak's failure ordering may not be `Release` or `AcqRel`, since a failed compare_exchange_weak does not result in a write
   --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:22:67
    |
 LL |     let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::Relaxed, Ordering::AcqRel);
-   |                                                                   ^^^^^^^^^^^^^^^^
+   |                                                                   ^^^^^^^^^^^^^^^^ invalid failure ordering
    |
    = note: `#[deny(invalid_atomic_ordering)]` on by default
-   = help: consider using ordering mode `Relaxed` instead
+   = help: consider using Acquire or Relaxed failure ordering instead
 
-error: compare_exchange_weak's failure ordering may not be `Release` or `AcqRel`
+error: compare_exchange_weak's failure ordering may not be `Release` or `AcqRel`, since a failed compare_exchange_weak does not result in a write
   --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:24:67
    |
 LL |     let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::Acquire, Ordering::AcqRel);
-   |                                                                   ^^^^^^^^^^^^^^^^
+   |                                                                   ^^^^^^^^^^^^^^^^ invalid failure ordering
    |
-   = help: consider using ordering modes `Acquire` or `Relaxed` instead
+   = help: consider using Acquire or Relaxed failure ordering instead
 
-error: compare_exchange_weak's failure ordering may not be `Release` or `AcqRel`
+error: compare_exchange_weak's failure ordering may not be `Release` or `AcqRel`, since a failed compare_exchange_weak does not result in a write
   --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:26:67
    |
 LL |     let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::Release, Ordering::AcqRel);
-   |                                                                   ^^^^^^^^^^^^^^^^
+   |                                                                   ^^^^^^^^^^^^^^^^ invalid failure ordering
    |
-   = help: consider using ordering mode `Relaxed` instead
+   = help: consider using Acquire or Relaxed failure ordering instead
 
-error: compare_exchange_weak's failure ordering may not be `Release` or `AcqRel`
+error: compare_exchange_weak's failure ordering may not be `Release` or `AcqRel`, since a failed compare_exchange_weak does not result in a write
   --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:28:66
    |
 LL |     let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::AcqRel, Ordering::AcqRel);
-   |                                                                  ^^^^^^^^^^^^^^^^
+   |                                                                  ^^^^^^^^^^^^^^^^ invalid failure ordering
    |
-   = help: consider using ordering modes `Acquire` or `Relaxed` instead
+   = help: consider using Acquire or Relaxed failure ordering instead
 
-error: compare_exchange_weak's failure ordering may not be `Release` or `AcqRel`
+error: compare_exchange_weak's failure ordering may not be `Release` or `AcqRel`, since a failed compare_exchange_weak does not result in a write
   --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:30:66
    |
 LL |     let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::SeqCst, Ordering::AcqRel);
-   |                                                                  ^^^^^^^^^^^^^^^^
+   |                                                                  ^^^^^^^^^^^^^^^^ invalid failure ordering
    |
-   = help: consider using ordering modes `Acquire`, `SeqCst` or `Relaxed` instead
+   = help: consider using Acquire or Relaxed failure ordering instead
 
-error: compare_exchange_weak's failure ordering may not be `Release` or `AcqRel`
+error: compare_exchange_weak's failure ordering may not be `Release` or `AcqRel`, since a failed compare_exchange_weak does not result in a write
   --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:34:67
    |
 LL |     let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::Relaxed, Ordering::Release);
-   |                                                                   ^^^^^^^^^^^^^^^^^
+   |                                                                   ^^^^^^^^^^^^^^^^^ invalid failure ordering
    |
-   = help: consider using ordering mode `Relaxed` instead
+   = help: consider using Acquire or Relaxed failure ordering instead
 
-error: compare_exchange_weak's failure ordering may not be `Release` or `AcqRel`
+error: compare_exchange_weak's failure ordering may not be `Release` or `AcqRel`, since a failed compare_exchange_weak does not result in a write
   --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:36:67
    |
 LL |     let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::Acquire, Ordering::Release);
-   |                                                                   ^^^^^^^^^^^^^^^^^
+   |                                                                   ^^^^^^^^^^^^^^^^^ invalid failure ordering
    |
-   = help: consider using ordering modes `Acquire` or `Relaxed` instead
+   = help: consider using Acquire or Relaxed failure ordering instead
 
-error: compare_exchange_weak's failure ordering may not be `Release` or `AcqRel`
+error: compare_exchange_weak's failure ordering may not be `Release` or `AcqRel`, since a failed compare_exchange_weak does not result in a write
   --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:38:67
    |
 LL |     let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::Release, Ordering::Release);
-   |                                                                   ^^^^^^^^^^^^^^^^^
+   |                                                                   ^^^^^^^^^^^^^^^^^ invalid failure ordering
    |
-   = help: consider using ordering mode `Relaxed` instead
+   = help: consider using Acquire or Relaxed failure ordering instead
 
-error: compare_exchange_weak's failure ordering may not be `Release` or `AcqRel`
+error: compare_exchange_weak's failure ordering may not be `Release` or `AcqRel`, since a failed compare_exchange_weak does not result in a write
   --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:40:66
    |
 LL |     let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::AcqRel, Ordering::Release);
-   |                                                                  ^^^^^^^^^^^^^^^^^
+   |                                                                  ^^^^^^^^^^^^^^^^^ invalid failure ordering
    |
-   = help: consider using ordering modes `Acquire` or `Relaxed` instead
+   = help: consider using Acquire or Relaxed failure ordering instead
 
-error: compare_exchange_weak's failure ordering may not be `Release` or `AcqRel`
+error: compare_exchange_weak's failure ordering may not be `Release` or `AcqRel`, since a failed compare_exchange_weak does not result in a write
   --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:42:66
    |
 LL |     let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::SeqCst, Ordering::Release);
-   |                                                                  ^^^^^^^^^^^^^^^^^
+   |                                                                  ^^^^^^^^^^^^^^^^^ invalid failure ordering
    |
-   = help: consider using ordering modes `Acquire`, `SeqCst` or `Relaxed` instead
+   = help: consider using Acquire or Relaxed failure ordering instead
 
-error: compare_exchange_weak's failure ordering may not be stronger than the success ordering of `Release`
-  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:46:67
+error: compare_exchange_weak's success ordering must be at least as strong as its failure ordering
+  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:46:48
    |
 LL |     let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::Release, Ordering::Acquire);
-   |                                                                   ^^^^^^^^^^^^^^^^^
+   |                                                ^^^^^^^^^^^^^^^^^  ----------------- Acquire failure ordering
+   |                                                |
+   |                                                Release success ordering
    |
-   = help: consider using ordering mode `Relaxed` instead
+   = help: consider using AcqRel success ordering instead
 
-error: compare_exchange_weak's failure ordering may not be stronger than the success ordering of `Release`
-  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:48:67
+error: compare_exchange_weak's success ordering must be at least as strong as its failure ordering
+  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:48:48
    |
 LL |     let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::Release, Ordering::SeqCst);
-   |                                                                   ^^^^^^^^^^^^^^^^
+   |                                                ^^^^^^^^^^^^^^^^^  ---------------- SeqCst failure ordering
+   |                                                |
+   |                                                Release success ordering
    |
-   = help: consider using ordering mode `Relaxed` instead
+   = help: consider using SeqCst success ordering instead
 
-error: compare_exchange_weak's failure ordering may not be stronger than the success ordering of `Relaxed`
-  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:52:67
+error: compare_exchange_weak's success ordering must be at least as strong as its failure ordering
+  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:52:48
    |
 LL |     let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::Relaxed, Ordering::SeqCst);
-   |                                                                   ^^^^^^^^^^^^^^^^
+   |                                                ^^^^^^^^^^^^^^^^^  ---------------- SeqCst failure ordering
+   |                                                |
+   |                                                Relaxed success ordering
    |
-   = help: consider using ordering mode `Relaxed` instead
+   = help: consider using SeqCst success ordering instead
 
-error: compare_exchange_weak's failure ordering may not be stronger than the success ordering of `Relaxed`
-  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:54:67
+error: compare_exchange_weak's success ordering must be at least as strong as its failure ordering
+  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:54:48
    |
 LL |     let _ = x.compare_exchange_weak(ptr, ptr2, Ordering::Relaxed, Ordering::Acquire);
-   |                                                                   ^^^^^^^^^^^^^^^^^
+   |                                                ^^^^^^^^^^^^^^^^^  ----------------- Acquire failure ordering
+   |                                                |
+   |                                                Relaxed success ordering
    |
-   = help: consider using ordering mode `Relaxed` instead
+   = help: consider using Acquire success ordering instead
 
-error: compare_exchange_weak's failure ordering may not be stronger than the success ordering of `Acquire`
-  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:58:67
+error: compare_exchange_weak's success ordering must be at least as strong as its failure ordering
+  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:58:48
    |
 LL |     let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::Acquire, Ordering::SeqCst);
-   |                                                                   ^^^^^^^^^^^^^^^^
+   |                                                ^^^^^^^^^^^^^^^^^  ---------------- SeqCst failure ordering
+   |                                                |
+   |                                                Acquire success ordering
    |
-   = help: consider using ordering modes `Acquire` or `Relaxed` instead
+   = help: consider using SeqCst success ordering instead
 
-error: compare_exchange_weak's failure ordering may not be stronger than the success ordering of `AcqRel`
-  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:60:66
+error: compare_exchange_weak's success ordering must be at least as strong as its failure ordering
+  --> $DIR/lint-invalid-atomic-ordering-exchange-weak.rs:60:48
    |
 LL |     let _ = x.compare_exchange_weak(ptr2, ptr, Ordering::AcqRel, Ordering::SeqCst);
-   |                                                                  ^^^^^^^^^^^^^^^^
+   |                                                ^^^^^^^^^^^^^^^^  ---------------- SeqCst failure ordering
+   |                                                |
+   |                                                AcqRel success ordering
    |
-   = help: consider using ordering modes `Acquire` or `Relaxed` instead
+   = help: consider using SeqCst success ordering instead
 
 error: aborting due to 16 previous errors
 

--- a/src/test/ui/lint/lint-invalid-atomic-ordering-exchange.rs
+++ b/src/test/ui/lint/lint-invalid-atomic-ordering-exchange.rs
@@ -18,43 +18,43 @@ fn main() {
 
     // AcqRel is always forbidden as a failure ordering
     let _ = x.compare_exchange(0, 0, Ordering::Relaxed, Ordering::AcqRel);
-    //~^ ERROR compare_exchange's failure ordering may not be `Release` or `AcqRel`
+    //~^ ERROR `compare_exchange`'s failure ordering may not be `Release` or `AcqRel`
     let _ = x.compare_exchange(0, 0, Ordering::Acquire, Ordering::AcqRel);
-    //~^ ERROR compare_exchange's failure ordering may not be `Release` or `AcqRel`
+    //~^ ERROR `compare_exchange`'s failure ordering may not be `Release` or `AcqRel`
     let _ = x.compare_exchange(0, 0, Ordering::Release, Ordering::AcqRel);
-    //~^ ERROR compare_exchange's failure ordering may not be `Release` or `AcqRel`
+    //~^ ERROR `compare_exchange`'s failure ordering may not be `Release` or `AcqRel`
     let _ = x.compare_exchange(0, 0, Ordering::AcqRel, Ordering::AcqRel);
-    //~^ ERROR compare_exchange's failure ordering may not be `Release` or `AcqRel`
+    //~^ ERROR `compare_exchange`'s failure ordering may not be `Release` or `AcqRel`
     let _ = x.compare_exchange(0, 0, Ordering::SeqCst, Ordering::AcqRel);
-    //~^ ERROR compare_exchange's failure ordering may not be `Release` or `AcqRel`
+    //~^ ERROR `compare_exchange`'s failure ordering may not be `Release` or `AcqRel`
 
     // Release is always forbidden as a failure ordering
     let _ = x.compare_exchange(0, 0, Ordering::Relaxed, Ordering::Release);
-    //~^ ERROR compare_exchange's failure ordering may not be `Release` or `AcqRel`
+    //~^ ERROR `compare_exchange`'s failure ordering may not be `Release` or `AcqRel`
     let _ = x.compare_exchange(0, 0, Ordering::Acquire, Ordering::Release);
-    //~^ ERROR compare_exchange's failure ordering may not be `Release` or `AcqRel`
+    //~^ ERROR `compare_exchange`'s failure ordering may not be `Release` or `AcqRel`
     let _ = x.compare_exchange(0, 0, Ordering::Release, Ordering::Release);
-    //~^ ERROR compare_exchange's failure ordering may not be `Release` or `AcqRel`
+    //~^ ERROR `compare_exchange`'s failure ordering may not be `Release` or `AcqRel`
     let _ = x.compare_exchange(0, 0, Ordering::AcqRel, Ordering::Release);
-    //~^ ERROR compare_exchange's failure ordering may not be `Release` or `AcqRel`
+    //~^ ERROR `compare_exchange`'s failure ordering may not be `Release` or `AcqRel`
     let _ = x.compare_exchange(0, 0, Ordering::SeqCst, Ordering::Release);
-    //~^ ERROR compare_exchange's failure ordering may not be `Release` or `AcqRel`
+    //~^ ERROR `compare_exchange`'s failure ordering may not be `Release` or `AcqRel`
 
     // Release success order forbids failure order of Acquire or SeqCst
     let _ = x.compare_exchange(0, 0, Ordering::Release, Ordering::Acquire);
-    //~^ ERROR compare_exchange's success ordering must be at least as strong as
+    //~^ ERROR `compare_exchange`'s success ordering must be at least as strong as
     let _ = x.compare_exchange(0, 0, Ordering::Release, Ordering::SeqCst);
-    //~^ ERROR compare_exchange's success ordering must be at least as strong as
+    //~^ ERROR `compare_exchange`'s success ordering must be at least as strong as
 
     // Relaxed success order also forbids failure order of Acquire or SeqCst
     let _ = x.compare_exchange(0, 0, Ordering::Relaxed, Ordering::SeqCst);
-    //~^ ERROR compare_exchange's success ordering must be at least as strong as
+    //~^ ERROR `compare_exchange`'s success ordering must be at least as strong as
     let _ = x.compare_exchange(0, 0, Ordering::Relaxed, Ordering::Acquire);
-    //~^ ERROR compare_exchange's success ordering must be at least as strong as
+    //~^ ERROR `compare_exchange`'s success ordering must be at least as strong as
 
     // Acquire/AcqRel forbids failure order of SeqCst
     let _ = x.compare_exchange(0, 0, Ordering::Acquire, Ordering::SeqCst);
-    //~^ ERROR compare_exchange's success ordering must be at least as strong as
+    //~^ ERROR `compare_exchange`'s success ordering must be at least as strong as
     let _ = x.compare_exchange(0, 0, Ordering::AcqRel, Ordering::SeqCst);
-    //~^ ERROR compare_exchange's success ordering must be at least as strong as
+    //~^ ERROR `compare_exchange`'s success ordering must be at least as strong as
 }

--- a/src/test/ui/lint/lint-invalid-atomic-ordering-exchange.rs
+++ b/src/test/ui/lint/lint-invalid-atomic-ordering-exchange.rs
@@ -42,19 +42,19 @@ fn main() {
 
     // Release success order forbids failure order of Acquire or SeqCst
     let _ = x.compare_exchange(0, 0, Ordering::Release, Ordering::Acquire);
-    //~^ ERROR compare_exchange's failure ordering may not be stronger
+    //~^ ERROR compare_exchange's success ordering must be at least as strong as
     let _ = x.compare_exchange(0, 0, Ordering::Release, Ordering::SeqCst);
-    //~^ ERROR compare_exchange's failure ordering may not be stronger
+    //~^ ERROR compare_exchange's success ordering must be at least as strong as
 
     // Relaxed success order also forbids failure order of Acquire or SeqCst
     let _ = x.compare_exchange(0, 0, Ordering::Relaxed, Ordering::SeqCst);
-    //~^ ERROR compare_exchange's failure ordering may not be stronger
+    //~^ ERROR compare_exchange's success ordering must be at least as strong as
     let _ = x.compare_exchange(0, 0, Ordering::Relaxed, Ordering::Acquire);
-    //~^ ERROR compare_exchange's failure ordering may not be stronger
+    //~^ ERROR compare_exchange's success ordering must be at least as strong as
 
     // Acquire/AcqRel forbids failure order of SeqCst
     let _ = x.compare_exchange(0, 0, Ordering::Acquire, Ordering::SeqCst);
-    //~^ ERROR compare_exchange's failure ordering may not be stronger
+    //~^ ERROR compare_exchange's success ordering must be at least as strong as
     let _ = x.compare_exchange(0, 0, Ordering::AcqRel, Ordering::SeqCst);
-    //~^ ERROR compare_exchange's failure ordering may not be stronger
+    //~^ ERROR compare_exchange's success ordering must be at least as strong as
 }

--- a/src/test/ui/lint/lint-invalid-atomic-ordering-exchange.stderr
+++ b/src/test/ui/lint/lint-invalid-atomic-ordering-exchange.stderr
@@ -1,137 +1,137 @@
-error: compare_exchange's failure ordering may not be `Release` or `AcqRel`, since a failed compare_exchange does not result in a write
+error: `compare_exchange`'s failure ordering may not be `Release` or `AcqRel`, since a failed `compare_exchange` does not result in a write
   --> $DIR/lint-invalid-atomic-ordering-exchange.rs:20:57
    |
 LL |     let _ = x.compare_exchange(0, 0, Ordering::Relaxed, Ordering::AcqRel);
    |                                                         ^^^^^^^^^^^^^^^^ invalid failure ordering
    |
    = note: `#[deny(invalid_atomic_ordering)]` on by default
-   = help: consider using Acquire or Relaxed failure ordering instead
+   = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
-error: compare_exchange's failure ordering may not be `Release` or `AcqRel`, since a failed compare_exchange does not result in a write
+error: `compare_exchange`'s failure ordering may not be `Release` or `AcqRel`, since a failed `compare_exchange` does not result in a write
   --> $DIR/lint-invalid-atomic-ordering-exchange.rs:22:57
    |
 LL |     let _ = x.compare_exchange(0, 0, Ordering::Acquire, Ordering::AcqRel);
    |                                                         ^^^^^^^^^^^^^^^^ invalid failure ordering
    |
-   = help: consider using Acquire or Relaxed failure ordering instead
+   = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
-error: compare_exchange's failure ordering may not be `Release` or `AcqRel`, since a failed compare_exchange does not result in a write
+error: `compare_exchange`'s failure ordering may not be `Release` or `AcqRel`, since a failed `compare_exchange` does not result in a write
   --> $DIR/lint-invalid-atomic-ordering-exchange.rs:24:57
    |
 LL |     let _ = x.compare_exchange(0, 0, Ordering::Release, Ordering::AcqRel);
    |                                                         ^^^^^^^^^^^^^^^^ invalid failure ordering
    |
-   = help: consider using Acquire or Relaxed failure ordering instead
+   = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
-error: compare_exchange's failure ordering may not be `Release` or `AcqRel`, since a failed compare_exchange does not result in a write
+error: `compare_exchange`'s failure ordering may not be `Release` or `AcqRel`, since a failed `compare_exchange` does not result in a write
   --> $DIR/lint-invalid-atomic-ordering-exchange.rs:26:56
    |
 LL |     let _ = x.compare_exchange(0, 0, Ordering::AcqRel, Ordering::AcqRel);
    |                                                        ^^^^^^^^^^^^^^^^ invalid failure ordering
    |
-   = help: consider using Acquire or Relaxed failure ordering instead
+   = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
-error: compare_exchange's failure ordering may not be `Release` or `AcqRel`, since a failed compare_exchange does not result in a write
+error: `compare_exchange`'s failure ordering may not be `Release` or `AcqRel`, since a failed `compare_exchange` does not result in a write
   --> $DIR/lint-invalid-atomic-ordering-exchange.rs:28:56
    |
 LL |     let _ = x.compare_exchange(0, 0, Ordering::SeqCst, Ordering::AcqRel);
    |                                                        ^^^^^^^^^^^^^^^^ invalid failure ordering
    |
-   = help: consider using Acquire or Relaxed failure ordering instead
+   = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
-error: compare_exchange's failure ordering may not be `Release` or `AcqRel`, since a failed compare_exchange does not result in a write
+error: `compare_exchange`'s failure ordering may not be `Release` or `AcqRel`, since a failed `compare_exchange` does not result in a write
   --> $DIR/lint-invalid-atomic-ordering-exchange.rs:32:57
    |
 LL |     let _ = x.compare_exchange(0, 0, Ordering::Relaxed, Ordering::Release);
    |                                                         ^^^^^^^^^^^^^^^^^ invalid failure ordering
    |
-   = help: consider using Acquire or Relaxed failure ordering instead
+   = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
-error: compare_exchange's failure ordering may not be `Release` or `AcqRel`, since a failed compare_exchange does not result in a write
+error: `compare_exchange`'s failure ordering may not be `Release` or `AcqRel`, since a failed `compare_exchange` does not result in a write
   --> $DIR/lint-invalid-atomic-ordering-exchange.rs:34:57
    |
 LL |     let _ = x.compare_exchange(0, 0, Ordering::Acquire, Ordering::Release);
    |                                                         ^^^^^^^^^^^^^^^^^ invalid failure ordering
    |
-   = help: consider using Acquire or Relaxed failure ordering instead
+   = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
-error: compare_exchange's failure ordering may not be `Release` or `AcqRel`, since a failed compare_exchange does not result in a write
+error: `compare_exchange`'s failure ordering may not be `Release` or `AcqRel`, since a failed `compare_exchange` does not result in a write
   --> $DIR/lint-invalid-atomic-ordering-exchange.rs:36:57
    |
 LL |     let _ = x.compare_exchange(0, 0, Ordering::Release, Ordering::Release);
    |                                                         ^^^^^^^^^^^^^^^^^ invalid failure ordering
    |
-   = help: consider using Acquire or Relaxed failure ordering instead
+   = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
-error: compare_exchange's failure ordering may not be `Release` or `AcqRel`, since a failed compare_exchange does not result in a write
+error: `compare_exchange`'s failure ordering may not be `Release` or `AcqRel`, since a failed `compare_exchange` does not result in a write
   --> $DIR/lint-invalid-atomic-ordering-exchange.rs:38:56
    |
 LL |     let _ = x.compare_exchange(0, 0, Ordering::AcqRel, Ordering::Release);
    |                                                        ^^^^^^^^^^^^^^^^^ invalid failure ordering
    |
-   = help: consider using Acquire or Relaxed failure ordering instead
+   = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
-error: compare_exchange's failure ordering may not be `Release` or `AcqRel`, since a failed compare_exchange does not result in a write
+error: `compare_exchange`'s failure ordering may not be `Release` or `AcqRel`, since a failed `compare_exchange` does not result in a write
   --> $DIR/lint-invalid-atomic-ordering-exchange.rs:40:56
    |
 LL |     let _ = x.compare_exchange(0, 0, Ordering::SeqCst, Ordering::Release);
    |                                                        ^^^^^^^^^^^^^^^^^ invalid failure ordering
    |
-   = help: consider using Acquire or Relaxed failure ordering instead
+   = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
-error: compare_exchange's success ordering must be at least as strong as its failure ordering
+error: `compare_exchange`'s success ordering must be at least as strong as its failure ordering
   --> $DIR/lint-invalid-atomic-ordering-exchange.rs:44:38
    |
 LL |     let _ = x.compare_exchange(0, 0, Ordering::Release, Ordering::Acquire);
-   |                                      ^^^^^^^^^^^^^^^^^  ----------------- Acquire failure ordering
+   |                                      ^^^^^^^^^^^^^^^^^  ----------------- `Acquire` failure ordering
    |                                      |
-   |                                      Release success ordering
-   |                                      help: consider using AcqRel success ordering instead
+   |                                      `Release` success ordering
+   |                                      help: consider using `AcqRel` success ordering instead
 
-error: compare_exchange's success ordering must be at least as strong as its failure ordering
+error: `compare_exchange`'s success ordering must be at least as strong as its failure ordering
   --> $DIR/lint-invalid-atomic-ordering-exchange.rs:46:38
    |
 LL |     let _ = x.compare_exchange(0, 0, Ordering::Release, Ordering::SeqCst);
-   |                                      ^^^^^^^^^^^^^^^^^  ---------------- SeqCst failure ordering
+   |                                      ^^^^^^^^^^^^^^^^^  ---------------- `SeqCst` failure ordering
    |                                      |
-   |                                      Release success ordering
-   |                                      help: consider using SeqCst success ordering instead
+   |                                      `Release` success ordering
+   |                                      help: consider using `SeqCst` success ordering instead
 
-error: compare_exchange's success ordering must be at least as strong as its failure ordering
+error: `compare_exchange`'s success ordering must be at least as strong as its failure ordering
   --> $DIR/lint-invalid-atomic-ordering-exchange.rs:50:38
    |
 LL |     let _ = x.compare_exchange(0, 0, Ordering::Relaxed, Ordering::SeqCst);
-   |                                      ^^^^^^^^^^^^^^^^^  ---------------- SeqCst failure ordering
+   |                                      ^^^^^^^^^^^^^^^^^  ---------------- `SeqCst` failure ordering
    |                                      |
-   |                                      Relaxed success ordering
-   |                                      help: consider using SeqCst success ordering instead
+   |                                      `Relaxed` success ordering
+   |                                      help: consider using `SeqCst` success ordering instead
 
-error: compare_exchange's success ordering must be at least as strong as its failure ordering
+error: `compare_exchange`'s success ordering must be at least as strong as its failure ordering
   --> $DIR/lint-invalid-atomic-ordering-exchange.rs:52:38
    |
 LL |     let _ = x.compare_exchange(0, 0, Ordering::Relaxed, Ordering::Acquire);
-   |                                      ^^^^^^^^^^^^^^^^^  ----------------- Acquire failure ordering
+   |                                      ^^^^^^^^^^^^^^^^^  ----------------- `Acquire` failure ordering
    |                                      |
-   |                                      Relaxed success ordering
-   |                                      help: consider using Acquire success ordering instead
+   |                                      `Relaxed` success ordering
+   |                                      help: consider using `Acquire` success ordering instead
 
-error: compare_exchange's success ordering must be at least as strong as its failure ordering
+error: `compare_exchange`'s success ordering must be at least as strong as its failure ordering
   --> $DIR/lint-invalid-atomic-ordering-exchange.rs:56:38
    |
 LL |     let _ = x.compare_exchange(0, 0, Ordering::Acquire, Ordering::SeqCst);
-   |                                      ^^^^^^^^^^^^^^^^^  ---------------- SeqCst failure ordering
+   |                                      ^^^^^^^^^^^^^^^^^  ---------------- `SeqCst` failure ordering
    |                                      |
-   |                                      Acquire success ordering
-   |                                      help: consider using SeqCst success ordering instead
+   |                                      `Acquire` success ordering
+   |                                      help: consider using `SeqCst` success ordering instead
 
-error: compare_exchange's success ordering must be at least as strong as its failure ordering
+error: `compare_exchange`'s success ordering must be at least as strong as its failure ordering
   --> $DIR/lint-invalid-atomic-ordering-exchange.rs:58:38
    |
 LL |     let _ = x.compare_exchange(0, 0, Ordering::AcqRel, Ordering::SeqCst);
-   |                                      ^^^^^^^^^^^^^^^^  ---------------- SeqCst failure ordering
+   |                                      ^^^^^^^^^^^^^^^^  ---------------- `SeqCst` failure ordering
    |                                      |
-   |                                      AcqRel success ordering
-   |                                      help: consider using SeqCst success ordering instead
+   |                                      `AcqRel` success ordering
+   |                                      help: consider using `SeqCst` success ordering instead
 
 error: aborting due to 16 previous errors
 

--- a/src/test/ui/lint/lint-invalid-atomic-ordering-exchange.stderr
+++ b/src/test/ui/lint/lint-invalid-atomic-ordering-exchange.stderr
@@ -86,8 +86,7 @@ LL |     let _ = x.compare_exchange(0, 0, Ordering::Release, Ordering::Acquire);
    |                                      ^^^^^^^^^^^^^^^^^  ----------------- Acquire failure ordering
    |                                      |
    |                                      Release success ordering
-   |
-   = help: consider using AcqRel success ordering instead
+   |                                      help: consider using AcqRel success ordering instead
 
 error: compare_exchange's success ordering must be at least as strong as its failure ordering
   --> $DIR/lint-invalid-atomic-ordering-exchange.rs:46:38
@@ -96,8 +95,7 @@ LL |     let _ = x.compare_exchange(0, 0, Ordering::Release, Ordering::SeqCst);
    |                                      ^^^^^^^^^^^^^^^^^  ---------------- SeqCst failure ordering
    |                                      |
    |                                      Release success ordering
-   |
-   = help: consider using SeqCst success ordering instead
+   |                                      help: consider using SeqCst success ordering instead
 
 error: compare_exchange's success ordering must be at least as strong as its failure ordering
   --> $DIR/lint-invalid-atomic-ordering-exchange.rs:50:38
@@ -106,8 +104,7 @@ LL |     let _ = x.compare_exchange(0, 0, Ordering::Relaxed, Ordering::SeqCst);
    |                                      ^^^^^^^^^^^^^^^^^  ---------------- SeqCst failure ordering
    |                                      |
    |                                      Relaxed success ordering
-   |
-   = help: consider using SeqCst success ordering instead
+   |                                      help: consider using SeqCst success ordering instead
 
 error: compare_exchange's success ordering must be at least as strong as its failure ordering
   --> $DIR/lint-invalid-atomic-ordering-exchange.rs:52:38
@@ -116,8 +113,7 @@ LL |     let _ = x.compare_exchange(0, 0, Ordering::Relaxed, Ordering::Acquire);
    |                                      ^^^^^^^^^^^^^^^^^  ----------------- Acquire failure ordering
    |                                      |
    |                                      Relaxed success ordering
-   |
-   = help: consider using Acquire success ordering instead
+   |                                      help: consider using Acquire success ordering instead
 
 error: compare_exchange's success ordering must be at least as strong as its failure ordering
   --> $DIR/lint-invalid-atomic-ordering-exchange.rs:56:38
@@ -126,8 +122,7 @@ LL |     let _ = x.compare_exchange(0, 0, Ordering::Acquire, Ordering::SeqCst);
    |                                      ^^^^^^^^^^^^^^^^^  ---------------- SeqCst failure ordering
    |                                      |
    |                                      Acquire success ordering
-   |
-   = help: consider using SeqCst success ordering instead
+   |                                      help: consider using SeqCst success ordering instead
 
 error: compare_exchange's success ordering must be at least as strong as its failure ordering
   --> $DIR/lint-invalid-atomic-ordering-exchange.rs:58:38
@@ -136,8 +131,7 @@ LL |     let _ = x.compare_exchange(0, 0, Ordering::AcqRel, Ordering::SeqCst);
    |                                      ^^^^^^^^^^^^^^^^  ---------------- SeqCst failure ordering
    |                                      |
    |                                      AcqRel success ordering
-   |
-   = help: consider using SeqCst success ordering instead
+   |                                      help: consider using SeqCst success ordering instead
 
 error: aborting due to 16 previous errors
 

--- a/src/test/ui/lint/lint-invalid-atomic-ordering-exchange.stderr
+++ b/src/test/ui/lint/lint-invalid-atomic-ordering-exchange.stderr
@@ -1,131 +1,143 @@
-error: compare_exchange's failure ordering may not be `Release` or `AcqRel`
+error: compare_exchange's failure ordering may not be `Release` or `AcqRel`, since a failed compare_exchange does not result in a write
   --> $DIR/lint-invalid-atomic-ordering-exchange.rs:20:57
    |
 LL |     let _ = x.compare_exchange(0, 0, Ordering::Relaxed, Ordering::AcqRel);
-   |                                                         ^^^^^^^^^^^^^^^^
+   |                                                         ^^^^^^^^^^^^^^^^ invalid failure ordering
    |
    = note: `#[deny(invalid_atomic_ordering)]` on by default
-   = help: consider using ordering mode `Relaxed` instead
+   = help: consider using Acquire or Relaxed failure ordering instead
 
-error: compare_exchange's failure ordering may not be `Release` or `AcqRel`
+error: compare_exchange's failure ordering may not be `Release` or `AcqRel`, since a failed compare_exchange does not result in a write
   --> $DIR/lint-invalid-atomic-ordering-exchange.rs:22:57
    |
 LL |     let _ = x.compare_exchange(0, 0, Ordering::Acquire, Ordering::AcqRel);
-   |                                                         ^^^^^^^^^^^^^^^^
+   |                                                         ^^^^^^^^^^^^^^^^ invalid failure ordering
    |
-   = help: consider using ordering modes `Acquire` or `Relaxed` instead
+   = help: consider using Acquire or Relaxed failure ordering instead
 
-error: compare_exchange's failure ordering may not be `Release` or `AcqRel`
+error: compare_exchange's failure ordering may not be `Release` or `AcqRel`, since a failed compare_exchange does not result in a write
   --> $DIR/lint-invalid-atomic-ordering-exchange.rs:24:57
    |
 LL |     let _ = x.compare_exchange(0, 0, Ordering::Release, Ordering::AcqRel);
-   |                                                         ^^^^^^^^^^^^^^^^
+   |                                                         ^^^^^^^^^^^^^^^^ invalid failure ordering
    |
-   = help: consider using ordering mode `Relaxed` instead
+   = help: consider using Acquire or Relaxed failure ordering instead
 
-error: compare_exchange's failure ordering may not be `Release` or `AcqRel`
+error: compare_exchange's failure ordering may not be `Release` or `AcqRel`, since a failed compare_exchange does not result in a write
   --> $DIR/lint-invalid-atomic-ordering-exchange.rs:26:56
    |
 LL |     let _ = x.compare_exchange(0, 0, Ordering::AcqRel, Ordering::AcqRel);
-   |                                                        ^^^^^^^^^^^^^^^^
+   |                                                        ^^^^^^^^^^^^^^^^ invalid failure ordering
    |
-   = help: consider using ordering modes `Acquire` or `Relaxed` instead
+   = help: consider using Acquire or Relaxed failure ordering instead
 
-error: compare_exchange's failure ordering may not be `Release` or `AcqRel`
+error: compare_exchange's failure ordering may not be `Release` or `AcqRel`, since a failed compare_exchange does not result in a write
   --> $DIR/lint-invalid-atomic-ordering-exchange.rs:28:56
    |
 LL |     let _ = x.compare_exchange(0, 0, Ordering::SeqCst, Ordering::AcqRel);
-   |                                                        ^^^^^^^^^^^^^^^^
+   |                                                        ^^^^^^^^^^^^^^^^ invalid failure ordering
    |
-   = help: consider using ordering modes `Acquire`, `SeqCst` or `Relaxed` instead
+   = help: consider using Acquire or Relaxed failure ordering instead
 
-error: compare_exchange's failure ordering may not be `Release` or `AcqRel`
+error: compare_exchange's failure ordering may not be `Release` or `AcqRel`, since a failed compare_exchange does not result in a write
   --> $DIR/lint-invalid-atomic-ordering-exchange.rs:32:57
    |
 LL |     let _ = x.compare_exchange(0, 0, Ordering::Relaxed, Ordering::Release);
-   |                                                         ^^^^^^^^^^^^^^^^^
+   |                                                         ^^^^^^^^^^^^^^^^^ invalid failure ordering
    |
-   = help: consider using ordering mode `Relaxed` instead
+   = help: consider using Acquire or Relaxed failure ordering instead
 
-error: compare_exchange's failure ordering may not be `Release` or `AcqRel`
+error: compare_exchange's failure ordering may not be `Release` or `AcqRel`, since a failed compare_exchange does not result in a write
   --> $DIR/lint-invalid-atomic-ordering-exchange.rs:34:57
    |
 LL |     let _ = x.compare_exchange(0, 0, Ordering::Acquire, Ordering::Release);
-   |                                                         ^^^^^^^^^^^^^^^^^
+   |                                                         ^^^^^^^^^^^^^^^^^ invalid failure ordering
    |
-   = help: consider using ordering modes `Acquire` or `Relaxed` instead
+   = help: consider using Acquire or Relaxed failure ordering instead
 
-error: compare_exchange's failure ordering may not be `Release` or `AcqRel`
+error: compare_exchange's failure ordering may not be `Release` or `AcqRel`, since a failed compare_exchange does not result in a write
   --> $DIR/lint-invalid-atomic-ordering-exchange.rs:36:57
    |
 LL |     let _ = x.compare_exchange(0, 0, Ordering::Release, Ordering::Release);
-   |                                                         ^^^^^^^^^^^^^^^^^
+   |                                                         ^^^^^^^^^^^^^^^^^ invalid failure ordering
    |
-   = help: consider using ordering mode `Relaxed` instead
+   = help: consider using Acquire or Relaxed failure ordering instead
 
-error: compare_exchange's failure ordering may not be `Release` or `AcqRel`
+error: compare_exchange's failure ordering may not be `Release` or `AcqRel`, since a failed compare_exchange does not result in a write
   --> $DIR/lint-invalid-atomic-ordering-exchange.rs:38:56
    |
 LL |     let _ = x.compare_exchange(0, 0, Ordering::AcqRel, Ordering::Release);
-   |                                                        ^^^^^^^^^^^^^^^^^
+   |                                                        ^^^^^^^^^^^^^^^^^ invalid failure ordering
    |
-   = help: consider using ordering modes `Acquire` or `Relaxed` instead
+   = help: consider using Acquire or Relaxed failure ordering instead
 
-error: compare_exchange's failure ordering may not be `Release` or `AcqRel`
+error: compare_exchange's failure ordering may not be `Release` or `AcqRel`, since a failed compare_exchange does not result in a write
   --> $DIR/lint-invalid-atomic-ordering-exchange.rs:40:56
    |
 LL |     let _ = x.compare_exchange(0, 0, Ordering::SeqCst, Ordering::Release);
-   |                                                        ^^^^^^^^^^^^^^^^^
+   |                                                        ^^^^^^^^^^^^^^^^^ invalid failure ordering
    |
-   = help: consider using ordering modes `Acquire`, `SeqCst` or `Relaxed` instead
+   = help: consider using Acquire or Relaxed failure ordering instead
 
-error: compare_exchange's failure ordering may not be stronger than the success ordering of `Release`
-  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:44:57
+error: compare_exchange's success ordering must be at least as strong as its failure ordering
+  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:44:38
    |
 LL |     let _ = x.compare_exchange(0, 0, Ordering::Release, Ordering::Acquire);
-   |                                                         ^^^^^^^^^^^^^^^^^
+   |                                      ^^^^^^^^^^^^^^^^^  ----------------- Acquire failure ordering
+   |                                      |
+   |                                      Release success ordering
    |
-   = help: consider using ordering mode `Relaxed` instead
+   = help: consider using AcqRel success ordering instead
 
-error: compare_exchange's failure ordering may not be stronger than the success ordering of `Release`
-  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:46:57
+error: compare_exchange's success ordering must be at least as strong as its failure ordering
+  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:46:38
    |
 LL |     let _ = x.compare_exchange(0, 0, Ordering::Release, Ordering::SeqCst);
-   |                                                         ^^^^^^^^^^^^^^^^
+   |                                      ^^^^^^^^^^^^^^^^^  ---------------- SeqCst failure ordering
+   |                                      |
+   |                                      Release success ordering
    |
-   = help: consider using ordering mode `Relaxed` instead
+   = help: consider using SeqCst success ordering instead
 
-error: compare_exchange's failure ordering may not be stronger than the success ordering of `Relaxed`
-  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:50:57
+error: compare_exchange's success ordering must be at least as strong as its failure ordering
+  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:50:38
    |
 LL |     let _ = x.compare_exchange(0, 0, Ordering::Relaxed, Ordering::SeqCst);
-   |                                                         ^^^^^^^^^^^^^^^^
+   |                                      ^^^^^^^^^^^^^^^^^  ---------------- SeqCst failure ordering
+   |                                      |
+   |                                      Relaxed success ordering
    |
-   = help: consider using ordering mode `Relaxed` instead
+   = help: consider using SeqCst success ordering instead
 
-error: compare_exchange's failure ordering may not be stronger than the success ordering of `Relaxed`
-  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:52:57
+error: compare_exchange's success ordering must be at least as strong as its failure ordering
+  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:52:38
    |
 LL |     let _ = x.compare_exchange(0, 0, Ordering::Relaxed, Ordering::Acquire);
-   |                                                         ^^^^^^^^^^^^^^^^^
+   |                                      ^^^^^^^^^^^^^^^^^  ----------------- Acquire failure ordering
+   |                                      |
+   |                                      Relaxed success ordering
    |
-   = help: consider using ordering mode `Relaxed` instead
+   = help: consider using Acquire success ordering instead
 
-error: compare_exchange's failure ordering may not be stronger than the success ordering of `Acquire`
-  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:56:57
+error: compare_exchange's success ordering must be at least as strong as its failure ordering
+  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:56:38
    |
 LL |     let _ = x.compare_exchange(0, 0, Ordering::Acquire, Ordering::SeqCst);
-   |                                                         ^^^^^^^^^^^^^^^^
+   |                                      ^^^^^^^^^^^^^^^^^  ---------------- SeqCst failure ordering
+   |                                      |
+   |                                      Acquire success ordering
    |
-   = help: consider using ordering modes `Acquire` or `Relaxed` instead
+   = help: consider using SeqCst success ordering instead
 
-error: compare_exchange's failure ordering may not be stronger than the success ordering of `AcqRel`
-  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:58:56
+error: compare_exchange's success ordering must be at least as strong as its failure ordering
+  --> $DIR/lint-invalid-atomic-ordering-exchange.rs:58:38
    |
 LL |     let _ = x.compare_exchange(0, 0, Ordering::AcqRel, Ordering::SeqCst);
-   |                                                        ^^^^^^^^^^^^^^^^
+   |                                      ^^^^^^^^^^^^^^^^  ---------------- SeqCst failure ordering
+   |                                      |
+   |                                      AcqRel success ordering
    |
-   = help: consider using ordering modes `Acquire` or `Relaxed` instead
+   = help: consider using SeqCst success ordering instead
 
 error: aborting due to 16 previous errors
 

--- a/src/test/ui/lint/lint-invalid-atomic-ordering-fetch-update.rs
+++ b/src/test/ui/lint/lint-invalid-atomic-ordering-fetch-update.rs
@@ -18,43 +18,43 @@ fn main() {
 
     // AcqRel is always forbidden as a failure ordering
     let _ = x.fetch_update(Ordering::Relaxed, Ordering::AcqRel, |old| Some(old + 1));
-    //~^ ERROR fetch_update's failure ordering may not be `Release` or `AcqRel`
+    //~^ ERROR `fetch_update`'s failure ordering may not be `Release` or `AcqRel`
     let _ = x.fetch_update(Ordering::Acquire, Ordering::AcqRel, |old| Some(old + 1));
-    //~^ ERROR fetch_update's failure ordering may not be `Release` or `AcqRel`
+    //~^ ERROR `fetch_update`'s failure ordering may not be `Release` or `AcqRel`
     let _ = x.fetch_update(Ordering::Release, Ordering::AcqRel, |old| Some(old + 1));
-    //~^ ERROR fetch_update's failure ordering may not be `Release` or `AcqRel`
+    //~^ ERROR `fetch_update`'s failure ordering may not be `Release` or `AcqRel`
     let _ = x.fetch_update(Ordering::AcqRel, Ordering::AcqRel, |old| Some(old + 1));
-    //~^ ERROR fetch_update's failure ordering may not be `Release` or `AcqRel`
+    //~^ ERROR `fetch_update`'s failure ordering may not be `Release` or `AcqRel`
     let _ = x.fetch_update(Ordering::SeqCst, Ordering::AcqRel, |old| Some(old + 1));
-    //~^ ERROR fetch_update's failure ordering may not be `Release` or `AcqRel`
+    //~^ ERROR `fetch_update`'s failure ordering may not be `Release` or `AcqRel`
 
     // Release is always forbidden as a failure ordering
     let _ = x.fetch_update(Ordering::Relaxed, Ordering::Release, |old| Some(old + 1));
-    //~^ ERROR fetch_update's failure ordering may not be `Release` or `AcqRel`
+    //~^ ERROR `fetch_update`'s failure ordering may not be `Release` or `AcqRel`
     let _ = x.fetch_update(Ordering::Acquire, Ordering::Release, |old| Some(old + 1));
-    //~^ ERROR fetch_update's failure ordering may not be `Release` or `AcqRel`
+    //~^ ERROR `fetch_update`'s failure ordering may not be `Release` or `AcqRel`
     let _ = x.fetch_update(Ordering::Release, Ordering::Release, |old| Some(old + 1));
-    //~^ ERROR fetch_update's failure ordering may not be `Release` or `AcqRel`
+    //~^ ERROR `fetch_update`'s failure ordering may not be `Release` or `AcqRel`
     let _ = x.fetch_update(Ordering::AcqRel, Ordering::Release, |old| Some(old + 1));
-    //~^ ERROR fetch_update's failure ordering may not be `Release` or `AcqRel`
+    //~^ ERROR `fetch_update`'s failure ordering may not be `Release` or `AcqRel`
     let _ = x.fetch_update(Ordering::SeqCst, Ordering::Release, |old| Some(old + 1));
-    //~^ ERROR fetch_update's failure ordering may not be `Release` or `AcqRel`
+    //~^ ERROR `fetch_update`'s failure ordering may not be `Release` or `AcqRel`
 
     // Release success order forbids failure order of Acquire or SeqCst
     let _ = x.fetch_update(Ordering::Release, Ordering::Acquire, |old| Some(old + 1));
-    //~^ ERROR fetch_update's success ordering must be at least as strong as
+    //~^ ERROR `fetch_update`'s success ordering must be at least as strong as
     let _ = x.fetch_update(Ordering::Release, Ordering::SeqCst, |old| Some(old + 1));
-    //~^ ERROR fetch_update's success ordering must be at least as strong as
+    //~^ ERROR `fetch_update`'s success ordering must be at least as strong as
 
     // Relaxed success order also forbids failure order of Acquire or SeqCst
     let _ = x.fetch_update(Ordering::Relaxed, Ordering::SeqCst, |old| Some(old + 1));
-    //~^ ERROR fetch_update's success ordering must be at least as strong as
+    //~^ ERROR `fetch_update`'s success ordering must be at least as strong as
     let _ = x.fetch_update(Ordering::Relaxed, Ordering::Acquire, |old| Some(old + 1));
-    //~^ ERROR fetch_update's success ordering must be at least as strong as
+    //~^ ERROR `fetch_update`'s success ordering must be at least as strong as
 
     // Acquire/AcqRel forbids failure order of SeqCst
     let _ = x.fetch_update(Ordering::Acquire, Ordering::SeqCst, |old| Some(old + 1));
-    //~^ ERROR fetch_update's success ordering must be at least as strong as
+    //~^ ERROR `fetch_update`'s success ordering must be at least as strong as
     let _ = x.fetch_update(Ordering::AcqRel, Ordering::SeqCst, |old| Some(old + 1));
-    //~^ ERROR fetch_update's success ordering must be at least as strong as
+    //~^ ERROR `fetch_update`'s success ordering must be at least as strong as
 }

--- a/src/test/ui/lint/lint-invalid-atomic-ordering-fetch-update.rs
+++ b/src/test/ui/lint/lint-invalid-atomic-ordering-fetch-update.rs
@@ -42,19 +42,19 @@ fn main() {
 
     // Release success order forbids failure order of Acquire or SeqCst
     let _ = x.fetch_update(Ordering::Release, Ordering::Acquire, |old| Some(old + 1));
-    //~^ ERROR fetch_update's failure ordering may not be stronger
+    //~^ ERROR fetch_update's success ordering must be at least as strong as
     let _ = x.fetch_update(Ordering::Release, Ordering::SeqCst, |old| Some(old + 1));
-    //~^ ERROR fetch_update's failure ordering may not be stronger
+    //~^ ERROR fetch_update's success ordering must be at least as strong as
 
     // Relaxed success order also forbids failure order of Acquire or SeqCst
     let _ = x.fetch_update(Ordering::Relaxed, Ordering::SeqCst, |old| Some(old + 1));
-    //~^ ERROR fetch_update's failure ordering may not be stronger
+    //~^ ERROR fetch_update's success ordering must be at least as strong as
     let _ = x.fetch_update(Ordering::Relaxed, Ordering::Acquire, |old| Some(old + 1));
-    //~^ ERROR fetch_update's failure ordering may not be stronger
+    //~^ ERROR fetch_update's success ordering must be at least as strong as
 
     // Acquire/AcqRel forbids failure order of SeqCst
     let _ = x.fetch_update(Ordering::Acquire, Ordering::SeqCst, |old| Some(old + 1));
-    //~^ ERROR fetch_update's failure ordering may not be stronger
+    //~^ ERROR fetch_update's success ordering must be at least as strong as
     let _ = x.fetch_update(Ordering::AcqRel, Ordering::SeqCst, |old| Some(old + 1));
-    //~^ ERROR fetch_update's failure ordering may not be stronger
+    //~^ ERROR fetch_update's success ordering must be at least as strong as
 }

--- a/src/test/ui/lint/lint-invalid-atomic-ordering-fetch-update.stderr
+++ b/src/test/ui/lint/lint-invalid-atomic-ordering-fetch-update.stderr
@@ -1,137 +1,137 @@
-error: fetch_update's failure ordering may not be `Release` or `AcqRel`, since a failed fetch_update does not result in a write
+error: `fetch_update`'s failure ordering may not be `Release` or `AcqRel`, since a failed `fetch_update` does not result in a write
   --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:20:47
    |
 LL |     let _ = x.fetch_update(Ordering::Relaxed, Ordering::AcqRel, |old| Some(old + 1));
    |                                               ^^^^^^^^^^^^^^^^ invalid failure ordering
    |
    = note: `#[deny(invalid_atomic_ordering)]` on by default
-   = help: consider using Acquire or Relaxed failure ordering instead
+   = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
-error: fetch_update's failure ordering may not be `Release` or `AcqRel`, since a failed fetch_update does not result in a write
+error: `fetch_update`'s failure ordering may not be `Release` or `AcqRel`, since a failed `fetch_update` does not result in a write
   --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:22:47
    |
 LL |     let _ = x.fetch_update(Ordering::Acquire, Ordering::AcqRel, |old| Some(old + 1));
    |                                               ^^^^^^^^^^^^^^^^ invalid failure ordering
    |
-   = help: consider using Acquire or Relaxed failure ordering instead
+   = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
-error: fetch_update's failure ordering may not be `Release` or `AcqRel`, since a failed fetch_update does not result in a write
+error: `fetch_update`'s failure ordering may not be `Release` or `AcqRel`, since a failed `fetch_update` does not result in a write
   --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:24:47
    |
 LL |     let _ = x.fetch_update(Ordering::Release, Ordering::AcqRel, |old| Some(old + 1));
    |                                               ^^^^^^^^^^^^^^^^ invalid failure ordering
    |
-   = help: consider using Acquire or Relaxed failure ordering instead
+   = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
-error: fetch_update's failure ordering may not be `Release` or `AcqRel`, since a failed fetch_update does not result in a write
+error: `fetch_update`'s failure ordering may not be `Release` or `AcqRel`, since a failed `fetch_update` does not result in a write
   --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:26:46
    |
 LL |     let _ = x.fetch_update(Ordering::AcqRel, Ordering::AcqRel, |old| Some(old + 1));
    |                                              ^^^^^^^^^^^^^^^^ invalid failure ordering
    |
-   = help: consider using Acquire or Relaxed failure ordering instead
+   = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
-error: fetch_update's failure ordering may not be `Release` or `AcqRel`, since a failed fetch_update does not result in a write
+error: `fetch_update`'s failure ordering may not be `Release` or `AcqRel`, since a failed `fetch_update` does not result in a write
   --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:28:46
    |
 LL |     let _ = x.fetch_update(Ordering::SeqCst, Ordering::AcqRel, |old| Some(old + 1));
    |                                              ^^^^^^^^^^^^^^^^ invalid failure ordering
    |
-   = help: consider using Acquire or Relaxed failure ordering instead
+   = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
-error: fetch_update's failure ordering may not be `Release` or `AcqRel`, since a failed fetch_update does not result in a write
+error: `fetch_update`'s failure ordering may not be `Release` or `AcqRel`, since a failed `fetch_update` does not result in a write
   --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:32:47
    |
 LL |     let _ = x.fetch_update(Ordering::Relaxed, Ordering::Release, |old| Some(old + 1));
    |                                               ^^^^^^^^^^^^^^^^^ invalid failure ordering
    |
-   = help: consider using Acquire or Relaxed failure ordering instead
+   = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
-error: fetch_update's failure ordering may not be `Release` or `AcqRel`, since a failed fetch_update does not result in a write
+error: `fetch_update`'s failure ordering may not be `Release` or `AcqRel`, since a failed `fetch_update` does not result in a write
   --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:34:47
    |
 LL |     let _ = x.fetch_update(Ordering::Acquire, Ordering::Release, |old| Some(old + 1));
    |                                               ^^^^^^^^^^^^^^^^^ invalid failure ordering
    |
-   = help: consider using Acquire or Relaxed failure ordering instead
+   = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
-error: fetch_update's failure ordering may not be `Release` or `AcqRel`, since a failed fetch_update does not result in a write
+error: `fetch_update`'s failure ordering may not be `Release` or `AcqRel`, since a failed `fetch_update` does not result in a write
   --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:36:47
    |
 LL |     let _ = x.fetch_update(Ordering::Release, Ordering::Release, |old| Some(old + 1));
    |                                               ^^^^^^^^^^^^^^^^^ invalid failure ordering
    |
-   = help: consider using Acquire or Relaxed failure ordering instead
+   = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
-error: fetch_update's failure ordering may not be `Release` or `AcqRel`, since a failed fetch_update does not result in a write
+error: `fetch_update`'s failure ordering may not be `Release` or `AcqRel`, since a failed `fetch_update` does not result in a write
   --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:38:46
    |
 LL |     let _ = x.fetch_update(Ordering::AcqRel, Ordering::Release, |old| Some(old + 1));
    |                                              ^^^^^^^^^^^^^^^^^ invalid failure ordering
    |
-   = help: consider using Acquire or Relaxed failure ordering instead
+   = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
-error: fetch_update's failure ordering may not be `Release` or `AcqRel`, since a failed fetch_update does not result in a write
+error: `fetch_update`'s failure ordering may not be `Release` or `AcqRel`, since a failed `fetch_update` does not result in a write
   --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:40:46
    |
 LL |     let _ = x.fetch_update(Ordering::SeqCst, Ordering::Release, |old| Some(old + 1));
    |                                              ^^^^^^^^^^^^^^^^^ invalid failure ordering
    |
-   = help: consider using Acquire or Relaxed failure ordering instead
+   = help: consider using `Acquire` or `Relaxed` failure ordering instead
 
-error: fetch_update's success ordering must be at least as strong as its failure ordering
+error: `fetch_update`'s success ordering must be at least as strong as its failure ordering
   --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:44:28
    |
 LL |     let _ = x.fetch_update(Ordering::Release, Ordering::Acquire, |old| Some(old + 1));
-   |                            ^^^^^^^^^^^^^^^^^  ----------------- Acquire failure ordering
+   |                            ^^^^^^^^^^^^^^^^^  ----------------- `Acquire` failure ordering
    |                            |
-   |                            Release success ordering
-   |                            help: consider using AcqRel success ordering instead
+   |                            `Release` success ordering
+   |                            help: consider using `AcqRel` success ordering instead
 
-error: fetch_update's success ordering must be at least as strong as its failure ordering
+error: `fetch_update`'s success ordering must be at least as strong as its failure ordering
   --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:46:28
    |
 LL |     let _ = x.fetch_update(Ordering::Release, Ordering::SeqCst, |old| Some(old + 1));
-   |                            ^^^^^^^^^^^^^^^^^  ---------------- SeqCst failure ordering
+   |                            ^^^^^^^^^^^^^^^^^  ---------------- `SeqCst` failure ordering
    |                            |
-   |                            Release success ordering
-   |                            help: consider using SeqCst success ordering instead
+   |                            `Release` success ordering
+   |                            help: consider using `SeqCst` success ordering instead
 
-error: fetch_update's success ordering must be at least as strong as its failure ordering
+error: `fetch_update`'s success ordering must be at least as strong as its failure ordering
   --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:50:28
    |
 LL |     let _ = x.fetch_update(Ordering::Relaxed, Ordering::SeqCst, |old| Some(old + 1));
-   |                            ^^^^^^^^^^^^^^^^^  ---------------- SeqCst failure ordering
+   |                            ^^^^^^^^^^^^^^^^^  ---------------- `SeqCst` failure ordering
    |                            |
-   |                            Relaxed success ordering
-   |                            help: consider using SeqCst success ordering instead
+   |                            `Relaxed` success ordering
+   |                            help: consider using `SeqCst` success ordering instead
 
-error: fetch_update's success ordering must be at least as strong as its failure ordering
+error: `fetch_update`'s success ordering must be at least as strong as its failure ordering
   --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:52:28
    |
 LL |     let _ = x.fetch_update(Ordering::Relaxed, Ordering::Acquire, |old| Some(old + 1));
-   |                            ^^^^^^^^^^^^^^^^^  ----------------- Acquire failure ordering
+   |                            ^^^^^^^^^^^^^^^^^  ----------------- `Acquire` failure ordering
    |                            |
-   |                            Relaxed success ordering
-   |                            help: consider using Acquire success ordering instead
+   |                            `Relaxed` success ordering
+   |                            help: consider using `Acquire` success ordering instead
 
-error: fetch_update's success ordering must be at least as strong as its failure ordering
+error: `fetch_update`'s success ordering must be at least as strong as its failure ordering
   --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:56:28
    |
 LL |     let _ = x.fetch_update(Ordering::Acquire, Ordering::SeqCst, |old| Some(old + 1));
-   |                            ^^^^^^^^^^^^^^^^^  ---------------- SeqCst failure ordering
+   |                            ^^^^^^^^^^^^^^^^^  ---------------- `SeqCst` failure ordering
    |                            |
-   |                            Acquire success ordering
-   |                            help: consider using SeqCst success ordering instead
+   |                            `Acquire` success ordering
+   |                            help: consider using `SeqCst` success ordering instead
 
-error: fetch_update's success ordering must be at least as strong as its failure ordering
+error: `fetch_update`'s success ordering must be at least as strong as its failure ordering
   --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:58:28
    |
 LL |     let _ = x.fetch_update(Ordering::AcqRel, Ordering::SeqCst, |old| Some(old + 1));
-   |                            ^^^^^^^^^^^^^^^^  ---------------- SeqCst failure ordering
+   |                            ^^^^^^^^^^^^^^^^  ---------------- `SeqCst` failure ordering
    |                            |
-   |                            AcqRel success ordering
-   |                            help: consider using SeqCst success ordering instead
+   |                            `AcqRel` success ordering
+   |                            help: consider using `SeqCst` success ordering instead
 
 error: aborting due to 16 previous errors
 

--- a/src/test/ui/lint/lint-invalid-atomic-ordering-fetch-update.stderr
+++ b/src/test/ui/lint/lint-invalid-atomic-ordering-fetch-update.stderr
@@ -86,8 +86,7 @@ LL |     let _ = x.fetch_update(Ordering::Release, Ordering::Acquire, |old| Some
    |                            ^^^^^^^^^^^^^^^^^  ----------------- Acquire failure ordering
    |                            |
    |                            Release success ordering
-   |
-   = help: consider using AcqRel success ordering instead
+   |                            help: consider using AcqRel success ordering instead
 
 error: fetch_update's success ordering must be at least as strong as its failure ordering
   --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:46:28
@@ -96,8 +95,7 @@ LL |     let _ = x.fetch_update(Ordering::Release, Ordering::SeqCst, |old| Some(
    |                            ^^^^^^^^^^^^^^^^^  ---------------- SeqCst failure ordering
    |                            |
    |                            Release success ordering
-   |
-   = help: consider using SeqCst success ordering instead
+   |                            help: consider using SeqCst success ordering instead
 
 error: fetch_update's success ordering must be at least as strong as its failure ordering
   --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:50:28
@@ -106,8 +104,7 @@ LL |     let _ = x.fetch_update(Ordering::Relaxed, Ordering::SeqCst, |old| Some(
    |                            ^^^^^^^^^^^^^^^^^  ---------------- SeqCst failure ordering
    |                            |
    |                            Relaxed success ordering
-   |
-   = help: consider using SeqCst success ordering instead
+   |                            help: consider using SeqCst success ordering instead
 
 error: fetch_update's success ordering must be at least as strong as its failure ordering
   --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:52:28
@@ -116,8 +113,7 @@ LL |     let _ = x.fetch_update(Ordering::Relaxed, Ordering::Acquire, |old| Some
    |                            ^^^^^^^^^^^^^^^^^  ----------------- Acquire failure ordering
    |                            |
    |                            Relaxed success ordering
-   |
-   = help: consider using Acquire success ordering instead
+   |                            help: consider using Acquire success ordering instead
 
 error: fetch_update's success ordering must be at least as strong as its failure ordering
   --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:56:28
@@ -126,8 +122,7 @@ LL |     let _ = x.fetch_update(Ordering::Acquire, Ordering::SeqCst, |old| Some(
    |                            ^^^^^^^^^^^^^^^^^  ---------------- SeqCst failure ordering
    |                            |
    |                            Acquire success ordering
-   |
-   = help: consider using SeqCst success ordering instead
+   |                            help: consider using SeqCst success ordering instead
 
 error: fetch_update's success ordering must be at least as strong as its failure ordering
   --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:58:28
@@ -136,8 +131,7 @@ LL |     let _ = x.fetch_update(Ordering::AcqRel, Ordering::SeqCst, |old| Some(o
    |                            ^^^^^^^^^^^^^^^^  ---------------- SeqCst failure ordering
    |                            |
    |                            AcqRel success ordering
-   |
-   = help: consider using SeqCst success ordering instead
+   |                            help: consider using SeqCst success ordering instead
 
 error: aborting due to 16 previous errors
 

--- a/src/test/ui/lint/lint-invalid-atomic-ordering-fetch-update.stderr
+++ b/src/test/ui/lint/lint-invalid-atomic-ordering-fetch-update.stderr
@@ -1,131 +1,143 @@
-error: fetch_update's failure ordering may not be `Release` or `AcqRel`
+error: fetch_update's failure ordering may not be `Release` or `AcqRel`, since a failed fetch_update does not result in a write
   --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:20:47
    |
 LL |     let _ = x.fetch_update(Ordering::Relaxed, Ordering::AcqRel, |old| Some(old + 1));
-   |                                               ^^^^^^^^^^^^^^^^
+   |                                               ^^^^^^^^^^^^^^^^ invalid failure ordering
    |
    = note: `#[deny(invalid_atomic_ordering)]` on by default
-   = help: consider using ordering mode `Relaxed` instead
+   = help: consider using Acquire or Relaxed failure ordering instead
 
-error: fetch_update's failure ordering may not be `Release` or `AcqRel`
+error: fetch_update's failure ordering may not be `Release` or `AcqRel`, since a failed fetch_update does not result in a write
   --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:22:47
    |
 LL |     let _ = x.fetch_update(Ordering::Acquire, Ordering::AcqRel, |old| Some(old + 1));
-   |                                               ^^^^^^^^^^^^^^^^
+   |                                               ^^^^^^^^^^^^^^^^ invalid failure ordering
    |
-   = help: consider using ordering modes `Acquire` or `Relaxed` instead
+   = help: consider using Acquire or Relaxed failure ordering instead
 
-error: fetch_update's failure ordering may not be `Release` or `AcqRel`
+error: fetch_update's failure ordering may not be `Release` or `AcqRel`, since a failed fetch_update does not result in a write
   --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:24:47
    |
 LL |     let _ = x.fetch_update(Ordering::Release, Ordering::AcqRel, |old| Some(old + 1));
-   |                                               ^^^^^^^^^^^^^^^^
+   |                                               ^^^^^^^^^^^^^^^^ invalid failure ordering
    |
-   = help: consider using ordering mode `Relaxed` instead
+   = help: consider using Acquire or Relaxed failure ordering instead
 
-error: fetch_update's failure ordering may not be `Release` or `AcqRel`
+error: fetch_update's failure ordering may not be `Release` or `AcqRel`, since a failed fetch_update does not result in a write
   --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:26:46
    |
 LL |     let _ = x.fetch_update(Ordering::AcqRel, Ordering::AcqRel, |old| Some(old + 1));
-   |                                              ^^^^^^^^^^^^^^^^
+   |                                              ^^^^^^^^^^^^^^^^ invalid failure ordering
    |
-   = help: consider using ordering modes `Acquire` or `Relaxed` instead
+   = help: consider using Acquire or Relaxed failure ordering instead
 
-error: fetch_update's failure ordering may not be `Release` or `AcqRel`
+error: fetch_update's failure ordering may not be `Release` or `AcqRel`, since a failed fetch_update does not result in a write
   --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:28:46
    |
 LL |     let _ = x.fetch_update(Ordering::SeqCst, Ordering::AcqRel, |old| Some(old + 1));
-   |                                              ^^^^^^^^^^^^^^^^
+   |                                              ^^^^^^^^^^^^^^^^ invalid failure ordering
    |
-   = help: consider using ordering modes `Acquire`, `SeqCst` or `Relaxed` instead
+   = help: consider using Acquire or Relaxed failure ordering instead
 
-error: fetch_update's failure ordering may not be `Release` or `AcqRel`
+error: fetch_update's failure ordering may not be `Release` or `AcqRel`, since a failed fetch_update does not result in a write
   --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:32:47
    |
 LL |     let _ = x.fetch_update(Ordering::Relaxed, Ordering::Release, |old| Some(old + 1));
-   |                                               ^^^^^^^^^^^^^^^^^
+   |                                               ^^^^^^^^^^^^^^^^^ invalid failure ordering
    |
-   = help: consider using ordering mode `Relaxed` instead
+   = help: consider using Acquire or Relaxed failure ordering instead
 
-error: fetch_update's failure ordering may not be `Release` or `AcqRel`
+error: fetch_update's failure ordering may not be `Release` or `AcqRel`, since a failed fetch_update does not result in a write
   --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:34:47
    |
 LL |     let _ = x.fetch_update(Ordering::Acquire, Ordering::Release, |old| Some(old + 1));
-   |                                               ^^^^^^^^^^^^^^^^^
+   |                                               ^^^^^^^^^^^^^^^^^ invalid failure ordering
    |
-   = help: consider using ordering modes `Acquire` or `Relaxed` instead
+   = help: consider using Acquire or Relaxed failure ordering instead
 
-error: fetch_update's failure ordering may not be `Release` or `AcqRel`
+error: fetch_update's failure ordering may not be `Release` or `AcqRel`, since a failed fetch_update does not result in a write
   --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:36:47
    |
 LL |     let _ = x.fetch_update(Ordering::Release, Ordering::Release, |old| Some(old + 1));
-   |                                               ^^^^^^^^^^^^^^^^^
+   |                                               ^^^^^^^^^^^^^^^^^ invalid failure ordering
    |
-   = help: consider using ordering mode `Relaxed` instead
+   = help: consider using Acquire or Relaxed failure ordering instead
 
-error: fetch_update's failure ordering may not be `Release` or `AcqRel`
+error: fetch_update's failure ordering may not be `Release` or `AcqRel`, since a failed fetch_update does not result in a write
   --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:38:46
    |
 LL |     let _ = x.fetch_update(Ordering::AcqRel, Ordering::Release, |old| Some(old + 1));
-   |                                              ^^^^^^^^^^^^^^^^^
+   |                                              ^^^^^^^^^^^^^^^^^ invalid failure ordering
    |
-   = help: consider using ordering modes `Acquire` or `Relaxed` instead
+   = help: consider using Acquire or Relaxed failure ordering instead
 
-error: fetch_update's failure ordering may not be `Release` or `AcqRel`
+error: fetch_update's failure ordering may not be `Release` or `AcqRel`, since a failed fetch_update does not result in a write
   --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:40:46
    |
 LL |     let _ = x.fetch_update(Ordering::SeqCst, Ordering::Release, |old| Some(old + 1));
-   |                                              ^^^^^^^^^^^^^^^^^
+   |                                              ^^^^^^^^^^^^^^^^^ invalid failure ordering
    |
-   = help: consider using ordering modes `Acquire`, `SeqCst` or `Relaxed` instead
+   = help: consider using Acquire or Relaxed failure ordering instead
 
-error: fetch_update's failure ordering may not be stronger than the success ordering of `Release`
-  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:44:47
+error: fetch_update's success ordering must be at least as strong as its failure ordering
+  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:44:28
    |
 LL |     let _ = x.fetch_update(Ordering::Release, Ordering::Acquire, |old| Some(old + 1));
-   |                                               ^^^^^^^^^^^^^^^^^
+   |                            ^^^^^^^^^^^^^^^^^  ----------------- Acquire failure ordering
+   |                            |
+   |                            Release success ordering
    |
-   = help: consider using ordering mode `Relaxed` instead
+   = help: consider using AcqRel success ordering instead
 
-error: fetch_update's failure ordering may not be stronger than the success ordering of `Release`
-  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:46:47
+error: fetch_update's success ordering must be at least as strong as its failure ordering
+  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:46:28
    |
 LL |     let _ = x.fetch_update(Ordering::Release, Ordering::SeqCst, |old| Some(old + 1));
-   |                                               ^^^^^^^^^^^^^^^^
+   |                            ^^^^^^^^^^^^^^^^^  ---------------- SeqCst failure ordering
+   |                            |
+   |                            Release success ordering
    |
-   = help: consider using ordering mode `Relaxed` instead
+   = help: consider using SeqCst success ordering instead
 
-error: fetch_update's failure ordering may not be stronger than the success ordering of `Relaxed`
-  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:50:47
+error: fetch_update's success ordering must be at least as strong as its failure ordering
+  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:50:28
    |
 LL |     let _ = x.fetch_update(Ordering::Relaxed, Ordering::SeqCst, |old| Some(old + 1));
-   |                                               ^^^^^^^^^^^^^^^^
+   |                            ^^^^^^^^^^^^^^^^^  ---------------- SeqCst failure ordering
+   |                            |
+   |                            Relaxed success ordering
    |
-   = help: consider using ordering mode `Relaxed` instead
+   = help: consider using SeqCst success ordering instead
 
-error: fetch_update's failure ordering may not be stronger than the success ordering of `Relaxed`
-  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:52:47
+error: fetch_update's success ordering must be at least as strong as its failure ordering
+  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:52:28
    |
 LL |     let _ = x.fetch_update(Ordering::Relaxed, Ordering::Acquire, |old| Some(old + 1));
-   |                                               ^^^^^^^^^^^^^^^^^
+   |                            ^^^^^^^^^^^^^^^^^  ----------------- Acquire failure ordering
+   |                            |
+   |                            Relaxed success ordering
    |
-   = help: consider using ordering mode `Relaxed` instead
+   = help: consider using Acquire success ordering instead
 
-error: fetch_update's failure ordering may not be stronger than the success ordering of `Acquire`
-  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:56:47
+error: fetch_update's success ordering must be at least as strong as its failure ordering
+  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:56:28
    |
 LL |     let _ = x.fetch_update(Ordering::Acquire, Ordering::SeqCst, |old| Some(old + 1));
-   |                                               ^^^^^^^^^^^^^^^^
+   |                            ^^^^^^^^^^^^^^^^^  ---------------- SeqCst failure ordering
+   |                            |
+   |                            Acquire success ordering
    |
-   = help: consider using ordering modes `Acquire` or `Relaxed` instead
+   = help: consider using SeqCst success ordering instead
 
-error: fetch_update's failure ordering may not be stronger than the success ordering of `AcqRel`
-  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:58:46
+error: fetch_update's success ordering must be at least as strong as its failure ordering
+  --> $DIR/lint-invalid-atomic-ordering-fetch-update.rs:58:28
    |
 LL |     let _ = x.fetch_update(Ordering::AcqRel, Ordering::SeqCst, |old| Some(old + 1));
-   |                                              ^^^^^^^^^^^^^^^^
+   |                            ^^^^^^^^^^^^^^^^  ---------------- SeqCst failure ordering
+   |                            |
+   |                            AcqRel success ordering
    |
-   = help: consider using ordering modes `Acquire` or `Relaxed` instead
+   = help: consider using SeqCst success ordering instead
 
 error: aborting due to 16 previous errors
 


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/783247/170234545-891cac30-eaa2-4186-847b-35cd51e00f2b.png)

After:

![image](https://user-images.githubusercontent.com/783247/170239684-645f186f-5a02-4eb9-8651-2e5fe9591352.png)

---

Before this change, the compiler suggests the failure ordering is too strong and suggests choosing a weaker ordering. After this change, it instead suggests the success ordering is not strong enough, and suggests chosing a stronger one. This is more likely to be correct.

Also, before this change, the compiler suggested downgrading an invalid AcqRel failure ordering to Relaxed, without mentioning Acquire as an option.