### PR TITLE
Windows: No panic if function not (yet) available

### DIFF
--- a/library/std/src/sys/windows/c.rs
+++ b/library/std/src/sys/windows/c.rs
@@ -276,6 +276,7 @@ pub const STATUS_INVALID_PARAMETER: NTSTATUS = 0xc000000d_u32 as _;
 
 pub const STATUS_PENDING: NTSTATUS = 0x103 as _;
 pub const STATUS_END_OF_FILE: NTSTATUS = 0xC0000011_u32 as _;
+pub const STATUS_NOT_IMPLEMENTED: NTSTATUS = 0xC0000002_u32 as _;
 
 // Equivalent to the `NT_SUCCESS` C preprocessor macro.
 // See: https://docs.microsoft.com/en-us/windows-hardware/drivers/kernel/using-ntstatus-values
@@ -1264,7 +1265,7 @@ compat_fn! {
         EaBuffer: *mut c_void,
         EaLength: ULONG
     ) -> NTSTATUS {
-        panic!("`NtCreateFile` not available");
+        STATUS_NOT_IMPLEMENTED
     }
     pub fn NtReadFile(
         FileHandle: BorrowedHandle<'_>,
@@ -1277,7 +1278,7 @@ compat_fn! {
         ByteOffset: Option<&LARGE_INTEGER>,
         Key: Option<&ULONG>
     ) -> NTSTATUS {
-        panic!("`NtReadFile` not available");
+        STATUS_NOT_IMPLEMENTED
     }
     pub fn NtWriteFile(
         FileHandle: BorrowedHandle<'_>,
@@ -1290,12 +1291,12 @@ compat_fn! {
         ByteOffset: Option<&LARGE_INTEGER>,
         Key: Option<&ULONG>
     ) -> NTSTATUS {
-        panic!("`NtWriteFile` not available");
+        STATUS_NOT_IMPLEMENTED
     }
     pub fn RtlNtStatusToDosError(
         Status: NTSTATUS
     ) -> ULONG {
-        panic!("`RtlNtStatusToDosError` not available");
+        Status as ULONG
     }
     pub fn NtCreateKeyedEvent(
         KeyedEventHandle: LPHANDLE,


### PR DESCRIPTION
In some situations (e.g. #97814) it is possible for required functions to be called before they've had a chance to be loaded. Therefore, we make it possible to recover from this situation simply by looking at error codes.

@rustbot label +O-windows