### PR TITLE
Add a link to the unstable book page on Generator doc comment

### DIFF
--- a/library/core/src/ops/generator.rs
+++ b/library/core/src/ops/generator.rs
@@ -61,9 +61,10 @@ pub enum GeneratorState<Y, R> {
 /// }
 /// ```
 ///
-/// More documentation of generators can be found in the unstable book.
+/// More documentation of generators can be found in the [unstable book].
 ///
 /// [RFC 2033]: https://github.com/rust-lang/rfcs/pull/2033
+/// [unstable book]: ../../unstable-book/language-features/generators.html
 #[lang = "generator"]
 #[unstable(feature = "generator_trait", issue = "43122")]
 #[fundamental]


### PR DESCRIPTION
This makes it easier to jump into the Generator section on the unstable book.

Signed-off-by: Yuki Okushi <jtitor@2k36.org>