### PR TITLE
Migrate two diagnostics from the `rustc_builtin_macros` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3669,6 +3669,7 @@ dependencies = [
  "rustc_feature",
  "rustc_lexer",
  "rustc_lint_defs",
+ "rustc_macros",
  "rustc_parse",
  "rustc_parse_format",
  "rustc_session",

--- a/compiler/rustc_builtin_macros/Cargo.toml
+++ b/compiler/rustc_builtin_macros/Cargo.toml
@@ -16,6 +16,7 @@ rustc_errors = { path = "../rustc_errors" }
 rustc_feature = { path = "../rustc_feature" }
 rustc_lexer = { path = "../rustc_lexer" }
 rustc_lint_defs = { path = "../rustc_lint_defs" }
+rustc_macros = { path = "../rustc_macros" }
 rustc_parse = { path = "../rustc_parse" }
 rustc_target = { path = "../rustc_target" }
 rustc_session = { path = "../rustc_session" }

--- a/compiler/rustc_builtin_macros/src/cfg.rs
+++ b/compiler/rustc_builtin_macros/src/cfg.rs
@@ -43,6 +43,13 @@ struct RequiresCfgPattern {
     span: Span,
 }
 
+#[derive(SessionDiagnostic)]
+#[error(slug = "builtin-macros-expected-one-cfg-pattern")]
+struct OneCfgPattern {
+    #[primary_span]
+    span: Span,
+}
+
 fn parse_cfg<'a>(cx: &mut ExtCtxt<'a>, span: Span, tts: TokenStream) -> PResult<'a, ast::MetaItem> {
     let mut p = cx.new_parser_from_tts(tts);
 
@@ -55,7 +62,7 @@ fn parse_cfg<'a>(cx: &mut ExtCtxt<'a>, span: Span, tts: TokenStream) -> PResult<
     let _ = p.eat(&token::Comma);
 
     if !p.eat(&token::Eof) {
-        return Err(cx.struct_span_err(span, "expected 1 cfg-pattern"));
+        return Err(cx.create_err(OneCfgPattern { span }));
     }
 
     Ok(cfg)

--- a/compiler/rustc_builtin_macros/src/cfg.rs
+++ b/compiler/rustc_builtin_macros/src/cfg.rs
@@ -8,6 +8,7 @@ use rustc_ast::tokenstream::TokenStream;
 use rustc_attr as attr;
 use rustc_errors::PResult;
 use rustc_expand::base::{self, *};
+use rustc_macros::SessionDiagnostic;
 use rustc_span::Span;
 
 pub fn expand_cfg(
@@ -34,13 +35,19 @@ pub fn expand_cfg(
     }
 }
 
-fn parse_cfg<'a>(cx: &mut ExtCtxt<'a>, sp: Span, tts: TokenStream) -> PResult<'a, ast::MetaItem> {
+#[derive(SessionDiagnostic)]
+#[error(slug = "builtin-macros-requires-cfg-pattern")]
+struct RequiresCfgPattern {
+    #[primary_span]
+    #[label]
+    span: Span,
+}
+
+fn parse_cfg<'a>(cx: &mut ExtCtxt<'a>, span: Span, tts: TokenStream) -> PResult<'a, ast::MetaItem> {
     let mut p = cx.new_parser_from_tts(tts);
 
     if p.token == token::Eof {
-        let mut err = cx.struct_span_err(sp, "macro requires a cfg-pattern as an argument");
-        err.span_label(sp, "cfg-pattern required");
-        return Err(err);
+        return Err(cx.create_err(RequiresCfgPattern { span }));
     }
 
     let cfg = p.parse_meta_item()?;
@@ -48,7 +55,7 @@ fn parse_cfg<'a>(cx: &mut ExtCtxt<'a>, sp: Span, tts: TokenStream) -> PResult<'a
     let _ = p.eat(&token::Comma);
 
     if !p.eat(&token::Eof) {
-        return Err(cx.struct_span_err(sp, "expected 1 cfg-pattern"));
+        return Err(cx.struct_span_err(span, "expected 1 cfg-pattern"));
     }
 
     Ok(cfg)

