### PR TITLE
Use repr(C) when depending on struct layout in ptr tests

### DIFF
--- a/library/core/tests/ptr.rs
+++ b/library/core/tests/ptr.rs
@@ -19,6 +19,7 @@ fn test_const_from_raw_parts() {
 #[test]
 fn test() {
     unsafe {
+        #[repr(C)]
         struct Pair {
             fst: isize,
             snd: isize,


### PR DESCRIPTION
The test depends on the layout of this struct `Pair`, so it should use `repr(C)` instead of the default `repr(Rust)`.