### PR TITLE
Hide irrelevant lines in suggestions to allow for suggestions that are far from each other to be shown

### DIFF
--- a/compiler/rustc_errors/src/emitter.rs
+++ b/compiler/rustc_errors/src/emitter.rs
@@ -656,6 +656,11 @@ impl Emitter for SilentEmitter {
     }
 }
 
+/// Maximum number of lines we will print for a multiline suggestion; arbitrary.
+///
+/// This should be replaced with a more involved mechanism to output multiline suggestions that
+/// more closely mimics the regular diagnostic output, where irrelevant code lines are elided.
+pub const MAX_SUGGESTION_HIGHLIGHT_LINES: usize = 6;
 /// Maximum number of suggestions to be shown
 ///
 /// Arbitrary, but taken from trait import suggestion limit

--- a/compiler/rustc_errors/src/lib.rs
+++ b/compiler/rustc_errors/src/lib.rs
@@ -1145,7 +1145,7 @@ impl HandlerInner {
             !this.emitted_diagnostics.insert(diagnostic_hash)
         };
 
-        // Only emit the diagnostic if we've been asked to deduplicate and
+        // Only emit the diagnostic if we've been asked to deduplicate or
         // haven't already emitted an equivalent diagnostic.
         if !(self.flags.deduplicate_diagnostics && already_emitted(self)) {
             debug!(?diagnostic);

--- a/src/test/ui/associated-consts/issue-93835.stderr
+++ b/src/test/ui/associated-consts/issue-93835.stderr
@@ -19,11 +19,10 @@ help: you might have meant to write a `struct` literal
    |
 LL ~ fn e() { SomeStruct {
 LL |     p:a<p:p<e=6>>
-LL |
-LL |
-LL |
-LL |
  ...
+LL |
+LL ~ }}
+   |
 help: maybe you meant to write a path separator here
    |
 LL |     p::a<p:p<e=6>>

--- a/src/test/ui/closures/2229_closure_analysis/migrations/auto_traits.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/auto_traits.stderr
@@ -17,11 +17,10 @@ help: add a dummy let to cause `fptr` to be fully captured
    |
 LL ~     thread::spawn(move || { let _ = &fptr; unsafe {
 LL |
-LL |
-LL |
-LL |
-LL |         *fptr.0 = 20;
  ...
+LL |
+LL ~     } });
+   |
 
 error: changes to closure capture in Rust 2021 will affect which traits the closure implements
   --> $DIR/auto_traits.rs:42:19
@@ -40,11 +39,10 @@ help: add a dummy let to cause `fptr` to be fully captured
    |
 LL ~     thread::spawn(move || { let _ = &fptr; unsafe {
 LL |
-LL |
-LL |
-LL |
-LL |
  ...
+LL |
+LL ~     } });
+   |
 
 error: changes to closure capture in Rust 2021 will affect drop order and which traits the closure implements
   --> $DIR/auto_traits.rs:67:13

--- a/src/test/ui/closures/2229_closure_analysis/migrations/multi_diagnostics.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/multi_diagnostics.stderr
@@ -109,11 +109,10 @@ help: add a dummy let to cause `fptr1`, `fptr2` to be fully captured
    |
 LL ~     thread::spawn(move || { let _ = (&fptr1, &fptr2); unsafe {
 LL |
-LL |
-LL |
-LL |
-LL |
  ...
+LL |
+LL ~     } });
+   |
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/imports/issue-59764.stderr
+++ b/src/test/ui/imports/issue-59764.stderr
@@ -209,8 +209,7 @@ help: a macro with this name exists at the root of the crate
    |
 LL ~         issue_59764::{makro as foobar, 
 LL | 
-LL |             foobaz,
-LL | 
+ ...
 LL | 
 LL ~             foo::{baz}
    |

--- a/src/test/ui/issues/issue-22644.stderr
+++ b/src/test/ui/issues/issue-22644.stderr
@@ -90,11 +90,10 @@ help: try comparing the cast value
    |
 LL ~     println!("{}", (a
 LL | 
-LL | 
-LL |                    as
-LL | 
-LL | 
  ...
+LL | 
+LL ~                    usize)
+   |
 
 error: `<` is interpreted as a start of generic arguments for `usize`, not a shift
   --> $DIR/issue-22644.rs:32:31

--- a/src/test/ui/let-else/let-else-if.stderr
+++ b/src/test/ui/let-else/let-else-if.stderr
@@ -8,8 +8,7 @@ help: try placing this code inside a block
    |
 LL ~     let Some(_) = Some(()) else { if true {
 LL |
-LL |         return;
-LL |     } else {
+ ...
 LL |         return;
 LL ~     } };
    |

--- a/src/test/ui/parser/recover-labeled-non-block-expr.stderr
+++ b/src/test/ui/parser/recover-labeled-non-block-expr.stderr
@@ -54,11 +54,10 @@ help: consider enclosing expression in a block
    |
 LL ~     let _i = 'label: { match x {
 LL |         0 => 42,
-LL |         1 if false => break 'label 17,
-LL |         1 => {
-LL |             if true {
-LL |                 break 'label 13
  ...
+LL |         _ => 1,
+LL ~     } };
+   |
 
 error: expected `while`, `for`, `loop` or `{` after a label
   --> $DIR/recover-labeled-non-block-expr.rs:26:24

--- a/src/test/ui/type/ascription/issue-34255-1.stderr
+++ b/src/test/ui/type/ascription/issue-34255-1.stderr
@@ -8,8 +8,7 @@ help: you might have meant to write a `struct` literal
    |
 LL ~     pub fn new() -> Self { SomeStruct {
 LL |         input_cells: Vec::new()
-LL |
-LL |
+ ...
 LL |
 LL ~     }}
    |

--- a/src/test/ui/unboxed-closures/unboxed-closure-sugar-lifetime-elision.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closure-sugar-lifetime-elision.stderr
@@ -9,11 +9,10 @@ help: consider introducing a named lifetime parameter
    |
 LL ~ fn main<'a>() {
 LL |     eq::< dyn for<'a> Foo<(&'a isize,), Output=&'a isize>,
-LL |           dyn Foo(&isize) -> &isize                                   >();
-LL |     eq::< dyn for<'a> Foo<(&'a isize,), Output=(&'a isize, &'a isize)>,
-LL |           dyn Foo(&isize) -> (&isize, &isize)                           >();
-LL | 
  ...
+LL | 
+LL ~     let _: dyn Foo(&'a isize, &'a usize) -> &'a usize;
+   |
 
 error: aborting due to previous error
 

--- a/src/tools/clippy/tests/ui/bind_instead_of_map_multipart.stderr
+++ b/src/tools/clippy/tests/ui/bind_instead_of_map_multipart.stderr
@@ -56,7 +56,25 @@ LL |             if s == "43" {
 LL ~                 return 43;
 LL |             }
 LL |             s == "42"
+LL |         } {
+LL ~             return 45;
+LL |         }
+LL |         match s.len() {
+LL ~             10 => 2,
+LL |             20 => {
  ...
+LL |                         if foo() {
+LL ~                             return 20;
+LL |                         }
+LL |                         println!("foo");
+LL ~                         3
+LL |                     };
+LL |                 }
+LL ~                 20
+LL |             },
+LL ~             40 => 30,
+LL ~             _ => 1,
+   |
 
 error: using `Option.and_then(|x| Some(y))`, which is more succinctly expressed as `map(|x| y)`
   --> $DIR/bind_instead_of_map_multipart.rs:61:13

