### PR TITLE
rustdoc: clean up primitive.slice.html links

### DIFF
--- a/src/etc/htmldocck.py
+++ b/src/etc/htmldocck.py
@@ -423,6 +423,8 @@ def check_snapshot(snapshot_name, actual_tree, normalize_to_text):
     else:
         actual_str = flatten(actual_tree)
 
+    expected_str = expected_str.replace("{{channel}}", channel)
+
     # Conditions:
     #  1. Is --bless
     #  2. Are actual and expected tree different

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -881,11 +881,16 @@ fn fmt_type<'cx>(
                 }
             }
         }
-        clean::Slice(ref t) => {
-            primitive_link(f, PrimitiveType::Slice, "[", cx)?;
-            fmt::Display::fmt(&t.print(cx), f)?;
-            primitive_link(f, PrimitiveType::Slice, "]", cx)
-        }
+        clean::Slice(ref t) => match **t {
+            clean::Generic(name) => {
+                primitive_link(f, PrimitiveType::Slice, &format!("[{name}]"), cx)
+            }
+            _ => {
+                primitive_link(f, PrimitiveType::Slice, "[", cx)?;
+                fmt::Display::fmt(&t.print(cx), f)?;
+                primitive_link(f, PrimitiveType::Slice, "]", cx)
+            }
+        },
         clean::Array(ref t, ref n) => {
             primitive_link(f, PrimitiveType::Array, "[", cx)?;
             fmt::Display::fmt(&t.print(cx), f)?;
@@ -924,23 +929,12 @@ fn fmt_type<'cx>(
                 clean::Slice(ref bt) => {
                     // `BorrowedRef{ ... Slice(T) }` is `&[T]`
                     match **bt {
-                        clean::Generic(_) => {
-                            if f.alternate() {
-                                primitive_link(
-                                    f,
-                                    PrimitiveType::Slice,
-                                    &format!("{}{}{}[{:#}]", amp, lt, m, bt.print(cx)),
-                                    cx,
-                                )
-                            } else {
-                                primitive_link(
-                                    f,
-                                    PrimitiveType::Slice,
-                                    &format!("{}{}{}[{}]", amp, lt, m, bt.print(cx)),
-                                    cx,
-                                )
-                            }
-                        }
+                        clean::Generic(name) => primitive_link(
+                            f,
+                            PrimitiveType::Slice,
+                            &format!("{amp}{lt}{m}[{name}]"),
+                            cx,
+                        ),
                         _ => {
                             primitive_link(
                                 f,

--- a/src/test/rustdoc/slice-links.link_box_generic.html
+++ b/src/test/rustdoc/slice-links.link_box_generic.html
@@ -1,0 +1,1 @@
+<code>pub fn delta&lt;T&gt;() -&gt; <a class="struct" href="struct.MyBox.html" title="struct foo::MyBox">MyBox</a>&lt;<a class="primitive" href="{{channel}}/core/primitive.slice.html">[T]</a>&gt;</code>

--- a/src/test/rustdoc/slice-links.link_box_u32.html
+++ b/src/test/rustdoc/slice-links.link_box_u32.html
@@ -1,0 +1,1 @@
+<code>pub fn gamma() -&gt; <a class="struct" href="struct.MyBox.html" title="struct foo::MyBox">MyBox</a>&lt;<a class="primitive" href="{{channel}}/core/primitive.slice.html">[</a><a class="primitive" href="{{channel}}/core/primitive.u32.html">u32</a><a class="primitive" href="{{channel}}/core/primitive.slice.html">]</a>&gt;</code>

--- a/src/test/rustdoc/slice-links.link_slice_generic.html
+++ b/src/test/rustdoc/slice-links.link_slice_generic.html
@@ -1,0 +1,1 @@
+<code>pub fn beta&lt;T&gt;() -&gt; <a class="primitive" href="{{channel}}/core/primitive.slice.html">&amp;'static [T]</a></code>

--- a/src/test/rustdoc/slice-links.link_slice_u32.html
+++ b/src/test/rustdoc/slice-links.link_slice_u32.html
@@ -1,0 +1,1 @@
+<code>pub fn alpha() -&gt; <a class="primitive" href="{{channel}}/core/primitive.slice.html">&amp;'static [</a><a class="primitive" href="{{channel}}/core/primitive.u32.html">u32</a><a class="primitive" href="{{channel}}/core/primitive.slice.html">]</a></code>

--- a/src/test/rustdoc/slice-links.rs
+++ b/src/test/rustdoc/slice-links.rs
@@ -1,0 +1,28 @@
+#![crate_name = "foo"]
+#![no_std]
+
+pub struct MyBox<T: ?Sized>(*const T);
+
+// @has 'foo/fn.alpha.html'
+// @snapshot link_slice_u32 - '//pre[@class="rust fn"]/code'
+pub fn alpha() -> &'static [u32] {
+    loop {}
+}
+
+// @has 'foo/fn.beta.html'
+// @snapshot link_slice_generic - '//pre[@class="rust fn"]/code'
+pub fn beta<T>() -> &'static [T] {
+    loop {}
+}
+
+// @has 'foo/fn.gamma.html'
+// @snapshot link_box_u32 - '//pre[@class="rust fn"]/code'
+pub fn gamma() -> MyBox<[u32]> {
+    loop {}
+}
+
+// @has 'foo/fn.delta.html'
+// @snapshot link_box_generic - '//pre[@class="rust fn"]/code'
+pub fn delta<T>() -> MyBox<[T]> {
+    loop {}
+}


### PR DESCRIPTION
Before: <a href="https://doc.rust-lang.org/stable/std/boxed/struct.Box.html">Box</a>&lt;<a href="https://doc.rust-lang.org/stable/std/primitive.slice.html">[</a>T<a href="https://doc.rust-lang.org/stable/std/primitive.slice.html">]</a>&gt;

After: <a href="https://doc.rust-lang.org/stable/std/boxed/struct.Box.html">Box</a>&lt;<a href="https://doc.rust-lang.org/stable/std/primitive.slice.html">[T]</a>&gt;