### PR TITLE
Fix ICEs from zsts within unsized types with non-zero offsets

### DIFF
--- a/compiler/rustc_codegen_ssa/src/base.rs
+++ b/compiler/rustc_codegen_ssa/src/base.rs
@@ -216,11 +216,12 @@ pub fn unsize_ptr<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
             let mut result = None;
             for i in 0..src_layout.fields.count() {
                 let src_f = src_layout.field(bx.cx(), i);
-                assert_eq!(src_layout.fields.offset(i).bytes(), 0);
-                assert_eq!(dst_layout.fields.offset(i).bytes(), 0);
                 if src_f.is_zst() {
                     continue;
                 }
+
+                assert_eq!(src_layout.fields.offset(i).bytes(), 0);
+                assert_eq!(dst_layout.fields.offset(i).bytes(), 0);
                 assert_eq!(src_layout.size, src_f.size);
 
                 let dst_f = dst_layout.field(bx.cx(), i);

--- a/src/test/ui/unsized/issue-97732.rs
+++ b/src/test/ui/unsized/issue-97732.rs
@@ -1,0 +1,23 @@
+// check-pass
+
+#![feature(coerce_unsized)]
+
+// Ensure that unsizing structs that contain ZSTs at non-zero offsets don't ICE
+
+use std::ops::CoerceUnsized;
+
+#[repr(C)]
+pub struct BoxWithZstTail<T: ?Sized>(Box<T>, ());
+
+impl<S: ?Sized, T: ?Sized> CoerceUnsized<BoxWithZstTail<T>> for BoxWithZstTail<S> where
+    Box<S>: CoerceUnsized<Box<T>>
+{
+}
+
+pub fn noop_dyn_upcast_with_zst_tail(
+    b: BoxWithZstTail<dyn Send + Sync>,
+) -> BoxWithZstTail<dyn Send> {
+    b
+}
+
+fn main() {}

--- a/src/test/ui/unsized/issue-97732.rs
+++ b/src/test/ui/unsized/issue-97732.rs
@@ -15,9 +15,14 @@ impl<S: ?Sized, T: ?Sized> CoerceUnsized<BoxWithZstTail<T>> for BoxWithZstTail<S
 }
 
 pub fn noop_dyn_upcast_with_zst_tail(
-    b: BoxWithZstTail<dyn Send + Sync>,
-) -> BoxWithZstTail<dyn Send> {
+    b: BoxWithZstTail<dyn ToString + Send>,
+) -> BoxWithZstTail<dyn ToString> {
     b
 }
 
-fn main() {}
+fn main() {
+    let original = "foo";
+    let boxed = BoxWithZstTail(Box::new(original) as Box<dyn ToString + Send>, ());
+    let noop_upcasted = noop_dyn_upcast_with_zst_tail(boxed);
+    assert_eq!(original, noop_upcasted.0.to_string());
+}


### PR DESCRIPTION
- Fixes #97732
- Fixes ICEs while compiling `alloc` with `-Z randomize-layout`

r? @eddyb 