### PR TITLE
Rollup of 9 pull requests

### DIFF
--- a/compiler/rustc_infer/src/infer/resolve.rs
+++ b/compiler/rustc_infer/src/infer/resolve.rs
@@ -92,7 +92,7 @@ impl<'a, 'tcx> TypeFolder<'tcx> for OpportunisticRegionResolver<'a, 'tcx> {
                     .borrow_mut()
                     .unwrap_region_constraints()
                     .opportunistic_resolve_var(rid);
-                self.tcx().reuse_or_mk_region(r, ty::ReVar(resolved))
+                TypeFolder::tcx(self).reuse_or_mk_region(r, ty::ReVar(resolved))
             }
             _ => r,
         }
@@ -179,15 +179,13 @@ struct FullTypeResolver<'a, 'tcx> {
     infcx: &'a InferCtxt<'a, 'tcx>,
 }
 
-impl<'a, 'tcx> TypeFolder<'tcx> for FullTypeResolver<'a, 'tcx> {
+impl<'a, 'tcx> FallibleTypeFolder<'tcx> for FullTypeResolver<'a, 'tcx> {
     type Error = FixupError<'tcx>;
 
     fn tcx<'b>(&'b self) -> TyCtxt<'tcx> {
         self.infcx.tcx
     }
-}
 
