### PR TITLE
Improve some inference diagnostics

### DIFF
--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -914,8 +914,16 @@ impl<'tcx> Term<'tcx> {
     pub fn ty(&self) -> Option<Ty<'tcx>> {
         if let Term::Ty(ty) = self { Some(*ty) } else { None }
     }
+
     pub fn ct(&self) -> Option<Const<'tcx>> {
         if let Term::Const(c) = self { Some(*c) } else { None }
+    }
+
+    pub fn into_arg(self) -> GenericArg<'tcx> {
+        match self {
+            Term::Ty(ty) => ty.into(),
+            Term::Const(c) => c.into(),
+        }
     }
 }
 

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
@@ -2020,7 +2020,7 @@ impl<'a, 'tcx> InferCtxtPrivExt<'a, 'tcx> for InferCtxt<'a, 'tcx> {
                     subst,
                     impl_candidates,
                     ErrorCode::E0283,
-                    false,
+                    true,
                 );
 
                 let obligation = Obligation::new(
@@ -2132,7 +2132,7 @@ impl<'a, 'tcx> InferCtxtPrivExt<'a, 'tcx> for InferCtxt<'a, 'tcx> {
                     a.into(),
                     vec![],
                     ErrorCode::E0282,
-                    false,
+                    true,
                 )
             }
             ty::PredicateKind::Projection(data) => {
@@ -2149,7 +2149,7 @@ impl<'a, 'tcx> InferCtxtPrivExt<'a, 'tcx> for InferCtxt<'a, 'tcx> {
                         self_ty.into(),
                         vec![],
                         ErrorCode::E0284,
-                        false,
+                        true,
                     );
                     err.note(&format!("cannot satisfy `{}`", predicate));
                     err

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
@@ -2002,6 +2002,7 @@ impl<'a, 'tcx> InferCtxtPrivExt<'a, 'tcx> for InferCtxt<'a, 'tcx> {
                             subst,
                             vec![],
                             ErrorCode::E0282,
+                            false,
                         )
                         .emit();
                     }
@@ -2019,6 +2020,7 @@ impl<'a, 'tcx> InferCtxtPrivExt<'a, 'tcx> for InferCtxt<'a, 'tcx> {
                     subst,
                     impl_candidates,
                     ErrorCode::E0283,
+                    false,
                 );
 
                 let obligation = Obligation::new(
@@ -2110,7 +2112,7 @@ impl<'a, 'tcx> InferCtxtPrivExt<'a, 'tcx> for InferCtxt<'a, 'tcx> {
                     return;
                 }
 
-                self.emit_inference_failure_err(body_id, span, arg, vec![], ErrorCode::E0282)
+                self.emit_inference_failure_err(body_id, span, arg, vec![], ErrorCode::E0282, false)
             }
 
             ty::PredicateKind::Subtype(data) => {
@@ -2124,7 +2126,14 @@ impl<'a, 'tcx> InferCtxtPrivExt<'a, 'tcx> for InferCtxt<'a, 'tcx> {
                 let SubtypePredicate { a_is_expected: _, a, b } = data;
                 // both must be type variables, or the other would've been instantiated
                 assert!(a.is_ty_var() && b.is_ty_var());
-                self.emit_inference_failure_err(body_id, span, a.into(), vec![], ErrorCode::E0282)
+                self.emit_inference_failure_err(
+                    body_id,
+                    span,
+                    a.into(),
+                    vec![],
+                    ErrorCode::E0282,
+                    false,
+                )
             }
             ty::PredicateKind::Projection(data) => {
                 let self_ty = data.projection_ty.self_ty();
@@ -2140,6 +2149,7 @@ impl<'a, 'tcx> InferCtxtPrivExt<'a, 'tcx> for InferCtxt<'a, 'tcx> {
                         self_ty.into(),
                         vec![],
                         ErrorCode::E0284,
+                        false,
                     );
                     err.note(&format!("cannot satisfy `{}`", predicate));
                     err

--- a/compiler/rustc_typeck/src/check/fn_ctxt/_impl.rs
+++ b/compiler/rustc_typeck/src/check/fn_ctxt/_impl.rs
@@ -1538,9 +1538,15 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             ty
         } else {
             if !self.is_tainted_by_errors() {
-                self.emit_inference_failure_err((**self).body_id, sp, ty.into(), vec![], E0282)
-                    .note("type must be known at this point")
-                    .emit();
+                self.emit_inference_failure_err(
+                    (**self).body_id,
+                    sp,
+                    ty.into(),
+                    vec![],
+                    E0282,
+                    true,
+                )
+                .emit();
             }
             let err = self.tcx.ty_error();
             self.demand_suptype(sp, err, ty);

--- a/compiler/rustc_typeck/src/check/writeback.rs
+++ b/compiler/rustc_typeck/src/check/writeback.rs
@@ -694,6 +694,7 @@ impl<'cx, 'tcx> Resolver<'cx, 'tcx> {
                     t.into(),
                     vec![],
                     E0282,
+                    false,
                 )
                 .emit();
         }
@@ -708,6 +709,7 @@ impl<'cx, 'tcx> Resolver<'cx, 'tcx> {
                     c.into(),
                     vec![],
                     E0282,
+                    false,
                 )
                 .emit();
         }

