### PR TITLE
Ensure source file present when calculating max line number

### DIFF
--- a/compiler/rustc_errors/src/emitter.rs
+++ b/compiler/rustc_errors/src/emitter.rs
@@ -1261,16 +1261,23 @@ impl EmitterWriter {
             return 0;
         };
 
+        let will_be_emitted = |span: Span| {
+            !span.is_dummy() && {
+                let file = sm.lookup_source_file(span.hi());
+                sm.ensure_source_file_source_present(file)
+            }
+        };
+
         let mut max = 0;
         for primary_span in msp.primary_spans() {
-            if !primary_span.is_dummy() {
+            if will_be_emitted(*primary_span) {
                 let hi = sm.lookup_char_pos(primary_span.hi());
                 max = (hi.line).max(max);
             }
         }
         if !self.short_message {
             for span_label in msp.span_labels() {
-                if !span_label.span.is_dummy() {
+                if will_be_emitted(span_label.span) {
                     let hi = sm.lookup_char_pos(span_label.span.hi());
                     max = (hi.line).max(max);
                 }

--- a/src/test/ui/span/issue-71363.rs
+++ b/src/test/ui/span/issue-71363.rs
@@ -1,0 +1,10 @@
+// compile-flags: -Z simulate-remapped-rust-src-base=/rustc/xyz -Z ui-testing=no
+// only-x86_64-unknown-linux-gnu
+//---^ Limiting target as the above unstable flags don't play well on some environment.
+
+struct MyError;
+impl std::error::Error for MyError {}
+//~^ ERROR: `MyError` doesn't implement `std::fmt::Display`
+//~| ERROR: `MyError` doesn't implement `Debug`
+
+fn main() {}

--- a/src/test/ui/span/issue-71363.stderr
+++ b/src/test/ui/span/issue-71363.stderr
@@ -1,0 +1,27 @@
+error[E0277]: `MyError` doesn't implement `std::fmt::Display`
+ --> $DIR/issue-71363.rs:6:6
+  |
+6 | impl std::error::Error for MyError {}
+  |      ^^^^^^^^^^^^^^^^^ `MyError` cannot be formatted with the default formatter
+  |
+  = help: the trait `std::fmt::Display` is not implemented for `MyError`
+  = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
+note: required by a bound in `std::error::Error`
+
+error[E0277]: `MyError` doesn't implement `Debug`
+ --> $DIR/issue-71363.rs:6:6
+  |
+6 | impl std::error::Error for MyError {}
+  |      ^^^^^^^^^^^^^^^^^ `MyError` cannot be formatted using `{:?}`
+  |
+  = help: the trait `Debug` is not implemented for `MyError`
+  = note: add `#[derive(Debug)]` to `MyError` or manually `impl Debug for MyError`
+note: required by a bound in `std::error::Error`
+help: consider annotating `MyError` with `#[derive(Debug)]`
+  |
+5 | #[derive(Debug)]
+  |
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
Resubmission of #89268, fixes #71363
The behavior difference of `simulate-remapped-rust-src-base` is not something we should take into account here, so limiting targets to run the test makes sense, I think.

r? @davidtwco, and @estebank, you might be interested in this change