### PR TITLE
lub: don't bail out due to empty binders

### DIFF
--- a/compiler/rustc_infer/src/infer/glb.rs
+++ b/compiler/rustc_infer/src/infer/glb.rs
@@ -95,12 +95,20 @@ impl<'tcx> TypeRelation<'tcx> for Glb<'_, '_, 'tcx> {
         T: Relate<'tcx>,
     {
         debug!("binders(a={:?}, b={:?})", a, b);
-
-        // When higher-ranked types are involved, computing the LUB is
-        // very challenging, switch to invariance. This is obviously
-        // overly conservative but works ok in practice.
-        self.relate_with_variance(ty::Variance::Invariant, ty::VarianceDiagInfo::default(), a, b)?;
-        Ok(a)
+        if a.skip_binder().has_escaping_bound_vars() || b.skip_binder().has_escaping_bound_vars() {
+            // When higher-ranked types are involved, computing the GLB is
+            // very challenging, switch to invariance. This is obviously
+            // overly conservative but works ok in practice.
+            self.relate_with_variance(
+                ty::Variance::Invariant,
+                ty::VarianceDiagInfo::default(),
+                a,
+                b,
+            )?;
+            Ok(a)
+        } else {
+            Ok(ty::Binder::dummy(self.relate(a.skip_binder(), b.skip_binder())?))
+        }
     }
 }
 

--- a/compiler/rustc_infer/src/infer/lub.rs
+++ b/compiler/rustc_infer/src/infer/lub.rs
@@ -95,12 +95,20 @@ impl<'tcx> TypeRelation<'tcx> for Lub<'_, '_, 'tcx> {
         T: Relate<'tcx>,
     {
         debug!("binders(a={:?}, b={:?})", a, b);
-
-        // When higher-ranked types are involved, computing the LUB is
-        // very challenging, switch to invariance. This is obviously
-        // overly conservative but works ok in practice.
-        self.relate_with_variance(ty::Variance::Invariant, ty::VarianceDiagInfo::default(), a, b)?;
-        Ok(a)
+        if a.skip_binder().has_escaping_bound_vars() || b.skip_binder().has_escaping_bound_vars() {
+            // When higher-ranked types are involved, computing the LUB is
+            // very challenging, switch to invariance. This is obviously
+            // overly conservative but works ok in practice.
+            self.relate_with_variance(
+                ty::Variance::Invariant,
+                ty::VarianceDiagInfo::default(),
+                a,
+                b,
+            )?;
+            Ok(a)
+        } else {
+            Ok(ty::Binder::dummy(self.relate(a.skip_binder(), b.skip_binder())?))
+        }
     }
 }
 

--- a/src/test/ui/lub-glb/empty-binder-future-compat.rs
+++ b/src/test/ui/lub-glb/empty-binder-future-compat.rs
@@ -1,0 +1,22 @@
+// check-pass
+fn lt_in_fn_fn<'a: 'a>() -> fn(fn(&'a ())) {
+    |_| ()
+}
+
+
+fn foo<'a, 'b, 'lower>(v: bool)
+where
+    'a: 'lower,
+    'b: 'lower,
+{
+        // if we infer `x` to be higher ranked in the future,
+        // this would cause a type error.
+        let x = match v {
+            true => lt_in_fn_fn::<'a>(),
+            false => lt_in_fn_fn::<'b>(),
+        };
+
+        let _: fn(fn(&'lower())) = x;
+}
+
+fn main() {}

--- a/src/test/ui/lub-glb/empty-binders-err.rs
+++ b/src/test/ui/lub-glb/empty-binders-err.rs
@@ -11,12 +11,10 @@ fn lt_in_contra<'a: 'a>() -> Contra<'a> {
     Contra(|_| ())
 }
 
-fn covariance<'a, 'b, 'upper, 'lower>(v: bool)
+fn covariance<'a, 'b, 'upper>(v: bool)
 where
     'upper: 'a,
     'upper: 'b,
-    'a: 'lower,
-    'b: 'lower,
 
 {
     let _: &'upper () = match v {
@@ -27,10 +25,8 @@ where
     };
 }
 
-fn contra_fn<'a, 'b, 'upper, 'lower>(v: bool)
+fn contra_fn<'a, 'b, 'lower>(v: bool)
 where
-    'upper: 'a,
-    'upper: 'b,
     'a: 'lower,
     'b: 'lower,
 
@@ -43,10 +39,8 @@ where
     };
 }
 