--- a/src/test/ui/array-slice-vec/infer_array_len.stderr
+++ b/src/test/ui/array-slice-vec/infer_array_len.stderr
@@ -4,7 +4,6 @@ error[E0282]: type annotations needed
 LL |     let [_, _] = a.into();
    |         ^^^^^^
    |
-   = note: type must be known at this point
 help: consider giving this pattern a type
    |
 LL |     let [_, _]: _ = a.into();

--- a/src/test/ui/array-slice-vec/slice-pat-type-mismatches.stderr
+++ b/src/test/ui/array-slice-vec/slice-pat-type-mismatches.stderr
@@ -27,8 +27,6 @@ error[E0282]: type annotations needed
    |
 LL |         [] => {}
    |         ^^ cannot infer type
-   |
-   = note: type must be known at this point
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/cast/issue-85586.stderr
+++ b/src/test/ui/cast/issue-85586.stderr
@@ -3,8 +3,6 @@ error[E0282]: type annotations needed
    |
 LL |     let b = (a + 1) as usize;
    |             ^^^^^^^ cannot infer type
-   |
-   = note: type must be known at this point
 
 error: aborting due to previous error
 

--- a/src/test/ui/coherence/coherence-overlap-trait-alias.stderr
+++ b/src/test/ui/coherence/coherence-overlap-trait-alias.stderr
@@ -1,8 +1,8 @@
-error[E0283]: type annotations needed
+error[E0283]: type annotations needed: cannot satisfy `u32: C`
   --> $DIR/coherence-overlap-trait-alias.rs:15:6
    |
 LL | impl C for u32 {}
-   |      ^ cannot infer type for type `u32`
+   |      ^
    |
 note: multiple `impl`s satisfying `u32: C` found
   --> $DIR/coherence-overlap-trait-alias.rs:14:1

--- a/src/test/ui/const-generics/generic_arg_infer/issue-91614.stderr
+++ b/src/test/ui/const-generics/generic_arg_infer/issue-91614.stderr
@@ -2,7 +2,7 @@ error[E0283]: type annotations needed for `Mask<_, LANES>`
   --> $DIR/issue-91614.rs:6:9
    |
 LL |     let y = Mask::<_, _>::splat(false);
-   |         ^
+   |         ^   ------------------- type must be known at this point
    |
    = note: cannot satisfy `_: MaskElement`
 note: required by a bound in `Mask::<T, LANES>::splat`

--- a/src/test/ui/const-generics/generic_const_exprs/issue-72787.min.stderr
+++ b/src/test/ui/const-generics/generic_const_exprs/issue-72787.min.stderr
@@ -34,19 +34,19 @@ LL |     IsLessOrEqual<{ 8 - I }, { 8 - J }>: True,
    = help: const parameters may only be used as standalone arguments, i.e. `J`
    = help: use `#![feature(generic_const_exprs)]` to allow generic const expressions
 
-error[E0283]: type annotations needed
+error[E0283]: type annotations needed: cannot satisfy `IsLessOrEqual<I, 8_u32>: True`
   --> $DIR/issue-72787.rs:21:26
    |
 LL |     IsLessOrEqual<I, 8>: True,
-   |                          ^^^^ cannot infer type for struct `IsLessOrEqual<I, 8_u32>`
+   |                          ^^^^
    |
    = note: cannot satisfy `IsLessOrEqual<I, 8_u32>: True`
 
-error[E0283]: type annotations needed
+error[E0283]: type annotations needed: cannot satisfy `IsLessOrEqual<I, 8_u32>: True`
   --> $DIR/issue-72787.rs:21:26
    |
 LL |     IsLessOrEqual<I, 8>: True,
-   |                          ^^^^ cannot infer type for struct `IsLessOrEqual<I, 8_u32>`
+   |                          ^^^^
    |
    = note: cannot satisfy `IsLessOrEqual<I, 8_u32>: True`
 

--- a/src/test/ui/const-generics/generic_const_exprs/issue-72787.rs
+++ b/src/test/ui/const-generics/generic_const_exprs/issue-72787.rs
@@ -19,8 +19,8 @@ struct S<const I: u32, const J: u32>;
 impl<const I: u32, const J: u32> S<I, J>
 where
     IsLessOrEqual<I, 8>: True,
