### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -2605,9 +2605,30 @@ pub enum Rvalue<'tcx> {
 static_assert_size!(Rvalue<'_>, 40);
 
 impl<'tcx> Rvalue<'tcx> {
+    /// Returns true if rvalue can be safely removed when the result is unused.
     #[inline]
-    pub fn is_pointer_int_cast(&self) -> bool {
-        matches!(self, Rvalue::Cast(CastKind::PointerExposeAddress, _, _))
+    pub fn is_safe_to_remove(&self) -> bool {
+        match self {
+            // Pointer to int casts may be side-effects due to exposing the provenance.
+            // While the model is undecided, we should be conservative. See
+            // <https://www.ralfj.de/blog/2022/04/11/provenance-exposed.html>
+            Rvalue::Cast(CastKind::PointerExposeAddress, _, _) => false,
+
+            Rvalue::Use(_)
+            | Rvalue::Repeat(_, _)
+            | Rvalue::Ref(_, _, _)
+            | Rvalue::ThreadLocalRef(_)
+            | Rvalue::AddressOf(_, _)
+            | Rvalue::Len(_)
+            | Rvalue::Cast(CastKind::Misc | CastKind::Pointer(_), _, _)
+            | Rvalue::BinaryOp(_, _)
+            | Rvalue::CheckedBinaryOp(_, _)
+            | Rvalue::NullaryOp(_, _)
+            | Rvalue::UnaryOp(_, _)
+            | Rvalue::Discriminant(_)
+            | Rvalue::Aggregate(_, _)
+            | Rvalue::ShallowInitBox(_, _) => true,
+        }
     }
 }
 

--- a/compiler/rustc_middle/src/thir.rs
+++ b/compiler/rustc_middle/src/thir.rs
@@ -317,9 +317,11 @@ pub enum ExprKind<'tcx> {
         lhs: ExprId,
         rhs: ExprId,
     },
-    /// Access to a struct or tuple field.
+    /// Access to a field of a struct, a tuple, an union, or an enum.
     Field {
         lhs: ExprId,
+        /// Variant containing the field.
+        variant_index: VariantIdx,
         /// This can be a named (`.foo`) or unnamed (`.0`) field.
         name: Field,
     },

--- a/compiler/rustc_middle/src/thir/visit.rs
+++ b/compiler/rustc_middle/src/thir/visit.rs
@@ -80,7 +80,7 @@ pub fn walk_expr<'a, 'tcx: 'a, V: Visitor<'a, 'tcx>>(visitor: &mut V, expr: &Exp
             visitor.visit_expr(&visitor.thir()[lhs]);
             visitor.visit_expr(&visitor.thir()[rhs]);
         }
