### PR TITLE
correct the output of a `capacity` method example

### DIFF
--- a/library/alloc/src/string.rs
+++ b/library/alloc/src/string.rs
@@ -317,11 +317,11 @@ use crate::vec::Vec;
 ///
 /// ```text
 /// 0
-/// 5
-/// 10
-/// 20
-/// 20
-/// 40
+/// 8
+/// 16
+/// 16
+/// 32
+/// 32
 /// ```
 ///
 /// At first, we have no memory allocated at all, but as we append to the


### PR DESCRIPTION
The output of this example in std::alloc is different from which shown in the comment. I have tested it on both Linux and Windows.