### PR TITLE
Include ForeignItem when visiting types for WF check

### DIFF
--- a/compiler/rustc_typeck/src/hir_wf_check.rs
+++ b/compiler/rustc_typeck/src/hir_wf_check.rs
@@ -1,7 +1,7 @@
 use crate::collect::ItemCtxt;
 use rustc_hir as hir;
 use rustc_hir::intravisit::{self, Visitor};
-use rustc_hir::HirId;
+use rustc_hir::{ForeignItem, ForeignItemKind, HirId};
 use rustc_infer::infer::TyCtxtInferExt;
 use rustc_infer::traits::TraitEngine;
 use rustc_infer::traits::{ObligationCause, WellFormedLoc};
@@ -141,6 +141,9 @@ fn diagnostic_hir_wf_check<'tcx>(
                 ref item => bug!("Unexpected item {:?}", item),
             },
             hir::Node::Field(field) => Some(field.ty),
+            hir::Node::ForeignItem(ForeignItem {
+                kind: ForeignItemKind::Static(ty, _), ..
+            }) => Some(*ty),
             ref node => bug!("Unexpected node {:?}", node),
         },
         WellFormedLoc::Param { function: _, param_idx } => {

--- a/src/test/ui/wf/issue-95665.rs
+++ b/src/test/ui/wf/issue-95665.rs
@@ -1,0 +1,18 @@
+// Regression test for the ICE described in #95665.
+// Ensure that the expected error is output (and thus that there is no ICE)
+
+pub trait Trait: {}
+
+pub struct Struct<T: Trait> {
+    member: T,
+}
+
+// uncomment and bug goes away
+// impl Trait for u8 {}
+
+extern "C" {
+    static VAR: Struct<u8>;
+                //~^ 14:17: 14:27: the trait bound `u8: Trait` is not satisfied [E0277]
+}
+
+fn main() {}

--- a/src/test/ui/wf/issue-95665.stderr
+++ b/src/test/ui/wf/issue-95665.stderr
@@ -1,0 +1,15 @@
+error[E0277]: the trait bound `u8: Trait` is not satisfied
+  --> $DIR/issue-95665.rs:14:17
+   |
+LL |     static VAR: Struct<u8>;
+   |                 ^^^^^^^^^^ the trait `Trait` is not implemented for `u8`
+   |
+note: required by a bound in `Struct`
+  --> $DIR/issue-95665.rs:6:22
+   |
+LL | pub struct Struct<T: Trait> {
+   |                      ^^^^^ required by this bound in `Struct`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
Addresses Issue 95665 by including `hir::Node::ForeignItem` as a valid
type to visit in `diagnostic_hir_wf_check`.

Fixes #95665