### PR TITLE
Clarify String::from_utf8_unchecked's invariants

### DIFF
--- a/library/alloc/src/string.rs
+++ b/library/alloc/src/string.rs
@@ -819,10 +819,7 @@ impl String {
     ///
     /// # Safety
     ///
-    /// This function is unsafe because it does not check that the bytes passed
-    /// to it are valid UTF-8. If this constraint is violated, it may cause
-    /// memory unsafety issues with future users of the `String`, as the rest of
-    /// the standard library assumes that `String`s are valid UTF-8.
+    /// The provided bytes must be valid UTF-8.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
This is the same clarification as in https://github.com/rust-lang/rust/pull/95895, and makes `str::from_utf8_unchecked` and `String::from_utf8_unchecked` agree again. Either `String` should be changed to match `str` (this PR), or `str` should be reverted to match `String`. (Or both are changed to a new, better description of what it means to violate the safety invariant.)

Strictly speaking, String's buffer being valid UTF-8 is a *safety* invariant, not a *validity* invariant. This means that String managing a non-UTF-8 buffer is not an AM violation / UB, but can result in safe API surface causing an AM violation / UB.

Currently, *no* String functionality, including Drop::drop, say they are valid on invalid UTF-8. As such, the only thing possible to do with an unsafe String is forget to drop it. Everything else is library UB.

Making valid UTF-8 a precondition of from_utf8_unchecked then is an API simplification. Additionally, this makes `from_utf8(bytes).unwrap()` a valid sanitizing implementation.

I opened [a #t-lang/wg-unsafe-code-guidelines Zulip thread](https://rust-lang.zulipchat.com/#narrow/stream/136281-t-lang.2Fwg-unsafe-code-guidelines/topic/from_unchecked.20and.20safety.20invariants) to discuss whether `from_unchecked` style functions should prefer documenting a safety precondition or a safety postcondition.