### PR TITLE
Add E0788 for improper #[no_coverage] usage

### DIFF
--- a/compiler/rustc_error_codes/src/error_codes.rs
+++ b/compiler/rustc_error_codes/src/error_codes.rs
@@ -491,6 +491,7 @@ E0784: include_str!("./error_codes/E0784.md"),
 E0785: include_str!("./error_codes/E0785.md"),
 E0786: include_str!("./error_codes/E0786.md"),
 E0787: include_str!("./error_codes/E0787.md"),
+E0788: include_str!("./error_codes/E0788.md"),
 ;
 //  E0006, // merged with E0005
 //  E0008, // cannot bind by-move into a pattern guard

--- a/compiler/rustc_error_codes/src/error_codes/E0788.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0788.md
@@ -1,0 +1,21 @@
+A `#[no_coverage]` attribute was incorrectly placed on something that couldn't
+be covered.
+
+Example of erroneous code:
+
+```compile_fail,E0788
+#[no_coverage]
+struct Foo;
+
+#[no_coverage]
+const FOO: Foo = Foo;
+```
+
+`#[no_coverage]` tells the compiler to not generate coverage instrumentation for
+a piece of code when the `-C instrument-coverage` flag is passed. Things like
+structs and consts are not coverable code, and thus cannot do anything with this
+attribute.
+
+If you wish to apply this attribute to all methods in an impl or module,
+manually annotate each method; it is not possible to annotate the entire impl
+with a `#[no_coverage]` attribute.

