### PR TITLE
Fix "kind" for associated types in trait implementations in rustdoc JSON

### DIFF
--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -252,8 +252,11 @@ fn from_clean_item(item: clean::Item, tcx: TyCtxt<'_>) -> ItemEnum {
             bounds: b.into_iter().map(|x| x.into_tcx(tcx)).collect(),
             default: None,
         },
-        // FIXME: do not map to Typedef but to a custom variant
-        AssocTypeItem(t, _) => ItemEnum::Typedef(t.into_tcx(tcx)),
+        AssocTypeItem(t, b) => ItemEnum::AssocType {
+            generics: t.generics.into_tcx(tcx),
+            bounds: b.into_iter().map(|x| x.into_tcx(tcx)).collect(),
+            default: t.item_type.map(|ty| ty.into_tcx(tcx)),
+        },
         // `convert_item` early returns `None` for striped items and keywords.
         StrippedItem(_) | KeywordItem(_) => unreachable!(),
         ExternCrateItem { ref src } => ItemEnum::ExternCrate {

--- a/src/test/rustdoc-json/assoc_items.rs
+++ b/src/test/rustdoc-json/assoc_items.rs
@@ -1,0 +1,29 @@
+#![no_std]
+
+// @has assoc_items.json
+
+pub struct Simple;
+
+impl Simple {
+    // @has - "$.index[*][?(@.name=='CONSTANT')].kind" \"assoc_const\"
+    pub const CONSTANT: usize = 0;
+}
+
+pub trait EasyToImpl {
+    // @has - "$.index[*][?(@.name=='ToDeclare')].kind" \"assoc_type\"
+    // @has - "$.index[*][?(@.name=='ToDeclare')].inner.default" null
+    type ToDeclare;
+    // @has - "$.index[*][?(@.name=='AN_ATTRIBUTE')].kind" \"assoc_const\"
+    // @has - "$.index[*][?(@.name=='AN_ATTRIBUTE')].inner.default" null
+    const AN_ATTRIBUTE: usize;
+}
+
+impl EasyToImpl for Simple {
+    // @has - "$.index[*][?(@.name=='ToDeclare')].inner.default.kind" \"primitive\"
+    // @has - "$.index[*][?(@.name=='ToDeclare')].inner.default.inner" \"usize\"
+    type ToDeclare = usize;
+    // @has - "$.index[*][?(@.name=='AN_ATTRIBUTE')].inner.type.kind" \"primitive\"
+    // @has - "$.index[*][?(@.name=='AN_ATTRIBUTE')].inner.type.inner" \"usize\"
+    // @has - "$.index[*][?(@.name=='AN_ATTRIBUTE')].inner.default" \"12\"
+    const AN_ATTRIBUTE: usize = 12;
+}


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/81340.

Contrary to what is suggested in the issue, I really think we should distinguish between associated items and "normal" constants and types.

cc @CraftSpider @SimonSapin 
r? @notriddle 