### PR TITLE
Fix erroneous span for borrowck error

### DIFF
--- a/src/test/ui/hrtb/hrtb-just-for-static.stderr
+++ b/src/test/ui/hrtb/hrtb-just-for-static.stderr
@@ -2,7 +2,7 @@ error: implementation of `Foo` is not general enough
   --> $DIR/hrtb-just-for-static.rs:24:5
    |
 LL |     want_hrtb::<StaticInt>()
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^ implementation of `Foo` is not general enough
+   |     ^^^^^^^^^^^^^^^^^^^^^^ implementation of `Foo` is not general enough
    |
    = note: `StaticInt` must implement `Foo<&'0 isize>`, for any lifetime `'0`...
    = note: ...but it actually implements `Foo<&'static isize>`

--- a/src/test/ui/nll/issue-97997.rs
+++ b/src/test/ui/nll/issue-97997.rs
@@ -1,0 +1,16 @@
+trait Foo {
+    const ASSOC: bool = true;
+}
+impl<T> Foo for fn(T) {}
+
+fn foo(_x: i32) {}
+
+fn impls_foo<T: Foo>(_x: T) {}
+
+fn main() {
+    impls_foo(foo as fn(i32));
+
+    <fn(&u8) as Foo>::ASSOC;
+    //~^ ERROR implementation of `Foo` is not general enough
+    //~| ERROR implementation of `Foo` is not general enough
+}

--- a/src/test/ui/nll/issue-97997.stderr
+++ b/src/test/ui/nll/issue-97997.stderr
@@ -1,0 +1,20 @@
+error: implementation of `Foo` is not general enough
+  --> $DIR/issue-97997.rs:13:5
+   |
+LL |     <fn(&u8) as Foo>::ASSOC;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^ implementation of `Foo` is not general enough
+   |
+   = note: `Foo` would have to be implemented for the type `for<'r> fn(&'r u8)`
+   = note: ...but `Foo` is actually implemented for the type `fn(&'0 u8)`, for some specific lifetime `'0`
+
+error: implementation of `Foo` is not general enough
+  --> $DIR/issue-97997.rs:13:5
+   |
+LL |     <fn(&u8) as Foo>::ASSOC;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^ implementation of `Foo` is not general enough
+   |
+   = note: `Foo` would have to be implemented for the type `for<'r> fn(&'r u8)`
+   = note: ...but `Foo` is actually implemented for the type `fn(&'0 u8)`, for some specific lifetime `'0`
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
I am not confident that this is the correct fix, but it does the job. Open to suggestions for a real fix instead.

Fixes #97997

The issue is that we pass a [dummy location](https://doc.rust-lang.org/nightly/nightly-rustc/src/rustc_middle/mir/visit.rs.html#302) when type-checking the ["required consts"](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_middle/mir/struct.Body.html#structfield.required_consts) that are needed by the MIR body during borrowck. This means that when we fail to evaluate the constant, we use the span of `bb0[0]`, instead of the actual span of the constant.

There are quite a few other places that use `START_BLOCK.start_location()`, `Location::START`, etc. when calling for a random/unspecified `Location` value. This is because, unlike (for example) `Span`, we don't have a dummy/miscellaneous value to use instead. I would appreciate guidance (either in this PR, or a follow-up) on what needs to be done to clean this up in general.