### PR TITLE
optimize `dominates` using `post-order-rank`

### DIFF
--- a/compiler/rustc_data_structures/src/graph/dominators/mod.rs
+++ b/compiler/rustc_data_structures/src/graph/dominators/mod.rs
@@ -287,7 +287,17 @@ impl<Node: Idx> Dominators<Node> {
     }
 
     pub fn is_dominated_by(&self, node: Node, dom: Node) -> bool {
-        self.dominators(node).any(|n| n == dom)
+        self.dominators(node)
+            .find_map(|n| {
+                if n == dom {
+                    Some(true)
+                } else if Ordering::is_gt(self.rank_partial_cmp(n, dom).unwrap()) {
+                    Some(false)
+                } else {
+                    None
+                }
+            })
+            .unwrap_or(false)
     }
 
     /// Provide deterministic ordering of nodes such that, if any two nodes have a dominator

--- a/compiler/rustc_data_structures/src/graph/dominators/mod.rs
+++ b/compiler/rustc_data_structures/src/graph/dominators/mod.rs
@@ -287,7 +287,6 @@ impl<Node: Idx> Dominators<Node> {
     }
 
     pub fn is_dominated_by(&self, node: Node, dom: Node) -> bool {
-        // FIXME -- could be optimized by using post-order-rank
         self.dominators(node).any(|n| n == dom)
     }
 
@@ -295,6 +294,7 @@ impl<Node: Idx> Dominators<Node> {
     /// relationship, the dominator will always precede the dominated. (The relative ordering
     /// of two unrelated nodes will also be consistent, but otherwise the order has no
     /// meaning.) This method cannot be used to determine if either Node dominates the other.
+    #[inline]
     pub fn rank_partial_cmp(&self, lhs: Node, rhs: Node) -> Option<Ordering> {
         self.post_order_rank[lhs].partial_cmp(&self.post_order_rank[rhs])
     }

--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -37,7 +37,6 @@ use rustc_target::asm::InlineAsmRegOrRegClass;
 use either::Either;
 
 use std::borrow::Cow;
-use std::cmp::Ordering;
 use std::convert::TryInto;
 use std::fmt::{self, Debug, Display, Formatter, Write};
 use std::ops::{ControlFlow, Index, IndexMut};
@@ -3590,8 +3589,6 @@ impl Location {
     pub fn dominates(&self, other: Location, dominators: &Dominators<BasicBlock>) -> bool {
         if self.block == other.block {
             self.statement_index <= other.statement_index
-        } else if Ordering::is_lt(dominators.rank_partial_cmp(self.block, other.block).unwrap()) {
-            false
         } else {
             dominators.is_dominated_by(other.block, self.block)
         }

--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -37,6 +37,7 @@ use rustc_target::asm::InlineAsmRegOrRegClass;
 use either::Either;
 
 use std::borrow::Cow;
+use std::cmp::Ordering;
 use std::convert::TryInto;
 use std::fmt::{self, Debug, Display, Formatter, Write};
 use std::ops::{ControlFlow, Index, IndexMut};
@@ -3589,6 +3590,8 @@ impl Location {
     pub fn dominates(&self, other: Location, dominators: &Dominators<BasicBlock>) -> bool {
         if self.block == other.block {
             self.statement_index <= other.statement_index
+        } else if Ordering::is_lt(dominators.rank_partial_cmp(self.block, other.block).unwrap()) {
+            false
         } else {
             dominators.is_dominated_by(other.block, self.block)
         }


### PR DESCRIPTION
Like the FIXME of `is_dominated_by` and comments of `rank_partial_cmp` method, if any two nodes have a dominator relationship, the dominator will always precede the dominated. We can reduce the calculation of some scenarios based on this. The easiest way is to judge directly in the `dominates` method ([Edit]during the `is_dominated_by` method)