### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/compiler/rustc_ty_utils/src/instance.rs
+++ b/compiler/rustc_ty_utils/src/instance.rs
@@ -347,11 +347,15 @@ fn resolve_associated_item<'tcx>(
             _ => None,
         },
         traits::ImplSource::Object(ref data) => {
-            let index = traits::get_vtable_index_of_object_method(tcx, data, trait_item_id);
-            Some(Instance {
-                def: ty::InstanceDef::Virtual(trait_item_id, index),
-                substs: rcvr_substs,
-            })
+            if let Some(index) = traits::get_vtable_index_of_object_method(tcx, data, trait_item_id)
+            {
+                Some(Instance {
+                    def: ty::InstanceDef::Virtual(trait_item_id, index),
+                    substs: rcvr_substs,
+                })
+            } else {
+                None
+            }
         }
         traits::ImplSource::Builtin(..) => {
             if Some(trait_ref.def_id) == tcx.lang_items().clone_trait() {

--- a/library/alloc/tests/lib.rs
+++ b/library/alloc/tests/lib.rs
@@ -7,7 +7,6 @@
 #![feature(const_convert)]
 #![feature(const_cow_is_borrowed)]
 #![feature(const_heap)]
-#![feature(const_intrinsic_copy)]
 #![feature(const_mut_refs)]
 #![feature(const_nonnull_slice_from_raw_parts)]
 #![feature(const_ptr_write)]

--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -2116,11 +2116,11 @@ pub(crate) fn is_nonoverlapping<T>(src: *const T, dst: *const T, count: usize) -
 /// [`Vec::append`]: ../../std/vec/struct.Vec.html#method.append
 #[doc(alias = "memcpy")]
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_const_unstable(feature = "const_intrinsic_copy", issue = "80697")]
+#[rustc_const_stable(feature = "const_intrinsic_copy", since = "1.63.0")]
 #[inline]
 pub const unsafe fn copy_nonoverlapping<T>(src: *const T, dst: *mut T, count: usize) {
     extern "rust-intrinsic" {
-        #[rustc_const_unstable(feature = "const_intrinsic_copy", issue = "80697")]
+        #[rustc_const_stable(feature = "const_intrinsic_copy", since = "1.63.0")]
         pub fn copy_nonoverlapping<T>(src: *const T, dst: *mut T, count: usize);
     }
 
@@ -2198,11 +2198,11 @@ pub const unsafe fn copy_nonoverlapping<T>(src: *const T, dst: *mut T, count: us
 /// ```
 #[doc(alias = "memmove")]
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_const_unstable(feature = "const_intrinsic_copy", issue = "80697")]
+#[rustc_const_stable(feature = "const_intrinsic_copy", since = "1.63.0")]
 #[inline]
 pub const unsafe fn copy<T>(src: *const T, dst: *mut T, count: usize) {
     extern "rust-intrinsic" {
-        #[rustc_const_unstable(feature = "const_intrinsic_copy", issue = "80697")]
+        #[rustc_const_stable(feature = "const_intrinsic_copy", since = "1.63.0")]
         fn copy<T>(src: *const T, dst: *mut T, count: usize);
     }
 

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -114,7 +114,6 @@
 #![feature(const_convert)]
 #![feature(const_inherent_unchecked_arith)]
 #![feature(const_int_unchecked_arith)]
-#![feature(const_intrinsic_copy)]
 #![feature(const_intrinsic_forget)]
 #![feature(const_likely)]
 #![feature(const_maybe_uninit_uninit_array)]

--- a/library/core/src/ptr/const_ptr.rs
+++ b/library/core/src/ptr/const_ptr.rs
@@ -1197,7 +1197,7 @@ impl<T: ?Sized> *const T {
     /// See [`ptr::copy`] for safety concerns and examples.
     ///
     /// [`ptr::copy`]: crate::ptr::copy()
-    #[rustc_const_unstable(feature = "const_intrinsic_copy", issue = "80697")]
+    #[rustc_const_stable(feature = "const_intrinsic_copy", since = "1.63.0")]
     #[stable(feature = "pointer_methods", since = "1.26.0")]
     #[inline]
     pub const unsafe fn copy_to(self, dest: *mut T, count: usize)
@@ -1216,7 +1216,7 @@ impl<T: ?Sized> *const T {
     /// See [`ptr::copy_nonoverlapping`] for safety concerns and examples.
     ///
     /// [`ptr::copy_nonoverlapping`]: crate::ptr::copy_nonoverlapping()
-    #[rustc_const_unstable(feature = "const_intrinsic_copy", issue = "80697")]
+    #[rustc_const_stable(feature = "const_intrinsic_copy", since = "1.63.0")]
     #[stable(feature = "pointer_methods", since = "1.26.0")]
     #[inline]
     pub const unsafe fn copy_to_nonoverlapping(self, dest: *mut T, count: usize)

--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -1089,7 +1089,7 @@ pub const unsafe fn read<T>(src: *const T) -> T {
     // We are calling the intrinsics directly to avoid function calls in the generated code
     // as `intrinsics::copy_nonoverlapping` is a wrapper function.
     extern "rust-intrinsic" {
-        #[rustc_const_unstable(feature = "const_intrinsic_copy", issue = "80697")]
+        #[rustc_const_stable(feature = "const_intrinsic_copy", since = "1.63.0")]
         fn copy_nonoverlapping<T>(src: *const T, dst: *mut T, count: usize);
     }
 
@@ -1284,7 +1284,7 @@ pub const unsafe fn write<T>(dst: *mut T, src: T) {
     // We are calling the intrinsics directly to avoid function calls in the generated code
     // as `intrinsics::copy_nonoverlapping` is a wrapper function.
     extern "rust-intrinsic" {
-        #[rustc_const_unstable(feature = "const_intrinsic_copy", issue = "80697")]
+        #[rustc_const_stable(feature = "const_intrinsic_copy", since = "1.63.0")]
         fn copy_nonoverlapping<T>(src: *const T, dst: *mut T, count: usize);
     }
 

--- a/library/core/src/ptr/mut_ptr.rs
+++ b/library/core/src/ptr/mut_ptr.rs
@@ -1309,7 +1309,7 @@ impl<T: ?Sized> *mut T {
     /// See [`ptr::copy`] for safety concerns and examples.
     ///
     /// [`ptr::copy`]: crate::ptr::copy()
-    #[rustc_const_unstable(feature = "const_intrinsic_copy", issue = "80697")]
+    #[rustc_const_stable(feature = "const_intrinsic_copy", since = "1.63.0")]
     #[stable(feature = "pointer_methods", since = "1.26.0")]
     #[inline(always)]
     pub const unsafe fn copy_to(self, dest: *mut T, count: usize)
@@ -1328,7 +1328,7 @@ impl<T: ?Sized> *mut T {
     /// See [`ptr::copy_nonoverlapping`] for safety concerns and examples.
     ///
     /// [`ptr::copy_nonoverlapping`]: crate::ptr::copy_nonoverlapping()
-    #[rustc_const_unstable(feature = "const_intrinsic_copy", issue = "80697")]
+    #[rustc_const_stable(feature = "const_intrinsic_copy", since = "1.63.0")]
     #[stable(feature = "pointer_methods", since = "1.26.0")]
     #[inline(always)]
     pub const unsafe fn copy_to_nonoverlapping(self, dest: *mut T, count: usize)
@@ -1347,7 +1347,7 @@ impl<T: ?Sized> *mut T {
     /// See [`ptr::copy`] for safety concerns and examples.
     ///
     /// [`ptr::copy`]: crate::ptr::copy()
-    #[rustc_const_unstable(feature = "const_intrinsic_copy", issue = "80697")]
+    #[rustc_const_stable(feature = "const_intrinsic_copy", since = "1.63.0")]
     #[stable(feature = "pointer_methods", since = "1.26.0")]
     #[inline(always)]
     pub const unsafe fn copy_from(self, src: *const T, count: usize)
@@ -1366,7 +1366,7 @@ impl<T: ?Sized> *mut T {
     /// See [`ptr::copy_nonoverlapping`] for safety concerns and examples.
     ///
     /// [`ptr::copy_nonoverlapping`]: crate::ptr::copy_nonoverlapping()
-    #[rustc_const_unstable(feature = "const_intrinsic_copy", issue = "80697")]
+    #[rustc_const_stable(feature = "const_intrinsic_copy", since = "1.63.0")]
     #[stable(feature = "pointer_methods", since = "1.26.0")]
     #[inline(always)]
     pub const unsafe fn copy_from_nonoverlapping(self, src: *const T, count: usize)

--- a/library/core/tests/ptr.rs
+++ b/library/core/tests/ptr.rs
@@ -19,6 +19,7 @@ fn test_const_from_raw_parts() {
 #[test]
 fn test() {
     unsafe {
+        #[repr(C)]
         struct Pair {
             fst: isize,
             snd: isize,

--- a/src/test/ui/consts/copy-intrinsic.rs
+++ b/src/test/ui/consts/copy-intrinsic.rs
@@ -2,14 +2,14 @@
 
 // ignore-tidy-linelength
 #![feature(intrinsics, staged_api)]
-#![feature(const_mut_refs, const_intrinsic_copy)]
+#![feature(const_mut_refs)]
 use std::mem;
 
 extern "rust-intrinsic" {
-    #[rustc_const_unstable(feature = "const_intrinsic_copy", issue = "80697")]
+    #[rustc_const_stable(feature = "const_intrinsic_copy", since = "1.63.0")]
     fn copy_nonoverlapping<T>(src: *const T, dst: *mut T, count: usize);
 
-    #[rustc_const_unstable(feature = "const_intrinsic_copy", issue = "80697")]
+    #[rustc_const_stable(feature = "const_intrinsic_copy", since = "1.63.0")]
     fn copy<T>(src: *const T, dst: *mut T, count: usize);
 }
 

--- a/src/test/ui/consts/intrinsic_without_const_stab.rs
+++ b/src/test/ui/consts/intrinsic_without_const_stab.rs
@@ -1,8 +1,8 @@
-#![feature(intrinsics, staged_api, const_intrinsic_copy)]
+#![feature(intrinsics, staged_api)]
 #![stable(feature = "core", since = "1.6.0")]
 
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_const_unstable(feature = "const_intrinsic_copy", issue = "80697")]
+#[rustc_const_stable(feature = "const_intrinsic_copy", since = "1.63.0")]
 #[inline]
 pub const unsafe fn copy<T>(src: *const T, dst: *mut T, count: usize) {
     // Const stability attributes are not inherited from parent items.

--- a/src/test/ui/consts/intrinsic_without_const_stab_fail.rs
+++ b/src/test/ui/consts/intrinsic_without_const_stab_fail.rs
@@ -1,4 +1,4 @@
-#![feature(intrinsics, staged_api, const_intrinsic_copy)]
+#![feature(intrinsics, staged_api)]
 #![stable(feature = "core", since = "1.6.0")]
 
 extern "rust-intrinsic" {
@@ -6,7 +6,7 @@ extern "rust-intrinsic" {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_const_unstable(feature = "const_intrinsic_copy", issue = "80697")]
+#[rustc_const_stable(feature = "const_intrinsic_copy", since = "1.63.0")]
 #[inline]
 pub const unsafe fn stuff<T>(src: *const T, dst: *mut T, count: usize) {
     unsafe { copy(src, dst, count) } //~ ERROR cannot call non-const fn

--- a/src/test/ui/did_you_mean/use_instead_of_import.fixed
+++ b/src/test/ui/did_you_mean/use_instead_of_import.fixed
@@ -1,0 +1,15 @@
+// run-rustfix
+
+use std::{
+    //~^ ERROR expected item, found `import`
+    io::Write,
+    rc::Rc,
+};
+
+pub use std::io;
+//~^ ERROR expected item, found `using`
+
+fn main() {
+    let x = Rc::new(1);
+    let _ = write!(io::stdout(), "{:?}", x);
+}

--- a/src/test/ui/did_you_mean/use_instead_of_import.rs
+++ b/src/test/ui/did_you_mean/use_instead_of_import.rs
@@ -1,0 +1,15 @@
+// run-rustfix
+
+import std::{
+    //~^ ERROR expected item, found `import`
+    io::Write,
+    rc::Rc,
+};
+
+pub using std::io;
+//~^ ERROR expected item, found `using`
+
+fn main() {
+    let x = Rc::new(1);
+    let _ = write!(io::stdout(), "{:?}", x);
+}

--- a/src/test/ui/did_you_mean/use_instead_of_import.stderr
+++ b/src/test/ui/did_you_mean/use_instead_of_import.stderr
@@ -1,0 +1,14 @@
+error: expected item, found `import`
+  --> $DIR/use_instead_of_import.rs:3:1
+   |
+LL | import std::{
+   | ^^^^^^ help: items are imported using the `use` keyword
+
+error: expected item, found `using`
+  --> $DIR/use_instead_of_import.rs:9:5
+   |
+LL | pub using std::io;
+   |     ^^^^^ help: items are imported using the `use` keyword
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/parser/match-arm-without-braces.rs
+++ b/src/test/ui/parser/match-arm-without-braces.rs
@@ -45,9 +45,9 @@ fn main() {
           15;
     }
     match S::get(16) {
-        Some(Val::Foo) => 17
-        _ => 18, //~ ERROR expected one of
-    }
+        Some(Val::Foo) => 17 //~ ERROR expected `,` following `match` arm
+        _ => 18,
+    };
     match S::get(19) {
         Some(Val::Foo) =>
           20; //~ ERROR `match` arm body without braces

--- a/src/test/ui/parser/match-arm-without-braces.stderr
+++ b/src/test/ui/parser/match-arm-without-braces.stderr
@@ -52,15 +52,11 @@ LL ~           { 14;
 LL ~           15; }
    |
 
-error: expected one of `,`, `.`, `?`, `}`, or an operator, found reserved identifier `_`
-  --> $DIR/match-arm-without-braces.rs:49:9
+error: expected `,` following `match` arm
+  --> $DIR/match-arm-without-braces.rs:48:29
    |
 LL |         Some(Val::Foo) => 17
-   |                        --   - expected one of `,`, `.`, `?`, `}`, or an operator
-   |                        |
-   |                        while parsing the `match` arm starting here
-LL |         _ => 18,
-   |         ^ unexpected token
+   |                             ^ help: missing a comma here to end this `match` arm: `,`
 
 error: `match` arm body without braces
   --> $DIR/match-arm-without-braces.rs:53:11

--- a/src/test/ui/traits/vtable/issue-97381.rs
+++ b/src/test/ui/traits/vtable/issue-97381.rs
@@ -1,0 +1,30 @@
+use std::ops::Deref;
+trait MyTrait: Deref<Target = u32> {}
+struct MyStruct(u32);
+impl MyTrait for MyStruct {}
+impl Deref for MyStruct {
+    type Target = u32;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+fn get_concrete_value(i: u32) -> MyStruct {
+    MyStruct(i)
+}
+fn get_boxed_value(i: u32) -> Box<dyn MyTrait> {
+    Box::new(get_concrete_value(i))
+}
+fn main() {
+    let v = [1, 2, 3]
+        .iter()
+        .map(|i| get_boxed_value(*i))
+        .collect::<Vec<_>>();
+
+    let el = &v[0];
+
+    for _ in v {
+        //~^ ERROR cannot move out of `v` because it is borrowed
+        println!("{}", ***el > 0);
+    }
+}

--- a/src/test/ui/traits/vtable/issue-97381.stderr
+++ b/src/test/ui/traits/vtable/issue-97381.stderr
@@ -1,0 +1,15 @@
+error[E0505]: cannot move out of `v` because it is borrowed
+  --> $DIR/issue-97381.rs:26:14
+   |
+LL |     let el = &v[0];
+   |               - borrow of `v` occurs here
+LL | 
+LL |     for _ in v {
+   |              ^ move out of `v` occurs here
+LL |
+LL |         println!("{}", ***el > 0);
+   |                         ---- borrow later used here
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0505`.

--- a/src/test/ui/type/type-unsatisfiable.rs
+++ b/src/test/ui/type/type-unsatisfiable.rs
@@ -1,0 +1,59 @@
+// revisions: lib usage
+//[lib] compile-flags: --crate-type=lib
+//[lib] build-pass
+
+use std::ops::Sub;
+trait Vector2 {
+    type ScalarType;
+
+    fn from_values(x: Self::ScalarType, y: Self::ScalarType) -> Self
+    where
+        Self: Sized;
+
+    fn x(&self) -> Self::ScalarType;
+    fn y(&self) -> Self::ScalarType;
+}
+
+impl<T> Sub for dyn Vector2<ScalarType = T>
+where
+    T: Sub<Output = T>,
+    (dyn Vector2<ScalarType = T>): Sized,
+{
+    type Output = dyn Vector2<ScalarType = T>;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        Self::from_values(self.x() - rhs.x(), self.y() - rhs.y())
+    }
+}
+
+struct Vec2 {
+    x: i32,
+    y: i32,
+}
+
+impl Vector2 for Vec2 {
+    type ScalarType = i32;
+
+    fn from_values(x: Self::ScalarType, y: Self::ScalarType) -> Self
+    where
+        Self: Sized,
+    {
+        Self { x, y }
+    }
+
+    fn x(&self) -> Self::ScalarType {
+        self.x
+    }
+    fn y(&self) -> Self::ScalarType {
+        self.y
+    }
+}
+
+#[cfg(usage)]
+fn main() {
+    let hey: Box<dyn Vector2<ScalarType = i32>> = Box::new(Vec2 { x: 1, y: 2 });
+    let word: Box<dyn Vector2<ScalarType = i32>> = Box::new(Vec2 { x: 1, y: 2 });
+
+    let bar = *hey - *word;
+    //[usage]~^ ERROR cannot subtract
+}

--- a/src/test/ui/type/type-unsatisfiable.usage.stderr
+++ b/src/test/ui/type/type-unsatisfiable.usage.stderr
@@ -1,0 +1,11 @@
+error[E0369]: cannot subtract `(dyn Vector2<ScalarType = i32> + 'static)` from `dyn Vector2<ScalarType = i32>`
+  --> $DIR/type-unsatisfiable.rs:57:20
+   |
+LL |     let bar = *hey - *word;
+   |               ---- ^ ----- (dyn Vector2<ScalarType = i32> + 'static)
+   |               |
+   |               dyn Vector2<ScalarType = i32>
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0369`.


### PR DESCRIPTION
Successful merges:

 - #97276 (Stabilize `const_intrinsic_copy`)
 - #97595 (Remove unwrap from get_vtable)
 - #97819 (Recover `import` instead of `use` in item)
 - #97823 (Recover missing comma after match arm)
 - #97851 (Use repr(C) when depending on struct layout in ptr tests)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=97276,97595,97819,97823,97851)
<!-- homu-ignore:end -->