### PR TITLE
Source code page: line number click adds `NaN`

### DIFF
--- a/src/librustdoc/html/static/js/source-script.js
+++ b/src/librustdoc/html/static/js/source-script.js
@@ -205,6 +205,10 @@ const handleSourceHighlight = (function() {
 
     return ev => {
         let cur_line_id = parseInt(ev.target.id, 10);
+        // It can happen when clicking not on a line number span.
+        if (isNaN(cur_line_id)) {
+            return;
+        }
         ev.preventDefault();
 
         if (ev.shiftKey && prev_line_id) {

--- a/src/test/rustdoc-gui/source-code-page.goml
+++ b/src/test/rustdoc-gui/source-code-page.goml
@@ -2,9 +2,9 @@
 goto: file://|DOC_PATH|/src/test_docs/lib.rs.html
 // Check that we can click on the line number.
 click: ".line-numbers > span:nth-child(4)" // This is the span for line 4.
-// Unfortunately, "#4" isn't a valid query selector, so we have to go around that limitation
-// by instead getting the nth span.
-assert-attribute: (".line-numbers > span:nth-child(4)", {"class": "line-highlighted"})
+// Ensure that the page URL was updated.
+assert-document-property: ({"URL": "#4"}, ENDS_WITH)
+assert-attribute: ("//*[@id='4']", {"class": "line-highlighted"})
 // We now check that the good spans are highlighted
 goto: file://|DOC_PATH|/src/test_docs/lib.rs.html#4-6
 assert-attribute-false: (".line-numbers > span:nth-child(3)", {"class": "line-highlighted"})

--- a/src/test/rustdoc-gui/source-code-page.goml
+++ b/src/test/rustdoc-gui/source-code-page.goml
@@ -3,7 +3,7 @@ goto: file://|DOC_PATH|/src/test_docs/lib.rs.html
 // Check that we can click on the line number.
 click: ".line-numbers > span:nth-child(4)" // This is the span for line 4.
 // Ensure that the page URL was updated.
-assert-document-property: ({"URL": "#4"}, ENDS_WITH)
+assert-document-property: ({"URL": "lib.rs.html#4"}, ENDS_WITH)
 assert-attribute: ("//*[@id='4']", {"class": "line-highlighted"})
 // We now check that the good spans are highlighted
 goto: file://|DOC_PATH|/src/test_docs/lib.rs.html#4-6
@@ -17,3 +17,13 @@ compare-elements-position: ("//*[@id='1']", ".rust > code > span", ("y"))
 
 // Assert that the line numbers text is aligned to the right.
 assert-css: (".line-numbers", {"text-align": "right"})
+
+// Now let's check that clicking on something else than the line number doesn't
+// do anything (and certainly not add a `#NaN` to the URL!).
+show-text: true
+goto: file://|DOC_PATH|/src/test_docs/lib.rs.html
+// We use this assert-position to know where we will click.
+assert-position: ("//*[@id='1']", {"x": 104, "y": 103})
+// We click on the left of the "1" span but still in the "line-number" `<pre>`.
+click: (103, 103)
+assert-document-property: ({"URL": "/lib.rs.html"}, ENDS_WITH)


### PR DESCRIPTION
When you click on the parent element of the line numbers in the source code pages, it'll add `NaN` (like in https://doc.rust-lang.org/nightly/src/alloc/lib.rs.html#NaN). This PR fixes this bug.

cc @jsha 
r? @notriddle 