### PR TITLE
Implement `From<{Rc,Arc}<str>>` for `[u8]` counterpart

### DIFF
--- a/library/alloc/src/rc.rs
+++ b/library/alloc/src/rc.rs
@@ -1884,6 +1884,17 @@ impl From<String> for Rc<str> {
     }
 }
 
+#[stable(feature = "shared_from_str", since = "1.63.0")]
+impl From<Rc<str>> for Rc<[u8]> {
+    #[inline]
+    fn from(s: Rc<str>) -> Self {
+        // SAFETY: the cast from `*const str` to `*const [u8]` is safe since
+        // `str` has the same layout as `[u8]` (only libstd can make this
+        // guarantee).
+        unsafe { Rc::from_raw(Rc::into_raw(s) as *const [u8]) }
+    }
+}
+
 #[cfg(not(no_global_oom_handling))]
 #[stable(feature = "shared_from_slice", since = "1.21.0")]
 impl<T: ?Sized> From<Box<T>> for Rc<T> {

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -2484,6 +2484,17 @@ impl From<String> for Arc<str> {
     }
 }
 
+#[stable(feature = "shared_from_str", since = "1.63.0")]
+impl From<Arc<str>> for Arc<[u8]> {
+    #[inline]
+    fn from(s: Arc<str>) -> Self {
+        // SAFETY: the cast from `*const str` to `*const [u8]` is safe since
+        // `str` has the same layout as `[u8]` (only libstd can make this
+        // guarantee).
+        unsafe { Arc::from_raw(Arc::into_raw(s) as *const [u8]) }
+    }
+}
+
 #[cfg(not(no_global_oom_handling))]
 #[stable(feature = "shared_from_slice", since = "1.21.0")]
 impl<T: ?Sized> From<Box<T>> for Arc<T> {


### PR DESCRIPTION
This enables safely converting from `Arc<str>` or `Rc<str>` to `Arc<[u8]>` or `Rc<[u8]>` respectively.

Currently the following steps are needed outside of the standard library:
```rs
fn from_str(s: Arc<str>) -> Arc<[u8]> {
    let len: usize = s.len();
    let ptr: *const u8 = Arc::into_raw(s).cast();
    let raw: *const [u8] = std::ptr::slice_from_raw_parts(ptr, len);
    unsafe { Arc::from_raw(raw) }
}
```