### PR TITLE
Emscripten target: replace -g4 with -g, and -g3 with --profiling-funcs

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/linker.rs
+++ b/compiler/rustc_codegen_ssa/src/back/linker.rs
@@ -1134,8 +1134,8 @@ impl<'a> Linker for EmLinker<'a> {
         // Preserve names or generate source maps depending on debug info
         self.cmd.arg(match self.sess.opts.debuginfo {
             DebugInfo::None => "-g0",
-            DebugInfo::Limited => "-g3",
-            DebugInfo::Full => "-g4",
+            DebugInfo::Limited => "--profiling-funcs",
+            DebugInfo::Full => "-g",
         });
     }
 


### PR DESCRIPTION
Emscripten prints the following warning:
```
emcc: warning: please replace -g4 with -gsource-map [-Wdeprecated]
```
@sbc100