### PR TITLE
Update #[doc(html_playground_url)] documentation to mention what the request will be

### DIFF
--- a/src/doc/rustdoc/src/write-documentation/the-doc-attribute.md
+++ b/src/doc/rustdoc/src/write-documentation/the-doc-attribute.md
@@ -87,7 +87,9 @@ on your documentation examples make requests to.
 #![doc(html_playground_url = "https://playground.example.com/")]
 ```
 
-Now, when you press "run", the button will make a request to this domain.
+Now, when you press "run", the button will make a request to this domain. The request 
+URL will contain 2 query parameters: `code` and `edition` for the code in the documentation
+and the Rust edition respectively. 
 
 If you don't use this attribute, there will be no run buttons.
 

--- a/src/doc/rustdoc/src/write-documentation/the-doc-attribute.md
+++ b/src/doc/rustdoc/src/write-documentation/the-doc-attribute.md
@@ -87,9 +87,9 @@ on your documentation examples make requests to.
 #![doc(html_playground_url = "https://playground.example.com/")]
 ```
 
-Now, when you press "run", the button will make a request to this domain. The request 
+Now, when you press "run", the button will make a request to this domain. The request
 URL will contain 2 query parameters: `code` and `edition` for the code in the documentation
-and the Rust edition respectively. 
+and the Rust edition respectively.
 
 If you don't use this attribute, there will be no run buttons.
 


### PR DESCRIPTION
The [documentation for `#![doc(html_playground_url = "_")]`](https://doc.rust-lang.org/rustdoc/write-documentation/the-doc-attribute.html#html_playground_url) specifies that a request will be made to the given URL but does specify what the contents of the request will be. This PR updates the documentation to include the query parameters through which the code is provided to the playground.