--- a/compiler/rustc_error_messages/locales/en-US/builtin_macros.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/builtin_macros.ftl
@@ -1,0 +1,3 @@
+builtin-macros-requires-cfg-pattern =
+    macro requires a cfg-pattern as an argument
+    .label = cfg-pattern required

--- a/compiler/rustc_error_messages/locales/en-US/builtin_macros.ftl
+++ b/compiler/rustc_error_messages/locales/en-US/builtin_macros.ftl
@@ -1,3 +1,5 @@
 builtin-macros-requires-cfg-pattern =
     macro requires a cfg-pattern as an argument
     .label = cfg-pattern required
+
+builtin-macros-expected-one-cfg-pattern = expected 1 cfg-pattern

--- a/compiler/rustc_error_messages/src/lib.rs
+++ b/compiler/rustc_error_messages/src/lib.rs
@@ -33,6 +33,7 @@ pub use unic_langid::{langid, LanguageIdentifier};
 fluent_messages! {
     parser => "../locales/en-US/parser.ftl",
     typeck => "../locales/en-US/typeck.ftl",
+    builtin_macros => "../locales/en-US/builtin_macros.ftl",
 }
 
 pub use fluent_generated::{self as fluent, DEFAULT_LOCALE_RESOURCES};

--- a/compiler/rustc_expand/src/base.rs
+++ b/compiler/rustc_expand/src/base.rs
@@ -14,7 +14,7 @@ use rustc_errors::{Applicability, DiagnosticBuilder, ErrorGuaranteed, MultiSpan,
 use rustc_lint_defs::builtin::PROC_MACRO_BACK_COMPAT;
 use rustc_lint_defs::BuiltinLintDiagnostics;
 use rustc_parse::{self, parser, MACRO_ARGUMENTS};
-use rustc_session::{parse::ParseSess, Limit, Session};
+use rustc_session::{parse::ParseSess, Limit, Session, SessionDiagnostic};
 use rustc_span::def_id::{CrateNum, DefId, LocalDefId};
 use rustc_span::edition::Edition;
 use rustc_span::hygiene::{AstPass, ExpnData, ExpnKind, LocalExpnId};
@@ -1083,6 +1083,17 @@ impl<'a> ExtCtxt<'a> {
         msg: &str,
     ) -> DiagnosticBuilder<'a, ErrorGuaranteed> {
         self.sess.parse_sess.span_diagnostic.struct_span_err(sp, msg)
+    }
+
+    pub fn create_err(
+        &self,
+        err: impl SessionDiagnostic<'a>,
+    ) -> DiagnosticBuilder<'a, ErrorGuaranteed> {
+        self.sess.create_err(err)
+    }
+
+    pub fn emit_err(&self, err: impl SessionDiagnostic<'a>) -> ErrorGuaranteed {
+        self.sess.emit_err(err)
     }
 
     /// Emit `msg` attached to `sp`, without immediately stopping

--- a/src/test/ui/macros/cfg.rs
+++ b/src/test/ui/macros/cfg.rs
@@ -2,4 +2,5 @@ fn main() {
     cfg!(); //~ ERROR macro requires a cfg-pattern
     cfg!(123); //~ ERROR expected identifier
     cfg!(foo = 123); //~ ERROR literal in `cfg` predicate value must be a string
+    cfg!(foo, bar); //~ ERROR expected 1 cfg-pattern
 }

--- a/src/test/ui/macros/cfg.stderr
+++ b/src/test/ui/macros/cfg.stderr
@@ -18,6 +18,14 @@ error[E0565]: literal in `cfg` predicate value must be a string
 LL |     cfg!(foo = 123);
    |                ^^^
 
-error: aborting due to 3 previous errors
+error: expected 1 cfg-pattern
+  --> $DIR/cfg.rs:5:5
+   |
+LL |     cfg!(foo, bar);
+   |     ^^^^^^^^^^^^^^
+   |
+   = note: this error originates in the macro `cfg` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0565`.


### PR DESCRIPTION
Migrate two diagnostics to use the struct derive and be translatable.

r? @davidtwco