### PR TITLE
Allow overriding linker scripts in built-in targets

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -1597,6 +1597,16 @@ fn add_pre_link_args(cmd: &mut dyn Linker, sess: &Session, flavor: LinkerFlavor)
 
 /// Add a link script embedded in the target, if applicable.
 fn add_link_script(cmd: &mut dyn Linker, sess: &Session, tmpdir: &Path, crate_type: CrateType) {
+    fn is_script_arg(arg: &str) -> bool {
+        arg.starts_with("--script")
+            || arg.starts_with("-T")
+            || arg.starts_with("--default-script")
+            || arg.starts_with("-dT")
+    }
+    // Omit the embedded linker script if a user supplied one
+    if sess.opts.cg.link_args.iter().any(|arg| is_script_arg(arg)) {
+        return;
+    }
     match (crate_type, &sess.target.link_script) {
         (CrateType::Cdylib | CrateType::Executable, Some(script)) => {
             if !sess.target.linker_is_gnu {


### PR DESCRIPTION
PR #72062 added the ability to include linker scripts with built-in targets. However, this only works for targets that never need to customize the ld script since it cannot be overridden. This commit checks user-supplied link args for ld scripts and omits the built-in script if another is found. Technically scripts may also be passed to ld without a flag (i.e. as if it were a .o), but detecting those requires opening and parsing the files specified in link args so I didn't check for those. I also considered changing `--script` with `--defaultscript` (which can be overridden), but lld doesn't support this. I'm not sure who should review this, but the PSP target (cc @overdrivenpotato) is the only one currently using built-in scripts and this shouldn't affect those users' workflow. 

For context, there's been interest in [adding a playstation 1 target](https://github.com/simias/psx-sdk-rs/issues/1) which would benefit from this change. Currently the required ld script is provided by the [psx crate's](https://crates.io/crates/psx) `build.rs`, but it would be nice to have a built-in target which just works without requiring any specific crate. The psx also needs customized ld scripts in some cases so the current built-in scripts are too inflexible.