### PR TITLE
Fix sidebar items expand collapse

### DIFF
--- a/src/librustdoc/html/static/js/source-script.js
+++ b/src/librustdoc/html/static/js/source-script.js
@@ -32,10 +32,10 @@ function createDirEntry(elem, parent, fullPath, currentFile, hasFoundFile) {
     fullPath += elem["name"] + "/";
 
     name.onclick = () => {
-        if (hasClass(this, "expand")) {
-            removeClass(this, "expand");
+        if (hasClass(name, "expand")) {
+            removeClass(name, "expand");
         } else {
-            addClass(this, "expand");
+            addClass(name, "expand");
         }
     };
     name.innerText = elem["name"];

--- a/src/test/rustdoc-gui/source-code-page.goml
+++ b/src/test/rustdoc-gui/source-code-page.goml
@@ -1,4 +1,4 @@
-// Checks that the interactions with the source code pages are workined as expected.
+// Checks that the interactions with the source code pages are working as expected.
 goto: file://|DOC_PATH|/src/test_docs/lib.rs.html
 // Check that we can click on the line number.
 click: ".line-numbers > span:nth-child(4)" // This is the span for line 4.
@@ -27,3 +27,26 @@ assert-position: ("//*[@id='1']", {"x": 104, "y": 103})
 // We click on the left of the "1" span but still in the "line-number" `<pre>`.
 click: (103, 103)
 assert-document-property: ({"URL": "/lib.rs.html"}, ENDS_WITH)
+
+// Checking the source code sidebar.
+
+// First we "open" it.
+click: "#sidebar-toggle"
+assert: ".sidebar.expanded"
+
+// We check that the first entry of the sidebar is collapsed (which, for whatever reason,
+// is number 2 and not 1...).
+assert-attribute: ("#source-sidebar .name:nth-child(2)", {"class": "name"})
+assert-text: ("#source-sidebar .name:nth-child(2)", "implementors")
+// We also check its children are hidden too.
+assert-css: ("#source-sidebar .name:nth-child(2) + .children", {"display": "none"})
+// We now click on it.
+click: "#source-sidebar .name:nth-child(2)"
+assert-attribute: ("#source-sidebar .name:nth-child(2)", {"class": "name expand"})
+// Checking that its children are displayed as well.
+assert-css: ("#source-sidebar .name:nth-child(2) + .children", {"display": "block"})
+
+// And now we collapse it again.
+click: "#source-sidebar .name:nth-child(2)"
+assert-attribute: ("#source-sidebar .name:nth-child(2)", {"class": "name"})
+assert-css: ("#source-sidebar .name:nth-child(2) + .children", {"display": "none"})


### PR DESCRIPTION
The collapse/expand event was not working for the items in the source code viewer sidebar (talking about these items:

![Screenshot from 2022-06-14 11-21-58](https://user-images.githubusercontent.com/3050060/173543346-af056928-e921-458f-b918-60f6fd0ecbde.png)

).

This PR fixes it and adds a GUI test to prevent another regression.

r? @notriddle 