### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/compiler/rustc_errors/src/emitter.rs
+++ b/compiler/rustc_errors/src/emitter.rs
@@ -656,6 +656,11 @@ impl Emitter for SilentEmitter {
     }
 }
 
+/// Maximum number of lines we will print for a multiline suggestion; arbitrary.
+///
+/// This should be replaced with a more involved mechanism to output multiline suggestions that
+/// more closely mimics the regular diagnostic output, where irrelevant code lines are elided.
+pub const MAX_SUGGESTION_HIGHLIGHT_LINES: usize = 6;
 /// Maximum number of suggestions to be shown
 ///
 /// Arbitrary, but taken from trait import suggestion limit

--- a/compiler/rustc_errors/src/lib.rs
+++ b/compiler/rustc_errors/src/lib.rs
@@ -1145,7 +1145,7 @@ impl HandlerInner {
             !this.emitted_diagnostics.insert(diagnostic_hash)
         };
 
-        // Only emit the diagnostic if we've been asked to deduplicate and
+        // Only emit the diagnostic if we've been asked to deduplicate or
         // haven't already emitted an equivalent diagnostic.
         if !(self.flags.deduplicate_diagnostics && already_emitted(self)) {
             debug!(?diagnostic);

--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -2042,9 +2042,9 @@ impl<'a> Parser<'a> {
                 match pat.kind {
                     PatKind::Ident(_, ident, _) => (
                         ident,
-                        "self: ".to_string(),
+                        "self: ",
                         ": TypeName".to_string(),
-                        "_: ".to_string(),
+                        "_: ",
                         pat.span.shrink_to_lo(),
                         pat.span.shrink_to_hi(),
                         pat.span.shrink_to_lo(),
@@ -2058,9 +2058,9 @@ impl<'a> Parser<'a> {
                                 let mutab = mutab.prefix_str();
                                 (
                                     ident,
-                                    "self: ".to_string(),
+                                    "self: ",
                                     format!("{ident}: &{mutab}TypeName"),
-                                    "_: ".to_string(),
+                                    "_: ",
                                     pat.span.shrink_to_lo(),
                                     pat.span,
                                     pat.span.shrink_to_lo(),

--- a/compiler/rustc_typeck/src/check/expr.rs
+++ b/compiler/rustc_typeck/src/check/expr.rs
@@ -1561,73 +1561,70 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             // FIXME: We are currently creating two branches here in order to maintain
             // consistency. But they should be merged as much as possible.
             let fru_tys = if self.tcx.features().type_changing_struct_update {
-                if let ty::Adt(adt, substs) = adt_ty.kind() && adt.is_struct() {
-                    // Make an ADT with fresh inference substitutions. This
-                    // will allow us to guide inference along so that, e.g.
-                    // ```
-                    // let x = MyStruct<'a, B, const C: usize> {
-                    //    f: 1,
-                    //    ..Default::default()
-                    // };
-                    // ```
-                    // will have the default base expression constrained to
-                    // `MyStruct<'_, _, _>`, as opposed to just `_`... This
-                    // will allow us to then do a subtyping relation on all
-                    // of the `remaining_fields` below, per the RFC.
+                if adt.is_struct() {
+                    // Make some fresh substitutions for our ADT type.
                     let fresh_substs = self.fresh_substs_for_item(base_expr.span, adt.did());
-                    let fresh_base_ty = self.tcx.mk_adt(*adt, fresh_substs);
-                    let base_ty = self.check_expr_has_type_or_error(
-                        base_expr,
-                        fresh_base_ty,
-                        |_| {
-                            error_happened = true;
-                        },
-                    );
-                    let base_ty = self.shallow_resolve(base_ty);
-                    if let ty::Adt(base_adt, base_substs) = base_ty.kind() && adt == base_adt {
-                        variant
-                            .fields
-                            .iter()
-                            .map(|f| {
-                                let fru_ty = self.normalize_associated_types_in(
-                                    expr_span,
-                                    self.field_ty(base_expr.span, f, base_substs),
-                                );
-                                let ident = self
-                                    .tcx
-                                    .adjust_ident(f.ident(self.tcx), variant.def_id);
-                                if let Some(_) = remaining_fields.remove(&ident) {
-                                    let target_ty =
-                                        self.field_ty(base_expr.span, f, substs);
-                                    let cause = self.misc(base_expr.span);
-                                    match self
-                                        .at(&cause, self.param_env)
-                                        .sup(target_ty, fru_ty)
-                                    {
-                                        Ok(InferOk { obligations, value: () }) => {
-                                            self.register_predicates(obligations)
-                                        }
-                                        // FIXME: Need better diagnostics for `FieldMisMatch` error
-                                        Err(_) => {
-                                            self.report_mismatched_types(
-                                                &cause,
-                                                target_ty,
-                                                fru_ty,
-                                                FieldMisMatch(variant.name, ident.name),
-                                            )
-                                            .emit();
-                                        }
+                    // We do subtyping on the FRU fields first, so we can
+                    // learn exactly what types we expect the base expr
+                    // needs constrained to be compatible with the struct
+                    // type we expect from the expectation value.
+                    let fru_tys = variant
+                        .fields
+                        .iter()
+                        .map(|f| {
+                            let fru_ty = self.normalize_associated_types_in(
+                                expr_span,
+                                self.field_ty(base_expr.span, f, fresh_substs),
+                            );
+                            let ident = self.tcx.adjust_ident(f.ident(self.tcx), variant.def_id);
+                            if let Some(_) = remaining_fields.remove(&ident) {
+                                let target_ty = self.field_ty(base_expr.span, f, substs);
+                                let cause = self.misc(base_expr.span);
+                                match self.at(&cause, self.param_env).sup(target_ty, fru_ty) {
+                                    Ok(InferOk { obligations, value: () }) => {
+                                        self.register_predicates(obligations)
+                                    }
+                                    Err(_) => {
+                                        // This should never happen, since we're just subtyping the
+                                        // remaining_fields, but it's fine to emit this, I guess.
+                                        self.report_mismatched_types(
+                                            &cause,
+                                            target_ty,
+                                            fru_ty,
+                                            FieldMisMatch(variant.name, ident.name),
+                                        )
+                                        .emit();
                                     }
                                 }
-                                self.resolve_vars_if_possible(fru_ty)
-                            })
-                            .collect()
-                    } else {
-                        if !error_happened && !base_ty.references_error() {
-                            span_bug!(base_expr.span, "expected an error to have been reported in `check_expr_has_type_or_error`");
-                        }
-                        return;
-                    }
+                            }
+                            self.resolve_vars_if_possible(fru_ty)
+                        })
+                        .collect();
+                    // The use of fresh substs that we have subtyped against
+                    // our base ADT type's fields allows us to guide inference
+                    // along so that, e.g.
+                    // ```
+                    // MyStruct<'a, F1, F2, const C: usize> {
+                    //     f: F1,
+                    //     // Other fields that reference `'a`, `F2`, and `C`
+                    // }
+                    //
+                    // let x = MyStruct {
+                    //    f: 1usize,
+                    //    ..other_struct
+                    // };
+                    // ```
+                    // will have the `other_struct` expression constrained to
+                    // `MyStruct<'a, _, F2, C>`, as opposed to just `_`...
+                    // This is important to allow coercions to happen in
+                    // `other_struct` itself. See `coerce-in-base-expr.rs`.
+                    let fresh_base_ty = self.tcx.mk_adt(*adt, fresh_substs);
+                    self.check_expr_has_type_or_error(
+                        base_expr,
+                        self.resolve_vars_if_possible(fresh_base_ty),
+                        |_| {},
+                    );
+                    fru_tys
                 } else {
                     // Check the base_expr, regardless of a bad expected adt_ty, so we can get
                     // type errors on that expression, too.

--- a/library/alloc/src/collections/binary_heap.rs
+++ b/library/alloc/src/collections/binary_heap.rs
@@ -978,7 +978,6 @@ impl<T> BinaryHeap<T> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(try_reserve_2)]
     /// use std::collections::BinaryHeap;
     /// use std::collections::TryReserveError;
     ///
@@ -995,7 +994,7 @@ impl<T> BinaryHeap<T> {
     /// }
     /// # find_max_slow(&[1, 2, 3]).expect("why is the test harness OOMing on 12 bytes?");
     /// ```
-    #[unstable(feature = "try_reserve_2", issue = "91789")]
+    #[stable(feature = "try_reserve_2", since = "1.63.0")]
     pub fn try_reserve_exact(&mut self, additional: usize) -> Result<(), TryReserveError> {
         self.data.try_reserve_exact(additional)
     }
@@ -1014,7 +1013,6 @@ impl<T> BinaryHeap<T> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(try_reserve_2)]
     /// use std::collections::BinaryHeap;
     /// use std::collections::TryReserveError;
     ///
@@ -1031,7 +1029,7 @@ impl<T> BinaryHeap<T> {
     /// }
     /// # find_max_slow(&[1, 2, 3]).expect("why is the test harness OOMing on 12 bytes?");
     /// ```
-    #[unstable(feature = "try_reserve_2", issue = "91789")]
+    #[stable(feature = "try_reserve_2", since = "1.63.0")]
     pub fn try_reserve(&mut self, additional: usize) -> Result<(), TryReserveError> {
         self.data.try_reserve(additional)
     }

--- a/library/std/src/ffi/os_str.rs
+++ b/library/std/src/ffi/os_str.rs
@@ -280,7 +280,6 @@ impl OsString {
     /// # Examples
     ///
     /// ```
-    /// #![feature(try_reserve_2)]
     /// use std::ffi::{OsStr, OsString};
     /// use std::collections::TryReserveError;
     ///
@@ -297,7 +296,7 @@ impl OsString {
     /// }
     /// # process_data("123").expect("why is the test harness OOMing on 3 bytes?");
     /// ```
-    #[unstable(feature = "try_reserve_2", issue = "91789")]
+    #[stable(feature = "try_reserve_2", since = "1.63.0")]
     #[inline]
     pub fn try_reserve(&mut self, additional: usize) -> Result<(), TryReserveError> {
         self.inner.try_reserve(additional)
@@ -348,7 +347,6 @@ impl OsString {
     /// # Examples
     ///
     /// ```
-    /// #![feature(try_reserve_2)]
     /// use std::ffi::{OsStr, OsString};
     /// use std::collections::TryReserveError;
     ///
@@ -365,7 +363,7 @@ impl OsString {
     /// }
     /// # process_data("123").expect("why is the test harness OOMing on 3 bytes?");
     /// ```
-    #[unstable(feature = "try_reserve_2", issue = "91789")]
+    #[stable(feature = "try_reserve_2", since = "1.63.0")]
     #[inline]
     pub fn try_reserve_exact(&mut self, additional: usize) -> Result<(), TryReserveError> {
         self.inner.try_reserve_exact(additional)

--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -1520,7 +1520,7 @@ impl PathBuf {
     /// Invokes [`try_reserve`] on the underlying instance of [`OsString`].
     ///
     /// [`try_reserve`]: OsString::try_reserve
-    #[unstable(feature = "try_reserve_2", issue = "91789")]
+    #[stable(feature = "try_reserve_2", since = "1.63.0")]
     #[inline]
     pub fn try_reserve(&mut self, additional: usize) -> Result<(), TryReserveError> {
         self.inner.try_reserve(additional)
@@ -1538,7 +1538,7 @@ impl PathBuf {
     /// Invokes [`try_reserve_exact`] on the underlying instance of [`OsString`].
     ///
     /// [`try_reserve_exact`]: OsString::try_reserve_exact
-    #[unstable(feature = "try_reserve_2", issue = "91789")]
+    #[stable(feature = "try_reserve_2", since = "1.63.0")]
     #[inline]
     pub fn try_reserve_exact(&mut self, additional: usize) -> Result<(), TryReserveError> {
         self.inner.try_reserve_exact(additional)

--- a/library/std/src/sys/windows/c.rs
+++ b/library/std/src/sys/windows/c.rs
@@ -276,6 +276,7 @@ pub const STATUS_INVALID_PARAMETER: NTSTATUS = 0xc000000d_u32 as _;
 
 pub const STATUS_PENDING: NTSTATUS = 0x103 as _;
 pub const STATUS_END_OF_FILE: NTSTATUS = 0xC0000011_u32 as _;
+pub const STATUS_NOT_IMPLEMENTED: NTSTATUS = 0xC0000002_u32 as _;
 
 // Equivalent to the `NT_SUCCESS` C preprocessor macro.
 // See: https://docs.microsoft.com/en-us/windows-hardware/drivers/kernel/using-ntstatus-values
@@ -1264,7 +1265,7 @@ compat_fn! {
         EaBuffer: *mut c_void,
         EaLength: ULONG
     ) -> NTSTATUS {
-        panic!("`NtCreateFile` not available");
+        STATUS_NOT_IMPLEMENTED
     }
     pub fn NtReadFile(
         FileHandle: BorrowedHandle<'_>,
@@ -1277,7 +1278,7 @@ compat_fn! {
         ByteOffset: Option<&LARGE_INTEGER>,
         Key: Option<&ULONG>
     ) -> NTSTATUS {
-        panic!("`NtReadFile` not available");
+        STATUS_NOT_IMPLEMENTED
     }
     pub fn NtWriteFile(
         FileHandle: BorrowedHandle<'_>,
@@ -1290,12 +1291,12 @@ compat_fn! {
         ByteOffset: Option<&LARGE_INTEGER>,
         Key: Option<&ULONG>
     ) -> NTSTATUS {
-        panic!("`NtWriteFile` not available");
+        STATUS_NOT_IMPLEMENTED
     }
     pub fn RtlNtStatusToDosError(
         Status: NTSTATUS
     ) -> ULONG {
-        panic!("`RtlNtStatusToDosError` not available");
+        Status as ULONG
     }
     pub fn NtCreateKeyedEvent(
         KeyedEventHandle: LPHANDLE,

--- a/src/test/ui/associated-consts/issue-93835.stderr
+++ b/src/test/ui/associated-consts/issue-93835.stderr
@@ -19,11 +19,10 @@ help: you might have meant to write a `struct` literal
    |
 LL ~ fn e() { SomeStruct {
 LL |     p:a<p:p<e=6>>
-LL |
-LL |
-LL |
-LL |
  ...
+LL |
+LL ~ }}
+   |
 help: maybe you meant to write a path separator here
    |
 LL |     p::a<p:p<e=6>>

--- a/src/test/ui/closures/2229_closure_analysis/migrations/auto_traits.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/auto_traits.stderr
@@ -17,11 +17,10 @@ help: add a dummy let to cause `fptr` to be fully captured
    |
 LL ~     thread::spawn(move || { let _ = &fptr; unsafe {
 LL |
-LL |
-LL |
-LL |
-LL |         *fptr.0 = 20;
  ...
+LL |
+LL ~     } });
+   |
 
 error: changes to closure capture in Rust 2021 will affect which traits the closure implements
   --> $DIR/auto_traits.rs:42:19
@@ -40,11 +39,10 @@ help: add a dummy let to cause `fptr` to be fully captured
    |
 LL ~     thread::spawn(move || { let _ = &fptr; unsafe {
 LL |
-LL |
-LL |
-LL |
-LL |
  ...
+LL |
+LL ~     } });
+   |
 
 error: changes to closure capture in Rust 2021 will affect drop order and which traits the closure implements
   --> $DIR/auto_traits.rs:67:13

--- a/src/test/ui/closures/2229_closure_analysis/migrations/multi_diagnostics.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/migrations/multi_diagnostics.stderr
@@ -109,11 +109,10 @@ help: add a dummy let to cause `fptr1`, `fptr2` to be fully captured
    |
 LL ~     thread::spawn(move || { let _ = (&fptr1, &fptr2); unsafe {
 LL |
-LL |
-LL |
-LL |
-LL |
  ...
+LL |
+LL ~     } });
+   |
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/imports/issue-59764.stderr
+++ b/src/test/ui/imports/issue-59764.stderr
@@ -209,8 +209,7 @@ help: a macro with this name exists at the root of the crate
    |
 LL ~         issue_59764::{makro as foobar, 
 LL | 
-LL |             foobaz,
-LL | 
+ ...
 LL | 
 LL ~             foo::{baz}
    |

--- a/src/test/ui/issues/issue-22644.stderr
+++ b/src/test/ui/issues/issue-22644.stderr
@@ -90,11 +90,10 @@ help: try comparing the cast value
    |
 LL ~     println!("{}", (a
 LL | 
-LL | 
-LL |                    as
-LL | 
-LL | 
  ...
+LL | 
+LL ~                    usize)
+   |
 
 error: `<` is interpreted as a start of generic arguments for `usize`, not a shift
   --> $DIR/issue-22644.rs:32:31

--- a/src/test/ui/let-else/let-else-if.stderr
+++ b/src/test/ui/let-else/let-else-if.stderr
@@ -8,8 +8,7 @@ help: try placing this code inside a block
    |
 LL ~     let Some(_) = Some(()) else { if true {
 LL |
-LL |         return;
-LL |     } else {
+ ...
 LL |         return;
 LL ~     } };
    |

--- a/src/test/ui/parser/recover-labeled-non-block-expr.stderr
+++ b/src/test/ui/parser/recover-labeled-non-block-expr.stderr
@@ -54,11 +54,10 @@ help: consider enclosing expression in a block
    |
 LL ~     let _i = 'label: { match x {
 LL |         0 => 42,
-LL |         1 if false => break 'label 17,
-LL |         1 => {
-LL |             if true {
-LL |                 break 'label 13
  ...
+LL |         _ => 1,
+LL ~     } };
+   |
 
 error: expected `while`, `for`, `loop` or `{` after a label
   --> $DIR/recover-labeled-non-block-expr.rs:26:24

--- a/src/test/ui/rfcs/rfc-2528-type-changing-struct-update/coerce-in-base-expr.rs
+++ b/src/test/ui/rfcs/rfc-2528-type-changing-struct-update/coerce-in-base-expr.rs
@@ -1,0 +1,28 @@
+// check-pass
+
+#![feature(type_changing_struct_update)]
+#![allow(incomplete_features)]
+
+use std::any::Any;
+
+struct Foo<A, B: ?Sized, C: ?Sized> {
+    a: A,
+    b: Box<B>,
+    c: Box<C>,
+}
+
+struct B;
+struct C;
+
+fn main() {
+    let y = Foo::<usize, dyn Any, dyn Any> {
+        a: 0,
+        b: Box::new(B),
+        ..Foo {
+            a: 0,
+            b: Box::new(B),
+            // C needs to be told to coerce to `Box<dyn Any>`
+            c: Box::new(C),
+        }
+    };
+}

--- a/src/test/ui/rfcs/rfc-2528-type-changing-struct-update/type-generic-update.rs
+++ b/src/test/ui/rfcs/rfc-2528-type-changing-struct-update/type-generic-update.rs
@@ -50,7 +50,6 @@ fn fail_update() {
     let m3 = Machine::<i32, i32> {
         ..m1
         //~^ ERROR mismatched types [E0308]
-        //~| ERROR mismatched types [E0308]
     };
 }
 

--- a/src/test/ui/rfcs/rfc-2528-type-changing-struct-update/type-generic-update.stderr
+++ b/src/test/ui/rfcs/rfc-2528-type-changing-struct-update/type-generic-update.stderr
@@ -2,29 +2,20 @@ error[E0308]: mismatched types
   --> $DIR/type-generic-update.rs:46:11
    |
 LL |         ..m1
-   |           ^^ field type mismatch: Machine.state
+   |           ^^ expected `i32`, found `f64`
    |
-   = note: expected type `i32`
-              found type `f64`
+   = note: expected struct `Machine<'_, i32, _>`
+              found struct `Machine<'_, f64, _>`
 
 error[E0308]: mismatched types
   --> $DIR/type-generic-update.rs:51:11
    |
 LL |         ..m1
-   |           ^^ field type mismatch: Machine.state
+   |           ^^ expected `i32`, found `f64`
    |
-   = note: expected type `i32`
-              found type `f64`
+   = note: expected struct `Machine<'_, i32, i32>`
+              found struct `Machine<'_, f64, f64>`
 
-error[E0308]: mismatched types
-  --> $DIR/type-generic-update.rs:51:11
-   |
-LL |         ..m1
-   |           ^^ field type mismatch: Machine.message
-   |
-   = note: expected type `i32`
-              found type `f64`
-
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/type/ascription/issue-34255-1.stderr
+++ b/src/test/ui/type/ascription/issue-34255-1.stderr
@@ -8,8 +8,7 @@ help: you might have meant to write a `struct` literal
    |
 LL ~     pub fn new() -> Self { SomeStruct {
 LL |         input_cells: Vec::new()
-LL |
-LL |
+ ...
 LL |
 LL ~     }}
    |

--- a/src/test/ui/unboxed-closures/unboxed-closure-sugar-lifetime-elision.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closure-sugar-lifetime-elision.stderr
@@ -9,11 +9,10 @@ help: consider introducing a named lifetime parameter
    |
 LL ~ fn main<'a>() {
 LL |     eq::< dyn for<'a> Foo<(&'a isize,), Output=&'a isize>,
-LL |           dyn Foo(&isize) -> &isize                                   >();
-LL |     eq::< dyn for<'a> Foo<(&'a isize,), Output=(&'a isize, &'a isize)>,
-LL |           dyn Foo(&isize) -> (&isize, &isize)                           >();
-LL | 
  ...
+LL | 
+LL ~     let _: dyn Foo(&'a isize, &'a usize) -> &'a usize;
+   |
 
 error: aborting due to previous error
 

--- a/src/tools/clippy/clippy_utils/src/sugg.rs
+++ b/src/tools/clippy/clippy_utils/src/sugg.rs
@@ -771,7 +771,7 @@ impl<T: LintContext> DiagnosticExt<T> for rustc_errors::Diagnostic {
             }
         }
 
-        self.span_suggestion(remove_span, msg, String::new(), applicability);
+        self.span_suggestion(remove_span, msg, "", applicability);
     }
 }
 

--- a/src/tools/clippy/tests/ui/bind_instead_of_map_multipart.stderr
+++ b/src/tools/clippy/tests/ui/bind_instead_of_map_multipart.stderr
@@ -56,7 +56,25 @@ LL |             if s == "43" {
 LL ~                 return 43;
 LL |             }
 LL |             s == "42"
+LL |         } {
+LL ~             return 45;
+LL |         }
+LL |         match s.len() {
+LL ~             10 => 2,
+LL |             20 => {
  ...
+LL |                         if foo() {
+LL ~                             return 20;
+LL |                         }
+LL |                         println!("foo");
+LL ~                         3
+LL |                     };
+LL |                 }
+LL ~                 20
+LL |             },
+LL ~             40 => 30,
+LL ~             _ => 1,
+   |
 
 error: using `Option.and_then(|x| Some(y))`, which is more succinctly expressed as `map(|x| y)`
   --> $DIR/bind_instead_of_map_multipart.rs:61:13

--- a/src/tools/clippy/tests/ui/branches_sharing_code/shared_at_top_and_bottom.stderr
+++ b/src/tools/clippy/tests/ui/branches_sharing_code/shared_at_top_and_bottom.stderr
@@ -98,7 +98,8 @@ LL +         id: e_id,
 LL +         name: "Player 1".to_string(),
 LL +         some_data: vec![0x12, 0x34, 0x56, 0x78, 0x90],
 LL +     };
- ...
+LL +     process_data(pack);
+   |
 
 error: all if blocks contain the same code at the start and the end. Here at the start
   --> $DIR/shared_at_top_and_bottom.rs:94:5

--- a/src/tools/clippy/tests/ui/entry.stderr
+++ b/src/tools/clippy/tests/ui/entry.stderr
@@ -28,7 +28,8 @@ LL +             v
 LL +         } else {
 LL +             v2
 LL +         }
- ...
+LL +     });
+   |
 
 error: usage of `contains_key` followed by `insert` on a `HashMap`
   --> $DIR/entry.rs:38:5
@@ -50,7 +51,8 @@ LL +             v
 LL +         } else {
 LL +             v2
 LL +         }
- ...
+LL +     });
+   |
 
 error: usage of `contains_key` followed by `insert` on a `HashMap`
   --> $DIR/entry.rs:47:5
@@ -72,7 +74,9 @@ LL +             e.insert(v);
 LL +         } else {
 LL +             e.insert(v2);
 LL +             return;
- ...
+LL +         }
+LL +     }
+   |
 
 error: usage of `contains_key` followed by `insert` on a `HashMap`
   --> $DIR/entry.rs:57:5
@@ -111,7 +115,11 @@ LL +             1 if true => {
 LL +                 v
 LL +             },
 LL +             _ => {
- ...
+LL +                 v2
+LL +             },
+LL +         }
+LL +     });
+   |
 
 error: usage of `contains_key` followed by `insert` on a `HashMap`
   --> $DIR/entry.rs:75:5
@@ -133,7 +141,9 @@ LL +             0 => foo(),
 LL +             _ => {
 LL +                 e.insert(v2);
 LL +             },
- ...
+LL +         };
+LL +     }
+   |
 
 error: usage of `contains_key` followed by `insert` on a `HashMap`
   --> $DIR/entry.rs:85:5
@@ -155,7 +165,26 @@ LL +         match 0 {
 LL +             0 if false => {
 LL +                 v
 LL +             },
- ...
+LL +             1 => {
+LL +                 foo();
+LL +                 v
+LL +             },
+LL +             2 | 3 => {
+LL +                 for _ in 0..2 {
+LL +                     foo();
+LL +                 }
+LL +                 if true {
+LL +                     v
+LL +                 } else {
+LL +                     v2
+LL +                 }
+LL +             },
+LL +             _ => {
+LL +                 v2
+LL +             },
+LL +         }
+LL +     });
+   |
 
 error: usage of `contains_key` followed by `insert` on a `HashMap`
   --> $DIR/entry.rs:119:5

--- a/src/tools/clippy/tests/ui/entry_with_else.stderr
+++ b/src/tools/clippy/tests/ui/entry_with_else.stderr
@@ -17,7 +17,9 @@ LL +             e.insert(v);
 LL +         }
 LL +         std::collections::hash_map::Entry::Occupied(mut e) => {
 LL +             e.insert(v2);
- ...
+LL +         }
+LL +     }
+   |
 
 error: usage of `contains_key` followed by `insert` on a `HashMap`
   --> $DIR/entry_with_else.rs:22:5
@@ -37,7 +39,9 @@ LL +             e.insert(v);
 LL +         }
 LL +         std::collections::hash_map::Entry::Vacant(e) => {
 LL +             e.insert(v2);
- ...
+LL +         }
+LL +     }
+   |
 
 error: usage of `contains_key` followed by `insert` on a `HashMap`
   --> $DIR/entry_with_else.rs:28:5
