### PR TITLE
rustdoc:  remove link on slice brackets

### DIFF
--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -886,9 +886,9 @@ fn fmt_type<'cx>(
                 primitive_link(f, PrimitiveType::Slice, &format!("[{name}]"), cx)
             }
             _ => {
-                primitive_link(f, PrimitiveType::Slice, "[", cx)?;
+                write!(f, "[")?;
                 fmt::Display::fmt(&t.print(cx), f)?;
-                primitive_link(f, PrimitiveType::Slice, "]", cx)
+                write!(f, "]")
             }
         },
         clean::Array(ref t, ref n) => {
@@ -926,31 +926,6 @@ fn fmt_type<'cx>(
             let m = mutability.print_with_space();
             let amp = if f.alternate() { "&".to_string() } else { "&amp;".to_string() };
             match **ty {
-                clean::Slice(ref bt) => {
-                    // `BorrowedRef{ ... Slice(T) }` is `&[T]`
-                    match **bt {
-                        clean::Generic(name) => primitive_link(
-                            f,
-                            PrimitiveType::Slice,
-                            &format!("{amp}{lt}{m}[{name}]"),
-                            cx,
-                        ),
-                        _ => {
-                            primitive_link(
-                                f,
-                                PrimitiveType::Slice,
-                                &format!("{}{}{}[", amp, lt, m),
-                                cx,
-                            )?;
-                            if f.alternate() {
-                                write!(f, "{:#}", bt.print(cx))?;
-                            } else {
-                                write!(f, "{}", bt.print(cx))?;
-                            }
-                            primitive_link(f, PrimitiveType::Slice, "]", cx)
-                        }
-                    }
-                }
                 clean::DynTrait(ref bounds, ref trait_lt)
                     if bounds.len() > 1 || trait_lt.is_some() =>
                 {

--- a/src/test/rustdoc/slice-links.link_box_u32.html
+++ b/src/test/rustdoc/slice-links.link_box_u32.html
@@ -1,1 +1,1 @@
-<code>pub fn gamma() -&gt; <a class="struct" href="struct.MyBox.html" title="struct foo::MyBox">MyBox</a>&lt;<a class="primitive" href="{{channel}}/core/primitive.slice.html">[</a><a class="primitive" href="{{channel}}/core/primitive.u32.html">u32</a><a class="primitive" href="{{channel}}/core/primitive.slice.html">]</a>&gt;</code>
+<code>pub fn gamma() -&gt; <a class="struct" href="struct.MyBox.html" title="struct foo::MyBox">MyBox</a>&lt;[<a class="primitive" href="{{channel}}/core/primitive.u32.html">u32</a>]&gt;</code>

--- a/src/test/rustdoc/slice-links.link_slice_generic.html
+++ b/src/test/rustdoc/slice-links.link_slice_generic.html
@@ -1,1 +1,1 @@
-<code>pub fn beta&lt;T&gt;() -&gt; <a class="primitive" href="{{channel}}/core/primitive.slice.html">&amp;'static [T]</a></code>
+<code>pub fn beta&lt;T&gt;() -&gt; &amp;'static <a class="primitive" href="{{channel}}/core/primitive.slice.html">[T]</a></code>

--- a/src/test/rustdoc/slice-links.link_slice_u32.html
+++ b/src/test/rustdoc/slice-links.link_slice_u32.html
@@ -1,1 +1,1 @@
-<code>pub fn alpha() -&gt; <a class="primitive" href="{{channel}}/core/primitive.slice.html">&amp;'static [</a><a class="primitive" href="{{channel}}/core/primitive.u32.html">u32</a><a class="primitive" href="{{channel}}/core/primitive.slice.html">]</a></code>
+<code>pub fn alpha() -&gt; &amp;'static [<a class="primitive" href="{{channel}}/core/primitive.u32.html">u32</a>]</code>


### PR DESCRIPTION
This is #91778, take two.

Fixes #91173

The reason I'm reevaluating this change is #97668, which makes fully-generic slices link to the slice docs page. This fixes some downsides in the original PR, where `Box<[T]>`, for example, was not linked to the primitive.slice.html page. In this PR, the `[T]` inside is still a link.

The other major reason for wanting to reevaluate this is the changed color scheme. When this feature was first introduced in rustdoc, primitives were a different color from structs and enums. This way, eagle-eyed users could figure out that the square brackets were separate links from the structs inside. Now, all types have the same color, so a significant fraction of users won't even know the links are there unless they pay close attention to the status bar or use an accessibility tool that lists all links on the page.