### PR TITLE
Avoid some `&str` to `String` conversions with `MultiSpan::push_span_label`

### DIFF
--- a/compiler/rustc_expand/src/tests.rs
+++ b/compiler/rustc_expand/src/tests.rs
@@ -136,7 +136,7 @@ fn test_harness(file_text: &str, span_labels: Vec<SpanLabel>, expected_output: &
         let mut msp = MultiSpan::from_span(primary_span);
         for span_label in span_labels {
             let span = make_span(&file_text, &span_label.start, &span_label.end);
-            msp.push_span_label(span, span_label.label.to_string());
+            msp.push_span_label(span, span_label.label);
             println!("span: {:?} label: {:?}", span, span_label.label);
             println!("text: {:?}", source_map.span_to_snippet(span));
         }

--- a/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/static_impl_trait.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/static_impl_trait.rs
@@ -194,10 +194,7 @@ impl<'a, 'tcx> NiceRegionError<'a, 'tcx> {
                         if !v.0.is_empty() {
                             span = v.0.clone().into();
                             for sp in v.0 {
-                                span.push_span_label(
-                                    sp,
-                                    "`'static` requirement introduced here".to_string(),
-                                );
+                                span.push_span_label(sp, "`'static` requirement introduced here");
                             }
                             add_label = false;
                         }
@@ -205,13 +202,10 @@ impl<'a, 'tcx> NiceRegionError<'a, 'tcx> {
                     if add_label {
                         span.push_span_label(
                             fn_decl.output.span(),
-                            "requirement introduced by this return type".to_string(),
+                            "requirement introduced by this return type",
                         );
                     }
-                    span.push_span_label(
-                        cause.span,
-                        "because of this returned expression".to_string(),
-                    );
+                    span.push_span_label(cause.span, "because of this returned expression");
                     err.span_note(
                         span,
                         "`'static` lifetime requirement introduced by the return type",
@@ -523,13 +517,11 @@ impl<'a, 'tcx> NiceRegionError<'a, 'tcx> {
             hir_v.visit_ty(&self_ty);
             for span in &traits {
                 let mut multi_span: MultiSpan = vec![*span].into();
-                multi_span.push_span_label(
-                    *span,
-                    "this has an implicit `'static` lifetime requirement".to_string(),
-                );
+                multi_span
+                    .push_span_label(*span, "this has an implicit `'static` lifetime requirement");
                 multi_span.push_span_label(
                     ident.span,
-                    "calling this method introduces the `impl`'s 'static` requirement".to_string(),
+                    "calling this method introduces the `impl`'s 'static` requirement",
                 );
                 err.span_note(multi_span, "the used `impl` has a `'static` requirement");
                 err.span_suggestion_verbose(

--- a/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/trait_impl_difference.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/trait_impl_difference.rs
@@ -128,10 +128,8 @@ impl<'a, 'tcx> NiceRegionError<'a, 'tcx> {
         }
         let mut type_param_span: MultiSpan = visitor.types.to_vec().into();
         for &span in &visitor.types {
-            type_param_span.push_span_label(
-                span,
-                "consider borrowing this type parameter in the trait".to_string(),
-            );
+            type_param_span
+                .push_span_label(span, "consider borrowing this type parameter in the trait");
         }
 
         err.note(&format!("expected `{}`\n   found `{}`", expected, found));

--- a/compiler/rustc_infer/src/traits/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/traits/error_reporting/mod.rs
@@ -85,8 +85,7 @@ pub fn report_object_safety_error<'tcx>(
     let has_multi_span = !multi_span.is_empty();
     let mut note_span = MultiSpan::from_spans(multi_span.clone());
     if let (Some(trait_span), true) = (trait_span, has_multi_span) {
-        note_span
-            .push_span_label(trait_span, "this trait cannot be made into an object...".to_string());
+        note_span.push_span_label(trait_span, "this trait cannot be made into an object...");
     }
     for (span, msg) in iter::zip(multi_span, messages) {
         note_span.push_span_label(span, msg);

--- a/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
@@ -947,7 +947,7 @@ fn adt_defined_here<'p, 'tcx>(
 
         span.push_span_label(def_span, String::new());
         for pat in spans {
-            span.push_span_label(pat, "not covered".to_string());
+            span.push_span_label(pat, "not covered");
         }
         err.span_note(span, &format!("`{}` defined here", ty));
     }

--- a/compiler/rustc_parse/src/parser/mod.rs
+++ b/compiler/rustc_parse/src/parser/mod.rs
@@ -887,22 +887,19 @@ impl<'a> Parser<'a> {
         let mut first_note = MultiSpan::from(vec![initial_semicolon]);
         first_note.push_span_label(
             initial_semicolon,
-            "this `;` turns the preceding closure into a statement".to_string(),
+            "this `;` turns the preceding closure into a statement",
         );
         first_note.push_span_label(
             closure_spans.body,
-            "this expression is a statement because of the trailing semicolon".to_string(),
+            "this expression is a statement because of the trailing semicolon",
         );
         expect_err.span_note(first_note, "statement found outside of a block");
 
         let mut second_note = MultiSpan::from(vec![closure_spans.whole_closure]);
-        second_note.push_span_label(
-            closure_spans.whole_closure,
-            "this is the parsed closure...".to_string(),
-        );
+        second_note.push_span_label(closure_spans.whole_closure, "this is the parsed closure...");
         second_note.push_span_label(
             following_token_span,
-            "...but likely you meant the closure to end here".to_string(),
+            "...but likely you meant the closure to end here",
         );
         expect_err.span_note(second_note, "the closure body may be incorrectly delimited");
 

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -857,11 +857,8 @@ impl CheckAttrVisitor<'_> {
             if let Some((prev_inline, prev_span)) = *specified_inline {
                 if do_inline != prev_inline {
                     let mut spans = MultiSpan::from_spans(vec![prev_span, meta.span()]);
-                    spans.push_span_label(prev_span, String::from("this attribute..."));
-                    spans.push_span_label(
-                        meta.span(),
-                        String::from("...conflicts with this attribute"),
-                    );
+                    spans.push_span_label(prev_span, "this attribute...");
+                    spans.push_span_label(meta.span(), "...conflicts with this attribute");
                     self.tcx
                         .sess
                         .struct_span_err(spans, "conflicting doc inlining attributes")

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -2561,7 +2561,7 @@ fn show_candidates(
                 let span = source_span[local_def_id];
                 let span = session.source_map().guess_head_span(span);
                 let mut multi_span = MultiSpan::from_span(span);
-                multi_span.push_span_label(span, "not accessible".to_string());
+                multi_span.push_span_label(span, "not accessible");
                 err.span_note(multi_span, &msg);
             } else {
                 err.note(&msg);

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -601,10 +601,8 @@ impl<'a: 'ast, 'ast> LateResolutionVisitor<'a, '_, 'ast> {
                         };
                         multi_span.push_span_label(sp, msg);
                     }
-                    multi_span.push_span_label(
-                        base_error.span,
-                        "expected this type to be a trait...".to_string(),
-                    );
+                    multi_span
+                        .push_span_label(base_error.span, "expected this type to be a trait...");
                     err.span_help(
                         multi_span,
                         "`+` is used to constrain a \"trait object\" type with lifetimes or \
@@ -1227,17 +1225,14 @@ impl<'a: 'ast, 'ast> LateResolutionVisitor<'a, '_, 'ast> {
                         let mut m: MultiSpan = non_visible_spans.clone().into();
                         non_visible_spans
                             .into_iter()
-                            .for_each(|s| m.push_span_label(s, "private field".to_string()));
+                            .for_each(|s| m.push_span_label(s, "private field"));
                         err.span_note(m, "constructor is not visible here due to private fields");
                     }
 
                     return true;
                 }
 
-                err.span_label(
-                    span,
-                    "constructor is not visible here due to private fields".to_string(),
-                );
+                err.span_label(span, "constructor is not visible here due to private fields");
             }
             (
                 Res::Def(

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -2204,8 +2204,7 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                             _ => true,
                         };
                     if !ident.span.overlaps(span) && !same_line {
-                        multispan
-                            .push_span_label(ident.span, "required by a bound in this".to_string());
+                        multispan.push_span_label(ident.span, "required by a bound in this");
                     }
                 }
                 let descr = format!("required by a bound in `{}`", item_name);

--- a/compiler/rustc_typeck/src/astconv/generics.rs
+++ b/compiler/rustc_typeck/src/astconv/generics.rs
@@ -645,7 +645,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                 err.emit();
             } else {
                 let mut multispan = MultiSpan::from_span(span);
-                multispan.push_span_label(span_late, note.to_string());
+                multispan.push_span_label(span_late, note);
                 tcx.struct_span_lint_hir(
                     LATE_BOUND_LIFETIME_ARGUMENTS,
                     args.args[0].id(),

--- a/compiler/rustc_typeck/src/check/_match.rs
+++ b/compiler/rustc_typeck/src/check/_match.rs
@@ -154,18 +154,14 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     ret_span.push_span_label(
                         expr.span,
                         "this could be implicitly returned but it is a statement, not a \
-                            tail expression"
-                            .to_owned(),
+                            tail expression",
                     );
-                    ret_span.push_span_label(
-                        ret,
-                        "the `match` arms can conform to this return type".to_owned(),
-                    );
+                    ret_span
+                        .push_span_label(ret, "the `match` arms can conform to this return type");
                     ret_span.push_span_label(
                         semi_span,
                         "the `match` is a statement because of this semicolon, consider \
-                            removing it"
-                            .to_owned(),
+                            removing it",
                     );
                     err.span_note(
                         ret_span,

--- a/compiler/rustc_typeck/src/check/check.rs
+++ b/compiler/rustc_typeck/src/check/check.rs
@@ -1591,8 +1591,7 @@ fn opaque_type_cycle_error(tcx: TyCtxt<'_>, def_id: LocalDefId, span: Span) -> E
             } else {
                 let mut multispan: MultiSpan = spans.clone().into();
                 for span in spans {
-                    multispan
-                        .push_span_label(span, "this returned value is of `!` type".to_string());
+                    multispan.push_span_label(span, "this returned value is of `!` type");
                 }
                 err.span_note(multispan, "these returned values have a concrete \"never\" type");
             }

--- a/compiler/rustc_typeck/src/check/fn_ctxt/_impl.rs
+++ b/compiler/rustc_typeck/src/check/fn_ctxt/_impl.rs
@@ -1034,7 +1034,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             );
             sp.push_span_label(
                 rcvr.span,
-                "you probably want to use this value after calling the method...".to_string(),
+                "you probably want to use this value after calling the method...",
             );
             err.span_note(
                 sp,

--- a/compiler/rustc_typeck/src/check/fn_ctxt/checks.rs
+++ b/compiler/rustc_typeck/src/check/fn_ctxt/checks.rs
@@ -1768,7 +1768,7 @@ fn label_fn_like<'tcx>(
             .flat_map(|id| tcx.hir().body(id).params);
 
         for param in params {
-            spans.push_span_label(param.span, String::new());
+            spans.push_span_label(param.span, "");
         }
 
         let def_kind = tcx.def_kind(def_id);

--- a/compiler/rustc_typeck/src/check/method/suggest.rs
+++ b/compiler/rustc_typeck/src/check/method/suggest.rs
@@ -638,7 +638,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         let parent_trait_ref = data.parent_trait_pred;
                         let path = parent_trait_ref.print_modifiers_and_trait_path();
                         let tr_self_ty = parent_trait_ref.skip_binder().self_ty();
-                        let unsatisfied_msg = "unsatisfied trait bound introduced here".to_string();
+                        let unsatisfied_msg = "unsatisfied trait bound introduced here";
                         let derive_msg =
                             "unsatisfied trait bound introduced in this `derive` macro";
                         match self.tcx.hir().get_if_local(impl_def_id) {
@@ -655,7 +655,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             {
                                 let span = ident.span.ctxt().outer_expn_data().call_site;
                                 let mut spans: MultiSpan = span.into();
-                                spans.push_span_label(span, derive_msg.to_string());
+                                spans.push_span_label(span, derive_msg);
                                 let entry = spanned_predicates.entry(spans);
                                 entry.or_insert_with(|| (path, tr_self_ty, Vec::new())).2.push(p);
                             }
@@ -678,7 +678,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             {
                                 let span = self_ty.span.ctxt().outer_expn_data().call_site;
                                 let mut spans: MultiSpan = span.into();
-                                spans.push_span_label(span, derive_msg.to_string());
+                                spans.push_span_label(span, derive_msg);
                                 let entry = spanned_predicates.entry(spans);
                                 entry.or_insert_with(|| (path, tr_self_ty, Vec::new())).2.push(p);
                             }
@@ -706,7 +706,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                                 } else {
                                     ident.span.into()
                                 };
-                                spans.push_span_label(ident.span, "in this trait".to_string());
+                                spans.push_span_label(ident.span, "in this trait");
                                 let entry = spanned_predicates.entry(spans);
                                 entry.or_insert_with(|| (path, tr_self_ty, Vec::new())).2.push(p);
                             }
@@ -747,9 +747,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                                     spans.into()
                                 };
                                 if let Some(trait_ref) = of_trait {
-                                    spans.push_span_label(trait_ref.path.span, String::new());
+                                    spans.push_span_label(trait_ref.path.span, "");
                                 }
-                                spans.push_span_label(self_ty.span, String::new());
+                                spans.push_span_label(self_ty.span, "");
 
                                 let entry = spanned_predicates.entry(spans);
                                 entry.or_insert_with(|| (path, tr_self_ty, Vec::new())).2.push(p);

--- a/compiler/rustc_typeck/src/structured_errors/wrong_number_of_generic_args.rs
+++ b/compiler/rustc_typeck/src/structured_errors/wrong_number_of_generic_args.rs
@@ -836,7 +836,7 @@ impl<'a, 'tcx> WrongNumberOfGenericArgs<'a, 'tcx> {
                     .take(bound)
                     .map(|param| {
                         let span = self.tcx.def_span(param.def_id);
-                        spans.push_span_label(span, String::new());
+                        spans.push_span_label(span, "");
                         param
                     })
                     .map(|param| format!("`{}`", param.name))


### PR DESCRIPTION
This patch removes some`&str` to `String` conversions with `MultiSpan::push_span_label`.