### PR TITLE
`try_fold_unevaluated` for infallible folders

### DIFF
--- a/compiler/rustc_middle/src/ty/fold.rs
+++ b/compiler/rustc_middle/src/ty/fold.rs
@@ -371,6 +371,13 @@ where
         Ok(self.fold_const(c))
     }
 
+    fn try_fold_unevaluated(
+        &mut self,
+        c: ty::Unevaluated<'tcx>,
+    ) -> Result<ty::Unevaluated<'tcx>, Self::Error> {
+        Ok(self.fold_unevaluated(c))
+    }
+
     fn try_fold_predicate(
         &mut self,
         p: ty::Predicate<'tcx>,


### PR DESCRIPTION
#97447 added folding of unevaluated constants, but did not include an override of the default (fallible) operation in the blanket impl of `FallibleTypeFolder` for infallible folders.  Here we provide that missing override.

r? @nnethercote