### PR TITLE
Make params be SmallVec as originally was

### DIFF
--- a/compiler/rustc_ast_lowering/src/item.rs
+++ b/compiler/rustc_ast_lowering/src/item.rs
@@ -1374,7 +1374,8 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 .map(|predicate| self.lower_where_predicate(predicate)),
         );
 
-        let mut params: Vec<_> = self.lower_generic_params_mut(&generics.params).collect();
+        let mut params: SmallVec<[hir::GenericParam<'hir>; 4]> =
+            self.lower_generic_params_mut(&generics.params).collect();
         let has_where_clause = !generics.where_clause.predicates.is_empty();
         let where_clause_span = self.lower_span(generics.where_clause.span);
         let span = self.lower_span(generics.span);


### PR DESCRIPTION
r? @cjgillot 
It was originally a [`SmallVec`](https://github.com/rust-lang/rust/pull/97598/files#diff-0a61b538a3cec072c76fecae4635af6a12ec3256860029ac70549c2aa53ab394L1497), I've mistakenly changed it [here](https://github.com/rust-lang/rust/pull/97598/files#diff-0a61b538a3cec072c76fecae4635af6a12ec3256860029ac70549c2aa53ab394R1377) to a `Vec`