### PR TITLE
Add more eslint rules

### DIFF
--- a/src/librustdoc/html/static/.eslintrc.js
+++ b/src/librustdoc/html/static/.eslintrc.js
@@ -50,5 +50,6 @@ module.exports = {
         "space-infix-ops": "error",
         "space-before-function-paren": ["error", "never"],
         "space-before-blocks": "error",
+        "comma-dangle": ["error", "always-multiline"],
     }
 };

--- a/src/librustdoc/html/static/.eslintrc.js
+++ b/src/librustdoc/html/static/.eslintrc.js
@@ -51,5 +51,6 @@ module.exports = {
         "space-before-function-paren": ["error", "never"],
         "space-before-blocks": "error",
         "comma-dangle": ["error", "always-multiline"],
+        "comma-style": ["error", "last"],
     }
 };

--- a/src/librustdoc/html/static/.eslintrc.js
+++ b/src/librustdoc/html/static/.eslintrc.js
@@ -53,5 +53,6 @@ module.exports = {
         "comma-dangle": ["error", "always-multiline"],
         "comma-style": ["error", "last"],
         "max-len": ["error", { "code": 100, "tabWidth": 4 }],
+        "eol-last": ["error", "always"],
     }
 };

--- a/src/librustdoc/html/static/.eslintrc.js
+++ b/src/librustdoc/html/static/.eslintrc.js
@@ -49,5 +49,6 @@ module.exports = {
         "func-call-spacing": ["error", "never"],
         "space-infix-ops": "error",
         "space-before-function-paren": ["error", "never"],
+        "space-before-blocks": "error",
     }
 };

--- a/src/librustdoc/html/static/.eslintrc.js
+++ b/src/librustdoc/html/static/.eslintrc.js
@@ -52,5 +52,6 @@ module.exports = {
         "space-before-blocks": "error",
         "comma-dangle": ["error", "always-multiline"],
         "comma-style": ["error", "last"],
+        "max-len": ["error", { "code": 100, "tabWidth": 4 }],
     }
 };

--- a/src/librustdoc/html/static/.eslintrc.js
+++ b/src/librustdoc/html/static/.eslintrc.js
@@ -47,5 +47,6 @@ module.exports = {
             { "beforeColon": false, "afterColon": true, "mode": "strict" }
         ],
         "func-call-spacing": ["error", "never"],
+        "space-infix-ops": "error",
     }
 };

--- a/src/librustdoc/html/static/.eslintrc.js
+++ b/src/librustdoc/html/static/.eslintrc.js
@@ -48,5 +48,6 @@ module.exports = {
         ],
         "func-call-spacing": ["error", "never"],
         "space-infix-ops": "error",
+        "space-before-function-paren": ["error", "never"],
     }
 };

--- a/src/librustdoc/html/static/js/main.js
+++ b/src/librustdoc/html/static/js/main.js
@@ -63,7 +63,7 @@ function showMain() {
     removeClass(document.getElementById(MAIN_ID), "hidden");
 }
 
-(function () {
+(function() {
     window.rootPath = getVar("root-path");
     window.currentCrate = getVar("current-crate");
     window.searchJS =  resourcePath("search", ".js");
@@ -929,7 +929,7 @@ function loadCss(cssFileName) {
     searchState.setup();
 }());
 
-(function () {
+(function() {
     let reset_button_timeout = null;
 
     window.copy_path = but => {

--- a/src/librustdoc/html/static/js/scrape-examples.js
+++ b/src/librustdoc/html/static/js/scrape-examples.js
@@ -2,7 +2,7 @@
 
 "use strict";
 
-(function () {
+(function() {
     // Number of lines shown when code viewer is not expanded
     const MAX_LINES = 10;
 

--- a/src/librustdoc/html/static/js/settings.js
+++ b/src/librustdoc/html/static/js/settings.js
@@ -5,7 +5,7 @@
 
 "use strict";
 
-(function () {
+(function() {
     const isSettingsPage = window.location.pathname.endsWith("/settings.html");
 
     function changeSetting(settingName, value) {

--- a/src/librustdoc/html/static/js/source-script.js
+++ b/src/librustdoc/html/static/js/source-script.js
@@ -187,7 +187,7 @@ function highlightSourceLines(match) {
     }
 }
 
-const handleSourceHighlight = (function () {
+const handleSourceHighlight = (function() {
     let prev_line_id = 0;
 
     const set_fragment = name => {

--- a/src/librustdoc/html/static/js/storage.js
+++ b/src/librustdoc/html/static/js/storage.js
@@ -4,7 +4,7 @@ const darkThemes = ["dark", "ayu"];
 window.currentTheme = document.getElementById("themeStyle");
 window.mainTheme = document.getElementById("mainThemeStyle");
 
-const settingsDataset = (function () {
+const settingsDataset = (function() {
     const settingsElement = document.getElementById("default-settings");
     if (settingsElement === null) {
         return null;
@@ -163,7 +163,7 @@ function useSystemTheme(value) {
     }
 }
 
-const updateSystemTheme = (function () {
+const updateSystemTheme = (function() {
     if (!window.matchMedia) {
         // fallback to the CSS computed value
         return () => {


### PR DESCRIPTION
This PR adds more eslint rules. Here are the explanations for each of them:

 * [space-infix-ops](https://eslint.org/docs/rules/space-infix-ops)
 * [space-before-function-paren](https://eslint.org/docs/rules/space-before-function-paren)
 * [space-before-blocks](https://eslint.org/docs/rules/space-before-blocks)
 * [comma-dangle](https://eslint.org/docs/rules/comma-dangle)
 * [comma-style](https://eslint.org/docs/rules/comma-style)
 * [max-len](https://eslint.org/docs/rules/max-len)
 * [eol-last](https://eslint.org/docs/rules/eol-last)

r? @notriddle 