### PR TITLE
Write help for unexpected `=>`. Fixes #98128

### DIFF
--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -606,6 +606,8 @@ impl<'a> Parser<'a> {
             && expected.iter().any(|tok| matches!(tok, TokenType::Token(TokenKind::Gt)))
         {
             err.span_label(self.prev_token.span, "maybe try to close unmatched angle bracket");
+        } else if self.token == token::FatArrow {
+            err.help("closures are written `|a, b| a + b` and greater-than-or-equal is `>=`.");
         }
 
         let sp = if self.token == token::Eof {

--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -606,7 +606,9 @@ impl<'a> Parser<'a> {
             && expected.iter().any(|tok| matches!(tok, TokenType::Token(TokenKind::Gt)))
         {
             err.span_label(self.prev_token.span, "maybe try to close unmatched angle bracket");
-        } else if self.token == token::FatArrow {
+        } else if self.token == token::FatArrow
+            && expected.iter().any(|tok| matches!(tok, TokenType::Operator))
+        {
             err.help("closures are written `|a, b| a + b` and greater-than-or-equal is `>=`.");
         }
 

--- a/src/test/ui/asm/x86_64/parse-error.stderr
+++ b/src/test/ui/asm/x86_64/parse-error.stderr
@@ -57,6 +57,8 @@ error: expected one of `!`, `,`, `.`, `::`, `?`, `{`, or an operator, found `=>`
    |
 LL |         asm!("{}", in(reg) foo => bar);
    |                                ^^ expected one of 7 possible tokens
+   |
+   = help: closures are written `|a, b| a + b` and greater-than-or-equal is `>=`.
 
 error: expected a path for argument to `sym`
   --> $DIR/parse-error.rs:31:24

--- a/src/test/ui/missing/missing-comma-in-match.stderr
+++ b/src/test/ui/missing/missing-comma-in-match.stderr
@@ -5,6 +5,8 @@ LL |         &None => 1
    |                   - help: missing a comma here to end this `match` arm
 LL |         &Some(2) => { 3 }
    |                  ^^ expected one of `,`, `.`, `?`, `}`, or an operator
+   |
+   = help: closures are written `|a, b| a + b` and greater-than-or-equal is `>=`.
 
 error: aborting due to previous error
 

--- a/src/test/ui/unexpected-fat-arrow.rs
+++ b/src/test/ui/unexpected-fat-arrow.rs
@@ -1,0 +1,5 @@
+fn main() {
+    // JavaScript-style arrow function.
+    let _lambda = (a, b) => { println!(); a + b };
+//~^ ERROR expected one of `.`, `;`, `?`, `else`, or an operator, found `=>`
+}

--- a/src/test/ui/unexpected-fat-arrow.stderr
+++ b/src/test/ui/unexpected-fat-arrow.stderr
@@ -1,0 +1,10 @@
+error: expected one of `.`, `;`, `?`, `else`, or an operator, found `=>`
+  --> $DIR/unexpected-fat-arrow.rs:3:26
+   |
+LL |     let _lambda = (a, b) => { println!(); a + b };
+   |                          ^^ expected one of `.`, `;`, `?`, `else`, or an operator
+   |
+   = help: closures are written `|a, b| a + b` and greater-than-or-equal is `>=`.
+
+error: aborting due to previous error
+


### PR DESCRIPTION
#98128 discusses what to do with the typo `=>` vs `>=`, or efforts to write a JavaScript-syntax closure in Rust (`(a, b) => (a + b)`). Both manifest as an unexpected `token::FatArrow` so the error message describes both. I think that only those who are very new to programming would actually need to be told how to spell `>=`, but I could understand someone misreading the existing error message and not realising what they'd typed. The opposite of this is:
```
(a, b) =< (a + b);
                 ^ expected one of `>` or `as`
```
which I think would be significantly more complex to detect because `=<` isn't a token, and less beneficial as I'm not aware of a language which actually uses that syntax for something.