### PR TITLE
Recover `import` instead of `use` in item

### DIFF
--- a/src/test/ui/did_you_mean/use_instead_of_import.fixed
+++ b/src/test/ui/did_you_mean/use_instead_of_import.fixed
@@ -1,0 +1,15 @@
+// run-rustfix
+
+use std::{
+    //~^ ERROR expected item, found `import`
+    io::Write,
+    rc::Rc,
+};
+
+pub use std::io;
+//~^ ERROR expected item, found `using`
+
+fn main() {
+    let x = Rc::new(1);
+    let _ = write!(io::stdout(), "{:?}", x);
+}

--- a/src/test/ui/did_you_mean/use_instead_of_import.rs
+++ b/src/test/ui/did_you_mean/use_instead_of_import.rs
@@ -1,0 +1,15 @@
+// run-rustfix
+
+import std::{
+    //~^ ERROR expected item, found `import`
+    io::Write,
+    rc::Rc,
+};
+
+pub using std::io;
+//~^ ERROR expected item, found `using`
+
+fn main() {
+    let x = Rc::new(1);
+    let _ = write!(io::stdout(), "{:?}", x);
+}

--- a/src/test/ui/did_you_mean/use_instead_of_import.stderr
+++ b/src/test/ui/did_you_mean/use_instead_of_import.stderr
@@ -1,0 +1,14 @@
+error: expected item, found `import`
+  --> $DIR/use_instead_of_import.rs:3:1
+   |
+LL | import std::{
+   | ^^^^^^ help: items are imported using the `use` keyword
+
+error: expected item, found `using`
+  --> $DIR/use_instead_of_import.rs:9:5
+   |
+LL | pub using std::io;
+   |     ^^^^^ help: items are imported using the `use` keyword
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
When we definitely don't have a macro invocation (i.e. when we don't have `import ::`), then it's more productive to parse `import` as if it was incorrectly mistaken for `use`.

Not sure if this needs to be a verbose suggestion, but it renders strangely when it's not verbose:
```
error: expected item, found `import`
 --> /home/michael/test.rs:1:1
  |
1 | import std::{io::{self, Write}, rc::Rc};
  | ^^^^^^ help: items are imported using the `use` keyword: `use`
```

Happy to change it to `span_suggestion` instead of `span_suggestion_verbose` though.

Fixes #97788