### PR TITLE
Suggest escaping `box` as identifier

### DIFF
--- a/src/test/ui/parser/keyword-box-as-identifier.rs
+++ b/src/test/ui/parser/keyword-box-as-identifier.rs
@@ -1,3 +1,10 @@
 fn main() {
-    let box = "foo"; //~ error: expected pattern, found `=`
+    let box = 0;
+    //~^ ERROR expected pattern, found `=`
+    let box: bool;
+    //~^ ERROR expected pattern, found `:`
+    let mut box = 0;
+    //~^ ERROR expected pattern, found `=`
+    let (box,) = (0,);
+    //~^ ERROR expected pattern, found `,`
 }

--- a/src/test/ui/parser/keyword-box-as-identifier.stderr
+++ b/src/test/ui/parser/keyword-box-as-identifier.stderr
@@ -1,8 +1,66 @@
 error: expected pattern, found `=`
   --> $DIR/keyword-box-as-identifier.rs:2:13
    |
-LL |     let box = "foo";
-   |             ^ expected pattern
+LL |     let box = 0;
+   |             ^
+   |
+note: `box` is a reserved keyword
+  --> $DIR/keyword-box-as-identifier.rs:2:9
+   |
+LL |     let box = 0;
+   |         ^^^
+help: escape `box` to use it as an identifier
+   |
+LL |     let r#box = 0;
+   |         ++
 
-error: aborting due to previous error
+error: expected pattern, found `:`
+  --> $DIR/keyword-box-as-identifier.rs:4:12
+   |
+LL |     let box: bool;
+   |            ^
+   |
+note: `box` is a reserved keyword
+  --> $DIR/keyword-box-as-identifier.rs:4:9
+   |
+LL |     let box: bool;
+   |         ^^^
+help: escape `box` to use it as an identifier
+   |
+LL |     let r#box: bool;
+   |         ++
+
+error: expected pattern, found `=`
+  --> $DIR/keyword-box-as-identifier.rs:6:17
+   |
+LL |     let mut box = 0;
+   |                 ^
+   |
+note: `box` is a reserved keyword
+  --> $DIR/keyword-box-as-identifier.rs:6:13
+   |
+LL |     let mut box = 0;
+   |             ^^^
+help: escape `box` to use it as an identifier
+   |
+LL |     let mut r#box = 0;
+   |             ++
+
+error: expected pattern, found `,`
+  --> $DIR/keyword-box-as-identifier.rs:8:13
+   |
+LL |     let (box,) = (0,);
+   |             ^
+   |
+note: `box` is a reserved keyword
+  --> $DIR/keyword-box-as-identifier.rs:8:10
+   |
+LL |     let (box,) = (0,);
+   |          ^^^
+help: escape `box` to use it as an identifier
+   |
+LL |     let (r#box,) = (0,);
+   |          ++
+
+error: aborting due to 4 previous errors
 


### PR DESCRIPTION
Fixes #97810.