### PR TITLE
Refactor path segment parameter error

### DIFF
--- a/src/test/ui/error-codes/E0214.stderr
+++ b/src/test/ui/error-codes/E0214.stderr
@@ -2,10 +2,12 @@ error[E0214]: parenthesized type parameters may only be used with a `Fn` trait
   --> $DIR/E0214.rs:2:12
    |
 LL |     let v: Vec(&str) = vec!["foo"];
-   |            ^^^^^^^^^
-   |            |
-   |            only `Fn` traits may use parentheses
-   |            help: use angle brackets instead: `Vec<&str>`
+   |            ^^^^^^^^^ only `Fn` traits may use parentheses
+   |
+help: use angle brackets instead
+   |
+LL |     let v: Vec<&str> = vec!["foo"];
+   |               ~    ~
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-23589.stderr
+++ b/src/test/ui/issues/issue-23589.stderr
@@ -2,10 +2,12 @@ error[E0214]: parenthesized type parameters may only be used with a `Fn` trait
   --> $DIR/issue-23589.rs:2:12
    |
 LL |     let v: Vec(&str) = vec!['1', '2'];
-   |            ^^^^^^^^^
-   |            |
-   |            only `Fn` traits may use parentheses
-   |            help: use angle brackets instead: `Vec<&str>`
+   |            ^^^^^^^^^ only `Fn` traits may use parentheses
+   |
+help: use angle brackets instead
+   |
+LL |     let v: Vec<&str> = vec!['1', '2'];
+   |               ~    ~
 
 error[E0308]: mismatched types
   --> $DIR/issue-23589.rs:2:29

--- a/src/test/ui/proc-macro/issue-66286.stderr
+++ b/src/test/ui/proc-macro/issue-66286.stderr
@@ -2,10 +2,12 @@ error[E0214]: parenthesized type parameters may only be used with a `Fn` trait
   --> $DIR/issue-66286.rs:8:22
    |
 LL | pub extern fn foo(_: Vec(u32)) -> u32 {
-   |                      ^^^^^^^^
-   |                      |
-   |                      only `Fn` traits may use parentheses
-   |                      help: use angle brackets instead: `Vec<u32>`
+   |                      ^^^^^^^^ only `Fn` traits may use parentheses
+   |
+help: use angle brackets instead
+   |
+LL | pub extern fn foo(_: Vec<u32>) -> u32 {
+   |                         ~   ~
 
 error: aborting due to previous error
 

--- a/src/test/ui/suggestions/let-binding-init-expr-as-ty.stderr
+++ b/src/test/ui/suggestions/let-binding-init-expr-as-ty.stderr
@@ -10,10 +10,12 @@ error[E0214]: parenthesized type parameters may only be used with a `Fn` trait
   --> $DIR/let-binding-init-expr-as-ty.rs:2:19
    |
 LL |     let foo: i32::from_be(num);
-   |                   ^^^^^^^^^^^^
-   |                   |
-   |                   only `Fn` traits may use parentheses
-   |                   help: use angle brackets instead: `from_be<num>`
+   |                   ^^^^^^^^^^^^ only `Fn` traits may use parentheses
+   |
+help: use angle brackets instead
+   |
+LL |     let foo: i32::from_be<num>;
+   |                          ~   ~
 
 error[E0223]: ambiguous associated type
   --> $DIR/let-binding-init-expr-as-ty.rs:2:14

--- a/src/test/ui/type/issue-91268.stderr
+++ b/src/test/ui/type/issue-91268.stderr
@@ -29,6 +29,11 @@ error[E0214]: parenthesized type parameters may only be used with a `Fn` trait
    |
 LL |     0: u8(ţ
    |        ^^^^ only `Fn` traits may use parentheses
+   |
+help: use angle brackets instead
+   |
+LL |     0: u8<ţ>
+   |          ~ +
 
 error[E0109]: type arguments are not allowed on this type
   --> $DIR/issue-91268.rs:9:11

--- a/src/test/ui/unboxed-closures/unboxed-closure-sugar-used-on-struct-3.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closure-sugar-used-on-struct-3.stderr
@@ -2,10 +2,12 @@ error[E0214]: parenthesized type parameters may only be used with a `Fn` trait
   --> $DIR/unboxed-closure-sugar-used-on-struct-3.rs:14:13
    |
 LL |     let b = Bar::(isize, usize)::new(); // OK too (for the parser)
-   |             ^^^^^^^^^^^^^^^^^^^
-   |             |
-   |             only `Fn` traits may use parentheses
-   |             help: use angle brackets instead: `Bar::<isize, usize>`
+   |             ^^^^^^^^^^^^^^^^^^^ only `Fn` traits may use parentheses
+   |
+help: use angle brackets instead
+   |
+LL |     let b = Bar::<isize, usize>::new(); // OK too (for the parser)
+   |                  ~            ~
 
 error: aborting due to previous error
 


### PR DESCRIPTION
This PR attempts to rewrite the error handling for an unexpected parenthesised type parameters to:
- Use provided data instead of re-parsing the whole span
- Add a multipart suggestion to reflect on the changes with an underline
- Remove the unnecessary "if" nesting 