### PR TITLE
Recover missing comma after match arm

### DIFF
--- a/src/test/ui/parser/match-arm-without-braces.rs
+++ b/src/test/ui/parser/match-arm-without-braces.rs
@@ -45,9 +45,9 @@ fn main() {
           15;
     }
     match S::get(16) {
-        Some(Val::Foo) => 17
-        _ => 18, //~ ERROR expected one of
-    }
+        Some(Val::Foo) => 17 //~ ERROR expected `,` following `match` arm
+        _ => 18,
+    };
     match S::get(19) {
         Some(Val::Foo) =>
           20; //~ ERROR `match` arm body without braces

--- a/src/test/ui/parser/match-arm-without-braces.stderr
+++ b/src/test/ui/parser/match-arm-without-braces.stderr
@@ -52,15 +52,11 @@ LL ~           { 14;
 LL ~           15; }
    |
 
-error: expected one of `,`, `.`, `?`, `}`, or an operator, found reserved identifier `_`
-  --> $DIR/match-arm-without-braces.rs:49:9
+error: expected `,` following `match` arm
+  --> $DIR/match-arm-without-braces.rs:48:29
    |
 LL |         Some(Val::Foo) => 17
-   |                        --   - expected one of `,`, `.`, `?`, `}`, or an operator
-   |                        |
-   |                        while parsing the `match` arm starting here
-LL |         _ => 18,
-   |         ^ unexpected token
+   |                             ^ help: missing a comma here to end this `match` arm: `,`
 
 error: `match` arm body without braces
   --> $DIR/match-arm-without-braces.rs:53:11


### PR DESCRIPTION
If we're missing a comma after a match arm expression, try parsing another pattern and a following `=>`. If we find both of those, then recover by suggesting to insert a `,`.

Fixes #80112