### PR TITLE
Improve loading of crates.js and sidebar-items.js

### DIFF
--- a/src/librustdoc/html/layout.rs
+++ b/src/librustdoc/html/layout.rs
@@ -31,8 +31,6 @@ pub(crate) struct Page<'a> {
     pub(crate) description: &'a str,
     pub(crate) keywords: &'a str,
     pub(crate) resource_suffix: &'a str,
-    pub(crate) extra_scripts: &'a [&'a str],
-    pub(crate) static_extra_scripts: &'a [&'a str],
 }
 
 impl<'a> Page<'a> {

--- a/src/librustdoc/html/render/context.rs
+++ b/src/librustdoc/html/render/context.rs
@@ -211,8 +211,6 @@ impl<'tcx> Context<'tcx> {
                 description: &desc,
                 keywords: &keywords,
                 resource_suffix: &clone_shared.resource_suffix,
-                extra_scripts: &[],
-                static_extra_scripts: &[],
             };
             let mut page_buffer = Buffer::html();
             print_item(self, it, &mut page_buffer, &page);
@@ -568,8 +566,6 @@ impl<'tcx> FormatRenderer<'tcx> for Context<'tcx> {
             description: "List of all items in this crate",
             keywords: BASIC_KEYWORDS,
             resource_suffix: &shared.resource_suffix,
-            extra_scripts: &[],
-            static_extra_scripts: &[],
         };
         let sidebar = if shared.cache.crate_version.is_some() {
             format!("<h2 class=\"location\">Crate {}</h2>", crate_name)
@@ -693,7 +689,7 @@ impl<'tcx> FormatRenderer<'tcx> for Context<'tcx> {
             else { unreachable!() };
             let items = self.build_sidebar_items(module);
             let js_dst = self.dst.join(&format!("sidebar-items{}.js", self.shared.resource_suffix));
-            let v = format!("initSidebarItems({});", serde_json::to_string(&items).unwrap());
+            let v = format!("window.SIDEBAR_ITEMS = {};", serde_json::to_string(&items).unwrap());
             self.shared.fs.write(js_dst, v)?;
         }
         Ok(())

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -56,7 +56,7 @@ use rustc_middle::middle::stability;
 use rustc_middle::ty;
 use rustc_middle::ty::TyCtxt;
 use rustc_span::{
-    symbol::{kw, sym, Symbol},
+    symbol::{sym, Symbol},
     BytePos, FileName, RealFileName,
 };
 use serde::ser::SerializeSeq;
@@ -1738,8 +1738,6 @@ pub(crate) fn render_impl_summary(
 }
 
 fn print_sidebar(cx: &Context<'_>, it: &clean::Item, buffer: &mut Buffer) {
-    let parentlen = cx.current.len() - if it.is_mod() { 1 } else { 0 };
-
     if it.is_struct()
         || it.is_trait()
         || it.is_primitive()
@@ -1800,21 +1798,6 @@ fn print_sidebar(cx: &Context<'_>, it: &clean::Item, buffer: &mut Buffer) {
         write!(buffer, "<h2 class=\"location\"><a href=\"index.html\">In {}</a></h2>", path);
     }
 
-    // Sidebar refers to the enclosing module, not this module.
-    let relpath = if it.is_mod() && parentlen != 0 { "./" } else { "" };
-    write!(
-        buffer,
-        "<div id=\"sidebar-vars\" data-name=\"{name}\" data-ty=\"{ty}\" data-relpath=\"{path}\">\
-        </div>",
-        name = it.name.unwrap_or(kw::Empty),
-        ty = it.type_(),
-        path = relpath
-    );
-    write!(
-        buffer,
-        "<script defer src=\"{}sidebar-items{}.js\"></script>",
-        relpath, cx.shared.resource_suffix
-    );
     // Closes sidebar-elems div.
     buffer.write_str("</div>");
 }

--- a/src/librustdoc/html/render/write_shared.rs
+++ b/src/librustdoc/html/render/write_shared.rs
@@ -475,8 +475,6 @@ if (typeof exports !== 'undefined') {exports.searchIndex = searchIndex};
                 description: "List of crates",
                 keywords: BASIC_KEYWORDS,
                 resource_suffix: &shared.resource_suffix,
