### PR TITLE
promote placeholder bounds to 'static obligations

### DIFF
--- a/src/test/ui/generic-associated-types/issue-91139.rs
+++ b/src/test/ui/generic-associated-types/issue-91139.rs
@@ -22,6 +22,7 @@ fn foo<T>() {
     //~| ERROR `T` does not live long enough
     //~| ERROR `T` does not live long enough
     //~| ERROR `T` does not live long enough
+    //~| ERROR `T` may not live long enough
     //
     // FIXME: This error is bogus, but it arises because we try to validate
     // that `<() as Foo<T>>::Type<'a>` is valid, which requires proving

--- a/src/test/ui/generic-associated-types/issue-91139.stderr
+++ b/src/test/ui/generic-associated-types/issue-91139.stderr
@@ -34,6 +34,17 @@ error: `T` does not live long enough
 LL |     let _: for<'a> fn(<() as Foo<T>>::Type<'a>, &'a T) = |_, _| ();
    |                                                          ^^^^^^^^^
 
+error[E0310]: the parameter type `T` may not live long enough
+  --> $DIR/issue-91139.rs:16:58
+   |
+LL |     let _: for<'a> fn(<() as Foo<T>>::Type<'a>, &'a T) = |_, _| ();
+   |                                                          ^^^^^^^^^ ...so that the type `T` will meet its required lifetime bounds
+   |
+help: consider adding an explicit lifetime bound...
+   |
+LL | fn foo<T: 'static>() {
+   |         +++++++++
+
 error: `T` does not live long enough
   --> $DIR/issue-91139.rs:16:58
    |
@@ -46,5 +57,6 @@ error: `T` does not live long enough
 LL |     let _: for<'a> fn(<() as Foo<T>>::Type<'a>, &'a T) = |_, _| ();
    |                                                          ^^^^^^^^^
 
-error: aborting due to 8 previous errors
+error: aborting due to 9 previous errors
 
+For more information about this error, try `rustc --explain E0310`.

--- a/src/test/ui/nll/issue-98693.rs
+++ b/src/test/ui/nll/issue-98693.rs
@@ -1,0 +1,21 @@
+// Regression test for #98693.
+//
+// The closure encounters an obligation that `T` must outlive `!U1`,
+// a placeholder from universe U1. We were ignoring this placeholder
+// when promoting the constraint to the enclosing function, and
+// thus incorrectly judging the closure to be safe.
+
+fn assert_static<T>()
+where
+    for<'a> T: 'a,
+{
+}
+
+fn test<T>() {
+    || {
+        //~^ ERROR the parameter type `T` may not live long enough
+        assert_static::<T>();
+    };
+}
+
+fn main() {}

--- a/src/test/ui/nll/issue-98693.stderr
+++ b/src/test/ui/nll/issue-98693.stderr
@@ -1,0 +1,17 @@
+error[E0310]: the parameter type `T` may not live long enough
+  --> $DIR/issue-98693.rs:15:5
+   |
+LL | /     || {
+LL | |
+LL | |         assert_static::<T>();
+LL | |     };
+   | |_____^ ...so that the type `T` will meet its required lifetime bounds
+   |
+help: consider adding an explicit lifetime bound...
+   |
+LL | fn test<T: 'static>() {
+   |          +++++++++
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0310`.


### PR DESCRIPTION
In NLL, when we are promoting a bound out from a closure, if we have a requirement that `T: 'a` where `'a` is in a higher universe, we were previously ignoring that, which is totally wrong. We should be promoting those constraints to `'static`, since universes are not expressible across closure boundaries.

Fixes #98693

~~(Marking as WIP because I'm still running tests, haven't add the new test, etc)~~

r? @jackh726 

