### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/compiler/rustc_const_eval/src/transform/check_consts/ops.rs
+++ b/compiler/rustc_const_eval/src/transform/check_consts/ops.rs
@@ -10,7 +10,8 @@ use rustc_middle::mir;
 use rustc_middle::ty::print::with_no_trimmed_paths;
 use rustc_middle::ty::subst::{GenericArgKind, SubstsRef};
 use rustc_middle::ty::{
-    suggest_constraining_type_param, Adt, Closure, FnDef, FnPtr, Param, TraitPredicate, Ty,
+    suggest_constraining_type_param, Adt, Closure, DefIdTree, FnDef, FnPtr, Param, TraitPredicate,
+    Ty,
 };
 use rustc_middle::ty::{Binder, BoundConstness, ImplPolarity, TraitRef};
 use rustc_session::parse::feature_err;
@@ -299,6 +300,15 @@ impl<'tcx> NonConstOp<'tcx> for FnCallNonConst<'tcx> {
 
                 diag_trait(&mut err, self_ty, tcx.lang_items().deref_trait().unwrap());
                 err
+            }
+            _ if tcx.opt_parent(callee) == tcx.get_diagnostic_item(sym::ArgumentV1Methods) => {
+                struct_span_err!(
+                    ccx.tcx.sess,
+                    span,
+                    E0015,
+                    "cannot call non-const formatting macro in {}s",
+                    ccx.const_kind(),
+                )
             }
             _ => struct_span_err!(
                 ccx.tcx.sess,

--- a/compiler/rustc_middle/src/mir/spanview.rs
+++ b/compiler/rustc_middle/src/mir/spanview.rs
@@ -667,7 +667,7 @@ fn trim_span_hi(span: Span, to_pos: BytePos) -> Span {
 fn fn_span<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId) -> Span {
     let fn_decl_span = tcx.def_span(def_id);
     if let Some(body_span) = hir_body(tcx, def_id).map(|hir_body| hir_body.value.span) {
-        if fn_decl_span.ctxt() == body_span.ctxt() { fn_decl_span.to(body_span) } else { body_span }
+        if fn_decl_span.eq_ctxt(body_span) { fn_decl_span.to(body_span) } else { body_span }
     } else {
         fn_decl_span
     }

--- a/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
@@ -821,16 +821,17 @@ fn non_exhaustive_match<'p, 'tcx>(
             ));
         }
         [only] => {
-            let pre_indentation = if let (Some(snippet), true) = (
-                sm.indentation_before(only.span),
-                sm.is_multiline(sp.shrink_to_hi().with_hi(only.span.lo())),
-            ) {
-                format!("\n{}", snippet)
+            let (pre_indentation, is_multiline) = if let Some(snippet) = sm.indentation_before(only.span)
+                && let Ok(with_trailing) = sm.span_extend_while(only.span, |c| c.is_whitespace() || c == ',')
+                && sm.is_multiline(with_trailing)
+            {
+                (format!("\n{}", snippet), true)
             } else {
-                " ".to_string()
+                (" ".to_string(), false)
             };
             let comma = if matches!(only.body.kind, hir::ExprKind::Block(..))
                 && only.span.eq_ctxt(only.body.span)
+                && is_multiline
             {
                 ""
             } else {

--- a/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
@@ -803,7 +803,7 @@ fn non_exhaustive_match<'p, 'tcx>(
     let mut suggestion = None;
     let sm = cx.tcx.sess.source_map();
     match arms {
-        [] if sp.ctxt() == expr_span.ctxt() => {
+        [] if sp.eq_ctxt(expr_span) => {
             // Get the span for the empty match body `{}`.
             let (indentation, more) = if let Some(snippet) = sm.indentation_before(sp) {
                 (format!("\n{}", snippet), "    ")
@@ -830,7 +830,7 @@ fn non_exhaustive_match<'p, 'tcx>(
                 " ".to_string()
             };
             let comma = if matches!(only.body.kind, hir::ExprKind::Block(..))
-                && only.span.ctxt() == only.body.span.ctxt()
+                && only.span.eq_ctxt(only.body.span)
             {
                 ""
             } else {
@@ -841,10 +841,10 @@ fn non_exhaustive_match<'p, 'tcx>(
                 format!("{}{}{} => todo!()", comma, pre_indentation, pattern),
             ));
         }
-        [.., prev, last] if prev.span.ctxt() == last.span.ctxt() => {
+        [.., prev, last] if prev.span.eq_ctxt(last.span) => {
             if let Ok(snippet) = sm.span_to_snippet(prev.span.between(last.span)) {
                 let comma = if matches!(last.body.kind, hir::ExprKind::Block(..))
-                    && last.span.ctxt() == last.body.span.ctxt()
+                    && last.span.eq_ctxt(last.body.span)
                 {
                     ""
                 } else {

--- a/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
@@ -829,7 +829,13 @@ fn non_exhaustive_match<'p, 'tcx>(
             } else {
                 " ".to_string()
             };
-            let comma = if matches!(only.body.kind, hir::ExprKind::Block(..)) { "" } else { "," };
+            let comma = if matches!(only.body.kind, hir::ExprKind::Block(..))
+                && only.span.ctxt() == only.body.span.ctxt()
+            {
+                ""
+            } else {
+                ","
+            };
             suggestion = Some((
                 only.span.shrink_to_hi(),
                 format!("{}{}{} => todo!()", comma, pre_indentation, pattern),
@@ -837,8 +843,13 @@ fn non_exhaustive_match<'p, 'tcx>(
         }
         [.., prev, last] if prev.span.ctxt() == last.span.ctxt() => {
             if let Ok(snippet) = sm.span_to_snippet(prev.span.between(last.span)) {
-                let comma =
-                    if matches!(last.body.kind, hir::ExprKind::Block(..)) { "" } else { "," };
+                let comma = if matches!(last.body.kind, hir::ExprKind::Block(..))
+                    && last.span.ctxt() == last.body.span.ctxt()
+                {
+                    ""
+                } else {
+                    ","
+                };
                 suggestion = Some((
                     last.span.shrink_to_hi(),
                     format!(

--- a/compiler/rustc_mir_transform/src/coverage/mod.rs
+++ b/compiler/rustc_mir_transform/src/coverage/mod.rs
@@ -121,7 +121,7 @@ impl<'a, 'tcx> Instrumentor<'a, 'tcx> {
 
         let source_file = source_map.lookup_source_file(body_span.lo());
         let fn_sig_span = match some_fn_sig.filter(|fn_sig| {
-            fn_sig.span.ctxt() == body_span.ctxt()
+            fn_sig.span.eq_ctxt(body_span)
                 && Lrc::ptr_eq(&source_file, &source_map.lookup_source_file(fn_sig.span.lo()))
         }) {
             Some(fn_sig) => fn_sig.span.with_hi(body_span.lo()),

--- a/compiler/rustc_mir_transform/src/coverage/spans.rs
+++ b/compiler/rustc_mir_transform/src/coverage/spans.rs
@@ -195,7 +195,7 @@ impl CoverageSpan {
             .expn_span
             .parent_callsite()
             .unwrap_or_else(|| bug!("macro must have a parent"))
-            .ctxt() == body_span.ctxt()
+            .eq_ctxt(body_span)
         {
             return Some(current_macro);
         }

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -1875,7 +1875,7 @@ impl<'a: 'ast, 'ast> LateResolutionVisitor<'a, '_, 'ast> {
         let names = rib
             .bindings
             .iter()
-            .filter(|(id, _)| id.span.ctxt() == label.span.ctxt())
+            .filter(|(id, _)| id.span.eq_ctxt(label.span))
             .map(|(id, _)| id.name)
             .collect::<Vec<Symbol>>();
 

--- a/compiler/rustc_span/src/lib.rs
+++ b/compiler/rustc_span/src/lib.rs
@@ -537,6 +537,9 @@ impl Span {
     pub fn ctxt(self) -> SyntaxContext {
         self.data_untracked().ctxt
     }
+    pub fn eq_ctxt(self, other: Span) -> bool {
+        self.data_untracked().ctxt == other.data_untracked().ctxt
+    }
     #[inline]
     pub fn with_ctxt(self, ctxt: SyntaxContext) -> Span {
         self.data_untracked().with_ctxt(ctxt)

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -131,6 +131,7 @@ symbols! {
         Arc,
         Argument,
         ArgumentV1,
+        ArgumentV1Methods,
         Arguments,
         AsMut,
         AsRef,

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1641,7 +1641,7 @@ impl Ident {
 
 impl PartialEq for Ident {
     fn eq(&self, rhs: &Self) -> bool {
-        self.name == rhs.name && self.span.ctxt() == rhs.span.ctxt()
+        self.name == rhs.name && self.span.eq_ctxt(rhs.span)
     }
 }
 

--- a/library/core/src/fmt/mod.rs
+++ b/library/core/src/fmt/mod.rs
@@ -320,6 +320,7 @@ macro_rules! arg_new {
     };
 }
 
+#[rustc_diagnostic_item = "ArgumentV1Methods"]
 impl<'a> ArgumentV1<'a> {
     #[doc(hidden)]
     #[unstable(feature = "fmt_internals", reason = "internal to format_args!", issue = "none")]

--- a/library/core/src/ops/generator.rs
+++ b/library/core/src/ops/generator.rs
@@ -61,9 +61,10 @@ pub enum GeneratorState<Y, R> {
 /// }
 /// ```
 ///
-/// More documentation of generators can be found in the unstable book.
+/// More documentation of generators can be found in the [unstable book].
 ///
 /// [RFC 2033]: https://github.com/rust-lang/rfcs/pull/2033
+/// [unstable book]: ../../unstable-book/language-features/generators.html
 #[lang = "generator"]
 #[unstable(feature = "generator_trait", issue = "43122")]
 #[fundamental]

--- a/src/test/ui/consts/const-eval/format.rs
+++ b/src/test/ui/consts/const-eval/format.rs
@@ -1,0 +1,21 @@
+const fn failure() {
+    panic!("{:?}", 0);
+    //~^ ERROR cannot call non-const formatting macro in constant functions
+    //~| ERROR erroneous constant used
+    //~| ERROR erroneous constant used
+    //~| WARN this was previously accepted by the compiler
+    //~| WARN this was previously accepted by the compiler
+}
+
+const fn print() {
+    println!("{:?}", 0);
+    //~^ ERROR cannot call non-const formatting macro in constant functions
+    //~| ERROR `Arguments::<'a>::new_v1` is not yet stable as a const fn
+    //~| ERROR cannot call non-const fn `_print` in constant functions
+    //~| ERROR erroneous constant used
+    //~| ERROR erroneous constant used
+    //~| WARN this was previously accepted by the compiler
+    //~| WARN this was previously accepted by the compiler
+}
+
+fn main() {}

--- a/src/test/ui/consts/const-eval/format.stderr
+++ b/src/test/ui/consts/const-eval/format.stderr
@@ -1,0 +1,78 @@
+error[E0015]: cannot call non-const formatting macro in constant functions
+  --> $DIR/format.rs:2:20
+   |
+LL |     panic!("{:?}", 0);
+   |                    ^
+   |
+   = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+   = note: this error originates in the macro `$crate::const_format_args` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0015]: cannot call non-const formatting macro in constant functions
+  --> $DIR/format.rs:11:22
+   |
+LL |     println!("{:?}", 0);
+   |                      ^
+   |
+   = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+   = note: this error originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: `Arguments::<'a>::new_v1` is not yet stable as a const fn
+  --> $DIR/format.rs:11:5
+   |
+LL |     println!("{:?}", 0);
+   |     ^^^^^^^^^^^^^^^^^^^
+   |
+   = help: add `#![feature(const_fmt_arguments_new)]` to the crate attributes to enable
+   = note: this error originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0015]: cannot call non-const fn `_print` in constant functions
+  --> $DIR/format.rs:11:5
+   |
+LL |     println!("{:?}", 0);
+   |     ^^^^^^^^^^^^^^^^^^^
+   |
+   = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
+   = note: this error originates in the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: erroneous constant used
+  --> $DIR/format.rs:2:12
+   |
+LL |     panic!("{:?}", 0);
+   |            ^^^^^^ referenced constant has errors
+   |
+   = note: `#[deny(const_err)]` on by default
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+
+error: erroneous constant used
+  --> $DIR/format.rs:2:20
+   |
+LL |     panic!("{:?}", 0);
+   |                    ^ referenced constant has errors
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+   = note: this error originates in the macro `$crate::const_format_args` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: erroneous constant used
+  --> $DIR/format.rs:11:14
+   |
+LL |     println!("{:?}", 0);
+   |              ^^^^^^ referenced constant has errors
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+
+error: erroneous constant used
+  --> $DIR/format.rs:11:22
+   |
+LL |     println!("{:?}", 0);
+   |                      ^ referenced constant has errors
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #71800 <https://github.com/rust-lang/rust/issues/71800>
+   = note: this error originates in the macro `$crate::format_args_nl` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 8 previous errors
+
+For more information about this error, try `rustc --explain E0015`.

--- a/src/test/ui/half-open-range-patterns/half-open-range-pats-exhaustive-fail.stderr
+++ b/src/test/ui/half-open-range-patterns/half-open-range-pats-exhaustive-fail.stderr
@@ -7,9 +7,8 @@ LL |     m!(0f32, f32::NEG_INFINITY..);
    = note: the matched value is of type `f32`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         match $s { $($t)+ => {}
-LL ~         _ => todo!() }
-   |
+LL |         match $s { $($t)+ => {}, _ => todo!() }
+   |                                ++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `_` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:17:8
@@ -20,9 +19,8 @@ LL |     m!(0f32, ..f32::INFINITY);
    = note: the matched value is of type `f32`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         match $s { $($t)+ => {}
-LL ~         _ => todo!() }
-   |
+LL |         match $s { $($t)+ => {}, _ => todo!() }
+   |                                ++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `'\u{10ffff}'` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:26:8
@@ -33,9 +31,8 @@ LL |     m!('a', ..core::char::MAX);
    = note: the matched value is of type `char`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         match $s { $($t)+ => {}
-LL ~         '\u{10ffff}' => todo!() }
-   |
+LL |         match $s { $($t)+ => {}, '\u{10ffff}' => todo!() }
+   |                                +++++++++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `'\u{10fffe}'..='\u{10ffff}'` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:27:8
@@ -46,9 +43,8 @@ LL |     m!('a', ..ALMOST_MAX);
    = note: the matched value is of type `char`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         match $s { $($t)+ => {}
-LL ~         '\u{10fffe}'..='\u{10ffff}' => todo!() }
-   |
+LL |         match $s { $($t)+ => {}, '\u{10fffe}'..='\u{10ffff}' => todo!() }
+   |                                ++++++++++++++++++++++++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `'\0'` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:28:8
@@ -59,9 +55,8 @@ LL |     m!('a', ALMOST_MIN..);
    = note: the matched value is of type `char`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         match $s { $($t)+ => {}
-LL ~         '\0' => todo!() }
-   |
+LL |         match $s { $($t)+ => {}, '\0' => todo!() }
+   |                                +++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `'\u{10ffff}'` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:29:8
@@ -72,9 +67,8 @@ LL |     m!('a', ..=ALMOST_MAX);
    = note: the matched value is of type `char`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         match $s { $($t)+ => {}
-LL ~         '\u{10ffff}' => todo!() }
-   |
+LL |         match $s { $($t)+ => {}, '\u{10ffff}' => todo!() }
+   |                                +++++++++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `'b'` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:30:8
@@ -85,9 +79,8 @@ LL |     m!('a', ..=VAL | VAL_2..);
    = note: the matched value is of type `char`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         match $s { $($t)+ => {}
-LL ~         'b' => todo!() }
-   |
+LL |         match $s { $($t)+ => {}, 'b' => todo!() }
+   |                                ++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `'b'` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:31:8
@@ -98,9 +91,8 @@ LL |     m!('a', ..VAL_1 | VAL_2..);
    = note: the matched value is of type `char`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         match $s { $($t)+ => {}
-LL ~         'b' => todo!() }
-   |
+LL |         match $s { $($t)+ => {}, 'b' => todo!() }
+   |                                ++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `u8::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:41:12
@@ -111,9 +103,8 @@ LL |         m!(0, ..u8::MAX);
    = note: the matched value is of type `u8`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         match $s { $($t)+ => {}
-LL ~         u8::MAX => todo!() }
-   |
+LL |         match $s { $($t)+ => {}, u8::MAX => todo!() }
+   |                                ++++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `254_u8..=u8::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:42:12
@@ -124,9 +115,8 @@ LL |         m!(0, ..ALMOST_MAX);
    = note: the matched value is of type `u8`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         match $s { $($t)+ => {}
-LL ~         254_u8..=u8::MAX => todo!() }
-   |
+LL |         match $s { $($t)+ => {}, 254_u8..=u8::MAX => todo!() }
+   |                                +++++++++++++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `0_u8` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:43:12
@@ -137,9 +127,8 @@ LL |         m!(0, ALMOST_MIN..);
    = note: the matched value is of type `u8`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         match $s { $($t)+ => {}
-LL ~         0_u8 => todo!() }
-   |
+LL |         match $s { $($t)+ => {}, 0_u8 => todo!() }
+   |                                +++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `u8::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:44:12
@@ -150,9 +139,8 @@ LL |         m!(0, ..=ALMOST_MAX);
    = note: the matched value is of type `u8`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         match $s { $($t)+ => {}
-LL ~         u8::MAX => todo!() }
-   |
+LL |         match $s { $($t)+ => {}, u8::MAX => todo!() }
+   |                                ++++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `43_u8` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:45:12
@@ -163,9 +151,8 @@ LL |         m!(0, ..=VAL | VAL_2..);
    = note: the matched value is of type `u8`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         match $s { $($t)+ => {}
-LL ~         43_u8 => todo!() }
-   |
+LL |         match $s { $($t)+ => {}, 43_u8 => todo!() }
+   |                                ++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `43_u8` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:46:12
@@ -176,9 +163,8 @@ LL |         m!(0, ..VAL_1 | VAL_2..);
    = note: the matched value is of type `u8`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         match $s { $($t)+ => {}
-LL ~         43_u8 => todo!() }
-   |
+LL |         match $s { $($t)+ => {}, 43_u8 => todo!() }
+   |                                ++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `u16::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:54:12
@@ -189,9 +175,8 @@ LL |         m!(0, ..u16::MAX);
    = note: the matched value is of type `u16`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         match $s { $($t)+ => {}
-LL ~         u16::MAX => todo!() }
-   |
+LL |         match $s { $($t)+ => {}, u16::MAX => todo!() }
+   |                                +++++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `65534_u16..=u16::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:55:12
@@ -202,9 +187,8 @@ LL |         m!(0, ..ALMOST_MAX);
    = note: the matched value is of type `u16`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         match $s { $($t)+ => {}
-LL ~         65534_u16..=u16::MAX => todo!() }
-   |
+LL |         match $s { $($t)+ => {}, 65534_u16..=u16::MAX => todo!() }
+   |                                +++++++++++++++++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `0_u16` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:56:12
@@ -215,9 +199,8 @@ LL |         m!(0, ALMOST_MIN..);
    = note: the matched value is of type `u16`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         match $s { $($t)+ => {}
-LL ~         0_u16 => todo!() }
-   |
+LL |         match $s { $($t)+ => {}, 0_u16 => todo!() }
+   |                                ++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `u16::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:57:12
@@ -228,9 +211,8 @@ LL |         m!(0, ..=ALMOST_MAX);
    = note: the matched value is of type `u16`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         match $s { $($t)+ => {}
-LL ~         u16::MAX => todo!() }
-   |
+LL |         match $s { $($t)+ => {}, u16::MAX => todo!() }
+   |                                +++++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `43_u16` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:58:12
@@ -241,9 +223,8 @@ LL |         m!(0, ..=VAL | VAL_2..);
    = note: the matched value is of type `u16`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         match $s { $($t)+ => {}
-LL ~         43_u16 => todo!() }
-   |
+LL |         match $s { $($t)+ => {}, 43_u16 => todo!() }
+   |                                +++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `43_u16` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:59:12
@@ -254,9 +235,8 @@ LL |         m!(0, ..VAL_1 | VAL_2..);
    = note: the matched value is of type `u16`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         match $s { $($t)+ => {}
-LL ~         43_u16 => todo!() }
-   |
+LL |         match $s { $($t)+ => {}, 43_u16 => todo!() }
+   |                                +++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `u32::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:67:12
@@ -267,9 +247,8 @@ LL |         m!(0, ..u32::MAX);
    = note: the matched value is of type `u32`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         match $s { $($t)+ => {}
-LL ~         u32::MAX => todo!() }
-   |
+LL |         match $s { $($t)+ => {}, u32::MAX => todo!() }
+   |                                +++++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `4294967294_u32..=u32::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:68:12
@@ -280,9 +259,8 @@ LL |         m!(0, ..ALMOST_MAX);
    = note: the matched value is of type `u32`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         match $s { $($t)+ => {}
-LL ~         4294967294_u32..=u32::MAX => todo!() }
-   |
+LL |         match $s { $($t)+ => {}, 4294967294_u32..=u32::MAX => todo!() }
+   |                                ++++++++++++++++++++++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `0_u32` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:69:12
@@ -293,9 +271,8 @@ LL |         m!(0, ALMOST_MIN..);
    = note: the matched value is of type `u32`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         match $s { $($t)+ => {}
-LL ~         0_u32 => todo!() }
-   |
+LL |         match $s { $($t)+ => {}, 0_u32 => todo!() }
+   |                                ++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `u32::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:70:12
@@ -306,9 +283,8 @@ LL |         m!(0, ..=ALMOST_MAX);
    = note: the matched value is of type `u32`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         match $s { $($t)+ => {}
-LL ~         u32::MAX => todo!() }
-   |
+LL |         match $s { $($t)+ => {}, u32::MAX => todo!() }
+   |                                +++++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `43_u32` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:71:12
@@ -319,9 +295,8 @@ LL |         m!(0, ..=VAL | VAL_2..);
    = note: the matched value is of type `u32`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         match $s { $($t)+ => {}
-LL ~         43_u32 => todo!() }
-   |
+LL |         match $s { $($t)+ => {}, 43_u32 => todo!() }
+   |                                +++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `43_u32` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:72:12
@@ -332,9 +307,8 @@ LL |         m!(0, ..VAL_1 | VAL_2..);
    = note: the matched value is of type `u32`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         match $s { $($t)+ => {}
-LL ~         43_u32 => todo!() }
-   |
+LL |         match $s { $($t)+ => {}, 43_u32 => todo!() }
+   |                                +++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `u64::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:80:12
@@ -345,9 +319,8 @@ LL |         m!(0, ..u64::MAX);
    = note: the matched value is of type `u64`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         match $s { $($t)+ => {}
-LL ~         u64::MAX => todo!() }
-   |
+LL |         match $s { $($t)+ => {}, u64::MAX => todo!() }
+   |                                +++++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `18446744073709551614_u64..=u64::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:81:12
@@ -358,9 +331,8 @@ LL |         m!(0, ..ALMOST_MAX);
    = note: the matched value is of type `u64`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         match $s { $($t)+ => {}
-LL ~         18446744073709551614_u64..=u64::MAX => todo!() }
-   |
+LL |         match $s { $($t)+ => {}, 18446744073709551614_u64..=u64::MAX => todo!() }
+   |                                ++++++++++++++++++++++++++++++++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `0_u64` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:82:12
@@ -371,9 +343,8 @@ LL |         m!(0, ALMOST_MIN..);
    = note: the matched value is of type `u64`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         match $s { $($t)+ => {}
-LL ~         0_u64 => todo!() }
-   |
+LL |         match $s { $($t)+ => {}, 0_u64 => todo!() }
+   |                                ++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `u64::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:83:12
@@ -384,9 +355,8 @@ LL |         m!(0, ..=ALMOST_MAX);
    = note: the matched value is of type `u64`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         match $s { $($t)+ => {}
-LL ~         u64::MAX => todo!() }
-   |
+LL |         match $s { $($t)+ => {}, u64::MAX => todo!() }
+   |                                +++++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `43_u64` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:84:12
@@ -397,9 +367,8 @@ LL |         m!(0, ..=VAL | VAL_2..);
    = note: the matched value is of type `u64`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         match $s { $($t)+ => {}
-LL ~         43_u64 => todo!() }
-   |
+LL |         match $s { $($t)+ => {}, 43_u64 => todo!() }
+   |                                +++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `43_u64` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:85:12
@@ -410,9 +379,8 @@ LL |         m!(0, ..VAL_1 | VAL_2..);
    = note: the matched value is of type `u64`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         match $s { $($t)+ => {}
-LL ~         43_u64 => todo!() }
-   |
+LL |         match $s { $($t)+ => {}, 43_u64 => todo!() }
+   |                                +++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `u128::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:93:12
@@ -423,9 +391,8 @@ LL |         m!(0, ..u128::MAX);
    = note: the matched value is of type `u128`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         match $s { $($t)+ => {}
-LL ~         u128::MAX => todo!() }
-   |
+LL |         match $s { $($t)+ => {}, u128::MAX => todo!() }
+   |                                ++++++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `340282366920938463463374607431768211454_u128..=u128::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:94:12
@@ -436,9 +403,8 @@ LL |         m!(0, ..ALMOST_MAX);
    = note: the matched value is of type `u128`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         match $s { $($t)+ => {}
-LL ~         340282366920938463463374607431768211454_u128..=u128::MAX => todo!() }
-   |
+LL |         match $s { $($t)+ => {}, 340282366920938463463374607431768211454_u128..=u128::MAX => todo!() }
+   |                                +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `0_u128` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:95:12
@@ -449,9 +415,8 @@ LL |         m!(0, ALMOST_MIN..);
    = note: the matched value is of type `u128`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         match $s { $($t)+ => {}
-LL ~         0_u128 => todo!() }
-   |
+LL |         match $s { $($t)+ => {}, 0_u128 => todo!() }
+   |                                +++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `u128::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:96:12
@@ -462,9 +427,8 @@ LL |         m!(0, ..=ALMOST_MAX);
    = note: the matched value is of type `u128`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         match $s { $($t)+ => {}
-LL ~         u128::MAX => todo!() }
-   |
+LL |         match $s { $($t)+ => {}, u128::MAX => todo!() }
+   |                                ++++++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `43_u128` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:97:12
@@ -475,9 +439,8 @@ LL |         m!(0, ..=VAL | VAL_2..);
    = note: the matched value is of type `u128`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         match $s { $($t)+ => {}
-LL ~         43_u128 => todo!() }
-   |
+LL |         match $s { $($t)+ => {}, 43_u128 => todo!() }
+   |                                ++++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `43_u128` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:98:12
@@ -488,9 +451,8 @@ LL |         m!(0, ..VAL_1 | VAL_2..);
    = note: the matched value is of type `u128`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         match $s { $($t)+ => {}
-LL ~         43_u128 => todo!() }
-   |
+LL |         match $s { $($t)+ => {}, 43_u128 => todo!() }
+   |                                ++++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `i8::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:109:12
@@ -501,9 +463,8 @@ LL |         m!(0, ..i8::MAX);
    = note: the matched value is of type `i8`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         match $s { $($t)+ => {}
-LL ~         i8::MAX => todo!() }
-   |
+LL |         match $s { $($t)+ => {}, i8::MAX => todo!() }
+   |                                ++++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `126_i8..=i8::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:110:12
@@ -514,9 +475,8 @@ LL |         m!(0, ..ALMOST_MAX);
    = note: the matched value is of type `i8`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         match $s { $($t)+ => {}
-LL ~         126_i8..=i8::MAX => todo!() }
-   |
+LL |         match $s { $($t)+ => {}, 126_i8..=i8::MAX => todo!() }
+   |                                +++++++++++++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `i8::MIN` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:111:12
@@ -527,9 +487,8 @@ LL |         m!(0, ALMOST_MIN..);
    = note: the matched value is of type `i8`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         match $s { $($t)+ => {}
-LL ~         i8::MIN => todo!() }
-   |
+LL |         match $s { $($t)+ => {}, i8::MIN => todo!() }
+   |                                ++++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `i8::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:112:12
@@ -540,9 +499,8 @@ LL |         m!(0, ..=ALMOST_MAX);
    = note: the matched value is of type `i8`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         match $s { $($t)+ => {}
-LL ~         i8::MAX => todo!() }
-   |
+LL |         match $s { $($t)+ => {}, i8::MAX => todo!() }
+   |                                ++++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `43_i8` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:113:12
@@ -553,9 +511,8 @@ LL |         m!(0, ..=VAL | VAL_2..);
    = note: the matched value is of type `i8`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         match $s { $($t)+ => {}
-LL ~         43_i8 => todo!() }
-   |
+LL |         match $s { $($t)+ => {}, 43_i8 => todo!() }
+   |                                ++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `43_i8` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:114:12
@@ -566,9 +523,8 @@ LL |         m!(0, ..VAL_1 | VAL_2..);
    = note: the matched value is of type `i8`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         match $s { $($t)+ => {}
-LL ~         43_i8 => todo!() }
-   |
+LL |         match $s { $($t)+ => {}, 43_i8 => todo!() }
+   |                                ++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `i16::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:122:12
@@ -579,9 +535,8 @@ LL |         m!(0, ..i16::MAX);
    = note: the matched value is of type `i16`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         match $s { $($t)+ => {}
-LL ~         i16::MAX => todo!() }
-   |
+LL |         match $s { $($t)+ => {}, i16::MAX => todo!() }
+   |                                +++++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `32766_i16..=i16::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:123:12
@@ -592,9 +547,8 @@ LL |         m!(0, ..ALMOST_MAX);
    = note: the matched value is of type `i16`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         match $s { $($t)+ => {}
-LL ~         32766_i16..=i16::MAX => todo!() }
-   |
+LL |         match $s { $($t)+ => {}, 32766_i16..=i16::MAX => todo!() }
+   |                                +++++++++++++++++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `i16::MIN` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:124:12
@@ -605,9 +559,8 @@ LL |         m!(0, ALMOST_MIN..);
    = note: the matched value is of type `i16`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         match $s { $($t)+ => {}
-LL ~         i16::MIN => todo!() }
-   |
+LL |         match $s { $($t)+ => {}, i16::MIN => todo!() }
+   |                                +++++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `i16::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:125:12
@@ -618,9 +571,8 @@ LL |         m!(0, ..=ALMOST_MAX);
    = note: the matched value is of type `i16`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         match $s { $($t)+ => {}
-LL ~         i16::MAX => todo!() }
-   |
+LL |         match $s { $($t)+ => {}, i16::MAX => todo!() }
+   |                                +++++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `43_i16` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:126:12
@@ -631,9 +583,8 @@ LL |         m!(0, ..=VAL | VAL_2..);
    = note: the matched value is of type `i16`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         match $s { $($t)+ => {}
-LL ~         43_i16 => todo!() }
-   |
+LL |         match $s { $($t)+ => {}, 43_i16 => todo!() }
+   |                                +++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `43_i16` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:127:12
@@ -644,9 +595,8 @@ LL |         m!(0, ..VAL_1 | VAL_2..);
    = note: the matched value is of type `i16`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         match $s { $($t)+ => {}
-LL ~         43_i16 => todo!() }
-   |
+LL |         match $s { $($t)+ => {}, 43_i16 => todo!() }
+   |                                +++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `i32::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:135:12
@@ -657,9 +607,8 @@ LL |         m!(0, ..i32::MAX);
    = note: the matched value is of type `i32`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         match $s { $($t)+ => {}
-LL ~         i32::MAX => todo!() }
-   |
+LL |         match $s { $($t)+ => {}, i32::MAX => todo!() }
+   |                                +++++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `2147483646_i32..=i32::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:136:12
@@ -670,9 +619,8 @@ LL |         m!(0, ..ALMOST_MAX);
    = note: the matched value is of type `i32`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         match $s { $($t)+ => {}
-LL ~         2147483646_i32..=i32::MAX => todo!() }
-   |
+LL |         match $s { $($t)+ => {}, 2147483646_i32..=i32::MAX => todo!() }
+   |                                ++++++++++++++++++++++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `i32::MIN` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:137:12
@@ -683,9 +631,8 @@ LL |         m!(0, ALMOST_MIN..);
    = note: the matched value is of type `i32`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         match $s { $($t)+ => {}
-LL ~         i32::MIN => todo!() }
-   |
+LL |         match $s { $($t)+ => {}, i32::MIN => todo!() }
+   |                                +++++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `i32::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:138:12
@@ -696,9 +643,8 @@ LL |         m!(0, ..=ALMOST_MAX);
    = note: the matched value is of type `i32`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         match $s { $($t)+ => {}
-LL ~         i32::MAX => todo!() }
-   |
+LL |         match $s { $($t)+ => {}, i32::MAX => todo!() }
+   |                                +++++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `43_i32` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:139:12
@@ -709,9 +655,8 @@ LL |         m!(0, ..=VAL | VAL_2..);
    = note: the matched value is of type `i32`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         match $s { $($t)+ => {}
-LL ~         43_i32 => todo!() }
-   |
+LL |         match $s { $($t)+ => {}, 43_i32 => todo!() }
+   |                                +++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `43_i32` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:140:12
@@ -722,9 +667,8 @@ LL |         m!(0, ..VAL_1 | VAL_2..);
    = note: the matched value is of type `i32`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         match $s { $($t)+ => {}
-LL ~         43_i32 => todo!() }
-   |
+LL |         match $s { $($t)+ => {}, 43_i32 => todo!() }
+   |                                +++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `i64::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:148:12
@@ -735,9 +679,8 @@ LL |         m!(0, ..i64::MAX);
    = note: the matched value is of type `i64`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         match $s { $($t)+ => {}
-LL ~         i64::MAX => todo!() }
-   |
+LL |         match $s { $($t)+ => {}, i64::MAX => todo!() }
+   |                                +++++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `9223372036854775806_i64..=i64::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:149:12
@@ -748,9 +691,8 @@ LL |         m!(0, ..ALMOST_MAX);
    = note: the matched value is of type `i64`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         match $s { $($t)+ => {}
-LL ~         9223372036854775806_i64..=i64::MAX => todo!() }
-   |
+LL |         match $s { $($t)+ => {}, 9223372036854775806_i64..=i64::MAX => todo!() }
+   |                                +++++++++++++++++++++++++++++++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `i64::MIN` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:150:12
@@ -761,9 +703,8 @@ LL |         m!(0, ALMOST_MIN..);
    = note: the matched value is of type `i64`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         match $s { $($t)+ => {}
-LL ~         i64::MIN => todo!() }
-   |
+LL |         match $s { $($t)+ => {}, i64::MIN => todo!() }
+   |                                +++++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `i64::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:151:12
@@ -774,9 +715,8 @@ LL |         m!(0, ..=ALMOST_MAX);
    = note: the matched value is of type `i64`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         match $s { $($t)+ => {}
-LL ~         i64::MAX => todo!() }
-   |
+LL |         match $s { $($t)+ => {}, i64::MAX => todo!() }
+   |                                +++++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `43_i64` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:152:12
@@ -787,9 +727,8 @@ LL |         m!(0, ..=VAL | VAL_2..);
    = note: the matched value is of type `i64`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         match $s { $($t)+ => {}
-LL ~         43_i64 => todo!() }
-   |
+LL |         match $s { $($t)+ => {}, 43_i64 => todo!() }
+   |                                +++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `43_i64` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:153:12
@@ -800,9 +739,8 @@ LL |         m!(0, ..VAL_1 | VAL_2..);
    = note: the matched value is of type `i64`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         match $s { $($t)+ => {}
-LL ~         43_i64 => todo!() }
-   |
+LL |         match $s { $($t)+ => {}, 43_i64 => todo!() }
+   |                                +++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `i128::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:161:12
@@ -813,9 +751,8 @@ LL |         m!(0, ..i128::MAX);
    = note: the matched value is of type `i128`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         match $s { $($t)+ => {}
-LL ~         i128::MAX => todo!() }
-   |
+LL |         match $s { $($t)+ => {}, i128::MAX => todo!() }
+   |                                ++++++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `170141183460469231731687303715884105726_i128..=i128::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:162:12
@@ -826,9 +763,8 @@ LL |         m!(0, ..ALMOST_MAX);
    = note: the matched value is of type `i128`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         match $s { $($t)+ => {}
-LL ~         170141183460469231731687303715884105726_i128..=i128::MAX => todo!() }
-   |
+LL |         match $s { $($t)+ => {}, 170141183460469231731687303715884105726_i128..=i128::MAX => todo!() }
+   |                                +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `i128::MIN` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:163:12
@@ -839,9 +775,8 @@ LL |         m!(0, ALMOST_MIN..);
    = note: the matched value is of type `i128`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         match $s { $($t)+ => {}
-LL ~         i128::MIN => todo!() }
-   |
+LL |         match $s { $($t)+ => {}, i128::MIN => todo!() }
+   |                                ++++++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `i128::MAX` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:164:12
@@ -852,9 +787,8 @@ LL |         m!(0, ..=ALMOST_MAX);
    = note: the matched value is of type `i128`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         match $s { $($t)+ => {}
-LL ~         i128::MAX => todo!() }
-   |
+LL |         match $s { $($t)+ => {}, i128::MAX => todo!() }
+   |                                ++++++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `43_i128` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:165:12
@@ -865,9 +799,8 @@ LL |         m!(0, ..=VAL | VAL_2..);
    = note: the matched value is of type `i128`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         match $s { $($t)+ => {}
-LL ~         43_i128 => todo!() }
-   |
+LL |         match $s { $($t)+ => {}, 43_i128 => todo!() }
+   |                                ++++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `43_i128` not covered
   --> $DIR/half-open-range-pats-exhaustive-fail.rs:166:12
@@ -878,9 +811,8 @@ LL |         m!(0, ..VAL_1 | VAL_2..);
    = note: the matched value is of type `i128`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         match $s { $($t)+ => {}
-LL ~         43_i128 => todo!() }
-   |
+LL |         match $s { $($t)+ => {}, 43_i128 => todo!() }
+   |                                ++++++++++++++++++++
 
 error: aborting due to 68 previous errors
 

--- a/src/test/ui/issue-94866.rs
+++ b/src/test/ui/issue-94866.rs
@@ -1,0 +1,14 @@
+macro_rules! m {
+    () => {
+        {}
+    };
+}
+
+enum Enum { A, B }
+
+fn main() {
+    match Enum::A {
+    //~^ ERROR non-exhaustive patterns
+    Enum::A => m!()
+    }
+}

--- a/src/test/ui/issue-94866.stderr
+++ b/src/test/ui/issue-94866.stderr
@@ -1,0 +1,21 @@
+error[E0004]: non-exhaustive patterns: `B` not covered
+  --> $DIR/issue-94866.rs:10:11
+   |
+LL |     match Enum::A {
+   |           ^^^^^^^ pattern `B` not covered
+   |
+note: `Enum` defined here
+  --> $DIR/issue-94866.rs:7:16
+   |
+LL | enum Enum { A, B }
+   |      ----      ^ not covered
+   = note: the matched value is of type `Enum`
+help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
+   |
+LL ~     Enum::A => m!(),
+LL +     B => todo!()
+   |
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0004`.

--- a/src/test/ui/pattern/usefulness/integer-ranges/exhaustiveness.stderr
+++ b/src/test/ui/pattern/usefulness/integer-ranges/exhaustiveness.stderr
@@ -7,9 +7,8 @@ LL |     m!(0u8, 0..255);
    = note: the matched value is of type `u8`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         match $s { $($t)+ => {}
-LL ~         u8::MAX => todo!() }
-   |
+LL |         match $s { $($t)+ => {}, u8::MAX => todo!() }
+   |                                ++++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `u8::MAX` not covered
   --> $DIR/exhaustiveness.rs:48:8
@@ -20,9 +19,8 @@ LL |     m!(0u8, 0..=254);
    = note: the matched value is of type `u8`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         match $s { $($t)+ => {}
-LL ~         u8::MAX => todo!() }
-   |
+LL |         match $s { $($t)+ => {}, u8::MAX => todo!() }
+   |                                ++++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `0_u8` not covered
   --> $DIR/exhaustiveness.rs:49:8
@@ -33,9 +31,8 @@ LL |     m!(0u8, 1..=255);
    = note: the matched value is of type `u8`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         match $s { $($t)+ => {}
-LL ~         0_u8 => todo!() }
-   |
+LL |         match $s { $($t)+ => {}, 0_u8 => todo!() }
+   |                                +++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `42_u8` not covered
   --> $DIR/exhaustiveness.rs:50:8
@@ -46,9 +43,8 @@ LL |     m!(0u8, 0..42 | 43..=255);
    = note: the matched value is of type `u8`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         match $s { $($t)+ => {}
-LL ~         42_u8 => todo!() }
-   |
+LL |         match $s { $($t)+ => {}, 42_u8 => todo!() }
+   |                                ++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `i8::MAX` not covered
   --> $DIR/exhaustiveness.rs:51:8
@@ -59,9 +55,8 @@ LL |     m!(0i8, -128..127);
    = note: the matched value is of type `i8`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         match $s { $($t)+ => {}
-LL ~         i8::MAX => todo!() }
-   |
+LL |         match $s { $($t)+ => {}, i8::MAX => todo!() }
+   |                                ++++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `i8::MAX` not covered
   --> $DIR/exhaustiveness.rs:52:8
@@ -72,9 +67,8 @@ LL |     m!(0i8, -128..=126);
    = note: the matched value is of type `i8`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         match $s { $($t)+ => {}
-LL ~         i8::MAX => todo!() }
-   |
+LL |         match $s { $($t)+ => {}, i8::MAX => todo!() }
+   |                                ++++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `i8::MIN` not covered
   --> $DIR/exhaustiveness.rs:53:8
@@ -85,9 +79,8 @@ LL |     m!(0i8, -127..=127);
    = note: the matched value is of type `i8`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         match $s { $($t)+ => {}
-LL ~         i8::MIN => todo!() }
-   |
+LL |         match $s { $($t)+ => {}, i8::MIN => todo!() }
+   |                                ++++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `0_i8` not covered
   --> $DIR/exhaustiveness.rs:54:11
@@ -111,9 +104,8 @@ LL |     m!(0u128, 0..=ALMOST_MAX);
    = note: the matched value is of type `u128`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         match $s { $($t)+ => {}
-LL ~         u128::MAX => todo!() }
-   |
+LL |         match $s { $($t)+ => {}, u128::MAX => todo!() }
+   |                                ++++++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `5_u128..=u128::MAX` not covered
   --> $DIR/exhaustiveness.rs:60:8
@@ -124,9 +116,8 @@ LL |     m!(0u128, 0..=4);
    = note: the matched value is of type `u128`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         match $s { $($t)+ => {}
-LL ~         5_u128..=u128::MAX => todo!() }
-   |
+LL |         match $s { $($t)+ => {}, 5_u128..=u128::MAX => todo!() }
+   |                                +++++++++++++++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `0_u128` not covered
   --> $DIR/exhaustiveness.rs:61:8
@@ -137,9 +128,8 @@ LL |     m!(0u128, 1..=u128::MAX);
    = note: the matched value is of type `u128`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         match $s { $($t)+ => {}
-LL ~         0_u128 => todo!() }
-   |
+LL |         match $s { $($t)+ => {}, 0_u128 => todo!() }
+   |                                +++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `(126_u8..=127_u8, false)` not covered
   --> $DIR/exhaustiveness.rs:69:11

--- a/src/test/ui/pattern/usefulness/integer-ranges/pointer-sized-int.deny.stderr
+++ b/src/test/ui/pattern/usefulness/integer-ranges/pointer-sized-int.deny.stderr
@@ -39,9 +39,8 @@ LL |     m!(0usize, 0..=usize::MAX);
    = help: add `#![feature(precise_pointer_size_matching)]` to the crate attributes to enable precise `usize` matching
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         match $s { $($t)+ => {}
-LL ~         _ => todo!() }
-   |
+LL |         match $s { $($t)+ => {}, _ => todo!() }
+   |                                ++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `_` not covered
   --> $DIR/pointer-sized-int.rs:24:8
@@ -54,9 +53,8 @@ LL |     m!(0usize, 0..5 | 5..=usize::MAX);
    = help: add `#![feature(precise_pointer_size_matching)]` to the crate attributes to enable precise `usize` matching
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         match $s { $($t)+ => {}
-LL ~         _ => todo!() }
-   |
+LL |         match $s { $($t)+ => {}, _ => todo!() }
+   |                                ++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `_` not covered
   --> $DIR/pointer-sized-int.rs:26:8
@@ -69,9 +67,8 @@ LL |     m!(0usize, 0..usize::MAX | usize::MAX);
    = help: add `#![feature(precise_pointer_size_matching)]` to the crate attributes to enable precise `usize` matching
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         match $s { $($t)+ => {}
-LL ~         _ => todo!() }
-   |
+LL |         match $s { $($t)+ => {}, _ => todo!() }
+   |                                ++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `(_, _)` not covered
   --> $DIR/pointer-sized-int.rs:28:8
@@ -82,9 +79,8 @@ LL |     m!((0usize, true), (0..5, true) | (5..=usize::MAX, true) | (0..=usize::
    = note: the matched value is of type `(usize, bool)`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         match $s { $($t)+ => {}
-LL ~         (_, _) => todo!() }
-   |
+LL |         match $s { $($t)+ => {}, (_, _) => todo!() }
+   |                                +++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `_` not covered
   --> $DIR/pointer-sized-int.rs:31:8
@@ -97,9 +93,8 @@ LL |     m!(0isize, isize::MIN..=isize::MAX);
    = help: add `#![feature(precise_pointer_size_matching)]` to the crate attributes to enable precise `isize` matching
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         match $s { $($t)+ => {}
-LL ~         _ => todo!() }
-   |
+LL |         match $s { $($t)+ => {}, _ => todo!() }
+   |                                ++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `_` not covered
   --> $DIR/pointer-sized-int.rs:33:8
@@ -112,9 +107,8 @@ LL |     m!(0isize, isize::MIN..5 | 5..=isize::MAX);
    = help: add `#![feature(precise_pointer_size_matching)]` to the crate attributes to enable precise `isize` matching
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         match $s { $($t)+ => {}
-LL ~         _ => todo!() }
-   |
+LL |         match $s { $($t)+ => {}, _ => todo!() }
+   |                                ++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `_` not covered
   --> $DIR/pointer-sized-int.rs:35:8
@@ -127,9 +121,8 @@ LL |     m!(0isize, isize::MIN..isize::MAX | isize::MAX);
    = help: add `#![feature(precise_pointer_size_matching)]` to the crate attributes to enable precise `isize` matching
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         match $s { $($t)+ => {}
-LL ~         _ => todo!() }
-   |
+LL |         match $s { $($t)+ => {}, _ => todo!() }
+   |                                ++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `(_, _)` not covered
   --> $DIR/pointer-sized-int.rs:37:8
@@ -140,9 +133,8 @@ LL |     m!((0isize, true), (isize::MIN..5, true)
    = note: the matched value is of type `(isize, bool)`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         match $s { $($t)+ => {}
-LL ~         (_, _) => todo!() }
-   |
+LL |         match $s { $($t)+ => {}, (_, _) => todo!() }
+   |                                +++++++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `_` not covered
   --> $DIR/pointer-sized-int.rs:41:11

--- a/src/test/ui/pattern/usefulness/non-exhaustive-match.stderr
+++ b/src/test/ui/pattern/usefulness/non-exhaustive-match.stderr
@@ -12,8 +12,8 @@ LL | enum T { A, B }
    = note: the matched value is of type `T`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL |     match x { T::B => { } A => todo!() }
-   |                           ++++++++++++
+LL |     match x { T::B => { }, A => todo!() }
+   |                          ++++++++++++++
 
 error[E0004]: non-exhaustive patterns: `false` not covered
   --> $DIR/non-exhaustive-match.rs:8:11

--- a/src/test/ui/pattern/usefulness/tuple-struct-nonexhaustive.stderr
+++ b/src/test/ui/pattern/usefulness/tuple-struct-nonexhaustive.stderr
@@ -12,7 +12,7 @@ LL | struct Foo(isize, isize);
    = note: the matched value is of type `Foo`
 help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
-LL ~         Foo(2, b) => println!("{}", b)
+LL ~         Foo(2, b) => println!("{}", b),
 LL +         Foo(_, _) => todo!()
    |
 


### PR DESCRIPTION
Successful merges:

 - #98235 (Drop magic value 3 from code)
 - #98267 (Don't omit comma when suggesting wildcard arm after macro expr)
 - #98276 (Mention formatting macros when encountering `ArgumentV1` method in const)
 - #98296 (Add a link to the unstable book page on Generator doc comment)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=98235,98267,98276,98296)
<!-- homu-ignore:end -->