-                extra_scripts: &[],
-                static_extra_scripts: &[],
             };
 
             let content = format!(

--- a/src/librustdoc/html/sources.rs
+++ b/src/librustdoc/html/sources.rs
@@ -203,8 +203,6 @@ impl SourceCollector<'_, '_> {
             description: &desc,
             keywords: BASIC_KEYWORDS,
             resource_suffix: &shared.resource_suffix,
-            extra_scripts: &[&format!("source-files{}", shared.resource_suffix)],
-            static_extra_scripts: &[&format!("source-script{}", shared.resource_suffix)],
         };
         let v = layout::render(
             &shared.layout,

--- a/src/librustdoc/html/static/js/search.js
+++ b/src/librustdoc/html/static/js/search.js
@@ -1719,10 +1719,11 @@ function initSearch(rawSearchIndex) {
         }
 
         let crates = "";
-        if (window.ALL_CRATES.length > 1) {
+        const crates_list = Object.keys(rawSearchIndex);
+        if (crates_list.length > 1) {
             crates = " in <select id=\"crate-search\"><option value=\"All crates\">" +
                 "All crates</option>";
-            for (const c of window.ALL_CRATES) {
+            for (const c of crates_list) {
                 crates += `<option value="${c}" ${c === filterCrates && "selected"}>${c}</option>`;
             }
             crates += "</select>";

--- a/src/librustdoc/html/static/js/source-script.js
+++ b/src/librustdoc/html/static/js/source-script.js
@@ -9,33 +9,19 @@
 
 (function() {
 
-function getCurrentFilePath() {
-    const parts = window.location.pathname.split("/");
-    const rootPathParts = window.rootPath.split("/");
+const rootPath = document.getElementById("rustdoc-vars").attributes["data-root-path"].value;
 
-    for (const rootPathPart of rootPathParts) {
-        if (rootPathPart === "..") {
-            parts.pop();
-        }
-    }
-    let file = window.location.pathname.substring(parts.join("/").length);
-    if (file.startsWith("/")) {
-        file = file.substring(1);
-    }
-    return file.substring(0, file.length - 5);
-}
-
-function createDirEntry(elem, parent, fullPath, currentFile, hasFoundFile) {
+function createDirEntry(elem, parent, fullPath, hasFoundFile) {
     const name = document.createElement("div");
     name.className = "name";
 
     fullPath += elem["name"] + "/";
 
-    name.onclick = () => {
-        if (hasClass(name, "expand")) {
-            removeClass(name, "expand");
+    name.onclick = ev => {
+        if (hasClass(ev.target, "expand")) {
+            removeClass(ev.target, "expand");
         } else {
-            addClass(name, "expand");
+            addClass(ev.target, "expand");
         }
     };
     name.innerText = elem["name"];
@@ -46,7 +32,7 @@ function createDirEntry(elem, parent, fullPath, currentFile, hasFoundFile) {
     folders.className = "folders";
     if (elem.dirs) {
         for (const dir of elem.dirs) {
-            if (createDirEntry(dir, folders, fullPath, currentFile, hasFoundFile)) {
+            if (createDirEntry(dir, folders, fullPath, hasFoundFile)) {
                 addClass(name, "expand");
                 hasFoundFile = true;
             }
@@ -60,8 +46,9 @@ function createDirEntry(elem, parent, fullPath, currentFile, hasFoundFile) {
         for (const file_text of elem.files) {
             const file = document.createElement("a");
             file.innerText = file_text;
-            file.href = window.rootPath + "src/" + fullPath + file_text + ".html";
-            if (!hasFoundFile && currentFile === fullPath + file_text) {
+            file.href = rootPath + "src/" + fullPath + file_text + ".html";
+            const w = window.location.href.split("#")[0];
+            if (!hasFoundFile && w === file.href) {
                 file.className = "selected";
                 addClass(name, "expand");
                 hasFoundFile = true;
@@ -72,7 +59,7 @@ function createDirEntry(elem, parent, fullPath, currentFile, hasFoundFile) {
     children.appendChild(files);
     parent.appendChild(name);
     parent.appendChild(children);
-    return hasFoundFile && currentFile.startsWith(fullPath);
+    return hasFoundFile;
 }
 
 function toggleSidebar() {
@@ -109,9 +96,6 @@ function createSidebarToggle() {
 // This function is called from "source-files.js", generated in `html/render/mod.rs`.
 // eslint-disable-next-line no-unused-vars
 function createSourceSidebar() {
-    if (!window.rootPath.endsWith("/")) {
-        window.rootPath += "/";
-    }
     const container = document.querySelector("nav.sidebar");
 
     const sidebarToggle = createSidebarToggle();
@@ -125,7 +109,6 @@ function createSourceSidebar() {
         container.classList.add("expanded");
     }
 
-    const currentFile = getCurrentFilePath();
     let hasFoundFile = false;
 
     const title = document.createElement("div");
@@ -135,7 +118,7 @@ function createSourceSidebar() {
     Object.keys(sourcesIndex).forEach(key => {
         sourcesIndex[key].name = key;
         hasFoundFile = createDirEntry(sourcesIndex[key], sidebar, "",
-                                      currentFile, hasFoundFile);
+            hasFoundFile);
     });
 
     container.appendChild(sidebar);

--- a/src/librustdoc/html/templates/page.html
+++ b/src/librustdoc/html/templates/page.html
@@ -34,17 +34,18 @@
       {%- endfor -%}
     ></script> {#- -#}
     <script src="{{static_root_path|safe}}storage{{page.resource_suffix}}.js"></script> {#- -#}
-    <script src="{{page.root_path|safe}}crates{{page.resource_suffix}}.js"></script> {#- -#}
+    {%- if page.css_class.contains("crate") -%}
+    <script defer src="{{page.root_path|safe}}crates{{page.resource_suffix}}.js"></script> {#- -#}
+    {%- else if page.css_class == "source" -%}
+    <script defer src="{{static_root_path|safe}}source-script{{page.resource_suffix}}.js"></script> {#- -#}
+    <script defer src="{{page.root_path|safe}}source-files{{page.resource_suffix}}.js"></script> {#- -#}
+    {%- else -%}
+    <script defer src="sidebar-items{{page.resource_suffix}}.js"></script> {#- -#}
+    {%- endif -%}
     <script defer src="{{static_root_path|safe}}main{{page.resource_suffix}}.js"></script> {#- -#}
-    {%- for script in page.static_extra_scripts -%}
-    <script defer src="{{static_root_path|safe}}{{script}}.js"></script> {#- -#}
-    {% endfor %}
     {%- if layout.scrape_examples_extension -%}
     <script defer src="{{page.root_path|safe}}scrape-examples{{page.resource_suffix}}.js"></script> {#- -#}
     {%- endif -%}
-    {%- for script in page.extra_scripts -%}
-    <script defer src="{{page.root_path|safe}}{{script}}.js"></script> {#- -#}
-    {% endfor %}
     <noscript> {#- -#}
         <link rel="stylesheet" {# -#}
            href="{{static_root_path|safe}}noscript{{page.resource_suffix}}.css"> {#- -#}

--- a/src/test/rustdoc-gui/duplicate-macro-reexport.goml
+++ b/src/test/rustdoc-gui/duplicate-macro-reexport.goml
@@ -1,14 +1,14 @@
 // This test ensures that there is no macro duplicates in the sidebar.
 goto: file://|DOC_PATH|/test_docs/macro.a.html
 // Waiting for the elements in the sidebar to be rendered.
-wait-for: ".sidebar-elems .others .macro"
+wait-for: ".sidebar-elems .macro"
 // Check there is only one macro named "a" listed in the sidebar.
 assert-count: (
-    "//*[@class='sidebar-elems']//*[@class='others']/*[@class='block macro']//li/a[text()='a']",
+    "//*[@class='sidebar-elems']//*[@class='block macro']//li/a[text()='a']",
     1,
 )
 // Check there is only one macro named "b" listed in the sidebar.
 assert-count: (
-    "//*[@class='sidebar-elems']//*[@class='others']/*[@class='block macro']//li/a[text()='b']",
+    "//*[@class='sidebar-elems']//*[@class='block macro']//li/a[text()='b']",
     1,
 )

--- a/src/test/rustdoc-gui/headings.goml
+++ b/src/test/rustdoc-gui/headings.goml
@@ -106,8 +106,8 @@ assert-css: ("h6#sub-heading-for-enum-impl-item-doc", {"border-bottom-width": "0
 assert-css: ("h6#sub-sub-heading-for-enum-impl-item-doc", {"font-size": "14px"})
 assert-css: ("h6#sub-sub-heading-for-enum-impl-item-doc", {"border-bottom-width": "0px"})
 
-assert-text: (".sidebar .others h3", "Modules")
-assert-css: (".sidebar .others h3", {"border-bottom-width": "0px"}, ALL)
+assert-text: (".sidebar .mod h3", "Modules")
+assert-css: (".sidebar .mod h3", {"border-bottom-width": "0px"}, ALL)
 
 goto: file://|DOC_PATH|/test_docs/union.HeavilyDocumentedUnion.html
 


### PR DESCRIPTION
Now that the "All Crates" dropdown is only rendered on the search results page,
there is no need to load crates.js on most pages. Load it only on crate pages.
Also, add the `defer` attribute so it does not block HTML parsing.

For sidebar-items.js, move the script tag to `<head>`. Since it already has the
defer attribute it won't block loading. The defer attribute does preserve
ordering between scripts, so instead of the callback on load, it can set a
global variable on load, which is slightly simpler. Also, since it is required
to finish rendering the page, beginning its load earlier is better.

Remove generation and handling of sidebar-vars. Everything there can be computed
with information available in JS via other means.

Remove the extra_scripts fields of the `Page` template. They were only
used by source-script.js and source-files.js, which are now linked by the template
based on whether it is rendering a source page.

Remove the "other" wrapper in the sidebar. It was unnecessary.

r? @GuillaumeGomez 

Demo: https://rustdoc.crud.net/jsha/defer-crates/std/index.html