### PR TITLE
Migrate more diagnostics to use the `#[derive(SessionDiagnostic)]`

### DIFF
--- a/compiler/rustc_error_messages/locales/en-US/parser.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/parser.ftl
@@ -28,3 +28,7 @@ parser-incorrect-use-of-await =
     incorrect use of `await`
     .parentheses-suggestion = `await` is not a method call, remove the parentheses
     .postfix-suggestion = `await` is a postfix operation
+
+parser-in-in-typo =
+    expected iterable, found keyword `in`
+    .suggestion = remove the duplicated `in`

--- a/compiler/rustc_error_messages/locales/en-US/parser.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/parser.ftl
@@ -26,9 +26,5 @@ parser-incorrect-semicolon =
 
 parser-incorrect-use-of-await =
     incorrect use of `await`
-    .suggestion = `await` is not a method call, remove the parentheses
-
-
-parser-incorrect-await =
-    incorrect use of `await`
-    .suggestion = `await` is a postfix operation
+    .parentheses-suggestion = `await` is not a method call, remove the parentheses
+    .postfix-suggestion = `await` is a postfix operation

--- a/compiler/rustc_error_messages/locales/en-US/parser.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/parser.ftl
@@ -27,3 +27,8 @@ parser-incorrect-semicolon =
 parser-incorrect-use-of-await =
     incorrect use of `await`
     .suggestion = `await` is not a method call, remove the parentheses
+
+
+parser-incorrect-await =
+    incorrect use of `await`
+    .suggestion = `await` is a postfix operation

--- a/compiler/rustc_error_messages/locales/en-US/parser.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/parser.ftl
@@ -14,3 +14,7 @@ parser-add-paren = try adding parentheses
 parser-forgot-paren = perhaps you forgot parentheses?
 
 parser-expect-path = expected a path
+
+parser-maybe-recover-from-bad-qpath-stage-2 =
+    missing angle brackets in associated item path
+    .suggestion = try: `{$ty}`

--- a/compiler/rustc_error_messages/locales/en-US/parser.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/parser.ftl
@@ -23,3 +23,7 @@ parser-incorrect-semicolon =
     expected item, found `;`
     .suggestion = remove this semicolon
     .help = {$name} declarations are not followed by a semicolon
+
+parser-incorrect-use-of-await =
+    incorrect use of `await`
+    .suggestion = `await` is not a method call, remove the parentheses

--- a/compiler/rustc_error_messages/locales/en-US/parser.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/parser.ftl
@@ -18,3 +18,8 @@ parser-expect-path = expected a path
 parser-maybe-recover-from-bad-qpath-stage-2 =
     missing angle brackets in associated item path
     .suggestion = try: `{$ty}`
+
+parser-incorrect-semicolon =
+    expected item, found `;`
+    .suggestion = remove this semicolon
+    .help = {$name} declarations are not followed by a semicolon

--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -1687,10 +1687,10 @@ impl<'a> Parser<'a> {
             // future.await()
             let lo = self.token.span;
             self.bump(); // (
-            let sp = lo.to(self.token.span);
+            let span = lo.to(self.token.span);
             self.bump(); // )
 
-            self.sess.emit_err(IncorrectUseOfAwait { span: sp });
+            self.sess.emit_err(IncorrectUseOfAwait { span });
         }
     }
 

--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -299,7 +299,7 @@ struct BadQPathStage2 {
 #[error(slug = "parser-incorrect-semicolon")]
 struct IncorrectSemicolon<'a> {
     #[primary_span]
-    #[suggestion(applicability = "machine-applicable")]
+    #[suggestion_short(applicability = "machine-applicable")]
     span: Span,
     #[help]
     opt_help: Option<()>,

--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -310,16 +310,16 @@ struct IncorrectSemicolon<'a> {
 #[error(slug = "parser-incorrect-use-of-await")]
 struct IncorrectUseOfAwait {
     #[primary_span]
-    #[suggestion(applicability = "machine-applicable")]
+    #[suggestion(message = "parentheses-suggestion", applicability = "machine-applicable")]
     span: Span,
 }
 
 #[derive(SessionDiagnostic)]
-#[error(slug = "parser-incorrect-await")]
+#[error(slug = "parser-incorrect-use-of-await")]
 struct IncorrectAwait {
     #[primary_span]
     span: Span,
-    #[suggestion(code = "{expr}.await{question_mark}")]
+    #[suggestion(message = "postfix-suggestion", code = "{expr}.await{question_mark}")]
     sugg_span: (Span, Applicability),
     expr: String,
     question_mark: &'static str,

--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -306,6 +306,14 @@ struct IncorrectSemicolon<'a> {
     name: &'a str,
 }
 
+#[derive(SessionDiagnostic)]
+#[error(slug = "parser-incorrect-use-of-await")]
+struct IncorrectUseOfAwait {
+    #[primary_span]
+    #[suggestion(applicability = "machine-applicable")]
+    span: Span,
+}
+
 // SnapshotParser is used to create a snapshot of the parser
 // without causing duplicate errors being emitted when the `Parser`
 // is dropped.
@@ -1659,14 +1667,8 @@ impl<'a> Parser<'a> {
             self.bump(); // (
             let sp = lo.to(self.token.span);
             self.bump(); // )
-            self.struct_span_err(sp, "incorrect use of `await`")
-                .span_suggestion(
-                    sp,
-                    "`await` is not a method call, remove the parentheses",
-                    String::new(),
-                    Applicability::MachineApplicable,
-                )
-                .emit();
+
+            self.sess.emit_err(IncorrectUseOfAwait { span: sp });
         }
     }
 


### PR DESCRIPTION
r? @davidtwco 