### PR TITLE
Separate object lifetime default from lifetime resolution

### DIFF
--- a/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/find_anon_type.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/find_anon_type.rs
@@ -120,7 +120,7 @@ impl<'tcx> Visitor<'tcx> for FindNestedTypeVisitor<'tcx> {
                     // Find the index of the named region that was part of the
                     // error. We will then search the function parameters for a bound
                     // region at the right depth with the same index
-                    (Some(rl::Region::EarlyBound(_, id)), ty::BrNamed(def_id, _)) => {
+                    (Some(rl::Region::EarlyBound(id)), ty::BrNamed(def_id, _)) => {
                         debug!("EarlyBound id={:?} def_id={:?}", id, def_id);
                         if id == def_id {
                             self.found_type = Some(arg);
@@ -150,7 +150,7 @@ impl<'tcx> Visitor<'tcx> for FindNestedTypeVisitor<'tcx> {
                         Some(
                             rl::Region::Static
                             | rl::Region::Free(_, _)
-                            | rl::Region::EarlyBound(_, _)
+                            | rl::Region::EarlyBound(_)
                             | rl::Region::LateBound(_, _, _)
                             | rl::Region::LateBoundAnon(_, _, _),
                         )
@@ -216,7 +216,7 @@ impl<'tcx> Visitor<'tcx> for TyPathVisitor<'tcx> {
                 }
             }
 
-            (Some(rl::Region::EarlyBound(_, id)), ty::BrNamed(def_id, _)) => {
+            (Some(rl::Region::EarlyBound(id)), ty::BrNamed(def_id, _)) => {
                 debug!("EarlyBound id={:?} def_id={:?}", id, def_id);
                 if id == def_id {
                     self.found_it = true;
@@ -237,7 +237,7 @@ impl<'tcx> Visitor<'tcx> for TyPathVisitor<'tcx> {
             (
                 Some(
                     rl::Region::Static
-                    | rl::Region::EarlyBound(_, _)
+                    | rl::Region::EarlyBound(_)
                     | rl::Region::LateBound(_, _, _)
                     | rl::Region::LateBoundAnon(_, _, _)
                     | rl::Region::Free(_, _),

--- a/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
@@ -199,6 +199,7 @@ provide! { <'tcx> tcx, def_id, other, cdata,
     codegen_fn_attrs => { table }
     impl_trait_ref => { table }
     const_param_default => { table }
+    object_lifetime_default => { table }
     thir_abstract_const => { table }
     optimized_mir => { table }
     mir_for_ctfe => { table }

--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -1035,6 +1035,11 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
                     record_array!(self.tables.inferred_outlives_of[def_id] <- inferred_outlives);
                 }
             }
+            if let DefKind::TyParam | DefKind::ConstParam = def_kind {
+                if let Some(default) = self.tcx.object_lifetime_default(def_id) {
+                    record!(self.tables.object_lifetime_default[def_id] <- default);
+                }
+            }
             if let DefKind::Trait | DefKind::TraitAlias = def_kind {
                 record!(self.tables.super_predicates_of[def_id] <- self.tcx.super_predicates_of(def_id));
             }

--- a/compiler/rustc_metadata/src/rmeta/mod.rs
+++ b/compiler/rustc_metadata/src/rmeta/mod.rs
@@ -16,6 +16,7 @@ use rustc_index::{bit_set::FiniteBitSet, vec::IndexVec};
 use rustc_middle::metadata::ModChild;
 use rustc_middle::middle::codegen_fn_attrs::CodegenFnAttrs;
 use rustc_middle::middle::exported_symbols::{ExportedSymbol, SymbolExportInfo};
+use rustc_middle::middle::resolve_lifetime::ObjectLifetimeDefault;
 use rustc_middle::mir;
 use rustc_middle::thir;
 use rustc_middle::ty::fast_reject::SimplifiedType;
@@ -357,6 +358,7 @@ define_tables! {
     codegen_fn_attrs: Table<DefIndex, LazyValue<CodegenFnAttrs>>,
     impl_trait_ref: Table<DefIndex, LazyValue<ty::TraitRef<'static>>>,
     const_param_default: Table<DefIndex, LazyValue<rustc_middle::ty::Const<'static>>>,
+    object_lifetime_default: Table<DefIndex, LazyValue<ObjectLifetimeDefault>>,
     optimized_mir: Table<DefIndex, LazyValue<mir::Body<'static>>>,
     mir_for_ctfe: Table<DefIndex, LazyValue<mir::Body<'static>>>,
     promoted_mir: Table<DefIndex, LazyValue<IndexVec<mir::Promoted, mir::Body<'static>>>>,

--- a/compiler/rustc_middle/src/hir/map/mod.rs
+++ b/compiler/rustc_middle/src/hir/map/mod.rs
@@ -546,7 +546,9 @@ impl<'hir> Map<'hir> {
         let def_kind = self.tcx.def_kind(def_id);
         match def_kind {
             DefKind::Trait | DefKind::TraitAlias => def_id,
-            DefKind::TyParam | DefKind::ConstParam => self.tcx.local_parent(def_id),
+            DefKind::TyParam | DefKind::ConstParam | DefKind::LifetimeParam => {
+                self.tcx.local_parent(def_id)
+            }
             _ => bug!("ty_param_owner: {:?} is a {:?} not a type parameter", def_id, def_kind),
         }
     }
@@ -555,7 +557,9 @@ impl<'hir> Map<'hir> {
         let def_kind = self.tcx.def_kind(def_id);
         match def_kind {
             DefKind::Trait | DefKind::TraitAlias => kw::SelfUpper,
-            DefKind::TyParam | DefKind::ConstParam => self.tcx.item_name(def_id.to_def_id()),
+            DefKind::TyParam | DefKind::ConstParam | DefKind::LifetimeParam => {
+                self.tcx.item_name(def_id.to_def_id())
+            }
             _ => bug!("ty_param_name: {:?} is a {:?} not a type parameter", def_id, def_kind),
         }
     }

--- a/compiler/rustc_middle/src/middle/resolve_lifetime.rs
+++ b/compiler/rustc_middle/src/middle/resolve_lifetime.rs
@@ -50,7 +50,13 @@ impl<T: PartialEq> Set1<T> {
     }
 }
 
-pub type ObjectLifetimeDefault = Set1<Region>;
+#[derive(Copy, Clone, Debug, HashStable, Encodable, Decodable)]
+pub enum ObjectLifetimeDefault {
+    Empty,
+    Static,
+    Ambiguous,
+    Param(DefId),
+}
 
 /// Maps the id of each lifetime reference to the lifetime decl
 /// that it corresponds to.

--- a/compiler/rustc_middle/src/middle/resolve_lifetime.rs
+++ b/compiler/rustc_middle/src/middle/resolve_lifetime.rs
@@ -10,7 +10,7 @@ use rustc_macros::HashStable;
 #[derive(Clone, Copy, PartialEq, Eq, Hash, TyEncodable, TyDecodable, Debug, HashStable)]
 pub enum Region {
     Static,
-    EarlyBound(/* index */ u32, /* lifetime decl */ DefId),
+    EarlyBound(/* lifetime decl */ DefId),
     LateBound(ty::DebruijnIndex, /* late-bound index */ u32, /* lifetime decl */ DefId),
     LateBoundAnon(ty::DebruijnIndex, /* late-bound index */ u32, /* anon index */ u32),
     Free(DefId, /* lifetime decl */ DefId),

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -1591,7 +1591,7 @@ rustc_queries! {
     /// for each parameter if a trait object were to be passed for that parameter.
     /// For example, for `struct Foo<'a, T, U>`, this would be `['static, 'static]`.
     /// For `struct Foo<'a, T: 'a, U>`, this would instead be `['a, 'static]`.
-    query object_lifetime_defaults(_: LocalDefId) -> Option<&'tcx [ObjectLifetimeDefault]> {
+    query object_lifetime_defaults(_: DefId) -> Option<&'tcx [ObjectLifetimeDefault]> {
         desc { "looking up lifetime defaults for a region on an item" }
     }
     query late_bound_vars_map(_: LocalDefId)

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -1591,7 +1591,7 @@ rustc_queries! {
     /// for each parameter if a trait object were to be passed for that parameter.
     /// For example, for `struct Foo<'a, T, U>`, this would be `['static, 'static]`.
     /// For `struct Foo<'a, T: 'a, U>`, this would instead be `['a, 'static]`.
-    query object_lifetime_defaults(_: DefId) -> Option<&'tcx [ObjectLifetimeDefault]> {
+    query object_lifetime_defaults(_: LocalDefId) -> Option<&'tcx [ObjectLifetimeDefault]> {
         desc { "looking up lifetime defaults for a region on an item" }
     }
     /// Fetch the lifetimes for all the trait objects in an item-like.

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -1594,6 +1594,11 @@ rustc_queries! {
     query object_lifetime_defaults(_: DefId) -> Option<&'tcx [ObjectLifetimeDefault]> {
         desc { "looking up lifetime defaults for a region on an item" }
     }
+    /// Fetch the lifetimes for all the trait objects in an item-like.
+    query object_lifetime_map(_: LocalDefId) -> FxHashMap<ItemLocalId, Region> {
+        storage(ArenaCacheSelector<'tcx>)
+        desc { "looking up lifetime defaults for a region on an item" }
+    }
     query late_bound_vars_map(_: LocalDefId)
         -> Option<&'tcx FxHashMap<ItemLocalId, Vec<ty::BoundVariableKind>>> {
         desc { "looking up late bound vars" }

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -1591,8 +1591,9 @@ rustc_queries! {
     /// for each parameter if a trait object were to be passed for that parameter.
     /// For example, for `struct Foo<'a, T, U>`, this would be `['static, 'static]`.
     /// For `struct Foo<'a, T: 'a, U>`, this would instead be `['a, 'static]`.
-    query object_lifetime_defaults(_: LocalDefId) -> Option<&'tcx [ObjectLifetimeDefault]> {
+    query object_lifetime_default(_: DefId) -> Option<ObjectLifetimeDefault> {
         desc { "looking up lifetime defaults for a region on an item" }
+        separate_provide_extern
     }
     /// Fetch the lifetimes for all the trait objects in an item-like.
     query object_lifetime_map(_: LocalDefId) -> FxHashMap<ItemLocalId, ty::Region<'tcx>> {

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -1595,7 +1595,7 @@ rustc_queries! {
         desc { "looking up lifetime defaults for a region on an item" }
     }
     /// Fetch the lifetimes for all the trait objects in an item-like.
-    query object_lifetime_map(_: LocalDefId) -> FxHashMap<ItemLocalId, Region> {
+    query object_lifetime_map(_: LocalDefId) -> FxHashMap<ItemLocalId, ty::Region<'tcx>> {
         storage(ArenaCacheSelector<'tcx>)
         desc { "looking up lifetime defaults for a region on an item" }
     }

--- a/compiler/rustc_middle/src/ty/generics.rs
+++ b/compiler/rustc_middle/src/ty/generics.rs
@@ -1,4 +1,3 @@
-use crate::middle::resolve_lifetime::ObjectLifetimeDefault;
 use crate::ty;
 use crate::ty::subst::{Subst, SubstsRef};
 use crate::ty::EarlyBinder;
@@ -13,7 +12,7 @@ use super::{EarlyBoundRegion, InstantiatedPredicates, ParamConst, ParamTy, Predi
 #[derive(Clone, Debug, TyEncodable, TyDecodable, HashStable)]
 pub enum GenericParamDefKind {
     Lifetime,
-    Type { has_default: bool, object_lifetime_default: ObjectLifetimeDefault, synthetic: bool },
+    Type { has_default: bool, synthetic: bool },
     Const { has_default: bool },
 }
 

--- a/compiler/rustc_middle/src/ty/parameterized.rs
+++ b/compiler/rustc_middle/src/ty/parameterized.rs
@@ -53,6 +53,7 @@ trivially_parameterized_over_tcx! {
     crate::metadata::ModChild,
     crate::middle::codegen_fn_attrs::CodegenFnAttrs,
     crate::middle::exported_symbols::SymbolExportInfo,
+    crate::middle::resolve_lifetime::ObjectLifetimeDefault,
     crate::mir::ConstQualifs,
     ty::Generics,
     ty::ImplPolarity,

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -16,6 +16,7 @@ use rustc_hir::intravisit::{self, Visitor};
 use rustc_hir::{self, FnSig, ForeignItem, HirId, Item, ItemKind, TraitItem, CRATE_HIR_ID};
 use rustc_hir::{MethodKind, Target};
 use rustc_middle::hir::nested_filter;
+use rustc_middle::middle::resolve_lifetime::ObjectLifetimeDefault;
 use rustc_middle::ty::query::Providers;
 use rustc_middle::ty::TyCtxt;
 use rustc_session::lint::builtin::{
@@ -163,6 +164,9 @@ impl CheckAttrVisitor<'_> {
                 }
                 sym::no_implicit_prelude => {
                     self.check_generic_attr(hir_id, attr, target, &[Target::Mod])
+                }
+                sym::rustc_object_lifetime_default => {
+                    self.check_object_lifetime_default(hir_id, span)
                 }
                 _ => {}
             }
@@ -365,6 +369,30 @@ impl CheckAttrVisitor<'_> {
                     .emit();
                 false
             }
+        }
+    }
+
+    /// Debugging aid for `object_lifetime_default` query.
+    fn check_object_lifetime_default(&self, hir_id: HirId, span: Span) {
+        let tcx = self.tcx;
+        if let Some(generics) = tcx.hir().get_generics(tcx.hir().local_def_id(hir_id)) {
+            let object_lifetime_default_reprs: String = generics
+                .params
+                .iter()
+                .filter_map(|p| {
+                    let param_id = tcx.hir().local_def_id(p.hir_id);
+                    let default = tcx.object_lifetime_default(param_id)?;
+                    Some(match default {
+                        ObjectLifetimeDefault::Empty => "BaseDefault".to_owned(),
+                        ObjectLifetimeDefault::Static => "'static".to_owned(),
+                        ObjectLifetimeDefault::Param(def_id) => tcx.item_name(def_id).to_string(),
+                        ObjectLifetimeDefault::Ambiguous => "Ambiguous".to_owned(),
+                    })
+                })
+                .collect::<Vec<String>>()
+                .join(",");
+
+            tcx.sess.span_err(span, &object_lifetime_default_reprs);
         }
     }
 

--- a/compiler/rustc_resolve/src/late/lifetimes.rs
+++ b/compiler/rustc_resolve/src/late/lifetimes.rs
@@ -20,12 +20,11 @@ use rustc_hir::{GenericParamKind, HirIdMap};
 use rustc_middle::hir::map::Map;
 use rustc_middle::hir::nested_filter;
 use rustc_middle::middle::resolve_lifetime::*;
-use rustc_middle::ty::{self, GenericParamDefKind, TyCtxt};
+use rustc_middle::ty::{self, TyCtxt};
 use rustc_middle::{bug, span_bug};
 use rustc_span::def_id::DefId;
 use rustc_span::symbol::{kw, sym, Ident};
 use rustc_span::Span;
-use std::borrow::Cow;
 use std::cell::Cell;
 use std::fmt;
 use std::mem::take;
@@ -44,10 +43,6 @@ trait RegionExt {
     fn shifted(self, amount: u32) -> Region;
 
     fn shifted_out_to_binder(self, binder: ty::DebruijnIndex) -> Region;
-
-    fn subst<'a, L>(self, params: L, map: &NamedRegionMap) -> Option<Region>
-    where
-        L: Iterator<Item = &'a hir::Lifetime>;
 }
 
 impl RegionExt for Region {
@@ -107,17 +102,6 @@ impl RegionExt for Region {
                 Region::LateBoundAnon(debruijn.shifted_out_to_binder(binder), index, anon_index)
             }
             _ => self,
-        }
-    }
-
-    fn subst<'a, L>(self, mut params: L, map: &NamedRegionMap) -> Option<Region>
-    where
-        L: Iterator<Item = &'a hir::Lifetime>,
-    {
-        if let Region::EarlyBound(index, _) = self {
-            params.nth(index as usize).and_then(|lifetime| map.defs.get(&lifetime.hir_id).cloned())
-        } else {
-            Some(self)
         }
     }
 }
@@ -222,14 +206,6 @@ enum Scope<'a> {
         s: ScopeRef<'a>,
     },
 
-    /// Use a specific lifetime (if `Some`) or leave it unset (to be
-    /// inferred in a function body or potentially error outside one),
-    /// for the default choice of lifetime in a trait object type.
-    ObjectLifetimeDefault {
-        lifetime: Option<Region>,
-        s: ScopeRef<'a>,
-    },
-
     /// When we have nested trait refs, we concatenate late bound vars for inner
     /// trait refs from outer ones. But we also need to include any HRTB
     /// lifetimes encountered when identifying the trait that an associated type
@@ -292,11 +268,6 @@ impl<'a> fmt::Debug for TruncatedScopeDebug<'a> {
             Scope::Elision { elide, s: _ } => {
                 f.debug_struct("Elision").field("elide", elide).field("s", &"..").finish()
             }
-            Scope::ObjectLifetimeDefault { lifetime, s: _ } => f
-                .debug_struct("ObjectLifetimeDefault")
-                .field("lifetime", lifetime)
-                .field("s", &"..")
-                .finish(),
             Scope::Supertrait { lifetimes, s: _ } => f
                 .debug_struct("Supertrait")
                 .field("lifetimes", lifetimes)
@@ -345,24 +316,6 @@ pub fn provide(providers: &mut ty::query::Providers) {
 
         named_region_map: |tcx, id| resolve_lifetimes_for(tcx, id).defs.get(&id),
         is_late_bound_map,
-        object_lifetime_defaults: |tcx, def_id| {
-            if let Some(def_id) = def_id.as_local() {
-                match tcx.hir().get_by_def_id(def_id) {
-                    Node::Item(item) => compute_object_lifetime_defaults(tcx, item),
-                    _ => None,
-                }
-            } else {
-                Some(tcx.arena.alloc_from_iter(tcx.generics_of(def_id).params.iter().filter_map(
-                    |param| match param.kind {
-                        GenericParamDefKind::Type { object_lifetime_default, .. } => {
-                            Some(object_lifetime_default)
-                        }
-                        GenericParamDefKind::Const { .. } => Some(Set1::Empty),
-                        GenericParamDefKind::Lifetime => None,
-                    },
-                )))
-            }
-        },
         late_bound_vars_map: |tcx, id| resolve_lifetimes_for(tcx, id).late_bound_vars.get(&id),
         lifetime_scope_map: |tcx, id| {
             let item_id = item_for(tcx, id);
@@ -544,9 +497,6 @@ fn get_lifetime_scopes_for_path(mut scope: &Scope<'_>) -> LifetimeScopeForPath {
                     scope = s;
                 }
             }
-            Scope::ObjectLifetimeDefault { s, .. } => {
-                scope = s;
-            }
             Scope::Root => {
                 return LifetimeScopeForPath::NonElided(available_lifetimes);
             }
@@ -568,7 +518,7 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
                     break (vec![], BinderScopeType::Normal);
                 }
 
-                Scope::Elision { s, .. } | Scope::ObjectLifetimeDefault { s, .. } => {
+                Scope::Elision { s, .. } => {
                     scope = s;
                 }
 
@@ -855,7 +805,6 @@ impl<'a, 'tcx> Visitor<'tcx> for LifetimeContext<'a, 'tcx> {
                         // use the object lifetime defaulting
                         // rules. So e.g., `Box<dyn Debug>` becomes
                         // `Box<dyn Debug + 'static>`.
-                        self.resolve_object_lifetime_default(lifetime)
                     }
                     LifetimeName::Underscore => {
                         // If the user writes `'_`, we use the *ordinary* elision
@@ -874,11 +823,7 @@ impl<'a, 'tcx> Visitor<'tcx> for LifetimeContext<'a, 'tcx> {
             }
             hir::TyKind::Rptr(ref lifetime_ref, ref mt) => {
                 self.visit_lifetime(lifetime_ref);
-                let scope = Scope::ObjectLifetimeDefault {
-                    lifetime: self.map.defs.get(&lifetime_ref.hir_id).cloned(),
-                    s: self.scope,
-                };
-                self.with(scope, |this| this.visit_ty(&mt.ty));
+                self.visit_ty(&mt.ty);
             }
             hir::TyKind::OpaqueDef(item_id, lifetimes) => {
                 // Resolve the lifetimes in the bounds to the lifetime defs in the generics.
@@ -1442,141 +1387,6 @@ impl<'a, 'tcx> Visitor<'tcx> for LifetimeContext<'a, 'tcx> {
     }
 }
 
-fn compute_object_lifetime_defaults<'tcx>(
-    tcx: TyCtxt<'tcx>,
-    item: &hir::Item<'_>,
-) -> Option<&'tcx [ObjectLifetimeDefault]> {
-    match item.kind {
-        hir::ItemKind::Struct(_, ref generics)
-        | hir::ItemKind::Union(_, ref generics)
-        | hir::ItemKind::Enum(_, ref generics)
-        | hir::ItemKind::OpaqueTy(hir::OpaqueTy {
-            ref generics,
-            origin: hir::OpaqueTyOrigin::TyAlias,
-            ..
-        })
-        | hir::ItemKind::TyAlias(_, ref generics)
-        | hir::ItemKind::Trait(_, _, ref generics, ..) => {
-            let result = object_lifetime_defaults_for_item(tcx, generics);
-
-            // Debugging aid.
-            let attrs = tcx.hir().attrs(item.hir_id());
-            if tcx.sess.contains_name(attrs, sym::rustc_object_lifetime_default) {
-                let object_lifetime_default_reprs: String = result
-                    .iter()
-                    .map(|set| match *set {
-                        Set1::Empty => "BaseDefault".into(),
-                        Set1::One(Region::Static) => "'static".into(),
-                        Set1::One(Region::EarlyBound(mut i, _)) => generics
-                            .params
-                            .iter()
-                            .find_map(|param| match param.kind {
-                                GenericParamKind::Lifetime { .. } => {
-                                    if i == 0 {
-                                        return Some(param.name.ident().to_string().into());
-                                    }
-                                    i -= 1;
-                                    None
-                                }
-                                _ => None,
-                            })
-                            .unwrap(),
-                        Set1::One(_) => bug!(),
-                        Set1::Many => "Ambiguous".into(),
-                    })
-                    .collect::<Vec<Cow<'static, str>>>()
-                    .join(",");
-                tcx.sess.span_err(item.span, &object_lifetime_default_reprs);
-            }
-
-            Some(result)
-        }
-        _ => None,
-    }
-}
-
-/// Scan the bounds and where-clauses on parameters to extract bounds
-/// of the form `T:'a` so as to determine the `ObjectLifetimeDefault`
-/// for each type parameter.
-fn object_lifetime_defaults_for_item<'tcx>(
-    tcx: TyCtxt<'tcx>,
-    generics: &hir::Generics<'_>,
-) -> &'tcx [ObjectLifetimeDefault] {
-    fn add_bounds(set: &mut Set1<hir::LifetimeName>, bounds: &[hir::GenericBound<'_>]) {
-        for bound in bounds {
-            if let hir::GenericBound::Outlives(ref lifetime) = *bound {
-                set.insert(lifetime.name.normalize_to_macros_2_0());
-            }
-        }
-    }
-
-    let process_param = |param: &hir::GenericParam<'_>| match param.kind {
-        GenericParamKind::Lifetime { .. } => None,
-        GenericParamKind::Type { .. } => {
-            let mut set = Set1::Empty;
-
-            let param_def_id = tcx.hir().local_def_id(param.hir_id);
-            for predicate in generics.predicates {
-                // Look for `type: ...` where clauses.
-                let hir::WherePredicate::BoundPredicate(ref data) = *predicate else { continue };
-
-                // Ignore `for<'a> type: ...` as they can change what
-                // lifetimes mean (although we could "just" handle it).
-                if !data.bound_generic_params.is_empty() {
-                    continue;
-                }
-
-                let res = match data.bounded_ty.kind {
-                    hir::TyKind::Path(hir::QPath::Resolved(None, ref path)) => path.res,
-                    _ => continue,
-                };
-
-                if res == Res::Def(DefKind::TyParam, param_def_id.to_def_id()) {
-                    add_bounds(&mut set, &data.bounds);
-                }
-            }
-
-            Some(match set {
-                Set1::Empty => Set1::Empty,
-                Set1::One(name) => {
-                    if name == hir::LifetimeName::Static {
-                        Set1::One(Region::Static)
-                    } else {
-                        generics
-                            .params
-                            .iter()
-                            .filter_map(|param| match param.kind {
-                                GenericParamKind::Lifetime { .. } => {
-                                    let param_def_id = tcx.hir().local_def_id(param.hir_id);
-                                    Some((
-                                        param_def_id,
-                                        hir::LifetimeName::Param(param_def_id, param.name),
-                                    ))
-                                }
-                                _ => None,
-                            })
-                            .enumerate()
-                            .find(|&(_, (_, lt_name))| lt_name == name)
-                            .map_or(Set1::Many, |(i, (def_id, _))| {
-                                Set1::One(Region::EarlyBound(i as u32, def_id.to_def_id()))
-                            })
-                    }
-                }
-                Set1::Many => Set1::Many,
-            })
-        }
-        GenericParamKind::Const { .. } => {
-            // Generic consts don't impose any constraints.
-            //
-            // We still store a dummy value here to allow generic parameters
-            // in an arbitrary order.
-            Some(Set1::Empty)
-        }
-    };
-
-    tcx.arena.alloc_from_iter(generics.params.iter().filter_map(process_param))
-}
-
 impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
     fn with<F>(&mut self, wrap_scope: Scope<'_>, f: F)
     where
@@ -1706,7 +1516,6 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
                 Scope::Binder { s, .. }
                 | Scope::Body { s, .. }
                 | Scope::Elision { s, .. }
-                | Scope::ObjectLifetimeDefault { s, .. }
                 | Scope::Supertrait { s, .. }
                 | Scope::TraitRefBoundary { s, .. } => scope = s,
             }
