### PR TITLE
Implement ExitCodeExt for Windows

### DIFF
--- a/library/std/src/os/windows/process.rs
+++ b/library/std/src/os/windows/process.rs
@@ -194,3 +194,22 @@ impl ChildExt for process::Child {
         self.handle.main_thread_handle()
     }
 }
+
+/// Windows-specific extensions to [`process::ExitCode`].
+///
+/// This trait is sealed: it cannot be implemented outside the standard library.
+/// This is so that future additional methods are not breaking changes.
+#[stable(feature = "windows_process_exit_code_from", since = "1.63.0")]
+pub trait ExitCodeExt: Sealed {
+    /// Creates a new `ExitStatus` from the raw underlying `u32` return value of
+    /// a process.
+    #[stable(feature = "windows_process_exit_code_from", since = "1.63.0")]
+    fn from_raw(raw: u32) -> Self;
+}
+
+#[stable(feature = "windows_process_exit_code_from", since = "1.63.0")]
+impl ExitCodeExt for process::ExitCode {
+    fn from_raw(raw: u32) -> Self {
+        process::ExitCode::from_inner(From::from(raw))
+    }
+}

--- a/library/std/src/os/windows/process.rs
+++ b/library/std/src/os/windows/process.rs
@@ -201,7 +201,7 @@ impl ChildExt for process::Child {
 /// This is so that future additional methods are not breaking changes.
 #[stable(feature = "windows_process_exit_code_from", since = "1.63.0")]
 pub trait ExitCodeExt: Sealed {
-    /// Creates a new `ExitStatus` from the raw underlying `u32` return value of
+    /// Creates a new `ExitCode` from the raw underlying `u32` return value of
     /// a process.
     #[stable(feature = "windows_process_exit_code_from", since = "1.63.0")]
     fn from_raw(raw: u32) -> Self;

--- a/library/std/src/os/windows/process.rs
+++ b/library/std/src/os/windows/process.rs
@@ -199,7 +199,7 @@ impl ChildExt for process::Child {
 ///
 /// This trait is sealed: it cannot be implemented outside the standard library.
 /// This is so that future additional methods are not breaking changes.
-#[stable(feature = "windows_process_exit_code_from", since = "1.63.0")]
+#[unstable(feature = "windows_process_exit_code_from", issue = "none")]
 pub trait ExitCodeExt: Sealed {
     /// Creates a new `ExitCode` from the raw underlying `u32` return value of
     /// a process.
@@ -207,11 +207,11 @@ pub trait ExitCodeExt: Sealed {
     /// The exit code should not be 259, as this conflicts with the `STILL_ACTIVE`
     /// macro returned from the `GetExitCodeProcess` function to signal that the
     /// process has yet to run to completion.
-    #[stable(feature = "windows_process_exit_code_from", since = "1.63.0")]
+    #[unstable(feature = "windows_process_exit_code_from", issue = "none")]
     fn from_raw(raw: u32) -> Self;
 }
 
-#[stable(feature = "windows_process_exit_code_from", since = "1.63.0")]
+#[unstable(feature = "windows_process_exit_code_from", issue = "none")]
 impl ExitCodeExt for process::ExitCode {
     fn from_raw(raw: u32) -> Self {
         process::ExitCode::from_inner(From::from(raw))

--- a/library/std/src/os/windows/process.rs
+++ b/library/std/src/os/windows/process.rs
@@ -203,6 +203,10 @@ impl ChildExt for process::Child {
 pub trait ExitCodeExt: Sealed {
     /// Creates a new `ExitCode` from the raw underlying `u32` return value of
     /// a process.
+    ///
+    /// The exit code should not be 259, as this conflicts with the `STILL_ACTIVE`
+    /// macro returned from the `GetExitCodeProcess` function to signal that the
+    /// process has yet to run to completion.
     #[stable(feature = "windows_process_exit_code_from", since = "1.63.0")]
     fn from_raw(raw: u32) -> Self;
 }

--- a/library/std/src/process.rs
+++ b/library/std/src/process.rs
@@ -1708,6 +1708,10 @@ impl crate::error::Error for ExitStatusError {}
 #[stable(feature = "process_exitcode", since = "1.61.0")]
 pub struct ExitCode(imp::ExitCode);
 
+/// Allows extension traits within `std`.
+#[unstable(feature = "sealed", issue = "none")]
+impl crate::sealed::Sealed for ExitCode {}
+
 #[stable(feature = "process_exitcode", since = "1.61.0")]
 impl ExitCode {
     /// The canonical `ExitCode` for successful termination on this platform.
@@ -1795,6 +1799,18 @@ impl From<u8> for ExitCode {
     /// Construct an `ExitCode` from an arbitrary u8 value.
     fn from(code: u8) -> Self {
         ExitCode(imp::ExitCode::from(code))
+    }
+}
+
+impl AsInner<imp::ExitCode> for ExitCode {
+    fn as_inner(&self) -> &imp::ExitCode {
+        &self.0
+    }
+}
+
+impl FromInner<imp::ExitCode> for ExitCode {
+    fn from_inner(s: imp::ExitCode) -> ExitCode {
+        ExitCode(s)
     }
 }
 

--- a/library/std/src/sys/windows/process.rs
+++ b/library/std/src/sys/windows/process.rs
@@ -707,6 +707,12 @@ impl From<u8> for ExitCode {
     }
 }
 
+impl From<u32> for ExitCode {
+    fn from(code: u32) -> Self {
+        ExitCode(c::DWORD::from(code))
+    }
+}
+
 fn zeroed_startupinfo() -> c::STARTUPINFO {
     c::STARTUPINFO {
         cb: 0,


### PR DESCRIPTION
Fixes #97914

### Motivation:

On Windows it is common for applications to return `HRESULT` (`i32`) or `DWORD` (`u32`) values. These stem from COM based components ([HRESULTS](https://docs.microsoft.com/en-us/windows/win32/api/objbase/nf-objbase-coinitialize)), Win32 errors ([GetLastError](https://docs.microsoft.com/en-us/windows/win32/api/errhandlingapi/nf-errhandlingapi-getlasterror)), GUI applications ([WM_QUIT](https://docs.microsoft.com/en-us/windows/win32/winmsg/wm-quit)) and more. The newly stabilized `ExitCode` provides an excellent fit for propagating these values, because `std::process::exit` does not run deconstructors which can result in errors. However, `ExitCode` currently only implements `From<u8> for ExitCode`, which disallows the full range of `i32`/`u32` values. This pull requests attempts to address that shortcoming by providing windows specific extensions that accept a `u32` value (which covers all possible `HRESULTS` and Win32 errors) analog to [ExitStatusExt::from_raw](https://doc.rust-lang.org/std/os/windows/process/trait.ExitStatusExt.html#tymethod.from_raw).

This was also intended by the original Stabilization https://github.com/rust-lang/rust/pull/93840#issue-1129209143=  as pointed out by @eggyal in https://github.com/rust-lang/rust/issues/97914#issuecomment-1151076755:

> Issues around platform specific representations: We resolved this issue by changing the return type of report from i32 to the opaque type ExitCode. __That way we can change the underlying representation without affecting the API, letting us offer full support for platform specific exit code APIs in the future.__

[Emphasis added]

### API

```rust
/// Windows-specific extensions to [`process::ExitCode`].
///
/// This trait is sealed: it cannot be implemented outside the standard library.
/// This is so that future additional methods are not breaking changes.
#[stable(feature = "windows_process_exit_code_from", since = "1.63.0")]
pub trait ExitCodeExt: Sealed {
    /// Creates a new `ExitCode` from the raw underlying `u32` return value of
    /// a process.
    #[stable(feature = "windows_process_exit_code_from", since = "1.63.0")]
    fn from_raw(raw: u32) -> Self;
}

#[stable(feature = "windows_process_exit_code_from", since = "1.63.0")]
impl ExitCodeExt for process::ExitCode {
    fn from_raw(raw: u32) -> Self {
        process::ExitCode::from_inner(From::from(raw))
    }
}
```

### Misc

I apologize in advance if I misplaced any attributes regarding stabilzation, as far as I learned traits are insta-stable so I chose to make them stable. If this is an error, please let me know and I'll correct it. I also added some additional machinery to make it work, analog to [ExitStatus](https://doc.rust-lang.org/std/process/struct.ExitStatus.html#).

EDIT: Proposal: https://github.com/rust-lang/libs-team/issues/48