### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/compiler/rustc_error_codes/src/error_codes.rs
+++ b/compiler/rustc_error_codes/src/error_codes.rs
@@ -528,7 +528,7 @@ E0788: include_str!("./error_codes/E0788.md"),
 //  E0190, // deprecated: can only cast a &-pointer to an &-object
 //  E0194, // merged into E0403
 //  E0196, // cannot determine a type for this closure
-    E0208,
+    E0208, // internal error code
 //  E0209, // builtin traits can only be implemented on structs or enums
 //  E0213, // associated types are not accepted in this context
 //  E0215, // angle-bracket notation is not stable with `Fn`
@@ -633,14 +633,14 @@ E0788: include_str!("./error_codes/E0788.md"),
 //  E0629, // missing 'feature' (rustc_const_unstable)
 //  E0630, // rustc_const_unstable attribute must be paired with stable/unstable
            // attribute
-    E0640, // infer outlives requirements
+    E0640, // infer outlives requirements, internal error code
 //  E0645, // trait aliases not finished
 //  E0694, // an unknown tool name found in scoped attributes
 //  E0702, // replaced with a generic attribute input check
 //  E0707, // multiple elided lifetimes used in arguments of `async fn`
 //  E0709, // multiple different lifetimes used in arguments of `async fn`
-    E0711, // a feature has been declared with conflicting stability attributes
-    E0717, // rustc_promotable without stability attribute
+    E0711, // a feature has been declared with conflicting stability attributes, internal error code
+    E0717, // rustc_promotable without stability attribute, internal error code
 //  E0721, // `await` keyword
 //  E0723, // unstable feature in `const` context
 //  E0738, // Removed; errored on `#[track_caller] fn`s in `extern "Rust" { ... }`.

--- a/library/core/src/cmp.rs
+++ b/library/core/src/cmp.rs
@@ -61,8 +61,8 @@ use self::Ordering::*;
 ///
 /// This trait can be used with `#[derive]`. When `derive`d on structs, two
 /// instances are equal if all fields are equal, and not equal if any fields
-/// are not equal. When `derive`d on enums, each variant is equal to itself
-/// and not equal to the other variants.
+/// are not equal. When `derive`d on enums, two instances are equal if they
+/// are the same variant and all fields are equal.
 ///
 /// ## How can I implement `PartialEq`?
 ///

--- a/src/test/ui/asm/x86_64/issue-82869.rs
+++ b/src/test/ui/asm/x86_64/issue-82869.rs
@@ -1,3 +1,4 @@
+// needs-asm-support
 // only-x86_64
 // Make sure rustc doesn't ICE on asm! for a foreign architecture.
 

--- a/src/test/ui/asm/x86_64/issue-82869.stderr
+++ b/src/test/ui/asm/x86_64/issue-82869.stderr
@@ -1,17 +1,17 @@
 error: invalid register class `vreg`: unknown register class
-  --> $DIR/issue-82869.rs:10:32
+  --> $DIR/issue-82869.rs:11:32
    |
 LL |     asm!("add {:d}, {:d}, d0", out(vreg) c, in(vreg) a, in("d0") {
    |                                ^^^^^^^^^^^
 
 error: invalid register class `vreg`: unknown register class
-  --> $DIR/issue-82869.rs:10:45
+  --> $DIR/issue-82869.rs:11:45
    |
 LL |     asm!("add {:d}, {:d}, d0", out(vreg) c, in(vreg) a, in("d0") {
    |                                             ^^^^^^^^^^
 
 error: invalid register `d0`: unknown register
-  --> $DIR/issue-82869.rs:10:57
+  --> $DIR/issue-82869.rs:11:57
    |
 LL |       asm!("add {:d}, {:d}, d0", out(vreg) c, in(vreg) a, in("d0") {
    |  _________________________________________________________^

--- a/src/test/ui/drop/repeat-drop.rs
+++ b/src/test/ui/drop/repeat-drop.rs
@@ -1,4 +1,5 @@
 // run-pass
+// needs-unwind
 // ignore-wasm32-bare no unwinding panic
 // ignore-avr no unwinding panic
 // ignore-nvptx64 no unwinding panic


### PR DESCRIPTION
Successful merges:

 - #97920 (Fix some test annotations)
 - #97950 (Clarify `#[derive(PartialEq)]` on enums)
 - #98011 (Add documentation for error E0208)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=97920,97950,98011)
<!-- homu-ignore:end -->