### PR TITLE
Make the Rust docs display properly in Netsurf browser

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -299,7 +299,6 @@ main {
 }
 
 .source main {
-	width: 100%;
 	padding: 15px;
 }
 

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -139,6 +139,7 @@ h1, h2, h3, h4 {
 	margin: 15px 0 5px 0;
 }
 h1.fqn {
+	display: inline-block;
 	margin: 0;
 	padding: 0;
 }
@@ -291,6 +292,7 @@ button {
 
 main {
 	position: relative;
+	display: inline-block;
 	flex-grow: 1;
 	padding: 10px 15px 40px 45px;
 	min-width: 0;
@@ -386,6 +388,7 @@ nav.sub {
 	height: 100vh;
 	top: 0;
 	left: 0;
+	display: inline-block;
 }
 
 .sidebar-elems,
@@ -479,6 +482,8 @@ nav.sub {
 .logo-container > img {
 	height: 100px;
 	width: 100px;
+	display: block;
+	margin: auto;
 }
 
 .location:empty {

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -299,6 +299,7 @@ main {
 }
 
 .source main {
+	width: 100%;
 	padding: 15px;
 }
 
@@ -308,7 +309,7 @@ main {
 }
 
 .source .width-limiter {
-	max-width: unset;
+	max-width: none;
 }
 
 details:not(.rustdoc-toggle) summary {
@@ -571,6 +572,7 @@ h2.location a {
 }
 
 .line-numbers {
+	display: inline-block;
 	text-align: right;
 }
 .rustdoc:not(.source) .example-wrap > pre:not(.line-number) {
@@ -1346,6 +1348,7 @@ pre.rust.rust-example-rendered {
 }
 
 pre.rust {
+	display: inline-block;
 	tab-size: 4;
 	-moz-tab-size: 4;
 }

--- a/src/librustdoc/html/static/css/themes/light.css
+++ b/src/librustdoc/html/static/css/themes/light.css
@@ -20,10 +20,6 @@ h1.fqn {
 	border-bottom-color: #DDDDDD;
 }
 
-h1.fqn a {
-	color: #000;
-}
-
 h2, h3, h4 {
 	border-bottom-color: #DDDDDD;
 }
@@ -34,10 +30,6 @@ h2, h3, h4 {
 
 .docblock code, .docblock-short code {
 	background-color: #F5F5F5;
-}
-
-.docblock pre > code, pre > code, .docblock code, span code, .code-header {
-	color: #000;
 }
 
 pre, .rustdoc.source .example-wrap {

--- a/src/librustdoc/html/static/css/themes/light.css
+++ b/src/librustdoc/html/static/css/themes/light.css
@@ -21,7 +21,7 @@ h1.fqn {
 }
 
 h1.fqn a {
-    color: #000;
+	color: #000;
 }
 
 h2, h3, h4 {

--- a/src/librustdoc/html/static/css/themes/light.css
+++ b/src/librustdoc/html/static/css/themes/light.css
@@ -19,6 +19,11 @@ input:focus + .slider {
 h1.fqn {
 	border-bottom-color: #DDDDDD;
 }
+
+h1.fqn a {
+    color: #000;
+}
+
 h2, h3, h4 {
 	border-bottom-color: #DDDDDD;
 }
@@ -30,6 +35,11 @@ h2, h3, h4 {
 .docblock code, .docblock-short code {
 	background-color: #F5F5F5;
 }
+
+.docblock pre > code, pre > code, .docblock code, span code, .code-header {
+	color: #000;
+}
+
 pre, .rustdoc.source .example-wrap {
 	background-color: #F5F5F5;
 }
@@ -239,7 +249,7 @@ pre.rust .question-mark {
 }
 
 a.test-arrow {
-	background-color: rgb(78, 139, 202, 0.2);
+	background-color: rgba(78, 139, 202, 0.2);
 }
 
 a.test-arrow:hover{


### PR DESCRIPTION
Adds minor tweaks to CSS which do not change the appearance in the major browsers.