### PR TITLE
`std::thread` support for the Nintendo 3DS

### DIFF
--- a/library/std/src/os/horizon/mod.rs
+++ b/library/std/src/os/horizon/mod.rs
@@ -4,3 +4,4 @@
 
 pub mod fs;
 pub(crate) mod raw;
+pub mod thread;

--- a/library/std/src/os/horizon/thread.rs
+++ b/library/std/src/os/horizon/thread.rs
@@ -32,13 +32,14 @@ pub trait BuilderExt: Sized {
     /// usually has a priority of 0x30, but not always.
     fn priority(self, priority: i32) -> Self;
 
-    /// Sets the ID of the processor the thread should be run on. Threads on the 3DS are only
-    /// preemptive if they are on the system core. Otherwise they are cooperative (must yield to let
-    /// other threads run).
+    /// Sets the ID of the processor the thread should be run on. Threads on the
+    /// 3DS are only preemptive if they are on the system core. Otherwise they
+    /// are cooperative (must yield to let other threads run).
     ///
     /// Processor IDs are labeled starting from 0. On Old3DS it must be <2, and
     /// on New3DS it must be <4. Pass -1 to execute the thread on all CPUs and
-    /// -2 to execute the thread on the default CPU (set in the application's Exheader).
+    /// -2 to execute the thread on the default CPU (set in the application's
+    /// Exheader).
     ///
     /// * Processor #0 is the application core. It is always possible to create
     ///   a thread on this core.
@@ -74,4 +75,14 @@ pub fn current_priority() -> i32 {
     assert_eq!(result, 0);
 
     sched_param.sched_priority
+}
+
+/// Get the current thread's processor ID.
+///
+/// * Processor #0 is the application core.
+/// * Processor #1 is the system core.
+/// * Processor #2 is New3DS exclusive.
+/// * Processor #3 is New3DS exclusive.
+pub fn current_processor() -> i32 {
+    unsafe { libc::pthread_getprocessorid_np() }
 }

--- a/library/std/src/os/horizon/thread.rs
+++ b/library/std/src/os/horizon/thread.rs
@@ -1,0 +1,77 @@
+//! Nintendo 3DS-specific extensions to primitives in the [`std::thread`] module.
+//!
+//! All 3DS models have at least two CPU cores available to spawn threads on:
+//! The application core (appcore) and the system core (syscore). The New 3DS
+//! has an additional two cores, the first of which can also run user-created
+//! threads.
+//!
+//! Threads spawned on the appcore are cooperative rather than preemptive. This
+//! means that threads must explicitly yield control to other threads (whether
+//! via synchronization primitives or explicit calls to `yield_now`) when they
+//! are not actively performing work. Failure to do so may result in control
+//! flow being stuck in an inactive thread while the other threads are powerless
+//! to continue their work.
+//!
+//! However, it is possible to spawn one fully preemptive thread on the syscore
+//! by using a service call to reserve a slice of time for a thread to run.
+//! Attempting to run more than one thread at a time on the syscore will result
+//! in an error.
+//!
+//! [`std::thread`]: crate::thread
+
+#![unstable(feature = "horizon_thread_ext", issue = "none")]
+
+/// Extensions on [`std::thread::Builder`] for the Nintendo 3DS.
+///
+/// [`std::thread::Builder`]: crate::thread::Builder
+pub trait BuilderExt: Sized {
+    /// Sets the priority level for the new thread.
+    ///
+    /// Low values gives the thread higher priority. For userland apps, this has
+    /// to be within the range of 0x18 to 0x3F inclusive. The main thread
+    /// usually has a priority of 0x30, but not always.
+    fn priority(self, priority: i32) -> Self;
+
+    /// Sets the ID of the processor the thread should be run on. Threads on the 3DS are only
+    /// preemptive if they are on the system core. Otherwise they are cooperative (must yield to let
+    /// other threads run).
+    ///
+    /// Processor IDs are labeled starting from 0. On Old3DS it must be <2, and
+    /// on New3DS it must be <4. Pass -1 to execute the thread on all CPUs and
+    /// -2 to execute the thread on the default CPU (set in the application's Exheader).
+    ///
+    /// * Processor #0 is the application core. It is always possible to create
+    ///   a thread on this core.
+    /// * Processor #1 is the system core. If the CPU time limit is set, it is
+    ///   possible to create a single thread on this core.
+    /// * Processor #2 is New3DS exclusive. Normal applications can create
+    ///   threads on this core only if the built application has proper external setup.
+    /// * Processor #3 is New3DS exclusive. Normal applications cannot create
+    ///   threads on this core.
+    fn processor_id(self, processor_id: i32) -> Self;
+}
+
+impl BuilderExt for crate::thread::Builder {
+    fn priority(mut self, priority: i32) -> Self {
+        self.native_options.priority = Some(priority);
+        self
+    }
+
+    fn processor_id(mut self, processor_id: i32) -> Self {
+        self.native_options.processor_id = Some(processor_id);
+        self
+    }
+}
+
+/// Get the current thread's priority level. Lower values correspond to higher
+/// priority levels.
+pub fn current_priority() -> i32 {
+    let thread_id = unsafe { libc::pthread_self() };
+    let mut policy = 0;
+    let mut sched_param = libc::sched_param { sched_priority: 0 };
+
+    let result = unsafe { libc::pthread_getschedparam(thread_id, &mut policy, &mut sched_param) };
+    assert_eq!(result, 0);
+
+    sched_param.sched_priority
+}

--- a/library/std/src/os/horizon/thread.rs
+++ b/library/std/src/os/horizon/thread.rs
@@ -21,10 +21,15 @@
 
 #![unstable(feature = "horizon_thread_ext", issue = "none")]
 
+use crate::sealed::Sealed;
+
 /// Extensions on [`std::thread::Builder`] for the Nintendo 3DS.
 ///
+/// This trait is sealed: it cannot be implemented outside the standard library.
+/// This is so that future additional methods are not breaking changes.
+///
 /// [`std::thread::Builder`]: crate::thread::Builder
-pub trait BuilderExt: Sized {
+pub trait BuilderExt: Sized + Sealed {
     /// Sets the priority level for the new thread.
     ///
     /// Low values gives the thread higher priority. For userland apps, this has

--- a/library/std/src/sys/hermit/thread.rs
+++ b/library/std/src/sys/hermit/thread.rs
@@ -101,7 +101,7 @@ impl Thread {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct BuilderOptions;
 
 pub fn available_parallelism() -> io::Result<NonZeroUsize> {

--- a/library/std/src/sys/hermit/thread.rs
+++ b/library/std/src/sys/hermit/thread.rs
@@ -55,7 +55,11 @@ impl Thread {
         }
     }
 
-    pub unsafe fn new(stack: usize, p: Box<dyn FnOnce()>) -> io::Result<Thread> {
+    pub unsafe fn new(
+        stack: usize,
+        p: Box<dyn FnOnce()>,
+        _native_options: BuilderOptions,
+    ) -> io::Result<Thread> {
         Thread::new_with_coreid(stack, p, -1 /* = no specific core */)
     }
 
@@ -96,6 +100,9 @@ impl Thread {
         id
     }
 }
+
+#[derive(Debug)]
+pub struct BuilderOptions;
 
 pub fn available_parallelism() -> io::Result<NonZeroUsize> {
     unsupported()

--- a/library/std/src/sys/itron/thread.rs
+++ b/library/std/src/sys/itron/thread.rs
@@ -292,7 +292,7 @@ impl Drop for Thread {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct BuilderOptions;
 
 pub mod guard {

--- a/library/std/src/sys/itron/thread.rs
+++ b/library/std/src/sys/itron/thread.rs
@@ -83,7 +83,11 @@ impl Thread {
     /// # Safety
     ///
     /// See `thread::Builder::spawn_unchecked` for safety requirements.
-    pub unsafe fn new(stack: usize, p: Box<dyn FnOnce()>) -> io::Result<Thread> {
+    pub unsafe fn new(
+        stack: usize,
+        p: Box<dyn FnOnce()>,
+        _native_options: BuilderOptions,
+    ) -> io::Result<Thread> {
         let inner = Box::new(ThreadInner {
             start: UnsafeCell::new(ManuallyDrop::new(p)),
             lifecycle: AtomicUsize::new(LIFECYCLE_INIT),
@@ -287,6 +291,9 @@ impl Drop for Thread {
         }
     }
 }
+
+#[derive(Debug)]
+pub struct BuilderOptions;
 
 pub mod guard {
     pub type Guard = !;

--- a/library/std/src/sys/sgx/thread.rs
+++ b/library/std/src/sys/sgx/thread.rs
@@ -141,7 +141,7 @@ impl Thread {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct BuilderOptions;
 
 pub fn available_parallelism() -> io::Result<NonZeroUsize> {

--- a/library/std/src/sys/sgx/thread.rs
+++ b/library/std/src/sys/sgx/thread.rs
@@ -104,7 +104,11 @@ pub mod wait_notify {
 
 impl Thread {
     // unsafe: see thread::Builder::spawn_unchecked for safety requirements
-    pub unsafe fn new(_stack: usize, p: Box<dyn FnOnce()>) -> io::Result<Thread> {
+    pub unsafe fn new(
+        _stack: usize,
+        p: Box<dyn FnOnce()>,
+        _native_options: BuilderOptions,
+    ) -> io::Result<Thread> {
         let mut queue_lock = task_queue::lock();
         unsafe { usercalls::launch_thread()? };
         let (task, handle) = task_queue::Task::new(p);
@@ -136,6 +140,9 @@ impl Thread {
         self.0.wait();
     }
 }
+
+#[derive(Debug)]
+pub struct BuilderOptions;
 
 pub fn available_parallelism() -> io::Result<NonZeroUsize> {
     unsupported()

--- a/library/std/src/sys/unix/thread.rs
+++ b/library/std/src/sys/unix/thread.rs
@@ -48,7 +48,12 @@ unsafe impl Sync for Thread {}
 
 impl Thread {
     // unsafe: see thread::Builder::spawn_unchecked for safety requirements
-    pub unsafe fn new(stack: usize, p: Box<dyn FnOnce()>) -> io::Result<Thread> {
+    pub unsafe fn new(
+        stack: usize,
+        p: Box<dyn FnOnce()>,
+        #[cfg(target_os = "horizon")] priority: i32,
+        #[cfg(target_os = "horizon")] affinity: i32,
+    ) -> io::Result<Thread> {
         let p = Box::into_raw(box p);
         let mut native: libc::pthread_t = mem::zeroed();
         let mut attr: libc::pthread_attr_t = mem::zeroed();
@@ -82,6 +87,13 @@ impl Thread {
                     assert_eq!(libc::pthread_attr_setstacksize(&mut attr, stack_size), 0);
                 }
             };
+        }
+
+        #[cfg(target_os = "horizon")]
+        {
+            // Set the priority and affinity values
+            assert_eq!(libc::pthread_attr_setpriority(&mut attr, priority), 0);
+            assert_eq!(libc::pthread_attr_setaffinity(&mut attr, affinity), 0);
         }
 
         let ret = libc::pthread_create(&mut native, &attr, thread_start, p as *mut _);
@@ -200,7 +212,8 @@ impl Thread {
         target_os = "l4re",
         target_os = "emscripten",
         target_os = "redox",
-        target_os = "vxworks"
+        target_os = "vxworks",
+        target_os = "horizon"
     ))]
     pub fn set_name(_name: &CStr) {
         // Newlib, Emscripten, and VxWorks have no way to set a thread name.
@@ -269,6 +282,12 @@ impl Drop for Thread {
         let ret = unsafe { libc::pthread_detach(self.id) };
         debug_assert_eq!(ret, 0);
     }
+}
+
+/// Returns the current thread's priority value.
+#[cfg(target_os = "horizon")]
+pub(crate) fn current_priority() -> i32 {
+    unsafe { libc::pthread_getpriority() }
 }
 
 pub fn available_parallelism() -> io::Result<NonZeroUsize> {

--- a/library/std/src/sys/unsupported/thread.rs
+++ b/library/std/src/sys/unsupported/thread.rs
@@ -35,7 +35,7 @@ impl Thread {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct BuilderOptions;
 
 pub fn available_parallelism() -> io::Result<NonZeroUsize> {

--- a/library/std/src/sys/unsupported/thread.rs
+++ b/library/std/src/sys/unsupported/thread.rs
@@ -10,7 +10,11 @@ pub const DEFAULT_MIN_STACK_SIZE: usize = 4096;
 
 impl Thread {
     // unsafe: see thread::Builder::spawn_unchecked for safety requirements
-    pub unsafe fn new(_stack: usize, _p: Box<dyn FnOnce()>) -> io::Result<Thread> {
+    pub unsafe fn new(
+        _stack: usize,
+        _p: Box<dyn FnOnce()>,
+        _native_options: BuilderOptions,
+    ) -> io::Result<Thread> {
         unsupported()
     }
 
@@ -30,6 +34,9 @@ impl Thread {
         self.0
     }
 }
+
+#[derive(Debug)]
+pub struct BuilderOptions;
 
 pub fn available_parallelism() -> io::Result<NonZeroUsize> {
     unsupported()

--- a/library/std/src/sys/wasi/thread.rs
+++ b/library/std/src/sys/wasi/thread.rs
@@ -70,7 +70,7 @@ impl Thread {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct BuilderOptions;
 
 pub fn available_parallelism() -> io::Result<NonZeroUsize> {

--- a/library/std/src/sys/wasi/thread.rs
+++ b/library/std/src/sys/wasi/thread.rs
@@ -13,7 +13,11 @@ pub const DEFAULT_MIN_STACK_SIZE: usize = 4096;
 
 impl Thread {
     // unsafe: see thread::Builder::spawn_unchecked for safety requirements
-    pub unsafe fn new(_stack: usize, _p: Box<dyn FnOnce()>) -> io::Result<Thread> {
+    pub unsafe fn new(
+        _stack: usize,
+        _p: Box<dyn FnOnce()>,
+        _native_options: BuilderOptions,
+    ) -> io::Result<Thread> {
         unsupported()
     }
 
@@ -65,6 +69,9 @@ impl Thread {
         self.0
     }
 }
+
+#[derive(Debug)]
+pub struct BuilderOptions;
 
 pub fn available_parallelism() -> io::Result<NonZeroUsize> {
     unsupported()

--- a/library/std/src/sys/wasm/atomics/thread.rs
+++ b/library/std/src/sys/wasm/atomics/thread.rs
@@ -44,7 +44,7 @@ impl Thread {
     pub fn join(self) {}
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct BuilderOptions;
 
 pub fn available_parallelism() -> io::Result<NonZeroUsize> {

--- a/library/std/src/sys/wasm/atomics/thread.rs
+++ b/library/std/src/sys/wasm/atomics/thread.rs
@@ -10,7 +10,11 @@ pub const DEFAULT_MIN_STACK_SIZE: usize = 4096;
 
 impl Thread {
     // unsafe: see thread::Builder::spawn_unchecked for safety requirements
-    pub unsafe fn new(_stack: usize, _p: Box<dyn FnOnce()>) -> io::Result<Thread> {
+    pub unsafe fn new(
+        _stack: usize,
+        _p: Box<dyn FnOnce()>,
+        _native_options: BuilderOptions,
+    ) -> io::Result<Thread> {
         unsupported()
     }
 
@@ -39,6 +43,9 @@ impl Thread {
 
     pub fn join(self) {}
 }
+
+#[derive(Debug)]
+pub struct BuilderOptions;
 
 pub fn available_parallelism() -> io::Result<NonZeroUsize> {
     unsupported()

--- a/library/std/src/sys/windows/thread.rs
+++ b/library/std/src/sys/windows/thread.rs
@@ -21,7 +21,11 @@ pub struct Thread {
 
 impl Thread {
     // unsafe: see thread::Builder::spawn_unchecked for safety requirements
-    pub unsafe fn new(stack: usize, p: Box<dyn FnOnce()>) -> io::Result<Thread> {
+    pub unsafe fn new(
+        stack: usize,
+        p: Box<dyn FnOnce()>,
+        _native_options: BuilderOptions,
+    ) -> io::Result<Thread> {
         let p = Box::into_raw(box p);
 
         // FIXME On UNIX, we guard against stack sizes that are too small but
@@ -97,6 +101,9 @@ impl Thread {
         self.handle
     }
 }
+
+#[derive(Debug)]
+pub struct BuilderOptions;
 
 pub fn available_parallelism() -> io::Result<NonZeroUsize> {
     let res = unsafe {

--- a/library/std/src/sys/windows/thread.rs
+++ b/library/std/src/sys/windows/thread.rs
@@ -102,7 +102,7 @@ impl Thread {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct BuilderOptions;
 
 pub fn available_parallelism() -> io::Result<NonZeroUsize> {

--- a/library/std/src/thread/mod.rs
+++ b/library/std/src/thread/mod.rs
@@ -272,6 +272,10 @@ pub struct Builder {
     pub(crate) native_options: imp::BuilderOptions,
 }
 
+/// Allows extension traits within `std`.
+#[unstable(feature = "sealed", issue = "none")]
+impl crate::sealed::Sealed for Builder {}
+
 impl Builder {
     /// Generates the base configuration for spawning a thread, from which
     /// configuration methods can be chained.

--- a/library/std/src/thread/mod.rs
+++ b/library/std/src/thread/mod.rs
@@ -267,12 +267,9 @@ pub struct Builder {
     name: Option<String>,
     // The size of the stack for the spawned thread in bytes
     stack_size: Option<usize>,
-    // The spawned thread's priority value
-    #[cfg(target_os = "horizon")]
-    priority: Option<i32>,
-    // The spawned thread's CPU affinity value
-    #[cfg(target_os = "horizon")]
-    affinity: Option<i32>,
+    // Other OS-specific fields. These can be set via extension traits, usually
+    // found in std::os.
+    pub(crate) native_options: imp::BuilderOptions,
 }
 
 impl Builder {
@@ -296,14 +293,7 @@ impl Builder {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn new() -> Builder {
-        Builder {
-            name: None,
-            stack_size: None,
-            #[cfg(target_os = "horizon")]
-            priority: None,
-            #[cfg(target_os = "horizon")]
-            affinity: None,
-        }
+        Builder { name: None, stack_size: None, native_options: imp::BuilderOptions::default() }
     }
 
     /// Names the thread-to-be. Currently the name is used for identification
@@ -356,58 +346,6 @@ impl Builder {
     #[stable(feature = "rust1", since = "1.0.0")]
     pub fn stack_size(mut self, size: usize) -> Builder {
         self.stack_size = Some(size);
-        self
-    }
-
-    /// **armv6k-nintendo-3ds specific!**
-    ///
-    /// Sets the priority level for the new thread.
-    ///
-    /// Low values gives the thread higher priority. For userland apps, this has
-    /// to be within the range of 0x18 to 0x3F inclusive. The main thread usually
-    /// has a priority of 0x30, but not always.
-    ///
-    /// # Examples
-    /// ```
-    /// use std::thread;
-    ///
-    /// let builder = thread::Builder::new().priority(0x30);
-    /// ```
-    #[cfg(target_os = "horizon")]
-    #[unstable(feature = "horizon_thread_ext", issue = "none")]
-    pub fn priority(mut self, priority: i32) -> Builder {
-        self.priority = Some(priority);
-        self
-    }
-
-    /// **armv6k-nintendo-3ds specific!**
-    ///
-    /// Sets the ID of the processor the thread should be run on.
-    ///
-    /// Processor IDs are labeled starting from 0. On Old3DS it must be <2, and
-    /// on New3DS it must be <4. Pass -1 to execute the thread on all CPUs and
-    /// -2 to execute the thread on the default CPU (set in the application's Exheader).
-    ///
-    /// *Processor #0 is the application core. It is always possible to create a thread on this
-    /// core.
-    /// *Processor #1 is the system core. If the CPU time limit is set, it is possible
-    /// to create a single thread on this core.
-    /// *Processor #2 is New3DS exclusive. Normal applications can create threads on
-    /// this core if the exheader kernel flags bitmask has 0x2000 set.
-    /// *Processor #3 is New3DS exclusive. Normal applications cannot create threads
-    /// on this core.
-    ///
-    /// # Examples
-    /// ```
-    /// use std::thread;
-    ///
-    /// // Spawn on the application core
-    /// let builder = thread::Builder::new().affinity(0);
-    /// ```
-    #[cfg(target_os = "horizon")]
-    #[unstable(feature = "horizon_thread_ext", issue = "none")]
-    pub fn affinity(mut self, affinity: i32) -> Builder {
-        self.affinity = Some(affinity);
         self
     }
 
@@ -537,16 +475,6 @@ impl Builder {
     {
         let stack_size = self.stack_size.unwrap_or_else(thread::min_stack);
 
-        // If no priority value is specified, spawn with the same
-        // priority as the parent thread
-        #[cfg(target_os = "horizon")]
-        let priority = self.priority.unwrap_or_else(imp::current_priority);
-
-        // If no affinity is specified, spawn on the default core (determined by
-        // the application's Exheader)
-        #[cfg(target_os = "horizon")]
-        let affinity = self.affinity.unwrap_or(-2);
-
         let my_thread = Thread::new(self.name.map(|name| {
             CString::new(name).expect("thread name may not contain interior null bytes")
         }));
@@ -604,10 +532,7 @@ impl Builder {
                     mem::transmute::<Box<dyn FnOnce() + 'a>, Box<dyn FnOnce() + 'static>>(
                         Box::new(main),
                     ),
-                    #[cfg(target_os = "horizon")]
-                    priority,
-                    #[cfg(target_os = "horizon")]
-                    affinity,
+                    self.native_options,
                 )?
             },
             thread: my_thread,


### PR DESCRIPTION
Rustc supports compiling for the Nintendo 3DS using the `armv6k-nintendo-3ds` target (Tier 3). Just recently we merged std support in #95897. A notable exclusion was `std::thread` support, which was moved into this PR as a follow-up since it required more complicated changes.

See #95897 for background on how rustc is able to support std for the 3DS.

A notable change in this PR is the addition of a "native options" parameter to the internal implementation of the thread builder on each platform. This is due to the 3DS requiring the "processor ID" where the thread should be spawned (certain cores are either cooperative or preemptive) and the thread priority up-front. There is an unstable thread builder extension trait added which allows users to set these values.

There are 2 non-portable pthread APIs which we depend on. Where possible, we tried to reuse existing standard APIs, but there are some features of the 3DS thread system which required us to add non-portable functions.
1. `pthread_attr_setprocessorid_np`: Used to set the new thread's processor ID.
2. `pthread_getprocessorid_np`: Used to retrieve the current thread's processor ID.

These are both implemented by https://github.com/Meziu/pthread-3ds, which is already noted as in the [platform support doc] as a requirement for the target's std support (note: it provides the backend for other pthread-based types such as `Mutex`). These functions have already been added to `libc` and are in the currently used version (https://github.com/rust-lang/libc/pull/2715).

~~Edit: libs team ACP has been opened for the changes to the thread builder: https://github.com/rust-lang/libs-team/issues/71~~

[platform support doc]: https://doc.rust-lang.org/nightly/rustc/platform-support/armv6k-nintendo-3ds.html

~~Blocked on https://github.com/rust-lang/rust/pull/101222~~ and ACP ~~https://github.com/rust-lang/libs-team/issues/71~~ https://github.com/rust-lang/libs-team/issues/195
