### PR TITLE
Revert part of #94372 to improve performance

### DIFF
--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -31,7 +31,7 @@ use rustc_data_structures::stack::ensure_sufficient_stack;
 use rustc_data_structures::sync::Lrc;
 use rustc_data_structures::thin_vec::ThinVec;
 use rustc_macros::HashStable_Generic;
-use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
+use rustc_serialize::{self, Decoder, Encoder};
 use rustc_span::source_map::{respan, Spanned};
 use rustc_span::symbol::{kw, sym, Ident, Symbol};
 use rustc_span::{Span, DUMMY_SP};
@@ -2488,11 +2488,11 @@ rustc_index::newtype_index! {
     }
 }
 
-impl<S: Encoder> Encodable<S> for AttrId {
+impl<S: Encoder> rustc_serialize::Encodable<S> for AttrId {
     fn encode(&self, _s: &mut S) {}
 }
 
-impl<D: Decoder> Decodable<D> for AttrId {
+impl<D: Decoder> rustc_serialize::Decodable<D> for AttrId {
     fn decode(_: &mut D) -> AttrId {
         crate::attr::mk_attr_id()
     }

--- a/compiler/rustc_codegen_ssa/src/lib.rs
+++ b/compiler/rustc_codegen_ssa/src/lib.rs
@@ -29,8 +29,7 @@ use rustc_middle::dep_graph::WorkProduct;
 use rustc_middle::middle::dependency_format::Dependencies;
 use rustc_middle::middle::exported_symbols::SymbolExportKind;
 use rustc_middle::ty::query::{ExternProviders, Providers};
-use rustc_serialize::opaque::{MemDecoder, MemEncoder};
-use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
+use rustc_serialize::{opaque, Decodable, Decoder, Encodable, Encoder};
 use rustc_session::config::{CrateType, OutputFilenames, OutputType, RUST_CGU_EXT};
 use rustc_session::cstore::{self, CrateSource};
 use rustc_session::utils::NativeLibKind;
@@ -204,7 +203,7 @@ const RUSTC_VERSION: Option<&str> = option_env!("CFG_VERSION");
 
 impl CodegenResults {
     pub fn serialize_rlink(codegen_results: &CodegenResults) -> Vec<u8> {
-        let mut encoder = MemEncoder::new();
+        let mut encoder = opaque::Encoder::new();
         encoder.emit_raw_bytes(RLINK_MAGIC);
         // `emit_raw_bytes` is used to make sure that the version representation does not depend on
         // Encoder's inner representation of `u32`.
@@ -231,7 +230,7 @@ impl CodegenResults {
             return Err(".rlink file was produced with encoding version {version_array}, but the current version is {RLINK_VERSION}".to_string());
         }
 
-        let mut decoder = MemDecoder::new(&data[4..], 0);
+        let mut decoder = opaque::Decoder::new(&data[4..], 0);
         let rustc_version = decoder.read_str();
         let current_version = RUSTC_VERSION.unwrap();
         if rustc_version != current_version {

--- a/compiler/rustc_codegen_ssa/src/lib.rs
+++ b/compiler/rustc_codegen_ssa/src/lib.rs
@@ -210,7 +210,7 @@ impl CodegenResults {
         encoder.emit_raw_bytes(&RLINK_VERSION.to_be_bytes());
         encoder.emit_str(RUSTC_VERSION.unwrap());
         Encodable::encode(codegen_results, &mut encoder);
-        encoder.finish()
+        encoder.finish().unwrap()
     }
 
     pub fn deserialize_rlink(data: Vec<u8>) -> Result<Self, String> {

--- a/compiler/rustc_data_structures/src/fingerprint.rs
+++ b/compiler/rustc_data_structures/src/fingerprint.rs
@@ -1,5 +1,5 @@
 use crate::stable_hasher;
-use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
+use rustc_serialize::{Decodable, Encodable};
 use std::convert::TryInto;
 use std::hash::{Hash, Hasher};
 
@@ -142,14 +142,14 @@ impl stable_hasher::StableHasherResult for Fingerprint {
 
 impl_stable_hash_via_hash!(Fingerprint);
 
-impl<E: Encoder> Encodable<E> for Fingerprint {
+impl<E: rustc_serialize::Encoder> Encodable<E> for Fingerprint {
     #[inline]
     fn encode(&self, s: &mut E) {
         s.emit_raw_bytes(&self.to_le_bytes());
     }
 }
 
-impl<D: Decoder> Decodable<D> for Fingerprint {
+impl<D: rustc_serialize::Decoder> Decodable<D> for Fingerprint {
     #[inline]
     fn decode(d: &mut D) -> Self {
         Fingerprint::from_le_bytes(d.read_raw_bytes(16).try_into().unwrap())
@@ -184,7 +184,7 @@ impl std::fmt::Display for PackedFingerprint {
     }
 }
 
-impl<E: Encoder> Encodable<E> for PackedFingerprint {
+impl<E: rustc_serialize::Encoder> Encodable<E> for PackedFingerprint {
     #[inline]
     fn encode(&self, s: &mut E) {
         // Copy to avoid taking reference to packed field.
@@ -193,7 +193,7 @@ impl<E: Encoder> Encodable<E> for PackedFingerprint {
     }
 }
 
-impl<D: Decoder> Decodable<D> for PackedFingerprint {
+impl<D: rustc_serialize::Decoder> Decodable<D> for PackedFingerprint {
     #[inline]
     fn decode(d: &mut D) -> Self {
         Self(Fingerprint::decode(d))

--- a/compiler/rustc_incremental/src/persist/load.rs
+++ b/compiler/rustc_incremental/src/persist/load.rs
@@ -4,7 +4,7 @@ use rustc_data_structures::fx::FxHashMap;
 use rustc_data_structures::memmap::Mmap;
 use rustc_middle::dep_graph::{SerializedDepGraph, WorkProduct, WorkProductId};
 use rustc_middle::ty::OnDiskCache;
-use rustc_serialize::opaque::MemDecoder;
+use rustc_serialize::opaque::Decoder;
 use rustc_serialize::Decodable;
 use rustc_session::config::IncrementalStateAssertion;
 use rustc_session::Session;
@@ -156,7 +156,7 @@ pub fn load_dep_graph(sess: &Session) -> DepGraphFuture {
 
         if let LoadResult::Ok { data: (work_products_data, start_pos) } = load_result {
             // Decode the list of work_products
-            let mut work_product_decoder = MemDecoder::new(&work_products_data[..], start_pos);
+            let mut work_product_decoder = Decoder::new(&work_products_data[..], start_pos);
             let work_products: Vec<SerializedWorkProduct> =
                 Decodable::decode(&mut work_product_decoder);
 
@@ -193,7 +193,7 @@ pub fn load_dep_graph(sess: &Session) -> DepGraphFuture {
             LoadResult::DataOutOfDate => LoadResult::DataOutOfDate,
             LoadResult::Error { message } => LoadResult::Error { message },
             LoadResult::Ok { data: (bytes, start_pos) } => {
-                let mut decoder = MemDecoder::new(&bytes, start_pos);
+                let mut decoder = Decoder::new(&bytes, start_pos);
                 let prev_commandline_args_hash = u64::decode(&mut decoder);
 
                 if prev_commandline_args_hash != expected_hash {

--- a/compiler/rustc_incremental/src/persist/save.rs
+++ b/compiler/rustc_incremental/src/persist/save.rs
@@ -3,7 +3,7 @@ use rustc_data_structures::sync::join;
 use rustc_middle::dep_graph::{DepGraph, SerializedDepGraph, WorkProduct, WorkProductId};
 use rustc_middle::ty::TyCtxt;
 use rustc_serialize::opaque::{FileEncodeResult, FileEncoder};
-use rustc_serialize::Encodable as RustcEncodable;
+use rustc_serialize::{Encodable as RustcEncodable, Encoder};
 use rustc_session::Session;
 use std::fs;
 

--- a/compiler/rustc_incremental/src/persist/save.rs
+++ b/compiler/rustc_incremental/src/persist/save.rs
@@ -3,7 +3,7 @@ use rustc_data_structures::sync::join;
 use rustc_middle::dep_graph::{DepGraph, SerializedDepGraph, WorkProduct, WorkProductId};
 use rustc_middle::ty::TyCtxt;
 use rustc_serialize::opaque::{FileEncodeResult, FileEncoder};
-use rustc_serialize::Encodable;
+use rustc_serialize::Encodable as RustcEncodable;
 use rustc_session::Session;
 use std::fs;
 

--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -93,6 +93,9 @@ macro_rules! encoder_methods {
 }
 
 impl<'a, 'tcx> Encoder for EncodeContext<'a, 'tcx> {
+    type Ok = <opaque::Encoder as Encoder>::Ok;
+    type Err = <opaque::Encoder as Encoder>::Err;
+
     encoder_methods! {
         emit_usize(usize);
         emit_u128(u128);
@@ -114,6 +117,10 @@ impl<'a, 'tcx> Encoder for EncodeContext<'a, 'tcx> {
         emit_char(char);
         emit_str(&str);
         emit_raw_bytes(&[u8]);
+    }
+
+    fn finish(self) -> Result<Self::Ok, Self::Err> {
+        self.opaque.finish()
     }
 }
 
@@ -2216,7 +2223,7 @@ fn encode_metadata_impl(tcx: TyCtxt<'_>) -> EncodedMetadata {
     // culminating in the `CrateRoot` which points to all of it.
     let root = ecx.encode_crate_root();
 
-    let mut result = ecx.opaque.finish();
+    let mut result = ecx.opaque.finish().unwrap();
 
     // Encode the root position.
     let header = METADATA_HEADER.len();

--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -27,8 +27,7 @@ use rustc_middle::ty::codec::TyEncoder;
 use rustc_middle::ty::fast_reject::{self, SimplifiedType, TreatParams};
 use rustc_middle::ty::query::Providers;
 use rustc_middle::ty::{self, SymbolName, Ty, TyCtxt};
-use rustc_serialize::opaque::MemEncoder;
-use rustc_serialize::{Encodable, Encoder};
+use rustc_serialize::{opaque, Encodable, Encoder};
 use rustc_session::config::CrateType;
 use rustc_session::cstore::{ForeignModule, LinkagePreference, NativeLib};
 use rustc_span::hygiene::{ExpnIndex, HygieneEncodeContext, MacroKind};
@@ -44,7 +43,7 @@ use std::num::NonZeroUsize;
 use tracing::{debug, trace};
 
 pub(super) struct EncodeContext<'a, 'tcx> {
-    opaque: MemEncoder,
+    opaque: opaque::Encoder,
     tcx: TyCtxt<'tcx>,
     feat: &'tcx rustc_feature::Features,
 
@@ -2182,7 +2181,7 @@ pub fn encode_metadata(tcx: TyCtxt<'_>) -> EncodedMetadata {
 }
 
 fn encode_metadata_impl(tcx: TyCtxt<'_>) -> EncodedMetadata {
-    let mut encoder = MemEncoder::new();
+    let mut encoder = opaque::Encoder::new();
     encoder.emit_raw_bytes(METADATA_HEADER);
 
     // Will be filled with the root position after encoding everything.

--- a/compiler/rustc_metadata/src/rmeta/mod.rs
+++ b/compiler/rustc_metadata/src/rmeta/mod.rs
@@ -22,7 +22,7 @@ use rustc_middle::ty::fast_reject::SimplifiedType;
 use rustc_middle::ty::query::Providers;
 use rustc_middle::ty::{self, ReprOptions, Ty};
 use rustc_middle::ty::{GeneratorDiagnosticData, ParameterizedOverTcx, TyCtxt};
-use rustc_serialize::opaque::MemEncoder;
+use rustc_serialize::opaque::Encoder;
 use rustc_session::config::SymbolManglingVersion;
 use rustc_session::cstore::{CrateDepKind, ForeignModule, LinkagePreference, NativeLib};
 use rustc_span::edition::Edition;
@@ -323,7 +323,7 @@ macro_rules! define_tables {
         }
 
         impl TableBuilders {
-            fn encode(&self, buf: &mut MemEncoder) -> LazyTables {
+            fn encode(&self, buf: &mut Encoder) -> LazyTables {
                 LazyTables {
                     $($name: self.$name.encode(buf)),+
                 }

--- a/compiler/rustc_metadata/src/rmeta/table.rs
+++ b/compiler/rustc_metadata/src/rmeta/table.rs
@@ -4,8 +4,8 @@ use rustc_data_structures::fingerprint::Fingerprint;
 use rustc_hir::def::{CtorKind, CtorOf};
 use rustc_index::vec::Idx;
 use rustc_middle::ty::ParameterizedOverTcx;
-use rustc_serialize::opaque::MemEncoder;
-use rustc_serialize::Encoder;
+use rustc_serialize::opaque::Encoder;
+use rustc_serialize::Encoder as _;
 use rustc_span::hygiene::MacroKind;
 use std::convert::TryInto;
 use std::marker::PhantomData;
@@ -281,7 +281,7 @@ where
         Some(value).write_to_bytes(&mut self.blocks[i]);
     }
 
-    pub(crate) fn encode<const N: usize>(&self, buf: &mut MemEncoder) -> LazyTable<I, T>
+    pub(crate) fn encode<const N: usize>(&self, buf: &mut Encoder) -> LazyTable<I, T>
     where
         Option<T>: FixedSizeEncoding<ByteArray = [u8; N]>,
     {

--- a/compiler/rustc_middle/src/mir/graph_cyclic_cache.rs
+++ b/compiler/rustc_middle/src/mir/graph_cyclic_cache.rs
@@ -3,7 +3,7 @@ use rustc_data_structures::graph::{
 };
 use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
 use rustc_data_structures::sync::OnceCell;
-use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
+use rustc_serialize as serialize;
 
 /// Helper type to cache the result of `graph::is_cyclic`.
 #[derive(Clone, Debug)]
@@ -36,17 +36,17 @@ impl GraphIsCyclicCache {
     }
 }
 
-impl<S: Encoder> Encodable<S> for GraphIsCyclicCache {
+impl<S: serialize::Encoder> serialize::Encodable<S> for GraphIsCyclicCache {
     #[inline]
     fn encode(&self, s: &mut S) {
-        Encodable::encode(&(), s);
+        serialize::Encodable::encode(&(), s);
     }
 }
 
-impl<D: Decoder> Decodable<D> for GraphIsCyclicCache {
+impl<D: serialize::Decoder> serialize::Decodable<D> for GraphIsCyclicCache {
     #[inline]
     fn decode(d: &mut D) -> Self {
-        let () = Decodable::decode(d);
+        let () = serialize::Decodable::decode(d);
         Self::new()
     }
 }

--- a/compiler/rustc_middle/src/mir/predecessors.rs
+++ b/compiler/rustc_middle/src/mir/predecessors.rs
@@ -3,7 +3,7 @@
 use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
 use rustc_data_structures::sync::OnceCell;
 use rustc_index::vec::IndexVec;
-use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
+use rustc_serialize as serialize;
 use smallvec::SmallVec;
 
 use crate::mir::{BasicBlock, BasicBlockData};
@@ -54,12 +54,12 @@ impl PredecessorCache {
     }
 }
 
-impl<S: Encoder> Encodable<S> for PredecessorCache {
+impl<S: serialize::Encoder> serialize::Encodable<S> for PredecessorCache {
     #[inline]
     fn encode(&self, _s: &mut S) {}
 }
 
-impl<D: Decoder> Decodable<D> for PredecessorCache {
+impl<D: serialize::Decoder> serialize::Decodable<D> for PredecessorCache {
     #[inline]
     fn decode(_: &mut D) -> Self {
         Self::new()

--- a/compiler/rustc_middle/src/mir/switch_sources.rs
+++ b/compiler/rustc_middle/src/mir/switch_sources.rs
@@ -5,7 +5,7 @@ use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
 use rustc_data_structures::stable_map::FxHashMap;
 use rustc_data_structures::sync::OnceCell;
 use rustc_index::vec::IndexVec;
-use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
+use rustc_serialize as serialize;
 use smallvec::SmallVec;
 
 use crate::mir::{BasicBlock, BasicBlockData, Terminator, TerminatorKind};
@@ -54,12 +54,12 @@ impl SwitchSourceCache {
     }
 }
 
-impl<S: Encoder> Encodable<S> for SwitchSourceCache {
+impl<S: serialize::Encoder> serialize::Encodable<S> for SwitchSourceCache {
     #[inline]
     fn encode(&self, _s: &mut S) {}
 }
 
-impl<D: Decoder> Decodable<D> for SwitchSourceCache {
+impl<D: serialize::Decoder> serialize::Decodable<D> for SwitchSourceCache {
     #[inline]
     fn decode(_: &mut D) -> Self {
         Self::new()

--- a/compiler/rustc_middle/src/mir/traversal.rs
+++ b/compiler/rustc_middle/src/mir/traversal.rs
@@ -1,7 +1,7 @@
 use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
 use rustc_data_structures::sync::OnceCell;
 use rustc_index::bit_set::BitSet;
-use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
+use rustc_serialize as serialize;
 
 use super::*;
 
@@ -365,12 +365,12 @@ impl PostorderCache {
     }
 }
 
-impl<S: Encoder> Encodable<S> for PostorderCache {
+impl<S: serialize::Encoder> serialize::Encodable<S> for PostorderCache {
     #[inline]
     fn encode(&self, _s: &mut S) {}
 }
 
-impl<D: Decoder> Decodable<D> for PostorderCache {
+impl<D: serialize::Decoder> serialize::Decodable<D> for PostorderCache {
     #[inline]
     fn decode(_: &mut D) -> Self {
         Self::new()

--- a/compiler/rustc_query_impl/src/on_disk_cache.rs
+++ b/compiler/rustc_query_impl/src/on_disk_cache.rs
@@ -25,7 +25,6 @@ use rustc_span::hygiene::{
 use rustc_span::source_map::{SourceMap, StableSourceFileId};
 use rustc_span::CachingSourceMapView;
 use rustc_span::{BytePos, ExpnData, ExpnHash, Pos, SourceFile, Span};
-use std::io;
 use std::mem;
 
 const TAG_FILE_FOOTER: u128 = 0xC0FFEE_C0FFEE_C0FFEE_C0FFEE_C0FFEE;
@@ -808,10 +807,21 @@ impl_ref_decoder! {<'tcx>
 
 //- ENCODING -------------------------------------------------------------------
 
+pub trait OpaqueEncoder: Encoder {
+    fn position(&self) -> usize;
+}
+
+impl OpaqueEncoder for FileEncoder {
+    #[inline]
+    fn position(&self) -> usize {
+        FileEncoder::position(self)
+    }
+}
+
 /// An encoder that can write to the incremental compilation cache.
-pub struct CacheEncoder<'a, 'tcx> {
+pub struct CacheEncoder<'a, 'tcx, E: OpaqueEncoder> {
     tcx: TyCtxt<'tcx>,
-    encoder: FileEncoder,
+    encoder: E,
     type_shorthands: FxHashMap<Ty<'tcx>, usize>,
     predicate_shorthands: FxHashMap<ty::PredicateKind<'tcx>, usize>,
     interpret_allocs: FxIndexSet<interpret::AllocId>,
@@ -820,7 +830,10 @@ pub struct CacheEncoder<'a, 'tcx> {
     hygiene_context: &'a HygieneEncodeContext,
 }
 
-impl<'a, 'tcx> CacheEncoder<'a, 'tcx> {
+impl<'a, 'tcx, E> CacheEncoder<'a, 'tcx, E>
+where
+    E: OpaqueEncoder,
+{
     fn source_file_index(&mut self, source_file: Lrc<SourceFile>) -> SourceFileIndex {
         self.file_to_file_index[&(&*source_file as *const SourceFile)]
     }
@@ -839,27 +852,32 @@ impl<'a, 'tcx> CacheEncoder<'a, 'tcx> {
         let end_pos = self.position();
         ((end_pos - start_pos) as u64).encode(self);
     }
-
-    fn finish(self) -> Result<usize, io::Error> {
-        self.encoder.finish()
-    }
 }
 
-impl<'a, 'tcx> Encodable<CacheEncoder<'a, 'tcx>> for SyntaxContext {
-    fn encode(&self, s: &mut CacheEncoder<'a, 'tcx>) {
+impl<'a, 'tcx, E> Encodable<CacheEncoder<'a, 'tcx, E>> for SyntaxContext
+where
+    E: OpaqueEncoder,
+{
+    fn encode(&self, s: &mut CacheEncoder<'a, 'tcx, E>) {
         rustc_span::hygiene::raw_encode_syntax_context(*self, s.hygiene_context, s);
     }
 }
 
-impl<'a, 'tcx> Encodable<CacheEncoder<'a, 'tcx>> for ExpnId {
-    fn encode(&self, s: &mut CacheEncoder<'a, 'tcx>) {
+impl<'a, 'tcx, E> Encodable<CacheEncoder<'a, 'tcx, E>> for ExpnId
+where
+    E: OpaqueEncoder,
+{
+    fn encode(&self, s: &mut CacheEncoder<'a, 'tcx, E>) {
         s.hygiene_context.schedule_expn_data_for_encoding(*self);
         self.expn_hash().encode(s);
     }
 }
 
-impl<'a, 'tcx> Encodable<CacheEncoder<'a, 'tcx>> for Span {
-    fn encode(&self, s: &mut CacheEncoder<'a, 'tcx>) {
+impl<'a, 'tcx, E> Encodable<CacheEncoder<'a, 'tcx, E>> for Span
+where
+    E: OpaqueEncoder,
+{
+    fn encode(&self, s: &mut CacheEncoder<'a, 'tcx, E>) {
         let span_data = self.data_untracked();
         span_data.ctxt.encode(s);
         span_data.parent.encode(s);
@@ -902,7 +920,10 @@ impl<'a, 'tcx> Encodable<CacheEncoder<'a, 'tcx>> for Span {
     }
 }
 
-impl<'a, 'tcx> TyEncoder for CacheEncoder<'a, 'tcx> {
+impl<'a, 'tcx, E> TyEncoder for CacheEncoder<'a, 'tcx, E>
+where
+    E: OpaqueEncoder,
+{
     type I = TyCtxt<'tcx>;
     const CLEAR_CROSS_CRATE: bool = false;
 
@@ -922,20 +943,29 @@ impl<'a, 'tcx> TyEncoder for CacheEncoder<'a, 'tcx> {
     }
 }
 
-impl<'a, 'tcx> Encodable<CacheEncoder<'a, 'tcx>> for CrateNum {
-    fn encode(&self, s: &mut CacheEncoder<'a, 'tcx>) {
+impl<'a, 'tcx, E> Encodable<CacheEncoder<'a, 'tcx, E>> for CrateNum
+where
+    E: OpaqueEncoder,
+{
+    fn encode(&self, s: &mut CacheEncoder<'a, 'tcx, E>) {
         s.tcx.stable_crate_id(*self).encode(s);
     }
 }
 
-impl<'a, 'tcx> Encodable<CacheEncoder<'a, 'tcx>> for DefId {
-    fn encode(&self, s: &mut CacheEncoder<'a, 'tcx>) {
+impl<'a, 'tcx, E> Encodable<CacheEncoder<'a, 'tcx, E>> for DefId
+where
+    E: OpaqueEncoder,
+{
+    fn encode(&self, s: &mut CacheEncoder<'a, 'tcx, E>) {
         s.tcx.def_path_hash(*self).encode(s);
     }
 }
 
-impl<'a, 'tcx> Encodable<CacheEncoder<'a, 'tcx>> for DefIndex {
-    fn encode(&self, _: &mut CacheEncoder<'a, 'tcx>) {
+impl<'a, 'tcx, E> Encodable<CacheEncoder<'a, 'tcx, E>> for DefIndex
+where
+    E: OpaqueEncoder,
+{
+    fn encode(&self, _: &mut CacheEncoder<'a, 'tcx, E>) {
         bug!("encoding `DefIndex` without context");
     }
 }
@@ -949,7 +979,13 @@ macro_rules! encoder_methods {
     }
 }
 
-impl<'a, 'tcx> Encoder for CacheEncoder<'a, 'tcx> {
+impl<'a, 'tcx, E> Encoder for CacheEncoder<'a, 'tcx, E>
+where
+    E: OpaqueEncoder,
+{
+    type Ok = E::Ok;
+    type Err = E::Err;
+
     encoder_methods! {
         emit_usize(usize);
         emit_u128(u128);
@@ -972,26 +1008,30 @@ impl<'a, 'tcx> Encoder for CacheEncoder<'a, 'tcx> {
         emit_str(&str);
         emit_raw_bytes(&[u8]);
     }
+
+    fn finish(self) -> Result<E::Ok, E::Err> {
+        self.encoder.finish()
+    }
 }
 
 // This ensures that the `Encodable<opaque::FileEncoder>::encode` specialization for byte slices
 // is used when a `CacheEncoder` having an `opaque::FileEncoder` is passed to `Encodable::encode`.
 // Unfortunately, we have to manually opt into specializations this way, given how `CacheEncoder`
 // and the encoding traits currently work.
-impl<'a, 'tcx> Encodable<CacheEncoder<'a, 'tcx>> for [u8] {
-    fn encode(&self, e: &mut CacheEncoder<'a, 'tcx>) {
+impl<'a, 'tcx> Encodable<CacheEncoder<'a, 'tcx, FileEncoder>> for [u8] {
+    fn encode(&self, e: &mut CacheEncoder<'a, 'tcx, FileEncoder>) {
         self.encode(&mut e.encoder);
     }
 }
 
 pub fn encode_query_results<'a, 'tcx, CTX, Q>(
     tcx: CTX,
-    encoder: &mut CacheEncoder<'a, 'tcx>,
+    encoder: &mut CacheEncoder<'a, 'tcx, FileEncoder>,
     query_result_index: &mut EncodedDepNodeIndex,
 ) where
     CTX: QueryContext + 'tcx,
     Q: super::QueryDescription<CTX>,
-    Q::Value: Encodable<CacheEncoder<'a, 'tcx>>,
+    Q::Value: Encodable<CacheEncoder<'a, 'tcx, FileEncoder>>,
 {
     let _timer = tcx
         .dep_context()

--- a/compiler/rustc_query_impl/src/plumbing.rs
+++ b/compiler/rustc_query_impl/src/plumbing.rs
@@ -12,6 +12,7 @@ use rustc_query_system::query::{QueryContext, QueryJobId, QueryMap, QuerySideEff
 use rustc_data_structures::sync::Lock;
 use rustc_data_structures::thin_vec::ThinVec;
 use rustc_errors::{Diagnostic, Handler};
+use rustc_serialize::opaque;
 
 use std::any::Any;
 use std::num::NonZeroU64;
@@ -139,7 +140,7 @@ impl<'tcx> QueryCtxt<'tcx> {
 
     pub(super) fn encode_query_results(
         self,
-        encoder: &mut on_disk_cache::CacheEncoder<'_, 'tcx>,
+        encoder: &mut on_disk_cache::CacheEncoder<'_, 'tcx, opaque::FileEncoder>,
         query_result_index: &mut on_disk_cache::EncodedDepNodeIndex,
     ) {
         macro_rules! encode_queries {

--- a/compiler/rustc_query_system/src/dep_graph/serialized.rs
+++ b/compiler/rustc_query_system/src/dep_graph/serialized.rs
@@ -19,7 +19,7 @@ use rustc_data_structures::fx::FxHashMap;
 use rustc_data_structures::profiling::SelfProfilerRef;
 use rustc_data_structures::sync::Lock;
 use rustc_index::vec::{Idx, IndexVec};
-use rustc_serialize::opaque::{FileEncodeResult, FileEncoder, IntEncodedWithFixedSize, MemDecoder};
+use rustc_serialize::opaque::{self, FileEncodeResult, FileEncoder, IntEncodedWithFixedSize};
 use rustc_serialize::{Decodable, Decoder, Encodable};
 use smallvec::SmallVec;
 use std::convert::TryInto;
@@ -96,11 +96,11 @@ impl<K: DepKind> SerializedDepGraph<K> {
     }
 }
 
-impl<'a, K: DepKind + Decodable<MemDecoder<'a>>> Decodable<MemDecoder<'a>>
+impl<'a, K: DepKind + Decodable<opaque::Decoder<'a>>> Decodable<opaque::Decoder<'a>>
     for SerializedDepGraph<K>
 {
     #[instrument(level = "debug", skip(d))]
-    fn decode(d: &mut MemDecoder<'a>) -> SerializedDepGraph<K> {
+    fn decode(d: &mut opaque::Decoder<'a>) -> SerializedDepGraph<K> {
         let start_position = d.position();
 
         // The last 16 bytes are the node count and edge count.

--- a/compiler/rustc_query_system/src/dep_graph/serialized.rs
+++ b/compiler/rustc_query_system/src/dep_graph/serialized.rs
@@ -20,7 +20,7 @@ use rustc_data_structures::profiling::SelfProfilerRef;
 use rustc_data_structures::sync::Lock;
 use rustc_index::vec::{Idx, IndexVec};
 use rustc_serialize::opaque::{self, FileEncodeResult, FileEncoder, IntEncodedWithFixedSize};
-use rustc_serialize::{Decodable, Decoder, Encodable};
+use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
 use smallvec::SmallVec;
 use std::convert::TryInto;
 

--- a/compiler/rustc_serialize/src/opaque.rs
+++ b/compiler/rustc_serialize/src/opaque.rs
@@ -24,10 +24,6 @@ impl Encoder {
     pub fn position(&self) -> usize {
         self.data.len()
     }
-
-    pub fn finish(self) -> Vec<u8> {
-        self.data
-    }
 }
 
 macro_rules! write_leb128 {
@@ -58,6 +54,9 @@ macro_rules! write_leb128 {
 const STR_SENTINEL: u8 = 0xC1;
 
 impl serialize::Encoder for Encoder {
+    type Ok = Vec<u8>;
+    type Err = !;
+
     #[inline]
     fn emit_usize(&mut self, v: usize) {
         write_leb128!(self, v, usize, write_usize_leb128)
@@ -150,6 +149,10 @@ impl serialize::Encoder for Encoder {
     #[inline]
     fn emit_raw_bytes(&mut self, s: &[u8]) {
         self.data.extend_from_slice(s);
+    }
+
+    fn finish(self) -> Result<Self::Ok, Self::Err> {
+        Ok(self.data)
     }
 }
 
@@ -386,13 +389,6 @@ impl FileEncoder {
             }
         }
     }
-
-    pub fn finish(mut self) -> Result<usize, io::Error> {
-        self.flush();
-
-        let res = std::mem::replace(&mut self.res, Ok(()));
-        res.map(|()| self.position())
-    }
 }
 
 impl Drop for FileEncoder {
@@ -430,6 +426,9 @@ macro_rules! file_encoder_write_leb128 {
 }
 
 impl serialize::Encoder for FileEncoder {
+    type Ok = usize;
+    type Err = io::Error;
+
     #[inline]
     fn emit_usize(&mut self, v: usize) {
         file_encoder_write_leb128!(self, v, usize, write_usize_leb128)
@@ -522,6 +521,13 @@ impl serialize::Encoder for FileEncoder {
     #[inline]
     fn emit_raw_bytes(&mut self, s: &[u8]) {
         self.write_all(s);
+    }
+
+    fn finish(mut self) -> Result<usize, io::Error> {
+        self.flush();
+
+        let res = std::mem::replace(&mut self.res, Ok(()));
+        res.map(|()| self.position())
     }
 }
 

--- a/compiler/rustc_serialize/src/serialize.rs
+++ b/compiler/rustc_serialize/src/serialize.rs
@@ -18,10 +18,13 @@ use std::sync::Arc;
 /// is pervasive and has non-trivial cost. Instead, impls of this trait must
 /// implement a delayed error handling strategy. If a failure occurs, they
 /// should record this internally, and all subsequent encoding operations can
-/// be processed or ignored, whichever is appropriate. Then they should provide
-/// a `finish` method that finishes up encoding. If the encoder is fallible,
-/// `finish` should return a `Result` that indicates success or failure.
+/// be processed or ignored, whichever is appropriate. Then when `finish()` is
+/// called, an error result should be returned to indicate the failure. If no
+/// failures occurred, then `finish()` should return a success result.
 pub trait Encoder {
+    type Ok;
+    type Err;
+
     // Primitive types:
     fn emit_usize(&mut self, v: usize);
     fn emit_u128(&mut self, v: u128);
@@ -61,6 +64,9 @@ pub trait Encoder {
     fn emit_fieldless_enum_variant<const ID: usize>(&mut self) {
         self.emit_usize(ID)
     }
+
+    // Consume the encoder, getting the result.
+    fn finish(self) -> Result<Self::Ok, Self::Err>;
 }
 
 // Note: all the methods in this trait are infallible, which may be surprising.

--- a/compiler/rustc_serialize/tests/opaque.rs
+++ b/compiler/rustc_serialize/tests/opaque.rs
@@ -1,7 +1,7 @@
 #![allow(rustc::internal)]
 
 use rustc_macros::{Decodable, Encodable};
-use rustc_serialize::opaque::{MemDecoder, MemEncoder};
+use rustc_serialize::opaque::{Decoder, Encoder};
 use rustc_serialize::{Decodable, Encodable};
 use std::fmt::Debug;
 
@@ -28,18 +28,16 @@ struct Struct {
     q: Option<u32>,
 }
 
-fn check_round_trip<
-    T: Encodable<MemEncoder> + for<'a> Decodable<MemDecoder<'a>> + PartialEq + Debug,
->(
+fn check_round_trip<T: Encodable<Encoder> + for<'a> Decodable<Decoder<'a>> + PartialEq + Debug>(
     values: Vec<T>,
 ) {
-    let mut encoder = MemEncoder::new();
+    let mut encoder = Encoder::new();
     for value in &values {
         Encodable::encode(value, &mut encoder);
     }
 
     let data = encoder.finish();
-    let mut decoder = MemDecoder::new(&data[..], 0);
+    let mut decoder = Decoder::new(&data[..], 0);
 
     for value in values {
         let decoded = Decodable::decode(&mut decoder);

--- a/compiler/rustc_serialize/tests/opaque.rs
+++ b/compiler/rustc_serialize/tests/opaque.rs
@@ -2,7 +2,7 @@
 
 use rustc_macros::{Decodable, Encodable};
 use rustc_serialize::opaque::{Decoder, Encoder};
-use rustc_serialize::{Decodable, Encodable};
+use rustc_serialize::{Decodable, Encodable, Encoder as EncoderTrait};
 use std::fmt::Debug;
 
 #[derive(PartialEq, Clone, Debug, Encodable, Decodable)]
@@ -36,7 +36,7 @@ fn check_round_trip<T: Encodable<Encoder> + for<'a> Decodable<Decoder<'a>> + Par
         Encodable::encode(value, &mut encoder);
     }
 
-    let data = encoder.finish();
+    let data = encoder.finish().unwrap();
     let mut decoder = Decoder::new(&data[..], 0);
 
     for value in values {

--- a/compiler/rustc_span/src/lib.rs
+++ b/compiler/rustc_span/src/lib.rs
@@ -1911,13 +1911,13 @@ impl_pos! {
     pub struct CharPos(pub usize);
 }
 
-impl<S: Encoder> Encodable<S> for BytePos {
+impl<S: rustc_serialize::Encoder> Encodable<S> for BytePos {
     fn encode(&self, s: &mut S) {
         s.emit_u32(self.0);
     }
 }
 
-impl<D: Decoder> Decodable<D> for BytePos {
+impl<D: rustc_serialize::Decoder> Decodable<D> for BytePos {
     fn decode(d: &mut D) -> BytePos {
         BytePos(d.read_u32())
     }

--- a/compiler/rustc_type_ir/src/sty.rs
+++ b/compiler/rustc_type_ir/src/sty.rs
@@ -14,7 +14,7 @@ use crate::UintTy;
 use self::TyKind::*;
 
 use rustc_data_structures::stable_hasher::HashStable;
-use rustc_serialize::{Decodable, Decoder, Encodable};
+use rustc_serialize::{Decodable, Encodable};
 
 /// Defines the kinds of types used by the type system.
 ///
@@ -833,34 +833,56 @@ where
     I::AllocId: Decodable<D>,
 {
     fn decode(d: &mut D) -> Self {
-        match Decoder::read_usize(d) {
+        match rustc_serialize::Decoder::read_usize(d) {
             0 => Bool,
             1 => Char,
-            2 => Int(Decodable::decode(d)),
-            3 => Uint(Decodable::decode(d)),
-            4 => Float(Decodable::decode(d)),
-            5 => Adt(Decodable::decode(d), Decodable::decode(d)),
-            6 => Foreign(Decodable::decode(d)),
+            2 => Int(rustc_serialize::Decodable::decode(d)),
+            3 => Uint(rustc_serialize::Decodable::decode(d)),
+            4 => Float(rustc_serialize::Decodable::decode(d)),
+            5 => Adt(rustc_serialize::Decodable::decode(d), rustc_serialize::Decodable::decode(d)),
+            6 => Foreign(rustc_serialize::Decodable::decode(d)),
             7 => Str,
-            8 => Array(Decodable::decode(d), Decodable::decode(d)),
-            9 => Slice(Decodable::decode(d)),
-            10 => RawPtr(Decodable::decode(d)),
-            11 => Ref(Decodable::decode(d), Decodable::decode(d), Decodable::decode(d)),
-            12 => FnDef(Decodable::decode(d), Decodable::decode(d)),
-            13 => FnPtr(Decodable::decode(d)),
-            14 => Dynamic(Decodable::decode(d), Decodable::decode(d)),
-            15 => Closure(Decodable::decode(d), Decodable::decode(d)),
-            16 => Generator(Decodable::decode(d), Decodable::decode(d), Decodable::decode(d)),
-            17 => GeneratorWitness(Decodable::decode(d)),
+            8 => {
+                Array(rustc_serialize::Decodable::decode(d), rustc_serialize::Decodable::decode(d))
+            }
+            9 => Slice(rustc_serialize::Decodable::decode(d)),
+            10 => RawPtr(rustc_serialize::Decodable::decode(d)),
+            11 => Ref(
+                rustc_serialize::Decodable::decode(d),
+                rustc_serialize::Decodable::decode(d),
+                rustc_serialize::Decodable::decode(d),
+            ),
+            12 => {
+                FnDef(rustc_serialize::Decodable::decode(d), rustc_serialize::Decodable::decode(d))
+            }
+            13 => FnPtr(rustc_serialize::Decodable::decode(d)),
+            14 => Dynamic(
+                rustc_serialize::Decodable::decode(d),
+                rustc_serialize::Decodable::decode(d),
+            ),
+            15 => Closure(
+                rustc_serialize::Decodable::decode(d),
+                rustc_serialize::Decodable::decode(d),
+            ),
+            16 => Generator(
+                rustc_serialize::Decodable::decode(d),
+                rustc_serialize::Decodable::decode(d),
+                rustc_serialize::Decodable::decode(d),
+            ),
+            17 => GeneratorWitness(rustc_serialize::Decodable::decode(d)),
             18 => Never,
-            19 => Tuple(Decodable::decode(d)),
-            20 => Projection(Decodable::decode(d)),
-            21 => Opaque(Decodable::decode(d), Decodable::decode(d)),
-            22 => Param(Decodable::decode(d)),
-            23 => Bound(Decodable::decode(d), Decodable::decode(d)),
-            24 => Placeholder(Decodable::decode(d)),
-            25 => Infer(Decodable::decode(d)),
-            26 => Error(Decodable::decode(d)),
+            19 => Tuple(rustc_serialize::Decodable::decode(d)),
+            20 => Projection(rustc_serialize::Decodable::decode(d)),
+            21 => {
+                Opaque(rustc_serialize::Decodable::decode(d), rustc_serialize::Decodable::decode(d))
+            }
+            22 => Param(rustc_serialize::Decodable::decode(d)),
+            23 => {
+                Bound(rustc_serialize::Decodable::decode(d), rustc_serialize::Decodable::decode(d))
+            }
+            24 => Placeholder(rustc_serialize::Decodable::decode(d)),
+            25 => Infer(rustc_serialize::Decodable::decode(d)),
+            26 => Error(rustc_serialize::Decodable::decode(d)),
             _ => panic!(
                 "{}",
                 format!(

--- a/src/librustdoc/scrape_examples.rs
+++ b/src/librustdoc/scrape_examples.rs
@@ -17,7 +17,7 @@ use rustc_middle::hir::map::Map;
 use rustc_middle::hir::nested_filter;
 use rustc_middle::ty::{self, TyCtxt};
 use rustc_serialize::{
-    opaque::{FileEncoder, MemDecoder},
+    opaque::{Decoder, FileEncoder},
     Decodable, Encodable,
 };
 use rustc_session::getopts;
@@ -336,7 +336,7 @@ pub(crate) fn load_call_locations(
         let mut all_calls: AllCallLocations = FxHashMap::default();
         for path in with_examples {
             let bytes = fs::read(&path).map_err(|e| format!("{} (for path {})", e, path))?;
-            let mut decoder = MemDecoder::new(&bytes, 0);
+            let mut decoder = Decoder::new(&bytes, 0);
             let calls = AllCallLocations::decode(&mut decoder);
 
             for (function, fn_calls) in calls.into_iter() {

--- a/src/librustdoc/scrape_examples.rs
+++ b/src/librustdoc/scrape_examples.rs
@@ -18,7 +18,7 @@ use rustc_middle::hir::nested_filter;
 use rustc_middle::ty::{self, TyCtxt};
 use rustc_serialize::{
     opaque::{Decoder, FileEncoder},
-    Decodable, Encodable,
+    Decodable, Encodable, Encoder,
 };
 use rustc_session::getopts;
 use rustc_span::{

--- a/src/test/ui-fulldeps/deriving-encodable-decodable-box.rs
+++ b/src/test/ui-fulldeps/deriving-encodable-decodable-box.rs
@@ -20,7 +20,7 @@ fn main() {
 
     let mut encoder = opaque::Encoder::new();
     obj.encode(&mut encoder);
-    let data = encoder.finish();
+    let data = encoder.finish().unwrap();
 
     let mut decoder = opaque::Decoder::new(&data, 0);
     let obj2 = A::decode(&mut decoder);

--- a/src/test/ui-fulldeps/deriving-encodable-decodable-box.rs
+++ b/src/test/ui-fulldeps/deriving-encodable-decodable-box.rs
@@ -7,7 +7,7 @@ extern crate rustc_macros;
 extern crate rustc_serialize;
 
 use rustc_macros::{Decodable, Encodable};
-use rustc_serialize::opaque::{MemDecoder, MemEncoder};
+use rustc_serialize::opaque;
 use rustc_serialize::{Decodable, Encodable, Encoder};
 
 #[derive(Encodable, Decodable)]
@@ -18,11 +18,11 @@ struct A {
 fn main() {
     let obj = A { foo: Box::new([true, false]) };
 
-    let mut encoder = MemEncoder::new();
+    let mut encoder = opaque::Encoder::new();
     obj.encode(&mut encoder);
     let data = encoder.finish();
 
-    let mut decoder = MemDecoder::new(&data, 0);
+    let mut decoder = opaque::Decoder::new(&data, 0);
     let obj2 = A::decode(&mut decoder);
 
     assert_eq!(obj.foo, obj2.foo);

--- a/src/test/ui-fulldeps/deriving-encodable-decodable-cell-refcell.rs
+++ b/src/test/ui-fulldeps/deriving-encodable-decodable-cell-refcell.rs
@@ -9,7 +9,7 @@ extern crate rustc_macros;
 extern crate rustc_serialize;
 
 use rustc_macros::{Decodable, Encodable};
-use rustc_serialize::opaque::{MemDecoder, MemEncoder};
+use rustc_serialize::opaque;
 use rustc_serialize::{Decodable, Encodable, Encoder};
 use std::cell::{Cell, RefCell};
 
@@ -27,11 +27,11 @@ struct B {
 fn main() {
     let obj = B { foo: Cell::new(true), bar: RefCell::new(A { baz: 2 }) };
 
-    let mut encoder = MemEncoder::new();
+    let mut encoder = opaque::Encoder::new();
     obj.encode(&mut encoder);
     let data = encoder.finish();
 
-    let mut decoder = MemDecoder::new(&data, 0);
+    let mut decoder = opaque::Decoder::new(&data, 0);
     let obj2 = B::decode(&mut decoder);
 
     assert_eq!(obj.foo.get(), obj2.foo.get());

--- a/src/test/ui-fulldeps/deriving-encodable-decodable-cell-refcell.rs
+++ b/src/test/ui-fulldeps/deriving-encodable-decodable-cell-refcell.rs
@@ -29,7 +29,7 @@ fn main() {
 
     let mut encoder = opaque::Encoder::new();
     obj.encode(&mut encoder);
-    let data = encoder.finish();
+    let data = encoder.finish().unwrap();
 
     let mut decoder = opaque::Decoder::new(&data, 0);
     let obj2 = B::decode(&mut decoder);

--- a/src/test/ui-fulldeps/issue-14021.rs
+++ b/src/test/ui-fulldeps/issue-14021.rs
@@ -8,7 +8,7 @@ extern crate rustc_macros;
 extern crate rustc_serialize;
 
 use rustc_macros::{Decodable, Encodable};
-use rustc_serialize::opaque::{MemDecoder, MemEncoder};
+use rustc_serialize::opaque;
 use rustc_serialize::{Decodable, Encodable, Encoder};
 
 #[derive(Encodable, Decodable, PartialEq, Debug)]
@@ -17,11 +17,11 @@ struct UnitLikeStruct;
 pub fn main() {
     let obj = UnitLikeStruct;
 
-    let mut encoder = MemEncoder::new();
+    let mut encoder = opaque::Encoder::new();
     obj.encode(&mut encoder);
     let data = encoder.finish();
 
-    let mut decoder = MemDecoder::new(&data, 0);
+    let mut decoder = opaque::Decoder::new(&data, 0);
     let obj2 = UnitLikeStruct::decode(&mut decoder);
 
     assert_eq!(obj, obj2);

--- a/src/test/ui-fulldeps/issue-14021.rs
+++ b/src/test/ui-fulldeps/issue-14021.rs
@@ -19,7 +19,7 @@ pub fn main() {
 
     let mut encoder = opaque::Encoder::new();
     obj.encode(&mut encoder);
-    let data = encoder.finish();
+    let data = encoder.finish().unwrap();
 
     let mut decoder = opaque::Decoder::new(&data, 0);
     let obj2 = UnitLikeStruct::decode(&mut decoder);


### PR DESCRIPTION
#94732 was supposed to give small but widespread performance improvements, as judged from three per-merge performance runs. But the performance run that occurred after merging included a roughly equal number of improvements and regressions, for unclear reasons.

This PR is for a test run reverting those changes, to see what happens.

r? @ghost