### PR TITLE
Make `from{,_mut}_ptr_range` const

### DIFF
--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -130,6 +130,7 @@
 #![feature(ptr_sub_ptr)]
 #![feature(receiver_trait)]
 #![feature(set_ptr_value)]
+#![feature(slice_from_ptr_range)]
 #![feature(slice_group_by)]
 #![feature(slice_ptr_get)]
 #![feature(slice_ptr_len)]

--- a/library/alloc/src/slice.rs
+++ b/library/alloc/src/slice.rs
@@ -114,6 +114,8 @@ pub use core::slice::EscapeAscii;
 pub use core::slice::SliceIndex;
 #[stable(feature = "from_ref", since = "1.28.0")]
 pub use core::slice::{from_mut, from_ref};
+#[unstable(feature = "slice_from_ptr_range", issue = "89792")]
+pub use core::slice::{from_mut_ptr_range, from_ptr_range};
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use core::slice::{from_raw_parts, from_raw_parts_mut};
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/library/core/src/slice/raw.rs
+++ b/library/core/src/slice/raw.rs
@@ -213,7 +213,8 @@ pub const fn from_mut<T>(s: &mut T) -> &mut [T] {
 ///
 /// [valid]: ptr#safety
 #[unstable(feature = "slice_from_ptr_range", issue = "89792")]
-pub unsafe fn from_ptr_range<'a, T>(range: Range<*const T>) -> &'a [T] {
+#[rustc_const_unstable(feature = "slice_from_ptr_range_const", issue = "89792")]
+pub const unsafe fn from_ptr_range<'a, T>(range: Range<*const T>) -> &'a [T] {
     // SAFETY: the caller must uphold the safety contract for `from_ptr_range`.
     unsafe { from_raw_parts(range.start, range.end.sub_ptr(range.start)) }
 }
@@ -263,7 +264,8 @@ pub unsafe fn from_ptr_range<'a, T>(range: Range<*const T>) -> &'a [T] {
 ///
 /// [valid]: ptr#safety
 #[unstable(feature = "slice_from_ptr_range", issue = "89792")]
-pub unsafe fn from_mut_ptr_range<'a, T>(range: Range<*mut T>) -> &'a mut [T] {
+#[rustc_const_unstable(feature = "slice_from_mut_ptr_range_const", issue = "89792")]
+pub const unsafe fn from_mut_ptr_range<'a, T>(range: Range<*mut T>) -> &'a mut [T] {
     // SAFETY: the caller must uphold the safety contract for `from_mut_ptr_range`.
     unsafe { from_raw_parts_mut(range.start, range.end.sub_ptr(range.start)) }
 }

--- a/library/core/src/slice/raw.rs
+++ b/library/core/src/slice/raw.rs
@@ -213,7 +213,7 @@ pub const fn from_mut<T>(s: &mut T) -> &mut [T] {
 ///
 /// [valid]: ptr#safety
 #[unstable(feature = "slice_from_ptr_range", issue = "89792")]
-#[rustc_const_unstable(feature = "slice_from_ptr_range_const", issue = "89792")]
+#[rustc_const_unstable(feature = "const_slice_from_ptr_range", issue = "89792")]
 pub const unsafe fn from_ptr_range<'a, T>(range: Range<*const T>) -> &'a [T] {
     // SAFETY: the caller must uphold the safety contract for `from_ptr_range`.
     unsafe { from_raw_parts(range.start, range.end.sub_ptr(range.start)) }

--- a/src/test/ui/const-ptr/allowed_slices.rs
+++ b/src/test/ui/const-ptr/allowed_slices.rs
@@ -1,0 +1,106 @@
+// run-pass
+#![feature(
+    const_slice_from_raw_parts,
+    slice_from_ptr_range,
+    slice_from_ptr_range_const,
+    pointer_byte_offsets,
+    const_pointer_byte_offsets
+)]
+use std::{
+    mem::MaybeUninit,
+    ptr,
+    slice::{from_ptr_range, from_raw_parts},
+};
+
+// Dangling is ok, as long as it's either for ZST reads or for no reads
+pub static S0: &[u32] = unsafe { from_raw_parts(dangling(), 0) };
+pub static S1: &[()] = unsafe { from_raw_parts(dangling(), 3) };
+
+// References are always valid of reads of a single element (basically `slice::from_ref`)
+pub static S2: &[u32] = unsafe { from_raw_parts(&D0, 1) };
+pub static S3: &[MaybeUninit<&u32>] = unsafe { from_raw_parts(&D1, 1) };
+
+// Reinterpreting data is fine, as long as layouts match
+pub static S4: &[u8] = unsafe { from_raw_parts((&D0) as *const _ as _, 3) };
+// This is only valid because D1 has uninitialized bytes, if it was an initialized pointer,
+// that would reinterpret pointers as integers which is UB in CTFE.
+pub static S5: &[MaybeUninit<u8>] = unsafe { from_raw_parts((&D1) as *const _ as _, 2) };
+// Even though u32 and [bool; 4] have different layouts, D0 has a value that
+// is valid as [bool; 4], so this is not UB (it's basically a transmute)
+pub static S6: &[bool] = unsafe { from_raw_parts((&D0) as *const _ as _, 4) };
+
+// Structs are considered single allocated objects,
+// as long as you don't reinterpret padding as initialized
+// data everything is ok.
+pub static S7: &[u16] = unsafe {
+    let ptr = (&D2 as *const Struct as *const u16).byte_add(4);
+
+    from_raw_parts(ptr, 3)
+};
+pub static S8: &[MaybeUninit<u16>] = unsafe {
+    let ptr = &D2 as *const Struct as *const MaybeUninit<u16>;
+
+    from_raw_parts(ptr, 6)
+};
+
+pub static R0: &[u32] = unsafe { from_ptr_range(dangling()..dangling()) };
+// from_ptr_range panics on zst
+//pub static R1: &[()] = unsafe { from_ptr_range(dangling(), dangling().byte_add(3)) };
+pub static R2: &[u32] = unsafe {
+    let ptr = &D0 as *const u32;
+    from_ptr_range(ptr..ptr.add(1))
+};
+pub static R3: &[MaybeUninit<&u32>] = unsafe {
+    let ptr = &D1 as *const MaybeUninit<&u32>;
+    from_ptr_range(ptr..ptr.add(1))
+};
+pub static R4: &[u8] = unsafe {
+    let ptr = &D0 as *const u32 as *const u8;
+    from_ptr_range(ptr..ptr.add(3))
+};
+pub static R5: &[MaybeUninit<u8>] = unsafe {
+    let ptr = &D1 as *const MaybeUninit<&u32> as *const MaybeUninit<u8>;
+    from_ptr_range(ptr..ptr.add(2))
+};
+pub static R6: &[bool] = unsafe {
+    let ptr = &D0 as *const u32 as *const bool;
+    from_ptr_range(ptr..ptr.add(4))
+};
+pub static R7: &[u16] = unsafe {
+    let d2 = &D2;
+    let l = &d2.b as *const u32 as *const u16;
+    let r = &d2.d as *const u8 as *const u16;
+
+    from_ptr_range(l..r)
+};
+pub static R8: &[MaybeUninit<u16>] = unsafe {
+    let d2 = &D2;
+    let l = d2 as *const Struct as *const MaybeUninit<u16>;
+    let r = &d2.d as *const u8 as *const MaybeUninit<u16>;
+
+    from_ptr_range(l..r)
+};
+
+// Using valid slice is always valid
+pub static R9: &[u32] = unsafe { from_ptr_range(R0.as_ptr_range()) };
+pub static R10: &[u32] = unsafe { from_ptr_range(R2.as_ptr_range()) };
+
+const D0: u32 = (1 << 16) | 1;
+const D1: MaybeUninit<&u32> = MaybeUninit::uninit();
+const D2: Struct = Struct { a: 1, b: 2, c: 3, d: 4 };
+
+const fn dangling<T>() -> *const T {
+    ptr::NonNull::dangling().as_ptr() as _
+}
+
+#[repr(C)]
+struct Struct {
+    a: u8,
+    // _pad: [MaybeUninit<u8>; 3]
+    b: u32,
+    c: u16,
+    d: u8,
+    // _pad: [MaybeUninit<u8>; 1]
+}
+
+fn main() {}

--- a/src/test/ui/const-ptr/allowed_slices.rs
+++ b/src/test/ui/const-ptr/allowed_slices.rs
@@ -2,7 +2,7 @@
 #![feature(
     const_slice_from_raw_parts,
     slice_from_ptr_range,
-    slice_from_ptr_range_const,
+    const_slice_from_ptr_range,
     pointer_byte_offsets,
     const_pointer_byte_offsets
 )]

--- a/src/test/ui/const-ptr/forbidden_slices.32bit.stderr
+++ b/src/test/ui/const-ptr/forbidden_slices.32bit.stderr
@@ -7,10 +7,10 @@ LL |         &*ptr::slice_from_raw_parts(data, len)
    |         dereferencing pointer failed: null pointer is not a valid pointer
    |         inside `std::slice::from_raw_parts::<u32>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
    |
-  ::: $DIR/forbidden_slices.rs:18:34
+  ::: $DIR/forbidden_slices.rs:19:34
    |
 LL | pub static S0: &[u32] = unsafe { from_raw_parts(ptr::null(), 0) };
-   |                                  ------------------------------ inside `S0` at $DIR/forbidden_slices.rs:18:34
+   |                                  ------------------------------ inside `S0` at $DIR/forbidden_slices.rs:19:34
 
 error[E0080]: could not evaluate static initializer
   --> $SRC_DIR/core/src/slice/raw.rs:LL:COL
@@ -21,10 +21,10 @@ LL |         &*ptr::slice_from_raw_parts(data, len)
    |         dereferencing pointer failed: null pointer is not a valid pointer
    |         inside `std::slice::from_raw_parts::<()>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
    |
-  ::: $DIR/forbidden_slices.rs:19:33
+  ::: $DIR/forbidden_slices.rs:20:33
    |
 LL | pub static S1: &[()] = unsafe { from_raw_parts(ptr::null(), 0) };
-   |                                 ------------------------------ inside `S1` at $DIR/forbidden_slices.rs:19:33
+   |                                 ------------------------------ inside `S1` at $DIR/forbidden_slices.rs:20:33
 
 error[E0080]: could not evaluate static initializer
   --> $SRC_DIR/core/src/slice/raw.rs:LL:COL
@@ -35,13 +35,13 @@ LL |         &*ptr::slice_from_raw_parts(data, len)
    |         dereferencing pointer failed: ALLOC_ID has size 4, so pointer to 8 bytes starting at offset 0 is out-of-bounds
    |         inside `std::slice::from_raw_parts::<u32>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
    |
-  ::: $DIR/forbidden_slices.rs:22:34
+  ::: $DIR/forbidden_slices.rs:23:34
    |
 LL | pub static S2: &[u32] = unsafe { from_raw_parts(&D0, 2) };
-   |                                  ---------------------- inside `S2` at $DIR/forbidden_slices.rs:22:34
+   |                                  ---------------------- inside `S2` at $DIR/forbidden_slices.rs:23:34
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/forbidden_slices.rs:25:1
+  --> $DIR/forbidden_slices.rs:26:1
    |
 LL | pub static S4: &[u8] = unsafe { from_raw_parts((&D1) as *const _ as _, 1) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .<deref>[0]: encountered uninitialized bytes
@@ -52,7 +52,7 @@ LL | pub static S4: &[u8] = unsafe { from_raw_parts((&D1) as *const _ as _, 1) }
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/forbidden_slices.rs:27:1
+  --> $DIR/forbidden_slices.rs:28:1
    |
 LL | pub static S5: &[u8] = unsafe { from_raw_parts((&D3) as *const _ as _, size_of::<&u32>()) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .<deref>: encountered a pointer, but expected plain (non-pointer) bytes
@@ -63,7 +63,7 @@ LL | pub static S5: &[u8] = unsafe { from_raw_parts((&D3) as *const _ as _, size
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/forbidden_slices.rs:29:1
+  --> $DIR/forbidden_slices.rs:30:1
    |
 LL | pub static S6: &[bool] = unsafe { from_raw_parts((&D0) as *const _ as _, 4) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .<deref>[0]: encountered 0x11, but expected a boolean
@@ -74,7 +74,7 @@ LL | pub static S6: &[bool] = unsafe { from_raw_parts((&D0) as *const _ as _, 4)
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/forbidden_slices.rs:32:1
+  --> $DIR/forbidden_slices.rs:33:1
    |
 LL | / pub static S7: &[u16] = unsafe {
 LL | |
@@ -86,7 +86,7 @@ LL | | };
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾─a79+0x1─╼ 04 00 00 00                         │ ╾──╼....
+               ╾─A_ID+0x1─╼ 04 00 00 00                         │ ╾──╼....
            }
 
 error[E0080]: could not evaluate static initializer
@@ -98,10 +98,10 @@ LL |         &*ptr::slice_from_raw_parts(data, len)
    |         dereferencing pointer failed: ALLOC_ID has size 8, so pointer to 8 bytes starting at offset 1 is out-of-bounds
    |         inside `std::slice::from_raw_parts::<u64>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
    |
-  ::: $DIR/forbidden_slices.rs:43:5
+  ::: $DIR/forbidden_slices.rs:44:5
    |
 LL |     from_raw_parts(ptr, 1)
-   |     ---------------------- inside `S8` at $DIR/forbidden_slices.rs:43:5
+   |     ---------------------- inside `S8` at $DIR/forbidden_slices.rs:44:5
 
 error[E0080]: could not evaluate static initializer
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
@@ -117,10 +117,10 @@ LL |         unsafe { intrinsics::ptr_offset_from_unsigned(self, origin) }
 LL |     unsafe { from_raw_parts(range.start, range.end.sub_ptr(range.start)) }
    |                                          ------------------------------ inside `from_ptr_range::<u32>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
    |
-  ::: $DIR/forbidden_slices.rs:46:34
+  ::: $DIR/forbidden_slices.rs:47:34
    |
 LL | pub static R0: &[u32] = unsafe { from_ptr_range(ptr::null()..ptr::null()) };
-   |                                  ---------------------------------------- inside `R0` at $DIR/forbidden_slices.rs:46:34
+   |                                  ---------------------------------------- inside `R0` at $DIR/forbidden_slices.rs:47:34
 
 error[E0080]: could not evaluate static initializer
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
@@ -136,10 +136,10 @@ LL |         assert!(0 < pointee_size && pointee_size <= isize::MAX as usize);
 LL |     unsafe { from_raw_parts(range.start, range.end.sub_ptr(range.start)) }
    |                                          ------------------------------ inside `from_ptr_range::<()>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
    |
-  ::: $DIR/forbidden_slices.rs:47:33
+  ::: $DIR/forbidden_slices.rs:48:33
    |
 LL | pub static R1: &[()] = unsafe { from_ptr_range(ptr::null()..ptr::null()) };
-   |                                 ---------------------------------------- inside `R1` at $DIR/forbidden_slices.rs:47:33
+   |                                 ---------------------------------------- inside `R1` at $DIR/forbidden_slices.rs:48:33
    |
    = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -155,13 +155,13 @@ LL |         unsafe { intrinsics::offset(self, count) }
 LL |         unsafe { self.offset(count as isize) }
    |                  --------------------------- inside `ptr::const_ptr::<impl *const u32>::add` at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
    |
-  ::: $DIR/forbidden_slices.rs:50:25
+  ::: $DIR/forbidden_slices.rs:51:25
    |
 LL |     from_ptr_range(ptr..ptr.add(2))
-   |                         ---------- inside `R2` at $DIR/forbidden_slices.rs:50:25
+   |                         ---------- inside `R2` at $DIR/forbidden_slices.rs:51:25
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/forbidden_slices.rs:52:1
+  --> $DIR/forbidden_slices.rs:53:1
    |
 LL | / pub static R4: &[u8] = unsafe {
 LL | |
@@ -176,7 +176,7 @@ LL | | };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/forbidden_slices.rs:57:1
+  --> $DIR/forbidden_slices.rs:58:1
    |
 LL | / pub static R5: &[u8] = unsafe {
 LL | |
@@ -191,7 +191,7 @@ LL | | };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/forbidden_slices.rs:62:1
+  --> $DIR/forbidden_slices.rs:63:1
    |
 LL | / pub static R6: &[bool] = unsafe {
 LL | |
@@ -206,7 +206,7 @@ LL | | };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/forbidden_slices.rs:67:1
+  --> $DIR/forbidden_slices.rs:68:1
    |
 LL | / pub static R7: &[u16] = unsafe {
 LL | |
@@ -217,7 +217,7 @@ LL | | };
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾a209+0x1─╼ 04 00 00 00                         │ ╾──╼....
+               ╾A_ID+0x1─╼ 04 00 00 00                         │ ╾──╼....
            }
 
 error[E0080]: could not evaluate static initializer
@@ -232,10 +232,10 @@ LL |         unsafe { intrinsics::offset(self, count) }
 LL |         unsafe { self.offset(count as isize) }
    |                  --------------------------- inside `ptr::const_ptr::<impl *const u64>::add` at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
    |
-  ::: $DIR/forbidden_slices.rs:74:25
+  ::: $DIR/forbidden_slices.rs:75:25
    |
 LL |     from_ptr_range(ptr..ptr.add(1))
-   |                         ---------- inside `R8` at $DIR/forbidden_slices.rs:74:25
+   |                         ---------- inside `R8` at $DIR/forbidden_slices.rs:75:25
 
 error[E0080]: could not evaluate static initializer
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
@@ -251,10 +251,10 @@ LL |         unsafe { intrinsics::ptr_offset_from_unsigned(self, origin) }
 LL |     unsafe { from_raw_parts(range.start, range.end.sub_ptr(range.start)) }
    |                                          ------------------------------ inside `from_ptr_range::<u32>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
    |
-  ::: $DIR/forbidden_slices.rs:79:34
+  ::: $DIR/forbidden_slices.rs:80:34
    |
 LL | pub static R9: &[u32] = unsafe { from_ptr_range(&D0..(&D0 as *const u32).add(1)) };
-   |                                  ----------------------------------------------- inside `R9` at $DIR/forbidden_slices.rs:79:34
+   |                                  ----------------------------------------------- inside `R9` at $DIR/forbidden_slices.rs:80:34
 
 error[E0080]: could not evaluate static initializer
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
@@ -270,10 +270,10 @@ LL |         unsafe { intrinsics::ptr_offset_from_unsigned(self, origin) }
 LL |     unsafe { from_raw_parts(range.start, range.end.sub_ptr(range.start)) }
    |                                          ------------------------------ inside `from_ptr_range::<u32>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
    |
-  ::: $DIR/forbidden_slices.rs:80:35
+  ::: $DIR/forbidden_slices.rs:81:35
    |
 LL | pub static R10: &[u32] = unsafe { from_ptr_range(&D0..&D0) };
-   |                                   ------------------------ inside `R10` at $DIR/forbidden_slices.rs:80:35
+   |                                   ------------------------ inside `R10` at $DIR/forbidden_slices.rs:81:35
 
 error: aborting due to 18 previous errors
 

--- a/src/test/ui/const-ptr/forbidden_slices.32bit.stderr
+++ b/src/test/ui/const-ptr/forbidden_slices.32bit.stderr
@@ -1,0 +1,280 @@
+error[E0080]: could not evaluate static initializer
+  --> $SRC_DIR/core/src/slice/raw.rs:LL:COL
+   |
+LL |         &*ptr::slice_from_raw_parts(data, len)
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         |
+   |         dereferencing pointer failed: null pointer is not a valid pointer
+   |         inside `std::slice::from_raw_parts::<u32>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
+   |
+  ::: $DIR/forbidden_slices.rs:17:34
+   |
+LL | pub static S0: &[u32] = unsafe { from_raw_parts(ptr::null(), 0) };
+   |                                  ------------------------------ inside `S0` at $DIR/forbidden_slices.rs:17:34
+
+error[E0080]: could not evaluate static initializer
+  --> $SRC_DIR/core/src/slice/raw.rs:LL:COL
+   |
+LL |         &*ptr::slice_from_raw_parts(data, len)
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         |
+   |         dereferencing pointer failed: null pointer is not a valid pointer
+   |         inside `std::slice::from_raw_parts::<()>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
+   |
+  ::: $DIR/forbidden_slices.rs:18:33
+   |
+LL | pub static S1: &[()] = unsafe { from_raw_parts(ptr::null(), 0) };
+   |                                 ------------------------------ inside `S1` at $DIR/forbidden_slices.rs:18:33
+
+error[E0080]: could not evaluate static initializer
+  --> $SRC_DIR/core/src/slice/raw.rs:LL:COL
+   |
+LL |         &*ptr::slice_from_raw_parts(data, len)
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         |
+   |         dereferencing pointer failed: alloc26 has size 4, so pointer to 8 bytes starting at offset 0 is out-of-bounds
+   |         inside `std::slice::from_raw_parts::<u32>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
+   |
+  ::: $DIR/forbidden_slices.rs:21:34
+   |
+LL | pub static S2: &[u32] = unsafe { from_raw_parts(&D0, 2) };
+   |                                  ---------------------- inside `S2` at $DIR/forbidden_slices.rs:21:34
+
+error[E0080]: it is undefined behavior to use this value
+  --> $DIR/forbidden_slices.rs:24:1
+   |
+LL | pub static S4: &[u8] = unsafe { from_raw_parts((&D1) as *const _ as _, 1) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .<deref>[0]: encountered uninitialized bytes
+   |
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
+   = note: the raw bytes of the constant (size: 8, align: 4) {
+               ╾─alloc42─╼ 01 00 00 00                         │ ╾──╼....
+           }
+
+error[E0080]: it is undefined behavior to use this value
+  --> $DIR/forbidden_slices.rs:26:1
+   |
+LL | pub static S5: &[u8] = unsafe { from_raw_parts((&D3) as *const _ as _, size_of::<&u32>()) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .<deref>: encountered a pointer, but expected plain (non-pointer) bytes
+   |
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
+   = note: the raw bytes of the constant (size: 8, align: 4) {
+               ╾─alloc55─╼ 04 00 00 00                         │ ╾──╼....
+           }
+
+error[E0080]: it is undefined behavior to use this value
+  --> $DIR/forbidden_slices.rs:28:1
+   |
+LL | pub static S6: &[bool] = unsafe { from_raw_parts((&D0) as *const _ as _, 4) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .<deref>[0]: encountered 0x11, but expected a boolean
+   |
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
+   = note: the raw bytes of the constant (size: 8, align: 4) {
+               ╾─alloc65─╼ 04 00 00 00                         │ ╾──╼....
+           }
+
+error[E0080]: it is undefined behavior to use this value
+  --> $DIR/forbidden_slices.rs:31:1
+   |
+LL | / pub static S7: &[u16] = unsafe {
+LL | |
+LL | |     let ptr = (&D2 as *const Struct as *const u16).byte_add(1);
+LL | |
+LL | |     from_raw_parts(ptr, 4)
+LL | | };
+   | |__^ type validation failed: encountered an unaligned reference (required 2 byte alignment but found 1)
+   |
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
+   = note: the raw bytes of the constant (size: 8, align: 4) {
+               ╾─a79+0x1─╼ 04 00 00 00                         │ ╾──╼....
+           }
+
+error[E0080]: could not evaluate static initializer
+  --> $SRC_DIR/core/src/slice/raw.rs:LL:COL
+   |
+LL |         &*ptr::slice_from_raw_parts(data, len)
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         |
+   |         dereferencing pointer failed: alloc96 has size 8, so pointer to 8 bytes starting at offset 1 is out-of-bounds
+   |         inside `std::slice::from_raw_parts::<u64>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
+   |
+  ::: $DIR/forbidden_slices.rs:42:5
+   |
+LL |     from_raw_parts(ptr, 1)
+   |     ---------------------- inside `S8` at $DIR/forbidden_slices.rs:42:5
+
+error[E0080]: could not evaluate static initializer
+  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+   |
+LL |         unsafe { intrinsics::ptr_offset_from_unsigned(self, origin) }
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                  |
+   |                  out-of-bounds offset_from: null pointer is not a valid pointer
+   |                  inside `ptr::const_ptr::<impl *const u32>::sub_ptr` at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+   |
+  ::: $SRC_DIR/core/src/slice/raw.rs:LL:COL
+   |
+LL |     unsafe { from_raw_parts(range.start, range.end.sub_ptr(range.start)) }
+   |                                          ------------------------------ inside `from_ptr_range::<u32>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
+   |
+  ::: $DIR/forbidden_slices.rs:45:34
+   |
+LL | pub static R0: &[u32] = unsafe { from_ptr_range(ptr::null()..ptr::null()) };
+   |                                  ---------------------------------------- inside `R0` at $DIR/forbidden_slices.rs:45:34
+
+error[E0080]: could not evaluate static initializer
+  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+   |
+LL |         assert!(0 < pointee_size && pointee_size <= isize::MAX as usize);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         |
+   |         the evaluated program panicked at 'assertion failed: 0 < pointee_size && pointee_size <= isize::MAX as usize', $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+   |         inside `ptr::const_ptr::<impl *const ()>::sub_ptr` at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+   |
+  ::: $SRC_DIR/core/src/slice/raw.rs:LL:COL
+   |
+LL |     unsafe { from_raw_parts(range.start, range.end.sub_ptr(range.start)) }
+   |                                          ------------------------------ inside `from_ptr_range::<()>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
+   |
+  ::: $DIR/forbidden_slices.rs:46:33
+   |
+LL | pub static R1: &[()] = unsafe { from_ptr_range(ptr::null()..ptr::null()) };
+   |                                 ---------------------------------------- inside `R1` at $DIR/forbidden_slices.rs:46:33
+   |
+   = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0080]: could not evaluate static initializer
+  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+   |
+LL |         unsafe { intrinsics::offset(self, count) }
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                  |
+   |                  pointer arithmetic failed: alloc154 has size 4, so pointer to 8 bytes starting at offset 0 is out-of-bounds
+   |                  inside `ptr::const_ptr::<impl *const u32>::offset` at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+...
+LL |         unsafe { self.offset(count as isize) }
+   |                  --------------------------- inside `ptr::const_ptr::<impl *const u32>::add` at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+   |
+  ::: $DIR/forbidden_slices.rs:49:25
+   |
+LL |     from_ptr_range(ptr..ptr.add(2))
+   |                         ---------- inside `R2` at $DIR/forbidden_slices.rs:49:25
+
+error[E0080]: it is undefined behavior to use this value
+  --> $DIR/forbidden_slices.rs:51:1
+   |
+LL | / pub static R4: &[u8] = unsafe {
+LL | |
+LL | |     let ptr = (&D1) as *const MaybeUninit<&u32> as *const u8;
+LL | |     from_ptr_range(ptr..ptr.add(1))
+LL | | };
+   | |__^ type validation failed at .<deref>[0]: encountered uninitialized bytes
+   |
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
+   = note: the raw bytes of the constant (size: 8, align: 4) {
+               ╾alloc159─╼ 01 00 00 00                         │ ╾──╼....
+           }
+
+error[E0080]: it is undefined behavior to use this value
+  --> $DIR/forbidden_slices.rs:56:1
+   |
+LL | / pub static R5: &[u8] = unsafe {
+LL | |
+LL | |     let ptr = &D3 as *const &u32;
+LL | |     from_ptr_range(ptr.cast()..ptr.add(1).cast())
+LL | | };
+   | |__^ type validation failed at .<deref>: encountered a pointer, but expected plain (non-pointer) bytes
+   |
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
+   = note: the raw bytes of the constant (size: 8, align: 4) {
+               ╾alloc175─╼ 04 00 00 00                         │ ╾──╼....
+           }
+
+error[E0080]: it is undefined behavior to use this value
+  --> $DIR/forbidden_slices.rs:61:1
+   |
+LL | / pub static R6: &[bool] = unsafe {
+LL | |
+LL | |     let ptr = &D0 as *const u32 as *const bool;
+LL | |     from_ptr_range(ptr..ptr.add(4))
+LL | | };
+   | |__^ type validation failed at .<deref>[0]: encountered 0x11, but expected a boolean
+   |
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
+   = note: the raw bytes of the constant (size: 8, align: 4) {
+               ╾alloc191─╼ 04 00 00 00                         │ ╾──╼....
+           }
+
+error[E0080]: it is undefined behavior to use this value
+  --> $DIR/forbidden_slices.rs:66:1
+   |
+LL | / pub static R7: &[u16] = unsafe {
+LL | |
+LL | |     let ptr = (&D2 as *const Struct as *const u16).byte_add(1);
+LL | |     from_ptr_range(ptr..ptr.add(4))
+LL | | };
+   | |__^ type validation failed: encountered an unaligned reference (required 2 byte alignment but found 1)
+   |
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
+   = note: the raw bytes of the constant (size: 8, align: 4) {
+               ╾a209+0x1─╼ 04 00 00 00                         │ ╾──╼....
+           }
+
+error[E0080]: could not evaluate static initializer
+  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+   |
+LL |         unsafe { intrinsics::offset(self, count) }
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                  |
+   |                  pointer arithmetic failed: alloc230 has size 8, so pointer to 8 bytes starting at offset 1 is out-of-bounds
+   |                  inside `ptr::const_ptr::<impl *const u64>::offset` at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+...
+LL |         unsafe { self.offset(count as isize) }
+   |                  --------------------------- inside `ptr::const_ptr::<impl *const u64>::add` at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+   |
+  ::: $DIR/forbidden_slices.rs:73:25
+   |
+LL |     from_ptr_range(ptr..ptr.add(1))
+   |                         ---------- inside `R8` at $DIR/forbidden_slices.rs:73:25
+
+error[E0080]: could not evaluate static initializer
+  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+   |
+LL |         unsafe { intrinsics::ptr_offset_from_unsigned(self, origin) }
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                  |
+   |                  ptr_offset_from_unsigned cannot compute offset of pointers into different allocations.
+   |                  inside `ptr::const_ptr::<impl *const u32>::sub_ptr` at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+   |
+  ::: $SRC_DIR/core/src/slice/raw.rs:LL:COL
+   |
+LL |     unsafe { from_raw_parts(range.start, range.end.sub_ptr(range.start)) }
+   |                                          ------------------------------ inside `from_ptr_range::<u32>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
+   |
+  ::: $DIR/forbidden_slices.rs:78:34
+   |
+LL | pub static R9: &[u32] = unsafe { from_ptr_range(&D0..(&D0 as *const u32).add(1)) };
+   |                                  ----------------------------------------------- inside `R9` at $DIR/forbidden_slices.rs:78:34
+
+error[E0080]: could not evaluate static initializer
+  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+   |
+LL |         unsafe { intrinsics::ptr_offset_from_unsigned(self, origin) }
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                  |
+   |                  ptr_offset_from_unsigned cannot compute offset of pointers into different allocations.
+   |                  inside `ptr::const_ptr::<impl *const u32>::sub_ptr` at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+   |
+  ::: $SRC_DIR/core/src/slice/raw.rs:LL:COL
+   |
+LL |     unsafe { from_raw_parts(range.start, range.end.sub_ptr(range.start)) }
+   |                                          ------------------------------ inside `from_ptr_range::<u32>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
+   |
+  ::: $DIR/forbidden_slices.rs:79:35
+   |
+LL | pub static R10: &[u32] = unsafe { from_ptr_range(&D0..&D0) };
+   |                                   ------------------------ inside `R10` at $DIR/forbidden_slices.rs:79:35
+
+error: aborting due to 18 previous errors
+
+For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/const-ptr/forbidden_slices.32bit.stderr
+++ b/src/test/ui/const-ptr/forbidden_slices.32bit.stderr
@@ -7,10 +7,10 @@ LL |         &*ptr::slice_from_raw_parts(data, len)
    |         dereferencing pointer failed: null pointer is not a valid pointer
    |         inside `std::slice::from_raw_parts::<u32>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
    |
-  ::: $DIR/forbidden_slices.rs:17:34
+  ::: $DIR/forbidden_slices.rs:18:34
    |
 LL | pub static S0: &[u32] = unsafe { from_raw_parts(ptr::null(), 0) };
-   |                                  ------------------------------ inside `S0` at $DIR/forbidden_slices.rs:17:34
+   |                                  ------------------------------ inside `S0` at $DIR/forbidden_slices.rs:18:34
 
 error[E0080]: could not evaluate static initializer
   --> $SRC_DIR/core/src/slice/raw.rs:LL:COL
@@ -21,10 +21,10 @@ LL |         &*ptr::slice_from_raw_parts(data, len)
    |         dereferencing pointer failed: null pointer is not a valid pointer
    |         inside `std::slice::from_raw_parts::<()>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
    |
