### PR TITLE
Suggest using `iter()` or `into_iter()` for `Vec`

### DIFF
--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -41,6 +41,10 @@ fn _assert_is_object_safe(_: &dyn Iterator<Item = ()>) {}
     ),
     on(_Self = "&[]", label = "`{Self}` is not an iterator; try calling `.iter()`"),
     on(
+        _Self = "std::vec::Vec<T, A>",
+        label = "`{Self}` is not an iterator; try calling `.into_iter()` or `.iter()`"
+    ),
+    on(
         _Self = "&str",
         label = "`{Self}` is not an iterator; try calling `.chars()` or `.bytes()`"
     ),

--- a/src/test/ui/iterators/vec-on-unimplemented.rs
+++ b/src/test/ui/iterators/vec-on-unimplemented.rs
@@ -1,0 +1,4 @@
+fn main() {
+    vec![true, false].map(|v| !v).collect::<Vec<_>>();
+    //~^ ERROR `Vec<bool>` is not an iterator
+}

--- a/src/test/ui/iterators/vec-on-unimplemented.stderr
+++ b/src/test/ui/iterators/vec-on-unimplemented.stderr
@@ -1,0 +1,20 @@
+error[E0599]: `Vec<bool>` is not an iterator
+  --> $DIR/vec-on-unimplemented.rs:2:23
+   |
+LL |     vec![true, false].map(|v| !v).collect::<Vec<_>>();
+   |                       ^^^ `Vec<bool>` is not an iterator; try calling `.into_iter()` or `.iter()`
+   |
+  ::: $SRC_DIR/alloc/src/vec/mod.rs:LL:COL
+   |
+LL | pub struct Vec<T, #[unstable(feature = "allocator_api", issue = "32838")] A: Allocator = Global> {
+   | ------------------------------------------------------------------------------------------------ doesn't satisfy `Vec<bool>: Iterator`
+   |
+   = note: the following trait bounds were not satisfied:
+           `Vec<bool>: Iterator`
+           which is required by `&mut Vec<bool>: Iterator`
+           `[bool]: Iterator`
+           which is required by `&mut [bool]: Iterator`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0599`.


### PR DESCRIPTION
We cannot do that for `&Vec` because `#[rustc_on_unimplemented]` is limited (it does not clean generic instantiation for references, only for ADTs).

@rustbot label +A-diagnostics