### PR TITLE
remove unneeded code

### DIFF
--- a/library/std/src/sys/hermit/condvar.rs
+++ b/library/std/src/sys/hermit/condvar.rs
@@ -24,11 +24,6 @@ impl Condvar {
         Condvar { counter: AtomicUsize::new(0), sem1: ptr::null(), sem2: ptr::null() }
     }
 
-    pub unsafe fn init(&mut self) {
-        let _ = abi::sem_init(&mut self.sem1 as *mut *const c_void, 0);
-        let _ = abi::sem_init(&mut self.sem2 as *mut *const c_void, 0);
-    }
-
     pub unsafe fn notify_one(&self) {
         if self.counter.load(SeqCst) > 0 {
             self.counter.fetch_sub(1, SeqCst);


### PR DESCRIPTION
The init function isn't longer part of `Condvar`. Consequently, we removed the implementation for the target os `hermit`.