### PR TITLE
Make some tests check-pass

### DIFF
--- a/src/test/ui/lint/lint-unknown-feature-default.rs
+++ b/src/test/ui/lint/lint-unknown-feature-default.rs
@@ -1,10 +1,9 @@
+// check-pass
+
 // Tests the default for the unused_features lint
 
 #![allow(stable_features)]
 // FIXME(#44232) we should warn that this isn't used.
 #![feature(rust1)]
 
-// build-pass (FIXME(62277): could be check-pass?)
-
-
-fn main() { }
+fn main() {}

--- a/src/test/ui/lint/lint-unknown-feature.rs
+++ b/src/test/ui/lint/lint-unknown-feature.rs
@@ -1,10 +1,9 @@
+// check-pass
+
 #![warn(unused_features)]
 
 #![allow(stable_features)]
 // FIXME(#44232) we should warn that this isn't used.
 #![feature(rust1)]
-
-// build-pass (FIXME(62277): could be check-pass?)
-
 
 fn main() {}

--- a/src/test/ui/parser/bounds-obj-parens.rs
+++ b/src/test/ui/parser/bounds-obj-parens.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 #![allow(bare_trait_objects)]
 

--- a/src/test/ui/parser/impl-qpath.rs
+++ b/src/test/ui/parser/impl-qpath.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 // compile-flags: -Z parse-only
 
 impl <*const u8>::AssocTy {} // OK

--- a/src/test/ui/parser/trailing-plus-in-bounds.rs
+++ b/src/test/ui/parser/trailing-plus-in-bounds.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 #![allow(bare_trait_objects)]
 

--- a/src/test/ui/parser/trait-plusequal-splitting.rs
+++ b/src/test/ui/parser/trait-plusequal-splitting.rs
@@ -1,6 +1,6 @@
 // Fixes issue where `+` in generics weren't parsed if they were part of a `+=`.
 
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 
 struct Whitespace<T: Clone + = ()> { t: T }
 struct TokenSplit<T: Clone +=  ()> { t: T }

--- a/src/test/ui/underscore-imports/duplicate.rs
+++ b/src/test/ui/underscore-imports/duplicate.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 // aux-build:duplicate.rs
 
 extern crate duplicate;

--- a/src/test/ui/underscore-imports/intercrate.rs
+++ b/src/test/ui/underscore-imports/intercrate.rs
@@ -1,4 +1,4 @@
-// build-pass (FIXME(62277): could be check-pass?)
+// check-pass
 // aux-build:underscore-imports.rs
 
 extern crate underscore_imports;


### PR DESCRIPTION
This touches the tests related to lint, parser, and importing, all of them should be fine with `check-pass`.
r? @compiler-errors 