-//[min]~^ Error type annotations needed [E0283]
-//[min]~| Error type annotations needed [E0283]
+//[min]~^ Error type annotations needed
+//[min]~| Error type annotations needed
     IsLessOrEqual<J, 8>: True,
     IsLessOrEqual<{ 8 - I }, { 8 - J }>: True,
 //[min]~^ Error generic parameters may not be used in const operations

--- a/src/test/ui/impl-trait/hidden-type-is-opaque-2.stderr
+++ b/src/test/ui/impl-trait/hidden-type-is-opaque-2.stderr
@@ -3,16 +3,12 @@ error[E0282]: type annotations needed
    |
 LL |         cont.reify_as();
    |         ^^^^ cannot infer type
-   |
-   = note: type must be known at this point
 
 error[E0282]: type annotations needed
   --> $DIR/hidden-type-is-opaque-2.rs:18:9
    |
 LL |         cont.reify_as();
    |         ^^^^ cannot infer type
-   |
-   = note: type must be known at this point
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/inference/cannot-infer-partial-try-return.stderr
+++ b/src/test/ui/inference/cannot-infer-partial-try-return.stderr
@@ -3,6 +3,9 @@ error[E0282]: type annotations needed for `Result<(), QualifiedError<_>>`
    |
 LL |     let x = || -> Result<_, QualifiedError<_>> {
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |
+LL |         infallible()?;
+   |         ------------- type must be known at this point
    |
 help: try giving this closure an explicit return type
    |

--- a/src/test/ui/inference/erase-type-params-in-label.stderr
+++ b/src/test/ui/inference/erase-type-params-in-label.stderr
@@ -2,7 +2,7 @@ error[E0283]: type annotations needed for `Foo<i32, &str, W, Z>`
   --> $DIR/erase-type-params-in-label.rs:2:9
    |
 LL |     let foo = foo(1, "");
-   |         ^^^
+   |         ^^^   --- type must be known at this point
    |
    = note: cannot satisfy `_: Default`
 note: required by a bound in `foo`
@@ -23,7 +23,7 @@ error[E0283]: type annotations needed for `Bar<i32, &str, Z>`
   --> $DIR/erase-type-params-in-label.rs:5:9
    |
 LL |     let bar = bar(1, "");
-   |         ^^^
+   |         ^^^   --- type must be known at this point
    |
    = note: cannot satisfy `_: Default`
 note: required by a bound in `bar`

--- a/src/test/ui/inference/issue-72616.stderr
+++ b/src/test/ui/inference/issue-72616.stderr
@@ -2,7 +2,9 @@ error[E0283]: type annotations needed
   --> $DIR/issue-72616.rs:20:37
    |
 LL |         if String::from("a") == "a".try_into().unwrap() {}
-   |                                     ^^^^^^^^
+   |                              --     ^^^^^^^^
+   |                              |
+   |                              type must be known at this point
    |
    = note: multiple `impl`s satisfying `String: PartialEq<_>` found in the `alloc` crate:
            - impl PartialEq for String;

--- a/src/test/ui/inference/issue-72690.stderr
+++ b/src/test/ui/inference/issue-72690.stderr
@@ -55,7 +55,7 @@ error[E0283]: type annotations needed for `&T`
   --> $DIR/issue-72690.rs:17:9
    |
 LL |     let _ = "x".as_ref();
-   |         ^
+   |         ^       ------ type must be known at this point
    |
    = note: multiple `impl`s satisfying `str: AsRef<_>` found in the following crates: `core`, `std`:
            - impl AsRef<OsStr> for str;

--- a/src/test/ui/inference/issue-86162-1.stderr
+++ b/src/test/ui/inference/issue-86162-1.stderr
@@ -2,7 +2,9 @@ error[E0283]: type annotations needed
   --> $DIR/issue-86162-1.rs:7:9
    |
 LL |     foo(gen()); //<- Do not suggest `foo::<impl Clone>()`!
-   |         ^^^ cannot infer type of the type parameter `T` declared on the function `gen`
+   |     --- ^^^ cannot infer type of the type parameter `T` declared on the function `gen`
+   |     |
+   |     type must be known at this point
    |
    = note: cannot satisfy `_: Clone`
 note: required by a bound in `foo`

--- a/src/test/ui/inference/issue-86162-2.stderr
+++ b/src/test/ui/inference/issue-86162-2.stderr
@@ -2,7 +2,9 @@ error[E0283]: type annotations needed
   --> $DIR/issue-86162-2.rs:12:14
    |
 LL |     Foo::bar(gen()); //<- Do not suggest `Foo::bar::<impl Clone>()`!
-   |              ^^^ cannot infer type of the type parameter `T` declared on the function `gen`
+   |     -------- ^^^ cannot infer type of the type parameter `T` declared on the function `gen`
+   |     |
+   |     type must be known at this point
    |
    = note: cannot satisfy `_: Clone`
 note: required by a bound in `Foo::bar`

--- a/src/test/ui/issues/issue-12028.stderr
+++ b/src/test/ui/issues/issue-12028.stderr
@@ -1,8 +1,14 @@
-error[E0284]: type annotations needed: cannot satisfy `<_ as StreamHasher>::S == <H as StreamHasher>::S`
+error[E0284]: type annotations needed
   --> $DIR/issue-12028.rs:27:14
    |
 LL |         self.input_stream(&mut stream);
-   |              ^^^^^^^^^^^^ cannot satisfy `<_ as StreamHasher>::S == <H as StreamHasher>::S`
+   |              ^^^^^^^^^^^^
+   |
+   = note: cannot satisfy `<_ as StreamHasher>::S == <H as StreamHasher>::S`
+help: try using a fully qualified path to specify the expected types
+   |
+LL |         <u8 as StreamHash<H>>::input_stream(self, &mut stream);
+   |         ++++++++++++++++++++++++++++++++++++    ~
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-15965.stderr
+++ b/src/test/ui/issues/issue-15965.stderr
@@ -5,8 +5,6 @@ LL | /         { return () }
 LL | |
 LL | |     ()
    | |______^ cannot infer type
-   |
-   = note: type must be known at this point
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-20261.stderr
+++ b/src/test/ui/issues/issue-20261.stderr
@@ -3,8 +3,6 @@ error[E0282]: type annotations needed
    |
 LL |         i.clone();
    |           ^^^^^ cannot infer type
-   |
-   = note: type must be known at this point
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-2151.stderr
+++ b/src/test/ui/issues/issue-2151.stderr
@@ -3,8 +3,9 @@ error[E0282]: type annotations needed
    |
 LL |     let x = panic!();
    |         ^
+LL |     x.clone();
+   |     - type must be known at this point
    |
-   = note: type must be known at this point
 help: consider giving `x` an explicit type
    |
 LL |     let x: _ = panic!();

--- a/src/test/ui/issues/issue-21974.stderr
+++ b/src/test/ui/issues/issue-21974.stderr
@@ -1,8 +1,8 @@
-error[E0283]: type annotations needed
+error[E0283]: type annotations needed: cannot satisfy `&'a T: Foo`
   --> $DIR/issue-21974.rs:11:19
    |
 LL |     where &'a T : Foo,
-   |                   ^^^ cannot infer type for reference `&'a T`
+   |                   ^^^
    |
    = note: cannot satisfy `&'a T: Foo`
 

--- a/src/test/ui/issues/issue-24424.stderr
+++ b/src/test/ui/issues/issue-24424.stderr
@@ -1,8 +1,8 @@
-error[E0283]: type annotations needed
+error[E0283]: type annotations needed: cannot satisfy `T0: Trait0<'l0>`
   --> $DIR/issue-24424.rs:4:57
    |
 LL | impl <'l0, 'l1, T0> Trait1<'l0, T0> for bool where T0 : Trait0<'l0>, T0 : Trait0<'l1> {}
-   |                                                         ^^^^^^^^^^^ cannot infer type for type parameter `T0`
+   |                                                         ^^^^^^^^^^^
    |
    = note: cannot satisfy `T0: Trait0<'l0>`
 

--- a/src/test/ui/issues/issue-51116.rs
+++ b/src/test/ui/issues/issue-51116.rs
@@ -5,7 +5,6 @@ fn main() {
             *tile = 0;
             //~^ ERROR type annotations needed
             //~| NOTE cannot infer type
-            //~| NOTE type must be known at this point
         }
     }
 

