### PR TITLE
Experiment: force debug_assertions in consteval context

### DIFF
--- a/library/core/src/char/convert.rs
+++ b/library/core/src/char/convert.rs
@@ -5,6 +5,7 @@ use crate::convert::TryFrom;
 use crate::fmt;
 use crate::mem::transmute;
 use crate::str::FromStr;
+use crate::use_debug_assertions::use_debug_assertions;
 
 /// Converts a `u32` to a `char`. See [`char::from_u32`].
 #[must_use]
@@ -23,7 +24,7 @@ pub(super) const fn from_u32(i: u32) -> Option<char> {
 #[must_use]
 pub(super) const unsafe fn from_u32_unchecked(i: u32) -> char {
     // SAFETY: the caller must guarantee that `i` is a valid char value.
-    if cfg!(debug_assertions) { char::from_u32(i).unwrap() } else { unsafe { transmute(i) } }
+    if use_debug_assertions!() { char::from_u32(i).unwrap() } else { unsafe { transmute(i) } }
 }
 
 #[stable(feature = "char_convert", since = "1.13.0")]

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -144,6 +144,7 @@
 #![feature(const_type_name)]
 #![feature(const_default_impls)]
 #![feature(const_unsafecell_get_mut)]
+#![feature(consteval_debug_assertions)]
 #![feature(core_panic)]
 #![feature(duration_consts_float)]
 #![feature(maybe_uninit_uninit_array)]
@@ -241,6 +242,15 @@ mod macros;
 pub mod assert_matches {
     #[unstable(feature = "assert_matches", issue = "82775")]
     pub use crate::macros::{assert_matches, debug_assert_matches};
+}
+
+// We don't export this through #[macro_export] for now, to avoid breakage.
+// See https://github.com/rust-lang/rust/issues/82913
+#[unstable(feature = "consteval_debug_assertions", issue = "none")]
+/// Unstable module containing the unstable `use_debug_assertions` macro.
+pub mod use_debug_assertions {
+    #[unstable(feature = "consteval_debug_assertions", issue = "none")]
+    pub use crate::macros::use_debug_assertions;
 }
 
 #[macro_use]


### PR DESCRIPTION
This is probably very cursed, but, I saw this as a potential avenue to problems like #95332 and decided to just try and implement it since it felt comically simple.

A lot of unsafe code uses debug assertions to verify safety constraints in debug mode, even though they're removed in release mode. Since compile time is expected to be longer in release mode anyway due to optimisations… why not enable these assertions when doing consteval, since we're expecting compile times to be longer anyway, if it means that we'll catch more problems? While a fully featured UB check is helpful, it's way easier to just use all of the checks we already use to make sure unsafe code is working correctly.

Of course, I have no idea how well this will work, or if it will cause a serious dip in performance, but the code is so small I figured I'd open a PR anyway and see what people think about this idea.

I did try testing and noticed a few UI tests that explicitly try to look for the UB-checker behaviour and try to disable the debug-assert behaviour, and I'm not sure how to deal with these. But other than that, it *looks* like everything works with this turned on.

----

Note: I think that a full implementation of this would involve modifying conditional compilation in constants to make `cfg!(debug_assertions)` actually just return true always in consteval, but that's way more complicated since it would mean actually compiling things twice for consteval. Plus, even if we technically modify the `cfg!` macro, it will leave `#[cfg]` unchanged.

This is basically a hack to just apply this to `debug_assert!` for now, and we can figure out the finer details later.

----

Okay, I'm genuinely unsure how tests managed to pass for this when `./x.py test --stage 1` failed locally. But 🤷🏻, cool.