### PR TITLE
Allow ptr_from_addr_cast to fail

### DIFF
--- a/compiler/rustc_const_eval/src/interpret/cast.rs
+++ b/compiler/rustc_const_eval/src/interpret/cast.rs
@@ -221,7 +221,7 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
         let addr = addr.to_machine_usize(self)?;
 
         // Then turn address into pointer.
-        let ptr = M::ptr_from_addr_cast(&self, addr);
+        let ptr = M::ptr_from_addr_cast(&self, addr)?;
         Ok(Scalar::from_maybe_pointer(ptr, self).into())
     }
 


### PR DESCRIPTION
This is needed for https://github.com/rust-lang/miri/issues/2133: I would like to have an option in Miri to error when a int2ptr cast is executed.