@@ -95,7 +99,9 @@ LL +             e.insert(v);
 LL +         }
 LL +         std::collections::hash_map::Entry::Occupied(mut e) => {
 LL +             e.insert(v2);
- ...
+LL +         }
+LL +     }
+   |
 
 error: usage of `contains_key` followed by `insert` on a `HashMap`
   --> $DIR/entry_with_else.rs:46:5
@@ -115,7 +121,10 @@ LL +             if true { Some(e.insert(v)) } else { Some(e.insert(v2)) }
 LL +         }
 LL +         std::collections::hash_map::Entry::Vacant(e) => {
 LL +             e.insert(v);
- ...
+LL +             None
+LL +         }
+LL ~     };
+   |
 
 error: usage of `contains_key` followed by `insert` on a `HashMap`
   --> $DIR/entry_with_else.rs:52:5

--- a/src/tools/clippy/tests/ui/let_unit.stderr
+++ b/src/tools/clippy/tests/ui/let_unit.stderr
@@ -32,7 +32,8 @@ LL +         .map(|i| i * 2)
 LL +         .filter(|i| i % 2 == 0)
 LL +         .map(|_| ())
 LL +         .next()
- ...
+LL +         .unwrap();
+   |
 
 error: this let-binding has unit value
   --> $DIR/let_unit.rs:80:5

