### PR TITLE
Fix backtrace UI test when panic=abort is used

### DIFF
--- a/src/test/ui/backtrace.rs
+++ b/src/test/ui/backtrace.rs
@@ -43,6 +43,7 @@ fn expected(fn_name: &str) -> String {
     format!(" backtrace::{}", fn_name)
 }
 
+#[cfg(not(panic = "abort"))]
 fn contains_verbose_expected(s: &str, fn_name: &str) -> bool {
     // HACK(eddyb) work around the fact that verbosely demangled stack traces
     // (from `RUST_BACKTRACE=full`, or, as is the case here, panic-in-panic)


### PR DESCRIPTION
The function `contains_verbose_expected` is only used when the panic strategy is not abort, so it caused a warning when it was abort, which made the UI test failed on stderr comparison.