--- a/src/tools/clippy/tests/ui/branches_sharing_code/shared_at_top_and_bottom.stderr
+++ b/src/tools/clippy/tests/ui/branches_sharing_code/shared_at_top_and_bottom.stderr
@@ -98,7 +98,8 @@ LL +         id: e_id,
 LL +         name: "Player 1".to_string(),
 LL +         some_data: vec![0x12, 0x34, 0x56, 0x78, 0x90],
 LL +     };
- ...
+LL +     process_data(pack);
+   |
 
 error: all if blocks contain the same code at the start and the end. Here at the start
   --> $DIR/shared_at_top_and_bottom.rs:94:5

--- a/src/tools/clippy/tests/ui/entry.stderr
+++ b/src/tools/clippy/tests/ui/entry.stderr
@@ -28,7 +28,8 @@ LL +             v
 LL +         } else {
 LL +             v2
 LL +         }
- ...
+LL +     });
+   |
 
 error: usage of `contains_key` followed by `insert` on a `HashMap`
   --> $DIR/entry.rs:38:5
@@ -50,7 +51,8 @@ LL +             v
 LL +         } else {
 LL +             v2
 LL +         }
- ...
+LL +     });
+   |
 
 error: usage of `contains_key` followed by `insert` on a `HashMap`
   --> $DIR/entry.rs:47:5
