### PR TITLE
Do not fetch HIR to compute variances.

### DIFF
--- a/compiler/rustc_middle/src/hir/mod.rs
+++ b/compiler/rustc_middle/src/hir/mod.rs
@@ -63,6 +63,15 @@ impl ModuleItems {
         self.foreign_items.iter().copied()
     }
 
+    pub fn definitions(&self) -> impl Iterator<Item = LocalDefId> + '_ {
+        self.items
+            .iter()
+            .map(|id| id.def_id)
+            .chain(self.trait_items.iter().map(|id| id.def_id))
+            .chain(self.impl_items.iter().map(|id| id.def_id))
+            .chain(self.foreign_items.iter().map(|id| id.def_id))
+    }
+
     pub fn par_items(&self, f: impl Fn(ItemId) + Send + Sync) {
         par_for_each_in(&self.items[..], |&id| f(id))
     }

--- a/compiler/rustc_typeck/src/variance/solve.rs
+++ b/compiler/rustc_typeck/src/variance/solve.rs
@@ -96,8 +96,7 @@ impl<'a, 'tcx> SolveContext<'a, 'tcx> {
         self.terms_cx
             .inferred_starts
             .iter()
-            .map(|(&id, &InferredIndex(start))| {
-                let def_id = tcx.hir().local_def_id(id);
+            .map(|(&def_id, &InferredIndex(start))| {
                 let generics = tcx.generics_of(def_id);
                 let count = generics.count();
 


### PR DESCRIPTION
Everything can be done using higher-level queries.  This simplifies the code, and should allow better incremental caching.