### PR TITLE
Fix generic impl rustdoc json output

### DIFF
--- a/src/test/rustdoc-json/generic_impl.rs
+++ b/src/test/rustdoc-json/generic_impl.rs
@@ -1,0 +1,24 @@
+// Regression test for <https://github.com/rust-lang/rust/issues/97986>.
+
+// @has generic_impl.json
+// @has - "$.index[*][?(@.name=='f')]"
+// @has - "$.index[*][?(@.name=='AssocTy')]"
+// @has - "$.index[*][?(@.name=='AssocConst')]"
+
+pub mod m {
+    pub struct S;
+}
+
+pub trait F {
+    type AssocTy;
+    const AssocConst: usize;
+    fn f() -> m::S;
+}
+
+impl<T> F for T {
+    type AssocTy = u32;
+    const AssocConst: usize = 0;
+    fn f() -> m::S {
+        m::S
+    }
+}


### PR DESCRIPTION
Fixes #97986.

The problem in case of generic trait impl is that the trait's items are the same for all the types afterward. But since they're the same, it's safe for rustdoc-json to just ignore them.

A little representation of what's going on:

```rust
trait T {
    fn f(); // <- defid 0
}

impl<Y> T for Y {
    fn f() {} // <- defid 1
}

struct S; // <- defid 1 (since it matches `impl<Y> T for Y`
```

cc @Urgau

r? @CraftSpider 