### PR TITLE
const-stabilize the `unchecked_{add,sub,mul}` *intrinsics*

### DIFF
--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -1760,21 +1760,21 @@ extern "rust-intrinsic" {
     /// undefined behavior when `x + y > T::MAX` or `x + y < T::MIN`.
     ///
     /// This intrinsic does not have a stable counterpart.
-    #[rustc_const_unstable(feature = "const_int_unchecked_arith", issue = "none")]
+    #[rustc_const_stable(feature = "const_int_unchecked_arith", since = "1.63.0")]
     pub fn unchecked_add<T: Copy>(x: T, y: T) -> T;
 
     /// Returns the result of an unchecked subtraction, resulting in
     /// undefined behavior when `x - y > T::MAX` or `x - y < T::MIN`.
     ///
     /// This intrinsic does not have a stable counterpart.
-    #[rustc_const_unstable(feature = "const_int_unchecked_arith", issue = "none")]
+    #[rustc_const_stable(feature = "const_int_unchecked_arith", since = "1.63.0")]
     pub fn unchecked_sub<T: Copy>(x: T, y: T) -> T;
 
     /// Returns the result of an unchecked multiplication, resulting in
     /// undefined behavior when `x * y > T::MAX` or `x * y < T::MIN`.
     ///
     /// This intrinsic does not have a stable counterpart.
-    #[rustc_const_unstable(feature = "const_int_unchecked_arith", issue = "none")]
+    #[rustc_const_stable(feature = "const_int_unchecked_arith", since = "1.63.0")]
     pub fn unchecked_mul<T: Copy>(x: T, y: T) -> T;
 
     /// Performs rotate left.

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -113,7 +113,6 @@
 #![feature(const_heap)]
 #![feature(const_convert)]
 #![feature(const_inherent_unchecked_arith)]
-#![feature(const_int_unchecked_arith)]
 #![feature(const_intrinsic_forget)]
 #![feature(const_likely)]
 #![feature(const_maybe_uninit_uninit_array)]

--- a/src/test/ui/consts/const-int-unchecked.rs
+++ b/src/test/ui/consts/const-int-unchecked.rs
@@ -1,5 +1,4 @@
 #![feature(core_intrinsics)]
-#![feature(const_int_unchecked_arith)]
 
 use std::intrinsics;
 

--- a/src/test/ui/consts/const-int-unchecked.stderr
+++ b/src/test/ui/consts/const-int-unchecked.stderr
@@ -1,293 +1,293 @@
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-int-unchecked.rs:15:29
+  --> $DIR/const-int-unchecked.rs:14:29
    |
 LL | const SHL_U8: u8 = unsafe { intrinsics::unchecked_shl(5_u8, 8) };
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflowing shift by 8 in `unchecked_shl`
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-int-unchecked.rs:17:31
+  --> $DIR/const-int-unchecked.rs:16:31
    |
 LL | const SHL_U16: u16 = unsafe { intrinsics::unchecked_shl(5_u16, 16) };
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflowing shift by 16 in `unchecked_shl`
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-int-unchecked.rs:19:31
+  --> $DIR/const-int-unchecked.rs:18:31
    |
 LL | const SHL_U32: u32 = unsafe { intrinsics::unchecked_shl(5_u32, 32) };
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflowing shift by 32 in `unchecked_shl`
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-int-unchecked.rs:21:31
+  --> $DIR/const-int-unchecked.rs:20:31
    |
 LL | const SHL_U64: u64 = unsafe { intrinsics::unchecked_shl(5_u64, 64) };
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflowing shift by 64 in `unchecked_shl`
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-int-unchecked.rs:23:33
+  --> $DIR/const-int-unchecked.rs:22:33
    |
 LL | const SHL_U128: u128 = unsafe { intrinsics::unchecked_shl(5_u128, 128) };
    |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflowing shift by 128 in `unchecked_shl`
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-int-unchecked.rs:28:29
+  --> $DIR/const-int-unchecked.rs:27:29
    |
 LL | const SHL_I8: i8 = unsafe { intrinsics::unchecked_shl(5_i8, 8) };
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflowing shift by 8 in `unchecked_shl`
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-int-unchecked.rs:30:31
+  --> $DIR/const-int-unchecked.rs:29:31
    |
 LL | const SHL_I16: i16 = unsafe { intrinsics::unchecked_shl(5_16, 16) };
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflowing shift by 16 in `unchecked_shl`
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-int-unchecked.rs:32:31
+  --> $DIR/const-int-unchecked.rs:31:31
    |
 LL | const SHL_I32: i32 = unsafe { intrinsics::unchecked_shl(5_i32, 32) };
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflowing shift by 32 in `unchecked_shl`
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-int-unchecked.rs:34:31
+  --> $DIR/const-int-unchecked.rs:33:31
    |
 LL | const SHL_I64: i64 = unsafe { intrinsics::unchecked_shl(5_i64, 64) };
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflowing shift by 64 in `unchecked_shl`
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-int-unchecked.rs:36:33
+  --> $DIR/const-int-unchecked.rs:35:33
    |
 LL | const SHL_I128: i128 = unsafe { intrinsics::unchecked_shl(5_i128, 128) };
    |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflowing shift by 128 in `unchecked_shl`
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-int-unchecked.rs:41:33
+  --> $DIR/const-int-unchecked.rs:40:33
    |
 LL | const SHL_I8_NEG: i8 = unsafe { intrinsics::unchecked_shl(5_i8, -1) };
    |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflowing shift by 255 in `unchecked_shl`
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-int-unchecked.rs:43:35
+  --> $DIR/const-int-unchecked.rs:42:35
    |
 LL | const SHL_I16_NEG: i16 = unsafe { intrinsics::unchecked_shl(5_16, -1) };
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflowing shift by 65535 in `unchecked_shl`
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-int-unchecked.rs:45:35
+  --> $DIR/const-int-unchecked.rs:44:35
    |
 LL | const SHL_I32_NEG: i32 = unsafe { intrinsics::unchecked_shl(5_i32, -1) };
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflowing shift by 4294967295 in `unchecked_shl`
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-int-unchecked.rs:47:35
+  --> $DIR/const-int-unchecked.rs:46:35
    |
 LL | const SHL_I64_NEG: i64 = unsafe { intrinsics::unchecked_shl(5_i64, -1) };
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflowing shift by 18446744073709551615 in `unchecked_shl`
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-int-unchecked.rs:49:37
+  --> $DIR/const-int-unchecked.rs:48:37
    |
 LL | const SHL_I128_NEG: i128 = unsafe { intrinsics::unchecked_shl(5_i128, -1) };
    |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflowing shift by 340282366920938463463374607431768211455 in `unchecked_shl`
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-int-unchecked.rs:55:40
+  --> $DIR/const-int-unchecked.rs:54:40
    |
 LL | const SHL_I8_NEG_RANDOM: i8 = unsafe { intrinsics::unchecked_shl(5_i8, -6) };
    |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflowing shift by 250 in `unchecked_shl`
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-int-unchecked.rs:57:42
+  --> $DIR/const-int-unchecked.rs:56:42
    |
 LL | const SHL_I16_NEG_RANDOM: i16 = unsafe { intrinsics::unchecked_shl(5_16, -13) };
    |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflowing shift by 65523 in `unchecked_shl`
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-int-unchecked.rs:59:42
+  --> $DIR/const-int-unchecked.rs:58:42
    |
 LL | const SHL_I32_NEG_RANDOM: i32 = unsafe { intrinsics::unchecked_shl(5_i32, -25) };
    |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflowing shift by 4294967271 in `unchecked_shl`
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-int-unchecked.rs:61:42
+  --> $DIR/const-int-unchecked.rs:60:42
    |
 LL | const SHL_I64_NEG_RANDOM: i64 = unsafe { intrinsics::unchecked_shl(5_i64, -30) };
    |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflowing shift by 18446744073709551586 in `unchecked_shl`
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-int-unchecked.rs:63:44
+  --> $DIR/const-int-unchecked.rs:62:44
    |
 LL | const SHL_I128_NEG_RANDOM: i128 = unsafe { intrinsics::unchecked_shl(5_i128, -93) };
    |                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflowing shift by 340282366920938463463374607431768211363 in `unchecked_shl`
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-int-unchecked.rs:70:29
+  --> $DIR/const-int-unchecked.rs:69:29
    |
 LL | const SHR_U8: u8 = unsafe { intrinsics::unchecked_shr(5_u8, 8) };
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflowing shift by 8 in `unchecked_shr`
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-int-unchecked.rs:72:31
+  --> $DIR/const-int-unchecked.rs:71:31
    |
 LL | const SHR_U16: u16 = unsafe { intrinsics::unchecked_shr(5_u16, 16) };
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflowing shift by 16 in `unchecked_shr`
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-int-unchecked.rs:74:31
+  --> $DIR/const-int-unchecked.rs:73:31
    |
 LL | const SHR_U32: u32 = unsafe { intrinsics::unchecked_shr(5_u32, 32) };
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflowing shift by 32 in `unchecked_shr`
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-int-unchecked.rs:76:31
+  --> $DIR/const-int-unchecked.rs:75:31
    |
 LL | const SHR_U64: u64 = unsafe { intrinsics::unchecked_shr(5_u64, 64) };
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflowing shift by 64 in `unchecked_shr`
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-int-unchecked.rs:78:33
+  --> $DIR/const-int-unchecked.rs:77:33
    |
 LL | const SHR_U128: u128 = unsafe { intrinsics::unchecked_shr(5_u128, 128) };
    |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflowing shift by 128 in `unchecked_shr`
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-int-unchecked.rs:83:29
+  --> $DIR/const-int-unchecked.rs:82:29
    |
 LL | const SHR_I8: i8 = unsafe { intrinsics::unchecked_shr(5_i8, 8) };
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflowing shift by 8 in `unchecked_shr`
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-int-unchecked.rs:85:31
+  --> $DIR/const-int-unchecked.rs:84:31
    |
 LL | const SHR_I16: i16 = unsafe { intrinsics::unchecked_shr(5_16, 16) };
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflowing shift by 16 in `unchecked_shr`
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-int-unchecked.rs:87:31
+  --> $DIR/const-int-unchecked.rs:86:31
    |
 LL | const SHR_I32: i32 = unsafe { intrinsics::unchecked_shr(5_i32, 32) };
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflowing shift by 32 in `unchecked_shr`
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-int-unchecked.rs:89:31
+  --> $DIR/const-int-unchecked.rs:88:31
    |
 LL | const SHR_I64: i64 = unsafe { intrinsics::unchecked_shr(5_i64, 64) };
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflowing shift by 64 in `unchecked_shr`
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-int-unchecked.rs:91:33
+  --> $DIR/const-int-unchecked.rs:90:33
    |
 LL | const SHR_I128: i128 = unsafe { intrinsics::unchecked_shr(5_i128, 128) };
    |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflowing shift by 128 in `unchecked_shr`
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-int-unchecked.rs:96:33
+  --> $DIR/const-int-unchecked.rs:95:33
    |
 LL | const SHR_I8_NEG: i8 = unsafe { intrinsics::unchecked_shr(5_i8, -1) };
    |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflowing shift by 255 in `unchecked_shr`
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-int-unchecked.rs:98:35
+  --> $DIR/const-int-unchecked.rs:97:35
    |
 LL | const SHR_I16_NEG: i16 = unsafe { intrinsics::unchecked_shr(5_16, -1) };
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflowing shift by 65535 in `unchecked_shr`
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-int-unchecked.rs:100:35
+  --> $DIR/const-int-unchecked.rs:99:35
    |
 LL | const SHR_I32_NEG: i32 = unsafe { intrinsics::unchecked_shr(5_i32, -1) };
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflowing shift by 4294967295 in `unchecked_shr`
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-int-unchecked.rs:102:35
+  --> $DIR/const-int-unchecked.rs:101:35
    |
 LL | const SHR_I64_NEG: i64 = unsafe { intrinsics::unchecked_shr(5_i64, -1) };
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflowing shift by 18446744073709551615 in `unchecked_shr`
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-int-unchecked.rs:104:37
+  --> $DIR/const-int-unchecked.rs:103:37
    |
 LL | const SHR_I128_NEG: i128 = unsafe { intrinsics::unchecked_shr(5_i128, -1) };
    |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflowing shift by 340282366920938463463374607431768211455 in `unchecked_shr`
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-int-unchecked.rs:110:40
+  --> $DIR/const-int-unchecked.rs:109:40
    |
 LL | const SHR_I8_NEG_RANDOM: i8 = unsafe { intrinsics::unchecked_shr(5_i8, -6) };
    |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflowing shift by 250 in `unchecked_shr`
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-int-unchecked.rs:112:42
+  --> $DIR/const-int-unchecked.rs:111:42
    |
 LL | const SHR_I16_NEG_RANDOM: i16 = unsafe { intrinsics::unchecked_shr(5_16, -13) };
    |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflowing shift by 65523 in `unchecked_shr`
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-int-unchecked.rs:114:42
+  --> $DIR/const-int-unchecked.rs:113:42
    |
 LL | const SHR_I32_NEG_RANDOM: i32 = unsafe { intrinsics::unchecked_shr(5_i32, -25) };
    |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflowing shift by 4294967271 in `unchecked_shr`
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-int-unchecked.rs:116:42
+  --> $DIR/const-int-unchecked.rs:115:42
    |
 LL | const SHR_I64_NEG_RANDOM: i64 = unsafe { intrinsics::unchecked_shr(5_i64, -30) };
    |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflowing shift by 18446744073709551586 in `unchecked_shr`
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-int-unchecked.rs:118:44
+  --> $DIR/const-int-unchecked.rs:117:44
    |
 LL | const SHR_I128_NEG_RANDOM: i128 = unsafe { intrinsics::unchecked_shr(5_i128, -93) };
    |                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflowing shift by 340282366920938463463374607431768211363 in `unchecked_shr`
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-int-unchecked.rs:123:25
+  --> $DIR/const-int-unchecked.rs:122:25
    |
 LL | const _: u16 = unsafe { std::intrinsics::unchecked_add(40000u16, 30000) };
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflow executing `unchecked_add`
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-int-unchecked.rs:126:25
+  --> $DIR/const-int-unchecked.rs:125:25
    |
 LL | const _: u32 = unsafe { std::intrinsics::unchecked_sub(14u32, 22) };
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflow executing `unchecked_sub`
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-int-unchecked.rs:129:25
+  --> $DIR/const-int-unchecked.rs:128:25
    |
 LL | const _: u16 = unsafe { std::intrinsics::unchecked_mul(300u16, 250u16) };
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflow executing `unchecked_mul`
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-int-unchecked.rs:132:25
+  --> $DIR/const-int-unchecked.rs:131:25
    |
 LL | const _: i32 = unsafe { std::intrinsics::unchecked_div(1, 0) };
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ dividing by zero
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-int-unchecked.rs:134:25
+  --> $DIR/const-int-unchecked.rs:133:25
    |
 LL | const _: i32 = unsafe { std::intrinsics::unchecked_div(i32::MIN, -1) };
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflow in signed division (dividing MIN by -1)
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-int-unchecked.rs:137:25
+  --> $DIR/const-int-unchecked.rs:136:25
    |
 LL | const _: i32 = unsafe { std::intrinsics::unchecked_rem(1, 0) };
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ calculating the remainder with a divisor of zero
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-int-unchecked.rs:139:25
+  --> $DIR/const-int-unchecked.rs:138:25
    |
 LL | const _: i32 = unsafe { std::intrinsics::unchecked_rem(i32::MIN, -1) };
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflow in signed remainder (dividing MIN by -1)
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-int-unchecked.rs:144:25
+  --> $DIR/const-int-unchecked.rs:143:25
    |
 LL | const _: u32 = unsafe { std::intrinsics::ctlz_nonzero(0) };
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `ctlz_nonzero` called on 0
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-int-unchecked.rs:146:25
+  --> $DIR/const-int-unchecked.rs:145:25
    |
 LL | const _: u32 = unsafe { std::intrinsics::cttz_nonzero(0) };
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `cttz_nonzero` called on 0


### PR DESCRIPTION
This is only the intrinsics, which aren't exposed anywhere, so I think we can just do this without an FCP.

The behaviour of these is well understood, have been implemented for ages, and don't offer any new functionality to `const fn`s -- it would be completely legal for them to be implemented via `wrapping_add`, since we don't promise to catch all UB.

(Sending this because I was working on something else where I wanted to use `unchecked_sub` for a length in a `const fn`, and it complained at me.)