### PR TITLE
Inline Windows `OsStrExt::encode_wide`

### DIFF
--- a/library/std/src/os/windows/ffi.rs
+++ b/library/std/src/os/windows/ffi.rs
@@ -129,6 +129,7 @@ pub trait OsStrExt: Sealed {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl OsStrExt for OsStr {
+    #[inline]
     fn encode_wide(&self) -> EncodeWide<'_> {
         self.as_inner().inner.encode_wide()
     }


### PR DESCRIPTION
User crates currently produce much more code than necessary because the optimizer fails to make assumptions about this method.