### PR TITLE
Create elided lifetime parameters for function-like types

### DIFF
--- a/compiler/rustc_hir/src/def.rs
+++ b/compiler/rustc_hir/src/def.rs
@@ -732,7 +732,9 @@ pub enum LifetimeRes {
     /// Created a generic parameter for an anonymous lifetime.
     Fresh {
         /// Id of the generic parameter that introduced it.
-        param: LocalDefId,
+        ///
+        /// Creating the associated `LocalDefId` is the responsibility of lowering.
+        param: NodeId,
         /// Id of the introducing place. See `Param`.
         binder: NodeId,
     },

--- a/compiler/rustc_hir/src/def.rs
+++ b/compiler/rustc_hir/src/def.rs
@@ -722,8 +722,7 @@ pub enum LifetimeRes {
         /// Id of the introducing place. That can be:
         /// - an item's id, for the item's generic parameters;
         /// - a TraitRef's ref_id, identifying the `for<...>` binder;
-        /// - a BareFn type's id;
-        /// - a Path's id when this path has parenthesized generic args.
+        /// - a BareFn type's id.
         ///
         /// This information is used for impl-trait lifetime captures, to know when to or not to
         /// capture any given lifetime.

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -1932,6 +1932,7 @@ pub enum ExprKind<'hir> {
     /// `Option<Movability>`.
     Closure {
         capture_clause: CaptureBy,
+        bound_generic_params: &'hir [GenericParam<'hir>],
         fn_decl: &'hir FnDecl<'hir>,
         body: BodyId,
         fn_decl_span: Span,
@@ -3480,7 +3481,7 @@ impl<'hir> Node<'hir> {
 #[cfg(all(target_arch = "x86_64", target_pointer_width = "64"))]
 mod size_asserts {
     rustc_data_structures::static_assert_size!(super::Block<'static>, 48);
-    rustc_data_structures::static_assert_size!(super::Expr<'static>, 56);
+    rustc_data_structures::static_assert_size!(super::Expr<'static>, 64);
     rustc_data_structures::static_assert_size!(super::Pat<'static>, 88);
     rustc_data_structures::static_assert_size!(super::QPath<'static>, 24);
     rustc_data_structures::static_assert_size!(super::Ty<'static>, 72);

--- a/compiler/rustc_hir/src/intravisit.rs
+++ b/compiler/rustc_hir/src/intravisit.rs
@@ -1169,12 +1169,16 @@ pub fn walk_expr<'v, V: Visitor<'v>>(visitor: &mut V, expression: &'v Expr<'v>) 
             walk_list!(visitor, visit_arm, arms);
         }
         ExprKind::Closure {
+            bound_generic_params,
             ref fn_decl,
             body,
             capture_clause: _,
             fn_decl_span: _,
             movability: _,
-        } => visitor.visit_fn(FnKind::Closure, fn_decl, body, expression.span, expression.hir_id),
+        } => {
+            walk_list!(visitor, visit_generic_param, bound_generic_params);
+            visitor.visit_fn(FnKind::Closure, fn_decl, body, expression.span, expression.hir_id)
+        }
         ExprKind::Block(ref block, ref opt_label) => {
             walk_list!(visitor, visit_label, opt_label);
             visitor.visit_block(block);

--- a/compiler/rustc_hir_pretty/src/lib.rs
+++ b/compiler/rustc_hir_pretty/src/lib.rs
@@ -1459,11 +1459,13 @@ impl<'a> State<'a> {
             }
             hir::ExprKind::Closure {
                 capture_clause,
+                bound_generic_params,
                 ref fn_decl,
                 body,
                 fn_decl_span: _,
                 movability: _,
             } => {
+                self.print_formal_generic_params(bound_generic_params);
                 self.print_capture_clause(capture_clause);
 
                 self.print_closure_params(&fn_decl, body);

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -1303,7 +1303,9 @@ impl<'a: 'ast, 'b, 'ast> LateResolutionVisitor<'a, 'b, 'ast> {
                                     | LifetimeRibKind::AnonymousCreateParameter { .. } => {
                                         Some(LifetimeUseSet::One { use_span: ident.span, use_ctxt })
                                     }
-                                    _ => None,
+                                    LifetimeRibKind::Generics { .. }
+                                    | LifetimeRibKind::ConstGeneric
+                                    | LifetimeRibKind::AnonConst => None,
                                 })
                                 .unwrap_or(LifetimeUseSet::Many);
                             debug!(?use_ctxt, ?use_set);
@@ -1390,7 +1392,9 @@ impl<'a: 'ast, 'b, 'ast> LateResolutionVisitor<'a, 'b, 'ast> {
                     return;
                 }
                 LifetimeRibKind::Item => break,
-                _ => {}
+                LifetimeRibKind::Generics { .. }
+                | LifetimeRibKind::ConstGeneric
+                | LifetimeRibKind::AnonConst => {}
             }
         }
         // This resolution is wrong, it passes the work to HIR lifetime resolution.
@@ -1576,7 +1580,9 @@ impl<'a: 'ast, 'b, 'ast> LateResolutionVisitor<'a, 'b, 'ast> {
                         }
                         break;
                     }
-                    _ => {}
+                    LifetimeRibKind::Generics { .. }
+                    | LifetimeRibKind::ConstGeneric
+                    | LifetimeRibKind::AnonConst => {}
                 }
             }
 

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -238,7 +238,7 @@ enum LifetimeRibKind {
     /// `body_id` is an anonymous constant and `lifetime_ref` is non-static.
     AnonConst,
 
-    /// Create a new anonymous region parameter and reference it.
+    /// Create a new anonymous lifetime parameter and reference it.
     ///
     /// If `report_in_path`, report an error when encountering lifetime elision in a path:
     /// ```ignore
@@ -1279,13 +1279,13 @@ impl<'a: 'ast, 'b, 'ast> LateResolutionVisitor<'a, 'b, 'ast> {
         for i in &mut indices {
             let rib = &self.lifetime_ribs[i];
             let normalized_ident = ident.normalize_to_macros_2_0();
-            if let Some(&(_, region)) = rib.bindings.get(&normalized_ident) {
-                self.record_lifetime_res(lifetime.id, region);
+            if let Some(&(_, res)) = rib.bindings.get(&normalized_ident) {
+                self.record_lifetime_res(lifetime.id, res);
 
-                if let LifetimeRes::Param { param, .. } = region {
+                if let LifetimeRes::Param { param, .. } = res {
                     match self.lifetime_uses.entry(param) {
                         Entry::Vacant(v) => {
-                            debug!("First use of {:?} at {:?}", region, ident.span);
+                            debug!("First use of {:?} at {:?}", res, ident.span);
                             let use_set = self
                                 .lifetime_ribs
                                 .iter()
@@ -1310,7 +1310,7 @@ impl<'a: 'ast, 'b, 'ast> LateResolutionVisitor<'a, 'b, 'ast> {
                             v.insert(use_set);
                         }
                         Entry::Occupied(mut o) => {
-                            debug!("Many uses of {:?} at {:?}", region, ident.span);
+                            debug!("Many uses of {:?} at {:?}", res, ident.span);
                             *o.get_mut() = LifetimeUseSet::Many;
                         }
                     }
@@ -1433,13 +1433,13 @@ impl<'a: 'ast, 'b, 'ast> LateResolutionVisitor<'a, 'b, 'ast> {
         );
         debug!(?def_id);
 
-        let region = LifetimeRes::Fresh { param: def_id, binder: item_node_id };
+        let res = LifetimeRes::Fresh { param: def_id, binder: item_node_id };
         self.r.extra_lifetime_params_map.entry(item_node_id).or_insert_with(Vec::new).push((
             ident,
             def_node_id,
-            region,
+            res,
         ));
-        region
+        res
     }
 
     #[tracing::instrument(level = "debug", skip(self))]

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -2223,9 +2223,18 @@ impl<'tcx> LifetimeContext<'_, 'tcx> {
             ]
             .contains(&Some(did))
             {
-                let (span, span_type) = match &trait_ref.bound_generic_params {
-                    [] => (trait_ref.span.shrink_to_lo(), ForLifetimeSpanType::BoundEmpty),
-                    [.., bound] => (bound.span.shrink_to_hi(), ForLifetimeSpanType::BoundTail),
+                let (span, span_type) = if let Some(bound) =
+                    trait_ref.bound_generic_params.iter().rfind(|param| {
+                        matches!(
+                            param.kind,
+                            hir::GenericParamKind::Lifetime {
+                                kind: hir::LifetimeParamKind::Explicit
+                            }
+                        )
+                    }) {
+                    (bound.span.shrink_to_hi(), ForLifetimeSpanType::BoundTail)
+                } else {
+                    (trait_ref.span.shrink_to_lo(), ForLifetimeSpanType::BoundEmpty)
                 };
                 self.missing_named_lifetime_spots
                     .push(MissingLifetimeSpot::HigherRanked { span, span_type });

--- a/compiler/rustc_resolve/src/late/lifetimes.rs
+++ b/compiler/rustc_resolve/src/late/lifetimes.rs
@@ -755,7 +755,9 @@ impl<'a, 'tcx> Visitor<'tcx> for LifetimeContext<'a, 'tcx> {
                 let next_early_index = self.next_early_index();
                 let lifetime_span: Option<Span> =
                     c.generic_params.iter().rev().find_map(|param| match param.kind {
-                        GenericParamKind::Lifetime { .. } => Some(param.span),
+                        GenericParamKind::Lifetime { kind: hir::LifetimeParamKind::Explicit } => {
+                            Some(param.span)
+                        }
                         _ => None,
                     });
                 let (span, span_type) = if let Some(span) = lifetime_span {

--- a/compiler/rustc_typeck/src/astconv/mod.rs
+++ b/compiler/rustc_typeck/src/astconv/mod.rs
@@ -2920,13 +2920,15 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
     ) {
         for br in referenced_regions.difference(&constrained_regions) {
             let br_name = match *br {
+                ty::BrNamed(_, kw::UnderscoreLifetime) | ty::BrAnon(_) | ty::BrEnv => {
+                    "an anonymous lifetime".to_string()
+                }
                 ty::BrNamed(_, name) => format!("lifetime `{}`", name),
-                ty::BrAnon(_) | ty::BrEnv => "an anonymous lifetime".to_string(),
             };
 
             let mut err = generate_err(&br_name);
 
-            if let ty::BrAnon(_) = *br {
+            if let ty::BrNamed(_, kw::UnderscoreLifetime) | ty::BrAnon(_) = *br {
                 // The only way for an anonymous lifetime to wind up
                 // in the return type but **also** be unconstrained is
                 // if it only appears in "associated types" in the

--- a/src/librustdoc/clean/utils.rs
+++ b/src/librustdoc/clean/utils.rs
@@ -84,12 +84,9 @@ pub(crate) fn substs_to_args<'tcx>(
     let mut ret_val =
         Vec::with_capacity(substs.len().saturating_sub(if skip_first { 1 } else { 0 }));
     ret_val.extend(substs.iter().filter_map(|kind| match kind.unpack() {
-        GenericArgKind::Lifetime(lt) => match *lt {
-            ty::ReLateBound(_, ty::BoundRegion { kind: ty::BrAnon(_), .. }) => {
-                Some(GenericArg::Lifetime(Lifetime::elided()))
-            }
-            _ => lt.clean(cx).map(GenericArg::Lifetime),
-        },
+        GenericArgKind::Lifetime(lt) => {
+            Some(GenericArg::Lifetime(lt.clean(cx).unwrap_or(Lifetime::elided())))
+        }
         GenericArgKind::Type(_) if skip_first => {
             skip_first = false;
             None

--- a/src/test/ui/generic-associated-types/issue-70304.rs
+++ b/src/test/ui/generic-associated-types/issue-70304.rs
@@ -45,7 +45,7 @@ where
 }
 
 fn create_doc() -> impl Document<Cursor<'_> = DocCursorImpl<'_>> {
-    //~^ ERROR: missing lifetime specifier
+    //~^ ERROR `'_` cannot be used here [E0637]
     //~| ERROR: missing lifetime specifier
     DocumentImpl {}
 }

--- a/src/test/ui/generic-associated-types/issue-70304.stderr
+++ b/src/test/ui/generic-associated-types/issue-70304.stderr
@@ -1,14 +1,8 @@
-error[E0106]: missing lifetime specifier
+error[E0637]: `'_` cannot be used here
   --> $DIR/issue-70304.rs:47:41
    |
 LL | fn create_doc() -> impl Document<Cursor<'_> = DocCursorImpl<'_>> {
-   |                                         ^^ expected named lifetime parameter
-   |
-   = help: this function's return type contains a borrowed value, but there is no value for it to be borrowed from
-help: consider using the `'static` lifetime
-   |
-LL | fn create_doc() -> impl Document<Cursor<'static> = DocCursorImpl<'_>> {
-   |                                         ~~~~~~~
+   |                                         ^^ `'_` is a reserved lifetime name
 
 error[E0106]: missing lifetime specifier
   --> $DIR/issue-70304.rs:47:61
@@ -24,4 +18,5 @@ LL | fn create_doc() -> impl Document<Cursor<'_> = DocCursorImpl<'static>> {
 
 error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0106`.
+Some errors have detailed explanations: E0106, E0637.
+For more information about an error, try `rustc --explain E0106`.

--- a/src/test/ui/generic-associated-types/issue-95305.rs
+++ b/src/test/ui/generic-associated-types/issue-95305.rs
@@ -9,7 +9,7 @@ trait Foo {
 }
 
 fn foo(x: &impl Foo<Item<'_> = u32>) { }
-                       //~^ ERROR missing lifetime specifier
+                       //~^ ERROR `'_` cannot be used here [E0637]
 
 fn bar(x: &impl for<'a> Foo<Item<'a> = &'_ u32>) { }
                                       //~^ ERROR missing lifetime specifier

--- a/src/test/ui/generic-associated-types/issue-95305.stderr
+++ b/src/test/ui/generic-associated-types/issue-95305.stderr
@@ -1,13 +1,8 @@
-error[E0106]: missing lifetime specifier
+error[E0637]: `'_` cannot be used here
   --> $DIR/issue-95305.rs:11:26
    |
 LL | fn foo(x: &impl Foo<Item<'_> = u32>) { }
-   |                          ^^ expected named lifetime parameter
-   |
-help: consider introducing a named lifetime parameter
-   |
-LL | fn foo<'a>(x: &impl Foo<Item<'a> = u32>) { }
-   |       ++++                   ~~
+   |                          ^^ `'_` is a reserved lifetime name
 
 error[E0106]: missing lifetime specifier
   --> $DIR/issue-95305.rs:14:41
@@ -22,4 +17,5 @@ LL | fn bar(x: &impl for<'a> Foo<Item<'a> = &'a u32>) { }
 
 error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0106`.
+Some errors have detailed explanations: E0106, E0637.
+For more information about an error, try `rustc --explain E0106`.

--- a/src/test/ui/generic-associated-types/parameter_number_and_kind_impl.stderr
+++ b/src/test/ui/generic-associated-types/parameter_number_and_kind_impl.stderr
@@ -8,7 +8,7 @@ LL |     type A = u32;
    |           ^ lifetimes do not match type in trait
 
 error[E0049]: type `B` has 1 type parameter but its trait declaration has 0 type parameters
-  --> $DIR/parameter_number_and_kind_impl.rs:17:16
+  --> $DIR/parameter_number_and_kind_impl.rs:17:12
    |
 LL |     type B<'a, 'b>;
    |            --  --
@@ -16,7 +16,9 @@ LL |     type B<'a, 'b>;
    |            expected 0 type parameters
 ...
 LL |     type B<'a, T> = Vec<T>;
-   |                ^ found 1 type parameter
+   |            ^^  ^
+   |            |
+   |            found 1 type parameter
 
 error[E0195]: lifetime parameters or bounds on type `C` do not match the trait declaration
   --> $DIR/parameter_number_and_kind_impl.rs:19:11

--- a/src/test/ui/higher-rank-trait-bounds/normalize-under-binder/issue-71955.stderr
+++ b/src/test/ui/higher-rank-trait-bounds/normalize-under-binder/issue-71955.stderr
@@ -23,7 +23,7 @@ error[E0308]: mismatched types
 LL |     foo(bar, "string", |s| s.len() == 5);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ one type is more general than the other
    |
-   = note: expected trait `FnOnce<(&&str,)>`
+   = note: expected trait `for<'r, 's> FnOnce<(&'r &'s str,)>`
               found trait `for<'r> FnOnce<(&'r &str,)>`
 note: this closure does not fulfill the lifetime requirements
   --> $DIR/issue-71955.rs:45:24
@@ -61,7 +61,7 @@ error[E0308]: mismatched types
 LL |     foo(baz, "string", |s| s.0.len() == 5);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ one type is more general than the other
    |
-   = note: expected trait `FnOnce<(&Wrapper<'_>,)>`
+   = note: expected trait `for<'r, 's> FnOnce<(&'r Wrapper<'s>,)>`
               found trait `for<'r> FnOnce<(&'r Wrapper<'_>,)>`
 note: this closure does not fulfill the lifetime requirements
   --> $DIR/issue-71955.rs:48:24

--- a/src/test/ui/higher-rank-trait-bounds/normalize-under-binder/issue-85455.rs
+++ b/src/test/ui/higher-rank-trait-bounds/normalize-under-binder/issue-85455.rs
@@ -6,8 +6,8 @@ trait SomeTrait<'a> {
 
 fn give_me_ice<T>() {
     callee::<fn(&()) -> <T as SomeTrait<'_>>::Associated>();
-    //~^ ERROR the trait bound `T: SomeTrait<'_>` is not satisfied [E0277]
-    //~| ERROR the trait bound `T: SomeTrait<'_>` is not satisfied [E0277]
+    //~^ ERROR the trait bound `for<'r> T: SomeTrait<'r>` is not satisfied [E0277]
+    //~| ERROR the trait bound `for<'r> T: SomeTrait<'r>` is not satisfied [E0277]
 }
 
 fn callee<T: Fn<(&'static (),)>>() {

--- a/src/test/ui/higher-rank-trait-bounds/normalize-under-binder/issue-85455.stderr
+++ b/src/test/ui/higher-rank-trait-bounds/normalize-under-binder/issue-85455.stderr
@@ -1,24 +1,24 @@
-error[E0277]: the trait bound `T: SomeTrait<'_>` is not satisfied
+error[E0277]: the trait bound `for<'r> T: SomeTrait<'r>` is not satisfied
   --> $DIR/issue-85455.rs:8:5
    |
 LL |     callee::<fn(&()) -> <T as SomeTrait<'_>>::Associated>();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `SomeTrait<'_>` is not implemented for `T`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `for<'r> SomeTrait<'r>` is not implemented for `T`
    |
 help: consider restricting type parameter `T`
    |
-LL | fn give_me_ice<T: SomeTrait<'_>>() {
-   |                 +++++++++++++++
+LL | fn give_me_ice<T: for<'r> SomeTrait<'r>>() {
+   |                 +++++++++++++++++++++++
 
-error[E0277]: the trait bound `T: SomeTrait<'_>` is not satisfied
+error[E0277]: the trait bound `for<'r> T: SomeTrait<'r>` is not satisfied
   --> $DIR/issue-85455.rs:8:14
    |
 LL |     callee::<fn(&()) -> <T as SomeTrait<'_>>::Associated>();
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `SomeTrait<'_>` is not implemented for `T`
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `for<'r> SomeTrait<'r>` is not implemented for `T`
    |
 help: consider restricting type parameter `T`
    |
-LL | fn give_me_ice<T: SomeTrait<'_>>() {
-   |                 +++++++++++++++
+LL | fn give_me_ice<T: for<'r> SomeTrait<'r>>() {
+   |                 +++++++++++++++++++++++
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/impl-header-lifetime-elision/dyn-trait.rs
+++ b/src/test/ui/impl-header-lifetime-elision/dyn-trait.rs
@@ -13,6 +13,10 @@ impl StaticTrait for Box<dyn Debug> { }
 trait NotStaticTrait { }
 impl NotStaticTrait for Box<dyn Debug + '_> { }
 
+// Check that we don't err when the trait has a lifetime parameter.
+trait TraitWithLifetime<'a> { }
+impl NotStaticTrait for &dyn TraitWithLifetime<'_> { }
+
 fn static_val<T: StaticTrait>(_: T) {
 }
 

--- a/src/test/ui/impl-header-lifetime-elision/dyn-trait.stderr
+++ b/src/test/ui/impl-header-lifetime-elision/dyn-trait.stderr
@@ -1,5 +1,5 @@
 error[E0521]: borrowed data escapes outside of function
-  --> $DIR/dyn-trait.rs:20:5
+  --> $DIR/dyn-trait.rs:24:5
    |
 LL | fn with_dyn_debug_static<'a>(x: Box<dyn Debug + 'a>) {
    |                          --  - `x` is a reference that is only valid in the function body

--- a/src/test/ui/issues/issue-37884.stderr
+++ b/src/test/ui/issues/issue-37884.stderr
@@ -11,7 +11,7 @@ LL | |     }
    |
    = note: expected fn pointer `fn(&mut RepeatMut<'a, T>) -> Option<_>`
               found fn pointer `fn(&'a mut RepeatMut<'a, T>) -> Option<_>`
-note: the anonymous lifetime as defined here...
+note: the anonymous lifetime #1 defined here...
   --> $DIR/issue-37884.rs:6:5
    |
 LL |     fn next(&'a mut self) -> Option<Self::Item>

--- a/src/test/ui/issues/issue-37884.stderr
+++ b/src/test/ui/issues/issue-37884.stderr
@@ -11,7 +11,7 @@ LL | |     }
    |
    = note: expected fn pointer `fn(&mut RepeatMut<'a, T>) -> Option<_>`
               found fn pointer `fn(&'a mut RepeatMut<'a, T>) -> Option<_>`
-note: the anonymous lifetime #1 defined here...
+note: the anonymous lifetime as defined here...
   --> $DIR/issue-37884.rs:6:5
    |
 LL |     fn next(&'a mut self) -> Option<Self::Item>

--- a/src/test/ui/lifetimes/elided-lifetime-in-path-in-pat.rs
+++ b/src/test/ui/lifetimes/elided-lifetime-in-path-in-pat.rs
@@ -1,0 +1,13 @@
+// check-pass
+
+struct Foo<'a> {
+    x: &'a (),
+}
+
+// The lifetime in pattern-position `Foo` is elided.
+// Verify that lowering does not create an independent lifetime parameter for it.
+fn foo<'a>(Foo { x }: Foo<'a>) {
+    *x
+}
+
+fn main() {}

--- a/src/test/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-using-trait-objects.stderr
+++ b/src/test/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-using-trait-objects.stderr
@@ -10,8 +10,8 @@ LL |   y.push(z);
    |
 help: consider introducing a named lifetime parameter
    |
-LL | fn foo<'a>(x:Box<dyn Fn(&'a u8, &'a u8)> , y: Vec<&u8>, z: &u8) {
-   |       ++++               ++      ++
+LL | fn foo<'a>(x:Box<dyn Fn(&u8, &u8)> , y: Vec<&'a u8>, z: &'a u8) {
+   |       ++++                                   ++          ++
 
 error[E0596]: cannot borrow `y` as mutable, as it is not declared as mutable
   --> $DIR/ex3-both-anon-regions-using-trait-objects.rs:2:3


### PR DESCRIPTION
Split from https://github.com/rust-lang/rust/pull/97720

This PR refactor lifetime generic parameters in bare function types and parenthesized traits to introduce the additional required lifetimes as fresh parameters in a `for<>` bound.

This PR does the same to lifetimes appearing in closure signatures, and as-if introducing `for<>` bounds on closures (without the associated change in semantics).

r? @petrochenkov 