### PR TITLE
Rollup of 10 pull requests

### DIFF
--- a/compiler/rustc_const_eval/src/const_eval/mod.rs
+++ b/compiler/rustc_const_eval/src/const_eval/mod.rs
@@ -5,7 +5,6 @@ use rustc_middle::mir;
 use rustc_middle::mir::interpret::{EvalToValTreeResult, GlobalId};
 use rustc_middle::ty::{self, TyCtxt};
 use rustc_span::{source_map::DUMMY_SP, symbol::Symbol};
-use rustc_target::abi::VariantIdx;
 
 use crate::interpret::{
     intern_const_alloc_recursive, ConstValue, InternKind, InterpCx, InterpResult, MemPlaceMeta,
@@ -88,83 +87,6 @@ pub(crate) fn eval_to_valtree<'tcx>(
                 ValTreeCreationError::NonSupportedType | ValTreeCreationError::Other => Ok(None),
             }
         }
-    }
-}
-
-/// Tries to destructure constants of type Array or Adt into the constants
-/// of its fields.
-pub(crate) fn try_destructure_const<'tcx>(
-    tcx: TyCtxt<'tcx>,
-    const_: ty::Const<'tcx>,
-) -> Option<ty::DestructuredConst<'tcx>> {
-    if let ty::ConstKind::Value(valtree) = const_.kind() {
-        let branches = match valtree {
-            ty::ValTree::Branch(b) => b,
-            _ => return None,
-        };
-
-        let (fields, variant) = match const_.ty().kind() {
-            ty::Array(inner_ty, _) | ty::Slice(inner_ty) => {
-                // construct the consts for the elements of the array/slice
-                let field_consts = branches
-                    .iter()
-                    .map(|b| {
-                        tcx.mk_const(ty::ConstS { kind: ty::ConstKind::Value(*b), ty: *inner_ty })
-                    })
-                    .collect::<Vec<_>>();
-                debug!(?field_consts);
-
-                (field_consts, None)
-            }
-            ty::Adt(def, _) if def.variants().is_empty() => bug!("unreachable"),
-            ty::Adt(def, substs) => {
-                let variant_idx = if def.is_enum() {
-                    VariantIdx::from_u32(branches[0].unwrap_leaf().try_to_u32().ok()?)
-                } else {
-                    VariantIdx::from_u32(0)
-                };
-                let fields = &def.variant(variant_idx).fields;
-                let mut field_consts = Vec::with_capacity(fields.len());
-
-                // Note: First element inValTree corresponds to variant of enum
-                let mut valtree_idx = if def.is_enum() { 1 } else { 0 };
-                for field in fields {
-                    let field_ty = field.ty(tcx, substs);
-                    let field_valtree = branches[valtree_idx]; // first element of branches is variant
-                    let field_const = tcx.mk_const(ty::ConstS {
-                        kind: ty::ConstKind::Value(field_valtree),
-                        ty: field_ty,
-                    });
-                    field_consts.push(field_const);
-                    valtree_idx += 1;
-                }
-                debug!(?field_consts);
-
-                (field_consts, Some(variant_idx))
-            }
-            ty::Tuple(elem_tys) => {
-                let fields = elem_tys
-                    .iter()
-                    .enumerate()
-                    .map(|(i, elem_ty)| {
-                        let elem_valtree = branches[i];
-                        tcx.mk_const(ty::ConstS {
-                            kind: ty::ConstKind::Value(elem_valtree),
-                            ty: elem_ty,
-                        })
-                    })
-                    .collect::<Vec<_>>();
-
-                (fields, None)
-            }
-            _ => bug!("cannot destructure constant {:?}", const_),
-        };
-
-        let fields = tcx.arena.alloc_from_iter(fields.into_iter());
-
-        Some(ty::DestructuredConst { variant, fields })
-    } else {
-        None
     }
 }
 

