### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/outlives_suggestion.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/outlives_suggestion.rs
@@ -62,7 +62,8 @@ impl OutlivesSuggestionBuilder {
             | RegionNameSource::AnonRegionFromUpvar(..)
             | RegionNameSource::AnonRegionFromOutput(..)
             | RegionNameSource::AnonRegionFromYieldTy(..)
-            | RegionNameSource::AnonRegionFromAsyncFn(..) => {
+            | RegionNameSource::AnonRegionFromAsyncFn(..)
+            | RegionNameSource::AnonRegionFromImplSignature(..) => {
                 debug!("Region {:?} is NOT suggestable", name);
                 false
             }

--- a/compiler/rustc_borrowck/src/diagnostics/region_name.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/region_name.rs
@@ -6,7 +6,7 @@ use rustc_hir as hir;
 use rustc_hir::def::{DefKind, Res};
 use rustc_middle::ty::print::RegionHighlightMode;
 use rustc_middle::ty::subst::{GenericArgKind, SubstsRef};
-use rustc_middle::ty::{self, RegionVid, Ty};
+use rustc_middle::ty::{self, DefIdTree, RegionVid, Ty};
 use rustc_span::symbol::{kw, sym, Ident, Symbol};
 use rustc_span::{Span, DUMMY_SP};
 
@@ -45,6 +45,8 @@ pub(crate) enum RegionNameSource {
     AnonRegionFromYieldTy(Span, String),
     /// An anonymous region from an async fn.
     AnonRegionFromAsyncFn(Span),
+    /// An anonymous region from an impl self type or trait
+    AnonRegionFromImplSignature(Span, &'static str),
 }
 
 /// Describes what to highlight to explain to the user that we're giving an anonymous region a
@@ -75,7 +77,8 @@ impl RegionName {
             | RegionNameSource::AnonRegionFromUpvar(..)
             | RegionNameSource::AnonRegionFromOutput(..)
             | RegionNameSource::AnonRegionFromYieldTy(..)
-            | RegionNameSource::AnonRegionFromAsyncFn(..) => false,
+            | RegionNameSource::AnonRegionFromAsyncFn(..)
+            | RegionNameSource::AnonRegionFromImplSignature(..) => false,
         }
     }
 
@@ -87,7 +90,8 @@ impl RegionName {
             | RegionNameSource::SynthesizedFreeEnvRegion(span, _)
             | RegionNameSource::AnonRegionFromUpvar(span, _)
             | RegionNameSource::AnonRegionFromYieldTy(span, _)
-            | RegionNameSource::AnonRegionFromAsyncFn(span) => Some(span),
+            | RegionNameSource::AnonRegionFromAsyncFn(span)
+            | RegionNameSource::AnonRegionFromImplSignature(span, _) => Some(span),
             RegionNameSource::AnonRegionFromArgument(ref highlight)
             | RegionNameSource::AnonRegionFromOutput(ref highlight, _) => match *highlight {
                 RegionNameHighlight::MatchedHirTy(span)
@@ -166,6 +170,12 @@ impl RegionName {
             RegionNameSource::AnonRegionFromYieldTy(span, type_name) => {
                 diag.span_label(*span, format!("yield type is {type_name}"));
             }
+            RegionNameSource::AnonRegionFromImplSignature(span, location) => {
+                diag.span_label(
+                    *span,
+                    format!("lifetime `{self}` appears in the `impl`'s {location}"),
+                );
+            }
             RegionNameSource::Static => {}
         }
     }
@@ -240,7 +250,8 @@ impl<'tcx> MirBorrowckCtxt<'_, 'tcx> {
             .or_else(|| self.give_name_if_anonymous_region_appears_in_arguments(fr))
             .or_else(|| self.give_name_if_anonymous_region_appears_in_upvars(fr))
             .or_else(|| self.give_name_if_anonymous_region_appears_in_output(fr))
-            .or_else(|| self.give_name_if_anonymous_region_appears_in_yield_ty(fr));
+            .or_else(|| self.give_name_if_anonymous_region_appears_in_yield_ty(fr))
+            .or_else(|| self.give_name_if_anonymous_region_appears_in_impl_signature(fr));
 
         if let Some(ref value) = value {
             self.region_names.try_borrow_mut().unwrap().insert(fr, value.clone());
@@ -838,6 +849,45 @@ impl<'tcx> MirBorrowckCtxt<'_, 'tcx> {
         Some(RegionName {
             name: self.synthesize_region_name(),
             source: RegionNameSource::AnonRegionFromYieldTy(yield_span, type_name),
+        })
+    }
+
+    fn give_name_if_anonymous_region_appears_in_impl_signature(
+        &self,
+        fr: RegionVid,
+    ) -> Option<RegionName> {
+        let ty::ReEarlyBound(region) = *self.to_error_region(fr)? else {
+            return None;
+        };
+        if region.has_name() {
+            return None;
+        };
+
+        let tcx = self.infcx.tcx;
+        let body_parent_did = tcx.opt_parent(self.mir_def_id().to_def_id())?;
+        if tcx.parent(region.def_id) != body_parent_did
+            || tcx.def_kind(body_parent_did) != DefKind::Impl
+        {
+            return None;
+        }
+
+        let mut found = false;
+        tcx.fold_regions(tcx.type_of(body_parent_did), &mut true, |r: ty::Region<'tcx>, _| {
+            if *r == ty::ReEarlyBound(region) {
+                found = true;
+            }
+            r
+        });
+
+        Some(RegionName {
+            name: self.synthesize_region_name(),
+            source: RegionNameSource::AnonRegionFromImplSignature(
+                tcx.def_span(region.def_id),
+                // FIXME(compiler-errors): Does this ever actually show up
+                // anywhere other than the self type? I couldn't create an
+                // example of a `'_` in the impl's trait being referenceable.
+                if found { "self type" } else { "header" },
+            ),
         })
     }
 }

--- a/compiler/rustc_codegen_ssa/src/back/linker.rs
+++ b/compiler/rustc_codegen_ssa/src/back/linker.rs
@@ -644,9 +644,12 @@ impl<'a> Linker for GccLinker<'a> {
 
     fn export_symbols(&mut self, tmpdir: &Path, crate_type: CrateType, symbols: &[String]) {
         // Symbol visibility in object files typically takes care of this.
-        if crate_type == CrateType::Executable && self.sess.target.override_export_symbols.is_none()
-        {
-            return;
+        if crate_type == CrateType::Executable {
+            if self.sess.target.override_export_symbols.is_none()
+                && !self.sess.opts.cg.export_executable_symbols
+            {
+                return;
+            }
         }
 
         // We manually create a list of exported symbols to ensure we don't expose any more.
@@ -970,7 +973,9 @@ impl<'a> Linker for MsvcLinker<'a> {
     fn export_symbols(&mut self, tmpdir: &Path, crate_type: CrateType, symbols: &[String]) {
         // Symbol visibility takes care of this typically
         if crate_type == CrateType::Executable {
-            return;
+            if !self.sess.opts.cg.export_executable_symbols {
+                return;
+            }
         }
 
         let path = tmpdir.join("lib.def");

--- a/compiler/rustc_codegen_ssa/src/back/linker.rs
+++ b/compiler/rustc_codegen_ssa/src/back/linker.rs
@@ -646,7 +646,7 @@ impl<'a> Linker for GccLinker<'a> {
         // Symbol visibility in object files typically takes care of this.
         if crate_type == CrateType::Executable {
             if self.sess.target.override_export_symbols.is_none()
-                && !self.sess.opts.cg.export_executable_symbols
+                && !self.sess.opts.debugging_opts.export_executable_symbols
             {
                 return;
             }
@@ -973,7 +973,7 @@ impl<'a> Linker for MsvcLinker<'a> {
     fn export_symbols(&mut self, tmpdir: &Path, crate_type: CrateType, symbols: &[String]) {
         // Symbol visibility takes care of this typically
         if crate_type == CrateType::Executable {
-            if !self.sess.opts.cg.export_executable_symbols {
+            if !self.sess.opts.debugging_opts.export_executable_symbols {
                 return;
             }
         }

--- a/compiler/rustc_infer/src/infer/glb.rs
+++ b/compiler/rustc_infer/src/infer/glb.rs
@@ -95,12 +95,20 @@ impl<'tcx> TypeRelation<'tcx> for Glb<'_, '_, 'tcx> {
         T: Relate<'tcx>,
     {
         debug!("binders(a={:?}, b={:?})", a, b);
-
-        // When higher-ranked types are involved, computing the LUB is
-        // very challenging, switch to invariance. This is obviously
-        // overly conservative but works ok in practice.
-        self.relate_with_variance(ty::Variance::Invariant, ty::VarianceDiagInfo::default(), a, b)?;
-        Ok(a)
+        if a.skip_binder().has_escaping_bound_vars() || b.skip_binder().has_escaping_bound_vars() {
+            // When higher-ranked types are involved, computing the GLB is
+            // very challenging, switch to invariance. This is obviously
+            // overly conservative but works ok in practice.
+            self.relate_with_variance(
+                ty::Variance::Invariant,
+                ty::VarianceDiagInfo::default(),
+                a,
+                b,
+            )?;
+            Ok(a)
+        } else {
+            Ok(ty::Binder::dummy(self.relate(a.skip_binder(), b.skip_binder())?))
+        }
     }
 }
 

--- a/compiler/rustc_infer/src/infer/lub.rs
+++ b/compiler/rustc_infer/src/infer/lub.rs
@@ -95,12 +95,20 @@ impl<'tcx> TypeRelation<'tcx> for Lub<'_, '_, 'tcx> {
         T: Relate<'tcx>,
     {
         debug!("binders(a={:?}, b={:?})", a, b);
-
-        // When higher-ranked types are involved, computing the LUB is
-        // very challenging, switch to invariance. This is obviously
-        // overly conservative but works ok in practice.
-        self.relate_with_variance(ty::Variance::Invariant, ty::VarianceDiagInfo::default(), a, b)?;
-        Ok(a)
+        if a.skip_binder().has_escaping_bound_vars() || b.skip_binder().has_escaping_bound_vars() {
+            // When higher-ranked types are involved, computing the LUB is
+            // very challenging, switch to invariance. This is obviously
+            // overly conservative but works ok in practice.
+            self.relate_with_variance(
+                ty::Variance::Invariant,
+                ty::VarianceDiagInfo::default(),
+                a,
+                b,
+            )?;
+            Ok(a)
+        } else {
+            Ok(ty::Binder::dummy(self.relate(a.skip_binder(), b.skip_binder())?))
+        }
     }
 }
 

--- a/compiler/rustc_interface/src/tests.rs
+++ b/compiler/rustc_interface/src/tests.rs
@@ -573,7 +573,6 @@ fn test_codegen_options_tracking_hash() {
     tracked!(debug_assertions, Some(true));
     tracked!(debuginfo, 0xdeadbeef);
     tracked!(embed_bitcode, false);
-    tracked!(export_executable_symbols, true);
     tracked!(force_frame_pointers, Some(false));
     tracked!(force_unwind_tables, Some(true));
     tracked!(inline_threshold, Some(0xf007ba11));
@@ -735,6 +734,7 @@ fn test_debugging_options_tracking_hash() {
     tracked!(debug_macros, true);
     tracked!(dep_info_omit_d_target, true);
     tracked!(drop_tracking, true);
+    tracked!(export_executable_symbols, true);
     tracked!(dual_proc_macros, true);
     tracked!(fewer_names, Some(true));
     tracked!(force_unstable_if_unmarked, true);

--- a/compiler/rustc_interface/src/tests.rs
+++ b/compiler/rustc_interface/src/tests.rs
@@ -573,6 +573,7 @@ fn test_codegen_options_tracking_hash() {
     tracked!(debug_assertions, Some(true));
     tracked!(debuginfo, 0xdeadbeef);
     tracked!(embed_bitcode, false);
+    tracked!(export_executable_symbols, true);
     tracked!(force_frame_pointers, Some(false));
     tracked!(force_unwind_tables, Some(true));
     tracked!(inline_threshold, Some(0xf007ba11));

--- a/compiler/rustc_metadata/src/creader.rs
+++ b/compiler/rustc_metadata/src/creader.rs
@@ -133,6 +133,10 @@ impl CStore {
         CrateNum::new(self.metas.len() - 1)
     }
 
+    pub fn has_crate_data(&self, cnum: CrateNum) -> bool {
+        self.metas[cnum].is_some()
+    }
+
     pub(crate) fn get_crate_data(&self, cnum: CrateNum) -> CrateMetadataRef<'_> {
         let cdata = self.metas[cnum]
             .as_ref()

--- a/compiler/rustc_resolve/src/ident.rs
+++ b/compiler/rustc_resolve/src/ident.rs
@@ -1502,6 +1502,7 @@ impl<'a> Resolver<'a> {
                         return PathResult::NonModule(PartialRes::new(Res::Err));
                     } else if opt_ns.is_some() && (is_last || maybe_assoc) {
                         self.lint_if_path_starts_with_module(finalize, path, second_binding);
+                        record_segment_res(self, res);
                         return PathResult::NonModule(PartialRes::with_unresolved_segments(
                             res,
                             path.len() - i - 1,

--- a/compiler/rustc_resolve/src/late/lifetimes.rs
+++ b/compiler/rustc_resolve/src/late/lifetimes.rs
@@ -846,8 +846,6 @@ impl<'a, 'tcx> Visitor<'tcx> for LifetimeContext<'a, 'tcx> {
                 //                                      the opaque_ty generics
                 let opaque_ty = self.tcx.hir().item(item_id);
                 let (generics, bounds) = match opaque_ty.kind {
-                    // Named opaque `impl Trait` types are reached via `TyKind::Path`.
-                    // This arm is for `impl Trait` in the types of statics, constants and locals.
                     hir::ItemKind::OpaqueTy(hir::OpaqueTy {
                         origin: hir::OpaqueTyOrigin::TyAlias,
                         ..
@@ -866,7 +864,6 @@ impl<'a, 'tcx> Visitor<'tcx> for LifetimeContext<'a, 'tcx> {
 
                         return;
                     }
-                    // RPIT (return position impl trait)
                     hir::ItemKind::OpaqueTy(hir::OpaqueTy {
                         origin: hir::OpaqueTyOrigin::FnReturn(..) | hir::OpaqueTyOrigin::AsyncFn(..),
                         ref generics,

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -1054,8 +1054,6 @@ options! {
         "allow the linker to link its default libraries (default: no)"),
     embed_bitcode: bool = (true, parse_bool, [TRACKED],
         "emit bitcode in rlibs (default: yes)"),
-    export_executable_symbols: bool = (false, parse_bool, [TRACKED],
-        "export symbols from executables, as if they were dynamic libraries"),
     extra_filename: String = (String::new(), parse_string, [UNTRACKED],
         "extra data to put in each output filename"),
     force_frame_pointers: Option<bool> = (None, parse_opt_bool, [TRACKED],
@@ -1244,6 +1242,8 @@ options! {
         an additional `.html` file showing the computed coverage spans."),
     emit_stack_sizes: bool = (false, parse_bool, [UNTRACKED],
         "emit a section containing stack size metadata (default: no)"),
+    export_executable_symbols: bool = (false, parse_bool, [TRACKED],
+        "export symbols from executables, as if they were dynamic libraries"),
     fewer_names: Option<bool> = (None, parse_opt_bool, [TRACKED],
         "reduce memory use by retaining fewer names within compilation artifacts (LLVM-IR) \
         (default: no)"),

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -1054,6 +1054,8 @@ options! {
         "allow the linker to link its default libraries (default: no)"),
     embed_bitcode: bool = (true, parse_bool, [TRACKED],
         "emit bitcode in rlibs (default: yes)"),
+    export_executable_symbols: bool = (false, parse_bool, [TRACKED],
+        "export symbols from executables, as if they were dynamic libraries"),
     extra_filename: String = (String::new(), parse_string, [UNTRACKED],
         "extra data to put in each output filename"),
     force_frame_pointers: Option<bool> = (None, parse_opt_bool, [TRACKED],

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -519,6 +519,7 @@ impl clean::GenericArgs {
 }
 
 // Possible errors when computing href link source for a `DefId`
+#[derive(PartialEq, Eq)]
 pub(crate) enum HrefError {
     /// This item is known to rustdoc, but from a crate that does not have documentation generated.
     ///

--- a/src/librustdoc/html/sources.rs
+++ b/src/librustdoc/html/sources.rs
@@ -299,7 +299,7 @@ pub(crate) fn print_src(
         None,
         edition,
         Some(line_numbers),
-        Some(highlight::ContextInfo { context, file_span, root_path }),
+        Some(highlight::HrefContext { context, file_span, root_path }),
         decoration_info,
     );
 }

--- a/src/test/run-make/export-executable-symbols/Makefile
+++ b/src/test/run-make/export-executable-symbols/Makefile
@@ -1,0 +1,7 @@
+-include ../../run-make-fulldeps/tools.mk
+
+all:
+	$(RUSTC) --crate-type=cdylib foo.rs
+	$(RUSTC) -Zexport-executable-symbols -lfoo -L "$(TMPDIR)" main.rs
+	$(call $(TMPDIR)/main)
+

--- a/src/test/run-make/export-executable-symbols/foo.rs
+++ b/src/test/run-make/export-executable-symbols/foo.rs
@@ -1,0 +1,8 @@
+extern "C" {
+    fn exported_symbol() -> i8;
+}
+
+#[no_mangle]
+pub extern "C" fn call_exported_symbol() -> i8 {
+    unsafe { exported_symbol() }
+}

--- a/src/test/run-make/export-executable-symbols/main.rs
+++ b/src/test/run-make/export-executable-symbols/main.rs
@@ -1,0 +1,10 @@
+// edition:2018
+
+fn main() {
+    foo();
+}
+
+#[no_mangle]
+pub extern "C" fn foo() -> i32 {
+    1 + 1
+}

--- a/src/test/run-make/export-executable-symbols/main.rs
+++ b/src/test/run-make/export-executable-symbols/main.rs
@@ -1,10 +1,37 @@
 // edition:2018
 
+#![feature(rustc_private)]
+
+extern crate libc;
+use std::ffi::*;
+use std::os::unix::ffi::*;
+
 fn main() {
-    foo();
+    let path = std::env::var("TMPDIR").unwrap();
+    let path = std::path::PathBuf::from(path).join("libfoo.so");
+
+    let s = CString::new(path.as_os_str().as_bytes()).unwrap();
+    let handle = unsafe { libc::dlopen(s.as_ptr(), libc::RTLD_LAZY | libc::RTLD_GLOBAL) };
+    if handle.is_null() {
+        let msg = unsafe { CStr::from_ptr(libc::dlerror() as *const _) };
+        panic!("failed to dlopen lib {:?}", msg);
+    }
+
+    unsafe {
+        libc::dlerror();
+    }
+
+    let raw_string = CString::new("call_exported_symbol").unwrap();
+    let symbol = unsafe { libc::dlsym(handle as *mut libc::c_void, raw_string.as_ptr()) };
+    if symbol.is_null() {
+        let msg = unsafe { CStr::from_ptr(libc::dlerror() as *const _) };
+        panic!("failed to load symbol {:?}", msg);
+    }
+    let func: extern "C" fn() -> i8 = unsafe { std::mem::transmute(symbol) };
+    assert_eq!(func(), 42);
 }
 
 #[no_mangle]
-pub extern "C" fn foo() -> i32 {
-    1 + 1
+pub fn exported_symbol() -> i8 {
+    42
 }

--- a/src/test/rustdoc/check-source-code-urls-to-def-std.rs
+++ b/src/test/rustdoc/check-source-code-urls-to-def-std.rs
@@ -15,3 +15,28 @@ pub fn foo(a: u32, b: &str, c: String) {
     let y: bool = true;
     babar();
 }
+
+macro_rules! yolo { () => {}}
+
+fn bar(a: i32) {}
+
+macro_rules! bar {
+    ($a:ident) => { bar($a) }
+}
+
+macro_rules! data {
+    ($x:expr) => { $x * 2 }
+}
+
+pub fn another_foo() {
+    // This is known limitation: if the macro doesn't generate anything, the visitor
+    // can't find any item or anything that could tell us that it comes from expansion.
+    // @!has - '//a[@href="../../src/foo/check-source-code-urls-to-def-std.rs.html#19"]' 'yolo!'
+    yolo!();
+    // @has - '//a[@href="{{channel}}/std/macro.eprintln.html"]' 'eprintln!'
+    eprintln!();
+    // @has - '//a[@href="../../src/foo/check-source-code-urls-to-def-std.rs.html#27-29"]' 'data!'
+    let x = data!(4);
+    // @has - '//a[@href="../../src/foo/check-source-code-urls-to-def-std.rs.html#23-25"]' 'bar!'
+    bar!(x);
+}

--- a/src/test/ui/const-generics/issues/issue-73727-static-reference-array-const-param.min.stderr
+++ b/src/test/ui/const-generics/issues/issue-73727-static-reference-array-const-param.min.stderr
@@ -1,5 +1,5 @@
 error: `&'static [u32]` is forbidden as the type of a const generic parameter
-  --> $DIR/static-reference-array-const-param.rs:1:15
+  --> $DIR/issue-73727-static-reference-array-const-param.rs:9:15
    |
 LL | fn a<const X: &'static [u32]>() {}
    |               ^^^^^^^^^^^^^^

--- a/src/test/ui/const-generics/issues/issue-73727-static-reference-array-const-param.rs
+++ b/src/test/ui/const-generics/issues/issue-73727-static-reference-array-const-param.rs
@@ -1,0 +1,14 @@
+// Regression test for #73727
+
+// revisions: full min
+//[full]check-pass
+
+#![cfg_attr(full, feature(adt_const_params))]
+#![cfg_attr(full, allow(incomplete_features))]
+
+fn a<const X: &'static [u32]>() {}
+//[min]~^ ERROR `&'static [u32]` is forbidden as the type of a const generic parameter
+
+fn main() {
+    a::<{&[]}>();
+}

--- a/src/test/ui/const-generics/min_const_generics/static-reference-array-const-param.rs
+++ b/src/test/ui/const-generics/min_const_generics/static-reference-array-const-param.rs
@@ -1,6 +1,0 @@
-fn a<const X: &'static [u32]>() {}
-//~^ ERROR `&'static [u32]` is forbidden as the type of a const generic parameter
-
-fn main() {
-    a::<{&[]}>();
-}

--- a/src/test/ui/error-codes/E0109.stderr
+++ b/src/test/ui/error-codes/E0109.stderr
@@ -1,10 +1,10 @@
-error[E0109]: type arguments are not allowed on this type
+error[E0109]: type arguments are not allowed on builtin type `u32`
   --> $DIR/E0109.rs:1:14
    |
 LL | type X = u32<i32>;
    |          --- ^^^ type argument not allowed
    |          |
-   |          not allowed on this type
+   |          not allowed on builtin type `u32`
    |
 help: primitive type `u32` doesn't have generic parameters
    |

--- a/src/test/ui/error-codes/E0110.stderr
+++ b/src/test/ui/error-codes/E0110.stderr
@@ -1,10 +1,10 @@
-error[E0109]: lifetime arguments are not allowed on this type
+error[E0109]: lifetime arguments are not allowed on builtin type `u32`
   --> $DIR/E0110.rs:1:14
    |
 LL | type X = u32<'static>;
    |          --- ^^^^^^^ lifetime argument not allowed
    |          |
-   |          not allowed on this type
+   |          not allowed on builtin type `u32`
    |
 help: primitive type `u32` doesn't have generic parameters
    |

--- a/src/test/ui/inference/cannot-infer-closure-circular.rs
+++ b/src/test/ui/inference/cannot-infer-closure-circular.rs
@@ -4,10 +4,10 @@ fn main() {
     // error handles this gracefully, and in particular doesn't generate an extra
     // note about the `?` operator in the closure body, which isn't relevant to
     // the inference.
-    let x = |r| {
+    let x = |r| { //~ ERROR type annotations needed for `Result<(), E>`
         let v = r?;
         Ok(v)
     };
 
-    let _ = x(x(Ok(())));  //~ ERROR type annotations needed for `Result<(), E>`
+    let _ = x(x(Ok(())));
 }

--- a/src/test/ui/inference/cannot-infer-closure-circular.stderr
+++ b/src/test/ui/inference/cannot-infer-closure-circular.stderr
@@ -1,13 +1,13 @@
 error[E0282]: type annotations needed for `Result<(), E>`
-  --> $DIR/cannot-infer-closure-circular.rs:12:9
+  --> $DIR/cannot-infer-closure-circular.rs:7:14
    |
-LL |     let _ = x(x(Ok(())));
-   |         ^
+LL |     let x = |r| {
+   |              ^
    |
-help: consider giving this pattern a type, where the type for type parameter `E` is specified
+help: consider giving this closure parameter an explicit type, where the type for type parameter `E` is specified
    |
-LL |     let _: Result<(), E> = x(x(Ok(())));
-   |          +++++++++++++++
+LL |     let x = |r: Result<(), E>| {
+   |               +++++++++++++++
 
 error: aborting due to previous error
 

--- a/src/test/ui/lub-glb/empty-binder-future-compat.rs
+++ b/src/test/ui/lub-glb/empty-binder-future-compat.rs
@@ -1,0 +1,22 @@
+// check-pass
+fn lt_in_fn_fn<'a: 'a>() -> fn(fn(&'a ())) {
+    |_| ()
+}
+
+
+fn foo<'a, 'b, 'lower>(v: bool)
+where
+    'a: 'lower,
+    'b: 'lower,
+{
+        // if we infer `x` to be higher ranked in the future,
+        // this would cause a type error.
+        let x = match v {
+            true => lt_in_fn_fn::<'a>(),
+            false => lt_in_fn_fn::<'b>(),
+        };
+
+        let _: fn(fn(&'lower())) = x;
+}
+
+fn main() {}

--- a/src/test/ui/lub-glb/empty-binders-err.rs
+++ b/src/test/ui/lub-glb/empty-binders-err.rs
@@ -11,12 +11,10 @@ fn lt_in_contra<'a: 'a>() -> Contra<'a> {
     Contra(|_| ())
 }
 
-fn covariance<'a, 'b, 'upper, 'lower>(v: bool)
+fn covariance<'a, 'b, 'upper>(v: bool)
 where
     'upper: 'a,
     'upper: 'b,
-    'a: 'lower,
-    'b: 'lower,
 
 {
     let _: &'upper () = match v {
@@ -27,10 +25,8 @@ where
     };
 }
 
-fn contra_fn<'a, 'b, 'upper, 'lower>(v: bool)
+fn contra_fn<'a, 'b, 'lower>(v: bool)
 where
-    'upper: 'a,
-    'upper: 'b,
     'a: 'lower,
     'b: 'lower,
 
@@ -43,10 +39,8 @@ where
     };
 }
 
-fn contra_struct<'a, 'b, 'upper, 'lower>(v: bool)
+fn contra_struct<'a, 'b, 'lower>(v: bool)
 where
-    'upper: 'a,
-    'upper: 'b,
     'a: 'lower,
     'b: 'lower,
 

--- a/src/test/ui/lub-glb/empty-binders-err.rs
+++ b/src/test/ui/lub-glb/empty-binders-err.rs
@@ -1,0 +1,61 @@
+fn lt<'a: 'a>() -> &'a () {
+    &()
+}
+
+fn lt_in_fn<'a: 'a>() -> fn(&'a ()) {
+    |_| ()
+}
+
+struct Contra<'a>(fn(&'a ()));
+fn lt_in_contra<'a: 'a>() -> Contra<'a> {
+    Contra(|_| ())
+}
+
+fn covariance<'a, 'b, 'upper, 'lower>(v: bool)
+where
+    'upper: 'a,
+    'upper: 'b,
+    'a: 'lower,
+    'b: 'lower,
+
+{
+    let _: &'upper () = match v {
+        //~^ ERROR lifetime may not live long enough
+        //~| ERROR lifetime may not live long enough
+        true => lt::<'a>(),
+        false => lt::<'b>(),
+    };
+}
+
+fn contra_fn<'a, 'b, 'upper, 'lower>(v: bool)
+where
+    'upper: 'a,
+    'upper: 'b,
+    'a: 'lower,
+    'b: 'lower,
+
+{
+
+    let _: fn(&'lower ()) = match v {
+        //~^ ERROR lifetime may not live long enough
+        true => lt_in_fn::<'a>(),
+        false => lt_in_fn::<'b>(),
+    };
+}
+
+fn contra_struct<'a, 'b, 'upper, 'lower>(v: bool)
+where
+    'upper: 'a,
+    'upper: 'b,
+    'a: 'lower,
+    'b: 'lower,
+
+{
+    let _: Contra<'lower> = match v {
+        //~^ ERROR lifetime may not live long enough
+        true => lt_in_contra::<'a>(),
+        false => lt_in_contra::<'b>(),
+    };
+}
+
+fn main() {}

--- a/src/test/ui/lub-glb/empty-binders-err.stderr
+++ b/src/test/ui/lub-glb/empty-binders-err.stderr
@@ -1,0 +1,59 @@
+error: lifetime may not live long enough
+  --> $DIR/empty-binders-err.rs:22:12
+   |
+LL | fn covariance<'a, 'b, 'upper, 'lower>(v: bool)
+   |               --      ------ lifetime `'upper` defined here
+   |               |
+   |               lifetime `'a` defined here
+...
+LL |     let _: &'upper () = match v {
+   |            ^^^^^^^^^^ type annotation requires that `'a` must outlive `'upper`
+   |
+   = help: consider adding the following bound: `'a: 'upper`
+
+error: lifetime may not live long enough
+  --> $DIR/empty-binders-err.rs:22:12
+   |
+LL | fn covariance<'a, 'b, 'upper, 'lower>(v: bool)
+   |                   --  ------ lifetime `'upper` defined here
+   |                   |
+   |                   lifetime `'b` defined here
+...
+LL |     let _: &'upper () = match v {
+   |            ^^^^^^^^^^ type annotation requires that `'b` must outlive `'upper`
+   |
+   = help: consider adding the following bound: `'b: 'upper`
+
+help: the following changes may resolve your lifetime errors
+   |
+   = help: add bound `'a: 'upper`
+   = help: add bound `'b: 'upper`
+
+error: lifetime may not live long enough
+  --> $DIR/empty-binders-err.rs:39:12
+   |
+LL | fn contra_fn<'a, 'b, 'upper, 'lower>(v: bool)
+   |              --              ------ lifetime `'lower` defined here
+   |              |
+   |              lifetime `'a` defined here
+...
+LL |     let _: fn(&'lower ()) = match v {
+   |            ^^^^^^^^^^^^^^ type annotation requires that `'lower` must outlive `'a`
+   |
+   = help: consider adding the following bound: `'lower: 'a`
+
+error: lifetime may not live long enough
+  --> $DIR/empty-binders-err.rs:54:12
+   |
+LL | fn contra_struct<'a, 'b, 'upper, 'lower>(v: bool)
+   |                  --              ------ lifetime `'lower` defined here
+   |                  |
+   |                  lifetime `'a` defined here
+...
+LL |     let _: Contra<'lower> = match v {
+   |            ^^^^^^^^^^^^^^ type annotation requires that `'lower` must outlive `'a`
+   |
+   = help: consider adding the following bound: `'lower: 'a`
+
+error: aborting due to 4 previous errors
+

--- a/src/test/ui/lub-glb/empty-binders-err.stderr
+++ b/src/test/ui/lub-glb/empty-binders-err.stderr
@@ -1,7 +1,7 @@
 error: lifetime may not live long enough
-  --> $DIR/empty-binders-err.rs:22:12
+  --> $DIR/empty-binders-err.rs:20:12
    |
-LL | fn covariance<'a, 'b, 'upper, 'lower>(v: bool)
+LL | fn covariance<'a, 'b, 'upper>(v: bool)
    |               --      ------ lifetime `'upper` defined here
    |               |
    |               lifetime `'a` defined here
@@ -12,9 +12,9 @@ LL |     let _: &'upper () = match v {
    = help: consider adding the following bound: `'a: 'upper`
 
 error: lifetime may not live long enough
-  --> $DIR/empty-binders-err.rs:22:12
+  --> $DIR/empty-binders-err.rs:20:12
    |
-LL | fn covariance<'a, 'b, 'upper, 'lower>(v: bool)
+LL | fn covariance<'a, 'b, 'upper>(v: bool)
    |                   --  ------ lifetime `'upper` defined here
    |                   |
    |                   lifetime `'b` defined here
@@ -30,10 +30,10 @@ help: the following changes may resolve your lifetime errors
    = help: add bound `'b: 'upper`
 
 error: lifetime may not live long enough
-  --> $DIR/empty-binders-err.rs:39:12
+  --> $DIR/empty-binders-err.rs:35:12
    |
-LL | fn contra_fn<'a, 'b, 'upper, 'lower>(v: bool)
-   |              --              ------ lifetime `'lower` defined here
+LL | fn contra_fn<'a, 'b, 'lower>(v: bool)
+   |              --      ------ lifetime `'lower` defined here
    |              |
    |              lifetime `'a` defined here
 ...
@@ -43,10 +43,10 @@ LL |     let _: fn(&'lower ()) = match v {
    = help: consider adding the following bound: `'lower: 'a`
 
 error: lifetime may not live long enough
-  --> $DIR/empty-binders-err.rs:54:12
+  --> $DIR/empty-binders-err.rs:48:12
    |
-LL | fn contra_struct<'a, 'b, 'upper, 'lower>(v: bool)
-   |                  --              ------ lifetime `'lower` defined here
+LL | fn contra_struct<'a, 'b, 'lower>(v: bool)
+   |                  --      ------ lifetime `'lower` defined here
    |                  |
    |                  lifetime `'a` defined here
 ...

--- a/src/test/ui/lub-glb/empty-binders.rs
+++ b/src/test/ui/lub-glb/empty-binders.rs
@@ -1,0 +1,45 @@
+// check-pass
+//
+// Check that computing the lub works even for empty binders.
+fn lt<'a: 'a>() -> &'a () {
+    &()
+}
+
+fn lt_in_fn<'a: 'a>() -> fn(&'a ()) {
+    |_| ()
+}
+
+struct Contra<'a>(fn(&'a ()));
+fn lt_in_contra<'a: 'a>() -> Contra<'a> {
+    Contra(|_| ())
+}
+
+fn ok<'a, 'b, 'upper, 'lower>(v: bool)
+where
+    'upper: 'a,
+    'upper: 'b,
+    'a: 'lower,
+    'b: 'lower,
+
+{
+    let _: &'lower () = match v {
+        true => lt::<'a>(),
+        false => lt::<'b>(),
+    };
+
+    // This errored in the past because LUB and GLB always
+    // bailed out when encountering binders, even if they were
+    // empty.
+    let _: fn(&'upper ()) = match v {
+        true => lt_in_fn::<'a>(),
+        false => lt_in_fn::<'b>(),
+    };
+
+    // This was already accepted, as relate didn't encounter any binders.
+    let _: Contra<'upper> = match v {
+        true => lt_in_contra::<'a>(),
+        false => lt_in_contra::<'b>(),
+    };
+}
+
+fn main() {}

--- a/src/test/ui/nll/issue-98170.rs
+++ b/src/test/ui/nll/issue-98170.rs
@@ -1,0 +1,25 @@
+pub struct MyStruct<'a> {
+    field: &'a [u32],
+}
+
+impl MyStruct<'_> {
+    pub fn new<'a>(field: &'a [u32]) -> MyStruct<'a> {
+        Self { field }
+        //~^ ERROR lifetime may not live long enough
+        //~| ERROR lifetime may not live long enough
+    }
+}
+
+trait Trait<'a> {
+    fn new(field: &'a [u32]) -> MyStruct<'a>;
+}
+
+impl<'a> Trait<'a> for MyStruct<'_> {
+    fn new(field: &'a [u32]) -> MyStruct<'a> {
+        Self { field }
+        //~^ ERROR lifetime may not live long enough
+        //~| ERROR lifetime may not live long enough
+    }
+}
+
+fn main() {}

--- a/src/test/ui/nll/issue-98170.stderr
+++ b/src/test/ui/nll/issue-98170.stderr
@@ -1,0 +1,44 @@
+error: lifetime may not live long enough
+  --> $DIR/issue-98170.rs:7:9
+   |
+LL | impl MyStruct<'_> {
+   |               -- lifetime `'1` appears in the `impl`'s self type
+LL |     pub fn new<'a>(field: &'a [u32]) -> MyStruct<'a> {
+   |                -- lifetime `'a` defined here
+LL |         Self { field }
+   |         ^^^^^^^^^^^^^^ associated function was supposed to return data with lifetime `'a` but it is returning data with lifetime `'1`
+
+error: lifetime may not live long enough
+  --> $DIR/issue-98170.rs:7:16
+   |
+LL | impl MyStruct<'_> {
+   |               -- lifetime `'1` appears in the `impl`'s self type
+LL |     pub fn new<'a>(field: &'a [u32]) -> MyStruct<'a> {
+   |                -- lifetime `'a` defined here
+LL |         Self { field }
+   |                ^^^^^ this usage requires that `'a` must outlive `'1`
+
+error: lifetime may not live long enough
+  --> $DIR/issue-98170.rs:19:9
+   |
+LL | impl<'a> Trait<'a> for MyStruct<'_> {
+   |      --                         -- lifetime `'1` appears in the `impl`'s self type
+   |      |
+   |      lifetime `'a` defined here
+LL |     fn new(field: &'a [u32]) -> MyStruct<'a> {
+LL |         Self { field }
+   |         ^^^^^^^^^^^^^^ associated function was supposed to return data with lifetime `'a` but it is returning data with lifetime `'1`
+
+error: lifetime may not live long enough
+  --> $DIR/issue-98170.rs:19:16
+   |
+LL | impl<'a> Trait<'a> for MyStruct<'_> {
+   |      --                         -- lifetime `'1` appears in the `impl`'s self type
+   |      |
+   |      lifetime `'a` defined here
+LL |     fn new(field: &'a [u32]) -> MyStruct<'a> {
+LL |         Self { field }
+   |                ^^^^^ this usage requires that `'a` must outlive `'1`
+
+error: aborting due to 4 previous errors
+

--- a/src/test/ui/type-alias-enum-variants/enum-variant-generic-args.rs
+++ b/src/test/ui/type-alias-enum-variants/enum-variant-generic-args.rs
@@ -52,7 +52,7 @@ fn main() {
     // Tuple struct variant
 
     Enum::<()>::TSVariant::<()>(());
-    //~^ ERROR type arguments are not allowed on this type [E0109]
+    //~^ ERROR type arguments are not allowed on tuple variant `TSVariant` [E0109]
 
     Alias::TSVariant::<()>(());
     //~^ ERROR type arguments are not allowed on this type [E0109]
@@ -70,7 +70,7 @@ fn main() {
     // Struct variant
 
     Enum::<()>::SVariant::<()> { v: () };
-    //~^ ERROR type arguments are not allowed on this type [E0109]
+    //~^ ERROR type arguments are not allowed on variant `SVariant` [E0109]
 
     Alias::SVariant::<()> { v: () };
     //~^ ERROR type arguments are not allowed on this type [E0109]
@@ -88,7 +88,7 @@ fn main() {
     // Unit variant
 
     Enum::<()>::UVariant::<()>;
-    //~^ ERROR type arguments are not allowed on this type [E0109]
+    //~^ ERROR type arguments are not allowed on unit variant `UVariant` [E0109]
 
     Alias::UVariant::<()>;
     //~^ ERROR type arguments are not allowed on this type [E0109]

--- a/src/test/ui/type-alias-enum-variants/enum-variant-generic-args.stderr
+++ b/src/test/ui/type-alias-enum-variants/enum-variant-generic-args.stderr
@@ -272,13 +272,13 @@ LL |         Self::<()>::UVariant::<()>;
    |                     |
    |                     not allowed on this type
 
-error[E0109]: type arguments are not allowed on this type
+error[E0109]: type arguments are not allowed on tuple variant `TSVariant`
   --> $DIR/enum-variant-generic-args.rs:54:29
    |
 LL |     Enum::<()>::TSVariant::<()>(());
    |                 ---------   ^^ type argument not allowed
    |                 |
-   |                 not allowed on this type
+   |                 not allowed on tuple variant `TSVariant`
 
 error[E0109]: type arguments are not allowed on this type
   --> $DIR/enum-variant-generic-args.rs:57:24
@@ -340,13 +340,13 @@ LL |     AliasFixed::<()>::TSVariant::<()>(());
    |                       |
    |                       not allowed on this type
 
-error[E0109]: type arguments are not allowed on this type
+error[E0109]: type arguments are not allowed on variant `SVariant`
   --> $DIR/enum-variant-generic-args.rs:72:28
    |
 LL |     Enum::<()>::SVariant::<()> { v: () };
    |                 --------   ^^ type argument not allowed
    |                 |
-   |                 not allowed on this type
+   |                 not allowed on variant `SVariant`
    |
    = note: enum variants can't have type parameters
 
@@ -438,13 +438,13 @@ LL -     AliasFixed::<()>::SVariant::<()> { v: () };
 LL +     AliasFixed::<()>::SVariant { v: () };
    |
 
-error[E0109]: type arguments are not allowed on this type
+error[E0109]: type arguments are not allowed on unit variant `UVariant`
   --> $DIR/enum-variant-generic-args.rs:90:28
    |
 LL |     Enum::<()>::UVariant::<()>;
    |                 --------   ^^ type argument not allowed
    |                 |
-   |                 not allowed on this type
+   |                 not allowed on unit variant `UVariant`
 
 error[E0109]: type arguments are not allowed on this type
   --> $DIR/enum-variant-generic-args.rs:93:23

--- a/src/test/ui/type/issue-91268.rs
+++ b/src/test/ui/type/issue-91268.rs
@@ -1,7 +1,7 @@
 // error-pattern: this file contains an unclosed delimiter
 // error-pattern: cannot find type `ţ` in this scope
 // error-pattern: parenthesized type parameters may only be used with a `Fn` trait
-// error-pattern: type arguments are not allowed on this type
+// error-pattern: type arguments are not allowed on builtin type `u8`
 // error-pattern: mismatched types
 // ignore-tidy-trailing-newlines
 // `ţ` must be the last character in this file, it cannot be followed by a newline

--- a/src/test/ui/type/issue-91268.stderr
+++ b/src/test/ui/type/issue-91268.stderr
@@ -35,13 +35,13 @@ help: use angle brackets instead
 LL |     0: u8<ţ>
    |          ~ +
 
-error[E0109]: type arguments are not allowed on this type
+error[E0109]: type arguments are not allowed on builtin type `u8`
   --> $DIR/issue-91268.rs:9:11
    |
 LL |     0: u8(ţ
    |        -- ^ type argument not allowed
    |        |
-   |        not allowed on this type
+   |        not allowed on builtin type `u8`
    |
 help: primitive type `u8` doesn't have generic parameters
    |

--- a/src/test/ui/typeck/prim-with-args.fixed
+++ b/src/test/ui/typeck/prim-with-args.fixed
@@ -1,28 +1,28 @@
 // run-rustfix
 fn main() {
 
-let _x: isize; //~ ERROR type arguments are not allowed on this type
-let _x: i8; //~ ERROR type arguments are not allowed on this type
-let _x: i16; //~ ERROR type arguments are not allowed on this type
-let _x: i32; //~ ERROR type arguments are not allowed on this type
-let _x: i64; //~ ERROR type arguments are not allowed on this type
-let _x: usize; //~ ERROR type arguments are not allowed on this type
-let _x: u8; //~ ERROR type arguments are not allowed on this type
-let _x: u16; //~ ERROR type arguments are not allowed on this type
-let _x: u32; //~ ERROR type arguments are not allowed on this type
-let _x: u64; //~ ERROR type arguments are not allowed on this type
-let _x: char; //~ ERROR type arguments are not allowed on this type
+let _x: isize; //~ ERROR type arguments are not allowed on builtin type
+let _x: i8; //~ ERROR type arguments are not allowed on builtin type
+let _x: i16; //~ ERROR type arguments are not allowed on builtin type
+let _x: i32; //~ ERROR type arguments are not allowed on builtin type
+let _x: i64; //~ ERROR type arguments are not allowed on builtin type
+let _x: usize; //~ ERROR type arguments are not allowed on builtin type
+let _x: u8; //~ ERROR type arguments are not allowed on builtin type
+let _x: u16; //~ ERROR type arguments are not allowed on builtin type
+let _x: u32; //~ ERROR type arguments are not allowed on builtin type
+let _x: u64; //~ ERROR type arguments are not allowed on builtin type
+let _x: char; //~ ERROR type arguments are not allowed on builtin type
 
-let _x: isize; //~ ERROR lifetime arguments are not allowed on this type
-let _x: i8; //~ ERROR lifetime arguments are not allowed on this type
-let _x: i16; //~ ERROR lifetime arguments are not allowed on this type
-let _x: i32; //~ ERROR lifetime arguments are not allowed on this type
-let _x: i64; //~ ERROR lifetime arguments are not allowed on this type
-let _x: usize; //~ ERROR lifetime arguments are not allowed on this type
-let _x: u8; //~ ERROR lifetime arguments are not allowed on this type
-let _x: u16; //~ ERROR lifetime arguments are not allowed on this type
-let _x: u32; //~ ERROR lifetime arguments are not allowed on this type
-let _x: u64; //~ ERROR lifetime arguments are not allowed on this type
-let _x: char; //~ ERROR lifetime arguments are not allowed on this type
+let _x: isize; //~ ERROR lifetime arguments are not allowed on builtin type
+let _x: i8; //~ ERROR lifetime arguments are not allowed on builtin type
+let _x: i16; //~ ERROR lifetime arguments are not allowed on builtin type
+let _x: i32; //~ ERROR lifetime arguments are not allowed on builtin type
+let _x: i64; //~ ERROR lifetime arguments are not allowed on builtin type
+let _x: usize; //~ ERROR lifetime arguments are not allowed on builtin type
+let _x: u8; //~ ERROR lifetime arguments are not allowed on builtin type
+let _x: u16; //~ ERROR lifetime arguments are not allowed on builtin type
+let _x: u32; //~ ERROR lifetime arguments are not allowed on builtin type
+let _x: u64; //~ ERROR lifetime arguments are not allowed on builtin type
+let _x: char; //~ ERROR lifetime arguments are not allowed on builtin type
 
 }

--- a/src/test/ui/typeck/prim-with-args.rs
+++ b/src/test/ui/typeck/prim-with-args.rs
@@ -1,28 +1,28 @@
 // run-rustfix
 fn main() {
 
-let _x: isize<isize>; //~ ERROR type arguments are not allowed on this type
-let _x: i8<isize>; //~ ERROR type arguments are not allowed on this type
-let _x: i16<isize>; //~ ERROR type arguments are not allowed on this type
-let _x: i32<isize>; //~ ERROR type arguments are not allowed on this type
-let _x: i64<isize>; //~ ERROR type arguments are not allowed on this type
-let _x: usize<isize>; //~ ERROR type arguments are not allowed on this type
-let _x: u8<isize>; //~ ERROR type arguments are not allowed on this type
-let _x: u16<isize>; //~ ERROR type arguments are not allowed on this type
-let _x: u32<isize>; //~ ERROR type arguments are not allowed on this type
-let _x: u64<isize>; //~ ERROR type arguments are not allowed on this type
-let _x: char<isize>; //~ ERROR type arguments are not allowed on this type
+let _x: isize<isize>; //~ ERROR type arguments are not allowed on builtin type
+let _x: i8<isize>; //~ ERROR type arguments are not allowed on builtin type
+let _x: i16<isize>; //~ ERROR type arguments are not allowed on builtin type
+let _x: i32<isize>; //~ ERROR type arguments are not allowed on builtin type
+let _x: i64<isize>; //~ ERROR type arguments are not allowed on builtin type
+let _x: usize<isize>; //~ ERROR type arguments are not allowed on builtin type
+let _x: u8<isize>; //~ ERROR type arguments are not allowed on builtin type
+let _x: u16<isize>; //~ ERROR type arguments are not allowed on builtin type
+let _x: u32<isize>; //~ ERROR type arguments are not allowed on builtin type
+let _x: u64<isize>; //~ ERROR type arguments are not allowed on builtin type
+let _x: char<isize>; //~ ERROR type arguments are not allowed on builtin type
 
-let _x: isize<'static>; //~ ERROR lifetime arguments are not allowed on this type
-let _x: i8<'static>; //~ ERROR lifetime arguments are not allowed on this type
-let _x: i16<'static>; //~ ERROR lifetime arguments are not allowed on this type
-let _x: i32<'static>; //~ ERROR lifetime arguments are not allowed on this type
-let _x: i64<'static>; //~ ERROR lifetime arguments are not allowed on this type
-let _x: usize<'static>; //~ ERROR lifetime arguments are not allowed on this type
-let _x: u8<'static>; //~ ERROR lifetime arguments are not allowed on this type
-let _x: u16<'static>; //~ ERROR lifetime arguments are not allowed on this type
-let _x: u32<'static>; //~ ERROR lifetime arguments are not allowed on this type
-let _x: u64<'static>; //~ ERROR lifetime arguments are not allowed on this type
-let _x: char<'static>; //~ ERROR lifetime arguments are not allowed on this type
+let _x: isize<'static>; //~ ERROR lifetime arguments are not allowed on builtin type
+let _x: i8<'static>; //~ ERROR lifetime arguments are not allowed on builtin type
+let _x: i16<'static>; //~ ERROR lifetime arguments are not allowed on builtin type
+let _x: i32<'static>; //~ ERROR lifetime arguments are not allowed on builtin type
+let _x: i64<'static>; //~ ERROR lifetime arguments are not allowed on builtin type
+let _x: usize<'static>; //~ ERROR lifetime arguments are not allowed on builtin type
+let _x: u8<'static>; //~ ERROR lifetime arguments are not allowed on builtin type
+let _x: u16<'static>; //~ ERROR lifetime arguments are not allowed on builtin type
+let _x: u32<'static>; //~ ERROR lifetime arguments are not allowed on builtin type
+let _x: u64<'static>; //~ ERROR lifetime arguments are not allowed on builtin type
+let _x: char<'static>; //~ ERROR lifetime arguments are not allowed on builtin type
 
 }

--- a/src/test/ui/typeck/prim-with-args.stderr
+++ b/src/test/ui/typeck/prim-with-args.stderr
@@ -1,10 +1,10 @@
-error[E0109]: type arguments are not allowed on this type
+error[E0109]: type arguments are not allowed on builtin type `isize`
   --> $DIR/prim-with-args.rs:4:15
    |
 LL | let _x: isize<isize>;
    |         ----- ^^^^^ type argument not allowed
    |         |
-   |         not allowed on this type
+   |         not allowed on builtin type `isize`
    |
 help: primitive type `isize` doesn't have generic parameters
    |
@@ -12,13 +12,13 @@ LL - let _x: isize<isize>;
 LL + let _x: isize;
    |
 
-error[E0109]: type arguments are not allowed on this type
+error[E0109]: type arguments are not allowed on builtin type `i8`
   --> $DIR/prim-with-args.rs:5:12
    |
 LL | let _x: i8<isize>;
    |         -- ^^^^^ type argument not allowed
    |         |
-   |         not allowed on this type
+   |         not allowed on builtin type `i8`
    |
 help: primitive type `i8` doesn't have generic parameters
    |
@@ -26,13 +26,13 @@ LL - let _x: i8<isize>;
 LL + let _x: i8;
    |
 
-error[E0109]: type arguments are not allowed on this type
+error[E0109]: type arguments are not allowed on builtin type `i16`
   --> $DIR/prim-with-args.rs:6:13
    |
 LL | let _x: i16<isize>;
    |         --- ^^^^^ type argument not allowed
    |         |
-   |         not allowed on this type
+   |         not allowed on builtin type `i16`
    |
 help: primitive type `i16` doesn't have generic parameters
    |
@@ -40,13 +40,13 @@ LL - let _x: i16<isize>;
 LL + let _x: i16;
    |
 
-error[E0109]: type arguments are not allowed on this type
+error[E0109]: type arguments are not allowed on builtin type `i32`
   --> $DIR/prim-with-args.rs:7:13
    |
 LL | let _x: i32<isize>;
    |         --- ^^^^^ type argument not allowed
    |         |
-   |         not allowed on this type
+   |         not allowed on builtin type `i32`
    |
 help: primitive type `i32` doesn't have generic parameters
    |
@@ -54,13 +54,13 @@ LL - let _x: i32<isize>;
 LL + let _x: i32;
    |
 
-error[E0109]: type arguments are not allowed on this type
+error[E0109]: type arguments are not allowed on builtin type `i64`
   --> $DIR/prim-with-args.rs:8:13
    |
 LL | let _x: i64<isize>;
    |         --- ^^^^^ type argument not allowed
    |         |
-   |         not allowed on this type
+   |         not allowed on builtin type `i64`
    |
 help: primitive type `i64` doesn't have generic parameters
    |
@@ -68,13 +68,13 @@ LL - let _x: i64<isize>;
 LL + let _x: i64;
    |
 
-error[E0109]: type arguments are not allowed on this type
+error[E0109]: type arguments are not allowed on builtin type `usize`
   --> $DIR/prim-with-args.rs:9:15
    |
 LL | let _x: usize<isize>;
    |         ----- ^^^^^ type argument not allowed
    |         |
-   |         not allowed on this type
+   |         not allowed on builtin type `usize`
    |
 help: primitive type `usize` doesn't have generic parameters
    |
@@ -82,13 +82,13 @@ LL - let _x: usize<isize>;
 LL + let _x: usize;
    |
 
-error[E0109]: type arguments are not allowed on this type
+error[E0109]: type arguments are not allowed on builtin type `u8`
   --> $DIR/prim-with-args.rs:10:12
    |
 LL | let _x: u8<isize>;
    |         -- ^^^^^ type argument not allowed
    |         |
-   |         not allowed on this type
+   |         not allowed on builtin type `u8`
    |
 help: primitive type `u8` doesn't have generic parameters
    |
@@ -96,13 +96,13 @@ LL - let _x: u8<isize>;
 LL + let _x: u8;
    |
 
-error[E0109]: type arguments are not allowed on this type
+error[E0109]: type arguments are not allowed on builtin type `u16`
   --> $DIR/prim-with-args.rs:11:13
    |
 LL | let _x: u16<isize>;
    |         --- ^^^^^ type argument not allowed
    |         |
-   |         not allowed on this type
+   |         not allowed on builtin type `u16`
    |
 help: primitive type `u16` doesn't have generic parameters
    |
@@ -110,13 +110,13 @@ LL - let _x: u16<isize>;
 LL + let _x: u16;
    |
 
-error[E0109]: type arguments are not allowed on this type
+error[E0109]: type arguments are not allowed on builtin type `u32`
   --> $DIR/prim-with-args.rs:12:13
    |
 LL | let _x: u32<isize>;
    |         --- ^^^^^ type argument not allowed
    |         |
-   |         not allowed on this type
+   |         not allowed on builtin type `u32`
    |
 help: primitive type `u32` doesn't have generic parameters
    |
@@ -124,13 +124,13 @@ LL - let _x: u32<isize>;
 LL + let _x: u32;
    |
 
-error[E0109]: type arguments are not allowed on this type
+error[E0109]: type arguments are not allowed on builtin type `u64`
   --> $DIR/prim-with-args.rs:13:13
    |
 LL | let _x: u64<isize>;
    |         --- ^^^^^ type argument not allowed
    |         |
-   |         not allowed on this type
+   |         not allowed on builtin type `u64`
    |
 help: primitive type `u64` doesn't have generic parameters
    |
@@ -138,13 +138,13 @@ LL - let _x: u64<isize>;
 LL + let _x: u64;
    |
 
-error[E0109]: type arguments are not allowed on this type
+error[E0109]: type arguments are not allowed on builtin type `char`
   --> $DIR/prim-with-args.rs:14:14
    |
 LL | let _x: char<isize>;
    |         ---- ^^^^^ type argument not allowed
    |         |
-   |         not allowed on this type
+   |         not allowed on builtin type `char`
    |
 help: primitive type `char` doesn't have generic parameters
    |
@@ -152,13 +152,13 @@ LL - let _x: char<isize>;
 LL + let _x: char;
    |
 
-error[E0109]: lifetime arguments are not allowed on this type
+error[E0109]: lifetime arguments are not allowed on builtin type `isize`
   --> $DIR/prim-with-args.rs:16:15
    |
 LL | let _x: isize<'static>;
    |         ----- ^^^^^^^ lifetime argument not allowed
    |         |
-   |         not allowed on this type
+   |         not allowed on builtin type `isize`
    |
 help: primitive type `isize` doesn't have generic parameters
    |
@@ -166,13 +166,13 @@ LL - let _x: isize<'static>;
 LL + let _x: isize;
    |
 
-error[E0109]: lifetime arguments are not allowed on this type
+error[E0109]: lifetime arguments are not allowed on builtin type `i8`
   --> $DIR/prim-with-args.rs:17:12
    |
 LL | let _x: i8<'static>;
    |         -- ^^^^^^^ lifetime argument not allowed
    |         |
-   |         not allowed on this type
+   |         not allowed on builtin type `i8`
    |
 help: primitive type `i8` doesn't have generic parameters
    |
@@ -180,13 +180,13 @@ LL - let _x: i8<'static>;
 LL + let _x: i8;
    |
 
-error[E0109]: lifetime arguments are not allowed on this type
+error[E0109]: lifetime arguments are not allowed on builtin type `i16`
   --> $DIR/prim-with-args.rs:18:13
    |
 LL | let _x: i16<'static>;
    |         --- ^^^^^^^ lifetime argument not allowed
    |         |
-   |         not allowed on this type
+   |         not allowed on builtin type `i16`
    |
 help: primitive type `i16` doesn't have generic parameters
    |
@@ -194,13 +194,13 @@ LL - let _x: i16<'static>;
 LL + let _x: i16;
    |
 
-error[E0109]: lifetime arguments are not allowed on this type
+error[E0109]: lifetime arguments are not allowed on builtin type `i32`
   --> $DIR/prim-with-args.rs:19:13
    |
 LL | let _x: i32<'static>;
    |         --- ^^^^^^^ lifetime argument not allowed
    |         |
-   |         not allowed on this type
+   |         not allowed on builtin type `i32`
    |
 help: primitive type `i32` doesn't have generic parameters
    |
@@ -208,13 +208,13 @@ LL - let _x: i32<'static>;
 LL + let _x: i32;
    |
 
-error[E0109]: lifetime arguments are not allowed on this type
+error[E0109]: lifetime arguments are not allowed on builtin type `i64`
   --> $DIR/prim-with-args.rs:20:13
    |
 LL | let _x: i64<'static>;
    |         --- ^^^^^^^ lifetime argument not allowed
    |         |
-   |         not allowed on this type
+   |         not allowed on builtin type `i64`
    |
 help: primitive type `i64` doesn't have generic parameters
    |
@@ -222,13 +222,13 @@ LL - let _x: i64<'static>;
 LL + let _x: i64;
    |
 
-error[E0109]: lifetime arguments are not allowed on this type
+error[E0109]: lifetime arguments are not allowed on builtin type `usize`
   --> $DIR/prim-with-args.rs:21:15
    |
 LL | let _x: usize<'static>;
    |         ----- ^^^^^^^ lifetime argument not allowed
    |         |
-   |         not allowed on this type
+   |         not allowed on builtin type `usize`
    |
 help: primitive type `usize` doesn't have generic parameters
    |
@@ -236,13 +236,13 @@ LL - let _x: usize<'static>;
 LL + let _x: usize;
    |
 
-error[E0109]: lifetime arguments are not allowed on this type
+error[E0109]: lifetime arguments are not allowed on builtin type `u8`
   --> $DIR/prim-with-args.rs:22:12
    |
 LL | let _x: u8<'static>;
    |         -- ^^^^^^^ lifetime argument not allowed
    |         |
-   |         not allowed on this type
+   |         not allowed on builtin type `u8`
    |
 help: primitive type `u8` doesn't have generic parameters
    |
@@ -250,13 +250,13 @@ LL - let _x: u8<'static>;
 LL + let _x: u8;
    |
 
-error[E0109]: lifetime arguments are not allowed on this type
+error[E0109]: lifetime arguments are not allowed on builtin type `u16`
   --> $DIR/prim-with-args.rs:23:13
    |
 LL | let _x: u16<'static>;
    |         --- ^^^^^^^ lifetime argument not allowed
    |         |
-   |         not allowed on this type
+   |         not allowed on builtin type `u16`
    |
 help: primitive type `u16` doesn't have generic parameters
    |
@@ -264,13 +264,13 @@ LL - let _x: u16<'static>;
 LL + let _x: u16;
    |
 
-error[E0109]: lifetime arguments are not allowed on this type
+error[E0109]: lifetime arguments are not allowed on builtin type `u32`
   --> $DIR/prim-with-args.rs:24:13
    |
 LL | let _x: u32<'static>;
    |         --- ^^^^^^^ lifetime argument not allowed
    |         |
-   |         not allowed on this type
+   |         not allowed on builtin type `u32`
    |
 help: primitive type `u32` doesn't have generic parameters
    |
@@ -278,13 +278,13 @@ LL - let _x: u32<'static>;
 LL + let _x: u32;
    |
 
-error[E0109]: lifetime arguments are not allowed on this type
+error[E0109]: lifetime arguments are not allowed on builtin type `u64`
   --> $DIR/prim-with-args.rs:25:13
    |
 LL | let _x: u64<'static>;
    |         --- ^^^^^^^ lifetime argument not allowed
    |         |
-   |         not allowed on this type
+   |         not allowed on builtin type `u64`
    |
 help: primitive type `u64` doesn't have generic parameters
    |
@@ -292,13 +292,13 @@ LL - let _x: u64<'static>;
 LL + let _x: u64;
    |
 
-error[E0109]: lifetime arguments are not allowed on this type
+error[E0109]: lifetime arguments are not allowed on builtin type `char`
   --> $DIR/prim-with-args.rs:26:14
    |
 LL | let _x: char<'static>;
    |         ---- ^^^^^^^ lifetime argument not allowed
    |         |
-   |         not allowed on this type
+   |         not allowed on builtin type `char`
    |
 help: primitive type `char` doesn't have generic parameters
    |

--- a/src/test/ui/usize-generic-argument-parent.rs
+++ b/src/test/ui/usize-generic-argument-parent.rs
@@ -1,5 +1,5 @@
 fn foo() {
-    let x: usize<foo>; //~ ERROR const arguments are not allowed on this type
+    let x: usize<foo>; //~ ERROR const arguments are not allowed on builtin type `usize`
 }
 
 fn main() {}

--- a/src/test/ui/usize-generic-argument-parent.stderr
+++ b/src/test/ui/usize-generic-argument-parent.stderr
@@ -1,10 +1,10 @@
-error[E0109]: const arguments are not allowed on this type
+error[E0109]: const arguments are not allowed on builtin type `usize`
   --> $DIR/usize-generic-argument-parent.rs:2:18
    |
 LL |     let x: usize<foo>;
    |            ----- ^^^ const argument not allowed
    |            |
-   |            not allowed on this type
+   |            not allowed on builtin type `usize`
    |
 help: primitive type `usize` doesn't have generic parameters
    |


### PR DESCRIPTION
Successful merges:

 - #85673 (RFC-2841: add codegen flag export symbols from executable)
 - #91264 (Add macro support in jump to definition feature)
 - #97867 (lub: don't bail out due to empty binders)
 - #98184 (Give name if anonymous region appears in impl signature)
 - #98269 (Provide a `PathSegment.res` in more cases)
 - #98334 (Add a full regression test for #73727)
 - #98344 (This comment is out dated and misleading, the arm is about TAITs)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=85673,91264,97867,98184,98269,98334,98344)
<!-- homu-ignore:end -->