### PR TITLE
Add new func `Pin::as_inner_ref`

### DIFF
--- a/library/core/src/pin.rs
+++ b/library/core/src/pin.rs
@@ -593,6 +593,17 @@ impl<P: Deref> Pin<P> {
         unsafe { Pin::new_unchecked(&*self.pointer) }
     }
 
+    /// Return a reference to the `pointer`.
+    ///
+    /// Since this function takes an immutable reference of `Pin<P>`,
+    /// it is impossible to move or move out from the pinned `pointer`.
+    ///
+    /// Thus it is safe to call this function.
+    #[inline(always)]
+    pub const fn as_inner_ref(&self) -> &P {
+        &self.p
+    }
+
     /// Unwraps this `Pin<P>` returning the underlying pointer.
     ///
     /// # Safety

--- a/library/core/src/pin.rs
+++ b/library/core/src/pin.rs
@@ -600,6 +600,7 @@ impl<P: Deref> Pin<P> {
     ///
     /// Thus it is safe to call this function.
     #[rustc_const_unstable(feature = "const_pin", issue = "76654")]
+    #[unstable(feature = "pin_as_inner_ref", issue = "none")]
     #[inline(always)]
     pub const fn as_inner_ref(&self) -> &P {
         &self.pointer

--- a/library/core/src/pin.rs
+++ b/library/core/src/pin.rs
@@ -602,7 +602,7 @@ impl<P: Deref> Pin<P> {
     #[rustc_const_unstable(feature = "const_pin", issue = "76654")]
     #[inline(always)]
     pub const fn as_inner_ref(&self) -> &P {
-        &self.p
+        &self.pointer
     }
 
     /// Unwraps this `Pin<P>` returning the underlying pointer.

--- a/library/core/src/pin.rs
+++ b/library/core/src/pin.rs
@@ -599,6 +599,7 @@ impl<P: Deref> Pin<P> {
     /// it is impossible to move or move out from the pinned `pointer`.
     ///
     /// Thus it is safe to call this function.
+    #[rustc_const_unstable(feature = "const_pin", issue = "76654")]
     #[inline(always)]
     pub const fn as_inner_ref(&self) -> &P {
         &self.p


### PR DESCRIPTION
It return a reference to the `pointer`.

Since this function takes an immutable reference of `Pin<P>`,
it is impossible to move or move out from the pinned `pointer`.

Thus it is safe to call this function.

## Motivation

This function makes it possible to call `Arc::strong_count` on `Pin<Arc<T>>`.

## Proposal

https://github.com/rust-lang/libs-team/issues/56

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>