### PR TITLE
Use get_many_mut to reduce the cost of setting up check cfg values

### DIFF
--- a/compiler/rustc_session/src/lib.rs
+++ b/compiler/rustc_session/src/lib.rs
@@ -6,6 +6,7 @@
 #![feature(once_cell)]
 #![feature(option_get_or_insert_default)]
 #![feature(rustc_attrs)]
+#![cfg_attr(not(bootstrap), feature(map_many_mut))]
 #![recursion_limit = "256"]
 #![allow(rustc::potential_query_instability)]
 


### PR DESCRIPTION
This PR use the newly added [`get_many_mut`](https://github.com/rust-lang/rust/issues/97601) function in [`HashMap`](https://doc.rust-lang.org/nightly/std/collections/hash_map/struct.HashMap.html#method.get_many_mut) to reduce the cost of setting up the initial check cfg values.

cc @petrochenkov