### PR TITLE
Fix #71363's test by adding `-Z translate-remapped-path-to-local-path=no`

### DIFF
--- a/compiler/rustc_interface/src/tests.rs
+++ b/compiler/rustc_interface/src/tests.rs
@@ -790,6 +790,7 @@ fn test_debugging_options_tracking_hash() {
     tracked!(thinlto, Some(true));
     tracked!(thir_unsafeck, true);
     tracked!(tls_model, Some(TlsModel::GeneralDynamic));
+    tracked!(translate_remapped_path_to_local_path, false);
     tracked!(trap_unreachable, Some(false));
     tracked!(treat_err_as_bug, NonZeroUsize::new(1));
     tracked!(tune_cpu, Some(String::from("abc")));

--- a/compiler/rustc_metadata/src/rmeta/decoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder.rs
@@ -1486,6 +1486,8 @@ impl<'a, 'tcx> CrateMetadataRef<'a> {
             .filter(|_| {
                 // Only spend time on further checks if we have what to translate *to*.
                 sess.opts.real_rust_source_base_dir.is_some()
+                    // Some tests need the translation to be always skipped.
+                    && sess.opts.debugging_opts.translate_remapped_path_to_local_path
             })
             .filter(|virtual_dir| {
                 // Don't translate away `/rustc/$hash` if we're still remapping to it,

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -1546,6 +1546,8 @@ options! {
         "choose the TLS model to use (`rustc --print tls-models` for details)"),
     trace_macros: bool = (false, parse_bool, [UNTRACKED],
         "for every macro invocation, print its name and arguments (default: no)"),
+    translate_remapped_path_to_local_path: bool = (true, parse_bool, [TRACKED],
+        "translate remapped paths into local paths when possible (default: yes)"),
     trap_unreachable: Option<bool> = (None, parse_opt_bool, [TRACKED],
         "generate trap instructions for unreachable intrinsics (default: use target setting, usually yes)"),
     treat_err_as_bug: Option<NonZeroUsize> = (None, parse_treat_err_as_bug, [TRACKED],

--- a/src/test/ui/span/issue-71363.rs
+++ b/src/test/ui/span/issue-71363.rs
@@ -1,6 +1,4 @@
-// compile-flags: -Z simulate-remapped-rust-src-base=/rustc/xyz -Z ui-testing=no
-// only-x86_64-unknown-linux-gnu
-//---^ Limiting target as the above unstable flags don't play well on some environment.
+// compile-flags: -Z simulate-remapped-rust-src-base=/rustc/xyz -Z translate-remapped-path-to-local-path=no -Z ui-testing=no
 
 struct MyError;
 impl std::error::Error for MyError {}
@@ -8,3 +6,14 @@ impl std::error::Error for MyError {}
 //~| ERROR: `MyError` doesn't implement `Debug`
 
 fn main() {}
+
+// This test relies on library/std/src/error.rs *not* being included in the error message, so that
+// we can test whether a file not included in the error message affects it (more specifically
+// whether the line number of the excluded file affects the indentation of the other line numbers).
+//
+// To test this we're simulating a remap of the rust src base (so that library/std/src/error.rs
+// does not point to a local file) *and* we're disabling the code to try mapping a remapped path to
+// a local file (which would defeat the purpose of the former flag).
+//
+// Note that this comment is at the bottom of the file intentionally, as we need the line number of
+// the impl to be lower than 10.

--- a/src/test/ui/span/issue-71363.stderr
+++ b/src/test/ui/span/issue-71363.stderr
@@ -1,7 +1,7 @@
 error[E0277]: `MyError` doesn't implement `std::fmt::Display`
- --> $DIR/issue-71363.rs:6:6
+ --> $DIR/issue-71363.rs:4:6
   |
-6 | impl std::error::Error for MyError {}
+4 | impl std::error::Error for MyError {}
   |      ^^^^^^^^^^^^^^^^^ `MyError` cannot be formatted with the default formatter
   |
   = help: the trait `std::fmt::Display` is not implemented for `MyError`
@@ -9,9 +9,9 @@ error[E0277]: `MyError` doesn't implement `std::fmt::Display`
 note: required by a bound in `std::error::Error`
 
 error[E0277]: `MyError` doesn't implement `Debug`
- --> $DIR/issue-71363.rs:6:6
+ --> $DIR/issue-71363.rs:4:6
   |
-6 | impl std::error::Error for MyError {}
+4 | impl std::error::Error for MyError {}
   |      ^^^^^^^^^^^^^^^^^ `MyError` cannot be formatted using `{:?}`
   |
   = help: the trait `Debug` is not implemented for `MyError`
@@ -19,7 +19,7 @@ error[E0277]: `MyError` doesn't implement `Debug`
 note: required by a bound in `std::error::Error`
 help: consider annotating `MyError` with `#[derive(Debug)]`
   |
-5 | #[derive(Debug)]
+3 | #[derive(Debug)]
   |
 
 error: aborting due to 2 previous errors


### PR DESCRIPTION
The test relies on `library/std/src/error.rs` not corresponding to a local path, but remapping might still find the related local file of a remapped path. To fix the test, this PR adds a new `-Z` flag to disable finding the corresponding local path of a remapped path.