### PR TITLE
Remove `ignore-compare-mode-nll` annotations from tests

### DIFF
--- a/src/test/ui/json-multiple.rs
+++ b/src/test/ui/json-multiple.rs
@@ -1,6 +1,5 @@
 // build-pass
 // ignore-pass (different metadata emitted in different modes)
 // compile-flags: --json=diagnostic-short --json artifacts --error-format=json
-// ignore-compare-mode-nll
 
 #![crate_type = "lib"]

--- a/src/test/ui/json-options.rs
+++ b/src/test/ui/json-options.rs
@@ -1,6 +1,5 @@
 // build-pass
 // ignore-pass (different metadata emitted in different modes)
 // compile-flags: --json=diagnostic-short,artifacts --error-format=json
-// ignore-compare-mode-nll
 
 #![crate_type = "lib"]

--- a/src/test/ui/rmeta/emit-artifact-notifications.rs
+++ b/src/test/ui/rmeta/emit-artifact-notifications.rs
@@ -2,7 +2,6 @@
 // build-pass
 // ignore-pass
 // ^-- needed because `--pass check` does not emit the output needed.
-// ignore-compare-mode-nll
 
 // A very basic test for the emission of artifact notifications in JSON output.
 

--- a/src/test/ui/save-analysis/emit-notifications.rs
+++ b/src/test/ui/save-analysis/emit-notifications.rs
@@ -3,6 +3,5 @@
 // compile-flags: --crate-type rlib --error-format=json
 // ignore-pass
 // ^-- needed because otherwise, the .stderr file changes with --pass check
-// ignore-compare-mode-nll
 
 pub fn foo() {}


### PR DESCRIPTION
Since #95565 these do nothing as compare-mode-nll has been removed.
r? @jackh726 