### PR TITLE
Add GDB/LLDB pretty-printers for NonZero types

### DIFF
--- a/src/etc/gdb_lookup.py
+++ b/src/etc/gdb_lookup.py
@@ -89,4 +89,7 @@ def lookup(valobj):
     if rust_type == RustType.STD_REF_CELL:
         return StdRefCellProvider(valobj)
 
+    if rust_type == RustType.STD_NONZERO_NUMBER:
+        return StdNonZeroNumberProvider(valobj)
+
     return None

--- a/src/etc/gdb_providers.py
+++ b/src/etc/gdb_providers.py
@@ -231,6 +231,17 @@ class StdRefCellProvider:
         yield "borrow", self.borrow
 
 
+class StdNonZeroNumberProvider:
+    def __init__(self, valobj):
+        fields = valobj.type.fields()
+        assert len(fields) == 1
+        field = list(fields)[0]
+        self.value = str(valobj[field.name])
+
+    def to_string(self):
+        return self.value
+
+
 # Yields children (in a provider's sense of the word) for a BTreeMap.
 def children_of_btree_map(map):
     # Yields each key/value pair in the node and in any child nodes.

--- a/src/etc/lldb_commands
+++ b/src/etc/lldb_commands
@@ -15,4 +15,5 @@ type summary add -F lldb_lookup.summary_lookup  -e -x -h "^(core::([a-z_]+::)+)C
 type summary add -F lldb_lookup.summary_lookup  -e -x -h "^(core::([a-z_]+::)+)Ref<.+>$" --category Rust
 type summary add -F lldb_lookup.summary_lookup  -e -x -h "^(core::([a-z_]+::)+)RefMut<.+>$" --category Rust
 type summary add -F lldb_lookup.summary_lookup  -e -x -h "^(core::([a-z_]+::)+)RefCell<.+>$" --category Rust
+type summary add -F lldb_lookup.summary_lookup  -e -x -h "^core::num::([a-z_]+::)*NonZero.+$" --category Rust
 type category enable Rust

--- a/src/etc/lldb_lookup.py
+++ b/src/etc/lldb_lookup.py
@@ -55,6 +55,9 @@ def summary_lookup(valobj, dict):
     if rust_type == RustType.STD_REF_CELL:
         return StdRefSummaryProvider(valobj, dict)
 
+    if rust_type == RustType.STD_NONZERO_NUMBER:
+        return StdNonZeroNumberSummaryProvider(valobj, dict)
+
     return ""
 
 

--- a/src/etc/lldb_providers.py
+++ b/src/etc/lldb_providers.py
@@ -739,3 +739,11 @@ class StdRefSyntheticProvider:
     def has_children(self):
         # type: () -> bool
         return True
+
+
+def StdNonZeroNumberSummaryProvider(valobj, _dict):
+    # type: (SBValue, dict) -> str
+    objtype = valobj.GetType()
+    field = objtype.GetFieldAtIndex(0)
+    element = valobj.GetChildMemberWithName(field.name)
+    return element.GetValue()

--- a/src/etc/rust_types.py
+++ b/src/etc/rust_types.py
@@ -31,6 +31,7 @@ class RustType(object):
     STD_REF = "StdRef"
     STD_REF_MUT = "StdRefMut"
     STD_REF_CELL = "StdRefCell"
+    STD_NONZERO_NUMBER = "StdNonZeroNumber"
 
 
 STD_STRING_REGEX = re.compile(r"^(alloc::(\w+::)+)String$")
@@ -49,6 +50,7 @@ STD_CELL_REGEX = re.compile(r"^(core::(\w+::)+)Cell<.+>$")
 STD_REF_REGEX = re.compile(r"^(core::(\w+::)+)Ref<.+>$")
 STD_REF_MUT_REGEX = re.compile(r"^(core::(\w+::)+)RefMut<.+>$")
 STD_REF_CELL_REGEX = re.compile(r"^(core::(\w+::)+)RefCell<.+>$")
+STD_NONZERO_NUMBER_REGEX = re.compile(r"^core::num::([a-z_]+::)*NonZero.+$")
 
 TUPLE_ITEM_REGEX = re.compile(r"__\d+$")
 
