### PR TITLE
Emit warning when named arguments are used positionally in format

### DIFF
--- a/compiler/rustc_expand/src/base.rs
+++ b/compiler/rustc_expand/src/base.rs
@@ -12,7 +12,7 @@ use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_data_structures::sync::{self, Lrc};
 use rustc_errors::{Applicability, DiagnosticBuilder, ErrorGuaranteed, MultiSpan, PResult};
 use rustc_lint_defs::builtin::PROC_MACRO_BACK_COMPAT;
-use rustc_lint_defs::BuiltinLintDiagnostics;
+use rustc_lint_defs::{BufferedEarlyLint, BuiltinLintDiagnostics};
 use rustc_parse::{self, parser, MACRO_ARGUMENTS};
 use rustc_session::{parse::ParseSess, Limit, Session, SessionDiagnostic};
 use rustc_span::def_id::{CrateNum, DefId, LocalDefId};
@@ -988,6 +988,8 @@ pub struct ExtCtxt<'a> {
     pub expansions: FxHashMap<Span, Vec<String>>,
     /// Used for running pre-expansion lints on freshly loaded modules.
     pub(super) lint_store: LintStoreExpandDyn<'a>,
+    /// Used for storing lints generated during expansion, like `NAMED_ARGUMENTS_USED_POSITIONALLY`
+    pub buffered_early_lint: Vec<BufferedEarlyLint>,
     /// When we 'expand' an inert attribute, we leave it
     /// in the AST, but insert it here so that we know
     /// not to expand it again.
@@ -1020,6 +1022,7 @@ impl<'a> ExtCtxt<'a> {
             force_mode: false,
             expansions: FxHashMap::default(),
             expanded_inert_attrs: MarkedAttrs::new(),
+            buffered_early_lint: vec![],
         }
     }
 

--- a/compiler/rustc_lint/src/context.rs
+++ b/compiler/rustc_lint/src/context.rs
@@ -857,6 +857,18 @@ pub trait LintContext: Sized {
                         Applicability::MachineApplicable,
                     );
                 },
+                BuiltinLintDiagnostics::NamedArgumentUsedPositionally(positional_arg, named_arg, name) => {
+                    db.span_label(named_arg, "this named argument is only referred to by position in formatting string");
+                    let msg = format!("this formatting argument uses named argument `{}` by position", name);
+                    db.span_label(positional_arg, msg);
+                    db.span_suggestion_verbose(
+                        positional_arg,
+                        "use the named argument by name to avoid ambiguity",
+                        format!("{{{}}}", name),
+                        Applicability::MaybeIncorrect,
+                    );
+
+                }
             }
             // Rewrap `db`, and pass control to the user.
             decorate(LintDiagnosticBuilder::new(db));

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -3292,6 +3292,7 @@ declare_lint_pass! {
         TEST_UNSTABLE_LINT,
         FFI_UNWIND_CALLS,
         REPR_TRANSPARENT_EXTERNAL_PRIVATE_FIELDS,
+        NAMED_ARGUMENTS_USED_POSITIONALLY,
     ]
 }
 
@@ -3995,4 +3996,34 @@ declare_lint! {
     Allow,
     "call to foreign functions or function pointers with FFI-unwind ABI",
     @feature_gate = sym::c_unwind;
+}
+
+declare_lint! {
+    /// The `named_arguments_used_positionally` lint detects cases where named arguments are only
+    /// used positionally in format strings. This usage is valid but potentially very confusing.
+    ///
+    /// ### Example
+    ///
+    /// ```rust,compile_fail
+    /// #![deny(named_arguments_used_positionally)]
+    /// fn main() {
+    ///     let _x = 5;
+    ///     println!("{}", _x = 1); // Prints 1, will trigger lint
+    ///
+    ///     println!("{}", _x); // Prints 5, no lint emitted
+    ///     println!("{_x}", _x = _x); // Prints 5, no lint emitted
+    /// }
+    /// ```
+    ///
+    /// {{produces}}
+    ///
+    /// ### Explanation
+    ///
+    /// Rust formatting strings can refer to named arguments by their position, but this usage is
+    /// potentially confusing. In particular, readers can incorrectly assume that the declaration
+    /// of named arguments is an assignment (which would produce the unit type).
+    /// For backwards compatibility, this is not a hard error.
+    pub NAMED_ARGUMENTS_USED_POSITIONALLY,
+    Warn,
+    "named arguments in format used positionally"
 }

--- a/compiler/rustc_lint_defs/src/lib.rs
+++ b/compiler/rustc_lint_defs/src/lib.rs
@@ -467,6 +467,7 @@ pub enum BuiltinLintDiagnostics {
         /// If true, the lifetime will be fully elided.
         use_span: Option<(Span, bool)>,
     },
