### PR TITLE
Improve pretty printing of valtrees for references

### DIFF
--- a/compiler/rustc_const_eval/src/const_eval/mod.rs
+++ b/compiler/rustc_const_eval/src/const_eval/mod.rs
@@ -5,7 +5,6 @@ use rustc_middle::mir;
 use rustc_middle::mir::interpret::{EvalToValTreeResult, GlobalId};
 use rustc_middle::ty::{self, TyCtxt};
 use rustc_span::{source_map::DUMMY_SP, symbol::Symbol};
-use rustc_target::abi::VariantIdx;
 
 use crate::interpret::{
     intern_const_alloc_recursive, ConstValue, InternKind, InterpCx, InterpResult, MemPlaceMeta,
@@ -88,83 +87,6 @@ pub(crate) fn eval_to_valtree<'tcx>(
                 ValTreeCreationError::NonSupportedType | ValTreeCreationError::Other => Ok(None),
             }
         }
-    }
-}
-
-/// Tries to destructure constants of type Array or Adt into the constants
-/// of its fields.
-pub(crate) fn try_destructure_const<'tcx>(
-    tcx: TyCtxt<'tcx>,
-    const_: ty::Const<'tcx>,
-) -> Option<ty::DestructuredConst<'tcx>> {
-    if let ty::ConstKind::Value(valtree) = const_.kind() {
-        let branches = match valtree {
-            ty::ValTree::Branch(b) => b,
-            _ => return None,
-        };
-
-        let (fields, variant) = match const_.ty().kind() {
-            ty::Array(inner_ty, _) | ty::Slice(inner_ty) => {
-                // construct the consts for the elements of the array/slice
-                let field_consts = branches
-                    .iter()
-                    .map(|b| {
-                        tcx.mk_const(ty::ConstS { kind: ty::ConstKind::Value(*b), ty: *inner_ty })
-                    })
-                    .collect::<Vec<_>>();
-                debug!(?field_consts);
-
-                (field_consts, None)
-            }
-            ty::Adt(def, _) if def.variants().is_empty() => bug!("unreachable"),
-            ty::Adt(def, substs) => {
-                let variant_idx = if def.is_enum() {
-                    VariantIdx::from_u32(branches[0].unwrap_leaf().try_to_u32().ok()?)
-                } else {
-                    VariantIdx::from_u32(0)
-                };
-                let fields = &def.variant(variant_idx).fields;
-                let mut field_consts = Vec::with_capacity(fields.len());
-
-                // Note: First element inValTree corresponds to variant of enum
-                let mut valtree_idx = if def.is_enum() { 1 } else { 0 };
-                for field in fields {
-                    let field_ty = field.ty(tcx, substs);
-                    let field_valtree = branches[valtree_idx]; // first element of branches is variant
-                    let field_const = tcx.mk_const(ty::ConstS {
-                        kind: ty::ConstKind::Value(field_valtree),
-                        ty: field_ty,
-                    });
-                    field_consts.push(field_const);
-                    valtree_idx += 1;
-                }
-                debug!(?field_consts);
-
-                (field_consts, Some(variant_idx))
-            }
-            ty::Tuple(elem_tys) => {
-                let fields = elem_tys
-                    .iter()
-                    .enumerate()
-                    .map(|(i, elem_ty)| {
-                        let elem_valtree = branches[i];
-                        tcx.mk_const(ty::ConstS {
-                            kind: ty::ConstKind::Value(elem_valtree),
-                            ty: elem_ty,
-                        })
-                    })
-                    .collect::<Vec<_>>();
-
-                (fields, None)
-            }
-            _ => bug!("cannot destructure constant {:?}", const_),
-        };
-
-        let fields = tcx.arena.alloc_from_iter(fields.into_iter());
-
-        Some(ty::DestructuredConst { variant, fields })
-    } else {
-        None
     }
 }
 

