### PR TITLE
Restore a test that was intended to test `as` cast to ptr

### DIFF
--- a/src/test/ui/cast/casts-issue-46365.rs
+++ b/src/test/ui/cast/casts-issue-46365.rs
@@ -3,5 +3,6 @@ struct Lorem {
 }
 
 fn main() {
-    let _foo: *mut Lorem = core::ptr::NonNull::dangling().as_ptr(); // no error here
+    // Testing `as` casts, so deliberately not using `ptr::null`.
+    let _foo: *mut Lorem = 0 as *mut _; // no error here
 }


### PR DESCRIPTION
This test was changed in https://github.com/rust-lang/rust/pull/61864, but the original bug https://github.com/rust-lang/rust/issues/46365 was about casts so I doubt the changed test still even tests what this was intended to test. Let's restore the original test.