@@ -1763,7 +1572,6 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
                 }
 
                 Scope::Elision { s, .. }
-                | Scope::ObjectLifetimeDefault { s, .. }
                 | Scope::Supertrait { s, .. }
                 | Scope::TraitRefBoundary { s, .. } => {
                     scope = s;
@@ -1857,138 +1665,29 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
         };
 
         debug!("visit_segment_args: type_def_id={:?}", type_def_id);
-
-        // Compute a vector of defaults, one for each type parameter,
-        // per the rules given in RFCs 599 and 1156. Example:
-        //
-        // ```rust
-        // struct Foo<'a, T: 'a, U> { }
-        // ```
-        //
-        // If you have `Foo<'x, dyn Bar, dyn Baz>`, we want to default
-        // `dyn Bar` to `dyn Bar + 'x` (because of the `T: 'a` bound)
-        // and `dyn Baz` to `dyn Baz + 'static` (because there is no
-        // such bound).
-        //
-        // Therefore, we would compute `object_lifetime_defaults` to a
-        // vector like `['x, 'static]`. Note that the vector only
-        // includes type parameters.
-        let object_lifetime_defaults = type_def_id.map_or_else(Vec::new, |def_id| {
-            let in_body = {
-                let mut scope = self.scope;
-                loop {
-                    match *scope {
-                        Scope::Root => break false,
-
-                        Scope::Body { .. } => break true,
-
-                        Scope::Binder { s, .. }
-                        | Scope::Elision { s, .. }
-                        | Scope::ObjectLifetimeDefault { s, .. }
-                        | Scope::Supertrait { s, .. }
-                        | Scope::TraitRefBoundary { s, .. } => {
-                            scope = s;
-                        }
-                    }
-                }
-            };
-
-            let map = &self.map;
-            let set_to_region = |set: &ObjectLifetimeDefault| match *set {
-                Set1::Empty => {
-                    if in_body {
-                        None
-                    } else {
-                        Some(Region::Static)
-                    }
-                }
-                Set1::One(r) => {
-                    let lifetimes = generic_args.args.iter().filter_map(|arg| match arg {
-                        GenericArg::Lifetime(lt) => Some(lt),
-                        _ => None,
-                    });
-                    r.subst(lifetimes, map)
-                }
-                Set1::Many => None,
-            };
-            self.tcx.object_lifetime_defaults(def_id).unwrap().iter().map(set_to_region).collect()
-        });
-
-        debug!("visit_segment_args: object_lifetime_defaults={:?}", object_lifetime_defaults);
-
-        let mut i = 0;
         for arg in generic_args.args {
             match arg {
                 GenericArg::Lifetime(_) => {}
-                GenericArg::Type(ty) => {
-                    if let Some(&lt) = object_lifetime_defaults.get(i) {
-                        let scope = Scope::ObjectLifetimeDefault { lifetime: lt, s: self.scope };
-                        self.with(scope, |this| this.visit_ty(ty));
-                    } else {
-                        self.visit_ty(ty);
-                    }
-                    i += 1;
-                }
-                GenericArg::Const(ct) => {
-                    self.visit_anon_const(&ct.value);
-                    i += 1;
-                }
-                GenericArg::Infer(inf) => {
-                    self.visit_id(inf.hir_id);
-                    i += 1;
-                }
+                GenericArg::Type(ty) => self.visit_ty(ty),
+                GenericArg::Const(ct) => self.visit_anon_const(&ct.value),
+                GenericArg::Infer(inf) => self.visit_id(inf.hir_id),
             }
         }
