### PR TITLE
Update minifier version to 0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2391,9 +2391,9 @@ dependencies = [
 
 [[package]]
 name = "minifier"
-version = "0.1.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7071d17e2898e134cabf624f43cdefa0cedf57c739e964df3d0df9d028701a72"
+checksum = "ac96d1e7a65f206443f95afff6de8f1690c77c97d6fc9c9bb2d2cd0662e9ff9f"
 
 [[package]]
 name = "minimal-lexical"

--- a/src/librustdoc/Cargo.toml
+++ b/src/librustdoc/Cargo.toml
@@ -11,7 +11,7 @@ arrayvec = { version = "0.7", default-features = false }
 askama = { version = "0.11", default-features = false, features = ["config"] }
 atty = "0.2"
 pulldown-cmark = { version = "0.9", default-features = false }
-minifier = "0.1.0"
+minifier = "0.2.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 smallvec = "1.6.1"

--- a/src/librustdoc/html/render/write_shared.rs
+++ b/src/librustdoc/html/render/write_shared.rs
@@ -122,11 +122,13 @@ impl Context<'_> {
         if minify {
             let contents = contents.as_ref();
             let contents = if resource.extension() == Some(OsStr::new("css")) {
-                minifier::css::minify(contents).map_err(|e| {
-                    Error::new(format!("failed to minify CSS file: {}", e), resource.path(self))
-                })?
+                minifier::css::minify(contents)
+                    .map_err(|e| {
+                        Error::new(format!("failed to minify CSS file: {}", e), resource.path(self))
+                    })?
+                    .to_string()
             } else {
-                minifier::js::minify(contents)
+                minifier::js::minify(contents).to_string()
             };
             self.write_shared(resource, contents, emit)
         } else {

--- a/src/librustdoc/theme.rs
+++ b/src/librustdoc/theme.rs
@@ -185,6 +185,7 @@ fn build_rule(v: &[u8], positions: &[usize]) -> String {
             .intersperse(" ")
             .collect::<String>(),
     )
+    .map(|css| css.to_string())
     .unwrap_or_else(|_| String::new())
 }
 

--- a/src/librustdoc/theme/tests.rs
+++ b/src/librustdoc/theme/tests.rs
@@ -106,7 +106,7 @@ fn check_invalid_css() {
 #[test]
 fn test_with_minification() {
     let text = include_str!("../html/static/css/themes/dark.css");
-    let minified = minifier::css::minify(&text).expect("CSS minification failed");
+    let minified = minifier::css::minify(&text).expect("CSS minification failed").to_string();
 
     let against = load_css_paths(text.as_bytes());
     let other = load_css_paths(minified.as_bytes());


### PR DESCRIPTION
This change and these changes come from an idea of @camelid: instead of creating a string, we just `write` the type into the file directly.

I don't think it'll have a big impact on perf but it's still a potential small improvement.

r? @notriddle 