### PR TITLE
Update `std::alloc::System` doc example code style

### DIFF
--- a/library/std/src/alloc.rs
+++ b/library/std/src/alloc.rs
@@ -102,7 +102,7 @@ pub use alloc_crate::alloc::*;
 ///         if !ret.is_null() {
 ///             ALLOCATED.fetch_add(layout.size(), SeqCst);
 ///         }
-///         return ret
+///         ret
 ///     }
 ///
 ///     unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {


### PR DESCRIPTION
`return` on the last line of a block is unidiomatic so I don't think the example should be using that here