### PR TITLE
Re-add help_on_error for download-ci-llvm

### DIFF
--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -63,7 +63,7 @@ def support_xz():
     except tarfile.CompressionError:
         return False
 
-def get(base, url, path, checksums, verbose=False, do_verify=True, help_on_error=None):
+def get(base, url, path, checksums, verbose=False, do_verify=True):
     with tempfile.NamedTemporaryFile(delete=False) as temp_file:
         temp_path = temp_file.name
 
@@ -86,7 +86,7 @@ def get(base, url, path, checksums, verbose=False, do_verify=True, help_on_error
                         print("ignoring already-download file",
                             path, "due to failed verification")
                     os.unlink(path)
-        download(temp_path, "{}/{}".format(base, url), True, verbose, help_on_error=help_on_error)
+        download(temp_path, "{}/{}".format(base, url), True, verbose)
         if do_verify and not verify(temp_path, sha256, verbose):
             raise RuntimeError("failed verification")
         if verbose:
@@ -99,17 +99,17 @@ def get(base, url, path, checksums, verbose=False, do_verify=True, help_on_error
             os.unlink(temp_path)
 
 
-def download(path, url, probably_big, verbose, help_on_error=None):
+def download(path, url, probably_big, verbose):
     for _ in range(0, 4):
         try:
-            _download(path, url, probably_big, verbose, True, help_on_error=help_on_error)
+            _download(path, url, probably_big, verbose, True)
             return
         except RuntimeError:
             print("\nspurious failure, trying again")
-    _download(path, url, probably_big, verbose, False, help_on_error=help_on_error)
+    _download(path, url, probably_big, verbose, False)
 
 
-def _download(path, url, probably_big, verbose, exception, help_on_error=None):
+def _download(path, url, probably_big, verbose, exception):
     # Try to use curl (potentially available on win32
     #    https://devblogs.microsoft.com/commandline/tar-and-curl-come-to-windows/)
     # If an error occurs:
@@ -134,7 +134,7 @@ def _download(path, url, probably_big, verbose, exception, help_on_error=None):
              "--retry", "3", "-Sf", "-o", path, url],
             verbose=verbose,
             exception=True, # Will raise RuntimeError on failure
-            help_on_error=help_on_error)
+        )
     except (subprocess.CalledProcessError, OSError, RuntimeError):
         # see http://serverfault.com/questions/301128/how-to-download
         if platform_is_win32:
@@ -186,7 +186,7 @@ def unpack(tarball, tarball_suffix, dst, verbose=False, match=None):
     shutil.rmtree(os.path.join(dst, fname))
 
 
-def run(args, verbose=False, exception=False, is_bootstrap=False, help_on_error=None, **kwargs):
+def run(args, verbose=False, exception=False, is_bootstrap=False, **kwargs):
     """Run a child program in a new process"""
     if verbose:
         print("running: " + ' '.join(args))
@@ -197,8 +197,6 @@ def run(args, verbose=False, exception=False, is_bootstrap=False, help_on_error=
     code = ret.wait()
     if code != 0:
         err = "failed to run: " + ' '.join(args)
-        if help_on_error is not None:
-            err += "\n" + help_on_error
         if verbose or exception:
             raise RuntimeError(err)
         # For most failures, we definitely do want to print this error, or the user will have no

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -1491,7 +1491,7 @@ fn download_component(builder: &Builder<'_>, filename: String, prefix: &str, com
     let url = format!("rustc-builds/{commit}");
     let tarball = rustc_cache.join(&filename);
     if !tarball.exists() {
-        builder.download_component(base, &format!("{url}/{filename}"), &tarball);
+        builder.download_component(base, &format!("{url}/{filename}"), &tarball, "");
     }
     let bin_root = builder.out.join(builder.config.build.triple).join("ci-rustc");
     builder.unpack(&tarball, &bin_root, prefix)

--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -179,7 +179,15 @@ fn download_ci_llvm(builder: &Builder<'_>, llvm_sha: &str) {
     let filename = format!("rust-dev-nightly-{}.tar.xz", builder.build.build.triple);
     let tarball = rustc_cache.join(&filename);
     if !tarball.exists() {
-        builder.download_component(base, &format!("{}/{}", url, filename), &tarball);
+        let help_on_error = "error: failed to download llvm from ci\n
+\nhelp: old builds get deleted after a certain time
+\nhelp: if trying to compile an old commit of rustc, disable `download-ci-llvm` in config.toml:
+\n
+\n[llvm]
+\ndownload-ci-llvm = false
+\n
+";
+        builder.download_component(base, &format!("{}/{}", url, filename), &tarball, help_on_error);
     }
     let llvm_root = builder.config.ci_llvm_root();
     builder.unpack(&tarball, &llvm_root, "rust-dev");


### PR DESCRIPTION
Closes #97503 

- Re-added `help_on_error` for `download_component()` and the downstream functions
- Removed dead code in `bootstrap.py`

Thanks @jyn514 for the helpful tips!

(first contribution here, please let me know if I missed anything out!)