### PR TITLE
Fix polonius compare mode.

### DIFF
--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -1939,7 +1939,7 @@ impl<'test> TestCx<'test> {
 
         match self.config.compare_mode {
             Some(CompareMode::Polonius) => {
-                rustc.args(&["-Zpolonius", "-Zborrowck=mir"]);
+                rustc.args(&["-Zpolonius"]);
             }
             Some(CompareMode::Chalk) => {
                 rustc.args(&["-Zchalk"]);


### PR DESCRIPTION
This fixes running compiler tests in `--compare-mode=polonius`. The `-Zborrowck=mir` option was removed in #95565.

r? @jackh726 