-  ::: $DIR/forbidden_slices.rs:18:33
+  ::: $DIR/forbidden_slices.rs:19:33
    |
 LL | pub static S1: &[()] = unsafe { from_raw_parts(ptr::null(), 0) };
-   |                                 ------------------------------ inside `S1` at $DIR/forbidden_slices.rs:18:33
+   |                                 ------------------------------ inside `S1` at $DIR/forbidden_slices.rs:19:33
 
 error[E0080]: could not evaluate static initializer
   --> $SRC_DIR/core/src/slice/raw.rs:LL:COL
@@ -32,49 +32,49 @@ error[E0080]: could not evaluate static initializer
 LL |         &*ptr::slice_from_raw_parts(data, len)
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |         |
-   |         dereferencing pointer failed: alloc26 has size 4, so pointer to 8 bytes starting at offset 0 is out-of-bounds
+   |         dereferencing pointer failed: ALLOC_ID has size 4, so pointer to 8 bytes starting at offset 0 is out-of-bounds
    |         inside `std::slice::from_raw_parts::<u32>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
    |
-  ::: $DIR/forbidden_slices.rs:21:34
+  ::: $DIR/forbidden_slices.rs:22:34
    |
 LL | pub static S2: &[u32] = unsafe { from_raw_parts(&D0, 2) };
-   |                                  ---------------------- inside `S2` at $DIR/forbidden_slices.rs:21:34
+   |                                  ---------------------- inside `S2` at $DIR/forbidden_slices.rs:22:34
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/forbidden_slices.rs:24:1
+  --> $DIR/forbidden_slices.rs:25:1
    |
 LL | pub static S4: &[u8] = unsafe { from_raw_parts((&D1) as *const _ as _, 1) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .<deref>[0]: encountered uninitialized bytes
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾─alloc42─╼ 01 00 00 00                         │ ╾──╼....
+               ╾─ALLOC_ID─╼ 01 00 00 00                         │ ╾──╼....
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/forbidden_slices.rs:26:1
+  --> $DIR/forbidden_slices.rs:27:1
    |
 LL | pub static S5: &[u8] = unsafe { from_raw_parts((&D3) as *const _ as _, size_of::<&u32>()) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .<deref>: encountered a pointer, but expected plain (non-pointer) bytes
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾─alloc55─╼ 04 00 00 00                         │ ╾──╼....
+               ╾─ALLOC_ID─╼ 04 00 00 00                         │ ╾──╼....
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/forbidden_slices.rs:28:1
+  --> $DIR/forbidden_slices.rs:29:1
    |
 LL | pub static S6: &[bool] = unsafe { from_raw_parts((&D0) as *const _ as _, 4) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .<deref>[0]: encountered 0x11, but expected a boolean
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾─alloc65─╼ 04 00 00 00                         │ ╾──╼....
+               ╾─ALLOC_ID─╼ 04 00 00 00                         │ ╾──╼....
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/forbidden_slices.rs:31:1
+  --> $DIR/forbidden_slices.rs:32:1
    |
 LL | / pub static S7: &[u16] = unsafe {
 LL | |
@@ -95,13 +95,13 @@ error[E0080]: could not evaluate static initializer
 LL |         &*ptr::slice_from_raw_parts(data, len)
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |         |
-   |         dereferencing pointer failed: alloc96 has size 8, so pointer to 8 bytes starting at offset 1 is out-of-bounds
+   |         dereferencing pointer failed: ALLOC_ID has size 8, so pointer to 8 bytes starting at offset 1 is out-of-bounds
    |         inside `std::slice::from_raw_parts::<u64>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
    |
