### PR TITLE
[WIP] Refine type trace in `higher_kinded_sub`

### DIFF
--- a/compiler/rustc_infer/src/infer/at.rs
+++ b/compiler/rustc_infer/src/infer/at.rs
@@ -81,6 +81,40 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
     }
 }
 
+pub trait SubTrace<'tcx> {
+    fn to_sub_trace(
+        tcx: TyCtxt<'tcx>,
+        cause: &ObligationCause<'tcx>,
+        a_is_expected: bool,
+        a: Self,
+        b: Self,
+    ) -> Option<TypeTrace<'tcx>>;
+}
+
+impl<'tcx, T> SubTrace<'tcx> for T {
+    default fn to_sub_trace(
+        _tcx: TyCtxt<'tcx>,
+        _cause: &ObligationCause<'tcx>,
+        _a_is_expected: bool,
+        _a: Self,
+        _b: Self,
+    ) -> Option<TypeTrace<'tcx>> {
+        None
+    }
+}
+
+impl<'tcx, T: ToTrace<'tcx>> SubTrace<'tcx> for T {
+    fn to_sub_trace(
+        tcx: TyCtxt<'tcx>,
+        cause: &ObligationCause<'tcx>,
+        a_is_expected: bool,
+        a: Self,
+        b: Self,
+    ) -> Option<TypeTrace<'tcx>> {
+        Some(T::to_trace(tcx, cause, a_is_expected, a, b))
+    }
+}
+
 pub trait ToTrace<'tcx>: Relate<'tcx> + Copy {
     fn to_trace(
         tcx: TyCtxt<'tcx>,

--- a/compiler/rustc_infer/src/lib.rs
+++ b/compiler/rustc_infer/src/lib.rs
@@ -20,10 +20,11 @@
 #![feature(label_break_value)]
 #![feature(let_chains)]
 #![feature(let_else)]
-#![feature(min_specialization)]
+#![feature(specialization)]
 #![feature(never_type)]
 #![feature(try_blocks)]
 #![recursion_limit = "512"] // For rustdoc
+#![allow(incomplete_features)]
 
 #[macro_use]
 extern crate rustc_macros;

--- a/src/test/ui/generator/resume-arg-late-bound.base.stderr
+++ b/src/test/ui/generator/resume-arg-late-bound.base.stderr
@@ -1,49 +1,20 @@
-error[E0308]: mismatched types
+error: implementation of `Generator` is not general enough
   --> $DIR/resume-arg-late-bound.rs:19:5
    |
 LL |     test(gen);
-   |     ^^^^ lifetime mismatch
+   |     ^^^^ implementation of `Generator` is not general enough
    |
-   = note: expected type `for<'a> Generator<&'a mut bool>`
-              found type `Generator<&mut bool>`
-note: the required lifetime does not necessarily outlive the anonymous lifetime #1 defined here
-  --> $DIR/resume-arg-late-bound.rs:15:15
-   |
-LL |       let gen = |arg: &mut bool| {
-   |  _______________^
-LL | |         yield ();
-LL | |         *arg = true;
-LL | |     };
-   | |_____^
-note: the lifetime requirement is introduced here
-  --> $DIR/resume-arg-late-bound.rs:12:17
-   |
-LL | fn test(a: impl for<'a> Generator<&'a mut bool>) {}
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: `[generator@$DIR/resume-arg-late-bound.rs:15:15: 18:6]` must implement `Generator<&'1 mut bool>`, for any lifetime `'1`...
+   = note: ...but it actually implements `Generator<&'2 mut bool>`, for some specific lifetime `'2`
 
-error[E0308]: mismatched types
+error: implementation of `Generator` is not general enough
   --> $DIR/resume-arg-late-bound.rs:19:5
    |
 LL |     test(gen);
-   |     ^^^^ lifetime mismatch
+   |     ^^^^ implementation of `Generator` is not general enough
    |
-   = note: expected type `for<'a> Generator<&'a mut bool>`
-              found type `Generator<&mut bool>`
-note: the anonymous lifetime #1 defined here doesn't meet the lifetime requirements
-  --> $DIR/resume-arg-late-bound.rs:15:15
-   |
-LL |       let gen = |arg: &mut bool| {
-   |  _______________^
-LL | |         yield ();
-LL | |         *arg = true;
-LL | |     };
-   | |_____^
-note: the lifetime requirement is introduced here
-  --> $DIR/resume-arg-late-bound.rs:12:17
-   |
-LL | fn test(a: impl for<'a> Generator<&'a mut bool>) {}
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: `[generator@$DIR/resume-arg-late-bound.rs:15:15: 18:6]` must implement `Generator<&'1 mut bool>`, for any lifetime `'1`...
+   = note: ...but it actually implements `Generator<&'2 mut bool>`, for some specific lifetime `'2`
 
 error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/generator/resume-arg-late-bound.nll.stderr
+++ b/src/test/ui/generator/resume-arg-late-bound.nll.stderr
@@ -1,17 +1,11 @@
-error[E0308]: mismatched types
+error: implementation of `Generator` is not general enough
   --> $DIR/resume-arg-late-bound.rs:19:5
    |
 LL |     test(gen);
-   |     ^^^^^^^^^ one type is more general than the other
+   |     ^^^^^^^^^ implementation of `Generator` is not general enough
    |
-   = note: expected type `for<'a> Generator<&'a mut bool>`
-              found type `Generator<&mut bool>`
-note: the lifetime requirement is introduced here
-  --> $DIR/resume-arg-late-bound.rs:12:17
-   |
-LL | fn test(a: impl for<'a> Generator<&'a mut bool>) {}
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: `[generator@$DIR/resume-arg-late-bound.rs:15:15: 18:6]` must implement `Generator<&'1 mut bool>`, for any lifetime `'1`...
+   = note: ...but it actually implements `Generator<&'2 mut bool>`, for some specific lifetime `'2`
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/generic-associated-types/bugs/issue-89352.base.stderr
+++ b/src/test/ui/generic-associated-types/bugs/issue-89352.base.stderr
@@ -4,8 +4,8 @@ error[E0308]: mismatched types
 LL |         let a = A::reborrow::<'ai, 's>(self.a.clone());
    |             ^ lifetime mismatch
    |
-   = note: expected type `<<A as GenAssoc<T>>::Iter<'s> as Sized>`
-              found type `<<A as GenAssoc<T>>::Iter<'ai> as Sized>`
+   = note: expected trait `<<A as GenAssoc<T>>::Iter<'s> as Sized>`
+              found trait `<<A as GenAssoc<T>>::Iter<'ai> as Sized>`
 note: the lifetime `'s` as defined here...
   --> $DIR/issue-89352.rs:35:13
    |

--- a/src/test/ui/higher-rank-trait-bounds/normalize-under-binder/issue-71955.nll.stderr
+++ b/src/test/ui/higher-rank-trait-bounds/normalize-under-binder/issue-71955.nll.stderr
@@ -1,79 +1,38 @@
-error[E0308]: mismatched types
+error: implementation of `FnOnce` is not general enough
   --> $DIR/issue-71955.rs:49:5
    |
 LL |     foo(bar, "string", |s| s.len() == 5);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ one type is more general than the other
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ implementation of `FnOnce` is not general enough
    |
-   = note: expected type `for<'r, 's> FnOnce<(&'r &'s str,)>`
-              found type `for<'r> FnOnce<(&'r &str,)>`
-note: this closure does not fulfill the lifetime requirements
-  --> $DIR/issue-71955.rs:49:24
-   |
-LL |     foo(bar, "string", |s| s.len() == 5);
-   |                        ^^^^^^^^^^^^^^^^
-note: the lifetime requirement is introduced here
-  --> $DIR/issue-71955.rs:29:9
-   |
-LL |     F2: FnOnce(&<F1 as Parser>::Output) -> bool
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: closure with signature `for<'r> fn(&'r &'2 str) -> bool` must implement `FnOnce<(&&'1 str,)>`, for any lifetime `'1`...
+   = note: ...but it actually implements `FnOnce<(&&'2 str,)>`, for some specific lifetime `'2`
 
-error[E0308]: mismatched types
+error: implementation of `FnOnce` is not general enough
   --> $DIR/issue-71955.rs:49:5
    |
 LL |     foo(bar, "string", |s| s.len() == 5);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ one type is more general than the other
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ implementation of `FnOnce` is not general enough
    |
-   = note: expected type `FnOnce<(&&str,)>`
-              found type `for<'r> FnOnce<(&'r &str,)>`
-note: this closure does not fulfill the lifetime requirements
-  --> $DIR/issue-71955.rs:49:24
-   |
-LL |     foo(bar, "string", |s| s.len() == 5);
-   |                        ^^^^^^^^^^^^^^^^
-note: the lifetime requirement is introduced here
-  --> $DIR/issue-71955.rs:29:44
-   |
-LL |     F2: FnOnce(&<F1 as Parser>::Output) -> bool
-   |                                            ^^^^
+   = note: closure with signature `for<'r> fn(&'r &'2 str) -> bool` must implement `FnOnce<(&&'1 str,)>`, for any lifetime `'1`...
+   = note: ...but it actually implements `FnOnce<(&&'2 str,)>`, for some specific lifetime `'2`
 
-error[E0308]: mismatched types
+error: implementation of `FnOnce` is not general enough
   --> $DIR/issue-71955.rs:53:5
    |
 LL |     foo(baz, "string", |s| s.0.len() == 5);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ one type is more general than the other
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ implementation of `FnOnce` is not general enough
    |
-   = note: expected type `for<'r, 's> FnOnce<(&'r Wrapper<'s>,)>`
-              found type `for<'r> FnOnce<(&'r Wrapper<'_>,)>`
-note: this closure does not fulfill the lifetime requirements
-  --> $DIR/issue-71955.rs:53:24
-   |
-LL |     foo(baz, "string", |s| s.0.len() == 5);
-   |                        ^^^^^^^^^^^^^^^^^^
-note: the lifetime requirement is introduced here
-  --> $DIR/issue-71955.rs:29:9
-   |
-LL |     F2: FnOnce(&<F1 as Parser>::Output) -> bool
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: closure with signature `for<'r> fn(&'r Wrapper<'2>) -> bool` must implement `FnOnce<(&Wrapper<'1>,)>`, for any lifetime `'1`...
+   = note: ...but it actually implements `FnOnce<(&Wrapper<'2>,)>`, for some specific lifetime `'2`
 
-error[E0308]: mismatched types
+error: implementation of `FnOnce` is not general enough
   --> $DIR/issue-71955.rs:53:5
    |
 LL |     foo(baz, "string", |s| s.0.len() == 5);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ one type is more general than the other
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ implementation of `FnOnce` is not general enough
    |
-   = note: expected type `FnOnce<(&Wrapper<'_>,)>`
-              found type `for<'r> FnOnce<(&'r Wrapper<'_>,)>`
-note: this closure does not fulfill the lifetime requirements
-  --> $DIR/issue-71955.rs:53:24
-   |
-LL |     foo(baz, "string", |s| s.0.len() == 5);
-   |                        ^^^^^^^^^^^^^^^^^^
-note: the lifetime requirement is introduced here
-  --> $DIR/issue-71955.rs:29:44
-   |
-LL |     F2: FnOnce(&<F1 as Parser>::Output) -> bool
-   |                                            ^^^^
+   = note: closure with signature `for<'r> fn(&'r Wrapper<'2>) -> bool` must implement `FnOnce<(&Wrapper<'1>,)>`, for any lifetime `'1`...
+   = note: ...but it actually implements `FnOnce<(&Wrapper<'2>,)>`, for some specific lifetime `'2`
 
 error: aborting due to 4 previous errors
 
-For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/issues/issue-27942.stderr
+++ b/src/test/ui/issues/issue-27942.stderr
@@ -4,8 +4,8 @@ error[E0308]: mismatched types
 LL |     fn select(&self) -> BufferViewHandle<R>;
    |                         ^^^^^^^^^^^^^^^^^^^ lifetime mismatch
    |
-   = note: expected type `Resources<'_>`
-              found type `Resources<'a>`
+   = note: expected trait `Resources<'_>`
+              found trait `Resources<'a>`
 note: the anonymous lifetime defined here...
   --> $DIR/issue-27942.rs:5:15
    |
@@ -23,8 +23,8 @@ error[E0308]: mismatched types
 LL |     fn select(&self) -> BufferViewHandle<R>;
    |                         ^^^^^^^^^^^^^^^^^^^ lifetime mismatch
    |
-   = note: expected type `Resources<'_>`
-              found type `Resources<'a>`
+   = note: expected trait `Resources<'_>`
+              found trait `Resources<'a>`
 note: the lifetime `'a` as defined here...
   --> $DIR/issue-27942.rs:3:18
    |

--- a/src/test/ui/lifetimes/issue-79187-2.base.stderr
+++ b/src/test/ui/lifetimes/issue-79187-2.base.stderr
@@ -1,21 +1,11 @@
-error[E0308]: mismatched types
+error: implementation of `Fn` is not general enough
   --> $DIR/issue-79187-2.rs:12:5
    |
 LL |     take_foo(|a| a);
-   |     ^^^^^^^^ lifetime mismatch
+   |     ^^^^^^^^ implementation of `Fn` is not general enough
    |
-   = note: expected type `for<'r> Fn<(&'r i32,)>`
-              found type `Fn<(&i32,)>`
-note: this closure does not fulfill the lifetime requirements
-  --> $DIR/issue-79187-2.rs:12:14
-   |
-LL |     take_foo(|a| a);
-   |              ^^^^^
-note: the lifetime requirement is introduced here
-  --> $DIR/issue-79187-2.rs:9:21
-   |
-LL | fn take_foo(_: impl Foo) {}
-   |                     ^^^
+   = note: closure with signature `fn(&'2 i32) -> &i32` must implement `Fn<(&'1 i32,)>`, for any lifetime `'1`...
+   = note: ...but it actually implements `Fn<(&'2 i32,)>`, for some specific lifetime `'2`
 
 error[E0308]: mismatched types
   --> $DIR/issue-79187-2.rs:16:5

--- a/src/test/ui/lifetimes/issue-79187-2.nll.stderr
+++ b/src/test/ui/lifetimes/issue-79187-2.nll.stderr
@@ -25,24 +25,14 @@ LL |     take_foo(|a| a);
    = note: closure with signature `fn(&'2 i32) -> &i32` must implement `FnOnce<(&'1 i32,)>`, for any lifetime `'1`...
    = note: ...but it actually implements `FnOnce<(&'2 i32,)>`, for some specific lifetime `'2`
 
-error[E0308]: mismatched types
+error: implementation of `Fn` is not general enough
   --> $DIR/issue-79187-2.rs:12:5
    |
 LL |     take_foo(|a| a);
-   |     ^^^^^^^^^^^^^^^ one type is more general than the other
+   |     ^^^^^^^^^^^^^^^ implementation of `Fn` is not general enough
    |
-   = note: expected type `for<'r> Fn<(&'r i32,)>`
-              found type `Fn<(&i32,)>`
-note: this closure does not fulfill the lifetime requirements
-  --> $DIR/issue-79187-2.rs:12:14
-   |
-LL |     take_foo(|a| a);
-   |              ^^^^^
-note: the lifetime requirement is introduced here
-  --> $DIR/issue-79187-2.rs:9:21
-   |
-LL | fn take_foo(_: impl Foo) {}
-   |                     ^^^
+   = note: closure with signature `fn(&'2 i32) -> &i32` must implement `Fn<(&'1 i32,)>`, for any lifetime `'1`...
+   = note: ...but it actually implements `Fn<(&'2 i32,)>`, for some specific lifetime `'2`
 
 error[E0308]: mismatched types
   --> $DIR/issue-79187-2.rs:16:5

--- a/src/test/ui/lifetimes/issue-79187.nll.stderr
+++ b/src/test/ui/lifetimes/issue-79187.nll.stderr
@@ -1,21 +1,11 @@
-error[E0308]: mismatched types
+error: implementation of `FnOnce` is not general enough
   --> $DIR/issue-79187.rs:9:5
    |
 LL |     thing(f);
-   |     ^^^^^^^^ one type is more general than the other
+   |     ^^^^^^^^ implementation of `FnOnce` is not general enough
    |
-   = note: expected type `for<'r> FnOnce<(&'r u32,)>`
-              found type `FnOnce<(&u32,)>`
-note: this closure does not fulfill the lifetime requirements
-  --> $DIR/issue-79187.rs:8:13
-   |
-LL |     let f = |_| ();
-   |             ^^^^^^
-note: the lifetime requirement is introduced here
-  --> $DIR/issue-79187.rs:5:18
-   |
-LL | fn thing(x: impl FnOnce(&u32)) {}
-   |                  ^^^^^^^^^^^^
+   = note: closure with signature `fn(&'2 u32)` must implement `FnOnce<(&'1 u32,)>`, for any lifetime `'1`...
+   = note: ...but it actually implements `FnOnce<(&'2 u32,)>`, for some specific lifetime `'2`
 
 error: implementation of `FnOnce` is not general enough
   --> $DIR/issue-79187.rs:9:5
@@ -28,4 +18,3 @@ LL |     thing(f);
 
 error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/lifetimes/lifetime-errors/issue_74400.nll.stderr
+++ b/src/test/ui/lifetimes/lifetime-errors/issue_74400.nll.stderr
@@ -9,19 +9,14 @@ help: consider adding an explicit lifetime bound...
 LL | fn g<T: 'static>(data: &[T]) {
    |       +++++++++
 
-error[E0308]: mismatched types
+error: implementation of `Fn` is not general enough
   --> $DIR/issue_74400.rs:16:5
    |
 LL |     f(data, identity)
-   |     ^^^^^^^^^^^^^^^^^ one type is more general than the other
+   |     ^^^^^^^^^^^^^^^^^ implementation of `Fn` is not general enough
    |
-   = note: expected type `for<'r> Fn<(&'r T,)>`
-              found type `Fn<(&T,)>`
-note: the lifetime requirement is introduced here
-  --> $DIR/issue_74400.rs:12:34
-   |
-LL | fn f<T, S>(data: &[T], key: impl Fn(&T) -> S) {
-   |                                  ^^^^^^^^^^^
+   = note: `fn(&'2 T) -> &'2 T {identity::<&'2 T>}` must implement `Fn<(&'1 T,)>`, for any lifetime `'1`...
+   = note: ...but it actually implements `Fn<(&'2 T,)>`, for some specific lifetime `'2`
 
 error: implementation of `FnOnce` is not general enough
   --> $DIR/issue_74400.rs:16:5
@@ -34,5 +29,4 @@ LL |     f(data, identity)
 
 error: aborting due to 3 previous errors
 
-Some errors have detailed explanations: E0308, E0310.
-For more information about an error, try `rustc --explain E0308`.
+For more information about this error, try `rustc --explain E0310`.

--- a/src/test/ui/mismatched_types/closure-arg-type-mismatch.base.stderr
+++ b/src/test/ui/mismatched_types/closure-arg-type-mismatch.base.stderr
@@ -40,24 +40,14 @@ note: required by a bound in `map`
 LL |         F: FnMut(Self::Item) -> B,
    |            ^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `map`
 
-error[E0308]: mismatched types
+error: implementation of `Fn` is not general enough
   --> $DIR/closure-arg-type-mismatch.rs:14:5
    |
 LL |     baz(f);
-   |     ^^^ lifetime mismatch
+   |     ^^^ implementation of `Fn` is not general enough
    |
-   = note: expected type `for<'r> Fn<(*mut &'r u32,)>`
-              found type `Fn<(*mut &'a u32,)>`
-note: the required lifetime does not necessarily outlive the lifetime `'a` as defined here
-  --> $DIR/closure-arg-type-mismatch.rs:13:10
-   |
-LL | fn _test<'a>(f: fn(*mut &'a u32)) {
-   |          ^^
-note: the lifetime requirement is introduced here
-  --> $DIR/closure-arg-type-mismatch.rs:12:11
-   |
-LL | fn baz<F: Fn(*mut &u32)>(_: F) {}
-   |           ^^^^^^^^^^^^^
+   = note: `fn(*mut &'a u32)` must implement `Fn<(*mut &'0 u32,)>`, for any lifetime `'0`...
+   = note: ...but it actually implements `Fn<(*mut &'a u32,)>`
 
 error: implementation of `FnOnce` is not general enough
   --> $DIR/closure-arg-type-mismatch.rs:14:5
@@ -68,24 +58,14 @@ LL |     baz(f);
    = note: `fn(*mut &'a u32)` must implement `FnOnce<(*mut &'0 u32,)>`, for any lifetime `'0`...
    = note: ...but it actually implements `FnOnce<(*mut &'a u32,)>`
 
-error[E0308]: mismatched types
+error: implementation of `Fn` is not general enough
   --> $DIR/closure-arg-type-mismatch.rs:14:5
    |
 LL |     baz(f);
-   |     ^^^ lifetime mismatch
+   |     ^^^ implementation of `Fn` is not general enough
    |
-   = note: expected type `for<'r> Fn<(*mut &'r u32,)>`
-              found type `Fn<(*mut &'a u32,)>`
-note: the lifetime `'a` as defined here doesn't meet the lifetime requirements
-  --> $DIR/closure-arg-type-mismatch.rs:13:10
-   |
-LL | fn _test<'a>(f: fn(*mut &'a u32)) {
-   |          ^^
-note: the lifetime requirement is introduced here
-  --> $DIR/closure-arg-type-mismatch.rs:12:11
-   |
-LL | fn baz<F: Fn(*mut &u32)>(_: F) {}
-   |           ^^^^^^^^^^^^^
+   = note: `fn(*mut &'a u32)` must implement `Fn<(*mut &'0 u32,)>`, for any lifetime `'0`...
+   = note: ...but it actually implements `Fn<(*mut &'a u32,)>`
 
 error: implementation of `FnOnce` is not general enough
   --> $DIR/closure-arg-type-mismatch.rs:14:5
@@ -98,5 +78,4 @@ LL |     baz(f);
 
 error: aborting due to 7 previous errors
 
-Some errors have detailed explanations: E0308, E0631.
-For more information about an error, try `rustc --explain E0308`.
+For more information about this error, try `rustc --explain E0631`.

--- a/src/test/ui/mismatched_types/closure-mismatch.base.stderr
+++ b/src/test/ui/mismatched_types/closure-mismatch.base.stderr
@@ -1,22 +1,11 @@
-error[E0308]: mismatched types
+error: implementation of `Fn` is not general enough
   --> $DIR/closure-mismatch.rs:12:5
    |
 LL |     baz(|_| ());
-   |     ^^^ lifetime mismatch
+   |     ^^^ implementation of `Fn` is not general enough
    |
-   = note: expected type `for<'r> Fn<(&'r (),)>`
-              found type `Fn<(&(),)>`
-note: this closure does not fulfill the lifetime requirements
-  --> $DIR/closure-mismatch.rs:12:9
-   |
-LL |     baz(|_| ());
-   |         ^^^^^^
-note: the lifetime requirement is introduced here
-  --> $DIR/closure-mismatch.rs:9:11
-   |
-LL | fn baz<T: Foo>(_: T) {}
-   |           ^^^
+   = note: closure with signature `fn(&'2 ())` must implement `Fn<(&'1 (),)>`, for any lifetime `'1`...
+   = note: ...but it actually implements `Fn<(&'2 (),)>`, for some specific lifetime `'2`
 
 error: aborting due to previous error
 
-For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/mismatched_types/closure-mismatch.nll.stderr
+++ b/src/test/ui/mismatched_types/closure-mismatch.nll.stderr
@@ -7,25 +7,14 @@ LL |     baz(|_| ());
    = note: closure with signature `fn(&'2 ())` must implement `FnOnce<(&'1 (),)>`, for any lifetime `'1`...
    = note: ...but it actually implements `FnOnce<(&'2 (),)>`, for some specific lifetime `'2`
 
-error[E0308]: mismatched types
+error: implementation of `Fn` is not general enough
   --> $DIR/closure-mismatch.rs:12:5
    |
 LL |     baz(|_| ());
-   |     ^^^^^^^^^^^ one type is more general than the other
+   |     ^^^^^^^^^^^ implementation of `Fn` is not general enough
    |
-   = note: expected type `for<'r> Fn<(&'r (),)>`
-              found type `Fn<(&(),)>`
-note: this closure does not fulfill the lifetime requirements
-  --> $DIR/closure-mismatch.rs:12:9
-   |
-LL |     baz(|_| ());
-   |         ^^^^^^
-note: the lifetime requirement is introduced here
-  --> $DIR/closure-mismatch.rs:9:11
-   |
-LL | fn baz<T: Foo>(_: T) {}
-   |           ^^^
+   = note: closure with signature `fn(&'2 ())` must implement `Fn<(&'1 (),)>`, for any lifetime `'1`...
+   = note: ...but it actually implements `Fn<(&'2 (),)>`, for some specific lifetime `'2`
 
 error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/nll/issue-50716.base.stderr
+++ b/src/test/ui/nll/issue-50716.base.stderr
@@ -4,8 +4,8 @@ error[E0308]: mismatched types
 LL |     let _x = *s;
    |         ^^ lifetime mismatch
    |
-   = note: expected type `<<&'a T as A>::X as Sized>`
-              found type `<<&'static T as A>::X as Sized>`
+   = note: expected trait `<<&'a T as A>::X as Sized>`
+              found trait `<<&'static T as A>::X as Sized>`
 note: the lifetime `'a` as defined here...
   --> $DIR/issue-50716.rs:13:8
    |

--- a/src/test/ui/rfc1623.nll.stderr
+++ b/src/test/ui/rfc1623.nll.stderr
@@ -1,20 +1,20 @@
-error[E0308]: mismatched types
+error: implementation of `Fn` is not general enough
   --> $DIR/rfc1623.rs:32:8
    |
 LL |     f: &id,
-   |        ^^^ one type is more general than the other
+   |        ^^^ implementation of `Fn` is not general enough
    |
-   = note: expected type `for<'a, 'b> Fn<(&'a Foo<'b>,)>`
-              found type `Fn<(&Foo<'_>,)>`
+   = note: `fn(&'2 Foo<'_>) -> &'2 Foo<'_> {id::<&'2 Foo<'_>>}` must implement `Fn<(&'1 Foo<'b>,)>`, for any lifetime `'1`...
+   = note: ...but it actually implements `Fn<(&'2 Foo<'_>,)>`, for some specific lifetime `'2`
 
-error[E0308]: mismatched types
+error: implementation of `Fn` is not general enough
   --> $DIR/rfc1623.rs:32:8
    |
 LL |     f: &id,
-   |        ^^^ one type is more general than the other
+   |        ^^^ implementation of `Fn` is not general enough
    |
-   = note: expected type `for<'a, 'b> Fn<(&'a Foo<'b>,)>`
-              found type `Fn<(&Foo<'_>,)>`
+   = note: `fn(&Foo<'2>) -> &Foo<'2> {id::<&Foo<'2>>}` must implement `Fn<(&'a Foo<'1>,)>`, for any lifetime `'1`...
+   = note: ...but it actually implements `Fn<(&Foo<'2>,)>`, for some specific lifetime `'2`
 
 error: implementation of `FnOnce` is not general enough
   --> $DIR/rfc1623.rs:32:8
@@ -36,4 +36,3 @@ LL |     f: &id,
 
 error: aborting due to 4 previous errors
 
-For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/type-alias-impl-trait/issue-57611-trait-alias.nll.stderr
+++ b/src/test/ui/type-alias-impl-trait/issue-57611-trait-alias.nll.stderr
@@ -1,16 +1,11 @@
-error[E0308]: mismatched types
+error: implementation of `Fn` is not general enough
   --> $DIR/issue-57611-trait-alias.rs:25:9
    |
 LL |         |x| x
-   |         ^^^^^ one type is more general than the other
+   |         ^^^^^ implementation of `Fn` is not general enough
    |
-   = note: expected type `for<'r> Fn<(&'r X,)>`
-              found type `Fn<(&X,)>`
-note: this closure does not fulfill the lifetime requirements
-  --> $DIR/issue-57611-trait-alias.rs:25:9
-   |
-LL |         |x| x
-   |         ^^^^^
+   = note: closure with signature `fn(&'2 X) -> &X` must implement `Fn<(&'1 X,)>`, for any lifetime `'1`...
+   = note: ...but it actually implements `Fn<(&'2 X,)>`, for some specific lifetime `'2`
 
 error: implementation of `FnOnce` is not general enough
   --> $DIR/issue-57611-trait-alias.rs:25:9
@@ -23,4 +18,3 @@ LL |         |x| x
 
 error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/variance/variance-contravariant-arg-trait-match.base.stderr
+++ b/src/test/ui/variance/variance-contravariant-arg-trait-match.base.stderr
@@ -4,8 +4,8 @@ error[E0308]: mismatched types
 LL |     impls_get::<G,&'min i32>()
    |     ^^^^^^^^^^^^^^^^^^^^^^^^ lifetime mismatch
    |
-   = note: expected type `Get<&'min i32>`
-              found type `Get<&'max i32>`
+   = note: expected trait `Get<&'min i32>`
+              found trait `Get<&'max i32>`
 note: the lifetime `'min` as defined here...
   --> $DIR/variance-contravariant-arg-trait-match.rs:14:21
    |
@@ -23,8 +23,8 @@ error[E0308]: mismatched types
 LL |     impls_get::<G,&'max i32>()
    |     ^^^^^^^^^^^^^^^^^^^^^^^^ lifetime mismatch
    |
-   = note: expected type `Get<&'max i32>`
-              found type `Get<&'min i32>`
+   = note: expected trait `Get<&'max i32>`
+              found trait `Get<&'min i32>`
 note: the lifetime `'min` as defined here...
   --> $DIR/variance-contravariant-arg-trait-match.rs:22:21
    |

--- a/src/test/ui/variance/variance-contravariant-self-trait-match.base.stderr
+++ b/src/test/ui/variance/variance-contravariant-self-trait-match.base.stderr
@@ -4,8 +4,8 @@ error[E0308]: mismatched types
 LL |     impls_get::<&'min G>();
    |     ^^^^^^^^^^^^^^^^^^^^ lifetime mismatch
    |
-   = note: expected type `<&'min G as Get>`
-              found type `<&'max G as Get>`
+   = note: expected trait `<&'min G as Get>`
+              found trait `<&'max G as Get>`
 note: the lifetime `'min` as defined here...
   --> $DIR/variance-contravariant-self-trait-match.rs:14:21
    |
@@ -23,8 +23,8 @@ error[E0308]: mismatched types
 LL |     impls_get::<&'max G>();
    |     ^^^^^^^^^^^^^^^^^^^^ lifetime mismatch
    |
-   = note: expected type `<&'max G as Get>`
-              found type `<&'min G as Get>`
+   = note: expected trait `<&'max G as Get>`
+              found trait `<&'min G as Get>`
 note: the lifetime `'min` as defined here...
   --> $DIR/variance-contravariant-self-trait-match.rs:22:21
    |

--- a/src/test/ui/variance/variance-covariant-arg-trait-match.base.stderr
+++ b/src/test/ui/variance/variance-covariant-arg-trait-match.base.stderr
@@ -4,8 +4,8 @@ error[E0308]: mismatched types
 LL |     impls_get::<G,&'min i32>()
    |     ^^^^^^^^^^^^^^^^^^^^^^^^ lifetime mismatch
    |
-   = note: expected type `Get<&'min i32>`
-              found type `Get<&'max i32>`
+   = note: expected trait `Get<&'min i32>`
+              found trait `Get<&'max i32>`
 note: the lifetime `'min` as defined here...
   --> $DIR/variance-covariant-arg-trait-match.rs:14:21
    |
@@ -23,8 +23,8 @@ error[E0308]: mismatched types
 LL |     impls_get::<G,&'max i32>()
    |     ^^^^^^^^^^^^^^^^^^^^^^^^ lifetime mismatch
    |
-   = note: expected type `Get<&'max i32>`
-              found type `Get<&'min i32>`
+   = note: expected trait `Get<&'max i32>`
+              found trait `Get<&'min i32>`
 note: the lifetime `'min` as defined here...
   --> $DIR/variance-covariant-arg-trait-match.rs:23:21
    |

--- a/src/test/ui/variance/variance-covariant-self-trait-match.base.stderr
+++ b/src/test/ui/variance/variance-covariant-self-trait-match.base.stderr
@@ -4,8 +4,8 @@ error[E0308]: mismatched types
 LL |     impls_get::<&'min G>();
    |     ^^^^^^^^^^^^^^^^^^^^ lifetime mismatch
    |
-   = note: expected type `<&'min G as Get>`
-              found type `<&'max G as Get>`
+   = note: expected trait `<&'min G as Get>`
+              found trait `<&'max G as Get>`
 note: the lifetime `'min` as defined here...
   --> $DIR/variance-covariant-self-trait-match.rs:14:21
    |
@@ -23,8 +23,8 @@ error[E0308]: mismatched types
 LL |     impls_get::<&'max G>();
    |     ^^^^^^^^^^^^^^^^^^^^ lifetime mismatch
    |
-   = note: expected type `<&'max G as Get>`
-              found type `<&'min G as Get>`
+   = note: expected trait `<&'max G as Get>`
+              found trait `<&'min G as Get>`
 note: the lifetime `'min` as defined here...
   --> $DIR/variance-covariant-self-trait-match.rs:23:21
    |

--- a/src/test/ui/variance/variance-invariant-arg-trait-match.base.stderr
+++ b/src/test/ui/variance/variance-invariant-arg-trait-match.base.stderr
@@ -4,8 +4,8 @@ error[E0308]: mismatched types
 LL |     impls_get::<G,&'min i32>()
    |     ^^^^^^^^^^^^^^^^^^^^^^^^ lifetime mismatch
    |
-   = note: expected type `Get<&'min i32>`
-              found type `Get<&'max i32>`
+   = note: expected trait `Get<&'min i32>`
+              found trait `Get<&'max i32>`
 note: the lifetime `'min` as defined here...
   --> $DIR/variance-invariant-arg-trait-match.rs:11:21
    |
@@ -23,8 +23,8 @@ error[E0308]: mismatched types
 LL |     impls_get::<G,&'max i32>()
    |     ^^^^^^^^^^^^^^^^^^^^^^^^ lifetime mismatch
    |
-   = note: expected type `Get<&'max i32>`
-              found type `Get<&'min i32>`
+   = note: expected trait `Get<&'max i32>`
+              found trait `Get<&'min i32>`
 note: the lifetime `'min` as defined here...
   --> $DIR/variance-invariant-arg-trait-match.rs:19:21
    |

--- a/src/test/ui/variance/variance-invariant-self-trait-match.base.stderr
+++ b/src/test/ui/variance/variance-invariant-self-trait-match.base.stderr
@@ -4,8 +4,8 @@ error[E0308]: mismatched types
 LL |     impls_get::<&'min G>();
    |     ^^^^^^^^^^^^^^^^^^^^ lifetime mismatch
    |
-   = note: expected type `<&'min G as Get>`
-              found type `<&'max G as Get>`
+   = note: expected trait `<&'min G as Get>`
+              found trait `<&'max G as Get>`
 note: the lifetime `'min` as defined here...
   --> $DIR/variance-invariant-self-trait-match.rs:11:21
    |
@@ -23,8 +23,8 @@ error[E0308]: mismatched types
 LL |     impls_get::<&'max G>();
    |     ^^^^^^^^^^^^^^^^^^^^ lifetime mismatch
    |
-   = note: expected type `<&'max G as Get>`
-              found type `<&'min G as Get>`
+   = note: expected trait `<&'max G as Get>`
+              found trait `<&'min G as Get>`
 note: the lifetime `'min` as defined here...
   --> $DIR/variance-invariant-self-trait-match.rs:19:21
    |


### PR DESCRIPTION
This (using specialization) refines the `TypeTrace` whenever we are relating two types under binders in `higher_kinded_sub`. This leads to better error messages usually.

This PR should be taken with a grain of salt. Just demonstrating what @jackh726 and I were investigating recently in https://rust-lang.zulipchat.com/#narrow/stream/144729-t-types/topic/NLL.20.20diagnostic.20debugging.20musings

r? @ghost