--- a/src/test/ui/issues/issue-51116.stderr
+++ b/src/test/ui/issues/issue-51116.stderr
@@ -3,8 +3,6 @@ error[E0282]: type annotations needed
    |
 LL |             *tile = 0;
    |             ^^^^^ cannot infer type
-   |
-   = note: type must be known at this point
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-69455.stderr
+++ b/src/test/ui/issues/issue-69455.stderr
@@ -14,7 +14,9 @@ error[E0283]: type annotations needed
   --> $DIR/issue-69455.rs:29:41
    |
 LL |     println!("{}", 23u64.test(xs.iter().sum()));
-   |                                         ^^^ cannot infer type of the type parameter `S` declared on the associated function `sum`
+   |                          ----           ^^^ cannot infer type of the type parameter `S` declared on the associated function `sum`
+   |                          |
+   |                          type must be known at this point
    |
 note: multiple `impl`s satisfying `u64: Test<_>` found
   --> $DIR/issue-69455.rs:11:1

--- a/src/test/ui/issues/issue-69683.stderr
+++ b/src/test/ui/issues/issue-69683.stderr
@@ -1,8 +1,14 @@
-error[E0284]: type annotations needed: cannot satisfy `<u8 as Element<_>>::Array == [u8; 3]`
+error[E0284]: type annotations needed
   --> $DIR/issue-69683.rs:30:10
    |
 LL |     0u16.foo(b);
