### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/compiler/rustc_codegen_cranelift/src/base.rs
+++ b/compiler/rustc_codegen_cranelift/src/base.rs
@@ -608,7 +608,9 @@ fn codegen_stmt<'tcx>(
                     lval.write_cvalue(fx, operand.cast_pointer_to(to_layout));
                 }
                 Rvalue::Cast(
-                    CastKind::Misc | CastKind::PointerExposeAddress,
+                    CastKind::Misc
+                    | CastKind::PointerExposeAddress
+                    | CastKind::PointerFromExposedAddress,
                     ref operand,
                     to_ty,
                 ) => {

--- a/compiler/rustc_codegen_ssa/src/mir/rvalue.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/rvalue.rs
@@ -270,6 +270,9 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                         PointerCast::MutToConstPointer | PointerCast::ArrayToPointer,
                     )
                     | mir::CastKind::Misc
+                    // Since int2ptr can have arbitrary integer types as input (so we have to do
+                    // sign extension and all that), it is currently best handled in the same code
+                    // path as the other integer-to-X casts.
                     | mir::CastKind::PointerFromExposedAddress => {
                         assert!(bx.cx().is_backend_immediate(cast));
                         let ll_t_out = bx.cx().immediate_backend_type(cast);

--- a/compiler/rustc_codegen_ssa/src/mir/rvalue.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/rvalue.rs
@@ -269,7 +269,8 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                     mir::CastKind::Pointer(
                         PointerCast::MutToConstPointer | PointerCast::ArrayToPointer,
                     )
-                    | mir::CastKind::Misc => {
+                    | mir::CastKind::Misc
+                    | mir::CastKind::PointerFromExposedAddress => {
                         assert!(bx.cx().is_backend_immediate(cast));
                         let ll_t_out = bx.cx().immediate_backend_type(cast);
                         if operand.layout.abi.is_uninhabited() {

--- a/compiler/rustc_const_eval/src/interpret/place.rs
+++ b/compiler/rustc_const_eval/src/interpret/place.rs
@@ -869,8 +869,6 @@ where
             Ok(src_val) => {
                 assert!(!src.layout.is_unsized(), "cannot have unsized immediates");
                 // Yay, we got a value that we can write directly.
-                // FIXME: Add a check to make sure that if `src` is indirect,
-                // it does not overlap with `dest`.
                 return self.write_immediate_no_validate(*src_val, dest);
             }
             Err(mplace) => mplace,
@@ -890,7 +888,7 @@ where
         });
         assert_eq!(src.meta, dest.meta, "Can only copy between equally-sized instances");
 
-        self.mem_copy(src.ptr, src.align, dest.ptr, dest.align, size, /*nonoverlapping*/ true)
+        self.mem_copy(src.ptr, src.align, dest.ptr, dest.align, size, /*nonoverlapping*/ false)
     }
 
     /// Copies the data from an operand to a place. The layouts may disagree, but they must

--- a/compiler/rustc_const_eval/src/interpret/step.rs
+++ b/compiler/rustc_const_eval/src/interpret/step.rs
@@ -158,6 +158,8 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
         place: mir::Place<'tcx>,
     ) -> InterpResult<'tcx> {
         let dest = self.eval_place(place)?;
