### PR TITLE
Fix multiline attributes processing in doctest

### DIFF
--- a/src/librustdoc/doctest.rs
+++ b/src/librustdoc/doctest.rs
@@ -795,7 +795,9 @@ fn partition_source(s: &str, edition: Edition) -> (String, String, String) {
                         // If not, then we append the new line into the pending attribute to check
                         // if this time it's complete...
                         mod_attr_pending.push_str(line);
-                        if !trimline.is_empty() && check_if_attr_is_complete(&mod_attr_pending, edition) {
+                        if !trimline.is_empty()
+                            && check_if_attr_is_complete(&mod_attr_pending, edition)
+                        {
                             // If it's complete, then we can clear the pending content.
                             mod_attr_pending.clear();
                         }

--- a/src/librustdoc/doctest.rs
+++ b/src/librustdoc/doctest.rs
@@ -795,7 +795,7 @@ fn partition_source(s: &str, edition: Edition) -> (String, String, String) {
                         // If not, then we append the new line into the pending attribute to check
                         // if this time it's complete...
                         mod_attr_pending.push_str(line);
-                        if !trimline.is_empty() && check_if_attr_is_complete(line, edition) {
+                        if !trimline.is_empty() && check_if_attr_is_complete(&mod_attr_pending, edition) {
                             // If it's complete, then we can clear the pending content.
                             mod_attr_pending.clear();
                         }

--- a/src/test/rustdoc-ui/doc-comment-multi-line-attr.rs
+++ b/src/test/rustdoc-ui/doc-comment-multi-line-attr.rs
@@ -1,0 +1,11 @@
+// Regression test for #97440: Multiline (more than 2 lines) inner attribute triggers ICE during doctest
+// compile-flags:--test
+// normalize-stdout-test: "src/test/rustdoc-ui" -> "$$DIR"
+// normalize-stdout-test "finished in \d+\.\d+s" -> "finished in $$TIME"
+// check-pass
+
+//! ```rust
+//! #![deny(
+//! unused_parens,
+//! )]
+//! ```

--- a/src/test/rustdoc-ui/doc-comment-multi-line-attr.rs
+++ b/src/test/rustdoc-ui/doc-comment-multi-line-attr.rs
@@ -1,4 +1,4 @@
-// Regression test for #97440: Multiline (more than 2 lines) inner attribute triggers ICE during doctest
+// Regression test for #97440: Multiline inner attribute triggers ICE during doctest
 // compile-flags:--test
 // normalize-stdout-test: "src/test/rustdoc-ui" -> "$$DIR"
 // normalize-stdout-test "finished in \d+\.\d+s" -> "finished in $$TIME"

--- a/src/test/rustdoc-ui/doc-comment-multi-line-attr.stdout
+++ b/src/test/rustdoc-ui/doc-comment-multi-line-attr.stdout
@@ -1,0 +1,6 @@
+
+running 1 test
+test $DIR/doc-comment-multi-line-attr.rs - (line 7) ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
+


### PR DESCRIPTION
Fixes #97440.

It seems like the call to `check_if_attr_is_complete` is not provided with the correct argument: the pending attribute should be passed, while the current line is actually being passed. This causes any attribute with more than 2 lines to fail and produces ICE when running through doctest.