### PR TITLE
Add macro_rules! rustdoc change to 1.62 relnotes

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -75,6 +75,7 @@ Compatibility Notes
 - `cargo test` now passes `--target` to `rustdoc` if the specified target is
   the same as the host target.
   [#10594](https://github.com/rust-lang/cargo/pull/10594)
+- [rustdoc: doctests are now run on unexported `macro_rules!` macros, matching other private items][96630]
 - [rustdoc: Remove .woff font files][96279]
 - [Enforce Copy bounds for repeat elements while considering lifetimes][95819]
 
@@ -109,6 +110,7 @@ and related tools.
 [96393]: https://github.com/rust-lang/rust/pull/96393/
 [96436]: https://github.com/rust-lang/rust/pull/96436/
 [96557]: https://github.com/rust-lang/rust/pull/96557/
+[96630]: https://github.com/rust-lang/rust/pull/96630/
 
 [`bool::then_some`]: https://doc.rust-lang.org/stable/std/primitive.bool.html#method.then_some
 [`f32::total_cmp`]: https://doc.rust-lang.org/stable/std/primitive.f32.html#method.total_cmp


### PR DESCRIPTION
#96630 was tagged <kbd>relnotes</kbd> but didn't make it into the notes. Given this is a compatibility issue (https://github.com/rust-lang/rust/issues/97030, https://github.com/rust-lang/rust/issues/98735, https://github.com/rust-lang/rust/issues/98743), it probably *should* be retroactively added.