### PR TITLE
don't use a `span_note` for ignored impls

### DIFF
--- a/compiler/rustc_passes/src/dead.rs
+++ b/compiler/rustc_passes/src/dead.rs
@@ -722,11 +722,7 @@ impl<'tcx> DeadVisitor<'tcx> {
                         traits_str,
                         is_are
                     );
-                    let multispan = ign_traits
-                        .iter()
-                        .map(|(_, impl_id)| self.tcx.def_span(*impl_id))
-                        .collect::<Vec<_>>();
-                    err.span_note(multispan, &msg);
+                    err.note(&msg);
                 }
                 err.emit();
             });

--- a/src/test/ui/derive-uninhabited-enum-38885.stderr
+++ b/src/test/ui/derive-uninhabited-enum-38885.stderr
@@ -5,12 +5,7 @@ LL |     Void(Void),
    |     ^^^^^^^^^^
    |
    = note: `-W dead-code` implied by `-W unused`
-note: `Foo` has a derived impl for the trait `Debug`, but this is intentionally ignored during dead code analysis
-  --> $DIR/derive-uninhabited-enum-38885.rs:10:10
-   |
-LL | #[derive(Debug)]
-   |          ^^^^^
-   = note: this warning originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: `Foo` has a derived impl for the trait `Debug`, but this is intentionally ignored during dead code analysis
 
 warning: 1 warning emitted
 

--- a/src/test/ui/derives/clone-debug-dead-code.stderr
+++ b/src/test/ui/derives/clone-debug-dead-code.stderr
@@ -16,12 +16,7 @@ error: field is never read: `f`
 LL | struct B { f: () }
    |            ^^^^^
    |
-note: `B` has a derived impl for the trait `Clone`, but this is intentionally ignored during dead code analysis
-  --> $DIR/clone-debug-dead-code.rs:9:10
-   |
-LL | #[derive(Clone)]
-   |          ^^^^^
-   = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: `B` has a derived impl for the trait `Clone`, but this is intentionally ignored during dead code analysis
 
 error: field is never read: `f`
   --> $DIR/clone-debug-dead-code.rs:14:12
@@ -29,12 +24,7 @@ error: field is never read: `f`
 LL | struct C { f: () }
    |            ^^^^^
    |
-note: `C` has a derived impl for the trait `Debug`, but this is intentionally ignored during dead code analysis
-  --> $DIR/clone-debug-dead-code.rs:13:10
-   |
-LL | #[derive(Debug)]
-   |          ^^^^^
-   = note: this error originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: `C` has a derived impl for the trait `Debug`, but this is intentionally ignored during dead code analysis
 
 error: field is never read: `f`
   --> $DIR/clone-debug-dead-code.rs:18:12
@@ -42,12 +32,7 @@ error: field is never read: `f`
 LL | struct D { f: () }
    |            ^^^^^
    |
-note: `D` has derived impls for the traits `Clone` and `Debug`, but these are intentionally ignored during dead code analysis
-  --> $DIR/clone-debug-dead-code.rs:17:10
-   |
-LL | #[derive(Debug,Clone)]
-   |          ^^^^^ ^^^^^
-   = note: this error originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: `D` has derived impls for the traits `Clone` and `Debug`, but these are intentionally ignored during dead code analysis
 
 error: field is never read: `f`
   --> $DIR/clone-debug-dead-code.rs:21:12

--- a/src/test/ui/lint/dead-code/unused-variant.stderr
+++ b/src/test/ui/lint/dead-code/unused-variant.stderr
@@ -9,12 +9,7 @@ note: the lint level is defined here
    |
 LL | #![deny(dead_code)]
    |         ^^^^^^^^^
-note: `Enum` has a derived impl for the trait `Clone`, but this is intentionally ignored during dead code analysis
-  --> $DIR/unused-variant.rs:3:10
-   |
-LL | #[derive(Clone)]
-   |          ^^^^^
-   = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: `Enum` has a derived impl for the trait `Clone`, but this is intentionally ignored during dead code analysis
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Searching for the `derive` isn't too difficult as it's right above the field definition.

By using a span these errors are a lot more verbose than they should be, which is especially annoying as one can end up with a lot of `dead_code` warnings.