-  ::: $DIR/forbidden_slices.rs:42:5
+  ::: $DIR/forbidden_slices.rs:43:5
    |
 LL |     from_raw_parts(ptr, 1)
-   |     ---------------------- inside `S8` at $DIR/forbidden_slices.rs:42:5
+   |     ---------------------- inside `S8` at $DIR/forbidden_slices.rs:43:5
 
 error[E0080]: could not evaluate static initializer
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
@@ -117,10 +117,10 @@ LL |         unsafe { intrinsics::ptr_offset_from_unsigned(self, origin) }
 LL |     unsafe { from_raw_parts(range.start, range.end.sub_ptr(range.start)) }
    |                                          ------------------------------ inside `from_ptr_range::<u32>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
    |
-  ::: $DIR/forbidden_slices.rs:45:34
+  ::: $DIR/forbidden_slices.rs:46:34
    |
 LL | pub static R0: &[u32] = unsafe { from_ptr_range(ptr::null()..ptr::null()) };
-   |                                  ---------------------------------------- inside `R0` at $DIR/forbidden_slices.rs:45:34
+   |                                  ---------------------------------------- inside `R0` at $DIR/forbidden_slices.rs:46:34
 
 error[E0080]: could not evaluate static initializer
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
@@ -136,10 +136,10 @@ LL |         assert!(0 < pointee_size && pointee_size <= isize::MAX as usize);
 LL |     unsafe { from_raw_parts(range.start, range.end.sub_ptr(range.start)) }
    |                                          ------------------------------ inside `from_ptr_range::<()>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
    |
-  ::: $DIR/forbidden_slices.rs:46:33
+  ::: $DIR/forbidden_slices.rs:47:33
    |
 LL | pub static R1: &[()] = unsafe { from_ptr_range(ptr::null()..ptr::null()) };
-   |                                 ---------------------------------------- inside `R1` at $DIR/forbidden_slices.rs:46:33
+   |                                 ---------------------------------------- inside `R1` at $DIR/forbidden_slices.rs:47:33
    |
    = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -149,19 +149,19 @@ error[E0080]: could not evaluate static initializer
 LL |         unsafe { intrinsics::offset(self, count) }
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |                  |
-   |                  pointer arithmetic failed: alloc154 has size 4, so pointer to 8 bytes starting at offset 0 is out-of-bounds
+   |                  pointer arithmetic failed: ALLOC_ID has size 4, so pointer to 8 bytes starting at offset 0 is out-of-bounds
    |                  inside `ptr::const_ptr::<impl *const u32>::offset` at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
 ...
 LL |         unsafe { self.offset(count as isize) }
    |                  --------------------------- inside `ptr::const_ptr::<impl *const u32>::add` at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
    |
-  ::: $DIR/forbidden_slices.rs:49:25
+  ::: $DIR/forbidden_slices.rs:50:25
    |
 LL |     from_ptr_range(ptr..ptr.add(2))
