### PR TITLE
Speed up `ptr::replace`

### DIFF
--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -1012,16 +1012,15 @@ const unsafe fn swap_nonoverlapping_simple<T>(x: *mut T, y: *mut T, count: usize
 #[inline]
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_const_unstable(feature = "const_replace", issue = "83164")]
-pub const unsafe fn replace<T>(dst: *mut T, mut src: T) -> T {
+pub const unsafe fn replace<T>(dst: *mut T, src: T) -> T {
     // SAFETY: the caller must guarantee that `dst` is valid to be
     // cast to a mutable reference (valid for writes, aligned, initialized),
     // and cannot overlap `src` since `dst` must point to a distinct
     // allocated object.
     unsafe {
         assert_unsafe_precondition!(is_aligned_and_not_null(dst));
-        mem::swap(&mut *dst, &mut src); // cannot overlap
+        mem::replace(&mut *dst, src)
     }
-    src
 }
 
 /// Reads the value from `src` without moving it. This leaves the

--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -1013,10 +1013,9 @@ const unsafe fn swap_nonoverlapping_simple<T>(x: *mut T, y: *mut T, count: usize
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_const_unstable(feature = "const_replace", issue = "83164")]
 pub const unsafe fn replace<T>(dst: *mut T, src: T) -> T {
-    // SAFETY: the caller must guarantee that `dst` is valid to be
-    // cast to a mutable reference (valid for writes, aligned, initialized),
-    // and cannot overlap `src` since `dst` must point to a distinct
-    // allocated object.
+    // SAFETY: The caller must guarantee that `dst` is valid to be
+    // cast to a mutable reference (valid for writes, aligned, initialized).
+    // `dst` cannot overlap `src` since `src` is a freshly stack-allocated local variable.
     unsafe {
         assert_unsafe_precondition!(is_aligned_and_not_null(dst));
         mem::replace(&mut *dst, src)


### PR DESCRIPTION
I noticed, that `ptr::replace` and `mem::replace` are implemented differently, even though they should probably be the same.

Looking at the [goldbolt output](https://godbolt.org/z/15b5GY883), it seems that `mem::replace` does only 2 `memcpy`s and `ptr::replace` does 2 `memcpy`s with an inlined copy in between.

I ran some benchmarks on my machine, in which `mem::replace` was more than 2x faster than `ptr::replace`.
<details>
<summary>Benchmark</summary>

### Code
```rust
#![feature(test)]
#![cfg(test)]

extern crate test;

use rand::Rng;
use std::{mem, ptr};
use test::Bencher;

#[bench]
fn mem_replace(b: &mut Bencher) {
    let mut rng = rand::thread_rng();

    let mut dst = [0u8; 256];
    rng.fill(&mut dst);

    let mut src = [0u8; 256];
    rng.fill(&mut src);

    b.iter(|| {
        let mut dst_copy = dst;
        let old = mem::replace(&mut dst_copy, src);
        (old, dst_copy)
    });
}

#[bench]
fn ptr_replace(b: &mut Bencher) {
    let mut rng = rand::thread_rng();

    let mut dst = [0u8; 256];
    rng.fill(&mut dst);

    let mut src = [0u8; 256];
    rng.fill(&mut src);

    b.iter(|| {
        let mut dst_copy = dst;
        let old = unsafe { ptr::replace(&mut dst_copy, src) };
        (old, dst_copy)
    });
}
```

### Output
```
test mem_replace ... bench:          11 ns/iter (+/- 0)
test ptr_replace ... bench:          25 ns/iter (+/- 0)
```
</details>

In this PR i have replaced the implementation of `ptr::replace` to call `mem::replace` instead of `mem::swap`.