-        Field { lhs, name: _ } => visitor.visit_expr(&visitor.thir()[lhs]),
+        Field { lhs, variant_index: _, name: _ } => visitor.visit_expr(&visitor.thir()[lhs]),
         Index { lhs, index } => {
             visitor.visit_expr(&visitor.thir()[lhs]);
             visitor.visit_expr(&visitor.thir()[index]);

--- a/compiler/rustc_mir_build/src/thir/cx/expr.rs
+++ b/compiler/rustc_mir_build/src/thir/cx/expr.rs
@@ -591,6 +591,7 @@ impl<'tcx> Cx<'tcx> {
             }
             hir::ExprKind::Field(ref source, ..) => ExprKind::Field {
                 lhs: self.mirror_expr(source),
+                variant_index: VariantIdx::new(0),
                 name: Field::new(tcx.field_index(expr.hir_id, self.typeck_results)),
             },
             hir::ExprKind::Cast(ref source, ref cast_ty) => {
@@ -994,14 +995,11 @@ impl<'tcx> Cx<'tcx> {
                 HirProjectionKind::Deref => {
                     ExprKind::Deref { arg: self.thir.exprs.push(captured_place_expr) }
                 }
-                HirProjectionKind::Field(field, ..) => {
-                    // Variant index will always be 0, because for multi-variant
-                    // enums, we capture the enum entirely.
-                    ExprKind::Field {
-                        lhs: self.thir.exprs.push(captured_place_expr),
-                        name: Field::new(field as usize),
-                    }
-                }
+                HirProjectionKind::Field(field, variant_index) => ExprKind::Field {
+                    lhs: self.thir.exprs.push(captured_place_expr),
+                    variant_index,
+                    name: Field::new(field as usize),
+                },
                 HirProjectionKind::Index | HirProjectionKind::Subslice => {
                     // We don't capture these projections, so we can ignore them here
                     continue;

--- a/compiler/rustc_mir_dataflow/src/impls/liveness.rs
+++ b/compiler/rustc_mir_dataflow/src/impls/liveness.rs
@@ -244,13 +244,10 @@ impl<'a, 'tcx> Analysis<'tcx> for MaybeTransitiveLiveLocals<'a> {
         // Compute the place that we are storing to, if any
         let destination = match &statement.kind {
             StatementKind::Assign(assign) => {
-                if assign.1.is_pointer_int_cast() {
-                    // Pointer to int casts may be side-effects due to exposing the provenance.
-                    // While the model is undecided, we should be conservative. See
-                    // <https://www.ralfj.de/blog/2022/04/11/provenance-exposed.html>
-                    None
-                } else {
+                if assign.1.is_safe_to_remove() {
                     Some(assign.0)
+                } else {
+                    None
                 }
             }
             StatementKind::SetDiscriminant { place, .. } | StatementKind::Deinit(place) => {

--- a/compiler/rustc_mir_transform/src/dead_store_elimination.rs
+++ b/compiler/rustc_mir_transform/src/dead_store_elimination.rs
@@ -34,7 +34,7 @@ pub fn eliminate<'tcx>(tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>, borrowed: &BitS
         for (statement_index, statement) in bb_data.statements.iter().enumerate().rev() {
             let loc = Location { block: bb, statement_index };
             if let StatementKind::Assign(assign) = &statement.kind {
-                if assign.1.is_pointer_int_cast() {
+                if !assign.1.is_safe_to_remove() {
                     continue;
                 }
             }

--- a/compiler/rustc_mir_transform/src/simplify.rs
+++ b/compiler/rustc_mir_transform/src/simplify.rs
@@ -494,8 +494,12 @@ impl<'tcx> Visitor<'tcx> for UsedLocals {
             StatementKind::StorageLive(_local) | StatementKind::StorageDead(_local) => {}
 
             StatementKind::Assign(box (ref place, ref rvalue)) => {
-                self.visit_lhs(place, location);
-                self.visit_rvalue(rvalue, location);
+                if rvalue.is_safe_to_remove() {
+                    self.visit_lhs(place, location);
+                    self.visit_rvalue(rvalue, location);
+                } else {
+                    self.super_statement(statement, location);
+                }
             }
 
             StatementKind::SetDiscriminant { ref place, variant_index: _ }

--- a/library/std/src/sync/mutex.rs
+++ b/library/std/src/sync/mutex.rs
@@ -10,7 +10,7 @@ use crate::sys_common::mutex as sys;
 /// A mutual exclusion primitive useful for protecting shared data
 ///
 /// This mutex will block threads waiting for the lock to become available. The
-/// mutex can created via a [`new`] constructor. Each mutex has a type parameter
+/// mutex can be created via a [`new`] constructor. Each mutex has a type parameter
 /// which represents the data that it is protecting. The data can only be accessed
 /// through the RAII guards returned from [`lock`] and [`try_lock`], which
 /// guarantees that the data is only ever accessed when the mutex is locked.

--- a/library/std/src/sync/mutex.rs
+++ b/library/std/src/sync/mutex.rs
@@ -10,11 +10,10 @@ use crate::sys_common::mutex as sys;
 /// A mutual exclusion primitive useful for protecting shared data
 ///
 /// This mutex will block threads waiting for the lock to become available. The
-/// mutex can also be statically initialized or created via a [`new`]
-/// constructor. Each mutex has a type parameter which represents the data that
-/// it is protecting. The data can only be accessed through the RAII guards
-/// returned from [`lock`] and [`try_lock`], which guarantees that the data is only
-/// ever accessed when the mutex is locked.
+/// mutex can created via a [`new`] constructor. Each mutex has a type parameter
+/// which represents the data that it is protecting. The data can only be accessed
+/// through the RAII guards returned from [`lock`] and [`try_lock`], which
+/// guarantees that the data is only ever accessed when the mutex is locked.
 ///
 /// # Poisoning
 ///

--- a/src/test/mir-opt/simplify-locals.rs
+++ b/src/test/mir-opt/simplify-locals.rs
@@ -62,6 +62,12 @@ fn t4() -> u32 {
     unsafe { X + 1 }
 }
 
+// EMIT_MIR simplify_locals.expose_addr.SimplifyLocals.diff
+fn expose_addr(p: *const usize) {
+    // Used pointer to address cast. Has a side effect of exposing the provenance.
+    p as usize;
+}
+
 fn main() {
     c();
     d1();
@@ -71,4 +77,5 @@ fn main() {
     t2();
     t3();
     t4();
+    expose_addr(&0);
 }

--- a/src/test/mir-opt/simplify_locals.expose_addr.SimplifyLocals.diff
+++ b/src/test/mir-opt/simplify_locals.expose_addr.SimplifyLocals.diff
@@ -1,0 +1,21 @@
+- // MIR for `expose_addr` before SimplifyLocals
++ // MIR for `expose_addr` after SimplifyLocals
+  
+  fn expose_addr(_1: *const usize) -> () {
+      debug p => _1;                       // in scope 0 at $DIR/simplify-locals.rs:66:16: 66:17
+      let mut _0: ();                      // return place in scope 0 at $DIR/simplify-locals.rs:66:33: 66:33
+      let _2: usize;                       // in scope 0 at $DIR/simplify-locals.rs:68:5: 68:15
+      let mut _3: *const usize;            // in scope 0 at $DIR/simplify-locals.rs:68:5: 68:6
+  
+      bb0: {
+          StorageLive(_2);                 // scope 0 at $DIR/simplify-locals.rs:68:5: 68:15
+          StorageLive(_3);                 // scope 0 at $DIR/simplify-locals.rs:68:5: 68:6
+          _3 = _1;                         // scope 0 at $DIR/simplify-locals.rs:68:5: 68:6
+          _2 = move _3 as usize (PointerExposeAddress); // scope 0 at $DIR/simplify-locals.rs:68:5: 68:15
+          StorageDead(_3);                 // scope 0 at $DIR/simplify-locals.rs:68:14: 68:15
+          StorageDead(_2);                 // scope 0 at $DIR/simplify-locals.rs:68:15: 68:16
+          _0 = const ();                   // scope 0 at $DIR/simplify-locals.rs:66:33: 69:2
+          return;                          // scope 0 at $DIR/simplify-locals.rs:69:2: 69:2
+      }
+  }
+  

--- a/src/test/ui/closures/2229_closure_analysis/capture-enum-field.rs
+++ b/src/test/ui/closures/2229_closure_analysis/capture-enum-field.rs
@@ -1,0 +1,27 @@
+// edition:2021
+// run-pass
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum Color {
+    RGB(u8, u8, u8),
+}
+
+fn main() {
+    let mut color = Color::RGB(0, 0, 0);
+    let mut red = |v| {
+        let Color::RGB(ref mut r, _, _) = color;
+        *r = v;
+    };
+    let mut green = |v| {
+        let Color::RGB(_, ref mut g, _) = color;
+        *g = v;
+    };
+    let mut blue = |v| {
+        let Color::RGB(_, _, ref mut b) = color;
+        *b = v;
+    };
+    red(1);
+    green(2);
+    blue(3);
+    assert_eq!(Color::RGB(1, 2, 3), color);
+}


### PR DESCRIPTION
Successful merges:

 - #95948 (Improve the safety docs for `CStr`)
 - #97325 (Fix precise field capture of univariant enums)
 - #97597 (Preserve unused pointer to address casts)
 - #97817 (:arrow_up: rust-analyzer)
 - #97821 (Remove confusing sentence from `Mutex` docs)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=95948,97325,97597,97817,97821)
<!-- homu-ignore:end -->