### PR TITLE
remove panic docs for atomic load and stores

### DIFF
--- a/library/core/src/sync/atomic.rs
+++ b/library/core/src/sync/atomic.rs
@@ -427,10 +427,6 @@ impl AtomicBool {
     /// `load` takes an [`Ordering`] argument which describes the memory ordering
     /// of this operation. Possible values are [`SeqCst`], [`Acquire`] and [`Relaxed`].
     ///
-    /// # Panics
-    ///
-    /// Panics if `order` is [`Release`] or [`AcqRel`].
-    ///
     /// # Examples
     ///
     /// ```
@@ -452,10 +448,6 @@ impl AtomicBool {
     ///
     /// `store` takes an [`Ordering`] argument which describes the memory ordering
     /// of this operation. Possible values are [`SeqCst`], [`Release`] and [`Relaxed`].
-    ///
-    /// # Panics
-    ///
-    /// Panics if `order` is [`Acquire`] or [`AcqRel`].
     ///
     /// # Examples
     ///
@@ -1109,10 +1101,6 @@ impl<T> AtomicPtr<T> {
     /// `load` takes an [`Ordering`] argument which describes the memory ordering
     /// of this operation. Possible values are [`SeqCst`], [`Acquire`] and [`Relaxed`].
     ///
-    /// # Panics
-    ///
-    /// Panics if `order` is [`Release`] or [`AcqRel`].
-    ///
     /// # Examples
     ///
     /// ```
@@ -1134,10 +1122,6 @@ impl<T> AtomicPtr<T> {
     ///
     /// `store` takes an [`Ordering`] argument which describes the memory ordering
     /// of this operation. Possible values are [`SeqCst`], [`Release`] and [`Relaxed`].
-    ///
-    /// # Panics
-    ///
-    /// Panics if `order` is [`Acquire`] or [`AcqRel`].
     ///
     /// # Examples
     ///
@@ -1692,10 +1676,6 @@ macro_rules! atomic_int {
             /// `load` takes an [`Ordering`] argument which describes the memory ordering of this operation.
             /// Possible values are [`SeqCst`], [`Acquire`] and [`Relaxed`].
             ///
-            /// # Panics
-            ///
-            /// Panics if `order` is [`Release`] or [`AcqRel`].
-            ///
             /// # Examples
             ///
             /// ```
@@ -1716,10 +1696,6 @@ macro_rules! atomic_int {
             ///
             /// `store` takes an [`Ordering`] argument which describes the memory ordering of this operation.
             ///  Possible values are [`SeqCst`], [`Release`] and [`Relaxed`].
-            ///
-            /// # Panics
-            ///
-            /// Panics if `order` is [`Acquire`] or [`AcqRel`].
             ///
             /// # Examples
             ///
@@ -2664,7 +2640,11 @@ unsafe fn atomic_compare_exchange<T: Copy>(
             _ => panic!("a failure ordering can't be stronger than a success ordering"),
         }
     };
-    if ok { Ok(val) } else { Err(val) }
+    if ok {
+        Ok(val)
+    } else {
+        Err(val)
+    }
 }
 
 #[inline]
@@ -2693,7 +2673,11 @@ unsafe fn atomic_compare_exchange_weak<T: Copy>(
             _ => panic!("a failure ordering can't be stronger than a success ordering"),
         }
     };
-    if ok { Ok(val) } else { Err(val) }
+    if ok {
+        Ok(val)
+    } else {
+        Err(val)
+    }
 }
 
 #[inline]

--- a/library/core/src/sync/atomic.rs
+++ b/library/core/src/sync/atomic.rs
@@ -2640,11 +2640,7 @@ unsafe fn atomic_compare_exchange<T: Copy>(
             _ => panic!("a failure ordering can't be stronger than a success ordering"),
         }
     };
-    if ok {
-        Ok(val)
-    } else {
-        Err(val)
-    }
+    if ok { Ok(val) } else { Err(val) }
 }
 
 #[inline]
@@ -2673,11 +2669,7 @@ unsafe fn atomic_compare_exchange_weak<T: Copy>(
             _ => panic!("a failure ordering can't be stronger than a success ordering"),
         }
     };
-    if ok {
-        Ok(val)
-    } else {
-        Err(val)
-    }
+    if ok { Ok(val) } else { Err(val) }
 }
 
 #[inline]


### PR DESCRIPTION
Currently, the docs for loads and stores for Atomic types looks like this:

Load:

