### PR TITLE
liballoc tests: avoid int2ptr cast

### DIFF
--- a/library/alloc/tests/fmt.rs
+++ b/library/alloc/tests/fmt.rs
@@ -207,7 +207,7 @@ fn test_format_macro_interface() {
     {
         let val = usize::MAX;
         let exp = format!("{val:#x}");
-        t!(format!("{:p}", val as *const isize), exp);
+        t!(format!("{:p}", std::ptr::invalid::<isize>(val)), exp);
     }
 
     // Escaping


### PR DESCRIPTION
I think we don't need `ptr::from_exposed_addr` here; `ptr::invalid` should be enough for this test. (And this makes Miri less unhappy when running these tests.)