### PR TITLE
Implement tuple<->array convertions via `From`

### DIFF
--- a/library/core/src/primitive_docs.rs
+++ b/library/core/src/primitive_docs.rs
@@ -610,6 +610,9 @@ mod prim_pointer {}
 /// if the element type allows it. As a stopgap, trait implementations are
 /// statically generated up to size 32.
 ///
+/// Arrays of sizes from 1 to 12 (inclusive) implement [`From<Tuple>`], where `Tuple`
+/// is a homogenous [prim@tuple] of appropriate length.
+///
 /// Arrays coerce to [slices (`[T]`)][slice], so a slice method may be called on
 /// an array. Indeed, this provides most of the API for working with arrays.
 ///
@@ -670,6 +673,13 @@ mod prim_pointer {}
 /// let [john, roa] = ["John".to_string(), "Roa".to_string()];
 /// move_away(john);
 /// move_away(roa);
+/// ```
+///
+/// Arrays can be created from homogenous tuples of appropriate length:
+///
+/// ```
+/// let tuple: (u32, u32, u32) = (1, 2, 3);
+/// let array: [u32; 3] = tuple.into();
 /// ```
 ///
 /// # Editions
@@ -774,6 +784,7 @@ mod prim_pointer {}
 /// [`Borrow`]: borrow::Borrow
 /// [`BorrowMut`]: borrow::BorrowMut
 /// [slice pattern]: ../reference/patterns.html#slice-patterns
+/// [`From<Tuple>`]: convert::From
 #[stable(feature = "rust1", since = "1.0.0")]
 mod prim_array {}
 
@@ -1000,7 +1011,9 @@ mod prim_str {}
 /// * [`Debug`]
 /// * [`Default`]
 /// * [`Hash`]
+/// * [`From<[T; N]>`][from]
 ///
+/// [from]: convert::From
 /// [`Debug`]: fmt::Debug
 /// [`Hash`]: hash::Hash
 ///
@@ -1049,6 +1062,13 @@ mod prim_str {}
 ///
 /// assert_eq!(x, 4);
 /// assert_eq!(y, 5);
+/// ```
+///
+/// Homogenous tuples can be created from arrays of appropriate length:
+///
+/// ```
+/// let array: [u32; 3] = [1, 2, 3];
+/// let tuple: (u32, u32, u32) = array.into();
 /// ```
 ///
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/library/core/src/tuple.rs
+++ b/library/core/src/tuple.rs
@@ -100,6 +100,26 @@ macro_rules! tuple_impls {
                 }
             }
         }
+
+        #[stable(feature = "array_tuple_conv", since = "1.63.0")]
+        impl<T> From<[T; count!($($T)+)]> for ($(${ignore(T)} T,)+) {
+            #[inline]
+            #[allow(non_snake_case)]
+            fn from(array: [T; count!($($T)+)]) -> Self {
+                let [$($T,)+] = array;
+                ($($T,)+)
+            }
+        }
+
+        #[stable(feature = "array_tuple_conv", since = "1.63.0")]
+        impl<T> From<($(${ignore(T)} T,)+)> for [T; count!($($T)+)] {
+            #[inline]
+            #[allow(non_snake_case)]
+            fn from(tuple: ($(${ignore(T)} T,)+)) -> Self {
+                let ($($T,)+) = tuple;
+                [$($T,)+]
+            }
+        }
     }
 }
 
@@ -179,3 +199,23 @@ macro_rules! last_type {
 }
 
 tuple_impls!(E D C B A Z Y X W V U T);
+
+macro_rules! count {
+    ($($a:ident)*) => {
+        0 $(${ignore(a)} + 1)*
+    };
+}
+
+#[stable(feature = "array_tuple_conv", since = "1.63.0")]
+impl<T> From<()> for [T; 0] {
+    fn from((): ()) -> Self {
+        []
+    }
+}
+
+#[stable(feature = "array_tuple_conv", since = "1.63.0")]
+impl<T> From<[T; 0]> for () {
+    fn from([]: [T; 0]) -> Self {
+        ()
+    }
+}

