### PR TITLE
Make debug_triple depend on target json file content rather than file path

### DIFF
--- a/src/librustdoc/doctest.rs
+++ b/src/librustdoc/doctest.rs
@@ -365,8 +365,8 @@ fn run_test(
     }
     compiler.arg("--target").arg(match target {
         TargetTriple::TargetTriple(s) => s,
-        TargetTriple::TargetPath(path) => {
-            path.to_str().expect("target path must be valid unicode").to_string()
+        TargetTriple::TargetJson { path_for_rustdoc, .. } => {
+            path_for_rustdoc.to_str().expect("target path must be valid unicode").to_string()
         }
     });
     if let ErrorOutputType::HumanReadable(kind) = rustdoc_options.error_format {


### PR DESCRIPTION
This ensures that changes to target json files will force a recompilation. And more importantly that moving the files doesn't force a recompilation.

This should fix https://github.com/Rust-for-Linux/linux/issues/792 (cc @ojeda)