### PR TITLE
Less confusing message for failed test returning Result

### DIFF
--- a/library/test/src/lib.rs
+++ b/library/test/src/lib.rs
@@ -182,8 +182,8 @@ fn make_owned_test(test: &&TestDescAndFn) -> TestDescAndFn {
 /// and checks for a `0` result.
 pub fn assert_test_result<T: Termination>(result: T) {
     let code = result.report().to_i32();
-    assert_eq!(
-        code, 0,
+    assert!(
+        code == 0,
         "the test returned a termination value with a non-zero status code ({}) \
          which indicates a failure",
         code


### PR DESCRIPTION
Failure message contained a part that is related to `assert_eq!` matcher.
This is confusing in the cases when test fails because of Err result.

Test:
```rust
#[test]
fn test() -> Result<(), &'static str> {
    Err("some failure")?;
    assert_eq!(1, 2);
    Ok(())
}
```

Before:
```
---- tests::test stdout ----
Error: "some failure"
thread 'tests::test' panicked at 'assertion failed: `(left == right)`
  left: `1`,
 right: `0`: the test returned a termination value with a non-zero status code (1) which indicates a failure', /rustc/7737e0b5c4103216d6fd8cf941b7ab9bdbaace7c/library/test/src/lib.rs:187:5
```

After:
```
 ---- tests::test stdout ----
Error: "some failure"
thread 'tests::test' panicked at 'the test returned a termination value with a non-zero status code (1) which indicates a failure', /rustc/7737e0b5c4103216d6fd8cf941b7ab9bdbaace7c/library/test/src/lib.rs:187:5
```

Fixes #69517