### PR TITLE
rustc_codegen_ssa: don't use LLVM struct types for field offsets.

### DIFF
--- a/compiler/rustc_codegen_gcc/src/type_of.rs
+++ b/compiler/rustc_codegen_gcc/src/type_of.rs
@@ -137,7 +137,6 @@ pub trait LayoutGccExt<'tcx> {
     fn immediate_gcc_type<'gcc>(&self, cx: &CodegenCx<'gcc, 'tcx>) -> Type<'gcc>;
     fn scalar_gcc_type_at<'gcc>(&self, cx: &CodegenCx<'gcc, 'tcx>, scalar: &abi::Scalar, offset: Size) -> Type<'gcc>;
     fn scalar_pair_element_gcc_type<'gcc>(&self, cx: &CodegenCx<'gcc, 'tcx>, index: usize, immediate: bool) -> Type<'gcc>;
-    fn gcc_field_index(&self, index: usize) -> u64;
     fn pointee_info_at<'gcc>(&self, cx: &CodegenCx<'gcc, 'tcx>, offset: Size) -> Option<PointeeInfo>;
 }
 
@@ -311,24 +310,6 @@ impl<'tcx> LayoutGccExt<'tcx> for TyAndLayout<'tcx> {
         self.scalar_gcc_type_at(cx, scalar, offset)
     }
 
