### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/library/std/src/collections/hash/set.rs
+++ b/library/std/src/collections/hash/set.rs
@@ -590,8 +590,9 @@ where
     ///
     /// When an equal element is present in `self` and `other`
     /// then the resulting `Intersection` may yield references to
-    /// one or the other, which will be visible in properties of `T`
-    /// not participating in the `Eq` implementation.
+    /// one or the other. This can be relevant if `T` contains fields which
+    /// are not compared by its `Eq` implementation, and may hold different
+    /// value between the two equal copies of `T` in the two sets.
     ///
     /// # Examples
     ///

--- a/library/std/src/collections/hash/set.rs
+++ b/library/std/src/collections/hash/set.rs
@@ -588,12 +588,10 @@ where
     /// Visits the values representing the intersection,
     /// i.e., the values that are both in `self` and `other`.
     ///
-    /// Note: this operation does not guarantee which collection
-    /// is visited from `self` or `other`. This has consequences
-    /// for values which may be defined as equal by the `Eq` trait
-    /// but which are not physically equivalent (eg. they may have
-    /// fields which differ or do not participate in the definition
-    /// of equivalence).
+    /// Note: When an equal element is present in `self` and `other`
+    /// then the resulting `Intersection` may yield references to
+    /// one or the other, which will be visible in properties of `T`
+    /// not participating in the `Eq` implementation.
     ///
     /// # Examples
     ///

--- a/library/std/src/collections/hash/set.rs
+++ b/library/std/src/collections/hash/set.rs
@@ -588,7 +588,7 @@ where
     /// Visits the values representing the intersection,
     /// i.e., the values that are both in `self` and `other`.
     ///
-    /// Note: When an equal element is present in `self` and `other`
+    /// When an equal element is present in `self` and `other`
     /// then the resulting `Intersection` may yield references to
     /// one or the other, which will be visible in properties of `T`
     /// not participating in the `Eq` implementation.

--- a/library/std/src/collections/hash/set.rs
+++ b/library/std/src/collections/hash/set.rs
@@ -588,6 +588,13 @@ where
     /// Visits the values representing the intersection,
     /// i.e., the values that are both in `self` and `other`.
     ///
+    /// Note: this operation does not guarantee which collection
+    /// is visited from `self` or `other`. This has consequences
+    /// for values which may be defined as equal by the `Eq` trait
+    /// but which are not physically equivalent (eg. they may have
+    /// fields which differ or do not participate in the definition
+    /// of equivalence).
+    ///
     /// # Examples
     ///
     /// ```

--- a/src/librustdoc/html/static/.eslintrc.js
+++ b/src/librustdoc/html/static/.eslintrc.js
@@ -78,5 +78,6 @@ module.exports = {
         "block-scoped-var": "error",
         "guard-for-in": "error",
         "no-alert": "error",
+        "no-confusing-arrow": "error",
     }
 };

--- a/src/librustdoc/html/static/.eslintrc.js
+++ b/src/librustdoc/html/static/.eslintrc.js
@@ -79,5 +79,6 @@ module.exports = {
         "guard-for-in": "error",
         "no-alert": "error",
         "no-confusing-arrow": "error",
+        "no-div-regex": "error",
     }
 };

--- a/src/librustdoc/html/static/.eslintrc.js
+++ b/src/librustdoc/html/static/.eslintrc.js
@@ -83,5 +83,6 @@ module.exports = {
         "no-floating-decimal": "error",
         "no-implicit-globals": "error",
         "no-implied-eval": "error",
+        "no-label-var": "error",
     }
 };

--- a/src/librustdoc/html/static/.eslintrc.js
+++ b/src/librustdoc/html/static/.eslintrc.js
@@ -81,5 +81,6 @@ module.exports = {
         "no-confusing-arrow": "error",
         "no-div-regex": "error",
         "no-floating-decimal": "error",
+        "no-implicit-globals": "error",
     }
 };

--- a/src/librustdoc/html/static/.eslintrc.js
+++ b/src/librustdoc/html/static/.eslintrc.js
@@ -82,5 +82,6 @@ module.exports = {
         "no-div-regex": "error",
         "no-floating-decimal": "error",
         "no-implicit-globals": "error",
+        "no-implied-eval": "error",
     }
 };

--- a/src/librustdoc/html/static/.eslintrc.js
+++ b/src/librustdoc/html/static/.eslintrc.js
@@ -80,5 +80,6 @@ module.exports = {
         "no-alert": "error",
         "no-confusing-arrow": "error",
         "no-div-regex": "error",
+        "no-floating-decimal": "error",
     }
 };

--- a/src/librustdoc/html/static/js/main.js
+++ b/src/librustdoc/html/static/js/main.js
@@ -882,7 +882,7 @@ function loadCss(cssFileName) {
             ["-", "Collapse all sections"],
         ].map(x => "<dt>" +
             x[0].split(" ")
-                .map((y, index) => (index & 1) === 0 ? "<kbd>" + y + "</kbd>" : " " + y + " ")
+                .map((y, index) => ((index & 1) === 0 ? "<kbd>" + y + "</kbd>" : " " + y + " "))
                 .join("") + "</dt><dd>" + x[1] + "</dd>").join("");
         const div_shortcuts = document.createElement("div");
         addClass(div_shortcuts, "shortcuts");

--- a/src/tools/clippy/clippy_lints/src/matches/redundant_pattern_match.rs
+++ b/src/tools/clippy/clippy_lints/src/matches/redundant_pattern_match.rs
@@ -68,7 +68,7 @@ fn temporaries_need_ordered_drop<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<
                         }
                     }
                 },
-                // the base type is alway taken by reference.
+                // the base type is always taken by reference.
                 // e.g. In `(vec![0])[0]` the vector is a temporary value.
                 ExprKind::Index(base, index) => {
                     if !matches!(base.kind, ExprKind::Path(_)) {


### PR DESCRIPTION
Successful merges:

 - #97700 (Add note to documentation of HashSet::intersection)
 - #97792 (More eslint checks)
 - #97794 (Fix typo in redundant_pattern_match.rs)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=97700,97792,97794)
<!-- homu-ignore:end -->