@@ -72,6 +74,7 @@ STD_TYPE_TO_REGEX = {
     RustType.STD_REF_MUT: STD_REF_MUT_REGEX,
     RustType.STD_REF_CELL: STD_REF_CELL_REGEX,
     RustType.STD_CELL: STD_CELL_REGEX,
+    RustType.STD_NONZERO_NUMBER: STD_NONZERO_NUMBER_REGEX,
 }
 
 def is_tuple_fields(fields):

--- a/src/test/debuginfo/numeric-types.rs
+++ b/src/test/debuginfo/numeric-types.rs
@@ -1,5 +1,6 @@
-// only-cdb
 // compile-flags:-g
+
+// min-gdb-version: 8.1
 
 // Tests the visualizations for `NonZero{I,U}{8,16,32,64,128,size}`, `Wrapping<T>` and
 // `Atomic{Bool,I8,I16,I32,I64,Isize,U8,U16,U32,U64,Usize}` located in `libcore.natvis`.
@@ -152,6 +153,90 @@
 // cdb-command: dx a_usize
 // cdb-check:a_usize          : 0x400 [Type: core::sync::atomic::AtomicUsize]
 // cdb-check:    [<Raw View>]     [Type: core::sync::atomic::AtomicUsize]
+
+
+// === GDB TESTS ===================================================================================
+
+// gdb-command:run
+
+// gdb-command:print/d nz_i8
+// gdb-check:[...]$1 = 11
+
+// gdb-command:print nz_i16
+// gdb-check:[...]$2 = 22
+
+// gdb-command:print nz_i32
+// gdb-check:[...]$3 = 33
+
+// gdb-command:print nz_i64
+// gdb-check:[...]$4 = 44
+
+// gdb-command:print nz_i128
+// gdb-check:[...]$5 = 55
+
+// gdb-command:print nz_isize
+// gdb-check:[...]$6 = 66
+
+// gdb-command:print/d nz_u8
+// gdb-check:[...]$7 = 77
+
+// gdb-command:print nz_u16
+// gdb-check:[...]$8 = 88
+
+// gdb-command:print nz_u32
+// gdb-check:[...]$9 = 99
+
+// gdb-command:print nz_u64
+// gdb-check:[...]$10 = 100
+
+// gdb-command:print nz_u128
+// gdb-check:[...]$11 = 111
+
+// gdb-command:print nz_usize
+// gdb-check:[...]$12 = 122
+
+
+
+// === LLDB TESTS ==================================================================================
+
+// lldb-command:run
+
+// lldb-command:print/d nz_i8
+// lldb-check:[...]$0 = 11 { __0 = 11 }
+
+// lldb-command:print nz_i16
+// lldb-check:[...]$1 = 22 { __0 = 22 }
+
+// lldb-command:print nz_i32
+// lldb-check:[...]$2 = 33 { __0 = 33 }
+
+// lldb-command:print nz_i64
+// lldb-check:[...]$3 = 44 { __0 = 44 }
+
+// lldb-command:print nz_i128
+// lldb-check:[...]$4 = 55 { __0 = 55 }
+
+// lldb-command:print nz_isize
+// lldb-check:[...]$5 = 66 { __0 = 66 }
+
+// lldb-command:print/d nz_u8
+// lldb-check:[...]$6 = 77 { __0 = 77 }
+
+// lldb-command:print nz_u16
+// lldb-check:[...]$7 = 88 { __0 = 88 }
+
+// lldb-command:print nz_u32
+// lldb-check:[...]$8 = 99 { __0 = 99 }
+
+// lldb-command:print nz_u64
+// lldb-check:[...]$9 = 100 { __0 = 100 }
+
+// lldb-command:print nz_u128
+// lldb-check:[...]$10 = 111 { __0 = 111 }
+
+// lldb-command:print nz_usize
+// lldb-check:[...]$11 = 122 { __0 = 122 }
+
 
 use std::num::*;
 use std::sync::atomic::*;

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -1094,6 +1094,7 @@ impl<'test> TestCx<'test> {
             "^(core::([a-z_]+::)+)Ref<.+>$",
             "^(core::([a-z_]+::)+)RefMut<.+>$",
             "^(core::([a-z_]+::)+)RefCell<.+>$",
+            "^core::num::([a-z_]+::)*NonZero.+$",
         ];
 
         script_str


### PR DESCRIPTION
Add GDB/LLDB pretty-printers for `NonZero` types.
These pretty-printers were originally implemented for IntelliJ Rust by @Kobzol in https://github.com/intellij-rust/intellij-rust/pull/5270.

Part of #29392.