### PR TITLE
Removes debug settings from wasm32_unknown_emscripten default link args

### DIFF
--- a/compiler/rustc_target/src/spec/wasm32_unknown_emscripten.rs
+++ b/compiler/rustc_target/src/spec/wasm32_unknown_emscripten.rs
@@ -16,11 +16,7 @@ pub fn target() -> Target {
     let mut post_link_args = LinkArgs::new();
     post_link_args.insert(
         LinkerFlavor::Em,
-        vec![
-            "-s".into(),
-            "ABORTING_MALLOC=0".into(),
-            "-Wl,--fatal-warnings".into(),
-        ],
+        vec!["-sABORTING_MALLOC=0".into(), "-Wl,--fatal-warnings".into()],
     );
 
     let opts = TargetOptions {

--- a/compiler/rustc_target/src/spec/wasm32_unknown_emscripten.rs
+++ b/compiler/rustc_target/src/spec/wasm32_unknown_emscripten.rs
@@ -18,8 +18,6 @@ pub fn target() -> Target {
         LinkerFlavor::Em,
         vec![
             "-s".into(),
-            "ERROR_ON_UNDEFINED_SYMBOLS=1".into(),
-            "-s".into(),
             "ABORTING_MALLOC=0".into(),
             "-Wl,--fatal-warnings".into(),
         ],

--- a/compiler/rustc_target/src/spec/wasm32_unknown_emscripten.rs
+++ b/compiler/rustc_target/src/spec/wasm32_unknown_emscripten.rs
@@ -20,8 +20,6 @@ pub fn target() -> Target {
             "-s".into(),
             "ERROR_ON_UNDEFINED_SYMBOLS=1".into(),
             "-s".into(),
-            "ASSERTIONS=1".into(),
-            "-s".into(),
             "ABORTING_MALLOC=0".into(),
             "-Wl,--fatal-warnings".into(),
         ],


### PR DESCRIPTION
This is a debug setting. We should only make debug builds if user requests
a debug build. Currently this is inserted in release builds.

Furthermore, it would be better to insert these settings in --pre-link-args
because then it would be possible to override them if appropriate. Because
these are inserted at the end, it is necessary to patch emscripten to remove
them.

@sbc100