### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/compiler/rustc_codegen_llvm/src/back/write.rs
+++ b/compiler/rustc_codegen_llvm/src/back/write.rs
@@ -340,7 +340,7 @@ fn report_inline_asm(
     }
     let level = match level {
         llvm::DiagnosticLevel::Error => Level::Error { lint: false },
-        llvm::DiagnosticLevel::Warning => Level::Warning,
+        llvm::DiagnosticLevel::Warning => Level::Warning(None),
         llvm::DiagnosticLevel::Note | llvm::DiagnosticLevel::Remark => Level::Note,
     };
     cgcx.diag_emitter.inline_asm_error(cookie as u32, msg, level, source);

--- a/compiler/rustc_codegen_ssa/src/back/write.rs
+++ b/compiler/rustc_codegen_ssa/src/back/write.rs
@@ -1761,7 +1761,7 @@ impl SharedEmitterMain {
 
                     let mut err = match level {
                         Level::Error { lint: false } => sess.struct_err(msg).forget_guarantee(),
-                        Level::Warning => sess.struct_warn(msg),
+                        Level::Warning(_) => sess.struct_warn(msg),
                         Level::Note => sess.struct_note_without_error(msg),
                         _ => bug!("Invalid inline asm diagnostic level"),
                     };

--- a/compiler/rustc_errors/src/annotate_snippet_emitter_writer.rs
+++ b/compiler/rustc_errors/src/annotate_snippet_emitter_writer.rs
@@ -87,7 +87,7 @@ fn annotation_type_for_level(level: Level) -> AnnotationType {
         Level::Bug | Level::DelayedBug | Level::Fatal | Level::Error { .. } => {
             AnnotationType::Error
         }
-        Level::Warning => AnnotationType::Warning,
+        Level::Warning(_) => AnnotationType::Warning,
         Level::Note | Level::OnceNote => AnnotationType::Note,
         Level::Help => AnnotationType::Help,
         // FIXME(#59346): Not sure how to map this level

--- a/compiler/rustc_errors/src/diagnostic.rs
+++ b/compiler/rustc_errors/src/diagnostic.rs
@@ -208,7 +208,7 @@ impl Diagnostic {
             | Level::Error { .. }
             | Level::FailureNote => true,
 
-            Level::Warning
+            Level::Warning(_)
             | Level::Note
             | Level::OnceNote
             | Level::Help
@@ -221,7 +221,9 @@ impl Diagnostic {
         &mut self,
         unstable_to_stable: &FxHashMap<LintExpectationId, LintExpectationId>,
     ) {
-        if let Level::Expect(expectation_id) = &mut self.level {
+        if let Level::Expect(expectation_id) | Level::Warning(Some(expectation_id)) =
+            &mut self.level
+        {
             if expectation_id.is_stable() {
                 return;
             }
@@ -445,7 +447,7 @@ impl Diagnostic {
 
     /// Add a warning attached to this diagnostic.
     pub fn warn(&mut self, msg: impl Into<SubdiagnosticMessage>) -> &mut Self {
-        self.sub(Level::Warning, msg, MultiSpan::new(), None);
+        self.sub(Level::Warning(None), msg, MultiSpan::new(), None);
         self
     }
 
@@ -456,7 +458,7 @@ impl Diagnostic {
         sp: S,
         msg: impl Into<SubdiagnosticMessage>,
     ) -> &mut Self {
-        self.sub(Level::Warning, msg, sp.into(), None);
+        self.sub(Level::Warning(None), msg, sp.into(), None);
         self
     }
 

--- a/compiler/rustc_errors/src/json.rs
+++ b/compiler/rustc_errors/src/json.rs
@@ -154,7 +154,7 @@ impl Emitter for JsonEmitter {
             .into_iter()
             .map(|mut diag| {
                 if diag.level == crate::Level::Allow {
-                    diag.level = crate::Level::Warning;
+                    diag.level = crate::Level::Warning(None);
                 }
                 FutureBreakageItem { diagnostic: Diagnostic::from_errors_diagnostic(&diag, self) }
             })

--- a/compiler/rustc_expand/src/proc_macro_server.rs
+++ b/compiler/rustc_expand/src/proc_macro_server.rs
@@ -267,7 +267,7 @@ impl ToInternal<rustc_errors::Level> for Level {
     fn to_internal(self) -> rustc_errors::Level {
         match self {
             Level::Error => rustc_errors::Level::Error { lint: false },
-            Level::Warning => rustc_errors::Level::Warning,
+            Level::Warning => rustc_errors::Level::Warning(None),
             Level::Note => rustc_errors::Level::Note,
             Level::Help => rustc_errors::Level::Help,
             _ => unreachable!("unknown proc_macro::Level variant: {:?}", self),

--- a/compiler/rustc_lint/src/context.rs
+++ b/compiler/rustc_lint/src/context.rs
@@ -324,7 +324,7 @@ impl LintStore {
         registered_tools: &RegisteredTools,
     ) {
         let (tool_name, lint_name_only) = parse_lint_and_tool_name(lint_name);
-        if lint_name_only == crate::WARNINGS.name_lower() && level == Level::ForceWarn {
+        if lint_name_only == crate::WARNINGS.name_lower() && matches!(level, Level::ForceWarn(_)) {
             struct_span_err!(
                 sess,
                 DUMMY_SP,
@@ -375,7 +375,7 @@ impl LintStore {
                 match level {
                     Level::Allow => "-A",
                     Level::Warn => "-W",
-                    Level::ForceWarn => "--force-warn",
+                    Level::ForceWarn(_) => "--force-warn",
                     Level::Deny => "-D",
                     Level::Forbid => "-F",
                     Level::Expect(_) => {

--- a/compiler/rustc_lint/src/expect.rs
+++ b/compiler/rustc_lint/src/expect.rs
@@ -19,16 +19,16 @@ fn check_expectations(tcx: TyCtxt<'_>, tool_filter: Option<Symbol>) {
     let lint_expectations = &tcx.lint_levels(()).lint_expectations;
 
     for (id, expectation) in lint_expectations {
-        if !fulfilled_expectations.contains(id)
-            && tool_filter.map_or(true, |filter| expectation.lint_tool == Some(filter))
-        {
-            // This check will always be true, since `lint_expectations` only
-            // holds stable ids
-            if let LintExpectationId::Stable { hir_id, .. } = id {
+        // This check will always be true, since `lint_expectations` only
+        // holds stable ids
+        if let LintExpectationId::Stable { hir_id, .. } = id {
+            if !fulfilled_expectations.contains(&id)
+                && tool_filter.map_or(true, |filter| expectation.lint_tool == Some(filter))
+            {
                 emit_unfulfilled_expectation_lint(tcx, *hir_id, expectation);
-            } else {
-                unreachable!("at this stage all `LintExpectationId`s are stable");
             }
+        } else {
+            unreachable!("at this stage all `LintExpectationId`s are stable");
         }
     }
 }

--- a/compiler/rustc_lint_defs/src/lib.rs
+++ b/compiler/rustc_lint_defs/src/lib.rs
@@ -162,13 +162,19 @@ pub enum Level {
     ///
     /// See RFC 2383.
     ///
-    /// The `LintExpectationId` is used to later link a lint emission to the actual
+    /// The [`LintExpectationId`] is used to later link a lint emission to the actual
     /// expectation. It can be ignored in most cases.
     Expect(LintExpectationId),
     /// The `warn` level will produce a warning if the lint was violated, however the
     /// compiler will continue with its execution.
     Warn,
-    ForceWarn,
+    /// This lint level is a special case of [`Warn`], that can't be overridden. This is used
+    /// to ensure that a lint can't be suppressed. This lint level can currently only be set
+    /// via the console and is therefore session specific.
+    ///
+    /// The [`LintExpectationId`] is intended to fulfill expectations marked via the
+    /// `#[expect]` attribute, that will still be suppressed due to the level.
+    ForceWarn(Option<LintExpectationId>),
     /// The `deny` level will produce an error and stop further execution after the lint
     /// pass is complete.
     Deny,
@@ -184,7 +190,7 @@ impl Level {
             Level::Allow => "allow",
             Level::Expect(_) => "expect",
             Level::Warn => "warn",
-            Level::ForceWarn => "force-warn",
+            Level::ForceWarn(_) => "force-warn",
             Level::Deny => "deny",
             Level::Forbid => "forbid",
         }
@@ -219,7 +225,7 @@ impl Level {
 
     pub fn is_error(self) -> bool {
         match self {
-            Level::Allow | Level::Expect(_) | Level::Warn | Level::ForceWarn => false,
+            Level::Allow | Level::Expect(_) | Level::Warn | Level::ForceWarn(_) => false,
             Level::Deny | Level::Forbid => true,
         }
     }

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -1432,7 +1432,7 @@ pub fn get_cmd_lint_options(
     let mut lint_opts_with_position = vec![];
     let mut describe_lints = false;
 
-    for level in [lint::Allow, lint::Warn, lint::ForceWarn, lint::Deny, lint::Forbid] {
+    for level in [lint::Allow, lint::Warn, lint::ForceWarn(None), lint::Deny, lint::Forbid] {
         for (arg_pos, lint_name) in matches.opt_strs_pos(level.as_str()) {
             if lint_name == "help" {
                 describe_lints = true;

--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -286,6 +286,14 @@ impl Session {
     ) -> DiagnosticBuilder<'_, ()> {
         self.diagnostic().struct_span_warn(sp, msg)
     }
+    pub fn struct_span_warn_with_expectation<S: Into<MultiSpan>>(
+        &self,
+        sp: S,
+        msg: impl Into<DiagnosticMessage>,
+        id: lint::LintExpectationId,
+    ) -> DiagnosticBuilder<'_, ()> {
+        self.diagnostic().struct_span_warn_with_expectation(sp, msg, id)
+    }
     pub fn struct_span_warn_with_code<S: Into<MultiSpan>>(
         &self,
         sp: S,
@@ -296,6 +304,13 @@ impl Session {
     }
     pub fn struct_warn(&self, msg: impl Into<DiagnosticMessage>) -> DiagnosticBuilder<'_, ()> {
         self.diagnostic().struct_warn(msg)
+    }
+    pub fn struct_warn_with_expectation(
+        &self,
+        msg: impl Into<DiagnosticMessage>,
+        id: lint::LintExpectationId,
+    ) -> DiagnosticBuilder<'_, ()> {
+        self.diagnostic().struct_warn_with_expectation(msg, id)
     }
     pub fn struct_span_allow<S: Into<MultiSpan>>(
         &self,

--- a/library/alloc/src/collections/btree/map.rs
+++ b/library/alloc/src/collections/btree/map.rs
@@ -159,6 +159,9 @@ pub(super) const MIN_LEN: usize = node::MIN_LEN_AFTER_SPLIT;
 /// // update a key, guarding against the key possibly not being set
 /// let stat = player_stats.entry("attack").or_insert(100);
 /// *stat += random_stat_buff();
+///
+/// // modify an entry before an insert with in-place mutation
+/// player_stats.entry("mana").and_modify(|mana| *mana += 200).or_insert(100);
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 #[cfg_attr(not(test), rustc_diagnostic_item = "BTreeMap")]
@@ -1135,10 +1138,12 @@ impl<K, V> BTreeMap<K, V> {
     ///
     /// // count the number of occurrences of letters in the vec
     /// for x in ["a", "b", "a", "c", "a", "b"] {
-    ///     *count.entry(x).or_insert(0) += 1;
+    ///     count.entry(x).and_modify(|curr| *curr += 1).or_insert(1);
     /// }
     ///
     /// assert_eq!(count["a"], 3);
+    /// assert_eq!(count["b"], 2);
+    /// assert_eq!(count["1"], 1);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn entry(&mut self, key: K) -> Entry<'_, K, V>

--- a/library/alloc/src/collections/btree/map.rs
+++ b/library/alloc/src/collections/btree/map.rs
@@ -1143,7 +1143,7 @@ impl<K, V> BTreeMap<K, V> {
     ///
     /// assert_eq!(count["a"], 3);
     /// assert_eq!(count["b"], 2);
-    /// assert_eq!(count["1"], 1);
+    /// assert_eq!(count["c"], 1);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn entry(&mut self, key: K) -> Entry<'_, K, V>

--- a/library/std/src/collections/hash/map.rs
+++ b/library/std/src/collections/hash/map.rs
@@ -164,6 +164,9 @@ use crate::sys;
 /// // update a key, guarding against the key possibly not being set
 /// let stat = player_stats.entry("attack").or_insert(100);
 /// *stat += random_stat_buff();
+///
+/// // modify an entry before an insert with in-place mutation
+/// player_stats.entry("mana").and_modify(|mana| *mana += 200).or_insert(100);
 /// ```
 ///
 /// The easiest way to use `HashMap` with a custom key type is to derive [`Eq`] and [`Hash`].
@@ -829,8 +832,7 @@ where
     /// let mut letters = HashMap::new();
     ///
     /// for ch in "a short treatise on fungi".chars() {
-    ///     let counter = letters.entry(ch).or_insert(0);
-    ///     *counter += 1;
+    ///     letters.entry(ch).and_modify(|counter| *counter += 1).or_insert(1);
     /// }
     ///
     /// assert_eq!(letters[&'s'], 2);

--- a/src/bootstrap/bin/rustc.rs
+++ b/src/bootstrap/bin/rustc.rs
@@ -127,12 +127,18 @@ fn main() {
             }
         }
 
+        // Cargo doesn't pass RUSTFLAGS to proc_macros:
+        // https://github.com/rust-lang/cargo/issues/4423
+        // Thus, if we are on stage 0, we explicitly set `--cfg=bootstrap`.
+        // We also declare that the flag is expected, which is mainly needed for
+        // later stages so that they don't warn about #[cfg(bootstrap)],
+        // but enabling it for stage 0 too lets any warnings, if they occur,
+        // occur more early on, e.g. about #[cfg(bootstrap = "foo")].
         if stage == "0" {
-            // Cargo doesn't pass RUSTFLAGS to proc_macros:
-            // https://github.com/rust-lang/cargo/issues/4423
-            // Set `--cfg=bootstrap` explicitly instead.
             cmd.arg("--cfg=bootstrap");
         }
+        cmd.arg("-Zunstable-options");
+        cmd.arg("--check-cfg=values(bootstrap)");
     }
 
     if let Ok(map) = env::var("RUSTC_DEBUGINFO_MAP") {

--- a/src/etc/natvis/liballoc.natvis
+++ b/src/etc/natvis/liballoc.natvis
@@ -59,39 +59,133 @@
     </Expand>
   </Type>
 
+  <!--
+      The display string for Rc, Arc, etc is optional because the expression cannot be evaluated
+      if the pointee is unsized (i.e. if `ptr.pointer` is a fat pointer).
+
+      There are also two versions for the reference count fields, one for sized and one for
+      dyn pointees.
+
+      Rc<[T]> and Arc<[T]> are handled separately altogether so we can actually show
+      the slice values.
+  -->
+  <!-- alloc::rc::Rc<T> -->
   <Type Name="alloc::rc::Rc&lt;*&gt;">
-    <DisplayString>{ptr.pointer->value}</DisplayString>
+    <DisplayString Optional="true">{ptr.pointer->value}</DisplayString>
     <Expand>
-      <ExpandedItem>ptr.pointer->value</ExpandedItem>
-      <Item Name="[Reference count]">ptr.pointer->strong</Item>
-      <Item Name="[Weak reference count]">ptr.pointer->weak</Item>
-    </Expand>
-  </Type>
-  <Type Name="alloc::rc::Weak&lt;*&gt;">
-    <DisplayString>{ptr.pointer->value}</DisplayString>
-    <Expand>
-      <ExpandedItem>ptr.pointer->value</ExpandedItem>
-      <Item Name="[Reference count]">ptr.pointer->strong</Item>
-      <Item Name="[Weak reference count]">ptr.pointer->weak</Item>
+      <!-- thin -->
+      <ExpandedItem Optional="true">ptr.pointer->value</ExpandedItem>
+      <Item Name="[Reference count]" Optional="true">ptr.pointer->strong</Item>
+      <Item Name="[Weak reference count]" Optional="true">ptr.pointer->weak</Item>
+
+      <!-- dyn -->
+      <Item Name="[Reference count]" Optional="true">ptr.pointer.pointer->strong</Item>
+      <Item Name="[Weak reference count]" Optional="true">ptr.pointer.pointer->weak</Item>
     </Expand>
   </Type>
 
+  <!-- alloc::rc::Rc<[T]> -->
+  <Type Name="alloc::rc::Rc&lt;slice$&lt;*&gt; &gt;">
+    <DisplayString>{{ len={ptr.pointer.length} }}</DisplayString>
+    <Expand>
+      <Item Name="[Length]" ExcludeView="simple">ptr.pointer.length</Item>
+      <Item Name="[Reference count]">ptr.pointer.data_ptr->strong</Item>
+      <Item Name="[Weak reference count]">ptr.pointer.data_ptr->weak</Item>
+      <ArrayItems>
+        <Size>ptr.pointer.length</Size>
+        <!-- We add +2 to the data_ptr in order to skip the ref count fields in the RcBox -->
+        <ValuePointer>($T1*)(((size_t*)ptr.pointer.data_ptr) + 2)</ValuePointer>
+      </ArrayItems>
+    </Expand>
+  </Type>
+
+  <!-- alloc::rc::Weak<T> -->
+  <Type Name="alloc::rc::Weak&lt;*&gt;">
+    <DisplayString Optional="true">{ptr.pointer->value}</DisplayString>
+    <Expand>
+      <!-- thin -->
+      <ExpandedItem Optional="true">ptr.pointer->value</ExpandedItem>
+      <Item Name="[Reference count]" Optional="true">ptr.pointer->strong</Item>
+      <Item Name="[Weak reference count]" Optional="true">ptr.pointer->weak</Item>
+
+      <!-- dyn -->
+      <Item Name="[Reference count]" Optional="true">ptr.pointer.pointer->strong</Item>
+      <Item Name="[Weak reference count]" Optional="true">ptr.pointer.pointer->weak</Item>
+    </Expand>
+  </Type>
+
+  <!-- alloc::rc::Weak<[T]> -->
+  <Type Name="alloc::rc::Weak&lt;slice$&lt;*&gt; &gt;">
+    <DisplayString>{{ len={ptr.pointer.length} }}</DisplayString>
+    <Expand>
+      <Item Name="[Length]" ExcludeView="simple">ptr.pointer.length</Item>
+      <Item Name="[Reference count]">ptr.pointer.data_ptr->strong</Item>
+      <Item Name="[Weak reference count]">ptr.pointer.data_ptr->weak</Item>
+      <ArrayItems>
+        <Size>ptr.pointer.length</Size>
+        <ValuePointer>($T1*)(((size_t*)ptr.pointer.data_ptr) + 2)</ValuePointer>
+      </ArrayItems>
+    </Expand>
+  </Type>
+
+  <!-- alloc::sync::Arc<T> -->
   <Type Name="alloc::sync::Arc&lt;*&gt;">
-    <DisplayString>{ptr.pointer->data}</DisplayString>
+    <DisplayString Optional="true">{ptr.pointer->data}</DisplayString>
     <Expand>
-      <ExpandedItem>ptr.pointer->data</ExpandedItem>
-      <Item Name="[Reference count]">ptr.pointer->strong</Item>
-      <Item Name="[Weak reference count]">ptr.pointer->weak</Item>
+      <!-- thin -->
+      <ExpandedItem Optional="true">ptr.pointer->data</ExpandedItem>
+      <Item Name="[Reference count]" Optional="true">ptr.pointer->strong</Item>
+      <Item Name="[Weak reference count]" Optional="true">ptr.pointer->weak</Item>
+
+      <!-- dyn -->
+      <Item Name="[Reference count]" Optional="true">ptr.pointer.pointer->strong</Item>
+      <Item Name="[Weak reference count]" Optional="true">ptr.pointer.pointer->weak</Item>
     </Expand>
   </Type>
+
+  <!-- alloc::sync::Arc<[T]> -->
+  <Type Name="alloc::sync::Arc&lt;slice$&lt;*&gt; &gt;">
+    <DisplayString>{{ len={ptr.pointer.length} }}</DisplayString>
+    <Expand>
+      <Item Name="[Length]" ExcludeView="simple">ptr.pointer.length</Item>
+      <Item Name="[Reference count]">ptr.pointer.data_ptr->strong</Item>
+      <Item Name="[Weak reference count]">ptr.pointer.data_ptr->weak</Item>
+      <ArrayItems>
+        <Size>ptr.pointer.length</Size>
+        <ValuePointer>($T1*)(((size_t*)ptr.pointer.data_ptr) + 2)</ValuePointer>
+      </ArrayItems>
+    </Expand>
+  </Type>
+
+  <!-- alloc::sync::Weak<T> -->
   <Type Name="alloc::sync::Weak&lt;*&gt;">
-    <DisplayString>{ptr.pointer->data}</DisplayString>
+    <DisplayString Optional="true">{ptr.pointer->data}</DisplayString>
     <Expand>
-      <ExpandedItem>ptr.pointer->data</ExpandedItem>
-      <Item Name="[Reference count]">ptr.pointer->strong</Item>
-      <Item Name="[Weak reference count]">ptr.pointer->weak</Item>
+      <!-- thin -->
+      <ExpandedItem Optional="true">ptr.pointer->data</ExpandedItem>
+      <Item Name="[Reference count]" Optional="true">ptr.pointer->strong</Item>
+      <Item Name="[Weak reference count]" Optional="true">ptr.pointer->weak</Item>
+
+      <!-- dyn -->
+      <Item Name="[Reference count]" Optional="true">ptr.pointer.pointer->strong</Item>
+      <Item Name="[Weak reference count]" Optional="true">ptr.pointer.pointer->weak</Item>
     </Expand>
   </Type>
+
+  <!-- alloc::sync::Weak<[T]> -->
+  <Type Name="alloc::sync::Weak&lt;slice$&lt;*&gt; &gt;">
+    <DisplayString>{{ len={ptr.pointer.length} }}</DisplayString>
+    <Expand>
+      <Item Name="[Length]" ExcludeView="simple">ptr.pointer.length</Item>
+      <Item Name="[Reference count]">ptr.pointer.data_ptr->strong</Item>
+      <Item Name="[Weak reference count]">ptr.pointer.data_ptr->weak</Item>
+      <ArrayItems>
+        <Size>ptr.pointer.length</Size>
+        <ValuePointer>($T1*)(((size_t*)ptr.pointer.data_ptr) + 2)</ValuePointer>
+      </ArrayItems>
+    </Expand>
+  </Type>
+
   <Type Name="alloc::borrow::Cow&lt;*&gt;">
     <DisplayString Condition="RUST$ENUM$DISR == 0x0">Borrowed({__0})</DisplayString>
     <DisplayString Condition="RUST$ENUM$DISR == 0x1">Owned({__0})</DisplayString>

--- a/src/test/debuginfo/rc_arc.rs
+++ b/src/test/debuginfo/rc_arc.rs
@@ -58,7 +58,7 @@
 
 // cdb-command:dx slice_rc,d
 // cdb-check:slice_rc,d       : { len=3 } [Type: alloc::rc::Rc<slice$<u32> >]
-// cdb-check:    [Length]         : 3 [Type: unsigned __int64]
+// cdb-check:    [Length]         : 3 [Type: [...]]
 // cdb-check:    [Reference count] : 41 [Type: core::cell::Cell<usize>]
 // cdb-check:    [Weak reference count] : 2 [Type: core::cell::Cell<usize>]
 // cdb-check:    [0]              : 1 [Type: u32]
@@ -67,7 +67,7 @@
 
 // cdb-command:dx slice_rc_weak,d
 // cdb-check:slice_rc_weak,d  : { len=3 } [Type: alloc::rc::Weak<slice$<u32> >]
-// cdb-check:    [Length]         : 3 [Type: unsigned __int64]
+// cdb-check:    [Length]         : 3 [Type: [...]]
 // cdb-check:    [Reference count] : 41 [Type: core::cell::Cell<usize>]
 // cdb-check:    [Weak reference count] : 2 [Type: core::cell::Cell<usize>]
 // cdb-check:    [0]              : 1 [Type: u32]
@@ -86,7 +86,7 @@
 
 // cdb-command:dx slice_arc,d
 // cdb-check:slice_arc,d      : { len=3 } [Type: alloc::sync::Arc<slice$<u32> >]
-// cdb-check:    [Length]         : 3 [Type: unsigned __int64]
+// cdb-check:    [Length]         : 3 [Type: [...]]
 // cdb-check:    [Reference count] : 61 [Type: core::sync::atomic::AtomicUsize]
 // cdb-check:    [Weak reference count] : 2 [Type: core::sync::atomic::AtomicUsize]
 // cdb-check:    [0]              : 4 [Type: u32]
@@ -95,7 +95,7 @@
 
 // cdb-command:dx slice_arc_weak,d
 // cdb-check:slice_arc_weak,d : { len=3 } [Type: alloc::sync::Weak<slice$<u32> >]
-// cdb-check:    [Length]         : 3 [Type: unsigned __int64]
+// cdb-check:    [Length]         : 3 [Type: [...]]
 // cdb-check:    [Reference count] : 61 [Type: core::sync::atomic::AtomicUsize]
 // cdb-check:    [Weak reference count] : 2 [Type: core::sync::atomic::AtomicUsize]
 // cdb-check:    [0]              : 4 [Type: u32]

--- a/src/test/debuginfo/rc_arc.rs
+++ b/src/test/debuginfo/rc_arc.rs
@@ -8,74 +8,138 @@
 
 // gdb-command:run
 
-// gdb-command:print r
-// gdb-check:[...]$1 = Rc(strong=2, weak=1) = {value = 42, strong = 2, weak = 1}
-// gdb-command:print a
-// gdb-check:[...]$2 = Arc(strong=2, weak=1) = {value = 42, strong = 2, weak = 1}
-
+// gdb-command:print rc
+// gdb-check:[...]$1 = Rc(strong=11, weak=1) = {value = 111, strong = 11, weak = 1}
+// gdb-command:print arc
+// gdb-check:[...]$2 = Arc(strong=21, weak=1) = {value = 222, strong = 21, weak = 1}
 
 // === LLDB TESTS ==================================================================================
 
 // lldb-command:run
 
-// lldb-command:print r
-// lldb-check:[...]$0 = strong=2, weak=1 { value = 42 }
-// lldb-command:print a
-// lldb-check:[...]$1 = strong=2, weak=1 { data = 42 }
+// lldb-command:print rc
+// lldb-check:[...]$0 = strong=11, weak=1 { value = 111 }
+// lldb-command:print arc
+// lldb-check:[...]$1 = strong=21, weak=1 { data = 222 }
 
 // === CDB TESTS ==================================================================================
 
 // cdb-command:g
 
-// cdb-command:dx r,d
-// cdb-check:r,d              : 42 [Type: alloc::rc::Rc<i32>]
-// cdb-check:    [<Raw View>]     [Type: alloc::rc::Rc<i32>]
-// cdb-check:    [Reference count] : 2 [Type: core::cell::Cell<usize>]
+// cdb-command:dx rc,d
+// cdb-check:rc,d             : 111 [Type: alloc::rc::Rc<i32>]
+// cdb-check:    [Reference count] : 11 [Type: core::cell::Cell<usize>]
 // cdb-check:    [Weak reference count] : 2 [Type: core::cell::Cell<usize>]
 
-// cdb-command:dx r1,d
-// cdb-check:r1,d             : 42 [Type: alloc::rc::Rc<i32>]
-// cdb-check:    [<Raw View>]     [Type: alloc::rc::Rc<i32>]
-// cdb-check:    [Reference count] : 2 [Type: core::cell::Cell<usize>]
+// cdb-command:dx weak_rc,d
+// cdb-check:weak_rc,d        : 111 [Type: alloc::rc::Weak<i32>]
+// cdb-check:    [Reference count] : 11 [Type: core::cell::Cell<usize>]
 // cdb-check:    [Weak reference count] : 2 [Type: core::cell::Cell<usize>]
 
-// cdb-command:dx w1,d
-// cdb-check:w1,d             : 42 [Type: alloc::rc::Weak<i32>]
-// cdb-check:    [<Raw View>]     [Type: alloc::rc::Weak<i32>]
-// cdb-check:    [Reference count] : 2 [Type: core::cell::Cell<usize>]
+// cdb-command:dx arc,d
+// cdb-check:arc,d            : 222 [Type: alloc::sync::Arc<i32>]
+// cdb-check:    [Reference count] : 21 [Type: core::sync::atomic::AtomicUsize]
+// cdb-check:    [Weak reference count] : 2 [Type: core::sync::atomic::AtomicUsize]
+
+// cdb-command:dx weak_arc,d
+// cdb-check:weak_arc,d       : 222 [Type: alloc::sync::Weak<i32>]
+// cdb-check:    [Reference count] : 21 [Type: core::sync::atomic::AtomicUsize]
+// cdb-check:    [Weak reference count] : 2 [Type: core::sync::atomic::AtomicUsize]
+
+// cdb-command:dx dyn_rc,d
+// cdb-check:dyn_rc,d         [Type: alloc::rc::Rc<dyn$<core::fmt::Debug> >]
+// cdb-check:    [Reference count] : 31 [Type: core::cell::Cell<usize>]
 // cdb-check:    [Weak reference count] : 2 [Type: core::cell::Cell<usize>]
 
-// cdb-command:dx a,d
-// cdb-check:a,d              : 42 [Type: alloc::sync::Arc<i32>]
-// cdb-check:    [<Raw View>]     [Type: alloc::sync::Arc<i32>]
-// cdb-check:    [Reference count] : 2 [Type: core::sync::atomic::AtomicUsize]
+// cdb-command:dx dyn_rc_weak,d
+// cdb-check:dyn_rc_weak,d    [Type: alloc::rc::Weak<dyn$<core::fmt::Debug> >]
+// cdb-check:    [Reference count] : 31 [Type: core::cell::Cell<usize>]
+// cdb-check:    [Weak reference count] : 2 [Type: core::cell::Cell<usize>]
+
+// cdb-command:dx slice_rc,d
+// cdb-check:slice_rc,d       : { len=3 } [Type: alloc::rc::Rc<slice$<u32> >]
+// cdb-check:    [Length]         : 3 [Type: unsigned __int64]
+// cdb-check:    [Reference count] : 41 [Type: core::cell::Cell<usize>]
+// cdb-check:    [Weak reference count] : 2 [Type: core::cell::Cell<usize>]
+// cdb-check:    [0]              : 1 [Type: u32]
+// cdb-check:    [1]              : 2 [Type: u32]
+// cdb-check:    [2]              : 3 [Type: u32]
+
+// cdb-command:dx slice_rc_weak,d
+// cdb-check:slice_rc_weak,d  : { len=3 } [Type: alloc::rc::Weak<slice$<u32> >]
+// cdb-check:    [Length]         : 3 [Type: unsigned __int64]
+// cdb-check:    [Reference count] : 41 [Type: core::cell::Cell<usize>]
+// cdb-check:    [Weak reference count] : 2 [Type: core::cell::Cell<usize>]
+// cdb-check:    [0]              : 1 [Type: u32]
+// cdb-check:    [1]              : 2 [Type: u32]
+// cdb-check:    [2]              : 3 [Type: u32]
+
+// cdb-command:dx dyn_arc,d
+// cdb-check:dyn_arc,d        [Type: alloc::sync::Arc<dyn$<core::fmt::Debug> >]
+// cdb-check:    [Reference count] : 51 [Type: core::sync::atomic::AtomicUsize]
 // cdb-check:    [Weak reference count] : 2 [Type: core::sync::atomic::AtomicUsize]
 
-// cdb-command:dx a1,d
-// cdb-check:a1,d             : 42 [Type: alloc::sync::Arc<i32>]
-// cdb-check:    [<Raw View>]     [Type: alloc::sync::Arc<i32>]
-// cdb-check:    [Reference count] : 2 [Type: core::sync::atomic::AtomicUsize]
+// cdb-command:dx dyn_arc_weak,d
+// cdb-check:dyn_arc_weak,d   [Type: alloc::sync::Weak<dyn$<core::fmt::Debug> >]
+// cdb-check:    [Reference count] : 51 [Type: core::sync::atomic::AtomicUsize]
 // cdb-check:    [Weak reference count] : 2 [Type: core::sync::atomic::AtomicUsize]
 
-// cdb-command:dx w2,d
-// cdb-check:w2,d             : 42 [Type: alloc::sync::Weak<i32>]
-// cdb-check:    [<Raw View>]     [Type: alloc::sync::Weak<i32>]
-// cdb-check:    [Reference count] : 2 [Type: core::sync::atomic::AtomicUsize]
+// cdb-command:dx slice_arc,d
+// cdb-check:slice_arc,d      : { len=3 } [Type: alloc::sync::Arc<slice$<u32> >]
+// cdb-check:    [Length]         : 3 [Type: unsigned __int64]
+// cdb-check:    [Reference count] : 61 [Type: core::sync::atomic::AtomicUsize]
 // cdb-check:    [Weak reference count] : 2 [Type: core::sync::atomic::AtomicUsize]
+// cdb-check:    [0]              : 4 [Type: u32]
+// cdb-check:    [1]              : 5 [Type: u32]
+// cdb-check:    [2]              : 6 [Type: u32]
 
+// cdb-command:dx slice_arc_weak,d
+// cdb-check:slice_arc_weak,d : { len=3 } [Type: alloc::sync::Weak<slice$<u32> >]
+// cdb-check:    [Length]         : 3 [Type: unsigned __int64]
+// cdb-check:    [Reference count] : 61 [Type: core::sync::atomic::AtomicUsize]
+// cdb-check:    [Weak reference count] : 2 [Type: core::sync::atomic::AtomicUsize]
+// cdb-check:    [0]              : 4 [Type: u32]
+// cdb-check:    [1]              : 5 [Type: u32]
+// cdb-check:    [2]              : 6 [Type: u32]
+
+use std::fmt::Debug;
 use std::rc::Rc;
 use std::sync::Arc;
 
 fn main() {
-    let r = Rc::new(42);
-    let r1 = Rc::clone(&r);
-    let w1 = Rc::downgrade(&r);
+    let rc = Rc::new(111);
+    inc_ref_count(&rc, 10);
+    let weak_rc = Rc::downgrade(&rc);
 
-    let a = Arc::new(42);
-    let a1 = Arc::clone(&a);
-    let w2 = Arc::downgrade(&a);
+    let arc = Arc::new(222);
+    inc_ref_count(&arc, 20);
+    let weak_arc = Arc::downgrade(&arc);
+
+    let dyn_rc: Rc<dyn Debug> = Rc::new(333);
+    inc_ref_count(&dyn_rc, 30);
+    let dyn_rc_weak = Rc::downgrade(&dyn_rc);
+
+    let slice_rc: Rc<[u32]> = Rc::from(vec![1, 2, 3]);
+    inc_ref_count(&slice_rc, 40);
+    let slice_rc_weak = Rc::downgrade(&slice_rc);
+
+    let dyn_arc: Arc<dyn Debug> = Arc::new(444);
+    inc_ref_count(&dyn_arc, 50);
+    let dyn_arc_weak = Arc::downgrade(&dyn_arc);
+
+    let slice_arc: Arc<[u32]> = Arc::from(vec![4, 5, 6]);
+    inc_ref_count(&slice_arc, 60);
+    let slice_arc_weak = Arc::downgrade(&slice_arc);
 
     zzz(); // #break
 }
 
-fn zzz() { () }
+fn inc_ref_count<T: Clone>(rc: &T, count: usize) {
+    for _ in 0..count {
+        std::mem::forget(rc.clone());
+    }
+}
+
+fn zzz() {
+    ()
+}

--- a/src/test/ui/lint/rfc-2383-lint-reason/force_warn_expected_lints_fulfilled.rs
+++ b/src/test/ui/lint/rfc-2383-lint-reason/force_warn_expected_lints_fulfilled.rs
@@ -1,0 +1,48 @@
+// compile-flags: --force-warn while_true
+// compile-flags: --force-warn unused_variables
+// compile-flags: --force-warn unused_mut
+// check-pass
+
+#![feature(lint_reasons)]
+
+fn expect_early_pass_lint() {
+    #[expect(while_true)]
+    while true {
+        //~^ WARNING denote infinite loops with `loop { ... }` [while_true]
+        //~| NOTE requested on the command line with `--force-warn while-true`
+        //~| HELP use `loop`
+        println!("I never stop")
+    }
+}
+
+#[expect(unused_variables, reason="<this should fail and display this reason>")]
+fn check_specific_lint() {
+    let x = 2;
+    //~^ WARNING unused variable: `x` [unused_variables]
+    //~| NOTE requested on the command line with `--force-warn unused-variables`
+    //~| HELP if this is intentional, prefix it with an underscore
+}
+
+#[expect(unused)]
+fn check_multiple_lints_with_lint_group() {
+    let fox_name = "Sir Nibbles";
+    //~^ WARNING unused variable: `fox_name` [unused_variables]
+    //~| HELP if this is intentional, prefix it with an underscore
+
+    let mut what_does_the_fox_say = "*ding* *deng* *dung*";
+    //~^ WARNING variable does not need to be mutable [unused_mut]
+    //~| NOTE requested on the command line with `--force-warn unused-mut`
+    //~| HELP remove this `mut`
+
+    println!("The fox says: {what_does_the_fox_say}");
+}
+
+#[allow(unused_variables)]
+fn check_expect_overrides_allow_lint_level() {
+    #[expect(unused_variables)]
+    let this_should_fulfill_the_expectation = "The `#[allow]` has no power here";
+    //~^ WARNING unused variable: `this_should_fulfill_the_expectation` [unused_variables]
+    //~| HELP if this is intentional, prefix it with an underscore
+}
+
+fn main() {}

--- a/src/test/ui/lint/rfc-2383-lint-reason/force_warn_expected_lints_fulfilled.stderr
+++ b/src/test/ui/lint/rfc-2383-lint-reason/force_warn_expected_lints_fulfilled.stderr
@@ -1,0 +1,40 @@
+warning: denote infinite loops with `loop { ... }`
+  --> $DIR/force_warn_expected_lints_fulfilled.rs:10:5
+   |
+LL |     while true {
+   |     ^^^^^^^^^^ help: use `loop`
+   |
+   = note: requested on the command line with `--force-warn while-true`
+
+warning: unused variable: `x`
+  --> $DIR/force_warn_expected_lints_fulfilled.rs:20:9
+   |
+LL |     let x = 2;
+   |         ^ help: if this is intentional, prefix it with an underscore: `_x`
+   |
+   = note: requested on the command line with `--force-warn unused-variables`
+
+warning: unused variable: `fox_name`
+  --> $DIR/force_warn_expected_lints_fulfilled.rs:28:9
+   |
+LL |     let fox_name = "Sir Nibbles";
+   |         ^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_fox_name`
+
+warning: unused variable: `this_should_fulfill_the_expectation`
+  --> $DIR/force_warn_expected_lints_fulfilled.rs:43:9
+   |
+LL |     let this_should_fulfill_the_expectation = "The `#[allow]` has no power here";
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_this_should_fulfill_the_expectation`
+
+warning: variable does not need to be mutable
+  --> $DIR/force_warn_expected_lints_fulfilled.rs:32:9
+   |
+LL |     let mut what_does_the_fox_say = "*ding* *deng* *dung*";
+   |         ----^^^^^^^^^^^^^^^^^^^^^
+   |         |
+   |         help: remove this `mut`
+   |
+   = note: requested on the command line with `--force-warn unused-mut`
+
+warning: 5 warnings emitted
+

--- a/src/test/ui/lint/rfc-2383-lint-reason/force_warn_expected_lints_unfulfilled.rs
+++ b/src/test/ui/lint/rfc-2383-lint-reason/force_warn_expected_lints_unfulfilled.rs
@@ -1,0 +1,49 @@
+// compile-flags: --force-warn while_true
+// compile-flags: --force-warn unused_variables
+// compile-flags: --force-warn unused_mut
+// check-pass
+
+#![feature(lint_reasons)]
+
+fn expect_early_pass_lint(terminate: bool) {
+    #[expect(while_true)]
+    //~^ WARNING this lint expectation is unfulfilled [unfulfilled_lint_expectations]
+    //~| NOTE `#[warn(unfulfilled_lint_expectations)]` on by default
+    while !terminate {
+        println!("Do you know what a spin lock is?")
+    }
+}
+
+#[expect(unused_variables, reason="<this should fail and display this reason>")]
+//~^ WARNING this lint expectation is unfulfilled [unfulfilled_lint_expectations]
+//~| NOTE <this should fail and display this reason>
+fn check_specific_lint() {
+    let _x = 2;
+}
+
+#[expect(unused)]
+//~^ WARNING this lint expectation is unfulfilled [unfulfilled_lint_expectations]
+fn check_multiple_lints_with_lint_group() {
+    let fox_name = "Sir Nibbles";
+
+    let what_does_the_fox_say = "*ding* *deng* *dung*";
+
+    println!("The fox says: {what_does_the_fox_say}");
+    println!("~ {fox_name}")
+}
+
+
+#[expect(unused)]
+//~^ WARNING this lint expectation is unfulfilled [unfulfilled_lint_expectations]
+fn check_overridden_expectation_lint_level() {
+    #[allow(unused_variables)]
+    let this_should_not_fulfill_the_expectation = "maybe";
+    //~^ WARNING unused variable: `this_should_not_fulfill_the_expectation` [unused_variables]
+    //~| NOTE requested on the command line with `--force-warn unused-variables`
+    //~| HELP if this is intentional, prefix it with an underscore
+}
+
+fn main() {
+    check_multiple_lints_with_lint_group();
+    check_overridden_expectation_lint_level();
+}

--- a/src/test/ui/lint/rfc-2383-lint-reason/force_warn_expected_lints_unfulfilled.stderr
+++ b/src/test/ui/lint/rfc-2383-lint-reason/force_warn_expected_lints_unfulfilled.stderr
@@ -1,0 +1,38 @@
+warning: unused variable: `this_should_not_fulfill_the_expectation`
+  --> $DIR/force_warn_expected_lints_unfulfilled.rs:40:9
+   |
+LL |     let this_should_not_fulfill_the_expectation = "maybe";
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_this_should_not_fulfill_the_expectation`
+   |
+   = note: requested on the command line with `--force-warn unused-variables`
+
+warning: this lint expectation is unfulfilled
+  --> $DIR/force_warn_expected_lints_unfulfilled.rs:9:14
+   |
+LL |     #[expect(while_true)]
+   |              ^^^^^^^^^^
+   |
+   = note: `#[warn(unfulfilled_lint_expectations)]` on by default
+
+warning: this lint expectation is unfulfilled
+  --> $DIR/force_warn_expected_lints_unfulfilled.rs:17:10
+   |
+LL | #[expect(unused_variables, reason="<this should fail and display this reason>")]
+   |          ^^^^^^^^^^^^^^^^
+   |
+   = note: <this should fail and display this reason>
+
+warning: this lint expectation is unfulfilled
+  --> $DIR/force_warn_expected_lints_unfulfilled.rs:24:10
+   |
+LL | #[expect(unused)]
+   |          ^^^^^^
+
+warning: this lint expectation is unfulfilled
+  --> $DIR/force_warn_expected_lints_unfulfilled.rs:36:10
+   |
+LL | #[expect(unused)]
+   |          ^^^^^^
+
+warning: 5 warnings emitted
+

--- a/src/tools/rustfmt/src/parse/session.rs
+++ b/src/tools/rustfmt/src/parse/session.rs
@@ -433,7 +433,7 @@ mod tests {
                 Some(ignore_list),
             );
             let span = MultiSpan::from_span(mk_sp(BytePos(0), BytePos(1)));
-            let non_fatal_diagnostic = build_diagnostic(DiagnosticLevel::Warning, Some(span));
+            let non_fatal_diagnostic = build_diagnostic(DiagnosticLevel::Warning(None), Some(span));
             emitter.emit_diagnostic(&non_fatal_diagnostic);
             assert_eq!(num_emitted_errors.load(Ordering::Acquire), 0);
             assert_eq!(can_reset_errors.load(Ordering::Acquire), true);
@@ -457,7 +457,7 @@ mod tests {
                 None,
             );
             let span = MultiSpan::from_span(mk_sp(BytePos(0), BytePos(1)));
-            let non_fatal_diagnostic = build_diagnostic(DiagnosticLevel::Warning, Some(span));
+            let non_fatal_diagnostic = build_diagnostic(DiagnosticLevel::Warning(None), Some(span));
             emitter.emit_diagnostic(&non_fatal_diagnostic);
             assert_eq!(num_emitted_errors.load(Ordering::Acquire), 1);
             assert_eq!(can_reset_errors.load(Ordering::Acquire), false);
@@ -494,8 +494,8 @@ mod tests {
             );
             let bar_span = MultiSpan::from_span(mk_sp(BytePos(0), BytePos(1)));
             let foo_span = MultiSpan::from_span(mk_sp(BytePos(21), BytePos(22)));
-            let bar_diagnostic = build_diagnostic(DiagnosticLevel::Warning, Some(bar_span));
-            let foo_diagnostic = build_diagnostic(DiagnosticLevel::Warning, Some(foo_span));
+            let bar_diagnostic = build_diagnostic(DiagnosticLevel::Warning(None), Some(bar_span));
+            let foo_diagnostic = build_diagnostic(DiagnosticLevel::Warning(None), Some(foo_span));
             let fatal_diagnostic = build_diagnostic(DiagnosticLevel::Fatal, None);
             emitter.emit_diagnostic(&bar_diagnostic);
             emitter.emit_diagnostic(&foo_diagnostic);


### PR DESCRIPTION
Successful merges:

 - #97757 (Support lint expectations for `--force-warn` lints (RFC 2383))
 - #98125 (Entry and_modify doc)
 - #98137 (debuginfo: Fix NatVis for Rc and Arc with unsized pointees.)
 - #98147 (Make #[cfg(bootstrap)] not error in proc macros on later stages )

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=97757,98125,98137,98147)
<!-- homu-ignore:end -->