-impl<'a, 'tcx> FallibleTypeFolder<'tcx> for FullTypeResolver<'a, 'tcx> {
     fn try_fold_ty(&mut self, t: Ty<'tcx>) -> Result<Ty<'tcx>, Self::Error> {
         if !t.needs_infer() {
             Ok(t) // micro-optimize -- if there is nothing in this type that this fold affects...

--- a/compiler/rustc_middle/src/traits/mod.rs
+++ b/compiler/rustc_middle/src/traits/mod.rs
@@ -253,7 +253,7 @@ pub enum ObligationCauseCode<'tcx> {
     ObjectTypeBound(Ty<'tcx>, ty::Region<'tcx>),
 
     /// Obligation incurred due to an object cast.
-    ObjectCastObligation(/* Object type */ Ty<'tcx>),
+    ObjectCastObligation(/* Concrete type */ Ty<'tcx>, /* Object type */ Ty<'tcx>),
 
     /// Obligation incurred due to a coercion.
     Coercion {

--- a/compiler/rustc_middle/src/ty/fold.rs
+++ b/compiler/rustc_middle/src/ty/fold.rs
@@ -86,7 +86,7 @@ pub trait TypeFoldable<'tcx>: fmt::Debug + Clone {
     /// A convenient alternative to `try_fold_with` for use with infallible
     /// folders. Do not override this method, to ensure coherence with
     /// `try_fold_with`.
-    fn fold_with<F: TypeFolder<'tcx, Error = !>>(self, folder: &mut F) -> Self {
+    fn fold_with<F: TypeFolder<'tcx>>(self, folder: &mut F) -> Self {
         self.try_fold_with(folder).into_ok()
     }
 
@@ -216,7 +216,7 @@ pub trait TypeSuperFoldable<'tcx>: TypeFoldable<'tcx> {
     /// A convenient alternative to `try_super_fold_with` for use with
     /// infallible folders. Do not override this method, to ensure coherence
     /// with `try_super_fold_with`.
-    fn super_fold_with<F: TypeFolder<'tcx, Error = !>>(self, folder: &mut F) -> Self {
+    fn super_fold_with<F: TypeFolder<'tcx>>(self, folder: &mut F) -> Self {
         self.try_super_fold_with(folder).into_ok()
     }
 
@@ -229,16 +229,13 @@ pub trait TypeSuperFoldable<'tcx>: TypeFoldable<'tcx> {
     fn super_visit_with<V: TypeVisitor<'tcx>>(&self, visitor: &mut V) -> ControlFlow<V::BreakTy>;
 }
 
-/// This trait is implemented for every folding traversal. There is a fold
-/// method defined for every type of interest. Each such method has a default
-/// that does an "identity" fold. Implementations of these methods often fall
-/// back to a `super_fold_with` method if the primary argument doesn't
-/// satisfy a particular condition.
+/// This trait is implemented for every infallible folding traversal. There is
+/// a fold method defined for every type of interest. Each such method has a
+/// default that does an "identity" fold. Implementations of these methods
+/// often fall back to a `super_fold_with` method if the primary argument
+/// doesn't satisfy a particular condition.
 ///
-/// If this folder is fallible (and therefore its [`Error`][`TypeFolder::Error`]
-/// associated type is something other than the default `!`) then
-/// [`FallibleTypeFolder`] should be implemented manually. Otherwise,
-/// a blanket implementation of [`FallibleTypeFolder`] will defer to
+/// A blanket implementation of [`FallibleTypeFolder`] will defer to
 /// the infallible methods of this trait to ensure that the two APIs
 /// are coherent.
 pub trait TypeFolder<'tcx>: FallibleTypeFolder<'tcx, Error = !> {
@@ -341,43 +338,40 @@ where
         TypeFolder::tcx(self)
     }
 
-    fn try_fold_binder<T>(&mut self, t: Binder<'tcx, T>) -> Result<Binder<'tcx, T>, Self::Error>
+    fn try_fold_binder<T>(&mut self, t: Binder<'tcx, T>) -> Result<Binder<'tcx, T>, !>
     where
         T: TypeFoldable<'tcx>,
     {
         Ok(self.fold_binder(t))
     }
 
-    fn try_fold_ty(&mut self, t: Ty<'tcx>) -> Result<Ty<'tcx>, Self::Error> {
+    fn try_fold_ty(&mut self, t: Ty<'tcx>) -> Result<Ty<'tcx>, !> {
         Ok(self.fold_ty(t))
     }
 
-    fn try_fold_region(&mut self, r: ty::Region<'tcx>) -> Result<ty::Region<'tcx>, Self::Error> {
+    fn try_fold_region(&mut self, r: ty::Region<'tcx>) -> Result<ty::Region<'tcx>, !> {
         Ok(self.fold_region(r))
     }
 
-    fn try_fold_const(&mut self, c: ty::Const<'tcx>) -> Result<ty::Const<'tcx>, Self::Error> {
+    fn try_fold_const(&mut self, c: ty::Const<'tcx>) -> Result<ty::Const<'tcx>, !> {
         Ok(self.fold_const(c))
     }
 
     fn try_fold_unevaluated(
         &mut self,
         c: ty::Unevaluated<'tcx>,
-    ) -> Result<ty::Unevaluated<'tcx>, Self::Error> {
+    ) -> Result<ty::Unevaluated<'tcx>, !> {
         Ok(self.fold_unevaluated(c))
     }
 
-    fn try_fold_predicate(
-        &mut self,
-        p: ty::Predicate<'tcx>,
-    ) -> Result<ty::Predicate<'tcx>, Self::Error> {
+    fn try_fold_predicate(&mut self, p: ty::Predicate<'tcx>) -> Result<ty::Predicate<'tcx>, !> {
         Ok(self.fold_predicate(p))
     }
 
     fn try_fold_mir_const(
         &mut self,
         c: mir::ConstantKind<'tcx>,
-    ) -> Result<mir::ConstantKind<'tcx>, Self::Error> {
+    ) -> Result<mir::ConstantKind<'tcx>, !> {
         Ok(self.fold_mir_const(c))
     }
 }

--- a/compiler/rustc_middle/src/ty/normalize_erasing_regions.rs
+++ b/compiler/rustc_middle/src/ty/normalize_erasing_regions.rs
@@ -228,15 +228,13 @@ impl<'tcx> TryNormalizeAfterErasingRegionsFolder<'tcx> {
     }
 }
 
-impl<'tcx> TypeFolder<'tcx> for TryNormalizeAfterErasingRegionsFolder<'tcx> {
+impl<'tcx> FallibleTypeFolder<'tcx> for TryNormalizeAfterErasingRegionsFolder<'tcx> {
     type Error = NormalizationError<'tcx>;
 
     fn tcx(&self) -> TyCtxt<'tcx> {
         self.tcx
     }
-}
 
-impl<'tcx> FallibleTypeFolder<'tcx> for TryNormalizeAfterErasingRegionsFolder<'tcx> {
     fn try_fold_ty(&mut self, ty: Ty<'tcx>) -> Result<Ty<'tcx>, Self::Error> {
         match self.try_normalize_generic_arg_after_erasing_regions(ty.into()) {
             Ok(t) => Ok(t.expect_ty()),

--- a/compiler/rustc_middle/src/ty/subst.rs
+++ b/compiler/rustc_middle/src/ty/subst.rs
@@ -705,7 +705,7 @@ impl<'a, 'tcx> SubstFolder<'a, 'tcx> {
             return val;
         }
 
-        let result = ty::fold::shift_vars(self.tcx(), val, self.binders_passed);
+        let result = ty::fold::shift_vars(TypeFolder::tcx(self), val, self.binders_passed);
         debug!("shift_vars: shifted result = {:?}", result);
 
         result

--- a/compiler/rustc_target/src/spec/wasm32_unknown_emscripten.rs
+++ b/compiler/rustc_target/src/spec/wasm32_unknown_emscripten.rs
@@ -1,5 +1,5 @@
 use super::{cvs, wasm_base};
-use super::{LinkArgs, LinkerFlavor, PanicStrategy, Target, TargetOptions};
+use super::{LinkArgs, LinkerFlavor, PanicStrategy, RelocModel, Target, TargetOptions};
 
 pub fn target() -> Target {
     let mut options = wasm_base::options();
@@ -26,6 +26,7 @@ pub fn target() -> Target {
         // functionality, and a .wasm file.
         exe_suffix: ".js".into(),
         linker: None,
+        relocation_model: RelocModel::Pic,
         panic_strategy: PanicStrategy::Unwind,
         no_default_libraries: false,
         post_link_args,

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
@@ -484,10 +484,9 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                             err.span_label(span, explanation);
                         }
 
-                        if let ObligationCauseCode::ObjectCastObligation(obj_ty) = obligation.cause.code().peel_derives() &&
-                           let Some(self_ty) = trait_predicate.self_ty().no_bound_vars() &&
+                        if let ObligationCauseCode::ObjectCastObligation(concrete_ty, obj_ty) = obligation.cause.code().peel_derives() &&
                            Some(trait_ref.def_id()) == self.tcx.lang_items().sized_trait() {
-                            self.suggest_borrowing_for_object_cast(&mut err, &obligation, self_ty, *obj_ty);
+                            self.suggest_borrowing_for_object_cast(&mut err, &root_obligation, *concrete_ty, *obj_ty);
                         }
 
                         if trait_predicate.is_const_if_const() && obligation.param_env.is_const() {
@@ -1560,7 +1559,7 @@ impl<'a, 'tcx> InferCtxtPrivExt<'a, 'tcx> for InferCtxt<'a, 'tcx> {
                     obligation.cause.code().peel_derives(),
                     ObligationCauseCode::ItemObligation(_)
                         | ObligationCauseCode::BindingObligation(_, _)
-                        | ObligationCauseCode::ObjectCastObligation(_)
+                        | ObligationCauseCode::ObjectCastObligation(..)
                         | ObligationCauseCode::OpaqueType
                 );
                 if let Err(error) = self.at(&obligation.cause, obligation.param_env).eq_exp(

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -2217,7 +2217,7 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                     err.span_note(tcx.def_span(item_def_id), &descr);
                 }
             }
-            ObligationCauseCode::ObjectCastObligation(object_ty) => {
+            ObligationCauseCode::ObjectCastObligation(_, object_ty) => {
                 err.note(&format!(
                     "required for the cast to the object type `{}`",
                     self.ty_to_string(object_ty)

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -2217,9 +2217,10 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                     err.span_note(tcx.def_span(item_def_id), &descr);
                 }
             }
-            ObligationCauseCode::ObjectCastObligation(_, object_ty) => {
+            ObligationCauseCode::ObjectCastObligation(concrete_ty, object_ty) => {
                 err.note(&format!(
-                    "required for the cast to the object type `{}`",
+                    "required for the cast from `{}` to the object type `{}`",
+                    self.ty_to_string(concrete_ty),
                     self.ty_to_string(object_ty)
                 ));
             }

--- a/compiler/rustc_trait_selection/src/traits/query/normalize.rs
+++ b/compiler/rustc_trait_selection/src/traits/query/normalize.rs
@@ -12,7 +12,7 @@ use rustc_data_structures::sso::SsoHashMap;
 use rustc_data_structures::stack::ensure_sufficient_stack;
 use rustc_infer::traits::Normalized;
 use rustc_middle::mir;
-use rustc_middle::ty::fold::{FallibleTypeFolder, TypeFoldable, TypeFolder, TypeSuperFoldable};
+use rustc_middle::ty::fold::{FallibleTypeFolder, TypeFoldable, TypeSuperFoldable};
 use rustc_middle::ty::subst::Subst;
 use rustc_middle::ty::{self, Ty, TyCtxt, TypeVisitor};
 
@@ -162,15 +162,13 @@ struct QueryNormalizer<'cx, 'tcx> {
     universes: Vec<Option<ty::UniverseIndex>>,
 }
 
-impl<'cx, 'tcx> TypeFolder<'tcx> for QueryNormalizer<'cx, 'tcx> {
+impl<'cx, 'tcx> FallibleTypeFolder<'tcx> for QueryNormalizer<'cx, 'tcx> {
     type Error = NoSolution;
 
     fn tcx<'c>(&'c self) -> TyCtxt<'tcx> {
         self.infcx.tcx
     }
-}
 
-impl<'cx, 'tcx> FallibleTypeFolder<'tcx> for QueryNormalizer<'cx, 'tcx> {
     fn try_fold_binder<T: TypeFoldable<'tcx>>(
         &mut self,
         t: ty::Binder<'tcx, T>,

--- a/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
@@ -813,7 +813,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                 let cause = ObligationCause::new(
                     obligation.cause.span,
                     obligation.cause.body_id,
-                    ObjectCastObligation(target),
+                    ObjectCastObligation(source, target),
                 );
                 let outlives = ty::OutlivesPredicate(r_a, r_b);
                 nested.push(Obligation::with_depth(
@@ -910,7 +910,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                 let cause = ObligationCause::new(
                     obligation.cause.span,
                     obligation.cause.body_id,
-                    ObjectCastObligation(target),
+                    ObjectCastObligation(source, target),
                 );
                 let outlives = ty::OutlivesPredicate(r_a, r_b);
                 nested.push(Obligation::with_depth(
@@ -931,7 +931,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                 let cause = ObligationCause::new(
                     obligation.cause.span,
                     obligation.cause.body_id,
-                    ObjectCastObligation(target),
+                    ObjectCastObligation(source, target),
                 );
 
                 let predicate_to_obligation = |predicate| {

--- a/compiler/rustc_typeck/src/check/pat.rs
+++ b/compiler/rustc_typeck/src/check/pat.rs
@@ -697,7 +697,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
                 Some((
                     pat.span,
-                    format!("to declare a mutable {ident_kind} use `mut variable_name`"),
+                    format!("to declare a mutable {ident_kind} use"),
                     format!("mut {binding}"),
                 ))
 

--- a/compiler/rustc_typeck/src/check/pat.rs
+++ b/compiler/rustc_typeck/src/check/pat.rs
@@ -669,9 +669,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 }
 
                 let ident_kind = match binding_parent {
-                    hir::Node::Param(_) => Some("parameter"),
-                    hir::Node::Local(_) => Some("variable"),
-                    hir::Node::Arm(_) => Some("binding"),
+                    hir::Node::Param(_) => "parameter",
+                    hir::Node::Local(_) => "variable",
+                    hir::Node::Arm(_) => "binding",
 
                     // Provide diagnostics only if the parent pattern is struct-like,
                     // i.e. where `mut binding` makes sense
@@ -680,7 +680,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         | PatKind::TupleStruct(..)
                         | PatKind::Or(..)
                         | PatKind::Tuple(..)
-                        | PatKind::Slice(..) => Some("binding"),
+                        | PatKind::Slice(..) => "binding",
 
                         PatKind::Wild
                         | PatKind::Binding(..)
@@ -688,16 +688,16 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         | PatKind::Box(..)
                         | PatKind::Ref(..)
                         | PatKind::Lit(..)
-                        | PatKind::Range(..) => None,
+                        | PatKind::Range(..) => break 'block None,
                     },
 
                     // Don't provide suggestions in other cases
-                    _ => None,
+                    _ => break 'block None,
                 };
 
-                ident_kind.map(|thing| (
+                Some((
                     pat.span,
-                    format!("to declare a mutable {thing} use `mut variable_name`"),
+                    format!("to declare a mutable {ident_kind} use `mut variable_name`"),
                     format!("mut {binding}"),
                 ))
 

--- a/library/std/src/sys/sgx/abi/usercalls/alloc.rs
+++ b/library/std/src/sys/sgx/abi/usercalls/alloc.rs
@@ -317,7 +317,7 @@ where
 /// * The `dst` pointer is null
 /// * The `src` memory range is not in enclave memory
 /// * The `dst` memory range is not in user memory
-unsafe fn copy_to_userspace(src: *const u8, dst: *mut u8, len: usize) {
+pub(crate) unsafe fn copy_to_userspace(src: *const u8, dst: *mut u8, len: usize) {
     unsafe fn copy_bytewise_to_userspace(src: *const u8, dst: *mut u8, len: usize) {
         unsafe {
             let seg_sel: u16 = 0;

--- a/library/std/src/sys/sgx/abi/usercalls/alloc.rs
+++ b/library/std/src/sys/sgx/abi/usercalls/alloc.rs
@@ -1,13 +1,15 @@
 #![allow(unused)]
 
+use crate::arch::asm;
 use crate::cell::UnsafeCell;
+use crate::convert::TryInto;
 use crate::mem;
 use crate::ops::{CoerceUnsized, Deref, DerefMut, Index, IndexMut};
 use crate::ptr::{self, NonNull};
 use crate::slice;
 use crate::slice::SliceIndex;
 
-use super::super::mem::is_user_range;
+use super::super::mem::{is_enclave_range, is_user_range};
 use fortanix_sgx_abi::*;
 
 /// A type that can be safely read from or written to userspace.
@@ -300,6 +302,100 @@ where
     }
 }
 
+/// Copies `len` bytes of data from enclave pointer `src` to userspace `dst`
+///
+/// This function mitigates stale data vulnerabilities
+/// https://www.intel.com/content/www/us/en/security-center/advisory/intel-sa-00615.html
+///
+/// # Panics
+/// This function panics if:
+///
+/// * The `src` pointer is null
+/// * The `dst` pointer is null
+/// * The `src` memory range is not in enclave memory
+/// * The `dst` memory range is not in user memory
+unsafe fn copy_to_userspace(src: *const u8, dst: *mut u8, len: usize) {
+    unsafe fn copy_bytewise_to_userspace(src: *const u8, dst: *mut u8, len: usize) {
+        unsafe {
+            let seg_sel: u16 = 0;
+            for off in 0..len {
+                asm!("
+                    mov %ds, ({seg_sel})
+                    verw ({seg_sel})
+                    movb {val}, ({dst})
+                    mfence
+                    lfence
+                     ",
+                    val = in(reg_byte) *src.offset(off as isize),
+                    dst = in(reg) dst.offset(off as isize),
+                    seg_sel = in(reg) &seg_sel,
+                    options(nostack, att_syntax)
+                );
+            }
+        }
+    }
+
+    unsafe fn copy_aligned_quadwords_to_userspace(src: *const u8, dst: *mut u8, len: usize) {
+        unsafe {
+            asm!(
+                "rep movsq (%rsi), (%rdi)",
+                inout("rcx") len / 8 => _,
+                inout("rdi") dst => _,
+                inout("rsi") src => _,
+                options(att_syntax, nostack, preserves_flags)
+            );
+        }
+    }
+    assert!(!src.is_null());
+    assert!(!dst.is_null());
+    assert!(is_enclave_range(src, len));
+    assert!(is_user_range(dst, len));
+    assert!(len < isize::MAX as usize);
+    assert!(!(src as usize).overflowing_add(len).1);
+    assert!(!(dst as usize).overflowing_add(len).1);
+
+    if len < 8 {
+        // Can't align on 8 byte boundary: copy safely byte per byte
+        unsafe {
+            copy_bytewise_to_userspace(src, dst, len);
+        }
+    } else if len % 8 == 0 && dst as usize % 8 == 0 {
+        // Copying 8-byte aligned quadwords: copy quad word per quad word
+        unsafe {
+            copy_aligned_quadwords_to_userspace(src, dst, len);
+        }
+    } else {
+        // Split copies into three parts:
+        //   +--------+
+        //   | small0 | Chunk smaller than 8 bytes
+        //   +--------+
+        //   |   big  | Chunk 8-byte aligned, and size a multiple of 8 bytes
+        //   +--------+
+        //   | small1 | Chunk smaller than 8 bytes
+        //   +--------+
+
+        unsafe {
+            // Copy small0
+            let small0_size = (8 - dst as usize % 8) as u8;
+            let small0_src = src;
+            let small0_dst = dst;
+            copy_bytewise_to_userspace(small0_src as _, small0_dst, small0_size as _);
+
+            // Copy big
+            let small1_size = ((len - small0_size as usize) % 8) as u8;
+            let big_size = len - small0_size as usize - small1_size as usize;
+            let big_src = src.offset(small0_size as _);
+            let big_dst = dst.offset(small0_size as _);
+            copy_aligned_quadwords_to_userspace(big_src as _, big_dst, big_size);
+
+            // Copy small1
+            let small1_src = src.offset(big_size as isize + small0_size as isize);
+            let small1_dst = dst.offset(big_size as isize + small0_size as isize);
+            copy_bytewise_to_userspace(small1_src, small1_dst, small1_size as _);
+        }
+    }
+}
+
 #[unstable(feature = "sgx_platform", issue = "56975")]
 impl<T: ?Sized> UserRef<T>
 where
@@ -348,7 +444,7 @@ where
     pub fn copy_from_enclave(&mut self, val: &T) {
         unsafe {
             assert_eq!(mem::size_of_val(val), mem::size_of_val(&*self.0.get()));
-            ptr::copy(
+            copy_to_userspace(
                 val as *const T as *const u8,
                 self.0.get() as *mut T as *mut u8,
                 mem::size_of_val(val),

--- a/library/std/src/sys/sgx/abi/usercalls/alloc.rs
+++ b/library/std/src/sys/sgx/abi/usercalls/alloc.rs
@@ -225,13 +225,9 @@ where
     /// Copies `val` into freshly allocated space in user memory.
     pub fn new_from_enclave(val: &T) -> Self {
         unsafe {
-            let ret = Self::new_uninit_bytes(mem::size_of_val(val));
-            ptr::copy(
-                val as *const T as *const u8,
-                ret.0.as_ptr() as *mut u8,
-                mem::size_of_val(val),
-            );
-            ret
+            let mut user = Self::new_uninit_bytes(mem::size_of_val(val));
+            user.copy_from_enclave(val);
+            user
         }
     }
 

--- a/library/std/src/sys/sgx/abi/usercalls/mod.rs
+++ b/library/std/src/sys/sgx/abi/usercalls/mod.rs
@@ -6,6 +6,8 @@ use crate::time::{Duration, Instant};
 pub(crate) mod alloc;
 #[macro_use]
 pub(crate) mod raw;
+#[cfg(test)]
+mod tests;
 
 use self::raw::*;
 

--- a/library/std/src/sys/sgx/abi/usercalls/tests.rs
+++ b/library/std/src/sys/sgx/abi/usercalls/tests.rs
@@ -1,0 +1,30 @@
+use super::alloc::copy_to_userspace;
+use super::alloc::User;
+
+#[test]
+fn test_copy_function() {
+    let mut src = [0u8; 100];
+    let mut dst = User::<[u8]>::uninitialized(100);
+
+    for i in 0..src.len() {
+        src[i] = i as _;
+    }
+
+    for size in 0..48 {
+        // For all possible alignment
+        for offset in 0..8 {
+            // overwrite complete dst
+            dst.copy_from_enclave(&[0u8; 100]);
+
+            // Copy src[0..size] to dst + offset
+            unsafe { copy_to_userspace(src.as_ptr(), dst.as_mut_ptr().offset(offset), size) };
+
+            // Verify copy
+            for byte in 0..size {
+                unsafe {
+                    assert_eq!(*dst.as_ptr().offset(offset + byte as isize), src[byte as usize]);
+                }
+            }
+        }
+    }
+}

--- a/library/std/src/sys/windows/fs.rs
+++ b/library/std/src/sys/windows/fs.rs
@@ -14,6 +14,7 @@ use crate::sys::handle::Handle;
 use crate::sys::time::SystemTime;
 use crate::sys::{c, cvt};
 use crate::sys_common::{AsInner, FromInner, IntoInner};
+use crate::thread;
 
 use super::path::maybe_verbatim;
 use super::to_u16s;
@@ -1059,6 +1060,7 @@ fn remove_dir_all_iterative(f: &File, delete: fn(&File) -> io::Result<()>) -> io
                         // Otherwise return the error.
                         Err(e) => return Err(e),
                     }
+                    thread::yield_now();
                 }
             }
         }
@@ -1072,6 +1074,7 @@ fn remove_dir_all_iterative(f: &File, delete: fn(&File) -> io::Result<()>) -> io
                         if i == MAX_RETRIES || e.kind() != io::ErrorKind::DirectoryNotEmpty {
                             return Err(e);
                         }
+                        thread::yield_now();
                     } else {
                         break;
                     }

--- a/library/std/src/sys/windows/fs.rs
+++ b/library/std/src/sys/windows/fs.rs
@@ -680,7 +680,7 @@ impl<'a> DirBuffIter<'a> {
     }
 }
 impl<'a> Iterator for DirBuffIter<'a> {
-    type Item = &'a [u16];
+    type Item = (&'a [u16], bool);
     fn next(&mut self) -> Option<Self::Item> {
         use crate::mem::size_of;
         let buffer = &self.buffer?[self.cursor..];
@@ -689,14 +689,16 @@ impl<'a> Iterator for DirBuffIter<'a> {
         // SAFETY: The buffer contains a `FILE_ID_BOTH_DIR_INFO` struct but the
         // last field (the file name) is unsized. So an offset has to be
         // used to get the file name slice.
-        let (name, next_entry) = unsafe {
+        let (name, is_directory, next_entry) = unsafe {
             let info = buffer.as_ptr().cast::<c::FILE_ID_BOTH_DIR_INFO>();
             let next_entry = (*info).NextEntryOffset as usize;
             let name = crate::slice::from_raw_parts(
                 (*info).FileName.as_ptr().cast::<u16>(),
                 (*info).FileNameLength as usize / size_of::<u16>(),
             );
-            (name, next_entry)
+            let is_directory = ((*info).FileAttributes & c::FILE_ATTRIBUTE_DIRECTORY) != 0;
+
+            (name, is_directory, next_entry)
         };
 
         if next_entry == 0 {
@@ -709,7 +711,7 @@ impl<'a> Iterator for DirBuffIter<'a> {
         const DOT: u16 = b'.' as u16;
         match name {
             [DOT] | [DOT, DOT] => self.next(),
-            _ => Some(name),
+            _ => Some((name, is_directory)),
         }
     }
 }
@@ -994,89 +996,77 @@ pub fn remove_dir_all(path: &Path) -> io::Result<()> {
     if (file.basic_info()?.FileAttributes & c::FILE_ATTRIBUTE_DIRECTORY) == 0 {
         return Err(io::Error::from_raw_os_error(c::ERROR_DIRECTORY as _));
     }
-    let mut delete: fn(&File) -> io::Result<()> = File::posix_delete;
-    let result = match delete(&file) {
-        Err(e) if e.kind() == io::ErrorKind::DirectoryNotEmpty => {
-            match remove_dir_all_recursive(&file, delete) {
-                // Return unexpected errors.
-                Err(e) if e.kind() != io::ErrorKind::DirectoryNotEmpty => return Err(e),
-                result => result,
+
+    match remove_dir_all_iterative(&file, File::posix_delete) {
+        Err(e) => {
+            if let Some(code) = e.raw_os_error() {
+                match code as u32 {
+                    // If POSIX delete is not supported for this filesystem then fallback to win32 delete.
+                    c::ERROR_NOT_SUPPORTED
+                    | c::ERROR_INVALID_FUNCTION
+                    | c::ERROR_INVALID_PARAMETER => {
+                        remove_dir_all_iterative(&file, File::win32_delete)
+                    }
+                    _ => Err(e),
+                }
+            } else {
+                Err(e)
             }
         }
-        // If POSIX delete is not supported for this filesystem then fallback to win32 delete.
-        Err(e)
-            if e.raw_os_error() == Some(c::ERROR_NOT_SUPPORTED as i32)
-                || e.raw_os_error() == Some(c::ERROR_INVALID_PARAMETER as i32) =>
-        {
-            delete = File::win32_delete;
-            Err(e)
-        }
-        result => result,
-    };
-    if result.is_ok() {
-        Ok(())
-    } else {
-        // This is a fallback to make sure the directory is actually deleted.
-        // Otherwise this function is prone to failing with `DirectoryNotEmpty`
-        // due to possible delays between marking a file for deletion and the
-        // file actually being deleted from the filesystem.
-        //
-        // So we retry a few times before giving up.
-        for _ in 0..5 {
-            match remove_dir_all_recursive(&file, delete) {
-                Err(e) if e.kind() == io::ErrorKind::DirectoryNotEmpty => {}
-                result => return result,
-            }
-        }
-        // Try one last time.
-        delete(&file)
+        ok => ok,
     }
 }
 
-fn remove_dir_all_recursive(f: &File, delete: fn(&File) -> io::Result<()>) -> io::Result<()> {
+fn remove_dir_all_iterative(f: &File, delete: fn(&File) -> io::Result<()>) -> io::Result<()> {
     let mut buffer = DirBuff::new();
-    let mut restart = true;
-    // Fill the buffer and iterate the entries.
-    while f.fill_dir_buff(&mut buffer, restart)? {
-        for name in buffer.iter() {
-            // Open the file without following symlinks and try deleting it.
-            // We try opening will all needed permissions and if that is denied
-            // fallback to opening without `FILE_LIST_DIRECTORY` permission.
-            // Note `SYNCHRONIZE` permission is needed for synchronous access.
-            let mut result =
-                open_link_no_reparse(&f, name, c::SYNCHRONIZE | c::DELETE | c::FILE_LIST_DIRECTORY);
-            if matches!(&result, Err(e) if e.kind() == io::ErrorKind::PermissionDenied) {
-                result = open_link_no_reparse(&f, name, c::SYNCHRONIZE | c::DELETE);
-            }
-            match result {
-                Ok(file) => match delete(&file) {
-                    Err(e) if e.kind() == io::ErrorKind::DirectoryNotEmpty => {
-                        // Iterate the directory's files.
-                        // Ignore `DirectoryNotEmpty` errors here. They will be
-                        // caught when `remove_dir_all` tries to delete the top
-                        // level directory. It can then decide if to retry or not.
-                        match remove_dir_all_recursive(&file, delete) {
-                            Err(e) if e.kind() == io::ErrorKind::DirectoryNotEmpty => {}
-                            result => result?,
-                        }
+    let mut dirlist = vec![f.duplicate()?];
+
+    // FIXME: This is a hack so we can push to the dirlist vec after borrowing from it.
+    fn copy_handle(f: &File) -> mem::ManuallyDrop<File> {
+        unsafe { mem::ManuallyDrop::new(File::from_raw_handle(f.as_raw_handle())) }
+    }
+
+    while let Some(dir) = dirlist.last() {
+        let dir = copy_handle(dir);
+
+        // Fill the buffer and iterate the entries.
+        let more_data = dir.fill_dir_buff(&mut buffer, false)?;
+        for (name, is_directory) in buffer.iter() {
+            if is_directory {
+                let child_dir = open_link_no_reparse(
+                    &dir,
+                    name,
+                    c::SYNCHRONIZE | c::DELETE | c::FILE_LIST_DIRECTORY,
+                )?;
+                dirlist.push(child_dir);
+            } else {
+                const MAX_RETRIES: u32 = 10;
+                for i in 1..=MAX_RETRIES {
+                    let result = open_link_no_reparse(&dir, name, c::SYNCHRONIZE | c::DELETE);
+                    match result {
+                        Ok(f) => delete(&f)?,
+                        // Already deleted, so skip.
+                        Err(e) if e.kind() == io::ErrorKind::NotFound => break,
+                        // Retry a few times if the file is locked or a delete is already in progress.
+                        Err(e)
+                            if i < MAX_RETRIES
+                                && (e.raw_os_error() == Some(c::ERROR_DELETE_PENDING as _)
+                                    || e.raw_os_error()
+                                        == Some(c::ERROR_SHARING_VIOLATION as _)) => {}
+                        // Otherwise return the error.
+                        Err(e) => return Err(e),
                     }
-                    result => result?,
-                },
-                // Ignore error if a delete is already in progress or the file
-                // has already been deleted. It also ignores sharing violations
-                // (where a file is locked by another process) as these are
-                // usually temporary.
-                Err(e)
-                    if e.raw_os_error() == Some(c::ERROR_DELETE_PENDING as _)
-                        || e.kind() == io::ErrorKind::NotFound
-                        || e.raw_os_error() == Some(c::ERROR_SHARING_VIOLATION as _) => {}
-                Err(e) => return Err(e),
+                }
             }
         }
-        // Continue reading directory entries without restarting from the beginning,
-        restart = false;
+        // If there were no more files then delete the directory.
+        if !more_data {
+            if let Some(dir) = dirlist.pop() {
+                delete(&dir)?;
+            }
+        }
     }
-    delete(&f)
+    Ok(())
 }
 
 pub fn readlink(path: &Path) -> io::Result<PathBuf> {

--- a/src/doc/unstable-book/src/compiler-flags/extern-options.md
+++ b/src/doc/unstable-book/src/compiler-flags/extern-options.md
@@ -1,5 +1,10 @@
 # `--extern` Options
 
+* Tracking issue for `--extern` crate modifiers: [#98405](https://github.com/rust-lang/rust/issues/98405)
+* Tracking issue for `noprelude`: [#98398](https://github.com/rust-lang/rust/issues/98398)
+* Tracking issue for `priv`: [#98399](https://github.com/rust-lang/rust/issues/98399)
+* Tracking issue for `nounused`: [#98400](https://github.com/rust-lang/rust/issues/98400)
+
 The behavior of the `--extern` flag can be modified with `noprelude`, `priv` or `nounused` options.
 
 This is unstable feature, so you have to provide `-Zunstable-options` to enable it.

--- a/src/test/ui/associated-item/associated-item-enum.stderr
+++ b/src/test/ui/associated-item/associated-item-enum.stderr
@@ -2,7 +2,7 @@ error[E0599]: no variant or associated item named `mispellable` found for enum `
   --> $DIR/associated-item-enum.rs:17:11
    |
 LL | enum Enum { Variant }
-   | --------- variant or associated item `mispellable` not found here
+   |      ---- variant or associated item `mispellable` not found for this enum
 ...
 LL |     Enum::mispellable();
    |           ^^^^^^^^^^^
@@ -14,7 +14,7 @@ error[E0599]: no variant or associated item named `mispellable_trait` found for 
   --> $DIR/associated-item-enum.rs:18:11
    |
 LL | enum Enum { Variant }
-   | --------- variant or associated item `mispellable_trait` not found here
+   |      ---- variant or associated item `mispellable_trait` not found for this enum
 ...
 LL |     Enum::mispellable_trait();
    |           ^^^^^^^^^^^^^^^^^
@@ -26,7 +26,7 @@ error[E0599]: no variant or associated item named `MISPELLABLE` found for enum `
   --> $DIR/associated-item-enum.rs:19:11
    |
 LL | enum Enum { Variant }
-   | --------- variant or associated item `MISPELLABLE` not found here
+   |      ---- variant or associated item `MISPELLABLE` not found for this enum
 ...
 LL |     Enum::MISPELLABLE;
    |           ^^^^^^^^^^^

--- a/src/test/ui/associated-type-bounds/assoc-type-eq-with-dyn-atb-fail.stderr
+++ b/src/test/ui/associated-type-bounds/assoc-type-eq-with-dyn-atb-fail.stderr
@@ -4,7 +4,7 @@ error[E0277]: the trait bound `String: Copy` is not satisfied
 LL |         Box::new(AssocNoCopy)
    |         ^^^^^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `String`
    |
-   = note: required for the cast to the object type `dyn Bar<Assoc = <AssocNoCopy as Thing>::Out::{opaque#0}>`
+   = note: required for the cast from `AssocNoCopy` to the object type `dyn Bar<Assoc = <AssocNoCopy as Thing>::Out::{opaque#0}>`
 
 error: aborting due to previous error
 

--- a/src/test/ui/associated-types/associated-types-eq-3.stderr
+++ b/src/test/ui/associated-types/associated-types-eq-3.stderr
@@ -41,7 +41,7 @@ note: expected this to be `Bar`
    |
 LL |     type A = usize;
    |              ^^^^^
-   = note: required for the cast to the object type `dyn Foo<A = Bar>`
+   = note: required for the cast from `isize` to the object type `dyn Foo<A = Bar>`
 
 error: aborting due to 3 previous errors
 

--- a/src/test/ui/associated-types/associated-types-overridden-binding-2.stderr
+++ b/src/test/ui/associated-types/associated-types-overridden-binding-2.stderr
@@ -4,7 +4,7 @@ error[E0271]: type mismatch resolving `<std::vec::IntoIter<u32> as Iterator>::It
 LL |     let _: &dyn I32Iterator<Item = u32> = &vec![42].into_iter();
    |                                           ^^^^^^^^^^^^^^^^^^^^^ expected `i32`, found `u32`
    |
-   = note: required for the cast to the object type `dyn Iterator<Item = u32, Item = i32>`
+   = note: required for the cast from `std::vec::IntoIter<u32>` to the object type `dyn Iterator<Item = u32, Item = i32>`
 
 error: aborting due to previous error
 

--- a/src/test/ui/associated-types/issue-65774-1.stderr
+++ b/src/test/ui/associated-types/issue-65774-1.stderr
@@ -23,7 +23,7 @@ note: required because of the requirements on the impl of `MyDisplay` for `&mut 
    |
 LL | impl<'a, T: MyDisplay> MyDisplay for &'a mut T { }
    |                        ^^^^^^^^^     ^^^^^^^^^
-   = note: required for the cast to the object type `dyn MyDisplay`
+   = note: required for the cast from `&mut T` to the object type `dyn MyDisplay`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/associated-types/issue-65774-2.stderr
+++ b/src/test/ui/associated-types/issue-65774-2.stderr
@@ -18,7 +18,7 @@ LL |         writer.my_write(valref)
    |                         ^^^^^^ the trait `MyDisplay` is not implemented for `T`
    |
    = help: the trait `MyDisplay` is implemented for `&'a mut T`
-   = note: required for the cast to the object type `dyn MyDisplay`
+   = note: required for the cast from `T` to the object type `dyn MyDisplay`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/async-await/async-block-control-flow-static-semantics.stderr
+++ b/src/test/ui/async-await/async-block-control-flow-static-semantics.stderr
@@ -37,7 +37,7 @@ error[E0271]: type mismatch resolving `<impl Future<Output = u8> as Future>::Out
 LL |     let _: &dyn Future<Output = ()> = &block;
    |                                       ^^^^^^ expected `()`, found `u8`
    |
-   = note: required for the cast to the object type `dyn Future<Output = ()>`
+   = note: required for the cast from `impl Future<Output = u8>` to the object type `dyn Future<Output = ()>`
 
 error[E0308]: mismatched types
   --> $DIR/async-block-control-flow-static-semantics.rs:12:43
@@ -53,7 +53,7 @@ error[E0271]: type mismatch resolving `<impl Future<Output = u8> as Future>::Out
 LL |     let _: &dyn Future<Output = ()> = &block;
    |                                       ^^^^^^ expected `()`, found `u8`
    |
-   = note: required for the cast to the object type `dyn Future<Output = ()>`
+   = note: required for the cast from `impl Future<Output = u8>` to the object type `dyn Future<Output = ()>`
 
 error[E0308]: mismatched types
   --> $DIR/async-block-control-flow-static-semantics.rs:47:44

--- a/src/test/ui/async-await/issue-86507.stderr
+++ b/src/test/ui/async-await/issue-86507.stderr
@@ -13,7 +13,7 @@ note: captured value is not `Send` because `&` references cannot be sent unless 
    |
 LL |                     let x = x;
    |                             ^ has type `&T` which is not `Send`, because `T` is not `Sync`
-   = note: required for the cast to the object type `dyn Future<Output = ()> + Send`
+   = note: required for the cast from `impl Future<Output = ()>` to the object type `dyn Future<Output = ()> + Send`
 help: consider further restricting this bound
    |
 LL |     fn bar<'me, 'async_trait, T: Send + std::marker::Sync>(x: &'me T)

--- a/src/test/ui/async-await/pin-needed-to-poll.stderr
+++ b/src/test/ui/async-await/pin-needed-to-poll.stderr
@@ -2,7 +2,7 @@ error[E0599]: no method named `poll` found for struct `Sleep` in the current sco
   --> $DIR/pin-needed-to-poll.rs:42:20
    |
 LL | struct Sleep;
-   | ------------- method `poll` not found for this
+   |        ----- method `poll` not found for this struct
 ...
 LL |         self.sleep.poll(cx)
    |                    ^^^^ method not found in `Sleep`

--- a/src/test/ui/bogus-tag.stderr
+++ b/src/test/ui/bogus-tag.stderr
@@ -2,7 +2,7 @@ error[E0599]: no variant or associated item named `Hsl` found for enum `Color` i
   --> $DIR/bogus-tag.rs:7:16
    |
 LL | enum Color { Rgb(isize, isize, isize), Rgba(isize, isize, isize, isize), }
-   | ---------- variant or associated item `Hsl` not found here
+   |      ----- variant or associated item `Hsl` not found for this enum
 ...
 LL |         Color::Hsl(h, s, l) => { println!("hsl"); }
    |                ^^^ variant or associated item not found in `Color`

--- a/src/test/ui/coercion/coerce-issue-49593-box-never.nofallback.stderr
+++ b/src/test/ui/coercion/coerce-issue-49593-box-never.nofallback.stderr
@@ -4,7 +4,7 @@ error[E0277]: the trait bound `(): std::error::Error` is not satisfied
 LL |     /* *mut $0 is coerced to Box<dyn Error> here */ Box::<_ /* ! */>::new(x)
    |                                                     ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::error::Error` is not implemented for `()`
    |
-   = note: required for the cast to the object type `dyn std::error::Error`
+   = note: required for the cast from `()` to the object type `dyn std::error::Error`
 
 error[E0277]: the trait bound `(): std::error::Error` is not satisfied
   --> $DIR/coerce-issue-49593-box-never.rs:23:49
@@ -12,7 +12,7 @@ error[E0277]: the trait bound `(): std::error::Error` is not satisfied
 LL |     /* *mut $0 is coerced to *mut Error here */ raw_ptr_box::<_ /* ! */>(x)
    |                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::error::Error` is not implemented for `()`
    |
-   = note: required for the cast to the object type `(dyn std::error::Error + 'static)`
+   = note: required for the cast from `()` to the object type `(dyn std::error::Error + 'static)`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/confuse-field-and-method/issue-18343.stderr
+++ b/src/test/ui/confuse-field-and-method/issue-18343.stderr
@@ -2,7 +2,7 @@ error[E0599]: no method named `closure` found for struct `Obj` in the current sc
   --> $DIR/issue-18343.rs:7:7
    |
 LL | struct Obj<F> where F: FnMut() -> u32 {
-   | ------------------------------------- method `closure` not found for this
+   |        --- method `closure` not found for this struct
 ...
 LL |     o.closure();
    |       ^^^^^^^ field, not a method

--- a/src/test/ui/confuse-field-and-method/issue-2392.stderr
+++ b/src/test/ui/confuse-field-and-method/issue-2392.stderr
@@ -2,7 +2,7 @@ error[E0599]: no method named `closure` found for struct `Obj` in the current sc
   --> $DIR/issue-2392.rs:36:15
    |
 LL | struct Obj<F> where F: FnOnce() -> u32 {
-   | -------------------------------------- method `closure` not found for this
+   |        --- method `closure` not found for this struct
 ...
 LL |     o_closure.closure();
    |               ^^^^^^^ field, not a method
@@ -16,7 +16,7 @@ error[E0599]: no method named `not_closure` found for struct `Obj` in the curren
   --> $DIR/issue-2392.rs:38:15
    |
 LL | struct Obj<F> where F: FnOnce() -> u32 {
-   | -------------------------------------- method `not_closure` not found for this
+   |        --- method `not_closure` not found for this struct
 ...
 LL |     o_closure.not_closure();
    |               ^^^^^^^^^^^-- help: remove the arguments
@@ -27,7 +27,7 @@ error[E0599]: no method named `closure` found for struct `Obj` in the current sc
   --> $DIR/issue-2392.rs:42:12
    |
 LL | struct Obj<F> where F: FnOnce() -> u32 {
-   | -------------------------------------- method `closure` not found for this
+   |        --- method `closure` not found for this struct
 ...
 LL |     o_func.closure();
    |            ^^^^^^^ field, not a method
@@ -41,7 +41,7 @@ error[E0599]: no method named `boxed_closure` found for struct `BoxedObj` in the
   --> $DIR/issue-2392.rs:45:14
    |
 LL | struct BoxedObj {
-   | --------------- method `boxed_closure` not found for this
+   |        -------- method `boxed_closure` not found for this struct
 ...
 LL |     boxed_fn.boxed_closure();
    |              ^^^^^^^^^^^^^ field, not a method
@@ -55,7 +55,7 @@ error[E0599]: no method named `boxed_closure` found for struct `BoxedObj` in the
   --> $DIR/issue-2392.rs:48:19
    |
 LL | struct BoxedObj {
-   | --------------- method `boxed_closure` not found for this
+   |        -------- method `boxed_closure` not found for this struct
 ...
 LL |     boxed_closure.boxed_closure();
    |                   ^^^^^^^^^^^^^ field, not a method
@@ -69,7 +69,7 @@ error[E0599]: no method named `closure` found for struct `Obj` in the current sc
   --> $DIR/issue-2392.rs:53:12
    |
 LL | struct Obj<F> where F: FnOnce() -> u32 {
-   | -------------------------------------- method `closure` not found for this
+   |        --- method `closure` not found for this struct
 ...
 LL |     w.wrap.closure();
    |            ^^^^^^^ field, not a method
@@ -83,7 +83,7 @@ error[E0599]: no method named `not_closure` found for struct `Obj` in the curren
   --> $DIR/issue-2392.rs:55:12
    |
 LL | struct Obj<F> where F: FnOnce() -> u32 {
-   | -------------------------------------- method `not_closure` not found for this
+   |        --- method `not_closure` not found for this struct
 ...
 LL |     w.wrap.not_closure();
    |            ^^^^^^^^^^^-- help: remove the arguments
@@ -94,7 +94,7 @@ error[E0599]: no method named `closure` found for struct `Obj` in the current sc
   --> $DIR/issue-2392.rs:58:24
    |
 LL | struct Obj<F> where F: FnOnce() -> u32 {
-   | -------------------------------------- method `closure` not found for this
+   |        --- method `closure` not found for this struct
 ...
 LL |     check_expression().closure();
    |                        ^^^^^^^ field, not a method
@@ -108,7 +108,7 @@ error[E0599]: no method named `f1` found for struct `FuncContainer` in the curre
   --> $DIR/issue-2392.rs:64:31
    |
 LL | struct FuncContainer {
-   | -------------------- method `f1` not found for this
+   |        ------------- method `f1` not found for this struct
 ...
 LL |             (*self.container).f1(1);
    |                               ^^ field, not a method
@@ -122,7 +122,7 @@ error[E0599]: no method named `f2` found for struct `FuncContainer` in the curre
   --> $DIR/issue-2392.rs:65:31
    |
 LL | struct FuncContainer {
-   | -------------------- method `f2` not found for this
+   |        ------------- method `f2` not found for this struct
 ...
 LL |             (*self.container).f2(1);
    |                               ^^ field, not a method
@@ -136,7 +136,7 @@ error[E0599]: no method named `f3` found for struct `FuncContainer` in the curre
   --> $DIR/issue-2392.rs:66:31
    |
 LL | struct FuncContainer {
-   | -------------------- method `f3` not found for this
+   |        ------------- method `f3` not found for this struct
 ...
 LL |             (*self.container).f3(1);
    |                               ^^ field, not a method

--- a/src/test/ui/confuse-field-and-method/issue-32128.stderr
+++ b/src/test/ui/confuse-field-and-method/issue-32128.stderr
@@ -2,7 +2,7 @@ error[E0599]: no method named `example` found for struct `Example` in the curren
   --> $DIR/issue-32128.rs:12:10
    |
 LL | struct Example {
-   | -------------- method `example` not found for this
+   |        ------- method `example` not found for this struct
 ...
 LL |     demo.example(1);
    |          ^^^^^^^ field, not a method

--- a/src/test/ui/confuse-field-and-method/private-field.stderr
+++ b/src/test/ui/confuse-field-and-method/private-field.stderr
@@ -2,7 +2,7 @@ error[E0599]: no method named `dog_age` found for struct `Dog` in the current sc
   --> $DIR/private-field.rs:16:23
    |
 LL |     pub struct Dog {
-   |     -------------- method `dog_age` not found for this
+   |                --- method `dog_age` not found for this struct
 ...
 LL |     let dog_age = dog.dog_age();
    |                       ^^^^^^^ private field, not a method

--- a/src/test/ui/const-generics/defaults/trait_objects_fail.stderr
+++ b/src/test/ui/const-generics/defaults/trait_objects_fail.stderr
@@ -7,7 +7,7 @@ LL |     foo(&10_u32);
    |     required by a bound introduced by this call
    |
    = help: the trait `Trait<2_u8>` is implemented for `u32`
-   = note: required for the cast to the object type `dyn Trait`
+   = note: required for the cast from `u32` to the object type `dyn Trait`
 
 error[E0277]: the trait bound `bool: Traitor<{_: u8}>` is not satisfied
   --> $DIR/trait_objects_fail.rs:28:9
@@ -18,7 +18,7 @@ LL |     bar(&true);
    |     required by a bound introduced by this call
    |
    = help: the trait `Traitor<2_u8, 3_u8>` is implemented for `bool`
-   = note: required for the cast to the object type `dyn Traitor<{_: u8}>`
+   = note: required for the cast from `bool` to the object type `dyn Traitor<{_: u8}>`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/const-generics/generic_const_exprs/issue-69654.stderr
+++ b/src/test/ui/const-generics/generic_const_exprs/issue-69654.stderr
@@ -8,7 +8,7 @@ error[E0599]: the function or associated item `foo` exists for struct `Foo<{_: u
   --> $DIR/issue-69654.rs:17:10
    |
 LL | struct Foo<const N: usize> {}
-   | -------------------------- function or associated item `foo` not found for this
+   |        --- function or associated item `foo` not found for this struct
 ...
 LL |     Foo::foo();
    |          ^^^ function or associated item cannot be called on `Foo<{_: usize}>` due to unsatisfied trait bounds

--- a/src/test/ui/const-generics/generic_const_exprs/issue-80742.stderr
+++ b/src/test/ui/const-generics/generic_const_exprs/issue-80742.stderr
@@ -15,22 +15,16 @@ LL |     [u8; size_of::<T>() + 1]: ,
 error[E0599]: the function or associated item `new` exists for struct `Inline<dyn Debug>`, but its trait bounds were not satisfied
   --> $DIR/issue-80742.rs:30:36
    |
-LL | / struct Inline<T>
-LL | | where
-LL | |     [u8; size_of::<T>() + 1]: ,
-LL | | {
-LL | |     _phantom: PhantomData<T>,
-LL | |     buf: [u8; size_of::<T>() + 1],
-LL | | }
-   | |_- function or associated item `new` not found for this
+LL | struct Inline<T>
+   |        ------ function or associated item `new` not found for this struct
 ...
-LL |       let dst = Inline::<dyn Debug>::new(0);
-   |                                      ^^^ function or associated item cannot be called on `Inline<dyn Debug>` due to unsatisfied trait bounds
+LL |     let dst = Inline::<dyn Debug>::new(0);
+   |                                    ^^^ function or associated item cannot be called on `Inline<dyn Debug>` due to unsatisfied trait bounds
    |
   ::: $SRC_DIR/core/src/fmt/mod.rs:LL:COL
    |
-LL |   pub trait Debug {
-   |   --------------- doesn't satisfy `dyn Debug: Sized`
+LL | pub trait Debug {
+   | --------------- doesn't satisfy `dyn Debug: Sized`
    |
    = note: the following trait bounds were not satisfied:
            `dyn Debug: Sized`

--- a/src/test/ui/const-generics/invalid-const-arg-for-type-param.stderr
+++ b/src/test/ui/const-generics/invalid-const-arg-for-type-param.stderr
@@ -16,7 +16,7 @@ error[E0599]: no method named `f` found for struct `S` in the current scope
   --> $DIR/invalid-const-arg-for-type-param.rs:9:7
    |
 LL | struct S;
-   | --------- method `f` not found for this
+   |        - method `f` not found for this struct
 ...
 LL |     S.f::<0>();
    |       ^ method not found in `S`

--- a/src/test/ui/consts/const-needs_drop-monomorphic.stderr
+++ b/src/test/ui/consts/const-needs_drop-monomorphic.stderr
@@ -2,7 +2,7 @@ error[E0599]: no function or associated item named `assert` found for struct `Bo
   --> $DIR/const-needs_drop-monomorphic.rs:11:46
    |
 LL | struct Bool<const B: bool> {}
-   | -------------------------- function or associated item `assert` not found for this
+   |        ---- function or associated item `assert` not found for this struct
 ...
 LL |     Bool::<{ std::mem::needs_drop::<T>() }>::assert();
    |                                              ^^^^^^ function or associated item cannot be called on `Bool<{ std::mem::needs_drop::<T>() }>` due to unsatisfied trait bounds

--- a/src/test/ui/copy-a-resource.stderr
+++ b/src/test/ui/copy-a-resource.stderr
@@ -2,7 +2,7 @@ error[E0599]: no method named `clone` found for struct `Foo` in the current scop
   --> $DIR/copy-a-resource.rs:18:16
    |
 LL | struct Foo {
-   | ---------- method `clone` not found for this
+   |        --- method `clone` not found for this struct
 ...
 LL |     let _y = x.clone();
    |                ^^^^^ method not found in `Foo`

--- a/src/test/ui/custom_test_frameworks/mismatch.stderr
+++ b/src/test/ui/custom_test_frameworks/mismatch.stderr
@@ -6,7 +6,7 @@ LL | #[test]
 LL | fn wrong_kind(){}
    | ^^^^^^^^^^^^^^^^^ the trait `Testable` is not implemented for `TestDescAndFn`
    |
-   = note: required for the cast to the object type `dyn Testable`
+   = note: required for the cast from `TestDescAndFn` to the object type `dyn Testable`
    = note: this error originates in the attribute macro `test` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to previous error

--- a/src/test/ui/derives/derive-assoc-type-not-impl.stderr
+++ b/src/test/ui/derives/derive-assoc-type-not-impl.stderr
@@ -3,8 +3,8 @@ error[E0599]: the method `clone` exists for struct `Bar<NotClone>`, but its trai
    |
 LL | struct Bar<T: Foo> {
    | ------------------
-   | |
-   | method `clone` not found for this
+   | |      |
+   | |      method `clone` not found for this struct
    | doesn't satisfy `Bar<NotClone>: Clone`
 ...
 LL | struct NotClone;

--- a/src/test/ui/derives/issue-91492.stderr
+++ b/src/test/ui/derives/issue-91492.stderr
@@ -37,7 +37,7 @@ LL | pub struct NoDerives;
    | --------------------- doesn't satisfy `NoDerives: Clone`
 ...
 LL | struct Object<T, A>(T, A);
-   | -------------------------- method `use_clone` not found for this
+   |        ------ method `use_clone` not found for this struct
 ...
 LL |     foo.use_clone();
    |         ^^^^^^^^^ method cannot be called on `Object<NoDerives, SomeDerives>` due to unsatisfied trait bounds

--- a/src/test/ui/derives/issue-91550.stderr
+++ b/src/test/ui/derives/issue-91550.stderr
@@ -25,7 +25,7 @@ LL | pub struct NoDerives;
    | --------------------- doesn't satisfy `NoDerives: Eq`
 LL | 
 LL | struct Object<T>(T);
-   | -------------------- method `use_eq` not found for this
+   |        ------ method `use_eq` not found for this struct
 ...
 LL |     foo.use_eq();
    |         ^^^^^^ method cannot be called on `Object<NoDerives>` due to unsatisfied trait bounds
@@ -44,7 +44,7 @@ LL | pub struct NoDerives;
    | --------------------- doesn't satisfy `NoDerives: Ord`
 LL | 
 LL | struct Object<T>(T);
-   | -------------------- method `use_ord` not found for this
+   |        ------ method `use_ord` not found for this struct
 ...
 LL |     foo.use_ord();
    |         ^^^^^^^ method cannot be called on `Object<NoDerives>` due to unsatisfied trait bounds
@@ -66,7 +66,7 @@ LL | pub struct NoDerives;
    | doesn't satisfy `NoDerives: PartialOrd`
 LL | 
 LL | struct Object<T>(T);
-   | -------------------- method `use_ord_and_partial_ord` not found for this
+   |        ------ method `use_ord_and_partial_ord` not found for this struct
 ...
 LL |     foo.use_ord_and_partial_ord();
    |         ^^^^^^^^^^^^^^^^^^^^^^^ method cannot be called on `Object<NoDerives>` due to unsatisfied trait bounds

--- a/src/test/ui/did_you_mean/issue-40006.stderr
+++ b/src/test/ui/did_you_mean/issue-40006.stderr
@@ -88,7 +88,7 @@ error[E0599]: no method named `hello_method` found for struct `S` in the current
   --> $DIR/issue-40006.rs:38:7
    |
 LL | struct S;
-   | --------- method `hello_method` not found for this
+   |        - method `hello_method` not found for this struct
 ...
 LL |     S.hello_method();
    |       ^^^^^^^^^^^^ method not found in `S`

--- a/src/test/ui/dont-suggest-private-trait-method.stderr
+++ b/src/test/ui/dont-suggest-private-trait-method.stderr
@@ -2,7 +2,7 @@ error[E0599]: no function or associated item named `new` found for struct `T` in
   --> $DIR/dont-suggest-private-trait-method.rs:4:8
    |
 LL | struct T;
-   | --------- function or associated item `new` not found for this
+   |        - function or associated item `new` not found for this struct
 ...
 LL |     T::new();
    |        ^^^ function or associated item not found in `T`

--- a/src/test/ui/dst/dst-bad-coerce1.stderr
+++ b/src/test/ui/dst/dst-bad-coerce1.stderr
@@ -15,7 +15,7 @@ error[E0277]: the trait bound `Foo: Bar` is not satisfied
 LL |     let f3: &Fat<dyn Bar> = f2;
    |                             ^^ the trait `Bar` is not implemented for `Foo`
    |
-   = note: required for the cast to the object type `dyn Bar`
+   = note: required for the cast from `Foo` to the object type `dyn Bar`
 
 error[E0308]: mismatched types
   --> $DIR/dst-bad-coerce1.rs:28:27
@@ -34,7 +34,7 @@ error[E0277]: the trait bound `Foo: Bar` is not satisfied
 LL |     let f3: &(dyn Bar,) = f2;
    |                           ^^ the trait `Bar` is not implemented for `Foo`
    |
-   = note: required for the cast to the object type `dyn Bar`
+   = note: required for the cast from `Foo` to the object type `dyn Bar`
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/dst/dst-object-from-unsized-type.stderr
+++ b/src/test/ui/dst/dst-object-from-unsized-type.stderr
@@ -6,7 +6,7 @@ LL | fn test1<T: ?Sized + Foo>(t: &T) {
 LL |     let u: &dyn Foo = t;
    |                       ^ doesn't have a size known at compile-time
    |
-   = note: required for the cast to the object type `dyn Foo`
+   = note: required for the cast from `T` to the object type `dyn Foo`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - fn test1<T: ?Sized + Foo>(t: &T) {
@@ -21,7 +21,7 @@ LL | fn test2<T: ?Sized + Foo>(t: &T) {
 LL |     let v: &dyn Foo = t as &dyn Foo;
    |                       ^ doesn't have a size known at compile-time
    |
-   = note: required for the cast to the object type `dyn Foo`
+   = note: required for the cast from `T` to the object type `dyn Foo`
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
    |
 LL - fn test2<T: ?Sized + Foo>(t: &T) {
@@ -35,7 +35,7 @@ LL |     let _: &[&dyn Foo] = &["hi"];
    |                            ^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `str`
-   = note: required for the cast to the object type `dyn Foo`
+   = note: required for the cast from `str` to the object type `dyn Foo`
 
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
   --> $DIR/dst-object-from-unsized-type.rs:23:23
@@ -44,7 +44,7 @@ LL |     let _: &dyn Foo = x as &dyn Foo;
    |                       ^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-   = note: required for the cast to the object type `dyn Foo`
+   = note: required for the cast from `[u8]` to the object type `dyn Foo`
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/error-codes/E0599.stderr
+++ b/src/test/ui/error-codes/E0599.stderr
@@ -2,7 +2,7 @@ error[E0599]: no associated item named `NotEvenReal` found for struct `Foo` in t
   --> $DIR/E0599.rs:4:20
    |
 LL | struct Foo;
-   | ----------- associated item `NotEvenReal` not found for this
+   |        --- associated item `NotEvenReal` not found for this struct
 ...
 LL |     || if let Foo::NotEvenReal() = Foo {};
    |                    ^^^^^^^^^^^ associated item not found in `Foo`

--- a/src/test/ui/generic-associated-types/issue-79422.extended.stderr
+++ b/src/test/ui/generic-associated-types/issue-79422.extended.stderr
@@ -27,7 +27,7 @@ LL |     type VRefCont<'a> = &'a V where Self: 'a;
    |                         ^^^^^
    = note: expected trait object `(dyn RefCont<'_, u8> + 'static)`
                  found reference `&u8`
-   = note: required for the cast to the object type `dyn MapLike<u8, u8, VRefCont = (dyn RefCont<'_, u8> + 'static)>`
+   = note: required for the cast from `BTreeMap<u8, u8>` to the object type `dyn MapLike<u8, u8, VRefCont = (dyn RefCont<'_, u8> + 'static)>`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/generic-associated-types/method-unsatified-assoc-type-predicate.stderr
+++ b/src/test/ui/generic-associated-types/method-unsatified-assoc-type-predicate.stderr
@@ -3,8 +3,8 @@ error[E0599]: the method `f` exists for struct `S`, but its trait bounds were no
    |
 LL | struct S;
    | ---------
-   | |
-   | method `f` not found for this
+   | |      |
+   | |      method `f` not found for this struct
    | doesn't satisfy `<S as X>::Y<i32> = i32`
    | doesn't satisfy `S: M`
 ...

--- a/src/test/ui/hrtb/issue-30786.stderr
+++ b/src/test/ui/hrtb/issue-30786.stderr
@@ -3,8 +3,8 @@ error[E0599]: the method `filterx` exists for struct `Map<Repeat, [closure@$DIR/
    |
 LL | pub struct Map<S, F> {
    | --------------------
-   | |
-   | method `filterx` not found for this
+   | |          |
+   | |          method `filterx` not found for this struct
    | doesn't satisfy `_: StreamExt`
 ...
 LL |     let filter = map.filterx(|x: &_| true);
@@ -28,8 +28,8 @@ error[E0599]: the method `countx` exists for struct `Filter<Map<Repeat, for<'r> 
    |
 LL | pub struct Filter<S, F> {
    | -----------------------
-   | |
-   | method `countx` not found for this
+   | |          |
+   | |          method `countx` not found for this struct
    | doesn't satisfy `_: StreamExt`
 ...
 LL |     let count = filter.countx();

--- a/src/test/ui/impl-trait/issues/issue-21659-show-relevant-trait-impls-3.stderr
+++ b/src/test/ui/impl-trait/issues/issue-21659-show-relevant-trait-impls-3.stderr
@@ -2,7 +2,7 @@ error[E0599]: no method named `foo` found for struct `Bar` in the current scope
   --> $DIR/issue-21659-show-relevant-trait-impls-3.rs:20:8
    |
 LL | struct Bar;
-   | ----------- method `foo` not found for this
+   |        --- method `foo` not found for this struct
 ...
 LL |     f1.foo(1usize);
    |        ^^^ method not found in `Bar`

--- a/src/test/ui/impl-trait/issues/issue-62742.stderr
+++ b/src/test/ui/impl-trait/issues/issue-62742.stderr
@@ -21,7 +21,7 @@ LL | pub struct RawImpl<T>(PhantomData<T>);
    | -------------------------------------- doesn't satisfy `RawImpl<()>: Raw<()>`
 ...
 LL | pub struct SafeImpl<T: ?Sized, A: Raw<T>>(PhantomData<(A, T)>);
-   | --------------------------------------------------------------- function or associated item `foo` not found for this
+   |            -------- function or associated item `foo` not found for this struct
    |
    = note: the following trait bounds were not satisfied:
            `RawImpl<()>: Raw<()>`

--- a/src/test/ui/impl-trait/method-suggestion-no-duplication.stderr
+++ b/src/test/ui/impl-trait/method-suggestion-no-duplication.stderr
@@ -2,7 +2,7 @@ error[E0599]: no method named `is_empty` found for struct `Foo` in the current s
   --> $DIR/method-suggestion-no-duplication.rs:7:15
    |
 LL | struct Foo;
-   | ----------- method `is_empty` not found for this
+   |        --- method `is_empty` not found for this struct
 ...
 LL |     foo(|s| s.is_empty());
    |               ^^^^^^^^ method not found in `Foo`

--- a/src/test/ui/impl-trait/no-method-suggested-traits.stderr
+++ b/src/test/ui/impl-trait/no-method-suggested-traits.stderr
@@ -94,7 +94,7 @@ error[E0599]: no method named `method` found for struct `Foo` in the current sco
   --> $DIR/no-method-suggested-traits.rs:40:9
    |
 LL | struct Foo;
-   | ----------- method `method` not found for this
+   |        --- method `method` not found for this struct
 ...
 LL |     Foo.method();
    |         ^^^^^^ method not found in `Foo`
@@ -201,7 +201,7 @@ error[E0599]: no method named `method3` found for struct `Foo` in the current sc
   --> $DIR/no-method-suggested-traits.rs:59:9
    |
 LL | struct Foo;
-   | ----------- method `method3` not found for this
+   |        --- method `method3` not found for this struct
 ...
 LL |     Foo.method3();
    |         ^^^^^^^ method not found in `Foo`
@@ -224,7 +224,7 @@ error[E0599]: no method named `method3` found for enum `Bar` in the current scop
   --> $DIR/no-method-suggested-traits.rs:63:12
    |
 LL | enum Bar { X }
-   | -------- method `method3` not found for this
+   |      --- method `method3` not found for this enum
 ...
 LL |     Bar::X.method3();
    |            ^^^^^^^ method not found in `Bar`

--- a/src/test/ui/infinite/infinite-autoderef.stderr
+++ b/src/test/ui/infinite/infinite-autoderef.stderr
@@ -43,7 +43,7 @@ error[E0599]: no method named `bar` found for struct `Foo` in the current scope
   --> $DIR/infinite-autoderef.rs:25:9
    |
 LL | struct Foo;
-   | ----------- method `bar` not found for this
+   |        --- method `bar` not found for this struct
 ...
 LL |     Foo.bar();
    |         ^^^ method not found in `Foo`

--- a/src/test/ui/issues/issue-14366.stderr
+++ b/src/test/ui/issues/issue-14366.stderr
@@ -5,7 +5,7 @@ LL |     let _x = "test" as &dyn (::std::any::Any);
    |              ^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `str`
-   = note: required for the cast to the object type `dyn Any`
+   = note: required for the cast from `str` to the object type `dyn Any`
 help: consider borrowing the value, since `&str` can be coerced into `dyn Any`
    |
 LL |     let _x = &"test" as &dyn (::std::any::Any);

--- a/src/test/ui/issues/issue-19692.stderr
+++ b/src/test/ui/issues/issue-19692.stderr
@@ -2,7 +2,7 @@ error[E0599]: no method named `kaname` found for struct `Homura` in the current 
   --> $DIR/issue-19692.rs:4:40
    |
 LL | struct Homura;
-   | -------------- method `kaname` not found for this
+   |        ------ method `kaname` not found for this struct
 ...
 LL |     let Some(ref madoka) = Some(homura.kaname());
    |                                        ^^^^^^ method not found in `Homura`

--- a/src/test/ui/issues/issue-22034.stderr
+++ b/src/test/ui/issues/issue-22034.stderr
@@ -6,7 +6,7 @@ LL |         &mut *(ptr as *mut dyn Fn())
    |
    = help: the trait `Fn<()>` is not implemented for `()`
    = note: wrap the `()` in a closure with no arguments: `|| { /* code */ }`
-   = note: required for the cast to the object type `dyn Fn()`
+   = note: required for the cast from `()` to the object type `dyn Fn()`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-22872.stderr
+++ b/src/test/ui/issues/issue-22872.stderr
@@ -10,7 +10,7 @@ note: required because of the requirements on the impl of `for<'b> Wrap<'b>` for
    |
 LL | impl<'b, P> Wrap<'b> for Wrapper<P>
    |             ^^^^^^^^     ^^^^^^^^^^
-   = note: required for the cast to the object type `dyn for<'b> Wrap<'b>`
+   = note: required for the cast from `Wrapper<P>` to the object type `dyn for<'b> Wrap<'b>`
 help: consider further restricting the associated type
    |
 LL | fn push_process<P>(process: P) where P: Process<'static>, <P as Process<'_>>::Item: Iterator {

--- a/src/test/ui/issues/issue-22933-2.stderr
+++ b/src/test/ui/issues/issue-22933-2.stderr
@@ -2,7 +2,7 @@ error[E0599]: no variant or associated item named `PIE` found for enum `Deliciou
   --> $DIR/issue-22933-2.rs:4:55
    |
 LL | enum Delicious {
-   | -------------- variant or associated item `PIE` not found here
+   |      --------- variant or associated item `PIE` not found for this enum
 ...
 LL |     ApplePie = Delicious::Apple as isize | Delicious::PIE as isize,
    |                                                       ^^^

--- a/src/test/ui/issues/issue-23173.stderr
+++ b/src/test/ui/issues/issue-23173.stderr
@@ -2,7 +2,7 @@ error[E0599]: no variant or associated item named `Homura` found for enum `Token
   --> $DIR/issue-23173.rs:9:23
    |
 LL | enum Token { LeftParen, RightParen, Plus, Minus, /* etc */ }
-   | ---------- variant or associated item `Homura` not found here
+   |      ----- variant or associated item `Homura` not found for this enum
 ...
 LL |     use_token(&Token::Homura);
    |                       ^^^^^^ variant or associated item not found in `Token`
@@ -11,7 +11,7 @@ error[E0599]: no function or associated item named `method` found for struct `St
   --> $DIR/issue-23173.rs:10:13
    |
 LL | struct Struct {
-   | ------------- function or associated item `method` not found for this
+   |        ------ function or associated item `method` not found for this struct
 ...
 LL |     Struct::method();
    |             ^^^^^^ function or associated item not found in `Struct`
@@ -20,7 +20,7 @@ error[E0599]: no function or associated item named `method` found for struct `St
   --> $DIR/issue-23173.rs:11:13
    |
 LL | struct Struct {
-   | ------------- function or associated item `method` not found for this
+   |        ------ function or associated item `method` not found for this struct
 ...
 LL |     Struct::method;
    |             ^^^^^^ function or associated item not found in `Struct`
@@ -29,7 +29,7 @@ error[E0599]: no associated item named `Assoc` found for struct `Struct` in the 
   --> $DIR/issue-23173.rs:12:13
    |
 LL | struct Struct {
-   | ------------- associated item `Assoc` not found for this
+   |        ------ associated item `Assoc` not found for this struct
 ...
 LL |     Struct::Assoc;
    |             ^^^^^ associated item not found in `Struct`

--- a/src/test/ui/issues/issue-23217.stderr
+++ b/src/test/ui/issues/issue-23217.stderr
@@ -2,7 +2,7 @@ error[E0599]: no variant or associated item named `A` found for enum `SomeEnum` 
   --> $DIR/issue-23217.rs:2:19
    |
 LL | pub enum SomeEnum {
-   | ----------------- variant or associated item `A` not found here
+   |          -------- variant or associated item `A` not found for this enum
 LL |     B = SomeEnum::A,
    |                   ^
    |                   |

--- a/src/test/ui/issues/issue-2823.stderr
+++ b/src/test/ui/issues/issue-2823.stderr
@@ -2,7 +2,7 @@ error[E0599]: no method named `clone` found for struct `C` in the current scope
   --> $DIR/issue-2823.rs:13:16
    |
 LL | struct C {
-   | -------- method `clone` not found for this
+   |        - method `clone` not found for this struct
 ...
 LL |     let _d = c.clone();
    |                ^^^^^ method not found in `C`

--- a/src/test/ui/issues/issue-28971.stderr
+++ b/src/test/ui/issues/issue-28971.stderr
@@ -2,7 +2,7 @@ error[E0599]: no variant or associated item named `Baz` found for enum `Foo` in 
   --> $DIR/issue-28971.rs:7:18
    |
 LL | enum Foo {
-   | -------- variant or associated item `Baz` not found here
+   |      --- variant or associated item `Baz` not found for this enum
 ...
 LL |             Foo::Baz(..) => (),
    |                  ^^^

--- a/src/test/ui/issues/issue-38919.stderr
+++ b/src/test/ui/issues/issue-38919.stderr
@@ -1,6 +1,8 @@
 error[E0599]: no associated item named `Item` found for type parameter `T` in the current scope
   --> $DIR/issue-38919.rs:2:8
    |
+LL | fn foo<T: Iterator>() {
+   |        - associated item `Item` not found for this type parameter
 LL |     T::Item;
    |        ^^^^ associated item not found in `T`
 

--- a/src/test/ui/issues/issue-41880.stderr
+++ b/src/test/ui/issues/issue-41880.stderr
@@ -2,7 +2,7 @@ error[E0599]: no method named `iter` found for struct `Iterate` in the current s
   --> $DIR/issue-41880.rs:27:24
    |
 LL | pub struct Iterate<T, F> {
-   | ------------------------ method `iter` not found for this
+   |            ------- method `iter` not found for this struct
 ...
 LL |     println!("{:?}", a.iter().take(10).collect::<Vec<usize>>());
    |                        ^^^^ method not found in `Iterate<{integer}, [closure@$DIR/issue-41880.rs:26:24: 26:31]>`

--- a/src/test/ui/issues/issue-64430.stderr
+++ b/src/test/ui/issues/issue-64430.stderr
@@ -2,7 +2,7 @@ error[E0599]: no method named `bar` found for struct `Foo` in the current scope
   --> $DIR/issue-64430.rs:7:9
    |
 LL | pub struct Foo;
-   | --------------- method `bar` not found for this
+   |            --- method `bar` not found for this struct
 ...
 LL |     Foo.bar()
    |         ^^^ method not found in `Foo`

--- a/src/test/ui/issues/issue-7013.stderr
+++ b/src/test/ui/issues/issue-7013.stderr
@@ -11,7 +11,7 @@ note: required because it appears within the type `B`
    |
 LL | struct B {
    |        ^
-   = note: required for the cast to the object type `dyn Foo + Send`
+   = note: required for the cast from `B` to the object type `dyn Foo + Send`
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-7950.stderr
+++ b/src/test/ui/issues/issue-7950.stderr
@@ -2,7 +2,7 @@ error[E0599]: no function or associated item named `bar` found for struct `Foo` 
   --> $DIR/issue-7950.rs:6:10
    |
 LL | struct Foo;
-   | ----------- function or associated item `bar` not found for this
+   |        --- function or associated item `bar` not found for this struct
 ...
 LL |     Foo::bar();
    |          ^^^ function or associated item not found in `Foo`

--- a/src/test/ui/kindck/kindck-impl-type-params.stderr
+++ b/src/test/ui/kindck/kindck-impl-type-params.stderr
@@ -9,7 +9,7 @@ note: required because of the requirements on the impl of `Gettable<T>` for `S<T
    |
 LL | impl<T: Send + Copy + 'static> Gettable<T> for S<T> {}
    |                                ^^^^^^^^^^^     ^^^^
-   = note: required for the cast to the object type `dyn Gettable<T>`
+   = note: required for the cast from `S<T>` to the object type `dyn Gettable<T>`
 help: consider restricting type parameter `T`
    |
 LL | fn f<T: std::marker::Send>(val: T) {
@@ -26,7 +26,7 @@ note: required because of the requirements on the impl of `Gettable<T>` for `S<T
    |
 LL | impl<T: Send + Copy + 'static> Gettable<T> for S<T> {}
    |                                ^^^^^^^^^^^     ^^^^
-   = note: required for the cast to the object type `dyn Gettable<T>`
+   = note: required for the cast from `S<T>` to the object type `dyn Gettable<T>`
 help: consider restricting type parameter `T`
    |
 LL | fn f<T: std::marker::Copy>(val: T) {
@@ -43,7 +43,7 @@ note: required because of the requirements on the impl of `Gettable<T>` for `S<T
    |
 LL | impl<T: Send + Copy + 'static> Gettable<T> for S<T> {}
    |                                ^^^^^^^^^^^     ^^^^
-   = note: required for the cast to the object type `dyn Gettable<T>`
+   = note: required for the cast from `S<T>` to the object type `dyn Gettable<T>`
 help: consider restricting type parameter `T`
    |
 LL | fn g<T: std::marker::Send>(val: T) {
@@ -60,7 +60,7 @@ note: required because of the requirements on the impl of `Gettable<T>` for `S<T
    |
 LL | impl<T: Send + Copy + 'static> Gettable<T> for S<T> {}
    |                                ^^^^^^^^^^^     ^^^^
-   = note: required for the cast to the object type `dyn Gettable<T>`
+   = note: required for the cast from `S<T>` to the object type `dyn Gettable<T>`
 help: consider restricting type parameter `T`
    |
 LL | fn g<T: std::marker::Copy>(val: T) {
@@ -78,7 +78,7 @@ note: required because of the requirements on the impl of `Gettable<String>` for
    |
 LL | impl<T: Send + Copy + 'static> Gettable<T> for S<T> {}
    |                                ^^^^^^^^^^^     ^^^^
-   = note: required for the cast to the object type `dyn Gettable<String>`
+   = note: required for the cast from `S<String>` to the object type `dyn Gettable<String>`
 
 error[E0277]: the trait bound `Foo: Copy` is not satisfied
   --> $DIR/kindck-impl-type-params.rs:43:37
@@ -92,7 +92,7 @@ note: required because of the requirements on the impl of `Gettable<Foo>` for `S
    |
 LL | impl<T: Send + Copy + 'static> Gettable<T> for S<T> {}
    |                                ^^^^^^^^^^^     ^^^^
-   = note: required for the cast to the object type `dyn Gettable<Foo>`
+   = note: required for the cast from `S<Foo>` to the object type `dyn Gettable<Foo>`
 help: consider annotating `Foo` with `#[derive(Copy)]`
    |
 LL |     #[derive(Copy)]

--- a/src/test/ui/lexical-scopes.stderr
+++ b/src/test/ui/lexical-scopes.stderr
@@ -7,6 +7,8 @@ LL |     let t = T { i: 0 };
 error[E0599]: no function or associated item named `f` found for type parameter `Foo` in the current scope
   --> $DIR/lexical-scopes.rs:10:10
    |
+LL | fn g<Foo>() {
+   |      --- function or associated item `f` not found for this type parameter
 LL |     Foo::f();
    |          ^ function or associated item not found in `Foo`
 

--- a/src/test/ui/methods/method-call-err-msg.stderr
+++ b/src/test/ui/methods/method-call-err-msg.stderr
@@ -51,8 +51,8 @@ error[E0599]: `Foo` is not an iterator
    |
 LL | pub struct Foo;
    | ---------------
-   | |
-   | method `take` not found for this
+   | |          |
+   | |          method `take` not found for this struct
    | doesn't satisfy `Foo: Iterator`
 ...
 LL |      .take()

--- a/src/test/ui/methods/method-not-found-generic-arg-elision.stderr
+++ b/src/test/ui/methods/method-not-found-generic-arg-elision.stderr
@@ -2,7 +2,7 @@ error[E0599]: no method named `distance` found for struct `Point<i32>` in the cu
   --> $DIR/method-not-found-generic-arg-elision.rs:82:23
    |
 LL | struct Point<T> {
-   | --------------- method `distance` not found for this
+   |        ----- method `distance` not found for this struct
 ...
 LL |     let d = point_i32.distance();
    |                       ^^^^^^^^ method not found in `Point<i32>`
@@ -14,7 +14,7 @@ error[E0599]: no method named `other` found for struct `Point` in the current sc
   --> $DIR/method-not-found-generic-arg-elision.rs:84:23
    |
 LL | struct Point<T> {
-   | --------------- method `other` not found for this
+   |        ----- method `other` not found for this struct
 ...
 LL |     let d = point_i32.other();
    |                       ^^^^^ method not found in `Point<i32>`
@@ -29,7 +29,7 @@ error[E0599]: no method named `method` found for struct `Wrapper<bool>` in the c
   --> $DIR/method-not-found-generic-arg-elision.rs:90:13
    |
 LL | struct Wrapper<T>(T);
-   | --------------------- method `method` not found for this
+   |        ------- method `method` not found for this struct
 ...
 LL |     wrapper.method();
    |             ^^^^^^ method not found in `Wrapper<bool>`
@@ -45,7 +45,7 @@ error[E0599]: no method named `other` found for struct `Wrapper` in the current 
   --> $DIR/method-not-found-generic-arg-elision.rs:92:13
    |
 LL | struct Wrapper<T>(T);
-   | --------------------- method `other` not found for this
+   |        ------- method `other` not found for this struct
 ...
 LL |     wrapper.other();
    |             ^^^^^ method not found in `Wrapper<bool>`
@@ -54,7 +54,7 @@ error[E0599]: no method named `method` found for struct `Wrapper2<'_, bool, 3_us
   --> $DIR/method-not-found-generic-arg-elision.rs:96:13
    |
 LL | struct Wrapper2<'a, T, const C: usize> {
-   | -------------------------------------- method `method` not found for this
+   |        -------- method `method` not found for this struct
 ...
 LL |     wrapper.method();
    |             ^^^^^^ method not found in `Wrapper2<'_, bool, 3_usize>`
@@ -68,7 +68,7 @@ error[E0599]: no method named `other` found for struct `Wrapper2` in the current
   --> $DIR/method-not-found-generic-arg-elision.rs:98:13
    |
 LL | struct Wrapper2<'a, T, const C: usize> {
-   | -------------------------------------- method `other` not found for this
+   |        -------- method `other` not found for this struct
 ...
 LL |     wrapper.other();
    |             ^^^^^ method not found in `Wrapper2<'_, bool, 3_usize>`
@@ -83,7 +83,7 @@ error[E0599]: the method `method` exists for struct `Struct<f64>`, but its trait
   --> $DIR/method-not-found-generic-arg-elision.rs:104:7
    |
 LL | struct Struct<T>{
-   | ---------------- method `method` not found for this
+   |        ------ method `method` not found for this struct
 ...
 LL |     s.method();
    |       ^^^^^^ method cannot be called on `Struct<f64>` due to unsatisfied trait bounds

--- a/src/test/ui/mismatched_types/cast-rfc0401.stderr
+++ b/src/test/ui/mismatched_types/cast-rfc0401.stderr
@@ -220,7 +220,7 @@ LL |     let _ = fat_v as *const dyn Foo;
    |             ^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[u8]`
-   = note: required for the cast to the object type `dyn Foo`
+   = note: required for the cast from `[u8]` to the object type `dyn Foo`
 help: consider borrowing the value, since `&[u8]` can be coerced into `dyn Foo`
    |
 LL |     let _ = &fat_v as *const dyn Foo;
@@ -233,7 +233,7 @@ LL |     let _ = a as *const dyn Foo;
    |             ^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `str`
-   = note: required for the cast to the object type `dyn Foo`
+   = note: required for the cast from `str` to the object type `dyn Foo`
 help: consider borrowing the value, since `&str` can be coerced into `dyn Foo`
    |
 LL |     let _ = &a as *const dyn Foo;

--- a/src/test/ui/mismatched_types/ref-pat-suggestions.fixed
+++ b/src/test/ui/mismatched_types/ref-pat-suggestions.fixed
@@ -21,4 +21,17 @@ fn main() {
     let _ = |&mut _a: &mut u32| (); //~ ERROR mismatched types
     let _ = |&_a: &u32| (); //~ ERROR mismatched types
     let _ = |&mut _a: &mut u32| (); //~ ERROR mismatched types
+
+    #[allow(unused_mut)]
+    {
+        struct S(u8);
+
+        let mut _a = 0; //~ ERROR mismatched types
+        let S(_b) = S(0); //~ ERROR mismatched types
+        let (_c,) = (0,); //~ ERROR mismatched types
+
+        match 0 {
+            _d => {} //~ ERROR mismatched types
+        }
+    }
 }

--- a/src/test/ui/mismatched_types/ref-pat-suggestions.rs
+++ b/src/test/ui/mismatched_types/ref-pat-suggestions.rs
@@ -21,4 +21,17 @@ fn main() {
     let _ = |&mut &_a: &mut u32| (); //~ ERROR mismatched types
     let _ = |&&mut _a: &u32| (); //~ ERROR mismatched types
     let _ = |&mut &mut _a: &mut u32| (); //~ ERROR mismatched types
+
+    #[allow(unused_mut)]
+    {
+        struct S(u8);
+
+        let &mut _a = 0; //~ ERROR mismatched types
+        let S(&mut _b) = S(0); //~ ERROR mismatched types
+        let (&mut _c,) = (0,); //~ ERROR mismatched types
+
+        match 0 {
+            &mut _d => {} //~ ERROR mismatched types
+        }
+    }
 }

--- a/src/test/ui/mismatched_types/ref-pat-suggestions.stderr
+++ b/src/test/ui/mismatched_types/ref-pat-suggestions.stderr
@@ -24,7 +24,7 @@ LL | fn _f1(&mut _a: u32) {}
    |
    = note:           expected type `u32`
            found mutable reference `&mut _`
-note: to declare a mutable parameter use `mut variable_name`: `mut _a`
+note: to declare a mutable parameter use: `mut _a`
   --> $DIR/ref-pat-suggestions.rs:4:8
    |
 LL | fn _f1(&mut _a: u32) {}
@@ -127,7 +127,7 @@ LL |     let _: fn(u32) = |&mut _a| ();
    |
    = note:           expected type `u32`
            found mutable reference `&mut _`
-note: to declare a mutable parameter use `mut variable_name`: `mut _a`
+note: to declare a mutable parameter use: `mut _a`
   --> $DIR/ref-pat-suggestions.rs:12:23
    |
 LL |     let _: fn(u32) = |&mut _a| ();
@@ -232,7 +232,7 @@ LL |     let _ = |&mut _a: u32| ();
    |
    = note:           expected type `u32`
            found mutable reference `&mut _`
-note: to declare a mutable parameter use `mut variable_name`: `mut _a`
+note: to declare a mutable parameter use: `mut _a`
   --> $DIR/ref-pat-suggestions.rs:19:14
    |
 LL |     let _ = |&mut _a: u32| ();
@@ -314,7 +314,7 @@ LL |         let &mut _a = 0;
    |             ^^^^^^^   - this expression has type `{integer}`
    |             |
    |             expected integer, found `&mut _`
-   |             help: to declare a mutable variable use `mut variable_name`: `mut _a`
+   |             help: to declare a mutable variable use: `mut _a`
    |
    = note:           expected type `{integer}`
            found mutable reference `&mut _`
@@ -329,7 +329,7 @@ LL |         let S(&mut _b) = S(0);
    |
    = note:           expected type `u8`
            found mutable reference `&mut _`
-note: to declare a mutable binding use `mut variable_name`: `mut _b`
+note: to declare a mutable binding use: `mut _b`
   --> $DIR/ref-pat-suggestions.rs:30:15
    |
 LL |         let S(&mut _b) = S(0);
@@ -350,7 +350,7 @@ LL |         let (&mut _c,) = (0,);
    |
    = note:           expected type `{integer}`
            found mutable reference `&mut _`
-note: to declare a mutable binding use `mut variable_name`: `mut _c`
+note: to declare a mutable binding use: `mut _c`
   --> $DIR/ref-pat-suggestions.rs:31:14
    |
 LL |         let (&mut _c,) = (0,);
@@ -371,7 +371,7 @@ LL |             &mut _d => {}
    |
    = note:           expected type `{integer}`
            found mutable reference `&mut _`
-note: to declare a mutable binding use `mut variable_name`: `mut _d`
+note: to declare a mutable binding use: `mut _d`
   --> $DIR/ref-pat-suggestions.rs:34:13
    |
 LL |             &mut _d => {}

--- a/src/test/ui/mismatched_types/ref-pat-suggestions.stderr
+++ b/src/test/ui/mismatched_types/ref-pat-suggestions.stderr
@@ -24,6 +24,11 @@ LL | fn _f1(&mut _a: u32) {}
    |
    = note:           expected type `u32`
            found mutable reference `&mut _`
+note: to declare a mutable parameter use `mut variable_name`: `mut _a`
+  --> $DIR/ref-pat-suggestions.rs:4:8
+   |
+LL | fn _f1(&mut _a: u32) {}
+   |        ^^^^^^^
 help: to take parameter `_a` by reference, move `&mut` to the type
    |
 LL - fn _f1(&mut _a: u32) {}
@@ -122,6 +127,11 @@ LL |     let _: fn(u32) = |&mut _a| ();
    |
    = note:           expected type `u32`
            found mutable reference `&mut _`
+note: to declare a mutable parameter use `mut variable_name`: `mut _a`
+  --> $DIR/ref-pat-suggestions.rs:12:23
+   |
+LL |     let _: fn(u32) = |&mut _a| ();
+   |                       ^^^^^^^
 help: consider removing `&mut` from the pattern
    |
 LL -     let _: fn(u32) = |&mut _a| ();
@@ -222,6 +232,11 @@ LL |     let _ = |&mut _a: u32| ();
    |
    = note:           expected type `u32`
            found mutable reference `&mut _`
+note: to declare a mutable parameter use `mut variable_name`: `mut _a`
+  --> $DIR/ref-pat-suggestions.rs:19:14
+   |
+LL |     let _ = |&mut _a: u32| ();
+   |              ^^^^^^^
 help: to take parameter `_a` by reference, move `&mut` to the type
    |
 LL -     let _ = |&mut _a: u32| ();
@@ -292,6 +307,81 @@ LL -     let _ = |&mut &mut _a: &mut u32| ();
 LL +     let _ = |&mut _a: &mut u32| ();
    |
 
-error: aborting due to 18 previous errors
+error[E0308]: mismatched types
+  --> $DIR/ref-pat-suggestions.rs:29:13
+   |
+LL |         let &mut _a = 0;
+   |             ^^^^^^^   - this expression has type `{integer}`
+   |             |
+   |             expected integer, found `&mut _`
+   |             help: to declare a mutable variable use `mut variable_name`: `mut _a`
+   |
+   = note:           expected type `{integer}`
+           found mutable reference `&mut _`
+
+error[E0308]: mismatched types
+  --> $DIR/ref-pat-suggestions.rs:30:15
+   |
+LL |         let S(&mut _b) = S(0);
+   |               ^^^^^^^    ---- this expression has type `S`
+   |               |
+   |               expected `u8`, found `&mut _`
+   |
+   = note:           expected type `u8`
+           found mutable reference `&mut _`
+note: to declare a mutable binding use `mut variable_name`: `mut _b`
+  --> $DIR/ref-pat-suggestions.rs:30:15
+   |
+LL |         let S(&mut _b) = S(0);
+   |               ^^^^^^^
+help: consider removing `&mut` from the pattern
+   |
+LL -         let S(&mut _b) = S(0);
+LL +         let S(_b) = S(0);
+   |
+
+error[E0308]: mismatched types
+  --> $DIR/ref-pat-suggestions.rs:31:14
+   |
+LL |         let (&mut _c,) = (0,);
+   |              ^^^^^^^     ---- this expression has type `({integer},)`
+   |              |
+   |              expected integer, found `&mut _`
+   |
+   = note:           expected type `{integer}`
+           found mutable reference `&mut _`
+note: to declare a mutable binding use `mut variable_name`: `mut _c`
+  --> $DIR/ref-pat-suggestions.rs:31:14
+   |
+LL |         let (&mut _c,) = (0,);
+   |              ^^^^^^^
+help: consider removing `&mut` from the pattern
+   |
+LL -         let (&mut _c,) = (0,);
+LL +         let (_c,) = (0,);
+   |
+
+error[E0308]: mismatched types
+  --> $DIR/ref-pat-suggestions.rs:34:13
+   |
+LL |         match 0 {
+   |               - this expression has type `{integer}`
+LL |             &mut _d => {}
+   |             ^^^^^^^ expected integer, found `&mut _`
+   |
+   = note:           expected type `{integer}`
+           found mutable reference `&mut _`
+note: to declare a mutable binding use `mut variable_name`: `mut _d`
+  --> $DIR/ref-pat-suggestions.rs:34:13
+   |
+LL |             &mut _d => {}
+   |             ^^^^^^^
+help: consider removing `&mut` from the pattern
+   |
+LL -             &mut _d => {}
+LL +             _d => {}
+   |
+
+error: aborting due to 22 previous errors
 
 For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/never_type/fallback-closure-wrap.fallback.stderr
+++ b/src/test/ui/never_type/fallback-closure-wrap.fallback.stderr
@@ -10,7 +10,7 @@ LL | |     }) as Box<dyn FnMut()>);
    |
    = note: expected unit type `()`
                    found type `!`
-   = note: required for the cast to the object type `dyn FnMut()`
+   = note: required for the cast from `[closure@$DIR/fallback-closure-wrap.rs:18:40: 21:6]` to the object type `dyn FnMut()`
 
 error: aborting due to previous error
 

--- a/src/test/ui/noncopyable-class.stderr
+++ b/src/test/ui/noncopyable-class.stderr
@@ -2,7 +2,7 @@ error[E0599]: no method named `clone` found for struct `Foo` in the current scop
   --> $DIR/noncopyable-class.rs:34:16
    |
 LL | struct Foo {
-   | ---------- method `clone` not found for this
+   |        --- method `clone` not found for this struct
 ...
 LL |     let _y = x.clone();
    |                ^^^^^ method not found in `Foo`

--- a/src/test/ui/parser/emoji-identifiers.stderr
+++ b/src/test/ui/parser/emoji-identifiers.stderr
@@ -77,7 +77,7 @@ error[E0599]: no function or associated item named `full_of✨` found for struct
   --> $DIR/emoji-identifiers.rs:9:8
    |
 LL | struct 👀;
-   | ---------- function or associated item `full_of✨` not found for this
+   |        -- function or associated item `full_of✨` not found for this struct
 ...
 LL |     👀::full_of✨()
    |         ^^^^^^^^^

--- a/src/test/ui/pattern/for-loop-bad-item.stderr
+++ b/src/test/ui/pattern/for-loop-bad-item.stderr
@@ -8,6 +8,11 @@ LL |     for ((_, _), (&mut c, _)) in &mut map {
    |
    = note:           expected type `char`
            found mutable reference `&mut _`
+note: to declare a mutable binding use `mut variable_name`: `mut c`
+  --> $DIR/for-loop-bad-item.rs:7:19
+   |
+LL |     for ((_, _), (&mut c, _)) in &mut map {
+   |                   ^^^^^^
 help: consider removing `&mut` from the pattern
    |
 LL -     for ((_, _), (&mut c, _)) in &mut map {

--- a/src/test/ui/pattern/for-loop-bad-item.stderr
+++ b/src/test/ui/pattern/for-loop-bad-item.stderr
@@ -8,7 +8,7 @@ LL |     for ((_, _), (&mut c, _)) in &mut map {
    |
    = note:           expected type `char`
            found mutable reference `&mut _`
-note: to declare a mutable binding use `mut variable_name`: `mut c`
+note: to declare a mutable binding use: `mut c`
   --> $DIR/for-loop-bad-item.rs:7:19
    |
 LL |     for ((_, _), (&mut c, _)) in &mut map {

--- a/src/test/ui/rust-2018/uniform-paths/issue-87932.stderr
+++ b/src/test/ui/rust-2018/uniform-paths/issue-87932.stderr
@@ -2,7 +2,7 @@ error[E0599]: no function or associated item named `deserialize` found for struc
   --> $DIR/issue-87932.rs:13:8
    |
 LL | pub struct A {}
-   | ------------ function or associated item `deserialize` not found for this
+   |            - function or associated item `deserialize` not found for this struct
 ...
 LL |     A::deserialize();
    |        ^^^^^^^^^^^ function or associated item not found in `A`

--- a/src/test/ui/self/point-at-arbitrary-self-type-method.stderr
+++ b/src/test/ui/self/point-at-arbitrary-self-type-method.stderr
@@ -2,7 +2,7 @@ error[E0599]: no method named `foo` found for struct `A` in the current scope
   --> $DIR/point-at-arbitrary-self-type-method.rs:8:7
    |
 LL | struct A;
-   | --------- method `foo` not found for this
+   |        - method `foo` not found for this struct
 ...
 LL |     fn foo(self: Box<Self>) {}
    |        --- the method is available for `Box<A>` here

--- a/src/test/ui/self/point-at-arbitrary-self-type-trait-method.stderr
+++ b/src/test/ui/self/point-at-arbitrary-self-type-trait-method.stderr
@@ -6,7 +6,7 @@ LL | trait B { fn foo(self: Box<Self>); }
    |              |
    |              the method is available for `Box<A>` here
 LL | struct A;
-   | --------- method `foo` not found for this
+   |        - method `foo` not found for this struct
 ...
 LL |     A.foo()
    |       ^^^ method not found in `A`

--- a/src/test/ui/span/issue-7575.stderr
+++ b/src/test/ui/span/issue-7575.stderr
@@ -42,7 +42,7 @@ error[E0599]: no method named `fff` found for struct `Myisize` in the current sc
   --> $DIR/issue-7575.rs:62:30
    |
 LL | struct Myisize(isize);
-   | ---------------------- method `fff` not found for this
+   |        ------- method `fff` not found for this struct
 ...
 LL |     u.f8(42) + u.f9(342) + m.fff(42)
    |                            --^^^
@@ -60,6 +60,8 @@ LL |     fn fff(i: isize) -> isize {
 error[E0599]: no method named `is_str` found for type parameter `T` in the current scope
   --> $DIR/issue-7575.rs:70:7
    |
+LL | fn param_bound<T: ManyImplTrait>(t: T) -> bool {
+   |                - method `is_str` not found for this type parameter
 LL |     t.is_str()
    |       ^^^^^^ this is an associated function, not a method
    |

--- a/src/test/ui/specialization/defaultimpl/specialization-trait-not-implemented.stderr
+++ b/src/test/ui/specialization/defaultimpl/specialization-trait-not-implemented.stderr
@@ -13,8 +13,8 @@ error[E0599]: the method `foo_one` exists for struct `MyStruct`, but its trait b
    |
 LL | struct MyStruct;
    | ----------------
-   | |
-   | method `foo_one` not found for this
+   | |      |
+   | |      method `foo_one` not found for this struct
    | doesn't satisfy `MyStruct: Foo`
 ...
 LL |     println!("{}", MyStruct.foo_one());

--- a/src/test/ui/suggestions/derive-macro-missing-bounds.stderr
+++ b/src/test/ui/suggestions/derive-macro-missing-bounds.stderr
@@ -33,7 +33,7 @@ LL |     impl<T: Debug + Trait> Debug for Inner<T> {
    |                            ^^^^^     ^^^^^^^^
    = note: 1 redundant requirement hidden
    = note: required because of the requirements on the impl of `Debug` for `&c::Inner<T>`
-   = note: required for the cast to the object type `dyn Debug`
+   = note: required for the cast from `&c::Inner<T>` to the object type `dyn Debug`
    = note: this error originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider restricting type parameter `T`
    |
@@ -55,7 +55,7 @@ LL |     impl<T> Debug for Inner<T> where T: Debug, T: Trait {
    |             ^^^^^     ^^^^^^^^
    = note: 1 redundant requirement hidden
    = note: required because of the requirements on the impl of `Debug` for `&d::Inner<T>`
-   = note: required for the cast to the object type `dyn Debug`
+   = note: required for the cast from `&d::Inner<T>` to the object type `dyn Debug`
    = note: this error originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider restricting type parameter `T`
    |
@@ -77,7 +77,7 @@ LL |     impl<T> Debug for Inner<T> where T: Debug + Trait {
    |             ^^^^^     ^^^^^^^^
    = note: 1 redundant requirement hidden
    = note: required because of the requirements on the impl of `Debug` for `&e::Inner<T>`
-   = note: required for the cast to the object type `dyn Debug`
+   = note: required for the cast from `&e::Inner<T>` to the object type `dyn Debug`
    = note: this error originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider restricting type parameter `T`
    |
@@ -99,7 +99,7 @@ LL |     impl<T: Debug> Debug for Inner<T> where T: Trait {
    |                    ^^^^^     ^^^^^^^^
    = note: 1 redundant requirement hidden
    = note: required because of the requirements on the impl of `Debug` for `&f::Inner<T>`
-   = note: required for the cast to the object type `dyn Debug`
+   = note: required for the cast from `&f::Inner<T>` to the object type `dyn Debug`
    = note: this error originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider restricting type parameter `T`
    |

--- a/src/test/ui/suggestions/derive-trait-for-method-call.stderr
+++ b/src/test/ui/suggestions/derive-trait-for-method-call.stderr
@@ -11,7 +11,7 @@ LL | enum CloneEnum {
    | -------------- doesn't satisfy `CloneEnum: Default`
 ...
 LL | struct Foo<X, Y> (X, Y);
-   | ------------------------ method `test` not found for this
+   |        --- method `test` not found for this struct
 ...
 LL |     let y = x.test();
    |               ^^^^ method cannot be called on `Foo<Enum, CloneEnum>` due to unsatisfied trait bounds
@@ -49,7 +49,7 @@ LL | struct CloneStruct {
    | ------------------ doesn't satisfy `CloneStruct: Default`
 ...
 LL | struct Foo<X, Y> (X, Y);
-   | ------------------------ method `test` not found for this
+   |        --- method `test` not found for this struct
 ...
 LL |     let y = x.test();
    |               ^^^^ method cannot be called on `Foo<Struct, CloneStruct>` due to unsatisfied trait bounds
@@ -71,7 +71,7 @@ error[E0599]: the method `test` exists for struct `Foo<Vec<Enum>, Instant>`, but
   --> $DIR/derive-trait-for-method-call.rs:40:15
    |
 LL | struct Foo<X, Y> (X, Y);
-   | ------------------------ method `test` not found for this
+   |        --- method `test` not found for this struct
 ...
 LL |     let y = x.test();
    |               ^^^^ method cannot be called on `Foo<Vec<Enum>, Instant>` due to unsatisfied trait bounds

--- a/src/test/ui/suggestions/dont-wrap-ambiguous-receivers.stderr
+++ b/src/test/ui/suggestions/dont-wrap-ambiguous-receivers.stderr
@@ -2,7 +2,7 @@ error[E0599]: no method named `pick` found for struct `Chaenomeles` in the curre
   --> $DIR/dont-wrap-ambiguous-receivers.rs:18:25
    |
 LL |     pub struct Chaenomeles;
-   |     ----------------------- method `pick` not found for this
+   |                ----------- method `pick` not found for this struct
 ...
 LL |     banana::Chaenomeles.pick()
    |                         ^^^^ method not found in `Chaenomeles`

--- a/src/test/ui/suggestions/field-has-method.stderr
+++ b/src/test/ui/suggestions/field-has-method.stderr
@@ -2,7 +2,7 @@ error[E0599]: no method named `kind` found for struct `InferOk` in the current s
   --> $DIR/field-has-method.rs:19:15
    |
 LL | struct InferOk<T> {
-   | ----------------- method `kind` not found for this
+   |        ------- method `kind` not found for this struct
 ...
 LL |     let k = i.kind();
    |               ^^^^ method not found in `InferOk<Ty>`

--- a/src/test/ui/suggestions/impl-trait-with-missing-trait-bounds-in-arg.stderr
+++ b/src/test/ui/suggestions/impl-trait-with-missing-trait-bounds-in-arg.stderr
@@ -1,6 +1,8 @@
 error[E0599]: no method named `hello` found for type parameter `impl Foo` in the current scope
   --> $DIR/impl-trait-with-missing-trait-bounds-in-arg.rs:15:9
    |
+LL | fn test(foo: impl Foo) {
+   |              -------- method `hello` not found for this type parameter
 LL |     foo.hello();
    |         ^^^^^ method not found in `impl Foo`
    |

--- a/src/test/ui/suggestions/issue-21673.stderr
+++ b/src/test/ui/suggestions/issue-21673.stderr
@@ -13,6 +13,8 @@ LL | fn call_method<T: std::fmt::Debug + Foo>(x: &T) {
 error[E0599]: no method named `method` found for type parameter `T` in the current scope
   --> $DIR/issue-21673.rs:10:7
    |
+LL | fn call_method_2<T>(x: T) {
+   |                  - method `method` not found for this type parameter
 LL |     x.method()
    |       ^^^^^^ method not found in `T`
    |

--- a/src/test/ui/suggestions/suggest-assoc-fn-call-with-turbofish.stderr
+++ b/src/test/ui/suggestions/suggest-assoc-fn-call-with-turbofish.stderr
@@ -2,7 +2,7 @@ error[E0599]: no method named `default_hello` found for struct `GenericAssocMeth
   --> $DIR/suggest-assoc-fn-call-with-turbofish.rs:9:7
    |
 LL | struct GenericAssocMethod<T>(T);
-   | -------------------------------- method `default_hello` not found for this
+   |        ------------------ method `default_hello` not found for this struct
 ...
 LL |     x.default_hello();
    |     --^^^^^^^^^^^^^

--- a/src/test/ui/suggestions/suggest-borrow-to-dyn-object.rs
+++ b/src/test/ui/suggestions/suggest-borrow-to-dyn-object.rs
@@ -1,0 +1,16 @@
+use std::ffi::{OsStr, OsString};
+use std::path::Path;
+
+fn check(p: &dyn AsRef<Path>) {
+    let m = std::fs::metadata(&p);
+    println!("{:?}", &m);
+}
+
+fn main() {
+    let s: OsString = ".".into();
+    let s: &OsStr = &s;
+    check(s);
+    //~^ ERROR the size for values of type `[u8]` cannot be known at compilation time
+    //~| HELP within `OsStr`, the trait `Sized` is not implemented for `[u8]`
+    //~| HELP consider borrowing the value, since `&OsStr` can be coerced into `dyn AsRef<Path>`
+}

--- a/src/test/ui/suggestions/suggest-borrow-to-dyn-object.stderr
+++ b/src/test/ui/suggestions/suggest-borrow-to-dyn-object.stderr
@@ -1,0 +1,19 @@
+error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
+  --> $DIR/suggest-borrow-to-dyn-object.rs:12:11
+   |
+LL |     check(s);
+   |     ----- ^ doesn't have a size known at compile-time
+   |     |
+   |     required by a bound introduced by this call
+   |
+   = help: within `OsStr`, the trait `Sized` is not implemented for `[u8]`
+   = note: required because it appears within the type `OsStr`
+   = note: required for the cast to the object type `dyn AsRef<Path>`
+help: consider borrowing the value, since `&OsStr` can be coerced into `dyn AsRef<Path>`
+   |
+LL |     check(&s);
+   |           +
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/src/test/ui/suggestions/suggest-borrow-to-dyn-object.stderr
+++ b/src/test/ui/suggestions/suggest-borrow-to-dyn-object.stderr
@@ -8,7 +8,7 @@ LL |     check(s);
    |
    = help: within `OsStr`, the trait `Sized` is not implemented for `[u8]`
    = note: required because it appears within the type `OsStr`
-   = note: required for the cast to the object type `dyn AsRef<Path>`
+   = note: required for the cast from `OsStr` to the object type `dyn AsRef<Path>`
 help: consider borrowing the value, since `&OsStr` can be coerced into `dyn AsRef<Path>`
    |
 LL |     check(&s);

--- a/src/test/ui/suggestions/suggest-methods.stderr
+++ b/src/test/ui/suggestions/suggest-methods.stderr
@@ -2,7 +2,7 @@ error[E0599]: no method named `bat` found for struct `Foo` in the current scope
   --> $DIR/suggest-methods.rs:18:7
    |
 LL | struct Foo;
-   | ----------- method `bat` not found for this
+   |        --- method `bat` not found for this struct
 ...
 LL |     f.bat(1.0);
    |       ^^^ help: there is an associated function with a similar name: `bar`

--- a/src/test/ui/suggestions/suggest-variants.stderr
+++ b/src/test/ui/suggestions/suggest-variants.stderr
@@ -29,7 +29,7 @@ error[E0599]: no variant or associated item named `Squareee` found for enum `Sha
   --> $DIR/suggest-variants.rs:15:12
    |
 LL | enum Shape {
-   | ---------- variant or associated item `Squareee` not found here
+   |      ----- variant or associated item `Squareee` not found for this enum
 ...
 LL |     Shape::Squareee;
    |            ^^^^^^^^
@@ -41,7 +41,7 @@ error[E0599]: no variant or associated item named `Circl` found for enum `Shape`
   --> $DIR/suggest-variants.rs:16:12
    |
 LL | enum Shape {
-   | ---------- variant or associated item `Circl` not found here
+   |      ----- variant or associated item `Circl` not found for this enum
 ...
 LL |     Shape::Circl;
    |            ^^^^^
@@ -53,7 +53,7 @@ error[E0599]: no variant or associated item named `Rombus` found for enum `Shape
   --> $DIR/suggest-variants.rs:17:12
    |
 LL | enum Shape {
-   | ---------- variant or associated item `Rombus` not found here
+   |      ----- variant or associated item `Rombus` not found for this enum
 ...
 LL |     Shape::Rombus;
    |            ^^^^^^ variant or associated item not found in `Shape`

--- a/src/test/ui/suggestions/use-placement-typeck.stderr
+++ b/src/test/ui/suggestions/use-placement-typeck.stderr
@@ -8,7 +8,7 @@ LL |         fn abc(&self) {}
    |            --- the method is available for `S` here
 LL |     }
 LL |     pub struct S;
-   |     ------------- method `abc` not found for this
+   |                - method `abc` not found for this struct
    |
    = help: items from traits can only be used if the trait is in scope
 help: the following trait is implemented but not in scope; perhaps add a `use` for it:

--- a/src/test/ui/traits/coercion-generic-bad.stderr
+++ b/src/test/ui/traits/coercion-generic-bad.stderr
@@ -5,7 +5,7 @@ LL |     let s: Box<dyn Trait<isize>> = Box::new(Struct { person: "Fred" });
    |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Trait<isize>` is not implemented for `Struct`
    |
    = help: the trait `Trait<&'static str>` is implemented for `Struct`
-   = note: required for the cast to the object type `dyn Trait<isize>`
+   = note: required for the cast from `Struct` to the object type `dyn Trait<isize>`
 
 error: aborting due to previous error
 

--- a/src/test/ui/traits/issue-3973.stderr
+++ b/src/test/ui/traits/issue-3973.stderr
@@ -11,7 +11,7 @@ error[E0599]: no function or associated item named `new` found for struct `Point
   --> $DIR/issue-3973.rs:22:20
    |
 LL | struct Point {
-   | ------------ function or associated item `new` not found for this
+   |        ----- function or associated item `new` not found for this struct
 ...
 LL |     let p = Point::new(0.0, 0.0);
    |                    ^^^ function or associated item not found in `Point`

--- a/src/test/ui/traits/issue-65284-suggest-generic-trait-bound.stderr
+++ b/src/test/ui/traits/issue-65284-suggest-generic-trait-bound.stderr
@@ -1,6 +1,8 @@
 error[E0599]: no method named `foo` found for type parameter `T` in the current scope
   --> $DIR/issue-65284-suggest-generic-trait-bound.rs:8:7
    |
+LL | fn do_stuff<T : Bar>(t : T) {
+   |             - method `foo` not found for this type parameter
 LL |     t.foo()
    |       ^^^ method not found in `T`
    |

--- a/src/test/ui/traits/issue-95898.stderr
+++ b/src/test/ui/traits/issue-95898.stderr
@@ -1,6 +1,8 @@
 error[E0599]: no method named `clone` found for type parameter `T` in the current scope
   --> $DIR/issue-95898.rs:5:7
    |
+LL | fn foo<T:>(t: T) {
+   |        - method `clone` not found for this type parameter
 LL |     t.clone();
    |       ^^^^^ method not found in `T`
    |

--- a/src/test/ui/traits/item-privacy.stderr
+++ b/src/test/ui/traits/item-privacy.stderr
@@ -2,7 +2,7 @@ error[E0599]: no method named `a` found for struct `S` in the current scope
   --> $DIR/item-privacy.rs:67:7
    |
 LL | struct S;
-   | --------- method `a` not found for this
+   |        - method `a` not found for this struct
 ...
 LL |     S.a();
    |       ^ method not found in `S`
@@ -18,7 +18,7 @@ error[E0599]: no method named `b` found for struct `S` in the current scope
   --> $DIR/item-privacy.rs:68:7
    |
 LL | struct S;
-   | --------- method `b` not found for this
+   |        - method `b` not found for this struct
 ...
 LL |         fn b(&self) { }
    |            - the method is available for `S` here
@@ -45,7 +45,7 @@ error[E0599]: no function or associated item named `a` found for struct `S` in t
   --> $DIR/item-privacy.rs:78:8
    |
 LL | struct S;
-   | --------- function or associated item `a` not found for this
+   |        - function or associated item `a` not found for this struct
 ...
 LL |     S::a(&S);
    |        ^ function or associated item not found in `S`
@@ -61,7 +61,7 @@ error[E0599]: no function or associated item named `b` found for struct `S` in t
   --> $DIR/item-privacy.rs:80:8
    |
 LL | struct S;
-   | --------- function or associated item `b` not found for this
+   |        - function or associated item `b` not found for this struct
 ...
 LL |     S::b(&S);
    |        ^ function or associated item not found in `S`
@@ -85,7 +85,7 @@ error[E0599]: no associated item named `A` found for struct `S` in the current s
   --> $DIR/item-privacy.rs:97:8
    |
 LL | struct S;
-   | --------- associated item `A` not found for this
+   |        - associated item `A` not found for this struct
 ...
 LL |     S::A;
    |        ^ associated item not found in `S`
@@ -101,7 +101,7 @@ error[E0599]: no associated item named `B` found for struct `S` in the current s
   --> $DIR/item-privacy.rs:98:8
    |
 LL | struct S;
-   | --------- associated item `B` not found for this
+   |        - associated item `B` not found for this struct
 ...
 LL |     S::B;
    |        ^ associated item not found in `S`

--- a/src/test/ui/traits/map-types.stderr
+++ b/src/test/ui/traits/map-types.stderr
@@ -5,7 +5,7 @@ LL |     let y: Box<dyn Map<usize, isize>> = Box::new(x);
    |                                         ^^^^^^^^^^^ the trait `Map<usize, isize>` is not implemented for `Box<dyn Map<isize, isize>>`
    |
    = help: the trait `Map<K, V>` is implemented for `HashMap<K, V>`
-   = note: required for the cast to the object type `dyn Map<usize, isize>`
+   = note: required for the cast from `Box<dyn Map<isize, isize>>` to the object type `dyn Map<usize, isize>`
 
 error: aborting due to previous error
 

--- a/src/test/ui/traits/negative-impls/explicitly-unimplemented-error-message.stderr
+++ b/src/test/ui/traits/negative-impls/explicitly-unimplemented-error-message.stderr
@@ -2,7 +2,7 @@ error[E0599]: no method named `clone` found for struct `Qux` in the current scop
   --> $DIR/explicitly-unimplemented-error-message.rs:34:9
    |
 LL | struct Qux;
-   | ----------- method `clone` not found for this
+   |        --- method `clone` not found for this struct
 ...
 LL |     Qux.clone();
    |         ^^^^^ method not found in `Qux`
@@ -23,7 +23,7 @@ error[E0599]: no method named `foo` found for struct `Qux` in the current scope
   --> $DIR/explicitly-unimplemented-error-message.rs:44:9
    |
 LL | struct Qux;
-   | ----------- method `foo` not found for this
+   |        --- method `foo` not found for this struct
 ...
 LL |     Qux.foo();
    |         ^^^ method not found in `Qux`

--- a/src/test/ui/traits/trait-upcasting/type-checking-test-1.stderr
+++ b/src/test/ui/traits/trait-upcasting/type-checking-test-1.stderr
@@ -15,7 +15,7 @@ error[E0277]: the trait bound `&dyn Foo: Bar<_>` is not satisfied
 LL |     let _ = x as &dyn Bar<_>; // Ambiguous
    |             ^ the trait `Bar<_>` is not implemented for `&dyn Foo`
    |
-   = note: required for the cast to the object type `dyn Bar<_>`
+   = note: required for the cast from `&dyn Foo` to the object type `dyn Bar<_>`
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/traits/trait-upcasting/type-checking-test-2.stderr
+++ b/src/test/ui/traits/trait-upcasting/type-checking-test-2.stderr
@@ -15,7 +15,7 @@ error[E0277]: the trait bound `&dyn Foo<i32>: Bar<u32>` is not satisfied
 LL |     let _ = x as &dyn Bar<u32>; // Error
    |             ^ the trait `Bar<u32>` is not implemented for `&dyn Foo<i32>`
    |
-   = note: required for the cast to the object type `dyn Bar<u32>`
+   = note: required for the cast from `&dyn Foo<i32>` to the object type `dyn Bar<u32>`
 
 error[E0605]: non-primitive cast: `&dyn Foo<u32>` as `&dyn Bar<_>`
   --> $DIR/type-checking-test-2.rs:26:13
@@ -34,7 +34,7 @@ error[E0277]: the trait bound `&dyn Foo<u32>: Bar<_>` is not satisfied
 LL |     let a = x as &dyn Bar<_>; // Ambiguous
    |             ^ the trait `Bar<_>` is not implemented for `&dyn Foo<u32>`
    |
-   = note: required for the cast to the object type `dyn Bar<_>`
+   = note: required for the cast from `&dyn Foo<u32>` to the object type `dyn Bar<_>`
 
 error: aborting due to 4 previous errors
 

--- a/src/test/ui/typeck/point-at-type-parameter-definition.rs
+++ b/src/test/ui/typeck/point-at-type-parameter-definition.rs
@@ -1,0 +1,17 @@
+trait Trait {
+    fn do_stuff(&self);
+}
+
+struct Hello;
+
+impl Hello {
+    fn method(&self) {}
+}
+
+impl<Hello> Trait for Vec<Hello> {
+    fn do_stuff(&self) {
+        self[0].method(); //~ ERROR no method named `method` found for type parameter `Hello` in the current scope
+    }
+}
+
+fn main() {}

--- a/src/test/ui/typeck/point-at-type-parameter-definition.stderr
+++ b/src/test/ui/typeck/point-at-type-parameter-definition.stderr
@@ -1,0 +1,12 @@
+error[E0599]: no method named `method` found for type parameter `Hello` in the current scope
+  --> $DIR/point-at-type-parameter-definition.rs:13:17
+   |
+LL | impl<Hello> Trait for Vec<Hello> {
+   |      ----- method `method` not found for this type parameter
+LL |     fn do_stuff(&self) {
+LL |         self[0].method();
+   |                 ^^^^^^ method not found in `Hello`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0599`.

--- a/src/test/ui/union/union-derive-clone.mirunsafeck.stderr
+++ b/src/test/ui/union/union-derive-clone.mirunsafeck.stderr
@@ -3,8 +3,8 @@ error[E0599]: the method `clone` exists for union `U5<CloneNoCopy>`, but its tra
    |
 LL | union U5<T> {
    | -----------
-   | |
-   | method `clone` not found for this
+   | |     |
+   | |     method `clone` not found for this union
    | doesn't satisfy `U5<CloneNoCopy>: Clone`
 ...
 LL | struct CloneNoCopy;

--- a/src/test/ui/union/union-derive-clone.thirunsafeck.stderr
+++ b/src/test/ui/union/union-derive-clone.thirunsafeck.stderr
@@ -3,8 +3,8 @@ error[E0599]: the method `clone` exists for union `U5<CloneNoCopy>`, but its tra
    |
 LL | union U5<T> {
    | -----------
-   | |
-   | method `clone` not found for this
+   | |     |
+   | |     method `clone` not found for this union
    | doesn't satisfy `U5<CloneNoCopy>: Clone`
 ...
 LL | struct CloneNoCopy;

--- a/src/test/ui/unsized/unsized-fn-param.stderr
+++ b/src/test/ui/unsized/unsized-fn-param.stderr
@@ -5,7 +5,7 @@ LL |     foo11("bar", &"baz");
    |           ^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `str`
-   = note: required for the cast to the object type `dyn AsRef<Path>`
+   = note: required for the cast from `str` to the object type `dyn AsRef<Path>`
 help: consider borrowing the value, since `&str` can be coerced into `dyn AsRef<Path>`
    |
 LL |     foo11(&"bar", &"baz");
@@ -18,7 +18,7 @@ LL |     foo12(&"bar", "baz");
    |                   ^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `str`
-   = note: required for the cast to the object type `dyn AsRef<Path>`
+   = note: required for the cast from `str` to the object type `dyn AsRef<Path>`
 help: consider borrowing the value, since `&str` can be coerced into `dyn AsRef<Path>`
    |
 LL |     foo12(&"bar", &"baz");
@@ -31,7 +31,7 @@ LL |     foo21("bar", &"baz");
    |           ^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `str`
-   = note: required for the cast to the object type `dyn AsRef<str>`
+   = note: required for the cast from `str` to the object type `dyn AsRef<str>`
 help: consider borrowing the value, since `&str` can be coerced into `dyn AsRef<str>`
    |
 LL |     foo21(&"bar", &"baz");
@@ -44,7 +44,7 @@ LL |     foo22(&"bar", "baz");
    |                   ^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `str`
-   = note: required for the cast to the object type `dyn AsRef<str>`
+   = note: required for the cast from `str` to the object type `dyn AsRef<str>`
 help: consider borrowing the value, since `&str` can be coerced into `dyn AsRef<str>`
    |
 LL |     foo22(&"bar", &"baz");


### PR DESCRIPTION
Successful merges:

 - #96412 (Windows: Iterative `remove_dir_all`)
 - #98126 (Mitigate MMIO stale data vulnerability)
 - #98149 (Set relocation_model to Pic on emscripten target)
 - #98194 (Leak pthread_{mutex,rwlock}_t if it's dropped while locked.)
 - #98277 (Fix trait object reborrow suggestion)
 - #98298 (Point to type parameter definition when not finding variant, method and associated item)
 - #98311 (Reverse folder hierarchy)
 - #98401 (Add tracking issues to `--extern` option docs.)
 - #98431 (Suggest defining variable as mutable on `&mut _` type mismatch in pats)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=96412,98126,98149,98194,98277,98298,98311,98401,98431)
<!-- homu-ignore:end -->