-
-        // Hack: when resolving the type `XX` in binding like `dyn
-        // Foo<'b, Item = XX>`, the current object-lifetime default
-        // would be to examine the trait `Foo` to check whether it has
-        // a lifetime bound declared on `Item`. e.g., if `Foo` is
-        // declared like so, then the default object lifetime bound in
-        // `XX` should be `'b`:
-        //
-        // ```rust
-        // trait Foo<'a> {
-        //   type Item: 'a;
-        // }
-        // ```
-        //
-        // but if we just have `type Item;`, then it would be
-        // `'static`. However, we don't get all of this logic correct.
-        //
-        // Instead, we do something hacky: if there are no lifetime parameters
-        // to the trait, then we simply use a default object lifetime
-        // bound of `'static`, because there is no other possibility. On the other hand,
-        // if there ARE lifetime parameters, then we require the user to give an
-        // explicit bound for now.
-        //
-        // This is intended to leave room for us to implement the
-        // correct behavior in the future.
-        let has_lifetime_parameter =
-            generic_args.args.iter().any(|arg| matches!(arg, GenericArg::Lifetime(_)));
 
         // Resolve lifetimes found in the bindings, so either in the type `XX` in `Item = XX` or
         // in the trait ref `YY<...>` in `Item: YY<...>`.
         for binding in generic_args.bindings {
-            let scope = Scope::ObjectLifetimeDefault {
-                lifetime: if has_lifetime_parameter { None } else { Some(Region::Static) },
-                s: self.scope,
-            };
             if let Some(type_def_id) = type_def_id {
                 let lifetimes = LifetimeContext::supertrait_hrtb_lifetimes(
                     self.tcx,
                     type_def_id,
                     binding.ident,
                 );
-                self.with(scope, |this| {
-                    let scope = Scope::Supertrait {
-                        lifetimes: lifetimes.unwrap_or_default(),
-                        s: this.scope,
-                    };
-                    this.with(scope, |this| this.visit_assoc_type_binding(binding));
-                });
-            } else {
+                let scope =
+                    Scope::Supertrait { lifetimes: lifetimes.unwrap_or_default(), s: self.scope };
                 self.with(scope, |this| this.visit_assoc_type_binding(binding));
+            } else {
+                self.visit_assoc_type_binding(binding);
             }
         }
     }
@@ -2069,8 +1768,7 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
                 Scope::Binder { hir_id, allow_late_bound: true, .. } => {
                     break *hir_id;
                 }
-                Scope::ObjectLifetimeDefault { ref s, .. }
-                | Scope::Elision { ref s, .. }
+                Scope::Elision { ref s, .. }
                 | Scope::Supertrait { ref s, .. }
                 | Scope::TraitRefBoundary { ref s, .. } => {
                     scope = *s;
@@ -2449,8 +2147,7 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
                                 in_scope_lifetimes.extend(lifetimes.keys().copied());
                                 scope = s;
                             }
-                            Scope::ObjectLifetimeDefault { ref s, .. }
-                            | Scope::Elision { ref s, .. }
+                            Scope::Elision { ref s, .. }
                             | Scope::TraitRefBoundary { ref s, .. } => {
                                 scope = s;
                             }
@@ -2462,9 +2159,7 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
 
                 Scope::Elision { elide: Elide::Forbid, .. } => break None,
 
-                Scope::ObjectLifetimeDefault { s, .. }
-                | Scope::Supertrait { s, .. }
-                | Scope::TraitRefBoundary { s, .. } => {
+                Scope::Supertrait { s, .. } | Scope::TraitRefBoundary { s, .. } => {
                     scope = s;
                 }
             }
@@ -2498,34 +2193,6 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
             error,
         );
         err.emit();
-    }
-
-    fn resolve_object_lifetime_default(&mut self, lifetime_ref: &'tcx hir::Lifetime) {
-        debug!("resolve_object_lifetime_default(lifetime_ref={:?})", lifetime_ref);
-        let mut late_depth = 0;
-        let mut scope = self.scope;
-        let lifetime = loop {
-            match *scope {
-                Scope::Binder { s, scope_type, .. } => {
-                    match scope_type {
-                        BinderScopeType::Normal => late_depth += 1,
-                        BinderScopeType::Concatenating => {}
-                    }
-                    scope = s;
-                }
-
-                Scope::Root | Scope::Elision { .. } => break Region::Static,
-
-                Scope::Body { .. } | Scope::ObjectLifetimeDefault { lifetime: None, .. } => return,
-
-                Scope::ObjectLifetimeDefault { lifetime: Some(l), .. } => break l,
-
-                Scope::Supertrait { s, .. } | Scope::TraitRefBoundary { s, .. } => {
-                    scope = s;
-                }
-            }
-        };
-        self.insert_lifetime(lifetime_ref, lifetime.shifted(late_depth));
     }
 
     #[tracing::instrument(level = "debug", skip(self))]

--- a/compiler/rustc_resolve/src/late/lifetimes.rs
+++ b/compiler/rustc_resolve/src/late/lifetimes.rs
@@ -1,4 +1,3 @@
-// ignore-tidy-filelength
 //! Name resolution for lifetimes.
 //!
 //! Name resolution for lifetimes follows *much* simpler rules than the

--- a/compiler/rustc_resolve/src/late/lifetimes.rs
+++ b/compiler/rustc_resolve/src/late/lifetimes.rs
@@ -12,7 +12,7 @@ use rustc_data_structures::fx::{FxHashMap, FxHashSet, FxIndexMap, FxIndexSet};
 use rustc_errors::struct_span_err;
 use rustc_hir as hir;
 use rustc_hir::def::{DefKind, Res};
-use rustc_hir::def_id::{DefIdMap, LocalDefId};
+use rustc_hir::def_id::LocalDefId;
 use rustc_hir::hir_id::ItemLocalId;
 use rustc_hir::intravisit::{self, Visitor};
 use rustc_hir::{GenericArg, GenericParam, LifetimeName, Node};
