### PR TITLE
Remove the source archive functionality of ArchiveWriter

### DIFF
--- a/compiler/rustc_codegen_cranelift/src/archive.rs
+++ b/compiler/rustc_codegen_cranelift/src/archive.rs
@@ -61,19 +61,6 @@ impl<'a> ArchiveBuilder<'a> for ArArchiveBuilder<'a> {
         }
     }
 
-    fn src_files(&mut self) -> Vec<String> {
-        self.entries.iter().map(|(name, _)| String::from_utf8(name.clone()).unwrap()).collect()
-    }
-
-    fn remove_file(&mut self, name: &str) {
-        let index = self
-            .entries
-            .iter()
-            .position(|(entry_name, _)| entry_name == name.as_bytes())
-            .expect("Tried to remove file not existing in src archive");
-        self.entries.remove(index);
-    }
-
     fn add_file(&mut self, file: &Path) {
         self.entries.push((
             file.file_name().unwrap().to_str().unwrap().to_string().into_bytes(),

--- a/compiler/rustc_codegen_cranelift/src/archive.rs
+++ b/compiler/rustc_codegen_cranelift/src/archive.rs
@@ -92,7 +92,7 @@ impl<'a> ArchiveBuilder<'a> for ArArchiveBuilder<'a> {
         Ok(())
     }
 
-    fn build(mut self) {
+    fn build(mut self) -> bool {
         enum BuilderKind {
             Bsd(ar::Builder<File>),
             Gnu(ar::GnuBuilder<File>),
@@ -191,6 +191,8 @@ impl<'a> ArchiveBuilder<'a> for ArArchiveBuilder<'a> {
             )
         };
 
+        let any_members = !entries.is_empty();
+
         // Add all files
         for (entry_name, data) in entries.into_iter() {
             let header = ar::Header::new(entry_name, data.len() as u64);
@@ -216,6 +218,8 @@ impl<'a> ArchiveBuilder<'a> for ArArchiveBuilder<'a> {
                 self.sess.fatal(&format!("Ranlib exited with code {:?}", status.code()));
             }
         }
+
+        any_members
     }
 
     fn inject_dll_import_lib(

--- a/compiler/rustc_codegen_cranelift/src/archive.rs
+++ b/compiler/rustc_codegen_cranelift/src/archive.rs
@@ -30,25 +30,7 @@ pub(crate) struct ArArchiveBuilder<'a> {
 }
 
 impl<'a> ArchiveBuilder<'a> for ArArchiveBuilder<'a> {
-    fn new(sess: &'a Session, output: &Path, input: Option<&Path>) -> Self {
-        let (src_archives, entries) = if let Some(input) = input {
-            let read_cache = ReadCache::new(File::open(input).unwrap());
-            let archive = ArchiveFile::parse(&read_cache).unwrap();
-            let mut entries = Vec::new();
-
-            for entry in archive.members() {
-                let entry = entry.unwrap();
-                entries.push((
-                    entry.name().to_vec(),
-                    ArchiveEntry::FromArchive { archive_index: 0, file_range: entry.file_range() },
-                ));
-            }
-
-            (vec![read_cache.into_inner()], entries)
-        } else {
-            (vec![], Vec::new())
-        };
-
+    fn new(sess: &'a Session, output: &Path) -> Self {
         ArArchiveBuilder {
             sess,
             dst: output.to_path_buf(),
@@ -56,8 +38,8 @@ impl<'a> ArchiveBuilder<'a> for ArArchiveBuilder<'a> {
             // FIXME fix builtin ranlib on macOS
             no_builtin_ranlib: sess.target.is_like_osx,
 
-            src_archives,
-            entries,
+            src_archives: vec![],
+            entries: vec![],
         }
     }
 

--- a/compiler/rustc_codegen_gcc/src/archive.rs
+++ b/compiler/rustc_codegen_gcc/src/archive.rs
@@ -70,19 +70,6 @@ impl<'a> ArchiveBuilder<'a> for ArArchiveBuilder<'a> {
         }
     }
 