```rs
pub fn [load](https://doc.rust-lang.org/std/sync/atomic/struct.AtomicUsize.html#method.load)(&self, order: [Ordering](https://doc.rust-lang.org/std/sync/atomic/enum.Ordering.html)) -> [usize](https://doc.rust-lang.org/std/primitive.usize.html)

Loads a value from the atomic integer.

load takes an [Ordering](https://doc.rust-lang.org/std/sync/atomic/enum.Ordering.html) argument which describes the memory ordering of this operation. Possible values are [SeqCst](https://doc.rust-lang.org/std/sync/atomic/enum.Ordering.html#variant.SeqCst), [Acquire](https://doc.rust-lang.org/std/sync/atomic/enum.Ordering.html#variant.Acquire) and [Relaxed](https://doc.rust-lang.org/std/sync/atomic/enum.Ordering.html#variant.Relaxed).
[Panics](https://doc.rust-lang.org/std/sync/atomic/struct.AtomicUsize.html#panics)

Panics if order is [Release](https://doc.rust-lang.org/std/sync/atomic/enum.Ordering.html#variant.Release) or [AcqRel](https://doc.rust-lang.org/std/sync/atomic/enum.Ordering.html#variant.AcqRel).
```

Store:

```rs
pub fn [store](https://doc.rust-lang.org/std/sync/atomic/struct.AtomicUsize.html#method.store)(&self, val: [usize](https://doc.rust-lang.org/std/primitive.usize.html), order: [Ordering](https://doc.rust-lang.org/std/sync/atomic/enum.Ordering.html))

Stores a value into the atomic integer.

store takes an [Ordering](https://doc.rust-lang.org/std/sync/atomic/enum.Ordering.html) argument which describes the memory ordering of this operation. Possible values are [SeqCst](https://doc.rust-lang.org/std/sync/atomic/enum.Ordering.html#variant.SeqCst), [Release](https://doc.rust-lang.org/std/sync/atomic/enum.Ordering.html#variant.Release) and [Relaxed](https://doc.rust-lang.org/std/sync/atomic/enum.Ordering.html#variant.Relaxed).
[Panics](https://doc.rust-lang.org/std/sync/atomic/struct.AtomicUsize.html#panics-1)

Panics if order is [Acquire](https://doc.rust-lang.org/std/sync/atomic/enum.Ordering.html#variant.Acquire) or [AcqRel](https://doc.rust-lang.org/std/sync/atomic/enum.Ordering.html#variant.AcqRel).
```

tl;dr, the docs indicate that storing with an ordering of `Acquire` or `AcqRel` panics at runtime, and loading with an ordering of `Release` or `AcqRel` panics at runtime.

This hasn't been true since 1.56 landed this patch, making it so incorrect orderings on loads and stores are compile time errors now.
https://github.com/rust-lang/rust/pull/84039

A minimum example here:

```sh
$ cat src/main.rs
use std::sync::atomic::{AtomicBool, AtomicPtr, AtomicUsize, Ordering};

fn main() {
    let atomic_usize = AtomicUsize::default();

    atomic_usize.store(10, Ordering::Acquire);
    atomic_usize.store(20, Ordering::AcqRel);
    atomic_usize.load(Ordering::Release);
    atomic_usize.load(Ordering::AcqRel);

    let atomic_bool = AtomicBool::default();

    atomic_bool.store(true, Ordering::Acquire);
    atomic_bool.store(false, Ordering::AcqRel);
    atomic_bool.load(Ordering::Release);
    atomic_bool.load(Ordering::AcqRel);

    let atomic_ptr = AtomicPtr::default();
    let ten_ptr: *mut i32 = &mut 10;

    atomic_ptr.store(ten_ptr, Ordering::Acquire);
    atomic_ptr.store(ten_ptr, Ordering::AcqRel);
    atomic_ptr.load(Ordering::Release);
    atomic_ptr.load(Ordering::AcqRel);
}
```

```sh
rustc --version
rustc 1.61.0 (fe5b13d68 2022-05-18)
```

```sh
﻿﻿$ cargo run
   Compiling ordering v0.1.0 (/Users/takashi/Desktop/concurrency-problems/ordering)
error: atomic stores cannot have `Acquire` or `AcqRel` ordering
 --> src/main.rs:6:28
  |
6 |     atomic_usize.store(10, Ordering::Acquire);
  |                            ^^^^^^^^^^^^^^^^^
  |
  = note: `#[deny(invalid_atomic_ordering)]` on by default
  = help: consider using ordering modes `Release`, `SeqCst` or `Relaxed`

