### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/compiler/rustc_codegen_cranelift/example/mini_core.rs
+++ b/compiler/rustc_codegen_cranelift/example/mini_core.rs
@@ -567,7 +567,7 @@ pub mod intrinsics {
         pub fn copy<T>(src: *const T, dst: *mut T, count: usize);
         pub fn transmute<T, U>(e: T) -> U;
         pub fn ctlz_nonzero<T>(x: T) -> T;
-        pub fn needs_drop<T>() -> bool;
+        pub fn needs_drop<T: ?::Sized>() -> bool;
         pub fn bitreverse<T>(x: T) -> T;
         pub fn bswap<T>(x: T) -> T;
         pub fn write_bytes<T>(dst: *mut T, val: u8, count: usize);

--- a/compiler/rustc_codegen_cranelift/example/mini_core_hello_world.rs
+++ b/compiler/rustc_codegen_cranelift/example/mini_core_hello_world.rs
@@ -55,6 +55,11 @@ struct NoisyDrop {
     inner: NoisyDropInner,
 }
 
+struct NoisyDropUnsized {
+    text: str,
+    inner: NoisyDropInner,
+}
+
 struct NoisyDropInner;
 
 impl Drop for NoisyDrop {
@@ -170,7 +175,9 @@ fn main() {
         assert_eq!(intrinsics::min_align_of_val(&a) as u8, intrinsics::min_align_of::<&str>() as u8);
 
         assert!(!intrinsics::needs_drop::<u8>());
+        assert!(!intrinsics::needs_drop::<[u8]>());
         assert!(intrinsics::needs_drop::<NoisyDrop>());
+        assert!(intrinsics::needs_drop::<NoisyDropUnsized>());
 
         Unique {
             pointer: NonNull(1 as *mut &str),

--- a/compiler/rustc_codegen_cranelift/example/mini_core_hello_world.rs
+++ b/compiler/rustc_codegen_cranelift/example/mini_core_hello_world.rs
@@ -56,8 +56,8 @@ struct NoisyDrop {
 }
 
 struct NoisyDropUnsized {
-    text: str,
     inner: NoisyDropInner,
+    text: str,
 }
 
 struct NoisyDropInner;

--- a/compiler/rustc_codegen_gcc/example/mini_core.rs
+++ b/compiler/rustc_codegen_gcc/example/mini_core.rs
@@ -514,7 +514,7 @@ pub mod intrinsics {
         pub fn copy<T>(src: *const T, dst: *mut T, count: usize);
         pub fn transmute<T, U>(e: T) -> U;
         pub fn ctlz_nonzero<T>(x: T) -> T;
-        pub fn needs_drop<T>() -> bool;
+        pub fn needs_drop<T: ?::Sized>() -> bool;
         pub fn bitreverse<T>(x: T) -> T;
         pub fn bswap<T>(x: T) -> T;
         pub fn write_bytes<T>(dst: *mut T, val: u8, count: usize);

--- a/compiler/rustc_codegen_gcc/example/mini_core_hello_world.rs
+++ b/compiler/rustc_codegen_gcc/example/mini_core_hello_world.rs
@@ -47,6 +47,11 @@ struct NoisyDrop {
     inner: NoisyDropInner,
 }
 
+struct NoisyDropUnsized {
+    text: str,
+    inner: NoisyDropInner,
+}
+
 struct NoisyDropInner;
 
 impl Drop for NoisyDrop {
@@ -184,7 +189,9 @@ fn main() {
         assert_eq!(intrinsics::min_align_of_val(&a) as u8, intrinsics::min_align_of::<&str>() as u8);
 
         assert!(!intrinsics::needs_drop::<u8>());
+        assert!(!intrinsics::needs_drop::<[u8]>());
         assert!(intrinsics::needs_drop::<NoisyDrop>());
+        assert!(intrinsics::needs_drop::<NoisyDropUnsized>());
 
         Unique {
             pointer: 0 as *const &str,

--- a/compiler/rustc_codegen_gcc/example/mini_core_hello_world.rs
+++ b/compiler/rustc_codegen_gcc/example/mini_core_hello_world.rs
@@ -48,8 +48,8 @@ struct NoisyDrop {
 }
 
 struct NoisyDropUnsized {
-    text: str,
     inner: NoisyDropInner,
+    text: str,
 }
 
 struct NoisyDropInner;

--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -1162,7 +1162,7 @@ extern "rust-intrinsic" {
     ///
     /// The stabilized version of this intrinsic is [`mem::needs_drop`](crate::mem::needs_drop).
     #[rustc_const_stable(feature = "const_needs_drop", since = "1.40.0")]
-    pub fn needs_drop<T>() -> bool;
+    pub fn needs_drop<T: ?Sized>() -> bool;
 
     /// Calculates the offset from a pointer.
     ///

--- a/library/core/src/mem/mod.rs
+++ b/library/core/src/mem/mod.rs
@@ -592,7 +592,7 @@ pub const unsafe fn align_of_val_raw<T: ?Sized>(val: *const T) -> usize {
 #[stable(feature = "needs_drop", since = "1.21.0")]
 #[rustc_const_stable(feature = "const_mem_needs_drop", since = "1.36.0")]
 #[rustc_diagnostic_item = "needs_drop"]
-pub const fn needs_drop<T>() -> bool {
+pub const fn needs_drop<T: ?Sized>() -> bool {
     intrinsics::needs_drop::<T>()
 }
 

--- a/library/std/src/keyword_docs.rs
+++ b/library/std/src/keyword_docs.rs
@@ -2257,7 +2257,7 @@ mod await_keyword {}
 /// `dyn` is a prefix of a [trait object]'s type.
 ///
 /// The `dyn` keyword is used to highlight that calls to methods on the associated `Trait`
-/// are dynamically dispatched. To use the trait this way, it must be 'object safe'.
+/// are [dynamically dispatched]. To use the trait this way, it must be 'object safe'.
 ///
 /// Unlike generic parameters or `impl Trait`, the compiler does not know the concrete type that
 /// is being passed. That is, the type has been [erased].
@@ -2281,6 +2281,7 @@ mod await_keyword {}
 /// the method won't be duplicated for each concrete type.
 ///
 /// [trait object]: ../book/ch17-02-trait-objects.html
+/// [dynamically dispatched]: https://en.wikipedia.org/wiki/Dynamic_dispatch
 /// [ref-trait-obj]: ../reference/types/trait-object.html
 /// [ref-obj-safety]: ../reference/items/traits.html#object-safety
 /// [erased]: https://en.wikipedia.org/wiki/Type_erasure

--- a/library/std/src/thread/tests.rs
+++ b/library/std/src/thread/tests.rs
@@ -316,3 +316,16 @@ fn test_scoped_threads_drop_result_before_join() {
     });
     assert!(actually_finished.load(Ordering::Relaxed));
 }
+
+#[test]
+fn test_scoped_threads_nll() {
+    // this is mostly a *compilation test* for this exact function:
+    fn foo(x: &u8) {
+        thread::scope(|s| {
+            s.spawn(|| drop(x));
+        });
+    }
+    // let's also run it for good measure
+    let x = 42_u8;
+    foo(&x);
+}

--- a/src/test/rustdoc-json/output_generics.rs
+++ b/src/test/rustdoc-json/output_generics.rs
@@ -1,0 +1,38 @@
+// compile-flags: --document-private-items --document-hidden-items
+
+// This is a regression test for #98009.
+
+// @has output_generics.json
+// @has - "$.index[*][?(@.name=='this_compiles')]"
+// @has - "$.index[*][?(@.name=='this_does_not')]"
+// @has - "$.index[*][?(@.name=='Events')]"
+// @has - "$.index[*][?(@.name=='Other')]"
+// @has - "$.index[*][?(@.name=='Trait')]"
+
+struct Events<R>(R);
+
+struct Other;
+
+pub trait Trait<T> {
+    fn handle(value: T) -> Self;
+}
+
+impl<T, U> Trait<U> for T where T: From<U> {
+    fn handle(_: U) -> Self { unimplemented!() }
+}
+
+impl<'a, R> Trait<&'a mut Events<R>> for Other {
+    fn handle(_: &'a mut Events<R>) -> Self { unimplemented!() }
+}
+
+fn this_compiles<'a, R>(value: &'a mut Events<R>) {
+    for _ in 0..3 {
+        Other::handle(&mut *value);
+    }
+}
+
+fn this_does_not<'a, R>(value: &'a mut Events<R>) {
+    for _ in 0..3 {
+        Other::handle(value);
+    }
+}

--- a/src/test/ui/proc-macro/auxiliary/issue-91800-macro.rs
+++ b/src/test/ui/proc-macro/auxiliary/issue-91800-macro.rs
@@ -1,0 +1,26 @@
+// force-host
+// no-prefer-dynamic
+
+#![crate_type = "proc-macro"]
+
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+
+fn compile_error() -> TokenStream {
+    r#"compile_error!("")"#.parse().unwrap()
+}
+
+#[proc_macro_derive(MyTrait)]
+pub fn derive(input: TokenStream) -> TokenStream {
+    compile_error()
+}
+#[proc_macro_attribute]
+pub fn attribute_macro(_attr: TokenStream, mut input: TokenStream) -> TokenStream {
+    input.extend(compile_error());
+    input
+}
+#[proc_macro]
+pub fn fn_macro(_item: TokenStream) -> TokenStream {
+    compile_error()
+}

--- a/src/test/ui/proc-macro/issue-91800.rs
+++ b/src/test/ui/proc-macro/issue-91800.rs
@@ -1,0 +1,16 @@
+// aux-build: issue-91800-macro.rs
+
+#[macro_use]
+extern crate issue_91800_macro;
+
+#[derive(MyTrait)]
+//~^ ERROR macros that expand to items must be delimited with braces or followed by a semicolon
+//~| ERROR proc-macro derive produced unparseable tokens
+#[attribute_macro]
+//~^ ERROR macros that expand to items must be delimited with braces or followed by a semicolon
+struct MyStruct;
+
+fn_macro! {}
+//~^ ERROR macros that expand to items must be delimited with braces or followed by a semicolon
+
+fn main() {}

--- a/src/test/ui/proc-macro/issue-91800.stderr
+++ b/src/test/ui/proc-macro/issue-91800.stderr
@@ -1,0 +1,56 @@
+error: macros that expand to items must be delimited with braces or followed by a semicolon
+  --> $DIR/issue-91800.rs:6:10
+   |
+LL | #[derive(MyTrait)]
+   |          ^^^^^^^
+   |
+   = note: this error originates in the derive macro `MyTrait` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: proc-macro derive produced unparseable tokens
+  --> $DIR/issue-91800.rs:6:10
+   |
+LL | #[derive(MyTrait)]
+   |          ^^^^^^^
+
+error: 
+  --> $DIR/issue-91800.rs:6:10
+   |
+LL | #[derive(MyTrait)]
+   |          ^^^^^^^
+   |
+   = note: this error originates in the derive macro `MyTrait` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: macros that expand to items must be delimited with braces or followed by a semicolon
+  --> $DIR/issue-91800.rs:9:1
+   |
+LL | #[attribute_macro]
+   | ^^^^^^^^^^^^^^^^^^
+   |
+   = note: this error originates in the attribute macro `attribute_macro` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: 
+  --> $DIR/issue-91800.rs:9:1
+   |
+LL | #[attribute_macro]
+   | ^^^^^^^^^^^^^^^^^^
+   |
+   = note: this error originates in the attribute macro `attribute_macro` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: macros that expand to items must be delimited with braces or followed by a semicolon
+  --> $DIR/issue-91800.rs:13:1
+   |
+LL | fn_macro! {}
+   | ^^^^^^^^^^^^
+   |
+   = note: this error originates in the macro `fn_macro` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: 
+  --> $DIR/issue-91800.rs:13:1
+   |
+LL | fn_macro! {}
+   | ^^^^^^^^^^^^
+   |
+   = note: this error originates in the macro `fn_macro` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 7 previous errors
+


### PR DESCRIPTION
Successful merges:

 - #97377 (Do not suggest adding semicolon/changing delimiters for macros in item position that originates in macros)
 - #97675 (Make `std::mem::needs_drop` accept `?Sized`)
 - #98118 (Test NLL fix of bad lifetime inference for reference captured in closure.)
 - #98166 (Add rustdoc-json regression test for #98009)
 - #98169 (Keyword docs: Link to wikipedia article for dynamic dispatch)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=97377,97675,98118,98166,98169)
<!-- homu-ignore:end -->