### PR TITLE
Build bootstrap tools in debug mode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,14 +97,27 @@ gimli.debug = 0
 miniz_oxide.debug = 0
 object.debug = 0
 
-# The only package that ever uses debug builds is bootstrap.
-# We care a lot about bootstrap's compile times, so don't include debug info for
-# dependencies, only bootstrap itself.
+# The only packages that ever use debug builds are bootstrap tools.
+# We care a lot about bootstrap compile times, so don't include debug info for
+# dependencies, only the tools themselves.
 [profile.dev]
 debug = 0
 [profile.dev.package]
 # Only use debuginfo=1 to further reduce compile times.
 bootstrap.debug = 1
+tidy.debug = 1
+rustbook.debug = 1
+unstable-book-gen.debug = 1
+cargotest2.debug = 1
+build-manifest.debug = 1
+remote-test-client.debug = 1
+installer.debug = 1
+rustdoc-themes.debug = 1
+expand-yaml-anchors.debug = 1
+lint-docs.debug = 1
+jsondocck.debug = 1
+html-checker.debug = 1
+bump-stage0.debug = 1
 
 # We want the RLS to use the version of Cargo that we've got vendored in this
 # repository to ensure that the same exact version of Cargo is used by both the

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -1728,7 +1728,8 @@ impl<'a> Builder<'a> {
             }
         }
 
-        if self.config.rust_optimize {
+        // Most bootstrap tools are fast to run. Compile them in debug mode to speed up compile times.
+        if self.config.rust_optimize && mode != Mode::ToolBootstrap {
             // FIXME: cargo bench/install do not accept `--release`
             if cmd != "bench" && cmd != "install" {
                 cargo.arg("--release");

--- a/src/bootstrap/dist.rs
+++ b/src/bootstrap/dist.rs
@@ -670,7 +670,7 @@ impl Step for Analysis {
         let src = builder
             .stage_out(compiler, Mode::Std)
             .join(target.triple)
-            .join(builder.cargo_dir())
+            .join(builder.cargo_dir(Mode::Std))
             .join("deps")
             .join("save-analysis");
 

--- a/src/bootstrap/lib.rs
+++ b/src/bootstrap/lib.rs
@@ -762,8 +762,8 @@ impl Build {
 
     /// Component directory that Cargo will produce output into (e.g.
     /// release/debug)
-    fn cargo_dir(&self) -> &'static str {
-        if self.config.rust_optimize { "release" } else { "debug" }
+    fn cargo_dir(&self, mode: Mode) -> &'static str {
+        if self.config.rust_optimize && mode != Mode::ToolBootstrap { "release" } else { "debug" }
     }
 
     fn tools_dir(&self, compiler: Compiler) -> PathBuf {
@@ -794,7 +794,7 @@ impl Build {
     /// running a particular compiler, whether or not we're building the
     /// standard library, and targeting the specified architecture.
     fn cargo_out(&self, compiler: Compiler, mode: Mode, target: TargetSelection) -> PathBuf {
-        self.stage_out(compiler, mode).join(&*target.triple).join(self.cargo_dir())
+        self.stage_out(compiler, mode).join(&*target.triple).join(self.cargo_dir(mode))
     }
 
     /// Root output directory for LLVM compiled for `target`
@@ -1425,7 +1425,7 @@ impl Build {
             return;
         }
         let _ = fs::remove_file(&dst);
-        let metadata = t!(src.symlink_metadata());
+        let metadata = t!(src.symlink_metadata(), src.display());
         if metadata.file_type().is_symlink() {
             let link = t!(fs::read_link(src));
             t!(symlink_file(link, dst));

--- a/src/bootstrap/test.rs
+++ b/src/bootstrap/test.rs
@@ -666,7 +666,7 @@ impl Step for Clippy {
 
         cargo.env("RUSTC_TEST_SUITE", builder.rustc(compiler));
         cargo.env("RUSTC_LIB_PATH", builder.rustc_libdir(compiler));
-        let host_libs = builder.stage_out(compiler, Mode::ToolRustc).join(builder.cargo_dir());
+        let host_libs = builder.stage_out(compiler, Mode::ToolRustc).join(builder.cargo_dir(Mode::ToolRustc));
         cargo.env("HOST_LIBS", host_libs);
 
         cargo.arg("--").args(builder.config.cmd.test_args());


### PR DESCRIPTION
There are a few motivations for this.
- The original reason is that I modified tidy and was annoyed the backtrace had no line numbers
- Bootstrap tools are usually quite fast to run and benefit more from the decreased compile time
- This makes the rest of the tools consistent with bootstrap itself, which is already built in debug mode

Before:
```
Building stage0 tool tidy (x86_64-unknown-linux-gnu(x86_64-unknown-linux-gnu))
    Finished release [optimized] target(s) in 21.13s
```

After:
```
Building stage0 tool tidy (x86_64-unknown-linux-gnu(x86_64-unknown-linux-gnu))
    Finished dev [unoptimized] target(s) in 13.36s
```

Timings were collected by running `rm -r build/x86_64-unknown-linux-gnu/stage0-bootstrap-tools build/x86_64-unknown-linux-gnu/stage0-tools-bin && x build tidy`.
The laptop I ran them on is fairly noisy, but nearly halving the time seems like a pretty good indication that it isn't noise.