### PR TITLE
resolve error when attempting to link a universal library on macOS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3297,6 +3297,7 @@ dependencies = [
  "rustc_symbol_mangling",
  "rustc_target",
  "smallvec",
+ "tempfile",
  "tracing",
 ]
 

--- a/compiler/rustc_codegen_llvm/Cargo.toml
+++ b/compiler/rustc_codegen_llvm/Cargo.toml
@@ -34,3 +34,4 @@ rustc_target = { path = "../rustc_target" }
 smallvec = { version = "1.8.1", features = ["union", "may_dangle"] }
 rustc_ast = { path = "../rustc_ast" }
 rustc_span = { path = "../rustc_span" }
+tempfile = "3.2.0"

--- a/src/test/run-make/macos-fat-archive/Makefile
+++ b/src/test/run-make/macos-fat-archive/Makefile
@@ -1,0 +1,10 @@
+# only-macos
+
+-include ../../run-make-fulldeps/tools.mk
+
+"$(TMPDIR)"/libnative-library.a: native-library.c
+	$(CC) -arch arm64 -arch x86_64 native-library.c -c -o "$(TMPDIR)"/native-library.o
+	$(AR) crs "$(TMPDIR)"/libnative-library.a "$(TMPDIR)"/native-library.o
+
+all: "$(TMPDIR)"/libnative-library.a
+	$(RUSTC) lib.rs --crate-type=lib -L "native=$(TMPDIR)" -l static=native-library

--- a/src/test/run-make/macos-fat-archive/lib.rs
+++ b/src/test/run-make/macos-fat-archive/lib.rs
@@ -1,0 +1,3 @@
+extern "C" {
+    pub fn native_func();
+}

--- a/src/test/run-make/macos-fat-archive/native-library.c
+++ b/src/test/run-make/macos-fat-archive/native-library.c
@@ -1,0 +1,1 @@
+void native_func() {}


### PR DESCRIPTION
Previously attempting to link universal libraries into libraries (but not binaries) would produce an error that "File too small to be an archive". This works around this by invoking `lipo -thin` to extract a library for the target platform when passed a univeral library.

Fixes #55235

It's worth acknowledging that this implementation is kind of a horrible hack. Unfortunately I don't know how to do anything better, hopefully this PR will be a jumping off point.