### PR TITLE
Do not try to statically link libstdc++ on Solaris

### DIFF
--- a/src/bootstrap/compile.rs
+++ b/src/bootstrap/compile.rs
@@ -730,6 +730,7 @@ pub fn rustc_cargo_env(builder: &Builder<'_>, cargo: &mut Cargo, target: TargetS
             && !target.contains("freebsd")
             && !target.contains("msvc")
             && !target.contains("apple")
+            && !target.contains("solaris")
         {
             let file = compiler_file(
                 builder,

--- a/src/bootstrap/native.rs
+++ b/src/bootstrap/native.rs
@@ -655,7 +655,7 @@ fn configure_cmake(
     // For distribution we want the LLVM tools to be *statically* linked to libstdc++.
     // We also do this if the user explicitly requested static libstdc++.
     if builder.config.llvm_static_stdcpp {
-        if !target.contains("msvc") && !target.contains("netbsd") {
+        if !target.contains("msvc") && !target.contains("netbsd") && !target.contains("solaris") {
             if target.contains("apple") || target.contains("windows") {
                 ldflags.push_all("-static-libstdc++");
             } else {


### PR DESCRIPTION
Fixes #97260