### PR TITLE
Add more information for rustdoc-gui tests

### DIFF
--- a/src/test/rustdoc-gui/README.md
+++ b/src/test/rustdoc-gui/README.md
@@ -11,14 +11,24 @@ You can find more information and its documentation in its [repository][browser-
 If you need to have more information on the tests run, you can use `--test-args`:
 
 ```bash
-$ ./x.py test src/test/rustdoc-gui --stage 1 --jobs 8 --test-args --debug
+$ ./x.py test src/test/rustdoc-gui --stage 1 --test-args --debug
 ```
 
-There are three options supported:
+If you don't want to run in headless mode (helpful to debug sometimes), you can use
+`--no-headless`:
 
- * `--debug`: allows to see puppeteer commands.
- * `--no-headless`: disable headless mode so you can see what's going on.
- * `--show-text`: by default, text isn't rendered because of issues with fonts, it enables it back.
+```bash
+$ ./x.py test src/test/rustdoc-gui --stage 1 --test-args --no-headless
+```
+
+To see the supported options, use `--help`.
+
+Important to be noted: if the chromium instance crashes when you run it, you might need to
+use `--no-sandbox` to make it work:
+
+```bash
+$ ./x.py test src/test/rustdoc-gui --stage 1 --test-args --no-sandbox
+```
 
 [browser-ui-test]: https://github.com/GuillaumeGomez/browser-UI-test/
 [puppeteer]: https://pptr.dev/

--- a/src/tools/rustdoc-gui/tester.js
+++ b/src/tools/rustdoc-gui/tester.js
@@ -16,6 +16,7 @@ function showHelp() {
     console.log("  --debug                    : show extra information about script run");
     console.log("  --show-text                : render font in pages");
     console.log("  --no-headless              : disable headless mode");
+    console.log("  --no-sandbox               : disable sandbox mode");
     console.log("  --help                     : show this message then quit");
     console.log("  --tests-folder [PATH]      : location of the .GOML tests folder");
     console.log("  --jobs [NUMBER]            : number of threads to run tests on");


### PR DESCRIPTION
It was missing `--no-sandbox` in the `--help` message and the README was a bit outdated.

cc @jsha (I recall you asking some questions about passing arguments to the rustdoc gui tester so here it).

r? @notriddle 