### PR TITLE
`std::thread::scope()` improvements

### DIFF
--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -287,6 +287,7 @@
 #![feature(prelude_2024)]
 #![feature(ptr_as_uninit)]
 #![feature(raw_os_nonzero)]
+#![feature(cfg_sanitize)]
 #![feature(slice_internals)]
 #![feature(slice_ptr_get)]
 #![feature(std_internals)]


### PR DESCRIPTION
- avoids calling to Thread::unpark() opportunistically.
- avoids calling thread::current() opportunistically.
- properly pins ScopeData to indicate its on-stack nature.
- outlines fast and slow paths for inc/dec/wait.
- specializes on ThreadSanitizer for fences.
- uses atomic intrinsics to avoid dangling shared references.