### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/library/alloc/src/collections/btree/map/tests.rs
+++ b/library/alloc/src/collections/btree/map/tests.rs
@@ -116,7 +116,11 @@ impl<K, V> BTreeMap<K, V> {
     {
         let iter = mem::take(self).into_iter();
         if !iter.is_empty() {
-            self.root.insert(Root::new()).bulk_push(iter, &mut self.length);
+            self.root.insert(Root::new(&*self.alloc)).bulk_push(
+                iter,
+                &mut self.length,
+                &*self.alloc,
+            );
         }
     }
 }

--- a/library/alloc/src/collections/btree/node/tests.rs
+++ b/library/alloc/src/collections/btree/node/tests.rs
@@ -1,5 +1,6 @@
 use super::super::navigate;
 use super::*;
+use crate::alloc::Global;
 use crate::fmt::Debug;
 use crate::string::String;
 
@@ -67,10 +68,10 @@ fn test_splitpoint() {
 
 #[test]
 fn test_partial_eq() {
-    let mut root1 = NodeRef::new_leaf();
+    let mut root1 = NodeRef::new_leaf(&Global);
     root1.borrow_mut().push(1, ());
-    let mut root1 = NodeRef::new_internal(root1.forget_type()).forget_type();
-    let root2 = Root::new();
+    let mut root1 = NodeRef::new_internal(root1.forget_type(), &Global).forget_type();
+    let root2 = Root::new(&Global);
     root1.reborrow().assert_back_pointers();
     root2.reborrow().assert_back_pointers();
 
@@ -86,9 +87,9 @@ fn test_partial_eq() {
     assert!(top_edge_1 == top_edge_1);
     assert!(top_edge_1 != top_edge_2);
 
-    root1.pop_internal_level();
-    unsafe { root1.into_dying().deallocate_and_ascend() };
-    unsafe { root2.into_dying().deallocate_and_ascend() };
+    root1.pop_internal_level(&Global);
+    unsafe { root1.into_dying().deallocate_and_ascend(&Global) };
+    unsafe { root2.into_dying().deallocate_and_ascend(&Global) };
 }
 
 #[test]

--- a/library/alloc/src/collections/btree/remove.rs
+++ b/library/alloc/src/collections/btree/remove.rs
@@ -1,26 +1,29 @@
 use super::map::MIN_LEN;
 use super::node::{marker, ForceResult::*, Handle, LeftOrRight::*, NodeRef};
+use core::alloc::Allocator;
 
 impl<'a, K: 'a, V: 'a> Handle<NodeRef<marker::Mut<'a>, K, V, marker::LeafOrInternal>, marker::KV> {
     /// Removes a key-value pair from the tree, and returns that pair, as well as
     /// the leaf edge corresponding to that former pair. It's possible this empties
     /// a root node that is internal, which the caller should pop from the map
     /// holding the tree. The caller should also decrement the map's length.
-    pub fn remove_kv_tracking<F: FnOnce()>(
+    pub fn remove_kv_tracking<F: FnOnce(), A: Allocator>(
         self,
         handle_emptied_internal_root: F,
+        alloc: &A,
     ) -> ((K, V), Handle<NodeRef<marker::Mut<'a>, K, V, marker::Leaf>, marker::Edge>) {
         match self.force() {
-            Leaf(node) => node.remove_leaf_kv(handle_emptied_internal_root),
-            Internal(node) => node.remove_internal_kv(handle_emptied_internal_root),
+            Leaf(node) => node.remove_leaf_kv(handle_emptied_internal_root, alloc),
+            Internal(node) => node.remove_internal_kv(handle_emptied_internal_root, alloc),
         }
     }
 }
 
 impl<'a, K: 'a, V: 'a> Handle<NodeRef<marker::Mut<'a>, K, V, marker::Leaf>, marker::KV> {
-    fn remove_leaf_kv<F: FnOnce()>(
+    fn remove_leaf_kv<F: FnOnce(), A: Allocator>(
         self,
         handle_emptied_internal_root: F,
+        alloc: &A,
     ) -> ((K, V), Handle<NodeRef<marker::Mut<'a>, K, V, marker::Leaf>, marker::Edge>) {
         let (old_kv, mut pos) = self.remove();
         let len = pos.reborrow().into_node().len();
@@ -32,7 +35,7 @@ impl<'a, K: 'a, V: 'a> Handle<NodeRef<marker::Mut<'a>, K, V, marker::Leaf>, mark
                 Ok(Left(left_parent_kv)) => {
                     debug_assert!(left_parent_kv.right_child_len() == MIN_LEN - 1);
                     if left_parent_kv.can_merge() {
-                        left_parent_kv.merge_tracking_child_edge(Right(idx))
+                        left_parent_kv.merge_tracking_child_edge(Right(idx), alloc)
                     } else {
                         debug_assert!(left_parent_kv.left_child_len() > MIN_LEN);
                         left_parent_kv.steal_left(idx)
@@ -41,7 +44,7 @@ impl<'a, K: 'a, V: 'a> Handle<NodeRef<marker::Mut<'a>, K, V, marker::Leaf>, mark
                 Ok(Right(right_parent_kv)) => {
                     debug_assert!(right_parent_kv.left_child_len() == MIN_LEN - 1);
                     if right_parent_kv.can_merge() {
-                        right_parent_kv.merge_tracking_child_edge(Left(idx))
+                        right_parent_kv.merge_tracking_child_edge(Left(idx), alloc)
                     } else {
                         debug_assert!(right_parent_kv.right_child_len() > MIN_LEN);
                         right_parent_kv.steal_right(idx)
@@ -60,7 +63,7 @@ impl<'a, K: 'a, V: 'a> Handle<NodeRef<marker::Mut<'a>, K, V, marker::Leaf>, mark
             // rearrange the parent through the grandparent, thus change the
             // link to the parent inside the leaf.
             if let Ok(parent) = unsafe { pos.reborrow_mut() }.into_node().ascend() {
-                if !parent.into_node().forget_type().fix_node_and_affected_ancestors() {
+                if !parent.into_node().forget_type().fix_node_and_affected_ancestors(alloc) {
                     handle_emptied_internal_root();
                 }
             }
@@ -70,16 +73,17 @@ impl<'a, K: 'a, V: 'a> Handle<NodeRef<marker::Mut<'a>, K, V, marker::Leaf>, mark
 }
 
 impl<'a, K: 'a, V: 'a> Handle<NodeRef<marker::Mut<'a>, K, V, marker::Internal>, marker::KV> {
-    fn remove_internal_kv<F: FnOnce()>(
+    fn remove_internal_kv<F: FnOnce(), A: Allocator>(
         self,
         handle_emptied_internal_root: F,
+        alloc: &A,
     ) -> ((K, V), Handle<NodeRef<marker::Mut<'a>, K, V, marker::Leaf>, marker::Edge>) {
         // Remove an adjacent KV from its leaf and then put it back in place of
         // the element we were asked to remove. Prefer the left adjacent KV,
         // for the reasons listed in `choose_parent_kv`.
         let left_leaf_kv = self.left_edge().descend().last_leaf_edge().left_kv();
         let left_leaf_kv = unsafe { left_leaf_kv.ok().unwrap_unchecked() };
-        let (left_kv, left_hole) = left_leaf_kv.remove_leaf_kv(handle_emptied_internal_root);
+        let (left_kv, left_hole) = left_leaf_kv.remove_leaf_kv(handle_emptied_internal_root, alloc);
 
         // The internal node may have been stolen from or merged. Go back right
         // to find where the original KV ended up.

--- a/library/alloc/src/collections/btree/set.rs
+++ b/library/alloc/src/collections/btree/set.rs
@@ -3,15 +3,19 @@
 
 use crate::vec::Vec;
 use core::borrow::Borrow;
-use core::cmp::Ordering::{Equal, Greater, Less};
+use core::cmp::Ordering::{self, Equal, Greater, Less};
 use core::cmp::{max, min};
 use core::fmt::{self, Debug};
+use core::hash::{Hash, Hasher};
 use core::iter::{FromIterator, FusedIterator, Peekable};
+use core::mem::ManuallyDrop;
 use core::ops::{BitAnd, BitOr, BitXor, RangeBounds, Sub};
 
 use super::map::{BTreeMap, Keys};
 use super::merge_iter::MergeIterInner;
 use super::Recover;
+
+use crate::alloc::{Allocator, Global};
 
 // FIXME(conventions): implement bounded iterators
 
@@ -71,15 +75,48 @@ use super::Recover;
 ///
 /// let set = BTreeSet::from([1, 2, 3]);
 /// ```
-#[derive(Hash, PartialEq, Eq, Ord, PartialOrd)]
 #[stable(feature = "rust1", since = "1.0.0")]
 #[cfg_attr(not(test), rustc_diagnostic_item = "BTreeSet")]
-pub struct BTreeSet<T> {
-    map: BTreeMap<T, ()>,
+pub struct BTreeSet<
+    T,
+    #[unstable(feature = "allocator_api", issue = "32838")] A: Allocator = Global,
+> {
+    map: BTreeMap<T, (), A>,
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T: Clone> Clone for BTreeSet<T> {
+impl<T: Hash, A: Allocator> Hash for BTreeSet<T, A> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.map.hash(state)
+    }
+}
+
+#[stable(feature = "rust1", since = "1.0.0")]
+impl<T: PartialEq, A: Allocator> PartialEq for BTreeSet<T, A> {
+    fn eq(&self, other: &BTreeSet<T, A>) -> bool {
+        self.map.eq(&other.map)
+    }
+}
+
+#[stable(feature = "rust1", since = "1.0.0")]
+impl<T: Eq, A: Allocator> Eq for BTreeSet<T, A> {}
+
+#[stable(feature = "rust1", since = "1.0.0")]
+impl<T: PartialOrd, A: Allocator> PartialOrd for BTreeSet<T, A> {
+    fn partial_cmp(&self, other: &BTreeSet<T, A>) -> Option<Ordering> {
+        self.map.partial_cmp(&other.map)
+    }
+}
+
+#[stable(feature = "rust1", since = "1.0.0")]
+impl<T: Ord, A: Allocator> Ord for BTreeSet<T, A> {
+    fn cmp(&self, other: &BTreeSet<T, A>) -> Ordering {
+        self.map.cmp(&other.map)
+    }
+}
+
+#[stable(feature = "rust1", since = "1.0.0")]
+impl<T: Clone, A: Allocator + Clone> Clone for BTreeSet<T, A> {
     fn clone(&self) -> Self {
         BTreeSet { map: self.map.clone() }
     }
@@ -117,8 +154,11 @@ impl<T: fmt::Debug> fmt::Debug for Iter<'_, T> {
 /// [`IntoIterator`]: core::iter::IntoIterator
 #[stable(feature = "rust1", since = "1.0.0")]
 #[derive(Debug)]
-pub struct IntoIter<T> {
-    iter: super::map::IntoIter<T, ()>,
+pub struct IntoIter<
+    T,
+    #[unstable(feature = "allocator_api", issue = "32838")] A: Allocator = Global,
+> {
+    iter: super::map::IntoIter<T, (), A>,
 }
 
 /// An iterator over a sub-range of items in a `BTreeSet`.
@@ -143,11 +183,14 @@ pub struct Range<'a, T: 'a> {
 #[must_use = "this returns the difference as an iterator, \
               without modifying either input set"]
 #[stable(feature = "rust1", since = "1.0.0")]
-pub struct Difference<'a, T: 'a> {
-    inner: DifferenceInner<'a, T>,
+pub struct Difference<
+    'a,
+    T: 'a,
+    #[unstable(feature = "allocator_api", issue = "32838")] A: Allocator = Global,
+> {
+    inner: DifferenceInner<'a, T, A>,
 }
-#[derive(Debug)]
-enum DifferenceInner<'a, T: 'a> {
+enum DifferenceInner<'a, T: 'a, A: Allocator> {
     Stitch {
         // iterate all of `self` and some of `other`, spotting matches along the way
         self_iter: Iter<'a, T>,
@@ -156,13 +199,32 @@ enum DifferenceInner<'a, T: 'a> {
     Search {
         // iterate `self`, look up in `other`
         self_iter: Iter<'a, T>,
-        other_set: &'a BTreeSet<T>,
+        other_set: &'a BTreeSet<T, A>,
     },
     Iterate(Iter<'a, T>), // simply produce all elements in `self`
 }
 
+// Explicit Debug impl necessary because of issue #26925
+impl<T: Debug, A: Allocator> Debug for DifferenceInner<'_, T, A> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            DifferenceInner::Stitch { self_iter, other_iter } => f
+                .debug_struct("Stitch")
+                .field("self_iter", self_iter)
+                .field("other_iter", other_iter)
+                .finish(),
+            DifferenceInner::Search { self_iter, other_set } => f
+                .debug_struct("Search")
+                .field("self_iter", self_iter)
+                .field("other_iter", other_set)
+                .finish(),
+            DifferenceInner::Iterate(x) => f.debug_tuple("Iterate").field(x).finish(),
+        }
+    }
+}
+
 #[stable(feature = "collection_debug", since = "1.17.0")]
-impl<T: fmt::Debug> fmt::Debug for Difference<'_, T> {
+impl<T: fmt::Debug, A: Allocator> fmt::Debug for Difference<'_, T, A> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_tuple("Difference").field(&self.inner).finish()
     }
@@ -195,11 +257,14 @@ impl<T: fmt::Debug> fmt::Debug for SymmetricDifference<'_, T> {
 #[must_use = "this returns the intersection as an iterator, \
               without modifying either input set"]
 #[stable(feature = "rust1", since = "1.0.0")]
-pub struct Intersection<'a, T: 'a> {
-    inner: IntersectionInner<'a, T>,
+pub struct Intersection<
+    'a,
+    T: 'a,
+    #[unstable(feature = "allocator_api", issue = "32838")] A: Allocator = Global,
+> {
+    inner: IntersectionInner<'a, T, A>,
 }
-#[derive(Debug)]
-enum IntersectionInner<'a, T: 'a> {
+enum IntersectionInner<'a, T: 'a, A: Allocator> {
     Stitch {
         // iterate similarly sized sets jointly, spotting matches along the way
         a: Iter<'a, T>,
@@ -208,13 +273,30 @@ enum IntersectionInner<'a, T: 'a> {
     Search {
         // iterate a small set, look up in the large set
         small_iter: Iter<'a, T>,
-        large_set: &'a BTreeSet<T>,
+        large_set: &'a BTreeSet<T, A>,
     },
     Answer(Option<&'a T>), // return a specific element or emptiness
 }
 
+// Explicit Debug impl necessary because of issue #26925
+impl<T: Debug, A: Allocator> Debug for IntersectionInner<'_, T, A> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            IntersectionInner::Stitch { a, b } => {
+                f.debug_struct("Stitch").field("a", a).field("b", b).finish()
+            }
+            IntersectionInner::Search { small_iter, large_set } => f
+                .debug_struct("Search")
+                .field("small_iter", small_iter)
+                .field("large_set", large_set)
+                .finish(),
+            IntersectionInner::Answer(x) => f.debug_tuple("Answer").field(x).finish(),
+        }
+    }
+}
+
 #[stable(feature = "collection_debug", since = "1.17.0")]
-impl<T: fmt::Debug> fmt::Debug for Intersection<'_, T> {
+impl<T: Debug, A: Allocator> Debug for Intersection<'_, T, A> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_tuple("Intersection").field(&self.inner).finish()
     }
@@ -264,6 +346,26 @@ impl<T> BTreeSet<T> {
     #[must_use]
     pub const fn new() -> BTreeSet<T> {
         BTreeSet { map: BTreeMap::new() }
+    }
+}
+
+impl<T, A: Allocator> BTreeSet<T, A> {
+    /// Makes a new `BTreeSet` with a reasonable choice of B.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #![allow(unused_mut)]
+    /// # #![feature(allocator_api)]
+    /// # #![feature(btreemap_alloc)]
+    /// use std::collections::BTreeSet;
+    /// use std::alloc::Global;
+    ///
+    /// let mut set: BTreeSet<i32> = BTreeSet::new_in(Global);
+    /// ```
+    #[unstable(feature = "btreemap_alloc", issue = "32838")]
+    pub fn new_in(alloc: A) -> BTreeSet<T, A> {
+        BTreeSet { map: BTreeMap::new_in(alloc) }
     }
 
     /// Constructs a double-ended iterator over a sub-range of elements in the set.
@@ -319,7 +421,7 @@ impl<T> BTreeSet<T> {
     /// assert_eq!(diff, [1]);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn difference<'a>(&'a self, other: &'a BTreeSet<T>) -> Difference<'a, T>
+    pub fn difference<'a>(&'a self, other: &'a BTreeSet<T, A>) -> Difference<'a, T, A>
     where
         T: Ord,
     {
@@ -380,7 +482,10 @@ impl<T> BTreeSet<T> {
     /// assert_eq!(sym_diff, [1, 3]);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn symmetric_difference<'a>(&'a self, other: &'a BTreeSet<T>) -> SymmetricDifference<'a, T>
+    pub fn symmetric_difference<'a>(
+        &'a self,
+        other: &'a BTreeSet<T, A>,
+    ) -> SymmetricDifference<'a, T>
     where
         T: Ord,
     {
@@ -408,7 +513,7 @@ impl<T> BTreeSet<T> {
     /// assert_eq!(intersection, [2]);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn intersection<'a>(&'a self, other: &'a BTreeSet<T>) -> Intersection<'a, T>
+    pub fn intersection<'a>(&'a self, other: &'a BTreeSet<T, A>) -> Intersection<'a, T, A>
     where
         T: Ord,
     {
@@ -459,7 +564,7 @@ impl<T> BTreeSet<T> {
     /// assert_eq!(union, [1, 2]);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn union<'a>(&'a self, other: &'a BTreeSet<T>) -> Union<'a, T>
+    pub fn union<'a>(&'a self, other: &'a BTreeSet<T, A>) -> Union<'a, T>
     where
         T: Ord,
     {
@@ -479,7 +584,10 @@ impl<T> BTreeSet<T> {
     /// assert!(v.is_empty());
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn clear(&mut self) {
+    pub fn clear(&mut self)
+    where
+        A: Clone,
+    {
         self.map.clear()
     }
 
@@ -551,7 +659,7 @@ impl<T> BTreeSet<T> {
     /// ```
     #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn is_disjoint(&self, other: &BTreeSet<T>) -> bool
+    pub fn is_disjoint(&self, other: &BTreeSet<T, A>) -> bool
     where
         T: Ord,
     {
@@ -577,7 +685,7 @@ impl<T> BTreeSet<T> {
     /// ```
     #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn is_subset(&self, other: &BTreeSet<T>) -> bool
+    pub fn is_subset(&self, other: &BTreeSet<T, A>) -> bool
     where
         T: Ord,
     {
@@ -657,7 +765,7 @@ impl<T> BTreeSet<T> {
     /// ```
     #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn is_superset(&self, other: &BTreeSet<T>) -> bool
+    pub fn is_superset(&self, other: &BTreeSet<T, A>) -> bool
     where
         T: Ord,
     {
@@ -931,6 +1039,7 @@ impl<T> BTreeSet<T> {
     pub fn append(&mut self, other: &mut Self)
     where
         T: Ord,
+        A: Clone,
     {
         self.map.append(&mut other.map);
     }
@@ -968,6 +1077,7 @@ impl<T> BTreeSet<T> {
     pub fn split_off<Q: ?Sized + Ord>(&mut self, value: &Q) -> Self
     where
         T: Borrow<Q> + Ord,
+        A: Clone,
     {
         BTreeSet { map: self.map.split_off(value) }
     }
@@ -1002,12 +1112,13 @@ impl<T> BTreeSet<T> {
     /// assert_eq!(odds.into_iter().collect::<Vec<_>>(), vec![1, 3, 5, 7]);
     /// ```
     #[unstable(feature = "btree_drain_filter", issue = "70530")]
-    pub fn drain_filter<'a, F>(&'a mut self, pred: F) -> DrainFilter<'a, T, F>
+    pub fn drain_filter<'a, F>(&'a mut self, pred: F) -> DrainFilter<'a, T, F, A>
     where
         T: Ord,
         F: 'a + FnMut(&T) -> bool,
     {
-        DrainFilter { pred, inner: self.map.drain_filter_inner() }
+        let (inner, alloc) = self.map.drain_filter_inner();
+        DrainFilter { pred, inner, alloc }
     }
 
     /// Gets an iterator that visits the elements in the `BTreeSet` in ascending
@@ -1093,14 +1204,14 @@ impl<T: Ord> FromIterator<T> for BTreeSet<T> {
 
         // use stable sort to preserve the insertion order.
         inputs.sort();
-        BTreeSet::from_sorted_iter(inputs.into_iter())
+        BTreeSet::from_sorted_iter(inputs.into_iter(), Global)
     }
 }
 
-impl<T: Ord> BTreeSet<T> {
-    fn from_sorted_iter<I: Iterator<Item = T>>(iter: I) -> BTreeSet<T> {
+impl<T: Ord, A: Allocator> BTreeSet<T, A> {
+    fn from_sorted_iter<I: Iterator<Item = T>>(iter: I, alloc: A) -> BTreeSet<T, A> {
         let iter = iter.map(|k| (k, ()));
-        let map = BTreeMap::bulk_build_from_sorted_iter(iter);
+        let map = BTreeMap::bulk_build_from_sorted_iter(iter, alloc);
         BTreeSet { map }
     }
 }
@@ -1124,15 +1235,15 @@ impl<T: Ord, const N: usize> From<[T; N]> for BTreeSet<T> {
         // use stable sort to preserve the insertion order.
         arr.sort();
         let iter = IntoIterator::into_iter(arr).map(|k| (k, ()));
-        let map = BTreeMap::bulk_build_from_sorted_iter(iter);
+        let map = BTreeMap::bulk_build_from_sorted_iter(iter, Global);
         BTreeSet { map }
     }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T> IntoIterator for BTreeSet<T> {
+impl<T, A: Allocator> IntoIterator for BTreeSet<T, A> {
     type Item = T;
-    type IntoIter = IntoIter<T>;
+    type IntoIter = IntoIter<T, A>;
 
     /// Gets an iterator for moving out the `BTreeSet`'s contents.
     ///
@@ -1146,13 +1257,13 @@ impl<T> IntoIterator for BTreeSet<T> {
     /// let v: Vec<_> = set.into_iter().collect();
     /// assert_eq!(v, [1, 2, 3, 4]);
     /// ```
-    fn into_iter(self) -> IntoIter<T> {
+    fn into_iter(self) -> IntoIter<T, A> {
         IntoIter { iter: self.map.into_iter() }
     }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<'a, T> IntoIterator for &'a BTreeSet<T> {
+impl<'a, T, A: Allocator> IntoIterator for &'a BTreeSet<T, A> {
     type Item = &'a T;
     type IntoIter = Iter<'a, T>;
 
@@ -1163,17 +1274,22 @@ impl<'a, T> IntoIterator for &'a BTreeSet<T> {
 
 /// An iterator produced by calling `drain_filter` on BTreeSet.
 #[unstable(feature = "btree_drain_filter", issue = "70530")]
-pub struct DrainFilter<'a, T, F>
-where
+pub struct DrainFilter<
+    'a,
+    T,
+    F,
+    #[unstable(feature = "allocator_api", issue = "32838")] A: Allocator = Global,
+> where
     T: 'a,
     F: 'a + FnMut(&T) -> bool,
 {
     pred: F,
     inner: super::map::DrainFilterInner<'a, T, ()>,
+    alloc: &'a A,
 }
 
 #[unstable(feature = "btree_drain_filter", issue = "70530")]
-impl<T, F> Drop for DrainFilter<'_, T, F>
+impl<T, F, A: Allocator> Drop for DrainFilter<'_, T, F, A>
 where
     F: FnMut(&T) -> bool,
 {
@@ -1183,7 +1299,7 @@ where
 }
 
 #[unstable(feature = "btree_drain_filter", issue = "70530")]
-impl<T, F> fmt::Debug for DrainFilter<'_, T, F>
+impl<T, F, A: Allocator> fmt::Debug for DrainFilter<'_, T, F, A>
 where
     T: fmt::Debug,
     F: FnMut(&T) -> bool,
@@ -1194,7 +1310,7 @@ where
 }
 
 #[unstable(feature = "btree_drain_filter", issue = "70530")]
-impl<'a, T, F> Iterator for DrainFilter<'_, T, F>
+impl<'a, T, F, A: Allocator> Iterator for DrainFilter<'_, T, F, A>
 where
     F: 'a + FnMut(&T) -> bool,
 {
@@ -1203,7 +1319,7 @@ where
     fn next(&mut self) -> Option<T> {
         let pred = &mut self.pred;
         let mut mapped_pred = |k: &T, _v: &mut ()| pred(k);
-        self.inner.next(&mut mapped_pred).map(|(k, _)| k)
+        self.inner.next(&mut mapped_pred, &self.alloc).map(|(k, _)| k)
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -1212,10 +1328,10 @@ where
 }
 
 #[unstable(feature = "btree_drain_filter", issue = "70530")]
-impl<T, F> FusedIterator for DrainFilter<'_, T, F> where F: FnMut(&T) -> bool {}
+impl<T, F, A: Allocator> FusedIterator for DrainFilter<'_, T, F, A> where F: FnMut(&T) -> bool {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T: Ord> Extend<T> for BTreeSet<T> {
+impl<T: Ord, A: Allocator> Extend<T> for BTreeSet<T, A> {
     #[inline]
     fn extend<Iter: IntoIterator<Item = T>>(&mut self, iter: Iter) {
         iter.into_iter().for_each(move |elem| {
@@ -1230,7 +1346,7 @@ impl<T: Ord> Extend<T> for BTreeSet<T> {
 }
 
 #[stable(feature = "extend_ref", since = "1.2.0")]
-impl<'a, T: 'a + Ord + Copy> Extend<&'a T> for BTreeSet<T> {
+impl<'a, T: 'a + Ord + Copy, A: Allocator> Extend<&'a T> for BTreeSet<T, A> {
     fn extend<I: IntoIterator<Item = &'a T>>(&mut self, iter: I) {
         self.extend(iter.into_iter().cloned());
     }
@@ -1250,8 +1366,8 @@ impl<T> Default for BTreeSet<T> {
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T: Ord + Clone> Sub<&BTreeSet<T>> for &BTreeSet<T> {
-    type Output = BTreeSet<T>;
+impl<T: Ord + Clone, A: Allocator + Clone> Sub<&BTreeSet<T, A>> for &BTreeSet<T, A> {
+    type Output = BTreeSet<T, A>;
 
     /// Returns the difference of `self` and `rhs` as a new `BTreeSet<T>`.
     ///
@@ -1266,14 +1382,17 @@ impl<T: Ord + Clone> Sub<&BTreeSet<T>> for &BTreeSet<T> {
     /// let result = &a - &b;
     /// assert_eq!(result, BTreeSet::from([1, 2]));
     /// ```
-    fn sub(self, rhs: &BTreeSet<T>) -> BTreeSet<T> {
-        BTreeSet::from_sorted_iter(self.difference(rhs).cloned())
+    fn sub(self, rhs: &BTreeSet<T, A>) -> BTreeSet<T, A> {
+        BTreeSet::from_sorted_iter(
+            self.difference(rhs).cloned(),
+            ManuallyDrop::into_inner(self.map.alloc.clone()),
+        )
     }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T: Ord + Clone> BitXor<&BTreeSet<T>> for &BTreeSet<T> {
-    type Output = BTreeSet<T>;
+impl<T: Ord + Clone, A: Allocator + Clone> BitXor<&BTreeSet<T, A>> for &BTreeSet<T, A> {
+    type Output = BTreeSet<T, A>;
 
     /// Returns the symmetric difference of `self` and `rhs` as a new `BTreeSet<T>`.
     ///
@@ -1288,14 +1407,17 @@ impl<T: Ord + Clone> BitXor<&BTreeSet<T>> for &BTreeSet<T> {
     /// let result = &a ^ &b;
     /// assert_eq!(result, BTreeSet::from([1, 4]));
     /// ```
-    fn bitxor(self, rhs: &BTreeSet<T>) -> BTreeSet<T> {
-        BTreeSet::from_sorted_iter(self.symmetric_difference(rhs).cloned())
+    fn bitxor(self, rhs: &BTreeSet<T, A>) -> BTreeSet<T, A> {
+        BTreeSet::from_sorted_iter(
+            self.symmetric_difference(rhs).cloned(),
+            ManuallyDrop::into_inner(self.map.alloc.clone()),
+        )
     }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T: Ord + Clone> BitAnd<&BTreeSet<T>> for &BTreeSet<T> {
-    type Output = BTreeSet<T>;
+impl<T: Ord + Clone, A: Allocator + Clone> BitAnd<&BTreeSet<T, A>> for &BTreeSet<T, A> {
+    type Output = BTreeSet<T, A>;
 
     /// Returns the intersection of `self` and `rhs` as a new `BTreeSet<T>`.
     ///
@@ -1310,14 +1432,17 @@ impl<T: Ord + Clone> BitAnd<&BTreeSet<T>> for &BTreeSet<T> {
     /// let result = &a & &b;
     /// assert_eq!(result, BTreeSet::from([2, 3]));
     /// ```
-    fn bitand(self, rhs: &BTreeSet<T>) -> BTreeSet<T> {
-        BTreeSet::from_sorted_iter(self.intersection(rhs).cloned())
+    fn bitand(self, rhs: &BTreeSet<T, A>) -> BTreeSet<T, A> {
+        BTreeSet::from_sorted_iter(
+            self.intersection(rhs).cloned(),
+            ManuallyDrop::into_inner(self.map.alloc.clone()),
+        )
     }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T: Ord + Clone> BitOr<&BTreeSet<T>> for &BTreeSet<T> {
-    type Output = BTreeSet<T>;
+impl<T: Ord + Clone, A: Allocator + Clone> BitOr<&BTreeSet<T, A>> for &BTreeSet<T, A> {
+    type Output = BTreeSet<T, A>;
 
     /// Returns the union of `self` and `rhs` as a new `BTreeSet<T>`.
     ///
@@ -1332,13 +1457,16 @@ impl<T: Ord + Clone> BitOr<&BTreeSet<T>> for &BTreeSet<T> {
     /// let result = &a | &b;
     /// assert_eq!(result, BTreeSet::from([1, 2, 3, 4, 5]));
     /// ```
-    fn bitor(self, rhs: &BTreeSet<T>) -> BTreeSet<T> {
-        BTreeSet::from_sorted_iter(self.union(rhs).cloned())
+    fn bitor(self, rhs: &BTreeSet<T, A>) -> BTreeSet<T, A> {
+        BTreeSet::from_sorted_iter(
+            self.union(rhs).cloned(),
+            ManuallyDrop::into_inner(self.map.alloc.clone()),
+        )
     }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T: Debug> Debug for BTreeSet<T> {
+impl<T: Debug, A: Allocator> Debug for BTreeSet<T, A> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_set().entries(self.iter()).finish()
     }
@@ -1391,7 +1519,7 @@ impl<T> ExactSizeIterator for Iter<'_, T> {
 impl<T> FusedIterator for Iter<'_, T> {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T> Iterator for IntoIter<T> {
+impl<T, A: Allocator> Iterator for IntoIter<T, A> {
     type Item = T;
 
     fn next(&mut self) -> Option<T> {
@@ -1403,20 +1531,20 @@ impl<T> Iterator for IntoIter<T> {
     }
 }
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T> DoubleEndedIterator for IntoIter<T> {
+impl<T, A: Allocator> DoubleEndedIterator for IntoIter<T, A> {
     fn next_back(&mut self) -> Option<T> {
         self.iter.next_back().map(|(k, _)| k)
     }
 }
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T> ExactSizeIterator for IntoIter<T> {
+impl<T, A: Allocator> ExactSizeIterator for IntoIter<T, A> {
     fn len(&self) -> usize {
         self.iter.len()
     }
 }
 
 #[stable(feature = "fused", since = "1.26.0")]
-impl<T> FusedIterator for IntoIter<T> {}
+impl<T, A: Allocator> FusedIterator for IntoIter<T, A> {}
 
 #[stable(feature = "btree_range", since = "1.17.0")]
 impl<T> Clone for Range<'_, T> {
@@ -1457,7 +1585,7 @@ impl<'a, T> DoubleEndedIterator for Range<'a, T> {
 impl<T> FusedIterator for Range<'_, T> {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T> Clone for Difference<'_, T> {
+impl<T, A: Allocator + Clone> Clone for Difference<'_, T, A> {
     fn clone(&self) -> Self {
         Difference {
             inner: match &self.inner {
@@ -1474,7 +1602,7 @@ impl<T> Clone for Difference<'_, T> {
     }
 }
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<'a, T: Ord> Iterator for Difference<'a, T> {
+impl<'a, T: Ord, A: Allocator> Iterator for Difference<'a, T, A> {
     type Item = &'a T;
 
     fn next(&mut self) -> Option<&'a T> {
@@ -1521,7 +1649,7 @@ impl<'a, T: Ord> Iterator for Difference<'a, T> {
 }
 
 #[stable(feature = "fused", since = "1.26.0")]
-impl<T: Ord> FusedIterator for Difference<'_, T> {}
+impl<T: Ord, A: Allocator> FusedIterator for Difference<'_, T, A> {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T> Clone for SymmetricDifference<'_, T> {
@@ -1559,7 +1687,7 @@ impl<'a, T: Ord> Iterator for SymmetricDifference<'a, T> {
 impl<T: Ord> FusedIterator for SymmetricDifference<'_, T> {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<T> Clone for Intersection<'_, T> {
+impl<T, A: Allocator + Clone> Clone for Intersection<'_, T, A> {
     fn clone(&self) -> Self {
         Intersection {
             inner: match &self.inner {
@@ -1575,7 +1703,7 @@ impl<T> Clone for Intersection<'_, T> {
     }
 }
 #[stable(feature = "rust1", since = "1.0.0")]
-impl<'a, T: Ord> Iterator for Intersection<'a, T> {
+impl<'a, T: Ord, A: Allocator> Iterator for Intersection<'a, T, A> {
     type Item = &'a T;
 
     fn next(&mut self) -> Option<&'a T> {
@@ -1616,7 +1744,7 @@ impl<'a, T: Ord> Iterator for Intersection<'a, T> {
 }
 
 #[stable(feature = "fused", since = "1.26.0")]
-impl<T: Ord> FusedIterator for Intersection<'_, T> {}
+impl<T: Ord, A: Allocator> FusedIterator for Intersection<'_, T, A> {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T> Clone for Union<'_, T> {

--- a/library/alloc/src/collections/btree/split.rs
+++ b/library/alloc/src/collections/btree/split.rs
@@ -1,5 +1,6 @@
 use super::node::{ForceResult::*, Root};
 use super::search::SearchResult::*;
+use core::alloc::Allocator;
 use core::borrow::Borrow;
 
 impl<K, V> Root<K, V> {
@@ -28,12 +29,12 @@ impl<K, V> Root<K, V> {
     /// and if the ordering of `Q` corresponds to that of `K`.
     /// If `self` respects all `BTreeMap` tree invariants, then both
     /// `self` and the returned tree will respect those invariants.
-    pub fn split_off<Q: ?Sized + Ord>(&mut self, key: &Q) -> Self
+    pub fn split_off<Q: ?Sized + Ord, A: Allocator>(&mut self, key: &Q, alloc: &A) -> Self
     where
         K: Borrow<Q>,
     {
         let left_root = self;
-        let mut right_root = Root::new_pillar(left_root.height());
+        let mut right_root = Root::new_pillar(left_root.height(), alloc);
         let mut left_node = left_root.borrow_mut();
         let mut right_node = right_root.borrow_mut();
 
@@ -56,16 +57,16 @@ impl<K, V> Root<K, V> {
             }
         }
 
-        left_root.fix_right_border();
-        right_root.fix_left_border();
+        left_root.fix_right_border(alloc);
+        right_root.fix_left_border(alloc);
         right_root
     }
 
     /// Creates a tree consisting of empty nodes.
-    fn new_pillar(height: usize) -> Self {
-        let mut root = Root::new();
+    fn new_pillar<A: Allocator>(height: usize, alloc: &A) -> Self {
+        let mut root = Root::new(alloc);
         for _ in 0..height {
-            root.push_internal_level();
+            root.push_internal_level(alloc);
         }
         root
     }

--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -2363,6 +2363,7 @@ pub const unsafe fn write_bytes<T>(dst: *mut T, val: u8, count: usize) {
 #[rustc_const_unstable(feature = "const_eval_select", issue = "none")]
 #[lang = "const_eval_select"]
 #[rustc_do_not_const_check]
+#[inline]
 pub const unsafe fn const_eval_select<ARG, F, G, RET>(
     arg: ARG,
     _called_in_const: F,

--- a/src/etc/natvis/liballoc.natvis
+++ b/src/etc/natvis/liballoc.natvis
@@ -59,39 +59,133 @@
     </Expand>
   </Type>
 
+  <!--
+      The display string for Rc, Arc, etc is optional because the expression cannot be evaluated
+      if the pointee is unsized (i.e. if `ptr.pointer` is a fat pointer).
+
+      There are also two versions for the reference count fields, one for sized and one for
+      dyn pointees.
+
+      Rc<[T]> and Arc<[T]> are handled separately altogether so we can actually show
+      the slice values.
+  -->
+  <!-- alloc::rc::Rc<T> -->
   <Type Name="alloc::rc::Rc&lt;*&gt;">
-    <DisplayString>{ptr.pointer->value}</DisplayString>
+    <DisplayString Optional="true">{ptr.pointer->value}</DisplayString>
     <Expand>
-      <ExpandedItem>ptr.pointer->value</ExpandedItem>
-      <Item Name="[Reference count]">ptr.pointer->strong</Item>
-      <Item Name="[Weak reference count]">ptr.pointer->weak</Item>
-    </Expand>
-  </Type>
-  <Type Name="alloc::rc::Weak&lt;*&gt;">
-    <DisplayString>{ptr.pointer->value}</DisplayString>
-    <Expand>
-      <ExpandedItem>ptr.pointer->value</ExpandedItem>
-      <Item Name="[Reference count]">ptr.pointer->strong</Item>
-      <Item Name="[Weak reference count]">ptr.pointer->weak</Item>
+      <!-- thin -->
+      <ExpandedItem Optional="true">ptr.pointer->value</ExpandedItem>
+      <Item Name="[Reference count]" Optional="true">ptr.pointer->strong</Item>
+      <Item Name="[Weak reference count]" Optional="true">ptr.pointer->weak</Item>
+
+      <!-- dyn -->
+      <Item Name="[Reference count]" Optional="true">ptr.pointer.pointer->strong</Item>
+      <Item Name="[Weak reference count]" Optional="true">ptr.pointer.pointer->weak</Item>
     </Expand>
   </Type>
 
+  <!-- alloc::rc::Rc<[T]> -->
+  <Type Name="alloc::rc::Rc&lt;slice$&lt;*&gt; &gt;">
+    <DisplayString>{{ len={ptr.pointer.length} }}</DisplayString>
+    <Expand>
+      <Item Name="[Length]" ExcludeView="simple">ptr.pointer.length</Item>
+      <Item Name="[Reference count]">ptr.pointer.data_ptr->strong</Item>
+      <Item Name="[Weak reference count]">ptr.pointer.data_ptr->weak</Item>
+      <ArrayItems>
+        <Size>ptr.pointer.length</Size>
+        <!-- We add +2 to the data_ptr in order to skip the ref count fields in the RcBox -->
+        <ValuePointer>($T1*)(((size_t*)ptr.pointer.data_ptr) + 2)</ValuePointer>
+      </ArrayItems>
+    </Expand>
+  </Type>
+
+  <!-- alloc::rc::Weak<T> -->
+  <Type Name="alloc::rc::Weak&lt;*&gt;">
+    <DisplayString Optional="true">{ptr.pointer->value}</DisplayString>
+    <Expand>
+      <!-- thin -->
+      <ExpandedItem Optional="true">ptr.pointer->value</ExpandedItem>
+      <Item Name="[Reference count]" Optional="true">ptr.pointer->strong</Item>
+      <Item Name="[Weak reference count]" Optional="true">ptr.pointer->weak</Item>
+
+      <!-- dyn -->
+      <Item Name="[Reference count]" Optional="true">ptr.pointer.pointer->strong</Item>
+      <Item Name="[Weak reference count]" Optional="true">ptr.pointer.pointer->weak</Item>
+    </Expand>
+  </Type>
+
+  <!-- alloc::rc::Weak<[T]> -->
+  <Type Name="alloc::rc::Weak&lt;slice$&lt;*&gt; &gt;">
+    <DisplayString>{{ len={ptr.pointer.length} }}</DisplayString>
+    <Expand>
+      <Item Name="[Length]" ExcludeView="simple">ptr.pointer.length</Item>
+      <Item Name="[Reference count]">ptr.pointer.data_ptr->strong</Item>
+      <Item Name="[Weak reference count]">ptr.pointer.data_ptr->weak</Item>
+      <ArrayItems>
+        <Size>ptr.pointer.length</Size>
+        <ValuePointer>($T1*)(((size_t*)ptr.pointer.data_ptr) + 2)</ValuePointer>
+      </ArrayItems>
+    </Expand>
+  </Type>
+
+  <!-- alloc::sync::Arc<T> -->
   <Type Name="alloc::sync::Arc&lt;*&gt;">
-    <DisplayString>{ptr.pointer->data}</DisplayString>
+    <DisplayString Optional="true">{ptr.pointer->data}</DisplayString>
     <Expand>
-      <ExpandedItem>ptr.pointer->data</ExpandedItem>
-      <Item Name="[Reference count]">ptr.pointer->strong</Item>
-      <Item Name="[Weak reference count]">ptr.pointer->weak</Item>
+      <!-- thin -->
+      <ExpandedItem Optional="true">ptr.pointer->data</ExpandedItem>
+      <Item Name="[Reference count]" Optional="true">ptr.pointer->strong</Item>
+      <Item Name="[Weak reference count]" Optional="true">ptr.pointer->weak</Item>
+
+      <!-- dyn -->
+      <Item Name="[Reference count]" Optional="true">ptr.pointer.pointer->strong</Item>
+      <Item Name="[Weak reference count]" Optional="true">ptr.pointer.pointer->weak</Item>
     </Expand>
   </Type>
+
+  <!-- alloc::sync::Arc<[T]> -->
+  <Type Name="alloc::sync::Arc&lt;slice$&lt;*&gt; &gt;">
+    <DisplayString>{{ len={ptr.pointer.length} }}</DisplayString>
+    <Expand>
+      <Item Name="[Length]" ExcludeView="simple">ptr.pointer.length</Item>
+      <Item Name="[Reference count]">ptr.pointer.data_ptr->strong</Item>
+      <Item Name="[Weak reference count]">ptr.pointer.data_ptr->weak</Item>
+      <ArrayItems>
+        <Size>ptr.pointer.length</Size>
+        <ValuePointer>($T1*)(((size_t*)ptr.pointer.data_ptr) + 2)</ValuePointer>
+      </ArrayItems>
+    </Expand>
+  </Type>
+
+  <!-- alloc::sync::Weak<T> -->
   <Type Name="alloc::sync::Weak&lt;*&gt;">
-    <DisplayString>{ptr.pointer->data}</DisplayString>
+    <DisplayString Optional="true">{ptr.pointer->data}</DisplayString>
     <Expand>
-      <ExpandedItem>ptr.pointer->data</ExpandedItem>
-      <Item Name="[Reference count]">ptr.pointer->strong</Item>
-      <Item Name="[Weak reference count]">ptr.pointer->weak</Item>
+      <!-- thin -->
+      <ExpandedItem Optional="true">ptr.pointer->data</ExpandedItem>
+      <Item Name="[Reference count]" Optional="true">ptr.pointer->strong</Item>
+      <Item Name="[Weak reference count]" Optional="true">ptr.pointer->weak</Item>
+
+      <!-- dyn -->
+      <Item Name="[Reference count]" Optional="true">ptr.pointer.pointer->strong</Item>
+      <Item Name="[Weak reference count]" Optional="true">ptr.pointer.pointer->weak</Item>
     </Expand>
   </Type>
+
+  <!-- alloc::sync::Weak<[T]> -->
+  <Type Name="alloc::sync::Weak&lt;slice$&lt;*&gt; &gt;">
+    <DisplayString>{{ len={ptr.pointer.length} }}</DisplayString>
+    <Expand>
+      <Item Name="[Length]" ExcludeView="simple">ptr.pointer.length</Item>
+      <Item Name="[Reference count]">ptr.pointer.data_ptr->strong</Item>
+      <Item Name="[Weak reference count]">ptr.pointer.data_ptr->weak</Item>
+      <ArrayItems>
+        <Size>ptr.pointer.length</Size>
+        <ValuePointer>($T1*)(((size_t*)ptr.pointer.data_ptr) + 2)</ValuePointer>
+      </ArrayItems>
+    </Expand>
+  </Type>
+
   <Type Name="alloc::borrow::Cow&lt;*&gt;">
     <DisplayString Condition="RUST$ENUM$DISR == 0x0">Borrowed({__0})</DisplayString>
     <DisplayString Condition="RUST$ENUM$DISR == 0x1">Owned({__0})</DisplayString>

--- a/src/librustdoc/html/static/js/source-script.js
+++ b/src/librustdoc/html/static/js/source-script.js
@@ -32,10 +32,10 @@ function createDirEntry(elem, parent, fullPath, currentFile, hasFoundFile) {
     fullPath += elem["name"] + "/";
 
     name.onclick = () => {
-        if (hasClass(this, "expand")) {
-            removeClass(this, "expand");
+        if (hasClass(name, "expand")) {
+            removeClass(name, "expand");
         } else {
-            addClass(this, "expand");
+            addClass(name, "expand");
         }
     };
     name.innerText = elem["name"];

--- a/src/test/debuginfo/rc_arc.rs
+++ b/src/test/debuginfo/rc_arc.rs
@@ -8,74 +8,138 @@
 
 // gdb-command:run
 
-// gdb-command:print r
-// gdb-check:[...]$1 = Rc(strong=2, weak=1) = {value = 42, strong = 2, weak = 1}
-// gdb-command:print a
-// gdb-check:[...]$2 = Arc(strong=2, weak=1) = {value = 42, strong = 2, weak = 1}
-
+// gdb-command:print rc
+// gdb-check:[...]$1 = Rc(strong=11, weak=1) = {value = 111, strong = 11, weak = 1}
+// gdb-command:print arc
+// gdb-check:[...]$2 = Arc(strong=21, weak=1) = {value = 222, strong = 21, weak = 1}
 
 // === LLDB TESTS ==================================================================================
 
 // lldb-command:run
 
-// lldb-command:print r
-// lldb-check:[...]$0 = strong=2, weak=1 { value = 42 }
-// lldb-command:print a
-// lldb-check:[...]$1 = strong=2, weak=1 { data = 42 }
+// lldb-command:print rc
+// lldb-check:[...]$0 = strong=11, weak=1 { value = 111 }
+// lldb-command:print arc
+// lldb-check:[...]$1 = strong=21, weak=1 { data = 222 }
 
 // === CDB TESTS ==================================================================================
 
 // cdb-command:g
 
-// cdb-command:dx r,d
-// cdb-check:r,d              : 42 [Type: alloc::rc::Rc<i32>]
-// cdb-check:    [<Raw View>]     [Type: alloc::rc::Rc<i32>]
-// cdb-check:    [Reference count] : 2 [Type: core::cell::Cell<usize>]
+// cdb-command:dx rc,d
+// cdb-check:rc,d             : 111 [Type: alloc::rc::Rc<i32>]
+// cdb-check:    [Reference count] : 11 [Type: core::cell::Cell<usize>]
 // cdb-check:    [Weak reference count] : 2 [Type: core::cell::Cell<usize>]
 
-// cdb-command:dx r1,d
-// cdb-check:r1,d             : 42 [Type: alloc::rc::Rc<i32>]
-// cdb-check:    [<Raw View>]     [Type: alloc::rc::Rc<i32>]
-// cdb-check:    [Reference count] : 2 [Type: core::cell::Cell<usize>]
+// cdb-command:dx weak_rc,d
+// cdb-check:weak_rc,d        : 111 [Type: alloc::rc::Weak<i32>]
+// cdb-check:    [Reference count] : 11 [Type: core::cell::Cell<usize>]
 // cdb-check:    [Weak reference count] : 2 [Type: core::cell::Cell<usize>]
 
-// cdb-command:dx w1,d
-// cdb-check:w1,d             : 42 [Type: alloc::rc::Weak<i32>]
-// cdb-check:    [<Raw View>]     [Type: alloc::rc::Weak<i32>]
-// cdb-check:    [Reference count] : 2 [Type: core::cell::Cell<usize>]
+// cdb-command:dx arc,d
+// cdb-check:arc,d            : 222 [Type: alloc::sync::Arc<i32>]
+// cdb-check:    [Reference count] : 21 [Type: core::sync::atomic::AtomicUsize]
+// cdb-check:    [Weak reference count] : 2 [Type: core::sync::atomic::AtomicUsize]
+
+// cdb-command:dx weak_arc,d
+// cdb-check:weak_arc,d       : 222 [Type: alloc::sync::Weak<i32>]
+// cdb-check:    [Reference count] : 21 [Type: core::sync::atomic::AtomicUsize]
+// cdb-check:    [Weak reference count] : 2 [Type: core::sync::atomic::AtomicUsize]
+
+// cdb-command:dx dyn_rc,d
+// cdb-check:dyn_rc,d         [Type: alloc::rc::Rc<dyn$<core::fmt::Debug> >]
+// cdb-check:    [Reference count] : 31 [Type: core::cell::Cell<usize>]
 // cdb-check:    [Weak reference count] : 2 [Type: core::cell::Cell<usize>]
 
-// cdb-command:dx a,d
-// cdb-check:a,d              : 42 [Type: alloc::sync::Arc<i32>]
-// cdb-check:    [<Raw View>]     [Type: alloc::sync::Arc<i32>]
-// cdb-check:    [Reference count] : 2 [Type: core::sync::atomic::AtomicUsize]
+// cdb-command:dx dyn_rc_weak,d
+// cdb-check:dyn_rc_weak,d    [Type: alloc::rc::Weak<dyn$<core::fmt::Debug> >]
+// cdb-check:    [Reference count] : 31 [Type: core::cell::Cell<usize>]
+// cdb-check:    [Weak reference count] : 2 [Type: core::cell::Cell<usize>]
+
+// cdb-command:dx slice_rc,d
+// cdb-check:slice_rc,d       : { len=3 } [Type: alloc::rc::Rc<slice$<u32> >]
+// cdb-check:    [Length]         : 3 [Type: unsigned __int64]
+// cdb-check:    [Reference count] : 41 [Type: core::cell::Cell<usize>]
+// cdb-check:    [Weak reference count] : 2 [Type: core::cell::Cell<usize>]
+// cdb-check:    [0]              : 1 [Type: u32]
+// cdb-check:    [1]              : 2 [Type: u32]
+// cdb-check:    [2]              : 3 [Type: u32]
+
+// cdb-command:dx slice_rc_weak,d
+// cdb-check:slice_rc_weak,d  : { len=3 } [Type: alloc::rc::Weak<slice$<u32> >]
+// cdb-check:    [Length]         : 3 [Type: unsigned __int64]
+// cdb-check:    [Reference count] : 41 [Type: core::cell::Cell<usize>]
+// cdb-check:    [Weak reference count] : 2 [Type: core::cell::Cell<usize>]
+// cdb-check:    [0]              : 1 [Type: u32]
+// cdb-check:    [1]              : 2 [Type: u32]
+// cdb-check:    [2]              : 3 [Type: u32]
+
+// cdb-command:dx dyn_arc,d
+// cdb-check:dyn_arc,d        [Type: alloc::sync::Arc<dyn$<core::fmt::Debug> >]
+// cdb-check:    [Reference count] : 51 [Type: core::sync::atomic::AtomicUsize]
 // cdb-check:    [Weak reference count] : 2 [Type: core::sync::atomic::AtomicUsize]
 
-// cdb-command:dx a1,d
-// cdb-check:a1,d             : 42 [Type: alloc::sync::Arc<i32>]
-// cdb-check:    [<Raw View>]     [Type: alloc::sync::Arc<i32>]
-// cdb-check:    [Reference count] : 2 [Type: core::sync::atomic::AtomicUsize]
+// cdb-command:dx dyn_arc_weak,d
+// cdb-check:dyn_arc_weak,d   [Type: alloc::sync::Weak<dyn$<core::fmt::Debug> >]
+// cdb-check:    [Reference count] : 51 [Type: core::sync::atomic::AtomicUsize]
 // cdb-check:    [Weak reference count] : 2 [Type: core::sync::atomic::AtomicUsize]
 
-// cdb-command:dx w2,d
-// cdb-check:w2,d             : 42 [Type: alloc::sync::Weak<i32>]
-// cdb-check:    [<Raw View>]     [Type: alloc::sync::Weak<i32>]
-// cdb-check:    [Reference count] : 2 [Type: core::sync::atomic::AtomicUsize]
+// cdb-command:dx slice_arc,d
+// cdb-check:slice_arc,d      : { len=3 } [Type: alloc::sync::Arc<slice$<u32> >]
+// cdb-check:    [Length]         : 3 [Type: unsigned __int64]
+// cdb-check:    [Reference count] : 61 [Type: core::sync::atomic::AtomicUsize]
 // cdb-check:    [Weak reference count] : 2 [Type: core::sync::atomic::AtomicUsize]
+// cdb-check:    [0]              : 4 [Type: u32]
+// cdb-check:    [1]              : 5 [Type: u32]
+// cdb-check:    [2]              : 6 [Type: u32]
 
+// cdb-command:dx slice_arc_weak,d
+// cdb-check:slice_arc_weak,d : { len=3 } [Type: alloc::sync::Weak<slice$<u32> >]
+// cdb-check:    [Length]         : 3 [Type: unsigned __int64]
+// cdb-check:    [Reference count] : 61 [Type: core::sync::atomic::AtomicUsize]
+// cdb-check:    [Weak reference count] : 2 [Type: core::sync::atomic::AtomicUsize]
+// cdb-check:    [0]              : 4 [Type: u32]
+// cdb-check:    [1]              : 5 [Type: u32]
+// cdb-check:    [2]              : 6 [Type: u32]
+
+use std::fmt::Debug;
 use std::rc::Rc;
 use std::sync::Arc;
 
 fn main() {
-    let r = Rc::new(42);
-    let r1 = Rc::clone(&r);
-    let w1 = Rc::downgrade(&r);
+    let rc = Rc::new(111);
+    inc_ref_count(&rc, 10);
+    let weak_rc = Rc::downgrade(&rc);
 
-    let a = Arc::new(42);
-    let a1 = Arc::clone(&a);
-    let w2 = Arc::downgrade(&a);
+    let arc = Arc::new(222);
+    inc_ref_count(&arc, 20);
+    let weak_arc = Arc::downgrade(&arc);
+
+    let dyn_rc: Rc<dyn Debug> = Rc::new(333);
+    inc_ref_count(&dyn_rc, 30);
+    let dyn_rc_weak = Rc::downgrade(&dyn_rc);
+
+    let slice_rc: Rc<[u32]> = Rc::from(vec![1, 2, 3]);
+    inc_ref_count(&slice_rc, 40);
+    let slice_rc_weak = Rc::downgrade(&slice_rc);
+
+    let dyn_arc: Arc<dyn Debug> = Arc::new(444);
+    inc_ref_count(&dyn_arc, 50);
+    let dyn_arc_weak = Arc::downgrade(&dyn_arc);
+
+    let slice_arc: Arc<[u32]> = Arc::from(vec![4, 5, 6]);
+    inc_ref_count(&slice_arc, 60);
+    let slice_arc_weak = Arc::downgrade(&slice_arc);
 
     zzz(); // #break
 }
 
-fn zzz() { () }
+fn inc_ref_count<T: Clone>(rc: &T, count: usize) {
+    for _ in 0..count {
+        std::mem::forget(rc.clone());
+    }
+}
+
+fn zzz() {
+    ()
+}

--- a/src/test/rustdoc-gui/source-code-page.goml
+++ b/src/test/rustdoc-gui/source-code-page.goml
@@ -1,4 +1,4 @@
-// Checks that the interactions with the source code pages are workined as expected.
+// Checks that the interactions with the source code pages are working as expected.
 goto: file://|DOC_PATH|/src/test_docs/lib.rs.html
 // Check that we can click on the line number.
 click: ".line-numbers > span:nth-child(4)" // This is the span for line 4.
@@ -27,3 +27,26 @@ assert-position: ("//*[@id='1']", {"x": 104, "y": 103})
 // We click on the left of the "1" span but still in the "line-number" `<pre>`.
 click: (103, 103)
 assert-document-property: ({"URL": "/lib.rs.html"}, ENDS_WITH)
+
+// Checking the source code sidebar.
+
+// First we "open" it.
+click: "#sidebar-toggle"
+assert: ".sidebar.expanded"
+
+// We check that the first entry of the sidebar is collapsed (which, for whatever reason,
+// is number 2 and not 1...).
+assert-attribute: ("#source-sidebar .name:nth-child(2)", {"class": "name"})
+assert-text: ("#source-sidebar .name:nth-child(2)", "implementors")
+// We also check its children are hidden too.
+assert-css: ("#source-sidebar .name:nth-child(2) + .children", {"display": "none"})
+// We now click on it.
+click: "#source-sidebar .name:nth-child(2)"
+assert-attribute: ("#source-sidebar .name:nth-child(2)", {"class": "name expand"})
+// Checking that its children are displayed as well.
+assert-css: ("#source-sidebar .name:nth-child(2) + .children", {"display": "block"})
+
+// And now we collapse it again.
+click: "#source-sidebar .name:nth-child(2)"
+assert-attribute: ("#source-sidebar .name:nth-child(2)", {"class": "name"})
+assert-css: ("#source-sidebar .name:nth-child(2) + .children", {"display": "none"})

--- a/src/test/rustdoc-json/generic_impl.rs
+++ b/src/test/rustdoc-json/generic_impl.rs
@@ -1,0 +1,24 @@
+// Regression test for <https://github.com/rust-lang/rust/issues/97986>.
+
+// @has generic_impl.json
+// @has - "$.index[*][?(@.name=='f')]"
+// @has - "$.index[*][?(@.name=='AssocTy')]"
+// @has - "$.index[*][?(@.name=='AssocConst')]"
+
+pub mod m {
+    pub struct S;
+}
+
+pub trait F {
+    type AssocTy;
+    const AssocConst: usize;
+    fn f() -> m::S;
+}
+
+impl<T> F for T {
+    type AssocTy = u32;
+    const AssocConst: usize = 0;
+    fn f() -> m::S {
+        m::S
+    }
+}

--- a/src/test/ui/associated-consts/issue-93775.rs
+++ b/src/test/ui/associated-consts/issue-93775.rs
@@ -1,0 +1,29 @@
+// build-pass
+// ignore-tidy-linelength
+
+// Regression for #93775, needs build-pass to test it.
+
+#![recursion_limit = "1000"]
+
+use std::marker::PhantomData;
+
+struct Z;
+struct S<T>(PhantomData<T>);
+
+type Nested = S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<Z>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>;
+
+trait AsNum {
+    const NUM: u32;
+}
+
+impl AsNum for Z {
+    const NUM: u32 = 0;
+}
+
+impl<T: AsNum> AsNum for S<T> {
+    const NUM: u32 = T::NUM + 1;
+}
+
+fn main() {
+    let _ = Nested::NUM;
+}

--- a/src/test/ui/variance/variance-btree-invariant-types.stderr
+++ b/src/test/ui/variance/variance-btree-invariant-types.stderr
@@ -104,7 +104,7 @@ LL |     v
    |     ^ returning this value requires that `'new` must outlive `'static`
    |
    = note: requirement occurs because of the type `std::collections::btree_map::OccupiedEntry<'_, &(), ()>`, which makes the generic argument `&()` invariant
-   = note: the struct `std::collections::btree_map::OccupiedEntry<'a, K, V>` is invariant over the parameter `K`
+   = note: the struct `std::collections::btree_map::OccupiedEntry<'a, K, V, A>` is invariant over the parameter `K`
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
 error: lifetime may not live long enough
@@ -117,7 +117,7 @@ LL |     v
    |     ^ returning this value requires that `'new` must outlive `'static`
    |
    = note: requirement occurs because of the type `std::collections::btree_map::OccupiedEntry<'_, (), &()>`, which makes the generic argument `()` invariant
-   = note: the struct `std::collections::btree_map::OccupiedEntry<'a, K, V>` is invariant over the parameter `K`
+   = note: the struct `std::collections::btree_map::OccupiedEntry<'a, K, V, A>` is invariant over the parameter `K`
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
 error: lifetime may not live long enough
@@ -130,7 +130,7 @@ LL |     v
    |     ^ returning this value requires that `'new` must outlive `'static`
    |
    = note: requirement occurs because of the type `std::collections::btree_map::OccupiedEntry<'_, &(), ()>`, which makes the generic argument `&()` invariant
-   = note: the struct `std::collections::btree_map::OccupiedEntry<'a, K, V>` is invariant over the parameter `K`
+   = note: the struct `std::collections::btree_map::OccupiedEntry<'a, K, V, A>` is invariant over the parameter `K`
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
 error: lifetime may not live long enough
@@ -143,7 +143,7 @@ LL |     v
    |     ^ returning this value requires that `'new` must outlive `'static`
    |
    = note: requirement occurs because of the type `std::collections::btree_map::OccupiedEntry<'_, (), &()>`, which makes the generic argument `()` invariant
-   = note: the struct `std::collections::btree_map::OccupiedEntry<'a, K, V>` is invariant over the parameter `K`
+   = note: the struct `std::collections::btree_map::OccupiedEntry<'a, K, V, A>` is invariant over the parameter `K`
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
 error: lifetime may not live long enough
@@ -156,7 +156,7 @@ LL |     v
    |     ^ returning this value requires that `'new` must outlive `'static`
    |
    = note: requirement occurs because of the type `std::collections::btree_map::VacantEntry<'_, &(), ()>`, which makes the generic argument `&()` invariant
-   = note: the struct `std::collections::btree_map::VacantEntry<'a, K, V>` is invariant over the parameter `K`
+   = note: the struct `std::collections::btree_map::VacantEntry<'a, K, V, A>` is invariant over the parameter `K`
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
 error: lifetime may not live long enough
@@ -169,7 +169,7 @@ LL |     v
    |     ^ returning this value requires that `'new` must outlive `'static`
    |
    = note: requirement occurs because of the type `std::collections::btree_map::VacantEntry<'_, (), &()>`, which makes the generic argument `()` invariant
-   = note: the struct `std::collections::btree_map::VacantEntry<'a, K, V>` is invariant over the parameter `K`
+   = note: the struct `std::collections::btree_map::VacantEntry<'a, K, V, A>` is invariant over the parameter `K`
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
 error: lifetime may not live long enough
@@ -182,7 +182,7 @@ LL |     v
    |     ^ returning this value requires that `'new` must outlive `'static`
    |
    = note: requirement occurs because of the type `std::collections::btree_map::VacantEntry<'_, &(), ()>`, which makes the generic argument `&()` invariant
-   = note: the struct `std::collections::btree_map::VacantEntry<'a, K, V>` is invariant over the parameter `K`
+   = note: the struct `std::collections::btree_map::VacantEntry<'a, K, V, A>` is invariant over the parameter `K`
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
 error: lifetime may not live long enough
@@ -195,7 +195,7 @@ LL |     v
    |     ^ returning this value requires that `'new` must outlive `'static`
    |
    = note: requirement occurs because of the type `std::collections::btree_map::VacantEntry<'_, (), &()>`, which makes the generic argument `()` invariant
-   = note: the struct `std::collections::btree_map::VacantEntry<'a, K, V>` is invariant over the parameter `K`
+   = note: the struct `std::collections::btree_map::VacantEntry<'a, K, V, A>` is invariant over the parameter `K`
    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 
 error: aborting due to 16 previous errors


### PR DESCRIPTION
Successful merges:

 - #98053 (Fix generic impl rustdoc json output)
 - #98059 (Inline `const_eval_select`)
 - #98092 (Fix sidebar items expand collapse)
 - #98103 (BTreeMap: Support custom allocators (v1.5))
 - #98135 (Add regression test for #93775)
 - #98137 (debuginfo: Fix NatVis for Rc and Arc with unsized pointees.)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=98053,98059,98092,98103,98135,98137)
<!-- homu-ignore:end -->