### PR TITLE
Rewrite dead-code pass to avoid fetching HIR.

### DIFF
--- a/compiler/rustc_mir_build/src/thir/cx/mod.rs
+++ b/compiler/rustc_mir_build/src/thir/cx/mod.rs
@@ -5,7 +5,6 @@
 use crate::thir::pattern::pat_from_hir;
 use crate::thir::util::UserAnnotatedTyHelpers;
 
-use rustc_ast as ast;
 use rustc_data_structures::steal::Steal;
 use rustc_errors::ErrorGuaranteed;
 use rustc_hir as hir;
@@ -13,10 +12,8 @@ use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_hir::HirId;
 use rustc_hir::Node;
 use rustc_middle::middle::region;
-use rustc_middle::mir::interpret::{LitToConstError, LitToConstInput};
-use rustc_middle::mir::ConstantKind;
 use rustc_middle::thir::*;
-use rustc_middle::ty::{self, RvalueScopes, Ty, TyCtxt};
+use rustc_middle::ty::{self, RvalueScopes, TyCtxt};
 use rustc_span::Span;
 
 pub(crate) fn thir_body<'tcx>(
@@ -77,24 +74,6 @@ impl<'tcx> Cx<'tcx> {
             rvalue_scopes: &typeck_results.rvalue_scopes,
             body_owner: def.did.to_def_id(),
             adjustment_span: None,
-        }
-    }
-
-    #[instrument(skip(self), level = "debug")]
-    pub(crate) fn const_eval_literal(
-        &mut self,
-        lit: &'tcx ast::LitKind,
-        ty: Ty<'tcx>,
-        sp: Span,
-        neg: bool,
-    ) -> ConstantKind<'tcx> {
-        match self.tcx.at(sp).lit_to_mir_constant(LitToConstInput { lit, ty, neg }) {
-            Ok(c) => c,
-            Err(LitToConstError::Reported) => {
-                // create a dummy value and continue compiling
-                ConstantKind::Ty(self.tcx.const_error(ty))
-            }
-            Err(LitToConstError::TypeError) => bug!("const_eval_literal: had type error"),
         }
     }
 

