### PR TITLE
Do not exclusively suggest `;` when `,` is also a choice

### DIFF
--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -560,7 +560,8 @@ impl<'a> Parser<'a> {
                     || (sm.is_multiline(
                         self.prev_token.span.shrink_to_hi().until(self.token.span.shrink_to_lo())
                     ) && t == &token::Pound)
-            }) {
+            }) && !expected.contains(&TokenType::Token(token::Comma))
+            {
                 // Missing semicolon typo. This is triggered if the next token could either start a
                 // new statement or is a block close. For example:
                 //

--- a/src/test/ui/parser/issues/issue-88770.rs
+++ b/src/test/ui/parser/issues/issue-88770.rs
@@ -3,7 +3,7 @@
 // error-pattern:this file contains an unclosed delimiter
 // error-pattern:expected one of
 // error-pattern:missing `in` in `for` loop
-// error-pattern:expected `;`, found `e`
+// error-pattern:expected one of `!`, `)`, `,`, `.`, `::`, `;`, `?`, `{`, or an operator, found `e`
 
 fn m(){print!("",(c for&g
 u

--- a/src/test/ui/parser/issues/issue-88770.stderr
+++ b/src/test/ui/parser/issues/issue-88770.stderr
@@ -48,19 +48,13 @@ error: expected one of `!`, `)`, `,`, `.`, `::`, `?`, `{`, or an operator, found
 LL | fn m(){print!("",(c for&g
    |                     ^^^ expected one of 8 possible tokens
 
-error: expected `;`, found `e`
-  --> $DIR/issue-88770.rs:10:2
+error: expected one of `!`, `)`, `,`, `.`, `::`, `;`, `?`, `{`, or an operator, found `e`
+  --> $DIR/issue-88770.rs:11:1
    |
 LL | e
-   |  ^ help: add `;` here
+   |  - expected one of 9 possible tokens
 LL | e
-   | - unexpected token
+   | ^ unexpected token
 
-error: expected one of `!`, `,`, `.`, `::`, `?`, `{`, or an operator, found `)`
-  --> $DIR/issue-88770.rs:11:3
-   |
-LL | e
-   |   ^ expected one of 7 possible tokens
-
-error: aborting due to 7 previous errors
+error: aborting due to 6 previous errors
 

--- a/src/test/ui/parser/suggest-semi-in-array.rs
+++ b/src/test/ui/parser/suggest-semi-in-array.rs
@@ -1,0 +1,5 @@
+fn main() {
+    let v = [1
+    2];
+    //~^ ERROR expected one of `,`, `.`, `;`, `?`, `]`, or an operator, found `2`
+}

--- a/src/test/ui/parser/suggest-semi-in-array.stderr
+++ b/src/test/ui/parser/suggest-semi-in-array.stderr
@@ -1,0 +1,10 @@
+error: expected one of `,`, `.`, `;`, `?`, `]`, or an operator, found `2`
+  --> $DIR/suggest-semi-in-array.rs:3:5
+   |
+LL |     let v = [1
+   |               - expected one of `,`, `.`, `;`, `?`, `]`, or an operator
+LL |     2];
+   |     ^ unexpected token
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Fixes #96791