-   |          ^^^ cannot satisfy `<u8 as Element<_>>::Array == [u8; 3]`
+   |          ^^^
+   |
+   = note: cannot satisfy `<u8 as Element<_>>::Array == [u8; 3]`
+help: try using a fully qualified path to specify the expected types
+   |
+LL |     <u16 as Foo<I>>::foo(0u16, b);
+   |     +++++++++++++++++++++    ~
 
 error[E0283]: type annotations needed
   --> $DIR/issue-69683.rs:30:10

--- a/src/test/ui/issues/issue-71584.stderr
+++ b/src/test/ui/issues/issue-71584.stderr
@@ -1,8 +1,16 @@
-error[E0284]: type annotations needed: cannot satisfy `<u64 as Rem<_>>::Output == u64`
-  --> $DIR/issue-71584.rs:4:11
+error[E0284]: type annotations needed
+  --> $DIR/issue-71584.rs:4:15
    |
 LL |     d = d % n.into();
-   |           ^ cannot satisfy `<u64 as Rem<_>>::Output == u64`
+   |           -   ^^^^
+   |           |
+   |           type must be known at this point
+   |
+   = note: cannot satisfy `<u64 as Rem<_>>::Output == u64`
+help: try using a fully qualified path to specify the expected types
+   |
+LL |     d = d % <u32 as Into<T>>::into(n);
+   |             +++++++++++++++++++++++ ~
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-7813.stderr
+++ b/src/test/ui/issues/issue-7813.stderr
@@ -2,7 +2,7 @@ error[E0282]: type annotations needed for `&[_; 0]`
   --> $DIR/issue-7813.rs:2:9
    |
 LL |     let v = &[];
-   |         ^
+   |         ^   --- type must be known at this point
    |
 help: consider giving `v` an explicit type, where the placeholders `_` are specified
    |

--- a/src/test/ui/lazy-type-alias-impl-trait/branches3.stderr
+++ b/src/test/ui/lazy-type-alias-impl-trait/branches3.stderr
@@ -2,9 +2,8 @@ error[E0282]: type annotations needed
   --> $DIR/branches3.rs:8:10
    |
 LL |         |s| s.len()
-   |          ^
+   |          ^  - type must be known at this point
    |
-   = note: type must be known at this point
 help: consider giving this closure parameter an explicit type
    |
 LL |         |s: _| s.len()
@@ -14,9 +13,8 @@ error[E0282]: type annotations needed
   --> $DIR/branches3.rs:15:10
    |
 LL |         |s| s.len()
-   |          ^
+   |          ^  - type must be known at this point
    |
-   = note: type must be known at this point
 help: consider giving this closure parameter an explicit type
    |
 LL |         |s: _| s.len()
@@ -26,9 +24,8 @@ error[E0282]: type annotations needed
   --> $DIR/branches3.rs:23:10
    |
 LL |         |s| s.len()
-   |          ^
+   |          ^  - type must be known at this point
    |
-   = note: type must be known at this point
 help: consider giving this closure parameter an explicit type
    |
 LL |         |s: _| s.len()
@@ -38,9 +35,8 @@ error[E0282]: type annotations needed
   --> $DIR/branches3.rs:30:10
    |
 LL |         |s| s.len()
-   |          ^
+   |          ^  - type must be known at this point
    |
-   = note: type must be known at this point
 help: consider giving this closure parameter an explicit type
    |
 LL |         |s: _| s.len()

--- a/src/test/ui/lifetimes/issue-34979.stderr
+++ b/src/test/ui/lifetimes/issue-34979.stderr
@@ -1,8 +1,8 @@
-error[E0283]: type annotations needed
+error[E0283]: type annotations needed: cannot satisfy `&'a (): Foo`
   --> $DIR/issue-34979.rs:6:13
    |
 LL |     &'a (): Foo,
-   |             ^^^ cannot infer type for reference `&'a ()`
+   |             ^^^
    |
    = note: cannot satisfy `&'a (): Foo`
 

