### PR TITLE
Make `bridge::Buffer` generic again.

### DIFF
--- a/library/proc_macro/src/bridge/client.rs
+++ b/library/proc_macro/src/bridge/client.rs
@@ -374,7 +374,7 @@ pub struct Client<I, O> {
     // a wrapper `fn` pointer, once `const fn` can reference `static`s.
     pub(super) get_handle_counters: extern "C" fn() -> &'static HandleCounters,
 
-    pub(super) run: extern "C" fn(Bridge<'_>) -> Buffer,
+    pub(super) run: extern "C" fn(Bridge<'_>) -> Buffer<u8>,
 
     pub(super) _marker: PhantomData<fn(I) -> O>,
 }
@@ -392,7 +392,7 @@ impl<I, O> Clone for Client<I, O> {
 fn run_client<A: for<'a, 's> DecodeMut<'a, 's, ()>, R: Encode<()>>(
     mut bridge: Bridge<'_>,
     f: impl FnOnce(A) -> R,
-) -> Buffer {
+) -> Buffer<u8> {
     // The initial `cached_buffer` contains the input.
     let mut buf = bridge.cached_buffer.take();
 

--- a/library/proc_macro/src/bridge/mod.rs
+++ b/library/proc_macro/src/bridge/mod.rs
@@ -226,10 +226,10 @@ use rpc::{Decode, DecodeMut, Encode, Reader, Writer};
 pub struct Bridge<'a> {
     /// Reusable buffer (only `clear`-ed, never shrunk), primarily
     /// used for making requests, but also for passing input to client.
-    cached_buffer: Buffer,
+    cached_buffer: Buffer<u8>,
 
     /// Server-side function that the client uses to make requests.
-    dispatch: closure::Closure<'a, Buffer, Buffer>,
+    dispatch: closure::Closure<'a, Buffer<u8>, Buffer<u8>>,
 
     /// If 'true', always invoke the default panic hook
     force_show_panics: bool,

--- a/library/proc_macro/src/bridge/rpc.rs
+++ b/library/proc_macro/src/bridge/rpc.rs
@@ -7,7 +7,7 @@ use std::num::NonZeroU32;
 use std::ops::Bound;
 use std::str;
 
-pub(super) type Writer = super::buffer::Buffer;
+pub(super) type Writer = super::buffer::Buffer<u8>;
 
 pub(super) trait Encode<S>: Sized {
     fn encode(self, w: &mut Writer, s: &mut S);


### PR DESCRIPTION
It was made non-generic in #97004, but that (surprisingly) caused a mild
performance regression.

r? @eddyb 