### PR TITLE
Make -Cpasses= only apply to pre-link optimization

### DIFF
--- a/compiler/rustc_codegen_llvm/src/back/write.rs
+++ b/compiler/rustc_codegen_llvm/src/back/write.rs
@@ -467,7 +467,7 @@ pub(crate) unsafe fn optimize_with_new_llvm_pass_manager(
     let llvm_selfprofiler =
         llvm_profiler.as_mut().map(|s| s as *mut _ as *mut c_void).unwrap_or(std::ptr::null_mut());
 
-    let extra_passes = config.passes.join(",");
+    let extra_passes = if !is_lto { config.passes.join(",") } else { "".to_string() };
 
     let llvm_plugins = config.llvm_plugins.join(",");
 


### PR DESCRIPTION
This change causes passes specified in -Cpasses= to be applied
only during pre-link optimization, not during LTO. This avoids
such passes running multiple times, which they may not be
designed for.

Fixes https://github.com/rust-lang/rust/issues/97713