### PR TITLE
Provide a `PathSegment.res` in more cases

### DIFF
--- a/compiler/rustc_resolve/src/ident.rs
+++ b/compiler/rustc_resolve/src/ident.rs
@@ -1502,6 +1502,7 @@ impl<'a> Resolver<'a> {
                         return PathResult::NonModule(PartialRes::new(Res::Err));
                     } else if opt_ns.is_some() && (is_last || maybe_assoc) {
                         self.lint_if_path_starts_with_module(finalize, path, second_binding);
+                        record_segment_res(self, res);
                         return PathResult::NonModule(PartialRes::with_unresolved_segments(
                             res,
                             path.len() - i - 1,

--- a/src/test/ui/error-codes/E0109.stderr
+++ b/src/test/ui/error-codes/E0109.stderr
@@ -1,10 +1,10 @@
-error[E0109]: type arguments are not allowed on this type
+error[E0109]: type arguments are not allowed on builtin type `u32`
   --> $DIR/E0109.rs:1:14
    |
 LL | type X = u32<i32>;
    |          --- ^^^ type argument not allowed
    |          |
-   |          not allowed on this type
+   |          not allowed on builtin type `u32`
    |
 help: primitive type `u32` doesn't have generic parameters
    |

--- a/src/test/ui/error-codes/E0110.stderr
+++ b/src/test/ui/error-codes/E0110.stderr
@@ -1,10 +1,10 @@
-error[E0109]: lifetime arguments are not allowed on this type
+error[E0109]: lifetime arguments are not allowed on builtin type `u32`
   --> $DIR/E0110.rs:1:14
    |
 LL | type X = u32<'static>;
    |          --- ^^^^^^^ lifetime argument not allowed
    |          |
-   |          not allowed on this type
+   |          not allowed on builtin type `u32`
    |
 help: primitive type `u32` doesn't have generic parameters
    |

--- a/src/test/ui/inference/cannot-infer-closure-circular.rs
+++ b/src/test/ui/inference/cannot-infer-closure-circular.rs
@@ -4,10 +4,10 @@ fn main() {
     // error handles this gracefully, and in particular doesn't generate an extra
     // note about the `?` operator in the closure body, which isn't relevant to
     // the inference.
-    let x = |r| {
+    let x = |r| { //~ ERROR type annotations needed for `Result<(), E>`
         let v = r?;
         Ok(v)
     };
 
-    let _ = x(x(Ok(())));  //~ ERROR type annotations needed for `Result<(), E>`
+    let _ = x(x(Ok(())));
 }

--- a/src/test/ui/inference/cannot-infer-closure-circular.stderr
+++ b/src/test/ui/inference/cannot-infer-closure-circular.stderr
@@ -1,13 +1,13 @@
 error[E0282]: type annotations needed for `Result<(), E>`
-  --> $DIR/cannot-infer-closure-circular.rs:12:9
+  --> $DIR/cannot-infer-closure-circular.rs:7:14
    |
-LL |     let _ = x(x(Ok(())));
-   |         ^
+LL |     let x = |r| {
+   |              ^
    |
-help: consider giving this pattern a type, where the type for type parameter `E` is specified
+help: consider giving this closure parameter an explicit type, where the type for type parameter `E` is specified
    |
-LL |     let _: Result<(), E> = x(x(Ok(())));
-   |          +++++++++++++++
+LL |     let x = |r: Result<(), E>| {
+   |               +++++++++++++++
 
 error: aborting due to previous error
 

--- a/src/test/ui/type-alias-enum-variants/enum-variant-generic-args.rs
+++ b/src/test/ui/type-alias-enum-variants/enum-variant-generic-args.rs
@@ -52,7 +52,7 @@ fn main() {
     // Tuple struct variant
 
     Enum::<()>::TSVariant::<()>(());
-    //~^ ERROR type arguments are not allowed on this type [E0109]
+    //~^ ERROR type arguments are not allowed on tuple variant `TSVariant` [E0109]
 
     Alias::TSVariant::<()>(());
     //~^ ERROR type arguments are not allowed on this type [E0109]
@@ -70,7 +70,7 @@ fn main() {
     // Struct variant
 
     Enum::<()>::SVariant::<()> { v: () };
-    //~^ ERROR type arguments are not allowed on this type [E0109]
+    //~^ ERROR type arguments are not allowed on variant `SVariant` [E0109]
 
     Alias::SVariant::<()> { v: () };
     //~^ ERROR type arguments are not allowed on this type [E0109]
@@ -88,7 +88,7 @@ fn main() {
     // Unit variant
 
     Enum::<()>::UVariant::<()>;
-    //~^ ERROR type arguments are not allowed on this type [E0109]
+    //~^ ERROR type arguments are not allowed on unit variant `UVariant` [E0109]
 
     Alias::UVariant::<()>;
     //~^ ERROR type arguments are not allowed on this type [E0109]

--- a/src/test/ui/type-alias-enum-variants/enum-variant-generic-args.stderr
+++ b/src/test/ui/type-alias-enum-variants/enum-variant-generic-args.stderr
@@ -272,13 +272,13 @@ LL |         Self::<()>::UVariant::<()>;
    |                     |
    |                     not allowed on this type
 
-error[E0109]: type arguments are not allowed on this type
+error[E0109]: type arguments are not allowed on tuple variant `TSVariant`
   --> $DIR/enum-variant-generic-args.rs:54:29
    |
 LL |     Enum::<()>::TSVariant::<()>(());
    |                 ---------   ^^ type argument not allowed
    |                 |
-   |                 not allowed on this type
+   |                 not allowed on tuple variant `TSVariant`
 
 error[E0109]: type arguments are not allowed on this type
   --> $DIR/enum-variant-generic-args.rs:57:24
@@ -340,13 +340,13 @@ LL |     AliasFixed::<()>::TSVariant::<()>(());
    |                       |
    |                       not allowed on this type
 
-error[E0109]: type arguments are not allowed on this type
+error[E0109]: type arguments are not allowed on variant `SVariant`
   --> $DIR/enum-variant-generic-args.rs:72:28
    |
 LL |     Enum::<()>::SVariant::<()> { v: () };
    |                 --------   ^^ type argument not allowed
    |                 |
-   |                 not allowed on this type
+   |                 not allowed on variant `SVariant`
    |
    = note: enum variants can't have type parameters
 
@@ -438,13 +438,13 @@ LL -     AliasFixed::<()>::SVariant::<()> { v: () };
 LL +     AliasFixed::<()>::SVariant { v: () };
    |
 
-error[E0109]: type arguments are not allowed on this type
+error[E0109]: type arguments are not allowed on unit variant `UVariant`
   --> $DIR/enum-variant-generic-args.rs:90:28
    |
 LL |     Enum::<()>::UVariant::<()>;
    |                 --------   ^^ type argument not allowed
    |                 |
-   |                 not allowed on this type
+   |                 not allowed on unit variant `UVariant`
 
 error[E0109]: type arguments are not allowed on this type
   --> $DIR/enum-variant-generic-args.rs:93:23

--- a/src/test/ui/type/issue-91268.rs
+++ b/src/test/ui/type/issue-91268.rs
@@ -1,7 +1,7 @@
 // error-pattern: this file contains an unclosed delimiter
 // error-pattern: cannot find type `ţ` in this scope
 // error-pattern: parenthesized type parameters may only be used with a `Fn` trait
-// error-pattern: type arguments are not allowed on this type
+// error-pattern: type arguments are not allowed on builtin type `u8`
 // error-pattern: mismatched types
 // ignore-tidy-trailing-newlines
 // `ţ` must be the last character in this file, it cannot be followed by a newline

--- a/src/test/ui/type/issue-91268.stderr
+++ b/src/test/ui/type/issue-91268.stderr
@@ -35,13 +35,13 @@ help: use angle brackets instead
 LL |     0: u8<ţ>
    |          ~ +
 
-error[E0109]: type arguments are not allowed on this type
+error[E0109]: type arguments are not allowed on builtin type `u8`
   --> $DIR/issue-91268.rs:9:11
    |
 LL |     0: u8(ţ
    |        -- ^ type argument not allowed
    |        |
-   |        not allowed on this type
+   |        not allowed on builtin type `u8`
    |
 help: primitive type `u8` doesn't have generic parameters
    |

--- a/src/test/ui/typeck/prim-with-args.fixed
+++ b/src/test/ui/typeck/prim-with-args.fixed
@@ -1,28 +1,28 @@
 // run-rustfix
 fn main() {
 
-let _x: isize; //~ ERROR type arguments are not allowed on this type
-let _x: i8; //~ ERROR type arguments are not allowed on this type
-let _x: i16; //~ ERROR type arguments are not allowed on this type
-let _x: i32; //~ ERROR type arguments are not allowed on this type
-let _x: i64; //~ ERROR type arguments are not allowed on this type
-let _x: usize; //~ ERROR type arguments are not allowed on this type
-let _x: u8; //~ ERROR type arguments are not allowed on this type
-let _x: u16; //~ ERROR type arguments are not allowed on this type
-let _x: u32; //~ ERROR type arguments are not allowed on this type
-let _x: u64; //~ ERROR type arguments are not allowed on this type
-let _x: char; //~ ERROR type arguments are not allowed on this type
+let _x: isize; //~ ERROR type arguments are not allowed on builtin type
+let _x: i8; //~ ERROR type arguments are not allowed on builtin type
+let _x: i16; //~ ERROR type arguments are not allowed on builtin type
+let _x: i32; //~ ERROR type arguments are not allowed on builtin type
+let _x: i64; //~ ERROR type arguments are not allowed on builtin type
+let _x: usize; //~ ERROR type arguments are not allowed on builtin type
+let _x: u8; //~ ERROR type arguments are not allowed on builtin type
+let _x: u16; //~ ERROR type arguments are not allowed on builtin type
+let _x: u32; //~ ERROR type arguments are not allowed on builtin type
+let _x: u64; //~ ERROR type arguments are not allowed on builtin type
+let _x: char; //~ ERROR type arguments are not allowed on builtin type
 
-let _x: isize; //~ ERROR lifetime arguments are not allowed on this type
-let _x: i8; //~ ERROR lifetime arguments are not allowed on this type
-let _x: i16; //~ ERROR lifetime arguments are not allowed on this type
-let _x: i32; //~ ERROR lifetime arguments are not allowed on this type
-let _x: i64; //~ ERROR lifetime arguments are not allowed on this type
-let _x: usize; //~ ERROR lifetime arguments are not allowed on this type
-let _x: u8; //~ ERROR lifetime arguments are not allowed on this type
-let _x: u16; //~ ERROR lifetime arguments are not allowed on this type
-let _x: u32; //~ ERROR lifetime arguments are not allowed on this type
-let _x: u64; //~ ERROR lifetime arguments are not allowed on this type
-let _x: char; //~ ERROR lifetime arguments are not allowed on this type
+let _x: isize; //~ ERROR lifetime arguments are not allowed on builtin type
+let _x: i8; //~ ERROR lifetime arguments are not allowed on builtin type
+let _x: i16; //~ ERROR lifetime arguments are not allowed on builtin type
+let _x: i32; //~ ERROR lifetime arguments are not allowed on builtin type
+let _x: i64; //~ ERROR lifetime arguments are not allowed on builtin type
+let _x: usize; //~ ERROR lifetime arguments are not allowed on builtin type
+let _x: u8; //~ ERROR lifetime arguments are not allowed on builtin type
+let _x: u16; //~ ERROR lifetime arguments are not allowed on builtin type
+let _x: u32; //~ ERROR lifetime arguments are not allowed on builtin type
+let _x: u64; //~ ERROR lifetime arguments are not allowed on builtin type
+let _x: char; //~ ERROR lifetime arguments are not allowed on builtin type
 
 }

--- a/src/test/ui/typeck/prim-with-args.rs
+++ b/src/test/ui/typeck/prim-with-args.rs
@@ -1,28 +1,28 @@
 // run-rustfix
 fn main() {
 
-let _x: isize<isize>; //~ ERROR type arguments are not allowed on this type
-let _x: i8<isize>; //~ ERROR type arguments are not allowed on this type
-let _x: i16<isize>; //~ ERROR type arguments are not allowed on this type
-let _x: i32<isize>; //~ ERROR type arguments are not allowed on this type
-let _x: i64<isize>; //~ ERROR type arguments are not allowed on this type
-let _x: usize<isize>; //~ ERROR type arguments are not allowed on this type
-let _x: u8<isize>; //~ ERROR type arguments are not allowed on this type
-let _x: u16<isize>; //~ ERROR type arguments are not allowed on this type
-let _x: u32<isize>; //~ ERROR type arguments are not allowed on this type
-let _x: u64<isize>; //~ ERROR type arguments are not allowed on this type
-let _x: char<isize>; //~ ERROR type arguments are not allowed on this type
+let _x: isize<isize>; //~ ERROR type arguments are not allowed on builtin type
+let _x: i8<isize>; //~ ERROR type arguments are not allowed on builtin type
+let _x: i16<isize>; //~ ERROR type arguments are not allowed on builtin type
+let _x: i32<isize>; //~ ERROR type arguments are not allowed on builtin type
+let _x: i64<isize>; //~ ERROR type arguments are not allowed on builtin type
+let _x: usize<isize>; //~ ERROR type arguments are not allowed on builtin type
+let _x: u8<isize>; //~ ERROR type arguments are not allowed on builtin type
+let _x: u16<isize>; //~ ERROR type arguments are not allowed on builtin type
+let _x: u32<isize>; //~ ERROR type arguments are not allowed on builtin type
+let _x: u64<isize>; //~ ERROR type arguments are not allowed on builtin type
+let _x: char<isize>; //~ ERROR type arguments are not allowed on builtin type
 
-let _x: isize<'static>; //~ ERROR lifetime arguments are not allowed on this type
-let _x: i8<'static>; //~ ERROR lifetime arguments are not allowed on this type
-let _x: i16<'static>; //~ ERROR lifetime arguments are not allowed on this type
-let _x: i32<'static>; //~ ERROR lifetime arguments are not allowed on this type
-let _x: i64<'static>; //~ ERROR lifetime arguments are not allowed on this type
-let _x: usize<'static>; //~ ERROR lifetime arguments are not allowed on this type
-let _x: u8<'static>; //~ ERROR lifetime arguments are not allowed on this type
-let _x: u16<'static>; //~ ERROR lifetime arguments are not allowed on this type
-let _x: u32<'static>; //~ ERROR lifetime arguments are not allowed on this type
-let _x: u64<'static>; //~ ERROR lifetime arguments are not allowed on this type
-let _x: char<'static>; //~ ERROR lifetime arguments are not allowed on this type
+let _x: isize<'static>; //~ ERROR lifetime arguments are not allowed on builtin type
+let _x: i8<'static>; //~ ERROR lifetime arguments are not allowed on builtin type
+let _x: i16<'static>; //~ ERROR lifetime arguments are not allowed on builtin type
+let _x: i32<'static>; //~ ERROR lifetime arguments are not allowed on builtin type
+let _x: i64<'static>; //~ ERROR lifetime arguments are not allowed on builtin type
+let _x: usize<'static>; //~ ERROR lifetime arguments are not allowed on builtin type
+let _x: u8<'static>; //~ ERROR lifetime arguments are not allowed on builtin type
+let _x: u16<'static>; //~ ERROR lifetime arguments are not allowed on builtin type
+let _x: u32<'static>; //~ ERROR lifetime arguments are not allowed on builtin type
+let _x: u64<'static>; //~ ERROR lifetime arguments are not allowed on builtin type
+let _x: char<'static>; //~ ERROR lifetime arguments are not allowed on builtin type
 
 }

--- a/src/test/ui/typeck/prim-with-args.stderr
+++ b/src/test/ui/typeck/prim-with-args.stderr
@@ -1,10 +1,10 @@
-error[E0109]: type arguments are not allowed on this type
+error[E0109]: type arguments are not allowed on builtin type `isize`
   --> $DIR/prim-with-args.rs:4:15
    |
 LL | let _x: isize<isize>;
    |         ----- ^^^^^ type argument not allowed
    |         |
-   |         not allowed on this type
+   |         not allowed on builtin type `isize`
    |
 help: primitive type `isize` doesn't have generic parameters
    |
@@ -12,13 +12,13 @@ LL - let _x: isize<isize>;
 LL + let _x: isize;
    |
 
-error[E0109]: type arguments are not allowed on this type
+error[E0109]: type arguments are not allowed on builtin type `i8`
   --> $DIR/prim-with-args.rs:5:12
    |
 LL | let _x: i8<isize>;
    |         -- ^^^^^ type argument not allowed
    |         |
-   |         not allowed on this type
+   |         not allowed on builtin type `i8`
    |
 help: primitive type `i8` doesn't have generic parameters
    |
@@ -26,13 +26,13 @@ LL - let _x: i8<isize>;
 LL + let _x: i8;
    |
 
-error[E0109]: type arguments are not allowed on this type
+error[E0109]: type arguments are not allowed on builtin type `i16`
   --> $DIR/prim-with-args.rs:6:13
    |
 LL | let _x: i16<isize>;
    |         --- ^^^^^ type argument not allowed
    |         |
-   |         not allowed on this type
+   |         not allowed on builtin type `i16`
    |
 help: primitive type `i16` doesn't have generic parameters
    |
@@ -40,13 +40,13 @@ LL - let _x: i16<isize>;
 LL + let _x: i16;
    |
 
-error[E0109]: type arguments are not allowed on this type
+error[E0109]: type arguments are not allowed on builtin type `i32`
   --> $DIR/prim-with-args.rs:7:13
    |
 LL | let _x: i32<isize>;
    |         --- ^^^^^ type argument not allowed
    |         |
-   |         not allowed on this type
+   |         not allowed on builtin type `i32`
    |
 help: primitive type `i32` doesn't have generic parameters
    |
@@ -54,13 +54,13 @@ LL - let _x: i32<isize>;
 LL + let _x: i32;
    |
 
-error[E0109]: type arguments are not allowed on this type
+error[E0109]: type arguments are not allowed on builtin type `i64`
   --> $DIR/prim-with-args.rs:8:13
    |
 LL | let _x: i64<isize>;
    |         --- ^^^^^ type argument not allowed
    |         |
-   |         not allowed on this type
+   |         not allowed on builtin type `i64`
    |
 help: primitive type `i64` doesn't have generic parameters
    |
@@ -68,13 +68,13 @@ LL - let _x: i64<isize>;
 LL + let _x: i64;
    |
 
-error[E0109]: type arguments are not allowed on this type
+error[E0109]: type arguments are not allowed on builtin type `usize`
   --> $DIR/prim-with-args.rs:9:15
    |
 LL | let _x: usize<isize>;
    |         ----- ^^^^^ type argument not allowed
    |         |
-   |         not allowed on this type
+   |         not allowed on builtin type `usize`
    |
 help: primitive type `usize` doesn't have generic parameters
    |
@@ -82,13 +82,13 @@ LL - let _x: usize<isize>;
 LL + let _x: usize;
    |
 
-error[E0109]: type arguments are not allowed on this type
+error[E0109]: type arguments are not allowed on builtin type `u8`
   --> $DIR/prim-with-args.rs:10:12
    |
 LL | let _x: u8<isize>;
    |         -- ^^^^^ type argument not allowed
    |         |
-   |         not allowed on this type
+   |         not allowed on builtin type `u8`
    |
 help: primitive type `u8` doesn't have generic parameters
    |
@@ -96,13 +96,13 @@ LL - let _x: u8<isize>;
 LL + let _x: u8;
    |
 
-error[E0109]: type arguments are not allowed on this type
+error[E0109]: type arguments are not allowed on builtin type `u16`
   --> $DIR/prim-with-args.rs:11:13
    |
 LL | let _x: u16<isize>;
    |         --- ^^^^^ type argument not allowed
    |         |
-   |         not allowed on this type
+   |         not allowed on builtin type `u16`
    |
 help: primitive type `u16` doesn't have generic parameters
    |
@@ -110,13 +110,13 @@ LL - let _x: u16<isize>;
 LL + let _x: u16;
    |
 
-error[E0109]: type arguments are not allowed on this type
+error[E0109]: type arguments are not allowed on builtin type `u32`
   --> $DIR/prim-with-args.rs:12:13
    |
 LL | let _x: u32<isize>;
    |         --- ^^^^^ type argument not allowed
    |         |
-   |         not allowed on this type
+   |         not allowed on builtin type `u32`
    |
 help: primitive type `u32` doesn't have generic parameters
    |
@@ -124,13 +124,13 @@ LL - let _x: u32<isize>;
 LL + let _x: u32;
    |
 
-error[E0109]: type arguments are not allowed on this type
+error[E0109]: type arguments are not allowed on builtin type `u64`
   --> $DIR/prim-with-args.rs:13:13
    |
 LL | let _x: u64<isize>;
    |         --- ^^^^^ type argument not allowed
    |         |
-   |         not allowed on this type
+   |         not allowed on builtin type `u64`
    |
 help: primitive type `u64` doesn't have generic parameters
    |
@@ -138,13 +138,13 @@ LL - let _x: u64<isize>;
 LL + let _x: u64;
    |
 
-error[E0109]: type arguments are not allowed on this type
+error[E0109]: type arguments are not allowed on builtin type `char`
   --> $DIR/prim-with-args.rs:14:14
    |
 LL | let _x: char<isize>;
    |         ---- ^^^^^ type argument not allowed
    |         |
-   |         not allowed on this type
+   |         not allowed on builtin type `char`
    |
 help: primitive type `char` doesn't have generic parameters
    |
@@ -152,13 +152,13 @@ LL - let _x: char<isize>;
 LL + let _x: char;
    |
 
-error[E0109]: lifetime arguments are not allowed on this type
+error[E0109]: lifetime arguments are not allowed on builtin type `isize`
   --> $DIR/prim-with-args.rs:16:15
    |
 LL | let _x: isize<'static>;
    |         ----- ^^^^^^^ lifetime argument not allowed
    |         |
-   |         not allowed on this type
+   |         not allowed on builtin type `isize`
    |
 help: primitive type `isize` doesn't have generic parameters
    |
@@ -166,13 +166,13 @@ LL - let _x: isize<'static>;
 LL + let _x: isize;
    |
 
-error[E0109]: lifetime arguments are not allowed on this type
+error[E0109]: lifetime arguments are not allowed on builtin type `i8`
   --> $DIR/prim-with-args.rs:17:12
    |
 LL | let _x: i8<'static>;
    |         -- ^^^^^^^ lifetime argument not allowed
    |         |
-   |         not allowed on this type
+   |         not allowed on builtin type `i8`
    |
 help: primitive type `i8` doesn't have generic parameters
    |
@@ -180,13 +180,13 @@ LL - let _x: i8<'static>;
 LL + let _x: i8;
    |
 
-error[E0109]: lifetime arguments are not allowed on this type
+error[E0109]: lifetime arguments are not allowed on builtin type `i16`
   --> $DIR/prim-with-args.rs:18:13
    |
 LL | let _x: i16<'static>;
    |         --- ^^^^^^^ lifetime argument not allowed
    |         |
-   |         not allowed on this type
+   |         not allowed on builtin type `i16`
    |
 help: primitive type `i16` doesn't have generic parameters
    |
@@ -194,13 +194,13 @@ LL - let _x: i16<'static>;
 LL + let _x: i16;
    |
 
-error[E0109]: lifetime arguments are not allowed on this type
+error[E0109]: lifetime arguments are not allowed on builtin type `i32`
   --> $DIR/prim-with-args.rs:19:13
    |
 LL | let _x: i32<'static>;
    |         --- ^^^^^^^ lifetime argument not allowed
    |         |
-   |         not allowed on this type
+   |         not allowed on builtin type `i32`
    |
 help: primitive type `i32` doesn't have generic parameters
    |
@@ -208,13 +208,13 @@ LL - let _x: i32<'static>;
 LL + let _x: i32;
    |
 
-error[E0109]: lifetime arguments are not allowed on this type
+error[E0109]: lifetime arguments are not allowed on builtin type `i64`
   --> $DIR/prim-with-args.rs:20:13
    |
 LL | let _x: i64<'static>;
    |         --- ^^^^^^^ lifetime argument not allowed
    |         |
-   |         not allowed on this type
+   |         not allowed on builtin type `i64`
    |
 help: primitive type `i64` doesn't have generic parameters
    |
@@ -222,13 +222,13 @@ LL - let _x: i64<'static>;
 LL + let _x: i64;
    |
 
-error[E0109]: lifetime arguments are not allowed on this type
+error[E0109]: lifetime arguments are not allowed on builtin type `usize`
   --> $DIR/prim-with-args.rs:21:15
    |
 LL | let _x: usize<'static>;
    |         ----- ^^^^^^^ lifetime argument not allowed
    |         |
-   |         not allowed on this type
+   |         not allowed on builtin type `usize`
    |
 help: primitive type `usize` doesn't have generic parameters
    |
@@ -236,13 +236,13 @@ LL - let _x: usize<'static>;
 LL + let _x: usize;
    |
 
-error[E0109]: lifetime arguments are not allowed on this type
+error[E0109]: lifetime arguments are not allowed on builtin type `u8`
   --> $DIR/prim-with-args.rs:22:12
    |
 LL | let _x: u8<'static>;
    |         -- ^^^^^^^ lifetime argument not allowed
    |         |
-   |         not allowed on this type
+   |         not allowed on builtin type `u8`
    |
 help: primitive type `u8` doesn't have generic parameters
    |
@@ -250,13 +250,13 @@ LL - let _x: u8<'static>;
 LL + let _x: u8;
    |
 
-error[E0109]: lifetime arguments are not allowed on this type
+error[E0109]: lifetime arguments are not allowed on builtin type `u16`
   --> $DIR/prim-with-args.rs:23:13
    |
 LL | let _x: u16<'static>;
    |         --- ^^^^^^^ lifetime argument not allowed
    |         |
-   |         not allowed on this type
+   |         not allowed on builtin type `u16`
    |
 help: primitive type `u16` doesn't have generic parameters
    |
@@ -264,13 +264,13 @@ LL - let _x: u16<'static>;
 LL + let _x: u16;
    |
 
-error[E0109]: lifetime arguments are not allowed on this type
+error[E0109]: lifetime arguments are not allowed on builtin type `u32`
   --> $DIR/prim-with-args.rs:24:13
    |
 LL | let _x: u32<'static>;
    |         --- ^^^^^^^ lifetime argument not allowed
    |         |
-   |         not allowed on this type
+   |         not allowed on builtin type `u32`
    |
 help: primitive type `u32` doesn't have generic parameters
    |
@@ -278,13 +278,13 @@ LL - let _x: u32<'static>;
 LL + let _x: u32;
    |
 
-error[E0109]: lifetime arguments are not allowed on this type
+error[E0109]: lifetime arguments are not allowed on builtin type `u64`
   --> $DIR/prim-with-args.rs:25:13
    |
 LL | let _x: u64<'static>;
    |         --- ^^^^^^^ lifetime argument not allowed
    |         |
-   |         not allowed on this type
+   |         not allowed on builtin type `u64`
    |
 help: primitive type `u64` doesn't have generic parameters
    |
@@ -292,13 +292,13 @@ LL - let _x: u64<'static>;
 LL + let _x: u64;
    |
 
-error[E0109]: lifetime arguments are not allowed on this type
+error[E0109]: lifetime arguments are not allowed on builtin type `char`
   --> $DIR/prim-with-args.rs:26:14
    |
 LL | let _x: char<'static>;
    |         ---- ^^^^^^^ lifetime argument not allowed
    |         |
-   |         not allowed on this type
+   |         not allowed on builtin type `char`
    |
 help: primitive type `char` doesn't have generic parameters
    |

--- a/src/test/ui/usize-generic-argument-parent.rs
+++ b/src/test/ui/usize-generic-argument-parent.rs
@@ -1,5 +1,5 @@
 fn foo() {
-    let x: usize<foo>; //~ ERROR const arguments are not allowed on this type
+    let x: usize<foo>; //~ ERROR const arguments are not allowed on builtin type `usize`
 }
 
 fn main() {}

--- a/src/test/ui/usize-generic-argument-parent.stderr
+++ b/src/test/ui/usize-generic-argument-parent.stderr
@@ -1,10 +1,10 @@
-error[E0109]: const arguments are not allowed on this type
+error[E0109]: const arguments are not allowed on builtin type `usize`
   --> $DIR/usize-generic-argument-parent.rs:2:18
    |
 LL |     let x: usize<foo>;
    |            ----- ^^^ const argument not allowed
    |            |
-   |            not allowed on this type
+   |            not allowed on builtin type `usize`
    |
 help: primitive type `usize` doesn't have generic parameters
    |


### PR DESCRIPTION
I find that in many cases, the `res` associated with a `PathSegment` is `Res::Err` even though the path was fully resolved. A few diagnostics use this `res` and their error messages suffer because of the lack of resolved segment. 

This fixes it a bit, but it's obviously not complete and I'm not exactly sure if it's correct.