### PR TITLE
Emscripten: Drop -lc the emcc driver will add it when it is needed

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/linker.rs
+++ b/compiler/rustc_codegen_ssa/src/back/linker.rs
@@ -1048,6 +1048,10 @@ impl<'a> Linker for EmLinker<'a> {
     }
 
     fn link_staticlib(&mut self, lib: Symbol, _verbatim: bool) {
+        //  remove -lc: the compiler driver emcc will add it if its needed.
+        if lib.as_str() == "c" {
+            return;
+        }
         self.cmd.arg("-l").sym_arg(lib);
     }
 


### PR DESCRIPTION
According to @sbc100, when linking with emcc we shouldn't pass -lc:

> your best bet is to remove any/all explicit additions of -lc, since
> the compiler driver (emcc) will add it if/when its needed.
> (I don't think this is an emscripten bug BTW, but a rustc driver bug)

https://github.com/emscripten-core/emscripten/issues/17191#issuecomment-1151607689

Resolves #98155.