+        // FIXME: ensure some kind of non-aliasing between LHS and RHS?
+        // Also see https://github.com/rust-lang/rust/issues/68364.
 
         use rustc_middle::mir::Rvalue::*;
         match *rvalue {

--- a/compiler/rustc_const_eval/src/transform/promote_consts.rs
+++ b/compiler/rustc_const_eval/src/transform/promote_consts.rs
@@ -504,7 +504,7 @@ impl<'tcx> Validator<'_, 'tcx> {
             // ptr-to-int casts are not possible in consts and thus not promotable
             Rvalue::Cast(CastKind::PointerExposeAddress, _, _) => return Err(Unpromotable),
 
-            // all ohter casts including int-to-ptr casts are fine, they just use the integer value
+            // all other casts including int-to-ptr casts are fine, they just use the integer value
             // at pointer type.
             Rvalue::Cast(_, operand, _) => {
                 self.validate_operand(operand)?;

--- a/compiler/rustc_const_eval/src/transform/promote_consts.rs
+++ b/compiler/rustc_const_eval/src/transform/promote_consts.rs
@@ -504,7 +504,8 @@ impl<'tcx> Validator<'_, 'tcx> {
             // ptr-to-int casts are not possible in consts and thus not promotable
             Rvalue::Cast(CastKind::PointerExposeAddress, _, _) => return Err(Unpromotable),
 
-            // int-to-ptr casts are fine, they just use the integer value at pointer type.
+            // all ohter casts including int-to-ptr casts are fine, they just use the integer value
+            // at pointer type.
             Rvalue::Cast(_, operand, _) => {
                 self.validate_operand(operand)?;
             }

--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -2613,12 +2613,18 @@ impl<'tcx> Rvalue<'tcx> {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, TyEncodable, TyDecodable, Hash, HashStable)]
 pub enum CastKind {
-    Misc,
     /// An exposing pointer to address cast. A cast between a pointer and an integer type, or
     /// between a function pointer and an integer type.
     /// See the docs on `expose_addr` for more details.
     PointerExposeAddress,
+    /// An address-to-pointer cast that picks up an exposed provenance.
+    /// See the docs on `from_exposed_addr` for more details.
+    PointerFromExposedAddress,
+    /// All sorts of pointer-to-pointer casts. Note that reference-to-raw-ptr casts are
+    /// translated into `&raw mut/const *r`, i.e., they are not actually casts.
     Pointer(PointerCast),
+    /// Remaining unclassified casts.
+    Misc,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, TyEncodable, TyDecodable, Hash, HashStable)]

--- a/compiler/rustc_middle/src/ty/diagnostics.rs
+++ b/compiler/rustc_middle/src/ty/diagnostics.rs
@@ -272,7 +272,10 @@ pub fn suggest_constraining_type_params<'a>(
             continue;
         }
 
