### PR TITLE
core::str::{chars_uppercase,chars_lowercase} iterators

### DIFF
--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -144,6 +144,7 @@
 #![feature(unicode_internals)]
 #![feature(unsize)]
 #![feature(std_internals)]
+#![feature(unicode_converter)]
 //
 // Language features:
 #![feature(allocator_internals)]

--- a/library/alloc/tests/lib.rs
+++ b/library/alloc/tests/lib.rs
@@ -44,6 +44,7 @@
 #![feature(bench_black_box)]
 #![feature(strict_provenance)]
 #![feature(once_cell)]
+#![feature(unicode_converter)]
 
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};

--- a/library/alloc/tests/str.rs
+++ b/library/alloc/tests/str.rs
@@ -1794,6 +1794,108 @@ fn to_uppercase() {
     assert_eq!("aéǅßﬁᾀ".to_uppercase(), "AÉǄSSFIἈΙ");
 }
 
+const CHARS_CONVERT_STRINGS: &[&str; 7] = &[
+    "aBcD",
+    "ὀδυσσεύς",
+    "ὈΔΥΣΣΕΎΣ",
+    "aößü💩στιγμαςǅﬁᾀ",
+    "AÖßÜ💩ΣΤΙΓΜΑΣǅﬁİ",
+    "İİİİİİİİİİİİİİİİİİİİİİİİ",
+    "i̇i̇i̇i̇i̇i̇i̇i̇i̇i̇i̇i̇i̇i̇i̇i̇i̇i̇i̇i̇i̇i̇i̇i̇",
+];
+
+// Run n times .next() then .next_back()
+fn chars_fwdback<I: DoubleEndedIterator<Item = char>>(mut iter: I, n: usize) -> String {
+    let mut buf1 = String::new();
+    let mut buf2 = String::new();
+    for _ in 0..n {
+        if let Some(c) = iter.next() {
+            buf1.push(c);
+        } else {
+            break;
+        }
+    }
+    while let Some(c) = iter.next_back() {
+        buf2.push(c);
+    }
+    for c in buf2.chars().rev() {
+        buf1.push(c);
+    }
+    buf1
+}
+
+// Run n times .next_back() then .next()
+fn chars_backfwd<I: DoubleEndedIterator<Item = char>>(mut iter: I, n: usize) -> String {
+    let mut buf1 = String::new();
+    let mut buf2 = String::new();
+    for _ in 0..n {
+        if let Some(c) = iter.next_back() {
+            buf2.push(c);
+        } else {
+            break;
+        }
+    }
+    while let Some(c) = iter.next() {
+        buf1.push(c);
+    }
+    for c in buf2.chars().rev() {
+        buf1.push(c);
+    }
+    buf1
+}
+
+#[test]
+fn test_chars_uppercase() {
+    for s in CHARS_CONVERT_STRINGS {
+        let exp = s.to_uppercase();
+        assert_eq!(s.chars_uppercase().collect::<String>(), exp);
+        for i in 0..s.len() {
+            assert_eq!((i, &chars_fwdback(s.chars_uppercase(), i)), (i, &exp));
+            assert_eq!((i, &chars_backfwd(s.chars_uppercase(), i)), (i, &exp));
+        }
+    }
+}
+
+#[test]
+fn test_chars_lowercase() {
+    for s in CHARS_CONVERT_STRINGS {
+        let exp = s.to_lowercase();
+        assert_eq!(s.chars_lowercase().collect::<String>(), exp);
+        for i in 0..s.len() {
+            assert_eq!((i, &chars_fwdback(s.chars_lowercase(), i)), (i, &exp));
+            assert_eq!((i, &chars_backfwd(s.chars_lowercase(), i)), (i, &exp));
+        }
+    }
+}
+
+#[test]
+fn test_chars_uppercase_clone_debug() {
+    let mut iter = "abc".chars_uppercase();
+    assert_eq!(iter.next(), Some('A'));
+    assert_eq!(iter.next(), Some('B'));
+    let mut iterc = iter.clone();
+    assert_eq!(&format!("{:?}", &iterc), "CharsUppercase(['C'])");
+    assert_eq!(iter.next(), Some('C'));
+    assert_eq!(iter.next(), None);
+    assert_eq!(iterc.clone().last(), Some('C'));
+    assert_eq!(iterc.next(), Some('C'));
+    assert_eq!(iterc.next(), None);
+}
+
+#[test]
+fn test_chars_lowercase_clone_debug() {
+    let mut iter = "ABC".chars_lowercase();
+    assert_eq!(iter.next(), Some('a'));
+    assert_eq!(iter.next(), Some('b'));
+    let mut iterc = iter.clone();
+    assert_eq!(&format!("{:?}", &iterc), "CharsLowercase(['c'])");
+    assert_eq!(iter.next(), Some('c'));
+    assert_eq!(iter.next(), None);
+    assert_eq!(iterc.clone().last(), Some('c'));
+    assert_eq!(iterc.next(), Some('c'));
+    assert_eq!(iterc.next(), None);
+}
+
 #[test]
 fn test_into_string() {
     // The only way to acquire a Box<str> in the first place is through a String, so just

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -156,6 +156,7 @@
 #![feature(const_slice_from_ref)]
 #![feature(const_slice_index)]
 #![feature(const_is_char_boundary)]
+#![feature(unicode_converter)]
 //
 // Language features:
 #![feature(abi_unadjusted)]

--- a/library/core/src/str/mod.rs
+++ b/library/core/src/str/mod.rs
@@ -69,6 +69,9 @@ pub use iter::SplitAsciiWhitespace;
 #[stable(feature = "split_inclusive", since = "1.51.0")]
 pub use iter::SplitInclusive;
 
+#[unstable(feature = "unicode_converter", issue = "none")]
+pub use iter::{CharsLowercase, CharsUppercase};
+
 #[unstable(feature = "str_internals", issue = "none")]
 pub use validations::{next_code_point, utf8_char_width};
 
@@ -836,6 +839,102 @@ impl str {
     #[inline]
     pub fn char_indices(&self) -> CharIndices<'_> {
         CharIndices { front_offset: 0, iter: self.chars() }
+    }
+
+    /// Returns an iterator over the [`char`]s of a string slice,
+    /// converted to uppercase.
+    ///
+    /// It is guaranteed to match the output of [`str::to_uppercase`]
+    /// as it uses same context-aware conversion method.
+    ///
+    /// It is not guarateed to match [`char::to_uppercase`]
+    /// as that API is not context-aware.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// #![feature(unicode_converter)]
+    ///
+    /// let input = "abc";
+    ///
+    /// let mut iter = input.chars_uppercase();
+    ///
+    /// assert_eq!(Some('A'), iter.next());
+    /// assert_eq!(Some('B'), iter.next());
+    /// assert_eq!(Some('C'), iter.next());
+    /// assert_eq!(None, iter.next());
+    /// ```
+    ///
+    /// Complex case:
+    ///
+    /// ```
+    /// #![feature(unicode_converter)]
+    ///
+    /// let input = "ὒ";
+    ///
+    /// let mut iter = input.chars_uppercase();
+    ///
+    /// assert_eq!(Some('Υ'), iter.next());
+    /// assert_eq!(Some('\u{300}'), iter.next_back());
+    /// assert_eq!(Some('\u{313}'), iter.next());
+    /// assert_eq!(None, iter.next_back());
+    /// ```
+    ///
+    /// [`char`]: prim@char
+    /// [`str::to_uppercase`]: https://doc.rust-lang.org/std/primitive.str.html#method.to_uppercase
+    #[unstable(feature = "unicode_converter", issue = "none")]
+    #[inline]
+    pub fn chars_uppercase(&self) -> CharsUppercase<'_> {
+        CharsUppercase::new(self)
+    }
+
+    /// Returns an iterator over the [`char`]s of a string slice,
+    /// converted to lowercase.
+    ///
+    /// It is guaranteed to match the output of [`str::to_lowercase`]
+    /// as it uses same context-aware conversion method.
+    ///
+    /// It is not guarateed to match [`char::to_lowercase`]
+    /// as that API is not context-aware.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// #![feature(unicode_converter)]
+    ///
+    /// let input = "ABC";
+    ///
+    /// let mut iter = input.chars_lowercase();
+    ///
+    /// assert_eq!(Some('a'), iter.next());
+    /// assert_eq!(Some('b'), iter.next());
+    /// assert_eq!(Some('c'), iter.next());
+    /// assert_eq!(None, iter.next());
+    /// ```
+    ///
+    /// Complex situation:
+    ///
+    /// ```
+    /// #![feature(unicode_converter)]
+    ///
+    /// let input = "ὈΔΥΣΣΕΎΣ";
+    ///
+    /// let mut iter = input.chars_lowercase();
+    ///
+    /// assert_eq!(Some('ς'), iter.next_back());
+    /// assert_eq!(Some('σ'), input.chars().flat_map(|c| c.to_lowercase()).last())
+    /// ```
+    ///
+    /// [`char`]: prim@char
+    /// [`str::to_lowercase`]: https://doc.rust-lang.org/std/primitive.str.html#method.to_lowercase
+    #[unstable(feature = "unicode_converter", issue = "none")]
+    #[inline]
+    pub fn chars_lowercase(&self) -> CharsLowercase<'_> {
+        CharsLowercase::new(self)
     }
 
     /// An iterator over the bytes of a string slice.

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -291,6 +291,7 @@
 #![feature(std_internals)]
 #![feature(str_internals)]
 #![feature(strict_provenance)]
+#![feature(unicode_converter)]
 //
 // Library features (alloc):
 #![feature(alloc_layout_extra)]

--- a/src/doc/unstable-book/src/library-features/unicode-converter.md
+++ b/src/doc/unstable-book/src/library-features/unicode-converter.md
@@ -1,0 +1,9 @@
+# `unicode_converter`
+
+No tracking issue
+
+------------------------
+
+Add `str::chars_uppercase` and `str::chars_lowercase` iterators.
+
+They are based on internal iterating, context-aware unicode converter API.


### PR DESCRIPTION
They are based on new UnicodeConverter + UnicodeIterator
internal API that supports context-sensitivity and char expansion.

API change proposal: https://github.com/rust-lang/libs-team/issues/58