### PR TITLE
Document Rust's stance on `/proc/self/mem`

### DIFF
--- a/library/std/src/os/unix/io/mod.rs
+++ b/library/std/src/os/unix/io/mod.rs
@@ -52,8 +52,8 @@
 //! and writes happen outside the control of the Rust compiler, so they do not
 //! uphold Rust's memory safety guarantees.
 //!
-//! Does this mean that all APIs that might allow `/proc/self/mem` to be opened
-//! and read from or written to must be `unsafe`? No. Rust's safety guarantees
+//! However, this does not mean that all APIs that might allow `/proc/self/mem`
+//! to be opened and read from or written must be `unsafe`. Rust's safety guarantees
 //! only cover what the program itself can do, and not what entities outside
 //! the program can do to it. `/proc/self/mem` is considered to be such an
 //! external entity, along with debugging interfaces, and people with physical access to

--- a/library/std/src/os/unix/io/mod.rs
+++ b/library/std/src/os/unix/io/mod.rs
@@ -44,14 +44,14 @@
 //! Like boxes, `OwnedFd` values conceptually own the resource they point to,
 //! and free (close) it when they are dropped.
 //!
-//! ## What about `/proc/self/mem` and similar OS features?
+//! ## `/proc/self/mem` and similar OS features
 //!
 //! Some platforms have special files, such as `/proc/self/mem`, which 
 //! provide read and write access to the process's memory. Such reads
 //! and writes happen outside the control of the Rust compiler, so they do not
 //! uphold Rust's memory safety guarantees.
 //!
-//! However, this does not mean that all APIs that might allow `/proc/self/mem`
+//! This does not mean that all APIs that might allow `/proc/self/mem`
 //! to be opened and read from or written must be `unsafe`. Rust's safety guarantees
 //! only cover what the program itself can do, and not what entities outside
 //! the program can do to it. `/proc/self/mem` is considered to be such an

--- a/library/std/src/os/unix/io/mod.rs
+++ b/library/std/src/os/unix/io/mod.rs
@@ -46,7 +46,7 @@
 //!
 //! ## What about `/proc/self/mem` and similar OS features?
 //!
-//! Some platforms have a feature known as `/proc/self/mem`, which is a
+//! Some platforms have special files, such as `/proc/self/mem`, which is a
 //! filesystem path that can be opened, producing a file descriptor that, when
 //! read from or written to, reads and writes the process's memory. These reads
 //! and writes happen outside the control of the Rust compiler, so they do not

--- a/library/std/src/os/unix/io/mod.rs
+++ b/library/std/src/os/unix/io/mod.rs
@@ -56,7 +56,7 @@
 //! and read from or written to must be `unsafe`? No. Rust's safety guarantees
 //! only cover what the program itself can do, and not what entities outside
 //! the program can do to it. `/proc/self/mem` is considered to be such an
-//! external entity, along with debugggers and people with physical access to
+//! external entity, along with debuggers and people with physical access to
 //! the hardware. This is true even in cases where the program is controling
 //! the external entity.
 //!

--- a/library/std/src/os/unix/io/mod.rs
+++ b/library/std/src/os/unix/io/mod.rs
@@ -44,6 +44,26 @@
 //! Like boxes, `OwnedFd` values conceptually own the resource they point to,
 //! and free (close) it when they are dropped.
 //!
+//! ## What about `/proc/self/mem` and similar OS features?
+//!
+//! Some platforms have a feature known as `/proc/self/mem`, which is a
+//! filesystem path that can be opened, producing a file descriptor that, when
+//! read from or written to, reads and writes the process's memory. These reads
+//! and writes happen outside the control of the Rust compiler, so they do not
+//! uphold Rust's memory safety guarantees.
+//!
+//! Does this mean that all APIs that might allow `/proc/self/mem` to be opened
+//! and read from or written to must be `unsafe`? No. Rust's safety guarantees
+//! only cover what the program itself can do, and not what entities outside
+//! the program can do to it. `/proc/self/mem` is considered to be such an
+//! external entity, along with debugggers and people with physical access to
+//! the hardware. This is true even in cases where the program is controling
+//! the external entity.
+//!
+//! If you desire to comprehensively prevent programs from reaching out and
+//! causing external entities to reach back in and violate memory safety, it's
+//! necessary to use *sandboxing*, which is outside the scope of `std`.
+//!
 //! [`BorrowedFd<'a>`]: crate::os::unix::io::BorrowedFd
 
 #![stable(feature = "rust1", since = "1.0.0")]

--- a/library/std/src/os/unix/io/mod.rs
+++ b/library/std/src/os/unix/io/mod.rs
@@ -56,7 +56,7 @@
 //! and read from or written to must be `unsafe`? No. Rust's safety guarantees
 //! only cover what the program itself can do, and not what entities outside
 //! the program can do to it. `/proc/self/mem` is considered to be such an
-//! external entity, along with debuggers and people with physical access to
+//! external entity, along with debugging interfaces, and people with physical access to
 //! the hardware. This is true even in cases where the program is controlling
 //! the external entity.
 //!

--- a/library/std/src/os/unix/io/mod.rs
+++ b/library/std/src/os/unix/io/mod.rs
@@ -57,7 +57,7 @@
 //! only cover what the program itself can do, and not what entities outside
 //! the program can do to it. `/proc/self/mem` is considered to be such an
 //! external entity, along with debuggers and people with physical access to
-//! the hardware. This is true even in cases where the program is controling
+//! the hardware. This is true even in cases where the program is controlling
 //! the external entity.
 //!
 //! If you desire to comprehensively prevent programs from reaching out and

--- a/library/std/src/os/unix/io/mod.rs
+++ b/library/std/src/os/unix/io/mod.rs
@@ -46,9 +46,8 @@
 //!
 //! ## What about `/proc/self/mem` and similar OS features?
 //!
-//! Some platforms have special files, such as `/proc/self/mem`, which is a
-//! filesystem path that can be opened, producing a file descriptor that, when
-//! read from or written to, reads and writes the process's memory. These reads
+//! Some platforms have special files, such as `/proc/self/mem`, which 
+//! provide read and write access to the process's memory. Such reads
 //! and writes happen outside the control of the Rust compiler, so they do not
 //! uphold Rust's memory safety guarantees.
 //!

--- a/library/std/src/os/unix/io/mod.rs
+++ b/library/std/src/os/unix/io/mod.rs
@@ -46,7 +46,7 @@
 //!
 //! ## `/proc/self/mem` and similar OS features
 //!
-//! Some platforms have special files, such as `/proc/self/mem`, which 
+//! Some platforms have special files, such as `/proc/self/mem`, which
 //! provide read and write access to the process's memory. Such reads
 //! and writes happen outside the control of the Rust compiler, so they do not
 //! uphold Rust's memory safety guarantees.


### PR DESCRIPTION
Add documentation to `std::os::unix::io` describing Rust's stance on
`/proc/self/mem`, treating it as an external entity which is outside
the scope of Rust's safety guarantees.