--- a/compiler/rustc_error_codes/src/error_codes/E0788.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0788.md
@@ -1,5 +1,10 @@
-A `#[no_coverage]` attribute was incorrectly placed on something that couldn't
-be covered.
+A `#[no_coverage]` attribute was applied to something which does not show up
+in code coverage, or is too granular to be excluded from the coverage report.
+
+For now, this attribute can only be applied to function, method, and closure
+definitions. In the future, it may be added to statements, blocks, and
+expressions, and for the time being, using this attribute in those places
+will just emit an `unused_attributes` lint instead of this error.
 
 Example of erroneous code:
 

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -76,6 +76,7 @@ impl CheckAttrVisitor<'_> {
         for attr in attrs {
             let attr_is_valid = match attr.name_or_empty() {
                 sym::inline => self.check_inline(hir_id, attr, span, target),
+                sym::no_coverage => self.check_no_coverage(hir_id, attr, span, target),
                 sym::non_exhaustive => self.check_non_exhaustive(hir_id, attr, span, target),
                 sym::marker => self.check_marker(hir_id, attr, span, target),
                 sym::rustc_must_implement_one_of => {
@@ -286,6 +287,56 @@ impl CheckAttrVisitor<'_> {
                     "attribute should be applied to function or closure",
                 )
                 .span_label(span, "not a function or closure")
+                .emit();
+                false
+            }
+        }
+    }
+
+    /// Checks if a `#[no_coverage]` is applied directly to a function
+    fn check_no_coverage(
+        &self,
+        hir_id: HirId,
+        attr: &Attribute,
+        span: Span,
+        target: Target,
+    ) -> bool {
+        match target {
+            // no_coverage on function is fine
+            Target::Fn
+            | Target::Closure
+            | Target::Method(MethodKind::Trait { body: true } | MethodKind::Inherent) => true,
+
+            // function prototypes can't be covered
+            Target::Method(MethodKind::Trait { body: false }) | Target::ForeignFn => {
+                self.tcx.struct_span_lint_hir(UNUSED_ATTRIBUTES, hir_id, attr.span, |lint| {
+                    lint.build("`#[no_coverage]` is ignored on function prototypes").emit();
+                });
+                true
+            }
+
+            Target::Mod | Target::ForeignMod | Target::Impl | Target::Trait => {
+                self.tcx.struct_span_lint_hir(UNUSED_ATTRIBUTES, hir_id, attr.span, |lint| {
+                    lint.build("`#[no_coverage]` cannot be done recursively and must be applied to functions directly").emit();
+                });
+                true
+            }
+
+            Target::Expression | Target::Statement | Target::Arm => {
+                self.tcx.struct_span_lint_hir(UNUSED_ATTRIBUTES, hir_id, attr.span, |lint| {
+                    lint.build("`#[no_coverage]` can only be applied at the function level, not on code directly").emit();
+                });
+                true
+            }
+
+            _ => {
+                struct_span_err!(
+                    self.tcx.sess,
+                    attr.span,
+                    E0788,
+                    "`#[no_coverage]` must be applied to coverable code",
+                )
+                .span_label(span, "not coverable code")
                 .emit();
                 false
             }

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -317,14 +317,15 @@ impl CheckAttrVisitor<'_> {
 
             Target::Mod | Target::ForeignMod | Target::Impl | Target::Trait => {
                 self.tcx.struct_span_lint_hir(UNUSED_ATTRIBUTES, hir_id, attr.span, |lint| {
-                    lint.build("`#[no_coverage]` cannot be done recursively and must be applied to functions directly").emit();
+                    lint.build("`#[no_coverage]` does not propagate into items and must be applied to the contained functions directly").emit();
                 });
                 true
             }
 
             Target::Expression | Target::Statement | Target::Arm => {
                 self.tcx.struct_span_lint_hir(UNUSED_ATTRIBUTES, hir_id, attr.span, |lint| {
-                    lint.build("`#[no_coverage]` can only be applied at the function level, not on code directly").emit();
+                    lint.build("`#[no_coverage]` may only be applied to function definitions")
+                        .emit();
                 });
                 true
             }

--- a/src/test/ui/lint/no-coverage.rs
+++ b/src/test/ui/lint/no-coverage.rs
@@ -2,7 +2,11 @@
 #![feature(no_coverage)]
 #![feature(type_alias_impl_trait)]
 #![warn(unused_attributes)]
+#![no_coverage]
+//~^ WARN: `#[no_coverage]` does not propagate into items and must be applied to the contained functions directly
 
+#[no_coverage]
+//~^ WARN: `#[no_coverage]` does not propagate into items and must be applied to the contained functions directly
 trait Trait {
     #[no_coverage] //~ ERROR `#[no_coverage]` must be applied to coverable code
     const X: u32;
@@ -13,6 +17,8 @@ trait Trait {
     type U;
 }
 
+#[no_coverage]
+//~^ WARN: `#[no_coverage]` does not propagate into items and must be applied to the contained functions directly
 impl Trait for () {
     const X: u32 = 0;
 
@@ -33,14 +39,17 @@ extern "C" {
 
 #[no_coverage]
 fn main() {
-    #[no_coverage] //~ WARN `#[no_coverage]` can only be applied at the function level, not on code directly
+    #[no_coverage]
+    //~^ WARN `#[no_coverage]` may only be applied to function definitions
     let _ = ();
 
     match () {
-        #[no_coverage] //~ WARN `#[no_coverage]` can only be applied at the function level, not on code directly
+        #[no_coverage]
+        //~^ WARN `#[no_coverage]` may only be applied to function definitions
         () => (),
     }
 
-    #[no_coverage] //~ WARN `#[no_coverage]` can only be applied at the function level, not on code directly
+    #[no_coverage]
+    //~^ WARN `#[no_coverage]` may only be applied to function definitions
     return ();
 }

--- a/src/test/ui/lint/no-coverage.rs
+++ b/src/test/ui/lint/no-coverage.rs
@@ -1,0 +1,46 @@
+#![feature(extern_types)]
+#![feature(no_coverage)]
+#![feature(type_alias_impl_trait)]
+#![warn(unused_attributes)]
+
+trait Trait {
+    #[no_coverage] //~ ERROR `#[no_coverage]` must be applied to coverable code
+    const X: u32;
+
+    #[no_coverage] //~ ERROR `#[no_coverage]` must be applied to coverable code
+    type T;
+
+    type U;
+}
+
+impl Trait for () {
+    const X: u32 = 0;
+
+    #[no_coverage] //~ ERROR `#[no_coverage]` must be applied to coverable code
+    type T = Self;
+
+    #[no_coverage] //~ ERROR `#[no_coverage]` must be applied to coverable code
+    type U = impl Trait; //~ ERROR unconstrained opaque type
+}
+
+extern "C" {
+    #[no_coverage] //~ ERROR `#[no_coverage]` must be applied to coverable code
+    static X: u32;
+
+    #[no_coverage] //~ ERROR `#[no_coverage]` must be applied to coverable code
+    type T;
+}
+
+#[no_coverage]
+fn main() {
+    #[no_coverage] //~ WARN `#[no_coverage]` can only be applied at the function level, not on code directly
+    let _ = ();
+
+    match () {
+        #[no_coverage] //~ WARN `#[no_coverage]` can only be applied at the function level, not on code directly
+        () => (),
+    }
+
+    #[no_coverage] //~ WARN `#[no_coverage]` can only be applied at the function level, not on code directly
+    return ();
+}

--- a/src/test/ui/lint/no-coverage.stderr
+++ b/src/test/ui/lint/no-coverage.stderr
@@ -1,8 +1,8 @@
-warning: `#[no_coverage]` can only be applied at the function level, not on code directly
-  --> $DIR/no-coverage.rs:36:5
+warning: `#[no_coverage]` does not propagate into items and must be applied to the contained functions directly
+  --> $DIR/no-coverage.rs:8:1
    |
-LL |     #[no_coverage]
-   |     ^^^^^^^^^^^^^^
+LL | #[no_coverage]
+   | ^^^^^^^^^^^^^^
    |
 note: the lint level is defined here
   --> $DIR/no-coverage.rs:4:9
@@ -10,20 +10,32 @@ note: the lint level is defined here
 LL | #![warn(unused_attributes)]
    |         ^^^^^^^^^^^^^^^^^
 
-warning: `#[no_coverage]` can only be applied at the function level, not on code directly
-  --> $DIR/no-coverage.rs:40:9
+warning: `#[no_coverage]` does not propagate into items and must be applied to the contained functions directly
+  --> $DIR/no-coverage.rs:20:1
+   |
+LL | #[no_coverage]
+   | ^^^^^^^^^^^^^^
+
+warning: `#[no_coverage]` may only be applied to function definitions
+  --> $DIR/no-coverage.rs:42:5
+   |
+LL |     #[no_coverage]
+   |     ^^^^^^^^^^^^^^
+
+warning: `#[no_coverage]` may only be applied to function definitions
+  --> $DIR/no-coverage.rs:47:9
    |
 LL |         #[no_coverage]
    |         ^^^^^^^^^^^^^^
 
-warning: `#[no_coverage]` can only be applied at the function level, not on code directly
-  --> $DIR/no-coverage.rs:44:5
+warning: `#[no_coverage]` may only be applied to function definitions
+  --> $DIR/no-coverage.rs:52:5
    |
 LL |     #[no_coverage]
    |     ^^^^^^^^^^^^^^
 
 error[E0788]: `#[no_coverage]` must be applied to coverable code
-  --> $DIR/no-coverage.rs:7:5
+  --> $DIR/no-coverage.rs:11:5
    |
 LL |     #[no_coverage]
    |     ^^^^^^^^^^^^^^
@@ -31,7 +43,7 @@ LL |     const X: u32;
    |     ------------- not coverable code
 
 error[E0788]: `#[no_coverage]` must be applied to coverable code
-  --> $DIR/no-coverage.rs:10:5
+  --> $DIR/no-coverage.rs:14:5
    |
 LL |     #[no_coverage]
    |     ^^^^^^^^^^^^^^
@@ -39,7 +51,7 @@ LL |     type T;
    |     ------- not coverable code
 
 error[E0788]: `#[no_coverage]` must be applied to coverable code
-  --> $DIR/no-coverage.rs:19:5
+  --> $DIR/no-coverage.rs:25:5
    |
 LL |     #[no_coverage]
    |     ^^^^^^^^^^^^^^
@@ -47,7 +59,7 @@ LL |     type T = Self;
    |     -------------- not coverable code
 
 error[E0788]: `#[no_coverage]` must be applied to coverable code
-  --> $DIR/no-coverage.rs:22:5
+  --> $DIR/no-coverage.rs:28:5
    |
 LL |     #[no_coverage]
    |     ^^^^^^^^^^^^^^
@@ -55,7 +67,7 @@ LL |     type U = impl Trait;
    |     -------------------- not coverable code
 
 error[E0788]: `#[no_coverage]` must be applied to coverable code
-  --> $DIR/no-coverage.rs:27:5
+  --> $DIR/no-coverage.rs:33:5
    |
 LL |     #[no_coverage]
    |     ^^^^^^^^^^^^^^
@@ -63,21 +75,27 @@ LL |     static X: u32;
    |     -------------- not coverable code
 
 error[E0788]: `#[no_coverage]` must be applied to coverable code
-  --> $DIR/no-coverage.rs:30:5
+  --> $DIR/no-coverage.rs:36:5
    |
 LL |     #[no_coverage]
    |     ^^^^^^^^^^^^^^
 LL |     type T;
    |     ------- not coverable code
 
+warning: `#[no_coverage]` does not propagate into items and must be applied to the contained functions directly
+  --> $DIR/no-coverage.rs:5:1
+   |
+LL | #![no_coverage]
+   | ^^^^^^^^^^^^^^^
+
 error: unconstrained opaque type
-  --> $DIR/no-coverage.rs:23:14
+  --> $DIR/no-coverage.rs:29:14
    |
 LL |     type U = impl Trait;
    |              ^^^^^^^^^^
    |
    = note: `U` must be used in combination with a concrete type within the same module
 
-error: aborting due to 7 previous errors; 3 warnings emitted
+error: aborting due to 7 previous errors; 6 warnings emitted
 
 For more information about this error, try `rustc --explain E0788`.

--- a/src/test/ui/lint/no-coverage.stderr
+++ b/src/test/ui/lint/no-coverage.stderr
@@ -1,0 +1,83 @@
+warning: `#[no_coverage]` can only be applied at the function level, not on code directly
+  --> $DIR/no-coverage.rs:36:5
+   |
+LL |     #[no_coverage]
+   |     ^^^^^^^^^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/no-coverage.rs:4:9
+   |
+LL | #![warn(unused_attributes)]
+   |         ^^^^^^^^^^^^^^^^^
+
+warning: `#[no_coverage]` can only be applied at the function level, not on code directly
+  --> $DIR/no-coverage.rs:40:9
+   |
+LL |         #[no_coverage]
+   |         ^^^^^^^^^^^^^^
+
+warning: `#[no_coverage]` can only be applied at the function level, not on code directly
+  --> $DIR/no-coverage.rs:44:5
+   |
+LL |     #[no_coverage]
+   |     ^^^^^^^^^^^^^^
+
+error[E0788]: `#[no_coverage]` must be applied to coverable code
+  --> $DIR/no-coverage.rs:7:5
+   |
+LL |     #[no_coverage]
+   |     ^^^^^^^^^^^^^^
+LL |     const X: u32;
+   |     ------------- not coverable code
+
+error[E0788]: `#[no_coverage]` must be applied to coverable code
+  --> $DIR/no-coverage.rs:10:5
+   |
+LL |     #[no_coverage]
+   |     ^^^^^^^^^^^^^^
+LL |     type T;
+   |     ------- not coverable code
+
+error[E0788]: `#[no_coverage]` must be applied to coverable code
+  --> $DIR/no-coverage.rs:19:5
+   |
+LL |     #[no_coverage]
+   |     ^^^^^^^^^^^^^^
+LL |     type T = Self;
+   |     -------------- not coverable code
+
+error[E0788]: `#[no_coverage]` must be applied to coverable code
+  --> $DIR/no-coverage.rs:22:5
+   |
+LL |     #[no_coverage]
+   |     ^^^^^^^^^^^^^^
+LL |     type U = impl Trait;
+   |     -------------------- not coverable code
+
+error[E0788]: `#[no_coverage]` must be applied to coverable code
+  --> $DIR/no-coverage.rs:27:5
+   |
+LL |     #[no_coverage]
+   |     ^^^^^^^^^^^^^^
+LL |     static X: u32;
+   |     -------------- not coverable code
+
+error[E0788]: `#[no_coverage]` must be applied to coverable code
+  --> $DIR/no-coverage.rs:30:5
+   |
+LL |     #[no_coverage]
+   |     ^^^^^^^^^^^^^^
+LL |     type T;
+   |     ------- not coverable code
+
+error: unconstrained opaque type
+  --> $DIR/no-coverage.rs:23:14
+   |
+LL |     type U = impl Trait;
+   |              ^^^^^^^^^^
+   |
+   = note: `U` must be used in combination with a concrete type within the same module
+
+error: aborting due to 7 previous errors; 3 warnings emitted
+
+For more information about this error, try `rustc --explain E0788`.


### PR DESCRIPTION
Essentially, this adds proper checking for the attribute (tracking issue #84605) and throws errors when it's put in obviously-wrong places, like on struct or const definitions. Most of the code is taken directly from the checks for the `#[inline]` attribute, since it's very similar.

Right now, the code only checks at the function level, but it seems reasonable to allow adding `#[no_coverage]` to individual blocks or expressions, so, for now those just throw `unused_attributes` warnings. Similarly, since there was a lot of desire to eventually allow recursive definitions as well on modules and impl blocks, these also throw `unused_attributes` instead of an error.

I'm not sure if anything has to be done since this error is technically for an unstable feature, but since an error for using unstable features will show up anyway, I think it's okay.

This is the first big piece needed for stabilising this attribute, although I personally would like to explore renaming it to `#[coverage(never)]` on a separate PR, which I will offer soon. There's a lot of discussion still to be had about that, which is why it will be kept separate.

I don't think much is needed besides adding this simple check and a UI test, but let me know if there's something else that should be added to make this happen.