### PR TITLE
Remove `memset` alias from `fill_with`.

### DIFF
--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -3083,7 +3083,6 @@ impl<T> [T] {
     /// buf.fill_with(Default::default);
     /// assert_eq!(buf, vec![0; 10]);
     /// ```
-    #[doc(alias = "memset")]
     #[stable(feature = "slice_fill_with", since = "1.51.0")]
     pub fn fill_with<F>(&mut self, mut f: F)
     where


### PR DESCRIPTION
In https://rust-lang.zulipchat.com/#narrow/stream/219381-t-libs/topic/Unsafe.20and.20Safe.20versions.20of.20APIs.20both.20getting.20the.20same.20alias/near/284413029 @Amanieu pointed out that we had this, which is not really right.

In our guidelines we say that we will "not add an alias for a function that's only somewhat similar or related", which applies here. Memset doesn't take a closure, not even conceptually.