### PR TITLE
Update no_default_libraries handling for emscripten target

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/linker.rs
+++ b/compiler/rustc_codegen_ssa/src/back/linker.rs
@@ -1140,7 +1140,7 @@ impl<'a> Linker for EmLinker<'a> {
     fn no_crt_objects(&mut self) {}
 
     fn no_default_libraries(&mut self) {
-        self.cmd.args(&["-s", "DEFAULT_LIBRARY_FUNCS_TO_INCLUDE=[]"]);
+        self.cmd.arg("-nodefaultlibs");
     }
 
     fn export_symbols(&mut self, _tmpdir: &Path, _crate_type: CrateType, symbols: &[String]) {

--- a/compiler/rustc_target/src/spec/wasm32_unknown_emscripten.rs
+++ b/compiler/rustc_target/src/spec/wasm32_unknown_emscripten.rs
@@ -28,6 +28,7 @@ pub fn target() -> Target {
         linker: None,
         is_like_emscripten: true,
         panic_strategy: PanicStrategy::Unwind,
+        no_default_libraries: false,
         post_link_args,
         families: cvs!["unix", "wasm"],
         ..options


### PR DESCRIPTION
@sbc100 says:

> `-sDEFAULT_LIBRARY_FUNCS_TO_INCLUDE=[]` is almost certainly wrong/out-of-date.   This setting defaults to the empty list anyway these days so its redundant.  Also we now support `-nodefaultlibs` so you can use that, as with other toolchains.

https://github.com/rust-lang/rust/issues/98303#issuecomment-1162163684