### PR TITLE
hexagon: adapt test for upstream output changes

### DIFF
--- a/src/test/assembly/asm/hexagon-types.rs
+++ b/src/test/assembly/asm/hexagon-types.rs
@@ -73,7 +73,7 @@ macro_rules! check_reg {
 
 // CHECK-LABEL: sym_static:
 // CHECK: InlineAsm Start
-// CHECK: r0 = #extern_static
+// CHECK: r0 = {{#+}}extern_static
 // CHECK: InlineAsm End
 #[no_mangle]
 pub unsafe fn sym_static() {
@@ -88,7 +88,7 @@ pub unsafe fn sym_static() {
 
 // CHECK-LABEL: sym_fn:
 // CHECK: InlineAsm Start
-// CHECK: r0 = #extern_func
+// CHECK: r0 = {{#+}}extern_func
 // CHECK: InlineAsm End
 #[no_mangle]
 pub unsafe fn sym_fn() {
@@ -108,7 +108,7 @@ pub unsafe fn sym_fn() {
 // CHECK: InlineAsm Start
 // CHECK: {
 // CHECK:   r{{[0-9]+}} = r0
-// CHECK:   memw(r1) = r{{[0-9]+}}
+// CHECK:   memw(r1{{(\+#0)?}}) = r{{[0-9]+}}
 // CHECK: }
 // CHECK: InlineAsm End
 #[no_mangle]


### PR DESCRIPTION
The output of IR formatting changed slightly in upstream rev
a0bc67e555f404d0e7ddb2e78cb891d96eaf913d
(https://reviews.llvm.org/D123096). I'm not actually sure what any of
that means, as I don't even know what hexagon is in this context, but
this change allows the test to pass on both old and new LLVMs.

r? @nikic