### PR TITLE
Implement `Send` and `Sync` for `ThinBox<T>`

### DIFF
--- a/library/alloc/src/boxed/thin.rs
+++ b/library/alloc/src/boxed/thin.rs
@@ -33,6 +33,14 @@ pub struct ThinBox<T: ?Sized> {
     _marker: PhantomData<T>,
 }
 
+/// `ThinBox<T>` is `Send` if `T` is `Send` because the data is owned.
+#[unstable(feature = "thin_box", issue = "92791")]
+unsafe impl<T: ?Sized + Send> Send for ThinBox<T> {}
+
+/// `ThinBox<T>` is `Sync` if `T` is `Sync` because the data is owned.
+#[unstable(feature = "thin_box", issue = "92791")]
+unsafe impl<T: ?Sized + Sync> Sync for ThinBox<T> {}
+
 #[unstable(feature = "thin_box", issue = "92791")]
 impl<T> ThinBox<T> {
     /// Moves a type to the heap with its `Metadata` stored in the heap allocation instead of on


### PR DESCRIPTION
Just like `Box<T>`, `ThinBox<T>` owns its data on the heap, so it should
implement `Send` and `Sync` when `T` does.

This extends tracking issue #92791.
