### PR TITLE
Fix minor documentation typo

### DIFF
--- a/compiler/rustc_trait_selection/src/lib.rs
+++ b/compiler/rustc_trait_selection/src/lib.rs
@@ -1,4 +1,4 @@
-//! This crates defines the trait resolution method.
+//! This crate defines the trait resolution method.
 //!
 //! - **Traits.** Trait resolution is implemented in the `traits` module.
 //!


### PR DESCRIPTION
Fixes incorrect pluralisation of `crate` in documentation for rustc_trait_selection