### PR TITLE
Session object: Set OS/ABI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1688,6 +1688,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c21d40587b92fa6a6c6e3c1bdbf87d75511db5672f9c93175574b3a00df1758"
 dependencies = [
+ "ahash",
  "compiler_builtins",
  "rustc-std-workspace-alloc",
  "rustc-std-workspace-core",
@@ -2535,6 +2536,18 @@ dependencies = [
  "crc32fast",
  "flate2",
  "hashbrown 0.11.2",
+ "indexmap",
+ "memchr",
+]
+
+[[package]]
+name = "object"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21158b2c33aa6d4561f1c0a6ea283ca92bc54802a93b263e910746d679a7eb53"
+dependencies = [
+ "crc32fast",
+ "hashbrown 0.12.0",
  "indexmap",
  "memchr",
 ]
@@ -3664,7 +3677,7 @@ dependencies = [
  "itertools",
  "jobserver",
  "libc",
- "object 0.28.4",
+ "object 0.29.0",
  "pathdiff",
  "regex",
  "rustc_apfloat",

--- a/compiler/rustc_codegen_ssa/Cargo.toml
+++ b/compiler/rustc_codegen_ssa/Cargo.toml
@@ -41,6 +41,6 @@ rustc_target = { path = "../rustc_target" }
 rustc_session = { path = "../rustc_session" }
 
 [dependencies.object]
-version = "0.28.4"
+version = "0.29.0"
 default-features = false
 features = ["read_core", "elf", "macho", "pe", "unaligned", "archive", "write"]

--- a/compiler/rustc_codegen_ssa/src/back/metadata.rs
+++ b/compiler/rustc_codegen_ssa/src/back/metadata.rs
@@ -171,7 +171,15 @@ pub(crate) fn create_object_file(sess: &Session) -> Option<write::Object<'static
         }
         _ => 0,
     };
-    file.flags = FileFlags::Elf { e_flags };
+    // adapted from LLVM's `MCELFObjectTargetWriter::getOSABI`
+    let os_abi = match sess.target.options.os.as_ref() {
+        "hermit" => elf::ELFOSABI_STANDALONE,
+        "freebsd" => elf::ELFOSABI_FREEBSD,
+        "solaris" => elf::ELFOSABI_SOLARIS,
+        _ => elf::ELFOSABI_NONE,
+    };
+    let abi_version = 0;
+    file.flags = FileFlags::Elf { os_abi, abi_version, e_flags };
     Some(file)
 }
 

--- a/compiler/rustc_codegen_ssa/src/back/metadata.rs
+++ b/compiler/rustc_codegen_ssa/src/back/metadata.rs
@@ -130,7 +130,7 @@ pub(crate) fn create_object_file(sess: &Session) -> Option<write::Object<'static
     };
 
     let mut file = write::Object::new(binary_format, architecture, endianness);
-    match architecture {
+    let e_flags = match architecture {
         Architecture::Mips => {
             let arch = match sess.target.options.cpu.as_ref() {
                 "mips1" => elf::EF_MIPS_ARCH_1,
@@ -149,7 +149,7 @@ pub(crate) fn create_object_file(sess: &Session) -> Option<write::Object<'static
             if sess.target.options.cpu.contains("r6") {
                 e_flags |= elf::EF_MIPS_NAN2008;
             }
-            file.flags = FileFlags::Elf { e_flags };
+            e_flags
         }
         Architecture::Mips64 => {
             // copied from `mips64el-linux-gnuabi64-gcc foo.c -c`
@@ -160,17 +160,18 @@ pub(crate) fn create_object_file(sess: &Session) -> Option<write::Object<'static
                 } else {
                     elf::EF_MIPS_ARCH_64R2
                 };
-            file.flags = FileFlags::Elf { e_flags };
+            e_flags
         }
         Architecture::Riscv64 if sess.target.options.features.contains("+d") => {
             // copied from `riscv64-linux-gnu-gcc foo.c -c`, note though
             // that the `+d` target feature represents whether the double
             // float abi is enabled.
             let e_flags = elf::EF_RISCV_RVC | elf::EF_RISCV_FLOAT_ABI_DOUBLE;
-            file.flags = FileFlags::Elf { e_flags };
+            e_flags
         }
-        _ => {}
+        _ => 0,
     };
+    file.flags = FileFlags::Elf { e_flags };
     Some(file)
 }
 


### PR DESCRIPTION
Closes https://github.com/rust-lang/rust/issues/97535.

This depends on
* https://github.com/gimli-rs/object/pull/438

This adapts LLVM's behavior of [`MCELFObjectTargetWriter::getOSABI`](https://github.com/llvm/llvm-project/blob/8c8a2679a20f621994fa904bcfc68775e7345edc/llvm/include/llvm/MC/MCELFObjectWriter.h#L72-L86).