### PR TITLE
Implement `fmt::Write` for `OsString`

### DIFF
--- a/library/std/src/ffi/os_str.rs
+++ b/library/std/src/ffi/os_str.rs
@@ -615,6 +615,14 @@ impl Hash for OsString {
     }
 }
 
+#[stable(feature = "os_string_fmt_write", since = "1.63.0")]
+impl fmt::Write for OsString {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        self.push(s);
+        Ok(())
+    }
+}
+
 impl OsStr {
     /// Coerces into an `OsStr` slice.
     ///

--- a/library/std/src/ffi/os_str.rs
+++ b/library/std/src/ffi/os_str.rs
@@ -615,7 +615,7 @@ impl Hash for OsString {
     }
 }
 
-#[stable(feature = "os_string_fmt_write", since = "1.63.0")]
+#[stable(feature = "os_string_fmt_write", since = "1.64.0")]
 impl fmt::Write for OsString {
     fn write_str(&mut self, s: &str) -> fmt::Result {
         self.push(s);


### PR DESCRIPTION
This allows to format into an `OsString` without unnecessary
allocations. E.g.

```
let mut temp_filename = path.into_os_string();
write!(&mut temp_filename, ".tmp.{}", process::id());
```