-    fn src_files(&mut self) -> Vec<String> {
-        self.entries.iter().map(|(name, _)| name.clone()).collect()
-    }
-
-    fn remove_file(&mut self, name: &str) {
-        let index = self
-            .entries
-            .iter()
-            .position(|(entry_name, _)| entry_name == name)
-            .expect("Tried to remove file not existing in src archive");
-        self.entries.remove(index);
-    }
-
     fn add_file(&mut self, file: &Path) {
         self.entries.push((
             file.file_name().unwrap().to_str().unwrap().to_string(),

--- a/compiler/rustc_codegen_gcc/src/archive.rs
+++ b/compiler/rustc_codegen_gcc/src/archive.rs
@@ -100,7 +100,7 @@ impl<'a> ArchiveBuilder<'a> for ArArchiveBuilder<'a> {
         Ok(())
     }
 
-    fn build(mut self) {
+    fn build(mut self) -> bool {
         use std::process::Command;
 
         fn add_file_using_ar(archive: &Path, file: &Path) {
@@ -132,6 +132,8 @@ impl<'a> ArchiveBuilder<'a> for ArArchiveBuilder<'a> {
         } else {
             BuilderKind::Bsd(ar::Builder::new(File::create(&self.config.dst).unwrap()))
         };
+
+        let any_members = !self.entries.is_empty();
 
         // Add all files
         for (entry_name, entry) in self.entries.into_iter() {
@@ -193,6 +195,8 @@ impl<'a> ArchiveBuilder<'a> for ArArchiveBuilder<'a> {
         if !status.success() {
             self.config.sess.fatal(&format!("Ranlib exited with code {:?}", status.code()));
         }
+
+        any_members
     }
 
     fn inject_dll_import_lib(&mut self, _lib_name: &str, _dll_imports: &[DllImport], _tmpdir: &MaybeTempDir) {

--- a/compiler/rustc_codegen_gcc/src/archive.rs
+++ b/compiler/rustc_codegen_gcc/src/archive.rs
@@ -32,7 +32,7 @@ pub struct ArArchiveBuilder<'a> {
 }
 
 impl<'a> ArchiveBuilder<'a> for ArArchiveBuilder<'a> {
-    fn new(sess: &'a Session, output: &Path, input: Option<&Path>) -> Self {
+    fn new(sess: &'a Session, output: &Path) -> Self {
         let config = ArchiveConfig {
             sess,
             dst: output.to_path_buf(),
@@ -41,32 +41,10 @@ impl<'a> ArchiveBuilder<'a> for ArArchiveBuilder<'a> {
             use_gnu_style_archive: sess.target.options.archive_format == "gnu",
         };
 
-        let (src_archives, entries) = if let Some(input) = input {
-            let mut archive = ar::Archive::new(File::open(input).unwrap());
-            let mut entries = Vec::new();
-
-            let mut i = 0;
-            while let Some(entry) = archive.next_entry() {
-                let entry = entry.unwrap();
-                entries.push((
-                    String::from_utf8(entry.header().identifier().to_vec()).unwrap(),
-                    ArchiveEntry::FromArchive {
-                        archive_index: 0,
-                        entry_index: i,
-                    },
-                ));
-                i += 1;
-            }
-
-            (vec![(input.to_owned(), archive)], entries)
-        } else {
-            (vec![], Vec::new())
-        };
-
         ArArchiveBuilder {
             config,
-            src_archives,
-            entries,
+            src_archives: vec![],
+            entries: vec![],
         }
     }
 

--- a/compiler/rustc_codegen_ssa/src/back/archive.rs
+++ b/compiler/rustc_codegen_ssa/src/back/archive.rs
@@ -50,7 +50,7 @@ pub trait ArchiveBuilder<'a> {
     where
         F: FnMut(&str) -> bool + 'static;
 
-    fn build(self);
+    fn build(self) -> bool;
 
     fn inject_dll_import_lib(
         &mut self,

--- a/compiler/rustc_codegen_ssa/src/back/archive.rs
+++ b/compiler/rustc_codegen_ssa/src/back/archive.rs
@@ -45,8 +45,6 @@ pub trait ArchiveBuilder<'a> {
     fn new(sess: &'a Session, output: &Path, input: Option<&Path>) -> Self;
 
     fn add_file(&mut self, path: &Path);
-    fn remove_file(&mut self, name: &str);
-    fn src_files(&mut self) -> Vec<String>;
 
     fn add_archive<F>(&mut self, archive: &Path, skip: F) -> io::Result<()>
     where

--- a/compiler/rustc_codegen_ssa/src/back/archive.rs
+++ b/compiler/rustc_codegen_ssa/src/back/archive.rs
@@ -42,7 +42,7 @@ pub(super) fn find_library(
 }
 
 pub trait ArchiveBuilder<'a> {
-    fn new(sess: &'a Session, output: &Path, input: Option<&Path>) -> Self;
+    fn new(sess: &'a Session, output: &Path) -> Self;
 
     fn add_file(&mut self, path: &Path);
 

--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -270,7 +270,7 @@ fn link_rlib<'a, B: ArchiveBuilder<'a>>(
 
     let lib_search_paths = archive_search_paths(sess);
 
-    let mut ab = <B as ArchiveBuilder>::new(sess, out_filename, None);
+    let mut ab = <B as ArchiveBuilder>::new(sess, out_filename);
 
     let trailing_metadata = match flavor {
         RlibFlavor::Normal => {
@@ -2472,7 +2472,7 @@ fn add_upstream_rust_crates<'a, B: ArchiveBuilder<'a>>(
             let is_builtins = sess.target.no_builtins
                 || !codegen_results.crate_info.is_no_builtins.contains(&cnum);
 
-            let mut archive = <B as ArchiveBuilder>::new(sess, &dst, None);
+            let mut archive = <B as ArchiveBuilder>::new(sess, &dst);
             if let Err(e) = archive.add_archive(cratepath, move |f| {
                 if f == METADATA_FILENAME {
                     return true;

--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -2503,8 +2503,9 @@ fn add_upstream_rust_crates<'a, B: ArchiveBuilder<'a>>(
             }) {
                 sess.fatal(&format!("failed to build archive from rlib: {}", e));
             }
-            archive.build();
-            link_upstream(&dst);
+            if archive.build() {
+                link_upstream(&dst);
+            }
         });
     }
 

--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -2466,17 +2466,19 @@ fn add_upstream_rust_crates<'a, B: ArchiveBuilder<'a>>(
         let name = &name[3..name.len() - 5]; // chop off lib/.rlib
 
         sess.prof.generic_activity_with_arg("link_altering_rlib", name).run(|| {
-            let mut archive = <B as ArchiveBuilder>::new(sess, &dst, Some(cratepath));
+            let canonical_name = name.replace('-', "_");
+            let upstream_rust_objects_already_included =
+                are_upstream_rust_objects_already_included(sess);
+            let is_builtins = sess.target.no_builtins
+                || !codegen_results.crate_info.is_no_builtins.contains(&cnum);
 
-            let mut any_objects = false;
-            for f in archive.src_files() {
+            let mut archive = <B as ArchiveBuilder>::new(sess, &dst, None);
+            if let Err(e) = archive.add_archive(cratepath, move |f| {
                 if f == METADATA_FILENAME {
-                    archive.remove_file(&f);
-                    continue;
+                    return true;
                 }
 
                 let canonical = f.replace('-', "_");
-                let canonical_name = name.replace('-', "_");
 
                 let is_rust_object =
                     canonical.starts_with(&canonical_name) && looks_like_rust_object_file(&f);
@@ -2490,20 +2492,16 @@ fn add_upstream_rust_crates<'a, B: ArchiveBuilder<'a>>(
                 // file, then we don't need the object file as it's part of the
                 // LTO module. Note that `#![no_builtins]` is excluded from LTO,
                 // though, so we let that object file slide.
-                let skip_because_lto = are_upstream_rust_objects_already_included(sess)
-                    && is_rust_object
-                    && (sess.target.no_builtins
-                        || !codegen_results.crate_info.is_no_builtins.contains(&cnum));
+                let skip_because_lto =
+                    upstream_rust_objects_already_included && is_rust_object && is_builtins;
 
                 if skip_because_cfg_say_so || skip_because_lto {
-                    archive.remove_file(&f);
-                } else {
-                    any_objects = true;
+                    return true;
                 }
-            }
 
-            if !any_objects {
-                return;
+                false
+            }) {
+                sess.fatal(&format!("failed to build archive from rlib: {}", e));
             }
             archive.build();
             link_upstream(&dst);


### PR DESCRIPTION
We now build archives through strictly additive means rather than taking an existing archive and potentially substracting parts. This is simpler and makes it easier to swap out the archive writer in https://github.com/rust-lang/rust/pull/97485.