### PR TITLE
Add more eslint checks

### DIFF
--- a/src/librustdoc/html/static/.eslintrc.js
+++ b/src/librustdoc/html/static/.eslintrc.js
@@ -77,5 +77,6 @@ module.exports = {
         "no-template-curly-in-string": "error",
         "block-scoped-var": "error",
         "guard-for-in": "error",
+        "no-alert": "error",
     }
 };

--- a/src/librustdoc/html/static/.eslintrc.js
+++ b/src/librustdoc/html/static/.eslintrc.js
@@ -73,5 +73,6 @@ module.exports = {
         "no-fallthrough": "error",
         "no-invalid-regexp": "error",
         "no-import-assign": "error",
+        "no-self-compare": "error",
     }
 };

--- a/src/librustdoc/html/static/.eslintrc.js
+++ b/src/librustdoc/html/static/.eslintrc.js
@@ -75,5 +75,6 @@ module.exports = {
         "no-import-assign": "error",
         "no-self-compare": "error",
         "no-template-curly-in-string": "error",
+        "block-scoped-var": "error",
     }
 };

--- a/src/librustdoc/html/static/.eslintrc.js
+++ b/src/librustdoc/html/static/.eslintrc.js
@@ -72,5 +72,6 @@ module.exports = {
         "no-ex-assign": "error",
         "no-fallthrough": "error",
         "no-invalid-regexp": "error",
+        "no-import-assign": "error",
     }
 };

--- a/src/librustdoc/html/static/.eslintrc.js
+++ b/src/librustdoc/html/static/.eslintrc.js
@@ -76,5 +76,6 @@ module.exports = {
         "no-self-compare": "error",
         "no-template-curly-in-string": "error",
         "block-scoped-var": "error",
+        "guard-for-in": "error",
     }
 };

--- a/src/librustdoc/html/static/.eslintrc.js
+++ b/src/librustdoc/html/static/.eslintrc.js
@@ -71,5 +71,6 @@ module.exports = {
         "no-duplicate-case": "error",
         "no-ex-assign": "error",
         "no-fallthrough": "error",
+        "no-invalid-regexp": "error",
     }
 };

--- a/src/librustdoc/html/static/.eslintrc.js
+++ b/src/librustdoc/html/static/.eslintrc.js
@@ -74,5 +74,6 @@ module.exports = {
         "no-invalid-regexp": "error",
         "no-import-assign": "error",
         "no-self-compare": "error",
+        "no-template-curly-in-string": "error",
     }
 };

--- a/src/librustdoc/html/static/.eslintrc.js
+++ b/src/librustdoc/html/static/.eslintrc.js
@@ -70,5 +70,6 @@ module.exports = {
         "no-dupe-keys": "error",
         "no-duplicate-case": "error",
         "no-ex-assign": "error",
+        "no-fallthrough": "error",
     }
 };


### PR DESCRIPTION
A new batch of eslint rules:

 * [no-fallthrough](https://eslint.org/docs/rules/no-fallthrough)
 * [no-invalid-regexp](https://eslint.org/docs/rules/no-invalid-regexp)
 * [no-import-assign](https://eslint.org/docs/rules/no-import-assign)
 * [no-self-compare](https://eslint.org/docs/rules/no-self-compare)
 * [no-template-curly-in-string](https://eslint.org/docs/rules/no-template-curly-in-string)
 * [block-scoped-var](https://eslint.org/docs/rules/block-scoped-var)
 * [guard-for-in](https://eslint.org/docs/rules/guard-for-in)
 * [no-alert](https://eslint.org/docs/rules/no-alert)

r? @notriddle 