### PR TITLE
Add note to documentation of HashSet::intersection

### DIFF
--- a/library/std/src/collections/hash/set.rs
+++ b/library/std/src/collections/hash/set.rs
@@ -590,8 +590,9 @@ where
     ///
     /// When an equal element is present in `self` and `other`
     /// then the resulting `Intersection` may yield references to
-    /// one or the other, which will be visible in properties of `T`
-    /// not participating in the `Eq` implementation.
+    /// one or the other. This can be relevant if `T` contains fields which
+    /// are not compared by its `Eq` implementation, and may hold different
+    /// value between the two equal copies of `T` in the two sets.
     ///
     /// # Examples
     ///

--- a/library/std/src/collections/hash/set.rs
+++ b/library/std/src/collections/hash/set.rs
@@ -588,12 +588,10 @@ where
     /// Visits the values representing the intersection,
     /// i.e., the values that are both in `self` and `other`.
     ///
-    /// Note: this operation does not guarantee which collection
-    /// is visited from `self` or `other`. This has consequences
-    /// for values which may be defined as equal by the `Eq` trait
-    /// but which are not physically equivalent (eg. they may have
-    /// fields which differ or do not participate in the definition
-    /// of equivalence).
+    /// Note: When an equal element is present in `self` and `other`
+    /// then the resulting `Intersection` may yield references to
+    /// one or the other, which will be visible in properties of `T`
+    /// not participating in the `Eq` implementation.
     ///
     /// # Examples
     ///

--- a/library/std/src/collections/hash/set.rs
+++ b/library/std/src/collections/hash/set.rs
@@ -588,7 +588,7 @@ where
     /// Visits the values representing the intersection,
     /// i.e., the values that are both in `self` and `other`.
     ///
-    /// Note: When an equal element is present in `self` and `other`
+    /// When an equal element is present in `self` and `other`
     /// then the resulting `Intersection` may yield references to
     /// one or the other, which will be visible in properties of `T`
     /// not participating in the `Eq` implementation.

--- a/library/std/src/collections/hash/set.rs
+++ b/library/std/src/collections/hash/set.rs
@@ -588,6 +588,13 @@ where
     /// Visits the values representing the intersection,
     /// i.e., the values that are both in `self` and `other`.
     ///
+    /// Note: this operation does not guarantee which collection
+    /// is visited from `self` or `other`. This has consequences
+    /// for values which may be defined as equal by the `Eq` trait
+    /// but which are not physically equivalent (eg. they may have
+    /// fields which differ or do not participate in the definition
+    /// of equivalence).
+    ///
     /// # Examples
     ///
     /// ```


### PR DESCRIPTION
The functionality of the `std::collections::HashSet::intersection(...)` method was slightly surprising to me so I wanted to take a sec to contribute to the documentation for this method.

I've added a `Note:` section if that is appropriate.