### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/compiler/rustc_typeck/src/hir_wf_check.rs
+++ b/compiler/rustc_typeck/src/hir_wf_check.rs
@@ -1,7 +1,7 @@
 use crate::collect::ItemCtxt;
 use rustc_hir as hir;
 use rustc_hir::intravisit::{self, Visitor};
-use rustc_hir::HirId;
+use rustc_hir::{ForeignItem, ForeignItemKind, HirId};
 use rustc_infer::infer::TyCtxtInferExt;
 use rustc_infer::traits::TraitEngine;
 use rustc_infer::traits::{ObligationCause, WellFormedLoc};
@@ -141,6 +141,9 @@ fn diagnostic_hir_wf_check<'tcx>(
                 ref item => bug!("Unexpected item {:?}", item),
             },
             hir::Node::Field(field) => Some(field.ty),
+            hir::Node::ForeignItem(ForeignItem {
+                kind: ForeignItemKind::Static(ty, _), ..
+            }) => Some(*ty),
             ref node => bug!("Unexpected node {:?}", node),
         },
         WellFormedLoc::Param { function: _, param_idx } => {

--- a/library/alloc/src/rc.rs
+++ b/library/alloc/src/rc.rs
@@ -1241,8 +1241,6 @@ impl<T: Clone> Rc<T> {
 }
 
 impl Rc<dyn Any> {
-    #[inline]
-    #[stable(feature = "rc_downcast", since = "1.29.0")]
     /// Attempt to downcast the `Rc<dyn Any>` to a concrete type.
     ///
     /// # Examples
@@ -1261,6 +1259,8 @@ impl Rc<dyn Any> {
     /// print_if_string(Rc::new(my_string));
     /// print_if_string(Rc::new(0i8));
     /// ```
+    #[inline]
+    #[stable(feature = "rc_downcast", since = "1.29.0")]
     pub fn downcast<T: Any>(self) -> Result<Rc<T>, Rc<dyn Any>> {
         if (*self).is::<T>() {
             unsafe {
@@ -1270,6 +1270,42 @@ impl Rc<dyn Any> {
             }
         } else {
             Err(self)
+        }
+    }
+
+    /// Downcasts the `Rc<dyn Any>` to a concrete type.
+    ///
+    /// For a safe alternative see [`downcast`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(downcast_unchecked)]
+    ///
+    /// use std::any::Any;
+    /// use std::rc::Rc;
+    ///
+    /// let x: Rc<dyn Any> = Rc::new(1_usize);
+    ///
+    /// unsafe {
+    ///     assert_eq!(*x.downcast_unchecked::<usize>(), 1);
+    /// }
+    /// ```
+    ///
+    /// # Safety
+    ///
+    /// The contained value must be of type `T`. Calling this method
+    /// with the incorrect type is *undefined behavior*.
+    ///
+    ///
+    /// [`downcast`]: Self::downcast
+    #[inline]
+    #[unstable(feature = "downcast_unchecked", issue = "90850")]
+    pub unsafe fn downcast_unchecked<T: Any>(self) -> Rc<T> {
+        unsafe {
+            let ptr = self.ptr.cast::<RcBox<T>>();
+            mem::forget(self);
+            Rc::from_inner(ptr)
         }
     }
 }

--- a/library/core/src/pin.rs
+++ b/library/core/src/pin.rs
@@ -1006,9 +1006,10 @@ impl<P, U> DispatchFromDyn<Pin<U>> for Pin<P> where P: DispatchFromDyn<U> {}
 ///  // Allow generator to be self-referential (not `Unpin`)
 ///  // vvvvvv        so that locals can cross yield points.
 ///     static || {
-///         let foo = String::from("foo"); // --+
-///         yield 0;                         // | <- crosses yield point!
-///         println!("{}", &foo); // <----------+
+///         let foo = String::from("foo");
+///         let foo_ref = &foo; // ------+
+///         yield 0;                  // | <- crosses yield point!
+///         println!("{foo_ref}"); // <--+
 ///         yield foo.len();
 ///     }
 /// }

--- a/library/core/src/slice/iter.rs
+++ b/library/core/src/slice/iter.rs
@@ -315,7 +315,7 @@ impl<'a, T> IterMut<'a, T> {
     /// Basic usage:
     ///
     /// ```
-    /// # #![feature(slice_iter_mut_as_mut_slice)]
+    /// #![feature(slice_iter_mut_as_mut_slice)]
     ///
     /// let mut slice: &mut [usize] = &mut [1, 2, 3];
     ///

--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -1085,6 +1085,10 @@ impl<'a> IoSliceMut<'a> {
     /// Also see [`IoSliceMut::advance_slices`] to advance the cursors of
     /// multiple buffers.
     ///
+    /// # Panics
+    ///
+    /// Panics when trying to advance beyond the end of the slice.
+    ///
     /// # Examples
     ///
     /// ```
@@ -1106,15 +1110,18 @@ impl<'a> IoSliceMut<'a> {
         self.0.advance(n)
     }
 
-    /// Advance the internal cursor of the slices.
+    /// Advance a slice of slices.
     ///
-    /// # Notes
+    /// Shrinks the slice to remove any `IoSliceMut`s that are fully advanced over.
+    /// If the cursor ends up in the middle of an `IoSliceMut`, it is modified
+    /// to start at that cursor.
     ///
-    /// Elements in the slice may be modified if the cursor is not advanced to
-    /// the end of the slice. For example if we have a slice of buffers with 2
-    /// `IoSliceMut`s, both of length 8, and we advance the cursor by 10 bytes
-    /// the first `IoSliceMut` will be untouched however the second will be
-    /// modified to remove the first 2 bytes (10 - 8).
+    /// For example, if we have a slice of two 8-byte `IoSliceMut`s, and we advance by 10 bytes,
+    /// the result will only include the second `IoSliceMut`, advanced by 2 bytes.
+    ///
+    /// # Panics
+    ///
+    /// Panics when trying to advance beyond the end of the slices.
     ///
     /// # Examples
     ///
@@ -1222,6 +1229,10 @@ impl<'a> IoSlice<'a> {
     /// Also see [`IoSlice::advance_slices`] to advance the cursors of multiple
     /// buffers.
     ///
+    /// # Panics
+    ///
+    /// Panics when trying to advance beyond the end of the slice.
+    ///
     /// # Examples
     ///
     /// ```
@@ -1243,15 +1254,18 @@ impl<'a> IoSlice<'a> {
         self.0.advance(n)
     }
 
-    /// Advance the internal cursor of the slices.
+    /// Advance a slice of slices.
     ///
-    /// # Notes
+    /// Shrinks the slice to remove any `IoSlice`s that are fully advanced over.
+    /// If the cursor ends up in the middle of an `IoSlice`, it is modified
+    /// to start at that cursor.
     ///
-    /// Elements in the slice may be modified if the cursor is not advanced to
-    /// the end of the slice. For example if we have a slice of buffers with 2
-    /// `IoSlice`s, both of length 8, and we advance the cursor by 10 bytes the
-    /// first `IoSlice` will be untouched however the second will be modified to
-    /// remove the first 2 bytes (10 - 8).
+    /// For example, if we have a slice of two 8-byte `IoSlice`s, and we advance by 10 bytes,
+    /// the result will only include the second `IoSlice`, advanced by 2 bytes.
+    ///
+    /// # Panics
+    ///
+    /// Panics when trying to advance beyond the end of the slices.
     ///
     /// # Examples
     ///

--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -1155,7 +1155,9 @@ impl<'a> IoSliceMut<'a> {
         }
 
         *bufs = &mut replace(bufs, &mut [])[remove..];
-        if !bufs.is_empty() {
+        if bufs.is_empty() {
+            assert!(n == accumulated_len, "advancing io slices beyond their length");
+        } else {
             bufs[0].advance(n - accumulated_len)
         }
     }
@@ -1289,7 +1291,9 @@ impl<'a> IoSlice<'a> {
         }
 
         *bufs = &mut replace(bufs, &mut [])[remove..];
-        if !bufs.is_empty() {
+        if bufs.is_empty() {
+            assert!(n == accumulated_len, "advancing io slices beyond their length");
+        } else {
             bufs[0].advance(n - accumulated_len)
         }
     }

--- a/library/std/src/io/tests.rs
+++ b/library/std/src/io/tests.rs
@@ -423,18 +423,18 @@ fn io_slice_mut_advance_slices() {
 }
 
 #[test]
+#[should_panic]
 fn io_slice_mut_advance_slices_empty_slice() {
     let mut empty_bufs = &mut [][..];
-    // Shouldn't panic.
     IoSliceMut::advance_slices(&mut empty_bufs, 1);
 }
 
 #[test]
+#[should_panic]
 fn io_slice_mut_advance_slices_beyond_total_length() {
     let mut buf1 = [1; 8];
     let mut bufs = &mut [IoSliceMut::new(&mut buf1)][..];
 
-    // Going beyond the total length should be ok.
     IoSliceMut::advance_slices(&mut bufs, 9);
     assert!(bufs.is_empty());
 }
@@ -463,18 +463,18 @@ fn io_slice_advance_slices() {
 }
 
 #[test]
+#[should_panic]
 fn io_slice_advance_slices_empty_slice() {
     let mut empty_bufs = &mut [][..];
-    // Shouldn't panic.
     IoSlice::advance_slices(&mut empty_bufs, 1);
 }
 
 #[test]
+#[should_panic]
 fn io_slice_advance_slices_beyond_total_length() {
     let buf1 = [1; 8];
     let mut bufs = &mut [IoSlice::new(&buf1)][..];
 
-    // Going beyond the total length should be ok.
     IoSlice::advance_slices(&mut bufs, 9);
     assert!(bufs.is_empty());
 }

--- a/library/std/src/os/unix/io/mod.rs
+++ b/library/std/src/os/unix/io/mod.rs
@@ -52,8 +52,8 @@
 //! and writes happen outside the control of the Rust compiler, so they do not
 //! uphold Rust's memory safety guarantees.
 //!
-//! Does this mean that all APIs that might allow `/proc/self/mem` to be opened
-//! and read from or written to must be `unsafe`? No. Rust's safety guarantees
+//! However, this does not mean that all APIs that might allow `/proc/self/mem`
+//! to be opened and read from or written must be `unsafe`. Rust's safety guarantees
 //! only cover what the program itself can do, and not what entities outside
 //! the program can do to it. `/proc/self/mem` is considered to be such an
 //! external entity, along with debugging interfaces, and people with physical access to

--- a/library/std/src/os/unix/io/mod.rs
+++ b/library/std/src/os/unix/io/mod.rs
@@ -44,14 +44,14 @@
 //! Like boxes, `OwnedFd` values conceptually own the resource they point to,
 //! and free (close) it when they are dropped.
 //!
-//! ## What about `/proc/self/mem` and similar OS features?
+//! ## `/proc/self/mem` and similar OS features
 //!
 //! Some platforms have special files, such as `/proc/self/mem`, which 
 //! provide read and write access to the process's memory. Such reads
 //! and writes happen outside the control of the Rust compiler, so they do not
 //! uphold Rust's memory safety guarantees.
 //!
-//! However, this does not mean that all APIs that might allow `/proc/self/mem`
+//! This does not mean that all APIs that might allow `/proc/self/mem`
 //! to be opened and read from or written must be `unsafe`. Rust's safety guarantees
 //! only cover what the program itself can do, and not what entities outside
 //! the program can do to it. `/proc/self/mem` is considered to be such an

--- a/library/std/src/os/unix/io/mod.rs
+++ b/library/std/src/os/unix/io/mod.rs
@@ -46,7 +46,7 @@
 //!
 //! ## What about `/proc/self/mem` and similar OS features?
 //!
-//! Some platforms have a feature known as `/proc/self/mem`, which is a
+//! Some platforms have special files, such as `/proc/self/mem`, which is a
 //! filesystem path that can be opened, producing a file descriptor that, when
 //! read from or written to, reads and writes the process's memory. These reads
 //! and writes happen outside the control of the Rust compiler, so they do not

--- a/library/std/src/os/unix/io/mod.rs
+++ b/library/std/src/os/unix/io/mod.rs
@@ -56,7 +56,7 @@
 //! and read from or written to must be `unsafe`? No. Rust's safety guarantees
 //! only cover what the program itself can do, and not what entities outside
 //! the program can do to it. `/proc/self/mem` is considered to be such an
-//! external entity, along with debugggers and people with physical access to
+//! external entity, along with debuggers and people with physical access to
 //! the hardware. This is true even in cases where the program is controling
 //! the external entity.
 //!

--- a/library/std/src/os/unix/io/mod.rs
+++ b/library/std/src/os/unix/io/mod.rs
@@ -44,6 +44,26 @@
 //! Like boxes, `OwnedFd` values conceptually own the resource they point to,
 //! and free (close) it when they are dropped.
 //!
+//! ## What about `/proc/self/mem` and similar OS features?
+//!
+//! Some platforms have a feature known as `/proc/self/mem`, which is a
+//! filesystem path that can be opened, producing a file descriptor that, when
+//! read from or written to, reads and writes the process's memory. These reads
+//! and writes happen outside the control of the Rust compiler, so they do not
+//! uphold Rust's memory safety guarantees.
+//!
+//! Does this mean that all APIs that might allow `/proc/self/mem` to be opened
+//! and read from or written to must be `unsafe`? No. Rust's safety guarantees
+//! only cover what the program itself can do, and not what entities outside
+//! the program can do to it. `/proc/self/mem` is considered to be such an
+//! external entity, along with debugggers and people with physical access to
+//! the hardware. This is true even in cases where the program is controling
+//! the external entity.
+//!
+//! If you desire to comprehensively prevent programs from reaching out and
+//! causing external entities to reach back in and violate memory safety, it's
+//! necessary to use *sandboxing*, which is outside the scope of `std`.
+//!
 //! [`BorrowedFd<'a>`]: crate::os::unix::io::BorrowedFd
 
 #![stable(feature = "rust1", since = "1.0.0")]

--- a/library/std/src/os/unix/io/mod.rs
+++ b/library/std/src/os/unix/io/mod.rs
@@ -56,7 +56,7 @@
 //! and read from or written to must be `unsafe`? No. Rust's safety guarantees
 //! only cover what the program itself can do, and not what entities outside
 //! the program can do to it. `/proc/self/mem` is considered to be such an
-//! external entity, along with debuggers and people with physical access to
+//! external entity, along with debugging interfaces, and people with physical access to
 //! the hardware. This is true even in cases where the program is controlling
 //! the external entity.
 //!

--- a/library/std/src/os/unix/io/mod.rs
+++ b/library/std/src/os/unix/io/mod.rs
@@ -57,7 +57,7 @@
 //! only cover what the program itself can do, and not what entities outside
 //! the program can do to it. `/proc/self/mem` is considered to be such an
 //! external entity, along with debuggers and people with physical access to
-//! the hardware. This is true even in cases where the program is controling
+//! the hardware. This is true even in cases where the program is controlling
 //! the external entity.
 //!
 //! If you desire to comprehensively prevent programs from reaching out and

--- a/library/std/src/os/unix/io/mod.rs
+++ b/library/std/src/os/unix/io/mod.rs
@@ -46,9 +46,8 @@
 //!
 //! ## What about `/proc/self/mem` and similar OS features?
 //!
-//! Some platforms have special files, such as `/proc/self/mem`, which is a
-//! filesystem path that can be opened, producing a file descriptor that, when
-//! read from or written to, reads and writes the process's memory. These reads
+//! Some platforms have special files, such as `/proc/self/mem`, which 
+//! provide read and write access to the process's memory. Such reads
 //! and writes happen outside the control of the Rust compiler, so they do not
 //! uphold Rust's memory safety guarantees.
 //!

--- a/library/std/src/os/unix/io/mod.rs
+++ b/library/std/src/os/unix/io/mod.rs
@@ -46,7 +46,7 @@
 //!
 //! ## `/proc/self/mem` and similar OS features
 //!
-//! Some platforms have special files, such as `/proc/self/mem`, which 
+//! Some platforms have special files, such as `/proc/self/mem`, which
 //! provide read and write access to the process's memory. Such reads
 //! and writes happen outside the control of the Rust compiler, so they do not
 //! uphold Rust's memory safety guarantees.

--- a/library/std/src/process.rs
+++ b/library/std/src/process.rs
@@ -1273,6 +1273,22 @@ impl Stdio {
     pub fn null() -> Stdio {
         Stdio(imp::Stdio::Null)
     }
+
+    /// Returns `true` if this requires [`Command`] to create a new pipe.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// #![feature(stdio_makes_pipe)]
+    /// use std::process::Stdio;
+    ///
+    /// let io = Stdio::piped();
+    /// assert_eq!(io.makes_pipe(), true);
+    /// ```
+    #[unstable(feature = "stdio_makes_pipe", issue = "98288")]
+    pub fn makes_pipe(&self) -> bool {
+        matches!(self.0, imp::Stdio::MakePipe)
+    }
 }
 
 impl FromInner<imp::Stdio> for Stdio {

--- a/src/test/ui/wf/issue-95665.rs
+++ b/src/test/ui/wf/issue-95665.rs
@@ -1,0 +1,18 @@
+// Regression test for the ICE described in #95665.
+// Ensure that the expected error is output (and thus that there is no ICE)
+
+pub trait Trait: {}
+
+pub struct Struct<T: Trait> {
+    member: T,
+}
+
+// uncomment and bug goes away
+// impl Trait for u8 {}
+
+extern "C" {
+    static VAR: Struct<u8>;
+                //~^ 14:17: 14:27: the trait bound `u8: Trait` is not satisfied [E0277]
+}
+
+fn main() {}

--- a/src/test/ui/wf/issue-95665.stderr
+++ b/src/test/ui/wf/issue-95665.stderr
@@ -1,0 +1,15 @@
+error[E0277]: the trait bound `u8: Trait` is not satisfied
+  --> $DIR/issue-95665.rs:14:17
+   |
+LL |     static VAR: Struct<u8>;
+   |                 ^^^^^^^^^^ the trait `Trait` is not implemented for `u8`
+   |
+note: required by a bound in `Struct`
+  --> $DIR/issue-95665.rs:6:22
+   |
+LL | pub struct Struct<T: Trait> {
+   |                      ^^^^^ required by this bound in `Struct`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
Successful merges:

 - #93080 (Implement `core::slice::IterMut::as_mut_slice` and `impl<T> AsMut<[T]> for IterMut<'_, T>`)
 - #94855 (Panic when advance_slices()'ing too far and update docs.)
 - #96609 (Add `{Arc, Rc}::downcast_unchecked`)
 - #96719 (Fix the generator example for `pin!()`)
 - #97149 (Windows: `CommandExt::async_pipes`)
 - #97150 (`Stdio::makes_pipe`)
 - #97837 (Document Rust's stance on `/proc/self/mem`)
 - #98159 (Include ForeignItem when visiting types for WF check)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=93080,94855,96609,96719,97149,97150,97837,98159)
<!-- homu-ignore:end -->