### PR TITLE
llvm-wrapper: adapt for removal of the ASanGlobalsMetadataAnalysis LLVM API

### DIFF
--- a/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
@@ -985,7 +985,9 @@ LLVMRustOptimizeWithNewPassManager(
     if (SanitizerOptions->SanitizeAddress) {
       OptimizerLastEPCallbacks.push_back(
         [SanitizerOptions](ModulePassManager &MPM, OptimizationLevel Level) {
+#if LLVM_VERSION_LT(15, 0)
           MPM.addPass(RequireAnalysisPass<ASanGlobalsMetadataAnalysis, Module>());
+#endif
 #if LLVM_VERSION_GE(14, 0)
           AddressSanitizerOptions opts = AddressSanitizerOptions{
             /*CompileKernel=*/false,


### PR DESCRIPTION
No functional changes intended.

This adapts llvm-wrapper for https://github.com/llvm/llvm-project/commit/dacfa24f75c328ae30b710ecadaa18e4ba10cdc6, which removed `ASanGlobalsMetadataAnalysis`.

Found via our experimental rust + HEAD llvm bot: https://buildkite.com/llvm-project/rust-llvm-integrate-prototype/builds/11565#0181a72f-75bb-4378-88f0-4c0bca7d03fa/231-505.