### PR TITLE
Impl Termination for Infallible and then make the Result impls of Termination more generic

### DIFF
--- a/src/test/ui/rfc-1937-termination-trait/termination-trait-test-wrong-type.stderr
+++ b/src/test/ui/rfc-1937-termination-trait/termination-trait-test-wrong-type.stderr
@@ -1,4 +1,4 @@
-error[E0277]: `main` has invalid return type `Result<f32, ParseFloatError>`
+error[E0277]: `main` has invalid return type `f32`
   --> $DIR/termination-trait-test-wrong-type.rs:6:1
    |
 LL |   #[test]
@@ -8,11 +8,8 @@ LL | |     "0".parse()
 LL | | }
    | |_^ `main` can only return types that implement `Termination`
    |
-   = help: the trait `Termination` is not implemented for `Result<f32, ParseFloatError>`
-   = help: the following other types implement trait `Termination`:
-             Result<!, E>
-             Result<(), E>
-             Result<Infallible, E>
+   = help: the trait `Termination` is not implemented for `f32`
+   = note: required because of the requirements on the impl of `Termination` for `Result<f32, ParseFloatError>`
 note: required by a bound in `assert_test_result`
   --> $SRC_DIR/test/src/lib.rs:LL:COL
    |


### PR DESCRIPTION
This allows things like `Result<ExitCode, E>` to 'just work'