### PR TITLE
Add str::Lines::as_str

### DIFF
--- a/library/core/src/str/iter.rs
+++ b/library/core/src/str/iter.rs
@@ -1093,6 +1093,14 @@ generate_pattern_iterators! {
 #[derive(Clone, Debug)]
 pub struct Lines<'a>(pub(super) Map<SplitTerminator<'a, char>, LinesAnyMap>);
 
+impl<'a> Lines<'a> {
+    /// Returns the remaining lines that weren't iterated yet as one string slice.
+    #[unstable(feature = "str_lines_as_str", issue = "none")]
+    pub fn as_str(&self) -> &'a str {
+        self.0.iter.as_str()
+    }
+}
+
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<'a> Iterator for Lines<'a> {
     type Item = &'a str;


### PR DESCRIPTION
~~Blocked on #95644~~, for now I'm using the same API as available on `SplitTerminator` but this should probably not be merged as-is since that API is changing.

Just wanted to open this now as a means to propose having the same "remainder of non-iterated parts as a contiguous `&str`" API on `Lines` as on `Split*` (tracked in #77998).

I'm also curious whether you think it makes sense to implement it like this (reaching into the inner `SplitTerminator` of `Map`) or whether the `Map` should maybe be replaced? I found the code a little hard to follow at first given it uses `Map` instead of just (?) doing the same thing manually in the `Iterator` implementation.