### PR TITLE
[Experiment] set .cargo/registry/src as readonly

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,8 @@
 	url = https://github.com/rust-lang/nomicon.git
 [submodule "src/tools/cargo"]
 	path = src/tools/cargo
-	url = https://github.com/rust-lang/cargo.git
+	url = https://github.com/weihanglo/cargo.git
+	branch = registry-src-readonly
 [submodule "src/doc/reference"]
 	path = src/doc/reference
 	url = https://github.com/rust-lang/reference.git


### PR DESCRIPTION
Need a crater run on `check` mode to see how readonly registry sources break stuff.

This does not take into account the case which [I mentioned earlier](https://github.com/rust-lang/cargo/issues/9455#issuecomment-1143026498), so failure cases may be far less than expected. I will appreciate if anyone gives a hint about how to make crater run `cargo c && rm -rf ~/.cargo/registry/src` && `cargo c` :)

Still, changing the permission bits causes `build.rs` not able to run some executables[^1], or makes `.cargo-ok` not able to write[^2]. So, let's see how far it goes.

r? @ghost

[^1]: https://github.com/rust-lang/cargo/pull/9131
[^2]: https://github.com/rust-lang/cargo/blob/c9d8c28cba959c347271eaf31c9abfbb74c690bd/src/cargo/sources/registry/mod.rs#L657-L664