### PR TITLE
Remove SIGIO reference on Haiku

### DIFF
--- a/library/std/src/sys/unix/process/process_unix.rs
+++ b/library/std/src/sys/unix/process/process_unix.rs
@@ -730,6 +730,7 @@ fn signal_string(signal: i32) -> &'static str {
         libc::SIGVTALRM => " (SIGVTALRM)",
         libc::SIGPROF => " (SIGPROF)",
         libc::SIGWINCH => " (SIGWINCH)",
+        #[cfg(not(target_os = "haiku"))]
         libc::SIGIO => " (SIGIO)",
         libc::SIGSYS => " (SIGSYS)",
         // For information on Linux signals, run `man 7 signal`


### PR DESCRIPTION
Haiku doesn't define SIGIO. The nix crate already employs this workaround:
https://github.com/nix-rust/nix/blob/5dedbc7850448ae3922ab0a833f3eb971bf7e25f/src/sys/signal.rs#L92-L94