### PR TITLE
Add a comment to the `x.py` shebang, using /usr/bin/env

### DIFF
--- a/README_ENTRYPOINT.md
+++ b/README_ENTRYPOINT.md
@@ -1,6 +1,7 @@
 There is no file shebang for python that works on all platforms (#71818).
-To minimize breakage we have chosen to make this work when `env` is in path, or when using python/python2/python3 directly.
-Unfortunately, this breaks users using the `py` wrapper on Windows, where env isn't supported outside of MingW shells.
+To minimize breakage we have chosen to make this work when `bash` is available, or when using python/python2/python3 directly.
+Unfortunately, this breaks users using the `py` wrapper on Windows, where `bash` isn't supported outside of MingW shells.
+Existing versions of `py` will see the bash shebang line and try to respect it and interpret the file with `bash`.
 
 You can do one of the following things to get x.py working:
 1. Use any of `python`, `python2`, `python3`, `py -2`, or `py -3` to invoke x.py.

--- a/README_ENTRYPOINT.md
+++ b/README_ENTRYPOINT.md
@@ -1,0 +1,17 @@
+There is no file shebang for python that works on all platforms (#71818).
+To minimize breakage we have chosen to make this work when `env` is in path, or when using python/python2/python3 directly.
+Unfortunately, this breaks users using the `py` wrapper on Windows, where env isn't supported outside of MingW shells.
+
+You can do one of the following things to get x.py working:
+1. Use any of `python`, `python2`, `python3`, `py -2`, or `py -3` to invoke x.py.
+2. Use a MingW shell (often installed as "Git Bash", or through Cygwin).
+3. Set the default file handler for .py files, which will allow using `./x.py` directly: `ftype Python.File="C:\Windows\py.exe" "-3" "%L" %*`.
+   `py` may be installed in a different location; use `where py` to determine where.
+4. Set a default python interpreter for the `py` wrapper: Add
+```ini
+[commands]
+bash=python
+```
+   to `%APPDATA%\py.ini`.
+
+5. Wait until October and update to the latest `py` wrapper, which fixes this bug: https://github.com/python/cpython/issues/94399#issuecomment-1170649407

--- a/x.py
+++ b/x.py
@@ -1,4 +1,6 @@
-#!/usr/bin/env bash
+#!/usr/bin/env -S -u If_this_file_fails_to_run,read_README_ENTRYPOINT.md bash
+# `py` fails when using a shebang other than /usr/bin/python{,2,3}.
+# Try and give a better error by embedding a comment in the shebang.
 
 # Modern Linux and macOS systems commonly only have a thing called `python3` and
 # not `python`, while Windows commonly does not have `python3`, so we cannot


### PR DESCRIPTION
This is a terrible, horrible, no-good, very-bad idea.

I kind of like it.

---

Shebang files can't have comments, so instead this passes `--unset VAR`, where the variable name itself is the comment.
Here's an example run of `py` on Windows:

```
PS C:\Users\Joshua Nelson\src\rust> py x.py
Unable to create process using '/usr/bin/env -S -u If_this_file_fails_to_run,read_README_ENTRYPOINT.md bash ./x.py'
```

This doesn't break anyone using python/python2/python3 directly, and still handles trying all three on distros where they might not exist. Unfortunately it's slightly less portable since not all `env` commands support -S and -u.

---

Happy to take improvements on the file name - I'm slightly reluctant to use spaces or punctuation since lots of shell scripts are bad at handling those, but since nothing should be invoking this file directly other than the kernel, it's *probably* fine.

Helps with https://github.com/rust-lang/rust/issues/98650.

r? @Mark-Simulacrum cc @dtolnay @CAD97 @yoshuawuyts