### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/compiler/rustc_passes/src/dead.rs
+++ b/compiler/rustc_passes/src/dead.rs
@@ -722,11 +722,7 @@ impl<'tcx> DeadVisitor<'tcx> {
                         traits_str,
                         is_are
                     );
-                    let multispan = ign_traits
-                        .iter()
-                        .map(|(_, impl_id)| self.tcx.def_span(*impl_id))
-                        .collect::<Vec<_>>();
-                    err.span_note(multispan, &msg);
+                    err.note(&msg);
                 }
                 err.emit();
             });

--- a/compiler/rustc_typeck/src/coherence/mod.rs
+++ b/compiler/rustc_typeck/src/coherence/mod.rs
@@ -57,7 +57,7 @@ fn enforce_trait_manually_implementable(
             E0322,
             "explicit impls for the `Pointee` trait are not permitted"
         )
-        .span_label(span, "impl of 'Pointee' not allowed")
+        .span_label(span, "impl of `Pointee` not allowed")
         .emit();
         return;
     }
@@ -70,7 +70,7 @@ fn enforce_trait_manually_implementable(
             E0322,
             "explicit impls for the `DiscriminantKind` trait are not permitted"
         )
-        .span_label(span, "impl of 'DiscriminantKind' not allowed")
+        .span_label(span, "impl of `DiscriminantKind` not allowed")
         .emit();
         return;
     }
@@ -83,7 +83,7 @@ fn enforce_trait_manually_implementable(
             E0322,
             "explicit impls for the `Sized` trait are not permitted"
         )
-        .span_label(span, "impl of 'Sized' not allowed")
+        .span_label(span, "impl of `Sized` not allowed")
         .emit();
         return;
     }

--- a/library/alloc/src/boxed.rs
+++ b/library/alloc/src/boxed.rs
@@ -266,8 +266,13 @@ impl<T> Box<T> {
         Self::new_zeroed_in(Global)
     }
 
-    /// Constructs a new `Pin<Box<T>>`. If `T` does not implement `Unpin`, then
+    /// Constructs a new `Pin<Box<T>>`. If `T` does not implement [`Unpin`], then
     /// `x` will be pinned in memory and unable to be moved.
+    ///
+    /// Constructing and pinning of the `Box` can also be done in two steps: `Box::pin(x)`
+    /// does the same as <code>[Box::into_pin]\([Box::new]\(x))</code>. Consider using
+    /// [`into_pin`](Box::into_pin) if you already have a `Box<T>`, or if you want to
+    /// construct a (pinned) `Box` in a different way than with [`Box::new`].
     #[cfg(not(no_global_oom_handling))]
     #[stable(feature = "pin", since = "1.33.0")]
     #[must_use]
@@ -553,8 +558,13 @@ impl<T, A: Allocator> Box<T, A> {
         unsafe { Ok(Box::from_raw_in(ptr.as_ptr(), alloc)) }
     }
 
-    /// Constructs a new `Pin<Box<T, A>>`. If `T` does not implement `Unpin`, then
+    /// Constructs a new `Pin<Box<T, A>>`. If `T` does not implement [`Unpin`], then
     /// `x` will be pinned in memory and unable to be moved.
+    ///
+    /// Constructing and pinning of the `Box` can also be done in two steps: `Box::pin_in(x, alloc)`
+    /// does the same as <code>[Box::into_pin]\([Box::new_in]\(x, alloc))</code>. Consider using
+    /// [`into_pin`](Box::into_pin) if you already have a `Box<T, A>`, or if you want to
+    /// construct a (pinned) `Box` in a different way than with [`Box::new_in`].
     #[cfg(not(no_global_oom_handling))]
     #[unstable(feature = "allocator_api", issue = "32838")]
     #[rustc_const_unstable(feature = "const_box", issue = "92521")]
@@ -1170,11 +1180,17 @@ impl<T: ?Sized, A: Allocator> Box<T, A> {
         unsafe { &mut *mem::ManuallyDrop::new(b).0.as_ptr() }
     }
 
