### PR TITLE
diagnostics: remove trailing spaces

### DIFF
--- a/compiler/rustc_errors/src/emitter.rs
+++ b/compiler/rustc_errors/src/emitter.rs
@@ -771,8 +771,12 @@ impl EmitterWriter {
         self
     }
 
-    fn maybe_anonymized(&self, line_num: usize) -> String {
-        if self.ui_testing { ANONYMIZED_LINE_NUM.to_string() } else { line_num.to_string() }
+    fn maybe_anonymized(&self, line_num: usize) -> Cow<'static, str> {
+        if self.ui_testing {
+            Cow::Borrowed(ANONYMIZED_LINE_NUM)
+        } else {
+            Cow::Owned(line_num.to_string())
+        }
     }
 
     fn draw_line(

--- a/compiler/rustc_errors/src/emitter.rs
+++ b/compiler/rustc_errors/src/emitter.rs
@@ -1920,7 +1920,7 @@ impl EmitterWriter {
             // Only show an underline in the suggestions if the suggestion is not the
             // entirety of the code being shown and the displayed code is not multiline.
             if let DisplaySuggestion::Diff | DisplaySuggestion::Underline = show_code_change {
-                draw_col_separator(&mut buffer, row_num, max_line_num_len + 1);
+                draw_col_separator_no_space(&mut buffer, row_num, max_line_num_len + 1);
                 for part in parts {
                     let span_start_pos = sm.lookup_char_pos(part.span.lo()).col_display;
                     let span_end_pos = sm.lookup_char_pos(part.span.hi()).col_display;

--- a/compiler/rustc_errors/src/emitter.rs
+++ b/compiler/rustc_errors/src/emitter.rs
@@ -819,7 +819,7 @@ impl EmitterWriter {
         }
         buffer.puts(line_offset, 0, &self.maybe_anonymized(line_index), Style::LineNumber);
 
-        draw_col_separator(buffer, line_offset, width_offset - 2);
+        draw_col_separator_no_space(buffer, line_offset, width_offset - 2);
     }
 
     fn render_source_line(

--- a/src/test/rustdoc-ui/intra-doc/disambiguator-mismatch.stderr
+++ b/src/test/rustdoc-ui/intra-doc/disambiguator-mismatch.stderr
@@ -68,7 +68,7 @@ help: to link to the macro, add an exclamation mark
    |
 LL - /// Link to [derive@m]
 LL + /// Link to [m!]
-   | 
+   |
 
 error: unresolved link to `m`
   --> $DIR/disambiguator-mismatch.rs:46:14
@@ -124,7 +124,7 @@ help: to link to the constant, prefix with `const@`
    |
 LL - /// Link to [c()]
 LL + /// Link to [const@c]
-   | 
+   |
 
 error: incompatible link kind for `f`
   --> $DIR/disambiguator-mismatch.rs:72:14
@@ -136,7 +136,7 @@ help: to link to the function, add parentheses
    |
 LL - /// Link to [const@f]
 LL + /// Link to [f()]
-   | 
+   |
 
 error: unresolved link to `std`
   --> $DIR/disambiguator-mismatch.rs:77:14

--- a/src/test/rustdoc-ui/intra-doc/errors.stderr
+++ b/src/test/rustdoc-ui/intra-doc/errors.stderr
@@ -98,7 +98,7 @@ help: to link to the associated function, add parentheses
    |
 LL - /// [type@Vec::into_iter]
 LL + /// [Vec::into_iter()]
-   | 
+   |
 
 error: unresolved link to `S`
   --> $DIR/errors.rs:68:6
@@ -110,7 +110,7 @@ help: to link to the struct, prefix with `struct@`
    |
 LL - /// [S!]
 LL + /// [struct@S]
-   | 
+   |
 
 error: unresolved link to `S::h`
   --> $DIR/errors.rs:78:6
@@ -122,7 +122,7 @@ help: to link to the associated function, add parentheses
    |
 LL - /// [type@S::h]
 LL + /// [S::h()]
-   | 
+   |
 
 error: unresolved link to `T::g`
   --> $DIR/errors.rs:86:6
@@ -134,7 +134,7 @@ help: to link to the associated function, add parentheses
    |
 LL - /// [type@T::g]
 LL + /// [T::g()]
-   | 
+   |
 
 error: unresolved link to `T::h`
   --> $DIR/errors.rs:91:6

--- a/src/test/rustdoc-ui/test-compile-fail1.stderr
+++ b/src/test/rustdoc-ui/test-compile-fail1.stderr
@@ -3,7 +3,7 @@ error[E0428]: the name `f` is defined multiple times
   |
 6 | pub fn f() {}
   | ---------- previous definition of the value `f` here
-7 | 
+7 |
 8 | pub fn f() {}
   | ^^^^^^^^^^ `f` redefined here
   |

--- a/src/test/ui/argument-suggestions/issue-97484.stderr
+++ b/src/test/ui/argument-suggestions/issue-97484.stderr
@@ -16,7 +16,7 @@ help: consider removing the ``
    |
 LL -     foo(&&A, B, C, D, E, F, G);
 LL +     foo(&&A, B, C, D, E, F, G);
-   | 
+   |
 help: remove the extra arguments
    |
 LL |     foo(&&A, D, {&E}, G);

--- a/src/test/ui/asm/type-check-1.stderr
+++ b/src/test/ui/asm/type-check-1.stderr
@@ -58,7 +58,7 @@ help: consider removing the borrow
    |
 LL -         asm!("{}", const &0);
 LL +         asm!("{}", const 0);
-   | 
+   |
 
 error: invalid asm output
   --> $DIR/type-check-1.rs:15:29

--- a/src/test/ui/associated-type-bounds/type-alias.stderr
+++ b/src/test/ui/associated-type-bounds/type-alias.stderr
@@ -9,7 +9,7 @@ help: the clause will not be checked when the type alias is used, and should be 
    |
 LL - type _TaWhere1<T> where T: Iterator<Item: Copy> = T;
 LL + type _TaWhere1<T>  = T;
-   | 
+   |
 
 warning: where clauses are not enforced in type aliases
   --> $DIR/type-alias.rs:6:25
@@ -21,7 +21,7 @@ help: the clause will not be checked when the type alias is used, and should be 
    |
 LL - type _TaWhere2<T> where T: Iterator<Item: 'static> = T;
 LL + type _TaWhere2<T>  = T;
-   | 
+   |
 
 warning: where clauses are not enforced in type aliases
   --> $DIR/type-alias.rs:7:25
@@ -33,7 +33,7 @@ help: the clause will not be checked when the type alias is used, and should be 
    |
 LL - type _TaWhere3<T> where T: Iterator<Item: 'static> = T;
 LL + type _TaWhere3<T>  = T;
-   | 
+   |
 
 warning: where clauses are not enforced in type aliases
   --> $DIR/type-alias.rs:8:25
@@ -45,7 +45,7 @@ help: the clause will not be checked when the type alias is used, and should be 
    |
 LL - type _TaWhere4<T> where T: Iterator<Item: 'static + Copy + Send> = T;
 LL + type _TaWhere4<T>  = T;
-   | 
+   |
 
 warning: where clauses are not enforced in type aliases
   --> $DIR/type-alias.rs:9:25
@@ -57,7 +57,7 @@ help: the clause will not be checked when the type alias is used, and should be 
    |
 LL - type _TaWhere5<T> where T: Iterator<Item: for<'a> Into<&'a u8>> = T;
 LL + type _TaWhere5<T>  = T;
-   | 
+   |
 
 warning: where clauses are not enforced in type aliases
   --> $DIR/type-alias.rs:10:25
@@ -69,7 +69,7 @@ help: the clause will not be checked when the type alias is used, and should be 
    |
 LL - type _TaWhere6<T> where T: Iterator<Item: Iterator<Item: Copy>> = T;
 LL + type _TaWhere6<T>  = T;
-   | 
+   |
 
 warning: bounds on generic parameters are not enforced in type aliases
   --> $DIR/type-alias.rs:12:20
@@ -81,7 +81,7 @@ help: the bound will not be checked when the type alias is used, and should be r
    |
 LL - type _TaInline1<T: Iterator<Item: Copy>> = T;
 LL + type _TaInline1<T> = T;
-   | 
+   |
 
 warning: bounds on generic parameters are not enforced in type aliases
   --> $DIR/type-alias.rs:13:20
@@ -93,7 +93,7 @@ help: the bound will not be checked when the type alias is used, and should be r
    |
 LL - type _TaInline2<T: Iterator<Item: 'static>> = T;
 LL + type _TaInline2<T> = T;
-   | 
+   |
 
 warning: bounds on generic parameters are not enforced in type aliases
   --> $DIR/type-alias.rs:14:20
@@ -105,7 +105,7 @@ help: the bound will not be checked when the type alias is used, and should be r
    |
 LL - type _TaInline3<T: Iterator<Item: 'static>> = T;
 LL + type _TaInline3<T> = T;
-   | 
+   |
 
 warning: bounds on generic parameters are not enforced in type aliases
   --> $DIR/type-alias.rs:15:20
@@ -117,7 +117,7 @@ help: the bound will not be checked when the type alias is used, and should be r
    |
 LL - type _TaInline4<T: Iterator<Item: 'static + Copy + Send>> = T;
 LL + type _TaInline4<T> = T;
-   | 
+   |
 
 warning: bounds on generic parameters are not enforced in type aliases
   --> $DIR/type-alias.rs:16:20
@@ -129,7 +129,7 @@ help: the bound will not be checked when the type alias is used, and should be r
    |
 LL - type _TaInline5<T: Iterator<Item: for<'a> Into<&'a u8>>> = T;
 LL + type _TaInline5<T> = T;
-   | 
+   |
 
 warning: bounds on generic parameters are not enforced in type aliases
   --> $DIR/type-alias.rs:17:20
@@ -141,7 +141,7 @@ help: the bound will not be checked when the type alias is used, and should be r
    |
 LL - type _TaInline6<T: Iterator<Item: Iterator<Item: Copy>>> = T;
 LL + type _TaInline6<T> = T;
-   | 
+   |
 
 warning: 12 warnings emitted
 

--- a/src/test/ui/associated-types/defaults-specialization.stderr
+++ b/src/test/ui/associated-types/defaults-specialization.stderr
@@ -30,7 +30,7 @@ error[E0053]: method `make` has an incompatible type for trait
    |
 LL |     default type Ty = bool;
    |     ----------------------- expected this associated type
-LL | 
+LL |
 LL |     fn make() -> bool { true }
    |                  ^^^^
    |                  |
@@ -50,7 +50,7 @@ error[E0308]: mismatched types
    |
 LL |     type Ty = u8;
    |     ------------- associated type defaults can't be assumed inside the trait defining them
-LL | 
+LL |
 LL |     fn make() -> Self::Ty {
    |                  -------- expected `<Self as Tr>::Ty` because of return type
 LL |         0u8
@@ -77,7 +77,7 @@ error[E0308]: mismatched types
    |
 LL |     default type Ty = bool;
    |     ----------------------- expected this associated type
-LL | 
+LL |
 LL |     fn make() -> Self::Ty { true }
    |                  --------   ^^^^ expected associated type, found `bool`
    |                  |

--- a/src/test/ui/associated-types/issue-22560.stderr
+++ b/src/test/ui/associated-types/issue-22560.stderr
@@ -5,7 +5,7 @@ LL | / trait Sub<Rhs=Self> {
 LL | |     type Output;
 LL | | }
    | |_- type parameter `Rhs` must be specified for this
-LL | 
+LL |
 LL |   type Test = dyn Add + Sub;
    |                         ^^^ help: set the type parameter to the desired type: `Sub<Rhs>`
    |

--- a/src/test/ui/associated-types/issue-36499.stderr
+++ b/src/test/ui/associated-types/issue-36499.stderr
@@ -8,7 +8,7 @@ help: try removing the `+`
    |
 LL -     2 + +2;
 LL +     2 + 2;
-   | 
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/async-await/issue-67765-async-diagnostic.stderr
+++ b/src/test/ui/async-await/issue-67765-async-diagnostic.stderr
@@ -3,7 +3,7 @@ error[E0515]: cannot return value referencing local variable `s`
    |
 LL |     let b = &s[..];
    |              - `s` is borrowed here
-LL | 
+LL |
 LL |     Err(b)?;
    |     ^^^^^^^ returns a value referencing data owned by the current function
 

--- a/src/test/ui/async-await/issue-70594.stderr
+++ b/src/test/ui/async-await/issue-70594.stderr
@@ -31,7 +31,7 @@ help: remove the `.await`
    |
 LL -     [1; ().await];
 LL +     [1; ()];
-   | 
+   |
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/async-await/issues/issue-54752-async-block.stderr
+++ b/src/test/ui/async-await/issues/issue-54752-async-block.stderr
@@ -9,7 +9,7 @@ help: remove these parentheses
    |
 LL - fn main() { let _a = (async { }); }
 LL + fn main() { let _a = async { }; }
-   | 
+   |
 
 warning: 1 warning emitted
 

--- a/src/test/ui/async-await/issues/issue-62009-1.stderr
+++ b/src/test/ui/async-await/issues/issue-62009-1.stderr
@@ -37,7 +37,7 @@ help: remove the `.await`
    |
 LL -     (|_| 2333).await;
 LL +     (|_| 2333);
-   | 
+   |
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/async-await/unnecessary-await.stderr
+++ b/src/test/ui/async-await/unnecessary-await.stderr
@@ -13,7 +13,7 @@ help: remove the `.await`
    |
 LL -     boo().await;
 LL +     boo();
-   | 
+   |
 help: alternatively, consider making `fn boo` asynchronous
    |
 LL | async fn boo() {}

--- a/src/test/ui/blind/blind-item-item-shadow.stderr
+++ b/src/test/ui/blind/blind-item-item-shadow.stderr
@@ -3,7 +3,7 @@ error[E0255]: the name `foo` is defined multiple times
    |
 LL | mod foo { pub mod foo {  } }
    | ------- previous definition of the module `foo` here
-LL | 
+LL |
 LL | use foo::foo;
    |     ^^^^^^^^ `foo` reimported here
    |

--- a/src/test/ui/block-result/issue-5500.stderr
+++ b/src/test/ui/block-result/issue-5500.stderr
@@ -12,7 +12,7 @@ help: consider removing the borrow
    |
 LL -     &panic!()
 LL +     panic!()
-   | 
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/borrowck/borrow-raw-address-of-borrowed.stderr
+++ b/src/test/ui/borrowck/borrow-raw-address-of-borrowed.stderr
@@ -3,10 +3,10 @@ error[E0502]: cannot borrow `x` as mutable because it is also borrowed as immuta
    |
 LL |     let y = &x;
    |             -- immutable borrow occurs here
-LL | 
+LL |
 LL |     let q = &raw mut x;
    |             ^^^^^^^^^^ mutable borrow occurs here
-LL | 
+LL |
 LL |     drop(y);
    |          - immutable borrow later used here
 
@@ -15,7 +15,7 @@ error[E0502]: cannot borrow `x` as immutable because it is also borrowed as muta
    |
 LL |     let y = &mut x;
    |             ------ mutable borrow occurs here
-LL | 
+LL |
 LL |     let p = &raw const x;
    |             ^^^^^^^^^^^^ immutable borrow occurs here
 ...
@@ -30,7 +30,7 @@ LL |     let y = &mut x;
 ...
 LL |     let q = &raw mut x;
    |             ^^^^^^^^^^ second mutable borrow occurs here
-LL | 
+LL |
 LL |     drop(y);
    |          - first borrow later used here
 

--- a/src/test/ui/borrowck/borrow-raw-address-of-deref-mutability.stderr
+++ b/src/test/ui/borrowck/borrow-raw-address-of-deref-mutability.stderr
@@ -3,7 +3,7 @@ error[E0596]: cannot borrow `*x` as mutable, as it is behind a `&` reference
    |
 LL |     let x = &0;
    |             -- help: consider changing this to be a mutable reference: `&mut 0`
-LL | 
+LL |
 LL |     let q = &raw mut *x;
    |             ^^^^^^^^^^^ `x` is a `&` reference, so the data it refers to cannot be borrowed as mutable
 
@@ -12,7 +12,7 @@ error[E0596]: cannot borrow `*x` as mutable, as it is behind a `*const` pointer
    |
 LL |     let x = &0 as *const i32;
    |             -- help: consider changing this to be a mutable pointer: `&mut 0`
-LL | 
+LL |
 LL |     let q = &raw mut *x;
    |             ^^^^^^^^^^^ `x` is a `*const` pointer, so the data it refers to cannot be borrowed as mutable
 

--- a/src/test/ui/borrowck/borrow-tuple-fields.stderr
+++ b/src/test/ui/borrowck/borrow-tuple-fields.stderr
@@ -5,7 +5,7 @@ LL |     let r = &x.0;
    |             ---- borrow of `x.0` occurs here
 LL |     let y = x;
    |             ^ move out of `x` occurs here
-LL | 
+LL |
 LL |     r.use_ref();
    |     ----------- borrow later used here
 

--- a/src/test/ui/borrowck/borrowck-assign-comp-idx.stderr
+++ b/src/test/ui/borrowck/borrowck-assign-comp-idx.stderr
@@ -3,10 +3,10 @@ error[E0502]: cannot borrow `p` as mutable because it is also borrowed as immuta
    |
 LL |     let q: &isize = &p[0];
    |                      - immutable borrow occurs here
-LL | 
+LL |
 LL |     p[0] = 5;
    |     ^ mutable borrow occurs here
-LL | 
+LL |
 LL |     println!("{}", *q);
    |                    -- immutable borrow later used here
 

--- a/src/test/ui/borrowck/borrowck-loan-rcvr-overloaded-op.stderr
+++ b/src/test/ui/borrowck/borrowck-loan-rcvr-overloaded-op.stderr
@@ -3,7 +3,7 @@ error[E0503]: cannot use `p` because it was mutably borrowed
    |
 LL |     let q = &mut p;
    |             ------ borrow of `p` occurs here
-LL | 
+LL |
 LL |     p + 3;
    |     ^ use of borrowed `p`
 ...
@@ -18,7 +18,7 @@ LL |     let q = &mut p;
 ...
 LL |     p.times(3);
    |     ^^^^^^^^^^ immutable borrow occurs here
-LL | 
+LL |
 LL |     *q + 3; // OK to use the new alias `q`
    |     -- mutable borrow later used here
 

--- a/src/test/ui/borrowck/borrowck-loan-rcvr.stderr
+++ b/src/test/ui/borrowck/borrowck-loan-rcvr.stderr
@@ -18,7 +18,7 @@ LL |     let l = &mut p;
    |             ------ mutable borrow occurs here
 LL |     p.impurem();
    |     ^^^^^^^^^^^ immutable borrow occurs here
-LL | 
+LL |
 LL |     l.x += 1;
    |     -------- mutable borrow later used here
 

--- a/src/test/ui/borrowck/borrowck-move-from-subpath-of-borrowed-path.stderr
+++ b/src/test/ui/borrowck/borrowck-move-from-subpath-of-borrowed-path.stderr
@@ -3,7 +3,7 @@ error[E0505]: cannot move out of `*a` because it is borrowed
    |
 LL |     let b = &a;
    |             -- borrow of `a` occurs here
-LL | 
+LL |
 LL |     let z = *a;
    |             ^^ move out of `*a` occurs here
 LL |     b.use_ref();

--- a/src/test/ui/borrowck/borrowck-move-moved-value-into-closure.stderr
+++ b/src/test/ui/borrowck/borrowck-move-moved-value-into-closure.stderr
@@ -3,7 +3,7 @@ error[E0382]: use of moved value: `t`
    |
 LL |     let t: Box<_> = Box::new(3);
    |         - move occurs because `t` has type `Box<isize>`, which does not implement the `Copy` trait
-LL | 
+LL |
 LL |     call_f(move|| { *t + 1 });
    |            ------   -- variable moved due to use in closure
    |            |

--- a/src/test/ui/borrowck/borrowck-overloaded-index-move-index.stderr
+++ b/src/test/ui/borrowck/borrowck-overloaded-index-move-index.stderr
@@ -3,7 +3,7 @@ error[E0505]: cannot move out of `s` because it is borrowed
    |
 LL |     let rs = &mut s;
    |              ------ borrow of `s` occurs here
-LL | 
+LL |
 LL |     println!("{}", f[s]);
    |                      ^ move out of `s` occurs here
 ...

--- a/src/test/ui/borrowck/borrowck-slice-pattern-element-loan-array.stderr
+++ b/src/test/ui/borrowck/borrowck-slice-pattern-element-loan-array.stderr
@@ -23,7 +23,7 @@ error[E0502]: cannot borrow `s[..]` as mutable because it is also borrowed as im
    |
 LL |     let [.., _, ref from_end4, ref from_end3, _, ref from_end1] = *s;
    |                 ------------- immutable borrow occurs here
-LL | 
+LL |
 LL |     let [_, _, ref mut from_begin2, ..] = *s;
    |                ^^^^^^^^^^^^^^^^^^^ mutable borrow occurs here
 LL |     nop(&[from_begin2, from_end1, from_end3, from_end4]);
@@ -45,7 +45,7 @@ error[E0502]: cannot borrow `s[..]` as mutable because it is also borrowed as im
    |
 LL |     let [ref from_begin0, ref from_begin1, _, ref from_begin3, _, ..] = *s;
    |                                               --------------- immutable borrow occurs here
-LL | 
+LL |
 LL |     let [.., ref mut from_end3, _,  _] = *s;
    |              ^^^^^^^^^^^^^^^^^ mutable borrow occurs here
 LL |     nop(&[from_begin0, from_begin1, from_begin3, from_end3]);

--- a/src/test/ui/borrowck/borrowck-union-borrow.stderr
+++ b/src/test/ui/borrowck/borrowck-union-borrow.stderr
@@ -99,7 +99,7 @@ LL |             let ra = &mut u.a;
    |                      -------- borrow of `u.a` occurs here
 LL |             let b = u.b;
    |                     ^^^ use of borrowed `u.a`
-LL | 
+LL |
 LL |             drop(ra);
    |                  -- borrow later used here
 

--- a/src/test/ui/borrowck/copy-suggestion-region-vid.stderr
+++ b/src/test/ui/borrowck/copy-suggestion-region-vid.stderr
@@ -3,7 +3,7 @@ error[E0382]: borrow of moved value: `helpers`
    |
 LL |         let helpers = [vec![], vec![]];
    |             ------- move occurs because `helpers` has type `[Vec<&i64>; 2]`, which does not implement the `Copy` trait
-LL | 
+LL |
 LL |         HelperStruct { helpers, is_empty: helpers[0].is_empty() }
    |                        -------            ^^^^^^^^^^^^^^^^^^^^^ value borrowed here after move
    |                        |

--- a/src/test/ui/borrowck/issue-58776-borrowck-scans-children.stderr
+++ b/src/test/ui/borrowck/issue-58776-borrowck-scans-children.stderr
@@ -5,7 +5,7 @@ LL |     let res = (|| (|| &greeting)())();
    |                --      -------- borrow occurs due to use in closure
    |                |
    |                borrow of `greeting` occurs here
-LL | 
+LL |
 LL |     greeting = "DEALLOCATED".to_string();
    |     ^^^^^^^^ assignment to borrowed `greeting` occurs here
 ...

--- a/src/test/ui/borrowck/mut-borrow-of-mut-ref.stderr
+++ b/src/test/ui/borrowck/mut-borrow-of-mut-ref.stderr
@@ -13,7 +13,7 @@ help: try removing `&mut` here
    |
 LL -     h(&mut b);
 LL +     h(b);
-   | 
+   |
 
 error[E0596]: cannot borrow `b` as mutable, as it is not declared as mutable
   --> $DIR/mut-borrow-of-mut-ref.rs:11:12
@@ -30,7 +30,7 @@ help: try removing `&mut` here
    |
 LL -     g(&mut &mut b);
 LL +     g(&mut b);
-   | 
+   |
 
 error[E0596]: cannot borrow `b` as mutable, as it is not declared as mutable
   --> $DIR/mut-borrow-of-mut-ref.rs:18:12
@@ -47,7 +47,7 @@ help: try removing `&mut` here
    |
 LL -     h(&mut &mut b);
 LL +     h(&mut b);
-   | 
+   |
 
 error[E0596]: cannot borrow `f` as mutable, as it is not declared as mutable
   --> $DIR/mut-borrow-of-mut-ref.rs:35:5

--- a/src/test/ui/borrowck/two-phase-allow-access-during-reservation.nll_target.stderr
+++ b/src/test/ui/borrowck/two-phase-allow-access-during-reservation.nll_target.stderr
@@ -3,7 +3,7 @@ error[E0503]: cannot use `i` because it was mutably borrowed
    |
 LL |     /*1*/ let p = &mut i; // (reservation of `i` starts here)
    |                   ------ borrow of `i` occurs here
-LL | 
+LL |
 LL |     /*2*/ let j = i;      // OK: `i` is only reserved here
    |                   ^ use of borrowed `i`
 ...

--- a/src/test/ui/borrowck/two-phase-reservation-sharing-interference-2.stderr
+++ b/src/test/ui/borrowck/two-phase-reservation-sharing-interference-2.stderr
@@ -3,7 +3,7 @@ error[E0502]: cannot borrow `v` as mutable because it is also borrowed as immuta
    |
 LL |     let shared = &v;
    |                  -- immutable borrow occurs here
-LL | 
+LL |
 LL |     v.extend(shared);
    |     ^^------^^^^^^^^
    |     | |

--- a/src/test/ui/borrowck/two-phase-sneaky.stderr
+++ b/src/test/ui/borrowck/two-phase-sneaky.stderr
@@ -5,7 +5,7 @@ LL |     v[0].push_str({
    |     -    -------- first borrow later used by call
    |     |
    |     first mutable borrow occurs here
-LL | 
+LL |
 LL |         v.push(format!("foo"));
    |         ^^^^^^^^^^^^^^^^^^^^^^ second mutable borrow occurs here
 

--- a/src/test/ui/cast/issue-89497.stderr
+++ b/src/test/ui/cast/issue-89497.stderr
@@ -8,7 +8,7 @@ help: consider borrowing the value
    |
 LL -     let _reference: &'static i32 = unsafe { pointer as *const i32 as &'static i32 };
 LL +     let _reference: &'static i32 = unsafe { &*(pointer as *const i32) };
-   | 
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/closures/2229_closure_analysis/diagnostics/mut_ref.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/diagnostics/mut_ref.stderr
@@ -3,7 +3,7 @@ error[E0596]: cannot borrow `**ref_mref_x` as mutable, as it is behind a `&` ref
    |
 LL |     let ref_mref_x = &mref_x;
    |                      ------- help: consider changing this to be a mutable reference: `&mut mref_x`
-LL | 
+LL |
 LL |     let c = || {
    |             ^^ `ref_mref_x` is a `&` reference, so the data it refers to cannot be borrowed as mutable
 LL |

--- a/src/test/ui/closures/issue-6801.stderr
+++ b/src/test/ui/closures/issue-6801.stderr
@@ -5,7 +5,7 @@ LL |       let sq =  || { *x * *x };
    |                 --   -- borrow occurs due to use in closure
    |                 |
    |                 borrow of `x` occurs here
-LL | 
+LL |
 LL |       twice(x);
    |             ^ move out of `x` occurs here
 LL |       invoke(sq);

--- a/src/test/ui/closures/issue-82438-mut-without-upvar.stderr
+++ b/src/test/ui/closures/issue-82438-mut-without-upvar.stderr
@@ -3,7 +3,7 @@ error[E0596]: cannot borrow `c` as mutable, as it is not declared as mutable
    |
 LL |     let c = |a, b, c, d| {};
    |         - help: consider changing this to be mutable: `mut c`
-LL | 
+LL |
 LL |     A.f(participant_name, &mut c);
    |                           ^^^^^^ cannot borrow as mutable
 

--- a/src/test/ui/coherence/coherence-conflicting-negative-trait-impl.stderr
+++ b/src/test/ui/coherence/coherence-conflicting-negative-trait-impl.stderr
@@ -3,7 +3,7 @@ error[E0751]: found both positive and negative implementation of trait `std::mar
    |
 LL | unsafe impl<T: MyTrait + 'static> Send for TestType<T> {}
    | ------------------------------------------------------ positive implementation here
-LL | 
+LL |
 LL | impl<T: MyTrait> !Send for TestType<T> {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ negative implementation here
 

--- a/src/test/ui/coherence/coherence-fn-implied-bounds.stderr
+++ b/src/test/ui/coherence/coherence-fn-implied-bounds.stderr
@@ -3,7 +3,7 @@ error: conflicting implementations of trait `Trait` for type `for<'a, 'b> fn(&'a
    |
 LL | impl Trait for for<'a, 'b> fn(&'a &'b u32, &'b &'a u32) -> &'b u32 {}
    | ------------------------------------------------------------------ first implementation here
-LL | 
+LL |
 LL | impl Trait for for<'c> fn(&'c &'c u32, &'c &'c u32) -> &'c u32 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `for<'a, 'b> fn(&'a &'b u32, &'b &'a u32) -> &'b u32`
    |

--- a/src/test/ui/coherence/coherence-free-vs-bound-region.stderr
+++ b/src/test/ui/coherence/coherence-free-vs-bound-region.stderr
@@ -3,7 +3,7 @@ error: conflicting implementations of trait `TheTrait` for type `fn(&u8)`
    |
 LL | impl<'a> TheTrait for fn(&'a u8) {}
    | -------------------------------- first implementation here
-LL | 
+LL |
 LL | impl TheTrait for fn(&u8) {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `fn(&u8)`
    |

--- a/src/test/ui/coherence/coherence-projection-conflict-orphan.stderr
+++ b/src/test/ui/coherence/coherence-projection-conflict-orphan.stderr
@@ -3,7 +3,7 @@ error[E0119]: conflicting implementations of trait `Foo<i32>` for type `i32`
    |
 LL | impl Foo<i32> for i32 { }
    | --------------------- first implementation here
-LL | 
+LL |
 LL | impl<A:Iterator> Foo<A::Item> for A { }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `i32`
    |

--- a/src/test/ui/coherence/coherence-projection-conflict-ty-param.stderr
+++ b/src/test/ui/coherence/coherence-projection-conflict-ty-param.stderr
@@ -3,7 +3,7 @@ error[E0119]: conflicting implementations of trait `Foo<_>` for type `std::optio
    |
 LL | impl <P, T: Foo<P>> Foo<P> for Option<T> {}
    | ---------------------------------------- first implementation here
-LL | 
+LL |
 LL | impl<T, U> Foo<T> for Option<U> { }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `std::option::Option<_>`
 

--- a/src/test/ui/coherence/coherence-projection-conflict.stderr
+++ b/src/test/ui/coherence/coherence-projection-conflict.stderr
@@ -3,7 +3,7 @@ error[E0119]: conflicting implementations of trait `Foo<i32>` for type `i32`
    |
 LL | impl Foo<i32> for i32 { }
    | --------------------- first implementation here
-LL | 
+LL |
 LL | impl<A:Bar> Foo<A::Output> for A { }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `i32`
 

--- a/src/test/ui/coherence/coherence-subtyping.stderr
+++ b/src/test/ui/coherence/coherence-subtyping.stderr
@@ -3,7 +3,7 @@ warning: conflicting implementations of trait `TheTrait` for type `for<'a, 'b> f
    |
 LL | impl TheTrait for for<'a, 'b> fn(&'a u8, &'b u8) -> &'a u8 {}
    | ---------------------------------------------------------- first implementation here
-LL | 
+LL |
 LL | impl TheTrait for for<'a> fn(&'a u8, &'a u8) -> &'a u8 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `for<'a, 'b> fn(&'a u8, &'b u8) -> &'a u8`
    |

--- a/src/test/ui/const-generics/const-argument-if-length.full.stderr
+++ b/src/test/ui/const-generics/const-argument-if-length.full.stderr
@@ -12,7 +12,7 @@ help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - pub struct AtLeastByte<T: ?Sized> {
 LL + pub struct AtLeastByte<T> {
-   | 
+   |
 help: borrowed types always have a statically known size
    |
 LL |     value: &T,

--- a/src/test/ui/const-generics/const-argument-if-length.min.stderr
+++ b/src/test/ui/const-generics/const-argument-if-length.min.stderr
@@ -21,7 +21,7 @@ help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - pub struct AtLeastByte<T: ?Sized> {
 LL + pub struct AtLeastByte<T> {
-   | 
+   |
 help: borrowed types always have a statically known size
    |
 LL |     value: &T,

--- a/src/test/ui/const-generics/parser-error-recovery/issue-89013-no-assoc.stderr
+++ b/src/test/ui/const-generics/parser-error-recovery/issue-89013-no-assoc.stderr
@@ -8,7 +8,7 @@ help: the `const` keyword is only needed in the definition of the type
    |
 LL - impl Foo<const 3> for Bar {
 LL + impl Foo<3> for Bar {
-   | 
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/const-generics/parser-error-recovery/issue-89013.stderr
+++ b/src/test/ui/const-generics/parser-error-recovery/issue-89013.stderr
@@ -8,7 +8,7 @@ help: the `const` keyword is only needed in the definition of the type
    |
 LL - impl Foo<N = const 3> for Bar {
 LL + impl Foo<N = 3> for Bar {
-   | 
+   |
 
 error[E0658]: associated const equality is incomplete
   --> $DIR/issue-89013.rs:9:10

--- a/src/test/ui/const-generics/unused_braces.stderr
+++ b/src/test/ui/const-generics/unused_braces.stderr
@@ -13,7 +13,7 @@ help: remove these braces
    |
 LL -     let _: A<{ 7 }>;
 LL +     let _: A<7>;
-   | 
+   |
 
 warning: 1 warning emitted
 

--- a/src/test/ui/deprecation/try-macro-suggestion.stderr
+++ b/src/test/ui/deprecation/try-macro-suggestion.stderr
@@ -21,7 +21,7 @@ help: you can use the `?` operator instead
    |
 LL -     Ok(try!(Ok(())))
 LL +     Ok(Ok(())?)
-   | 
+   |
 help: alternatively, you can still access the deprecated `try!()` macro using the "raw identifier" syntax
    |
 LL |     Ok(r#try!(Ok(())))

--- a/src/test/ui/derives/issue-91550.stderr
+++ b/src/test/ui/derives/issue-91550.stderr
@@ -23,7 +23,7 @@ error[E0599]: the method `use_eq` exists for struct `Object<NoDerives>`, but its
    |
 LL | pub struct NoDerives;
    | --------------------- doesn't satisfy `NoDerives: Eq`
-LL | 
+LL |
 LL | struct Object<T>(T);
    | -------------------- method `use_eq` not found for this
 ...
@@ -42,7 +42,7 @@ error[E0599]: the method `use_ord` exists for struct `Object<NoDerives>`, but it
    |
 LL | pub struct NoDerives;
    | --------------------- doesn't satisfy `NoDerives: Ord`
-LL | 
+LL |
 LL | struct Object<T>(T);
    | -------------------- method `use_ord` not found for this
 ...
@@ -64,7 +64,7 @@ LL | pub struct NoDerives;
    | |
    | doesn't satisfy `NoDerives: Ord`
    | doesn't satisfy `NoDerives: PartialOrd`
-LL | 
+LL |
 LL | struct Object<T>(T);
    | -------------------- method `use_ord_and_partial_ord` not found for this
 ...

--- a/src/test/ui/destructure-trait-ref.stderr
+++ b/src/test/ui/destructure-trait-ref.stderr
@@ -30,7 +30,7 @@ help: consider removing `&` from the pattern
    |
 LL -     let &&x = &1isize as &dyn T;
 LL +     let &x = &1isize as &dyn T;
-   | 
+   |
 
 error[E0308]: mismatched types
   --> $DIR/destructure-trait-ref.rs:36:11
@@ -46,7 +46,7 @@ help: consider removing `&` from the pattern
    |
 LL -     let &&&x = &(&1isize as &dyn T);
 LL +     let &&x = &(&1isize as &dyn T);
-   | 
+   |
 
 error[E0308]: mismatched types
   --> $DIR/destructure-trait-ref.rs:40:13

--- a/src/test/ui/did_you_mean/compatible-variants.stderr
+++ b/src/test/ui/did_you_mean/compatible-variants.stderr
@@ -71,7 +71,7 @@ help: try removing this `?`
    |
 LL -     c()?
 LL +     c()
-   | 
+   |
 help: try adding an expression at the end of the block
    |
 LL ~     c()?;

--- a/src/test/ui/did_you_mean/issue-34126.stderr
+++ b/src/test/ui/did_you_mean/issue-34126.stderr
@@ -13,7 +13,7 @@ help: try removing `&mut` here
    |
 LL -         self.run(&mut self);
 LL +         self.run(self);
-   | 
+   |
 
 error[E0502]: cannot borrow `self` as mutable because it is also borrowed as immutable
   --> $DIR/issue-34126.rs:6:18

--- a/src/test/ui/dst/dst-object-from-unsized-type.stderr
+++ b/src/test/ui/dst/dst-object-from-unsized-type.stderr
@@ -11,7 +11,7 @@ help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - fn test1<T: ?Sized + Foo>(t: &T) {
 LL + fn test1<T: Foo>(t: &T) {
-   | 
+   |
 
 error[E0277]: the size for values of type `T` cannot be known at compilation time
   --> $DIR/dst-object-from-unsized-type.rs:13:23
@@ -26,7 +26,7 @@ help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - fn test2<T: ?Sized + Foo>(t: &T) {
 LL + fn test2<T: Foo>(t: &T) {
-   | 
+   |
 
 error[E0277]: the size for values of type `str` cannot be known at compilation time
   --> $DIR/dst-object-from-unsized-type.rs:18:28

--- a/src/test/ui/dyn-keyword/dyn-2018-edition-lint.stderr
+++ b/src/test/ui/dyn-keyword/dyn-2018-edition-lint.stderr
@@ -15,7 +15,7 @@ help: use `dyn`
    |
 LL - fn function(x: &SomeTrait, y: Box<SomeTrait>) {
 LL + fn function(x: &dyn SomeTrait, y: Box<SomeTrait>) {
-   | 
+   |
 
 error: trait objects without an explicit `dyn` are deprecated
   --> $DIR/dyn-2018-edition-lint.rs:4:35
@@ -29,7 +29,7 @@ help: use `dyn`
    |
 LL - fn function(x: &SomeTrait, y: Box<SomeTrait>) {
 LL + fn function(x: &SomeTrait, y: Box<dyn SomeTrait>) {
-   | 
+   |
 
 error: trait objects without an explicit `dyn` are deprecated
   --> $DIR/dyn-2018-edition-lint.rs:17:14
@@ -43,7 +43,7 @@ help: use `dyn`
    |
 LL -     let _x: &SomeTrait = todo!();
 LL +     let _x: &dyn SomeTrait = todo!();
-   | 
+   |
 
 error: trait objects without an explicit `dyn` are deprecated
   --> $DIR/dyn-2018-edition-lint.rs:4:17
@@ -57,7 +57,7 @@ help: use `dyn`
    |
 LL - fn function(x: &SomeTrait, y: Box<SomeTrait>) {
 LL + fn function(x: &dyn SomeTrait, y: Box<SomeTrait>) {
-   | 
+   |
 
 error: trait objects without an explicit `dyn` are deprecated
   --> $DIR/dyn-2018-edition-lint.rs:4:17
@@ -71,7 +71,7 @@ help: use `dyn`
    |
 LL - fn function(x: &SomeTrait, y: Box<SomeTrait>) {
 LL + fn function(x: &dyn SomeTrait, y: Box<SomeTrait>) {
-   | 
+   |
 
 error: trait objects without an explicit `dyn` are deprecated
   --> $DIR/dyn-2018-edition-lint.rs:4:35
@@ -85,7 +85,7 @@ help: use `dyn`
    |
 LL - fn function(x: &SomeTrait, y: Box<SomeTrait>) {
 LL + fn function(x: &SomeTrait, y: Box<dyn SomeTrait>) {
-   | 
+   |
 
 error: trait objects without an explicit `dyn` are deprecated
   --> $DIR/dyn-2018-edition-lint.rs:4:35
@@ -99,7 +99,7 @@ help: use `dyn`
    |
 LL - fn function(x: &SomeTrait, y: Box<SomeTrait>) {
 LL + fn function(x: &SomeTrait, y: Box<dyn SomeTrait>) {
-   | 
+   |
 
 error: aborting due to 7 previous errors
 

--- a/src/test/ui/dyn-keyword/dyn-2021-edition-error.stderr
+++ b/src/test/ui/dyn-keyword/dyn-2021-edition-error.stderr
@@ -8,7 +8,7 @@ help: add `dyn` keyword before this trait
    |
 LL - fn function(x: &SomeTrait, y: Box<SomeTrait>) {
 LL + fn function(x: &dyn SomeTrait, y: Box<SomeTrait>) {
-   | 
+   |
 
 error[E0782]: trait objects must include the `dyn` keyword
   --> $DIR/dyn-2021-edition-error.rs:3:35
@@ -20,7 +20,7 @@ help: add `dyn` keyword before this trait
    |
 LL - fn function(x: &SomeTrait, y: Box<SomeTrait>) {
 LL + fn function(x: &SomeTrait, y: Box<dyn SomeTrait>) {
-   | 
+   |
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/dyn-keyword/dyn-angle-brackets.stderr
+++ b/src/test/ui/dyn-keyword/dyn-angle-brackets.stderr
@@ -15,7 +15,7 @@ help: use `dyn`
    |
 LL -         <fmt::Debug>::fmt(self, f)
 LL +         <dyn fmt::Debug>::fmt(self, f)
-   | 
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/empty/empty-struct-unit-expr.stderr
+++ b/src/test/ui/empty/empty-struct-unit-expr.stderr
@@ -24,7 +24,7 @@ help: `E::Empty4` is a unit variant, you need to write it without the parenthese
    |
 LL -     let e4 = E::Empty4();
 LL +     let e4 = E::Empty4;
-   | 
+   |
 
 error[E0618]: expected function, found `empty_struct::XEmpty2`
   --> $DIR/empty-struct-unit-expr.rs:18:15
@@ -46,7 +46,7 @@ help: `XE::XEmpty4` is a unit variant, you need to write it without the parenthe
    |
 LL -     let xe4 = XE::XEmpty4();
 LL +     let xe4 = XE::XEmpty4;
-   | 
+   |
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/error-codes/E0109.stderr
+++ b/src/test/ui/error-codes/E0109.stderr
@@ -10,7 +10,7 @@ help: primitive type `u32` doesn't have generic parameters
    |
 LL - type X = u32<i32>;
 LL + type X = u32;
-   | 
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/error-codes/E0110.stderr
+++ b/src/test/ui/error-codes/E0110.stderr
@@ -10,7 +10,7 @@ help: primitive type `u32` doesn't have generic parameters
    |
 LL - type X = u32<'static>;
 LL + type X = u32;
-   | 
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/error-codes/E0255.stderr
+++ b/src/test/ui/error-codes/E0255.stderr
@@ -3,7 +3,7 @@ error[E0255]: the name `foo` is defined multiple times
    |
 LL | use bar::foo;
    |     -------- previous import of the value `foo` here
-LL | 
+LL |
 LL | fn foo() {}
    | ^^^^^^^^ `foo` redefined here
    |

--- a/src/test/ui/error-codes/E0259.stderr
+++ b/src/test/ui/error-codes/E0259.stderr
@@ -3,7 +3,7 @@ error[E0259]: the name `alloc` is defined multiple times
    |
 LL | extern crate alloc;
    | ------------------- previous import of the extern crate `alloc` here
-LL | 
+LL |
 LL | extern crate libc as alloc;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `alloc` reimported here
    |

--- a/src/test/ui/error-codes/E0260.stderr
+++ b/src/test/ui/error-codes/E0260.stderr
@@ -3,7 +3,7 @@ error[E0260]: the name `alloc` is defined multiple times
    |
 LL | extern crate alloc;
    | ------------------- previous import of the extern crate `alloc` here
-LL | 
+LL |
 LL | mod alloc {
    | ^^^^^^^^^ `alloc` redefined here
    |

--- a/src/test/ui/error-codes/E0393.stderr
+++ b/src/test/ui/error-codes/E0393.stderr
@@ -3,7 +3,7 @@ error[E0393]: the type parameter `T` must be explicitly specified
    |
 LL | trait A<T=Self> {}
    | ------------------ type parameter `T` must be specified for this
-LL | 
+LL |
 LL | fn together_we_will_rule_the_galaxy(son: &dyn A) {}
    |                                               ^ help: set the type parameter to the desired type: `A<T>`
    |

--- a/src/test/ui/error-codes/E0423.stderr
+++ b/src/test/ui/error-codes/E0423.stderr
@@ -31,7 +31,7 @@ error[E0423]: expected function, tuple struct or tuple variant, found struct `Fo
    |
 LL |     struct Foo { a: bool };
    |     ---------------------- `Foo` defined here
-LL | 
+LL |
 LL |     let f = Foo();
    |             ^^^^^
 ...

--- a/src/test/ui/error-codes/E0429.stderr
+++ b/src/test/ui/error-codes/E0429.stderr
@@ -8,7 +8,7 @@ help: consider importing the module directly
    |
 LL - use std::fmt::self;
 LL + use std::fmt;
-   | 
+   |
 help: alternatively, use the multi-path `use` syntax to import `self`
    |
 LL | use std::fmt::{self};

--- a/src/test/ui/error-codes/E0446.stderr
+++ b/src/test/ui/error-codes/E0446.stderr
@@ -3,7 +3,7 @@ error[E0446]: private type `Bar` in public interface
    |
 LL |     struct Bar(u32);
    |     ---------------- `Bar` declared as private
-LL | 
+LL |
 LL |     pub fn bar() -> Bar {
    |     ^^^^^^^^^^^^^^^^^^^ can't leak private type
 

--- a/src/test/ui/error-codes/E0453.stderr
+++ b/src/test/ui/error-codes/E0453.stderr
@@ -3,7 +3,7 @@ error[E0453]: allow(non_snake_case) incompatible with previous forbid
    |
 LL | #![forbid(non_snake_case)]
    |           -------------- `forbid` level set here
-LL | 
+LL |
 LL | #[allow(non_snake_case)]
    |         ^^^^^^^^^^^^^^ overruled by previous forbid
 
@@ -12,7 +12,7 @@ error[E0453]: allow(non_snake_case) incompatible with previous forbid
    |
 LL | #![forbid(non_snake_case)]
    |           -------------- `forbid` level set here
-LL | 
+LL |
 LL | #[allow(non_snake_case)]
    |         ^^^^^^^^^^^^^^ overruled by previous forbid
 

--- a/src/test/ui/error-codes/E0504.stderr
+++ b/src/test/ui/error-codes/E0504.stderr
@@ -3,7 +3,7 @@ error[E0505]: cannot move out of `fancy_num` because it is borrowed
    |
 LL |     let fancy_ref = &fancy_num;
    |                     ---------- borrow of `fancy_num` occurs here
-LL | 
+LL |
 LL |     let x = move || {
    |             ^^^^^^^ move out of `fancy_num` occurs here
 LL |         println!("child function: {}", fancy_num.num);

--- a/src/test/ui/error-codes/E0506.stderr
+++ b/src/test/ui/error-codes/E0506.stderr
@@ -5,7 +5,7 @@ LL |     let fancy_ref = &fancy_num;
    |                     ---------- borrow of `fancy_num` occurs here
 LL |     fancy_num = FancyNum { num: 6 };
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ assignment to borrowed `fancy_num` occurs here
-LL | 
+LL |
 LL |     println!("Num: {}, Ref: {}", fancy_num.num, fancy_ref.num);
    |                                                 ------------- borrow later used here
 

--- a/src/test/ui/error-codes/E0605.stderr
+++ b/src/test/ui/error-codes/E0605.stderr
@@ -14,7 +14,7 @@ help: consider borrowing the value
    |
 LL -     v as &u8;
 LL +     &*v;
-   | 
+   |
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/error-codes/E0618.stderr
+++ b/src/test/ui/error-codes/E0618.stderr
@@ -13,7 +13,7 @@ help: `X::Entry` is a unit variant, you need to write it without the parentheses
    |
 LL -     X::Entry();
 LL +     X::Entry;
-   | 
+   |
 
 error[E0618]: expected function, found `i32`
   --> $DIR/E0618.rs:9:5

--- a/src/test/ui/expr/if/if-no-match-bindings.stderr
+++ b/src/test/ui/expr/if/if-no-match-bindings.stderr
@@ -30,7 +30,7 @@ help: consider removing the borrow
    |
 LL -     if &true {}
 LL +     if true {}
-   | 
+   |
 
 error[E0308]: mismatched types
   --> $DIR/if-no-match-bindings.rs:21:8
@@ -42,7 +42,7 @@ help: consider removing the borrow
    |
 LL -     if &mut true {}
 LL +     if true {}
-   | 
+   |
 
 error[E0308]: mismatched types
   --> $DIR/if-no-match-bindings.rs:24:11
@@ -76,7 +76,7 @@ help: consider removing the borrow
    |
 LL -     while &true {}
 LL +     while true {}
-   | 
+   |
 
 error[E0308]: mismatched types
   --> $DIR/if-no-match-bindings.rs:27:11
@@ -88,7 +88,7 @@ help: consider removing the borrow
    |
 LL -     while &mut true {}
 LL +     while true {}
-   | 
+   |
 
 error: aborting due to 8 previous errors
 

--- a/src/test/ui/feature-gates/feature-gate-with_negative_coherence.stderr
+++ b/src/test/ui/feature-gates/feature-gate-with_negative_coherence.stderr
@@ -3,7 +3,7 @@ error[E0119]: conflicting implementations of trait `Foo` for type `&_`
    |
 LL | impl<T: std::ops::DerefMut> Foo for T { }
    | ------------------------------------- first implementation here
-LL | 
+LL |
 LL | impl<T> Foo for &T { }
    | ^^^^^^^^^^^^^^^^^^ conflicting implementation for `&_`
 

--- a/src/test/ui/fmt/format-string-error.stderr
+++ b/src/test/ui/fmt/format-string-error.stderr
@@ -93,7 +93,7 @@ error: invalid format string: expected `'}'` but string was terminated
    |
 LL |     {
    |     - because of this opening brace
-LL | 
+LL |
 LL | "###);
    | ^ expected `'}'` in format string
    |

--- a/src/test/ui/generic-associated-types/equality-bound.stderr
+++ b/src/test/ui/generic-associated-types/equality-bound.stderr
@@ -9,7 +9,7 @@ help: if `Iterator::Item` is an associated type you're trying to set, use the as
    |
 LL - fn sum<I: Iterator<Item = ()>>(i: I) -> i32 where I::Item = i32 {
 LL + fn sum<I: Iterator<Item = (), Item = i32>>(i: I) -> i32 where  {
-   | 
+   |
 
 error: equality constraints are not yet supported in `where` clauses
   --> $DIR/equality-bound.rs:5:41
@@ -22,7 +22,7 @@ help: if `Iterator::Item` is an associated type you're trying to set, use the as
    |
 LL - fn sum2<I: Iterator>(i: I) -> i32 where I::Item = i32 {
 LL + fn sum2<I: Iterator<Item = i32>>(i: I) -> i32 where  {
-   | 
+   |
 
 error: equality constraints are not yet supported in `where` clauses
   --> $DIR/equality-bound.rs:9:41

--- a/src/test/ui/hashmap/hashmap-iter-value-lifetime.stderr
+++ b/src/test/ui/hashmap/hashmap-iter-value-lifetime.stderr
@@ -3,10 +3,10 @@ error[E0502]: cannot borrow `my_stuff` as mutable because it is also borrowed as
    |
 LL |     let (_, thing) = my_stuff.iter().next().unwrap();
    |                      --------------- immutable borrow occurs here
-LL | 
+LL |
 LL |     my_stuff.clear();
    |     ^^^^^^^^^^^^^^^^ mutable borrow occurs here
-LL | 
+LL |
 LL |     println!("{}", *thing);
    |                    ------ immutable borrow later used here
 

--- a/src/test/ui/impl-trait/impl-generic-mismatch.stderr
+++ b/src/test/ui/impl-trait/impl-generic-mismatch.stderr
@@ -11,7 +11,7 @@ help: try removing the generic parameter and using `impl Trait` instead
    |
 LL -     fn foo<U: Debug>(&self, _: &U) { }
 LL +     fn foo(&self, _: &impl Debug) { }
-   | 
+   |
 
 error[E0643]: method `bar` has incompatible signature for trait
   --> $DIR/impl-generic-mismatch.rs:17:23

--- a/src/test/ui/impl-trait/recursive-impl-trait-type-through-non-recursive.stderr
+++ b/src/test/ui/impl-trait/recursive-impl-trait-type-through-non-recursive.stderr
@@ -3,7 +3,7 @@ error[E0720]: cannot resolve opaque type
    |
 LL | fn id<T>(t: T) -> impl Sized { t }
    |                   ---------- returning this opaque type `impl Sized`
-LL | 
+LL |
 LL | fn recursive_id() -> impl Sized {
    |                      ^^^^^^^^^^ recursive opaque type
 LL |     id(recursive_id2())
@@ -25,7 +25,7 @@ error[E0720]: cannot resolve opaque type
    |
 LL | fn wrap<T>(t: T) -> impl Sized { (t,) }
    |                     ---------- returning this opaque type `impl Sized`
-LL | 
+LL |
 LL | fn recursive_wrap() -> impl Sized {
    |                        ^^^^^^^^^^ recursive opaque type
 LL |     wrap(recursive_wrap2())

--- a/src/test/ui/imports/issue-45829/import-self.stderr
+++ b/src/test/ui/imports/issue-45829/import-self.stderr
@@ -14,7 +14,7 @@ help: consider importing the module directly
    |
 LL - use foo::self;
 LL + use foo;
-   | 
+   |
 help: alternatively, use the multi-path `use` syntax to import `self`
    |
 LL | use foo::{self};

--- a/src/test/ui/imports/issue-59764.stderr
+++ b/src/test/ui/imports/issue-59764.stderr
@@ -9,7 +9,7 @@ help: a macro with this name exists at the root of the crate
    |
 LL -     use issue_59764::foo::{baz, makro};
 LL +     use issue_59764::{makro, foo::{baz}};
-   | 
+   |
 
 error[E0432]: unresolved import `issue_59764::foo::makro`
   --> $DIR/issue-59764.rs:21:9
@@ -52,7 +52,7 @@ help: a macro with this name exists at the root of the crate
    |
 LL -     use issue_59764::foo::{baz, makro, foobar};
 LL +     use issue_59764::{makro, foo::{baz, foobar}};
-   | 
+   |
 
 error[E0432]: unresolved import `issue_59764::foo::makro`
   --> $DIR/issue-59764.rs:40:9
@@ -97,7 +97,7 @@ help: a macro with this name exists at the root of the crate
    |
 LL -     use issue_59764::{foobaz, foo::makro};
 LL +     use issue_59764::{makro, foobaz};
-   | 
+   |
 
 error[E0432]: unresolved import `issue_59764::foo::makro`
   --> $DIR/issue-59764.rs:59:42
@@ -110,7 +110,7 @@ help: a macro with this name exists at the root of the crate
    |
 LL -     use issue_59764::{foobaz, foo::{baz, makro}};
 LL +     use issue_59764::{makro, foobaz, foo::{baz}};
-   | 
+   |
 
 error[E0432]: unresolved import `issue_59764::foo::makro`
   --> $DIR/issue-59764.rs:68:13
@@ -155,7 +155,7 @@ help: a macro with this name exists at the root of the crate
    |
 LL -     use issue_59764::{foobaz, foo::{baz, makro, barbaz::{barfoo}}};
 LL +     use issue_59764::{makro, foobaz, foo::{baz, barbaz::{barfoo}}};
-   | 
+   |
 
 error[E0432]: unresolved import `issue_59764::foo::makro`
   --> $DIR/issue-59764.rs:93:13
@@ -196,7 +196,7 @@ help: a macro with this name exists at the root of the crate
    |
 LL -     use issue_59764::foo::{baz, makro as foobar};
 LL +     use issue_59764::{makro as foobar, foo::{baz}};
-   | 
+   |
 
 error[E0432]: unresolved import `issue_59764::foo::makro`
   --> $DIR/issue-59764.rs:120:17

--- a/src/test/ui/inference/deref-suggestion.stderr
+++ b/src/test/ui/inference/deref-suggestion.stderr
@@ -48,7 +48,7 @@ help: consider removing the borrow
    |
 LL -     foo(&"aaa".to_owned());
 LL +     foo("aaa".to_owned());
-   | 
+   |
 
 error[E0308]: mismatched types
   --> $DIR/deref-suggestion.rs:32:9
@@ -67,7 +67,7 @@ help: consider removing the borrow
    |
 LL -     foo(&mut "aaa".to_owned());
 LL +     foo("aaa".to_owned());
-   | 
+   |
 
 error[E0308]: mismatched types
   --> $DIR/deref-suggestion.rs:2:20

--- a/src/test/ui/issues/issue-11873.stderr
+++ b/src/test/ui/issues/issue-11873.stderr
@@ -7,7 +7,7 @@ LL |     let mut f = || v.push(2);
    |                 borrow of `v` occurs here
 LL |     let _w = v;
    |              ^ move out of `v` occurs here
-LL | 
+LL |
 LL |     f();
    |     - borrow later used here
 

--- a/src/test/ui/issues/issue-22370.stderr
+++ b/src/test/ui/issues/issue-22370.stderr
@@ -3,7 +3,7 @@ error[E0393]: the type parameter `T` must be explicitly specified
    |
 LL | trait A<T=Self> {}
    | ------------------ type parameter `T` must be specified for this
-LL | 
+LL |
 LL | fn f(a: &dyn A) {}
    |              ^ help: set the type parameter to the desired type: `A<T>`
    |

--- a/src/test/ui/issues/issue-28472.stderr
+++ b/src/test/ui/issues/issue-28472.stderr
@@ -3,7 +3,7 @@ error[E0428]: the name `foo` is defined multiple times
    |
 LL |     fn foo();
    |     --------- previous definition of the value `foo` here
-LL | 
+LL |
 LL | /   pub
 LL | |   fn foo();
    | |___________^ `foo` redefined here

--- a/src/test/ui/issues/issue-2995.stderr
+++ b/src/test/ui/issues/issue-2995.stderr
@@ -8,7 +8,7 @@ help: consider borrowing the value
    |
 LL -     let _q: &isize = p as &isize;
 LL +     let _q: &isize = &*p;
-   | 
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-3099-a.stderr
+++ b/src/test/ui/issues/issue-3099-a.stderr
@@ -3,7 +3,7 @@ error[E0428]: the name `A` is defined multiple times
    |
 LL | enum A { B, C }
    | ------ previous definition of the type `A` here
-LL | 
+LL |
 LL | enum A { D, E }
    | ^^^^^^ `A` redefined here
    |

--- a/src/test/ui/issues/issue-3099-b.stderr
+++ b/src/test/ui/issues/issue-3099-b.stderr
@@ -3,7 +3,7 @@ error[E0428]: the name `a` is defined multiple times
    |
 LL | pub mod a {}
    | --------- previous definition of the module `a` here
-LL | 
+LL |
 LL | pub mod a {}
    | ^^^^^^^^^ `a` redefined here
    |

--- a/src/test/ui/issues/issue-35241.stderr
+++ b/src/test/ui/issues/issue-35241.stderr
@@ -3,7 +3,7 @@ error[E0308]: mismatched types
    |
 LL | struct Foo(u32);
    | ---------------- fn(u32) -> Foo {Foo} defined here
-LL | 
+LL |
 LL | fn test() -> Foo { Foo }
    |              ---   ^^^ expected struct `Foo`, found fn item
    |              |

--- a/src/test/ui/issues/issue-40510-1.stderr
+++ b/src/test/ui/issues/issue-40510-1.stderr
@@ -3,7 +3,7 @@ error: captured variable cannot escape `FnMut` closure body
    |
 LL |     let mut x: Box<()> = Box::new(());
    |         ----- variable defined here
-LL | 
+LL |
 LL |     || {
    |      - inferred to be a `FnMut` closure
 LL |         &mut x

--- a/src/test/ui/issues/issue-40510-3.stderr
+++ b/src/test/ui/issues/issue-40510-3.stderr
@@ -3,7 +3,7 @@ error: captured variable cannot escape `FnMut` closure body
    |
 LL |       let mut x: Vec<()> = Vec::new();
    |           ----- variable defined here
-LL | 
+LL |
 LL |       || {
    |        - inferred to be a `FnMut` closure
 LL | /         || {

--- a/src/test/ui/issues/issue-4265.stderr
+++ b/src/test/ui/issues/issue-4265.stderr
@@ -5,7 +5,7 @@ LL | /     fn bar() {
 LL | |         Foo { baz: 0 }.bar();
 LL | |     }
    | |_____- previous definition of `bar` here
-LL | 
+LL |
 LL | /     fn bar() {
 LL | |     }
    | |_____^ duplicate definition

--- a/src/test/ui/issues/issue-47646.stderr
+++ b/src/test/ui/issues/issue-47646.stderr
@@ -3,7 +3,7 @@ error[E0502]: cannot borrow `heap` as immutable because it is also borrowed as m
    |
 LL |     let borrow = heap.peek_mut();
    |                  --------------- mutable borrow occurs here
-LL | 
+LL |
 LL |     match (borrow, ()) {
    |           ------------ a temporary with access to the mutable borrow is created here ...
 LL |         (Some(_), ()) => {

--- a/src/test/ui/issues/issue-49257.stderr
+++ b/src/test/ui/issues/issue-49257.stderr
@@ -11,7 +11,7 @@ help: move the `..` to the end of the field list
    |
 LL -     let Point { .., y, } = p;
 LL +     let Point { y, .. } = p;
-   | 
+   |
 
 error: expected `}`, found `,`
   --> $DIR/issue-49257.rs:11:19
@@ -26,7 +26,7 @@ help: move the `..` to the end of the field list
    |
 LL -     let Point { .., y } = p;
 LL +     let Point { y , .. } = p;
-   | 
+   |
 
 error: expected `}`, found `,`
   --> $DIR/issue-49257.rs:12:19

--- a/src/test/ui/issues/issue-51632-try-desugar-incompatible-types.stderr
+++ b/src/test/ui/issues/issue-51632-try-desugar-incompatible-types.stderr
@@ -11,7 +11,7 @@ help: try removing this `?`
    |
 LL -     missing_discourses()?
 LL +     missing_discourses()
-   | 
+   |
 help: try wrapping the expression in `Ok`
    |
 LL |     Ok(missing_discourses()?)

--- a/src/test/ui/issues/issue-64792-bad-unicode-ctor.stderr
+++ b/src/test/ui/issues/issue-64792-bad-unicode-ctor.stderr
@@ -3,7 +3,7 @@ error[E0423]: expected function, tuple struct or tuple variant, found struct `X`
    |
 LL | struct X {}
    | ----------- `X` defined here
-LL | 
+LL |
 LL | const Y: X = X("ö");
    |              ^^^^^^ help: use struct literal syntax instead: `X {}`
 

--- a/src/test/ui/issues/issue-86756.stderr
+++ b/src/test/ui/issues/issue-86756.stderr
@@ -27,7 +27,7 @@ help: use `dyn`
    |
 LL -     eq::<dyn, Foo>
 LL +     eq::<dyn, dyn Foo>
-   | 
+   |
 
 error[E0107]: missing generics for trait `Foo`
   --> $DIR/issue-86756.rs:5:15

--- a/src/test/ui/iterators/into-iter-on-arrays-2018.stderr
+++ b/src/test/ui/iterators/into-iter-on-arrays-2018.stderr
@@ -59,7 +59,7 @@ help: or remove `.into_iter()` to iterate by value
    |
 LL -     for _ in [1, 2, 3].into_iter() {}
 LL +     for _ in [1, 2, 3] {}
-   | 
+   |
 
 warning: 5 warnings emitted
 

--- a/src/test/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-if-else-using-impl-3.stderr
+++ b/src/test/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-if-else-using-impl-3.stderr
@@ -3,7 +3,7 @@ error[E0621]: explicit lifetime required in the type of `x`
    |
 LL |   fn foo<'a>(&'a self, x: &i32) -> &i32 {
    |                           ---- help: add explicit lifetime `'a` to the type of `x`: `&'a i32`
-LL | 
+LL |
 LL |     if true { &self.field } else { x }
    |                                    ^ lifetime `'a` required
 

--- a/src/test/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-if-else-using-impl.stderr
+++ b/src/test/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-if-else-using-impl.stderr
@@ -5,7 +5,7 @@ LL |     fn foo<'a>(x: &i32, y: &'a i32) -> &'a i32 {
    |            --     - let's call the lifetime of this reference `'1`
    |            |
    |            lifetime `'a` defined here
-LL | 
+LL |
 LL |         if x > y { x } else { y }
    |                    ^ associated function was supposed to return data with lifetime `'a` but it is returning data with lifetime `'1`
 

--- a/src/test/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-return-type-is-anon.stderr
+++ b/src/test/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-return-type-is-anon.stderr
@@ -5,7 +5,7 @@ LL |   fn foo<'a>(&self, x: &'a i32) -> &i32 {
    |          --  - let's call the lifetime of this reference `'1`
    |          |
    |          lifetime `'a` defined here
-LL | 
+LL |
 LL |     x
    |     ^ associated function was supposed to return data with lifetime `'1` but it is returning data with lifetime `'a`
 

--- a/src/test/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-self-is-anon.stderr
+++ b/src/test/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-self-is-anon.stderr
@@ -5,7 +5,7 @@ LL |     fn foo<'a>(&self, x: &'a Foo) -> &'a Foo {
    |            --  - let's call the lifetime of this reference `'1`
    |            |
    |            lifetime `'a` defined here
-LL | 
+LL |
 LL |         if true { x } else { self }
    |                              ^^^^ associated function was supposed to return data with lifetime `'a` but it is returning data with lifetime `'1`
 

--- a/src/test/ui/lint/forbid-group-member.stderr
+++ b/src/test/ui/lint/forbid-group-member.stderr
@@ -3,7 +3,7 @@ warning: allow(unused_variables) incompatible with previous forbid
    |
 LL | #![forbid(unused)]
    |           ------ `forbid` level set here
-LL | 
+LL |
 LL | #[allow(unused_variables)]
    |         ^^^^^^^^^^^^^^^^ overruled by previous forbid
    |
@@ -16,7 +16,7 @@ warning: allow(unused_variables) incompatible with previous forbid
    |
 LL | #![forbid(unused)]
    |           ------ `forbid` level set here
-LL | 
+LL |
 LL | #[allow(unused_variables)]
    |         ^^^^^^^^^^^^^^^^ overruled by previous forbid
    |
@@ -28,7 +28,7 @@ warning: allow(unused_variables) incompatible with previous forbid
    |
 LL | #![forbid(unused)]
    |           ------ `forbid` level set here
-LL | 
+LL |
 LL | #[allow(unused_variables)]
    |         ^^^^^^^^^^^^^^^^ overruled by previous forbid
    |

--- a/src/test/ui/lint/forbid-member-group.stderr
+++ b/src/test/ui/lint/forbid-member-group.stderr
@@ -3,7 +3,7 @@ error[E0453]: allow(unused) incompatible with previous forbid
    |
 LL | #![forbid(unused_variables)]
    |           ---------------- `forbid` level set here
-LL | 
+LL |
 LL | #[allow(unused)]
    |         ^^^^^^ overruled by previous forbid
 
@@ -12,7 +12,7 @@ error[E0453]: allow(unused) incompatible with previous forbid
    |
 LL | #![forbid(unused_variables)]
    |           ---------------- `forbid` level set here
-LL | 
+LL |
 LL | #[allow(unused)]
    |         ^^^^^^ overruled by previous forbid
 

--- a/src/test/ui/lint/force-warn/allowed-group-warn-by-default-lint.stderr
+++ b/src/test/ui/lint/force-warn/allowed-group-warn-by-default-lint.stderr
@@ -11,7 +11,7 @@ help: use `dyn`
    |
 LL - pub fn function(_x: Box<SomeTrait>) {}
 LL + pub fn function(_x: Box<dyn SomeTrait>) {}
-   | 
+   |
 
 warning: trait objects without an explicit `dyn` are deprecated
   --> $DIR/allowed-group-warn-by-default-lint.rs:10:25
@@ -25,7 +25,7 @@ help: use `dyn`
    |
 LL - pub fn function(_x: Box<SomeTrait>) {}
 LL + pub fn function(_x: Box<dyn SomeTrait>) {}
-   | 
+   |
 
 warning: trait objects without an explicit `dyn` are deprecated
   --> $DIR/allowed-group-warn-by-default-lint.rs:10:25
@@ -39,7 +39,7 @@ help: use `dyn`
    |
 LL - pub fn function(_x: Box<SomeTrait>) {}
 LL + pub fn function(_x: Box<dyn SomeTrait>) {}
-   | 
+   |
 
 warning: 3 warnings emitted
 

--- a/src/test/ui/lint/force-warn/cap-lints-allow.stderr
+++ b/src/test/ui/lint/force-warn/cap-lints-allow.stderr
@@ -11,7 +11,7 @@ help: use `dyn`
    |
 LL - pub fn function(_x: Box<SomeTrait>) {}
 LL + pub fn function(_x: Box<dyn SomeTrait>) {}
-   | 
+   |
 
 warning: trait objects without an explicit `dyn` are deprecated
   --> $DIR/cap-lints-allow.rs:8:25
@@ -25,7 +25,7 @@ help: use `dyn`
    |
 LL - pub fn function(_x: Box<SomeTrait>) {}
 LL + pub fn function(_x: Box<dyn SomeTrait>) {}
-   | 
+   |
 
 warning: trait objects without an explicit `dyn` are deprecated
   --> $DIR/cap-lints-allow.rs:8:25
@@ -39,7 +39,7 @@ help: use `dyn`
    |
 LL - pub fn function(_x: Box<SomeTrait>) {}
 LL + pub fn function(_x: Box<dyn SomeTrait>) {}
-   | 
+   |
 
 warning: 3 warnings emitted
 

--- a/src/test/ui/lint/force-warn/lint-group-allowed-cli-warn-by-default-lint.stderr
+++ b/src/test/ui/lint/force-warn/lint-group-allowed-cli-warn-by-default-lint.stderr
@@ -11,7 +11,7 @@ help: use `dyn`
    |
 LL - pub fn function(_x: Box<SomeTrait>) {}
 LL + pub fn function(_x: Box<dyn SomeTrait>) {}
-   | 
+   |
 
 warning: trait objects without an explicit `dyn` are deprecated
   --> $DIR/lint-group-allowed-cli-warn-by-default-lint.rs:8:25
@@ -25,7 +25,7 @@ help: use `dyn`
    |
 LL - pub fn function(_x: Box<SomeTrait>) {}
 LL + pub fn function(_x: Box<dyn SomeTrait>) {}
-   | 
+   |
 
 warning: trait objects without an explicit `dyn` are deprecated
   --> $DIR/lint-group-allowed-cli-warn-by-default-lint.rs:8:25
@@ -39,7 +39,7 @@ help: use `dyn`
    |
 LL - pub fn function(_x: Box<SomeTrait>) {}
 LL + pub fn function(_x: Box<dyn SomeTrait>) {}
-   | 
+   |
 
 warning: 3 warnings emitted
 

--- a/src/test/ui/lint/force-warn/lint-group-allowed-lint-group.stderr
+++ b/src/test/ui/lint/force-warn/lint-group-allowed-lint-group.stderr
@@ -11,7 +11,7 @@ help: use `dyn`
    |
 LL - pub fn function(_x: Box<SomeTrait>) {}
 LL + pub fn function(_x: Box<dyn SomeTrait>) {}
-   | 
+   |
 
 warning: trait objects without an explicit `dyn` are deprecated
   --> $DIR/lint-group-allowed-lint-group.rs:10:25
@@ -25,7 +25,7 @@ help: use `dyn`
    |
 LL - pub fn function(_x: Box<SomeTrait>) {}
 LL + pub fn function(_x: Box<dyn SomeTrait>) {}
-   | 
+   |
 
 warning: trait objects without an explicit `dyn` are deprecated
   --> $DIR/lint-group-allowed-lint-group.rs:10:25
@@ -39,7 +39,7 @@ help: use `dyn`
    |
 LL - pub fn function(_x: Box<SomeTrait>) {}
 LL + pub fn function(_x: Box<dyn SomeTrait>) {}
-   | 
+   |
 
 warning: 3 warnings emitted
 

--- a/src/test/ui/lint/force-warn/lint-group-allowed-warn-by-default-lint.stderr
+++ b/src/test/ui/lint/force-warn/lint-group-allowed-warn-by-default-lint.stderr
@@ -11,7 +11,7 @@ help: use `dyn`
    |
 LL - pub fn function(_x: Box<SomeTrait>) {}
 LL + pub fn function(_x: Box<dyn SomeTrait>) {}
-   | 
+   |
 
 warning: trait objects without an explicit `dyn` are deprecated
   --> $DIR/lint-group-allowed-warn-by-default-lint.rs:10:25
@@ -25,7 +25,7 @@ help: use `dyn`
    |
 LL - pub fn function(_x: Box<SomeTrait>) {}
 LL + pub fn function(_x: Box<dyn SomeTrait>) {}
-   | 
+   |
 
 warning: trait objects without an explicit `dyn` are deprecated
   --> $DIR/lint-group-allowed-warn-by-default-lint.rs:10:25
@@ -39,7 +39,7 @@ help: use `dyn`
    |
 LL - pub fn function(_x: Box<SomeTrait>) {}
 LL + pub fn function(_x: Box<dyn SomeTrait>) {}
-   | 
+   |
 
 warning: 3 warnings emitted
 

--- a/src/test/ui/lint/issue-80988.stderr
+++ b/src/test/ui/lint/issue-80988.stderr
@@ -3,7 +3,7 @@ warning: deny(warnings) incompatible with previous forbid
    |
 LL | #![forbid(warnings)]
    |           -------- `forbid` level set here
-LL | 
+LL |
 LL | #[deny(warnings)]
    |        ^^^^^^^^ overruled by previous forbid
    |
@@ -16,7 +16,7 @@ warning: deny(warnings) incompatible with previous forbid
    |
 LL | #![forbid(warnings)]
    |           -------- `forbid` level set here
-LL | 
+LL |
 LL | #[deny(warnings)]
    |        ^^^^^^^^ overruled by previous forbid
    |
@@ -28,7 +28,7 @@ warning: deny(warnings) incompatible with previous forbid
    |
 LL | #![forbid(warnings)]
    |           -------- `forbid` level set here
-LL | 
+LL |
 LL | #[deny(warnings)]
    |        ^^^^^^^^ overruled by previous forbid
    |

--- a/src/test/ui/lint/lint-forbid-attr.stderr
+++ b/src/test/ui/lint/lint-forbid-attr.stderr
@@ -3,7 +3,7 @@ error[E0453]: allow(deprecated) incompatible with previous forbid
    |
 LL | #![forbid(deprecated)]
    |           ---------- `forbid` level set here
-LL | 
+LL |
 LL | #[allow(deprecated)]
    |         ^^^^^^^^^^ overruled by previous forbid
 
@@ -12,7 +12,7 @@ error[E0453]: allow(deprecated) incompatible with previous forbid
    |
 LL | #![forbid(deprecated)]
    |           ---------- `forbid` level set here
-LL | 
+LL |
 LL | #[allow(deprecated)]
    |         ^^^^^^^^^^ overruled by previous forbid
 

--- a/src/test/ui/lint/lint-incoherent-auto-trait-objects.stderr
+++ b/src/test/ui/lint/lint-incoherent-auto-trait-objects.stderr
@@ -3,7 +3,7 @@ error: conflicting implementations of trait `Foo` for type `(dyn std::marker::Se
    |
 LL | impl Foo for dyn Send {}
    | --------------------- first implementation here
-LL | 
+LL |
 LL | impl Foo for dyn Send + Send {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `(dyn std::marker::Send + 'static)`
    |
@@ -16,7 +16,7 @@ error: conflicting implementations of trait `Foo` for type `(dyn std::marker::Se
    |
 LL | impl Foo for dyn Send + Sync {}
    | ---------------------------- first implementation here
-LL | 
+LL |
 LL | impl Foo for dyn Sync + Send {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `(dyn std::marker::Send + std::marker::Sync + 'static)`
    |

--- a/src/test/ui/lint/lint-unnecessary-parens.stderr
+++ b/src/test/ui/lint/lint-unnecessary-parens.stderr
@@ -13,7 +13,7 @@ help: remove these parentheses
    |
 LL -     return (1);
 LL +     return 1;
-   | 
+   |
 
 error: unnecessary parentheses around `return` value
   --> $DIR/lint-unnecessary-parens.rs:16:12
@@ -25,7 +25,7 @@ help: remove these parentheses
    |
 LL -     return (X { y });
 LL +     return X { y };
-   | 
+   |
 
 error: unnecessary parentheses around type
   --> $DIR/lint-unnecessary-parens.rs:19:46
@@ -37,7 +37,7 @@ help: remove these parentheses
    |
 LL - pub fn unused_parens_around_return_type() -> (u32) {
 LL + pub fn unused_parens_around_return_type() -> u32 {
-   | 
+   |
 
 error: unnecessary parentheses around block return value
   --> $DIR/lint-unnecessary-parens.rs:25:9
@@ -49,7 +49,7 @@ help: remove these parentheses
    |
 LL -         (5)
 LL +         5
-   | 
+   |
 
 error: unnecessary parentheses around block return value
   --> $DIR/lint-unnecessary-parens.rs:27:5
@@ -61,7 +61,7 @@ help: remove these parentheses
    |
 LL -     (5)
 LL +     5
-   | 
+   |
 
 error: unnecessary parentheses around assigned value
   --> $DIR/lint-unnecessary-parens.rs:44:31
@@ -73,7 +73,7 @@ help: remove these parentheses
    |
 LL - pub const CONST_ITEM: usize = (10);
 LL + pub const CONST_ITEM: usize = 10;
-   | 
+   |
 
 error: unnecessary parentheses around assigned value
   --> $DIR/lint-unnecessary-parens.rs:45:33
@@ -85,7 +85,7 @@ help: remove these parentheses
    |
 LL - pub static STATIC_ITEM: usize = (10);
 LL + pub static STATIC_ITEM: usize = 10;
-   | 
+   |
 
 error: unnecessary parentheses around function argument
   --> $DIR/lint-unnecessary-parens.rs:49:9
@@ -97,7 +97,7 @@ help: remove these parentheses
    |
 LL -     bar((true));
 LL +     bar(true);
-   | 
+   |
 
 error: unnecessary parentheses around `if` condition
   --> $DIR/lint-unnecessary-parens.rs:51:8
@@ -109,7 +109,7 @@ help: remove these parentheses
    |
 LL -     if (true) {}
 LL +     if true {}
-   | 
+   |
 
 error: unnecessary parentheses around `while` condition
   --> $DIR/lint-unnecessary-parens.rs:52:11
@@ -121,7 +121,7 @@ help: remove these parentheses
    |
 LL -     while (true) {}
 LL +     while true {}
-   | 
+   |
 
 error: unnecessary parentheses around `match` scrutinee expression
   --> $DIR/lint-unnecessary-parens.rs:53:11
@@ -133,7 +133,7 @@ help: remove these parentheses
    |
 LL -     match (true) {
 LL +     match true {
-   | 
+   |
 
 error: unnecessary parentheses around `let` scrutinee expression
   --> $DIR/lint-unnecessary-parens.rs:56:16
@@ -145,7 +145,7 @@ help: remove these parentheses
    |
 LL -     if let 1 = (1) {}
 LL +     if let 1 = 1 {}
-   | 
+   |
 
 error: unnecessary parentheses around `let` scrutinee expression
   --> $DIR/lint-unnecessary-parens.rs:57:19
@@ -157,7 +157,7 @@ help: remove these parentheses
    |
 LL -     while let 1 = (2) {}
 LL +     while let 1 = 2 {}
-   | 
+   |
 
 error: unnecessary parentheses around method argument
   --> $DIR/lint-unnecessary-parens.rs:73:24
@@ -169,7 +169,7 @@ help: remove these parentheses
    |
 LL -     X { y: false }.foo((true));
 LL +     X { y: false }.foo(true);
-   | 
+   |
 
 error: unnecessary parentheses around assigned value
   --> $DIR/lint-unnecessary-parens.rs:75:18
@@ -181,7 +181,7 @@ help: remove these parentheses
    |
 LL -     let mut _a = (0);
 LL +     let mut _a = 0;
-   | 
+   |
 
 error: unnecessary parentheses around assigned value
   --> $DIR/lint-unnecessary-parens.rs:76:10
@@ -193,7 +193,7 @@ help: remove these parentheses
    |
 LL -     _a = (0);
 LL +     _a = 0;
-   | 
+   |
 
 error: unnecessary parentheses around assigned value
   --> $DIR/lint-unnecessary-parens.rs:77:11
@@ -205,7 +205,7 @@ help: remove these parentheses
    |
 LL -     _a += (1);
 LL +     _a += 1;
-   | 
+   |
 
 error: aborting due to 17 previous errors
 

--- a/src/test/ui/lint/must_not_suspend/ref.stderr
+++ b/src/test/ui/lint/must_not_suspend/ref.stderr
@@ -3,7 +3,7 @@ error: `Umm` held across a suspend point, but should not be
    |
 LL |         let guard = &mut self.u;
    |                          ^^^^^^
-LL | 
+LL |
 LL |         other().await;
    |                ------ the value is held across this suspend point
    |

--- a/src/test/ui/lint/must_not_suspend/trait.stderr
+++ b/src/test/ui/lint/must_not_suspend/trait.stderr
@@ -23,7 +23,7 @@ error: boxed `Wow` trait object held across a suspend point, but should not be
    |
 LL |     let _guard2 = r#dyn();
    |         ^^^^^^^
-LL | 
+LL |
 LL |     other().await;
    |            ------ the value is held across this suspend point
    |

--- a/src/test/ui/lint/renamed-lints-still-apply.stderr
+++ b/src/test/ui/lint/renamed-lints-still-apply.stderr
@@ -23,7 +23,7 @@ help: elide the single-use lifetime
    |
 LL - fn _foo<'a>(_x: &'a u32) {}
 LL + fn _foo(_x: &u32) {}
-   | 
+   |
 
 error: aborting due to previous error; 1 warning emitted
 

--- a/src/test/ui/lint/suggestions.stderr
+++ b/src/test/ui/lint/suggestions.stderr
@@ -21,7 +21,7 @@ help: remove these parentheses
    |
 LL -         let mut registry_no = (format!("NX-{}", 74205));
 LL +         let mut registry_no = format!("NX-{}", 74205);
-   | 
+   |
 
 warning: variable does not need to be mutable
   --> $DIR/suggestions.rs:48:13

--- a/src/test/ui/lint/unused/issue-54538-unused-parens-lint.stderr
+++ b/src/test/ui/lint/unused/issue-54538-unused-parens-lint.stderr
@@ -13,7 +13,7 @@ help: remove these parentheses
    |
 LL -     let (a) = 0;
 LL +     let a = 0;
-   | 
+   |
 
 error: unnecessary parentheses around pattern
   --> $DIR/issue-54538-unused-parens-lint.rs:17:9
@@ -25,7 +25,7 @@ help: remove these parentheses
    |
 LL -     for (a) in 0..1 {}
 LL +     for a in 0..1 {}
-   | 
+   |
 
 error: unnecessary parentheses around pattern
   --> $DIR/issue-54538-unused-parens-lint.rs:18:12
@@ -37,7 +37,7 @@ help: remove these parentheses
    |
 LL -     if let (a) = 0 {}
 LL +     if let a = 0 {}
-   | 
+   |
 
 error: unnecessary parentheses around pattern
   --> $DIR/issue-54538-unused-parens-lint.rs:19:15
@@ -49,7 +49,7 @@ help: remove these parentheses
    |
 LL -     while let (a) = 0 {}
 LL +     while let a = 0 {}
-   | 
+   |
 
 error: unnecessary parentheses around pattern
   --> $DIR/issue-54538-unused-parens-lint.rs:20:12
@@ -61,7 +61,7 @@ help: remove these parentheses
    |
 LL -     fn foo((a): u8) {}
 LL +     fn foo(a: u8) {}
-   | 
+   |
 
 error: unnecessary parentheses around pattern
   --> $DIR/issue-54538-unused-parens-lint.rs:21:14
@@ -73,7 +73,7 @@ help: remove these parentheses
    |
 LL -     let _ = |(a): u8| 0;
 LL +     let _ = |a: u8| 0;
-   | 
+   |
 
 error: unnecessary parentheses around pattern
   --> $DIR/issue-54538-unused-parens-lint.rs:49:12
@@ -85,7 +85,7 @@ help: remove these parentheses
    |
 LL -     if let (0 | 1) = 0 {}
 LL +     if let 0 | 1 = 0 {}
-   | 
+   |
 
 error: unnecessary parentheses around pattern
   --> $DIR/issue-54538-unused-parens-lint.rs:50:13
@@ -97,7 +97,7 @@ help: remove these parentheses
    |
 LL -     if let ((0 | 1),) = (0,) {}
 LL +     if let (0 | 1,) = (0,) {}
-   | 
+   |
 
 error: unnecessary parentheses around pattern
   --> $DIR/issue-54538-unused-parens-lint.rs:51:13
@@ -109,7 +109,7 @@ help: remove these parentheses
    |
 LL -     if let [(0 | 1)] = [0] {}
 LL +     if let [0 | 1] = [0] {}
-   | 
+   |
 
 error: unnecessary parentheses around pattern
   --> $DIR/issue-54538-unused-parens-lint.rs:52:16
@@ -121,7 +121,7 @@ help: remove these parentheses
    |
 LL -     if let 0 | (1 | 2) = 0 {}
 LL +     if let 0 | 1 | 2 = 0 {}
-   | 
+   |
 
 error: unnecessary parentheses around pattern
   --> $DIR/issue-54538-unused-parens-lint.rs:54:15
@@ -133,7 +133,7 @@ help: remove these parentheses
    |
 LL -     if let TS((0 | 1)) = TS(0) {}
 LL +     if let TS(0 | 1) = TS(0) {}
-   | 
+   |
 
 error: unnecessary parentheses around pattern
   --> $DIR/issue-54538-unused-parens-lint.rs:56:20
@@ -145,7 +145,7 @@ help: remove these parentheses
    |
 LL -     if let NS { f: (0 | 1) } = (NS { f: 0 }) {}
 LL +     if let NS { f: 0 | 1 } = (NS { f: 0 }) {}
-   | 
+   |
 
 error: unnecessary parentheses around pattern
   --> $DIR/issue-54538-unused-parens-lint.rs:66:9
@@ -157,7 +157,7 @@ help: remove these parentheses
    |
 LL -         (_) => {}
 LL +         _ => {}
-   | 
+   |
 
 error: unnecessary parentheses around pattern
   --> $DIR/issue-54538-unused-parens-lint.rs:67:9
@@ -169,7 +169,7 @@ help: remove these parentheses
    |
 LL -         (y) => {}
 LL +         y => {}
-   | 
+   |
 
 error: unnecessary parentheses around pattern
   --> $DIR/issue-54538-unused-parens-lint.rs:68:9
@@ -181,7 +181,7 @@ help: remove these parentheses
    |
 LL -         (ref r) => {}
 LL +         ref r => {}
-   | 
+   |
 
 error: unnecessary parentheses around pattern
   --> $DIR/issue-54538-unused-parens-lint.rs:69:9
@@ -193,7 +193,7 @@ help: remove these parentheses
    |
 LL -         (e @ 1...2) => {}
 LL +         e @ 1...2 => {}
-   | 
+   |
 
 error: unnecessary parentheses around pattern
   --> $DIR/issue-54538-unused-parens-lint.rs:75:9
@@ -205,7 +205,7 @@ help: remove these parentheses
    |
 LL -         (e @ &(1...2)) => {}
 LL +         e @ &(1...2) => {}
-   | 
+   |
 
 error: unnecessary parentheses around pattern
   --> $DIR/issue-54538-unused-parens-lint.rs:76:10
@@ -217,7 +217,7 @@ help: remove these parentheses
    |
 LL -         &(_) => {}
 LL +         &_ => {}
-   | 
+   |
 
 error: unnecessary parentheses around pattern
   --> $DIR/issue-54538-unused-parens-lint.rs:87:9
@@ -229,7 +229,7 @@ help: remove these parentheses
    |
 LL -         (_) => {}
 LL +         _ => {}
-   | 
+   |
 
 error: unnecessary parentheses around pattern
   --> $DIR/issue-54538-unused-parens-lint.rs:88:9
@@ -241,7 +241,7 @@ help: remove these parentheses
    |
 LL -         (y) => {}
 LL +         y => {}
-   | 
+   |
 
 error: unnecessary parentheses around pattern
   --> $DIR/issue-54538-unused-parens-lint.rs:89:9
@@ -253,7 +253,7 @@ help: remove these parentheses
    |
 LL -         (ref r) => {}
 LL +         ref r => {}
-   | 
+   |
 
 error: unnecessary parentheses around pattern
   --> $DIR/issue-54538-unused-parens-lint.rs:90:9
@@ -265,7 +265,7 @@ help: remove these parentheses
    |
 LL -         (e @ 1..=2) => {}
 LL +         e @ 1..=2 => {}
-   | 
+   |
 
 error: unnecessary parentheses around pattern
   --> $DIR/issue-54538-unused-parens-lint.rs:96:9
@@ -277,7 +277,7 @@ help: remove these parentheses
    |
 LL -         (e @ &(1..=2)) => {}
 LL +         e @ &(1..=2) => {}
-   | 
+   |
 
 error: unnecessary parentheses around pattern
   --> $DIR/issue-54538-unused-parens-lint.rs:97:10
@@ -289,7 +289,7 @@ help: remove these parentheses
    |
 LL -         &(_) => {}
 LL +         &_ => {}
-   | 
+   |
 
 error: aborting due to 24 previous errors
 

--- a/src/test/ui/lint/unused/issue-74883-unused-paren-baren-yield.stderr
+++ b/src/test/ui/lint/unused/issue-74883-unused-paren-baren-yield.stderr
@@ -13,7 +13,7 @@ help: remove these parentheses
    |
 LL -         while let Some(_) = ({yield}) {}
 LL +         while let Some(_) = {yield} {}
-   | 
+   |
 
 error: unnecessary parentheses around `let` scrutinee expression
   --> $DIR/issue-74883-unused-paren-baren-yield.rs:15:29
@@ -25,7 +25,7 @@ help: remove these parentheses
    |
 LL -         while let Some(_) = ((yield)) {}
 LL +         while let Some(_) = (yield) {}
-   | 
+   |
 
 error: unnecessary braces around block return value
   --> $DIR/issue-74883-unused-paren-baren-yield.rs:16:10
@@ -42,7 +42,7 @@ help: remove these braces
    |
 LL -         {{yield}};
 LL +         {yield};
-   | 
+   |
 
 error: unnecessary parentheses around block return value
   --> $DIR/issue-74883-unused-paren-baren-yield.rs:17:10
@@ -54,7 +54,7 @@ help: remove these parentheses
    |
 LL -         {( yield )};
 LL +         {yield};
-   | 
+   |
 
 error: unnecessary parentheses around block return value
   --> $DIR/issue-74883-unused-paren-baren-yield.rs:18:30
@@ -66,7 +66,7 @@ help: remove these parentheses
    |
 LL -         while let Some(_) = {(yield)} {}
 LL +         while let Some(_) = {yield} {}
-   | 
+   |
 
 error: unnecessary braces around block return value
   --> $DIR/issue-74883-unused-paren-baren-yield.rs:19:30
@@ -78,7 +78,7 @@ help: remove these braces
    |
 LL -         while let Some(_) = {{yield}} {}
 LL +         while let Some(_) = {yield} {}
-   | 
+   |
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/lint/unused/issue-90807-unused-paren-error.stderr
+++ b/src/test/ui/lint/unused/issue-90807-unused-paren-error.stderr
@@ -13,7 +13,7 @@ help: remove these parentheses
    |
 LL -     for _ in (1..loop { break 2 }) {}
 LL +     for _ in 1..loop { break 2 } {}
-   | 
+   |
 
 error: unnecessary parentheses around `for` iterator expression
   --> $DIR/issue-90807-unused-paren-error.rs:8:14
@@ -25,7 +25,7 @@ help: remove these parentheses
    |
 LL -     for _ in (1..match () { () => 2 }) {}
 LL +     for _ in 1..match () { () => 2 } {}
-   | 
+   |
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/lint/unused_braces.stderr
+++ b/src/test/ui/lint/unused_braces.stderr
@@ -13,7 +13,7 @@ help: remove these parentheses
    |
 LL -     let _ = (7);
 LL +     let _ = 7;
-   | 
+   |
 
 warning: unnecessary braces around `if` condition
   --> $DIR/unused_braces.rs:26:8
@@ -30,7 +30,7 @@ help: remove these braces
    |
 LL -     if { true } {
 LL +     if true {
-   | 
+   |
 
 warning: unnecessary braces around `while` condition
   --> $DIR/unused_braces.rs:30:11
@@ -42,7 +42,7 @@ help: remove these braces
    |
 LL -     while { false } {
 LL +     while false {
-   | 
+   |
 
 warning: unnecessary braces around const expression
   --> $DIR/unused_braces.rs:34:17
@@ -54,7 +54,7 @@ help: remove these braces
    |
 LL -     let _: [u8; { 3 }];
 LL +     let _: [u8; 3];
-   | 
+   |
 
 warning: unnecessary braces around function argument
   --> $DIR/unused_braces.rs:37:13
@@ -66,7 +66,7 @@ help: remove these braces
    |
 LL -     consume({ 7 });
 LL +     consume(7);
-   | 
+   |
 
 warning: 5 warnings emitted
 

--- a/src/test/ui/lint/unused_braces_borrow.stderr
+++ b/src/test/ui/lint/unused_braces_borrow.stderr
@@ -13,7 +13,7 @@ help: remove these braces
    |
 LL -     consume({ a.b });
 LL +     consume(a.b);
-   | 
+   |
 
 warning: 1 warning emitted
 

--- a/src/test/ui/lint/unused_parens_json_suggestion.stderr
+++ b/src/test/ui/lint/unused_parens_json_suggestion.stderr
@@ -13,7 +13,7 @@ help: remove these parentheses
    |
 LL -     let _a = (1 / (2 + 3));
 LL +     let _a = 1 / (2 + 3);
-   | 
+   |
 
 "}
 {"message":"aborting due to previous error","code":null,"level":"error","spans":[],"children":[],"rendered":"error: aborting due to previous error

--- a/src/test/ui/lint/unused_parens_remove_json_suggestion.stderr
+++ b/src/test/ui/lint/unused_parens_remove_json_suggestion.stderr
@@ -13,7 +13,7 @@ help: remove these parentheses
    |
 LL -     if (_b) {
 LL +     if _b {
-   | 
+   |
 
 "}
 {"message":"unnecessary parentheses around `if` condition","code":{"code":"unused_parens","explanation":null},"level":"error","spans":[{"file_name":"$DIR/unused_parens_remove_json_suggestion.rs","byte_start":612,"byte_end":613,"line_start":28,"line_end":28,"column_start":7,"column_end":8,"is_primary":true,"text":[{"text":"    if(c) {
@@ -26,7 +26,7 @@ help: remove these parentheses
    |
 LL -     if(c) {
 LL +     if c {
-   | 
+   |
 
 "}
 {"message":"unnecessary parentheses around `if` condition","code":{"code":"unused_parens","explanation":null},"level":"error","spans":[{"file_name":"$DIR/unused_parens_remove_json_suggestion.rs","byte_start":692,"byte_end":693,"line_start":32,"line_end":32,"column_start":8,"column_end":9,"is_primary":true,"text":[{"text":"    if (c){
@@ -39,7 +39,7 @@ help: remove these parentheses
    |
 LL -     if (c){
 LL +     if c {
-   | 
+   |
 
 "}
 {"message":"unnecessary parentheses around `while` condition","code":{"code":"unused_parens","explanation":null},"level":"error","spans":[{"file_name":"$DIR/unused_parens_remove_json_suggestion.rs","byte_start":774,"byte_end":775,"line_start":36,"line_end":36,"column_start":11,"column_end":12,"is_primary":true,"text":[{"text":"    while (false && true){","highlight_start":11,"highlight_end":12}],"label":null,"suggested_replacement":null,"suggestion_applicability":null,"expansion":null},{"file_name":"$DIR/unused_parens_remove_json_suggestion.rs","byte_start":788,"byte_end":789,"line_start":36,"line_end":36,"column_start":25,"column_end":26,"is_primary":true,"text":[{"text":"    while (false && true){","highlight_start":25,"highlight_end":26}],"label":null,"suggested_replacement":null,"suggestion_applicability":null,"expansion":null}],"children":[{"message":"remove these parentheses","code":null,"level":"help","spans":[{"file_name":"$DIR/unused_parens_remove_json_suggestion.rs","byte_start":774,"byte_end":775,"line_start":36,"line_end":36,"column_start":11,"column_end":12,"is_primary":true,"text":[{"text":"    while (false && true){","highlight_start":11,"highlight_end":12}],"label":null,"suggested_replacement":"","suggestion_applicability":"MachineApplicable","expansion":null},{"file_name":"$DIR/unused_parens_remove_json_suggestion.rs","byte_start":788,"byte_end":789,"line_start":36,"line_end":36,"column_start":25,"column_end":26,"is_primary":true,"text":[{"text":"    while (false && true){","highlight_start":25,"highlight_end":26}],"label":null,"suggested_replacement":" ","suggestion_applicability":"MachineApplicable","expansion":null}],"children":[],"rendered":null}],"rendered":"error: unnecessary parentheses around `while` condition
@@ -52,7 +52,7 @@ help: remove these parentheses
    |
 LL -     while (false && true){
 LL +     while false && true {
-   | 
+   |
 
 "}
 {"message":"unnecessary parentheses around `if` condition","code":{"code":"unused_parens","explanation":null},"level":"error","spans":[{"file_name":"$DIR/unused_parens_remove_json_suggestion.rs","byte_start":802,"byte_end":803,"line_start":37,"line_end":37,"column_start":12,"column_end":13,"is_primary":true,"text":[{"text":"        if (c) {
@@ -65,7 +65,7 @@ help: remove these parentheses
    |
 LL -         if (c) {
 LL +         if c {
-   | 
+   |
 
 "}
 {"message":"unnecessary parentheses around `while` condition","code":{"code":"unused_parens","explanation":null},"level":"error","spans":[{"file_name":"$DIR/unused_parens_remove_json_suggestion.rs","byte_start":899,"byte_end":900,"line_start":43,"line_end":43,"column_start":10,"column_end":11,"is_primary":true,"text":[{"text":"    while(true && false) {
@@ -78,7 +78,7 @@ help: remove these parentheses
    |
 LL -     while(true && false) {
 LL +     while true && false {
-   | 
+   |
 
 "}
 {"message":"unnecessary parentheses around `for` iterator expression","code":{"code":"unused_parens","explanation":null},"level":"error","spans":[{"file_name":"$DIR/unused_parens_remove_json_suggestion.rs","byte_start":968,"byte_end":969,"line_start":44,"line_end":44,"column_start":18,"column_end":19,"is_primary":true,"text":[{"text":"        for _ in (0 .. 3){
@@ -91,7 +91,7 @@ help: remove these parentheses
    |
 LL -         for _ in (0 .. 3){
 LL +         for _ in 0 .. 3 {
-   | 
+   |
 
 "}
 {"message":"unnecessary parentheses around `for` iterator expression","code":{"code":"unused_parens","explanation":null},"level":"error","spans":[{"file_name":"$DIR/unused_parens_remove_json_suggestion.rs","byte_start":1069,"byte_end":1070,"line_start":49,"line_end":49,"column_start":14,"column_end":15,"is_primary":true,"text":[{"text":"    for _ in (0 .. 3) {
@@ -104,7 +104,7 @@ help: remove these parentheses
    |
 LL -     for _ in (0 .. 3) {
 LL +     for _ in 0 .. 3 {
-   | 
+   |
 
 "}
 {"message":"unnecessary parentheses around `while` condition","code":{"code":"unused_parens","explanation":null},"level":"error","spans":[{"file_name":"$DIR/unused_parens_remove_json_suggestion.rs","byte_start":1128,"byte_end":1129,"line_start":50,"line_end":50,"column_start":15,"column_end":16,"is_primary":true,"text":[{"text":"        while (true && false) {
@@ -117,7 +117,7 @@ help: remove these parentheses
    |
 LL -         while (true && false) {
 LL +         while true && false {
-   | 
+   |
 
 "}
 {"message":"aborting due to 9 previous errors","code":null,"level":"error","spans":[],"children":[],"rendered":"error: aborting due to 9 previous errors

--- a/src/test/ui/liveness/liveness-use-after-move.stderr
+++ b/src/test/ui/liveness/liveness-use-after-move.stderr
@@ -5,7 +5,7 @@ LL |     let x: Box<_> = 5.into();
    |         - move occurs because `x` has type `Box<i32>`, which does not implement the `Copy` trait
 LL |     let y = x;
    |             - value moved here
-LL | 
+LL |
 LL |     println!("{}", *x);
    |                    ^^ value borrowed here after move
    |

--- a/src/test/ui/macros/macro-outer-attributes.stderr
+++ b/src/test/ui/macros/macro-outer-attributes.stderr
@@ -12,7 +12,7 @@ help: if you import `bar`, refer to it directly
    |
 LL -     a::bar();
 LL +     bar();
-   | 
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/match/match-tag-nullary.stderr
+++ b/src/test/ui/match/match-tag-nullary.stderr
@@ -3,7 +3,7 @@ error[E0308]: mismatched types
    |
 LL | enum B { B }
    |          - unit variant defined here
-LL | 
+LL |
 LL | fn main() { let x: A = A::A; match x { B::B => { } } }
    |                                    -   ^^^^ expected enum `A`, found enum `B`
    |                                    |

--- a/src/test/ui/mismatched_types/cast-rfc0401.stderr
+++ b/src/test/ui/mismatched_types/cast-rfc0401.stderr
@@ -30,7 +30,7 @@ help: consider borrowing the value
    |
 LL -     let _ = v as &u8;
 LL +     let _ = &*v;
-   | 
+   |
 
 error[E0605]: non-primitive cast: `*const u8` as `E`
   --> $DIR/cast-rfc0401.rs:30:13

--- a/src/test/ui/mismatched_types/issue-38371.stderr
+++ b/src/test/ui/mismatched_types/issue-38371.stderr
@@ -12,7 +12,7 @@ help: to take parameter `_a` by reference, move `&` to the type
    |
 LL - fn foo(&_a: Foo) {}
 LL + fn foo(_a: &Foo) {}
-   | 
+   |
 
 error[E0308]: mismatched types
   --> $DIR/issue-38371.rs:16:9
@@ -28,7 +28,7 @@ help: consider removing `&` from the pattern
    |
 LL - fn agh(&&_a: &u32) {}
 LL + fn agh(&_a: &u32) {}
-   | 
+   |
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/mismatched_types/ref-pat-suggestions.stderr
+++ b/src/test/ui/mismatched_types/ref-pat-suggestions.stderr
@@ -12,7 +12,7 @@ help: to take parameter `_a` by reference, move `&` to the type
    |
 LL - fn _f0(&_a: u32) {}
 LL + fn _f0(_a: &u32) {}
-   | 
+   |
 
 error[E0308]: mismatched types
   --> $DIR/ref-pat-suggestions.rs:4:8
@@ -28,7 +28,7 @@ help: to take parameter `_a` by reference, move `&mut` to the type
    |
 LL - fn _f1(&mut _a: u32) {}
 LL + fn _f1(_a: &mut u32) {}
-   | 
+   |
 
 error[E0308]: mismatched types
   --> $DIR/ref-pat-suggestions.rs:5:9
@@ -44,7 +44,7 @@ help: consider removing `&` from the pattern
    |
 LL - fn _f2(&&_a: &u32) {}
 LL + fn _f2(&_a: &u32) {}
-   | 
+   |
 
 error[E0308]: mismatched types
   --> $DIR/ref-pat-suggestions.rs:6:13
@@ -60,7 +60,7 @@ help: consider removing `&` from the pattern
    |
 LL - fn _f3(&mut &_a: &mut u32) {}
 LL + fn _f3(&mut _a: &mut u32) {}
-   | 
+   |
 
 error[E0308]: mismatched types
   --> $DIR/ref-pat-suggestions.rs:7:9
@@ -76,7 +76,7 @@ help: consider removing `&mut` from the pattern
    |
 LL - fn _f4(&&mut _a: &u32) {}
 LL + fn _f4(&_a: &u32) {}
-   | 
+   |
 
 error[E0308]: mismatched types
   --> $DIR/ref-pat-suggestions.rs:8:13
@@ -92,7 +92,7 @@ help: consider removing `&mut` from the pattern
    |
 LL - fn _f5(&mut &mut _a: &mut u32) {}
 LL + fn _f5(&mut _a: &mut u32) {}
-   | 
+   |
 
 error[E0308]: mismatched types
   --> $DIR/ref-pat-suggestions.rs:11:23
@@ -109,7 +109,7 @@ help: consider removing `&` from the pattern
    |
 LL -     let _: fn(u32) = |&_a| ();
 LL +     let _: fn(u32) = |_a| ();
-   | 
+   |
 
 error[E0308]: mismatched types
   --> $DIR/ref-pat-suggestions.rs:12:23
@@ -126,7 +126,7 @@ help: consider removing `&mut` from the pattern
    |
 LL -     let _: fn(u32) = |&mut _a| ();
 LL +     let _: fn(u32) = |_a| ();
-   | 
+   |
 
 error[E0308]: mismatched types
   --> $DIR/ref-pat-suggestions.rs:13:25
@@ -143,7 +143,7 @@ help: consider removing `&` from the pattern
    |
 LL -     let _: fn(&u32) = |&&_a| ();
 LL +     let _: fn(&u32) = |&_a| ();
-   | 
+   |
 
 error[E0308]: mismatched types
   --> $DIR/ref-pat-suggestions.rs:14:33
@@ -160,7 +160,7 @@ help: consider removing `&` from the pattern
    |
 LL -     let _: fn(&mut u32) = |&mut &_a| ();
 LL +     let _: fn(&mut u32) = |&mut _a| ();
-   | 
+   |
 
 error[E0308]: mismatched types
   --> $DIR/ref-pat-suggestions.rs:15:25
@@ -177,7 +177,7 @@ help: consider removing `&mut` from the pattern
    |
 LL -     let _: fn(&u32) = |&&mut _a| ();
 LL +     let _: fn(&u32) = |&_a| ();
-   | 
+   |
 
 error[E0308]: mismatched types
   --> $DIR/ref-pat-suggestions.rs:16:33
@@ -194,7 +194,7 @@ help: consider removing `&mut` from the pattern
    |
 LL -     let _: fn(&mut u32) = |&mut &mut _a| ();
 LL +     let _: fn(&mut u32) = |&mut _a| ();
-   | 
+   |
 
 error[E0308]: mismatched types
   --> $DIR/ref-pat-suggestions.rs:18:14
@@ -210,7 +210,7 @@ help: to take parameter `_a` by reference, move `&` to the type
    |
 LL -     let _ = |&_a: u32| ();
 LL +     let _ = |_a: &u32| ();
-   | 
+   |
 
 error[E0308]: mismatched types
   --> $DIR/ref-pat-suggestions.rs:19:14
@@ -226,7 +226,7 @@ help: to take parameter `_a` by reference, move `&mut` to the type
    |
 LL -     let _ = |&mut _a: u32| ();
 LL +     let _ = |_a: &mut u32| ();
-   | 
+   |
 
 error[E0308]: mismatched types
   --> $DIR/ref-pat-suggestions.rs:20:15
@@ -242,7 +242,7 @@ help: consider removing `&` from the pattern
    |
 LL -     let _ = |&&_a: &u32| ();
 LL +     let _ = |&_a: &u32| ();
-   | 
+   |
 
 error[E0308]: mismatched types
   --> $DIR/ref-pat-suggestions.rs:21:19
@@ -258,7 +258,7 @@ help: consider removing `&` from the pattern
    |
 LL -     let _ = |&mut &_a: &mut u32| ();
 LL +     let _ = |&mut _a: &mut u32| ();
-   | 
+   |
 
 error[E0308]: mismatched types
   --> $DIR/ref-pat-suggestions.rs:22:15
@@ -274,7 +274,7 @@ help: consider removing `&mut` from the pattern
    |
 LL -     let _ = |&&mut _a: &u32| ();
 LL +     let _ = |&_a: &u32| ();
-   | 
+   |
 
 error[E0308]: mismatched types
   --> $DIR/ref-pat-suggestions.rs:23:19
@@ -290,7 +290,7 @@ help: consider removing `&mut` from the pattern
    |
 LL -     let _ = |&mut &mut _a: &mut u32| ();
 LL +     let _ = |&mut _a: &mut u32| ();
-   | 
+   |
 
 error: aborting due to 18 previous errors
 

--- a/src/test/ui/missing/missing-items/missing-type-parameter2.stderr
+++ b/src/test/ui/missing/missing-items/missing-type-parameter2.stderr
@@ -3,7 +3,7 @@ error[E0412]: cannot find type `N` in this scope
    |
 LL | struct X<const N: u8>();
    | ------------------------ similarly named struct `X` defined here
-LL | 
+LL |
 LL | impl X<N> {}
    |        ^
    |

--- a/src/test/ui/namespace/namespace-mix.stderr
+++ b/src/test/ui/namespace/namespace-mix.stderr
@@ -22,7 +22,7 @@ help: if you import `S`, refer to it directly
    |
 LL -     check(m1::S);
 LL +     check(S);
-   | 
+   |
 
 error[E0423]: expected value, found type alias `xm1::S`
   --> $DIR/namespace-mix.rs:40:11
@@ -50,7 +50,7 @@ help: if you import `S`, refer to it directly
    |
 LL -     check(xm1::S);
 LL +     check(S);
-   | 
+   |
 
 error[E0423]: expected value, found struct variant `m7::V`
   --> $DIR/namespace-mix.rs:100:11
@@ -81,7 +81,7 @@ help: if you import `V`, refer to it directly
    |
 LL -     check(m7::V);
 LL +     check(V);
-   | 
+   |
 
 error[E0423]: expected value, found struct variant `xm7::V`
   --> $DIR/namespace-mix.rs:106:11
@@ -114,7 +114,7 @@ help: if you import `V`, refer to it directly
    |
 LL -     check(xm7::V);
 LL +     check(V);
-   | 
+   |
 
 error[E0277]: the trait bound `c::Item: Impossible` is not satisfied
   --> $DIR/namespace-mix.rs:33:11

--- a/src/test/ui/never_type/diverging-tuple-parts-39485.stderr
+++ b/src/test/ui/never_type/diverging-tuple-parts-39485.stderr
@@ -14,7 +14,7 @@ help: consider removing the borrow
    |
 LL -     &panic!()
 LL +     panic!()
-   | 
+   |
 
 error[E0308]: mismatched types
   --> $DIR/diverging-tuple-parts-39485.rs:12:5

--- a/src/test/ui/never_type/issue-52443.stderr
+++ b/src/test/ui/never_type/issue-52443.stderr
@@ -27,7 +27,7 @@ help: consider removing the borrow
    |
 LL -     [(); & { loop { continue } } ];
 LL +     [(); { loop { continue } } ];
-   | 
+   |
 
 error[E0308]: mismatched types
   --> $DIR/issue-52443.rs:4:17

--- a/src/test/ui/nll/capture-ref-in-struct.stderr
+++ b/src/test/ui/nll/capture-ref-in-struct.stderr
@@ -6,7 +6,7 @@ LL |             y: &y,
 ...
 LL |     }
    |     - `y` dropped here while still borrowed
-LL | 
+LL |
 LL |     deref(p);
    |           - borrow later used here
 

--- a/src/test/ui/nll/closure-requirements/escape-argument.stderr
+++ b/src/test/ui/nll/closure-requirements/escape-argument.stderr
@@ -32,7 +32,7 @@ LL |         closure(&mut p, &y);
 LL |
 LL |     }
    |     - `y` dropped here while still borrowed
-LL | 
+LL |
 LL |     deref(p);
    |           - borrow later used here
 

--- a/src/test/ui/nll/closure-requirements/escape-upvar-nested.stderr
+++ b/src/test/ui/nll/closure-requirements/escape-upvar-nested.stderr
@@ -54,7 +54,7 @@ LL |             let mut closure1 = || p = &y;
 ...
 LL |     }
    |     - `y` dropped here while still borrowed
-LL | 
+LL |
 LL |     deref(p);
    |           - borrow later used here
 

--- a/src/test/ui/nll/closure-requirements/escape-upvar-ref.stderr
+++ b/src/test/ui/nll/closure-requirements/escape-upvar-ref.stderr
@@ -36,7 +36,7 @@ LL |         let mut closure = || p = &y;
 ...
 LL |     }
    |     - `y` dropped here while still borrowed
-LL | 
+LL |
 LL |     deref(p);
    |           - borrow later used here
 

--- a/src/test/ui/nll/issue-52534-2.stderr
+++ b/src/test/ui/nll/issue-52534-2.stderr
@@ -6,7 +6,7 @@ LL |         y = &x
 LL |
 LL |     }
    |     - `x` dropped here while still borrowed
-LL | 
+LL |
 LL |     println!("{}", y);
    |                    - borrow later used here
 

--- a/src/test/ui/nll/issue-54382-use-span-of-tail-of-block.stderr
+++ b/src/test/ui/nll/issue-54382-use-span-of-tail-of-block.stderr
@@ -9,7 +9,7 @@ LL |             D("other").next(&_thing1)
 ...
 LL |     }
    |     - `_thing1` dropped here while still borrowed
-LL | 
+LL |
 LL |     ;
    |     - ... and the borrow might be used here, when that temporary is dropped and runs the `Drop` code for type `D`
    |

--- a/src/test/ui/nll/issue-54556-temps-in-tail-diagnostic.stderr
+++ b/src/test/ui/nll/issue-54556-temps-in-tail-diagnostic.stderr
@@ -8,7 +8,7 @@ LL |         D(&_thing1).end()
    |         a temporary with access to the borrow is created here ...
 LL |     }
    |     - `_thing1` dropped here while still borrowed
-LL | 
+LL |
 LL |     ;
    |     - ... and the borrow might be used here, when that temporary is dropped and runs the `Drop` code for type `D`
    |

--- a/src/test/ui/no-capture-arc.stderr
+++ b/src/test/ui/no-capture-arc.stderr
@@ -3,7 +3,7 @@ error[E0382]: borrow of moved value: `arc_v`
    |
 LL |     let arc_v = Arc::new(v);
    |         ----- move occurs because `arc_v` has type `Arc<Vec<i32>>`, which does not implement the `Copy` trait
-LL | 
+LL |
 LL |     thread::spawn(move|| {
    |                   ------ value moved into closure here
 LL |         assert_eq!((*arc_v)[3], 4);

--- a/src/test/ui/no-reuse-move-arc.stderr
+++ b/src/test/ui/no-reuse-move-arc.stderr
@@ -3,7 +3,7 @@ error[E0382]: borrow of moved value: `arc_v`
    |
 LL |     let arc_v = Arc::new(v);
    |         ----- move occurs because `arc_v` has type `Arc<Vec<i32>>`, which does not implement the `Copy` trait
-LL | 
+LL |
 LL |     thread::spawn(move|| {
    |                   ------ value moved into closure here
 LL |         assert_eq!((*arc_v)[3], 4);

--- a/src/test/ui/non-fmt-panic.stderr
+++ b/src/test/ui/non-fmt-panic.stderr
@@ -296,7 +296,7 @@ help: remove the `format!(..)` macro call
    |
 LL -     panic!(format!("{}", 1));
 LL +     panic!("{}", 1);
-   | 
+   |
 
 warning: panic message is not a string literal
   --> $DIR/non-fmt-panic.rs:50:18
@@ -311,7 +311,7 @@ help: remove the `format!(..)` macro call
    |
 LL -     unreachable!(format!("{}", 1));
 LL +     unreachable!("{}", 1);
-   | 
+   |
 
 warning: panic message is not a string literal
   --> $DIR/non-fmt-panic.rs:51:20
@@ -326,7 +326,7 @@ help: remove the `format!(..)` macro call
    |
 LL -     assert!(false, format!("{}", 1));
 LL +     assert!(false, "{}", 1);
-   | 
+   |
 
 warning: panic message is not a string literal
   --> $DIR/non-fmt-panic.rs:52:26
@@ -341,7 +341,7 @@ help: remove the `format!(..)` macro call
    |
 LL -     debug_assert!(false, format!("{}", 1));
 LL +     debug_assert!(false, "{}", 1);
-   | 
+   |
 
 warning: panic message is not a string literal
   --> $DIR/non-fmt-panic.rs:54:12

--- a/src/test/ui/not-clone-closure.stderr
+++ b/src/test/ui/not-clone-closure.stderr
@@ -6,7 +6,7 @@ LL |       let hello = move || {
 LL | |         println!("Hello {}", a.0);
 LL | |     };
    | |_____- within this `[closure@$DIR/not-clone-closure.rs:7:17: 9:6]`
-LL | 
+LL |
 LL |       let hello = hello.clone();
    |                         ^^^^^ within `[closure@$DIR/not-clone-closure.rs:7:17: 9:6]`, the trait `Clone` is not implemented for `S`
    |

--- a/src/test/ui/packed/issue-27060-2.stderr
+++ b/src/test/ui/packed/issue-27060-2.stderr
@@ -12,7 +12,7 @@ help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - pub struct Bad<T: ?Sized> {
 LL + pub struct Bad<T> {
-   | 
+   |
 help: borrowed types always have a statically known size
    |
 LL |     data: &T,

--- a/src/test/ui/parser/attr-stmt-expr-attr-bad.stderr
+++ b/src/test/ui/parser/attr-stmt-expr-attr-bad.stderr
@@ -322,7 +322,7 @@ help: to annotate the item macro invocation, change the attribute from inner to 
    |
 LL - #[cfg(FALSE)] fn s() { #[attr] #![attr] foo!(); }
 LL + #[cfg(FALSE)] fn s() { #[attr] #[attr] foo!(); }
-   | 
+   |
 
 error: an inner attribute is not permitted following an outer attribute
   --> $DIR/attr-stmt-expr-attr-bad.rs:80:32
@@ -338,7 +338,7 @@ help: to annotate the item macro invocation, change the attribute from inner to 
    |
 LL - #[cfg(FALSE)] fn s() { #[attr] #![attr] foo![]; }
 LL + #[cfg(FALSE)] fn s() { #[attr] #[attr] foo![]; }
-   | 
+   |
 
 error: an inner attribute is not permitted following an outer attribute
   --> $DIR/attr-stmt-expr-attr-bad.rs:82:32
@@ -354,7 +354,7 @@ help: to annotate the item macro invocation, change the attribute from inner to 
    |
 LL - #[cfg(FALSE)] fn s() { #[attr] #![attr] foo!{}; }
 LL + #[cfg(FALSE)] fn s() { #[attr] #[attr] foo!{}; }
-   | 
+   |
 
 error[E0586]: inclusive range with no end
   --> $DIR/attr-stmt-expr-attr-bad.rs:88:35

--- a/src/test/ui/parser/attr-with-a-semicolon.stderr
+++ b/src/test/ui/parser/attr-with-a-semicolon.stderr
@@ -8,7 +8,7 @@ help: consider removing this semicolon
    |
 LL - #[derive(Debug, Clone)];
 LL + #[derive(Debug, Clone)]
-   | 
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/attr.stderr
+++ b/src/test/ui/parser/attr.stderr
@@ -11,7 +11,7 @@ help: to annotate the function, change the attribute from inner to outer style
    |
 LL - #![lang = "foo"]
 LL + #[lang = "foo"]
-   | 
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/circular_modules_main.stderr
+++ b/src/test/ui/parser/circular_modules_main.stderr
@@ -18,7 +18,7 @@ help: if you import `hi_str`, refer to it directly
    |
 LL -     println!("{}", circular_modules_main::hi_str());
 LL +     println!("{}", hi_str());
-   | 
+   |
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/parser/doc-comment-in-if-statement.stderr
+++ b/src/test/ui/parser/doc-comment-in-if-statement.stderr
@@ -9,7 +9,7 @@ help: you might have meant to write a regular comment
    |
 LL -     if true /*!*/ {}
 LL +     if true /**/ {}
-   | 
+   |
 
 error: outer attributes are not allowed on `if` and `else` branches
   --> $DIR/doc-comment-in-if-statement.rs:2:13

--- a/src/test/ui/parser/expr-as-stmt-2.stderr
+++ b/src/test/ui/parser/expr-as-stmt-2.stderr
@@ -40,7 +40,7 @@ help: consider removing the `&&`
    |
 LL -     &&
 LL +     if let Some(y) = a { true } else { false }
-   | 
+   |
 help: parentheses are required to parse this as an expression
    |
 LL |     (if let Some(x) = a { true } else { false })

--- a/src/test/ui/parser/expr-as-stmt.stderr
+++ b/src/test/ui/parser/expr-as-stmt.stderr
@@ -174,7 +174,7 @@ help: consider removing the `&&`
    |
 LL -     { true } && { true }
 LL +     { true } { true }
-   | 
+   |
 help: parentheses are required to parse this as an expression
    |
 LL |     ({ true }) && { true }

--- a/src/test/ui/parser/increment-autofix.stderr
+++ b/src/test/ui/parser/increment-autofix.stderr
@@ -8,7 +8,7 @@ help: use `+= 1` instead
    |
 LL -     ++i;
 LL +     i += 1;
-   | 
+   |
 
 error: Rust has no prefix increment operator
   --> $DIR/increment-autofix.rs:11:11
@@ -33,7 +33,7 @@ help: use `+= 1` instead
    |
 LL -     ++tmp;
 LL +     tmp += 1;
-   | 
+   |
 
 error: Rust has no prefix increment operator
   --> $DIR/increment-autofix.rs:25:11

--- a/src/test/ui/parser/increment-notfixed.stderr
+++ b/src/test/ui/parser/increment-notfixed.stderr
@@ -10,7 +10,7 @@ LL |     { let tmp = i; i += 1; tmp };
    |     +++++++++++  ~~~~~~~~~~~~~~~
 LL -     i++;
 LL +     i += 1;
-   | 
+   |
 
 error: Rust has no postfix increment operator
   --> $DIR/increment-notfixed.rs:17:12
@@ -26,7 +26,7 @@ LL |     while { let tmp = i; i += 1; tmp } < 5 {
    |           +++++++++++  ~~~~~~~~~~~~~~~
 LL -     while i++ < 5 {
 LL +     while i += 1 < 5 {
-   | 
+   |
 
 error: Rust has no postfix increment operator
   --> $DIR/increment-notfixed.rs:25:8
@@ -40,7 +40,7 @@ LL |     { let tmp_ = tmp; tmp += 1; tmp_ };
    |     ++++++++++++    ~~~~~~~~~~~~~~~~~~
 LL -     tmp++;
 LL +     tmp += 1;
-   | 
+   |
 
 error: Rust has no postfix increment operator
   --> $DIR/increment-notfixed.rs:31:14
@@ -56,7 +56,7 @@ LL |     while { let tmp_ = tmp; tmp += 1; tmp_ } < 5 {
    |           ++++++++++++    ~~~~~~~~~~~~~~~~~~
 LL -     while tmp++ < 5 {
 LL +     while tmp += 1 < 5 {
-   | 
+   |
 
 error: Rust has no postfix increment operator
   --> $DIR/increment-notfixed.rs:39:16
@@ -70,7 +70,7 @@ LL |     { let tmp = foo.bar.qux; foo.bar.qux += 1; tmp };
    |     +++++++++++            ~~~~~~~~~~~~~~~~~~~~~~~~~
 LL -     foo.bar.qux++;
 LL +     foo.bar.qux += 1;
-   | 
+   |
 
 error: Rust has no postfix increment operator
   --> $DIR/increment-notfixed.rs:49:10
@@ -84,7 +84,7 @@ LL |     { let tmp = s.tmp; s.tmp += 1; tmp };
    |     +++++++++++      ~~~~~~~~~~~~~~~~~~~
 LL -     s.tmp++;
 LL +     s.tmp += 1;
-   | 
+   |
 
 error: Rust has no prefix increment operator
   --> $DIR/increment-notfixed.rs:56:5
@@ -96,7 +96,7 @@ help: use `+= 1` instead
    |
 LL -     ++foo.bar.qux;
 LL +     foo.bar.qux += 1;
-   | 
+   |
 
 error: aborting due to 7 previous errors
 

--- a/src/test/ui/parser/inner-attr-after-doc-comment.stderr
+++ b/src/test/ui/parser/inner-attr-after-doc-comment.stderr
@@ -5,7 +5,7 @@ LL | / /**
 LL | |  * My module
 LL | |  */
    | |___- previous doc comment
-LL | 
+LL |
 LL |   #![recursion_limit="100"]
    |   ^^^^^^^^^^^^^^^^^^^^^^^^^ not permitted following an outer attribute
 LL |

--- a/src/test/ui/parser/inner-attr-after-doc-comment.stderr
+++ b/src/test/ui/parser/inner-attr-after-doc-comment.stderr
@@ -17,7 +17,7 @@ help: to annotate the function, change the attribute from inner to outer style
    |
 LL - #![recursion_limit="100"]
 LL + #[recursion_limit="100"]
-   | 
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/inner-attr.stderr
+++ b/src/test/ui/parser/inner-attr.stderr
@@ -14,7 +14,7 @@ help: to annotate the function, change the attribute from inner to outer style
    |
 LL - #![recursion_limit="100"]
 LL + #[recursion_limit="100"]
-   | 
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/inner-attr.stderr
+++ b/src/test/ui/parser/inner-attr.stderr
@@ -3,7 +3,7 @@ error: an inner attribute is not permitted following an outer attribute
    |
 LL | #[feature(lang_items)]
    | ---------------------- previous outer attribute
-LL | 
+LL |
 LL | #![recursion_limit="100"]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^ not permitted following an outer attribute
 LL | fn main() {}

--- a/src/test/ui/parser/issues/issue-30318.stderr
+++ b/src/test/ui/parser/issues/issue-30318.stderr
@@ -25,7 +25,7 @@ help: to annotate the function, change the attribute from inner to outer style
    |
 LL - #![test]
 LL + #[test]
-   | 
+   |
 
 error[E0753]: expected outer doc comment
   --> $DIR/issue-30318.rs:13:1
@@ -52,7 +52,7 @@ help: you might have meant to write a regular comment
    |
 LL - //! Misplaced comment...
 LL + // Misplaced comment...
-   | 
+   |
 
 error[E0753]: expected outer doc comment
   --> $DIR/issue-30318.rs:23:1
@@ -65,7 +65,7 @@ help: you might have meant to write a regular comment
    |
 LL - /*! Misplaced comment... */
 LL + /* Misplaced comment... */
-   | 
+   |
 
 error: expected item after doc comment
   --> $DIR/issue-30318.rs:23:1

--- a/src/test/ui/parser/issues/issue-34255-1.stderr
+++ b/src/test/ui/parser/issues/issue-34255-1.stderr
@@ -12,7 +12,7 @@ help: if `Test::Drill` is a function, use the arguments directly
    |
 LL -     Test::Drill(field: 42);
 LL +     Test::Drill(42);
-   | 
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/issues/issue-35813-postfix-after-cast.stderr
+++ b/src/test/ui/parser/issues/issue-35813-postfix-after-cast.stderr
@@ -23,7 +23,7 @@ help: alternatively, remove the type ascription
    |
 LL -     vec![1, 2, 3]: Vec<i32>[0];
 LL +     vec![1, 2, 3][0];
-   | 
+   |
 
 error: casts cannot be followed by indexing
   --> $DIR/issue-35813-postfix-after-cast.rs:17:5
@@ -50,7 +50,7 @@ help: alternatively, remove the type ascription
    |
 LL -     (&[0i32]): &[i32; 1][0];
 LL +     (&[0i32])[0];
-   | 
+   |
 
 error: casts cannot be followed by a method call
   --> $DIR/issue-35813-postfix-after-cast.rs:39:13
@@ -66,7 +66,7 @@ help: alternatively, remove the type ascription
    |
 LL -     let _ = 0i32: i32: i32.count_ones();
 LL +     let _ = 0i32: i32.count_ones();
-   | 
+   |
 
 error: casts cannot be followed by a method call
   --> $DIR/issue-35813-postfix-after-cast.rs:41:13
@@ -82,7 +82,7 @@ help: alternatively, remove the type ascription
    |
 LL -     let _ = 0 as i32: i32.count_ones();
 LL +     let _ = 0 as i32.count_ones();
-   | 
+   |
 
 error: casts cannot be followed by a method call
   --> $DIR/issue-35813-postfix-after-cast.rs:43:13
@@ -131,7 +131,7 @@ help: alternatively, remove the type ascription
    |
 LL -     let _ = 0i32: i32.count_ones(): u32;
 LL +     let _ = 0i32.count_ones(): u32;
-   | 
+   |
 
 error: casts cannot be followed by a method call
   --> $DIR/issue-35813-postfix-after-cast.rs:51:13
@@ -158,7 +158,7 @@ help: alternatively, remove the type ascription
    |
 LL -     let _ = 0i32: i32.count_ones() as u32;
 LL +     let _ = 0i32.count_ones() as u32;
-   | 
+   |
 
 error: casts cannot be followed by a method call
   --> $DIR/issue-35813-postfix-after-cast.rs:55:13
@@ -185,7 +185,7 @@ help: alternatively, remove the type ascription
    |
 LL -     let _ = 0i32: i32: i32.count_ones() as u32 as i32;
 LL +     let _ = 0i32: i32.count_ones() as u32 as i32;
-   | 
+   |
 
 error: casts cannot be followed by a method call
   --> $DIR/issue-35813-postfix-after-cast.rs:62:13
@@ -237,7 +237,7 @@ help: alternatively, remove the type ascription
    |
 LL -     0: i32.max(0);
 LL +     0.max(0);
-   | 
+   |
 
 error: casts cannot be followed by a method call
   --> $DIR/issue-35813-postfix-after-cast.rs:92:8
@@ -264,7 +264,7 @@ help: alternatively, remove the type ascription
    |
 LL -     if 5u64: u64.max(0) == 0 {
 LL +     if 5u64.max(0) == 0 {
-   | 
+   |
 
 error: casts cannot be followed by a method call
   --> $DIR/issue-35813-postfix-after-cast.rs:102:9
@@ -291,7 +291,7 @@ help: alternatively, remove the type ascription
    |
 LL -         5u64: u64.max(0) == 0
 LL +         5u64.max(0) == 0
-   | 
+   |
 
 error: casts cannot be followed by indexing
   --> $DIR/issue-35813-postfix-after-cast.rs:111:24
@@ -318,7 +318,7 @@ help: alternatively, remove the type ascription
    |
 LL - static bar2: &[i32] = &(&[1i32,2,3]: &[i32; 3][0..1]);
 LL + static bar2: &[i32] = &(&[1i32,2,3][0..1]);
-   | 
+   |
 
 error: casts cannot be followed by `?`
   --> $DIR/issue-35813-postfix-after-cast.rs:119:5
@@ -345,7 +345,7 @@ help: alternatively, remove the type ascription
    |
 LL -     Err(0u64): Result<u64,u64>?;
 LL +     Err(0u64)?;
-   | 
+   |
 
 error: casts cannot be followed by a function call
   --> $DIR/issue-35813-postfix-after-cast.rs:145:5
@@ -372,7 +372,7 @@ help: alternatively, remove the type ascription
    |
 LL -     drop_ptr: fn(u8)(0);
 LL +     drop_ptr(0);
-   | 
+   |
 
 error: casts cannot be followed by `.await`
   --> $DIR/issue-35813-postfix-after-cast.rs:152:5
@@ -399,7 +399,7 @@ help: alternatively, remove the type ascription
    |
 LL -     Box::pin(noop()): Pin<Box<_>>.await;
 LL +     Box::pin(noop()).await;
-   | 
+   |
 
 error: casts cannot be followed by a field access
   --> $DIR/issue-35813-postfix-after-cast.rs:167:5
@@ -426,7 +426,7 @@ help: alternatively, remove the type ascription
    |
 LL -     Foo::default(): Foo.bar;
 LL +     Foo::default().bar;
-   | 
+   |
 
 error: casts cannot be followed by a method call
   --> $DIR/issue-35813-postfix-after-cast.rs:84:9
@@ -453,7 +453,7 @@ help: alternatively, remove the type ascription
    |
 LL -         if true { 33 } else { 44 }: i32.max(0)
 LL +         if true { 33 } else { 44 }.max(0)
-   | 
+   |
 
 error[E0214]: parenthesized type parameters may only be used with a `Fn` trait
   --> $DIR/issue-35813-postfix-after-cast.rs:131:13

--- a/src/test/ui/parser/issues/issue-44406.stderr
+++ b/src/test/ui/parser/issues/issue-44406.stderr
@@ -27,7 +27,7 @@ help: if `bar` is a function, use the arguments directly
    |
 LL -         bar(baz: $rest)
 LL +         bar(: $rest)
-   | 
+   |
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/parser/issues/issue-45296.stderr
+++ b/src/test/ui/parser/issues/issue-45296.stderr
@@ -11,7 +11,7 @@ help: to annotate the function, change the attribute from inner to outer style
    |
 LL -     #![allow(unused_variables)]
 LL +     #[allow(unused_variables)]
-   | 
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/issues/issue-56031.stderr
+++ b/src/test/ui/parser/issues/issue-56031.stderr
@@ -12,7 +12,7 @@ help: for an inherent impl, drop this `for`
    |
 LL - impl for T {}
 LL + impl T {}
-   | 
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/issues/issue-62894.stderr
+++ b/src/test/ui/parser/issues/issue-62894.stderr
@@ -6,7 +6,7 @@ LL | fn f() { assert_eq!(f(), (), assert_eq!(assert_eq!
    |        |           |
    |        |           unclosed delimiter
    |        unclosed delimiter
-LL | 
+LL |
 LL | fn main() {}
    |              ^
 
@@ -18,7 +18,7 @@ LL | fn f() { assert_eq!(f(), (), assert_eq!(assert_eq!
    |        |           |
    |        |           unclosed delimiter
    |        unclosed delimiter
-LL | 
+LL |
 LL | fn main() {}
    |              ^
 
@@ -30,7 +30,7 @@ LL | fn f() { assert_eq!(f(), (), assert_eq!(assert_eq!
    |        |           |
    |        |           unclosed delimiter
    |        unclosed delimiter
-LL | 
+LL |
 LL | fn main() {}
    |              ^
 
@@ -39,7 +39,7 @@ error: expected one of `(`, `[`, or `{`, found keyword `fn`
    |
 LL | fn f() { assert_eq!(f(), (), assert_eq!(assert_eq!
    |                                                   - expected one of `(`, `[`, or `{`
-LL | 
+LL |
 LL | fn main() {}
    | ^^ unexpected token
    |

--- a/src/test/ui/parser/issues/issue-62973.stderr
+++ b/src/test/ui/parser/issues/issue-62973.stderr
@@ -5,8 +5,8 @@ LL | fn p() { match s { v, E { [) {) }
    |        -         - unclosed delimiter
    |        |
    |        unclosed delimiter
-LL | 
-LL | 
+LL |
+LL |
    |  ^
 
 error: this file contains an unclosed delimiter
@@ -16,8 +16,8 @@ LL | fn p() { match s { v, E { [) {) }
    |        -         - unclosed delimiter
    |        |
    |        unclosed delimiter
-LL | 
-LL | 
+LL |
+LL |
    |  ^
 
 error: expected one of `,` or `}`, found `{`
@@ -51,8 +51,8 @@ error: expected one of `.`, `?`, `{`, or an operator, found `}`
    |
 LL | fn p() { match s { v, E { [) {) }
    |          ----- while parsing this `match` expression
-LL | 
-LL | 
+LL |
+LL |
    |  ^ expected one of `.`, `?`, `{`, or an operator
 
 error: mismatched closing delimiter: `)`

--- a/src/test/ui/parser/issues/issue-88276-unary-plus.stderr
+++ b/src/test/ui/parser/issues/issue-88276-unary-plus.stderr
@@ -8,7 +8,7 @@ help: try removing the `+`
    |
 LL -     let _ = +1;
 LL +     let _ = 1;
-   | 
+   |
 
 error: leading `+` is not supported
   --> $DIR/issue-88276-unary-plus.rs:5:20
@@ -20,7 +20,7 @@ help: try removing the `+`
    |
 LL -     let _ = (1.0 + +2.0) * +3.0;
 LL +     let _ = (1.0 + 2.0) * +3.0;
-   | 
+   |
 
 error: leading `+` is not supported
   --> $DIR/issue-88276-unary-plus.rs:5:28
@@ -32,7 +32,7 @@ help: try removing the `+`
    |
 LL -     let _ = (1.0 + +2.0) * +3.0;
 LL +     let _ = (1.0 + +2.0) * 3.0;
-   | 
+   |
 
 error: leading `+` is not supported
   --> $DIR/issue-88276-unary-plus.rs:7:14
@@ -44,7 +44,7 @@ help: try removing the `+`
    |
 LL -     let _ = [+3, 4+6];
 LL +     let _ = [3, 4+6];
-   | 
+   |
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/parser/issues/issue-88818.stderr
+++ b/src/test/ui/parser/issues/issue-88818.stderr
@@ -12,7 +12,7 @@ help: for an inherent impl, drop this `for`
    |
 LL - impl for S { }
 LL + impl S { }
-   | 
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/issues/issue-89971-outer-attr-following-inner-attr-ice.stderr
+++ b/src/test/ui/parser/issues/issue-89971-outer-attr-following-inner-attr-ice.stderr
@@ -12,7 +12,7 @@ help: to annotate the struct, change the attribute from inner to outer style
    |
 LL - #![deny(missing_docs)]
 LL + #[deny(missing_docs)]
-   | 
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/labeled-no-colon-expr.stderr
+++ b/src/test/ui/parser/labeled-no-colon-expr.stderr
@@ -52,7 +52,7 @@ help: consider removing the label
    |
 LL -     'l4 0;
 LL +     0;
-   | 
+   |
 
 error: labeled expression must be followed by `:`
   --> $DIR/labeled-no-colon-expr.rs:8:9

--- a/src/test/ui/parser/mismatched-delim-brace-empty-block.stderr
+++ b/src/test/ui/parser/mismatched-delim-brace-empty-block.stderr
@@ -3,7 +3,7 @@ error: unexpected closing delimiter: `}`
    |
 LL | fn main() {
    |           - this opening brace...
-LL | 
+LL |
 LL | }
    | - ...matches this closing brace
 LL |     let _ = ();

--- a/src/test/ui/parser/recover-assoc-eq-missing-term.stderr
+++ b/src/test/ui/parser/recover-assoc-eq-missing-term.stderr
@@ -12,7 +12,7 @@ help: remove the `=` if `Item` is a type
    |
 LL -     bar::<Item =   >();
 LL +     bar::<Item >();
-   | 
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/parser/recover-for-loop-parens-around-head.stderr
+++ b/src/test/ui/parser/recover-for-loop-parens-around-head.stderr
@@ -14,7 +14,7 @@ help: remove parentheses in `for` loop
    |
 LL -     for ( elem in vec ) {
 LL +     for  elem in vec  {
-   | 
+   |
 
 error[E0308]: mismatched types
   --> $DIR/recover-for-loop-parens-around-head.rs:13:38

--- a/src/test/ui/parser/recover-from-bad-variant.stderr
+++ b/src/test/ui/parser/recover-from-bad-variant.stderr
@@ -12,7 +12,7 @@ help: if `Enum::Foo` is a function, use the arguments directly
    |
 LL -     let x = Enum::Foo(a: 3, b: 4);
 LL +     let x = Enum::Foo(3, 4);
-   | 
+   |
 
 error[E0532]: expected tuple struct or tuple variant, found struct variant `Enum::Foo`
   --> $DIR/recover-from-bad-variant.rs:10:9

--- a/src/test/ui/parser/recover-labeled-non-block-expr.stderr
+++ b/src/test/ui/parser/recover-labeled-non-block-expr.stderr
@@ -8,7 +8,7 @@ help: consider removing the label
    |
 LL -     let _ = 'label: 1 + 1;
 LL +     let _ = 1 + 1;
-   | 
+   |
 
 error: expected `while`, `for`, `loop` or `{` after a label
   --> $DIR/recover-labeled-non-block-expr.rs:6:13
@@ -20,7 +20,7 @@ help: consider removing the label
    |
 LL -     'label: match () { () => {}, };
 LL +     match () { () => {}, };
-   | 
+   |
 
 error: expected `while`, `for`, `loop` or `{` after a label
   --> $DIR/recover-labeled-non-block-expr.rs:7:13

--- a/src/test/ui/parser/trait-object-delimiters.stderr
+++ b/src/test/ui/parser/trait-object-delimiters.stderr
@@ -14,7 +14,7 @@ help: remove the parentheses
    |
 LL - fn foo2(_: &dyn (Drop + AsRef<str>)) {}
 LL + fn foo2(_: &dyn Drop + AsRef<str>) {}
-   | 
+   |
 
 error: expected parameter name, found `{`
   --> $DIR/trait-object-delimiters.rs:8:17

--- a/src/test/ui/parser/trait-object-trait-parens.stderr
+++ b/src/test/ui/parser/trait-object-trait-parens.stderr
@@ -29,7 +29,7 @@ help: use `dyn`
    |
 LL -     let _: Box<(Obj) + (?Sized) + (for<'a> Trait<'a>)>;
 LL +     let _: Box<dyn (Obj) + (?Sized) + (for<'a> Trait<'a>)>;
-   | 
+   |
 
 error[E0225]: only auto traits can be used as additional traits in a trait object
   --> $DIR/trait-object-trait-parens.rs:8:35
@@ -54,7 +54,7 @@ help: use `dyn`
    |
 LL -     let _: Box<?Sized + (for<'a> Trait<'a>) + (Obj)>;
 LL +     let _: Box<dyn ?Sized + (for<'a> Trait<'a>) + (Obj)>;
-   | 
+   |
 
 error[E0225]: only auto traits can be used as additional traits in a trait object
   --> $DIR/trait-object-trait-parens.rs:13:47
@@ -79,7 +79,7 @@ help: use `dyn`
    |
 LL -     let _: Box<for<'a> Trait<'a> + (Obj) + (?Sized)>;
 LL +     let _: Box<dyn for<'a> Trait<'a> + (Obj) + (?Sized)>;
-   | 
+   |
 
 error[E0225]: only auto traits can be used as additional traits in a trait object
   --> $DIR/trait-object-trait-parens.rs:18:36

--- a/src/test/ui/parser/type-alias-where-fixable.stderr
+++ b/src/test/ui/parser/type-alias-where-fixable.stderr
@@ -10,7 +10,7 @@ help: move it to the end of the type declaration
    |
 LL -     type Assoc where u32: Copy = ();
 LL +     type Assoc  = () where u32: Copy;
-   | 
+   |
 
 warning: where clause not allowed here
   --> $DIR/type-alias-where-fixable.rs:18:17
@@ -23,7 +23,7 @@ help: move it to the end of the type declaration
    |
 LL -     type Assoc2 where u32: Copy = () where i32: Copy;
 LL +     type Assoc2  = () where i32: Copy, u32: Copy;
-   | 
+   |
 
 warning: where clause not allowed here
   --> $DIR/type-alias-where-fixable.rs:26:17
@@ -36,7 +36,7 @@ help: move it to the end of the type declaration
    |
 LL -     type Assoc2 where u32: Copy, i32: Copy = ();
 LL +     type Assoc2  = () where u32: Copy, i32: Copy;
-   | 
+   |
 
 warning: 3 warnings emitted
 

--- a/src/test/ui/path-lookahead.stderr
+++ b/src/test/ui/path-lookahead.stderr
@@ -13,7 +13,7 @@ help: remove these parentheses
    |
 LL -     return (<T as ToString>::to_string(&arg));
 LL +     return <T as ToString>::to_string(&arg);
-   | 
+   |
 
 warning: 1 warning emitted
 

--- a/src/test/ui/pattern/for-loop-bad-item.stderr
+++ b/src/test/ui/pattern/for-loop-bad-item.stderr
@@ -12,7 +12,7 @@ help: consider removing `&mut` from the pattern
    |
 LL -     for ((_, _), (&mut c, _)) in &mut map {
 LL +     for ((_, _), (c, _)) in &mut map {
-   | 
+   |
 
 error[E0308]: mismatched types
   --> $DIR/for-loop-bad-item.rs:14:14

--- a/src/test/ui/privacy/private-in-public-warn.stderr
+++ b/src/test/ui/privacy/private-in-public-warn.stderr
@@ -320,7 +320,7 @@ help: the bound will not be checked when the type alias is used, and should be r
    |
 LL -     pub type Alias<T: PrivTr> = T;
 LL +     pub type Alias<T> = T;
-   | 
+   |
 
 warning: where clauses are not enforced in type aliases
   --> $DIR/private-in-public-warn.rs:74:29
@@ -332,7 +332,7 @@ help: the clause will not be checked when the type alias is used, and should be 
    |
 LL -     pub type Alias<T> where T: PrivTr = T;
 LL +     pub type Alias<T>  = T;
-   | 
+   |
 
 error: aborting due to 34 previous errors; 2 warnings emitted
 

--- a/src/test/ui/reachable/unreachable-code.stderr
+++ b/src/test/ui/reachable/unreachable-code.stderr
@@ -3,7 +3,7 @@ error: unreachable statement
    |
 LL |   loop{}
    |   ------ any code following this expression is unreachable
-LL | 
+LL |
 LL |   let a = 3;
    |   ^^^^^^^^^^ unreachable statement
    |

--- a/src/test/ui/resolve/enums-are-namespaced-xc.stderr
+++ b/src/test/ui/resolve/enums-are-namespaced-xc.stderr
@@ -12,7 +12,7 @@ help: if you import `A`, refer to it directly
    |
 LL -     let _ = namespaced_enums::A;
 LL +     let _ = A;
-   | 
+   |
 
 error[E0425]: cannot find function, tuple struct or tuple variant `B` in crate `namespaced_enums`
   --> $DIR/enums-are-namespaced-xc.rs:7:31
@@ -28,7 +28,7 @@ help: if you import `B`, refer to it directly
    |
 LL -     let _ = namespaced_enums::B(10);
 LL +     let _ = B(10);
-   | 
+   |
 
 error[E0422]: cannot find struct, variant or union type `C` in crate `namespaced_enums`
   --> $DIR/enums-are-namespaced-xc.rs:9:31
@@ -44,7 +44,7 @@ help: if you import `C`, refer to it directly
    |
 LL -     let _ = namespaced_enums::C { a: 10 };
 LL +     let _ = C { a: 10 };
-   | 
+   |
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/resolve/issue-23716.stderr
+++ b/src/test/ui/resolve/issue-23716.stderr
@@ -3,7 +3,7 @@ error[E0530]: function parameters cannot shadow statics
    |
 LL | static foo: i32 = 0;
    | -------------------- the static `foo` is defined here
-LL | 
+LL |
 LL | fn bar(foo: i32) {}
    |        ^^^ cannot be named the same as a static
 
@@ -12,7 +12,7 @@ error[E0530]: function parameters cannot shadow statics
    |
 LL | use self::submod::answer;
    |     -------------------- the static `answer` is imported here
-LL | 
+LL |
 LL | fn question(answer: i32) {}
    |             ^^^^^^ cannot be named the same as a static
 

--- a/src/test/ui/resolve/issue-50599.stderr
+++ b/src/test/ui/resolve/issue-50599.stderr
@@ -14,7 +14,7 @@ help: if you import `LOG10_2`, refer to it directly
    |
 LL -     const M: usize = (f64::from(N) * std::f64::LOG10_2) as usize;
 LL +     const M: usize = (f64::from(N) * LOG10_2) as usize;
-   | 
+   |
 
 error[E0080]: evaluation of constant value failed
   --> $DIR/issue-50599.rs:4:29

--- a/src/test/ui/resolve/issue-81508.stderr
+++ b/src/test/ui/resolve/issue-81508.stderr
@@ -3,7 +3,7 @@ error[E0433]: failed to resolve: use of undeclared type `Baz`
    |
 LL |     let Baz: &str = "";
    |         --- help: `Baz` is defined here, but is not a type
-LL | 
+LL |
 LL |     println!("{}", Baz::Bar);
    |                    ^^^ use of undeclared type `Baz`
 

--- a/src/test/ui/resolve/levenshtein.stderr
+++ b/src/test/ui/resolve/levenshtein.stderr
@@ -9,7 +9,7 @@ error[E0412]: cannot find type `Baz` in this scope
    |
 LL | enum Bar { }
    | -------- similarly named enum `Bar` defined here
-LL | 
+LL |
 LL | type A = Baz; // Misspelled type name.
    |          ^^^ help: an enum with a similar name exists: `Bar`
 

--- a/src/test/ui/resolve/missing-in-namespace.stderr
+++ b/src/test/ui/resolve/missing-in-namespace.stderr
@@ -12,7 +12,7 @@ help: if you import `HashMap`, refer to it directly
    |
 LL -     let _map = std::hahmap::HashMap::new();
 LL +     let _map = HashMap::new();
-   | 
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/resolve/privacy-enum-ctor.stderr
+++ b/src/test/ui/resolve/privacy-enum-ctor.stderr
@@ -109,7 +109,7 @@ help: if you import `E`, refer to it directly
    |
 LL -     let _: E = m::E;
 LL +     let _: E = E;
-   | 
+   |
 
 error[E0423]: expected value, found struct variant `m::E::Struct`
   --> $DIR/privacy-enum-ctor.rs:45:16
@@ -347,7 +347,7 @@ help: `Z::Unit` is a unit variant, you need to write it without the parentheses
    |
 LL -         let _ = Z::Unit();
 LL +         let _ = Z::Unit;
-   | 
+   |
 
 error[E0308]: mismatched types
   --> $DIR/privacy-enum-ctor.rs:43:16
@@ -382,7 +382,7 @@ help: `m::E::Unit` is a unit variant, you need to write it without the parenthes
    |
 LL -     let _: E = m::E::Unit();
 LL +     let _: E = m::E::Unit;
-   | 
+   |
 
 error[E0308]: mismatched types
   --> $DIR/privacy-enum-ctor.rs:51:16
@@ -417,7 +417,7 @@ help: `E::Unit` is a unit variant, you need to write it without the parentheses
    |
 LL -     let _: E = E::Unit();
 LL +     let _: E = E::Unit;
-   | 
+   |
 
 error: aborting due to 23 previous errors
 

--- a/src/test/ui/resolve/resolve-conflict-item-vs-import.stderr
+++ b/src/test/ui/resolve/resolve-conflict-item-vs-import.stderr
@@ -3,7 +3,7 @@ error[E0255]: the name `transmute` is defined multiple times
    |
 LL | use std::mem::transmute;
    |     ------------------- previous import of the value `transmute` here
-LL | 
+LL |
 LL | fn transmute() {}
    | ^^^^^^^^^^^^^^ `transmute` redefined here
    |

--- a/src/test/ui/resolve/resolve-conflict-type-vs-import.stderr
+++ b/src/test/ui/resolve/resolve-conflict-type-vs-import.stderr
@@ -3,7 +3,7 @@ error[E0255]: the name `Iter` is defined multiple times
    |
 LL | use std::slice::Iter;
    |     ---------------- previous import of the type `Iter` here
-LL | 
+LL |
 LL | struct Iter;
    | ^^^^^^^^^^^^ `Iter` redefined here
    |

--- a/src/test/ui/resolve/resolve-primitive-fallback.stderr
+++ b/src/test/ui/resolve/resolve-primitive-fallback.stderr
@@ -18,7 +18,7 @@ help: if you import `u8`, refer to it directly
    |
 LL -     let _: ::u8;
 LL +     let _: u8;
-   | 
+   |
 
 error[E0061]: this function takes 0 arguments but 1 argument was supplied
   --> $DIR/resolve-primitive-fallback.rs:3:5

--- a/src/test/ui/rfc-2497-if-let-chains/disallowed-positions.stderr
+++ b/src/test/ui/rfc-2497-if-let-chains/disallowed-positions.stderr
@@ -982,7 +982,7 @@ help: consider removing the borrow
    |
 LL -     if &let 0 = 0 {}
 LL +     if let 0 = 0 {}
-   | 
+   |
 
 error[E0614]: type `bool` cannot be dereferenced
   --> $DIR/disallowed-positions.rs:94:8
@@ -1149,7 +1149,7 @@ help: consider removing the `&&`
    |
 LL -     if let Range { start: true, end } = t..&&false {}
 LL +     if let Range { start: true, end } = t..false {}
-   | 
+   |
 
 error[E0308]: mismatched types
   --> $DIR/disallowed-positions.rs:144:8
@@ -1178,7 +1178,7 @@ help: consider removing the borrow
    |
 LL -     while &let 0 = 0 {}
 LL +     while let 0 = 0 {}
-   | 
+   |
 
 error[E0614]: type `bool` cannot be dereferenced
   --> $DIR/disallowed-positions.rs:158:11
@@ -1345,7 +1345,7 @@ help: consider removing the `&&`
    |
 LL -     while let Range { start: true, end } = t..&&false {}
 LL +     while let Range { start: true, end } = t..false {}
-   | 
+   |
 
 error[E0308]: mismatched types
   --> $DIR/disallowed-positions.rs:208:11

--- a/src/test/ui/rfc-2632-const-trait-impl/const-impl-recovery.stderr
+++ b/src/test/ui/rfc-2632-const-trait-impl/const-impl-recovery.stderr
@@ -8,7 +8,7 @@ help: you might have meant to write a const trait impl
    |
 LL - const impl Foo for i32 {}
 LL + impl const Foo for i32 {}
-   | 
+   |
 
 error: expected identifier, found keyword `impl`
   --> $DIR/const-impl-recovery.rs:9:7
@@ -20,7 +20,7 @@ help: you might have meant to write a const trait impl
    |
 LL - const impl<T: Foo> Bar for T {}
 LL + impl<T: Foo> const Bar for T {}
-   | 
+   |
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/rust-2018/edition-lint-infer-outlives-multispan.stderr
+++ b/src/test/ui/rust-2018/edition-lint-infer-outlives-multispan.stderr
@@ -13,7 +13,7 @@ help: remove these bounds
    |
 LL -     struct TeeOutlivesAyIsDebugBee<'a, 'b, T: 'a + Debug + 'b> {
 LL +     struct TeeOutlivesAyIsDebugBee<'a, 'b, T: Debug> {
-   | 
+   |
 
 error: outlives requirements can be inferred
   --> $DIR/edition-lint-infer-outlives-multispan.rs:18:61
@@ -25,7 +25,7 @@ help: remove these bounds
    |
 LL -     struct TeeWhereOutlivesAyIsDebugBee<'a, 'b, T> where T: 'a + Debug + 'b {
 LL +     struct TeeWhereOutlivesAyIsDebugBee<'a, 'b, T> where T: Debug {
-   | 
+   |
 
 error: outlives requirements can be inferred
   --> $DIR/edition-lint-infer-outlives-multispan.rs:23:53
@@ -37,7 +37,7 @@ help: remove these bounds
    |
 LL -     struct TeeYooOutlivesAyIsDebugBee<'a, 'b, T, U: 'a + Debug + 'b> {
 LL +     struct TeeYooOutlivesAyIsDebugBee<'a, 'b, T, U: Debug> {
-   | 
+   |
 
 error: outlives requirements can be inferred
   --> $DIR/edition-lint-infer-outlives-multispan.rs:29:48
@@ -49,7 +49,7 @@ help: remove these bounds
    |
 LL -     struct TeeOutlivesAyYooBeeIsDebug<'a, 'b, T: 'a, U: 'b + Debug> {
 LL +     struct TeeOutlivesAyYooBeeIsDebug<'a, 'b, T, U: Debug> {
-   | 
+   |
 
 error: outlives requirements can be inferred
   --> $DIR/edition-lint-infer-outlives-multispan.rs:35:48
@@ -61,7 +61,7 @@ help: remove these bounds
    |
 LL -     struct TeeOutlivesAyYooIsDebugBee<'a, 'b, T: 'a, U: Debug + 'b> {
 LL +     struct TeeOutlivesAyYooIsDebugBee<'a, 'b, T, U: Debug> {
-   | 
+   |
 
 error: outlives requirements can be inferred
   --> $DIR/edition-lint-infer-outlives-multispan.rs:41:46
@@ -73,7 +73,7 @@ help: remove these bounds
    |
 LL -     struct TeeOutlivesAyYooWhereBee<'a, 'b, T: 'a, U> where U: 'b {
 LL +     struct TeeOutlivesAyYooWhereBee<'a, 'b, T, U> {
-   | 
+   |
 
 error: outlives requirements can be inferred
   --> $DIR/edition-lint-infer-outlives-multispan.rs:47:67
@@ -85,7 +85,7 @@ help: remove these bounds
    |
 LL -     struct TeeYooWhereOutlivesAyIsDebugBee<'a, 'b, T, U> where U: 'a + Debug + 'b {
 LL +     struct TeeYooWhereOutlivesAyIsDebugBee<'a, 'b, T, U> where U: Debug {
-   | 
+   |
 
 error: outlives requirements can be inferred
   --> $DIR/edition-lint-infer-outlives-multispan.rs:53:53
@@ -97,7 +97,7 @@ help: remove these bounds
    |
 LL -     struct TeeOutlivesAyYooWhereBeeIsDebug<'a, 'b, T: 'a, U> where U: 'b + Debug {
 LL +     struct TeeOutlivesAyYooWhereBeeIsDebug<'a, 'b, T, U> where U: Debug {
-   | 
+   |
 
 error: outlives requirements can be inferred
   --> $DIR/edition-lint-infer-outlives-multispan.rs:59:53
@@ -109,7 +109,7 @@ help: remove these bounds
    |
 LL -     struct TeeOutlivesAyYooWhereIsDebugBee<'a, 'b, T: 'a, U> where U: Debug + 'b {
 LL +     struct TeeOutlivesAyYooWhereIsDebugBee<'a, 'b, T, U> where U: Debug {
-   | 
+   |
 
 error: outlives requirements can be inferred
   --> $DIR/edition-lint-infer-outlives-multispan.rs:65:69
@@ -121,7 +121,7 @@ help: remove these bounds
    |
 LL -     struct TeeWhereOutlivesAyYooWhereBeeIsDebug<'a, 'b, T, U> where T: 'a, U: 'b + Debug {
 LL +     struct TeeWhereOutlivesAyYooWhereBeeIsDebug<'a, 'b, T, U> where U: Debug {
-   | 
+   |
 
 error: outlives requirements can be inferred
   --> $DIR/edition-lint-infer-outlives-multispan.rs:71:69
@@ -133,7 +133,7 @@ help: remove these bounds
    |
 LL -     struct TeeWhereOutlivesAyYooWhereIsDebugBee<'a, 'b, T, U> where T: 'a, U: Debug + 'b {
 LL +     struct TeeWhereOutlivesAyYooWhereIsDebugBee<'a, 'b, T, U> where U: Debug {
-   | 
+   |
 
 error: outlives requirements can be inferred
   --> $DIR/edition-lint-infer-outlives-multispan.rs:77:38
@@ -145,7 +145,7 @@ help: remove these bounds
    |
 LL -     struct BeeOutlivesAyTeeBee<'a, 'b: 'a, T: 'b> {
 LL +     struct BeeOutlivesAyTeeBee<'a, 'b, T> {
-   | 
+   |
 
 error: outlives requirements can be inferred
   --> $DIR/edition-lint-infer-outlives-multispan.rs:82:40
@@ -157,7 +157,7 @@ help: remove these bounds
    |
 LL -     struct BeeOutlivesAyTeeAyBee<'a, 'b: 'a, T: 'a + 'b> {
 LL +     struct BeeOutlivesAyTeeAyBee<'a, 'b, T> {
-   | 
+   |
 
 error: outlives requirements can be inferred
   --> $DIR/edition-lint-infer-outlives-multispan.rs:87:55
@@ -169,7 +169,7 @@ help: remove these bounds
    |
 LL -     struct BeeOutlivesAyTeeOutlivesAyIsDebugBee<'a, 'b: 'a, T: 'a + Debug + 'b> {
 LL +     struct BeeOutlivesAyTeeOutlivesAyIsDebugBee<'a, 'b, T: Debug> {
-   | 
+   |
 
 error: outlives requirements can be inferred
   --> $DIR/edition-lint-infer-outlives-multispan.rs:92:68
@@ -181,7 +181,7 @@ help: remove these bounds
    |
 LL -     struct BeeWhereAyTeeWhereOutlivesAyIsDebugBee<'a, 'b, T> where 'b: 'a, T: 'a + Debug + 'b {
 LL +     struct BeeWhereAyTeeWhereOutlivesAyIsDebugBee<'a, 'b, T> where T: Debug {
-   | 
+   |
 
 error: outlives requirements can be inferred
   --> $DIR/edition-lint-infer-outlives-multispan.rs:97:58
@@ -193,7 +193,7 @@ help: remove these bounds
    |
 LL -     struct BeeOutlivesAyTeeYooOutlivesAyIsDebugBee<'a, 'b: 'a, T, U: 'a + Debug + 'b> {
 LL +     struct BeeOutlivesAyTeeYooOutlivesAyIsDebugBee<'a, 'b, T, U: Debug> {
-   | 
+   |
 
 error: outlives requirements can be inferred
   --> $DIR/edition-lint-infer-outlives-multispan.rs:104:18
@@ -205,7 +205,7 @@ help: remove these bounds
    |
 LL -         where U: 'a + Debug + 'b, 'b: 'a
 LL +         where U: Debug, 
-   | 
+   |
 
 error: outlives requirements can be inferred
   --> $DIR/edition-lint-infer-outlives-multispan.rs:115:47
@@ -217,7 +217,7 @@ help: remove these bounds
    |
 LL -     struct TeeOutlivesAyIsDebugBee<'a, 'b, T: 'a + Debug + 'b>(&'a &'b T);
 LL +     struct TeeOutlivesAyIsDebugBee<'a, 'b, T: Debug>(&'a &'b T);
-   | 
+   |
 
 error: outlives requirements can be inferred
   --> $DIR/edition-lint-infer-outlives-multispan.rs:118:72
@@ -229,7 +229,7 @@ help: remove these bounds
    |
 LL -     struct TeeWhereOutlivesAyIsDebugBee<'a, 'b, T>(&'a &'b T) where T: 'a + Debug + 'b;
 LL +     struct TeeWhereOutlivesAyIsDebugBee<'a, 'b, T>(&'a &'b T) where T: Debug;
-   | 
+   |
 
 error: outlives requirements can be inferred
   --> $DIR/edition-lint-infer-outlives-multispan.rs:121:53
@@ -241,7 +241,7 @@ help: remove these bounds
    |
 LL -     struct TeeYooOutlivesAyIsDebugBee<'a, 'b, T, U: 'a + Debug + 'b>(T, &'a &'b U);
 LL +     struct TeeYooOutlivesAyIsDebugBee<'a, 'b, T, U: Debug>(T, &'a &'b U);
-   | 
+   |
 
 error: outlives requirements can be inferred
   --> $DIR/edition-lint-infer-outlives-multispan.rs:124:48
@@ -253,7 +253,7 @@ help: remove these bounds
    |
 LL -     struct TeeOutlivesAyYooBeeIsDebug<'a, 'b, T: 'a, U: 'b + Debug>(&'a T, &'b U);
 LL +     struct TeeOutlivesAyYooBeeIsDebug<'a, 'b, T, U: Debug>(&'a T, &'b U);
-   | 
+   |
 
 error: outlives requirements can be inferred
   --> $DIR/edition-lint-infer-outlives-multispan.rs:127:48
@@ -265,7 +265,7 @@ help: remove these bounds
    |
 LL -     struct TeeOutlivesAyYooIsDebugBee<'a, 'b, T: 'a, U: Debug + 'b>(&'a T, &'b U);
 LL +     struct TeeOutlivesAyYooIsDebugBee<'a, 'b, T, U: Debug>(&'a T, &'b U);
-   | 
+   |
 
 error: outlives requirements can be inferred
   --> $DIR/edition-lint-infer-outlives-multispan.rs:130:46
@@ -277,7 +277,7 @@ help: remove these bounds
    |
 LL -     struct TeeOutlivesAyYooWhereBee<'a, 'b, T: 'a, U>(&'a T, &'b U) where U: 'b;
 LL +     struct TeeOutlivesAyYooWhereBee<'a, 'b, T, U>(&'a T, &'b U) ;
-   | 
+   |
 
 error: outlives requirements can be inferred
   --> $DIR/edition-lint-infer-outlives-multispan.rs:133:81
@@ -289,7 +289,7 @@ help: remove these bounds
    |
 LL -     struct TeeYooWhereOutlivesAyIsDebugBee<'a, 'b, T, U>(T, &'a &'b U) where U: 'a + Debug + 'b;
 LL +     struct TeeYooWhereOutlivesAyIsDebugBee<'a, 'b, T, U>(T, &'a &'b U) where U: Debug;
-   | 
+   |
 
 error: outlives requirements can be inferred
   --> $DIR/edition-lint-infer-outlives-multispan.rs:136:53
@@ -301,7 +301,7 @@ help: remove these bounds
    |
 LL -     struct TeeOutlivesAyYooWhereBeeIsDebug<'a, 'b, T: 'a, U>(&'a T, &'b U) where U: 'b + Debug;
 LL +     struct TeeOutlivesAyYooWhereBeeIsDebug<'a, 'b, T, U>(&'a T, &'b U) where U: Debug;
-   | 
+   |
 
 error: outlives requirements can be inferred
   --> $DIR/edition-lint-infer-outlives-multispan.rs:139:53
@@ -313,7 +313,7 @@ help: remove these bounds
    |
 LL -     struct TeeOutlivesAyYooWhereIsDebugBee<'a, 'b, T: 'a, U>(&'a T, &'b U) where U: Debug + 'b;
 LL +     struct TeeOutlivesAyYooWhereIsDebugBee<'a, 'b, T, U>(&'a T, &'b U) where U: Debug;
-   | 
+   |
 
 error: outlives requirements can be inferred
   --> $DIR/edition-lint-infer-outlives-multispan.rs:142:75
@@ -325,7 +325,7 @@ help: remove these bounds
    |
 LL -     struct TeeWhereAyYooWhereBeeIsDebug<'a, 'b, T, U>(&'a T, &'b U) where T: 'a, U: 'b + Debug;
 LL +     struct TeeWhereAyYooWhereBeeIsDebug<'a, 'b, T, U>(&'a T, &'b U) where U: Debug;
-   | 
+   |
 
 error: outlives requirements can be inferred
   --> $DIR/edition-lint-infer-outlives-multispan.rs:145:75
@@ -337,7 +337,7 @@ help: remove these bounds
    |
 LL -     struct TeeWhereAyYooWhereIsDebugBee<'a, 'b, T, U>(&'a T, &'b U) where T: 'a, U: Debug + 'b;
 LL +     struct TeeWhereAyYooWhereIsDebugBee<'a, 'b, T, U>(&'a T, &'b U) where U: Debug;
-   | 
+   |
 
 error: outlives requirements can be inferred
   --> $DIR/edition-lint-infer-outlives-multispan.rs:148:38
@@ -349,7 +349,7 @@ help: remove these bounds
    |
 LL -     struct BeeOutlivesAyTeeBee<'a, 'b: 'a, T: 'b>(&'a &'b T);
 LL +     struct BeeOutlivesAyTeeBee<'a, 'b, T>(&'a &'b T);
-   | 
+   |
 
 error: outlives requirements can be inferred
   --> $DIR/edition-lint-infer-outlives-multispan.rs:151:40
@@ -361,7 +361,7 @@ help: remove these bounds
    |
 LL -     struct BeeOutlivesAyTeeAyBee<'a, 'b: 'a, T: 'a + 'b>(&'a &'b T);
 LL +     struct BeeOutlivesAyTeeAyBee<'a, 'b, T>(&'a &'b T);
-   | 
+   |
 
 error: outlives requirements can be inferred
   --> $DIR/edition-lint-infer-outlives-multispan.rs:154:55
@@ -373,7 +373,7 @@ help: remove these bounds
    |
 LL -     struct BeeOutlivesAyTeeOutlivesAyIsDebugBee<'a, 'b: 'a, T: 'a + Debug + 'b>(&'a &'b T);
 LL +     struct BeeOutlivesAyTeeOutlivesAyIsDebugBee<'a, 'b, T: Debug>(&'a &'b T);
-   | 
+   |
 
 error: outlives requirements can be inferred
   --> $DIR/edition-lint-infer-outlives-multispan.rs:157:71
@@ -385,7 +385,7 @@ help: remove these bounds
    |
 LL -     struct BeeWhereAyTeeWhereAyIsDebugBee<'a, 'b, T>(&'a &'b T) where 'b: 'a, T: 'a + Debug + 'b;
 LL +     struct BeeWhereAyTeeWhereAyIsDebugBee<'a, 'b, T>(&'a &'b T) where T: Debug;
-   | 
+   |
 
 error: outlives requirements can be inferred
   --> $DIR/edition-lint-infer-outlives-multispan.rs:160:58
@@ -397,7 +397,7 @@ help: remove these bounds
    |
 LL -     struct BeeOutlivesAyTeeYooOutlivesAyIsDebugBee<'a, 'b: 'a, T, U: 'a + Debug + 'b>(T, &'a &'b U);
 LL +     struct BeeOutlivesAyTeeYooOutlivesAyIsDebugBee<'a, 'b, T, U: Debug>(T, &'a &'b U);
-   | 
+   |
 
 error: outlives requirements can be inferred
   --> $DIR/edition-lint-infer-outlives-multispan.rs:164:18
@@ -409,7 +409,7 @@ help: remove these bounds
    |
 LL -         where U: 'a + Debug + 'b, 'b: 'a;
 LL +         where U: Debug, ;
-   | 
+   |
 
 error: outlives requirements can be inferred
   --> $DIR/edition-lint-infer-outlives-multispan.rs:171:45
@@ -421,7 +421,7 @@ help: remove these bounds
    |
 LL -     enum TeeOutlivesAyIsDebugBee<'a, 'b, T: 'a + Debug + 'b> {
 LL +     enum TeeOutlivesAyIsDebugBee<'a, 'b, T: Debug> {
-   | 
+   |
 
 error: outlives requirements can be inferred
   --> $DIR/edition-lint-infer-outlives-multispan.rs:176:59
@@ -433,7 +433,7 @@ help: remove these bounds
    |
 LL -     enum TeeWhereOutlivesAyIsDebugBee<'a, 'b, T> where T: 'a + Debug + 'b {
 LL +     enum TeeWhereOutlivesAyIsDebugBee<'a, 'b, T> where T: Debug {
-   | 
+   |
 
 error: outlives requirements can be inferred
   --> $DIR/edition-lint-infer-outlives-multispan.rs:181:51
@@ -445,7 +445,7 @@ help: remove these bounds
    |
 LL -     enum TeeYooOutlivesAyIsDebugBee<'a, 'b, T, U: 'a + Debug + 'b> {
 LL +     enum TeeYooOutlivesAyIsDebugBee<'a, 'b, T, U: Debug> {
-   | 
+   |
 
 error: outlives requirements can be inferred
   --> $DIR/edition-lint-infer-outlives-multispan.rs:187:46
@@ -457,7 +457,7 @@ help: remove these bounds
    |
 LL -     enum TeeOutlivesAyYooBeeIsDebug<'a, 'b, T: 'a, U: 'b + Debug> {
 LL +     enum TeeOutlivesAyYooBeeIsDebug<'a, 'b, T, U: Debug> {
-   | 
+   |
 
 error: outlives requirements can be inferred
   --> $DIR/edition-lint-infer-outlives-multispan.rs:193:46
@@ -469,7 +469,7 @@ help: remove these bounds
    |
 LL -     enum TeeOutlivesAyYooIsDebugBee<'a, 'b, T: 'a, U: Debug + 'b> {
 LL +     enum TeeOutlivesAyYooIsDebugBee<'a, 'b, T, U: Debug> {
-   | 
+   |
 
 error: outlives requirements can be inferred
   --> $DIR/edition-lint-infer-outlives-multispan.rs:199:44
@@ -481,7 +481,7 @@ help: remove these bounds
    |
 LL -     enum TeeOutlivesAyYooWhereBee<'a, 'b, T: 'a, U> where U: 'b {
 LL +     enum TeeOutlivesAyYooWhereBee<'a, 'b, T, U> {
-   | 
+   |
 
 error: outlives requirements can be inferred
   --> $DIR/edition-lint-infer-outlives-multispan.rs:205:65
@@ -493,7 +493,7 @@ help: remove these bounds
    |
 LL -     enum TeeYooWhereOutlivesAyIsDebugBee<'a, 'b, T, U> where U: 'a + Debug + 'b {
 LL +     enum TeeYooWhereOutlivesAyIsDebugBee<'a, 'b, T, U> where U: Debug {
-   | 
+   |
 
 error: outlives requirements can be inferred
   --> $DIR/edition-lint-infer-outlives-multispan.rs:211:51
@@ -505,7 +505,7 @@ help: remove these bounds
    |
 LL -     enum TeeOutlivesAyYooWhereBeeIsDebug<'a, 'b, T: 'a, U> where U: 'b + Debug {
 LL +     enum TeeOutlivesAyYooWhereBeeIsDebug<'a, 'b, T, U> where U: Debug {
-   | 
+   |
 
 error: outlives requirements can be inferred
   --> $DIR/edition-lint-infer-outlives-multispan.rs:217:51
@@ -517,7 +517,7 @@ help: remove these bounds
    |
 LL -     enum TeeOutlivesAyYooWhereIsDebugBee<'a, 'b, T: 'a, U> where U: Debug + 'b {
 LL +     enum TeeOutlivesAyYooWhereIsDebugBee<'a, 'b, T, U> where U: Debug {
-   | 
+   |
 
 error: outlives requirements can be inferred
   --> $DIR/edition-lint-infer-outlives-multispan.rs:223:67
@@ -529,7 +529,7 @@ help: remove these bounds
    |
 LL -     enum TeeWhereOutlivesAyYooWhereBeeIsDebug<'a, 'b, T, U> where T: 'a, U: 'b + Debug {
 LL +     enum TeeWhereOutlivesAyYooWhereBeeIsDebug<'a, 'b, T, U> where U: Debug {
-   | 
+   |
 
 error: outlives requirements can be inferred
   --> $DIR/edition-lint-infer-outlives-multispan.rs:229:67
@@ -541,7 +541,7 @@ help: remove these bounds
    |
 LL -     enum TeeWhereOutlivesAyYooWhereIsDebugBee<'a, 'b, T, U> where T: 'a, U: Debug + 'b {
 LL +     enum TeeWhereOutlivesAyYooWhereIsDebugBee<'a, 'b, T, U> where U: Debug {
-   | 
+   |
 
 error: outlives requirements can be inferred
   --> $DIR/edition-lint-infer-outlives-multispan.rs:235:36
@@ -553,7 +553,7 @@ help: remove these bounds
    |
 LL -     enum BeeOutlivesAyTeeBee<'a, 'b: 'a, T: 'b> {
 LL +     enum BeeOutlivesAyTeeBee<'a, 'b, T> {
-   | 
+   |
 
 error: outlives requirements can be inferred
   --> $DIR/edition-lint-infer-outlives-multispan.rs:240:38
@@ -565,7 +565,7 @@ help: remove these bounds
    |
 LL -     enum BeeOutlivesAyTeeAyBee<'a, 'b: 'a, T: 'a + 'b> {
 LL +     enum BeeOutlivesAyTeeAyBee<'a, 'b, T> {
-   | 
+   |
 
 error: outlives requirements can be inferred
   --> $DIR/edition-lint-infer-outlives-multispan.rs:246:53
@@ -577,7 +577,7 @@ help: remove these bounds
    |
 LL -     enum BeeOutlivesAyTeeOutlivesAyIsDebugBee<'a, 'b: 'a, T: 'a + Debug + 'b> {
 LL +     enum BeeOutlivesAyTeeOutlivesAyIsDebugBee<'a, 'b, T: Debug> {
-   | 
+   |
 
 error: outlives requirements can be inferred
   --> $DIR/edition-lint-infer-outlives-multispan.rs:251:66
@@ -589,7 +589,7 @@ help: remove these bounds
    |
 LL -     enum BeeWhereAyTeeWhereOutlivesAyIsDebugBee<'a, 'b, T> where 'b: 'a, T: 'a + Debug + 'b {
 LL +     enum BeeWhereAyTeeWhereOutlivesAyIsDebugBee<'a, 'b, T> where T: Debug {
-   | 
+   |
 
 error: outlives requirements can be inferred
   --> $DIR/edition-lint-infer-outlives-multispan.rs:256:56
@@ -601,7 +601,7 @@ help: remove these bounds
    |
 LL -     enum BeeOutlivesAyTeeYooOutlivesAyIsDebugBee<'a, 'b: 'a, T, U: 'a + Debug + 'b> {
 LL +     enum BeeOutlivesAyTeeYooOutlivesAyIsDebugBee<'a, 'b, T, U: Debug> {
-   | 
+   |
 
 error: outlives requirements can be inferred
   --> $DIR/edition-lint-infer-outlives-multispan.rs:262:75
@@ -613,7 +613,7 @@ help: remove these bounds
    |
 LL -     enum BeeWhereAyTeeYooWhereOutlivesAyIsDebugBee<'a, 'b, T, U> where U: 'a + Debug + 'b, 'b: 'a {
 LL +     enum BeeWhereAyTeeYooWhereOutlivesAyIsDebugBee<'a, 'b, T, U> where U: Debug,  {
-   | 
+   |
 
 error: outlives requirements can be inferred
   --> $DIR/edition-lint-infer-outlives-multispan.rs:271:46
@@ -625,7 +625,7 @@ help: remove these bounds
    |
 LL -     union TeeOutlivesAyIsDebugBee<'a, 'b, T: 'a + Debug + 'b> {
 LL +     union TeeOutlivesAyIsDebugBee<'a, 'b, T: Debug> {
-   | 
+   |
 
 error: outlives requirements can be inferred
   --> $DIR/edition-lint-infer-outlives-multispan.rs:276:60
@@ -637,7 +637,7 @@ help: remove these bounds
    |
 LL -     union TeeWhereOutlivesAyIsDebugBee<'a, 'b, T> where T: 'a + Debug + 'b {
 LL +     union TeeWhereOutlivesAyIsDebugBee<'a, 'b, T> where T: Debug {
-   | 
+   |
 
 error: outlives requirements can be inferred
   --> $DIR/edition-lint-infer-outlives-multispan.rs:281:52
@@ -649,7 +649,7 @@ help: remove these bounds
    |
 LL -     union TeeYooOutlivesAyIsDebugBee<'a, 'b, T, U: 'a + Debug + 'b> {
 LL +     union TeeYooOutlivesAyIsDebugBee<'a, 'b, T, U: Debug> {
-   | 
+   |
 
 error: outlives requirements can be inferred
   --> $DIR/edition-lint-infer-outlives-multispan.rs:287:47
@@ -661,7 +661,7 @@ help: remove these bounds
    |
 LL -     union TeeOutlivesAyYooBeeIsDebug<'a, 'b, T: 'a, U: 'b + Debug> {
 LL +     union TeeOutlivesAyYooBeeIsDebug<'a, 'b, T, U: Debug> {
-   | 
+   |
 
 error: outlives requirements can be inferred
   --> $DIR/edition-lint-infer-outlives-multispan.rs:293:47
@@ -673,7 +673,7 @@ help: remove these bounds
    |
 LL -     union TeeOutlivesAyYooIsDebugBee<'a, 'b, T: 'a, U: Debug + 'b> {
 LL +     union TeeOutlivesAyYooIsDebugBee<'a, 'b, T, U: Debug> {
-   | 
+   |
 
 error: outlives requirements can be inferred
   --> $DIR/edition-lint-infer-outlives-multispan.rs:299:45
@@ -685,7 +685,7 @@ help: remove these bounds
    |
 LL -     union TeeOutlivesAyYooWhereBee<'a, 'b, T: 'a, U> where U: 'b {
 LL +     union TeeOutlivesAyYooWhereBee<'a, 'b, T, U> {
-   | 
+   |
 
 error: outlives requirements can be inferred
   --> $DIR/edition-lint-infer-outlives-multispan.rs:305:66
@@ -697,7 +697,7 @@ help: remove these bounds
    |
 LL -     union TeeYooWhereOutlivesAyIsDebugBee<'a, 'b, T, U> where U: 'a + Debug + 'b {
 LL +     union TeeYooWhereOutlivesAyIsDebugBee<'a, 'b, T, U> where U: Debug {
-   | 
+   |
 
 error: outlives requirements can be inferred
   --> $DIR/edition-lint-infer-outlives-multispan.rs:311:52
@@ -709,7 +709,7 @@ help: remove these bounds
    |
 LL -     union TeeOutlivesAyYooWhereBeeIsDebug<'a, 'b, T: 'a, U> where U: 'b + Debug {
 LL +     union TeeOutlivesAyYooWhereBeeIsDebug<'a, 'b, T, U> where U: Debug {
-   | 
+   |
 
 error: outlives requirements can be inferred
   --> $DIR/edition-lint-infer-outlives-multispan.rs:317:52
@@ -721,7 +721,7 @@ help: remove these bounds
    |
 LL -     union TeeOutlivesAyYooWhereIsDebugBee<'a, 'b, T: 'a, U> where U: Debug + 'b {
 LL +     union TeeOutlivesAyYooWhereIsDebugBee<'a, 'b, T, U> where U: Debug {
-   | 
+   |
 
 error: outlives requirements can be inferred
   --> $DIR/edition-lint-infer-outlives-multispan.rs:323:68
@@ -733,7 +733,7 @@ help: remove these bounds
    |
 LL -     union TeeWhereOutlivesAyYooWhereBeeIsDebug<'a, 'b, T, U> where T: 'a, U: 'b + Debug {
 LL +     union TeeWhereOutlivesAyYooWhereBeeIsDebug<'a, 'b, T, U> where U: Debug {
-   | 
+   |
 
 error: outlives requirements can be inferred
   --> $DIR/edition-lint-infer-outlives-multispan.rs:329:68
@@ -745,7 +745,7 @@ help: remove these bounds
    |
 LL -     union TeeWhereOutlivesAyYooWhereIsDebugBee<'a, 'b, T, U> where T: 'a, U: Debug + 'b {
 LL +     union TeeWhereOutlivesAyYooWhereIsDebugBee<'a, 'b, T, U> where U: Debug {
-   | 
+   |
 
 error: outlives requirements can be inferred
   --> $DIR/edition-lint-infer-outlives-multispan.rs:335:37
@@ -757,7 +757,7 @@ help: remove these bounds
    |
 LL -     union BeeOutlivesAyTeeBee<'a, 'b: 'a, T: 'b> {
 LL +     union BeeOutlivesAyTeeBee<'a, 'b, T> {
-   | 
+   |
 
 error: outlives requirements can be inferred
   --> $DIR/edition-lint-infer-outlives-multispan.rs:340:39
@@ -769,7 +769,7 @@ help: remove these bounds
    |
 LL -     union BeeOutlivesAyTeeAyBee<'a, 'b: 'a, T: 'a + 'b> {
 LL +     union BeeOutlivesAyTeeAyBee<'a, 'b, T> {
-   | 
+   |
 
 error: outlives requirements can be inferred
   --> $DIR/edition-lint-infer-outlives-multispan.rs:345:54
@@ -781,7 +781,7 @@ help: remove these bounds
    |
 LL -     union BeeOutlivesAyTeeOutlivesAyIsDebugBee<'a, 'b: 'a, T: 'a + Debug + 'b> {
 LL +     union BeeOutlivesAyTeeOutlivesAyIsDebugBee<'a, 'b, T: Debug> {
-   | 
+   |
 
 error: outlives requirements can be inferred
   --> $DIR/edition-lint-infer-outlives-multispan.rs:350:67
@@ -793,7 +793,7 @@ help: remove these bounds
    |
 LL -     union BeeWhereAyTeeWhereOutlivesAyIsDebugBee<'a, 'b, T> where 'b: 'a, T: 'a + Debug + 'b {
 LL +     union BeeWhereAyTeeWhereOutlivesAyIsDebugBee<'a, 'b, T> where T: Debug {
-   | 
+   |
 
 error: outlives requirements can be inferred
   --> $DIR/edition-lint-infer-outlives-multispan.rs:355:57
@@ -805,7 +805,7 @@ help: remove these bounds
    |
 LL -     union BeeOutlivesAyTeeYooOutlivesAyIsDebugBee<'a, 'b: 'a, T, U: 'a + Debug + 'b> {
 LL +     union BeeOutlivesAyTeeYooOutlivesAyIsDebugBee<'a, 'b, T, U: Debug> {
-   | 
+   |
 
 error: outlives requirements can be inferred
   --> $DIR/edition-lint-infer-outlives-multispan.rs:361:76
@@ -817,7 +817,7 @@ help: remove these bounds
    |
 LL -     union BeeWhereAyTeeYooWhereOutlivesAyIsDebugBee<'a, 'b, T, U> where U: 'a + Debug + 'b, 'b: 'a {
 LL +     union BeeWhereAyTeeYooWhereOutlivesAyIsDebugBee<'a, 'b, T, U> where U: Debug,  {
-   | 
+   |
 
 error: aborting due to 68 previous errors
 

--- a/src/test/ui/rust-2021/reserved-prefixes-migration.stderr
+++ b/src/test/ui/rust-2021/reserved-prefixes-migration.stderr
@@ -15,7 +15,7 @@ help: insert whitespace here to avoid this being parsed as a prefix in Rust 2021
    |
 LL -     m2!(z"hey");
 LL +     m2!(z "hey");
-   | 
+   |
 
 warning: prefix `prefix` is unknown
   --> $DIR/reserved-prefixes-migration.rs:19:9
@@ -29,7 +29,7 @@ help: insert whitespace here to avoid this being parsed as a prefix in Rust 2021
    |
 LL -     m2!(prefix"hey");
 LL +     m2!(prefix "hey");
-   | 
+   |
 
 warning: prefix `hey` is unknown
   --> $DIR/reserved-prefixes-migration.rs:22:9
@@ -43,7 +43,7 @@ help: insert whitespace here to avoid this being parsed as a prefix in Rust 2021
    |
 LL -     m3!(hey#123);
 LL +     m3!(hey #123);
-   | 
+   |
 
 warning: prefix `hey` is unknown
   --> $DIR/reserved-prefixes-migration.rs:25:9
@@ -57,7 +57,7 @@ help: insert whitespace here to avoid this being parsed as a prefix in Rust 2021
    |
 LL -     m3!(hey#hey);
 LL +     m3!(hey #hey);
-   | 
+   |
 
 warning: prefix `kind` is unknown
   --> $DIR/reserved-prefixes-migration.rs:35:14
@@ -71,7 +71,7 @@ help: insert whitespace here to avoid this being parsed as a prefix in Rust 2021
    |
 LL -     #name = #kind#value
 LL +     #name = #kind #value
-   | 
+   |
 
 warning: 5 warnings emitted
 

--- a/src/test/ui/rust-2021/reserved-prefixes.stderr
+++ b/src/test/ui/rust-2021/reserved-prefixes.stderr
@@ -9,7 +9,7 @@ help: consider inserting whitespace here
    |
 LL -     demo3!(foo#bar);
 LL +     demo3!(foo #bar);
-   | 
+   |
 
 error: prefix `foo` is unknown
   --> $DIR/reserved-prefixes.rs:17:12
@@ -22,7 +22,7 @@ help: consider inserting whitespace here
    |
 LL -     demo2!(foo"bar");
 LL +     demo2!(foo "bar");
-   | 
+   |
 
 error: prefix `foo` is unknown
   --> $DIR/reserved-prefixes.rs:18:12
@@ -35,7 +35,7 @@ help: consider inserting whitespace here
    |
 LL -     demo2!(foo'b');
 LL +     demo2!(foo 'b');
-   | 
+   |
 
 error: prefix `foo` is unknown
   --> $DIR/reserved-prefixes.rs:20:12
@@ -48,7 +48,7 @@ help: consider inserting whitespace here
    |
 LL -     demo2!(foo'b);
 LL +     demo2!(foo 'b);
-   | 
+   |
 
 error: prefix `foo` is unknown
   --> $DIR/reserved-prefixes.rs:21:12
@@ -61,7 +61,7 @@ help: consider inserting whitespace here
    |
 LL -     demo3!(foo# bar);
 LL +     demo3!(foo # bar);
-   | 
+   |
 
 error: prefix `foo` is unknown
   --> $DIR/reserved-prefixes.rs:22:12
@@ -74,7 +74,7 @@ help: consider inserting whitespace here
    |
 LL -     demo4!(foo#! bar);
 LL +     demo4!(foo #! bar);
-   | 
+   |
 
 error: prefix `foo` is unknown
   --> $DIR/reserved-prefixes.rs:23:12
@@ -87,7 +87,7 @@ help: consider inserting whitespace here
    |
 LL -     demo4!(foo## bar);
 LL +     demo4!(foo ## bar);
-   | 
+   |
 
 error: prefix `foo` is unknown
   --> $DIR/reserved-prefixes.rs:25:12
@@ -100,7 +100,7 @@ help: consider inserting whitespace here
    |
 LL -     demo4!(foo#bar#);
 LL +     demo4!(foo #bar#);
-   | 
+   |
 
 error: prefix `bar` is unknown
   --> $DIR/reserved-prefixes.rs:25:16
@@ -113,7 +113,7 @@ help: consider inserting whitespace here
    |
 LL -     demo4!(foo#bar#);
 LL +     demo4!(foo#bar #);
-   | 
+   |
 
 error: aborting due to 9 previous errors
 

--- a/src/test/ui/single-use-lifetime/fn-types.stderr
+++ b/src/test/ui/single-use-lifetime/fn-types.stderr
@@ -15,7 +15,7 @@ help: elide the single-use lifetime
    |
 LL -   a: for<'a> fn(&'a u32),
 LL +   a: fn(&u32),
-   | 
+   |
 
 error[E0581]: return type references lifetime `'a`, which is not constrained by the fn input types
   --> $DIR/fn-types.rs:12:22

--- a/src/test/ui/single-use-lifetime/one-use-in-fn-argument.stderr
+++ b/src/test/ui/single-use-lifetime/one-use-in-fn-argument.stderr
@@ -15,7 +15,7 @@ help: elide the single-use lifetime
    |
 LL - fn a<'a>(x: &'a u32) {
 LL + fn a(x: &u32) {
-   | 
+   |
 
 error: lifetime parameter `'m` only used once
   --> $DIR/one-use-in-fn-argument.rs:15:11
@@ -29,7 +29,7 @@ help: elide the single-use lifetime
    |
 LL - fn center<'m>(_: Single<'m>) {}
 LL + fn center(_: Single<'_>) {}
-   | 
+   |
 
 error: lifetime parameter `'y` only used once
   --> $DIR/one-use-in-fn-argument.rs:17:13
@@ -41,7 +41,7 @@ help: elide the single-use lifetime
    |
 LL - fn left<'x, 'y>(foo: Double<'x, 'y>) -> &'x u32 { foo.f }
 LL + fn left<'x>(foo: Double<'x, '_>) -> &'x u32 { foo.f }
-   | 
+   |
 
 error: lifetime parameter `'x` only used once
   --> $DIR/one-use-in-fn-argument.rs:19:10
@@ -53,7 +53,7 @@ help: elide the single-use lifetime
    |
 LL - fn right<'x, 'y>(foo: Double<'x, 'y>) -> &'y u32 { foo.f }
 LL + fn right<'y>(foo: Double<'_, 'y>) -> &'y u32 { foo.f }
-   | 
+   |
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/single-use-lifetime/one-use-in-inherent-impl-header.stderr
+++ b/src/test/ui/single-use-lifetime/one-use-in-inherent-impl-header.stderr
@@ -15,7 +15,7 @@ help: elide the single-use lifetime
    |
 LL - impl<'f> Foo<'f> {
 LL + impl Foo<'_> {
-   | 
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/single-use-lifetime/one-use-in-inherent-method-argument.stderr
+++ b/src/test/ui/single-use-lifetime/one-use-in-inherent-method-argument.stderr
@@ -15,7 +15,7 @@ help: elide the single-use lifetime
    |
 LL - impl<'f> Foo<'f> {
 LL + impl Foo<'_> {
-   | 
+   |
 
 error: lifetime parameter `'a` only used once
   --> $DIR/one-use-in-inherent-method-argument.rs:13:19
@@ -29,7 +29,7 @@ help: elide the single-use lifetime
    |
 LL -     fn inherent_a<'a>(&self, data: &'a u32) {
 LL +     fn inherent_a(&self, data: &u32) {
-   | 
+   |
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/single-use-lifetime/one-use-in-inherent-method-return.stderr
+++ b/src/test/ui/single-use-lifetime/one-use-in-inherent-method-return.stderr
@@ -15,7 +15,7 @@ help: elide the single-use lifetime
    |
 LL - impl<'f> Foo<'f> {
 LL + impl Foo<'_> {
-   | 
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/single-use-lifetime/one-use-in-trait-method-argument.stderr
+++ b/src/test/ui/single-use-lifetime/one-use-in-trait-method-argument.stderr
@@ -15,7 +15,7 @@ help: elide the single-use lifetime
    |
 LL -     fn next<'g>(&'g mut self) -> Option<Self::Item> {
 LL +     fn next(&mut self) -> Option<Self::Item> {
-   | 
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/single-use-lifetime/two-uses-in-inherent-method-argument-and-return.stderr
+++ b/src/test/ui/single-use-lifetime/two-uses-in-inherent-method-argument-and-return.stderr
@@ -15,7 +15,7 @@ help: elide the single-use lifetime
    |
 LL - impl<'f> Foo<'f> {
 LL + impl Foo<'_> {
-   | 
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/span/issue-39018.stderr
+++ b/src/test/ui/span/issue-39018.stderr
@@ -66,7 +66,7 @@ help: remove the borrow to obtain an owned `String`
    |
 LL -     let _ = &a + &b;
 LL +     let _ = a + &b;
-   | 
+   |
 
 error[E0369]: cannot add `String` to `&String`
   --> $DIR/issue-39018.rs:27:16
@@ -81,7 +81,7 @@ help: remove the borrow on the left and add one on the right
    |
 LL -     let _ = &a + b;
 LL +     let _ = a + &b;
-   | 
+   |
 
 error[E0308]: mismatched types
   --> $DIR/issue-39018.rs:29:17

--- a/src/test/ui/specialization/issue-52050.stderr
+++ b/src/test/ui/specialization/issue-52050.stderr
@@ -17,7 +17,7 @@ LL | |     I: Iterator,
 LL | | {
 LL | | }
    | |_- first implementation here
-LL | 
+LL |
 LL |   impl IntoPyDictPointer for ()
    |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `()`
    |

--- a/src/test/ui/str/str-lit-type-mismatch.stderr
+++ b/src/test/ui/str/str-lit-type-mismatch.stderr
@@ -42,7 +42,7 @@ help: consider removing the leading `b`
    |
 LL -     let z: &str = b"foo";
 LL +     let z: &str = "foo";
-   | 
+   |
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/structs/struct-path-self.stderr
+++ b/src/test/ui/structs/struct-path-self.stderr
@@ -16,7 +16,7 @@ help: the `Self` type doesn't accept type parameters
    |
 LL -         let z = Self::<u8> {};
 LL +         let z = Self {};
-   | 
+   |
 
 error[E0071]: expected struct, variant or union type, found type parameter `Self`
   --> $DIR/struct-path-self.rs:7:17
@@ -50,7 +50,7 @@ help: the `Self` type doesn't accept type parameters
    |
 LL -         let z = Self::<u8> {};
 LL +         let z = Self {};
-   | 
+   |
 
 error[E0109]: type arguments are not allowed on self type
   --> $DIR/struct-path-self.rs:30:24
@@ -72,7 +72,7 @@ help: the `Self` type doesn't accept type parameters
    |
 LL -         let z = Self::<u8> {};
 LL +         let z = Self {};
-   | 
+   |
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/suggestions/adt-param-with-implicit-sized-bound.stderr
+++ b/src/test/ui/suggestions/adt-param-with-implicit-sized-bound.stderr
@@ -105,7 +105,7 @@ help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - struct Struct5<T: ?Sized>{
 LL + struct Struct5<T>{
-   | 
+   |
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/suggestions/format-borrow.stderr
+++ b/src/test/ui/suggestions/format-borrow.stderr
@@ -10,7 +10,7 @@ help: consider removing the borrow
    |
 LL -     let a: String = &String::from("a");
 LL +     let a: String = String::from("a");
-   | 
+   |
 
 error[E0308]: mismatched types
   --> $DIR/format-borrow.rs:4:21
@@ -24,7 +24,7 @@ help: consider removing the borrow
    |
 LL -     let b: String = &format!("b");
 LL +     let b: String = format!("b");
-   | 
+   |
 
 error[E0308]: mismatched types
   --> $DIR/format-borrow.rs:6:21
@@ -38,7 +38,7 @@ help: consider removing the borrow
    |
 LL -     let c: String = &mut format!("c");
 LL +     let c: String = format!("c");
-   | 
+   |
 
 error[E0308]: mismatched types
   --> $DIR/format-borrow.rs:8:21
@@ -52,7 +52,7 @@ help: consider removing the borrow
    |
 LL -     let d: String = &mut (format!("d"));
 LL +     let d: String = format!("d"));
-   | 
+   |
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/suggestions/issue-61963.stderr
+++ b/src/test/ui/suggestions/issue-61963.stderr
@@ -15,7 +15,7 @@ help: use `dyn`
    |
 LL -     bar: Box<Bar>,
 LL +     bar: Box<dyn Bar>,
-   | 
+   |
 
 error: trait objects without an explicit `dyn` are deprecated
   --> $DIR/issue-61963.rs:18:1
@@ -29,7 +29,7 @@ help: use `dyn`
    |
 LL - pub struct Foo {
 LL + dyn pub struct Foo {
-   | 
+   |
 
 error: trait objects without an explicit `dyn` are deprecated
   --> $DIR/issue-61963.rs:28:14
@@ -43,7 +43,7 @@ help: use `dyn`
    |
 LL -     bar: Box<Bar>,
 LL +     bar: Box<dyn Bar>,
-   | 
+   |
 
 error: trait objects without an explicit `dyn` are deprecated
   --> $DIR/issue-61963.rs:28:14
@@ -57,7 +57,7 @@ help: use `dyn`
    |
 LL -     bar: Box<Bar>,
 LL +     bar: Box<dyn Bar>,
-   | 
+   |
 
 error: trait objects without an explicit `dyn` are deprecated
   --> $DIR/issue-61963.rs:18:1
@@ -71,7 +71,7 @@ help: use `dyn`
    |
 LL - pub struct Foo {
 LL + dyn pub struct Foo {
-   | 
+   |
 
 error: trait objects without an explicit `dyn` are deprecated
   --> $DIR/issue-61963.rs:18:1
@@ -85,7 +85,7 @@ help: use `dyn`
    |
 LL - pub struct Foo {
 LL + dyn pub struct Foo {
-   | 
+   |
 
 error: trait objects without an explicit `dyn` are deprecated
   --> $DIR/issue-61963.rs:18:1
@@ -99,7 +99,7 @@ help: use `dyn`
    |
 LL - pub struct Foo {
 LL + dyn pub struct Foo {
-   | 
+   |
 
 error: aborting due to 7 previous errors
 

--- a/src/test/ui/suggestions/issue-82361.stderr
+++ b/src/test/ui/suggestions/issue-82361.stderr
@@ -31,7 +31,7 @@ help: consider removing the borrow
    |
 LL -         &1
 LL +         1
-   | 
+   |
 
 error[E0308]: `if` and `else` have incompatible types
   --> $DIR/issue-82361.rs:22:9
@@ -49,7 +49,7 @@ help: consider removing the borrow
    |
 LL -         &mut 1
 LL +         1
-   | 
+   |
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/suggestions/issue-96555.stderr
+++ b/src/test/ui/suggestions/issue-96555.stderr
@@ -13,7 +13,7 @@ help: remove the `.await`
    |
 LL -     m::f1().await;
 LL +     m::f1();
-   | 
+   |
 help: alternatively, consider making `fn f1` asynchronous
    |
 LL |     pub async fn f1() {}
@@ -34,7 +34,7 @@ help: remove the `.await`
    |
 LL -     m::f2().await;
 LL +     m::f2();
-   | 
+   |
 help: alternatively, consider making `fn f2` asynchronous
    |
 LL |     pub(crate) async fn f2() {}
@@ -55,7 +55,7 @@ help: remove the `.await`
    |
 LL -     m::f3().await;
 LL +     m::f3();
-   | 
+   |
 help: alternatively, consider making `fn f3` asynchronous
    |
 LL |     pub async

--- a/src/test/ui/suggestions/match-ergonomics.stderr
+++ b/src/test/ui/suggestions/match-ergonomics.stderr
@@ -12,7 +12,7 @@ help: consider removing `&` from the pattern
    |
 LL -         [&v] => {},
 LL +         [v] => {},
-   | 
+   |
 
 error[E0529]: expected an array or slice, found `Vec<i32>`
   --> $DIR/match-ergonomics.rs:8:9
@@ -44,7 +44,7 @@ help: consider removing `&` from the pattern
    |
 LL -         &v => {},
 LL +         v => {},
-   | 
+   |
 
 error[E0308]: mismatched types
   --> $DIR/match-ergonomics.rs:40:13
@@ -60,7 +60,7 @@ help: consider removing `&` from the pattern
    |
 LL -     if let [&v] = &x[..] {}
 LL +     if let [v] = &x[..] {}
-   | 
+   |
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/suggestions/match-prev-arm-needing-semi.stderr
+++ b/src/test/ui/suggestions/match-prev-arm-needing-semi.stderr
@@ -30,7 +30,7 @@ help: consider removing this semicolon
    |
 LL -             async_dummy();
 LL +             async_dummy()
-   | 
+   |
 
 error[E0308]: `match` arms have incompatible types
   --> $DIR/match-prev-arm-needing-semi.rs:48:18

--- a/src/test/ui/suggestions/removal-of-multiline-trait-bound-in-where-clause.stderr
+++ b/src/test/ui/suggestions/removal-of-multiline-trait-bound-in-where-clause.stderr
@@ -25,7 +25,7 @@ LL -     T
 LL -     :
 LL -     ?
 LL -     Sized
-   | 
+   |
 
 error[E0277]: the size for values of type `T` cannot be known at compilation time
   --> $DIR/removal-of-multiline-trait-bound-in-where-clause.rs:14:16
@@ -50,7 +50,7 @@ LL | struct Wrapper<T>(T);
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - where T: ?Sized
-   | 
+   |
 
 error[E0277]: the size for values of type `T` cannot be known at compilation time
   --> $DIR/removal-of-multiline-trait-bound-in-where-clause.rs:21:16
@@ -76,7 +76,7 @@ help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - where
 LL -     T: ?Sized
-   | 
+   |
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/suggestions/suggest-change-mut.stderr
+++ b/src/test/ui/suggestions/suggest-change-mut.stderr
@@ -15,7 +15,7 @@ help: consider removing the leading `&`-reference
    |
 LL -         let mut stream_reader = BufReader::new(&stream);
 LL +         let mut stream_reader = BufReader::new(stream);
-   | 
+   |
 help: consider introducing a `where` clause, but there might be an alternative better way to express this requirement
    |
 LL | fn issue_81421<T: Read + Write>(mut stream: T) where &T: std::io::Read {

--- a/src/test/ui/suggestions/suggest-swapping-self-ty-and-trait-edition-2021.stderr
+++ b/src/test/ui/suggestions/suggest-swapping-self-ty-and-trait-edition-2021.stderr
@@ -41,7 +41,7 @@ help: add `dyn` keyword before this trait
    |
 LL - impl<'a, T> Struct<T> for Trait<'a, T> {}
 LL + impl<'a, T> Struct<T> for dyn Trait<'a, T> {}
-   | 
+   |
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/suggestions/suggest-swapping-self-ty-and-trait.stderr
+++ b/src/test/ui/suggestions/suggest-swapping-self-ty-and-trait.stderr
@@ -44,7 +44,7 @@ help: use `dyn`
    |
 LL - impl<'a, T> Struct<T> for Trait<'a, T> {}
 LL + impl<'a, T> Struct<T> for dyn Trait<'a, T> {}
-   | 
+   |
 
 error: aborting due to 3 previous errors; 1 warning emitted
 

--- a/src/test/ui/suggestions/suggest-trait-items.stderr
+++ b/src/test/ui/suggestions/suggest-trait-items.stderr
@@ -48,7 +48,7 @@ error[E0046]: not all trait items implemented, missing: `Type`, `foo`, `bar`, `q
    |
 LL |     type Type;
    |     ---------- `Type` from trait
-LL | 
+LL |
 LL |     fn foo();
    |     --------- `foo` from trait
 LL |     fn bar();

--- a/src/test/ui/trait-bounds/shadowed-path-in-trait-bound-suggestion.stderr
+++ b/src/test/ui/trait-bounds/shadowed-path-in-trait-bound-suggestion.stderr
@@ -12,7 +12,7 @@ help: if you import `Trait`, refer to it directly
    |
 LL -     pub struct A<H: A::Trait>(pub H);
 LL +     pub struct A<H: Trait>(pub H);
-   | 
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/trait-bounds/unsized-bound.stderr
+++ b/src/test/ui/trait-bounds/unsized-bound.stderr
@@ -16,7 +16,7 @@ help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - impl<A, B> Trait<(A, B)> for (A, B) where A: ?Sized, B: ?Sized, {}
 LL + impl<A, B> Trait<(A, B)> for (A, B) where A: ?Sized, {}
-   | 
+   |
 help: consider relaxing the implicit `Sized` restriction
    |
 LL | trait Trait<A: ?Sized> {}
@@ -35,7 +35,7 @@ help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - impl<A, B> Trait<(A, B)> for (A, B) where A: ?Sized, B: ?Sized, {}
 LL + impl<A, B> Trait<(A, B)> for (A, B) where B: ?Sized, {}
-   | 
+   |
 
 error[E0277]: the size for values of type `C` cannot be known at compilation time
   --> $DIR/unsized-bound.rs:5:31
@@ -55,7 +55,7 @@ help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - impl<A, B: ?Sized, C: ?Sized> Trait<(A, B, C)> for (A, B, C) where A: ?Sized, {}
 LL + impl<A, B: ?Sized, C> Trait<(A, B, C)> for (A, B, C) where A: ?Sized, {}
-   | 
+   |
 help: consider relaxing the implicit `Sized` restriction
    |
 LL | trait Trait<A: ?Sized> {}
@@ -74,7 +74,7 @@ help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - impl<A, B: ?Sized, C: ?Sized> Trait<(A, B, C)> for (A, B, C) where A: ?Sized, {}
 LL + impl<A, B: ?Sized, C: ?Sized> Trait<(A, B, C)> for (A, B, C)  {}
-   | 
+   |
 
 error[E0277]: the size for values of type `B` cannot be known at compilation time
   --> $DIR/unsized-bound.rs:5:52
@@ -89,7 +89,7 @@ help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - impl<A, B: ?Sized, C: ?Sized> Trait<(A, B, C)> for (A, B, C) where A: ?Sized, {}
 LL + impl<A, B, C: ?Sized> Trait<(A, B, C)> for (A, B, C) where A: ?Sized, {}
-   | 
+   |
 
 error[E0277]: the size for values of type `B` cannot be known at compilation time
   --> $DIR/unsized-bound.rs:10:28
@@ -109,7 +109,7 @@ help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - impl<A: ?Sized, B: ?Sized> Trait2<(A, B)> for (A, B) {}
 LL + impl<A: ?Sized, B> Trait2<(A, B)> for (A, B) {}
-   | 
+   |
 help: consider relaxing the implicit `Sized` restriction
    |
 LL | trait Trait2<A: ?Sized> {}
@@ -128,7 +128,7 @@ help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - impl<A: ?Sized, B: ?Sized> Trait2<(A, B)> for (A, B) {}
 LL + impl<A, B: ?Sized> Trait2<(A, B)> for (A, B) {}
-   | 
+   |
 
 error[E0277]: the size for values of type `A` cannot be known at compilation time
   --> $DIR/unsized-bound.rs:14:9
@@ -147,7 +147,7 @@ help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - impl<A> Trait3<A> for A where A: ?Sized {}
 LL + impl<A> Trait3<A> for A  {}
-   | 
+   |
 help: consider relaxing the implicit `Sized` restriction
    |
 LL | trait Trait3<A: ?Sized> {}
@@ -170,7 +170,7 @@ help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - impl<A: ?Sized> Trait4<A> for A {}
 LL + impl<A> Trait4<A> for A {}
-   | 
+   |
 help: consider relaxing the implicit `Sized` restriction
    |
 LL | trait Trait4<A: ?Sized> {}
@@ -193,7 +193,7 @@ help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - impl<X, Y> Trait5<X, Y> for X where X: ?Sized {}
 LL + impl<X, Y> Trait5<X, Y> for X  {}
-   | 
+   |
 help: consider relaxing the implicit `Sized` restriction
    |
 LL | trait Trait5<A: ?Sized, B> {}
@@ -216,7 +216,7 @@ help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - impl<X: ?Sized, Y> Trait6<X, Y> for X {}
 LL + impl<X, Y> Trait6<X, Y> for X {}
-   | 
+   |
 help: consider relaxing the implicit `Sized` restriction
    |
 LL | trait Trait6<A: ?Sized, B> {}
@@ -239,7 +239,7 @@ help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - impl<X, Y> Trait7<X, Y> for X where Y: ?Sized {}
 LL + impl<X, Y> Trait7<X, Y> for X  {}
-   | 
+   |
 help: consider relaxing the implicit `Sized` restriction
    |
 LL | trait Trait7<A, B: ?Sized> {}
@@ -262,7 +262,7 @@ help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - impl<X, Y: ?Sized> Trait8<X, Y> for X {}
 LL + impl<X, Y> Trait8<X, Y> for X {}
-   | 
+   |
 help: consider relaxing the implicit `Sized` restriction
    |
 LL | trait Trait8<A, B: ?Sized> {}

--- a/src/test/ui/traits/alias/no-duplicates.stderr
+++ b/src/test/ui/traits/alias/no-duplicates.stderr
@@ -262,7 +262,7 @@ LL | trait _5 = Obj + Send;
    |            |
    |            additional non-auto trait
    |            first non-auto trait
-LL | 
+LL |
 LL | type _T20 = dyn _5 + _5;
    |                 --   ^^ trait alias used in trait object type (additional use)
    |                 |
@@ -326,7 +326,7 @@ LL | trait _6 = _5 + _5; // ==> Obj + Send + Obj + Send
    |            --   -- referenced here (additional use)
    |            |
    |            referenced here (first use)
-LL | 
+LL |
 LL | type _T30 = dyn _6;
    |                 ^^
    |                 |
@@ -392,7 +392,7 @@ LL | trait _7 = _5 + Sync;
    |            -- referenced here (first use)
 LL | trait _8 = Unpin + _7;
    |                    -- referenced here (first use)
-LL | 
+LL |
 LL | type _T40 = dyn _8 + Obj;
    |                 --   ^^^ additional non-auto trait
    |                 |

--- a/src/test/ui/traits/alias/no-extra-traits.stderr
+++ b/src/test/ui/traits/alias/no-extra-traits.stderr
@@ -148,7 +148,7 @@ LL | trait _1 = _0;
 ...
 LL | trait _5 = Sync + ObjB + Send;
    |                   ---- first non-auto trait
-LL | 
+LL |
 LL | type _T20 = dyn _5 + _1;
    |                 --   ^^ trait alias used in trait object type (additional use)
    |                 |
@@ -460,7 +460,7 @@ LL | trait _9 = _5 + Sync;
    |            -- referenced here (first use)
 LL | trait _10 = Unpin + _9;
    |                     -- referenced here (first use)
-LL | 
+LL |
 LL | type _T40 = dyn _10 + ObjA;
    |                 ---   ^^^^ additional non-auto trait
    |                 |

--- a/src/test/ui/traits/alias/only-maybe-bound.stderr
+++ b/src/test/ui/traits/alias/only-maybe-bound.stderr
@@ -12,7 +12,7 @@ error[E0224]: at least one trait is required for an object type
    |
 LL | trait _2 = _1 + _1;
    | ------------------- this alias does not contain a trait
-LL | 
+LL |
 LL | type _T1 = dyn _2;
    |            ^^^^^^
 

--- a/src/test/ui/traits/bound/not-on-bare-trait.stderr
+++ b/src/test/ui/traits/bound/not-on-bare-trait.stderr
@@ -11,7 +11,7 @@ help: use `dyn`
    |
 LL - fn foo(_x: Foo + Send) {
 LL + fn foo(_x: dyn Foo + Send) {
-   | 
+   |
 
 error[E0277]: the size for values of type `(dyn Foo + Send + 'static)` cannot be known at compilation time
   --> $DIR/not-on-bare-trait.rs:7:8

--- a/src/test/ui/traits/bound/not-on-struct.stderr
+++ b/src/test/ui/traits/bound/not-on-struct.stderr
@@ -47,7 +47,7 @@ help: if you meant to use a type and not a trait here, remove the bounds
    |
 LL - fn a() -> A + 'static {
 LL + fn a() -> A {
-   | 
+   |
 
 error[E0404]: expected trait, found enum `Result`
   --> $DIR/not-on-struct.rs:16:34
@@ -66,7 +66,7 @@ help: if you meant to use a type and not a trait here, remove the bounds
    |
 LL - fn b<'a,T,E>(iter: Iterator<Item=Result<T,E> + 'a>) {
 LL + fn b<'a,T,E>(iter: Iterator<Item=Result<T,E>>) {
-   | 
+   |
 
 error[E0404]: expected trait, found struct `A`
   --> $DIR/not-on-struct.rs:19:21
@@ -85,7 +85,7 @@ help: if you meant to use a type and not a trait here, remove the bounds
    |
 LL - fn c() -> 'static + A {
 LL + fn c() -> A {
-   | 
+   |
 
 error[E0404]: expected trait, found enum `Result`
   --> $DIR/not-on-struct.rs:22:39
@@ -104,7 +104,7 @@ help: if you meant to use a type and not a trait here, remove the bounds
    |
 LL - fn d<'a,T,E>(iter: Iterator<Item='a + Result<T,E>>) {
 LL + fn d<'a,T,E>(iter: Iterator<Item=Result<T,E>>) {
-   | 
+   |
 
 error[E0404]: expected trait, found struct `A`
   --> $DIR/not-on-struct.rs:25:21
@@ -123,7 +123,7 @@ help: if you meant to use a type and not a trait here, remove the bounds
    |
 LL - fn e() -> 'static + A + 'static {
 LL + fn e() -> A {
-   | 
+   |
 
 error[E0404]: expected trait, found enum `Result`
   --> $DIR/not-on-struct.rs:29:39
@@ -142,7 +142,7 @@ help: if you meant to use a type and not a trait here, remove the bounds
    |
 LL - fn f<'a,T,E>(iter: Iterator<Item='a + Result<T,E> + 'a>) {
 LL + fn f<'a,T,E>(iter: Iterator<Item=Result<T,E>>) {
-   | 
+   |
 
 error[E0404]: expected trait, found struct `Traitor`
   --> $DIR/not-on-struct.rs:35:11
@@ -163,7 +163,7 @@ help: if you meant to use a type and not a trait here, remove the bounds
    |
 LL - fn g() -> Traitor + 'static {
 LL + fn g() -> Traitor {
-   | 
+   |
 help: a trait with a similar name exists
    |
 LL | fn g() -> Trait + 'static {

--- a/src/test/ui/traits/suggest-where-clause.stderr
+++ b/src/test/ui/traits/suggest-where-clause.stderr
@@ -16,7 +16,7 @@ help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - fn check<T: Iterator, U: ?Sized>() {
 LL + fn check<T: Iterator, U>() {
-   | 
+   |
 
 error[E0277]: the size for values of type `U` cannot be known at compilation time
   --> $DIR/suggest-where-clause.rs:10:5
@@ -41,7 +41,7 @@ help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - fn check<T: Iterator, U: ?Sized>() {
 LL + fn check<T: Iterator, U>() {
-   | 
+   |
 
 error[E0277]: the trait bound `u64: From<T>` is not satisfied
   --> $DIR/suggest-where-clause.rs:15:5

--- a/src/test/ui/traits/vtable/issue-97381.stderr
+++ b/src/test/ui/traits/vtable/issue-97381.stderr
@@ -3,7 +3,7 @@ error[E0505]: cannot move out of `v` because it is borrowed
    |
 LL |     let el = &v[0];
    |               - borrow of `v` occurs here
-LL | 
+LL |
 LL |     for _ in v {
    |              ^ move out of `v` occurs here
 LL |

--- a/src/test/ui/trivial-bounds/trivial-bounds-inconsistent.stderr
+++ b/src/test/ui/trivial-bounds/trivial-bounds-inconsistent.stderr
@@ -35,7 +35,7 @@ help: the clause will not be checked when the type alias is used, and should be 
    |
 LL - type Y where i32: Foo = ();
 LL + type Y  = ();
-   | 
+   |
 
 warning: trait bound i32: Foo does not depend on any type or lifetime parameters
   --> $DIR/trivial-bounds-inconsistent.rs:22:19

--- a/src/test/ui/try-block/try-block-bad-lifetime.stderr
+++ b/src/test/ui/try-block/try-block-bad-lifetime.stderr
@@ -42,7 +42,7 @@ LL |         let k = &mut i;
 ...
 LL |         i = 40;
    |         ^^^^^^ assignment to borrowed `i` occurs here
-LL | 
+LL |
 LL |         let i_ptr = if let Err(i_ptr) = j { i_ptr } else { panic ! ("") };
    |                                         - borrow later used here
 

--- a/src/test/ui/try-block/try-block-unreachable-code-lint.stderr
+++ b/src/test/ui/try-block/try-block-unreachable-code-lint.stderr
@@ -3,7 +3,7 @@ warning: unreachable expression
    |
 LL |           return;
    |           ------ any code following this expression is unreachable
-LL | 
+LL |
 LL | /         try {
 LL | |             loop {
 LL | |                 err()?;
@@ -32,7 +32,7 @@ LL | /         loop {
 LL | |             err()?;
 LL | |         }
    | |_________- any code following this expression is unreachable
-LL | 
+LL |
 LL |           42
    |           ^^ unreachable expression
 

--- a/src/test/ui/try-block/try-block-unused-delims.stderr
+++ b/src/test/ui/try-block/try-block-unused-delims.stderr
@@ -13,7 +13,7 @@ help: remove these parentheses
    |
 LL -     consume((try {}));
 LL +     consume(try {});
-   | 
+   |
 
 warning: unnecessary braces around function argument
   --> $DIR/try-block-unused-delims.rs:14:13
@@ -30,7 +30,7 @@ help: remove these braces
    |
 LL -     consume({ try {} });
 LL +     consume(try {});
-   | 
+   |
 
 warning: unnecessary parentheses around `match` scrutinee expression
   --> $DIR/try-block-unused-delims.rs:17:11
@@ -42,7 +42,7 @@ help: remove these parentheses
    |
 LL -     match (try {}) {
 LL +     match try {} {
-   | 
+   |
 
 warning: unnecessary parentheses around `let` scrutinee expression
   --> $DIR/try-block-unused-delims.rs:22:22
@@ -54,7 +54,7 @@ help: remove these parentheses
    |
 LL -     if let Err(()) = (try {}) {}
 LL +     if let Err(()) = try {} {}
-   | 
+   |
 
 warning: unnecessary parentheses around `match` scrutinee expression
   --> $DIR/try-block-unused-delims.rs:25:11
@@ -66,7 +66,7 @@ help: remove these parentheses
    |
 LL -     match (try {}) {
 LL +     match try {} {
-   | 
+   |
 
 warning: 5 warnings emitted
 

--- a/src/test/ui/type-alias-enum-variants/enum-variant-generic-args.stderr
+++ b/src/test/ui/type-alias-enum-variants/enum-variant-generic-args.stderr
@@ -119,7 +119,7 @@ help: you might have meant to specity type parameters on enum `Enum`
    |
 LL -         Self::SVariant::<()> { v: () };
 LL +         Enum::<()>::SVariant { v: () };
-   | 
+   |
 
 error[E0308]: mismatched types
   --> $DIR/enum-variant-generic-args.rs:28:35
@@ -200,7 +200,7 @@ help: you might have meant to specity type parameters on enum `Enum`
    |
 LL -         Self::<()>::SVariant::<()> { v: () };
 LL +         Enum::<()>::SVariant { v: () };
-   | 
+   |
 
 error[E0308]: mismatched types
   --> $DIR/enum-variant-generic-args.rs:34:41
@@ -363,7 +363,7 @@ help: you might have meant to specity type parameters on enum `Enum`
    |
 LL -     Alias::SVariant::<()> { v: () };
 LL +     Alias::<()>::SVariant { v: () };
-   | 
+   |
 
 error[E0109]: type arguments are not allowed on this type
   --> $DIR/enum-variant-generic-args.rs:77:29
@@ -378,7 +378,7 @@ help: you might have meant to specity type parameters on enum `Enum`
    |
 LL -     Alias::<()>::SVariant::<()> { v: () };
 LL +     Alias::<()>::SVariant { v: () };
-   | 
+   |
 
 error[E0109]: type arguments are not allowed on this type
   --> $DIR/enum-variant-generic-args.rs:80:28
@@ -393,7 +393,7 @@ help: you might have meant to specity type parameters on enum `Enum`
    |
 LL -     AliasFixed::SVariant::<()> { v: () };
 LL +     AliasFixed::<()>::SVariant { v: () };
-   | 
+   |
 
 error[E0107]: this type alias takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/enum-variant-generic-args.rs:82:5
@@ -436,7 +436,7 @@ help: you might have meant to specity type parameters on enum `Enum`
    |
 LL -     AliasFixed::<()>::SVariant::<()> { v: () };
 LL +     AliasFixed::<()>::SVariant { v: () };
-   | 
+   |
 
 error[E0109]: type arguments are not allowed on this type
   --> $DIR/enum-variant-generic-args.rs:90:28

--- a/src/test/ui/type-alias-enum-variants/incorrect-variant-form-through-alias-caught.stderr
+++ b/src/test/ui/type-alias-enum-variants/incorrect-variant-form-through-alias-caught.stderr
@@ -31,7 +31,7 @@ help: `Alias::Unit` is a unit variant, you need to write it without the parenthe
    |
 LL -     Alias::Unit();
 LL +     Alias::Unit;
-   | 
+   |
 
 error[E0164]: expected tuple struct or tuple variant, found unit variant `Alias::Unit`
   --> $DIR/incorrect-variant-form-through-alias-caught.rs:17:9

--- a/src/test/ui/type-alias-impl-trait/issue-63279.stderr
+++ b/src/test/ui/type-alias-impl-trait/issue-63279.stderr
@@ -21,7 +21,7 @@ error[E0308]: mismatched types
    |
 LL | type Closure = impl FnOnce();
    |                ------------- the expected opaque type
-LL | 
+LL |
 LL | fn c() -> Closure {
    |           ------- expected `Closure` because of return type
 LL |     || -> Closure { || () }

--- a/src/test/ui/type-alias-impl-trait/issue-74280.stderr
+++ b/src/test/ui/type-alias-impl-trait/issue-74280.stderr
@@ -3,7 +3,7 @@ error[E0308]: mismatched types
    |
 LL | type Test = impl Copy;
    |             --------- the expected opaque type
-LL | 
+LL |
 LL | fn test() -> Test {
    |              ---- expected `Test` because of return type
 LL |     let y = || -> Test { () };

--- a/src/test/ui/type/issue-67690-type-alias-bound-diagnostic-crash.stderr
+++ b/src/test/ui/type/issue-67690-type-alias-bound-diagnostic-crash.stderr
@@ -9,7 +9,7 @@ help: the bound will not be checked when the type alias is used, and should be r
    |
 LL - pub type T<P: Send + Send + Send> = P;
 LL + pub type T<P> = P;
-   | 
+   |
 
 warning: 1 warning emitted
 

--- a/src/test/ui/type/issue-91268.stderr
+++ b/src/test/ui/type/issue-91268.stderr
@@ -47,7 +47,7 @@ help: primitive type `u8` doesn't have generic parameters
    |
 LL -     0: u8(ţ
 LL +     0: u8
-   | 
+   |
 
 error[E0308]: mismatched types
   --> $DIR/issue-91268.rs:9:5

--- a/src/test/ui/type/type-alias-bounds.stderr
+++ b/src/test/ui/type/type-alias-bounds.stderr
@@ -9,7 +9,7 @@ help: the bound will not be checked when the type alias is used, and should be r
    |
 LL - type SVec<T: Send + Send> = Vec<T>;
 LL + type SVec<T> = Vec<T>;
-   | 
+   |
 
 warning: where clauses are not enforced in type aliases
   --> $DIR/type-alias-bounds.rs:10:21
@@ -21,7 +21,7 @@ help: the clause will not be checked when the type alias is used, and should be 
    |
 LL - type S2Vec<T> where T: Send = Vec<T>;
 LL + type S2Vec<T>  = Vec<T>;
-   | 
+   |
 
 warning: bounds on generic parameters are not enforced in type aliases
   --> $DIR/type-alias-bounds.rs:12:19
@@ -33,7 +33,7 @@ help: the bound will not be checked when the type alias is used, and should be r
    |
 LL - type VVec<'b, 'a: 'b + 'b> = (&'b u32, Vec<&'a i32>);
 LL + type VVec<'b, 'a> = (&'b u32, Vec<&'a i32>);
-   | 
+   |
 
 warning: bounds on generic parameters are not enforced in type aliases
   --> $DIR/type-alias-bounds.rs:14:18
@@ -45,7 +45,7 @@ help: the bound will not be checked when the type alias is used, and should be r
    |
 LL - type WVec<'b, T: 'b + 'b> = (&'b u32, Vec<T>);
 LL + type WVec<'b, T> = (&'b u32, Vec<T>);
-   | 
+   |
 
 warning: where clauses are not enforced in type aliases
   --> $DIR/type-alias-bounds.rs:16:25
@@ -57,7 +57,7 @@ help: the clause will not be checked when the type alias is used, and should be 
    |
 LL - type W2Vec<'b, T> where T: 'b, T: 'b = (&'b u32, Vec<T>);
 LL + type W2Vec<'b, T>  = (&'b u32, Vec<T>);
-   | 
+   |
 
 warning: bounds on generic parameters are not enforced in type aliases
   --> $DIR/type-alias-bounds.rs:47:12
@@ -74,7 +74,7 @@ help: the bound will not be checked when the type alias is used, and should be r
    |
 LL - type T1<U: Bound> = U::Assoc;
 LL + type T1<U> = U::Assoc;
-   | 
+   |
 
 warning: where clauses are not enforced in type aliases
   --> $DIR/type-alias-bounds.rs:48:18
@@ -91,7 +91,7 @@ help: the clause will not be checked when the type alias is used, and should be 
    |
 LL - type T2<U> where U: Bound = U::Assoc;
 LL + type T2<U>  = U::Assoc;
-   | 
+   |
 
 warning: bounds on generic parameters are not enforced in type aliases
   --> $DIR/type-alias-bounds.rs:56:12
@@ -103,7 +103,7 @@ help: the bound will not be checked when the type alias is used, and should be r
    |
 LL - type T5<U: Bound> = <U as Bound>::Assoc;
 LL + type T5<U> = <U as Bound>::Assoc;
-   | 
+   |
 
 warning: bounds on generic parameters are not enforced in type aliases
   --> $DIR/type-alias-bounds.rs:57:12
@@ -115,7 +115,7 @@ help: the bound will not be checked when the type alias is used, and should be r
    |
 LL - type T6<U: Bound> = ::std::vec::Vec<U>;
 LL + type T6<U> = ::std::vec::Vec<U>;
-   | 
+   |
 
 warning: 9 warnings emitted
 

--- a/src/test/ui/type/type-parameter-defaults-referencing-Self.stderr
+++ b/src/test/ui/type/type-parameter-defaults-referencing-Self.stderr
@@ -5,7 +5,7 @@ LL | / trait Foo<T=Self> {
 LL | |     fn method(&self);
 LL | | }
    | |_- type parameter `T` must be specified for this
-LL | 
+LL |
 LL |   fn foo(x: &dyn Foo) { }
    |                  ^^^ help: set the type parameter to the desired type: `Foo<T>`
    |

--- a/src/test/ui/typeck/issue-88803-call-expr-method.stderr
+++ b/src/test/ui/typeck/issue-88803-call-expr-method.stderr
@@ -8,7 +8,7 @@ help: remove wrapping parentheses to call the method
    |
 LL -         (a.unwrap)()
 LL +         a.unwrap()
-   | 
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/typeck/prim-with-args.stderr
+++ b/src/test/ui/typeck/prim-with-args.stderr
@@ -10,7 +10,7 @@ help: primitive type `isize` doesn't have generic parameters
    |
 LL - let _x: isize<isize>;
 LL + let _x: isize;
-   | 
+   |
 
 error[E0109]: type arguments are not allowed on this type
   --> $DIR/prim-with-args.rs:5:12
@@ -24,7 +24,7 @@ help: primitive type `i8` doesn't have generic parameters
    |
 LL - let _x: i8<isize>;
 LL + let _x: i8;
-   | 
+   |
 
 error[E0109]: type arguments are not allowed on this type
   --> $DIR/prim-with-args.rs:6:13
@@ -38,7 +38,7 @@ help: primitive type `i16` doesn't have generic parameters
    |
 LL - let _x: i16<isize>;
 LL + let _x: i16;
-   | 
+   |
 
 error[E0109]: type arguments are not allowed on this type
   --> $DIR/prim-with-args.rs:7:13
@@ -52,7 +52,7 @@ help: primitive type `i32` doesn't have generic parameters
    |
 LL - let _x: i32<isize>;
 LL + let _x: i32;
-   | 
+   |
 
 error[E0109]: type arguments are not allowed on this type
   --> $DIR/prim-with-args.rs:8:13
@@ -66,7 +66,7 @@ help: primitive type `i64` doesn't have generic parameters
    |
 LL - let _x: i64<isize>;
 LL + let _x: i64;
-   | 
+   |
 
 error[E0109]: type arguments are not allowed on this type
   --> $DIR/prim-with-args.rs:9:15
@@ -80,7 +80,7 @@ help: primitive type `usize` doesn't have generic parameters
    |
 LL - let _x: usize<isize>;
 LL + let _x: usize;
-   | 
+   |
 
 error[E0109]: type arguments are not allowed on this type
   --> $DIR/prim-with-args.rs:10:12
@@ -94,7 +94,7 @@ help: primitive type `u8` doesn't have generic parameters
    |
 LL - let _x: u8<isize>;
 LL + let _x: u8;
-   | 
+   |
 
 error[E0109]: type arguments are not allowed on this type
   --> $DIR/prim-with-args.rs:11:13
@@ -108,7 +108,7 @@ help: primitive type `u16` doesn't have generic parameters
    |
 LL - let _x: u16<isize>;
 LL + let _x: u16;
-   | 
+   |
 
 error[E0109]: type arguments are not allowed on this type
   --> $DIR/prim-with-args.rs:12:13
@@ -122,7 +122,7 @@ help: primitive type `u32` doesn't have generic parameters
    |
 LL - let _x: u32<isize>;
 LL + let _x: u32;
-   | 
+   |
 
 error[E0109]: type arguments are not allowed on this type
   --> $DIR/prim-with-args.rs:13:13
@@ -136,7 +136,7 @@ help: primitive type `u64` doesn't have generic parameters
    |
 LL - let _x: u64<isize>;
 LL + let _x: u64;
-   | 
+   |
 
 error[E0109]: type arguments are not allowed on this type
   --> $DIR/prim-with-args.rs:14:14
@@ -150,7 +150,7 @@ help: primitive type `char` doesn't have generic parameters
    |
 LL - let _x: char<isize>;
 LL + let _x: char;
-   | 
+   |
 
 error[E0109]: lifetime arguments are not allowed on this type
   --> $DIR/prim-with-args.rs:16:15
@@ -164,7 +164,7 @@ help: primitive type `isize` doesn't have generic parameters
    |
 LL - let _x: isize<'static>;
 LL + let _x: isize;
-   | 
+   |
 
 error[E0109]: lifetime arguments are not allowed on this type
   --> $DIR/prim-with-args.rs:17:12
@@ -178,7 +178,7 @@ help: primitive type `i8` doesn't have generic parameters
    |
 LL - let _x: i8<'static>;
 LL + let _x: i8;
-   | 
+   |
 
 error[E0109]: lifetime arguments are not allowed on this type
   --> $DIR/prim-with-args.rs:18:13
@@ -192,7 +192,7 @@ help: primitive type `i16` doesn't have generic parameters
    |
 LL - let _x: i16<'static>;
 LL + let _x: i16;
-   | 
+   |
 
 error[E0109]: lifetime arguments are not allowed on this type
   --> $DIR/prim-with-args.rs:19:13
@@ -206,7 +206,7 @@ help: primitive type `i32` doesn't have generic parameters
    |
 LL - let _x: i32<'static>;
 LL + let _x: i32;
-   | 
+   |
 
 error[E0109]: lifetime arguments are not allowed on this type
   --> $DIR/prim-with-args.rs:20:13
@@ -220,7 +220,7 @@ help: primitive type `i64` doesn't have generic parameters
    |
 LL - let _x: i64<'static>;
 LL + let _x: i64;
-   | 
+   |
 
 error[E0109]: lifetime arguments are not allowed on this type
   --> $DIR/prim-with-args.rs:21:15
@@ -234,7 +234,7 @@ help: primitive type `usize` doesn't have generic parameters
    |
 LL - let _x: usize<'static>;
 LL + let _x: usize;
-   | 
+   |
 
 error[E0109]: lifetime arguments are not allowed on this type
   --> $DIR/prim-with-args.rs:22:12
@@ -248,7 +248,7 @@ help: primitive type `u8` doesn't have generic parameters
    |
 LL - let _x: u8<'static>;
 LL + let _x: u8;
-   | 
+   |
 
 error[E0109]: lifetime arguments are not allowed on this type
   --> $DIR/prim-with-args.rs:23:13
@@ -262,7 +262,7 @@ help: primitive type `u16` doesn't have generic parameters
    |
 LL - let _x: u16<'static>;
 LL + let _x: u16;
-   | 
+   |
 
 error[E0109]: lifetime arguments are not allowed on this type
   --> $DIR/prim-with-args.rs:24:13
@@ -276,7 +276,7 @@ help: primitive type `u32` doesn't have generic parameters
    |
 LL - let _x: u32<'static>;
 LL + let _x: u32;
-   | 
+   |
 
 error[E0109]: lifetime arguments are not allowed on this type
   --> $DIR/prim-with-args.rs:25:13
@@ -290,7 +290,7 @@ help: primitive type `u64` doesn't have generic parameters
    |
 LL - let _x: u64<'static>;
 LL + let _x: u64;
-   | 
+   |
 
 error[E0109]: lifetime arguments are not allowed on this type
   --> $DIR/prim-with-args.rs:26:14
@@ -304,7 +304,7 @@ help: primitive type `char` doesn't have generic parameters
    |
 LL - let _x: char<'static>;
 LL + let _x: char;
-   | 
+   |
 
 error: aborting due to 22 previous errors
 

--- a/src/test/ui/unboxed-closures/unboxed-closures-failed-recursive-fn-1.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closures-failed-recursive-fn-1.stderr
@@ -31,7 +31,7 @@ error[E0597]: `factorial` does not live long enough
    |
 LL |     let mut factorial: Option<Box<dyn Fn(u32) -> u32 + 'static>> = None;
    |                        ----------------------------------------- type annotation requires that `factorial` is borrowed for `'static`
-LL | 
+LL |
 LL |     let f = |x: u32| -> u32 {
    |             --------------- value captured here
 LL |         let g = factorial.as_ref().unwrap();
@@ -45,7 +45,7 @@ error[E0506]: cannot assign to `factorial` because it is borrowed
    |
 LL |     let mut factorial: Option<Box<dyn Fn(u32) -> u32 + 'static>> = None;
    |                        ----------------------------------------- type annotation requires that `factorial` is borrowed for `'static`
-LL | 
+LL |
 LL |     let f = |x: u32| -> u32 {
    |             --------------- borrow of `factorial` occurs here
 LL |         let g = factorial.as_ref().unwrap();

--- a/src/test/ui/union/union-sized-field.stderr
+++ b/src/test/ui/union/union-sized-field.stderr
@@ -12,7 +12,7 @@ help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - union Foo<T: ?Sized> {
 LL + union Foo<T> {
-   | 
+   |
 help: borrowed types always have a statically known size
    |
 LL |     value: &T,
@@ -36,7 +36,7 @@ help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - struct Foo2<T: ?Sized> {
 LL + struct Foo2<T> {
-   | 
+   |
 help: borrowed types always have a statically known size
    |
 LL |     value: &T,
@@ -60,7 +60,7 @@ help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - enum Foo3<T: ?Sized> {
 LL + enum Foo3<T> {
-   | 
+   |
 help: borrowed types always have a statically known size
    |
 LL |     Value(&T),

--- a/src/test/ui/unop-move-semantics.stderr
+++ b/src/test/ui/unop-move-semantics.stderr
@@ -5,7 +5,7 @@ LL | fn move_then_borrow<T: Not<Output=T> + Clone>(x: T) {
    |                                               - move occurs because `x` has type `T`, which does not implement the `Copy` trait
 LL |     !x;
    |     -- `x` moved due to usage in operator
-LL | 
+LL |
 LL |     x.clone();
    |     ^^^^^^^^^ value borrowed here after move
    |

--- a/src/test/ui/unsized/unsized-bare-typaram.stderr
+++ b/src/test/ui/unsized/unsized-bare-typaram.stderr
@@ -15,7 +15,7 @@ help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - fn foo<T: ?Sized>() { bar::<T>() }
 LL + fn foo<T>() { bar::<T>() }
-   | 
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/unsized/unsized-enum.stderr
+++ b/src/test/ui/unsized/unsized-enum.stderr
@@ -22,7 +22,7 @@ help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - fn foo2<T: ?Sized>() { not_sized::<Foo<T>>() }
 LL + fn foo2<T>() { not_sized::<Foo<T>>() }
-   | 
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/unsized/unsized-enum2.stderr
+++ b/src/test/ui/unsized/unsized-enum2.stderr
@@ -13,7 +13,7 @@ help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - enum E<W: ?Sized, X: ?Sized, Y: ?Sized, Z: ?Sized> {
 LL + enum E<W, X: ?Sized, Y: ?Sized, Z: ?Sized> {
-   | 
+   |
 help: borrowed types always have a statically known size
    |
 LL |     VA(&W),
@@ -38,7 +38,7 @@ help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - enum E<W: ?Sized, X: ?Sized, Y: ?Sized, Z: ?Sized> {
 LL + enum E<W: ?Sized, X, Y: ?Sized, Z: ?Sized> {
-   | 
+   |
 help: borrowed types always have a statically known size
    |
 LL |     VB{x: &X},
@@ -63,7 +63,7 @@ help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - enum E<W: ?Sized, X: ?Sized, Y: ?Sized, Z: ?Sized> {
 LL + enum E<W: ?Sized, X: ?Sized, Y, Z: ?Sized> {
-   | 
+   |
 help: borrowed types always have a statically known size
    |
 LL |     VC(isize, &Y),
@@ -88,7 +88,7 @@ help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - enum E<W: ?Sized, X: ?Sized, Y: ?Sized, Z: ?Sized> {
 LL + enum E<W: ?Sized, X: ?Sized, Y: ?Sized, Z> {
-   | 
+   |
 help: borrowed types always have a statically known size
    |
 LL |     VD{u: isize, x: &Z},

--- a/src/test/ui/unsized/unsized-fn-arg.stderr
+++ b/src/test/ui/unsized/unsized-fn-arg.stderr
@@ -11,7 +11,7 @@ help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - fn f<T: ?Sized>(t: T) {}
 LL + fn f<T>(t: T) {}
-   | 
+   |
 help: function arguments must have a statically known size, borrowed types always have a known size
    |
 LL | fn f<T: ?Sized>(t: &T) {}

--- a/src/test/ui/unsized/unsized-inherent-impl-self-type.stderr
+++ b/src/test/ui/unsized/unsized-inherent-impl-self-type.stderr
@@ -22,7 +22,7 @@ help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - impl<X: ?Sized> S5<X> {
 LL + impl<X> S5<X> {
-   | 
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/unsized/unsized-struct.stderr
+++ b/src/test/ui/unsized/unsized-struct.stderr
@@ -22,7 +22,7 @@ help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - fn foo2<T: ?Sized>() { not_sized::<Foo<T>>() }
 LL + fn foo2<T>() { not_sized::<Foo<T>>() }
-   | 
+   |
 
 error[E0277]: the size for values of type `T` cannot be known at compilation time
   --> $DIR/unsized-struct.rs:13:24
@@ -46,7 +46,7 @@ help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - fn bar2<T: ?Sized>() { is_sized::<Bar<T>>() }
 LL + fn bar2<T>() { is_sized::<Bar<T>>() }
-   | 
+   |
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/unsized/unsized-trait-impl-self-type.stderr
+++ b/src/test/ui/unsized/unsized-trait-impl-self-type.stderr
@@ -22,7 +22,7 @@ help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - impl<X: ?Sized> T3<X> for S5<X> {
 LL + impl<X> T3<X> for S5<X> {
-   | 
+   |
 
 error: aborting due to previous error
 

--- a/src/test/ui/unsized/unsized-trait-impl-trait-arg.stderr
+++ b/src/test/ui/unsized/unsized-trait-impl-trait-arg.stderr
@@ -15,7 +15,7 @@ help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - impl<X: ?Sized> T2<X> for S4<X> {
 LL + impl<X> T2<X> for S4<X> {
-   | 
+   |
 help: consider relaxing the implicit `Sized` restriction
    |
 LL | trait T2<Z: ?Sized> {

--- a/src/test/ui/unsized/unsized3.stderr
+++ b/src/test/ui/unsized/unsized3.stderr
@@ -17,7 +17,7 @@ help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - fn f1<X: ?Sized>(x: &X) {
 LL + fn f1<X>(x: &X) {
-   | 
+   |
 help: consider relaxing the implicit `Sized` restriction
    |
 LL | fn f2<X: ?Sized>(x: &X) {
@@ -42,7 +42,7 @@ help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - fn f3<X: ?Sized + T>(x: &X) {
 LL + fn f3<X: T>(x: &X) {
-   | 
+   |
 help: consider relaxing the implicit `Sized` restriction
    |
 LL | fn f4<X: T + ?Sized>(x: &X) {
@@ -72,7 +72,7 @@ help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - fn f8<X: ?Sized>(x1: &S<X>, x2: &S<X>) {
 LL + fn f8<X>(x1: &S<X>, x2: &S<X>) {
-   | 
+   |
 help: consider relaxing the implicit `Sized` restriction
    |
 LL | fn f5<Y: ?Sized>(x: &Y) {}
@@ -98,7 +98,7 @@ help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - fn f9<X: ?Sized>(x1: Box<S<X>>) {
 LL + fn f9<X>(x1: Box<S<X>>) {
-   | 
+   |
 
 error[E0277]: the size for values of type `X` cannot be known at compilation time
   --> $DIR/unsized3.rs:45:8
@@ -121,7 +121,7 @@ help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - fn f10<X: ?Sized>(x1: Box<S<X>>) {
 LL + fn f10<X>(x1: Box<S<X>>) {
-   | 
+   |
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/unsized/unsized5.stderr
+++ b/src/test/ui/unsized/unsized5.stderr
@@ -12,7 +12,7 @@ help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - struct S1<X: ?Sized> {
 LL + struct S1<X> {
-   | 
+   |
 help: borrowed types always have a statically known size
    |
 LL |     f1: &X,
@@ -37,7 +37,7 @@ help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - struct S2<X: ?Sized> {
 LL + struct S2<X> {
-   | 
+   |
 help: borrowed types always have a statically known size
    |
 LL |     g: &X,
@@ -97,7 +97,7 @@ help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - enum E<X: ?Sized> {
 LL + enum E<X> {
-   | 
+   |
 help: borrowed types always have a statically known size
    |
 LL |     V1(&X, isize),
@@ -121,7 +121,7 @@ help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - enum F<X: ?Sized> {
 LL + enum F<X> {
-   | 
+   |
 help: borrowed types always have a statically known size
    |
 LL |     V2{f1: &X, f: isize},

--- a/src/test/ui/unsized/unsized6.stderr
+++ b/src/test/ui/unsized/unsized6.stderr
@@ -13,7 +13,7 @@ help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - fn f1<W: ?Sized, X: ?Sized, Y: ?Sized, Z: ?Sized>(x: &X) {
 LL + fn f1<W: ?Sized, X: ?Sized, Y, Z: ?Sized>(x: &X) {
-   | 
+   |
 
 error[E0277]: the size for values of type `X` cannot be known at compilation time
   --> $DIR/unsized6.rs:7:12
@@ -29,7 +29,7 @@ help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - fn f1<W: ?Sized, X: ?Sized, Y: ?Sized, Z: ?Sized>(x: &X) {
 LL + fn f1<W: ?Sized, X, Y: ?Sized, Z: ?Sized>(x: &X) {
-   | 
+   |
 
 error[E0277]: the size for values of type `Z` cannot be known at compilation time
   --> $DIR/unsized6.rs:11:12
@@ -45,7 +45,7 @@ help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - fn f1<W: ?Sized, X: ?Sized, Y: ?Sized, Z: ?Sized>(x: &X) {
 LL + fn f1<W: ?Sized, X: ?Sized, Y: ?Sized, Z>(x: &X) {
-   | 
+   |
 
 error[E0277]: the size for values of type `X` cannot be known at compilation time
   --> $DIR/unsized6.rs:15:9
@@ -61,7 +61,7 @@ help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - fn f2<X: ?Sized, Y: ?Sized>(x: &X) {
 LL + fn f2<X, Y: ?Sized>(x: &X) {
-   | 
+   |
 
 error[E0277]: the size for values of type `Y` cannot be known at compilation time
   --> $DIR/unsized6.rs:17:12
@@ -77,7 +77,7 @@ help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - fn f2<X: ?Sized, Y: ?Sized>(x: &X) {
 LL + fn f2<X: ?Sized, Y>(x: &X) {
-   | 
+   |
 
 error[E0277]: the size for values of type `X` cannot be known at compilation time
   --> $DIR/unsized6.rs:22:9
@@ -93,7 +93,7 @@ help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - fn f3<X: ?Sized>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
 LL + fn f3<X>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
-   | 
+   |
 
 error[E0277]: the size for values of type `X` cannot be known at compilation time
   --> $DIR/unsized6.rs:24:9
@@ -110,7 +110,7 @@ help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - fn f3<X: ?Sized>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
 LL + fn f3<X>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
-   | 
+   |
 
 error[E0277]: the size for values of type `X` cannot be known at compilation time
   --> $DIR/unsized6.rs:26:10
@@ -127,7 +127,7 @@ help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - fn f3<X: ?Sized>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
 LL + fn f3<X>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
-   | 
+   |
 
 error[E0277]: the size for values of type `X` cannot be known at compilation time
   --> $DIR/unsized6.rs:30:9
@@ -143,7 +143,7 @@ help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - fn f4<X: ?Sized + T>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
 LL + fn f4<X: T>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
-   | 
+   |
 
 error[E0277]: the size for values of type `X` cannot be known at compilation time
   --> $DIR/unsized6.rs:32:9
@@ -160,7 +160,7 @@ help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - fn f4<X: ?Sized + T>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
 LL + fn f4<X: T>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
-   | 
+   |
 
 error[E0277]: the size for values of type `X` cannot be known at compilation time
   --> $DIR/unsized6.rs:34:10
@@ -177,7 +177,7 @@ help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - fn f4<X: ?Sized + T>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
 LL + fn f4<X: T>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
-   | 
+   |
 
 error[E0277]: the size for values of type `X` cannot be known at compilation time
   --> $DIR/unsized6.rs:38:18
@@ -192,7 +192,7 @@ help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - fn g1<X: ?Sized>(x: X) {}
 LL + fn g1<X>(x: X) {}
-   | 
+   |
 help: function arguments must have a statically known size, borrowed types always have a known size
    |
 LL | fn g1<X: ?Sized>(x: &X) {}
@@ -211,7 +211,7 @@ help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - fn g2<X: ?Sized + T>(x: X) {}
 LL + fn g2<X: T>(x: X) {}
-   | 
+   |
 help: function arguments must have a statically known size, borrowed types always have a known size
    |
 LL | fn g2<X: ?Sized + T>(x: &X) {}

--- a/src/test/ui/unsized/unsized7.stderr
+++ b/src/test/ui/unsized/unsized7.stderr
@@ -15,7 +15,7 @@ help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - impl<X: ?Sized + T> T1<X> for S3<X> {
 LL + impl<X: T> T1<X> for S3<X> {
-   | 
+   |
 help: consider relaxing the implicit `Sized` restriction
    |
 LL | trait T1<Z: T + ?Sized> {

--- a/src/test/ui/use/use-after-move-implicity-coerced-object.stderr
+++ b/src/test/ui/use/use-after-move-implicity-coerced-object.stderr
@@ -6,7 +6,7 @@ LL |     let n: Box<_> = Number { n: 42 }.into();
 LL |     let mut l: Box<_> = List { list: Vec::new() }.into();
 LL |     l.push(n);
    |            - value moved here
-LL | 
+LL |
 LL |     let x = n.to_string();
    |             ^^^^^^^^^^^^^ value borrowed here after move
 

--- a/src/test/ui/use/use-mod/use-mod-4.stderr
+++ b/src/test/ui/use/use-mod/use-mod-4.stderr
@@ -8,7 +8,7 @@ help: consider importing the module directly
    |
 LL - use foo::self;
 LL + use foo;
-   | 
+   |
 help: alternatively, use the multi-path `use` syntax to import `self`
    |
 LL | use foo::{self};
@@ -24,7 +24,7 @@ help: consider importing the module directly
    |
 LL - use std::mem::self;
 LL + use std::mem;
-   | 
+   |
 help: alternatively, use the multi-path `use` syntax to import `self`
    |
 LL | use std::mem::{self};

--- a/src/test/ui/use/use-mod/use-mod-5.stderr
+++ b/src/test/ui/use/use-mod/use-mod-5.stderr
@@ -8,7 +8,7 @@ help: consider importing the module directly
    |
 LL - use foo::bar::self;
 LL + use foo::bar;
-   | 
+   |
 help: alternatively, use the multi-path `use` syntax to import `self`
    |
 LL | use foo::bar::{self};

--- a/src/test/ui/use/use-mod/use-mod-6.stderr
+++ b/src/test/ui/use/use-mod/use-mod-6.stderr
@@ -8,7 +8,7 @@ help: consider importing the module directly
    |
 LL - use foo::bar::self as abc;
 LL + use foo::bar as abc;
-   | 
+   |
 help: alternatively, use the multi-path `use` syntax to import `self`
    |
 LL | use foo::bar::{self as abc};

--- a/src/test/ui/usize-generic-argument-parent.stderr
+++ b/src/test/ui/usize-generic-argument-parent.stderr
@@ -10,7 +10,7 @@ help: primitive type `usize` doesn't have generic parameters
    |
 LL -     let x: usize<foo>;
 LL +     let x: usize;
-   | 
+   |
 
 error: aborting due to previous error
 

--- a/src/tools/clippy/tests/ui/eprint_with_newline.stderr
+++ b/src/tools/clippy/tests/ui/eprint_with_newline.stderr
@@ -9,7 +9,7 @@ help: use `eprintln!` instead
    |
 LL -     eprint!("Hello/n");
 LL +     eprintln!("Hello");
-   | 
+   |
 
 error: using `eprint!()` with a format string that ends in a single newline
   --> $DIR/eprint_with_newline.rs:6:5
@@ -21,7 +21,7 @@ help: use `eprintln!` instead
    |
 LL -     eprint!("Hello {}/n", "world");
 LL +     eprintln!("Hello {}", "world");
-   | 
+   |
 
 error: using `eprint!()` with a format string that ends in a single newline
   --> $DIR/eprint_with_newline.rs:7:5
@@ -33,7 +33,7 @@ help: use `eprintln!` instead
    |
 LL -     eprint!("Hello {} {}/n", "world", "#2");
 LL +     eprintln!("Hello {} {}", "world", "#2");
-   | 
+   |
 
 error: using `eprint!()` with a format string that ends in a single newline
   --> $DIR/eprint_with_newline.rs:8:5
@@ -45,7 +45,7 @@ help: use `eprintln!` instead
    |
 LL -     eprint!("{}/n", 1265);
 LL +     eprintln!("{}", 1265);
-   | 
+   |
 
 error: using `eprint!()` with a format string that ends in a single newline
   --> $DIR/eprint_with_newline.rs:9:5
@@ -57,7 +57,7 @@ help: use `eprintln!` instead
    |
 LL -     eprint!("/n");
 LL +     eprintln!();
-   | 
+   |
 
 error: using `eprint!()` with a format string that ends in a single newline
   --> $DIR/eprint_with_newline.rs:28:5
@@ -69,7 +69,7 @@ help: use `eprintln!` instead
    |
 LL -     eprint!("//n"); // should fail
 LL +     eprintln!("/"); // should fail
-   | 
+   |
 
 error: using `eprint!()` with a format string that ends in a single newline
   --> $DIR/eprint_with_newline.rs:35:5
@@ -111,7 +111,7 @@ help: use `eprintln!` instead
    |
 LL -     eprint!("/r/n"); //~ ERROR
 LL +     eprintln!("/r"); //~ ERROR
-   | 
+   |
 
 error: using `eprint!()` with a format string that ends in a single newline
   --> $DIR/eprint_with_newline.rs:48:5
@@ -123,7 +123,7 @@ help: use `eprintln!` instead
    |
 LL -     eprint!("foo/rbar/n") // ~ ERROR
 LL +     eprintln!("foo/rbar") // ~ ERROR
-   | 
+   |
 
 error: aborting due to 10 previous errors
 

--- a/src/tools/clippy/tests/ui/manual_split_once.stderr
+++ b/src/tools/clippy/tests/ui/manual_split_once.stderr
@@ -96,12 +96,12 @@ help: remove the `iter` usages
    |
 LL -     let l = iter.next().unwrap();
 LL +     
-   | 
+   |
 help: remove the `iter` usages
    |
 LL -     let r = iter.next().unwrap();
 LL +     
-   | 
+   |
 
 error: manual implementation of `split_once`
   --> $DIR/manual_split_once.rs:49:5
@@ -121,12 +121,12 @@ help: remove the `iter` usages
    |
 LL -     let l = iter.next()?;
 LL +     
-   | 
+   |
 help: remove the `iter` usages
    |
 LL -     let r = iter.next()?;
 LL +     
-   | 
+   |
 
 error: manual implementation of `rsplit_once`
   --> $DIR/manual_split_once.rs:53:5
@@ -146,12 +146,12 @@ help: remove the `iter` usages
    |
 LL -     let r = iter.next().unwrap();
 LL +     
-   | 
+   |
 help: remove the `iter` usages
    |
 LL -     let l = iter.next().unwrap();
 LL +     
-   | 
+   |
 
 error: manual implementation of `rsplit_once`
   --> $DIR/manual_split_once.rs:57:5
@@ -171,12 +171,12 @@ help: remove the `iter` usages
    |
 LL -     let r = iter.next()?;
 LL +     
-   | 
+   |
 help: remove the `iter` usages
    |
 LL -     let l = iter.next()?;
 LL +     
-   | 
+   |
 
 error: manual implementation of `split_once`
   --> $DIR/manual_split_once.rs:142:13
@@ -202,12 +202,12 @@ help: remove the `iter` usages
    |
 LL -     let a = iter.next().unwrap();
 LL +     
-   | 
+   |
 help: remove the `iter` usages
    |
 LL -     let b = iter.next().unwrap();
 LL +     
-   | 
+   |
 
 error: aborting due to 19 previous errors
 

--- a/src/tools/clippy/tests/ui/map_unwrap_or.stderr
+++ b/src/tools/clippy/tests/ui/map_unwrap_or.stderr
@@ -12,7 +12,7 @@ help: use `map_or(<a>, <f>)` instead
    |
 LL -     let _ = opt.map(|x| x + 1)
 LL +     let _ = opt.map_or(0, |x| x + 1);
-   | 
+   |
 
 error: called `map(<f>).unwrap_or(<a>)` on an `Option` value. This can be done more directly by calling `map_or(<a>, <f>)` instead
   --> $DIR/map_unwrap_or.rs:20:13
@@ -59,7 +59,7 @@ help: use `and_then(<f>)` instead
    |
 LL -     let _ = opt.map(|x| Some(x + 1)).unwrap_or(None);
 LL +     let _ = opt.and_then(|x| Some(x + 1));
-   | 
+   |
 
 error: called `map(<f>).unwrap_or(None)` on an `Option` value. This can be done more directly by calling `and_then(<f>)` instead
   --> $DIR/map_unwrap_or.rs:31:13
@@ -92,7 +92,7 @@ help: use `and_then(<f>)` instead
    |
 LL -         .map(|x| Some(x + 1))
 LL +         .and_then(|x| Some(x + 1));
-   | 
+   |
 
 error: called `map(<f>).unwrap_or(<a>)` on an `Option` value. This can be done more directly by calling `map_or(<a>, <f>)` instead
   --> $DIR/map_unwrap_or.rs:46:13
@@ -104,7 +104,7 @@ help: use `map_or(<a>, <f>)` instead
    |
 LL -     let _ = Some("prefix").map(|p| format!("{}.", p)).unwrap_or(id);
 LL +     let _ = Some("prefix").map_or(id, |p| format!("{}.", p));
-   | 
+   |
 
 error: called `map(<f>).unwrap_or_else(<g>)` on an `Option` value. This can be done more directly by calling `map_or_else(<g>, <f>)` instead
   --> $DIR/map_unwrap_or.rs:50:13

--- a/src/tools/clippy/tests/ui/needless_late_init.stderr
+++ b/src/tools/clippy/tests/ui/needless_late_init.stderr
@@ -164,7 +164,7 @@ help: remove the assignments from the `match` arms
    |
 LL -         1 => f = "three",
 LL +         1 => "three",
-   | 
+   |
 
 error: unneeded late initialization
   --> $DIR/needless_late_init.rs:76:5
@@ -180,7 +180,7 @@ help: remove the assignments from the branches
    |
 LL -         g = 5;
 LL +         5
-   | 
+   |
 help: add a semicolon after the `if` expression
    |
 LL |     };

--- a/src/tools/clippy/tests/ui/print_literal.stderr
+++ b/src/tools/clippy/tests/ui/print_literal.stderr
@@ -9,7 +9,7 @@ help: try this
    |
 LL -     print!("Hello {}", "world");
 LL +     print!("Hello world");
-   | 
+   |
 
 error: literal with an empty format string
   --> $DIR/print_literal.rs:26:36
@@ -21,7 +21,7 @@ help: try this
    |
 LL -     println!("Hello {} {}", world, "world");
 LL +     println!("Hello {} world", world);
-   | 
+   |
 
 error: literal with an empty format string
   --> $DIR/print_literal.rs:27:26
@@ -33,7 +33,7 @@ help: try this
    |
 LL -     println!("Hello {}", "world");
 LL +     println!("Hello world");
-   | 
+   |
 
 error: literal with an empty format string
   --> $DIR/print_literal.rs:32:25
@@ -45,7 +45,7 @@ help: try this
    |
 LL -     println!("{0} {1}", "hello", "world");
 LL +     println!("hello {1}", "world");
-   | 
+   |
 
 error: literal with an empty format string
   --> $DIR/print_literal.rs:32:34
@@ -57,7 +57,7 @@ help: try this
    |
 LL -     println!("{0} {1}", "hello", "world");
 LL +     println!("{0} world", "hello");
-   | 
+   |
 
 error: literal with an empty format string
   --> $DIR/print_literal.rs:33:25
@@ -69,7 +69,7 @@ help: try this
    |
 LL -     println!("{1} {0}", "hello", "world");
 LL +     println!("{1} hello", "world");
-   | 
+   |
 
 error: literal with an empty format string
   --> $DIR/print_literal.rs:33:34
@@ -81,7 +81,7 @@ help: try this
    |
 LL -     println!("{1} {0}", "hello", "world");
 LL +     println!("world {0}", "hello");
-   | 
+   |
 
 error: literal with an empty format string
   --> $DIR/print_literal.rs:36:29
@@ -93,7 +93,7 @@ help: try this
    |
 LL -     println!("{foo} {bar}", foo = "hello", bar = "world");
 LL +     println!("hello {bar}", bar = "world");
-   | 
+   |
 
 error: literal with an empty format string
   --> $DIR/print_literal.rs:36:44
@@ -105,7 +105,7 @@ help: try this
    |
 LL -     println!("{foo} {bar}", foo = "hello", bar = "world");
 LL +     println!("{foo} world", foo = "hello");
-   | 
+   |
 
 error: literal with an empty format string
   --> $DIR/print_literal.rs:37:29
@@ -117,7 +117,7 @@ help: try this
    |
 LL -     println!("{bar} {foo}", foo = "hello", bar = "world");
 LL +     println!("{bar} hello", bar = "world");
-   | 
+   |
 
 error: literal with an empty format string
   --> $DIR/print_literal.rs:37:44
@@ -129,7 +129,7 @@ help: try this
    |
 LL -     println!("{bar} {foo}", foo = "hello", bar = "world");
 LL +     println!("world {foo}", foo = "hello");
-   | 
+   |
 
 error: aborting due to 11 previous errors
 

--- a/src/tools/clippy/tests/ui/print_with_newline.stderr
+++ b/src/tools/clippy/tests/ui/print_with_newline.stderr
@@ -9,7 +9,7 @@ help: use `println!` instead
    |
 LL -     print!("Hello/n");
 LL +     println!("Hello");
-   | 
+   |
 
 error: using `print!()` with a format string that ends in a single newline
   --> $DIR/print_with_newline.rs:9:5
@@ -21,7 +21,7 @@ help: use `println!` instead
    |
 LL -     print!("Hello {}/n", "world");
 LL +     println!("Hello {}", "world");
-   | 
+   |
 
 error: using `print!()` with a format string that ends in a single newline
   --> $DIR/print_with_newline.rs:10:5
@@ -33,7 +33,7 @@ help: use `println!` instead
    |
 LL -     print!("Hello {} {}/n", "world", "#2");
 LL +     println!("Hello {} {}", "world", "#2");
-   | 
+   |
 
 error: using `print!()` with a format string that ends in a single newline
   --> $DIR/print_with_newline.rs:11:5
@@ -45,7 +45,7 @@ help: use `println!` instead
    |
 LL -     print!("{}/n", 1265);
 LL +     println!("{}", 1265);
-   | 
+   |
 
 error: using `print!()` with a format string that ends in a single newline
   --> $DIR/print_with_newline.rs:12:5
@@ -57,7 +57,7 @@ help: use `println!` instead
    |
 LL -     print!("/n");
 LL +     println!();
-   | 
+   |
 
 error: using `print!()` with a format string that ends in a single newline
   --> $DIR/print_with_newline.rs:31:5
@@ -69,7 +69,7 @@ help: use `println!` instead
    |
 LL -     print!("//n"); // should fail
 LL +     println!("/"); // should fail
-   | 
+   |
 
 error: using `print!()` with a format string that ends in a single newline
   --> $DIR/print_with_newline.rs:38:5
@@ -111,7 +111,7 @@ help: use `println!` instead
    |
 LL -     print!("/r/n"); //~ ERROR
 LL +     println!("/r"); //~ ERROR
-   | 
+   |
 
 error: using `print!()` with a format string that ends in a single newline
   --> $DIR/print_with_newline.rs:51:5
@@ -123,7 +123,7 @@ help: use `println!` instead
    |
 LL -     print!("foo/rbar/n") // ~ ERROR
 LL +     println!("foo/rbar") // ~ ERROR
-   | 
+   |
 
 error: aborting due to 10 previous errors
 

--- a/src/tools/clippy/tests/ui/unnecessary_iter_cloned.stderr
+++ b/src/tools/clippy/tests/ui/unnecessary_iter_cloned.stderr
@@ -13,7 +13,7 @@ help: remove this `&`
    |
 LL -         let other = match get_file_path(&t) {
 LL +         let other = match get_file_path(t) {
-   | 
+   |
 
 error: unnecessary use of `copied`
   --> $DIR/unnecessary_iter_cloned.rs:46:22
@@ -29,7 +29,7 @@ help: remove this `&`
    |
 LL -         let other = match get_file_path(&t) {
 LL +         let other = match get_file_path(t) {
-   | 
+   |
 
 error: aborting due to 2 previous errors
 

--- a/src/tools/clippy/tests/ui/unnecessary_to_owned.stderr
+++ b/src/tools/clippy/tests/ui/unnecessary_to_owned.stderr
@@ -489,7 +489,7 @@ help: remove this `&`
    |
 LL -         let path = match get_file_path(&t) {
 LL +         let path = match get_file_path(t) {
-   | 
+   |
 
 error: unnecessary use of `to_vec`
   --> $DIR/unnecessary_to_owned.rs:221:14

--- a/src/tools/clippy/tests/ui/write_literal.stderr
+++ b/src/tools/clippy/tests/ui/write_literal.stderr
@@ -9,7 +9,7 @@ help: try this
    |
 LL -     write!(v, "Hello {}", "world");
 LL +     write!(v, "Hello world");
-   | 
+   |
 
 error: literal with an empty format string
   --> $DIR/write_literal.rs:31:39
@@ -21,7 +21,7 @@ help: try this
    |
 LL -     writeln!(v, "Hello {} {}", world, "world");
 LL +     writeln!(v, "Hello {} world", world);
-   | 
+   |
 
 error: literal with an empty format string
   --> $DIR/write_literal.rs:32:29
@@ -33,7 +33,7 @@ help: try this
    |
 LL -     writeln!(v, "Hello {}", "world");
 LL +     writeln!(v, "Hello world");
-   | 
+   |
 
 error: literal with an empty format string
   --> $DIR/write_literal.rs:37:28
@@ -45,7 +45,7 @@ help: try this
    |
 LL -     writeln!(v, "{0} {1}", "hello", "world");
 LL +     writeln!(v, "hello {1}", "world");
-   | 
+   |
 
 error: literal with an empty format string
   --> $DIR/write_literal.rs:37:37
@@ -57,7 +57,7 @@ help: try this
    |
 LL -     writeln!(v, "{0} {1}", "hello", "world");
 LL +     writeln!(v, "{0} world", "hello");
-   | 
+   |
 
 error: literal with an empty format string
   --> $DIR/write_literal.rs:38:28
@@ -69,7 +69,7 @@ help: try this
    |
 LL -     writeln!(v, "{1} {0}", "hello", "world");
 LL +     writeln!(v, "{1} hello", "world");
-   | 
+   |
 
 error: literal with an empty format string
   --> $DIR/write_literal.rs:38:37
@@ -81,7 +81,7 @@ help: try this
    |
 LL -     writeln!(v, "{1} {0}", "hello", "world");
 LL +     writeln!(v, "world {0}", "hello");
-   | 
+   |
 
 error: literal with an empty format string
   --> $DIR/write_literal.rs:41:32
@@ -93,7 +93,7 @@ help: try this
    |
 LL -     writeln!(v, "{foo} {bar}", foo = "hello", bar = "world");
 LL +     writeln!(v, "hello {bar}", bar = "world");
-   | 
+   |
 
 error: literal with an empty format string
   --> $DIR/write_literal.rs:41:47
@@ -105,7 +105,7 @@ help: try this
    |
 LL -     writeln!(v, "{foo} {bar}", foo = "hello", bar = "world");
 LL +     writeln!(v, "{foo} world", foo = "hello");
-   | 
+   |
 
 error: literal with an empty format string
   --> $DIR/write_literal.rs:42:32
@@ -117,7 +117,7 @@ help: try this
    |
 LL -     writeln!(v, "{bar} {foo}", foo = "hello", bar = "world");
 LL +     writeln!(v, "{bar} hello", bar = "world");
-   | 
+   |
 
 error: literal with an empty format string
   --> $DIR/write_literal.rs:42:47
@@ -129,7 +129,7 @@ help: try this
    |
 LL -     writeln!(v, "{bar} {foo}", foo = "hello", bar = "world");
 LL +     writeln!(v, "world {foo}", foo = "hello");
-   | 
+   |
 
 error: aborting due to 11 previous errors
 

--- a/src/tools/clippy/tests/ui/write_literal_2.stderr
+++ b/src/tools/clippy/tests/ui/write_literal_2.stderr
@@ -9,7 +9,7 @@ help: try this
    |
 LL -     writeln!(v, "{}", "{hello}");
 LL +     writeln!(v, "{{hello}}");
-   | 
+   |
 
 error: literal with an empty format string
   --> $DIR/write_literal_2.rs:10:24
@@ -21,7 +21,7 @@ help: try this
    |
 LL -     writeln!(v, r"{}", r"{hello}");
 LL +     writeln!(v, r"{{hello}}");
-   | 
+   |
 
 error: literal with an empty format string
   --> $DIR/write_literal_2.rs:11:23
@@ -33,7 +33,7 @@ help: try this
    |
 LL -     writeln!(v, "{}", '/'');
 LL +     writeln!(v, "'");
-   | 
+   |
 
 error: literal with an empty format string
   --> $DIR/write_literal_2.rs:12:23
@@ -45,7 +45,7 @@ help: try this
    |
 LL -     writeln!(v, "{}", '"');
 LL +     writeln!(v, "/"");
-   | 
+   |
 
 error: literal with an empty format string
   --> $DIR/write_literal_2.rs:14:24
@@ -57,7 +57,7 @@ help: try this
    |
 LL -     writeln!(v, r"{}", '/'');
 LL +     writeln!(v, r"'");
-   | 
+   |
 
 error: literal with an empty format string
   --> $DIR/write_literal_2.rs:18:9

--- a/src/tools/clippy/tests/ui/write_with_newline.stderr
+++ b/src/tools/clippy/tests/ui/write_with_newline.stderr
@@ -9,7 +9,7 @@ help: use `writeln!()` instead
    |
 LL -     write!(v, "Hello/n");
 LL +     writeln!(v, "Hello");
-   | 
+   |
 
 error: using `write!()` with a format string that ends in a single newline
   --> $DIR/write_with_newline.rs:14:5
@@ -21,7 +21,7 @@ help: use `writeln!()` instead
    |
 LL -     write!(v, "Hello {}/n", "world");
 LL +     writeln!(v, "Hello {}", "world");
-   | 
+   |
 
 error: using `write!()` with a format string that ends in a single newline
   --> $DIR/write_with_newline.rs:15:5
@@ -33,7 +33,7 @@ help: use `writeln!()` instead
    |
 LL -     write!(v, "Hello {} {}/n", "world", "#2");
 LL +     writeln!(v, "Hello {} {}", "world", "#2");
-   | 
+   |
 
 error: using `write!()` with a format string that ends in a single newline
   --> $DIR/write_with_newline.rs:16:5
@@ -45,7 +45,7 @@ help: use `writeln!()` instead
    |
 LL -     write!(v, "{}/n", 1265);
 LL +     writeln!(v, "{}", 1265);
-   | 
+   |
 
 error: using `write!()` with a format string that ends in a single newline
   --> $DIR/write_with_newline.rs:17:5
@@ -57,7 +57,7 @@ help: use `writeln!()` instead
    |
 LL -     write!(v, "/n");
 LL +     writeln!(v);
-   | 
+   |
 
 error: using `write!()` with a format string that ends in a single newline
   --> $DIR/write_with_newline.rs:36:5
@@ -69,7 +69,7 @@ help: use `writeln!()` instead
    |
 LL -     write!(v, "//n"); // should fail
 LL +     writeln!(v, "/"); // should fail
-   | 
+   |
 
 error: using `write!()` with a format string that ends in a single newline
   --> $DIR/write_with_newline.rs:43:5
@@ -115,7 +115,7 @@ help: use `writeln!()` instead
    |
 LL -     write!(v, "/r/n"); //~ ERROR
 LL +     writeln!(v, "/r"); //~ ERROR
-   | 
+   |
 
 error: using `write!()` with a format string that ends in a single newline
   --> $DIR/write_with_newline.rs:58:5
@@ -127,7 +127,7 @@ help: use `writeln!()` instead
    |
 LL -     write!(v, "foo/rbar/n");
 LL +     writeln!(v, "foo/rbar");
-   | 
+   |
 
 error: aborting due to 10 previous errors
 


### PR DESCRIPTION
Remove few occurrences of trailing spaces and drive by fix of needless alloc of const string.