### PR TITLE
Use two words for "file name"

### DIFF
--- a/library/std/src/io/error.rs
+++ b/library/std/src/io/error.rs
@@ -309,11 +309,11 @@ pub enum ErrorKind {
     /// The filesystem does not support making so many hardlinks to the same file.
     #[unstable(feature = "io_error_more", issue = "86442")]
     TooManyLinks,
-    /// A filename was invalid.
+    /// A file name was invalid.
     ///
-    /// This error can also cause if it exceeded the filename length limit.
+    /// This error can also cause if it exceeded the file name length limit.
     #[unstable(feature = "io_error_more", issue = "86442")]
-    InvalidFilename,
+    InvalidFileName,
     /// Program argument list too long.
     ///
     /// When trying to run an external program, a system or process limit on the size of the
@@ -399,7 +399,7 @@ impl ErrorKind {
             HostUnreachable => "host unreachable",
             Interrupted => "operation interrupted",
             InvalidData => "invalid data",
-            InvalidFilename => "invalid filename",
+            InvalidFileName => "invalid file name",
             InvalidInput => "invalid input parameter",
             IsADirectory => "is a directory",
             NetworkDown => "network down",

--- a/library/std/src/io/error/repr_bitpacked.rs
+++ b/library/std/src/io/error/repr_bitpacked.rs
@@ -324,7 +324,7 @@ fn kind_from_prim(ek: u32) -> Option<ErrorKind> {
         Deadlock,
         CrossesDevices,
         TooManyLinks,
-        InvalidFilename,
+        InvalidFileName,
         ArgumentListTooLong,
         Interrupted,
         Other,

--- a/library/std/src/sys/unix/mod.rs
+++ b/library/std/src/sys/unix/mod.rs
@@ -158,7 +158,7 @@ pub fn decode_error_kind(errno: i32) -> ErrorKind {
         libc::ENOSPC => StorageFull,
         libc::ENOSYS => Unsupported,
         libc::EMLINK => TooManyLinks,
-        libc::ENAMETOOLONG => InvalidFilename,
+        libc::ENAMETOOLONG => InvalidFileName,
         libc::ENETDOWN => NetworkDown,
         libc::ENETUNREACH => NetworkUnreachable,
         libc::ENOTCONN => NotConnected,

--- a/library/std/src/sys/windows/mod.rs
+++ b/library/std/src/sys/windows/mod.rs
@@ -68,7 +68,7 @@ pub fn decode_error_kind(errno: i32) -> ErrorKind {
         c::ERROR_FILE_NOT_FOUND => return NotFound,
         c::ERROR_PATH_NOT_FOUND => return NotFound,
         c::ERROR_NO_DATA => return BrokenPipe,
-        c::ERROR_INVALID_NAME => return InvalidFilename,
+        c::ERROR_INVALID_NAME => return InvalidFileName,
         c::ERROR_INVALID_PARAMETER => return InvalidInput,
         c::ERROR_NOT_ENOUGH_MEMORY | c::ERROR_OUTOFMEMORY => return OutOfMemory,
         c::ERROR_SEM_TIMEOUT
@@ -102,7 +102,7 @@ pub fn decode_error_kind(errno: i32) -> ErrorKind {
         c::ERROR_POSSIBLE_DEADLOCK => return Deadlock,
         c::ERROR_NOT_SAME_DEVICE => return CrossesDevices,
         c::ERROR_TOO_MANY_LINKS => return TooManyLinks,
-        c::ERROR_FILENAME_EXCED_RANGE => return InvalidFilename,
+        c::ERROR_FILENAME_EXCED_RANGE => return InvalidFileName,
         _ => {}
     }
 


### PR DESCRIPTION
While both "file name" and "filename" are perfectly cromulent, "file name" is more consistent with existing usage in the standard library. I believe we should try to be consistent where we can.

E.g. [`Path::file_name`](https://doc.rust-lang.org/std/path/struct.Path.html#method.file_name) and [`DirEntry::file_name`](https://doc.rust-lang.org/std/fs/struct.DirEntry.html#method.file_name)