@@ -72,7 +74,9 @@ LL +             e.insert(v);
 LL +         } else {
 LL +             e.insert(v2);
 LL +             return;
- ...
+LL +         }
+LL +     }
+   |
 
 error: usage of `contains_key` followed by `insert` on a `HashMap`
   --> $DIR/entry.rs:57:5
@@ -111,7 +115,11 @@ LL +             1 if true => {
 LL +                 v
 LL +             },
 LL +             _ => {
- ...
+LL +                 v2
+LL +             },
+LL +         }
+LL +     });
+   |
 
 error: usage of `contains_key` followed by `insert` on a `HashMap`
   --> $DIR/entry.rs:75:5
@@ -133,7 +141,9 @@ LL +             0 => foo(),
 LL +             _ => {
 LL +                 e.insert(v2);
 LL +             },
- ...
+LL +         };
+LL +     }
+   |
 
 error: usage of `contains_key` followed by `insert` on a `HashMap`
   --> $DIR/entry.rs:85:5
@@ -155,7 +165,26 @@ LL +         match 0 {
 LL +             0 if false => {
 LL +                 v
 LL +             },
- ...
+LL +             1 => {
+LL +                 foo();
+LL +                 v
+LL +             },
+LL +             2 | 3 => {
+LL +                 for _ in 0..2 {
+LL +                     foo();
+LL +                 }
+LL +                 if true {
+LL +                     v
+LL +                 } else {
+LL +                     v2
+LL +                 }
+LL +             },
+LL +             _ => {
+LL +                 v2
+LL +             },
+LL +         }
+LL +     });
+   |
 
 error: usage of `contains_key` followed by `insert` on a `HashMap`
   --> $DIR/entry.rs:119:5

--- a/src/tools/clippy/tests/ui/entry_with_else.stderr
+++ b/src/tools/clippy/tests/ui/entry_with_else.stderr
@@ -17,7 +17,9 @@ LL +             e.insert(v);
 LL +         }
 LL +         std::collections::hash_map::Entry::Occupied(mut e) => {
 LL +             e.insert(v2);
- ...
+LL +         }
+LL +     }
+   |
 
 error: usage of `contains_key` followed by `insert` on a `HashMap`
   --> $DIR/entry_with_else.rs:22:5
@@ -37,7 +39,9 @@ LL +             e.insert(v);
 LL +         }
 LL +         std::collections::hash_map::Entry::Vacant(e) => {
 LL +             e.insert(v2);
- ...
+LL +         }
+LL +     }
+   |
 
 error: usage of `contains_key` followed by `insert` on a `HashMap`
   --> $DIR/entry_with_else.rs:28:5
@@ -95,7 +99,9 @@ LL +             e.insert(v);
 LL +         }
 LL +         std::collections::hash_map::Entry::Occupied(mut e) => {
 LL +             e.insert(v2);
- ...
+LL +         }
+LL +     }
+   |
 
 error: usage of `contains_key` followed by `insert` on a `HashMap`
   --> $DIR/entry_with_else.rs:46:5
@@ -115,7 +121,10 @@ LL +             if true { Some(e.insert(v)) } else { Some(e.insert(v2)) }
 LL +         }
 LL +         std::collections::hash_map::Entry::Vacant(e) => {
 LL +             e.insert(v);
- ...
+LL +             None
+LL +         }
+LL ~     };
+   |
 
 error: usage of `contains_key` followed by `insert` on a `HashMap`
   --> $DIR/entry_with_else.rs:52:5

--- a/src/tools/clippy/tests/ui/let_unit.stderr
+++ b/src/tools/clippy/tests/ui/let_unit.stderr
@@ -32,7 +32,8 @@ LL +         .map(|i| i * 2)
 LL +         .filter(|i| i % 2 == 0)
 LL +         .map(|_| ())
 LL +         .next()
- ...
+LL +         .unwrap();
+   |
 
 error: this let-binding has unit value
   --> $DIR/let_unit.rs:80:5

--- a/src/tools/clippy/tests/ui/manual_async_fn.stderr
+++ b/src/tools/clippy/tests/ui/manual_async_fn.stderr
@@ -122,7 +122,14 @@ LL +         let a = 42;
 LL +         let b = 21;
 LL +         if a < b {
 LL +             let c = 21;
- ...
+LL +             let d = 42;
+LL +             if c < d {
+LL +                 let _ = 42;
+LL +             }
+LL +         }
+LL +         42
+LL +     }
+   |
 
 error: this function can be simplified using the `async fn` syntax
   --> $DIR/manual_async_fn.rs:92:1

