### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/compiler/rustc_codegen_llvm/src/back/write.rs
+++ b/compiler/rustc_codegen_llvm/src/back/write.rs
@@ -56,28 +56,24 @@ pub fn write_output_file<'ll>(
     file_type: llvm::FileType,
     self_profiler_ref: &SelfProfilerRef,
 ) -> Result<(), FatalError> {
+    debug!("write_output_file output={:?} dwo_output={:?}", output, dwo_output);
     unsafe {
         let output_c = path_to_c_string(output);
-        let result = if let Some(dwo_output) = dwo_output {
-            let dwo_output_c = path_to_c_string(dwo_output);
-            llvm::LLVMRustWriteOutputFile(
-                target,
-                pm,
-                m,
-                output_c.as_ptr(),
-                dwo_output_c.as_ptr(),
-                file_type,
-            )
+        let dwo_output_c;
+        let dwo_output_ptr = if let Some(dwo_output) = dwo_output {
+            dwo_output_c = path_to_c_string(dwo_output);
+            dwo_output_c.as_ptr()
         } else {
-            llvm::LLVMRustWriteOutputFile(
-                target,
-                pm,
-                m,
-                output_c.as_ptr(),
-                std::ptr::null(),
-                file_type,
-            )
+            std::ptr::null()
         };
+        let result = llvm::LLVMRustWriteOutputFile(
+            target,
+            pm,
+            m,
+            output_c.as_ptr(),
+            dwo_output_ptr,
+            file_type,
+        );
 
         // Record artifact sizes for self-profiling
         if result == llvm::LLVMRustResult::Success {

--- a/compiler/rustc_error_codes/src/error_codes/E0451.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0451.md
@@ -3,14 +3,14 @@ A struct constructor with private fields was invoked.
 Erroneous code example:
 
 ```compile_fail,E0451
-mod Bar {
+mod bar {
     pub struct Foo {
         pub a: isize,
         b: isize,
     }
 }
 
-let f = Bar::Foo{ a: 0, b: 0 }; // error: field `b` of struct `Bar::Foo`
+let f = bar::Foo{ a: 0, b: 0 }; // error: field `b` of struct `bar::Foo`
                                 //        is private
 ```
 
@@ -18,20 +18,20 @@ To fix this error, please ensure that all the fields of the struct are public,
 or implement a function for easy instantiation. Examples:
 
 ```
-mod Bar {
+mod bar {
     pub struct Foo {
         pub a: isize,
         pub b: isize, // we set `b` field public
     }
 }
 
-let f = Bar::Foo{ a: 0, b: 0 }; // ok!
+let f = bar::Foo{ a: 0, b: 0 }; // ok!
 ```
 
 Or:
 
 ```
-mod Bar {
+mod bar {
     pub struct Foo {
         pub a: isize,
         b: isize, // still private
@@ -44,5 +44,5 @@ mod Bar {
     }
 }
 
-let f = Bar::Foo::new(); // ok!
+let f = bar::Foo::new(); // ok!
 ```

--- a/compiler/rustc_error_codes/src/error_codes/E0574.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0574.md
@@ -4,9 +4,9 @@ expected.
 Erroneous code example:
 
 ```compile_fail,E0574
-mod Mordor {}
+mod mordor {}
 
-let sauron = Mordor { x: () }; // error!
+let sauron = mordor { x: () }; // error!
 
 enum Jak {
     Daxter { i: isize },
@@ -19,17 +19,17 @@ match eco {
 ```
 
 In all these errors, a type was expected. For example, in the first error,
-we tried to instantiate the `Mordor` module, which is impossible. If you want
+we tried to instantiate the `mordor` module, which is impossible. If you want
 to instantiate a type inside a module, you can do it as follow:
 
 ```
-mod Mordor {
+mod mordor {
     pub struct TheRing {
         pub x: usize,
     }
 }
 
-let sauron = Mordor::TheRing { x: 1 }; // ok!
+let sauron = mordor::TheRing { x: 1 }; // ok!
 ```
 
 In the second error, we tried to bind the `Jak` enum directly, which is not

--- a/compiler/rustc_error_codes/src/error_codes/E0577.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0577.md
@@ -3,21 +3,21 @@ Something other than a module was found in visibility scope.
 Erroneous code example:
 
 ```compile_fail,E0577,edition2018
-pub struct Sea;
+pub struct sea;
 
-pub (in crate::Sea) struct Shark; // error!
+pub (in crate::sea) struct Shark; // error!
 
 fn main() {}
 ```
 
-`Sea` is not a module, therefore it is invalid to use it in a visibility path.
-To fix this error we need to ensure `Sea` is a module.
+`sea` is not a module, therefore it is invalid to use it in a visibility path.
+To fix this error we need to ensure `sea` is a module.
 
 Please note that the visibility scope can only be applied on ancestors!
 
 ```edition2018
-pub mod Sea {
-    pub (in crate::Sea) struct Shark; // ok!
+pub mod sea {
+    pub (in crate::sea) struct Shark; // ok!
 }
 
 fn main() {}

--- a/compiler/rustc_error_codes/src/error_codes/E0577.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0577.md
@@ -3,14 +3,14 @@ Something other than a module was found in visibility scope.
 Erroneous code example:
 
 ```compile_fail,E0577,edition2018
-pub struct sea;
+pub struct Sea;
 
-pub (in crate::sea) struct Shark; // error!
+pub (in crate::Sea) struct Shark; // error!
 
 fn main() {}
 ```
 
-`sea` is not a module, therefore it is invalid to use it in a visibility path.
+`Sea` is not a module, therefore it is invalid to use it in a visibility path.
 To fix this error we need to ensure `sea` is a module.
 
 Please note that the visibility scope can only be applied on ancestors!

--- a/compiler/rustc_error_codes/src/error_codes/E0603.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0603.md
@@ -3,13 +3,13 @@ A private item was used outside its scope.
 Erroneous code example:
 
 ```compile_fail,E0603
-mod SomeModule {
+mod foo {
     const PRIVATE: u32 = 0x_a_bad_1dea_u32; // This const is private, so we
                                             // can't use it outside of the
-                                            // `SomeModule` module.
+                                            // `foo` module.
 }
 
-println!("const value: {}", SomeModule::PRIVATE); // error: constant `PRIVATE`
+println!("const value: {}", foo::PRIVATE); // error: constant `PRIVATE`
                                                   //        is private
 ```
 
@@ -17,10 +17,10 @@ In order to fix this error, you need to make the item public by using the `pub`
 keyword. Example:
 
 ```
-mod SomeModule {
+mod foo {
     pub const PRIVATE: u32 = 0x_a_bad_1dea_u32; // We set it public by using the
                                                 // `pub` keyword.
 }
 
-println!("const value: {}", SomeModule::PRIVATE); // ok!
+println!("const value: {}", foo::PRIVATE); // ok!
 ```

--- a/compiler/rustc_error_codes/src/error_codes/E0742.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0742.md
@@ -4,18 +4,18 @@ item.
 Erroneous code example:
 
 ```compile_fail,E0742,edition2018
-pub mod Sea {}
+pub mod sea {}
 
-pub (in crate::Sea) struct Shark; // error!
+pub (in crate::sea) struct Shark; // error!
 
 fn main() {}
 ```
 
-To fix this error, we need to move the `Shark` struct inside the `Sea` module:
+To fix this error, we need to move the `Shark` struct inside the `sea` module:
 
 ```edition2018
-pub mod Sea {
-    pub (in crate::Sea) struct Shark; // ok!
+pub mod sea {
+    pub (in crate::sea) struct Shark; // ok!
 }
 
 fn main() {}
@@ -25,9 +25,9 @@ Of course, you can do it as long as the module you're referring to is an
 ancestor:
 
 ```edition2018
-pub mod Earth {
-    pub mod Sea {
-        pub (in crate::Earth) struct Shark; // ok!
+pub mod earth {
+    pub mod sea {
+        pub (in crate::earth) struct Shark; // ok!
     }
 }
 

--- a/compiler/rustc_target/src/spec/wasm32_unknown_emscripten.rs
+++ b/compiler/rustc_target/src/spec/wasm32_unknown_emscripten.rs
@@ -16,11 +16,7 @@ pub fn target() -> Target {
     let mut post_link_args = LinkArgs::new();
     post_link_args.insert(
         LinkerFlavor::Em,
-        vec![
-            "-s".into(),
-            "ABORTING_MALLOC=0".into(),
-            "-Wl,--fatal-warnings".into(),
-        ],
+        vec!["-sABORTING_MALLOC=0".into(), "-Wl,--fatal-warnings".into()],
     );
 
     let opts = TargetOptions {

--- a/compiler/rustc_target/src/spec/wasm32_unknown_emscripten.rs
+++ b/compiler/rustc_target/src/spec/wasm32_unknown_emscripten.rs
@@ -18,8 +18,6 @@ pub fn target() -> Target {
         LinkerFlavor::Em,
         vec![
             "-s".into(),
-            "ERROR_ON_UNDEFINED_SYMBOLS=1".into(),
-            "-s".into(),
             "ABORTING_MALLOC=0".into(),
             "-Wl,--fatal-warnings".into(),
         ],

--- a/compiler/rustc_target/src/spec/wasm32_unknown_emscripten.rs
+++ b/compiler/rustc_target/src/spec/wasm32_unknown_emscripten.rs
@@ -20,8 +20,6 @@ pub fn target() -> Target {
             "-s".into(),
             "ERROR_ON_UNDEFINED_SYMBOLS=1".into(),
             "-s".into(),
-            "ASSERTIONS=1".into(),
-            "-s".into(),
             "ABORTING_MALLOC=0".into(),
             "-Wl,--fatal-warnings".into(),
         ],

--- a/library/core/src/hash/sip.rs
+++ b/library/core/src/hash/sip.rs
@@ -38,7 +38,7 @@ struct SipHasher24 {
 /// SipHash is a general-purpose hashing function: it runs at a good
 /// speed (competitive with Spooky and City) and permits strong _keyed_
 /// hashing. This lets you key your hash tables from a strong RNG, such as
-/// [`rand::os::OsRng`](https://doc.rust-lang.org/rand/rand/os/struct.OsRng.html).
+/// [`rand::os::OsRng`](https://docs.rs/rand/latest/rand/rngs/struct.OsRng.html).
 ///
 /// Although the SipHash algorithm is considered to be generally strong,
 /// it is not intended for cryptographic purposes. As such, all

--- a/library/core/src/mem/maybe_uninit.rs
+++ b/library/core/src/mem/maybe_uninit.rs
@@ -865,7 +865,7 @@ impl<T> MaybeUninit<T> {
     ///
     /// For instance, you cannot [`Read`] into an uninitialized buffer:
     ///
-    /// [`Read`]: https://doc.rust-lang.org/std/io/trait.Read.html
+    /// [`Read`]: ../../std/io/trait.Read.html
     ///
     /// ```rust,no_run
     /// use std::{io, mem::MaybeUninit};

--- a/src/test/ui/lifetimes/issue-54378.rs
+++ b/src/test/ui/lifetimes/issue-54378.rs
@@ -1,0 +1,26 @@
+// check-pass
+
+// Regression test for #54378.
+
+#![feature(never_type)]
+
+use std::marker::PhantomData;
+
+pub trait Machine<'a, 'mir, 'tcx>: Sized {
+    type MemoryKinds: ::std::fmt::Debug + Copy + Eq;
+    const MUT_STATIC_KIND: Option<Self::MemoryKinds>;
+}
+
+pub struct CompileTimeEvaluator<'a, 'mir, 'tcx: 'a+'mir> {
+    pub _data: PhantomData<(&'a (), &'mir (), &'tcx ())>,
+}
+
+impl<'a, 'mir, 'tcx: 'a + 'mir> Machine<'a, 'mir, 'tcx>
+    for CompileTimeEvaluator<'a, 'mir, 'tcx>
+{
+    type MemoryKinds = !;
+
+    const MUT_STATIC_KIND: Option<!> = None;
+}
+
+fn main() {}

--- a/src/test/ui/suggestions/suggest-std-when-using-type.fixed
+++ b/src/test/ui/suggestions/suggest-std-when-using-type.fixed
@@ -1,8 +1,8 @@
 // run-rustfix
 fn main() {
-    let pi = f32::consts::PI; //~ ERROR ambiguous associated type
+    let pi = std::f32::consts::PI; //~ ERROR ambiguous associated type
     let bytes = "hello world".as_bytes();
-    let string = str::from_utf8(bytes).unwrap();
+    let string = std::str::from_utf8(bytes).unwrap();
     //~^ ERROR no function or associated item named `from_utf8` found
     println!("{pi} {bytes:?} {string}");
 }

--- a/src/test/ui/suggestions/suggest-std-when-using-type.stderr
+++ b/src/test/ui/suggestions/suggest-std-when-using-type.stderr
@@ -1,5 +1,5 @@
 error[E0223]: ambiguous associated type
-  --> $DIR/suggest-std-when-using-type.rs:2:14
+  --> $DIR/suggest-std-when-using-type.rs:3:14
    |
 LL |     let pi = f32::consts::PI;
    |              ^^^^^^^^^^^
@@ -10,15 +10,15 @@ LL |     let pi = std::f32::consts::PI;
    |              +++++
 
 error[E0599]: no function or associated item named `from_utf8` found for type `str` in the current scope
-  --> $DIR/suggest-std-when-using-type.rs:5:14
+  --> $DIR/suggest-std-when-using-type.rs:5:23
    |
-LL |         str::from_utf8(bytes)
-   |              ^^^^^^^^^ function or associated item not found in `str`
+LL |     let string = str::from_utf8(bytes).unwrap();
+   |                       ^^^^^^^^^ function or associated item not found in `str`
    |
 help: you are looking for the module in `std`, not the primitive type
    |
-LL |         std::str::from_utf8(bytes)
-   |         +++++
+LL |     let string = std::str::from_utf8(bytes).unwrap();
+   |                  +++++
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION
Successful merges:

 - #93331 (refactor write_output_file to merge two invocation paths into one.)
 - #97928 (Removes debug settings from wasm32_unknown_emscripten default link args)
 - #97940 (Use relative links instead of linking to doc.rust-lang.org when possible)
 - #97941 (nit: Fixed several error_codes/Exxxx.md messages which used UpperCamelCase…)
 - #97953 (Add regression test for #54378)
 - #97957 (Make `std::` prefix suggestion test `run-rustfix`)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=93331,97928,97940,97941,97953,97957)
<!-- homu-ignore:end -->