-   |                         ---------- inside `R2` at $DIR/forbidden_slices.rs:49:25
+   |                         ---------- inside `R2` at $DIR/forbidden_slices.rs:50:25
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/forbidden_slices.rs:51:1
+  --> $DIR/forbidden_slices.rs:52:1
    |
 LL | / pub static R4: &[u8] = unsafe {
 LL | |
@@ -172,11 +172,11 @@ LL | | };
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾alloc159─╼ 01 00 00 00                         │ ╾──╼....
+               ╾ALLOC_ID─╼ 01 00 00 00                         │ ╾──╼....
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/forbidden_slices.rs:56:1
+  --> $DIR/forbidden_slices.rs:57:1
    |
 LL | / pub static R5: &[u8] = unsafe {
 LL | |
@@ -187,11 +187,11 @@ LL | | };
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾alloc175─╼ 04 00 00 00                         │ ╾──╼....
+               ╾ALLOC_ID─╼ 04 00 00 00                         │ ╾──╼....
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/forbidden_slices.rs:61:1
+  --> $DIR/forbidden_slices.rs:62:1
    |
 LL | / pub static R6: &[bool] = unsafe {
 LL | |
@@ -202,11 +202,11 @@ LL | | };
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 8, align: 4) {
-               ╾alloc191─╼ 04 00 00 00                         │ ╾──╼....
+               ╾ALLOC_ID─╼ 04 00 00 00                         │ ╾──╼....
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/forbidden_slices.rs:66:1
+  --> $DIR/forbidden_slices.rs:67:1
    |
 LL | / pub static R7: &[u16] = unsafe {
 LL | |
@@ -226,16 +226,16 @@ error[E0080]: could not evaluate static initializer
 LL |         unsafe { intrinsics::offset(self, count) }
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |                  |
-   |                  pointer arithmetic failed: alloc230 has size 8, so pointer to 8 bytes starting at offset 1 is out-of-bounds
+   |                  pointer arithmetic failed: ALLOC_ID has size 8, so pointer to 8 bytes starting at offset 1 is out-of-bounds
    |                  inside `ptr::const_ptr::<impl *const u64>::offset` at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
 ...
 LL |         unsafe { self.offset(count as isize) }
    |                  --------------------------- inside `ptr::const_ptr::<impl *const u64>::add` at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
    |
-  ::: $DIR/forbidden_slices.rs:73:25
+  ::: $DIR/forbidden_slices.rs:74:25
    |
 LL |     from_ptr_range(ptr..ptr.add(1))
-   |                         ---------- inside `R8` at $DIR/forbidden_slices.rs:73:25
+   |                         ---------- inside `R8` at $DIR/forbidden_slices.rs:74:25
 
 error[E0080]: could not evaluate static initializer
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
@@ -251,10 +251,10 @@ LL |         unsafe { intrinsics::ptr_offset_from_unsigned(self, origin) }
 LL |     unsafe { from_raw_parts(range.start, range.end.sub_ptr(range.start)) }
    |                                          ------------------------------ inside `from_ptr_range::<u32>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
    |
-  ::: $DIR/forbidden_slices.rs:78:34
+  ::: $DIR/forbidden_slices.rs:79:34
    |
 LL | pub static R9: &[u32] = unsafe { from_ptr_range(&D0..(&D0 as *const u32).add(1)) };
-   |                                  ----------------------------------------------- inside `R9` at $DIR/forbidden_slices.rs:78:34
+   |                                  ----------------------------------------------- inside `R9` at $DIR/forbidden_slices.rs:79:34
 
 error[E0080]: could not evaluate static initializer
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
@@ -270,10 +270,10 @@ LL |         unsafe { intrinsics::ptr_offset_from_unsigned(self, origin) }
 LL |     unsafe { from_raw_parts(range.start, range.end.sub_ptr(range.start)) }
    |                                          ------------------------------ inside `from_ptr_range::<u32>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
    |
-  ::: $DIR/forbidden_slices.rs:79:35
+  ::: $DIR/forbidden_slices.rs:80:35
    |
 LL | pub static R10: &[u32] = unsafe { from_ptr_range(&D0..&D0) };
-   |                                   ------------------------ inside `R10` at $DIR/forbidden_slices.rs:79:35
+   |                                   ------------------------ inside `R10` at $DIR/forbidden_slices.rs:80:35
 
 error: aborting due to 18 previous errors
 

--- a/src/test/ui/const-ptr/forbidden_slices.64bit.stderr
+++ b/src/test/ui/const-ptr/forbidden_slices.64bit.stderr
@@ -7,10 +7,10 @@ LL |         &*ptr::slice_from_raw_parts(data, len)
    |         dereferencing pointer failed: null pointer is not a valid pointer
    |         inside `std::slice::from_raw_parts::<u32>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
    |
-  ::: $DIR/forbidden_slices.rs:18:34
+  ::: $DIR/forbidden_slices.rs:19:34
    |
 LL | pub static S0: &[u32] = unsafe { from_raw_parts(ptr::null(), 0) };
-   |                                  ------------------------------ inside `S0` at $DIR/forbidden_slices.rs:18:34
+   |                                  ------------------------------ inside `S0` at $DIR/forbidden_slices.rs:19:34
 
 error[E0080]: could not evaluate static initializer
   --> $SRC_DIR/core/src/slice/raw.rs:LL:COL
@@ -21,10 +21,10 @@ LL |         &*ptr::slice_from_raw_parts(data, len)
    |         dereferencing pointer failed: null pointer is not a valid pointer
    |         inside `std::slice::from_raw_parts::<()>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
    |
-  ::: $DIR/forbidden_slices.rs:19:33
+  ::: $DIR/forbidden_slices.rs:20:33
    |
 LL | pub static S1: &[()] = unsafe { from_raw_parts(ptr::null(), 0) };
-   |                                 ------------------------------ inside `S1` at $DIR/forbidden_slices.rs:19:33
+   |                                 ------------------------------ inside `S1` at $DIR/forbidden_slices.rs:20:33
 
 error[E0080]: could not evaluate static initializer
   --> $SRC_DIR/core/src/slice/raw.rs:LL:COL
@@ -35,13 +35,13 @@ LL |         &*ptr::slice_from_raw_parts(data, len)
    |         dereferencing pointer failed: ALLOC_ID has size 4, so pointer to 8 bytes starting at offset 0 is out-of-bounds
    |         inside `std::slice::from_raw_parts::<u32>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
    |
-  ::: $DIR/forbidden_slices.rs:22:34
+  ::: $DIR/forbidden_slices.rs:23:34
    |
 LL | pub static S2: &[u32] = unsafe { from_raw_parts(&D0, 2) };
-   |                                  ---------------------- inside `S2` at $DIR/forbidden_slices.rs:22:34
+   |                                  ---------------------- inside `S2` at $DIR/forbidden_slices.rs:23:34
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/forbidden_slices.rs:25:1
+  --> $DIR/forbidden_slices.rs:26:1
    |
 LL | pub static S4: &[u8] = unsafe { from_raw_parts((&D1) as *const _ as _, 1) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .<deref>[0]: encountered uninitialized bytes
@@ -52,7 +52,7 @@ LL | pub static S4: &[u8] = unsafe { from_raw_parts((&D1) as *const _ as _, 1) }
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/forbidden_slices.rs:27:1
+  --> $DIR/forbidden_slices.rs:28:1
    |
 LL | pub static S5: &[u8] = unsafe { from_raw_parts((&D3) as *const _ as _, size_of::<&u32>()) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .<deref>: encountered a pointer, but expected plain (non-pointer) bytes
@@ -63,7 +63,7 @@ LL | pub static S5: &[u8] = unsafe { from_raw_parts((&D3) as *const _ as _, size
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/forbidden_slices.rs:29:1
+  --> $DIR/forbidden_slices.rs:30:1
    |
 LL | pub static S6: &[bool] = unsafe { from_raw_parts((&D0) as *const _ as _, 4) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .<deref>[0]: encountered 0x11, but expected a boolean
@@ -74,7 +74,7 @@ LL | pub static S6: &[bool] = unsafe { from_raw_parts((&D0) as *const _ as _, 4)
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/forbidden_slices.rs:32:1
+  --> $DIR/forbidden_slices.rs:33:1
    |
 LL | / pub static S7: &[u16] = unsafe {
 LL | |
@@ -98,10 +98,10 @@ LL |         &*ptr::slice_from_raw_parts(data, len)
    |         dereferencing pointer failed: ALLOC_ID has size 8, so pointer to 8 bytes starting at offset 1 is out-of-bounds
    |         inside `std::slice::from_raw_parts::<u64>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
    |
-  ::: $DIR/forbidden_slices.rs:43:5
+  ::: $DIR/forbidden_slices.rs:44:5
    |
 LL |     from_raw_parts(ptr, 1)
-   |     ---------------------- inside `S8` at $DIR/forbidden_slices.rs:43:5
+   |     ---------------------- inside `S8` at $DIR/forbidden_slices.rs:44:5
 
 error[E0080]: could not evaluate static initializer
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
@@ -117,10 +117,10 @@ LL |         unsafe { intrinsics::ptr_offset_from_unsigned(self, origin) }
 LL |     unsafe { from_raw_parts(range.start, range.end.sub_ptr(range.start)) }
    |                                          ------------------------------ inside `from_ptr_range::<u32>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
    |
-  ::: $DIR/forbidden_slices.rs:46:34
+  ::: $DIR/forbidden_slices.rs:47:34
    |
 LL | pub static R0: &[u32] = unsafe { from_ptr_range(ptr::null()..ptr::null()) };
-   |                                  ---------------------------------------- inside `R0` at $DIR/forbidden_slices.rs:46:34
+   |                                  ---------------------------------------- inside `R0` at $DIR/forbidden_slices.rs:47:34
 
 error[E0080]: could not evaluate static initializer
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
@@ -136,10 +136,10 @@ LL |         assert!(0 < pointee_size && pointee_size <= isize::MAX as usize);
 LL |     unsafe { from_raw_parts(range.start, range.end.sub_ptr(range.start)) }
    |                                          ------------------------------ inside `from_ptr_range::<()>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
    |
-  ::: $DIR/forbidden_slices.rs:47:33
+  ::: $DIR/forbidden_slices.rs:48:33
    |
 LL | pub static R1: &[()] = unsafe { from_ptr_range(ptr::null()..ptr::null()) };
-   |                                 ---------------------------------------- inside `R1` at $DIR/forbidden_slices.rs:47:33
+   |                                 ---------------------------------------- inside `R1` at $DIR/forbidden_slices.rs:48:33
    |
    = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -155,13 +155,13 @@ LL |         unsafe { intrinsics::offset(self, count) }
 LL |         unsafe { self.offset(count as isize) }
    |                  --------------------------- inside `ptr::const_ptr::<impl *const u32>::add` at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
    |
-  ::: $DIR/forbidden_slices.rs:50:25
+  ::: $DIR/forbidden_slices.rs:51:25
    |
 LL |     from_ptr_range(ptr..ptr.add(2))
-   |                         ---------- inside `R2` at $DIR/forbidden_slices.rs:50:25
+   |                         ---------- inside `R2` at $DIR/forbidden_slices.rs:51:25
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/forbidden_slices.rs:52:1
+  --> $DIR/forbidden_slices.rs:53:1
    |
 LL | / pub static R4: &[u8] = unsafe {
 LL | |
@@ -176,7 +176,7 @@ LL | | };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/forbidden_slices.rs:57:1
+  --> $DIR/forbidden_slices.rs:58:1
    |
 LL | / pub static R5: &[u8] = unsafe {
 LL | |
@@ -191,7 +191,7 @@ LL | | };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/forbidden_slices.rs:62:1
+  --> $DIR/forbidden_slices.rs:63:1
    |
 LL | / pub static R6: &[bool] = unsafe {
 LL | |
@@ -206,7 +206,7 @@ LL | | };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/forbidden_slices.rs:67:1
+  --> $DIR/forbidden_slices.rs:68:1
    |
 LL | / pub static R7: &[u16] = unsafe {
 LL | |
@@ -232,10 +232,10 @@ LL |         unsafe { intrinsics::offset(self, count) }
 LL |         unsafe { self.offset(count as isize) }
    |                  --------------------------- inside `ptr::const_ptr::<impl *const u64>::add` at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
    |
-  ::: $DIR/forbidden_slices.rs:74:25
+  ::: $DIR/forbidden_slices.rs:75:25
    |
 LL |     from_ptr_range(ptr..ptr.add(1))
-   |                         ---------- inside `R8` at $DIR/forbidden_slices.rs:74:25
+   |                         ---------- inside `R8` at $DIR/forbidden_slices.rs:75:25
 
 error[E0080]: could not evaluate static initializer
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
@@ -251,10 +251,10 @@ LL |         unsafe { intrinsics::ptr_offset_from_unsigned(self, origin) }
 LL |     unsafe { from_raw_parts(range.start, range.end.sub_ptr(range.start)) }
    |                                          ------------------------------ inside `from_ptr_range::<u32>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
    |
-  ::: $DIR/forbidden_slices.rs:79:34
+  ::: $DIR/forbidden_slices.rs:80:34
    |
 LL | pub static R9: &[u32] = unsafe { from_ptr_range(&D0..(&D0 as *const u32).add(1)) };
-   |                                  ----------------------------------------------- inside `R9` at $DIR/forbidden_slices.rs:79:34
+   |                                  ----------------------------------------------- inside `R9` at $DIR/forbidden_slices.rs:80:34
 
 error[E0080]: could not evaluate static initializer
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
@@ -270,10 +270,10 @@ LL |         unsafe { intrinsics::ptr_offset_from_unsigned(self, origin) }
 LL |     unsafe { from_raw_parts(range.start, range.end.sub_ptr(range.start)) }
    |                                          ------------------------------ inside `from_ptr_range::<u32>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
    |
-  ::: $DIR/forbidden_slices.rs:80:35
+  ::: $DIR/forbidden_slices.rs:81:35
    |
 LL | pub static R10: &[u32] = unsafe { from_ptr_range(&D0..&D0) };
-   |                                   ------------------------ inside `R10` at $DIR/forbidden_slices.rs:80:35
+   |                                   ------------------------ inside `R10` at $DIR/forbidden_slices.rs:81:35
 
 error: aborting due to 18 previous errors
 

--- a/src/test/ui/const-ptr/forbidden_slices.64bit.stderr
+++ b/src/test/ui/const-ptr/forbidden_slices.64bit.stderr
@@ -7,10 +7,10 @@ LL |         &*ptr::slice_from_raw_parts(data, len)
    |         dereferencing pointer failed: null pointer is not a valid pointer
    |         inside `std::slice::from_raw_parts::<u32>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
    |
-  ::: $DIR/forbidden_slices.rs:17:34
+  ::: $DIR/forbidden_slices.rs:18:34
    |
 LL | pub static S0: &[u32] = unsafe { from_raw_parts(ptr::null(), 0) };
-   |                                  ------------------------------ inside `S0` at $DIR/forbidden_slices.rs:17:34
+   |                                  ------------------------------ inside `S0` at $DIR/forbidden_slices.rs:18:34
 
 error[E0080]: could not evaluate static initializer
   --> $SRC_DIR/core/src/slice/raw.rs:LL:COL
@@ -21,10 +21,10 @@ LL |         &*ptr::slice_from_raw_parts(data, len)
    |         dereferencing pointer failed: null pointer is not a valid pointer
    |         inside `std::slice::from_raw_parts::<()>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
    |
-  ::: $DIR/forbidden_slices.rs:18:33
+  ::: $DIR/forbidden_slices.rs:19:33
    |
 LL | pub static S1: &[()] = unsafe { from_raw_parts(ptr::null(), 0) };
-   |                                 ------------------------------ inside `S1` at $DIR/forbidden_slices.rs:18:33
+   |                                 ------------------------------ inside `S1` at $DIR/forbidden_slices.rs:19:33
 
 error[E0080]: could not evaluate static initializer
   --> $SRC_DIR/core/src/slice/raw.rs:LL:COL
@@ -32,49 +32,49 @@ error[E0080]: could not evaluate static initializer
 LL |         &*ptr::slice_from_raw_parts(data, len)
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |         |
-   |         dereferencing pointer failed: alloc26 has size 4, so pointer to 8 bytes starting at offset 0 is out-of-bounds
+   |         dereferencing pointer failed: ALLOC_ID has size 4, so pointer to 8 bytes starting at offset 0 is out-of-bounds
    |         inside `std::slice::from_raw_parts::<u32>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
    |
-  ::: $DIR/forbidden_slices.rs:21:34
+  ::: $DIR/forbidden_slices.rs:22:34
    |
 LL | pub static S2: &[u32] = unsafe { from_raw_parts(&D0, 2) };
-   |                                  ---------------------- inside `S2` at $DIR/forbidden_slices.rs:21:34
+   |                                  ---------------------- inside `S2` at $DIR/forbidden_slices.rs:22:34
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/forbidden_slices.rs:24:1
+  --> $DIR/forbidden_slices.rs:25:1
    |
 LL | pub static S4: &[u8] = unsafe { from_raw_parts((&D1) as *const _ as _, 1) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .<deref>[0]: encountered uninitialized bytes
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾───────alloc42───────╼ 01 00 00 00 00 00 00 00 │ ╾──────╼........
+               ╾───────ALLOC_ID───────╼ 01 00 00 00 00 00 00 00 │ ╾──────╼........
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/forbidden_slices.rs:26:1
+  --> $DIR/forbidden_slices.rs:27:1
    |
 LL | pub static S5: &[u8] = unsafe { from_raw_parts((&D3) as *const _ as _, size_of::<&u32>()) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .<deref>: encountered a pointer, but expected plain (non-pointer) bytes
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾───────alloc55───────╼ 08 00 00 00 00 00 00 00 │ ╾──────╼........
+               ╾───────ALLOC_ID───────╼ 08 00 00 00 00 00 00 00 │ ╾──────╼........
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/forbidden_slices.rs:28:1
+  --> $DIR/forbidden_slices.rs:29:1
    |
 LL | pub static S6: &[bool] = unsafe { from_raw_parts((&D0) as *const _ as _, 4) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .<deref>[0]: encountered 0x11, but expected a boolean
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾───────alloc65───────╼ 04 00 00 00 00 00 00 00 │ ╾──────╼........
+               ╾───────ALLOC_ID───────╼ 04 00 00 00 00 00 00 00 │ ╾──────╼........
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/forbidden_slices.rs:31:1
+  --> $DIR/forbidden_slices.rs:32:1
    |
 LL | / pub static S7: &[u16] = unsafe {
 LL | |
@@ -86,7 +86,7 @@ LL | | };
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾─────alloc79+0x1─────╼ 04 00 00 00 00 00 00 00 │ ╾──────╼........
+               ╾─────ALLOC_ID+0x1─────╼ 04 00 00 00 00 00 00 00 │ ╾──────╼........
            }
 
 error[E0080]: could not evaluate static initializer
@@ -95,13 +95,13 @@ error[E0080]: could not evaluate static initializer
 LL |         &*ptr::slice_from_raw_parts(data, len)
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |         |
-   |         dereferencing pointer failed: alloc96 has size 8, so pointer to 8 bytes starting at offset 1 is out-of-bounds
+   |         dereferencing pointer failed: ALLOC_ID has size 8, so pointer to 8 bytes starting at offset 1 is out-of-bounds
    |         inside `std::slice::from_raw_parts::<u64>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
    |
-  ::: $DIR/forbidden_slices.rs:42:5
+  ::: $DIR/forbidden_slices.rs:43:5
    |
 LL |     from_raw_parts(ptr, 1)
-   |     ---------------------- inside `S8` at $DIR/forbidden_slices.rs:42:5
+   |     ---------------------- inside `S8` at $DIR/forbidden_slices.rs:43:5
 
 error[E0080]: could not evaluate static initializer
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
@@ -117,10 +117,10 @@ LL |         unsafe { intrinsics::ptr_offset_from_unsigned(self, origin) }
 LL |     unsafe { from_raw_parts(range.start, range.end.sub_ptr(range.start)) }
    |                                          ------------------------------ inside `from_ptr_range::<u32>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
    |
-  ::: $DIR/forbidden_slices.rs:45:34
+  ::: $DIR/forbidden_slices.rs:46:34
    |
 LL | pub static R0: &[u32] = unsafe { from_ptr_range(ptr::null()..ptr::null()) };
-   |                                  ---------------------------------------- inside `R0` at $DIR/forbidden_slices.rs:45:34
+   |                                  ---------------------------------------- inside `R0` at $DIR/forbidden_slices.rs:46:34
 
 error[E0080]: could not evaluate static initializer
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
@@ -136,10 +136,10 @@ LL |         assert!(0 < pointee_size && pointee_size <= isize::MAX as usize);
 LL |     unsafe { from_raw_parts(range.start, range.end.sub_ptr(range.start)) }
    |                                          ------------------------------ inside `from_ptr_range::<()>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
    |
-  ::: $DIR/forbidden_slices.rs:46:33
+  ::: $DIR/forbidden_slices.rs:47:33
    |
 LL | pub static R1: &[()] = unsafe { from_ptr_range(ptr::null()..ptr::null()) };
-   |                                 ---------------------------------------- inside `R1` at $DIR/forbidden_slices.rs:46:33
+   |                                 ---------------------------------------- inside `R1` at $DIR/forbidden_slices.rs:47:33
    |
    = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -149,19 +149,19 @@ error[E0080]: could not evaluate static initializer
 LL |         unsafe { intrinsics::offset(self, count) }
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |                  |
-   |                  pointer arithmetic failed: alloc154 has size 4, so pointer to 8 bytes starting at offset 0 is out-of-bounds
+   |                  pointer arithmetic failed: ALLOC_ID has size 4, so pointer to 8 bytes starting at offset 0 is out-of-bounds
    |                  inside `ptr::const_ptr::<impl *const u32>::offset` at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
 ...
 LL |         unsafe { self.offset(count as isize) }
    |                  --------------------------- inside `ptr::const_ptr::<impl *const u32>::add` at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
    |
-  ::: $DIR/forbidden_slices.rs:49:25
+  ::: $DIR/forbidden_slices.rs:50:25
    |
 LL |     from_ptr_range(ptr..ptr.add(2))
-   |                         ---------- inside `R2` at $DIR/forbidden_slices.rs:49:25
+   |                         ---------- inside `R2` at $DIR/forbidden_slices.rs:50:25
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/forbidden_slices.rs:51:1
+  --> $DIR/forbidden_slices.rs:52:1
    |
 LL | / pub static R4: &[u8] = unsafe {
 LL | |
@@ -172,11 +172,11 @@ LL | | };
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾──────alloc159───────╼ 01 00 00 00 00 00 00 00 │ ╾──────╼........
+               ╾──────ALLOC_ID───────╼ 01 00 00 00 00 00 00 00 │ ╾──────╼........
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/forbidden_slices.rs:56:1
+  --> $DIR/forbidden_slices.rs:57:1
    |
 LL | / pub static R5: &[u8] = unsafe {
 LL | |
@@ -187,11 +187,11 @@ LL | | };
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾──────alloc175───────╼ 08 00 00 00 00 00 00 00 │ ╾──────╼........
+               ╾──────ALLOC_ID───────╼ 08 00 00 00 00 00 00 00 │ ╾──────╼........
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/forbidden_slices.rs:61:1
+  --> $DIR/forbidden_slices.rs:62:1
    |
 LL | / pub static R6: &[bool] = unsafe {
 LL | |
@@ -202,11 +202,11 @@ LL | | };
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾──────alloc191───────╼ 04 00 00 00 00 00 00 00 │ ╾──────╼........
+               ╾──────ALLOC_ID───────╼ 04 00 00 00 00 00 00 00 │ ╾──────╼........
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/forbidden_slices.rs:66:1
+  --> $DIR/forbidden_slices.rs:67:1
    |
 LL | / pub static R7: &[u16] = unsafe {
 LL | |
@@ -217,7 +217,7 @@ LL | | };
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 16, align: 8) {
-               ╾────alloc209+0x1─────╼ 04 00 00 00 00 00 00 00 │ ╾──────╼........
+               ╾────ALLOC_ID+0x1─────╼ 04 00 00 00 00 00 00 00 │ ╾──────╼........
            }
 
 error[E0080]: could not evaluate static initializer
@@ -226,16 +226,16 @@ error[E0080]: could not evaluate static initializer
 LL |         unsafe { intrinsics::offset(self, count) }
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |                  |
-   |                  pointer arithmetic failed: alloc230 has size 8, so pointer to 8 bytes starting at offset 1 is out-of-bounds
+   |                  pointer arithmetic failed: ALLOC_ID has size 8, so pointer to 8 bytes starting at offset 1 is out-of-bounds
    |                  inside `ptr::const_ptr::<impl *const u64>::offset` at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
 ...
 LL |         unsafe { self.offset(count as isize) }
    |                  --------------------------- inside `ptr::const_ptr::<impl *const u64>::add` at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
    |
-  ::: $DIR/forbidden_slices.rs:73:25
+  ::: $DIR/forbidden_slices.rs:74:25
    |
 LL |     from_ptr_range(ptr..ptr.add(1))
-   |                         ---------- inside `R8` at $DIR/forbidden_slices.rs:73:25
+   |                         ---------- inside `R8` at $DIR/forbidden_slices.rs:74:25
 
 error[E0080]: could not evaluate static initializer
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
@@ -251,10 +251,10 @@ LL |         unsafe { intrinsics::ptr_offset_from_unsigned(self, origin) }
 LL |     unsafe { from_raw_parts(range.start, range.end.sub_ptr(range.start)) }
    |                                          ------------------------------ inside `from_ptr_range::<u32>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
    |
-  ::: $DIR/forbidden_slices.rs:78:34
+  ::: $DIR/forbidden_slices.rs:79:34
    |
 LL | pub static R9: &[u32] = unsafe { from_ptr_range(&D0..(&D0 as *const u32).add(1)) };
-   |                                  ----------------------------------------------- inside `R9` at $DIR/forbidden_slices.rs:78:34
+   |                                  ----------------------------------------------- inside `R9` at $DIR/forbidden_slices.rs:79:34
 
 error[E0080]: could not evaluate static initializer
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
@@ -270,10 +270,10 @@ LL |         unsafe { intrinsics::ptr_offset_from_unsigned(self, origin) }
 LL |     unsafe { from_raw_parts(range.start, range.end.sub_ptr(range.start)) }
    |                                          ------------------------------ inside `from_ptr_range::<u32>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
    |
-  ::: $DIR/forbidden_slices.rs:79:35
+  ::: $DIR/forbidden_slices.rs:80:35
    |
 LL | pub static R10: &[u32] = unsafe { from_ptr_range(&D0..&D0) };
-   |                                   ------------------------ inside `R10` at $DIR/forbidden_slices.rs:79:35
+   |                                   ------------------------ inside `R10` at $DIR/forbidden_slices.rs:80:35
 
 error: aborting due to 18 previous errors
 

--- a/src/test/ui/const-ptr/forbidden_slices.64bit.stderr
+++ b/src/test/ui/const-ptr/forbidden_slices.64bit.stderr
@@ -7,10 +7,10 @@ LL |         &*ptr::slice_from_raw_parts(data, len)
    |         dereferencing pointer failed: null pointer is not a valid pointer
    |         inside `std::slice::from_raw_parts::<u32>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
    |
-  ::: $DIR/forbidden_slices.rs:16:34
+  ::: $DIR/forbidden_slices.rs:17:34
    |
 LL | pub static S0: &[u32] = unsafe { from_raw_parts(ptr::null(), 0) };
-   |                                  ------------------------------ inside `S0` at $DIR/forbidden_slices.rs:16:34
+   |                                  ------------------------------ inside `S0` at $DIR/forbidden_slices.rs:17:34
 
 error[E0080]: could not evaluate static initializer
   --> $SRC_DIR/core/src/slice/raw.rs:LL:COL
@@ -21,10 +21,10 @@ LL |         &*ptr::slice_from_raw_parts(data, len)
    |         dereferencing pointer failed: null pointer is not a valid pointer
    |         inside `std::slice::from_raw_parts::<()>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
    |
-  ::: $DIR/forbidden_slices.rs:17:33
+  ::: $DIR/forbidden_slices.rs:18:33
    |
 LL | pub static S1: &[()] = unsafe { from_raw_parts(ptr::null(), 0) };
-   |                                 ------------------------------ inside `S1` at $DIR/forbidden_slices.rs:17:33
+   |                                 ------------------------------ inside `S1` at $DIR/forbidden_slices.rs:18:33
 
 error[E0080]: could not evaluate static initializer
   --> $SRC_DIR/core/src/slice/raw.rs:LL:COL
@@ -35,13 +35,13 @@ LL |         &*ptr::slice_from_raw_parts(data, len)
    |         dereferencing pointer failed: alloc26 has size 4, so pointer to 8 bytes starting at offset 0 is out-of-bounds
    |         inside `std::slice::from_raw_parts::<u32>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
    |
-  ::: $DIR/forbidden_slices.rs:20:34
+  ::: $DIR/forbidden_slices.rs:21:34
    |
 LL | pub static S2: &[u32] = unsafe { from_raw_parts(&D0, 2) };
-   |                                  ---------------------- inside `S2` at $DIR/forbidden_slices.rs:20:34
+   |                                  ---------------------- inside `S2` at $DIR/forbidden_slices.rs:21:34
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/forbidden_slices.rs:23:1
+  --> $DIR/forbidden_slices.rs:24:1
    |
 LL | pub static S4: &[u8] = unsafe { from_raw_parts((&D1) as *const _ as _, 1) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .<deref>[0]: encountered uninitialized bytes
@@ -52,7 +52,7 @@ LL | pub static S4: &[u8] = unsafe { from_raw_parts((&D1) as *const _ as _, 1) }
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/forbidden_slices.rs:25:1
+  --> $DIR/forbidden_slices.rs:26:1
    |
 LL | pub static S5: &[u8] = unsafe { from_raw_parts((&D3) as *const _ as _, size_of::<&u32>()) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .<deref>: encountered a pointer, but expected plain (non-pointer) bytes
@@ -63,7 +63,7 @@ LL | pub static S5: &[u8] = unsafe { from_raw_parts((&D3) as *const _ as _, size
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/forbidden_slices.rs:27:1
+  --> $DIR/forbidden_slices.rs:28:1
    |
 LL | pub static S6: &[bool] = unsafe { from_raw_parts((&D0) as *const _ as _, 4) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .<deref>[0]: encountered 0x11, but expected a boolean
@@ -74,7 +74,7 @@ LL | pub static S6: &[bool] = unsafe { from_raw_parts((&D0) as *const _ as _, 4)
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/forbidden_slices.rs:30:1
+  --> $DIR/forbidden_slices.rs:31:1
    |
 LL | / pub static S7: &[u16] = unsafe {
 LL | |
@@ -98,10 +98,10 @@ LL |         &*ptr::slice_from_raw_parts(data, len)
    |         dereferencing pointer failed: alloc96 has size 8, so pointer to 8 bytes starting at offset 1 is out-of-bounds
    |         inside `std::slice::from_raw_parts::<u64>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
    |
-  ::: $DIR/forbidden_slices.rs:41:5
+  ::: $DIR/forbidden_slices.rs:42:5
    |
 LL |     from_raw_parts(ptr, 1)
-   |     ---------------------- inside `S8` at $DIR/forbidden_slices.rs:41:5
+   |     ---------------------- inside `S8` at $DIR/forbidden_slices.rs:42:5
 
 error[E0080]: could not evaluate static initializer
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
@@ -117,10 +117,10 @@ LL |         unsafe { intrinsics::ptr_offset_from_unsigned(self, origin) }
 LL |     unsafe { from_raw_parts(range.start, range.end.sub_ptr(range.start)) }
    |                                          ------------------------------ inside `from_ptr_range::<u32>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
    |
-  ::: $DIR/forbidden_slices.rs:44:34
+  ::: $DIR/forbidden_slices.rs:45:34
    |
 LL | pub static R0: &[u32] = unsafe { from_ptr_range(ptr::null()..ptr::null()) };
-   |                                  ---------------------------------------- inside `R0` at $DIR/forbidden_slices.rs:44:34
+   |                                  ---------------------------------------- inside `R0` at $DIR/forbidden_slices.rs:45:34
 
 error[E0080]: could not evaluate static initializer
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
@@ -136,10 +136,10 @@ LL |         assert!(0 < pointee_size && pointee_size <= isize::MAX as usize);
 LL |     unsafe { from_raw_parts(range.start, range.end.sub_ptr(range.start)) }
    |                                          ------------------------------ inside `from_ptr_range::<()>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
    |
-  ::: $DIR/forbidden_slices.rs:45:33
+  ::: $DIR/forbidden_slices.rs:46:33
    |
 LL | pub static R1: &[()] = unsafe { from_ptr_range(ptr::null()..ptr::null()) };
-   |                                 ---------------------------------------- inside `R1` at $DIR/forbidden_slices.rs:45:33
+   |                                 ---------------------------------------- inside `R1` at $DIR/forbidden_slices.rs:46:33
    |
    = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -155,13 +155,13 @@ LL |         unsafe { intrinsics::offset(self, count) }
 LL |         unsafe { self.offset(count as isize) }
    |                  --------------------------- inside `ptr::const_ptr::<impl *const u32>::add` at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
    |
-  ::: $DIR/forbidden_slices.rs:48:25
+  ::: $DIR/forbidden_slices.rs:49:25
    |
 LL |     from_ptr_range(ptr..ptr.add(2))
-   |                         ---------- inside `R2` at $DIR/forbidden_slices.rs:48:25
+   |                         ---------- inside `R2` at $DIR/forbidden_slices.rs:49:25
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/forbidden_slices.rs:50:1
+  --> $DIR/forbidden_slices.rs:51:1
    |
 LL | / pub static R4: &[u8] = unsafe {
 LL | |
@@ -176,7 +176,7 @@ LL | | };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/forbidden_slices.rs:55:1
+  --> $DIR/forbidden_slices.rs:56:1
    |
 LL | / pub static R5: &[u8] = unsafe {
 LL | |
@@ -191,7 +191,7 @@ LL | | };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/forbidden_slices.rs:60:1
+  --> $DIR/forbidden_slices.rs:61:1
    |
 LL | / pub static R6: &[bool] = unsafe {
 LL | |
@@ -206,7 +206,7 @@ LL | | };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/forbidden_slices.rs:65:1
+  --> $DIR/forbidden_slices.rs:66:1
    |
 LL | / pub static R7: &[u16] = unsafe {
 LL | |
@@ -232,10 +232,10 @@ LL |         unsafe { intrinsics::offset(self, count) }
 LL |         unsafe { self.offset(count as isize) }
    |                  --------------------------- inside `ptr::const_ptr::<impl *const u64>::add` at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
    |
-  ::: $DIR/forbidden_slices.rs:72:25
+  ::: $DIR/forbidden_slices.rs:73:25
    |
 LL |     from_ptr_range(ptr..ptr.add(1))
-   |                         ---------- inside `R8` at $DIR/forbidden_slices.rs:72:25
+   |                         ---------- inside `R8` at $DIR/forbidden_slices.rs:73:25
 
 error[E0080]: could not evaluate static initializer
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
@@ -251,10 +251,10 @@ LL |         unsafe { intrinsics::ptr_offset_from_unsigned(self, origin) }
 LL |     unsafe { from_raw_parts(range.start, range.end.sub_ptr(range.start)) }
    |                                          ------------------------------ inside `from_ptr_range::<u32>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
    |
-  ::: $DIR/forbidden_slices.rs:77:34
+  ::: $DIR/forbidden_slices.rs:78:34
    |
 LL | pub static R9: &[u32] = unsafe { from_ptr_range(&D0..(&D0 as *const u32).add(1)) };
-   |                                  ----------------------------------------------- inside `R9` at $DIR/forbidden_slices.rs:77:34
+   |                                  ----------------------------------------------- inside `R9` at $DIR/forbidden_slices.rs:78:34
 
 error[E0080]: could not evaluate static initializer
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
@@ -270,10 +270,10 @@ LL |         unsafe { intrinsics::ptr_offset_from_unsigned(self, origin) }
 LL |     unsafe { from_raw_parts(range.start, range.end.sub_ptr(range.start)) }
    |                                          ------------------------------ inside `from_ptr_range::<u32>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
    |
-  ::: $DIR/forbidden_slices.rs:78:35
+  ::: $DIR/forbidden_slices.rs:79:35
    |
 LL | pub static R10: &[u32] = unsafe { from_ptr_range(&D0..&D0) };
-   |                                   ------------------------ inside `R10` at $DIR/forbidden_slices.rs:78:35
+   |                                   ------------------------ inside `R10` at $DIR/forbidden_slices.rs:79:35
 
 error: aborting due to 18 previous errors
 

--- a/src/test/ui/const-ptr/forbidden_slices.rs
+++ b/src/test/ui/const-ptr/forbidden_slices.rs
@@ -1,3 +1,4 @@
+// stderr-per-bitwidth
 // error-pattern: could not evaluate static initializer
 #![feature(
     const_slice_from_raw_parts,

--- a/src/test/ui/const-ptr/forbidden_slices.rs
+++ b/src/test/ui/const-ptr/forbidden_slices.rs
@@ -1,0 +1,95 @@
+#![feature(
+    const_slice_from_raw_parts,
+    slice_from_ptr_range,
+    slice_from_ptr_range_const,
+    pointer_byte_offsets,
+    const_pointer_byte_offsets
+)]
+use std::{
+    mem::{size_of, MaybeUninit},
+    ptr,
+    slice::{from_ptr_range, from_raw_parts},
+};
+
+// Null is never valid for reads
+pub static S0: &[u32] = unsafe { from_raw_parts(ptr::null(), 0) };
+pub static S1: &[()] = unsafe { from_raw_parts(ptr::null(), 0) };
+
+// Out of bounds
+pub static S2: &[u32] = unsafe { from_raw_parts(&D0, 2) };
+
+// Reading uninitialized  data
+pub static S4: &[u8] = unsafe { from_raw_parts((&D1) as *const _ as _, 1) }; //~ ERROR: it is undefined behavior to use this value
+// Reinterpret pointers as integers (UB in CTFE.)
+pub static S5: &[u8] = unsafe { from_raw_parts((&D3) as *const _ as _, size_of::<&u32>()) }; //~ ERROR: it is undefined behavior to use this value
+// Layout mismatch
+pub static S6: &[bool] = unsafe { from_raw_parts((&D0) as *const _ as _, 4) }; //~ ERROR: it is undefined behavior to use this value
+
+// Reading padding is not ok
+pub static S7: &[u16] = unsafe {
+    //~^ ERROR: it is undefined behavior to use this value
+    let ptr = (&D2 as *const Struct as *const u16).byte_add(1);
+
+    from_raw_parts(ptr, 4)
+};
+
+// Unaligned read
+pub static S8: &[u64] = unsafe {
+    let ptr = (&D4 as *const [u32; 2] as *const u32).byte_add(1).cast::<u64>();
+
+    from_raw_parts(ptr, 1)
+};
+
+pub static R0: &[u32] = unsafe { from_ptr_range(ptr::null()..ptr::null()) };
+pub static R1: &[()] = unsafe { from_ptr_range(ptr::null()..ptr::null()) };
+pub static R2: &[u32] = unsafe {
+    let ptr = &D0 as *const u32;
+    from_ptr_range(ptr..ptr.add(2))
+};
+pub static R4: &[u8] = unsafe {
+    //~^ ERROR: it is undefined behavior to use this value
+    let ptr = (&D1) as *const MaybeUninit<&u32> as *const u8;
+    from_ptr_range(ptr..ptr.add(1))
+};
+pub static R5: &[u8] = unsafe {
+    //~^ ERROR: it is undefined behavior to use this value
+    let ptr = &D3 as *const &u32;
+    from_ptr_range(ptr.cast()..ptr.add(1).cast())
+};
+pub static R6: &[bool] = unsafe {
+    //~^ ERROR: it is undefined behavior to use this value
+    let ptr = &D0 as *const u32 as *const bool;
+    from_ptr_range(ptr..ptr.add(4))
+};
+pub static R7: &[u16] = unsafe {
+    //~^ ERROR: it is undefined behavior to use this value
+    let ptr = (&D2 as *const Struct as *const u16).byte_add(1);
+    from_ptr_range(ptr..ptr.add(4))
+};
+pub static R8: &[u64] = unsafe {
+    let ptr = (&D4 as *const [u32; 2] as *const u32).byte_add(1).cast::<u64>();
+    from_ptr_range(ptr..ptr.add(1))
+};
+
+// This is sneaky: &D0 and &D0 point to different objects
+// (even if at runtime they have the same address)
+pub static R9: &[u32] = unsafe { from_ptr_range(&D0..(&D0 as *const u32).add(1)) };
+pub static R10: &[u32] = unsafe { from_ptr_range(&D0..&D0) };
+
+const D0: u32 = 0x11;
+const D1: MaybeUninit<&u32> = MaybeUninit::uninit();
+const D2: Struct = Struct { a: 1, b: 2, c: 3, d: 4 };
+const D3: &u32 = &42;
+const D4: [u32; 2] = [17, 42];
+
+#[repr(C)]
+struct Struct {
+    a: u8,
+    // _pad: [MaybeUninit<u8>; 3]
+    b: u32,
+    c: u16,
+    d: u8,
+    // _pad: [MaybeUninit<u8>; 1]
+}
+
+fn main() {}

--- a/src/test/ui/const-ptr/forbidden_slices.rs
+++ b/src/test/ui/const-ptr/forbidden_slices.rs
@@ -1,3 +1,4 @@
+// error-pattern: could not evaluate static initializer
 #![feature(
     const_slice_from_raw_parts,
     slice_from_ptr_range,

--- a/src/test/ui/const-ptr/forbidden_slices.rs
+++ b/src/test/ui/const-ptr/forbidden_slices.rs
@@ -1,5 +1,6 @@
 // stderr-per-bitwidth
 // normalize-stderr-test "alloc[0-9]+" -> "ALLOC_ID"
+// normalize-stderr-test "a[0-9]+\+0x" -> "A_ID+0x"
 // error-pattern: could not evaluate static initializer
 #![feature(
     const_slice_from_raw_parts,

--- a/src/test/ui/const-ptr/forbidden_slices.rs
+++ b/src/test/ui/const-ptr/forbidden_slices.rs
@@ -1,7 +1,7 @@
 #![feature(
     const_slice_from_raw_parts,
     slice_from_ptr_range,
-    slice_from_ptr_range_const,
+    const_slice_from_ptr_range,
     pointer_byte_offsets,
     const_pointer_byte_offsets
 )]

