### PR TITLE
remove use of &Alloc in btree tests

### DIFF
--- a/library/alloc/src/collections/btree/node/tests.rs
+++ b/library/alloc/src/collections/btree/node/tests.rs
@@ -68,10 +68,10 @@ fn test_splitpoint() {
 
 #[test]
 fn test_partial_eq() {
-    let mut root1 = NodeRef::new_leaf(&Global);
+    let mut root1 = NodeRef::new_leaf(Global);
     root1.borrow_mut().push(1, ());
-    let mut root1 = NodeRef::new_internal(root1.forget_type(), &Global).forget_type();
-    let root2 = Root::new(&Global);
+    let mut root1 = NodeRef::new_internal(root1.forget_type(), Global).forget_type();
+    let root2 = Root::new(Global);
     root1.reborrow().assert_back_pointers();
     root2.reborrow().assert_back_pointers();
 
@@ -87,9 +87,9 @@ fn test_partial_eq() {
     assert!(top_edge_1 == top_edge_1);
     assert!(top_edge_1 != top_edge_2);
 
-    root1.pop_internal_level(&Global);
-    unsafe { root1.into_dying().deallocate_and_ascend(&Global) };
-    unsafe { root2.into_dying().deallocate_and_ascend(&Global) };
+    root1.pop_internal_level(Global);
+    unsafe { root1.into_dying().deallocate_and_ascend(Global) };
+    unsafe { root2.into_dying().deallocate_and_ascend(Global) };
 }
 
 #[test]


### PR DESCRIPTION
I missed these in https://github.com/rust-lang/rust/pull/98233.

r? @thomcc 