### PR TITLE
Use `#!/usr/bin/env python3` instead of a bash script in the x.py shebang

### DIFF
--- a/x.py
+++ b/x.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # This file is only a "symlink" to bootstrap.py, all logic should go there.
 

--- a/x.py
+++ b/x.py
@@ -1,25 +1,5 @@
-#!/usr/bin/env bash
+#!/usr/bin/env python
 
-# Modern Linux and macOS systems commonly only have a thing called `python3` and
-# not `python`, while Windows commonly does not have `python3`, so we cannot
-# directly use python in the shebang and have it consistently work. Instead we
-# embed some bash to look for a python to run the rest of the script.
-#
-# On Windows, `py -3` sometimes works. We need to try it first because `python3`
-# sometimes tries to launch the app store on Windows.
-'''':
-for PYTHON in "py -3" python3 python python2; do
-    if command -v $PYTHON >/dev/null; then
-        exec $PYTHON "$0" "$@"
-        break
-    fi
-done
-echo "$0: error: did not find python installed" >&2
-exit 1
-'''
-
-# The rest of this file is Python.
-#
 # This file is only a "symlink" to bootstrap.py, all logic should go there.
 
 import os
@@ -27,12 +7,11 @@ import sys
 
 # If this is python2, check if python3 is available and re-execute with that
 # interpreter.
-#
-# `./x.py` would not normally benefit from this because the bash above tries
-# python3 before 2, but this matters if someone ran `python x.py` and their
-# system's `python` is python2.
 if sys.version_info.major < 3:
     try:
+        # On Windows, `py -3` sometimes works.
+        # Try this first, because 'python3' sometimes tries to launch the app
+        # store on Windows
         os.execvp("py", ["py", "-3"] + sys.argv)
     except OSError:
         try:


### PR DESCRIPTION
Reverts rust-lang/rust#98474. This uses Unix-isms that don't work on Windows, and break at least one python entrypoint (`py x.py`). Instead this uses `#!/usr/bin/env python3`, which at least breaks fewer systems than `python` alone.

r? @Mark-Simulacrum cc @dtolnay @CAD97 @yoshuawuyts 