### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/compiler/rustc_expand/src/mbe/quoted.rs
+++ b/compiler/rustc_expand/src/mbe/quoted.rs
@@ -234,8 +234,6 @@ fn parse_tree(
                             sess,
                             &Token { kind: token::Dollar, span },
                         );
-                    } else {
-                        maybe_emit_macro_metavar_expr_feature(features, sess, span);
                     }
                     TokenTree::token(token::Dollar, span)
                 }

--- a/compiler/rustc_infer/src/infer/combine.rs
+++ b/compiler/rustc_infer/src/infer/combine.rs
@@ -1,26 +1,26 @@
-///////////////////////////////////////////////////////////////////////////
-// # Type combining
-//
-// There are four type combiners: equate, sub, lub, and glb.  Each
-// implements the trait `Combine` and contains methods for combining
-// two instances of various things and yielding a new instance.  These
-// combiner methods always yield a `Result<T>`.  There is a lot of
-// common code for these operations, implemented as default methods on
-// the `Combine` trait.
-//
-// Each operation may have side-effects on the inference context,
-// though these can be unrolled using snapshots. On success, the
-// LUB/GLB operations return the appropriate bound. The Eq and Sub
-// operations generally return the first operand.
-//
-// ## Contravariance
-//
-// When you are relating two things which have a contravariant
-// relationship, you should use `contratys()` or `contraregions()`,
-// rather than inversing the order of arguments!  This is necessary
-// because the order of arguments is not relevant for LUB and GLB.  It
-// is also useful to track which value is the "expected" value in
-// terms of error reporting.
+//! There are four type combiners: [Equate], [Sub], [Lub], and [Glb].
+//! Each implements the trait [TypeRelation] and contains methods for
+//! combining two instances of various things and yielding a new instance.
+//! These combiner methods always yield a `Result<T>`. To relate two
+//! types, you can use `infcx.at(cause, param_env)` which then allows
+//! you to use the relevant methods of [At](super::at::At).
+//!
+//! Combiners mostly do their specific behavior and then hand off the
+//! bulk of the work to [InferCtxt::super_combine_tys] and
+//! [InferCtxt::super_combine_consts].
+//!
+//! Combining two types may have side-effects on the inference contexts
+//! which can be undone by using snapshots. You probably want to use
+//! either [InferCtxt::commit_if_ok] or [InferCtxt::probe].
+//!
+//! On success, the  LUB/GLB operations return the appropriate bound. The
+//! return value of `Equate` or `Sub` shouldn't really be used.
+//!
+//! ## Contravariance
+//!
+//! We explicitly track which argument is expected using
+//! [TypeRelation::a_is_expected], so when dealing with contravariance
+//! this should be correctly updated.
 
 use super::equate::Equate;
 use super::glb::Glb;