-fn contra_struct<'a, 'b, 'upper, 'lower>(v: bool)
+fn contra_struct<'a, 'b, 'lower>(v: bool)
 where
-    'upper: 'a,
-    'upper: 'b,
     'a: 'lower,
     'b: 'lower,
 

--- a/src/test/ui/lub-glb/empty-binders-err.rs
+++ b/src/test/ui/lub-glb/empty-binders-err.rs
@@ -1,0 +1,61 @@
+fn lt<'a: 'a>() -> &'a () {
+    &()
+}
+
+fn lt_in_fn<'a: 'a>() -> fn(&'a ()) {
+    |_| ()
+}
+
+struct Contra<'a>(fn(&'a ()));
+fn lt_in_contra<'a: 'a>() -> Contra<'a> {
+    Contra(|_| ())
+}
+
+fn covariance<'a, 'b, 'upper, 'lower>(v: bool)
+where
+    'upper: 'a,
+    'upper: 'b,
+    'a: 'lower,
+    'b: 'lower,
+
+{
+    let _: &'upper () = match v {
+        //~^ ERROR lifetime may not live long enough
+        //~| ERROR lifetime may not live long enough
+        true => lt::<'a>(),
+        false => lt::<'b>(),
+    };
+}
+
+fn contra_fn<'a, 'b, 'upper, 'lower>(v: bool)
+where
+    'upper: 'a,
+    'upper: 'b,
+    'a: 'lower,
+    'b: 'lower,
+
+{
+
+    let _: fn(&'lower ()) = match v {
+        //~^ ERROR lifetime may not live long enough
+        true => lt_in_fn::<'a>(),
+        false => lt_in_fn::<'b>(),
+    };
+}
+
+fn contra_struct<'a, 'b, 'upper, 'lower>(v: bool)
+where
+    'upper: 'a,
+    'upper: 'b,
+    'a: 'lower,
+    'b: 'lower,
+
+{
+    let _: Contra<'lower> = match v {
+        //~^ ERROR lifetime may not live long enough
+        true => lt_in_contra::<'a>(),
+        false => lt_in_contra::<'b>(),
+    };
+}
+
+fn main() {}

