### PR TITLE
std: promote debug_assert to assert

### DIFF
--- a/library/std/src/alloc.rs
+++ b/library/std/src/alloc.rs
@@ -154,7 +154,7 @@ impl System {
         new_layout: Layout,
         zeroed: bool,
     ) -> Result<NonNull<[u8]>, AllocError> {
-        debug_assert!(
+        assert!(
             new_layout.size() >= old_layout.size(),
             "`new_layout.size()` must be greater than or equal to `old_layout.size()`"
         );
@@ -246,7 +246,7 @@ unsafe impl Allocator for System {
         old_layout: Layout,
         new_layout: Layout,
     ) -> Result<NonNull<[u8]>, AllocError> {
-        debug_assert!(
+        assert!(
             new_layout.size() <= old_layout.size(),
             "`new_layout.size()` must be smaller than or equal to `old_layout.size()`"
         );

--- a/library/std/src/io/buffered/bufreader.rs
+++ b/library/std/src/io/buffered/bufreader.rs
@@ -376,7 +376,7 @@ impl<R: Read> BufRead for BufReader<R> {
         // Branch using `>=` instead of the more correct `==`
         // to tell the compiler that the pos..cap slice is always valid.
         if self.pos >= self.cap {
-            debug_assert!(self.pos == self.cap);
+            assert!(self.pos == self.cap, "unexpected end of buffer");
 
             let mut readbuf = ReadBuf::uninit(&mut self.buf);
 

--- a/library/std/src/io/buffered/bufwriter.rs
+++ b/library/std/src/io/buffered/bufwriter.rs
@@ -428,7 +428,7 @@ impl<W: Write> BufWriter<W> {
     // i.e., that input buffer length is less than or equal to spare capacity.
     #[inline]
     unsafe fn write_to_buffer_unchecked(&mut self, buf: &[u8]) {
-        debug_assert!(buf.len() <= self.spare_capacity());
+        assert!(buf.len() <= self.spare_capacity(), "unexpected write operation");
         let old_len = self.buf.len();
         let buf_len = buf.len();
         let src = buf.as_ptr();
@@ -610,7 +610,7 @@ impl<W: Write> Write for BufWriter<W> {
             } else {
                 return Ok(0);
             };
-            debug_assert!(total_written != 0);
+            assert!(total_written != 0, "unexpected `total_written` value: {:?}", total_written);
             for buf in iter {
                 if buf.len() <= self.spare_capacity() {
                     // SAFETY: safe by above conditional.

--- a/library/std/src/io/cursor.rs
+++ b/library/std/src/io/cursor.rs
@@ -426,7 +426,7 @@ fn reserve_and_pad<A: Allocator>(
         // realise the `reserve` it does can be eliminated. So we do it manually
         // to eliminate that extra branch
         let spare = vec.spare_capacity_mut();
-        debug_assert!(spare.len() >= diff);
+        assert!(spare.len() >= diff, "unexpected allocated capacity");
         // Safety: we have allocated enough capacity for this.
         // And we are only writing, not reading
         unsafe {
@@ -444,7 +444,7 @@ unsafe fn vec_write_unchecked<A>(pos: usize, vec: &mut Vec<u8, A>, buf: &[u8]) -
 where
     A: Allocator,
 {
-    debug_assert!(vec.capacity() >= pos + buf.len());
+    assert!(vec.capacity() >= pos + buf.len(), "unexpected write out of bound");
     vec.as_mut_ptr().add(pos).copy_from(buf.as_ptr(), buf.len());
     pos + buf.len()
 }

--- a/library/std/src/io/error/repr_bitpacked.rs
+++ b/library/std/src/io/error/repr_bitpacked.rs
@@ -145,7 +145,7 @@ impl Repr {
         let p = Box::into_raw(b).cast::<u8>();
         // Should only be possible if an allocator handed out a pointer with
         // wrong alignment.
-        debug_assert_eq!(p.addr() & TAG_MASK, 0);
+        assert_eq!(p.addr() & TAG_MASK, 0);
         // Note: We know `TAG_CUSTOM <= size_of::<Custom>()` (static_assert at
         // end of file), and both the start and end of the expression must be
         // valid without address space wraparound due to `Box`'s semantics.
@@ -167,7 +167,7 @@ impl Repr {
         let res = Self(unsafe { NonNull::new_unchecked(tagged) }, PhantomData);
         // quickly smoke-check we encoded the right thing (This generally will
         // only run in libstd's tests, unless the user uses -Zbuild-std)
-        debug_assert!(matches!(res.data(), ErrorData::Custom(_)), "repr(custom) encoding failed");
+        assert!(matches!(res.data(), ErrorData::Custom(_)), "repr(custom) encoding failed");
         res
     }
 
@@ -178,7 +178,7 @@ impl Repr {
         let res = Self(unsafe { NonNull::new_unchecked(ptr::invalid_mut(utagged)) }, PhantomData);
         // quickly smoke-check we encoded the right thing (This generally will
         // only run in libstd's tests, unless the user uses -Zbuild-std)
-        debug_assert!(
+        assert!(
             matches!(res.data(), ErrorData::Os(c) if c == code),
             "repr(os) encoding failed for {code}"
         );
@@ -192,7 +192,7 @@ impl Repr {
         let res = Self(unsafe { NonNull::new_unchecked(ptr::invalid_mut(utagged)) }, PhantomData);
         // quickly smoke-check we encoded the right thing (This generally will
         // only run in libstd's tests, unless the user uses -Zbuild-std)
-        debug_assert!(
+        assert!(
             matches!(res.data(), ErrorData::Simple(k) if k == kind),
             "repr(simple) encoding failed {:?}",
             kind,
@@ -256,7 +256,7 @@ where
         TAG_SIMPLE => {
             let kind_bits = (bits >> 32) as u32;
             let kind = kind_from_prim(kind_bits).unwrap_or_else(|| {
-                debug_assert!(false, "Invalid io::error::Repr bits: `Repr({:#018x})`", bits);
+                assert!(false, "Invalid io::error::Repr bits: `Repr({:#018x})`", bits);
                 // This means the `ptr` passed in was not valid, which violates
                 // the unsafe contract of `decode_repr`.
                 //

--- a/library/std/src/os/windows/io/socket.rs
+++ b/library/std/src/os/windows/io/socket.rs
@@ -193,7 +193,7 @@ impl IntoRawSocket for OwnedSocket {
 impl FromRawSocket for OwnedSocket {
     #[inline]
     unsafe fn from_raw_socket(socket: RawSocket) -> Self {
-        debug_assert_ne!(socket, c::INVALID_SOCKET as RawSocket);
+        assert_ne!(socket, c::INVALID_SOCKET as RawSocket);
         Self { socket }
     }
 }

--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -749,7 +749,7 @@ impl<'a> Components<'a> {
     // parse a component from the left, saying how many bytes to consume to
     // remove the component
     fn parse_next_component(&self) -> (usize, Option<Component<'a>>) {
-        debug_assert!(self.front == State::Body);
+        assert!(self.front == State::Body, "unexpected component during parsing: {:?}", self.front);
         let (extra, comp) = match self.path.iter().position(|b| self.is_sep_byte(*b)) {
             None => (0, self.path),
             Some(i) => (1, &self.path[..i]),
@@ -760,7 +760,7 @@ impl<'a> Components<'a> {
     // parse a component from the right, saying how many bytes to consume to
     // remove the component
     fn parse_next_component_back(&self) -> (usize, Option<Component<'a>>) {
-        debug_assert!(self.back == State::Body);
+        assert!(self.back == State::Body, "unexpected component during parsing: {:?}", self.back);
         let start = self.len_before_body();
         let (extra, comp) = match self.path[start..].iter().rposition(|b| self.is_sep_byte(*b)) {
             None => (0, &self.path[start..]),
@@ -893,7 +893,11 @@ impl<'a> Iterator for Components<'a> {
             match self.front {
                 State::Prefix if self.prefix_len() > 0 => {
                     self.front = State::StartDir;
-                    debug_assert!(self.prefix_len() <= self.path.len());
+                    assert!(
+                        self.prefix_len() <= self.path.len(),
+                        "unexpected prefix len: {:?}",
+                        self.prefix_len()
+                    );
                     let raw = &self.path[..self.prefix_len()];
                     self.path = &self.path[self.prefix_len()..];
                     return Some(Component::Prefix(PrefixComponent {
@@ -907,7 +911,7 @@ impl<'a> Iterator for Components<'a> {
                 State::StartDir => {
                     self.front = State::Body;
                     if self.has_physical_root {
-                        debug_assert!(!self.path.is_empty());
+                        assert!(!self.path.is_empty(), "unexpected path value");
                         self.path = &self.path[1..];
                         return Some(Component::RootDir);
                     } else if let Some(p) = self.prefix {
@@ -915,7 +919,7 @@ impl<'a> Iterator for Components<'a> {
                             return Some(Component::RootDir);
                         }
                     } else if self.include_cur_dir() {
-                        debug_assert!(!self.path.is_empty());
+                        assert!(!self.path.is_empty(), "unexpected path value");
                         self.path = &self.path[1..];
                         return Some(Component::CurDir);
                     }
@@ -1406,7 +1410,7 @@ impl PathBuf {
     fn _set_file_name(&mut self, file_name: &OsStr) {
         if self.file_name().is_some() {
             let popped = self.pop();
-            debug_assert!(popped);
+            assert!(popped, "unexpected error during unwrap file name");
         }
         self.push(file_name);
     }

--- a/library/std/src/sync/mpsc/oneshot.rs
+++ b/library/std/src/sync/mpsc/oneshot.rs
@@ -138,7 +138,7 @@ impl<T> Packet<T> {
                     }
                 } else {
                     wait_token.wait();
-                    debug_assert!(self.state.load(Ordering::SeqCst) != EMPTY);
+                    assert!(self.state.load(Ordering::SeqCst) != EMPTY, "packet state not empity");
                 }
             } else {
                 // drop the signal token, since we never blocked

--- a/library/std/src/sync/once_lock.rs
+++ b/library/std/src/sync/once_lock.rs
@@ -217,7 +217,7 @@ impl<T> OnceLock<T> {
         }
         self.initialize(f)?;
 
-        debug_assert!(self.is_initialized());
+        assert!(self.is_initialized(), "bad initialization");
 
         // SAFETY: The inner value has been initialized
         Ok(unsafe { self.get_unchecked() })
@@ -369,7 +369,7 @@ impl<T> OnceLock<T> {
     ///
     /// The value must be initialized
     unsafe fn get_unchecked(&self) -> &T {
-        debug_assert!(self.is_initialized());
+        assert!(self.is_initialized(), "value not initialized");
         (&*self.value.get()).assume_init_ref()
     }
 
@@ -377,7 +377,7 @@ impl<T> OnceLock<T> {
     ///
     /// The value must be initialized
     unsafe fn get_unchecked_mut(&mut self) -> &mut T {
-        debug_assert!(self.is_initialized());
+        assert!(self.is_initialized(), "value not initialized");
         (&mut *self.value.get()).assume_init_mut()
     }
 }

--- a/library/std/src/sys/itron/condvar.rs
+++ b/library/std/src/sys/itron/condvar.rs
@@ -157,7 +157,7 @@ mod waiter_queue {
             // Zeroness of `Waiter::task` indicates whether the `Waiter` is
             // linked to a queue or not. This invariant is important for
             // the correctness.
-            debug_assert_ne!(task, 0);
+            assert_ne!(task, 0);
 
             Self { task, priority, prev: None, next: None }
         }
@@ -182,8 +182,8 @@ mod waiter_queue {
             unsafe {
                 let waiter = waiter_ptr.as_mut();
 
-                debug_assert!(waiter.prev.is_none());
-                debug_assert!(waiter.next.is_none());
+                assert!(waiter.prev.is_none());
+                assert!(waiter.next.is_none());
 
                 if let Some(head) = &mut self.head {
                     // Find the insertion position and insert `waiter`

--- a/library/std/src/sys/itron/thread.rs
+++ b/library/std/src/sys/itron/thread.rs
@@ -202,9 +202,21 @@ impl Thread {
         // Get the current task ID. Panicking here would cause a resource leak,
         // so just abort on failure.
         let current_task = task::current_task_id_aborting();
-        debug_assert!(usize::try_from(current_task).is_ok());
-        debug_assert_ne!(current_task as usize, LIFECYCLE_INIT);
-        debug_assert_ne!(current_task as usize, LIFECYCLE_DETACHED);
+        assert!(
+            usize::try_from(current_task).is_ok(),
+            "fails to convert `current_task_id` to `usize`: {:?}",
+            current_task
+        );
+        assert_ne!(
+            current_task as usize, LIFECYCLE_INIT,
+            "`current_task` is not in a valid state: {:?}",
+            current_task
+        );
+        assert_ne!(
+            current_task as usize, LIFECYCLE_DETACHED,
+            "`current_task` is not in a valid state: {:?}",
+            current_task
+        );
 
         let current_task = current_task as usize;
 

--- a/library/std/src/sys/unix/fs.rs
+++ b/library/std/src/sys/unix/fs.rs
@@ -636,7 +636,7 @@ impl Iterator for ReadDir {
 impl Drop for Dir {
     fn drop(&mut self) {
         let r = unsafe { libc::closedir(self.0) };
-        assert_eq!(r, 0, "unexpected error during closedir: {:?}", r);
+        assert!(r == 0 || r == libc::EINTR, "unexpected error during closedir: {:?}", r);
     }
 }
 

--- a/library/std/src/sys/unix/fs.rs
+++ b/library/std/src/sys/unix/fs.rs
@@ -636,7 +636,7 @@ impl Iterator for ReadDir {
 impl Drop for Dir {
     fn drop(&mut self) {
         let r = unsafe { libc::closedir(self.0) };
-        debug_assert_eq!(r, 0);
+        assert_eq!(r, 0, "unexpected error during closedir: {:?}", r);
     }
 }
 

--- a/library/std/src/sys/unix/locks/pthread_condvar.rs
+++ b/library/std/src/sys/unix/locks/pthread_condvar.rs
@@ -186,7 +186,7 @@ impl Condvar {
         let r = libc::pthread_cond_timedwait(self.inner.get(), pthread_mutex::raw(mutex), &timeout);
         assert!(
             r == libc::ETIMEDOUT || r == 0,
-            "unexpected error during pthread_conf_timedwait: {:?}",
+            "unexpected error during pthread_cond_timedwait: {:?}",
             r
         );
 

--- a/library/std/src/sys/unix/locks/pthread_mutex.rs
+++ b/library/std/src/sys/unix/locks/pthread_mutex.rs
@@ -87,12 +87,12 @@ impl Mutex {
     #[inline]
     pub unsafe fn lock(&self) {
         let r = libc::pthread_mutex_lock(self.inner.get());
-        debug_assert_eq!(r, 0);
+        assert_eq!(r, 0, "unexpected error during pthread_mutex_lock: {:?}", r);
     }
     #[inline]
     pub unsafe fn unlock(&self) {
         let r = libc::pthread_mutex_unlock(self.inner.get());
-        debug_assert_eq!(r, 0);
+        assert_eq!(r, 0, "unexpected error during pthread_mutex_unlock: {:?}", r);
     }
     #[inline]
     pub unsafe fn try_lock(&self) -> bool {
@@ -102,7 +102,7 @@ impl Mutex {
     #[cfg(not(target_os = "dragonfly"))]
     unsafe fn destroy(&mut self) {
         let r = libc::pthread_mutex_destroy(self.inner.get());
-        debug_assert_eq!(r, 0);
+        assert_eq!(r, 0, "unexpected error during pthread_mutex_destroy: {:?}", r);
     }
     #[inline]
     #[cfg(target_os = "dragonfly")]
@@ -112,7 +112,11 @@ impl Mutex {
         // mutex that was just initialized with libc::PTHREAD_MUTEX_INITIALIZER.
         // Once it is used (locked/unlocked) or pthread_mutex_init() is called,
         // this behaviour no longer occurs.
-        debug_assert!(r == 0 || r == libc::EINVAL);
+        assert!(
+            r == 0 || r == libc::EINVAL,
+            "unexpected error during pthread_mutex_destroy: {:?}",
+            r
+        );
     }
 }
 
@@ -129,7 +133,11 @@ impl Drop for PthreadMutexAttr<'_> {
     fn drop(&mut self) {
         unsafe {
             let result = libc::pthread_mutexattr_destroy(self.0.as_mut_ptr());
-            debug_assert_eq!(result, 0);
+            assert_eq!(
+                result, 0,
+                "unexpected error during: pthread_mutexattr_destroy: {:?}",
+                result
+            );
         }
     }
 }

--- a/library/std/src/sys/unix/locks/pthread_rwlock.rs
+++ b/library/std/src/sys/unix/locks/pthread_rwlock.rs
@@ -110,8 +110,6 @@ impl RwLock {
             }
             panic!("rwlock write lock would result in deadlock");
         } else {
-            // According to POSIX, for a properly initialized rwlock this can only
-            // return EDEADLK or 0. We rely on that.
             assert_eq!(r, 0, "unexpected error during pthread_rwlock_wrlock: {:?}", r);
         }
         *self.write_locked.get() = true;
@@ -145,7 +143,7 @@ impl RwLock {
     }
     #[inline]
     pub unsafe fn write_unlock(&self) {
-        debug_assert_eq!(self.num_readers.load(Ordering::Relaxed), 0);
+        assert_eq!(self.num_readers.load(Ordering::Relaxed), 0);
         assert!(*self.write_locked.get(), "trying to unlock a thread already unlocked");
         *self.write_locked.get() = false;
         self.raw_unlock();

--- a/library/std/src/sys/unix/process/process_common.rs
+++ b/library/std/src/sys/unix/process/process_common.rs
@@ -177,7 +177,7 @@ impl Command {
     pub fn set_arg_0(&mut self, arg: &OsStr) {
         // Set a new arg0
         let arg = os2c(arg, &mut self.saw_nul);
-        debug_assert!(self.argv.0.len() > 1);
+        assert!(self.argv.0.len() > 1, "invalid number of argument: {:?}", self.argv.0);
         self.argv.0[0] = arg.as_ptr();
         self.args[0] = arg;
     }

--- a/library/std/src/sys/unix/thread.rs
+++ b/library/std/src/sys/unix/thread.rs
@@ -112,8 +112,7 @@ impl Thread {
     }
 
     pub fn yield_now() {
-        let ret = unsafe { libc::sched_yield() };
-        assert_eq!(ret, 0, "unexpected error during sched_yield: {:?}", ret);
+        let _ = unsafe { libc::sched_yield() };
     }
 
     #[cfg(any(target_os = "linux", target_os = "android"))]

--- a/library/std/src/sys/unix/thread.rs
+++ b/library/std/src/sys/unix/thread.rs
@@ -113,7 +113,7 @@ impl Thread {
 
     pub fn yield_now() {
         let ret = unsafe { libc::sched_yield() };
-        debug_assert_eq!(ret, 0);
+        assert_eq!(ret, 0, "unexpected error during sched_yield: {:?}", ret);
     }
 
     #[cfg(any(target_os = "linux", target_os = "android"))]
@@ -267,7 +267,7 @@ impl Thread {
 impl Drop for Thread {
     fn drop(&mut self) {
         let ret = unsafe { libc::pthread_detach(self.id) };
-        debug_assert_eq!(ret, 0);
+        assert_eq!(ret, 0, "unexpected error during pthread_detach: {:?}", ret);
     }
 }
 

--- a/library/std/src/sys/unix/thread_local_key.rs
+++ b/library/std/src/sys/unix/thread_local_key.rs
@@ -14,7 +14,7 @@ pub unsafe fn create(dtor: Option<unsafe extern "C" fn(*mut u8)>) -> Key {
 #[inline]
 pub unsafe fn set(key: Key, value: *mut u8) {
     let r = libc::pthread_setspecific(key, value as *mut _);
-    debug_assert_eq!(r, 0);
+    assert_eq!(r, 0, "unexpected error during pthread_setspecific: {:?}", r);
 }
 
 #[inline]
@@ -25,7 +25,7 @@ pub unsafe fn get(key: Key) -> *mut u8 {
 #[inline]
 pub unsafe fn destroy(key: Key) {
     let r = libc::pthread_key_delete(key);
-    debug_assert_eq!(r, 0);
+    assert_eq!(r, 0, "unexpected error during pthread_key_delete: {:?}", r);
 }
 
 #[inline]

--- a/library/std/src/sys/unix/thread_parker.rs
+++ b/library/std/src/sys/unix/thread_parker.rs
@@ -24,22 +24,22 @@ const NOTIFIED: usize = 2;
 
 unsafe fn lock(lock: *mut libc::pthread_mutex_t) {
     let r = libc::pthread_mutex_lock(lock);
-    debug_assert_eq!(r, 0);
+    assert_eq!(r, 0, "unexpected error during pthread_mutex_lock: {:?}", r);
 }
 
 unsafe fn unlock(lock: *mut libc::pthread_mutex_t) {
     let r = libc::pthread_mutex_unlock(lock);
-    debug_assert_eq!(r, 0);
+    assert_eq!(r, 0, "unexpected error during pthread_mutex_ulock: {:?}", r);
 }
 
 unsafe fn notify_one(cond: *mut libc::pthread_cond_t) {
     let r = libc::pthread_cond_signal(cond);
-    debug_assert_eq!(r, 0);
+    assert_eq!(r, 0, "unexpected error during pthread_cond_signal: {:?}", r);
 }
 
 unsafe fn wait(cond: *mut libc::pthread_cond_t, lock: *mut libc::pthread_mutex_t) {
     let r = libc::pthread_cond_wait(cond, lock);
-    debug_assert_eq!(r, 0);
+    assert_eq!(r, 0, "unexpected error during pthread_cond_wait: {:?}", r);
 }
 
 const TIMESPEC_MAX: libc::timespec =
@@ -83,7 +83,11 @@ unsafe fn wait_timeout(
     let timeout =
         now.checked_add_duration(&dur).and_then(|t| t.to_timespec()).unwrap_or(TIMESPEC_MAX);
     let r = libc::pthread_cond_timedwait(cond, lock, &timeout);
-    debug_assert!(r == libc::ETIMEDOUT || r == 0);
+    assert!(
+        r == libc::ETIMEDOUT || r == 0,
+        "unexpected error during pthread_cond_timedwait: {:?}",
+        ret
+    );
 }
 
 pub struct Parker {

--- a/library/std/src/sys/wasi/thread.rs
+++ b/library/std/src/sys/wasi/thread.rs
@@ -19,7 +19,7 @@ impl Thread {
 
     pub fn yield_now() {
         let ret = unsafe { wasi::sched_yield() };
-        debug_assert_eq!(ret, Ok(()));
+        assert_eq!(ret, Ok(()), "unexpected error wasi::sched_yield: {:?}", ret);
     }
 
     pub fn set_name(_name: &CStr) {

--- a/library/std/src/sys/wasm/alloc.rs
+++ b/library/std/src/sys/wasm/alloc.rs
@@ -79,7 +79,7 @@ mod lock {
             //             1,  //     expected value
             //             -1, //     timeout
             //         );
-            //         debug_assert!(r == 0 || r == 1);
+            //         assert!(r == 0 || r == 1);
             //     }
             //
             // Unfortunately though in doing so we would cause issues for the
@@ -144,7 +144,7 @@ mod lock {
     impl Drop for DropLock {
         fn drop(&mut self) {
             let r = LOCKED.swap(0, SeqCst);
-            debug_assert_eq!(r, 1);
+            assert_eq!(r, 1, "unexpected error during swap: {:?}", r);
 
             // Note that due to the above logic we don't actually need to wake
             // anyone up, but if we did it'd likely look something like this:

--- a/library/std/src/sys/wasm/atomics/thread.rs
+++ b/library/std/src/sys/wasm/atomics/thread.rs
@@ -32,7 +32,7 @@ impl Thread {
             let amt = cmp::min(i64::MAX as u128, nanos);
             let mut x = 0;
             let val = unsafe { wasm32::memory_atomic_wait32(&mut x, 0, amt as i64) };
-            debug_assert_eq!(val, 2);
+            assert_eq!(val, 2, "unexpected value during wasm32::memory_atomic_wait32: {:?}", val);
             nanos -= amt;
         }
     }

--- a/library/std/src/sys/windows/fs.rs
+++ b/library/std/src/sys/windows/fs.rs
@@ -123,7 +123,7 @@ impl Iterator for ReadDir {
 impl Drop for FindNextFileHandle {
     fn drop(&mut self) {
         let r = unsafe { c::FindClose(self.0) };
-        debug_assert!(r != 0);
+        assert!(r != 0, "unexpected error during FindClose: {:?}", r);
     }
 }
 

--- a/library/std/src/sys/windows/locks/condvar.rs
+++ b/library/std/src/sys/windows/locks/condvar.rs
@@ -22,7 +22,7 @@ impl Condvar {
     #[inline]
     pub unsafe fn wait(&self, mutex: &Mutex) {
         let r = c::SleepConditionVariableSRW(self.inner.get(), mutex::raw(mutex), c::INFINITE, 0);
-        debug_assert!(r != 0);
+        assert!(r != 0, "unexpected error during SleepConditionVariableSRW: {:?}", r);
     }
 
     pub unsafe fn wait_timeout(&self, mutex: &Mutex, dur: Duration) -> bool {
@@ -33,7 +33,12 @@ impl Condvar {
             0,
         );
         if r == 0 {
-            debug_assert_eq!(os::errno() as usize, c::ERROR_TIMEOUT as usize);
+            assert_eq!(
+                os::errno() as usize,
+                c::ERROR_TIMEOUT as usize,
+                "unexpected error during SleepConditionariableSRW: {:?}",
+                r
+            );
             false
         } else {
             true

--- a/library/std/src/sys/windows/stdio.rs
+++ b/library/std/src/sys/windows/stdio.rs
@@ -205,7 +205,11 @@ fn write_valid_utf8_to_console(handle: c::HANDLE, utf8: &str) -> io::Result<usiz
                 _ => 3,
             };
         }
-        debug_assert!(String::from_utf16(&utf16[..written]).unwrap() == utf8[..count]);
+        assert_eq!(
+            String::from_utf16(&utf16[..written]).unwrap(),
+            utf8[..count],
+            "unexpected partial lenght written"
+        );
         Ok(count)
     }
 }

--- a/library/std/src/sys/windows/thread_local_key.rs
+++ b/library/std/src/sys/windows/thread_local_key.rs
@@ -58,7 +58,7 @@ pub unsafe fn create(dtor: Option<Dtor>) -> Key {
 #[inline]
 pub unsafe fn set(key: Key, value: *mut u8) {
     let r = c::TlsSetValue(key, value as c::LPVOID);
-    debug_assert!(r != 0);
+    assert!(r != 0, "unexpected error during TlsSetValue: {:?}", r);
 }
 
 #[inline]

--- a/library/std/src/sys_common/remutex.rs
+++ b/library/std/src/sys_common/remutex.rs
@@ -123,7 +123,12 @@ impl<T> ReentrantMutex<T> {
             } else {
                 self.mutex.lock();
                 self.owner.store(this_thread, Relaxed);
-                debug_assert_eq!(*self.lock_count.get(), 0);
+                assert_eq!(
+                    *self.lock_count.get(),
+                    0,
+                    "unexpected value of lock_count: {:?}",
+                    *self.lock_count.get()
+                );
                 *self.lock_count.get() = 1;
             }
         }
@@ -152,7 +157,12 @@ impl<T> ReentrantMutex<T> {
                 Some(ReentrantMutexGuard { lock: self })
             } else if self.mutex.try_lock() {
                 self.owner.store(this_thread, Relaxed);
-                debug_assert_eq!(*self.lock_count.get(), 0);
+                assert_eq!(
+                    *self.lock_count.get(),
+                    0,
+                    "unexpected value of lock_count: {:?}",
+                    *self.lock_count.get()
+                );
                 *self.lock_count.get() = 1;
                 Some(ReentrantMutexGuard { lock: self })
             } else {


### PR DESCRIPTION
This is a continuation of work started in https://github.com/rust-lang/rust/pull/94712 based on the issue https://github.com/rust-lang/rust/issues/94705

I cleanup all the debug_assert in the std, most of them was related to the UNIX crate

r? @RalfJung

Signed-off-by: Vincenzo Palazzo <vincenzopalazzodev@gmail.com>