### PR TITLE
`ValuePairs::PolyTraitRefs` should be called "trait"s in type error diagnostics

### DIFF
--- a/compiler/rustc_infer/src/infer/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/mod.rs
@@ -1588,7 +1588,9 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                             Mismatch::Variable(infer::ExpectedFound { expected, found }),
                         )
                     }
-                    ValuePairs::TraitRefs(_) => (false, Mismatch::Fixed("trait")),
+                    ValuePairs::TraitRefs(_) | ValuePairs::PolyTraitRefs(_) => {
+                        (false, Mismatch::Fixed("trait"))
+                    }
                     _ => (false, Mismatch::Fixed("type")),
                 };
                 let vals = match self.values_str(values) {

--- a/src/test/ui/generator/resume-arg-late-bound.stderr
+++ b/src/test/ui/generator/resume-arg-late-bound.stderr
@@ -4,8 +4,8 @@ error[E0308]: mismatched types
 LL |     test(gen);
    |     ^^^^^^^^^ one type is more general than the other
    |
-   = note: expected type `for<'a> Generator<&'a mut bool>`
-              found type `Generator<&mut bool>`
+   = note: expected trait `for<'a> Generator<&'a mut bool>`
+              found trait `Generator<&mut bool>`
 note: the lifetime requirement is introduced here
   --> $DIR/resume-arg-late-bound.rs:8:17
    |

--- a/src/test/ui/higher-rank-trait-bounds/normalize-under-binder/issue-71955.stderr
+++ b/src/test/ui/higher-rank-trait-bounds/normalize-under-binder/issue-71955.stderr
@@ -4,8 +4,8 @@ error[E0308]: mismatched types
 LL |     foo(bar, "string", |s| s.len() == 5);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ one type is more general than the other
    |
-   = note: expected type `for<'r, 's> FnOnce<(&'r &'s str,)>`
-              found type `for<'r> FnOnce<(&'r &str,)>`
+   = note: expected trait `for<'r, 's> FnOnce<(&'r &'s str,)>`
+              found trait `for<'r> FnOnce<(&'r &str,)>`
 note: this closure does not fulfill the lifetime requirements
   --> $DIR/issue-71955.rs:45:24
    |
@@ -23,8 +23,8 @@ error[E0308]: mismatched types
 LL |     foo(bar, "string", |s| s.len() == 5);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ one type is more general than the other
    |
-   = note: expected type `FnOnce<(&&str,)>`
-              found type `for<'r> FnOnce<(&'r &str,)>`
+   = note: expected trait `FnOnce<(&&str,)>`
+              found trait `for<'r> FnOnce<(&'r &str,)>`
 note: this closure does not fulfill the lifetime requirements
   --> $DIR/issue-71955.rs:45:24
    |
@@ -42,8 +42,8 @@ error[E0308]: mismatched types
 LL |     foo(baz, "string", |s| s.0.len() == 5);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ one type is more general than the other
    |
-   = note: expected type `for<'r, 's> FnOnce<(&'r Wrapper<'s>,)>`
-              found type `for<'r> FnOnce<(&'r Wrapper<'_>,)>`
+   = note: expected trait `for<'r, 's> FnOnce<(&'r Wrapper<'s>,)>`
+              found trait `for<'r> FnOnce<(&'r Wrapper<'_>,)>`
 note: this closure does not fulfill the lifetime requirements
   --> $DIR/issue-71955.rs:48:24
    |
@@ -61,8 +61,8 @@ error[E0308]: mismatched types
 LL |     foo(baz, "string", |s| s.0.len() == 5);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ one type is more general than the other
    |
-   = note: expected type `FnOnce<(&Wrapper<'_>,)>`
-              found type `for<'r> FnOnce<(&'r Wrapper<'_>,)>`
+   = note: expected trait `FnOnce<(&Wrapper<'_>,)>`
+              found trait `for<'r> FnOnce<(&'r Wrapper<'_>,)>`
 note: this closure does not fulfill the lifetime requirements
   --> $DIR/issue-71955.rs:48:24
    |

--- a/src/test/ui/issues/issue-27942.stderr
+++ b/src/test/ui/issues/issue-27942.stderr
@@ -4,8 +4,8 @@ error[E0308]: mismatched types
 LL |     fn select(&self) -> BufferViewHandle<R>;
    |                         ^^^^^^^^^^^^^^^^^^^ lifetime mismatch
    |
-   = note: expected type `Resources<'_>`
-              found type `Resources<'a>`
+   = note: expected trait `Resources<'_>`
+              found trait `Resources<'a>`
 note: the anonymous lifetime defined here...
   --> $DIR/issue-27942.rs:5:15
    |
@@ -23,8 +23,8 @@ error[E0308]: mismatched types
 LL |     fn select(&self) -> BufferViewHandle<R>;
    |                         ^^^^^^^^^^^^^^^^^^^ lifetime mismatch
    |
-   = note: expected type `Resources<'_>`
-              found type `Resources<'a>`
+   = note: expected trait `Resources<'_>`
+              found trait `Resources<'a>`
 note: the lifetime `'a` as defined here...
   --> $DIR/issue-27942.rs:3:18
    |

--- a/src/test/ui/lifetimes/issue-79187-2.stderr
+++ b/src/test/ui/lifetimes/issue-79187-2.stderr
@@ -31,8 +31,8 @@ error[E0308]: mismatched types
 LL |     take_foo(|a| a);
    |     ^^^^^^^^^^^^^^^ one type is more general than the other
    |
-   = note: expected type `for<'r> Fn<(&'r i32,)>`
-              found type `Fn<(&i32,)>`
+   = note: expected trait `for<'r> Fn<(&'r i32,)>`
+              found trait `Fn<(&i32,)>`
 note: this closure does not fulfill the lifetime requirements
   --> $DIR/issue-79187-2.rs:8:14
    |

--- a/src/test/ui/lifetimes/issue-79187.stderr
+++ b/src/test/ui/lifetimes/issue-79187.stderr
@@ -4,8 +4,8 @@ error[E0308]: mismatched types
 LL |     thing(f);
    |     ^^^^^^^^ one type is more general than the other
    |
-   = note: expected type `for<'r> FnOnce<(&'r u32,)>`
-              found type `FnOnce<(&u32,)>`
+   = note: expected trait `for<'r> FnOnce<(&'r u32,)>`
+              found trait `FnOnce<(&u32,)>`
 note: this closure does not fulfill the lifetime requirements
   --> $DIR/issue-79187.rs:4:13
    |

--- a/src/test/ui/lifetimes/lifetime-errors/issue_74400.stderr
+++ b/src/test/ui/lifetimes/lifetime-errors/issue_74400.stderr
@@ -15,8 +15,8 @@ error[E0308]: mismatched types
 LL |     f(data, identity)
    |     ^^^^^^^^^^^^^^^^^ one type is more general than the other
    |
-   = note: expected type `for<'r> Fn<(&'r T,)>`
-              found type `Fn<(&T,)>`
+   = note: expected trait `for<'r> Fn<(&'r T,)>`
+              found trait `Fn<(&T,)>`
 note: the lifetime requirement is introduced here
   --> $DIR/issue_74400.rs:8:34
    |

--- a/src/test/ui/mismatched_types/closure-mismatch.stderr
+++ b/src/test/ui/mismatched_types/closure-mismatch.stderr
@@ -13,8 +13,8 @@ error[E0308]: mismatched types
 LL |     baz(|_| ());
    |     ^^^^^^^^^^^ one type is more general than the other
    |
-   = note: expected type `for<'r> Fn<(&'r (),)>`
-              found type `Fn<(&(),)>`
+   = note: expected trait `for<'r> Fn<(&'r (),)>`
+              found trait `Fn<(&(),)>`
 note: this closure does not fulfill the lifetime requirements
   --> $DIR/closure-mismatch.rs:8:9
    |

--- a/src/test/ui/rfc1623.stderr
+++ b/src/test/ui/rfc1623.stderr
@@ -4,8 +4,8 @@ error[E0308]: mismatched types
 LL |     f: &id,
    |        ^^^ one type is more general than the other
    |
-   = note: expected type `for<'a, 'b> Fn<(&'a Foo<'b>,)>`
-              found type `Fn<(&Foo<'_>,)>`
+   = note: expected trait `for<'a, 'b> Fn<(&'a Foo<'b>,)>`
+              found trait `Fn<(&Foo<'_>,)>`
 
 error[E0308]: mismatched types
   --> $DIR/rfc1623.rs:28:8
@@ -13,8 +13,8 @@ error[E0308]: mismatched types
 LL |     f: &id,
    |        ^^^ one type is more general than the other
    |
-   = note: expected type `for<'a, 'b> Fn<(&'a Foo<'b>,)>`
-              found type `Fn<(&Foo<'_>,)>`
+   = note: expected trait `for<'a, 'b> Fn<(&'a Foo<'b>,)>`
+              found trait `Fn<(&Foo<'_>,)>`
 
 error: implementation of `FnOnce` is not general enough
   --> $DIR/rfc1623.rs:28:8

--- a/src/test/ui/type-alias-impl-trait/issue-57611-trait-alias.stderr
+++ b/src/test/ui/type-alias-impl-trait/issue-57611-trait-alias.stderr
@@ -4,8 +4,8 @@ error[E0308]: mismatched types
 LL |         |x| x
    |         ^^^^^ one type is more general than the other
    |
-   = note: expected type `for<'r> Fn<(&'r X,)>`
-              found type `Fn<(&X,)>`
+   = note: expected trait `for<'r> Fn<(&'r X,)>`
+              found trait `Fn<(&X,)>`
 note: this closure does not fulfill the lifetime requirements
   --> $DIR/issue-57611-trait-alias.rs:21:9
    |


### PR DESCRIPTION
Pretty simple, we already do this for `ValuePairs::TraitRefs`...