--- a/src/test/ui/const-ptr/forbidden_slices.rs
+++ b/src/test/ui/const-ptr/forbidden_slices.rs
@@ -1,4 +1,5 @@
 // stderr-per-bitwidth
+// normalize-stderr-test "alloc[0-9]+" -> "ALLOC_ID"
 // error-pattern: could not evaluate static initializer
 #![feature(
     const_slice_from_raw_parts,

--- a/src/test/ui/const-ptr/forbidden_slices.stderr
+++ b/src/test/ui/const-ptr/forbidden_slices.stderr
@@ -1,0 +1,280 @@
+error[E0080]: could not evaluate static initializer
+  --> $SRC_DIR/core/src/slice/raw.rs:LL:COL
+   |
+LL |         &*ptr::slice_from_raw_parts(data, len)
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         |
+   |         dereferencing pointer failed: null pointer is not a valid pointer
+   |         inside `std::slice::from_raw_parts::<u32>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
+   |
+  ::: $DIR/forbidden_slices.rs:15:34
+   |
+LL | pub static S0: &[u32] = unsafe { from_raw_parts(ptr::null(), 0) };
+   |                                  ------------------------------ inside `S0` at $DIR/forbidden_slices.rs:15:34
+
+error[E0080]: could not evaluate static initializer
+  --> $SRC_DIR/core/src/slice/raw.rs:LL:COL
+   |
+LL |         &*ptr::slice_from_raw_parts(data, len)
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         |
+   |         dereferencing pointer failed: null pointer is not a valid pointer
+   |         inside `std::slice::from_raw_parts::<()>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
+   |
+  ::: $DIR/forbidden_slices.rs:16:33
+   |
+LL | pub static S1: &[()] = unsafe { from_raw_parts(ptr::null(), 0) };
+   |                                 ------------------------------ inside `S1` at $DIR/forbidden_slices.rs:16:33
+
+error[E0080]: could not evaluate static initializer
+  --> $SRC_DIR/core/src/slice/raw.rs:LL:COL
+   |
+LL |         &*ptr::slice_from_raw_parts(data, len)
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         |
+   |         dereferencing pointer failed: alloc26 has size 4, so pointer to 8 bytes starting at offset 0 is out-of-bounds
+   |         inside `std::slice::from_raw_parts::<u32>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
+   |
+  ::: $DIR/forbidden_slices.rs:19:34
+   |
+LL | pub static S2: &[u32] = unsafe { from_raw_parts(&D0, 2) };
+   |                                  ---------------------- inside `S2` at $DIR/forbidden_slices.rs:19:34
+
+error[E0080]: it is undefined behavior to use this value
+  --> $DIR/forbidden_slices.rs:22:1
+   |
+LL | pub static S4: &[u8] = unsafe { from_raw_parts((&D1) as *const _ as _, 1) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .<deref>[0]: encountered uninitialized bytes
+   |
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
+   = note: the raw bytes of the constant (size: 16, align: 8) {
+               ╾───────alloc42───────╼ 01 00 00 00 00 00 00 00 │ ╾──────╼........
+           }
+
+error[E0080]: it is undefined behavior to use this value
+  --> $DIR/forbidden_slices.rs:24:1
+   |
+LL | pub static S5: &[u8] = unsafe { from_raw_parts((&D3) as *const _ as _, size_of::<&u32>()) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .<deref>: encountered a pointer, but expected plain (non-pointer) bytes
+   |
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
+   = note: the raw bytes of the constant (size: 16, align: 8) {
+               ╾───────alloc55───────╼ 08 00 00 00 00 00 00 00 │ ╾──────╼........
+           }
+
+error[E0080]: it is undefined behavior to use this value
+  --> $DIR/forbidden_slices.rs:26:1
+   |
+LL | pub static S6: &[bool] = unsafe { from_raw_parts((&D0) as *const _ as _, 4) };
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .<deref>[0]: encountered 0x11, but expected a boolean
+   |
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
+   = note: the raw bytes of the constant (size: 16, align: 8) {
+               ╾───────alloc65───────╼ 04 00 00 00 00 00 00 00 │ ╾──────╼........
+           }
+
+error[E0080]: it is undefined behavior to use this value
+  --> $DIR/forbidden_slices.rs:29:1
+   |
+LL | / pub static S7: &[u16] = unsafe {
+LL | |
+LL | |     let ptr = (&D2 as *const Struct as *const u16).byte_add(1);
+LL | |
+LL | |     from_raw_parts(ptr, 4)
+LL | | };
+   | |__^ type validation failed: encountered an unaligned reference (required 2 byte alignment but found 1)
+   |
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
+   = note: the raw bytes of the constant (size: 16, align: 8) {
+               ╾─────alloc79+0x1─────╼ 04 00 00 00 00 00 00 00 │ ╾──────╼........
+           }
+
+error[E0080]: could not evaluate static initializer
+  --> $SRC_DIR/core/src/slice/raw.rs:LL:COL
+   |
+LL |         &*ptr::slice_from_raw_parts(data, len)
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         |
+   |         dereferencing pointer failed: alloc96 has size 8, so pointer to 8 bytes starting at offset 1 is out-of-bounds
+   |         inside `std::slice::from_raw_parts::<u64>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
+   |
+  ::: $DIR/forbidden_slices.rs:40:5
+   |
+LL |     from_raw_parts(ptr, 1)
+   |     ---------------------- inside `S8` at $DIR/forbidden_slices.rs:40:5
+
+error[E0080]: could not evaluate static initializer
+  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+   |
+LL |         unsafe { intrinsics::ptr_offset_from_unsigned(self, origin) }
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                  |
+   |                  out-of-bounds offset_from: null pointer is not a valid pointer
+   |                  inside `ptr::const_ptr::<impl *const u32>::sub_ptr` at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+   |
+  ::: $SRC_DIR/core/src/slice/raw.rs:LL:COL
+   |
+LL |     unsafe { from_raw_parts(range.start, range.end.sub_ptr(range.start)) }
+   |                                          ------------------------------ inside `from_ptr_range::<u32>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
+   |
+  ::: $DIR/forbidden_slices.rs:43:34
+   |
+LL | pub static R0: &[u32] = unsafe { from_ptr_range(ptr::null()..ptr::null()) };
+   |                                  ---------------------------------------- inside `R0` at $DIR/forbidden_slices.rs:43:34
+
+error[E0080]: could not evaluate static initializer
+  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+   |
+LL |         assert!(0 < pointee_size && pointee_size <= isize::MAX as usize);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         |
+   |         the evaluated program panicked at 'assertion failed: 0 < pointee_size && pointee_size <= isize::MAX as usize', $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+   |         inside `ptr::const_ptr::<impl *const ()>::sub_ptr` at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+   |
+  ::: $SRC_DIR/core/src/slice/raw.rs:LL:COL
+   |
+LL |     unsafe { from_raw_parts(range.start, range.end.sub_ptr(range.start)) }
+   |                                          ------------------------------ inside `from_ptr_range::<()>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
+   |
+  ::: $DIR/forbidden_slices.rs:44:33
+   |
+LL | pub static R1: &[()] = unsafe { from_ptr_range(ptr::null()..ptr::null()) };
+   |                                 ---------------------------------------- inside `R1` at $DIR/forbidden_slices.rs:44:33
+   |
+   = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0080]: could not evaluate static initializer
+  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+   |
+LL |         unsafe { intrinsics::offset(self, count) }
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                  |
+   |                  pointer arithmetic failed: alloc154 has size 4, so pointer to 8 bytes starting at offset 0 is out-of-bounds
+   |                  inside `ptr::const_ptr::<impl *const u32>::offset` at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+...
+LL |         unsafe { self.offset(count as isize) }
+   |                  --------------------------- inside `ptr::const_ptr::<impl *const u32>::add` at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+   |
+  ::: $DIR/forbidden_slices.rs:47:25
+   |
+LL |     from_ptr_range(ptr..ptr.add(2))
+   |                         ---------- inside `R2` at $DIR/forbidden_slices.rs:47:25
+
+error[E0080]: it is undefined behavior to use this value
+  --> $DIR/forbidden_slices.rs:49:1
+   |
+LL | / pub static R4: &[u8] = unsafe {
+LL | |
+LL | |     let ptr = (&D1) as *const MaybeUninit<&u32> as *const u8;
+LL | |     from_ptr_range(ptr..ptr.add(1))
+LL | | };
+   | |__^ type validation failed at .<deref>[0]: encountered uninitialized bytes
+   |
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
+   = note: the raw bytes of the constant (size: 16, align: 8) {
+               ╾──────alloc159───────╼ 01 00 00 00 00 00 00 00 │ ╾──────╼........
+           }
+
+error[E0080]: it is undefined behavior to use this value
+  --> $DIR/forbidden_slices.rs:54:1
+   |
+LL | / pub static R5: &[u8] = unsafe {
+LL | |
+LL | |     let ptr = &D3 as *const &u32;
+LL | |     from_ptr_range(ptr.cast()..ptr.add(1).cast())
+LL | | };
+   | |__^ type validation failed at .<deref>: encountered a pointer, but expected plain (non-pointer) bytes
+   |
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
+   = note: the raw bytes of the constant (size: 16, align: 8) {
+               ╾──────alloc175───────╼ 08 00 00 00 00 00 00 00 │ ╾──────╼........
+           }
+
+error[E0080]: it is undefined behavior to use this value
+  --> $DIR/forbidden_slices.rs:59:1
+   |
+LL | / pub static R6: &[bool] = unsafe {
+LL | |
+LL | |     let ptr = &D0 as *const u32 as *const bool;
+LL | |     from_ptr_range(ptr..ptr.add(4))
+LL | | };
+   | |__^ type validation failed at .<deref>[0]: encountered 0x11, but expected a boolean
+   |
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
+   = note: the raw bytes of the constant (size: 16, align: 8) {
+               ╾──────alloc191───────╼ 04 00 00 00 00 00 00 00 │ ╾──────╼........
+           }
+
+error[E0080]: it is undefined behavior to use this value
+  --> $DIR/forbidden_slices.rs:64:1
+   |
+LL | / pub static R7: &[u16] = unsafe {
+LL | |
+LL | |     let ptr = (&D2 as *const Struct as *const u16).byte_add(1);
+LL | |     from_ptr_range(ptr..ptr.add(4))
+LL | | };
+   | |__^ type validation failed: encountered an unaligned reference (required 2 byte alignment but found 1)
+   |
+   = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
+   = note: the raw bytes of the constant (size: 16, align: 8) {
+               ╾────alloc209+0x1─────╼ 04 00 00 00 00 00 00 00 │ ╾──────╼........
+           }
+
+error[E0080]: could not evaluate static initializer
+  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+   |
+LL |         unsafe { intrinsics::offset(self, count) }
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                  |
+   |                  pointer arithmetic failed: alloc230 has size 8, so pointer to 8 bytes starting at offset 1 is out-of-bounds
+   |                  inside `ptr::const_ptr::<impl *const u64>::offset` at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+...
+LL |         unsafe { self.offset(count as isize) }
+   |                  --------------------------- inside `ptr::const_ptr::<impl *const u64>::add` at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+   |
+  ::: $DIR/forbidden_slices.rs:71:25
+   |
+LL |     from_ptr_range(ptr..ptr.add(1))
+   |                         ---------- inside `R8` at $DIR/forbidden_slices.rs:71:25
+
+error[E0080]: could not evaluate static initializer
+  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+   |
+LL |         unsafe { intrinsics::ptr_offset_from_unsigned(self, origin) }
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                  |
+   |                  ptr_offset_from_unsigned cannot compute offset of pointers into different allocations.
+   |                  inside `ptr::const_ptr::<impl *const u32>::sub_ptr` at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+   |
+  ::: $SRC_DIR/core/src/slice/raw.rs:LL:COL
+   |
+LL |     unsafe { from_raw_parts(range.start, range.end.sub_ptr(range.start)) }
+   |                                          ------------------------------ inside `from_ptr_range::<u32>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
+   |
+  ::: $DIR/forbidden_slices.rs:76:34
+   |
+LL | pub static R9: &[u32] = unsafe { from_ptr_range(&D0..(&D0 as *const u32).add(1)) };
+   |                                  ----------------------------------------------- inside `R9` at $DIR/forbidden_slices.rs:76:34
+
+error[E0080]: could not evaluate static initializer
+  --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+   |
+LL |         unsafe { intrinsics::ptr_offset_from_unsigned(self, origin) }
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                  |
+   |                  ptr_offset_from_unsigned cannot compute offset of pointers into different allocations.
+   |                  inside `ptr::const_ptr::<impl *const u32>::sub_ptr` at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
+   |
+  ::: $SRC_DIR/core/src/slice/raw.rs:LL:COL
+   |
+LL |     unsafe { from_raw_parts(range.start, range.end.sub_ptr(range.start)) }
+   |                                          ------------------------------ inside `from_ptr_range::<u32>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
+   |
+  ::: $DIR/forbidden_slices.rs:77:35
+   |
+LL | pub static R10: &[u32] = unsafe { from_ptr_range(&D0..&D0) };
+   |                                   ------------------------ inside `R10` at $DIR/forbidden_slices.rs:77:35
+
+error: aborting due to 18 previous errors
+
+For more information about this error, try `rustc --explain E0080`.