error: atomic stores cannot have `Acquire` or `AcqRel` ordering
 --> src/main.rs:7:28
  |
7 |     atomic_usize.store(20, Ordering::AcqRel);
  |                            ^^^^^^^^^^^^^^^^
  |
  = help: consider using ordering modes `Release`, `SeqCst` or `Relaxed`

error: atomic loads cannot have `Release` or `AcqRel` ordering
 --> src/main.rs:8:23
  |
8 |     atomic_usize.load(Ordering::Release);
  |                       ^^^^^^^^^^^^^^^^^
  |
  = help: consider using ordering modes `Acquire`, `SeqCst` or `Relaxed`

error: atomic loads cannot have `Release` or `AcqRel` ordering
 --> src/main.rs:9:23
  |
9 |     atomic_usize.load(Ordering::AcqRel);
  |                       ^^^^^^^^^^^^^^^^
  |
  = help: consider using ordering modes `Acquire`, `SeqCst` or `Relaxed`

error: atomic stores cannot have `Acquire` or `AcqRel` ordering
  --> src/main.rs:13:29
   |
13 |     atomic_bool.store(true, Ordering::Acquire);
   |                             ^^^^^^^^^^^^^^^^^
   |
   = help: consider using ordering modes `Release`, `SeqCst` or `Relaxed`

error: atomic stores cannot have `Acquire` or `AcqRel` ordering
  --> src/main.rs:14:30
   |
14 |     atomic_bool.store(false, Ordering::AcqRel);
   |                              ^^^^^^^^^^^^^^^^
   |
   = help: consider using ordering modes `Release`, `SeqCst` or `Relaxed`

error: atomic loads cannot have `Release` or `AcqRel` ordering
  --> src/main.rs:15:22
   |
15 |     atomic_bool.load(Ordering::Release);
   |                      ^^^^^^^^^^^^^^^^^
   |
   = help: consider using ordering modes `Acquire`, `SeqCst` or `Relaxed`

error: atomic loads cannot have `Release` or `AcqRel` ordering
  --> src/main.rs:16:22
   |
16 |     atomic_bool.load(Ordering::AcqRel);
   |                      ^^^^^^^^^^^^^^^^
   |
   = help: consider using ordering modes `Acquire`, `SeqCst` or `Relaxed`

error: atomic stores cannot have `Acquire` or `AcqRel` ordering
  --> src/main.rs:21:31
   |
21 |     atomic_ptr.store(ten_ptr, Ordering::Acquire);
   |                               ^^^^^^^^^^^^^^^^^
   |
   = help: consider using ordering modes `Release`, `SeqCst` or `Relaxed`

error: atomic stores cannot have `Acquire` or `AcqRel` ordering
  --> src/main.rs:22:31
   |
22 |     atomic_ptr.store(ten_ptr, Ordering::AcqRel);
   |                               ^^^^^^^^^^^^^^^^
   |
   = help: consider using ordering modes `Release`, `SeqCst` or `Relaxed`

error: atomic loads cannot have `Release` or `AcqRel` ordering
  --> src/main.rs:23:21
   |
23 |     atomic_ptr.load(Ordering::Release);
   |                     ^^^^^^^^^^^^^^^^^
   |
   = help: consider using ordering modes `Acquire`, `SeqCst` or `Relaxed`

error: atomic loads cannot have `Release` or `AcqRel` ordering
  --> src/main.rs:24:21
   |
24 |     atomic_ptr.load(Ordering::AcqRel);
   |                     ^^^^^^^^^^^^^^^^
   |
   = help: consider using ordering modes `Acquire`, `SeqCst` or `Relaxed`

error: could not compile `ordering` due to 12 previous errors
```

On 1.55, the same program panics, indicating that the docs were correct at that point in time.

```sh
$ rustup default 1.55
info: using existing install for '1.55-x86_64-apple-darwin'
info: default toolchain set to '1.55-x86_64-apple-darwin'

  1.55-x86_64-apple-darwin unchanged - rustc 1.55.0 (c8dfcfe04 2021-09-06)
```

```sh
$ rustc --version
rustc 1.55.0 (c8dfcfe04 2021-09-06)
```

```sh
$ cargo run
   Compiling ordering v0.1.0 (/Users/takashi/Desktop/concurrency-problems/ordering)
    Finished dev [unoptimized + debuginfo] target(s) in 1.58s
     Running `target/debug/ordering`
thread 'main' panicked at 'there is no such thing as an acquire store', /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/core/src/sync/atomic.rs:2342:24
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```