### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/region_name.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/region_name.rs
@@ -567,14 +567,14 @@ impl<'tcx> MirBorrowckCtxt<'_, 'tcx> {
         let lifetime =
             self.try_match_adt_and_generic_args(substs, needle_fr, args, search_stack)?;
         match lifetime.name {
-            hir::LifetimeName::Param(hir::ParamName::Plain(_) | hir::ParamName::Error)
+            hir::LifetimeName::Param(_, hir::ParamName::Plain(_) | hir::ParamName::Error)
             | hir::LifetimeName::Error
             | hir::LifetimeName::Static => {
                 let lifetime_span = lifetime.span;
                 Some(RegionNameHighlight::MatchedAdtAndSegment(lifetime_span))
             }
 
-            hir::LifetimeName::Param(hir::ParamName::Fresh(_))
+            hir::LifetimeName::Param(_, hir::ParamName::Fresh)
             | hir::LifetimeName::ImplicitObjectLifetimeDefault
             | hir::LifetimeName::Implicit
             | hir::LifetimeName::Underscore => {

--- a/compiler/rustc_borrowck/src/universal_regions.rs
+++ b/compiler/rustc_borrowck/src/universal_regions.rs
@@ -830,11 +830,11 @@ fn for_each_late_bound_region_defined_on<'tcx>(
     fn_def_id: DefId,
     mut f: impl FnMut(ty::Region<'tcx>),
 ) {
-    if let Some((owner, late_bounds)) = tcx.is_late_bound_map(fn_def_id.expect_local()) {
+    if let Some(late_bounds) = tcx.is_late_bound_map(fn_def_id.expect_local()) {
         for &region_def_id in late_bounds.iter() {
             let name = tcx.item_name(region_def_id.to_def_id());
             let liberated_region = tcx.mk_region(ty::ReFree(ty::FreeRegion {
-                scope: owner.to_def_id(),
+                scope: fn_def_id,
                 bound_region: ty::BoundRegionKind::BrNamed(region_def_id.to_def_id(), name),
             }));
             f(liberated_region);

--- a/compiler/rustc_hir/src/intravisit.rs
+++ b/compiler/rustc_hir/src/intravisit.rs
@@ -510,11 +510,11 @@ pub fn walk_label<'v, V: Visitor<'v>>(visitor: &mut V, label: &'v Label) {
 pub fn walk_lifetime<'v, V: Visitor<'v>>(visitor: &mut V, lifetime: &'v Lifetime) {
     visitor.visit_id(lifetime.hir_id);
     match lifetime.name {
-        LifetimeName::Param(ParamName::Plain(ident)) => {
+        LifetimeName::Param(_, ParamName::Plain(ident)) => {
             visitor.visit_ident(ident);
         }
-        LifetimeName::Param(ParamName::Fresh(_))
-        | LifetimeName::Param(ParamName::Error)
+        LifetimeName::Param(_, ParamName::Fresh)
+        | LifetimeName::Param(_, ParamName::Error)
         | LifetimeName::Static
         | LifetimeName::Error
         | LifetimeName::Implicit
@@ -879,7 +879,7 @@ pub fn walk_generic_param<'v, V: Visitor<'v>>(visitor: &mut V, param: &'v Generi
     visitor.visit_id(param.hir_id);
     match param.name {
         ParamName::Plain(ident) => visitor.visit_ident(ident),
-        ParamName::Error | ParamName::Fresh(_) => {}
+        ParamName::Error | ParamName::Fresh => {}
     }
     match param.kind {
         GenericParamKind::Lifetime { .. } => {}

--- a/compiler/rustc_middle/src/hir/map/mod.rs
+++ b/compiler/rustc_middle/src/hir/map/mod.rs
@@ -364,7 +364,11 @@ impl<'hir> Map<'hir> {
         match node.node {
             OwnerNode::ImplItem(impl_item) => Some(&impl_item.generics),
             OwnerNode::TraitItem(trait_item) => Some(&trait_item.generics),
-            OwnerNode::Item(Item {
+            OwnerNode::ForeignItem(ForeignItem {
+                kind: ForeignItemKind::Fn(_, _, generics),
+                ..
+            })
+            | OwnerNode::Item(Item {
                 kind:
                     ItemKind::Fn(_, generics, _)
                     | ItemKind::TyAlias(_, generics)

--- a/compiler/rustc_middle/src/middle/resolve_lifetime.rs
+++ b/compiler/rustc_middle/src/middle/resolve_lifetime.rs
@@ -6,7 +6,6 @@ use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_hir::ItemLocalId;
 use rustc_macros::HashStable;
-use rustc_span::symbol::Symbol;
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash, TyEncodable, TyDecodable, Debug, HashStable)]
 pub enum Region {
@@ -22,12 +21,12 @@ pub enum Region {
 /// so that we can e.g. suggest elided-lifetimes-in-paths of the form <'_, '_> e.g.
 #[derive(Clone, PartialEq, Eq, Hash, TyEncodable, TyDecodable, Debug, HashStable)]
 pub enum LifetimeScopeForPath {
-    // Contains all lifetime names that are in scope and could possibly be used in generics
-    // arguments of path.
-    NonElided(Vec<Symbol>),
+    /// Contains all lifetime names that are in scope and could possibly be used in generics
+    /// arguments of path.
+    NonElided(Vec<LocalDefId>),
 
-    // Information that allows us to suggest args of the form `<'_>` in case
-    // no generic arguments were provided for a path.
+    /// Information that allows us to suggest args of the form `<'_>` in case
+    /// no generic arguments were provided for a path.
     Elided,
 }
 

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -1584,7 +1584,7 @@ rustc_queries! {
         Option<&'tcx FxHashMap<ItemLocalId, Region>> {
         desc { "looking up a named region" }
     }
-    query is_late_bound_map(_: LocalDefId) -> Option<(LocalDefId, &'tcx FxHashSet<LocalDefId>)> {
+    query is_late_bound_map(_: LocalDefId) -> Option<&'tcx FxHashSet<LocalDefId>> {
         desc { "testing if a region is late bound" }
     }
     /// For a given item (like a struct), gets the default lifetimes to be used

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -2803,6 +2803,13 @@ impl<'tcx> TyCtxt<'tcx> {
         self.named_region_map(id.owner).and_then(|map| map.get(&id.local_id).cloned())
     }
 
+    pub fn is_late_bound(self, id: HirId) -> bool {
+        self.is_late_bound_map(id.owner).map_or(false, |set| {
+            let def_id = self.hir().local_def_id(id);
+            set.contains(&def_id)
+        })
+    }
+
     pub fn late_bound_vars(self, id: HirId) -> &'tcx List<ty::BoundVariableKind> {
         self.mk_bound_variable_kinds(
             self.late_bound_vars_map(id.owner)

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -13,7 +13,7 @@ use rustc_ast::{
 };
 use rustc_ast_lowering::ResolverAstLowering;
 use rustc_ast_pretty::pprust::path_segment_to_string;
-use rustc_data_structures::fx::FxHashSet;
+use rustc_data_structures::fx::{FxHashSet, FxIndexSet};
 use rustc_errors::{
     pluralize, struct_span_err, Applicability, Diagnostic, DiagnosticBuilder, ErrorGuaranteed,
     MultiSpan,
@@ -21,7 +21,7 @@ use rustc_errors::{
 use rustc_hir as hir;
 use rustc_hir::def::Namespace::{self, *};
 use rustc_hir::def::{self, CtorKind, CtorOf, DefKind};
-use rustc_hir::def_id::{DefId, CRATE_DEF_ID, LOCAL_CRATE};
+use rustc_hir::def_id::{DefId, LocalDefId, CRATE_DEF_ID, LOCAL_CRATE};
 use rustc_hir::PrimTy;
 use rustc_session::lint;
 use rustc_session::parse::feature_err;
@@ -2082,7 +2082,7 @@ impl<'tcx> LifetimeContext<'_, 'tcx> {
 
     /// Returns whether to add `'static` lifetime to the suggested lifetime list.
     pub(crate) fn report_elision_failure(
-        &mut self,
+        &self,
         diag: &mut Diagnostic,
         params: &[ElisionFailureInfo],
     ) -> bool {
@@ -2187,10 +2187,27 @@ impl<'tcx> LifetimeContext<'_, 'tcx> {
         &self,
         err: &mut Diagnostic,
         mut spans_with_counts: Vec<(Span, usize)>,
-        lifetime_names: &FxHashSet<Symbol>,
-        lifetime_spans: Vec<Span>,
-        params: &[ElisionFailureInfo],
+        in_scope_lifetimes: FxIndexSet<LocalDefId>,
+        params: Option<&[ElisionFailureInfo]>,
     ) {
+        let (mut lifetime_names, lifetime_spans): (FxHashSet<_>, Vec<_>) = in_scope_lifetimes
+            .iter()
+            .filter_map(|def_id| {
+                let name = self.tcx.item_name(def_id.to_def_id());
+                let span = self.tcx.def_ident_span(def_id.to_def_id())?;
+                Some((name, span))
+            })
+            .filter(|&(n, _)| n != kw::UnderscoreLifetime)
+            .unzip();
+
+        if let Some(params) = params {
+            // If there's no lifetime available, suggest `'static`.
+            if self.report_elision_failure(err, params) && lifetime_names.is_empty() {
+                lifetime_names.insert(kw::StaticLifetime);
+            }
+        }
+        let params = params.unwrap_or(&[]);
+
         let snippets: Vec<Option<String>> = spans_with_counts
             .iter()
             .map(|(span, _)| self.tcx.sess.source_map().span_to_snippet(*span).ok())

--- a/compiler/rustc_typeck/src/astconv/mod.rs
+++ b/compiler/rustc_typeck/src/astconv/mod.rs
@@ -16,7 +16,7 @@ use crate::require_c_abi_if_c_variadic;
 use rustc_ast::TraitObjectSyntax;
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_errors::{
-    struct_span_err, Applicability, DiagnosticBuilder, ErrorGuaranteed, FatalError,
+    struct_span_err, Applicability, DiagnosticBuilder, ErrorGuaranteed, FatalError, MultiSpan,
 };
 use rustc_hir as hir;
 use rustc_hir::def::{CtorOf, DefKind, Namespace, Res};
@@ -653,7 +653,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
             span, item_def_id, item_segment
         );
         if tcx.generics_of(item_def_id).params.is_empty() {
-            self.prohibit_generics(slice::from_ref(item_segment));
+            self.prohibit_generics(slice::from_ref(item_segment).iter());
 
             parent_substs
         } else {
@@ -681,7 +681,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
         trait_ref: &hir::TraitRef<'_>,
         self_ty: Ty<'tcx>,
     ) -> ty::TraitRef<'tcx> {
-        self.prohibit_generics(trait_ref.path.segments.split_last().unwrap().1);
+        self.prohibit_generics(trait_ref.path.segments.split_last().unwrap().1.iter());
 
         self.ast_path_to_mono_trait_ref(
             trait_ref.path.span,
@@ -784,7 +784,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
         let args = trait_segment.args();
         let infer_args = trait_segment.infer_args;
 
-        self.prohibit_generics(trait_ref.path.segments.split_last().unwrap().1);
+        self.prohibit_generics(trait_ref.path.segments.split_last().unwrap().1.iter());
         self.complain_about_internal_fn_trait(span, trait_def_id, trait_segment, false);
 
         self.instantiate_poly_trait_ref_inner(
@@ -1796,7 +1796,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                 if let Some(variant_def) = variant_def {
                     if permit_variants {
                         tcx.check_stability(variant_def.def_id, Some(hir_ref_id), span, None);
-                        self.prohibit_generics(slice::from_ref(assoc_segment));
+                        self.prohibit_generics(slice::from_ref(assoc_segment).iter());
                         return Ok((qself_ty, DefKind::Variant, variant_def.def_id));
                     } else {
                         variant_resolution = Some(variant_def.def_id);
@@ -2017,69 +2017,79 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
         self.normalize_ty(span, tcx.mk_projection(item_def_id, item_substs))
     }
 
-    pub fn prohibit_generics<'a, T: IntoIterator<Item = &'a hir::PathSegment<'a>>>(
+    pub fn prohibit_generics<'a, T: Iterator<Item = &'a hir::PathSegment<'a>> + Clone>(
         &self,
         segments: T,
     ) -> bool {
-        let mut has_err = false;
-        for segment in segments {
-            let (mut err_for_lt, mut err_for_ty, mut err_for_ct) = (false, false, false);
-            for arg in segment.args().args {
-                let (span, kind) = match arg {
-                    hir::GenericArg::Lifetime(lt) => {
-                        if err_for_lt {
-                            continue;
-                        }
-                        err_for_lt = true;
-                        has_err = true;
-                        (lt.span, "lifetime")
-                    }
-                    hir::GenericArg::Type(ty) => {
-                        if err_for_ty {
-                            continue;
-                        }
-                        err_for_ty = true;
-                        has_err = true;
-                        (ty.span, "type")
-                    }
-                    hir::GenericArg::Const(ct) => {
-                        if err_for_ct {
-                            continue;
-                        }
-                        err_for_ct = true;
-                        has_err = true;
-                        (ct.span, "const")
-                    }
-                    hir::GenericArg::Infer(inf) => {
-                        if err_for_ty {
-                            continue;
-                        }
-                        has_err = true;
-                        err_for_ty = true;
-                        (inf.span, "generic")
-                    }
-                };
-                let mut err = struct_span_err!(
-                    self.tcx().sess,
-                    span,
-                    E0109,
-                    "{} arguments are not allowed for this type",
-                    kind,
-                );
-                err.span_label(span, format!("{} argument not allowed", kind));
-                err.emit();
-                if err_for_lt && err_for_ty && err_for_ct {
-                    break;
-                }
-            }
+        let args = segments.clone().flat_map(|segment| segment.args().args);
 
+        let (lt, ty, ct, inf) =
+            args.clone().fold((false, false, false, false), |(lt, ty, ct, inf), arg| match arg {
+                hir::GenericArg::Lifetime(_) => (true, ty, ct, inf),
+                hir::GenericArg::Type(_) => (lt, true, ct, inf),
+                hir::GenericArg::Const(_) => (lt, ty, true, inf),
+                hir::GenericArg::Infer(_) => (lt, ty, ct, true),
+            });
+        let mut emitted = false;
+        if lt || ty || ct || inf {
+            let arg_spans: Vec<Span> = args
+                .map(|arg| match arg {
+                    hir::GenericArg::Lifetime(lt) => lt.span,
+                    hir::GenericArg::Type(ty) => ty.span,
+                    hir::GenericArg::Const(ct) => ct.span,
+                    hir::GenericArg::Infer(inf) => inf.span,
+                })
+                .collect();
+
+            let mut types = Vec::with_capacity(4);
+            if lt {
+                types.push("lifetime");
+            }
+            if ty {
+                types.push("type");
+            }
+            if ct {
+                types.push("const");
+            }
+            if inf {
+                types.push("generic");
+            }
+            let (kind, s) = match types[..] {
+                [.., _, last] => (
+                    format!(
+                        "{} and `{last}`",
+                        types[..types.len() - 1]
+                            .iter()
+                            .map(|&x| x)
+                            .intersperse(", ")
+                            .collect::<String>()
+                    ),
+                    "s",
+                ),
+                [only] => (format!("{only}"), ""),
+                [] => unreachable!(),
+            };
+            let last_span = *arg_spans.last().unwrap();
+            let span: MultiSpan = arg_spans.into();
+            let mut err = struct_span_err!(
+                self.tcx().sess,
+                span,
+                E0109,
+                "{kind} arguments are not allowed for this type",
+            );
+            err.span_label(last_span, format!("{kind} argument{s} not allowed"));
+            err.emit();
+            emitted = true;
+        }
+
+        for segment in segments {
             // Only emit the first error to avoid overloading the user with error messages.
             if let [binding, ..] = segment.args().bindings {
-                has_err = true;
                 Self::prohibit_assoc_ty_binding(self.tcx(), binding.span);
+                return true;
             }
         }
-        has_err
+        emitted
     }
 
     // FIXME(eddyb, varkor) handle type paths here too, not just value ones.
@@ -2229,7 +2239,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                 // Check for desugared `impl Trait`.
                 assert!(ty::is_impl_trait_defn(tcx, did).is_none());
                 let item_segment = path.segments.split_last().unwrap();
-                self.prohibit_generics(item_segment.1);
+                self.prohibit_generics(item_segment.1.iter());
                 let substs = self.ast_path_substs_for_ty(span, did, item_segment.0);
                 self.normalize_ty(span, tcx.mk_opaque(did, substs))
             }
@@ -2242,7 +2252,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                 did,
             ) => {
                 assert_eq!(opt_self_ty, None);
-                self.prohibit_generics(path.segments.split_last().unwrap().1);
+                self.prohibit_generics(path.segments.split_last().unwrap().1.iter());
                 self.ast_path_to_ty(span, did, path.segments.last().unwrap())
             }
             Res::Def(kind @ DefKind::Variant, def_id) if permit_variants => {
@@ -2265,7 +2275,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
             }
             Res::Def(DefKind::TyParam, def_id) => {
                 assert_eq!(opt_self_ty, None);
-                self.prohibit_generics(path.segments);
+                self.prohibit_generics(path.segments.iter());
 
                 let def_id = def_id.expect_local();
                 let item_def_id = tcx.hir().ty_param_owner(def_id);
@@ -2276,13 +2286,13 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
             Res::SelfTy { trait_: Some(_), alias_to: None } => {
                 // `Self` in trait or type alias.
                 assert_eq!(opt_self_ty, None);
-                self.prohibit_generics(path.segments);
+                self.prohibit_generics(path.segments.iter());
                 tcx.types.self_param
             }
             Res::SelfTy { trait_: _, alias_to: Some((def_id, forbid_generic)) } => {
                 // `Self` in impl (we know the concrete type).
                 assert_eq!(opt_self_ty, None);
-                self.prohibit_generics(path.segments);
+                self.prohibit_generics(path.segments.iter());
                 // Try to evaluate any array length constants.
                 let ty = tcx.at(span).type_of(def_id);
                 // HACK(min_const_generics): Forbid generic `Self` types
@@ -2324,7 +2334,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
             }
             Res::Def(DefKind::AssocTy, def_id) => {
                 debug_assert!(path.segments.len() >= 2);
-                self.prohibit_generics(&path.segments[..path.segments.len() - 2]);
+                self.prohibit_generics(path.segments[..path.segments.len() - 2].iter());
                 self.qpath_to_ty(
                     span,
                     opt_self_ty,
@@ -2335,7 +2345,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
             }
             Res::PrimTy(prim_ty) => {
                 assert_eq!(opt_self_ty, None);
-                self.prohibit_generics(path.segments);
+                self.prohibit_generics(path.segments.iter());
                 match prim_ty {
                     hir::PrimTy::Bool => tcx.types.bool,
                     hir::PrimTy::Char => tcx.types.char,

--- a/compiler/rustc_typeck/src/astconv/mod.rs
+++ b/compiler/rustc_typeck/src/astconv/mod.rs
@@ -2417,7 +2417,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                         let mut span: MultiSpan = vec![t_sp].into();
                         span.push_span_label(
                             i_sp,
-                            &format!("`Self` is or type `{type_name}` in this `impl`"),
+                            &format!("`Self` is on type `{type_name}` in this `impl`"),
                         );
                         let mut postfix = "";
                         if generics == 0 {

--- a/compiler/rustc_typeck/src/check/fn_ctxt/_impl.rs
+++ b/compiler/rustc_typeck/src/check/fn_ctxt/_impl.rs
@@ -1228,6 +1228,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     None
                 }
             }),
+            |_| {},
         );
 
         if let Res::Local(hid) = res {

--- a/compiler/rustc_typeck/src/check/fn_ctxt/checks.rs
+++ b/compiler/rustc_typeck/src/check/fn_ctxt/checks.rs
@@ -1564,13 +1564,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             QPath::TypeRelative(ref qself, ref segment) => {
                 let ty = self.to_ty(qself);
 
-                let res = if let hir::TyKind::Path(QPath::Resolved(_, ref path)) = qself.kind {
-                    path.res
-                } else {
-                    Res::Err
-                };
                 let result = <dyn AstConv<'_>>::associated_path_to_ty(
-                    self, hir_id, path_span, ty, res, segment, true,
+                    self, hir_id, path_span, ty, qself, segment, true,
                 );
                 let ty = result.map(|(ty, _, _)| ty).unwrap_or_else(|_| self.tcx().ty_error());
                 let result = result.map(|(_, kind, def_id)| (kind, def_id));

--- a/compiler/rustc_typeck/src/structured_errors/wrong_number_of_generic_args.rs
+++ b/compiler/rustc_typeck/src/structured_errors/wrong_number_of_generic_args.rs
@@ -514,7 +514,9 @@ impl<'a, 'tcx> WrongNumberOfGenericArgs<'a, 'tcx> {
                             param_names
                                 .iter()
                                 .take(num_params_to_take)
-                                .map(|p| p.as_str())
+                                .map(|def_id| {
+                                    self.tcx.item_name(def_id.to_def_id()).to_ident_string()
+                                })
                                 .collect::<Vec<_>>()
                                 .join(", ")
                         } else {

--- a/src/librustdoc/html/static/.eslintrc.js
+++ b/src/librustdoc/html/static/.eslintrc.js
@@ -77,5 +77,6 @@ module.exports = {
         "no-template-curly-in-string": "error",
         "block-scoped-var": "error",
         "guard-for-in": "error",
+        "no-alert": "error",
     }
 };

--- a/src/librustdoc/html/static/.eslintrc.js
+++ b/src/librustdoc/html/static/.eslintrc.js
@@ -73,5 +73,6 @@ module.exports = {
         "no-fallthrough": "error",
         "no-invalid-regexp": "error",
         "no-import-assign": "error",
+        "no-self-compare": "error",
     }
 };

--- a/src/librustdoc/html/static/.eslintrc.js
+++ b/src/librustdoc/html/static/.eslintrc.js
@@ -75,5 +75,6 @@ module.exports = {
         "no-import-assign": "error",
         "no-self-compare": "error",
         "no-template-curly-in-string": "error",
+        "block-scoped-var": "error",
     }
 };

--- a/src/librustdoc/html/static/.eslintrc.js
+++ b/src/librustdoc/html/static/.eslintrc.js
@@ -72,5 +72,6 @@ module.exports = {
         "no-ex-assign": "error",
         "no-fallthrough": "error",
         "no-invalid-regexp": "error",
+        "no-import-assign": "error",
     }
 };

--- a/src/librustdoc/html/static/.eslintrc.js
+++ b/src/librustdoc/html/static/.eslintrc.js
@@ -76,5 +76,6 @@ module.exports = {
         "no-self-compare": "error",
         "no-template-curly-in-string": "error",
         "block-scoped-var": "error",
+        "guard-for-in": "error",
     }
 };

--- a/src/librustdoc/html/static/.eslintrc.js
+++ b/src/librustdoc/html/static/.eslintrc.js
@@ -71,5 +71,6 @@ module.exports = {
         "no-duplicate-case": "error",
         "no-ex-assign": "error",
         "no-fallthrough": "error",
+        "no-invalid-regexp": "error",
     }
 };

--- a/src/librustdoc/html/static/.eslintrc.js
+++ b/src/librustdoc/html/static/.eslintrc.js
@@ -74,5 +74,6 @@ module.exports = {
         "no-invalid-regexp": "error",
         "no-import-assign": "error",
         "no-self-compare": "error",
+        "no-template-curly-in-string": "error",
     }
 };

--- a/src/librustdoc/html/static/.eslintrc.js
+++ b/src/librustdoc/html/static/.eslintrc.js
@@ -70,5 +70,6 @@ module.exports = {
         "no-dupe-keys": "error",
         "no-duplicate-case": "error",
         "no-ex-assign": "error",
+        "no-fallthrough": "error",
     }
 };

--- a/src/test/ui/derives/issue-97343.rs
+++ b/src/test/ui/derives/issue-97343.rs
@@ -1,7 +1,7 @@
 use std::fmt::Debug;
 
 #[derive(Debug)]
-pub struct Irrelevant<Irrelevant> { //~ ERROR type arguments are not allowed for this type
+pub struct Irrelevant<Irrelevant> { //~ ERROR type arguments are not allowed on type parameter
     irrelevant: Irrelevant,
 }
 

--- a/src/test/ui/derives/issue-97343.stderr
+++ b/src/test/ui/derives/issue-97343.stderr
@@ -1,8 +1,11 @@
-error[E0109]: type arguments are not allowed for this type
+error[E0109]: type arguments are not allowed on type parameter `Irrelevant`
   --> $DIR/issue-97343.rs:4:23
    |
 LL | #[derive(Debug)]
-   |          ----- in this derive macro expansion
+   |          -----
+   |          |
+   |          not allowed on this
+   |          in this derive macro expansion
 LL | pub struct Irrelevant<Irrelevant> {
    |                       ^^^^^^^^^^ type argument not allowed
    |

--- a/src/test/ui/derives/issue-97343.stderr
+++ b/src/test/ui/derives/issue-97343.stderr
@@ -6,6 +6,11 @@ LL | #[derive(Debug)]
 LL | pub struct Irrelevant<Irrelevant> {
    |                       ^^^^^^^^^^ type argument not allowed
    |
+note: type parameter `Irrelevant` defined here
+  --> $DIR/issue-97343.rs:4:23
+   |
+LL | pub struct Irrelevant<Irrelevant> {
+   |                       ^^^^^^^^^^
    = note: this error originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error

--- a/src/test/ui/error-codes/E0109.stderr
+++ b/src/test/ui/error-codes/E0109.stderr
@@ -3,6 +3,12 @@ error[E0109]: type arguments are not allowed for this type
    |
 LL | type X = u32<i32>;
    |              ^^^ type argument not allowed
+   |
+help: primitive type `u32` doesn't have type parameters
+   |
+LL - type X = u32<i32>;
+LL + type X = u32;
+   | 
 
 error: aborting due to previous error
 

--- a/src/test/ui/error-codes/E0109.stderr
+++ b/src/test/ui/error-codes/E0109.stderr
@@ -1,8 +1,10 @@
-error[E0109]: type arguments are not allowed for this type
+error[E0109]: type arguments are not allowed on this type
   --> $DIR/E0109.rs:1:14
    |
 LL | type X = u32<i32>;
-   |              ^^^ type argument not allowed
+   |          --- ^^^ type argument not allowed
+   |          |
+   |          not allowed on this
    |
 help: primitive type `u32` doesn't have type parameters
    |

--- a/src/test/ui/error-codes/E0109.stderr
+++ b/src/test/ui/error-codes/E0109.stderr
@@ -6,7 +6,7 @@ LL | type X = u32<i32>;
    |          |
    |          not allowed on this
    |
-help: primitive type `u32` doesn't have type parameters
+help: primitive type `u32` doesn't have generic parameters
    |
 LL - type X = u32<i32>;
 LL + type X = u32;

--- a/src/test/ui/error-codes/E0110.stderr
+++ b/src/test/ui/error-codes/E0110.stderr
@@ -3,6 +3,12 @@ error[E0109]: lifetime arguments are not allowed for this type
    |
 LL | type X = u32<'static>;
    |              ^^^^^^^ lifetime argument not allowed
+   |
+help: primitive type `u32` doesn't have type parameters
+   |
+LL - type X = u32<'static>;
+LL + type X = u32;
+   | 
 
 error: aborting due to previous error
 

--- a/src/test/ui/error-codes/E0110.stderr
+++ b/src/test/ui/error-codes/E0110.stderr
@@ -6,7 +6,7 @@ LL | type X = u32<'static>;
    |          |
    |          not allowed on this
    |
-help: primitive type `u32` doesn't have type parameters
+help: primitive type `u32` doesn't have generic parameters
    |
 LL - type X = u32<'static>;
 LL + type X = u32;

--- a/src/test/ui/error-codes/E0110.stderr
+++ b/src/test/ui/error-codes/E0110.stderr
@@ -1,8 +1,10 @@
-error[E0109]: lifetime arguments are not allowed for this type
+error[E0109]: lifetime arguments are not allowed on this type
   --> $DIR/E0110.rs:1:14
    |
 LL | type X = u32<'static>;
-   |              ^^^^^^^ lifetime argument not allowed
+   |          --- ^^^^^^^ lifetime argument not allowed
+   |          |
+   |          not allowed on this
    |
 help: primitive type `u32` doesn't have type parameters
    |

--- a/src/test/ui/issues/issue-22706.rs
+++ b/src/test/ui/issues/issue-22706.rs
@@ -1,3 +1,3 @@
 fn is_copy<T: ::std::marker<i32>::Copy>() {}
-//~^ ERROR type arguments are not allowed for this type [E0109]
+//~^ ERROR type arguments are not allowed on module `marker` [E0109]
 fn main() {}

--- a/src/test/ui/issues/issue-22706.stderr
+++ b/src/test/ui/issues/issue-22706.stderr
@@ -1,8 +1,10 @@
-error[E0109]: type arguments are not allowed for this type
+error[E0109]: type arguments are not allowed on module `marker`
   --> $DIR/issue-22706.rs:1:29
    |
 LL | fn is_copy<T: ::std::marker<i32>::Copy>() {}
-   |                             ^^^ type argument not allowed
+   |                      ------ ^^^ type argument not allowed
+   |                      |
+   |                      not allowed on this
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-57924.rs
+++ b/src/test/ui/issues/issue-57924.rs
@@ -3,7 +3,7 @@ pub struct Gcm<E>(E);
 impl<E> Gcm<E> {
     pub fn crash(e: E) -> Self {
         Self::<E>(e)
-        //~^ ERROR type arguments are not allowed for this type
+        //~^ ERROR type arguments are not allowed on self constructor
     }
 }
 

--- a/src/test/ui/issues/issue-57924.stderr
+++ b/src/test/ui/issues/issue-57924.stderr
@@ -1,8 +1,10 @@
-error[E0109]: type arguments are not allowed for this type
+error[E0109]: type arguments are not allowed on self constructor
   --> $DIR/issue-57924.rs:5:16
    |
 LL |         Self::<E>(e)
-   |                ^ type argument not allowed
+   |         ----   ^ type argument not allowed
+   |         |
+   |         not allowed on this
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-60989.rs
+++ b/src/test/ui/issues/issue-60989.rs
@@ -10,9 +10,9 @@ impl From<A> for B {
 fn main() {
     let c1 = ();
     c1::<()>;
-    //~^ ERROR type arguments are not allowed for this type
+    //~^ ERROR type arguments are not allowed on local variable
 
     let c1 = A {};
     c1::<dyn Into<B>>;
-    //~^ ERROR type arguments are not allowed for this type
+    //~^ ERROR type arguments are not allowed on local variable
 }

--- a/src/test/ui/issues/issue-60989.stderr
+++ b/src/test/ui/issues/issue-60989.stderr
@@ -1,14 +1,18 @@
-error[E0109]: type arguments are not allowed for this type
+error[E0109]: type arguments are not allowed on local variable
   --> $DIR/issue-60989.rs:12:10
    |
 LL |     c1::<()>;
-   |          ^^ type argument not allowed
+   |     --   ^^ type argument not allowed
+   |     |
+   |     not allowed on this
 
-error[E0109]: type arguments are not allowed for this type
+error[E0109]: type arguments are not allowed on local variable
   --> $DIR/issue-60989.rs:16:10
    |
 LL |     c1::<dyn Into<B>>;
-   |          ^^^^^^^^^^^ type argument not allowed
+   |     --   ^^^^^^^^^^^ type argument not allowed
+   |     |
+   |     not allowed on this
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/mod-subitem-as-enum-variant.rs
+++ b/src/test/ui/mod-subitem-as-enum-variant.rs
@@ -5,5 +5,5 @@ mod Mod {
 fn main() {
     Mod::FakeVariant::<i32>(0);
     Mod::<i32>::FakeVariant(0);
-    //~^ ERROR type arguments are not allowed for this type [E0109]
+    //~^ ERROR type arguments are not allowed on module `Mod` [E0109]
 }

--- a/src/test/ui/mod-subitem-as-enum-variant.stderr
+++ b/src/test/ui/mod-subitem-as-enum-variant.stderr
@@ -1,8 +1,10 @@
-error[E0109]: type arguments are not allowed for this type
+error[E0109]: type arguments are not allowed on module `Mod`
   --> $DIR/mod-subitem-as-enum-variant.rs:7:11
    |
 LL |     Mod::<i32>::FakeVariant(0);
-   |           ^^^ type argument not allowed
+   |     ---   ^^^ type argument not allowed
+   |     |
+   |     not allowed on this
 
 error: aborting due to previous error
 

--- a/src/test/ui/structs/struct-path-associated-type.rs
+++ b/src/test/ui/structs/struct-path-associated-type.rs
@@ -13,7 +13,7 @@ fn f<T: Tr>() {
     //~^ ERROR expected struct, variant or union type, found associated type
     let z = T::A::<u8> {};
     //~^ ERROR expected struct, variant or union type, found associated type
-    //~| ERROR type arguments are not allowed for this type
+    //~| ERROR type arguments are not allowed on this type
     match S {
         T::A {} => {}
         //~^ ERROR expected struct, variant or union type, found associated type
@@ -22,7 +22,7 @@ fn f<T: Tr>() {
 
 fn g<T: Tr<A = S>>() {
     let s = T::A {}; // OK
-    let z = T::A::<u8> {}; //~ ERROR type arguments are not allowed for this type
+    let z = T::A::<u8> {}; //~ ERROR type arguments are not allowed on this type
     match S {
         T::A {} => {} // OK
     }

--- a/src/test/ui/structs/struct-path-associated-type.stderr
+++ b/src/test/ui/structs/struct-path-associated-type.stderr
@@ -4,11 +4,13 @@ error[E0071]: expected struct, variant or union type, found associated type
 LL |     let s = T::A {};
    |             ^^^^ not a struct
 
-error[E0109]: type arguments are not allowed for this type
+error[E0109]: type arguments are not allowed on this type
   --> $DIR/struct-path-associated-type.rs:14:20
    |
 LL |     let z = T::A::<u8> {};
-   |                    ^^ type argument not allowed
+   |                -   ^^ type argument not allowed
+   |                |
+   |                not allowed on this
 
 error[E0071]: expected struct, variant or union type, found associated type
   --> $DIR/struct-path-associated-type.rs:14:13
@@ -22,11 +24,13 @@ error[E0071]: expected struct, variant or union type, found associated type
 LL |         T::A {} => {}
    |         ^^^^ not a struct
 
-error[E0109]: type arguments are not allowed for this type
+error[E0109]: type arguments are not allowed on this type
   --> $DIR/struct-path-associated-type.rs:25:20
    |
 LL |     let z = T::A::<u8> {};
-   |                    ^^ type argument not allowed
+   |                -   ^^ type argument not allowed
+   |                |
+   |                not allowed on this
 
 error[E0223]: ambiguous associated type
   --> $DIR/struct-path-associated-type.rs:32:13

--- a/src/test/ui/structs/struct-path-self.rs
+++ b/src/test/ui/structs/struct-path-self.rs
@@ -6,7 +6,7 @@ trait Tr {
         //~^ ERROR expected struct, variant or union type, found type parameter
         let z = Self::<u8> {};
         //~^ ERROR expected struct, variant or union type, found type parameter
-        //~| ERROR type arguments are not allowed for this type
+        //~| ERROR type arguments are not allowed on self type
         match s {
             Self { .. } => {}
             //~^ ERROR expected struct, variant or union type, found type parameter
@@ -17,7 +17,7 @@ trait Tr {
 impl Tr for S {
     fn f() {
         let s = Self {}; // OK
-        let z = Self::<u8> {}; //~ ERROR type arguments are not allowed for this type
+        let z = Self::<u8> {}; //~ ERROR type arguments are not allowed on self type
         match s {
             Self { .. } => {} // OK
         }
@@ -27,7 +27,7 @@ impl Tr for S {
 impl S {
     fn g() {
         let s = Self {}; // OK
-        let z = Self::<u8> {}; //~ ERROR type arguments are not allowed for this type
+        let z = Self::<u8> {}; //~ ERROR type arguments are not allowed on self type
         match s {
             Self { .. } => {} // OK
         }

--- a/src/test/ui/structs/struct-path-self.stderr
+++ b/src/test/ui/structs/struct-path-self.stderr
@@ -42,7 +42,7 @@ note: `Self` is of type `S`
   --> $DIR/struct-path-self.rs:1:8
    |
 LL | struct S;
-   |        ^ `Self` corresponds to this type, which doesn't have type parameters
+   |        ^ `Self` corresponds to this type, which doesn't have generic parameters
 ...
 LL | impl Tr for S {
    | ------------- `Self` is on type `S` in this `impl`
@@ -64,7 +64,7 @@ note: `Self` is of type `S`
   --> $DIR/struct-path-self.rs:1:8
    |
 LL | struct S;
-   |        ^ `Self` corresponds to this type, which doesn't have type parameters
+   |        ^ `Self` corresponds to this type, which doesn't have generic parameters
 ...
 LL | impl S {
    | ------ `Self` is on type `S` in this `impl`

--- a/src/test/ui/structs/struct-path-self.stderr
+++ b/src/test/ui/structs/struct-path-self.stderr
@@ -41,7 +41,7 @@ LL | struct S;
    |        ^ `Self` corresponds to this type, which doesn't have type parameters
 ...
 LL | impl Tr for S {
-   | ------------- `Self` is or type `S` in this `impl`
+   | ------------- `Self` is on type `S` in this `impl`
 help: the `Self` type doesn't accept type parameters
    |
 LL -         let z = Self::<u8> {};
@@ -61,7 +61,7 @@ LL | struct S;
    |        ^ `Self` corresponds to this type, which doesn't have type parameters
 ...
 LL | impl S {
-   | ------ `Self` is or type `S` in this `impl`
+   | ------ `Self` is on type `S` in this `impl`
 help: the `Self` type doesn't accept type parameters
    |
 LL -         let z = Self::<u8> {};

--- a/src/test/ui/structs/struct-path-self.stderr
+++ b/src/test/ui/structs/struct-path-self.stderr
@@ -4,11 +4,13 @@ error[E0071]: expected struct, variant or union type, found type parameter `Self
 LL |         let s = Self {};
    |                 ^^^^ not a struct
 
-error[E0109]: type arguments are not allowed for this type
+error[E0109]: type arguments are not allowed on self type
   --> $DIR/struct-path-self.rs:7:24
    |
 LL |         let z = Self::<u8> {};
-   |                        ^^ type argument not allowed
+   |                 ----   ^^ type argument not allowed
+   |                 |
+   |                 not allowed on this
    |
 help: the `Self` type doesn't accept type parameters
    |
@@ -28,11 +30,13 @@ error[E0071]: expected struct, variant or union type, found type parameter `Self
 LL |             Self { .. } => {}
    |             ^^^^ not a struct
 
-error[E0109]: type arguments are not allowed for this type
+error[E0109]: type arguments are not allowed on self type
   --> $DIR/struct-path-self.rs:20:24
    |
 LL |         let z = Self::<u8> {};
-   |                        ^^ type argument not allowed
+   |                 ----   ^^ type argument not allowed
+   |                 |
+   |                 not allowed on this
    |
 note: `Self` is of type `S`
   --> $DIR/struct-path-self.rs:1:8
@@ -48,11 +52,13 @@ LL -         let z = Self::<u8> {};
 LL +         let z = Self {};
    | 
 
-error[E0109]: type arguments are not allowed for this type
+error[E0109]: type arguments are not allowed on self type
   --> $DIR/struct-path-self.rs:30:24
    |
 LL |         let z = Self::<u8> {};
-   |                        ^^ type argument not allowed
+   |                 ----   ^^ type argument not allowed
+   |                 |
+   |                 not allowed on this
    |
 note: `Self` is of type `S`
   --> $DIR/struct-path-self.rs:1:8

--- a/src/test/ui/structs/struct-path-self.stderr
+++ b/src/test/ui/structs/struct-path-self.stderr
@@ -9,6 +9,12 @@ error[E0109]: type arguments are not allowed for this type
    |
 LL |         let z = Self::<u8> {};
    |                        ^^ type argument not allowed
+   |
+help: the `Self` type doesn't accept type parameters
+   |
+LL -         let z = Self::<u8> {};
+LL +         let z = Self {};
+   | 
 
 error[E0071]: expected struct, variant or union type, found type parameter `Self`
   --> $DIR/struct-path-self.rs:7:17
@@ -27,12 +33,38 @@ error[E0109]: type arguments are not allowed for this type
    |
 LL |         let z = Self::<u8> {};
    |                        ^^ type argument not allowed
+   |
+note: the `Self` type is `S`
+  --> $DIR/struct-path-self.rs:1:8
+   |
+LL | struct S;
+   |        ^ `Self` corresponds to this type
+...
+LL | impl Tr for S {
+   | ------------- `Self` is `S` in this `impl`
+help: the `Self` type doesn't accept type parameters, use the concrete type's name `S` instead if you want to specify its type parameters
+   |
+LL |         let z = S::<u8> {};
+   |                 ~
 
 error[E0109]: type arguments are not allowed for this type
   --> $DIR/struct-path-self.rs:30:24
    |
 LL |         let z = Self::<u8> {};
    |                        ^^ type argument not allowed
+   |
+note: the `Self` type is `S`
+  --> $DIR/struct-path-self.rs:1:8
+   |
+LL | struct S;
+   |        ^ `Self` corresponds to this type
+...
+LL | impl S {
+   | ------ `Self` is `S` in this `impl`
+help: the `Self` type doesn't accept type parameters, use the concrete type's name `S` instead if you want to specify its type parameters
+   |
+LL |         let z = S::<u8> {};
+   |                 ~
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/structs/struct-path-self.stderr
+++ b/src/test/ui/structs/struct-path-self.stderr
@@ -34,18 +34,19 @@ error[E0109]: type arguments are not allowed for this type
 LL |         let z = Self::<u8> {};
    |                        ^^ type argument not allowed
    |
-note: the `Self` type is `S`
+note: `Self` is of type `S`
   --> $DIR/struct-path-self.rs:1:8
    |
 LL | struct S;
-   |        ^ `Self` corresponds to this type
+   |        ^ `Self` corresponds to this type, which doesn't have type parameters
 ...
 LL | impl Tr for S {
-   | ------------- `Self` is `S` in this `impl`
-help: the `Self` type doesn't accept type parameters, use the concrete type's name `S` instead if you want to specify its type parameters
+   | ------------- `Self` is or type `S` in this `impl`
+help: the `Self` type doesn't accept type parameters
    |
-LL |         let z = S::<u8> {};
-   |                 ~
+LL -         let z = Self::<u8> {};
+LL +         let z = Self {};
+   | 
 
 error[E0109]: type arguments are not allowed for this type
   --> $DIR/struct-path-self.rs:30:24
@@ -53,18 +54,19 @@ error[E0109]: type arguments are not allowed for this type
 LL |         let z = Self::<u8> {};
    |                        ^^ type argument not allowed
    |
-note: the `Self` type is `S`
+note: `Self` is of type `S`
   --> $DIR/struct-path-self.rs:1:8
    |
 LL | struct S;
-   |        ^ `Self` corresponds to this type
+   |        ^ `Self` corresponds to this type, which doesn't have type parameters
 ...
 LL | impl S {
-   | ------ `Self` is `S` in this `impl`
-help: the `Self` type doesn't accept type parameters, use the concrete type's name `S` instead if you want to specify its type parameters
+   | ------ `Self` is or type `S` in this `impl`
+help: the `Self` type doesn't accept type parameters
    |
-LL |         let z = S::<u8> {};
-   |                 ~
+LL -         let z = Self::<u8> {};
+LL +         let z = Self {};
+   | 
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/type-alias-enum-variants/enum-variant-generic-args.rs
+++ b/src/test/ui/type-alias-enum-variants/enum-variant-generic-args.rs
@@ -13,38 +13,38 @@ impl<T> Enum<T> {
         Self::TSVariant(());
         //~^ ERROR mismatched types [E0308]
         Self::TSVariant::<()>(());
-        //~^ ERROR type arguments are not allowed for this type [E0109]
+        //~^ ERROR type arguments are not allowed on this type [E0109]
         Self::<()>::TSVariant(());
-        //~^ ERROR type arguments are not allowed for this type [E0109]
+        //~^ ERROR type arguments are not allowed on self type [E0109]
         //~| ERROR mismatched types [E0308]
         Self::<()>::TSVariant::<()>(());
-        //~^ ERROR type arguments are not allowed for this type [E0109]
-        //~| ERROR type arguments are not allowed for this type [E0109]
+        //~^ ERROR type arguments are not allowed on self type [E0109]
+        //~| ERROR type arguments are not allowed on this type [E0109]
     }
 
     fn s_variant() {
         Self::SVariant { v: () };
         //~^ ERROR mismatched types [E0308]
         Self::SVariant::<()> { v: () };
-        //~^ ERROR type arguments are not allowed for this type [E0109]
+        //~^ ERROR type arguments are not allowed on this type [E0109]
         //~| ERROR mismatched types [E0308]
         Self::<()>::SVariant { v: () };
-        //~^ ERROR type arguments are not allowed for this type [E0109]
+        //~^ ERROR type arguments are not allowed on self type [E0109]
         //~| ERROR mismatched types [E0308]
         Self::<()>::SVariant::<()> { v: () };
-        //~^ ERROR type arguments are not allowed for this type [E0109]
-        //~| ERROR type arguments are not allowed for this type [E0109]
+        //~^ ERROR type arguments are not allowed on self type [E0109]
+        //~| ERROR type arguments are not allowed on this type [E0109]
         //~| ERROR mismatched types [E0308]
     }
 
     fn u_variant() {
         Self::UVariant::<()>;
-        //~^ ERROR type arguments are not allowed for this type [E0109]
+        //~^ ERROR type arguments are not allowed on this type [E0109]
         Self::<()>::UVariant;
-        //~^ ERROR type arguments are not allowed for this type [E0109]
+        //~^ ERROR type arguments are not allowed on self type [E0109]
         Self::<()>::UVariant::<()>;
-        //~^ ERROR type arguments are not allowed for this type [E0109]
-        //~| ERROR type arguments are not allowed for this type [E0109]
+        //~^ ERROR type arguments are not allowed on self type [E0109]
+        //~| ERROR type arguments are not allowed on this type [E0109]
     }
 }
 
@@ -52,54 +52,54 @@ fn main() {
     // Tuple struct variant
 
     Enum::<()>::TSVariant::<()>(());
-    //~^ ERROR type arguments are not allowed for this type [E0109]
+    //~^ ERROR type arguments are not allowed on this type [E0109]
 
     Alias::TSVariant::<()>(());
-    //~^ ERROR type arguments are not allowed for this type [E0109]
+    //~^ ERROR type arguments are not allowed on this type [E0109]
     Alias::<()>::TSVariant::<()>(());
-    //~^ ERROR type arguments are not allowed for this type [E0109]
+    //~^ ERROR type arguments are not allowed on this type [E0109]
 
     AliasFixed::TSVariant::<()>(());
-    //~^ ERROR type arguments are not allowed for this type [E0109]
+    //~^ ERROR type arguments are not allowed on this type [E0109]
     AliasFixed::<()>::TSVariant(());
     //~^ ERROR this type alias takes 0 generic arguments but 1 generic argument was supplied [E0107]
     AliasFixed::<()>::TSVariant::<()>(());
-    //~^ ERROR type arguments are not allowed for this type [E0109]
+    //~^ ERROR type arguments are not allowed on this type [E0109]
     //~| ERROR this type alias takes 0 generic arguments but 1 generic argument was supplied [E0107]
 
     // Struct variant
 
     Enum::<()>::SVariant::<()> { v: () };
-    //~^ ERROR type arguments are not allowed for this type [E0109]
+    //~^ ERROR type arguments are not allowed on this type [E0109]
 
     Alias::SVariant::<()> { v: () };
-    //~^ ERROR type arguments are not allowed for this type [E0109]
+    //~^ ERROR type arguments are not allowed on this type [E0109]
     Alias::<()>::SVariant::<()> { v: () };
-    //~^ ERROR type arguments are not allowed for this type [E0109]
+    //~^ ERROR type arguments are not allowed on this type [E0109]
 
     AliasFixed::SVariant::<()> { v: () };
-    //~^ ERROR type arguments are not allowed for this type [E0109]
+    //~^ ERROR type arguments are not allowed on this type [E0109]
     AliasFixed::<()>::SVariant { v: () };
     //~^ ERROR this type alias takes 0 generic arguments but 1 generic argument was supplied [E0107]
     AliasFixed::<()>::SVariant::<()> { v: () };
-    //~^ ERROR type arguments are not allowed for this type [E0109]
+    //~^ ERROR type arguments are not allowed on this type [E0109]
     //~| ERROR this type alias takes 0 generic arguments but 1 generic argument was supplied [E0107]
 
     // Unit variant
 
     Enum::<()>::UVariant::<()>;
-    //~^ ERROR type arguments are not allowed for this type [E0109]
+    //~^ ERROR type arguments are not allowed on this type [E0109]
 
     Alias::UVariant::<()>;
-    //~^ ERROR type arguments are not allowed for this type [E0109]
+    //~^ ERROR type arguments are not allowed on this type [E0109]
     Alias::<()>::UVariant::<()>;
-    //~^ ERROR type arguments are not allowed for this type [E0109]
+    //~^ ERROR type arguments are not allowed on this type [E0109]
 
     AliasFixed::UVariant::<()>;
-    //~^ ERROR type arguments are not allowed for this type [E0109]
+    //~^ ERROR type arguments are not allowed on this type [E0109]
     AliasFixed::<()>::UVariant;
     //~^ ERROR this type alias takes 0 generic arguments but 1 generic argument was supplied [E0107]
     AliasFixed::<()>::UVariant::<()>;
-    //~^ ERROR type arguments are not allowed for this type [E0109]
+    //~^ ERROR type arguments are not allowed on this type [E0109]
     //~| ERROR this type alias takes 0 generic arguments but 1 generic argument was supplied [E0107]
 }

--- a/src/test/ui/type-alias-enum-variants/enum-variant-generic-args.stderr
+++ b/src/test/ui/type-alias-enum-variants/enum-variant-generic-args.stderr
@@ -17,17 +17,21 @@ note: tuple variant defined here
 LL | enum Enum<T> { TSVariant(T), SVariant { v: T }, UVariant }
    |                ^^^^^^^^^
 
-error[E0109]: type arguments are not allowed for this type
+error[E0109]: type arguments are not allowed on this type
   --> $DIR/enum-variant-generic-args.rs:15:27
    |
 LL |         Self::TSVariant::<()>(());
-   |                           ^^ type argument not allowed
+   |               ---------   ^^ type argument not allowed
+   |               |
+   |               not allowed on this
 
-error[E0109]: type arguments are not allowed for this type
+error[E0109]: type arguments are not allowed on self type
   --> $DIR/enum-variant-generic-args.rs:17:16
    |
 LL |         Self::<()>::TSVariant(());
-   |                ^^ type argument not allowed
+   |         ----   ^^ type argument not allowed
+   |         |
+   |         not allowed on this
    |
 note: `Self` is of type `Enum<T>`
   --> $DIR/enum-variant-generic-args.rs:7:6
@@ -61,11 +65,13 @@ note: tuple variant defined here
 LL | enum Enum<T> { TSVariant(T), SVariant { v: T }, UVariant }
    |                ^^^^^^^^^
 
-error[E0109]: type arguments are not allowed for this type
+error[E0109]: type arguments are not allowed on self type
   --> $DIR/enum-variant-generic-args.rs:20:16
    |
 LL |         Self::<()>::TSVariant::<()>(());
-   |                ^^ type argument not allowed
+   |         ----   ^^ type argument not allowed
+   |         |
+   |         not allowed on this
    |
 note: `Self` is of type `Enum<T>`
   --> $DIR/enum-variant-generic-args.rs:7:6
@@ -80,11 +86,13 @@ help: the `Self` type doesn't accept type parameters, use the concrete type's na
 LL |         Enum::<()>::TSVariant::<()>(());
    |         ~~~~
 
-error[E0109]: type arguments are not allowed for this type
+error[E0109]: type arguments are not allowed on this type
   --> $DIR/enum-variant-generic-args.rs:20:33
    |
 LL |         Self::<()>::TSVariant::<()>(());
-   |                                 ^^ type argument not allowed
+   |                     ---------   ^^ type argument not allowed
+   |                     |
+   |                     not allowed on this
 
 error[E0308]: mismatched types
   --> $DIR/enum-variant-generic-args.rs:26:29
@@ -98,11 +106,13 @@ LL |         Self::SVariant { v: () };
    = note: expected type parameter `T`
                    found unit type `()`
 
-error[E0109]: type arguments are not allowed for this type
+error[E0109]: type arguments are not allowed on this type
   --> $DIR/enum-variant-generic-args.rs:28:26
    |
 LL |         Self::SVariant::<()> { v: () };
-   |                          ^^ type argument not allowed
+   |               --------   ^^ type argument not allowed
+   |               |
+   |               not allowed on this
    |
    = note: enum variants can't have type parameters
 help: you might have meant to specity type parameters on enum `Enum`
@@ -123,11 +133,13 @@ LL |         Self::SVariant::<()> { v: () };
    = note: expected type parameter `T`
                    found unit type `()`
 
-error[E0109]: type arguments are not allowed for this type
+error[E0109]: type arguments are not allowed on self type
   --> $DIR/enum-variant-generic-args.rs:31:16
    |
 LL |         Self::<()>::SVariant { v: () };
-   |                ^^ type argument not allowed
+   |         ----   ^^ type argument not allowed
+   |         |
+   |         not allowed on this
    |
 note: `Self` is of type `Enum<T>`
   --> $DIR/enum-variant-generic-args.rs:7:6
@@ -154,11 +166,13 @@ LL |         Self::<()>::SVariant { v: () };
    = note: expected type parameter `T`
                    found unit type `()`
 
-error[E0109]: type arguments are not allowed for this type
+error[E0109]: type arguments are not allowed on self type
   --> $DIR/enum-variant-generic-args.rs:34:16
    |
 LL |         Self::<()>::SVariant::<()> { v: () };
-   |                ^^ type argument not allowed
+   |         ----   ^^ type argument not allowed
+   |         |
+   |         not allowed on this
    |
 note: `Self` is of type `Enum<T>`
   --> $DIR/enum-variant-generic-args.rs:7:6
@@ -173,11 +187,13 @@ help: the `Self` type doesn't accept type parameters, use the concrete type's na
 LL |         Enum::<()>::SVariant::<()> { v: () };
    |         ~~~~
 
-error[E0109]: type arguments are not allowed for this type
+error[E0109]: type arguments are not allowed on this type
   --> $DIR/enum-variant-generic-args.rs:34:32
    |
 LL |         Self::<()>::SVariant::<()> { v: () };
-   |                                ^^ type argument not allowed
+   |                     --------   ^^ type argument not allowed
+   |                     |
+   |                     not allowed on this
    |
    = note: enum variants can't have type parameters
 help: you might have meant to specity type parameters on enum `Enum`
@@ -198,17 +214,21 @@ LL |         Self::<()>::SVariant::<()> { v: () };
    = note: expected type parameter `T`
                    found unit type `()`
 
-error[E0109]: type arguments are not allowed for this type
+error[E0109]: type arguments are not allowed on this type
   --> $DIR/enum-variant-generic-args.rs:41:26
    |
 LL |         Self::UVariant::<()>;
-   |                          ^^ type argument not allowed
+   |               --------   ^^ type argument not allowed
+   |               |
+   |               not allowed on this
 
-error[E0109]: type arguments are not allowed for this type
+error[E0109]: type arguments are not allowed on self type
   --> $DIR/enum-variant-generic-args.rs:43:16
    |
 LL |         Self::<()>::UVariant;
-   |                ^^ type argument not allowed
+   |         ----   ^^ type argument not allowed
+   |         |
+   |         not allowed on this
    |
 note: `Self` is of type `Enum<T>`
   --> $DIR/enum-variant-generic-args.rs:7:6
@@ -223,11 +243,13 @@ help: the `Self` type doesn't accept type parameters, use the concrete type's na
 LL |         Enum::<()>::UVariant;
    |         ~~~~
 
-error[E0109]: type arguments are not allowed for this type
+error[E0109]: type arguments are not allowed on self type
   --> $DIR/enum-variant-generic-args.rs:45:16
    |
 LL |         Self::<()>::UVariant::<()>;
-   |                ^^ type argument not allowed
+   |         ----   ^^ type argument not allowed
+   |         |
+   |         not allowed on this
    |
 note: `Self` is of type `Enum<T>`
   --> $DIR/enum-variant-generic-args.rs:7:6
@@ -242,35 +264,45 @@ help: the `Self` type doesn't accept type parameters, use the concrete type's na
 LL |         Enum::<()>::UVariant::<()>;
    |         ~~~~
 
-error[E0109]: type arguments are not allowed for this type
+error[E0109]: type arguments are not allowed on this type
   --> $DIR/enum-variant-generic-args.rs:45:32
    |
 LL |         Self::<()>::UVariant::<()>;
-   |                                ^^ type argument not allowed
+   |                     --------   ^^ type argument not allowed
+   |                     |
+   |                     not allowed on this
 
-error[E0109]: type arguments are not allowed for this type
+error[E0109]: type arguments are not allowed on this type
   --> $DIR/enum-variant-generic-args.rs:54:29
    |
 LL |     Enum::<()>::TSVariant::<()>(());
-   |                             ^^ type argument not allowed
+   |                 ---------   ^^ type argument not allowed
+   |                 |
+   |                 not allowed on this
 
-error[E0109]: type arguments are not allowed for this type
+error[E0109]: type arguments are not allowed on this type
   --> $DIR/enum-variant-generic-args.rs:57:24
    |
 LL |     Alias::TSVariant::<()>(());
-   |                        ^^ type argument not allowed
+   |            ---------   ^^ type argument not allowed
+   |            |
+   |            not allowed on this
 
-error[E0109]: type arguments are not allowed for this type
+error[E0109]: type arguments are not allowed on this type
   --> $DIR/enum-variant-generic-args.rs:59:30
    |
 LL |     Alias::<()>::TSVariant::<()>(());
-   |                              ^^ type argument not allowed
+   |                  ---------   ^^ type argument not allowed
+   |                  |
+   |                  not allowed on this
 
-error[E0109]: type arguments are not allowed for this type
+error[E0109]: type arguments are not allowed on this type
   --> $DIR/enum-variant-generic-args.rs:62:29
    |
 LL |     AliasFixed::TSVariant::<()>(());
-   |                             ^^ type argument not allowed
+   |                 ---------   ^^ type argument not allowed
+   |                 |
+   |                 not allowed on this
 
 error[E0107]: this type alias takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/enum-variant-generic-args.rs:64:5
@@ -300,25 +332,31 @@ note: type alias defined here, with 0 generic parameters
 LL | type AliasFixed = Enum<()>;
    |      ^^^^^^^^^^
 
-error[E0109]: type arguments are not allowed for this type
+error[E0109]: type arguments are not allowed on this type
   --> $DIR/enum-variant-generic-args.rs:66:35
    |
 LL |     AliasFixed::<()>::TSVariant::<()>(());
-   |                                   ^^ type argument not allowed
+   |                       ---------   ^^ type argument not allowed
+   |                       |
+   |                       not allowed on this
 
-error[E0109]: type arguments are not allowed for this type
+error[E0109]: type arguments are not allowed on this type
   --> $DIR/enum-variant-generic-args.rs:72:28
    |
 LL |     Enum::<()>::SVariant::<()> { v: () };
-   |                            ^^ type argument not allowed
+   |                 --------   ^^ type argument not allowed
+   |                 |
+   |                 not allowed on this
    |
    = note: enum variants can't have type parameters
 
-error[E0109]: type arguments are not allowed for this type
+error[E0109]: type arguments are not allowed on this type
   --> $DIR/enum-variant-generic-args.rs:75:23
    |
 LL |     Alias::SVariant::<()> { v: () };
-   |                       ^^ type argument not allowed
+   |            --------   ^^ type argument not allowed
+   |            |
+   |            not allowed on this
    |
    = note: enum variants can't have type parameters
 help: you might have meant to specity type parameters on enum `Enum`
@@ -327,11 +365,13 @@ LL -     Alias::SVariant::<()> { v: () };
 LL +     Alias::<()>::SVariant { v: () };
    | 
 
-error[E0109]: type arguments are not allowed for this type
+error[E0109]: type arguments are not allowed on this type
   --> $DIR/enum-variant-generic-args.rs:77:29
    |
 LL |     Alias::<()>::SVariant::<()> { v: () };
-   |                             ^^ type argument not allowed
+   |                  --------   ^^ type argument not allowed
+   |                  |
+   |                  not allowed on this
    |
    = note: enum variants can't have type parameters
 help: you might have meant to specity type parameters on enum `Enum`
@@ -340,11 +380,13 @@ LL -     Alias::<()>::SVariant::<()> { v: () };
 LL +     Alias::<()>::SVariant { v: () };
    | 
 
-error[E0109]: type arguments are not allowed for this type
+error[E0109]: type arguments are not allowed on this type
   --> $DIR/enum-variant-generic-args.rs:80:28
    |
 LL |     AliasFixed::SVariant::<()> { v: () };
-   |                            ^^ type argument not allowed
+   |                 --------   ^^ type argument not allowed
+   |                 |
+   |                 not allowed on this
    |
    = note: enum variants can't have type parameters
 help: you might have meant to specity type parameters on enum `Enum`
@@ -381,11 +423,13 @@ note: type alias defined here, with 0 generic parameters
 LL | type AliasFixed = Enum<()>;
    |      ^^^^^^^^^^
 
-error[E0109]: type arguments are not allowed for this type
+error[E0109]: type arguments are not allowed on this type
   --> $DIR/enum-variant-generic-args.rs:84:34
    |
 LL |     AliasFixed::<()>::SVariant::<()> { v: () };
-   |                                  ^^ type argument not allowed
+   |                       --------   ^^ type argument not allowed
+   |                       |
+   |                       not allowed on this
    |
    = note: enum variants can't have type parameters
 help: you might have meant to specity type parameters on enum `Enum`
@@ -394,29 +438,37 @@ LL -     AliasFixed::<()>::SVariant::<()> { v: () };
 LL +     AliasFixed::<()>::SVariant { v: () };
    | 
 
-error[E0109]: type arguments are not allowed for this type
+error[E0109]: type arguments are not allowed on this type
   --> $DIR/enum-variant-generic-args.rs:90:28
    |
 LL |     Enum::<()>::UVariant::<()>;
-   |                            ^^ type argument not allowed
+   |                 --------   ^^ type argument not allowed
+   |                 |
+   |                 not allowed on this
 
-error[E0109]: type arguments are not allowed for this type
+error[E0109]: type arguments are not allowed on this type
   --> $DIR/enum-variant-generic-args.rs:93:23
    |
 LL |     Alias::UVariant::<()>;
-   |                       ^^ type argument not allowed
+   |            --------   ^^ type argument not allowed
+   |            |
+   |            not allowed on this
 
-error[E0109]: type arguments are not allowed for this type
+error[E0109]: type arguments are not allowed on this type
   --> $DIR/enum-variant-generic-args.rs:95:29
    |
 LL |     Alias::<()>::UVariant::<()>;
-   |                             ^^ type argument not allowed
+   |                  --------   ^^ type argument not allowed
+   |                  |
+   |                  not allowed on this
 
-error[E0109]: type arguments are not allowed for this type
+error[E0109]: type arguments are not allowed on this type
   --> $DIR/enum-variant-generic-args.rs:98:28
    |
 LL |     AliasFixed::UVariant::<()>;
-   |                            ^^ type argument not allowed
+   |                 --------   ^^ type argument not allowed
+   |                 |
+   |                 not allowed on this
 
 error[E0107]: this type alias takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/enum-variant-generic-args.rs:100:5
@@ -446,11 +498,13 @@ note: type alias defined here, with 0 generic parameters
 LL | type AliasFixed = Enum<()>;
    |      ^^^^^^^^^^
 
-error[E0109]: type arguments are not allowed for this type
+error[E0109]: type arguments are not allowed on this type
   --> $DIR/enum-variant-generic-args.rs:102:34
    |
 LL |     AliasFixed::<()>::UVariant::<()>;
-   |                                  ^^ type argument not allowed
+   |                       --------   ^^ type argument not allowed
+   |                       |
+   |                       not allowed on this
 
 error: aborting due to 39 previous errors
 

--- a/src/test/ui/type-alias-enum-variants/enum-variant-generic-args.stderr
+++ b/src/test/ui/type-alias-enum-variants/enum-variant-generic-args.stderr
@@ -29,14 +29,14 @@ error[E0109]: type arguments are not allowed for this type
 LL |         Self::<()>::TSVariant(());
    |                ^^ type argument not allowed
    |
-note: the `Self` type is `Enum<T>`
+note: `Self` is of type `Enum<T>`
   --> $DIR/enum-variant-generic-args.rs:7:6
    |
 LL | enum Enum<T> { TSVariant(T), SVariant { v: T }, UVariant }
    |      ^^^^ `Self` corresponds to this type
 ...
 LL | impl<T> Enum<T> {
-   | --------------- `Self` is `Enum` in this `impl`
+   | --------------- `Self` is or type `Enum` in this `impl`
 help: the `Self` type doesn't accept type parameters, use the concrete type's name `Enum` instead if you want to specify its type parameters
    |
 LL |         Enum::<()>::TSVariant(());
@@ -67,14 +67,14 @@ error[E0109]: type arguments are not allowed for this type
 LL |         Self::<()>::TSVariant::<()>(());
    |                ^^ type argument not allowed
    |
-note: the `Self` type is `Enum<T>`
+note: `Self` is of type `Enum<T>`
   --> $DIR/enum-variant-generic-args.rs:7:6
    |
 LL | enum Enum<T> { TSVariant(T), SVariant { v: T }, UVariant }
    |      ^^^^ `Self` corresponds to this type
 ...
 LL | impl<T> Enum<T> {
-   | --------------- `Self` is `Enum` in this `impl`
+   | --------------- `Self` is or type `Enum` in this `impl`
 help: the `Self` type doesn't accept type parameters, use the concrete type's name `Enum` instead if you want to specify its type parameters
    |
 LL |         Enum::<()>::TSVariant::<()>(());
@@ -129,14 +129,14 @@ error[E0109]: type arguments are not allowed for this type
 LL |         Self::<()>::SVariant { v: () };
    |                ^^ type argument not allowed
    |
-note: the `Self` type is `Enum<T>`
+note: `Self` is of type `Enum<T>`
   --> $DIR/enum-variant-generic-args.rs:7:6
    |
 LL | enum Enum<T> { TSVariant(T), SVariant { v: T }, UVariant }
    |      ^^^^ `Self` corresponds to this type
 ...
 LL | impl<T> Enum<T> {
-   | --------------- `Self` is `Enum` in this `impl`
+   | --------------- `Self` is or type `Enum` in this `impl`
 help: the `Self` type doesn't accept type parameters, use the concrete type's name `Enum` instead if you want to specify its type parameters
    |
 LL |         Enum::<()>::SVariant { v: () };
@@ -160,14 +160,14 @@ error[E0109]: type arguments are not allowed for this type
 LL |         Self::<()>::SVariant::<()> { v: () };
    |                ^^ type argument not allowed
    |
-note: the `Self` type is `Enum<T>`
+note: `Self` is of type `Enum<T>`
   --> $DIR/enum-variant-generic-args.rs:7:6
    |
 LL | enum Enum<T> { TSVariant(T), SVariant { v: T }, UVariant }
    |      ^^^^ `Self` corresponds to this type
 ...
 LL | impl<T> Enum<T> {
-   | --------------- `Self` is `Enum` in this `impl`
+   | --------------- `Self` is or type `Enum` in this `impl`
 help: the `Self` type doesn't accept type parameters, use the concrete type's name `Enum` instead if you want to specify its type parameters
    |
 LL |         Enum::<()>::SVariant::<()> { v: () };
@@ -210,14 +210,14 @@ error[E0109]: type arguments are not allowed for this type
 LL |         Self::<()>::UVariant;
    |                ^^ type argument not allowed
    |
-note: the `Self` type is `Enum<T>`
+note: `Self` is of type `Enum<T>`
   --> $DIR/enum-variant-generic-args.rs:7:6
    |
 LL | enum Enum<T> { TSVariant(T), SVariant { v: T }, UVariant }
    |      ^^^^ `Self` corresponds to this type
 ...
 LL | impl<T> Enum<T> {
-   | --------------- `Self` is `Enum` in this `impl`
+   | --------------- `Self` is or type `Enum` in this `impl`
 help: the `Self` type doesn't accept type parameters, use the concrete type's name `Enum` instead if you want to specify its type parameters
    |
 LL |         Enum::<()>::UVariant;
@@ -229,14 +229,14 @@ error[E0109]: type arguments are not allowed for this type
 LL |         Self::<()>::UVariant::<()>;
    |                ^^ type argument not allowed
    |
-note: the `Self` type is `Enum<T>`
+note: `Self` is of type `Enum<T>`
   --> $DIR/enum-variant-generic-args.rs:7:6
    |
 LL | enum Enum<T> { TSVariant(T), SVariant { v: T }, UVariant }
    |      ^^^^ `Self` corresponds to this type
 ...
 LL | impl<T> Enum<T> {
-   | --------------- `Self` is `Enum` in this `impl`
+   | --------------- `Self` is or type `Enum` in this `impl`
 help: the `Self` type doesn't accept type parameters, use the concrete type's name `Enum` instead if you want to specify its type parameters
    |
 LL |         Enum::<()>::UVariant::<()>;

--- a/src/test/ui/type-alias-enum-variants/enum-variant-generic-args.stderr
+++ b/src/test/ui/type-alias-enum-variants/enum-variant-generic-args.stderr
@@ -28,6 +28,19 @@ error[E0109]: type arguments are not allowed for this type
    |
 LL |         Self::<()>::TSVariant(());
    |                ^^ type argument not allowed
+   |
+note: the `Self` type is `Enum<T>`
+  --> $DIR/enum-variant-generic-args.rs:7:6
+   |
+LL | enum Enum<T> { TSVariant(T), SVariant { v: T }, UVariant }
+   |      ^^^^ `Self` corresponds to this type
+...
+LL | impl<T> Enum<T> {
+   | --------------- `Self` is `Enum` in this `impl`
+help: the `Self` type doesn't accept type parameters, use the concrete type's name `Enum` instead if you want to specify its type parameters
+   |
+LL |         Enum::<()>::TSVariant(());
+   |         ~~~~
 
 error[E0308]: mismatched types
   --> $DIR/enum-variant-generic-args.rs:17:31
@@ -53,6 +66,19 @@ error[E0109]: type arguments are not allowed for this type
    |
 LL |         Self::<()>::TSVariant::<()>(());
    |                ^^ type argument not allowed
+   |
+note: the `Self` type is `Enum<T>`
+  --> $DIR/enum-variant-generic-args.rs:7:6
+   |
+LL | enum Enum<T> { TSVariant(T), SVariant { v: T }, UVariant }
+   |      ^^^^ `Self` corresponds to this type
+...
+LL | impl<T> Enum<T> {
+   | --------------- `Self` is `Enum` in this `impl`
+help: the `Self` type doesn't accept type parameters, use the concrete type's name `Enum` instead if you want to specify its type parameters
+   |
+LL |         Enum::<()>::TSVariant::<()>(());
+   |         ~~~~
 
 error[E0109]: type arguments are not allowed for this type
   --> $DIR/enum-variant-generic-args.rs:20:33
@@ -77,6 +103,13 @@ error[E0109]: type arguments are not allowed for this type
    |
 LL |         Self::SVariant::<()> { v: () };
    |                          ^^ type argument not allowed
+   |
+   = note: enum variants can't have type parameters
+help: you might have meant to specity type parameters on enum `Enum`
+   |
+LL -         Self::SVariant::<()> { v: () };
+LL +         Enum::<()>::SVariant { v: () };
+   | 
 
 error[E0308]: mismatched types
   --> $DIR/enum-variant-generic-args.rs:28:35
@@ -95,6 +128,19 @@ error[E0109]: type arguments are not allowed for this type
    |
 LL |         Self::<()>::SVariant { v: () };
    |                ^^ type argument not allowed
+   |
+note: the `Self` type is `Enum<T>`
+  --> $DIR/enum-variant-generic-args.rs:7:6
+   |
+LL | enum Enum<T> { TSVariant(T), SVariant { v: T }, UVariant }
+   |      ^^^^ `Self` corresponds to this type
+...
+LL | impl<T> Enum<T> {
+   | --------------- `Self` is `Enum` in this `impl`
+help: the `Self` type doesn't accept type parameters, use the concrete type's name `Enum` instead if you want to specify its type parameters
+   |
+LL |         Enum::<()>::SVariant { v: () };
+   |         ~~~~
 
 error[E0308]: mismatched types
   --> $DIR/enum-variant-generic-args.rs:31:35
@@ -113,12 +159,32 @@ error[E0109]: type arguments are not allowed for this type
    |
 LL |         Self::<()>::SVariant::<()> { v: () };
    |                ^^ type argument not allowed
+   |
+note: the `Self` type is `Enum<T>`
+  --> $DIR/enum-variant-generic-args.rs:7:6
+   |
+LL | enum Enum<T> { TSVariant(T), SVariant { v: T }, UVariant }
+   |      ^^^^ `Self` corresponds to this type
+...
+LL | impl<T> Enum<T> {
+   | --------------- `Self` is `Enum` in this `impl`
+help: the `Self` type doesn't accept type parameters, use the concrete type's name `Enum` instead if you want to specify its type parameters
+   |
+LL |         Enum::<()>::SVariant::<()> { v: () };
+   |         ~~~~
 
 error[E0109]: type arguments are not allowed for this type
   --> $DIR/enum-variant-generic-args.rs:34:32
    |
 LL |         Self::<()>::SVariant::<()> { v: () };
    |                                ^^ type argument not allowed
+   |
+   = note: enum variants can't have type parameters
+help: you might have meant to specity type parameters on enum `Enum`
+   |
+LL -         Self::<()>::SVariant::<()> { v: () };
+LL +         Enum::<()>::SVariant { v: () };
+   | 
 
 error[E0308]: mismatched types
   --> $DIR/enum-variant-generic-args.rs:34:41
@@ -143,12 +209,38 @@ error[E0109]: type arguments are not allowed for this type
    |
 LL |         Self::<()>::UVariant;
    |                ^^ type argument not allowed
+   |
+note: the `Self` type is `Enum<T>`
+  --> $DIR/enum-variant-generic-args.rs:7:6
+   |
+LL | enum Enum<T> { TSVariant(T), SVariant { v: T }, UVariant }
+   |      ^^^^ `Self` corresponds to this type
+...
+LL | impl<T> Enum<T> {
+   | --------------- `Self` is `Enum` in this `impl`
+help: the `Self` type doesn't accept type parameters, use the concrete type's name `Enum` instead if you want to specify its type parameters
+   |
+LL |         Enum::<()>::UVariant;
+   |         ~~~~
 
 error[E0109]: type arguments are not allowed for this type
   --> $DIR/enum-variant-generic-args.rs:45:16
    |
 LL |         Self::<()>::UVariant::<()>;
    |                ^^ type argument not allowed
+   |
+note: the `Self` type is `Enum<T>`
+  --> $DIR/enum-variant-generic-args.rs:7:6
+   |
+LL | enum Enum<T> { TSVariant(T), SVariant { v: T }, UVariant }
+   |      ^^^^ `Self` corresponds to this type
+...
+LL | impl<T> Enum<T> {
+   | --------------- `Self` is `Enum` in this `impl`
+help: the `Self` type doesn't accept type parameters, use the concrete type's name `Enum` instead if you want to specify its type parameters
+   |
+LL |         Enum::<()>::UVariant::<()>;
+   |         ~~~~
 
 error[E0109]: type arguments are not allowed for this type
   --> $DIR/enum-variant-generic-args.rs:45:32
@@ -219,24 +311,47 @@ error[E0109]: type arguments are not allowed for this type
    |
 LL |     Enum::<()>::SVariant::<()> { v: () };
    |                            ^^ type argument not allowed
+   |
+   = note: enum variants can't have type parameters
 
 error[E0109]: type arguments are not allowed for this type
   --> $DIR/enum-variant-generic-args.rs:75:23
    |
 LL |     Alias::SVariant::<()> { v: () };
    |                       ^^ type argument not allowed
+   |
+   = note: enum variants can't have type parameters
+help: you might have meant to specity type parameters on enum `Enum`
+   |
+LL -     Alias::SVariant::<()> { v: () };
+LL +     Alias::<()>::SVariant { v: () };
+   | 
 
 error[E0109]: type arguments are not allowed for this type
   --> $DIR/enum-variant-generic-args.rs:77:29
    |
 LL |     Alias::<()>::SVariant::<()> { v: () };
    |                             ^^ type argument not allowed
+   |
+   = note: enum variants can't have type parameters
+help: you might have meant to specity type parameters on enum `Enum`
+   |
+LL -     Alias::<()>::SVariant::<()> { v: () };
+LL +     Alias::<()>::SVariant { v: () };
+   | 
 
 error[E0109]: type arguments are not allowed for this type
   --> $DIR/enum-variant-generic-args.rs:80:28
    |
 LL |     AliasFixed::SVariant::<()> { v: () };
    |                            ^^ type argument not allowed
+   |
+   = note: enum variants can't have type parameters
+help: you might have meant to specity type parameters on enum `Enum`
+   |
+LL -     AliasFixed::SVariant::<()> { v: () };
+LL +     AliasFixed::<()>::SVariant { v: () };
+   | 
 
 error[E0107]: this type alias takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/enum-variant-generic-args.rs:82:5
@@ -271,6 +386,13 @@ error[E0109]: type arguments are not allowed for this type
    |
 LL |     AliasFixed::<()>::SVariant::<()> { v: () };
    |                                  ^^ type argument not allowed
+   |
+   = note: enum variants can't have type parameters
+help: you might have meant to specity type parameters on enum `Enum`
+   |
+LL -     AliasFixed::<()>::SVariant::<()> { v: () };
+LL +     AliasFixed::<()>::SVariant { v: () };
+   | 
 
 error[E0109]: type arguments are not allowed for this type
   --> $DIR/enum-variant-generic-args.rs:90:28

--- a/src/test/ui/type-alias-enum-variants/enum-variant-generic-args.stderr
+++ b/src/test/ui/type-alias-enum-variants/enum-variant-generic-args.stderr
@@ -36,7 +36,7 @@ LL | enum Enum<T> { TSVariant(T), SVariant { v: T }, UVariant }
    |      ^^^^ `Self` corresponds to this type
 ...
 LL | impl<T> Enum<T> {
-   | --------------- `Self` is or type `Enum` in this `impl`
+   | --------------- `Self` is on type `Enum` in this `impl`
 help: the `Self` type doesn't accept type parameters, use the concrete type's name `Enum` instead if you want to specify its type parameters
    |
 LL |         Enum::<()>::TSVariant(());
@@ -74,7 +74,7 @@ LL | enum Enum<T> { TSVariant(T), SVariant { v: T }, UVariant }
    |      ^^^^ `Self` corresponds to this type
 ...
 LL | impl<T> Enum<T> {
-   | --------------- `Self` is or type `Enum` in this `impl`
+   | --------------- `Self` is on type `Enum` in this `impl`
 help: the `Self` type doesn't accept type parameters, use the concrete type's name `Enum` instead if you want to specify its type parameters
    |
 LL |         Enum::<()>::TSVariant::<()>(());
@@ -136,7 +136,7 @@ LL | enum Enum<T> { TSVariant(T), SVariant { v: T }, UVariant }
    |      ^^^^ `Self` corresponds to this type
 ...
 LL | impl<T> Enum<T> {
-   | --------------- `Self` is or type `Enum` in this `impl`
+   | --------------- `Self` is on type `Enum` in this `impl`
 help: the `Self` type doesn't accept type parameters, use the concrete type's name `Enum` instead if you want to specify its type parameters
    |
 LL |         Enum::<()>::SVariant { v: () };
@@ -167,7 +167,7 @@ LL | enum Enum<T> { TSVariant(T), SVariant { v: T }, UVariant }
    |      ^^^^ `Self` corresponds to this type
 ...
 LL | impl<T> Enum<T> {
-   | --------------- `Self` is or type `Enum` in this `impl`
+   | --------------- `Self` is on type `Enum` in this `impl`
 help: the `Self` type doesn't accept type parameters, use the concrete type's name `Enum` instead if you want to specify its type parameters
    |
 LL |         Enum::<()>::SVariant::<()> { v: () };
@@ -217,7 +217,7 @@ LL | enum Enum<T> { TSVariant(T), SVariant { v: T }, UVariant }
    |      ^^^^ `Self` corresponds to this type
 ...
 LL | impl<T> Enum<T> {
-   | --------------- `Self` is or type `Enum` in this `impl`
+   | --------------- `Self` is on type `Enum` in this `impl`
 help: the `Self` type doesn't accept type parameters, use the concrete type's name `Enum` instead if you want to specify its type parameters
    |
 LL |         Enum::<()>::UVariant;
@@ -236,7 +236,7 @@ LL | enum Enum<T> { TSVariant(T), SVariant { v: T }, UVariant }
    |      ^^^^ `Self` corresponds to this type
 ...
 LL | impl<T> Enum<T> {
-   | --------------- `Self` is or type `Enum` in this `impl`
+   | --------------- `Self` is on type `Enum` in this `impl`
 help: the `Self` type doesn't accept type parameters, use the concrete type's name `Enum` instead if you want to specify its type parameters
    |
 LL |         Enum::<()>::UVariant::<()>;

--- a/src/test/ui/type-alias-enum-variants/no-type-application-on-aliased-enum-variant.rs
+++ b/src/test/ui/type-alias-enum-variants/no-type-application-on-aliased-enum-variant.rs
@@ -10,5 +10,5 @@ fn main() {
     let _ = Option::<u8>::None; // OK
     let _ = Option::None::<u8>; // OK (Lint in future!)
     let _ = Alias::<u8>::None; // OK
-    let _ = Alias::None::<u8>; //~ ERROR type arguments are not allowed for this type
+    let _ = Alias::None::<u8>; //~ ERROR type arguments are not allowed on this type
 }

--- a/src/test/ui/type-alias-enum-variants/no-type-application-on-aliased-enum-variant.stderr
+++ b/src/test/ui/type-alias-enum-variants/no-type-application-on-aliased-enum-variant.stderr
@@ -1,8 +1,10 @@
-error[E0109]: type arguments are not allowed for this type
+error[E0109]: type arguments are not allowed on this type
   --> $DIR/no-type-application-on-aliased-enum-variant.rs:13:27
    |
 LL |     let _ = Alias::None::<u8>;
-   |                           ^^ type argument not allowed
+   |                    ----   ^^ type argument not allowed
+   |                    |
+   |                    not allowed on this
 
 error: aborting due to previous error
 

--- a/src/test/ui/type/issue-91268.rs
+++ b/src/test/ui/type/issue-91268.rs
@@ -1,7 +1,7 @@
 // error-pattern: this file contains an unclosed delimiter
 // error-pattern: cannot find type `ţ` in this scope
 // error-pattern: parenthesized type parameters may only be used with a `Fn` trait
-// error-pattern: type arguments are not allowed for this type
+// error-pattern: type arguments are not allowed on this type
 // error-pattern: mismatched types
 // ignore-tidy-trailing-newlines
 // `ţ` must be the last character in this file, it cannot be followed by a newline

--- a/src/test/ui/type/issue-91268.stderr
+++ b/src/test/ui/type/issue-91268.stderr
@@ -38,7 +38,7 @@ LL |     0: u8(ţ
    |        |
    |        not allowed on this
    |
-help: primitive type `u8` doesn't have type parameters
+help: primitive type `u8` doesn't have generic parameters
    |
 LL -     0: u8(ţ
 LL +     0: u8

--- a/src/test/ui/type/issue-91268.stderr
+++ b/src/test/ui/type/issue-91268.stderr
@@ -35,6 +35,12 @@ error[E0109]: type arguments are not allowed for this type
    |
 LL |     0: u8(ţ
    |           ^ type argument not allowed
+   |
+help: primitive type `u8` doesn't have type parameters
+   |
+LL -     0: u8(ţ
+LL +     0: u8
+   | 
 
 error[E0308]: mismatched types
   --> $DIR/issue-91268.rs:9:5

--- a/src/test/ui/type/issue-91268.stderr
+++ b/src/test/ui/type/issue-91268.stderr
@@ -30,11 +30,13 @@ error[E0214]: parenthesized type parameters may only be used with a `Fn` trait
 LL |     0: u8(ţ
    |        ^^^^ only `Fn` traits may use parentheses
 
-error[E0109]: type arguments are not allowed for this type
+error[E0109]: type arguments are not allowed on this type
   --> $DIR/issue-91268.rs:9:11
    |
 LL |     0: u8(ţ
-   |           ^ type argument not allowed
+   |        -- ^ type argument not allowed
+   |        |
+   |        not allowed on this
    |
 help: primitive type `u8` doesn't have type parameters
    |

--- a/src/test/ui/typeck/prim-with-args.fixed
+++ b/src/test/ui/typeck/prim-with-args.fixed
@@ -1,0 +1,28 @@
+// run-rustfix
+fn main() {
+
+let _x: isize; //~ ERROR type arguments are not allowed for this type
+let _x: i8; //~ ERROR type arguments are not allowed for this type
+let _x: i16; //~ ERROR type arguments are not allowed for this type
+let _x: i32; //~ ERROR type arguments are not allowed for this type
+let _x: i64; //~ ERROR type arguments are not allowed for this type
+let _x: usize; //~ ERROR type arguments are not allowed for this type
+let _x: u8; //~ ERROR type arguments are not allowed for this type
+let _x: u16; //~ ERROR type arguments are not allowed for this type
+let _x: u32; //~ ERROR type arguments are not allowed for this type
+let _x: u64; //~ ERROR type arguments are not allowed for this type
+let _x: char; //~ ERROR type arguments are not allowed for this type
+
+let _x: isize; //~ ERROR lifetime arguments are not allowed for this type
+let _x: i8; //~ ERROR lifetime arguments are not allowed for this type
+let _x: i16; //~ ERROR lifetime arguments are not allowed for this type
+let _x: i32; //~ ERROR lifetime arguments are not allowed for this type
+let _x: i64; //~ ERROR lifetime arguments are not allowed for this type
+let _x: usize; //~ ERROR lifetime arguments are not allowed for this type
+let _x: u8; //~ ERROR lifetime arguments are not allowed for this type
+let _x: u16; //~ ERROR lifetime arguments are not allowed for this type
+let _x: u32; //~ ERROR lifetime arguments are not allowed for this type
+let _x: u64; //~ ERROR lifetime arguments are not allowed for this type
+let _x: char; //~ ERROR lifetime arguments are not allowed for this type
+
+}

--- a/src/test/ui/typeck/prim-with-args.fixed
+++ b/src/test/ui/typeck/prim-with-args.fixed
@@ -1,28 +1,28 @@
 // run-rustfix
 fn main() {
 
-let _x: isize; //~ ERROR type arguments are not allowed for this type
-let _x: i8; //~ ERROR type arguments are not allowed for this type
-let _x: i16; //~ ERROR type arguments are not allowed for this type
-let _x: i32; //~ ERROR type arguments are not allowed for this type
-let _x: i64; //~ ERROR type arguments are not allowed for this type
-let _x: usize; //~ ERROR type arguments are not allowed for this type
-let _x: u8; //~ ERROR type arguments are not allowed for this type
-let _x: u16; //~ ERROR type arguments are not allowed for this type
-let _x: u32; //~ ERROR type arguments are not allowed for this type
-let _x: u64; //~ ERROR type arguments are not allowed for this type
-let _x: char; //~ ERROR type arguments are not allowed for this type
+let _x: isize; //~ ERROR type arguments are not allowed on this type
+let _x: i8; //~ ERROR type arguments are not allowed on this type
+let _x: i16; //~ ERROR type arguments are not allowed on this type
+let _x: i32; //~ ERROR type arguments are not allowed on this type
+let _x: i64; //~ ERROR type arguments are not allowed on this type
+let _x: usize; //~ ERROR type arguments are not allowed on this type
+let _x: u8; //~ ERROR type arguments are not allowed on this type
+let _x: u16; //~ ERROR type arguments are not allowed on this type
+let _x: u32; //~ ERROR type arguments are not allowed on this type
+let _x: u64; //~ ERROR type arguments are not allowed on this type
+let _x: char; //~ ERROR type arguments are not allowed on this type
 
-let _x: isize; //~ ERROR lifetime arguments are not allowed for this type
-let _x: i8; //~ ERROR lifetime arguments are not allowed for this type
-let _x: i16; //~ ERROR lifetime arguments are not allowed for this type
-let _x: i32; //~ ERROR lifetime arguments are not allowed for this type
-let _x: i64; //~ ERROR lifetime arguments are not allowed for this type
-let _x: usize; //~ ERROR lifetime arguments are not allowed for this type
-let _x: u8; //~ ERROR lifetime arguments are not allowed for this type
-let _x: u16; //~ ERROR lifetime arguments are not allowed for this type
-let _x: u32; //~ ERROR lifetime arguments are not allowed for this type
-let _x: u64; //~ ERROR lifetime arguments are not allowed for this type
-let _x: char; //~ ERROR lifetime arguments are not allowed for this type
+let _x: isize; //~ ERROR lifetime arguments are not allowed on this type
+let _x: i8; //~ ERROR lifetime arguments are not allowed on this type
+let _x: i16; //~ ERROR lifetime arguments are not allowed on this type
+let _x: i32; //~ ERROR lifetime arguments are not allowed on this type
+let _x: i64; //~ ERROR lifetime arguments are not allowed on this type
+let _x: usize; //~ ERROR lifetime arguments are not allowed on this type
+let _x: u8; //~ ERROR lifetime arguments are not allowed on this type
+let _x: u16; //~ ERROR lifetime arguments are not allowed on this type
+let _x: u32; //~ ERROR lifetime arguments are not allowed on this type
+let _x: u64; //~ ERROR lifetime arguments are not allowed on this type
+let _x: char; //~ ERROR lifetime arguments are not allowed on this type
 
 }

--- a/src/test/ui/typeck/prim-with-args.rs
+++ b/src/test/ui/typeck/prim-with-args.rs
@@ -1,28 +1,28 @@
 // run-rustfix
 fn main() {
 
-let _x: isize<isize>; //~ ERROR type arguments are not allowed for this type
-let _x: i8<isize>; //~ ERROR type arguments are not allowed for this type
-let _x: i16<isize>; //~ ERROR type arguments are not allowed for this type
-let _x: i32<isize>; //~ ERROR type arguments are not allowed for this type
-let _x: i64<isize>; //~ ERROR type arguments are not allowed for this type
-let _x: usize<isize>; //~ ERROR type arguments are not allowed for this type
-let _x: u8<isize>; //~ ERROR type arguments are not allowed for this type
-let _x: u16<isize>; //~ ERROR type arguments are not allowed for this type
-let _x: u32<isize>; //~ ERROR type arguments are not allowed for this type
-let _x: u64<isize>; //~ ERROR type arguments are not allowed for this type
-let _x: char<isize>; //~ ERROR type arguments are not allowed for this type
+let _x: isize<isize>; //~ ERROR type arguments are not allowed on this type
+let _x: i8<isize>; //~ ERROR type arguments are not allowed on this type
+let _x: i16<isize>; //~ ERROR type arguments are not allowed on this type
+let _x: i32<isize>; //~ ERROR type arguments are not allowed on this type
+let _x: i64<isize>; //~ ERROR type arguments are not allowed on this type
+let _x: usize<isize>; //~ ERROR type arguments are not allowed on this type
+let _x: u8<isize>; //~ ERROR type arguments are not allowed on this type
+let _x: u16<isize>; //~ ERROR type arguments are not allowed on this type
+let _x: u32<isize>; //~ ERROR type arguments are not allowed on this type
+let _x: u64<isize>; //~ ERROR type arguments are not allowed on this type
+let _x: char<isize>; //~ ERROR type arguments are not allowed on this type
 
-let _x: isize<'static>; //~ ERROR lifetime arguments are not allowed for this type
-let _x: i8<'static>; //~ ERROR lifetime arguments are not allowed for this type
-let _x: i16<'static>; //~ ERROR lifetime arguments are not allowed for this type
-let _x: i32<'static>; //~ ERROR lifetime arguments are not allowed for this type
-let _x: i64<'static>; //~ ERROR lifetime arguments are not allowed for this type
-let _x: usize<'static>; //~ ERROR lifetime arguments are not allowed for this type
-let _x: u8<'static>; //~ ERROR lifetime arguments are not allowed for this type
-let _x: u16<'static>; //~ ERROR lifetime arguments are not allowed for this type
-let _x: u32<'static>; //~ ERROR lifetime arguments are not allowed for this type
-let _x: u64<'static>; //~ ERROR lifetime arguments are not allowed for this type
-let _x: char<'static>; //~ ERROR lifetime arguments are not allowed for this type
+let _x: isize<'static>; //~ ERROR lifetime arguments are not allowed on this type
+let _x: i8<'static>; //~ ERROR lifetime arguments are not allowed on this type
+let _x: i16<'static>; //~ ERROR lifetime arguments are not allowed on this type
+let _x: i32<'static>; //~ ERROR lifetime arguments are not allowed on this type
+let _x: i64<'static>; //~ ERROR lifetime arguments are not allowed on this type
+let _x: usize<'static>; //~ ERROR lifetime arguments are not allowed on this type
+let _x: u8<'static>; //~ ERROR lifetime arguments are not allowed on this type
+let _x: u16<'static>; //~ ERROR lifetime arguments are not allowed on this type
+let _x: u32<'static>; //~ ERROR lifetime arguments are not allowed on this type
+let _x: u64<'static>; //~ ERROR lifetime arguments are not allowed on this type
+let _x: char<'static>; //~ ERROR lifetime arguments are not allowed on this type
 
 }

--- a/src/test/ui/typeck/prim-with-args.rs
+++ b/src/test/ui/typeck/prim-with-args.rs
@@ -1,27 +1,28 @@
+// run-rustfix
 fn main() {
 
-let x: isize<isize>; //~ ERROR type arguments are not allowed for this type
-let x: i8<isize>; //~ ERROR type arguments are not allowed for this type
-let x: i16<isize>; //~ ERROR type arguments are not allowed for this type
-let x: i32<isize>; //~ ERROR type arguments are not allowed for this type
-let x: i64<isize>; //~ ERROR type arguments are not allowed for this type
-let x: usize<isize>; //~ ERROR type arguments are not allowed for this type
-let x: u8<isize>; //~ ERROR type arguments are not allowed for this type
-let x: u16<isize>; //~ ERROR type arguments are not allowed for this type
-let x: u32<isize>; //~ ERROR type arguments are not allowed for this type
-let x: u64<isize>; //~ ERROR type arguments are not allowed for this type
-let x: char<isize>; //~ ERROR type arguments are not allowed for this type
+let _x: isize<isize>; //~ ERROR type arguments are not allowed for this type
+let _x: i8<isize>; //~ ERROR type arguments are not allowed for this type
+let _x: i16<isize>; //~ ERROR type arguments are not allowed for this type
+let _x: i32<isize>; //~ ERROR type arguments are not allowed for this type
+let _x: i64<isize>; //~ ERROR type arguments are not allowed for this type
+let _x: usize<isize>; //~ ERROR type arguments are not allowed for this type
+let _x: u8<isize>; //~ ERROR type arguments are not allowed for this type
+let _x: u16<isize>; //~ ERROR type arguments are not allowed for this type
+let _x: u32<isize>; //~ ERROR type arguments are not allowed for this type
+let _x: u64<isize>; //~ ERROR type arguments are not allowed for this type
+let _x: char<isize>; //~ ERROR type arguments are not allowed for this type
 
-let x: isize<'static>; //~ ERROR lifetime arguments are not allowed for this type
-let x: i8<'static>; //~ ERROR lifetime arguments are not allowed for this type
-let x: i16<'static>; //~ ERROR lifetime arguments are not allowed for this type
-let x: i32<'static>; //~ ERROR lifetime arguments are not allowed for this type
-let x: i64<'static>; //~ ERROR lifetime arguments are not allowed for this type
-let x: usize<'static>; //~ ERROR lifetime arguments are not allowed for this type
-let x: u8<'static>; //~ ERROR lifetime arguments are not allowed for this type
-let x: u16<'static>; //~ ERROR lifetime arguments are not allowed for this type
-let x: u32<'static>; //~ ERROR lifetime arguments are not allowed for this type
-let x: u64<'static>; //~ ERROR lifetime arguments are not allowed for this type
-let x: char<'static>; //~ ERROR lifetime arguments are not allowed for this type
+let _x: isize<'static>; //~ ERROR lifetime arguments are not allowed for this type
+let _x: i8<'static>; //~ ERROR lifetime arguments are not allowed for this type
+let _x: i16<'static>; //~ ERROR lifetime arguments are not allowed for this type
+let _x: i32<'static>; //~ ERROR lifetime arguments are not allowed for this type
+let _x: i64<'static>; //~ ERROR lifetime arguments are not allowed for this type
+let _x: usize<'static>; //~ ERROR lifetime arguments are not allowed for this type
+let _x: u8<'static>; //~ ERROR lifetime arguments are not allowed for this type
+let _x: u16<'static>; //~ ERROR lifetime arguments are not allowed for this type
+let _x: u32<'static>; //~ ERROR lifetime arguments are not allowed for this type
+let _x: u64<'static>; //~ ERROR lifetime arguments are not allowed for this type
+let _x: char<'static>; //~ ERROR lifetime arguments are not allowed for this type
 
 }

--- a/src/test/ui/typeck/prim-with-args.stderr
+++ b/src/test/ui/typeck/prim-with-args.stderr
@@ -6,7 +6,7 @@ LL | let _x: isize<isize>;
    |         |
    |         not allowed on this
    |
-help: primitive type `isize` doesn't have type parameters
+help: primitive type `isize` doesn't have generic parameters
    |
 LL - let _x: isize<isize>;
 LL + let _x: isize;
@@ -20,7 +20,7 @@ LL | let _x: i8<isize>;
    |         |
    |         not allowed on this
    |
-help: primitive type `i8` doesn't have type parameters
+help: primitive type `i8` doesn't have generic parameters
    |
 LL - let _x: i8<isize>;
 LL + let _x: i8;
@@ -34,7 +34,7 @@ LL | let _x: i16<isize>;
    |         |
    |         not allowed on this
    |
-help: primitive type `i16` doesn't have type parameters
+help: primitive type `i16` doesn't have generic parameters
    |
 LL - let _x: i16<isize>;
 LL + let _x: i16;
@@ -48,7 +48,7 @@ LL | let _x: i32<isize>;
    |         |
    |         not allowed on this
    |
-help: primitive type `i32` doesn't have type parameters
+help: primitive type `i32` doesn't have generic parameters
    |
 LL - let _x: i32<isize>;
 LL + let _x: i32;
@@ -62,7 +62,7 @@ LL | let _x: i64<isize>;
    |         |
    |         not allowed on this
    |
-help: primitive type `i64` doesn't have type parameters
+help: primitive type `i64` doesn't have generic parameters
    |
 LL - let _x: i64<isize>;
 LL + let _x: i64;
@@ -76,7 +76,7 @@ LL | let _x: usize<isize>;
    |         |
    |         not allowed on this
    |
-help: primitive type `usize` doesn't have type parameters
+help: primitive type `usize` doesn't have generic parameters
    |
 LL - let _x: usize<isize>;
 LL + let _x: usize;
@@ -90,7 +90,7 @@ LL | let _x: u8<isize>;
    |         |
    |         not allowed on this
    |
-help: primitive type `u8` doesn't have type parameters
+help: primitive type `u8` doesn't have generic parameters
    |
 LL - let _x: u8<isize>;
 LL + let _x: u8;
@@ -104,7 +104,7 @@ LL | let _x: u16<isize>;
    |         |
    |         not allowed on this
    |
-help: primitive type `u16` doesn't have type parameters
+help: primitive type `u16` doesn't have generic parameters
    |
 LL - let _x: u16<isize>;
 LL + let _x: u16;
@@ -118,7 +118,7 @@ LL | let _x: u32<isize>;
    |         |
    |         not allowed on this
    |
-help: primitive type `u32` doesn't have type parameters
+help: primitive type `u32` doesn't have generic parameters
    |
 LL - let _x: u32<isize>;
 LL + let _x: u32;
@@ -132,7 +132,7 @@ LL | let _x: u64<isize>;
    |         |
    |         not allowed on this
    |
-help: primitive type `u64` doesn't have type parameters
+help: primitive type `u64` doesn't have generic parameters
    |
 LL - let _x: u64<isize>;
 LL + let _x: u64;
@@ -146,7 +146,7 @@ LL | let _x: char<isize>;
    |         |
    |         not allowed on this
    |
-help: primitive type `char` doesn't have type parameters
+help: primitive type `char` doesn't have generic parameters
    |
 LL - let _x: char<isize>;
 LL + let _x: char;
@@ -160,7 +160,7 @@ LL | let _x: isize<'static>;
    |         |
    |         not allowed on this
    |
-help: primitive type `isize` doesn't have type parameters
+help: primitive type `isize` doesn't have generic parameters
    |
 LL - let _x: isize<'static>;
 LL + let _x: isize;
@@ -174,7 +174,7 @@ LL | let _x: i8<'static>;
    |         |
    |         not allowed on this
    |
-help: primitive type `i8` doesn't have type parameters
+help: primitive type `i8` doesn't have generic parameters
    |
 LL - let _x: i8<'static>;
 LL + let _x: i8;
@@ -188,7 +188,7 @@ LL | let _x: i16<'static>;
    |         |
    |         not allowed on this
    |
-help: primitive type `i16` doesn't have type parameters
+help: primitive type `i16` doesn't have generic parameters
    |
 LL - let _x: i16<'static>;
 LL + let _x: i16;
@@ -202,7 +202,7 @@ LL | let _x: i32<'static>;
    |         |
    |         not allowed on this
    |
-help: primitive type `i32` doesn't have type parameters
+help: primitive type `i32` doesn't have generic parameters
    |
 LL - let _x: i32<'static>;
 LL + let _x: i32;
@@ -216,7 +216,7 @@ LL | let _x: i64<'static>;
    |         |
    |         not allowed on this
    |
-help: primitive type `i64` doesn't have type parameters
+help: primitive type `i64` doesn't have generic parameters
    |
 LL - let _x: i64<'static>;
 LL + let _x: i64;
@@ -230,7 +230,7 @@ LL | let _x: usize<'static>;
    |         |
    |         not allowed on this
    |
-help: primitive type `usize` doesn't have type parameters
+help: primitive type `usize` doesn't have generic parameters
    |
 LL - let _x: usize<'static>;
 LL + let _x: usize;
@@ -244,7 +244,7 @@ LL | let _x: u8<'static>;
    |         |
    |         not allowed on this
    |
-help: primitive type `u8` doesn't have type parameters
+help: primitive type `u8` doesn't have generic parameters
    |
 LL - let _x: u8<'static>;
 LL + let _x: u8;
@@ -258,7 +258,7 @@ LL | let _x: u16<'static>;
    |         |
    |         not allowed on this
    |
-help: primitive type `u16` doesn't have type parameters
+help: primitive type `u16` doesn't have generic parameters
    |
 LL - let _x: u16<'static>;
 LL + let _x: u16;
@@ -272,7 +272,7 @@ LL | let _x: u32<'static>;
    |         |
    |         not allowed on this
    |
-help: primitive type `u32` doesn't have type parameters
+help: primitive type `u32` doesn't have generic parameters
    |
 LL - let _x: u32<'static>;
 LL + let _x: u32;
@@ -286,7 +286,7 @@ LL | let _x: u64<'static>;
    |         |
    |         not allowed on this
    |
-help: primitive type `u64` doesn't have type parameters
+help: primitive type `u64` doesn't have generic parameters
    |
 LL - let _x: u64<'static>;
 LL + let _x: u64;
@@ -300,7 +300,7 @@ LL | let _x: char<'static>;
    |         |
    |         not allowed on this
    |
-help: primitive type `char` doesn't have type parameters
+help: primitive type `char` doesn't have generic parameters
    |
 LL - let _x: char<'static>;
 LL + let _x: char;

--- a/src/test/ui/typeck/prim-with-args.stderr
+++ b/src/test/ui/typeck/prim-with-args.stderr
@@ -1,134 +1,266 @@
 error[E0109]: type arguments are not allowed for this type
-  --> $DIR/prim-with-args.rs:3:14
+  --> $DIR/prim-with-args.rs:4:15
    |
-LL | let x: isize<isize>;
-   |              ^^^^^ type argument not allowed
-
-error[E0109]: type arguments are not allowed for this type
-  --> $DIR/prim-with-args.rs:4:11
+LL | let _x: isize<isize>;
+   |               ^^^^^ type argument not allowed
    |
-LL | let x: i8<isize>;
-   |           ^^^^^ type argument not allowed
+help: primitive type `isize` doesn't have type parameters
+   |
+LL - let _x: isize<isize>;
+LL + let _x: isize;
+   | 
 
 error[E0109]: type arguments are not allowed for this type
   --> $DIR/prim-with-args.rs:5:12
    |
-LL | let x: i16<isize>;
+LL | let _x: i8<isize>;
    |            ^^^^^ type argument not allowed
+   |
+help: primitive type `i8` doesn't have type parameters
+   |
+LL - let _x: i8<isize>;
+LL + let _x: i8;
+   | 
 
 error[E0109]: type arguments are not allowed for this type
-  --> $DIR/prim-with-args.rs:6:12
+  --> $DIR/prim-with-args.rs:6:13
    |
-LL | let x: i32<isize>;
-   |            ^^^^^ type argument not allowed
+LL | let _x: i16<isize>;
+   |             ^^^^^ type argument not allowed
+   |
+help: primitive type `i16` doesn't have type parameters
+   |
+LL - let _x: i16<isize>;
+LL + let _x: i16;
+   | 
 
 error[E0109]: type arguments are not allowed for this type
-  --> $DIR/prim-with-args.rs:7:12
+  --> $DIR/prim-with-args.rs:7:13
    |
-LL | let x: i64<isize>;
-   |            ^^^^^ type argument not allowed
+LL | let _x: i32<isize>;
+   |             ^^^^^ type argument not allowed
+   |
+help: primitive type `i32` doesn't have type parameters
+   |
+LL - let _x: i32<isize>;
+LL + let _x: i32;
+   | 
 
 error[E0109]: type arguments are not allowed for this type
-  --> $DIR/prim-with-args.rs:8:14
+  --> $DIR/prim-with-args.rs:8:13
    |
-LL | let x: usize<isize>;
-   |              ^^^^^ type argument not allowed
+LL | let _x: i64<isize>;
+   |             ^^^^^ type argument not allowed
+   |
+help: primitive type `i64` doesn't have type parameters
+   |
+LL - let _x: i64<isize>;
+LL + let _x: i64;
+   | 
 
 error[E0109]: type arguments are not allowed for this type
-  --> $DIR/prim-with-args.rs:9:11
+  --> $DIR/prim-with-args.rs:9:15
    |
-LL | let x: u8<isize>;
-   |           ^^^^^ type argument not allowed
+LL | let _x: usize<isize>;
+   |               ^^^^^ type argument not allowed
+   |
+help: primitive type `usize` doesn't have type parameters
+   |
+LL - let _x: usize<isize>;
+LL + let _x: usize;
+   | 
 
 error[E0109]: type arguments are not allowed for this type
   --> $DIR/prim-with-args.rs:10:12
    |
-LL | let x: u16<isize>;
+LL | let _x: u8<isize>;
    |            ^^^^^ type argument not allowed
+   |
+help: primitive type `u8` doesn't have type parameters
+   |
+LL - let _x: u8<isize>;
+LL + let _x: u8;
+   | 
 
 error[E0109]: type arguments are not allowed for this type
-  --> $DIR/prim-with-args.rs:11:12
+  --> $DIR/prim-with-args.rs:11:13
    |
-LL | let x: u32<isize>;
-   |            ^^^^^ type argument not allowed
+LL | let _x: u16<isize>;
+   |             ^^^^^ type argument not allowed
+   |
+help: primitive type `u16` doesn't have type parameters
+   |
+LL - let _x: u16<isize>;
+LL + let _x: u16;
+   | 
 
 error[E0109]: type arguments are not allowed for this type
-  --> $DIR/prim-with-args.rs:12:12
+  --> $DIR/prim-with-args.rs:12:13
    |
-LL | let x: u64<isize>;
-   |            ^^^^^ type argument not allowed
+LL | let _x: u32<isize>;
+   |             ^^^^^ type argument not allowed
+   |
+help: primitive type `u32` doesn't have type parameters
+   |
+LL - let _x: u32<isize>;
+LL + let _x: u32;
+   | 
 
 error[E0109]: type arguments are not allowed for this type
   --> $DIR/prim-with-args.rs:13:13
    |
-LL | let x: char<isize>;
+LL | let _x: u64<isize>;
    |             ^^^^^ type argument not allowed
+   |
+help: primitive type `u64` doesn't have type parameters
+   |
+LL - let _x: u64<isize>;
+LL + let _x: u64;
+   | 
+
+error[E0109]: type arguments are not allowed for this type
+  --> $DIR/prim-with-args.rs:14:14
+   |
+LL | let _x: char<isize>;
+   |              ^^^^^ type argument not allowed
+   |
+help: primitive type `char` doesn't have type parameters
+   |
+LL - let _x: char<isize>;
+LL + let _x: char;
+   | 
 
 error[E0109]: lifetime arguments are not allowed for this type
-  --> $DIR/prim-with-args.rs:15:14
+  --> $DIR/prim-with-args.rs:16:15
    |
-LL | let x: isize<'static>;
-   |              ^^^^^^^ lifetime argument not allowed
-
-error[E0109]: lifetime arguments are not allowed for this type
-  --> $DIR/prim-with-args.rs:16:11
+LL | let _x: isize<'static>;
+   |               ^^^^^^^ lifetime argument not allowed
    |
-LL | let x: i8<'static>;
-   |           ^^^^^^^ lifetime argument not allowed
+help: primitive type `isize` doesn't have type parameters
+   |
+LL - let _x: isize<'static>;
+LL + let _x: isize;
+   | 
 
 error[E0109]: lifetime arguments are not allowed for this type
   --> $DIR/prim-with-args.rs:17:12
    |
-LL | let x: i16<'static>;
+LL | let _x: i8<'static>;
    |            ^^^^^^^ lifetime argument not allowed
+   |
+help: primitive type `i8` doesn't have type parameters
+   |
+LL - let _x: i8<'static>;
+LL + let _x: i8;
+   | 
 
 error[E0109]: lifetime arguments are not allowed for this type
-  --> $DIR/prim-with-args.rs:18:12
+  --> $DIR/prim-with-args.rs:18:13
    |
-LL | let x: i32<'static>;
-   |            ^^^^^^^ lifetime argument not allowed
+LL | let _x: i16<'static>;
+   |             ^^^^^^^ lifetime argument not allowed
+   |
+help: primitive type `i16` doesn't have type parameters
+   |
+LL - let _x: i16<'static>;
+LL + let _x: i16;
+   | 
 
 error[E0109]: lifetime arguments are not allowed for this type
-  --> $DIR/prim-with-args.rs:19:12
+  --> $DIR/prim-with-args.rs:19:13
    |
-LL | let x: i64<'static>;
-   |            ^^^^^^^ lifetime argument not allowed
+LL | let _x: i32<'static>;
+   |             ^^^^^^^ lifetime argument not allowed
+   |
+help: primitive type `i32` doesn't have type parameters
+   |
+LL - let _x: i32<'static>;
+LL + let _x: i32;
+   | 
 
 error[E0109]: lifetime arguments are not allowed for this type
-  --> $DIR/prim-with-args.rs:20:14
+  --> $DIR/prim-with-args.rs:20:13
    |
-LL | let x: usize<'static>;
-   |              ^^^^^^^ lifetime argument not allowed
+LL | let _x: i64<'static>;
+   |             ^^^^^^^ lifetime argument not allowed
+   |
+help: primitive type `i64` doesn't have type parameters
+   |
+LL - let _x: i64<'static>;
+LL + let _x: i64;
+   | 
 
 error[E0109]: lifetime arguments are not allowed for this type
-  --> $DIR/prim-with-args.rs:21:11
+  --> $DIR/prim-with-args.rs:21:15
    |
-LL | let x: u8<'static>;
-   |           ^^^^^^^ lifetime argument not allowed
+LL | let _x: usize<'static>;
+   |               ^^^^^^^ lifetime argument not allowed
+   |
+help: primitive type `usize` doesn't have type parameters
+   |
+LL - let _x: usize<'static>;
+LL + let _x: usize;
+   | 
 
 error[E0109]: lifetime arguments are not allowed for this type
   --> $DIR/prim-with-args.rs:22:12
    |
-LL | let x: u16<'static>;
+LL | let _x: u8<'static>;
    |            ^^^^^^^ lifetime argument not allowed
+   |
+help: primitive type `u8` doesn't have type parameters
+   |
+LL - let _x: u8<'static>;
+LL + let _x: u8;
+   | 
 
 error[E0109]: lifetime arguments are not allowed for this type
-  --> $DIR/prim-with-args.rs:23:12
+  --> $DIR/prim-with-args.rs:23:13
    |
-LL | let x: u32<'static>;
-   |            ^^^^^^^ lifetime argument not allowed
+LL | let _x: u16<'static>;
+   |             ^^^^^^^ lifetime argument not allowed
+   |
+help: primitive type `u16` doesn't have type parameters
+   |
+LL - let _x: u16<'static>;
+LL + let _x: u16;
+   | 
 
 error[E0109]: lifetime arguments are not allowed for this type
-  --> $DIR/prim-with-args.rs:24:12
+  --> $DIR/prim-with-args.rs:24:13
    |
-LL | let x: u64<'static>;
-   |            ^^^^^^^ lifetime argument not allowed
+LL | let _x: u32<'static>;
+   |             ^^^^^^^ lifetime argument not allowed
+   |
+help: primitive type `u32` doesn't have type parameters
+   |
+LL - let _x: u32<'static>;
+LL + let _x: u32;
+   | 
 
 error[E0109]: lifetime arguments are not allowed for this type
   --> $DIR/prim-with-args.rs:25:13
    |
-LL | let x: char<'static>;
+LL | let _x: u64<'static>;
    |             ^^^^^^^ lifetime argument not allowed
+   |
+help: primitive type `u64` doesn't have type parameters
+   |
+LL - let _x: u64<'static>;
+LL + let _x: u64;
+   | 
+
+error[E0109]: lifetime arguments are not allowed for this type
+  --> $DIR/prim-with-args.rs:26:14
+   |
+LL | let _x: char<'static>;
+   |              ^^^^^^^ lifetime argument not allowed
+   |
+help: primitive type `char` doesn't have type parameters
+   |
+LL - let _x: char<'static>;
+LL + let _x: char;
+   | 
 
 error: aborting due to 22 previous errors
 

--- a/src/test/ui/typeck/prim-with-args.stderr
+++ b/src/test/ui/typeck/prim-with-args.stderr
@@ -1,8 +1,10 @@
-error[E0109]: type arguments are not allowed for this type
+error[E0109]: type arguments are not allowed on this type
   --> $DIR/prim-with-args.rs:4:15
    |
 LL | let _x: isize<isize>;
-   |               ^^^^^ type argument not allowed
+   |         ----- ^^^^^ type argument not allowed
+   |         |
+   |         not allowed on this
    |
 help: primitive type `isize` doesn't have type parameters
    |
@@ -10,11 +12,13 @@ LL - let _x: isize<isize>;
 LL + let _x: isize;
    | 
 
-error[E0109]: type arguments are not allowed for this type
+error[E0109]: type arguments are not allowed on this type
   --> $DIR/prim-with-args.rs:5:12
    |
 LL | let _x: i8<isize>;
-   |            ^^^^^ type argument not allowed
+   |         -- ^^^^^ type argument not allowed
+   |         |
+   |         not allowed on this
    |
 help: primitive type `i8` doesn't have type parameters
    |
@@ -22,11 +26,13 @@ LL - let _x: i8<isize>;
 LL + let _x: i8;
    | 
 
-error[E0109]: type arguments are not allowed for this type
+error[E0109]: type arguments are not allowed on this type
   --> $DIR/prim-with-args.rs:6:13
    |
 LL | let _x: i16<isize>;
-   |             ^^^^^ type argument not allowed
+   |         --- ^^^^^ type argument not allowed
+   |         |
+   |         not allowed on this
    |
 help: primitive type `i16` doesn't have type parameters
    |
@@ -34,11 +40,13 @@ LL - let _x: i16<isize>;
 LL + let _x: i16;
    | 
 
-error[E0109]: type arguments are not allowed for this type
+error[E0109]: type arguments are not allowed on this type
   --> $DIR/prim-with-args.rs:7:13
    |
 LL | let _x: i32<isize>;
-   |             ^^^^^ type argument not allowed
+   |         --- ^^^^^ type argument not allowed
+   |         |
+   |         not allowed on this
    |
 help: primitive type `i32` doesn't have type parameters
    |
@@ -46,11 +54,13 @@ LL - let _x: i32<isize>;
 LL + let _x: i32;
    | 
 
-error[E0109]: type arguments are not allowed for this type
+error[E0109]: type arguments are not allowed on this type
   --> $DIR/prim-with-args.rs:8:13
    |
 LL | let _x: i64<isize>;
-   |             ^^^^^ type argument not allowed
+   |         --- ^^^^^ type argument not allowed
+   |         |
+   |         not allowed on this
    |
 help: primitive type `i64` doesn't have type parameters
    |
@@ -58,11 +68,13 @@ LL - let _x: i64<isize>;
 LL + let _x: i64;
    | 
 
-error[E0109]: type arguments are not allowed for this type
+error[E0109]: type arguments are not allowed on this type
   --> $DIR/prim-with-args.rs:9:15
    |
 LL | let _x: usize<isize>;
-   |               ^^^^^ type argument not allowed
+   |         ----- ^^^^^ type argument not allowed
+   |         |
+   |         not allowed on this
    |
 help: primitive type `usize` doesn't have type parameters
    |
@@ -70,11 +82,13 @@ LL - let _x: usize<isize>;
 LL + let _x: usize;
    | 
 
-error[E0109]: type arguments are not allowed for this type
+error[E0109]: type arguments are not allowed on this type
   --> $DIR/prim-with-args.rs:10:12
    |
 LL | let _x: u8<isize>;
-   |            ^^^^^ type argument not allowed
+   |         -- ^^^^^ type argument not allowed
+   |         |
+   |         not allowed on this
    |
 help: primitive type `u8` doesn't have type parameters
    |
@@ -82,11 +96,13 @@ LL - let _x: u8<isize>;
 LL + let _x: u8;
    | 
 
-error[E0109]: type arguments are not allowed for this type
+error[E0109]: type arguments are not allowed on this type
   --> $DIR/prim-with-args.rs:11:13
    |
 LL | let _x: u16<isize>;
-   |             ^^^^^ type argument not allowed
+   |         --- ^^^^^ type argument not allowed
+   |         |
+   |         not allowed on this
    |
 help: primitive type `u16` doesn't have type parameters
    |
@@ -94,11 +110,13 @@ LL - let _x: u16<isize>;
 LL + let _x: u16;
    | 
 
-error[E0109]: type arguments are not allowed for this type
+error[E0109]: type arguments are not allowed on this type
   --> $DIR/prim-with-args.rs:12:13
    |
 LL | let _x: u32<isize>;
-   |             ^^^^^ type argument not allowed
+   |         --- ^^^^^ type argument not allowed
+   |         |
+   |         not allowed on this
    |
 help: primitive type `u32` doesn't have type parameters
    |
@@ -106,11 +124,13 @@ LL - let _x: u32<isize>;
 LL + let _x: u32;
    | 
 
-error[E0109]: type arguments are not allowed for this type
+error[E0109]: type arguments are not allowed on this type
   --> $DIR/prim-with-args.rs:13:13
    |
 LL | let _x: u64<isize>;
-   |             ^^^^^ type argument not allowed
+   |         --- ^^^^^ type argument not allowed
+   |         |
+   |         not allowed on this
    |
 help: primitive type `u64` doesn't have type parameters
    |
@@ -118,11 +138,13 @@ LL - let _x: u64<isize>;
 LL + let _x: u64;
    | 
 
-error[E0109]: type arguments are not allowed for this type
+error[E0109]: type arguments are not allowed on this type
   --> $DIR/prim-with-args.rs:14:14
    |
 LL | let _x: char<isize>;
-   |              ^^^^^ type argument not allowed
+   |         ---- ^^^^^ type argument not allowed
+   |         |
+   |         not allowed on this
    |
 help: primitive type `char` doesn't have type parameters
    |
@@ -130,11 +152,13 @@ LL - let _x: char<isize>;
 LL + let _x: char;
    | 
 
-error[E0109]: lifetime arguments are not allowed for this type
+error[E0109]: lifetime arguments are not allowed on this type
   --> $DIR/prim-with-args.rs:16:15
    |
 LL | let _x: isize<'static>;
-   |               ^^^^^^^ lifetime argument not allowed
+   |         ----- ^^^^^^^ lifetime argument not allowed
+   |         |
+   |         not allowed on this
    |
 help: primitive type `isize` doesn't have type parameters
    |
@@ -142,11 +166,13 @@ LL - let _x: isize<'static>;
 LL + let _x: isize;
    | 
 
-error[E0109]: lifetime arguments are not allowed for this type
+error[E0109]: lifetime arguments are not allowed on this type
   --> $DIR/prim-with-args.rs:17:12
    |
 LL | let _x: i8<'static>;
-   |            ^^^^^^^ lifetime argument not allowed
+   |         -- ^^^^^^^ lifetime argument not allowed
+   |         |
+   |         not allowed on this
    |
 help: primitive type `i8` doesn't have type parameters
    |
@@ -154,11 +180,13 @@ LL - let _x: i8<'static>;
 LL + let _x: i8;
    | 
 
-error[E0109]: lifetime arguments are not allowed for this type
+error[E0109]: lifetime arguments are not allowed on this type
   --> $DIR/prim-with-args.rs:18:13
    |
 LL | let _x: i16<'static>;
-   |             ^^^^^^^ lifetime argument not allowed
+   |         --- ^^^^^^^ lifetime argument not allowed
+   |         |
+   |         not allowed on this
    |
 help: primitive type `i16` doesn't have type parameters
    |
@@ -166,11 +194,13 @@ LL - let _x: i16<'static>;
 LL + let _x: i16;
    | 
 
-error[E0109]: lifetime arguments are not allowed for this type
+error[E0109]: lifetime arguments are not allowed on this type
   --> $DIR/prim-with-args.rs:19:13
    |
 LL | let _x: i32<'static>;
-   |             ^^^^^^^ lifetime argument not allowed
+   |         --- ^^^^^^^ lifetime argument not allowed
+   |         |
+   |         not allowed on this
    |
 help: primitive type `i32` doesn't have type parameters
    |
@@ -178,11 +208,13 @@ LL - let _x: i32<'static>;
 LL + let _x: i32;
    | 
 
-error[E0109]: lifetime arguments are not allowed for this type
+error[E0109]: lifetime arguments are not allowed on this type
   --> $DIR/prim-with-args.rs:20:13
    |
 LL | let _x: i64<'static>;
-   |             ^^^^^^^ lifetime argument not allowed
+   |         --- ^^^^^^^ lifetime argument not allowed
+   |         |
+   |         not allowed on this
    |
 help: primitive type `i64` doesn't have type parameters
    |
@@ -190,11 +222,13 @@ LL - let _x: i64<'static>;
 LL + let _x: i64;
    | 
 
-error[E0109]: lifetime arguments are not allowed for this type
+error[E0109]: lifetime arguments are not allowed on this type
   --> $DIR/prim-with-args.rs:21:15
    |
 LL | let _x: usize<'static>;
-   |               ^^^^^^^ lifetime argument not allowed
+   |         ----- ^^^^^^^ lifetime argument not allowed
+   |         |
+   |         not allowed on this
    |
 help: primitive type `usize` doesn't have type parameters
    |
@@ -202,11 +236,13 @@ LL - let _x: usize<'static>;
 LL + let _x: usize;
    | 
 
-error[E0109]: lifetime arguments are not allowed for this type
+error[E0109]: lifetime arguments are not allowed on this type
   --> $DIR/prim-with-args.rs:22:12
    |
 LL | let _x: u8<'static>;
-   |            ^^^^^^^ lifetime argument not allowed
+   |         -- ^^^^^^^ lifetime argument not allowed
+   |         |
+   |         not allowed on this
    |
 help: primitive type `u8` doesn't have type parameters
    |
@@ -214,11 +250,13 @@ LL - let _x: u8<'static>;
 LL + let _x: u8;
    | 
 
-error[E0109]: lifetime arguments are not allowed for this type
+error[E0109]: lifetime arguments are not allowed on this type
   --> $DIR/prim-with-args.rs:23:13
    |
 LL | let _x: u16<'static>;
-   |             ^^^^^^^ lifetime argument not allowed
+   |         --- ^^^^^^^ lifetime argument not allowed
+   |         |
+   |         not allowed on this
    |
 help: primitive type `u16` doesn't have type parameters
    |
@@ -226,11 +264,13 @@ LL - let _x: u16<'static>;
 LL + let _x: u16;
    | 
 
-error[E0109]: lifetime arguments are not allowed for this type
+error[E0109]: lifetime arguments are not allowed on this type
   --> $DIR/prim-with-args.rs:24:13
    |
 LL | let _x: u32<'static>;
-   |             ^^^^^^^ lifetime argument not allowed
+   |         --- ^^^^^^^ lifetime argument not allowed
+   |         |
+   |         not allowed on this
    |
 help: primitive type `u32` doesn't have type parameters
    |
@@ -238,11 +278,13 @@ LL - let _x: u32<'static>;
 LL + let _x: u32;
    | 
 
-error[E0109]: lifetime arguments are not allowed for this type
+error[E0109]: lifetime arguments are not allowed on this type
   --> $DIR/prim-with-args.rs:25:13
    |
 LL | let _x: u64<'static>;
-   |             ^^^^^^^ lifetime argument not allowed
+   |         --- ^^^^^^^ lifetime argument not allowed
+   |         |
+   |         not allowed on this
    |
 help: primitive type `u64` doesn't have type parameters
    |
@@ -250,11 +292,13 @@ LL - let _x: u64<'static>;
 LL + let _x: u64;
    | 
 
-error[E0109]: lifetime arguments are not allowed for this type
+error[E0109]: lifetime arguments are not allowed on this type
   --> $DIR/prim-with-args.rs:26:14
    |
 LL | let _x: char<'static>;
-   |              ^^^^^^^ lifetime argument not allowed
+   |         ---- ^^^^^^^ lifetime argument not allowed
+   |         |
+   |         not allowed on this
    |
 help: primitive type `char` doesn't have type parameters
    |

--- a/src/test/ui/usize-generic-argument-parent.rs
+++ b/src/test/ui/usize-generic-argument-parent.rs
@@ -1,5 +1,5 @@
 fn foo() {
-    let x: usize<foo>; //~ ERROR const arguments are not allowed for this type
+    let x: usize<foo>; //~ ERROR const arguments are not allowed on this type
 }
 
 fn main() {}

--- a/src/test/ui/usize-generic-argument-parent.stderr
+++ b/src/test/ui/usize-generic-argument-parent.stderr
@@ -1,8 +1,10 @@
-error[E0109]: const arguments are not allowed for this type
+error[E0109]: const arguments are not allowed on this type
   --> $DIR/usize-generic-argument-parent.rs:2:18
    |
 LL |     let x: usize<foo>;
-   |                  ^^^ const argument not allowed
+   |            ----- ^^^ const argument not allowed
+   |            |
+   |            not allowed on this
    |
 help: primitive type `usize` doesn't have type parameters
    |

--- a/src/test/ui/usize-generic-argument-parent.stderr
+++ b/src/test/ui/usize-generic-argument-parent.stderr
@@ -6,7 +6,7 @@ LL |     let x: usize<foo>;
    |            |
    |            not allowed on this
    |
-help: primitive type `usize` doesn't have type parameters
+help: primitive type `usize` doesn't have generic parameters
    |
 LL -     let x: usize<foo>;
 LL +     let x: usize;

--- a/src/test/ui/usize-generic-argument-parent.stderr
+++ b/src/test/ui/usize-generic-argument-parent.stderr
@@ -3,6 +3,12 @@ error[E0109]: const arguments are not allowed for this type
    |
 LL |     let x: usize<foo>;
    |                  ^^^ const argument not allowed
+   |
+help: primitive type `usize` doesn't have type parameters
+   |
+LL -     let x: usize<foo>;
+LL +     let x: usize;
+   | 
 
 error: aborting due to previous error
 

--- a/src/tools/clippy/clippy_lints/src/lifetimes.rs
+++ b/src/tools/clippy/clippy_lints/src/lifetimes.rs
@@ -371,7 +371,7 @@ impl<'a, 'tcx> RefVisitor<'a, 'tcx> {
         if let Some(ref lt) = *lifetime {
             if lt.name == LifetimeName::Static {
                 self.lts.push(RefLt::Static);
-            } else if let LifetimeName::Param(ParamName::Fresh(_)) = lt.name {
+            } else if let LifetimeName::Param(_, ParamName::Fresh) = lt.name {
                 // Fresh lifetimes generated should be ignored.
             } else if lt.is_elided() {
                 self.lts.push(RefLt::Unnamed);

--- a/src/tools/clippy/clippy_lints/src/ptr.rs
+++ b/src/tools/clippy/clippy_lints/src/ptr.rs
@@ -343,7 +343,7 @@ impl fmt::Display for RefPrefix {
         use fmt::Write;
         f.write_char('&')?;
         match self.lt {
-            LifetimeName::Param(ParamName::Plain(name)) => {
+            LifetimeName::Param(_, ParamName::Plain(name)) => {
                 name.fmt(f)?;
                 f.write_char(' ')?;
             },

--- a/src/tools/clippy/clippy_utils/src/hir_utils.rs
+++ b/src/tools/clippy/clippy_utils/src/hir_utils.rs
@@ -902,16 +902,14 @@ impl<'a, 'tcx> SpanlessHash<'a, 'tcx> {
 
     pub fn hash_lifetime(&mut self, lifetime: Lifetime) {
         std::mem::discriminant(&lifetime.name).hash(&mut self.s);
-        if let LifetimeName::Param(ref name) = lifetime.name {
+        if let LifetimeName::Param(param_id, ref name) = lifetime.name {
             std::mem::discriminant(name).hash(&mut self.s);
+            param_id.hash(&mut self.s);
             match name {
                 ParamName::Plain(ref ident) => {
                     ident.name.hash(&mut self.s);
                 },
-                ParamName::Fresh(ref size) => {
-                    size.hash(&mut self.s);
-                },
-                ParamName::Error => {},
+                ParamName::Fresh | ParamName::Error => {},
             }
         }
     }


### PR DESCRIPTION
Successful merges:

 - #97415 (Compute `is_late_bound_map` query separately from lifetime resolution)
 - #97471 (Provide more context when denying invalid type params )
 - #97681 (Add more eslint checks)

Failed merges:

 - #97446 (Make hir().get_generics and generics_of consistent.)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=97415,97471,97681)
<!-- homu-ignore:end -->