--- a/src/test/ui/marker_trait_attr/region-overlap.stderr
+++ b/src/test/ui/marker_trait_attr/region-overlap.stderr
@@ -1,8 +1,8 @@
-error[E0283]: type annotations needed
+error[E0283]: type annotations needed: cannot satisfy `(&'static (), &'a ()): A`
   --> $DIR/region-overlap.rs:5:10
    |
 LL | impl<'a> A for (&'static (), &'a ()) {}
-   |          ^ cannot infer type for tuple `(&'static (), &'a ())`
+   |          ^
    |
 note: multiple `impl`s satisfying `(&'static (), &'a ()): A` found
   --> $DIR/region-overlap.rs:5:1
@@ -12,11 +12,11 @@ LL | impl<'a> A for (&'static (), &'a ()) {}
 LL | impl<'a> A for (&'a (), &'static ()) {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0283]: type annotations needed
+error[E0283]: type annotations needed: cannot satisfy `(&'a (), &'static ()): A`
   --> $DIR/region-overlap.rs:6:10
    |
 LL | impl<'a> A for (&'a (), &'static ()) {}
-   |          ^ cannot infer type for tuple `(&'a (), &'static ())`
+   |          ^
    |
 note: multiple `impl`s satisfying `(&'a (), &'static ()): A` found
   --> $DIR/region-overlap.rs:5:1

--- a/src/test/ui/pattern/issue-88074-pat-range-type-inference-err.stderr
+++ b/src/test/ui/pattern/issue-88074-pat-range-type-inference-err.stderr
@@ -12,8 +12,6 @@ error[E0282]: type annotations needed
    |
 LL |         Zero::ZERO ..= Zero::ZERO => {},
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type
-   |
-   = note: type must be known at this point
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/pattern/pat-tuple-bad-type.stderr
+++ b/src/test/ui/pattern/pat-tuple-bad-type.stderr
@@ -3,8 +3,10 @@ error[E0282]: type annotations needed
    |
 LL |     let x;
    |         ^
+...
+LL |         (..) => {}
+   |         ---- type must be known at this point
    |
-   = note: type must be known at this point
 help: consider giving `x` an explicit type
    |
 LL |     let x: _;

--- a/src/test/ui/span/issue-42234-unknown-receiver-type.full.stderr
+++ b/src/test/ui/span/issue-42234-unknown-receiver-type.full.stderr
@@ -3,8 +3,9 @@ error[E0282]: type annotations needed
    |
 LL |     let x: Option<_> = None;
    |                        ^^^^ cannot infer type of the type parameter `T` declared on the enum `Option`
+LL |     x.unwrap().method_that_could_exist_on_some_type();
+   |     ---------- type must be known at this point
    |
-   = note: type must be known at this point
 help: consider specifying the generic argument
    |
 LL |     let x: Option<_> = None::<T>;
@@ -16,7 +17,6 @@ error[E0282]: type annotations needed
 LL |         .sum::<_>()
    |          ^^^ cannot infer type of the type parameter `S` declared on the associated function `sum`
    |
-   = note: type must be known at this point
 help: consider specifying the generic argument
    |
 LL |         .sum::<_>()

--- a/src/test/ui/span/issue-42234-unknown-receiver-type.generic_arg.stderr
+++ b/src/test/ui/span/issue-42234-unknown-receiver-type.generic_arg.stderr
@@ -3,8 +3,9 @@ error[E0282]: type annotations needed
    |
 LL |     let x: Option<_> = None;
    |                        ^^^^ cannot infer type of the type parameter `T` declared on the enum `Option`
+LL |     x.unwrap().method_that_could_exist_on_some_type();
+   |     ---------- type must be known at this point
    |
-   = note: type must be known at this point
 help: consider specifying the generic argument
    |
 LL |     let x: Option<_> = None::<T>;
@@ -16,7 +17,6 @@ error[E0282]: type annotations needed
 LL |         .sum::<_>()
    |          ^^^ cannot infer type of the type parameter `S` declared on the associated function `sum`
    |
-   = note: type must be known at this point
 help: consider specifying the generic argument
    |
 LL |         .sum::<S>()

--- a/src/test/ui/span/method-and-field-eager-resolution.stderr
+++ b/src/test/ui/span/method-and-field-eager-resolution.stderr
@@ -3,8 +3,10 @@ error[E0282]: type annotations needed
    |
 LL |     let mut x = Default::default();
    |         ^^^^^
+LL |
+LL |     x.0;
+   |     - type must be known at this point
    |
-   = note: type must be known at this point
 help: consider giving `x` an explicit type
    |
 LL |     let mut x: _ = Default::default();
@@ -15,8 +17,10 @@ error[E0282]: type annotations needed
    |
 LL |     let mut x = Default::default();
    |         ^^^^^
+LL |
+LL |     x[0];
+   |     - type must be known at this point
    |