--- a/src/test/ui/const-ptr/forbidden_slices.stderr
+++ b/src/test/ui/const-ptr/forbidden_slices.stderr
@@ -7,10 +7,10 @@ LL |         &*ptr::slice_from_raw_parts(data, len)
    |         dereferencing pointer failed: null pointer is not a valid pointer
    |         inside `std::slice::from_raw_parts::<u32>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
    |
-  ::: $DIR/forbidden_slices.rs:15:34
+  ::: $DIR/forbidden_slices.rs:16:34
    |
 LL | pub static S0: &[u32] = unsafe { from_raw_parts(ptr::null(), 0) };
-   |                                  ------------------------------ inside `S0` at $DIR/forbidden_slices.rs:15:34
+   |                                  ------------------------------ inside `S0` at $DIR/forbidden_slices.rs:16:34
 
 error[E0080]: could not evaluate static initializer
   --> $SRC_DIR/core/src/slice/raw.rs:LL:COL
@@ -21,10 +21,10 @@ LL |         &*ptr::slice_from_raw_parts(data, len)
    |         dereferencing pointer failed: null pointer is not a valid pointer
    |         inside `std::slice::from_raw_parts::<()>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
    |
-  ::: $DIR/forbidden_slices.rs:16:33
+  ::: $DIR/forbidden_slices.rs:17:33
    |
 LL | pub static S1: &[()] = unsafe { from_raw_parts(ptr::null(), 0) };
