### PR TITLE
Fix typo (panick -> panic)

### DIFF
--- a/library/std/src/error.rs
+++ b/library/std/src/error.rs
@@ -52,7 +52,7 @@
 //! to convey your intent and assumptions which makes tracking down the source
 //! of a panic easier. `unwrap` on the other hand can still be a good fit in
 //! situations where you can trivially show that a piece of code will never
-//! panick, such as `"127.0.0.1".parse::<std::net::IpAddr>().unwrap()` or early
+//! panic, such as `"127.0.0.1".parse::<std::net::IpAddr>().unwrap()` or early
 //! prototyping.
 //!
 //! # Common Message Styles


### PR DESCRIPTION
Fix typo (panick -> panic) in `std::error` module docs.