### PR TITLE
Make some lints incremental.

### DIFF
--- a/compiler/rustc_lint/src/builtin.rs
+++ b/compiler/rustc_lint/src/builtin.rs
@@ -1610,13 +1610,11 @@ impl<'tcx> LateLintPass<'tcx> for UnusedBrokenConst {
             hir::ItemKind::Const(_, body_id) => {
                 let def_id = cx.tcx.hir().body_owner_def_id(body_id).to_def_id();
                 // trigger the query once for all constants since that will already report the errors
-                // FIXME: Use ensure here
-                let _ = cx.tcx.const_eval_poly(def_id);
+                cx.tcx.ensure().const_eval_poly(def_id);
             }
             hir::ItemKind::Static(_, _, body_id) => {
                 let def_id = cx.tcx.hir().body_owner_def_id(body_id).to_def_id();
-                // FIXME: Use ensure here
-                let _ = cx.tcx.eval_static_initializer(def_id);
+                cx.tcx.ensure().eval_static_initializer(def_id);
             }
             _ => {}
         }

--- a/compiler/rustc_lint/src/lib.rs
+++ b/compiler/rustc_lint/src/lib.rs
@@ -159,28 +159,16 @@ macro_rules! late_lint_passes {
         $macro!(
             $args,
             [
-                // FIXME: Look into regression when this is used as a module lint
-                // May Depend on constants elsewhere
-                UnusedBrokenConst: UnusedBrokenConst,
-                // Needs to run after UnusedAttributes as it marks all `feature` attributes as used.
-                UnstableFeatures: UnstableFeatures,
                 // Tracks state across modules
                 UnnameableTestItems: UnnameableTestItems::new(),
                 // Tracks attributes of parents
                 MissingDoc: MissingDoc::new(),
-                // Depends on access levels
+                // Builds a global list of all impls of `Debug`.
                 // FIXME: Turn the computation of types which implement Debug into a query
                 // and change this to a module lint pass
                 MissingDebugImplementations: MissingDebugImplementations::default(),
-                ArrayIntoIter: ArrayIntoIter::default(),
+                // Keeps a global list of foreign declarations.
                 ClashingExternDeclarations: ClashingExternDeclarations::new(),
-                DropTraitConstraints: DropTraitConstraints,
-                TemporaryCStringAsPtr: TemporaryCStringAsPtr,
-                NonPanicFmt: NonPanicFmt,
-                NoopMethodCall: NoopMethodCall,
-                EnumIntrinsicsNonEnums: EnumIntrinsicsNonEnums,
-                InvalidAtomicOrdering: InvalidAtomicOrdering,
-                NamedAsmLabels: NamedAsmLabels,
             ]
         );
     };
@@ -216,6 +204,17 @@ macro_rules! late_lint_mod_passes {
                 ExplicitOutlivesRequirements: ExplicitOutlivesRequirements,
                 InvalidValue: InvalidValue,
                 DerefNullPtr: DerefNullPtr,
+                // May Depend on constants elsewhere
+                UnusedBrokenConst: UnusedBrokenConst,
+                UnstableFeatures: UnstableFeatures,
+                ArrayIntoIter: ArrayIntoIter::default(),
+                DropTraitConstraints: DropTraitConstraints,
+                TemporaryCStringAsPtr: TemporaryCStringAsPtr,
+                NonPanicFmt: NonPanicFmt,
+                NoopMethodCall: NoopMethodCall,
+                EnumIntrinsicsNonEnums: EnumIntrinsicsNonEnums,
+                InvalidAtomicOrdering: InvalidAtomicOrdering,
+                NamedAsmLabels: NamedAsmLabels,
             ]
         );
     };

