### PR TITLE
improve format impl for literals

### DIFF
--- a/library/alloc/src/fmt.rs
+++ b/library/alloc/src/fmt.rs
@@ -606,13 +606,12 @@ use crate::string;
 #[stable(feature = "rust1", since = "1.0.0")]
 #[inline]
 pub fn format(args: Arguments<'_>) -> string::String {
-    #[cold]
-    fn format_cold(args: Arguments<'_>) -> string::String {
+    fn format_inner(args: Arguments<'_>) -> string::String {
         let capacity = args.estimated_capacity();
         let mut output = string::String::with_capacity(capacity);
         output.write_fmt(args).expect("a formatting trait implementation returned an error");
         output
     }
 
-    args.as_str().map_or_else(|| format_cold(args), crate::borrow::ToOwned::to_owned)
+    args.as_str().map_or_else(|| format_inner(args), crate::borrow::ToOwned::to_owned)
 }


### PR DESCRIPTION
The basic idea of this change can be seen here https://godbolt.org/z/MT37cWoe1.

Updates the format impl to have a fast path for string literals and the default path for regular format args.

This change will allow `format!("string literal")` to be used interchangably with `"string literal".to_owned()`. 

This would be relevant in the case of `f!"string literal"` being legal (https://github.com/rust-lang/rfcs/pull/3267) in which case it would be the easiest way to create owned strings from literals, while also being just as efficient as any other impl 