### PR TITLE
rustdoc-json: Add assoc type ICE regression test

### DIFF
--- a/src/test/rustdoc-json/assoc_type.rs
+++ b/src/test/rustdoc-json/assoc_type.rs
@@ -1,0 +1,16 @@
+// Regression test for <https://github.com/rust-lang/rust/issues/98547>.
+
+// @has assoc_type.json
+// @has - "$.index[*][?(@.name=='Trait')]"
+// @has - "$.index[*][?(@.name=='AssocType')]"
+// @has - "$.index[*][?(@.name=='S')]"
+
+pub trait Trait {
+    type AssocType;
+}
+
+impl<T> Trait for T {
+    type AssocType = Self;
+}
+
+pub struct S;

--- a/src/test/rustdoc-json/assoc_type.rs
+++ b/src/test/rustdoc-json/assoc_type.rs
@@ -4,6 +4,7 @@
 // @has - "$.index[*][?(@.name=='Trait')]"
 // @has - "$.index[*][?(@.name=='AssocType')]"
 // @has - "$.index[*][?(@.name=='S')]"
+// @has - "$.index[*][?(@.name=='S2')]"
 
 pub trait Trait {
     type AssocType;
@@ -14,3 +15,8 @@ impl<T> Trait for T {
 }
 
 pub struct S;
+
+/// Not needed for the #98547 ICE to occur, but added to maximize the chance of
+/// getting an ICE in the future. See
+/// <https://github.com/rust-lang/rust/pull/98548#discussion_r908219164>
+pub struct S2;


### PR DESCRIPTION
Closes #98547

This fix is a natural extension of #98053.

r? @notriddle

(Since you reviewed the other PR.)

CC @GuillaumeGomez 

@rustbot labels +A-rustdoc-json +T-rustdoc