--- a/compiler/rustc_const_eval/src/lib.rs
+++ b/compiler/rustc_const_eval/src/lib.rs
@@ -42,7 +42,6 @@ pub fn provide(providers: &mut Providers) {
     providers.eval_to_const_value_raw = const_eval::eval_to_const_value_raw_provider;
     providers.eval_to_allocation_raw = const_eval::eval_to_allocation_raw_provider;
     providers.const_caller_location = const_eval::const_caller_location;
-    providers.try_destructure_const = |tcx, val| const_eval::try_destructure_const(tcx, val);
     providers.eval_to_valtree = |tcx, param_env_and_value| {
         let (param_env, raw) = param_env_and_value.into_parts();
         const_eval::eval_to_valtree(tcx, param_env, raw)

--- a/compiler/rustc_expand/src/tests.rs
+++ b/compiler/rustc_expand/src/tests.rs
@@ -136,7 +136,7 @@ fn test_harness(file_text: &str, span_labels: Vec<SpanLabel>, expected_output: &
         let mut msp = MultiSpan::from_span(primary_span);
         for span_label in span_labels {
             let span = make_span(&file_text, &span_label.start, &span_label.end);
-            msp.push_span_label(span, span_label.label.to_string());
+            msp.push_span_label(span, span_label.label);
             println!("span: {:?} label: {:?}", span, span_label.label);
             println!("text: {:?}", source_map.span_to_snippet(span));
         }

--- a/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/static_impl_trait.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/static_impl_trait.rs
@@ -194,10 +194,7 @@ impl<'a, 'tcx> NiceRegionError<'a, 'tcx> {
                         if !v.0.is_empty() {
                             span = v.0.clone().into();
                             for sp in v.0 {
-                                span.push_span_label(
-                                    sp,
-                                    "`'static` requirement introduced here".to_string(),
-                                );
+                                span.push_span_label(sp, "`'static` requirement introduced here");
                             }
                             add_label = false;
                         }
@@ -205,13 +202,10 @@ impl<'a, 'tcx> NiceRegionError<'a, 'tcx> {
                     if add_label {
                         span.push_span_label(
                             fn_decl.output.span(),
-                            "requirement introduced by this return type".to_string(),
+                            "requirement introduced by this return type",
                         );
                     }
-                    span.push_span_label(
-                        cause.span,
-                        "because of this returned expression".to_string(),
-                    );
+                    span.push_span_label(cause.span, "because of this returned expression");
                     err.span_note(
                         span,
                         "`'static` lifetime requirement introduced by the return type",
@@ -523,13 +517,11 @@ impl<'a, 'tcx> NiceRegionError<'a, 'tcx> {
             hir_v.visit_ty(&self_ty);
             for span in &traits {
                 let mut multi_span: MultiSpan = vec![*span].into();
-                multi_span.push_span_label(
-                    *span,
-                    "this has an implicit `'static` lifetime requirement".to_string(),
-                );
+                multi_span
+                    .push_span_label(*span, "this has an implicit `'static` lifetime requirement");
                 multi_span.push_span_label(
                     ident.span,
-                    "calling this method introduces the `impl`'s 'static` requirement".to_string(),
+                    "calling this method introduces the `impl`'s 'static` requirement",
                 );
                 err.span_note(multi_span, "the used `impl` has a `'static` requirement");
                 err.span_suggestion_verbose(

--- a/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/trait_impl_difference.rs
+++ b/compiler/rustc_infer/src/infer/error_reporting/nice_region_error/trait_impl_difference.rs
@@ -128,10 +128,8 @@ impl<'a, 'tcx> NiceRegionError<'a, 'tcx> {
         }
         let mut type_param_span: MultiSpan = visitor.types.to_vec().into();
         for &span in &visitor.types {
-            type_param_span.push_span_label(
-                span,
-                "consider borrowing this type parameter in the trait".to_string(),
-            );
+            type_param_span
+                .push_span_label(span, "consider borrowing this type parameter in the trait");
         }
 
         err.note(&format!("expected `{}`\n   found `{}`", expected, found));

--- a/compiler/rustc_infer/src/traits/error_reporting/mod.rs
+++ b/compiler/rustc_infer/src/traits/error_reporting/mod.rs
@@ -85,8 +85,7 @@ pub fn report_object_safety_error<'tcx>(
     let has_multi_span = !multi_span.is_empty();
     let mut note_span = MultiSpan::from_spans(multi_span.clone());
     if let (Some(trait_span), true) = (trait_span, has_multi_span) {
-        note_span
-            .push_span_label(trait_span, "this trait cannot be made into an object...".to_string());
+        note_span.push_span_label(trait_span, "this trait cannot be made into an object...");
     }
     for (span, msg) in iter::zip(multi_span, messages) {
         note_span.push_span_label(span, msg);

--- a/compiler/rustc_middle/src/middle/stability.rs
+++ b/compiler/rustc_middle/src/middle/stability.rs
@@ -150,7 +150,7 @@ pub fn deprecation_suggestion(
     span: Span,
 ) {
     if let Some(suggestion) = suggestion {
-        diag.span_suggestion(
+        diag.span_suggestion_verbose(
             span,
             &format!("replace the use of the deprecated {}", kind),
             suggestion,

--- a/compiler/rustc_middle/src/mir/interpret/queries.rs
+++ b/compiler/rustc_middle/src/mir/interpret/queries.rs
@@ -205,14 +205,8 @@ impl<'tcx> TyCtxtEnsure<'tcx> {
 }
 
 impl<'tcx> TyCtxt<'tcx> {
-    /// Destructure a type-level constant ADT or array into its variant index and its field values.
-    /// Panics if the destructuring fails, use `try_destructure_const` for fallible version.
-    pub fn destructure_const(self, const_: ty::Const<'tcx>) -> ty::DestructuredConst<'tcx> {
-        self.try_destructure_const(const_).unwrap()
-    }
-
     /// Destructure a mir constant ADT or array into its variant index and its field values.
-    /// Panics if the destructuring fails, use `try_destructure_const` for fallible version.
+    /// Panics if the destructuring fails, use `try_destructure_mir_constant` for fallible version.
     pub fn destructure_mir_constant(
         self,
         param_env: ty::ParamEnv<'tcx>,

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -978,11 +978,8 @@ rustc_queries! {
         desc { "converting type-level constant value to mir constant value"}
     }
 
-    /// Destructure a constant ADT or array into its variant index and its
-    /// field values or return `None` if constant is invalid.
-    ///
-    /// Use infallible `TyCtxt::destructure_const` when you know that constant is valid.
-    query try_destructure_const(key: ty::Const<'tcx>) -> Option<ty::DestructuredConst<'tcx>> {
+    /// Destructure a type-level constant ADT or array into its variant index and its field values.
+    query destructure_const(key: ty::Const<'tcx>) -> ty::DestructuredConst<'tcx> {
         desc { "destructuring type level constant"}
     }
 

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -978,7 +978,8 @@ rustc_queries! {
         desc { "converting type-level constant value to mir constant value"}
     }
 
-    /// Destructure a type-level constant ADT or array into its variant index and its field values.
+    /// Destructures array, ADT or tuple constants into the constants
+    /// of their fields.
     query destructure_const(key: ty::Const<'tcx>) -> ty::DestructuredConst<'tcx> {
         desc { "destructuring type level constant"}
     }

--- a/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
@@ -947,7 +947,7 @@ fn adt_defined_here<'p, 'tcx>(
 
         span.push_span_label(def_span, String::new());
         for pat in spans {
-            span.push_span_label(pat, "not covered".to_string());
+            span.push_span_label(pat, "not covered");
         }
         err.span_note(span, &format!("`{}` defined here", ty));
     }

--- a/compiler/rustc_parse/src/parser/mod.rs
+++ b/compiler/rustc_parse/src/parser/mod.rs
@@ -887,22 +887,19 @@ impl<'a> Parser<'a> {
         let mut first_note = MultiSpan::from(vec![initial_semicolon]);
         first_note.push_span_label(
             initial_semicolon,
-            "this `;` turns the preceding closure into a statement".to_string(),
+            "this `;` turns the preceding closure into a statement",
         );
         first_note.push_span_label(
             closure_spans.body,
-            "this expression is a statement because of the trailing semicolon".to_string(),
+            "this expression is a statement because of the trailing semicolon",
         );
         expect_err.span_note(first_note, "statement found outside of a block");
 
         let mut second_note = MultiSpan::from(vec![closure_spans.whole_closure]);
-        second_note.push_span_label(
-            closure_spans.whole_closure,
-            "this is the parsed closure...".to_string(),
-        );
+        second_note.push_span_label(closure_spans.whole_closure, "this is the parsed closure...");
         second_note.push_span_label(
             following_token_span,
-            "...but likely you meant the closure to end here".to_string(),
+            "...but likely you meant the closure to end here",
         );
         expect_err.span_note(second_note, "the closure body may be incorrectly delimited");
 

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -857,11 +857,8 @@ impl CheckAttrVisitor<'_> {
             if let Some((prev_inline, prev_span)) = *specified_inline {
                 if do_inline != prev_inline {
                     let mut spans = MultiSpan::from_spans(vec![prev_span, meta.span()]);
-                    spans.push_span_label(prev_span, String::from("this attribute..."));
-                    spans.push_span_label(
-                        meta.span(),
-                        String::from("...conflicts with this attribute"),
-                    );
+                    spans.push_span_label(prev_span, "this attribute...");
+                    spans.push_span_label(meta.span(), "...conflicts with this attribute");
                     self.tcx
                         .sess
                         .struct_span_err(spans, "conflicting doc inlining attributes")

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -2561,7 +2561,7 @@ fn show_candidates(
                 let span = source_span[local_def_id];
                 let span = session.source_map().guess_head_span(span);
                 let mut multi_span = MultiSpan::from_span(span);
-                multi_span.push_span_label(span, "not accessible".to_string());
+                multi_span.push_span_label(span, "not accessible");
                 err.span_note(multi_span, &msg);
             } else {
                 err.note(&msg);

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -601,10 +601,8 @@ impl<'a: 'ast, 'ast> LateResolutionVisitor<'a, '_, 'ast> {
                         };
                         multi_span.push_span_label(sp, msg);
                     }
-                    multi_span.push_span_label(
-                        base_error.span,
-                        "expected this type to be a trait...".to_string(),
-                    );
+                    multi_span
+                        .push_span_label(base_error.span, "expected this type to be a trait...");
                     err.span_help(
                         multi_span,
                         "`+` is used to constrain a \"trait object\" type with lifetimes or \
@@ -1227,17 +1225,14 @@ impl<'a: 'ast, 'ast> LateResolutionVisitor<'a, '_, 'ast> {
                         let mut m: MultiSpan = non_visible_spans.clone().into();
                         non_visible_spans
                             .into_iter()
-                            .for_each(|s| m.push_span_label(s, "private field".to_string()));
+                            .for_each(|s| m.push_span_label(s, "private field"));
                         err.span_note(m, "constructor is not visible here due to private fields");
                     }
 
                     return true;
                 }
 
-                err.span_label(
-                    span,
-                    "constructor is not visible here due to private fields".to_string(),
-                );
+                err.span_label(span, "constructor is not visible here due to private fields");
             }
             (
                 Res::Def(

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/suggestions.rs
@@ -2204,8 +2204,7 @@ impl<'a, 'tcx> InferCtxtExt<'tcx> for InferCtxt<'a, 'tcx> {
                             _ => true,
                         };
                     if !ident.span.overlaps(span) && !same_line {
-                        multispan
-                            .push_span_label(ident.span, "required by a bound in this".to_string());
+                        multispan.push_span_label(ident.span, "required by a bound in this");
                     }
                 }
                 let descr = format!("required by a bound in `{}`", item_name);

--- a/compiler/rustc_ty_utils/src/consts.rs
+++ b/compiler/rustc_ty_utils/src/consts.rs
@@ -1,84 +1,77 @@
 use rustc_middle::ty::{self, TyCtxt};
 use rustc_target::abi::VariantIdx;
 
-/// Tries to destructure constants of type Array or Adt into the constants
+use std::iter;
+
+/// Tries to destructure array, ADT or tuple constants into the constants
 /// of its fields.
 pub(crate) fn destructure_const<'tcx>(
     tcx: TyCtxt<'tcx>,
     const_: ty::Const<'tcx>,
 ) -> ty::DestructuredConst<'tcx> {
-    if let ty::ConstKind::Value(valtree) = const_.kind() {
-        let branches = match valtree {
-            ty::ValTree::Branch(b) => b,
-            _ => bug!("cannot destructure constant {:?}", const_),
-        };
-
-        let (fields, variant) = match const_.ty().kind() {
-            ty::Array(inner_ty, _) | ty::Slice(inner_ty) => {
-                // construct the consts for the elements of the array/slice
-                let field_consts = branches
-                    .iter()
-                    .map(|b| {
-                        tcx.mk_const(ty::ConstS { kind: ty::ConstKind::Value(*b), ty: *inner_ty })
-                    })
-                    .collect::<Vec<_>>();
-                debug!(?field_consts);
-
-                (field_consts, None)
-            }
-            ty::Adt(def, _) if def.variants().is_empty() => bug!("unreachable"),
-            ty::Adt(def, substs) => {
-                let variant_idx = if def.is_enum() {
-                    VariantIdx::from_u32(branches[0].unwrap_leaf().try_to_u32().unwrap())
-                } else {
-                    VariantIdx::from_u32(0)
-                };
-                let fields = &def.variant(variant_idx).fields;
-                let mut field_consts = Vec::with_capacity(fields.len());
-
-                // Note: First element inValTree corresponds to variant of enum
-                let mut valtree_idx = if def.is_enum() { 1 } else { 0 };
-                for field in fields {
-                    let field_ty = field.ty(tcx, substs);
-                    let field_valtree = branches[valtree_idx]; // first element of branches is variant
-                    let field_const = tcx.mk_const(ty::ConstS {
-                        kind: ty::ConstKind::Value(field_valtree),
-                        ty: field_ty,
-                    });
-                    field_consts.push(field_const);
-                    valtree_idx += 1;
-                }
-                debug!(?field_consts);
-
-                (field_consts, Some(variant_idx))
-            }
-            ty::Tuple(elem_tys) => {
-                let fields = elem_tys
-                    .iter()
-                    .enumerate()
-                    .map(|(i, elem_ty)| {
-                        let elem_valtree = branches[i];
-                        tcx.mk_const(ty::ConstS {
-                            kind: ty::ConstKind::Value(elem_valtree),
-                            ty: elem_ty,
-                        })
-                    })
-                    .collect::<Vec<_>>();
-
-                (fields, None)
-            }
-            _ => bug!("cannot destructure constant {:?}", const_),
-        };
-
-        let fields = tcx.arena.alloc_from_iter(fields.into_iter());
-
-        ty::DestructuredConst { variant, fields }
-    } else {
+    let ty::ConstKind::Value(valtree) = const_.kind() else {
         bug!("cannot destructure constant {:?}", const_)
-    }
+    };
+
+    let branches = match valtree {
+        ty::ValTree::Branch(b) => b,
+        _ => bug!("cannot destructure constant {:?}", const_),
+    };
+
+    let (fields, variant) = match const_.ty().kind() {
+        ty::Array(inner_ty, _) | ty::Slice(inner_ty) => {
+            // construct the consts for the elements of the array/slice
+            let field_consts = branches
+                .iter()
+                .map(|b| tcx.mk_const(ty::ConstS { kind: ty::ConstKind::Value(*b), ty: *inner_ty }))
+                .collect::<Vec<_>>();
+            debug!(?field_consts);
+
+            (field_consts, None)
+        }
+        ty::Adt(def, _) if def.variants().is_empty() => bug!("unreachable"),
+        ty::Adt(def, substs) => {
+            let (variant_idx, branches) = if def.is_enum() {
+                let (head, rest) = branches.split_first().unwrap();
+                (VariantIdx::from_u32(head.unwrap_leaf().try_to_u32().unwrap()), rest)
+            } else {
+                (VariantIdx::from_u32(0), branches)
+            };
+            let fields = &def.variant(variant_idx).fields;
+            let mut field_consts = Vec::with_capacity(fields.len());
+
+            for (field, field_valtree) in iter::zip(fields, branches) {
+                let field_ty = field.ty(tcx, substs);
+                let field_const = tcx.mk_const(ty::ConstS {
+                    kind: ty::ConstKind::Value(*field_valtree),
+                    ty: field_ty,
+                });
+                field_consts.push(field_const);
+            }
+            debug!(?field_consts);
+
+            (field_consts, Some(variant_idx))
+        }
+        ty::Tuple(elem_tys) => {
+            let fields = iter::zip(*elem_tys, branches)
+                .map(|(elem_ty, elem_valtree)| {
+                    tcx.mk_const(ty::ConstS {
+                        kind: ty::ConstKind::Value(*elem_valtree),
+                        ty: elem_ty,
+                    })
+                })
+                .collect::<Vec<_>>();
+
+            (fields, None)
+        }
+        _ => bug!("cannot destructure constant {:?}", const_),
+    };
+
+    let fields = tcx.arena.alloc_from_iter(fields.into_iter());
+
+    ty::DestructuredConst { variant, fields }
 }
 
 pub fn provide(providers: &mut ty::query::Providers) {
-    *providers =
-        ty::query::Providers { destructure_const, ..*providers };
+    *providers = ty::query::Providers { destructure_const, ..*providers };
 }

--- a/compiler/rustc_ty_utils/src/consts.rs
+++ b/compiler/rustc_ty_utils/src/consts.rs
@@ -3,8 +3,8 @@ use rustc_target::abi::VariantIdx;
 
 use std::iter;
 
-/// Tries to destructure array, ADT or tuple constants into the constants
-/// of its fields.
+/// Destructures array, ADT or tuple constants into the constants
+/// of their fields.
 pub(crate) fn destructure_const<'tcx>(
     tcx: TyCtxt<'tcx>,
     const_: ty::Const<'tcx>,

--- a/compiler/rustc_ty_utils/src/consts.rs
+++ b/compiler/rustc_ty_utils/src/consts.rs
@@ -1,0 +1,84 @@
+use rustc_middle::ty::{self, TyCtxt};
+use rustc_target::abi::VariantIdx;
+
+/// Tries to destructure constants of type Array or Adt into the constants
+/// of its fields.
+pub(crate) fn destructure_const<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    const_: ty::Const<'tcx>,
+) -> ty::DestructuredConst<'tcx> {
+    if let ty::ConstKind::Value(valtree) = const_.kind() {
+        let branches = match valtree {
+            ty::ValTree::Branch(b) => b,
+            _ => bug!("cannot destructure constant {:?}", const_),
+        };
+
+        let (fields, variant) = match const_.ty().kind() {
+            ty::Array(inner_ty, _) | ty::Slice(inner_ty) => {
+                // construct the consts for the elements of the array/slice
+                let field_consts = branches
+                    .iter()
+                    .map(|b| {
+                        tcx.mk_const(ty::ConstS { kind: ty::ConstKind::Value(*b), ty: *inner_ty })
+                    })
+                    .collect::<Vec<_>>();
+                debug!(?field_consts);
+
+                (field_consts, None)
+            }
+            ty::Adt(def, _) if def.variants().is_empty() => bug!("unreachable"),
+            ty::Adt(def, substs) => {
+                let variant_idx = if def.is_enum() {
+                    VariantIdx::from_u32(branches[0].unwrap_leaf().try_to_u32().unwrap())
+                } else {
+                    VariantIdx::from_u32(0)
+                };
+                let fields = &def.variant(variant_idx).fields;
+                let mut field_consts = Vec::with_capacity(fields.len());
+
+                // Note: First element inValTree corresponds to variant of enum
+                let mut valtree_idx = if def.is_enum() { 1 } else { 0 };
+                for field in fields {
+                    let field_ty = field.ty(tcx, substs);
+                    let field_valtree = branches[valtree_idx]; // first element of branches is variant
+                    let field_const = tcx.mk_const(ty::ConstS {
+                        kind: ty::ConstKind::Value(field_valtree),
+                        ty: field_ty,
+                    });
+                    field_consts.push(field_const);
+                    valtree_idx += 1;
+                }
+                debug!(?field_consts);
+
+                (field_consts, Some(variant_idx))
+            }
+            ty::Tuple(elem_tys) => {
+                let fields = elem_tys
+                    .iter()
+                    .enumerate()
+                    .map(|(i, elem_ty)| {
+                        let elem_valtree = branches[i];
+                        tcx.mk_const(ty::ConstS {
+                            kind: ty::ConstKind::Value(elem_valtree),
+                            ty: elem_ty,
+                        })
+                    })
+                    .collect::<Vec<_>>();
+
+                (fields, None)
+            }
+            _ => bug!("cannot destructure constant {:?}", const_),
+        };
+
+        let fields = tcx.arena.alloc_from_iter(fields.into_iter());
+
+        ty::DestructuredConst { variant, fields }
+    } else {
+        bug!("cannot destructure constant {:?}", const_)
+    }
+}
+
+pub fn provide(providers: &mut ty::query::Providers) {
+    *providers =
+        ty::query::Providers { destructure_const, ..*providers };
+}

--- a/compiler/rustc_ty_utils/src/lib.rs
+++ b/compiler/rustc_ty_utils/src/lib.rs
@@ -18,6 +18,7 @@ use rustc_middle::ty::query::Providers;
 
 mod assoc;
 mod common_traits;
+pub mod consts;
 pub mod instance;
 mod needs_drop;
 pub mod representability;
@@ -26,6 +27,7 @@ mod ty;
 pub fn provide(providers: &mut Providers) {
     assoc::provide(providers);
     common_traits::provide(providers);
+    consts::provide(providers);
     needs_drop::provide(providers);
     ty::provide(providers);
     instance::provide(providers);

--- a/compiler/rustc_ty_utils/src/lib.rs
+++ b/compiler/rustc_ty_utils/src/lib.rs
@@ -18,7 +18,7 @@ use rustc_middle::ty::query::Providers;
 
 mod assoc;
 mod common_traits;
-pub mod consts;
+mod consts;
 pub mod instance;
 mod needs_drop;
 pub mod representability;

--- a/compiler/rustc_typeck/src/astconv/generics.rs
+++ b/compiler/rustc_typeck/src/astconv/generics.rs
@@ -645,7 +645,7 @@ impl<'o, 'tcx> dyn AstConv<'tcx> + 'o {
                 err.emit();
             } else {
                 let mut multispan = MultiSpan::from_span(span);
-                multispan.push_span_label(span_late, note.to_string());
+                multispan.push_span_label(span_late, note);
                 tcx.struct_span_lint_hir(
                     LATE_BOUND_LIFETIME_ARGUMENTS,
                     args.args[0].id(),

--- a/compiler/rustc_typeck/src/check/_match.rs
+++ b/compiler/rustc_typeck/src/check/_match.rs
@@ -154,18 +154,14 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     ret_span.push_span_label(
                         expr.span,
                         "this could be implicitly returned but it is a statement, not a \
-                            tail expression"
-                            .to_owned(),
+                            tail expression",
                     );
-                    ret_span.push_span_label(
-                        ret,
-                        "the `match` arms can conform to this return type".to_owned(),
-                    );
+                    ret_span
+                        .push_span_label(ret, "the `match` arms can conform to this return type");
                     ret_span.push_span_label(
                         semi_span,
                         "the `match` is a statement because of this semicolon, consider \
-                            removing it"
-                            .to_owned(),
+                            removing it",
                     );
                     err.span_note(
                         ret_span,

--- a/compiler/rustc_typeck/src/check/check.rs
+++ b/compiler/rustc_typeck/src/check/check.rs
@@ -1591,8 +1591,7 @@ fn opaque_type_cycle_error(tcx: TyCtxt<'_>, def_id: LocalDefId, span: Span) -> E
             } else {
                 let mut multispan: MultiSpan = spans.clone().into();
                 for span in spans {
-                    multispan
-                        .push_span_label(span, "this returned value is of `!` type".to_string());
+                    multispan.push_span_label(span, "this returned value is of `!` type");
                 }
                 err.span_note(multispan, "these returned values have a concrete \"never\" type");
             }

--- a/compiler/rustc_typeck/src/check/fn_ctxt/_impl.rs
+++ b/compiler/rustc_typeck/src/check/fn_ctxt/_impl.rs
@@ -1034,7 +1034,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             );
             sp.push_span_label(
                 rcvr.span,
-                "you probably want to use this value after calling the method...".to_string(),
+                "you probably want to use this value after calling the method...",
             );
             err.span_note(
                 sp,

--- a/compiler/rustc_typeck/src/check/fn_ctxt/checks.rs
+++ b/compiler/rustc_typeck/src/check/fn_ctxt/checks.rs
@@ -1768,7 +1768,7 @@ fn label_fn_like<'tcx>(
             .flat_map(|id| tcx.hir().body(id).params);
 
         for param in params {
-            spans.push_span_label(param.span, String::new());
+            spans.push_span_label(param.span, "");
         }
 
         let def_kind = tcx.def_kind(def_id);

--- a/compiler/rustc_typeck/src/check/method/suggest.rs
+++ b/compiler/rustc_typeck/src/check/method/suggest.rs
@@ -638,7 +638,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         let parent_trait_ref = data.parent_trait_pred;
                         let path = parent_trait_ref.print_modifiers_and_trait_path();
                         let tr_self_ty = parent_trait_ref.skip_binder().self_ty();
-                        let unsatisfied_msg = "unsatisfied trait bound introduced here".to_string();
+                        let unsatisfied_msg = "unsatisfied trait bound introduced here";
                         let derive_msg =
                             "unsatisfied trait bound introduced in this `derive` macro";
                         match self.tcx.hir().get_if_local(impl_def_id) {
@@ -655,7 +655,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             {
                                 let span = ident.span.ctxt().outer_expn_data().call_site;
                                 let mut spans: MultiSpan = span.into();
-                                spans.push_span_label(span, derive_msg.to_string());
+                                spans.push_span_label(span, derive_msg);
                                 let entry = spanned_predicates.entry(spans);
                                 entry.or_insert_with(|| (path, tr_self_ty, Vec::new())).2.push(p);
                             }
@@ -678,7 +678,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             {
                                 let span = self_ty.span.ctxt().outer_expn_data().call_site;
                                 let mut spans: MultiSpan = span.into();
-                                spans.push_span_label(span, derive_msg.to_string());
+                                spans.push_span_label(span, derive_msg);
                                 let entry = spanned_predicates.entry(spans);
                                 entry.or_insert_with(|| (path, tr_self_ty, Vec::new())).2.push(p);
                             }
@@ -706,7 +706,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                                 } else {
                                     ident.span.into()
                                 };
-                                spans.push_span_label(ident.span, "in this trait".to_string());
+                                spans.push_span_label(ident.span, "in this trait");
                                 let entry = spanned_predicates.entry(spans);
                                 entry.or_insert_with(|| (path, tr_self_ty, Vec::new())).2.push(p);
                             }
@@ -747,9 +747,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                                     spans.into()
                                 };
                                 if let Some(trait_ref) = of_trait {
-                                    spans.push_span_label(trait_ref.path.span, String::new());
+                                    spans.push_span_label(trait_ref.path.span, "");
                                 }
-                                spans.push_span_label(self_ty.span, String::new());
+                                spans.push_span_label(self_ty.span, "");
 
                                 let entry = spanned_predicates.entry(spans);
                                 entry.or_insert_with(|| (path, tr_self_ty, Vec::new())).2.push(p);

--- a/compiler/rustc_typeck/src/structured_errors/wrong_number_of_generic_args.rs
+++ b/compiler/rustc_typeck/src/structured_errors/wrong_number_of_generic_args.rs
@@ -836,7 +836,7 @@ impl<'a, 'tcx> WrongNumberOfGenericArgs<'a, 'tcx> {
                     .take(bound)
                     .map(|param| {
                         let span = self.tcx.def_span(param.def_id);
-                        spans.push_span_label(span, String::new());
+                        spans.push_span_label(span, "");
                         param
                     })
                     .map(|param| format!("`{}`", param.name))

--- a/compiler/rustc_typeck/src/variance/mod.rs
+++ b/compiler/rustc_typeck/src/variance/mod.rs
@@ -37,6 +37,11 @@ fn crate_variances(tcx: TyCtxt<'_>, (): ()) -> CrateVariancesMap<'_> {
 }
 
 fn variances_of(tcx: TyCtxt<'_>, item_def_id: DefId) -> &[ty::Variance] {
+    // Skip items with no generics - there's nothing to infer in them.
+    if tcx.generics_of(item_def_id).count() == 0 {
+        return &[];
+    }
+
     match tcx.def_kind(item_def_id) {
         DefKind::Fn
         | DefKind::AssocFn

--- a/library/alloc/src/boxed/thin.rs
+++ b/library/alloc/src/boxed/thin.rs
@@ -3,7 +3,9 @@
 // by matthieu-m
 use crate::alloc::{self, Layout, LayoutError};
 use core::fmt::{self, Debug, Display, Formatter};
-use core::marker::{PhantomData, Unsize};
+use core::marker::PhantomData;
+#[cfg(not(no_global_oom_handling))]
+use core::marker::Unsize;
 use core::mem;
 use core::ops::{Deref, DerefMut};
 use core::ptr::Pointee;

--- a/library/alloc/src/raw_vec.rs
+++ b/library/alloc/src/raw_vec.rs
@@ -421,6 +421,7 @@ impl<T, A: Allocator> RawVec<T, A> {
         Ok(())
     }
 
+    #[cfg(not(no_global_oom_handling))]
     fn shrink(&mut self, cap: usize) -> Result<(), TryReserveError> {
         assert!(cap <= self.capacity(), "Tried to shrink to a larger capacity");
 

--- a/library/alloc/src/string.rs
+++ b/library/alloc/src/string.rs
@@ -46,9 +46,9 @@
 use core::char::{decode_utf16, REPLACEMENT_CHARACTER};
 use core::fmt;
 use core::hash;
+use core::iter::FusedIterator;
 #[cfg(not(no_global_oom_handling))]
-use core::iter::FromIterator;
-use core::iter::{from_fn, FusedIterator};
+use core::iter::{from_fn, FromIterator};
 #[cfg(not(no_global_oom_handling))]
 use core::ops::Add;
 #[cfg(not(no_global_oom_handling))]

--- a/library/alloc/src/vec/into_iter.rs
+++ b/library/alloc/src/vec/into_iter.rs
@@ -9,6 +9,7 @@ use core::iter::{
 };
 use core::marker::PhantomData;
 use core::mem::{self, ManuallyDrop};
+#[cfg(not(no_global_oom_handling))]
 use core::ops::Deref;
 use core::ptr::{self, NonNull};
 use core::slice::{self};
@@ -123,6 +124,7 @@ impl<T, A: Allocator> IntoIter<T, A> {
     }
 
     /// Forgets to Drop the remaining elements while still allowing the backing allocation to be freed.
+    #[cfg(not(no_global_oom_handling))]
     pub(crate) fn forget_remaining_elements(&mut self) {
         self.ptr = self.end;
     }

--- a/src/librustdoc/html/static/js/main.js
+++ b/src/librustdoc/html/static/js/main.js
@@ -419,7 +419,8 @@ function loadCss(cssFileName) {
             return;
         }
 
-        if (document.activeElement.tagName === "INPUT") {
+        if (document.activeElement.tagName === "INPUT" &&
+            document.activeElement.type !== "checkbox") {
             switch (getVirtualKey(ev)) {
             case "Escape":
                 handleEscape(ev);

--- a/src/librustdoc/html/static/js/main.js
+++ b/src/librustdoc/html/static/js/main.js
@@ -926,6 +926,7 @@ function loadCss(cssFileName) {
     function showHelp() {
         const menu = getHelpMenu(true);
         if (menu.style.display === "none") {
+            window.hidePopoverMenus();
             menu.style.display = "";
         }
     }
@@ -939,6 +940,8 @@ function loadCss(cssFileName) {
         const shouldShowHelp = menu.style.display === "none";
         if (shouldShowHelp) {
             showHelp();
+        } else {
+            window.hidePopoverMenus();
         }
     });
 

--- a/src/librustdoc/html/static/js/main.js
+++ b/src/librustdoc/html/static/js/main.js
@@ -412,9 +412,9 @@ function loadCss(cssFileName) {
         window.hidePopoverMenus();
     }
 
-    const disableShortcuts = getSettingValue("disable-shortcuts") === "true";
     function handleShortcut(ev) {
         // Don't interfere with browser shortcuts
+        const disableShortcuts = getSettingValue("disable-shortcuts") === "true";
         if (ev.ctrlKey || ev.altKey || ev.metaKey || disableShortcuts) {
             return;
         }

--- a/src/test/run-make-fulldeps/alloc-no-oom-handling/Makefile
+++ b/src/test/run-make-fulldeps/alloc-no-oom-handling/Makefile
@@ -1,4 +1,4 @@
 -include ../tools.mk
 
 all:
-	$(RUSTC) --edition=2021 --crate-type=rlib ../../../../library/alloc/src/lib.rs --cfg no_global_oom_handling
+	$(RUSTC) --edition=2021 -Dwarnings --crate-type=rlib ../../../../library/alloc/src/lib.rs --cfg no_global_oom_handling

--- a/src/test/rustdoc-gui/pocket-menu.goml
+++ b/src/test/rustdoc-gui/pocket-menu.goml
@@ -24,6 +24,11 @@ click: "#help-button"
 assert-css: ("#help-button .popover", {"display": "block"})
 assert-css: ("#settings-menu .popover", {"display": "none"})
 
+// Now verify that clicking the help menu again closes it.
+click: "#help-button"
+assert-css: ("#help-button .popover", {"display": "none"})
+assert-css: ("#settings-menu .popover", {"display": "none"})
+
 // We check the borders color now:
 
 // Ayu theme

--- a/src/test/rustdoc-gui/settings.goml
+++ b/src/test/rustdoc-gui/settings.goml
@@ -122,6 +122,7 @@ click: ".setting-line:last-child .toggle .label"
 assert-local-storage: {"rustdoc-disable-shortcuts": "true"}
 
 // Make sure that "Disable keyboard shortcuts" actually took effect.
+// The help popover won't exist yet.
 press-key: "?"
 wait-for-css: ("#settings-menu .popover", {"display": "block"})
 

--- a/src/test/rustdoc-gui/settings.goml
+++ b/src/test/rustdoc-gui/settings.goml
@@ -121,6 +121,17 @@ local-storage: {"rustdoc-disable-shortcuts": "false"}
 click: ".setting-line:last-child .toggle .label"
 assert-local-storage: {"rustdoc-disable-shortcuts": "true"}
 
+// Make sure that "Disable keyboard shortcuts" actually took effect.
+press-key: "?"
+wait-for-css: ("#settings-menu .popover", {"display": "block"})
+
+// Now turn keyboard shortcuts back on, and see if they work.
+click: ".setting-line:last-child .toggle .label"
+assert-local-storage: {"rustdoc-disable-shortcuts": "false"}
+press-key: "?"
+wait-for-css: ("#help-button .popover", {"display": "block"})
+assert-css: ("#settings-menu .popover", {"display": "none"})
+
 // Now we go to the settings page to check that the CSS is loaded as expected.
 goto: file://|DOC_PATH|/settings.html
 wait-for: "#settings"

--- a/src/test/rustdoc-gui/settings.goml
+++ b/src/test/rustdoc-gui/settings.goml
@@ -122,13 +122,15 @@ click: ".setting-line:last-child .toggle .label"
 assert-local-storage: {"rustdoc-disable-shortcuts": "true"}
 
 // Make sure that "Disable keyboard shortcuts" actually took effect.
-// The help popover won't exist yet.
+press-key: "Escape"
 press-key: "?"
+assert-false: "#help-button .popover"
 wait-for-css: ("#settings-menu .popover", {"display": "block"})
 
 // Now turn keyboard shortcuts back on, and see if they work.
 click: ".setting-line:last-child .toggle .label"
 assert-local-storage: {"rustdoc-disable-shortcuts": "false"}
+press-key: "Escape"
 press-key: "?"
 wait-for-css: ("#help-button .popover", {"display": "block"})
 assert-css: ("#settings-menu .popover", {"display": "none"})

--- a/src/test/ui/const-generics/issue-66451.rs
+++ b/src/test/ui/const-generics/issue-66451.rs
@@ -1,0 +1,28 @@
+#![feature(adt_const_params)]
+#![allow(incomplete_features)]
+
+#[derive(Debug, PartialEq, Eq)]
+struct Foo {
+    value: i32,
+    nested: &'static Bar<i32>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct Bar<T>(T);
+
+struct Test<const F: Foo>;
+
+fn main() {
+    let x: Test<{
+        Foo {
+            value: 3,
+            nested: &Bar(4),
+        }  
+    }> = Test;
+    let y: Test<{
+        Foo {
+            value: 3,
+            nested: &Bar(5),
+        }
+    }> = x; //~ ERROR mismatched types
+}

--- a/src/test/ui/const-generics/issue-66451.rs
+++ b/src/test/ui/const-generics/issue-66451.rs
@@ -17,7 +17,7 @@ fn main() {
         Foo {
             value: 3,
             nested: &Bar(4),
-        }  
+        }
     }> = Test;
     let y: Test<{
         Foo {

--- a/src/test/ui/const-generics/issue-66451.stderr
+++ b/src/test/ui/const-generics/issue-66451.stderr
@@ -1,0 +1,20 @@
+error[E0308]: mismatched types
+  --> $DIR/issue-66451.rs:27:10
+   |
+LL |       let y: Test<{
+   |  ____________-
+LL | |         Foo {
+LL | |             value: 3,
+LL | |             nested: &Bar(5),
+LL | |         }
+LL | |     }> = x;
+   | |      -   ^ expected `Foo { value: 3_i32, nested: &Bar::<i32>(5_i32) }`, found `Foo { value: 3_i32, nested: &Bar::<i32>(4_i32) }`
+   | |______|
+   |        expected due to this
+   |
+   = note: expected struct `Test<Foo { value: 3_i32, nested: &Bar::<i32>(5_i32) }>`
+              found struct `Test<Foo { value: 3_i32, nested: &Bar::<i32>(4_i32) }>`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/src/test/ui/deprecation/atomic_initializers.stderr
+++ b/src/test/ui/deprecation/atomic_initializers.stderr
@@ -2,9 +2,13 @@ warning: use of deprecated constant `std::sync::atomic::ATOMIC_ISIZE_INIT`: the 
   --> $DIR/atomic_initializers.rs:8:27
    |
 LL | static FOO: AtomicIsize = ATOMIC_ISIZE_INIT;
-   |                           ^^^^^^^^^^^^^^^^^ help: replace the use of the deprecated constant: `AtomicIsize::new(0)`
+   |                           ^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(deprecated)]` on by default
+help: replace the use of the deprecated constant
+   |
+LL | static FOO: AtomicIsize = AtomicIsize::new(0);
+   |                           ~~~~~~~~~~~~~~~~~~~
 
 warning: 1 warning emitted
 

--- a/src/test/ui/deprecation/issue-84637-deprecated-associated-function.stderr
+++ b/src/test/ui/deprecation/issue-84637-deprecated-associated-function.stderr
@@ -2,19 +2,28 @@ error: use of deprecated associated function `core::str::<impl str>::trim_left`:
   --> $DIR/issue-84637-deprecated-associated-function.rs:6:21
    |
 LL |     let _foo = str::trim_left("   aoeu");
-   |                     ^^^^^^^^^ help: replace the use of the deprecated associated function: `trim_start`
+   |                     ^^^^^^^^^
    |
 note: the lint level is defined here
   --> $DIR/issue-84637-deprecated-associated-function.rs:3:9
    |
 LL | #![deny(deprecated)]
    |         ^^^^^^^^^^
+help: replace the use of the deprecated associated function
+   |
+LL |     let _foo = str::trim_start("   aoeu");
+   |                     ~~~~~~~~~~
 
 error: use of deprecated associated function `core::str::<impl str>::trim_left`: superseded by `trim_start`
   --> $DIR/issue-84637-deprecated-associated-function.rs:8:26
    |
 LL |     let _bar = "   aoeu".trim_left();
-   |                          ^^^^^^^^^ help: replace the use of the deprecated associated function: `trim_start`
+   |                          ^^^^^^^^^
+   |
+help: replace the use of the deprecated associated function
+   |
+LL |     let _bar = "   aoeu".trim_start();
+   |                          ~~~~~~~~~~
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/deprecation/suggestion.stderr
+++ b/src/test/ui/deprecation/suggestion.stderr
@@ -2,19 +2,28 @@ error: use of deprecated function `bar::deprecated`: replaced by `replacement`
   --> $DIR/suggestion.rs:42:10
    |
 LL |     bar::deprecated();
-   |          ^^^^^^^^^^ help: replace the use of the deprecated function: `replacement`
+   |          ^^^^^^^^^^
    |
 note: the lint level is defined here
   --> $DIR/suggestion.rs:8:9
    |
 LL | #![deny(deprecated)]
    |         ^^^^^^^^^^
+help: replace the use of the deprecated function
+   |
+LL |     bar::replacement();
+   |          ~~~~~~~~~~~
 
 error: use of deprecated associated function `Foo::deprecated`: replaced by `replacement`
   --> $DIR/suggestion.rs:40:9
    |
 LL |     foo.deprecated();
-   |         ^^^^^^^^^^ help: replace the use of the deprecated associated function: `replacement`
+   |         ^^^^^^^^^^
+   |
+help: replace the use of the deprecated associated function
+   |
+LL |     foo.replacement();
+   |         ~~~~~~~~~~~
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/proc-macro/invalid-punct-ident-1.rs
+++ b/src/test/ui/proc-macro/invalid-punct-ident-1.rs
@@ -1,17 +1,9 @@
 // aux-build:invalid-punct-ident.rs
-// rustc-env:RUST_BACKTRACE=0
-
-// FIXME https://github.com/rust-lang/rust/issues/59998
-// normalize-stderr-test "thread.*panicked.*proc_macro.*lib.rs.*\n" -> ""
-// normalize-stderr-test "note:.*RUST_BACKTRACE=1.*\n" -> ""
-// normalize-stderr-test "\nerror: internal compiler error.*\n\n" -> ""
-// normalize-stderr-test "note:.*unexpectedly panicked.*\n\n" -> ""
-// normalize-stderr-test "note: we would appreciate a bug report.*\n\n" -> ""
-// normalize-stderr-test "note: compiler flags.*\n\n" -> ""
-// normalize-stderr-test "note: rustc.*running on.*\n\n" -> ""
-// normalize-stderr-test "query stack during panic:\n" -> ""
-// normalize-stderr-test "we're just showing a limited slice of the query stack\n" -> ""
-// normalize-stderr-test "end of query stack\n" -> ""
+// ignore-stage1
+// only-linux
+//
+// FIXME: This should be a normal (stage1, all platforms) test in
+// src/test/ui/proc-macro once issue #59998 is fixed.
 
 #[macro_use]
 extern crate invalid_punct_ident;

--- a/src/test/ui/proc-macro/invalid-punct-ident-1.stderr
+++ b/src/test/ui/proc-macro/invalid-punct-ident-1.stderr
@@ -1,5 +1,5 @@
 error: proc macro panicked
-  --> $DIR/invalid-punct-ident-1.rs:19:1
+  --> $DIR/invalid-punct-ident-1.rs:11:1
    |
 LL | invalid_punct!();
    | ^^^^^^^^^^^^^^^^

--- a/src/test/ui/typeck/issue-98260.rs
+++ b/src/test/ui/typeck/issue-98260.rs
@@ -1,0 +1,9 @@
+fn main() {}
+trait A {
+    fn a(aa: B) -> Result<_, B> {
+    //~^ ERROR: the placeholder `_` is not allowed within types on item signatures for return types [E0121]
+        Ok(())
+    }
+}
+
+enum B {}

--- a/src/test/ui/typeck/issue-98260.stderr
+++ b/src/test/ui/typeck/issue-98260.stderr
@@ -1,0 +1,12 @@
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
+  --> $DIR/issue-98260.rs:3:27
+   |
+LL |     fn a(aa: B) -> Result<_, B> {
+   |                    -------^----
+   |                    |      |
+   |                    |      not allowed in type signatures
+   |                    help: replace with the correct return type: `Result<(), B>`
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0121`.

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -219,7 +219,7 @@ changelog-branch = "master"
 
 [mentions."compiler/rustc_apfloat"]
 message = """
-Changes rustc_apfloat. rustc_apfloat is currently in limbo and you almost
+Changes rustc_apfloat. rustc_apfloat is currently in limbo and you almost \
 certainly don't want to change it (see #55993).
 """
 cc = ["@eddyb"]
@@ -258,22 +258,22 @@ cc = ["@GuillaumeGomez"]
 message = """
 Hey! It looks like you've submitted a new PR for the library teams!
 
-If this PR contains changes to any `rust-lang/rust` public library APIs then
-please comment with `@rustbot label +T-libs-api -T-libs` to tag it
-appropriately. If this PR contains changes to any unstable APIs please edit
-the PR description to add a link to the relevant [API Change
-Proposal](https://std-dev-guide.rust-lang.org/feature-lifecycle/api-change-proposals.html)
-or [create one](https://github.com/rust-lang/libs-team/issues/new?assignees=&labels=api-change-proposal%2C+T-libs-api&template=api-change-proposal.md&title=%28My+API+Change+Proposal%29)
-if you haven't already. If you're unsure where your change falls no worries,
-just leave it as is and the reviewer will take a look and make a decision to
+If this PR contains changes to any `rust-lang/rust` public library APIs then \
+please comment with `@rustbot label +T-libs-api -T-libs` to tag it \
+appropriately. If this PR contains changes to any unstable APIs please edit \
+the PR description to add a link to the relevant [API Change \
+Proposal](https://std-dev-guide.rust-lang.org/feature-lifecycle/api-change-proposals.html) \
+or [create one](https://github.com/rust-lang/libs-team/issues/new?assignees=&labels=api-change-proposal%2C+T-libs-api&template=api-change-proposal.md&title=%28My+API+Change+Proposal%29) \
+if you haven't already. If you're unsure where your change falls no worries, \
+just leave it as is and the reviewer will take a look and make a decision to \
 forward on if necessary.
 
 Examples of `T-libs-api` changes:
 
 * Stabilizing library features
-* Introducing insta-stable changes such as new implementations of existing
+* Introducing insta-stable changes such as new implementations of existing \
   stable traits on existing stable types
-* Introducing new or changing existing unstable library APIs (excluding
+* Introducing new or changing existing unstable library APIs (excluding \
   permanently unstable features / features without a tracking issue)
 * Changing public documentation in ways that create new stability guarantees
 * Changing observable runtime behavior of library APIs
@@ -300,8 +300,8 @@ cc = ["@Cldfire"]
 
 [mentions."src/rustdoc-json-types"]
 message = """
-rustdoc-json-types is a **public** (although nightly-only) API.
-If possible, consider changing `src/librustdoc/json/conversions.rs`;
+rustdoc-json-types is a **public** (although nightly-only) API. \
+If possible, consider changing `src/librustdoc/json/conversions.rs`; \
 otherwise, make sure you bump the `FORMAT_VERSION` constant.
 """
 cc = [


### PR DESCRIPTION
Successful merges:

 - #98434 (Ensure that `static_crt` is set in the bootstrapper whenever using `cc-rs` to get a compiler command line.)
 - #98636 (Triagebot: Fix mentions word wrapping.)
 - #98642 (Fix #98260)
 - #98643 (Improve pretty printing of valtrees for references)
 - #98646 (rustdoc: fix bugs in main.js popover help and settings)
 - #98647 (Update cargo)
 - #98652 (`alloc`: clean and ensure `no_global_oom_handling`  builds are warning-free)
 - #98660 (Unbreak stage1 tests via ignore-stage1 in `proc-macro/invalid-punct-ident-1.rs`.)
 - #98665 (Use verbose help for deprecation suggestion)
 - #98668 (Avoid some `&str` to `String` conversions with `MultiSpan::push_span_label`)

Failed merges:


r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=98434,98636,98642,98643,98646,98647,98652,98660,98665,98668)
<!-- homu-ignore:end -->