-    /// Converts a `Box<T>` into a `Pin<Box<T>>`
+    /// Converts a `Box<T>` into a `Pin<Box<T>>`. If `T` does not implement [`Unpin`], then
+    /// `*boxed` will be pinned in memory and unable to be moved.
     ///
     /// This conversion does not allocate on the heap and happens in place.
     ///
     /// This is also available via [`From`].
+    ///
+    /// Constructing and pinning a `Box` with <code>Box::into_pin([Box::new]\(x))</code>
+    /// can also be written more concisely using <code>[Box::pin]\(x)</code>.
+    /// This `into_pin` method is useful if you already have a `Box<T>`, or you are
+    /// constructing a (pinned) `Box` in a different way than with [`Box::new`].
     ///
     /// # Notes
     ///
@@ -1437,9 +1453,17 @@ impl<T: ?Sized, A: Allocator> const From<Box<T, A>> for Pin<Box<T, A>>
 where
     A: 'static,
 {
-    /// Converts a `Box<T>` into a `Pin<Box<T>>`
+    /// Converts a `Box<T>` into a `Pin<Box<T>>`. If `T` does not implement [`Unpin`], then
+    /// `*boxed` will be pinned in memory and unable to be moved.
     ///
     /// This conversion does not allocate on the heap and happens in place.
+    ///
+    /// This is also available via [`Box::into_pin`].
+    ///
+    /// Constructing and pinning a `Box` with <code><Pin<Box\<T>>>::from([Box::new]\(x))</code>
+    /// can also be written more concisely using <code>[Box::pin]\(x)</code>.
+    /// This `From` implementation is useful if you already have a `Box<T>`, or you are
+    /// constructing a (pinned) `Box` in a different way than with [`Box::new`].
     fn from(boxed: Box<T, A>) -> Self {
         Box::into_pin(boxed)
     }

--- a/library/std/src/sys/unix/process/process_unix.rs
+++ b/library/std/src/sys/unix/process/process_unix.rs
@@ -696,41 +696,46 @@ impl From<c_int> for ExitStatus {
 }
 
 /// Convert a signal number to a readable, searchable name.
-fn signal_string(signal: i32) -> String {
-    (match signal {
-        libc::SIGHUP => "SIGHUP",
-        libc::SIGINT => "SIGINT",
-        libc::SIGQUIT => "SIGQUIT",
-        libc::SIGILL => "SIGILL",
-        libc::SIGTRAP => "SIGTRAP",
-        libc::SIGABRT => "SIGABRT",
-        libc::SIGBUS => "SIGBUS",
-        libc::SIGFPE => "SIGFPE",
-        libc::SIGKILL => "SIGKILL",
-        libc::SIGUSR1 => "SIGUSR1",
-        libc::SIGSEGV => "SIGSEGV",
-        libc::SIGUSR2 => "SIGUSR2",
-        libc::SIGPIPE => "SIGPIPE",
-        libc::SIGALRM => "SIGALRM",
-        libc::SIGTERM => "SIGTERM",
-        libc::SIGCHLD => "SIGCHLD",
-        libc::SIGCONT => "SIGCONT",
-        libc::SIGSTOP => "SIGSTOP",
-        libc::SIGTSTP => "SIGTSTP",
-        libc::SIGTTIN => "SIGTTIN",
-        libc::SIGTTOU => "SIGTTOU",
-        libc::SIGURG => "SIGURG",
-        libc::SIGXCPU => "SIGXCPU",
-        libc::SIGXFSZ => "SIGXFSZ",
-        libc::SIGVTALRM => "SIGVTALRM",
-        libc::SIGPROF => "SIGPROF",
-        libc::SIGWINCH => "SIGWINCH",
-        libc::SIGIO => "SIGIO",
-        libc::SIGSYS => "SIGSYS",
+///
+/// This string should be displayed right after the signal number.
+/// If a signal is unrecognized, it returns the empty string, so that
+/// you just get the number like "0". If it is recognized, you'll get
+/// something like "9 (SIGKILL)".
+fn signal_string(signal: i32) -> &'static str {
+    match signal {
+        libc::SIGHUP => " (SIGHUP)",
+        libc::SIGINT => " (SIGINT)",
+        libc::SIGQUIT => " (SIGQUIT)",
+        libc::SIGILL => " (SIGILL)",
+        libc::SIGTRAP => " (SIGTRAP)",
+        libc::SIGABRT => " (SIGABRT)",
+        libc::SIGBUS => " (SIGBUS)",
+        libc::SIGFPE => " (SIGFPE)",
+        libc::SIGKILL => " (SIGKILL)",
+        libc::SIGUSR1 => " (SIGUSR1)",
+        libc::SIGSEGV => " (SIGSEGV)",
+        libc::SIGUSR2 => " (SIGUSR2)",
+        libc::SIGPIPE => " (SIGPIPE)",
+        libc::SIGALRM => " (SIGALRM)",
+        libc::SIGTERM => " (SIGTERM)",
+        libc::SIGCHLD => " (SIGCHLD)",
+        libc::SIGCONT => " (SIGCONT)",
+        libc::SIGSTOP => " (SIGSTOP)",
+        libc::SIGTSTP => " (SIGTSTP)",
+        libc::SIGTTIN => " (SIGTTIN)",
+        libc::SIGTTOU => " (SIGTTOU)",
+        libc::SIGURG => " (SIGURG)",
+        libc::SIGXCPU => " (SIGXCPU)",
+        libc::SIGXFSZ => " (SIGXFSZ)",
+        libc::SIGVTALRM => " (SIGVTALRM)",
+        libc::SIGPROF => " (SIGPROF)",
+        libc::SIGWINCH => " (SIGWINCH)",
+        libc::SIGIO => " (SIGIO)",
+        libc::SIGSYS => " (SIGSYS)",
         #[cfg(target_os = "linux")]
-        libc::SIGSTKFLT => "SIGSTKFLT",
+        libc::SIGSTKFLT => " (SIGSTKFLT)",
         #[cfg(target_os = "linux")]
-        libc::SIGPWR => "SIGPWR",
+        libc::SIGPWR => " (SIGPWR)",
         #[cfg(any(
             target_os = "macos",
             target_os = "ios",
@@ -740,7 +745,7 @@ fn signal_string(signal: i32) -> String {
             target_os = "openbsd",
             target_os = "dragonfly"
         ))]
-        libc::SIGEMT => "SIGEMT",
+        libc::SIGEMT => " (SIGEMT)",
         #[cfg(any(
             target_os = "macos",
             target_os = "ios",
@@ -750,10 +755,9 @@ fn signal_string(signal: i32) -> String {
             target_os = "openbsd",
             target_os = "dragonfly"
         ))]
-        libc::SIGINFO => "SIGINFO",
-        _ => return format!("{signal}"),
-    })
-    .to_string()
+        libc::SIGINFO => " (SIGINFO)",
+        _ => "",
+    }
 }
 
 impl fmt::Display for ExitStatus {
@@ -761,15 +765,15 @@ impl fmt::Display for ExitStatus {
         if let Some(code) = self.code() {
             write!(f, "exit status: {code}")
         } else if let Some(signal) = self.signal() {
-            let signal = signal_string(signal);
+            let signal_string = signal_string(signal);
             if self.core_dumped() {
-                write!(f, "signal: {signal} (core dumped)")
+                write!(f, "signal: {signal}{signal_string} (core dumped)")
             } else {
-                write!(f, "signal: {signal}")
+                write!(f, "signal: {signal}{signal_string}")
             }
         } else if let Some(signal) = self.stopped_signal() {
-            let signal = signal_string(signal);
-            write!(f, "stopped (not terminated) by signal: {signal}")
+            let signal_string = signal_string(signal);
+            write!(f, "stopped (not terminated) by signal: {signal}{signal_string}")
         } else if self.continued() {
             write!(f, "continued (WIFCONTINUED)")
         } else {

--- a/library/std/src/sys/unix/process/process_unix.rs
+++ b/library/std/src/sys/unix/process/process_unix.rs
@@ -695,17 +695,80 @@ impl From<c_int> for ExitStatus {
     }
 }
 
+/// Convert a signal number to a readable, searchable name.
+fn signal_string(signal: i32) -> String {
+    (match signal {
+        libc::SIGHUP => "SIGHUP",
+        libc::SIGINT => "SIGINT",
+        libc::SIGQUIT => "SIGQUIT",
+        libc::SIGILL => "SIGILL",
+        libc::SIGTRAP => "SIGTRAP",
+        libc::SIGABRT => "SIGABRT",
+        libc::SIGBUS => "SIGBUS",
+        libc::SIGFPE => "SIGFPE",
+        libc::SIGKILL => "SIGKILL",
+        libc::SIGUSR1 => "SIGUSR1",
+        libc::SIGSEGV => "SIGSEGV",
+        libc::SIGUSR2 => "SIGUSR2",
+        libc::SIGPIPE => "SIGPIPE",
+        libc::SIGALRM => "SIGALRM",
+        libc::SIGTERM => "SIGTERM",
+        libc::SIGCHLD => "SIGCHLD",
+        libc::SIGCONT => "SIGCONT",
+        libc::SIGSTOP => "SIGSTOP",
+        libc::SIGTSTP => "SIGTSTP",
+        libc::SIGTTIN => "SIGTTIN",
+        libc::SIGTTOU => "SIGTTOU",
+        libc::SIGURG => "SIGURG",
+        libc::SIGXCPU => "SIGXCPU",
+        libc::SIGXFSZ => "SIGXFSZ",
+        libc::SIGVTALRM => "SIGVTALRM",
+        libc::SIGPROF => "SIGPROF",
+        libc::SIGWINCH => "SIGWINCH",
+        libc::SIGIO => "SIGIO",
+        libc::SIGSYS => "SIGSYS",
+        #[cfg(target_os = "linux")]
+        libc::SIGSTKFLT => "SIGSTKFLT",
+        #[cfg(target_os = "linux")]
+        libc::SIGPWR => "SIGPWR",
+        #[cfg(any(
+            target_os = "macos",
+            target_os = "ios",
+            target_os = "tvos",
+            target_os = "freebsd",
+            target_os = "netbsd",
+            target_os = "openbsd",
+            target_os = "dragonfly"
+        ))]
+        libc::SIGEMT => "SIGEMT",
+        #[cfg(any(
+            target_os = "macos",
+            target_os = "ios",
+            target_os = "tvos",
+            target_os = "freebsd",
+            target_os = "netbsd",
+            target_os = "openbsd",
+            target_os = "dragonfly"
+        ))]
+        libc::SIGINFO => "SIGINFO",
+        _ => return format!("{signal}"),
+    })
+    .to_string()
+}
+
 impl fmt::Display for ExitStatus {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if let Some(code) = self.code() {
             write!(f, "exit status: {code}")
         } else if let Some(signal) = self.signal() {
+            let signal = signal_string(signal);
             if self.core_dumped() {
                 write!(f, "signal: {signal} (core dumped)")
             } else {
                 write!(f, "signal: {signal}")
             }
         } else if let Some(signal) = self.stopped_signal() {
+            let signal = signal_string(signal);
             write!(f, "stopped (not terminated) by signal: {signal}")
         } else if self.continued() {
             write!(f, "continued (WIFCONTINUED)")

--- a/library/std/src/sys/unix/process/process_unix/tests.rs
+++ b/library/std/src/sys/unix/process/process_unix/tests.rs
@@ -14,8 +14,8 @@ fn exitstatus_display_tests() {
 
     let t = |v, s| assert_eq!(s, format!("{}", <ExitStatus as ExitStatusExt>::from_raw(v)));
 
-    t(0x0000f, "signal: 15");
-    t(0x0008b, "signal: 11 (core dumped)");
+    t(0x0000f, "signal: SIGTERM");
+    t(0x0008b, "signal: SIGSEGV (core dumped)");
     t(0x00000, "exit status: 0");
     t(0x0ff00, "exit status: 255");
 
@@ -24,7 +24,7 @@ fn exitstatus_display_tests() {
     // The purpose of this test is to test our string formatting, not our understanding of the wait
     // status magic numbers.  So restrict these to Linux.
     if cfg!(target_os = "linux") {
-        t(0x0137f, "stopped (not terminated) by signal: 19");
+        t(0x0137f, "stopped (not terminated) by signal: SIGSTOP");
         t(0x0ffff, "continued (WIFCONTINUED)");
     }
 

--- a/library/std/src/sys/unix/process/process_unix/tests.rs
+++ b/library/std/src/sys/unix/process/process_unix/tests.rs
@@ -14,8 +14,8 @@ fn exitstatus_display_tests() {
 
     let t = |v, s| assert_eq!(s, format!("{}", <ExitStatus as ExitStatusExt>::from_raw(v)));
 
-    t(0x0000f, "signal: SIGTERM");
-    t(0x0008b, "signal: SIGSEGV (core dumped)");
+    t(0x0000f, "signal: 15 (SIGTERM)");
+    t(0x0008b, "signal: 11 (SIGSEGV) (core dumped)");
     t(0x00000, "exit status: 0");
     t(0x0ff00, "exit status: 255");
 
@@ -24,7 +24,7 @@ fn exitstatus_display_tests() {
     // The purpose of this test is to test our string formatting, not our understanding of the wait
     // status magic numbers.  So restrict these to Linux.
     if cfg!(target_os = "linux") {
-        t(0x0137f, "stopped (not terminated) by signal: SIGSTOP");
+        t(0x0137f, "stopped (not terminated) by signal: 19 (SIGSTOP)");
         t(0x0ffff, "continued (WIFCONTINUED)");
     }
 

--- a/src/test/rustdoc/nested-modules.rs
+++ b/src/test/rustdoc/nested-modules.rs
@@ -1,0 +1,42 @@
+#![crate_name = "aCrate"]
+
+mod a_module {
+    pub fn private_function() {}
+
+    pub use a_module::private_function as other_private_function;
+
+    pub mod a_nested_module {
+        // @has aCrate/a_nested_module/index.html '//a[@href="fn.a_nested_public_function.html"]' 'a_nested_public_function'
+        // @has aCrate/a_nested_module/fn.a_nested_public_function.html 'pub fn a_nested_public_function()'
+        pub fn a_nested_public_function() {}
+
+        // @has aCrate/a_nested_module/index.html '//a[@href="fn.another_nested_public_function.html"]' 'another_nested_public_function'
+        // @has aCrate/a_nested_module/fn.another_nested_public_function.html 'pub fn another_nested_public_function()'
+        pub use a_nested_module::a_nested_public_function as another_nested_public_function;
+    }
+
+    // @!has aCrate/a_nested_module/index.html 'yet_another_nested_public_function'
+    pub use a_nested_module::a_nested_public_function as yet_another_nested_public_function;
+
+    // @!has aCrate/a_nested_module/index.html 'one_last_nested_public_function'
+    pub use a_nested_module::another_nested_public_function as one_last_nested_public_function;
+}
+
+// @!has aCrate/index.html 'a_module'
+// @has aCrate/index.html '//a[@href="a_nested_module/index.html"]' 'a_nested_module'
+pub use a_module::a_nested_module;
+
+// @has aCrate/index.html '//a[@href="fn.a_nested_public_function.html"]' 'a_nested_public_function'
+// @has aCrate/index.html '//a[@href="fn.another_nested_public_function.html"]' 'another_nested_public_function'
+// @has aCrate/index.html '//a[@href="fn.yet_another_nested_public_function.html"]' 'yet_another_nested_public_function'
+// @has aCrate/index.html '//a[@href="fn.one_last_nested_public_function.html"]' 'one_last_nested_public_function'
+pub use a_module::{
+    a_nested_module::{a_nested_public_function, another_nested_public_function},
+    one_last_nested_public_function, yet_another_nested_public_function,
+};
+
+// @has aCrate/index.html '//a[@href="fn.private_function.html"]' 'private_function'
+// @!has aCrate/fn.private_function.html 'a_module'
+// @has aCrate/index.html '//a[@href="fn.other_private_function.html"]' 'other_private_function'
+// @!has aCrate/fn.other_private_function.html 'a_module'
+pub use a_module::{other_private_function, private_function};

--- a/src/test/ui/coherence/coherence-impls-sized.stderr
+++ b/src/test/ui/coherence/coherence-impls-sized.stderr
@@ -35,37 +35,37 @@ error[E0322]: explicit impls for the `Sized` trait are not permitted
   --> $DIR/coherence-impls-sized.rs:14:1
    |
 LL | impl Sized for TestE {}
-   | ^^^^^^^^^^^^^^^^^^^^ impl of 'Sized' not allowed
+   | ^^^^^^^^^^^^^^^^^^^^ impl of `Sized` not allowed
 
 error[E0322]: explicit impls for the `Sized` trait are not permitted
   --> $DIR/coherence-impls-sized.rs:17:1
    |
 LL | impl Sized for MyType {}
-   | ^^^^^^^^^^^^^^^^^^^^^ impl of 'Sized' not allowed
+   | ^^^^^^^^^^^^^^^^^^^^^ impl of `Sized` not allowed
 
 error[E0322]: explicit impls for the `Sized` trait are not permitted
   --> $DIR/coherence-impls-sized.rs:20:1
    |
 LL | impl Sized for (MyType, MyType) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl of 'Sized' not allowed
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl of `Sized` not allowed
 
 error[E0322]: explicit impls for the `Sized` trait are not permitted
   --> $DIR/coherence-impls-sized.rs:24:1
    |
 LL | impl Sized for &'static NotSync {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl of 'Sized' not allowed
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl of `Sized` not allowed
 
 error[E0322]: explicit impls for the `Sized` trait are not permitted
   --> $DIR/coherence-impls-sized.rs:27:1
    |
 LL | impl Sized for [MyType] {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^ impl of 'Sized' not allowed
+   | ^^^^^^^^^^^^^^^^^^^^^^^ impl of `Sized` not allowed
 
 error[E0322]: explicit impls for the `Sized` trait are not permitted
   --> $DIR/coherence-impls-sized.rs:31:1
    |
 LL | impl Sized for &'static [NotSync] {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl of 'Sized' not allowed
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl of `Sized` not allowed
 
 error: aborting due to 9 previous errors
 

--- a/src/test/ui/derive-uninhabited-enum-38885.stderr
+++ b/src/test/ui/derive-uninhabited-enum-38885.stderr
@@ -5,12 +5,7 @@ LL |     Void(Void),
    |     ^^^^^^^^^^
    |
    = note: `-W dead-code` implied by `-W unused`
-note: `Foo` has a derived impl for the trait `Debug`, but this is intentionally ignored during dead code analysis
-  --> $DIR/derive-uninhabited-enum-38885.rs:10:10
-   |
-LL | #[derive(Debug)]
-   |          ^^^^^
-   = note: this warning originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: `Foo` has a derived impl for the trait `Debug`, but this is intentionally ignored during dead code analysis
 
 warning: 1 warning emitted
 

--- a/src/test/ui/derives/clone-debug-dead-code.stderr
+++ b/src/test/ui/derives/clone-debug-dead-code.stderr
@@ -16,12 +16,7 @@ error: field is never read: `f`
 LL | struct B { f: () }
    |            ^^^^^
    |
-note: `B` has a derived impl for the trait `Clone`, but this is intentionally ignored during dead code analysis
-  --> $DIR/clone-debug-dead-code.rs:9:10
-   |
-LL | #[derive(Clone)]
-   |          ^^^^^
-   = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: `B` has a derived impl for the trait `Clone`, but this is intentionally ignored during dead code analysis
 
 error: field is never read: `f`
   --> $DIR/clone-debug-dead-code.rs:14:12
@@ -29,12 +24,7 @@ error: field is never read: `f`
 LL | struct C { f: () }
    |            ^^^^^
    |
-note: `C` has a derived impl for the trait `Debug`, but this is intentionally ignored during dead code analysis
-  --> $DIR/clone-debug-dead-code.rs:13:10
-   |
-LL | #[derive(Debug)]
-   |          ^^^^^
-   = note: this error originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: `C` has a derived impl for the trait `Debug`, but this is intentionally ignored during dead code analysis
 
 error: field is never read: `f`
   --> $DIR/clone-debug-dead-code.rs:18:12
@@ -42,12 +32,7 @@ error: field is never read: `f`
 LL | struct D { f: () }
    |            ^^^^^
    |
-note: `D` has derived impls for the traits `Clone` and `Debug`, but these are intentionally ignored during dead code analysis
-  --> $DIR/clone-debug-dead-code.rs:17:10
-   |
-LL | #[derive(Debug,Clone)]
-   |          ^^^^^ ^^^^^
-   = note: this error originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: `D` has derived impls for the traits `Clone` and `Debug`, but these are intentionally ignored during dead code analysis
 
 error: field is never read: `f`
   --> $DIR/clone-debug-dead-code.rs:21:12

--- a/src/test/ui/enum-discriminant/forbidden-discriminant-kind-impl.stderr
+++ b/src/test/ui/enum-discriminant/forbidden-discriminant-kind-impl.stderr
@@ -2,7 +2,7 @@ error[E0322]: explicit impls for the `DiscriminantKind` trait are not permitted
   --> $DIR/forbidden-discriminant-kind-impl.rs:9:1
    |
 LL | impl DiscriminantKind for NewType {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl of 'DiscriminantKind' not allowed
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl of `DiscriminantKind` not allowed
 
 error: aborting due to previous error
 

--- a/src/test/ui/lint/dead-code/unused-variant.stderr
+++ b/src/test/ui/lint/dead-code/unused-variant.stderr
@@ -9,12 +9,7 @@ note: the lint level is defined here
    |
 LL | #![deny(dead_code)]
    |         ^^^^^^^^^
-note: `Enum` has a derived impl for the trait `Clone`, but this is intentionally ignored during dead code analysis
-  --> $DIR/unused-variant.rs:3:10
-   |
-LL | #[derive(Clone)]
-   |          ^^^^^
-   = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: `Enum` has a derived impl for the trait `Clone`, but this is intentionally ignored during dead code analysis
 
 error: aborting due to previous error
 

--- a/src/test/ui/traits/issue-97576.rs
+++ b/src/test/ui/traits/issue-97576.rs
@@ -1,0 +1,13 @@
+struct Foo {
+    bar: String,
+}
+
+impl Foo {
+    pub fn new(bar: impl ToString) -> Self {
+        Self {
+            bar: bar.into(), //~ ERROR the trait bound `String: From<impl ToString>` is not satisfied
+        }
+    }
+}
+
+fn main() {}

--- a/src/test/ui/traits/issue-97576.stderr
+++ b/src/test/ui/traits/issue-97576.stderr
@@ -1,0 +1,11 @@
+error[E0277]: the trait bound `String: From<impl ToString>` is not satisfied
+  --> $DIR/issue-97576.rs:8:22
+   |
+LL |             bar: bar.into(),
+   |                      ^^^^ the trait `From<impl ToString>` is not implemented for `String`
+   |
+   = note: required because of the requirements on the impl of `Into<String>` for `impl ToString`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
Successful merges:

 - #95833 (std: `<ExitStatus as Display>::fmt` name the signal it died from)
 - #97502 (rustdoc: Add more test coverage)
 - #97627 (update explicit impls error msg)
 - #97640 (Fix wrong suggestion for adding where clauses)
 - #97645 (don't use a `span_note` for ignored impls)
 - #97655 (Improve documentation for constructors of pinned `Box`es)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=95833,97502,97627,97640,97645,97655)
<!-- homu-ignore:end -->