--- a/src/test/ui/lub-glb/empty-binders-err.stderr
+++ b/src/test/ui/lub-glb/empty-binders-err.stderr
@@ -1,0 +1,59 @@
+error: lifetime may not live long enough
+  --> $DIR/empty-binders-err.rs:22:12
+   |
+LL | fn covariance<'a, 'b, 'upper, 'lower>(v: bool)
+   |               --      ------ lifetime `'upper` defined here
+   |               |
+   |               lifetime `'a` defined here
+...
+LL |     let _: &'upper () = match v {
+   |            ^^^^^^^^^^ type annotation requires that `'a` must outlive `'upper`
+   |
+   = help: consider adding the following bound: `'a: 'upper`
+
+error: lifetime may not live long enough
+  --> $DIR/empty-binders-err.rs:22:12
+   |
+LL | fn covariance<'a, 'b, 'upper, 'lower>(v: bool)
+   |                   --  ------ lifetime `'upper` defined here
+   |                   |
+   |                   lifetime `'b` defined here
+...
+LL |     let _: &'upper () = match v {
+   |            ^^^^^^^^^^ type annotation requires that `'b` must outlive `'upper`
+   |
+   = help: consider adding the following bound: `'b: 'upper`
+
+help: the following changes may resolve your lifetime errors
+   |
+   = help: add bound `'a: 'upper`
+   = help: add bound `'b: 'upper`
+
+error: lifetime may not live long enough
+  --> $DIR/empty-binders-err.rs:39:12
+   |
+LL | fn contra_fn<'a, 'b, 'upper, 'lower>(v: bool)
+   |              --              ------ lifetime `'lower` defined here
+   |              |
+   |              lifetime `'a` defined here
+...
+LL |     let _: fn(&'lower ()) = match v {
+   |            ^^^^^^^^^^^^^^ type annotation requires that `'lower` must outlive `'a`
+   |
+   = help: consider adding the following bound: `'lower: 'a`
+
+error: lifetime may not live long enough
+  --> $DIR/empty-binders-err.rs:54:12
+   |
+LL | fn contra_struct<'a, 'b, 'upper, 'lower>(v: bool)
+   |                  --              ------ lifetime `'lower` defined here
+   |                  |
+   |                  lifetime `'a` defined here
+...
+LL |     let _: Contra<'lower> = match v {
+   |            ^^^^^^^^^^^^^^ type annotation requires that `'lower` must outlive `'a`
+   |
+   = help: consider adding the following bound: `'lower: 'a`
+
+error: aborting due to 4 previous errors
+

--- a/src/test/ui/lub-glb/empty-binders-err.stderr
+++ b/src/test/ui/lub-glb/empty-binders-err.stderr
@@ -1,7 +1,7 @@
 error: lifetime may not live long enough
-  --> $DIR/empty-binders-err.rs:22:12
+  --> $DIR/empty-binders-err.rs:20:12
    |
-LL | fn covariance<'a, 'b, 'upper, 'lower>(v: bool)
+LL | fn covariance<'a, 'b, 'upper>(v: bool)
    |               --      ------ lifetime `'upper` defined here
    |               |
    |               lifetime `'a` defined here
@@ -12,9 +12,9 @@ LL |     let _: &'upper () = match v {
    = help: consider adding the following bound: `'a: 'upper`
 
 error: lifetime may not live long enough
-  --> $DIR/empty-binders-err.rs:22:12
+  --> $DIR/empty-binders-err.rs:20:12
    |
-LL | fn covariance<'a, 'b, 'upper, 'lower>(v: bool)
+LL | fn covariance<'a, 'b, 'upper>(v: bool)
    |                   --  ------ lifetime `'upper` defined here
    |                   |
    |                   lifetime `'b` defined here
@@ -30,10 +30,10 @@ help: the following changes may resolve your lifetime errors
    = help: add bound `'b: 'upper`
 
 error: lifetime may not live long enough
-  --> $DIR/empty-binders-err.rs:39:12
+  --> $DIR/empty-binders-err.rs:35:12
    |
-LL | fn contra_fn<'a, 'b, 'upper, 'lower>(v: bool)
-   |              --              ------ lifetime `'lower` defined here
+LL | fn contra_fn<'a, 'b, 'lower>(v: bool)
+   |              --      ------ lifetime `'lower` defined here
    |              |
    |              lifetime `'a` defined here
 ...
@@ -43,10 +43,10 @@ LL |     let _: fn(&'lower ()) = match v {
    = help: consider adding the following bound: `'lower: 'a`
 
 error: lifetime may not live long enough
-  --> $DIR/empty-binders-err.rs:54:12
+  --> $DIR/empty-binders-err.rs:48:12
    |
-LL | fn contra_struct<'a, 'b, 'upper, 'lower>(v: bool)
-   |                  --              ------ lifetime `'lower` defined here
+LL | fn contra_struct<'a, 'b, 'lower>(v: bool)
+   |                  --      ------ lifetime `'lower` defined here
    |                  |
    |                  lifetime `'a` defined here
 ...

--- a/src/test/ui/lub-glb/empty-binders.rs
+++ b/src/test/ui/lub-glb/empty-binders.rs
@@ -1,0 +1,45 @@
+// check-pass
+//
+// Check that computing the lub works even for empty binders.
+fn lt<'a: 'a>() -> &'a () {
+    &()
+}
+
+fn lt_in_fn<'a: 'a>() -> fn(&'a ()) {
+    |_| ()
+}
+
+struct Contra<'a>(fn(&'a ()));
+fn lt_in_contra<'a: 'a>() -> Contra<'a> {
+    Contra(|_| ())
+}
+
+fn ok<'a, 'b, 'upper, 'lower>(v: bool)
+where
+    'upper: 'a,
+    'upper: 'b,
+    'a: 'lower,
+    'b: 'lower,
+
+{
+    let _: &'lower () = match v {
+        true => lt::<'a>(),
+        false => lt::<'b>(),
+    };
+
+    // This errored in the past because LUB and GLB always
+    // bailed out when encountering binders, even if they were
+    // empty.
+    let _: fn(&'upper ()) = match v {
+        true => lt_in_fn::<'a>(),
+        false => lt_in_fn::<'b>(),
+    };
+
+    // This was already accepted, as relate didn't encounter any binders.
+    let _: Contra<'upper> = match v {
+        true => lt_in_contra::<'a>(),
+        false => lt_in_contra::<'b>(),
+    };
+}
+
+fn main() {}


### PR DESCRIPTION
allows for the following to compile. The equivalent code using `struct Wrapper<'upper>(fn(&'upper ());` already compiles on stable. 
```rust
let _: fn(&'upper ()) = match v {
    true => lt_in_fn::<'a>(),
    false => lt_in_fn::<'b>(),
};
```
see https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=7034a677190110941223cafac6632f70 for a complete example

r? @rust-lang/types 