### PR TITLE
compiletest: strip debuginfo by default for mode=ui

### DIFF
--- a/src/test/ui/backtrace-apple-no-dsymutil.rs
+++ b/src/test/ui/backtrace-apple-no-dsymutil.rs
@@ -1,5 +1,6 @@
 // run-pass
 
+// compile-flags:-Cstrip=none
 // compile-flags:-g -Csplit-debuginfo=unpacked
 // only-macos
 

--- a/src/test/ui/backtrace.rs
+++ b/src/test/ui/backtrace.rs
@@ -5,6 +5,7 @@
 // ignore-sgx no processes
 // ignore-msvc see #62897 and `backtrace-debuginfo.rs` test
 // compile-flags:-g
+// compile-flags:-Cstrip=none
 
 use std::env;
 use std::process::{Command, Stdio};

--- a/src/test/ui/numbers-arithmetic/promoted_overflow.rs
+++ b/src/test/ui/numbers-arithmetic/promoted_overflow.rs
@@ -3,6 +3,10 @@
 // run-fail
 // error-pattern: overflow
 // compile-flags: -C overflow-checks=yes
+// for some reason, fails to match error string on
+// wasm32-unknown-unknown with stripped debuginfo and symbols,
+// so don't strip it
+// compile-flags:-Cstrip=none
 
 fn main() {
     let x: &'static u32 = &(0u32 - 1);

--- a/src/test/ui/panics/issue-47429-short-backtraces.legacy.run.stderr
+++ b/src/test/ui/panics/issue-47429-short-backtraces.legacy.run.stderr
@@ -1,4 +1,4 @@
-thread 'main' panicked at 'explicit panic', $DIR/issue-47429-short-backtraces.rs:21:5
+thread 'main' panicked at 'explicit panic', $DIR/issue-47429-short-backtraces.rs:22:5
 stack backtrace:
    0: std::panicking::begin_panic
    1: issue_47429_short_backtraces::main

--- a/src/test/ui/panics/issue-47429-short-backtraces.rs
+++ b/src/test/ui/panics/issue-47429-short-backtraces.rs
@@ -1,6 +1,7 @@
 // Regression test for #47429: short backtraces were not terminating correctly
 
 // compile-flags: -O
+// compile-flags:-Cstrip=none
 // run-fail
 // check-run-results
 // exec-env:RUST_BACKTRACE=1

--- a/src/test/ui/panics/issue-47429-short-backtraces.v0.run.stderr
+++ b/src/test/ui/panics/issue-47429-short-backtraces.v0.run.stderr
@@ -1,4 +1,4 @@
-thread 'main' panicked at 'explicit panic', $DIR/issue-47429-short-backtraces.rs:21:5
+thread 'main' panicked at 'explicit panic', $DIR/issue-47429-short-backtraces.rs:22:5
 stack backtrace:
    0: std::panicking::begin_panic::<&str>
    1: issue_47429_short_backtraces::main

--- a/src/test/ui/panics/runtime-switch.legacy.run.stderr
+++ b/src/test/ui/panics/runtime-switch.legacy.run.stderr
@@ -1,4 +1,4 @@
-thread 'main' panicked at 'explicit panic', $DIR/runtime-switch.rs:24:5
+thread 'main' panicked at 'explicit panic', $DIR/runtime-switch.rs:25:5
 stack backtrace:
    0: std::panicking::begin_panic
    1: runtime_switch::main

--- a/src/test/ui/panics/runtime-switch.rs
+++ b/src/test/ui/panics/runtime-switch.rs
@@ -1,6 +1,7 @@
 // Test for std::panic::set_backtrace_style.
 
 // compile-flags: -O
+// compile-flags:-Cstrip=none
 // run-fail
 // check-run-results
 // exec-env:RUST_BACKTRACE=0

--- a/src/test/ui/panics/runtime-switch.v0.run.stderr
+++ b/src/test/ui/panics/runtime-switch.v0.run.stderr
@@ -1,4 +1,4 @@
-thread 'main' panicked at 'explicit panic', $DIR/runtime-switch.rs:24:5
+thread 'main' panicked at 'explicit panic', $DIR/runtime-switch.rs:25:5
 stack backtrace:
    0: std::panicking::begin_panic::<&str>
    1: runtime_switch::main

--- a/src/test/ui/panics/unique-panic.rs
+++ b/src/test/ui/panics/unique-panic.rs
@@ -1,5 +1,9 @@
 // run-fail
 // error-pattern: panic
+// for some reason, fails to match error string on
+// wasm32-unknown-unknown with stripped debuginfo and symbols,
+// so don't strip it
+// compile-flags:-Cstrip=none
 
 fn main() {
     Box::new(panic!());

--- a/src/test/ui/runtime/backtrace-debuginfo.rs
+++ b/src/test/ui/runtime/backtrace-debuginfo.rs
@@ -8,6 +8,7 @@
 
 // compile-flags:-g -Copt-level=0 -Cllvm-args=-enable-tail-merge=0
 // compile-flags:-Cforce-frame-pointers=yes
+// compile-flags:-Cstrip=none
 // ignore-pretty issue #37195
 // ignore-emscripten spawning processes is not supported
 // ignore-sgx no processes

--- a/src/test/ui/std-backtrace.rs
+++ b/src/test/ui/std-backtrace.rs
@@ -5,6 +5,7 @@
 // ignore-sgx no processes
 // ignore-msvc see #62897 and `backtrace-debuginfo.rs` test
 // compile-flags:-g
+// compile-flags:-Cstrip=none
 
 #![feature(backtrace)]
 

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -1882,6 +1882,8 @@ impl<'test> TestCx<'test> {
                 rustc.arg("-Ccodegen-units=1");
                 rustc.arg("-Zui-testing");
                 rustc.arg("-Zdeduplicate-diagnostics=no");
+                // FIXME: use this for other modes too, for perf?
+                rustc.arg("-Cstrip=debuginfo");
             }
             MirOpt => {
                 rustc.args(&[


### PR DESCRIPTION
This reduces occupied disk space, for example for src/test/ui it drops from 1972mb to 132mb (x86_64-pc-windows-msvc).

Individual tests that require debuginfo/symbols should turn this option off (as in fixed tests).