--- a/src/test/ui/consts/const-eval/validate_uninhabited_zsts.32bit.stderr
+++ b/src/test/ui/consts/const-eval/validate_uninhabited_zsts.32bit.stderr
@@ -1,3 +1,15 @@
+warning: the type `!` does not permit zero-initialization
+  --> $DIR/validate_uninhabited_zsts.rs:4:14
+   |
+LL |     unsafe { std::mem::transmute(()) }
+   |              ^^^^^^^^^^^^^^^^^^^^^^^
+   |              |
+   |              this code causes undefined behavior when executed
+   |              help: use `MaybeUninit<T>` instead, and only call `assume_init` after initialization is done
+   |
+   = note: `#[warn(invalid_value)]` on by default
+   = note: the `!` type has no valid value
+
 error[E0080]: evaluation of constant value failed
   --> $DIR/validate_uninhabited_zsts.rs:4:14
    |
@@ -18,18 +30,6 @@ LL | const BAR: [empty::Empty; 3] = [unsafe { std::mem::transmute(()) }; 3];
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 0, align: 1) {}
-
-warning: the type `!` does not permit zero-initialization
-  --> $DIR/validate_uninhabited_zsts.rs:4:14
-   |
-LL |     unsafe { std::mem::transmute(()) }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^
-   |              |
-   |              this code causes undefined behavior when executed
-   |              help: use `MaybeUninit<T>` instead, and only call `assume_init` after initialization is done
-   |
-   = note: `#[warn(invalid_value)]` on by default
-   = note: the `!` type has no valid value
 
 warning: the type `empty::Empty` does not permit zero-initialization
   --> $DIR/validate_uninhabited_zsts.rs:23:42

--- a/src/test/ui/consts/const-eval/validate_uninhabited_zsts.64bit.stderr
+++ b/src/test/ui/consts/const-eval/validate_uninhabited_zsts.64bit.stderr
@@ -1,3 +1,15 @@
+warning: the type `!` does not permit zero-initialization
+  --> $DIR/validate_uninhabited_zsts.rs:4:14
+   |
+LL |     unsafe { std::mem::transmute(()) }
+   |              ^^^^^^^^^^^^^^^^^^^^^^^
+   |              |
+   |              this code causes undefined behavior when executed
+   |              help: use `MaybeUninit<T>` instead, and only call `assume_init` after initialization is done
+   |
+   = note: `#[warn(invalid_value)]` on by default
+   = note: the `!` type has no valid value
+
 error[E0080]: evaluation of constant value failed
   --> $DIR/validate_uninhabited_zsts.rs:4:14
    |
@@ -18,18 +30,6 @@ LL | const BAR: [empty::Empty; 3] = [unsafe { std::mem::transmute(()) }; 3];
    |
    = note: The rules on what exactly is undefined behavior aren't clear, so this check might be overzealous. Please open an issue on the rustc repository if you believe it should not be considered undefined behavior.
    = note: the raw bytes of the constant (size: 0, align: 1) {}
-
-warning: the type `!` does not permit zero-initialization
-  --> $DIR/validate_uninhabited_zsts.rs:4:14
-   |
-LL |     unsafe { std::mem::transmute(()) }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^
-   |              |
-   |              this code causes undefined behavior when executed
-   |              help: use `MaybeUninit<T>` instead, and only call `assume_init` after initialization is done
-   |
-   = note: `#[warn(invalid_value)]` on by default
-   = note: the `!` type has no valid value
 
 warning: the type `empty::Empty` does not permit zero-initialization
   --> $DIR/validate_uninhabited_zsts.rs:23:42

--- a/src/test/ui/consts/recursive-zst-static.default.stderr
+++ b/src/test/ui/consts/recursive-zst-static.default.stderr
@@ -10,7 +10,15 @@ note: ...which requires const-evaluating + checking `FOO`...
 LL | static FOO: () = FOO;
    |                  ^^^
    = note: ...which again requires const-evaluating + checking `FOO`, completing the cycle
