### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/compiler/rustc_builtin_macros/src/deriving/generic/mod.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/generic/mod.rs
@@ -257,7 +257,7 @@ pub struct Substructure<'a> {
     pub type_ident: Ident,
     /// ident of the method
     pub method_ident: Ident,
-    /// dereferenced access to any [`Self_`] or [`Ptr(Self_, _)][ptr]` arguments
+    /// dereferenced access to any [`Self_`] or [`Ptr(Self_, _)`][ptr] arguments
     ///
     /// [`Self_`]: ty::Ty::Self_
     /// [ptr]: ty::Ty::Ptr

--- a/compiler/rustc_metadata/src/native_libs.rs
+++ b/compiler/rustc_metadata/src/native_libs.rs
@@ -418,10 +418,11 @@ impl<'tcx> Collector<'tcx> {
                             // involved or not, library reordering and kind overriding without
                             // explicit `:rename` in particular.
                             if lib.has_modifiers() || passed_lib.has_modifiers() {
-                                self.tcx.sess.span_err(
-                                    self.tcx.def_span(lib.foreign_module.unwrap()),
-                                    "overriding linking modifiers from command line is not supported"
-                                );
+                                let msg = "overriding linking modifiers from command line is not supported";
+                                match lib.foreign_module {
+                                    Some(def_id) => self.tcx.sess.span_err(self.tcx.def_span(def_id), msg),
+                                    None => self.tcx.sess.err(msg),
+                                };
                             }
                             if passed_lib.kind != NativeLibKind::Unspecified {
                                 lib.kind = passed_lib.kind;

--- a/compiler/rustc_mir_build/src/thir/pattern/const_to_pat.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/const_to_pat.rs
@@ -121,27 +121,27 @@ impl<'a, 'tcx> ConstToPat<'a, 'tcx> {
 
     fn search_for_structural_match_violation(&self, ty: Ty<'tcx>) -> Option<String> {
         traits::search_for_structural_match_violation(self.span, self.tcx(), ty).map(|non_sm_ty| {
-            with_no_trimmed_paths!(match non_sm_ty {
-                traits::NonStructuralMatchTy::Adt(adt) => self.adt_derive_msg(adt),
-                traits::NonStructuralMatchTy::Dynamic => {
+            with_no_trimmed_paths!(match non_sm_ty.kind {
+                traits::NonStructuralMatchTyKind::Adt(adt) => self.adt_derive_msg(adt),
+                traits::NonStructuralMatchTyKind::Dynamic => {
                     "trait objects cannot be used in patterns".to_string()
                 }
-                traits::NonStructuralMatchTy::Opaque => {
+                traits::NonStructuralMatchTyKind::Opaque => {
                     "opaque types cannot be used in patterns".to_string()
                 }
-                traits::NonStructuralMatchTy::Closure => {
+                traits::NonStructuralMatchTyKind::Closure => {
                     "closures cannot be used in patterns".to_string()
                 }
-                traits::NonStructuralMatchTy::Generator => {
+                traits::NonStructuralMatchTyKind::Generator => {
                     "generators cannot be used in patterns".to_string()
                 }
-                traits::NonStructuralMatchTy::Param => {
+                traits::NonStructuralMatchTyKind::Param => {
                     bug!("use of a constant whose type is a parameter inside a pattern")
                 }
-                traits::NonStructuralMatchTy::Projection => {
+                traits::NonStructuralMatchTyKind::Projection => {
                     bug!("use of a constant whose type is a projection inside a pattern")
                 }
-                traits::NonStructuralMatchTy::Foreign => {
+                traits::NonStructuralMatchTyKind::Foreign => {
                     bug!("use of a value of a foreign type inside a pattern")
                 }
             })

--- a/compiler/rustc_trait_selection/src/traits/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/mod.rs
@@ -62,7 +62,7 @@ pub use self::specialize::specialization_graph::FutureCompatOverlapError;
 pub use self::specialize::specialization_graph::FutureCompatOverlapErrorKind;
 pub use self::specialize::{specialization_graph, translate_substs, OverlapError};
 pub use self::structural_match::search_for_structural_match_violation;
-pub use self::structural_match::NonStructuralMatchTy;
+pub use self::structural_match::{NonStructuralMatchTy, NonStructuralMatchTyKind};
 pub use self::util::{
     elaborate_obligations, elaborate_predicates, elaborate_predicates_with_span,
     elaborate_trait_ref, elaborate_trait_refs,

--- a/compiler/rustc_typeck/src/check/writeback.rs
+++ b/compiler/rustc_typeck/src/check/writeback.rs
@@ -263,8 +263,6 @@ impl<'cx, 'tcx> Visitor<'tcx> for WritebackCx<'cx, 'tcx> {
         self.fix_scalar_builtin_expr(e);
         self.fix_index_builtin_expr(e);
 
-        self.visit_node_id(e.span, e.hir_id);
-
         match e.kind {
             hir::ExprKind::Closure(_, _, body, _, _) => {
                 let body = self.fcx.tcx.hir().body(body);
@@ -291,6 +289,7 @@ impl<'cx, 'tcx> Visitor<'tcx> for WritebackCx<'cx, 'tcx> {
             _ => {}
         }
 
+        self.visit_node_id(e.span, e.hir_id);
         intravisit::walk_expr(self, e);
     }
 

--- a/src/test/ui/const-generics/issues/issue-63322-forbid-dyn.full.stderr
+++ b/src/test/ui/const-generics/issues/issue-63322-forbid-dyn.full.stderr
@@ -1,8 +1,8 @@
-error[E0741]: `&'static (dyn A + 'static)` must be annotated with `#[derive(PartialEq, Eq)]` to be used as the type of a const parameter
+error[E0741]: `(dyn A + 'static)` must be annotated with `#[derive(PartialEq, Eq)]` to be used as the type of a const parameter
   --> $DIR/issue-63322-forbid-dyn.rs:9:18
    |
 LL | fn test<const T: &'static dyn A>() {
-   |                  ^^^^^^^^^^^^^^ `&'static (dyn A + 'static)` doesn't derive both `PartialEq` and `Eq`
+   |                  ^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 

--- a/src/test/ui/const-generics/issues/issue-97278.rs
+++ b/src/test/ui/const-generics/issues/issue-97278.rs
@@ -1,0 +1,14 @@
+#![feature(adt_const_params)]
+#![allow(incomplete_features)]
+
+use std::sync::Arc;
+
+#[derive(PartialEq, Eq)]
+enum Bar {
+    Bar(Arc<i32>)
+}
+
+fn test<const BAR: Bar>() {}
+//~^ ERROR `Arc<i32>` must be annotated with `#[derive(PartialEq, Eq)]`
+
+fn main() {}

--- a/src/test/ui/const-generics/issues/issue-97278.stderr
+++ b/src/test/ui/const-generics/issues/issue-97278.stderr
@@ -1,0 +1,9 @@
+error[E0741]: `Arc<i32>` must be annotated with `#[derive(PartialEq, Eq)]` to be used as the type of a const parameter
+  --> $DIR/issue-97278.rs:11:20
+   |
+LL | fn test<const BAR: Bar>() {}
+   |                    ^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0741`.

--- a/src/test/ui/native-library-link-flags/modifiers-override-3.rs
+++ b/src/test/ui/native-library-link-flags/modifiers-override-3.rs
@@ -1,0 +1,7 @@
+// Regression test for issue #97299, one command line library with modifiers
+// overrides another command line library with modifiers.
+
+// compile-flags:-lstatic:+whole-archive=foo -lstatic:+whole-archive=foo
+// error-pattern: overriding linking modifiers from command line is not supported
+
+fn main() {}

--- a/src/test/ui/native-library-link-flags/modifiers-override-3.stderr
+++ b/src/test/ui/native-library-link-flags/modifiers-override-3.stderr
@@ -1,0 +1,4 @@
+error: overriding linking modifiers from command line is not supported
+
+error: aborting due to previous error
+

--- a/src/test/ui/traits/issue-82830.rs
+++ b/src/test/ui/traits/issue-82830.rs
@@ -1,0 +1,16 @@
+trait A<Y, N> {
+    type B;
+}
+
+type MaybeBox<T> = <T as A<T, Box<T>>>::B;
+struct P {
+    t: MaybeBox<P>, //~ ERROR: overflow evaluating the requirement `P: Sized`
+}
+
+impl<Y, N> A<Y, N> for P {
+    type B = N;
+}
+
+fn main() {
+    let t: MaybeBox<P>;
+}

--- a/src/test/ui/traits/issue-82830.stderr
+++ b/src/test/ui/traits/issue-82830.stderr
@@ -1,0 +1,15 @@
+error[E0275]: overflow evaluating the requirement `P: Sized`
+  --> $DIR/issue-82830.rs:7:8
+   |
+LL |     t: MaybeBox<P>,
+   |        ^^^^^^^^^^^
+   |
+note: required because of the requirements on the impl of `A<P, Box<P>>` for `P`
+  --> $DIR/issue-82830.rs:10:12
+   |
+LL | impl<Y, N> A<Y, N> for P {
+   |            ^^^^^^^     ^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0275`.

--- a/src/test/ui/type/type-check/unknown_type_for_closure.rs
+++ b/src/test/ui/type/type-check/unknown_type_for_closure.rs
@@ -1,3 +1,17 @@
-fn main() {
-    let x = |_| {    }; //~ ERROR type annotations needed
+fn infer_in_arg() {
+    let x = |b: Vec<_>| {}; //~ ERROR E0282
 }
+
+fn empty_pattern() {
+    let x = |_| {}; //~ ERROR type annotations needed
+}
+
+fn infer_ty() {
+    let x = |k: _| {}; //~ ERROR type annotations needed
+}
+
+fn ambig_return() {
+    let x = || -> Vec<_> { Vec::new() }; //~ ERROR type annotations needed for the closure `fn() -> Vec<_>`
+}
+
+fn main() {}

--- a/src/test/ui/type/type-check/unknown_type_for_closure.stderr
+++ b/src/test/ui/type/type-check/unknown_type_for_closure.stderr
@@ -1,9 +1,32 @@
-error[E0282]: type annotations needed
+error[E0282]: type annotations needed for `Vec<_>`
   --> $DIR/unknown_type_for_closure.rs:2:14
    |
-LL |     let x = |_| {    };
+LL |     let x = |b: Vec<_>| {};
    |              ^ consider giving this closure parameter a type
 
-error: aborting due to previous error
+error[E0282]: type annotations needed
+  --> $DIR/unknown_type_for_closure.rs:6:14
+   |
+LL |     let x = |_| {};
+   |              ^ consider giving this closure parameter a type
+
+error[E0282]: type annotations needed
+  --> $DIR/unknown_type_for_closure.rs:10:14
+   |
+LL |     let x = |k: _| {};
+   |              ^ consider giving this closure parameter a type
+
+error[E0282]: type annotations needed for the closure `fn() -> Vec<_>`
+  --> $DIR/unknown_type_for_closure.rs:14:28
+   |
+LL |     let x = || -> Vec<_> { Vec::new() };
+   |                            ^^^^^^^^ cannot infer type for type parameter `T`
+   |
+help: give this closure an explicit return type without `_` placeholders
+   |
+LL |     let x = || -> Vec<_> { Vec::new() };
+   |                   ~~~~~~
+
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0282`.


### PR DESCRIPTION
Successful merges:

 - #97302 (Do writeback of Closure params before visiting the parent expression)
 - #97328 (rustc: Fix ICE in native library error reporting)
 - #97351 (Output correct type responsible for structural match violation)
 - #97398 (Add regression test for #82830)
 - #97400 (Fix a typo on Struct `Substructure`)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=97302,97328,97351,97398,97400)
<!-- homu-ignore:end -->