@@ -155,9 +155,6 @@ pub(crate) struct LifetimeContext<'a, 'tcx> {
     /// be false if the `Item` we are resolving lifetimes for is not a trait or
     /// we eventually need lifetimes resolve for trait items.
     trait_definition_only: bool,
-
-    /// Cache for cross-crate per-definition object lifetime defaults.
-    xcrate_object_lifetime_defaults: DefIdMap<Vec<ObjectLifetimeDefault>>,
 
     /// When encountering an undefined named lifetime, we will suggest introducing it in these
     /// places.
@@ -348,9 +345,23 @@ pub fn provide(providers: &mut ty::query::Providers) {
 
         named_region_map: |tcx, id| resolve_lifetimes_for(tcx, id).defs.get(&id),
         is_late_bound_map,
-        object_lifetime_defaults: |tcx, id| match tcx.hir().find_by_def_id(id) {
-            Some(Node::Item(item)) => compute_object_lifetime_defaults(tcx, item),
-            _ => None,
+        object_lifetime_defaults: |tcx, def_id| {
+            if let Some(def_id) = def_id.as_local() {
+                match tcx.hir().get_by_def_id(def_id) {
+                    Node::Item(item) => compute_object_lifetime_defaults(tcx, item),
+                    _ => None,
+                }
+            } else {
+                Some(tcx.arena.alloc_from_iter(tcx.generics_of(def_id).params.iter().filter_map(
+                    |param| match param.kind {
+                        GenericParamDefKind::Type { object_lifetime_default, .. } => {
+                            Some(object_lifetime_default)
+                        }
+                        GenericParamDefKind::Const { .. } => Some(Set1::Empty),
+                        GenericParamDefKind::Lifetime => None,
+                    },
+                )))
+            }
         },
         late_bound_vars_map: |tcx, id| resolve_lifetimes_for(tcx, id).late_bound_vars.get(&id),
         lifetime_scope_map: |tcx, id| {
@@ -425,7 +436,6 @@ fn do_resolve(
         map: &mut named_region_map,
         scope: ROOT_SCOPE,
         trait_definition_only,
-        xcrate_object_lifetime_defaults: Default::default(),
         missing_named_lifetime_spots: vec![],
     };
     visitor.visit_item(item);
@@ -1573,14 +1583,12 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
         F: for<'b> FnOnce(&mut LifetimeContext<'b, 'tcx>),
     {
         let LifetimeContext { tcx, map, .. } = self;
-        let xcrate_object_lifetime_defaults = take(&mut self.xcrate_object_lifetime_defaults);
         let missing_named_lifetime_spots = take(&mut self.missing_named_lifetime_spots);
         let mut this = LifetimeContext {
             tcx: *tcx,
             map,
             scope: &wrap_scope,
             trait_definition_only: self.trait_definition_only,
-            xcrate_object_lifetime_defaults,
             missing_named_lifetime_spots,
         };
         let span = tracing::debug_span!("scope", scope = ?TruncatedScopeDebug(&this.scope));
@@ -1588,7 +1596,6 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
             let _enter = span.enter();
             f(&mut this);
         }
-        self.xcrate_object_lifetime_defaults = this.xcrate_object_lifetime_defaults;
         self.missing_named_lifetime_spots = this.missing_named_lifetime_spots;
     }
 
@@ -1904,35 +1911,7 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
                 }
                 Set1::Many => None,
             };
-            if let Some(def_id) = def_id.as_local() {
-                let id = self.tcx.hir().local_def_id_to_hir_id(def_id);
-                self.tcx
-                    .object_lifetime_defaults(id.owner)
-                    .unwrap()
-                    .iter()
-                    .map(set_to_region)
-                    .collect()
-            } else {
-                let tcx = self.tcx;
-                self.xcrate_object_lifetime_defaults
-                    .entry(def_id)
-                    .or_insert_with(|| {
-                        tcx.generics_of(def_id)
-                            .params
-                            .iter()
-                            .filter_map(|param| match param.kind {
-                                GenericParamDefKind::Type { object_lifetime_default, .. } => {
-                                    Some(object_lifetime_default)
-                                }
-                                GenericParamDefKind::Const { .. } => Some(Set1::Empty),
-                                GenericParamDefKind::Lifetime => None,
-                            })
-                            .collect()
-                    })
-                    .iter()
-                    .map(set_to_region)
-                    .collect()
-            }
+            self.tcx.object_lifetime_defaults(def_id).unwrap().iter().map(set_to_region).collect()
         });
 
         debug!("visit_segment_args: object_lifetime_defaults={:?}", object_lifetime_defaults);

--- a/compiler/rustc_typeck/src/astconv/mod.rs
+++ b/compiler/rustc_typeck/src/astconv/mod.rs
@@ -266,9 +266,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                 // (*) -- not late-bound, won't change
             }
         };
-
         debug!("ast_region_to_region(lifetime={:?}) yields {:?}", lifetime, r);
-
         r
     }
 

--- a/compiler/rustc_typeck/src/astconv/mod.rs
+++ b/compiler/rustc_typeck/src/astconv/mod.rs
@@ -251,7 +251,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                 tcx.mk_region(ty::ReLateBound(debruijn, br))
             }
 
-            rl::Region::EarlyBound(_, def_id) => {
+            rl::Region::EarlyBound(def_id) => {
                 let name = tcx.hir().ty_param_name(def_id.expect_local());
                 let item_def_id = tcx.hir().ty_param_owner(def_id.expect_local());
                 let generics = tcx.generics_of(item_def_id);

--- a/compiler/rustc_typeck/src/astconv/mod.rs
+++ b/compiler/rustc_typeck/src/astconv/mod.rs
@@ -251,9 +251,12 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                 tcx.mk_region(ty::ReLateBound(debruijn, br))
             }
 
-            rl::Region::EarlyBound(index, id) => {
-                let name = lifetime_name(id.expect_local());
-                tcx.mk_region(ty::ReEarlyBound(ty::EarlyBoundRegion { def_id: id, index, name }))
+            rl::Region::EarlyBound(_, def_id) => {
+                let name = tcx.hir().ty_param_name(def_id.expect_local());
+                let item_def_id = tcx.hir().ty_param_owner(def_id.expect_local());
+                let generics = tcx.generics_of(item_def_id);
+                let index = generics.param_def_id_to_index[&def_id];
+                tcx.mk_region(ty::ReEarlyBound(ty::EarlyBoundRegion { def_id, index, name }))
             }
 
             rl::Region::Free(scope, id) => {

--- a/compiler/rustc_typeck/src/collect.rs
+++ b/compiler/rustc_typeck/src/collect.rs
@@ -1,3 +1,4 @@
+// ignore-tidy-filelength
 //! "Collection" is the process of determining the type and other external
 //! details of each item in Rust. Collection is specifically concerned
 //! with *inter-procedural* things -- for example, for a function

--- a/compiler/rustc_typeck/src/collect.rs
+++ b/compiler/rustc_typeck/src/collect.rs
@@ -35,7 +35,6 @@ use rustc_hir::weak_lang_items;
 use rustc_hir::{GenericParamKind, HirId, Node};
 use rustc_middle::hir::nested_filter;
 use rustc_middle::middle::codegen_fn_attrs::{CodegenFnAttrFlags, CodegenFnAttrs};
-use rustc_middle::middle::resolve_lifetime::ObjectLifetimeDefault;
 use rustc_middle::mir::mono::Linkage;
 use rustc_middle::ty::query::Providers;
 use rustc_middle::ty::subst::InternalSubsts;
@@ -71,7 +70,7 @@ pub fn provide(providers: &mut Providers) {
         type_of: type_of::type_of,
         item_bounds: item_bounds::item_bounds,
         explicit_item_bounds: item_bounds::explicit_item_bounds,
-        object_lifetime_defaults: object_lifetime_defaults::object_lifetime_defaults,
+        object_lifetime_default: object_lifetime_defaults::object_lifetime_default,
         object_lifetime_map: object_lifetime_defaults::object_lifetime_map,
         generics_of,
         predicates_of,
@@ -1638,7 +1637,6 @@ fn generics_of(tcx: TyCtxt<'_>, def_id: DefId) -> ty::Generics {
                         pure_wrt_drop: false,
                         kind: ty::GenericParamDefKind::Type {
                             has_default: false,
-                            object_lifetime_default: ObjectLifetimeDefault::Empty,
                             synthetic: false,
                         },
                     });
@@ -1686,8 +1684,6 @@ fn generics_of(tcx: TyCtxt<'_>, def_id: DefId) -> ty::Generics {
         kind: ty::GenericParamDefKind::Lifetime,
     }));
 
-    let object_lifetime_defaults = tcx.object_lifetime_defaults(hir_id.owner);
-
     // Now create the real type and const parameters.
     let type_start = own_start - has_self as u32 + params.len() as u32;
     let mut i = 0;
@@ -1712,13 +1708,7 @@ fn generics_of(tcx: TyCtxt<'_>, def_id: DefId) -> ty::Generics {
                 }
             }
 
-            let kind = ty::GenericParamDefKind::Type {
-                has_default: default.is_some(),
-                object_lifetime_default: object_lifetime_defaults
-                    .as_ref()
-                    .map_or(ObjectLifetimeDefault::Empty, |o| o[i]),
-                synthetic,
-            };
+            let kind = ty::GenericParamDefKind::Type { has_default: default.is_some(), synthetic };
 
             let param_def = ty::GenericParamDef {
                 index: type_start + i as u32,
@@ -1766,11 +1756,7 @@ fn generics_of(tcx: TyCtxt<'_>, def_id: DefId) -> ty::Generics {
             name: Symbol::intern(arg),
             def_id,
             pure_wrt_drop: false,
-            kind: ty::GenericParamDefKind::Type {
-                has_default: false,
-                object_lifetime_default: ObjectLifetimeDefault::Empty,
-                synthetic: false,
-            },
+            kind: ty::GenericParamDefKind::Type { has_default: false, synthetic: false },
         }));
     }
 
@@ -1783,11 +1769,7 @@ fn generics_of(tcx: TyCtxt<'_>, def_id: DefId) -> ty::Generics {
                 name: Symbol::intern("<const_ty>"),
                 def_id,
                 pure_wrt_drop: false,
-                kind: ty::GenericParamDefKind::Type {
-                    has_default: false,
-                    object_lifetime_default: ObjectLifetimeDefault::Empty,
-                    synthetic: false,
-                },
+                kind: ty::GenericParamDefKind::Type { has_default: false, synthetic: false },
             });
         }
     }

--- a/compiler/rustc_typeck/src/collect.rs
+++ b/compiler/rustc_typeck/src/collect.rs
@@ -34,6 +34,7 @@ use rustc_hir::weak_lang_items;
 use rustc_hir::{GenericParamKind, HirId, Node};
 use rustc_middle::hir::nested_filter;
 use rustc_middle::middle::codegen_fn_attrs::{CodegenFnAttrFlags, CodegenFnAttrs};
+use rustc_middle::middle::resolve_lifetime::ObjectLifetimeDefault;
 use rustc_middle::mir::mono::Linkage;
 use rustc_middle::ty::query::Providers;
 use rustc_middle::ty::subst::InternalSubsts;
@@ -1636,7 +1637,7 @@ fn generics_of(tcx: TyCtxt<'_>, def_id: DefId) -> ty::Generics {
                         pure_wrt_drop: false,
                         kind: ty::GenericParamDefKind::Type {
                             has_default: false,
-                            object_lifetime_default: rl::Set1::Empty,
+                            object_lifetime_default: ObjectLifetimeDefault::Empty,
                             synthetic: false,
                         },
                     });
@@ -1714,7 +1715,7 @@ fn generics_of(tcx: TyCtxt<'_>, def_id: DefId) -> ty::Generics {
                 has_default: default.is_some(),
                 object_lifetime_default: object_lifetime_defaults
                     .as_ref()
-                    .map_or(rl::Set1::Empty, |o| o[i]),
+                    .map_or(ObjectLifetimeDefault::Empty, |o| o[i]),
                 synthetic,
             };
 
@@ -1766,7 +1767,7 @@ fn generics_of(tcx: TyCtxt<'_>, def_id: DefId) -> ty::Generics {
             pure_wrt_drop: false,
             kind: ty::GenericParamDefKind::Type {
                 has_default: false,
-                object_lifetime_default: rl::Set1::Empty,
+                object_lifetime_default: ObjectLifetimeDefault::Empty,
                 synthetic: false,
             },
         }));
@@ -1783,7 +1784,7 @@ fn generics_of(tcx: TyCtxt<'_>, def_id: DefId) -> ty::Generics {
                 pure_wrt_drop: false,
                 kind: ty::GenericParamDefKind::Type {
                     has_default: false,
-                    object_lifetime_default: rl::Set1::Empty,
+                    object_lifetime_default: ObjectLifetimeDefault::Empty,
                     synthetic: false,
                 },
             });

--- a/compiler/rustc_typeck/src/collect/object_lifetime_defaults.rs
+++ b/compiler/rustc_typeck/src/collect/object_lifetime_defaults.rs
@@ -171,7 +171,6 @@ enum Scope<'a> {
     /// it should be shifted by the number of `Binder`s in between the
     /// declaration `Binder` and the location it's referenced from.
     Binder {
-        scope_type: BinderScopeType,
         s: ScopeRef<'a>,
     },
 
@@ -197,35 +196,19 @@ enum Scope<'a> {
     Root,
 }
 
-#[derive(Copy, Clone, Debug)]
-enum BinderScopeType {
-    /// Any non-concatenating binder scopes.
-    Normal,
-    /// Within a syntactic trait ref, there may be multiple poly trait refs that
-    /// are nested (under the `associated_type_bounds` feature). The binders of
-    /// the inner poly trait refs are extended from the outer poly trait refs
-    /// and don't increase the late bound depth. If you had
-    /// `T: for<'a>  Foo<Bar: for<'b> Baz<'a, 'b>>`, then the `for<'b>` scope
-    /// would be `Concatenating`. This also used in trait refs in where clauses
-    /// where we have two binders `for<> T: for<> Foo` (I've intentionally left
-    /// out any lifetimes because they aren't needed to show the two scopes).
-    /// The inner `for<>` has a scope of `Concatenating`.
-    Concatenating,
-}
-
 type ScopeRef<'a> = &'a Scope<'a>;
 
 const ROOT_SCOPE: ScopeRef<'static> = &Scope::Root;
 
 impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
     /// Returns the binders in scope and the type of `Binder` that should be created for a poly trait ref.
