### PR TITLE
Fix error message for `download-ci-llvm`

### DIFF
--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -179,13 +179,13 @@ fn download_ci_llvm(builder: &Builder<'_>, llvm_sha: &str) {
     let filename = format!("rust-dev-nightly-{}.tar.xz", builder.build.build.triple);
     let tarball = rustc_cache.join(&filename);
     if !tarball.exists() {
-        let help_on_error = "error: failed to download llvm from ci\n
-\nhelp: old builds get deleted after a certain time
-\nhelp: if trying to compile an old commit of rustc, disable `download-ci-llvm` in config.toml:
-\n
-\n[llvm]
-\ndownload-ci-llvm = false
-\n
+        let help_on_error = "error: failed to download llvm from ci
+
+help: old builds get deleted after a certain time
+help: if trying to compile an old commit of rustc, disable `download-ci-llvm` in config.toml:
+
+[llvm]
+download-ci-llvm = false
 ";
         builder.download_component(base, &format!("{}/{}", url, filename), &tarball, help_on_error);
     }


### PR DESCRIPTION
The error message when `download-ci-llvm` fails includes too many newlines right now:

```
curl: (22) The requested URL returned error: 404                                                                                                                                                                    

error: failed to download llvm from ci


help: old builds get deleted after a certain time

help: if trying to compile an old commit of rustc, disable `download-ci-llvm` in config.toml:



[llvm]

download-ci-llvm = false



Build completed unsuccessfully in 0:01:15
```

This PR fixes the message to include the right amount of newlines:

```
curl: (22) The requested URL returned error: 404

error: failed to download llvm from ci

help: old builds get deleted after a certain time
help: if trying to compile an old commit of rustc, disable `download-ci-llvm` in config.toml:

[llvm]
download-ci-llvm = false

Build completed unsuccessfully in 0:00:07
```

r? @jyn514 