### PR TITLE
Compile `unicode-normalization` faster

### DIFF
--- a/compiler/rustc_mir_build/src/build/matches/simplify.rs
+++ b/compiler/rustc_mir_build/src/build/matches/simplify.rs
@@ -227,15 +227,18 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     _ => (None, 0),
                 };
                 if let Some((min, max, sz)) = range {
-                    if let (Some(lo), Some(hi)) = (lo.try_to_bits(sz), hi.try_to_bits(sz)) {
-                        // We want to compare ranges numerically, but the order of the bitwise
-                        // representation of signed integers does not match their numeric order.
-                        // Thus, to correct the ordering, we need to shift the range of signed
-                        // integers to correct the comparison. This is achieved by XORing with a
-                        // bias (see pattern/_match.rs for another pertinent example of this
-                        // pattern).
-                        let (lo, hi) = (lo ^ bias, hi ^ bias);
-                        if lo <= min && (hi > max || hi == max && end == RangeEnd::Included) {
+                    // We want to compare ranges numerically, but the order of the bitwise
+                    // representation of signed integers does not match their numeric order. Thus,
+                    // to correct the ordering, we need to shift the range of signed integers to
+                    // correct the comparison. This is achieved by XORing with a bias (see
+                    // pattern/_match.rs for another pertinent example of this pattern).
+                    //
+                    // Also, for performance, it's important to only do the second `try_to_bits` if
+                    // necessary.
+                    let lo = lo.try_to_bits(sz).unwrap() ^ bias;
+                    if lo <= min {
+                        let hi = hi.try_to_bits(sz).unwrap() ^ bias;
+                        if hi > max || hi == max && end == RangeEnd::Included {
                             // Irrefutable pattern match.
                             return Ok(());
                         }

--- a/compiler/rustc_mir_build/src/build/matches/test.rs
+++ b/compiler/rustc_mir_build/src/build/matches/test.rs
@@ -639,16 +639,13 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     return Some(0);
                 }
 
-                let tcx = self.tcx;
-                let test_ty = test.lo.ty();
-
                 // For performance, it's important to only do the second
                 // `compare_const_vals` if necessary.
                 let no_overlap = if matches!(
-                    (compare_const_vals(tcx, test.hi, pat.lo, self.param_env, test_ty)?, test.end),
+                    (compare_const_vals(self.tcx, test.hi, pat.lo, self.param_env)?, test.end),
                     (Less, _) | (Equal, RangeEnd::Excluded) // test < pat
                 ) || matches!(
-                    (compare_const_vals(tcx, test.lo, pat.hi, self.param_env, test_ty)?, pat.end),
+                    (compare_const_vals(self.tcx, test.lo, pat.hi, self.param_env)?, pat.end),
                     (Greater, _) | (Equal, RangeEnd::Excluded) // test > pat
                 ) {
                     Some(1)
@@ -762,15 +759,12 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
     ) -> Option<bool> {
         use std::cmp::Ordering::*;
 
-        let tcx = self.tcx;
-        let param_env = self.param_env;
-        let ty = range.lo.ty();
         // For performance, it's important to only do the second
         // `compare_const_vals` if necessary.
         Some(
-            matches!(compare_const_vals(tcx, range.lo, value, param_env, ty)?, Less | Equal)
+            matches!(compare_const_vals(self.tcx, range.lo, value, self.param_env)?, Less | Equal)
                 && matches!(
-                    (compare_const_vals(tcx, value, range.hi, param_env, ty)?, range.end),
+                    (compare_const_vals(self.tcx, value, range.hi, self.param_env)?, range.end),
                     (Less, _) | (Equal, RangeEnd::Included)
                 ),
         )

--- a/compiler/rustc_mir_build/src/thir/pattern/deconstruct_pat.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/deconstruct_pat.rs
@@ -848,16 +848,7 @@ impl<'tcx> Constructor<'tcx> {
             (Str(self_val), Str(other_val)) => {
                 // FIXME Once valtrees are available we can directly use the bytes
                 // in the `Str` variant of the valtree for the comparison here.
-                match compare_const_vals(
-                    pcx.cx.tcx,
-                    *self_val,
-                    *other_val,
-                    pcx.cx.param_env,
-                    pcx.ty,
-                ) {
-                    Some(comparison) => comparison == Ordering::Equal,
-                    None => false,
-                }
+                self_val == other_val
             }
             (Slice(self_slice), Slice(other_slice)) => self_slice.is_covered_by(*other_slice),
 

--- a/compiler/rustc_mir_build/src/thir/pattern/deconstruct_pat.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/deconstruct_pat.rs
@@ -828,14 +828,8 @@ impl<'tcx> Constructor<'tcx> {
                 FloatRange(other_from, other_to, other_end),
             ) => {
                 match (
-                    compare_const_vals(pcx.cx.tcx, *self_to, *other_to, pcx.cx.param_env, pcx.ty),
-                    compare_const_vals(
-                        pcx.cx.tcx,
-                        *self_from,
-                        *other_from,
-                        pcx.cx.param_env,
-                        pcx.ty,
-                    ),
+                    compare_const_vals(pcx.cx.tcx, *self_to, *other_to, pcx.cx.param_env),
+                    compare_const_vals(pcx.cx.tcx, *self_from, *other_from, pcx.cx.param_env),
                 ) {
                     (Some(to), Some(from)) => {
                         (from == Ordering::Greater || from == Ordering::Equal)

--- a/compiler/rustc_mir_build/src/thir/pattern/mod.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/mod.rs
@@ -755,15 +755,11 @@ pub(crate) fn compare_const_vals<'tcx>(
     ty: Ty<'tcx>,
 ) -> Option<Ordering> {
     assert_eq!(a.ty(), b.ty());
+    assert_eq!(a.ty(), ty);
 
     let from_bool = |v: bool| v.then_some(Ordering::Equal);
 
     let fallback = || from_bool(a == b);
-
-    // Use the fallback if any type differs
-    if a.ty() != ty {
-        return fallback();
-    }
 
     if a == b {
         return from_bool(true);

--- a/compiler/rustc_mir_build/src/thir/pattern/mod.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/mod.rs
@@ -754,12 +754,14 @@ pub(crate) fn compare_const_vals<'tcx>(
     param_env: ty::ParamEnv<'tcx>,
     ty: Ty<'tcx>,
 ) -> Option<Ordering> {
+    assert_eq!(a.ty(), b.ty());
+
     let from_bool = |v: bool| v.then_some(Ordering::Equal);
 
     let fallback = || from_bool(a == b);
 
     // Use the fallback if any type differs
-    if a.ty() != b.ty() || a.ty() != ty {
+    if a.ty() != ty {
         return fallback();
     }
 

--- a/compiler/rustc_mir_build/src/thir/pattern/mod.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/mod.rs
@@ -757,10 +757,8 @@ pub(crate) fn compare_const_vals<'tcx>(
     assert_eq!(a.ty(), b.ty());
     assert_eq!(a.ty(), ty);
 
-    let from_bool = |v: bool| v.then_some(Ordering::Equal);
-
     if a == b {
-        return from_bool(true);
+        return Some(Ordering::Equal);
     }
 
     let a_bits = a.try_eval_bits(tcx, param_env, ty);
@@ -790,5 +788,5 @@ pub(crate) fn compare_const_vals<'tcx>(
         };
     }
 
-    from_bool(a == b)
+    None
 }

--- a/compiler/rustc_mir_build/src/thir/pattern/mod.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/mod.rs
@@ -128,7 +128,7 @@ impl<'a, 'tcx> PatCtxt<'a, 'tcx> {
     ) -> PatKind<'tcx> {
         assert_eq!(lo.ty(), ty);
         assert_eq!(hi.ty(), ty);
-        let cmp = compare_const_vals(self.tcx, lo, hi, self.param_env, ty);
+        let cmp = compare_const_vals(self.tcx, lo, hi, self.param_env);
         match (end, cmp) {
             // `x..y` where `x < y`.
             // Non-empty because the range includes at least `x`.
@@ -752,15 +752,14 @@ pub(crate) fn compare_const_vals<'tcx>(
     a: mir::ConstantKind<'tcx>,
     b: mir::ConstantKind<'tcx>,
     param_env: ty::ParamEnv<'tcx>,
-    ty: Ty<'tcx>,
 ) -> Option<Ordering> {
     assert_eq!(a.ty(), b.ty());
-    assert_eq!(a.ty(), ty);
 
     if a == b {
         return Some(Ordering::Equal);
     }
 
+    let ty = a.ty();
     let a_bits = a.try_eval_bits(tcx, param_env, ty);
     let b_bits = b.try_eval_bits(tcx, param_env, ty);
 

--- a/compiler/rustc_mir_build/src/thir/pattern/mod.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/mod.rs
@@ -15,7 +15,6 @@ use rustc_hir::def::{CtorOf, DefKind, Res};
 use rustc_hir::pat_util::EnumerateAndAdjustIterator;
 use rustc_hir::RangeEnd;
 use rustc_index::vec::Idx;
-use rustc_middle::mir::interpret::{get_slice_bytes, ConstValue};
 use rustc_middle::mir::interpret::{ErrorHandled, LitToConstError, LitToConstInput};
 use rustc_middle::mir::{self, UserTypeProjection};
 use rustc_middle::mir::{BorrowKind, Field, Mutability};
@@ -793,16 +792,6 @@ pub(crate) fn compare_const_vals<'tcx>(
             }
             _ => Some(a.cmp(&b)),
         };
-    }
-
-    if let ty::Str = ty.kind() && let (
-        Some(a_val @ ConstValue::Slice { .. }),
-        Some(b_val @ ConstValue::Slice { .. }),
-    ) = (a.try_to_value(tcx), b.try_to_value(tcx))
-    {
-        let a_bytes = get_slice_bytes(&tcx, a_val);
-        let b_bytes = get_slice_bytes(&tcx, b_val);
-        return from_bool(a_bytes == b_bytes);
     }
 
     fallback()

--- a/compiler/rustc_mir_build/src/thir/pattern/mod.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/mod.rs
@@ -759,8 +759,6 @@ pub(crate) fn compare_const_vals<'tcx>(
 
     let from_bool = |v: bool| v.then_some(Ordering::Equal);
 
-    let fallback = || from_bool(a == b);
-
     if a == b {
         return from_bool(true);
     }
@@ -792,5 +790,5 @@ pub(crate) fn compare_const_vals<'tcx>(
         };
     }
 
-    fallback()
+    from_bool(a == b)
 }


### PR DESCRIPTION
Various optimizations and cleanups aimed at improving compilation of `unicode-normalization`, which is notable for having several very large `match`es with many char ranges.

Best reviewed one commit at a time.

r? @oli-obk 