### PR TITLE
Always create elided lifetime parameters for functions

### DIFF
--- a/compiler/rustc_feature/src/active.rs
+++ b/compiler/rustc_feature/src/active.rs
@@ -148,6 +148,8 @@ declare_features! (
     /// below (it has to be checked before expansion possibly makes
     /// macros disappear).
     (active, allow_internal_unstable, "1.0.0", None, None),
+    /// Allows using anonymous lifetimes in argument-position impl-trait.
+    (active, anonymous_lifetime_in_impl_trait, "1.63.0", None, None),
     /// Allows identifying the `compiler_builtins` crate.
     (active, compiler_builtins, "1.13.0", None, None),
     /// Outputs useful `assert!` messages

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -341,6 +341,7 @@ symbols! {
         always,
         and,
         and_then,
+        anonymous_lifetime_in_impl_trait,
         any,
         append_const_msg,
         arbitrary_enum_discriminant,

--- a/src/test/ui-fulldeps/internal-lints/rustc_pass_by_value.rs
+++ b/src/test/ui-fulldeps/internal-lints/rustc_pass_by_value.rs
@@ -93,7 +93,7 @@ impl CustomStruct {
 
     fn test_alias(
         value: CustomAlias,
-        reference: &CustomAlias, //~ ERROR passing `CustomAlias<>` by reference
+        reference: &CustomAlias, //~ ERROR passing `CustomAlias<'_>` by reference
     ) {
     }
 }

--- a/src/test/ui-fulldeps/internal-lints/rustc_pass_by_value.stderr
+++ b/src/test/ui-fulldeps/internal-lints/rustc_pass_by_value.stderr
@@ -94,11 +94,11 @@ error: passing `CustomStruct` by reference
 LL |         reference: &CustomStruct,
    |                    ^^^^^^^^^^^^^ help: try passing by value: `CustomStruct`
 
-error: passing `CustomAlias<>` by reference
+error: passing `CustomAlias<'_>` by reference
   --> $DIR/rustc_pass_by_value.rs:96:20
    |
 LL |         reference: &CustomAlias,
-   |                    ^^^^^^^^^^^^ help: try passing by value: `CustomAlias<>`
+   |                    ^^^^^^^^^^^^ help: try passing by value: `CustomAlias<'_>`
 
 error: passing `WithParameters<T, 1>` by reference
   --> $DIR/rustc_pass_by_value.rs:110:20

--- a/src/test/ui/generic-associated-types/bugs/issue-87748.stderr
+++ b/src/test/ui/generic-associated-types/bugs/issue-87748.stderr
@@ -4,12 +4,12 @@ error[E0478]: lifetime bound not satisfied
 LL |     fn do_sth(_: u32) {}
    |     ^^^^^^^^^^^^^^^^^
    |
-note: lifetime parameter instantiated with the anonymous lifetime #2 defined here
+note: lifetime parameter instantiated with the anonymous lifetime as defined here
   --> $DIR/issue-87748.rs:18:5
    |
 LL |     fn do_sth(_: u32) {}
    |     ^^^^^^^^^^^^^^^^^
-note: but lifetime parameter must outlive the anonymous lifetime #1 defined here
+note: but lifetime parameter must outlive the anonymous lifetime as defined here
   --> $DIR/issue-87748.rs:18:5
    |
 LL |     fn do_sth(_: u32) {}

--- a/src/test/ui/generic-associated-types/issue-95305.rs
+++ b/src/test/ui/generic-associated-types/issue-95305.rs
@@ -11,7 +11,10 @@ trait Foo {
 fn foo(x: &impl Foo<Item<'_> = u32>) { }
                        //~^ ERROR `'_` cannot be used here [E0637]
 
+// Ok: the anonymous lifetime is bound to the function.
 fn bar(x: &impl for<'a> Foo<Item<'a> = &'_ u32>) { }
-                                      //~^ ERROR missing lifetime specifier
+
+// Ok: the anonymous lifetime is bound to the function.
+fn baz(x: &impl for<'a> Foo<Item<'a> = &u32>) { }
 
 fn main() {}

--- a/src/test/ui/generic-associated-types/issue-95305.rs
+++ b/src/test/ui/generic-associated-types/issue-95305.rs
@@ -3,7 +3,7 @@
 // at some point in the future.
 
 #![feature(generic_associated_types)]
-
+#![feature(anonymous_lifetime_in_impl_trait)]
 trait Foo {
     type Item<'a>;
 }

--- a/src/test/ui/generic-associated-types/issue-95305.stderr
+++ b/src/test/ui/generic-associated-types/issue-95305.stderr
@@ -4,18 +4,6 @@ error[E0637]: `'_` cannot be used here
 LL | fn foo(x: &impl Foo<Item<'_> = u32>) { }
    |                          ^^ `'_` is a reserved lifetime name
 
-error[E0106]: missing lifetime specifier
-  --> $DIR/issue-95305.rs:14:41
-   |
-LL | fn bar(x: &impl for<'a> Foo<Item<'a> = &'_ u32>) { }
-   |                                         ^^ expected named lifetime parameter
-   |
-help: consider using the `'a` lifetime
-   |
-LL | fn bar(x: &impl for<'a> Foo<Item<'a> = &'a u32>) { }
-   |                                         ~~
+error: aborting due to previous error
 
-error: aborting due to 2 previous errors
-
-Some errors have detailed explanations: E0106, E0637.
-For more information about an error, try `rustc --explain E0106`.
+For more information about this error, try `rustc --explain E0637`.

--- a/src/test/ui/issues/issue-37884.stderr
+++ b/src/test/ui/issues/issue-37884.stderr
@@ -6,7 +6,7 @@ LL |     fn next(&'a mut self) -> Option<Self::Item>
    |
    = note: expected fn pointer `fn(&mut RepeatMut<'a, T>) -> Option<_>`
               found fn pointer `fn(&'a mut RepeatMut<'a, T>) -> Option<_>`
-note: the anonymous lifetime #1 defined here...
+note: the anonymous lifetime as defined here...
   --> $DIR/issue-37884.rs:6:5
    |
 LL |     fn next(&'a mut self) -> Option<Self::Item>

--- a/src/test/ui/nll/ty-outlives/impl-trait-captures.stderr
+++ b/src/test/ui/nll/ty-outlives/impl-trait-captures.stderr
@@ -2,14 +2,14 @@ error[E0700]: hidden type for `impl Trait` captures lifetime that does not appea
   --> $DIR/impl-trait-captures.rs:11:5
    |
 LL | fn foo<'a, T>(x: &T) -> impl Foo<'a> {
-   |                  -- hidden type `&ReFree(DefId(0:8 ~ impl_trait_captures[1afc]::foo), BrAnon(0)) T` captures the anonymous lifetime defined here
+   |                  -- hidden type `&ReFree(DefId(0:8 ~ impl_trait_captures[1afc]::foo), BrNamed(DefId(0:13 ~ impl_trait_captures[1afc]::foo::'_), '_)) T` captures the anonymous lifetime defined here
 LL |     x
    |     ^
    |
-help: to declare that the `impl Trait` captures `ReFree(DefId(0:8 ~ impl_trait_captures[1afc]::foo), BrAnon(0))`, you can add an explicit `ReFree(DefId(0:8 ~ impl_trait_captures[1afc]::foo), BrAnon(0))` lifetime bound
+help: to declare that the `impl Trait` captures `ReFree(DefId(0:8 ~ impl_trait_captures[1afc]::foo), BrNamed(DefId(0:13 ~ impl_trait_captures[1afc]::foo::'_), '_))`, you can add an explicit `ReFree(DefId(0:8 ~ impl_trait_captures[1afc]::foo), BrNamed(DefId(0:13 ~ impl_trait_captures[1afc]::foo::'_), '_))` lifetime bound
    |
-LL | fn foo<'a, T>(x: &T) -> impl Foo<'a> + ReFree(DefId(0:8 ~ impl_trait_captures[1afc]::foo), BrAnon(0)) {
-   |                                      ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+LL | fn foo<'a, T>(x: &T) -> impl Foo<'a> + ReFree(DefId(0:8 ~ impl_trait_captures[1afc]::foo), BrNamed(DefId(0:13 ~ impl_trait_captures[1afc]::foo::'_), '_)) {
+   |                                      ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 error: aborting due to previous error
 

--- a/src/test/ui/suggestions/impl-trait-missing-lifetime-gated.rs
+++ b/src/test/ui/suggestions/impl-trait-missing-lifetime-gated.rs
@@ -1,17 +1,19 @@
 // edition:2021
+// gate-test-anonymous_lifetime_in_impl_trait
+// Verify the behaviour of `feature(anonymous_lifetime_in_impl_trait)`.
 
-#![feature(anonymous_lifetime_in_impl_trait)]
-
-// This is understood as `fn foo<'_1>(_: impl Iterator<Item = &'_1 ()>) {}`.
 fn f(_: impl Iterator<Item = &'_ ()>) {}
+//~^ ERROR anonymous lifetimes in `impl Trait` are unstable
 
-// But that lifetime does not participate in resolution.
 fn g(x: impl Iterator<Item = &'_ ()>) -> Option<&'_ ()> { x.next() }
-//~^ ERROR missing lifetime specifier
+//~^ ERROR anonymous lifetimes in `impl Trait` are unstable
+//~| ERROR missing lifetime specifier
 
+// Anonymous lifetimes in async fn are already allowed.
 // This is understood as `fn foo<'_1>(_: impl Iterator<Item = &'_1 ()>) {}`.
 async fn h(_: impl Iterator<Item = &'_ ()>) {}
 
+// Anonymous lifetimes in async fn are already allowed.
 // But that lifetime does not participate in resolution.
 async fn i(x: impl Iterator<Item = &'_ ()>) -> Option<&'_ ()> { x.next() }
 //~^ ERROR missing lifetime specifier

--- a/src/test/ui/suggestions/impl-trait-missing-lifetime-gated.stderr
+++ b/src/test/ui/suggestions/impl-trait-missing-lifetime-gated.stderr
@@ -1,5 +1,13 @@
+error[E0658]: anonymous lifetimes in `impl Trait` are unstable
+  --> $DIR/impl-trait-missing-lifetime-gated.rs:5:31
+   |
+LL | fn f(_: impl Iterator<Item = &'_ ()>) {}
+   |                               ^^
+   |
+   = help: add `#![feature(anonymous_lifetime_in_impl_trait)]` to the crate attributes to enable
+
 error[E0106]: missing lifetime specifier
-  --> $DIR/impl-trait-missing-lifetime.rs:9:50
+  --> $DIR/impl-trait-missing-lifetime-gated.rs:8:50
    |
 LL | fn g(x: impl Iterator<Item = &'_ ()>) -> Option<&'_ ()> { x.next() }
    |                                                  ^^ expected named lifetime parameter
@@ -10,8 +18,16 @@ help: consider using the `'static` lifetime
 LL | fn g(x: impl Iterator<Item = &'_ ()>) -> Option<&'static ()> { x.next() }
    |                                                  ~~~~~~~
 
+error[E0658]: anonymous lifetimes in `impl Trait` are unstable
+  --> $DIR/impl-trait-missing-lifetime-gated.rs:8:31
+   |
+LL | fn g(x: impl Iterator<Item = &'_ ()>) -> Option<&'_ ()> { x.next() }
+   |                               ^^
+   |
+   = help: add `#![feature(anonymous_lifetime_in_impl_trait)]` to the crate attributes to enable
+
 error[E0106]: missing lifetime specifier
-  --> $DIR/impl-trait-missing-lifetime.rs:16:56
+  --> $DIR/impl-trait-missing-lifetime-gated.rs:18:56
    |
 LL | async fn i(x: impl Iterator<Item = &'_ ()>) -> Option<&'_ ()> { x.next() }
    |                                                        ^^ expected named lifetime parameter
@@ -22,6 +38,7 @@ help: consider using the `'static` lifetime
 LL | async fn i(x: impl Iterator<Item = &'_ ()>) -> Option<&'static ()> { x.next() }
    |                                                        ~~~~~~~
 
-error: aborting due to 2 previous errors
+error: aborting due to 4 previous errors
 
-For more information about this error, try `rustc --explain E0106`.
+Some errors have detailed explanations: E0106, E0658.
+For more information about an error, try `rustc --explain E0106`.

--- a/src/test/ui/suggestions/impl-trait-missing-lifetime.rs
+++ b/src/test/ui/suggestions/impl-trait-missing-lifetime.rs
@@ -1,2 +1,8 @@
-fn f(_: impl Iterator<Item = &'_ ()>) {} //~ ERROR missing lifetime specifier
+// This is understood as `fn foo<'_1>(_: impl Iterator<Item = &'_1 ()>) {}`.
+fn f(_: impl Iterator<Item = &'_ ()>) {}
+
+// But that lifetime does not participate in resolution.
+fn g(x: impl Iterator<Item = &'_ ()>) -> Option<&'_ ()> { x.next() }
+//~^ ERROR missing lifetime specifier
+
 fn main() {}

--- a/src/test/ui/suggestions/impl-trait-missing-lifetime.stderr
+++ b/src/test/ui/suggestions/impl-trait-missing-lifetime.stderr
@@ -1,13 +1,14 @@
 error[E0106]: missing lifetime specifier
-  --> $DIR/impl-trait-missing-lifetime.rs:1:31
+  --> $DIR/impl-trait-missing-lifetime.rs:5:50
    |
-LL | fn f(_: impl Iterator<Item = &'_ ()>) {}
-   |                               ^^ expected named lifetime parameter
+LL | fn g(x: impl Iterator<Item = &'_ ()>) -> Option<&'_ ()> { x.next() }
+   |                                                  ^^ expected named lifetime parameter
    |
-help: consider introducing a named lifetime parameter
+   = help: this function's return type contains a borrowed value with an elided lifetime, but the lifetime cannot be derived from the arguments
+help: consider using the `'static` lifetime
    |
-LL | fn f<'a>(_: impl Iterator<Item = &'a ()>) {}
-   |     ++++                          ~~
+LL | fn g(x: impl Iterator<Item = &'_ ()>) -> Option<&'static ()> { x.next() }
+   |                                                  ~~~~~~~
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/wf-in-foreign-fn-decls-issue-80468.stderr
+++ b/src/test/ui/wf/wf-in-foreign-fn-decls-issue-80468.stderr
@@ -21,11 +21,11 @@ note: because this has an unmet lifetime requirement
    |
 LL | pub struct Wrapper<T: Trait>(T);
    |                       ^^^^^ introduces a `'static` lifetime requirement
-note: the anonymous lifetime #1 defined here...
-  --> $DIR/wf-in-foreign-fn-decls-issue-80468.rs:16:5
+note: the anonymous lifetime as defined here...
+  --> $DIR/wf-in-foreign-fn-decls-issue-80468.rs:16:29
    |
 LL |     pub fn repro(_: Wrapper<Ref>);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |                             ^^^
 note: ...does not necessarily outlive the static lifetime introduced by the compatible `impl`
   --> $DIR/wf-in-foreign-fn-decls-issue-80468.rs:13:1
    |

--- a/src/tools/clippy/clippy_lints/src/inherent_to_string.rs
+++ b/src/tools/clippy/clippy_lints/src/inherent_to_string.rs
@@ -2,7 +2,7 @@ use clippy_utils::diagnostics::span_lint_and_help;
 use clippy_utils::ty::{implements_trait, is_type_diagnostic_item};
 use clippy_utils::{get_trait_def_id, paths, return_ty, trait_ref_of_method};
 use if_chain::if_chain;
-use rustc_hir::{ImplItem, ImplItemKind};
+use rustc_hir::{GenericParamKind, ImplItem, ImplItemKind};
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_session::{declare_lint_pass, declare_tool_lint};
 use rustc_span::sym;
@@ -102,7 +102,7 @@ impl<'tcx> LateLintPass<'tcx> for InherentToString {
             let decl = &signature.decl;
             if decl.implicit_self.has_implicit_self();
             if decl.inputs.len() == 1;
-            if impl_item.generics.params.is_empty();
+            if impl_item.generics.params.iter().all(|p| matches!(p.kind, GenericParamKind::Lifetime { .. }));
 
             // Check if return type is String
             if is_type_diagnostic_item(cx, return_ty(cx, impl_item.hir_id()), sym::String);

--- a/src/tools/clippy/clippy_lints/src/ptr.rs
+++ b/src/tools/clippy/clippy_lints/src/ptr.rs
@@ -495,12 +495,13 @@ fn check_mut_from_ref<'tcx>(cx: &LateContext<'tcx>, sig: &FnSig<'_>, body: Optio
     if let FnRetTy::Return(ty) = sig.decl.output
         && let Some((out, Mutability::Mut, _)) = get_rptr_lm(ty)
     {
+        let out_region = cx.tcx.named_region(out.hir_id);
         let args: Option<Vec<_>> = sig
             .decl
             .inputs
             .iter()
             .filter_map(get_rptr_lm)
-            .filter(|&(lt, _, _)| lt.name == out.name)
+            .filter(|&(lt, _, _)| cx.tcx.named_region(lt.hir_id) == out_region)
             .map(|(_, mutability, span)| (mutability == Mutability::Not).then(|| span))
             .collect();
         if let Some(args) = args

--- a/src/tools/clippy/clippy_lints/src/types/borrowed_box.rs
+++ b/src/tools/clippy/clippy_lints/src/types/borrowed_box.rs
@@ -31,7 +31,7 @@ pub(super) fn check(cx: &LateContext<'_>, hir_ty: &hir::Ty<'_>, lt: &Lifetime, m
                         return false;
                     }
 
-                    let ltopt = if lt.is_elided() {
+                    let ltopt = if lt.name.is_anonymous() {
                         String::new()
                     } else {
                         format!("{} ", lt.name.ident().as_str())


### PR DESCRIPTION
Anonymous and elided lifetimes in functions are sometimes (async fns) --and sometimes not (regular fns)-- desugared to implicit generic parameters.

This difference of treatment makes it some downstream analyses more complicated to handle.  This step is a pre-requisite to perform lifetime elision resolution on AST.

There is currently an inconsistency in the treatment of argument-position impl-trait for functions and async fns:
```rust
trait Foo<'a> {}
fn foo(t: impl Foo<'_>) {} //~ ERROR missing lifetime specifier
async fn async_foo(t: impl Foo<'_>) {} //~ OK
fn bar(t: impl Iterator<Item = &'_ u8>) {} //~ ERROR missing lifetime specifier
async fn async_bar(t: impl Iterator<Item = &'_ u8>) {} //~ OK
```

The current implementation reports "missing lifetime specifier" on `foo`, but **accepts it** in `async_foo`.
This PR **proposes to accept** the anonymous lifetime in both cases as an extra generic lifetime parameter.
This change would be insta-stable, so let's ping t-lang.
Anonymous lifetimes in GAT bindings keep being forbidden:
```rust
fn foo(t: impl Foo<Assoc<'_> = Bar<'_>>) {}
                         ^^        ^^
                       forbidden   ok
```
I started a discussion here: https://rust-lang.zulipchat.com/#narrow/stream/213817-t-lang/topic/Anonymous.20lifetimes.20in.20universal.20impl-trait/near/284968606

r? @petrochenkov 