### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/compiler/rustc_error_codes/src/error_codes/E0451.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0451.md
@@ -3,14 +3,14 @@ A struct constructor with private fields was invoked.
 Erroneous code example:
 
 ```compile_fail,E0451
-mod Bar {
+mod bar {
     pub struct Foo {
         pub a: isize,
         b: isize,
     }
 }
 
-let f = Bar::Foo{ a: 0, b: 0 }; // error: field `b` of struct `Bar::Foo`
+let f = bar::Foo{ a: 0, b: 0 }; // error: field `b` of struct `bar::Foo`
                                 //        is private
 ```
 
@@ -18,20 +18,20 @@ To fix this error, please ensure that all the fields of the struct are public,
 or implement a function for easy instantiation. Examples:
 
 ```
-mod Bar {
+mod bar {
     pub struct Foo {
         pub a: isize,
         pub b: isize, // we set `b` field public
     }
 }
 
-let f = Bar::Foo{ a: 0, b: 0 }; // ok!
+let f = bar::Foo{ a: 0, b: 0 }; // ok!
 ```
 
 Or:
 
 ```
-mod Bar {
+mod bar {
     pub struct Foo {
         pub a: isize,
         b: isize, // still private
@@ -44,5 +44,5 @@ mod Bar {
     }
 }
 
-let f = Bar::Foo::new(); // ok!
+let f = bar::Foo::new(); // ok!
 ```

--- a/compiler/rustc_error_codes/src/error_codes/E0574.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0574.md
@@ -4,9 +4,9 @@ expected.
 Erroneous code example:
 
 ```compile_fail,E0574
-mod Mordor {}
+mod mordor {}
 
-let sauron = Mordor { x: () }; // error!
+let sauron = mordor { x: () }; // error!
 
 enum Jak {
     Daxter { i: isize },
@@ -19,17 +19,17 @@ match eco {
 ```
 
 In all these errors, a type was expected. For example, in the first error,
-we tried to instantiate the `Mordor` module, which is impossible. If you want
+we tried to instantiate the `mordor` module, which is impossible. If you want
 to instantiate a type inside a module, you can do it as follow:
 
 ```
-mod Mordor {
+mod mordor {
     pub struct TheRing {
         pub x: usize,
     }
 }
 
-let sauron = Mordor::TheRing { x: 1 }; // ok!
+let sauron = mordor::TheRing { x: 1 }; // ok!
 ```
 
 In the second error, we tried to bind the `Jak` enum directly, which is not

--- a/compiler/rustc_error_codes/src/error_codes/E0577.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0577.md
@@ -3,21 +3,21 @@ Something other than a module was found in visibility scope.
 Erroneous code example:
 
 ```compile_fail,E0577,edition2018
-pub struct Sea;
+pub struct sea;
 
-pub (in crate::Sea) struct Shark; // error!
+pub (in crate::sea) struct Shark; // error!
 
 fn main() {}
 ```
 
-`Sea` is not a module, therefore it is invalid to use it in a visibility path.
-To fix this error we need to ensure `Sea` is a module.
+`sea` is not a module, therefore it is invalid to use it in a visibility path.
+To fix this error we need to ensure `sea` is a module.
 
 Please note that the visibility scope can only be applied on ancestors!
 
 ```edition2018
-pub mod Sea {
-    pub (in crate::Sea) struct Shark; // ok!
+pub mod sea {
+    pub (in crate::sea) struct Shark; // ok!
 }
 
 fn main() {}

--- a/compiler/rustc_error_codes/src/error_codes/E0577.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0577.md
@@ -3,14 +3,14 @@ Something other than a module was found in visibility scope.
 Erroneous code example:
 
 ```compile_fail,E0577,edition2018
-pub struct sea;
+pub struct Sea;
 
-pub (in crate::sea) struct Shark; // error!
+pub (in crate::Sea) struct Shark; // error!
 
 fn main() {}
 ```
 
-`sea` is not a module, therefore it is invalid to use it in a visibility path.
+`Sea` is not a module, therefore it is invalid to use it in a visibility path.
 To fix this error we need to ensure `sea` is a module.
 
 Please note that the visibility scope can only be applied on ancestors!

--- a/compiler/rustc_error_codes/src/error_codes/E0603.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0603.md
@@ -3,13 +3,13 @@ A private item was used outside its scope.
 Erroneous code example:
 
 ```compile_fail,E0603
