### PR TITLE
Explicitly deref in float partial_eq

### DIFF
--- a/library/core/src/cmp.rs
+++ b/library/core/src/cmp.rs
@@ -1349,7 +1349,7 @@ mod impls {
             impl PartialOrd for $t {
                 #[inline]
                 fn partial_cmp(&self, other: &$t) -> Option<Ordering> {
-                    match (self <= other, self >= other) {
+                    match ((*self) <= (*other), (*self) >= (*other)) {
                         (false, false) => None,
                         (false, true) => Some(Greater),
                         (true, false) => Some(Less),

--- a/library/core/src/cmp.rs
+++ b/library/core/src/cmp.rs
@@ -1349,7 +1349,7 @@ mod impls {
             impl PartialOrd for $t {
                 #[inline]
                 fn partial_cmp(&self, other: &$t) -> Option<Ordering> {
-                    match ((*self) <= (*other), (*self) >= (*other)) {
+                    match (*self <= *other, *self >= *other) {
                         (false, false) => None,
                         (false, true) => Some(Greater),
                         (true, false) => Some(Less),


### PR DESCRIPTION
The current code will not results bug, but it difficult to understand. These code result to call &f32::partial_cmp(), and the performance will be lower than the changed code. I'm not sure why the current code don't use (*self) (*other), if you have some idea, please let me know.