-   = note: type must be known at this point
 help: consider giving `x` an explicit type
    |
 LL |     let mut x: _ = Default::default();

--- a/src/test/ui/span/type-annotations-needed-expr.stderr
+++ b/src/test/ui/span/type-annotations-needed-expr.stderr
@@ -4,7 +4,6 @@ error[E0282]: type annotations needed
 LL |     let _ = (vec![1,2,3]).into_iter().sum() as f64;
    |                                       ^^^ cannot infer type of the type parameter `S` declared on the associated function `sum`
    |
-   = note: type must be known at this point
 help: consider specifying the generic argument
    |
 LL |     let _ = (vec![1,2,3]).into_iter().sum::<S>() as f64;

--- a/src/test/ui/suggestions/suggest-closure-return-type-1.stderr
+++ b/src/test/ui/suggestions/suggest-closure-return-type-1.stderr
@@ -2,7 +2,7 @@ error[E0282]: type annotations needed for `[_; 0]`
   --> $DIR/suggest-closure-return-type-1.rs:4:18
    |
 LL |     unbound_drop(|| -> _ { [] });
-   |                  ^^^^^^^
+   |                  ^^^^^^^   -- type must be known at this point
    |
 help: try giving this closure an explicit return type
    |

--- a/src/test/ui/suggestions/suggest-closure-return-type-2.stderr
+++ b/src/test/ui/suggestions/suggest-closure-return-type-2.stderr
@@ -2,7 +2,7 @@ error[E0282]: type annotations needed for `[_; 0]`
   --> $DIR/suggest-closure-return-type-2.rs:4:18
    |
 LL |     unbound_drop(|| { [] })
-   |                  ^^
+   |                  ^^   -- type must be known at this point
    |
 help: try giving this closure an explicit return type
    |

--- a/src/test/ui/suggestions/suggest-closure-return-type-3.stderr
+++ b/src/test/ui/suggestions/suggest-closure-return-type-3.stderr
@@ -2,7 +2,7 @@ error[E0282]: type annotations needed for `[_; 0]`
   --> $DIR/suggest-closure-return-type-3.rs:4:18
    |
 LL |     unbound_drop(|| []);
-   |                  ^^
+   |                  ^^ -- type must be known at this point
    |
 help: try giving this closure an explicit return type
    |

--- a/src/test/ui/traits/issue-77982.stderr
+++ b/src/test/ui/traits/issue-77982.stderr
@@ -26,7 +26,9 @@ error[E0283]: type annotations needed
   --> $DIR/issue-77982.rs:8:10
    |
 LL |     opts.get(opt.as_ref());
-   |          ^^^ cannot infer type of the type parameter `Q` declared on the associated function `get`
+   |          ^^^     ------ type must be known at this point
+   |          |
+   |          cannot infer type of the type parameter `Q` declared on the associated function `get`
    |
    = note: multiple `impl`s satisfying `String: AsRef<_>` found in the following crates: `alloc`, `std`:
            - impl AsRef<OsStr> for String;
@@ -42,7 +44,9 @@ error[E0283]: type annotations needed
   --> $DIR/issue-77982.rs:13:59
    |
 LL |     let ips: Vec<_> = (0..100_000).map(|_| u32::from(0u32.into())).collect();
-   |                                                           ^^^^
+   |                                            ---------      ^^^^
+   |                                            |
+   |                                            type must be known at this point
    |
    = note: multiple `impl`s satisfying `u32: From<_>` found in the following crates: `core`, `std`:
            - impl From<Ipv4Addr> for u32;
@@ -59,7 +63,7 @@ error[E0283]: type annotations needed for `Box<T>`
   --> $DIR/issue-77982.rs:36:9
    |
 LL |     let _ = ().foo();
-   |         ^
+   |         ^      --- type must be known at this point
    |
 note: multiple `impl`s satisfying `(): Foo<'_, _>` found
   --> $DIR/issue-77982.rs:29:1
@@ -77,7 +81,7 @@ error[E0283]: type annotations needed for `Box<T>`
   --> $DIR/issue-77982.rs:40:9
    |
 LL |     let _ = (&()).bar();
-   |         ^
+   |         ^         --- type must be known at this point
    |
 note: multiple `impl`s satisfying `&(): Bar<'_, _>` found
   --> $DIR/issue-77982.rs:32:1

