### PR TITLE
Don't use __gxx_personality_v0 in panic_unwind on emscripten target

### DIFF
--- a/library/panic_unwind/src/emcc.rs
+++ b/library/panic_unwind/src/emcc.rs
@@ -111,11 +111,11 @@ extern "C" fn exception_cleanup(ptr: *mut libc::c_void) -> *mut libc::c_void {
 // Wasm error handling would use __gxx_personality_wasm0.
 #[lang = "eh_personality"]
 unsafe extern "C" fn rust_eh_personality(
-    version: c_int,
-    actions: uw::_Unwind_Action,
-    exception_class: uw::_Unwind_Exception_Class,
-    exception_object: *mut uw::_Unwind_Exception,
-    context: *mut uw::_Unwind_Context,
+    _version: c_int,
+    _actions: uw::_Unwind_Action,
+    _exception_class: uw::_Unwind_Exception_Class,
+    _exception_object: *mut uw::_Unwind_Exception,
+    _context: *mut uw::_Unwind_Context,
 ) -> uw::_Unwind_Reason_Code {
     core::intrinsics::abort()
 }

--- a/library/panic_unwind/src/emcc.rs
+++ b/library/panic_unwind/src/emcc.rs
@@ -105,7 +105,6 @@ extern "C" fn exception_cleanup(ptr: *mut libc::c_void) -> *mut libc::c_void {
     }
 }
 
-
 // This is required by the compiler to exist (e.g., it's a lang item), but it's
 // never actually called by the compiler.  Emscripten EH doesn't use a
 // personality function at all, it instead uses __cxa_find_matching_catch.

--- a/library/panic_unwind/src/emcc.rs
+++ b/library/panic_unwind/src/emcc.rs
@@ -129,11 +129,4 @@ extern "C" {
         tinfo: *const TypeInfo,
         dest: extern "C" fn(*mut libc::c_void) -> *mut libc::c_void,
     ) -> !;
-    fn __gxx_personality_v0(
-        version: c_int,
-        actions: uw::_Unwind_Action,
-        exception_class: uw::_Unwind_Exception_Class,
-        exception_object: *mut uw::_Unwind_Exception,
-        context: *mut uw::_Unwind_Context,
-    ) -> uw::_Unwind_Reason_Code;
 }

--- a/library/panic_unwind/src/emcc.rs
+++ b/library/panic_unwind/src/emcc.rs
@@ -105,6 +105,11 @@ extern "C" fn exception_cleanup(ptr: *mut libc::c_void) -> *mut libc::c_void {
     }
 }
 
+
+// This is required by the compiler to exist (e.g., it's a lang item), but it's
+// never actually called by the compiler.  Emscripten EH doesn't use a
+// personality function at all, it instead uses __cxa_find_matching_catch.
+// Wasm error handling would use __gxx_personality_wasm0.
 #[lang = "eh_personality"]
 unsafe extern "C" fn rust_eh_personality(
     version: c_int,
@@ -113,7 +118,7 @@ unsafe extern "C" fn rust_eh_personality(
     exception_object: *mut uw::_Unwind_Exception,
     context: *mut uw::_Unwind_Context,
 ) -> uw::_Unwind_Reason_Code {
-    __gxx_personality_v0(version, actions, exception_class, exception_object, context)
+    core::intrinsics::abort()
 }
 
 extern "C" {


### PR DESCRIPTION
This resolves #85821. See also the discussion here:
https://github.com/emscripten-core/emscripten/issues/17128

The consensus seems to be that rust_eh_personality is never invoked.
I patched __gxx_personality_v0 to log invocations and then ran
various panic tests and it was never called, so this analysis matches
what seems to happen in practice. This replaces the definition with
an abort, modeled on the structured exception handling implementation.
