### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/compiler/rustc_expand/src/mbe/macro_rules.rs
+++ b/compiler/rustc_expand/src/mbe/macro_rules.rs
@@ -204,7 +204,7 @@ fn trace_macros_note(cx_expansions: &mut FxHashMap<Span, Vec<String>>, sp: Span,
 
 /// Expands the rules based macro defined by `lhses` and `rhses` for a given
 /// input `arg`.
-fn expand_macro<'cx, 'tt>(
+fn expand_macro<'cx>(
     cx: &'cx mut ExtCtxt<'_>,
     sp: Span,
     def_span: Span,
@@ -212,8 +212,8 @@ fn expand_macro<'cx, 'tt>(
     name: Ident,
     transparency: Transparency,
     arg: TokenStream,
-    lhses: &'tt [Vec<MatcherLoc>],
-    rhses: &'tt [mbe::TokenTree],
+    lhses: &[Vec<MatcherLoc>],
+    rhses: &[mbe::TokenTree],
 ) -> Box<dyn MacResult + 'cx> {
     let sess = &cx.sess.parse_sess;
     // Macros defined in the current crate have a real node id,

--- a/compiler/rustc_typeck/src/check/intrinsicck.rs
+++ b/compiler/rustc_typeck/src/check/intrinsicck.rs
@@ -9,6 +9,7 @@ use rustc_session::lint;
 use rustc_span::{Span, Symbol, DUMMY_SP};
 use rustc_target::abi::{Pointer, VariantIdx};
 use rustc_target::asm::{InlineAsmReg, InlineAsmRegClass, InlineAsmRegOrRegClass, InlineAsmType};
+use rustc_trait_selection::infer::InferCtxtExt;
 
 use super::FnCtxt;
 
@@ -210,7 +211,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         // Check that the type implements Copy. The only case where this can
         // possibly fail is for SIMD types which don't #[derive(Copy)].
-        if !ty.is_copy_modulo_regions(self.tcx.at(DUMMY_SP), self.param_env) {
+        if !self.infcx.type_is_copy_modulo_regions(self.param_env, ty, DUMMY_SP) {
             let msg = "arguments for inline assembly must be copyable";
             let mut err = self.tcx.sess.struct_span_err(expr.span, msg);
             err.note(&format!("`{ty}` does not implement the Copy trait"));

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -1764,7 +1764,7 @@ fn print_sidebar(cx: &Context<'_>, it: &clean::Item, buffer: &mut Buffer) {
             write!(buffer, "<li class=\"version\">Version {}</li>", Escape(version));
         }
         write!(buffer, "<li><a id=\"all-types\" href=\"all.html\">All Items</a></li>");
-        buffer.write_str("</div></ul>");
+        buffer.write_str("</ul></div>");
     }
 
     match *it.kind {

--- a/src/librustdoc/html/static/.eslintrc.js
+++ b/src/librustdoc/html/static/.eslintrc.js
@@ -65,5 +65,6 @@ module.exports = {
         "eqeqeq": "error",
         "no-const-assign": "error",
         "no-debugger": "error",
+        "no-dupe-args": "error",
     }
 };

--- a/src/librustdoc/html/static/.eslintrc.js
+++ b/src/librustdoc/html/static/.eslintrc.js
@@ -64,5 +64,6 @@ module.exports = {
         ],
         "eqeqeq": "error",
         "no-const-assign": "error",
+        "no-debugger": "error",
     }
 };

--- a/src/librustdoc/html/static/.eslintrc.js
+++ b/src/librustdoc/html/static/.eslintrc.js
@@ -67,5 +67,6 @@ module.exports = {
         "no-debugger": "error",
         "no-dupe-args": "error",
         "no-dupe-else-if": "error",
+        "no-dupe-keys": "error",
     }
 };

--- a/src/librustdoc/html/static/.eslintrc.js
+++ b/src/librustdoc/html/static/.eslintrc.js
@@ -68,5 +68,6 @@ module.exports = {
         "no-dupe-args": "error",
         "no-dupe-else-if": "error",
         "no-dupe-keys": "error",
+        "no-duplicate-case": "error",
     }
 };

--- a/src/librustdoc/html/static/.eslintrc.js
+++ b/src/librustdoc/html/static/.eslintrc.js
@@ -66,5 +66,6 @@ module.exports = {
         "no-const-assign": "error",
         "no-debugger": "error",
         "no-dupe-args": "error",
+        "no-dupe-else-if": "error",
     }
 };

--- a/src/librustdoc/html/static/.eslintrc.js
+++ b/src/librustdoc/html/static/.eslintrc.js
@@ -63,5 +63,6 @@ module.exports = {
             }
         ],
         "eqeqeq": "error",
+        "no-const-assign": "error",
     }
 };

--- a/src/librustdoc/html/static/.eslintrc.js
+++ b/src/librustdoc/html/static/.eslintrc.js
@@ -69,5 +69,6 @@ module.exports = {
         "no-dupe-else-if": "error",
         "no-dupe-keys": "error",
         "no-duplicate-case": "error",
+        "no-ex-assign": "error",
     }
 };

--- a/src/test/ui/asm/issue-97490.rs
+++ b/src/test/ui/asm/issue-97490.rs
@@ -1,0 +1,12 @@
+// check-pass
+// only-x86_64
+// needs-asm-support
+
+pub type Yes = extern "sysv64" fn(&'static u8) -> !;
+
+fn main() {
+    unsafe {
+        let yes = &6 as *const _ as *const Yes;
+        core::arch::asm!("call {}", in(reg) yes, options(noreturn));
+    }
+}


### PR DESCRIPTION
Successful merges:

 - #97493 (Use `type_is_copy_modulo_regions` check in intrisicck)
 - #97518 (Fix order of closing HTML elements in rustdoc output)
 - #97530 (Add more eslint checks)
 - #97536 (Remove unused lifetimes from expand_macro)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=97493,97518,97530,97536)
<!-- homu-ignore:end -->