### PR TITLE
Make a test `check-pass` because it passes even though it was marked to fail

### DIFF
--- a/src/test/ui/specialization/issue-38091-2.rs
+++ b/src/test/ui/specialization/issue-38091-2.rs
@@ -1,6 +1,4 @@
-// build-fail
-//~^ ERROR overflow evaluating the requirement `i32: Check`
-
+// check-pass
 #![feature(specialization)]
 //~^ WARN the feature `specialization` is incomplete
 

--- a/src/test/ui/specialization/issue-38091-2.stderr
+++ b/src/test/ui/specialization/issue-38091-2.stderr
@@ -1,5 +1,5 @@
 warning: the feature `specialization` is incomplete and may not be safe to use and/or cause compiler crashes
-  --> $DIR/issue-38091-2.rs:4:12
+  --> $DIR/issue-38091-2.rs:2:12
    |
 LL | #![feature(specialization)]
    |            ^^^^^^^^^^^^^^
@@ -8,14 +8,5 @@ LL | #![feature(specialization)]
    = note: see issue #31844 <https://github.com/rust-lang/rust/issues/31844> for more information
    = help: consider using `min_specialization` instead, which is more stable and complete
 
-error[E0275]: overflow evaluating the requirement `i32: Check`
-   |
-note: required because of the requirements on the impl of `Iterate` for `i32`
-  --> $DIR/issue-38091-2.rs:11:13
-   |
-LL | impl<'a, T> Iterate<'a> for T
-   |             ^^^^^^^^^^^     ^
+warning: 1 warning emitted
 
-error: aborting due to previous error; 1 warning emitted
-
-For more information about this error, try `rustc --explain E0275`.


### PR DESCRIPTION
I'm not entirely sure why this test "passed" despite it being marked `build-fail` and having a stderr file when actually running the code in the test would succeed with only a warning :sweat_smile:  