--- a/compiler/rustc_passes/src/dead.rs
+++ b/compiler/rustc_passes/src/dead.rs
@@ -82,8 +82,8 @@ impl<'tcx> MarkSymbolVisitor<'tcx> {
 
     fn handle_res(&mut self, res: Res) {
         match res {
-            Res::Def(DefKind::Const | DefKind::AssocConst | DefKind::TyAlias, _) => {
-                self.check_def_id(res.def_id());
+            Res::Def(DefKind::Const | DefKind::AssocConst | DefKind::TyAlias, def_id) => {
+                self.check_def_id(def_id);
             }
             _ if self.in_pat => {}
             Res::PrimTy(..) | Res::SelfCtor(..) | Res::Local(..) => {}
@@ -102,6 +102,7 @@ impl<'tcx> MarkSymbolVisitor<'tcx> {
                     self.check_def_id(variant_id);
                 }
             }
+            Res::Def(_, def_id) => self.check_def_id(def_id),
             Res::SelfTy { trait_: t, alias_to: i } => {
                 if let Some(t) = t {
                     self.check_def_id(t);
@@ -111,9 +112,6 @@ impl<'tcx> MarkSymbolVisitor<'tcx> {
                 }
             }
             Res::ToolMod | Res::NonMacroAttr(..) | Res::Err => {}
-            _ => {
-                self.check_def_id(res.def_id());
-            }
         }
     }
 

--- a/src/test/ui/associated-consts/associated-const-dead-code.stderr
+++ b/src/test/ui/associated-consts/associated-const-dead-code.stderr
@@ -1,8 +1,8 @@
 error: associated constant `BAR` is never used
-  --> $DIR/associated-const-dead-code.rs:6:5
+  --> $DIR/associated-const-dead-code.rs:6:11
    |
 LL |     const BAR: u32 = 1;
-   |     ^^^^^^^^^^^^^^^^^^^
+   |           ^^^
    |
 note: the lint level is defined here
   --> $DIR/associated-const-dead-code.rs:1:9

--- a/src/test/ui/closures/2229_closure_analysis/issue-87987.stderr
+++ b/src/test/ui/closures/2229_closure_analysis/issue-87987.stderr
@@ -4,9 +4,9 @@ warning: fields `field_1` and `field_2` are never read
 LL | struct Props {
    |        ----- fields in this struct
 LL |     field_1: u32,
-   |     ^^^^^^^^^^^^
+   |     ^^^^^^^
 LL |     field_2: u32,
-   |     ^^^^^^^^^^^^
+   |     ^^^^^^^
    |
    = note: `#[warn(dead_code)]` on by default
 

--- a/src/test/ui/derive-uninhabited-enum-38885.stderr
+++ b/src/test/ui/derive-uninhabited-enum-38885.stderr
@@ -5,7 +5,7 @@ LL | enum Foo {
    |      --- variant in this enum
 LL |     Bar(u8),
 LL |     Void(Void),
-   |     ^^^^^^^^^^
+   |     ^^^^
    |
    = note: `-W dead-code` implied by `-W unused`
    = note: `Foo` has a derived impl for the trait `Debug`, but this is intentionally ignored during dead code analysis

--- a/src/test/ui/derives/clone-debug-dead-code-in-the-same-struct.stderr
+++ b/src/test/ui/derives/clone-debug-dead-code-in-the-same-struct.stderr
@@ -5,13 +5,13 @@ LL | pub struct Whatever {
    |            -------- fields in this struct
 LL |     pub field0: (),
 LL |     field1: (),
-   |     ^^^^^^^^^^
+   |     ^^^^^^
 LL |     field2: (),
-   |     ^^^^^^^^^^
+   |     ^^^^^^
 LL |     field3: (),
-   |     ^^^^^^^^^^
+   |     ^^^^^^
 LL |     field4: (),
-   |     ^^^^^^^^^^
+   |     ^^^^^^
    |
 note: the lint level is defined here
   --> $DIR/clone-debug-dead-code-in-the-same-struct.rs:1:11

--- a/src/test/ui/derives/clone-debug-dead-code.stderr
+++ b/src/test/ui/derives/clone-debug-dead-code.stderr
@@ -2,7 +2,7 @@ error: field `f` is never read
   --> $DIR/clone-debug-dead-code.rs:6:12
    |
 LL | struct A { f: () }
-   |        -   ^^^^^
+   |        -   ^
    |        |
    |        field in this struct
    |
@@ -16,7 +16,7 @@ error: field `f` is never read
   --> $DIR/clone-debug-dead-code.rs:10:12
    |
 LL | struct B { f: () }
-   |        -   ^^^^^
+   |        -   ^
    |        |
    |        field in this struct
    |
@@ -26,7 +26,7 @@ error: field `f` is never read
   --> $DIR/clone-debug-dead-code.rs:14:12
    |
 LL | struct C { f: () }
-   |        -   ^^^^^
+   |        -   ^
    |        |
    |        field in this struct
    |
@@ -36,7 +36,7 @@ error: field `f` is never read
   --> $DIR/clone-debug-dead-code.rs:18:12
    |
 LL | struct D { f: () }
-   |        -   ^^^^^
+   |        -   ^
    |        |
    |        field in this struct
    |
@@ -46,7 +46,7 @@ error: field `f` is never read
   --> $DIR/clone-debug-dead-code.rs:21:12
    |
 LL | struct E { f: () }
-   |        -   ^^^^^
+   |        -   ^
    |        |
    |        field in this struct
 

--- a/src/test/ui/issues/issue-37515.stderr
+++ b/src/test/ui/issues/issue-37515.stderr
@@ -1,8 +1,8 @@
 warning: type alias `Z` is never used
-  --> $DIR/issue-37515.rs:5:1
+  --> $DIR/issue-37515.rs:5:6
    |
 LL | type Z = dyn for<'x> Send;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |      ^
    |
 note: the lint level is defined here
   --> $DIR/issue-37515.rs:3:9

--- a/src/test/ui/lint/dead-code/impl-trait.stderr
+++ b/src/test/ui/lint/dead-code/impl-trait.stderr
@@ -1,8 +1,8 @@
 error: type alias `Unused` is never used
-  --> $DIR/impl-trait.rs:12:1
+  --> $DIR/impl-trait.rs:12:6
    |
 LL | type Unused = ();
-   | ^^^^^^^^^^^^^^^^^
+   |      ^^^^^^
    |
 note: the lint level is defined here
   --> $DIR/impl-trait.rs:1:9

--- a/src/test/ui/lint/dead-code/issue-85255.stderr
+++ b/src/test/ui/lint/dead-code/issue-85255.stderr
@@ -4,9 +4,9 @@ warning: fields `a` and `b` are never read
 LL | struct Foo {
    |        --- fields in this struct
 LL |     a: i32,
-   |     ^^^^^^
+   |     ^
 LL |     pub b: i32,
-   |     ^^^^^^^^^^
+   |         ^
    |
 note: the lint level is defined here
   --> $DIR/issue-85255.rs:4:9
@@ -32,9 +32,9 @@ warning: fields `a` and `b` are never read
 LL | pub(crate) struct Foo1 {
    |                   ---- fields in this struct
 LL |     a: i32,
-   |     ^^^^^^
+   |     ^
 LL |     pub b: i32,
-   |     ^^^^^^^^^^
+   |         ^
 
 warning: associated function `a` is never used
   --> $DIR/issue-85255.rs:26:8
@@ -54,9 +54,9 @@ warning: fields `a` and `b` are never read
 LL | pub(crate) struct Foo2 {
    |                   ---- fields in this struct
 LL |     a: i32,
-   |     ^^^^^^
+   |     ^
 LL |     pub b: i32,
-   |     ^^^^^^^^^^
+   |         ^
 
 warning: associated function `a` is never used
   --> $DIR/issue-85255.rs:38:8

--- a/src/test/ui/lint/dead-code/issue-85255.stderr
+++ b/src/test/ui/lint/dead-code/issue-85255.stderr
@@ -14,6 +14,26 @@ note: the lint level is defined here
 LL | #![warn(dead_code)]
    |         ^^^^^^^^^
 
+warning: fields `a` and `b` are never read
+  --> $DIR/issue-85255.rs:19:5
+   |
+LL | pub(crate) struct Foo1 {
+   |                   ---- fields in this struct
+LL |     a: i32,
+   |     ^
+LL |     pub b: i32,
+   |         ^
+
+warning: fields `a` and `b` are never read
+  --> $DIR/issue-85255.rs:31:5
+   |
+LL | pub(crate) struct Foo2 {
+   |                   ---- fields in this struct
+LL |     a: i32,
+   |     ^
+LL |     pub b: i32,
+   |         ^
+
 warning: associated function `a` is never used
   --> $DIR/issue-85255.rs:14:8
    |
@@ -26,16 +46,6 @@ warning: associated function `b` is never used
 LL |     pub fn b(&self) -> i32 { 6 }
    |            ^
 
-warning: fields `a` and `b` are never read
-  --> $DIR/issue-85255.rs:19:5
-   |
-LL | pub(crate) struct Foo1 {
-   |                   ---- fields in this struct
-LL |     a: i32,
-   |     ^
-LL |     pub b: i32,
-   |         ^
-
 warning: associated function `a` is never used
   --> $DIR/issue-85255.rs:26:8
    |
@@ -47,16 +57,6 @@ warning: associated function `b` is never used
    |
 LL |     pub fn b(&self) -> i32 { 6 }
    |            ^
-
-warning: fields `a` and `b` are never read
-  --> $DIR/issue-85255.rs:31:5
-   |
-LL | pub(crate) struct Foo2 {
-   |                   ---- fields in this struct
-LL |     a: i32,
-   |     ^
-LL |     pub b: i32,
-   |         ^
 
 warning: associated function `a` is never used
   --> $DIR/issue-85255.rs:38:8

--- a/src/test/ui/lint/dead-code/lint-dead-code-1.stderr
+++ b/src/test/ui/lint/dead-code/lint-dead-code-1.stderr
@@ -1,8 +1,8 @@
 error: static `priv_static` is never used
-  --> $DIR/lint-dead-code-1.rs:20:1
+  --> $DIR/lint-dead-code-1.rs:20:8
    |
 LL | static priv_static: isize = 0;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |        ^^^^^^^^^^^
    |
 note: the lint level is defined here
   --> $DIR/lint-dead-code-1.rs:5:9
@@ -11,10 +11,10 @@ LL | #![deny(dead_code)]
    |         ^^^^^^^^^
 
 error: constant `priv_const` is never used
-  --> $DIR/lint-dead-code-1.rs:27:1
+  --> $DIR/lint-dead-code-1.rs:27:7
    |
 LL | const priv_const: isize = 0;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^^^^^^^^
 
 error: struct `PrivStruct` is never constructed
   --> $DIR/lint-dead-code-1.rs:35:8

--- a/src/test/ui/lint/dead-code/lint-dead-code-3.rs
+++ b/src/test/ui/lint/dead-code/lint-dead-code-3.rs
@@ -73,7 +73,18 @@ mod inner {
     fn f() {}
 }
 
+fn anon_const() -> [(); {
+    fn blah() {} //~ ERROR: function `blah` is never used
+    1
+}] {
+    [(); {
+        fn blah() {} //~ ERROR: function `blah` is never used
+        1
+    }]
+}
+
 pub fn foo() {
     let a: &dyn inner::Trait = &1_isize;
     a.f();
+    anon_const();
 }

--- a/src/test/ui/lint/dead-code/lint-dead-code-3.stderr
+++ b/src/test/ui/lint/dead-code/lint-dead-code-3.stderr
@@ -29,10 +29,10 @@ LL | enum c_void {}
    |      ^^^^^^
 
 error: function `free` is never used
-  --> $DIR/lint-dead-code-3.rs:62:5
+  --> $DIR/lint-dead-code-3.rs:62:8
    |
 LL |     fn free(p: *const c_void);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |        ^^^^
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/lint/dead-code/lint-dead-code-3.stderr
+++ b/src/test/ui/lint/dead-code/lint-dead-code-3.stderr
@@ -10,12 +10,6 @@ note: the lint level is defined here
 LL | #![deny(dead_code)]
    |         ^^^^^^^^^
 
-error: associated function `foo` is never used
-  --> $DIR/lint-dead-code-3.rs:16:8
-   |
-LL |     fn foo(&self) {
-   |        ^^^
-
 error: function `bar` is never used
   --> $DIR/lint-dead-code-3.rs:21:4
    |
@@ -28,11 +22,29 @@ error: enum `c_void` is never used
 LL | enum c_void {}
    |      ^^^^^^
 
+error: function `blah` is never used
+  --> $DIR/lint-dead-code-3.rs:77:8
+   |
+LL |     fn blah() {}
+   |        ^^^^
+
+error: function `blah` is never used
+  --> $DIR/lint-dead-code-3.rs:81:12
+   |
+LL |         fn blah() {}
+   |            ^^^^
+
+error: associated function `foo` is never used
+  --> $DIR/lint-dead-code-3.rs:16:8
+   |
+LL |     fn foo(&self) {
+   |        ^^^
+
 error: function `free` is never used
   --> $DIR/lint-dead-code-3.rs:62:8
    |
 LL |     fn free(p: *const c_void);
    |        ^^^^
 
-error: aborting due to 5 previous errors
+error: aborting due to 7 previous errors
 

--- a/src/test/ui/lint/dead-code/lint-dead-code-4.stderr
+++ b/src/test/ui/lint/dead-code/lint-dead-code-4.stderr
@@ -32,9 +32,9 @@ LL | enum ABC {
 error: fields `b` and `c` are never read
   --> $DIR/lint-dead-code-4.rs:39:9
    |
-LL | enum IJK {
-   |      --- fields in this enum
-...
+LL |     J {
+   |     - fields in this variant
+LL |         a: String,
 LL |         b: i32,
    |         ^
 LL |         c: i32,

--- a/src/test/ui/lint/dead-code/lint-dead-code-4.stderr
+++ b/src/test/ui/lint/dead-code/lint-dead-code-4.stderr
@@ -5,7 +5,7 @@ LL | struct Foo {
    |        --- field in this struct
 LL |     x: usize,
 LL |     b: bool,
-   |     ^^^^^^^
+   |     ^
    |
 note: the lint level is defined here
   --> $DIR/lint-dead-code-4.rs:3:9
@@ -16,16 +16,12 @@ LL | #![deny(dead_code)]
 error: variants `X` and `Y` are never constructed
   --> $DIR/lint-dead-code-4.rs:15:5
    |
-LL |   enum XYZ {
-   |        --- variants in this enum
-LL |       X,
-   |       ^
-LL | /     Y {
-LL | |         a: String,
-LL | |         b: i32,
-LL | |         c: i32,
-LL | |     },
-   | |_____^
+LL | enum XYZ {
+   |      --- variants in this enum
+LL |     X,
+   |     ^
+LL |     Y {
+   |     ^
 
 error: enum `ABC` is never used
   --> $DIR/lint-dead-code-4.rs:24:6
@@ -40,9 +36,9 @@ LL | enum IJK {
    |      --- fields in this enum
 ...
 LL |         b: i32,
-   |         ^^^^^^
+   |         ^
 LL |         c: i32,
-   |         ^^^^^^
+   |         ^
 
 error: variants `I` and `K` are never constructed
   --> $DIR/lint-dead-code-4.rs:36:5
@@ -61,10 +57,10 @@ error: fields `x` and `c` are never read
 LL | struct Bar {
    |        --- fields in this struct
 LL |     x: usize,
-   |     ^^^^^^^^
+   |     ^
 LL |     b: bool,
 LL |     c: bool,
-   |     ^^^^^^^
+   |     ^
 
 error: aborting due to 6 previous errors
 

--- a/src/test/ui/lint/dead-code/lint-dead-code-5.stderr
+++ b/src/test/ui/lint/dead-code/lint-dead-code-5.stderr
@@ -20,9 +20,9 @@ LL | enum Enum2 {
    |      ----- variants in this enum
 ...
 LL |     Variant5 { _x: isize },
-   |     ^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^
 LL |     Variant6(isize),
-   |     ^^^^^^^^^^^^^^^
+   |     ^^^^^^^^
 
 error: enum `Enum3` is never used
   --> $DIR/lint-dead-code-5.rs:35:6

--- a/src/test/ui/lint/dead-code/multiple-dead-codes-in-the-same-struct.stderr
+++ b/src/test/ui/lint/dead-code/multiple-dead-codes-in-the-same-struct.stderr
@@ -5,12 +5,12 @@ LL | struct Bar {
    |        --- fields in this struct
 ...
 LL |     d: usize,
-   |     ^^^^^^^^
+   |     ^
 ...
 LL |     f: usize,
-   |     ^^^^^^^^
+   |     ^
 LL |     g: usize,
-   |     ^^^^^^^^
+   |     ^
    |
 note: the lint level is defined here
   --> $DIR/multiple-dead-codes-in-the-same-struct.rs:1:9
@@ -25,10 +25,10 @@ LL | struct Bar {
    |        --- fields in this struct
 ...
 LL |     c: usize,
-   |     ^^^^^^^^
+   |     ^
 ...
 LL |     e: usize,
-   |     ^^^^^^^^
+   |     ^
    |
 note: the lint level is defined here
   --> $DIR/multiple-dead-codes-in-the-same-struct.rs:8:12
@@ -43,7 +43,7 @@ LL | struct Bar {
    |        --- field in this struct
 ...
 LL |     b: usize,
-   |     ^^^^^^^^
+   |     ^
    |
 note: the lint level is defined here
   --> $DIR/multiple-dead-codes-in-the-same-struct.rs:6:14

--- a/src/test/ui/lint/dead-code/type-alias.stderr
+++ b/src/test/ui/lint/dead-code/type-alias.stderr
@@ -1,8 +1,8 @@
 error: type alias `Unused` is never used
-  --> $DIR/type-alias.rs:4:1
+  --> $DIR/type-alias.rs:4:6
    |
 LL | type Unused = u8;
-   | ^^^^^^^^^^^^^^^^^
+   |      ^^^^^^
    |
 note: the lint level is defined here
   --> $DIR/type-alias.rs:1:9

--- a/src/test/ui/lint/dead-code/unused-struct-variant.stderr
+++ b/src/test/ui/lint/dead-code/unused-struct-variant.stderr
@@ -5,7 +5,7 @@ LL | enum E {
    |      - variant in this enum
 LL |     Foo(F),
 LL |     Bar(B),
-   |     ^^^^^^
+   |     ^^^
    |
 note: the lint level is defined here
   --> $DIR/unused-struct-variant.rs:1:9

--- a/src/test/ui/lint/issue-17718-const-naming.stderr
+++ b/src/test/ui/lint/issue-17718-const-naming.stderr
@@ -1,8 +1,8 @@
 error: constant `foo` is never used
-  --> $DIR/issue-17718-const-naming.rs:4:1
+  --> $DIR/issue-17718-const-naming.rs:4:7
    |
 LL | const foo: isize = 3;
-   | ^^^^^^^^^^^^^^^^^^^^^
+   |       ^^^
    |
 note: the lint level is defined here
   --> $DIR/issue-17718-const-naming.rs:2:9

--- a/src/test/ui/span/macro-span-replacement.stderr
+++ b/src/test/ui/span/macro-span-replacement.stderr
@@ -1,8 +1,8 @@
 warning: struct `S` is never constructed
-  --> $DIR/macro-span-replacement.rs:7:14
+  --> $DIR/macro-span-replacement.rs:7:12
    |
 LL |         $b $a;
-   |              ^
+   |            ^^
 ...
 LL |     m!(S struct);
    |     ------------ in this macro invocation

--- a/src/test/ui/union/union-fields-1.mirunsafeck.stderr
+++ b/src/test/ui/union/union-fields-1.mirunsafeck.stderr
@@ -5,7 +5,7 @@ LL | union U1 {
    |       -- field in this union
 ...
 LL |     c: u8,
-   |     ^^^^^
+   |     ^
    |
 note: the lint level is defined here
   --> $DIR/union-fields-1.rs:4:9
@@ -19,13 +19,13 @@ error: field `a` is never read
 LL | union U2 {
    |       -- field in this union
 LL |     a: u8,
-   |     ^^^^^
+   |     ^
 
 error: field `a` is never read
   --> $DIR/union-fields-1.rs:16:20
    |
 LL | union NoDropLike { a: u8 }
-   |       ----------   ^^^^^
+   |       ----------   ^
    |       |
    |       field in this union
 
@@ -36,7 +36,7 @@ LL | union U {
    |       - field in this union
 ...
 LL |     c: u8,
-   |     ^^^^^
+   |     ^
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/union/union-fields-1.thirunsafeck.stderr
+++ b/src/test/ui/union/union-fields-1.thirunsafeck.stderr
@@ -5,7 +5,7 @@ LL | union U1 {
    |       -- field in this union
 ...
 LL |     c: u8,
-   |     ^^^^^
+   |     ^
    |
 note: the lint level is defined here
   --> $DIR/union-fields-1.rs:4:9
@@ -19,13 +19,13 @@ error: field `a` is never read
 LL | union U2 {
    |       -- field in this union
 LL |     a: u8,
-   |     ^^^^^
+   |     ^
 
 error: field `a` is never read
   --> $DIR/union-fields-1.rs:16:20
    |
 LL | union NoDropLike { a: u8 }
-   |       ----------   ^^^^^
+   |       ----------   ^
    |       |
    |       field in this union
 
@@ -36,7 +36,7 @@ LL | union U {
    |       - field in this union
 ...
 LL |     c: u8,
-   |     ^^^^^
+   |     ^
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/union/union-lint-dead-code.mirunsafeck.stderr
+++ b/src/test/ui/union/union-lint-dead-code.mirunsafeck.stderr
@@ -5,7 +5,7 @@ LL | union Foo {
    |       --- field in this union
 LL |     x: usize,
 LL |     b: bool,
-   |     ^^^^^^^
+   |     ^
    |
 note: the lint level is defined here
   --> $DIR/union-lint-dead-code.rs:4:9

--- a/src/test/ui/union/union-lint-dead-code.thirunsafeck.stderr
+++ b/src/test/ui/union/union-lint-dead-code.thirunsafeck.stderr
@@ -5,7 +5,7 @@ LL | union Foo {
    |       --- field in this union
 LL |     x: usize,
 LL |     b: bool,
-   |     ^^^^^^^
+   |     ^
    |
 note: the lint level is defined here
   --> $DIR/union-lint-dead-code.rs:4:9


### PR DESCRIPTION
This allows to get a more uniform handling of spans, and to simplify the grouping of diagnostics for variants and fields.