### PR TITLE
rustdoc: filter '_ lifetimes from ty::PolyTraitRef

### DIFF
--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -167,7 +167,7 @@ fn clean_poly_trait_ref_with_bindings<'tcx>(
         .collect_referenced_late_bound_regions(&poly_trait_ref)
         .into_iter()
         .filter_map(|br| match br {
-            ty::BrNamed(_, name) => Some(GenericParamDef {
+            ty::BrNamed(_, name) if name != kw::UnderscoreLifetime => Some(GenericParamDef {
                 name,
                 kind: GenericParamDefKind::Lifetime { outlives: vec![] },
             }),

--- a/src/test/rustdoc/auxiliary/issue-98697-reexport-with-anonymous-lifetime.rs
+++ b/src/test/rustdoc/auxiliary/issue-98697-reexport-with-anonymous-lifetime.rs
@@ -1,0 +1,9 @@
+/// When reexporting this function, make sure the anonymous lifetimes are not rendered.
+///
+/// https://github.com/rust-lang/rust/issues/98697
+pub fn repro<F>()
+where
+    F: Fn(&str),
+{
+    unimplemented!()
+}

--- a/src/test/rustdoc/issue-98697.rs
+++ b/src/test/rustdoc/issue-98697.rs
@@ -1,0 +1,13 @@
+// aux-build:issue-98697-reexport-with-anonymous-lifetime.rs
+// ignore-cross-compile
+
+// When reexporting a function with a HRTB with anonymous lifetimes,
+// make sure the anonymous lifetimes are not rendered.
+//
+// https://github.com/rust-lang/rust/issues/98697
+
+extern crate issue_98697_reexport_with_anonymous_lifetime;
+
+// @has issue_98697/fn.repro.html '//pre[@class="rust fn"]/code' 'fn repro<F>() where F: Fn(&str)'
+// @!has issue_98697/fn.repro.html '//pre[@class="rust fn"]/code' 'for<'
+pub use issue_98697_reexport_with_anonymous_lifetime::repro;


### PR DESCRIPTION
Fixes #98697