--- a/library/core/src/tuple.rs
+++ b/library/core/src/tuple.rs
@@ -102,17 +102,17 @@ macro_rules! tuple_impls {
         }
 
         #[stable(feature = "array_tuple_conv", since = "1.63.0")]
-        impl<T> From<[T; count!($($T)+)]> for ($(${ignore(T)} T,)+) {
+        impl<T> From<[T; ${count(T)}]> for ($(${ignore(T)} T,)+) {
             #[inline]
             #[allow(non_snake_case)]
-            fn from(array: [T; count!($($T)+)]) -> Self {
+            fn from(array: [T; ${count(T)}]) -> Self {
                 let [$($T,)+] = array;
                 ($($T,)+)
             }
         }
 
         #[stable(feature = "array_tuple_conv", since = "1.63.0")]
-        impl<T> From<($(${ignore(T)} T,)+)> for [T; count!($($T)+)] {
+        impl<T> From<($(${ignore(T)} T,)+)> for [T; ${count(T)}] {
             #[inline]
             #[allow(non_snake_case)]
             fn from(tuple: ($(${ignore(T)} T,)+)) -> Self {
@@ -199,12 +199,6 @@ macro_rules! last_type {
 }
 
 tuple_impls!(E D C B A Z Y X W V U T);
-
-macro_rules! count {
-    ($($a:ident)*) => {
-        0 $(${ignore(a)} + 1)*
-    };
-}
 
 #[stable(feature = "array_tuple_conv", since = "1.63.0")]
 impl<T> From<()> for [T; 0] {

--- a/library/core/src/tuple.rs
+++ b/library/core/src/tuple.rs
@@ -199,17 +199,3 @@ macro_rules! last_type {
 }
 
 tuple_impls!(E D C B A Z Y X W V U T);
-
-#[stable(feature = "array_tuple_conv", since = "1.63.0")]
-impl<T> From<()> for [T; 0] {
-    fn from((): ()) -> Self {
-        []
-    }
-}
-
-#[stable(feature = "array_tuple_conv", since = "1.63.0")]
-impl<T> From<[T; 0]> for () {
-    fn from([]: [T; 0]) -> Self {
-        ()
-    }
-}

--- a/library/std/src/primitive_docs.rs
+++ b/library/std/src/primitive_docs.rs
@@ -610,6 +610,9 @@ mod prim_pointer {}
 /// if the element type allows it. As a stopgap, trait implementations are
 /// statically generated up to size 32.
 ///
+/// Arrays of sizes from 1 to 12 (inclusive) implement [`From<Tuple>`], where `Tuple`
+/// is a homogenous [prim@tuple] of appropriate length.
+///
 /// Arrays coerce to [slices (`[T]`)][slice], so a slice method may be called on
 /// an array. Indeed, this provides most of the API for working with arrays.
 ///
@@ -670,6 +673,13 @@ mod prim_pointer {}
 /// let [john, roa] = ["John".to_string(), "Roa".to_string()];
 /// move_away(john);
 /// move_away(roa);
+/// ```
+///
+/// Arrays can be created from homogenous tuples of appropriate length:
+///
+/// ```
+/// let tuple: (u32, u32, u32) = (1, 2, 3);
+/// let array: [u32; 3] = tuple.into();
 /// ```
 ///
 /// # Editions
@@ -774,6 +784,7 @@ mod prim_pointer {}
 /// [`Borrow`]: borrow::Borrow
 /// [`BorrowMut`]: borrow::BorrowMut
 /// [slice pattern]: ../reference/patterns.html#slice-patterns
+/// [`From<Tuple>`]: convert::From
 #[stable(feature = "rust1", since = "1.0.0")]
 mod prim_array {}
 
@@ -1000,7 +1011,9 @@ mod prim_str {}
 /// * [`Debug`]
 /// * [`Default`]
 /// * [`Hash`]
+/// * [`From<[T; N]>`][from]
 ///
+/// [from]: convert::From
 /// [`Debug`]: fmt::Debug
 /// [`Hash`]: hash::Hash
 ///
@@ -1049,6 +1062,13 @@ mod prim_str {}
 ///
 /// assert_eq!(x, 4);
 /// assert_eq!(y, 5);
+/// ```
+///
+/// Homogenous tuples can be created from arrays of appropriate length:
+///
+/// ```
+/// let array: [u32; 3] = [1, 2, 3];
+/// let tuple: (u32, u32, u32) = array.into();
 /// ```
 ///
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/tests/ui/issues/issue-32709.stderr
+++ b/tests/ui/issues/issue-32709.stderr
@@ -7,9 +7,16 @@ LL |     Err(5)?;
    |           ^ the trait `From<{integer}>` is not implemented for `()`
    |
    = note: the question mark operation (`?`) implicitly performs a conversion on the error value using the `From` trait
-   = help: the following other types implement trait `FromResidual<R>`:
-             <Result<T, F> as FromResidual<Result<Infallible, E>>>
-             <Result<T, F> as FromResidual<Yeet<E>>>
+   = help: the following other types implement trait `From<T>`:
+             <(T, T) as From<[T; 2]>>
+             <(T, T, T) as From<[T; 3]>>
+             <(T, T, T, T) as From<[T; 4]>>
+             <(T, T, T, T, T) as From<[T; 5]>>
+             <(T, T, T, T, T, T) as From<[T; 6]>>
+             <(T, T, T, T, T, T, T) as From<[T; 7]>>
+             <(T, T, T, T, T, T, T, T) as From<[T; 8]>>
+             <(T, T, T, T, T, T, T, T, T) as From<[T; 9]>>
+           and 4 others
    = note: required for `Result<i32, ()>` to implement `FromResidual<Result<Infallible, {integer}>>`
 
 error: aborting due to previous error

--- a/tests/ui/suggestions/issue-71394-no-from-impl.stderr
+++ b/tests/ui/suggestions/issue-71394-no-from-impl.stderr
@@ -6,8 +6,14 @@ LL |     let _: &[i8] = data.into();
    |
    = help: the following other types implement trait `From<T>`:
              <&'input [u8] as From<gimli::read::endian_slice::EndianSlice<'input, Endian>>>
-             <[T; LANES] as From<Simd<T, LANES>>>
-             <[bool; LANES] as From<Mask<T, LANES>>>
+             <[T; 10] as From<(T, T, T, T, T, T, T, T, T, T)>>
+             <[T; 11] as From<(T, T, T, T, T, T, T, T, T, T, T)>>
+             <[T; 12] as From<(T, T, T, T, T, T, T, T, T, T, T, T)>>
+             <[T; 1] as From<(T,)>>
+             <[T; 2] as From<(T, T)>>
+             <[T; 3] as From<(T, T, T)>>
+             <[T; 4] as From<(T, T, T, T)>>
+           and 7 others
    = note: required for `&[u8]` to implement `Into<&[i8]>`
 
 error: aborting due to previous error


### PR DESCRIPTION
This PR adds the following impls that convert between homogeneous tuples and arrays of the corresponding lengths:
```rust
impl<T> From<[T; 1]> for (T,) { ... }
impl<T> From<[T; 2]> for (T, T) { ... }
/* ... */
impl<T> From<[T; 12]> for (T, T, T, T, T, T, T, T, T, T, T, T) { ... }

impl<T> From<(T,)> for [T; 1] { ... }
impl<T> From<(T, T)> for [T; 2] { ... }
/* ... */
impl<T> From<(T, T, T, T, T, T, T, T, T, T, T, T)> for [T; 12] { ... }
```

IMO these are quite uncontroversial but note that they are, just like any other trait impls, insta-stable.