-   |                                 ------------------------------ inside `S1` at $DIR/forbidden_slices.rs:16:33
+   |                                 ------------------------------ inside `S1` at $DIR/forbidden_slices.rs:17:33
 
 error[E0080]: could not evaluate static initializer
   --> $SRC_DIR/core/src/slice/raw.rs:LL:COL
@@ -35,13 +35,13 @@ LL |         &*ptr::slice_from_raw_parts(data, len)
    |         dereferencing pointer failed: alloc26 has size 4, so pointer to 8 bytes starting at offset 0 is out-of-bounds
    |         inside `std::slice::from_raw_parts::<u32>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
    |
-  ::: $DIR/forbidden_slices.rs:19:34
+  ::: $DIR/forbidden_slices.rs:20:34
    |
 LL | pub static S2: &[u32] = unsafe { from_raw_parts(&D0, 2) };
-   |                                  ---------------------- inside `S2` at $DIR/forbidden_slices.rs:19:34
+   |                                  ---------------------- inside `S2` at $DIR/forbidden_slices.rs:20:34
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/forbidden_slices.rs:22:1
+  --> $DIR/forbidden_slices.rs:23:1
    |
 LL | pub static S4: &[u8] = unsafe { from_raw_parts((&D1) as *const _ as _, 1) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .<deref>[0]: encountered uninitialized bytes
@@ -52,7 +52,7 @@ LL | pub static S4: &[u8] = unsafe { from_raw_parts((&D1) as *const _ as _, 1) }
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/forbidden_slices.rs:24:1
+  --> $DIR/forbidden_slices.rs:25:1
    |
 LL | pub static S5: &[u8] = unsafe { from_raw_parts((&D3) as *const _ as _, size_of::<&u32>()) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .<deref>: encountered a pointer, but expected plain (non-pointer) bytes
@@ -63,7 +63,7 @@ LL | pub static S5: &[u8] = unsafe { from_raw_parts((&D3) as *const _ as _, size
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/forbidden_slices.rs:26:1
+  --> $DIR/forbidden_slices.rs:27:1
    |
 LL | pub static S6: &[bool] = unsafe { from_raw_parts((&D0) as *const _ as _, 4) };
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed at .<deref>[0]: encountered 0x11, but expected a boolean
@@ -74,7 +74,7 @@ LL | pub static S6: &[bool] = unsafe { from_raw_parts((&D0) as *const _ as _, 4)
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/forbidden_slices.rs:29:1
+  --> $DIR/forbidden_slices.rs:30:1
    |
 LL | / pub static S7: &[u16] = unsafe {
 LL | |
@@ -98,10 +98,10 @@ LL |         &*ptr::slice_from_raw_parts(data, len)
    |         dereferencing pointer failed: alloc96 has size 8, so pointer to 8 bytes starting at offset 1 is out-of-bounds
    |         inside `std::slice::from_raw_parts::<u64>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
    |