-        let constraint = constraints.iter().map(|&(c, _)| c).collect::<Vec<_>>().join(" + ");
+        let mut constraint = constraints.iter().map(|&(c, _)| c).collect::<Vec<_>>();
+        constraint.sort();
+        constraint.dedup();
+        let constraint = constraint.join(" + ");
         let mut suggest_restrict = |span, bound_list_non_empty| {
             suggestions.push((
                 span,

--- a/compiler/rustc_mir_build/src/build/expr/as_rvalue.rs
+++ b/compiler/rustc_mir_build/src/build/expr/as_rvalue.rs
@@ -196,6 +196,9 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     (Some(CastTy::Ptr(_) | CastTy::FnPtr), Some(CastTy::Int(_))) => {
                         CastKind::PointerExposeAddress
                     }
+                    (Some(CastTy::Int(_)), Some(CastTy::Ptr(_))) => {
+                        CastKind::PointerFromExposedAddress
+                    }
                     (_, _) => CastKind::Misc,
                 };
                 let source = unpack!(

--- a/library/core/src/array/mod.rs
+++ b/library/core/src/array/mod.rs
@@ -92,7 +92,7 @@ where
 
 /// Converts a reference to `T` into a reference to an array of length 1 (without copying).
 #[stable(feature = "array_from_ref", since = "1.53.0")]
-#[rustc_const_unstable(feature = "const_array_from_ref", issue = "90206")]
+#[rustc_const_stable(feature = "const_array_from_ref_shared", since = "1.63.0")]
 pub const fn from_ref<T>(s: &T) -> &[T; 1] {
     // SAFETY: Converting `&T` to `&[T; 1]` is sound.
     unsafe { &*(s as *const T).cast::<[T; 1]>() }

--- a/library/core/src/slice/raw.rs
+++ b/library/core/src/slice/raw.rs
@@ -144,7 +144,7 @@ pub const unsafe fn from_raw_parts_mut<'a, T>(data: *mut T, len: usize) -> &'a m
 
 /// Converts a reference to T into a slice of length 1 (without copying).
 #[stable(feature = "from_ref", since = "1.28.0")]
-#[rustc_const_unstable(feature = "const_slice_from_ref", issue = "90206")]
+#[rustc_const_stable(feature = "const_slice_from_ref_shared", since = "1.63.0")]
 #[must_use]
 pub const fn from_ref<T>(s: &T) -> &[T] {
     array::from_ref(s)

--- a/src/etc/htmldocck.py
+++ b/src/etc/htmldocck.py
@@ -423,6 +423,8 @@ def check_snapshot(snapshot_name, actual_tree, normalize_to_text):
     else:
         actual_str = flatten(actual_tree)
 
+    expected_str = expected_str.replace("{{channel}}", channel)
+
     # Conditions:
     #  1. Is --bless
     #  2. Are actual and expected tree different

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -881,11 +881,16 @@ fn fmt_type<'cx>(
                 }
             }
         }
-        clean::Slice(ref t) => {
-            primitive_link(f, PrimitiveType::Slice, "[", cx)?;
-            fmt::Display::fmt(&t.print(cx), f)?;
-            primitive_link(f, PrimitiveType::Slice, "]", cx)
-        }
+        clean::Slice(ref t) => match **t {
+            clean::Generic(name) => {
+                primitive_link(f, PrimitiveType::Slice, &format!("[{name}]"), cx)
+            }
+            _ => {
+                primitive_link(f, PrimitiveType::Slice, "[", cx)?;
+                fmt::Display::fmt(&t.print(cx), f)?;
+                primitive_link(f, PrimitiveType::Slice, "]", cx)
+            }
+        },
         clean::Array(ref t, ref n) => {
             primitive_link(f, PrimitiveType::Array, "[", cx)?;
             fmt::Display::fmt(&t.print(cx), f)?;
@@ -924,23 +929,12 @@ fn fmt_type<'cx>(
                 clean::Slice(ref bt) => {
                     // `BorrowedRef{ ... Slice(T) }` is `&[T]`
                     match **bt {
-                        clean::Generic(_) => {
-                            if f.alternate() {
-                                primitive_link(
-                                    f,
-                                    PrimitiveType::Slice,
-                                    &format!("{}{}{}[{:#}]", amp, lt, m, bt.print(cx)),
-                                    cx,
-                                )
-                            } else {
-                                primitive_link(
-                                    f,
-                                    PrimitiveType::Slice,
-                                    &format!("{}{}{}[{}]", amp, lt, m, bt.print(cx)),
-                                    cx,
-                                )
-                            }
-                        }
+                        clean::Generic(name) => primitive_link(
+                            f,
+                            PrimitiveType::Slice,
+                            &format!("{amp}{lt}{m}[{name}]"),
+                            cx,
+                        ),
                         _ => {
                             primitive_link(
                                 f,

--- a/src/test/mir-opt/const_prop/reify_fn_ptr.main.ConstProp.diff
+++ b/src/test/mir-opt/const_prop/reify_fn_ptr.main.ConstProp.diff
@@ -19,7 +19,7 @@
                                            // + literal: Const { ty: fn() {main}, val: Value(Scalar(<ZST>)) }
           _2 = move _3 as usize (PointerExposeAddress); // scope 0 at $DIR/reify_fn_ptr.rs:4:13: 4:26
           StorageDead(_3);                 // scope 0 at $DIR/reify_fn_ptr.rs:4:25: 4:26
-          _1 = move _2 as *const fn() (Misc); // scope 0 at $DIR/reify_fn_ptr.rs:4:13: 4:41
+          _1 = move _2 as *const fn() (PointerFromExposedAddress); // scope 0 at $DIR/reify_fn_ptr.rs:4:13: 4:41
           StorageDead(_2);                 // scope 0 at $DIR/reify_fn_ptr.rs:4:40: 4:41
           StorageDead(_1);                 // scope 0 at $DIR/reify_fn_ptr.rs:4:41: 4:42
           nop;                             // scope 0 at $DIR/reify_fn_ptr.rs:3:11: 5:2

--- a/src/test/rustdoc/slice-links.link_box_generic.html
+++ b/src/test/rustdoc/slice-links.link_box_generic.html
@@ -1,0 +1,1 @@
+<code>pub fn delta&lt;T&gt;() -&gt; <a class="struct" href="struct.MyBox.html" title="struct foo::MyBox">MyBox</a>&lt;<a class="primitive" href="{{channel}}/core/primitive.slice.html">[T]</a>&gt;</code>

--- a/src/test/rustdoc/slice-links.link_box_u32.html
+++ b/src/test/rustdoc/slice-links.link_box_u32.html
@@ -1,0 +1,1 @@
+<code>pub fn gamma() -&gt; <a class="struct" href="struct.MyBox.html" title="struct foo::MyBox">MyBox</a>&lt;<a class="primitive" href="{{channel}}/core/primitive.slice.html">[</a><a class="primitive" href="{{channel}}/core/primitive.u32.html">u32</a><a class="primitive" href="{{channel}}/core/primitive.slice.html">]</a>&gt;</code>

--- a/src/test/rustdoc/slice-links.link_slice_generic.html
+++ b/src/test/rustdoc/slice-links.link_slice_generic.html
@@ -1,0 +1,1 @@
+<code>pub fn beta&lt;T&gt;() -&gt; <a class="primitive" href="{{channel}}/core/primitive.slice.html">&amp;'static [T]</a></code>

--- a/src/test/rustdoc/slice-links.link_slice_u32.html
+++ b/src/test/rustdoc/slice-links.link_slice_u32.html
@@ -1,0 +1,1 @@
+<code>pub fn alpha() -&gt; <a class="primitive" href="{{channel}}/core/primitive.slice.html">&amp;'static [</a><a class="primitive" href="{{channel}}/core/primitive.u32.html">u32</a><a class="primitive" href="{{channel}}/core/primitive.slice.html">]</a></code>

--- a/src/test/rustdoc/slice-links.rs
+++ b/src/test/rustdoc/slice-links.rs
@@ -1,0 +1,28 @@
+#![crate_name = "foo"]
+#![no_std]
+
+pub struct MyBox<T: ?Sized>(*const T);
+
+// @has 'foo/fn.alpha.html'
+// @snapshot link_slice_u32 - '//pre[@class="rust fn"]/code'
+pub fn alpha() -> &'static [u32] {
+    loop {}
+}
+
+// @has 'foo/fn.beta.html'
+// @snapshot link_slice_generic - '//pre[@class="rust fn"]/code'
+pub fn beta<T>() -> &'static [T] {
+    loop {}
+}
+
+// @has 'foo/fn.gamma.html'
+// @snapshot link_box_u32 - '//pre[@class="rust fn"]/code'
+pub fn gamma() -> MyBox<[u32]> {
+    loop {}
+}
+
+// @has 'foo/fn.delta.html'
+// @snapshot link_box_generic - '//pre[@class="rust fn"]/code'
+pub fn delta<T>() -> MyBox<[T]> {
+    loop {}
+}

--- a/src/test/ui/moves/use_of_moved_value_copy_suggestions.fixed
+++ b/src/test/ui/moves/use_of_moved_value_copy_suggestions.fixed
@@ -21,7 +21,7 @@ fn duplicate_tup2<A: Copy, B: Copy>(t: (A, B)) -> ((A, B), (A, B)) {
     (t, t) //~ use of moved value: `t`
 }
 
-fn duplicate_custom<T: Trait + Copy>(t: S<T>) -> (S<T>, S<T>) {
+fn duplicate_custom<T: Copy + Trait>(t: S<T>) -> (S<T>, S<T>) {
     //~^ HELP consider restricting type parameter `T`
     (t, t) //~ use of moved value: `t`
 }
@@ -39,14 +39,14 @@ trait A {}
 trait B {}
 
 // Test where bounds are added with different bound placements
-fn duplicate_custom_1<T: Trait + Copy>(t: S<T>) -> (S<T>, S<T>) where {
+fn duplicate_custom_1<T: Copy + Trait>(t: S<T>) -> (S<T>, S<T>) where {
     //~^ HELP consider restricting type parameter `T`
     (t, t) //~ use of moved value: `t`
 }
 
 fn duplicate_custom_2<T>(t: S<T>) -> (S<T>, S<T>)
 where
-    T: A + Trait + Copy,
+    T: A + Copy + Trait,
     //~^ HELP consider further restricting this bound
 {
     (t, t) //~ use of moved value: `t`
@@ -54,14 +54,14 @@ where
 
 fn duplicate_custom_3<T>(t: S<T>) -> (S<T>, S<T>)
 where
-    T: A + Trait + Copy,
+    T: A + Copy + Trait,
     //~^ HELP consider further restricting this bound
     T: B,
 {
     (t, t) //~ use of moved value: `t`
 }
 
-fn duplicate_custom_4<T: A + Trait + Copy>(t: S<T>) -> (S<T>, S<T>)
+fn duplicate_custom_4<T: A + Copy + Trait>(t: S<T>) -> (S<T>, S<T>)
 //~^ HELP consider further restricting this bound
 where
     T: B,

--- a/src/test/ui/moves/use_of_moved_value_copy_suggestions.stderr
+++ b/src/test/ui/moves/use_of_moved_value_copy_suggestions.stderr
@@ -75,7 +75,7 @@ LL |     (t, t)
    |
 help: consider restricting type parameter `T`
    |
-LL | fn duplicate_custom<T: Trait + Copy>(t: S<T>) -> (S<T>, S<T>) {
+LL | fn duplicate_custom<T: Copy + Trait>(t: S<T>) -> (S<T>, S<T>) {
    |                      ++++++++++++++
 
 error[E0382]: use of moved value: `t`
@@ -91,7 +91,7 @@ LL |     (t, t)
    |
 help: consider restricting type parameter `T`
    |
-LL | fn duplicate_custom_1<T: Trait + Copy>(t: S<T>) -> (S<T>, S<T>) where {
+LL | fn duplicate_custom_1<T: Copy + Trait>(t: S<T>) -> (S<T>, S<T>) where {
    |                        ++++++++++++++
 
 error[E0382]: use of moved value: `t`
@@ -107,7 +107,7 @@ LL |     (t, t)
    |
 help: consider further restricting this bound
    |
-LL |     T: A + Trait + Copy,
+LL |     T: A + Copy + Trait,
    |          ++++++++++++++
 
 error[E0382]: use of moved value: `t`
@@ -123,7 +123,7 @@ LL |     (t, t)
    |
 help: consider further restricting this bound
    |
-LL |     T: A + Trait + Copy,
+LL |     T: A + Copy + Trait,
    |          ++++++++++++++
 
 error[E0382]: use of moved value: `t`
@@ -139,7 +139,7 @@ LL |     (t, t)
    |
 help: consider further restricting this bound
    |
-LL | fn duplicate_custom_4<T: A + Trait + Copy>(t: S<T>) -> (S<T>, S<T>)
+LL | fn duplicate_custom_4<T: A + Copy + Trait>(t: S<T>) -> (S<T>, S<T>)
    |                            ++++++++++++++
 
 error[E0382]: use of moved value: `t`

--- a/src/test/ui/suggestions/missing-bound-in-derive-copy-impl-2.fixed
+++ b/src/test/ui/suggestions/missing-bound-in-derive-copy-impl-2.fixed
@@ -1,0 +1,16 @@
+// run-rustfix
+use std::fmt::Debug;
+
+#[derive(Debug, Copy, Clone)]
+pub struct Vector2<T: Debug + Copy + Clone>{
+    pub x: T,
+    pub y: T
+}
+
+#[derive(Debug, Copy, Clone)]
+pub struct AABB<K: Debug + std::marker::Copy>{
+    pub loc: Vector2<K>, //~ ERROR the trait bound `K: Copy` is not satisfied
+    pub size: Vector2<K>
+}
+
+fn main() {}

--- a/src/test/ui/suggestions/missing-bound-in-derive-copy-impl-2.rs
+++ b/src/test/ui/suggestions/missing-bound-in-derive-copy-impl-2.rs
@@ -1,0 +1,16 @@
+// run-rustfix
+use std::fmt::Debug;
+
+#[derive(Debug, Copy, Clone)]
+pub struct Vector2<T: Debug + Copy + Clone>{
+    pub x: T,
+    pub y: T
+}
+
+#[derive(Debug, Copy, Clone)]
+pub struct AABB<K: Debug>{
+    pub loc: Vector2<K>, //~ ERROR the trait bound `K: Copy` is not satisfied
+    pub size: Vector2<K>
+}
+
+fn main() {}

--- a/src/test/ui/suggestions/missing-bound-in-derive-copy-impl-2.stderr
+++ b/src/test/ui/suggestions/missing-bound-in-derive-copy-impl-2.stderr
@@ -1,0 +1,19 @@
+error[E0277]: the trait bound `K: Copy` is not satisfied
+  --> $DIR/missing-bound-in-derive-copy-impl-2.rs:12:14
+   |
+LL |     pub loc: Vector2<K>,
+   |              ^^^^^^^^^^ the trait `Copy` is not implemented for `K`
+   |
+note: required by a bound in `Vector2`
+  --> $DIR/missing-bound-in-derive-copy-impl-2.rs:5:31
+   |
+LL | pub struct Vector2<T: Debug + Copy + Clone>{
+   |                               ^^^^ required by this bound in `Vector2`
+help: consider further restricting this bound
+   |
+LL | pub struct AABB<K: Debug + std::marker::Copy>{
+   |                          +++++++++++++++++++
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/suggestions/missing-bound-in-derive-copy-impl-3.fixed
+++ b/src/test/ui/suggestions/missing-bound-in-derive-copy-impl-3.fixed
@@ -1,0 +1,16 @@
+//run-rustfix
+use std::fmt::Debug;
+
+#[derive(Debug, Copy, Clone)]
+pub struct Vector2<T: Debug + Copy + Clone>{
+    pub x: T,
+    pub y: T
+}
+
+#[derive(Debug, Copy, Clone)] //~ ERROR the trait `Copy` may not be implemented for this type
+pub struct AABB<K: Copy + Debug>{
+    pub loc: Vector2<K>,
+    pub size: Vector2<K>
+}
+
+fn main() {}

--- a/src/test/ui/suggestions/missing-bound-in-derive-copy-impl-3.rs
+++ b/src/test/ui/suggestions/missing-bound-in-derive-copy-impl-3.rs
@@ -1,0 +1,16 @@
+//run-rustfix
+use std::fmt::Debug;
+
+#[derive(Debug, Copy, Clone)]
+pub struct Vector2<T: Debug + Copy + Clone>{
+    pub x: T,
+    pub y: T
+}
+
+#[derive(Debug, Copy, Clone)] //~ ERROR the trait `Copy` may not be implemented for this type
+pub struct AABB<K: Copy>{
+    pub loc: Vector2<K>,
+    pub size: Vector2<K>
+}
+
+fn main() {}

--- a/src/test/ui/suggestions/missing-bound-in-derive-copy-impl-3.stderr
+++ b/src/test/ui/suggestions/missing-bound-in-derive-copy-impl-3.stderr
@@ -14,9 +14,6 @@ note: the `Copy` impl for `Vector2<K>` requires that `K: Debug`
    |
 LL |     pub loc: Vector2<K>,
    |     ^^^^^^^^^^^^^^^^^^^
-note: the `Copy` impl for `Vector2<K>` requires that `K: Debug`
-  --> $DIR/missing-bound-in-derive-copy-impl-3.rs:13:5
-   |
 LL |     pub size: Vector2<K>
    |     ^^^^^^^^^^^^^^^^^^^^
    = note: this error originates in the derive macro `Copy` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/src/test/ui/suggestions/missing-bound-in-derive-copy-impl-3.stderr
+++ b/src/test/ui/suggestions/missing-bound-in-derive-copy-impl-3.stderr
@@ -1,0 +1,30 @@
+error[E0204]: the trait `Copy` may not be implemented for this type
+  --> $DIR/missing-bound-in-derive-copy-impl-3.rs:10:17
+   |
+LL | #[derive(Debug, Copy, Clone)]
+   |                 ^^^^
+LL | pub struct AABB<K: Copy>{
+LL |     pub loc: Vector2<K>,
+   |     ------------------- this field does not implement `Copy`
+LL |     pub size: Vector2<K>
+   |     -------------------- this field does not implement `Copy`
+   |
+note: the `Copy` impl for `Vector2<K>` requires that `K: Debug`
+  --> $DIR/missing-bound-in-derive-copy-impl-3.rs:12:5
+   |
+LL |     pub loc: Vector2<K>,
+   |     ^^^^^^^^^^^^^^^^^^^
+note: the `Copy` impl for `Vector2<K>` requires that `K: Debug`
+  --> $DIR/missing-bound-in-derive-copy-impl-3.rs:13:5
+   |
+LL |     pub size: Vector2<K>
+   |     ^^^^^^^^^^^^^^^^^^^^
+   = note: this error originates in the derive macro `Copy` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider further restricting this bound
+   |
+LL | pub struct AABB<K: Copy + Debug>{
+   |                         +++++++
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0204`.

--- a/src/test/ui/suggestions/missing-bound-in-derive-copy-impl.rs
+++ b/src/test/ui/suggestions/missing-bound-in-derive-copy-impl.rs
@@ -1,0 +1,15 @@
+use std::fmt::Debug;
+
+#[derive(Debug, Copy, Clone)]
+pub struct Vector2<T: Debug + Copy + Clone>{
+    pub x: T,
+    pub y: T
+}
+
+#[derive(Debug, Copy, Clone)] //~ ERROR the trait `Copy` may not be implemented for this type
+pub struct AABB<K>{
+    pub loc: Vector2<K>,
+    pub size: Vector2<K>
+}
+
+fn main() {}

--- a/src/test/ui/suggestions/missing-bound-in-derive-copy-impl.stderr
+++ b/src/test/ui/suggestions/missing-bound-in-derive-copy-impl.stderr
@@ -14,9 +14,6 @@ note: the `Copy` impl for `Vector2<K>` requires that `K: Debug`
    |
 LL |     pub loc: Vector2<K>,
    |     ^^^^^^^^^^^^^^^^^^^
-note: the `Copy` impl for `Vector2<K>` requires that `K: Debug`
-  --> $DIR/missing-bound-in-derive-copy-impl.rs:12:5
-   |
 LL |     pub size: Vector2<K>
    |     ^^^^^^^^^^^^^^^^^^^^
    = note: this error originates in the derive macro `Copy` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/src/test/ui/suggestions/missing-bound-in-derive-copy-impl.stderr
+++ b/src/test/ui/suggestions/missing-bound-in-derive-copy-impl.stderr
@@ -1,0 +1,30 @@
+error[E0204]: the trait `Copy` may not be implemented for this type
+  --> $DIR/missing-bound-in-derive-copy-impl.rs:9:17
+   |
+LL | #[derive(Debug, Copy, Clone)]
+   |                 ^^^^
+LL | pub struct AABB<K>{
+LL |     pub loc: Vector2<K>,
+   |     ------------------- this field does not implement `Copy`
+LL |     pub size: Vector2<K>
+   |     -------------------- this field does not implement `Copy`
+   |
+note: the `Copy` impl for `Vector2<K>` requires that `K: Debug`
+  --> $DIR/missing-bound-in-derive-copy-impl.rs:11:5
+   |
+LL |     pub loc: Vector2<K>,
+   |     ^^^^^^^^^^^^^^^^^^^
+note: the `Copy` impl for `Vector2<K>` requires that `K: Debug`
+  --> $DIR/missing-bound-in-derive-copy-impl.rs:12:5
+   |
+LL |     pub size: Vector2<K>
+   |     ^^^^^^^^^^^^^^^^^^^^
+   = note: this error originates in the derive macro `Copy` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider restricting type parameter `K`
+   |
+LL | pub struct AABB<K: Debug>{
+   |                  +++++++
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0204`.

--- a/src/tools/clippy/clippy_utils/src/qualify_min_const_fn.rs
+++ b/src/tools/clippy/clippy_utils/src/qualify_min_const_fn.rs
@@ -131,7 +131,12 @@ fn check_rvalue<'tcx>(
         Rvalue::Cast(CastKind::Misc, operand, _) => {
             check_operand(tcx, operand, span, body)
         },
-        Rvalue::Cast(CastKind::Pointer(PointerCast::MutToConstPointer | PointerCast::ArrayToPointer), operand, _) => {
+        Rvalue::Cast(
+            CastKind::PointerFromExposedAddress
+            | CastKind::Pointer(PointerCast::MutToConstPointer | PointerCast::ArrayToPointer),
+            operand,
+            _
+        ) => {
             check_operand(tcx, operand, span, body)
         },
         Rvalue::Cast(


### PR DESCRIPTION
Successful merges:

 - #97366 (Stabilize `{slice,array}::from_ref`)
 - #97653 (add cast kind of from_exposed_addr (int-to-ptr casts))
 - #97663 (take back half-baked noaliasing check in Assignment)
 - #97664 (On E0204 suggest missing type param bounds)
 - #97668 (rustdoc: clean up primitive.slice.html links)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=97366,97653,97663,97664,97668)
<!-- homu-ignore:end -->