### PR TITLE
Don't internalize symbols used by `global_asm`

### DIFF
--- a/src/test/ui/issues/issue-96797.rs
+++ b/src/test/ui/issues/issue-96797.rs
@@ -1,0 +1,22 @@
+// build-pass
+// compile-flags: -O
+
+// regression test for #96797
+
+#![feature(asm_sym)]
+
+use std::arch::global_asm;
+
+#[no_mangle]
+fn my_func() {}
+
+global_asm!("call_foobar: jmp {}", sym foobar);
+
+fn foobar() {}
+
+fn main() {
+    extern "Rust" {
+        fn call_foobar();
+    }
+    unsafe { call_foobar() };
+}


### PR DESCRIPTION
Symbols that are only reachable from the current CGU have their
visibility changed to internal to allow LLVM to better optimize them.

However this doesn't work for symbols that are used in `global_asm!`:
the symbol name is inserted into the assembly code as text, which LLVM
is not aware of. In particular, LLVM may delete the symbol in the
MergeFunctions pass if it can't see any other uses of it.

The solution here is to ensure that symbols used by `global_asm!` are
always marked with external linkage.

Fixes #96797

cc @nbdd0121 