### PR TITLE
Improve `lifetime arguments are not allowed on` error message

### DIFF
--- a/compiler/rustc_typeck/src/astconv/mod.rs
+++ b/compiler/rustc_typeck/src/astconv/mod.rs
@@ -2195,8 +2195,8 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                 "{kind} arguments are not allowed on {this_type}",
             );
             err.span_label(last_span, format!("{kind} argument{s} not allowed"));
-            for (_, span) in types_and_spans {
-                err.span_label(span, "not allowed on this");
+            for (what, span) in types_and_spans {
+                err.span_label(span, format!("not allowed on {what}"));
             }
             extend(&mut err);
             err.emit();

--- a/src/test/ui/derives/issue-97343.stderr
+++ b/src/test/ui/derives/issue-97343.stderr
@@ -4,7 +4,7 @@ error[E0109]: type arguments are not allowed on type parameter `Irrelevant`
 LL | #[derive(Debug)]
    |          -----
    |          |
-   |          not allowed on this
+   |          not allowed on type parameter `Irrelevant`
    |          in this derive macro expansion
 LL | pub struct Irrelevant<Irrelevant> {
    |                       ^^^^^^^^^^ type argument not allowed

--- a/src/test/ui/error-codes/E0109.stderr
+++ b/src/test/ui/error-codes/E0109.stderr
@@ -4,7 +4,7 @@ error[E0109]: type arguments are not allowed on this type
 LL | type X = u32<i32>;
    |          --- ^^^ type argument not allowed
    |          |
-   |          not allowed on this
+   |          not allowed on this type
    |
 help: primitive type `u32` doesn't have generic parameters
    |

--- a/src/test/ui/error-codes/E0110.stderr
+++ b/src/test/ui/error-codes/E0110.stderr
@@ -4,7 +4,7 @@ error[E0109]: lifetime arguments are not allowed on this type
 LL | type X = u32<'static>;
    |          --- ^^^^^^^ lifetime argument not allowed
    |          |
-   |          not allowed on this
+   |          not allowed on this type
    |
 help: primitive type `u32` doesn't have generic parameters
    |

--- a/src/test/ui/issues/issue-22706.stderr
+++ b/src/test/ui/issues/issue-22706.stderr
@@ -4,7 +4,7 @@ error[E0109]: type arguments are not allowed on module `marker`
 LL | fn is_copy<T: ::std::marker<i32>::Copy>() {}
    |                      ------ ^^^ type argument not allowed
    |                      |
-   |                      not allowed on this
+   |                      not allowed on module `marker`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-57924.stderr
+++ b/src/test/ui/issues/issue-57924.stderr
@@ -4,7 +4,7 @@ error[E0109]: type arguments are not allowed on self constructor
 LL |         Self::<E>(e)
    |         ----   ^ type argument not allowed
    |         |
-   |         not allowed on this
+   |         not allowed on self constructor
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-60989.stderr
+++ b/src/test/ui/issues/issue-60989.stderr
@@ -4,7 +4,7 @@ error[E0109]: type arguments are not allowed on local variable
 LL |     c1::<()>;
    |     --   ^^ type argument not allowed
    |     |
-   |     not allowed on this
+   |     not allowed on local variable
 
 error[E0109]: type arguments are not allowed on local variable
   --> $DIR/issue-60989.rs:16:10
@@ -12,7 +12,7 @@ error[E0109]: type arguments are not allowed on local variable
 LL |     c1::<dyn Into<B>>;
    |     --   ^^^^^^^^^^^ type argument not allowed
    |     |
-   |     not allowed on this
+   |     not allowed on local variable
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/mod-subitem-as-enum-variant.stderr
+++ b/src/test/ui/mod-subitem-as-enum-variant.stderr
@@ -4,7 +4,7 @@ error[E0109]: type arguments are not allowed on module `Mod`
 LL |     Mod::<i32>::FakeVariant(0);
    |     ---   ^^^ type argument not allowed
    |     |
-   |     not allowed on this
+   |     not allowed on module `Mod`
 
 error: aborting due to previous error
 

--- a/src/test/ui/structs/struct-path-associated-type.stderr
+++ b/src/test/ui/structs/struct-path-associated-type.stderr
@@ -10,7 +10,7 @@ error[E0109]: type arguments are not allowed on this type
 LL |     let z = T::A::<u8> {};
    |                -   ^^ type argument not allowed
    |                |
-   |                not allowed on this
+   |                not allowed on this type
 
 error[E0071]: expected struct, variant or union type, found associated type
   --> $DIR/struct-path-associated-type.rs:14:13
@@ -30,7 +30,7 @@ error[E0109]: type arguments are not allowed on this type
 LL |     let z = T::A::<u8> {};
    |                -   ^^ type argument not allowed
    |                |
-   |                not allowed on this
+   |                not allowed on this type
 
 error[E0223]: ambiguous associated type
   --> $DIR/struct-path-associated-type.rs:32:13

--- a/src/test/ui/structs/struct-path-self.stderr
+++ b/src/test/ui/structs/struct-path-self.stderr
@@ -10,7 +10,7 @@ error[E0109]: type arguments are not allowed on self type
 LL |         let z = Self::<u8> {};
    |                 ----   ^^ type argument not allowed
    |                 |
-   |                 not allowed on this
+   |                 not allowed on self type
    |
 help: the `Self` type doesn't accept type parameters
    |
@@ -36,7 +36,7 @@ error[E0109]: type arguments are not allowed on self type
 LL |         let z = Self::<u8> {};
    |                 ----   ^^ type argument not allowed
    |                 |
-   |                 not allowed on this
+   |                 not allowed on self type
    |
 note: `Self` is of type `S`
   --> $DIR/struct-path-self.rs:1:8
@@ -58,7 +58,7 @@ error[E0109]: type arguments are not allowed on self type
 LL |         let z = Self::<u8> {};
    |                 ----   ^^ type argument not allowed
    |                 |
-   |                 not allowed on this
+   |                 not allowed on self type
    |
 note: `Self` is of type `S`
   --> $DIR/struct-path-self.rs:1:8

--- a/src/test/ui/type-alias-enum-variants/enum-variant-generic-args.stderr
+++ b/src/test/ui/type-alias-enum-variants/enum-variant-generic-args.stderr
@@ -23,7 +23,7 @@ error[E0109]: type arguments are not allowed on this type
 LL |         Self::TSVariant::<()>(());
    |               ---------   ^^ type argument not allowed
    |               |
-   |               not allowed on this
+   |               not allowed on this type
 
 error[E0109]: type arguments are not allowed on self type
   --> $DIR/enum-variant-generic-args.rs:17:16
@@ -31,7 +31,7 @@ error[E0109]: type arguments are not allowed on self type
 LL |         Self::<()>::TSVariant(());
    |         ----   ^^ type argument not allowed
    |         |
-   |         not allowed on this
+   |         not allowed on self type
    |
 note: `Self` is of type `Enum<T>`
   --> $DIR/enum-variant-generic-args.rs:7:6
@@ -71,7 +71,7 @@ error[E0109]: type arguments are not allowed on self type
 LL |         Self::<()>::TSVariant::<()>(());
    |         ----   ^^ type argument not allowed
    |         |
-   |         not allowed on this
+   |         not allowed on self type
    |
 note: `Self` is of type `Enum<T>`
   --> $DIR/enum-variant-generic-args.rs:7:6
@@ -92,7 +92,7 @@ error[E0109]: type arguments are not allowed on this type
 LL |         Self::<()>::TSVariant::<()>(());
    |                     ---------   ^^ type argument not allowed
    |                     |
-   |                     not allowed on this
+   |                     not allowed on this type
 
 error[E0308]: mismatched types
   --> $DIR/enum-variant-generic-args.rs:26:29
@@ -112,7 +112,7 @@ error[E0109]: type arguments are not allowed on this type
 LL |         Self::SVariant::<()> { v: () };
    |               --------   ^^ type argument not allowed
    |               |
-   |               not allowed on this
+   |               not allowed on this type
    |
    = note: enum variants can't have type parameters
 help: you might have meant to specity type parameters on enum `Enum`
@@ -139,7 +139,7 @@ error[E0109]: type arguments are not allowed on self type
 LL |         Self::<()>::SVariant { v: () };
    |         ----   ^^ type argument not allowed
    |         |
-   |         not allowed on this
+   |         not allowed on self type
    |
 note: `Self` is of type `Enum<T>`
   --> $DIR/enum-variant-generic-args.rs:7:6
@@ -172,7 +172,7 @@ error[E0109]: type arguments are not allowed on self type
 LL |         Self::<()>::SVariant::<()> { v: () };
    |         ----   ^^ type argument not allowed
    |         |
-   |         not allowed on this
+   |         not allowed on self type
    |
 note: `Self` is of type `Enum<T>`
   --> $DIR/enum-variant-generic-args.rs:7:6
@@ -193,7 +193,7 @@ error[E0109]: type arguments are not allowed on this type
 LL |         Self::<()>::SVariant::<()> { v: () };
    |                     --------   ^^ type argument not allowed
    |                     |
-   |                     not allowed on this
+   |                     not allowed on this type
    |
    = note: enum variants can't have type parameters
 help: you might have meant to specity type parameters on enum `Enum`
@@ -220,7 +220,7 @@ error[E0109]: type arguments are not allowed on this type
 LL |         Self::UVariant::<()>;
    |               --------   ^^ type argument not allowed
    |               |
-   |               not allowed on this
+   |               not allowed on this type
 
 error[E0109]: type arguments are not allowed on self type
   --> $DIR/enum-variant-generic-args.rs:43:16
@@ -228,7 +228,7 @@ error[E0109]: type arguments are not allowed on self type
 LL |         Self::<()>::UVariant;
    |         ----   ^^ type argument not allowed
    |         |
-   |         not allowed on this
+   |         not allowed on self type
    |
 note: `Self` is of type `Enum<T>`
   --> $DIR/enum-variant-generic-args.rs:7:6
@@ -249,7 +249,7 @@ error[E0109]: type arguments are not allowed on self type
 LL |         Self::<()>::UVariant::<()>;
    |         ----   ^^ type argument not allowed
    |         |
-   |         not allowed on this
+   |         not allowed on self type
    |
 note: `Self` is of type `Enum<T>`
   --> $DIR/enum-variant-generic-args.rs:7:6
@@ -270,7 +270,7 @@ error[E0109]: type arguments are not allowed on this type
 LL |         Self::<()>::UVariant::<()>;
    |                     --------   ^^ type argument not allowed
    |                     |
-   |                     not allowed on this
+   |                     not allowed on this type
 
 error[E0109]: type arguments are not allowed on this type
   --> $DIR/enum-variant-generic-args.rs:54:29
@@ -278,7 +278,7 @@ error[E0109]: type arguments are not allowed on this type
 LL |     Enum::<()>::TSVariant::<()>(());
    |                 ---------   ^^ type argument not allowed
    |                 |
-   |                 not allowed on this
+   |                 not allowed on this type
 
 error[E0109]: type arguments are not allowed on this type
   --> $DIR/enum-variant-generic-args.rs:57:24
@@ -286,7 +286,7 @@ error[E0109]: type arguments are not allowed on this type
 LL |     Alias::TSVariant::<()>(());
    |            ---------   ^^ type argument not allowed
    |            |
-   |            not allowed on this
+   |            not allowed on this type
 
 error[E0109]: type arguments are not allowed on this type
   --> $DIR/enum-variant-generic-args.rs:59:30
@@ -294,7 +294,7 @@ error[E0109]: type arguments are not allowed on this type
 LL |     Alias::<()>::TSVariant::<()>(());
    |                  ---------   ^^ type argument not allowed
    |                  |
-   |                  not allowed on this
+   |                  not allowed on this type
 
 error[E0109]: type arguments are not allowed on this type
   --> $DIR/enum-variant-generic-args.rs:62:29
@@ -302,7 +302,7 @@ error[E0109]: type arguments are not allowed on this type
 LL |     AliasFixed::TSVariant::<()>(());
    |                 ---------   ^^ type argument not allowed
    |                 |
-   |                 not allowed on this
+   |                 not allowed on this type
 
 error[E0107]: this type alias takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/enum-variant-generic-args.rs:64:5
@@ -338,7 +338,7 @@ error[E0109]: type arguments are not allowed on this type
 LL |     AliasFixed::<()>::TSVariant::<()>(());
    |                       ---------   ^^ type argument not allowed
    |                       |
-   |                       not allowed on this
+   |                       not allowed on this type
 
 error[E0109]: type arguments are not allowed on this type
   --> $DIR/enum-variant-generic-args.rs:72:28
@@ -346,7 +346,7 @@ error[E0109]: type arguments are not allowed on this type
 LL |     Enum::<()>::SVariant::<()> { v: () };
    |                 --------   ^^ type argument not allowed
    |                 |
-   |                 not allowed on this
+   |                 not allowed on this type
    |
    = note: enum variants can't have type parameters
 
@@ -356,7 +356,7 @@ error[E0109]: type arguments are not allowed on this type
 LL |     Alias::SVariant::<()> { v: () };
    |            --------   ^^ type argument not allowed
    |            |
-   |            not allowed on this
+   |            not allowed on this type
    |
    = note: enum variants can't have type parameters
 help: you might have meant to specity type parameters on enum `Enum`
@@ -371,7 +371,7 @@ error[E0109]: type arguments are not allowed on this type
 LL |     Alias::<()>::SVariant::<()> { v: () };
    |                  --------   ^^ type argument not allowed
    |                  |
-   |                  not allowed on this
+   |                  not allowed on this type
    |
    = note: enum variants can't have type parameters
 help: you might have meant to specity type parameters on enum `Enum`
@@ -386,7 +386,7 @@ error[E0109]: type arguments are not allowed on this type
 LL |     AliasFixed::SVariant::<()> { v: () };
    |                 --------   ^^ type argument not allowed
    |                 |
-   |                 not allowed on this
+   |                 not allowed on this type
    |
    = note: enum variants can't have type parameters
 help: you might have meant to specity type parameters on enum `Enum`
@@ -429,7 +429,7 @@ error[E0109]: type arguments are not allowed on this type
 LL |     AliasFixed::<()>::SVariant::<()> { v: () };
    |                       --------   ^^ type argument not allowed
    |                       |
-   |                       not allowed on this
+   |                       not allowed on this type
    |
    = note: enum variants can't have type parameters
 help: you might have meant to specity type parameters on enum `Enum`
@@ -444,7 +444,7 @@ error[E0109]: type arguments are not allowed on this type
 LL |     Enum::<()>::UVariant::<()>;
    |                 --------   ^^ type argument not allowed
    |                 |
-   |                 not allowed on this
+   |                 not allowed on this type
 
 error[E0109]: type arguments are not allowed on this type
   --> $DIR/enum-variant-generic-args.rs:93:23
@@ -452,7 +452,7 @@ error[E0109]: type arguments are not allowed on this type
 LL |     Alias::UVariant::<()>;
    |            --------   ^^ type argument not allowed
    |            |
-   |            not allowed on this
+   |            not allowed on this type
 
 error[E0109]: type arguments are not allowed on this type
   --> $DIR/enum-variant-generic-args.rs:95:29
@@ -460,7 +460,7 @@ error[E0109]: type arguments are not allowed on this type
 LL |     Alias::<()>::UVariant::<()>;
    |                  --------   ^^ type argument not allowed
    |                  |
-   |                  not allowed on this
+   |                  not allowed on this type
 
 error[E0109]: type arguments are not allowed on this type
   --> $DIR/enum-variant-generic-args.rs:98:28
@@ -468,7 +468,7 @@ error[E0109]: type arguments are not allowed on this type
 LL |     AliasFixed::UVariant::<()>;
    |                 --------   ^^ type argument not allowed
    |                 |
-   |                 not allowed on this
+   |                 not allowed on this type
 
 error[E0107]: this type alias takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/enum-variant-generic-args.rs:100:5
@@ -504,7 +504,7 @@ error[E0109]: type arguments are not allowed on this type
 LL |     AliasFixed::<()>::UVariant::<()>;
    |                       --------   ^^ type argument not allowed
    |                       |
-   |                       not allowed on this
+   |                       not allowed on this type
 
 error: aborting due to 39 previous errors
 

--- a/src/test/ui/type-alias-enum-variants/no-type-application-on-aliased-enum-variant.stderr
+++ b/src/test/ui/type-alias-enum-variants/no-type-application-on-aliased-enum-variant.stderr
@@ -4,7 +4,7 @@ error[E0109]: type arguments are not allowed on this type
 LL |     let _ = Alias::None::<u8>;
    |                    ----   ^^ type argument not allowed
    |                    |
-   |                    not allowed on this
+   |                    not allowed on this type
 
 error: aborting due to previous error
 

--- a/src/test/ui/type/issue-91268.stderr
+++ b/src/test/ui/type/issue-91268.stderr
@@ -41,7 +41,7 @@ error[E0109]: type arguments are not allowed on this type
 LL |     0: u8(ţ
    |        -- ^ type argument not allowed
    |        |
-   |        not allowed on this
+   |        not allowed on this type
    |
 help: primitive type `u8` doesn't have generic parameters
    |

--- a/src/test/ui/typeck/prim-with-args.stderr
+++ b/src/test/ui/typeck/prim-with-args.stderr
@@ -4,7 +4,7 @@ error[E0109]: type arguments are not allowed on this type
 LL | let _x: isize<isize>;
    |         ----- ^^^^^ type argument not allowed
    |         |
-   |         not allowed on this
+   |         not allowed on this type
    |
 help: primitive type `isize` doesn't have generic parameters
    |
@@ -18,7 +18,7 @@ error[E0109]: type arguments are not allowed on this type
 LL | let _x: i8<isize>;
    |         -- ^^^^^ type argument not allowed
    |         |
-   |         not allowed on this
+   |         not allowed on this type
    |
 help: primitive type `i8` doesn't have generic parameters
    |
@@ -32,7 +32,7 @@ error[E0109]: type arguments are not allowed on this type
 LL | let _x: i16<isize>;
    |         --- ^^^^^ type argument not allowed
    |         |
-   |         not allowed on this
+   |         not allowed on this type
    |
 help: primitive type `i16` doesn't have generic parameters
    |
@@ -46,7 +46,7 @@ error[E0109]: type arguments are not allowed on this type
 LL | let _x: i32<isize>;
    |         --- ^^^^^ type argument not allowed
    |         |
-   |         not allowed on this
+   |         not allowed on this type
    |
 help: primitive type `i32` doesn't have generic parameters
    |
@@ -60,7 +60,7 @@ error[E0109]: type arguments are not allowed on this type
 LL | let _x: i64<isize>;
    |         --- ^^^^^ type argument not allowed
    |         |
-   |         not allowed on this
+   |         not allowed on this type
    |
 help: primitive type `i64` doesn't have generic parameters
    |
@@ -74,7 +74,7 @@ error[E0109]: type arguments are not allowed on this type
 LL | let _x: usize<isize>;
    |         ----- ^^^^^ type argument not allowed
    |         |
-   |         not allowed on this
+   |         not allowed on this type
    |
 help: primitive type `usize` doesn't have generic parameters
    |
@@ -88,7 +88,7 @@ error[E0109]: type arguments are not allowed on this type
 LL | let _x: u8<isize>;
    |         -- ^^^^^ type argument not allowed
    |         |
-   |         not allowed on this
+   |         not allowed on this type
    |
 help: primitive type `u8` doesn't have generic parameters
    |
@@ -102,7 +102,7 @@ error[E0109]: type arguments are not allowed on this type
 LL | let _x: u16<isize>;
    |         --- ^^^^^ type argument not allowed
    |         |
-   |         not allowed on this
+   |         not allowed on this type
    |
 help: primitive type `u16` doesn't have generic parameters
    |
@@ -116,7 +116,7 @@ error[E0109]: type arguments are not allowed on this type
 LL | let _x: u32<isize>;
    |         --- ^^^^^ type argument not allowed
    |         |
-   |         not allowed on this
+   |         not allowed on this type
    |
 help: primitive type `u32` doesn't have generic parameters
    |
@@ -130,7 +130,7 @@ error[E0109]: type arguments are not allowed on this type
 LL | let _x: u64<isize>;
    |         --- ^^^^^ type argument not allowed
    |         |
-   |         not allowed on this
+   |         not allowed on this type
    |
 help: primitive type `u64` doesn't have generic parameters
    |
@@ -144,7 +144,7 @@ error[E0109]: type arguments are not allowed on this type
 LL | let _x: char<isize>;
    |         ---- ^^^^^ type argument not allowed
    |         |
-   |         not allowed on this
+   |         not allowed on this type
    |
 help: primitive type `char` doesn't have generic parameters
    |
@@ -158,7 +158,7 @@ error[E0109]: lifetime arguments are not allowed on this type
 LL | let _x: isize<'static>;
    |         ----- ^^^^^^^ lifetime argument not allowed
    |         |
-   |         not allowed on this
+   |         not allowed on this type
    |
 help: primitive type `isize` doesn't have generic parameters
    |
@@ -172,7 +172,7 @@ error[E0109]: lifetime arguments are not allowed on this type
 LL | let _x: i8<'static>;
    |         -- ^^^^^^^ lifetime argument not allowed
    |         |
-   |         not allowed on this
+   |         not allowed on this type
    |
 help: primitive type `i8` doesn't have generic parameters
    |
@@ -186,7 +186,7 @@ error[E0109]: lifetime arguments are not allowed on this type
 LL | let _x: i16<'static>;
    |         --- ^^^^^^^ lifetime argument not allowed
    |         |
-   |         not allowed on this
+   |         not allowed on this type
    |
 help: primitive type `i16` doesn't have generic parameters
    |
@@ -200,7 +200,7 @@ error[E0109]: lifetime arguments are not allowed on this type
 LL | let _x: i32<'static>;
    |         --- ^^^^^^^ lifetime argument not allowed
    |         |
-   |         not allowed on this
+   |         not allowed on this type
    |
 help: primitive type `i32` doesn't have generic parameters
    |
@@ -214,7 +214,7 @@ error[E0109]: lifetime arguments are not allowed on this type
 LL | let _x: i64<'static>;
    |         --- ^^^^^^^ lifetime argument not allowed
    |         |
-   |         not allowed on this
+   |         not allowed on this type
    |
 help: primitive type `i64` doesn't have generic parameters
    |
@@ -228,7 +228,7 @@ error[E0109]: lifetime arguments are not allowed on this type
 LL | let _x: usize<'static>;
    |         ----- ^^^^^^^ lifetime argument not allowed
    |         |
-   |         not allowed on this
+   |         not allowed on this type
    |
 help: primitive type `usize` doesn't have generic parameters
    |
@@ -242,7 +242,7 @@ error[E0109]: lifetime arguments are not allowed on this type
 LL | let _x: u8<'static>;
    |         -- ^^^^^^^ lifetime argument not allowed
    |         |
-   |         not allowed on this
+   |         not allowed on this type
    |
 help: primitive type `u8` doesn't have generic parameters
    |
@@ -256,7 +256,7 @@ error[E0109]: lifetime arguments are not allowed on this type
 LL | let _x: u16<'static>;
    |         --- ^^^^^^^ lifetime argument not allowed
    |         |
-   |         not allowed on this
+   |         not allowed on this type
    |
 help: primitive type `u16` doesn't have generic parameters
    |
@@ -270,7 +270,7 @@ error[E0109]: lifetime arguments are not allowed on this type
 LL | let _x: u32<'static>;
    |         --- ^^^^^^^ lifetime argument not allowed
    |         |
-   |         not allowed on this
+   |         not allowed on this type
    |
 help: primitive type `u32` doesn't have generic parameters
    |
@@ -284,7 +284,7 @@ error[E0109]: lifetime arguments are not allowed on this type
 LL | let _x: u64<'static>;
    |         --- ^^^^^^^ lifetime argument not allowed
    |         |
-   |         not allowed on this
+   |         not allowed on this type
    |
 help: primitive type `u64` doesn't have generic parameters
    |
@@ -298,7 +298,7 @@ error[E0109]: lifetime arguments are not allowed on this type
 LL | let _x: char<'static>;
    |         ---- ^^^^^^^ lifetime argument not allowed
    |         |
-   |         not allowed on this
+   |         not allowed on this type
    |
 help: primitive type `char` doesn't have generic parameters
    |

--- a/src/test/ui/usize-generic-argument-parent.stderr
+++ b/src/test/ui/usize-generic-argument-parent.stderr
@@ -4,7 +4,7 @@ error[E0109]: const arguments are not allowed on this type
 LL |     let x: usize<foo>;
    |            ----- ^^^ const argument not allowed
    |            |
-   |            not allowed on this
+   |            not allowed on this type
    |
 help: primitive type `usize` doesn't have generic parameters
    |


### PR DESCRIPTION
Actually mention what thing we're improperly trying to add lifetime generics to.