### PR TITLE
optimize `superset` method of `IntervalSet`

### DIFF
--- a/compiler/rustc_index/src/interval.rs
+++ b/compiler/rustc_index/src/interval.rs
@@ -203,7 +203,9 @@ impl<I: Idx> IntervalSet<I> {
 
     pub fn insert_all(&mut self) {
         self.clear();
-        self.map.push((0, self.domain.try_into().unwrap()));
+        if let Some(end) = self.domain.checked_sub(1) {
+            self.map.push((0, end.try_into().unwrap()));
+        }
         debug_assert!(self.check_invariants());
     }
 

--- a/compiler/rustc_index/src/interval/tests.rs
+++ b/compiler/rustc_index/src/interval/tests.rs
@@ -2,7 +2,7 @@ use super::*;
 
 #[test]
 fn insert_collapses() {
-    let mut set = IntervalSet::<u32>::new(3000);
+    let mut set = IntervalSet::<u32>::new(10000);
     set.insert_range(9831..=9837);
     set.insert_range(43..=9830);
     assert_eq!(set.iter_intervals().collect::<Vec<_>>(), [43..9838]);


### PR DESCRIPTION
Given that intervals in the `IntervalSet` are sorted and strictly separated( it means the `end` of the previous interval will not be equal to the `start` of the next interval), we can reduce the complexity of the `superset` method from O(NMlogN) to O(2N) (N is the number of intervals and M is the length of each interval)