### PR TITLE
Remove "sys isn't exported yet" phrase

### DIFF
--- a/library/std/src/sys/unix/locks/pthread_mutex.rs
+++ b/library/std/src/sys/unix/locks/pthread_mutex.rs
@@ -16,7 +16,6 @@ pub unsafe fn raw(m: &Mutex) -> *mut libc::pthread_mutex_t {
 unsafe impl Send for Mutex {}
 unsafe impl Sync for Mutex {}
 
-#[allow(dead_code)] // sys isn't exported yet
 impl Mutex {
     pub const fn new() -> Mutex {
         // Might be moved to a different address, so it is better to avoid

--- a/library/std/src/sys_common/thread_local_dtor.rs
+++ b/library/std/src/sys_common/thread_local_dtor.rs
@@ -11,7 +11,7 @@
 //! or implement something more efficient.
 
 #![unstable(feature = "thread_local_internals", issue = "none")]
-#![allow(dead_code)] // sys isn't exported yet
+#![allow(dead_code)]
 
 use crate::ptr;
 use crate::sys_common::thread_local_key::StaticKey;

--- a/library/std/src/sys_common/thread_local_key.rs
+++ b/library/std/src/sys_common/thread_local_key.rs
@@ -46,7 +46,7 @@
 
 #![allow(non_camel_case_types)]
 #![unstable(feature = "thread_local_internals", issue = "none")]
-#![allow(dead_code)] // sys isn't exported yet
+#![allow(dead_code)]
 
 #[cfg(test)]
 mod tests;


### PR DESCRIPTION
The oldest occurence is from 9e224c2bf18ebf8f871efb2e1aba43ed7970ebb7,
which is from the pre-1.0 days. In the years since then, std::sys still
hasn't been exported, and the last attempt was met with strong criticism:
https://github.com/rust-lang/rust/pull/97151

Thus, removing the "yet" part makes a lot of sense.