### PR TITLE
ignore `invalid-punct-ident-1.rs` proc-macro test on stage1

### DIFF
--- a/src/test/ui/proc-macro/invalid-punct-ident-1.rs
+++ b/src/test/ui/proc-macro/invalid-punct-ident-1.rs
@@ -1,7 +1,7 @@
 // aux-build:invalid-punct-ident.rs
 // rustc-env:RUST_BACKTRACE=0
 
-// FIXME https://github.com/rust-lang/rust/issues/59998
+// ignore-stage1: FIXME https://github.com/rust-lang/rust/issues/59998
 // normalize-stderr-test "thread.*panicked.*proc_macro.*lib.rs.*\n" -> ""
 // normalize-stderr-test "note:.*RUST_BACKTRACE=1.*\n" -> ""
 // normalize-stderr-test "\nerror: internal compiler error.*\n\n" -> ""


### PR DESCRIPTION
`invalid-punct-ident-1.rs` has been failing on stage1, which impacts people's workflows. 

More details in this [zulip thread](https://rust-lang.zulipchat.com/#narrow/stream/131828-t-compiler/topic/invalid-punct-ident-1.2Ers.20test.20failure)

r? @eddyb 