### PR TITLE
Fix reachability analysis for const methods

### DIFF
--- a/src/test/ui/codegen/auxiliary/issue-97708-aux.rs
+++ b/src/test/ui/codegen/auxiliary/issue-97708-aux.rs
@@ -1,0 +1,41 @@
+use std::{ptr::NonNull, task::Poll};
+
+struct TaskRef;
+
+struct Header {
+    vtable: &'static Vtable,
+}
+
+struct Vtable {
+    poll: unsafe fn(TaskRef) -> Poll<()>,
+    deallocate: unsafe fn(NonNull<Header>),
+}
+
+// in the "Header" type, which is a private type in maitake
+impl Header {
+    pub(crate) const fn new_stub() -> Self {
+        unsafe fn nop(_ptr: TaskRef) -> Poll<()> {
+            Poll::Pending
+        }
+
+        unsafe fn nop_deallocate(ptr: NonNull<Header>) {
+            unreachable!("stub task ({ptr:p}) should never be deallocated!");
+        }
+
+        Self { vtable: &Vtable { poll: nop, deallocate: nop_deallocate } }
+    }
+}
+
+// This is a public type in `maitake`
+#[repr(transparent)]
+#[cfg_attr(loom, allow(dead_code))]
+pub struct TaskStub {
+    hdr: Header,
+}
+
+impl TaskStub {
+    /// Create a new unique stub [`Task`].
+    pub const fn new() -> Self {
+        Self { hdr: Header::new_stub() }
+    }
+}

--- a/src/test/ui/codegen/issue-97708.rs
+++ b/src/test/ui/codegen/issue-97708.rs
@@ -1,0 +1,9 @@
+// build-pass
+// aux-build:issue-97708-aux.rs
+
+extern crate issue_97708_aux;
+use issue_97708_aux::TaskStub;
+
+static TASK_STUB: TaskStub = TaskStub::new();
+
+fn main() {}


### PR DESCRIPTION
Use `method_might_be_inlined` directly for `ImplItemKind::Fn` instead of duplicating the logic in `def_id_represents_local_inlined_item`. 

This is parallel to how we use `item_might_be_inlined` for `ItemKind::Fn` in that same body.

Fixes #97708