-    fn poly_trait_ref_binder_info(&mut self) -> BinderScopeType {
+    fn poly_trait_ref_needs_binder(&mut self) -> bool {
         let mut scope = self.scope;
         loop {
             match scope {
                 // Nested poly trait refs have the binders concatenated
-                Scope::Binder { .. } => break BinderScopeType::Concatenating,
-                Scope::Body | Scope::Root => break BinderScopeType::Normal,
+                Scope::Binder { .. } => break false,
+                Scope::Body | Scope::Root => break true,
                 Scope::Static { s, .. } | Scope::ObjectLifetimeDefault { s, .. } => scope = s,
             }
         }
@@ -247,7 +230,7 @@ impl<'a, 'tcx> Visitor<'tcx> for LifetimeContext<'a, 'tcx> {
 
     fn visit_expr(&mut self, e: &'tcx hir::Expr<'tcx>) {
         if let hir::ExprKind::Closure(..) = e.kind {
-            let scope = Scope::Binder { s: self.scope, scope_type: BinderScopeType::Normal };
+            let scope = Scope::Binder { s: self.scope };
             self.with(scope, |this| {
                 // a closure has no bounds, so everything
                 // contained within is scoped within its binder.
@@ -285,7 +268,7 @@ impl<'a, 'tcx> Visitor<'tcx> for LifetimeContext<'a, 'tcx> {
             | hir::ItemKind::Fn(..)
             | hir::ItemKind::Impl(..) => {
                 // These kinds of items have only early-bound lifetime parameters.
-                let scope = Scope::Binder { scope_type: BinderScopeType::Normal, s: ROOT_SCOPE };
+                let scope = Scope::Binder { s: ROOT_SCOPE };
                 self.with(scope, |this| intravisit::walk_item(this, item));
             }
         }
@@ -294,7 +277,7 @@ impl<'a, 'tcx> Visitor<'tcx> for LifetimeContext<'a, 'tcx> {
     fn visit_foreign_item(&mut self, item: &'tcx hir::ForeignItem<'tcx>) {
         match item.kind {
             hir::ForeignItemKind::Fn(..) => {
-                let scope = Scope::Binder { s: self.scope, scope_type: BinderScopeType::Normal };
+                let scope = Scope::Binder { s: self.scope };
                 self.with(scope, |this| intravisit::walk_foreign_item(this, item))
             }
             hir::ForeignItemKind::Static(..) | hir::ForeignItemKind::Type => {
@@ -307,7 +290,7 @@ impl<'a, 'tcx> Visitor<'tcx> for LifetimeContext<'a, 'tcx> {
     fn visit_ty(&mut self, ty: &'tcx hir::Ty<'tcx>) {
         match ty.kind {
             hir::TyKind::BareFn(..) => {
-                let scope = Scope::Binder { s: self.scope, scope_type: BinderScopeType::Normal };
+                let scope = Scope::Binder { s: self.scope };
                 self.with(scope, |this| {
                     // a bare fn has no bounds, so everything
                     // contained within is scoped within its binder.
@@ -340,7 +323,7 @@ impl<'a, 'tcx> Visitor<'tcx> for LifetimeContext<'a, 'tcx> {
         use self::hir::TraitItemKind::*;
         match trait_item.kind {
             Fn(..) | Type(..) => {
-                let scope = Scope::Binder { s: self.scope, scope_type: BinderScopeType::Normal };
+                let scope = Scope::Binder { s: self.scope };
                 self.with(scope, |this| intravisit::walk_trait_item(this, trait_item));
             }
             // Only methods and types support generics.
@@ -352,7 +335,7 @@ impl<'a, 'tcx> Visitor<'tcx> for LifetimeContext<'a, 'tcx> {
         use self::hir::ImplItemKind::*;
         match impl_item.kind {
             Fn(..) | TyAlias(..) => {
-                let scope = Scope::Binder { s: self.scope, scope_type: BinderScopeType::Normal };
+                let scope = Scope::Binder { s: self.scope };
                 self.with(scope, |this| intravisit::walk_impl_item(this, impl_item));
             }
             // Only methods and types support generics.
@@ -376,7 +359,7 @@ impl<'a, 'tcx> Visitor<'tcx> for LifetimeContext<'a, 'tcx> {
                 // scope. If there happens to be a nested poly trait ref (an error), that
                 // will be `Concatenating` anyways, so we don't have to worry about the depth
                 // being wrong.
-                let scope = Scope::Binder { s: self.scope, scope_type: BinderScopeType::Normal };
+                let scope = Scope::Binder { s: self.scope };
                 self.with(scope, |this| intravisit::walk_where_predicate(this, predicate))
             }
             &hir::WherePredicate::RegionPredicate(..) | &hir::WherePredicate::EqPredicate(..) => {
@@ -387,15 +370,13 @@ impl<'a, 'tcx> Visitor<'tcx> for LifetimeContext<'a, 'tcx> {
 
     fn visit_param_bound(&mut self, bound: &'tcx hir::GenericBound<'tcx>) {
         match bound {
-            hir::GenericBound::LangItemTrait(..) => {
-                // FIXME(jackh726): This is pretty weird. `LangItemTrait` doesn't go
-                // through the regular poly trait ref code, so we don't get another
-                // chance to introduce a binder. For now, I'm keeping the existing logic
-                // of "if there isn't a Binder scope above us, add one", but I
-                // imagine there's a better way to go about this.
-                let scope_type = self.poly_trait_ref_binder_info();
-
-                let scope = Scope::Binder { s: self.scope, scope_type };
+            // FIXME(jackh726): This is pretty weird. `LangItemTrait` doesn't go
+            // through the regular poly trait ref code, so we don't get another
+            // chance to introduce a binder. For now, I'm keeping the existing logic
+            // of "if there isn't a Binder scope above us, add one", but I
+            // imagine there's a better way to go about this.
+            hir::GenericBound::LangItemTrait(..) if self.poly_trait_ref_needs_binder() => {
+                let scope = Scope::Binder { s: self.scope };
                 self.with(scope, |this| intravisit::walk_param_bound(this, bound));
             }
             _ => intravisit::walk_param_bound(self, bound),
@@ -409,14 +390,16 @@ impl<'a, 'tcx> Visitor<'tcx> for LifetimeContext<'a, 'tcx> {
     ) {
         debug!("visit_poly_trait_ref(trait_ref={:?})", trait_ref);
 
-        let scope_type = self.poly_trait_ref_binder_info();
-
-        // Always introduce a scope here, even if this is in a where clause and
-        // we introduced the binders around the bounded Ty. In that case, we
-        // just reuse the concatenation functionality also present in nested trait
-        // refs.
-        let scope = Scope::Binder { s: self.scope, scope_type };
-        self.with(scope, |this| intravisit::walk_poly_trait_ref(this, trait_ref, modifier));
+        if self.poly_trait_ref_needs_binder() {
+            // Always introduce a scope here, even if this is in a where clause and
+            // we introduced the binders around the bounded Ty. In that case, we
+            // just reuse the concatenation functionality also present in nested trait
+            // refs.
+            let scope = Scope::Binder { s: self.scope };
+            self.with(scope, |this| intravisit::walk_poly_trait_ref(this, trait_ref, modifier));
+        } else {
+            intravisit::walk_poly_trait_ref(self, trait_ref, modifier);
+        }
     }
 }
 
@@ -589,11 +572,8 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
         let mut scope = self.scope;
         let lifetime = loop {
             match *scope {
-                Scope::Binder { s, scope_type, .. } => {
-                    match scope_type {
-                        BinderScopeType::Normal => late_depth += 1,
-                        BinderScopeType::Concatenating => {}
-                    }
+                Scope::Binder { s, .. } => {
+                    late_depth += 1;
                     scope = s;
                 }
 

--- a/compiler/rustc_typeck/src/collect/object_lifetime_defaults.rs
+++ b/compiler/rustc_typeck/src/collect/object_lifetime_defaults.rs
@@ -17,30 +17,9 @@ use tracing::debug;
 
 pub(super) fn object_lifetime_defaults(
     tcx: TyCtxt<'_>,
-    def_id: DefId,
+    def_id: LocalDefId,
 ) -> Option<&[ObjectLifetimeDefault]> {
-    if let Some(def_id) = def_id.as_local() {
-        match tcx.hir().get_by_def_id(def_id) {
-            Node::Item(item) => compute_object_lifetime_defaults(tcx, item),
-            _ => None,
-        }
-    } else {
-        Some(tcx.arena.alloc_from_iter(tcx.generics_of(def_id).params.iter().filter_map(|param| {
-            match param.kind {
-                GenericParamDefKind::Type { object_lifetime_default, .. } => {
-                    Some(object_lifetime_default)
-                }
-                GenericParamDefKind::Const { .. } => Some(Set1::Empty),
-                GenericParamDefKind::Lifetime => None,
-            }
-        })))
-    }
-}
-
-fn compute_object_lifetime_defaults<'tcx>(
-    tcx: TyCtxt<'tcx>,
-    item: &hir::Item<'_>,
-) -> Option<&'tcx [ObjectLifetimeDefault]> {
+    let Node::Item(item) = tcx.hir().get_by_def_id(def_id) else { return None };
     match item.kind {
         hir::ItemKind::Struct(_, ref generics)
         | hir::ItemKind::Union(_, ref generics)
@@ -61,24 +40,18 @@ fn compute_object_lifetime_defaults<'tcx>(
                 let object_lifetime_default_reprs: String = result
                     .iter()
                     .map(|set| match *set {
-                        Set1::Empty => "BaseDefault".into(),
-                        Set1::One(Region::Static) => "'static".into(),
-                        Set1::One(Region::EarlyBound(mut i, _)) => generics
-                            .params
-                            .iter()
-                            .find_map(|param| match param.kind {
-                                GenericParamKind::Lifetime { .. } => {
-                                    if i == 0 {
-                                        return Some(param.name.ident().to_string().into());
-                                    }
-                                    i -= 1;
-                                    None
-                                }
-                                _ => None,
-                            })
-                            .unwrap(),
-                        Set1::One(_) => bug!(),
-                        Set1::Many => "Ambiguous".into(),
+                        ObjectLifetimeDefault::Empty => "BaseDefault".into(),
+                        ObjectLifetimeDefault::Static => "'static".into(),
+                        ObjectLifetimeDefault::Param(def_id) => {
+                            let def_id = def_id.expect_local();
+                            generics
+                                .params
+                                .iter()
+                                .find(|param| tcx.hir().local_def_id(param.hir_id) == def_id)
+                                .map(|param| param.name.ident().to_string().into())
+                                .unwrap()
+                        }
+                        ObjectLifetimeDefault::Ambiguous => "Ambiguous".into(),
                     })
                     .collect::<Vec<Cow<'static, str>>>()
                     .join(",");
@@ -133,24 +106,12 @@ fn object_lifetime_defaults_for_item<'tcx>(
             }
 
             Some(match set {
-                Set1::Empty => Set1::Empty,
-                Set1::One(hir::LifetimeName::Static) => Set1::One(Region::Static),
-                Set1::One(hir::LifetimeName::Param(def_id, _)) => generics
-                    .params
-                    .iter()
-                    .filter_map(|param| match param.kind {
-                        GenericParamKind::Lifetime { .. } => {
-                            let param_def_id = tcx.hir().local_def_id(param.hir_id);
-                            Some(param_def_id)
-                        }
-                        _ => None,
-                    })
-                    .enumerate()
-                    .find(|&(_, param_def_id)| param_def_id == def_id)
-                    .map_or(Set1::Many, |(i, _)| {
-                        Set1::One(Region::EarlyBound(i as u32, def_id.to_def_id()))
-                    }),
-                Set1::One(_) | Set1::Many => Set1::Many,
+                Set1::Empty => ObjectLifetimeDefault::Empty,
+                Set1::One(hir::LifetimeName::Static) => ObjectLifetimeDefault::Static,
+                Set1::One(hir::LifetimeName::Param(def_id, _)) => {
+                    ObjectLifetimeDefault::Param(def_id.to_def_id())
+                }
+                Set1::One(_) | Set1::Many => ObjectLifetimeDefault::Ambiguous,
             })
         }
         GenericParamKind::Const { .. } => {
@@ -158,7 +119,7 @@ fn object_lifetime_defaults_for_item<'tcx>(
             //
             // We still store a dummy value here to allow generic parameters
             // in an arbitrary order.
-            Some(Set1::Empty)
+            Some(ObjectLifetimeDefault::Empty)
         }
     };
 
@@ -528,9 +489,7 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
                 loop {
                     match *scope {
                         Scope::Root => break false,
-
                         Scope::Body => break true,
-
                         Scope::Binder { s, .. }
                         | Scope::Static { s, .. }
                         | Scope::ObjectLifetimeDefault { s, .. } => {
@@ -539,28 +498,37 @@ impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
                     }
                 }
             };
-
-            let set_to_region = |set: &ObjectLifetimeDefault| match *set {
-                Set1::Empty => {
+            let generics = self.tcx.generics_of(def_id);
+            let set_to_region = |set: ObjectLifetimeDefault| match set {
+                ObjectLifetimeDefault::Empty => {
                     if in_body {
                         None
                     } else {
                         Some(Region::Static)
                     }
                 }
-                Set1::One(Region::EarlyBound(index, _)) => {
-                    let mut lifetimes = generic_args.args.iter().filter_map(|arg| match arg {
-                        GenericArg::Lifetime(lt) => Some(lt),
+                ObjectLifetimeDefault::Static => Some(Region::Static),
+                ObjectLifetimeDefault::Param(def_id) => {
+                    let index = generics.param_def_id_to_index[&def_id];
+                    generic_args.args.get(index as usize).and_then(|arg| match arg {
+                        GenericArg::Lifetime(lt) => self.tcx.named_region(lt.hir_id),
                         _ => None,
-                    });
-                    lifetimes
-                        .nth(index as usize)
-                        .and_then(|lifetime| self.tcx.named_region(lifetime.hir_id))
+                    })
                 }
-                Set1::One(r) => Some(r),
-                Set1::Many => None,
+                ObjectLifetimeDefault::Ambiguous => None,
             };
-            self.tcx.object_lifetime_defaults(def_id).unwrap().iter().map(set_to_region).collect()
+            generics
+                .params
+                .iter()
+                .filter_map(|param| match param.kind {
+                    GenericParamDefKind::Type { object_lifetime_default, .. } => {
+                        Some(object_lifetime_default)
+                    }
+                    GenericParamDefKind::Const { .. } => Some(ObjectLifetimeDefault::Empty),
+                    GenericParamDefKind::Lifetime => None,
+                })
+                .map(set_to_region)
+                .collect()
         });
         debug!(?object_lifetime_defaults);
 

--- a/compiler/rustc_typeck/src/collect/object_lifetime_defaults.rs
+++ b/compiler/rustc_typeck/src/collect/object_lifetime_defaults.rs
@@ -189,6 +189,7 @@ enum Scope<'a> {
     /// inferred in a function body or potentially error outside one),
     /// for the default choice of lifetime in a trait object type.
     ObjectLifetimeDefault {
+        //FIXME(cjgillot) This should use a `ty::Region`.
         lifetime: Option<Region>,
         s: ScopeRef<'a>,
     },

--- a/compiler/rustc_typeck/src/collect/object_lifetime_defaults.rs
+++ b/compiler/rustc_typeck/src/collect/object_lifetime_defaults.rs
@@ -1,0 +1,654 @@
+use rustc_data_structures::fx::FxHashMap;
+use rustc_hir as hir;
+use rustc_hir::def::{DefKind, Res};
+use rustc_hir::def_id::LocalDefId;
+use rustc_hir::hir_id::ItemLocalId;
+use rustc_hir::intravisit::{self, Visitor};
+use rustc_hir::{GenericArg, GenericParamKind, LifetimeName, Node};
+use rustc_middle::bug;
+use rustc_middle::hir::nested_filter;
+use rustc_middle::middle::resolve_lifetime::*;
+use rustc_middle::ty::{GenericParamDefKind, TyCtxt};
+use rustc_span::def_id::DefId;
+use rustc_span::symbol::sym;
+use std::borrow::Cow;
+
+use tracing::debug;
+
+pub(super) fn object_lifetime_defaults(
+    tcx: TyCtxt<'_>,
+    def_id: DefId,
+) -> Option<&[ObjectLifetimeDefault]> {
+    if let Some(def_id) = def_id.as_local() {
+        match tcx.hir().get_by_def_id(def_id) {
+            Node::Item(item) => compute_object_lifetime_defaults(tcx, item),
+            _ => None,
+        }
+    } else {
+        Some(tcx.arena.alloc_from_iter(tcx.generics_of(def_id).params.iter().filter_map(|param| {
+            match param.kind {
+                GenericParamDefKind::Type { object_lifetime_default, .. } => {
+                    Some(object_lifetime_default)
+                }
+                GenericParamDefKind::Const { .. } => Some(Set1::Empty),
+                GenericParamDefKind::Lifetime => None,
+            }
+        })))
+    }
+}
+
+fn compute_object_lifetime_defaults<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    item: &hir::Item<'_>,
+) -> Option<&'tcx [ObjectLifetimeDefault]> {
+    match item.kind {
+        hir::ItemKind::Struct(_, ref generics)
+        | hir::ItemKind::Union(_, ref generics)
+        | hir::ItemKind::Enum(_, ref generics)
+        | hir::ItemKind::OpaqueTy(hir::OpaqueTy {
+            ref generics,
+            origin: hir::OpaqueTyOrigin::TyAlias,
+            ..
+        })
+        | hir::ItemKind::TyAlias(_, ref generics)
+        | hir::ItemKind::Trait(_, _, ref generics, ..) => {
+            let result = object_lifetime_defaults_for_item(tcx, generics);
+            debug!(?result);
+
+            // Debugging aid.
+            let attrs = tcx.hir().attrs(item.hir_id());
+            if tcx.sess.contains_name(attrs, sym::rustc_object_lifetime_default) {
+                let object_lifetime_default_reprs: String = result
+                    .iter()
+                    .map(|set| match *set {
+                        Set1::Empty => "BaseDefault".into(),
+                        Set1::One(Region::Static) => "'static".into(),
+                        Set1::One(Region::EarlyBound(mut i, _)) => generics
+                            .params
+                            .iter()
+                            .find_map(|param| match param.kind {
+                                GenericParamKind::Lifetime { .. } => {
+                                    if i == 0 {
+                                        return Some(param.name.ident().to_string().into());
+                                    }
+                                    i -= 1;
+                                    None
+                                }
+                                _ => None,
+                            })
+                            .unwrap(),
+                        Set1::One(_) => bug!(),
+                        Set1::Many => "Ambiguous".into(),
+                    })
+                    .collect::<Vec<Cow<'static, str>>>()
+                    .join(",");
+                tcx.sess.span_err(item.span, &object_lifetime_default_reprs);
+            }
+
+            Some(result)
+        }
+        _ => None,
+    }
+}
+
+/// Scan the bounds and where-clauses on parameters to extract bounds
+/// of the form `T:'a` so as to determine the `ObjectLifetimeDefault`
+/// for each type parameter.
+fn object_lifetime_defaults_for_item<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    generics: &hir::Generics<'_>,
+) -> &'tcx [ObjectLifetimeDefault] {
+    fn add_bounds(set: &mut Set1<hir::LifetimeName>, bounds: &[hir::GenericBound<'_>]) {
+        for bound in bounds {
+            if let hir::GenericBound::Outlives(ref lifetime) = *bound {
+                set.insert(lifetime.name.normalize_to_macros_2_0());
+            }
+        }
+    }
+
+    let process_param = |param: &hir::GenericParam<'_>| match param.kind {
+        GenericParamKind::Lifetime { .. } => None,
+        GenericParamKind::Type { .. } => {
+            let mut set = Set1::Empty;
+
+            let param_def_id = tcx.hir().local_def_id(param.hir_id);
+            for predicate in generics.predicates {
+                // Look for `type: ...` where clauses.
+                let hir::WherePredicate::BoundPredicate(ref data) = *predicate else { continue };
+
+                // Ignore `for<'a> type: ...` as they can change what
+                // lifetimes mean (although we could "just" handle it).
+                if !data.bound_generic_params.is_empty() {
+                    continue;
+                }
+
+                let res = match data.bounded_ty.kind {
+                    hir::TyKind::Path(hir::QPath::Resolved(None, ref path)) => path.res,
+                    _ => continue,
+                };
+
+                if res == Res::Def(DefKind::TyParam, param_def_id.to_def_id()) {
+                    add_bounds(&mut set, &data.bounds);
+                }
+            }
+
+            Some(match set {
+                Set1::Empty => Set1::Empty,
+                Set1::One(hir::LifetimeName::Static) => Set1::One(Region::Static),
+                Set1::One(hir::LifetimeName::Param(def_id, _)) => generics
+                    .params
+                    .iter()
+                    .filter_map(|param| match param.kind {
+                        GenericParamKind::Lifetime { .. } => {
+                            let param_def_id = tcx.hir().local_def_id(param.hir_id);
+                            Some(param_def_id)
+                        }
+                        _ => None,
+                    })
+                    .enumerate()
+                    .find(|&(_, param_def_id)| param_def_id == def_id)
+                    .map_or(Set1::Many, |(i, _)| {
+                        Set1::One(Region::EarlyBound(i as u32, def_id.to_def_id()))
+                    }),
+                Set1::One(_) | Set1::Many => Set1::Many,
+            })
+        }
+        GenericParamKind::Const { .. } => {
+            // Generic consts don't impose any constraints.
+            //
+            // We still store a dummy value here to allow generic parameters
+            // in an arbitrary order.
+            Some(Set1::Empty)
+        }
+    };
+
+    tcx.arena.alloc_from_iter(generics.params.iter().filter_map(process_param))
+}
+
+pub(super) fn object_lifetime_map(
+    tcx: TyCtxt<'_>,
+    def_id: LocalDefId,
+) -> FxHashMap<ItemLocalId, Region> {
+    let mut named_region_map = Default::default();
+    let mut visitor = LifetimeContext { tcx, defs: &mut named_region_map, scope: ROOT_SCOPE };
+    let node = tcx.hir().get_by_def_id(def_id);
+    match node {
+        Node::Item(item) => visitor.visit_item(item),
+        Node::TraitItem(item) => visitor.visit_trait_item(item),
+        Node::ImplItem(item) => visitor.visit_impl_item(item),
+        Node::ForeignItem(item) => visitor.visit_foreign_item(item),
+        _ => bug!(),
+    }
+
+    named_region_map
+}
+
+trait RegionExt {
+    fn shifted(self, amount: u32) -> Region;
+}
+
+impl RegionExt for Region {
+    fn shifted(self, amount: u32) -> Region {
+        match self {
+            Region::LateBound(debruijn, idx, id) => {
+                Region::LateBound(debruijn.shifted_in(amount), idx, id)
+            }
+            _ => self,
+        }
+    }
+}
+
+struct LifetimeContext<'a, 'tcx> {
+    tcx: TyCtxt<'tcx>,
+    defs: &'a mut FxHashMap<ItemLocalId, Region>,
+    scope: ScopeRef<'a>,
+}
+
+#[derive(Debug)]
+enum Scope<'a> {
+    /// Declares lifetimes, and each can be early-bound or late-bound.
+    /// The `DebruijnIndex` of late-bound lifetimes starts at `1` and
+    /// it should be shifted by the number of `Binder`s in between the
+    /// declaration `Binder` and the location it's referenced from.
+    Binder {
+        scope_type: BinderScopeType,
+        s: ScopeRef<'a>,
+    },
+
+    /// Lifetimes introduced by a fn are scoped to the call-site for that fn,
+    /// if this is a fn body, otherwise the original definitions are used.
+    /// Unspecified lifetimes are inferred, unless an elision scope is nested,
+    /// e.g., `(&T, fn(&T) -> &T);` becomes `(&'_ T, for<'a> fn(&'a T) -> &'a T)`.
+    Body,
+
+    /// A scope which either determines unspecified lifetimes to static.
+    Static {
+        s: ScopeRef<'a>,
+    },
+
+    /// Use a specific lifetime (if `Some`) or leave it unset (to be
+    /// inferred in a function body or potentially error outside one),
+    /// for the default choice of lifetime in a trait object type.
+    ObjectLifetimeDefault {
+        lifetime: Option<Region>,
+        s: ScopeRef<'a>,
+    },
+
+    Root,
+}
+
+#[derive(Copy, Clone, Debug)]
+enum BinderScopeType {
+    /// Any non-concatenating binder scopes.
+    Normal,
+    /// Within a syntactic trait ref, there may be multiple poly trait refs that
+    /// are nested (under the `associated_type_bounds` feature). The binders of
+    /// the inner poly trait refs are extended from the outer poly trait refs
+    /// and don't increase the late bound depth. If you had
+    /// `T: for<'a>  Foo<Bar: for<'b> Baz<'a, 'b>>`, then the `for<'b>` scope
+    /// would be `Concatenating`. This also used in trait refs in where clauses
+    /// where we have two binders `for<> T: for<> Foo` (I've intentionally left
+    /// out any lifetimes because they aren't needed to show the two scopes).
+    /// The inner `for<>` has a scope of `Concatenating`.
+    Concatenating,
+}
+
+type ScopeRef<'a> = &'a Scope<'a>;
+
+const ROOT_SCOPE: ScopeRef<'static> = &Scope::Root;
+
+impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
+    /// Returns the binders in scope and the type of `Binder` that should be created for a poly trait ref.
+    fn poly_trait_ref_binder_info(&mut self) -> BinderScopeType {
+        let mut scope = self.scope;
+        loop {
+            match scope {
+                // Nested poly trait refs have the binders concatenated
+                Scope::Binder { .. } => break BinderScopeType::Concatenating,
+                Scope::Body | Scope::Root => break BinderScopeType::Normal,
+                Scope::Static { s, .. } | Scope::ObjectLifetimeDefault { s, .. } => scope = s,
+            }
+        }
+    }
+}
+impl<'a, 'tcx> Visitor<'tcx> for LifetimeContext<'a, 'tcx> {
+    type NestedFilter = nested_filter::OnlyBodies;
+
+    fn nested_visit_map(&mut self) -> Self::Map {
+        self.tcx.hir()
+    }
+
+    fn visit_nested_body(&mut self, body: hir::BodyId) {
+        let body = self.tcx.hir().body(body);
+        self.with(Scope::Body, |this| {
+            this.visit_body(body);
+        });
+    }
+
+    fn visit_expr(&mut self, e: &'tcx hir::Expr<'tcx>) {
+        if let hir::ExprKind::Closure(..) = e.kind {
+            let scope = Scope::Binder { s: self.scope, scope_type: BinderScopeType::Normal };
+            self.with(scope, |this| {
+                // a closure has no bounds, so everything
+                // contained within is scoped within its binder.
+                intravisit::walk_expr(this, e)
+            });
+        } else {
+            intravisit::walk_expr(self, e)
+        }
+    }
+
+    fn visit_item(&mut self, item: &'tcx hir::Item<'tcx>) {
+        match item.kind {
+            hir::ItemKind::ExternCrate(_)
+            | hir::ItemKind::Use(..)
+            | hir::ItemKind::Macro(..)
+            | hir::ItemKind::Mod(..)
+            | hir::ItemKind::ForeignMod { .. }
+            | hir::ItemKind::GlobalAsm(..) => {
+                // These sorts of items have no lifetime parameters at all.
+                intravisit::walk_item(self, item);
+            }
+            hir::ItemKind::Static(..) | hir::ItemKind::Const(..) => {
+                // No lifetime parameters, but implied 'static.
+                self.with(Scope::Static { s: self.scope }, |this| {
+                    intravisit::walk_item(this, item)
+                });
+            }
+            hir::ItemKind::OpaqueTy(..)
+            | hir::ItemKind::TyAlias(..)
+            | hir::ItemKind::Enum(..)
+            | hir::ItemKind::Struct(..)
+            | hir::ItemKind::Union(..)
+            | hir::ItemKind::Trait(..)
+            | hir::ItemKind::TraitAlias(..)
+            | hir::ItemKind::Fn(..)
+            | hir::ItemKind::Impl(..) => {
+                // These kinds of items have only early-bound lifetime parameters.
+                let scope = Scope::Binder { scope_type: BinderScopeType::Normal, s: ROOT_SCOPE };
+                self.with(scope, |this| intravisit::walk_item(this, item));
+            }
+        }
+    }
+
+    fn visit_foreign_item(&mut self, item: &'tcx hir::ForeignItem<'tcx>) {
+        match item.kind {
+            hir::ForeignItemKind::Fn(..) => {
+                let scope = Scope::Binder { s: self.scope, scope_type: BinderScopeType::Normal };
+                self.with(scope, |this| intravisit::walk_foreign_item(this, item))
+            }
+            hir::ForeignItemKind::Static(..) | hir::ForeignItemKind::Type => {
+                intravisit::walk_foreign_item(self, item)
+            }
+        }
+    }
+
+    #[tracing::instrument(level = "debug", skip(self))]
+    fn visit_ty(&mut self, ty: &'tcx hir::Ty<'tcx>) {
+        match ty.kind {
+            hir::TyKind::BareFn(..) => {
+                let scope = Scope::Binder { s: self.scope, scope_type: BinderScopeType::Normal };
+                self.with(scope, |this| {
+                    // a bare fn has no bounds, so everything
+                    // contained within is scoped within its binder.
+                    intravisit::walk_ty(this, ty);
+                });
+            }
+            hir::TyKind::TraitObject(bounds, ref lifetime, _) => {
+                debug!(?bounds, ?lifetime, "TraitObject");
+                for bound in bounds {
+                    self.visit_poly_trait_ref(bound, hir::TraitBoundModifier::None);
+                }
+                if let LifetimeName::ImplicitObjectLifetimeDefault = lifetime.name {
+                    // If the user does not write *anything*, we
+                    // use the object lifetime defaulting
+                    // rules. So e.g., `Box<dyn Debug>` becomes
+                    // `Box<dyn Debug + 'static>`.
+                    self.resolve_object_lifetime_default(lifetime)
+                }
+            }
+            hir::TyKind::Rptr(ref lifetime_ref, ref mt) => {
+                let lifetime = self.tcx.named_region(lifetime_ref.hir_id);
+                let scope = Scope::ObjectLifetimeDefault { lifetime, s: self.scope };
+                self.with(scope, |this| this.visit_ty(&mt.ty));
+            }
+            _ => intravisit::walk_ty(self, ty),
+        }
+    }
+
+    fn visit_trait_item(&mut self, trait_item: &'tcx hir::TraitItem<'tcx>) {
+        use self::hir::TraitItemKind::*;
+        match trait_item.kind {
+            Fn(..) | Type(..) => {
+                let scope = Scope::Binder { s: self.scope, scope_type: BinderScopeType::Normal };
+                self.with(scope, |this| intravisit::walk_trait_item(this, trait_item));
+            }
+            // Only methods and types support generics.
+            Const(_, _) => intravisit::walk_trait_item(self, trait_item),
+        }
+    }
+
+    fn visit_impl_item(&mut self, impl_item: &'tcx hir::ImplItem<'tcx>) {
+        use self::hir::ImplItemKind::*;
+        match impl_item.kind {
+            Fn(..) | TyAlias(..) => {
+                let scope = Scope::Binder { s: self.scope, scope_type: BinderScopeType::Normal };
+                self.with(scope, |this| intravisit::walk_impl_item(this, impl_item));
+            }
+            // Only methods and types support generics.
+            Const(..) => intravisit::walk_impl_item(self, impl_item),
+        }
+    }
+
+    fn visit_path(&mut self, path: &'tcx hir::Path<'tcx>, _: hir::HirId) {
+        for (i, segment) in path.segments.iter().enumerate() {
+            let depth = path.segments.len() - i - 1;
+            if let Some(ref args) = segment.args {
+                self.visit_segment_args(path.res, depth, args);
+            }
+        }
+    }
+
+    fn visit_where_predicate(&mut self, predicate: &'tcx hir::WherePredicate<'tcx>) {
+        match predicate {
+            &hir::WherePredicate::BoundPredicate(..) => {
+                // Even if there are no lifetimes defined here, we still wrap it in a binder
+                // scope. If there happens to be a nested poly trait ref (an error), that
+                // will be `Concatenating` anyways, so we don't have to worry about the depth
+                // being wrong.
+                let scope = Scope::Binder { s: self.scope, scope_type: BinderScopeType::Normal };
+                self.with(scope, |this| intravisit::walk_where_predicate(this, predicate))
+            }
+            &hir::WherePredicate::RegionPredicate(..) | &hir::WherePredicate::EqPredicate(..) => {
+                intravisit::walk_where_predicate(self, predicate)
+            }
+        }
+    }
+
+    fn visit_param_bound(&mut self, bound: &'tcx hir::GenericBound<'tcx>) {
+        match bound {
+            hir::GenericBound::LangItemTrait(..) => {
+                // FIXME(jackh726): This is pretty weird. `LangItemTrait` doesn't go
+                // through the regular poly trait ref code, so we don't get another
+                // chance to introduce a binder. For now, I'm keeping the existing logic
+                // of "if there isn't a Binder scope above us, add one", but I
+                // imagine there's a better way to go about this.
+                let scope_type = self.poly_trait_ref_binder_info();
+
+                let scope = Scope::Binder { s: self.scope, scope_type };
+                self.with(scope, |this| intravisit::walk_param_bound(this, bound));
+            }
+            _ => intravisit::walk_param_bound(self, bound),
+        }
+    }
+
+    fn visit_poly_trait_ref(
+        &mut self,
+        trait_ref: &'tcx hir::PolyTraitRef<'tcx>,
+        modifier: hir::TraitBoundModifier,
+    ) {
+        debug!("visit_poly_trait_ref(trait_ref={:?})", trait_ref);
+
+        let scope_type = self.poly_trait_ref_binder_info();
+
+        // Always introduce a scope here, even if this is in a where clause and
+        // we introduced the binders around the bounded Ty. In that case, we
+        // just reuse the concatenation functionality also present in nested trait
+        // refs.
+        let scope = Scope::Binder { s: self.scope, scope_type };
+        self.with(scope, |this| intravisit::walk_poly_trait_ref(this, trait_ref, modifier));
+    }
+}
+
+impl<'a, 'tcx> LifetimeContext<'a, 'tcx> {
+    fn with<F>(&mut self, wrap_scope: Scope<'_>, f: F)
+    where
+        F: for<'b> FnOnce(&mut LifetimeContext<'b, 'tcx>),
+    {
+        let LifetimeContext { tcx, defs, .. } = self;
+        let mut this = LifetimeContext { tcx: *tcx, defs, scope: &wrap_scope };
+        f(&mut this);
+    }
+
+    #[tracing::instrument(level = "debug", skip(self))]
+    fn visit_segment_args(
+        &mut self,
+        res: Res,
+        depth: usize,
+        generic_args: &'tcx hir::GenericArgs<'tcx>,
+    ) {
+        if generic_args.parenthesized {
+            for input in generic_args.inputs() {
+                self.visit_ty(input);
+            }
+            let output = generic_args.bindings[0].ty();
+            self.visit_ty(output);
+            return;
+        }
+
+        // Figure out if this is a type/trait segment,
+        // which requires object lifetime defaults.
+        let parent_def_id = |this: &mut Self, def_id: DefId| {
+            let def_key = this.tcx.def_key(def_id);
+            DefId { krate: def_id.krate, index: def_key.parent.expect("missing parent") }
+        };
+        let type_def_id = match res {
+            Res::Def(DefKind::AssocTy, def_id) if depth == 1 => Some(parent_def_id(self, def_id)),
+            Res::Def(DefKind::Variant, def_id) if depth == 0 => Some(parent_def_id(self, def_id)),
+            Res::Def(
+                DefKind::Struct
+                | DefKind::Union
+                | DefKind::Enum
+                | DefKind::TyAlias
+                | DefKind::Trait,
+                def_id,
+            ) if depth == 0 => Some(def_id),
+            _ => None,
+        };
+        debug!(?type_def_id);
+
+        // Compute a vector of defaults, one for each type parameter,
+        // per the rules given in RFCs 599 and 1156. Example:
+        //
+        // ```rust
+        // struct Foo<'a, T: 'a, U> { }
+        // ```
+        //
+        // If you have `Foo<'x, dyn Bar, dyn Baz>`, we want to default
+        // `dyn Bar` to `dyn Bar + 'x` (because of the `T: 'a` bound)
+        // and `dyn Baz` to `dyn Baz + 'static` (because there is no
+        // such bound).
+        //
+        // Therefore, we would compute `object_lifetime_defaults` to a
+        // vector like `['x, 'static]`. Note that the vector only
+        // includes type parameters.
+        let object_lifetime_defaults = type_def_id.map_or_else(Vec::new, |def_id| {
+            let in_body = {
+                let mut scope = self.scope;
+                loop {
+                    match *scope {
+                        Scope::Root => break false,
+
+                        Scope::Body => break true,
+
+                        Scope::Binder { s, .. }
+                        | Scope::Static { s, .. }
+                        | Scope::ObjectLifetimeDefault { s, .. } => {
+                            scope = s;
+                        }
+                    }
+                }
+            };
+
+            let set_to_region = |set: &ObjectLifetimeDefault| match *set {
+                Set1::Empty => {
+                    if in_body {
+                        None
+                    } else {
+                        Some(Region::Static)
+                    }
+                }
+                Set1::One(Region::EarlyBound(index, _)) => {
+                    let mut lifetimes = generic_args.args.iter().filter_map(|arg| match arg {
+                        GenericArg::Lifetime(lt) => Some(lt),
+                        _ => None,
+                    });
+                    lifetimes
+                        .nth(index as usize)
+                        .and_then(|lifetime| self.tcx.named_region(lifetime.hir_id))
+                }
+                Set1::One(r) => Some(r),
+                Set1::Many => None,
+            };
+            self.tcx.object_lifetime_defaults(def_id).unwrap().iter().map(set_to_region).collect()
+        });
+        debug!(?object_lifetime_defaults);
+
+        let mut i = 0;
+        for arg in generic_args.args {
+            match arg {
+                GenericArg::Lifetime(_) => {}
+                GenericArg::Type(ty) => {
+                    if let Some(&lt) = object_lifetime_defaults.get(i) {
+                        let scope = Scope::ObjectLifetimeDefault { lifetime: lt, s: self.scope };
+                        self.with(scope, |this| this.visit_ty(ty));
+                    } else {
+                        self.visit_ty(ty);
+                    }
+                    i += 1;
+                }
+                GenericArg::Const(ct) => {
+                    self.visit_anon_const(&ct.value);
+                    i += 1;
+                }
+                GenericArg::Infer(inf) => {
+                    self.visit_id(inf.hir_id);
+                    i += 1;
+                }
+            }
+        }
+
+        // Hack: when resolving the type `XX` in binding like `dyn
+        // Foo<'b, Item = XX>`, the current object-lifetime default
+        // would be to examine the trait `Foo` to check whether it has
+        // a lifetime bound declared on `Item`. e.g., if `Foo` is
+        // declared like so, then the default object lifetime bound in
+        // `XX` should be `'b`:
+        //
+        // ```rust
+        // trait Foo<'a> {
+        //   type Item: 'a;
+        // }
+        // ```
+        //
+        // but if we just have `type Item;`, then it would be
+        // `'static`. However, we don't get all of this logic correct.
+        //
+        // Instead, we do something hacky: if there are no lifetime parameters
+        // to the trait, then we simply use a default object lifetime
+        // bound of `'static`, because there is no other possibility. On the other hand,
+        // if there ARE lifetime parameters, then we require the user to give an
+        // explicit bound for now.
+        //
+        // This is intended to leave room for us to implement the
+        // correct behavior in the future.
+        let has_lifetime_parameter =
+            generic_args.args.iter().any(|arg| matches!(arg, GenericArg::Lifetime(_)));
+
+        // Resolve lifetimes found in the bindings, so either in the type `XX` in `Item = XX` or
+        // in the trait ref `YY<...>` in `Item: YY<...>`.
+        for binding in generic_args.bindings {
+            let scope = Scope::ObjectLifetimeDefault {
+                lifetime: if has_lifetime_parameter { None } else { Some(Region::Static) },
+                s: self.scope,
+            };
+            self.with(scope, |this| this.visit_assoc_type_binding(binding));
+        }
+    }
+
+    fn resolve_object_lifetime_default(&mut self, lifetime_ref: &'tcx hir::Lifetime) {
+        debug!("resolve_object_lifetime_default(lifetime_ref={:?})", lifetime_ref);
+        let mut late_depth = 0;
+        let mut scope = self.scope;
+        let lifetime = loop {
+            match *scope {
+                Scope::Binder { s, scope_type, .. } => {
+                    match scope_type {
+                        BinderScopeType::Normal => late_depth += 1,
+                        BinderScopeType::Concatenating => {}
+                    }
+                    scope = s;
+                }
+
+                Scope::Root | Scope::Static { .. } => break Region::Static,
+
+                Scope::Body | Scope::ObjectLifetimeDefault { lifetime: None, .. } => return,
+
+                Scope::ObjectLifetimeDefault { lifetime: Some(l), .. } => break l,
+            }
+        };
+        let def = lifetime.shifted(late_depth);
+        debug!(?def);
+        self.defs.insert(lifetime_ref.hir_id.local_id, def);
+    }
+}

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -192,7 +192,7 @@ impl<'tcx> Clean<'tcx, Lifetime> for hir::Lifetime {
     fn clean(&self, cx: &mut DocContext<'tcx>) -> Lifetime {
         let def = cx.tcx.named_region(self.hir_id);
         if let Some(
-            rl::Region::EarlyBound(_, node_id)
+            rl::Region::EarlyBound(node_id)
             | rl::Region::LateBound(_, _, node_id)
             | rl::Region::Free(_, node_id),
         ) = def

--- a/src/test/incremental/hashes/enum_defs.rs
+++ b/src/test/incremental/hashes/enum_defs.rs
@@ -504,9 +504,9 @@ enum EnumAddLifetimeBoundToParameter<'a, T> {
 }
 
 #[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="hir_owner,hir_owner_nodes,generics_of,predicates_of")]
+#[rustc_clean(cfg="cfail2", except="hir_owner,hir_owner_nodes,predicates_of")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="hir_owner,hir_owner_nodes,generics_of,predicates_of")]
+#[rustc_clean(cfg="cfail5", except="hir_owner,hir_owner_nodes,predicates_of")]
 #[rustc_clean(cfg="cfail6")]
 enum EnumAddLifetimeBoundToParameter<'a, T: 'a> {
     Variant1(T),
@@ -559,9 +559,9 @@ enum EnumAddLifetimeBoundToParameterWhere<'a, T> {
 }
 
 #[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="hir_owner,hir_owner_nodes,generics_of,predicates_of")]
+#[rustc_clean(cfg="cfail2", except="hir_owner,hir_owner_nodes,predicates_of")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(cfg="cfail5", except="hir_owner,hir_owner_nodes,generics_of,predicates_of")]
+#[rustc_clean(cfg="cfail5", except="hir_owner,hir_owner_nodes,predicates_of")]
 #[rustc_clean(cfg="cfail6")]
 enum EnumAddLifetimeBoundToParameterWhere<'a, T> where T: 'a {
     Variant1(T),

--- a/src/test/incremental/hashes/trait_defs.rs
+++ b/src/test/incremental/hashes/trait_defs.rs
@@ -1054,9 +1054,9 @@ trait TraitAddTraitBoundToTypeParameterOfTrait<T: ReferencedTrait0> { }
 trait TraitAddLifetimeBoundToTypeParameterOfTrait<'a, T> { }
 
 #[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="hir_owner,hir_owner_nodes,generics_of,predicates_of", cfg="cfail2")]
+#[rustc_clean(except="hir_owner,hir_owner_nodes,predicates_of", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="hir_owner,hir_owner_nodes,generics_of,predicates_of", cfg="cfail5")]
+#[rustc_clean(except="hir_owner,hir_owner_nodes,predicates_of", cfg="cfail5")]
 #[rustc_clean(cfg="cfail6")]
 trait TraitAddLifetimeBoundToTypeParameterOfTrait<'a, T: 'a> { }
 
@@ -1132,9 +1132,9 @@ trait TraitAddSecondTraitBoundToTypeParameterOfTrait<T: ReferencedTrait0 + Refer
 trait TraitAddSecondLifetimeBoundToTypeParameterOfTrait<'a, 'b, T: 'a> { }
 
 #[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="hir_owner,hir_owner_nodes,generics_of,predicates_of", cfg="cfail2")]
+#[rustc_clean(except="hir_owner,hir_owner_nodes,predicates_of", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="hir_owner,hir_owner_nodes,generics_of,predicates_of", cfg="cfail5")]
+#[rustc_clean(except="hir_owner,hir_owner_nodes,predicates_of", cfg="cfail5")]
 #[rustc_clean(cfg="cfail6")]
 trait TraitAddSecondLifetimeBoundToTypeParameterOfTrait<'a, 'b, T: 'a + 'b> { }
 
@@ -1189,9 +1189,9 @@ trait TraitAddTraitBoundToTypeParameterOfTraitWhere<T> where T: ReferencedTrait0
 trait TraitAddLifetimeBoundToTypeParameterOfTraitWhere<'a, T> { }
 
 #[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="hir_owner,hir_owner_nodes,generics_of,predicates_of", cfg="cfail2")]
+#[rustc_clean(except="hir_owner,hir_owner_nodes,predicates_of", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="hir_owner,hir_owner_nodes,generics_of,predicates_of", cfg="cfail5")]
+#[rustc_clean(except="hir_owner,hir_owner_nodes,predicates_of", cfg="cfail5")]
 #[rustc_clean(cfg="cfail6")]
 trait TraitAddLifetimeBoundToTypeParameterOfTraitWhere<'a, T> where T: 'a { }
 
@@ -1242,9 +1242,9 @@ trait TraitAddSecondTraitBoundToTypeParameterOfTraitWhere<T>
 trait TraitAddSecondLifetimeBoundToTypeParameterOfTraitWhere<'a, 'b, T> where T: 'a { }
 
 #[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(except="hir_owner,hir_owner_nodes,generics_of,predicates_of", cfg="cfail2")]
+#[rustc_clean(except="hir_owner,hir_owner_nodes,predicates_of", cfg="cfail2")]
 #[rustc_clean(cfg="cfail3")]
-#[rustc_clean(except="hir_owner,hir_owner_nodes,generics_of,predicates_of", cfg="cfail5")]
+#[rustc_clean(except="hir_owner,hir_owner_nodes,predicates_of", cfg="cfail5")]
 #[rustc_clean(cfg="cfail6")]
 trait TraitAddSecondLifetimeBoundToTypeParameterOfTraitWhere<'a, 'b, T> where T: 'a + 'b { }
 

--- a/src/test/ui/issues/issue-41139.rs
+++ b/src/test/ui/issues/issue-41139.rs
@@ -8,5 +8,5 @@ fn main() {
     // This isn't great. The issue here is that `dyn Trait` is not sized, so
     // `dyn Fn() -> dyn Trait` is not well-formed.
     let t: &dyn Trait = &get_function()();
-    //~^ ERROR expected function, found `&dyn Fn() -> (dyn Trait + 'static)`
+    //~^ ERROR expected function, found `&dyn Fn() -> dyn Trait`
 }

--- a/src/test/ui/issues/issue-41139.stderr
+++ b/src/test/ui/issues/issue-41139.stderr
@@ -1,8 +1,8 @@
-error[E0618]: expected function, found `&dyn Fn() -> (dyn Trait + 'static)`
+error[E0618]: expected function, found `&dyn Fn() -> dyn Trait`
   --> $DIR/issue-41139.rs:10:26
    |
 LL | fn get_function<'a>() -> &'a dyn Fn() -> dyn Trait {
-   | -------------------------------------------------- `get_function` defined here returns `&dyn Fn() -> (dyn Trait + 'static)`
+   | -------------------------------------------------- `get_function` defined here returns `&dyn Fn() -> dyn Trait`
 ...
 LL |     let t: &dyn Trait = &get_function()();
    |                          ^^^^^^^^^^^^^^--


### PR DESCRIPTION
Resolution of object lifetime default is currently done during lifetime resolution.
However, this computation happens at a higher level, fetching `generics_of` query to be well defined.

This separation allows to remove the computation of "early index" from lifetime resolution,
relying on the computation performed by `generics_of` instead.
Having a completely separate computation allows to avoid cycles between lifetime resolution and `generics_of`.

Caveat: this implementation still replicates the nested `Binder` model from lifetime resolution
to correctly handle late-bound Debruijn indices.  I don't know yet how to clean this up.

~Based on https://github.com/rust-lang/rust/pull/96296~