### PR TITLE
make cenum_impl_drop_cast deny-by-default

### DIFF
--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -2650,10 +2650,11 @@ declare_lint! {
     /// [issue #73333]: https://github.com/rust-lang/rust/issues/73333
     /// [`Copy`]: https://doc.rust-lang.org/std/marker/trait.Copy.html
     pub CENUM_IMPL_DROP_CAST,
-    Warn,
+    Deny,
     "a C-like enum implementing Drop is cast",
     @future_incompatible = FutureIncompatibleInfo {
         reference: "issue #73333 <https://github.com/rust-lang/rust/issues/73333>",
+        reason: FutureIncompatibilityReason::FutureReleaseErrorReportNow,
     };
 }
 

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -1154,7 +1154,6 @@ declare_lint! {
     /// ### Example
     ///
     /// ```compile_fail
-    /// #![deny(unaligned_references)]
     /// #[repr(packed)]
     /// pub struct Foo {
     ///     field1: u64,
@@ -2614,7 +2613,7 @@ declare_lint! {
     ///
     /// ### Example
     ///
-    /// ```rust
+    /// ```compile_fail
     /// # #![allow(unused)]
     /// enum E {
     ///     A,

--- a/src/test/run-pass-valgrind/cast-enum-with-dtor.rs
+++ b/src/test/run-pass-valgrind/cast-enum-with-dtor.rs
@@ -1,4 +1,4 @@
-#![allow(dead_code)]
+#![allow(dead_code, cenum_impl_drop_cast)]
 
 // check dtor calling order when casting enums.
 

--- a/src/test/ui/cenum_impl_drop_cast.stderr
+++ b/src/test/ui/cenum_impl_drop_cast.stderr
@@ -14,3 +14,18 @@ LL | #![deny(cenum_impl_drop_cast)]
 
 error: aborting due to previous error
 
+Future incompatibility report: Future breakage diagnostic:
+error: cannot cast enum `E` into integer `u32` because it implements `Drop`
+  --> $DIR/cenum_impl_drop_cast.rs:15:13
+   |
+LL |     let i = e as u32;
+   |             ^^^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/cenum_impl_drop_cast.rs:1:9
+   |
+LL | #![deny(cenum_impl_drop_cast)]
+   |         ^^^^^^^^^^^^^^^^^^^^
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #73333 <https://github.com/rust-lang/rust/issues/73333>
+


### PR DESCRIPTION
Also make it show up as future breakage diagnostic.

In https://github.com/rust-lang/rust/pull/96862 we are proposing to change behavior of those drops *again*, so this looks like a good opportunity to increase our pressure on getting them out of the ecosystem. Looking at the [tracking issue](https://github.com/rust-lang/rust/issues/73333), so far nobody spoke up in favor of this (accidental) feature.

Cc https://github.com/rust-lang/rust/issues/73333 @oli-obk 