### PR TITLE
Fix data race in `thread::scope()`

### DIFF
--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -291,6 +291,7 @@
 #![feature(std_internals)]
 #![feature(str_internals)]
 #![feature(strict_provenance)]
+#![feature(sync_unsafe_cell)]
 //
 // Library features (alloc):
 #![feature(alloc_layout_extra)]

--- a/library/std/src/thread/scoped.rs
+++ b/library/std/src/thread/scoped.rs
@@ -72,8 +72,8 @@ impl ScopeData {
             //   - it can spuriously unpark / wake up, **so `self` can no longer be used**, even
             //     before we, ourselves, unpark. Hence why we've cloned the `main_thread`'s handle.
             //   - no matter how it unparks, `*self` may be deallocated before this function
-            //     returns, so all of `*self` data, **including `main_thread`**, must be interiorly
-            //     mutable. See https://github.com/rust-lang/rust/issues/55005 for more info.
+            //     returns, so all of `*self` fields, *including `main_thread`*, must be interiorly
+            //     mutable. See https://github.com/rust-lang/rust/pull/98017 for more info.
             main_thread.unpark();
         }
     }

--- a/library/std/src/thread/scoped.rs
+++ b/library/std/src/thread/scoped.rs
@@ -41,7 +41,10 @@ pub struct ScopedJoinHandle<'scope, T>(JoinInner<'scope, T>);
 pub(super) struct ScopeData {
     num_running_threads: AtomicUsize,
     a_thread_panicked: AtomicBool,
-    main_thread: UnsafeCell<Thread>,
+    // SAFETY: `ScopeData` is `&`-shared by all the scoped threads, with no
+    // mutation whatsoever, except when `num_running_threads` drops down to `0`,
+    // which is when the main thread's `scope()` may deallocate this data.
+    main_thread: crate::cell::SyncUnsafeCell<Thread>,
 }
 
 impl ScopeData {


### PR DESCRIPTION
Fixes #98498, based on @RalfJung's suggestions (taking the non-`Arc` approach; for an `Arc`-based alternative, see #98503).

r? @m-ou-se 