### PR TITLE
Simplify `likely!` and `unlikely!` macro

### DIFF
--- a/compiler/rustc_data_structures/src/lib.rs
+++ b/compiler/rustc_data_structures/src/lib.rs
@@ -11,7 +11,6 @@
 #![feature(associated_type_bounds)]
 #![feature(auto_traits)]
 #![feature(control_flow_enum)]
-#![feature(core_intrinsics)]
 #![feature(extend_one)]
 #![feature(let_else)]
 #![feature(hash_raw_entry)]
@@ -42,26 +41,6 @@ pub use rustc_index::static_assert_size;
 #[cold]
 pub fn cold_path<F: FnOnce() -> R, R>(f: F) -> R {
     f()
-}
-
-#[macro_export]
-macro_rules! likely {
-    ($e:expr) => {
-        match $e {
-            #[allow(unused_unsafe)]
-            e => unsafe { std::intrinsics::likely(e) },
-        }
-    };
-}
-
-#[macro_export]
-macro_rules! unlikely {
-    ($e:expr) => {
-        match $e {
-            #[allow(unused_unsafe)]
-            e => unsafe { std::intrinsics::unlikely(e) },
-        }
-    };
 }
 
 pub mod base_n;

--- a/compiler/rustc_data_structures/src/profiling.rs
+++ b/compiler/rustc_data_structures/src/profiling.rs
@@ -195,6 +195,7 @@ impl SelfProfilerRef {
         F: for<'a> FnOnce(&'a SelfProfiler) -> TimingGuard<'a>,
     {
         #[inline(never)]
+        #[cold]
         fn cold_call<F>(profiler_ref: &SelfProfilerRef, f: F) -> TimingGuard<'_>
         where
             F: for<'a> FnOnce(&'a SelfProfiler) -> TimingGuard<'a>,
@@ -203,7 +204,7 @@ impl SelfProfilerRef {
             f(&**profiler)
         }
 
-        if unlikely!(self.event_filter_mask.contains(event_filter)) {
+        if self.event_filter_mask.contains(event_filter) {
             cold_call(self, f)
         } else {
             TimingGuard::none()

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -804,7 +804,7 @@ pub type PolyTraitPredicate<'tcx> = ty::Binder<'tcx, TraitPredicate<'tcx>>;
 
 impl<'tcx> TraitPredicate<'tcx> {
     pub fn remap_constness(&mut self, tcx: TyCtxt<'tcx>, param_env: &mut ParamEnv<'tcx>) {
-        if unlikely!(Some(self.trait_ref.def_id) == tcx.lang_items().drop_trait()) {
+        if std::intrinsics::unlikely(Some(self.trait_ref.def_id) == tcx.lang_items().drop_trait()) {
             // remap without changing constness of this predicate.
             // this is because `T: ~const Drop` has a different meaning to `T: Drop`
             // FIXME(fee1-dead): remove this logic after beta bump

--- a/compiler/rustc_query_system/src/dep_graph/graph.rs
+++ b/compiler/rustc_query_system/src/dep_graph/graph.rs
@@ -750,7 +750,7 @@ impl<K: DepKind> DepGraph<K> {
             dep_node
         );
 
-        if unlikely!(!side_effects.is_empty()) {
+        if !side_effects.is_empty() {
             self.emit_side_effects(tcx, data, dep_node_index, side_effects);
         }
 

--- a/compiler/rustc_query_system/src/query/plumbing.rs
+++ b/compiler/rustc_query_system/src/query/plumbing.rs
@@ -316,7 +316,7 @@ where
     OnHit: FnOnce(&C::Stored) -> R,
 {
     cache.lookup(&key, |value, index| {
-        if unlikely!(tcx.profiler().enabled()) {
+        if std::intrinsics::unlikely(tcx.profiler().enabled()) {
             tcx.profiler().query_cache_hit(index.into());
         }
         tcx.dep_graph().read_index(index);
@@ -354,7 +354,7 @@ where
                 .lookup(&key, |value, index| (value.clone(), index))
                 .unwrap_or_else(|_| panic!("value must be in cache after waiting"));
 
-            if unlikely!(tcx.dep_context().profiler().enabled()) {
+            if std::intrinsics::unlikely(tcx.dep_context().profiler().enabled()) {
                 tcx.dep_context().profiler().query_cache_hit(index.into());
             }
             query_blocked_prof_timer.finish_with_query_invocation_id(index.into());
@@ -422,7 +422,7 @@ where
     let diagnostics = diagnostics.into_inner();
     let side_effects = QuerySideEffects { diagnostics };
 
-    if unlikely!(!side_effects.is_empty()) {
+    if std::intrinsics::unlikely(!side_effects.is_empty()) {
         if query.anon {
             tcx.store_side_effects_for_anon_node(dep_node_index, side_effects);
         } else {
@@ -466,7 +466,9 @@ where
         prof_timer.finish_with_query_invocation_id(dep_node_index.into());
 
         if let Some(result) = result {
-            if unlikely!(tcx.dep_context().sess().opts.debugging_opts.query_dep_graph) {
+            if std::intrinsics::unlikely(
+                tcx.dep_context().sess().opts.debugging_opts.query_dep_graph,
+            ) {
                 dep_graph.mark_debug_loaded_from_disk(*dep_node)
             }
 
@@ -483,8 +485,8 @@ where
             // currently afford to verify every hash. This subset should still
             // give us some coverage of potential bugs though.
             let try_verify = prev_fingerprint.as_value().1 % 32 == 0;
-            if unlikely!(
-                try_verify || tcx.dep_context().sess().opts.debugging_opts.incremental_verify_ich
+            if std::intrinsics::unlikely(
+                try_verify || tcx.dep_context().sess().opts.debugging_opts.incremental_verify_ich,
             ) {
                 incremental_verify_ich(*tcx.dep_context(), &result, dep_node, query);
             }
@@ -723,7 +725,7 @@ where
     // Ensure that only one of them runs the query.
     let cache = Q::query_cache(tcx);
     let cached = cache.lookup(&key, |_, index| {
-        if unlikely!(tcx.dep_context().profiler().enabled()) {
+        if std::intrinsics::unlikely(tcx.dep_context().profiler().enabled()) {
             tcx.dep_context().profiler().query_cache_hit(index.into());
         }
     });


### PR DESCRIPTION
The corresponding intrinsics have long been safe-to-call, so the unsafe block is no longer needed.