+    NamedArgumentUsedPositionally(Span, Span, String),
 }
 
 /// Lints that are buffered up early on in the `Session` before the

--- a/src/test/ui/macros/issue-98466-allow.rs
+++ b/src/test/ui/macros/issue-98466-allow.rs
@@ -1,0 +1,16 @@
+// check-pass
+#![allow(named_arguments_used_positionally)]
+
+fn main() {
+    let mut _x: usize;
+    _x = 1;
+    println!("_x is {}", _x = 5);
+    println!("_x is {}", y = _x);
+    println!("first positional arg {}, second positional arg {}, _x is {}", 1, 2, y = _x);
+
+    let mut _x: usize;
+    _x = 1;
+    let _f = format!("_x is {}", _x = 5);
+    let _f = format!("_x is {}", y = _x);
+    let _f = format!("first positional arg {}, second positional arg {}, _x is {}", 1, 2, y = _x);
+}

--- a/src/test/ui/macros/issue-98466.fixed
+++ b/src/test/ui/macros/issue-98466.fixed
@@ -1,0 +1,51 @@
+// check-pass
+// run-rustfix
+
+fn main() {
+    let mut _x: usize;
+    _x = 1;
+    println!("_x is {_x}", _x = 5);
+    //~^ WARNING named argument `_x` is not used by name [named_arguments_used_positionally]
+    //~| HELP use the named argument by name to avoid ambiguity
+    println!("_x is {y}", y = _x);
+    //~^ WARNING named argument `y` is not used by name [named_arguments_used_positionally]
+    //~| HELP use the named argument by name to avoid ambiguity
+    println!("first positional arg {}, second positional arg {}, _x is {y}", 1, 2, y = _x);
+    //~^ WARNING named argument `y` is not used by name [named_arguments_used_positionally]
+    //~| HELP use the named argument by name to avoid ambiguity
+
+    let mut _x: usize;
+    _x = 1;
+    let _f = format!("_x is {_x}", _x = 5);
+    //~^ WARNING named argument `_x` is not used by name [named_arguments_used_positionally]
+    //~| HELP use the named argument by name to avoid ambiguity
+    let _f = format!("_x is {y}", y = _x);
+    //~^ WARNING named argument `y` is not used by name [named_arguments_used_positionally]
+    //~| HELP use the named argument by name to avoid ambiguity
+    let _f = format!("first positional arg {}, second positional arg {}, _x is {y}", 1, 2, y = _x);
+    //~^ WARNING named argument `y` is not used by name [named_arguments_used_positionally]
+    //~| HELP use the named argument by name to avoid ambiguity
+
+    let s = "0.009";
+    // Confirm that named arguments used in formatting are correctly considered.
+    println!(".{:0<width$}", s, width = _x);
+
+    let region = "abc";
+    let width = 8;
+    let ls = "abcde";
+    let full = "abcde";
+    // Confirm that named arguments used in formatting are correctly considered.
+    println!(
+        "| {r:rw$?} | {ui:4?} | {v}",
+        r = region,
+        rw = width,
+        ui = ls,
+        v = full,
+    );
+
+    // Confirm that named arguments used in formatting are correctly considered.
+    println!("{:.a$}", "aaaaaaaaaaaaaaaaaa", a = 4);
+
+    // Confirm that named arguments used in formatting are correctly considered.
+    println!("{:._a$}", "aaaaaaaaaaaaaaaaaa", _a = 4);
+}

--- a/src/test/ui/macros/issue-98466.rs
+++ b/src/test/ui/macros/issue-98466.rs
@@ -1,0 +1,51 @@
+// check-pass
+// run-rustfix
+
+fn main() {
+    let mut _x: usize;
+    _x = 1;
+    println!("_x is {}", _x = 5);
+    //~^ WARNING named argument `_x` is not used by name [named_arguments_used_positionally]
+    //~| HELP use the named argument by name to avoid ambiguity
+    println!("_x is {}", y = _x);
+    //~^ WARNING named argument `y` is not used by name [named_arguments_used_positionally]
+    //~| HELP use the named argument by name to avoid ambiguity
+    println!("first positional arg {}, second positional arg {}, _x is {}", 1, 2, y = _x);
+    //~^ WARNING named argument `y` is not used by name [named_arguments_used_positionally]
+    //~| HELP use the named argument by name to avoid ambiguity
+
+    let mut _x: usize;
+    _x = 1;
+    let _f = format!("_x is {}", _x = 5);
+    //~^ WARNING named argument `_x` is not used by name [named_arguments_used_positionally]
+    //~| HELP use the named argument by name to avoid ambiguity
+    let _f = format!("_x is {}", y = _x);
+    //~^ WARNING named argument `y` is not used by name [named_arguments_used_positionally]
+    //~| HELP use the named argument by name to avoid ambiguity
+    let _f = format!("first positional arg {}, second positional arg {}, _x is {}", 1, 2, y = _x);
+    //~^ WARNING named argument `y` is not used by name [named_arguments_used_positionally]
+    //~| HELP use the named argument by name to avoid ambiguity
+
+    let s = "0.009";
+    // Confirm that named arguments used in formatting are correctly considered.
+    println!(".{:0<width$}", s, width = _x);
+
+    let region = "abc";
+    let width = 8;
+    let ls = "abcde";
+    let full = "abcde";
+    // Confirm that named arguments used in formatting are correctly considered.
+    println!(
+        "| {r:rw$?} | {ui:4?} | {v}",
+        r = region,
+        rw = width,
+        ui = ls,
+        v = full,
+    );
+
+    // Confirm that named arguments used in formatting are correctly considered.
+    println!("{:.a$}", "aaaaaaaaaaaaaaaaaa", a = 4);
+
+    // Confirm that named arguments used in formatting are correctly considered.
+    println!("{:._a$}", "aaaaaaaaaaaaaaaaaa", _a = 4);
+}

