### PR TITLE
Update tendril

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1428,9 +1428,9 @@ checksum = "d79238883cf0307100b90aba4a755d8051a3182305dfe7f649a1e9dc0517006f"
 
 [[package]]
 name = "futf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c9c1ce3fa9336301af935ab852c437817d14cd33690446569392e65170aac3b"
+checksum = "df420e2e84819663797d1ec6544b13c5be84629e7bb00dc960d6917db2987843"
 dependencies = [
  "mac",
  "new_debug_unreachable",
@@ -5190,9 +5190,9 @@ dependencies = [
 
 [[package]]
 name = "tendril"
-version = "0.4.1"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707feda9f2582d5d680d733e38755547a3e8fb471e7ba11452ecfd9ce93a5d3b"
+checksum = "d24a120c5fc464a3458240ee02c299ebcb9d67b5249c8848b09d639dca8d7bb0"
 dependencies = [
  "futf",
  "mac",


### PR DESCRIPTION
The 0.4.1 version of `tendril` (used by mdbook) triggers the `unaligned_references` lint which is now reported as a future-compatibility warning as of #95372. This updates it to 0.4.3 which does not trigger the warning. This update also triggered the update of `futf` from 0.1.4 to 0.1.5.

tendril changes: https://github.com/servo/tendril/compare/v0.4.1...v0.4.3
futf changes: https://github.com/servo/futf/compare/v0.1.4...v0.1.5
