### PR TITLE
[�CP] `Option`: add by-{ref,mut} variants to the most pervasive adapters

### DIFF
--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -739,6 +739,26 @@ impl<T> Option<T> {
         }
     }
 
+    /// Like `.expect()` but with a `&self` receiver.
+    ///
+    /// Convenience shorthand for `.as_ref().expect()`.
+    #[inline]
+    #[doc(alias = "ref_expect")]
+    #[unstable(feature = "option_borrowing_adapters", issue = "none")]
+    pub fn expect_ref(&self, msg: &str) -> &T {
+        self.as_ref().expect(msg)
+    }
+
+    /// Like `.expect()` but with a `&mut self` receiver.
+    ///
+    /// Convenience shorthand for `.as_mut().expect()`.
+    #[inline]
+    #[doc(alias = "mut_expect")]
+    #[unstable(feature = "option_borrowing_adapters", issue = "none")]
+    pub fn expect_mut(&mut self, msg: &str) -> &mut T {
+        self.as_mut().expect(msg)
+    }
+
     /// Returns the contained [`Some`] value, consuming the `self` value.
     ///
     /// Because this function may panic, its use is generally discouraged.
@@ -774,6 +794,26 @@ impl<T> Option<T> {
             Some(val) => val,
             None => panic("called `Option::unwrap()` on a `None` value"),
         }
+    }
+
+    /// Like `.unwrap()` but with a `&self` receiver.
+    ///
+    /// Convenience shorthand for `.as_ref().unwrap()`.
+    #[inline]
+    #[doc(alias = "ref_unwrap")]
+    #[unstable(feature = "option_borrowing_adapters", issue = "none")]
+    pub fn unwrap_ref(&self) -> &T {
+        self.as_ref().unwrap()
+    }
+
+    /// Like `.unwrap()` but with a `&mut self` receiver.
+    ///
+    /// Convenience shorthand for `.as_mut().unwrap()`.
+    #[inline]
+    #[doc(alias = "mut_unwrap")]
+    #[unstable(feature = "option_borrowing_adapters", issue = "none")]
+    pub fn unwrap_mut(&mut self) -> &mut T {
+        self.as_mut().unwrap()
     }
 
     /// Returns the contained [`Some`] value or a provided default.
@@ -929,6 +969,32 @@ impl<T> Option<T> {
             Some(x) => Some(f(x)),
             None => None,
         }