--- a/src/tools/clippy/tests/ui/manual_async_fn.stderr
+++ b/src/tools/clippy/tests/ui/manual_async_fn.stderr
@@ -122,7 +122,14 @@ LL +         let a = 42;
 LL +         let b = 21;
 LL +         if a < b {
 LL +             let c = 21;
- ...
+LL +             let d = 42;
+LL +             if c < d {
+LL +                 let _ = 42;
+LL +             }
+LL +         }
+LL +         42
+LL +     }
+   |
 
 error: this function can be simplified using the `async fn` syntax
   --> $DIR/manual_async_fn.rs:92:1

--- a/src/tools/clippy/tests/ui/needless_for_each_unfixable.stderr
+++ b/src/tools/clippy/tests/ui/needless_for_each_unfixable.stderr
@@ -19,7 +19,8 @@ LL +             return;
 LL +         } else {
 LL +             println!("{}", v);
 LL +         }
- ...
+LL +     }
+   |
 help: ...and replace `return` with `continue`
    |
 LL |             continue;

--- a/src/tools/clippy/tests/ui/new_without_default.stderr
+++ b/src/tools/clippy/tests/ui/new_without_default.stderr
@@ -117,7 +117,8 @@ LL +             Self::new()
 LL +         }
 LL +     }
 LL + 
