### PR TITLE
rustdoc: remove tuple link on round braces

### DIFF
--- a/src/etc/htmldocck.py
+++ b/src/etc/htmldocck.py
@@ -417,7 +417,7 @@ def check_snapshot(snapshot_name, actual_tree, normalize_to_text):
     snapshot_path = '{}.{}.{}'.format(rust_test_path[:-3], snapshot_name, 'html')
     try:
         with open(snapshot_path, 'r') as snapshot_file:
-            expected_str = snapshot_file.read()
+            expected_str = snapshot_file.read().replace("{{channel}}", channel)
     except FileNotFoundError:
         if bless:
             expected_str = None
@@ -428,8 +428,6 @@ def check_snapshot(snapshot_name, actual_tree, normalize_to_text):
         actual_str = ET.tostring(actual_tree).decode('utf-8')
     else:
         actual_str = flatten(actual_tree)
-
-    expected_str = expected_str.replace("{{channel}}", channel)
 
     # Conditions:
     #  1. Is --bless

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -23,6 +23,8 @@ use rustc_span::symbol::kw;
 use rustc_span::{sym, Symbol};
 use rustc_target::spec::abi::Abi;
 
+use itertools::Itertools;
+
 use crate::clean::{
     self, types::ExternalLocation, utils::find_nearest_parent_module, ExternalCrate, ItemId,
     PrimitiveType,
@@ -864,20 +866,42 @@ fn fmt_type<'cx>(
             match &typs[..] {
                 &[] => primitive_link(f, PrimitiveType::Unit, "()", cx),
                 &[ref one] => {
-                    primitive_link(f, PrimitiveType::Tuple, "(", cx)?;
-                    // Carry `f.alternate()` into this display w/o branching manually.
-                    fmt::Display::fmt(&one.print(cx), f)?;
-                    primitive_link(f, PrimitiveType::Tuple, ",)", cx)
+                    if let clean::Generic(name) = one {
+                        primitive_link(f, PrimitiveType::Tuple, &format!("({name},)"), cx)
+                    } else {
+                        write!(f, "(")?;
+                        // Carry `f.alternate()` into this display w/o branching manually.
+                        fmt::Display::fmt(&one.print(cx), f)?;
+                        write!(f, ",)")
+                    }
                 }
                 many => {
-                    primitive_link(f, PrimitiveType::Tuple, "(", cx)?;
-                    for (i, item) in many.iter().enumerate() {
-                        if i != 0 {
-                            write!(f, ", ")?;
+                    let generic_names: Vec<Symbol> = many
+                        .iter()
+                        .filter_map(|t| match t {
+                            clean::Generic(name) => Some(*name),
+                            _ => None,
+                        })
+                        .collect();
+                    let is_generic = generic_names.len() == many.len();
+                    if is_generic {
+                        primitive_link(
+                            f,
+                            PrimitiveType::Tuple,
+                            &format!("({})", generic_names.iter().map(|s| s.as_str()).join(", ")),
+                            cx,
+                        )
+                    } else {
+                        write!(f, "(")?;
+                        for (i, item) in many.iter().enumerate() {
+                            if i != 0 {
+                                write!(f, ", ")?;
+                            }
+                            // Carry `f.alternate()` into this display w/o branching manually.
+                            fmt::Display::fmt(&item.print(cx), f)?;
                         }
-                        fmt::Display::fmt(&item.print(cx), f)?;
+                        write!(f, ")")
                     }
-                    primitive_link(f, PrimitiveType::Tuple, ")", cx)
                 }
             }
         }

--- a/src/test/rustdoc/tuples.link1_i32.html
+++ b/src/test/rustdoc/tuples.link1_i32.html
@@ -1,0 +1,1 @@
+<code>pub fn tuple1(x: (<a class="primitive" href="{{channel}}/std/primitive.i32.html">i32</a>,)) -&gt; (<a class="primitive" href="{{channel}}/std/primitive.i32.html">i32</a>,)</code>

--- a/src/test/rustdoc/tuples.link1_t.html
+++ b/src/test/rustdoc/tuples.link1_t.html
@@ -1,0 +1,1 @@
+<code>pub fn tuple1_t&lt;T&gt;(x: <a class="primitive" href="{{channel}}/std/primitive.tuple.html">(T,)</a>) -&gt; <a class="primitive" href="{{channel}}/std/primitive.tuple.html">(T,)</a></code>

--- a/src/test/rustdoc/tuples.link2_i32.html
+++ b/src/test/rustdoc/tuples.link2_i32.html
@@ -1,0 +1,1 @@
+<code>pub fn tuple2(x: (<a class="primitive" href="{{channel}}/std/primitive.i32.html">i32</a>, <a class="primitive" href="{{channel}}/std/primitive.i32.html">i32</a>)) -&gt; (<a class="primitive" href="{{channel}}/std/primitive.i32.html">i32</a>, <a class="primitive" href="{{channel}}/std/primitive.i32.html">i32</a>)</code>

--- a/src/test/rustdoc/tuples.link2_t.html
+++ b/src/test/rustdoc/tuples.link2_t.html
@@ -1,0 +1,1 @@
+<code>pub fn tuple2_t&lt;T&gt;(x: <a class="primitive" href="{{channel}}/std/primitive.tuple.html">(T, T)</a>) -&gt; <a class="primitive" href="{{channel}}/std/primitive.tuple.html">(T, T)</a></code>

--- a/src/test/rustdoc/tuples.link2_tu.html
+++ b/src/test/rustdoc/tuples.link2_tu.html
@@ -1,0 +1,1 @@
+<code>pub fn tuple2_tu&lt;T, U&gt;(x: <a class="primitive" href="{{channel}}/std/primitive.tuple.html">(T, U)</a>) -&gt; <a class="primitive" href="{{channel}}/std/primitive.tuple.html">(T, U)</a></code>

--- a/src/test/rustdoc/tuples.link_unit.html
+++ b/src/test/rustdoc/tuples.link_unit.html
@@ -1,0 +1,1 @@
+<code>pub fn tuple0(x: <a class="primitive" href="{{channel}}/std/primitive.unit.html">()</a>)</code>

--- a/src/test/rustdoc/tuples.rs
+++ b/src/test/rustdoc/tuples.rs
@@ -1,8 +1,20 @@
 #![crate_name = "foo"]
 
 // @has foo/fn.tuple0.html //pre 'pub fn tuple0(x: ())'
+// @snapshot link_unit - '//pre[@class="rust fn"]/code'
 pub fn tuple0(x: ()) -> () { x }
 // @has foo/fn.tuple1.html //pre 'pub fn tuple1(x: (i32,)) -> (i32,)'
+// @snapshot link1_i32 - '//pre[@class="rust fn"]/code'
 pub fn tuple1(x: (i32,)) -> (i32,) { x }
 // @has foo/fn.tuple2.html //pre 'pub fn tuple2(x: (i32, i32)) -> (i32, i32)'
+// @snapshot link2_i32 - '//pre[@class="rust fn"]/code'
 pub fn tuple2(x: (i32, i32)) -> (i32, i32) { x }
+// @has foo/fn.tuple1_t.html //pre 'pub fn tuple1_t<T>(x: (T,)) -> (T,)'
+// @snapshot link1_t - '//pre[@class="rust fn"]/code'
+pub fn tuple1_t<T>(x: (T,)) -> (T,) { x }
+// @has foo/fn.tuple2_t.html //pre 'pub fn tuple2_t<T>(x: (T, T)) -> (T, T)'
+// @snapshot link2_t - '//pre[@class="rust fn"]/code'
+pub fn tuple2_t<T>(x: (T, T)) -> (T, T) { x }
+// @has foo/fn.tuple2_tu.html //pre 'pub fn tuple2_tu<T, U>(x: (T, U)) -> (T, U)'
+// @snapshot link2_tu - '//pre[@class="rust fn"]/code'
+pub fn tuple2_tu<T, U>(x: (T, U)) -> (T, U) { x }


### PR DESCRIPTION
This is #98069 but for tuples. The reasoning is the same:

* This PR also changes it so that tuples with all-generic elements still link to the primitive.tuple.html page, just like slices. So there still plenty of on-ramps for anybody who doesn't know about it.
* It's too hard to see when round braces are a separate link from the type inside of them.
* It's too hard to click even if you do notice them.

Before:

* impl [ToSocketAddrs](https://doc.rust-lang.org/nightly/std/net/trait.ToSocketAddrs.html) for [(](https://doc.rust-lang.org/nightly/std/primitive.tuple.html)[IpAddr](https://doc.rust-lang.org/nightly/std/net/enum.IpAddr.html), [u16](https://doc.rust-lang.org/nightly/std/primitive.u16.html)[)](https://doc.rust-lang.org/nightly/std/primitive.tuple.html)
* impl<K, V> [FromIterator](https://notriddle.com/notriddle-rustdoc-test/std/iter/trait.FromIterator.html)<[(](https://notriddle.com/notriddle-rustdoc-test/std/primitive.tuple.html)K, V[)](https://notriddle.com/notriddle-rustdoc-test/std/primitive.tuple.html)> for [BTreeMap](https://notriddle.com/notriddle-rustdoc-test/std/collections/struct.BTreeMap.html)<K, V>

After:

* impl [ToSocketAddrs](https://doc.rust-lang.org/nightly/std/net/trait.ToSocketAddrs.html) for ([IpAddr](https://doc.rust-lang.org/nightly/std/net/enum.IpAddr.html), [u16](https://doc.rust-lang.org/nightly/std/primitive.u16.html))
* impl<K, V> [FromIterator](https://notriddle.com/notriddle-rustdoc-test/std/iter/trait.FromIterator.html)<[(K, V)](https://notriddle.com/notriddle-rustdoc-test/std/primitive.tuple.html)> for [BTreeMap](https://notriddle.com/notriddle-rustdoc-test/std/collections/struct.BTreeMap.html)<K, V>