--- a/src/test/ui/traits/issue-85735.rs
+++ b/src/test/ui/traits/issue-85735.rs
@@ -5,7 +5,7 @@ trait Foo {}
 impl<'a, 'b, T> Foo for T
 where
     T: FnMut(&'a ()),
-    //~^ ERROR: type annotations needed [E0283]
+    //~^ ERROR: type annotations needed
     T: FnMut(&'b ()),
 {
 }

--- a/src/test/ui/traits/issue-85735.stderr
+++ b/src/test/ui/traits/issue-85735.stderr
@@ -1,8 +1,8 @@
-error[E0283]: type annotations needed
+error[E0283]: type annotations needed: cannot satisfy `T: FnMut<(&'a (),)>`
   --> $DIR/issue-85735.rs:7:8
    |
 LL |     T: FnMut(&'a ()),
-   |        ^^^^^^^^^^^^^ cannot infer type for type parameter `T`
+   |        ^^^^^^^^^^^^^
    |
    = note: cannot satisfy `T: FnMut<(&'a (),)>`
 

--- a/src/test/ui/type-alias-impl-trait/closures_in_branches.stderr
+++ b/src/test/ui/type-alias-impl-trait/closures_in_branches.stderr
@@ -14,9 +14,8 @@ error[E0282]: type annotations needed
   --> $DIR/closures_in_branches.rs:21:10
    |
 LL |         |x| x.len()
-   |          ^
+   |          ^  - type must be known at this point
    |
-   = note: type must be known at this point
 help: consider giving this closure parameter an explicit type
    |
 LL |         |x: _| x.len()

--- a/src/test/ui/type-alias-impl-trait/closures_in_branches.stderr
+++ b/src/test/ui/type-alias-impl-trait/closures_in_branches.stderr
@@ -2,9 +2,8 @@ error[E0282]: type annotations needed
   --> $DIR/closures_in_branches.rs:7:10
    |
 LL |         |x| x.len()
-   |          ^
+   |          ^  - type must be known at this point
    |
-   = note: type must be known at this point
 help: consider giving this closure parameter an explicit type
    |
 LL |         |x: _| x.len()

--- a/src/test/ui/type-alias-impl-trait/fallback.stderr
+++ b/src/test/ui/type-alias-impl-trait/fallback.stderr
@@ -1,6 +1,8 @@
 error[E0283]: type annotations needed
   --> $DIR/fallback.rs:24:5
    |
+LL | fn unconstrained_foo() -> Wrapper<Foo> {
+   |                           ------------ type must be known at this point
 LL |     Wrapper::Second
    |     ^^^^^^^^^^^^^^^ cannot infer type of the type parameter `T` declared on the enum `Wrapper`
    |

--- a/src/test/ui/type/type-check/cannot_infer_local_or_array.stderr
+++ b/src/test/ui/type/type-check/cannot_infer_local_or_array.stderr
@@ -2,7 +2,7 @@ error[E0282]: type annotations needed for `[_; 0]`
   --> $DIR/cannot_infer_local_or_array.rs:2:9
    |
 LL |     let x = [];
-   |         ^
+   |         ^   -- type must be known at this point
    |
 help: consider giving `x` an explicit type, where the placeholders `_` are specified
    |

--- a/src/test/ui/type/type-check/issue-40294.stderr
+++ b/src/test/ui/type/type-check/issue-40294.stderr
@@ -1,8 +1,8 @@
-error[E0283]: type annotations needed
+error[E0283]: type annotations needed: cannot satisfy `&'a T: Foo`
   --> $DIR/issue-40294.rs:6:19
    |
 LL |     where &'a T : Foo,
-   |                   ^^^ cannot infer type for reference `&'a T`
+   |                   ^^^
    |
    = note: cannot satisfy `&'a T: Foo`
 

--- a/src/test/ui/typeck/issue-65611.stderr
+++ b/src/test/ui/typeck/issue-65611.stderr
@@ -3,8 +3,6 @@ error[E0282]: type annotations needed
    |
 LL |     let x = buffer.last().unwrap().0.clone();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type for type parameter `T`
-   |
-   = note: type must be known at this point
 
 error[E0609]: no field `0` on type `&_`
   --> $DIR/issue-65611.rs:59:36

--- a/src/test/ui/unboxed-closures/unboxed-closures-failed-recursive-fn-2.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closures-failed-recursive-fn-2.stderr
@@ -3,8 +3,10 @@ error[E0282]: type annotations needed for `Option<T>`
    |
 LL |     let mut closure0 = None;
    |         ^^^^^^^^^^^^
+...
+LL |                         return c();
+   |                                --- type must be known at this point
    |
-   = note: type must be known at this point
 help: consider giving `closure0` an explicit type, where the placeholders `_` are specified
    |
 LL |     let mut closure0: Option<T> = None;


### PR DESCRIPTION
- Properly point out point location where "type must be known at this point", or else omit the note if it's not associated with a useful span.
- Fix up some type ambiguity diagnostics, errors shouldn't say "cannot infer type for reference `&'a ()`" when the given type has no inference variables.