### PR TITLE
Relax mipsel-sony-psp's linker script

### DIFF
--- a/compiler/rustc_target/src/spec/mipsel_sony_psp.rs
+++ b/compiler/rustc_target/src/spec/mipsel_sony_psp.rs
@@ -6,10 +6,8 @@ const LINKER_SCRIPT: &str = include_str!("./mipsel_sony_psp_linker_script.ld");
 
 pub fn target() -> Target {
     let mut pre_link_args = LinkArgs::new();
-    pre_link_args.insert(
-        LinkerFlavor::Lld(LldFlavor::Ld),
-        vec!["--emit-relocs".into(), "--nmagic".into()],
-    );
+    pre_link_args
+        .insert(LinkerFlavor::Lld(LldFlavor::Ld), vec!["--emit-relocs".into(), "--nmagic".into()]);
 
     Target {
         llvm_target: "mipsel-sony-psp".into(),

--- a/compiler/rustc_target/src/spec/mipsel_sony_psp.rs
+++ b/compiler/rustc_target/src/spec/mipsel_sony_psp.rs
@@ -6,7 +6,10 @@ const LINKER_SCRIPT: &str = include_str!("./mipsel_sony_psp_linker_script.ld");
 
 pub fn target() -> Target {
     let mut pre_link_args = LinkArgs::new();
-    pre_link_args.insert(LinkerFlavor::Lld(LldFlavor::Ld), vec!["--emit-relocs".into()]);
+    pre_link_args.insert(
+        LinkerFlavor::Lld(LldFlavor::Ld),
+        vec!["--emit-relocs".into(), "--nmagic".into()],
+    );
 
     Target {
         llvm_target: "mipsel-sony-psp".into(),

--- a/compiler/rustc_target/src/spec/mipsel_sony_psp_linker_script.ld
+++ b/compiler/rustc_target/src/spec/mipsel_sony_psp_linker_script.ld
@@ -7,14 +7,18 @@ SECTIONS
   /* Sort stubs for convenient ordering */
   .sceStub.text : { *(.sceStub.text) *(SORT(.sceStub.text.*)) }
 
+  /* PSP import library stub sections. Bundles together `.lib.stub.entry.*`
+   * sections for better `--gc-sections` support. */
+  .lib.stub.top : { *(.lib.stub.top) }
+  .lib.stub :     { *(.lib.stub) *(.lib.stub.entry.*) }
+  .lib.stub.btm : { *(.lib.stub.btm) }
+
   /* Keep these sections around, even though they may appear unused to the linker */
   .lib.ent.top :  { KEEP(*(.lib.ent.top)) }
   .lib.ent :      { KEEP(*(.lib.ent)) }
   .lib.ent.btm :  { KEEP(*(.lib.ent.btm)) }
-  .lib.stub.top : { KEEP(*(.lib.stub.top)) }
-  .lib.stub :     { KEEP(*(.lib.stub)) }
-  .lib.stub.btm : { KEEP(*(.lib.stub.btm)) }
-  .eh_frame_hdr : { KEEP(*(.eh_frame_hdr)) }
+
+  .eh_frame_hdr : { *(.eh_frame_hdr) }
 
   /* Add symbols for LLVM's libunwind */
   __eh_frame_hdr_start = SIZEOF(.eh_frame_hdr) > 0 ? ADDR(.eh_frame_hdr) : 0;
@@ -27,8 +31,15 @@ SECTIONS
   }
 
   /* These are explicitly listed to avoid being merged into .rodata */
-  .rodata.sceResident : { *(.rodata.sceResident) }
+  .rodata.sceResident : { *(.rodata.sceResident) *(.rodata.sceResident.*) }
   .rodata.sceModuleInfo : { *(.rodata.sceModuleInfo) }
   /* Sort NIDs for convenient ordering */
   .rodata.sceNid : { *(.rodata.sceNid) *(SORT(.rodata.sceNid.*)) }
+
+  .rodata : { *(.rodata .rodata.*) }
+  .data : { *(.data .data.*) }
+  .gcc_except_table : { *(.gcc_except_table .gcc_except_table.*) }
+  .bss : { *(.bss .bss.*) }
+
+  /DISCARD/ : { *(.rel.sceStub.text .MIPS.abiflags .reginfo) }
 }


### PR DESCRIPTION
Previously, the linker script forcefully kept all `.lib.stub` sections, unnecessarily bloating the binary. Now, the script is LTO and `--gc-sections` friendly.

`--nmagic` was also added to the linker, because page alignment is not required on the PSP. This further reduces binary size.

Accompanying changes for the `psp` crate are found in: https://github.com/overdrivenpotato/rust-psp/pull/118