-  ::: $DIR/forbidden_slices.rs:40:5
+  ::: $DIR/forbidden_slices.rs:41:5
    |
 LL |     from_raw_parts(ptr, 1)
-   |     ---------------------- inside `S8` at $DIR/forbidden_slices.rs:40:5
+   |     ---------------------- inside `S8` at $DIR/forbidden_slices.rs:41:5
 
 error[E0080]: could not evaluate static initializer
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
@@ -117,10 +117,10 @@ LL |         unsafe { intrinsics::ptr_offset_from_unsigned(self, origin) }
 LL |     unsafe { from_raw_parts(range.start, range.end.sub_ptr(range.start)) }
    |                                          ------------------------------ inside `from_ptr_range::<u32>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
    |
-  ::: $DIR/forbidden_slices.rs:43:34
+  ::: $DIR/forbidden_slices.rs:44:34
    |
 LL | pub static R0: &[u32] = unsafe { from_ptr_range(ptr::null()..ptr::null()) };
-   |                                  ---------------------------------------- inside `R0` at $DIR/forbidden_slices.rs:43:34
+   |                                  ---------------------------------------- inside `R0` at $DIR/forbidden_slices.rs:44:34
 
 error[E0080]: could not evaluate static initializer
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
@@ -136,10 +136,10 @@ LL |         assert!(0 < pointee_size && pointee_size <= isize::MAX as usize);
 LL |     unsafe { from_raw_parts(range.start, range.end.sub_ptr(range.start)) }
    |                                          ------------------------------ inside `from_ptr_range::<()>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
    |
-  ::: $DIR/forbidden_slices.rs:44:33
+  ::: $DIR/forbidden_slices.rs:45:33
    |
 LL | pub static R1: &[()] = unsafe { from_ptr_range(ptr::null()..ptr::null()) };
-   |                                 ---------------------------------------- inside `R1` at $DIR/forbidden_slices.rs:44:33
+   |                                 ---------------------------------------- inside `R1` at $DIR/forbidden_slices.rs:45:33
    |
    = note: this error originates in the macro `assert` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -155,13 +155,13 @@ LL |         unsafe { intrinsics::offset(self, count) }
 LL |         unsafe { self.offset(count as isize) }
    |                  --------------------------- inside `ptr::const_ptr::<impl *const u32>::add` at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
    |
-  ::: $DIR/forbidden_slices.rs:47:25
+  ::: $DIR/forbidden_slices.rs:48:25
    |
 LL |     from_ptr_range(ptr..ptr.add(2))
-   |                         ---------- inside `R2` at $DIR/forbidden_slices.rs:47:25
+   |                         ---------- inside `R2` at $DIR/forbidden_slices.rs:48:25
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/forbidden_slices.rs:49:1
+  --> $DIR/forbidden_slices.rs:50:1
    |
 LL | / pub static R4: &[u8] = unsafe {
 LL | |
@@ -176,7 +176,7 @@ LL | | };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/forbidden_slices.rs:54:1
+  --> $DIR/forbidden_slices.rs:55:1
    |
 LL | / pub static R5: &[u8] = unsafe {
 LL | |
@@ -191,7 +191,7 @@ LL | | };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/forbidden_slices.rs:59:1
+  --> $DIR/forbidden_slices.rs:60:1
    |
 LL | / pub static R6: &[bool] = unsafe {
 LL | |
@@ -206,7 +206,7 @@ LL | | };
            }
 
 error[E0080]: it is undefined behavior to use this value
-  --> $DIR/forbidden_slices.rs:64:1
+  --> $DIR/forbidden_slices.rs:65:1
    |
 LL | / pub static R7: &[u16] = unsafe {
 LL | |
@@ -232,10 +232,10 @@ LL |         unsafe { intrinsics::offset(self, count) }
 LL |         unsafe { self.offset(count as isize) }
    |                  --------------------------- inside `ptr::const_ptr::<impl *const u64>::add` at $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
    |
-  ::: $DIR/forbidden_slices.rs:71:25
+  ::: $DIR/forbidden_slices.rs:72:25
    |
 LL |     from_ptr_range(ptr..ptr.add(1))
-   |                         ---------- inside `R8` at $DIR/forbidden_slices.rs:71:25
+   |                         ---------- inside `R8` at $DIR/forbidden_slices.rs:72:25
 
 error[E0080]: could not evaluate static initializer
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
@@ -251,10 +251,10 @@ LL |         unsafe { intrinsics::ptr_offset_from_unsigned(self, origin) }
 LL |     unsafe { from_raw_parts(range.start, range.end.sub_ptr(range.start)) }
    |                                          ------------------------------ inside `from_ptr_range::<u32>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
    |
-  ::: $DIR/forbidden_slices.rs:76:34
+  ::: $DIR/forbidden_slices.rs:77:34
    |
 LL | pub static R9: &[u32] = unsafe { from_ptr_range(&D0..(&D0 as *const u32).add(1)) };
-   |                                  ----------------------------------------------- inside `R9` at $DIR/forbidden_slices.rs:76:34
+   |                                  ----------------------------------------------- inside `R9` at $DIR/forbidden_slices.rs:77:34
 
 error[E0080]: could not evaluate static initializer
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
@@ -270,10 +270,10 @@ LL |         unsafe { intrinsics::ptr_offset_from_unsigned(self, origin) }
 LL |     unsafe { from_raw_parts(range.start, range.end.sub_ptr(range.start)) }
    |                                          ------------------------------ inside `from_ptr_range::<u32>` at $SRC_DIR/core/src/slice/raw.rs:LL:COL
    |
-  ::: $DIR/forbidden_slices.rs:77:35
+  ::: $DIR/forbidden_slices.rs:78:35
    |
 LL | pub static R10: &[u32] = unsafe { from_ptr_range(&D0..&D0) };
-   |                                   ------------------------ inside `R10` at $DIR/forbidden_slices.rs:77:35
+   |                                   ------------------------ inside `R10` at $DIR/forbidden_slices.rs:78:35
 
 error: aborting due to 18 previous errors
 


### PR DESCRIPTION
This PR makes the following APIs `const`:
```rust
// core::slice

pub const unsafe fn from_ptr_range<'a, T>(range: Range<*const T>) -> &'a [T];
pub const unsafe fn from_mut_ptr_range<'a, T>(range: Range<*mut T>) -> &'a mut [T];
```

Tracking issue: #89792.
Feature for `from_ptr_range` as a `const fn`: `slice_from_ptr_range_const`.
Feature for `from_mut_ptr_range` as a `const fn`: `slice_from_mut_ptr_range_const`.

r? @oli-obk 