### PR TITLE
Do not call `check_expr` in `check_compatible`, since it has side-effects

### DIFF
--- a/compiler/rustc_typeck/src/check/expr.rs
+++ b/compiler/rustc_typeck/src/check/expr.rs
@@ -271,7 +271,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     }
 
     #[instrument(skip(self, expr), level = "debug")]
-    pub(super) fn check_expr_kind(
+    fn check_expr_kind(
         &self,
         expr: &'tcx hir::Expr<'tcx>,
         expected: Expectation<'tcx>,

--- a/src/test/ui/issues/issue-3044.rs
+++ b/src/test/ui/issues/issue-3044.rs
@@ -1,7 +1,6 @@
 fn main() {
     let needlesArr: Vec<char> = vec!['a', 'f'];
     needlesArr.iter().fold(|x, y| {
+        //~^ ERROR this function takes 2 arguments but 1 argument was supplied
     });
-    //~^^ ERROR mismatched types
-    //~| ERROR this function takes 2 arguments but 1 argument was supplied
 }

--- a/src/test/ui/issues/issue-3044.stderr
+++ b/src/test/ui/issues/issue-3044.stderr
@@ -1,21 +1,9 @@
-error[E0308]: mismatched types
-  --> $DIR/issue-3044.rs:3:35
-   |
-LL |       needlesArr.iter().fold(|x, y| {
-   |  ____________________________------_^
-   | |                            |
-   | |                            the expected closure
-LL | |     });
-   | |_____^ expected closure, found `()`
-   |
-   = note: expected closure `[closure@$DIR/issue-3044.rs:3:28: 3:34]`
-            found unit type `()`
-
 error[E0061]: this function takes 2 arguments but 1 argument was supplied
   --> $DIR/issue-3044.rs:3:23
    |
 LL |       needlesArr.iter().fold(|x, y| {
    |  _______________________^^^^-
+LL | |
 LL | |     });
    | |______- an argument is missing
    |
@@ -27,10 +15,10 @@ LL |     fn fold<B, F>(mut self, init: B, mut f: F) -> B
 help: provide the argument
    |
 LL ~     needlesArr.iter().fold(|x, y| {
+LL +
 LL ~     }, /* value */);
    |
 
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 
-Some errors have detailed explanations: E0061, E0308.
-For more information about an error, try `rustc --explain E0061`.
+For more information about this error, try `rustc --explain E0061`.


### PR DESCRIPTION
Fixes a weird suggestion in #98784

found later:
Fixes #98894
Fixes #98897