--- a/compiler/rustc_target/src/spec/mipsel_sony_psp.rs
+++ b/compiler/rustc_target/src/spec/mipsel_sony_psp.rs
@@ -6,10 +6,8 @@ const LINKER_SCRIPT: &str = include_str!("./mipsel_sony_psp_linker_script.ld");
 
 pub fn target() -> Target {
     let mut pre_link_args = LinkArgs::new();
-    pre_link_args.insert(
-        LinkerFlavor::Lld(LldFlavor::Ld),
-        vec!["--emit-relocs".into(), "--nmagic".into()],
-    );
+    pre_link_args
+        .insert(LinkerFlavor::Lld(LldFlavor::Ld), vec!["--emit-relocs".into(), "--nmagic".into()]);
 
     Target {
         llvm_target: "mipsel-sony-psp".into(),

--- a/compiler/rustc_target/src/spec/mipsel_sony_psp.rs
+++ b/compiler/rustc_target/src/spec/mipsel_sony_psp.rs
@@ -6,7 +6,10 @@ const LINKER_SCRIPT: &str = include_str!("./mipsel_sony_psp_linker_script.ld");
 
 pub fn target() -> Target {
     let mut pre_link_args = LinkArgs::new();
-    pre_link_args.insert(LinkerFlavor::Lld(LldFlavor::Ld), vec!["--emit-relocs".into()]);
+    pre_link_args.insert(
+        LinkerFlavor::Lld(LldFlavor::Ld),
+        vec!["--emit-relocs".into(), "--nmagic".into()],
+    );
 
     Target {
         llvm_target: "mipsel-sony-psp".into(),

--- a/compiler/rustc_target/src/spec/mipsel_sony_psp_linker_script.ld
+++ b/compiler/rustc_target/src/spec/mipsel_sony_psp_linker_script.ld
@@ -7,14 +7,18 @@ SECTIONS
   /* Sort stubs for convenient ordering */
   .sceStub.text : { *(.sceStub.text) *(SORT(.sceStub.text.*)) }
 
+  /* PSP import library stub sections. Bundles together `.lib.stub.entry.*`
+   * sections for better `--gc-sections` support. */
+  .lib.stub.top : { *(.lib.stub.top) }
+  .lib.stub :     { *(.lib.stub) *(.lib.stub.entry.*) }
+  .lib.stub.btm : { *(.lib.stub.btm) }
+
   /* Keep these sections around, even though they may appear unused to the linker */
   .lib.ent.top :  { KEEP(*(.lib.ent.top)) }
   .lib.ent :      { KEEP(*(.lib.ent)) }
   .lib.ent.btm :  { KEEP(*(.lib.ent.btm)) }
-  .lib.stub.top : { KEEP(*(.lib.stub.top)) }
-  .lib.stub :     { KEEP(*(.lib.stub)) }
-  .lib.stub.btm : { KEEP(*(.lib.stub.btm)) }
-  .eh_frame_hdr : { KEEP(*(.eh_frame_hdr)) }
+
+  .eh_frame_hdr : { *(.eh_frame_hdr) }
 
   /* Add symbols for LLVM's libunwind */
   __eh_frame_hdr_start = SIZEOF(.eh_frame_hdr) > 0 ? ADDR(.eh_frame_hdr) : 0;
@@ -27,8 +31,15 @@ SECTIONS
   }
 
   /* These are explicitly listed to avoid being merged into .rodata */
-  .rodata.sceResident : { *(.rodata.sceResident) }
+  .rodata.sceResident : { *(.rodata.sceResident) *(.rodata.sceResident.*) }
   .rodata.sceModuleInfo : { *(.rodata.sceModuleInfo) }
   /* Sort NIDs for convenient ordering */
   .rodata.sceNid : { *(.rodata.sceNid) *(SORT(.rodata.sceNid.*)) }
+
+  .rodata : { *(.rodata .rodata.*) }
+  .data : { *(.data .data.*) }
+  .gcc_except_table : { *(.gcc_except_table .gcc_except_table.*) }
+  .bss : { *(.bss .bss.*) }
+
+  /DISCARD/ : { *(.rel.sceStub.text .MIPS.abiflags .reginfo) }
 }

--- a/library/panic_unwind/src/emcc.rs
+++ b/library/panic_unwind/src/emcc.rs
@@ -105,7 +105,6 @@ extern "C" fn exception_cleanup(ptr: *mut libc::c_void) -> *mut libc::c_void {
     }
 }
 
-
 // This is required by the compiler to exist (e.g., it's a lang item), but it's
 // never actually called by the compiler.  Emscripten EH doesn't use a
 // personality function at all, it instead uses __cxa_find_matching_catch.

--- a/library/panic_unwind/src/emcc.rs
+++ b/library/panic_unwind/src/emcc.rs
@@ -129,11 +129,4 @@ extern "C" {
         tinfo: *const TypeInfo,
         dest: extern "C" fn(*mut libc::c_void) -> *mut libc::c_void,
     ) -> !;
-    fn __gxx_personality_v0(
-        version: c_int,
-        actions: uw::_Unwind_Action,
-        exception_class: uw::_Unwind_Exception_Class,
-        exception_object: *mut uw::_Unwind_Exception,
-        context: *mut uw::_Unwind_Context,
-    ) -> uw::_Unwind_Reason_Code;
 }

--- a/library/panic_unwind/src/emcc.rs
+++ b/library/panic_unwind/src/emcc.rs
@@ -105,6 +105,11 @@ extern "C" fn exception_cleanup(ptr: *mut libc::c_void) -> *mut libc::c_void {
     }
 }
 