--- a/src/tools/clippy/tests/ui/needless_for_each_unfixable.stderr
+++ b/src/tools/clippy/tests/ui/needless_for_each_unfixable.stderr
@@ -19,7 +19,8 @@ LL +             return;
 LL +         } else {
 LL +             println!("{}", v);
 LL +         }
- ...
+LL +     }
+   |
 help: ...and replace `return` with `continue`
    |
 LL |             continue;

--- a/src/tools/clippy/tests/ui/new_without_default.stderr
+++ b/src/tools/clippy/tests/ui/new_without_default.stderr
@@ -117,7 +117,8 @@ LL +             Self::new()
 LL +         }
 LL +     }
 LL + 
- ...
+LL ~     impl<T> Foo<T> {
+   |
 
 error: aborting due to 7 previous errors
 

--- a/src/tools/clippy/tests/ui/ptr_arg.stderr
+++ b/src/tools/clippy/tests/ui/ptr_arg.stderr
@@ -56,7 +56,8 @@ LL |     let f = e.clone(); // OK
 LL |     let g = x;
 LL ~     let h = g.to_owned();
 LL |     let i = (e).clone();
- ...
+LL ~     x.to_owned()
+   |
 
 error: writing `&String` instead of `&str` involves a new object where a slice will do
   --> $DIR/ptr_arg.rs:57:18

--- a/src/tools/clippy/tests/ui/significant_drop_in_scrutinee.stderr
+++ b/src/tools/clippy/tests/ui/significant_drop_in_scrutinee.stderr
@@ -188,7 +188,9 @@ LL +         _ => mutex2.lock().unwrap(),
 LL +     }
 LL +     .s
 LL +     .len()
- ...
+LL +         > 1;
+LL ~     match value
+   |
 
 error: temporary with significant drop in match scrutinee
   --> $DIR/significant_drop_in_scrutinee.rs:397:11
@@ -211,7 +213,10 @@ LL +     } else {
 LL +         mutex2.lock().unwrap()
 LL +     }
 LL +     .s
- ...
+LL +     .len()
+LL +         > 1;
+LL ~     match value
+   |
 
 error: temporary with significant drop in match scrutinee
   --> $DIR/significant_drop_in_scrutinee.rs:451:11

--- a/src/tools/clippy/tests/ui/unit_arg.stderr
+++ b/src/tools/clippy/tests/ui/unit_arg.stderr
@@ -137,7 +137,13 @@ LL +         foo(1);
 LL +     };
 LL +     {
 LL +         foo(2);
- ...
+LL +         foo(3);
+LL +     };
+LL +     taking_multiple_units(
+LL +         (),
+LL +         (),
+LL ~     );
+   |
 
 error: passing a unit value to a function
   --> $DIR/unit_arg.rs:85:13

--- a/src/tools/clippy/tests/ui/unnecessary_wraps.stderr
+++ b/src/tools/clippy/tests/ui/unnecessary_wraps.stderr
@@ -23,7 +23,8 @@ LL |     if a {
 LL |         Some(-1);
 LL ~         2
 LL |     } else {
- ...
+LL ~         return 1337;
+   |
 
 error: this function's return value is unnecessarily wrapped by `Option`
   --> $DIR/unnecessary_wraps.rs:21:1
@@ -122,7 +123,8 @@ LL |     if a {
 LL |         Some(());
 LL ~         
 LL |     } else {
- ...
+LL ~         return ;
+   |
 
 error: this function's return value is unnecessary
   --> $DIR/unnecessary_wraps.rs:117:1


### PR DESCRIPTION
This is an attempt to fix suggestions one part of which is 6 lines or more far from the first. I've noticed "the problem" (of not showing some parts of the suggestion) here: https://github.com/rust-lang/rust/pull/97759#discussion_r889689230.

I'm not sure about the implementation (this big closure is just bad and makes already complicated code even more so), but I want to at least discuss the result.

Here is an example of how this changes the output:

Before:
```text
help: consider enclosing expression in a block
  |
3 ~     'l: { match () { () => break 'l,
4 |
5 |
6 |
7 |
8 |
...
```

After:
```text
help: consider enclosing expression in a block
  |
3 ~     'l: { match () { () => break 'l,
4 |
...
31|
32~ } };
  |
```

r? @estebank 
@rustbot label +A-diagnostics +A-suggestion-diagnostics