--- a/compiler/rustc_const_eval/src/lib.rs
+++ b/compiler/rustc_const_eval/src/lib.rs
@@ -42,7 +42,6 @@ pub fn provide(providers: &mut Providers) {
     providers.eval_to_const_value_raw = const_eval::eval_to_const_value_raw_provider;
     providers.eval_to_allocation_raw = const_eval::eval_to_allocation_raw_provider;
     providers.const_caller_location = const_eval::const_caller_location;
-    providers.try_destructure_const = |tcx, val| const_eval::try_destructure_const(tcx, val);
     providers.eval_to_valtree = |tcx, param_env_and_value| {
         let (param_env, raw) = param_env_and_value.into_parts();
         const_eval::eval_to_valtree(tcx, param_env, raw)

--- a/compiler/rustc_middle/src/mir/interpret/queries.rs
+++ b/compiler/rustc_middle/src/mir/interpret/queries.rs
@@ -205,14 +205,8 @@ impl<'tcx> TyCtxtEnsure<'tcx> {
 }
 
 impl<'tcx> TyCtxt<'tcx> {
-    /// Destructure a type-level constant ADT or array into its variant index and its field values.
-    /// Panics if the destructuring fails, use `try_destructure_const` for fallible version.
-    pub fn destructure_const(self, const_: ty::Const<'tcx>) -> ty::DestructuredConst<'tcx> {
-        self.try_destructure_const(const_).unwrap()
-    }
-
     /// Destructure a mir constant ADT or array into its variant index and its field values.
-    /// Panics if the destructuring fails, use `try_destructure_const` for fallible version.
+    /// Panics if the destructuring fails, use `try_destructure_mir_constant` for fallible version.
     pub fn destructure_mir_constant(
         self,
         param_env: ty::ParamEnv<'tcx>,

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -978,11 +978,8 @@ rustc_queries! {
         desc { "converting type-level constant value to mir constant value"}
     }
 
-    /// Destructure a constant ADT or array into its variant index and its
-    /// field values or return `None` if constant is invalid.
-    ///
-    /// Use infallible `TyCtxt::destructure_const` when you know that constant is valid.
-    query try_destructure_const(key: ty::Const<'tcx>) -> Option<ty::DestructuredConst<'tcx>> {
+    /// Destructure a type-level constant ADT or array into its variant index and its field values.
+    query destructure_const(key: ty::Const<'tcx>) -> ty::DestructuredConst<'tcx> {
         desc { "destructuring type level constant"}
     }
 

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -978,7 +978,8 @@ rustc_queries! {
         desc { "converting type-level constant value to mir constant value"}
     }
 
-    /// Destructure a type-level constant ADT or array into its variant index and its field values.
+    /// Destructures array, ADT or tuple constants into the constants
+    /// of their fields.
     query destructure_const(key: ty::Const<'tcx>) -> ty::DestructuredConst<'tcx> {
         desc { "destructuring type level constant"}
     }

--- a/compiler/rustc_ty_utils/src/consts.rs
+++ b/compiler/rustc_ty_utils/src/consts.rs
@@ -1,84 +1,77 @@
 use rustc_middle::ty::{self, TyCtxt};
 use rustc_target::abi::VariantIdx;
 
-/// Tries to destructure constants of type Array or Adt into the constants
+use std::iter;
+
+/// Tries to destructure array, ADT or tuple constants into the constants
 /// of its fields.
 pub(crate) fn destructure_const<'tcx>(
     tcx: TyCtxt<'tcx>,
     const_: ty::Const<'tcx>,
 ) -> ty::DestructuredConst<'tcx> {
-    if let ty::ConstKind::Value(valtree) = const_.kind() {
-        let branches = match valtree {
-            ty::ValTree::Branch(b) => b,
-            _ => bug!("cannot destructure constant {:?}", const_),
-        };
-
-        let (fields, variant) = match const_.ty().kind() {
-            ty::Array(inner_ty, _) | ty::Slice(inner_ty) => {
-                // construct the consts for the elements of the array/slice
-                let field_consts = branches
-                    .iter()
-                    .map(|b| {
-                        tcx.mk_const(ty::ConstS { kind: ty::ConstKind::Value(*b), ty: *inner_ty })
-                    })
-                    .collect::<Vec<_>>();
-                debug!(?field_consts);
-
-                (field_consts, None)
-            }
-            ty::Adt(def, _) if def.variants().is_empty() => bug!("unreachable"),
-            ty::Adt(def, substs) => {
-                let variant_idx = if def.is_enum() {
-                    VariantIdx::from_u32(branches[0].unwrap_leaf().try_to_u32().unwrap())
-                } else {
-                    VariantIdx::from_u32(0)
-                };
-                let fields = &def.variant(variant_idx).fields;
-                let mut field_consts = Vec::with_capacity(fields.len());
-
-                // Note: First element inValTree corresponds to variant of enum
-                let mut valtree_idx = if def.is_enum() { 1 } else { 0 };
-                for field in fields {
-                    let field_ty = field.ty(tcx, substs);
-                    let field_valtree = branches[valtree_idx]; // first element of branches is variant
-                    let field_const = tcx.mk_const(ty::ConstS {
-                        kind: ty::ConstKind::Value(field_valtree),
-                        ty: field_ty,
-                    });
-                    field_consts.push(field_const);
-                    valtree_idx += 1;
-                }
-                debug!(?field_consts);
-
-                (field_consts, Some(variant_idx))
-            }
-            ty::Tuple(elem_tys) => {
-                let fields = elem_tys
-                    .iter()
-                    .enumerate()
-                    .map(|(i, elem_ty)| {
-                        let elem_valtree = branches[i];
-                        tcx.mk_const(ty::ConstS {
-                            kind: ty::ConstKind::Value(elem_valtree),
-                            ty: elem_ty,
-                        })
-                    })
-                    .collect::<Vec<_>>();
-
-                (fields, None)
-            }
-            _ => bug!("cannot destructure constant {:?}", const_),
-        };
-
-        let fields = tcx.arena.alloc_from_iter(fields.into_iter());
-
-        ty::DestructuredConst { variant, fields }
-    } else {
+    let ty::ConstKind::Value(valtree) = const_.kind() else {
         bug!("cannot destructure constant {:?}", const_)
-    }
+    };
+
+    let branches = match valtree {
+        ty::ValTree::Branch(b) => b,
+        _ => bug!("cannot destructure constant {:?}", const_),
+    };
+
+    let (fields, variant) = match const_.ty().kind() {
+        ty::Array(inner_ty, _) | ty::Slice(inner_ty) => {
+            // construct the consts for the elements of the array/slice
+            let field_consts = branches
+                .iter()
+                .map(|b| tcx.mk_const(ty::ConstS { kind: ty::ConstKind::Value(*b), ty: *inner_ty }))
+                .collect::<Vec<_>>();
+            debug!(?field_consts);
+
+            (field_consts, None)
+        }
+        ty::Adt(def, _) if def.variants().is_empty() => bug!("unreachable"),
+        ty::Adt(def, substs) => {
+            let (variant_idx, branches) = if def.is_enum() {
+                let (head, rest) = branches.split_first().unwrap();
+                (VariantIdx::from_u32(head.unwrap_leaf().try_to_u32().unwrap()), rest)
+            } else {
+                (VariantIdx::from_u32(0), branches)
+            };
+            let fields = &def.variant(variant_idx).fields;
+            let mut field_consts = Vec::with_capacity(fields.len());
+
+            for (field, field_valtree) in iter::zip(fields, branches) {
+                let field_ty = field.ty(tcx, substs);
+                let field_const = tcx.mk_const(ty::ConstS {
+                    kind: ty::ConstKind::Value(*field_valtree),
+                    ty: field_ty,
+                });
+                field_consts.push(field_const);
+            }
+            debug!(?field_consts);
+
+            (field_consts, Some(variant_idx))
+        }
+        ty::Tuple(elem_tys) => {
+            let fields = iter::zip(*elem_tys, branches)
+                .map(|(elem_ty, elem_valtree)| {
+                    tcx.mk_const(ty::ConstS {
+                        kind: ty::ConstKind::Value(*elem_valtree),
+                        ty: elem_ty,
+                    })
+                })
+                .collect::<Vec<_>>();
+
+            (fields, None)
+        }
+        _ => bug!("cannot destructure constant {:?}", const_),
+    };
+
+    let fields = tcx.arena.alloc_from_iter(fields.into_iter());
+
+    ty::DestructuredConst { variant, fields }
 }
 
 pub fn provide(providers: &mut ty::query::Providers) {
-    *providers =
-        ty::query::Providers { destructure_const, ..*providers };
+    *providers = ty::query::Providers { destructure_const, ..*providers };
 }

--- a/compiler/rustc_ty_utils/src/consts.rs
+++ b/compiler/rustc_ty_utils/src/consts.rs
@@ -3,8 +3,8 @@ use rustc_target::abi::VariantIdx;
 
 use std::iter;
 
-/// Tries to destructure array, ADT or tuple constants into the constants
-/// of its fields.
+/// Destructures array, ADT or tuple constants into the constants
+/// of their fields.
 pub(crate) fn destructure_const<'tcx>(
     tcx: TyCtxt<'tcx>,
     const_: ty::Const<'tcx>,

--- a/compiler/rustc_ty_utils/src/consts.rs
+++ b/compiler/rustc_ty_utils/src/consts.rs
@@ -1,0 +1,84 @@
+use rustc_middle::ty::{self, TyCtxt};
+use rustc_target::abi::VariantIdx;
+
+/// Tries to destructure constants of type Array or Adt into the constants
+/// of its fields.
+pub(crate) fn destructure_const<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    const_: ty::Const<'tcx>,
+) -> ty::DestructuredConst<'tcx> {
+    if let ty::ConstKind::Value(valtree) = const_.kind() {
+        let branches = match valtree {
+            ty::ValTree::Branch(b) => b,
+            _ => bug!("cannot destructure constant {:?}", const_),
+        };
+
+        let (fields, variant) = match const_.ty().kind() {
+            ty::Array(inner_ty, _) | ty::Slice(inner_ty) => {
+                // construct the consts for the elements of the array/slice
+                let field_consts = branches
+                    .iter()
+                    .map(|b| {
+                        tcx.mk_const(ty::ConstS { kind: ty::ConstKind::Value(*b), ty: *inner_ty })
+                    })
+                    .collect::<Vec<_>>();
+                debug!(?field_consts);
+
+                (field_consts, None)
+            }
+            ty::Adt(def, _) if def.variants().is_empty() => bug!("unreachable"),
+            ty::Adt(def, substs) => {
+                let variant_idx = if def.is_enum() {
+                    VariantIdx::from_u32(branches[0].unwrap_leaf().try_to_u32().unwrap())
+                } else {
+                    VariantIdx::from_u32(0)
+                };
+                let fields = &def.variant(variant_idx).fields;
+                let mut field_consts = Vec::with_capacity(fields.len());
+
+                // Note: First element inValTree corresponds to variant of enum
+                let mut valtree_idx = if def.is_enum() { 1 } else { 0 };
+                for field in fields {
+                    let field_ty = field.ty(tcx, substs);
+                    let field_valtree = branches[valtree_idx]; // first element of branches is variant
+                    let field_const = tcx.mk_const(ty::ConstS {
+                        kind: ty::ConstKind::Value(field_valtree),
+                        ty: field_ty,
+                    });
+                    field_consts.push(field_const);
+                    valtree_idx += 1;
+                }
+                debug!(?field_consts);
+
+                (field_consts, Some(variant_idx))
+            }
+            ty::Tuple(elem_tys) => {
+                let fields = elem_tys
+                    .iter()
+                    .enumerate()
+                    .map(|(i, elem_ty)| {
+                        let elem_valtree = branches[i];
+                        tcx.mk_const(ty::ConstS {
+                            kind: ty::ConstKind::Value(elem_valtree),
+                            ty: elem_ty,
+                        })
+                    })
+                    .collect::<Vec<_>>();
+
+                (fields, None)
+            }
+            _ => bug!("cannot destructure constant {:?}", const_),
+        };
+
+        let fields = tcx.arena.alloc_from_iter(fields.into_iter());
+
+        ty::DestructuredConst { variant, fields }
+    } else {
+        bug!("cannot destructure constant {:?}", const_)
+    }
+}
+
+pub fn provide(providers: &mut ty::query::Providers) {
+    *providers =
+        ty::query::Providers { destructure_const, ..*providers };
+}

--- a/compiler/rustc_ty_utils/src/lib.rs
+++ b/compiler/rustc_ty_utils/src/lib.rs
@@ -18,6 +18,7 @@ use rustc_middle::ty::query::Providers;
 
 mod assoc;
 mod common_traits;
+pub mod consts;
 pub mod instance;
 mod needs_drop;
 pub mod representability;
@@ -26,6 +27,7 @@ mod ty;
 pub fn provide(providers: &mut Providers) {
     assoc::provide(providers);
     common_traits::provide(providers);
+    consts::provide(providers);
     needs_drop::provide(providers);
     ty::provide(providers);
     instance::provide(providers);

--- a/compiler/rustc_ty_utils/src/lib.rs
+++ b/compiler/rustc_ty_utils/src/lib.rs
@@ -18,7 +18,7 @@ use rustc_middle::ty::query::Providers;
 
 mod assoc;
 mod common_traits;
-pub mod consts;
+mod consts;
 pub mod instance;
 mod needs_drop;
 pub mod representability;

--- a/src/test/ui/const-generics/issue-66451.rs
+++ b/src/test/ui/const-generics/issue-66451.rs
@@ -1,0 +1,28 @@
+#![feature(adt_const_params)]
+#![allow(incomplete_features)]
+
+#[derive(Debug, PartialEq, Eq)]
+struct Foo {
+    value: i32,
+    nested: &'static Bar<i32>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct Bar<T>(T);
+
+struct Test<const F: Foo>;
+
+fn main() {
+    let x: Test<{
+        Foo {
+            value: 3,
+            nested: &Bar(4),
+        }  
+    }> = Test;
+    let y: Test<{
+        Foo {
+            value: 3,
+            nested: &Bar(5),
+        }
+    }> = x; //~ ERROR mismatched types
+}

--- a/src/test/ui/const-generics/issue-66451.rs
+++ b/src/test/ui/const-generics/issue-66451.rs
@@ -17,7 +17,7 @@ fn main() {
         Foo {
             value: 3,
             nested: &Bar(4),
-        }  
+        }
     }> = Test;
     let y: Test<{
         Foo {

--- a/src/test/ui/const-generics/issue-66451.stderr
+++ b/src/test/ui/const-generics/issue-66451.stderr
@@ -1,0 +1,20 @@
+error[E0308]: mismatched types
+  --> $DIR/issue-66451.rs:27:10
+   |
+LL |       let y: Test<{
+   |  ____________-
+LL | |         Foo {
+LL | |             value: 3,
+LL | |             nested: &Bar(5),
+LL | |         }
+LL | |     }> = x;
+   | |      -   ^ expected `Foo { value: 3_i32, nested: &Bar::<i32>(5_i32) }`, found `Foo { value: 3_i32, nested: &Bar::<i32>(4_i32) }`
+   | |______|
+   |        expected due to this
+   |
+   = note: expected struct `Test<Foo { value: 3_i32, nested: &Bar::<i32>(5_i32) }>`
+              found struct `Test<Foo { value: 3_i32, nested: &Bar::<i32>(4_i32) }>`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
This implements the changes outlined in https://github.com/rust-lang/rust/issues/66451#issuecomment-1168859638.

r? @lcnr 
Fixes #66451