### PR TITLE
Clarify Semantics of Assignment in MIR

### DIFF
--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -1767,6 +1767,8 @@ pub enum RetagKind {
     Raw,
     /// A "normal" retag.
     Default,
+    /// Retagging for the lhs of an assignment: `this_place = val;`
+    Assign,
 }
 
 /// The `FakeReadCause` describes the type of pattern why a FakeRead statement exists.
@@ -1838,6 +1840,7 @@ impl Debug for Statement<'_> {
                     RetagKind::TwoPhase => "[2phase] ",
                     RetagKind::Raw => "[raw] ",
                     RetagKind::Default => "",
+                    RetagKind::Assign => "[assign]",
                 },
                 place,
             ),

--- a/compiler/rustc_middle/src/mir/tcx.rs
+++ b/compiler/rustc_middle/src/mir/tcx.rs
@@ -240,6 +240,27 @@ impl<'tcx> Rvalue<'tcx> {
 
         false
     }
+
+    /// Returns true if evaluation of the rvalue is left to right.
+    ///
+    /// See [`StatementKind::Asssign`](crate::mir::StatementKind::Assign) for details.
+    #[inline]
+    pub fn is_left_to_right(&self) -> bool {
+        match self {
+            Rvalue::Use(_) | Rvalue::Repeat(..) | Rvalue::Aggregate(..) => true,
+            Rvalue::Ref(..)
+            | Rvalue::ThreadLocalRef(..)
+            | Rvalue::AddressOf(..)
+            | Rvalue::Len(..)
+            | Rvalue::Cast(..)
+            | Rvalue::BinaryOp(..)
+            | Rvalue::CheckedBinaryOp(..)
+            | Rvalue::NullaryOp(..)
+            | Rvalue::UnaryOp(..)
+            | Rvalue::Discriminant(..)
+            | Rvalue::ShallowInitBox(..) => false,
+        }
+    }
 }
 
 impl<'tcx> Operand<'tcx> {


### PR DESCRIPTION
This PR clarifies the semantics of assignments in MIR to match [what I suggested here](https://github.com/rust-lang/rust/issues/68364#issuecomment-1093894612) (cc #68364).

 - The first commit updates documentation to reflect this change.
 - The second commit updates const eval to use the correct evaluation order. It does not yet update it to also retag the LHS place as unique. It is unclear how to implement this and likely needs a significant refactor, and so might be better left to future work.
 - The third commit adds utilities to `rustc_middle` to handle these semantics soundly.
 - The fourth commit updates `InstCombine` to be sound in the face of these semantics. I was not able to add a test for this, because without destprop or a similar function pass, there are too many temporaries to set this off. I briefly went through all the other passes, and I did not find anything that might not comply with this (except for dest prop, but that's being fixed elsewhere).

@RalfJung expressed some concerns that these semantics might be too subtle/footgunny, and we should instead have an explicit flag on `StatementKind::Assign` that indicates which version of the semantics the statement gets. This is a tradeoff - it would indeed simplify things for people trying to reason about the semantics. However, it would also be a larger refactor and we'd have to decide whether/how not to support it in borrowck, support it in codegen, etc. Seeing that at least for now the amount of complexity this introduces seems to be minimal, I am personally against such a change until we have more evidence of this causing actual problems.

r? @oli-obk