### PR TITLE
[RFC 2011] Expand expressions where possible

### DIFF
--- a/src/test/ui/macros/rfc-2011-nicer-assert-messages/all-expr-kinds.rs
+++ b/src/test/ui/macros/rfc-2011-nicer-assert-messages/all-expr-kinds.rs
@@ -55,14 +55,56 @@ struct Foo {
   bar: i32
 }
 
+impl Foo {
+  fn add(&self, a: i32, b: i32) -> i32 { a + b }
+}
+
+fn add(a: i32, b: i32) -> i32 { a + b }
+
 fn main() {
   // ***** Allowed *****
 
   tests!(
     let mut elem = 1i32;
 
+    // addr of
+    [ &elem == &3 ] => "Assertion failed: &elem == &3\nWith captures:\n  elem = 1\n"
+
+    // array
+    [ [elem][0] == 3 ] => "Assertion failed: [elem][0] == 3\nWith captures:\n  elem = 1\n"
+
     // binary
     [ elem + 1 == 3 ] => "Assertion failed: elem + 1 == 3\nWith captures:\n  elem = 1\n"
+
+    // call
+    [ add(elem, elem) == 3 ] => "Assertion failed: add(elem, elem) == 3\nWith captures:\n  elem = 1\n"
+
+    // cast
+    [ elem as i32 == 3 ] => "Assertion failed: elem as i32 == 3\nWith captures:\n  elem = 1\n"
+
+    // index
+    [ [1i32, 1][elem as usize] == 3 ] => "Assertion failed: [1i32, 1][elem as usize] == 3\nWith captures:\n  elem = 1\n"
+
+    // method call
+    [ FOO.add(elem, elem) == 3 ] => "Assertion failed: FOO.add(elem, elem) == 3\nWith captures:\n  elem = 1\n"
+
+    // paren
+    [ (elem) == 3 ] => "Assertion failed: (elem) == 3\nWith captures:\n  elem = 1\n"
+
+    // range
+    [ (0..elem) == (0..3) ] => "Assertion failed: (0..elem) == (0..3)\nWith captures:\n  elem = 1\n"
+
+    // repeat
+    [ [elem; 1] == [3; 1] ] => "Assertion failed: [elem; 1] == [3; 1]\nWith captures:\n  elem = 1\n"
+
+    // struct
+    [ Foo { bar: elem } == Foo { bar: 3 } ] => "Assertion failed: Foo { bar: elem } == Foo { bar: 3 }\nWith captures:\n  elem = 1\n"
+
+    // tuple
+    [ (elem, 1) == (3, 3) ] => "Assertion failed: (elem, 1) == (3, 3)\nWith captures:\n  elem = 1\n"
+
+    // unary
+    [ -elem == -3 ] => "Assertion failed: -elem == -3\nWith captures:\n  elem = 1\n"
   );
 
   // ***** Disallowed *****


### PR DESCRIPTION
Tracking issue: https://github.com/rust-lang/rust/issues/44838
Fourth step of https://github.com/rust-lang/rust/pull/96496

Extends https://github.com/rust-lang/rust/pull/97665 considering expressions that are good candidates for expansion.

r? @oli-obk