### PR TITLE
Modify `derive(Debug)` to use `Self` in struct literal to avoid redundant error

### DIFF
--- a/compiler/rustc_builtin_macros/src/deriving/generic/mod.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/generic/mod.rs
@@ -1039,7 +1039,9 @@ impl<'a> MethodDef<'a> {
         let span = trait_.span;
         let mut patterns = Vec::new();
         for i in 0..self_args.len() {
-            let struct_path = cx.path(span, vec![type_ident]);
+            // We could use `type_ident` instead of `Self`, but in the case of a type parameter
+            // shadowing the struct name, that causes a second, unnecessary E0578 error. #97343
+            let struct_path = cx.path(span, vec![Ident::new(kw::SelfUpper, type_ident.span)]);
             let (pat, ident_expr) = trait_.create_struct_pattern(
                 cx,
                 struct_path,

--- a/src/test/ui/derives/issue-97343.rs
+++ b/src/test/ui/derives/issue-97343.rs
@@ -1,6 +1,6 @@
 use std::fmt::Debug;
 
-#[derive(Debug)] //~ ERROR expected struct, variant or union type, found type parameter `Irrelevant`
+#[derive(Debug)]
 pub struct Irrelevant<Irrelevant> { //~ ERROR type arguments are not allowed for this type
     irrelevant: Irrelevant,
 }

--- a/src/test/ui/derives/issue-97343.rs
+++ b/src/test/ui/derives/issue-97343.rs
@@ -1,0 +1,8 @@
+use std::fmt::Debug;
+
+#[derive(Debug)] //~ ERROR expected struct, variant or union type, found type parameter `Irrelevant`
+pub struct Irrelevant<Irrelevant> { //~ ERROR type arguments are not allowed for this type
+    irrelevant: Irrelevant,
+}
+
+fn main() {}

--- a/src/test/ui/derives/issue-97343.stderr
+++ b/src/test/ui/derives/issue-97343.stderr
@@ -1,11 +1,3 @@
-error[E0574]: expected struct, variant or union type, found type parameter `Irrelevant`
-  --> $DIR/issue-97343.rs:3:10
-   |
-LL | #[derive(Debug)]
-   |          ^^^^^ not a struct, variant or union type
-   |
-   = note: this error originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)
-
 error[E0109]: type arguments are not allowed for this type
   --> $DIR/issue-97343.rs:4:23
    |
@@ -16,7 +8,6 @@ LL | pub struct Irrelevant<Irrelevant> {
    |
    = note: this error originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 
-Some errors have detailed explanations: E0109, E0574.
-For more information about an error, try `rustc --explain E0109`.
+For more information about this error, try `rustc --explain E0109`.

--- a/src/test/ui/derives/issue-97343.stderr
+++ b/src/test/ui/derives/issue-97343.stderr
@@ -1,0 +1,22 @@
+error[E0574]: expected struct, variant or union type, found type parameter `Irrelevant`
+  --> $DIR/issue-97343.rs:3:10
+   |
+LL | #[derive(Debug)]
+   |          ^^^^^ not a struct, variant or union type
+   |
+   = note: this error originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0109]: type arguments are not allowed for this type
+  --> $DIR/issue-97343.rs:4:23
+   |
+LL | #[derive(Debug)]
+   |          ----- in this derive macro expansion
+LL | pub struct Irrelevant<Irrelevant> {
+   |                       ^^^^^^^^^^ type argument not allowed
+   |
+   = note: this error originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0109, E0574.
+For more information about an error, try `rustc --explain E0109`.


### PR DESCRIPTION
Reduce verbosity in #97343.