--- a/src/test/ui/macros/issue-98466.stderr
+++ b/src/test/ui/macros/issue-98466.stderr
@@ -1,0 +1,81 @@
+warning: named argument `_x` is not used by name
+  --> $DIR/issue-98466.rs:7:26
+   |
+LL |     println!("_x is {}", _x = 5);
+   |                     --   ^^ this named argument is only referred to by position in formatting string
+   |                     |
+   |                     this formatting argument uses named argument `_x` by position
+   |
+   = note: `#[warn(named_arguments_used_positionally)]` on by default
+help: use the named argument by name to avoid ambiguity
+   |
+LL |     println!("_x is {_x}", _x = 5);
+   |                     ~~~~
+
+warning: named argument `y` is not used by name
+  --> $DIR/issue-98466.rs:10:26
+   |
+LL |     println!("_x is {}", y = _x);
+   |                     --   ^ this named argument is only referred to by position in formatting string
+   |                     |
+   |                     this formatting argument uses named argument `y` by position
+   |
+help: use the named argument by name to avoid ambiguity
+   |
+LL |     println!("_x is {y}", y = _x);
+   |                     ~~~
+
+warning: named argument `y` is not used by name
+  --> $DIR/issue-98466.rs:13:83
+   |
+LL |     println!("first positional arg {}, second positional arg {}, _x is {}", 1, 2, y = _x);
+   |                                                                        --         ^ this named argument is only referred to by position in formatting string
+   |                                                                        |
+   |                                                                        this formatting argument uses named argument `y` by position
+   |
+help: use the named argument by name to avoid ambiguity
+   |
+LL |     println!("first positional arg {}, second positional arg {}, _x is {y}", 1, 2, y = _x);
+   |                                                                        ~~~
+
+warning: named argument `_x` is not used by name
+  --> $DIR/issue-98466.rs:19:34
+   |
+LL |     let _f = format!("_x is {}", _x = 5);
+   |                             --   ^^ this named argument is only referred to by position in formatting string
+   |                             |
+   |                             this formatting argument uses named argument `_x` by position
+   |
+help: use the named argument by name to avoid ambiguity
+   |
+LL |     let _f = format!("_x is {_x}", _x = 5);
+   |                             ~~~~
+
+warning: named argument `y` is not used by name
+  --> $DIR/issue-98466.rs:22:34
+   |
+LL |     let _f = format!("_x is {}", y = _x);
+   |                             --   ^ this named argument is only referred to by position in formatting string
+   |                             |
+   |                             this formatting argument uses named argument `y` by position
+   |
+help: use the named argument by name to avoid ambiguity
+   |
+LL |     let _f = format!("_x is {y}", y = _x);
+   |                             ~~~
+
+warning: named argument `y` is not used by name
+  --> $DIR/issue-98466.rs:25:91
+   |
+LL |     let _f = format!("first positional arg {}, second positional arg {}, _x is {}", 1, 2, y = _x);
+   |                                                                                --         ^ this named argument is only referred to by position in formatting string
+   |                                                                                |
+   |                                                                                this formatting argument uses named argument `y` by position
+   |
+help: use the named argument by name to avoid ambiguity
+   |
+LL |     let _f = format!("first positional arg {}, second positional arg {}, _x is {y}", 1, 2, y = _x);
+   |                                                                                ~~~
+
+warning: 6 warnings emitted
+


### PR DESCRIPTION
Addresses Issue 98466 by emitting an error if a named argument
is used like a position argument (i.e. the name is not used in
the string to be formatted).

Fixes rust-lang#98466