### PR TITLE
Implement From<OwnedFd/Handle> for ChildStdin/out/err object

### DIFF
--- a/library/std/src/os/unix/process.rs
+++ b/library/std/src/os/unix/process.rs
@@ -434,6 +434,10 @@ impl From<crate::process::ChildStdin> for OwnedFd {
     }
 }
 
+/// Create a `ChildStdin` from the provided `OwnedFd`.
+///
+/// The provided file descriptor must point to a pipe
+/// with the `CLOEXEC` flag set.
 #[stable(feature = "io_safety", since = "1.63.0")]
 impl From<OwnedFd> for process::ChildStdin {
     #[inline]
@@ -460,6 +464,10 @@ impl From<crate::process::ChildStdout> for OwnedFd {
     }
 }
 
+/// Create a `ChildStdout` from the provided `OwnedFd`.
+///
+/// The provided file descriptor must point to a pipe
+/// with the `CLOEXEC` flag set.
 #[stable(feature = "io_safety", since = "1.63.0")]
 impl From<OwnedFd> for process::ChildStdout {
     #[inline]
@@ -486,6 +494,10 @@ impl From<crate::process::ChildStderr> for OwnedFd {
     }
 }
 
+/// Create a `ChildStderr` from the provided `OwnedFd`.
+///
+/// The provided file descriptor must point to a pipe
+/// with the `CLOEXEC` flag set.
 #[stable(feature = "io_safety", since = "1.63.0")]
 impl From<OwnedFd> for process::ChildStderr {
     #[inline]

--- a/library/std/src/os/unix/process.rs
+++ b/library/std/src/os/unix/process.rs
@@ -435,6 +435,16 @@ impl From<crate::process::ChildStdin> for OwnedFd {
 }
 
 #[stable(feature = "io_safety", since = "1.63.0")]
+impl From<OwnedFd> for process::ChildStdin {
+    #[inline]
+    fn from(fd: OwnedFd) -> process::ChildStdin {
+        let fd = sys::fd::FileDesc::from_inner(fd);
+        let pipe = sys::pipe::AnonPipe::from_inner(fd);
+        process::ChildStdin::from_inner(pipe)
+    }
+}
+
+#[stable(feature = "io_safety", since = "1.63.0")]
 impl AsFd for crate::process::ChildStdout {
     #[inline]
     fn as_fd(&self) -> BorrowedFd<'_> {
@@ -451,6 +461,16 @@ impl From<crate::process::ChildStdout> for OwnedFd {
 }
 
 #[stable(feature = "io_safety", since = "1.63.0")]
+impl From<OwnedFd> for process::ChildStdout {
+    #[inline]
+    fn from(fd: OwnedFd) -> process::ChildStdout {
+        let fd = sys::fd::FileDesc::from_inner(fd);
+        let pipe = sys::pipe::AnonPipe::from_inner(fd);
+        process::ChildStdout::from_inner(pipe)
+    }
+}
+
+#[stable(feature = "io_safety", since = "1.63.0")]
 impl AsFd for crate::process::ChildStderr {
     #[inline]
     fn as_fd(&self) -> BorrowedFd<'_> {
@@ -463,6 +483,16 @@ impl From<crate::process::ChildStderr> for OwnedFd {
     #[inline]
     fn from(child_stderr: crate::process::ChildStderr) -> OwnedFd {
         child_stderr.into_inner().into_inner().into_inner()
+    }
+}
+
+#[stable(feature = "io_safety", since = "1.63.0")]
+impl From<OwnedFd> for process::ChildStderr {
+    #[inline]
+    fn from(fd: OwnedFd) -> process::ChildStderr {
+        let fd = sys::fd::FileDesc::from_inner(fd);
+        let pipe = sys::pipe::AnonPipe::from_inner(fd);
+        process::ChildStderr::from_inner(pipe)
     }
 }
 

--- a/library/std/src/os/unix/process.rs
+++ b/library/std/src/os/unix/process.rs
@@ -438,7 +438,7 @@ impl From<crate::process::ChildStdin> for OwnedFd {
 ///
 /// The provided file descriptor must point to a pipe
 /// with the `CLOEXEC` flag set.
-#[stable(feature = "io_safety", since = "1.63.0")]
+#[stable(feature = "child_stream_from_fd", since = "CURRENT_RUSTC_VERSION")]
 impl From<OwnedFd> for process::ChildStdin {
     #[inline]
     fn from(fd: OwnedFd) -> process::ChildStdin {
@@ -468,7 +468,7 @@ impl From<crate::process::ChildStdout> for OwnedFd {
 ///
 /// The provided file descriptor must point to a pipe
 /// with the `CLOEXEC` flag set.
-#[stable(feature = "io_safety", since = "1.63.0")]
+#[stable(feature = "child_stream_from_fd", since = "CURRENT_RUSTC_VERSION")]
 impl From<OwnedFd> for process::ChildStdout {
     #[inline]
     fn from(fd: OwnedFd) -> process::ChildStdout {
@@ -498,7 +498,7 @@ impl From<crate::process::ChildStderr> for OwnedFd {
 ///
 /// The provided file descriptor must point to a pipe
 /// with the `CLOEXEC` flag set.
-#[stable(feature = "io_safety", since = "1.63.0")]
+#[stable(feature = "child_stream_from_fd", since = "CURRENT_RUSTC_VERSION")]
 impl From<OwnedFd> for process::ChildStderr {
     #[inline]
     fn from(fd: OwnedFd) -> process::ChildStderr {

--- a/library/std/src/os/windows/process.rs
+++ b/library/std/src/os/windows/process.rs
@@ -110,7 +110,7 @@ impl IntoRawHandle for process::ChildStderr {
 ///
 /// The provided handle must be asynchronous, as reading and
 /// writing from and to it is implemented using asynchronous APIs.
-#[stable(feature = "io_safety", since = "1.63.0")]
+#[stable(feature = "child_stream_from_fd", since = "CURRENT_RUSTC_VERSION")]
 impl From<OwnedHandle> for process::ChildStdin {
     fn from(handle: OwnedHandle) -> process::ChildStdin {
         let handle = sys::handle::Handle::from_inner(handle);
@@ -123,7 +123,7 @@ impl From<OwnedHandle> for process::ChildStdin {
 ///
 /// The provided handle must be asynchronous, as reading and
 /// writing from and to it is implemented using asynchronous APIs.
-#[stable(feature = "io_safety", since = "1.63.0")]
+#[stable(feature = "child_stream_from_fd", since = "CURRENT_RUSTC_VERSION")]
 impl From<OwnedHandle> for process::ChildStdout {
     fn from(handle: OwnedHandle) -> process::ChildStdout {
         let handle = sys::handle::Handle::from_inner(handle);
@@ -136,7 +136,7 @@ impl From<OwnedHandle> for process::ChildStdout {
 ///
 /// The provided handle must be asynchronous, as reading and
 /// writing from and to it is implemented using asynchronous APIs.
-#[stable(feature = "io_safety", since = "1.63.0")]
+#[stable(feature = "child_stream_from_fd", since = "CURRENT_RUSTC_VERSION")]
 impl From<OwnedHandle> for process::ChildStderr {
     fn from(handle: OwnedHandle) -> process::ChildStderr {
         let handle = sys::handle::Handle::from_inner(handle);

--- a/library/std/src/os/windows/process.rs
+++ b/library/std/src/os/windows/process.rs
@@ -106,6 +106,10 @@ impl IntoRawHandle for process::ChildStderr {
     }
 }
 
+/// Create a `ChildStdin` from the provided `OwnedHandle`.
+///
+/// The provided handle must be asynchronous, as reading and
+/// writing from and to it is implemented using asynchronous APIs.
 #[stable(feature = "io_safety", since = "1.63.0")]
 impl From<OwnedHandle> for process::ChildStdin {
     fn from(handle: OwnedHandle) -> process::ChildStdin {
@@ -115,6 +119,10 @@ impl From<OwnedHandle> for process::ChildStdin {
     }
 }
 
+/// Create a `ChildStdout` from the provided `OwnedHandle`.
+///
+/// The provided handle must be asynchronous, as reading and
+/// writing from and to it is implemented using asynchronous APIs.
 #[stable(feature = "io_safety", since = "1.63.0")]
 impl From<OwnedHandle> for process::ChildStdout {
     fn from(handle: OwnedHandle) -> process::ChildStdout {
@@ -124,6 +132,10 @@ impl From<OwnedHandle> for process::ChildStdout {
     }
 }
 
+/// Create a `ChildStderr` from the provided `OwnedHandle`.
+///
+/// The provided handle must be asynchronous, as reading and
+/// writing from and to it is implemented using asynchronous APIs.
 #[stable(feature = "io_safety", since = "1.63.0")]
 impl From<OwnedHandle> for process::ChildStderr {
     fn from(handle: OwnedHandle) -> process::ChildStderr {

--- a/library/std/src/os/windows/process.rs
+++ b/library/std/src/os/windows/process.rs
@@ -106,6 +106,33 @@ impl IntoRawHandle for process::ChildStderr {
     }
 }
 
+#[stable(feature = "io_safety", since = "1.63.0")]
+impl From<OwnedHandle> for process::ChildStdin {
+    fn from(handle: OwnedHandle) -> process::ChildStdin {
+        let handle = sys::handle::Handle::from_inner(handle);
+        let pipe = sys::pipe::AnonPipe::from_inner(handle);
+        process::ChildStdin::from_inner(pipe)
+    }
+}
+
+#[stable(feature = "io_safety", since = "1.63.0")]
+impl From<OwnedHandle> for process::ChildStdout {
+    fn from(handle: OwnedHandle) -> process::ChildStdout {
+        let handle = sys::handle::Handle::from_inner(handle);
+        let pipe = sys::pipe::AnonPipe::from_inner(handle);
+        process::ChildStdout::from_inner(pipe)
+    }
+}
+
+#[stable(feature = "io_safety", since = "1.63.0")]
+impl From<OwnedHandle> for process::ChildStderr {
+    fn from(handle: OwnedHandle) -> process::ChildStderr {
+        let handle = sys::handle::Handle::from_inner(handle);
+        let pipe = sys::pipe::AnonPipe::from_inner(handle);
+        process::ChildStderr::from_inner(pipe)
+    }
+}
+
 /// Windows-specific extensions to [`process::ExitStatus`].
 ///
 /// This trait is sealed: it cannot be implemented outside the standard library.

--- a/library/std/src/sys/unix/pipe.rs
+++ b/library/std/src/sys/unix/pipe.rs
@@ -3,7 +3,7 @@ use crate::mem;
 use crate::os::unix::io::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, RawFd};
 use crate::sys::fd::FileDesc;
 use crate::sys::{cvt, cvt_r};
-use crate::sys_common::IntoInner;
+use crate::sys_common::{FromInner, IntoInner};
 
 ////////////////////////////////////////////////////////////////////////////////
 // Anonymous pipes
@@ -156,5 +156,11 @@ impl IntoRawFd for AnonPipe {
 impl FromRawFd for AnonPipe {
     unsafe fn from_raw_fd(raw_fd: RawFd) -> Self {
         Self(FromRawFd::from_raw_fd(raw_fd))
+    }
+}
+
+impl FromInner<FileDesc> for AnonPipe {
+    fn from_inner(fd: FileDesc) -> Self {
+        Self(fd)
     }
 }

--- a/library/std/src/sys/windows/pipe.rs
+++ b/library/std/src/sys/windows/pipe.rs
@@ -12,7 +12,7 @@ use crate::sys::c;
 use crate::sys::fs::{File, OpenOptions};
 use crate::sys::handle::Handle;
 use crate::sys::hashmap_random_keys;
-use crate::sys_common::IntoInner;
+use crate::sys_common::{FromInner, IntoInner};
 
 ////////////////////////////////////////////////////////////////////////////////
 // Anonymous pipes
@@ -25,6 +25,12 @@ pub struct AnonPipe {
 impl IntoInner<Handle> for AnonPipe {
     fn into_inner(self) -> Handle {
         self.inner
+    }
+}
+
+impl FromInner<Handle> for AnonPipe {
+    fn from_inner(inner: Handle) -> AnonPipe {
+        Self { inner }
     }
 }
 


### PR DESCRIPTION
## Summary 

Comments in `library/std/src/process.rs` ( https://github.com/rust-lang/rust/commit/ab08639e5950f5c8a42a2870c9636181308c3686 ) indicates that `ChildStdin`, `ChildStdout`, `ChildStderr` implements some traits that are not actually implemented: `FromRawFd`, `FromRawHandle`, and the `From<OwnedFd>/From<OwnedHandle>` from the io_safety feature.

In this PR I implement `FromRawHandle` and `FromRawFd` for those 3 objects.

## Usecase

I have a usecase where those implementations are basically needed. I want to customize
in the `Command::spawn` API how the pipes for the parent/child communications are created (mainly to strengthen the security attributes on them). I can properly setup the pipes,
and the "child" handles can be provided to `Child::spawn` easily using `Stdio::from_raw_handle`. However, there is no way to generate the `ChildStd*` objects from the raw handle of the created name pipe, which would be very useful to still expose the same API
than in other OS (basically a `spawn(...) -> (Child, ChildStdin, ChildStdout, ChildSterr)`, where on windows this is customized), and to for example use `tokio::ChildStdin::from_std` afterwards.

## Questions

* Are those impls OK to add? I have searched to see if those impls were missing on purpose, or if it was just never implemented because never needed. I haven't found any indication on why they couldn't be added, although the user clearly has to be very careful that the handle provided makes sense (i think, mainly that it is in overlapped mode for windows).
* If this change is ok, adding the impls for the io_safety feature would probably be best, or should it be done in another PR?
* I just copy-pasted the `#[stable(...)]` attributes, but the `since` value has to be updated, I'm not sure to which value.

