### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -914,8 +914,16 @@ impl<'tcx> Term<'tcx> {
     pub fn ty(&self) -> Option<Ty<'tcx>> {
         if let Term::Ty(ty) = self { Some(*ty) } else { None }
     }
+
     pub fn ct(&self) -> Option<Const<'tcx>> {
         if let Term::Const(c) = self { Some(*c) } else { None }
+    }
+
+    pub fn into_arg(self) -> GenericArg<'tcx> {
+        match self {
+            Term::Ty(ty) => ty.into(),
+            Term::Const(c) => c.into(),
+        }
     }
 }
 

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
@@ -2020,7 +2020,7 @@ impl<'a, 'tcx> InferCtxtPrivExt<'a, 'tcx> for InferCtxt<'a, 'tcx> {
                     subst,
                     impl_candidates,
                     ErrorCode::E0283,
-                    false,
+                    true,
                 );
 
                 let obligation = Obligation::new(
@@ -2132,7 +2132,7 @@ impl<'a, 'tcx> InferCtxtPrivExt<'a, 'tcx> for InferCtxt<'a, 'tcx> {
                     a.into(),
                     vec![],
                     ErrorCode::E0282,
-                    false,
+                    true,
                 )
             }
             ty::PredicateKind::Projection(data) => {
@@ -2149,7 +2149,7 @@ impl<'a, 'tcx> InferCtxtPrivExt<'a, 'tcx> for InferCtxt<'a, 'tcx> {
                         self_ty.into(),
                         vec![],
                         ErrorCode::E0284,
-                        false,
+                        true,
                     );
                     err.note(&format!("cannot satisfy `{}`", predicate));
                     err

--- a/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/error_reporting/mod.rs
@@ -2002,6 +2002,7 @@ impl<'a, 'tcx> InferCtxtPrivExt<'a, 'tcx> for InferCtxt<'a, 'tcx> {
                             subst,
                             vec![],
                             ErrorCode::E0282,
+                            false,
                         )
                         .emit();
                     }
@@ -2019,6 +2020,7 @@ impl<'a, 'tcx> InferCtxtPrivExt<'a, 'tcx> for InferCtxt<'a, 'tcx> {
                     subst,
                     impl_candidates,
                     ErrorCode::E0283,
+                    false,
                 );
 
                 let obligation = Obligation::new(
@@ -2110,7 +2112,7 @@ impl<'a, 'tcx> InferCtxtPrivExt<'a, 'tcx> for InferCtxt<'a, 'tcx> {
                     return;
                 }
 
-                self.emit_inference_failure_err(body_id, span, arg, vec![], ErrorCode::E0282)
+                self.emit_inference_failure_err(body_id, span, arg, vec![], ErrorCode::E0282, false)
             }
 
             ty::PredicateKind::Subtype(data) => {
@@ -2124,7 +2126,14 @@ impl<'a, 'tcx> InferCtxtPrivExt<'a, 'tcx> for InferCtxt<'a, 'tcx> {
                 let SubtypePredicate { a_is_expected: _, a, b } = data;
                 // both must be type variables, or the other would've been instantiated
                 assert!(a.is_ty_var() && b.is_ty_var());
-                self.emit_inference_failure_err(body_id, span, a.into(), vec![], ErrorCode::E0282)
+                self.emit_inference_failure_err(
+                    body_id,
+                    span,
+                    a.into(),
+                    vec![],
+                    ErrorCode::E0282,
+                    false,
+                )
             }
             ty::PredicateKind::Projection(data) => {
                 let self_ty = data.projection_ty.self_ty();
@@ -2140,6 +2149,7 @@ impl<'a, 'tcx> InferCtxtPrivExt<'a, 'tcx> for InferCtxt<'a, 'tcx> {
                         self_ty.into(),
                         vec![],
                         ErrorCode::E0284,
+                        false,
                     );
                     err.note(&format!("cannot satisfy `{}`", predicate));
                     err

--- a/compiler/rustc_typeck/src/check/fn_ctxt/_impl.rs
+++ b/compiler/rustc_typeck/src/check/fn_ctxt/_impl.rs
@@ -1538,9 +1538,15 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             ty
         } else {
             if !self.is_tainted_by_errors() {
-                self.emit_inference_failure_err((**self).body_id, sp, ty.into(), vec![], E0282)
-                    .note("type must be known at this point")
-                    .emit();
+                self.emit_inference_failure_err(
+                    (**self).body_id,
+                    sp,
+                    ty.into(),
+                    vec![],
+                    E0282,
+                    true,
+                )
+                .emit();
             }
             let err = self.tcx.ty_error();
             self.demand_suptype(sp, err, ty);

--- a/compiler/rustc_typeck/src/check/writeback.rs
+++ b/compiler/rustc_typeck/src/check/writeback.rs
@@ -694,6 +694,7 @@ impl<'cx, 'tcx> Resolver<'cx, 'tcx> {
                     t.into(),
                     vec![],
                     E0282,
+                    false,
                 )
                 .emit();
         }
@@ -708,6 +709,7 @@ impl<'cx, 'tcx> Resolver<'cx, 'tcx> {
                     c.into(),
                     vec![],
                     E0282,
+                    false,
                 )
                 .emit();
         }

--- a/src/librustdoc/doctest.rs
+++ b/src/librustdoc/doctest.rs
@@ -1003,8 +1003,10 @@ impl Tester for Collector {
         let outdir = if let Some(mut path) = rustdoc_options.persist_doctests.clone() {
             path.push(&test_id);
 
-            std::fs::create_dir_all(&path)
-                .expect("Couldn't create directory for doctest executables");
+            if let Err(err) = std::fs::create_dir_all(&path) {
+                eprintln!("Couldn't create directory for doctest executables: {}", err);
+                panic::resume_unwind(box ());
+            }
 
             DirState::Perm(path)
         } else {

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -114,6 +114,9 @@ body {
 	-webkit-font-feature-settings: "kern", "liga";
 	-moz-font-feature-settings: "kern", "liga";
 	font-feature-settings: "kern", "liga";
+
+	background-color: var(--main-background-color);
+	color: var(--main-color);
 }
 
 h1 {
@@ -212,6 +215,26 @@ a.srclink,
 /* This selector is for the items listed in the "all items" page. */
 #main-content > ul.docblock > li > a {
 	font-family: "Fira Sans", Arial, NanumBarunGothic, sans-serif;
+}
+
+h1, h2, h3, h4,
+a#toggle-all-docs,
+a.anchor,
+.small-section-header a,
+#source-sidebar a,
+pre.rust a,
+.sidebar h2 a,
+.sidebar h3 a,
+.mobile-topbar h2 a,
+.in-band a,
+.search-results a,
+.module-item .stab,
+.import-item .stab,
+.result-name .primitive > i, .result-name .keyword > i,
+.content .method .where,
+.content .fn .where,
+.content .where.fmt-newline {
+	color: var(--main-color);
 }
 
 ol, ul {
@@ -389,6 +412,14 @@ nav.sub {
 
 .rustdoc.source .sidebar .sidebar-logo {
 	display: none;
+}
+
+.source .sidebar, #sidebar-toggle, #source-sidebar {
+	background-color: var(--sidebar-background-color);
+}
+
+#sidebar-toggle:hover {
+	background-color: var(--sidebar-background-color-hover);
 }
 
 .source .sidebar > *:not(#sidebar-toggle) {
@@ -1003,6 +1034,11 @@ table,
 	top: -5px;
 }
 
+.popover, .popover::before {
+	background-color: var(--main-background-color);
+	color: var(--main-color);
+}
+
 #help-button .popover {
 	max-width: 600px;
 }
@@ -1421,6 +1457,25 @@ pre.rust {
 }
 #settings-menu.rotate > a img {
 	animation: rotating 2s linear infinite;
+}
+
+.setting-line .radio-line input:checked {
+	box-shadow: inset 0 0 0 3px var(--main-background-color);
+	background-color: var(--settings-input-color);
+}
+.setting-line .radio-line input:focus {
+	box-shadow: 0 0 1px 1px var(--settings-input-color);
+}
+/* In here we combine both `:focus` and `:checked` properties. */
+.setting-line .radio-line input:checked:focus {
+	box-shadow: inset 0 0 0 3px var(--main-background-color),
+		0 0 2px 2px var(--settings-input-color);
+}
+.setting-line .radio-line input:hover {
+	border-color: var(--settings-input-color) !important;
+}
+input:checked + .slider {
+	background-color: var(--settings-input-color);
 }
 
 #help-button > button {

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -629,11 +629,6 @@ h2.location a {
 	display: block;
 }
 
