### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/compiler/rustc_typeck/src/check/intrinsicck.rs
+++ b/compiler/rustc_typeck/src/check/intrinsicck.rs
@@ -9,6 +9,7 @@ use rustc_session::lint;
 use rustc_span::{Span, Symbol, DUMMY_SP};
 use rustc_target::abi::{Pointer, VariantIdx};
 use rustc_target::asm::{InlineAsmReg, InlineAsmRegClass, InlineAsmRegOrRegClass, InlineAsmType};
+use rustc_trait_selection::infer::InferCtxtExt;
 
 use super::FnCtxt;
 
@@ -210,7 +211,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         // Check that the type implements Copy. The only case where this can
         // possibly fail is for SIMD types which don't #[derive(Copy)].
-        if !ty.is_copy_modulo_regions(self.tcx.at(DUMMY_SP), self.param_env) {
+        if !self.infcx.type_is_copy_modulo_regions(self.param_env, ty, DUMMY_SP) {
             let msg = "arguments for inline assembly must be copyable";
             let mut err = self.tcx.sess.struct_span_err(expr.span, msg);
             err.note(&format!("`{ty}` does not implement the Copy trait"));

--- a/library/std/src/error.rs
+++ b/library/std/src/error.rs
@@ -52,7 +52,7 @@
 //! to convey your intent and assumptions which makes tracking down the source
 //! of a panic easier. `unwrap` on the other hand can still be a good fit in
 //! situations where you can trivially show that a piece of code will never
-//! panick, such as `"127.0.0.1".parse::<std::net::IpAddr>().unwrap()` or early
+//! panic, such as `"127.0.0.1".parse::<std::net::IpAddr>().unwrap()` or early
 //! prototyping.
 //!
 //! # Common Message Styles

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -1764,7 +1764,7 @@ fn print_sidebar(cx: &Context<'_>, it: &clean::Item, buffer: &mut Buffer) {
             write!(buffer, "<li class=\"version\">Version {}</li>", Escape(version));
         }
         write!(buffer, "<li><a id=\"all-types\" href=\"all.html\">All Items</a></li>");
-        buffer.write_str("</div></ul>");
+        buffer.write_str("</ul></div>");
     }
 
     match *it.kind {

--- a/src/test/ui/asm/issue-97490.rs
+++ b/src/test/ui/asm/issue-97490.rs
@@ -1,0 +1,10 @@
+// check-pass
+
+pub type Yes = extern "sysv64" fn(&'static u8) -> !;
+
+fn main() {
+    unsafe {
+        let yes = &6 as *const _ as *const Yes;
+        core::arch::asm!("call {}", in(reg) yes, options(noreturn));
+    }
+}


### PR DESCRIPTION
Successful merges:

 - #97493 (Use `type_is_copy_modulo_regions` check in intrisicck)
 - #97514 (Fix typo (panick -> panic))
 - #97518 (Fix order of closing HTML elements in rustdoc output)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=97493,97514,97518)
<!-- homu-ignore:end -->