### PR TITLE
`alloc`: clean and ensure `no_global_oom_handling`  builds are warning-free

### DIFF
--- a/library/alloc/src/boxed/thin.rs
+++ b/library/alloc/src/boxed/thin.rs
@@ -3,7 +3,9 @@
 // by matthieu-m
 use crate::alloc::{self, Layout, LayoutError};
 use core::fmt::{self, Debug, Display, Formatter};
-use core::marker::{PhantomData, Unsize};
+use core::marker::PhantomData;
+#[cfg(not(no_global_oom_handling))]
+use core::marker::Unsize;
 use core::mem;
 use core::ops::{Deref, DerefMut};
 use core::ptr::Pointee;

--- a/library/alloc/src/raw_vec.rs
+++ b/library/alloc/src/raw_vec.rs
@@ -421,6 +421,7 @@ impl<T, A: Allocator> RawVec<T, A> {
         Ok(())
     }
 
+    #[cfg(not(no_global_oom_handling))]
     fn shrink(&mut self, cap: usize) -> Result<(), TryReserveError> {
         assert!(cap <= self.capacity(), "Tried to shrink to a larger capacity");
 

--- a/library/alloc/src/string.rs
+++ b/library/alloc/src/string.rs
@@ -46,9 +46,9 @@
 use core::char::{decode_utf16, REPLACEMENT_CHARACTER};
 use core::fmt;
 use core::hash;
+use core::iter::FusedIterator;
 #[cfg(not(no_global_oom_handling))]
-use core::iter::FromIterator;
-use core::iter::{from_fn, FusedIterator};
+use core::iter::{from_fn, FromIterator};
 #[cfg(not(no_global_oom_handling))]
 use core::ops::Add;
 #[cfg(not(no_global_oom_handling))]

--- a/library/alloc/src/vec/into_iter.rs
+++ b/library/alloc/src/vec/into_iter.rs
@@ -9,6 +9,7 @@ use core::iter::{
 };
 use core::marker::PhantomData;
 use core::mem::{self, ManuallyDrop};
+#[cfg(not(no_global_oom_handling))]
 use core::ops::Deref;
 use core::ptr::{self, NonNull};
 use core::slice::{self};
@@ -123,6 +124,7 @@ impl<T, A: Allocator> IntoIter<T, A> {
     }
 
     /// Forgets to Drop the remaining elements while still allowing the backing allocation to be freed.
+    #[cfg(not(no_global_oom_handling))]
     pub(crate) fn forget_remaining_elements(&mut self) {
         self.ptr = self.end;
     }

--- a/src/test/run-make-fulldeps/alloc-no-oom-handling/Makefile
+++ b/src/test/run-make-fulldeps/alloc-no-oom-handling/Makefile
@@ -1,4 +1,4 @@
 -include ../tools.mk
 
 all:
-	$(RUSTC) --edition=2021 --crate-type=rlib ../../../../library/alloc/src/lib.rs --cfg no_global_oom_handling
+	$(RUSTC) --edition=2021 -Dwarnings --crate-type=rlib ../../../../library/alloc/src/lib.rs --cfg no_global_oom_handling


### PR DESCRIPTION
Rust 1.62.0 introduced a couple new `unused_imports` warnings
in `no_global_oom_handling` builds, making a total of 5 warnings.

<details>

```txt
warning: unused import: `Unsize`
 --> library/alloc/src/boxed/thin.rs:6:33
  |
6 | use core::marker::{PhantomData, Unsize};
  |                                 ^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default

warning: unused import: `from_fn`
  --> library/alloc/src/string.rs:51:18
   |
51 | use core::iter::{from_fn, FusedIterator};
   |                  ^^^^^^^

warning: unused import: `core::ops::Deref`
  --> library/alloc/src/vec/into_iter.rs:12:5
   |
12 | use core::ops::Deref;
   |     ^^^^^^^^^^^^^^^^

warning: associated function `shrink` is never used
   --> library/alloc/src/raw_vec.rs:424:8
    |
424 |     fn shrink(&mut self, cap: usize) -> Result<(), TryReserveError> {
    |        ^^^^^^
    |
    = note: `#[warn(dead_code)]` on by default

warning: associated function `forget_remaining_elements` is never used
   --> library/alloc/src/vec/into_iter.rs:126:19
    |
126 |     pub(crate) fn forget_remaining_elements(&mut self) {
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^
```

</details>

This PR cleans them and ensures no new ones are introduced
so that projects compiling `alloc` without infallible allocations
do not see them (and may want to enable `-Dwarnings`).

The couple `dead_code` ones may be reverted when some fallible
allocation support starts using them.