### PR TITLE
Test NLL fix of bad lifetime inference for reference captured in closure.

### DIFF
--- a/library/std/src/thread/tests.rs
+++ b/library/std/src/thread/tests.rs
@@ -316,3 +316,16 @@ fn test_scoped_threads_drop_result_before_join() {
     });
     assert!(actually_finished.load(Ordering::Relaxed));
 }
+
+#[test]
+fn test_scoped_threads_nll() {
+    // this is mostly a *compilation test* for this exact function:
+    fn foo(x: &u8) {
+        thread::scope(|s| {
+            s.spawn(|| drop(x));
+        });
+    }
+    // let's also run it for good measure
+    let x = 42_u8;
+    foo(&x);
+}


### PR DESCRIPTION
This came up as a use-case for `thread::scope` API that only compiles successfully since `feature(nll)` got stabilized recently.

Closes #93203 which had been re-opened for tracking this very test case to be added.