### PR TITLE
don't do `Sized` and other return type checks on RPIT's real type

### DIFF
--- a/src/test/ui/impl-trait/rpit-not-sized.rs
+++ b/src/test/ui/impl-trait/rpit-not-sized.rs
@@ -1,0 +1,6 @@
+fn foo() -> impl ?Sized {
+    //~^ ERROR the size for values of type `impl ?Sized` cannot be known at compilation time
+    ()
+}
+
+fn main() {}

--- a/src/test/ui/impl-trait/rpit-not-sized.stderr
+++ b/src/test/ui/impl-trait/rpit-not-sized.stderr
@@ -1,0 +1,12 @@
+error[E0277]: the size for values of type `impl ?Sized` cannot be known at compilation time
+  --> $DIR/rpit-not-sized.rs:1:13
+   |
+LL | fn foo() -> impl ?Sized {
+   |             ^^^^^^^^^^^ doesn't have a size known at compile-time
+   |
+   = help: the trait `Sized` is not implemented for `impl ?Sized`
+   = note: the return type of a function must have a statically known size
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
Fixes an ICE where we're doing `Sized` check against the RPIT's real type, instead of against the opaque type. This differs from what we're doing in MIR typeck, which causes ICE #97226. 

This regressed in #96516 -- this adjusts that fix to be a bit more conservative. That PR was backported and thus the ICE is also present in stable. Not sure if it's worth to beta and/or stable backport, probably not the latter but I could believe the former.

r? @oli-obk

cc: another attempt to fix this ICE #97413. I believe this PR addresses the root cause.

Fixes #97226