-    fn gcc_field_index(&self, index: usize) -> u64 {
-        match self.abi {
-            Abi::Scalar(_) | Abi::ScalarPair(..) => {
-                bug!("TyAndLayout::gcc_field_index({:?}): not applicable", self)
-            }
-            _ => {}
-        }
-        match self.fields {
-            FieldsShape::Primitive | FieldsShape::Union(_) => {
-                bug!("TyAndLayout::gcc_field_index({:?}): not applicable", self)
-            }
-
-            FieldsShape::Array { .. } => index as u64,
-
-            FieldsShape::Arbitrary { .. } => 1 + (self.fields.memory_index(index) as u64) * 2,
-        }
-    }
-
     fn pointee_info_at<'a>(&self, cx: &CodegenCx<'a, 'tcx>, offset: Size) -> Option<PointeeInfo> {
         if let Some(&pointee) = cx.pointee_infos.borrow().get(&(self.ty, offset)) {
             return pointee;
@@ -356,10 +337,6 @@ impl<'gcc, 'tcx> LayoutTypeMethods<'tcx> for CodegenCx<'gcc, 'tcx> {
 
     fn is_backend_scalar_pair(&self, layout: TyAndLayout<'tcx>) -> bool {
         layout.is_gcc_scalar_pair()
-    }
-
-    fn backend_field_index(&self, layout: TyAndLayout<'tcx>, index: usize) -> u64 {
-        layout.gcc_field_index(index)
     }
 
     fn scalar_pair_element_backend_type(&self, layout: TyAndLayout<'tcx>, index: usize, immediate: bool) -> Type<'gcc> {

--- a/compiler/rustc_codegen_llvm/src/type_.rs
+++ b/compiler/rustc_codegen_llvm/src/type_.rs
@@ -265,9 +265,6 @@ impl<'ll, 'tcx> LayoutTypeMethods<'tcx> for CodegenCx<'ll, 'tcx> {
     fn is_backend_scalar_pair(&self, layout: TyAndLayout<'tcx>) -> bool {
         layout.is_llvm_scalar_pair()
     }
-    fn backend_field_index(&self, layout: TyAndLayout<'tcx>, index: usize) -> u64 {
-        layout.llvm_field_index(self, index)
-    }
     fn scalar_pair_element_backend_type(
         &self,
         layout: TyAndLayout<'tcx>,

--- a/compiler/rustc_codegen_llvm/src/type_of.rs
+++ b/compiler/rustc_codegen_llvm/src/type_of.rs
@@ -194,6 +194,7 @@ pub trait LayoutLlvmExt<'tcx> {
         index: usize,
         immediate: bool,
     ) -> &'a Type;
+    // FIXME(eddyb) remove (used only by `va_arg::emit_aapcs_va_arg`).
     fn llvm_field_index<'a>(&self, cx: &CodegenCx<'a, 'tcx>, index: usize) -> u64;
     fn pointee_info_at<'a>(&self, cx: &CodegenCx<'a, 'tcx>, offset: Size) -> Option<PointeeInfo>;
 }
@@ -366,6 +367,7 @@ impl<'tcx> LayoutLlvmExt<'tcx> for TyAndLayout<'tcx> {
         self.scalar_llvm_type_at(cx, scalar, offset)
     }
 
+    // FIXME(eddyb) remove (used only by `va_arg::emit_aapcs_va_arg`).
     fn llvm_field_index<'a>(&self, cx: &CodegenCx<'a, 'tcx>, index: usize) -> u64 {
         match self.abi {
             Abi::Scalar(_) | Abi::ScalarPair(..) => {

--- a/compiler/rustc_codegen_llvm/src/va_arg.rs
+++ b/compiler/rustc_codegen_llvm/src/va_arg.rs
@@ -110,6 +110,7 @@ fn emit_aapcs_va_arg<'ll, 'tcx>(
     let offset_align = Align::from_bytes(4).unwrap();
 
     let gr_type = target_ty.is_any_ptr() || target_ty.is_integral();
+    // FIXME(eddyb) this should use the higher-level `PlaceRef` APIs.
     let (reg_off, reg_top_index, slot_size) = if gr_type {
         let gr_offs =
             bx.struct_gep(va_list_ty, va_list_addr, va_list_layout.llvm_field_index(bx.cx, 3));

--- a/compiler/rustc_codegen_ssa/src/mir/place.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/place.rs
@@ -97,8 +97,8 @@ impl<'a, 'tcx, V: CodegenObject> PlaceRef<'tcx, V> {
                 self.llval
             } else {
                 let byte_ptr = bx.pointercast(self.llval, bx.cx().type_i8p());
-                // FIXME(eddyb) when can this not be `inbounds`? ZSTs?
-                // (but since `offset` is larger than `0`, that would mean the
+                // This is always `inbounds`. For example, ZSTs cannot arise
+                // because `offset` is larger than `0`, which means the
                 // allocation the place points into has at least one byte, so
                 // any possible offset in the layout *should* be in-bounds)
                 bx.inbounds_gep(bx.cx().type_i8(), byte_ptr, &[bx.const_usize(offset.bytes())])

--- a/compiler/rustc_codegen_ssa/src/traits/type_.rs
+++ b/compiler/rustc_codegen_ssa/src/traits/type_.rs
@@ -108,7 +108,6 @@ pub trait LayoutTypeMethods<'tcx>: Backend<'tcx> {
     fn immediate_backend_type(&self, layout: TyAndLayout<'tcx>) -> Self::Type;
     fn is_backend_immediate(&self, layout: TyAndLayout<'tcx>) -> bool;
     fn is_backend_scalar_pair(&self, layout: TyAndLayout<'tcx>) -> bool;
-    fn backend_field_index(&self, layout: TyAndLayout<'tcx>, index: usize) -> u64;
     fn scalar_pair_element_backend_type(
         &self,
         layout: TyAndLayout<'tcx>,

--- a/src/test/codegen/zst-offset.rs
+++ b/src/test/codegen/zst-offset.rs
@@ -13,7 +13,7 @@ pub fn helper(_: usize) {
 // CHECK-LABEL: @scalar_layout
 #[no_mangle]
 pub fn scalar_layout(s: &(u64, ())) {
-// CHECK: getelementptr i8, {{.+}}, [[USIZE]] 8
+// CHECK: getelementptr inbounds i8, {{.+}}, [[USIZE]] 8
     let x = &s.1;
     &x; // keep variable in an alloca
 }
@@ -22,7 +22,7 @@ pub fn scalar_layout(s: &(u64, ())) {
 // CHECK-LABEL: @scalarpair_layout
 #[no_mangle]
 pub fn scalarpair_layout(s: &(u64, u32, ())) {
-// CHECK: getelementptr i8, {{.+}}, [[USIZE]] 12
+// CHECK: getelementptr inbounds i8, {{.+}}, [[USIZE]] 12
     let x = &s.2;
     &x; // keep variable in an alloca
 }
@@ -34,7 +34,7 @@ pub struct U64x4(u64, u64, u64, u64);
 // CHECK-LABEL: @vector_layout
 #[no_mangle]
 pub fn vector_layout(s: &(U64x4, ())) {
-// CHECK: getelementptr i8, {{.+}}, [[USIZE]] 32
+// CHECK: getelementptr inbounds i8, {{.+}}, [[USIZE]] 32
     let x = &s.1;
     &x; // keep variable in an alloca
 }


### PR DESCRIPTION
As [opaque pointers in LLVM](https://llvm.org/docs/OpaquePointers.html) become inevitable, let's review our usage of LLVM "struct" types:
* **representing Rust types**
  * ~~constants~~ (gone since miri, we just flatly serialize the mix of raw bytes and relocations)
  * ~~pointee types~~ (will be gone with opaque pointers)
  * `alloca`: only for size (we already always supply the alignment explicitly)
    * impact of replacing the type with `[i8 x sizeof(T)]` still needs to be measured, I have a sneaking suspicion that (even post-opaque-pointers) some LLVM passes use the type to make decisions
  * **`getelementptr`: only for offset computation**
    * this PR replaces them with byte offsets, which might interfere with some optimizations (as I worry about `alloca`), but I doubt LLVM would have a hard time rewriting the GEP to fit the type (i.e. this might  push back all the pessimizations to a future `alloca` de-typing)
    * my intuition back when I tried to get involved with the opaque pointers work, was that LLVM was wasting a lot of time (re)computing<sup>1</sup> offsets<sup>2</sup> when a more pragmatic IR would just put the constant offset in the instruction (at most you'd end up with what I call "integer dot product", for the full form that indexes nested arrays)
      <sub><sup>1</sup>can't be easily cached IIRC because types are interned in the `Context` but only a `Module` can specify a `datalayout`</sub>
      <sub><sup>2</sup>you want offsets as any decision based on "fields" would likely miss some optimization opportunities</sub>
* **not representing Rust types** (but automatically generated for e.g. ABI reasons)
  * the common one here is "returning more than one value" (as LLVM doesn't support the feature itself, but forces emitters to go through the tuple-returning idiom)
  * wherever possible, `rustc_codegen_ssa`'s abstractions should work with e.g. `SmallVec<[Bx::Value; 2]>` (or have some sort of `Bx::ValueBundle` for handling trickier situations like `invoke`, where the `invoke` and the `extract`s are in different BBs)

I never got LLVM devs to agree with me that aggregate types in LLVM were a mistake, but if we can get away with not using them (outside of "multiple return values"), maybe that will make a difference.
<sub>(a commonly cited reason was debugging the IR, but wouldn't you want more readable DWARF metadata in that case? LLVM types are already quite lossy. also, the representation of LLVM constants I was floating back then in the context of removing LLVM aggregates, [turned into a miri "abstract allocation" representation proposal](https://internals.rust-lang.org/t/mir-constant-evaluation/3143/31), so it wasn't entirely a waste of time)</sub>

<hr/>

A couple notes for context:
* historically the lack of opaque pointers, and the (perceived?) need to represent Rust types (or rather, their layouts) using LLVM aggregates, had delayed (and complicated) what we now call the `rustc` ABI/layout system (thankfully we didn't end up needing cycle detection for "mutual recursion" groups)
* I was looking into [generalizing "scalar pair" layouts the other day](https://github.com/rust-lang/rust/pull/97861#issuecomment-1167313517), and the interaction with LLVM struct types is getting in the way a lot (both coming up with appropriate LLVM types for "scalar components", and subsequent GEPs)

<hr/>

Some additional concerns come from backends that are even higher-level than LLVM:
* **`rustc_codegen_gcc`** (cc @antoyo)
  * not super familiar with it, but I suspect it could also switch fully to untyped pointers
* **`rustc_codegen_spirv`**
  * currently takes advantage of being able to represent Rust `struct` types (and a limited selection of `enum`s, based on layout) as SPIR-V structs
  * already handles pointer-casting GEPs (i.e. it tries to recover a castless GEP based on the offset), so all it really needs is to see the layout in `alloca` and all the call ABI handling
    * that is, its backend `Value`s would be tracking a richer SPIR-V type than `rustc_codegen_ssa` needs or wants for the backend `Type`, in an opaque-pointer/aggreggate-less world
  * long-term the plan is to introduce a SPIR-V derivative IR that would more readily allow both representing the "untyped memory" semantics Rust wants, and legalizing it away (mostly into SSA values, but inferring "typed memory" is also an option for some things)

<hr/>

I'm not sure how well we can test the LLVM optimization impact of this PR, but to some extent a perf run might be able to reflect at least the impact on `rustc`'s code.

cc @rust-lang/wg-llvm @bjorn3 @tmiasko