### PR TITLE
Reword safety comments in core/hash/sip.rs

### DIFF
--- a/library/core/src/hash/sip.rs
+++ b/library/core/src/hash/sip.rs
@@ -96,7 +96,8 @@ macro_rules! compress {
 /// `copy_nonoverlapping` to let the compiler generate the most efficient way
 /// to load it from a possibly unaligned address.
 ///
-/// Unsafe because: unchecked indexing at i..i+size_of(int_ty)
+/// Safety: this performs unchecked indexing of `$buf` at
+/// `$i..$i+size_of::<$int_ty>()`, so that must be in-bounds.
 macro_rules! load_int_le {
     ($buf:expr, $i:expr, $int_ty:ident) => {{
         debug_assert!($i + mem::size_of::<$int_ty>() <= $buf.len());
@@ -114,7 +115,8 @@ macro_rules! load_int_le {
 /// `copy_nonoverlapping` calls that occur (via `load_int_le!`) all have fixed
 /// sizes and avoid calling `memcpy`, which is good for speed.
 ///
-/// Unsafe because: unchecked indexing at start..start+len
+/// Safety: this performs unchecked indexing of `buf` at `start..start+len`, so
+/// that must be in-bounds.
 #[inline]
 unsafe fn u8to64_le(buf: &[u8], start: usize, len: usize) -> u64 {
     debug_assert!(len < 8);


### PR DESCRIPTION
In https://rust-lang.zulipchat.com/#narrow/stream/136281-t-lang.2Fwg-unsafe-code-guidelines/topic/Is.20there.20any.20way.20to.20soundly.20do.20a.20masked.20out-of-bounds.20read.3F/near/284329248 it came up that this is using an atypical (and somewhat vague) phrasing of the safety requirement, so this slightly rewords it.