### PR TITLE
Walk nested abstract consts

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/const_evaluatable.rs
+++ b/compiler/rustc_trait_selection/src/traits/const_evaluatable.rs
@@ -668,15 +668,9 @@ where
         ct: AbstractConst<'tcx>,
         f: &mut dyn FnMut(AbstractConst<'tcx>) -> ControlFlow<R>,
     ) -> ControlFlow<R> {
-        let root = ct.root(tcx);
-        if let Node::Leaf(leaf) = root {
-            if let Ok(Some(ac)) = AbstractConst::from_const(tcx, leaf) {
-                return recurse(tcx, ac, f);
-            }
-            return ControlFlow::CONTINUE;
-        };
         f(ct)?;
-        match ct.root(tcx) {
+        let root = ct.root(tcx);
+        match root {
             Node::Leaf(_) => ControlFlow::CONTINUE,
             Node::Binop(_, l, r) => {
                 recurse(tcx, ct.subtree(l), f)?;

--- a/compiler/rustc_trait_selection/src/traits/const_evaluatable.rs
+++ b/compiler/rustc_trait_selection/src/traits/const_evaluatable.rs
@@ -672,7 +672,13 @@ where
         let root = ct.root(tcx);
         debug!(?root);
         match root {
-            Node::Leaf(_) => ControlFlow::CONTINUE,
+            Node::Leaf(ct) => {
+                if let Ok(Some(ac)) = AbstractConst::from_const(tcx, ct) {
+                    recurse(tcx, ac, f)
+                } else {
+                    ControlFlow::CONTINUE
+                }
+            }
             Node::Binop(_, l, r) => {
                 recurse(tcx, ct.subtree(l), f)?;
                 recurse(tcx, ct.subtree(r), f)

--- a/src/test/ui/const-generics/recur-walk.rs
+++ b/src/test/ui/const-generics/recur-walk.rs
@@ -18,7 +18,7 @@ fn baz<const A: usize>(a: [u32; A]) -> [u32; A + 1] {
 }
 
 fn blah<T>() {
-    baz::<{1 + 2}>([123]);
+    baz::<{1 + 2}>([123, 231, 312]);
 }
 
 fn main() {}

--- a/src/test/ui/const-generics/recur-walk.rs
+++ b/src/test/ui/const-generics/recur-walk.rs
@@ -13,4 +13,12 @@ fn bar<const N: usize>() {
     foo::<LEN>([123]);
 }
 
+fn baz<const A: usize>(a: [u32; A]) -> [u32; A + 1] {
+    panic!()
+}
+
+fn blah<T>() {
+    baz::<{1 + 2}>([123]);
+}
+
 fn main() {}

--- a/src/test/ui/const-generics/recur-walk.rs
+++ b/src/test/ui/const-generics/recur-walk.rs
@@ -1,0 +1,16 @@
+// check-pass
+#![allow(incomplete_features)]
+#![feature(generic_const_exprs)]
+#![feature(associated_type_defaults)]
+
+fn foo<const A: usize>(a: [u32; A]) -> [u32; A + 1] {
+    panic!()
+}
+
+const LEN: usize = 1;
+
+fn bar<const N: usize>() {
+    foo::<LEN>([123]);
+}
+
+fn main() {}


### PR DESCRIPTION
Walks nested abstract consts, rather than stopping at leaves as was the previous behavior.

r? @lcnr

Also, I'm not sure why I had to change the other line, but it didn't seem to compile without changing it.