### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/compiler/rustc_typeck/src/check/pat.rs
+++ b/compiler/rustc_typeck/src/check/pat.rs
@@ -666,7 +666,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             match binding_parent {
                 hir::Node::Param(hir::Param { ty_span, .. }) if binding.span.hi() <= ty_span.lo() => {
                     err.multipart_suggestion_verbose(
-                        format!("to take parameter by ref, move `&{mutability}` to the type"), 
+                        format!("to take parameter `{binding}` by reference, move `&{mutability}` to the type"), 
                         vec![
                             (pat.span.until(inner.span), "".to_owned()),
                             (ty_span.shrink_to_lo(), format!("&{}", mutbl.prefix_str())),

--- a/compiler/rustc_typeck/src/check/pat.rs
+++ b/compiler/rustc_typeck/src/check/pat.rs
@@ -668,7 +668,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 // so we don't suggest moving something to the type that does not exist
                 hir::Node::Param(hir::Param { ty_span, .. }) if binding.span != *ty_span => {
                     err.multipart_suggestion_verbose(
-                        format!("to take parameter `{binding}` by reference, move `&{mutability}` to the type"), 
+                        format!("to take parameter `{binding}` by reference, move `&{mutability}` to the type"),
                         vec![
                             (pat.span.until(inner.span), "".to_owned()),
                             (ty_span.shrink_to_lo(), format!("&{}", mutbl.prefix_str())),

--- a/compiler/rustc_typeck/src/check/pat.rs
+++ b/compiler/rustc_typeck/src/check/pat.rs
@@ -664,7 +664,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             };
 
             match binding_parent {
-                hir::Node::Param(hir::Param { ty_span, .. }) if binding.span.hi() <= ty_span.lo() => {
+                // Check that there is explicit type (ie this is not a closure param with inferred type)
+                // so we don't suggest moving something to the type that does not exist
+                hir::Node::Param(hir::Param { ty_span, .. }) if binding.span != *ty_span => {
                     err.multipart_suggestion_verbose(
                         format!("to take parameter `{binding}` by reference, move `&{mutability}` to the type"), 
                         vec![

--- a/compiler/rustc_typeck/src/check/pat.rs
+++ b/compiler/rustc_typeck/src/check/pat.rs
@@ -649,39 +649,38 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         }
     }
 
-    fn borrow_pat_suggestion(
-        &self,
-        err: &mut Diagnostic,
-        pat: &Pat<'_>,
-        inner: &Pat<'_>,
-        expected: Ty<'tcx>,
-    ) {
+    fn borrow_pat_suggestion(&self, err: &mut Diagnostic, pat: &Pat<'_>, inner: &Pat<'_>) {
         let tcx = self.tcx;
-        if let PatKind::Binding(..) = inner.kind {
+        if let PatKind::Ref(_, mutbl) = pat.kind
+        && let PatKind::Binding(_, _, binding, ..) = inner.kind {
             let binding_parent_id = tcx.hir().get_parent_node(pat.hir_id);
             let binding_parent = tcx.hir().get(binding_parent_id);
-            debug!("inner {:?} pat {:?} parent {:?}", inner, pat, binding_parent);
+            debug!(?inner, ?pat, ?binding_parent);
+
+            let mutability = match mutbl {
+                ast::Mutability::Mut => "mut",
+                ast::Mutability::Not => "",
+            };
+
             match binding_parent {
-                hir::Node::Param(hir::Param { span, .. })
-                    if let Ok(snippet) = tcx.sess.source_map().span_to_snippet(inner.span) =>
-                {
-                    err.span_suggestion(
-                        *span,
-                        &format!("did you mean `{snippet}`"),
-                        format!(" &{expected}"),
-                        Applicability::MachineApplicable,
+                hir::Node::Param(hir::Param { ty_span, .. }) if binding.span.hi() <= ty_span.lo() => {
+                    err.multipart_suggestion_verbose(
+                        format!("to take parameter by ref, move `&{mutability}` to the type"), 
+                        vec![
+                            (pat.span.until(inner.span), "".to_owned()),
+                            (ty_span.shrink_to_lo(), format!("&{}", mutbl.prefix_str())),
+                        ],
+                        Applicability::MachineApplicable
                     );
                 }
-                hir::Node::Arm(_) | hir::Node::Pat(_) => {
+                hir::Node::Param(_) | hir::Node::Arm(_) | hir::Node::Pat(_) => {
                     // rely on match ergonomics or it might be nested `&&pat`
-                    if let Ok(snippet) = tcx.sess.source_map().span_to_snippet(inner.span) {
-                        err.span_suggestion(
-                            pat.span,
-                            "you can probably remove the explicit borrow",
-                            snippet,
-                            Applicability::MaybeIncorrect,
-                        );
-                    }
+                    err.span_suggestion_verbose(
+                        pat.span.until(inner.span),
+                        format!("consider removing `&{mutability}` from the pattern"),
+                        "",
+                        Applicability::MaybeIncorrect,
+                    );
                 }
                 _ => {} // don't provide suggestions in other cases #55175
             }
@@ -1853,7 +1852,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
             // Take region, inner-type from expected type if we can,
             // to avoid creating needless variables. This also helps with
-            // the bad  interactions of the given hack detailed in (note_1).
+            // the bad interactions of the given hack detailed in (note_1).
             debug!("check_pat_ref: expected={:?}", expected);
             match *expected.kind() {
                 ty::Ref(_, r_ty, r_mutbl) if r_mutbl == mutbl => (expected, r_ty),
@@ -1869,7 +1868,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     // Look for a case like `fn foo(&foo: u32)` and suggest
                     // `fn foo(foo: &u32)`
                     if let Some(mut err) = err {
-                        self.borrow_pat_suggestion(&mut err, pat, inner, expected);
+                        self.borrow_pat_suggestion(&mut err, pat, inner);
                         err.emit();
                     }
                     (rptr_ty, inner_ty)

--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -2363,6 +2363,7 @@ pub const unsafe fn write_bytes<T>(dst: *mut T, val: u8, count: usize) {
 #[rustc_const_unstable(feature = "const_eval_select", issue = "none")]
 #[lang = "const_eval_select"]
 #[rustc_do_not_const_check]
+#[inline]
 pub const unsafe fn const_eval_select<ARG, F, G, RET>(
     arg: ARG,
     _called_in_const: F,

--- a/library/std/src/ffi/os_str.rs
+++ b/library/std/src/ffi/os_str.rs
@@ -45,6 +45,11 @@ use crate::sys_common::{AsInner, FromInner, IntoInner};
 /// values, encoded in a less-strict variant of UTF-8. This is useful to
 /// understand when handling capacity and length values.
 ///
+/// # Capacity of OsString
+///
+/// Capacity means UTF-8 byte size for OS strings which created from
+/// valid unicode, and not otherwise specified for other contents.
+///
 /// # Creating an `OsString`
 ///
 /// **From a Rust string**: `OsString` implements
@@ -188,6 +193,11 @@ impl OsString {
     ///
     /// See main `OsString` documentation information about encoding.
     ///
+    /// # Notes
+    ///
+    /// Capacity means UTF-8 byte size for OS strings which created from
+    /// valid unicode, and not otherwise specified for other contents.
+    ///
     /// # Examples
     ///
     /// ```
@@ -231,6 +241,11 @@ impl OsString {
     ///
     /// See `OsString` introduction for information about encoding.
     ///
+    /// # Notes
+    ///
+    /// Capacity means UTF-8 byte size for OS strings which created from
+    /// valid unicode, and not otherwise specified for other contents.
+    ///
     /// # Examples
     ///
     /// ```
@@ -271,6 +286,11 @@ impl OsString {
     /// frequent reallocations. After calling `try_reserve`, capacity will be
     /// greater than or equal to `self.len() + additional`. Does nothing if
     /// capacity is already sufficient.
+    ///
+    /// # Notes
+    ///
+    /// Capacity means UTF-8 byte size for OS strings which created from
+    /// valid unicode, and not otherwise specified for other contents.
     ///
     /// # Errors
     ///
@@ -313,6 +333,11 @@ impl OsString {
     ///
     /// [`reserve`]: OsString::reserve
     ///
+    /// # Notes
+    ///
+    /// Capacity means UTF-8 byte size for OS strings which created from
+    /// valid unicode, and not otherwise specified for other contents.
+    ///
     /// # Examples
     ///
     /// ```
@@ -339,6 +364,11 @@ impl OsString {
     /// minimal. Prefer [`try_reserve`] if future insertions are expected.
     ///
     /// [`try_reserve`]: OsString::try_reserve
+    ///
+    /// # Notes
+    ///
+    /// Capacity means UTF-8 byte size for OS strings which created from
+    /// valid unicode, and not otherwise specified for other contents.
     ///
     /// # Errors
     ///
@@ -398,6 +428,11 @@ impl OsString {
     /// and the supplied value.
     ///
     /// If the current capacity is less than the lower limit, this is a no-op.
+    ///
+    /// # Notes
+    ///
+    /// Capacity means UTF-8 byte size for OS strings which created from
+    /// valid unicode, and not otherwise specified for other contents.
     ///
     /// # Examples
     ///

--- a/library/std/src/ffi/os_str.rs
+++ b/library/std/src/ffi/os_str.rs
@@ -191,12 +191,7 @@ impl OsString {
     /// OS strings without reallocating. If `capacity` is 0, the string will not
     /// allocate.
     ///
-    /// See main `OsString` documentation information about encoding.
-    ///
-    /// # Notes
-    ///
-    /// Capacity means UTF-8 byte size for OS strings which created from
-    /// valid unicode, and not otherwise specified for other contents.
+    /// See the main `OsString` documentation information about encoding and capacity units.
     ///
     /// # Examples
     ///
@@ -239,12 +234,7 @@ impl OsString {
 
     /// Returns the capacity this `OsString` can hold without reallocating.
     ///
-    /// See `OsString` introduction for information about encoding.
-    ///
-    /// # Notes
-    ///
-    /// Capacity means UTF-8 byte size for OS strings which created from
-    /// valid unicode, and not otherwise specified for other contents.
+    /// See the main `OsString` documentation information about encoding and capacity units.
     ///
     /// # Examples
     ///
@@ -265,6 +255,8 @@ impl OsString {
     /// in the given `OsString`.
     ///
     /// The collection may reserve more space to avoid frequent reallocations.
+    ///
+    /// See the main `OsString` documentation information about encoding and capacity units.
     ///
     /// # Examples
     ///
@@ -287,10 +279,7 @@ impl OsString {
     /// greater than or equal to `self.len() + additional`. Does nothing if
     /// capacity is already sufficient.
     ///
-    /// # Notes
-    ///
-    /// Capacity means UTF-8 byte size for OS strings which created from
-    /// valid unicode, and not otherwise specified for other contents.
+    /// See the main `OsString` documentation information about encoding and capacity units.
     ///
     /// # Errors
     ///
@@ -333,10 +322,7 @@ impl OsString {
     ///
     /// [`reserve`]: OsString::reserve
     ///
-    /// # Notes
-    ///
-    /// Capacity means UTF-8 byte size for OS strings which created from
-    /// valid unicode, and not otherwise specified for other contents.
+    /// See the main `OsString` documentation information about encoding and capacity units.
     ///
     /// # Examples
     ///
@@ -365,10 +351,7 @@ impl OsString {
     ///
     /// [`try_reserve`]: OsString::try_reserve
     ///
-    /// # Notes
-    ///
-    /// Capacity means UTF-8 byte size for OS strings which created from
-    /// valid unicode, and not otherwise specified for other contents.
+    /// See the main `OsString` documentation information about encoding and capacity units.
     ///
     /// # Errors
     ///
@@ -403,6 +386,8 @@ impl OsString {
 
     /// Shrinks the capacity of the `OsString` to match its length.
     ///
+    /// See the main `OsString` documentation information about encoding and capacity units.
+    ///
     /// # Examples
     ///
     /// ```
@@ -429,10 +414,7 @@ impl OsString {
     ///
     /// If the current capacity is less than the lower limit, this is a no-op.
     ///
-    /// # Notes
-    ///
-    /// Capacity means UTF-8 byte size for OS strings which created from
-    /// valid unicode, and not otherwise specified for other contents.
+    /// See the main `OsString` documentation information about encoding and capacity units.
     ///
     /// # Examples
     ///
@@ -807,6 +789,8 @@ impl OsStr {
     ///
     /// This number is simply useful for passing to other methods, like
     /// [`OsString::with_capacity`] to avoid reallocations.
+    ///
+    /// See the main `OsString` documentation information about encoding and capacity units.
     ///
     /// # Examples
     ///

--- a/library/std/src/ffi/os_str.rs
+++ b/library/std/src/ffi/os_str.rs
@@ -45,10 +45,21 @@ use crate::sys_common::{AsInner, FromInner, IntoInner};
 /// values, encoded in a less-strict variant of UTF-8. This is useful to
 /// understand when handling capacity and length values.
 ///
-/// # Capacity of OsString
+/// # Capacity of `OsString`
 ///
-/// Capacity means UTF-8 byte size for OS strings which created from
-/// valid unicode, and not otherwise specified for other contents.
+/// Capacity uses units of UTF-8 bytes for OS strings which were created from valid unicode, and
+/// uses units of bytes in an unspecified encoding for other contents. On a given target, all
+/// `OsString` and `OsStr` values use the same units for capacity, so the following will work:
+/// ```
+/// use std::ffi::{OsStr, OsString};
+///
+/// fn concat_os_strings(a: &OsStr, b: &OsStr) -> OsString {
+///     let mut ret = OsString::with_capacity(a.len() + b.len()); // This will allocate
+///     ret.push(a); // This will not allocate further
+///     ret.push(b); // This will not allocate further
+///     ret
+/// }
+/// ```
 ///
 /// # Creating an `OsString`
 ///

--- a/src/librustdoc/html/static/js/source-script.js
+++ b/src/librustdoc/html/static/js/source-script.js
@@ -32,10 +32,10 @@ function createDirEntry(elem, parent, fullPath, currentFile, hasFoundFile) {
     fullPath += elem["name"] + "/";
 
     name.onclick = () => {
-        if (hasClass(this, "expand")) {
-            removeClass(this, "expand");
+        if (hasClass(name, "expand")) {
+            removeClass(name, "expand");
         } else {
-            addClass(this, "expand");
+            addClass(name, "expand");
         }
     };
     name.innerText = elem["name"];

--- a/src/test/rustdoc-gui/source-code-page.goml
+++ b/src/test/rustdoc-gui/source-code-page.goml
@@ -1,4 +1,4 @@
-// Checks that the interactions with the source code pages are workined as expected.
+// Checks that the interactions with the source code pages are working as expected.
 goto: file://|DOC_PATH|/src/test_docs/lib.rs.html
 // Check that we can click on the line number.
 click: ".line-numbers > span:nth-child(4)" // This is the span for line 4.
@@ -27,3 +27,26 @@ assert-position: ("//*[@id='1']", {"x": 104, "y": 103})
 // We click on the left of the "1" span but still in the "line-number" `<pre>`.
 click: (103, 103)
 assert-document-property: ({"URL": "/lib.rs.html"}, ENDS_WITH)
+
+// Checking the source code sidebar.
+
+// First we "open" it.
+click: "#sidebar-toggle"
+assert: ".sidebar.expanded"
+
+// We check that the first entry of the sidebar is collapsed (which, for whatever reason,
+// is number 2 and not 1...).
+assert-attribute: ("#source-sidebar .name:nth-child(2)", {"class": "name"})
+assert-text: ("#source-sidebar .name:nth-child(2)", "implementors")
+// We also check its children are hidden too.
+assert-css: ("#source-sidebar .name:nth-child(2) + .children", {"display": "none"})
+// We now click on it.
+click: "#source-sidebar .name:nth-child(2)"
+assert-attribute: ("#source-sidebar .name:nth-child(2)", {"class": "name expand"})
+// Checking that its children are displayed as well.
+assert-css: ("#source-sidebar .name:nth-child(2) + .children", {"display": "block"})
+
+// And now we collapse it again.
+click: "#source-sidebar .name:nth-child(2)"
+assert-attribute: ("#source-sidebar .name:nth-child(2)", {"class": "name"})
+assert-css: ("#source-sidebar .name:nth-child(2) + .children", {"display": "none"})

--- a/src/test/rustdoc-json/generic_impl.rs
+++ b/src/test/rustdoc-json/generic_impl.rs
@@ -1,0 +1,24 @@
+// Regression test for <https://github.com/rust-lang/rust/issues/97986>.
+
+// @has generic_impl.json
+// @has - "$.index[*][?(@.name=='f')]"
+// @has - "$.index[*][?(@.name=='AssocTy')]"
+// @has - "$.index[*][?(@.name=='AssocConst')]"
+
+pub mod m {
+    pub struct S;
+}
+
+pub trait F {
+    type AssocTy;
+    const AssocConst: usize;
+    fn f() -> m::S;
+}
+
+impl<T> F for T {
+    type AssocTy = u32;
+    const AssocConst: usize = 0;
+    fn f() -> m::S {
+        m::S
+    }
+}

--- a/src/test/ui/associated-consts/issue-93775.rs
+++ b/src/test/ui/associated-consts/issue-93775.rs
@@ -1,0 +1,29 @@
+// build-pass
+// ignore-tidy-linelength
+
+// Regression for #93775, needs build-pass to test it.
+
+#![recursion_limit = "1000"]
+
+use std::marker::PhantomData;
+
+struct Z;
+struct S<T>(PhantomData<T>);
+
+type Nested = S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<S<Z>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>;
+
+trait AsNum {
+    const NUM: u32;
+}
+
+impl AsNum for Z {
+    const NUM: u32 = 0;
+}
+
+impl<T: AsNum> AsNum for S<T> {
+    const NUM: u32 = T::NUM + 1;
+}
+
+fn main() {
+    let _ = Nested::NUM;
+}

--- a/src/test/ui/destructure-trait-ref.stderr
+++ b/src/test/ui/destructure-trait-ref.stderr
@@ -23,10 +23,14 @@ LL |     let &&x = &1isize as &dyn T;
    |          ^^   ----------------- this expression has type `&dyn T`
    |          |
    |          expected trait object `dyn T`, found reference
-   |          help: you can probably remove the explicit borrow: `x`
    |
    = note: expected trait object `dyn T`
                  found reference `&_`
+help: consider removing `&` from the pattern
+   |
+LL -     let &&x = &1isize as &dyn T;
+LL +     let &x = &1isize as &dyn T;
+   | 
 
 error[E0308]: mismatched types
   --> $DIR/destructure-trait-ref.rs:36:11
@@ -35,10 +39,14 @@ LL |     let &&&x = &(&1isize as &dyn T);
    |           ^^   -------------------- this expression has type `&&dyn T`
    |           |
    |           expected trait object `dyn T`, found reference
-   |           help: you can probably remove the explicit borrow: `x`
    |
    = note: expected trait object `dyn T`
                  found reference `&_`
+help: consider removing `&` from the pattern
+   |
+LL -     let &&&x = &(&1isize as &dyn T);
+LL +     let &&x = &(&1isize as &dyn T);
+   | 
 
 error[E0308]: mismatched types
   --> $DIR/destructure-trait-ref.rs:40:13

--- a/src/test/ui/error-codes/E0214.stderr
+++ b/src/test/ui/error-codes/E0214.stderr
@@ -2,10 +2,12 @@ error[E0214]: parenthesized type parameters may only be used with a `Fn` trait
   --> $DIR/E0214.rs:2:12
    |
 LL |     let v: Vec(&str) = vec!["foo"];
-   |            ^^^^^^^^^
-   |            |
-   |            only `Fn` traits may use parentheses
-   |            help: use angle brackets instead: `Vec<&str>`
+   |            ^^^^^^^^^ only `Fn` traits may use parentheses
+   |
+help: use angle brackets instead
+   |
+LL |     let v: Vec<&str> = vec!["foo"];
+   |               ~    ~
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-23589.stderr
+++ b/src/test/ui/issues/issue-23589.stderr
@@ -2,10 +2,12 @@ error[E0214]: parenthesized type parameters may only be used with a `Fn` trait
   --> $DIR/issue-23589.rs:2:12
    |
 LL |     let v: Vec(&str) = vec!['1', '2'];
-   |            ^^^^^^^^^
-   |            |
-   |            only `Fn` traits may use parentheses
-   |            help: use angle brackets instead: `Vec<&str>`
+   |            ^^^^^^^^^ only `Fn` traits may use parentheses
+   |
+help: use angle brackets instead
+   |
+LL |     let v: Vec<&str> = vec!['1', '2'];
+   |               ~    ~
 
 error[E0308]: mismatched types
   --> $DIR/issue-23589.rs:2:29

--- a/src/test/ui/mismatched_types/issue-38371-unfixable.rs
+++ b/src/test/ui/mismatched_types/issue-38371-unfixable.rs
@@ -1,0 +1,5 @@
+fn ugh(&[bar]: &u32) {} //~ ERROR expected an array or slice
+
+fn bgh(&&bar: u32) {} //~ ERROR mismatched types
+
+fn main() {}

--- a/src/test/ui/mismatched_types/issue-38371-unfixable.stderr
+++ b/src/test/ui/mismatched_types/issue-38371-unfixable.stderr
@@ -1,0 +1,21 @@
+error[E0529]: expected an array or slice, found `u32`
+  --> $DIR/issue-38371-unfixable.rs:1:9
+   |
+LL | fn ugh(&[bar]: &u32) {}
+   |         ^^^^^ pattern cannot match with input type `u32`
+
+error[E0308]: mismatched types
+  --> $DIR/issue-38371-unfixable.rs:3:8
+   |
+LL | fn bgh(&&bar: u32) {}
+   |        ^^^^^  --- expected due to this
+   |        |
+   |        expected `u32`, found reference
+   |
+   = note:   expected type `u32`
+           found reference `&_`
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0308, E0529.
+For more information about an error, try `rustc --explain E0308`.

--- a/src/test/ui/mismatched_types/issue-38371.fixed
+++ b/src/test/ui/mismatched_types/issue-38371.fixed
@@ -5,7 +5,7 @@
 #[derive(Copy, Clone)]
 struct Foo {}
 
-fn foo(&_a: Foo) {} //~ ERROR mismatched types
+fn foo(_a: &Foo) {} //~ ERROR mismatched types
 
 fn bar(_a: Foo) {}
 
@@ -13,6 +13,6 @@ fn qux(_a: &Foo) {}
 
 fn zar(&_a: &Foo) {}
 
-fn agh(&&_a: &u32) {} //~ ERROR mismatched types
+fn agh(&_a: &u32) {} //~ ERROR mismatched types
 
 fn main() {}

--- a/src/test/ui/mismatched_types/issue-38371.stderr
+++ b/src/test/ui/mismatched_types/issue-38371.stderr
@@ -8,7 +8,7 @@ LL | fn foo(&_a: Foo) {}
    |
    = note: expected struct `Foo`
            found reference `&_`
-help: to take parameter by ref, move `&` to the type
+help: to take parameter `_a` by reference, move `&` to the type
    |
 LL - fn foo(&_a: Foo) {}
 LL + fn foo(_a: &Foo) {}

--- a/src/test/ui/mismatched_types/issue-38371.stderr
+++ b/src/test/ui/mismatched_types/issue-38371.stderr
@@ -1,46 +1,35 @@
 error[E0308]: mismatched types
-  --> $DIR/issue-38371.rs:4:8
+  --> $DIR/issue-38371.rs:8:8
    |
-LL | fn foo(&foo: Foo) {
-   |        ^^^^-----
-   |        |     |
-   |        |     expected due to this
+LL | fn foo(&_a: Foo) {}
+   |        ^^^  --- expected due to this
+   |        |
    |        expected struct `Foo`, found reference
-   |        help: did you mean `foo`: `&Foo`
    |
    = note: expected struct `Foo`
            found reference `&_`
+help: to take parameter by ref, move `&` to the type
+   |
+LL - fn foo(&_a: Foo) {}
+LL + fn foo(_a: &Foo) {}
+   | 
 
 error[E0308]: mismatched types
-  --> $DIR/issue-38371.rs:18:9
+  --> $DIR/issue-38371.rs:16:9
    |
-LL | fn agh(&&bar: &u32) {
-   |         ^^^^  ---- expected due to this
+LL | fn agh(&&_a: &u32) {}
+   |         ^^^  ---- expected due to this
    |         |
    |         expected `u32`, found reference
-   |         help: you can probably remove the explicit borrow: `bar`
    |
    = note:   expected type `u32`
            found reference `&_`
-
-error[E0308]: mismatched types
-  --> $DIR/issue-38371.rs:21:8
+help: consider removing `&` from the pattern
    |
-LL | fn bgh(&&bar: u32) {
-   |        ^^^^^  --- expected due to this
-   |        |
-   |        expected `u32`, found reference
-   |
-   = note:   expected type `u32`
-           found reference `&_`
+LL - fn agh(&&_a: &u32) {}
+LL + fn agh(&_a: &u32) {}
+   | 
 
-error[E0529]: expected an array or slice, found `u32`
-  --> $DIR/issue-38371.rs:24:9
-   |
-LL | fn ugh(&[bar]: &u32) {
-   |         ^^^^^ pattern cannot match with input type `u32`
+error: aborting due to 2 previous errors
 
-error: aborting due to 4 previous errors
-
-Some errors have detailed explanations: E0308, E0529.
-For more information about an error, try `rustc --explain E0308`.
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/mismatched_types/ref-pat-suggestions.fixed
+++ b/src/test/ui/mismatched_types/ref-pat-suggestions.fixed
@@ -13,7 +13,7 @@ fn main() {
     let _: fn(&u32) = |&_a| (); //~ ERROR mismatched types
     let _: fn(&mut u32) = |&mut _a| (); //~ ERROR mismatched types
     let _: fn(&u32) = |&_a| (); //~ ERROR mismatched types
-    let _: fn(&mut u32) = |&mut _a| (); //~ ERROR mismatched types   
+    let _: fn(&mut u32) = |&mut _a| (); //~ ERROR mismatched types
 
     let _ = |_a: &u32| (); //~ ERROR mismatched types
     let _ = |_a: &mut u32| (); //~ ERROR mismatched types

--- a/src/test/ui/mismatched_types/ref-pat-suggestions.fixed
+++ b/src/test/ui/mismatched_types/ref-pat-suggestions.fixed
@@ -1,0 +1,24 @@
+// run-rustfix
+
+fn _f0(_a: &u32) {} //~ ERROR mismatched types
+fn _f1(_a: &mut u32) {} //~ ERROR mismatched types
+fn _f2(&_a: &u32) {} //~ ERROR mismatched types
+fn _f3(&mut _a: &mut u32) {} //~ ERROR mismatched types
+fn _f4(&_a: &u32) {} //~ ERROR mismatched types
+fn _f5(&mut _a: &mut u32) {} //~ ERROR mismatched types
+
+fn main() {
+    let _: fn(u32) = |_a| (); //~ ERROR mismatched types
+    let _: fn(u32) = |_a| (); //~ ERROR mismatched types
+    let _: fn(&u32) = |&_a| (); //~ ERROR mismatched types
+    let _: fn(&mut u32) = |&mut _a| (); //~ ERROR mismatched types
+    let _: fn(&u32) = |&_a| (); //~ ERROR mismatched types
+    let _: fn(&mut u32) = |&mut _a| (); //~ ERROR mismatched types   
+
+    let _ = |_a: &u32| (); //~ ERROR mismatched types
+    let _ = |_a: &mut u32| (); //~ ERROR mismatched types
+    let _ = |&_a: &u32| (); //~ ERROR mismatched types
+    let _ = |&mut _a: &mut u32| (); //~ ERROR mismatched types
+    let _ = |&_a: &u32| (); //~ ERROR mismatched types
+    let _ = |&mut _a: &mut u32| (); //~ ERROR mismatched types
+}

--- a/src/test/ui/mismatched_types/ref-pat-suggestions.rs
+++ b/src/test/ui/mismatched_types/ref-pat-suggestions.rs
@@ -13,7 +13,7 @@ fn main() {
     let _: fn(&u32) = |&&_a| (); //~ ERROR mismatched types
     let _: fn(&mut u32) = |&mut &_a| (); //~ ERROR mismatched types
     let _: fn(&u32) = |&&mut _a| (); //~ ERROR mismatched types
-    let _: fn(&mut u32) = |&mut &mut _a| (); //~ ERROR mismatched types   
+    let _: fn(&mut u32) = |&mut &mut _a| (); //~ ERROR mismatched types
 
     let _ = |&_a: u32| (); //~ ERROR mismatched types
     let _ = |&mut _a: u32| (); //~ ERROR mismatched types

--- a/src/test/ui/mismatched_types/ref-pat-suggestions.rs
+++ b/src/test/ui/mismatched_types/ref-pat-suggestions.rs
@@ -1,0 +1,24 @@
+// run-rustfix
+
+fn _f0(&_a: u32) {} //~ ERROR mismatched types
+fn _f1(&mut _a: u32) {} //~ ERROR mismatched types
+fn _f2(&&_a: &u32) {} //~ ERROR mismatched types
+fn _f3(&mut &_a: &mut u32) {} //~ ERROR mismatched types
+fn _f4(&&mut _a: &u32) {} //~ ERROR mismatched types
+fn _f5(&mut &mut _a: &mut u32) {} //~ ERROR mismatched types
+
+fn main() {
+    let _: fn(u32) = |&_a| (); //~ ERROR mismatched types
+    let _: fn(u32) = |&mut _a| (); //~ ERROR mismatched types
+    let _: fn(&u32) = |&&_a| (); //~ ERROR mismatched types
+    let _: fn(&mut u32) = |&mut &_a| (); //~ ERROR mismatched types
+    let _: fn(&u32) = |&&mut _a| (); //~ ERROR mismatched types
+    let _: fn(&mut u32) = |&mut &mut _a| (); //~ ERROR mismatched types   
+
+    let _ = |&_a: u32| (); //~ ERROR mismatched types
+    let _ = |&mut _a: u32| (); //~ ERROR mismatched types
+    let _ = |&&_a: &u32| (); //~ ERROR mismatched types
+    let _ = |&mut &_a: &mut u32| (); //~ ERROR mismatched types
+    let _ = |&&mut _a: &u32| (); //~ ERROR mismatched types
+    let _ = |&mut &mut _a: &mut u32| (); //~ ERROR mismatched types
+}

--- a/src/test/ui/mismatched_types/ref-pat-suggestions.stderr
+++ b/src/test/ui/mismatched_types/ref-pat-suggestions.stderr
@@ -1,0 +1,297 @@
+error[E0308]: mismatched types
+  --> $DIR/ref-pat-suggestions.rs:3:8
+   |
+LL | fn _f0(&_a: u32) {}
+   |        ^^^  --- expected due to this
+   |        |
+   |        expected `u32`, found reference
+   |
+   = note:   expected type `u32`
+           found reference `&_`
+help: to take parameter by ref, move `&` to the type
+   |
+LL - fn _f0(&_a: u32) {}
+LL + fn _f0(_a: &u32) {}
+   | 
+
+error[E0308]: mismatched types
+  --> $DIR/ref-pat-suggestions.rs:4:8
+   |
+LL | fn _f1(&mut _a: u32) {}
+   |        ^^^^^^^  --- expected due to this
+   |        |
+   |        expected `u32`, found `&mut _`
+   |
+   = note:           expected type `u32`
+           found mutable reference `&mut _`
+help: to take parameter by ref, move `&mut` to the type
+   |
+LL - fn _f1(&mut _a: u32) {}
+LL + fn _f1(_a: &mut u32) {}
+   | 
+
+error[E0308]: mismatched types
+  --> $DIR/ref-pat-suggestions.rs:5:9
+   |
+LL | fn _f2(&&_a: &u32) {}
+   |         ^^^  ---- expected due to this
+   |         |
+   |         expected `u32`, found reference
+   |
+   = note:   expected type `u32`
+           found reference `&_`
+help: consider removing `&` from the pattern
+   |
+LL - fn _f2(&&_a: &u32) {}
+LL + fn _f2(&_a: &u32) {}
+   | 
+
+error[E0308]: mismatched types
+  --> $DIR/ref-pat-suggestions.rs:6:13
+   |
+LL | fn _f3(&mut &_a: &mut u32) {}
+   |             ^^^  -------- expected due to this
+   |             |
+   |             expected `u32`, found reference
+   |
+   = note:   expected type `u32`
+           found reference `&_`
+help: consider removing `&` from the pattern
+   |
+LL - fn _f3(&mut &_a: &mut u32) {}
+LL + fn _f3(&mut _a: &mut u32) {}
+   | 
+
+error[E0308]: mismatched types
+  --> $DIR/ref-pat-suggestions.rs:7:9
+   |
+LL | fn _f4(&&mut _a: &u32) {}
+   |         ^^^^^^^  ---- expected due to this
+   |         |
+   |         expected `u32`, found `&mut _`
+   |
+   = note:           expected type `u32`
+           found mutable reference `&mut _`
+help: consider removing `&mut` from the pattern
+   |
+LL - fn _f4(&&mut _a: &u32) {}
+LL + fn _f4(&_a: &u32) {}
+   | 
+
+error[E0308]: mismatched types
+  --> $DIR/ref-pat-suggestions.rs:8:13
+   |
+LL | fn _f5(&mut &mut _a: &mut u32) {}
+   |             ^^^^^^^  -------- expected due to this
+   |             |
+   |             expected `u32`, found `&mut _`
+   |
+   = note:           expected type `u32`
+           found mutable reference `&mut _`
+help: consider removing `&mut` from the pattern
+   |
+LL - fn _f5(&mut &mut _a: &mut u32) {}
+LL + fn _f5(&mut _a: &mut u32) {}
+   | 
+
+error[E0308]: mismatched types
+  --> $DIR/ref-pat-suggestions.rs:11:23
+   |
+LL |     let _: fn(u32) = |&_a| ();
+   |                       ^--
+   |                       ||
+   |                       |expected due to this
+   |                       expected `u32`, found reference
+   |
+   = note:   expected type `u32`
+           found reference `&_`
+help: consider removing `&` from the pattern
+   |
+LL -     let _: fn(u32) = |&_a| ();
+LL +     let _: fn(u32) = |_a| ();
+   | 
+
+error[E0308]: mismatched types
+  --> $DIR/ref-pat-suggestions.rs:12:23
+   |
+LL |     let _: fn(u32) = |&mut _a| ();
+   |                       ^^^^^--
+   |                       |    |
+   |                       |    expected due to this
+   |                       expected `u32`, found `&mut _`
+   |
+   = note:           expected type `u32`
+           found mutable reference `&mut _`
+help: consider removing `&mut` from the pattern
+   |
+LL -     let _: fn(u32) = |&mut _a| ();
+LL +     let _: fn(u32) = |_a| ();
+   | 
+
+error[E0308]: mismatched types
+  --> $DIR/ref-pat-suggestions.rs:13:25
+   |
+LL |     let _: fn(&u32) = |&&_a| ();
+   |                         ^--
+   |                         ||
+   |                         |expected due to this
+   |                         expected `u32`, found reference
+   |
+   = note:   expected type `u32`
+           found reference `&_`
+help: consider removing `&` from the pattern
+   |
+LL -     let _: fn(&u32) = |&&_a| ();
+LL +     let _: fn(&u32) = |&_a| ();
+   | 
+
+error[E0308]: mismatched types
+  --> $DIR/ref-pat-suggestions.rs:14:33
+   |
+LL |     let _: fn(&mut u32) = |&mut &_a| ();
+   |                                 ^--
+   |                                 ||
+   |                                 |expected due to this
+   |                                 expected `u32`, found reference
+   |
+   = note:   expected type `u32`
+           found reference `&_`
+help: consider removing `&` from the pattern
+   |
+LL -     let _: fn(&mut u32) = |&mut &_a| ();
+LL +     let _: fn(&mut u32) = |&mut _a| ();
+   | 
+
+error[E0308]: mismatched types
+  --> $DIR/ref-pat-suggestions.rs:15:25
+   |
+LL |     let _: fn(&u32) = |&&mut _a| ();
+   |                         ^^^^^--
+   |                         |    |
+   |                         |    expected due to this
+   |                         expected `u32`, found `&mut _`
+   |
+   = note:           expected type `u32`
+           found mutable reference `&mut _`
+help: consider removing `&mut` from the pattern
+   |
+LL -     let _: fn(&u32) = |&&mut _a| ();
+LL +     let _: fn(&u32) = |&_a| ();
+   | 
+
+error[E0308]: mismatched types
+  --> $DIR/ref-pat-suggestions.rs:16:33
+   |
+LL |     let _: fn(&mut u32) = |&mut &mut _a| ();
+   |                                 ^^^^^--
+   |                                 |    |
+   |                                 |    expected due to this
+   |                                 expected `u32`, found `&mut _`
+   |
+   = note:           expected type `u32`
+           found mutable reference `&mut _`
+help: consider removing `&mut` from the pattern
+   |
+LL -     let _: fn(&mut u32) = |&mut &mut _a| ();
+LL +     let _: fn(&mut u32) = |&mut _a| ();
+   | 
+
+error[E0308]: mismatched types
+  --> $DIR/ref-pat-suggestions.rs:18:14
+   |
+LL |     let _ = |&_a: u32| ();
+   |              ^^^  --- expected due to this
+   |              |
+   |              expected `u32`, found reference
+   |
+   = note:   expected type `u32`
+           found reference `&_`
+help: to take parameter by ref, move `&` to the type
+   |
+LL -     let _ = |&_a: u32| ();
+LL +     let _ = |_a: &u32| ();
+   | 
+
+error[E0308]: mismatched types
+  --> $DIR/ref-pat-suggestions.rs:19:14
+   |
+LL |     let _ = |&mut _a: u32| ();
+   |              ^^^^^^^  --- expected due to this
+   |              |
+   |              expected `u32`, found `&mut _`
+   |
+   = note:           expected type `u32`
+           found mutable reference `&mut _`
+help: to take parameter by ref, move `&mut` to the type
+   |
+LL -     let _ = |&mut _a: u32| ();
+LL +     let _ = |_a: &mut u32| ();
+   | 
+
+error[E0308]: mismatched types
+  --> $DIR/ref-pat-suggestions.rs:20:15
+   |
+LL |     let _ = |&&_a: &u32| ();
+   |               ^^^  ---- expected due to this
+   |               |
+   |               expected `u32`, found reference
+   |
+   = note:   expected type `u32`
+           found reference `&_`
+help: consider removing `&` from the pattern
+   |
+LL -     let _ = |&&_a: &u32| ();
+LL +     let _ = |&_a: &u32| ();
+   | 
+
+error[E0308]: mismatched types
+  --> $DIR/ref-pat-suggestions.rs:21:19
+   |
+LL |     let _ = |&mut &_a: &mut u32| ();
+   |                   ^^^  -------- expected due to this
+   |                   |
+   |                   expected `u32`, found reference
+   |
+   = note:   expected type `u32`
+           found reference `&_`
+help: consider removing `&` from the pattern
+   |
+LL -     let _ = |&mut &_a: &mut u32| ();
+LL +     let _ = |&mut _a: &mut u32| ();
+   | 
+
+error[E0308]: mismatched types
+  --> $DIR/ref-pat-suggestions.rs:22:15
+   |
+LL |     let _ = |&&mut _a: &u32| ();
+   |               ^^^^^^^  ---- expected due to this
+   |               |
+   |               expected `u32`, found `&mut _`
+   |
+   = note:           expected type `u32`
+           found mutable reference `&mut _`
+help: consider removing `&mut` from the pattern
+   |
+LL -     let _ = |&&mut _a: &u32| ();
+LL +     let _ = |&_a: &u32| ();
+   | 
+
+error[E0308]: mismatched types
+  --> $DIR/ref-pat-suggestions.rs:23:19
+   |
+LL |     let _ = |&mut &mut _a: &mut u32| ();
+   |                   ^^^^^^^  -------- expected due to this
+   |                   |
+   |                   expected `u32`, found `&mut _`
+   |
+   = note:           expected type `u32`
+           found mutable reference `&mut _`
+help: consider removing `&mut` from the pattern
+   |
+LL -     let _ = |&mut &mut _a: &mut u32| ();
+LL +     let _ = |&mut _a: &mut u32| ();
+   | 
+
+error: aborting due to 18 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/mismatched_types/ref-pat-suggestions.stderr
+++ b/src/test/ui/mismatched_types/ref-pat-suggestions.stderr
@@ -8,7 +8,7 @@ LL | fn _f0(&_a: u32) {}
    |
    = note:   expected type `u32`
            found reference `&_`
-help: to take parameter by ref, move `&` to the type
+help: to take parameter `_a` by reference, move `&` to the type
    |
 LL - fn _f0(&_a: u32) {}
 LL + fn _f0(_a: &u32) {}
@@ -24,7 +24,7 @@ LL | fn _f1(&mut _a: u32) {}
    |
    = note:           expected type `u32`
            found mutable reference `&mut _`
-help: to take parameter by ref, move `&mut` to the type
+help: to take parameter `_a` by reference, move `&mut` to the type
    |
 LL - fn _f1(&mut _a: u32) {}
 LL + fn _f1(_a: &mut u32) {}
@@ -206,7 +206,7 @@ LL |     let _ = |&_a: u32| ();
    |
    = note:   expected type `u32`
            found reference `&_`
-help: to take parameter by ref, move `&` to the type
+help: to take parameter `_a` by reference, move `&` to the type
    |
 LL -     let _ = |&_a: u32| ();
 LL +     let _ = |_a: &u32| ();
@@ -222,7 +222,7 @@ LL |     let _ = |&mut _a: u32| ();
    |
    = note:           expected type `u32`
            found mutable reference `&mut _`
-help: to take parameter by ref, move `&mut` to the type
+help: to take parameter `_a` by reference, move `&mut` to the type
    |
 LL -     let _ = |&mut _a: u32| ();
 LL +     let _ = |_a: &mut u32| ();

--- a/src/test/ui/pattern/for-loop-bad-item.stderr
+++ b/src/test/ui/pattern/for-loop-bad-item.stderr
@@ -5,10 +5,14 @@ LL |     for ((_, _), (&mut c, _)) in &mut map {
    |                   ^^^^^^         -------- this is an iterator with items of type `(&(char, char), &mut (char, char))`
    |                   |
    |                   expected `char`, found `&mut _`
-   |                   help: you can probably remove the explicit borrow: `c`
    |
    = note:           expected type `char`
            found mutable reference `&mut _`
+help: consider removing `&mut` from the pattern
+   |
+LL -     for ((_, _), (&mut c, _)) in &mut map {
+LL +     for ((_, _), (c, _)) in &mut map {
+   | 
 
 error[E0308]: mismatched types
   --> $DIR/for-loop-bad-item.rs:14:14

--- a/src/test/ui/proc-macro/issue-66286.stderr
+++ b/src/test/ui/proc-macro/issue-66286.stderr
@@ -2,10 +2,12 @@ error[E0214]: parenthesized type parameters may only be used with a `Fn` trait
   --> $DIR/issue-66286.rs:8:22
    |
 LL | pub extern fn foo(_: Vec(u32)) -> u32 {
-   |                      ^^^^^^^^
-   |                      |
-   |                      only `Fn` traits may use parentheses
-   |                      help: use angle brackets instead: `Vec<u32>`
+   |                      ^^^^^^^^ only `Fn` traits may use parentheses
+   |
+help: use angle brackets instead
+   |
+LL | pub extern fn foo(_: Vec<u32>) -> u32 {
+   |                         ~   ~
 
 error: aborting due to previous error
 

--- a/src/test/ui/suggestions/let-binding-init-expr-as-ty.stderr
+++ b/src/test/ui/suggestions/let-binding-init-expr-as-ty.stderr
@@ -10,10 +10,12 @@ error[E0214]: parenthesized type parameters may only be used with a `Fn` trait
   --> $DIR/let-binding-init-expr-as-ty.rs:2:19
    |
 LL |     let foo: i32::from_be(num);
-   |                   ^^^^^^^^^^^^
-   |                   |
-   |                   only `Fn` traits may use parentheses
-   |                   help: use angle brackets instead: `from_be<num>`
+   |                   ^^^^^^^^^^^^ only `Fn` traits may use parentheses
+   |
+help: use angle brackets instead
+   |
+LL |     let foo: i32::from_be<num>;
+   |                          ~   ~
 
 error[E0223]: ambiguous associated type
   --> $DIR/let-binding-init-expr-as-ty.rs:2:14

--- a/src/test/ui/suggestions/match-ergonomics.stderr
+++ b/src/test/ui/suggestions/match-ergonomics.stderr
@@ -4,13 +4,15 @@ error[E0308]: mismatched types
 LL |     match &x[..] {
    |           ------ this expression has type `&[i32]`
 LL |         [&v] => {},
-   |          ^^
-   |          |
-   |          expected `i32`, found reference
-   |          help: you can probably remove the explicit borrow: `v`
+   |          ^^ expected `i32`, found reference
    |
    = note:   expected type `i32`
            found reference `&_`
+help: consider removing `&` from the pattern
+   |
+LL -         [&v] => {},
+LL +         [v] => {},
+   | 
 
 error[E0529]: expected an array or slice, found `Vec<i32>`
   --> $DIR/match-ergonomics.rs:8:9
@@ -34,13 +36,15 @@ error[E0308]: mismatched types
 LL |     match y {
    |           - this expression has type `i32`
 LL |         &v => {},
-   |         ^^
-   |         |
-   |         expected `i32`, found reference
-   |         help: you can probably remove the explicit borrow: `v`
+   |         ^^ expected `i32`, found reference
    |
    = note:   expected type `i32`
            found reference `&_`
+help: consider removing `&` from the pattern
+   |
+LL -         &v => {},
+LL +         v => {},
+   | 
 
 error[E0308]: mismatched types
   --> $DIR/match-ergonomics.rs:40:13
@@ -49,10 +53,14 @@ LL |     if let [&v] = &x[..] {}
    |             ^^    ------ this expression has type `&[i32]`
    |             |
    |             expected `i32`, found reference
-   |             help: you can probably remove the explicit borrow: `v`
    |
    = note:   expected type `i32`
            found reference `&_`
+help: consider removing `&` from the pattern
+   |
+LL -     if let [&v] = &x[..] {}
+LL +     if let [v] = &x[..] {}
+   | 
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/type/issue-91268.stderr
+++ b/src/test/ui/type/issue-91268.stderr
@@ -29,6 +29,11 @@ error[E0214]: parenthesized type parameters may only be used with a `Fn` trait
    |
 LL |     0: u8(ţ
    |        ^^^^ only `Fn` traits may use parentheses
+   |
+help: use angle brackets instead
+   |
+LL |     0: u8<ţ>
+   |          ~ +
 
 error[E0109]: type arguments are not allowed on this type
   --> $DIR/issue-91268.rs:9:11

--- a/src/test/ui/unboxed-closures/unboxed-closure-sugar-used-on-struct-3.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closure-sugar-used-on-struct-3.stderr
@@ -2,10 +2,12 @@ error[E0214]: parenthesized type parameters may only be used with a `Fn` trait
   --> $DIR/unboxed-closure-sugar-used-on-struct-3.rs:14:13
    |
 LL |     let b = Bar::(isize, usize)::new(); // OK too (for the parser)
-   |             ^^^^^^^^^^^^^^^^^^^
-   |             |
-   |             only `Fn` traits may use parentheses
-   |             help: use angle brackets instead: `Bar::<isize, usize>`
+   |             ^^^^^^^^^^^^^^^^^^^ only `Fn` traits may use parentheses
+   |
+help: use angle brackets instead
+   |
+LL |     let b = Bar::<isize, usize>::new(); // OK too (for the parser)
+   |                  ~            ~
 
 error: aborting due to previous error
 


### PR DESCRIPTION
Successful merges:

 - #97202 (os str capacity documentation)
 - #97964 (Fix suggestions for `&a: T` parameters)
 - #98053 (Fix generic impl rustdoc json output)
 - #98059 (Inline `const_eval_select`)
 - #98092 (Fix sidebar items expand collapse)
 - #98119 (Refactor path segment parameter error)
 - #98135 (Add regression test for #93775)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=97202,97964,98053,98059,98092,98119,98135)
<!-- homu-ignore:end -->