### PR TITLE
Check if programmer has fallen asleep

### DIFF
--- a/compiler/rustc_typeck/src/lib.rs
+++ b/compiler/rustc_typeck/src/lib.rs
@@ -70,6 +70,7 @@ This API is completely unstable and subject to change.
 #![feature(min_specialization)]
 #![feature(never_type)]
 #![feature(once_cell)]
+#![feature(round_char_boundary)]
 #![feature(slice_partition_dedup)]
 #![feature(try_blocks)]
 #![recursion_limit = "256"]

--- a/src/test/ui/structs/struct-field-asleep-hint.rs
+++ b/src/test/ui/structs/struct-field-asleep-hint.rs
@@ -1,0 +1,9 @@
+struct S { pre: i32 }
+impl S {
+    fn f(self) -> i32 {
+        self.prehopjpokppppppppppppppppppp
+        //~^ ERROR it seems like you've fallen asleep and hit your keyboard
+    }
+}
+
+fn main() {}

--- a/src/test/ui/structs/struct-field-asleep-hint.stderr
+++ b/src/test/ui/structs/struct-field-asleep-hint.stderr
@@ -1,0 +1,12 @@
+error: it seems like you've fallen asleep and hit your keyboard
+  --> $DIR/struct-field-asleep-hint.rs:4:17
+   |
+LL |         self.prehopjpokppppppppppppppppppp
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^ you fell asleep here
+   |
+   = help: try improving your sleep schedule or reducing your hours
+   = note: you have been asleep for about 1.36 seconds
+   = note: available fields are: `pre`
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Well, it started as a meme...
![asleep](https://user-images.githubusercontent.com/34382234/175831343-5b55b44b-d84b-45f1-829f-6c1f57a42f83.png)
and I decided to hack it into the compiler.

This isn't a perfect solution, ideally it would work also with variable names, but at least it has a unit test, so this change can be treated seriously.

@Ben-Lichtman @5225225 