- ...
+LL ~     impl<T> Foo<T> {
+   |
 
 error: aborting due to 7 previous errors
 

--- a/src/tools/clippy/tests/ui/ptr_arg.stderr
+++ b/src/tools/clippy/tests/ui/ptr_arg.stderr
@@ -56,7 +56,8 @@ LL |     let f = e.clone(); // OK
 LL |     let g = x;
 LL ~     let h = g.to_owned();
 LL |     let i = (e).clone();
- ...
+LL ~     x.to_owned()
+   |
 
 error: writing `&String` instead of `&str` involves a new object where a slice will do
   --> $DIR/ptr_arg.rs:57:18

--- a/src/tools/clippy/tests/ui/significant_drop_in_scrutinee.stderr
+++ b/src/tools/clippy/tests/ui/significant_drop_in_scrutinee.stderr
@@ -188,7 +188,9 @@ LL +         _ => mutex2.lock().unwrap(),
 LL +     }
 LL +     .s
 LL +     .len()
- ...
+LL +         > 1;
+LL ~     match value
+   |
 
 error: temporary with significant drop in match scrutinee
   --> $DIR/significant_drop_in_scrutinee.rs:397:11
@@ -211,7 +213,10 @@ LL +     } else {
 LL +         mutex2.lock().unwrap()
 LL +     }
 LL +     .s
