### PR TITLE
Implement set_output_kind for Emscripten linker

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/linker.rs
+++ b/compiler/rustc_codegen_ssa/src/back/linker.rs
@@ -1041,7 +1041,32 @@ impl<'a> Linker for EmLinker<'a> {
         &mut self.cmd
     }
 
-    fn set_output_kind(&mut self, _output_kind: LinkOutputKind, _out_filename: &Path) {}
+    fn set_output_kind(&mut self, output_kind: LinkOutputKind, _out_filename: &Path) {
+        match output_kind {
+            LinkOutputKind::DynamicNoPicExe | LinkOutputKind::DynamicPicExe => {
+                // "-sMAIN_MODULE=1" breaks
+                // https://github.com/rust-lang/rust/issues/92738
+                self.cmd.arg("-sMAIN_MODULE=2");
+            }
+            LinkOutputKind::DynamicDylib | LinkOutputKind::StaticDylib => {
+                // -sSIDE_MODULE=1 breaks
+                // https://github.com/rust-lang/rust/issues/92738
+                // In any case, -sSIDE_MODULE=2 is better because Rust is good at
+                // calculating exports.
+                self.cmd.arg("-sSIDE_MODULE=2");
+                // Without -sWASM_BIGINT there are issues with dynamic Rust libraries. There
+                // are no plans to fix this in Emscripten AFAIK. See
+                // https://github.com/emscripten-core/emscripten/pull/16693 This could also
+                // be fixed with panic=abort.
+                self.cmd.arg("-sWASM_BIGINT");
+            }
+            // -fno-pie is the default on Emscripten.
+            LinkOutputKind::StaticNoPicExe | LinkOutputKind::StaticPicExe => {}
+            LinkOutputKind::WasiReactorExe => {
+                unreachable!();
+            }
+        }
+    }
 
     fn include_path(&mut self, path: &Path) {
         self.cmd.arg("-L").arg(path);

--- a/compiler/rustc_target/src/spec/wasm32_unknown_emscripten.rs
+++ b/compiler/rustc_target/src/spec/wasm32_unknown_emscripten.rs
@@ -27,6 +27,8 @@ pub fn target() -> Target {
         exe_suffix: ".js".into(),
         linker: None,
         relocation_model: RelocModel::Pic,
+        crt_static_respected: true,
+        crt_static_default: true,
         panic_strategy: PanicStrategy::Unwind,
         no_default_libraries: false,
         post_link_args,


### PR DESCRIPTION
This is on top of #98149. See also the earlier discussion on https://github.com/rust-lang/rust/pull/98303. With this PR, a crate that specifies that it is a cdylib will compile to a working Emscripten dynamic library without adding any extra cargo, rustc, or linker flags and without fiddling with environment variables.

@sbc100 

r? @petrochenkov