### PR TITLE
Bump to clap 3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3385,7 +3385,7 @@ dependencies = [
 name = "rustbook"
 version = "0.1.0"
 dependencies = [
- "clap 2.34.0",
+ "clap 3.1.1",
  "env_logger 0.7.1",
  "mdbook",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -307,7 +307,7 @@ dependencies = [
  "cargo-test-macro",
  "cargo-test-support",
  "cargo-util",
- "clap 3.2.5",
+ "clap",
  "crates-io",
  "crossbeam-utils",
  "curl",
@@ -574,21 +574,6 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
-dependencies = [
- "ansi_term",
- "atty",
- "bitflags",
- "strsim 0.8.0",
- "textwrap 0.11.0",
- "unicode-width",
- "vec_map",
-]
-
-[[package]]
-name = "clap"
 version = "3.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d53da17d37dba964b9b3ecb5c5a1f193a2762c700e6829201e645b9381c99dc7"
@@ -599,9 +584,9 @@ dependencies = [
  "clap_lex",
  "indexmap",
  "once_cell",
- "strsim 0.10.0",
+ "strsim",
  "termcolor",
- "textwrap 0.15.0",
+ "textwrap",
 ]
 
 [[package]]
@@ -610,7 +595,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df6f3613c0a3cddfd78b41b10203eb322cb29b600cbdf808a7d3db95691b8e25"
 dependencies = [
- "clap 3.2.5",
+ "clap",
 ]
 
 [[package]]
@@ -668,7 +653,7 @@ name = "clippy_dev"
 version = "0.0.1"
 dependencies = [
  "aho-corasick",
- "clap 3.2.5",
+ "clap",
  "indoc",
  "itertools",
  "opener",
@@ -1861,7 +1846,7 @@ name = "installer"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "clap 3.1.1",
+ "clap",
  "flate2",
  "lazy_static",
  "num_cpus",
@@ -2309,7 +2294,7 @@ dependencies = [
  "ammonia",
  "anyhow",
  "chrono",
- "clap 3.2.5",
+ "clap",
  "clap_complete",
  "elasticlunr-rs",
  "env_logger 0.7.1",
@@ -3384,7 +3369,7 @@ dependencies = [
 name = "rustbook"
 version = "0.1.0"
 dependencies = [
- "clap 3.1.1",
+ "clap",
  "env_logger 0.7.1",
  "mdbook",
 ]
@@ -3472,7 +3457,7 @@ version = "1.0.0"
 dependencies = [
  "bstr",
  "byteorder",
- "clap 3.2.5",
+ "clap",
  "crossbeam-utils",
  "libc",
  "libz-sys",
@@ -4661,7 +4646,7 @@ dependencies = [
  "anyhow",
  "bytecount",
  "cargo_metadata",
- "clap 3.2.5",
+ "clap",
  "derive-new",
  "diff",
  "dirs",
@@ -5054,12 +5039,6 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
@@ -5196,15 +5175,6 @@ dependencies = [
  "libc",
  "num_cpus",
  "term",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
 ]
 
 [[package]]
@@ -5726,12 +5696,6 @@ name = "vcpkg"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6454029bf181f092ad1b853286f23e2c507d8e8194d01d92da4a55c274a5508c"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "vergen"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -585,7 +585,6 @@ dependencies = [
  "textwrap 0.11.0",
  "unicode-width",
  "vec_map",
- "yaml-rust 0.3.5",
 ]
 
 [[package]]
@@ -1242,7 +1241,7 @@ name = "expand-yaml-anchors"
 version = "0.1.0"
 dependencies = [
  "yaml-merge-keys",
- "yaml-rust 0.4.4",
+ "yaml-rust",
 ]
 
 [[package]]
@@ -1862,7 +1861,7 @@ name = "installer"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "clap 2.34.0",
+ "clap 3.1.1",
  "flate2",
  "lazy_static",
  "num_cpus",
@@ -5892,14 +5891,8 @@ checksum = "fd236a7dc9bb598f349fe4a8754f49181fee50284daa15cd1ba652d722280004"
 dependencies = [
  "lazy_static",
  "thiserror",
- "yaml-rust 0.4.4",
+ "yaml-rust",
 ]
-
-[[package]]
-name = "yaml-rust"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e66366e18dc58b46801afbf2ca7661a9f59cc8c5962c29892b6039b4f86fa992"
 
 [[package]]
 name = "yaml-rust"

--- a/src/bootstrap/tool.rs
+++ b/src/bootstrap/tool.rs
@@ -367,7 +367,7 @@ bootstrap_tool!(
     Compiletest, "src/tools/compiletest", "compiletest", is_unstable_tool = true;
     BuildManifest, "src/tools/build-manifest", "build-manifest";
     RemoteTestClient, "src/tools/remote-test-client", "remote-test-client";
-    RustInstaller, "src/tools/rust-installer", "fabricate", is_external_tool = true;
+    RustInstaller, "src/tools/rust-installer", "rust-installer", is_external_tool = true;
     RustdocTheme, "src/tools/rustdoc-themes", "rustdoc-themes";
     ExpandYamlAnchors, "src/tools/expand-yaml-anchors", "expand-yaml-anchors";
     LintDocs, "src/tools/lint-docs", "lint-docs";

--- a/src/tools/rustbook/Cargo.toml
+++ b/src/tools/rustbook/Cargo.toml
@@ -5,7 +5,7 @@ license = "MIT OR Apache-2.0"
 edition = "2021"
 
 [dependencies]
-clap = "2.25.0"
+clap = "3.1.1"
 env_logger = "0.7.1"
 
 [dependencies.mdbook]

--- a/src/tools/rustbook/src/main.rs
+++ b/src/tools/rustbook/src/main.rs
@@ -12,15 +12,17 @@ fn main() {
     let crate_version = format!("v{}", crate_version!());
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("warn")).init();
     let d_arg = arg!(-d --"dest-dir" <DEST_DIR>
-"The output directory for your book{n}(Defaults to ./book when omitted)");
+"The output directory for your book\n(Defaults to ./book when omitted)")
+    .required(false);
     let dir_arg = arg!([dir]
-"A directory for your book{n}(Defaults to Current Directory when omitted)");
+"A directory for your book\n(Defaults to Current Directory when omitted)");
 
     let matches = Command::new("rustbook")
         .about("Build a book with mdBook")
         .author("Steve Klabnik <steve@steveklabnik.com>")
         .version(&*crate_version)
         .subcommand_required(true)
+        .arg_required_else_help(true)
         .subcommand(
             Command::new("build")
                 .about("Build the book from the markdown files")

--- a/src/tools/rustbook/src/main.rs
+++ b/src/tools/rustbook/src/main.rs
@@ -3,54 +3,55 @@ use clap::crate_version;
 use std::env;
 use std::path::{Path, PathBuf};
 
-use clap::{App, AppSettings, ArgMatches, SubCommand};
+use clap::{arg, ArgMatches, Command};
 
 use mdbook::errors::Result as Result3;
 use mdbook::MDBook;
 
 fn main() {
+    let crate_version = format!("v{}", crate_version!());
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("warn")).init();
-    let d_message = "-d, --dest-dir=[dest-dir]
-'The output directory for your book{n}(Defaults to ./book when omitted)'";
-    let dir_message = "[dir]
-'A directory for your book{n}(Defaults to Current Directory when omitted)'";
+    let d_arg = arg!(-d --"dest-dir" <DEST_DIR>
+"The output directory for your book{n}(Defaults to ./book when omitted)");
+    let dir_arg = arg!([dir]
+"A directory for your book{n}(Defaults to Current Directory when omitted)");
 
-    let matches = App::new("rustbook")
+    let matches = Command::new("rustbook")
         .about("Build a book with mdBook")
         .author("Steve Klabnik <steve@steveklabnik.com>")
-        .version(&*format!("v{}", crate_version!()))
-        .setting(AppSettings::SubcommandRequired)
+        .version(&*crate_version)
+        .subcommand_required(true)
         .subcommand(
-            SubCommand::with_name("build")
+            Command::new("build")
                 .about("Build the book from the markdown files")
-                .arg_from_usage(d_message)
-                .arg_from_usage(dir_message),
+                .arg(d_arg)
+                .arg(&dir_arg),
         )
         .subcommand(
-            SubCommand::with_name("test")
+            Command::new("test")
                 .about("Tests that a book's Rust code samples compile")
-                .arg_from_usage(dir_message),
+                .arg(dir_arg),
         )
         .get_matches();
 
     // Check which subcomamnd the user ran...
     match matches.subcommand() {
-        ("build", Some(sub_matches)) => {
+        Some(("build", sub_matches)) => {
             if let Err(e) = build(sub_matches) {
                 handle_error(e);
             }
         }
-        ("test", Some(sub_matches)) => {
+        Some(("test", sub_matches)) => {
             if let Err(e) = test(sub_matches) {
                 handle_error(e);
             }
         }
-        (_, _) => unreachable!(),
+        _ => unreachable!(),
     };
 }
 
 // Build command implementation
-pub fn build(args: &ArgMatches<'_>) -> Result3<()> {
+pub fn build(args: &ArgMatches) -> Result3<()> {
     let book_dir = get_book_dir(args);
     let mut book = load_book(&book_dir)?;
 
@@ -66,13 +67,13 @@ pub fn build(args: &ArgMatches<'_>) -> Result3<()> {
     Ok(())
 }
 
-fn test(args: &ArgMatches<'_>) -> Result3<()> {
+fn test(args: &ArgMatches) -> Result3<()> {
     let book_dir = get_book_dir(args);
     let mut book = load_book(&book_dir)?;
     book.test(vec![])
 }
 
-fn get_book_dir(args: &ArgMatches<'_>) -> PathBuf {
+fn get_book_dir(args: &ArgMatches) -> PathBuf {
     if let Some(dir) = args.value_of("dir") {
         // Check if path is relative from current dir, or absolute...
         let p = Path::new(dir);


### PR DESCRIPTION
This PR, along with several others, will entirely remove the Clap 2 dependency from the rust source tree.

* https://github.com/rust-lang/rust-installer/pull/114
* https://github.com/rust-lang/rls/pull/1779

This PR includes a submodule bump for rust-installer, which includes the following PRs:

* https://github.com/rust-lang/rust-installer/pull/114
* https://github.com/rust-lang/rust-installer/pull/113
* https://github.com/rust-lang/rust-installer/pull/115