### PR TITLE
make fn name more closely match returned type

### DIFF
--- a/compiler/rustc_interface/src/proc_macro_decls.rs
+++ b/compiler/rustc_interface/src/proc_macro_decls.rs
@@ -7,7 +7,7 @@ use rustc_span::symbol::sym;
 fn proc_macro_decls_static(tcx: TyCtxt<'_>, (): ()) -> Option<LocalDefId> {
     let mut finder = Finder { tcx, decls: None };
 
-    for id in tcx.hir().items() {
+    for id in tcx.hir().item_ids() {
         let attrs = finder.tcx.hir().attrs(id.hir_id());
         if finder.tcx.sess.contains_name(attrs, sym::rustc_proc_macro_decls) {
             finder.decls = Some(id.def_id);

--- a/compiler/rustc_metadata/src/foreign_modules.rs
+++ b/compiler/rustc_metadata/src/foreign_modules.rs
@@ -5,7 +5,7 @@ use rustc_session::cstore::ForeignModule;
 
 pub(crate) fn collect(tcx: TyCtxt<'_>) -> Vec<ForeignModule> {
     let mut modules = Vec::new();
-    for id in tcx.hir().items() {
+    for id in tcx.hir().item_ids() {
         if !matches!(tcx.def_kind(id.def_id), DefKind::ForeignMod) {
             continue;
         }

--- a/compiler/rustc_metadata/src/native_libs.rs
+++ b/compiler/rustc_metadata/src/native_libs.rs
@@ -14,7 +14,7 @@ use rustc_target::spec::abi::Abi;
 
 pub(crate) fn collect(tcx: TyCtxt<'_>) -> Vec<NativeLib> {
     let mut collector = Collector { tcx, libs: Vec::new() };
-    for id in tcx.hir().items() {
+    for id in tcx.hir().item_ids() {
         collector.process_item(id);
     }
     collector.process_command_line();

--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -1810,7 +1810,7 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
         let mut fx_hash_map: FxHashMap<DefId, Vec<(DefIndex, Option<SimplifiedType>)>> =
             FxHashMap::default();
 
-        for id in tcx.hir().items() {
+        for id in tcx.hir().item_ids() {
             if matches!(tcx.def_kind(id.def_id), DefKind::Impl) {
                 if let Some(trait_ref) = tcx.impl_trait_ref(id.def_id.to_def_id()) {
                     let simplified_self_ty = fast_reject::simplify_type(
@@ -2231,7 +2231,7 @@ pub fn provide(providers: &mut Providers) {
             assert_eq!(cnum, LOCAL_CRATE);
 
             let mut traits = Vec::new();
-            for id in tcx.hir().items() {
+            for id in tcx.hir().item_ids() {
                 if matches!(tcx.def_kind(id.def_id), DefKind::Trait | DefKind::TraitAlias) {
                     traits.push(id.def_id.to_def_id())
                 }

--- a/compiler/rustc_middle/src/hir/map/mod.rs
+++ b/compiler/rustc_middle/src/hir/map/mod.rs
@@ -156,7 +156,7 @@ impl<'hir> Map<'hir> {
         }
     }
 
-    pub fn items(self) -> impl Iterator<Item = ItemId> + 'hir {
+    pub fn item_ids(self) -> impl Iterator<Item = ItemId> + 'hir {
         self.tcx.hir_crate_items(()).items.iter().copied()
     }
 

--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -2633,7 +2633,7 @@ define_print_and_forward_display! {
 fn for_each_def(tcx: TyCtxt<'_>, mut collect_fn: impl for<'b> FnMut(&'b Ident, Namespace, DefId)) {
     // Iterate all local crate items no matter where they are defined.
     let hir = tcx.hir();
-    for id in hir.items() {
+    for id in hir.item_ids() {
         if matches!(tcx.def_kind(id.def_id), DefKind::Use) {
             continue;
         }

--- a/compiler/rustc_passes/src/entry.rs
+++ b/compiler/rustc_passes/src/entry.rs
@@ -40,7 +40,7 @@ fn entry_fn(tcx: TyCtxt<'_>, (): ()) -> Option<(DefId, EntryFnType)> {
     let mut ctxt =
         EntryContext { tcx, attr_main_fn: None, start_fn: None, non_main_fns: Vec::new() };
 
-    for id in tcx.hir().items() {
+    for id in tcx.hir().item_ids() {
         find_item(id, &mut ctxt);
     }
 

--- a/compiler/rustc_passes/src/layout_test.rs
+++ b/compiler/rustc_passes/src/layout_test.rs
@@ -10,7 +10,7 @@ use rustc_target::abi::{HasDataLayout, TargetDataLayout};
 pub fn test_layout(tcx: TyCtxt<'_>) {
     if tcx.features().rustc_attrs {
         // if the `rustc_attrs` feature is not enabled, don't bother testing layout
-        for id in tcx.hir().items() {
+        for id in tcx.hir().item_ids() {
             if matches!(
                 tcx.def_kind(id.def_id),
                 DefKind::TyAlias | DefKind::Enum | DefKind::Struct | DefKind::Union

--- a/compiler/rustc_privacy/src/lib.rs
+++ b/compiler/rustc_privacy/src/lib.rs
@@ -2092,7 +2092,7 @@ fn check_private_in_public(tcx: TyCtxt<'_>, (): ()) {
             .collect(),
     };
 
-    for id in tcx.hir().items() {
+    for id in tcx.hir().item_ids() {
         checker.check_item(id);
     }
 }

--- a/compiler/rustc_typeck/src/check_unused.rs
+++ b/compiler/rustc_typeck/src/check_unused.rs
@@ -84,7 +84,7 @@ fn unused_crates_lint(tcx: TyCtxt<'_>) {
     // Collect all the extern crates (in a reliable order).
     let mut crates_to_lint = vec![];
 
-    for id in tcx.hir().items() {
+    for id in tcx.hir().item_ids() {
         if matches!(tcx.def_kind(id.def_id), DefKind::ExternCrate) {
             let item = tcx.hir().item(id);
             if let hir::ItemKind::ExternCrate(orig_name) = item.kind {

--- a/compiler/rustc_typeck/src/coherence/inherent_impls.rs
+++ b/compiler/rustc_typeck/src/coherence/inherent_impls.rs
@@ -19,7 +19,7 @@ use rustc_span::Span;
 /// On-demand query: yields a map containing all types mapped to their inherent impls.
 pub fn crate_inherent_impls(tcx: TyCtxt<'_>, (): ()) -> CrateInherentImpls {
     let mut collect = InherentCollect { tcx, impls_map: Default::default() };
-    for id in tcx.hir().items() {
+    for id in tcx.hir().item_ids() {
         collect.check_item(id);
     }
     collect.impls_map

--- a/compiler/rustc_typeck/src/coherence/inherent_impls_overlap.rs
+++ b/compiler/rustc_typeck/src/coherence/inherent_impls_overlap.rs
@@ -13,7 +13,7 @@ use std::collections::hash_map::Entry;
 
 pub fn crate_inherent_impls_overlap_check(tcx: TyCtxt<'_>, (): ()) {
     let mut inherent_overlap_checker = InherentOverlapChecker { tcx };
-    for id in tcx.hir().items() {
+    for id in tcx.hir().item_ids() {
         inherent_overlap_checker.check_item(id);
     }
 }

--- a/compiler/rustc_typeck/src/coherence/unsafety.rs
+++ b/compiler/rustc_typeck/src/coherence/unsafety.rs
@@ -8,7 +8,7 @@ use rustc_hir::Unsafety;
 use rustc_middle::ty::TyCtxt;
 
 pub fn check(tcx: TyCtxt<'_>) {
-    for id in tcx.hir().items() {
+    for id in tcx.hir().item_ids() {
         if matches!(tcx.def_kind(id.def_id), DefKind::Impl) {
             let item = tcx.hir().item(id);
             if let hir::ItemKind::Impl(ref impl_) = item.kind {

--- a/compiler/rustc_typeck/src/outlives/implicit_infer.rs
+++ b/compiler/rustc_typeck/src/outlives/implicit_infer.rs
@@ -29,7 +29,7 @@ pub fn infer_predicates<'tcx>(
         predicates_added = false;
 
         // Visit all the crates and infer predicates
-        for id in tcx.hir().items() {
+        for id in tcx.hir().item_ids() {
             let item_did = id.def_id;
 
             debug!("InferVisitor::visit_item(item={:?})", item_did);

--- a/compiler/rustc_typeck/src/outlives/test.rs
+++ b/compiler/rustc_typeck/src/outlives/test.rs
@@ -3,7 +3,7 @@ use rustc_middle::ty::TyCtxt;
 use rustc_span::symbol::sym;
 
 pub fn test_inferred_outlives(tcx: TyCtxt<'_>) {
-    for id in tcx.hir().items() {
+    for id in tcx.hir().item_ids() {
         // For unit testing: check for a special "rustc_outlives"
         // attribute and report an error with various results if found.
         if tcx.has_attr(id.def_id.to_def_id(), sym::rustc_outlives) {

--- a/compiler/rustc_typeck/src/variance/test.rs
+++ b/compiler/rustc_typeck/src/variance/test.rs
@@ -5,7 +5,7 @@ use rustc_span::symbol::sym;
 pub fn test_variance(tcx: TyCtxt<'_>) {
     // For unit testing: check for a special "rustc_variance"
     // attribute and report an error with various results if found.
-    for id in tcx.hir().items() {
+    for id in tcx.hir().item_ids() {
         if tcx.has_attr(id.def_id.to_def_id(), sym::rustc_variance) {
             let variances_of = tcx.variances_of(id.def_id);
             struct_span_err!(tcx.sess, tcx.def_span(id.def_id), E0208, "{:?}", variances_of).emit();

--- a/src/tools/clippy/clippy_lints/src/same_name_method.rs
+++ b/src/tools/clippy/clippy_lints/src/same_name_method.rs
@@ -51,7 +51,7 @@ impl<'tcx> LateLintPass<'tcx> for SameNameMethod {
     fn check_crate_post(&mut self, cx: &LateContext<'tcx>) {
         let mut map = FxHashMap::<Res, ExistingName>::default();
 
-        for id in cx.tcx.hir().items() {
+        for id in cx.tcx.hir().item_ids() {
             if matches!(cx.tcx.def_kind(id.def_id), DefKind::Impl)
                 && let item = cx.tcx.hir().item(id)
                 && let ItemKind::Impl(Impl {


### PR DESCRIPTION
b73b4de982a16e8819e804cb648ff3ea63d22028 changed return type to use
ItemIds instead of Items, but it did not rename the function.