- ...
+LL +     .len()
+LL +         > 1;
+LL ~     match value
+   |
 
 error: temporary with significant drop in match scrutinee
   --> $DIR/significant_drop_in_scrutinee.rs:451:11

--- a/src/tools/clippy/tests/ui/unit_arg.stderr
+++ b/src/tools/clippy/tests/ui/unit_arg.stderr
@@ -137,7 +137,13 @@ LL +         foo(1);
 LL +     };
 LL +     {
 LL +         foo(2);
- ...
+LL +         foo(3);
+LL +     };
+LL +     taking_multiple_units(
+LL +         (),
+LL +         (),
+LL ~     );
+   |
 
 error: passing a unit value to a function
   --> $DIR/unit_arg.rs:85:13

--- a/src/tools/clippy/tests/ui/unnecessary_wraps.stderr
+++ b/src/tools/clippy/tests/ui/unnecessary_wraps.stderr
@@ -23,7 +23,8 @@ LL |     if a {
 LL |         Some(-1);
 LL ~         2
 LL |     } else {
- ...
+LL ~         return 1337;
+   |
 
 error: this function's return value is unnecessarily wrapped by `Option`
   --> $DIR/unnecessary_wraps.rs:21:1
@@ -122,7 +123,8 @@ LL |     if a {
 LL |         Some(());
 LL ~         
 LL |     } else {
- ...
+LL ~         return ;
+   |
 
 error: this function's return value is unnecessary
   --> $DIR/unnecessary_wraps.rs:117:1


### PR DESCRIPTION
Successful merges:

 - #95392 (std: Stabilize feature try_reserve_2 )
 - #97798 (Hide irrelevant lines in suggestions to allow for suggestions that are far from each other to be shown)
 - #97844 (Windows: No panic if function not (yet) available)
 - #98013 (Subtype FRU fields first in `type_changing_struct_update`)
 - #98191 (Remove the rest of unnecessary `to_string`)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=95392,97798,97844,98013,98191)
<!-- homu-ignore:end -->