### PR TITLE
BinaryHeap: implement IterMut

### DIFF
--- a/library/alloc/src/collections/binary_heap/tests.rs
+++ b/library/alloc/src/collections/binary_heap/tests.rs
@@ -95,8 +95,9 @@ fn check_exact_size_iterator<I: ExactSizeIterator>(len: usize, it: I) {
 
 #[test]
 fn test_exact_size_iterator() {
-    let heap = BinaryHeap::from(vec![2, 4, 6, 2, 1, 8, 10, 3, 5, 7, 0, 9, 1]);
+    let mut heap = BinaryHeap::from(vec![2, 4, 6, 2, 1, 8, 10, 3, 5, 7, 0, 9, 1]);
     check_exact_size_iterator(heap.len(), heap.iter());
+    check_exact_size_iterator(heap.len(), heap.iter_mut());
     check_exact_size_iterator(heap.len(), heap.clone().into_iter());
     check_exact_size_iterator(heap.len(), heap.clone().into_iter_sorted());
     check_exact_size_iterator(heap.len(), heap.clone().drain());
@@ -120,6 +121,28 @@ fn test_trusted_len() {
     let heap = BinaryHeap::from(vec![2, 4, 6, 2, 1, 8, 10, 3, 5, 7, 0, 9, 1]);
     check_trusted_len(heap.len(), heap.clone().into_iter_sorted());
     check_trusted_len(heap.len(), heap.clone().drain_sorted());
+}
+
+#[test]
+fn test_iter_mut() {
+    let mut heap = BinaryHeap::from([5, 9, 3]);
+    heap.iter_mut().for_each(|e| *e += 1);
+    assert_eq!(heap.into_vec(), vec![10, 6, 4]);
+
+    let mut heap = BinaryHeap::from([5, 9, 3]);
+    *heap.iter_mut().next().unwrap() -= 10;
+    assert_eq!(heap.into_vec(), vec![9, 5, -7]);
+
+    let mut heap = BinaryHeap::from([5, 9, 3]);
+    *heap.iter_mut().next().unwrap() += 10;
+    assert_eq!(heap.into_vec(), vec![13, 5, 9]);
+
+    let mut heap = BinaryHeap::from([5, 9, 3]);
+    *heap.iter_mut().last().unwrap() += 10;
+    assert_eq!(heap.into_vec(), vec![19, 5, 3]);
+
+    let mut heap = BinaryHeap::<i32>::new();
+    assert_eq!(heap.iter_mut().next(), None);
 }
 
 #[test]

--- a/library/alloc/src/collections/btree/mod.rs
+++ b/library/alloc/src/collections/btree/mod.rs
@@ -1,5 +1,5 @@
 mod append;
-mod borrow;
+pub(super) mod borrow;
 mod dedup_sorted_iter;
 mod fix;
 pub mod map;

--- a/library/alloc/tests/lib.rs
+++ b/library/alloc/tests/lib.rs
@@ -23,6 +23,7 @@
 #![feature(unboxed_closures)]
 #![feature(associated_type_bounds)]
 #![feature(binary_heap_into_iter_sorted)]
+#![feature(binary_heap_iter_mut)]
 #![feature(binary_heap_drain_sorted)]
 #![feature(slice_ptr_get)]
 #![feature(binary_heap_retain)]


### PR DESCRIPTION
I recently had a need for this and decided to go ahead and implement it.

### Some notes:
- `iter_mut()` is implemented for `BinaryHeap<T: Ord>`. Generalizing to `BinaryHeap<T>` would require a specialized drop. This limitation might be fine (not sure why you would use a heap without ordering anyway) but it feels a little odd.
- I used a type from the `btree` module (`DormantMutRef`). It might make sense to move that file.
- In principle, `IterMut` can be made double-ended. However it would _greatly_ complicate things, and since the iteration order is mostly arbitrary, I don't see much point.