### PR TITLE
Add `fetch_not` method on `AtomicBool`

### DIFF
--- a/library/core/src/sync/atomic.rs
+++ b/library/core/src/sync/atomic.rs
@@ -883,7 +883,7 @@ impl AtomicBool {
     /// assert_eq!(foo.load(Ordering::SeqCst), true);
     /// ```
     #[inline]
-    #[stable(feature = "rust1", since = "1.0.0")]
+    #[unstable(feature = "atomic_bool_fetch_not", issue = "98485")]
     #[cfg(target_has_atomic = "8")]
     pub fn fetch_not(&self, order: Ordering) -> bool {
         self.fetch_xor(true, order)

--- a/library/core/src/sync/atomic.rs
+++ b/library/core/src/sync/atomic.rs
@@ -854,6 +854,41 @@ impl AtomicBool {
         unsafe { atomic_xor(self.v.get(), val as u8, order) != 0 }
     }
 
+    /// Logical "not" with a boolean value.
+    ///
+    /// Performs a logical "not" operation on the current value, and sets
+    /// the new value to the result.
+    ///
+    /// Returns the previous value.
+    ///
+    /// `fetch_not` takes an [`Ordering`] argument which describes the memory ordering
+    /// of this operation. All ordering modes are possible. Note that using
+    /// [`Acquire`] makes the store part of this operation [`Relaxed`], and
+    /// using [`Release`] makes the load part [`Relaxed`].
+    ///
+    /// **Note:** This method is only available on platforms that support atomic
+    /// operations on `u8`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::sync::atomic::{AtomicBool, Ordering};
+    ///
+    /// let foo = AtomicBool::new(true);
+    /// assert_eq!(foo.fetch_not(Ordering::SeqCst), true);
+    /// assert_eq!(foo.load(Ordering::SeqCst), false);
+    ///
+    /// let foo = AtomicBool::new(false);
+    /// assert_eq!(foo.fetch_not(Ordering::SeqCst), false);
+    /// assert_eq!(foo.load(Ordering::SeqCst), true);
+    /// ```
+    #[inline]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    #[cfg(target_has_atomic = "8")]
+    pub fn fetch_not(&self, order: Ordering) -> bool {
+        self.fetch_xor(true, order)
+    }
+
     /// Returns a mutable pointer to the underlying [`bool`].
     ///
     /// Doing non-atomic reads and writes on the resulting integer can be a data race.

--- a/library/core/src/sync/atomic.rs
+++ b/library/core/src/sync/atomic.rs
@@ -872,6 +872,7 @@ impl AtomicBool {
     /// # Examples
     ///
     /// ```
+    /// #![feature(atomic_bool_fetch_not)]
     /// use std::sync::atomic::{AtomicBool, Ordering};
     ///
     /// let foo = AtomicBool::new(true);

--- a/library/core/tests/atomic.rs
+++ b/library/core/tests/atomic.rs
@@ -30,6 +30,18 @@ fn bool_nand() {
     assert_eq!(a.fetch_nand(true, SeqCst), false);
     assert_eq!(a.load(SeqCst), true);
 }
+#[test]
+fn bool_not() {
+    let a = AtomicBool::new(false);
+    assert_eq!(a.fetch_not(SeqCst), false);
+    assert_eq!(a.load(SeqCst), true);
+    assert_eq!(a.fetch_not(SeqCst), true);
+    assert_eq!(a.load(SeqCst), false);
+    assert_eq!(a.fetch_not(SeqCst), false);
+    assert_eq!(a.load(SeqCst), true);
+    assert_eq!(a.fetch_not(SeqCst), true);
+    assert_eq!(a.load(SeqCst), false);
+}
 
 #[test]
 fn uint_and() {
@@ -158,6 +170,8 @@ fn atomic_access_bool() {
         assert_eq!(*ATOMIC.get_mut(), true);
         ATOMIC.fetch_xor(true, SeqCst);
         assert_eq!(*ATOMIC.get_mut(), false);
+        ATOMIC.fetch_not(SeqCst);
+        assert_eq!(*ATOMIC.get_mut(), true);
     }
 }
 

--- a/library/core/tests/atomic.rs
+++ b/library/core/tests/atomic.rs
@@ -30,18 +30,6 @@ fn bool_nand() {
     assert_eq!(a.fetch_nand(true, SeqCst), false);
     assert_eq!(a.load(SeqCst), true);
 }
-#[test]
-fn bool_not() {
-    let a = AtomicBool::new(false);
-    assert_eq!(a.fetch_not(SeqCst), false);
-    assert_eq!(a.load(SeqCst), true);
-    assert_eq!(a.fetch_not(SeqCst), true);
-    assert_eq!(a.load(SeqCst), false);
-    assert_eq!(a.fetch_not(SeqCst), false);
-    assert_eq!(a.load(SeqCst), true);
-    assert_eq!(a.fetch_not(SeqCst), true);
-    assert_eq!(a.load(SeqCst), false);
-}
 
 #[test]
 fn uint_and() {
@@ -170,8 +158,6 @@ fn atomic_access_bool() {
         assert_eq!(*ATOMIC.get_mut(), true);
         ATOMIC.fetch_xor(true, SeqCst);
         assert_eq!(*ATOMIC.get_mut(), false);
-        ATOMIC.fetch_not(SeqCst);
-        assert_eq!(*ATOMIC.get_mut(), true);
     }
 }
 


### PR DESCRIPTION
This PR adds a `fetch_not` method on `AtomicBool` performs the NOT operation on the inner value.
Internally, this just calls the `fetch_xor` method with the value `true`.

[See this IRLO discussion](https://internals.rust-lang.org/t/could-we-have-fetch-not-for-atomicbool-s/16881)