### PR TITLE
Only allow `compiletest` to use `feature(test)`, not any other feature

### DIFF
--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -1232,7 +1232,12 @@ impl<'a> Builder<'a> {
                 // HACK: because anyhow does feature detection in build.rs, we need to allow the backtrace feature too.
                 rustflags.arg("-Zallow-features=binary-dep-depinfo,backtrace");
             }
-            Mode::Std | Mode::Rustc | Mode::ToolStd | Mode::Codegen | Mode::ToolRustc => {}
+            Mode::ToolStd => {
+                // Right now this is just compiletest and a few other tools that build on stable.
+                // Allow them to use `feature(test)`, but nothing else.
+                rustflags.arg("-Zallow-features=binary-dep-depinfo,test,backtrace");
+            }
+            Mode::Std | Mode::Rustc | Mode::Codegen | Mode::ToolRustc => {}
         }
 
         cargo.arg("-j").arg(self.jobs().to_string());


### PR DESCRIPTION
Using language features occasionally causes issues when using nightly to bootstrap, rather than beta.
See #59264 for additional context.