### PR TITLE
Remove feature `const_option` from std

### DIFF
--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -335,7 +335,6 @@
 #![feature(const_ip)]
 #![feature(const_ipv4)]
 #![feature(const_ipv6)]
-#![feature(const_option)]
 #![feature(const_socketaddr)]
 #![feature(thread_local_internals)]
 //

--- a/library/std/src/sys/windows/args.rs
+++ b/library/std/src/sys/windows/args.rs
@@ -22,6 +22,9 @@ use crate::vec;
 use core::iter;
 
 /// This is the const equivalent to `NonZeroU16::new(n).unwrap()`
+///
+/// FIXME: This can be removed once `Option::unwrap` is stably const.
+/// See the `const_option` feature (#67441).
 const fn non_zero_u16(n: u16) -> NonZeroU16 {
     match NonZeroU16::new(n) {
         Some(n) => n,

--- a/library/std/src/sys/windows/args.rs
+++ b/library/std/src/sys/windows/args.rs
@@ -21,6 +21,14 @@ use crate::vec;
 
 use core::iter;
 
+/// This is the const equivalent to `NonZeroU16::new(n).unwrap()`
+const fn non_zero_u16(n: u16) -> NonZeroU16 {
+    match NonZeroU16::new(n) {
+        Some(n) => n,
+        None => panic!("called `unwrap` on a `None` value"),
+    }
+}
+
 pub fn args() -> Args {
     // SAFETY: `GetCommandLineW` returns a pointer to a null terminated UTF-16
     // string so it's safe for `WStrUnits` to use.
@@ -58,10 +66,10 @@ fn parse_lp_cmd_line<'a, F: Fn() -> OsString>(
     lp_cmd_line: Option<WStrUnits<'a>>,
     exe_name: F,
 ) -> Vec<OsString> {
-    const BACKSLASH: NonZeroU16 = NonZeroU16::new(b'\\' as u16).unwrap();
-    const QUOTE: NonZeroU16 = NonZeroU16::new(b'"' as u16).unwrap();
-    const TAB: NonZeroU16 = NonZeroU16::new(b'\t' as u16).unwrap();
-    const SPACE: NonZeroU16 = NonZeroU16::new(b' ' as u16).unwrap();
+    const BACKSLASH: NonZeroU16 = non_zero_u16(b'\\' as u16);
+    const QUOTE: NonZeroU16 = non_zero_u16(b'"' as u16);
+    const TAB: NonZeroU16 = non_zero_u16(b'\t' as u16);
+    const SPACE: NonZeroU16 = non_zero_u16(b' ' as u16);
 
     let mut ret_val = Vec::new();
     // If the cmd line pointer is null or it points to an empty string then


### PR DESCRIPTION
This is part of the effort to reduce the number of unstable features used by std. This one is easy as it's only used in one place.