-mod SomeModule {
+mod foo {
     const PRIVATE: u32 = 0x_a_bad_1dea_u32; // This const is private, so we
                                             // can't use it outside of the
-                                            // `SomeModule` module.
+                                            // `foo` module.
 }
 
-println!("const value: {}", SomeModule::PRIVATE); // error: constant `PRIVATE`
+println!("const value: {}", foo::PRIVATE); // error: constant `PRIVATE`
                                                   //        is private
 ```
 
@@ -17,10 +17,10 @@ In order to fix this error, you need to make the item public by using the `pub`
 keyword. Example:
 
 ```
-mod SomeModule {
+mod foo {
     pub const PRIVATE: u32 = 0x_a_bad_1dea_u32; // We set it public by using the
                                                 // `pub` keyword.
 }
 
-println!("const value: {}", SomeModule::PRIVATE); // ok!
+println!("const value: {}", foo::PRIVATE); // ok!
 ```

--- a/compiler/rustc_error_codes/src/error_codes/E0742.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0742.md
@@ -4,18 +4,18 @@ item.
 Erroneous code example:
 
 ```compile_fail,E0742,edition2018
-pub mod Sea {}
+pub mod sea {}
 
-pub (in crate::Sea) struct Shark; // error!
+pub (in crate::sea) struct Shark; // error!
 
 fn main() {}
 ```
 
-To fix this error, we need to move the `Shark` struct inside the `Sea` module:
+To fix this error, we need to move the `Shark` struct inside the `sea` module:
 
 ```edition2018
-pub mod Sea {
-    pub (in crate::Sea) struct Shark; // ok!
+pub mod sea {
+    pub (in crate::sea) struct Shark; // ok!
 }
 
 fn main() {}
@@ -25,9 +25,9 @@ Of course, you can do it as long as the module you're referring to is an
 ancestor:
 
 ```edition2018
-pub mod Earth {
-    pub mod Sea {
-        pub (in crate::Earth) struct Shark; // ok!
+pub mod earth {
+    pub mod sea {
+        pub (in crate::earth) struct Shark; // ok!
     }
 }
 

--- a/compiler/rustc_expand/src/lib.rs
+++ b/compiler/rustc_expand/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(rustc::potential_query_instability)]
+#![feature(array_windows)]
 #![feature(associated_type_bounds)]
 #![feature(associated_type_defaults)]
 #![feature(if_let_guard)]

--- a/compiler/rustc_expand/src/mbe/macro_rules.rs
+++ b/compiler/rustc_expand/src/mbe/macro_rules.rs
@@ -539,11 +539,11 @@ pub fn compile_declarative_macro(
         None => {}
     }
 
-    // Compute the spans of the macro rules
-    // We only take the span of the lhs here,
-    // so that the spans of created warnings are smaller.
+    // Compute the spans of the macro rules for unused rule linting.
+    // To avoid warning noise, only consider the rules of this
+    // macro for the lint, if all rules are valid.
     // Also, we are only interested in non-foreign macros.
-    let rule_spans = if def.id != DUMMY_NODE_ID {
+    let rule_spans = if valid && def.id != DUMMY_NODE_ID {
         lhses
             .iter()
             .zip(rhses.iter())
@@ -551,6 +551,8 @@ pub fn compile_declarative_macro(
             // If the rhs contains an invocation like compile_error!,
             // don't consider the rule for the unused rule lint.
             .filter(|(_idx, (_lhs, rhs))| !has_compile_error_macro(rhs))
+            // We only take the span of the lhs here,
+            // so that the spans of created warnings are smaller.
             .map(|(idx, (lhs, _rhs))| (idx, lhs.span()))
             .collect::<Vec<_>>()
     } else {

--- a/compiler/rustc_middle/src/thir.rs
+++ b/compiler/rustc_middle/src/thir.rs
@@ -191,6 +191,20 @@ pub enum StmtKind<'tcx> {
 #[cfg(all(target_arch = "x86_64", target_pointer_width = "64"))]
 rustc_data_structures::static_assert_size!(Expr<'_>, 104);
 
+#[derive(
+    Clone,
+    Debug,
+    Copy,
+    PartialEq,
+    Eq,
+    Hash,
+    HashStable,
+    TyEncodable,
+    TyDecodable,
+    TypeFoldable
+)]
+pub struct LocalVarId(pub hir::HirId);
+
 /// A THIR expression.
 #[derive(Clone, Debug, HashStable)]
 pub struct Expr<'tcx> {
@@ -332,7 +346,7 @@ pub enum ExprKind<'tcx> {
     },
     /// A local variable.
     VarRef {
-        id: hir::HirId,
+        id: LocalVarId,
     },
     /// Used to represent upvars mentioned in a closure/generator
     UpvarRef {
@@ -340,7 +354,7 @@ pub enum ExprKind<'tcx> {
         closure_def_id: DefId,
 
         /// HirId of the root variable
-        var_hir_id: hir::HirId,
+        var_hir_id: LocalVarId,
     },
     /// A borrow, e.g. `&arg`.
     Borrow {
@@ -596,7 +610,7 @@ pub enum PatKind<'tcx> {
         mutability: Mutability,
         name: Symbol,
         mode: BindingMode,
-        var: hir::HirId,
+        var: LocalVarId,
         ty: Ty<'tcx>,
         subpattern: Option<Pat<'tcx>>,
         /// Is this the leftmost occurrence of the binding, i.e., is `var` the

--- a/compiler/rustc_mir_build/src/thir/cx/expr.rs
+++ b/compiler/rustc_mir_build/src/thir/cx/expr.rs
@@ -903,9 +903,12 @@ impl<'tcx> Cx<'tcx> {
         );
 
         if is_upvar {
-            ExprKind::UpvarRef { closure_def_id: self.body_owner, var_hir_id }
+            ExprKind::UpvarRef {
+                closure_def_id: self.body_owner,
+                var_hir_id: LocalVarId(var_hir_id),
+            }
         } else {
-            ExprKind::VarRef { id: var_hir_id }
+            ExprKind::VarRef { id: LocalVarId(var_hir_id) }
         }
     }
 

--- a/compiler/rustc_mir_build/src/thir/pattern/mod.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/mod.rs
@@ -19,7 +19,7 @@ use rustc_middle::mir::interpret::{get_slice_bytes, ConstValue};
 use rustc_middle::mir::interpret::{ErrorHandled, LitToConstError, LitToConstInput};
 use rustc_middle::mir::{self, UserTypeProjection};
 use rustc_middle::mir::{BorrowKind, Field, Mutability};
-use rustc_middle::thir::{Ascription, BindingMode, FieldPat, Pat, PatKind, PatRange};
+use rustc_middle::thir::{Ascription, BindingMode, FieldPat, LocalVarId, Pat, PatKind, PatRange};
 use rustc_middle::ty::subst::{GenericArg, SubstsRef};
 use rustc_middle::ty::CanonicalUserTypeAnnotation;
 use rustc_middle::ty::{self, AdtDef, ConstKind, DefIdTree, Region, Ty, TyCtxt, UserType};
@@ -288,7 +288,7 @@ impl<'a, 'tcx> PatCtxt<'a, 'tcx> {
                     mutability,
                     mode,
                     name: ident.name,
-                    var: id,
+                    var: LocalVarId(id),
                     ty: var_ty,
                     subpattern: self.lower_opt_pattern(sub),
                     is_primary: id == pat.hir_id,
@@ -664,7 +664,7 @@ macro_rules! ClonePatternFoldableImpls {
 }
 
 ClonePatternFoldableImpls! { <'tcx>
-    Span, Field, Mutability, Symbol, hir::HirId, usize, ty::Const<'tcx>,
+    Span, Field, Mutability, Symbol, LocalVarId, usize, ty::Const<'tcx>,
     Region<'tcx>, Ty<'tcx>, BindingMode, AdtDef<'tcx>,
     SubstsRef<'tcx>, &'tcx GenericArg<'tcx>, UserType<'tcx>,
     UserTypeProjection, CanonicalUserTypeAnnotation<'tcx>

--- a/compiler/rustc_resolve/src/build_reduced_graph.rs
+++ b/compiler/rustc_resolve/src/build_reduced_graph.rs
@@ -1220,12 +1220,12 @@ impl<'a, 'b> BuildReducedGraphVisitor<'a, 'b> {
         ident: Ident,
         def_id: LocalDefId,
         node_id: NodeId,
-        rule_spans: &[Span],
+        rule_spans: &[(usize, Span)],
     ) {
         if !ident.as_str().starts_with('_') {
             self.r.unused_macros.insert(def_id, (node_id, ident));
-            for (rule_i, rule_span) in rule_spans.iter().enumerate() {
-                self.r.unused_macro_rules.insert((def_id, rule_i), (ident, *rule_span));
+            for (rule_i, rule_span) in rule_spans.iter() {
+                self.r.unused_macro_rules.insert((def_id, *rule_i), (ident, *rule_span));
             }
         }
     }

--- a/compiler/rustc_resolve/src/macros.rs
+++ b/compiler/rustc_resolve/src/macros.rs
@@ -870,7 +870,7 @@ impl<'a> Resolver<'a> {
         &mut self,
         item: &ast::Item,
         edition: Edition,
-    ) -> (SyntaxExtension, Vec<Span>) {
+    ) -> (SyntaxExtension, Vec<(usize, Span)>) {
         let (mut result, mut rule_spans) = compile_declarative_macro(
             &self.session,
             self.session.features_untracked(),

--- a/compiler/rustc_target/src/spec/wasm32_unknown_emscripten.rs
+++ b/compiler/rustc_target/src/spec/wasm32_unknown_emscripten.rs
@@ -16,11 +16,7 @@ pub fn target() -> Target {
     let mut post_link_args = LinkArgs::new();
     post_link_args.insert(
         LinkerFlavor::Em,
-        vec![
-            "-s".into(),
-            "ABORTING_MALLOC=0".into(),
-            "-Wl,--fatal-warnings".into(),
-        ],
+        vec!["-sABORTING_MALLOC=0".into(), "-Wl,--fatal-warnings".into()],
     );
 
     let opts = TargetOptions {

--- a/compiler/rustc_target/src/spec/wasm32_unknown_emscripten.rs
+++ b/compiler/rustc_target/src/spec/wasm32_unknown_emscripten.rs
@@ -18,8 +18,6 @@ pub fn target() -> Target {
         LinkerFlavor::Em,
         vec![
             "-s".into(),
-            "ERROR_ON_UNDEFINED_SYMBOLS=1".into(),
-            "-s".into(),
             "ABORTING_MALLOC=0".into(),
             "-Wl,--fatal-warnings".into(),
         ],

--- a/compiler/rustc_target/src/spec/wasm32_unknown_emscripten.rs
+++ b/compiler/rustc_target/src/spec/wasm32_unknown_emscripten.rs
@@ -20,8 +20,6 @@ pub fn target() -> Target {
             "-s".into(),
             "ERROR_ON_UNDEFINED_SYMBOLS=1".into(),
             "-s".into(),
-            "ASSERTIONS=1".into(),
-            "-s".into(),
             "ABORTING_MALLOC=0".into(),
             "-Wl,--fatal-warnings".into(),
         ],

--- a/library/core/src/hash/sip.rs
+++ b/library/core/src/hash/sip.rs
@@ -38,7 +38,7 @@ struct SipHasher24 {
 /// SipHash is a general-purpose hashing function: it runs at a good
 /// speed (competitive with Spooky and City) and permits strong _keyed_
 /// hashing. This lets you key your hash tables from a strong RNG, such as
-/// [`rand::os::OsRng`](https://doc.rust-lang.org/rand/rand/os/struct.OsRng.html).
+/// [`rand::os::OsRng`](https://docs.rs/rand/latest/rand/rngs/struct.OsRng.html).
 ///
 /// Although the SipHash algorithm is considered to be generally strong,
 /// it is not intended for cryptographic purposes. As such, all

--- a/library/core/src/mem/maybe_uninit.rs
+++ b/library/core/src/mem/maybe_uninit.rs
@@ -865,7 +865,7 @@ impl<T> MaybeUninit<T> {
     ///
     /// For instance, you cannot [`Read`] into an uninitialized buffer:
     ///
-    /// [`Read`]: https://doc.rust-lang.org/std/io/trait.Read.html
+    /// [`Read`]: ../../std/io/trait.Read.html
     ///
     /// ```rust,no_run
     /// use std::{io, mem::MaybeUninit};

--- a/src/test/ui/lint/unused/unused-macro-rules-compile-error.rs
+++ b/src/test/ui/lint/unused/unused-macro-rules-compile-error.rs
@@ -1,0 +1,27 @@
+#![deny(unused_macro_rules)]
+// To make sure we are not hitting this
+#![deny(unused_macros)]
+
+macro_rules! num {
+    (one) => { 1 };
+    // Most simple (and common) case
+    (two) => { compile_error!("foo"); };
+    // Some nested use
+    (two_) => { foo(compile_error!("foo")); };
+    (three) => { 3 };
+    (four) => { 4 }; //~ ERROR: rule of macro
+}
+const _NUM: u8 = num!(one) + num!(three);
+
+// compile_error not used as a macro invocation
+macro_rules! num2 {
+    (one) => { 1 };
+    // Only identifier present
+    (two) => { fn compile_error() {} }; //~ ERROR: rule of macro
+    // Only identifier and bang present
+    (two_) => { compile_error! }; //~ ERROR: rule of macro
+    (three) => { 3 };
+}
+const _NUM2: u8 = num2!(one) + num2!(three);
+
+fn main() {}

--- a/src/test/ui/lint/unused/unused-macro-rules-compile-error.stderr
+++ b/src/test/ui/lint/unused/unused-macro-rules-compile-error.stderr
@@ -1,0 +1,26 @@
+error: 5th rule of macro `num` is never used
+  --> $DIR/unused-macro-rules-compile-error.rs:12:5
+   |
+LL |     (four) => { 4 };
+   |     ^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/unused-macro-rules-compile-error.rs:1:9
+   |
+LL | #![deny(unused_macro_rules)]
+   |         ^^^^^^^^^^^^^^^^^^
+
+error: 3rd rule of macro `num2` is never used
+  --> $DIR/unused-macro-rules-compile-error.rs:22:5
+   |
+LL |     (two_) => { compile_error! };
+   |     ^^^^^^
+
+error: 2nd rule of macro `num2` is never used
+  --> $DIR/unused-macro-rules-compile-error.rs:20:5
+   |
+LL |     (two) => { fn compile_error() {} };
+   |     ^^^^^
+
+error: aborting due to 3 previous errors
+

--- a/src/test/ui/lint/unused/unused-macro-rules-malformed-rule.rs
+++ b/src/test/ui/lint/unused/unused-macro-rules-malformed-rule.rs
@@ -1,0 +1,11 @@
+#![deny(unused_macro_rules)]
+
+macro_rules! foo {
+    (v) => {};
+    (w) => {};
+    () => 0; //~ ERROR: macro rhs must be delimited
+}
+
+fn main() {
+    foo!(v);
+}

--- a/src/test/ui/lint/unused/unused-macro-rules-malformed-rule.stderr
+++ b/src/test/ui/lint/unused/unused-macro-rules-malformed-rule.stderr
@@ -1,0 +1,8 @@
+error: macro rhs must be delimited
+  --> $DIR/unused-macro-rules-malformed-rule.rs:6:11
+   |
+LL |     () => 0;
+   |           ^
+
+error: aborting due to previous error
+

--- a/src/test/ui/lint/unused/unused-macros-malformed-rule.rs
+++ b/src/test/ui/lint/unused/unused-macros-malformed-rule.rs
@@ -1,0 +1,15 @@
+#![deny(unused_macros)]
+
+macro_rules! foo { //~ ERROR: unused macro definition
+    (v) => {};
+    () => 0; //~ ERROR: macro rhs must be delimited
+}
+
+macro_rules! bar {
+    (v) => {};
+    () => 0; //~ ERROR: macro rhs must be delimited
+}
+
+fn main() {
+    bar!(v);
+}

--- a/src/test/ui/lint/unused/unused-macros-malformed-rule.stderr
+++ b/src/test/ui/lint/unused/unused-macros-malformed-rule.stderr
@@ -1,0 +1,26 @@
+error: macro rhs must be delimited
+  --> $DIR/unused-macros-malformed-rule.rs:5:11
+   |
+LL |     () => 0;
+   |           ^
+
+error: macro rhs must be delimited
+  --> $DIR/unused-macros-malformed-rule.rs:10:11
+   |
+LL |     () => 0;
+   |           ^
+
+error: unused macro definition: `foo`
+  --> $DIR/unused-macros-malformed-rule.rs:3:14
+   |
+LL | macro_rules! foo {
+   |              ^^^
+   |
+note: the lint level is defined here
+  --> $DIR/unused-macros-malformed-rule.rs:1:9
+   |
+LL | #![deny(unused_macros)]
+   |         ^^^^^^^^^^^^^
+
+error: aborting due to 3 previous errors
+


### PR DESCRIPTION
Successful merges:

 - #97903 (Never regard macro rules with compile_error! invocations as unused)
 - #97913 (Wrap `HirId`s of locals into `LocalVarId`s for THIR nodes)
 - #97928 (Removes debug settings from wasm32_unknown_emscripten default link args)
 - #97940 (Use relative links instead of linking to doc.rust-lang.org when possible)
 - #97941 (nit: Fixed several error_codes/Exxxx.md messages which used UpperCamelCase…)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=97903,97913,97928,97940,97941)
<!-- homu-ignore:end -->