### PR TITLE
Add __CxxFrameHandler3 to panic_abort for UEFI

### DIFF
--- a/library/panic_abort/src/lib.rs
+++ b/library/panic_abort/src/lib.rs
@@ -153,4 +153,8 @@ pub mod personalities {
     #[rustc_std_internal_symbol]
     #[cfg(all(target_os = "windows", target_env = "gnu", target_arch = "x86"))]
     pub extern "C" fn rust_eh_unregister_frames() {}
+
+    #[cfg(target_os = "uefi")]
+    #[no_mangle]
+    pub extern "C" fn __CxxFrameHandler3() {}
 }


### PR DESCRIPTION
This function is needed to compile std under UEFI.

Related to #98133 

Maybe it should be present for the whole llvm-windows target family?