### PR TITLE
Remove unwrap from get_vtable

### DIFF
--- a/compiler/rustc_ty_utils/src/instance.rs
+++ b/compiler/rustc_ty_utils/src/instance.rs
@@ -347,11 +347,15 @@ fn resolve_associated_item<'tcx>(
             _ => None,
         },
         traits::ImplSource::Object(ref data) => {
-            let index = traits::get_vtable_index_of_object_method(tcx, data, trait_item_id);
-            Some(Instance {
-                def: ty::InstanceDef::Virtual(trait_item_id, index),
-                substs: rcvr_substs,
-            })
+            if let Some(index) = traits::get_vtable_index_of_object_method(tcx, data, trait_item_id)
+            {
+                Some(Instance {
+                    def: ty::InstanceDef::Virtual(trait_item_id, index),
+                    substs: rcvr_substs,
+                })
+            } else {
+                None
+            }
         }
         traits::ImplSource::Builtin(..) => {
             if Some(trait_ref.def_id) == tcx.lang_items().clone_trait() {

--- a/src/test/ui/traits/vtable/issue-97381.rs
+++ b/src/test/ui/traits/vtable/issue-97381.rs
@@ -1,0 +1,30 @@
+use std::ops::Deref;
+trait MyTrait: Deref<Target = u32> {}
+struct MyStruct(u32);
+impl MyTrait for MyStruct {}
+impl Deref for MyStruct {
+    type Target = u32;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+fn get_concrete_value(i: u32) -> MyStruct {
+    MyStruct(i)
+}
+fn get_boxed_value(i: u32) -> Box<dyn MyTrait> {
+    Box::new(get_concrete_value(i))
+}
+fn main() {
+    let v = [1, 2, 3]
+        .iter()
+        .map(|i| get_boxed_value(*i))
+        .collect::<Vec<_>>();
+
+    let el = &v[0];
+
+    for _ in v {
+        //~^ ERROR cannot move out of `v` because it is borrowed
+        println!("{}", ***el > 0);
+    }
+}

--- a/src/test/ui/traits/vtable/issue-97381.stderr
+++ b/src/test/ui/traits/vtable/issue-97381.stderr
@@ -1,0 +1,15 @@
+error[E0505]: cannot move out of `v` because it is borrowed
+  --> $DIR/issue-97381.rs:26:14
+   |
+LL |     let el = &v[0];
+   |               - borrow of `v` occurs here
+LL | 
+LL |     for _ in v {
+   |              ^ move out of `v` occurs here
+LL |
+LL |         println!("{}", ***el > 0);
+   |                         ---- borrow later used here
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0505`.

--- a/src/test/ui/type/type-unsatisfiable.rs
+++ b/src/test/ui/type/type-unsatisfiable.rs
@@ -1,0 +1,59 @@
+// revisions: lib usage
+//[lib] compile-flags: --crate-type=lib
+//[lib] build-pass
+
+use std::ops::Sub;
+trait Vector2 {
+    type ScalarType;
+
+    fn from_values(x: Self::ScalarType, y: Self::ScalarType) -> Self
+    where
+        Self: Sized;
+
+    fn x(&self) -> Self::ScalarType;
+    fn y(&self) -> Self::ScalarType;
+}
+
+impl<T> Sub for dyn Vector2<ScalarType = T>
+where
+    T: Sub<Output = T>,
+    (dyn Vector2<ScalarType = T>): Sized,
+{
+    type Output = dyn Vector2<ScalarType = T>;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        Self::from_values(self.x() - rhs.x(), self.y() - rhs.y())
+    }
+}
+
+struct Vec2 {
+    x: i32,
+    y: i32,
+}
+
+impl Vector2 for Vec2 {
+    type ScalarType = i32;
+
+    fn from_values(x: Self::ScalarType, y: Self::ScalarType) -> Self
+    where
+        Self: Sized,
+    {
+        Self { x, y }
+    }
+
+    fn x(&self) -> Self::ScalarType {
+        self.x
+    }
+    fn y(&self) -> Self::ScalarType {
+        self.y
+    }
+}
+
+#[cfg(usage)]
+fn main() {
+    let hey: Box<dyn Vector2<ScalarType = i32>> = Box::new(Vec2 { x: 1, y: 2 });
+    let word: Box<dyn Vector2<ScalarType = i32>> = Box::new(Vec2 { x: 1, y: 2 });
+
+    let bar = *hey - *word;
+    //[usage]~^ ERROR cannot subtract
+}

--- a/src/test/ui/type/type-unsatisfiable.usage.stderr
+++ b/src/test/ui/type/type-unsatisfiable.usage.stderr
@@ -1,0 +1,11 @@
+error[E0369]: cannot subtract `(dyn Vector2<ScalarType = i32> + 'static)` from `dyn Vector2<ScalarType = i32>`
+  --> $DIR/type-unsatisfiable.rs:57:20
+   |
+LL |     let bar = *hey - *word;
+   |               ---- ^ ----- (dyn Vector2<ScalarType = i32> + 'static)
+   |               |
+   |               dyn Vector2<ScalarType = i32>
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0369`.


### PR DESCRIPTION
This avoids ICE on issue #97381 I think the bug is a bit deeper though, it compiles fine when `v` is `&v` which makes me think `Deref` is causing some issue with borrowck but it's fine I guess since this thing crashes since `nightly-2020-09-17` 😅 