### PR TITLE
option: implement ToOwned for convenience

### DIFF
--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -1901,6 +1901,31 @@ where
     }
 }
 
+#[stable(since = "1.61.0")]
+impl<T: ToOwned> ToOwned for Option<T> {
+    type Owned = Self<T::Owned>;
+    
+    #[inline]
+    fn to_owned(&self) -> Self::Owned {
+        match self {
+            Some(x) => Some(x.to_owned()),
+            None => None,
+        }
+    }
+    
+    #[inline]
+    //#[unstable(feature = "toowned_clone_into", issue = "41263")]
+    // FIXME: I've no idea if that's how it's supposed to be implemented. Never used clone_into() myself.
+    fn clone_into(&self, target: &mut Self::Owned) {
+        match (self, source) {
+            (Some(source), Some(target)) => source.clone_into(target),
+            (source, target) => *target = source.to_owned(),
+        }
+    }
+}
+
+
+
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_const_unstable(feature = "const_default_impls", issue = "87864")]
 impl<T> const Default for Option<T> {

--- a/library/core/tests/option.rs
+++ b/library/core/tests/option.rs
@@ -553,3 +553,17 @@ fn zip_unzip_roundtrip() {
     let a = z.unzip();
     assert_eq!(a, (x, y));
 }
+
+#[test]
+fn test_to_owned() {
+    assert_eq!(Some("foo").to_owned(), Some(String::from("foo"));
+    assert_eq!(None::<&str>.to_owned(), None::<String>);
+    
+    let mut y = None;
+    Some("foo").clone_into(&mut y);
+    assert_eq!(y, Some(String::from("foo")));
+    Some("bar").clone_into(&mut y);
+    assert_eq!(y, Some(String::from("bar")));
+    None::<&str>.clone_into(&mut y);
+    assert_eq!(y, None);
+}


### PR DESCRIPTION
Similar to the Clone implementation for Option, this ToOwned implementation
is very convenient as it allows going from a borrowed Option<&str> directly
to an owned Option<String>. It is especially useful in a zero-copy parser
context, where everything's borrowed from the input data so it's not
possible to simply clone() to get our own owned data, as Clone is only
available when the input and output types are the same (which isn't the
case for &str, which instead implements ToOwned).

-----------------------

Note I didn't have the opportunity to test these changes as I'm pretty sure compiling it would take hours on my computer. I did not open an issue (and could not find one) because this change seems pretty uncontroversial to me, and at least things can be discussed here if needed. There's two commented lines left in my code here, as I'm not sure if the `unstable` attribute is required when implementing traits, and to make sure that my `clone_into()` code is correct (as I've never used that code).

FYI I thought it was weird this feature did not exist when implementing an XML format parser, where I parse "meaningless" XML nodes into proper structs fields, so I currently have code like so:
```rust
struct Metadata {
    title: Option<String>,
}

// snip […]
let meta = Metadata::default();
// snip, iterate on all childs nodes
if let Some(text) = node.text() {
    match node.tag_name().name() {
        "title" => meta.title = Some(text.to_owned()),
    }
}
```
where I could instead have:
```rust
match node.tag_name().name() {
    "title" => meta.title = text.to_owned(),
}
```

It might not sound like much but when there's lots of different struct fields it starts to be really heavy on the eyes that `opt.to_owned()` can't be used here. It does work fine for an Option where T implements Clone (which isn't the case for `&str`), it's just that there's no similar counterpart for ToOwned.

(using [roxmltree](https://docs.rs/roxmltree/latest/roxmltree/struct.Node.html#method.text) which does not copy the input data, as it takes the whole XML as a &str and not a stream).