+
+// This is required by the compiler to exist (e.g., it's a lang item), but it's
+// never actually called by the compiler.  Emscripten EH doesn't use a
+// personality function at all, it instead uses __cxa_find_matching_catch.
+// Wasm error handling would use __gxx_personality_wasm0.
 #[lang = "eh_personality"]
 unsafe extern "C" fn rust_eh_personality(
     version: c_int,
@@ -113,7 +118,7 @@ unsafe extern "C" fn rust_eh_personality(
     exception_object: *mut uw::_Unwind_Exception,
     context: *mut uw::_Unwind_Context,
 ) -> uw::_Unwind_Reason_Code {
-    __gxx_personality_v0(version, actions, exception_class, exception_object, context)
+    core::intrinsics::abort()
 }
 
 extern "C" {

--- a/src/test/assembly/asm/hexagon-types.rs
+++ b/src/test/assembly/asm/hexagon-types.rs
@@ -73,7 +73,7 @@ macro_rules! check_reg {
 
 // CHECK-LABEL: sym_static:
 // CHECK: InlineAsm Start
-// CHECK: r0 = #extern_static
+// CHECK: r0 = {{#+}}extern_static
 // CHECK: InlineAsm End
 #[no_mangle]
 pub unsafe fn sym_static() {
@@ -88,7 +88,7 @@ pub unsafe fn sym_static() {
 
 // CHECK-LABEL: sym_fn:
 // CHECK: InlineAsm Start
-// CHECK: r0 = #extern_func
+// CHECK: r0 = {{#+}}extern_func
 // CHECK: InlineAsm End
 #[no_mangle]
 pub unsafe fn sym_fn() {
@@ -108,7 +108,7 @@ pub unsafe fn sym_fn() {
 // CHECK: InlineAsm Start
 // CHECK: {
 // CHECK:   r{{[0-9]+}} = r0
-// CHECK:   memw(r1) = r{{[0-9]+}}
+// CHECK:   memw(r1{{(\+#0)?}}) = r{{[0-9]+}}
 // CHECK: }
 // CHECK: InlineAsm End
 #[no_mangle]

--- a/src/test/ui/macros/rfc-3086-metavar-expr/allowed-features.rs
+++ b/src/test/ui/macros/rfc-3086-metavar-expr/allowed-features.rs
@@ -1,0 +1,12 @@
+// check-pass
+
+macro_rules! dollar_dollar {
+    () => {
+        macro_rules! bar {
+            ( $$( $$any:tt )* ) => { $$( $$any )* };
+        }
+    };
+}
+
+fn main() {
+}

--- a/src/test/ui/macros/rfc-3086-metavar-expr/required-features.rs
+++ b/src/test/ui/macros/rfc-3086-metavar-expr/required-features.rs
@@ -5,18 +5,6 @@ macro_rules! count {
     };
 }
 
-macro_rules! dollar_dollar {
-    () => {
-        macro_rules! bar {
-            ( $$( $$any:tt )* ) => { $$( $$any )* };
-            //~^ ERROR meta-variable expressions are unstable
-            //~| ERROR meta-variable expressions are unstable
-            //~| ERROR meta-variable expressions are unstable
-            //~| ERROR meta-variable expressions are unstable
-        }
-    };
-}
-
 macro_rules! index {
     ( $( $e:stmt ),* ) => {
         $( ${ignore(e)} ${index()} )*

--- a/src/test/ui/macros/rfc-3086-metavar-expr/required-features.stderr
+++ b/src/test/ui/macros/rfc-3086-metavar-expr/required-features.stderr
@@ -1,5 +1,5 @@
 error[E0658]: meta-variable expressions are unstable
-  --> $DIR/required-feature.rs:3:10
+  --> $DIR/required-features.rs:3:10
    |
 LL |         ${ count(e) }
    |          ^^^^^^^^^^^^
@@ -8,43 +8,7 @@ LL |         ${ count(e) }
    = help: add `#![feature(macro_metavar_expr)]` to the crate attributes to enable
 
 error[E0658]: meta-variable expressions are unstable
-  --> $DIR/required-feature.rs:11:16
-   |
-LL |             ( $$( $$any:tt )* ) => { $$( $$any )* };
-   |                ^
-   |
-   = note: see issue #83527 <https://github.com/rust-lang/rust/issues/83527> for more information
-   = help: add `#![feature(macro_metavar_expr)]` to the crate attributes to enable
-
-error[E0658]: meta-variable expressions are unstable
-  --> $DIR/required-feature.rs:11:20
-   |
-LL |             ( $$( $$any:tt )* ) => { $$( $$any )* };
-   |                    ^
-   |
-   = note: see issue #83527 <https://github.com/rust-lang/rust/issues/83527> for more information
-   = help: add `#![feature(macro_metavar_expr)]` to the crate attributes to enable
-
-error[E0658]: meta-variable expressions are unstable
-  --> $DIR/required-feature.rs:11:39
-   |
-LL |             ( $$( $$any:tt )* ) => { $$( $$any )* };
-   |                                       ^
-   |
-   = note: see issue #83527 <https://github.com/rust-lang/rust/issues/83527> for more information
-   = help: add `#![feature(macro_metavar_expr)]` to the crate attributes to enable
-
-error[E0658]: meta-variable expressions are unstable
-  --> $DIR/required-feature.rs:11:43
-   |
-LL |             ( $$( $$any:tt )* ) => { $$( $$any )* };
-   |                                           ^
-   |
-   = note: see issue #83527 <https://github.com/rust-lang/rust/issues/83527> for more information
-   = help: add `#![feature(macro_metavar_expr)]` to the crate attributes to enable
-
-error[E0658]: meta-variable expressions are unstable
-  --> $DIR/required-feature.rs:22:13
+  --> $DIR/required-features.rs:10:13
    |
 LL |         $( ${ignore(e)} ${index()} )*
    |             ^^^^^^^^^^^
@@ -53,7 +17,7 @@ LL |         $( ${ignore(e)} ${index()} )*
    = help: add `#![feature(macro_metavar_expr)]` to the crate attributes to enable
 
 error[E0658]: meta-variable expressions are unstable
-  --> $DIR/required-feature.rs:22:26
+  --> $DIR/required-features.rs:10:26
    |
 LL |         $( ${ignore(e)} ${index()} )*
    |                          ^^^^^^^^^
@@ -62,7 +26,7 @@ LL |         $( ${ignore(e)} ${index()} )*
    = help: add `#![feature(macro_metavar_expr)]` to the crate attributes to enable
 
 error[E0658]: meta-variable expressions are unstable
-  --> $DIR/required-feature.rs:30:19
+  --> $DIR/required-features.rs:18:19
    |
 LL |         0 $( + 1 ${ignore(i)} )*
    |                   ^^^^^^^^^^^
@@ -71,7 +35,7 @@ LL |         0 $( + 1 ${ignore(i)} )*
    = help: add `#![feature(macro_metavar_expr)]` to the crate attributes to enable
 
 error[E0658]: meta-variable expressions are unstable
-  --> $DIR/required-feature.rs:37:13
+  --> $DIR/required-features.rs:25:13
    |
 LL |         $( ${ignore(e)} ${length()} )*
    |             ^^^^^^^^^^^
@@ -80,7 +44,7 @@ LL |         $( ${ignore(e)} ${length()} )*
    = help: add `#![feature(macro_metavar_expr)]` to the crate attributes to enable
 
 error[E0658]: meta-variable expressions are unstable
-  --> $DIR/required-feature.rs:37:26
+  --> $DIR/required-features.rs:25:26
    |
 LL |         $( ${ignore(e)} ${length()} )*
    |                          ^^^^^^^^^^
@@ -88,6 +52,6 @@ LL |         $( ${ignore(e)} ${length()} )*
    = note: see issue #83527 <https://github.com/rust-lang/rust/issues/83527> for more information
    = help: add `#![feature(macro_metavar_expr)]` to the crate attributes to enable
 
-error: aborting due to 10 previous errors
+error: aborting due to 6 previous errors
 
 For more information about this error, try `rustc --explain E0658`.


### PR DESCRIPTION
Successful merges:

 - #95632 (impl Read and Write for VecDeque<u8>)
 - #95860 (Stabilize `$$` in Rust 1.63.0)
 - #97838 (hexagon: adapt test for upstream output changes)
 - #97843 (Relax mipsel-sony-psp's linker script)
 - #97874 (rewrite combine doc comment)
 - #97888 (Don't use __gxx_personality_v0 in panic_unwind on emscripten target)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=95632,95860,97838,97843,97874,97888)
<!-- homu-ignore:end -->