### PR TITLE
Fix whitespace handling after where clause

### DIFF
--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -146,6 +146,10 @@ impl Buffer {
     pub(crate) fn reserve(&mut self, additional: usize) {
         self.buffer.reserve(additional)
     }
+
+    pub(crate) fn len(&self) -> usize {
+        self.buffer.len()
+    }
 }
 
 fn comma_sep<T: fmt::Display>(

--- a/src/test/rustdoc/whitespace-after-where-clause.enum.html
+++ b/src/test/rustdoc/whitespace-after-where-clause.enum.html
@@ -1,0 +1,4 @@
+<div class="docblock item-decl"><pre class="rust enum"><code>pub enum Cow&lt;'a, B:&#160;?<a class="trait" href="{{channel}}/core/marker/trait.Sized.html" title="trait core::marker::Sized">Sized</a> + 'a&gt; <span class="where fmt-newline">where<br />&#160;&#160;&#160;&#160;B: <a class="trait" href="trait.ToOwned.html" title="trait foo::ToOwned">ToOwned</a>&lt;dyn <a class="trait" href="{{channel}}/core/clone/trait.Clone.html" title="trait core::clone::Clone">Clone</a>&gt;,&#160;</span>{
+    Borrowed(<a class="primitive" href="{{channel}}/std/primitive.reference.html">&amp;'a </a>B),
+    Whatever(<a class="primitive" href="{{channel}}/std/primitive.u32.html">u32</a>),
+}</code></pre></div>

--- a/src/test/rustdoc/whitespace-after-where-clause.enum2.html
+++ b/src/test/rustdoc/whitespace-after-where-clause.enum2.html
@@ -1,0 +1,4 @@
+<div class="docblock item-decl"><pre class="rust enum"><code>pub enum Cow2&lt;'a, B:&#160;?<a class="trait" href="{{channel}}/core/marker/trait.Sized.html" title="trait core::marker::Sized">Sized</a> + <a class="trait" href="trait.ToOwned.html" title="trait foo::ToOwned">ToOwned</a>&lt;dyn <a class="trait" href="{{channel}}/core/clone/trait.Clone.html" title="trait core::clone::Clone">Clone</a>&gt; + 'a&gt; {
+    Borrowed(<a class="primitive" href="{{channel}}/std/primitive.reference.html">&amp;'a </a>B),
+    Whatever(<a class="primitive" href="{{channel}}/std/primitive.u32.html">u32</a>),
+}</code></pre></div>

--- a/src/test/rustdoc/whitespace-after-where-clause.rs
+++ b/src/test/rustdoc/whitespace-after-where-clause.rs
@@ -1,0 +1,77 @@
+// This test ensures there is no whitespace before the first brace of
+// trait, enum, struct and union items when they have a where clause.
+
+#![crate_name = "foo"]
+
+// @has 'foo/trait.ToOwned.html'
+// @snapshot trait - '//*[@class="docblock item-decl"]'
+pub trait ToOwned<T>
+where T: Clone
+{
+    type Owned;
+    fn to_owned(&self) -> Self::Owned;
+    fn whatever(&self) -> T;
+}
+
+// @has 'foo/trait.ToOwned2.html'
+// @snapshot trait2 - '//*[@class="docblock item-decl"]'
+// There should be a whitespace before `{` in this case!
+pub trait ToOwned2<T: Clone> {
+    type Owned;
+    fn to_owned(&self) -> Self::Owned;
+    fn whatever(&self) -> T;
+}
+
+// @has 'foo/enum.Cow.html'
+// @snapshot enum - '//*[@class="docblock item-decl"]'
+pub enum Cow<'a, B: ?Sized + 'a>
+where
+    B: ToOwned<Clone>,
+{
+    Borrowed(&'a B),
+    Whatever(u32),
+}
+
+// @has 'foo/enum.Cow2.html'
+// @snapshot enum2 - '//*[@class="docblock item-decl"]'
+// There should be a whitespace before `{` in this case!
+pub enum Cow2<'a, B: ?Sized + ToOwned<Clone> + 'a> {
+    Borrowed(&'a B),
+    Whatever(u32),
+}
+
+// @has 'foo/struct.Struct.html'
+// @snapshot struct - '//*[@class="docblock item-decl"]'
+pub struct Struct<'a, B: ?Sized + 'a>
+where
+    B: ToOwned<Clone>,
+{
+    pub a: &'a B,
+    pub b: u32,
+}
+
+// @has 'foo/struct.Struct2.html'
+// @snapshot struct2 - '//*[@class="docblock item-decl"]'
+// There should be a whitespace before `{` in this case!
+pub struct Struct2<'a, B: ?Sized + ToOwned<Clone> + 'a> {
+    pub a: &'a B,
+    pub b: u32,
+}
+
+// @has 'foo/union.Union.html'
+// @snapshot union - '//*[@class="docblock item-decl"]'
+pub union Union<'a, B: ?Sized + 'a>
+where
+    B: ToOwned<Clone>,
+{
+    a: &'a B,
+    b: u32,
+}
+
+// @has 'foo/union.Union2.html'
+// @snapshot union2 - '//*[@class="docblock item-decl"]'
+// There should be a whitespace before `{` in this case!
+pub union Union2<'a, B: ?Sized + ToOwned<Clone> + 'a> {
+    a: &'a B,
+    b: u32,
+}

--- a/src/test/rustdoc/whitespace-after-where-clause.struct.html
+++ b/src/test/rustdoc/whitespace-after-where-clause.struct.html
@@ -1,0 +1,4 @@
+<div class="docblock item-decl"><pre class="rust struct"><code>pub struct Struct&lt;'a, B:&#160;?<a class="trait" href="{{channel}}/core/marker/trait.Sized.html" title="trait core::marker::Sized">Sized</a> + 'a&gt; <span class="where fmt-newline">where<br />&#160;&#160;&#160;&#160;B: <a class="trait" href="trait.ToOwned.html" title="trait foo::ToOwned">ToOwned</a>&lt;dyn <a class="trait" href="{{channel}}/core/clone/trait.Clone.html" title="trait core::clone::Clone">Clone</a>&gt;,&#160;</span>{
+    pub a: <a class="primitive" href="{{channel}}/std/primitive.reference.html">&amp;'a </a>B,
+    pub b: <a class="primitive" href="{{channel}}/std/primitive.u32.html">u32</a>,
+}</code></pre></div>

--- a/src/test/rustdoc/whitespace-after-where-clause.struct2.html
+++ b/src/test/rustdoc/whitespace-after-where-clause.struct2.html
@@ -1,0 +1,4 @@
+<div class="docblock item-decl"><pre class="rust struct"><code>pub struct Struct2&lt;'a, B:&#160;?<a class="trait" href="{{channel}}/core/marker/trait.Sized.html" title="trait core::marker::Sized">Sized</a> + <a class="trait" href="trait.ToOwned.html" title="trait foo::ToOwned">ToOwned</a>&lt;dyn <a class="trait" href="{{channel}}/core/clone/trait.Clone.html" title="trait core::clone::Clone">Clone</a>&gt; + 'a&gt; {
+    pub a: <a class="primitive" href="{{channel}}/std/primitive.reference.html">&amp;'a </a>B,
+    pub b: <a class="primitive" href="{{channel}}/std/primitive.u32.html">u32</a>,
+}</code></pre></div>

--- a/src/test/rustdoc/whitespace-after-where-clause.trait.html
+++ b/src/test/rustdoc/whitespace-after-where-clause.trait.html
@@ -1,0 +1,6 @@
+<div class="docblock item-decl"><pre class="rust trait"><code>pub trait ToOwned&lt;T&gt; <span class="where fmt-newline">where<br />&#160;&#160;&#160;&#160;T: <a class="trait" href="{{channel}}/core/clone/trait.Clone.html" title="trait core::clone::Clone">Clone</a>,&#160;</span>{
+    type <a href="#associatedtype.Owned" class="associatedtype">Owned</a>;
+
+    fn <a href="#tymethod.to_owned" class="fnname">to_owned</a>(&amp;self) -&gt; Self::<a class="associatedtype" href="trait.ToOwned.html#associatedtype.Owned" title="type foo::ToOwned::Owned">Owned</a>;
+<span class="item-spacer" />    fn <a href="#tymethod.whatever" class="fnname">whatever</a>(&amp;self) -&gt; T;
+}</code></pre></div>

--- a/src/test/rustdoc/whitespace-after-where-clause.trait2.html
+++ b/src/test/rustdoc/whitespace-after-where-clause.trait2.html
@@ -1,0 +1,6 @@
+<div class="docblock item-decl"><pre class="rust trait"><code>pub trait ToOwned2&lt;T:&#160;<a class="trait" href="{{channel}}/core/clone/trait.Clone.html" title="trait core::clone::Clone">Clone</a>&gt; {
+    type <a href="#associatedtype.Owned" class="associatedtype">Owned</a>;
+
+    fn <a href="#tymethod.to_owned" class="fnname">to_owned</a>(&amp;self) -&gt; Self::<a class="associatedtype" href="trait.ToOwned2.html#associatedtype.Owned" title="type foo::ToOwned2::Owned">Owned</a>;
+<span class="item-spacer" />    fn <a href="#tymethod.whatever" class="fnname">whatever</a>(&amp;self) -&gt; T;
+}</code></pre></div>

--- a/src/test/rustdoc/whitespace-after-where-clause.union.html
+++ b/src/test/rustdoc/whitespace-after-where-clause.union.html
@@ -1,0 +1,3 @@
+<div class="docblock item-decl"><pre class="rust union"><code>pub union Union&lt;'a, B:&#160;?<a class="trait" href="{{channel}}/core/marker/trait.Sized.html" title="trait core::marker::Sized">Sized</a> + 'a&gt; <span class="where fmt-newline">where<br />&#160;&#160;&#160;&#160;B: <a class="trait" href="trait.ToOwned.html" title="trait foo::ToOwned">ToOwned</a>&lt;dyn <a class="trait" href="{{channel}}/core/clone/trait.Clone.html" title="trait core::clone::Clone">Clone</a>&gt;,&#160;</span>{
+    /* private fields */
+}</code></pre></div>

--- a/src/test/rustdoc/whitespace-after-where-clause.union2.html
+++ b/src/test/rustdoc/whitespace-after-where-clause.union2.html
@@ -1,0 +1,3 @@
+<div class="docblock item-decl"><pre class="rust union"><code>pub union Union2&lt;'a, B:&#160;?<a class="trait" href="{{channel}}/core/marker/trait.Sized.html" title="trait core::marker::Sized">Sized</a> + <a class="trait" href="trait.ToOwned.html" title="trait foo::ToOwned">ToOwned</a>&lt;dyn <a class="trait" href="{{channel}}/core/clone/trait.Clone.html" title="trait core::clone::Clone">Clone</a>&gt; + 'a&gt; {
+    /* private fields */
+}</code></pre></div>


### PR DESCRIPTION
Fixes #97733.

You can see the result [here](https://rustdoc.crud.net/imperio/whitespace-where-clause/doc/foo/index.html).

r? @jsha