### PR TITLE
rustdoc-json: Make default value of blanket impl assoc types work

### DIFF
--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -255,7 +255,7 @@ fn from_clean_item(item: clean::Item, tcx: TyCtxt<'_>) -> ItemEnum {
         AssocTypeItem(t, b) => ItemEnum::AssocType {
             generics: t.generics.into_tcx(tcx),
             bounds: b.into_iter().map(|x| x.into_tcx(tcx)).collect(),
-            default: t.item_type.map(|ty| ty.into_tcx(tcx)),
+            default: Some(t.item_type.unwrap_or(t.type_).into_tcx(tcx)),
         },
         // `convert_item` early returns `None` for striped items and keywords.
         StrippedItem(_) | KeywordItem(_) => unreachable!(),

--- a/src/test/rustdoc-json/blanket_impls.rs
+++ b/src/test/rustdoc-json/blanket_impls.rs
@@ -1,0 +1,9 @@
+// Regression test for <https://github.com/rust-lang/rust/issues/98658>
+
+#![no_std]
+
+// @has blanket_impls.json
+// @has - "$.index[*][?(@.name=='Error')].kind" \"assoc_type\"
+// @has - "$.index[*][?(@.name=='Error')].inner.default.kind" \"resolved_path\"
+// @has - "$.index[*][?(@.name=='Error')].inner.default.inner.name" \"Infallible\"
+pub struct ForBlanketTryFromImpl;


### PR DESCRIPTION
Closes #98658

r? @GuillaumeGomez 

@rustbot labels +A-rustdoc-json