### PR TITLE
Improve suggestion for calling fn-like expr on type mismatch

### DIFF
--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -856,7 +856,7 @@ pub trait PrettyPrinter<'tcx>:
                     p!(")");
                     if let Term::Ty(ty) = return_ty.skip_binder() {
                         if !ty.is_unit() {
-                            p!("-> ", print(return_ty));
+                            p!(" -> ", print(return_ty));
                         }
                     }
                     p!(write("{}", if paren_needed { ")" } else { "" }));

--- a/src/test/ui/impl-trait/suggest-calling-rpit-closure.rs
+++ b/src/test/ui/impl-trait/suggest-calling-rpit-closure.rs
@@ -1,0 +1,12 @@
+fn whatever() -> i32 {
+    opaque()
+//~^ ERROR mismatched types
+}
+
+fn opaque() -> impl Fn() -> i32 {
+    || 0
+}
+
+fn main() {
+    let _ = whatever();
+}

--- a/src/test/ui/impl-trait/suggest-calling-rpit-closure.stderr
+++ b/src/test/ui/impl-trait/suggest-calling-rpit-closure.stderr
@@ -1,0 +1,21 @@
+error[E0308]: mismatched types
+  --> $DIR/suggest-calling-rpit-closure.rs:2:5
+   |
+LL | fn whatever() -> i32 {
+   |                  --- expected `i32` because of return type
+LL |     opaque()
+   |     ^^^^^^^^ expected `i32`, found opaque type
+...
+LL | fn opaque() -> impl Fn() -> i32 {
+   |                ---------------- the found opaque type
+   |
+   = note:     expected type `i32`
+           found opaque type `impl Fn() -> i32`
+help: use parentheses to call this closure
+   |
+LL |     opaque()()
+   |             ++
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/parser/expr-as-stmt.stderr
+++ b/src/test/ui/parser/expr-as-stmt.stderr
@@ -201,6 +201,10 @@ LL |     { true } || { true }
    |
    = note: expected type `bool`
            found closure `[closure@$DIR/expr-as-stmt.rs:51:14: 51:25]`
+help: use parentheses to call this closure
+   |
+LL |     { true } (|| { true })()
+   |              +           +++
 help: parentheses are required to parse this as an expression
    |
 LL |     ({ true }) || { true }

--- a/src/test/ui/parser/struct-literal-restrictions-in-lamda.stderr
+++ b/src/test/ui/parser/struct-literal-restrictions-in-lamda.stderr
@@ -25,6 +25,12 @@ LL | |     }.hi() {
    |
    = note: expected type `bool`
            found closure `[closure@$DIR/struct-literal-restrictions-in-lamda.rs:12:11: 14:11]`
+help: use parentheses to call this closure
+   |
+LL ~     while (|| Foo {
+LL |         x: 3
+LL ~     }.hi())() {
+   |
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/reify-intrinsic.stderr
+++ b/src/test/ui/reify-intrinsic.stderr
@@ -8,10 +8,6 @@ LL |     let _: unsafe extern "rust-intrinsic" fn(isize) -> usize = std::mem::tr
    |
    = note: expected fn pointer `unsafe extern "rust-intrinsic" fn(isize) -> usize`
                  found fn item `unsafe extern "rust-intrinsic" fn(_) -> _ {transmute::<_, _>}`
-help: use parentheses to call this function
-   |
-LL |     let _: unsafe extern "rust-intrinsic" fn(isize) -> usize = std::mem::transmute(...);
-   |                                                                                   +++++
 
 error[E0606]: casting `unsafe extern "rust-intrinsic" fn(_) -> _ {transmute::<_, _>}` as `unsafe extern "rust-intrinsic" fn(isize) -> usize` is invalid
   --> $DIR/reify-intrinsic.rs:11:13

--- a/src/test/ui/rfc-2497-if-let-chains/disallowed-positions.stderr
+++ b/src/test/ui/rfc-2497-if-let-chains/disallowed-positions.stderr
@@ -1118,6 +1118,10 @@ LL |     if let Range { start: F, end } = F..|| true {}
    |
    = note: expected type `bool`
            found closure `[closure@$DIR/disallowed-positions.rs:136:41: 136:48]`
+help: use parentheses to call this closure
+   |
+LL |     if let Range { start: F, end } = F..(|| true)() {}
+   |                                         +       +++
 
 error[E0308]: mismatched types
   --> $DIR/disallowed-positions.rs:136:8
@@ -1314,6 +1318,10 @@ LL |     while let Range { start: F, end } = F..|| true {}
    |
    = note: expected type `bool`
            found closure `[closure@$DIR/disallowed-positions.rs:200:44: 200:51]`
+help: use parentheses to call this closure
+   |
+LL |     while let Range { start: F, end } = F..(|| true)() {}
+   |                                            +       +++
 
 error[E0308]: mismatched types
   --> $DIR/disallowed-positions.rs:200:11

--- a/src/test/ui/span/move-closure.stderr
+++ b/src/test/ui/span/move-closure.stderr
@@ -8,6 +8,10 @@ LL |     let x: () = move || ();
    |
    = note: expected unit type `()`
                 found closure `[closure@$DIR/move-closure.rs:5:17: 5:27]`
+help: use parentheses to call this closure
+   |
+LL |     let x: () = (move || ())();
+   |                 +          +++
 
 error: aborting due to previous error
 

--- a/src/test/ui/suggestions/fn-or-tuple-struct-without-args.stderr
+++ b/src/test/ui/suggestions/fn-or-tuple-struct-without-args.stderr
@@ -33,7 +33,7 @@ LL |     let _: usize = foo;
            found fn item `fn(usize, usize) -> usize {foo}`
 help: use parentheses to call this function
    |
-LL |     let _: usize = foo(a, b);
+LL |     let _: usize = foo(_, _);
    |                       ++++++
 
 error[E0308]: mismatched types
@@ -105,7 +105,7 @@ LL |     let _: usize = T::baz;
            found fn item `fn(usize, usize) -> usize {<_ as T>::baz}`
 help: use parentheses to call this function
    |
-LL |     let _: usize = T::baz(x, y);
+LL |     let _: usize = T::baz(_, _);
    |                          ++++++
 
 error[E0308]: mismatched types
@@ -123,7 +123,7 @@ LL |     let _: usize = T::bat;
            found fn item `fn(usize) -> usize {<_ as T>::bat}`
 help: use parentheses to call this function
    |
-LL |     let _: usize = T::bat(x);
+LL |     let _: usize = T::bat(_);
    |                          +++
 
 error[E0308]: mismatched types
@@ -159,7 +159,7 @@ LL |     let _: usize = X::baz;
            found fn item `fn(usize, usize) -> usize {<X as T>::baz}`
 help: use parentheses to call this function
    |
-LL |     let _: usize = X::baz(x, y);
+LL |     let _: usize = X::baz(_, _);
    |                          ++++++
 
 error[E0308]: mismatched types
@@ -177,7 +177,7 @@ LL |     let _: usize = X::bat;
            found fn item `fn(usize) -> usize {<X as T>::bat}`
 help: use parentheses to call this function
    |
-LL |     let _: usize = X::bat(x);
+LL |     let _: usize = X::bat(_);
    |                          +++
 
 error[E0308]: mismatched types
@@ -195,7 +195,7 @@ LL |     let _: usize = X::bax;
            found fn item `fn(usize) -> usize {<X as T>::bax}`
 help: use parentheses to call this function
    |
-LL |     let _: usize = X::bax(x);
+LL |     let _: usize = X::bax(_);
    |                          +++
 
 error[E0308]: mismatched types
@@ -213,7 +213,7 @@ LL |     let _: usize = X::bach;
            found fn item `fn(usize) -> usize {<X as T>::bach}`
 help: use parentheses to call this function
    |
-LL |     let _: usize = X::bach(x);
+LL |     let _: usize = X::bach(_);
    |                           +++
 
 error[E0308]: mismatched types

--- a/src/test/ui/type-alias-impl-trait/issue-63279.stderr
+++ b/src/test/ui/type-alias-impl-trait/issue-63279.stderr
@@ -15,6 +15,10 @@ LL |     || -> Closure { || () }
    |
    = note: expected unit type `()`
                 found closure `[closure@$DIR/issue-63279.rs:8:21: 8:26]`
+help: use parentheses to call this closure
+   |
+LL |     || -> Closure { (|| ())() }
+   |                     +     +++
 
 error[E0308]: mismatched types
   --> $DIR/issue-63279.rs:8:5


### PR DESCRIPTION
1.) Suggest calling values of with RPIT types (and probably TAIT) when we expect `Ty` and have `impl Fn() -> Ty`
2.) Suggest calling closures even when they're not assigned to a local variable first
3.) Drive-by fix of a pretty-printing bug (`impl Fn()-> Ty` => `impl Fn() -> Ty`)

r? @estebank