### PR TITLE
Fixes handling of keywords in rustdoc json output

### DIFF
--- a/src/test/rustdoc-json/keyword.rs
+++ b/src/test/rustdoc-json/keyword.rs
@@ -1,0 +1,21 @@
+// Regression test for <https://github.com/rust-lang/rust/issues/98002>.
+
+// Keywords should not be generated in rustdoc JSON output and this test
+// ensures it.
+
+#![feature(rustdoc_internals)]
+#![no_std]
+
+// @has keyword.json
+// @!has - "$.index[*][?(@.name=='match')]"
+// @has - "$.index[*][?(@.name=='foo')]"
+
+#[doc(keyword = "match")]
+/// this is a test!
+pub mod foo {}
+
+// @!has - "$.index[*][?(@.name=='hello')]"
+// @!has - "$.index[*][?(@.name=='bar')]"
+#[doc(keyword = "hello")]
+/// hello
+mod bar {}


### PR DESCRIPTION
Fixes #98002.

Instead of panicking, we just filter them out.

cc @matthiaskrgr 
r? @notriddle 