### PR TITLE
For diagnostic information of Boolean, remind it as use the type: 'bool'

### DIFF
--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -1508,6 +1508,8 @@ impl<'a: 'ast, 'ast> LateResolutionVisitor<'a, '_, 'ast> {
         Some(match name {
             "byte" => sym::u8, // In Java, bytes are signed, but in practice one almost always wants unsigned bytes.
             "short" => sym::i16,
+            "Bool" => sym::bool,
+            "Boolean" => sym::bool,
             "boolean" => sym::bool,
             "int" => sym::i32,
             "long" => sym::i64,

--- a/src/test/ui/lint/recommend-literal.rs
+++ b/src/test/ui/lint/recommend-literal.rs
@@ -7,6 +7,13 @@ fn main() {
     let y: long = 74802374902374923;
     //~^ ERROR cannot find type `long` in this scope
     //~| HELP perhaps you intended to use this type
+    let v1: Boolean = true;
+    //~^ ERROR: cannot find type `Boolean` in this scope [E0412]
+    //~| HELP perhaps you intended to use this type
+    let v2: Bool = true;
+    //~^ ERROR: cannot find type `Bool` in this scope [E0412]
+    //~| HELP a builtin type with a similar name exists
+    //~| HELP perhaps you intended to use this type
 }
 
 fn z(a: boolean) {

--- a/src/test/ui/lint/recommend-literal.stderr
+++ b/src/test/ui/lint/recommend-literal.stderr
@@ -16,8 +16,32 @@ LL |     let y: long = 74802374902374923;
    |            not found in this scope
    |            help: perhaps you intended to use this type: `i64`
 
+error[E0412]: cannot find type `Boolean` in this scope
+  --> $DIR/recommend-literal.rs:10:13
+   |
+LL |     let v1: Boolean = true;
+   |             ^^^^^^^
+   |             |
+   |             not found in this scope
+   |             help: perhaps you intended to use this type: `bool`
+
+error[E0412]: cannot find type `Bool` in this scope
+  --> $DIR/recommend-literal.rs:13:13
+   |
+LL |     let v2: Bool = true;
+   |             ^^^^
+   |
+help: a builtin type with a similar name exists
+   |
+LL |     let v2: bool = true;
+   |             ~~~~
+help: perhaps you intended to use this type
+   |
+LL |     let v2: bool = true;
+   |             ~~~~
+
 error[E0412]: cannot find type `boolean` in this scope
-  --> $DIR/recommend-literal.rs:12:9
+  --> $DIR/recommend-literal.rs:19:9
    |
 LL | fn z(a: boolean) {
    |         ^^^^^^^
@@ -26,7 +50,7 @@ LL | fn z(a: boolean) {
    |         help: perhaps you intended to use this type: `bool`
 
 error[E0412]: cannot find type `byte` in this scope
-  --> $DIR/recommend-literal.rs:17:11
+  --> $DIR/recommend-literal.rs:24:11
    |
 LL | fn a() -> byte {
    |           ^^^^
@@ -35,7 +59,7 @@ LL | fn a() -> byte {
    |           help: perhaps you intended to use this type: `u8`
 
 error[E0412]: cannot find type `float` in this scope
-  --> $DIR/recommend-literal.rs:24:12
+  --> $DIR/recommend-literal.rs:31:12
    |
 LL |     width: float,
    |            ^^^^^
@@ -44,7 +68,7 @@ LL |     width: float,
    |            help: perhaps you intended to use this type: `f32`
 
 error[E0412]: cannot find type `int` in this scope
-  --> $DIR/recommend-literal.rs:27:19
+  --> $DIR/recommend-literal.rs:34:19
    |
 LL |     depth: Option<int>,
    |                   ^^^ not found in this scope
@@ -59,7 +83,7 @@ LL | struct Data<int> {
    |            +++++
 
 error[E0412]: cannot find type `short` in this scope
-  --> $DIR/recommend-literal.rs:33:16
+  --> $DIR/recommend-literal.rs:40:16
    |
 LL | impl Stuff for short {}
    |                ^^^^^
@@ -67,6 +91,6 @@ LL | impl Stuff for short {}
    |                not found in this scope
    |                help: perhaps you intended to use this type: `i16`
 
-error: aborting due to 7 previous errors
+error: aborting due to 9 previous errors
 
 For more information about this error, try `rustc --explain E0412`.


### PR DESCRIPTION
Fixes #98492.

It helps programmers coming from other languages
	modified:   compiler/rustc_resolve/src/late/diagnostics.rs