-.invisible {
-	width: 100%;
-	display: inline-block;
-}
-
 .content .in-band {
 	flex-grow: 1;
 	margin: 0px;

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -158,8 +158,8 @@ h1.fqn {
 	Underlines elsewhere in the documentation break up visual flow and tend to invert
 	section hierarchies. */
 h2,
-.top-doc h3,
-.top-doc h4 {
+.top-doc .docblock > h3,
+.top-doc .docblock > h4 {
 	border-bottom: 1px solid;
 }
 h3.code-header {
@@ -1667,6 +1667,18 @@ details.rustdoc-toggle[open] > summary.hideme::before {
 details.rustdoc-toggle[open] > summary::after,
 details.rustdoc-toggle[open] > summary.hideme::after {
 	content: "Collapse";
+}
+
+.docblock details summary {
+	display: flex;
+	list-style: none;
+	align-items: center;
+}
+.docblock details[open] summary::before {
+	content: "► ";
+}
+.docblock details[open] summary::before {
+	content: "▼ ";
 }
 
 /* Media Queries */

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1669,16 +1669,9 @@ details.rustdoc-toggle[open] > summary.hideme::after {
 	content: "Collapse";
 }
 
-.docblock details summary {
-	display: flex;
-	list-style: none;
-	align-items: center;
-}
-.docblock details[open] summary::before {
-	content: "► ";
-}
-.docblock details[open] summary::before {
-	content: "▼ ";
+/* This is needed in docblocks to have the "▶" element to be on the same line. */
+.docblock summary > * {
+	display: inline-block;
 }
 
 /* Media Queries */

--- a/src/librustdoc/html/static/css/themes/ayu.css
+++ b/src/librustdoc/html/static/css/themes/ayu.css
@@ -62,10 +62,6 @@ h4 {
 	background-color: #0f1419;
 }
 
-.invisible {
-	background: rgba(0, 0, 0, 0);
-}
-
 .docblock code {
 	color: #ffb454;
 }

--- a/src/librustdoc/html/static/css/themes/ayu.css
+++ b/src/librustdoc/html/static/css/themes/ayu.css
@@ -3,30 +3,12 @@ Based off of the Ayu theme
 Original by Dempfi (https://github.com/dempfi/ayu)
 */
 
-/* General structure and fonts */
-
-body, .popover, .popover::before {
-	background-color: #0f1419;
-	color: #c5c5c5;
-}
-
-.setting-line .radio-line input {
-	border-color: #c5c5c5;
-}
-.setting-line .radio-line input:checked {
-	box-shadow: inset 0 0 0 3px #0f1419;
-	background-color: #ffb454;
-}
-.setting-line .radio-line input:focus {
-	box-shadow: 0 0 1px 1px #ffb454;
-}
-/* In here we combine both `:focus` and `:checked` properties. */
-.setting-line .radio-line input:checked:focus {
-	box-shadow: inset 0 0 0 3px 0f1419,
-		0 0 2px 2px #ffb454;
-}
-.setting-line .radio-line input:hover {
-	border-color: #ffb454 !important;
+:root {
+	--main-background-color: #0f1419;
+	--main-color: #c5c5c5;
+	--settings-input-color: #ffb454;
+	--sidebar-background-color: #14191f;
+	--sidebar-background-color-hover: rgba(70, 70, 70, 0.33);
 }
 
 .slider {
@@ -34,9 +16,6 @@ body, .popover, .popover::before {
 }
 .slider:before {
 	background-color: white;
-}
-input:checked + .slider {
-	background-color: #ffb454;
 }
 input:focus + .slider {
 	box-shadow: 0 0 0 2px #0a84ff, 0 0 0 6px rgba(10, 132, 255, 0.3);
@@ -125,10 +104,6 @@ pre, .rustdoc.source .example-wrap {
 	color: #ffb44c;
 }
 
-.source .sidebar {
-	background-color: #14191f;
-}
-
 .sidebar-elems .location {
 	color: #ff7733;
 }
@@ -147,12 +122,6 @@ pre, .rustdoc.source .example-wrap {
 
 .docblock table td, .docblock table th {
 	border-color: #5c6773;
-}
-
-.content .method .where,
-.content .fn .where,
-.content .where.fmt-newline {
-	color: #c5c5c5;
 }
 
 .search-results a:hover {
@@ -229,17 +198,6 @@ a {
 	color: #39AFD7;
 }
 
-a#toggle-all-docs,
-a.anchor,
-.small-section-header a,
-#source-sidebar a,
-pre.rust a,
-.sidebar h2 a,
-.sidebar h3 a,
-.mobile-topbar h2 a,
-.in-band a {
-	color: #c5c5c5;
-}
 .sidebar h2 a,
 .sidebar h3 a {
 	color: white;
@@ -613,15 +571,6 @@ kbd {
 	color: #999;
 }
 
-#sidebar-toggle {
-	background-color: #14191f;
-}
-#sidebar-toggle:hover {
-	background-color: rgba(70, 70, 70, 0.33);
-}
-#source-sidebar {
-	background-color: #14191f;
-}
 #source-sidebar > .title {
 	color: #fff;
 	border-bottom-color: #5c6773;

--- a/src/librustdoc/html/static/css/themes/dark.css
+++ b/src/librustdoc/html/static/css/themes/dark.css
@@ -1,25 +1,9 @@
-body, .popover, .popover::before {
-	background-color: #353535;
-	color: #ddd;
-}
-
-.setting-line .radio-line input {
-	border-color: #ddd;
-}
-.setting-line .radio-line input:checked {
-	box-shadow: inset 0 0 0 3px #353535;
-	background-color: #2196f3;
-}
-.setting-line .radio-line input:focus {
-	box-shadow: 0 0 1px 1px #2196f3;
-}
-/* In here we combine both `:focus` and `:checked` properties. */
-.setting-line .radio-line input:checked:focus {
-	box-shadow: inset 0 0 0 3px #353535,
-		0 0 2px 2px #2196f3;
-}
-.setting-line .radio-line input:hover {
-	border-color: #2196f3 !important;
+:root {
+	--main-background-color: #353535;
+	--main-color: #ddd;
+	--settings-input-color: #2196f3;
+	--sidebar-background-color: #565656;
+	--sidebar-background-color-hover: #676767;
 }
 
 .slider {
@@ -28,16 +12,10 @@ body, .popover, .popover::before {
 .slider:before {
 	background-color: white;
 }
-input:checked + .slider {
-	background-color: #2196F3;
-}
 input:focus + .slider {
 	box-shadow: 0 0 0 2px #0a84ff, 0 0 0 6px rgba(10, 132, 255, 0.3);
 }
 
-h1, h2, h3, h4 {
-	color: #ddd;
-}
 h1.fqn {
 	border-bottom-color: #d2d2d2;
 }
@@ -94,10 +72,6 @@ pre, .rustdoc.source .example-wrap {
 	background: #444;
 }
 
-.source .sidebar {
-	background-color: #565656;
-}
-
 .line-numbers span { color: #3B91E2; }
 .line-numbers .line-highlighted {
 	background-color: #0a042f !important;
@@ -109,12 +83,6 @@ pre, .rustdoc.source .example-wrap {
 
 .docblock table td, .docblock table th {
 	border-color: #ddd;
-}
-
-.content .method .where,
-.content .fn .where,
-.content .where.fmt-newline {
-	color: #ddd;
 }
 
 .search-results a:hover {
@@ -210,20 +178,6 @@ a {
 	color: #D2991D;
 }
 
-a#toggle-all-docs,
-a.anchor,
-.small-section-header a,
-#source-sidebar a,
-pre.rust a,
-.sidebar h2 a,
-.sidebar h3 a,
-.mobile-topbar h2 a,
-.in-band a {
-	color: #ddd;
-}
-.search-results a {
-	color: #ddd;
-}
 a.test-arrow {
 	color: #dedede;
 }
@@ -257,11 +211,6 @@ details.undocumented > summary::before {
 	border-color: #008dfd;
 }
 
-.module-item .stab,
-.import-item .stab {
-	color: #ddd;
-}
-
 .stab.empty-impl { background: #FFF5D6; border-color: #FFC600; color: #2f2f2f; }
 .stab.unstable { background: #FFF5D6; border-color: #FFC600; color: #2f2f2f; }
 .stab.deprecated { background: #ffc4c4; border-color: #db7b7b; color: #2f2f2f; }
@@ -285,10 +234,6 @@ details.undocumented > summary::before {
 .rightside,
 .out-of-band {
 	color: grey;
-}
-
-.result-name .primitive > i, .result-name .keyword > i {
-	color: #ddd;
 }
 
 .line-numbers :target { background-color: transparent; }
@@ -484,15 +429,6 @@ kbd {
 	color: #ccc;
 }
 
-#sidebar-toggle {
-	background-color: #565656;
-}
-#sidebar-toggle:hover {
-	background-color: #676767;
-}
-#source-sidebar {
-	background-color: #565656;
-}
 #source-sidebar > .title {
 	border-bottom-color: #ccc;
 }

--- a/src/librustdoc/html/static/css/themes/dark.css
+++ b/src/librustdoc/html/static/css/themes/dark.css
@@ -49,10 +49,6 @@ h2, h3, h4 {
 	background-color: #353535;
 }
 
-.invisible {
-	background: rgba(0, 0, 0, 0);
-}
-
 .docblock code, .docblock-short code {
 	background-color: #2A2A2A;
 }

--- a/src/librustdoc/html/static/css/themes/light.css
+++ b/src/librustdoc/html/static/css/themes/light.css
@@ -1,27 +1,9 @@
-/* General structure and fonts */
-
-body, .popover, .popover::before {
-	background-color: white;
-	color: black;
-}
-
-.setting-line .radio-line input {
-	border-color: black;
-}
-.setting-line .radio-line input:checked {
-	box-shadow: inset 0 0 0 3px white;
-	background-color: #2196f3;
-}
-.setting-line .radio-line input:focus {
-	box-shadow: 0 0 1px 1px #2196f3;
-}
-/* In here we combine both `:focus` and `:checked` properties. */
-.setting-line .radio-line input:checked:focus {
-	box-shadow: inset 0 0 0 3px white,
-		0 0 2px 2px #2196f3;
-}
-.setting-line .radio-line input:hover {
-	border-color: #2196f3 !important;
+:root {
+	--main-background-color: white;
+	--main-color: black;
+	--settings-input-color: #2196f3;
+	--sidebar-background-color: #F5F5F5;
+	--sidebar-background-color-hover: #E0E0E0;
 }
 
 .slider {
@@ -30,16 +12,10 @@ body, .popover, .popover::before {
 .slider:before {
 	background-color: white;
 }
-input:checked + .slider {
-	background-color: #2196F3;
-}
 input:focus + .slider {
 	box-shadow: 0 0 0 2px #0a84ff, 0 0 0 6px rgba(10, 132, 255, 0.3);
 }
 
-h1, h2, h3, h4 {
-	color: black;
-}
 h1.fqn {
 	border-bottom-color: #DDDDDD;
 }
@@ -96,10 +72,6 @@ pre, .rustdoc.source .example-wrap {
 	background-color: #fff;
 }
 
-.source .sidebar {
-	background-color: #f1f1f1;
-}
-
 .line-numbers span { color: #c67e2d; }
 .line-numbers .line-highlighted {
 	background-color: #FDFFD3 !important;
@@ -111,12 +83,6 @@ pre, .rustdoc.source .example-wrap {
 
 .docblock table td, .docblock table th {
 	border-color: #ddd;
-}
-
-.content .method .where,
-.content .fn .where,
-.content .where.fmt-newline {
-	color: #4E4C4C;
 }
 
 .search-results a:hover {
@@ -209,20 +175,6 @@ a {
 	color: #3873AD;
 }
 
-a#toggle-all-docs,
-a.anchor,
-.small-section-header a,
-#source-sidebar a,
-pre.rust a,
-.sidebar h2 a,
-.sidebar h3 a,
-.mobile-topbar h2 a,
-.in-band a {
-	color: #000;
-}
-.search-results a {
-	color: initial;
-}
 a.test-arrow {
 	color: #f5f5f5;
 }
@@ -246,11 +198,6 @@ details.undocumented > summary::before {
 	border-color: #66afe9;
 }
 
-.module-item .stab,
-.import-item .stab {
-	color: #000;
-}
-
 .stab.empty-impl { background: #FFF5D6; border-color: #FFC600; }
 .stab.unstable { background: #FFF5D6; border-color: #FFC600; }
 .stab.deprecated { background: #ffc4c4; border-color: #db7b7b; }
@@ -269,10 +216,6 @@ details.undocumented > summary::before {
 .rightside,
 .out-of-band {
 	color: grey;
-}
-
-.result-name .primitive > i, .result-name .keyword > i {
-	color: black;
 }
 
 .line-numbers :target { background-color: transparent; }
@@ -468,15 +411,6 @@ kbd {
 	color: #999;
 }
 
-#sidebar-toggle {
-	background-color: #F5F5F5;
-}
-#sidebar-toggle:hover {
-	background-color: #E0E0E0;
-}
-#source-sidebar {
-	background-color: #F5F5F5;
-}
 #source-sidebar > .title {
 	border-bottom-color: #ccc;
 }

--- a/src/librustdoc/html/static/css/themes/light.css
+++ b/src/librustdoc/html/static/css/themes/light.css
@@ -51,10 +51,6 @@ h2, h3, h4 {
 	background-color: white;
 }
 
-.invisible {
-	background: rgba(0, 0, 0, 0);
-}
-
 .docblock code, .docblock-short code {
 	background-color: #F5F5F5;
 }

--- a/src/test/rustdoc-gui/docblock-details.goml
+++ b/src/test/rustdoc-gui/docblock-details.goml
@@ -1,0 +1,23 @@
+// This ensures that the `<details>`/`<summary>` elements are displayed as expected.
+goto: file://|DOC_PATH|/test_docs/details/struct.Details.html
+show-text: true
+local-storage: {"rustdoc-theme": "dark", "rustdoc-use-system-theme": "false"}
+reload:
+
+// We first check that the headers in the `.top-doc` doc block still have their
+// bottom border.
+assert-text: (".top-doc .docblock > h3", "Hello")
+assert-css: (
+    ".top-doc .docblock > h3",
+    {"border-bottom": "1px solid rgb(221, 221, 221)"},
+)
+// We now check that the `<summary>` doesn't have a bottom border and has the correct display.
+assert-css: (
+    ".top-doc .docblock summary h4",
+    {"border-bottom": "0px none rgb(221, 221, 221)"},
+)
+// This allows to ensure that summary is on one line only!
+assert-property: (".top-doc .docblock summary h4", {"offsetHeight": "33"})
+assert-css: (".top-doc .docblock summary h4", {"margin-top": "15px", "margin-bottom": "5px"})
+// So `33 + 15 + 5` == `53`
+assert-property: (".top-doc .docblock summary", {"offsetHeight": "53"})

--- a/src/test/rustdoc-gui/src/test_docs/lib.rs
+++ b/src/test/rustdoc-gui/src/test_docs/lib.rs
@@ -277,3 +277,15 @@ pub use macros::*;
 
 #[doc(alias = "AliasForTheStdReexport")]
 pub use ::std as TheStdReexport;
+
+pub mod details {
+    /// We check the appearance of the `<details>`/`<summary>` in here.
+    ///
+    /// ## Hello
+    ///
+    /// <details>
+    /// <summary><h4>I'm a summary</h4></summary>
+    /// <div>I'm the content of the details!</div>
+    /// </details>
+    pub struct Details;
+}

--- a/src/test/rustdoc-ui/issue-98690.rs
+++ b/src/test/rustdoc-ui/issue-98690.rs
@@ -1,0 +1,10 @@
+// compile-flags: --test --persist-doctests /../../ -Z unstable-options
+// failure-status: 101
+// only-linux
+
+#![crate_name = "foo"]
+
+//! ```rust
+//! use foo::dummy;
+//! dummy();
+//! ```

--- a/src/test/rustdoc-ui/issue-98690.stderr
+++ b/src/test/rustdoc-ui/issue-98690.stderr
@@ -1,0 +1,1 @@
+Couldn't create directory for doctest executables: Permission denied (os error 13)

--- a/src/test/ui/array-slice-vec/infer_array_len.stderr
+++ b/src/test/ui/array-slice-vec/infer_array_len.stderr
@@ -4,7 +4,6 @@ error[E0282]: type annotations needed
 LL |     let [_, _] = a.into();
    |         ^^^^^^
    |
-   = note: type must be known at this point
 help: consider giving this pattern a type
    |
 LL |     let [_, _]: _ = a.into();

--- a/src/test/ui/array-slice-vec/slice-pat-type-mismatches.stderr
+++ b/src/test/ui/array-slice-vec/slice-pat-type-mismatches.stderr
@@ -27,8 +27,6 @@ error[E0282]: type annotations needed
    |
 LL |         [] => {}
    |         ^^ cannot infer type
-   |
-   = note: type must be known at this point
 
 error: aborting due to 5 previous errors
 

--- a/src/test/ui/cast/issue-85586.stderr
+++ b/src/test/ui/cast/issue-85586.stderr
@@ -3,8 +3,6 @@ error[E0282]: type annotations needed
    |
 LL |     let b = (a + 1) as usize;
    |             ^^^^^^^ cannot infer type
-   |
-   = note: type must be known at this point
 
 error: aborting due to previous error
 

--- a/src/test/ui/coherence/coherence-overlap-trait-alias.stderr
+++ b/src/test/ui/coherence/coherence-overlap-trait-alias.stderr
@@ -1,8 +1,8 @@
-error[E0283]: type annotations needed
+error[E0283]: type annotations needed: cannot satisfy `u32: C`
   --> $DIR/coherence-overlap-trait-alias.rs:15:6
    |
 LL | impl C for u32 {}
-   |      ^ cannot infer type for type `u32`
+   |      ^
    |
 note: multiple `impl`s satisfying `u32: C` found
   --> $DIR/coherence-overlap-trait-alias.rs:14:1

--- a/src/test/ui/const-generics/generic_arg_infer/issue-91614.stderr
+++ b/src/test/ui/const-generics/generic_arg_infer/issue-91614.stderr
@@ -2,7 +2,7 @@ error[E0283]: type annotations needed for `Mask<_, LANES>`
   --> $DIR/issue-91614.rs:6:9
    |
 LL |     let y = Mask::<_, _>::splat(false);
-   |         ^
+   |         ^   ------------------- type must be known at this point
    |
    = note: cannot satisfy `_: MaskElement`
 note: required by a bound in `Mask::<T, LANES>::splat`

--- a/src/test/ui/const-generics/generic_const_exprs/issue-72787.min.stderr
+++ b/src/test/ui/const-generics/generic_const_exprs/issue-72787.min.stderr
@@ -34,19 +34,19 @@ LL |     IsLessOrEqual<{ 8 - I }, { 8 - J }>: True,
    = help: const parameters may only be used as standalone arguments, i.e. `J`
    = help: use `#![feature(generic_const_exprs)]` to allow generic const expressions
 
-error[E0283]: type annotations needed
+error[E0283]: type annotations needed: cannot satisfy `IsLessOrEqual<I, 8_u32>: True`
   --> $DIR/issue-72787.rs:21:26
    |
 LL |     IsLessOrEqual<I, 8>: True,
-   |                          ^^^^ cannot infer type for struct `IsLessOrEqual<I, 8_u32>`
+   |                          ^^^^
    |
    = note: cannot satisfy `IsLessOrEqual<I, 8_u32>: True`
 
-error[E0283]: type annotations needed
+error[E0283]: type annotations needed: cannot satisfy `IsLessOrEqual<I, 8_u32>: True`
   --> $DIR/issue-72787.rs:21:26
    |
 LL |     IsLessOrEqual<I, 8>: True,
-   |                          ^^^^ cannot infer type for struct `IsLessOrEqual<I, 8_u32>`
+   |                          ^^^^
    |
    = note: cannot satisfy `IsLessOrEqual<I, 8_u32>: True`
 

--- a/src/test/ui/const-generics/generic_const_exprs/issue-72787.rs
+++ b/src/test/ui/const-generics/generic_const_exprs/issue-72787.rs
@@ -19,8 +19,8 @@ struct S<const I: u32, const J: u32>;
 impl<const I: u32, const J: u32> S<I, J>
 where
     IsLessOrEqual<I, 8>: True,
-//[min]~^ Error type annotations needed [E0283]
-//[min]~| Error type annotations needed [E0283]
+//[min]~^ Error type annotations needed
+//[min]~| Error type annotations needed
     IsLessOrEqual<J, 8>: True,
     IsLessOrEqual<{ 8 - I }, { 8 - J }>: True,
 //[min]~^ Error generic parameters may not be used in const operations

--- a/src/test/ui/impl-trait/hidden-type-is-opaque-2.stderr
+++ b/src/test/ui/impl-trait/hidden-type-is-opaque-2.stderr
@@ -3,16 +3,12 @@ error[E0282]: type annotations needed
    |
 LL |         cont.reify_as();
    |         ^^^^ cannot infer type
-   |
-   = note: type must be known at this point
 
 error[E0282]: type annotations needed
   --> $DIR/hidden-type-is-opaque-2.rs:18:9
    |
 LL |         cont.reify_as();
    |         ^^^^ cannot infer type
-   |
-   = note: type must be known at this point
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/inference/cannot-infer-partial-try-return.stderr
+++ b/src/test/ui/inference/cannot-infer-partial-try-return.stderr
@@ -3,6 +3,9 @@ error[E0282]: type annotations needed for `Result<(), QualifiedError<_>>`
    |
 LL |     let x = || -> Result<_, QualifiedError<_>> {
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |
+LL |         infallible()?;
+   |         ------------- type must be known at this point
    |
 help: try giving this closure an explicit return type
    |

--- a/src/test/ui/inference/erase-type-params-in-label.stderr
+++ b/src/test/ui/inference/erase-type-params-in-label.stderr
@@ -2,7 +2,7 @@ error[E0283]: type annotations needed for `Foo<i32, &str, W, Z>`
   --> $DIR/erase-type-params-in-label.rs:2:9
    |
 LL |     let foo = foo(1, "");
-   |         ^^^
+   |         ^^^   --- type must be known at this point
    |
    = note: cannot satisfy `_: Default`
 note: required by a bound in `foo`
@@ -23,7 +23,7 @@ error[E0283]: type annotations needed for `Bar<i32, &str, Z>`
   --> $DIR/erase-type-params-in-label.rs:5:9
    |
 LL |     let bar = bar(1, "");
-   |         ^^^
+   |         ^^^   --- type must be known at this point
    |
    = note: cannot satisfy `_: Default`
 note: required by a bound in `bar`

--- a/src/test/ui/inference/issue-72616.stderr
+++ b/src/test/ui/inference/issue-72616.stderr
@@ -2,7 +2,9 @@ error[E0283]: type annotations needed
   --> $DIR/issue-72616.rs:20:37
    |
 LL |         if String::from("a") == "a".try_into().unwrap() {}
-   |                                     ^^^^^^^^
+   |                              --     ^^^^^^^^
+   |                              |
+   |                              type must be known at this point
    |
    = note: multiple `impl`s satisfying `String: PartialEq<_>` found in the `alloc` crate:
            - impl PartialEq for String;

--- a/src/test/ui/inference/issue-72690.stderr
+++ b/src/test/ui/inference/issue-72690.stderr
@@ -55,7 +55,7 @@ error[E0283]: type annotations needed for `&T`
   --> $DIR/issue-72690.rs:17:9
    |
 LL |     let _ = "x".as_ref();
-   |         ^
+   |         ^       ------ type must be known at this point
    |
    = note: multiple `impl`s satisfying `str: AsRef<_>` found in the following crates: `core`, `std`:
            - impl AsRef<OsStr> for str;

--- a/src/test/ui/inference/issue-86162-1.stderr
+++ b/src/test/ui/inference/issue-86162-1.stderr
@@ -2,7 +2,9 @@ error[E0283]: type annotations needed
   --> $DIR/issue-86162-1.rs:7:9
    |
 LL |     foo(gen()); //<- Do not suggest `foo::<impl Clone>()`!
-   |         ^^^ cannot infer type of the type parameter `T` declared on the function `gen`
+   |     --- ^^^ cannot infer type of the type parameter `T` declared on the function `gen`
+   |     |
+   |     type must be known at this point
    |
    = note: cannot satisfy `_: Clone`
 note: required by a bound in `foo`

--- a/src/test/ui/inference/issue-86162-2.stderr
+++ b/src/test/ui/inference/issue-86162-2.stderr
@@ -2,7 +2,9 @@ error[E0283]: type annotations needed
   --> $DIR/issue-86162-2.rs:12:14
    |
 LL |     Foo::bar(gen()); //<- Do not suggest `Foo::bar::<impl Clone>()`!
-   |              ^^^ cannot infer type of the type parameter `T` declared on the function `gen`
+   |     -------- ^^^ cannot infer type of the type parameter `T` declared on the function `gen`
+   |     |
+   |     type must be known at this point
    |
    = note: cannot satisfy `_: Clone`
 note: required by a bound in `Foo::bar`

--- a/src/test/ui/issues/issue-12028.stderr
+++ b/src/test/ui/issues/issue-12028.stderr
@@ -1,8 +1,14 @@
-error[E0284]: type annotations needed: cannot satisfy `<_ as StreamHasher>::S == <H as StreamHasher>::S`
+error[E0284]: type annotations needed
   --> $DIR/issue-12028.rs:27:14
    |
 LL |         self.input_stream(&mut stream);
-   |              ^^^^^^^^^^^^ cannot satisfy `<_ as StreamHasher>::S == <H as StreamHasher>::S`
+   |              ^^^^^^^^^^^^
+   |
+   = note: cannot satisfy `<_ as StreamHasher>::S == <H as StreamHasher>::S`
+help: try using a fully qualified path to specify the expected types
+   |
+LL |         <u8 as StreamHash<H>>::input_stream(self, &mut stream);
+   |         ++++++++++++++++++++++++++++++++++++    ~
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-15965.stderr
+++ b/src/test/ui/issues/issue-15965.stderr
@@ -5,8 +5,6 @@ LL | /         { return () }
 LL | |
 LL | |     ()
    | |______^ cannot infer type
-   |
-   = note: type must be known at this point
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-20261.stderr
+++ b/src/test/ui/issues/issue-20261.stderr
@@ -3,8 +3,6 @@ error[E0282]: type annotations needed
    |
 LL |         i.clone();
    |           ^^^^^ cannot infer type
-   |
-   = note: type must be known at this point
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-2151.stderr
+++ b/src/test/ui/issues/issue-2151.stderr
@@ -3,8 +3,9 @@ error[E0282]: type annotations needed
    |
 LL |     let x = panic!();
    |         ^
+LL |     x.clone();
+   |     - type must be known at this point
    |
-   = note: type must be known at this point
 help: consider giving `x` an explicit type
    |
 LL |     let x: _ = panic!();

--- a/src/test/ui/issues/issue-21974.stderr
+++ b/src/test/ui/issues/issue-21974.stderr
@@ -1,8 +1,8 @@
-error[E0283]: type annotations needed
+error[E0283]: type annotations needed: cannot satisfy `&'a T: Foo`
   --> $DIR/issue-21974.rs:11:19
    |
 LL |     where &'a T : Foo,
-   |                   ^^^ cannot infer type for reference `&'a T`
+   |                   ^^^
    |
    = note: cannot satisfy `&'a T: Foo`
 

--- a/src/test/ui/issues/issue-24424.stderr
+++ b/src/test/ui/issues/issue-24424.stderr
@@ -1,8 +1,8 @@
-error[E0283]: type annotations needed
+error[E0283]: type annotations needed: cannot satisfy `T0: Trait0<'l0>`
   --> $DIR/issue-24424.rs:4:57
    |
 LL | impl <'l0, 'l1, T0> Trait1<'l0, T0> for bool where T0 : Trait0<'l0>, T0 : Trait0<'l1> {}
-   |                                                         ^^^^^^^^^^^ cannot infer type for type parameter `T0`
+   |                                                         ^^^^^^^^^^^
    |
    = note: cannot satisfy `T0: Trait0<'l0>`
 

--- a/src/test/ui/issues/issue-51116.rs
+++ b/src/test/ui/issues/issue-51116.rs
@@ -5,7 +5,6 @@ fn main() {
             *tile = 0;
             //~^ ERROR type annotations needed
             //~| NOTE cannot infer type
-            //~| NOTE type must be known at this point
         }
     }
 

--- a/src/test/ui/issues/issue-51116.stderr
+++ b/src/test/ui/issues/issue-51116.stderr
@@ -3,8 +3,6 @@ error[E0282]: type annotations needed
    |
 LL |             *tile = 0;
    |             ^^^^^ cannot infer type
-   |
-   = note: type must be known at this point
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-69455.stderr
+++ b/src/test/ui/issues/issue-69455.stderr
@@ -14,7 +14,9 @@ error[E0283]: type annotations needed
   --> $DIR/issue-69455.rs:29:41
    |
 LL |     println!("{}", 23u64.test(xs.iter().sum()));
-   |                                         ^^^ cannot infer type of the type parameter `S` declared on the associated function `sum`
+   |                          ----           ^^^ cannot infer type of the type parameter `S` declared on the associated function `sum`
+   |                          |
+   |                          type must be known at this point
    |
 note: multiple `impl`s satisfying `u64: Test<_>` found
   --> $DIR/issue-69455.rs:11:1

--- a/src/test/ui/issues/issue-69683.stderr
+++ b/src/test/ui/issues/issue-69683.stderr
@@ -1,8 +1,14 @@
-error[E0284]: type annotations needed: cannot satisfy `<u8 as Element<_>>::Array == [u8; 3]`
+error[E0284]: type annotations needed
   --> $DIR/issue-69683.rs:30:10
    |
 LL |     0u16.foo(b);
-   |          ^^^ cannot satisfy `<u8 as Element<_>>::Array == [u8; 3]`
+   |          ^^^
+   |
+   = note: cannot satisfy `<u8 as Element<_>>::Array == [u8; 3]`
+help: try using a fully qualified path to specify the expected types
+   |
+LL |     <u16 as Foo<I>>::foo(0u16, b);
+   |     +++++++++++++++++++++    ~
 
 error[E0283]: type annotations needed
   --> $DIR/issue-69683.rs:30:10

--- a/src/test/ui/issues/issue-71584.stderr
+++ b/src/test/ui/issues/issue-71584.stderr
@@ -1,8 +1,16 @@
-error[E0284]: type annotations needed: cannot satisfy `<u64 as Rem<_>>::Output == u64`
-  --> $DIR/issue-71584.rs:4:11
+error[E0284]: type annotations needed
+  --> $DIR/issue-71584.rs:4:15
    |
 LL |     d = d % n.into();
-   |           ^ cannot satisfy `<u64 as Rem<_>>::Output == u64`
+   |           -   ^^^^
+   |           |
+   |           type must be known at this point
+   |
+   = note: cannot satisfy `<u64 as Rem<_>>::Output == u64`
+help: try using a fully qualified path to specify the expected types
+   |
+LL |     d = d % <u32 as Into<T>>::into(n);
+   |             +++++++++++++++++++++++ ~
 
 error: aborting due to previous error
 

--- a/src/test/ui/issues/issue-7813.stderr
+++ b/src/test/ui/issues/issue-7813.stderr
@@ -2,7 +2,7 @@ error[E0282]: type annotations needed for `&[_; 0]`
   --> $DIR/issue-7813.rs:2:9
    |
 LL |     let v = &[];
-   |         ^
+   |         ^   --- type must be known at this point
    |
 help: consider giving `v` an explicit type, where the placeholders `_` are specified
    |

--- a/src/test/ui/lazy-type-alias-impl-trait/branches3.stderr
+++ b/src/test/ui/lazy-type-alias-impl-trait/branches3.stderr
@@ -2,9 +2,8 @@ error[E0282]: type annotations needed
   --> $DIR/branches3.rs:8:10
    |
 LL |         |s| s.len()
-   |          ^
+   |          ^  - type must be known at this point
    |
-   = note: type must be known at this point
 help: consider giving this closure parameter an explicit type
    |
 LL |         |s: _| s.len()
@@ -14,9 +13,8 @@ error[E0282]: type annotations needed
   --> $DIR/branches3.rs:15:10
    |
 LL |         |s| s.len()
-   |          ^
+   |          ^  - type must be known at this point
    |
-   = note: type must be known at this point
 help: consider giving this closure parameter an explicit type
    |
 LL |         |s: _| s.len()
@@ -26,9 +24,8 @@ error[E0282]: type annotations needed
   --> $DIR/branches3.rs:23:10
    |
 LL |         |s| s.len()
-   |          ^
+   |          ^  - type must be known at this point
    |
-   = note: type must be known at this point
 help: consider giving this closure parameter an explicit type
    |
 LL |         |s: _| s.len()
@@ -38,9 +35,8 @@ error[E0282]: type annotations needed
   --> $DIR/branches3.rs:30:10
    |
 LL |         |s| s.len()
-   |          ^
+   |          ^  - type must be known at this point
    |
-   = note: type must be known at this point
 help: consider giving this closure parameter an explicit type
    |
 LL |         |s: _| s.len()

--- a/src/test/ui/lifetimes/issue-34979.stderr
+++ b/src/test/ui/lifetimes/issue-34979.stderr
@@ -1,8 +1,8 @@
-error[E0283]: type annotations needed
+error[E0283]: type annotations needed: cannot satisfy `&'a (): Foo`
   --> $DIR/issue-34979.rs:6:13
    |
 LL |     &'a (): Foo,
-   |             ^^^ cannot infer type for reference `&'a ()`
+   |             ^^^
    |
    = note: cannot satisfy `&'a (): Foo`
 

--- a/src/test/ui/marker_trait_attr/region-overlap.stderr
+++ b/src/test/ui/marker_trait_attr/region-overlap.stderr
@@ -1,8 +1,8 @@
-error[E0283]: type annotations needed
+error[E0283]: type annotations needed: cannot satisfy `(&'static (), &'a ()): A`
   --> $DIR/region-overlap.rs:5:10
    |
 LL | impl<'a> A for (&'static (), &'a ()) {}
-   |          ^ cannot infer type for tuple `(&'static (), &'a ())`
+   |          ^
    |
 note: multiple `impl`s satisfying `(&'static (), &'a ()): A` found
   --> $DIR/region-overlap.rs:5:1
@@ -12,11 +12,11 @@ LL | impl<'a> A for (&'static (), &'a ()) {}
 LL | impl<'a> A for (&'a (), &'static ()) {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0283]: type annotations needed
+error[E0283]: type annotations needed: cannot satisfy `(&'a (), &'static ()): A`
   --> $DIR/region-overlap.rs:6:10
    |
 LL | impl<'a> A for (&'a (), &'static ()) {}
-   |          ^ cannot infer type for tuple `(&'a (), &'static ())`
+   |          ^
    |
 note: multiple `impl`s satisfying `(&'a (), &'static ()): A` found
   --> $DIR/region-overlap.rs:5:1

--- a/src/test/ui/pattern/issue-88074-pat-range-type-inference-err.stderr
+++ b/src/test/ui/pattern/issue-88074-pat-range-type-inference-err.stderr
@@ -12,8 +12,6 @@ error[E0282]: type annotations needed
    |
 LL |         Zero::ZERO ..= Zero::ZERO => {},
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type
-   |
-   = note: type must be known at this point
 
 error: aborting due to 2 previous errors
 

--- a/src/test/ui/pattern/pat-tuple-bad-type.stderr
+++ b/src/test/ui/pattern/pat-tuple-bad-type.stderr
@@ -3,8 +3,10 @@ error[E0282]: type annotations needed
    |
 LL |     let x;
    |         ^
+...
+LL |         (..) => {}
+   |         ---- type must be known at this point
    |
-   = note: type must be known at this point
 help: consider giving `x` an explicit type
    |
 LL |     let x: _;

--- a/src/test/ui/span/issue-42234-unknown-receiver-type.full.stderr
+++ b/src/test/ui/span/issue-42234-unknown-receiver-type.full.stderr
@@ -3,8 +3,9 @@ error[E0282]: type annotations needed
    |
 LL |     let x: Option<_> = None;
    |                        ^^^^ cannot infer type of the type parameter `T` declared on the enum `Option`
+LL |     x.unwrap().method_that_could_exist_on_some_type();
+   |     ---------- type must be known at this point
    |
-   = note: type must be known at this point
 help: consider specifying the generic argument
    |
 LL |     let x: Option<_> = None::<T>;
@@ -16,7 +17,6 @@ error[E0282]: type annotations needed
 LL |         .sum::<_>()
    |          ^^^ cannot infer type of the type parameter `S` declared on the associated function `sum`
    |
-   = note: type must be known at this point
 help: consider specifying the generic argument
    |
 LL |         .sum::<_>()

--- a/src/test/ui/span/issue-42234-unknown-receiver-type.generic_arg.stderr
+++ b/src/test/ui/span/issue-42234-unknown-receiver-type.generic_arg.stderr
@@ -3,8 +3,9 @@ error[E0282]: type annotations needed
    |
 LL |     let x: Option<_> = None;
    |                        ^^^^ cannot infer type of the type parameter `T` declared on the enum `Option`
+LL |     x.unwrap().method_that_could_exist_on_some_type();
+   |     ---------- type must be known at this point
    |
-   = note: type must be known at this point
 help: consider specifying the generic argument
    |
 LL |     let x: Option<_> = None::<T>;
@@ -16,7 +17,6 @@ error[E0282]: type annotations needed
 LL |         .sum::<_>()
    |          ^^^ cannot infer type of the type parameter `S` declared on the associated function `sum`
    |
-   = note: type must be known at this point
 help: consider specifying the generic argument
    |
 LL |         .sum::<S>()

--- a/src/test/ui/span/method-and-field-eager-resolution.stderr
+++ b/src/test/ui/span/method-and-field-eager-resolution.stderr
@@ -3,8 +3,10 @@ error[E0282]: type annotations needed
    |
 LL |     let mut x = Default::default();
    |         ^^^^^
+LL |
+LL |     x.0;
+   |     - type must be known at this point
    |
-   = note: type must be known at this point
 help: consider giving `x` an explicit type
    |
 LL |     let mut x: _ = Default::default();
@@ -15,8 +17,10 @@ error[E0282]: type annotations needed
    |
 LL |     let mut x = Default::default();
    |         ^^^^^
+LL |
+LL |     x[0];
+   |     - type must be known at this point
    |
-   = note: type must be known at this point
 help: consider giving `x` an explicit type
    |
 LL |     let mut x: _ = Default::default();

--- a/src/test/ui/span/type-annotations-needed-expr.stderr
+++ b/src/test/ui/span/type-annotations-needed-expr.stderr
@@ -4,7 +4,6 @@ error[E0282]: type annotations needed
 LL |     let _ = (vec![1,2,3]).into_iter().sum() as f64;
    |                                       ^^^ cannot infer type of the type parameter `S` declared on the associated function `sum`
    |
-   = note: type must be known at this point
 help: consider specifying the generic argument
    |
 LL |     let _ = (vec![1,2,3]).into_iter().sum::<S>() as f64;

--- a/src/test/ui/suggestions/suggest-closure-return-type-1.stderr
+++ b/src/test/ui/suggestions/suggest-closure-return-type-1.stderr
@@ -2,7 +2,7 @@ error[E0282]: type annotations needed for `[_; 0]`
   --> $DIR/suggest-closure-return-type-1.rs:4:18
    |
 LL |     unbound_drop(|| -> _ { [] });
-   |                  ^^^^^^^
+   |                  ^^^^^^^   -- type must be known at this point
    |
 help: try giving this closure an explicit return type
    |

--- a/src/test/ui/suggestions/suggest-closure-return-type-2.stderr
+++ b/src/test/ui/suggestions/suggest-closure-return-type-2.stderr
@@ -2,7 +2,7 @@ error[E0282]: type annotations needed for `[_; 0]`
   --> $DIR/suggest-closure-return-type-2.rs:4:18
    |
 LL |     unbound_drop(|| { [] })
-   |                  ^^
+   |                  ^^   -- type must be known at this point
    |
 help: try giving this closure an explicit return type
    |

--- a/src/test/ui/suggestions/suggest-closure-return-type-3.stderr
+++ b/src/test/ui/suggestions/suggest-closure-return-type-3.stderr
@@ -2,7 +2,7 @@ error[E0282]: type annotations needed for `[_; 0]`
   --> $DIR/suggest-closure-return-type-3.rs:4:18
    |
 LL |     unbound_drop(|| []);
-   |                  ^^
+   |                  ^^ -- type must be known at this point
    |
 help: try giving this closure an explicit return type
    |

--- a/src/test/ui/traits/issue-77982.stderr
+++ b/src/test/ui/traits/issue-77982.stderr
@@ -26,7 +26,9 @@ error[E0283]: type annotations needed
   --> $DIR/issue-77982.rs:8:10
    |
 LL |     opts.get(opt.as_ref());
-   |          ^^^ cannot infer type of the type parameter `Q` declared on the associated function `get`
+   |          ^^^     ------ type must be known at this point
+   |          |
+   |          cannot infer type of the type parameter `Q` declared on the associated function `get`
    |
    = note: multiple `impl`s satisfying `String: AsRef<_>` found in the following crates: `alloc`, `std`:
            - impl AsRef<OsStr> for String;
@@ -42,7 +44,9 @@ error[E0283]: type annotations needed
   --> $DIR/issue-77982.rs:13:59
    |
 LL |     let ips: Vec<_> = (0..100_000).map(|_| u32::from(0u32.into())).collect();
-   |                                                           ^^^^
+   |                                            ---------      ^^^^
+   |                                            |
+   |                                            type must be known at this point
    |
    = note: multiple `impl`s satisfying `u32: From<_>` found in the following crates: `core`, `std`:
            - impl From<Ipv4Addr> for u32;
@@ -59,7 +63,7 @@ error[E0283]: type annotations needed for `Box<T>`
   --> $DIR/issue-77982.rs:36:9
    |
 LL |     let _ = ().foo();
-   |         ^
+   |         ^      --- type must be known at this point
    |
 note: multiple `impl`s satisfying `(): Foo<'_, _>` found
   --> $DIR/issue-77982.rs:29:1
@@ -77,7 +81,7 @@ error[E0283]: type annotations needed for `Box<T>`
   --> $DIR/issue-77982.rs:40:9
    |
 LL |     let _ = (&()).bar();
-   |         ^
+   |         ^         --- type must be known at this point
    |
 note: multiple `impl`s satisfying `&(): Bar<'_, _>` found
   --> $DIR/issue-77982.rs:32:1

--- a/src/test/ui/traits/issue-85735.rs
+++ b/src/test/ui/traits/issue-85735.rs
@@ -5,7 +5,7 @@ trait Foo {}
 impl<'a, 'b, T> Foo for T
 where
     T: FnMut(&'a ()),
-    //~^ ERROR: type annotations needed [E0283]
+    //~^ ERROR: type annotations needed
     T: FnMut(&'b ()),
 {
 }

--- a/src/test/ui/traits/issue-85735.stderr
+++ b/src/test/ui/traits/issue-85735.stderr
@@ -1,8 +1,8 @@
-error[E0283]: type annotations needed
+error[E0283]: type annotations needed: cannot satisfy `T: FnMut<(&'a (),)>`
   --> $DIR/issue-85735.rs:7:8
    |
 LL |     T: FnMut(&'a ()),
-   |        ^^^^^^^^^^^^^ cannot infer type for type parameter `T`
+   |        ^^^^^^^^^^^^^
    |
    = note: cannot satisfy `T: FnMut<(&'a (),)>`
 

--- a/src/test/ui/type-alias-impl-trait/closures_in_branches.stderr
+++ b/src/test/ui/type-alias-impl-trait/closures_in_branches.stderr
@@ -14,9 +14,8 @@ error[E0282]: type annotations needed
   --> $DIR/closures_in_branches.rs:21:10
    |
 LL |         |x| x.len()
-   |          ^
+   |          ^  - type must be known at this point
    |
-   = note: type must be known at this point
 help: consider giving this closure parameter an explicit type
    |
 LL |         |x: _| x.len()

--- a/src/test/ui/type-alias-impl-trait/closures_in_branches.stderr
+++ b/src/test/ui/type-alias-impl-trait/closures_in_branches.stderr
@@ -2,9 +2,8 @@ error[E0282]: type annotations needed
   --> $DIR/closures_in_branches.rs:7:10
    |
 LL |         |x| x.len()
-   |          ^
+   |          ^  - type must be known at this point
    |
-   = note: type must be known at this point
 help: consider giving this closure parameter an explicit type
    |
 LL |         |x: _| x.len()

--- a/src/test/ui/type-alias-impl-trait/fallback.stderr
+++ b/src/test/ui/type-alias-impl-trait/fallback.stderr
@@ -1,6 +1,8 @@
 error[E0283]: type annotations needed
   --> $DIR/fallback.rs:24:5
    |
+LL | fn unconstrained_foo() -> Wrapper<Foo> {
+   |                           ------------ type must be known at this point
 LL |     Wrapper::Second
    |     ^^^^^^^^^^^^^^^ cannot infer type of the type parameter `T` declared on the enum `Wrapper`
    |

--- a/src/test/ui/type/type-check/cannot_infer_local_or_array.stderr
+++ b/src/test/ui/type/type-check/cannot_infer_local_or_array.stderr
@@ -2,7 +2,7 @@ error[E0282]: type annotations needed for `[_; 0]`
   --> $DIR/cannot_infer_local_or_array.rs:2:9
    |
 LL |     let x = [];
-   |         ^
+   |         ^   -- type must be known at this point
    |
 help: consider giving `x` an explicit type, where the placeholders `_` are specified
    |

--- a/src/test/ui/type/type-check/issue-40294.stderr
+++ b/src/test/ui/type/type-check/issue-40294.stderr
@@ -1,8 +1,8 @@
-error[E0283]: type annotations needed
+error[E0283]: type annotations needed: cannot satisfy `&'a T: Foo`
   --> $DIR/issue-40294.rs:6:19
    |
 LL |     where &'a T : Foo,
-   |                   ^^^ cannot infer type for reference `&'a T`
+   |                   ^^^
    |
    = note: cannot satisfy `&'a T: Foo`
 

--- a/src/test/ui/typeck/issue-65611.stderr
+++ b/src/test/ui/typeck/issue-65611.stderr
@@ -3,8 +3,6 @@ error[E0282]: type annotations needed
    |
 LL |     let x = buffer.last().unwrap().0.clone();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type for type parameter `T`
-   |
-   = note: type must be known at this point
 
 error[E0609]: no field `0` on type `&_`
   --> $DIR/issue-65611.rs:59:36

--- a/src/test/ui/unboxed-closures/unboxed-closures-failed-recursive-fn-2.stderr
+++ b/src/test/ui/unboxed-closures/unboxed-closures-failed-recursive-fn-2.stderr
@@ -3,8 +3,10 @@ error[E0282]: type annotations needed for `Option<T>`
    |
 LL |     let mut closure0 = None;
    |         ^^^^^^^^^^^^
+...
+LL |                         return c();
+   |                                --- type must be known at this point
    |
-   = note: type must be known at this point
 help: consider giving `closure0` an explicit type, where the placeholders `_` are specified
    |
 LL |     let mut closure0: Option<T> = None;


### PR DESCRIPTION
Successful merges:

 - #97249 (`<details>`/`<summary>` UI fixes)
 - #98418 (Allow macOS to build LLVM as shared library)
 - #98460 (Use CSS variables to handle theming)
 - #98497 (Improve some inference diagnostics)
 - #98708 (rustdoc: fix 98690 Panic if invalid path for -Z persist-doctests)

Failed merges:

 - #98761 (more `need_type_info` improvements)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=97249,98418,98460,98497,98708)
<!-- homu-ignore:end -->