### PR TITLE
proc_macro/bridge: remove client->server `&HandleCounters` passing.

### DIFF
--- a/library/proc_macro/src/bridge/server.rs
+++ b/library/proc_macro/src/bridge/server.rs
@@ -257,14 +257,13 @@ fn run_server<
     O: for<'a, 's> DecodeMut<'a, 's, HandleStore<MarkedTypes<S>>>,
 >(
     strategy: &impl ExecutionStrategy,
-    handle_counters: &'static client::HandleCounters,
     server: S,
     input: I,
     run_client: extern "C" fn(Bridge<'_>) -> Buffer,
     force_show_panics: bool,
 ) -> Result<O, PanicMessage> {
     let mut dispatcher =
-        Dispatcher { handle_store: HandleStore::new(handle_counters), server: MarkedTypes(server) };
+        Dispatcher { handle_store: HandleStore::new(), server: MarkedTypes(server) };
 
     let mut buf = Buffer::new();
     input.encode(&mut buf, &mut dispatcher.handle_store);
@@ -282,10 +281,9 @@ impl client::Client<crate::TokenStream, crate::TokenStream> {
         input: S::TokenStream,
         force_show_panics: bool,
     ) -> Result<S::TokenStream, PanicMessage> {
-        let client::Client { get_handle_counters, run, _marker } = *self;
+        let client::Client { run, _marker } = *self;
         run_server(
             strategy,
-            get_handle_counters(),
             server,
             <MarkedTypes<S> as Types>::TokenStream::mark(input),
             run,
@@ -304,10 +302,9 @@ impl client::Client<(crate::TokenStream, crate::TokenStream), crate::TokenStream
         input2: S::TokenStream,
         force_show_panics: bool,
     ) -> Result<S::TokenStream, PanicMessage> {
-        let client::Client { get_handle_counters, run, _marker } = *self;
+        let client::Client { run, _marker } = *self;
         run_server(
             strategy,
-            get_handle_counters(),
             server,
             (
                 <MarkedTypes<S> as Types>::TokenStream::mark(input),


### PR DESCRIPTION
Just like #97461, this was inspired by @nnethercote's efforts in this area (see https://github.com/rust-lang/rust/pull/97004#issuecomment-1139273301).
The purpose of the counters was never to protect from server-side misuse, only client-side misuse (e.g. a proc macro storing a `proc_macro` public API type in TLS), so the FIXME comment should suffice for now.

As this PR removes `get_handle_counters` (the only non-ZST `Client` field other than `run`, since #97461), it will allow a `#[repr(transparent)]` `Client` that only newtypes the `run` C ABI entry-point `fn` pointer <sub>(and in the context of e.g. wasm isolation, that's *all* you want, since you can reason about it from outside the wasm VM, as just a 32-bit "function table index", that you can pass to the wasm VM to call that function)</sub>.

However, I haven't changed any `#[repr]` attributes in this PR to avoid unforseen perf interactions.

cc @mystor @bjorn3 