### PR TITLE
Add sentence in case JS is disabled on settings.html page

### DIFF
--- a/src/librustdoc/html/render/context.rs
+++ b/src/librustdoc/html/render/context.rs
@@ -609,6 +609,11 @@ impl<'tcx> FormatRenderer<'tcx> for Context<'tcx> {
                         </a>\
                      </span>\
                      </div>\
+                     <noscript>\
+                        <section>\
+                            You need to enable Javascript be able to update your settings.\
+                        </section>\
+                     </noscript>\
                      <link rel=\"stylesheet\" type=\"text/css\" \
                          href=\"{root_path}settings{suffix}.css\">\
                      <script defer src=\"{root_path}settings{suffix}.js\"></script>",

--- a/src/test/rustdoc-gui/settings.goml
+++ b/src/test/rustdoc-gui/settings.goml
@@ -65,3 +65,9 @@ assert-local-storage: {"rustdoc-disable-shortcuts": "true"}
 goto: file://|DOC_PATH|/settings.html
 wait-for: "#settings"
 assert-css: (".setting-line .toggle .slider", {"width": "45px", "margin-right": "20px"})
+
+// We now check the display with JS disabled.
+assert-false: "noscript section"
+javascript: false
+reload:
+assert-css: ("noscript section", {"display": "block"})


### PR DESCRIPTION
Instead of having an empty page, it'll look like this:

![Screenshot from 2022-05-28 17-46-23](https://user-images.githubusercontent.com/3050060/170833333-e1a59c2b-27ca-47da-9c08-2356e4a689cb.png)

r? @notriddle 