### PR TITLE
Check ADT field is well-formed before checking it is sized

### DIFF
--- a/compiler/rustc_middle/src/traits/mod.rs
+++ b/compiler/rustc_middle/src/traits/mod.rs
@@ -403,7 +403,7 @@ pub enum ObligationCauseCode<'tcx> {
     QuestionMark,
 
     /// Well-formed checking. If a `WellFormedLoc` is provided,
-    /// then it will be used to eprform HIR-based wf checking
+    /// then it will be used to perform HIR-based wf checking
     /// after an error occurs, in order to generate a more precise error span.
     /// This is purely for diagnostic purposes - it is always
     /// correct to use `MiscObligation` instead, or to specify

--- a/src/test/ui/generic-associated-types/bugs/issue-80626.stderr
+++ b/src/test/ui/generic-associated-types/bugs/issue-80626.stderr
@@ -4,16 +4,11 @@ error[E0275]: overflow evaluating the requirement `LinkedList<A>: Sized`
 LL |     Next(A::Allocated<Self>)
    |          ^^^^^^^^^^^^^^^^^^
    |
-   = note: no field of an enum variant may have a dynamically sized type
-   = help: change the field's type to have a statically known size
-help: borrowed types always have a statically known size
+note: required by a bound in `Allocator::Allocated`
+  --> $DIR/issue-80626.rs:9:20
    |
-LL |     Next(&A::Allocated<Self>)
-   |          +
-help: the `Box` type always has a statically known size and allocates its contents in the heap
-   |
-LL |     Next(Box<A::Allocated<Self>>)
-   |          ++++                  +
+LL |     type Allocated<T>;
+   |                    ^ required by this bound in `Allocator::Allocated`
 
 error: aborting due to previous error
 

--- a/src/test/ui/union/issue-81199.stderr
+++ b/src/test/ui/union/issue-81199.stderr
@@ -1,28 +1,18 @@
-error[E0277]: the trait bound `T: Pointee` is not satisfied in `PtrComponents<T>`
+error[E0277]: the trait bound `T: Pointee` is not satisfied
   --> $DIR/issue-81199.rs:5:17
    |
 LL |     components: PtrComponents<T>,
-   |                 ^^^^^^^^^^^^^^^^ within `PtrComponents<T>`, the trait `Pointee` is not implemented for `T`
+   |                 ^^^^^^^^^^^^^^^^ the trait `Pointee` is not implemented for `T`
    |
-note: required because it appears within the type `PtrComponents<T>`
-  --> $DIR/issue-81199.rs:10:8
+note: required by a bound in `PtrComponents`
+  --> $DIR/issue-81199.rs:10:25
    |
 LL | struct PtrComponents<T: Pointee + ?Sized> {
-   |        ^^^^^^^^^^^^^
-   = note: no field of a union may have a dynamically sized type
-   = help: change the field's type to have a statically known size
+   |                         ^^^^^^^ required by this bound in `PtrComponents`
 help: consider further restricting this bound
    |
 LL | union PtrRepr<T: ?Sized + Pointee> {
    |                         +++++++++
-help: borrowed types always have a statically known size
-   |
-LL |     components: &PtrComponents<T>,
-   |                 +
-help: the `Box` type always has a statically known size and allocates its contents in the heap
-   |
-LL |     components: Box<PtrComponents<T>>,
-   |                 ++++                +
 
 error: aborting due to previous error
 

--- a/src/test/ui/wf/issue-96810.rs
+++ b/src/test/ui/wf/issue-96810.rs
@@ -1,0 +1,12 @@
+struct S<T: Tr>(T::Assoc);
+
+trait Tr {
+    type Assoc;
+}
+
+struct Hoge<K> {
+    s: S<K>, //~ ERROR the trait bound `K: Tr` is not satisfied
+    a: u32,
+}
+
+fn main() {}

--- a/src/test/ui/wf/issue-96810.stderr
+++ b/src/test/ui/wf/issue-96810.stderr
@@ -1,0 +1,19 @@
+error[E0277]: the trait bound `K: Tr` is not satisfied
+  --> $DIR/issue-96810.rs:8:8
+   |
+LL |     s: S<K>,
+   |        ^^^^ the trait `Tr` is not implemented for `K`
+   |
+note: required by a bound in `S`
+  --> $DIR/issue-96810.rs:1:13
+   |
+LL | struct S<T: Tr>(T::Assoc);
+   |             ^^ required by this bound in `S`
+help: consider restricting type parameter `K`
+   |
+LL | struct Hoge<K: Tr> {
+   |              ++++
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
Fixes #96810.

There is one diagnostics regression, in [`src/test/ui/generic-associated-types/bugs/issue-80626.stderr`](https://github.com/rust-lang/rust/pull/97780/files#diff-53795946378e78a0af23a10277c628ff79091c18090fdc385801ee70c1ba6963). I am not super concerned about it, since it's GAT related.
We _could_ fix it, possibly by using the `FieldSized` obligation cause code instead of `BuiltinDerivedObligation`. But that would require changing `Sized` trait confirmation and the `adt_sized_constraint` query.