### PR TITLE
Don't generate "Impls on Foreign Types" for std

### DIFF
--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -2281,11 +2281,10 @@ fn sidebar_trait(cx: &Context<'_>, buf: &mut Buffer, it: &clean::Item, t: &clean
         |sym| format!("<a href=\"#{1}.{0}\">{0}</a>", sym, ItemType::Method),
     );
 
-    let cache = cx.cache();
-    if let Some(implementors) = cache.implementors.get(&it.item_id.expect_def_id()) {
+    if let Some(implementors) = cx.cache().implementors.get(&it.item_id.expect_def_id()) {
         let mut res = implementors
             .iter()
-            .filter(|i| !i.is_on_local_type(cache))
+            .filter(|i| !i.is_on_local_type(cx))
             .filter_map(|i| extract_for_impl_name(&i.impl_item, cx))
             .collect::<Vec<_>>();
 

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -823,7 +823,7 @@ fn item_trait(w: &mut Buffer, cx: &mut Context<'_>, it: &clean::Item, t: &clean:
         }
 
         let (local, foreign) =
-            implementors.iter().partition::<Vec<_>, _>(|i| i.is_on_local_type(cache));
+            implementors.iter().partition::<Vec<_>, _>(|i| i.is_on_local_type(cx));
 
         let (mut synthetic, mut concrete): (Vec<&&Impl>, Vec<&&Impl>) =
             local.iter().partition(|i| i.inner_impl().kind.is_auto());


### PR DESCRIPTION
Hack: many traits and types in std are re-exported from core or alloc. In general, rustdoc is capable of recognizing these implementations as being on local types. However, in at least one case, rustdoc gets confused and labels an implementation as being on a foreign type. To make sure that confusion doesn't pass on to the reader, consider all implementations in std, core, and alloc to be on local types.

Demo: https://rustdoc.crud.net/jsha/no-foreign-std/std/clone/trait.Clone.html