### PR TITLE
Remove --memory-init-file flag when linking with Emscripten

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/linker.rs
+++ b/compiler/rustc_codegen_ssa/src/back/linker.rs
@@ -1120,8 +1120,6 @@ impl<'a> Linker for EmLinker<'a> {
             OptLevel::Size => "-Os",
             OptLevel::SizeMin => "-Oz",
         });
-        // Unusable until https://github.com/rust-lang/rust/issues/38454 is resolved
-        self.cmd.args(&["--memory-init-file", "0"]);
     }
 
     fn pgo_gen(&mut self) {

--- a/compiler/rustc_target/src/spec/asmjs_unknown_emscripten.rs
+++ b/compiler/rustc_target/src/spec/asmjs_unknown_emscripten.rs
@@ -2,10 +2,10 @@ use super::{wasm32_unknown_emscripten, LinkerFlavor, Target};
 
 pub fn target() -> Target {
     let mut target = wasm32_unknown_emscripten::target();
-    target
-        .post_link_args
-        .entry(LinkerFlavor::Em)
-        .or_default()
-        .extend(vec!["-s".into(), "WASM=0".into()]);
+    target.post_link_args.entry(LinkerFlavor::Em).or_default().extend(vec![
+        "-sWASM=0".into(),
+        "--memory-init-file".into(),
+        "0".into(),
+    ]);
     target
 }


### PR DESCRIPTION
This flag does nothing. It only applies when generating asmjs JavaScript.
@sbc100