### PR TITLE
Pass --out-dir for run-pass tests in Compiletest

### DIFF
--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -1905,13 +1905,15 @@ impl<'test> TestCx<'test> {
         match output_file {
             TargetLocation::ThisFile(path) => {
                 rustc.arg("-o").arg(path);
+                rustc.arg("--out-dir").arg(&self.config.build_base);
+
             }
             TargetLocation::ThisDirectory(path) => {
                 if is_rustdoc {
                     // `rustdoc` uses `-o` for the output directory.
                     rustc.arg("-o").arg(path);
                 } else {
-                    rustc.arg("--out-dir").arg(path);
+                    rustc.arg("--out-dir").arg(&self.config.build_base);
                 }
             }
         }

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -1906,7 +1906,6 @@ impl<'test> TestCx<'test> {
             TargetLocation::ThisFile(path) => {
                 rustc.arg("-o").arg(path);
                 rustc.arg("--out-dir").arg(&self.config.build_base);
-
             }
             TargetLocation::ThisDirectory(path) => {
                 if is_rustdoc {


### PR DESCRIPTION
This addresses the issue https://github.com/rust-lang/rust/issues/96928

Ran the following command with a local patch:

**Local Patch**
```
--- a/src/test/ui/const-generics/const-argument-non-static-lifetime.rs
+++ b/src/test/ui/const-generics/const-argument-non-static-lifetime.rs
@@ -1,4 +1,4 @@
-// [full] check-pass
+// [full] run-pass
```

**Command**
```
./x.py test  --bless src/test/ui/const-generics/const-argument-non-static-lifetime.rs
```

Before Change behavior: We create a temp folder `save-analysis-temp` which contains the json as well as one in the build folder.

After Change Behaviour: Only one json file is created in the build folder 
```
lionellloh@lionellloh-mbp rust % find ./ -name "const_argument_non_static_lifetime.json"
.//build/x86_64-apple-darwin/test/ui/save-analysis/const_argument_non_static_lifetime.json
```