### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/compiler/rustc_infer/src/infer/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/mod.rs
@@ -1588,7 +1588,9 @@ impl<'a, 'tcx> InferCtxt<'a, 'tcx> {
                             Mismatch::Variable(infer::ExpectedFound { expected, found }),
                         )
                     }
-                    ValuePairs::TraitRefs(_) => (false, Mismatch::Fixed("trait")),
+                    ValuePairs::TraitRefs(_) | ValuePairs::PolyTraitRefs(_) => {
+                        (false, Mismatch::Fixed("trait"))
+                    }
                     _ => (false, Mismatch::Fixed("type")),
                 };
                 let vals = match self.values_str(values) {

--- a/library/alloc/src/str.rs
+++ b/library/alloc/src/str.rs
@@ -271,6 +271,7 @@ impl str {
     /// let s = "this is old";
     ///
     /// assert_eq!("this is new", s.replace("old", "new"));
+    /// assert_eq!("than an old", s.replace("is", "an"));
     /// ```
     ///
     /// When the pattern doesn't match:

--- a/library/core/src/sync/atomic.rs
+++ b/library/core/src/sync/atomic.rs
@@ -350,7 +350,7 @@ impl AtomicBool {
     /// # Examples
     ///
     /// ```
-    /// #![feature(atomic_from_mut, inline_const, scoped_threads)]
+    /// #![feature(atomic_from_mut, inline_const)]
     /// use std::sync::atomic::{AtomicBool, Ordering};
     ///
     /// let mut some_bools = [const { AtomicBool::new(false) }; 10];
@@ -381,7 +381,7 @@ impl AtomicBool {
     /// # Examples
     ///
     /// ```
-    /// #![feature(atomic_from_mut, scoped_threads)]
+    /// #![feature(atomic_from_mut)]
     /// use std::sync::atomic::{AtomicBool, Ordering};
     ///
     /// let mut some_bools = [false; 10];
@@ -1015,7 +1015,7 @@ impl<T> AtomicPtr<T> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(atomic_from_mut, inline_const, scoped_threads)]
+    /// #![feature(atomic_from_mut, inline_const)]
     /// use std::ptr::null_mut;
     /// use std::sync::atomic::{AtomicPtr, Ordering};
     ///
@@ -1052,7 +1052,7 @@ impl<T> AtomicPtr<T> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(atomic_from_mut, scoped_threads)]
+    /// #![feature(atomic_from_mut)]
     /// use std::ptr::null_mut;
     /// use std::sync::atomic::{AtomicPtr, Ordering};
     ///
@@ -1607,7 +1607,7 @@ macro_rules! atomic_int {
             /// # Examples
             ///
             /// ```
-            /// #![feature(atomic_from_mut, inline_const, scoped_threads)]
+            /// #![feature(atomic_from_mut, inline_const)]
             #[doc = concat!($extra_feature, "use std::sync::atomic::{", stringify!($atomic_type), ", Ordering};")]
             ///
             #[doc = concat!("let mut some_ints = [const { ", stringify!($atomic_type), "::new(0) }; 10];")]
@@ -1640,7 +1640,7 @@ macro_rules! atomic_int {
             /// # Examples
             ///
             /// ```
-            /// #![feature(atomic_from_mut, scoped_threads)]
+            /// #![feature(atomic_from_mut)]
             #[doc = concat!($extra_feature, "use std::sync::atomic::{", stringify!($atomic_type), ", Ordering};")]
             ///
             /// let mut some_ints = [0; 10];

--- a/library/std/src/process.rs
+++ b/library/std/src/process.rs
@@ -2161,7 +2161,9 @@ impl Termination for ! {
 impl<E: fmt::Debug> Termination for Result<!, E> {
     fn report(self) -> ExitCode {
         let Err(err) = self;
-        eprintln!("Error: {err:?}");
+        // Ignore error if the write fails, for example because stderr is
+        // already closed. There is not much point panicking at this point.
+        let _ = writeln!(io::stderr(), "Error: {err:?}");
         ExitCode::FAILURE
     }
 }

--- a/library/std/src/thread/mod.rs
+++ b/library/std/src/thread/mod.rs
@@ -183,10 +183,10 @@ use crate::time::Duration;
 #[macro_use]
 mod local;
 
-#[unstable(feature = "scoped_threads", issue = "93203")]
+#[stable(feature = "scoped_threads", since = "1.63.0")]
 mod scoped;
 
-#[unstable(feature = "scoped_threads", issue = "93203")]
+#[stable(feature = "scoped_threads", since = "1.63.0")]
 pub use scoped::{scope, Scope, ScopedJoinHandle};
 
 #[stable(feature = "rust1", since = "1.0.0")]

--- a/library/std/src/thread/scoped.rs
+++ b/library/std/src/thread/scoped.rs
@@ -9,6 +9,7 @@ use crate::sync::Arc;
 /// A scope to spawn scoped threads in.
 ///
 /// See [`scope`] for details.
+#[stable(feature = "scoped_threads", since = "1.63.0")]
 pub struct Scope<'scope, 'env: 'scope> {
     data: ScopeData,
     /// Invariance over 'scope, to make sure 'scope cannot shrink,
@@ -17,8 +18,6 @@ pub struct Scope<'scope, 'env: 'scope> {
     /// Without invariance, this would compile fine but be unsound:
     ///
     /// ```compile_fail,E0373
-    /// #![feature(scoped_threads)]
-    ///
     /// std::thread::scope(|s| {
     ///     s.spawn(|| {
     ///         let a = String::from("abcd");
@@ -33,6 +32,7 @@ pub struct Scope<'scope, 'env: 'scope> {
 /// An owned permission to join on a scoped thread (block on its termination).
 ///
 /// See [`Scope::spawn`] for details.
+#[stable(feature = "scoped_threads", since = "1.63.0")]
 pub struct ScopedJoinHandle<'scope, T>(JoinInner<'scope, T>);
 
 pub(super) struct ScopeData {
@@ -82,7 +82,6 @@ impl ScopeData {
 /// # Example
 ///
 /// ```
-/// #![feature(scoped_threads)]
 /// use std::thread;
 ///
 /// let mut a = vec![1, 2, 3];
@@ -126,6 +125,7 @@ impl ScopeData {
 ///
 /// The `'env: 'scope` bound is part of the definition of the `Scope` type.
 #[track_caller]
+#[stable(feature = "scoped_threads", since = "1.63.0")]
 pub fn scope<'env, F, T>(f: F) -> T
 where
     F: for<'scope> FnOnce(&'scope Scope<'scope, 'env>) -> T,
@@ -183,6 +183,7 @@ impl<'scope, 'env> Scope<'scope, 'env> {
     /// to recover from such errors.
     ///
     /// [`join`]: ScopedJoinHandle::join
+    #[stable(feature = "scoped_threads", since = "1.63.0")]
     pub fn spawn<F, T>(&'scope self, f: F) -> ScopedJoinHandle<'scope, T>
     where
         F: FnOnce() -> T + Send + 'scope,
@@ -207,7 +208,6 @@ impl Builder {
     /// # Example
     ///
     /// ```
-    /// #![feature(scoped_threads)]
     /// use std::thread;
     ///
     /// let mut a = vec![1, 2, 3];
@@ -240,6 +240,7 @@ impl Builder {
     /// a.push(4);
     /// assert_eq!(x, a.len());
     /// ```
+    #[stable(feature = "scoped_threads", since = "1.63.0")]
     pub fn spawn_scoped<'scope, 'env, F, T>(
         self,
         scope: &'scope Scope<'scope, 'env>,
@@ -259,8 +260,6 @@ impl<'scope, T> ScopedJoinHandle<'scope, T> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(scoped_threads)]
-    ///
     /// use std::thread;
     ///
     /// thread::scope(|s| {
@@ -271,6 +270,7 @@ impl<'scope, T> ScopedJoinHandle<'scope, T> {
     /// });
     /// ```
     #[must_use]
+    #[stable(feature = "scoped_threads", since = "1.63.0")]
     pub fn thread(&self) -> &Thread {
         &self.0.thread
     }
@@ -292,8 +292,6 @@ impl<'scope, T> ScopedJoinHandle<'scope, T> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(scoped_threads)]
-    ///
     /// use std::thread;
     ///
     /// thread::scope(|s| {
@@ -303,6 +301,7 @@ impl<'scope, T> ScopedJoinHandle<'scope, T> {
     ///     assert!(t.join().is_err());
     /// });
     /// ```
+    #[stable(feature = "scoped_threads", since = "1.63.0")]
     pub fn join(self) -> Result<T> {
         self.0.join()
     }
@@ -316,11 +315,13 @@ impl<'scope, T> ScopedJoinHandle<'scope, T> {
     ///
     /// This function does not block. To block while waiting on the thread to finish,
     /// use [`join`][Self::join].
+    #[stable(feature = "scoped_threads", since = "1.63.0")]
     pub fn is_finished(&self) -> bool {
         Arc::strong_count(&self.0.packet) == 1
     }
 }
 
+#[stable(feature = "scoped_threads", since = "1.63.0")]
 impl fmt::Debug for Scope<'_, '_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Scope")
@@ -331,6 +332,7 @@ impl fmt::Debug for Scope<'_, '_> {
     }
 }
 
+#[stable(feature = "scoped_threads", since = "1.63.0")]
 impl<'scope, T> fmt::Debug for ScopedJoinHandle<'scope, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ScopedJoinHandle").finish_non_exhaustive()

--- a/src/test/ui/generator/resume-arg-late-bound.stderr
+++ b/src/test/ui/generator/resume-arg-late-bound.stderr
@@ -4,8 +4,8 @@ error[E0308]: mismatched types
 LL |     test(gen);
    |     ^^^^^^^^^ one type is more general than the other
    |
-   = note: expected type `for<'a> Generator<&'a mut bool>`
-              found type `Generator<&mut bool>`
+   = note: expected trait `for<'a> Generator<&'a mut bool>`
+              found trait `Generator<&mut bool>`
 note: the lifetime requirement is introduced here
   --> $DIR/resume-arg-late-bound.rs:8:17
    |

--- a/src/test/ui/higher-rank-trait-bounds/normalize-under-binder/issue-71955.stderr
+++ b/src/test/ui/higher-rank-trait-bounds/normalize-under-binder/issue-71955.stderr
@@ -4,8 +4,8 @@ error[E0308]: mismatched types
 LL |     foo(bar, "string", |s| s.len() == 5);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ one type is more general than the other
    |
-   = note: expected type `for<'r, 's> FnOnce<(&'r &'s str,)>`
-              found type `for<'r> FnOnce<(&'r &str,)>`
+   = note: expected trait `for<'r, 's> FnOnce<(&'r &'s str,)>`
+              found trait `for<'r> FnOnce<(&'r &str,)>`
 note: this closure does not fulfill the lifetime requirements
   --> $DIR/issue-71955.rs:45:24
    |
@@ -23,8 +23,8 @@ error[E0308]: mismatched types
 LL |     foo(bar, "string", |s| s.len() == 5);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ one type is more general than the other
    |
-   = note: expected type `FnOnce<(&&str,)>`
-              found type `for<'r> FnOnce<(&'r &str,)>`
+   = note: expected trait `FnOnce<(&&str,)>`
+              found trait `for<'r> FnOnce<(&'r &str,)>`
 note: this closure does not fulfill the lifetime requirements
   --> $DIR/issue-71955.rs:45:24
    |
@@ -42,8 +42,8 @@ error[E0308]: mismatched types
 LL |     foo(baz, "string", |s| s.0.len() == 5);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ one type is more general than the other
    |
-   = note: expected type `for<'r, 's> FnOnce<(&'r Wrapper<'s>,)>`
-              found type `for<'r> FnOnce<(&'r Wrapper<'_>,)>`
+   = note: expected trait `for<'r, 's> FnOnce<(&'r Wrapper<'s>,)>`
+              found trait `for<'r> FnOnce<(&'r Wrapper<'_>,)>`
 note: this closure does not fulfill the lifetime requirements
   --> $DIR/issue-71955.rs:48:24
    |
@@ -61,8 +61,8 @@ error[E0308]: mismatched types
 LL |     foo(baz, "string", |s| s.0.len() == 5);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ one type is more general than the other
    |
-   = note: expected type `FnOnce<(&Wrapper<'_>,)>`
-              found type `for<'r> FnOnce<(&'r Wrapper<'_>,)>`
+   = note: expected trait `FnOnce<(&Wrapper<'_>,)>`
+              found trait `for<'r> FnOnce<(&'r Wrapper<'_>,)>`
 note: this closure does not fulfill the lifetime requirements
   --> $DIR/issue-71955.rs:48:24
    |

--- a/src/test/ui/issues/issue-27942.stderr
+++ b/src/test/ui/issues/issue-27942.stderr
@@ -4,8 +4,8 @@ error[E0308]: mismatched types
 LL |     fn select(&self) -> BufferViewHandle<R>;
    |                         ^^^^^^^^^^^^^^^^^^^ lifetime mismatch
    |
-   = note: expected type `Resources<'_>`
-              found type `Resources<'a>`
+   = note: expected trait `Resources<'_>`
+              found trait `Resources<'a>`
 note: the anonymous lifetime defined here...
   --> $DIR/issue-27942.rs:5:15
    |
@@ -23,8 +23,8 @@ error[E0308]: mismatched types
 LL |     fn select(&self) -> BufferViewHandle<R>;
    |                         ^^^^^^^^^^^^^^^^^^^ lifetime mismatch
    |
-   = note: expected type `Resources<'_>`
-              found type `Resources<'a>`
+   = note: expected trait `Resources<'_>`
+              found trait `Resources<'a>`
 note: the lifetime `'a` as defined here...
   --> $DIR/issue-27942.rs:3:18
    |

--- a/src/test/ui/lifetimes/issue-79187-2.stderr
+++ b/src/test/ui/lifetimes/issue-79187-2.stderr
@@ -31,8 +31,8 @@ error[E0308]: mismatched types
 LL |     take_foo(|a| a);
    |     ^^^^^^^^^^^^^^^ one type is more general than the other
    |
-   = note: expected type `for<'r> Fn<(&'r i32,)>`
-              found type `Fn<(&i32,)>`
+   = note: expected trait `for<'r> Fn<(&'r i32,)>`
+              found trait `Fn<(&i32,)>`
 note: this closure does not fulfill the lifetime requirements
   --> $DIR/issue-79187-2.rs:8:14
    |

--- a/src/test/ui/lifetimes/issue-79187.stderr
+++ b/src/test/ui/lifetimes/issue-79187.stderr
@@ -4,8 +4,8 @@ error[E0308]: mismatched types
 LL |     thing(f);
    |     ^^^^^^^^ one type is more general than the other
    |
-   = note: expected type `for<'r> FnOnce<(&'r u32,)>`
-              found type `FnOnce<(&u32,)>`
+   = note: expected trait `for<'r> FnOnce<(&'r u32,)>`
+              found trait `FnOnce<(&u32,)>`
 note: this closure does not fulfill the lifetime requirements
   --> $DIR/issue-79187.rs:4:13
    |

--- a/src/test/ui/lifetimes/lifetime-errors/issue_74400.stderr
+++ b/src/test/ui/lifetimes/lifetime-errors/issue_74400.stderr
@@ -15,8 +15,8 @@ error[E0308]: mismatched types
 LL |     f(data, identity)
    |     ^^^^^^^^^^^^^^^^^ one type is more general than the other
    |
-   = note: expected type `for<'r> Fn<(&'r T,)>`
-              found type `Fn<(&T,)>`
+   = note: expected trait `for<'r> Fn<(&'r T,)>`
+              found trait `Fn<(&T,)>`
 note: the lifetime requirement is introduced here
   --> $DIR/issue_74400.rs:8:34
    |

--- a/src/test/ui/mismatched_types/closure-mismatch.stderr
+++ b/src/test/ui/mismatched_types/closure-mismatch.stderr
@@ -13,8 +13,8 @@ error[E0308]: mismatched types
 LL |     baz(|_| ());
    |     ^^^^^^^^^^^ one type is more general than the other
    |
-   = note: expected type `for<'r> Fn<(&'r (),)>`
-              found type `Fn<(&(),)>`
+   = note: expected trait `for<'r> Fn<(&'r (),)>`
+              found trait `Fn<(&(),)>`
 note: this closure does not fulfill the lifetime requirements
   --> $DIR/closure-mismatch.rs:8:9
    |

--- a/src/test/ui/rfc1623.stderr
+++ b/src/test/ui/rfc1623.stderr
@@ -4,8 +4,8 @@ error[E0308]: mismatched types
 LL |     f: &id,
    |        ^^^ one type is more general than the other
    |
-   = note: expected type `for<'a, 'b> Fn<(&'a Foo<'b>,)>`
-              found type `Fn<(&Foo<'_>,)>`
+   = note: expected trait `for<'a, 'b> Fn<(&'a Foo<'b>,)>`
+              found trait `Fn<(&Foo<'_>,)>`
 
 error[E0308]: mismatched types
   --> $DIR/rfc1623.rs:28:8
@@ -13,8 +13,8 @@ error[E0308]: mismatched types
 LL |     f: &id,
    |        ^^^ one type is more general than the other
    |
-   = note: expected type `for<'a, 'b> Fn<(&'a Foo<'b>,)>`
-              found type `Fn<(&Foo<'_>,)>`
+   = note: expected trait `for<'a, 'b> Fn<(&'a Foo<'b>,)>`
+              found trait `Fn<(&Foo<'_>,)>`
 
 error: implementation of `FnOnce` is not general enough
   --> $DIR/rfc1623.rs:28:8

--- a/src/test/ui/type-alias-impl-trait/issue-57611-trait-alias.stderr
+++ b/src/test/ui/type-alias-impl-trait/issue-57611-trait-alias.stderr
@@ -4,8 +4,8 @@ error[E0308]: mismatched types
 LL |         |x| x
    |         ^^^^^ one type is more general than the other
    |
-   = note: expected type `for<'r> Fn<(&'r X,)>`
-              found type `Fn<(&X,)>`
+   = note: expected trait `for<'r> Fn<(&'r X,)>`
+              found trait `Fn<(&X,)>`
 note: this closure does not fulfill the lifetime requirements
   --> $DIR/issue-57611-trait-alias.rs:21:9
    |


### PR DESCRIPTION
Successful merges:

 - #97921 (additional docs example for replace **all** of str)
 - #97970 (Fix Termination impl panic on closed stderr)
 - #97991 (Use safer `strip=symbols`-flag for dylibs on macOS)
 - #97992 (Stabilize scoped threads.)
 - #98012 (`ValuePairs::PolyTraitRefs` should be called "trait"s in type error diagnostics)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=97921,97970,97991,97992,98012)
<!-- homu-ignore:end -->