### PR TITLE
Tighten spans for bad fields in struct deriving `Copy`

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/misc.rs
+++ b/compiler/rustc_trait_selection/src/traits/misc.rs
@@ -20,7 +20,7 @@ pub fn can_type_implement_copy<'tcx>(
     tcx: TyCtxt<'tcx>,
     param_env: ty::ParamEnv<'tcx>,
     self_type: Ty<'tcx>,
-    cause: ObligationCause<'tcx>,
+    parent_cause: ObligationCause<'tcx>,
 ) -> Result<(), CopyImplementationError<'tcx>> {
     // FIXME: (@jroesch) float this code up
     tcx.infer_ctxt().enter(|infcx| {
@@ -59,7 +59,7 @@ pub fn can_type_implement_copy<'tcx>(
                     .ty(tcx, traits::InternalSubsts::identity_for_item(tcx, adt.did()))
                     .has_param_types_or_consts()
                 {
-                    cause.clone()
+                    parent_cause.clone()
                 } else {
                     ObligationCause::dummy_with_span(span)
                 };

--- a/src/test/ui/suggestions/missing-bound-in-derive-copy-impl-3.stderr
+++ b/src/test/ui/suggestions/missing-bound-in-derive-copy-impl-3.stderr
@@ -10,12 +10,12 @@ LL |     pub size: Vector2<K>
    |     -------------------- this field does not implement `Copy`
    |
 note: the `Copy` impl for `Vector2<K>` requires that `K: Debug`
-  --> $DIR/missing-bound-in-derive-copy-impl-3.rs:12:5
+  --> $DIR/missing-bound-in-derive-copy-impl-3.rs:12:14
    |
 LL |     pub loc: Vector2<K>,
-   |     ^^^^^^^^^^^^^^^^^^^
+   |              ^^^^^^^^^^
 LL |     pub size: Vector2<K>
-   |     ^^^^^^^^^^^^^^^^^^^^
+   |               ^^^^^^^^^^
    = note: this error originates in the derive macro `Copy` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider further restricting this bound
    |

--- a/src/test/ui/suggestions/missing-bound-in-derive-copy-impl.stderr
+++ b/src/test/ui/suggestions/missing-bound-in-derive-copy-impl.stderr
@@ -10,12 +10,12 @@ LL |     pub size: Vector2<K>
    |     -------------------- this field does not implement `Copy`
    |
 note: the `Copy` impl for `Vector2<K>` requires that `K: Debug`
-  --> $DIR/missing-bound-in-derive-copy-impl.rs:11:5
+  --> $DIR/missing-bound-in-derive-copy-impl.rs:11:14
    |
 LL |     pub loc: Vector2<K>,
-   |     ^^^^^^^^^^^^^^^^^^^
+   |              ^^^^^^^^^^
 LL |     pub size: Vector2<K>
-   |     ^^^^^^^^^^^^^^^^^^^^
+   |               ^^^^^^^^^^
    = note: this error originates in the derive macro `Copy` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider restricting type parameter `K`
    |

--- a/src/test/ui/union/union-copy.stderr
+++ b/src/test/ui/union/union-copy.stderr
@@ -8,10 +8,10 @@ LL | impl Copy for W {}
    |      ^^^^
    |
 note: the `Copy` impl for `ManuallyDrop<String>` requires that `String: Copy`
-  --> $DIR/union-copy.rs:8:5
+  --> $DIR/union-copy.rs:8:8
    |
 LL |     a: std::mem::ManuallyDrop<String>
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to previous error
 


### PR DESCRIPTION
r? @estebank 

Closes #89137 for good, I think

Not sure if this is what you were looking for in https://github.com/rust-lang/rust/issues/89137#issuecomment-1146201791