### PR TITLE
Specify DWARF alignment in bits, not bytes.

### DIFF
--- a/compiler/rustc_codegen_llvm/src/debuginfo/metadata.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/metadata.rs
@@ -1365,7 +1365,7 @@ pub fn build_global_var_di_node<'ll>(cx: &CodegenCx<'ll, '_>, def_id: DefId, glo
             is_local_to_unit,
             global,
             None,
-            global_align.bytes() as u32,
+            global_align.bits() as u32,
         );
     }
 }

--- a/src/test/codegen/debug-alignment.rs
+++ b/src/test/codegen/debug-alignment.rs
@@ -1,0 +1,8 @@
+// Verifies that DWARF alignment is specified properly.
+//
+// compile-flags: -C debuginfo=2
+#![crate_type = "lib"]
+
+// CHECK: !DIGlobalVariable
+// CHECK: align: 32
+pub static A: u32 = 1;


### PR DESCRIPTION
In DWARF, alignment of types is specified in bits, as is made clear by the
parameter name `AlignInBits`. However, `rustc` was incorrectly passing a byte
alignment. This commit fixes that.

This was noticed in upstream LLVM when I tried to check in a test consisting of
LLVM IR generated from `rustc` and it triggered assertions [1].

[1]: https://reviews.llvm.org/D126835