### PR TITLE
Rebase LLVM submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -34,7 +34,7 @@
 [submodule "src/llvm-project"]
 	path = src/llvm-project
 	url = https://github.com/rust-lang/llvm-project.git
-	branch = rustc/14.0-2022-03-22
+	branch = rustc/14.0-2022-06-20
 [submodule "src/doc/embedded-book"]
 	path = src/doc/embedded-book
 	url = https://github.com/rust-embedded/book.git


### PR DESCRIPTION
This is a rebase of our LLVM fork onto LLVM 14.0.5, which is intended to be the last release of the 14.x series. Additionally:

 * I've dropped three patches that were needed to build on FreeBSD 11, which is no longer necessary after #97944.
 * I've dropped some cherry-picks that were later reverted.
 * I've cherry-picked https://github.com/llvm/llvm-project/commit/caa2a829cdf905a5e8664d96a464d414b2adb42e for https://github.com/rust-lang/rust/issues/96797 (fyi @Amanieu)