### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/compiler/rustc_mir_dataflow/src/impls/liveness.rs
+++ b/compiler/rustc_mir_dataflow/src/impls/liveness.rs
@@ -244,13 +244,10 @@ impl<'a, 'tcx> Analysis<'tcx> for MaybeTransitiveLiveLocals<'a> {
         // Compute the place that we are storing to, if any
         let destination = match &statement.kind {
             StatementKind::Assign(assign) => {
-                if assign.1.is_pointer_int_cast() {
-                    // Pointer to int casts may be side-effects due to exposing the provenance.
-                    // While the model is undecided, we should be conservative. See
-                    // <https://www.ralfj.de/blog/2022/04/11/provenance-exposed.html>
-                    None
-                } else {
+                if assign.1.is_safe_to_remove() {
                     Some(assign.0)
+                } else {
+                    None
                 }
             }
             StatementKind::SetDiscriminant { place, .. } | StatementKind::Deinit(place) => {

--- a/compiler/rustc_mir_transform/src/dead_store_elimination.rs
+++ b/compiler/rustc_mir_transform/src/dead_store_elimination.rs
@@ -34,7 +34,7 @@ pub fn eliminate<'tcx>(tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>, borrowed: &BitS
         for (statement_index, statement) in bb_data.statements.iter().enumerate().rev() {
             let loc = Location { block: bb, statement_index };
             if let StatementKind::Assign(assign) = &statement.kind {
-                if assign.1.is_pointer_int_cast() {
+                if !assign.1.is_safe_to_remove() {
                     continue;
                 }
             }

--- a/compiler/rustc_mir_transform/src/simplify.rs
+++ b/compiler/rustc_mir_transform/src/simplify.rs
@@ -494,8 +494,12 @@ impl<'tcx> Visitor<'tcx> for UsedLocals {
             StatementKind::StorageLive(_local) | StatementKind::StorageDead(_local) => {}
 
             StatementKind::Assign(box (ref place, ref rvalue)) => {
-                self.visit_lhs(place, location);
-                self.visit_rvalue(rvalue, location);
+                if rvalue.is_safe_to_remove() {
+                    self.visit_lhs(place, location);
+                    self.visit_rvalue(rvalue, location);
+                } else {
+                    self.super_statement(statement, location);
+                }
             }
 
             StatementKind::SetDiscriminant { ref place, variant_index: _ }

--- a/compiler/rustc_ty_utils/src/instance.rs
+++ b/compiler/rustc_ty_utils/src/instance.rs
@@ -347,11 +347,15 @@ fn resolve_associated_item<'tcx>(
             _ => None,
         },
         traits::ImplSource::Object(ref data) => {
-            let index = traits::get_vtable_index_of_object_method(tcx, data, trait_item_id);
-            Some(Instance {
-                def: ty::InstanceDef::Virtual(trait_item_id, index),
-                substs: rcvr_substs,
-            })
+            if let Some(index) = traits::get_vtable_index_of_object_method(tcx, data, trait_item_id)
+            {
+                Some(Instance {
+                    def: ty::InstanceDef::Virtual(trait_item_id, index),
+                    substs: rcvr_substs,
+                })
+            } else {
+                None
+            }
         }
         traits::ImplSource::Builtin(..) => {
             if Some(trait_ref.def_id) == tcx.lang_items().clone_trait() {

--- a/library/core/tests/ptr.rs
+++ b/library/core/tests/ptr.rs
@@ -19,6 +19,7 @@ fn test_const_from_raw_parts() {
 #[test]
 fn test() {
     unsafe {
+        #[repr(C)]
         struct Pair {
             fst: isize,
             snd: isize,

--- a/src/test/mir-opt/simplify-locals.rs
+++ b/src/test/mir-opt/simplify-locals.rs
@@ -62,6 +62,12 @@ fn t4() -> u32 {
     unsafe { X + 1 }
 }
 
+// EMIT_MIR simplify_locals.expose_addr.SimplifyLocals.diff
+fn expose_addr(p: *const usize) {
+    // Used pointer to address cast. Has a side effect of exposing the provenance.
+    p as usize;
+}
+
 fn main() {
     c();
     d1();
@@ -71,4 +77,5 @@ fn main() {
     t2();
     t3();
     t4();
+    expose_addr(&0);
 }

--- a/src/test/mir-opt/simplify_locals.expose_addr.SimplifyLocals.diff
+++ b/src/test/mir-opt/simplify_locals.expose_addr.SimplifyLocals.diff
@@ -1,0 +1,21 @@
+- // MIR for `expose_addr` before SimplifyLocals
++ // MIR for `expose_addr` after SimplifyLocals
+  
+  fn expose_addr(_1: *const usize) -> () {
+      debug p => _1;                       // in scope 0 at $DIR/simplify-locals.rs:66:16: 66:17
+      let mut _0: ();                      // return place in scope 0 at $DIR/simplify-locals.rs:66:33: 66:33
+      let _2: usize;                       // in scope 0 at $DIR/simplify-locals.rs:68:5: 68:15
+      let mut _3: *const usize;            // in scope 0 at $DIR/simplify-locals.rs:68:5: 68:6
+  
+      bb0: {
+          StorageLive(_2);                 // scope 0 at $DIR/simplify-locals.rs:68:5: 68:15
+          StorageLive(_3);                 // scope 0 at $DIR/simplify-locals.rs:68:5: 68:6
+          _3 = _1;                         // scope 0 at $DIR/simplify-locals.rs:68:5: 68:6
+          _2 = move _3 as usize (PointerExposeAddress); // scope 0 at $DIR/simplify-locals.rs:68:5: 68:15
+          StorageDead(_3);                 // scope 0 at $DIR/simplify-locals.rs:68:14: 68:15
+          StorageDead(_2);                 // scope 0 at $DIR/simplify-locals.rs:68:15: 68:16
+          _0 = const ();                   // scope 0 at $DIR/simplify-locals.rs:66:33: 69:2
+          return;                          // scope 0 at $DIR/simplify-locals.rs:69:2: 69:2
+      }
+  }
+  

--- a/src/test/ui/did_you_mean/use_instead_of_import.fixed
+++ b/src/test/ui/did_you_mean/use_instead_of_import.fixed
@@ -1,0 +1,15 @@
+// run-rustfix
+
+use std::{
+    //~^ ERROR expected item, found `import`
+    io::Write,
+    rc::Rc,
+};
+
+pub use std::io;
+//~^ ERROR expected item, found `using`
+
+fn main() {
+    let x = Rc::new(1);
+    let _ = write!(io::stdout(), "{:?}", x);
+}

--- a/src/test/ui/did_you_mean/use_instead_of_import.rs
+++ b/src/test/ui/did_you_mean/use_instead_of_import.rs
@@ -1,0 +1,15 @@
+// run-rustfix
+
+import std::{
+    //~^ ERROR expected item, found `import`
+    io::Write,
+    rc::Rc,
+};
+
+pub using std::io;
+//~^ ERROR expected item, found `using`
+
+fn main() {
+    let x = Rc::new(1);
+    let _ = write!(io::stdout(), "{:?}", x);
+}

--- a/src/test/ui/did_you_mean/use_instead_of_import.stderr
+++ b/src/test/ui/did_you_mean/use_instead_of_import.stderr
@@ -1,0 +1,14 @@
+error: expected item, found `import`
+  --> $DIR/use_instead_of_import.rs:3:1
+   |
+LL | import std::{
+   | ^^^^^^ help: items are imported using the `use` keyword
+
+error: expected item, found `using`
+  --> $DIR/use_instead_of_import.rs:9:5
+   |
+LL | pub using std::io;
+   |     ^^^^^ help: items are imported using the `use` keyword
+
+error: aborting due to 2 previous errors
+

--- a/src/test/ui/parser/match-arm-without-braces.rs
+++ b/src/test/ui/parser/match-arm-without-braces.rs
@@ -45,9 +45,9 @@ fn main() {
           15;
     }
     match S::get(16) {
-        Some(Val::Foo) => 17
-        _ => 18, //~ ERROR expected one of
-    }
+        Some(Val::Foo) => 17 //~ ERROR expected `,` following `match` arm
+        _ => 18,
+    };
     match S::get(19) {
         Some(Val::Foo) =>
           20; //~ ERROR `match` arm body without braces

--- a/src/test/ui/parser/match-arm-without-braces.stderr
+++ b/src/test/ui/parser/match-arm-without-braces.stderr
@@ -52,15 +52,11 @@ LL ~           { 14;
 LL ~           15; }
    |
 
-error: expected one of `,`, `.`, `?`, `}`, or an operator, found reserved identifier `_`
-  --> $DIR/match-arm-without-braces.rs:49:9
+error: expected `,` following `match` arm
+  --> $DIR/match-arm-without-braces.rs:48:29
    |
 LL |         Some(Val::Foo) => 17
-   |                        --   - expected one of `,`, `.`, `?`, `}`, or an operator
-   |                        |
-   |                        while parsing the `match` arm starting here
-LL |         _ => 18,
-   |         ^ unexpected token
+   |                             ^ help: missing a comma here to end this `match` arm: `,`
 
 error: `match` arm body without braces
   --> $DIR/match-arm-without-braces.rs:53:11

--- a/src/test/ui/traits/vtable/issue-97381.rs
+++ b/src/test/ui/traits/vtable/issue-97381.rs
@@ -1,0 +1,30 @@
+use std::ops::Deref;
+trait MyTrait: Deref<Target = u32> {}
+struct MyStruct(u32);
+impl MyTrait for MyStruct {}
+impl Deref for MyStruct {
+    type Target = u32;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+fn get_concrete_value(i: u32) -> MyStruct {
+    MyStruct(i)
+}
+fn get_boxed_value(i: u32) -> Box<dyn MyTrait> {
+    Box::new(get_concrete_value(i))
+}
+fn main() {
+    let v = [1, 2, 3]
+        .iter()
+        .map(|i| get_boxed_value(*i))
+        .collect::<Vec<_>>();
+
+    let el = &v[0];
+
+    for _ in v {
+        //~^ ERROR cannot move out of `v` because it is borrowed
+        println!("{}", ***el > 0);
+    }
+}

--- a/src/test/ui/traits/vtable/issue-97381.stderr
+++ b/src/test/ui/traits/vtable/issue-97381.stderr
@@ -1,0 +1,15 @@
+error[E0505]: cannot move out of `v` because it is borrowed
+  --> $DIR/issue-97381.rs:26:14
+   |
+LL |     let el = &v[0];
+   |               - borrow of `v` occurs here
+LL | 
+LL |     for _ in v {
+   |              ^ move out of `v` occurs here
+LL |
+LL |         println!("{}", ***el > 0);
+   |                         ---- borrow later used here
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0505`.

--- a/src/test/ui/type/type-unsatisfiable.rs
+++ b/src/test/ui/type/type-unsatisfiable.rs
@@ -1,0 +1,59 @@
+// revisions: lib usage
+//[lib] compile-flags: --crate-type=lib
+//[lib] build-pass
+
+use std::ops::Sub;
+trait Vector2 {
+    type ScalarType;
+
+    fn from_values(x: Self::ScalarType, y: Self::ScalarType) -> Self
+    where
+        Self: Sized;
+
+    fn x(&self) -> Self::ScalarType;
+    fn y(&self) -> Self::ScalarType;
+}
+
+impl<T> Sub for dyn Vector2<ScalarType = T>
+where
+    T: Sub<Output = T>,
+    (dyn Vector2<ScalarType = T>): Sized,
+{
+    type Output = dyn Vector2<ScalarType = T>;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        Self::from_values(self.x() - rhs.x(), self.y() - rhs.y())
+    }
+}
+
+struct Vec2 {
+    x: i32,
+    y: i32,
+}
+
+impl Vector2 for Vec2 {
+    type ScalarType = i32;
+
+    fn from_values(x: Self::ScalarType, y: Self::ScalarType) -> Self
+    where
+        Self: Sized,
+    {
+        Self { x, y }
+    }
+
+    fn x(&self) -> Self::ScalarType {
+        self.x
+    }
+    fn y(&self) -> Self::ScalarType {
+        self.y
+    }
+}
+
+#[cfg(usage)]
+fn main() {
+    let hey: Box<dyn Vector2<ScalarType = i32>> = Box::new(Vec2 { x: 1, y: 2 });
+    let word: Box<dyn Vector2<ScalarType = i32>> = Box::new(Vec2 { x: 1, y: 2 });
+
+    let bar = *hey - *word;
+    //[usage]~^ ERROR cannot subtract
+}

--- a/src/test/ui/type/type-unsatisfiable.usage.stderr
+++ b/src/test/ui/type/type-unsatisfiable.usage.stderr
@@ -1,0 +1,11 @@
+error[E0369]: cannot subtract `(dyn Vector2<ScalarType = i32> + 'static)` from `dyn Vector2<ScalarType = i32>`
+  --> $DIR/type-unsatisfiable.rs:57:20
+   |
+LL |     let bar = *hey - *word;
+   |               ---- ^ ----- (dyn Vector2<ScalarType = i32> + 'static)
+   |               |
+   |               dyn Vector2<ScalarType = i32>
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0369`.


### PR DESCRIPTION
Successful merges:

 - #97595 (Remove unwrap from get_vtable)
 - #97597 (Preserve unused pointer to address casts)
 - #97819 (Recover `import` instead of `use` in item)
 - #97823 (Recover missing comma after match arm)
 - #97851 (Use repr(C) when depending on struct layout in ptr tests)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=97595,97597,97819,97823,97851)
<!-- homu-ignore:end -->