+    }
+
+    /// Like `.map()` but with a `&self` receiver.
+    ///
+    /// Convenience shorthand for `.as_ref().map()`.
+    #[inline]
+    #[doc(alias = "ref_map")]
+    #[unstable(feature = "option_borrowing_adapters", issue = "none")]
+    pub fn map_ref<'r, U, F>(&'r self, f: F) -> Option<U>
+    where
+        F: FnOnce(&'r T) -> U,
+    {
+        self.as_ref().map(f)
+    }
+
+    /// Like `.map()` but with a `&mut self` receiver.
+    ///
+    /// Convenience shorthand for `.as_mut().map()`.
+    #[inline]
+    #[doc(alias = "mut_map")]
+    #[unstable(feature = "option_borrowing_adapters", issue = "none")]
+    pub fn map_mut<'r, U, F>(&'r mut self, f: F) -> Option<U>
+    where
+        F: FnOnce(&'r mut T) -> U,
+    {
+        self.as_mut().map(f)
     }
 
     /// Calls the provided closure with a reference to the contained value (if [`Some`]).
@@ -1262,6 +1328,32 @@ impl<T> Option<T> {
             Some(x) => f(x),
             None => None,
         }
+    }
+
+    /// Like `.and_then()`, but with a `&self` receiver.
+    ///
+    /// Convenience shorthand for `.as_ref().and_then()`.
+    #[inline]
+    #[doc(alias = "ref_and_then")]
+    #[unstable(feature = "option_borrowing_adapters", issue = "none")]
+    pub fn and_then_ref<'r, U, F>(&'r self, f: F) -> Option<U>
+    where
+        F: FnOnce(&'r T) -> Option<U>,
+    {
+        self.as_ref().and_then(f)
+    }
+
+    /// Like `.and_then()`, but with a `&mut self` receiver.
+    ///
+    /// Convenience shorthand for `.as_mut().and_then()`.
+    #[inline]
+    #[doc(alias = "mut_and_then")]
+    #[unstable(feature = "option_borrowing_adapters", issue = "none")]
+    pub fn and_then_mut<'r, U, F>(&'r mut self, f: F) -> Option<U>
+    where
+        F: FnOnce(&'r mut T) -> Option<U>,
+    {
+        self.as_mut().and_then(f)
     }
 
     /// Returns [`None`] if the option is [`None`], otherwise calls `predicate`


### PR DESCRIPTION
  - <sub><sup>\[META: this follows the [\[_CP\] ideas as outlined over here](https://hackmd.io/qwtiQZfVQ_WxYZAYZ0ys3w#Agenda), and demo'd [over here](https://github.com/rust-lang/rust/pull/97629#issuecomment-1148916727).\]</sup></sub>

## Add by-ref & by-mut variants to the most pervasive adapters of `Option`

  - shorthand for things like `borrowed_struct.field.as_ref().unwrap()` ([8382 instances of single-line `.as_ref().unwrap()` on grep.app as of this writing](https://grep.app/search?q=.as_ref%28%29.unwrap%28%29));
  - makes it easier for beginners struggling with "use of owned values" and navigating stdlib docs ([https://doc.rust-lang.org/std](https://doc.rust-lang.org/std/option/enum.Option.html)) to know what to reach for (before understanding the full generalization to calling the generic `.as_{ref,mut}()` adapters beforehand).
  - follows the `…{∅,_ref}` / `…_mut` naming convention for such methods;

## API Overview

```rust
#[unstable(feature = "option_borrowing_adapters", …)]
```

```rust
impl<T> Option<T> {
    pub fn unwrap_ref(&self) -> &T;
    pub fn unwrap_mut(&mut self) -> &mut T;

    pub fn expect_ref(&self, msg: &str) -> &T;
    pub fn expect_mut(&mut self, msg: &str) -> &mut T;

    pub fn map_ref<'r, U, F>(&'r self, f: F) -> Option<U>
    where
        F: FnOnce(&'r T) -> U,
    ;
    pub fn map_mut<'r, U, F>(&'r mut self, f: F) -> Option<U>
    where
        F: FnOnce(&'r mut T) -> U,
    ;

    pub fn and_then_ref<'r, U, F>(&'r self, f: F) -> Option<U>
    where
        F: FnOnce(&'r T) -> Option<U>,
    ;
    pub fn and_then_mut<'r, U, F>(&'r mut self, f: F) -> Option<U>
    where
        F: FnOnce(&'r mut T) -> Option<U>,
    ;
}
```

## Questions

  - Should we also offer some of these for `Result`?
      - In practice borrowing `Option`s is very typical due to struct fields having them, whereas `Result` is almost exclusively used by-value / in an owned fashion. Thence left for a potential follow-up PR.

  - would there be other `Option` methods that could benefit from `_{ref,mut}` flavors (_e.g._, `.unwrap_or{,_else}()`)?
      - If so, follow-up PRs could easily add those

  - bikeshedding names _etc._
      - To be left for stabilization, should it ever happen (this is just a \[�CP\] proposal, for `nightly` experimentation. It may not be stabilized or even be removed from future nightlies should the experimentation yield mixed results).

## Alternatives

  - Have a `.map()` (and so on) in-prelude extension trait for `&Option` and `&mut Option`, so that `borrowed_opt.map(…)` (and so on) would Just Work™ (but then for a struct field we'd need some postfix borrowing thing, such as `borrowed_struct.field&.map(…)` or what not… which is way beyond the scope of this API suggestion);

___

@rustbot modify labels: +T-libs-api -T-libs