### PR TITLE
[WIP] Also lint Box::new in unused_allocation

### DIFF
--- a/compiler/rustc_hir/src/lang_items.rs
+++ b/compiler/rustc_hir/src/lang_items.rs
@@ -276,6 +276,7 @@ language_item_table! {
     EhCatchTypeinfo,         sym::eh_catch_typeinfo,   eh_catch_typeinfo,          Target::Static,         GenericRequirement::None;
 
     OwnedBox,                sym::owned_box,           owned_box,                  Target::Struct,         GenericRequirement::Minimum(1);
+    OwnedBoxNew,             sym::owned_box_new,       owned_box_new,              Target::Method(MethodKind::Inherent), GenericRequirement::None;
 
     PhantomData,             sym::phantom_data,        phantom_data,               Target::Struct,         GenericRequirement::Exact(1);
 

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1037,6 +1037,7 @@ symbols! {
         out,
         overlapping_marker_traits,
         owned_box,
+        owned_box_new,
         packed,
         panic,
         panic_2015,

--- a/library/alloc/src/boxed.rs
+++ b/library/alloc/src/boxed.rs
@@ -207,6 +207,7 @@ impl<T> Box<T> {
     /// let five = Box::new(5);
     /// ```
     #[cfg(all(not(no_global_oom_handling)))]
+    #[lang = "owned_box_new"]
     #[inline(always)]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[must_use]

--- a/library/alloc/src/tests.rs
+++ b/library/alloc/src/tests.rs
@@ -25,13 +25,13 @@ fn any_move() {
 
     match a.downcast::<i32>() {
         Ok(a) => {
-            assert!(a == Box::new(8));
+            assert!(*a == 8);
         }
         Err(..) => panic!(),
     }
     match b.downcast::<Test>() {
         Ok(a) => {
-            assert!(a == Box::new(Test));
+            assert!(*a == Test);
         }
         Err(..) => panic!(),
     }

--- a/src/test/ui/iterators/into-iter-on-arrays-lint.fixed
+++ b/src/test/ui/iterators/into-iter-on-arrays-lint.fixed
@@ -2,7 +2,7 @@
 // run-rustfix
 // rustfix-only-machine-applicable
 
-#[allow(unused_must_use)]
+#[allow(unused_must_use, unused_allocation)]
 fn main() {
     let small = [1, 2];
     let big = [0u8; 33];

--- a/src/test/ui/iterators/into-iter-on-arrays-lint.rs
+++ b/src/test/ui/iterators/into-iter-on-arrays-lint.rs
@@ -2,7 +2,7 @@
 // run-rustfix
 // rustfix-only-machine-applicable
 
-#[allow(unused_must_use)]
+#[allow(unused_must_use, unused_allocation)]
 fn main() {
     let small = [1, 2];
     let big = [0u8; 33];

--- a/src/test/ui/lint/unused/unused-allocation.rs
+++ b/src/test/ui/lint/unused/unused-allocation.rs
@@ -1,0 +1,10 @@
+#![feature(box_syntax)]
+#![deny(unused_allocation)]
+
+fn main() {
+    let foo = (box [1, 2, 3]).len(); //~ ERROR: unnecessary allocation
+    let one = (box vec![1]).pop(); //~ ERROR: unnecessary allocation
+
+    let foo = Box::new([1, 2, 3]).len(); //~ ERROR: unnecessary allocation
+    let one = Box::new(vec![1]).pop(); //~ ERROR: unnecessary allocation
+}

--- a/src/test/ui/lint/unused/unused-allocation.stderr
+++ b/src/test/ui/lint/unused/unused-allocation.stderr
@@ -1,0 +1,32 @@
+error: unnecessary allocation, use `&` instead
+  --> $DIR/unused-allocation.rs:5:15
+   |
+LL |     let foo = (box [1, 2, 3]).len();
+   |               ^^^^^^^^^^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/unused-allocation.rs:2:9
+   |
+LL | #![deny(unused_allocation)]
+   |         ^^^^^^^^^^^^^^^^^
+
+error: unnecessary allocation, use `&mut` instead
+  --> $DIR/unused-allocation.rs:6:15
+   |
+LL |     let one = (box vec![1]).pop();
+   |               ^^^^^^^^^^^^^
+
+error: unnecessary allocation, use `&` instead
+  --> $DIR/unused-allocation.rs:8:15
+   |
+LL |     let foo = Box::new([1, 2, 3]).len();
+   |               ^^^^^^^^
+
+error: unnecessary allocation, use `&mut` instead
+  --> $DIR/unused-allocation.rs:9:15
+   |
+LL |     let one = Box::new(vec![1]).pop();
+   |               ^^^^^^^^
+
+error: aborting due to 4 previous errors
+

--- a/src/test/ui/self/arbitrary_self_types_trait.rs
+++ b/src/test/ui/self/arbitrary_self_types_trait.rs
@@ -1,4 +1,5 @@
 // run-pass
+#![allow(unused_allocation)]
 
 use std::rc::Rc;
 

--- a/src/test/ui/structs-enums/align-struct.rs
+++ b/src/test/ui/structs-enums/align-struct.rs
@@ -1,5 +1,6 @@
 // run-pass
 #![allow(dead_code)]
+#![allow(unused_allocation)]
 
 use std::mem;
 


### PR DESCRIPTION
Previously, only `box` syntax uses would yield in the `unused_allocation` lint issuing warnings. Now, equivalent unnecessary usage of `Box::new` also gives a warning. Furthermore, this PR adds a test of the `unused_allocation` lint which was previously never tested anywhere in the test suite.

With the changes from this pr, this snippet

```rust
fn main() {
    let foo = Box::new([1, 2, 3]).len(); //~ ERROR: unnecessary allocation
}
```

gives

```
error: unnecessary allocation, use `&` instead
  --> $DIR/unused-allocation.rs:
   |
LL |     let foo = Box::new([1, 2, 3]).len();
   |               ^^^^^^^^
```

Just like how it lints for the equivalent snippet just with `box` instead of `Box::new`.