### PR TITLE
rustdoc: fix 98690 Panic if invalid path for -Z persist-doctests

### DIFF
--- a/src/librustdoc/doctest.rs
+++ b/src/librustdoc/doctest.rs
@@ -1003,8 +1003,10 @@ impl Tester for Collector {
         let outdir = if let Some(mut path) = rustdoc_options.persist_doctests.clone() {
             path.push(&test_id);
 
-            std::fs::create_dir_all(&path)
-                .expect("Couldn't create directory for doctest executables");
+            if let Err(err) = std::fs::create_dir_all(&path) {
+                eprintln!("Couldn't create directory for doctest executables: {}", err);
+                panic::resume_unwind(box ());
+            }
 
             DirState::Perm(path)
         } else {

--- a/src/test/rustdoc-ui/issue-98690.rs
+++ b/src/test/rustdoc-ui/issue-98690.rs
@@ -1,0 +1,10 @@
+// compile-flags: --test --persist-doctests /../../ -Z unstable-options
+// failure-status: 101
+// only-linux
+
+#![crate_name = "foo"]
+
+//! ```rust
+//! use foo::dummy;
+//! dummy();
+//! ```

--- a/src/test/rustdoc-ui/issue-98690.stderr
+++ b/src/test/rustdoc-ui/issue-98690.stderr
@@ -1,0 +1,1 @@
+Couldn't create directory for doctest executables: Permission denied (os error 13)


### PR DESCRIPTION
Closes #98690 for rustdoc panic

I changed this to do eprintln and orderly panic instead of unwrap doing unhandled panic

~/gg/rust/build/x86_64-unknown-linux-gnu/stage2/bin/rustdoc --test -Z unstable-options --persist-doctests /tmp/foobar main.rs 
Couldn't create directory for doctest executables: Permission denied (os error 13)