-   = note: cycle used when running analysis passes on this crate
+note: cycle used when linting top-level module
+  --> $DIR/recursive-zst-static.rs:10:1
+   |
+LL | / static FOO: () = FOO;
+LL | |
+LL | | fn main() {
+LL | |     FOO
+LL | | }
+   | |_^
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/recursive-zst-static.unleash.stderr
+++ b/src/test/ui/consts/recursive-zst-static.unleash.stderr
@@ -10,7 +10,15 @@ note: ...which requires const-evaluating + checking `FOO`...
 LL | static FOO: () = FOO;
    |                  ^^^
    = note: ...which again requires const-evaluating + checking `FOO`, completing the cycle
-   = note: cycle used when running analysis passes on this crate
+note: cycle used when linting top-level module
+  --> $DIR/recursive-zst-static.rs:10:1
+   |
+LL | / static FOO: () = FOO;
+LL | |
+LL | | fn main() {
+LL | |     FOO
+LL | | }
+   | |_^
 
 error: aborting due to previous error
 

--- a/src/test/ui/consts/write-to-static-mut-in-static.stderr
+++ b/src/test/ui/consts/write-to-static-mut-in-static.stderr
@@ -16,7 +16,17 @@ note: ...which requires const-evaluating + checking `C`...
 LL | pub static mut C: u32 = unsafe { C = 1; 0 };
    |                                  ^^^^^
    = note: ...which again requires const-evaluating + checking `C`, completing the cycle
-   = note: cycle used when running analysis passes on this crate
+note: cycle used when linting top-level module
+  --> $DIR/write-to-static-mut-in-static.rs:1:1
+   |
+LL | / pub static mut A: u32 = 0;
+LL | | pub static mut B: () = unsafe { A = 1; };
+LL | |
+LL | |
+...  |
+LL | |
+LL | | fn main() {}
+   | |____________^
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/recursion/recursive-static-definition.stderr
+++ b/src/test/ui/recursion/recursive-static-definition.stderr
@@ -10,7 +10,14 @@ note: ...which requires const-evaluating + checking `FOO`...
 LL | pub static FOO: u32 = FOO;
    |                       ^^^
    = note: ...which again requires const-evaluating + checking `FOO`, completing the cycle
-   = note: cycle used when running analysis passes on this crate
+note: cycle used when linting top-level module
+  --> $DIR/recursive-static-definition.rs:1:1
+   |
+LL | / pub static FOO: u32 = FOO;
+LL | |
+LL | |
+LL | | fn main() {}
+   | |____________^
 
 error: aborting due to previous error
 

--- a/src/test/ui/statics/uninhabited-static.stderr
+++ b/src/test/ui/statics/uninhabited-static.stderr
@@ -49,12 +49,6 @@ error[E0080]: could not evaluate static initializer
 LL | static VOID2: Void = unsafe { std::mem::transmute(()) };
    |                               ^^^^^^^^^^^^^^^^^^^^^^^ transmuting to uninhabited type
 
-error[E0080]: could not evaluate static initializer
-  --> $DIR/uninhabited-static.rs:16:32
-   |
-LL | static NEVER2: Void = unsafe { std::mem::transmute(()) };
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^ transmuting to uninhabited type
-
 warning: the type `Void` does not permit zero-initialization
   --> $DIR/uninhabited-static.rs:12:31
    |
@@ -66,6 +60,12 @@ LL | static VOID2: Void = unsafe { std::mem::transmute(()) };
    |
    = note: `#[warn(invalid_value)]` on by default
    = note: enums with no variants have no valid value
+
+error[E0080]: could not evaluate static initializer
+  --> $DIR/uninhabited-static.rs:16:32
+   |
+LL | static NEVER2: Void = unsafe { std::mem::transmute(()) };
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^ transmuting to uninhabited type
 
 warning: the type `Void` does not permit zero-initialization
   --> $DIR/uninhabited-static.rs:16:32


### PR DESCRIPTION
Those lints do not track a state, so don't need to be performed for the full crate at once.
