### PR TITLE
Fix `x dist --stage 1 src/tools/rust-analyzer`

### DIFF
--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -879,6 +879,9 @@ impl Step for PlainSourceTarball {
 
         // If we're building from git sources, we need to vendor a complete distribution.
         if builder.rust_info.is_git() {
+            // Ensure we have the submodules checked out.
+            builder.update_submodule(Path::new("src/tools/rust-analyzer"));
+
             // Vendor all Cargo dependencies
             let mut cmd = Command::new(&builder.initial_cargo);
             cmd.arg("vendor")


### PR DESCRIPTION
Previously, this would break because the submodule wasn't checked out.

Fixes https://github.com/rust-lang/rust/issues/97464.